### PR TITLE
Fixed broken link in README.md file.

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ $ make build
 Using the provider
 ----------------------
 
-See the [IBM Provider documentation](https://ibm-bluemix.github.io/tf-ibm-docs) to get started using the IBM provider.
+See the [IBM Provider documentation](https://ibm-cloud.github.io/tf-ibm-docs/v0.6.0/) to get started using the IBM provider.
 
 Developing the Provider
 ---------------------------


### PR DESCRIPTION
[IBM Provider documentation] was pointing to https://ibm-bluemix.github.io/tf-ibm-docs which is not accessible. Changes to docs at https://ibm-cloud.github.io/tf-ibm-docs/v0.6.0/