### PR TITLE
Add the ssh keys to Container_Product_Order rather than to the hardwa…

### DIFF
--- a/ibm/resource_ibm_compute_bare_metal.go
+++ b/ibm/resource_ibm_compute_bare_metal.go
@@ -1232,10 +1232,12 @@ func setCommonBareMetalOrderOptions(d *schema.ResourceData, meta interface{}, or
 	// Get configured ssh_keys
 	ssh_key_ids := d.Get("ssh_key_ids").([]interface{})
 	if len(ssh_key_ids) > 0 {
-		order.Hardware[0].SshKeys = make([]datatypes.Security_Ssh_Key, 0, len(ssh_key_ids))
+		order.SshKeys = make([]datatypes.Container_Product_Order_SshKeys, 0, len(ssh_key_ids))
 		for _, ssh_key_id := range ssh_key_ids {
-			order.Hardware[0].SshKeys = append(order.Hardware[0].SshKeys, datatypes.Security_Ssh_Key{
-				Id: sl.Int(ssh_key_id.(int)),
+			sshKeyA := make([]int, 1)
+			sshKeyA[0] = ssh_key_id.(int)
+			order.SshKeys = append(order.SshKeys, datatypes.Container_Product_Order_SshKeys{
+				SshKeyIds: sshKeyA,
 			})
 		}
 	}


### PR DESCRIPTION
…re to configure shhkeys to Hardware
Wen the fixed_config_preset is set the order generated using GenerateOrderTemplate and the ssh keys are added to container product order. So in this case there is no issue. 
But in the other case the sshkeys are added to only hardware.
    Softlayer Support who has Fabric-SRE and Compute-SRE look at it. Here is their output:

It seems an issue with the terraform ibm provider, I verified that it is sending the sshKeys inside the hardware array, this is why it`s not being provisioned with them, they should be sent outside in the sshKeys>sshKeyIds (arrayOfInt) .
After applying the fix the ssh keys are configured and able to ssh to the hardware
