### PR TITLE
Fix issue #180

### DIFF
--- a/ibm/resource_ibm_storage_block_test.go
+++ b/ibm/resource_ibm_storage_block_test.go
@@ -61,10 +61,12 @@ func TestAccIBMStorageBlock_Basic(t *testing.T) {
 					// Endurance Storage
 					resource.TestCheckResourceAttr("ibm_storage_block.bs_endurance", "allowed_virtual_guest_ids.#", "1"),
 					resource.TestCheckResourceAttr("ibm_storage_block.bs_endurance", "allowed_ip_addresses.#", "1"),
+					resource.TestCheckResourceAttr("ibm_storage_block.bs_endurance", "allowed_host_info.#", "2"),
 					resource.TestCheckResourceAttr("ibm_storage_block.bs_endurance", "notes", "updated endurance notes"),
 					// Performance Storage
 					resource.TestCheckResourceAttr("ibm_storage_block.bs_performance", "allowed_virtual_guest_ids.#", "1"),
 					resource.TestCheckResourceAttr("ibm_storage_block.bs_performance", "allowed_ip_addresses.#", "1"),
+					resource.TestCheckResourceAttr("ibm_storage_block.bs_performance", "allowed_host_info.#", "2"),
 				),
 			},
 		},
@@ -165,6 +167,7 @@ func TestAccIBMStorageBlock_hourly(t *testing.T) {
 					// Endurance Storage
 					resource.TestCheckResourceAttr("ibm_storage_block.bs_endurance", "allowed_virtual_guest_ids.#", "1"),
 					resource.TestCheckResourceAttr("ibm_storage_block.bs_endurance", "allowed_ip_addresses.#", "1"),
+					resource.TestCheckResourceAttr("ibm_storage_block.bs_endurance", "allowed_host_info.#", "2"),
 					resource.TestCheckResourceAttr("ibm_storage_block.bs_endurance", "notes", "updated endurance notes"),
 				),
 			},

--- a/ibm/resource_ibm_storage_file.go
+++ b/ibm/resource_ibm_storage_file.go
@@ -25,7 +25,7 @@ const (
 	storageNasPackageType         = "ADDITIONAL_SERVICES_NETWORK_ATTACHED_STORAGE"
 	storageMask                   = "id,billingItem.orderItem.order.id"
 	storageDetailMask             = "id,capacityGb,iops,storageType,username,serviceResourceBackendIpAddress,properties[type]" +
-		",serviceResourceName,allowedIpAddresses,allowedSubnets,allowedVirtualGuests[id,allowedHost[name,credential[username,password]]],snapshotCapacityGb,osType,notes,billingItem[hourlyFlag],serviceResource[datacenter[name]]"
+		",serviceResourceName,allowedIpAddresses[ipAddress,subnetId,allowedHost[name,credential[username,password]]],allowedSubnets[allowedHost[name,credential[username,password]]],allowedHardware[allowedHost[name,credential[username,password]]],allowedVirtualGuests[id,allowedHost[name,credential[username,password]]],snapshotCapacityGb,osType,notes,billingItem[hourlyFlag],serviceResource[datacenter[name]]"
 	itemMask        = "id,capacity,description,units,keyName,prices[id,categories[id,name,categoryCode],capacityRestrictionMinimum,capacityRestrictionMaximum,locationGroupId]"
 	enduranceType   = "Endurance"
 	performanceType = "Performance"

--- a/website/docs/r/storage_block.html.markdown
+++ b/website/docs/r/storage_block.html.markdown
@@ -78,5 +78,6 @@ The following attributes are exported:
 * `id` - The unique identifier of the storage.
 * `hostname` - The fully qualified domain name of the storage.
 * `volumename` - The name of the storage volume.
-* `allowed_virtual_guest_info` - The user name, password, and host IQN of the virtual guests with access to the storage.
-* `allowed_hardware_info` - The user name, password, and host IQN of the bare metal servers with access to the storage.
+* `allowed_virtual_guest_info` - Deprecated please use `allowed_host_info` instead.
+* `allowed_hardware_info` - Deprecated please use `allowed_host_info` instead.
+* `allowed_host_info` - The user name, password, and host IQN of the hosts with access to the storage.


### PR DESCRIPTION
Test results
Harinis-MacBook-Pro:terraform-provider-ibm hkantare$ make testacc TEST=./ibm TESTARGS='-run=TestAccIBMStorageBlock'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./ibm -v -run=TestAccIBMStorageBlock -timeout 700m
[WARN] Set the environment variable IBM_ORG for testing ibm_org  resource Some tests for that resource will fail if this is not set correctly
[WARN] Set the environment variable IBM_SPACE for testing ibm_space  resource Some tests for that resource will fail if this is not set correctly
[WARN] Set the environment variable IBM_ID1 for testing ibm_space resource Some tests for that resource will fail if this is not set correctly
[WARN] Set the environment variable IBM_ID2 for testing ibm_space resource Some tests for that resource will fail if this is not set correctly
[WARN] Set the environment variable IBM_IAMUSER for testing ibm_iam_user_policy resource Some tests for that resource will fail if this is not set correctly
[INFO] Set the environment variable IBM_DATACENTER for testing ibm_container_cluster resource else it is set to default value 'ams03'
[INFO] Set the environment variable IBM_MACHINE_TYPE for testing ibm_container_cluster resource else it is set to default value 'u1c.2x4'
[INFO] Set the environment variable IBM_PUBLIC_VLAN_ID for testing ibm_container_cluster resource else it is set to default value '1764435'
[INFO] Set the environment variable IBM_PRIVATE_VLAN_ID for testing ibm_container_cluster resource else it is set to default value '1764491'
[INFO] Set the environment variable IBM_PRIVATE_SUBNET_ID for testing ibm_container_cluster resource else it is set to default value '1574951'
[INFO] Set the environment variable IBM_PUBLIC_SUBNET_ID for testing ibm_container_cluster resource else it is set to default value '1415689'
[INFO] Set the environment variable IBM_SUBNET_ID for testing ibm_container_cluster resource else it is set to default value '1415689'
[INFO] Set the environment variable IBM_LBAAS_DATACENTER for testing ibm_lbaas resource else it is set to default value 'wdc04'
[INFO] Set the environment variable IBM_LBAAS_SUBNETID for testing ibm_lbaas resource else it is set to default value '1511875'
[INFO] Set the environment variable IBM_DEDICATED_HOSTNAME for testing ibm_compute_vm_instance resource else it is set to default value 'terraform-dedicatedhost'
[INFO] Set the environment variable IBM_DEDICATED_HOST_ID for testing ibm_compute_vm_instance resource else it is set to default value '30301'
[WARN] Set the environment variable IBM_COMPUTE_VM_INSTANCE_IMAGE_ID for testing the ibm_compute_vm_instance resource. The image should be replicated in the Washington 4 datacenter. Some tests for that resource will fail if this is not set correctly
=== RUN   TestAccIBMStorageBlock_Basic
--- PASS: TestAccIBMStorageBlock_Basic (809.20s)
=== RUN   TestAccIBMStorageBlockwithTag
--- PASS: TestAccIBMStorageBlockwithTag (402.64s)
=== RUN   TestAccIBMStorageBlock_hourly
--- PASS: TestAccIBMStorageBlock_hourly (501.45s)
PASS
ok  	github.com/terraform-providers/terraform-provider-ibm/ibm	1714.876s