### PR TITLE
Add resource support for resource key

### DIFF
--- a/ibm/data_source_ibm_iam_user_policy.go
+++ b/ibm/data_source_ibm_iam_user_policy.go
@@ -89,7 +89,7 @@ func dataSourceIBMIAMUserPolicy() *schema.Resource {
 }
 
 func dataSourceIBMIAMUserPolicyRead(d *schema.ResourceData, meta interface{}) error {
-	iamClient, err := meta.(ClientSession).IAMAPI()
+	iamClient, err := meta.(ClientSession).IAMPAPAPI()
 	if err != nil {
 		return err
 	}

--- a/ibm/provider.go
+++ b/ibm/provider.go
@@ -142,6 +142,7 @@ func Provider() terraform.ResourceProvider {
 			"ibm_object_storage_account":           resourceIBMObjectStorageAccount(),
 			"ibm_org":                              resourceIBMOrg(),
 			"ibm_resource_instance":                resourceIBMResourceInstance(),
+			"ibm_resource_key":                     resourceIBMResourceKey(),
 			"ibm_security_group":                   resourceIBMSecurityGroup(),
 			"ibm_security_group_rule":              resourceIBMSecurityGroupRule(),
 			"ibm_service_instance":                 resourceIBMServiceInstance(),

--- a/ibm/resource_ibm_iam_user_policy.go
+++ b/ibm/resource_ibm_iam_user_policy.go
@@ -111,7 +111,7 @@ func resourceIBMIAMUserPolicy() *schema.Resource {
 }
 
 func resourceIBMIAMUserPolicyCreate(d *schema.ResourceData, meta interface{}) error {
-	iamClient, err := meta.(ClientSession).IAMAPI()
+	iamClient, err := meta.(ClientSession).IAMPAPAPI()
 	if err != nil {
 		return err
 	}
@@ -151,7 +151,7 @@ func resourceIBMIAMUserPolicyCreate(d *schema.ResourceData, meta interface{}) er
 }
 
 func resourceIBMIAMUserPolicyRead(d *schema.ResourceData, meta interface{}) error {
-	iamClient, err := meta.(ClientSession).IAMAPI()
+	iamClient, err := meta.(ClientSession).IAMPAPAPI()
 	if err != nil {
 		return err
 	}
@@ -177,7 +177,7 @@ func resourceIBMIAMUserPolicyRead(d *schema.ResourceData, meta interface{}) erro
 }
 
 func resourceIBMIAMUserPolicyUpdate(d *schema.ResourceData, meta interface{}) error {
-	iamClient, err := meta.(ClientSession).IAMAPI()
+	iamClient, err := meta.(ClientSession).IAMPAPAPI()
 	if err != nil {
 		return err
 	}
@@ -214,7 +214,7 @@ func resourceIBMIAMUserPolicyUpdate(d *schema.ResourceData, meta interface{}) er
 }
 
 func resourceIBMIAMUserPolicyDelete(d *schema.ResourceData, meta interface{}) error {
-	iamClient, err := meta.(ClientSession).IAMAPI()
+	iamClient, err := meta.(ClientSession).IAMPAPAPI()
 	if err != nil {
 		return err
 	}
@@ -234,7 +234,7 @@ func resourceIBMIAMUserPolicyDelete(d *schema.ResourceData, meta interface{}) er
 }
 
 func resourceIBMIAMUserPolicyExists(d *schema.ResourceData, meta interface{}) (bool, error) {
-	iamClient, err := meta.(ClientSession).IAMAPI()
+	iamClient, err := meta.(ClientSession).IAMPAPAPI()
 	if err != nil {
 		return false, err
 	}

--- a/ibm/resource_ibm_iam_user_policy_test.go
+++ b/ibm/resource_ibm_iam_user_policy_test.go
@@ -117,7 +117,7 @@ func TestAccIBMIAMUserPolicy_InvalidUser(t *testing.T) {
 }
 
 func testAccCheckIBMIAMUserPolicyDestroy(s *terraform.State) error {
-	client, err := testAccProvider.Meta().(ClientSession).IAMAPI()
+	client, err := testAccProvider.Meta().(ClientSession).IAMPAPAPI()
 	if err != nil {
 		return fmt.Errorf("Error checking IAM Policy %s", err)
 	}

--- a/ibm/resource_ibm_resource_key.go
+++ b/ibm/resource_ibm_resource_key.go
@@ -1,0 +1,299 @@
+package ibm
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/IBM-Cloud/bluemix-go/models"
+
+	"github.com/hashicorp/terraform/flatmap"
+
+	"github.com/IBM-Cloud/bluemix-go/api/resource/resourcev1/controller"
+	"github.com/IBM-Cloud/bluemix-go/bmxerror"
+	"github.com/IBM-Cloud/bluemix-go/crn"
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func resourceIBMResourceKey() *schema.Resource {
+	return &schema.Resource{
+		Create:   resourceIBMResourceKeyCreate,
+		Read:     resourceIBMResourceKeyRead,
+		Update:   resourceIBMResourceKeyUpdate,
+		Delete:   resourceIBMResourceKeyDelete,
+		Exists:   resourceIBMResourceKeyExists,
+		Importer: &schema.ResourceImporter{},
+
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(10 * time.Minute),
+			Delete: schema.DefaultTimeout(10 * time.Minute),
+		},
+
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: "The name of the resource key",
+			},
+
+			"role": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				Description:  "Name of the user role.Valid roles are Writer, Reader, Manager, Administrator, Operator, Viewer, Editor.",
+				ValidateFunc: validateRole,
+			},
+
+			"resource_instance_id": {
+				Type:          schema.TypeString,
+				Optional:      true,
+				ForceNew:      true,
+				Description:   "The id of the resource instance for which to create resource key",
+				ConflictsWith: []string{"resource_alias_id"},
+			},
+
+			"resource_alias_id": {
+				Type:          schema.TypeString,
+				Optional:      true,
+				ForceNew:      true,
+				Description:   "The id of the resource alias for which to create resource key",
+				ConflictsWith: []string{"resource_instance_id"},
+			},
+
+			"parameters": {
+				Type:        schema.TypeMap,
+				Optional:    true,
+				Computed:    true,
+				ForceNew:    true,
+				Description: "Arbitrary parameters to pass. Must be a JSON object",
+			},
+
+			"credentials": {
+				Description: "Credentials asociated with the key",
+				Type:        schema.TypeMap,
+				Sensitive:   true,
+				Computed:    true,
+			},
+
+			"status": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "Status of resource key",
+			},
+
+			"tags": {
+				Type:     schema.TypeSet,
+				Optional: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+				Set:      schema.HashString,
+			},
+		},
+	}
+}
+
+func resourceIBMResourceKeyCreate(d *schema.ResourceData, meta interface{}) error {
+	rsContClient, err := meta.(ClientSession).ResourceControllerAPI()
+	if err != nil {
+		return err
+	}
+	name := d.Get("name").(string)
+	role := d.Get("role").(string)
+
+	var instanceID, aliasID string
+	if insID, ok := d.GetOk("resource_instance_id"); ok {
+		instanceID = insID.(string)
+	}
+
+	if aliID, ok := d.GetOk("resource_alias_id"); ok {
+		aliasID = aliID.(string)
+	}
+
+	if instanceID == "" && aliasID == "" {
+		return fmt.Errorf("Provide either `resource_instance_id` or `resource_alias_id`")
+	}
+
+	var keyParams map[string]interface{}
+
+	if parameters, ok := d.GetOk("parameters"); ok {
+		keyParams = parameters.(map[string]interface{})
+	} else {
+		keyParams = make(map[string]interface{})
+	}
+
+	resourceInstance, sourceCRN, err := getResourceInstanceAndCRN(d, meta)
+	if err != nil {
+		return fmt.Errorf("Error creating resource key: %s", err)
+	}
+
+	serviceID := resourceInstance.ServiceID
+
+	rsCatClient, err := meta.(ClientSession).ResourceCatalogAPI()
+	if err != nil {
+		return fmt.Errorf("Error creating resource key: %s", err)
+	}
+
+	service, err := rsCatClient.ResourceCatalog().Get(serviceID, true)
+	if err != nil {
+		return fmt.Errorf("Error creating resource key: %s", err)
+	}
+
+	serviceRole, err := getRoleFromName(role, service.Name, meta)
+	if err != nil {
+		return fmt.Errorf("Error creating resource key: %s", err)
+	}
+	keyParams["role_crn"] = serviceRole.ID
+
+	request := controller.CreateServiceKeyRequest{
+		Name:       name,
+		SourceCRN:  *sourceCRN,
+		Parameters: keyParams,
+	}
+
+	resourceKey, err := rsContClient.ResourceServiceKey().CreateKey(request)
+	if err != nil {
+		return fmt.Errorf("Error creating resource key: %s", err)
+	}
+
+	d.SetId(resourceKey.ID)
+
+	return resourceIBMResourceKeyRead(d, meta)
+}
+
+func resourceIBMResourceKeyUpdate(d *schema.ResourceData, meta interface{}) error {
+	return nil
+}
+
+func resourceIBMResourceKeyRead(d *schema.ResourceData, meta interface{}) error {
+	rsContClient, err := meta.(ClientSession).ResourceControllerAPI()
+	if err != nil {
+		return err
+	}
+	resourceKeyID := d.Id()
+
+	resourceKey, err := rsContClient.ResourceServiceKey().GetKey(resourceKeyID)
+	if err != nil {
+		return fmt.Errorf("Error retrieving resource key: %s", err)
+	}
+	d.Set("credentials", flatmap.Flatten(resourceKey.Credentials))
+	d.Set("name", resourceKey.Name)
+	d.Set("status", resourceKey.State)
+	role := resourceKey.Parameters["role_crn"].(string)
+	role = role[strings.LastIndex(role, ":")+1:]
+	d.Set("role", role)
+	d.Set("parameters", flatmap.Flatten(filterResourceKeyParameters(resourceKey.Parameters)))
+
+	return nil
+}
+
+func resourceIBMResourceKeyDelete(d *schema.ResourceData, meta interface{}) error {
+	rsContClient, err := meta.(ClientSession).ResourceControllerAPI()
+	if err != nil {
+		return err
+	}
+
+	resourceKeyID := d.Id()
+
+	err = rsContClient.ResourceServiceKey().DeleteKey(resourceKeyID)
+	if err != nil {
+		return fmt.Errorf("Error deleting resource key: %s", err)
+	}
+
+	d.SetId("")
+
+	return nil
+}
+
+func resourceIBMResourceKeyExists(d *schema.ResourceData, meta interface{}) (bool, error) {
+	rsContClient, err := meta.(ClientSession).ResourceControllerAPI()
+	if err != nil {
+		return false, err
+	}
+	resourceKeyID := d.Id()
+
+	resourceKey, err := rsContClient.ResourceServiceKey().GetKey(resourceKeyID)
+	if err != nil {
+		if apiErr, ok := err.(bmxerror.RequestFailure); ok {
+			if apiErr.StatusCode() == 404 {
+				return false, nil
+			}
+		}
+		return false, fmt.Errorf("Error communicating with the API: %s", err)
+	}
+
+	return resourceKey.ID == resourceKeyID, nil
+}
+
+func getResourceInstanceAndCRN(d *schema.ResourceData, meta interface{}) (*models.ServiceInstance, *crn.CRN, error) {
+	rsContClient, err := meta.(ClientSession).ResourceControllerAPI()
+	if err != nil {
+		return nil, nil, err
+	}
+	if insID, ok := d.GetOk("resource_instance_id"); ok {
+		instance, err := rsContClient.ResourceServiceInstance().GetInstance(insID.(string))
+		if err != nil {
+			return nil, nil, err
+		}
+		return &instance, &instance.Crn, nil
+
+	}
+
+	alias, err := rsContClient.ResourceServiceAlias().Alias(d.Get("resource_alias_id").(string))
+	if err != nil {
+		return nil, nil, err
+	}
+	instance, err := rsContClient.ResourceServiceInstance().GetInstance(alias.ServiceInstanceID)
+	if err != nil {
+		return nil, nil, err
+	}
+	return &instance, &instance.Crn, nil
+
+}
+
+func getRoleFromName(roleName, serviceName string, meta interface{}) (models.PolicyRole, error) {
+
+	iamClient, err := meta.(ClientSession).IAMAPI()
+	if err != nil {
+		return models.PolicyRole{}, err
+	}
+
+	iamRepo := iamClient.ServiceRoles()
+
+	var roles []models.PolicyRole
+
+	if serviceName == "" {
+		roles, err = iamRepo.ListSystemDefinedRoles()
+	} else {
+		roles, err = iamRepo.ListServiceRoles(serviceName)
+	}
+	if err != nil {
+		return models.PolicyRole{}, err
+	}
+	role, err := findRoleByName(roles, roleName)
+	if err != nil {
+		return models.PolicyRole{}, err
+	}
+	return role, nil
+
+}
+
+func findRoleByName(supported []models.PolicyRole, name string) (models.PolicyRole, error) {
+	for _, role := range supported {
+		if role.DisplayName == name {
+			return role, nil
+		}
+	}
+
+	return models.PolicyRole{}, fmt.Errorf("Role [%s] was not found. Valid roles are %s", name, getSupportedRolesString(supported))
+}
+
+func getSupportedRolesString(supported []models.PolicyRole) string {
+	rolesStr := ""
+	for index, role := range supported {
+		if index != 0 {
+			rolesStr += ", "
+		}
+		rolesStr += role.DisplayName
+	}
+	return rolesStr
+}

--- a/ibm/resource_ibm_resource_key_test.go
+++ b/ibm/resource_ibm_resource_key_test.go
@@ -1,0 +1,224 @@
+package ibm
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/IBM-Cloud/bluemix-go/models"
+
+	"strings"
+
+	"github.com/hashicorp/terraform/helper/acctest"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+)
+
+func TestAccIBMResourceKey_Basic(t *testing.T) {
+	var conf models.ServiceKey
+	resourceName := fmt.Sprintf("terraform_%d", acctest.RandInt())
+	resourceKey := fmt.Sprintf("terraform_%d", acctest.RandInt())
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckIBMResourceKeyDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccCheckIBMResourceKey_basic(resourceName, resourceKey),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckIBMResourceKeyExists("ibm_resource_key.resourceKey", conf),
+					resource.TestCheckResourceAttr("ibm_resource_key.resourceKey", "name", resourceKey),
+					resource.TestCheckResourceAttr("ibm_resource_key.resourceKey", "credentials.%", "7"),
+					resource.TestCheckResourceAttr("ibm_resource_key.resourceKey", "role", "Reader"),
+				),
+			},
+			resource.TestStep{
+				ResourceName:      "ibm_resource_key.resourceKey",
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"resource_instance_id", "resource_alias_id"},
+			},
+		},
+	})
+}
+
+func TestAccIBMResourceKey_With_Tags(t *testing.T) {
+	var conf models.ServiceKey
+	resourceName := fmt.Sprintf("terraform_%d", acctest.RandInt())
+	resourceKey := fmt.Sprintf("terraform_%d", acctest.RandInt())
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckIBMResourceKeyDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccCheckIBMResourceKey_with_tags(resourceName, resourceKey),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckIBMResourceKeyExists("ibm_resource_key.resourceKey", conf),
+					resource.TestCheckResourceAttr("ibm_resource_key.resourceKey", "name", resourceKey),
+					resource.TestCheckResourceAttr("ibm_resource_key.resourceKey", "role", "Viewer"),
+					resource.TestCheckResourceAttr("ibm_resource_key.resourceKey", "tags.#", "1"),
+				),
+			},
+			resource.TestStep{
+				Config: testAccCheckIBMResourceKey_with_updated_tags(resourceName, resourceKey),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckIBMResourceKeyExists("ibm_resource_key.resourceKey", conf),
+					resource.TestCheckResourceAttr("ibm_resource_key.resourceKey", "tags.#", "2"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccIBMResourceKey_Parameters(t *testing.T) {
+	var conf models.ServiceKey
+	resourceName := fmt.Sprintf("terraform_%d", acctest.RandInt())
+	resourceKey := fmt.Sprintf("terraform_%d", acctest.RandInt())
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckIBMResourceKeyDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccCheckIBMResourceKey_parameters(resourceName, resourceKey),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckIBMResourceKeyExists("ibm_resource_key.resourceKey", conf),
+					resource.TestCheckResourceAttr("ibm_resource_key.resourceKey", "name", resourceKey),
+					resource.TestCheckResourceAttr("ibm_resource_key.resourceKey", "parameters.%", "1"),
+					resource.TestCheckResourceAttr("ibm_resource_key.resourceKey", "role", "Manager"),
+					resource.TestCheckResourceAttr("ibm_resource_key.resourceKey", "credentials.%", "9"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckIBMResourceKeyExists(n string, obj models.ServiceKey) resource.TestCheckFunc {
+
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+
+		rsContClient, err := testAccProvider.Meta().(ClientSession).ResourceControllerAPI()
+		if err != nil {
+			return err
+		}
+		resourceKeyID := rs.Primary.ID
+
+		resourceKey, err := rsContClient.ResourceServiceKey().GetKey(resourceKeyID)
+		if err != nil {
+			return err
+		}
+
+		obj = resourceKey
+		return nil
+	}
+}
+
+func testAccCheckIBMResourceKeyDestroy(s *terraform.State) error {
+	rsContClient, err := testAccProvider.Meta().(ClientSession).ResourceControllerAPI()
+	if err != nil {
+		return err
+	}
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "ibm_resource_key" {
+			continue
+		}
+
+		resourceKeyID := rs.Primary.ID
+
+		// Try to find the key
+		_, err := rsContClient.ResourceServiceKey().GetKey(resourceKeyID)
+
+		if err != nil && !strings.Contains(err.Error(), "404") {
+			return fmt.Errorf("Error waiting for resource key (%s) to be destroyed: %s", rs.Primary.ID, err)
+		}
+	}
+
+	return nil
+}
+
+func testAccCheckIBMResourceKey_basic(resourceName, resourceKey string) string {
+	return fmt.Sprintf(`
+		
+		resource "ibm_resource_instance" "resource" {
+			name              = "%s"
+			service           = "cloud-object-storage"
+			plan              = "lite"
+			location          = "global"
+			tags              = ["tag1","tag2"]
+		}
+
+		resource "ibm_resource_key" "resourceKey" {
+			name = "%s"
+			resource_instance_id = "${ibm_resource_instance.resource.id}"
+			role = "Reader"
+		}
+	`, resourceName, resourceKey)
+}
+
+func testAccCheckIBMResourceKey_with_tags(resourceName, resourceKey string) string {
+	return fmt.Sprintf(`
+		
+		resource "ibm_resource_instance" "resource" {
+			name              = "%s"
+			service           = "cloud-object-storage"
+			plan              = "lite"
+			location          = "global"
+			tags              = ["tag1","tag2"]
+		}
+
+		resource "ibm_resource_key" "resourceKey" {
+			name = "%s"
+			resource_instance_id = "${ibm_resource_instance.resource.id}"
+			role = "Viewer"
+			tags				  = ["one"]	
+		}
+	`, resourceName, resourceKey)
+}
+
+func testAccCheckIBMResourceKey_with_updated_tags(resourceName, resourceKey string) string {
+	return fmt.Sprintf(`
+		resource "ibm_resource_instance" "resource" {
+			name              = "%s"
+			service           = "cloud-object-storage"
+			plan              = "lite"
+			location          = "global"
+			tags              = ["tag1","tag2"]
+		}
+
+		resource "ibm_resource_key" "resourceKey" {
+			name = "%s"
+			resource_instance_id = "${ibm_resource_instance.resource.id}"
+			role = "Viewer"
+			tags				  = ["one", "two"]	
+		}
+	`, resourceName, resourceKey)
+}
+
+func testAccCheckIBMResourceKey_parameters(resourceName, resourceKey string) string {
+	return fmt.Sprintf(`
+		
+		resource "ibm_resource_instance" "resource" {
+			name              = "%s"
+			service           = "cloud-object-storage"
+			plan              = "lite"
+			location          = "global"
+			tags              = ["tag1","tag2"]
+		}
+
+		resource "ibm_resource_key" "resourceKey" {
+			name = "%s"
+			resource_instance_id = "${ibm_resource_instance.resource.id}"
+			parameters        = {"HMAC" = true}
+			role = "Manager"
+		}
+	`, resourceName, resourceKey)
+}

--- a/ibm/structures.go
+++ b/ibm/structures.go
@@ -670,3 +670,8 @@ func flattenDisks(result datatypes.Virtual_Guest, d *schema.ResourceData) []int 
 
 	return out
 }
+
+func filterResourceKeyParameters(params map[string]interface{}) map[string]interface{} {
+	delete(params, "role_crn")
+	return params
+}

--- a/ibm/validators.go
+++ b/ibm/validators.go
@@ -412,3 +412,28 @@ func validateStorageType(v interface{}, k string) (ws []string, errors []error) 
 	}
 	return
 }
+
+func validateRole(v interface{}, k string) (ws []string, errors []error) {
+	validRolesTypes := map[string]bool{
+		"Writer":        true,
+		"Reader":        true,
+		"Manager":       true,
+		"Administrator": true,
+		"Operator":      true,
+		"Viewer":        true,
+		"Editor":        true,
+	}
+
+	value := v.(string)
+	_, found := validRolesTypes[value]
+	if !found {
+		strarray := make([]string, 0, len(validRolesTypes))
+		for key := range validRolesTypes {
+			strarray = append(strarray, key)
+		}
+		errors = append(errors, fmt.Errorf(
+			"%q contains an invalid role %q. Valid roles are %q.",
+			k, value, strings.Join(strarray, ",")))
+	}
+	return
+}

--- a/website/docs/r/resource_key.html.markdown
+++ b/website/docs/r/resource_key.html.markdown
@@ -1,0 +1,58 @@
+---
+layout: "ibm"
+page_title: "IBM : resource_key"
+sidebar_current: "docs-ibm-resource-resource-key"
+description: |-
+  Manages IBM Resource Key.
+---
+
+# ibm\_resource_key
+
+Provides a resource key resource. This allows resource keys to be created, and deleted.
+
+## Example Usage
+
+```hcl
+data "ibm_resource_instance" "resource_instance" {
+  name = "myobjectsotrage"
+}
+
+resource "ibm_resource_key" "resourceKey" {
+  name                 = "myobjectkey"
+  role                 = "Viewer"
+  resource_instance_id = "${data.ibm_resource_instance.resource_instance.id}"
+
+  //User can increase timeouts 
+  timeouts {
+    create = "15m"
+    delete = "15m"
+  }
+}
+```
+
+## Timeouts
+
+ibm_resource_key provides the following [Timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) configuration options:
+
+* `create` - (Default 10 minutes) Used for Creating Key.
+* `delete` - (Default 10 minutes) Used for Deleting Key.
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `name` - (Required, string) A descriptive name used to identify a resource key.
+* `role` - (Required, string) Name of the user role.Valid roles are Writer, Reader, Manager, Administrator, Operator, Viewer, Editor.
+* `parameters` - (Optional, map) Arbitrary parameters to pass. Must be a JSON object.
+* `resource_instance_id` - (Optional, string) The id of the resource instance associated with the resource key.
+* `resource_alias_id` - (Optional, string) The id of the resource alias associated with the resource key.
+* `tags` - (Optional, array of strings) Tags associated with the resource key instance.
+  **NOTE**: `Tags` are managed locally and not stored on the IBM Cloud service endpoint at this moment.
+
+## Attribute Reference
+
+The following attributes are exported:
+
+* `id` - The unique identifier of the new resource key.
+* `credentials` - The credentials associated with the key.
+* `status` - Status of resource key.

--- a/website/ibm.erb
+++ b/website/ibm.erb
@@ -135,6 +135,9 @@
               <li<%= sidebar_current("docs-ibm-resource-resource-instance") %>>
                 <a href="/docs/providers/ibm/r/resource_instance.html">resource_instance</a>
               </li>
+              <li<%= sidebar_current("docs-ibm-resource-resource-key") %>>
+                <a href="/docs/providers/ibm/r/resource_key.html">resource_key</a>
+              </li>
               <li<%= sidebar_current("docs-ibm-resource-service-instance") %>>
                 <a href="/docs/providers/ibm/r/service_instance.html">service_instance</a>
               </li>


### PR DESCRIPTION
Harinis-MacBook-Pro:terraform-provider-ibm hkantare$ make testacc TEST=./ibm TESTARGS='-run=TestAccIBMResourceKey'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./ibm -v -run=TestAccIBMResourceKey -timeout 700m
[WARN] Set the environment variable IBM_ORG for testing ibm_org  resource Some tests for that resource will fail if this is not set correctly
[WARN] Set the environment variable IBM_SPACE for testing ibm_space  resource Some tests for that resource will fail if this is not set correctly
[WARN] Set the environment variable IBM_ID1 for testing ibm_space resource Some tests for that resource will fail if this is not set correctly
[WARN] Set the environment variable IBM_ID2 for testing ibm_space resource Some tests for that resource will fail if this is not set correctly
[WARN] Set the environment variable IBM_IAMUSER for testing ibm_iam_user_policy resource Some tests for that resource will fail if this is not set correctly
[INFO] Set the environment variable IBM_DATACENTER for testing ibm_container_cluster resource else it is set to default value 'ams03'
[INFO] Set the environment variable IBM_MACHINE_TYPE for testing ibm_container_cluster resource else it is set to default value 'u1c.2x4'
[INFO] Set the environment variable IBM_PUBLIC_VLAN_ID for testing ibm_container_cluster resource else it is set to default value '1764435'
[INFO] Set the environment variable IBM_PRIVATE_VLAN_ID for testing ibm_container_cluster resource else it is set to default value '1764491'
[INFO] Set the environment variable IBM_PRIVATE_SUBNET_ID for testing ibm_container_cluster resource else it is set to default value '1574951'
[INFO] Set the environment variable IBM_PUBLIC_SUBNET_ID for testing ibm_container_cluster resource else it is set to default value '1415689'
[INFO] Set the environment variable IBM_SUBNET_ID for testing ibm_container_cluster resource else it is set to default value '1415689'
[INFO] Set the environment variable IBM_LBAAS_DATACENTER for testing ibm_lbaas resource else it is set to default value 'wdc04'
[INFO] Set the environment variable IBM_LBAAS_SUBNETID for testing ibm_lbaas resource else it is set to default value '1511875'
[INFO] Set the environment variable IBM_DEDICATED_HOSTNAME for testing ibm_compute_vm_instance resource else it is set to default value 'terraform-dedicatedhost'
[INFO] Set the environment variable IBM_DEDICATED_HOST_ID for testing ibm_compute_vm_instance resource else it is set to default value '30301'
[WARN] Set the environment variable IBM_COMPUTE_VM_INSTANCE_IMAGE_ID for testing the ibm_compute_vm_instance resource. The image should be replicated in the Washington 4 datacenter. Some tests for that resource will fail if this is not set correctly
=== RUN   TestAccIBMResourceKey_Basic
--- PASS: TestAccIBMResourceKey_Basic (87.79s)
=== RUN   TestAccIBMResourceKey_With_Tags
--- PASS: TestAccIBMResourceKey_With_Tags (100.85s)
=== RUN   TestAccIBMResourceKey_Parameters
--- PASS: TestAccIBMResourceKey_Parameters (76.30s)
PASS
ok  	github.com/terraform-providers/terraform-provider-ibm/ibm	266.493s