### PR TITLE
Add datasource support for resource key

### DIFF
--- a/ibm/data_source_ibm_resource_key.go
+++ b/ibm/data_source_ibm_resource_key.go
@@ -1,0 +1,162 @@
+package ibm
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/IBM-Cloud/bluemix-go/crn"
+	"github.com/IBM-Cloud/bluemix-go/models"
+	"github.com/hashicorp/terraform/flatmap"
+
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func dataSourceIBMResourceKey() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceIBMResourceKeyRead,
+
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Description: "The name of the resource key",
+				Type:        schema.TypeString,
+				Required:    true,
+			},
+
+			"resource_instance_id": {
+				Type:          schema.TypeString,
+				Optional:      true,
+				Description:   "The id of the resource instance",
+				ConflictsWith: []string{"resource_alias_id"},
+			},
+
+			"resource_alias_id": {
+				Type:          schema.TypeString,
+				Optional:      true,
+				Description:   "The id of the resource alias",
+				ConflictsWith: []string{"resource_instance_id"},
+			},
+
+			"role": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "User role",
+			},
+
+			"status": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "Status of resource key",
+			},
+
+			"credentials": {
+				Description: "Credentials asociated with the key",
+				Sensitive:   true,
+				Type:        schema.TypeMap,
+				Computed:    true,
+			},
+
+			"most_recent": &schema.Schema{
+				Description: "If true and multiple entries are found, the most recently created resource key is used. " +
+					"If false, an error is returned",
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  false,
+			},
+		},
+	}
+}
+
+func dataSourceIBMResourceKeyRead(d *schema.ResourceData, meta interface{}) error {
+	rsContClient, err := meta.(ClientSession).ResourceControllerAPI()
+	if err != nil {
+		return err
+	}
+	rkAPI := rsContClient.ResourceServiceKey()
+	name := d.Get("name").(string)
+	mostRecent := d.Get("most_recent").(bool)
+
+	keys, err := rkAPI.GetKeys(name)
+	if err != nil {
+		return err
+	}
+	var filteredKeys []models.ServiceKey
+
+	if d.Get("resource_instance_id") == "" && d.Get("resource_instance_id") == "" {
+		filteredKeys = keys
+	} else {
+		crn, err := getCRN(d, meta)
+		if err != nil {
+			return err
+		}
+		for _, key := range keys {
+			if key.SourceCrn == *crn {
+				filteredKeys = append(filteredKeys, key)
+			}
+		}
+
+	}
+
+	var key models.ServiceKey
+
+	if len(filteredKeys) > 1 {
+		if mostRecent {
+			key = mostRecentResourceKey(filteredKeys)
+		} else {
+			return fmt.Errorf(
+				"More than one resource key found with name matching [%s]. "+
+					"Set 'most_recent' to true in your configuration to force the most recent resource key "+
+					"to be used", name)
+		}
+	} else {
+		key = filteredKeys[0]
+	}
+
+	d.SetId(key.ID)
+	role := key.Parameters["role_crn"].(string)
+	role = role[strings.LastIndex(role, ":")+1:]
+	d.Set("role", role)
+	d.Set("credentials", flatmap.Flatten(key.Credentials))
+	d.Set("status", key.State)
+	return nil
+}
+
+func getCRN(d *schema.ResourceData, meta interface{}) (*crn.CRN, error) {
+
+	rsContClient, err := meta.(ClientSession).ResourceControllerAPI()
+	if err != nil {
+		return nil, err
+	}
+
+	if insID, ok := d.GetOk("resource_instance_id"); ok {
+		instance, err := rsContClient.ResourceServiceInstance().GetInstance(insID.(string))
+		if err != nil {
+			return nil, err
+		}
+		return &(instance.Crn), nil
+
+	}
+
+	alias, err := rsContClient.ResourceServiceAlias().Alias(d.Get("resource_alias_id").(string))
+	if err != nil {
+		return nil, err
+	}
+	return &(alias.CRN), nil
+
+}
+
+type resourceKeys []models.ServiceKey
+
+func (k resourceKeys) Len() int { return len(k) }
+
+func (k resourceKeys) Swap(i, j int) { k[i], k[j] = k[j], k[i] }
+
+func (k resourceKeys) Less(i, j int) bool {
+	return (*k[i].CreatedAt).Before(*k[j].CreatedAt)
+}
+
+func mostRecentResourceKey(keys resourceKeys) models.ServiceKey {
+	sortedKeys := keys
+	sort.Sort(sortedKeys)
+	return sortedKeys[len(sortedKeys)-1]
+}

--- a/ibm/data_source_ibm_resource_key_test.go
+++ b/ibm/data_source_ibm_resource_key_test.go
@@ -1,0 +1,117 @@
+package ibm
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/acctest"
+	"github.com/hashicorp/terraform/helper/resource"
+)
+
+func TestAccIBMResourceKeyDataSource_basic(t *testing.T) {
+	resourceName := fmt.Sprintf("terraform_%d", acctest.RandInt())
+	resourceKey := fmt.Sprintf("terraform_%d", acctest.RandInt())
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccCheckIBMResourceKeyDataSourceConfig(resourceName, resourceKey),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("data.ibm_resource_key.testacc_ds_resource_key", "name", resourceKey),
+					resource.TestCheckResourceAttr("data.ibm_resource_key.testacc_ds_resource_key", "credentials.%", "7"),
+					resource.TestCheckResourceAttr("data.ibm_resource_key.testacc_ds_resource_key", "role", "Viewer"),
+					resource.TestCheckResourceAttr("data.ibm_resource_key.testacc_ds_resource_key1", "name", resourceKey),
+					resource.TestCheckResourceAttr("data.ibm_resource_key.testacc_ds_resource_key1", "credentials.%", "7"),
+					resource.TestCheckResourceAttr("data.ibm_resource_key.testacc_ds_resource_key1", "role", "Viewer"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccIBMResourceKeyDataSource_mostrecent(t *testing.T) {
+	resourceName := fmt.Sprintf("terraform_%d", acctest.RandInt())
+	resourceKey := fmt.Sprintf("terraform_%d", acctest.RandInt())
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccCheckIBMResourceKeyDataSourceConfigRecent(resourceName, resourceKey),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("data.ibm_resource_key.testacc_ds_resource_key", "name", resourceKey),
+					resource.TestCheckResourceAttr("data.ibm_resource_key.testacc_ds_resource_key", "credentials.%", "7"),
+					resource.TestCheckResourceAttr("data.ibm_resource_key.testacc_ds_resource_key1", "name", resourceKey),
+					resource.TestCheckResourceAttr("data.ibm_resource_key.testacc_ds_resource_key1", "credentials.%", "7"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckIBMResourceKeyDataSourceConfig(resourceName, resourceKey string) string {
+	return fmt.Sprintf(`
+
+resource "ibm_resource_instance" "resource" {
+  name       = "%s"
+  service    = "cloud-object-storage"
+  plan       = "lite"
+  location   = "global"
+ 
+}
+
+resource "ibm_resource_key" "resourcekey" {
+  name                  = "%s"
+  role                  = "Viewer"
+  resource_instance_id  = "${ibm_resource_instance.resource.id}"
+}
+
+data "ibm_resource_key" "testacc_ds_resource_key" {
+  name                  = "${ibm_resource_key.resourcekey.name}"
+}
+
+data "ibm_resource_key" "testacc_ds_resource_key1" {
+	name                  = "${ibm_resource_key.resourcekey.name}"
+	resource_instance_id  = "${ibm_resource_instance.resource.id}"
+}`, resourceName, resourceKey)
+
+}
+
+func testAccCheckIBMResourceKeyDataSourceConfigRecent(resourceName, resourceKey string) string {
+	return fmt.Sprintf(`
+
+resource "ibm_resource_instance" "resource" {
+  name       = "%s"
+  service    = "cloud-object-storage"
+  plan       = "lite"
+  location   = "global"
+ 
+}
+
+resource "ibm_resource_key" "resourcekey" {
+  name                  = "%s"
+  role                  = "Reader"
+  resource_instance_id  = "${ibm_resource_instance.resource.id}"
+}
+
+resource "ibm_resource_key" "resourcekey1" {
+	name                  = "%s"
+	role                  = "Viewer"
+	resource_instance_id  = "${ibm_resource_instance.resource.id}"
+}
+
+data "ibm_resource_key" "testacc_ds_resource_key" {
+  name                  = "${ibm_resource_key.resourcekey.name}"
+  most_recent           = "true"
+}
+
+data "ibm_resource_key" "testacc_ds_resource_key1" {
+	name                  = "${ibm_resource_key.resourcekey.name}"
+	resource_instance_id  = "${ibm_resource_instance.resource.id}"
+	most_recent           = "true"
+}`, resourceName, resourceKey, resourceKey)
+
+}

--- a/ibm/provider.go
+++ b/ibm/provider.go
@@ -92,6 +92,7 @@ func Provider() terraform.ResourceProvider {
 			"ibm_org_quota":                  dataSourceIBMOrgQuota(),
 			"ibm_resource_group":             dataSourceIBMResourceGroup(),
 			"ibm_resource_instance":          dataSourceIBMResourceInstance(),
+			"ibm_resource_key":               dataSourceIBMResourceKey(),
 			"ibm_security_group":             dataSourceIBMSecurityGroup(),
 			"ibm_service_instance":           dataSourceIBMServiceInstance(),
 			"ibm_service_key":                dataSourceIBMServiceKey(),

--- a/website/docs/d/resource_key.html.markdown
+++ b/website/docs/d/resource_key.html.markdown
@@ -1,0 +1,40 @@
+---
+layout: "ibm"
+page_title: "IBM: ibm_resource_key"
+sidebar_current: "docs-ibm-datasource-resource-key"
+description: |-
+  Get information about a resource key from IBM Cloud.
+---
+
+# ibm\_resource_key
+
+Import the details of an existing IBM resource key from IBM Cloud as a read-only data source. You can then reference the fields of the data source in other resources within the same configuration by using interpolation syntax.
+
+## Example Usage
+
+```hcl
+data "ibm_resource_key" "resourceKeydata" {
+  name                  = "myobjectKey"
+  resource_instance_id  = "${ibm_resource_instance.resource.id}"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `name` - (Required, string) The name of the resource key. You can retrieve the value by running the `bx resource service-keys` command in the [IBM Cloud CLI](https://console.bluemix.net/docs/cli/reference/bluemix_cli/get_started.html#getting-started).
+* `resource_instance_id` - (Optional, string) The id of the resource instance that the resource key is associated with. You can retrieve the value by running the `bx resource service-instances` command in the IBM Cloud CLI.  
+  **NOTE**: Conflicts with `resource_alias_id`.
+* `resource_alias_id` - (Optional, string) The id of the resource alias that the resource key is associated with. You can retrieve the value by running the `bx resource service-alias` command in the IBM Cloud CLI.  
+  **NOTE**: Conflicts with `resource_instance_id`.
+* `most_recent` - (Optional, boolean) If there are multiple resource keys, you can set this argument to `true` to import only the most recently created key.
+
+## Attribute Reference
+
+The following attributes are exported:
+
+* `id` - The unique identifier of the resource key.
+* `credentials` - The credentials associated with the key.
+* `role` - The user role.
+* `status` - Status of resource key.  

--- a/website/ibm.erb
+++ b/website/ibm.erb
@@ -38,6 +38,9 @@
             <li<%= sidebar_current("docs-ibm-datasource-resource-instance") %>>
               <a href="/docs/providers/ibm/d/resource_instance.html">resource_instance</a>
             </li>
+            <li<%= sidebar_current("docs-ibm-datasource-resource-key") %>>
+              <a href="/docs/providers/ibm/d/resource_key.html">resource_key</a>
+            </li>
             <li<%= sidebar_current("docs-ibm-datasource-service-instance") %>>
               <a href="/docs/providers/ibm/d/service_instance.html">service_instance</a>
             </li>


### PR DESCRIPTION
Harinis-MacBook-Pro:terraform-provider-ibm hkantare$ make testacc TEST=./ibm TESTARGS='-run=TestAccIBMResourceKeyDataSource'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./ibm -v -run=TestAccIBMResourceKeyDataSource -timeout 700m
[WARN] Set the environment variable IBM_ORG for testing ibm_org  resource Some tests for that resource will fail if this is not set correctly
[WARN] Set the environment variable IBM_SPACE for testing ibm_space  resource Some tests for that resource will fail if this is not set correctly
[WARN] Set the environment variable IBM_ID1 for testing ibm_space resource Some tests for that resource will fail if this is not set correctly
[WARN] Set the environment variable IBM_ID2 for testing ibm_space resource Some tests for that resource will fail if this is not set correctly
[WARN] Set the environment variable IBM_IAMUSER for testing ibm_iam_user_policy resource Some tests for that resource will fail if this is not set correctly
[INFO] Set the environment variable IBM_DATACENTER for testing ibm_container_cluster resource else it is set to default value 'ams03'
[INFO] Set the environment variable IBM_MACHINE_TYPE for testing ibm_container_cluster resource else it is set to default value 'u1c.2x4'
[INFO] Set the environment variable IBM_PUBLIC_VLAN_ID for testing ibm_container_cluster resource else it is set to default value '1764435'
[INFO] Set the environment variable IBM_PRIVATE_VLAN_ID for testing ibm_container_cluster resource else it is set to default value '1764491'
[INFO] Set the environment variable IBM_PRIVATE_SUBNET_ID for testing ibm_container_cluster resource else it is set to default value '1574951'
[INFO] Set the environment variable IBM_PUBLIC_SUBNET_ID for testing ibm_container_cluster resource else it is set to default value '1415689'
[INFO] Set the environment variable IBM_SUBNET_ID for testing ibm_container_cluster resource else it is set to default value '1415689'
[INFO] Set the environment variable IBM_LBAAS_DATACENTER for testing ibm_lbaas resource else it is set to default value 'wdc04'
[INFO] Set the environment variable IBM_LBAAS_SUBNETID for testing ibm_lbaas resource else it is set to default value '1511875'
[INFO] Set the environment variable IBM_DEDICATED_HOSTNAME for testing ibm_compute_vm_instance resource else it is set to default value 'terraform-dedicatedhost'
[INFO] Set the environment variable IBM_DEDICATED_HOST_ID for testing ibm_compute_vm_instance resource else it is set to default value '30301'
[WARN] Set the environment variable IBM_COMPUTE_VM_INSTANCE_IMAGE_ID for testing the ibm_compute_vm_instance resource. The image should be replicated in the Washington 4 datacenter. Some tests for that resource will fail if this is not set correctly
=== RUN   TestAccIBMResourceKeyDataSource_basic
--- PASS: TestAccIBMResourceKeyDataSource_basic (114.84s)
=== RUN   TestAccIBMResourceKeyDataSource_mostrecent
--- PASS: TestAccIBMResourceKeyDataSource_mostrecent (82.70s)
PASS
ok  	github.com/terraform-providers/terraform-provider-ibm/ibm	199.157s
