### PR TITLE
Add support for IBM dns secondary zone

### DIFF
--- a/ibm/provider.go
+++ b/ibm/provider.go
@@ -123,6 +123,7 @@ func Provider() terraform.ResourceProvider {
 			"ibm_container_cluster":                resourceIBMContainerCluster(),
 			"ibm_container_bind_service":           resourceIBMContainerBindService(),
 			"ibm_dns_domain":                       resourceIBMDNSDomain(),
+			"ibm_dns_secondary":                    resourceIBMDNSSecondary(),
 			"ibm_dns_record":                       resourceIBMDNSRecord(),
 			"ibm_firewall":                         resourceIBMFirewall(),
 			"ibm_firewall_policy":                  resourceIBMFirewallPolicy(),

--- a/ibm/resource_ibm_dns_secondary.go
+++ b/ibm/resource_ibm_dns_secondary.go
@@ -1,0 +1,170 @@
+package ibm
+
+import (
+	"errors"
+	"fmt"
+	"log"
+	"strconv"
+
+	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/softlayer/softlayer-go/datatypes"
+	"github.com/softlayer/softlayer-go/services"
+	"github.com/softlayer/softlayer-go/sl"
+)
+
+func resourceIBMDNSSecondary() *schema.Resource {
+	return &schema.Resource{
+		Exists:   resourceIBMDNSSecondaryExists,
+		Create:   resourceIBMDNSSecondaryCreate,
+		Read:     resourceIBMDNSSecondaryRead,
+		Update:   resourceIBMDNSSecondaryUpdate,
+		Delete:   resourceIBMDNSSecondaryDelete,
+		Importer: &schema.ResourceImporter{},
+		Schema: map[string]*schema.Schema{
+			"master_ip_address": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+
+			"transfer_frequency": {
+				Type:     schema.TypeInt,
+				Required: true,
+			},
+
+			"zone_name": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+
+			"status_id": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+
+			"status_text": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+
+			"tags": {
+				Type:     schema.TypeSet,
+				Optional: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+				Set:      schema.HashString,
+			},
+		},
+	}
+}
+
+func resourceIBMDNSSecondaryCreate(d *schema.ResourceData, meta interface{}) error {
+	sess := meta.(ClientSession).SoftLayerSession()
+	service := services.GetDnsSecondaryService(sess)
+
+	// prepare creation parameters
+	opts := datatypes.Dns_Secondary{
+		MasterIpAddress:   sl.String(d.Get("master_ip_address").(string)),
+		TransferFrequency: sl.Int(d.Get("transfer_frequency").(int)),
+		ZoneName:          sl.String(d.Get("zone_name").(string)),
+	}
+
+	// create Dns_Secondary object
+	response, err := service.CreateObject(&opts)
+	if err != nil {
+		return fmt.Errorf("Error creating Dns Secondary Zone: %s", err)
+	}
+
+	// populate id
+	id := *response.Id
+	d.SetId(strconv.Itoa(id))
+	log.Printf("[INFO] Created Dns Secondary Zone: %d", id)
+
+	// read remote state
+	return resourceIBMDNSSecondaryRead(d, meta)
+}
+
+func resourceIBMDNSSecondaryRead(d *schema.ResourceData, meta interface{}) error {
+	sess := meta.(ClientSession).SoftLayerSession()
+	service := services.GetDnsSecondaryService(sess)
+
+	dnsId, _ := strconv.Atoi(d.Id())
+
+	// retrieve remote object state
+	dns_domain_secondary, err := service.Id(dnsId).GetObject()
+	if err != nil {
+		return fmt.Errorf("Error retrieving Dns Secondary Zone %d: %s", dnsId, err)
+	}
+
+	// populate fields
+	d.Set("master_ip_address", *dns_domain_secondary.MasterIpAddress)
+	d.Set("transfer_frequency", *dns_domain_secondary.TransferFrequency)
+	d.Set("zone_name", *dns_domain_secondary.ZoneName)
+	d.Set("status_id", *dns_domain_secondary.StatusId)
+	d.Set("status_text", *dns_domain_secondary.StatusText)
+
+	return nil
+}
+
+func resourceIBMDNSSecondaryUpdate(d *schema.ResourceData, meta interface{}) error {
+	sess := meta.(ClientSession).SoftLayerSession()
+	domainId, _ := strconv.Atoi(d.Id())
+	hasChange := false
+
+	opts := datatypes.Dns_Secondary{}
+	if d.HasChange("master_ip_address") {
+		opts.MasterIpAddress = sl.String(d.Get("master_ip_address").(string))
+		hasChange = true
+	}
+
+	if d.HasChange("transfer_frequency") {
+		opts.TransferFrequency = sl.Int(d.Get("transfer_frequency").(int))
+		hasChange = true
+	}
+
+	if hasChange {
+		service := services.GetDnsSecondaryService(sess)
+		_, err := service.Id(domainId).EditObject(&opts)
+
+		if err != nil {
+			return fmt.Errorf("Error editing DNS secondary zone (%d): %s", domainId, err)
+		}
+	}
+
+	return nil
+}
+
+func resourceIBMDNSSecondaryDelete(d *schema.ResourceData, meta interface{}) error {
+	sess := meta.(ClientSession).SoftLayerSession()
+	service := services.GetDnsSecondaryService(sess)
+
+	dnsId, err := strconv.Atoi(d.Id())
+	if err != nil {
+		return fmt.Errorf("Error deleting Dns Secondary Zone: %s", err)
+	}
+
+	log.Printf("[INFO] Deleting Dns Secondary Zone: %d", dnsId)
+	result, err := service.Id(dnsId).DeleteObject()
+	if err != nil {
+		return fmt.Errorf("Error deleting Dns Secondary Zone: %s", err)
+	}
+
+	if !result {
+		return errors.New("Error deleting Dns Secondary Zone")
+	}
+
+	d.SetId("")
+	return nil
+}
+
+func resourceIBMDNSSecondaryExists(d *schema.ResourceData, meta interface{}) (bool, error) {
+	sess := meta.(ClientSession).SoftLayerSession()
+	service := services.GetDnsSecondaryService(sess)
+
+	dnsId, err := strconv.Atoi(d.Id())
+	if err != nil {
+		return false, fmt.Errorf("Not a valid ID, must be an integer: %s", err)
+	}
+
+	result, err := service.Id(dnsId).GetObject()
+	return err == nil && result.Id != nil && *result.Id == dnsId, nil
+}

--- a/ibm/resource_ibm_dns_secondary_test.go
+++ b/ibm/resource_ibm_dns_secondary_test.go
@@ -1,0 +1,188 @@
+package ibm
+
+import (
+	"fmt"
+	"strconv"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/acctest"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+	"github.com/softlayer/softlayer-go/services"
+)
+
+func TestAccIBMDnsSecondary_Basic(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckIBMDNSSecondaryDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: fmt.Sprintf(testAccCheckIBMDnsSecondaryConfig, zoneName, transferFrequency1, masterIPAddress1),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckIBMDnsSecondaryZoneExists("ibm_dns_secondary.dns-secondary-zone-1"),
+					resource.TestCheckResourceAttr(
+						"ibm_dns_secondary.dns-secondary-zone-1", "zone_name", zoneName),
+					resource.TestCheckResourceAttr(
+						"ibm_dns_secondary.dns-secondary-zone-1", "transfer_frequency", "10"),
+					resource.TestCheckResourceAttr(
+						"ibm_dns_secondary.dns-secondary-zone-1", "master_ip_address", masterIPAddress1),
+				),
+			},
+			{
+				Config: fmt.Sprintf(testAccCheckIBMDnsSecondaryConfig, zoneName, transferFrequency2, masterIPAddress2),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(
+						"ibm_dns_secondary.dns-secondary-zone-1", "transfer_frequency", "15"),
+					resource.TestCheckResourceAttr(
+						"ibm_dns_secondary.dns-secondary-zone-1", "master_ip_address", masterIPAddress2),
+				),
+			},
+		},
+	})
+}
+
+func TestAccIBMDnsSecondary_Basic_Tags(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckIBMDNSSecondaryDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: fmt.Sprintf(testAccCheckIBMDnsSecondaryConfig_basic_tags, zoneName, transferFrequency1, masterIPAddress1),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckIBMDnsSecondaryZoneExists("ibm_dns_secondary.dns-secondary-zone-1"),
+					resource.TestCheckResourceAttr(
+						"ibm_dns_secondary.dns-secondary-zone-1", "zone_name", zoneName),
+					resource.TestCheckResourceAttr(
+						"ibm_dns_secondary.dns-secondary-zone-1", "transfer_frequency", "10"),
+					resource.TestCheckResourceAttr(
+						"ibm_dns_secondary.dns-secondary-zone-1", "master_ip_address", masterIPAddress1),
+					resource.TestCheckResourceAttr(
+						"ibm_dns_secondary.dns-secondary-zone-1", "tags.#", "2"),
+				),
+			},
+			{
+				Config: fmt.Sprintf(testAccCheckIBMDnsSecondaryConfig_updated_tags, zoneName, transferFrequency2, masterIPAddress2),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(
+						"ibm_dns_secondary.dns-secondary-zone-1", "transfer_frequency", "15"),
+					resource.TestCheckResourceAttr(
+						"ibm_dns_secondary.dns-secondary-zone-1", "master_ip_address", masterIPAddress2),
+					resource.TestCheckResourceAttr(
+						"ibm_dns_secondary.dns-secondary-zone-1", "tags.#", "3"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccIBMDnsSecondary_Import(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckIBMDNSSecondaryDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: fmt.Sprintf(testAccCheckIBMDnsSecondaryConfig, zoneName, transferFrequency1, masterIPAddress1),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckIBMDnsSecondaryZoneExists("ibm_dns_secondary.dns-secondary-zone-1"),
+					resource.TestCheckResourceAttr(
+						"ibm_dns_secondary.dns-secondary-zone-1", "zone_name", zoneName),
+					resource.TestCheckResourceAttr(
+						"ibm_dns_secondary.dns-secondary-zone-1", "transfer_frequency", "10"),
+					resource.TestCheckResourceAttr(
+						"ibm_dns_secondary.dns-secondary-zone-1", "master_ip_address", masterIPAddress1),
+				),
+			},
+
+			resource.TestStep{
+				ResourceName:      "ibm_dns_secondary.dns-secondary-zone-1",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testAccCheckIBMDnsSecondaryZoneExists(n string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No Record ID is set")
+		}
+
+		dnsId, _ := strconv.Atoi(rs.Primary.ID)
+
+		service := services.GetDnsSecondaryService(testAccProvider.Meta().(ClientSession).SoftLayerSession())
+		foundSecondaryZone, err := service.Id(dnsId).GetObject()
+
+		if err != nil {
+			return err
+		}
+
+		if strconv.Itoa(int(*foundSecondaryZone.Id)) != rs.Primary.ID {
+			return fmt.Errorf("Record not found")
+		}
+
+		return nil
+	}
+}
+
+func testAccCheckIBMDNSSecondaryDestroy(s *terraform.State) error {
+	service := services.GetDnsSecondaryService(testAccProvider.Meta().(ClientSession).SoftLayerSession())
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "ibm_dns_secondary" {
+			continue
+		}
+
+		dnsId, _ := strconv.Atoi(rs.Primary.ID)
+
+		// Try to find the domain
+		_, err := service.Id(dnsId).GetObject()
+
+		if err == nil {
+			return fmt.Errorf("Dns secondary zone with id %d still exists", dnsId)
+		}
+	}
+
+	return nil
+}
+
+const testAccCheckIBMDnsSecondaryConfig = `
+resource "ibm_dns_secondary" "dns-secondary-zone-1" {
+    zone_name = "%s"
+    transfer_frequency = "%d"
+    master_ip_address = "%s"
+}
+`
+
+const testAccCheckIBMDnsSecondaryConfig_basic_tags = `
+resource "ibm_dns_secondary" "dns-secondary-zone-1" {
+    zone_name = "%s"
+    transfer_frequency = "%d"
+	master_ip_address = "%s"
+	tags = ["one", "two"]
+}
+`
+
+const testAccCheckIBMDnsSecondaryConfig_updated_tags = `
+resource "ibm_dns_secondary" "dns-secondary-zone-1" {
+    zone_name = "%s"
+    transfer_frequency = "%d"
+	master_ip_address = "%s"
+	tags = ["one", "two", "three"]
+}
+`
+
+var zoneName = fmt.Sprintf("tfuatdomain%s.com", acctest.RandString(10))
+var masterIPAddress1 = "172.16.0.1"
+var masterIPAddress2 = "172.16.0.2"
+var transferFrequency1 = 10
+var transferFrequency2 = 15

--- a/website/docs/r/dns_secondary.html.markdown
+++ b/website/docs/r/dns_secondary.html.markdown
@@ -1,0 +1,39 @@
+---
+layout: "ibm"
+page_title: "IBM: dns_secondary"
+sidebar_current: "docs-ibm-resource-dns-secondary"
+description: |-
+  Manages IBM DNS Secondary Zone.
+---
+
+# ibm\_dns_secondary
+
+The `ibm_dns_secondary` resource represents a single secondary DNS zone managed on SoftLayer. Each record created within the secondary DNS service defines which zone is transferred, what server it is transferred from, and the frequency that zone transfers occur at. Zone transfers are performed automatically based on the transfer frequency set on the secondary DNS record.
+
+## Example Usage
+
+```hcl
+resource "ibm_dns_secondary" "dns-secondary-test" {
+    zone_name = "dns-secondary-test.com"
+    master_ip_address = "127.0.0.10"
+    transfer_frequency = 10
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `zone_name` - (Required, string) The name of the zone that is transferred.
+* `transfer_frequency` - (Required, int) Signifies how often a secondary DNS zone should be transferred in minutes.
+* `master_ip_address` - (Required, string)  The IP address of the master name server where a secondary DNS zone is transferred from.
+* `tags` - (Optional, array of strings) Tags associated with the DNS secondary instance.
+  **NOTE**: `Tags` are managed locally and not stored on the IBM Cloud service endpoint at this moment.
+
+## Attribute Reference
+
+The following attributes are exported:
+
+* `id` - A secondary zone's internal identifier.
+* `status_id` - The current status of a secondary DNS record.
+* `status_text` - The textual representation of a secondary DNS zone's status.

--- a/website/ibm.erb
+++ b/website/ibm.erb
@@ -216,6 +216,9 @@
               <li<%= sidebar_current("docs-ibm-resource-dns-domain") %>>
                 <a href="/docs/providers/ibm/r/dns_domain.html">dns_domain</a>
               </li>
+              <li<%= sidebar_current("docs-ibm-resource-dns-secondary") %>>
+                <a href="/docs/providers/ibm/r/dns_secondary.html">dns_secondary</a>
+              </li>
               <li<%= sidebar_current("docs-ibm-resource-dns-record") %>>
                 <a href="/docs/providers/ibm/r/dns_record.html">dns_record</a>
               </li>


### PR DESCRIPTION
```
=== RUN   TestAccIBMDnsSecondary_Basic
--- PASS: TestAccIBMDnsSecondary_Basic (76.62s)
=== RUN   TestAccIBMDnsSecondary_Basic_Tags
--- PASS: TestAccIBMDnsSecondary_Basic_Tags (54.55s)
=== RUN   TestAccIBMDnsSecondary_Import
--- PASS: TestAccIBMDnsSecondary_Import (41.73s)
PASS
ok      github.com/terraform-providers/terraform-provider-ibm/ibm    174.511s
```