### PR TITLE
Add resource support for IAM Service Policy

### DIFF
--- a/ibm/provider.go
+++ b/ibm/provider.go
@@ -131,6 +131,7 @@ func Provider() terraform.ResourceProvider {
 			"ibm_firewall_policy":                  resourceIBMFirewallPolicy(),
 			"ibm_iam_user_policy":                  resourceIBMIAMUserPolicy(),
 			"ibm_iam_service_id":                   resourceIBMIAMServiceID(),
+			"ibm_iam_service_policy":               resourceIBMIAMServicePolicy(),
 			"ibm_lb":                               resourceIBMLb(),
 			"ibm_lbaas":                            resourceIBMLbaas(),
 			"ibm_lbaas_server_instance_attachment": resourceIBMLbaasServerInstanceAttachment(),

--- a/ibm/resource_ibm_iam_service_policy.go
+++ b/ibm/resource_ibm_iam_service_policy.go
@@ -1,0 +1,430 @@
+package ibm
+
+import (
+	"fmt"
+
+	"github.com/IBM-Cloud/bluemix-go/api/iam/iamv1"
+	"github.com/IBM-Cloud/bluemix-go/models"
+
+	"github.com/IBM-Cloud/bluemix-go/bmxerror"
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func resourceIBMIAMServicePolicy() *schema.Resource {
+	return &schema.Resource{
+		Create:   resourceIBMIAMServicePolicyCreate,
+		Read:     resourceIBMIAMServicePolicyRead,
+		Update:   resourceIBMIAMServicePolicyUpdate,
+		Delete:   resourceIBMIAMServicePolicyDelete,
+		Exists:   resourceIBMIAMServicePolicyExists,
+		Importer: &schema.ResourceImporter{},
+
+		Schema: map[string]*schema.Schema{
+			"serviceID_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "UUID of ServiceID",
+				ForceNew:    true,
+			},
+
+			"roles": {
+				Type:        schema.TypeList,
+				Required:    true,
+				Elem:        &schema.Schema{Type: schema.TypeString},
+				Description: "Role names of the policy definition",
+			},
+
+			"resources": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Computed: true,
+				MaxItems: 1,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"service": {
+							Type:        schema.TypeString,
+							Optional:    true,
+							Description: "Service name of the policy definition",
+						},
+
+						"resource_instance_id": {
+							Type:        schema.TypeString,
+							Optional:    true,
+							Description: "ID of resource instance of the policy definition",
+						},
+
+						"region": {
+							Type:        schema.TypeString,
+							Optional:    true,
+							Description: "Region of the policy definition",
+						},
+
+						"resource_type": {
+							Type:        schema.TypeString,
+							Optional:    true,
+							Description: "Resource type of the policy definition",
+						},
+
+						"resource": {
+							Type:        schema.TypeString,
+							Optional:    true,
+							Description: "Resource of the policy definition",
+						},
+
+						"resource_group_id": {
+							Type:        schema.TypeString,
+							Optional:    true,
+							Description: "ID of the resource group.",
+						},
+					},
+				},
+			},
+
+			"tags": {
+				Type:     schema.TypeSet,
+				Optional: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+				Set:      schema.HashString,
+			},
+
+			"version": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func resourceIBMIAMServicePolicyCreate(d *schema.ResourceData, meta interface{}) error {
+	iamClient, err := meta.(ClientSession).IAMAPI()
+	if err != nil {
+		return err
+	}
+	serviceIDUUID := d.Get("serviceID_id").(string)
+
+	bmxSess, err := meta.(ClientSession).BluemixSession()
+	if err != nil {
+		return err
+	}
+
+	mccpAPI, err := meta.(ClientSession).MccpAPI()
+	if err != nil {
+		return err
+	}
+	region, err := mccpAPI.Regions().FindRegionByName(bmxSess.Config.Region)
+	if err != nil {
+		return err
+	}
+
+	userDetails, err := meta.(ClientSession).BluemixUserDetails()
+	if err != nil {
+		return err
+	}
+
+	boundTo := GenerateBoundToCRN(*region, userDetails.userAccount)
+	var policy models.Policy
+
+	policy, err = generatePolicy(d, meta, userDetails.userAccount)
+	if err != nil {
+		return err
+	}
+
+	serviceID, err := iamClient.ServiceIds().Get(serviceIDUUID)
+	if err != nil {
+		return err
+	}
+
+	servicePolicy, err := iamClient.ServicePolicies().Create(boundTo.ScopeSegment(), serviceID.IAMID, policy)
+
+	if err != nil {
+		return fmt.Errorf("Error creating servicePolicy: %s", err)
+	}
+
+	d.SetId(fmt.Sprintf("%s/%s", serviceIDUUID, servicePolicy.ID))
+
+	return resourceIBMIAMServicePolicyRead(d, meta)
+}
+
+func resourceIBMIAMServicePolicyRead(d *schema.ResourceData, meta interface{}) error {
+
+	iamClient, err := meta.(ClientSession).IAMAPI()
+	if err != nil {
+		return err
+	}
+
+	serviceIDUUID, servicePolicyID, err := idParts(d.Id())
+	if err != nil {
+		return err
+	}
+
+	bmxSess, err := meta.(ClientSession).BluemixSession()
+	if err != nil {
+		return err
+	}
+
+	mccpAPI, err := meta.(ClientSession).MccpAPI()
+	if err != nil {
+		return err
+	}
+	region, err := mccpAPI.Regions().FindRegionByName(bmxSess.Config.Region)
+	if err != nil {
+		return err
+	}
+
+	userDetails, err := meta.(ClientSession).BluemixUserDetails()
+	if err != nil {
+		return err
+	}
+
+	boundTo := GenerateBoundToCRN(*region, userDetails.userAccount)
+
+	serviceID, err := iamClient.ServiceIds().Get(serviceIDUUID)
+	if err != nil {
+		return err
+	}
+
+	servicePolicy, err := iamClient.ServicePolicies().Get(boundTo.ScopeSegment(), serviceID.IAMID, servicePolicyID)
+	if err != nil {
+		return fmt.Errorf("Error retrieving servicePolicy: %s", err)
+	}
+
+	d.Set("serviceID_id", serviceIDUUID)
+	roles := make([]string, len(servicePolicy.Roles))
+	for i, role := range servicePolicy.Roles {
+		roles[i] = role.DisplayName
+	}
+	d.Set("roles", roles)
+	d.Set("version", servicePolicy.Version)
+	d.Set("resources", flattenPolicyResource(servicePolicy.Resources))
+
+	return nil
+}
+
+func resourceIBMIAMServicePolicyUpdate(d *schema.ResourceData, meta interface{}) error {
+
+	iamClient, err := meta.(ClientSession).IAMAPI()
+	if err != nil {
+		return err
+	}
+	if d.HasChange("roles") || d.HasChange("resources") {
+		serviceIDUUID, servicePolicyID, err := idParts(d.Id())
+		if err != nil {
+			return err
+		}
+
+		bmxSess, err := meta.(ClientSession).BluemixSession()
+		if err != nil {
+			return err
+		}
+
+		mccpAPI, err := meta.(ClientSession).MccpAPI()
+		if err != nil {
+			return err
+		}
+		region, err := mccpAPI.Regions().FindRegionByName(bmxSess.Config.Region)
+		if err != nil {
+			return err
+		}
+
+		userDetails, err := meta.(ClientSession).BluemixUserDetails()
+		if err != nil {
+			return err
+		}
+
+		boundTo := GenerateBoundToCRN(*region, userDetails.userAccount)
+		var policy models.Policy
+
+		policy, err = generatePolicy(d, meta, userDetails.userAccount)
+		if err != nil {
+			return err
+		}
+
+		serviceID, err := iamClient.ServiceIds().Get(serviceIDUUID)
+		if err != nil {
+			return err
+		}
+
+		_, err = iamClient.ServicePolicies().Update(iamv1.ServicePolicyIdentifier{
+			Scope:    boundTo.ScopeSegment(),
+			IAMID:    serviceID.IAMID,
+			PolicyID: servicePolicyID,
+		}, policy, d.Get("version").(string))
+		if err != nil {
+			return fmt.Errorf("Error updating service policy: %s", err)
+		}
+
+	}
+
+	return resourceIBMIAMServicePolicyRead(d, meta)
+
+}
+
+func resourceIBMIAMServicePolicyDelete(d *schema.ResourceData, meta interface{}) error {
+	iamClient, err := meta.(ClientSession).IAMAPI()
+	if err != nil {
+		return err
+	}
+
+	serviceIDUUID, servicePolicyID, err := idParts(d.Id())
+	if err != nil {
+		return err
+	}
+
+	bmxSess, err := meta.(ClientSession).BluemixSession()
+	if err != nil {
+		return err
+	}
+
+	mccpAPI, err := meta.(ClientSession).MccpAPI()
+	if err != nil {
+		return err
+	}
+	region, err := mccpAPI.Regions().FindRegionByName(bmxSess.Config.Region)
+	if err != nil {
+		return err
+	}
+
+	userDetails, err := meta.(ClientSession).BluemixUserDetails()
+	if err != nil {
+		return err
+	}
+
+	boundTo := GenerateBoundToCRN(*region, userDetails.userAccount)
+
+	serviceID, err := iamClient.ServiceIds().Get(serviceIDUUID)
+	if err != nil {
+		return err
+	}
+
+	err = iamClient.ServicePolicies().Delete(iamv1.ServicePolicyIdentifier{
+		Scope:    boundTo.ScopeSegment(),
+		IAMID:    serviceID.IAMID,
+		PolicyID: servicePolicyID,
+	})
+	if err != nil {
+		return fmt.Errorf("Error deleting service policy: %s", err)
+	}
+
+	d.SetId("")
+
+	return nil
+}
+
+func resourceIBMIAMServicePolicyExists(d *schema.ResourceData, meta interface{}) (bool, error) {
+	iamClient, err := meta.(ClientSession).IAMAPI()
+	if err != nil {
+		return false, err
+	}
+	serviceIDUUID, servicePolicyID, err := idParts(d.Id())
+	if err != nil {
+		return false, err
+	}
+
+	bmxSess, err := meta.(ClientSession).BluemixSession()
+	if err != nil {
+		return false, err
+	}
+
+	mccpAPI, err := meta.(ClientSession).MccpAPI()
+	if err != nil {
+		return false, err
+	}
+	region, err := mccpAPI.Regions().FindRegionByName(bmxSess.Config.Region)
+	if err != nil {
+		return false, err
+	}
+
+	userDetails, err := meta.(ClientSession).BluemixUserDetails()
+	if err != nil {
+		return false, err
+	}
+
+	boundTo := GenerateBoundToCRN(*region, userDetails.userAccount)
+
+	serviceID, err := iamClient.ServiceIds().Get(serviceIDUUID)
+	if err != nil {
+		return false, err
+	}
+
+	servicePolicy, err := iamClient.ServicePolicies().Get(boundTo.ScopeSegment(), serviceID.IAMID, servicePolicyID)
+	if err != nil {
+		return false, fmt.Errorf("Error retrieving servicePolicy: %s", err)
+	}
+	if err != nil {
+		if apiErr, ok := err.(bmxerror.RequestFailure); ok {
+			if apiErr.StatusCode() == 404 {
+				return false, nil
+			}
+		}
+		return false, fmt.Errorf("Error communicating with the API: %s", err)
+	}
+
+	tempID := fmt.Sprintf("%s/%s", serviceIDUUID, servicePolicy.ID)
+
+	return tempID == d.Id(), nil
+}
+
+func generatePolicy(d *schema.ResourceData, meta interface{}, accountID string) (models.Policy, error) {
+
+	policyResources := []models.PolicyResource{}
+	var resources []interface{}
+	var serviceName string
+
+	if res, ok := d.GetOk("resources"); ok {
+		resources = res.([]interface{})
+		for _, resource := range resources {
+			r, _ := resource.(map[string]interface{})
+			serviceName = r["service"].(string)
+			resourceParam := models.PolicyResource{
+				ServiceName:     r["service"].(string),
+				ServiceInstance: r["resource_instance_id"].(string),
+				Region:          r["region"].(string),
+				ResourceType:    r["resource_type"].(string),
+				Resource:        r["resource"].(string),
+				AccountID:       accountID,
+				ResourceGroupID: r["resource_group_id"].(string),
+			}
+			policyResources = append(policyResources, resourceParam)
+		}
+	} else {
+		policyResources = append(policyResources, models.PolicyResource{AccountID: accountID})
+	}
+
+	iamClient, err := meta.(ClientSession).IAMAPI()
+	if err != nil {
+		return models.Policy{}, err
+	}
+
+	iamRepo := iamClient.ServiceRoles()
+
+	var roles []models.PolicyRole
+
+	if serviceName == "" {
+		roles, err = iamRepo.ListSystemDefinedRoles()
+	} else {
+		roles, err = iamRepo.ListServiceRoles(serviceName)
+	}
+	if err != nil {
+		return models.Policy{}, err
+	}
+
+	policyRoles, err := getRolesFromRoleNames(expandStringList(d.Get("roles").([]interface{})), roles)
+	if err != nil {
+		return models.Policy{}, err
+	}
+
+	return models.Policy{Roles: policyRoles, Resources: policyResources}, nil
+}
+
+func getRolesFromRoleNames(roleNames []string, roles []models.PolicyRole) ([]models.PolicyRole, error) {
+
+	filteredRoles := []models.PolicyRole{}
+	for _, roleName := range roleNames {
+		role, err := findRoleByName(roles, roleName)
+		if err != nil {
+			return []models.PolicyRole{}, err
+		}
+		filteredRoles = append(filteredRoles, role)
+	}
+	return filteredRoles, nil
+}

--- a/ibm/resource_ibm_iam_service_policy_test.go
+++ b/ibm/resource_ibm_iam_service_policy_test.go
@@ -1,0 +1,434 @@
+package ibm
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/IBM-Cloud/bluemix-go/api/iam/iamv1"
+	"github.com/IBM-Cloud/bluemix-go/models"
+
+	"strings"
+
+	"github.com/hashicorp/terraform/helper/acctest"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+)
+
+func TestAccIBMIAMServicePolicy_Basic(t *testing.T) {
+	var conf models.Policy
+	name := fmt.Sprintf("terraform_%d", acctest.RandInt())
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckIBMIAMServicePolicyDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccCheckIBMIAMServicePolicy_basic(name),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckIBMIAMServicePolicyExists("ibm_iam_service_policy.policy", conf),
+					resource.TestCheckResourceAttr("ibm_iam_service_id.serviceID", "name", name),
+					resource.TestCheckResourceAttr("ibm_iam_service_policy.policy", "tags.#", "1"),
+					resource.TestCheckResourceAttr("ibm_iam_service_policy.policy", "roles.#", "1"),
+				),
+			},
+			resource.TestStep{
+				Config: testAccCheckIBMIAMServicePolicy_updateRole(name),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("ibm_iam_service_id.serviceID", "name", name),
+					resource.TestCheckResourceAttr("ibm_iam_service_policy.policy", "tags.#", "2"),
+					resource.TestCheckResourceAttr("ibm_iam_service_policy.policy", "roles.#", "2"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccIBMIAMServicePolicy_With_Service(t *testing.T) {
+	var conf models.Policy
+	name := fmt.Sprintf("terraform_%d", acctest.RandInt())
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckIBMIAMServicePolicyDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccCheckIBMIAMServicePolicy_service(name),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckIBMIAMServicePolicyExists("ibm_iam_service_policy.policy", conf),
+					resource.TestCheckResourceAttr("ibm_iam_service_id.serviceID", "name", name),
+					resource.TestCheckResourceAttr("ibm_iam_service_policy.policy", "resources.0.service", "cloud-object-storage"),
+					resource.TestCheckResourceAttr("ibm_iam_service_policy.policy", "roles.#", "1"),
+				),
+			},
+			resource.TestStep{
+				Config: testAccCheckIBMIAMServicePolicy_updateServiceAndRegion(name),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("ibm_iam_service_id.serviceID", "name", name),
+					resource.TestCheckResourceAttr("ibm_iam_service_policy.policy", "resources.0.service", "kms"),
+					resource.TestCheckResourceAttr("ibm_iam_service_policy.policy", "resources.0.region", "us-south"),
+					resource.TestCheckResourceAttr("ibm_iam_service_policy.policy", "roles.#", "2"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccIBMIAMServicePolicy_With_ResourceInstance(t *testing.T) {
+	var conf models.Policy
+	name := fmt.Sprintf("terraform_%d", acctest.RandInt())
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckIBMIAMServicePolicyDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccCheckIBMIAMServicePolicy_resource_instance(name),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckIBMIAMServicePolicyExists("ibm_iam_service_policy.policy", conf),
+					resource.TestCheckResourceAttr("ibm_iam_service_id.serviceID", "name", name),
+					resource.TestCheckResourceAttr("ibm_iam_service_policy.policy", "resources.0.service", "kms"),
+					resource.TestCheckResourceAttr("ibm_iam_service_policy.policy", "roles.#", "3"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccIBMIAMServicePolicy_With_Resource_Group(t *testing.T) {
+	var conf models.Policy
+	name := fmt.Sprintf("terraform_%d", acctest.RandInt())
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckIBMIAMServicePolicyDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccCheckIBMIAMServicePolicy_resource_group(name),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckIBMIAMServicePolicyExists("ibm_iam_service_policy.policy", conf),
+					resource.TestCheckResourceAttr("ibm_iam_service_id.serviceID", "name", name),
+					resource.TestCheckResourceAttr("ibm_iam_service_policy.policy", "resources.0.service", "containers-kubernetes"),
+					resource.TestCheckResourceAttr("ibm_iam_service_policy.policy", "roles.#", "1"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccIBMIAMServicePolicy_With_Resource_Type(t *testing.T) {
+	var conf models.Policy
+	name := fmt.Sprintf("terraform_%d", acctest.RandInt())
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckIBMIAMServicePolicyDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccCheckIBMIAMServicePolicy_resource_type(name),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckIBMIAMServicePolicyExists("ibm_iam_service_policy.policy", conf),
+					resource.TestCheckResourceAttr("ibm_iam_service_id.serviceID", "name", name),
+					resource.TestCheckResourceAttr("ibm_iam_service_policy.policy", "roles.#", "1"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccIBMIAMServicePolicy_import(t *testing.T) {
+	var conf models.Policy
+	name := fmt.Sprintf("terraform_%d", acctest.RandInt())
+	resourceName := "ibm_iam_service_policy.policy"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckIBMIAMServicePolicyDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccCheckIBMIAMServicePolicy_import(name),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckIBMIAMServicePolicyExists(resourceName, conf),
+					resource.TestCheckResourceAttr("ibm_iam_service_id.serviceID", "name", name),
+					resource.TestCheckResourceAttr("ibm_iam_service_policy.policy", "roles.#", "1"),
+				),
+			},
+			resource.TestStep{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testAccCheckIBMIAMServicePolicyDestroy(s *terraform.State) error {
+	rsContClient, err := testAccProvider.Meta().(ClientSession).IAMAPI()
+	if err != nil {
+		return err
+	}
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "ibm_iam_service_policy" {
+			continue
+		}
+
+		policyID := rs.Primary.ID
+
+		serviceIDUUID, ServicePolicyID, err := idParts(policyID)
+		if err != nil {
+			return err
+		}
+
+		bmxSess, err := testAccProvider.Meta().(ClientSession).BluemixSession()
+		if err != nil {
+			return err
+		}
+
+		mccpAPI, err := testAccProvider.Meta().(ClientSession).MccpAPI()
+		if err != nil {
+			return err
+		}
+		region, err := mccpAPI.Regions().FindRegionByName(bmxSess.Config.Region)
+		if err != nil {
+			return err
+		}
+
+		userDetails, err := testAccProvider.Meta().(ClientSession).BluemixUserDetails()
+
+		boundTo := GenerateBoundToCRN(*region, userDetails.userAccount)
+
+		serviceID, err := rsContClient.ServiceIds().Get(serviceIDUUID)
+		if err != nil {
+			return nil
+		}
+
+		// Try to find the key
+		err = rsContClient.ServicePolicies().Delete(iamv1.ServicePolicyIdentifier{
+			Scope:    boundTo.ScopeSegment(),
+			IAMID:    serviceID.IAMID,
+			PolicyID: ServicePolicyID,
+		})
+
+		if err != nil && !strings.Contains(err.Error(), "404") {
+			return fmt.Errorf("Error waiting for service policy (%s) to be destroyed: %s", rs.Primary.ID, err)
+		}
+	}
+
+	return nil
+}
+
+func testAccCheckIBMIAMServicePolicyExists(n string, obj models.Policy) resource.TestCheckFunc {
+
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+
+		rsContClient, err := testAccProvider.Meta().(ClientSession).IAMAPI()
+		if err != nil {
+			return err
+		}
+
+		policyID := rs.Primary.ID
+
+		serviceIDUUID, ServicePolicyID, err := idParts(policyID)
+		if err != nil {
+			return err
+		}
+
+		bmxSess, err := testAccProvider.Meta().(ClientSession).BluemixSession()
+		if err != nil {
+			return err
+		}
+
+		mccpAPI, err := testAccProvider.Meta().(ClientSession).MccpAPI()
+		if err != nil {
+			return err
+		}
+		region, err := mccpAPI.Regions().FindRegionByName(bmxSess.Config.Region)
+		if err != nil {
+			return err
+		}
+
+		userDetails, err := testAccProvider.Meta().(ClientSession).BluemixUserDetails()
+
+		boundTo := GenerateBoundToCRN(*region, userDetails.userAccount)
+
+		serviceID, err := rsContClient.ServiceIds().Get(serviceIDUUID)
+		if err != nil {
+			return err
+		}
+
+		// Try to find the key
+		policy, err := rsContClient.ServicePolicies().Get(boundTo.ScopeSegment(), serviceID.IAMID, ServicePolicyID)
+		obj = policy
+		return nil
+	}
+}
+
+func testAccCheckIBMIAMServicePolicy_basic(name string) string {
+	return fmt.Sprintf(`
+
+		resource "ibm_iam_service_id" "serviceID" {
+			name = "%s"
+		  }
+		  
+		  resource "ibm_iam_service_policy" "policy" {
+			serviceID_id = "${ibm_iam_service_id.serviceID.id}"
+			roles        = ["Viewer"]
+			tags         = ["tag1"]
+		  }
+
+	`, name)
+}
+
+func testAccCheckIBMIAMServicePolicy_updateRole(name string) string {
+	return fmt.Sprintf(`
+		
+		resource "ibm_iam_service_id" "serviceID" {
+			name = "%s"
+		  }
+		  
+		  resource "ibm_iam_service_policy" "policy" {
+			serviceID_id = "${ibm_iam_service_id.serviceID.id}"
+			roles        = ["Viewer","Manager"]
+			tags         = ["tag1", "tag2"]
+		  }
+	`, name)
+}
+
+func testAccCheckIBMIAMServicePolicy_service(name string) string {
+	return fmt.Sprintf(`
+
+		resource "ibm_iam_service_id" "serviceID" {
+			name = "%s"
+		  }
+		  
+		resource "ibm_iam_service_policy" "policy" {
+			serviceID_id = "${ibm_iam_service_id.serviceID.id}"
+			roles        = ["Viewer"]
+		  
+			resources = [{
+			  service = "cloud-object-storage"
+			}]
+		  }
+
+	`, name)
+}
+
+func testAccCheckIBMIAMServicePolicy_updateServiceAndRegion(name string) string {
+	return fmt.Sprintf(`
+		
+		resource "ibm_iam_service_id" "serviceID" {
+			name = "%s"
+		  }
+		  
+		resource "ibm_iam_service_policy" "policy" {
+			serviceID_id = "${ibm_iam_service_id.serviceID.id}"
+			roles        = ["Viewer", "Manager"]
+		  
+			resources = [{
+			  service = "kms"
+			  region  = "us-south"
+			}]
+		  }
+	`, name)
+}
+
+func testAccCheckIBMIAMServicePolicy_resource_instance(name string) string {
+	return fmt.Sprintf(`
+
+		resource "ibm_iam_service_id" "serviceID" {
+			name = "%s"
+		  }
+		  
+		resource "ibm_resource_instance" "instance" {
+			name     = "%s"
+			service  = "kms"
+			plan     = "tiered-pricing"
+			location = "us-south"
+		  }
+		  
+		resource "ibm_iam_service_policy" "policy" {
+			serviceID_id = "${ibm_iam_service_id.serviceID.id}"
+			roles        = ["Manager", "Viewer", "Administrator"]
+		  
+			resources = [{
+			  service              = "kms"
+			  region               = "us-south"
+			  resource_instance_id = "${element(split(":",ibm_resource_instance.instance.id),7)}"
+			}]
+		  }
+		  
+
+	`, name, name)
+}
+
+func testAccCheckIBMIAMServicePolicy_resource_group(name string) string {
+	return fmt.Sprintf(`
+
+		resource "ibm_iam_service_id" "serviceID" {
+			name = "%s"
+		  }
+		  
+		data "ibm_resource_group" "group" {
+			name = "default"
+		  }
+		  
+		resource "ibm_iam_service_policy" "policy" {
+			serviceID_id = "${ibm_iam_service_id.serviceID.id}"
+			roles        = ["Viewer"]
+		  
+			resources = [{
+			  service           = "containers-kubernetes"
+			  resource_group_id = "${data.ibm_resource_group.group.id}"
+			}]
+		  }
+		  
+
+	`, name)
+}
+
+func testAccCheckIBMIAMServicePolicy_resource_type(name string) string {
+	return fmt.Sprintf(`
+
+		resource "ibm_iam_service_id" "serviceID" {
+			name = "%s"
+		  }
+		  
+		data "ibm_resource_group" "group" {
+			name = "default"
+		  }
+		  
+		resource "ibm_iam_service_policy" "policy" {
+			serviceID_id = "${ibm_iam_service_id.serviceID.id}"
+			roles        = ["Administrator"]
+		  
+			resources = [{
+			  resource_type = "resource-group"
+			  resource      = "${data.ibm_resource_group.group.id}"
+			}]
+		  }
+	`, name)
+}
+
+func testAccCheckIBMIAMServicePolicy_import(name string) string {
+	return fmt.Sprintf(`
+
+		resource "ibm_iam_service_id" "serviceID" {
+			name = "%s"
+		  }
+		  
+		  resource "ibm_iam_service_policy" "policy" {
+			serviceID_id = "${ibm_iam_service_id.serviceID.id}"
+			roles        = ["Viewer"]
+		  }
+
+	`, name)
+}

--- a/ibm/structures.go
+++ b/ibm/structures.go
@@ -6,6 +6,8 @@ import (
 	"reflect"
 	"strings"
 
+	"github.com/IBM-Cloud/bluemix-go/models"
+
 	"github.com/hashicorp/terraform/flatmap"
 
 	"github.com/IBM-Cloud/bluemix-go/api/container/containerv1"
@@ -674,4 +676,28 @@ func flattenDisks(result datatypes.Virtual_Guest, d *schema.ResourceData) []int 
 func filterResourceKeyParameters(params map[string]interface{}) map[string]interface{} {
 	delete(params, "role_crn")
 	return params
+}
+
+func idParts(id string) (string, string, error) {
+	if strings.Contains(id, "/") {
+		parts := strings.Split(id, "/")
+		return parts[0], parts[1], nil
+	}
+	return "", "", fmt.Errorf("The given id %s does not contain / please check documentation on how to provider id during import command", id)
+}
+
+func flattenPolicyResource(list []models.PolicyResource) []map[string]interface{} {
+	result := make([]map[string]interface{}, 0, len(list))
+	for _, i := range list {
+		l := map[string]interface{}{
+			"service":              i.ServiceName,
+			"resource_instance_id": i.ServiceInstance,
+			"region":               i.Region,
+			"resource_type":        i.ResourceType,
+			"resource":             i.Resource,
+			"resource_group_id":    i.ResourceGroupID,
+		}
+		result = append(result, l)
+	}
+	return result
 }

--- a/website/docs/r/iam_service_policy.html.markdown
+++ b/website/docs/r/iam_service_policy.html.markdown
@@ -1,0 +1,151 @@
+---
+layout: "ibm"
+page_title: "IBM : service_policy"
+sidebar_current: "docs-ibm-resource-service-policy"
+description: |-
+  Manages IBM IAM Service Policy.
+---
+
+# ibm\_service_id
+
+Provides a resource for IAM Service Policy. This allows service policy  to be created, updated and deleted.
+
+## Example Usage
+
+### Service Policy for All Identity and Access enabled services 
+
+```hcl
+resource "ibm_iam_service_id" "serviceID" {
+  name = "test"
+}
+
+resource "ibm_iam_service_policy" "policy" {
+  serviceID_id = "${ibm_iam_service_id.serviceID.id}"
+  roles        = ["Viewer"]
+}
+
+```
+
+### Service Policy using service with region
+
+```hcl
+resource "ibm_iam_service_id" "serviceID" {
+  name = "test"
+}
+
+resource "ibm_iam_service_policy" "policy" {
+  serviceID_id = "${ibm_iam_service_id.serviceID.id}"
+  roles        = ["Viewer"]
+
+  resources = [{
+    service = "cloud-object-storage"
+  }]
+}
+
+```
+### Service Policy using resource instance 
+
+```hcl
+resource "ibm_iam_service_id" "serviceID" {
+  name = "test"
+}
+
+resource "ibm_resource_instance" "instance" {
+  name     = "test"
+  service  = "kms"
+  plan     = "tiered-pricing"
+  location = "us-south"
+}
+
+resource "ibm_iam_service_policy" "policy" {
+  serviceID_id = "${ibm_iam_service_id.serviceID.id}"
+  roles        = ["Manager", "Viewer", "Administrator"]
+
+  resources = [{
+    service              = "kms"
+    region               = "us-south"
+    resource_instance_id = "${element(split(":",ibm_resource_instance.instance.id),7)}"
+  }]
+}
+
+```
+
+### Service Policy using resource group 
+
+```hcl
+resource "ibm_iam_service_id" "serviceID" {
+  name = "test"
+}
+
+data "ibm_resource_group" "group" {
+  name = "default"
+}
+
+resource "ibm_iam_service_policy" "policy" {
+  serviceID_id = "${ibm_iam_service_id.serviceID.id}"
+  roles        = ["Viewer"]
+
+  resources = [{
+    service           = "containers-kubernetes"
+    resource_group_id = "${data.ibm_resource_group.group.id}"
+  }]
+}
+
+```
+
+### Service Policy using resource and resource type 
+
+```hcl
+resource "ibm_iam_service_id" "serviceID" {
+  name = "test"
+}
+
+data "ibm_resource_group" "group" {
+  name = "default"
+}
+
+resource "ibm_iam_service_policy" "policy" {
+  serviceID_id = "${ibm_iam_service_id.serviceID.id}"
+  roles        = ["Administrator"]
+
+  resources = [{
+    resource_type = "resource-group"
+    resource      = "${data.ibm_resource_group.group.id}"
+  }]
+}
+
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `serviceID_id` - (Required, string) UUID of the serviceID.
+* `roles` - (Required, list) comma separated list of roles. Valid roles are Writer, Reader, Manager, Administrator, Operator, Viewer, Editor.
+* `resources` - (Optional, list) A nested block describing the resource of this policy.
+Nested `resources` blocks have the following structure:
+  * `service` - (Optional, string) Service name of the policy definition.  You can retrieve the value by running the `bx catalog service-marketplace` or `bx catalog search` command in the [IBM Cloud CLI](https://console.bluemix.net/docs/cli/reference/bluemix_cli/get_started.html#getting-started).
+  * `resource_instance_id` - (Optional, string) ID of resource instance of the policy definition.
+  * `region` - (Optional, string) Region of the policy definition.
+  * `resource_type` - (Optional, string) Resource type of the policy definition.
+  * `resource` - (Optional, string) Resource of the policy definition.
+  * `resource_group_id` - (Optional, string) The ID of the resource group.  You can retrieve the value from data source `ibm_resource_group`.
+* `tags` - (Optional, array of strings) Tags associated with the resource key instance.
+  **NOTE**: `Tags` are managed locally and not stored on the IBM Cloud service endpoint at this moment.
+
+## Attribute Reference
+
+The following attributes are exported:
+
+* `id` - The unique identifier of the service policy. The id is composed of \<serviceID_id\>/\<service_policy_id\>
+
+* `version` - Version of the service policy.
+
+## Import
+
+ibm_iam_service_policy can be imported using serviceID and service policy id, eg
+
+```
+$ terraform import ibm_iam_service_policy.example ServiceId-d7bec597-4726-451f-8a63-e62e6f19c32c/cea6651a-bc0a-4438-9f8a-a0770bbf3ebb
+```
+

--- a/website/ibm.erb
+++ b/website/ibm.erb
@@ -197,7 +197,10 @@
               <li<%= sidebar_current("docs-ibm-resource-service-id") %>>
                 <a href="/docs/providers/ibm/r/iam_service_id.html">service_id</a>
               </li>
-              </ul>
+              <li<%= sidebar_current("docs-ibm-resource-service-policy") %>>
+                <a href="/docs/providers/ibm/r/iam_service_policy.html">service_policy</a>
+              </li>
+            </ul>
           </li>
           <li<%= sidebar_current("docs-ibm-resource-infra") %>>
             <a href="#">Infrastructure Resources</a>


### PR DESCRIPTION
[WARN] Set the environment variable IBM_COMPUTE_VM_INSTANCE_IMAGE_ID for testing the ibm_compute_vm_instance resource. The image should be replicated in the Washington 4 datacenter. Some tests for that resource will fail if this is not set correctly
=== RUN   TestAccIBMIAMServicePolicy_Basic
--- PASS: TestAccIBMIAMServicePolicy_Basic (109.14s)
=== RUN   TestAccIBMIAMServicePolicy_With_Service
--- PASS: TestAccIBMIAMServicePolicy_With_Service (93.01s)
=== RUN   TestAccIBMIAMServicePolicy_With_ResourceInstance
--- PASS: TestAccIBMIAMServicePolicy_With_ResourceInstance (96.33s)
=== RUN   TestAccIBMIAMServicePolicy_With_Resource_Group
--- PASS: TestAccIBMIAMServicePolicy_With_Resource_Group (69.65s)
=== RUN   TestAccIBMIAMServicePolicy_With_Resource_Type
--- PASS: TestAccIBMIAMServicePolicy_With_Resource_Type (72.12s)
=== RUN   TestAccIBMIAMServicePolicy_import
--- PASS: TestAccIBMIAMServicePolicy_import (67.07s)
PASS
ok  	github.com/terraform-providers/terraform-provider-ibm/ibm	509.000s