### PR TITLE
add computed ip address ids to compute_bare_metal

### DIFF
--- a/ibm/resource_ibm_compute_bare_metal.go
+++ b/ibm/resource_ibm_compute_bare_metal.go
@@ -346,10 +346,21 @@ func resourceIBMComputeBareMetal() *schema.Resource {
 				Computed: true,
 			},
 
+			"public_ipv4_address_id": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+
 			"private_ipv4_address": {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
+
+			"private_ipv4_address_id": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+
 			"secondary_ip_count": {
 				Type:         schema.TypeInt,
 				Optional:     true,
@@ -376,6 +387,10 @@ func resourceIBMComputeBareMetal() *schema.Resource {
 			},
 			"ipv6_address": {
 				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"ipv6_address_id": {
+				Type:     schema.TypeInt,
 				Computed: true,
 			},
 			"ipv6_static_enabled": {
@@ -624,8 +639,11 @@ func resourceIBMComputeBareMetalRead(d *schema.ResourceData, meta interface{}) e
 			"hourlyBillingFlag," +
 			"datacenter[id,name,longName]," +
 			"primaryNetworkComponent[networkVlan[id,primaryRouter,vlanNumber],maxSpeed," +
-			"primaryVersion6IpAddressRecord[subnet,guestNetworkComponentBinding[ipAddressId]]]," +
-			"primaryBackendNetworkComponent[networkVlan[id,primaryRouter,vlanNumber],maxSpeed,redundancyEnabledFlag]," +
+			"primaryIpAddressRecord[id]," +
+			"primaryVersion6IpAddressRecord[subnet,id]]," +
+			"primaryBackendNetworkComponent[networkVlan[id,primaryRouter,vlanNumber]," +
+			"primaryIpAddressRecord[id]," +
+			"maxSpeed,redundancyEnabledFlag]," +
 			"memoryCapacity,powerSupplyCount," +
 			"operatingSystem[softwareLicense[softwareDescription[referenceCode]]]",
 	).GetObject()
@@ -646,7 +664,12 @@ func resourceIBMComputeBareMetalRead(d *schema.ResourceData, meta interface{}) e
 	if result.PrimaryIpAddress != nil {
 		d.Set("public_ipv4_address", *result.PrimaryIpAddress)
 	}
+	if result.PrimaryNetworkComponent.PrimaryIpAddressRecord != nil {
+		d.Set("public_ipv4_address_id", *result.PrimaryNetworkComponent.PrimaryIpAddressRecord.Id)
+	}
 	d.Set("private_ipv4_address", *result.PrimaryBackendIpAddress)
+	d.Set("private_ipv4_address_id",
+		*result.PrimaryBackendNetworkComponent.PrimaryIpAddressRecord.Id)
 
 	d.Set("private_network_only", *result.PrivateNetworkOnlyFlag)
 	d.Set("hourly_billing", *result.HourlyBillingFlag)
@@ -729,6 +752,7 @@ func resourceIBMComputeBareMetalRead(d *schema.ResourceData, meta interface{}) e
 	if result.PrimaryNetworkComponent.PrimaryVersion6IpAddressRecord != nil {
 		d.Set("ipv6_enabled", true)
 		d.Set("ipv6_address", *result.PrimaryNetworkComponent.PrimaryVersion6IpAddressRecord.IpAddress)
+		d.Set("ipv6_address_id", *result.PrimaryNetworkComponent.PrimaryVersion6IpAddressRecord.Id)
 	}
 	err = readSecondaryIPAddresses(d, meta, result.PrimaryIpAddress)
 	return err

--- a/website/docs/d/compute_bare_metal.html.markdown
+++ b/website/docs/d/compute_bare_metal.html.markdown
@@ -46,7 +46,9 @@ The following attributes are exported:
 * `network_speed` - The connection speed, expressed in Mbps,  for the server network components.
 * `public_bandwidth` - The amount of public network traffic, allowed per month.
 * `public_ipv4_address` - The public IPv4 address of the bare metal server.
+* `public_ipv4_address_id` - The unique identifier for the public IPv4 address of the bare metal server.
 * `private_ipv4_address` - The private IPv4 address of the bare metal server.
+* `private_ipv4_address_id` - The unique identifier for the private IPv4 address of the bare metal server.
 * `public_vlan_id` - The public VLAN used for the public network interface of the server. 
 * `private_vlan_id` - The private VLAN used for the private network interface of the server. 
 * `public_subnet` - The public subnet used for the public network interface of the server. 
@@ -65,5 +67,6 @@ The following attributes are exported:
 * `file_storage_ids` - File storage to which this computing server have access.
 * `ipv6_enabled` - Indicates whether the public IPv6 address enabled or not.
 * `ipv6_address` - The public IPv6 address of the bare metal server.
+* `ipv6_address_id` - The unique identifier for the public IPv6 address of the bare metal server.
 * `secondary_ip_count` - The number of secondary IPv4 addresses of the bare metal server.
 * `secondary_ip_addresses` - The public secondary IPv4 addresses of the bare metal server.

--- a/website/docs/r/compute_bare_metal.html.markdown
+++ b/website/docs/r/compute_bare_metal.html.markdown
@@ -182,8 +182,11 @@ The following attributes are exported:
 
 * `id` - The unique identifier of the bare metal server.
 * `public_ipv4_address` - The public IPv4 address of the bare metal server.
+* `public_ipv4_address_id` - The unique identifier for the public IPv4 address of the bare metal server.
 * `private_ipv4_address` - The private IPv4 address of the bare metal server.
+* `private_ipv4_address_id` - The unique identifier for the private IPv4 address of the bare metal server.
 * `ipv6_address` - The public IPv6 address of the bare metal server instance provided when `ipv6_enabled` is set to `true`.
+* `ipv6_address_id` - The unique identifier for the public IPv6 address of the bare metal server.
 * `secondary_ip_addresses` - The public secondary IPv4 addresses of the bare metal server instance when `secondary_ip_count` is set to non-zero value.
 * `global_identifier` - The unique global identifier of the bare metal server.
 


### PR DESCRIPTION
these ip address ids are needed as input for e.g. ibm_lb_service

also note: i removed "guestNetworkComponentBinding[ipAddressId]" from "primaryVersion6IpAddressRecord" in the object masks in {data,resource}_ibm_compute_bare_metal because they didn't seem to be used.

please let me know if acceptance tests for this are expected, which i didn't write because the existing ip address attributes did not have acceptance tests either.