### PR TITLE
Change the import path to match the real import path

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,12 +3,6 @@ language: go
 go:
 - 1.9.2
 
-
-before_install:
-- mkdir -p $GOPATH/src/github.com/terraform-providers/terraform-provider-ibm
-- mv $TRAVIS_BUILD_DIR/* $GOPATH/src/github.com/terraform-providers/terraform-provider-ibm
-- cd $GOPATH/src/github.com/terraform-providers/terraform-provider-ibm
-
 install:
 # This script is used by the Travis build to install a cookie for
 # go.googlesource.com so rate limits are higher when using `go get` to fetch

--- a/README.md
+++ b/README.md
@@ -14,17 +14,17 @@ Requirements
 Building The Provider
 ---------------------
 
-Clone repository to: `$GOPATH/src/github.com/terraform-providers/terraform-provider-ibm`
+Clone repository to: `$GOPATH/src/github.com/IBM-Cloud/terraform-provider-ibm`
 
 ```sh
-$ mkdir -p $GOPATH/src/github.com/terraform-providers; cd $GOPATH/src/github.com/terraform-providers
-$ git clone git@github.com:IBM-Bluemix/terraform-provider-ibm.git
+$ mkdir -p $GOPATH/src/github.com/IBM-Cloud; cd $GOPATH/src/github.com/IBM-Cloud
+$ git clone git@github.com:IBM-Cloud/terraform-provider-ibm.git
 ```
 
 Enter the provider directory and build the provider
 
 ```sh
-$ cd $GOPATH/src/github.com/terraform-providers/terraform-provider-ibm
+$ cd $GOPATH/src/github.com/IBM-Cloud/terraform-provider-ibm
 $ make build
 ```
 

--- a/ibm/auth_helpers.go
+++ b/ibm/auth_helpers.go
@@ -8,8 +8,8 @@ import (
 
 	bluemix "github.com/IBM-Cloud/bluemix-go"
 	"github.com/IBM-Cloud/bluemix-go/rest"
+	"github.com/IBM-Cloud/terraform-provider-ibm/version"
 	"github.com/apache/incubator-openwhisk-client-go/whisk"
-	"github.com/terraform-providers/terraform-provider-ibm/version"
 )
 
 //AuthResponse ...

--- a/ibm/config.go
+++ b/ibm/config.go
@@ -16,8 +16,8 @@ import (
 
 	jwt "github.com/dgrijalva/jwt-go"
 
+	"github.com/IBM-Cloud/terraform-provider-ibm/version"
 	slsession "github.com/softlayer/softlayer-go/session"
-	"github.com/terraform-providers/terraform-provider-ibm/version"
 
 	bluemix "github.com/IBM-Cloud/bluemix-go"
 	"github.com/IBM-Cloud/bluemix-go/api/account/accountv1"

--- a/ibm/data_source_ibm_container_cluster_versions.go
+++ b/ibm/data_source_ibm_container_cluster_versions.go
@@ -2,8 +2,9 @@ package ibm
 
 import (
 	"fmt"
-	"github.com/hashicorp/terraform/helper/schema"
 	"time"
+
+	"github.com/hashicorp/terraform/helper/schema"
 )
 
 func dataSourceIBMContainerClusterVersions() *schema.Resource {

--- a/main.go
+++ b/main.go
@@ -3,9 +3,9 @@ package main
 import (
 	"log"
 
+	"github.com/IBM-Cloud/terraform-provider-ibm/ibm"
+	"github.com/IBM-Cloud/terraform-provider-ibm/version"
 	"github.com/hashicorp/terraform/plugin"
-	"github.com/terraform-providers/terraform-provider-ibm/ibm"
-	"github.com/terraform-providers/terraform-provider-ibm/version"
 )
 
 func main() {


### PR DESCRIPTION
This commit changes the import path to match the upstream Github path.
This makes the project Go-idiomatic and also go-gettable.

closes #373