### PR TITLE
Check nil value to retrive role_crn without crash 

### DIFF
--- a/ibm/resource_ibm_resource_key.go
+++ b/ibm/resource_ibm_resource_key.go
@@ -178,9 +178,13 @@ func resourceIBMResourceKeyRead(d *schema.ResourceData, meta interface{}) error 
 	d.Set("credentials", flatmap.Flatten(resourceKey.Credentials))
 	d.Set("name", resourceKey.Name)
 	d.Set("status", resourceKey.State)
-	role := resourceKey.Parameters["role_crn"].(string)
-	role = role[strings.LastIndex(role, ":")+1:]
-	d.Set("role", role)
+
+	if roleCrn, ok := resourceKey.Parameters["role_crn"].(string); ok {
+		d.Set("role", roleCrn[strings.LastIndex(roleCrn, ":")+1:])
+	} else if roleCrn, ok := resourceKey.Credentials["iam_role_crn"].(string); ok {
+		d.Set("role", roleCrn[strings.LastIndex(roleCrn, ":")+1:])
+	}
+
 	d.Set("parameters", flatmap.Flatten(filterResourceKeyParameters(resourceKey.Parameters)))
 
 	return nil


### PR DESCRIPTION
- Check if resourceKey.Parameters["role_crn"] is nil. 
- Use resourceKey.Credentials["iam_role_crn"] when resourceKey.Parameters["role_crn"] is nil.
- This fix resolves the issue #451.