### PR TITLE
Check nil value to retrive role_crn for data_source_ibm_resource_key

### DIFF
--- a/ibm/data_source_ibm_resource_key.go
+++ b/ibm/data_source_ibm_resource_key.go
@@ -113,9 +113,13 @@ func dataSourceIBMResourceKeyRead(d *schema.ResourceData, meta interface{}) erro
 	}
 
 	d.SetId(key.ID)
-	role := key.Parameters["role_crn"].(string)
-	role = role[strings.LastIndex(role, ":")+1:]
-	d.Set("role", role)
+
+	if roleCrn, ok := key.Parameters["role_crn"].(string); ok {
+		d.Set("role", roleCrn[strings.LastIndex(roleCrn, ":")+1:])
+	} else if roleCrn, ok := key.Credentials["iam_role_crn"].(string); ok {
+		d.Set("role", roleCrn[strings.LastIndex(roleCrn, ":")+1:])
+	}
+
 	d.Set("credentials", flatmap.Flatten(key.Credentials))
 	d.Set("status", key.State)
 	return nil


### PR DESCRIPTION
- Check if key.Parameters["role_crn"] is nil.
- Use key.Credentials["iam_role_crn"] when key.Parameters["role_crn"]  is nil.
This fix is related to issue #451.