### PR TITLE
Change git clone command to http

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Clone repository to: `$GOPATH/src/github.com/IBM-Cloud/terraform-provider-ibm`
 
 ```sh
 mkdir -p $GOPATH/src/github.com/IBM-Cloud; cd $GOPATH/src/github.com/IBM-Cloud
-git clone git@github.com:IBM-Cloud/terraform-provider-ibm.git
+git clone https://github.com/IBM-Cloud/terraform-provider-ibm.git
 ```
 
 Enter the provider directory and build the provider


### PR DESCRIPTION
Makes instructions more copy and paste friendly.