### PR TITLE
handle error when retrieving vlan order

### DIFF
--- a/ibm/resource_ibm_network_vlan.go
+++ b/ibm/resource_ibm_network_vlan.go
@@ -163,6 +163,9 @@ func resourceIBMNetworkVlanCreate(d *schema.ResourceData, meta interface{}) erro
 	}
 
 	vlan, err := findVlanByOrderId(sess, *receipt.OrderId)
+	if err != nil {
+		return fmt.Errorf("Error finding VLAN order %d: %s", *receipt.OrderId, err)
+	}
 
 	if len(name) > 0 {
 		_, err = services.GetNetworkVlanService(sess).


### PR DESCRIPTION
We are experiencing issues provisioning VLANs on SoftLayer.  Because this error is unhandled, it crashes Terraform when attempting to access `*vlan.Id` later in the code.  This change returns the error safely.