### PR TITLE
Add optional `most_recent` parameter to `ibm_compute_image_template`

### DIFF
--- a/ibm/data_source_ibm_compute_image_template.go
+++ b/ibm/data_source_ibm_compute_image_template.go
@@ -26,6 +26,12 @@ func dataSourceIBMComputeImageTemplate() *schema.Resource {
 				Type:        schema.TypeString,
 				Required:    true,
 			},
+
+			"latest": {
+				Description: "Get the latest id of this image template",
+				Type:        schema.TypeBool,
+				Optional:    true,
+			},
 		},
 	}
 }
@@ -35,6 +41,7 @@ func dataSourceIBMComputeImageTemplateRead(d *schema.ResourceData, meta interfac
 	service := services.GetAccountService(sess)
 
 	name := d.Get("name").(string)
+	latest := d.Get("latest").(bool)
 
 	imageTemplates, err := service.
 		Mask("id,name").
@@ -63,6 +70,13 @@ func dataSourceIBMComputeImageTemplateRead(d *schema.ResourceData, meta interfac
 
 	if len(pubImageTemplates) > 0 {
 		imageTemplate := pubImageTemplates[0]
+		if latest {
+			for _, image := range pubImageTemplates {
+				if *imageTemplate.Id < *image.Id {
+					imageTemplate = image
+				}
+			}
+		}
 		d.SetId(fmt.Sprintf("%d", *imageTemplate.Id))
 		return nil
 	}

--- a/ibm/data_source_ibm_compute_image_template.go
+++ b/ibm/data_source_ibm_compute_image_template.go
@@ -27,8 +27,8 @@ func dataSourceIBMComputeImageTemplate() *schema.Resource {
 				Required:    true,
 			},
 
-			"latest": {
-				Description: "Get the latest id of this image template",
+			"most_recent": {
+				Description: "Get the most_recent id of this image template",
 				Type:        schema.TypeBool,
 				Optional:    true,
 			},
@@ -41,7 +41,7 @@ func dataSourceIBMComputeImageTemplateRead(d *schema.ResourceData, meta interfac
 	service := services.GetAccountService(sess)
 
 	name := d.Get("name").(string)
-	latest := d.Get("latest").(bool)
+	most_recent := d.Get("most_recent").(bool)
 
 	imageTemplates, err := service.
 		Mask("id,name").
@@ -70,7 +70,7 @@ func dataSourceIBMComputeImageTemplateRead(d *schema.ResourceData, meta interfac
 
 	if len(pubImageTemplates) > 0 {
 		imageTemplate := pubImageTemplates[0]
-		if latest {
+		if most_recent {
 			for _, image := range pubImageTemplates {
 				if *imageTemplate.Id < *image.Id {
 					imageTemplate = image

--- a/ibm/data_source_ibm_compute_image_template_test.go
+++ b/ibm/data_source_ibm_compute_image_template_test.go
@@ -21,6 +21,10 @@ func TestAccIBMComputeImageTemplateDataSource_Basic(t *testing.T) {
 						"name",
 						"jumpbox",
 					),
+					resource.TestCheckNoResourceAttr(
+						"data.ibm_compute_image_template.tfacc_img_tmpl",
+						"most_recent",
+					),
 					resource.TestMatchResourceAttr(
 						"data.ibm_compute_image_template.tfacc_img_tmpl",
 						"id",
@@ -36,6 +40,10 @@ func TestAccIBMComputeImageTemplateDataSource_Basic(t *testing.T) {
 						"data.ibm_compute_image_template.tfacc_img_tmpl",
 						"name",
 						"RightImage_Ubuntu_12.04_amd64_v13.5",
+					),
+					resource.TestCheckNoResourceAttr(
+						"data.ibm_compute_image_template.tfacc_img_tmpl",
+						"most_recent",
 					),
 					resource.TestMatchResourceAttr(
 						"data.ibm_compute_image_template.tfacc_img_tmpl",
@@ -53,6 +61,11 @@ func TestAccIBMComputeImageTemplateDataSource_Basic(t *testing.T) {
 						"name",
 						"25GB - Ubuntu / Ubuntu / 18.04-64 Minimal for VSI",
 					),
+					resource.TestCheckResourceAttr(
+						"data.ibm_compute_image_template.tfacc_img_tmpl",
+						"most_recent",
+						"true",
+					),
 					resource.TestMatchResourceAttr(
 						"data.ibm_compute_image_template.tfacc_img_tmpl",
 						"id",
@@ -68,6 +81,11 @@ func TestAccIBMComputeImageTemplateDataSource_Basic(t *testing.T) {
 						"data.ibm_compute_image_template.tfacc_img_tmpl",
 						"name",
 						"25GB - Ubuntu / Ubuntu / 18.04-64 Minimal for VSI",
+					),
+					resource.TestCheckResourceAttr(
+						"data.ibm_compute_image_template.tfacc_img_tmpl",
+						"most_recent",
+						"false",
 					),
 					resource.TestMatchResourceAttr(
 						"data.ibm_compute_image_template.tfacc_img_tmpl",

--- a/ibm/data_source_ibm_compute_image_template_test.go
+++ b/ibm/data_source_ibm_compute_image_template_test.go
@@ -44,6 +44,38 @@ func TestAccIBMComputeImageTemplateDataSource_Basic(t *testing.T) {
 					),
 				),
 			},
+			// Tests looking up the latest of a public image
+			{
+				Config: testAccCheckIBMComputeImageTemplateDataSourceConfig_latest,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(
+						"data.ibm_compute_image_template.tfacc_img_tmpl",
+						"name",
+						"25GB - Ubuntu / Ubuntu / 18.04-64 Minimal for VSI",
+					),
+					resource.TestMatchResourceAttr(
+						"data.ibm_compute_image_template.tfacc_img_tmpl",
+						"id",
+						regexp.MustCompile("^[0-9]+$"),
+					),
+				),
+			},
+			// Tests looking up the first returned of a public image
+			{
+				Config: testAccCheckIBMComputeImageTemplateDataSourceConfig_notlatest,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(
+						"data.ibm_compute_image_template.tfacc_img_tmpl",
+						"name",
+						"25GB - Ubuntu / Ubuntu / 18.04-64 Minimal for VSI",
+					),
+					resource.TestMatchResourceAttr(
+						"data.ibm_compute_image_template.tfacc_img_tmpl",
+						"id",
+						regexp.MustCompile("^[0-9]+$"),
+					),
+				),
+			},
 		},
 	})
 }
@@ -57,5 +89,19 @@ data "ibm_compute_image_template" "tfacc_img_tmpl" {
 const testAccCheckIBMComputeImageTemplateDataSourceConfig_basic2 = `
 data "ibm_compute_image_template" "tfacc_img_tmpl" {
     name = "RightImage_Ubuntu_12.04_amd64_v13.5"
+}
+`
+
+const testAccCheckIBMComputeImageTemplateDataSourceConfig_latest = `
+data "ibm_compute_image_template" "tfacc_img_tmpl" {
+    name = "25GB - Ubuntu / Ubuntu / 18.04-64 Minimal for VSI"
+    latest = true
+}
+`
+
+const testAccCheckIBMComputeImageTemplateDataSourceConfig_notlatest = `
+data "ibm_compute_image_template" "tfacc_img_tmpl" {
+    name = "25GB - Ubuntu / Ubuntu / 18.04-64 Minimal for VSI"
+    latest = false
 }
 `

--- a/ibm/data_source_ibm_compute_image_template_test.go
+++ b/ibm/data_source_ibm_compute_image_template_test.go
@@ -44,9 +44,9 @@ func TestAccIBMComputeImageTemplateDataSource_Basic(t *testing.T) {
 					),
 				),
 			},
-			// Tests looking up the latest of a public image
+			// Tests looking up the most_recent of a public image
 			{
-				Config: testAccCheckIBMComputeImageTemplateDataSourceConfig_latest,
+				Config: testAccCheckIBMComputeImageTemplateDataSourceConfig_mostrecent,
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(
 						"data.ibm_compute_image_template.tfacc_img_tmpl",
@@ -62,7 +62,7 @@ func TestAccIBMComputeImageTemplateDataSource_Basic(t *testing.T) {
 			},
 			// Tests looking up the first returned of a public image
 			{
-				Config: testAccCheckIBMComputeImageTemplateDataSourceConfig_notlatest,
+				Config: testAccCheckIBMComputeImageTemplateDataSourceConfig_mostrecent2,
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(
 						"data.ibm_compute_image_template.tfacc_img_tmpl",
@@ -92,16 +92,16 @@ data "ibm_compute_image_template" "tfacc_img_tmpl" {
 }
 `
 
-const testAccCheckIBMComputeImageTemplateDataSourceConfig_latest = `
+const testAccCheckIBMComputeImageTemplateDataSourceConfig_mostrecent = `
 data "ibm_compute_image_template" "tfacc_img_tmpl" {
     name = "25GB - Ubuntu / Ubuntu / 18.04-64 Minimal for VSI"
-    latest = true
+    most_recent = true
 }
 `
 
-const testAccCheckIBMComputeImageTemplateDataSourceConfig_notlatest = `
+const testAccCheckIBMComputeImageTemplateDataSourceConfig_mostrecent2 = `
 data "ibm_compute_image_template" "tfacc_img_tmpl" {
     name = "25GB - Ubuntu / Ubuntu / 18.04-64 Minimal for VSI"
-    latest = false
+    most_recent = false
 }
 `

--- a/website/docs/d/compute_image_template.html.markdown
+++ b/website/docs/d/compute_image_template.html.markdown
@@ -33,6 +33,7 @@ resource "ibm_compute_vm_instance" "vm1" {
 The following arguments are supported:
 
 * `name` - (Required, string) The name of the image template as it was defined in IBM Cloud Infrastructure (SoftLayer). You can find the name in the [IBM Cloud infrastructure customer portal](https://control.softlayer.com) by navigating to **Devices > Manage > Images**.
+* `most_recent` - (Optional, boolean) Ask the provider for the latest version of the image template by selecting the one with the highest identifier with the requested name.
 
 ## Attribute Reference
 


### PR DESCRIPTION
The data source is pretty useless when using public images from IBM (among many others) that have the same name over the many different versions of the image.
Adding an optional `most_recent` parameter allows the data source to return the highest ID number in the set instead of just the first it encounters while retaining the original behavior if unset or set to false.

This solution is the same as implemented by the [analogous data source in the AWS provider](https://www.terraform.io/docs/providers/aws/d/ami.html)
