### PR TITLE
Support private network only VM configuration for datacenter_choice

### DIFF
--- a/ibm/resource_ibm_compute_vm_instance.go
+++ b/ibm/resource_ibm_compute_vm_instance.go
@@ -944,11 +944,6 @@ func resourceIBMComputeVmInstanceCreate(d *schema.ResourceData, meta interface{}
 				privateVlan, _ = strconv.Atoi(v.(string))
 			}
 
-			if publicVlan > 0 && privateVlan == 0 || publicVlan == 0 && privateVlan > 0 {
-				return fmt.Errorf("Provide both `public_vlan_id` and `private_vlan_id` in `datacenter_choice`")
-
-			}
-
 			receipt, err1 = placeOrder(d, meta, name, publicVlan, privateVlan)
 			if err1 == nil {
 				break


### PR DESCRIPTION
Support the following three different configurations:
1) data center only
```
  datacenter_choice = [
    {
      datacenter      = "dal12"
    }
```
2) public and private network
```
  datacenter_choice = [
    {
      datacenter      = "dal12"
      public_vlan_id  = 1111111
      private_vlan_id = 222222
    }
```
3) private network only(for private network only VM)
```
  datacenter_choice = [
    {
      datacenter      = "dal12"
      private_vlan_id = 222222
    }
```

If public_vlan_id is provided but, private_vlan_id is not provided to datacenter_choice, SoftLayer generates validation error. Example:
```
* ibm_compute_vm_instance.vm2: Error ordering virtual guest: SoftLayer_Exception_Public: Only the frontend VLAN was specified. Please specify the backend VLAN as well. (HTTP 500)
```
This PR is related to #592 