### PR TITLE
Do not recreate VMs if Security Groups are added/removed

### DIFF
--- a/ibm/resource_ibm_compute_vm_instance.go
+++ b/ibm/resource_ibm_compute_vm_instance.go
@@ -288,7 +288,7 @@ func resourceIBMComputeVmInstance() *schema.Resource {
 				Set: func(v interface{}) int {
 					return v.(int)
 				},
-				ForceNew: true,
+				ForceNew: false,
 				MaxItems: 5,
 			},
 
@@ -323,7 +323,7 @@ func resourceIBMComputeVmInstance() *schema.Resource {
 				Set: func(v interface{}) int {
 					return v.(int)
 				},
-				ForceNew: true,
+				ForceNew: false,
 				MaxItems: 5,
 			},
 


### PR DESCRIPTION
It's possible to add/remove security groups easily via the API
and Web UI for IBM Cloud on VMs. There's no need to recreate a VM
resource when changing them via Terraform