### PR TITLE
Select latest image template instead of earliest

### DIFF
--- a/ibm/data_source_ibm_compute_image_template.go
+++ b/ibm/data_source_ibm_compute_image_template.go
@@ -62,7 +62,7 @@ func dataSourceIBMComputeImageTemplateRead(d *schema.ResourceData, meta interfac
 	}
 
 	if len(pubImageTemplates) > 0 {
-		imageTemplate := pubImageTemplates[0]
+		imageTemplate := pubImageTemplates[len(pubImageTemplates)-1]
 		d.SetId(fmt.Sprintf("%d", *imageTemplate.Id))
 		return nil
 	}

--- a/ibm/data_source_ibm_compute_image_template_test.go
+++ b/ibm/data_source_ibm_compute_image_template_test.go
@@ -48,6 +48,31 @@ func TestAccIBMComputeImageTemplateDataSource_Basic(t *testing.T) {
 	})
 }
 
+func TestAccIBMComputeImageTemplateDataSourceLatestImage(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			// Tests looking up a latest image id
+			{
+				Config: testAccCheckIBMComputeImageTemplateDataSourceConfigLatestImage,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(
+						"data.ibm_compute_image_template.tfacc_img_tmpl",
+						"name",
+						"25GB - Ubuntu / Ubuntu / 18.04-64 Minimal for VSI",
+					),
+					resource.TestCheckResourceAttr(
+						"data.ibm_compute_image_template.tfacc_img_tmpl",
+						"id",
+						"2354286",
+					),
+				),
+			},
+		},
+	})
+}
+
 const testAccCheckIBMComputeImageTemplateDataSourceConfig_basic = `
 data "ibm_compute_image_template" "tfacc_img_tmpl" {
     name = "jumpbox"
@@ -57,5 +82,11 @@ data "ibm_compute_image_template" "tfacc_img_tmpl" {
 const testAccCheckIBMComputeImageTemplateDataSourceConfig_basic2 = `
 data "ibm_compute_image_template" "tfacc_img_tmpl" {
     name = "RightImage_Ubuntu_12.04_amd64_v13.5"
+}
+`
+
+const testAccCheckIBMComputeImageTemplateDataSourceConfigLatestImage = `
+data "ibm_compute_image_template" "tfacc_img_tmpl" {
+    name = "25GB - Ubuntu / Ubuntu / 18.04-64 Minimal for VSI"
 }
 `


### PR DESCRIPTION
Hello -

I'm using the `data_source_ibm_compute_image_template` data source to pull an image reference for Ubuntu per the documentation at https://ibm-cloud.github.io/tf-ibm-docs/v0.17.2/d/compute_image_template.html. It seems to return the oldest image when multiple images exist with the same name instead of the newest.

I couldn't find existing functionality to select the latest image with the data source or an open issue/PR addressing it but I could have missed it. If that's the case, please let me know.

### Environment Details

```
atlas$ tf11 -version
Terraform v0.11.14
+ provider.ibm v0.17.2
```

Image name: `25GB - Ubuntu / Ubuntu / 18.04-64 Minimal for VSI`

### Test Case
When I call Terraform with:

```
# Truncated for brevity
data "ibm_compute_image_template" "os_image" {
  name = "${lookup(local.image_parameters[var.vm_os], "os_reference_code")}"
}

output "os_image" {
  value = "${data.ibm_compute_image_template.os_image.*.id}"
}
```

I see:

```
atlas$ rm -rf .terraform/ && tf11 init && tf11 apply

Initializing provider plugins...

The following providers do not have any version constraints in configuration,
so the latest version was installed.

To prevent automatic upgrades to new major versions that may contain breaking
changes, it is recommended to add version = "..." constraints to the
corresponding provider blocks in configuration, with the constraint strings
suggested below.

* provider.ibm: version = "~> 0.17"

Terraform has been successfully initialized!

You may now begin working with Terraform. Try running "terraform plan" to see
any changes that are required for your infrastructure. All Terraform commands
should now work.

If you ever set or change modules or backend configuration for Terraform,
rerun this command to reinitialize your working directory. If you forget, other
commands will detect it and remind you to do so if necessary.
data.ibm_space.spacedata: Refreshing state...
data.ibm_compute_image_template.os_image: Refreshing state...

Apply complete! Resources: 0 added, 0 changed, 0 destroyed.

Outputs:

os_image = [
    1936715
]

```

The image ID `1936715` returned here corresponds to the image `25GB - Ubuntu / Ubuntu / 18.04-64 Minimal for VSI` with kernel `4.15.0-20-generic` published on 5/22/2018, 1:12:23 PM per https://cloud.ibm.com/gen1/infrastructure/image-templates/1936715/details#main.

I deployed a gen1 VM with Ubuntu LTS 18.04 through the cloud.ibm.com interface and looked at the image attributes. I confirmed that the image label was `25GB - Ubuntu / Ubuntu / 18.04-64 Minimal for VSI` and the reported kernel was `4.15.0-54-generic x86_64`. I had to go back to the list of images to correlate the kernel version to the image ID and publish date but, as far as I can tell, `4.15.0-54-generic` corresponds to image ID `2354286` with a publish date of 7/29/2019, 12:45:58 PM.

It looks like the web portal is correctly selecting the latest image when given an image with more than one ID and the IBM Terraform data source is using the oldest.

### What changed
This pull request just selects from the end of the list instead of the beginning. I've included a test case for this though it's hardcoded to the *current* latest image which is probably not the best.

With the update in place the terraform run looks like this:

```
atlas$ rm -rf .terraform/ && tf11 init && tf11 apply

Initializing provider plugins...

The following providers do not have any version constraints in configuration,
so the latest version was installed.

To prevent automatic upgrades to new major versions that may contain breaking
changes, it is recommended to add version = "..." constraints to the
corresponding provider blocks in configuration, with the constraint strings
suggested below.

* provider.ibm: version = "~> 0.23"

Terraform has been successfully initialized!

You may now begin working with Terraform. Try running "terraform plan" to see
any changes that are required for your infrastructure. All Terraform commands
should now work.

If you ever set or change modules or backend configuration for Terraform,
rerun this command to reinitialize your working directory. If you forget, other
commands will detect it and remind you to do so if necessary.
data.ibm_compute_image_template.os_image: Refreshing state...
data.ibm_space.spacedata: Refreshing state...

Apply complete! Resources: 0 added, 0 changed, 0 destroyed.

Outputs:

os_image = [
    2354286
]
```

I realize this changes the default behavior of this data source. The alternative might be to add a flag for `latest` and let the user choose. Since the user would probably not select `oldest` given the choice, it seemed reasonable to modify the default behavior.

Does this seem like it would be useful?