### PR TITLE
Remove port speed

### DIFF
--- a/examples/ibm-is-vpc/main.tf
+++ b/examples/ibm-is-vpc/main.tf
@@ -43,7 +43,6 @@ resource "ibm_is_instance" "instance1" {
   profile = var.profile
 
   primary_network_interface {
-    port_speed = "1000"
     subnet     = ibm_is_subnet.subnet1.id
   }
 
@@ -142,7 +141,6 @@ resource "ibm_is_instance" "instance2" {
   profile = var.profile
 
   primary_network_interface {
-    port_speed = "1000"
     subnet     = ibm_is_subnet.subnet2.id
   }
 


### PR DESCRIPTION
As port speed is set by image profile as per https://cloud.ibm.com/docs/vpc?topic=vpc-pricing-for-vpc#base-instance-prices, perhaps we should remove setting it statically inside primary_network_interface?