### PR TITLE
Add subnet1 as dependency for route1

### DIFF
--- a/examples/ibm-is-vpc/main.tf
+++ b/examples/ibm-is-vpc/main.tf
@@ -8,6 +8,7 @@ resource "ibm_is_vpc_route" "route" {
   zone        = var.zone1
   destination = "192.168.4.0/24"
   next_hop    = "10.240.0.4"
+  depends_on = ["ibm_is_subnet.subnet1"]
 }
 
 resource "ibm_is_subnet" "subnet1" {


### PR DESCRIPTION
Without stating the dependency, this error may be encountered: "Cannot find subnet containing next hop address".