### PR TITLE
Remove default value from 'Removed' parameter

### DIFF
--- a/ibm/resource_ibm_is_vpc.go
+++ b/ibm/resource_ibm_is_vpc.go
@@ -55,7 +55,6 @@ func resourceIBMISVPC() *schema.Resource {
 			isVPCIsDefault: {
 				Type:     schema.TypeBool,
 				ForceNew: true,
-				Default:  false,
 				Optional: true,
 				Removed:  "This field is removed use classic_access",
 			},


### PR DESCRIPTION
If an existing cloud VPC resource is imported by id
(i.e. 'terraform import ADDR ID') _any_ subsequent changes to the VPC
will force the creation of a new resource. The 'is_default' parameter
cannot be set by the user since it's deprecated which forces a plan diff
of 'is_default: "" => "false" (forces new resource)'.