### PR TITLE
Fix the error code of non existing ibm_is_vpn_gateway

### DIFF
--- a/ibm/resource_ibm_is_vpn_gateway.go
+++ b/ibm/resource_ibm_is_vpn_gateway.go
@@ -290,7 +290,7 @@ func resourceIBMISVPNGatewayExists(d *schema.ResourceData, meta interface{}) (bo
 		iserror, ok := err.(iserrors.RiaasError)
 		if ok {
 			if len(iserror.Payload.Errors) == 1 &&
-				iserror.Payload.Errors[0].Code == "not_found" {
+				iserror.Payload.Errors[0].Code == "vpn_gateway_not_found" {
 				return false, nil
 			}
 		}


### PR DESCRIPTION
When the specified VPN gateway does not exist, the API returns not "not_found" but "vpn_gateway_not_found".  The acceptance test should cover the case where Terraform checks non-existing ibm_is_vpn_gateway.

I've tested this fix on the terraform_v0.12 branch.  Probably this fix should be applied to the master branch, too.