### PR TITLE
Fix the error code of non existing IPSec and IKE policies

### DIFF
--- a/ibm/resource_ibm_is_ike_policy.go
+++ b/ibm/resource_ibm_is_ike_policy.go
@@ -268,7 +268,7 @@ func resourceIBMISIKEPolicyExists(d *schema.ResourceData, meta interface{}) (boo
 		iserror, ok := err.(iserrors.RiaasError)
 		if ok {
 			if len(iserror.Payload.Errors) == 1 &&
-				iserror.Payload.Errors[0].Code == "not_found" {
+				iserror.Payload.Errors[0].Code == "ike_policy_not_found" {
 				return false, nil
 			}
 		}

--- a/ibm/resource_ibm_is_ipsec_policy.go
+++ b/ibm/resource_ibm_is_ipsec_policy.go
@@ -268,7 +268,7 @@ func resourceIBMISIPSecPolicyExists(d *schema.ResourceData, meta interface{}) (b
 		iserror, ok := err.(iserrors.RiaasError)
 		if ok {
 			if len(iserror.Payload.Errors) == 1 &&
-				iserror.Payload.Errors[0].Code == "not_found" {
+				iserror.Payload.Errors[0].Code == "ipsec_policy_not_found" {
 				return false, nil
 			}
 		}


### PR DESCRIPTION
The same as #936, but for ibm_is_ipsec_policy and  ibm_is_ike_policy.