### PR TITLE
Fix the error code of non existing VPN gateway when querying about a connection

### DIFF
--- a/ibm/resource_ibm_is_vpn_gateway_connections.go
+++ b/ibm/resource_ibm_is_vpn_gateway_connections.go
@@ -402,7 +402,8 @@ func resourceIBMISVPNGatewayConnectionExists(d *schema.ResourceData, meta interf
 		iserror, ok := err.(iserrors.RiaasError)
 		if ok {
 			if len(iserror.Payload.Errors) == 1 &&
-				iserror.Payload.Errors[0].Code == "vpn_connection_not_found" {
+				(iserror.Payload.Errors[0].Code == "vpn_connection_not_found" ||
+					iserror.Payload.Errors[0].Code == "vpn_gateway_not_found") {
 				return false, nil
 			}
 		}


### PR DESCRIPTION
The API returns `vpn_gateway_not_found` when a VPN connection in a VPN gateway is queried about but when the gateway does not exist.