### PR TITLE
VPC cluster resources update: Kubernetes version and cluster resize - v11

### DIFF
--- a/vendor/github.com/IBM-Cloud/bluemix-go/api/container/containerv2/workers.go
+++ b/vendor/github.com/IBM-Cloud/bluemix-go/api/container/containerv2/workers.go
@@ -49,11 +49,18 @@ type Network struct {
 	SubnetID  string `json:"subnetID"`
 }
 
+type ReplaceWorker struct {
+	ClusterIDOrName string `json:"cluster"`
+	Update          bool   `json:"update"`
+	WorkerID        string `json:"workerID"`
+}
+
 //Workers ...
 type Workers interface {
 	ListByWorkerPool(clusterIDOrName, workerPoolIDOrName string, showDeleted bool, target ClusterTargetHeader) ([]Worker, error)
 	ListWorkers(clusterIDOrName string, showDeleted bool, target ClusterTargetHeader) ([]Worker, error)
 	Get(clusterIDOrName, workerID string, target ClusterTargetHeader) (Worker, error)
+	ReplaceWokerNode(clusterIDOrName, workerID string, target ClusterTargetHeader) (string, error)
 }
 
 type worker struct {
@@ -100,4 +107,18 @@ func (r *worker) Get(clusterIDOrName, workerID string, target ClusterTargetHeade
 		return worker, err
 	}
 	return worker, err
+}
+
+func (r *worker) ReplaceWokerNode(clusterIDOrName, workerID string, target ClusterTargetHeader) (string, error) {
+	payload := ReplaceWorker{
+		ClusterIDOrName: clusterIDOrName,
+		WorkerID:        workerID,
+		Update:          true,
+	}
+	var response string
+	_, err := r.client.Post("/v2/vpc/replaceWorker", payload, &response, target.ToMap())
+	if err != nil {
+		return response, err
+	}
+	return response, err
 }

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -48,10 +48,10 @@
 			"revisionTime": "2019-12-11T04:38:12Z"
 		},
 		{
-			"checksumSHA1": "7OwkRJrIEn3cLw4vZtKiRXkBO9c=",
+			"checksumSHA1": "vkr0B6DaplZZ0tjMhMSB4e1ETP4=",
 			"path": "github.com/IBM-Cloud/bluemix-go/api/container/containerv2",
-			"revision": "ac9b271eaf42942cb8c2c2e68b8343466ae6b3cc",
-			"revisionTime": "2019-12-11T04:38:12Z"
+			"revision": "0408d77148388e314e3204a3674a85cd16b7b6c2",
+			"revisionTime": "2020-01-22T11:47:15Z"
 		},
 		{
 			"checksumSHA1": "H2TOe3MqDWY1FwV8czBE2D3sZ9o=",

--- a/website/docs/r/container_vpc_cluster.html.markdown
+++ b/website/docs/r/container_vpc_cluster.html.markdown
@@ -45,7 +45,7 @@ The following arguments are supported:
 * `kube_version` - (Optional,String) Specify the Kubernetes version, including at least the major.minor version. If you do not include this flag, the default version is used. To see available versions, run 'ibmcloud ks versions'.
 * `pod_subnet` - (Optional, Forces new resource,String) Specify a custom subnet CIDR to provide private IP addresses for pods. The subnet must be at least '/23' or larger. For more info, refer [here](https://cloud.ibm.com/docs/containers?topic=containers-cli-plugin-kubernetes-service-cli#pod-subnet) Default value: '172.30.0.0/16'
 * `service_subnet` - (Optional, Forces new resource,String) Specify a custom subnet CIDR to provide private IP addresses for services. The subnet must be at least '/24' or larger. For more info, refer [here](https://cloud.ibm.com/docs/containers?topic=containers-cli-plugin-kubernetes-service-cli#service-subnet) Default value: '172.21.0.0/16'.
-* `worker_count` - (Optional, Forces new resource,Int) The number of worker nodes per zone in the default worker pool. Default value '1'.
+* `worker_count` - (Optional, Int) The number of worker nodes per zone in the default worker pool. Default value '1'.
 * `resource_group_id` - (Optional, Forces new resource, string) The ID of the resource group. You can retrieve the value from data source `ibm_resource_group`. If not provided defaults to default resource group.
 * `tags` - (Optional, array of strings) Tags associated with the container cluster instance.  
   **NOTE**: For users on account to add tags to a resource, they must be assigned the appropriate access. Learn more about tags permission [here](https://cloud.ibm.com/docs/resources?topic=resources-access)

--- a/website/docs/r/container_vpc_worker_pool.html.markdown
+++ b/website/docs/r/container_vpc_worker_pool.html.markdown
@@ -47,7 +47,7 @@ The following arguments are supported:
 * `worker_pool_name` - (Required, Forces new resource, string) The name of the worker pool.
 * `cluster` - (Required, Forces new resource, string) The name or id of the cluster.
 * `vpc_id` - (Required, Forces new resource, string) The Id of VPC 
-* `worker_count` - (Required, Forces new resource, Int) The number of worker nodes per zone in the worker pool.
+* `worker_count` - (Required, Int) The number of worker nodes per zone in the worker pool.
 * `flavor` - (Required, Forces new resource, string) The flavour of the worker node.
 * `zones` - (Required, Forces new resource, list) A nested block describing the zones of this worker_pool. Nested zones blocks have the following structure:
   * `subnet-id` - (Required, string) The worker pool subnet to assign the cluster. 


### PR DESCRIPTION
VPC Cluster resources : ibm_container_vpc_cluster & ibm_container_vpc_worker_pool
Update : Supporting terraform_v0.11.x
               1. Cluster and Worker pool resizing 
               2. Updating Kube version

Issue:  https://github.com/IBM-Cloud/terraform-provider-ibm/issues/1004