### PR TITLE
Fix for ibm_container_cluster data source for openshift v4.3

### DIFF
--- a/ibm/data_source_ibm_container_cluster.go
+++ b/ibm/data_source_ibm_container_cluster.go
@@ -356,7 +356,7 @@ func dataSourceIBMContainerClusterRead(d *schema.ResourceData, meta interface{})
 	}
 
 	albs, err := albsAPI.ListClusterALBs(name, targetEnv)
-	if err != nil && !strings.Contains(err.Error(), "The specified cluster is a lite cluster.") {
+	if err != nil && !strings.Contains(err.Error(), "The specified cluster is a lite cluster.") && !strings.Contains(err.Error(), "This operation is not supported for your cluster's version.") {
 		return fmt.Errorf("Error retrieving alb's of the cluster %s: %s", name, err)
 	}
 


### PR DESCRIPTION
Fix for ibm_container_cluster data source for openshift v4.3