### PR TITLE
Consider it successful to delete a non-existing FIP

### DIFF
--- a/ibm/resource_ibm_is_floating_ip.go
+++ b/ibm/resource_ibm_is_floating_ip.go
@@ -281,6 +281,13 @@ func resourceIBMISFloatingIPDelete(d *schema.ResourceData, meta interface{}) err
 
 	err = floatingipC.Delete(d.Id())
 	if err != nil {
+		iserror, ok := err.(iserrors.RiaasError)
+		if ok {
+			if len(iserror.Payload.Errors) == 1 &&
+				iserror.Payload.Errors[0].Code == "service_error" {
+				return nil
+			}
+		}
 		return err
 	}
 


### PR DESCRIPTION
Sometimes users need to destroy a resource without refresh `terraform destroy -refresh=false` for various reasons. Even when the resource does not exist any more, the delete operation should be considered successful.

This PR allows deletion of a non-existing FIP.  It is already allowed for a security group rule:
https://github.com/IBM-Cloud/terraform-provider-ibm/blob/b9fb8aeedd852071061c680ec4cfb18f9fde503b/ibm/resource_ibm_is_security_group_rule.go#L286-L296