### PR TITLE
added support for network subnets in vpc resource and data source

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -350,6 +350,7 @@ github.com/hashicorp/terraform-plugin-sdk v1.6.0 h1:Um5hsAL7kKsfTHtan8lybY/d03F2
 github.com/hashicorp/terraform-plugin-sdk v1.6.0/go.mod h1:H5QLx/uhwfxBZ59Bc5SqT19M4i+fYt7LZjHTpbLZiAg=
 github.com/hashicorp/terraform-plugin-sdk v1.7.0 h1:B//oq0ZORG+EkVrIJy0uPGSonvmXqxSzXe8+GhknoW0=
 github.com/hashicorp/terraform-plugin-sdk v1.8.0 h1:HE1p52nzcgz88hIJmapUnkmM9noEjV3QhTOLaua5XUA=
+github.com/hashicorp/terraform-plugin-sdk v1.9.0 h1:WBHHIX/RgF6/lbfMCzx0qKl96BbQy3bexWFvDqt1bhE=
 github.com/hashicorp/terraform-svchost v0.0.0-20191011084731-65d371908596 h1:hjyO2JsNZUKT1ym+FAdlBEkGPevazYsmVgIMw7dVELg=
 github.com/hashicorp/terraform-svchost v0.0.0-20191011084731-65d371908596/go.mod h1:kNDNcF7sN4DocDLBkQYz73HGKwN1ANB1blq4lIYLYvg=
 github.com/hashicorp/tf-sdk-migrator v1.0.0/go.mod h1:QWLOMtAF2IMPDqKLN30L4ijNYVco4YF6HLul6VDPNfc=

--- a/ibm/resource_ibm_is_vpc.go
+++ b/ibm/resource_ibm_is_vpc.go
@@ -13,10 +13,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 
-	//"github.ibm.com/Bluemix/riaas-go-client/clients/network"
 	"github.ibm.com/Bluemix/riaas-go-client/clients/network"
 	iserrors "github.ibm.com/Bluemix/riaas-go-client/errors"
-	//"github.ibm.com/amallak1/riaas-go-client/clients/network"
 )
 
 const (
@@ -35,6 +33,9 @@ const (
 	isVPCPending                 = "pending"
 	isVPCAddressPrefixManagement = "address_prefix_management"
 	cseSourceAddresses           = "cse_source_addresses"
+	subnetsList                  = "subnets"
+	totalIPV4AddressCount        = "total_ipv4_address_count"
+	availableIPV4AddressCount    = "available_ipv4_address_count"
 )
 
 func resourceIBMISVPC() *schema.Resource {
@@ -166,6 +167,44 @@ func resourceIBMISVPC() *schema.Resource {
 					},
 				},
 			},
+
+			subnetsList: {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"name": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "subent name",
+						},
+
+						"id": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "subnet ID",
+						},
+
+						"status": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "subnet status",
+						},
+
+						totalIPV4AddressCount: {
+							Type:        schema.TypeInt,
+							Computed:    true,
+							Description: "Total IPv4 address count in the subnet",
+						},
+
+						availableIPV4AddressCount: {
+							Type:        schema.TypeInt,
+							Computed:    true,
+							Description: "Available IPv4 address count in the subnet",
+						},
+					},
+				},
+			},
 		},
 	}
 }
@@ -220,6 +259,7 @@ func resourceIBMISVPCRead(d *schema.ResourceData, meta interface{}) error {
 		return err
 	}
 	vpcC := network.NewVPCClient(sess)
+	vpcNetworkClient := network.NewSubnetClient(sess)
 
 	vpc, err := vpcC.Get(d.Id())
 	if err != nil {
@@ -283,7 +323,26 @@ func resourceIBMISVPCRead(d *schema.ResourceData, meta interface{}) error {
 		info := flattenCseIPs(displaySourceIps)
 		d.Set(cseSourceAddresses, info)
 	}
-
+	// set the subnets list
+	s, _, err := vpcNetworkClient.List("")
+	if err != nil {
+		log.Println("Error Fetching subnets")
+	} else {
+		subnetsInfo := make([]map[string]interface{}, 0)
+		for _, subnet := range s {
+			if subnet.Vpc.ID.String() == d.Id() {
+				l := map[string]interface{}{
+					"name":                    subnet.Name,
+					"id":                      subnet.ID,
+					"status":                  subnet.Status,
+					totalIPV4AddressCount:     subnet.TotalIPV4AddressCount,
+					availableIPV4AddressCount: subnet.AvailableIPV4AddressCount,
+				}
+				subnetsInfo = append(subnetsInfo, l)
+			}
+		}
+		d.Set(subnetsList, subnetsInfo)
+	}
 	return nil
 }
 

--- a/website/docs/d/is_vpc.html.markdown
+++ b/website/docs/d/is_vpc.html.markdown
@@ -42,4 +42,10 @@ The following attributes are exported:
 * `resource_controller_url` - The URL of the IBM Cloud dashboard that can be used to explore and view details about this instance.
 * `cse_source_addresses` - A list describing the cloud service endpoint source ip adresses and zones. The nested cse_source_addresses block have the following structure:
   * `address` - Ip Address of the cloud service endpoint.
-  * `zone_name` - Zone associated with the IP Address.  
+  * `zone_name` - Zone associated with the IP Address.
+* `subnets` - A list of subnets attached to VPC. The nested subnets block have the following structure:
+  * `name` - Name of the subnet.
+  * `id` - ID of the subnet.
+  * `status` -  Status of the subnet.
+  * `total_ipv4_address_count` - Total IPv4 addresses under the subnet.
+  * `available_ipv4_address_count` - Available IPv4 addresses available for the usage in the subnet.

--- a/website/docs/r/is_vpc.html.markdown
+++ b/website/docs/r/is_vpc.html.markdown
@@ -44,7 +44,13 @@ The following attributes are exported:
 * `resource_controller_url` - The URL of the IBM Cloud dashboard that can be used to explore and view details about this instance.
 * `cse_source_addresses` - A list describing the cloud service endpoint source ip adresses and zones. The nested cse_source_addresses block have the following structure:
   * `address` - Ip Address of the cloud service endpoint.
-  * `zone_name` - Zone associated with the IP Address.  
+  * `zone_name` - Zone associated with the IP Address.
+* `subnets` - A list of subnets attached to VPC. The nested subnets block have the following structure:
+  * `name` - Name of the subnet.
+  * `id` - ID of the subnet.
+  * `status` -  Status of the subnet.
+  * `total_ipv4_address_count` - Total IPv4 addresses under the subnet.
+  * `available_ipv4_address_count` - Available IPv4 addresses available for the usage in the subnet.  
 
 
 ## Import


### PR DESCRIPTION
This PR provides the support to list the subnets info associated with the vpc resource in the terraform state file
```
"subnets": [
              {
                "available_ipv4_address_count": 247,
                "id": "4c1b0db5-a8be-44bd-a148-0cf0a7a80ba2",
                "name": "test-2",
                "status": "available",
                "total_ipv4_address_count": 256
              },
              {
                "available_ipv4_address_count": 248,
                "id": "9e35de54-7550-476a-919d-992826487379",
                "name": "test-1",
                "status": "available",
                "total_ipv4_address_count": 256
              },
              {
                "available_ipv4_address_count": 247,
                "id": "72d58212-b4ce-4a61-8a79-1cf392db3a32",
                "name": "test-0",
                "status": "available",
                "total_ipv4_address_count": 256
              }
            ],
```