### PR TITLE
added support for vpc subnets list

### DIFF
--- a/website/docs/d/is_vpc.html.markdown
+++ b/website/docs/d/is_vpc.html.markdown
@@ -42,4 +42,10 @@ The following attributes are exported:
 * `resource_controller_url` - The URL of the IBM Cloud dashboard that can be used to explore and view details about this instance.
 * `cse_source_addresses` - A list describing the cloud service endpoint source ip adresses and zones. The nested cse_source_addresses block have the following structure:
    * `address` - Ip Address of the cloud service endpoint.
-   * `zone_name` - Zone associated with the IP Address. 
+   * `zone_name` - Zone associated with the IP Address.
+* `subnets` - A list of subnets attached to VPC. The nested subnets block have the following structure:
+  * `name` - Name of the subnet.
+  * `id` - ID of the subnet.
+  * `status` -  Status of the subnet.
+  * `total_ipv4_address_count` - Total IPv4 addresses under the subnet.
+  * `available_ipv4_address_count` - Available IPv4 addresses available for the usage in the subnet.

--- a/website/docs/r/is_vpc.html.markdown
+++ b/website/docs/r/is_vpc.html.markdown
@@ -44,7 +44,13 @@ The following attributes are exported:
 * `resource_controller_url` - The URL of the IBM Cloud dashboard that can be used to explore and view details about this instance.
 * `cse_source_addresses` - A list describing the cloud service endpoint source ip adresses and zones. The nested cse_source_addresses block have the following structure:
    * `address` - Ip Address of the cloud service endpoint.
-   * `zone_name` - Zone associated with the IP Address. 
+   * `zone_name` - Zone associated with the IP Address.
+* `subnets` - A list of subnets attached to VPC. The nested subnets block have the following structure:
+  * `name` - Name of the subnet.
+  * `id` - ID of the subnet.
+  * `status` -  Status of the subnet.
+  * `total_ipv4_address_count` - Total IPv4 addresses under the subnet.
+  * `available_ipv4_address_count` - Available IPv4 addresses available for the usage in the subnet.
 
 
 ## Import


### PR DESCRIPTION
This PR introduces subnets attribute in vpc resource and data sources. Attribute will fetch the subnets associated with VPC resource with the below info.

```
"subnets.#": "1",
"subnets.0.available_ipv4_address_count": "251",
"subnets.0.id": "0717-9345f93b-9140-4053-88cd-393fd69f89dd",
"subnets.0.name": "test-vpc",
"subnets.0.status": "available",
"subnets.0.total_ipv4_address_count": "256",
```
