### PR TITLE
data source : ibm_schematics_workspace attributes update

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.12
 
 require (
 	github.com/Bowery/prompt v0.0.0-20190916142128-fa8279994f75 // indirect
-	github.com/IBM-Cloud/bluemix-go v0.0.0-20200423115010-befac795f3cd
+	github.com/IBM-Cloud/bluemix-go v0.0.0-20200429085924-f3425a5eace0
 	github.com/IBM-Cloud/power-go-client v1.0.0
 	github.com/IBM/apigateway-go-sdk v0.0.0-20200414212859-416e5948678a
 	github.com/IBM/dns-svcs-go-sdk v0.0.3

--- a/go.sum
+++ b/go.sum
@@ -43,6 +43,8 @@ github.com/IBM-Cloud/bluemix-go v0.0.0-20200414105249-d884072eb6f5 h1:px0gg5nRSp
 github.com/IBM-Cloud/bluemix-go v0.0.0-20200414105249-d884072eb6f5/go.mod h1:gPJbH1etcDj7qS/hBRiLuYW9CY0bRcostSKusa51xR0=
 github.com/IBM-Cloud/bluemix-go v0.0.0-20200423115010-befac795f3cd h1:sl8hlZke57zm0eHdvFDwfHs4F3gDsoZ9A8P5qo9zhu4=
 github.com/IBM-Cloud/bluemix-go v0.0.0-20200423115010-befac795f3cd/go.mod h1:gPJbH1etcDj7qS/hBRiLuYW9CY0bRcostSKusa51xR0=
+github.com/IBM-Cloud/bluemix-go v0.0.0-20200429085924-f3425a5eace0 h1:EmD/vdPcta44Tbat65+YFXddRULHGSAkWWWIQ5iAABc=
+github.com/IBM-Cloud/bluemix-go v0.0.0-20200429085924-f3425a5eace0/go.mod h1:gPJbH1etcDj7qS/hBRiLuYW9CY0bRcostSKusa51xR0=
 github.com/IBM-Cloud/ibm-cloud-cli-sdk v0.6.7/go.mod h1:RiUvKuHKTBmBApDMUQzBL14pQUGKcx/IioKQPIcRQjs=
 github.com/IBM-Cloud/power-go-client v1.0.0 h1:iy7ElG6CmCYOeRal07JMGtIvby0qOKBPPL9Wuf1Oo4E=
 github.com/IBM-Cloud/power-go-client v1.0.0/go.mod h1:+mOxjyLeLIloR4EMHTpiDbN+FilZpiVHTwu5eqi+cbI=

--- a/ibm/data_source_ibm_schematics_workspace.go
+++ b/ibm/data_source_ibm_schematics_workspace.go
@@ -55,6 +55,46 @@ func dataSourceSchematicsWorkspace() *schema.Resource {
 				Computed: true,
 				Elem:     &schema.Schema{Type: schema.TypeString},
 			},
+			"location": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The location of workspace",
+			},
+			"description": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The description of workspace",
+			},
+			"crn": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "cloud resource name of the workspace",
+			},
+			"catalog_ref": {
+				Type:        schema.TypeMap,
+				Computed:    true,
+				Description: "Catalog references",
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"item_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"item_name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"offering_version": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"item_url": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
 			ResourceControllerURL: {
 				Type:        schema.TypeString,
 				Computed:    true,
@@ -90,10 +130,16 @@ func resourceIBMSchematicsWorkspaceRead(d *schema.ResourceData, meta interface{}
 	d.Set("status", WorkspaceInfo.Status)
 	d.Set("is_frozen", WorkspaceInfo.WorkspaceStatus.Frozen)
 	d.Set("is_locked", WorkspaceInfo.WorkspaceStatus.Locked)
+	d.Set("location", WorkspaceInfo.Location)
+	d.Set("description", WorkspaceInfo.Description)
+	d.Set("crn", WorkspaceInfo.CRN)
 	d.Set("template_id", templateID)
 
 	types := WorkspaceInfo.Type
 	d.Set("types", types)
+
+	//Update content catalog info of the workspace
+	d.Set("catalog_ref", flattenCatalogRef(WorkspaceInfo.CatalogRef))
 
 	tags := WorkspaceInfo.Tags
 	d.Set("tags", tags)

--- a/ibm/structures.go
+++ b/ibm/structures.go
@@ -26,6 +26,7 @@ import (
 	"github.com/IBM-Cloud/bluemix-go/api/iamuum/iamuumv2"
 	"github.com/IBM-Cloud/bluemix-go/api/icd/icdv4"
 	"github.com/IBM-Cloud/bluemix-go/api/mccp/mccpv2"
+	"github.com/IBM-Cloud/bluemix-go/api/schematics"
 	"github.com/IBM-Cloud/bluemix-go/models"
 )
 
@@ -1659,4 +1660,14 @@ func flattenCseIPs(list []VPCCSESourceIP) []map[string]interface{} {
 		cseIPsInfo = append(cseIPsInfo, l)
 	}
 	return cseIPsInfo
+}
+
+func flattenCatalogRef(object schematics.CatalogInfo) map[string]interface{} {
+	catalogRef := map[string]interface{}{
+		"item_id":          object.ItemID,
+		"item_name":        object.ItemName,
+		"item_url":         object.ItemURL,
+		"offering_version": object.OfferingVersion,
+	}
+	return catalogRef
 }

--- a/vendor/github.com/IBM-Cloud/bluemix-go/api/schematics/workspace.go
+++ b/vendor/github.com/IBM-Cloud/bluemix-go/api/schematics/workspace.go
@@ -25,6 +25,8 @@ type WorkspaceConfig struct {
 	SharedData         SharedDataInfo     `json:"shared_data"`
 	UpdatedAt          string             `json:"updated_at"`
 	LastHealthCheckAt  string             `json:"last_health_check_at"`
+	CatalogRef         CatalogInfo        `json:"catalog_ref"`
+	CRN                string             `json:"crn"`
 }
 
 type StatusMsgInfo struct {
@@ -41,16 +43,16 @@ type StatusInfo struct {
 }
 
 type TemplateDataInfo struct {
-	Env                 []EnvValues         `json:"env_values"`
-	Folder              string              `json:"folder"`
-	TemplateID          string              `json:"id"`
-	Type                string              `json:"type"`
-	Locked              bool                `json:"locked"`
-	UninstallScriptName string              `json:"uninstall_script_name"`
-	Values              string              `json:"values"`
-	ValuesMetadata      []map[string]string `json:"values_metadata"`
-	ValuesURL           string              `json:"values_url"`
-	Variablestore       []Variablestore     `json:"variablestore"`
+	Env                 []EnvValues     `json:"env_values"`
+	Folder              string          `json:"folder"`
+	TemplateID          string          `json:"id"`
+	Type                string          `json:"type"`
+	Locked              bool            `json:"locked"`
+	UninstallScriptName string          `json:"uninstall_script_name"`
+	Values              string          `json:"values"`
+	ValuesMetadata      interface{}     `json:"values_metadata"`
+	ValuesURL           string          `json:"values_url"`
+	Variablestore       []Variablestore `json:"variablestore"`
 }
 
 type RuntimeDataInfo struct {
@@ -136,6 +138,14 @@ type TemplateData struct {
 	Variablestore []Variablestore `json:"variablestore"`
 }
 
+type CatalogInfo struct {
+	ItemID          string `json:"item_id"`
+	ItemName        string `json:"item_name"`
+	ItemURL         string `json:"item_url"`
+	ItemReadmeURL   string `json:"item_readme_url"`
+	ItemIconURL     string `json:"item_icon_url"`
+	OfferingVersion string `json:"offering_version"`
+}
 type workspace struct {
 	client *client.Client
 }

--- a/vendor/github.com/go-openapi/errors/.travis.yml
+++ b/vendor/github.com/go-openapi/errors/.travis.yml
@@ -1,12 +1,10 @@
 after_success:
 - bash <(curl -s https://codecov.io/bash)
 go:
-- 1.11.x
-- 1.12.x
+- 1.13.x
+- 1.14.x
 install:
 - GO111MODULE=off go get -u gotest.tools/gotestsum
-env:
-- GO111MODULE=on
 language: go
 notifications:
   slack:

--- a/vendor/github.com/go-openapi/strfmt/time.go
+++ b/vendor/github.com/go-openapi/strfmt/time.go
@@ -59,12 +59,16 @@ const (
 	RFC3339Micro = "2006-01-02T15:04:05.000000Z07:00"
 	// ISO8601LocalTime represents a ISO8601 format to ISO8601 in local time (no timezone)
 	ISO8601LocalTime = "2006-01-02T15:04:05"
+	// ISO8601TimeWithReducedPrecision represents a ISO8601 format with reduced precision (dropped secs)
+	ISO8601TimeWithReducedPrecision = "2006-01-02T15:04Z"
+	// ISO8601TimeWithReducedPrecision represents a ISO8601 format with reduced precision and no timezone (dropped seconds + no timezone)
+	ISO8601TimeWithReducedPrecisionLocaltime = "2006-01-02T15:04"
 	// DateTimePattern pattern to match for the date-time format from http://tools.ietf.org/html/rfc3339#section-5.6
 	DateTimePattern = `^([0-9]{2}):([0-9]{2}):([0-9]{2})(.[0-9]+)?(z|([+-][0-9]{2}:[0-9]{2}))$`
 )
 
 var (
-	dateTimeFormats = []string{RFC3339Micro, RFC3339Millis, time.RFC3339, time.RFC3339Nano, ISO8601LocalTime}
+	dateTimeFormats = []string{RFC3339Micro, RFC3339Millis, time.RFC3339, time.RFC3339Nano, ISO8601LocalTime, ISO8601TimeWithReducedPrecision, ISO8601TimeWithReducedPrecisionLocaltime}
 	rxDateTime      = regexp.MustCompile(DateTimePattern)
 	// MarshalFormat sets the time resolution format used for marshaling time (set to milliseconds)
 	MarshalFormat = RFC3339Millis

--- a/vendor/github.com/go-openapi/swag/.travis.yml
+++ b/vendor/github.com/go-openapi/swag/.travis.yml
@@ -1,12 +1,10 @@
 after_success:
 - bash <(curl -s https://codecov.io/bash)
 go:
-- 1.11.x
-- 1.12.x
+- 1.13.x
+- 1.14.x
 install:
 - GO111MODULE=off go get -u gotest.tools/gotestsum
-env:
-- GO111MODULE=on
 language: go
 notifications:
   slack:

--- a/vendor/github.com/go-openapi/validate/.travis.yml
+++ b/vendor/github.com/go-openapi/validate/.travis.yml
@@ -1,12 +1,10 @@
 after_success:
 - bash <(curl -s https://codecov.io/bash)
 go:
-- 1.11.x
-- 1.12.x
+- 1.13.x
+- 1.14.x
 install:
 - GO111MODULE=off go get -u gotest.tools/gotestsum
-env:
-- GO111MODULE=on
 language: go
 notifications:
   slack:

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -6,7 +6,7 @@ cloud.google.com/go/internal/optional
 cloud.google.com/go/internal/trace
 cloud.google.com/go/internal/version
 cloud.google.com/go/storage
-# github.com/IBM-Cloud/bluemix-go v0.0.0-20200423115010-befac795f3cd
+# github.com/IBM-Cloud/bluemix-go v0.0.0-20200429085924-f3425a5eace0
 github.com/IBM-Cloud/bluemix-go
 github.com/IBM-Cloud/bluemix-go/api/account/accountv1
 github.com/IBM-Cloud/bluemix-go/api/account/accountv2
@@ -185,7 +185,7 @@ github.com/ghodss/yaml
 # github.com/go-openapi/analysis v0.19.5
 github.com/go-openapi/analysis
 github.com/go-openapi/analysis/internal
-# github.com/go-openapi/errors v0.19.3
+# github.com/go-openapi/errors v0.19.4
 github.com/go-openapi/errors
 # github.com/go-openapi/jsonpointer v0.19.3
 github.com/go-openapi/jsonpointer
@@ -204,11 +204,11 @@ github.com/go-openapi/runtime/middleware/untyped
 github.com/go-openapi/runtime/security
 # github.com/go-openapi/spec v0.19.3
 github.com/go-openapi/spec
-# github.com/go-openapi/strfmt v0.19.4
+# github.com/go-openapi/strfmt v0.19.5
 github.com/go-openapi/strfmt
-# github.com/go-openapi/swag v0.19.7
+# github.com/go-openapi/swag v0.19.8
 github.com/go-openapi/swag
-# github.com/go-openapi/validate v0.19.6
+# github.com/go-openapi/validate v0.19.7
 github.com/go-openapi/validate
 # github.com/go-playground/locales v0.13.0
 github.com/go-playground/locales

--- a/website/docs/d/schematics_workspace.html.markdown
+++ b/website/docs/d/schematics_workspace.html.markdown
@@ -39,4 +39,12 @@ The following attributes are exported:
 * `tags` - The tags suppoprted by workspace.
 * `resource_group` - The resource group associated with the workspace.
 * `resource_controller_url` - The URL of the IBM Cloud dashboard that can be used to explore and view details about the workspace.
+* `location` - The location of worspace instantiated.
+* `crn` - The cloud resource name of the worspace.
+* `description` - The description provided for the workspace.
+* `catalog_ref` - A nested block describing the catalog template and its properties associated with worksapce. Nested `catalog_ref` blocks have the following structure:
+  * `item_id` - The catalog template Id.
+  * `item_name` - The catalog template name.
+  * `item_url` - The catlog template URL.
+  * `offering_version` - The catalog template offering version.
 


### PR DESCRIPTION
The PR has the fix ibm_schematics_workspace data source attributes update:
1. location
2. description
3. CRN and 
4. catalog reference -  item_id, item_name, item_url and offering_version.

The output from terraform state file would look like below.
```
          "attributes": {
            "catalog_ref": {
              "item_id": "1082e7d2-5e2f-0a11-a3bc-f88a8e1931fc.f49ae2d5-1c4a-4189-b922-a3b7ebe44194-global",
              "item_name": "etcd",
              "item_url": "/catalog/content/etcd?kind=iks\u0026version=3.4.7",
              "offering_version": "3.4.7"
            },
            "crn": "crn:v1:bluemix:public:schematics:us-south:a/96fe4b4beb8947bf85223e69dab47878:774d14ce-f57a-4cb4-bd90-2b4512ff8115:workspace:etcd-04-28-2020-4651dcad-af60-49",
            "description": "",
            "id": "etcd-04-28-2020-4651dcad-af60-49",
            "is_frozen": false,
            "is_locked": false,
            "location": "US",
            "name": "etcd-04-28-2020",
```

