### PR TITLE
handle location info

### DIFF
--- a/ibm/resource_ibm_cos_bucket.go
+++ b/ibm/resource_ibm_cos_bucket.go
@@ -233,6 +233,9 @@ func resourceIBMCOSCreate(d *schema.ResourceData, meta interface{}) error {
 		bLocation = bucketLocation.(string)
 		apiType = "ssl"
 	}
+	if bLocation == "" {
+		return fmt.Errorf("Provide either `cross_region_location` or `region_location` or `single_site_location`")
+	}
 	lConstraint := fmt.Sprintf("%s-%s", bLocation, storageClass)
 	apiEndpoint, _ := selectCosApi(apiType, bLocation)
 	create := &s3.CreateBucketInput{


### PR DESCRIPTION
when location info is not provided in cos_bucket resource, resource forms invalid URL and throws below error.

```
020/05/22 13:56:36 [DEBUG] ibm_cos_bucket.ansible_20200522-132444: apply errored, but we're indicating that via the Error pointer rather than returning it: RequestError: send request failed
caused by: Put https://s3..amazonaws.com/test_ansible_bucket_example: dial tcp: lookup s3..amazonaws.com: no such host
2020/05/22 13:56:36 [ERROR] <root>: eval: *terraform.EvalApplyPost, err: RequestError: send request failed
caused by: Put https://s3..amazonaws.com/test_ansible_bucket_example: dial tcp: lookup s3..amazonaws.com: no such host
2020/05/22 13:56:36 [ERROR] <root>: eval: *terraform.EvalSequence, err: RequestError: send request failed
caused by: Put https://s3..amazonaws.com/test_ansible_bucket_example: dial tcp: lookup s3..amazonaws.com: no such host

Error: RequestError: send request failed
caused by: Put https://s3..amazonaws.com/test_ansible_bucket_example: dial tcp: lookup s3..amazonaws.com: no such host
```

Added check in this PR.