### PR TITLE
Handle FIP without target correctly

### DIFF
--- a/ibm/resource_ibm_is_floating_ip.go
+++ b/ibm/resource_ibm_is_floating_ip.go
@@ -316,8 +316,8 @@ func classicFipGet(d *schema.ResourceData, meta interface{}, id string) error {
 	d.Set(isFloatingIPAddress, *floatingip.Address)
 	d.Set(isFloatingIPStatus, *floatingip.Status)
 	d.Set(isFloatingIPZone, *floatingip.Zone.Name)
-	target := floatingip.Target.(*vpcclassicv1.FloatingIPTarget)
-	if target != nil {
+	target, ok := floatingip.Target.(*vpcclassicv1.FloatingIPTarget)
+	if ok {
 		d.Set(isFloatingIPTarget, target.ID)
 	}
 	tags, err := GetTagsUsingCRN(meta, *floatingip.Crn)

--- a/ibm/resource_ibm_is_floating_ip.go
+++ b/ibm/resource_ibm_is_floating_ip.go
@@ -358,8 +358,8 @@ func fipGet(d *schema.ResourceData, meta interface{}, id string) error {
 	d.Set(isFloatingIPAddress, *floatingip.Address)
 	d.Set(isFloatingIPStatus, *floatingip.Status)
 	d.Set(isFloatingIPZone, *floatingip.Zone.Name)
-	target := floatingip.Target.(*vpcv1.FloatingIPTarget)
-	if target != nil {
+	target, ok := floatingip.Target.(*vpcv1.FloatingIPTarget)
+	if ok {
 		d.Set(isFloatingIPTarget, target.ID)
 	}
 	tags, err := GetTagsUsingCRN(meta, *floatingip.Crn)


### PR DESCRIPTION
FIP without a target causes a panic in the plugin.
```
resource "ibm_is_floating_ip" "fip1" {
  name    = "myfip"
  zone    = "us-south-1"
}
```
```
2020-06-03T15:26:58.585-0500 [DEBUG] plugin.terraform-provider-ibm: panic: interface conversion: vpcv1.FloatingIPTargetIntf is nil, not *vpcv1.FloatingIPTarget
2020-06-03T15:26:58.585-0500 [DEBUG] plugin.terraform-provider-ibm:
2020-06-03T15:26:58.585-0500 [DEBUG] plugin.terraform-provider-ibm: goroutine 417 [running]:
2020-06-03T15:26:58.585-0500 [DEBUG] plugin.terraform-provider-ibm: github.com/IBM-Cloud/terraform-provider-ibm/ibm.fipGet(0xc0003eb9d0, 0x21a9500, 0xc000d6a000, 0xc000f79950, 0x29, 0x0, 0x0)
2020-06-03T15:26:58.585-0500 [DEBUG] plugin.terraform-provider-ibm:     /home/rodaira/go/src/github.com/IBM-Cloud/terraform-provider-ibm/ibm/resource_ibm_is_floating_ip.go:361 +0x98b
2020-06-03T15:26:58.585-0500 [DEBUG] plugin.terraform-provider-ibm: github.com/IBM-Cloud/terraform-provider-ibm/ibm.resourceIBMISFloatingIPRead(0xc0003eb9d0, 0x21a9500, 0xc000d6a000, 0xc0003eb9d0, 0x0)
2020-06-03T15:26:58.585-0500 [DEBUG] plugin.terraform-provider-ibm:     /home/rodaira/go/src/github.com/IBM-Cloud/terraform-provider-ibm/ibm/resource_ibm_is_floating_ip.go:290 +0x13c
2020-06-03T15:26:58.585-0500 [DEBUG] plugin.terraform-provider-ibm: github.com/hashicorp/terraform-plugin-sdk/helper/schema.(*Resource).RefreshWithoutUpgrade(0xc00061f000, 0xc000fdc8c0, 0x21a9500, 0xc000d6a000, 0xc000011668, 0x0, 0x0)
2020-06-03T15:26:58.585-0500 [DEBUG] plugin.terraform-provider-ibm:     /home/rodaira/go/pkg/mod/github.com/hashicorp/terraform-plugin-sdk@v1.6.0/helper/schema/resource.go:455 +0x119
2020-06-03T15:26:58.585-0500 [DEBUG] plugin.terraform-provider-ibm: github.com/hashicorp/terraform-plugin-sdk/internal/helper/plugin.(*GRPCProviderServer).ReadResource(0xc0005d01e8, 0x2699bc0, 0xc000ecc540, 0xc000fdc7d0, 0xc0005d01e8, 0xc000ecc540, 0xc0007e4a80)
2020-06-03T15:26:58.585-0500 [DEBUG] plugin.terraform-provider-ibm:     /home/rodaira/go/pkg/mod/github.com/hashicorp/terraform-plugin-sdk@v1.6.0/internal/helper/plugin/grpc_provider.go:525 +0x3d8
2020-06-03T15:26:58.585-0500 [DEBUG] plugin.terraform-provider-ibm: github.com/hashicorp/terraform-plugin-sdk/internal/tfplugin5._Provider_ReadResource_Handler(0x21272e0, 0xc0005d01e8, 0x2699bc0, 0xc000ecc540, 0xc000f04240, 0x0, 0x2699bc0, 0xc000ecc540, 0xc000726000, 0x2ac)
2020-06-03T15:26:58.585-0500 [DEBUG] plugin.terraform-provider-ibm:     /home/rodaira/go/pkg/mod/github.com/hashicorp/terraform-plugin-sdk@v1.6.0/internal/tfplugin5/tfplugin5.pb.go:3153 +0x217
2020-06-03T15:26:58.585-0500 [DEBUG] plugin.terraform-provider-ibm: google.golang.org/grpc.(*Server).processUnaryRPC(0xc0001866e0, 0x26adcc0, 0xc0004b9080, 0xc000f01100, 0xc000c16ba0, 0x35ec990, 0x0, 0x0, 0x0)
2020-06-03T15:26:58.585-0500 [DEBUG] plugin.terraform-provider-ibm:     /home/rodaira/go/pkg/mod/google.golang.org/grpc@v1.23.0/server.go:995 +0x460
2020-06-03T15:26:58.585-0500 [DEBUG] plugin.terraform-provider-ibm: google.golang.org/grpc.(*Server).handleStream(0xc0001866e0, 0x26adcc0, 0xc0004b9080, 0xc000f01100, 0x0)
2020-06-03T15:26:58.585-0500 [DEBUG] plugin.terraform-provider-ibm:     /home/rodaira/go/pkg/mod/google.golang.org/grpc@v1.23.0/server.go:1275 +0xd97
2020-06-03T15:26:58.585-0500 [DEBUG] plugin.terraform-provider-ibm: google.golang.org/grpc.(*Server).serveStreams.func1.1(0xc0005c2740, 0xc0001866e0, 0x26adcc0, 0xc0004b9080, 0xc000f01100)
2020-06-03T15:26:58.585-0500 [DEBUG] plugin.terraform-provider-ibm:     /home/rodaira/go/pkg/mod/google.golang.org/grpc@v1.23.0/server.go:710 +0xbb
2020-06-03T15:26:58.585-0500 [DEBUG] plugin.terraform-provider-ibm: created by google.golang.org/grpc.(*Server).serveStreams.func1
2020-06-03T15:26:58.585-0500 [DEBUG] plugin.terraform-provider-ibm:     /home/rodaira/go/pkg/mod/google.golang.org/grpc@v1.23.0/server.go:708 +0xa1
2020/06/03 15:26:58 [ERROR] <root>: eval: *terraform.EvalRefresh, err: rpc error: code = Unavailable desc = transport is closing
2020/06/03 15:26:58 [ERROR] <root>: eval: *terraform.EvalSequence, err: rpc error: code = Unavailable desc = transport is closing
```
Terraform v0.12.26, plugin def2ea353f623f46c7029c060d468633654f16e3