### PR TITLE
Removing resource group name

### DIFF
--- a/ibm/resource_ibm_is_image.go
+++ b/ibm/resource_ibm_is_image.go
@@ -552,7 +552,6 @@ func imgGet(d *schema.ResourceData, meta interface{}, id string) error {
 	d.Set(ResourceCRN, *image.Crn)
 	if image.ResourceGroup != nil {
 		d.Set(isImageResourceGroup, *image.ResourceGroup.ID)
-		d.Set(ResourceGroupName, *image.ResourceGroup.Name)
 	}
 	return nil
 }


### PR DESCRIPTION
Removing set resource group name as user will pass only resource group id. 