### PR TITLE
Avoid infinite wait when deleting an instance with a data volume

### DIFF
--- a/ibm/resource_ibm_is_instance.go
+++ b/ibm/resource_ibm_is_instance.go
@@ -1758,7 +1758,6 @@ func classicInstanceDelete(d *schema.ResourceData, meta interface{}, id string) 
 			if err != nil {
 				return err
 			}
-			break
 		}
 		if *vol.Type == "boot" {
 			bootvolid = *vol.Volume.ID
@@ -1839,7 +1838,6 @@ func instanceDelete(d *schema.ResourceData, meta interface{}, id string) error {
 			if err != nil {
 				return err
 			}
-			break
 		}
 		if *vol.Type == "boot" {
 			bootvolid = *vol.Volume.ID


### PR DESCRIPTION
When deleting an instance with a data volume, the plugin fetches a list of the volume attachments, which includes both the data and boot volume attachments, and then deletes the data volume attachment.  The order of the data and boot in the list is not deterministic.  When the data comes first, the execution would break the loop by the `break` statement removed by this PR.  This means the `bootvolid` variable remains `""`.  Later in the same function, the plugin waits for the boot volume to be deleted by calling `isWaitForVolumeDeleted()`.  However, because the `bootvolid` argument is `""`, it would wait infinitely until the timeout.