### PR TITLE
Add a test case for #1594 #1595

### DIFF
--- a/ibm/resource_ibm_is_instance_test.go
+++ b/ibm/resource_ibm_is_instance_test.go
@@ -82,6 +82,18 @@ ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCKVmnMOlHKcZK8tpt3MP1lqOLAcqcJzhsvJcjscgVE
 						"ibm_is_instance.testacc_instance", "volumes.#", "0"),
 				),
 			},
+			{
+				Config: testAccCheckIBMISInstanceVolume(vpcname, subnetname, sshname, publicKey, volname, name),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckIBMISInstanceExists("ibm_is_instance.testacc_instance", instance),
+					resource.TestCheckResourceAttr(
+						"ibm_is_instance.testacc_instance", "name", name),
+					resource.TestCheckResourceAttr(
+						"ibm_is_instance.testacc_instance", "zone", ISZoneName),
+					resource.TestCheckResourceAttr(
+						"ibm_is_instance.testacc_instance", "volumes.#", "1"),
+				),
+			},
 		},
 	})
 }


### PR DESCRIPTION
I propose to add one more step that attaches the volume again, so that the test covers the case in which TF destroys an instance with a data volume.