### PR TITLE
New PR for security group Rules

### DIFF
--- a/examples/ibm-is-vpc/main.tf
+++ b/examples/ibm-is-vpc/main.tf
@@ -166,6 +166,7 @@ resource "ibm_is_security_group_rule" "sg1_app_tcp_rule" {
   }
 }
 
+
 resource "ibm_is_vpc" "vpc2" {
   name = "vpc2"
 }

--- a/ibm/data_source_ibm_is_security_group.go
+++ b/ibm/data_source_ibm_is_security_group.go
@@ -1,0 +1,427 @@
+package ibm
+
+import (
+	"reflect"
+
+	"github.com/IBM/vpc-go-sdk/vpcclassicv1"
+	"github.com/IBM/vpc-go-sdk/vpcv1"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+)
+
+const (
+	isSgName          = "name"
+	isSgRules         = "rules"
+	isSgRuleID        = "rule_id"
+	isSgRuleDirection = "direction"
+	isSgRuleIPVersion = "ip_version"
+	isSgRuleRemote    = "remote"
+	isSgRuleType      = "type"
+	isSgRuleCode      = "code"
+	isSgRulePortMax   = "port_max"
+	isSgRulePortMin   = "port_min"
+	isSgRuleProtocol  = "protocol"
+	isSgVPC           = "vpc"
+)
+
+func dataSourceIBMISSecurityGroup() *schema.Resource {
+	return &schema.Resource{
+
+		Read: dataSourceIBMISSecurityGroupRuleRead,
+
+		Schema: map[string]*schema.Schema{
+
+			isSgName: {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "Security group name",
+			},
+
+			isSecurityGroupVPC: {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "Security group's resource group id",
+				ForceNew:    true,
+			},
+
+			isSgRules: {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Description: "Security Rules",
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+
+						isSgRuleID: {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "Rule id",
+						},
+
+						isSgRuleDirection: {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "Direction of traffic to enforce, either inbound or outbound",
+						},
+
+						isSgRuleIPVersion: {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "IP version: ipv4 or ipv6",
+						},
+
+						isSgRuleRemote: {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "Security group id: an IP address, a CIDR block, or a single security group identifier",
+						},
+
+						isSgRuleType: {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+
+						isSgRuleCode: {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+
+						isSgRulePortMin: {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+
+						isSgRulePortMax: {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+
+						isSgRuleProtocol: {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
+
+			ResourceControllerURL: {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The URL of the IBM Cloud dashboard that can be used to explore and view details about this instance",
+			},
+
+			ResourceName: {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The name of the resource",
+			},
+
+			ResourceCRN: {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The crn of the resource",
+			},
+
+			ResourceGroupName: {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The resource group name in which resource is provisioned",
+			},
+		},
+	}
+}
+
+func dataSourceIBMISSecurityGroupRuleRead(d *schema.ResourceData, meta interface{}) error {
+	userDetails, err := meta.(ClientSession).BluemixUserDetails()
+	if err != nil {
+		return err
+	}
+	sgName := d.Get(isSgName).(string)
+	if userDetails.generation == 1 {
+		err := classicSecurityGroupGet(d, meta, sgName)
+		if err != nil {
+			return err
+		}
+	} else {
+		err := securityGroupGet(d, meta, sgName)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func classicSecurityGroupGet(d *schema.ResourceData, meta interface{}, name string) error {
+	sess, err := classicVpcClient(meta)
+	if err != nil {
+		return err
+	}
+
+	listSgOptions := &vpcclassicv1.ListSecurityGroupsOptions{}
+	sgs, _, err := sess.ListSecurityGroups(listSgOptions)
+	if err != nil {
+		return err
+	}
+
+	for _, group := range sgs.SecurityGroups {
+		if *group.Name == name {
+
+			d.Set(isSgName, *group.Name)
+			d.Set(isSgVPC, *group.VPC.ID)
+
+			rules := make([]map[string]interface{}, 0)
+			for _, sgrule := range group.Rules {
+				switch reflect.TypeOf(sgrule).String() {
+				case "*vpcclassicv1.SecurityGroupRuleProtocolIcmp":
+					{
+
+						rule := sgrule.(*vpcclassicv1.SecurityGroupRuleProtocolIcmp)
+						r := make(map[string]interface{})
+						if rule.Code != nil {
+							r[isSgRuleCode] = int(*rule.Code)
+						}
+						if rule.Type != nil {
+							r[isSgRuleType] = int(*rule.Type)
+						}
+						r[isSgRuleDirection] = *rule.Direction
+						r[isSgRuleIPVersion] = *rule.IPVersion
+						if rule.Protocol != nil {
+							r[isSgRuleProtocol] = *rule.Protocol
+						}
+						r[isSgRuleID] = *rule.ID
+
+						if rule.Remote != nil && reflect.ValueOf(rule.Remote).IsNil() == false {
+							for k, v := range rule.Remote.(map[string]interface{}) {
+								if k == "id" || k == "address" || k == "cidr_block" {
+									r[isSgRuleRemote] = v.(string)
+									break
+								}
+							}
+						}
+
+						rules = append(rules, r)
+					}
+
+				case "*vpcclassicv1.SecurityGroupRuleProtocolAll":
+					{
+
+						rule := sgrule.(*vpcclassicv1.SecurityGroupRuleProtocolAll)
+						r := make(map[string]interface{})
+						r[isSgRuleDirection] = *rule.Direction
+						r[isSgRuleIPVersion] = *rule.IPVersion
+						if rule.Protocol != nil {
+							r[isSgRuleProtocol] = *rule.Protocol
+						}
+						r[isSgRuleID] = *rule.ID
+
+						if rule.Remote != nil && reflect.ValueOf(rule.Remote).IsNil() == false {
+							for k, v := range rule.Remote.(map[string]interface{}) {
+								if k == "id" || k == "address" || k == "cidr_block" {
+									r[isSgRuleRemote] = v.(string)
+									break
+								}
+							}
+						}
+
+						rules = append(rules, r)
+					}
+
+				case "*vpcclassicv1.SecurityGroupRuleProtocolTcpudp":
+					{
+						rule := sgrule.(*vpcclassicv1.SecurityGroupRuleProtocolTcpudp)
+						r := make(map[string]interface{})
+						if rule.PortMin != nil {
+							r[isSgRulePortMin] = int(*rule.PortMin)
+						}
+						if rule.PortMax != nil {
+							r[isSgRulePortMax] = int(*rule.PortMax)
+						}
+						r[isSgRuleDirection] = *rule.Direction
+						r[isSgRuleIPVersion] = *rule.IPVersion
+						if rule.Protocol != nil {
+							r[isSgRuleProtocol] = *rule.Protocol
+						}
+
+						r[isSgRuleID] = *rule.ID
+						if rule.Remote != nil && reflect.ValueOf(rule.Remote).IsNil() == false {
+							for k, v := range rule.Remote.(map[string]interface{}) {
+								if k == "id" || k == "address" || k == "cidr_block" {
+									r[isSgRuleRemote] = v.(string)
+									break
+								}
+							}
+						}
+
+						rules = append(rules, r)
+					}
+				}
+			}
+
+			d.Set(isSgRules, rules)
+			d.SetId(*group.ID)
+
+			if group.ResourceGroup != nil {
+				rsMangClient, err := meta.(ClientSession).ResourceManagementAPIv2()
+				if err != nil {
+					return err
+				}
+				grp, err := rsMangClient.ResourceGroup().Get(*group.ResourceGroup.ID)
+				if err != nil {
+					return err
+				}
+				d.Set(ResourceGroupName, grp.Name)
+			}
+
+			controller, err := getBaseController(meta)
+			if err != nil {
+				return err
+			}
+			d.Set(ResourceControllerURL, controller+"/vpc/network/securityGroups")
+			if group.Name != nil {
+				d.Set(ResourceName, *group.Name)
+			}
+
+			if group.CRN != nil {
+				d.Set(ResourceCRN, *group.CRN)
+			}
+			return nil
+		}
+	}
+
+	return nil
+}
+
+func securityGroupGet(d *schema.ResourceData, meta interface{}, name string) error {
+	sess, err := vpcClient(meta)
+	if err != nil {
+		return err
+	}
+
+	listSgOptions := &vpcv1.ListSecurityGroupsOptions{}
+	sgs, _, err := sess.ListSecurityGroups(listSgOptions)
+	if err != nil {
+		return err
+	}
+
+	for _, group := range sgs.SecurityGroups {
+		if *group.Name == name {
+
+			d.Set(isSgName, *group.Name)
+			d.Set(isSgVPC, *group.VPC.ID)
+
+			rules := make([]map[string]interface{}, 0)
+			for _, sgrule := range group.Rules {
+				switch reflect.TypeOf(sgrule).String() {
+				case "*vpcv1.SecurityGroupRuleProtocolIcmp":
+					{
+						rule := sgrule.(*vpcv1.SecurityGroupRuleProtocolIcmp)
+						r := make(map[string]interface{})
+						if rule.Code != nil {
+							r[isSgRuleCode] = int(*rule.Code)
+						}
+						if rule.Type != nil {
+							r[isSgRuleType] = int(*rule.Type)
+						}
+						r[isSgRuleDirection] = *rule.Direction
+						r[isSgRuleIPVersion] = *rule.IPVersion
+						if rule.Protocol != nil {
+							r[isSgRuleProtocol] = *rule.Protocol
+						}
+						r[isSgRuleID] = *rule.ID
+
+						if rule.Remote != nil && reflect.ValueOf(rule.Remote).IsNil() == false {
+							for k, v := range rule.Remote.(map[string]interface{}) {
+								if k == "id" || k == "address" || k == "cidr_block" {
+									r[isSgRuleRemote] = v.(string)
+									break
+								}
+							}
+						}
+						rules = append(rules, r)
+					}
+
+				case "*vpcv1.SecurityGroupRuleProtocolAll":
+					{
+						rule := sgrule.(*vpcv1.SecurityGroupRuleProtocolAll)
+						r := make(map[string]interface{})
+						r[isSgRuleDirection] = *rule.Direction
+						r[isSgRuleIPVersion] = *rule.IPVersion
+						if rule.Protocol != nil {
+							r[isSgRuleProtocol] = *rule.Protocol
+						}
+						r[isSgRuleID] = *rule.ID
+
+						if rule.Remote != nil && reflect.ValueOf(rule.Remote).IsNil() == false {
+							for k, v := range rule.Remote.(map[string]interface{}) {
+								if k == "id" || k == "address" || k == "cidr_block" {
+									r[isSgRuleRemote] = v.(string)
+									break
+								}
+							}
+						}
+						rules = append(rules, r)
+					}
+
+				case "*vpcv1.SecurityGroupRuleProtocolTcpudp":
+					{
+						rule := sgrule.(*vpcv1.SecurityGroupRuleProtocolTcpudp)
+						r := make(map[string]interface{})
+						if rule.PortMin != nil {
+							r[isSgRulePortMin] = int(*rule.PortMin)
+						}
+						if rule.PortMax != nil {
+							r[isSgRulePortMax] = int(*rule.PortMax)
+						}
+						r[isSgRuleDirection] = *rule.Direction
+						r[isSgRuleIPVersion] = *rule.IPVersion
+						if rule.Protocol != nil {
+							r[isSgRuleProtocol] = *rule.Protocol
+						}
+
+						r[isSgRuleID] = *rule.ID
+						if rule.Remote != nil && reflect.ValueOf(rule.Remote).IsNil() == false {
+							for k, v := range rule.Remote.(map[string]interface{}) {
+								if k == "id" || k == "address" || k == "cidr_block" {
+									r[isSgRuleRemote] = v.(string)
+									break
+								}
+							}
+						}
+
+						rules = append(rules, r)
+					}
+				}
+			}
+
+			d.Set(isSgRules, rules)
+			d.SetId(*group.ID)
+
+			if group.ResourceGroup != nil {
+				rsMangClient, err := meta.(ClientSession).ResourceManagementAPIv2()
+				if err != nil {
+					return err
+				}
+				grp, err := rsMangClient.ResourceGroup().Get(*group.ResourceGroup.ID)
+				if err != nil {
+					return err
+				}
+				d.Set(ResourceGroupName, grp.Name)
+			}
+
+			controller, err := getBaseController(meta)
+			if err != nil {
+				return err
+			}
+			d.Set(ResourceControllerURL, controller+"/vpc/network/securityGroups")
+			if group.Name != nil {
+				d.Set(ResourceName, *group.Name)
+			}
+
+			if group.CRN != nil {
+				d.Set(ResourceCRN, *group.CRN)
+			}
+			return nil
+		}
+	}
+
+	return nil
+
+}

--- a/ibm/data_source_ibm_is_security_group_test.go
+++ b/ibm/data_source_ibm_is_security_group_test.go
@@ -1,0 +1,89 @@
+package ibm
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+)
+
+func TestAccIBMISSecurityGroupDatasource_basic(t *testing.T) {
+	vpcname := fmt.Sprintf("tfsubnet-vpc-%d", acctest.RandIntRange(10, 100))
+	sgname := fmt.Sprintf("tfsubnet-name-%d", acctest.RandIntRange(10, 100))
+	dataSourceName := "data.ibm_is_security_group.sg1_rule"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckIBMISSecurityGroupDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccCheckIBMISSgRuleConfig(vpcname, sgname),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet(dataSourceName, "vpc"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "rules.#"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckIBMISSgRuleConfig(vpcname, sgname string) string {
+	return fmt.Sprintf(`
+	resource "ibm_is_vpc" "testacc_vpc" {
+		name = "%s"
+	  }
+	  
+	  resource "ibm_is_security_group" "testacc_security_group" {
+		name = "%s"
+		vpc  = ibm_is_vpc.testacc_vpc.id
+	  }
+	  
+	  resource "ibm_is_security_group_rule" "testacc_security_group_rule_all" {
+		group     = ibm_is_security_group.testacc_security_group.id
+		direction = "inbound"
+		remote    = "127.0.0.1"
+	  }
+
+	  resource "ibm_is_security_group_rule" "testacc_security_group_rule_icmp" {
+        depends_on = [ibm_is_security_group_rule.testacc_security_group_rule_all]
+        group      = ibm_is_security_group.testacc_security_group.id
+        direction  = "inbound"
+        remote     = "127.0.0.1"
+        icmp {
+          code = 20
+          type = 30
+        }
+      }
+      
+      resource "ibm_is_security_group_rule" "testacc_security_group_rule_udp" {
+        depends_on = [ibm_is_security_group_rule.testacc_security_group_rule_icmp]
+        group      = ibm_is_security_group.testacc_security_group.id
+        direction  = "inbound"
+        remote     = "127.0.0.1"
+        udp {
+          port_min = 805
+          port_max = 807
+        }
+      }
+      
+      resource "ibm_is_security_group_rule" "testacc_security_group_rule_tcp" {
+        depends_on = [ibm_is_security_group_rule.testacc_security_group_rule_udp]
+        group      = ibm_is_security_group.testacc_security_group.id
+        direction  = "inbound"
+        remote     = "127.0.0.1"
+        tcp {
+          port_min = 8080
+          port_max = 8080
+        }
+	  }
+	  
+	  data "ibm_is_security_group" "sg1_rule" {
+		name = ibm_is_security_group.testacc_security_group.name
+	}
+
+	  
+    `, vpcname, sgname)
+
+}

--- a/ibm/provider.go
+++ b/ibm/provider.go
@@ -204,6 +204,7 @@ func Provider() terraform.ResourceProvider {
 			"ibm_is_ssh_key":                       dataSourceIBMISSSHKey(),
 			"ibm_is_subnet":                        dataSourceIBMISSubnet(),
 			"ibm_is_subnets":                       dataSourceIBMISSubnets(),
+			"ibm_is_security_group":                dataSourceIBMISSecurityGroup(),
 			"ibm_is_vpc":                           dataSourceIBMISVPC(),
 			"ibm_is_zone":                          dataSourceIBMISZone(),
 			"ibm_is_zones":                         dataSourceIBMISZones(),

--- a/website/docs/d/is_security_group.html.markdown
+++ b/website/docs/d/is_security_group.html.markdown
@@ -1,0 +1,92 @@
+---
+layout: "ibm"
+page_title: "IBM : security_group"
+sidebar_current: "docs-ibm-resource-is-security-group"
+description: |-
+  Reads IBM Cloud Security Group.
+---
+
+# ibm\_is_security_group
+
+Import the details of a security group as a read-only data source. You can then reference the fields of the data source in other resources within the same configuration using interpolation syntax.
+
+
+## Example Usage
+
+In the following example, you can create a different types of protocol rules `ALL`, `ICMP`, `UDP`, `TCP` and read the security group.
+
+```hcl
+resource "ibm_is_vpc" "testacc_vpc" {
+  name = "test"
+}
+
+resource "ibm_is_security_group" "testacc_security_group" {
+  name = "test"
+  vpc  = ibm_is_vpc.testacc_vpc.id
+}
+
+resource "ibm_is_security_group_rule" "testacc_security_group_rule_all" {
+  group     = ibm_is_security_group.testacc_security_group.id
+  direction = "inbound"
+  remote    = "127.0.0.1"
+}
+
+resource "ibm_is_security_group_rule" "testacc_security_group_rule_icmp" {
+  group     = ibm_is_security_group.testacc_security_group.id
+  direction = "inbound"
+  remote    = "127.0.0.1"
+  icmp {
+    code = 20
+    type = 30
+  }
+}
+
+resource "ibm_is_security_group_rule" "testacc_security_group_rule_udp" {
+  group     = ibm_is_security_group.testacc_security_group.id
+  direction = "inbound"
+  remote    = "127.0.0.1"
+  udp {
+    port_min = 805
+    port_max = 807
+  }
+}
+
+resource "ibm_is_security_group_rule" "testacc_security_group_rule_tcp" {
+  group     = ibm_is_security_group.testacc_security_group.id
+  direction = "egress"
+  remote    = "127.0.0.1"
+  tcp {
+    port_min = 8080
+    port_max = 8080
+  }
+}
+
+data "ibm_is_security_group" "sg1_rule" {
+  name = ibm_is_security_group.testacc_security_group.name
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+`name` - (Required, string) The name of the security group.
+
+## Attribute Reference
+
+The following attributes are exported:
+
+* `id` - The id of the security group. 
+* `rules` - Rules associated with security group. Each rule has follwoing attributes
+  * `rule_id` - ID of the rule.
+  * `direction` - Direction of traffic to enforce, either inbound or outbound.
+  * `ip_version` - IP version: ipv4 or ipv6.
+  * `remote` - Security group id, an IP address, a CIDR block, or a single security group identifier.
+  * `type` - The traffic type to allow.
+  * `code` - The traffic code to allow.
+  * `port_max` - The inclusive upper bound of TCP/UDP port range.
+  * `port_min` - The inclusive lower bound of TCP/UDP port range.
+  * `protocol` - The type of the protocol all, icmp, tcp, udp.
+  
+
+


### PR DESCRIPTION
Test results

Apply complete! Resources: 6 added, 0 changed, 0 destroyed.

Outputs:

sg_rules = [
  {
    "code" = 0
    "direction" = "inbound"
    "ip_version" = "ipv4"
    "port_max" = 0
    "port_min" = 0
    "protocol" = "all"
    "remote" = "127.0.0.1"
    "rule_id" = "r006-ddfd256c-b3e7-4b97-9794-f16590bef872"
    "type" = 0
  },
  {
    "code" = 0
    "direction" = "inbound"
    "ip_version" = "ipv4"
    "port_max" = 807
    "port_min" = 805
    "protocol" = "udp"
    "remote" = "127.0.0.1"
    "rule_id" = "r006-053ba215-813b-4242-8201-f3bf38a7fd0a"
    "type" = 0
  },
  {
    "code" = 0
    "direction" = "inbound"
    "ip_version" = "ipv4"
    "port_max" = 22
    "port_min" = 22
    "protocol" = "tcp"
    "remote" = "0.0.0.0/0"
    "rule_id" = "r006-e540c4a8-37a5-490b-a2b3-4a21c042adb3"
    "type" = 0
  },
  {
    "code" = 0
    "direction" = "inbound"
    "ip_version" = "ipv4"
    "port_max" = 0
    "port_min" = 0
    "protocol" = "icmp"
    "remote" = "127.0.0.9/0"
    "rule_id" = "r006-378c5d6c-f44c-46b9-98fe-49ce4d13ac15"
    "type" = 8
  },
]
