### PR TITLE
Regard all the status other than stopped as stopping

### DIFF
--- a/ibm/resource_ibm_is_instance.go
+++ b/ibm/resource_ibm_is_instance.go
@@ -1997,7 +1997,7 @@ func isWaitForInstanceDelete(instanceC *vpcv1.VpcV1, d *schema.ResourceData, id 
 func isWaitForClassicInstanceActionStop(instanceC *vpcclassicv1.VpcClassicV1, d *schema.ResourceData, meta interface{}, id string) (interface{}, error) {
 
 	stateConf := &resource.StateChangeConf{
-		Pending: []string{isInstanceStatusRunning, isInstanceStatusPending, isInstanceActionStatusStopping},
+		Pending: []string{isInstanceActionStatusStopping},
 		Target:  []string{isInstanceActionStatusStopped, isInstanceStatusFailed, ""},
 		Refresh: func() (interface{}, string, error) {
 			getinsoptions := &vpcclassicv1.GetInstanceOptions{
@@ -2009,8 +2009,10 @@ func isWaitForClassicInstanceActionStop(instanceC *vpcclassicv1.VpcClassicV1, d 
 			}
 			if *instance.Status == isInstanceStatusFailed {
 				return instance, *instance.Status, fmt.Errorf("The  instance %s failed to stop: %v", d.Id(), err)
+			} else if *instance.Status == isInstanceActionStatusStopped {
+				return instance, *instance.Status, nil
 			}
-			return instance, *instance.Status, nil
+			return instance, isInstanceActionStatusStopping, nil
 		},
 		Timeout:    d.Timeout(schema.TimeoutDelete),
 		Delay:      10 * time.Second,
@@ -2022,7 +2024,7 @@ func isWaitForClassicInstanceActionStop(instanceC *vpcclassicv1.VpcClassicV1, d 
 func isWaitForInstanceActionStop(instanceC *vpcv1.VpcV1, d *schema.ResourceData, meta interface{}, id string) (interface{}, error) {
 
 	stateConf := &resource.StateChangeConf{
-		Pending: []string{isInstanceStatusRunning, isInstanceStatusPending, isInstanceActionStatusStopping},
+		Pending: []string{isInstanceActionStatusStopping},
 		Target:  []string{isInstanceActionStatusStopped, isInstanceStatusFailed, ""},
 		Refresh: func() (interface{}, string, error) {
 			getinsoptions := &vpcv1.GetInstanceOptions{
@@ -2034,8 +2036,10 @@ func isWaitForInstanceActionStop(instanceC *vpcv1.VpcV1, d *schema.ResourceData,
 			}
 			if *instance.Status == isInstanceStatusFailed {
 				return instance, *instance.Status, fmt.Errorf("The  instance %s failed to stop: %v", d.Id(), err)
+			} else if *instance.Status == isInstanceActionStatusStopped {
+				return instance, *instance.Status, nil
 			}
-			return instance, *instance.Status, nil
+			return instance, isInstanceActionStatusStopping, nil
 		},
 		Timeout:    d.Timeout(schema.TimeoutDelete),
 		Delay:      10 * time.Second,


### PR DESCRIPTION
`isWaitForInstanceActionStop()` regards only `running`, `pending`, and `stopping` as pending status.  However, RIAS API defines more other status:
```
status*	string
The status of the virtual server instance
Enum:
[ failed, paused, pausing, pending, restarting, resuming, running, starting, stopped, stopping ]
```

Specifically, when trouble occurs during provisioning, an instance can remain in the `starting` status.  When TF tries to destroy such an instance, it will throw an error about the unrecognized status, which would confuse the user:
```
Error: unexpected state 'starting', wanted target 'stopped, failed, '. last error: %!s(<nil>)
```

I think `isWaitForInstanceActionStop()` should regard all the status other than `stopped` (and `failed`) as stopping.