### PR TITLE
Add public gateways and link to subnets to ROKS gen2 example.

### DIFF
--- a/examples/ibm-cluster/roks-on-vpc-gen2/roks_on_vpc/roks_on_vpc.tf
+++ b/examples/ibm-cluster/roks-on-vpc-gen2/roks_on_vpc/roks_on_vpc.tf
@@ -15,6 +15,18 @@ resource "ibm_is_vpc" "vpc1" {
   name = "vpc-${random_id.name1.hex}"
 }
 
+resource "ibm_is_public_gateway" "testacc_gateway1" {
+    name = "public-gateway1"
+    vpc = ibm_is_vpc.vpc1.id
+    zone = local.ZONE1
+}
+
+resource "ibm_is_public_gateway" "testacc_gateway2" {
+    name = "public-gateway2"
+    vpc = ibm_is_vpc.vpc1.id
+    zone = local.ZONE2
+}
+
 resource "ibm_is_security_group_rule" "testacc_security_group_rule_tcp" {
     group = ibm_is_vpc.vpc1.default_security_group
     direction = "inbound"
@@ -29,6 +41,7 @@ resource "ibm_is_subnet" "subnet1" {
   vpc                      = ibm_is_vpc.vpc1.id
   zone                     = local.ZONE1
   total_ipv4_address_count = 256
+  public_gateway = ibm_is_public_gateway.testacc_gateway1.id
 }
 
 resource "ibm_is_subnet" "subnet2" {
@@ -36,6 +49,7 @@ resource "ibm_is_subnet" "subnet2" {
   vpc                      = ibm_is_vpc.vpc1.id
   zone                     = local.ZONE2
   total_ipv4_address_count = 256
+  public_gateway = ibm_is_public_gateway.testacc_gateway2.id
 }
 
 data "ibm_resource_group" "resource_group" {


### PR DESCRIPTION
This enhancement to the ROKS gen2 VPC example adds two public gateways and links to the two subnets, so the OpenShift web console is available immediately after provisioning.