### PR TITLE
Handling Interface nil pointer exception for remote argument

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -556,6 +556,7 @@ github.com/onsi/ginkgo v1.12.1/go.mod h1:zj2OWP4+oCPe1qIXoGWkgMRwljMUYCdkwsT2108
 github.com/onsi/ginkgo v1.12.3/go.mod h1:iSB4RoI2tjJc9BBv4NKIKWKya62Rps+oPG/Lv9klQyY=
 github.com/onsi/ginkgo v1.13.0 h1:M76yO2HkZASFjXL0HSoZJ1AYEmQxNJmY41Jx1zNUq1Y=
 github.com/onsi/ginkgo v1.13.0/go.mod h1:+REjRxOmWfHCjfv9TTWB1jD1Frx4XydAD3zm1lskyM0=
+github.com/onsi/ginkgo v1.14.0/go.mod h1:iSB4RoI2tjJc9BBv4NKIKWKya62Rps+oPG/Lv9klQyY=
 github.com/onsi/gomega v1.7.0/go.mod h1:ex+gbHU/CVuBBDIJjb2X0qEXbFg53c61hWP/1CpauHY=
 github.com/onsi/gomega v1.7.1/go.mod h1:XdKZgCCFLUoM/7CFJVPcG8C1xQ1AJ0vpAezJrB7JYyY=
 github.com/onsi/gomega v1.9.0 h1:R1uwffexN6Pr340GtYRIdZmAiN4J+iw6WG4wog1DUXg=

--- a/ibm/data_source_ibm_is_vpc.go
+++ b/ibm/data_source_ibm_is_vpc.go
@@ -386,9 +386,14 @@ func classicVpcGetByName(d *schema.ResourceData, meta interface{}, name string) 
 									r[isVPCSecurityGroupRuleProtocol] = *rule.Protocol
 								}
 								r[isVPCSecurityGroupRuleID] = *rule.ID
-								//remote:<map[string]interface {} Value>
-								for _, v := range rule.Remote.(map[string]interface{}) {
-									r[isVPCSecurityGroupRuleRemote] = v.(string)
+
+								if rule.Remote != nil && reflect.ValueOf(rule.Remote).IsNil() == false {
+									for k, v := range rule.Remote.(map[string]interface{}) {
+										if k == "id" || k == "address" || k == "cidr_block" {
+											r[isVPCSecurityGroupRuleRemote] = v.(string)
+											break
+										}
+									}
 								}
 
 								rules = append(rules, r)
@@ -405,9 +410,13 @@ func classicVpcGetByName(d *schema.ResourceData, meta interface{}, name string) 
 								}
 								r[isVPCSecurityGroupRuleID] = *rule.ID
 
-								//remote:<map[string]interface {} Value>
-								for _, v := range rule.Remote.(map[string]interface{}) {
-									r[isVPCSecurityGroupRuleRemote] = v.(string)
+								if rule.Remote != nil && reflect.ValueOf(rule.Remote).IsNil() == false {
+									for k, v := range rule.Remote.(map[string]interface{}) {
+										if k == "id" || k == "address" || k == "cidr_block" {
+											r[isVPCSecurityGroupRuleRemote] = v.(string)
+											break
+										}
+									}
 								}
 
 								rules = append(rules, r)
@@ -432,10 +441,15 @@ func classicVpcGetByName(d *schema.ResourceData, meta interface{}, name string) 
 
 								r[isVPCSecurityGroupRuleID] = *rule.ID
 
-								//remote:<map[string]interface {} Value>
-								for _, v := range rule.Remote.(map[string]interface{}) {
-									r[isVPCSecurityGroupRuleRemote] = v.(string)
+								if rule.Remote != nil && reflect.ValueOf(rule.Remote).IsNil() == false {
+									for k, v := range rule.Remote.(map[string]interface{}) {
+										if k == "id" || k == "address" || k == "cidr_block" {
+											r[isVPCSecurityGroupRuleRemote] = v.(string)
+											break
+										}
+									}
 								}
+
 								rules = append(rules, r)
 							}
 						}
@@ -579,9 +593,14 @@ func vpcGetByName(d *schema.ResourceData, meta interface{}, name string) error {
 									r[isVPCSecurityGroupRuleProtocol] = *rule.Protocol
 								}
 								r[isVPCSecurityGroupRuleID] = *rule.ID
-								//remote:<map[string]interface {} Value>
-								for _, v := range rule.Remote.(map[string]interface{}) {
-									r[isVPCSecurityGroupRuleRemote] = v.(string)
+
+								if rule.Remote != nil && reflect.ValueOf(rule.Remote).IsNil() == false {
+									for k, v := range rule.Remote.(map[string]interface{}) {
+										if k == "id" || k == "address" || k == "cidr_block" {
+											r[isVPCSecurityGroupRuleRemote] = v.(string)
+											break
+										}
+									}
 								}
 
 								rules = append(rules, r)
@@ -598,9 +617,13 @@ func vpcGetByName(d *schema.ResourceData, meta interface{}, name string) error {
 								}
 								r[isVPCSecurityGroupRuleID] = *rule.ID
 
-								//remote:<map[string]interface {} Value>
-								for _, v := range rule.Remote.(map[string]interface{}) {
-									r[isVPCSecurityGroupRuleRemote] = v.(string)
+								if rule.Remote != nil && reflect.ValueOf(rule.Remote).IsNil() == false {
+									for k, v := range rule.Remote.(map[string]interface{}) {
+										if k == "id" || k == "address" || k == "cidr_block" {
+											r[isVPCSecurityGroupRuleRemote] = v.(string)
+											break
+										}
+									}
 								}
 
 								rules = append(rules, r)
@@ -625,9 +648,13 @@ func vpcGetByName(d *schema.ResourceData, meta interface{}, name string) error {
 
 								r[isVPCSecurityGroupRuleID] = *rule.ID
 
-								//remote:<map[string]interface {} Value>
-								for _, v := range rule.Remote.(map[string]interface{}) {
-									r[isVPCSecurityGroupRuleRemote] = v.(string)
+								if rule.Remote != nil && reflect.ValueOf(rule.Remote).IsNil() == false {
+									for k, v := range rule.Remote.(map[string]interface{}) {
+										if k == "id" || k == "address" || k == "cidr_block" {
+											r[isVPCSecurityGroupRuleRemote] = v.(string)
+											break
+										}
+									}
 								}
 								rules = append(rules, r)
 							}

--- a/ibm/resource_ibm_is_vpc.go
+++ b/ibm/resource_ibm_is_vpc.go
@@ -654,6 +654,7 @@ func classicVpcGet(d *schema.ResourceData, meta interface{}, id string) error {
 	securityGroupList := make([]map[string]interface{}, 0)
 
 	for _, group := range sgs.SecurityGroups {
+
 		if *group.VPC.ID == d.Id() {
 			g := make(map[string]interface{})
 
@@ -679,9 +680,14 @@ func classicVpcGet(d *schema.ResourceData, meta interface{}, id string) error {
 							r[isVPCSecurityGroupRuleProtocol] = *rule.Protocol
 						}
 						r[isVPCSecurityGroupRuleID] = *rule.ID
-						//remote:<map[string]interface {} Value>
-						for _, v := range rule.Remote.(map[string]interface{}) {
-							r[isVPCSecurityGroupRuleRemote] = v.(string)
+
+						if rule.Remote != nil && reflect.ValueOf(rule.Remote).IsNil() == false {
+							for k, v := range rule.Remote.(map[string]interface{}) {
+								if k == "id" || k == "address" || k == "cidr_block" {
+									r[isVPCSecurityGroupRuleRemote] = v.(string)
+									break
+								}
+							}
 						}
 
 						rules = append(rules, r)
@@ -698,9 +704,13 @@ func classicVpcGet(d *schema.ResourceData, meta interface{}, id string) error {
 						}
 						r[isVPCSecurityGroupRuleID] = *rule.ID
 
-						//remote:<map[string]interface {} Value>
-						for _, v := range rule.Remote.(map[string]interface{}) {
-							r[isVPCSecurityGroupRuleRemote] = v.(string)
+						if rule.Remote != nil && reflect.ValueOf(rule.Remote).IsNil() == false {
+							for k, v := range rule.Remote.(map[string]interface{}) {
+								if k == "id" || k == "address" || k == "cidr_block" {
+									r[isVPCSecurityGroupRuleRemote] = v.(string)
+									break
+								}
+							}
 						}
 
 						rules = append(rules, r)
@@ -725,10 +735,15 @@ func classicVpcGet(d *schema.ResourceData, meta interface{}, id string) error {
 
 						r[isVPCSecurityGroupRuleID] = *rule.ID
 
-						//remote:<map[string]interface {} Value>
-						for _, v := range rule.Remote.(map[string]interface{}) {
-							r[isVPCSecurityGroupRuleRemote] = v.(string)
+						if rule.Remote != nil && reflect.ValueOf(rule.Remote).IsNil() == false {
+							for k, v := range rule.Remote.(map[string]interface{}) {
+								if k == "id" || k == "address" || k == "cidr_block" {
+									r[isVPCSecurityGroupRuleRemote] = v.(string)
+									break
+								}
+							}
 						}
+
 						rules = append(rules, r)
 					}
 				}
@@ -877,9 +892,14 @@ func vpcGet(d *schema.ResourceData, meta interface{}, id string) error {
 							r[isVPCSecurityGroupRuleProtocol] = *rule.Protocol
 						}
 						r[isVPCSecurityGroupRuleID] = *rule.ID
-						//remote:<map[string]interface {} Value>
-						for _, v := range rule.Remote.(map[string]interface{}) {
-							r[isVPCSecurityGroupRuleRemote] = v.(string)
+
+						if rule.Remote != nil && reflect.ValueOf(rule.Remote).IsNil() == false {
+							for k, v := range rule.Remote.(map[string]interface{}) {
+								if k == "id" || k == "address" || k == "cidr_block" {
+									r[isVPCSecurityGroupRuleRemote] = v.(string)
+									break
+								}
+							}
 						}
 
 						rules = append(rules, r)
@@ -896,9 +916,13 @@ func vpcGet(d *schema.ResourceData, meta interface{}, id string) error {
 						}
 						r[isVPCSecurityGroupRuleID] = *rule.ID
 
-						//remote:<map[string]interface {} Value>
-						for _, v := range rule.Remote.(map[string]interface{}) {
-							r[isVPCSecurityGroupRuleRemote] = v.(string)
+						if rule.Remote != nil && reflect.ValueOf(rule.Remote).IsNil() == false {
+							for k, v := range rule.Remote.(map[string]interface{}) {
+								if k == "id" || k == "address" || k == "cidr_block" {
+									r[isVPCSecurityGroupRuleRemote] = v.(string)
+									break
+								}
+							}
 						}
 
 						rules = append(rules, r)
@@ -923,9 +947,13 @@ func vpcGet(d *schema.ResourceData, meta interface{}, id string) error {
 
 						r[isVPCSecurityGroupRuleID] = *rule.ID
 
-						//remote:<map[string]interface {} Value>
-						for _, v := range rule.Remote.(map[string]interface{}) {
-							r[isVPCSecurityGroupRuleRemote] = v.(string)
+						if rule.Remote != nil && reflect.ValueOf(rule.Remote).IsNil() == false {
+							for k, v := range rule.Remote.(map[string]interface{}) {
+								if k == "id" || k == "address" || k == "cidr_block" {
+									r[isVPCSecurityGroupRuleRemote] = v.(string)
+									break
+								}
+							}
 						}
 						rules = append(rules, r)
 					}

--- a/ibm/resource_ibm_is_vpc_test.go
+++ b/ibm/resource_ibm_is_vpc_test.go
@@ -205,8 +205,8 @@ func testAccCheckIBMISVPCSgConfig(vpcname string, sgname string) string {
 		direction  = "inbound"
 		remote     = "127.0.0.1"
 		udp {
-		  port_min = 805
-		  port_max = 807
+			port_min = 805
+			port_max = 807
 		}
 	}  
 `, vpcname, sgname)


### PR DESCRIPTION
In VPC, argument "remote" could be a ip address, CIDR block or security group ID.  It comes as map[string]interface{}. 

Added a check over the remote before looping through the map.  Based on the key ( could be id, address or cidr_block ) populating the remote value.



<img width="1114" alt="Screenshot 2020-07-16 at 5 17 52 PM" src="https://user-images.githubusercontent.com/55839118/87668966-c30c5100-c78a-11ea-8de7-395275cd6d06.png">
<img width="1114" alt="Screenshot 2020-07-16 at 5 17 59 PM" src="https://user-images.githubusercontent.com/55839118/87668974-c7386e80-c78a-11ea-8538-27eaacf32a27.png">
<img width="1114" alt="Screenshot 2020-07-16 at 5 27 26 PM" src="https://user-images.githubusercontent.com/55839118/87668982-cb648c00-c78a-11ea-9db8-239ce9092e9a.png">


