### PR TITLE
set labels on default worker pool

### DIFF
--- a/ibm/resource_ibm_container_vpc_cluster.go
+++ b/ibm/resource_ibm_container_vpc_cluster.go
@@ -142,6 +142,15 @@ func resourceIBMContainerVpcCluster() *schema.Resource {
 				Description: "Number of worker nodes in the cluster",
 			},
 
+			"worker_labels": {
+				Type:             schema.TypeMap,
+				Optional:         true,
+				Computed:         true,
+				DiffSuppressFunc: applyOnce,
+				Elem:             &schema.Schema{Type: schema.TypeString},
+				Description:      "Labels for default worker pool",
+			},
+
 			"disable_public_service_endpoint": {
 				Type:        schema.TypeBool,
 				Optional:    true,
@@ -364,6 +373,14 @@ func resourceIBMContainerVpcClusterCreate(d *schema.ResourceData, meta interface
 		Flavor:      flavor,
 		WorkerCount: workerCount,
 		Zones:       zonesList,
+	}
+
+	if l, ok := d.GetOk("worker_labels"); ok {
+		labels := make(map[string]string)
+		for k, v := range l.(map[string]interface{}) {
+			labels[k] = v.(string)
+		}
+		workerpool.Labels = labels
 	}
 
 	params := v2.ClusterCreateRequest{

--- a/ibm/resource_ibm_container_vpc_cluster.go
+++ b/ibm/resource_ibm_container_vpc_cluster.go
@@ -583,6 +583,7 @@ func resourceIBMContainerVpcClusterRead(d *schema.ResourceData, meta interface{}
 
 	}
 	d.Set("worker_count", workerPool.WorkerCount)
+	d.Set("worker_labels", workerPool.Labels)
 	d.Set("vpc_id", cls.Vpcs[0])
 	d.Set("master_url", cls.MasterURL)
 	d.Set("flavor", workerPool.Flavor)

--- a/website/docs/r/container_vpc_cluster.html.markdown
+++ b/website/docs/r/container_vpc_cluster.html.markdown
@@ -106,6 +106,7 @@ The following arguments are supported:
 * `pod_subnet` - (Optional, Forces new resource,String) Specify a custom subnet CIDR to provide private IP addresses for pods. The subnet must be at least '/23' or larger. For more info, refer [here](https://cloud.ibm.com/docs/containers?topic=containers-cli-plugin-kubernetes-service-cli#pod-subnet).
 * `service_subnet` - (Optional, Forces new resource,String) Specify a custom subnet CIDR to provide private IP addresses for services. The subnet must be at least '/24' or larger. For more info, refer [here](https://cloud.ibm.com/docs/containers?topic=containers-cli-plugin-kubernetes-service-cli#service-subnet).
 * `worker_count` - (Optional, Int) The number of worker nodes per zone in the default worker pool. Default value '1'.
+* `worker_labels` - (Optional, map) Labels on all the workers in the default worker pool.
 * `resource_group_id` - (Optional, Forces new resource, string) The ID of the resource group. You can retrieve the value from data source `ibm_resource_group`. If not provided defaults to default resource group.
 * `tags` - (Optional, array of strings) Tags associated with the container cluster instance.
 * `entitlement` - (Optional, String) The openshift cluster entitlement avoids the OCP licence charges incurred. Use cloud paks with OCP Licence entitlement to create the Openshift cluster.


### PR DESCRIPTION
This allows for setting the default worker labels when using the `ibm_container_vpc_cluster` resource to create a cluster.