### PR TITLE
added wait logic for alb certificate deletion

### DIFF
--- a/website/docs/r/container_alb_cert.html.markdown
+++ b/website/docs/r/container_alb_cert.html.markdown
@@ -29,6 +29,7 @@ ibm_container_alb_cert provides the following [Timeouts](https://www.terraform.i
 
 * `create` - (Default 5 minutes) Used for creating Instance.
 * `update` - (Default 5 minutes) Used for updating Instance.
+* `delete` - (Default 5 minutes) Used for deleting Instance.
 
 ## Argument Reference
 


### PR DESCRIPTION
This PR adds wait logic in alb certificate destroy function for issue [1712](https://github.com/IBM-Cloud/terraform-provider-ibm/issues/1712l)