### PR TITLE
Force delete storage

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.12
 
 require (
 	github.com/Bowery/prompt v0.0.0-20190916142128-fa8279994f75 // indirect
-	github.com/IBM-Cloud/bluemix-go v0.0.0-20200826105524-338a070b12f9
+	github.com/IBM-Cloud/bluemix-go v0.0.0-20200903083903-3b405c2db0da
 	github.com/IBM-Cloud/power-go-client v1.0.46
 	github.com/IBM/apigateway-go-sdk v0.0.0-20200414212859-416e5948678a
 	github.com/IBM/dns-svcs-go-sdk v0.0.3

--- a/go.sum
+++ b/go.sum
@@ -32,6 +32,8 @@ github.com/IBM-Cloud/bluemix-go v0.0.0-20200817085617-1ab9730ce32a h1:oHU39mAaz/
 github.com/IBM-Cloud/bluemix-go v0.0.0-20200817085617-1ab9730ce32a/go.mod h1:gPJbH1etcDj7qS/hBRiLuYW9CY0bRcostSKusa51xR0=
 github.com/IBM-Cloud/bluemix-go v0.0.0-20200826105524-338a070b12f9 h1:XcbBjvwV8iSEqyBOo5sXDi5tGT6f9UJ3cwvryenZJfc=
 github.com/IBM-Cloud/bluemix-go v0.0.0-20200826105524-338a070b12f9/go.mod h1:gPJbH1etcDj7qS/hBRiLuYW9CY0bRcostSKusa51xR0=
+github.com/IBM-Cloud/bluemix-go v0.0.0-20200903083903-3b405c2db0da h1:JhJqeK2fZ0JuRoDI/p/r0t4UXiTUVIvWvMbQFlt/q9w=
+github.com/IBM-Cloud/bluemix-go v0.0.0-20200903083903-3b405c2db0da/go.mod h1:gPJbH1etcDj7qS/hBRiLuYW9CY0bRcostSKusa51xR0=
 github.com/IBM-Cloud/ibm-cloud-cli-sdk v0.6.7/go.mod h1:RiUvKuHKTBmBApDMUQzBL14pQUGKcx/IioKQPIcRQjs=
 github.com/IBM-Cloud/power-go-client v1.0.46 h1:MPtg+gF8JUvitbF9H0kkTgJVrC/QTrY0UroAJbRyRmY=
 github.com/IBM-Cloud/power-go-client v1.0.46/go.mod h1:+mOxjyLeLIloR4EMHTpiDbN+FilZpiVHTwu5eqi+cbI=

--- a/vendor/github.com/IBM-Cloud/bluemix-go/api/container/containerv1/clusters.go
+++ b/vendor/github.com/IBM-Cloud/bluemix-go/api/container/containerv1/clusters.go
@@ -256,7 +256,7 @@ type Clusters interface {
 	Update(name string, params ClusterUpdateParam, target ClusterTargetHeader) error
 	UpdateClusterWorker(clusterNameOrID string, workerID string, params UpdateWorkerCommand, target ClusterTargetHeader) error
 	UpdateClusterWorkers(clusterNameOrID string, workerIDs []string, params UpdateWorkerCommand, target ClusterTargetHeader) error
-	Delete(name string, target ClusterTargetHeader) error
+	Delete(name string, target ClusterTargetHeader, deleteDependencies ...bool) error
 	Find(name string, target ClusterTargetHeader) (ClusterInfo, error)
 	FindWithOutShowResources(name string, target ClusterTargetHeader) (ClusterInfo, error)
 	FindWithOutShowResourcesCompatible(name string, target ClusterTargetHeader) (ClusterInfo, error)
@@ -327,8 +327,13 @@ func (r *clusters) UpdateClusterWorkers(clusterNameOrID string, workerIDs []stri
 }
 
 //Delete ...
-func (r *clusters) Delete(name string, target ClusterTargetHeader) error {
-	rawURL := fmt.Sprintf("/v1/clusters/%s", name)
+func (r *clusters) Delete(name string, target ClusterTargetHeader, deleteDependencies ...bool) error {
+	var rawURL string
+	if len(deleteDependencies) != 0 {
+		rawURL = fmt.Sprintf("/v1/clusters/%s?deleteResources=%t", name, deleteDependencies[0])
+	} else {
+		rawURL = fmt.Sprintf("/v1/clusters/%s", name)
+	}
 	_, err := r.client.Delete(rawURL, target.ToMap())
 	return err
 }

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -6,7 +6,7 @@ cloud.google.com/go/internal/optional
 cloud.google.com/go/internal/trace
 cloud.google.com/go/internal/version
 cloud.google.com/go/storage
-# github.com/IBM-Cloud/bluemix-go v0.0.0-20200826105524-338a070b12f9
+# github.com/IBM-Cloud/bluemix-go v0.0.0-20200903083903-3b405c2db0da
 github.com/IBM-Cloud/bluemix-go
 github.com/IBM-Cloud/bluemix-go/api/account/accountv1
 github.com/IBM-Cloud/bluemix-go/api/account/accountv2

--- a/website/docs/r/container_cluster.html.markdown
+++ b/website/docs/r/container_cluster.html.markdown
@@ -183,6 +183,8 @@ The following arguments are supported:
 	* `instance_id` - The guid of the key protect instance.
 	* `crk_id` - Id of the customer root key (CRK).
 	* `private_endpoint` - Set this to true to configure the KMS private service endpoint. Default is false.
+* `force_delete_storage` - (Optional, bool) If set to true, force the removal of persistent storage associated with the cluster during cluster deletion. Default: false
+    **NOTE**: Before doing terraform destroy if force_delete_storage param is introduced after provisioning the cluster, a terraform apply must be done before terraform destroy for force_delete_storage param to take effect.
 ## Attribute Reference
 
 The following attributes are exported:

--- a/website/docs/r/container_vpc_cluster.html.markdown
+++ b/website/docs/r/container_vpc_cluster.html.markdown
@@ -147,6 +147,8 @@ Resource will wait for only the specified stage and complete execution. The supp
   - *IngressReady*: resource will wait till the ingress-host and ingress-secret are available.
 
   Default value: IngressReady
+* `force_delete_storage` - (Optional, bool) If set to true, force the removal of persistent storage associated with the cluster during cluster deletion. Default: false
+    **NOTE**: Before doing terraform destroy if force_delete_storage param is introduced after provisioning the cluster, a terraform apply must be done before terraform destroy for force_delete_storage param to take effect.
 
 **NOTE**:
 1. For users on account to add tags to a resource, they must be assigned the appropriate access. Learn more about tags permission [here](https://cloud.ibm.com/docs/resources?topic=resources-access)


### PR DESCRIPTION
This PR has fix for : https://github.com/IBM-Cloud/terraform-provider-ibm/issues/1847
An optional param `force_delete_storage`can be specified to remove the storage PVCs associated with cluster, during cluster deletion.