### PR TITLE
Changed kube version to be 4.4 so the kms will work.

### DIFF
--- a/examples/ibm-cluster/roks-on-vpc-gen2/variables.tf
+++ b/examples/ibm-cluster/roks-on-vpc-gen2/variables.tf
@@ -15,7 +15,7 @@ variable "cluster_node_flavor" {
 }
 
 variable "cluster_kube_version" {
-    default = "4.3_openshift"
+    default = "4.4_openshift"
 }
 
 variable "deafult_worker_pool_count"{


### PR DESCRIPTION
The current example for ROKs on VPC gen 2 will correctly create the cluster but will fail when adding kms to the cluster. This due to the fact that the kube version supplied in the variables.tf file, 4.3_openshift which is incompatible with kms. According to IBM cloud documentation the version of Openshift should be 4.4 to support kms. 
The change to kube version would fix it, as I have done here.  However I personally think there should be a different example created that includes kms which is separate from the standard ROKs cluster creation. 