### PR TITLE
fix: IAM access groups test CheckDestroy method

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -230,7 +230,9 @@ Notice that the only information used from the Terraform state is the ID of the 
 
 		// Wait
 
-		if err != nil && !strings.Contains(err.Error(), "404") {
+		if err == nil {
+			return fmt.Errorf("Virtual guest still exists: %s", rs.Primary.ID)
+		else if !strings.Contains(err.Error(), "404") {
 			return fmt.Errorf(
 				"Error waiting for virtual guest (%s) to be destroyed: %s",
 				rs.Primary.ID, err)

--- a/ibm/resource_ibm_iam_access_group_test.go
+++ b/ibm/resource_ibm_iam_access_group_test.go
@@ -94,7 +94,9 @@ func testAccCheckIBMIAMAccessGroupDestroy(s *terraform.State) error {
 		// Try to find the key
 		_, _, err := accClient.AccessGroup().Get(agID)
 
-		if err != nil && !strings.Contains(err.Error(), "404") {
+		if err == nil {
+			return fmt.Errorf("Access group still exists: %s", rs.Primary.ID)
+		} else if !strings.Contains(err.Error(), "404") {
 			return fmt.Errorf("Error waiting for access group (%s) to be destroyed: %s", rs.Primary.ID, err)
 		}
 	}


### PR DESCRIPTION
This PR fixes a minor error in the "CheckDestroy" method of the IAM Access Groups resource test file.

According to the [Terraform docs](https://www.terraform.io/docs/extend/testing/acceptance-tests/testcase.html#checkdestroy), the CheckDestroy method should:
> return an error if any resources remain.

As originally coded, the CheckDestroy method would not return an error if `err == nil`, but a get that returns `err == nil` indicates that the requested resource still exists (and was returned).