### PR TITLE
fix: Update error check in test Destroy methods

### DIFF
--- a/ibm/resource_ibm_app_domain_private_test.go
+++ b/ibm/resource_ibm_app_domain_private_test.go
@@ -106,7 +106,9 @@ func testAccCheckIBMAppDomainPrivateDestroy(s *terraform.State) error {
 		// Try to find the private domain
 		_, err := cfClient.PrivateDomains().Get(privateDomainGUID)
 
-		if err != nil && !strings.Contains(err.Error(), "404") {
+		if err == nil {
+			return fmt.Errorf("CF private domain still exists: %s", rs.Primary.ID)
+		} else if !strings.Contains(err.Error(), "404") {
 			return fmt.Errorf("Error waiting for CF private domain (%s) to be destroyed: %s", rs.Primary.ID, err)
 		}
 	}

--- a/ibm/resource_ibm_app_domain_shared_test.go
+++ b/ibm/resource_ibm_app_domain_shared_test.go
@@ -100,7 +100,9 @@ func testAccCheckIBMAppDomainSharedDestroy(s *terraform.State) error {
 		// Try to find the shared domain
 		_, err := cfClient.SharedDomains().Get(sharedDomainGUID)
 
-		if err != nil && !strings.Contains(err.Error(), "404") {
+		if err == nil {
+			return fmt.Errorf("CF shared domain still exists: %s", rs.Primary.ID)
+		} else if !strings.Contains(err.Error(), "404") {
 			return fmt.Errorf("Error waiting for CF shared domain (%s) to be destroyed: %s", rs.Primary.ID, err)
 		}
 	}

--- a/ibm/resource_ibm_app_route_test.go
+++ b/ibm/resource_ibm_app_route_test.go
@@ -93,7 +93,9 @@ func testAccCheckIBMAppRouteDestroy(s *terraform.State) error {
 		// Try to find the key
 		_, err := cfClient.Routes().Get(routeGuid)
 
-		if err != nil && !strings.Contains(err.Error(), "404") {
+		if err == nil {
+			return fmt.Errorf("CF route still exists: %s", rs.Primary.ID)
+		} else if !strings.Contains(err.Error(), "404") {
 			return fmt.Errorf("Error waiting for CF route (%s) to be destroyed: %s", rs.Primary.ID, err)
 		}
 	}

--- a/ibm/resource_ibm_cis_test.go
+++ b/ibm/resource_ibm_cis_test.go
@@ -120,7 +120,9 @@ func testAccCheckIBMCisInstanceDestroy(s *terraform.State) error {
 
 		_, err := rsContClient.ResourceServiceInstance().GetInstance(instanceID)
 
-		if err != nil && !strings.Contains(err.Error(), "404") {
+		if err == nil {
+			return fmt.Errorf("Instance still exists: %s", rs.Primary.ID)
+		} else if strings.Contains(err.Error(), "404") {
 			return fmt.Errorf("Error checking if instance (%s) has been destroyed: %s", rs.Primary.ID, err)
 		}
 	}

--- a/ibm/resource_ibm_compute_autoscale_group_test.go
+++ b/ibm/resource_ibm_compute_autoscale_group_test.go
@@ -186,7 +186,9 @@ func testAccCheckIBMComputeAutoScaleGroupDestroy(s *terraform.State) error {
 		// Try to find the key
 		_, err := service.Id(scalegroupId).GetObject()
 
-		if err != nil && !strings.Contains(err.Error(), "404") {
+		if err == nil {
+			return fmt.Errorf("Auto Scale still exists: %s", rs.Primary.ID)
+		} else if !strings.Contains(err.Error(), "404") {
 			return fmt.Errorf("Error waiting for Auto Scale (%s) to be destroyed: %s", rs.Primary.ID, err)
 		}
 	}

--- a/ibm/resource_ibm_compute_autoscale_policy_test.go
+++ b/ibm/resource_ibm_compute_autoscale_policy_test.go
@@ -120,7 +120,9 @@ func testAccCheckIBMComputeAutoScalePolicyDestroy(s *terraform.State) error {
 		// Try to find the key
 		_, err := service.Id(scalepolicyId).GetObject()
 
-		if err != nil && !strings.Contains(err.Error(), "404") {
+		if err == nil {
+			return fmt.Errorf("Auto Scale Policy still exists: %s", rs.Primary.ID)
+		} else if !strings.Contains(err.Error(), "404") {
 			return fmt.Errorf("Error waiting for Auto Scale Policy (%s) to be destroyed: %s", rs.Primary.ID, err)
 		}
 	}

--- a/ibm/resource_ibm_compute_dedicated_host_test.go
+++ b/ibm/resource_ibm_compute_dedicated_host_test.go
@@ -192,7 +192,9 @@ func testAccCheckIBMComputerDedicatedHostDestroy(s *terraform.State) error {
 		// Try to find the key
 		_, err := service.Id(dedicatedId).GetObject()
 
-		if err != nil && !strings.Contains(err.Error(), "404") {
+		if err == nil {
+			return fmt.Errorf("Dedicated host still exists: %s", rs.Primary.ID)
+		} else if !strings.Contains(err.Error(), "404") {
 			return fmt.Errorf("Error waiting for dedicated host (%s) to be destroyed: %s", rs.Primary.ID, err)
 		}
 	}

--- a/ibm/resource_ibm_compute_placement_group_test.go
+++ b/ibm/resource_ibm_compute_placement_group_test.go
@@ -145,7 +145,9 @@ func testAccCheckIBMComputePlacementGroupDestroy(s *terraform.State) error {
 		// Try to find the provisioning pgrp
 		_, err := service.Id(pgrpId).GetObject()
 
-		if err != nil && !strings.Contains(err.Error(), "404") {
+		if err == nil {
+			return fmt.Errorf("Placement group still exists: %s", rs.Primary.ID)
+		} else if !strings.Contains(err.Error(), "404") {
 			return fmt.Errorf("Error waiting for placement group (%s) to be destroyed: %s", rs.Primary.ID, err)
 		}
 	}

--- a/ibm/resource_ibm_container_addons_test.go
+++ b/ibm/resource_ibm_container_addons_test.go
@@ -57,7 +57,9 @@ func testAccCheckIBMContainerAddOnsDestroy(s *terraform.State) error {
 		cluster := rs.Primary.ID
 		addOnAPI := csClient.AddOns()
 		_, err = addOnAPI.GetAddons(cluster, targetEnv)
-		if err != nil && !strings.Contains(err.Error(), "404") {
+		if err == nil {
+			return fmt.Errorf("AddOns still exists: %s", rs.Primary.ID)
+		} else if !strings.Contains(err.Error(), "404") {
 			return fmt.Errorf("Error checking if AddOns (%s) has been destroyed: %s", rs.Primary.ID, err)
 		}
 	}

--- a/ibm/resource_ibm_container_alb_cert_test.go
+++ b/ibm/resource_ibm_container_alb_cert_test.go
@@ -65,7 +65,9 @@ func testAccCheckIBMContainerALBCertDestroy(s *terraform.State) error {
 		albAPI := csClient.Albs()
 		_, err = albAPI.GetClusterALBCertBySecretName(clusterID, secretName, targetEnv)
 
-		if err != nil && !strings.Contains(err.Error(), "404") {
+		if err == nil {
+			return fmt.Errorf("Instance still exists: %s", rs.Primary.ID)
+		} else if !strings.Contains(err.Error(), "404") {
 			return fmt.Errorf("Error checking if instance (%s) has been destroyed: %s", rs.Primary.ID, err)
 		}
 	}

--- a/ibm/resource_ibm_container_alb_test.go
+++ b/ibm/resource_ibm_container_alb_test.go
@@ -55,7 +55,9 @@ func testAccCheckIBMContainerALBDestroy(s *terraform.State) error {
 		albAPI := csClient.Albs()
 		_, err = albAPI.GetALB(albID, targetEnv)
 
-		if err != nil && !strings.Contains(err.Error(), "404") {
+		if err == nil {
+			return fmt.Errorf("Instance still exists: %s", rs.Primary.ID)
+		} else if !strings.Contains(err.Error(), "404") {
 			return fmt.Errorf("Error checking if instance (%s) has been destroyed: %s", rs.Primary.ID, err)
 		}
 	}

--- a/ibm/resource_ibm_container_cluster_test.go
+++ b/ibm/resource_ibm_container_cluster_test.go
@@ -337,7 +337,9 @@ func testAccCheckIBMContainerClusterDestroy(s *terraform.State) error {
 		// Try to find the key
 		_, err := csClient.Clusters().Find(rs.Primary.ID, targetEnv)
 
-		if err != nil && !strings.Contains(err.Error(), "404") {
+		if err == nil {
+			return fmt.Errorf("Cluster still exists: %s", rs.Primary.ID)
+		} else if !strings.Contains(err.Error(), "404") {
 			return fmt.Errorf("Error waiting for cluster (%s) to be destroyed: %s", rs.Primary.ID, err)
 		}
 	}

--- a/ibm/resource_ibm_container_vpc_alb_test.go
+++ b/ibm/resource_ibm_container_vpc_alb_test.go
@@ -56,7 +56,9 @@ func testAccCheckIBMVpcContainerALBDestroy(s *terraform.State) error {
 		albAPI := csClient.Albs()
 		_, err = albAPI.GetAlb(albID, targetEnv)
 
-		if err != nil && !strings.Contains(err.Error(), "404") {
+		if err == nil {
+			return fmt.Errorf("Instance still exists: %s", rs.Primary.ID)
+		} else if !strings.Contains(err.Error(), "404") {
 			return fmt.Errorf("Error checking if instance (%s) has been destroyed: %s", rs.Primary.ID, err)
 		}
 	}

--- a/ibm/resource_ibm_container_vpc_cluster_test.go
+++ b/ibm/resource_ibm_container_vpc_cluster_test.go
@@ -167,7 +167,9 @@ func testAccCheckIBMContainerVpcClusterDestroy(s *terraform.State) error {
 		// Try to find the key
 		_, err := csClient.Clusters().GetCluster(rs.Primary.ID, targetEnv)
 
-		if err != nil && !strings.Contains(err.Error(), "404") {
+		if err == nil {
+			return fmt.Errorf("Cluster still exists: %s", rs.Primary.ID)
+		} else if !strings.Contains(err.Error(), "404") {
 			return fmt.Errorf("Error waiting for cluster (%s) to be destroyed: %s", rs.Primary.ID, err)
 		}
 	}

--- a/ibm/resource_ibm_container_vpc_worker_pool_test.go
+++ b/ibm/resource_ibm_container_vpc_worker_pool_test.go
@@ -92,7 +92,9 @@ func testAccCheckIBMVpcContainerWorkerPoolDestroy(s *terraform.State) error {
 		// Try to find the key
 		_, err = wpClient.WorkerPools().GetWorkerPool(cluster, workerPoolID, target)
 
-		if err != nil && !strings.Contains(err.Error(), "404") {
+		if err == nil {
+			return fmt.Errorf("Worker pool still exists: %s", rs.Primary.ID)
+		} else if !strings.Contains(err.Error(), "404") {
 			return fmt.Errorf("Error waiting for worker pool (%s) to be destroyed: %s", rs.Primary.ID, err)
 		}
 	}

--- a/ibm/resource_ibm_container_worker_pool_test.go
+++ b/ibm/resource_ibm_container_worker_pool_test.go
@@ -124,7 +124,9 @@ func testAccCheckIBMContainerWorkerPoolDestroy(s *terraform.State) error {
 		// Try to find the key
 		_, err = csClient.WorkerPools().GetWorkerPool(cluster, workerPoolID, target)
 
-		if err != nil && !strings.Contains(err.Error(), "404") {
+		if err == nil {
+			return fmt.Errorf("Worker pool still exists: %s", rs.Primary.ID)
+		} else if !strings.Contains(err.Error(), "404") {
 			return fmt.Errorf("Error waiting for worker pool (%s) to be destroyed: %s", rs.Primary.ID, err)
 		}
 	}

--- a/ibm/resource_ibm_database_postgresql_test.go
+++ b/ibm/resource_ibm_database_postgresql_test.go
@@ -146,7 +146,9 @@ func testAccCheckIBMDatabaseInstanceDestroy(s *terraform.State) error {
 
 		_, err := rsContClient.ResourceServiceInstance().GetInstance(instanceID)
 
-		if err != nil && !strings.Contains(err.Error(), "404") {
+		if err == nil {
+			return fmt.Errorf("Instance still exists: %s", rs.Primary.ID)
+		} else if !strings.Contains(err.Error(), "404") {
 			return fmt.Errorf("Error checking if instance (%s) has been destroyed: %s", rs.Primary.ID, err)
 		}
 	}

--- a/ibm/resource_ibm_event_streams_topic_test.go
+++ b/ibm/resource_ibm_event_streams_topic_test.go
@@ -305,7 +305,9 @@ func testAccCheckIBMEventStreamsInstanceDestroy(s *terraform.State) error {
 		instanceID := rs.Primary.ID
 		_, err := rsContClient.ResourceServiceInstance().GetInstance(instanceID)
 
-		if err != nil && !strings.Contains(err.Error(), "404") {
+		if err == nil {
+			return fmt.Errorf("Instance still exists: %s", rs.Primary.ID)
+		} else if !strings.Contains(err.Error(), "404") {
 			return fmt.Errorf("Error checking if instance (%s) has been destroyed: %s", rs.Primary.ID, err)
 		}
 	}

--- a/ibm/resource_ibm_iam_access_group_dynamic_rule_test.go
+++ b/ibm/resource_ibm_iam_access_group_dynamic_rule_test.go
@@ -86,7 +86,9 @@ func testAccCheckIBMIAMDynamicRuleDestroy(s *terraform.State) error {
 		// Try to find the key
 		_, _, err = accClient.DynamicRule().Get(grpID, ruleID)
 
-		if err != nil && !strings.Contains(err.Error(), "404") {
+		if err == nil {
+			return fmt.Errorf("Dynamic rule still exists: %s", rs.Primary.ID)
+		} else if !strings.Contains(err.Error(), "404") {
 			return fmt.Errorf("Error waiting for Dynamic rule (%s) to be destroyed: %s", ruleID, err)
 		}
 	}

--- a/ibm/resource_ibm_iam_custom_role_test.go
+++ b/ibm/resource_ibm_iam_custom_role_test.go
@@ -95,7 +95,9 @@ func testAccCheckIBMIAMCustomRoleDestroy(s *terraform.State) error {
 		// Try to find the role
 		_, _, err := accClient.IAMRoles().Get(roleID)
 
-		if err != nil && !strings.Contains(err.Error(), "404") {
+		if err == nil {
+			return fmt.Errorf("Custom Role still exists: %s", rs.Primary.ID)
+		} else if !strings.Contains(err.Error(), "404") {
 			return fmt.Errorf("Error waiting for Custom Role (%s) to be destroyed: %s", roleID, err)
 		}
 	}

--- a/ibm/resource_ibm_iam_service_id_test.go
+++ b/ibm/resource_ibm_iam_service_id_test.go
@@ -94,7 +94,9 @@ func testAccCheckIBMIAMServiceIDDestroy(s *terraform.State) error {
 		// Try to find the key
 		_, err := rsContClient.ServiceIds().Get(serviceIDUUID)
 
-		if err != nil && !strings.Contains(err.Error(), "404") {
+		if err == nil {
+			return fmt.Errorf("ServiceID still exists: %s", rs.Primary.ID)
+		} else if !strings.Contains(err.Error(), "404") {
 			return fmt.Errorf("Error waiting for serviceID (%s) to be destroyed: %s", rs.Primary.ID, err)
 		}
 	}

--- a/ibm/resource_ibm_iam_user_policy_test.go
+++ b/ibm/resource_ibm_iam_user_policy_test.go
@@ -232,7 +232,9 @@ func testAccCheckIBMIAMUserPolicyDestroy(s *terraform.State) error {
 		// Try to find the key
 		_, err = rsContClient.V1Policy().Get(userPolicyID)
 
-		if err != nil && !strings.Contains(err.Error(), "404") {
+		if err == nil {
+			return fmt.Errorf("User policy still exists: %s", rs.Primary.ID)
+		} else if !strings.Contains(err.Error(), "404") {
 			return fmt.Errorf("Error waiting for user policy (%s) to be destroyed: %s", rs.Primary.ID, err)
 		}
 	}

--- a/ibm/resource_ibm_resource_group_test.go
+++ b/ibm/resource_ibm_resource_group_test.go
@@ -118,7 +118,9 @@ func testAccCheckIBMResourceGroupDestroy(s *terraform.State) error {
 		// Try to find the key
 		_, err := rsContClient.ResourceGroup().Get(resourceGroupID)
 
-		if err != nil && !strings.Contains(err.Error(), "404") {
+		if err == nil {
+			return fmt.Errorf("Resource group still exists: %s", rs.Primary.ID)
+		} else if !strings.Contains(err.Error(), "404") {
 			return fmt.Errorf("Error waiting for resource group (%s) to be destroyed: %s", rs.Primary.ID, err)
 		}
 	}

--- a/ibm/resource_ibm_resource_instance_test.go
+++ b/ibm/resource_ibm_resource_instance_test.go
@@ -158,7 +158,9 @@ func testAccCheckIBMResourceInstanceDestroy(s *terraform.State) error {
 		// Try to find the key
 		_, err := rsContClient.ResourceServiceInstance().GetInstance(instanceID)
 
-		if err != nil && !strings.Contains(err.Error(), "404") {
+		if err == nil {
+			return fmt.Errorf("Resource instance still exists: %s", rs.Primary.ID)
+		} else if !strings.Contains(err.Error(), "404") {
 			return fmt.Errorf("Error waiting for resource instance (%s) to be destroyed: %s", rs.Primary.ID, err)
 		}
 	}

--- a/ibm/resource_ibm_resource_key_test.go
+++ b/ibm/resource_ibm_resource_key_test.go
@@ -161,7 +161,9 @@ func testAccCheckIBMResourceKeyDestroy(s *terraform.State) error {
 		// Try to find the key
 		_, err := rsContClient.ResourceServiceKey().GetKey(resourceKeyID)
 
-		if err != nil && !strings.Contains(err.Error(), "404") {
+		if err == nil {
+			return fmt.Errorf("Resource key still exists: %s", rs.Primary.ID)
+		} else if !strings.Contains(err.Error(), "404") {
 			return fmt.Errorf("Error waiting for resource key (%s) to be destroyed: %s", rs.Primary.ID, err)
 		}
 	}

--- a/ibm/resource_ibm_service_instance_test.go
+++ b/ibm/resource_ibm_service_instance_test.go
@@ -111,7 +111,9 @@ func testAccCheckIBMServiceInstanceDestroy(s *terraform.State) error {
 		// Try to find the key
 		_, err := cfClient.ServiceInstances().Get(serviceGuid)
 
-		if err != nil && !strings.Contains(err.Error(), "404") {
+		if err == nil {
+			return fmt.Errorf("CF service still exists: %s", rs.Primary.ID)
+		} else if !strings.Contains(err.Error(), "404") {
 			return fmt.Errorf("Error waiting for CF service (%s) to be destroyed: %s", rs.Primary.ID, err)
 		}
 	}

--- a/ibm/resource_ibm_service_key_test.go
+++ b/ibm/resource_ibm_service_key_test.go
@@ -127,7 +127,9 @@ func testAccCheckIBMServiceKeyDestroy(s *terraform.State) error {
 		// Try to find the key
 		_, err := cfClient.ServiceKeys().Get(serviceKeyGuid)
 
-		if err != nil && !strings.Contains(err.Error(), "404") {
+		if err == nil {
+			return fmt.Errorf("CF service key still exists: %s", rs.Primary.ID)
+		} else if !strings.Contains(err.Error(), "404") {
 			return fmt.Errorf("Error waiting for CF service key (%s) to be destroyed: %s", rs.Primary.ID, err)
 		}
 	}


### PR DESCRIPTION
This PR fixes the `Destroy` method in a number of the test files to follow the updated pattern for error checking introduced in PR #1988