### PR TITLE
add provision parameter kms_key_crn for Event Streams

### DIFF
--- a/examples/ibm-event-streams/main.tf
+++ b/examples/ibm-event-streams/main.tf
@@ -18,6 +18,7 @@ resource "ibm_resource_instance" "es_instance_1" {
 
   #   throughput   = "150"  # for enterprise instance only. Options are: "150", "300", "450". Default is "150" when not specified.
   #   storage_size = "2048" # for enterprise instance only. Options are: "2048", "4096", "6144", "8192", "10240", "12288". Default is "2048" when not specified.
+  #   kms_key_crn  = "crn:v1:bluemix:public:kms:us-south:a/6db1b0d0b5c54ee5c201552547febcd8:0aa69b09-941b-41b2-bbf9-9f9f0f6a6f79:key:dd37a0b6-eff4-4708-8459-e29ae0a8f256" # for enterprise instance only. Specify the CRN of a root key from a Key Management Service instance used to encrypt disks.
   #   # Note: when throughput is "300", storage_size starts from "4096",  when throughput is "450", storage_size starts from "6144"
   #   # document about supported combinations of throughput and storage_size: https://cloud.ibm.com/docs/EventStreams?topic=EventStreams-ES_scaling_capacity#ES_scaling_combinations
   # }

--- a/ibm/resource_ibm_event_streams_topic_test.go
+++ b/ibm/resource_ibm_event_streams_topic_test.go
@@ -153,6 +153,7 @@ func TestAccIBMEventStreamsEnterprise(t *testing.T) {
 		"private_ip_allowlist": "[9.0.0.0/8]", // allowing jenkins access
 		"throughput":           "150",
 		"storage_size":         "2048",
+		"kms_key_crn":          "crn:v1:staging:public:kms:us-south:a/6db1b0d0b5c54ee5c201552547febcd8:0aa69b09-941b-41b2-bbf9-9f9f0f6a6f79:key:dd37a0b6-eff4-4708-8459-e29ae0a8f256", //preprod-byok-customer-key from KMS instance keyprotect-preprod-customer-keys
 	}
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -246,6 +247,7 @@ func createPlatformResources(instanceName, serviceName, planID, location string,
 		  private_ip_allowlist = "%s"
 		  throughput           = "%s"
 		  storage_size         = "%s"
+		  kms_key_crn          = "%s"
 		}
 		timeouts {
 		  create = "3h"
@@ -253,7 +255,7 @@ func createPlatformResources(instanceName, serviceName, planID, location string,
 		  delete = "15m"
 		}
 	  }`, instanceName, serviceName, planID, location,
-		parameters["service-endpoints"], parameters["private_ip_allowlist"], parameters["throughput"], parameters["storage_size"])
+		parameters["service-endpoints"], parameters["private_ip_allowlist"], parameters["throughput"], parameters["storage_size"], parameters["kms_key_crn"])
 }
 
 func createEventStreamsTopicResourceWithoutConfig(createInstance bool, topicName string, partitions int) string {

--- a/website/docs/r/event_streams_topic.html.markdown
+++ b/website/docs/r/event_streams_topic.html.markdown
@@ -26,6 +26,7 @@ resource "ibm_resource_instance" "es_instance_1" {
 
   #   throughput   = "150"  # for enterprise instance only. Options are: "150", "300", "450". Default is "150" when not specified.
   #   storage_size = "2048" # for enterprise instance only. Options are: "2048", "4096", "6144", "8192", "10240", "12288". Default is "2048" when not specified.
+  #   kms_key_crn  = "crn:v1:bluemix:public:kms:us-south:a/6db1b0d0b5c54ee5c201552547febcd8:0aa69b09-941b-41b2-bbf9-9f9f0f6a6f79:key:dd37a0b6-eff4-4708-8459-e29ae0a8f256" # for enterprise instance only. Specify the CRN of a root key from a Key Management Service instance used to encrypt disks.
   #   # Note: when throughput is "300", storage_size starts from "4096",  when throughput is "450", storage_size starts from "6144"
   #   # document about supported combinations of throughput and storage_size: https://cloud.ibm.com/docs/EventStreams?topic=EventStreams-ES_scaling_capacity#ES_scaling_combinations
   # }


### PR DESCRIPTION
document and test update for new provision parameter `kms_key_crn` in Event Streams

contribute to: https://github.ibm.com/mhub/zh/issues/1677