### PR TITLE
refactor: add method to get default resource group

### DIFF
--- a/ibm/data_source_ibm_cis.go
+++ b/ibm/data_source_ibm_cis.go
@@ -7,7 +7,6 @@ import (
 	"github.com/IBM-Cloud/bluemix-go/models"
 
 	"github.com/IBM-Cloud/bluemix-go/api/resource/resourcev1/controller"
-	"github.com/IBM-Cloud/bluemix-go/api/resource/resourcev2/managementv2"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 )
@@ -105,18 +104,11 @@ func dataSourceIBMCISInstanceRead(d *schema.ResourceData, meta interface{}) erro
 	if rsGrpID, ok := d.GetOk("resource_group_id"); ok {
 		rsInstQuery.ResourceGroupID = rsGrpID.(string)
 	} else {
-		rsMangClient, err := meta.(ClientSession).ResourceManagementAPIv2()
+		defaultRg, err := defaultResourceGroup(meta)
 		if err != nil {
 			return err
 		}
-		resourceGroupQuery := managementv2.ResourceGroupQuery{
-			Default: true,
-		}
-		grpList, err := rsMangClient.ResourceGroup().List(&resourceGroupQuery)
-		if err != nil {
-			return err
-		}
-		rsInstQuery.ResourceGroupID = grpList[0].ID
+		rsInstQuery.ResourceGroupID = defaultRg
 	}
 
 	rsCatClient, err := meta.(ClientSession).ResourceCatalogAPI()

--- a/ibm/data_source_ibm_database.go
+++ b/ibm/data_source_ibm_database.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/IBM-Cloud/bluemix-go/api/icd/icdv4"
 	"github.com/IBM-Cloud/bluemix-go/api/resource/resourcev1/controller"
-	"github.com/IBM-Cloud/bluemix-go/api/resource/resourcev2/managementv2"
 	"github.com/IBM-Cloud/bluemix-go/bmxerror"
 	"github.com/IBM-Cloud/bluemix-go/models"
 )
@@ -567,18 +566,11 @@ func dataSourceIBMDatabaseInstanceRead(d *schema.ResourceData, meta interface{})
 	if rsGrpID, ok := d.GetOk("resource_group_id"); ok {
 		rsInstQuery.ResourceGroupID = rsGrpID.(string)
 	} else {
-		rsMangClient, err := meta.(ClientSession).ResourceManagementAPIv2()
+		defaultRg, err := defaultResourceGroup(meta)
 		if err != nil {
 			return err
 		}
-		resourceGroupQuery := managementv2.ResourceGroupQuery{
-			Default: true,
-		}
-		grpList, err := rsMangClient.ResourceGroup().List(&resourceGroupQuery)
-		if err != nil {
-			return err
-		}
-		rsInstQuery.ResourceGroupID = grpList[0].ID
+		rsInstQuery.ResourceGroupID = defaultRg
 	}
 
 	rsCatClient, err := meta.(ClientSession).ResourceCatalogAPI()

--- a/ibm/data_source_ibm_resource_instance.go
+++ b/ibm/data_source_ibm_resource_instance.go
@@ -6,7 +6,6 @@ import (
 	"github.com/IBM-Cloud/bluemix-go/models"
 
 	"github.com/IBM-Cloud/bluemix-go/api/resource/resourcev1/controller"
-	"github.com/IBM-Cloud/bluemix-go/api/resource/resourcev2/managementv2"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 )
@@ -120,21 +119,11 @@ func dataSourceIBMResourceInstanceRead(d *schema.ResourceData, meta interface{})
 	if rsGrpID, ok := d.GetOk("resource_group_id"); ok {
 		rsInstQuery.ResourceGroupID = rsGrpID.(string)
 	} else {
-		rsMangClient, err := meta.(ClientSession).ResourceManagementAPIv2()
+		defaultRg, err := defaultResourceGroup(meta)
 		if err != nil {
 			return err
 		}
-		resourceGroupQuery := managementv2.ResourceGroupQuery{
-			Default: true,
-		}
-		grpList, err := rsMangClient.ResourceGroup().List(&resourceGroupQuery)
-		if err != nil {
-			return err
-		}
-		if len(grpList) <= 0 {
-			return fmt.Errorf("The targeted resource group could not be found. Make sure you have required permissions to access the resource group.")
-		}
-		rsInstQuery.ResourceGroupID = grpList[0].ID
+		rsInstQuery.ResourceGroupID = defaultRg
 	}
 
 	rsCatClient, err := meta.(ClientSession).ResourceCatalogAPI()

--- a/ibm/resource_ibm_cis.go
+++ b/ibm/resource_ibm_cis.go
@@ -8,7 +8,6 @@ import (
 	"time"
 
 	"github.com/IBM-Cloud/bluemix-go/api/resource/resourcev1/controller"
-	"github.com/IBM-Cloud/bluemix-go/api/resource/resourcev2/managementv2"
 	"github.com/IBM-Cloud/bluemix-go/models"
 
 	"github.com/IBM-Cloud/bluemix-go/bmxerror"
@@ -186,18 +185,11 @@ func resourceIBMCISInstanceCreate(d *schema.ResourceData, meta interface{}) erro
 	if rsGrpID, ok := d.GetOk("resource_group_id"); ok {
 		rsInst.ResourceGroupID = rsGrpID.(string)
 	} else {
-		rsMangClient, err := meta.(ClientSession).ResourceManagementAPIv2()
+		defaultRg, err := defaultResourceGroup(meta)
 		if err != nil {
 			return err
 		}
-		resourceGroupQuery := managementv2.ResourceGroupQuery{
-			Default: true,
-		}
-		grpList, err := rsMangClient.ResourceGroup().List(&resourceGroupQuery)
-		if err != nil {
-			return err
-		}
-		rsInst.ResourceGroupID = grpList[0].ID
+		rsInst.ResourceGroupID = defaultRg
 	}
 
 	if parameters, ok := d.GetOk("parameters"); ok {

--- a/ibm/resource_ibm_container_worker_pool.go
+++ b/ibm/resource_ibm_container_worker_pool.go
@@ -6,7 +6,6 @@ import (
 	"time"
 
 	v1 "github.com/IBM-Cloud/bluemix-go/api/container/containerv1"
-	"github.com/IBM-Cloud/bluemix-go/api/resource/resourcev2/managementv2"
 	"github.com/IBM-Cloud/bluemix-go/bmxerror"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
@@ -447,21 +446,11 @@ func getWorkerPoolTargetHeader(d *schema.ResourceData, meta interface{}) (v1.Clu
 		resourceGroup = sess.Config.ResourceGroup
 
 		if resourceGroup == "" {
-			rsMangClient, err := meta.(ClientSession).ResourceManagementAPIv2()
+			defaultRg, err := defaultResourceGroup(meta)
 			if err != nil {
 				return v1.ClusterTargetHeader{}, err
 			}
-			resourceGroupQuery := managementv2.ResourceGroupQuery{
-				Default: true,
-			}
-			grpList, err := rsMangClient.ResourceGroup().List(&resourceGroupQuery)
-			if err != nil {
-				return v1.ClusterTargetHeader{}, err
-			}
-			if len(grpList) <= 0 {
-				return v1.ClusterTargetHeader{}, fmt.Errorf("The targeted resource group could not be found. Make sure you have required permissions to access the resource group.")
-			}
-			resourceGroup = grpList[0].ID
+			resourceGroup = defaultRg
 		}
 	}
 

--- a/ibm/resource_ibm_database.go
+++ b/ibm/resource_ibm_database.go
@@ -17,7 +17,6 @@ import (
 	//	"github.com/IBM-Cloud/bluemix-go/api/globaltagging/globaltaggingv3"
 	"github.com/IBM-Cloud/bluemix-go/api/icd/icdv4"
 	"github.com/IBM-Cloud/bluemix-go/api/resource/resourcev1/controller"
-	"github.com/IBM-Cloud/bluemix-go/api/resource/resourcev2/managementv2"
 	"github.com/IBM-Cloud/bluemix-go/bmxerror"
 	"github.com/IBM-Cloud/bluemix-go/models"
 )
@@ -729,18 +728,11 @@ func resourceIBMDatabaseInstanceCreate(d *schema.ResourceData, meta interface{})
 	if rsGrpID, ok := d.GetOk("resource_group_id"); ok {
 		rsInst.ResourceGroupID = rsGrpID.(string)
 	} else {
-		rsMangClient, err := meta.(ClientSession).ResourceManagementAPIv2()
+		defaultRg, err := defaultResourceGroup(meta)
 		if err != nil {
 			return err
 		}
-		resourceGroupQuery := managementv2.ResourceGroupQuery{
-			Default: true,
-		}
-		grpList, err := rsMangClient.ResourceGroup().List(&resourceGroupQuery)
-		if err != nil {
-			return err
-		}
-		rsInst.ResourceGroupID = grpList[0].ID
+		rsInst.ResourceGroupID = defaultRg
 	}
 
 	params := Params{}

--- a/ibm/resource_ibm_resource_instance.go
+++ b/ibm/resource_ibm_resource_instance.go
@@ -9,7 +9,6 @@ import (
 	"time"
 
 	"github.com/IBM-Cloud/bluemix-go/api/resource/resourcev1/controller"
-	"github.com/IBM-Cloud/bluemix-go/api/resource/resourcev2/managementv2"
 	"github.com/IBM-Cloud/bluemix-go/bmxerror"
 	"github.com/IBM-Cloud/bluemix-go/models"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/customdiff"
@@ -226,21 +225,11 @@ func resourceIBMResourceInstanceCreate(d *schema.ResourceData, meta interface{})
 	if rsGrpID, ok := d.GetOk("resource_group_id"); ok {
 		rsInst.ResourceGroupID = rsGrpID.(string)
 	} else {
-		rsMangClient, err := meta.(ClientSession).ResourceManagementAPIv2()
+		defaultRg, err := defaultResourceGroup(meta)
 		if err != nil {
 			return err
 		}
-		resourceGroupQuery := managementv2.ResourceGroupQuery{
-			Default: true,
-		}
-		grpList, err := rsMangClient.ResourceGroup().List(&resourceGroupQuery)
-		if err != nil {
-			return err
-		}
-		if len(grpList) <= 0 {
-			return fmt.Errorf("The targeted resource group could not be found. Make sure you have required permissions to access the resource group.")
-		}
-		rsInst.ResourceGroupID = grpList[0].ID
+		rsInst.ResourceGroupID = defaultRg
 	}
 	params := map[string]interface{}{}
 

--- a/ibm/structures.go
+++ b/ibm/structures.go
@@ -19,6 +19,7 @@ import (
 	"github.com/IBM-Cloud/bluemix-go/api/iamuum/iamuumv2"
 	"github.com/IBM-Cloud/bluemix-go/api/icd/icdv4"
 	"github.com/IBM-Cloud/bluemix-go/api/mccp/mccpv2"
+	"github.com/IBM-Cloud/bluemix-go/api/resource/resourcev2/managementv2"
 	"github.com/IBM-Cloud/bluemix-go/api/schematics"
 	"github.com/IBM-Cloud/bluemix-go/api/usermanagement/usermanagementv2"
 	"github.com/IBM-Cloud/bluemix-go/models"
@@ -1725,4 +1726,23 @@ func GetNext(next interface{}) string {
 
 	q := u.Query()
 	return q.Get("start")
+}
+
+/* Return the default resource group */
+func defaultResourceGroup(meta interface{}) (string, error) {
+	rsMangClient, err := meta.(ClientSession).ResourceManagementAPIv2()
+	if err != nil {
+		return "", err
+	}
+	resourceGroupQuery := managementv2.ResourceGroupQuery{
+		Default: true,
+	}
+	grpList, err := rsMangClient.ResourceGroup().List(&resourceGroupQuery)
+	if err != nil {
+		return "", err
+	}
+	if len(grpList) <= 0 {
+		return "", fmt.Errorf("The targeted resource group could not be found. Make sure you have required permissions to access the resource group.")
+	}
+	return grpList[0].ID, nil
 }


### PR DESCRIPTION
The PR creates a helper method to get the default resource group and employs this method in several data source and resources that previously replicated this code.