### PR TITLE
Key policies for ibm_kms_key resource

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,8 +11,8 @@ require (
 	github.com/IBM/go-sdk-core/v3 v3.3.1
 	github.com/IBM/ibm-cos-sdk-go v1.3.1
 	github.com/IBM/ibm-cos-sdk-go-config v1.0.1
-	github.com/IBM/keyprotect-go-client v0.3.5-0.20200325142150-b63163832e26
 	github.com/IBM/networking-go-sdk v0.12.0
+	github.com/IBM/keyprotect-go-client v0.5.2
 	github.com/IBM/vpc-go-sdk v0.2.0
 	github.com/ScaleFT/sshkeys v0.0.0-20200327173127-6142f742bca5
 	github.com/Shopify/sarama v1.26.4

--- a/go.sum
+++ b/go.sum
@@ -49,10 +49,10 @@ github.com/IBM/ibm-cos-sdk-go v1.3.1 h1:6SHueqFpznp7S/9b39/WiJ9mt3TgD322j2pArzyd
 github.com/IBM/ibm-cos-sdk-go v1.3.1/go.mod h1:YLBAYobEA8bD27P7xpMwSQeNQu6W3DNBtBComXrRzRY=
 github.com/IBM/ibm-cos-sdk-go-config v1.0.1 h1:Nld42UysaZ16hPl4XMnkCgbuwW+s4OVctqEf2QbE5ec=
 github.com/IBM/ibm-cos-sdk-go-config v1.0.1/go.mod h1:BAbdv1Zf8mRP6rj40Cem7KgBp+UQn9Fe2EWxIBrp5sM=
-github.com/IBM/keyprotect-go-client v0.3.5-0.20200325142150-b63163832e26 h1:ktAExgvUrXaXvHjsnUtQqRhoqi5fyQjLXQIlD3YH60o=
-github.com/IBM/keyprotect-go-client v0.3.5-0.20200325142150-b63163832e26/go.mod h1:5TwDM/4FRJq1ZOlwQL1xFahLWQ3TveR88VmL1u3njyI=
 github.com/IBM/networking-go-sdk v0.12.0 h1:9vJRCGF7RXgAbkSvK1sGvdshraYuGffxWoDqhVZ079o=
 github.com/IBM/networking-go-sdk v0.12.0/go.mod h1:WB/PjK7LA6VuIOsGjv1gm6WS/Ki6nF8KmycwMU0bgIs=
+github.com/IBM/keyprotect-go-client v0.5.2 h1:A4yp2Fc7mg4dtotZErZXwJb9XKpb3ONexnVB+/JqLDM=
+github.com/IBM/keyprotect-go-client v0.5.2/go.mod h1:5TwDM/4FRJq1ZOlwQL1xFahLWQ3TveR88VmL1u3njyI=
 github.com/IBM/vpc-go-sdk v0.2.0 h1:LkKIeC1cGb4c21lHs1pfUHyV+06wFyzLZyF4fNrPTC4=
 github.com/IBM/vpc-go-sdk v0.2.0/go.mod h1:QlPyV8sf1K4Si7CgEyAbmDonabnhJ7tC4owcjrTz3Ys=
 github.com/PuerkitoBio/purell v1.1.0/go.mod h1:c11w/QuzBsJSee3cPx9rAFu61PvFxuPbtSwDGJws/X0=

--- a/ibm/resource_ibm_kms_key.go
+++ b/ibm/resource_ibm_kms_key.go
@@ -100,6 +100,111 @@ func resourceIBMKmskey() *schema.Resource {
 				Description: "The date the key material expires. The date format follows RFC 3339. You can set an expiration date on any key on its creation. A key moves into the Deactivated state within one hour past its expiration date, if one is assigned. If you create a key without specifying an expiration date, the key does not expire",
 				ForceNew:    true,
 			},
+			"policies": {
+				Type:        schema.TypeList,
+				Optional:    true,
+				Computed:    true,
+				Description: "Creates or updates one or more policies for the specified key",
+				MinItems:    1,
+				MaxItems:    1,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"rotation": {
+							Type:         schema.TypeList,
+							Optional:     true,
+							Computed:     true,
+							AtLeastOneOf: []string{"policies.0.rotation", "policies.0.dual_auth_delete"},
+							Description:  "Specifies the key rotation time interval in months, with a minimum of 1, and a maximum of 12",
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"id": {
+										Type:        schema.TypeString,
+										Computed:    true,
+										Description: "The v4 UUID used to uniquely identify the policy resource, as specified by RFC 4122.",
+									},
+									"crn": {
+										Type:        schema.TypeString,
+										Computed:    true,
+										Description: "Cloud Resource Name (CRN) that uniquely identifies your cloud resources.",
+									},
+									"created_by": {
+										Type:        schema.TypeString,
+										Computed:    true,
+										Description: "The unique identifier for the resource that created the policy.",
+									},
+									"creation_date": {
+										Type:        schema.TypeString,
+										Computed:    true,
+										Description: "The date the policy was created. The date format follows RFC 3339.",
+									},
+									"updated_by": {
+										Type:        schema.TypeString,
+										Computed:    true,
+										Description: "The unique identifier for the resource that updated the policy.",
+									},
+									"last_update_date": {
+										Type:        schema.TypeString,
+										Computed:    true,
+										Description: "Updates when the policy is replaced or modified. The date format follows RFC 3339.",
+									},
+									"interval_month": {
+										Type:         schema.TypeInt,
+										Required:     true,
+										ValidateFunc: validateAllowedRangeInt(1, 12),
+										Description:  "Specifies the key rotation time interval in months",
+									},
+								},
+							},
+						},
+						"dual_auth_delete": {
+							Type:         schema.TypeList,
+							Optional:     true,
+							Computed:     true,
+							AtLeastOneOf: []string{"policies.0.rotation", "policies.0.dual_auth_delete"},
+							Description:  "Data associated with the dual authorization delete policy.",
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"id": {
+										Type:        schema.TypeString,
+										Computed:    true,
+										Description: "The v4 UUID used to uniquely identify the policy resource, as specified by RFC 4122.",
+									},
+									"crn": {
+										Type:        schema.TypeString,
+										Computed:    true,
+										Description: "Cloud Resource Name (CRN) that uniquely identifies your cloud resources.",
+									},
+									"created_by": {
+										Type:        schema.TypeString,
+										Computed:    true,
+										Description: "The unique identifier for the resource that created the policy.",
+									},
+									"creation_date": {
+										Type:        schema.TypeString,
+										Computed:    true,
+										Description: "The date the policy was created. The date format follows RFC 3339.",
+									},
+									"updated_by": {
+										Type:        schema.TypeString,
+										Computed:    true,
+										Description: "The unique identifier for the resource that updated the policy.",
+									},
+									"last_update_date": {
+										Type:        schema.TypeString,
+										Computed:    true,
+										Description: "Updates when the policy is replaced or modified. The date format follows RFC 3339.",
+									},
+									"enabled": {
+										Type:        schema.TypeBool,
+										Required:    true,
+										Description: "If set to true, Key Protect enables a dual authorization policy on a single key.",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
 			ResourceName: {
 				Type:        schema.TypeString,
 				Computed:    true,
@@ -217,6 +322,8 @@ func resourceIBMKmsKeyCreate(d *schema.ResourceData, meta interface{}) error {
 			}
 			log.Printf("New key created: %v", *stkey)
 			keyCRN = stkey.CRN
+			d.SetId(keyCRN)
+
 		} else {
 			//create standard key
 			stkey, err := kpAPI.CreateStandardKey(context.Background(), name, expiration)
@@ -226,8 +333,9 @@ func resourceIBMKmsKeyCreate(d *schema.ResourceData, meta interface{}) error {
 			}
 			log.Printf("New key created: %v", *stkey)
 			keyCRN = stkey.CRN
+			d.SetId(keyCRN)
+
 		}
-		d.SetId(keyCRN)
 	} else {
 		if v, ok := d.GetOk("payload"); ok {
 			payload := v.(string)
@@ -239,7 +347,10 @@ func resourceIBMKmsKeyCreate(d *schema.ResourceData, meta interface{}) error {
 					"Error while creating Root key with payload: %s", err)
 			}
 			log.Printf("New key created: %v", *stkey)
+
 			keyCRN = stkey.CRN
+			d.SetId(keyCRN)
+
 		} else {
 			stkey, err := kpAPI.CreateRootKey(context.Background(), name, expiration)
 			if err != nil {
@@ -248,13 +359,11 @@ func resourceIBMKmsKeyCreate(d *schema.ResourceData, meta interface{}) error {
 			}
 			log.Printf("New key created: %v", *stkey)
 			keyCRN = stkey.CRN
+			d.SetId(keyCRN)
+
 		}
-
-		d.SetId(keyCRN)
-
 	}
-
-	return resourceIBMKmsKeyRead(d, meta)
+	return resourceIBMKmsKeyUpdate(d, meta)
 }
 
 func resourceIBMKmsKeyRead(d *schema.ResourceData, meta interface{}) error {
@@ -310,8 +419,18 @@ func resourceIBMKmsKeyRead(d *schema.ResourceData, meta interface{}) error {
 	// keyid := d.Id()
 	key, err := kpAPI.GetKey(context.Background(), keyid)
 	if err != nil {
-		return fmt.Errorf(
-			"Get Key failed with error: %s", err)
+		return fmt.Errorf("Get Key failed with error: %s", err)
+	}
+
+	policies, err := kpAPI.GetPolicies(context.Background(), keyid)
+
+	if err != nil {
+		return fmt.Errorf("Failed to read policies: %s", err)
+	}
+	if len(policies) == 0 {
+		log.Printf("No Policy Configurations read\n")
+	} else {
+		d.Set("policies", flattenKeyPolicies(policies))
 	}
 	d.Set("key_id", keyid)
 	d.Set("standard_key", key.Extractable)
@@ -344,6 +463,76 @@ func resourceIBMKmsKeyUpdate(d *schema.ResourceData, meta interface{}) error {
 
 	if d.HasChange("force_delete") {
 		d.Set("force_delete", d.Get("force_delete").(bool))
+	}
+	if d.HasChange("policies") {
+
+		kpAPI, err := meta.(ClientSession).keyManagementAPI()
+		if err != nil {
+			return err
+		}
+
+		rContollerClient, err := meta.(ClientSession).ResourceControllerAPIV2()
+		if err != nil {
+			return err
+		}
+
+		instanceID := d.Get("instance_id").(string)
+		endpointType := d.Get("endpoint_type").(string)
+
+		rContollerApi := rContollerClient.ResourceServiceInstanceV2()
+
+		instanceData, err := rContollerApi.GetInstance(instanceID)
+		if err != nil {
+			return err
+		}
+		instanceCRN := instanceData.Crn.String()
+		crnData := strings.Split(instanceCRN, ":")
+
+		var hpcsEndpointURL string
+
+		if crnData[4] == "hs-crypto" {
+			hpcsEndpointAPI, err := meta.(ClientSession).HpcsEndpointAPI()
+			if err != nil {
+				return err
+			}
+
+			resp, err := hpcsEndpointAPI.Endpoint().GetAPIEndpoint(instanceID)
+			if err != nil {
+				return err
+			}
+
+			if endpointType == "public" {
+				hpcsEndpointURL = "https://" + resp.Kms.Public + "/api/v2/keys"
+			} else {
+				hpcsEndpointURL = "https://" + resp.Kms.Private + "/api/v2/keys"
+			}
+
+			u, err := url.Parse(hpcsEndpointURL)
+			if err != nil {
+				return fmt.Errorf("Error Parsing hpcs EndpointURL")
+			}
+			kpAPI.URL = u
+		} else if crnData[4] == "kms" {
+			if endpointType == "private" {
+				if !strings.HasPrefix(kpAPI.Config.BaseURL, "private") {
+					kpAPI.Config.BaseURL = "private." + kpAPI.Config.BaseURL
+				}
+			}
+		} else {
+			return fmt.Errorf("Invalid or unsupported service Instance")
+		}
+
+		kpAPI.Config.InstanceID = instanceID
+
+		crn := d.Id()
+		crnData = strings.Split(crn, ":")
+		key_id := crnData[len(crnData)-1]
+
+		err = handlePolicies(d, kpAPI, meta, key_id)
+		if err != nil {
+			resourceIBMKmsKeyRead(d, meta)
+			return fmt.Errorf("Could not create policies: %s", err)
+		}
 	}
 	return resourceIBMKmsKeyRead(d, meta)
 
@@ -467,4 +656,38 @@ func resourceIBMKmsKeyExists(d *schema.ResourceData, meta interface{}) (bool, er
 	}
 	return true, nil
 
+}
+
+func handlePolicies(d *schema.ResourceData, kpAPI *kp.Client, meta interface{}, key_id string) error {
+	var setRotation, setDualAuthDelete, dualAuthEnable bool
+	var rotationInterval int
+
+	if policyInfo, ok := d.GetOk("policies"); ok {
+
+		policyDataList := policyInfo.([]interface{})
+		policyData := policyDataList[0].(map[string]interface{})
+
+		if rpd, ok := policyData["rotation"]; ok {
+			rpdList := rpd.([]interface{})
+			rd := rpdList[0].(map[string]interface{})
+			if ri, ok := rd["interval_month"]; ok {
+				rotationInterval = ri.(int)
+				setRotation = true
+			}
+		}
+		if dadp, ok := policyData["dual_auth_delete"]; ok {
+			dadpList := dadp.([]interface{})
+			dad := dadpList[0].(map[string]interface{})
+			if da, ok := dad["enabled"]; ok {
+				dualAuthEnable = da.(bool)
+				setDualAuthDelete = true
+			}
+		}
+
+		_, err := kpAPI.SetPolicies(context.Background(), key_id, setRotation, rotationInterval, setDualAuthDelete, dualAuthEnable)
+		if err != nil {
+			return fmt.Errorf("Error while creating policies: %s", err)
+		}
+	}
+	return nil
 }

--- a/ibm/validators.go
+++ b/ibm/validators.go
@@ -972,7 +972,7 @@ func validateAllowedRangeInt(start, end int) schema.SchemaValidateFunc {
 		value := v.(int)
 		if value < start || value > end {
 			errors = append(errors, fmt.Errorf(
-				"%q must contain a valid int value should be in range(%d, %d), got %q",
+				"%q must contain a valid int value should be in range(%d, %d), got %d",
 				k, start, end, value))
 		}
 		return

--- a/vendor/github.com/IBM/keyprotect-go-client/.travis.yml
+++ b/vendor/github.com/IBM/keyprotect-go-client/.travis.yml
@@ -2,8 +2,8 @@ language: go
 dist: xenial
 
 go: 
- - 1.13.x
- - 1.12.x
+ - 1.14.x
+ - 1.15.x
 
 env:
   - GO111MODULE=on

--- a/vendor/github.com/IBM/keyprotect-go-client/CONTRIBUTING.md
+++ b/vendor/github.com/IBM/keyprotect-go-client/CONTRIBUTING.md
@@ -1,0 +1,49 @@
+# Contributing to keyprotect-go-client
+
+`keyprotect-go-client` is open for code perusal and contributions. We welcome contributions in the form of feedback, bugs, or patches.
+
+## Bugs and Feature Requests
+
+If you find something that does not work as expected or would like to see a new feature added, 
+please open a [Github Issue](https://github.com/IBM/keyprotect-go-client/issues)
+
+## Pull Requests
+
+For your pull request to be merged, it must meet the criteria of a "correct patch", and also
+be fully reviewed and approved by two Maintainer level contributors.
+
+A correct patch is defined as the following:
+
+ - If the patch fixes a bug, it must be the simplest way to fix the issue
+ - Your patch must come with unit tests
+ - Unit tests (CI job) must pass
+ - New feature function should have integration tests as well
+
+
+# Development
+
+## Compiling the package
+
+```sh
+go build ./...
+```
+
+The client relies on go modules to pull in required dependencies at build time.
+
+https://github.com/golang/go/wiki/Modules#how-to-use-modules
+
+## Running the test cases
+
+Using `go test`
+
+```sh
+go test -v -race ./...
+```
+
+The test cases are also runnable through `make`
+
+```sh
+make test
+# or
+make test-integration
+```

--- a/vendor/github.com/IBM/keyprotect-go-client/README.md
+++ b/vendor/github.com/IBM/keyprotect-go-client/README.md
@@ -5,10 +5,25 @@
 
 keyprotect-go-client is a Go client library for interacting with the IBM KeyProtect service.
 
-This client expects that you have an existing IBM Cloud Key Protect Service Instance, for more information see:
-https://console.bluemix.net/catalog/services/key-protect/.
+* [Questions / Support](#questions--support)
+* [Usage](#usage)
+  * [Migrating](#migrating)
+  * [Authentication](#authentication)
+  * [Finding Instance UUIDs](#finding-a-keyprotect-service-instances-uuid)
+  * [Examples](#examples)
+* [Contributing](/CONTRIBUTING.md)
+
+## Questions / Support
+
+There are many channels for asking questions about KeyProtect and this client.
+
+- Ask a question on Stackoverflow and tag it with `key-protect` and `ibm-cloud`
+- Open a [Github Issue](https://github.com/IBM/keyprotect-go-client/issues)
+- If you work at IBM and have access to the internal Slack, you can join the `#key-protect` channel and ask there.
 
 ## Usage
+
+This client expects that you have an existing IBM Cloud Key Protect Service Instance. To get started, visit the [IBM KeyProtect Catalog Page](https://cloud.ibm.com/catalog/services/key-protect).
 
 Build a client with `ClientConfig` and `New`, then use the client to do some operations.
 ```go
@@ -108,7 +123,7 @@ wrappedDEK, err := client.Wrap(ctx, crkID, myDEK, nil)
 
 
 // Unwrap the DEK
-dek, err := client.UnWrap(ctx, crkID, wrappedDEK, nil)
+dek, err := client.Unwrap(ctx, crkID, wrappedDEK, nil)
 // Do some encryption/decryption using the DEK
 // Discard the DEK
 dek = nil
@@ -127,7 +142,7 @@ wrappedDEK, err := client.Wrap(ctx, crkID, myDEK, &myAAD)
 
 
 // Unwrap the DEK
-dek, err := client.UnWrap(ctx, crkID, wrappedDEK, &myAAD)
+dek, err := client.Unwrap(ctx, crkID, wrappedDEK, &myAAD)
 // Do some encryption/decryption using the DEK
 // Discard the DEK
 dek = nil
@@ -155,28 +170,4 @@ dek = nil
 
 // Save the wrapped DEK for later.  Call Unwrap to use it, make
 // sure to specify the same AAD.
-```
-
-## Compiling the package
-
-```sh
-go build ./...
-```
-
-https://github.com/golang/go/wiki/Modules#how-to-use-modules
-
-## Running the test cases
-
-Using `go test`
-
-```sh
-go test -v -race ./...
-```
-
-The test cases are also runnable through `make`
-
-```sh
-make test
-# or
-make test-integration
 ```

--- a/vendor/github.com/IBM/keyprotect-go-client/iam/iam.go
+++ b/vendor/github.com/IBM/keyprotect-go-client/iam/iam.go
@@ -236,6 +236,17 @@ type iamRequestContext struct {
 }
 
 func (ie Error) Error() string {
+
+	reqId := ""
+	if ie.Context != nil {
+		reqId = ie.Context.RequestID
+	}
+
+	statusCode := 0
+	if ie.HTTPResponse != nil {
+		statusCode = ie.HTTPResponse.StatusCode
+	}
+
 	return fmt.Sprintf("iam.Error: HTTP %d requestId='%s' message='%s %s'",
-		ie.HTTPResponse.StatusCode, ie.Context.RequestID, ie.ErrorCode, ie.ErrorMessage)
+		statusCode, reqId, ie.ErrorCode, ie.ErrorMessage)
 }

--- a/vendor/github.com/IBM/keyprotect-go-client/instances.go
+++ b/vendor/github.com/IBM/keyprotect-go-client/instances.go
@@ -1,0 +1,251 @@
+// Copyright 2019 IBM Corp.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package kp
+
+import (
+	"context"
+	"net/url"
+	"time"
+)
+
+const (
+	//DualAuthDelete defines the policy type as dual auth delete
+	DualAuthDelete = "dualAuthDelete"
+
+	//AllowedNetwork defines the policy type as allowed network
+	AllowedNetwork = "allowedNetwork"
+)
+
+// InstancePolicy represents a instance-level policy of a key as returned by the KP API.
+// this policy enables dual authorization for deleting a key
+type InstancePolicy struct {
+	CreatedBy  string     `json:"createdBy,omitempty"`
+	CreatedAt  *time.Time `json:"creationDate,omitempty"`
+	UpdatedAt  *time.Time `json:"lastUpdated,omitempty"`
+	UpdatedBy  string     `json:"updatedBy,omitempty"`
+	PolicyType string     `json:"policy_type,omitempty"`
+	PolicyData PolicyData `json:"policy_data,omitempty" mapstructure:"policyData"`
+}
+
+// PolicyData contains the details of the policy type
+type PolicyData struct {
+	Enabled    *bool       `json:"enabled,omitempty"`
+	Attributes *Attributes `json:"attributes,omitempty"`
+}
+
+// Attributes contains the detals of allowed network policy type
+type Attributes struct {
+	AllowedNetwork string `json:"allowed_network,omitempty"`
+}
+
+// InstancePolicies represents a collection of Policies associated with Key Protect instances.
+type InstancePolicies struct {
+	Metadata PoliciesMetadata `json:"metadata"`
+	Policies []InstancePolicy `json:"resources"`
+}
+
+// GetDualAuthInstancePolicy retrieves the dual auth delete policy details associated with the instance
+// For more information can refer the Key Protect docs in the link below:
+// https://cloud.ibm.com/docs/key-protect?topic=key-protect-manage-dual-auth
+func (c *Client) GetDualAuthInstancePolicy(ctx context.Context) (*InstancePolicy, error) {
+	policyResponse := InstancePolicies{}
+
+	err := c.getInstancePolicy(ctx, DualAuthDelete, &policyResponse)
+	if err != nil {
+		return nil, err
+	}
+
+	if len(policyResponse.Policies) == 0 {
+		return nil, nil
+	}
+	return &policyResponse.Policies[0], nil
+}
+
+// GetAllowedNetworkInstancePolicy retrieves the allowed network policy details associated with the instance.
+// For more information can refer the Key Protect docs in the link below:
+// https://cloud.ibm.com/docs/key-protect?topic=key-protect-managing-network-access-policies
+func (c *Client) GetAllowedNetworkInstancePolicy(ctx context.Context) (*InstancePolicy, error) {
+	policyResponse := InstancePolicies{}
+
+	err := c.getInstancePolicy(ctx, AllowedNetwork, &policyResponse)
+	if err != nil {
+		return nil, err
+	}
+
+	if len(policyResponse.Policies) == 0 {
+		return nil, nil
+	}
+
+	return &policyResponse.Policies[0], nil
+}
+
+func (c *Client) getInstancePolicy(ctx context.Context, policyType string, policyResponse *InstancePolicies) error {
+	req, err := c.newRequest("GET", "instance/policies", nil)
+	if err != nil {
+		return err
+	}
+
+	v := url.Values{}
+	v.Set("policy", policyType)
+	req.URL.RawQuery = v.Encode()
+
+	_, err = c.do(ctx, req, &policyResponse)
+	if err != nil {
+		return err
+	}
+	return err
+}
+
+// GetInstancePolicies retrieves all policies of an Instance.
+func (c *Client) GetInstancePolicies(ctx context.Context) ([]InstancePolicy, error) {
+	policyresponse := InstancePolicies{}
+
+	req, err := c.newRequest("GET", "instance/policies", nil)
+	if err != nil {
+		return nil, err
+	}
+
+	_, err = c.do(ctx, req, &policyresponse)
+	if err != nil {
+		return nil, err
+	}
+
+	return policyresponse.Policies, nil
+}
+
+func (c *Client) setInstancePolicy(ctx context.Context, policyType string, policyRequest InstancePolicies) error {
+	req, err := c.newRequest("PUT", "instance/policies", &policyRequest)
+	if err != nil {
+		return err
+	}
+
+	v := url.Values{}
+	v.Set("policy", policyType)
+	req.URL.RawQuery = v.Encode()
+
+	policiesResponse := Policies{}
+	_, err = c.do(ctx, req, &policiesResponse)
+	if err != nil {
+		return err
+	}
+	return err
+}
+
+// SetDualAuthInstancePolicy updates the dual auth delete policy details associated with an instance
+// For more information can refer the Key Protect docs in the link below:
+// https://cloud.ibm.com/docs/key-protect?topic=key-protect-manage-dual-auth
+func (c *Client) SetDualAuthInstancePolicy(ctx context.Context, enable bool) error {
+	policy := InstancePolicy{
+		PolicyType: DualAuthDelete,
+		PolicyData: PolicyData{
+			Enabled: &enable,
+		},
+	}
+
+	policyRequest := InstancePolicies{
+		Metadata: PoliciesMetadata{
+			CollectionType:   policyType,
+			NumberOfPolicies: 1,
+		},
+		Policies: []InstancePolicy{policy},
+	}
+
+	err := c.setInstancePolicy(ctx, DualAuthDelete, policyRequest)
+	if err != nil {
+		return err
+	}
+
+	return err
+}
+
+// SetAllowedNetWorkInstancePolicy updates the allowed network policy details associated with an instance
+// For more information can refer to the Key Protect docs in the link below:
+// https://cloud.ibm.com/docs/key-protect?topic=key-protect-managing-network-access-policies
+func (c *Client) SetAllowedNetworkInstancePolicy(ctx context.Context, enable bool, networkType string) error {
+	policy := InstancePolicy{
+		PolicyType: AllowedNetwork,
+		PolicyData: PolicyData{
+			Enabled:    &enable,
+			Attributes: &Attributes{},
+		},
+	}
+	if networkType != "" {
+		policy.PolicyData.Attributes.AllowedNetwork = networkType
+	}
+
+	policyRequest := InstancePolicies{
+		Metadata: PoliciesMetadata{
+			CollectionType:   policyType,
+			NumberOfPolicies: 1,
+		},
+		Policies: []InstancePolicy{policy},
+	}
+
+	err := c.setInstancePolicy(ctx, AllowedNetwork, policyRequest)
+	if err != nil {
+		return err
+	}
+
+	return err
+}
+
+// SetInstancePolicies updates single or multiple policy details of an instance.
+func (c *Client) SetInstancePolicies(ctx context.Context, setDualAuth, dualAuthEnable bool, setAllowedNetwork, allowedNetworkEnable bool, networkType string) error {
+	var policies []InstancePolicy
+
+	if setDualAuth {
+		policy := InstancePolicy{
+			PolicyType: DualAuthDelete,
+		}
+		policy.PolicyData.Enabled = &dualAuthEnable
+		policies = append(policies, policy)
+	}
+
+	if setAllowedNetwork {
+		policy := InstancePolicy{
+			PolicyType: AllowedNetwork,
+			PolicyData: PolicyData{
+				Enabled:    &allowedNetworkEnable,
+				Attributes: &Attributes{},
+			},
+		}
+		if networkType != "" {
+			policy.PolicyData.Attributes.AllowedNetwork = networkType
+		}
+		policies = append(policies, policy)
+	}
+
+	policyRequest := InstancePolicies{
+		Metadata: PoliciesMetadata{
+			CollectionType:   policyType,
+			NumberOfPolicies: len(policies),
+		},
+		Policies: policies,
+	}
+
+	policyresponse := Policies{}
+
+	req, err := c.newRequest("PUT", "instance/policies", &policyRequest)
+	if err != nil {
+		return err
+	}
+
+	_, err = c.do(ctx, req, &policyresponse)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/vendor/github.com/IBM/keyprotect-go-client/kp.go
+++ b/vendor/github.com/IBM/keyprotect-go-client/kp.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// keyprotect-go-client is a Go client library for interacting with the IBM KeyProtect service.
 package kp
 
 import (
@@ -190,6 +191,9 @@ type reason struct {
 }
 
 func (r reason) String() string {
+	if r.MoreInfo != "" {
+		return fmt.Sprintf("%s: %s - FOR_MORE_INFO_REFER: %s", r.Code, r.Message, r.MoreInfo)
+	}
 	return fmt.Sprintf("%s: %s", r.Code, r.Message)
 }
 

--- a/vendor/github.com/IBM/keyprotect-go-client/policy.go
+++ b/vendor/github.com/IBM/keyprotect-go-client/policy.go
@@ -1,0 +1,317 @@
+// Copyright 2020 IBM Corp.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package kp
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+	"time"
+)
+
+const (
+	policyType = "application/vnd.ibm.kms.policy+json"
+
+	RotationPolicy = "rotation"
+)
+
+// Policy represents a policy as returned by the KP API.
+type Policy struct {
+	Type      string     `json:"type,omitempty"`
+	CreatedBy string     `json:"createdBy,omitempty"`
+	CreatedAt *time.Time `json:"creationDate,omitempty"`
+	CRN       string     `json:"crn,omitempty"`
+	UpdatedAt *time.Time `json:"lastUpdateDate,omitempty"`
+	UpdatedBy string     `json:"updatedBy,omitempty"`
+	Rotation  *Rotation  `json:"rotation,omitempty"`
+	DualAuth  *DualAuth  `json:"dualAuthDelete,omitempty"`
+}
+
+type Rotation struct {
+	Interval int `json:"interval_month,omitempty"`
+}
+
+type DualAuth struct {
+	Enabled *bool `json:"enabled,omitempty"`
+}
+
+// PoliciesMetadata represents the metadata of a collection of keys.
+type PoliciesMetadata struct {
+	CollectionType   string `json:"collectionType"`
+	NumberOfPolicies int    `json:"collectionTotal"`
+}
+
+// Policies represents a collection of Policies.
+type Policies struct {
+	Metadata PoliciesMetadata `json:"metadata"`
+	Policies []Policy         `json:"resources"`
+}
+
+// GetPolicy retrieves a policy by Key ID. This function is
+// deprecated, as it only returns one policy and does not let you
+// select which policy set it will return. It is kept for backward
+// compatibility on keys with only one rotation policy. Please update
+// to use the new GetPolicies or Get<type>Policy functions.
+func (c *Client) GetPolicy(ctx context.Context, id string) (*Policy, error) {
+	policyresponse := Policies{}
+
+	req, err := c.newRequest("GET", fmt.Sprintf("keys/%s/policies", id), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	_, err = c.do(ctx, req, &policyresponse)
+	if err != nil {
+		return nil, err
+	}
+
+	return &policyresponse.Policies[0], nil
+}
+
+// SetPolicy updates a policy resource by specifying the ID of the key and
+// the rotation interval needed. This function is deprecated as it will only
+// let you set key rotation  policies. To set dual auth and other newer policies
+// on a key, please use the new SetPolicies of Set<type>Policy functions.
+func (c *Client) SetPolicy(ctx context.Context, id string, prefer PreferReturn, rotationInterval int) (*Policy, error) {
+
+	policy := Policy{
+		Type: policyType,
+		Rotation: &Rotation{
+			Interval: rotationInterval,
+		},
+	}
+
+	policyRequest := Policies{
+		Metadata: PoliciesMetadata{
+			CollectionType:   policyType,
+			NumberOfPolicies: 1,
+		},
+		Policies: []Policy{policy},
+	}
+
+	policyresponse := Policies{}
+
+	req, err := c.newRequest("PUT", fmt.Sprintf("keys/%s/policies", id), &policyRequest)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Set("Prefer", preferHeaders[prefer])
+
+	_, err = c.do(ctx, req, &policyresponse)
+	if err != nil {
+		return nil, err
+	}
+
+	return &policyresponse.Policies[0], nil
+}
+
+// GetPolicies retrieves all policies details associated with a Key ID.
+func (c *Client) GetPolicies(ctx context.Context, id string) ([]Policy, error) {
+	policyresponse := Policies{}
+
+	req, err := c.newRequest("GET", fmt.Sprintf("keys/%s/policies", id), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	_, err = c.do(ctx, req, &policyresponse)
+	if err != nil {
+		return nil, err
+	}
+
+	return policyresponse.Policies, nil
+}
+
+func (c *Client) getPolicy(ctx context.Context, id, policyType string, policyresponse *Policies) error {
+	req, err := c.newRequest("GET", fmt.Sprintf("keys/%s/policies", id), nil)
+	if err != nil {
+		return err
+	}
+
+	v := url.Values{}
+	v.Set("policy", policyType)
+	req.URL.RawQuery = v.Encode()
+
+	_, err = c.do(ctx, req, &policyresponse)
+	if err != nil {
+		return err
+	}
+	return err
+}
+
+// GetRotationPolivy method retrieves rotation policy details of a key
+// For more information can refet the Key Protect docs in the link below:
+// https://cloud.ibm.com/docs/key-protect?topic=key-protect-set-rotation-policy#view-rotation-policy-api
+func (c *Client) GetRotationPolicy(ctx context.Context, id string) (*Policy, error) {
+	policyresponse := Policies{}
+
+	err := c.getPolicy(ctx, id, RotationPolicy, &policyresponse)
+	if err != nil {
+		return nil, err
+	}
+
+	if len(policyresponse.Policies) == 0 {
+		return nil, nil
+	}
+
+	return &policyresponse.Policies[0], nil
+}
+
+// GetDualAuthDeletePolicy method retrieves dual auth delete policy details of a key
+// For more information can refer the Key Protect docs in the link below:
+// https://cloud.ibm.com/docs/key-protect?topic=key-protect-set-dual-auth-key-policy#view-dual-auth-key-policy-api
+func (c *Client) GetDualAuthDeletePolicy(ctx context.Context, id string) (*Policy, error) {
+	policyresponse := Policies{}
+
+	err := c.getPolicy(ctx, id, DualAuthDelete, &policyresponse)
+	if err != nil {
+		return nil, err
+	}
+
+	if len(policyresponse.Policies) == 0 {
+		return nil, nil
+	}
+
+	return &policyresponse.Policies[0], nil
+}
+
+func (c *Client) setPolicy(ctx context.Context, id, policyType string, policyRequest Policies) (*Policies, error) {
+	policyresponse := Policies{}
+
+	req, err := c.newRequest("PUT", fmt.Sprintf("keys/%s/policies", id), &policyRequest)
+	if err != nil {
+		return nil, err
+	}
+
+	v := url.Values{}
+	v.Set("policy", policyType)
+	req.URL.RawQuery = v.Encode()
+
+	_, err = c.do(ctx, req, &policyresponse)
+	if err != nil {
+		return nil, err
+	}
+	return &policyresponse, nil
+}
+
+// SetRotationPolicy updates the rotation policy associated with a key by specifying key ID and rotation interval.
+// For more information can refer the Key Protect docs in the link below:
+// https://cloud.ibm.com/docs/key-protect?topic=key-protect-set-rotation-policy#update-rotation-policy-api
+func (c *Client) SetRotationPolicy(ctx context.Context, id string, rotationInterval int) (*Policy, error) {
+	policy := Policy{
+		Type: policyType,
+		Rotation: &Rotation{
+			Interval: rotationInterval,
+		},
+	}
+
+	policyRequest := Policies{
+		Metadata: PoliciesMetadata{
+			CollectionType:   policyType,
+			NumberOfPolicies: 1,
+		},
+		Policies: []Policy{policy},
+	}
+
+	policyresponse, err := c.setPolicy(ctx, id, RotationPolicy, policyRequest)
+	if err != nil {
+		return nil, err
+	}
+
+	if len(policyresponse.Policies) == 0 {
+		return nil, nil
+	}
+
+	return &policyresponse.Policies[0], nil
+}
+
+// SetDualAuthDeletePolicy updates the dual auth delete policy by passing the key ID and enable detail
+// For more information can refer the Key Protect docs in the link below:
+// https://cloud.ibm.com/docs/key-protect?topic=key-protect-set-dual-auth-key-policy#create-dual-auth-key-policy-api
+func (c *Client) SetDualAuthDeletePolicy(ctx context.Context, id string, enabled bool) (*Policy, error) {
+	policy := Policy{
+		Type: policyType,
+		DualAuth: &DualAuth{
+			Enabled: &enabled,
+		},
+	}
+
+	policyRequest := Policies{
+		Metadata: PoliciesMetadata{
+			CollectionType:   policyType,
+			NumberOfPolicies: 1,
+		},
+		Policies: []Policy{policy},
+	}
+
+	policyresponse, err := c.setPolicy(ctx, id, DualAuthDelete, policyRequest)
+	if err != nil {
+		return nil, err
+	}
+
+	if len(policyresponse.Policies) == 0 {
+		return nil, nil
+	}
+
+	return &policyresponse.Policies[0], nil
+}
+
+// SetPolicies updates all policies of the key or a single policy by passing key ID.
+// To set rotation policy for the key pass the setRotationPolicy parameter as true and set the rotationInterval detail.
+// To set dual auth delete policy for the key pass the setDualAuthDeletePolicy parameter as true and set the dualAuthEnable detail.
+// Both the policies can be set or either of the policies can be set.
+func (c *Client) SetPolicies(ctx context.Context, id string, setRotationPolicy bool, rotationInterval int, setDualAuthDeletePolicy, dualAuthEnable bool) ([]Policy, error) {
+	policies := []Policy{}
+	if setRotationPolicy {
+		rotationPolicy := Policy{
+			Type: policyType,
+			Rotation: &Rotation{
+				Interval: rotationInterval,
+			},
+		}
+		policies = append(policies, rotationPolicy)
+	}
+	if setDualAuthDeletePolicy {
+		dulaAuthPolicy := Policy{
+			Type: policyType,
+			DualAuth: &DualAuth{
+				Enabled: &dualAuthEnable,
+			},
+		}
+		policies = append(policies, dulaAuthPolicy)
+	}
+
+	policyRequest := Policies{
+		Metadata: PoliciesMetadata{
+			CollectionType:   policyType,
+			NumberOfPolicies: len(policies),
+		},
+		Policies: policies,
+	}
+
+	policyresponse := Policies{}
+
+	req, err := c.newRequest("PUT", fmt.Sprintf("keys/%s/policies", id), &policyRequest)
+	if err != nil {
+		return nil, err
+	}
+	_, err = c.do(ctx, req, &policyresponse)
+	if err != nil {
+		return nil, err
+	}
+
+	return policyresponse.Policies, nil
+}

--- a/vendor/github.com/IBM/keyprotect-go-client/registrations.go
+++ b/vendor/github.com/IBM/keyprotect-go-client/registrations.go
@@ -1,0 +1,69 @@
+// Copyright 2020 IBM Corp.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package kp
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+	"time"
+)
+
+// Registration represents the registration as returned by KP API
+type Registration struct {
+	KeyID              string     `json:"keyId,omitempty"`
+	ResourceCrn        string     `json:"resourceCrn,omitempty"`
+	CreatedBy          string     `json:"createdBy,omitempty"`
+	CreationDate       *time.Time `json:"creationDate,omitempty"`
+	UpdatedBy          string     `json:"updatedBy,omitempty"`
+	LastUpdateDate     *time.Time `json:"lastUpdated,omitempty"`
+	Description        string     `json:"description,omitempty"`
+	PreventKeyDeletion bool       `json:"preventKeyDeletion,omitempty"`
+	KeyVersion         KeyVersion `json:"keyVersion,omitempty"`
+}
+
+type registrations struct {
+	Metadata      KeysMetadata   `json:"metadata"`
+	Registrations []Registration `json:"resources"`
+}
+
+// ListRegistrations retrieves a collection of registrations
+func (c *Client) ListRegistrations(ctx context.Context, keyId, crn string) (*registrations, error) {
+	registrationAPI := ""
+	if keyId != "" {
+		registrationAPI = fmt.Sprintf("keys/%s/registrations", keyId)
+	} else {
+		registrationAPI = "keys/registrations"
+	}
+
+	req, err := c.newRequest("GET", registrationAPI, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	if crn != "" {
+		v := url.Values{}
+		v.Set("urlEncodedResourceCRNQuery", crn)
+		req.URL.RawQuery = v.Encode()
+	}
+
+	regs := registrations{}
+	_, err = c.do(ctx, req, &regs)
+	if err != nil {
+		return nil, err
+	}
+
+	return &regs, nil
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -122,7 +122,7 @@ github.com/IBM/ibm-cos-sdk-go/service/s3/internal/arn
 # github.com/IBM/ibm-cos-sdk-go-config v1.0.1
 github.com/IBM/ibm-cos-sdk-go-config/common
 github.com/IBM/ibm-cos-sdk-go-config/resourceconfigurationv1
-# github.com/IBM/keyprotect-go-client v0.3.5-0.20200325142150-b63163832e26
+# github.com/IBM/keyprotect-go-client v0.5.2
 github.com/IBM/keyprotect-go-client
 github.com/IBM/keyprotect-go-client/iam
 # github.com/IBM/networking-go-sdk v0.12.0

--- a/website/docs/r/kms_key.html.markdown
+++ b/website/docs/r/kms_key.html.markdown
@@ -68,6 +68,32 @@ resource "ibm_kms_key" "key" {
   force_delete = true
 }
 ```
+## Example usage to provision Key Management Service Key with Key Policies
+
+Set policies for a key, such as an automatic rotation policy or a dual authorization policy to protect against the accidental deletion of keys.
+
+```hcl
+resource "ibm_resource_instance" "kp_instance" {
+  name     = "test_kp"
+  service  = "kms"
+  plan     = "tiered-pricing"
+  location = "us-south"
+}
+resource "ibm_kms_key" "key" {
+  instance_id = ibm_resource_instance.kp_instance.guid
+  key_name       = "key"
+  standard_key   = false
+  expiration_date = "2020-12-05T15:43:46Z"
+  policies {
+    rotation {
+      interval_month = 3
+    }
+    dual_auth_delete {
+      enabled = false
+    }
+  }
+}
+```
 
 ## Argument Reference
 
@@ -84,6 +110,14 @@ The following arguments are supported:
     **NOTE**: Before doing terraform destroy if force_delete flag is introduced after provisioning keys, a terraform apply must be done before terraform destroy for force_delete flag to take effect.
 * `expiration_date` - (Optional, Forces new resource, string) The date the key material expires. The date format follows RFC 3339. You can set an expiration date on any key on its creation. A key moves into the Deactivated state within one hour past its expiration date, if one is assigned. If you create a key without specifying an expiration date, the key does not expire
 `Example: 2018-12-01T23:20:50.52Z`.
+* `policies` - (Optional, list) Set policies for a key, such as an automatic rotation policy or a dual authorization policy to protect against the accidental deletion of keys. Policies folow the following structure.
+  * `rotation` - (Optional, list) Specifies the key rotation time interval in months, with a minimum of 1, and a maximum of 12.
+    * `interval_month` - (Required, int) Specifies the key rotation time interval in months.
+      **CONSTRAINTS**: 1 ≤ value ≤ 12
+      **NOTE**: Rotation policy is cannot be set for standard key and imported key. Once Rotation Policy is set, it is not possible to unset/remove it using Terraform.
+  * `dual_auth_delete` - (Required, list) Data associated with the dual authorization delete policy.
+    * `enabled` - (Optional, bool) If set to true, Key Protect enables a dual authorization policy on a single key.
+      **NOTE**: Once the dual authorization policy is set on the key, it cannot be reverted. A key with dual authorization policy enabled cannot be destroyed using Terraform.
 
 
 ## Attribute Reference
@@ -95,6 +129,23 @@ The following attributes are exported:
 * `status` - The status of the key.
 * `key_id` - The id of the key. 
 * `type` - The type of the key kms or hs-crypto. 
+* `policy` - The policies associated with the key.
+  * `rotation` - The key rotation time interval in months, with a minimum of 1, and a maximum of 12.
+    * `created_by` - The unique identifier for the resource that created the policy.
+    * `creation_date` - The date the policy was created. The date format follows RFC 3339.
+    * `crn` - The Cloud Resource Name (CRN) that uniquely identifies your cloud resources.
+    * `id` - The v4 UUID used to uniquely identify the policy resource, as specified by RFC 4122.
+    * `interval_month` - The key rotation time interval in months.
+    * `last_update_date` - The date when the policy was last replaced or modified. The date format follows RFC 3339.
+    * `updated_by` - The unique identifier for the resource that updated the policy.
+  * `dual_auth_delete` - The data associated with the dual authorization delete policy.
+    * `created_by` - The unique identifier for the resource that created the policy.
+    * `creation_date` - The date the policy was created. The date format follows RFC 3339.
+    * `crn` - The Cloud Resource Name (CRN) that uniquely identifies your cloud resources.
+    * `id` - The v4 UUID used to uniquely identify the policy resource, as specified by RFC 4122.
+    * `enabled` - If set to true, Key Protect enables a dual authorization policy on the key.
+    * `last_update_date` - The date when the policy was last replaced or modified. The date format follows RFC 3339.
+    * `updated_by` - The unique identifier for the resource that updated the policy.
 
 
 ## Import


### PR DESCRIPTION
- Updated keyprotect-go-client from 0.3.5 to 0.5.2
- Added key policies functionality so that user can specify key policy configuration while creating key
