### PR TITLE
check instance state after destroy

### DIFF
--- a/ibm/resource_ibm_event_streams_topic_test.go
+++ b/ibm/resource_ibm_event_streams_topic_test.go
@@ -305,9 +305,9 @@ func testAccCheckIBMEventStreamsInstanceDestroy(s *terraform.State) error {
 			continue
 		}
 		instanceID := rs.Primary.ID
-		_, err := rsContClient.ResourceServiceInstance().GetInstance(instanceID)
+		instance, err := rsContClient.ResourceServiceInstance().GetInstance(instanceID)
 
-		if err == nil {
+		if err == nil && instance.State == "active" {
 			return fmt.Errorf("Instance still exists: %s", rs.Primary.ID)
 		} else if !strings.Contains(err.Error(), "404") {
 			return fmt.Errorf("Error checking if instance (%s) has been destroyed: %s", rs.Primary.ID, err)


### PR DESCRIPTION
this change breaks our test
https://github.com/IBM-Cloud/terraform-provider-ibm/commit/bf33718b21ed7a88f64319a28a33cfee889b098a#diff-db14e0ef8c2849b7a8ce8b65b7abce6763b7d12f1fa4f86b007d0527fce1308fR308

Because we support reclamation, after instance is deleted,
`rsContClient.ResourceServiceInstance().GetInstance` still returns 200, but `instance.state=pending_reclamation`
