### PR TITLE
Add example for Importing a Key

### DIFF
--- a/website/docs/r/kms_key.html.markdown
+++ b/website/docs/r/kms_key.html.markdown
@@ -69,6 +69,23 @@ resource "ibm_kms_key" "key" {
 }
 ```
 
+## Example usage to provision Key Management Service and Import a Key
+
+```hcl
+resource "ibm_resource_instance" "kp_instance" {
+  name     = "test_kp"
+  service  = "kms"
+  plan     = "tiered-pricing"
+  location = "us-south"
+}
+resource "ibm_kms_key" "key" {
+  instance_id = ibm_resource_instance.kp_instance.guid
+  key_name       = "key"
+  standard_key   = false
+  payload = "aW1wb3J0ZWQucGF5bG9hZA=="
+}
+```
+
 ## Argument Reference
 
 The following arguments are supported:


### PR DESCRIPTION
Description: Adding an example for Importing a Key. There was no example on how to import a Key to Key Protect using Terraform as pointed out by an user. 