### PR TITLE
Added input to ibm container data source in order to skip listing bounded services

### DIFF
--- a/ibm/data_source_ibm_container_cluster.go
+++ b/ibm/data_source_ibm_container_cluster.go
@@ -284,6 +284,13 @@ func dataSourceIBMContainerCluster() *schema.Resource {
 				Computed: true,
 			},
 
+			"list_bounded_services": {
+				Type:        schema.TypeBool,
+				Default:     true,
+				Optional:    true,
+				Description: "If set to false bounded services won't be listed.",
+			},
+
 			ResourceControllerURL: {
 				Type:        schema.TypeString,
 				Computed:    true,
@@ -352,19 +359,24 @@ func dataSourceIBMContainerClusterRead(d *schema.ResourceData, meta interface{})
 	for i, worker := range workerFields {
 		workers[i] = worker.ID
 	}
-	servicesBoundToCluster, err := csAPI.ListServicesBoundToCluster(name, "", targetEnv)
-	if err != nil {
-		return fmt.Errorf("Error retrieving services bound to cluster: %s", err)
-	}
+
+	listBoundedServices := d.Get("list_bounded_services").(bool)
 	boundedServices := make([]map[string]interface{}, 0)
-	for _, service := range servicesBoundToCluster {
-		boundedService := make(map[string]interface{})
-		boundedService["service_name"] = service.ServiceName
-		boundedService["service_id"] = service.ServiceID
-		boundedService["service_key_name"] = service.ServiceKeyName
-		boundedService["namespace"] = service.Namespace
-		boundedServices = append(boundedServices, boundedService)
+	if listBoundedServices {
+		servicesBoundToCluster, err := csAPI.ListServicesBoundToCluster(name, "", targetEnv)
+		if err != nil {
+			return fmt.Errorf("Error retrieving services bound to cluster: %s", err)
+		}
+		for _, service := range servicesBoundToCluster {
+			boundedService := make(map[string]interface{})
+			boundedService["service_name"] = service.ServiceName
+			boundedService["service_id"] = service.ServiceID
+			boundedService["service_key_name"] = service.ServiceKeyName
+			boundedService["namespace"] = service.Namespace
+			boundedServices = append(boundedServices, boundedService)
+		}
 	}
+
 	workerPools, err := workerPoolsAPI.ListWorkerPools(name, targetEnv)
 	if err != nil {
 		return fmt.Errorf("Error retrieving worker pools of the cluster %s: %s", name, err)

--- a/website/docs/d/container_cluster.html.markdown
+++ b/website/docs/d/container_cluster.html.markdown
@@ -27,6 +27,7 @@ The following arguments are supported:
 * `cluster_name_id` - (Deprecated, string) Name of the Cluster
 * `name` - (Optional, string) Name or ID of the cluster.
 * `alb_type` - (Optional, string) Used to filter the albs based on type. Valid values are `private`, `public` and `all`. The default value is `all`.
+* `list_bounded_services` - (Optional, bool) If set to false services which are bound to the cluster are not going to be listed. The default value is `true`.
 * `org_guid` - (Deprecated, string) The GUID for the IBM Cloud organization associated with the cluster. You can retrieve the value from the `ibm_org` data source or by running the `ibmcloud iam orgs --guid` command in the [IBM Cloud CLI](https://cloud.ibm.com/docs/cli?topic=cloud-cli-getting-started).
 * `space_guid` - (Deprecated, string) The GUID for the IBM Cloud space associated with the cluster. You can retrieve the value from the `ibm_space` data source or by running the `ibmcloud iam space <space-name> --guid` command in the IBM Cloud CLI.
 * `account_guid` - (Deprecated, string) The GUID for the IBM Cloud account associated with the cluster. You can retrieve the value from the `ibm_account` data source or by running the `ibmcloud iam accounts` command in the IBM Cloud CLI.


### PR DESCRIPTION
Hi there, 
a lot of services are bound to our Kubernetes cluster. Everytime we run the Terraform scripts the ibm_container_cluster data source is executed which fetches all bounded services. In our case this leads to a very long execution time as the API does not respond very fast when there are more than 100 services bound to the cluster (actually it even results in timeout exceptions).

As we do not even need the information about all bounded services I would like to introduce the possibility to add an additional variable to filter for specific namespaces.

This should improve the overall performance of the data source and also the reliability.
The default value still remains as an empty string, so the changes should be backwards compatible.

In case of any questions, don't hesitate to contact me.