### PR TITLE
Private key passphrase should be marked sensitive

### DIFF
--- a/ibm/data_source_ibm_is_instance.go
+++ b/ibm/data_source_ibm_is_instance.go
@@ -48,6 +48,7 @@ func dataSourceIBMISInstance() *schema.Resource {
 			isInstancePassphrase: {
 				Type:        schema.TypeString,
 				Optional:    true,
+				Sensitive:   true,
 				Description: "Passphrase for Instance Private Key file",
 			},
 


### PR DESCRIPTION
The VPC instance data source (`ibm_is_instance`) SSH private key passphrase parameter should be marked as a sensitive value to prevent logging.