### PR TITLE
Add helper functions for generated SDKs

### DIFF
--- a/ibm/structures.go
+++ b/ibm/structures.go
@@ -754,6 +754,20 @@ func ptrToString(s string) *string {
 	return &s
 }
 
+func intValue(i64 *int64) (i int) {
+	if i64 != nil {
+		i = int(*i64)
+	}
+	return
+}
+
+func float64Value(f32 *float32) (f float64) {
+	if f32 != nil {
+		f = float64(*f32)
+	}
+	return
+}
+
 func filterActionAnnotations(in whisk.KeyValueArr) (string, error) {
 	noExec := make(whisk.KeyValueArr, 0, len(in))
 	for _, v := range in {


### PR DESCRIPTION
This PR adds two small helper methods that will be useful in providers that use the generated Go SDKs.

The generated Go SDKs use `*int64` for all integer types, but Terraform uses `int`, so we need to do this small conversion for every int value received from the SDK that we want to store into the Terraform state.

Likewise, the generated Go SDKs use either `*float32` or `*float64` for float types, based on size, but Terraform uses `float64` always.  So we need to convert `*float32` to `float64` (`ResourceData.Set` automatically dereferences `*float64` to `float64`, so we don't need a helper for that).