### PR TITLE
ISSUE-2121: add sleep in ibm-hpcs-crypto example

### DIFF
--- a/examples/ibm-hpcs-crypto/main.tf
+++ b/examples/ibm-hpcs-crypto/main.tf
@@ -18,18 +18,25 @@ data "ibm_resource_instance" "hpcs_instance" {
   service  = "hs-crypto"
   location = var.location
 }
+
+# time_sleep after hpcs service instance was created
+resource time_sleep "wait_3_mins" {
+  depends_on      = [data.ibm_resource_instance.hpcs_instance]
+  create_duration = "3m"
+}
+
 # ------------------------------------------------------------------------------------------------------------
 # #Intialization of the hpcs crypto service may be use some scripts and null_resource to intialize the service
 # -------------------------------------------------------------------------------------------------------------
-/* 
+/*
    Initilialising hpcs instance requires json file that containes all the creditials of admin and master keys as an input..
-   This file can be fed as an input to the `hpcs_init` null resource in multiple ways out of which, 
+   This file can be fed as an input to the `hpcs_init` null resource in multiple ways out of which,
    the present template supports file from IBM-Object-Storage Bucket or directly from the local.
    Use null resource blocks accordingly..
 */
 
 # This `download_from_cos` downloads json file cos-bucket..
-/* 
+/*
      Json file should already be fed to cos bucket before accessing it via null resource.
      This block takes cos credentials as input and and dowloads file in the current directory.
      This block can be commented if user doesnt wish to download input from cos-bucket
@@ -51,12 +58,12 @@ resource "null_resource" "download_from_cos" {
 }
 
 # This `hpcs_init` Initialises HPCS Instance by running all the tke command that are required for initialisation..
-/* 
+/*
      This take the content of the json file as input and perform necessary operations
      The set of CLOUDTKEFILES that are obtained as an input is stored in the `tke_files_path` provided by user as a folder of secrets.
   */
 resource "null_resource" "hpcs_init" {
-  depends_on = [null_resource.download_from_cos] // Dependson can be removed if the download_from_cos null resource is not used..
+  depends_on = [null_resource.download_from_cos, time_sleep.wait_3_mins] // Dependson can be removed if the download_from_cos null resource is not used..
   provisioner "local-exec" {
     command = <<EOT
     python ./scripts/init.py
@@ -68,8 +75,8 @@ resource "null_resource" "hpcs_init" {
     }
   }
 }
-# This `upload_to_cos` uploads CLOUDTKEFILES that are present in `tke_files_path` as a zip file . 
-/* 
+# This `upload_to_cos` uploads CLOUDTKEFILES that are present in `tke_files_path` as a zip file .
+/*
      This block takes cos credentials as input and and uploads zip file
      This block can be commented if user doesnt wish to upload files to cos-bucket
      Different cos credentials can also be used to upload files
@@ -90,8 +97,8 @@ resource "null_resource" "upload_to_cos" {
     }
   }
 }
-# This `remove_tke_files` removes CLOUDTKEFILES that are present in `tke_files_path` . 
-/* 
+# This `remove_tke_files` removes CLOUDTKEFILES that are present in `tke_files_path` .
+/*
      NOTE: This block has to be used only if user wish to delete CLOUDTKEFILES or the input file
   */
 resource "null_resource" "remove_tke_files" {
@@ -113,7 +120,7 @@ resource "null_resource" "remove_tke_files" {
 # --------------------------------
 
 resource "ibm_kms_key" "key" {
-  depends_on = [null_resource.hpcs_init]
+  depends_on   = [null_resource.hpcs_init]
   instance_id  = data.ibm_resource_instance.hpcs_instance.guid
   key_name     = var.key_name
   standard_key = false


### PR DESCRIPTION
## Summary
 This PR is to resolve the ISSUE : [ISSUE-2121](https://github.com/IBM-Cloud/terraform-provider-ibm/issues/2121)

 ## Description

It was frequently observed that there were intermittent failures when `hpcs_init` script runs right after `ibm_resource_instance` `hpcs_instance` was created.

This PR is adding `time_sleep` in between them.
