### PR TITLE
ISSUE-2123: A method to cryptounit zeroize

### DIFF
--- a/examples/ibm-hpcs-crypto/scripts/packages/hpcs.py
+++ b/examples/ibm-hpcs-crypto/scripts/packages/hpcs.py
@@ -24,6 +24,21 @@ def crypto_unit_add(cu_num):
     selected_crypto = "".join(out)
     print (selected_crypto)
 
+def crypto_unit_zeroize(admin_password):
+    print("########### ibmcloud tke crypto_unit-zeroize ########### \n")
+    if admin_password == "":
+        print ("[ERROR] the password is invalid")
+        return
+    child = pexpect.spawn('ibmcloud tke crypto_unit-zeroize', encoding='utf-8')
+    child.expect (r'Answer.*>.* ')
+    time.sleep(1)
+    child.sendline ('y')
+    child.expect (r'admin.*>.* ')
+    child.sendline (admin_password)
+    out= child.readlines()
+    zeroized = "".join(out)
+    print (zeroized)
+
 def list_sig_keys():
     print("########### ibmcloud tke sigkeys ########### \n")
     child = pexpect.spawn('ibmcloud tke sigkeys', encoding='utf-8')
@@ -209,4 +224,3 @@ def list_mk_registry():
     mk_registry = "".join(out)
     print (mk_registry)
     return mk_registry
-    


### PR DESCRIPTION
## Summary
This PR is to resolve [ISSUE-2123](https://github.com/IBM-Cloud/terraform-provider-ibm/issues/2123) partially. The example `ibm-hpcs-crypto`: `terraform destroy` failure due to the cryptounits were not zeroized. 

## Description

A method to zeroize hpcs crypto_units so that `terraform destory` on HPCS service instance can be carried out.

 ## Tests
```
ibm_resource_instance.hpcs_instance[0]: Destroying... [id=crn:v1:staging:public:hs-crypto:us-south:a/3771957022b64706b0dc1c92b5153c20:3924aa3e-4ded-413f-8437-571302a31654::]
ibm_resource_instance.hpcs_instance[0]: Provisioning with 'local-exec'...
ibm_resource_instance.hpcs_instance[0] (local-exec): Executing: ["/bin/sh" "-c" "        python ./scripts/destroy.py\n"]
ibm_resource_instance.hpcs_instance[0] (local-exec): [INFO] TKE Files will be located at /system-tf-base/tke-files
ibm_resource_instance.hpcs_instance[0]: Still destroying... [id=crn:v1:staging:public:hs-crypto:us-sout...3924aa3e-4ded-413f-8437-571302a31654::, 10s elapsed]
ibm_resource_instance.hpcs_instance[0]: Still destroying... [id=crn:v1:staging:public:hs-crypto:us-sout...3924aa3e-4ded-413f-8437-571302a31654::, 20s elapsed]
ibm_resource_instance.hpcs_instance[0]: Still destroying... [id=crn:v1:staging:public:hs-crypto:us-sout...3924aa3e-4ded-413f-8437-571302a31654::, 30s elapsed]
ibm_resource_instance.hpcs_instance[0]: Still destroying... [id=crn:v1:staging:public:hs-crypto:us-sout...3924aa3e-4ded-413f-8437-571302a31654::, 40s elapsed]
ibm_resource_instance.hpcs_instance[0]: Still destroying... [id=crn:v1:staging:public:hs-crypto:us-sout...3924aa3e-4ded-413f-8437-571302a31654::, 50s elapsed]
ibm_resource_instance.hpcs_instance[0]: Still destroying... [id=crn:v1:staging:public:hs-crypto:us-sout...3924aa3e-4ded-413f-8437-571302a31654::, 1m0s elapsed]
ibm_resource_instance.hpcs_instance[0] (local-exec): {'admin_name': 'admin', 'admin_password': 'xxxx@xxxxxx', 'threshold': '1', 'rev_threshold': '1', 'random_mk': [{'description': 'key1', 'password': 'xxxx@xxx'}, {'description': 'key2', 'password': 'xxxx@xxxxx'}]}
ibm_resource_instance.hpcs_instance[0] (local-exec): ########### ibmcloud tke cryptounit-zeroize ###########


ibm_resource_instance.hpcs_instance[0] (local-exec): OK
ibm_resource_instance.hpcs_instance[0] (local-exec): The selected crypto units have been zeroized.

ibm_resource_instance.hpcs_instance[0]: Still destroying... [id=crn:v1:staging:public:hs-crypto:us-sout...3924aa3e-4ded-413f-8437-571302a31654::, 1m10s elapsed]
ibm_resource_instance.hpcs_instance[0]: Destruction complete after 1m18s
```
