### PR TITLE
added support for patch update for cluster worker nodes

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -382,6 +382,7 @@ github.com/hashicorp/terraform-config-inspect v0.0.0-20191212124732-c6ae6269b9d7
 github.com/hashicorp/terraform-config-inspect v0.0.0-20191212124732-c6ae6269b9d7/go.mod h1:p+ivJws3dpqbp1iP84+npOyAmTTOLMgCzrXd3GSdn/A=
 github.com/hashicorp/terraform-plugin-sdk v1.6.0 h1:Um5hsAL7kKsfTHtan8lybY/d03F2bHu4fjRB1H6Ag4U=
 github.com/hashicorp/terraform-plugin-sdk v1.6.0/go.mod h1:H5QLx/uhwfxBZ59Bc5SqT19M4i+fYt7LZjHTpbLZiAg=
+github.com/hashicorp/terraform-plugin-sdk v1.16.0 h1:NrkXMRjHErUPPTHQkZ6JIn6bByiJzGnlJzH1rVdNEuE=
 github.com/hashicorp/terraform-svchost v0.0.0-20191011084731-65d371908596 h1:hjyO2JsNZUKT1ym+FAdlBEkGPevazYsmVgIMw7dVELg=
 github.com/hashicorp/terraform-svchost v0.0.0-20191011084731-65d371908596/go.mod h1:kNDNcF7sN4DocDLBkQYz73HGKwN1ANB1blq4lIYLYvg=
 github.com/hashicorp/vault v0.10.4/go.mod h1:KfSyffbKxoVyspOdlaGVjIuwLobi07qD1bAbosPMpP0=

--- a/ibm/resource_ibm_container_cluster.go
+++ b/ibm/resource_ibm_container_cluster.go
@@ -218,6 +218,12 @@ func resourceIBMContainerCluster() *schema.Resource {
 				Description: "Kubernetes version info",
 			},
 
+			"patch_version": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "Kubernetes patch version",
+			},
+
 			"update_all_workers": {
 				Type:        schema.TypeBool,
 				Optional:    true,
@@ -787,7 +793,6 @@ func resourceIBMContainerClusterRead(d *schema.ResourceData, meta interface{}) e
 		d.Set("kube_version", strings.Split(cls.MasterKubeVersion, "_")[0]+"_openshift")
 	} else {
 		d.Set("kube_version", strings.Split(cls.MasterKubeVersion, "_")[0])
-
 	}
 	d.Set("albs", flattenAlbs(albs, "all"))
 	d.Set("resource_group_id", cls.ResourceGroupID)
@@ -834,7 +839,7 @@ func resourceIBMContainerClusterUpdate(d *schema.ResourceData, meta interface{})
 
 	clusterID := d.Id()
 
-	if (d.HasChange("kube_version") || d.HasChange("update_all_workers")) && !d.IsNewResource() {
+	if (d.HasChange("kube_version") || d.HasChange("update_all_workers")) || d.HasChange("patch_version") && !d.IsNewResource() {
 		if d.HasChange("kube_version") {
 			var masterVersion string
 			if v, ok := d.GetOk("kube_version"); ok {
@@ -855,10 +860,11 @@ func resourceIBMContainerClusterUpdate(d *schema.ResourceData, meta interface{})
 					"Error waiting for cluster (%s) version to be updated: %s", d.Id(), err)
 			}
 		}
-		// "update_all_workers" deafult is false, enable to true when all eorker nodes to be updated
+		// "update_all_workers" deafult is false, enable to true when all worker nodes to be updated
 		// with major and minor updates.
 		updateAllWorkers := d.Get("update_all_workers").(bool)
-		if updateAllWorkers {
+		if updateAllWorkers || d.HasChange("patch_version") {
+			patchVersion := d.Get("patch_version").(string)
 			workerFields, err := wrkAPI.List(clusterID, targetEnv)
 			if err != nil {
 				return fmt.Errorf("Error retrieving workers for cluster: %s", err)
@@ -871,7 +877,7 @@ func resourceIBMContainerClusterUpdate(d *schema.ResourceData, meta interface{})
 			waitForWorkerUpdate := d.Get("wait_for_worker_update").(bool)
 
 			for _, w := range workerFields {
-				if strings.Split(w.KubeVersion, "_")[0] != strings.Split(cluster.MasterKubeVersion, "_")[0] {
+				if strings.Split(w.KubeVersion, "_")[0] != strings.Split(cluster.MasterKubeVersion, "_")[0] || (strings.Split(w.KubeVersion, ".")[2] != patchVersion && strings.Split(cluster.MasterKubeVersion, ".")[2] != patchVersion) {
 					params := v1.WorkerUpdateParam{
 						Action: "update",
 					}

--- a/website/docs/r/container_cluster.html.markdown
+++ b/website/docs/r/container_cluster.html.markdown
@@ -196,6 +196,7 @@ The following arguments are supported:
 	* `private_endpoint` - Set this to true to configure the KMS private service endpoint. Default is false.
 * `force_delete_storage` - (Optional, bool) If set to true, force the removal of persistent storage associated with the cluster during cluster deletion. Default: false
     **NOTE**: Before doing terraform destroy if force_delete_storage param is introduced after provisioning the cluster, a terraform apply must be done before terraform destroy for force_delete_storage param to take effect.
+* `patch_version` - (Optional, string) Set this to update the worker nodes with the required patch version. Learn More about the Kuberentes version [here](https://cloud.ibm.com/docs/containers?topic=containers-cs_versions)
 ## Attribute Reference
 
 The following attributes are exported:

--- a/website/docs/r/container_vpc_cluster.html.markdown
+++ b/website/docs/r/container_vpc_cluster.html.markdown
@@ -148,6 +148,7 @@ Resource will wait for only the specified stage and complete execution. The supp
   Default value: IngressReady
 * `force_delete_storage` - (Optional, bool) If set to true, force the removal of persistent storage associated with the cluster during cluster deletion. Default: false
     **NOTE**: Before doing terraform destroy if force_delete_storage param is introduced after provisioning the cluster, a terraform apply must be done before terraform destroy for force_delete_storage param to take effect.
+* `patch_version` - (Optional, string) Set this to update the worker nodes with the required patch version. Learn More about the Kuberentes version [here](https://cloud.ibm.com/docs/containers?topic=containers-cs_versions)
 
 **NOTE**:
 1. For users on account to add tags to a resource, they must be assigned the appropriate access. Learn more about tags permission [here](https://cloud.ibm.com/docs/resources?topic=resources-access)


### PR DESCRIPTION
The current IKS cluster resources supports only Major and Minor version update. This PR supports the PATCH update supports.

The `patch_version` parameter can be used to achieve the same. This parameter can be used to Update Patch version. If  `patch_version`  is set to required version and if there is a change in the worker node's Patch version and input Patch version, the worker node will be updated.