### PR TITLE
fix broken link for IBM docs in Terraform Registry

### DIFF
--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -235,4 +235,4 @@ export IBMCLOUD_UAA_ENDPOINT="https://iam.cloud.ibm.com/cloudfoundry/login/<regi
 
 ## References 
 
-* [IBM Cloud Terraform Docs](https://cloud.ibm.com/docs/terraform?topic=terraform-tf-provider)
+* [IBM Cloud Terraform Docs](https://cloud.ibm.com/docs/terraform?topic=terraform-index-of-ibm-cloud-provider-plug-in-for-terraform-resources-and-data-sources)


### PR DESCRIPTION
link doesn't work, updating to our index of supported resources