### PR TITLE
Expose LUN Id of Block volume

### DIFF
--- a/ibm/resource_ibm_storage_block.go
+++ b/ibm/resource_ibm_storage_block.go
@@ -69,6 +69,12 @@ func resourceIBMStorageBlock() *schema.Resource {
 				Description: "Hostname",
 			},
 
+			"lunid": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "LUN Id",
+			},
+
 			"snapshot_capacity": {
 				Type:        schema.TypeInt,
 				Optional:    true,
@@ -346,6 +352,7 @@ func resourceIBMStorageBlockRead(d *schema.ResourceData, meta interface{}) error
 	d.Set("capacity", *storage.CapacityGb)
 	d.Set("volumename", *storage.Username)
 	d.Set("hostname", *storage.ServiceResourceBackendIpAddress)
+	d.Set("lunid", *storage.LunId)
 	d.Set("iops", iops)
 	if storage.SnapshotCapacityGb != nil {
 		snapshotCapacity, _ := strconv.Atoi(*storage.SnapshotCapacityGb)

--- a/ibm/resource_ibm_storage_block_test.go
+++ b/ibm/resource_ibm_storage_block_test.go
@@ -143,6 +143,8 @@ func TestAccIBMStorageBlock_hourly(t *testing.T) {
 						"ibm_storage_block.bs_endurance", "notes", "endurance notes"),
 					resource.TestCheckResourceAttr(
 						"ibm_storage_block.bs_endurance", "hourly_billing", "true"),
+					resource.TestCheckResourceAttrSet(
+						"ibm_storage_block.bs_endurance", "lunid"),
 					testAccCheckIBMResources("ibm_storage_block.bs_endurance", "datacenter",
 						"ibm_compute_vm_instance.storagevm2", "datacenter"),
 					// Performance Storage
@@ -157,6 +159,8 @@ func TestAccIBMStorageBlock_hourly(t *testing.T) {
 						"ibm_storage_block.bs_performance", "os_format_type", "Linux"),
 					resource.TestCheckResourceAttr(
 						"ibm_storage_block.bs_performance", "hourly_billing", "true"),
+					resource.TestCheckResourceAttrSet(
+						"ibm_storage_block.bs_performance", "lunid"),
 					resource.TestCheckResourceAttr(
 						"ibm_storage_block.bs_performance", "snapshot_capacity", "20"),
 					testAccCheckIBMResources("ibm_storage_block.bs_performance", "datacenter",
@@ -212,7 +216,7 @@ const testAccCheckIBMStorageBlockConfig_basic = `
 resource "ibm_compute_vm_instance" "storagevm2" {
     hostname = "storagevm2"
     domain = "example.com"
-    os_reference_code = "DEBIAN_8_64"
+    os_reference_code = "DEBIAN_9_64"
     datacenter = "dal05"
     network_speed = 100
     hourly_billing = true
@@ -244,7 +248,7 @@ const testAccCheckIBMStorageBlockConfig_update = `
 resource "ibm_compute_vm_instance" "storagevm2" {
     hostname = "storagevm2"
     domain = "example.com"
-    os_reference_code = "DEBIAN_8_64"
+    os_reference_code = "DEBIAN_9_64"
     datacenter = "dal05"
     network_speed = 100
     hourly_billing = true
@@ -280,7 +284,7 @@ const testAccCheckIBMStorageBlockWithTag = `
 resource "ibm_compute_vm_instance" "storagevm2" {
     hostname = "storagevm2"
     domain = "example.com"
-    os_reference_code = "DEBIAN_8_64"
+    os_reference_code = "DEBIAN_9_64"
     datacenter = "dal05"
     network_speed = 100
     hourly_billing = true
@@ -306,7 +310,7 @@ const testAccCheckIBMStorageBlockWithUpdatedTag = `
 resource "ibm_compute_vm_instance" "storagevm2" {
     hostname = "storagevm2"
     domain = "example.com"
-    os_reference_code = "DEBIAN_8_64"
+    os_reference_code = "DEBIAN_9_64"
     datacenter = "dal05"
     network_speed = 100
     hourly_billing = true
@@ -332,7 +336,7 @@ const testAccCheckIBMStorageBlockConfig_hourly = `
 resource "ibm_compute_vm_instance" "storagevm2" {
     hostname = "storagevm2"
     domain = "example.com"
-    os_reference_code = "DEBIAN_8_64"
+    os_reference_code = "DEBIAN_9_64"
     datacenter = "dal10"
     network_speed = 100
     hourly_billing = true
@@ -370,7 +374,7 @@ const testAccCheckIBMStorageBlockConfig_hourly_update = `
 resource "ibm_compute_vm_instance" "storagevm2" {
     hostname = "storagevm2"
     domain = "example.com"
-    os_reference_code = "DEBIAN_8_64"
+    os_reference_code = "DEBIAN_9_64"
     datacenter = "dal10"
     network_speed = 100
     hourly_billing = true

--- a/ibm/resource_ibm_storage_file.go
+++ b/ibm/resource_ibm_storage_file.go
@@ -24,7 +24,7 @@ import (
 const (
 	storagePackageType = "STORAGE_AS_A_SERVICE"
 	storageMask        = "id,billingItem.orderItem.order.id"
-	storageDetailMask  = "id,billingItem[location],storageTierLevel,provisionedIops,capacityGb,iops,storageType[keyName,description],username,serviceResourceBackendIpAddress,properties[type]" +
+	storageDetailMask  = "id,billingItem[location],storageTierLevel,provisionedIops,capacityGb,iops,lunId,storageType[keyName,description],username,serviceResourceBackendIpAddress,properties[type]" +
 		",serviceResourceName,allowedIpAddresses[id,ipAddress,subnetId,allowedHost[name,credential[username,password]]],allowedSubnets[allowedHost[name,credential[username,password]]],allowedHardware[allowedHost[name,credential[username,password]]],allowedVirtualGuests[id,allowedHost[name,credential[username,password]]],snapshotCapacityGb,osType,notes,billingItem[hourlyFlag],serviceResource[datacenter[name]],schedules[dayOfWeek,hour,minute,retentionCount,type[keyname,name]],iscsiTargetIpAddresses"
 	itemMask        = "id,capacity,description,units,keyName,capacityMinimum,capacityMaximum,prices[id,categories[id,name,categoryCode],capacityRestrictionMinimum,capacityRestrictionMaximum,capacityRestrictionType,locationGroupId],itemCategory[categoryCode]"
 	enduranceType   = "Endurance"

--- a/website/docs/r/storage_block.html.markdown
+++ b/website/docs/r/storage_block.html.markdown
@@ -87,6 +87,7 @@ The following attributes are exported:
 * `id` - The unique identifier of the storage.
 * `hostname` - The fully qualified domain name of the storage.
 * `volumename` - The name of the storage volume.
+* `lunid` - The LUN Id of the storage device.
 * `allowed_virtual_guest_info` - Deprecated please use `allowed_host_info` instead.
 * `allowed_hardware_info` - Deprecated please use `allowed_host_info` instead.
 * `allowed_host_info` - The user name, password, and host IQN of the hosts with access to the storage.


### PR DESCRIPTION
Resolves #1491 

![image](https://user-images.githubusercontent.com/2170339/105775485-c9ac2a00-5f5e-11eb-898d-80e81234af7a.png)

**Use case:**

* The LUN Id is required for creating a `kubernetes_persistent_volume` resource for the IBM Cloud [Block Storage Attacher](https://cloud.ibm.com/docs/openshift?topic=openshift-utilities#block_storage_attacher) plug-in.

EDIT: Where should the documentation changes be made? I just realised that the markdown change I made for the output parameters wouldn't get picked up as it's a completely different structure to the [published docs](https://cloud.ibm.com/docs/terraform?topic=terraform-infrastructure-resources#storage-block)