### PR TITLE
Event Streams fix: reset Id to be empty when topic does not exist

### DIFF
--- a/ibm/data_source_ibm_event_streams_topic.go
+++ b/ibm/data_source_ibm_event_streams_topic.go
@@ -50,7 +50,7 @@ func dataSourceIBMEventStreamsTopicRead(d *schema.ResourceData, meta interface{}
 	adminClient, instanceCRN, err := createSaramaAdminClient(d, meta)
 	if err != nil {
 		log.Printf("[DEBUG]dataSourceIBMEventStreamsTopicRead createSaramaAdminClient err %s", err)
-		return nil
+		return err
 	}
 	topics, err := adminClient.ListTopics()
 	if err != nil {

--- a/ibm/resource_ibm_event_streams_topic.go
+++ b/ibm/resource_ibm_event_streams_topic.go
@@ -154,8 +154,9 @@ func resourceIBMEventStreamsTopicRead(d *schema.ResourceData, meta interface{}) 
 			return nil
 		}
 	}
-	log.Printf("[DEBUG] resourceIBMEventStreamsTopicRead topic %s does not exist", topicName)
-	return fmt.Errorf("topic %s does not exist", topicName)
+	log.Printf("[INFO] resourceIBMEventStreamsTopicRead topic %s does not exist", topicName)
+	d.SetId("")
+	return nil
 }
 
 func resourceIBMEventStreamsTopicUpdate(d *schema.ResourceData, meta interface{}) error {


### PR DESCRIPTION
tested this scenario:
1. create Event Streams instance and topic
```
$terraform apply -auto-approve 
data.ibm_resource_group.group: Refreshing state...
ibm_resource_instance.es_instance_1: Creating...
ibm_resource_instance.es_instance_1: Still creating... [10s elapsed]
ibm_resource_instance.es_instance_1: Creation complete after 16s [id=crn:v1:bluemix:public:messagehub:us-south:a/2b658d1bce63465653497228f9736952:0f97b516-4059-4f64-ab08-a629da76c74e::]
ibm_event_streams_topic.es_topic_1: Creating...
ibm_event_streams_topic.es_topic_1: Creation complete after 5s [id=crn:v1:bluemix:public:messagehub:us-south:a/2b658d1bce63465653497228f9736952:0f97b516-4059-4f64-ab08-a629da76c74e:topic:my-es-topic]

Apply complete! Resources: 2 added, 0 changed, 0 destroyed.
```

2. delete topic
```
$bx es init -i terraform-integration-1
API Endpoint:		https://kcvkxdympxmdnyzh.svc04.us-south.eventstreams.cloud.ibm.com
OK

$bx es topic-delete my-es-topic -f
Topic my-es-topic deleted successfully
OK
```

3. re-apply
```
$terraform apply -auto-approve
data.ibm_resource_group.group: Refreshing state...
ibm_resource_instance.es_instance_1: Refreshing state... [id=crn:v1:bluemix:public:messagehub:us-south:a/2b658d1bce63465653497228f9736952:0f97b516-4059-4f64-ab08-a629da76c74e::]
ibm_event_streams_topic.es_topic_1: Refreshing state... [id=crn:v1:bluemix:public:messagehub:us-south:a/2b658d1bce63465653497228f9736952:0f97b516-4059-4f64-ab08-a629da76c74e:topic:my-es-topic]
ibm_event_streams_topic.es_topic_1: Creating...
ibm_event_streams_topic.es_topic_1: Creation complete after 4s [id=crn:v1:bluemix:public:messagehub:us-south:a/2b658d1bce63465653497228f9736952:0f97b516-4059-4f64-ab08-a629da76c74e:topic:my-es-topic]

Apply complete! Resources: 1 added, 0 changed, 0 destroyed.
```