### PR TITLE
Use IAM Autheticator rather than BearerToken when possible

### DIFF
--- a/ibm/config.go
+++ b/ibm/config.go
@@ -1003,8 +1003,13 @@ func (c *Config) ClientSession() (interface{}, error) {
 	}
 	session.kmsAPI = kmsAPIclient
 
-	var authenticator *core.BearerTokenAuthenticator
-	if strings.HasPrefix(sess.BluemixSession.Config.IAMAccessToken, "Bearer") {
+	var authenticator core.Authenticator
+	if c.BluemixAPIKey != "" {
+		authenticator = &core.IamAuthenticator{
+			ApiKey: c.BluemixAPIKey,
+			URL:    envFallBack([]string{"IBMCLOUD_IAM_API_ENDPOINT"}, "https://iam.cloud.ibm.com") + "/identity/token",
+		}
+	} else if strings.HasPrefix(sess.BluemixSession.Config.IAMAccessToken, "Bearer") {
 		authenticator = &core.BearerTokenAuthenticator{
 			BearerToken: sess.BluemixSession.Config.IAMAccessToken[7:],
 		}


### PR DESCRIPTION
This PR creates an IAM authenticator when the IAM key is available, since this will be more robust than using the Bearer Token  authenticator.  The IAM authenticator will obtain and refresh the bearer token as needed.