### PR TITLE
Enhancement : added default routing table id to output parameters of ibm_is_vpc

### DIFF
--- a/ibm/data_source_ibm_is_vpc.go
+++ b/ibm/data_source_ibm_is_vpc.go
@@ -25,6 +25,12 @@ func dataSourceIBMISVPC() *schema.Resource {
 				Computed: true,
 			},
 
+			isVPCDefaultRoutingTable: {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "Default routing table associated with VPC",
+			},
+
 			isVPCName: {
 				Type:         schema.TypeString,
 				Required:     true,
@@ -516,6 +522,9 @@ func vpcGetByName(d *schema.ResourceData, meta interface{}, name string) error {
 				d.Set(isVPCDefaultNetworkACL, *vpc.DefaultNetworkACL.ID)
 			} else {
 				d.Set(isVPCDefaultNetworkACL, nil)
+			}
+			if vpc.DefaultRoutingTable != nil {
+				d.Set(isVPCDefaultRoutingTable, *vpc.DefaultRoutingTable.ID)
 			}
 			if vpc.DefaultSecurityGroup != nil {
 				d.Set(isVPCIDefaultSecurityGroup, *vpc.DefaultSecurityGroup.ID)

--- a/ibm/resource_ibm_is_vpc.go
+++ b/ibm/resource_ibm_is_vpc.go
@@ -19,6 +19,7 @@ import (
 const (
 	isVPCDefaultNetworkACL          = "default_network_acl"
 	isVPCIDefaultSecurityGroup      = "default_security_group"
+	isVPCDefaultRoutingTable        = "default_routing_table"
 	isVPCName                       = "name"
 	isVPCResourceGroup              = "resource_group"
 	isVPCStatus                     = "status"
@@ -87,6 +88,12 @@ func resourceIBMISVPC() *schema.Resource {
 				Computed:    true,
 				Deprecated:  "This field is deprecated",
 				Description: "Default network ACL",
+			},
+
+			isVPCDefaultRoutingTable: {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "Default routing table associated with VPC",
 			},
 
 			isVPCClassicAccess: {
@@ -795,6 +802,9 @@ func vpcGet(d *schema.ResourceData, meta interface{}, id string) error {
 		d.Set(isVPCIDefaultSecurityGroup, *vpc.DefaultSecurityGroup.ID)
 	} else {
 		d.Set(isVPCIDefaultSecurityGroup, nil)
+	}
+	if vpc.DefaultRoutingTable != nil {
+		d.Set(isVPCDefaultRoutingTable, *vpc.DefaultRoutingTable.ID)
 	}
 	tags, err := GetTagsUsingCRN(meta, *vpc.CRN)
 	if err != nil {

--- a/website/docs/d/is_vpc.html.markdown
+++ b/website/docs/d/is_vpc.html.markdown
@@ -38,6 +38,7 @@ The following attributes are exported:
 * `status` - The status of VPC.
 * `default_network_acl` - ID of the default network ACL.
 * `default_security_group` - The unique identifier of the VPC default security group.
+* `default_routing_table` - The unique identifier of the VPC default routing table.
 * `classic_access` - Indicates whether this VPC is connected to Classic Infrastructure.
 * `resource_group` - The resource group ID where the VPC created.
 * `tags` - Tags associated with the instance.

--- a/website/docs/r/is_vpc.html.markdown
+++ b/website/docs/r/is_vpc.html.markdown
@@ -48,6 +48,7 @@ The following attributes are exported:
 * `id` - The unique identifier of the VPC.
 * `crn` - The CRN of VPC.
 * `default_security_group` - The unique identifier of the VPC default security group.
+* `default_routing_table` - The unique identifier of the VPC default routing table.
 * `default_network_acl` - The unique identifier of the VPC default Network ACL.
 * `status` - The status of VPC.
 * `cse_source_addresses` - A list describing the cloud service endpoint source ip adresses and zones. The nested cse_source_addresses block have the following structure:


### PR DESCRIPTION
Added an output parameter "default_routing_table" which returns the id of the default routing table created