### PR TITLE
Enhancement: renaming of default routing table, security group, netwo…

### DIFF
--- a/ibm/data_source_ibm_is_vpc.go
+++ b/ibm/data_source_ibm_is_vpc.go
@@ -40,6 +40,24 @@ func dataSourceIBMISVPC() *schema.Resource {
 				ValidateFunc: InvokeDataSourceValidator("ibm_is_subnet", isVPCName),
 			},
 
+			isVPCDefaultNetworkACLName: {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "Default Network ACL name",
+			},
+
+			isVPCIDefaultSecurityGroupName: {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "Default security group name",
+			},
+
+			isVPCDefaultRoutingTableName: {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "Default routing table name",
+			},
+
 			isVPCResourceGroup: {
 				Type:     schema.TypeString,
 				Computed: true,
@@ -521,6 +539,9 @@ func vpcGetByName(d *schema.ResourceData, meta interface{}, name string) error {
 			d.Set(isVPCClassicAccess, *vpc.ClassicAccess)
 			d.Set(isVPCStatus, *vpc.Status)
 			d.Set(isVPCResourceGroup, *vpc.ResourceGroup.ID)
+			d.Set(isVPCDefaultNetworkACLName, *vpc.DefaultNetworkACL.Name)
+			d.Set(isVPCDefaultRoutingTableName, *vpc.DefaultRoutingTable.Name)
+			d.Set(isVPCIDefaultSecurityGroupName, *vpc.DefaultSecurityGroup.Name)
 			if vpc.DefaultNetworkACL != nil {
 				d.Set(isVPCDefaultNetworkACL, *vpc.DefaultNetworkACL.ID)
 			} else {

--- a/ibm/data_source_ibm_is_vpc_test.go
+++ b/ibm/data_source_ibm_is_vpc_test.go
@@ -29,6 +29,9 @@ func TestAccIBMISVPCDatasource_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"data.ibm_is_vpc.ds_vpc", "tags.#", "1"),
 					resource.TestCheckResourceAttrSet("data.ibm_is_vpc.ds_vpc", "cse_source_addresses.#"),
+					resource.TestCheckResourceAttrSet("data.ibm_is_vpc.ds_vpc", "default_network_acl_name"),
+					resource.TestCheckResourceAttrSet("data.ibm_is_vpc.ds_vpc", "default_security_group_name"),
+					resource.TestCheckResourceAttrSet("data.ibm_is_vpc.ds_vpc", "default_routing_table_name"),
 				),
 			},
 		},

--- a/ibm/resource_ibm_is_vpc.go
+++ b/ibm/resource_ibm_is_vpc.go
@@ -26,6 +26,9 @@ const (
 	isVPCIDefaultSecurityGroup      = "default_security_group"
 	isVPCDefaultRoutingTable        = "default_routing_table"
 	isVPCName                       = "name"
+	isVPCDefaultNetworkACLName      = "default_network_acl_name"
+	isVPCIDefaultSecurityGroupName  = "default_security_group_name"
+	isVPCDefaultRoutingTableName    = "default_routing_table_name"
 	isVPCResourceGroup              = "resource_group"
 	isVPCStatus                     = "status"
 	isVPCDeleting                   = "deleting"
@@ -115,6 +118,30 @@ func resourceIBMISVPC() *schema.Resource {
 				ForceNew:     false,
 				ValidateFunc: InvokeValidator("ibm_is_vpc", isVPCName),
 				Description:  "VPC name",
+			},
+
+			isVPCDefaultNetworkACLName: {
+				Type:         schema.TypeString,
+				Optional:     true,
+				Computed:     true,
+				ValidateFunc: InvokeValidator("ibm_is_vpc", isVPCDefaultNetworkACLName),
+				Description:  "Default Network ACL name",
+			},
+
+			isVPCIDefaultSecurityGroupName: {
+				Type:         schema.TypeString,
+				Optional:     true,
+				Computed:     true,
+				ValidateFunc: InvokeValidator("ibm_is_vpc", isVPCIDefaultSecurityGroupName),
+				Description:  "Default security group name",
+			},
+
+			isVPCDefaultRoutingTableName: {
+				Type:         schema.TypeString,
+				Optional:     true,
+				Computed:     true,
+				ValidateFunc: InvokeValidator("ibm_is_vpc", isVPCDefaultRoutingTableName),
+				Description:  "Default routing table name",
 			},
 
 			isVPCResourceGroup: {
@@ -349,6 +376,33 @@ func resourceIBMISVPCValidator() *ResourceValidator {
 			Regexp:                     `^([a-z]|[a-z][-a-z0-9]*[a-z0-9])$`,
 			MinValueLength:             1,
 			MaxValueLength:             63})
+	validateSchema = append(validateSchema,
+		ValidateSchema{
+			Identifier:                 isVPCDefaultNetworkACLName,
+			ValidateFunctionIdentifier: ValidateRegexpLen,
+			Type:                       TypeString,
+			Required:                   true,
+			Regexp:                     `^([a-z]|[a-z][-a-z0-9]*[a-z0-9])$`,
+			MinValueLength:             1,
+			MaxValueLength:             63})
+	validateSchema = append(validateSchema,
+		ValidateSchema{
+			Identifier:                 isVPCIDefaultSecurityGroupName,
+			ValidateFunctionIdentifier: ValidateRegexpLen,
+			Type:                       TypeString,
+			Required:                   true,
+			Regexp:                     `^([a-z]|[a-z][-a-z0-9]*[a-z0-9])$`,
+			MinValueLength:             1,
+			MaxValueLength:             63})
+	validateSchema = append(validateSchema,
+		ValidateSchema{
+			Identifier:                 isVPCDefaultRoutingTableName,
+			ValidateFunctionIdentifier: ValidateRegexpLen,
+			Type:                       TypeString,
+			Required:                   true,
+			Regexp:                     `^([a-z]|[a-z][-a-z0-9]*[a-z0-9])$`,
+			MinValueLength:             1,
+			MaxValueLength:             63})
 
 	ibmISVPCResourceValidator := ResourceValidator{ResourceName: "ibm_is_vpc", Schema: validateSchema}
 	return &ibmISVPCResourceValidator
@@ -486,6 +540,19 @@ func vpcCreate(d *schema.ResourceData, meta interface{}, name, apm, rg string, i
 		return fmt.Errorf("Error while creating VPC err %s\n%s", err, response)
 	}
 	d.SetId(*vpc.ID)
+
+	if defaultSGName, ok := d.GetOk(isVPCIDefaultSecurityGroupName); ok {
+		sgNameUpdate(sess, *vpc.DefaultSecurityGroup.ID, defaultSGName.(string))
+	}
+
+	if defaultRTName, ok := d.GetOk(isVPCDefaultRoutingTableName); ok {
+		rtNameUpdate(sess, *vpc.ID, *vpc.DefaultRoutingTable.ID, defaultRTName.(string))
+	}
+
+	if defaultACLName, ok := d.GetOk(isVPCDefaultNetworkACLName); ok {
+		nwaclNameUpdate(sess, *vpc.DefaultNetworkACL.ID, defaultACLName.(string))
+	}
+
 	log.Printf("[INFO] VPC : %s", *vpc.ID)
 	_, err = isWaitForVPCAvailable(sess, d.Id(), d.Timeout(schema.TimeoutCreate))
 	if err != nil {
@@ -799,17 +866,20 @@ func vpcGet(d *schema.ResourceData, meta interface{}, id string) error {
 	if vpc.DefaultNetworkACL != nil {
 		log.Printf("[DEBUG] vpc default network acl is not null :%s", *vpc.DefaultNetworkACL.ID)
 		d.Set(isVPCDefaultNetworkACL, *vpc.DefaultNetworkACL.ID)
+		d.Set(isVPCDefaultNetworkACLName, *vpc.DefaultNetworkACL.Name)
 	} else {
 		log.Printf("[DEBUG] vpc default network acl is  null")
 		d.Set(isVPCDefaultNetworkACL, nil)
 	}
 	if vpc.DefaultSecurityGroup != nil {
 		d.Set(isVPCIDefaultSecurityGroup, *vpc.DefaultSecurityGroup.ID)
+		d.Set(isVPCIDefaultSecurityGroupName, *vpc.DefaultSecurityGroup.Name)
 	} else {
 		d.Set(isVPCIDefaultSecurityGroup, nil)
 	}
 	if vpc.DefaultRoutingTable != nil {
 		d.Set(isVPCDefaultRoutingTable, *vpc.DefaultRoutingTable.ID)
+		d.Set(isVPCDefaultRoutingTableName, *vpc.DefaultRoutingTable.Name)
 	}
 	tags, err := GetTagsUsingCRN(meta, *vpc.CRN)
 	if err != nil {
@@ -1085,6 +1155,23 @@ func vpcUpdate(d *schema.ResourceData, meta interface{}, id, name string, hasCha
 				"Error on update of resource vpc (%s) tags: %s", d.Id(), err)
 		}
 	}
+
+	if d.HasChange(isVPCIDefaultSecurityGroupName) {
+		if defaultSGName, ok := d.GetOk(isVPCIDefaultSecurityGroupName); ok {
+			sgNameUpdate(sess, d.Get(isVPCIDefaultSecurityGroup).(string), defaultSGName.(string))
+		}
+	}
+	if d.HasChange(isVPCDefaultRoutingTableName) {
+		if defaultRTName, ok := d.GetOk(isVPCDefaultRoutingTableName); ok {
+			rtNameUpdate(sess, id, d.Get(isVPCDefaultRoutingTable).(string), defaultRTName.(string))
+		}
+	}
+	if d.HasChange(isVPCDefaultNetworkACLName) {
+		if defaultACLName, ok := d.GetOk(isVPCDefaultNetworkACLName); ok {
+			nwaclNameUpdate(sess, d.Get(isVPCDefaultNetworkACL).(string), defaultACLName.(string))
+		}
+	}
+
 	if hasChanged {
 		updateVpcOptions := &vpcv1.UpdateVPCOptions{
 			ID: &id,
@@ -1317,4 +1404,60 @@ func resourceIBMVPCHash(v interface{}) int {
 	buf.WriteString(fmt.Sprintf("%s",
 		strings.ToLower(v.(string))))
 	return hashcode.String(buf.String())
+}
+
+func nwaclNameUpdate(sess *vpcv1.VpcV1, id, name string) error {
+	updateNetworkACLOptions := &vpcv1.UpdateNetworkACLOptions{
+		ID: &id,
+	}
+	networkACLPatchModel := &vpcv1.NetworkACLPatch{
+		Name: &name,
+	}
+	networkACLPatch, err := networkACLPatchModel.AsPatch()
+	if err != nil {
+		return fmt.Errorf("Error calling asPatch for NetworkACLPatch: %s", err)
+	}
+	updateNetworkACLOptions.NetworkACLPatch = networkACLPatch
+	_, response, err := sess.UpdateNetworkACL(updateNetworkACLOptions)
+	if err != nil {
+		return fmt.Errorf("Error Updating Network ACL(%s) name : %s\n%s", id, err, response)
+	}
+	return nil
+}
+
+func sgNameUpdate(sess *vpcv1.VpcV1, id, name string) error {
+	updateSecurityGroupOptions := &vpcv1.UpdateSecurityGroupOptions{
+		ID: &id,
+	}
+	securityGroupPatchModel := &vpcv1.SecurityGroupPatch{
+		Name: &name,
+	}
+	securityGroupPatch, err := securityGroupPatchModel.AsPatch()
+	if err != nil {
+		return fmt.Errorf("Error calling asPatch for SecurityGroupPatch: %s", err)
+	}
+	updateSecurityGroupOptions.SecurityGroupPatch = securityGroupPatch
+	_, response, err := sess.UpdateSecurityGroup(updateSecurityGroupOptions)
+	if err != nil {
+		return fmt.Errorf("Error Updating Security Group name : %s\n%s", err, response)
+	}
+	return nil
+}
+
+func rtNameUpdate(sess *vpcv1.VpcV1, vpcID, id, name string) error {
+	updateVpcRoutingTableOptions := new(vpcv1.UpdateVPCRoutingTableOptions)
+	updateVpcRoutingTableOptions.VPCID = &vpcID
+	updateVpcRoutingTableOptions.ID = &id
+	routingTablePatchModel := new(vpcv1.RoutingTablePatch)
+	routingTablePatchModel.Name = &name
+	routingTablePatchModelAsPatch, asPatchErr := routingTablePatchModel.AsPatch()
+	if asPatchErr != nil {
+		return fmt.Errorf("Error calling asPatch for RoutingTablePatchModel: %s", asPatchErr)
+	}
+	updateVpcRoutingTableOptions.RoutingTablePatch = routingTablePatchModelAsPatch
+	_, response, err := sess.UpdateVPCRoutingTable(updateVpcRoutingTableOptions)
+	if err != nil {
+		return fmt.Errorf("Error Updating Routing table name %s\n%s", err, response)
+	}
+	return nil
 }

--- a/ibm/resource_ibm_is_vpc_test.go
+++ b/ibm/resource_ibm_is_vpc_test.go
@@ -33,6 +33,12 @@ func TestAccIBMISVPC_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"ibm_is_vpc.testacc_vpc", "name", name1),
 					resource.TestCheckResourceAttr(
+						"ibm_is_vpc.testacc_vpc", "default_network_acl_name", "dnwacln"),
+					resource.TestCheckResourceAttr(
+						"ibm_is_vpc.testacc_vpc", "default_security_group_name", "dsgn"),
+					resource.TestCheckResourceAttr(
+						"ibm_is_vpc.testacc_vpc", "default_routing_table_name", "drtn"),
+					resource.TestCheckResourceAttr(
 						"ibm_is_vpc.testacc_vpc", "tags.#", "2"),
 				),
 			},
@@ -168,6 +174,9 @@ func testAccCheckIBMISVPCConfig(name string) string {
 	return fmt.Sprintf(`
 resource "ibm_is_vpc" "testacc_vpc" {
 	name = "%s"
+	default_network_acl_name = "dnwacln"
+    default_security_group_name = "dsgn"
+    default_routing_table_name = "drtn"
 	tags = ["Tag1", "tag2"]
 }`, name)
 

--- a/website/docs/d/is_vpc.html.markdown
+++ b/website/docs/d/is_vpc.html.markdown
@@ -64,3 +64,6 @@ The following attributes are exported:
     * `code` - The ICMP traffic code to allow.
     * `port_min` - The inclusive lower bound of TCP port range. 
     * `port_max` - The inclusive upper bound of TCP port range. 
+* `default_network_acl_name` - The name of the default network acl.
+* `default_security_group_name` - The name of the default security group.
+* `default_routing_table_name` - The name of the default routing table.

--- a/website/docs/r/is_vpc.html.markdown
+++ b/website/docs/r/is_vpc.html.markdown
@@ -41,6 +41,9 @@ The following arguments are supported:
 * `name` - (Required, string) The name of the VPC.
 * `resource_group` - (Optional, Forces new resource, string) The resource group ID where the VPC to be created
 * `tags` - (Optional, array of strings) Tags associated with the instance.
+* `default_network_acl_name` - (Optional, string) The name of the default network acl.
+* `default_security_group_name` - (Optional, string) The name of the default security group.
+* `default_routing_table_name` - (Optional, string) The name of the default routing table.
 
 ## Attribute Reference
 


### PR DESCRIPTION
At the time of vpc creation, default routing table, security group and Network ACL are created with default names. Adding an enhancement to make the names configurable.


=== RUN   TestAccIBMISVPC_basic
--- PASS: TestAccIBMISVPC_basic (224.07s)
PASS
ok  	github.com/IBM-Cloud/terraform-provider-ibm/ibm	227.212s