### PR TITLE
enhancement : added tag support for network ACL

### DIFF
--- a/ibm/resource_ibm_is_networkacls_test.go
+++ b/ibm/resource_ibm_is_networkacls_test.go
@@ -50,6 +50,8 @@ func TestNetworkACLGen2(t *testing.T) {
 						"ibm_is_network_acl.isExampleACL", "name", "is-example-acl"),
 					resource.TestCheckResourceAttr(
 						"ibm_is_network_acl.isExampleACL", "rules.#", "2"),
+					resource.TestCheckResourceAttr(
+						"ibm_is_network_acl.isExampleACL", "tags.#", "2"),
 				),
 			},
 		},
@@ -133,8 +135,13 @@ func testAccCheckIBMISNetworkACLExists(n, nwACL string) resource.TestCheckFunc {
 
 func testAccCheckIBMISNetworkACLConfig() string {
 	return fmt.Sprintf(`
+	resource "ibm_is_vpc" "testacc_vpc" {
+		name = "tf-nwacl-vpc"
+	  }
+
 	resource "ibm_is_network_acl" "isExampleACL" {
 		name = "is-example-acl"
+		vpc  = ibm_is_vpc.testacc_vpc.id
 		rules {
 		  name        = "outbound"
 		  action      = "allow"
@@ -175,6 +182,7 @@ func testAccCheckIBMISNetworkACLConfig1() string {
 
 	resource "ibm_is_network_acl" "isExampleACL" {
 		name = "is-example-acl"
+		tags = ["Tag1", "tag2"]
 		vpc  = ibm_is_vpc.testacc_vpc.id
 		rules {
 		  name        = "outbound"

--- a/website/docs/r/is_network_acl.html.markdown
+++ b/website/docs/r/is_network_acl.html.markdown
@@ -144,6 +144,7 @@ Nested `rules` blocks have the following structure:
 		* `port_min` - (Optional, int) The lowest port in the range of ports to be matched; if unspecified, 1 is used.
 		* `source_port_max` - (Optional, int) The highest port in the range of ports to be matched; if unspecified, 65535 is used.
 		* `source_port_min` - (Optional, int) The lowest port in the range of ports to be matched; if unspecified, 1 is used.
+* `tags` - (Optional, list(string)) Tags associated with the network ACL.
 		
 
 ## Attribute Reference
@@ -156,6 +157,7 @@ Nested `rules` blocks have the following structure:
 	* `id` - The rule id.
 	* `ip_version` - The IP version of the rule.
 	* `subnets` - The subnets for the ACL rule.
+* `crn` - The CRN of the network ACL.
 
 ## Import
 


### PR DESCRIPTION
=== RUN   TestNetworkACLGen1
siv  map[ibm_is_network_acl.isExampleACL:Type = ibm_is_network_acl ibm_is_vpc.testacc_vpc:Type = ibm_is_vpc]
--- PASS: TestNetworkACLGen1 (87.78s)
PASS
ok  	github.com/IBM-Cloud/terraform-provider-ibm/ibm	91.492s

=== RUN   TestNetworkACLGen2
siv  map[ibm_is_network_acl.isExampleACL:Type = ibm_is_network_acl ibm_is_vpc.testacc_vpc:Type = ibm_is_vpc]
--- PASS: TestNetworkACLGen2 (79.80s)
PASS
ok  	github.com/IBM-Cloud/terraform-provider-ibm/ibm	82.648s