### PR TITLE
Fix the default RC endpoint

### DIFF
--- a/ibm/config.go
+++ b/ibm/config.go
@@ -1657,7 +1657,7 @@ func (c *Config) ClientSession() (interface{}, error) {
 
 	resourceManagerOptions := &resourcemanager.ResourceManagerV2Options{
 		Authenticator: authenticator,
-		URL:           envFallBack([]string{"IBMCLOUD_RESOURCE_MANAGER_API_ENDPOINT"}, "https://resource-controller.cloud.ibm.com/v2"),
+		URL:           envFallBack([]string{"IBMCLOUD_RESOURCE_MANAGER_API_ENDPOINT"}, resourcemanager.DefaultServiceURL),
 	}
 	resourceManagerClient, err := resourcemanager.NewResourceManagerV2(resourceManagerOptions)
 	if err != nil {


### PR DESCRIPTION
Default endpoint should not include `/v2`