### PR TITLE
Fix: default resource group in testcases

### DIFF
--- a/ibm/data_source_ibm_event_streams_topic_test.go
+++ b/ibm/data_source_ibm_event_streams_topic_test.go
@@ -61,7 +61,7 @@ func TestAccIBMEventStreamsTopicDataSourceBasic(t *testing.T) {
 func testAccCheckIBMEventStreamsTopicDataSourceConfigBasic(instancecName, topicName string) string {
 	return fmt.Sprintf(`
 	data "ibm_resource_group" "my_group" {
-		name = "default"
+		is_default=true
 	  }
 	data "ibm_resource_instance" "es_instance" {
 		resource_group_id = data.ibm_resource_group.my_group.id

--- a/ibm/data_source_ibm_iam_service_policy_test.go
+++ b/ibm/data_source_ibm_iam_service_policy_test.go
@@ -102,7 +102,7 @@ resource "ibm_iam_service_policy" "policy" {
 }
 
 data "ibm_resource_group" "group" {
-  name = "default"
+  is_default=true
 }
 
 resource "ibm_iam_service_policy" "policy1" {

--- a/ibm/data_source_ibm_iam_user_policy_test.go
+++ b/ibm/data_source_ibm_iam_user_policy_test.go
@@ -93,7 +93,7 @@ resource "ibm_iam_user_policy" "policy" {
 }
 
 data "ibm_resource_group" "group" {
-  name = "default"
+  is_default=true
 }
 
 resource "ibm_iam_user_policy" "policy1" {

--- a/ibm/data_source_ibm_is_flow_logs_test.go
+++ b/ibm/data_source_ibm_is_flow_logs_test.go
@@ -93,7 +93,7 @@ func testAccCheckIBMISFlowLogsDataSourceConfig(vpcname, name, flowlogname, sshna
 	  }
 
 	data "ibm_resource_group" "cos_group" {
-		name = "default"
+		is_default=true
 	}
 	  
 	resource "ibm_resource_instance" "instance2" {

--- a/ibm/data_source_ibm_private_dns_glb_monitors_test.go
+++ b/ibm/data_source_ibm_private_dns_glb_monitors_test.go
@@ -40,7 +40,7 @@ func testAccCheckIBMPrivateDNSGlbMonitordDataSConfig(vpcname, riname, zonename, 
 	// status filter defaults to empty
 	return fmt.Sprintf(`
 	data "ibm_resource_group" "rg" {
-		name = "default"
+		is_default=true
 	}
 
     resource "ibm_is_vpc" "test-pdns-vpc" {

--- a/ibm/data_source_ibm_private_dns_glb_pools_test.go
+++ b/ibm/data_source_ibm_private_dns_glb_pools_test.go
@@ -40,7 +40,7 @@ func testAccCheckIBMPrivateDNSGlbPoolsDataSourceConfig(vpcname, riname, zonename
 	// status filter defaults to empty
 	return fmt.Sprintf(`
 	data "ibm_resource_group" "rg" {
-		name = "default"
+		is_default=true
 	}
     resource "ibm_is_vpc" "test-pdns-vpc" {
 		depends_on = [data.ibm_resource_group.rg]

--- a/ibm/data_source_ibm_private_dns_glbs_test.go
+++ b/ibm/data_source_ibm_private_dns_glbs_test.go
@@ -38,7 +38,7 @@ func TestAccIBMPrivateDNSGlbLoadBalancersDataSource_basic(t *testing.T) {
 func testAccCheckIBMPrivateDNSGlbLoadBalancerdDataSConfig(riname, zonename, poolname, lbname string) string {
 	return fmt.Sprintf(`
 	data "ibm_resource_group" "rg" {
-		name = "default"
+		is_default=true
 	  }
 
 	  resource "ibm_resource_instance" "test_pdns_instance" {

--- a/ibm/data_source_ibm_private_dns_permitted_network_test.go
+++ b/ibm/data_source_ibm_private_dns_permitted_network_test.go
@@ -36,7 +36,7 @@ func testAccCheckIBMpDNSPermittedNetworksDataSourceConfig(riname, vpcname, zonen
 	// status filter defaults to empty
 	return fmt.Sprintf(`
 	data "ibm_resource_group" "rg" {
-		name = "default"
+		is_default=true
 	}
 
 	resource "ibm_resource_instance" "test-pdns-instance" {

--- a/ibm/data_source_ibm_private_dns_resource_records_test.go
+++ b/ibm/data_source_ibm_private_dns_resource_records_test.go
@@ -37,7 +37,7 @@ func testAccCheckIBMPrivateDNSResourceRecordsDataSourceConfig(riname, zonename, 
 	// status filter defaults to empty
 	return fmt.Sprintf(`
 	data "ibm_resource_group" "rg" {
-		name = "default"
+		is_default=true
 	}
 
 	resource "ibm_resource_instance" "test-pdns-instance" {

--- a/ibm/data_source_ibm_private_dns_zones_test.go
+++ b/ibm/data_source_ibm_private_dns_zones_test.go
@@ -35,7 +35,7 @@ func testAccCheckIBMPrivateDNSZonesDataSourceConfig(riname, zonename string) str
 	// status filter defaults to empty
 	return fmt.Sprintf(`
 	data "ibm_resource_group" "rg" {
-		name = "default"
+		is_default=true
 	}
 
 	resource "ibm_resource_instance" "test-pdns-instance" {

--- a/ibm/data_source_ibm_resource_group_test.go
+++ b/ibm/data_source_ibm_resource_group_test.go
@@ -57,7 +57,7 @@ func testAccCheckIBMResourceGroupDataSourceConfigWithName() string {
 	return fmt.Sprintf(`
 
 data "ibm_resource_group" "testacc_ds_resource_group_name" {
-	name = "default"
+	is_default=true
 }`)
 
 }

--- a/ibm/data_source_ibm_resource_instance_test.go
+++ b/ibm/data_source_ibm_resource_instance_test.go
@@ -73,7 +73,7 @@ resource "ibm_resource_instance" "instance2" {
 func testAccCheckIBMResourceInstanceDataSourceConfig(instanceName string) string {
 	return fmt.Sprintf(`
 data "ibm_resource_group" "group" {
-  name = "default"
+  is_default=true
 }
 
 resource "ibm_resource_instance" "instance" {

--- a/ibm/resource_ibm_certificate_manager_order_test.go
+++ b/ibm/resource_ibm_certificate_manager_order_test.go
@@ -115,7 +115,7 @@ func testAccCheckIBMCertificateManagerOrder_basic(cmsName, orderName string) str
 		plan                = "free"
 	}
 	data "ibm_resource_group" "web_group" {
-		name = "default"
+		is_default=true
 	}
 	data "ibm_cis" "instance" {
 		name              = "Terraform-Test-CIS"
@@ -147,7 +147,7 @@ func testAccCheckIBMCertificateManagerOrder_Update(cmsName, updatedName string) 
 		plan                = "free"
 	}
 	data "ibm_resource_group" "web_group" {
-		name = "default"
+		is_default=true
 	}
 	data "ibm_cis" "instance" {
 		name              = "Terraform-Test-CIS"

--- a/ibm/resource_ibm_container_cluster_test.go
+++ b/ibm/resource_ibm_container_cluster_test.go
@@ -235,7 +235,7 @@ func testAccCheckIBMContainerClusterKmsEnable(clusterName, kmsInstanceName, root
 	return fmt.Sprintf(`
 	
 	data "ibm_resource_group" "testacc_ds_resource_group" {
-		name = "default"
+		is_default=true
 	}
 	resource "ibm_resource_instance" "kms_instance" {
 		name              = "%s"

--- a/ibm/resource_ibm_cos_bucket_test.go
+++ b/ibm/resource_ibm_cos_bucket_test.go
@@ -449,7 +449,7 @@ func testAccCheckIBMCosBucket_basic(serviceName string, bucketName string, regio
 
 	return fmt.Sprintf(`
 	data "ibm_resource_group" "group" {
-		name = "default"
+		is_default=true
 	}
 	  
 	resource "ibm_resource_instance" "instance" {
@@ -475,7 +475,7 @@ func testAccCheckIBMCosBucket_updateWithSameName(serviceName string, bucketName 
 
 	return fmt.Sprintf(`	
 	data "ibm_resource_group" "group" {
-		name = "default"
+		is_default=true
 	}
 	  
 	resource "ibm_resource_instance" "instance" {
@@ -500,7 +500,7 @@ func testAccCheckIBMCosBucket_activityTracker_monitor(cosServiceName, activitySe
 	return fmt.Sprintf(`
 
 	data "ibm_resource_group" "cos_group" {
-		name = "default"
+		is_default=true
 	  }
 	  resource "ibm_resource_instance" "instance2" {
 		name              = "%s"
@@ -545,7 +545,7 @@ func testAccCheckIBMCosBucket_update_activityTracker_monitor(cosServiceName, act
 
 	return fmt.Sprintf(`	
 	data "ibm_resource_group" "cos_group" {
-		name = "default"
+		is_default=true
 	}
 	  
 	resource "ibm_resource_instance" "instance2" {
@@ -584,7 +584,7 @@ func testAccCheckIBMCosBucket_archive(cosServiceName string, bucketName string, 
 
 	return fmt.Sprintf(`
 	data "ibm_resource_group" "cos_group" {
-		name = "default"
+		is_default=true
 	}
 
 	resource "ibm_resource_instance" "instance" {
@@ -614,7 +614,7 @@ func testAccCheckIBMCosBucket_archive_updateDays(cosServiceName string, bucketNa
 
 	return fmt.Sprintf(`
 	data "ibm_resource_group" "cos_group" {
-		name = "default"
+		is_default=true
 	}
 
 	resource "ibm_resource_instance" "instance" {
@@ -643,7 +643,7 @@ func testAccCheckIBMCosBucket_update_archive(cosServiceName string, bucketName s
 
 	return fmt.Sprintf(`
 	data "ibm_resource_group" "cos_group" {
-		name = "default"
+		is_default=true
 	}
 
 	resource "ibm_resource_instance" "instance" {
@@ -667,7 +667,7 @@ func testAccCheckIBMCosBucket_expire(cosServiceName string, bucketName string, r
 
 	return fmt.Sprintf(`
 	data "ibm_resource_group" "cos_group" {
-		name = "default"
+		is_default=true
 	}
 
 	resource "ibm_resource_instance" "instance" {
@@ -697,7 +697,7 @@ func testAccCheckIBMCosBucket_expire_updateDays(cosServiceName string, bucketNam
 
 	return fmt.Sprintf(`
 	data "ibm_resource_group" "cos_group" {
-		name = "default"
+		is_default=true
 	}
 
 	resource "ibm_resource_instance" "instance" {
@@ -727,7 +727,7 @@ func testAccCheckIBMCosBucket_update_expire(cosServiceName string, bucketName st
 
 	return fmt.Sprintf(`
 	data "ibm_resource_group" "cos_group" {
-		name = "default"
+		is_default=true
 	}
 
 	resource "ibm_resource_instance" "instance" {
@@ -751,7 +751,7 @@ func testAccCheckIBMCosBucket_archive_expire(cosServiceName string, bucketName s
 
 	return fmt.Sprintf(`
 	data "ibm_resource_group" "cos_group" {
-		name = "default"
+		is_default=true
 	}
 
 	resource "ibm_resource_instance" "instance" {
@@ -786,7 +786,7 @@ func testAccCheckIBMCosBucket_archive_expire_updateDays(cosServiceName string, b
 
 	return fmt.Sprintf(`
 	data "ibm_resource_group" "cos_group" {
-		name = "default"
+		is_default=true
 	}
 
 	resource "ibm_resource_instance" "instance" {
@@ -822,7 +822,7 @@ func testAccCheckIBMCosBucket_update_archive_expire(cosServiceName string, bucke
 
 	return fmt.Sprintf(`
 	data "ibm_resource_group" "cos_group" {
-		name = "default"
+		is_default=true
 	}
 
 	resource "ibm_resource_instance" "instance" {

--- a/ibm/resource_ibm_event_streams_topic_test.go
+++ b/ibm/resource_ibm_event_streams_topic_test.go
@@ -214,7 +214,7 @@ func testAccCheckIBMEventStreamsTopicWithExistingInstanceWithConfig(instanceName
 func getPlatformResource(instanceName string) string {
 	return fmt.Sprintf(`
 	  data "ibm_resource_group" "group" {
-		name = "default"
+		is_default=true
 	  }
 	  data "ibm_resource_instance" "es_instance" {
 		resource_group_id = data.ibm_resource_group.group.id
@@ -226,7 +226,7 @@ func createPlatformResources(instanceName, serviceName, planID, location string,
 	if planID == "standard" || planID == "lite" {
 		return fmt.Sprintf(`
 		data "ibm_resource_group" "group" {
-		  name = "default"
+		  is_default=true
 		}
 		resource "ibm_resource_instance" "es_instance" {
 		  name              = "%s"
@@ -239,7 +239,7 @@ func createPlatformResources(instanceName, serviceName, planID, location string,
 	// create enterprise instance
 	return fmt.Sprintf(`
 	data "ibm_resource_group" "group" {
-		name = "default"
+		is_default=true
 	  }
 	resource "ibm_resource_instance" "es_instance" {
 		name              = "%s"

--- a/ibm/resource_ibm_function_action_test.go
+++ b/ibm/resource_ibm_function_action_test.go
@@ -712,7 +712,7 @@ func testAccCheckFunctionActionDestroy(s *terraform.State) error {
 func testAccCheckIAMFunctionActionNodeJS(name, namespace string) string {
 	return fmt.Sprintf(`
 	data "ibm_resource_group" "test_acc" {
-		name = "default"
+		is_default=true
 	}
 
 	resource "ibm_function_namespace" "namespace" {
@@ -738,7 +738,7 @@ func testAccCheckIAMFunctionActionNodeJSWithParams(name, namespace string) strin
 	return fmt.Sprintf(`
 
 	data "ibm_resource_group" "test_acc" {
-		name = "default"
+		is_default=true
 	}
 
 	resource "ibm_function_namespace" "namespace" {
@@ -773,7 +773,7 @@ func testAccCheckIAMFunctionActionNodeJSWithParams(name, namespace string) strin
 func testAccCheckIAMFunctionActionNodeJSZip(name, namespace string) string {
 	return fmt.Sprintf(`
 	data "ibm_resource_group" "test_acc" {
-		name = "default"
+		is_default=true
 	}
 
 	resource "ibm_function_namespace" "namespace" {
@@ -797,7 +797,7 @@ func testAccCheckIAMFunctionActionNodeJSZip(name, namespace string) string {
 func testAccCheckIAMFunctionActionPython(name, namespace string) string {
 	return fmt.Sprintf(`
 	data "ibm_resource_group" "test_acc" {
-		name = "default"
+		is_default=true
 	}
 
 	resource "ibm_function_namespace" "namespace" {
@@ -821,7 +821,7 @@ func testAccCheckIAMFunctionActionPython(name, namespace string) string {
 func testAccCheckIAMFunctionActionPythonZip(name, namespace string) string {
 	return fmt.Sprintf(`
 	data "ibm_resource_group" "test_acc" {
-		name = "default"
+		is_default=true
 	}
 
 	resource "ibm_function_namespace" "namespace" {
@@ -845,7 +845,7 @@ func testAccCheckIAMFunctionActionPythonZip(name, namespace string) string {
 func testAccCheckIAMFunctionActionPHP(name, namespace string) string {
 	return fmt.Sprintf(`
 	data "ibm_resource_group" "test_acc" {
-		name = "default"
+		is_default=true
 	}
 
 	resource "ibm_function_namespace" "namespace" {
@@ -869,7 +869,7 @@ func testAccCheckIAMFunctionActionPHP(name, namespace string) string {
 func testAccCheckIAMFunctionActionPHPZip(name, namespace string) string {
 	return fmt.Sprintf(`
 	data "ibm_resource_group" "test_acc" {
-		name = "default"
+		is_default=true
 	}
 
 	resource "ibm_function_namespace" "namespace" {
@@ -893,7 +893,7 @@ func testAccCheckIAMFunctionActionPHPZip(name, namespace string) string {
 func testAccCheckIAMFunctionActionSwift(name, namespace string) string {
 	return fmt.Sprintf(`
 	data "ibm_resource_group" "test_acc" {
-		name = "default"
+		is_default=true
 	}
 
 	resource "ibm_function_namespace" "namespace" {
@@ -918,7 +918,7 @@ func testAccCheckIAMFunctionActionSwift(name, namespace string) string {
 func testAccCheckIAMFunctionActionSequence(name, namespace string) string {
 	return fmt.Sprintf(`
 	data "ibm_resource_group" "test_acc" {
-		name = "default"
+		is_default=true
 	}
 
 	resource "ibm_function_namespace" "namespace" {
@@ -942,7 +942,7 @@ func testAccCheckIAMFunctionActionSequence(name, namespace string) string {
 func testAccCheckIAMFunctionActionCreate(name, namespace string) string {
 	return fmt.Sprintf(`
 	data "ibm_resource_group" "test_acc" {
-		name = "default"
+		is_default=true
 	}
 
 	resource "ibm_function_namespace" "namespace" {
@@ -968,7 +968,7 @@ func testAccCheckIAMFunctionActionCreate(name, namespace string) string {
 func testAccCheckIAMFunctionActionUpdate(name, namespace string) string {
 	return fmt.Sprintf(`
 	data "ibm_resource_group" "test_acc" {
-		name = "default"
+		is_default=true
 	}
 
 	resource "ibm_function_namespace" "namespace" {
@@ -1009,7 +1009,7 @@ func testAccCheckIAMFunctionActionUpdate(name, namespace string) string {
 func testAccCheckIAMFunctionActionImport(name, namespace string) string {
 	return fmt.Sprintf(`
 	data "ibm_resource_group" "test_acc" {
-		name = "default"
+		is_default=true
 	}
 
 	resource "ibm_function_namespace" "namespace" {

--- a/ibm/resource_ibm_function_package_test.go
+++ b/ibm/resource_ibm_function_package_test.go
@@ -530,7 +530,7 @@ func testAccCheckIAMFunctionPackageCreate(name string, namespace string) string 
 	return fmt.Sprintf(`
 
 	data "ibm_resource_group" "test_acc" {
-		name = "default"
+		is_default=true
 	}
 
 	resource "ibm_function_namespace" "namespace" {
@@ -560,7 +560,7 @@ func testAccCheckIAMFunctionPackageNameUpdate(updatedName string, namespace stri
 	return fmt.Sprintf(`
 
 	data "ibm_resource_group" "test_acc" {
-		name = "default"
+		is_default=true
 	}
 
 	resource "ibm_function_namespace" "namespace" {
@@ -588,7 +588,7 @@ func testAccCheckIAMFunctionPackageWithAnnotations(name string, namespace string
 	return fmt.Sprintf(`
 
 	data "ibm_resource_group" "test_acc" {
-		name = "default"
+		is_default=true
 	}
 
 	resource "ibm_function_namespace" "namespace" {
@@ -670,7 +670,7 @@ func testAccCheckIAMFunctionPackageWithAnnotationsUpdate(name string, namespace 
 	return fmt.Sprintf(`
 
 	data "ibm_resource_group" "test_acc" {
-		name = "default"
+		is_default=true
 	}
 
 	resource "ibm_function_namespace" "namespace" {
@@ -718,7 +718,7 @@ func testAccCheckIAMFunctionPackageWithParameters(name string, namespace string)
 	return fmt.Sprintf(`
 
 	data "ibm_resource_group" "test_acc" {
-		name = "default"
+		is_default=true
 	}
 
 	resource "ibm_function_namespace" "namespace" {
@@ -822,7 +822,7 @@ func testAccCheckIAMFunctionPackageWithParametersUpdate(name string, namespace s
 	return fmt.Sprintf(`
 
 	data "ibm_resource_group" "test_acc" {
-		name = "default"
+		is_default=true
 	}
 
 	resource "ibm_function_namespace" "namespace" {
@@ -894,7 +894,7 @@ func testAccCheckIAMFunctionPackageImport(name string, namespace string) string 
 	return fmt.Sprintf(`
 
 	data "ibm_resource_group" "test_acc" {
-		name = "default"
+		is_default=true
 	}
 
 	resource "ibm_function_namespace" "namespace" {
@@ -926,7 +926,7 @@ func testAccCheckIAMFunctionPackageUpdatePublish(name string, namespace string) 
 	return fmt.Sprintf(`
 
 	data "ibm_resource_group" "test_acc" {
-		name = "default"
+		is_default=true
 	}
 
 	resource "ibm_function_namespace" "namespace" {
@@ -996,7 +996,7 @@ func testAccCheckIAMFunctionPackageBindCreate(name, namespace, bind string) stri
 	return fmt.Sprintf(`
 
 	data "ibm_resource_group" "test_acc" {
-		name = "default"
+		is_default=true
 	}
 
 	resource "ibm_function_namespace" "namespace" {
@@ -1029,7 +1029,7 @@ func testAccCheckIAMFunctionPackageNameBindUpdate(updatedName, namespace, bind s
 	return fmt.Sprintf(`
 
 	data "ibm_resource_group" "test_acc" {
-		name = "default"
+		is_default=true
 	}
 
 	resource "ibm_function_namespace" "namespace" {
@@ -1058,7 +1058,7 @@ func testAccCheckIAMFunctionPackageBindWithAnnotations(name, namespace, bind str
 	return fmt.Sprintf(`
 
 	data "ibm_resource_group" "test_acc" {
-		name = "default"
+		is_default=true
 	}
 
 	resource "ibm_function_namespace" "namespace" {
@@ -1142,7 +1142,7 @@ func testAccCheckIAMFunctionPackageBindWithAnnotationsUpdate(name, namespace, bi
 	return fmt.Sprintf(`
 
 	data "ibm_resource_group" "test_acc" {
-		name = "default"
+		is_default=true
 	}
 
 	resource "ibm_function_namespace" "namespace" {
@@ -1194,7 +1194,7 @@ func testAccCheckIAMFunctionPackageBindWithParameters(name, namespace, bind stri
 	return fmt.Sprintf(`
 
 	data "ibm_resource_group" "test_acc" {
-		name = "default"
+		is_default=true
 	}
 
 	resource "ibm_function_namespace" "namespace" {
@@ -1290,7 +1290,7 @@ func testAccCheckIAMFunctionPackageBindWithParametersUpdate(name, namespace, bin
 	return fmt.Sprintf(`
 
 	data "ibm_resource_group" "test_acc" {
-		name = "default"
+		is_default=true
 	}
 
 	resource "ibm_function_namespace" "namespace" {
@@ -1362,7 +1362,7 @@ func testAccCheckIAMFunctionPackageBindUpdatePublish(name, namespace, bind strin
 	return fmt.Sprintf(`
 
 	data "ibm_resource_group" "test_acc" {
-		name = "default"
+		is_default=true
 	}
 
 	resource "ibm_function_namespace" "namespace" {

--- a/ibm/resource_ibm_function_rule_test.go
+++ b/ibm/resource_ibm_function_rule_test.go
@@ -249,7 +249,7 @@ func testAccCheckFunctionRuleDestroy(s *terraform.State) error {
 func testAccCheckIAMFunctionRuleCreate(actionName, triggerName, name, namespace string) string {
 	return fmt.Sprintf(`
 	data "ibm_resource_group" "test_acc" {
-		name = "default"
+		is_default=true
 	}
 
 	resource "ibm_function_namespace" "namespace" {
@@ -310,7 +310,7 @@ func testAccCheckIAMFunctionRuleCreate(actionName, triggerName, name, namespace 
 func testAccCheckIAMFunctionRuleUpdate(updatedTriggerName, name, namespace string) string {
 	return fmt.Sprintf(`
 	data "ibm_resource_group" "test_acc" {
-		name = "default"
+		is_default=true
 	}
 
 	resource "ibm_function_namespace" "namespace" {
@@ -346,7 +346,7 @@ func testAccCheckIAMFunctionRuleUpdate(updatedTriggerName, name, namespace strin
 func testAccCheckIAMFunctionRuleImport(triggerName, name, namespace string) string {
 	return fmt.Sprintf(`
 	data "ibm_resource_group" "test_acc" {
-		name = "default"
+		is_default=true
 	}
 
 	resource "ibm_function_namespace" "namespace" {

--- a/ibm/resource_ibm_function_trigger_test.go
+++ b/ibm/resource_ibm_function_trigger_test.go
@@ -304,7 +304,7 @@ func testAccCheckFunctionTriggerDestroy(s *terraform.State) error {
 func testAccCheckIAMFunctionTriggerCreate(name, namespace string) string {
 	return fmt.Sprintf(`
 	data "ibm_resource_group" "test_acc" {
-		name = "default"
+		is_default=true
 	}
 
 	resource "ibm_function_namespace" "namespace" {
@@ -326,7 +326,7 @@ func testAccCheckIAMFunctionTriggerUpdate(name, namespace string) string {
 	return fmt.Sprintf(`
 
 	data "ibm_resource_group" "test_acc" {
-		name = "default"
+		is_default=true
 	}
 
 	resource "ibm_function_namespace" "namespace" {
@@ -367,7 +367,7 @@ func testAccCheckIAMFunctionTriggerUpdate(name, namespace string) string {
 func testAccCheckIAMFunctionTriggerFeedCreate(name, namespace string) string {
 	return fmt.Sprintf(`
 	data "ibm_resource_group" "test_acc" {
-		name = "default"
+		is_default=true
 	}
 
 	resource "ibm_function_namespace" "namespace" {
@@ -411,7 +411,7 @@ func testAccCheckIAMFunctionTriggerFeedCreate(name, namespace string) string {
 func testAccCheckIAMFunctionTriggerFeedUpdate(name, namespace string) string {
 	return fmt.Sprintf(`
 	data "ibm_resource_group" "test_acc" {
-		name = "default"
+		is_default=true
 	}
 
 	resource "ibm_function_namespace" "namespace" {
@@ -468,7 +468,7 @@ func testAccCheckIAMFunctionTriggerFeedUpdate(name, namespace string) string {
 func testAccCheckIAMFunctionTriggerImport(name, namespace string) string {
 	return fmt.Sprintf(`
 	data "ibm_resource_group" "test_acc" {
-		name = "default"
+		is_default=true
 	}
 
 	resource "ibm_function_namespace" "namespace" {

--- a/ibm/resource_ibm_iam_access_group_policy_test.go
+++ b/ibm/resource_ibm_iam_access_group_policy_test.go
@@ -5,15 +5,14 @@ package ibm
 
 import (
 	"fmt"
-	"testing"
-
-	"github.com/IBM-Cloud/bluemix-go/api/iampap/iampapv1"
-
 	"strings"
+	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	"github.com/IBM-Cloud/bluemix-go/api/iampap/iampapv1"
 )
 
 func TestAccIBMIAMAccessGroupPolicy_Basic(t *testing.T) {
@@ -395,7 +394,7 @@ func testAccCheckIBMIAMAccessGroupPolicyResourceGroup(name string) string {
 	  	}
 	  
 	  	data "ibm_resource_group" "group" {
-			name = "default"
+			is_default=true
 	  	}
 	  
 	  	resource "ibm_iam_access_group_policy" "policy" {
@@ -420,7 +419,7 @@ func testAccCheckIBMIAMAccessGroupPolicyResourceType(name string) string {
 	  	}
 	  
 	  	data "ibm_resource_group" "group" {
-			name = "default"
+			is_default=true
 	  	}
 	  
 	  	resource "ibm_iam_access_group_policy" "policy" {

--- a/ibm/resource_ibm_iam_service_policy_test.go
+++ b/ibm/resource_ibm_iam_service_policy_test.go
@@ -373,7 +373,7 @@ func testAccCheckIBMIAMServicePolicyResourceGroup(name string) string {
 	  	}
 	  
 	  	data "ibm_resource_group" "group" {
-			name = "default"
+			is_default=true
 	  	}
 	  
 	  	resource "ibm_iam_service_policy" "policy" {
@@ -398,7 +398,7 @@ func testAccCheckIBMIAMServicePolicyResourceType(name string) string {
 	  	}
 	  
 	  	data "ibm_resource_group" "group" {
-			name = "default"
+			is_default=true
 	  	}
 	  
 	  	resource "ibm_iam_service_policy" "policy" {

--- a/ibm/resource_ibm_iam_user_policy_test.go
+++ b/ibm/resource_ibm_iam_user_policy_test.go
@@ -359,7 +359,7 @@ func testAccCheckIBMIAMUserPolicyResourceGroup() string {
 
 		  
 		data "ibm_resource_group" "group" {
-			name = "default"
+			is_default=true
 	  	}
 	  
 	  	resource "ibm_iam_user_policy" "policy" {
@@ -381,7 +381,7 @@ func testAccCheckIBMIAMUserPolicyResourceType() string {
 
 		  
 		data "ibm_resource_group" "group" {
-			name = "default"
+			is_default=true
 		  }
 		  
 		resource "ibm_iam_user_policy" "policy" {

--- a/ibm/resource_ibm_is_flow_log_test.go
+++ b/ibm/resource_ibm_is_flow_log_test.go
@@ -94,7 +94,7 @@ func testAccCheckIBMISFlowLogConfig(vpcname, name, flowlogname, sshname, publicK
 	  }
 
 	data "ibm_resource_group" "cos_group" {
-		name = "default"
+		is_default=true
 	}
 	  
 	resource "ibm_resource_instance" "instance2" {

--- a/ibm/resource_ibm_is_virtual_endpoint_gateway_test.go
+++ b/ibm/resource_ibm_is_virtual_endpoint_gateway_test.go
@@ -183,7 +183,7 @@ func testAccCheckisVirtualEndpointGatewayExists(n string, tfEndpointGwID *string
 func testAccCheckisVirtualEndpointGatewayConfigBasic(vpcname1, subnetname1, name1 string) string {
 	return fmt.Sprintf(`
 	data "ibm_resource_group" "test_acc" {
-		name = "default"
+		is_default=true
     }
 	resource "ibm_is_vpc" "testacc_vpc" {
 		name = "%[1]s"
@@ -210,7 +210,7 @@ func testAccCheckisVirtualEndpointGatewayConfigBasic(vpcname1, subnetname1, name
 func testAccCheckisVirtualEndpointGatewayConfigFullySpecified(vpcname1, subnetname1, name1 string) string {
 	return fmt.Sprintf(`
 	data "ibm_resource_group" "test_acc" {
-		name = "default"
+		is_default=true
     }
 	resource "ibm_is_vpc" "testacc_vpc" {
 		name = "%[1]s"

--- a/ibm/resource_ibm_private_dns_glb_monitor_test.go
+++ b/ibm/resource_ibm_private_dns_glb_monitor_test.go
@@ -75,7 +75,7 @@ func TestAccIBMPrivateDNSGlbMonitorImport(t *testing.T) {
 func testAccCheckIBMPrivateDNSGlbMonitorBasic(name string) string {
 	return fmt.Sprintf(`
 	data "ibm_resource_group" "rg" {
-		name = "default"
+		is_default=true
     }
 
     resource "ibm_is_vpc" "test-pdns-vpc" {
@@ -134,7 +134,7 @@ func testAccCheckIBMPrivateDNSGlbMonitorBasic(name string) string {
 func testAccCheckIBMPrivateDNSGlbUpdateMonitorBasic(name string) string {
 	return fmt.Sprintf(`
 	data "ibm_resource_group" "rg" {
-		name = "default"
+		is_default=true
     }
 
     resource "ibm_is_vpc" "test-pdns-vpc" {

--- a/ibm/resource_ibm_private_dns_glb_pool_test.go
+++ b/ibm/resource_ibm_private_dns_glb_pool_test.go
@@ -69,7 +69,7 @@ func TestAccIBMPrivateDNSGlbPoolImport(t *testing.T) {
 func testAccCheckIBMGlbPoolBasic(name string) string {
 	return fmt.Sprintf(`
 	data "ibm_resource_group" "rg" {
-		name = "default"
+		is_default=true
 	}
 	resource "ibm_is_vpc" "test-pdns-glb-pool-vpc" {
 		name = "test-pdns-glb-pool-vpc"
@@ -130,7 +130,7 @@ func testAccCheckIBMGlbPoolBasic(name string) string {
 func testAccCheckIBMGlbPoolUpdate(name string) string {
 	return fmt.Sprintf(`
 	data "ibm_resource_group" "rg" {
-		name = "default"
+		is_default=true
 	}
 	resource "ibm_is_vpc" "test-pdns-glb-pool-vpc" {
 		name = "test-pdns-glb-pool-vpc"

--- a/ibm/resource_ibm_private_dns_glb_test.go
+++ b/ibm/resource_ibm_private_dns_glb_test.go
@@ -70,7 +70,7 @@ func TestAccIBMPrivateDNSGlboadBalancerImport(t *testing.T) {
 func testAccCheckIBMPrivateDNSGlbLoadBalancerBasic(name string) string {
 	return fmt.Sprintf(`
 	data "ibm_resource_group" "rg" {
-		name = "default"
+		is_default=true
 	  }
 
 	  resource "ibm_resource_instance" "test-pdns-instance" {
@@ -125,7 +125,7 @@ func testAccCheckIBMPrivateDNSGlbLoadBalancerBasic(name string) string {
 func testAccCheckIBMPrivateDNSGlbUpdateLoadBalancerBasic(name string) string {
 	return fmt.Sprintf(`
 	data "ibm_resource_group" "rg" {
-		name = "default"
+		is_default=true
 	  }
 
 	  resource "ibm_resource_instance" "test-pdns-instance" {

--- a/ibm/resource_ibm_private_dns_permitted_network_test.go
+++ b/ibm/resource_ibm_private_dns_permitted_network_test.go
@@ -61,7 +61,7 @@ func TestAccIBMPrivateDNSPermittedNetworkImport(t *testing.T) {
 func testAccCheckIBMPrivateDNSPermittedNetworkBasic(name string) string {
 	return fmt.Sprintf(`
 	data "ibm_resource_group" "rg" {
-		name = "default"
+		is_default=true
 	}
 	resource "ibm_is_vpc" "test-pdns-permitted-network" {
 		name = "test-pdns-permitted-network"

--- a/ibm/resource_ibm_private_dns_resource_record_test.go
+++ b/ibm/resource_ibm_private_dns_resource_record_test.go
@@ -72,7 +72,7 @@ func TestAccIBMPrivateDNSResourceRecordImport(t *testing.T) {
 func testAccCheckIBMPrivateDNSResourceRecordBasic(name string) string {
 	return fmt.Sprintf(`
 	data "ibm_resource_group" "rg" {
-		name = "default"
+		is_default=true
 	}
 
 	resource "ibm_is_vpc" "test_pdns_vpc" {
@@ -178,7 +178,7 @@ func testAccCheckIBMPrivateDNSResourceRecordBasic(name string) string {
 func testAccCheckIBMPrivateDNSResourceRecordUpdate(name string) string {
 	return fmt.Sprintf(`
 	data "ibm_resource_group" "rg" {
-		name = "default"
+		is_default=true
 	}
 
 	resource "ibm_is_vpc" "test_pdns_vpc" {

--- a/ibm/resource_ibm_private_dns_zones_test.go
+++ b/ibm/resource_ibm_private_dns_zones_test.go
@@ -63,7 +63,7 @@ func TestAccIBMPrivateDNSZoneImport(t *testing.T) {
 func testAccCheckIBMPrivateDNSZoneBasic(name string) string {
 	return fmt.Sprintf(`
 	data "ibm_resource_group" "rg" {
-		name = "default"
+		is_default=true
 	}
 	resource "ibm_resource_instance" "test-pdns-zone-instance" {
 		name = "test-pdns-zone-instance"

--- a/ibm/resource_ibm_resource_instance_test.go
+++ b/ibm/resource_ibm_resource_instance_test.go
@@ -269,7 +269,7 @@ func testAccCheckIBMResourceInstanceWithResourceGroup(serviceName string) string
 	return fmt.Sprintf(`
 
 	data "ibm_resource_group" "group" {
-		name = "default"
+		is_default=true
 	  }
 	  
 	resource "ibm_resource_instance" "instance" {


### PR DESCRIPTION
Few accounts has default resource group as `default` and few has `Default` In order to remove this conflict, have changed to is_default=true in the testcases