### PR TITLE
Add Terraform support for ATracker service

### DIFF
--- a/ibm/config.go
+++ b/ibm/config.go
@@ -1107,7 +1107,7 @@ func (c *Config) ClientSession() (interface{}, error) {
 	}
 
 	// Construct an "options" struct for creating the service client.
-	atrackerClientURL, err := atrackerv1.GetServiceURLForRegion(c.Region)
+	atrackerClientURL, err := atrackerv1.GetServiceURLForRegion("private." + c.Region)
 	if err != nil {
 		atrackerClientURL = atrackerv1.DefaultServiceURL
 	}

--- a/ibm/data_source_ibm_atracker_routes.go
+++ b/ibm/data_source_ibm_atracker_routes.go
@@ -1,0 +1,185 @@
+// Copyright IBM Corp. 2021 All Rights Reserved.
+// Licensed under the Mozilla Public License v2.0
+
+package ibm
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"time"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/IBM/platform-services-go-sdk/atrackerv1"
+)
+
+func dataSourceIBMAtrackerRoutes() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceIBMAtrackerRoutesRead,
+
+		Schema: map[string]*schema.Schema{
+			"name": &schema.Schema{
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "The name of this route.",
+			},
+			"routes": &schema.Schema{
+				Type:        schema.TypeList,
+				Computed:    true,
+				Description: "A list of route resources.",
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"id": &schema.Schema{
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "The uuid of this route resource.",
+						},
+						"name": &schema.Schema{
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "The name of this route.",
+						},
+						"crn": &schema.Schema{
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "The crn of this route type resource.",
+						},
+						"version": &schema.Schema{
+							Type:        schema.TypeInt,
+							Computed:    true,
+							Description: "The version of this route.",
+						},
+						"receive_global_events": &schema.Schema{
+							Type:        schema.TypeBool,
+							Computed:    true,
+							Description: "Whether or not all global events should be forwarded to this region.",
+						},
+						"rules": &schema.Schema{
+							Type:        schema.TypeList,
+							Computed:    true,
+							Description: "The routing rules that will be evaluated in their order of the array.",
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"target_ids": &schema.Schema{
+										Type:        schema.TypeList,
+										Computed:    true,
+										Description: "The target ID List. Only one target id is supported.",
+										Elem: &schema.Schema{
+											Type: schema.TypeString,
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func dataSourceIBMAtrackerRoutesRead(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	atrackerClient, err := meta.(ClientSession).AtrackerV1()
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	listRoutesOptions := &atrackerv1.ListRoutesOptions{}
+
+	routeList, response, err := atrackerClient.ListRoutesWithContext(context, listRoutesOptions)
+	if err != nil {
+		log.Printf("[DEBUG] ListRoutesWithContext failed %s\n%s", err, response)
+		return diag.FromErr(err)
+	}
+
+	// Use the provided filter argument and construct a new list with only the requested resource(s)
+	var matchRoutes []atrackerv1.Route
+	var name string
+	var suppliedFilter bool
+
+	if v, ok := d.GetOk("name"); ok {
+		name = v.(string)
+		suppliedFilter = true
+		for _, data := range routeList.Routes {
+			if *data.Name == name {
+				matchRoutes = append(matchRoutes, data)
+			}
+		}
+	} else {
+		matchRoutes = routeList.Routes
+	}
+	routeList.Routes = matchRoutes
+
+	if len(routeList.Routes) == 0 {
+		return diag.FromErr(fmt.Errorf("no Routes found with name %s\nIf not specified, please specify more filters", name))
+	}
+
+	if suppliedFilter {
+		d.SetId(name)
+	} else {
+		d.SetId(dataSourceIBMAtrackerRoutesID(d))
+	}
+
+	if routeList.Routes != nil {
+		err = d.Set("routes", dataSourceRouteListFlattenRoutes(routeList.Routes))
+		if err != nil {
+			return diag.FromErr(fmt.Errorf("Error setting routes %s", err))
+		}
+	}
+
+	return nil
+}
+
+// dataSourceIBMAtrackerRoutesID returns a reasonable ID for the list.
+func dataSourceIBMAtrackerRoutesID(d *schema.ResourceData) string {
+	return time.Now().UTC().String()
+}
+
+func dataSourceRouteListFlattenRoutes(result []atrackerv1.Route) (routes []map[string]interface{}) {
+	for _, routesItem := range result {
+		routes = append(routes, dataSourceRouteListRoutesToMap(routesItem))
+	}
+
+	return routes
+}
+
+func dataSourceRouteListRoutesToMap(routesItem atrackerv1.Route) (routesMap map[string]interface{}) {
+	routesMap = map[string]interface{}{}
+
+	if routesItem.ID != nil {
+		routesMap["id"] = routesItem.ID
+	}
+	if routesItem.Name != nil {
+		routesMap["name"] = routesItem.Name
+	}
+	if routesItem.CRN != nil {
+		routesMap["crn"] = routesItem.CRN
+	}
+	if routesItem.Version != nil {
+		routesMap["version"] = routesItem.Version
+	}
+	if routesItem.ReceiveGlobalEvents != nil {
+		routesMap["receive_global_events"] = routesItem.ReceiveGlobalEvents
+	}
+	if routesItem.Rules != nil {
+		rulesList := []map[string]interface{}{}
+		for _, rulesItem := range routesItem.Rules {
+			rulesList = append(rulesList, dataSourceRouteListRoutesRulesToMap(rulesItem))
+		}
+		routesMap["rules"] = rulesList
+	}
+
+	return routesMap
+}
+
+func dataSourceRouteListRoutesRulesToMap(rulesItem atrackerv1.Rule) (rulesMap map[string]interface{}) {
+	rulesMap = map[string]interface{}{}
+
+	if rulesItem.TargetIds != nil {
+		rulesMap["target_ids"] = rulesItem.TargetIds
+	}
+
+	return rulesMap
+}

--- a/ibm/data_source_ibm_atracker_routes_test.go
+++ b/ibm/data_source_ibm_atracker_routes_test.go
@@ -1,0 +1,61 @@
+// Copyright IBM Corp. 2021 All Rights Reserved.
+// Licensed under the Mozilla Public License v2.0
+
+package ibm
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+func TestAccIBMAtrackerRoutesDataSourceBasic(t *testing.T) {
+	routeName := fmt.Sprintf("tf_name_%d", acctest.RandIntRange(10, 100))
+	routeReceiveGlobalEvents := "false"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccCheckIBMAtrackerRoutesDataSourceConfigBasic(routeName, routeReceiveGlobalEvents),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet("data.ibm_atracker_routes.atracker_routes", "id"),
+					resource.TestCheckResourceAttrSet("data.ibm_atracker_routes.atracker_routes", "name"),
+					resource.TestCheckResourceAttrSet("data.ibm_atracker_routes.atracker_routes", "routes.#"),
+					resource.TestCheckResourceAttr("data.ibm_atracker_routes.atracker_routes", "routes.0.name", routeName),
+					resource.TestCheckResourceAttr("data.ibm_atracker_routes.atracker_routes", "routes.0.receive_global_events", routeReceiveGlobalEvents),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckIBMAtrackerRoutesDataSourceConfigBasic(routeName string, routeReceiveGlobalEvents string) string {
+	return fmt.Sprintf(`
+		resource "ibm_atracker_target" "atracker_target" {
+			name = "my-cos-target"
+			target_type = "cloud_object_storage"
+			cos_endpoint {
+				endpoint = "s3.private.us-east.cloud-object-storage.appdomain.cloud"
+				target_crn = "crn:v1:bluemix:public:cloud-object-storage:global:a/11111111111111111111111111111111:22222222-2222-2222-2222-222222222222::"
+				bucket = "my-atracker-bucket"
+				api_key = "xxxxxxxxxxxxxx"
+			}
+		}
+
+		resource "ibm_atracker_route" "atracker_route" {
+			name = "%s"
+			receive_global_events = %s
+			rules {
+				target_ids = [ "c3af557f-fb0e-4476-85c3-0889e7fe7bc4" ]
+			}
+		}
+
+		data "ibm_atracker_routes" "atracker_routes" {
+			name = ibm_atracker_route.atracker_route.name
+		}
+	`, routeName, routeReceiveGlobalEvents)
+}

--- a/ibm/data_source_ibm_atracker_routes_test.go
+++ b/ibm/data_source_ibm_atracker_routes_test.go
@@ -50,7 +50,7 @@ func testAccCheckIBMAtrackerRoutesDataSourceConfigBasic(routeName string, routeR
 			name = "%s"
 			receive_global_events = %s
 			rules {
-				target_ids = [ "c3af557f-fb0e-4476-85c3-0889e7fe7bc4" ]
+				target_ids = [ ibm_atracker_target.atracker_target.id ]
 			}
 		}
 

--- a/ibm/data_source_ibm_atracker_targets.go
+++ b/ibm/data_source_ibm_atracker_targets.go
@@ -1,0 +1,205 @@
+// Copyright IBM Corp. 2021 All Rights Reserved.
+// Licensed under the Mozilla Public License v2.0
+
+package ibm
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"time"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/IBM/platform-services-go-sdk/atrackerv1"
+)
+
+func dataSourceIBMAtrackerTargets() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceIBMAtrackerTargetsRead,
+
+		Schema: map[string]*schema.Schema{
+			"name": &schema.Schema{
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "The name of this target resource.",
+			},
+			"targets": &schema.Schema{
+				Type:        schema.TypeList,
+				Computed:    true,
+				Description: "A list of target resources.",
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"id": &schema.Schema{
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "The uuid of this target resource.",
+						},
+						"name": &schema.Schema{
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "The name of this target resource.",
+						},
+						"crn": &schema.Schema{
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "The crn of this target type resource.",
+						},
+						"target_type": &schema.Schema{
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "The type of this target.",
+						},
+						"encrypt_key": &schema.Schema{
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "The encryption key used to encrypt events before ATracker services buffer them on storage. This credential will be masked in the response.",
+						},
+						"cos_endpoint": &schema.Schema{
+							Type:        schema.TypeList,
+							Computed:    true,
+							Description: "Property values for a Cloud Object Storage Endpoint.",
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"endpoint": &schema.Schema{
+										Type:        schema.TypeString,
+										Computed:    true,
+										Description: "The host name of this COS endpoint.",
+									},
+									"target_crn": &schema.Schema{
+										Type:        schema.TypeString,
+										Computed:    true,
+										Description: "The CRN of this COS instance.",
+									},
+									"bucket": &schema.Schema{
+										Type:        schema.TypeString,
+										Computed:    true,
+										Description: "The bucket name under this COS instance.",
+									},
+									"api_key": &schema.Schema{
+										Type:        schema.TypeString,
+										Computed:    true,
+										Description: "The IAM Api key that have writer access to this cos instance. This credential will be masked in the response.",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func dataSourceIBMAtrackerTargetsRead(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	atrackerClient, err := meta.(ClientSession).AtrackerV1()
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	listTargetsOptions := &atrackerv1.ListTargetsOptions{}
+
+	targetList, response, err := atrackerClient.ListTargetsWithContext(context, listTargetsOptions)
+	if err != nil {
+		log.Printf("[DEBUG] ListTargetsWithContext failed %s\n%s", err, response)
+		return diag.FromErr(err)
+	}
+
+	// Use the provided filter argument and construct a new list with only the requested resource(s)
+	var matchTargets []atrackerv1.Target
+	var name string
+	var suppliedFilter bool
+
+	if v, ok := d.GetOk("name"); ok {
+		name = v.(string)
+		suppliedFilter = true
+		for _, data := range targetList.Targets {
+			if *data.Name == name {
+				matchTargets = append(matchTargets, data)
+			}
+		}
+	} else {
+		matchTargets = targetList.Targets
+	}
+	targetList.Targets = matchTargets
+
+	if len(targetList.Targets) == 0 {
+		return diag.FromErr(fmt.Errorf("no Targets found with name %s\nIf not specified, please specify more filters", name))
+	}
+
+	if suppliedFilter {
+		d.SetId(name)
+	} else {
+		d.SetId(dataSourceIBMAtrackerTargetsID(d))
+	}
+
+	if targetList.Targets != nil {
+		err = d.Set("targets", dataSourceTargetListFlattenTargets(targetList.Targets))
+		if err != nil {
+			return diag.FromErr(fmt.Errorf("Error setting targets %s", err))
+		}
+	}
+
+	return nil
+}
+
+// dataSourceIBMAtrackerTargetsID returns a reasonable ID for the list.
+func dataSourceIBMAtrackerTargetsID(d *schema.ResourceData) string {
+	return time.Now().UTC().String()
+}
+
+func dataSourceTargetListFlattenTargets(result []atrackerv1.Target) (targets []map[string]interface{}) {
+	for _, targetsItem := range result {
+		targets = append(targets, dataSourceTargetListTargetsToMap(targetsItem))
+	}
+
+	return targets
+}
+
+func dataSourceTargetListTargetsToMap(targetsItem atrackerv1.Target) (targetsMap map[string]interface{}) {
+	targetsMap = map[string]interface{}{}
+
+	if targetsItem.ID != nil {
+		targetsMap["id"] = targetsItem.ID
+	}
+	if targetsItem.Name != nil {
+		targetsMap["name"] = targetsItem.Name
+	}
+	if targetsItem.CRN != nil {
+		targetsMap["crn"] = targetsItem.CRN
+	}
+	if targetsItem.TargetType != nil {
+		targetsMap["target_type"] = targetsItem.TargetType
+	}
+	if targetsItem.EncryptKey != nil {
+		targetsMap["encrypt_key"] = targetsItem.EncryptKey
+	}
+	if targetsItem.CosEndpoint != nil {
+		cosEndpointList := []map[string]interface{}{}
+		cosEndpointMap := dataSourceTargetListTargetsCosEndpointToMap(*targetsItem.CosEndpoint)
+		cosEndpointList = append(cosEndpointList, cosEndpointMap)
+		targetsMap["cos_endpoint"] = cosEndpointList
+	}
+
+	return targetsMap
+}
+
+func dataSourceTargetListTargetsCosEndpointToMap(cosEndpointItem atrackerv1.CosEndpoint) (cosEndpointMap map[string]interface{}) {
+	cosEndpointMap = map[string]interface{}{}
+
+	if cosEndpointItem.Endpoint != nil {
+		cosEndpointMap["endpoint"] = cosEndpointItem.Endpoint
+	}
+	if cosEndpointItem.TargetCRN != nil {
+		cosEndpointMap["target_crn"] = cosEndpointItem.TargetCRN
+	}
+	if cosEndpointItem.Bucket != nil {
+		cosEndpointMap["bucket"] = cosEndpointItem.Bucket
+	}
+	if cosEndpointItem.APIKey != nil {
+		cosEndpointMap["api_key"] = cosEndpointItem.APIKey
+	}
+
+	return cosEndpointMap
+}

--- a/ibm/data_source_ibm_atracker_targets_test.go
+++ b/ibm/data_source_ibm_atracker_targets_test.go
@@ -1,0 +1,53 @@
+// Copyright IBM Corp. 2021 All Rights Reserved.
+// Licensed under the Mozilla Public License v2.0
+
+package ibm
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+func TestAccIBMAtrackerTargetsDataSourceBasic(t *testing.T) {
+	targetName := fmt.Sprintf("tf_name_%d", acctest.RandIntRange(10, 100))
+	targetTargetType := "cloud_object_storage"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccCheckIBMAtrackerTargetsDataSourceConfigBasic(targetName, targetTargetType),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet("data.ibm_atracker_targets.atracker_targets", "id"),
+					resource.TestCheckResourceAttrSet("data.ibm_atracker_targets.atracker_targets", "name"),
+					resource.TestCheckResourceAttrSet("data.ibm_atracker_targets.atracker_targets", "targets.#"),
+					resource.TestCheckResourceAttr("data.ibm_atracker_targets.atracker_targets", "targets.0.name", targetName),
+					resource.TestCheckResourceAttr("data.ibm_atracker_targets.atracker_targets", "targets.0.target_type", targetTargetType),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckIBMAtrackerTargetsDataSourceConfigBasic(targetName string, targetTargetType string) string {
+	return fmt.Sprintf(`
+		resource "ibm_atracker_target" "atracker_target" {
+			name = "%s"
+			target_type = "%s"
+			cos_endpoint {
+				endpoint = "s3.private.us-east.cloud-object-storage.appdomain.cloud"
+				target_crn = "crn:v1:bluemix:public:cloud-object-storage:global:a/11111111111111111111111111111111:22222222-2222-2222-2222-222222222222::"
+				bucket = "my-atracker-bucket"
+				api_key = "xxxxxxxxxxxxxx"
+			}
+		}
+
+		data "ibm_atracker_targets" "atracker_targets" {
+			name = ibm_atracker_target.atracker_target.name
+		}
+	`, targetName, targetTargetType)
+}

--- a/ibm/provider.go
+++ b/ibm/provider.go
@@ -163,6 +163,8 @@ func Provider() *schema.Provider {
 			"ibm_app_domain_private":                 dataSourceIBMAppDomainPrivate(),
 			"ibm_app_domain_shared":                  dataSourceIBMAppDomainShared(),
 			"ibm_app_route":                          dataSourceIBMAppRoute(),
+			"ibm_atracker_targets":                   dataSourceIBMAtrackerTargets(),
+			"ibm_atracker_routes":                    dataSourceIBMAtrackerRoutes(),
 			"ibm_function_action":                    dataSourceIBMFunctionAction(),
 			"ibm_function_package":                   dataSourceIBMFunctionPackage(),
 			"ibm_function_rule":                      dataSourceIBMFunctionRule(),
@@ -344,6 +346,8 @@ func Provider() *schema.Provider {
 			"ibm_app_domain_private":                             resourceIBMAppDomainPrivate(),
 			"ibm_app_domain_shared":                              resourceIBMAppDomainShared(),
 			"ibm_app_route":                                      resourceIBMAppRoute(),
+			"ibm_atracker_target":                                resourceIBMAtrackerTarget(),
+			"ibm_atracker_route":                                 resourceIBMAtrackerRoute(),
 			"ibm_function_action":                                resourceIBMFunctionAction(),
 			"ibm_function_package":                               resourceIBMFunctionPackage(),
 			"ibm_function_rule":                                  resourceIBMFunctionRule(),
@@ -543,6 +547,7 @@ func Validator() ValidatorDict {
 	initOnce.Do(func() {
 		globalValidatorDict = ValidatorDict{
 			ResourceValidatorDictionary: map[string]*ResourceValidator{
+				"ibm_atracker_target":        resourceIBMAtrackerTargetValidator(),
 				"ibm_iam_custom_role":        resourceIBMIAMCustomRoleValidator(),
 				"ibm_cis_healthcheck":        resourceIBMCISHealthCheckValidator(),
 				"ibm_cis_rate_limit":         resourceIBMCISRateLimitValidator(),

--- a/ibm/resource_ibm_atracker_route.go
+++ b/ibm/resource_ibm_atracker_route.go
@@ -1,0 +1,211 @@
+// Copyright IBM Corp. 2021 All Rights Reserved.
+// Licensed under the Mozilla Public License v2.0
+
+package ibm
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"time"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/IBM/platform-services-go-sdk/atrackerv1"
+)
+
+func resourceIBMAtrackerRoute() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceIBMAtrackerRouteCreate,
+		ReadContext:   resourceIBMAtrackerRouteRead,
+		UpdateContext: resourceIBMAtrackerRouteUpdate,
+		DeleteContext: resourceIBMAtrackerRouteDelete,
+		Importer:      &schema.ResourceImporter{},
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(60 * time.Minute),
+			Update: schema.DefaultTimeout(20 * time.Minute),
+			Delete: schema.DefaultTimeout(10 * time.Minute),
+		},
+
+		Schema: map[string]*schema.Schema{
+			"name": &schema.Schema{
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "The name of the route. Must be 180 characters or less and cannot include any special characters other than `(space) - . _ :`.",
+			},
+			"receive_global_events": &schema.Schema{
+				Type:        schema.TypeBool,
+				Required:    true,
+				Description: "Whether or not all global events should be forwarded to this region.",
+			},
+			"rules": &schema.Schema{
+				Type:        schema.TypeList,
+				Required:    true,
+				Description: "Routing rules that will be evaluated in their order of the array.",
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"target_ids": &schema.Schema{
+							Type:        schema.TypeList,
+							Required:    true,
+							Description: "The target ID List. Only one target id is supported.",
+							Elem:        &schema.Schema{Type: schema.TypeString},
+						},
+					},
+				},
+			},
+			"crn": &schema.Schema{
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The crn of this route type resource.",
+			},
+			"version": &schema.Schema{
+				Type:        schema.TypeInt,
+				Computed:    true,
+				Description: "The version of this route.",
+			},
+		},
+	}
+}
+
+func resourceIBMAtrackerRouteCreate(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	atrackerClient, err := meta.(ClientSession).AtrackerV1()
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	createRouteOptions := &atrackerv1.CreateRouteOptions{}
+
+	createRouteOptions.SetName(d.Get("name").(string))
+	createRouteOptions.SetReceiveGlobalEvents(d.Get("receive_global_events").(bool))
+	var rules []atrackerv1.Rule
+	for _, e := range d.Get("rules").([]interface{}) {
+		value := e.(map[string]interface{})
+		rulesItem := resourceIBMAtrackerRouteMapToRule(value)
+		rules = append(rules, rulesItem)
+	}
+	createRouteOptions.SetRules(rules)
+
+	route, response, err := atrackerClient.CreateRouteWithContext(context, createRouteOptions)
+	if err != nil {
+		log.Printf("[DEBUG] CreateRouteWithContext failed %s\n%s", err, response)
+		return diag.FromErr(err)
+	}
+
+	d.SetId(*route.ID)
+
+	return resourceIBMAtrackerRouteRead(context, d, meta)
+}
+
+func resourceIBMAtrackerRouteMapToRule(ruleMap map[string]interface{}) atrackerv1.Rule {
+	rule := atrackerv1.Rule{}
+
+	targetIds := []string{}
+	for _, targetIdsItem := range ruleMap["target_ids"].([]interface{}) {
+		targetIds = append(targetIds, targetIdsItem.(string))
+	}
+	rule.TargetIds = targetIds
+
+	return rule
+}
+
+func resourceIBMAtrackerRouteRead(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	atrackerClient, err := meta.(ClientSession).AtrackerV1()
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	getRouteOptions := &atrackerv1.GetRouteOptions{}
+
+	getRouteOptions.SetID(d.Id())
+
+	route, response, err := atrackerClient.GetRouteWithContext(context, getRouteOptions)
+	if err != nil {
+		if response != nil && response.StatusCode == 404 {
+			d.SetId("")
+			return nil
+		}
+		log.Printf("[DEBUG] GetRouteWithContext failed %s\n%s", err, response)
+		return diag.FromErr(err)
+	}
+
+	if err = d.Set("name", route.Name); err != nil {
+		return diag.FromErr(fmt.Errorf("Error setting name: %s", err))
+	}
+	if err = d.Set("receive_global_events", route.ReceiveGlobalEvents); err != nil {
+		return diag.FromErr(fmt.Errorf("Error setting receive_global_events: %s", err))
+	}
+	rules := []map[string]interface{}{}
+	for _, rulesItem := range route.Rules {
+		rulesItemMap := resourceIBMAtrackerRouteRuleToMap(rulesItem)
+		rules = append(rules, rulesItemMap)
+	}
+	if err = d.Set("rules", rules); err != nil {
+		return diag.FromErr(fmt.Errorf("Error setting rules: %s", err))
+	}
+	if err = d.Set("crn", route.CRN); err != nil {
+		return diag.FromErr(fmt.Errorf("Error setting crn: %s", err))
+	}
+	if err = d.Set("version", intValue(route.Version)); err != nil {
+		return diag.FromErr(fmt.Errorf("Error setting version: %s", err))
+	}
+
+	return nil
+}
+
+func resourceIBMAtrackerRouteRuleToMap(rule atrackerv1.Rule) map[string]interface{} {
+	ruleMap := map[string]interface{}{}
+
+	ruleMap["target_ids"] = rule.TargetIds
+
+	return ruleMap
+}
+
+func resourceIBMAtrackerRouteUpdate(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	atrackerClient, err := meta.(ClientSession).AtrackerV1()
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	replaceRouteOptions := &atrackerv1.ReplaceRouteOptions{}
+
+	replaceRouteOptions.SetID(d.Id())
+	replaceRouteOptions.SetName(d.Get("name").(string))
+	replaceRouteOptions.SetReceiveGlobalEvents(d.Get("receive_global_events").(bool))
+	var rules []atrackerv1.Rule
+	for _, e := range d.Get("rules").([]interface{}) {
+		value := e.(map[string]interface{})
+		rulesItem := resourceIBMAtrackerRouteMapToRule(value)
+		rules = append(rules, rulesItem)
+	}
+	replaceRouteOptions.SetRules(rules)
+
+	_, response, err := atrackerClient.ReplaceRouteWithContext(context, replaceRouteOptions)
+	if err != nil {
+		log.Printf("[DEBUG] ReplaceRouteWithContext failed %s\n%s", err, response)
+		return diag.FromErr(err)
+	}
+
+	return resourceIBMAtrackerRouteRead(context, d, meta)
+}
+
+func resourceIBMAtrackerRouteDelete(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	atrackerClient, err := meta.(ClientSession).AtrackerV1()
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	deleteRouteOptions := &atrackerv1.DeleteRouteOptions{}
+
+	deleteRouteOptions.SetID(d.Id())
+
+	response, err := atrackerClient.DeleteRouteWithContext(context, deleteRouteOptions)
+	if err != nil {
+		log.Printf("[DEBUG] DeleteRouteWithContext failed %s\n%s", err, response)
+		return diag.FromErr(err)
+	}
+
+	d.SetId("")
+
+	return nil
+}

--- a/ibm/resource_ibm_atracker_route_test.go
+++ b/ibm/resource_ibm_atracker_route_test.go
@@ -67,7 +67,7 @@ func testAccCheckIBMAtrackerRouteConfigBasic(name string, receiveGlobalEvents st
 			name = "%s"
 			receive_global_events = %s
 			rules {
-				target_ids = [ "c3af557f-fb0e-4476-85c3-0889e7fe7bc4" ]
+				target_ids = [ ibm_atracker_target.atracker_target.id ]
 			}
 		}
 	`, name, receiveGlobalEvents)

--- a/ibm/resource_ibm_atracker_route_test.go
+++ b/ibm/resource_ibm_atracker_route_test.go
@@ -1,0 +1,128 @@
+// Copyright IBM Corp. 2021 All Rights Reserved.
+// Licensed under the Mozilla Public License v2.0
+
+package ibm
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	"github.com/IBM/platform-services-go-sdk/atrackerv1"
+)
+
+func TestAccIBMAtrackerRouteBasic(t *testing.T) {
+	var conf atrackerv1.Route
+	name := fmt.Sprintf("tf_name_%d", acctest.RandIntRange(10, 100))
+	receiveGlobalEvents := "false"
+	nameUpdate := fmt.Sprintf("tf_name_%d", acctest.RandIntRange(10, 100))
+	receiveGlobalEventsUpdate := "true"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckIBMAtrackerRouteDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccCheckIBMAtrackerRouteConfigBasic(name, receiveGlobalEvents),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckIBMAtrackerRouteExists("ibm_atracker_route.atracker_route", conf),
+					resource.TestCheckResourceAttr("ibm_atracker_route.atracker_route", "name", name),
+					resource.TestCheckResourceAttr("ibm_atracker_route.atracker_route", "receive_global_events", receiveGlobalEvents),
+				),
+			},
+			resource.TestStep{
+				Config: testAccCheckIBMAtrackerRouteConfigBasic(nameUpdate, receiveGlobalEventsUpdate),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("ibm_atracker_route.atracker_route", "name", nameUpdate),
+					resource.TestCheckResourceAttr("ibm_atracker_route.atracker_route", "receive_global_events", receiveGlobalEventsUpdate),
+				),
+			},
+			resource.TestStep{
+				ResourceName:      "ibm_atracker_route.atracker_route",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testAccCheckIBMAtrackerRouteConfigBasic(name string, receiveGlobalEvents string) string {
+	return fmt.Sprintf(`
+		resource "ibm_atracker_target" "atracker_target" {
+			name = "my-cos-target"
+			target_type = "cloud_object_storage"
+			cos_endpoint {
+				endpoint = "s3.private.us-east.cloud-object-storage.appdomain.cloud"
+				target_crn = "crn:v1:bluemix:public:cloud-object-storage:global:a/11111111111111111111111111111111:22222222-2222-2222-2222-222222222222::"
+				bucket = "my-atracker-bucket"
+				api_key = "xxxxxxxxxxxxxx"
+			}
+		}
+
+		resource "ibm_atracker_route" "atracker_route" {
+			name = "%s"
+			receive_global_events = %s
+			rules {
+				target_ids = [ "c3af557f-fb0e-4476-85c3-0889e7fe7bc4" ]
+			}
+		}
+	`, name, receiveGlobalEvents)
+}
+
+func testAccCheckIBMAtrackerRouteExists(n string, obj atrackerv1.Route) resource.TestCheckFunc {
+
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+
+		atrackerClient, err := testAccProvider.Meta().(ClientSession).AtrackerV1()
+		if err != nil {
+			return err
+		}
+
+		getRouteOptions := &atrackerv1.GetRouteOptions{}
+
+		getRouteOptions.SetID(rs.Primary.ID)
+
+		route, _, err := atrackerClient.GetRoute(getRouteOptions)
+		if err != nil {
+			return err
+		}
+
+		obj = *route
+		return nil
+	}
+}
+
+func testAccCheckIBMAtrackerRouteDestroy(s *terraform.State) error {
+	atrackerClient, err := testAccProvider.Meta().(ClientSession).AtrackerV1()
+	if err != nil {
+		return err
+	}
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "ibm_atracker_route" {
+			continue
+		}
+
+		getRouteOptions := &atrackerv1.GetRouteOptions{}
+
+		getRouteOptions.SetID(rs.Primary.ID)
+
+		// Try to find the key
+		_, response, err := atrackerClient.GetRoute(getRouteOptions)
+
+		if err == nil {
+			return fmt.Errorf("ATracker Route still exists: %s", rs.Primary.ID)
+		} else if response.StatusCode != 404 {
+			return fmt.Errorf("Error checking for ATracker Route (%s) has been destroyed: %s", rs.Primary.ID, err)
+		}
+	}
+
+	return nil
+}

--- a/ibm/resource_ibm_atracker_target.go
+++ b/ibm/resource_ibm_atracker_target.go
@@ -165,6 +165,10 @@ func resourceIBMAtrackerTargetRead(context context.Context, d *schema.ResourceDa
 		return diag.FromErr(fmt.Errorf("Error setting target_type: %s", err))
 	}
 	cosEndpointMap := resourceIBMAtrackerTargetCosEndpointToMap(*target.CosEndpoint)
+	// This line is a workaround for api_key, which comes back as "REDACTED" from the service.
+	// This causes havok in the tests (in legacy testing framework) so we store the original
+	// api_key value into the state.  This is the least bad solution I could come up with.
+	cosEndpointMap["api_key"] = d.Get("cos_endpoint.0.api_key")
 	if err = d.Set("cos_endpoint", []map[string]interface{}{cosEndpointMap}); err != nil {
 		return diag.FromErr(fmt.Errorf("Error setting cos_endpoint: %s", err))
 	}

--- a/ibm/resource_ibm_atracker_target.go
+++ b/ibm/resource_ibm_atracker_target.go
@@ -1,0 +1,234 @@
+// Copyright IBM Corp. 2021 All Rights Reserved.
+// Licensed under the Mozilla Public License v2.0
+
+package ibm
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"time"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/IBM/go-sdk-core/v5/core"
+	"github.com/IBM/platform-services-go-sdk/atrackerv1"
+)
+
+func resourceIBMAtrackerTarget() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceIBMAtrackerTargetCreate,
+		ReadContext:   resourceIBMAtrackerTargetRead,
+		UpdateContext: resourceIBMAtrackerTargetUpdate,
+		DeleteContext: resourceIBMAtrackerTargetDelete,
+		Importer:      &schema.ResourceImporter{},
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(60 * time.Minute),
+			Update: schema.DefaultTimeout(20 * time.Minute),
+			Delete: schema.DefaultTimeout(10 * time.Minute),
+		},
+
+		Schema: map[string]*schema.Schema{
+			"name": &schema.Schema{
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "The name of the target. Must be 256 characters or less.",
+			},
+			"target_type": &schema.Schema{
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: InvokeValidator("ibm_atracker_target", "target_type"),
+				Description:  "The type of the target.",
+			},
+			"cos_endpoint": &schema.Schema{
+				Type:        schema.TypeList,
+				MinItems:    1,
+				MaxItems:    1,
+				Required:    true,
+				Description: "Property values for a Cloud Object Storage Endpoint.",
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"endpoint": &schema.Schema{
+							Type:        schema.TypeString,
+							Required:    true,
+							Description: "The host name of this COS endpoint.",
+						},
+						"target_crn": &schema.Schema{
+							Type:        schema.TypeString,
+							Required:    true,
+							Description: "The CRN of this COS instance.",
+						},
+						"bucket": &schema.Schema{
+							Type:        schema.TypeString,
+							Required:    true,
+							Description: "The bucket name under this COS instance.",
+						},
+						"api_key": &schema.Schema{
+							Type:        schema.TypeString,
+							Required:    true,
+							Description: "The IAM Api key that have writer access to this cos instance. This credential will be masked in the response.",
+						},
+					},
+				},
+			},
+			"crn": &schema.Schema{
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The crn of this target type resource.",
+			},
+			"encrypt_key": &schema.Schema{
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The encryption key used to encrypt events before ATracker services buffer them on storage. This credential will be masked in the response.",
+			},
+		},
+	}
+}
+
+func resourceIBMAtrackerTargetValidator() *ResourceValidator {
+	validateSchema := make([]ValidateSchema, 1)
+	validateSchema = append(validateSchema,
+		ValidateSchema{
+			Identifier:                 "target_type",
+			ValidateFunctionIdentifier: ValidateAllowedStringValue,
+			Type:                       TypeString,
+			Required:                   true,
+			AllowedValues:              "cloud_object_storage",
+		},
+	)
+
+	resourceValidator := ResourceValidator{ResourceName: "ibm_atracker_target", Schema: validateSchema}
+	return &resourceValidator
+}
+
+func resourceIBMAtrackerTargetCreate(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	atrackerClient, err := meta.(ClientSession).AtrackerV1()
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	createTargetOptions := &atrackerv1.CreateTargetOptions{}
+
+	createTargetOptions.SetName(d.Get("name").(string))
+	createTargetOptions.SetTargetType(d.Get("target_type").(string))
+	cosEndpoint := resourceIBMAtrackerTargetMapToCosEndpoint(d.Get("cos_endpoint.0").(map[string]interface{}))
+	createTargetOptions.SetCosEndpoint(&cosEndpoint)
+
+	target, response, err := atrackerClient.CreateTargetWithContext(context, createTargetOptions)
+	if err != nil {
+		log.Printf("[DEBUG] CreateTargetWithContext failed %s\n%s", err, response)
+		return diag.FromErr(err)
+	}
+
+	d.SetId(*target.ID)
+
+	return resourceIBMAtrackerTargetRead(context, d, meta)
+}
+
+func resourceIBMAtrackerTargetMapToCosEndpoint(cosEndpointMap map[string]interface{}) atrackerv1.CosEndpoint {
+	cosEndpoint := atrackerv1.CosEndpoint{}
+
+	cosEndpoint.Endpoint = core.StringPtr(cosEndpointMap["endpoint"].(string))
+	cosEndpoint.TargetCRN = core.StringPtr(cosEndpointMap["target_crn"].(string))
+	cosEndpoint.Bucket = core.StringPtr(cosEndpointMap["bucket"].(string))
+	cosEndpoint.APIKey = core.StringPtr(cosEndpointMap["api_key"].(string))
+
+	return cosEndpoint
+}
+
+func resourceIBMAtrackerTargetRead(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	atrackerClient, err := meta.(ClientSession).AtrackerV1()
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	getTargetOptions := &atrackerv1.GetTargetOptions{}
+
+	getTargetOptions.SetID(d.Id())
+
+	target, response, err := atrackerClient.GetTargetWithContext(context, getTargetOptions)
+	if err != nil {
+		if response != nil && response.StatusCode == 404 {
+			d.SetId("")
+			return nil
+		}
+		log.Printf("[DEBUG] GetTargetWithContext failed %s\n%s", err, response)
+		return diag.FromErr(err)
+	}
+
+	if err = d.Set("name", target.Name); err != nil {
+		return diag.FromErr(fmt.Errorf("Error setting name: %s", err))
+	}
+	if err = d.Set("target_type", target.TargetType); err != nil {
+		return diag.FromErr(fmt.Errorf("Error setting target_type: %s", err))
+	}
+	cosEndpointMap := resourceIBMAtrackerTargetCosEndpointToMap(*target.CosEndpoint)
+	if err = d.Set("cos_endpoint", []map[string]interface{}{cosEndpointMap}); err != nil {
+		return diag.FromErr(fmt.Errorf("Error setting cos_endpoint: %s", err))
+	}
+	if err = d.Set("crn", target.CRN); err != nil {
+		return diag.FromErr(fmt.Errorf("Error setting crn: %s", err))
+	}
+	if err = d.Set("encrypt_key", target.EncryptKey); err != nil {
+		return diag.FromErr(fmt.Errorf("Error setting encrypt_key: %s", err))
+	}
+
+	return nil
+}
+
+func resourceIBMAtrackerTargetCosEndpointToMap(cosEndpoint atrackerv1.CosEndpoint) map[string]interface{} {
+	cosEndpointMap := map[string]interface{}{}
+
+	cosEndpointMap["endpoint"] = cosEndpoint.Endpoint
+	cosEndpointMap["target_crn"] = cosEndpoint.TargetCRN
+	cosEndpointMap["bucket"] = cosEndpoint.Bucket
+	cosEndpointMap["api_key"] = cosEndpoint.APIKey
+
+	return cosEndpointMap
+}
+
+func resourceIBMAtrackerTargetUpdate(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	atrackerClient, err := meta.(ClientSession).AtrackerV1()
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	replaceTargetOptions := &atrackerv1.ReplaceTargetOptions{}
+
+	replaceTargetOptions.SetID(d.Id())
+	replaceTargetOptions.SetName(d.Get("name").(string))
+	replaceTargetOptions.SetTargetType(d.Get("target_type").(string))
+	cosEndpoint := resourceIBMAtrackerTargetMapToCosEndpoint(d.Get("cos_endpoint.0").(map[string]interface{}))
+	replaceTargetOptions.SetCosEndpoint(&cosEndpoint)
+
+	_, response, err := atrackerClient.ReplaceTargetWithContext(context, replaceTargetOptions)
+	if err != nil {
+		log.Printf("[DEBUG] ReplaceTargetWithContext failed %s\n%s", err, response)
+		return diag.FromErr(err)
+	}
+
+	return resourceIBMAtrackerTargetRead(context, d, meta)
+}
+
+func resourceIBMAtrackerTargetDelete(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	atrackerClient, err := meta.(ClientSession).AtrackerV1()
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	deleteTargetOptions := &atrackerv1.DeleteTargetOptions{}
+
+	deleteTargetOptions.SetID(d.Id())
+
+	response, err := atrackerClient.DeleteTargetWithContext(context, deleteTargetOptions)
+	if err != nil {
+		log.Printf("[DEBUG] DeleteTargetWithContext failed %s\n%s", err, response)
+		return diag.FromErr(err)
+	}
+
+	d.SetId("")
+
+	return nil
+}

--- a/ibm/resource_ibm_atracker_target_test.go
+++ b/ibm/resource_ibm_atracker_target_test.go
@@ -1,0 +1,121 @@
+// Copyright IBM Corp. 2021 All Rights Reserved.
+// Licensed under the Mozilla Public License v2.0
+
+package ibm
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	"github.com/IBM/platform-services-go-sdk/atrackerv1"
+)
+
+func TestAccIBMAtrackerTargetBasic(t *testing.T) {
+	var conf atrackerv1.Target
+	name := fmt.Sprintf("tf_name_%d", acctest.RandIntRange(10, 100))
+	targetType := "cloud_object_storage"
+	nameUpdate := fmt.Sprintf("tf_name_%d", acctest.RandIntRange(10, 100))
+	targetTypeUpdate := "cloud_object_storage"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckIBMAtrackerTargetDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccCheckIBMAtrackerTargetConfigBasic(name, targetType),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckIBMAtrackerTargetExists("ibm_atracker_target.atracker_target", conf),
+					resource.TestCheckResourceAttr("ibm_atracker_target.atracker_target", "name", name),
+					resource.TestCheckResourceAttr("ibm_atracker_target.atracker_target", "target_type", targetType),
+				),
+			},
+			resource.TestStep{
+				Config: testAccCheckIBMAtrackerTargetConfigBasic(nameUpdate, targetTypeUpdate),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("ibm_atracker_target.atracker_target", "name", nameUpdate),
+					resource.TestCheckResourceAttr("ibm_atracker_target.atracker_target", "target_type", targetTypeUpdate),
+				),
+			},
+			resource.TestStep{
+				ResourceName:      "ibm_atracker_target.atracker_target",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testAccCheckIBMAtrackerTargetConfigBasic(name string, targetType string) string {
+	return fmt.Sprintf(`
+
+		resource "ibm_atracker_target" "atracker_target" {
+			name = "%s"
+			target_type = "%s"
+			cos_endpoint {
+				endpoint = "s3.private.us-east.cloud-object-storage.appdomain.cloud"
+				target_crn = "crn:v1:bluemix:public:cloud-object-storage:global:a/11111111111111111111111111111111:22222222-2222-2222-2222-222222222222::"
+				bucket = "my-atracker-bucket"
+				api_key = "xxxxxxxxxxxxxx"
+			}
+		}
+	`, name, targetType)
+}
+
+func testAccCheckIBMAtrackerTargetExists(n string, obj atrackerv1.Target) resource.TestCheckFunc {
+
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+
+		atrackerClient, err := testAccProvider.Meta().(ClientSession).AtrackerV1()
+		if err != nil {
+			return err
+		}
+
+		getTargetOptions := &atrackerv1.GetTargetOptions{}
+
+		getTargetOptions.SetID(rs.Primary.ID)
+
+		target, _, err := atrackerClient.GetTarget(getTargetOptions)
+		if err != nil {
+			return err
+		}
+
+		obj = *target
+		return nil
+	}
+}
+
+func testAccCheckIBMAtrackerTargetDestroy(s *terraform.State) error {
+	atrackerClient, err := testAccProvider.Meta().(ClientSession).AtrackerV1()
+	if err != nil {
+		return err
+	}
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "ibm_atracker_target" {
+			continue
+		}
+
+		getTargetOptions := &atrackerv1.GetTargetOptions{}
+
+		getTargetOptions.SetID(rs.Primary.ID)
+
+		// Try to find the key
+		_, response, err := atrackerClient.GetTarget(getTargetOptions)
+
+		if err == nil {
+			return fmt.Errorf("ATracker Target still exists: %s", rs.Primary.ID)
+		} else if response.StatusCode != 404 {
+			return fmt.Errorf("Error checking for ATracker Target (%s) has been destroyed: %s", rs.Primary.ID, err)
+		}
+	}
+
+	return nil
+}


### PR DESCRIPTION
This PR adds the Terraform support for the new ATracker service.

The code is mostly generated from our Terraform generator, with just a few small hand-edits.

The new code has not been tested as I do not have access to a test environment.

Marking as Draft for now until testing has been completed.