### PR TITLE
Database node support

### DIFF
--- a/ibm/resource_ibm_database_elasticsearch_test.go
+++ b/ibm/resource_ibm_database_elasticsearch_test.go
@@ -83,6 +83,102 @@ func TestAccIBMDatabaseInstance_Elasticsearch_Basic(t *testing.T) {
 	})
 }
 
+func TestAccIBMDatabaseInstance_Elasticsearch_Node(t *testing.T) {
+	t.Parallel()
+	databaseResourceGroup := "default"
+	var databaseInstanceOne string
+	rnd := fmt.Sprintf("tf-Es-%d", acctest.RandIntRange(10, 100))
+	testName := rnd
+	name := "ibm_database." + testName
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckIBMDatabaseInstanceDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckIBMDatabaseInstanceElasticsearchNodeBasic(databaseResourceGroup, testName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckIBMDatabaseInstanceExists(name, &databaseInstanceOne),
+					resource.TestCheckResourceAttr(name, "name", testName),
+					resource.TestCheckResourceAttr(name, "service", "databases-for-elasticsearch"),
+					resource.TestCheckResourceAttr(name, "plan", "standard"),
+					resource.TestCheckResourceAttr(name, "location", "us-south"),
+					resource.TestCheckResourceAttr(name, "adminuser", "admin"),
+					resource.TestCheckResourceAttr(name, "node_count", "3"),
+					resource.TestCheckResourceAttr(name, "node_memory_allocation_mb", "1024"),
+					resource.TestCheckResourceAttr(name, "node_disk_allocation_mb", "5120"),
+					resource.TestCheckResourceAttr(name, "node_cpu_allocation_count", "3"),
+
+					resource.TestCheckResourceAttr(name, "whitelist.#", "1"),
+					resource.TestCheckResourceAttr(name, "users.#", "1"),
+					resource.TestCheckResourceAttr(name, "connectionstrings.#", "2"),
+					resource.TestCheckResourceAttr(name, "connectionstrings.1.name", "admin"),
+					resource.TestCheckResourceAttr(name, "connectionstrings.0.hosts.#", "1"),
+					resource.TestCheckResourceAttr(name, "connectionstrings.0.database", ""),
+				),
+			},
+			{
+				Config: testAccCheckIBMDatabaseInstanceElasticsearchNodeFullyspecified(databaseResourceGroup, testName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckIBMDatabaseInstanceExists(name, &databaseInstanceOne),
+					resource.TestCheckResourceAttr(name, "name", testName),
+					resource.TestCheckResourceAttr(name, "service", "databases-for-elasticsearch"),
+					resource.TestCheckResourceAttr(name, "plan", "standard"),
+					resource.TestCheckResourceAttr(name, "location", "us-south"),
+					resource.TestCheckResourceAttr(name, "node_count", "3"),
+					resource.TestCheckResourceAttr(name, "node_memory_allocation_mb", "1024"),
+					resource.TestCheckResourceAttr(name, "node_disk_allocation_mb", "6144"),
+					resource.TestCheckResourceAttr(name, "node_cpu_allocation_count", "3"),
+					resource.TestCheckResourceAttr(name, "whitelist.#", "2"),
+					resource.TestCheckResourceAttr(name, "users.#", "2"),
+					resource.TestCheckResourceAttr(name, "connectionstrings.#", "3"),
+					resource.TestCheckResourceAttr(name, "connectionstrings.2.name", "admin"),
+				),
+			},
+			{
+				Config: testAccCheckIBMDatabaseInstanceElasticsearchNodeReduced(databaseResourceGroup, testName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckIBMDatabaseInstanceExists(name, &databaseInstanceOne),
+					resource.TestCheckResourceAttr(name, "name", testName),
+					resource.TestCheckResourceAttr(name, "service", "databases-for-elasticsearch"),
+					resource.TestCheckResourceAttr(name, "plan", "standard"),
+					resource.TestCheckResourceAttr(name, "location", "us-south"),
+					resource.TestCheckResourceAttr(name, "node_count", "3"),
+					resource.TestCheckResourceAttr(name, "node_memory_allocation_mb", "1024"),
+					resource.TestCheckResourceAttr(name, "node_disk_allocation_mb", "6144"),
+					resource.TestCheckResourceAttr(name, "node_cpu_allocation_count", "3"),
+					resource.TestCheckResourceAttr(name, "whitelist.#", "0"),
+					resource.TestCheckResourceAttr(name, "users.#", "0"),
+					resource.TestCheckResourceAttr(name, "connectionstrings.#", "1"),
+				),
+			},
+			{
+				Config: testAccCheckIBMDatabaseInstanceElasticsearchNodeScaleOut(databaseResourceGroup, testName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckIBMDatabaseInstanceExists(name, &databaseInstanceOne),
+					resource.TestCheckResourceAttr(name, "name", testName),
+					resource.TestCheckResourceAttr(name, "service", "databases-for-elasticsearch"),
+					resource.TestCheckResourceAttr(name, "plan", "standard"),
+					resource.TestCheckResourceAttr(name, "location", "us-south"),
+					resource.TestCheckResourceAttr(name, "node_count", "4"),
+					resource.TestCheckResourceAttr(name, "node_memory_allocation_mb", "1024"),
+					resource.TestCheckResourceAttr(name, "node_disk_allocation_mb", "6144"),
+					resource.TestCheckResourceAttr(name, "node_cpu_allocation_count", "3"),
+					resource.TestCheckResourceAttr(name, "whitelist.#", "0"),
+					resource.TestCheckResourceAttr(name, "users.#", "0"),
+					resource.TestCheckResourceAttr(name, "connectionstrings.#", "1"),
+				),
+			},
+			//{
+			//	ResourceName:      name,
+			//	ImportState:       true,
+			//	ImportStateVerify: true,
+			//},
+		},
+	})
+}
+
 // TestAccIBMDatabaseInstance_CreateAfterManualDestroy not required as tested by resource_instance tests
 
 func TestAccIBMDatabaseInstanceElasticsearchImport(t *testing.T) {
@@ -113,7 +209,7 @@ func TestAccIBMDatabaseInstanceElasticsearchImport(t *testing.T) {
 				ImportState:       true,
 				ImportStateVerify: true,
 				ImportStateVerifyIgnore: []string{
-					"wait_time_minutes"},
+					"wait_time_minutes", "plan_validation"},
 			},
 		},
 	})
@@ -206,6 +302,120 @@ func testAccCheckIBMDatabaseInstanceElasticsearchReduced(databaseResourceGroup s
 				`, databaseResourceGroup, name)
 }
 
+func testAccCheckIBMDatabaseInstanceElasticsearchNodeBasic(databaseResourceGroup string, name string) string {
+	return fmt.Sprintf(`
+	data "ibm_resource_group" "test_acc" {
+		is_default = true
+		# name = "%[1]s"
+	}
+	  
+	resource "ibm_database" "%[2]s" {
+		resource_group_id            = data.ibm_resource_group.test_acc.id
+		name                         = "%[2]s"
+		service                      = "databases-for-elasticsearch"
+		plan                         = "standard"
+		location                     = "us-south"
+		adminpassword                = "password12"
+		node_count					 = 3
+		node_memory_allocation_mb    = 1024
+		node_disk_allocation_mb      = 5120
+        node_cpu_allocation_count    = 3
+
+		users {
+		  name     = "user123"
+		  password = "password12"
+		}
+		whitelist {
+		  address     = "172.168.1.2/32"
+		  description = "desc1"
+		}
+	}
+				`, databaseResourceGroup, name)
+}
+
+func testAccCheckIBMDatabaseInstanceElasticsearchNodeFullyspecified(databaseResourceGroup string, name string) string {
+	return fmt.Sprintf(`
+	data "ibm_resource_group" "test_acc" {
+		is_default = true
+		# name = "%[1]s"
+	}
+	  
+	resource "ibm_database" "%[2]s" {
+		resource_group_id            = data.ibm_resource_group.test_acc.id
+		name                         = "%[2]s"
+		service                      = "databases-for-elasticsearch"
+		plan                         = "standard"
+		location                     = "us-south"
+		adminpassword                = "password12"
+		node_count					 = 3
+		node_memory_allocation_mb    = 1024
+		node_disk_allocation_mb      = 6144
+        node_cpu_allocation_count    = 3
+		users {
+		  name     = "user123"
+		  password = "password12"
+		}
+		users {
+		  name     = "user124"
+		  password = "password12"
+		}
+		whitelist {
+		  address     = "172.168.1.2/32"
+		  description = "desc1"
+		}
+		whitelist {
+		  address     = "172.168.1.1/32"
+		  description = "desc"
+		}
+	}
+	  
+				`, databaseResourceGroup, name)
+}
+
+func testAccCheckIBMDatabaseInstanceElasticsearchNodeReduced(databaseResourceGroup string, name string) string {
+	return fmt.Sprintf(`
+	data "ibm_resource_group" "test_acc" {
+		is_default = true
+		# name = "%[1]s"
+	}
+	  
+	resource "ibm_database" "%[2]s" {
+		resource_group_id            = data.ibm_resource_group.test_acc.id
+		name                         = "%[2]s"
+		service                      = "databases-for-elasticsearch"
+		plan                         = "standard"
+		location                     = "us-south"
+		adminpassword                = "password12"
+		node_count					 = 3
+		node_memory_allocation_mb    = 1024
+		node_disk_allocation_mb      = 6144
+        node_cpu_allocation_count    = 3
+	}
+				`, databaseResourceGroup, name)
+}
+
+func testAccCheckIBMDatabaseInstanceElasticsearchNodeScaleOut(databaseResourceGroup string, name string) string {
+	return fmt.Sprintf(`
+	data "ibm_resource_group" "test_acc" {
+		is_default = true
+		# name = "%[1]s"
+	}
+	  
+	resource "ibm_database" "%[2]s" {
+		resource_group_id            = data.ibm_resource_group.test_acc.id
+		name                         = "%[2]s"
+		service                      = "databases-for-elasticsearch"
+		plan                         = "standard"
+		location                     = "us-south"
+		adminpassword                = "password12"
+        node_count                   = 4
+		node_memory_allocation_mb    = 1024
+		node_disk_allocation_mb      = 6144
+        node_cpu_allocation_count    = 3
+	}
+				`, databaseResourceGroup, name)
+}
+
 func testAccCheckIBMDatabaseInstanceElasticsearchImport(databaseResourceGroup string, name string) string {
 	return fmt.Sprintf(`
 	data "ibm_resource_group" "test_acc" {
@@ -220,5 +430,6 @@ func testAccCheckIBMDatabaseInstanceElasticsearchImport(databaseResourceGroup st
 		plan              = "standard"
 		location          = "us-south"
 	}
+
 				`, databaseResourceGroup, name)
 }

--- a/ibm/resource_ibm_database_etcd_test.go
+++ b/ibm/resource_ibm_database_etcd_test.go
@@ -108,7 +108,7 @@ func TestAccIBMDatabaseInstanceEtcdImport(t *testing.T) {
 				ImportState:       true,
 				ImportStateVerify: true,
 				ImportStateVerifyIgnore: []string{
-					"wait_time_minutes"},
+					"wait_time_minutes", "plan_validation"},
 			},
 		},
 	})

--- a/ibm/resource_ibm_database_mongodb_test.go
+++ b/ibm/resource_ibm_database_mongodb_test.go
@@ -115,7 +115,7 @@ func TestAccIBMDatabaseInstanceMongodbImport(t *testing.T) {
 				ImportState:       true,
 				ImportStateVerify: true,
 				ImportStateVerifyIgnore: []string{
-					"wait_time_minutes", "connectionstrings"},
+					"wait_time_minutes", "connectionstrings", "plan_validation"},
 			},
 		},
 	})

--- a/ibm/resource_ibm_database_postgresql_test.go
+++ b/ibm/resource_ibm_database_postgresql_test.go
@@ -103,6 +103,112 @@ func TestAccIBMDatabaseInstance_Postgres_Basic(t *testing.T) {
 	})
 }
 
+func TestAccIBMDatabaseInstance_Postgres_Node(t *testing.T) {
+	t.Parallel()
+	databaseResourceGroup := "default"
+	var databaseInstanceOne string
+	rnd := fmt.Sprintf("tf-Pgress-%d", acctest.RandIntRange(10, 100))
+	testName := rnd
+	name := "ibm_database." + testName
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckIBMDatabaseInstanceDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckIBMDatabaseInstancePostgresNodeBasic(databaseResourceGroup, testName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckIBMDatabaseInstanceExists(name, &databaseInstanceOne),
+					resource.TestCheckResourceAttr(name, "name", testName),
+					resource.TestCheckResourceAttr(name, "service", "databases-for-postgresql"),
+					resource.TestCheckResourceAttr(name, "plan", "standard"),
+					resource.TestCheckResourceAttr(name, "location", "us-south"),
+					resource.TestCheckResourceAttr(name, "adminuser", "admin"),
+					resource.TestCheckResourceAttr(name, "node_count", "2"),
+					resource.TestCheckResourceAttr(name, "node_memory_allocation_mb", "1024"),
+					resource.TestCheckResourceAttr(name, "node_disk_allocation_mb", "5120"),
+					resource.TestCheckResourceAttr(name, "node_cpu_allocation_count", "3"),
+					resource.TestCheckResourceAttr(name, "service_endpoints", "public"),
+					resource.TestCheckResourceAttr(name, "whitelist.#", "1"),
+					resource.TestCheckResourceAttr(name, "users.#", "1"),
+					resource.TestCheckResourceAttr(name, "connectionstrings.#", "2"),
+					resource.TestCheckResourceAttr(name, "connectionstrings.1.name", "admin"),
+					resource.TestMatchResourceAttr(name, "connectionstrings.1.certname", regexp.MustCompile("[-a-z0-9]*")),
+					resource.TestMatchResourceAttr(name, "connectionstrings.1.certbase64", regexp.MustCompile("^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$")),
+					resource.TestCheckResourceAttr(name, "tags.#", "1"),
+				),
+			},
+			{
+				Config: testAccCheckIBMDatabaseInstancePostgresNodeFullyspecified(databaseResourceGroup, testName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckIBMDatabaseInstanceExists(name, &databaseInstanceOne),
+					resource.TestCheckResourceAttr(name, "name", testName),
+					resource.TestCheckResourceAttr(name, "service", "databases-for-postgresql"),
+					resource.TestCheckResourceAttr(name, "plan", "standard"),
+					resource.TestCheckResourceAttr(name, "location", "us-south"),
+					resource.TestCheckResourceAttr(name, "node_count", "2"),
+					resource.TestCheckResourceAttr(name, "node_memory_allocation_mb", "1024"),
+					resource.TestCheckResourceAttr(name, "node_disk_allocation_mb", "7168"),
+					resource.TestCheckResourceAttr(name, "node_cpu_allocation_count", "3"),
+					resource.TestCheckResourceAttr(name, "service_endpoints", "public-and-private"),
+					resource.TestCheckResourceAttr(name, "whitelist.#", "2"),
+					resource.TestCheckResourceAttr(name, "users.#", "2"),
+					resource.TestCheckResourceAttr(name, "connectionstrings.#", "3"),
+					resource.TestCheckResourceAttr(name, "connectionstrings.2.name", "admin"),
+					resource.TestCheckResourceAttr(name, "connectionstrings.0.hosts.#", "1"),
+					resource.TestCheckResourceAttr(name, "connectionstrings.0.scheme", "postgres"),
+					resource.TestMatchResourceAttr(name, "connectionstrings.0.certname", regexp.MustCompile("[-a-z0-9]*")),
+					resource.TestMatchResourceAttr(name, "connectionstrings.0.certbase64", regexp.MustCompile("^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$")),
+					resource.TestMatchResourceAttr(name, "connectionstrings.0.database", regexp.MustCompile("[-a-z0-9]+")),
+					resource.TestCheckResourceAttr(name, "tags.#", "1"),
+				),
+			},
+			{
+				Config: testAccCheckIBMDatabaseInstancePostgresNodeReduced(databaseResourceGroup, testName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckIBMDatabaseInstanceExists(name, &databaseInstanceOne),
+					resource.TestCheckResourceAttr(name, "name", testName),
+					resource.TestCheckResourceAttr(name, "service", "databases-for-postgresql"),
+					resource.TestCheckResourceAttr(name, "plan", "standard"),
+					resource.TestCheckResourceAttr(name, "location", "us-south"),
+					resource.TestCheckResourceAttr(name, "node_count", "2"),
+					resource.TestCheckResourceAttr(name, "node_memory_allocation_mb", "1024"),
+					resource.TestCheckResourceAttr(name, "node_disk_allocation_mb", "7168"),
+					resource.TestCheckResourceAttr(name, "node_cpu_allocation_count", "3"),
+					resource.TestCheckResourceAttr(name, "whitelist.#", "0"),
+					resource.TestCheckResourceAttr(name, "users.#", "0"),
+					resource.TestCheckResourceAttr(name, "connectionstrings.#", "1"),
+					resource.TestCheckResourceAttr(name, "tags.#", "1"),
+				),
+			},
+			{
+				Config: testAccCheckIBMDatabaseInstancePostgresNodeScaleOut(databaseResourceGroup, testName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckIBMDatabaseInstanceExists(name, &databaseInstanceOne),
+					resource.TestCheckResourceAttr(name, "name", testName),
+					resource.TestCheckResourceAttr(name, "service", "databases-for-postgresql"),
+					resource.TestCheckResourceAttr(name, "plan", "standard"),
+					resource.TestCheckResourceAttr(name, "location", "us-south"),
+					resource.TestCheckResourceAttr(name, "node_count", "3"),
+					resource.TestCheckResourceAttr(name, "node_memory_allocation_mb", "1024"),
+					resource.TestCheckResourceAttr(name, "node_disk_allocation_mb", "7168"),
+					resource.TestCheckResourceAttr(name, "node_cpu_allocation_count", "3"),
+					resource.TestCheckResourceAttr(name, "whitelist.#", "0"),
+					resource.TestCheckResourceAttr(name, "users.#", "0"),
+					resource.TestCheckResourceAttr(name, "connectionstrings.#", "1"),
+					resource.TestCheckResourceAttr(name, "tags.#", "1"),
+				),
+			},
+			// {
+			// 	ResourceName:      name,
+			// 	ImportState:       true,
+			// 	ImportStateVerify: true,
+			// },
+		},
+	})
+}
+
 // TestAccIBMDatabaseInstance_CreateAfterManualDestroy not required as tested by resource_instance tests
 
 func TestAccIBMDatabaseInstancePostgresImport(t *testing.T) {
@@ -133,7 +239,7 @@ func TestAccIBMDatabaseInstancePostgresImport(t *testing.T) {
 				ImportState:       true,
 				ImportStateVerify: true,
 				ImportStateVerifyIgnore: []string{
-					"wait_time_minutes"},
+					"wait_time_minutes", "plan_validation"},
 			},
 		},
 	})
@@ -344,6 +450,120 @@ func testAccCheckIBMDatabaseInstancePostgresReduced(databaseResourceGroup string
 		adminpassword                = "password12"
 		members_memory_allocation_mb = 2048
 		members_disk_allocation_mb   = 14336
+		service_endpoints            = "public"
+		tags                         = ["one:two"]
+	  }
+				`, databaseResourceGroup, name)
+}
+
+func testAccCheckIBMDatabaseInstancePostgresNodeBasic(databaseResourceGroup string, name string) string {
+	return fmt.Sprintf(`
+	data "ibm_resource_group" "test_acc" {
+		name = "%[1]s"
+	}
+	  
+	resource "ibm_database" "%[2]s" {
+		resource_group_id            = data.ibm_resource_group.test_acc.id
+		name                         = "%[2]s"
+		service                      = "databases-for-postgresql"
+		plan                         = "standard"
+		location                     = "us-south"
+		adminpassword                = "password12"
+        node_count                   = 2
+        node_memory_allocation_mb    = 1024
+        node_disk_allocation_mb      = 7168
+	    node_cpu_allocation_count    = 3
+		tags                         = ["one:two"]
+		users {
+		  name     = "user123"
+		  password = "password12"
+		}
+		whitelist {
+		  address     = "172.168.1.2/32"
+		  description = "desc1"
+		}
+	}
+				`, databaseResourceGroup, name)
+}
+
+func testAccCheckIBMDatabaseInstancePostgresNodeFullyspecified(databaseResourceGroup string, name string) string {
+	return fmt.Sprintf(`
+	data "ibm_resource_group" "test_acc" {
+		name = "%[1]s"
+	}
+	  
+	resource "ibm_database" "%[2]s" {
+		resource_group_id            = data.ibm_resource_group.test_acc.id
+		name                         = "%[2]s"
+		service                      = "databases-for-postgresql"
+		plan                         = "standard"
+		location                     = "us-south"
+		adminpassword                = "password12"
+        node_count                   = 2
+        node_memory_allocation_mb    = 1024
+        node_disk_allocation_mb      = 7168
+		node_cpu_allocation_count    = 3
+		service_endpoints            = "public-and-private"
+		tags                         = ["one:two"]
+		users {
+		  name     = "user123"
+		  password = "password12"
+		}
+		users {
+		  name     = "user124"
+		  password = "password12"
+		}
+		whitelist {
+		  address     = "172.168.1.2/32"
+		  description = "desc1"
+		}
+		whitelist {
+		  address     = "172.168.1.1/32"
+		  description = "desc"
+		}
+	}
+				`, databaseResourceGroup, name)
+}
+
+func testAccCheckIBMDatabaseInstancePostgresNodeReduced(databaseResourceGroup string, name string) string {
+	return fmt.Sprintf(`
+	data "ibm_resource_group" "test_acc" {
+		name = "%[1]s"
+	  }
+	  
+	  resource "ibm_database" "%[2]s" {
+		resource_group_id            = data.ibm_resource_group.test_acc.id
+		name                         = "%[2]s"
+		service                      = "databases-for-postgresql"
+		plan                         = "standard"
+		location                     = "us-south"
+		adminpassword                = "password12"
+        node_count                   = 2
+        node_memory_allocation_mb    = 1024
+        node_disk_allocation_mb      = 7168
+        node_cpu_allocation_count    = 3
+		service_endpoints            = "public"
+		tags                         = ["one:two"]
+	  }
+				`, databaseResourceGroup, name)
+}
+func testAccCheckIBMDatabaseInstancePostgresNodeScaleOut(databaseResourceGroup string, name string) string {
+	return fmt.Sprintf(`
+	data "ibm_resource_group" "test_acc" {
+		name = "%[1]s"
+	  }
+	  
+	  resource "ibm_database" "%[2]s" {
+		resource_group_id            = data.ibm_resource_group.test_acc.id
+		name                         = "%[2]s"
+		service                      = "databases-for-postgresql"
+		plan                         = "standard"
+		location                     = "us-south"
+		adminpassword                = "password12"
+        node_count                   = 3
+        node_memory_allocation_mb    = 1024
+        node_disk_allocation_mb      = 7168
+        node_cpu_allocation_count    = 3
 		service_endpoints            = "public"
 		tags                         = ["one:two"]
 	  }

--- a/ibm/resource_ibm_database_rabbitmq_test.go
+++ b/ibm/resource_ibm_database_rabbitmq_test.go
@@ -113,7 +113,7 @@ func TestAccIBMDatabaseInstanceRabbitmqImport(t *testing.T) {
 				ImportState:       true,
 				ImportStateVerify: true,
 				ImportStateVerifyIgnore: []string{
-					"wait_time_minutes"},
+					"wait_time_minutes", "plan_validation"},
 			},
 		},
 	})

--- a/ibm/resource_ibm_database_redis_test.go
+++ b/ibm/resource_ibm_database_redis_test.go
@@ -105,7 +105,7 @@ func TestAccIBMDatabaseInstanceRedisImport(t *testing.T) {
 				ImportState:       true,
 				ImportStateVerify: true,
 				ImportStateVerifyIgnore: []string{
-					"wait_time_minutes"},
+					"wait_time_minutes", "plan_validation"},
 			},
 		},
 	})


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/IBM-Cloud/terraform-provider-ibm/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

New Features for postgres and elasticsearch.:
- Validation is now performed during the plan phase instead of apply
- Horizontal scaling with new attributes `node_count`,  `node_memory_allocation_mb`, `node_disk_allocation_mb`, `node_cpu_allocation_count`
- Deployments can switch between `memory_` to `node_`

- Validation during plan can be enabled for all databases once ICD Deployables is working: https://github.ibm.com/compose/compose/issues/21523
- Since the deployables API is not fully functional an optional `plan_validation` attribute was added to maintain the existing functionality.   See PR Review comments on how this is being used. 

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Closes #2313
Relates  https://github.com/IBM-Cloud/bluemix-go/pull/291
Relates  https://github.ibm.com/compose/compose/issues/21523

Test Cases:

```
 make testacc TESTARGS='-run= TestAccIBMDatabaseInstance_Elasticsearch_Basic'
 make testacc TESTARGS='-run=TestAccIBMDatabaseInstance_Elasticsearch_Node'
 make testacc TESTARGS='-run=TestAccIBMDatabaseInstance_Postgres_Basic'
 make testacc TESTARGS='-run=TestAccIBMDatabaseInstance_Postgres_Node'

...
```
