### PR TITLE
Support virtual endpoint gateway as target to subnet reserved IP

### DIFF
--- a/ibm/data_source_ibm_is_subnet_reserved_ip.go
+++ b/ibm/data_source_ibm_is_subnet_reserved_ip.go
@@ -6,6 +6,7 @@ package ibm
 import (
 	"fmt"
 
+	"github.com/IBM/vpc-go-sdk/vpcv1"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
@@ -87,6 +88,11 @@ func dataSourceIBMISReservedIP() *schema.Resource {
 				Computed:    true,
 				Description: "The resource type.",
 			},
+			isReservedIPTarget: {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "Reserved IP target id.",
+			},
 		},
 	}
 }
@@ -116,5 +122,11 @@ func dataSdataSourceIBMISReservedIPRead(d *schema.ResourceData, meta interface{}
 	d.Set(isReservedIPName, *reserveIP.Name)
 	d.Set(isReservedIPOwner, *reserveIP.Owner)
 	d.Set(isReservedIPType, *reserveIP.ResourceType)
+	if reserveIP.Target != nil {
+		target, ok := reserveIP.Target.(*vpcv1.ReservedIPTarget)
+		if ok {
+			d.Set(isReservedIPTarget, target.ID)
+		}
+	}
 	return nil // By default there should be no error
 }

--- a/ibm/data_source_ibm_is_subnet_reserved_ips.go
+++ b/ibm/data_source_ibm_is_subnet_reserved_ips.go
@@ -87,6 +87,11 @@ func dataSourceIBMISReservedIPs() *schema.Resource {
 							Computed:    true,
 							Description: "The resource type.",
 						},
+						isReservedIPTarget: {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "Reserved IP target id",
+						},
 					},
 				},
 			},
@@ -140,7 +145,10 @@ func dataSdataSourceIBMISReservedIPsRead(d *schema.ResourceData, meta interface{
 		ipsOutput[isReservedIPName] = *data.Name
 		ipsOutput[isReservedIPOwner] = *data.Owner
 		ipsOutput[isReservedIPType] = *data.ResourceType
-
+		target, ok := data.Target.(*vpcv1.ReservedIPTarget)
+		if ok {
+			ipsOutput[isReservedIPTarget] = target.ID
+		}
 		reservedIPs = append(reservedIPs, ipsOutput)
 	}
 

--- a/ibm/resource_ibm_is_subnet_reserved_ip.go
+++ b/ibm/resource_ibm_is_subnet_reserved_ip.go
@@ -16,6 +16,7 @@ const (
 	isReservedIPProvisioning     = "provisioning"
 	isReservedIPProvisioningDone = "done"
 	isReservedIP                 = "reserved_ip"
+	isReservedIPTarget           = "target"
 )
 
 func resourceIBMISReservedIP() *schema.Resource {
@@ -55,6 +56,12 @@ func resourceIBMISReservedIP() *schema.Resource {
 				Optional:     true,
 				ValidateFunc: InvokeValidator("ibm_is_subnet_reserved_ip", isReservedIPName),
 				Description:  "The user-defined or system-provided name for this reserved IP.",
+			},
+			isReservedIPTarget: {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Optional:    true,
+				Description: "The unique identifier for target.",
 			},
 			/*
 				Response Parameters
@@ -133,7 +140,12 @@ func resourceIBMISReservedIPCreate(d *schema.ResourceData, meta interface{}) err
 
 	autoDeleteBool := d.Get(isReservedIPAutoDelete).(bool)
 	options.AutoDelete = &autoDeleteBool
-
+	if t, ok := d.GetOk(isReservedIPTarget); ok {
+		targetId := t.(string)
+		options.Target = &vpcv1.ReservedIPTargetPrototype{
+			ID: &targetId,
+		}
+	}
 	rip, response, err := sess.CreateSubnetReservedIP(options)
 	if err != nil || response == nil || rip == nil {
 		return fmt.Errorf("Error creating the reserved IP: %s\n%s", err, response)
@@ -167,6 +179,12 @@ func resourceIBMISReservedIPRead(d *schema.ResourceData, meta interface{}) error
 		d.Set(isReservedIPName, *rip.Name)
 		d.Set(isReservedIPOwner, *rip.Owner)
 		d.Set(isReservedIPType, *rip.ResourceType)
+		if rip.Target != nil {
+			target, ok := rip.Target.(*vpcv1.ReservedIPTarget)
+			if ok {
+				d.Set(isReservedIPTarget, target.ID)
+			}
+		}
 	}
 	return nil
 }

--- a/ibm/resource_ibm_is_subnet_reserved_ip_test.go
+++ b/ibm/resource_ibm_is_subnet_reserved_ip_test.go
@@ -111,9 +111,19 @@ func testAccCheckISSubnetReservedIPConfigBasic(vpcName, subnetName, resIPName st
 		total_ipv4_address_count = 256
 	  }
 
+	  resource "ibm_is_virtual_endpoint_gateway" "endpoint_gateway" {
+		name = "my-endpoint-gateway-1"
+		target {
+		  name          = "ibm-ntp-server"
+		  resource_type = "provider_infrastructure_service"
+		}
+		vpc = ibm_is_vpc.vpc1.id
+	  }
+
 	  resource "ibm_is_subnet_reserved_ip" "resIP1" {
 		subnet = ibm_is_subnet.subnet1.id
 		name = "%s"
+		target = ibm_is_virtual_endpoint_gateway.endpoint_gateway.id
 	  }
 	`, vpcName, subnetName, resIPName)
 }

--- a/website/docs/d/is_subnet_reserved_ip.html.markdown
+++ b/website/docs/d/is_subnet_reserved_ip.html.markdown
@@ -40,3 +40,4 @@ The following attributes are exported as output/response:
 * `reserved_ip` - Same as `id`
 * `resource_type` - The type of resource
 * `subnet` - The id for the subnet for the reserved IP
+* `target` - The id for the target for the reserved IP

--- a/website/docs/d/is_subnet_reserved_ips.html.markdown
+++ b/website/docs/d/is_subnet_reserved_ips.html.markdown
@@ -40,7 +40,8 @@ The following attributes are exported as output/response:
    - `name` - The user-defined or system-provided name for this reserved IP
    - `owner` - The owner of a reserved IP, defining whether it is managed by the user or the provider
    - `resource_type` - The resource type
-  
+   - `target` - The id for the target for the reserved IP.
+
 * `sort` - The keyword on which all the reserved IPs are sorted
 * `subnet` - The id for the subnet for the reserved IP
 * `total_count` - The number of reserved IP in the subnet

--- a/website/docs/r/is_subnet_reserved_ip.html.markdown
+++ b/website/docs/r/is_subnet_reserved_ip.html.markdown
@@ -38,7 +38,7 @@ In the following example, you can create a Reserved IP:
     // Subnet ID with a given name
     resource "ibm_is_subnet_reserved_ip" "res_ip_name" {
         subnet = ibm_is_subnet.subnet1.id
-        name = "my-subnet"
+        name = "my-subnet-reserved-ip"
     }
 
     // Subnet ID with auto_delete
@@ -50,8 +50,23 @@ In the following example, you can create a Reserved IP:
     // Subnet ID with both name and auto_delete
     resource "ibm_is_subnet_reserved_ip" "res_ip_auto_delete_name" {
         subnet = ibm_is_subnet.subnet1.id
-        name = "my-subnet"
+        name = "my-subnet-reserved-ip"
         auto_delete = true
+    }
+
+        // Create a virtual endpoint gateway and set as a target for reserved IP
+    resource "ibm_is_virtual_endpoint_gateway" "endpoint_gateway" {
+        name = "my-endpoint-gateway-1"
+        target {
+            name          = "ibm-ntp-server"
+            resource_type = "provider_infrastructure_service"
+        }
+        vpc = ibm_is_vpc.vpc1.id
+    }
+    resource "ibm_is_subnet_reserved_ip" "reserved_ip_1" {
+        subnet = ibm_is_subnet.subnet1.id
+        name = "%s"
+        target = ibm_is_virtual_endpoint_gateway.endpoint_gateway.id
     }
 ```
 
@@ -63,6 +78,7 @@ The following arguments are supported:
 * `name` - (Optional, string) The name of the reserved IP.
     **NOTE**: Raise error if name is given with a prefix `ibm-`.
 * `auto_delete` - (Optional, boolean) If reserved IP is auto deleted.
+* `target` - The id for the target endpoint gateway for the reserved IP.
 
 
 ## Attribure Reference
@@ -74,6 +90,7 @@ The following arguments are supported:
 * `owner` - The owner of a reserved IP, defining whether it is managed by the user or the provider.
 * `resource_type` - The resource type.
 * `address` - The IP address.
+* `target` - The id for the target endpoint gateway for the reserved IP.
 
 ## Import
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/IBM-Cloud/terraform-provider-ibm/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
(venv) astha@Asthas-MacBook-Pro:~/go/src/github.com/IBM-Cloud/terraform-provider-ibm$ TF_ACC=1 go test -v -run=TestAccIBMISSubnetReservedIPResource_basic ./ibm

=== RUN   TestAccIBMISSubnetReservedIPResource_basic
--- PASS: TestAccIBMISSubnetReservedIPResource_basic (105.43s)
PASS
ok      github.com/IBM-Cloud/terraform-provider-ibm/ibm 106.826s
...

...
```
