### PR TITLE
feat(ibm_cis_dns_record): Support PTR DNS records

### DIFF
--- a/ibm/resource_ibm_cis_dns_record.go
+++ b/ibm/resource_ibm_cis_dns_record.go
@@ -401,7 +401,7 @@ func resourceIBMCISDnsRecordCreate(d *schema.ResourceData, meta interface{}) err
 			opt.SetPriority(priority.(int64))
 		}
 		if ttl, ok := d.GetOk("ttl"); ok {
-			opt.SetTTL(ttl.(int64))
+			opt.SetTTL(int64(ttl.(int)))
 		}
 
 	}
@@ -736,7 +736,7 @@ func resourceIBMCISDnsRecordUpdate(d *schema.ResourceData, meta interface{}) err
 					opt.SetProxied(proxied.(bool))
 				}
 				if ttlOK {
-					opt.SetTTL(ttl.(int64))
+					opt.SetTTL(int64(ttl.(int)))
 				}
 				if ttl != 1 && proxied == true {
 					return fmt.Errorf("To enable proxy TTL should be Automatic %s",

--- a/ibm/resource_ibm_cis_dns_record.go
+++ b/ibm/resource_ibm_cis_dns_record.go
@@ -43,6 +43,7 @@ const (
 	cisDNSRecordTypeSPF   = "SPF"
 	cisDNSRecordTypeSRV   = "SRV"
 	cisDNSRecordTypeTXT   = "TXT"
+	cisDNSRecordTypePTR   = "PTR"
 )
 
 func resourceIBMCISDnsRecord() *schema.Resource {
@@ -173,13 +174,14 @@ func resourceIBMCISDnsRecordCreate(d *schema.ResourceData, meta interface{}) err
 	opt.SetTTL(int64(ttl))
 
 	switch recordType {
-	// A, AAAA, CNAME, SPF, TXT & NS records inputs
+	// A, AAAA, CNAME, SPF, TXT, NS, PTR records inputs
 	case cisDNSRecordTypeA,
 		cisDNSRecordTypeAAAA,
 		cisDNSRecordTypeCNAME,
 		cisDNSRecordTypeSPF,
 		cisDNSRecordTypeTXT,
-		cisDNSRecordTypeNS:
+		cisDNSRecordTypeNS,
+		cisDNSRecordTypePTR:
 		// set record name & content
 		recordName = d.Get(cisDNSRecordName).(string)
 		opt.SetName(recordName)
@@ -522,13 +524,14 @@ func resourceIBMCISDnsRecordUpdate(d *schema.ResourceData, meta interface{}) err
 		opt.SetProxied(proxied)
 
 		switch recordType {
-		// A, AAAA, CNAME, SPF, TXT & NS records inputs
+		// A, AAAA, CNAME, SPF, TXT, NS, PTR records inputs
 		case cisDNSRecordTypeA,
 			cisDNSRecordTypeAAAA,
 			cisDNSRecordTypeCNAME,
 			cisDNSRecordTypeSPF,
 			cisDNSRecordTypeTXT,
-			cisDNSRecordTypeNS:
+			cisDNSRecordTypeNS,
+			cisDNSRecordTypePTR:
 			// set record name & content
 			recordName = d.Get(cisDNSRecordName).(string)
 			opt.SetName(recordName)

--- a/ibm/resource_ibm_cis_dns_record_test.go
+++ b/ibm/resource_ibm_cis_dns_record_test.go
@@ -39,6 +39,33 @@ func TestAccIBMCisDNSRecord_Basic(t *testing.T) {
 	})
 }
 
+func TestAccIBMCisDNSRecord_PTR(t *testing.T) {
+	//t.Parallel()
+	var record string
+	testName := "tf-acctest-ptr"
+	resourceName := fmt.Sprintf("ibm_cis_dns_record.%s", testName)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheckCis(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckIBMCisDNSRecordDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckIBMCisDNSRecordConfigPTR(testName, cisDomainStatic),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckIBMCisDNSRecordExists(resourceName, &record),
+					resource.TestCheckResourceAttr(
+						resourceName, "name", "192.168.0.10."+cisDomainStatic),
+					resource.TestCheckResourceAttr(
+						resourceName, "content", testName+"."+cisDomainStatic),
+					resource.TestCheckResourceAttr(
+						resourceName, "data.%", "0"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccIBMCisDNSRecord_import(t *testing.T) {
 	name := "ibm_cis_dns_record.test"
 
@@ -309,6 +336,18 @@ func testAccCheckIBMCisDNSRecordConfigCisRIBasic(resourceID string, cisDomain st
 		type    = "A"
 	  }
 `, resourceID)
+}
+
+func testAccCheckIBMCisDNSRecordConfigPTR(resourceID string, cisDomainStatic string) string {
+	return testAccCheckIBMCisDomainDataSourceConfigBasic1() + fmt.Sprintf(`
+	resource "ibm_cis_dns_record" "%[1]s" {
+		cis_id    = data.ibm_cis.cis.id
+		domain_id = data.ibm_cis_domain.cis_domain.id
+		name    = "192.168.0.10"
+		content = "%[1]s.%[2]s"
+		type    = "PTR"
+	  }
+	`, resourceID, cisDomainStatic)
 }
 
 func testAccCheckIBMCisDNSRecordConfigCaseSensitive(resourceID string, cisDomainStatic string) string {

--- a/website/docs/d/cis_dns_records.html.markdown
+++ b/website/docs/d/cis_dns_records.html.markdown
@@ -43,7 +43,7 @@ In addition to all arguments above, the following attributes are exported:
   - `created_on` - The DNS record created date.
   - `modified_on`- The DNS record modified date.
   - `zone_name` - The DNS zone name.
-  - `type` - The type of the DNS record to be created. Supported Record types are: A, AAAA, CNAME, LOC, TXT, MX, SRV, SPF, NS, CAA.
+  - `type` - The type of the DNS record to be created. Supported Record types are: A, AAAA, CNAME, LOC, TXT, MX, SRV, SPF, NS, CAA, PTR.
   - `content` - The (string) value of the record.
   - `ttl`-TTL of the record. It should be automatic(i.e ttl=1) if the record is proxied. Terraform provider takes ttl in unit seconds.
   - `priority` - The priority of the record. Mandatory field for SRV record type.

--- a/website/docs/r/cis_dns_record.html.markdown
+++ b/website/docs/r/cis_dns_record.html.markdown
@@ -277,13 +277,29 @@ output "ns_record_output" {
 }
 ```
 
+## Example Usage 11 : Create PTR record
+
+```hcl
+resource "ibm_cis_dns_record" "test_dns_ptr_record" {
+  cis_id  = var.cis_crn
+  domain_id = var.zone_id
+  name    = "1.2.3.4"
+  type    = "PTR"
+  content = "test-exmple.ptr.com"
+}
+
+output "ns_record_output" {
+  value = ibm_cis_dns_record.test_dns_ptr_record
+}
+```
+
 ## Argument Reference
 
 The following arguments are supported:
 
 - `cis_id` - (Required,string) The ID of the CIS service instance
 - `domain_id` - (Required,string) The ID of the domain to add the DNS record to. IT can either be a combination of <domain_id>:<cis_id> or <domain_id>
-- `type` - (Required, string) The type of the DNS record to be created. Supported Record types are: A, AAAA, CNAME, LOC, TXT, MX, SRV, SPF, NS, CAA.
+- `type` - (Required, string) The type of the DNS record to be created. Supported Record types are: A, AAAA, CNAME, LOC, TXT, MX, SRV, SPF, NS, CAA, PTR.
 - `name` - (Required, string) The name of a DNS record.
 - `content` - (Optional,string) The (string) value of the record, e.g. "192.168.127.127". Either this or `data` must be specified
 - `ttl`-(Optional,int) TTL of the record. It should be automatic(i.e ttl=1) if the record is proxied. Terraform provider takes ttl in unit seconds. Therefore, it starts with value 120.


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/IBM-Cloud/terraform-provider-ibm/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #2535

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccIBMCisDNSRecord_PTR'

...
=== RUN   TestAccIBMCisDNSRecord_PTR
--- PASS: TestAccIBMCisDNSRecord_PTR (22.92s)
PASS
ok      github.com/IBM-Cloud/terraform-provider-ibm/ibm 26.516s
testing: warning: no tests to run
PASS
ok      github.com/IBM-Cloud/terraform-provider-ibm/ibm/internal/hashcode       (cached) [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/IBM-Cloud/terraform-provider-ibm/ibm/internal/mutexkv        (cached) [no tests to run]
?       github.com/IBM-Cloud/terraform-provider-ibm/version     [no test files]
```
