### PR TITLE
UI-14859: Instance Group Delete Bugfix

### DIFF
--- a/ibm/resource_ibm_is_instance_group.go
+++ b/ibm/resource_ibm_is_instance_group.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"log"
 	"os"
+	"strings"
 	"time"
 
 	"github.com/IBM/vpc-go-sdk/vpcv1"
@@ -397,12 +398,53 @@ func resourceIBMISInstanceGroupRead(d *schema.ResourceData, meta interface{}) er
 	return nil
 }
 
+func getLBStatus(sess *vpcv1.VpcV1, lbId string) (string, error) {
+	getlboptions := &vpcv1.GetLoadBalancerOptions{
+		ID: &lbId,
+	}
+	lb, response, err := sess.GetLoadBalancer(getlboptions)
+	if err != nil {
+		return "", fmt.Errorf("Error Getting Load Balancer : %s\n%s", err, response)
+	}
+	return *lb.ProvisioningStatus, nil
+}
+
+// func isWaitForLBActive(sess *vpcv1.VpcV1, lbId string, timeout time.Duration) (interface{}, error) {
+// 	fmt.Printf("Waiting for load balancer (%s) to be available.", lbId)
+
+// 	stateConf := &resource.StateChangeConf{
+// 		Pending:    []string{"retry", "provisioning", "update_pending", "delete_pending", "maintenance_pending", "create_pending"},
+// 		Target:     []string{"done", "active", "failed", "online", ""},
+// 		Refresh:    isLBRefreshFunc(sess, lbId),
+// 		Timeout:    timeout,
+// 		Delay:      10 * time.Second,
+// 		MinTimeout: 10 * time.Second,
+// 	}
+// 	return stateConf.WaitForState()
+// }
+
 func resourceIBMISInstanceGroupDelete(d *schema.ResourceData, meta interface{}) error {
 	sess, err := vpcClient(meta)
 	if err != nil {
 		return err
 	}
 	instanceGroupID := d.Id()
+
+	// Before we delete the instance group, we need to
+	// know if the load balancer attached is in active state
+
+	// First, get the instance
+	igOpts := vpcv1.GetInstanceGroupOptions{ID: &instanceGroupID}
+	instanceGroup, response, err := sess.GetInstanceGroup(&igOpts)
+	if err != nil || instanceGroup == nil {
+		if response != nil && response.StatusCode == 404 {
+			return fmt.Errorf("Instance Group with id:[%s] not found!!", instanceGroupID)
+		}
+		return fmt.Errorf("Internal Error fetching info for instance group [%s]", instanceGroupID)
+	}
+
+	// Now get the Load balancer ID from the instance
+	// var ls string
 
 	// Inorder to delete instance group, need to update membership count to 0
 	zeroMembers := int64(0)
@@ -417,7 +459,7 @@ func resourceIBMISInstanceGroupDelete(d *schema.ResourceData, meta interface{}) 
 
 	instanceGroupUpdateOptions.ID = &instanceGroupID
 	instanceGroupUpdateOptions.InstanceGroupPatch = instanceGroupPatch
-	_, response, err := sess.UpdateInstanceGroup(&instanceGroupUpdateOptions)
+	_, response, err = sess.UpdateInstanceGroup(&instanceGroupUpdateOptions)
 	if err != nil {
 		return fmt.Errorf("Error updating instanceGroup's instance count to 0 : %s\n%s", err, response)
 	}
@@ -426,7 +468,38 @@ func resourceIBMISInstanceGroupDelete(d *schema.ResourceData, meta interface{}) 
 		return healthError
 	}
 
+	// If there is any load balancer, please check if it is active
+	if instanceGroup.LoadBalancerPool != nil {
+		loadBalancerPool := *instanceGroup.LoadBalancerPool.Href
+		// The sixth component is the Load Balancer ID
+		loadBalancerID := strings.Split(loadBalancerPool, "/")[5]
+
+		// Now check if the load balancer is in active state or not
+		lbStatus, err := getLBStatus(sess, loadBalancerID)
+		if err != nil {
+			return err
+		}
+		if lbStatus != "active" {
+			log.Printf("Load Balancer [%s] is not active....Waiting it to be active!\n", loadBalancerID)
+			// _, err := isWaitForLBActive(sess, loadBalancerID, time.Minute*10)
+			_, err := isWaitForLBAvailable(sess, loadBalancerID, d.Timeout(schema.TimeoutDelete))
+			if err != nil {
+				return err
+			}
+			// log.Println("Calling the status function after wait")
+			lbStatus, err = getLBStatus(sess, loadBalancerID)
+			if err != nil {
+				return err
+			}
+			// log.Printf("Checking the status if it is active after wait %s", lbStatus)
+			if lbStatus != "active" {
+				return fmt.Errorf("LoadBalancer [%s] is not active yet! Current Load Balancer status is [%s]", loadBalancerID, lbStatus)
+			}
+		}
+	}
+
 	deleteInstanceGroupOptions := vpcv1.DeleteInstanceGroupOptions{ID: &instanceGroupID}
+	// log.Printf("Just Before the delete function %s", loadS)
 	response, Err := sess.DeleteInstanceGroup(&deleteInstanceGroupOptions)
 	if Err != nil {
 		if response != nil && response.StatusCode == 404 {

--- a/ibm/resource_ibm_is_instance_group.go
+++ b/ibm/resource_ibm_is_instance_group.go
@@ -403,7 +403,7 @@ func getLBStatus(sess *vpcv1.VpcV1, lbId string) (string, error) {
 		ID: &lbId,
 	}
 	lb, response, err := sess.GetLoadBalancer(getlboptions)
-	if err != nil {
+	if err != nil || lb == nil {
 		return "", fmt.Errorf("Error Getting Load Balancer : %s\n%s", err, response)
 	}
 	return *lb.ProvisioningStatus, nil

--- a/ibm/resource_ibm_is_lb.go
+++ b/ibm/resource_ibm_is_lb.go
@@ -985,7 +985,7 @@ func isWaitForLBAvailable(sess *vpcv1.VpcV1, lbId string, timeout time.Duration)
 	log.Printf("Waiting for load balancer (%s) to be available.", lbId)
 
 	stateConf := &resource.StateChangeConf{
-		Pending:    []string{"retry", isLBProvisioning, "update_pending", "delete_pending"},
+		Pending:    []string{"retry", isLBProvisioning, "update_pending"},
 		Target:     []string{isLBProvisioningDone, ""},
 		Refresh:    isLBRefreshFunc(sess, lbId),
 		Timeout:    timeout,

--- a/ibm/resource_ibm_is_lb.go
+++ b/ibm/resource_ibm_is_lb.go
@@ -985,7 +985,7 @@ func isWaitForLBAvailable(sess *vpcv1.VpcV1, lbId string, timeout time.Duration)
 	log.Printf("Waiting for load balancer (%s) to be available.", lbId)
 
 	stateConf := &resource.StateChangeConf{
-		Pending:    []string{"retry", isLBProvisioning},
+		Pending:    []string{"retry", isLBProvisioning, "update_pending", "delete_pending"},
 		Target:     []string{isLBProvisioningDone, ""},
 		Refresh:    isLBRefreshFunc(sess, lbId),
 		Timeout:    timeout,


### PR DESCRIPTION
The bug was while deleting the instance_groups, we need to check if the load balancer is active or not. If not, then wait for the load balancer to be active and then delete the instance groups. Otherwise raise the error. 

Jira Task: https://jiracloud.swg.usma.ibm.com:8443/browse/UI-14859

**Bug Description**
Destroy fails with
 
```
{{Error: Error Deleting the InstanceGroup: Load Balancer r006-c66bd695-f88b-4c7d-a4a5-ed69637d021b provisioning_status must be active to delete instance group
{
"StatusCode": 409,
"Headers":
{ ..., "X-Request-Id": [ "9bc944a6-9297-448c-97e1-742c0d1856da" ], "X-Xss-Protection": [ "1; mode=block" ] }
,
"Result": {
"errors": [
{
"code": "conflict_field",
"message": "Load Balancer r006-c66bd695-f88b-4c7d-a4a5-ed69637d021b provisioning_status must be active to delete instance group",
"target":
{ "name": "load_balancer", "type": "load_balancer" }
}
],
"trace": "9bc944a6-9297-448c-97e1-742c0d1856da"
},
"RawResult": null
}}}
```