### PR TITLE
added support to make the prefix as default in vpc

### DIFF
--- a/website/docs/r/is_vpc_address_prefix.html.markdown
+++ b/website/docs/r/is_vpc_address_prefix.html.markdown
@@ -36,6 +36,7 @@ The following arguments are supported:
 * `vpc` - (Required, Forces new resource, string) The vpc id. 
 * `zone` - (Required, Forces new resource, string) Name of the zone. 
 * `cidr` - (Required, Forces new resource, string) The CIDR block for the address prefix. 
+* `is_default` - (Optional, string) Makes the prefix as default prefix for this zone in this VPC. 
 
 ## Attribute Reference
 


### PR DESCRIPTION

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #2282

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
--- PASS: TestAccIBMISVPCAddressPrefix_basic (192.30s)
PASS
ok  	github.com/IBM-Cloud/terraform-provider-ibm/ibm	196.098s

--- PASS: TestAccIBMISVPCAddressPrefix_InvalidCidr (0.53s)
PASS
ok  	github.com/IBM-Cloud/terraform-provider-ibm/ibm	3.251s

...
```
