### PR TITLE
Fix ICMP type in is_networkacls

### DIFF
--- a/ibm/resource_ibm_is_networkacls.go
+++ b/ibm/resource_ibm_is_networkacls.go
@@ -573,7 +573,7 @@ func classicNwaclGet(d *schema.ResourceData, meta interface{}, id string) error 
 					if rulex.Code != nil && rulex.Type != nil {
 						icmp[0] = map[string]int{
 							isNetworkACLRuleICMPCode: int(*rulex.Code),
-							isNetworkACLRuleICMPType: int(*rulex.Code),
+							isNetworkACLRuleICMPType: int(*rulex.Type),
 						}
 					}
 					rule[isNetworkACLRuleICMP] = icmp
@@ -693,7 +693,7 @@ func nwaclGet(d *schema.ResourceData, meta interface{}, id string) error {
 					if rulex.Code != nil && rulex.Type != nil {
 						icmp[0] = map[string]int{
 							isNetworkACLRuleICMPCode: int(*rulex.Code),
-							isNetworkACLRuleICMPType: int(*rulex.Code),
+							isNetworkACLRuleICMPType: int(*rulex.Type),
 						}
 					}
 					rule[isNetworkACLRuleICMP] = icmp

--- a/ibm/resource_ibm_is_networkacls_test.go
+++ b/ibm/resource_ibm_is_networkacls_test.go
@@ -149,7 +149,7 @@ func testAccCheckIBMISNetworkACLConfig() string {
 		  destination = "0.0.0.0/0"
 		  direction   = "outbound"
 		  icmp {
-			code = 1
+			code = 8
 			type = 1
 		  }
 		  # Optionals :
@@ -163,7 +163,7 @@ func testAccCheckIBMISNetworkACLConfig() string {
 		  destination = "0.0.0.0/0"
 		  direction   = "inbound"
 		  icmp {
-			code = 1
+			code = 8
 			type = 1
 		  }
 		  # Optionals :
@@ -191,7 +191,7 @@ func testAccCheckIBMISNetworkACLConfig1() string {
 		  destination = "0.0.0.0/0"
 		  direction   = "outbound"
 		  icmp {
-			code = 1
+			code = 8
 			type = 1
 		  }
 		  # Optionals :
@@ -205,7 +205,7 @@ func testAccCheckIBMISNetworkACLConfig1() string {
 		  destination = "0.0.0.0/0"
 		  direction   = "inbound"
 		  icmp {
-			code = 1
+			code = 8
 			type = 1
 		  }
 		  # Optionals :


### PR DESCRIPTION
In the is_networkacls resource, ICMP type was incorrectly being set to the value of the ICMP code field. This results in the state being continually out of sync with resources when ICMP type is set to a different value to code.

This PR sets the type correctly and modifies the networkacl tests to validate this. Without the fix, the tests fail because Terraform creates a non-empty plan after the initial test step that creates the `is_networkacls`:

without the fix:
```
resource_ibm_is_networkacls_test.go:40: Step 1/1 error: After applying this test step, the plan was not empty.
        stdout:


        Terraform used the selected providers to generate the following execution
        plan. Resource actions are indicated with the following symbols:
          ~ update in-place

        Terraform will perform the following actions:

          # ibm_is_network_acl.isExampleACL will be updated in-place
          ~ resource "ibm_is_network_acl" "isExampleACL" {
                id                      = "r006-46fa82a3-d382-4a55-940a-9bf2927f20b4"
                name                    = "is-example-acl"
                tags                    = [
                    "Tag1",
                    "tag2",
                ]
                # (6 unchanged attributes hidden)

              ~ rules {
                    id          = "fcf2cbc9-5548-4fb2-a95e-8fde4dc9e686"
                    name        = "outbound"
                    # (6 unchanged attributes hidden)

                  ~ icmp {
                      ~ type = 8 -> 1
                        # (1 unchanged attribute hidden)
                    }
                }
              ~ rules {
                    id          = "a2664e74-2b03-480c-8441-0294e61459e5"
                    name        = "inbound"
                    # (6 unchanged attributes hidden)

                  ~ icmp {
                      ~ type = 8 -> 1
                        # (1 unchanged attribute hidden)
                    }
                }
                # (1 unchanged block hidden)
            }

        Plan: 0 to add, 1 to change, 0 to destroy.

--- FAIL: TestNetworkACLGen2 (52.77s)
FAIL
FAIL	github.com/IBM-Cloud/terraform-provider-ibm/ibm	54.375s
FAIL
make: *** [testacc] Error 1
```

with the fix:
```
--- PASS: TestNetworkACLGen2 (55.02s)
PASS
ok  	github.com/IBM-Cloud/terraform-provider-ibm/ibm	56.790s
```


<!--- See what makes a good Pull Request at : https://github.com/IBM-Cloud/terraform-provider-ibm/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #2559

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestNetworkACLGen2'
$ make testacc TESTARGS='-run=TestNetworkACLGen1'

...
```
