### PR TITLE
Added utility function to split an ID on a custom separator

### DIFF
--- a/ibm/structures.go
+++ b/ibm/structures.go
@@ -1132,6 +1132,14 @@ func idParts(id string) ([]string, error) {
 	return []string{}, fmt.Errorf("The given id %s does not contain / please check documentation on how to provider id during import command", id)
 }
 
+func sepIdParts(id string, separator string) ([]string, error) {
+	if strings.Contains(id, separator) {
+		parts := strings.Split(id, separator)
+		return parts, nil
+	}
+	return []string{}, fmt.Errorf("The given id %s does not contain %s please check documentation on how to provider id during import command", id, separator)
+}
+
 func vmIdParts(id string) ([]string, error) {
 	parts := strings.Split(id, "/")
 	return parts, nil


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/IBM-Cloud/terraform-provider-ibm/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

This PR adds a utility function `sepIdParts` which is an extension of the `idParts` function but with a custom separator parameter.

This is used by new SDKs generated by the Terraform SDK generator in order to support resource IDs that may use alternate separators besides the `/` separator.
