### PR TITLE
Support: IAM Policies Operator

### DIFF
--- a/ibm/config.go
+++ b/ibm/config.go
@@ -2128,7 +2128,7 @@ func newSession(c *Config) (*Session, error) {
 		bmxConfig := &bluemix.Config{
 			BluemixAPIKey: c.BluemixAPIKey,
 			//Comment out debug mode for v0.12
-			Debug:         os.Getenv("TF_LOG") != "",
+			// Debug:         os.Getenv("TF_LOG") != "",
 			HTTPTimeout:   c.BluemixTimeout,
 			Region:        c.Region,
 			ResourceGroup: c.ResourceGroup,

--- a/ibm/data_source_ibm_iam_roles.go
+++ b/ibm/data_source_ibm_iam_roles.go
@@ -68,12 +68,12 @@ func datasourceIBMIAMRoleRead(d *schema.ResourceData, meta interface{}) error {
 		listRoleOptions.ServiceName = &serviceName
 	}
 	roleList, _, err := iamPolicyManagementClient.ListRoles(listRoleOptions)
-	customRoles = roleList.CustomRoles
-	serviceRoles = roleList.ServiceRoles
-	systemRoles = roleList.SystemRoles
 	if err != nil {
 		return err
 	}
+	customRoles = roleList.CustomRoles
+	serviceRoles = roleList.ServiceRoles
+	systemRoles = roleList.SystemRoles
 
 	d.SetId(userDetails.userAccount)
 

--- a/ibm/resource_ibm_iam_user_policy_test.go
+++ b/ibm/resource_ibm_iam_user_policy_test.go
@@ -146,14 +146,39 @@ func TestAccIBMIAMUserPolicy_import(t *testing.T) {
 				),
 			},
 			resource.TestStep{
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"resources", "resource_attributes"},
 			},
 		},
 	})
 }
+func TestAccIBMIAMUserPolicy_With_Resource_Attributes(t *testing.T) {
+	var conf iampolicymanagementv1.Policy
 
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckIBMIAMServicePolicyDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckIBMIAMUserPolicyResourceAttributes(),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckIBMIAMAccessGroupPolicyExists("ibm_iam_user_policy.policy", conf),
+					resource.TestCheckResourceAttr("ibm_iam_user_policy.policy", "resource_attributes.#", "2"),
+				),
+			},
+			{
+				Config: testAccCheckIBMIAMUserPolicyResourceAttributesUpdate(),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckIBMIAMAccessGroupPolicyExists("ibm_iam_user_policy.policy", conf),
+					resource.TestCheckResourceAttr("ibm_iam_user_policy.policy", "resource_attributes.#", "2"),
+				),
+			},
+		},
+	})
+}
 func TestAccIBMIAMUserPolicy_account_management(t *testing.T) {
 	var conf iampolicymanagementv1.Policy
 	name := fmt.Sprintf("terraform_%d", acctest.RandIntRange(10, 100))
@@ -456,4 +481,41 @@ func testAccCheckIBMIAMUserPolicyWithCustomRole(crName, displayName string) stri
 	  	}
 
 	`, crName, displayName, IAMUser)
+}
+
+func testAccCheckIBMIAMUserPolicyResourceAttributes() string {
+	return fmt.Sprintf(`
+  
+	  resource "ibm_iam_user_policy" "policy" {
+		ibm_id = "%s"
+		roles  = ["Viewer"]
+		resource_attributes {
+			name     = "resource"
+			value    = "test*"
+			operator = "stringMatch"
+		}
+		resource_attributes {
+			name     = "serviceName"
+			value    = "messagehub"
+		}
+	  }
+	  
+`, IAMUser)
+}
+func testAccCheckIBMIAMUserPolicyResourceAttributesUpdate() string {
+	return fmt.Sprintf(`
+	resource "ibm_iam_user_policy" "policy" {
+		ibm_id = "%s"
+		roles  = ["Viewer"]
+		resource_attributes {
+			name     = "resource"
+			value    = "test*"
+			operator = "stringMatch"
+		}
+		resource_attributes {
+			name     = "serviceName"
+			value    = "messagehub"
+		}
+	  }
+	`, IAMUser)
 }

--- a/website/docs/r/iam_access_group_dynamic_rule.html.markdown
+++ b/website/docs/r/iam_access_group_dynamic_rule.html.markdown
@@ -7,7 +7,7 @@ description: |-
   Manages Dynamic Rule for IBM IAM Access Group.
 ---
 
-# ibm\_iam_access_group
+# ibm\_iam_access_group_dynamic_rule
 
 Provides a resource for Dynamic Rule of an IAM access group. This allows rules to be created, updated and deleted.
 

--- a/website/docs/r/iam_access_group_policy.html.markdown
+++ b/website/docs/r/iam_access_group_policy.html.markdown
@@ -7,7 +7,7 @@ description: |-
   Manages IBM IAM Access Group Policy.
 ---
 
-# ibm\_access_group_id
+# ibm\_access_group_policy
 
 Provides a resource for IAM Access Group Policy. This allows access group policy to be created, updated and deleted.
 
@@ -166,6 +166,27 @@ resource "ibm_iam_access_group_policy" "policy" {
 
 ```
 
+### Access Group Policy using resource_attributes
+
+```hcl
+resource "ibm_iam_access_group" "accgrp" {
+  name = "access_group"
+}
+resource "ibm_iam_access_group_policy" "policy" {
+  access_group_id = ibm_iam_access_group.accgrp.id
+  roles           = ["Viewer"]
+  resource_attributes {
+    name  = "resource"
+    value = "test123*"
+    operator = "stringMatch"
+  }
+  resource_attributes {
+    name  = "serviceName"
+    value = "messagehub"
+  }
+}
+```
+
 ## Argument Reference
 
 The following arguments are supported:
@@ -181,9 +202,15 @@ Nested `resources` blocks have the following structure:
   * `resource` - (Optional, string) Resource of the policy definition.
   * `resource_group_id` - (Optional, string) The ID of the resource group.  You can retrieve the value from data source `ibm_resource_group`. 
   * `attributes` - (Optional, map) Set resource attributes in the form of `'name=value,name=value...`.
- **NOTE**: Conflicts with `account_management`.
+ **NOTE**: Conflicts with `account_management` and `resource_attributes`.
+* `resource_attributes` - (Optional, list) A nested block describing the resource of this policy.
+Nested `resource_attributes` blocks have the following structure:
+  * `name` - (Required, string) Name of the Attribute. Supported values are`serviceName` , `serviceInstance` , `region` ,`resourceType` , `resource` , `resourceGroupId` and other service specific resource attributes.
+  * `value` - (Required, string) Value of the Attribute.
+  * `operator` - (Optional, string) Operator of the Attribute. Default Value: `stringEquals`
+ **NOTE**: Conflicts with `account_management` and `resources`.
 * `account_management` - (Optional, bool) Gives access to all account management services if set to `true`. Default value `false`. 
- **NOTE**: Conflicts with `resources`.
+ **NOTE**: **NOTE**: Conflicts with `resources` and `resource_attributes`.
 * `tags` - (Optional, array of strings) Tags associated with the access group Policy instance.
   **NOTE**: `Tags` are managed locally and not stored on the IBM Cloud service endpoint at this moment.
 

--- a/website/docs/r/iam_authorization_policy.html.markdown
+++ b/website/docs/r/iam_authorization_policy.html.markdown
@@ -7,7 +7,7 @@ description: |-
   Manages IBM IAM Service Authorizations.
 ---
 
-# ibm\_authorization_policy
+# ibm\_iam_authorization_policy
 
 Provides a resource for IAM Service Authorizations. This allows authorization policy to be created and deleted.
 

--- a/website/docs/r/iam_service_policy.html.markdown
+++ b/website/docs/r/iam_service_policy.html.markdown
@@ -7,7 +7,7 @@ description: |-
   Manages IBM IAM Service Policy.
 ---
 
-# ibm\_iam_service_id
+# ibm\_iam_service_policy
 
 Provides a resource for IAM Service Policy. This allows service policy  to be created, updated and deleted.
 
@@ -169,6 +169,27 @@ resource "ibm_iam_service_policy" "policy" {
 
 ```
 
+### Service Policy using resource_attributes
+
+```hcl
+resource "ibm_iam_service_id" "serviceID" {
+  name = "test"
+}
+resource "ibm_iam_service_policy" "policy" {
+  iam_service_id = ibm_iam_service_id.serviceID.id
+  roles           = ["Viewer"]
+  resource_attributes {
+    name  = "resource"
+    value = "test123*"
+    operator = "stringMatch"
+  }
+  resource_attributes {
+    name  = "serviceName"
+    value = "messagehub"
+  }
+}
+```
+
 ## Argument Reference
 
 The following arguments are supported:
@@ -185,9 +206,15 @@ Nested `resources` blocks have the following structure:
   * `resource` - (Optional, string) Resource of the policy definition.
   * `resource_group_id` - (Optional, string) The ID of the resource group.  You can retrieve the value from data source `ibm_resource_group`. 
   * `attributes` - (Optional, map) Set resource attributes in the form of `'name=value,name=value...`.
- **NOTE**: Conflicts with `account_management`.
+ **NOTE**: Conflicts with `account_management` and `resource_attributes`.
+* `resource_attributes` - (Optional, list) A nested block describing the resource of this policy.
+Nested `resource_attributes` blocks have the following structure:
+  * `name` - (Required, string) Name of the Attribute. Supported values are`serviceName` , `serviceInstance` , `region` ,`resourceType` , `resource` , `resourceGroupId` and other service specific resource attributes.
+  * `value` - (Required, string) Value of the Attribute.
+  * `operator` - (Optional, string) Operator of the Attribute. Default Value: `stringEquals`
+ **NOTE**: Conflicts with `account_management` and `resources`.
 * `account_management` - (Optional, bool) Gives access to all account management services if set to `true`. Default value `false`. 
- **NOTE**: Conflicts with `resources`.
+  **NOTE**: Conflicts with `resources`and `resource_attributes`.
 * `tags` - (Optional, array of strings) Tags associated with the service policy instance.  
   **NOTE**: `Tags` are managed locally and not stored on the IBM Cloud service endpoint at this moment.
 

--- a/website/docs/r/iam_user_policy.html.markdown
+++ b/website/docs/r/iam_user_policy.html.markdown
@@ -118,6 +118,24 @@ resource "ibm_iam_user_policy" "policy" {
 
 ```
 
+### User Policy using resource_attributes
+
+```hcl
+resource "ibm_iam_user_policy" "policy" {
+  ibm_id = "test@in.ibm.com"
+  roles           = ["Viewer"]
+  resource_attributes {
+    name  = "resource"
+    value = "test123*"
+    operator = "stringMatch"
+  }
+  resource_attributes {
+    name  = "serviceName"
+    value = "messagehub"
+  }
+}
+```
+
 
 ## Argument Reference
 
@@ -134,9 +152,15 @@ Nested `resources` blocks have the following structure:
   * `resource` - (Optional, string) Resource of the policy definition.
   * `resource_group_id` - (Optional, string) The ID of the resource group. You can retrieve the value from data source `ibm_resource_group`. 
   * `attributes` - (Optional, map) Set resource attributes in the form of `'name=value,name=value...`.
- **NOTE**: Conflicts with `account_management`.
+ **NOTE**: Conflicts with `account_management` and `resource_attributes`.
+* `resource_attributes` - (Optional, list) A nested block describing the resource of this policy.
+Nested `resource_attributes` blocks have the following structure:
+  * `name` - (Required, string) Name of the Attribute. Supported values are`serviceName` , `serviceInstance` , `region` ,`resourceType` , `resource` , `resourceGroupId` and other service specific resource attributes.
+  * `value` - (Required, string) Value of the Attribute.
+  * `operator` - (Optional, string) Operator of the Attribute. Default Value: `stringEquals`
+ **NOTE**: Conflicts with `account_management` and `resources`.
 * `account_management` - (Optional, bool) Gives access to all account management services if set to `true`. Default value `false`. 
- **NOTE**: Conflicts with `resources`.
+  **NOTE**: Conflicts with `resources`and `resource_attributes`.
 * `tags` - (Optional, array of strings) Tags associated with the user policy instance.  
   **NOTE**: `Tags` are managed locally and not stored on the IBM Cloud service endpoint at this moment.
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/IBM-Cloud/terraform-provider-ibm/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #2533

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
 RUN   TestAccIBMIAMAccessGroupPolicy_Basic
--- PASS: TestAccIBMIAMAccessGroupPolicy_Basic (47.60s)
=== RUN   TestAccIBMIAMAccessGroupPolicy_With_Service
--- PASS: TestAccIBMIAMAccessGroupPolicy_With_Service (49.90s)
=== RUN   TestAccIBMIAMAccessGroupPolicy_With_ResourceInstance
--- PASS: TestAccIBMIAMAccessGroupPolicy_With_ResourceInstance (83.18s)
=== RUN   TestAccIBMIAMAccessGroupPolicy_With_Resource_Group
--- PASS: TestAccIBMIAMAccessGroupPolicy_With_Resource_Group (51.88s)
=== RUN   TestAccIBMIAMAccessGroupPolicy_With_Resource_Type
--- PASS: TestAccIBMIAMAccessGroupPolicy_With_Resource_Type (34.51s)
=== RUN   TestAccIBMIAMAccessGroupPolicy_import
    resource_ibm_iam_access_group_policy_test.go:148: ImportStateVerify attributes not equivalent. Difference is shown below. Top is actual, bottom is expected.
        
        (map[string]string) (len=13) {
         (string) (len=21) "resource_attributes.#": (string) (len=1) "1",
         (string) (len=23) "resource_attributes.0.%": (string) (len=1) "3",
         (string) (len=26) "resource_attributes.0.name": (string) (len=11) "serviceType",
         (string) (len=30) "resource_attributes.0.operator": (string) (len=12) "stringEquals",
         (string) (len=27) "resource_attributes.0.value": (string) (len=7) "service",
         (string) (len=11) "resources.#": (string) (len=1) "1",
         (string) (len=13) "resources.0.%": (string) (len=1) "7",
         (string) (len=18) "resources.0.region": (string) "",
         (string) (len=20) "resources.0.resource": (string) "",
         (string) (len=29) "resources.0.resource_group_id": (string) "",
         (string) (len=32) "resources.0.resource_instance_id": (string) "",
         (string) (len=25) "resources.0.resource_type": (string) "",
         (string) (len=19) "resources.0.service": (string) ""
        }
        
        
        (map[string]string) {
        }
--- FAIL: TestAccIBMIAMAccessGroupPolicy_import (42.83s)
=== RUN   TestAccIBMIAMAccessGroupPolicy_account_management
--- PASS: TestAccIBMIAMAccessGroupPolicy_account_management (31.40s)
=== RUN   TestAccIBMIAMAccessGroupPolicy_With_Attributese
--- PASS: TestAccIBMIAMAccessGroupPolicy_With_Attributese (26.77s)
=== RUN   TestAccIBMIAMAccessGroupPolicy_With_Resource_Attributes
--- PASS: TestAccIBMIAMAccessGroupPolicy_With_Resource_Attributes (55.69s)


...
```

service policy

```

TestAccIBMIAMServicePolicyDataSource_Basic
--- PASS: TestAccIBMIAMServicePolicyDataSource_Basic (73.79s)
=== RUN   TestAccIBMIAMServicePolicyDataSource_Multiple_Policies
--- PASS: TestAccIBMIAMServicePolicyDataSource_Multiple_Policies (69.52s)
=== RUN   TestAccIBMIAMServicePolicy_Basic
--- PASS: TestAccIBMIAMServicePolicy_Basic (53.76s)
=== RUN   TestAccIBMIAMServicePolicy_With_Service
--- PASS: TestAccIBMIAMServicePolicy_With_Service (50.41s)
=== RUN   TestAccIBMIAMServicePolicy_With_ResourceInstance
--- PASS: TestAccIBMIAMServicePolicy_With_ResourceInstance (62.03s)
=== RUN   TestAccIBMIAMServicePolicy_With_Resource_Group
--- PASS: TestAccIBMIAMServicePolicy_With_Resource_Group (30.65s)
=== RUN   TestAccIBMIAMServicePolicy_With_Resource_Type
--- PASS: TestAccIBMIAMServicePolicy_With_Resource_Type (30.66s)
=== RUN   TestAccIBMIAMServicePolicy_import
    resource_ibm_iam_service_policy_test.go:149: ImportStateVerify attributes not equivalent. Difference is shown below. Top is actual, bottom is expected.
        
        (map[string]string) (len=13) {
         (string) (len=21) "resource_attributes.#": (string) (len=1) "1",
         (string) (len=23) "resource_attributes.0.%": (string) (len=1) "3",
         (string) (len=26) "resource_attributes.0.name": (string) (len=11) "serviceType",
         (string) (len=30) "resource_attributes.0.operator": (string) (len=12) "stringEquals",
         (string) (len=27) "resource_attributes.0.value": (string) (len=7) "service",
         (string) (len=11) "resources.#": (string) (len=1) "1",
         (string) (len=13) "resources.0.%": (string) (len=1) "7",
         (string) (len=18) "resources.0.region": (string) "",
         (string) (len=20) "resources.0.resource": (string) "",
         (string) (len=29) "resources.0.resource_group_id": (string) "",
         (string) (len=32) "resources.0.resource_instance_id": (string) "",
         (string) (len=25) "resources.0.resource_type": (string) "",
         (string) (len=19) "resources.0.service": (string) ""
        }
        
        
        (map[string]string) {
        }
--- FAIL: TestAccIBMIAMServicePolicy_import (32.46s)
=== RUN   TestAccIBMIAMServicePolicy_account_management
--- PASS: TestAccIBMIAMServicePolicy_account_management (27.49s)
=== RUN   TestAccIBMIAMServicePolicy_With_Resource_Attributes
--- PASS: TestAccIBMIAMServicePolicy_With_Resource_Attributes (47.43s)
```

User Policy

```

=== RUN   TestAccIBMIAMUserPolicy_With_Resource_Attributes
--- PASS: TestAccIBMIAMUserPolicy_With_Resource_Attributes (42.80s)
PASS
```
