### PR TITLE
Add new API param to provider

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "go.sum|^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2021-05-06T10:49:17Z",
+  "generated_at": "2021-05-11T14:26:53Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -829,7 +829,7 @@
         "hashed_secret": "3046d9f6cfaaeea6eed9bb7a4ab010fe49b0cfd4",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 37,
+        "line_number": 38,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -837,7 +837,7 @@
         "hashed_secret": "b732fb611fd46a38e8667f9972e0cde777fbe37f",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 144,
+        "line_number": 149,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -927,7 +927,7 @@
         "hashed_secret": "c8b6f5ef11b9223ac35a5663975a466ebe7ebba9",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 772,
+        "line_number": 781,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -935,7 +935,7 @@
         "hashed_secret": "8abf4899c01104241510ba87685ad4de76b0c437",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 778,
+        "line_number": 787,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -945,7 +945,7 @@
         "hashed_secret": "813274ccae5b6b509379ab56982d862f7b5969b6",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 475,
+        "line_number": 489,
         "type": "Base64 High Entropy String",
         "verified_result": null
       }
@@ -1281,7 +1281,7 @@
         "hashed_secret": "b732fb611fd46a38e8667f9972e0cde777fbe37f",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 219,
+        "line_number": 225,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -1299,7 +1299,7 @@
         "hashed_secret": "347cd9c53ff77d41a7b22aa56c7b4efaf54658e3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 121,
+        "line_number": 123,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -1497,7 +1497,7 @@
         "hashed_secret": "da8cae6284528565678de15e03d461e23fe22538",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1306,
+        "line_number": 1314,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -1775,7 +1775,7 @@
       }
     ]
   },
-  "version": "0.13.1+ibm.34.dss",
+  "version": "0.13.1+ibm.33.dss",
   "word_list": {
     "file": null,
     "hash": null

--- a/examples/ibm-iam_identity/README.md
+++ b/examples/ibm-iam_identity/README.md
@@ -62,6 +62,7 @@ data "ibm_iam_account_settings" "iam_account_settings_source" {
 | mfa | Defines the MFA trait for the account. | `string` | false |
 | session_expiration_in_seconds | Defines the session expiration in seconds for the account. | `string` | false |
 | session_invalidation_in_seconds | Defines the period of time in seconds in which a session will be invalidated due  to inactivity. | `string` | false |
+| max_sessions_per_identity | Defines the max allowed sessions per identity required by the account. | `string` | false |
 
 
 

--- a/ibm/data_source_ibm_iam_account_settings.go
+++ b/ibm/data_source_ibm_iam_account_settings.go
@@ -6,9 +6,10 @@ package ibm
 import (
 	"context"
 	"fmt"
+	"log"
+
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"log"
 
 	"github.com/IBM/platform-services-go-sdk/iamidentityv1"
 )
@@ -106,6 +107,11 @@ func dataSourceIBMIAMAccountSettings() *schema.Resource {
 				Computed:    true,
 				Description: "Defines the period of time in seconds in which a session will be invalidated due  to inactivity. Valid values:   * Any whole number between '900' and '7200'   * NOT_SET - To unset account setting and use service default.",
 			},
+			"max_sessions_per_identity": &schema.Schema{
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "Defines the max allowed sessions per identity required by the account. Value values: * Any whole number greater than '0'   * NOT_SET - To unset account setting and use service default.",
+			},
 		},
 	}
 }
@@ -117,7 +123,6 @@ func dataSourceIbmIamAccountSettingsRead(context context.Context, d *schema.Reso
 	}
 
 	getAccountSettingsOptions := &iamidentityv1.GetAccountSettingsOptions{}
-	//getAccountSettingsOptions.SetIncludeHistory(d.Get("include_history").(bool))
 
 	userDetails, err := meta.(ClientSession).BluemixUserDetails()
 	if err != nil {
@@ -164,6 +169,9 @@ func dataSourceIbmIamAccountSettingsRead(context context.Context, d *schema.Reso
 	}
 	if err = d.Set("session_invalidation_in_seconds", accountSettingsResponse.SessionInvalidationInSeconds); err != nil {
 		return diag.FromErr(fmt.Errorf("Error setting session_invalidation_in_seconds: %s", err))
+	}
+	if err = d.Set("max_sessions_per_identity", accountSettingsResponse.MaxSessionsPerIdentity); err != nil {
+		return diag.FromErr(fmt.Errorf("Error setting max_sessions_per_identity: %s", err))
 	}
 
 	return nil

--- a/ibm/data_source_ibm_iam_account_settings.go
+++ b/ibm/data_source_ibm_iam_account_settings.go
@@ -123,6 +123,7 @@ func dataSourceIbmIamAccountSettingsRead(context context.Context, d *schema.Reso
 	}
 
 	getAccountSettingsOptions := &iamidentityv1.GetAccountSettingsOptions{}
+	getAccountSettingsOptions.SetIncludeHistory(d.Get("include_history").(bool))
 
 	userDetails, err := meta.(ClientSession).BluemixUserDetails()
 	if err != nil {

--- a/ibm/data_source_ibm_iam_account_settings_test.go
+++ b/ibm/data_source_ibm_iam_account_settings_test.go
@@ -27,6 +27,7 @@ func TestAccIBMIAMAccountSettingsDataSourceBasic(t *testing.T) {
 					resource.TestCheckResourceAttrSet("data.ibm_iam_account_settings.iam_account_settings", "history.#"),
 					resource.TestCheckResourceAttrSet("data.ibm_iam_account_settings.iam_account_settings", "session_expiration_in_seconds"),
 					resource.TestCheckResourceAttrSet("data.ibm_iam_account_settings.iam_account_settings", "session_invalidation_in_seconds"),
+					resource.TestCheckResourceAttrSet("data.ibm_iam_account_settings.iam_account_settings", "max_sessions_per_identity"),
 				),
 			},
 		},

--- a/ibm/resource_ibm_iam_account_settings.go
+++ b/ibm/resource_ibm_iam_account_settings.go
@@ -127,6 +127,12 @@ func resourceIbmIamAccountSettings() *schema.Resource {
 				Computed:    true,
 				Description: "Defines the period of time in seconds in which a session will be invalidated due  to inactivity. Valid values:   * Any whole number between '900' and '7200'   * NOT_SET - To unset account setting and use service default.",
 			},
+			"max_sessions_per_identity": &schema.Schema{
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				Description: "Defines the max allowed sessions per identity required by the account. Value values: * Any whole number greater than '0'   * NOT_SET - To unset account setting and use service default.",
+			},
 		},
 	}
 }
@@ -243,6 +249,9 @@ func resourceIbmIamAccountSettingsRead(context context.Context, d *schema.Resour
 	if err = d.Set("session_invalidation_in_seconds", accountSettingsResponse.SessionInvalidationInSeconds); err != nil {
 		return diag.FromErr(fmt.Errorf("Error setting session_invalidation_in_seconds: %s", err))
 	}
+	if err = d.Set("max_sessions_per_identity", accountSettingsResponse.MaxSessionsPerIdentity); err != nil {
+		return diag.FromErr(fmt.Errorf("Error setting max_sessions_per_identity: %s", err))
+	}
 
 	return nil
 }
@@ -306,6 +315,12 @@ func resourceIbmIamAccountSettingsUpdate(context context.Context, d *schema.Reso
 	if d.HasChange("session_invalidation_in_seconds") {
 		session_invalidation_in_seconds_str := d.Get("session_invalidation_in_seconds").(string)
 		updateAccountSettingsOptions.SetSessionInvalidationInSeconds(session_invalidation_in_seconds_str)
+		hasChange = true
+	}
+
+	if d.HasChange("max_sessions_per_identity") {
+		max_sessions_per_identity_str := d.Get("max_sessions_per_identity").(string)
+		updateAccountSettingsOptions.SetMaxSessionsPerIdentity(max_sessions_per_identity_str)
 		hasChange = true
 	}
 

--- a/ibm/resource_ibm_iam_account_settings_test.go
+++ b/ibm/resource_ibm_iam_account_settings_test.go
@@ -20,6 +20,7 @@ var (
 	mfa_trait                       = "NONE"
 	session_expiration_in_seconds   = "NOT_SET"
 	session_invalidation_in_seconds = "NOT_SET"
+	max_sessions_per_identity       = "NOT_SET"
 )
 
 func TestAccIBMIAMAccountSettingsBasic(t *testing.T) {
@@ -90,6 +91,7 @@ func TestAccIBMIAMAccountSettingsUpdate(t *testing.T) {
 					resource.TestCheckResourceAttr("ibm_iam_account_settings.iam_account_settings", "mfa", mfa_trait),
 					resource.TestCheckResourceAttr("ibm_iam_account_settings.iam_account_settings", "session_expiration_in_seconds", session_expiration_in_seconds),
 					resource.TestCheckResourceAttr("ibm_iam_account_settings.iam_account_settings", "session_invalidation_in_seconds", session_invalidation_in_seconds),
+					resource.TestCheckResourceAttr("ibm_iam_account_settings.iam_account_settings", "max_sessions_per_identity", max_sessions_per_identity),
 				),
 			},
 		},
@@ -123,6 +125,7 @@ func testAccCheckIbmIamAccountSettingsUpdateConfig() string {
 			mfa = "%s"
 			session_expiration_in_seconds = "%s"
 			session_invalidation_in_seconds = "%s"
+			max_sessions_per_identity = "%s"
 		}
 	`,
 		restrict_create_service_id,
@@ -131,6 +134,7 @@ func testAccCheckIbmIamAccountSettingsUpdateConfig() string {
 		mfa_trait,
 		session_expiration_in_seconds,
 		session_invalidation_in_seconds,
+		max_sessions_per_identity,
 	)
 }
 

--- a/website/docs/d/iam_account_settings.html.markdown
+++ b/website/docs/d/iam_account_settings.html.markdown
@@ -47,3 +47,4 @@ In addition to all arguments above, the following attributes are exported:
 
 * `session_invalidation_in_seconds` - Defines the period of time in seconds in which a session will be invalidated due  to inactivity. Valid values:   * Any whole number between '900' and '7200'   * NOT_SET - To unset account setting and use service default.
 
+* `max_sessions_per_identity` - Defines the max allowed sessions per identity required by the account. Value values: * Any whole number greater than '0'   * NOT_SET - To unset account setting and use service default 

--- a/website/docs/d/iam_account_settings.html.markdown
+++ b/website/docs/d/iam_account_settings.html.markdown
@@ -17,6 +17,12 @@ data "ibm_iam_account_settings" "iam_account_settings" {
 }
 ```
 
+## Argument Reference
+
+The following arguments are supported:
+
+* `include_history` - (Optional, boolean) Defines if the entity history is included in the response.
+
 ## Attribute Reference
 
 In addition to all arguments above, the following attributes are exported:
@@ -25,15 +31,15 @@ In addition to all arguments above, the following attributes are exported:
 
 * `account_id` - Unique ID of the account.
 
-* `restrict_create_service_id` - Defines whether or not creating a Service Id is access controlled. Valid values:  * RESTRICTED - to apply access control  * NOT_RESTRICTED - to remove access control  * NOT_SET - to 'unset' a previous set value.
-
-* `restrict_create_platform_apikey` - Defines whether or not creating platform API keys is access controlled. Valid values:  * RESTRICTED - to apply access control  * NOT_RESTRICTED - to remove access control  * NOT_SET - to 'unset' a previous set value.
-
+* `restrict_create_service_id` - Defines whether or not creating a Service Id is access controlled.
+  
+* `restrict_create_platform_apikey` - Defines whether or not creating platform API keys is access controlled. 
+  
 * `allowed_ip_addresses` - Defines the IP addresses and subnets from which IAM tokens can be created for the account.
 
 * `entity_tag` - Version of the account settings.
 
-* `mfa` - Defines the MFA trait for the account. Valid values:  * NONE - No MFA trait set  * TOTP - For all non-federated IBMId users  * TOTP4ALL - For all users  * LEVEL1 - Email-based MFA for all users  * LEVEL2 - TOTP-based MFA for all users  * LEVEL3 - U2F MFA for all users.
+* `mfa` - Defines the MFA trait for the account.
 
 * `history` - History of the Account Settings. Nested `history` blocks have the following structure:
 	* `timestamp` - Timestamp when the action was triggered.
@@ -43,8 +49,8 @@ In addition to all arguments above, the following attributes are exported:
 	* `params` - Params of the history entry.
 	* `message` - Message which summarizes the executed action.
 
-* `session_expiration_in_seconds` - Defines the session expiration in seconds for the account. Valid values:  * Any whole number between between '900' and '86400'  * NOT_SET - To unset account setting and use service default.
+* `session_expiration_in_seconds` - Defines the session expiration in seconds for the account.
 
-* `session_invalidation_in_seconds` - Defines the period of time in seconds in which a session will be invalidated due  to inactivity. Valid values:   * Any whole number between '900' and '7200'   * NOT_SET - To unset account setting and use service default.
+* `session_invalidation_in_seconds` - Defines the period of time in seconds in which a session will be invalidated due  to inactivity.
 
-* `max_sessions_per_identity` - Defines the max allowed sessions per identity required by the account. Value values: * Any whole number greater than '0'   * NOT_SET - To unset account setting and use service default 
+* `max_sessions_per_identity` - Defines the max allowed sessions per identity required by the account.

--- a/website/docs/r/iam_account_settings.html.markdown
+++ b/website/docs/r/iam_account_settings.html.markdown
@@ -31,6 +31,7 @@ The following arguments are supported:
 * `mfa` - (Optional, string) Defines the session expiration in seconds for the account.
 * `session_expiration_in_seconds` - (Optional, string) Defines the session expiration in seconds for the account.
 * `session_invalidation_in_seconds` - (Optional, string) Defines the period of time in seconds in which a session will be invalidated due to inactivity.
+* `max_sessions_per_identity` - (Optional, string) Defines the max allowed sessions per identity required by the account.
 
 ## Attribute Reference
 
@@ -44,5 +45,6 @@ In addition to all arguments above, the following attributes are exported:
 * `mfa` - Defines the session expiration in seconds for the account.
 * `session_expiration_in_seconds` - Defines the session expiration in seconds for the account.
 * `session_invalidation_in_seconds` - Defines the period of time in seconds in which a session will be invalidated due to inactivity.
+* `max_sessions_per_identity` - Defines the max allowed sessions per identity required by the account.
 * `account_id` - Unique Id of the account.
 * `id` - Unique Id of the account settings instance

--- a/website/docs/r/iam_account_settings.html.markdown
+++ b/website/docs/r/iam_account_settings.html.markdown
@@ -25,13 +25,31 @@ The following arguments are supported:
 
 * `include_history` - (Optional, boolean) Defines if the entity history is included in the response.
 * `if_match` - (Optional, string) Version of the account settings to be updated, if no value is supplied then the default value `*` will be used to indicate to update any version available. This might result in stale updates.
-* `restrict_create_service_id` - (Optional, string) Defines whether or not creating a Service Id is access controlled.
-* `restrict_create_platform_apikey` - (Optional, string) Defines whether or not creating platform API keys is access controlled.
-* `allowed_ip_addresses` - (Optional, string) Defines the IP addresses and subnets from which IAM tokens can be created for the account. Value should be a comma separated string.* 
-* `mfa` - (Optional, string) Defines the session expiration in seconds for the account.
-* `session_expiration_in_seconds` - (Optional, string) Defines the session expiration in seconds for the account.
-* `session_invalidation_in_seconds` - (Optional, string) Defines the period of time in seconds in which a session will be invalidated due to inactivity.
-* `max_sessions_per_identity` - (Optional, string) Defines the max allowed sessions per identity required by the account.
+* `restrict_create_service_id` - (Optional, string) Defines whether or not creating a Service Id is access controlled. Valid values:  
+  * RESTRICTED - to apply access control  
+  * NOT_RESTRICTED - to remove access control  
+  * NOT_SET - to 'unset' a previous set value.
+* `restrict_create_platform_apikey` - (Optional, string) Defines whether or not creating platform API keys is access controlled. Valid values:  
+  * RESTRICTED - to apply access control  
+  * NOT_RESTRICTED - to remove access control  
+  * NOT_SET - to 'unset' a previous set value.
+* `allowed_ip_addresses` - (Optional, string) Defines the IP addresses and subnets from which IAM tokens can be created for the account. Value should be a comma separated string. 
+* `mfa` - (Optional, string) Defines the session expiration in seconds for the account.  Valid values:  
+  * NONE - No MFA trait set  
+  * TOTP - For all non-federated IBMId users
+  * TOTP4ALL - For all users
+  * LEVEL1 - Email-based MFA for all users
+  * LEVEL2 - TOTP-based MFA for all users
+  * LEVEL3 - U2F MFA for all users.
+* `session_expiration_in_seconds` - (Optional, string) Defines the session expiration in seconds for the account. Valid values:  
+  * Any whole number between between '900' and '86400'  
+  * NOT_SET - To unset account setting and use service default.
+* `session_invalidation_in_seconds` - (Optional, string) Defines the period of time in seconds in which a session will be invalidated due to inactivity. Valid values:
+  * Any whole number between '900' and '7200'
+  * NOT_SET - To unset account setting and use service default.
+* `max_sessions_per_identity` - (Optional, string) Defines the max allowed sessions per identity required by the account. Valid values:
+  * Any whole number greater than '0' 
+  * NOT_SET - To unset account setting and use service default.
 
 ## Attribute Reference
 


### PR DESCRIPTION
Update provider to include a new parameter `max_sessions_per_identity` in the [Account Settings API](https://cloud.ibm.com/apidocs/iam-identity-token-api#updateaccountsettings)

Relevant tests are passing.
![Screenshot 2021-05-11 at 15 28 45](https://user-images.githubusercontent.com/9368984/117832987-e0f0f800-b26d-11eb-9272-1d0864736ca6.png)

