### PR TITLE
Create Key With Writer Role Assignment.

### DIFF
--- a/ibm/resource_ibm_kms_key.go
+++ b/ibm/resource_ibm_kms_key.go
@@ -448,16 +448,16 @@ func resourceIBMKmsKeyRead(d *schema.ResourceData, meta interface{}) error {
 	if err != nil {
 		return fmt.Errorf("Get Key failed with error: %s", err)
 	}
-
-	policies, err := kpAPI.GetPolicies(context.Background(), keyid)
-
-	if err != nil {
-		return fmt.Errorf("Failed to read policies: %s", err)
-	}
-	if len(policies) == 0 {
-		log.Printf("No Policy Configurations read\n")
-	} else {
-		d.Set("policies", flattenKeyPolicies(policies))
+	if d.Get("policies") != nil {
+		policies, err := kpAPI.GetPolicies(context.Background(), keyid)
+		if err != nil {
+			return fmt.Errorf("Failed to read policies: %s", err)
+		}
+		if len(policies) == 0 {
+			log.Printf("No Policy Configurations read\n")
+		} else {
+			d.Set("policies", flattenKeyPolicies(policies))
+		}
 	}
 	d.Set("instance_id", instanceID)
 	d.Set("key_id", keyid)

--- a/ibm/resource_ibm_kms_key.go
+++ b/ibm/resource_ibm_kms_key.go
@@ -448,16 +448,15 @@ func resourceIBMKmsKeyRead(d *schema.ResourceData, meta interface{}) error {
 	if err != nil {
 		return fmt.Errorf("Get Key failed with error: %s", err)
 	}
-	if d.Get("policies") != nil {
-		policies, err := kpAPI.GetPolicies(context.Background(), keyid)
-		if err != nil {
-			return fmt.Errorf("Failed to read policies: %s", err)
-		}
-		if len(policies) == 0 {
-			log.Printf("No Policy Configurations read\n")
-		} else {
-			d.Set("policies", flattenKeyPolicies(policies))
-		}
+
+	policies, err := kpAPI.GetPolicies(context.Background(), keyid)
+	if err != nil && !strings.Contains(fmt.Sprint(err), "Unauthorized: The user does not have access to the specified resource") {
+		return fmt.Errorf("Failed to read policies: %s", err)
+	}
+	if len(policies) == 0 {
+		log.Printf("No Policy Configurations read\n")
+	} else {
+		d.Set("policies", flattenKeyPolicies(policies))
 	}
 	d.Set("instance_id", instanceID)
 	d.Set("key_id", keyid)


### PR DESCRIPTION
**Current Behavior**
When they are trying to create/manage keys using terraform. 
With a user who's been given minimal permissions from their perspective for key management, i.e Reader and Writer
They run into permission issues, since terraform attempts to read the policies for the key as well(example terraform block below).
(Reader+Writer works fine for creating keys using API's)

So, we need to find a way to decouple the key_policy operation through terraform based on user privilege. 

# Both the following will require the "Manager" role which is not minimal from the banks perspective. 
 
resource "ibm_kms_key" "key" {
  instance_id = ibm_resource_instance.kp_instance.guid
  key_name       = "key"
  standard_key   = false
  expiration_date = "2020-12-05T15:43:46Z"
}
 
 
resource "ibm_kms_key" "key" {
  instance_id = ibm_resource_instance.kp_instance.guid
  key_name       = "key"
  standard_key   = false
  expiration_date = "2020-12-05T15:43:46Z"
  policies {
    rotation {
      interval_month = 3
    }
    dual_auth_delete {
      enabled = false
    }
  }
} 

**Expected Behavior**
As per our Built in roles "Key Policy Management" requires "Manager" role; this could/may cause inconvenience to the customers in general when using terraform requiring to give extra permissions
 
**With the Writer Role assigned to the user The current change should gives access to the user to Create Key without Policy.**

**Security/Compliance Considerations**
<!--- Describe bug's and/or solution's effects on security and compliance --->
<!--- ex: security vunerability due to ... --->
<!--- ex: 30 day deprecation notice required due to ... behavior change --->
<!--- KMK ex: unit test coverage --->
<!--- SST ex: networking or port changes --->

**Additional Information**
<!--- Add any additional info, tickets, tests, etc. that relate to or add context to this bug --->
<!--- ex: known customer impact: ... --->