### PR TITLE
update azure script to grow root volume group

### DIFF
--- a/ibm/data_source_ibm_satellite_host_script.go
+++ b/ibm/data_source_ibm_satellite_host_script.go
@@ -120,25 +120,24 @@ func dataSourceIBMSatelliteAttachHostScriptRead(d *schema.ResourceData, meta int
 			} else if strings.ToLower(hostProvider) == "ibm" {
 				lines[i] = "subscription-manager refresh\nsubscription-manager repos --enable=*\n"
 			} else if strings.ToLower(hostProvider) == "azure" {
-				lines[i] = fmt.Sprintf(`
-					#Grow the base volume group first
-					echo -e "r\ne\ny\nw\ny\ny\n" | gdisk /dev/sda
-					#mark result as true as this returns a non-0 RC when syncing disks
-					echo -e "n\n\n\n\n\nw\n" | fdisk /dev/sda || true
-					partx -l /dev/sda || true
-					partx -v -a /dev/sda || true
-					pvcreate /dev/sda5
-					vgextend rootvg /dev/sda5
-					# Grow the TMP LV
-					lvextend -L+10G /dev/rootvg/tmplv
-					xfs_growfs /dev/rootvg/tmplv
-					# Grow the var LV
-					lvextend -L+20G /dev/rootvg/varlv
-					xfs_growfs /dev/rootvg/varlv
-					yum update --disablerepo=* --enablerepo="*microsoft*" -y
-					yum-config-manager --enable '*'
-					yum repolist all
-					yum install container-selinux -y
+				lines[i] = fmt.Sprintf(`#Grow the base volume group first
+echo -e "r\ne\ny\nw\ny\ny\n" | gdisk /dev/sda
+#mark result as true as this returns a non-0 RC when syncing disks
+echo -e "n\n\n\n\n\nw\n" | fdisk /dev/sda || true
+partx -l /dev/sda || true
+partx -v -a /dev/sda || true
+pvcreate /dev/sda5
+vgextend rootvg /dev/sda5
+# Grow the TMP LV
+lvextend -L+10G /dev/rootvg/tmplv
+xfs_growfs /dev/rootvg/tmplv
+# Grow the var LV
+lvextend -L+20G /dev/rootvg/varlv
+xfs_growfs /dev/rootvg/varlv
+yum update --disablerepo=* --enablerepo="*microsoft*" -y
+yum-config-manager --enable '*'
+yum repolist all
+yum install container-selinux -y
 				`)
 			}
 		}

--- a/ibm/data_source_ibm_satellite_host_script.go
+++ b/ibm/data_source_ibm_satellite_host_script.go
@@ -135,7 +135,7 @@ func dataSourceIBMSatelliteAttachHostScriptRead(d *schema.ResourceData, meta int
 					# Grow the var LV
 					lvextend -L+20G /dev/rootvg/varlv
 					xfs_growfs /dev/rootvg/varlv
-					yum update -y
+					yum update --disablerepo=* --enablerepo="*microsoft*" -y
 					yum-config-manager --enable '*'
 					yum repolist all
 					yum install container-selinux -y

--- a/ibm/data_source_ibm_satellite_host_script.go
+++ b/ibm/data_source_ibm_satellite_host_script.go
@@ -120,7 +120,25 @@ func dataSourceIBMSatelliteAttachHostScriptRead(d *schema.ResourceData, meta int
 			} else if strings.ToLower(hostProvider) == "ibm" {
 				lines[i] = "subscription-manager refresh\nsubscription-manager repos --enable=*\n"
 			} else if strings.ToLower(hostProvider) == "azure" {
-				lines[i] = "# Grow the TMP LV\nlvextend -L+10G /dev/rootvg/tmplv\nxfs_growfs /dev/rootvg/tmplv\n# Grow the var LV\nlvextend -L+20G /dev/rootvg/varlv\nxfs_growfs /dev/rootvg/varlv\nyum update -y\nyum-config-manager --enable '*'\nyum repolist all\nyum install container-selinux -y"
+				lines[i] = fmt.Sprintf(`
+					#Grow the base volume group first
+					echo -e "r\ne\ny\nw\ny\ny\n" | gdisk /dev/sda
+					echo -e "n\n\n\n\n\nw\n" | fdisk /dev/sda
+					partx -l /dev/sda
+					partx -v -a /dev/sda
+					pvcreate /dev/sda5
+					vgextend rootvg /dev/sda5
+					# Grow the TMP LV
+					lvextend -L+10G /dev/rootvg/tmplv
+					xfs_growfs /dev/rootvg/tmplv
+					# Grow the var LV
+					lvextend -L+20G /dev/rootvg/varlv
+					xfs_growfs /dev/rootvg/varlv
+					yum update -y
+					yum-config-manager --enable '*'
+					yum repolist all
+					yum install container-selinux -y
+				)`)
 			}
 		}
 	}

--- a/ibm/data_source_ibm_satellite_host_script.go
+++ b/ibm/data_source_ibm_satellite_host_script.go
@@ -139,7 +139,7 @@ func dataSourceIBMSatelliteAttachHostScriptRead(d *schema.ResourceData, meta int
 					yum-config-manager --enable '*'
 					yum repolist all
 					yum install container-selinux -y
-				)`)
+				`)
 			}
 		}
 	}

--- a/ibm/data_source_ibm_satellite_host_script.go
+++ b/ibm/data_source_ibm_satellite_host_script.go
@@ -123,9 +123,10 @@ func dataSourceIBMSatelliteAttachHostScriptRead(d *schema.ResourceData, meta int
 				lines[i] = fmt.Sprintf(`
 					#Grow the base volume group first
 					echo -e "r\ne\ny\nw\ny\ny\n" | gdisk /dev/sda
-					echo -e "n\n\n\n\n\nw\n" | fdisk /dev/sda
-					partx -l /dev/sda
-					partx -v -a /dev/sda
+					#mark result as true as this returns a non-0 RC when syncing disks
+					echo -e "n\n\n\n\n\nw\n" | fdisk /dev/sda || true
+					partx -l /dev/sda || true
+					partx -v -a /dev/sda || true
 					pvcreate /dev/sda5
 					vgextend rootvg /dev/sda5
 					# Grow the TMP LV


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/IBM-Cloud/terraform-provider-ibm/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
 make testacc TESTARGS='-run=TestAccXXX'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test $(go list ./... |grep -v 'vendor') -v -run=TestAccXXX -timeout 700m
?   	github.com/IBM-Cloud/terraform-provider-ibm	[no test files]
[WARN] Set the environment variable IBM_ORG for testing ibm_org  resource Some tests for that resource will fail if this is not set correctly
[WARN] Set the environment variable IBM_SPACE for testing ibm_space  resource Some tests for that resource will fail if this is not set correctly
[WARN] Set the environment variable IBM_ID1 for testing ibm_space resource Some tests for that resource will fail if this is not set correctly
[WARN] Set the environment variable IBM_ID2 for testing ibm_space resource Some tests for that resource will fail if this is not set correctly
[WARN] Set the environment variable IBM_IAMUSER for testing ibm_iam_user_policy resource Some tests for that resource will fail if this is not set correctly
[WARN] Set the environment variable IBM_DATACENTER for testing ibm_container_cluster resource else it is set to default value 'par01'
[WARN] Set the environment variable IBM_MACHINE_TYPE for testing ibm_container_cluster resource else it is set to default value 'u2c.2x4'
[WARN] Set the environment variable IBM_CERT_CRN for testing ibm_container_alb_cert resource else it is set to default value
[WARN] Set the environment variable IBM_UPDATE_CERT_CRN for testing ibm_container_alb_cert resource else it is set to default value
[WARN] Set the environment variable IBM_CONTAINER_REGION for testing ibm_container resources else it is set to default value 'eu-de'
[WARN] Set the environment variable IBM_CIS_INSTANCE with a VALID CIS Instance NAME for testing ibm_cis resources on staging/test
[WARN] Set the environment variable IBM_CIS_DOMAIN_STATIC with the Domain name registered with the CIS instance on test/staging. Domain must be predefined in CIS to avoid CIS billing costs due to domain delete/create
[WARN] Set the environment variable IBM_CIS_DOMAIN_TEST with a VALID Domain name for testing the one time create and delete of a domain in CIS. Note each create/delete will trigger a monthly billing instance. Only to be run in staging/test
[WARN] Set the environment variable IBM_CIS_RESOURCE_GROUP with the resource group for the CIS Instance
[WARN] Set the environment variable IBM_TRUSTED_MACHINE_TYPE for testing ibm_container_cluster resource else it is set to default value 'mb1c.16x64'
[WARN] Set the environment variable IBM_BM_EXTENDED_HW_TESTING to true/false for testing ibm_compute_bare_metal resource else it is set to default value 'false'
[WARN] Set the environment variable IBM_PUBLIC_VLAN_ID for testing ibm_container_cluster resource else it is set to default value '2393319'
[WARN] Set the environment variable IBM_PRIVATE_VLAN_ID for testing ibm_container_cluster resource else it is set to default value '2393321'
[WARN] Set the environment variable IBM_KUBE_VERSION for testing ibm_container_cluster resource else it is set to default value '1.18.14'
[WARN] Set the environment variable IBM_KUBE_UPDATE_VERSION for testing ibm_container_cluster resource else it is set to default value '1.19.6'
[WARN] Set the environment variable IBM_PRIVATE_SUBNET_ID for testing ibm_container_cluster resource else it is set to default value '1636107'
[WARN] Set the environment variable IBM_PUBLIC_SUBNET_ID for testing ibm_container_cluster resource else it is set to default value '1165645'
[WARN] Set the environment variable IBM_SUBNET_ID for testing ibm_container_cluster resource else it is set to default value '1165645'
[INFO] Set the environment variable IBM_IPSEC_DATACENTER for testing ibm_ipsec_vpn resource else it is set to default value 'tok02'
[INFO] Set the environment variable IBM_IPSEC_CUSTOMER_SUBNET_ID for testing ibm_ipsec_vpn resource else it is set to default value '123456'
[INFO] Set the environment variable IBM_IPSEC_CUSTOMER_PEER_IP for testing ibm_ipsec_vpn resource else it is set to default value '192.168.0.1'
[WARN] Set the environment variable IBM_LBAAS_DATACENTER for testing ibm_lbaas resource else it is set to default value 'dal13'
[WARN] Set the environment variable IBM_LBAAS_SUBNETID for testing ibm_lbaas resource else it is set to default value '2144241'
[WARN] Set the environment variable IBM_DEDICATED_HOSTNAME for testing ibm_compute_vm_instance resource else it is set to default value 'terraform-dedicatedhost'
[WARN] Set the environment variable IBM_DEDICATED_HOST_ID for testing ibm_compute_vm_instance resource else it is set to default value '30301'
[WARN] Set the environment variable IBM_WORKER_POOL_ZONE for testing ibm_container_worker_pool_zone_attachment resource else it is set to default value 'ams03'
[WARN] Set the environment variable IBM_WORKER_POOL_ZONE_PRIVATE_VLAN for testing ibm_container_worker_pool_zone_attachment resource else it is set to default value '2538975'
[WARN] Set the environment variable IBM_WORKER_POOL_ZONE_PUBLIC_VLAN for testing ibm_container_worker_pool_zone_attachment resource else it is set to default value '2538967'
[WARN] Set the environment variable IBM_WORKER_POOL_ZONE_UPDATE_PRIVATE_VLAN for testing ibm_container_worker_pool_zone_attachment resource else it is set to default value '2388377'
[WARN] Set the environment variable IBM_WORKER_POOL_ZONE_UPDATE_PUBLIC_VLAN for testing ibm_container_worker_pool_zone_attachment resource else it is set to default value '2388375'
[WARN] Set the environment variable IBM_PLACEMENT_GROUP_NAME for testing ibm_compute_vm_instance resource else it is set to default value 'terraform-group'
[INFO] Set the environment variable SL_REGION for testing ibm_is_region datasource else it is set to default value 'us-south'
[INFO] Set the environment variable SL_ZONE for testing ibm_is_zone datasource else it is set to default value 'us-south-1'
[INFO] Set the environment variable SL_CIDR for testing ibm_is_subnet else it is set to default value '10.240.0.0/24'
[INFO] Set the environment variable SL_ADDRESS_PREFIX_CIDR for testing ibm_is_vpc_address_prefix else it is set to default value '10.120.0.0/24'
[INFO] Set the environment variable IS_IMAGE for testing ibm_is_instance, ibm_is_floating_ip else it is set to default value 'r006-ed3f775f-ad7e-4e37-ae62-7199b4988b00'
[INFO] Set the environment variable IS_WIN_IMAGE for testing ibm_is_instance data source else it is set to default value 'r006-5f9568ae-792e-47e1-a710-5538b2bdfca7'
[INFO] Set the environment variable SL_INSTANCE_PROFILE for testing ibm_is_instance resource else it is set to default value 'cx2-2x4'
[INFO] Set the environment variable SL_INSTANCE_PROFILE_UPDATE for testing ibm_is_instance resource else it is set to default value 'cx2-4x8'
[INFO] Set the environment variable IS_DEDICATED_HOST_PROFILE for testing ibm_is_instance resource else it is set to default value 'bx2d-host-152x608'
[INFO] Set the environment variable IS_DEDICATED_HOST_GROUP_CLASS for testing ibm_is_instance resource else it is set to default value 'bx2d'
[INFO] Set the environment variable IS_DEDICATED_HOST_GROUP_FAMILY for testing ibm_is_instance resource else it is set to default value 'balanced'
[INFO] Set the environment variable SL_INSTANCE_PROFILE for testing ibm_is_instance resource else it is set to default value 'bx2d-16x64'
[INFO] Set the environment variable IS_VOLUME_PROFILE for testing ibm_is_volume_profile else it is set to default value 'general-purpose'
[INFO] Set the environment variable SL_ROUTE_DESTINATION for testing ibm_is_vpc_route else it is set to default value '192.168.4.0/24'
[INFO] Set the environment variable SL_ROUTE_NEXTHOP for testing ibm_is_vpc_route else it is set to default value '10.0.0.4'
[INFO] Set the environment variable PI_IMAGE for testing ibm_pi_image resource else it is set to default value '7200-03-03'
[INFO] Set the environment variable PI_KEY_NAME for testing ibm_pi_key_name resource else it is set to default value 'terraform-test-power'
[INFO] Set the environment variable PI_NETWORK_NAME for testing ibm_pi_network_name resource else it is set to default value 'terraform-test-power'
[INFO] Set the environment variable PI_VOLUME_NAME for testing ibm_pi_network_name resource else it is set to default value 'terraform-test-power'
[INFO] Set the environment variable PI_CLOUDINSTANCE_ID for testing ibm_pi_image resource else it is set to default value 'd16705bd-7f1a-48c9-9e0e-1c17b71e7331'
[INFO] Set the environment variable PI_PVM_INSTANCE_ID for testing pi_instance_name resource else it is set to default value 'terraform-test-power'
[INFO] Set the environment variable SCHEMATICS_WORKSPACE_ID for testing schematics resources else it is set to default value
[INFO] Set the environment variable SCHEMATICS_TEMPLATE_ID for testing schematics resources else it is set to default value
[INFO] Set the environment variable SCHEMATICS_ACTION_ID for testing schematics resources else it is set to default value
[WARN] Set the environment variable IMAGE_COS_URL with a VALID COS Image SQL URL for testing ibm_is_image resources on staging/test
[WARN] Set the environment variable IMAGE_COS_URL_ENCRYPTED with a VALID COS Image SQL URL for testing ibm_is_image resources on staging/test
[WARN] Set the environment variable IMAGE_OPERATING_SYSTEM with a VALID Operating system for testing ibm_is_image resources on staging/test
[INFO] Set the environment variable IS_IMAGE_NAME for testing data source ibm_is_image else it is set to default value `ibm-ubuntu-18-04-1-minimal-amd64-2`
[INFO] Set the environment variable IS_IMAGE_ENCRYPTED_DATA_KEY for testing resource ibm_is_image else it is set to default value
[INFO] Set the environment variable IS_IMAGE_ENCRYPTION_KEY for testing resource ibm_is_image else it is set to default value
[INFO] Set the environment variable IBM_FUNCTION_NAMESPACE for testing ibm_function_package, ibm_function_action, ibm_function_rule, ibm_function_trigger resource else  tests will fail if this is not set correctly
[INFO] Set the environment variable HPCS_INSTANCE_ID for testing data_source_ibm_kms_key_test else it is set to default value
[INFO] Set the environment variable SECRETS_MANAGER_INSTANCE_ID for testing data_source_ibm_secrets_manager_secrets_test else tests will fail if this is not set correctly
[INFO] Set the environment variable SECRETS_MANAGER_SECRET_TYPE for testing data_source_ibm_secrets_manager_secrets_test, else it is set to default value. For data_source_ibm_secrets_manager_secret_test, tests will fail if this is not set correctly
[WARN] Set the environment variable SECRETS_MANAGER_SECRET_ID for testing data_source_ibm_secrets_manager_secret_test else tests will fail if this is not set correctly
[INFO] Set the environment variable IBM_TG_CROSS_ACCOUNT_ID for testing ibm_tg_connection resource else  tests will fail if this is not set correctly
[INFO] Set the environment variable IBM_TG_CROSS_NETWORK_ID for testing ibm_tg_connection resource else  tests will fail if this is not set correctly
[INFO] Set the environment variable ACCOUNT_TO_BE_IMPORTED for testing import enterprise account resource else  tests will fail if this is not set correctly
testing: warning: no tests to run
PASS
ok  	github.com/IBM-Cloud/terraform-provider-ibm/ibm	1.646s [no tests to run]
testing: warning: no tests to run
PASS
ok  	github.com/IBM-Cloud/terraform-provider-ibm/ibm/internal/hashcode	0.847s [no tests to run]
testing: warning: no tests to run
PASS
ok  	github.com/IBM-Cloud/terraform-provider-ibm/ibm/internal/mutexkv	1.412s [no tests to run]
?   	github.com/IBM-Cloud/terraform-provider-ibm/version	[no test files]

...
```
