### PR TITLE
fix: instance group manager policy synchronization

### DIFF
--- a/ibm/resource_ibm_is_instance_group.go
+++ b/ibm/resource_ibm_is_instance_group.go
@@ -239,7 +239,7 @@ func resourceIBMISInstanceGroupCreate(d *schema.ResourceData, meta interface{}) 
 	}
 	d.SetId(*instanceGroup.ID)
 
-	_, healthError := waitForHealthyInstanceGroup(d, meta, d.Timeout(schema.TimeoutCreate))
+	_, healthError := waitForHealthyInstanceGroup(d.Id(), meta, d.Timeout(schema.TimeoutCreate))
 	if healthError != nil {
 		return healthError
 	}
@@ -339,7 +339,7 @@ func resourceIBMISInstanceGroupUpdate(d *schema.ResourceData, meta interface{}) 
 		}
 
 		// wait for instance group health update with update timeout configured.
-		_, healthError := waitForHealthyInstanceGroup(d, meta, d.Timeout(schema.TimeoutUpdate))
+		_, healthError := waitForHealthyInstanceGroup(instanceGroupID, meta, d.Timeout(schema.TimeoutUpdate))
 		if healthError != nil {
 			return healthError
 		}
@@ -445,7 +445,7 @@ func resourceIBMISInstanceGroupDelete(d *schema.ResourceData, meta interface{}) 
 	if err != nil {
 		return fmt.Errorf("Error updating instanceGroup's instance count to 0 : %s\n%s", err, response)
 	}
-	_, healthError := waitForHealthyInstanceGroup(d, meta, d.Timeout(schema.TimeoutUpdate))
+	_, healthError := waitForHealthyInstanceGroup(instanceGroupID, meta, d.Timeout(schema.TimeoutUpdate))
 	if healthError != nil {
 		return healthError
 	}
@@ -511,13 +511,12 @@ func resourceIBMISInstanceGroupExists(d *schema.ResourceData, meta interface{}) 
 	return true, nil
 }
 
-func waitForHealthyInstanceGroup(d *schema.ResourceData, meta interface{}, timeout time.Duration) (interface{}, error) {
+func waitForHealthyInstanceGroup(instanceGroupID string, meta interface{}, timeout time.Duration) (interface{}, error) {
 	sess, err := vpcClient(meta)
 	if err != nil {
 		return nil, err
 	}
 
-	instanceGroupID := d.Id()
 	getInstanceGroupOptions := vpcv1.GetInstanceGroupOptions{ID: &instanceGroupID}
 
 	healthStateConf := &resource.StateChangeConf{


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/IBM-Cloud/terraform-provider-ibm/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```
