### PR TITLE
Bring cr_namespaces datasource doc in line with provider

### DIFF
--- a/website/docs/d/cr_namespaces.html.markdown
+++ b/website/docs/d/cr_namespaces.html.markdown
@@ -8,11 +8,9 @@ description: |-
 
 # ibm\_cr_namespaces
 
-Lists a Container Registry Namespaces of an account. 
+Lists IBM Cloud Container Registry namespaces of an account in the targeted region.
 
 ## Example Usage
-
-In the following example, you can configure a alb:
 
 ```hcl
 data "ibm_cr_namespaces" "test" {}
@@ -29,8 +27,10 @@ In addition to all arguments above, the following attributes are exported:
 
 * `id` - Id of the Namespace Datasource.
 * `namespaces` - List of namespaces available in the account.
-    * `name` - The Name of the Namespace that has to be created.
+    * `name` - The Name of the namespace.
     * `resource_group_id` -  Id of the resource group to which the namespace has to be assigned.
-    * `crn` - Crn of the namespace.
-    * `created_on` - The Created Time of the Namespace.
-    * `updated_on` - The Updated Time of the Namespace.
+    * `account` - The IBM Cloud account that owns the namespace.
+    * `crn` - If the namespace has been assigned to a resource group, this is the IBM Cloud CRN representing the namespace.
+    * `created_date` - When the namespace was created.
+    * `resource_created_date` - When the namespace was assigned to a resource group.
+    * `updated_date` - When the namespace was last updated.


### PR DESCRIPTION
Signed-off-by: James Hart <jhart@uk.ibm.com>

When delivering the updated container-registry provider, the datasource was updated, but its docs were not.

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

Output from acceptance testing:
N/A - documentation only
