### PR TITLE
Feat: Adding CIS Filter

### DIFF
--- a/examples/ibm-cis/main.tf
+++ b/examples/ibm-cis/main.tf
@@ -168,6 +168,18 @@ resource "ibm_cis_rate_limit" "ratelimit" {
   }
 }
 
+
+# CIS Filter Function
+resource "ibm_cis_filter" "test" {
+  cis_id      = data.ibm_cis.cis.id
+  domain_id   = data.ibm_cis_domain.cis_domain.domain_id
+  expression         =  "(http.request.uri eq \"/test-update?number=212\")"
+  paused             =  "false"
+  description        = "Filter-creation"
+
+
+}
+
 # CIS Edge Functions action
 resource "ibm_cis_edge_functions_action" "test_action" {
   cis_id      = data.ibm_cis.cis.id

--- a/ibm/provider.go
+++ b/ibm/provider.go
@@ -562,6 +562,7 @@ func Provider() *schema.Provider {
 			"ibm_ssl_certificate":                                resourceIBMSSLCertificate(),
 			"ibm_cdn":                                            resourceIBMCDN(),
 			"ibm_hardware_firewall_shared":                       resourceIBMFirewallShared(),
+			"ibm_cis_filter":                                     resourceIBMCISFilter(),
 
 			//Added for Power Colo
 
@@ -707,6 +708,7 @@ func Validator() ValidatorDict {
 				"ibm_container_cluster":                 resourceIBMContainerClusterValidator(),
 				"ibm_resource_tag":                      resourceIBMResourceTagValidator(),
 				"ibm_satellite_location":                resourceIBMSatelliteLocationValidator(),
+				"ibm_cis_filter":                        resourceIBMCISFilterValidator(),
 			},
 			DataSourceValidatorDictionary: map[string]*ResourceValidator{
 				"ibm_is_subnet":               dataSourceIBMISSubnetValidator(),

--- a/ibm/resource_ibm_cis_filter.go
+++ b/ibm/resource_ibm_cis_filter.go
@@ -1,0 +1,305 @@
+// Copyright IBM Corp. 2017, 2021 All Rights Reserved.
+// Licensed under the Mozilla Public License v2.0
+
+package ibm
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"log"
+
+	"github.com/IBM/networking-go-sdk/filtersv1"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+const (
+	ibmCISFilters        = "ibm_cis_filter"
+	cisFilterExpression  = "expression"
+	cisFilterPaused      = "paused"
+	cisFilterDescription = "description"
+	cisFilterID          = "filterid"
+)
+
+type FilterCreateUpdate struct {
+	Success bool `json:"success"`
+	Errors  []struct {
+	} `json:"errors"`
+	Messages []struct {
+	} `json:"messages"`
+	Result []struct {
+		ID          string `json:"id"`
+		Paused      bool   `json:"paused"`
+		Description string `json:"description"`
+		Expression  string `json:"expression"`
+		CreatedOn   struct {
+		} `json:"created_on"`
+		ModifiedOn struct {
+		} `json:"modified_on"`
+	} `json:"result"`
+}
+type FilterRead struct {
+	Success bool `json:"success"`
+	Errors  []struct {
+	} `json:"errors"`
+	Messages []struct {
+	} `json:"messages"`
+	Result struct {
+		ID          string `json:"id"`
+		Paused      bool   `json:"paused"`
+		Description string `json:"description"`
+		Expression  string `json:"expression"`
+		CreatedOn   struct {
+		} `json:"created_on"`
+		ModifiedOn struct {
+		} `json:"modified_on"`
+	} `json:"result"`
+}
+
+func resourceIBMCISFilter() *schema.Resource {
+	return &schema.Resource{
+		Create:   resourceIBMCISFilterCreate,
+		Read:     resourceIBMCISFilterRead,
+		Update:   resourceIBMCISFilterUpdate,
+		Delete:   resourceIBMCISFilterDelete,
+		Importer: &schema.ResourceImporter{},
+		Schema: map[string]*schema.Schema{
+			cisID: {
+				Type:        schema.TypeString,
+				Description: "CIS instance crn",
+				Required:    true,
+			},
+			cisDomainID: {
+				Type:             schema.TypeString,
+				Description:      "Associated CIS domain",
+				Required:         true,
+				DiffSuppressFunc: suppressDomainIDDiff,
+			},
+			cisFilterPaused: {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Description: "Filter Paused",
+			},
+			cisFilterID: {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "Filter ID",
+			},
+			cisFilterExpression: {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "Filter Expression",
+			},
+			cisFilterDescription: {
+				Type:         schema.TypeString,
+				Optional:     true,
+				Description:  "Filter Description",
+				ValidateFunc: InvokeValidator(ibmCISFilters, cisFilterDescription),
+			},
+		},
+	}
+}
+func resourceIBMCISFilterCreate(d *schema.ResourceData, meta interface{}) error {
+	sess, err := meta.(ClientSession).BluemixSession()
+	if err != nil {
+		return fmt.Errorf("Error while Getting IAM Access Token using BluemixSession %s", err)
+	}
+	xAuthtoken := sess.Config.IAMAccessToken
+
+	cisClient, err := meta.(ClientSession).CisFiltersSession()
+	if err != nil {
+		return fmt.Errorf("Error while getting the CisFiltersSession %s", err)
+	}
+
+	crn := d.Get(cisID).(string)
+	zoneID, _, err := convertTftoCisTwoVar(d.Get(cisDomainID).(string))
+
+	var newfilter filtersv1.FilterInput
+
+	if _, ok := d.GetOk(cisFilterPaused); ok {
+		paused := d.Get(cisFilterPaused).(bool)
+		newfilter.Paused = &paused
+	}
+	if _, ok := d.GetOk(cisFilterDescription); ok {
+		description := d.Get(cisFilterDescription).(string)
+		newfilter.Description = &description
+	}
+	if _, ok := d.GetOk(cisFilterExpression); ok {
+		expression := d.Get(cisFilterExpression).(string)
+		newfilter.Expression = &expression
+	}
+
+	opt := cisClient.NewCreateFilterOptions(xAuthtoken, crn, zoneID)
+
+	filetrInput := &filtersv1.FilterInput{
+		Expression:  newfilter.Expression,
+		Paused:      newfilter.Paused,
+		Description: newfilter.Description,
+	}
+
+	opt.SetFilterInput([]filtersv1.FilterInput{*filetrInput})
+
+	result, response, err := cisClient.CreateFilter(opt)
+	if err != nil {
+		if response != nil && response.StatusCode == 404 {
+			return nil
+		}
+		return fmt.Errorf("Error creating Filter for zone %q: %s", zoneID, err)
+	}
+	buf := new(bytes.Buffer)
+	buf.ReadFrom(result)
+	newStr := buf.String()
+
+	filter_res := FilterCreateUpdate{}
+	json_err := json.Unmarshal([]byte(newStr), &filter_res)
+
+	if json_err != nil {
+		return fmt.Errorf("Error unmarshal the jason string %s", json_err)
+	}
+
+	d.SetId(convertCisToTfThreeVar(filter_res.Result[0].ID, zoneID, crn))
+	return resourceIBMCISFilterRead(d, meta)
+
+}
+func resourceIBMCISFilterRead(d *schema.ResourceData, meta interface{}) error {
+	sess, err := meta.(ClientSession).BluemixSession()
+	if err != nil {
+		return fmt.Errorf("Error while Getting IAM Access Token using BluemixSession %s", err)
+	}
+	xAuthtoken := sess.Config.IAMAccessToken
+
+	cisClient, err := meta.(ClientSession).CisFiltersSession()
+	if err != nil {
+		return fmt.Errorf("Error while getting the CisFiltersSession %s", err)
+	}
+	filterid, zoneID, crn, err := convertTfToCisThreeVar(d.Id())
+	if err != nil {
+		return err
+	}
+
+	opt := cisClient.NewGetFilterOptions(xAuthtoken, crn, zoneID, filterid)
+
+	filters, response, err := cisClient.GetFilter(opt)
+	if err != nil {
+		if response != nil && response.StatusCode == 404 {
+			log.Printf("Error GetFilter not found ")
+			return nil
+		}
+		return fmt.Errorf("Error finding GetFilter %q: %s", d.Id(), err)
+	}
+
+	buf := new(bytes.Buffer)
+	buf.ReadFrom(filters)
+	newStr := buf.String()
+
+	filter_res := FilterRead{}
+	json_err := json.Unmarshal([]byte(newStr), &filter_res)
+	if json_err != nil {
+		return fmt.Errorf("Error unmarshal the json string resourceIBMCISFilterRead %s", json_err)
+	}
+	d.Set(cisID, crn)
+	d.Set(cisDomainID, zoneID)
+	d.Set(cisFilterID, filter_res.Result.ID)
+	d.Set(cisFilterPaused, filter_res.Result.Paused)
+	d.Set(cisFilterDescription, filter_res.Result.Description)
+	d.Set(cisFilterExpression, filter_res.Result.Expression)
+
+	return nil
+}
+func resourceIBMCISFilterUpdate(d *schema.ResourceData, meta interface{}) error {
+	sess, err := meta.(ClientSession).BluemixSession()
+	if err != nil {
+		return fmt.Errorf("Error while Getting IAM Access Token using BluemixSession %s", err)
+	}
+	xAuthtoken := sess.Config.IAMAccessToken
+
+	cisClient, err := meta.(ClientSession).CisFiltersSession()
+	if err != nil {
+		return fmt.Errorf("Error while getting the CisFiltersSession %s", err)
+	}
+
+	filterid, zoneID, crn, err := convertTfToCisThreeVar(d.Id())
+	if err != nil {
+		return err
+	}
+	var updatefilter filtersv1.FilterUpdateInput
+	updatefilter.ID = &filterid
+
+	if _, ok := d.GetOk(cisFilterPaused); ok {
+		paused := d.Get(cisFilterPaused).(bool)
+		updatefilter.Paused = &paused
+	}
+	if _, ok := d.GetOk(cisFilterDescription); ok {
+		description := d.Get(cisFilterDescription).(string)
+		updatefilter.Description = &description
+	}
+	if _, ok := d.GetOk(cisFilterExpression); ok {
+		expression := d.Get(cisFilterExpression).(string)
+		updatefilter.Expression = &expression
+	}
+
+	opt := cisClient.NewUpdateFiltersOptions(xAuthtoken, crn, zoneID)
+
+	filterUpdateInput := &filtersv1.FilterUpdateInput{
+		ID:          updatefilter.ID,
+		Expression:  updatefilter.Expression,
+		Paused:      updatefilter.Paused,
+		Description: updatefilter.Description,
+	}
+	opt.SetFilterUpdateInput([]filtersv1.FilterUpdateInput{*filterUpdateInput})
+
+	result, _, err := cisClient.UpdateFilters(opt)
+	if err != nil {
+		return fmt.Errorf("Error updating Filter for zone %q: %s", zoneID, err)
+	}
+
+	buf := new(bytes.Buffer)
+	buf.ReadFrom(result)
+	newStr := buf.String()
+
+	filter_res := FilterCreateUpdate{}
+	json_err := json.Unmarshal([]byte(newStr), &filter_res)
+	if json_err != nil {
+		return fmt.Errorf("Error unmarshal the json string resourceIBMCISFilterUpdate %s", json_err)
+	}
+	if filter_res.Result[0].ID == "" {
+		return fmt.Errorf("Error failed to find id in Update response; resource was empty")
+	}
+	return resourceIBMCISFilterRead(d, meta)
+}
+func resourceIBMCISFilterDelete(d *schema.ResourceData, meta interface{}) error {
+	sess, err := meta.(ClientSession).BluemixSession()
+	if err != nil {
+		return err
+	}
+	xAuthtoken := sess.Config.IAMAccessToken
+	cisClient, err := meta.(ClientSession).CisFiltersSession()
+	if err != nil {
+		return err
+	}
+	filterid, zoneID, crn, err := convertTfToCisThreeVar(d.Id())
+	if err != nil {
+		return err
+	}
+	opt := cisClient.NewDeleteFiltersOptions(xAuthtoken, crn, zoneID, filterid)
+	_, _, err = cisClient.DeleteFilters(opt)
+	if err != nil {
+		return fmt.Errorf("Error deleting Filter: %s", err)
+	}
+
+	return nil
+}
+
+func resourceIBMCISFilterValidator() *ResourceValidator {
+	validateSchema := make([]ValidateSchema, 1)
+	validateSchema = append(validateSchema,
+		ValidateSchema{
+			Identifier:                 cisFilterDescription,
+			ValidateFunctionIdentifier: ValidateAllowedStringValue,
+			Type:                       TypeString,
+			Required:                   true,
+			AllowedValues:              "Filter-creation"})
+
+	ibmCISFiltersResourceValidator := ResourceValidator{ResourceName: ibmCISFilters, Schema: validateSchema}
+	return &ibmCISFiltersResourceValidator
+}

--- a/ibm/resource_ibm_cis_filter_test.go
+++ b/ibm/resource_ibm_cis_filter_test.go
@@ -1,0 +1,41 @@
+// Copyright IBM Corp. 2017, 2021 All Rights Reserved.
+// Licensed under the Mozilla Public License v2.0
+
+package ibm
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+func TestAccIBMCisFilter_Basic(t *testing.T) {
+	name := "ibm_cis_filter." + "test"
+	filterexp := "(http.request.uri eq \"/test-update?number=5\")"
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheckCis(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckCisFilter_basic("test", cisDomainStatic, "true", "Filter-creation", filterexp),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(name, "description", "Filter-creation"),
+					resource.TestCheckResourceAttr(name, "expression", filterexp),
+					resource.TestCheckResourceAttr(name, "paused", "true"),
+				),
+			},
+		},
+	})
+}
+func testAccCheckCisFilter_basic(id, cisDomainStatic, paused, description, expression string) string {
+	return testAccCheckIBMCisDomainDataSourceConfigBasic1() + fmt.Sprintf(`
+	resource "ibm_cis_filter" "%[1]s" {
+		cis_id          = data.ibm_cis.cis.id
+		domain_id       = data.ibm_cis_domain.cis_domain.domain_id
+		paused			= "true"
+		description		= "Filter-creation"
+		expression		= "(http.request.uri eq \"/test-update?number=5\")"
+	  }
+`, id, cisDomainStatic, paused, description, expression)
+}


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/IBM-Cloud/terraform-provider-ibm/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Output from acceptance testing:

<!--
Replace TestAccIBMCisFilters_Basic with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccIBMCisFilters_Basic'

 make testacc TEST=./ibm TESTARGS='-run=TestAccIBMCisFilter_Basic' 
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./ibm -v -run=TestAccIBMCisFilter_Basic -timeout 700m
[WARN] Set the environment variable IBM_ORG for testing ibm_org  resource Some tests for that resource will fail if this is not set correctly
[WARN] Set the environment variable IBM_SPACE for testing ibm_space  resource Some tests for that resource will fail if this is not set correctly
[WARN] Set the environment variable IBM_ID1 for testing ibm_space resource Some tests for that resource will fail if this is not set correctly
[WARN] Set the environment variable IBM_ID2 for testing ibm_space resource Some tests for that resource will fail if this is not set correctly
[WARN] Set the environment variable IBM_IAMUSER for testing ibm_iam_user_policy resource Some tests for that resource will fail if this is not set correctly
[WARN] Set the environment variable IBM_DATACENTER for testing ibm_container_cluster resource else it is set to default value 'par01'
[WARN] Set the environment variable IBM_MACHINE_TYPE for testing ibm_container_cluster resource else it is set to default value 'u2c.2x4'
[WARN] Set the environment variable IBM_CERT_CRN for testing ibm_container_alb_cert resource else it is set to default value
[WARN] Set the environment variable IBM_UPDATE_CERT_CRN for testing ibm_container_alb_cert resource else it is set to default value
[WARN] Set the environment variable IBM_CONTAINER_REGION for testing ibm_container resources else it is set to default value 'eu-de'
[WARN] Set the environment variable IBM_COS_CRN with a VALID COS instance CRN for testing ibm_cos_* resources
[WARN] Set the environment variable IBM_TRUSTED_MACHINE_TYPE for testing ibm_container_cluster resource else it is set to default value 'mb1c.16x64'
[WARN] Set the environment variable IBM_BM_EXTENDED_HW_TESTING to true/false for testing ibm_compute_bare_metal resource else it is set to default value 'false'
[WARN] Set the environment variable IBM_PUBLIC_VLAN_ID for testing ibm_container_cluster resource else it is set to default value '2393319'
[WARN] Set the environment variable IBM_PRIVATE_VLAN_ID for testing ibm_container_cluster resource else it is set to default value '2393321'
[WARN] Set the environment variable IBM_KUBE_VERSION for testing ibm_container_cluster resource else it is set to default value '1.18.14'
[WARN] Set the environment variable IBM_KUBE_UPDATE_VERSION for testing ibm_container_cluster resource else it is set to default value '1.19.6'
[WARN] Set the environment variable IBM_PRIVATE_SUBNET_ID for testing ibm_container_cluster resource else it is set to default value '1636107'
[WARN] Set the environment variable IBM_PUBLIC_SUBNET_ID for testing ibm_container_cluster resource else it is set to default value '1165645'
[WARN] Set the environment variable IBM_SUBNET_ID for testing ibm_container_cluster resource else it is set to default value '1165645'
[INFO] Set the environment variable IBM_IPSEC_DATACENTER for testing ibm_ipsec_vpn resource else it is set to default value 'tok02'
[INFO] Set the environment variable IBM_IPSEC_CUSTOMER_SUBNET_ID for testing ibm_ipsec_vpn resource else it is set to default value '123456'
[INFO] Set the environment variable IBM_IPSEC_CUSTOMER_PEER_IP for testing ibm_ipsec_vpn resource else it is set to default value '192.168.0.1'
[WARN] Set the environment variable IBM_LBAAS_DATACENTER for testing ibm_lbaas resource else it is set to default value 'dal13'
[WARN] Set the environment variable IBM_LBAAS_SUBNETID for testing ibm_lbaas resource else it is set to default value '2144241'
[WARN] Set the environment variable IBM_DEDICATED_HOSTNAME for testing ibm_compute_vm_instance resource else it is set to default value 'terraform-dedicatedhost'
[WARN] Set the environment variable IBM_DEDICATED_HOST_ID for testing ibm_compute_vm_instance resource else it is set to default value '30301'
[WARN] Set the environment variable IBM_WORKER_POOL_ZONE for testing ibm_container_worker_pool_zone_attachment resource else it is set to default value 'ams03'
[WARN] Set the environment variable IBM_WORKER_POOL_ZONE_PRIVATE_VLAN for testing ibm_container_worker_pool_zone_attachment resource else it is set to default value '2538975'
[WARN] Set the environment variable IBM_WORKER_POOL_ZONE_PUBLIC_VLAN for testing ibm_container_worker_pool_zone_attachment resource else it is set to default value '2538967'
[WARN] Set the environment variable IBM_WORKER_POOL_ZONE_UPDATE_PRIVATE_VLAN for testing ibm_container_worker_pool_zone_attachment resource else it is set to default value '2388377'
[WARN] Set the environment variable IBM_WORKER_POOL_ZONE_UPDATE_PUBLIC_VLAN for testing ibm_container_worker_pool_zone_attachment resource else it is set to default value '2388375'
[WARN] Set the environment variable IBM_PLACEMENT_GROUP_NAME for testing ibm_compute_vm_instance resource else it is set to default value 'terraform-group'
[INFO] Set the environment variable SL_REGION for testing ibm_is_region datasource else it is set to default value 'us-south'
[INFO] Set the environment variable SL_ZONE for testing ibm_is_zone datasource else it is set to default value 'us-south-1'
[INFO] Set the environment variable SL_CIDR for testing ibm_is_subnet else it is set to default value '10.240.0.0/24'
[INFO] Set the environment variable SL_ADDRESS_PREFIX_CIDR for testing ibm_is_vpc_address_prefix else it is set to default value '10.120.0.0/24'
[INFO] Set the environment variable IS_IMAGE for testing ibm_is_instance, ibm_is_floating_ip else it is set to default value 'r006-ed3f775f-ad7e-4e37-ae62-7199b4988b00'
[INFO] Set the environment variable IS_WIN_IMAGE for testing ibm_is_instance data source else it is set to default value 'r006-5f9568ae-792e-47e1-a710-5538b2bdfca7'
[INFO] Set the environment variable SL_INSTANCE_PROFILE for testing ibm_is_instance resource else it is set to default value 'cx2-2x4'
[INFO] Set the environment variable SL_INSTANCE_PROFILE_UPDATE for testing ibm_is_instance resource else it is set to default value 'cx2-4x8'
[INFO] Set the environment variable IS_DEDICATED_HOST_NAME for testing ibm_is_instance resource else it is set to default value 'tf-dhost-01'
[INFO] Set the environment variable IS_DEDICATED_HOST_GROUP_ID for testing ibm_is_instance resource else it is set to default value '0717-9104e7b5-77ad-44ad-9eaa-091e6b6efce1'
[INFO] Set the environment variable IS_DEDICATED_HOST_PROFILE for testing ibm_is_instance resource else it is set to default value 'bx2d-host-152x608'
[INFO] Set the environment variable IS_DEDICATED_HOST_GROUP_CLASS for testing ibm_is_instance resource else it is set to default value 'bx2d'
[INFO] Set the environment variable IS_DEDICATED_HOST_GROUP_FAMILY for testing ibm_is_instance resource else it is set to default value 'balanced'
[INFO] Set the environment variable SL_INSTANCE_PROFILE for testing ibm_is_instance resource else it is set to default value 'bx2d-16x64'
[INFO] Set the environment variable IS_VOLUME_PROFILE for testing ibm_is_volume_profile else it is set to default value 'general-purpose'
[INFO] Set the environment variable SL_ROUTE_DESTINATION for testing ibm_is_vpc_route else it is set to default value '192.168.4.0/24'
[INFO] Set the environment variable SL_ROUTE_NEXTHOP for testing ibm_is_vpc_route else it is set to default value '10.0.0.4'
[INFO] Set the environment variable PI_IMAGE for testing ibm_pi_image resource else it is set to default value '7200-03-03'
[INFO] Set the environment variable PI_KEY_NAME for testing ibm_pi_key_name resource else it is set to default value 'terraform-test-power'
[INFO] Set the environment variable PI_NETWORK_NAME for testing ibm_pi_network_name resource else it is set to default value 'terraform-test-power'
[INFO] Set the environment variable PI_VOLUME_NAME for testing ibm_pi_network_name resource else it is set to default value 'terraform-test-power'
[INFO] Set the environment variable PI_CLOUDINSTANCE_ID for testing ibm_pi_image resource else it is set to default value 'd16705bd-7f1a-48c9-9e0e-1c17b71e7331'
[INFO] Set the environment variable PI_PVM_INSTANCE_ID for testing pi_instance_name resource else it is set to default value 'terraform-test-power'
[INFO] Set the environment variable SCHEMATICS_WORKSPACE_ID for testing schematics resources else it is set to default value
[INFO] Set the environment variable SCHEMATICS_TEMPLATE_ID for testing schematics resources else it is set to default value
[INFO] Set the environment variable SCHEMATICS_ACTION_ID for testing schematics resources else it is set to default value
[WARN] Set the environment variable IMAGE_COS_URL with a VALID COS Image SQL URL for testing ibm_is_image resources on staging/test
[WARN] Set the environment variable IMAGE_COS_URL_ENCRYPTED with a VALID COS Image SQL URL for testing ibm_is_image resources on staging/test
[WARN] Set the environment variable IMAGE_OPERATING_SYSTEM with a VALID Operating system for testing ibm_is_image resources on staging/test
[INFO] Set the environment variable IS_IMAGE_NAME for testing data source ibm_is_image else it is set to default value `ibm-ubuntu-18-04-1-minimal-amd64-2`
[INFO] Set the environment variable IS_IMAGE_ENCRYPTED_DATA_KEY for testing resource ibm_is_image else it is set to default value
[INFO] Set the environment variable IS_IMAGE_ENCRYPTION_KEY for testing resource ibm_is_image else it is set to default value
[INFO] Set the environment variable IBM_FUNCTION_NAMESPACE for testing ibm_function_package, ibm_function_action, ibm_function_rule, ibm_function_trigger resource else  tests will fail if this is not set correctly
[INFO] Set the environment variable HPCS_INSTANCE_ID for testing data_source_ibm_kms_key_test else it is set to default value
[INFO] Set the environment variable SECRETS_MANAGER_INSTANCE_ID for testing data_source_ibm_secrets_manager_secrets_test else tests will fail if this is not set correctly
[INFO] Set the environment variable SECRETS_MANAGER_SECRET_TYPE for testing data_source_ibm_secrets_manager_secrets_test, else it is set to default value. For data_source_ibm_secrets_manager_secret_test, tests will fail if this is not set correctly
[WARN] Set the environment variable SECRETS_MANAGER_SECRET_ID for testing data_source_ibm_secrets_manager_secret_test else tests will fail if this is not set correctly
[INFO] Set the environment variable IBM_TG_CROSS_ACCOUNT_ID for testing ibm_tg_connection resource else  tests will fail if this is not set correctly
[INFO] Set the environment variable IBM_TG_CROSS_NETWORK_ID for testing ibm_tg_connection resource else  tests will fail if this is not set correctly
[INFO] Set the environment variable ACCOUNT_TO_BE_IMPORTED for testing import enterprise account resource else  tests will fail if this is not set correctly
=== RUN   TestAccIBMCisFilter_Basic
--- PASS: TestAccIBMCisFilter_Basic (66.09s)
PASS
ok  	github.com/IBM-Cloud/terraform-provider-ibm/ibm	69.588s

...
```
