### PR TITLE
Support: tags in resource_instance datasource

### DIFF
--- a/ibm/data_source_ibm_resource_instance.go
+++ b/ibm/data_source_ibm_resource_instance.go
@@ -5,6 +5,7 @@ package ibm
 
 import (
 	"fmt"
+	"log"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 
@@ -60,6 +61,12 @@ func dataSourceIBMResourceInstance() *schema.Resource {
 				Type:        schema.TypeString,
 				Computed:    true,
 				Description: "CRN of resource instance",
+			},
+			"tags": {
+				Type:        schema.TypeSet,
+				Computed:    true,
+				Description: "Tags of Resource Instance",
+				Elem:        &schema.Schema{Type: schema.TypeString},
 			},
 
 			"guid": {
@@ -210,6 +217,12 @@ func dataSourceIBMResourceInstanceRead(d *schema.ResourceData, meta interface{})
 	}
 	d.Set("plan", servicePlan)
 	d.Set("crn", instance.Crn.String())
+	tags, err := GetTagsUsingCRN(meta, instance.Crn.String())
+	if err != nil {
+		log.Printf(
+			"Error on get of resource instance tags (%s) tags: %s", d.Id(), err)
+	}
+	d.Set("tags", tags)
 
 	return nil
 }


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/IBM-Cloud/terraform-provider-ibm/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->


Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$terraform show

# data.ibm_resource_instance.logdna_instance:
data "ibm_resource_instance" "logdna_instance" {
    crn                     = "crn:v1:bluemix:public:logdna:us-south:a/4448261269a14562b839e0a3019ed980:cad272c8-fcf7-4e3a-8bcf-07b1e294b316::"
    extensions              = {}
    guid                    = "cad272c8-fcf7-4e3a-8bcf-07b1e294b316"
    id                      = "crn:v1:bluemix:public:logdna:us-south:a/4448261269a14562b839e0a3019ed980:cad272c8-fcf7-4e3a-8bcf-07b1e294b316::"
    location                = "us-south"
    name                    = "fs-logdna"
    plan                    = "30-day"
    resource_controller_url = "https://cloud.ibm.com/services/"
    resource_crn            = "crn:v1:bluemix:public:logdna:us-south:a/4448261269a14562b839e0a3019ed980:cad272c8-fcf7-4e3a-8bcf-07b1e294b316::"
    resource_group_id       = "a06db00ce84e4b8a8ac81ef56748c513"
    resource_name           = "fs-logdna"
    resource_status         = "active"
    service                 = "logdna"
    status                  = "active"
    tags                    = [
        "fs-cloud",
    ]
}

...
```
