### PR TITLE
Removed IPV6 References in vpc resources

### DIFF
--- a/ibm/data_source_ibm_is_instance_templates.go
+++ b/ibm/data_source_ibm_is_instance_templates.go
@@ -67,7 +67,6 @@ const (
 	isInstanceTemplateNicPortSpeed            = "port_speed"
 	isInstanceTemplateNicAllowIPSpoofing      = "allow_ip_spoofing"
 	isInstanceTemplateNicPrimaryIpv4Address   = "primary_ipv4_address"
-	isInstanceTemplateNicPrimaryIpv6Address   = "primary_ipv6_address"
 	isInstanceTemplateNicSecondaryAddress     = "secondary_addresses"
 	isInstanceTemplateNicSecurityGroups       = "security_groups"
 	isInstanceTemplateNicSubnet               = "subnet"

--- a/ibm/data_source_ibm_is_security_group.go
+++ b/ibm/data_source_ibm_is_security_group.go
@@ -71,7 +71,7 @@ func dataSourceIBMISSecurityGroup() *schema.Resource {
 						isSgRuleIPVersion: {
 							Type:        schema.TypeString,
 							Computed:    true,
-							Description: "IP version: ipv4 or ipv6",
+							Description: "IP version: ipv4",
 						},
 
 						isSgRuleRemote: {

--- a/ibm/data_source_ibm_is_subnet.go
+++ b/ibm/data_source_ibm_is_subnet.go
@@ -29,11 +29,6 @@ func dataSourceIBMISSubnet() *schema.Resource {
 				Computed: true,
 			},
 
-			isSubnetIpv6CidrBlock: {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-
 			isSubnetAvailableIpv4AddressCount: {
 				Type:     schema.TypeInt,
 				Computed: true,

--- a/ibm/data_source_ibm_is_subnets.go
+++ b/ibm/data_source_ibm_is_subnets.go
@@ -67,10 +67,6 @@ func dataSourceIBMISSubnets() *schema.Resource {
 							Type:     schema.TypeString,
 							Computed: true,
 						},
-						"ipv6_cidr_block": {
-							Type:     schema.TypeString,
-							Computed: true,
-						},
 						"available_ipv4_address_count": {
 							Type:     schema.TypeString,
 							Computed: true,

--- a/ibm/data_source_ibm_is_vpc.go
+++ b/ibm/data_source_ibm_is_vpc.go
@@ -174,7 +174,7 @@ func dataSourceIBMISVPC() *schema.Resource {
 									isVPCSecurityGroupRuleIPVersion: {
 										Type:        schema.TypeString,
 										Computed:    true,
-										Description: "IP version: ipv4 or ipv6",
+										Description: "IP version: ipv4",
 									},
 
 									isVPCSecurityGroupRuleRemote: {

--- a/ibm/resource_ibm_is_instance.go
+++ b/ibm/resource_ibm_is_instance.go
@@ -27,7 +27,6 @@ const (
 	isInstanceNicPortSpeed            = "port_speed"
 	isInstanceNicAllowIPSpoofing      = "allow_ip_spoofing"
 	isInstanceNicPrimaryIpv4Address   = "primary_ipv4_address"
-	isInstanceNicPrimaryIpv6Address   = "primary_ipv6_address"
 	isInstanceNicSecondaryAddress     = "secondary_addresses"
 	isInstanceNicSecurityGroups       = "security_groups"
 	isInstanceNicSubnet               = "subnet"

--- a/ibm/resource_ibm_is_security_group.go
+++ b/ibm/resource_ibm_is_security_group.go
@@ -458,7 +458,7 @@ func makeIBMISSecurityRuleSchema() map[string]*schema.Schema {
 		isSecurityGroupRuleIPVersion: {
 			Type:        schema.TypeString,
 			Computed:    true,
-			Description: "IP version: ipv4 or ipv6",
+			Description: "IP version: ipv4",
 		},
 
 		isSecurityGroupRuleRemote: {

--- a/ibm/resource_ibm_is_security_group_rule.go
+++ b/ibm/resource_ibm_is_security_group_rule.go
@@ -64,7 +64,7 @@ func resourceIBMISSecurityGroupRule() *schema.Resource {
 			isSecurityGroupRuleIPVersion: {
 				Type:         schema.TypeString,
 				Optional:     true,
-				Description:  "IP version: ipv4 or ipv6",
+				Description:  "IP version: ipv4",
 				Default:      isSecurityGroupRuleIPVersionDefault,
 				ValidateFunc: InvokeValidator("ibm_is_security_group_rule", isSecurityGroupRuleIPVersion),
 			},
@@ -175,7 +175,7 @@ func resourceIBMISSecurityGroupRule() *schema.Resource {
 func resourceIBMISSecurityGroupRuleValidator() *ResourceValidator {
 	validateSchema := make([]ValidateSchema, 1)
 	direction := "inbound, outbound"
-	ip_version := "ipv4, ipv6"
+	ip_version := "ipv4"
 
 	validateSchema = append(validateSchema,
 		ValidateSchema{

--- a/ibm/resource_ibm_is_subnet.go
+++ b/ibm/resource_ibm_is_subnet.go
@@ -20,7 +20,6 @@ import (
 
 const (
 	isSubnetIpv4CidrBlock             = "ipv4_cidr_block"
-	isSubnetIpv6CidrBlock             = "ipv6_cidr_block"
 	isSubnetTotalIpv4AddressCount     = "total_ipv4_address_count"
 	isSubnetIPVersion                 = "ip_version"
 	isSubnetName                      = "name"
@@ -71,12 +70,6 @@ func resourceIBMISSubnet() *schema.Resource {
 				ConflictsWith: []string{isSubnetTotalIpv4AddressCount},
 				ValidateFunc:  InvokeValidator("ibm_is_subnet", isSubnetIpv4CidrBlock),
 				Description:   "IPV4 subnet - CIDR block",
-			},
-
-			isSubnetIpv6CidrBlock: {
-				Type:        schema.TypeString,
-				Computed:    true,
-				Description: "IPV6 subnet - CIDR block",
 			},
 
 			isSubnetAvailableIpv4AddressCount: {
@@ -426,7 +419,6 @@ func subnetGet(d *schema.ResourceData, meta interface{}, id string) error {
 	d.Set(isSubnetName, *subnet.Name)
 	d.Set(isSubnetIPVersion, *subnet.IPVersion)
 	d.Set(isSubnetIpv4CidrBlock, *subnet.Ipv4CIDRBlock)
-	// d.Set(isSubnetIpv6CidrBlock, *subnet.IPV6CidrBlock)
 	d.Set(isSubnetAvailableIpv4AddressCount, *subnet.AvailableIpv4AddressCount)
 	d.Set(isSubnetTotalIpv4AddressCount, *subnet.TotalIpv4AddressCount)
 	if subnet.NetworkACL != nil {

--- a/ibm/resource_ibm_is_vpc.go
+++ b/ibm/resource_ibm_is_vpc.go
@@ -266,7 +266,7 @@ func resourceIBMISVPC() *schema.Resource {
 									isVPCSecurityGroupRuleIPVersion: {
 										Type:        schema.TypeString,
 										Computed:    true,
-										Description: "IP version: ipv4 or ipv6",
+										Description: "IP version: ipv4",
 									},
 
 									isVPCSecurityGroupRuleRemote: {

--- a/website/docs/d/is_security_group.html.markdown
+++ b/website/docs/d/is_security_group.html.markdown
@@ -79,7 +79,7 @@ In addition to all argument reference list, you can access the following attribu
   Nested scheme for `rules`:
   - `rule_id`-  (String) ID of the rule.
   - `direction` - (String) Direction of traffic to enforce, either inbound or outbound.
-  - `ip_version` - (String) IP version: IPv4 or IPv6.
+  - `ip_version` - (String) IP version: IPv4
   - `protocol` - (String) The type of the protocol `all`, `icmp`, `tcp`, `udp`.
   - `type` - (String) The traffic type to allow.
   - `code` - (String) The traffic code to allow.

--- a/website/docs/d/is_subnet.html.markdown
+++ b/website/docs/d/is_subnet.html.markdown
@@ -62,7 +62,6 @@ In addition to all argument reference list, you can access the following attribu
 - `available_ipv4_address_count` - (Integer) The total number of available IPv4 addresses.
 - `crn` - (String) The CRN of subnet.
 - `ipv4_cidr_block` -  (String) The IPv4 range of the subnet.
-- `ipv6_cidr_block` - (String) The IPv6 range of the subnet.
 - `ip_version` - (String) The IP version.
 - `name` - (String) The name of the subnet.
 - `network_acl` - (String) The ID of the network ACL for the subnet.

--- a/website/docs/d/is_vpc.html.markdown
+++ b/website/docs/d/is_vpc.html.markdown
@@ -56,7 +56,7 @@ In addition to all argument reference list, you can access the following attribu
     Nested scheme for `rules`:
     - `direction` - (String) Direction of the traffic either inbound or outbound.
     - `code` - (String) The ICMP traffic code to allow.
-    - `ip_version` - (String) The IP version either **ipv4** or **ipv6**.
+    - `ip_version` - (String) The IP version **ipv4**
     - `port_min` - (String) The inclusive lower bound of TCP port range. 
     - `port_max` - (String) The inclusive upper bound of TCP port range. 
     - `remote` - (String) The security group ID, an IP address, a CIDR block, or a single security group identifier.

--- a/website/docs/r/is_security_group.html.markdown
+++ b/website/docs/r/is_security_group.html.markdown
@@ -43,7 +43,7 @@ In addition to all argument reference list, you can access the following attribu
   Nested scheme for `rules`:
   - `code` - (String) The `ICMP` traffic code to allow.
   - `direction`-  (String) The direction of the traffic either `inbound` or `outbound`.
-  - `ip_version` - (String) IP version either `ipv4` or `ipv6`.
+  - `ip_version` - (String) IP version: `ipv4`
   - `protocol` - (String) The type of the protocol `all`, `icmp`, `tcp`, `udp`.
   - `port_max`- (Integer) The `TCP/UDP` port range that includes the maximum bound.
   - `port_min`- (Integer) The `TCP/UDP` port range that includes the minimum bound.

--- a/website/docs/r/is_vpc.html.markdown
+++ b/website/docs/r/is_vpc.html.markdown
@@ -73,7 +73,7 @@ In addition to all argument reference list, you can access the following attribu
     Nested scheme for `rules`:
     - `code`- (String) The ICMP traffic code to allow.
 	- `direction`- (String) The direction of the traffic either inbound or outbound.
-    - `ip_version`-  (String) The IP version either **ipv4** or **IPv6**.
+    - `ip_version`-  (String) The IP version: **ipv4**.
     - `remote` -  (String) Security group ID, an IP address, a CIDR block, or a single security group identifier.
 	- `rule_id` - (String) The rule ID.
     - `port_min` - (String) The inclusive lower bound of TCP port range.


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/IBM-Cloud/terraform-provider-ibm/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```
