### PR TITLE
Fix the NotFound Checks if the resource is still provisioning

### DIFF
--- a/ibm/resource_ibm_firewall.go
+++ b/ibm/resource_ibm_firewall.go
@@ -336,7 +336,7 @@ func findDedicatedFirewallByOrderId(sess *session.Session, orderId int, d *schem
 			} else if len(firewalls) == 1 {
 				return firewalls[0], "complete", nil
 			} else if len(vlans) == 0 || len(firewalls) == 0 || *upgraderequest.Status.Name != "Complete" {
-				return nil, "pending", nil
+				return datatypes.Network_Vlan{}, "pending", nil
 			}
 			return nil, "", fmt.Errorf("Expected one dedicated firewall: %s", err)
 		},

--- a/ibm/resource_ibm_ipsec_vpn.go
+++ b/ibm/resource_ibm_ipsec_vpn.go
@@ -265,7 +265,7 @@ func findIPSecVpnByOrderID(sess *session.Session, orderID int, d *schema.Resourc
 			if len(vpn) == 1 {
 				return vpn[0], "complete", nil
 			} else if len(vpn) == 0 {
-				return nil, "pending", nil
+				return datatypes.Network_Tunnel_Module_Context{}, "pending", nil
 			}
 			return nil, "", fmt.Errorf("Expected one IPSec VPN: %s", err)
 		},

--- a/ibm/resource_ibm_lb.go
+++ b/ibm/resource_ibm_lb.go
@@ -433,7 +433,7 @@ func findLoadBalancerByOrderId(sess *session.Session, orderId int, dedicated boo
 			if len(lbs) == 1 {
 				return lbs[0], "complete", nil
 			} else if len(lbs) == 0 {
-				return nil, "pending", nil
+				return datatypes.Network_Application_Delivery_Controller_LoadBalancer_VirtualIpAddress{}, "pending", nil
 			} else {
 				return nil, "", fmt.Errorf("Expected one load balancer: %s", err)
 			}

--- a/ibm/resource_ibm_lb_vpx.go
+++ b/ibm/resource_ibm_lb_vpx.go
@@ -294,7 +294,7 @@ func findVPXByOrderId(orderId int, meta interface{}) (datatypes.Network_Applicat
 			if len(vpxs) == 1 {
 				return vpxs[0], "complete", nil
 			} else if len(vpxs) == 0 {
-				return nil, "pending", nil
+				return datatypes.Network_Application_Delivery_Controller{}, "pending", nil
 			} else {
 				return nil, "", fmt.Errorf("Expected one VPX: %s", err)
 			}

--- a/ibm/resource_ibm_network_public_ip.go
+++ b/ibm/resource_ibm_network_public_ip.go
@@ -268,7 +268,7 @@ func findGlobalIpByOrderId(sess *session.Session, orderId int, d *schema.Resourc
 			if len(globalIps) == 1 && globalIps[0].IpAddress != nil {
 				return globalIps[0], "complete", nil
 			} else if len(globalIps) == 0 || len(globalIps) == 1 {
-				return nil, "pending", nil
+				return datatypes.Network_Subnet_IpAddress_Global{}, "pending", nil
 			} else {
 				return nil, "", fmt.Errorf("Expected one network public ip: %s", err)
 			}

--- a/ibm/resource_ibm_network_vlan.go
+++ b/ibm/resource_ibm_network_vlan.go
@@ -419,7 +419,7 @@ func findVlanByOrderId(sess *session.Session, orderId int, timeout time.Duration
 			if len(vlans) == 1 {
 				return vlans[0], "complete", nil
 			} else if len(vlans) == 0 {
-				return nil, "pending", nil
+				return []datatypes.Network_Vlan{}, "pending", nil
 			} else {
 				return nil, "", fmt.Errorf("Expected one vlan: %s", err)
 			}

--- a/ibm/resource_ibm_ssl_certificate.go
+++ b/ibm/resource_ibm_ssl_certificate.go
@@ -830,7 +830,7 @@ func findSSLByOrderId(sess *session1.Session, orderId int) (datatypes.Security_C
 			if len(ssls) >= 1 {
 				return ssls[0], "complete", nil
 			} else {
-				return nil, "pending", nil
+				return datatypes.Security_Certificate_Request{}, "pending", nil
 			}
 		},
 		Timeout:    10 * time.Minute,

--- a/ibm/resource_ibm_storage_evault.go
+++ b/ibm/resource_ibm_storage_evault.go
@@ -337,7 +337,7 @@ func findEvaultStorageByOrderID(d *schema.ResourceData, meta interface{}, orderI
 			if len(storages) == 1 {
 				return storages[0], "complete", nil
 			} else if len(storages) == 0 {
-				return nil, "pending", nil
+				return datatypes.Network_Storage{}, "pending", nil
 			} else {
 				return nil, "", fmt.Errorf("Expected one evault: %s", err)
 			}

--- a/ibm/resource_ibm_storage_file.go
+++ b/ibm/resource_ibm_storage_file.go
@@ -718,7 +718,7 @@ func findStorageByOrderId(sess *session.Session, orderId int, timeout time.Durat
 			if len(storage) == 1 {
 				return storage[0], "complete", nil
 			} else if len(storage) == 0 {
-				return nil, "pending", nil
+				return datatypes.Network_Storage{}, "pending", nil
 			} else {
 				return nil, "", fmt.Errorf("Expected one Storage: %s", err)
 			}

--- a/ibm/resource_ibm_subnet.go
+++ b/ibm/resource_ibm_subnet.go
@@ -294,7 +294,7 @@ func findSubnetByOrderID(sess *session.Session, orderID int, d *schema.ResourceD
 			if len(subnets) == 1 && subnets[0].ActiveTransaction == nil {
 				return subnets[0], "complete", nil
 			}
-			return nil, "pending", nil
+			return datatypes.Network_Subnet{}, "pending", nil
 		},
 		Timeout:        d.Timeout(schema.TimeoutCreate),
 		Delay:          5 * time.Second,


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/IBM-Cloud/terraform-provider-ibm/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```
