### PR TITLE
Retrieval of Key with Policy Using DataSource

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,8 +7,8 @@ require (
 	github.com/IBM-Cloud/bluemix-go v0.0.0-20210521083814-a0bd7732f494
 	github.com/IBM-Cloud/power-go-client v1.0.55
 	github.com/IBM/apigateway-go-sdk v0.0.0-20200414212859-416e5948678a
-	github.com/IBM/appconfiguration-go-admin-sdk v0.1.0 // indirect
-	github.com/IBM/container-registry-go-sdk v0.0.12
+	github.com/IBM/appconfiguration-go-admin-sdk v0.1.0
+	github.com/IBM/container-registry-go-sdk v0.0.13
 	github.com/IBM/go-sdk-core v1.1.0
 	github.com/IBM/go-sdk-core/v3 v3.3.1
 	github.com/IBM/go-sdk-core/v4 v4.10.0

--- a/ibm/data_source_ibm_kms_key.go
+++ b/ibm/data_source_ibm_kms_key.go
@@ -96,6 +96,11 @@ func dataSourceIBMKMSkey() *schema.Resource {
 													Type:     schema.TypeString,
 													Computed: true,
 												},
+												"crn": {
+													Type:        schema.TypeString,
+													Computed:    true,
+													Description: "Cloud Resource Name (CRN) that uniquely identifies your cloud resources.",
+												},
 												"updated_by": {
 													Type:     schema.TypeString,
 													Computed: true,
@@ -127,6 +132,11 @@ func dataSourceIBMKMSkey() *schema.Resource {
 												"creation_date": {
 													Type:     schema.TypeString,
 													Computed: true,
+												},
+												"crn": {
+													Type:        schema.TypeString,
+													Computed:    true,
+													Description: "Cloud Resource Name (CRN) that uniquely identifies your cloud resources.",
 												},
 												"updated_by": {
 													Type:     schema.TypeString,
@@ -265,7 +275,7 @@ func dataSourceIBMKMSKeyRead(d *schema.ResourceData, meta interface{}) error {
 		d.Set("keys", keyMap)
 		d.Set("instance_id", instanceID)
 	} else {
-		aliasName := d.Get("alias_name").(string)
+		aliasName := d.Get("alias").(string)
 		key, err := api.GetKey(context.Background(), aliasName)
 		if err != nil {
 			return fmt.Errorf(


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/IBM-Cloud/terraform-provider-ibm/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### FIX

* Bug Fix for retrieving Keys with Policy using "data.ibm_kms_key"
<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->

Output : 
![Screenshot 2021-06-11 at 1 54 29 AM](https://user-images.githubusercontent.com/25618813/121592577-80193300-ca58-11eb-892a-950df0fcc9ba.png)


<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

