### PR TITLE
Fix: Add changes to resources Exists and test cases to be aware of Soft deleted policies

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -1353,6 +1353,7 @@ gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15/go.mod h1:Co6ibVJAznAaIkqp8
 gopkg.in/check.v1 v1.0.0-20200227125254-8fa46927fb4f/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20200902074654-038fdea0a05b h1:QRR6H1YWRnHb4Y/HeNFCTJLFVxaq6wH4YuVdsUOr75U=
 gopkg.in/check.v1 v1.0.0-20200902074654-038fdea0a05b/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c h1:Hei/4ADfdWqJk1ZMxUNpqntNwaWcugrBjAiHlqqRiVk=
 gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c/go.mod h1:JHkPIbrfpd72SG/EVd6muEfDQjcINNoR0C8j2r3qZ4Q=
 gopkg.in/cheggaaa/pb.v1 v1.0.27/go.mod h1:V/YB90LKu/1FcN3WVnfiiE5oMCibMjukxqG/qStrOgw=
 gopkg.in/errgo.v2 v2.1.0/go.mod h1:hNsd1EY+bozCKY1Ytp96fpM3vjJbqLJn88ws8XvfDNI=

--- a/ibm/resource_ibm_iam_access_group_policy_test.go
+++ b/ibm/resource_ibm_iam_access_group_policy_test.go
@@ -288,7 +288,7 @@ func testAccCheckIBMIAMAccessGroupPolicyDestroy(s *terraform.State) error {
 
 		if err == nil && *destroyedPolicy.State != "deleted" {
 			return fmt.Errorf("Access group policy still exists: %s\n", rs.Primary.ID)
-		} else if response.StatusCode != 404 && *destroyedPolicy.State != "deleted" {
+		} else if response.StatusCode != 404 && destroyedPolicy.State != nil && *destroyedPolicy.State != "deleted" {
 			return fmt.Errorf("Error waiting for access group policy (%s) to be destroyed: %s", rs.Primary.ID, err)
 		}
 	}

--- a/ibm/resource_ibm_iam_access_group_policy_test.go
+++ b/ibm/resource_ibm_iam_access_group_policy_test.go
@@ -264,7 +264,7 @@ func TestAccIBMIAMAccessGroupPolicy_WithCustomRole(t *testing.T) {
 }
 
 func testAccCheckIBMIAMAccessGroupPolicyDestroy(s *terraform.State) error {
-	iampapClient, err := testAccProvider.Meta().(ClientSession).IAMPolicyManagementV1API()
+	iamPolicyManagementClient, err := testAccProvider.Meta().(ClientSession).IAMPolicyManagementV1API()
 	if err != nil {
 		return err
 	}
@@ -278,15 +278,17 @@ func testAccCheckIBMIAMAccessGroupPolicyDestroy(s *terraform.State) error {
 			return err
 		}
 
-		accgrpPolicyID := parts[1]
+		accessGroupPolicyID := parts[1]
 
-		deletePolicyOptions := &iampolicymanagementv1.DeletePolicyOptions{
-			PolicyID: &accgrpPolicyID,
-		}
+		getPolicyOptions := iamPolicyManagementClient.NewGetPolicyOptions(
+			accessGroupPolicyID,
+		)
 
-		response, err := iampapClient.DeletePolicy(deletePolicyOptions)
+		destroyedPolicy, response, err := iamPolicyManagementClient.GetPolicy(getPolicyOptions)
 
-		if err != nil && response.StatusCode != 404 {
+		if err == nil && *destroyedPolicy.State != "deleted" {
+			return fmt.Errorf("Access group policy still exists: %s\n", rs.Primary.ID)
+		} else if response.StatusCode != 404 && *destroyedPolicy.State != "deleted" {
 			return fmt.Errorf("Error waiting for access group policy (%s) to be destroyed: %s", rs.Primary.ID, err)
 		}
 	}
@@ -302,7 +304,7 @@ func testAccCheckIBMIAMAccessGroupPolicyExists(n string, obj iampolicymanagement
 			return fmt.Errorf("Not found: %s", n)
 		}
 
-		iampapClient, err := testAccProvider.Meta().(ClientSession).IAMPolicyManagementV1API()
+		iamPolicyManagementClient, err := testAccProvider.Meta().(ClientSession).IAMPolicyManagementV1API()
 		if err != nil {
 			return err
 		}
@@ -314,15 +316,15 @@ func testAccCheckIBMIAMAccessGroupPolicyExists(n string, obj iampolicymanagement
 			return err
 		}
 
-		accgrpPolicyID := parts[1]
+		accessGroupPolicyID := parts[1]
 
-		getPolicyOptions := &iampolicymanagementv1.GetPolicyOptions{
-			PolicyID: &accgrpPolicyID,
-		}
+		getPolicyOptions := iamPolicyManagementClient.NewGetPolicyOptions(
+			accessGroupPolicyID,
+		)
 
-		policy, _, err := iampapClient.GetPolicy(getPolicyOptions)
+		policy, _, err := iamPolicyManagementClient.GetPolicy(getPolicyOptions)
 		if err != nil {
-			return fmt.Errorf("Error retrieving Policy %s err: %s", accgrpPolicyID, err)
+			return fmt.Errorf("Error retrieving Policy %s err: %s", accessGroupPolicyID, err)
 		}
 		obj = *policy
 		return nil

--- a/ibm/resource_ibm_iam_authorization.policy_test.go
+++ b/ibm/resource_ibm_iam_authorization.policy_test.go
@@ -128,7 +128,7 @@ func testAccCheckIBMIAMAuthorizationPolicyDestroy(s *terraform.State) error {
 
 		if err == nil && *destroyedPolicy.State != "deleted" {
 			return fmt.Errorf("Authorization policy still exists: %s\n", rs.Primary.ID)
-		} else if response.StatusCode != 404 && *destroyedPolicy.State != "deleted" {
+		} else if response.StatusCode != 404 && destroyedPolicy.State != nil && *destroyedPolicy.State != "deleted" {
 			return fmt.Errorf("Error waiting for authorization policy (%s) to be destroyed: %s", rs.Primary.ID, err)
 		}
 	}
@@ -178,7 +178,7 @@ func testAccCheckIBMIAMAuthorizationPolicyResourceInstance(instanceName string) 
 	resource "ibm_resource_instance" "instance1" {
 		name     = "%s"
 		service  = "cloud-object-storage"
-		plan     = "standard"
+		plan     = "lite"
 		location = "global"
 	  }
 	  

--- a/ibm/resource_ibm_iam_authorization_policy.go
+++ b/ibm/resource_ibm_iam_authorization_policy.go
@@ -296,7 +296,7 @@ func resourceIBMIAMAuthorizationPolicyExists(d *schema.ResourceData, meta interf
 	authorizationPolicy, _, err := iampapClient.GetPolicy(getPolicyOptions)
 	if err != nil {
 		if apiErr, ok := err.(bmxerror.RequestFailure); ok {
-			if apiErr.StatusCode() == 404 {
+			if apiErr.StatusCode() == 404 || *authorizationPolicy.State == "deleted" {
 				return false, nil
 			}
 		}

--- a/ibm/resource_ibm_iam_authorization_policy.go
+++ b/ibm/resource_ibm_iam_authorization_policy.go
@@ -11,7 +11,6 @@ import (
 	"github.com/IBM/go-sdk-core/v5/core"
 	"github.com/IBM/platform-services-go-sdk/iampolicymanagementv1"
 
-	"github.com/IBM-Cloud/bluemix-go/bmxerror"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
@@ -293,14 +292,16 @@ func resourceIBMIAMAuthorizationPolicyExists(d *schema.ResourceData, meta interf
 	getPolicyOptions := &iampolicymanagementv1.GetPolicyOptions{
 		PolicyID: core.StringPtr(d.Id()),
 	}
-	authorizationPolicy, _, err := iampapClient.GetPolicy(getPolicyOptions)
-	if err != nil {
-		if apiErr, ok := err.(bmxerror.RequestFailure); ok {
-			if apiErr.StatusCode() == 404 || *authorizationPolicy.State == "deleted" {
-				return false, nil
-			}
+	authorizationPolicy, resp, err := iampapClient.GetPolicy(getPolicyOptions)
+	if err != nil || authorizationPolicy == nil {
+		if resp != nil && resp.StatusCode == 404 {
+			return false, nil
 		}
-		return false, fmt.Errorf("Error communicating with the API: %s", err)
+		return false, fmt.Errorf("Error communicating with the API: %s\n%s", err, resp)
+	}
+
+	if authorizationPolicy != nil && authorizationPolicy.State != nil && *authorizationPolicy.State == "deleted" {
+		return false, nil
 	}
 
 	return *authorizationPolicy.ID == d.Id(), nil

--- a/ibm/resource_ibm_iam_service_policy.go
+++ b/ibm/resource_ibm_iam_service_policy.go
@@ -12,8 +12,6 @@ import (
 	"github.com/IBM/platform-services-go-sdk/iampolicymanagementv1"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-
-	"github.com/IBM-Cloud/bluemix-go/bmxerror"
 )
 
 func resourceIBMIAMServicePolicy() *schema.Resource {
@@ -234,15 +232,13 @@ func resourceIBMIAMServicePolicyCreate(d *schema.ResourceData, meta interface{})
 
 	err = resource.Retry(5*time.Minute, func() *resource.RetryError {
 		var err error
-		_, _, err = iamPolicyManagementClient.GetPolicy(getPolicyOptions)
+		policy, res, err := iamPolicyManagementClient.GetPolicy(getPolicyOptions)
 
-		if err != nil {
-			if apiErr, ok := err.(bmxerror.RequestFailure); ok {
-				if apiErr.StatusCode() == 404 {
-					return resource.RetryableError(err)
-				}
-				return resource.NonRetryableError(err)
+		if err != nil || policy == nil {
+			if res != nil && res.StatusCode == 404 {
+				return resource.RetryableError(err)
 			}
+			return resource.NonRetryableError(err)
 		}
 		return nil
 	})
@@ -443,14 +439,16 @@ func resourceIBMIAMServicePolicyExists(d *schema.ResourceData, meta interface{})
 		servicePolicyID,
 	)
 
-	servicePolicy, _, err := iamPolicyManagementClient.GetPolicy(getPolicyOptions)
-	if err != nil {
-		if apiErr, ok := err.(bmxerror.RequestFailure); ok {
-			if apiErr.StatusCode() == 404 || *servicePolicy.State == "deleted" {
-				return false, nil
-			}
+	servicePolicy, resp, err := iamPolicyManagementClient.GetPolicy(getPolicyOptions)
+	if err != nil || servicePolicy == nil {
+		if resp != nil && resp.StatusCode == 404 {
+			return false, nil
 		}
-		return false, fmt.Errorf("Error communicating with the API: %s", err)
+		return false, fmt.Errorf("Error communicating with the API: %s\n%s", err, resp)
+	}
+
+	if servicePolicy != nil && servicePolicy.State != nil && *servicePolicy.State == "deleted" {
+		return false, nil
 	}
 
 	tempID := fmt.Sprintf("%s/%s", serviceIDUUID, *servicePolicy.ID)

--- a/ibm/resource_ibm_iam_service_policy.go
+++ b/ibm/resource_ibm_iam_service_policy.go
@@ -446,7 +446,7 @@ func resourceIBMIAMServicePolicyExists(d *schema.ResourceData, meta interface{})
 	servicePolicy, _, err := iamPolicyManagementClient.GetPolicy(getPolicyOptions)
 	if err != nil {
 		if apiErr, ok := err.(bmxerror.RequestFailure); ok {
-			if apiErr.StatusCode() == 404 {
+			if apiErr.StatusCode() == 404 || *servicePolicy.State == "deleted" {
 				return false, nil
 			}
 		}

--- a/ibm/resource_ibm_iam_service_policy_test.go
+++ b/ibm/resource_ibm_iam_service_policy_test.go
@@ -266,7 +266,7 @@ func testAccCheckIBMIAMServicePolicyDestroy(s *terraform.State) error {
 
 		if err == nil && *destroyedPolicy.State != "deleted" {
 			return fmt.Errorf("User policy still exists: %s\n", rs.Primary.ID)
-		} else if response.StatusCode != 404 && *destroyedPolicy.State != "deleted" {
+		} else if response.StatusCode != 404 && destroyedPolicy.State != nil && *destroyedPolicy.State != "deleted" {
 			return fmt.Errorf("Error waiting for user policy (%s) to be destroyed: %s", rs.Primary.ID, err)
 		}
 	}

--- a/ibm/resource_ibm_iam_user_policy.go
+++ b/ibm/resource_ibm_iam_user_policy.go
@@ -11,8 +11,6 @@ import (
 	"github.com/IBM/platform-services-go-sdk/iampolicymanagementv1"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-
-	"github.com/IBM-Cloud/bluemix-go/bmxerror"
 )
 
 func resourceIBMIAMUserPolicy() *schema.Resource {
@@ -212,15 +210,13 @@ func resourceIBMIAMUserPolicyCreate(d *schema.ResourceData, meta interface{}) er
 
 	err = resource.Retry(5*time.Minute, func() *resource.RetryError {
 		var err error
-		_, _, err = iamPolicyManagementClient.GetPolicy(getPolicyOptions)
+		policy, res, err := iamPolicyManagementClient.GetPolicy(getPolicyOptions)
 
-		if err != nil {
-			if apiErr, ok := err.(bmxerror.RequestFailure); ok {
-				if apiErr.StatusCode() == 404 {
-					return resource.RetryableError(err)
-				}
-				return resource.NonRetryableError(err)
+		if err != nil || policy == nil {
+			if res != nil && res.StatusCode == 404 {
+				return resource.RetryableError(err)
 			}
+			return resource.NonRetryableError(err)
 		}
 		return nil
 	})
@@ -403,20 +399,21 @@ func resourceIBMIAMUserPolicyExists(d *schema.ResourceData, meta interface{}) (b
 		userPolicyID,
 	)
 
-	userPolicy, _, err := iamPolicyManagementClient.GetPolicy(getPolicyOptions)
-	if err != nil {
-		if apiErr, ok := err.(bmxerror.RequestFailure); ok {
-			if apiErr.StatusCode() == 404 || *userPolicy.State == "deleted" {
-				return false, nil
-			}
+	userPolicy, resp, err := iamPolicyManagementClient.GetPolicy(getPolicyOptions)
+	if err != nil || userPolicy == nil {
+		if resp != nil && resp.StatusCode == 404 {
+			return false, nil
 		}
-		return false, fmt.Errorf("Error communicating with the API: %s", err)
+		return false, fmt.Errorf("Error communicating with the API: %s\n%s", err, resp)
+	}
+
+	if userPolicy != nil && userPolicy.State != nil && *userPolicy.State == "deleted" {
+		return false, nil
 	}
 
 	tempID := fmt.Sprintf("%s/%s", userEmail, *userPolicy.ID)
 
 	return tempID == d.Id(), nil
-
 }
 
 func importUserPolicy(d *schema.ResourceData, meta interface{}) (interface{}, interface{}, error) {

--- a/ibm/resource_ibm_iam_user_policy.go
+++ b/ibm/resource_ibm_iam_user_policy.go
@@ -406,7 +406,7 @@ func resourceIBMIAMUserPolicyExists(d *schema.ResourceData, meta interface{}) (b
 	userPolicy, _, err := iamPolicyManagementClient.GetPolicy(getPolicyOptions)
 	if err != nil {
 		if apiErr, ok := err.(bmxerror.RequestFailure); ok {
-			if apiErr.StatusCode() == 404 {
+			if apiErr.StatusCode() == 404 || *userPolicy.State == "deleted" {
 				return false, nil
 			}
 		}

--- a/ibm/resource_ibm_iam_user_policy_test.go
+++ b/ibm/resource_ibm_iam_user_policy_test.go
@@ -263,7 +263,7 @@ func testAccCheckIBMIAMUserPolicyDestroy(s *terraform.State) error {
 
 		if err == nil && *destroyedPolicy.State != "deleted" {
 			return fmt.Errorf("User policy still exists: %s\n", rs.Primary.ID)
-		} else if response.StatusCode != 404 && *destroyedPolicy.State != "deleted" {
+		} else if response.StatusCode != 404 && destroyedPolicy.State != nil && *destroyedPolicy.State != "deleted" {
 			return fmt.Errorf("Error waiting for user policy (%s) to be destroyed: %s", rs.Primary.ID, err)
 		}
 	}


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/IBM-Cloud/terraform-provider-ibm/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #2703 

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccXXX'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test $(go list ./... |grep -v 'vendor') -v -run=TestAccXXX -timeout 700m
?   	github.com/IBM-Cloud/terraform-provider-ibm	[no test files]
[WARN] Set the environment variable IBM_ORG for testing ibm_org  resource Some tests for that resource will fail if this is not set correctly
[WARN] Set the environment variable IBM_SPACE for testing ibm_space  resource Some tests for that resource will fail if this is not set correctly
[WARN] Set the environment variable IBM_ID1 for testing ibm_space resource Some tests for that resource will fail if this is not set correctly
[WARN] Set the environment variable IBM_ID2 for testing ibm_space resource Some tests for that resource will fail if this is not set correctly
[WARN] Set the environment variable IBM_DATACENTER for testing ibm_container_cluster resource else it is set to default value 'par01'
[WARN] Set the environment variable IBM_MACHINE_TYPE for testing ibm_container_cluster resource else it is set to default value 'u2c.2x4'
[WARN] Set the environment variable IBM_CERT_CRN for testing ibm_container_alb_cert resource else it is set to default value
[WARN] Set the environment variable IBM_UPDATE_CERT_CRN for testing ibm_container_alb_cert resource else it is set to default value
[WARN] Set the environment variable IBM_CONTAINER_REGION for testing ibm_container resources else it is set to default value 'eu-de'
[WARN] Set the environment variable IBM_CIS_INSTANCE with a VALID CIS Instance NAME for testing ibm_cis resources on staging/test
[WARN] Set the environment variable IBM_CIS_DOMAIN_STATIC with the Domain name registered with the CIS instance on test/staging. Domain must be predefined in CIS to avoid CIS billing costs due to domain delete/create
[WARN] Set the environment variable IBM_CIS_DOMAIN_TEST with a VALID Domain name for testing the one time create and delete of a domain in CIS. Note each create/delete will trigger a monthly billing instance. Only to be run in staging/test
[WARN] Set the environment variable IBM_CIS_RESOURCE_GROUP with the resource group for the CIS Instance
[WARN] Set the environment variable IBM_COS_CRN with a VALID COS instance CRN for testing ibm_cos_* resources
[WARN] Set the environment variable IBM_TRUSTED_MACHINE_TYPE for testing ibm_container_cluster resource else it is set to default value 'mb1c.16x64'
[WARN] Set the environment variable IBM_BM_EXTENDED_HW_TESTING to true/false for testing ibm_compute_bare_metal resource else it is set to default value 'false'
[WARN] Set the environment variable IBM_PUBLIC_VLAN_ID for testing ibm_container_cluster resource else it is set to default value '2393319'
[WARN] Set the environment variable IBM_PRIVATE_VLAN_ID for testing ibm_container_cluster resource else it is set to default value '2393321'
[WARN] Set the environment variable IBM_KUBE_VERSION for testing ibm_container_cluster resource else it is set to default value '1.18.14'
[WARN] Set the environment variable IBM_KUBE_UPDATE_VERSION for testing ibm_container_cluster resource else it is set to default value '1.19.6'
[WARN] Set the environment variable IBM_PRIVATE_SUBNET_ID for testing ibm_container_cluster resource else it is set to default value '1636107'
[WARN] Set the environment variable IBM_PUBLIC_SUBNET_ID for testing ibm_container_cluster resource else it is set to default value '1165645'
[WARN] Set the environment variable IBM_SUBNET_ID for testing ibm_container_cluster resource else it is set to default value '1165645'
[INFO] Set the environment variable IBM_IPSEC_DATACENTER for testing ibm_ipsec_vpn resource else it is set to default value 'tok02'
[INFO] Set the environment variable IBM_IPSEC_CUSTOMER_SUBNET_ID for testing ibm_ipsec_vpn resource else it is set to default value '123456'
[INFO] Set the environment variable IBM_IPSEC_CUSTOMER_PEER_IP for testing ibm_ipsec_vpn resource else it is set to default value '192.168.0.1'
[WARN] Set the environment variable IBM_LBAAS_DATACENTER for testing ibm_lbaas resource else it is set to default value 'dal13'
[WARN] Set the environment variable IBM_LBAAS_SUBNETID for testing ibm_lbaas resource else it is set to default value '2144241'
[WARN] Set the environment variable IBM_DEDICATED_HOSTNAME for testing ibm_compute_vm_instance resource else it is set to default value 'terraform-dedicatedhost'
[WARN] Set the environment variable IBM_DEDICATED_HOST_ID for testing ibm_compute_vm_instance resource else it is set to default value '30301'
[WARN] Set the environment variable IBM_WORKER_POOL_ZONE for testing ibm_container_worker_pool_zone_attachment resource else it is set to default value 'ams03'
[WARN] Set the environment variable IBM_WORKER_POOL_ZONE_PRIVATE_VLAN for testing ibm_container_worker_pool_zone_attachment resource else it is set to default value '2538975'
[WARN] Set the environment variable IBM_WORKER_POOL_ZONE_PUBLIC_VLAN for testing ibm_container_worker_pool_zone_attachment resource else it is set to default value '2538967'
[WARN] Set the environment variable IBM_WORKER_POOL_ZONE_UPDATE_PRIVATE_VLAN for testing ibm_container_worker_pool_zone_attachment resource else it is set to default value '2388377'
[WARN] Set the environment variable IBM_WORKER_POOL_ZONE_UPDATE_PUBLIC_VLAN for testing ibm_container_worker_pool_zone_attachment resource else it is set to default value '2388375'
[WARN] Set the environment variable IBM_PLACEMENT_GROUP_NAME for testing ibm_compute_vm_instance resource else it is set to default value 'terraform-group'
[INFO] Set the environment variable SL_REGION for testing ibm_is_region datasource else it is set to default value 'us-south'
[INFO] Set the environment variable SL_ZONE for testing ibm_is_zone datasource else it is set to default value 'us-south-1'
[INFO] Set the environment variable SL_CIDR for testing ibm_is_subnet else it is set to default value '10.240.0.0/24'
[INFO] Set the environment variable SL_ADDRESS_PREFIX_CIDR for testing ibm_is_vpc_address_prefix else it is set to default value '10.120.0.0/24'
[INFO] Set the environment variable IS_IMAGE for testing ibm_is_instance, ibm_is_floating_ip else it is set to default value 'r006-ed3f775f-ad7e-4e37-ae62-7199b4988b00'
[INFO] Set the environment variable IS_WIN_IMAGE for testing ibm_is_instance data source else it is set to default value 'r006-5f9568ae-792e-47e1-a710-5538b2bdfca7'
[INFO] Set the environment variable SL_INSTANCE_PROFILE for testing ibm_is_instance resource else it is set to default value 'cx2-2x4'
[INFO] Set the environment variable SL_INSTANCE_PROFILE_UPDATE for testing ibm_is_instance resource else it is set to default value 'cx2-4x8'
[INFO] Set the environment variable IS_DEDICATED_HOST_NAME for testing ibm_is_instance resource else it is set to default value 'tf-dhost-01'
[INFO] Set the environment variable IS_DEDICATED_HOST_GROUP_ID for testing ibm_is_instance resource else it is set to default value '0717-9104e7b5-77ad-44ad-9eaa-091e6b6efce1'
[INFO] Set the environment variable IS_DEDICATED_HOST_PROFILE for testing ibm_is_instance resource else it is set to default value 'bx2d-host-152x608'
[INFO] Set the environment variable IS_DEDICATED_HOST_GROUP_CLASS for testing ibm_is_instance resource else it is set to default value 'bx2d'
[INFO] Set the environment variable IS_DEDICATED_HOST_GROUP_FAMILY for testing ibm_is_instance resource else it is set to default value 'balanced'
[INFO] Set the environment variable SL_INSTANCE_PROFILE for testing ibm_is_instance resource else it is set to default value 'bx2d-16x64'
[INFO] Set the environment variable IS_VOLUME_PROFILE for testing ibm_is_volume_profile else it is set to default value 'general-purpose'
[INFO] Set the environment variable SL_ROUTE_DESTINATION for testing ibm_is_vpc_route else it is set to default value '192.168.4.0/24'
[INFO] Set the environment variable SL_ROUTE_NEXTHOP for testing ibm_is_vpc_route else it is set to default value '10.0.0.4'
[INFO] Set the environment variable PI_IMAGE for testing ibm_pi_image resource else it is set to default value '7200-03-03'
[INFO] Set the environment variable PI_KEY_NAME for testing ibm_pi_key_name resource else it is set to default value 'terraform-test-power'
[INFO] Set the environment variable PI_NETWORK_NAME for testing ibm_pi_network_name resource else it is set to default value 'terraform-test-power'
[INFO] Set the environment variable PI_VOLUME_NAME for testing ibm_pi_network_name resource else it is set to default value 'terraform-test-power'
[INFO] Set the environment variable PI_CLOUDINSTANCE_ID for testing ibm_pi_image resource else it is set to default value 'd16705bd-7f1a-48c9-9e0e-1c17b71e7331'
[INFO] Set the environment variable PI_PVM_INSTANCE_ID for testing pi_instance_name resource else it is set to default value 'terraform-test-power'
[INFO] Set the environment variable SCHEMATICS_WORKSPACE_ID for testing schematics resources else it is set to default value
[INFO] Set the environment variable SCHEMATICS_TEMPLATE_ID for testing schematics resources else it is set to default value
[INFO] Set the environment variable SCHEMATICS_ACTION_ID for testing schematics resources else it is set to default value
[WARN] Set the environment variable IMAGE_COS_URL with a VALID COS Image SQL URL for testing ibm_is_image resources on staging/test
[WARN] Set the environment variable IMAGE_COS_URL_ENCRYPTED with a VALID COS Image SQL URL for testing ibm_is_image resources on staging/test
[WARN] Set the environment variable IMAGE_OPERATING_SYSTEM with a VALID Operating system for testing ibm_is_image resources on staging/test
[INFO] Set the environment variable IS_IMAGE_NAME for testing data source ibm_is_image else it is set to default value `ibm-ubuntu-18-04-1-minimal-amd64-2`
[INFO] Set the environment variable IS_IMAGE_ENCRYPTED_DATA_KEY for testing resource ibm_is_image else it is set to default value
[INFO] Set the environment variable IS_IMAGE_ENCRYPTION_KEY for testing resource ibm_is_image else it is set to default value
[INFO] Set the environment variable IBM_FUNCTION_NAMESPACE for testing ibm_function_package, ibm_function_action, ibm_function_rule, ibm_function_trigger resource else  tests will fail if this is not set correctly
[INFO] Set the environment variable HPCS_INSTANCE_ID for testing data_source_ibm_kms_key_test else it is set to default value
[INFO] Set the environment variable SECRETS_MANAGER_INSTANCE_ID for testing data_source_ibm_secrets_manager_secrets_test else tests will fail if this is not set correctly
[INFO] Set the environment variable SECRETS_MANAGER_SECRET_TYPE for testing data_source_ibm_secrets_manager_secrets_test, else it is set to default value. For data_source_ibm_secrets_manager_secret_test, tests will fail if this is not set correctly
[WARN] Set the environment variable SECRETS_MANAGER_SECRET_ID for testing data_source_ibm_secrets_manager_secret_test else tests will fail if this is not set correctly
[INFO] Set the environment variable IBM_TG_CROSS_NETWORK_ID for testing ibm_tg_connection resource else  tests will fail if this is not set correctly
[INFO] Set the environment variable ACCOUNT_TO_BE_IMPORTED for testing import enterprise account resource else  tests will fail if this is not set correctly
testing: warning: no tests to run
PASS
ok  	github.com/IBM-Cloud/terraform-provider-ibm/ibm	1.256s [no tests to run]
testing: warning: no tests to run
PASS
ok  	github.com/IBM-Cloud/terraform-provider-ibm/ibm/internal/hashcode	0.451s [no tests to run]
testing: warning: no tests to run
PASS
ok  	github.com/IBM-Cloud/terraform-provider-ibm/ibm/internal/mutexkv	0.583s [no tests to run]
?   	github.com/IBM-Cloud/terraform-provider-ibm/version	[no test files]
```
