### PR TITLE
Fixed resource_tag crn validation issue

### DIFF
--- a/ibm/data_source_ibm_resource_tag_test.go
+++ b/ibm/data_source_ibm_resource_tag_test.go
@@ -41,7 +41,7 @@ func testAccCheckResourceTagReadDataSource(name, managed_from string) string {
 	}
 
 	data "ibm_satellite_location" "get_location" {
-		location   = ibm_satellite_location.location.location
+		location   = ibm_satellite_location.location.id
 	}
 
 	resource "ibm_resource_tag" "tag" {

--- a/ibm/resource_ibm_resource_tag.go
+++ b/ibm/resource_ibm_resource_tag.go
@@ -23,7 +23,7 @@ const (
 	tagType      = "tag_type"
 	acccountID   = "acccount_id"
 	service      = "service"
-	crnRegex     = "^crn:.+:.+:.+:.+:.+:$"
+	crnRegex     = "^crn:v1(:[a-zA-Z0-9 \\-\\._~\\*\\+,;=!$&'\\(\\)\\/\\?#\\[\\]@]*){8}$|^[0-9]+$"
 )
 
 func resourceIBMResourceTag() *schema.Resource {
@@ -156,7 +156,7 @@ func resourceIBMResourceTagCreate(d *schema.ResourceData, meta interface{}) erro
 	if len(add) > 0 {
 		_, resp, err := gtClient.AttachTag(AttachTagOptions)
 		if err != nil {
-			return fmt.Errorf("Error attaching resource tags >>>>  %v : %s", resp, err)
+			return fmt.Errorf("Error attaching resource tags : %v\n%s", resp, err)
 		}
 	}
 

--- a/ibm/resource_ibm_resource_tag_test.go
+++ b/ibm/resource_ibm_resource_tag_test.go
@@ -81,7 +81,7 @@ func testAccCheckResourceTagCreate(name, managed_from string) string {
 	}
 
 	data "ibm_satellite_location" "test_location" {
-		location  = ibm_satellite_location.location.location
+		location  = ibm_satellite_location.location.id
 	}
 
 	resource "ibm_resource_tag" "tag" {


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/IBM-Cloud/terraform-provider-ibm/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->



<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccXXX'

anilkumarnagaraj@anis-MacBook-Pro terraform-provider-ibm % make testacc TEST=./ibm TESTARGS='-run=TestAccResourceTag'      
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./ibm -v -run=TestAccResourceTag -timeout 700m
[WARN] Set the environment variable IBM_ORG for testing ibm_org  resource Some tests for that resource will fail if this is not set correctly
[WARN] Set the environment variable IBM_SPACE for testing ibm_space  resource Some tests for that resource will fail if this is not set correctly
[WARN] Set the environment variable IBM_ID1 for testing ibm_space resource Some tests for that resource will fail if this is not set correctly
[WARN] Set the environment variable IBM_ID2 for testing ibm_space resource Some tests for that resource will fail if this is not set correctly
[WARN] Set the environment variable IBM_IAMUSER for testing ibm_iam_user_policy resource Some tests for that resource will fail if this is not set correctly
[WARN] Set the environment variable IBM_DATACENTER for testing ibm_container_cluster resource else it is set to default value 'par01'
[WARN] Set the environment variable IBM_MACHINE_TYPE for testing ibm_container_cluster resource else it is set to default value 'u2c.2x4'
[WARN] Set the environment variable IBM_CERT_CRN for testing ibm_container_alb_cert resource else it is set to default value
[WARN] Set the environment variable IBM_UPDATE_CERT_CRN for testing ibm_container_alb_cert resource else it is set to default value
[WARN] Set the environment variable IBM_CONTAINER_REGION for testing ibm_container resources else it is set to default value 'eu-de'
[WARN] Set the environment variable IBM_CIS_INSTANCE with a VALID CIS Instance NAME for testing ibm_cis resources on staging/test
[WARN] Set the environment variable IBM_CIS_DOMAIN_STATIC with the Domain name registered with the CIS instance on test/staging. Domain must be predefined in CIS to avoid CIS billing costs due to domain delete/create
[WARN] Set the environment variable IBM_CIS_DOMAIN_TEST with a VALID Domain name for testing the one time create and delete of a domain in CIS. Note each create/delete will trigger a monthly billing instance. Only to be run in staging/test
[WARN] Set the environment variable IBM_CIS_RESOURCE_GROUP with the resource group for the CIS Instance 
[WARN] Set the environment variable IBM_COS_CRN with a VALID COS instance CRN for testing ibm_cos_* resources
[WARN] Set the environment variable IBM_TRUSTED_MACHINE_TYPE for testing ibm_container_cluster resource else it is set to default value 'mb1c.16x64'
[WARN] Set the environment variable IBM_BM_EXTENDED_HW_TESTING to true/false for testing ibm_compute_bare_metal resource else it is set to default value 'false'
[WARN] Set the environment variable IBM_PUBLIC_VLAN_ID for testing ibm_container_cluster resource else it is set to default value '2393319'
[WARN] Set the environment variable IBM_PRIVATE_VLAN_ID for testing ibm_container_cluster resource else it is set to default value '2393321'
[WARN] Set the environment variable IBM_KUBE_VERSION for testing ibm_container_cluster resource else it is set to default value '1.18.14'
[WARN] Set the environment variable IBM_KUBE_UPDATE_VERSION for testing ibm_container_cluster resource else it is set to default value '1.19.6'
[WARN] Set the environment variable IBM_PRIVATE_SUBNET_ID for testing ibm_container_cluster resource else it is set to default value '1636107'
[WARN] Set the environment variable IBM_PUBLIC_SUBNET_ID for testing ibm_container_cluster resource else it is set to default value '1165645'
[WARN] Set the environment variable IBM_SUBNET_ID for testing ibm_container_cluster resource else it is set to default value '1165645'
[INFO] Set the environment variable IBM_IPSEC_DATACENTER for testing ibm_ipsec_vpn resource else it is set to default value 'tok02'
[INFO] Set the environment variable IBM_IPSEC_CUSTOMER_SUBNET_ID for testing ibm_ipsec_vpn resource else it is set to default value '123456'
[INFO] Set the environment variable IBM_IPSEC_CUSTOMER_PEER_IP for testing ibm_ipsec_vpn resource else it is set to default value '192.168.0.1'
[WARN] Set the environment variable IBM_LBAAS_DATACENTER for testing ibm_lbaas resource else it is set to default value 'dal13'
[WARN] Set the environment variable IBM_LBAAS_SUBNETID for testing ibm_lbaas resource else it is set to default value '2144241'
[WARN] Set the environment variable IBM_DEDICATED_HOSTNAME for testing ibm_compute_vm_instance resource else it is set to default value 'terraform-dedicatedhost'
[WARN] Set the environment variable IBM_DEDICATED_HOST_ID for testing ibm_compute_vm_instance resource else it is set to default value '30301'
[WARN] Set the environment variable IBM_WORKER_POOL_ZONE for testing ibm_container_worker_pool_zone_attachment resource else it is set to default value 'ams03'
[WARN] Set the environment variable IBM_WORKER_POOL_ZONE_PRIVATE_VLAN for testing ibm_container_worker_pool_zone_attachment resource else it is set to default value '2538975'
[WARN] Set the environment variable IBM_WORKER_POOL_ZONE_PUBLIC_VLAN for testing ibm_container_worker_pool_zone_attachment resource else it is set to default value '2538967'
[WARN] Set the environment variable IBM_WORKER_POOL_ZONE_UPDATE_PRIVATE_VLAN for testing ibm_container_worker_pool_zone_attachment resource else it is set to default value '2388377'
[WARN] Set the environment variable IBM_WORKER_POOL_ZONE_UPDATE_PUBLIC_VLAN for testing ibm_container_worker_pool_zone_attachment resource else it is set to default value '2388375'
[WARN] Set the environment variable IBM_PLACEMENT_GROUP_NAME for testing ibm_compute_vm_instance resource else it is set to default value 'terraform-group'
[INFO] Set the environment variable SL_REGION for testing ibm_is_region datasource else it is set to default value 'us-south'
[INFO] Set the environment variable SL_ZONE for testing ibm_is_zone datasource else it is set to default value 'us-south-1'
[INFO] Set the environment variable SL_CIDR for testing ibm_is_subnet else it is set to default value '10.240.0.0/24'
[INFO] Set the environment variable SL_ADDRESS_PREFIX_CIDR for testing ibm_is_vpc_address_prefix else it is set to default value '10.120.0.0/24'
[INFO] Set the environment variable IS_IMAGE for testing ibm_is_instance, ibm_is_floating_ip else it is set to default value 'r006-ed3f775f-ad7e-4e37-ae62-7199b4988b00'
[INFO] Set the environment variable IS_WIN_IMAGE for testing ibm_is_instance data source else it is set to default value 'r006-5f9568ae-792e-47e1-a710-5538b2bdfca7'
[INFO] Set the environment variable SL_INSTANCE_PROFILE for testing ibm_is_instance resource else it is set to default value 'cx2-2x4'
[INFO] Set the environment variable SL_INSTANCE_PROFILE_UPDATE for testing ibm_is_instance resource else it is set to default value 'cx2-4x8'
[INFO] Set the environment variable IS_DEDICATED_HOST_NAME for testing ibm_is_instance resource else it is set to default value 'tf-dhost-01'
[INFO] Set the environment variable IS_DEDICATED_HOST_GROUP_ID for testing ibm_is_instance resource else it is set to default value '0717-9104e7b5-77ad-44ad-9eaa-091e6b6efce1'
[INFO] Set the environment variable IS_DEDICATED_HOST_PROFILE for testing ibm_is_instance resource else it is set to default value 'bx2d-host-152x608'
[INFO] Set the environment variable IS_DEDICATED_HOST_GROUP_CLASS for testing ibm_is_instance resource else it is set to default value 'bx2d'
[INFO] Set the environment variable IS_DEDICATED_HOST_GROUP_FAMILY for testing ibm_is_instance resource else it is set to default value 'balanced'
[INFO] Set the environment variable SL_INSTANCE_PROFILE for testing ibm_is_instance resource else it is set to default value 'bx2d-16x64'
[INFO] Set the environment variable IS_VOLUME_PROFILE for testing ibm_is_volume_profile else it is set to default value 'general-purpose'
[INFO] Set the environment variable SL_ROUTE_DESTINATION for testing ibm_is_vpc_route else it is set to default value '192.168.4.0/24'
[INFO] Set the environment variable SL_ROUTE_NEXTHOP for testing ibm_is_vpc_route else it is set to default value '10.0.0.4'
[INFO] Set the environment variable PI_IMAGE for testing ibm_pi_image resource else it is set to default value '7200-03-03'
[INFO] Set the environment variable PI_KEY_NAME for testing ibm_pi_key_name resource else it is set to default value 'terraform-test-power'
[INFO] Set the environment variable PI_NETWORK_NAME for testing ibm_pi_network_name resource else it is set to default value 'terraform-test-power'
[INFO] Set the environment variable PI_VOLUME_NAME for testing ibm_pi_network_name resource else it is set to default value 'terraform-test-power'
[INFO] Set the environment variable PI_CLOUDINSTANCE_ID for testing ibm_pi_image resource else it is set to default value 'd16705bd-7f1a-48c9-9e0e-1c17b71e7331'
[INFO] Set the environment variable PI_PVM_INSTANCE_ID for testing pi_instance_name resource else it is set to default value 'terraform-test-power'
[INFO] Set the environment variable SCHEMATICS_WORKSPACE_ID for testing schematics resources else it is set to default value
[INFO] Set the environment variable SCHEMATICS_TEMPLATE_ID for testing schematics resources else it is set to default value
[INFO] Set the environment variable SCHEMATICS_ACTION_ID for testing schematics resources else it is set to default value
[WARN] Set the environment variable IMAGE_COS_URL with a VALID COS Image SQL URL for testing ibm_is_image resources on staging/test
[WARN] Set the environment variable IMAGE_COS_URL_ENCRYPTED with a VALID COS Image SQL URL for testing ibm_is_image resources on staging/test
[WARN] Set the environment variable IMAGE_OPERATING_SYSTEM with a VALID Operating system for testing ibm_is_image resources on staging/test
[INFO] Set the environment variable IS_IMAGE_NAME for testing data source ibm_is_image else it is set to default value `ibm-ubuntu-18-04-1-minimal-amd64-2`
[INFO] Set the environment variable IS_IMAGE_ENCRYPTED_DATA_KEY for testing resource ibm_is_image else it is set to default value
[INFO] Set the environment variable IS_IMAGE_ENCRYPTION_KEY for testing resource ibm_is_image else it is set to default value
[INFO] Set the environment variable IBM_FUNCTION_NAMESPACE for testing ibm_function_package, ibm_function_action, ibm_function_rule, ibm_function_trigger resource else  tests will fail if this is not set correctly
[INFO] Set the environment variable HPCS_INSTANCE_ID for testing data_source_ibm_kms_key_test else it is set to default value
[INFO] Set the environment variable SECRETS_MANAGER_INSTANCE_ID for testing data_source_ibm_secrets_manager_secrets_test else tests will fail if this is not set correctly
[INFO] Set the environment variable SECRETS_MANAGER_SECRET_TYPE for testing data_source_ibm_secrets_manager_secrets_test, else it is set to default value. For data_source_ibm_secrets_manager_secret_test, tests will fail if this is not set correctly
[WARN] Set the environment variable SECRETS_MANAGER_SECRET_ID for testing data_source_ibm_secrets_manager_secret_test else tests will fail if this is not set correctly
[INFO] Set the environment variable IBM_TG_CROSS_ACCOUNT_ID for testing ibm_tg_connection resource else  tests will fail if this is not set correctly
[INFO] Set the environment variable IBM_TG_CROSS_NETWORK_ID for testing ibm_tg_connection resource else  tests will fail if this is not set correctly
[INFO] Set the environment variable ACCOUNT_TO_BE_IMPORTED for testing import enterprise account resource else  tests will fail if this is not set correctly
=== RUN   TestAccResourceTagDataSource_basic
2021/06/16 17:10:40 [WARN] Truncating attribute path of 0 diagnostics for TypeSet
2021/06/16 17:10:40 [WARN] Truncating attribute path of 0 diagnostics for TypeSet
2021/06/16 17:10:40 Configuring SoftLayer Session with API key
2021/06/16 17:10:40 Configuring IBM Cloud Session with API key
2021/06/16 17:10:40 [INFO] Configured Region: us-south
2021/06/16 17:10:43 [WARN] Truncating attribute path of 0 diagnostics for TypeSet
2021/06/16 17:10:43 [WARN] Truncating attribute path of 0 diagnostics for TypeSet
2021/06/16 17:10:43 Configuring SoftLayer Session with API key
2021/06/16 17:10:43 Configuring IBM Cloud Session with API key
2021/06/16 17:10:43 [INFO] Configured Region: us-south
2021/06/16 17:10:44 [WARN] Truncating attribute path of 0 diagnostics for TypeSet
2021/06/16 17:10:44 [WARN] Truncating attribute path of 0 diagnostics for TypeSet
2021/06/16 17:10:44 Configuring SoftLayer Session with API key
2021/06/16 17:10:44 Configuring IBM Cloud Session with API key
2021/06/16 17:10:44 [INFO] Configured Region: us-south
2021/06/16 17:10:45 [WARN] Truncating attribute path of 0 diagnostics for TypeSet
2021/06/16 17:10:45 [DEBUG] setting computed for "tags" from ComputedKeys
2021/06/16 17:11:03 [INFO] Created satellite location : tf-satellitelocation-13
2021/06/16 17:11:03 [DEBUG] Waiting for state to become: [action required deploy_failed]
2021/06/16 17:24:41 tagList:  []
2021/06/16 17:24:44 tagList:  []
2021/06/16 17:24:44 [WARN] Truncating attribute path of 0 diagnostics for TypeSet
2021/06/16 17:24:45 tagList:  [cpu:4 env:dev]
2021/06/16 17:24:46 tagList:  [cpu:4 env:dev]
2021/06/16 17:24:46 [WARN] Truncating attribute path of 0 diagnostics for TypeSet
2021/06/16 17:24:46 [WARN] Truncating attribute path of 0 diagnostics for TypeSet
2021/06/16 17:24:46 Configuring SoftLayer Session with API key
2021/06/16 17:24:46 Configuring IBM Cloud Session with API key
2021/06/16 17:24:46 [INFO] Configured Region: us-south
2021/06/16 17:24:48 [WARN] Truncating attribute path of 0 diagnostics for TypeSet
2021/06/16 17:24:48 [WARN] Truncating attribute path of 0 diagnostics for TypeSet
2021/06/16 17:24:49 tagList:  [cpu:4 env:dev]
2021/06/16 17:24:50 [WARN] Truncating attribute path of 0 diagnostics for TypeSet
2021/06/16 17:24:50 [WARN] Truncating attribute path of 0 diagnostics for TypeSet
2021/06/16 17:24:50 Configuring SoftLayer Session with API key
2021/06/16 17:24:50 Configuring IBM Cloud Session with API key
2021/06/16 17:24:50 [INFO] Configured Region: us-south
2021/06/16 17:24:55 tagList:  [cpu:4 env:dev]
2021/06/16 17:24:58 tagList:  [cpu:4 env:dev]
2021/06/16 17:24:58 tagList:  [cpu:4 env:dev]
2021/06/16 17:24:59 tagList:  [cpu:4 env:dev]
2021/06/16 17:25:00 [WARN] Truncating attribute path of 0 diagnostics for TypeSet
2021/06/16 17:25:00 [WARN] Truncating attribute path of 0 diagnostics for TypeSet
2021/06/16 17:25:00 Configuring SoftLayer Session with API key
2021/06/16 17:25:00 Configuring IBM Cloud Session with API key
2021/06/16 17:25:00 [INFO] Configured Region: us-south
2021/06/16 17:25:01 [WARN] Truncating attribute path of 0 diagnostics for TypeSet
2021/06/16 17:25:01 [WARN] Truncating attribute path of 0 diagnostics for TypeSet
2021/06/16 17:25:01 tagList:  [cpu:4 env:dev]
2021/06/16 17:25:02 [WARN] Truncating attribute path of 0 diagnostics for TypeSet
2021/06/16 17:25:02 [WARN] Truncating attribute path of 0 diagnostics for TypeSet
2021/06/16 17:25:02 Configuring SoftLayer Session with API key
2021/06/16 17:25:02 Configuring IBM Cloud Session with API key
2021/06/16 17:25:02 [INFO] Configured Region: us-south
2021/06/16 17:25:08 [DEBUG] Waiting for state to become: [done]
--- PASS: TestAccResourceTagDataSource_basic (1061.52s)
=== RUN   TestAccResourceTag_Basic
2021/06/16 17:28:22 [WARN] Truncating attribute path of 0 diagnostics for TypeSet
2021/06/16 17:28:22 [WARN] Truncating attribute path of 0 diagnostics for TypeSet
2021/06/16 17:28:22 Configuring SoftLayer Session with API key
2021/06/16 17:28:22 Configuring IBM Cloud Session with API key
2021/06/16 17:28:22 [INFO] Configured Region: us-south
2021/06/16 17:28:24 [WARN] Truncating attribute path of 0 diagnostics for TypeSet
2021/06/16 17:28:24 [WARN] Truncating attribute path of 0 diagnostics for TypeSet
2021/06/16 17:28:24 Configuring SoftLayer Session with API key
2021/06/16 17:28:24 Configuring IBM Cloud Session with API key
2021/06/16 17:28:24 [INFO] Configured Region: us-south
2021/06/16 17:28:25 [WARN] Truncating attribute path of 0 diagnostics for TypeSet
2021/06/16 17:28:25 [WARN] Truncating attribute path of 0 diagnostics for TypeSet
2021/06/16 17:28:25 Configuring SoftLayer Session with API key
2021/06/16 17:28:25 Configuring IBM Cloud Session with API key
2021/06/16 17:28:25 [INFO] Configured Region: us-south
2021/06/16 17:28:26 [WARN] Truncating attribute path of 0 diagnostics for TypeSet
2021/06/16 17:28:26 [DEBUG] setting computed for "tags" from ComputedKeys
2021/06/16 17:28:45 [INFO] Created satellite location : tf-satellitelocation-32
2021/06/16 17:28:45 [DEBUG] Waiting for state to become: [action required deploy_failed]
2021/06/16 17:44:57 tagList:  []
2021/06/16 17:45:01 tagList:  []
2021/06/16 17:45:01 [WARN] Truncating attribute path of 0 diagnostics for TypeSet
2021/06/16 17:45:02 tagList:  [cpu:4 env:dev]
2021/06/16 17:45:03 tagList:  [cpu:4 env:dev]
2021/06/16 17:45:03 [WARN] Truncating attribute path of 0 diagnostics for TypeSet
2021/06/16 17:45:03 [WARN] Truncating attribute path of 0 diagnostics for TypeSet
2021/06/16 17:45:03 Configuring SoftLayer Session with API key
2021/06/16 17:45:03 Configuring IBM Cloud Session with API key
2021/06/16 17:45:03 [INFO] Configured Region: us-south
2021/06/16 17:45:06 [WARN] Truncating attribute path of 0 diagnostics for TypeSet
2021/06/16 17:45:06 [WARN] Truncating attribute path of 0 diagnostics for TypeSet
2021/06/16 17:45:06 [WARN] Truncating attribute path of 0 diagnostics for TypeSet
2021/06/16 17:45:06 [WARN] Truncating attribute path of 0 diagnostics for TypeSet
2021/06/16 17:45:06 Configuring SoftLayer Session with API key
2021/06/16 17:45:06 Configuring IBM Cloud Session with API key
2021/06/16 17:45:06 [INFO] Configured Region: us-south
2021/06/16 17:45:12 tagList:  [cpu:4 env:dev]
2021/06/16 17:45:17 tagList:  [cpu:4 env:dev]
2021/06/16 17:45:17 tagList:  [cpu:4 env:dev]
2021/06/16 17:45:17 [WARN] Truncating attribute path of 0 diagnostics for TypeSet
2021/06/16 17:45:17 [WARN] Truncating attribute path of 0 diagnostics for TypeSet
2021/06/16 17:45:17 Configuring SoftLayer Session with API key
2021/06/16 17:45:17 Configuring IBM Cloud Session with API key
2021/06/16 17:45:17 [INFO] Configured Region: us-south
2021/06/16 17:45:19 [WARN] Truncating attribute path of 0 diagnostics for TypeSet
2021/06/16 17:45:19 [WARN] Truncating attribute path of 0 diagnostics for TypeSet
2021/06/16 17:45:19 Configuring SoftLayer Session with API key
2021/06/16 17:45:19 Configuring IBM Cloud Session with API key
2021/06/16 17:45:19 [INFO] Configured Region: us-south
2021/06/16 17:45:22 tagList:  [cpu:4 env:dev]
2021/06/16 17:45:22 [WARN] Truncating attribute path of 0 diagnostics for TypeSet
2021/06/16 17:45:22 [WARN] Truncating attribute path of 0 diagnostics for TypeSet
2021/06/16 17:45:22 Configuring SoftLayer Session with API key
2021/06/16 17:45:22 Configuring IBM Cloud Session with API key
2021/06/16 17:45:22 [INFO] Configured Region: us-south
2021/06/16 17:45:30 [DEBUG] Waiting for state to become: [done]
--- PASS: TestAccResourceTag_Basic (1233.22s)
PASS
ok  	github.com/IBM-Cloud/terraform-provider-ibm/ibm	2298.238s

```
