### PR TITLE
Datasource and Documentation for VPC Address Prefix

### DIFF
--- a/ibm/data_source_ibm_is_vpc_address_prefix.go
+++ b/ibm/data_source_ibm_is_vpc_address_prefix.go
@@ -1,0 +1,307 @@
+// Copyright IBM Corp. 2021 All Rights Reserved.
+// Licensed under the Mozilla Public License v2.0
+
+package ibm
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"time"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/IBM/vpc-go-sdk/vpcv1"
+)
+
+func dataSourceIbmIsVpcAddressPrefix() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceIbmIsVpcAddressPrefixRead,
+
+		Schema: map[string]*schema.Schema{
+			"vpc": &schema.Schema{
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "The VPC identifier.",
+			},
+			"name": &schema.Schema{
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "The user-defined name for this address prefix. Names must be unique within the VPC the address prefix resides in.",
+			},
+			"address_prefixes": &schema.Schema{
+				Type:        schema.TypeList,
+				Computed:    true,
+				Description: "Collection of address prefixes.",
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"cidr": &schema.Schema{
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "The CIDR block for this prefix.",
+						},
+						"created_at": &schema.Schema{
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "The date and time that the prefix was created.",
+						},
+						"has_subnets": &schema.Schema{
+							Type:        schema.TypeBool,
+							Computed:    true,
+							Description: "Indicates whether subnets exist with addresses from this prefix.",
+						},
+						"href": &schema.Schema{
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "The URL for this address prefix.",
+						},
+						"id": &schema.Schema{
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "The unique identifier for this address prefix.",
+						},
+						"is_default": &schema.Schema{
+							Type:        schema.TypeBool,
+							Computed:    true,
+							Description: "Indicates whether this is the default prefix for this zone in this VPC. If a default prefix was automatically created when the VPC was created, the prefix is automatically named using a hyphenated list of randomly-selected words, but may be updated with a user-specified name.",
+						},
+						"name": &schema.Schema{
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "The user-defined name for this address prefix. Names must be unique within the VPC the address prefix resides in.",
+						},
+						"zone": &schema.Schema{
+							Type:        schema.TypeList,
+							Computed:    true,
+							Description: "The zone this address prefix resides in.",
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"href": &schema.Schema{
+										Type:        schema.TypeString,
+										Computed:    true,
+										Description: "The URL for this zone.",
+									},
+									"name": &schema.Schema{
+										Type:        schema.TypeString,
+										Computed:    true,
+										Description: "The globally unique name for this zone.",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			"first": &schema.Schema{
+				Type:        schema.TypeList,
+				Computed:    true,
+				Description: "A link to the first page of resources.",
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"href": &schema.Schema{
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "The URL for a page of resources.",
+						},
+					},
+				},
+			},
+			"limit": &schema.Schema{
+				Type:        schema.TypeInt,
+				Computed:    true,
+				Description: "The maximum number of resources that can be returned by the request.",
+			},
+			"next": &schema.Schema{
+				Type:        schema.TypeList,
+				Computed:    true,
+				Description: "A link to the next page of resources. This property is present for all pagesexcept the last page.",
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"href": &schema.Schema{
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "The URL for a page of resources.",
+						},
+					},
+				},
+			},
+			"total_count": &schema.Schema{
+				Type:        schema.TypeInt,
+				Computed:    true,
+				Description: "The total number of resources across all pages.",
+			},
+		},
+	}
+}
+
+func dataSourceIbmIsVpcAddressPrefixRead(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+
+	vpcClient, err := meta.(ClientSession).VpcV1API()
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	listVpcAddressPrefixesOptions := &vpcv1.ListVPCAddressPrefixesOptions{}
+
+	listVpcAddressPrefixesOptions.SetVPCID(d.Get("vpc").(string))
+
+	addressPrefixCollection, response, err := vpcClient.ListVPCAddressPrefixesWithContext(context, listVpcAddressPrefixesOptions)
+	if err != nil {
+		log.Printf("[DEBUG] ListVpcAddressPrefixesWithContext failed %s\n%s", err, response)
+		return diag.FromErr(fmt.Errorf("ListVpcAddressPrefixesWithContext failed %s\n%s", err, response))
+	}
+
+	// Use the provided filter argument and construct a new list with only the requested resource(s)
+	var matchAddressPrefixes []vpcv1.AddressPrefix
+	var name string
+	var suppliedFilter bool
+
+	if v, ok := d.GetOk("name"); ok {
+		name = v.(string)
+		suppliedFilter = true
+		for _, data := range addressPrefixCollection.AddressPrefixes {
+			if *data.Name == name {
+				matchAddressPrefixes = append(matchAddressPrefixes, data)
+			}
+		}
+	} else {
+		matchAddressPrefixes = addressPrefixCollection.AddressPrefixes
+	}
+	addressPrefixCollection.AddressPrefixes = matchAddressPrefixes
+
+	if suppliedFilter {
+		if len(addressPrefixCollection.AddressPrefixes) == 0 {
+			return diag.FromErr(fmt.Errorf("no AddressPrefixes found with name %s", name))
+		}
+		d.SetId(name)
+	} else {
+		d.SetId(dataSourceIbmIsVpcAddressPrefixID(d))
+	}
+
+	if addressPrefixCollection.AddressPrefixes != nil {
+		err = d.Set("address_prefixes", dataSourceAddressPrefixCollectionFlattenAddressPrefixes(addressPrefixCollection.AddressPrefixes))
+		if err != nil {
+			return diag.FromErr(fmt.Errorf("Error setting address_prefixes %s", err))
+		}
+	}
+
+	if addressPrefixCollection.First != nil {
+		err = d.Set("first", dataSourceAddressPrefixCollectionFlattenFirst(*addressPrefixCollection.First))
+		if err != nil {
+			return diag.FromErr(fmt.Errorf("Error setting first %s", err))
+		}
+	}
+	if err = d.Set("limit", addressPrefixCollection.Limit); err != nil {
+		return diag.FromErr(fmt.Errorf("Error setting limit: %s", err))
+	}
+
+	if addressPrefixCollection.Next != nil {
+		err = d.Set("next", dataSourceAddressPrefixCollectionFlattenNext(*addressPrefixCollection.Next))
+		if err != nil {
+			return diag.FromErr(fmt.Errorf("Error setting next %s", err))
+		}
+	}
+	if err = d.Set("total_count", addressPrefixCollection.TotalCount); err != nil {
+		return diag.FromErr(fmt.Errorf("Error setting total_count: %s", err))
+	}
+
+	return nil
+}
+
+// dataSourceIbmIsVpcAddressPrefixID returns a reasonable ID for the list.
+func dataSourceIbmIsVpcAddressPrefixID(d *schema.ResourceData) string {
+	return time.Now().UTC().String()
+}
+
+func dataSourceAddressPrefixCollectionFlattenAddressPrefixes(result []vpcv1.AddressPrefix) (addressPrefixes []map[string]interface{}) {
+	for _, addressPrefixesItem := range result {
+		addressPrefixes = append(addressPrefixes, dataSourceAddressPrefixCollectionAddressPrefixesToMap(addressPrefixesItem))
+	}
+
+	return addressPrefixes
+}
+
+func dataSourceAddressPrefixCollectionAddressPrefixesToMap(addressPrefixesItem vpcv1.AddressPrefix) (addressPrefixesMap map[string]interface{}) {
+
+	addressPrefixesMap = map[string]interface{}{}
+
+	if addressPrefixesItem.CIDR != nil {
+		addressPrefixesMap["cidr"] = addressPrefixesItem.CIDR
+	}
+	if addressPrefixesItem.CreatedAt != nil {
+		addressPrefixesMap["created_at"] = addressPrefixesItem.CreatedAt.String()
+	}
+	if addressPrefixesItem.HasSubnets != nil {
+		addressPrefixesMap["has_subnets"] = addressPrefixesItem.HasSubnets
+	}
+	if addressPrefixesItem.Href != nil {
+		addressPrefixesMap["href"] = addressPrefixesItem.Href
+	}
+	if addressPrefixesItem.ID != nil {
+		addressPrefixesMap["id"] = addressPrefixesItem.ID
+	}
+	if addressPrefixesItem.IsDefault != nil {
+		addressPrefixesMap["is_default"] = addressPrefixesItem.IsDefault
+	}
+	if addressPrefixesItem.Name != nil {
+		addressPrefixesMap["name"] = addressPrefixesItem.Name
+	}
+	if addressPrefixesItem.Zone != nil {
+		zoneList := []map[string]interface{}{}
+		zoneMap := dataSourceAddressPrefixCollectionAddressPrefixesZoneToMap(*addressPrefixesItem.Zone)
+		zoneList = append(zoneList, zoneMap)
+		addressPrefixesMap["zone"] = zoneList
+	}
+
+	return addressPrefixesMap
+}
+
+func dataSourceAddressPrefixCollectionAddressPrefixesZoneToMap(zoneItem vpcv1.ZoneReference) (zoneMap map[string]interface{}) {
+	zoneMap = map[string]interface{}{}
+
+	if zoneItem.Href != nil {
+		zoneMap["href"] = zoneItem.Href
+	}
+	if zoneItem.Name != nil {
+		zoneMap["name"] = zoneItem.Name
+	}
+
+	return zoneMap
+}
+
+func dataSourceAddressPrefixCollectionFlattenFirst(result vpcv1.AddressPrefixCollectionFirst) (finalList []map[string]interface{}) {
+	finalList = []map[string]interface{}{}
+	finalMap := dataSourceAddressPrefixCollectionFirstToMap(result)
+	finalList = append(finalList, finalMap)
+
+	return finalList
+}
+
+func dataSourceAddressPrefixCollectionFirstToMap(firstItem vpcv1.AddressPrefixCollectionFirst) (firstMap map[string]interface{}) {
+	firstMap = map[string]interface{}{}
+
+	if firstItem.Href != nil {
+		firstMap["href"] = firstItem.Href
+	}
+
+	return firstMap
+}
+
+func dataSourceAddressPrefixCollectionFlattenNext(result vpcv1.AddressPrefixCollectionNext) (finalList []map[string]interface{}) {
+	finalList = []map[string]interface{}{}
+	finalMap := dataSourceAddressPrefixCollectionNextToMap(result)
+	finalList = append(finalList, finalMap)
+
+	return finalList
+}
+
+func dataSourceAddressPrefixCollectionNextToMap(nextItem vpcv1.AddressPrefixCollectionNext) (nextMap map[string]interface{}) {
+	nextMap = map[string]interface{}{}
+
+	if nextItem.Href != nil {
+		nextMap["href"] = nextItem.Href
+	}
+
+	return nextMap
+}

--- a/ibm/data_source_ibm_is_vpc_address_prefix_test.go
+++ b/ibm/data_source_ibm_is_vpc_address_prefix_test.go
@@ -1,0 +1,41 @@
+// Copyright IBM Corp. 2021 All Rights Reserved.
+// Licensed under the Mozilla Public License v2.0
+
+package ibm
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+func TestAccIbmIsVpcAddressPrefixDataSourceBasic(t *testing.T) {
+	name := fmt.Sprintf("tfvpcuat-%d", acctest.RandIntRange(10, 100))
+	prefixName := fmt.Sprintf("tfaddprename-%d", acctest.RandIntRange(10, 100))
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccCheckIbmIsVpcAddressPrefixDataSourceConfigBasic(name, prefixName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet("data.ibm_is_vpc_address_prefix.is_vpc_address_prefix", "id"),
+					resource.TestCheckResourceAttrSet("data.ibm_is_vpc_address_prefix.is_vpc_address_prefix", "vpc"),
+					resource.TestCheckResourceAttrSet("data.ibm_is_vpc_address_prefix.is_vpc_address_prefix", "address_prefixes.#"),
+					resource.TestCheckResourceAttrSet("data.ibm_is_vpc_address_prefix.is_vpc_address_prefix", "limit"),
+					resource.TestCheckResourceAttrSet("data.ibm_is_vpc_address_prefix.is_vpc_address_prefix", "total_count"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckIbmIsVpcAddressPrefixDataSourceConfigBasic(name, prefixName string) string {
+	return testAccCheckIBMISVPCAddressPrefixConfig(name, prefixName) + fmt.Sprintf(`
+		data "ibm_is_vpc_address_prefixs" "is_vpc_address_prefix" {
+			vpc = "${ibm_is_vpc.testacc_vpc.id}"
+		}
+	`)
+}

--- a/ibm/provider.go
+++ b/ibm/provider.go
@@ -288,6 +288,7 @@ func Provider() *schema.Provider {
 			"ibm_is_volume_profiles":                 dataSourceIBMISVolumeProfiles(),
 			"ibm_is_vpc":                             dataSourceIBMISVPC(),
 			"ibm_is_vpn_gateways":                    dataSourceIBMISVPNGateways(),
+			"ibm_is_vpc_address_prefixs":             dataSourceIbmIsVpcAddressPrefix(),
 			"ibm_is_vpn_gateway_connections":         dataSourceIBMISVPNGatewayConnections(),
 			"ibm_is_vpc_default_routing_table":       dataSourceIBMISVPCDefaultRoutingTable(),
 			"ibm_is_vpc_routing_tables":              dataSourceIBMISVPCRoutingTables(),

--- a/website/docs/d/is_vpc_address_prefix.html.markdown
+++ b/website/docs/d/is_vpc_address_prefix.html.markdown
@@ -1,0 +1,48 @@
+---
+subcategory: "VPC infrastructure"
+layout: "ibm"
+page_title: "IBM : is_vpc_address_prefix"
+description: |-
+  Get information about VPC Address Prefixes
+---
+
+# ibm\_is_vpc_address_prefix
+
+Retrieve information of an existing IBM Cloud AddressPrefixCollection. For more information, about IS VPC address prefix, see [address prefixes](https://cloud.ibm.com/docs/vpc?topic=vpc-vpc-behind-the-curtain#address-prefixes).
+
+
+## Example Usage
+
+```hcl
+data "ibm_is_vpc_address_prefix" "is_vpc_address_prefix_name" {
+  vpc  = "r134-b5938d43-cb2f-4666-bc99-9410863ed305"
+  name = "outsider-sense-motor-chomp"
+}
+```
+
+## Argument Reference
+Review the argument references that you can specify for your data source. 
+
+- `name` - (Optional, string) The user-defined name for this address prefix. Names must be unique within the VPC the address prefix resides in.
+- `vpc`  - (Required, string) The VPC identifier.
+
+## Attribute Reference
+In addition to all argument reference list, you can access the following attribute references after your data source is created.
+
+- `id` - The unique identifier of the AddressPrefixCollection.
+- `total_count` - The total number of resources across all pages.
+- `address_prefixes` - Collection of address prefixes. 
+
+Nested `address_prefixes` blocks have the following structure:
+- `cidr` - The CIDR block for this prefix.
+- `created_at` - The date and time that the prefix was created.
+- `has_subnets` - Indicates whether subnets exist with addresses from this prefix.
+- `href` - The URL for this address prefix.
+- `id` - The unique identifier for this address prefix.
+- `is_default` - Indicates whether this is the default prefix for this zone in this VPC. If a default prefix was automatically created when the VPC was created, the prefix is automatically named using a hyphenated list of randomly-selected words, but may be updated with a user-specified name.
+- `name` - The user-defined name for this address prefix. Names must be unique within the VPC the address prefix resides in.
+- `zone` - The zone this address prefix resides in. 
+
+Nested `zone` blocks have the following structure:
+- `href` - The URL for this zone.
+- `name` - The globally unique name for this zone.


### PR DESCRIPTION
### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

Relates OR Closes #2594 
https://jiracloud.swg.usma.ibm.com:8443/browse/UI-16837

Output from acceptance testing:

<img width="499" alt="Screenshot 2021-06-22 at 2 38 47 PM" src="https://user-images.githubusercontent.com/78336632/122897418-9fbd2f00-d367-11eb-927b-73f7564d0310.png">

```
$ make testacc TEST=./ibm TESTARGS='-run=TestAccIbmIsVpcAddressPrefixDataSourceBasic'
```
