### PR TITLE
feat: adding MD5 authentication key for Direct link Resources, DataSources and Documents

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,7 @@ website/vendor
 *.attach
 *.xml
 *.old
+vendor/
 
 # Test exclusions
 !command/test-fixtures/**/*.tfstate

--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/IBM/ibm-cos-sdk-go v1.7.0
 	github.com/IBM/ibm-cos-sdk-go-config v1.2.0
 	github.com/IBM/keyprotect-go-client v0.7.0
-	github.com/IBM/networking-go-sdk v0.17.0
+	github.com/IBM/networking-go-sdk v0.18.0
 	github.com/IBM/platform-services-go-sdk v0.18.16
 	github.com/IBM/push-notifications-go-sdk v0.0.0-20210310100607-5790b96c47f5
 	github.com/IBM/schematics-go-sdk v0.0.2

--- a/go.sum
+++ b/go.sum
@@ -72,6 +72,8 @@ github.com/IBM/keyprotect-go-client v0.7.0 h1:JstSHD14Lp6ihwQseyPuGcs1AjOBjAmcis
 github.com/IBM/keyprotect-go-client v0.7.0/go.mod h1:SVr2ylV/fhSQPDiUjWirN9fsyWFCNNbt8GIT8hPJVjE=
 github.com/IBM/networking-go-sdk v0.17.0 h1:AkP0aFX8ZfkHT7LDUOD1DtcImZWXqrlTr5eHlCgDcC4=
 github.com/IBM/networking-go-sdk v0.17.0/go.mod h1:nViqUm1Bv+ke8dyOhjQ6e+2U1XeqZX2y4bQbR8Od3Hc=
+github.com/IBM/networking-go-sdk v0.18.0 h1:mlALxXptnoDGviRW59ZQTyCr4PgTdQKp/5ksh2NM6Sk=
+github.com/IBM/networking-go-sdk v0.18.0/go.mod h1:nViqUm1Bv+ke8dyOhjQ6e+2U1XeqZX2y4bQbR8Od3Hc=
 github.com/IBM/platform-services-go-sdk v0.18.16 h1:blYycstPoNtPKtu1uZe240WvzcJENy/Lzx+HMUA8bOo=
 github.com/IBM/platform-services-go-sdk v0.18.16/go.mod h1:awc7TZUeGMlToSeMSaWEz34Knf0lQnuGWumcI4pcuoM=
 github.com/IBM/push-notifications-go-sdk v0.0.0-20210310100607-5790b96c47f5 h1:NPUhkoOCRuv3OFWt19PmwjXGGTKlvmbuPg9fUrBUNe4=

--- a/ibm/data_source_ibm_dl_gateway.go
+++ b/ibm/data_source_ibm_dl_gateway.go
@@ -73,6 +73,11 @@ func dataSourceIBMDLGateway() *schema.Resource {
 				},
 			},
 
+			dlAuthenticationKey: {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "BGP MD5 authentication key",
+			},
 			dlBgpAsn: {
 				Type:        schema.TypeInt,
 				Computed:    true,
@@ -454,6 +459,10 @@ func dataSourceIBMDLGatewayRead(d *schema.ResourceData, meta interface{}) error 
 			if instance.ResourceGroup != nil {
 				rg := instance.ResourceGroup
 				d.Set(dlResourceGroup, *rg.ID)
+			}
+
+			if instance.AuthenticationKey != nil {
+				d.Set(dlAuthenticationKey, *instance.AuthenticationKey.Crn)
 			}
 
 		}

--- a/ibm/data_source_ibm_dl_gateways.go
+++ b/ibm/data_source_ibm_dl_gateways.go
@@ -31,6 +31,11 @@ func dataSourceIBMDLGateways() *schema.Resource {
 							Computed:    true,
 							Description: "Id of the data source gateways",
 						},
+						dlAuthenticationKey: {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "BGP MD5 authentication key",
+						},
 						dlBgpAsn: {
 							Type:        schema.TypeInt,
 							Computed:    true,
@@ -368,6 +373,11 @@ func dataSourceIBMDLGatewaysRead(d *schema.ResourceData, meta interface{}) error
 			gatewayChangeRequest := gatewayChangeRequestIntf.(*directlinkv1.GatewayChangeRequest)
 			gateway[dlChangeRequest] = *gatewayChangeRequest.Type
 		}
+
+		if instance.AuthenticationKey != nil {
+			gateway[dlAuthenticationKey] = *instance.AuthenticationKey.Crn
+		}
+
 		gateways = append(gateways, gateway)
 	}
 	d.SetId(dataSourceIBMDLGatewaysID(d))

--- a/ibm/resource_ibm_dl_gateway.go
+++ b/ibm/resource_ibm_dl_gateway.go
@@ -60,6 +60,7 @@ const (
 	dlGatewayProvisioning          = "configuring"
 	dlGatewayProvisioningDone      = "provisioned"
 	dlGatewayProvisioningRejected  = "create_rejected"
+	dlAuthenticationKey            = "authentication_key"
 )
 
 func resourceIBMDLGateway() *schema.Resource {
@@ -84,6 +85,12 @@ func resourceIBMDLGateway() *schema.Resource {
 		),
 
 		Schema: map[string]*schema.Schema{
+			dlAuthenticationKey: {
+				Type:        schema.TypeString,
+				Optional:    true,
+				ForceNew:    false,
+				Description: "BGP MD5 authentication key",
+			},
 			dlBgpAsn: {
 				Type:        schema.TypeInt,
 				Required:    true,
@@ -503,6 +510,12 @@ func resourceIBMdlGatewayCreate(d *schema.ResourceData, meta interface{}) error 
 			}
 			gatewayDedicatedTemplateModel.MacsecConfig = gatewayMacsecConfigTemplateModel
 		}
+
+		if authKeyCrn, ok := d.GetOk(dlAuthenticationKey); ok {
+			authKeyCrnStr := authKeyCrn.(string)
+			gatewayDedicatedTemplateModel.AuthenticationKey = &directlinkv1.GatewayTemplateAuthenticationKey{Crn: &authKeyCrnStr}
+		}
+
 		createGatewayOptionsModel.GatewayTemplate = gatewayDedicatedTemplateModel
 
 	} else if dtype == "connect" {
@@ -533,6 +546,12 @@ func resourceIBMdlGatewayCreate(d *schema.ResourceData, meta interface{}) error 
 				gatewayConnectTemplateModel.ResourceGroup = &directlinkv1.ResourceGroupIdentity{ID: &resourceGroup}
 
 			}
+
+			if authKeyCrn, ok := d.GetOk(dlAuthenticationKey); ok {
+				authKeyCrnStr := authKeyCrn.(string)
+				gatewayConnectTemplateModel.AuthenticationKey = &directlinkv1.GatewayTemplateAuthenticationKey{Crn: &authKeyCrnStr}
+			}
+
 			createGatewayOptionsModel.GatewayTemplate = gatewayConnectTemplateModel
 
 		} else {
@@ -665,6 +684,9 @@ func resourceIBMdlGatewayRead(d *schema.ResourceData, meta interface{}) error {
 	}
 	if instance.CreatedAt != nil {
 		d.Set(dlCreatedAt, instance.CreatedAt.String())
+	}
+	if instance.AuthenticationKey != nil {
+		d.Set(dlAuthenticationKey, *instance.AuthenticationKey.Crn)
 	}
 	if dtype == "dedicated" {
 		if instance.MacsecConfig != nil {
@@ -835,6 +857,13 @@ func resourceIBMdlGatewayUpdate(d *schema.ResourceData, meta interface{}) error 
 		metered := d.Get(dlMetered).(bool)
 		updateGatewayOptionsModel.Metered = &metered
 	}
+	if d.HasChange(dlAuthenticationKey) {
+		authenticationKeyCrn := d.Get(dlAuthenticationKey).(string)
+		authenticationKeyPatchTemplate := new(directlinkv1.GatewayPatchTemplateAuthenticationKey)
+		authenticationKeyPatchTemplate.Crn = &authenticationKeyCrn
+		updateGatewayOptionsModel = updateGatewayOptionsModel.SetAuthenticationKey(authenticationKeyPatchTemplate)
+	}
+
 	if dtype == "dedicated" {
 		if d.HasChange(dlMacSecConfig) && !d.IsNewResource() {
 			// Construct an instance of the GatewayMacsecConfigTemplate model

--- a/website/docs/d/dl_gateway.html.markdown
+++ b/website/docs/d/dl_gateway.html.markdown
@@ -29,6 +29,7 @@ Review the argument reference that you can specify for your resource.
 ## Attribute reference
 In addition to the argument reference list, you can access the following attribute references after your data source is created.
 
+- `authentication_key` - (String) BGP MD5 authentication key.
 - `bgp_asn` - (String) Customer BGP ASN.
 - `bgp_base_cidr` - (String) The BGP base CIDR.
 - `bgp_cer_cidr` - (String) The BGP customer edge router CIDR.

--- a/website/docs/d/dl_gateways.html.markdown
+++ b/website/docs/d/dl_gateways.html.markdown
@@ -29,6 +29,7 @@ You can access the following attribute references after your data source is crea
 - `gateways` - (String) List of all the Direct Link Gateways in the IBM Cloud infrastructure.
 
   Nested scheme for `gateways`:
+  - `authentication_key` - (String) BGP MD5 authentication key.
   - `bgp_asn` - (String) Customer BGP ASN.
   - `bgp_base_cidr` - (String) The BGP base CIDR.
   - `bgp_cer_cidr` - (String) The BGP customer edge router CIDR.

--- a/website/docs/r/dl_gateway.html.markdown
+++ b/website/docs/r/dl_gateway.html.markdown
@@ -58,6 +58,7 @@ resource "ibm_dl_gateway" "test_dl_connect" {
 ## Argument reference
 Review the argument reference that you can specify for your resource. 
 
+- `authentication_key` - (Optional, String) BGP MD5 authentication key.
 - `bgp_asn`- (Required, Forces new resource, Integer) The BGP ASN of the gateway to be created. For example, `64999`.
 - `bgp_base_cidr` - (Optional, String) (Deprecated) The BGP base CIDR of the gateway to be created. See `bgp_ibm_cidr` and `bgp_cer_cidr` for details on how to create a gateway by using  automatic or explicit IP assignment. Any `bgp_base_cidr` value set will be ignored.
 - `bgp_cer_cidr` - (Optional, Forces new resource, String) The BGP customer edge router CIDR. Specify a value within `bgp_base_cidr`.  For auto IP assignment, omit `bgp_cer_cidr` and `bgp_ibm_cidr`. IBM will automatically select values for `bgp_cer_cidr` and `bgp_ibm_cidr`.


### PR DESCRIPTION
### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

Output from acceptance testing:

```
$ make testacc TEST=./ibm TESTARGS='-run=TestAccIBMDLGateway_basic'

==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./ibm -run=TestAccIBMDLGateway_basic -timeout 700m
ok  	github.com/IBM-Cloud/terraform-provider-ibm/ibm	70.421s
```

```
$ make testacc TEST=./ibm TESTARGS='-run=TestAccIBMDLGatewayConnect_basic'    
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./ibm -run=TestAccIBMDLGatewayConnect_basic -timeout 700m
ok  	github.com/IBM-Cloud/terraform-provider-ibm/ibm	135.526s
```

```
$ make testacc TEST=./ibm TESTARGS='-run=TestAccIBMDLGatewayDataSource_basic' 
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./ibm -run=TestAccIBMDLGatewayDataSource_basic -timeout 700m
ok  	github.com/IBM-Cloud/terraform-provider-ibm/ibm	90.479s
```

```
$ make testacc TEST=./ibm TESTARGS='-run=TestAccIBMDLGatewaysDataSource_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./ibm -run=TestAccIBMDLGatewaysDataSource_basic -timeout 700m
ok  	github.com/IBM-Cloud/terraform-provider-ibm/ibm	96.848s
```

