### PR TITLE
Fix: Id of database in error

### DIFF
--- a/ibm/resource_ibm_database.go
+++ b/ibm/resource_ibm_database.go
@@ -1044,7 +1044,7 @@ func resourceIBMDatabaseInstanceCreate(d *schema.ResourceData, meta interface{})
 	_, err = waitForDatabaseInstanceCreate(d, meta, *instance.ID)
 	if err != nil {
 		return fmt.Errorf(
-			"Error waiting for create database instance (%s) to complete: %s", d.Id(), err)
+			"Error waiting for create database instance (%s) to complete: %s", *instance.ID, err)
 	}
 
 	d.SetId(*instance.ID)
@@ -1841,7 +1841,7 @@ func waitForDatabaseInstanceCreate(d *schema.ResourceData, meta interface{}, ins
 				ID: &instanceID,
 			}
 			instance, response, err := rsConClient.GetResourceInstance(&rsInst)
-			if err != nil {
+			if err != nil || instance == nil {
 				if apiErr, ok := err.(bmxerror.RequestFailure); ok && apiErr.StatusCode() == 404 {
 					return nil, "", fmt.Errorf("The resource instance %s does not exist anymore: %v %s", d.Id(), err, response)
 				}


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/IBM-Cloud/terraform-provider-ibm/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->


Id is set after the wait logic so d.Id() will not work in the error