### PR TITLE
Fix: Resource group crash

### DIFF
--- a/ibm/data_source_ibm_resource_group.go
+++ b/ibm/data_source_ibm_resource_group.go
@@ -17,16 +17,16 @@ func dataSourceIBMResourceGroup() *schema.Resource {
 
 		Schema: map[string]*schema.Schema{
 			"name": {
-				Description:   "Resource group name",
-				Type:          schema.TypeString,
-				Optional:      true,
-				ConflictsWith: []string{"is_default"},
+				Description:  "Resource group name",
+				Type:         schema.TypeString,
+				Optional:     true,
+				ExactlyOneOf: []string{"is_default", "name"},
 			},
 			"is_default": {
-				Description:   "Default Resource group",
-				Type:          schema.TypeBool,
-				Optional:      true,
-				ConflictsWith: []string{"name"},
+				Description:  "Default Resource group",
+				Type:         schema.TypeBool,
+				Optional:     true,
+				ExactlyOneOf: []string{"is_default", "name"},
 			},
 		},
 	}
@@ -62,7 +62,10 @@ func dataSourceIBMResourceGroupRead(d *schema.ResourceData, meta interface{}) er
 		grp, err = rsGroup.List(&resourceGroupQuery)
 
 		if err != nil {
-			return fmt.Errorf("Error retrieving default resource group: %s", err)
+			return fmt.Errorf("[ERROR] Error retrieving default resource group: %s", err)
+		}
+		if len(grp) < 1 {
+			return fmt.Errorf("[ERROR] No Default resource group found: %s", err)
 		}
 		d.SetId(grp[0].ID)
 
@@ -72,12 +75,10 @@ func dataSourceIBMResourceGroupRead(d *schema.ResourceData, meta interface{}) er
 		}
 		grp, err := rsGroup.FindByName(resourceGroupQuery, name)
 		if err != nil {
-			return fmt.Errorf("Error retrieving resource group %s: %s", name, err)
+			return fmt.Errorf("[ERROR] Error retrieving resource group %s: %s", name, err)
 		}
 		d.SetId(grp[0].ID)
 
-	} else {
-		return fmt.Errorf("Missing required properties. Need a resource group name, or the is_default true")
 	}
 
 	return nil


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/IBM-Cloud/terraform-provider-ibm/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #2808 

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
=== RUN   TestAccIBMResourceGroupDataSource_Basic
--- PASS: TestAccIBMResourceGroupDataSource_Basic (38.58s)
PASS
ok  	github.com/IBM-Cloud/terraform-provider-ibm/ibm	40.710s
...
```
