### PR TITLE
fix: set required cluster_name_id attribute

### DIFF
--- a/ibm/resource_ibm_container_bind_service.go
+++ b/ibm/resource_ibm_container_bind_service.go
@@ -203,6 +203,7 @@ func resourceIBMContainerBindServiceRead(d *schema.ResourceData, meta interface{
 
 	d.Set("service_instance_name", boundService.ServiceName)
 	d.Set("service_instance_id", boundService.ServiceID)
+	d.Set("cluster_name_id", clusterNameID)
 	//d.Set(key, boundService.ServiceKeyName)
 	//d.Set(key, boundService.ServiceName)
 	return nil

--- a/ibm/resource_ibm_container_bind_service_test.go
+++ b/ibm/resource_ibm_container_bind_service_test.go
@@ -23,8 +23,8 @@ func TestAccIBMContainerBindServiceBasic(t *testing.T) {
 			{
 				Config: testAccCheckIBMContainerBindServiceBasic(clusterName, serviceName),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(
-						"ibm_container_bind_service.bind_service", "namespace_id", "default"),
+					resource.TestCheckResourceAttr("ibm_container_bind_service.bind_service", "namespace_id", "default"),
+					resource.TestCheckResourceAttrSet("ibm_container_bind_service.bind_service", "cluster_name_id"),
 				),
 			},
 			{


### PR DESCRIPTION
# ibm_container_bind_service import functionality is broken

It was not setting required `cluster_name_id` property and so after import terraform was flagging all bindings to be re-created due to "new" `cluster_name_id` setting. I double checked terraform state after import and all resources had `null` for `cluster_name_id`

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

## Terraform CLI Version
```bash
Terraform v0.15.4
on darwin_amd64
```

Output from acceptance testing (looks like it requires paid account to run tests):

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccIBMContainerBindServiceBasic'

=== RUN   TestAccIBMContainerBindServiceBasic
    resource_ibm_container_bind_service_test.go:19: Step 1/2 error: Error running apply: exit status 1
        
        Error: Request failed with status code: 401, ServerErrorResponse: {"incidentID":"9a465202-7a7e-49cf-a2a0-992be7b42221,9a465202-7a7e-49cf-a2a0-992be7b42221","code":"A0012","description":"The IBM Cloud Infrastructure credentials could not be validated.","type":"Authentication"}
        
          with ibm_container_cluster.testacc_cluster,
          on terraform_plugin_test.tf line 3, in resource "ibm_container_cluster" "testacc_cluster":
           3: resource "ibm_container_cluster" "testacc_cluster" {
        
        
        Error: Error when creating resource instance: This plan requires a paid account. You can upgrade by adding a credit card to your account or you can select the free plan if it's available. with resp code: {
            "StatusCode": 400,
            "Headers": {
                "Cache-Control": [
                    "max-age=0, no-cache, no-store"
                ],
                "Content-Length": [
                    "214"
                ],
                "Content-Type": [
                    "application/json; charset=utf-8"
                ],
                "Date": [
                    "Mon, 12 Jul 2021 18:54:57 GMT"
                ],
                "Expires": [
                    "Mon, 12 Jul 2021 18:54:57 GMT"
                ],
                "Pragma": [
                    "no-cache"
                ],
                "Request-Id": [
                    "bss-8d6aa7e67f19f5ad"
                ],
                "Retry-After": [
                    "0"
                ],
                "Server": [
                    "istio-envoy"
                ],
                "Set-Cookie": [
                    "ak_bmsc=2A783D63F1722F28E9F38955492F143E~000000000000000000000000000000~YAAQzyABF/eTbIV6AQAAJoUSnAzF3OY/lAzBHU3f66dkexOAkruHKred8tec+/kUisJ03E6S84WcsOlHN3ZSS8COM0S5fHeVANQH8zJT3DgKGrYB67GVFV2ZwTXEl6qzHqJHptXXn7yZdK6AxI4JtQrx7jdaUog4P43LA0dIXHQ4sSGZQ3vPZAJEZB79MCb/Kh3+fqeY2nvI9mGEWRZqYXq5Wba97rnl3OqYdModeE6xiIDSnBw+wLEuBqdVXjN5UcFOAKB4thPdidW5JU5khi2550o6+tg80JaAHotQJtvQwMr20/xCmn33UsxY2WlKOmdK3UOSK+pnkeGktsut6XjN7pV/jrXmeiqupiDxc7hjbKnUQqp7vKSMuY8t00izcFNUJ/ivJr7M30BZ0WA=; Domain=.cloud.ibm.com; Path=/; Expires=Mon, 12 Jul 2021 20:54:55 GMT; Max-Age=7198; HttpOnly"
                ],
                "Strict-Transport-Security": [
                    "max-age=31536000;includeSubDomains"
                ],
                "Transaction-Id": [
                    "bss-8d6aa7e67f19f5ad"
                ],
                "X-Content-Type-Options": [
                    "nosniff"
                ],
                "X-Envoy-Upstream-Service-Time": [
                    "1726"
                ],
                "X-Global-K8fdic-Transaction-Id": [
                    "bss-8d6aa7e67f19f5ad"
                ],
                "X-Global-Transaction-Id": [
                    "bss-8d6aa7e67f19f5ad"
                ],
                "X-Op-Completion-Time": [
                    ""
                ],
                "X-Ratelimit-Limit": [
                    "120"
                ],
                "X-Ratelimit-Remaining": [
                    "119"
                ],
                "X-Ratelimit-Reset": [
                    "0"
                ],
                "X-Request-Id": [
                    "bss-8d6aa7e67f19f5ad"
                ],
                "X-Transaction-Id": [
                    "bss-8d6aa7e67f19f5ad"
                ]
            },
            "Result": {
                "message": "This plan requires a paid account. You can upgrade by adding a credit card to your account or you can select the free plan if it's available.",
                "status_code": 400,
                "transaction_id": "bss-8d6aa7e67f19f5ad"
            },
            "RawResult": null
        }
        
        
          with ibm_resource_instance.cos_instance,
          on terraform_plugin_test.tf line 13, in resource "ibm_resource_instance" "cos_instance":
          13: resource "ibm_resource_instance" "cos_instance" {
        
--- FAIL: TestAccIBMContainerBindServiceBasic (25.62s)
FAIL
FAIL    github.com/IBM-Cloud/terraform-provider-ibm/ibm 27.320s
testing: warning: no tests to run
PASS
ok      github.com/IBM-Cloud/terraform-provider-ibm/ibm/internal/hashcode       (cached) [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/IBM-Cloud/terraform-provider-ibm/ibm/internal/mutexkv        (cached) [no tests to run]
?       github.com/IBM-Cloud/terraform-provider-ibm/version     [no test files]
FAIL
make: *** [testacc] Error 1
...
```
