### PR TITLE
IS Volume - Access management tags

### DIFF
--- a/ibm/data_source_ibm_is_volume.go
+++ b/ibm/data_source_ibm_is_volume.go
@@ -102,6 +102,14 @@ func dataSourceIBMISVolume() *schema.Resource {
 				Description: "Tags for the volume instance",
 			},
 
+			isVolumeAccessTags: {
+				Type:        schema.TypeSet,
+				Computed:    true,
+				Elem:        &schema.Schema{Type: schema.TypeString},
+				Set:         resourceIBMVPCHash,
+				Description: "Access management tags for the volume instance",
+			},
+
 			ResourceControllerURL: {
 				Type:        schema.TypeString,
 				Computed:    true,
@@ -286,12 +294,23 @@ func volumeGet(d *schema.ResourceData, meta interface{}, name string) error {
 			}
 			d.Set(isVolumeStatusReasons, statusReasonsList)
 		}
-		tags, err := GetTagsUsingCRN(meta, *vol.CRN)
+		var rType string
+		if v, ok := d.GetOk("resource_type"); ok && v != nil {
+			rType = v.(string)
+		}
+
+		tags, err := GetGlobalTagsUsingCRN(meta, *vol.CRN, rType, isVolumeUserTagType)
 		if err != nil {
 			log.Printf(
 				"Error on get of resource vpc volume (%s) tags: %s", d.Id(), err)
 		}
 		d.Set(isVolumeTags, tags)
+		accesstags, err := GetGlobalTagsUsingCRN(meta, *vol.CRN, rType, isVolumeAccessTagType)
+		if err != nil {
+			log.Printf(
+				"Error on get of resource vpc volume (%s) access tags: %s", d.Id(), err)
+		}
+		d.Set(isVolumeAccessTags, accesstags)
 		controller, err := getBaseController(meta)
 		if err != nil {
 			return err

--- a/ibm/structures.go
+++ b/ibm/structures.go
@@ -1840,9 +1840,14 @@ func UpdateGlobalTagsUsingCRN(oldList, newList interface{}, meta interface{}, re
 	}
 
 	if len(remove) > 0 {
-		detachTagOptions := &globaltaggingv1.DetachTagOptions{
-			Resources: resources,
-			TagNames:  remove,
+		detachTagOptions := &globaltaggingv1.DetachTagOptions{}
+		detachTagOptions.Resources = resources
+		detachTagOptions.TagNames = remove
+		if len(tagType) > 0 {
+			detachTagOptions.TagType = ptrToString(tagType)
+			if tagType == service {
+				detachTagOptions.AccountID = ptrToString(acctID)
+			}
 		}
 
 		_, resp, err := gtClient.DetachTag(detachTagOptions)

--- a/website/docs/d/is_volume.html.markdown
+++ b/website/docs/d/is_volume.html.markdown
@@ -33,6 +33,7 @@ Review the argument references that you can specify for your data source.
 ## Attribute reference
 In addition to all argument reference list, you can access the following attribute references after your data source is created.
 
+- `access_tags`  - (String) Access management tags associated for the instance.
 - `capacity` - (String) The capacity of the volume in gigabytes.
 - `encryption_key` - (String) The key to use for encrypting this volume.
 - `iops` - (String) The bandwidth for the volume.

--- a/website/docs/r/is_volume.html.markdown
+++ b/website/docs/r/is_volume.html.markdown
@@ -45,6 +45,7 @@ The `ibm_is_volume` resource provides the following [Timeouts](https://www.terra
 ## Argument reference
 Review the argument references that you can specify for your resource. 
 
+- `access_tags` - (Optional, List of Strings) A list of access management tags for the volume. **Note** Currently we are supporting only the existing tags attachement.
 - `capacity` - (Optional, Forces new resource, Integer) (The capacity of the volume in gigabytes. This defaults to `100`.
 - `encryption_key` - (Optional, Forces new resource, String) The key to use for encrypting this volume.
 - `iops` - (Optional, Forces new resource, Integer) The total input/ output operations per second (IOPS) for your storage. This value is required for `custom` storage profiles only.


### PR DESCRIPTION
IS Volume - Added support for AccessManagement tags

<!--- See what makes a good Pull Request at : https://github.com/IBM-Cloud/terraform-provider-ibm/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```
