### PR TITLE
bug: added a null check for default names in is_vpc datasource

### DIFF
--- a/ibm/data_source_ibm_is_vpc.go
+++ b/ibm/data_source_ibm_is_vpc.go
@@ -310,19 +310,21 @@ func vpcGetByName(d *schema.ResourceData, meta interface{}, name string) error {
 			d.Set(isVPCName, *vpc.Name)
 			d.Set(isVPCClassicAccess, *vpc.ClassicAccess)
 			d.Set(isVPCStatus, *vpc.Status)
-			d.Set(isVPCResourceGroup, *vpc.ResourceGroup.ID)
-			d.Set(isVPCDefaultNetworkACLName, *vpc.DefaultNetworkACL.Name)
-			d.Set(isVPCDefaultRoutingTableName, *vpc.DefaultRoutingTable.Name)
-			d.Set(isVPCDefaultSecurityGroupName, *vpc.DefaultSecurityGroup.Name)
+			if vpc.ResourceGroup != nil {
+				d.Set(isVPCResourceGroup, *vpc.ResourceGroup.ID)
+			}
 			if vpc.DefaultNetworkACL != nil {
+				d.Set(isVPCDefaultNetworkACLName, *vpc.DefaultNetworkACL.Name)
 				d.Set(isVPCDefaultNetworkACL, *vpc.DefaultNetworkACL.ID)
 			} else {
 				d.Set(isVPCDefaultNetworkACL, nil)
 			}
 			if vpc.DefaultRoutingTable != nil {
+				d.Set(isVPCDefaultRoutingTableName, *vpc.DefaultRoutingTable.Name)
 				d.Set(isVPCDefaultRoutingTable, *vpc.DefaultRoutingTable.ID)
 			}
 			if vpc.DefaultSecurityGroup != nil {
+				d.Set(isVPCDefaultSecurityGroupName, *vpc.DefaultSecurityGroup.Name)
 				d.Set(isVPCDefaultSecurityGroup, *vpc.DefaultSecurityGroup.ID)
 			} else {
 				d.Set(isVPCDefaultSecurityGroup, nil)


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/IBM-Cloud/terraform-provider-ibm/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```
