### PR TITLE
Correction to VPC address prefixes

### DIFF
--- a/examples/ibm-is-ng/main.tf
+++ b/examples/ibm-is-ng/main.tf
@@ -2,6 +2,14 @@ resource "ibm_is_vpc" "vpc1" {
   name = "vpc1"
 }
 
+resource "ibm_is_vpc_address_prefix" "testacc_vpc_address_prefix" {
+  name        = "vpcaddressprefix"
+  zone        = var.zone1
+  vpc         = ibm_is_vpc.vpc1.id
+	cidr        = var.cidr1
+	is_default  = true
+}
+
 resource "ibm_is_vpc_route" "route1" {
   name        = "route1"
   vpc         = ibm_is_vpc.vpc1.id

--- a/examples/ibm-is-ng/variables.tf
+++ b/examples/ibm-is-ng/variables.tf
@@ -26,3 +26,6 @@ variable "image_operating_system" {
   default = "red-7-amd64"
 }
 
+variable "cidr1" {
+  default = "10.120.0.0/24"
+}

--- a/ibm/data_source_ibm_is_vpc_address_prefixes_test.go
+++ b/ibm/data_source_ibm_is_vpc_address_prefixes_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 )
 
-func TestAccIbmIsVpcAddressPrefixDataSourceBasic(t *testing.T) {
+func TestAccIbmIsVpcAddressPrefixesDataSourceBasic(t *testing.T) {
 	name := fmt.Sprintf("tfvpcuat-%d", acctest.RandIntRange(10, 100))
 	prefixName := fmt.Sprintf("tfaddprename-%d", acctest.RandIntRange(10, 100))
 	resource.Test(t, resource.TestCase{
@@ -21,11 +21,9 @@ func TestAccIbmIsVpcAddressPrefixDataSourceBasic(t *testing.T) {
 			resource.TestStep{
 				Config: testAccCheckIbmIsVpcAddressPrefixDataSourceConfigBasic(name, prefixName),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttrSet("data.ibm_is_vpc_address_prefix.is_vpc_address_prefix", "id"),
-					resource.TestCheckResourceAttrSet("data.ibm_is_vpc_address_prefix.is_vpc_address_prefix", "vpc"),
-					resource.TestCheckResourceAttrSet("data.ibm_is_vpc_address_prefix.is_vpc_address_prefix", "address_prefixes.#"),
-					resource.TestCheckResourceAttrSet("data.ibm_is_vpc_address_prefix.is_vpc_address_prefix", "limit"),
-					resource.TestCheckResourceAttrSet("data.ibm_is_vpc_address_prefix.is_vpc_address_prefix", "total_count"),
+					resource.TestCheckResourceAttrSet("data.ibm_is_vpc_address_prefixes.is_vpc_address_prefix", "id"),
+					resource.TestCheckResourceAttrSet("data.ibm_is_vpc_address_prefixes.is_vpc_address_prefix", "vpc"),
+					resource.TestCheckResourceAttrSet("data.ibm_is_vpc_address_prefixes.is_vpc_address_prefix", "address_prefixes.#"),
 				),
 			},
 		},
@@ -34,7 +32,7 @@ func TestAccIbmIsVpcAddressPrefixDataSourceBasic(t *testing.T) {
 
 func testAccCheckIbmIsVpcAddressPrefixDataSourceConfigBasic(name, prefixName string) string {
 	return testAccCheckIBMISVPCAddressPrefixConfig(name, prefixName) + fmt.Sprintf(`
-		data "ibm_is_vpc_address_prefixs" "is_vpc_address_prefix" {
+		data "ibm_is_vpc_address_prefixes" "is_vpc_address_prefix" {
 			vpc = "${ibm_is_vpc.testacc_vpc.id}"
 		}
 	`)

--- a/ibm/provider.go
+++ b/ibm/provider.go
@@ -293,7 +293,7 @@ func Provider() *schema.Provider {
 			"ibm_is_volume_profiles":                 dataSourceIBMISVolumeProfiles(),
 			"ibm_is_vpc":                             dataSourceIBMISVPC(),
 			"ibm_is_vpn_gateways":                    dataSourceIBMISVPNGateways(),
-			"ibm_is_vpc_address_prefixs":             dataSourceIbmIsVpcAddressPrefix(),
+			"ibm_is_vpc_address_prefixes":            dataSourceIbmIsVpcAddressPrefixes(),
 			"ibm_is_vpn_gateway_connections":         dataSourceIBMISVPNGatewayConnections(),
 			"ibm_is_vpc_default_routing_table":       dataSourceIBMISVPCDefaultRoutingTable(),
 			"ibm_is_vpc_routing_tables":              dataSourceIBMISVPCRoutingTables(),

--- a/website/docs/d/is_vpc_address_prefixes.html.markdown
+++ b/website/docs/d/is_vpc_address_prefixes.html.markdown
@@ -14,7 +14,7 @@ Retrieve information of an existing IBM Cloud AddressPrefixCollection. For more 
 ## Example Usage
 
 ```hcl
-data "ibm_is_vpc_address_prefix" "is_vpc_address_prefix_name" {
+data "ibm_is_vpc_address_prefixes" "is_vpc_address_prefix_name" {
   vpc  = "r134-b5938d43-cb2f-4666-bc99-9410863ed305"
   name = "outsider-sense-motor-chomp"
 }
@@ -29,13 +29,13 @@ Review the argument references that you can specify for your data source.
 ## Attribute Reference
 In addition to all argument reference list, you can access the following attribute references after your data source is created.
 
+- `address_prefixes` - Collection of address prefixes. 
 - `id` - The unique identifier of the AddressPrefixCollection.
 - `total_count` - The total number of resources across all pages.
-- `address_prefixes` - Collection of address prefixes. 
 
 Nested `address_prefixes` blocks have the following structure:
-- `cidr` - The CIDR block for this prefix.
 - `created_at` - The date and time that the prefix was created.
+- `cidr` - The CIDR block for this prefix.
 - `has_subnets` - Indicates whether subnets exist with addresses from this prefix.
 - `href` - The URL for this address prefix.
 - `id` - The unique identifier for this address prefix.


### PR DESCRIPTION
### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

Relates OR Closes #0000

Output from acceptance testing:
<img width="766" alt="Screenshot 2021-07-15 at 1 52 28 PM" src="https://user-images.githubusercontent.com/78336632/125754715-215c7395-7bc3-40d5-803a-625177e3005a.png">


```
$ make testacc TEST=./ibm TESTARGS='-run=TestAccIbmIsVpcAddressPrefixesDataSourceBasic'

```
