### PR TITLE
force new floating ip when there is a change in target zone

### DIFF
--- a/ibm/resource_ibm_is_floating_ip.go
+++ b/ibm/resource_ibm_is_floating_ip.go
@@ -45,10 +45,27 @@ func resourceIBMISFloatingIP() *schema.Resource {
 			Delete: schema.DefaultTimeout(10 * time.Minute),
 		},
 
-		CustomizeDiff: customdiff.Sequence(
-			func(_ context.Context, diff *schema.ResourceDiff, v interface{}) error {
-				return resourceTagsCustomizeDiff(diff)
-			},
+		CustomizeDiff: customdiff.All(
+			customdiff.Sequence(
+				func(_ context.Context, diff *schema.ResourceDiff, v interface{}) error {
+					return resourceTagsCustomizeDiff(diff)
+				},
+			),
+			customdiff.Sequence(
+				func(_ context.Context, diff *schema.ResourceDiff, v interface{}) error {
+					if diff.HasChange(isFloatingIPTarget) {
+						old, new := diff.GetChange(isFloatingIPTarget)
+						sess, err := vpcClient(v)
+						if err != nil {
+							return err
+						}
+						if checkIfZoneChanged(old.(string), new.(string), sess) {
+							diff.ForceNew(isFloatingIPTarget)
+						}
+					}
+					return nil
+				},
+			),
 		),
 
 		Schema: map[string]*schema.Schema{
@@ -493,4 +510,41 @@ func isInstanceFloatingIPRefreshFunc(floatingipC *vpcv1.VpcV1, id string) resour
 
 		return instance, isFloatingIPPending, nil
 	}
+}
+
+func checkIfZoneChanged(oldNic, newNic string, floatingipC *vpcv1.VpcV1) bool {
+	var oldZone, newZone string
+	listInstancesOptions := &vpcv1.ListInstancesOptions{}
+	start := ""
+	allrecs := []vpcv1.Instance{}
+	for {
+
+		if start != "" {
+			listInstancesOptions.Start = &start
+		}
+
+		instances, _, err := floatingipC.ListInstances(listInstancesOptions)
+		if err != nil {
+			return false
+		}
+		start = GetNext(instances.Next)
+		allrecs = append(allrecs, instances.Instances...)
+		if start == "" {
+			break
+		}
+	}
+	for _, instance := range allrecs {
+		for _, nic := range instance.NetworkInterfaces {
+			if oldNic == *nic.ID {
+				oldZone = *instance.Zone.Name
+			}
+			if newNic == *nic.ID {
+				newZone = *instance.Zone.Name
+			}
+		}
+	}
+	if newZone != oldZone {
+		return true
+	}
+	return false
 }

--- a/website/docs/r/is_floating_ip.html.markdown
+++ b/website/docs/r/is_floating_ip.html.markdown
@@ -49,9 +49,9 @@ Review the argument references that you can specify for your resource.
 
 - `name` - (Required, String) Enter a name for the floating IP address. 
 - `resource_group` - (Optional, String) The resource group ID where you want to create the floating IP.
-- `target` - (Optional, String) Enter the ID of the network interface that you want to use to allocate the IP address. If you specify this option, do not specify `zone` at the same time. **Note** conflicts with `zone`.
+- `target` - (Optional, String) Enter the ID of the network interface that you want to use to allocate the IP address. If you specify this option, do not specify `zone` at the same time. **Note** conflicts with `zone`. A change in `target` which is in a different `zone` will show a change to replace current floating ip with a new one.
 - `tags` (Optional, Array of Strings) Enter any tags that you want to associate with your VPC. Tags might help you find your VPC more easily after it is created. Separate multiple tags with a comma (`,`).
-- `zone` - (Optional, String) Enter the name of the zone where you want to create the floating IP address. To list available zones, run `ibmcloud is zones`. If you specify this option, do not specify `target` at the same time. **Note** Conflicts with `target` and one of `target`, or `zone` is mandatory.
+- `zone` - (Optional, Force New Resource, String) Enter the name of the zone where you want to create the floating IP address. To list available zones, run `ibmcloud is zones`. If you specify this option, do not specify `target` at the same time. **Note** Conflicts with `target` and one of `target`, or `zone` is mandatory.
 
 
 ## Attribute reference


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/IBM-Cloud/terraform-provider-ibm/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #2911

Output :

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
ibm_is_floating_ip.this: Refreshing state... [id=xxxx-xxxx-xxxx-xxxxx-xxxxxx-xxx]

Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
-/+ destroy and then create replacement

Terraform will perform the following actions:

  # ibm_is_floating_ip.this must be replaced
-/+ resource "ibm_is_floating_ip" "this" {
      ~ address                 = "xxxx-xxxx-xxxx-xxxxx-xxxxxx-xxx" -> (known after apply)
      ~ id                      = "xxxx-xxxx-xxxx-xxxxx-xxxxxx-xxx" -> (known after apply)
        name                    = "fip1"
      ~ resource_controller_url = "xxxx-xxxx-xxxx-xxxxx-xxxxxx-xxx" -> (known after apply)
      ~ resource_crn            = "xxxx-xxxx-xxxx-xxxxx-xxxxxx-xxx" -> (known after apply)
      ~ resource_group          = "xxxx-xxxx-xxxx-xxxxx-xxxxxx-xxx" -> (known after apply)
      ~ resource_group_name     = "Default" -> (known after apply)
      ~ resource_name           = "fip1" -> (known after apply)
      ~ resource_status         = "available" -> (known after apply)
      ~ status                  = "available" -> (known after apply)
      ~ tags                    = [] -> (known after apply)
      ~ target                  = "xxxx-xxxx-xxxx-xxxxx-xxxxxx-xxx" -> "xxxx-xxxx-xxxx-xxxxx-xxxxxx-xxx" # forces replacement
      ~ zone                    = "us-south-2" -> (known after apply)
    }

Plan: 1 to add, 0 to change, 1 to destroy.

```
