### PR TITLE
VPE gateway creation suppresses error message

### DIFF
--- a/ibm/resource_ibm_is_virtual_endpoint_gateway.go
+++ b/ibm/resource_ibm_is_virtual_endpoint_gateway.go
@@ -254,7 +254,7 @@ func resourceIBMisVirtualEndpointGatewayCreate(d *schema.ResourceData, meta inte
 	result, response, err := sess.CreateEndpointGateway(opt)
 	if err != nil {
 		log.Printf("Create Endpoint Gateway failed: %v", response)
-		return err
+		return fmt.Errorf("Create Endpoint Gateway failed %s\n%s", err, response)
 	}
 
 	d.SetId(*result.ID)
@@ -287,7 +287,7 @@ func resourceIBMisVirtualEndpointGatewayUpdate(d *schema.ResourceData, meta inte
 		_, response, err := sess.UpdateEndpointGateway(opt)
 		if err != nil {
 			log.Printf("Update Endpoint Gateway failed: %v", response)
-			return err
+			return fmt.Errorf("Update Endpoint Gateway failed : %s\n%s", err, response)
 		}
 
 	}
@@ -316,8 +316,12 @@ func resourceIBMisVirtualEndpointGatewayRead(d *schema.ResourceData, meta interf
 	opt := sess.NewGetEndpointGatewayOptions(d.Id())
 	result, response, err := sess.GetEndpointGateway(opt)
 	if err != nil {
+		if response != nil && response.StatusCode == 404 {
+			d.SetId("")
+			return nil
+		}
 		log.Printf("Get Endpoint Gateway failed: %v", response)
-		return err
+		return fmt.Errorf("Get Endpoint Gateway failed %s\n%s", err, response)
 	}
 	d.Set(isVirtualEndpointGatewayName, result.Name)
 	d.Set(isVirtualEndpointGatewayHealthState, result.HealthState)
@@ -348,6 +352,7 @@ func resourceIBMisVirtualEndpointGatewayDelete(d *schema.ResourceData, meta inte
 	response, err := sess.DeleteEndpointGateway(opt)
 	if err != nil {
 		log.Printf("Delete Endpoint Gateway failed: %v", response)
+		return fmt.Errorf("Delete Endpoint Gateway failed : %s\n%s", err, response)
 	}
 	return nil
 }


### PR DESCRIPTION
### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

Closes #2923 

Output from acceptance testing:
<img width="1266" alt="Screenshot 2021-08-09 at 11 52 54 AM" src="https://user-images.githubusercontent.com/78336632/128667043-a7fd13f5-76c1-4a78-b372-af8c7c3e9578.png">


Run the below test with very long ips name
ips  {
       subnet   =  "0726-2f03f187-5854-4f10-80f0-4e57b7c0442f"
       name        = "test-reserved-ip1-hi-what-is-the-error-i-dont-know-test-reserved-ip1-hi-what-is-the-error-i-dont-know-test-reserved-ip1-hi-what-is-the-error-i-dont-know-test-reserved-ip1-hi-what-is-the-error-i-dont-know"
}
```
make testacc TEST=./ibm TESTARGS='-run=TestAccIBMISVirtualEndpointGateway_FullySpecified'
```