### PR TITLE
AppID application roles

### DIFF
--- a/ibm/data_source_ibm_appid_application_roles.go
+++ b/ibm/data_source_ibm_appid_application_roles.go
@@ -1,0 +1,95 @@
+package ibm
+
+import (
+	"context"
+	"fmt"
+	appid "github.com/IBM/appid-management-go-sdk/appidmanagementv4"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+func dataSourceIBMAppIDApplicationRoles() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceIBMAppIDApplicationRolesRead,
+		Schema: map[string]*schema.Schema{
+			"tenant_id": {
+				Description: "The service `tenantId`",
+				Type:        schema.TypeString,
+				Required:    true,
+			},
+			"client_id": {
+				Description: "The `client_id` is a public identifier for applications",
+				Type:        schema.TypeString,
+				Required:    true,
+			},
+			"roles": {
+				Description: "Defined roles for an application that is registered with an App ID instance",
+				Type:        schema.TypeSet,
+				Computed:    true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"id": {
+							Type:        schema.TypeString,
+							Description: "Application role ID",
+							Computed:    true,
+						},
+						"name": {
+							Type:        schema.TypeString,
+							Description: "Application role name",
+							Computed:    true,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func dataSourceIBMAppIDApplicationRolesRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	appIDClient, err := meta.(ClientSession).AppIDAPI()
+
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	tenantID := d.Get("tenant_id").(string)
+	clientID := d.Get("client_id").(string)
+
+	roles, _, err := appIDClient.GetApplicationRolesWithContext(ctx, &appid.GetApplicationRolesOptions{
+		TenantID: &tenantID,
+		ClientID: &clientID,
+	})
+
+	if err != nil {
+		return diag.Errorf("Error getting AppID application roles: %s", err)
+	}
+
+	if err := d.Set("roles", flattenAppIDApplicationRoles(roles.Roles)); err != nil {
+		return diag.Errorf("Error setting AppID application roles: %s", err)
+	}
+
+	d.SetId(fmt.Sprintf("%s/%s", tenantID, clientID))
+	return nil
+}
+
+func flattenAppIDApplicationRoles(r []appid.GetUserRolesResponseRolesItem) []interface{} {
+	var result []interface{}
+
+	if r == nil {
+		return result
+	}
+
+	for _, v := range r {
+		role := map[string]interface{}{
+			"id": *v.ID,
+		}
+
+		if v.Name != nil {
+			role["name"] = *v.Name
+		}
+
+		result = append(result, role)
+	}
+
+	return result
+}

--- a/ibm/data_source_ibm_appid_application_roles_test.go
+++ b/ibm/data_source_ibm_appid_application_roles_test.go
@@ -1,0 +1,58 @@
+package ibm
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+func TestAccIBMAppIDApplicationRolesDataSource_basic(t *testing.T) {
+	appName := fmt.Sprintf("tf_testacc_app_roles_%d", acctest.RandIntRange(10, 100))
+	roleName := fmt.Sprintf("tf_testacc_app_roles_%d", acctest.RandIntRange(10, 100))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckIBMAppIDApplicationRolesDataSourceConfig(appIDTenantID, appName, roleName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("data.ibm_appid_application_roles.roles", "roles.#", "1"),
+					resource.TestCheckResourceAttrPair("ibm_appid_role.role", "role_id", "data.ibm_appid_application_roles.roles", "roles.0.id"),
+					resource.TestCheckResourceAttr("data.ibm_appid_application_roles.roles", "roles.0.name", roleName),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckIBMAppIDApplicationRolesDataSourceConfig(tenantID string, appName string, roleName string) string {
+	return fmt.Sprintf(`
+		resource "ibm_appid_application" "test_app" {
+			tenant_id = "%s"
+			name = "%s"  	
+		}
+
+		resource "ibm_appid_role" "role" {
+			tenant_id = ibm_appid_application.test_app.tenant_id
+			name = "%s"
+		}
+
+		resource "ibm_appid_application_roles" "roles" {
+			tenant_id = ibm_appid_application.test_app.tenant_id
+			client_id = ibm_appid_application.test_app.client_id
+			roles = [ibm_appid_role.role.role_id]        
+		}
+
+		data "ibm_appid_application_roles" "roles" {
+			tenant_id = ibm_appid_application.test_app.tenant_id
+			client_id = ibm_appid_application.test_app.client_id
+	
+			depends_on = [
+				ibm_appid_application_roles.roles
+			]
+		}
+	`, tenantID, appName, roleName)
+}

--- a/ibm/data_source_ibm_appid_token_config.go
+++ b/ibm/data_source_ibm_appid_token_config.go
@@ -115,8 +115,6 @@ func flattenTokenClaims(c []appid.TokenClaimMapping) []interface{} {
 }
 
 func dataSourceIBMAppIDTokenConfigRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	var diags diag.Diagnostics
-
 	appidClient, err := meta.(ClientSession).AppIDAPI()
 
 	if err != nil {
@@ -165,5 +163,5 @@ func dataSourceIBMAppIDTokenConfigRead(ctx context.Context, d *schema.ResourceDa
 
 	d.SetId(tenantID)
 
-	return diags
+	return nil
 }

--- a/ibm/provider.go
+++ b/ibm/provider.go
@@ -175,6 +175,7 @@ func Provider() *schema.Provider {
 			// AppID
 			"ibm_appid_application":        dataSourceIBMAppIDApplication(),
 			"ibm_appid_application_scopes": dataSourceIBMAppIDApplicationScopes(),
+			"ibm_appid_application_roles":  dataSourceIBMAppIDApplicationRoles(),
 			"ibm_appid_token_config":       dataSourceIBMAppIDTokenConfig(),
 			"ibm_appid_role":               dataSourceIBMAppIDRole(),
 
@@ -436,6 +437,7 @@ func Provider() *schema.Provider {
 
 			"ibm_appid_application":        resourceIBMAppIDApplication(),
 			"ibm_appid_application_scopes": resourceIBMAppIDApplicationScopes(),
+			"ibm_appid_application_roles":  resourceIBMAppIDApplicationRoles(),
 			"ibm_appid_token_config":       resourceIBMAppIDTokenConfig(),
 			"ibm_appid_role":               resourceIBMAppIDRole(),
 

--- a/ibm/resource_ibm_appid_application_roles.go
+++ b/ibm/resource_ibm_appid_application_roles.go
@@ -1,0 +1,182 @@
+package ibm
+
+import (
+	"context"
+	"fmt"
+	appid "github.com/IBM/appid-management-go-sdk/appidmanagementv4"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"log"
+	"strings"
+)
+
+func resourceIBMAppIDApplicationRoles() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceIBMAppIDApplicationRolesCreate,
+		ReadContext:   resourceIBMAppIDApplicationRolesRead,
+		DeleteContext: resourceIBMAppIDApplicationRolesDelete,
+		UpdateContext: resourceIBMAppIDApplicationRolesUpdate,
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
+		Schema: map[string]*schema.Schema{
+			"tenant_id": {
+				Description: "The service `tenantId`",
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+			},
+			"client_id": {
+				Description: "The `client_id` is a public identifier for applications",
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+			},
+			"roles": {
+				Description: "A list of role IDs for roles that you want to be assigned to the application (this is different from AppID role access)",
+				Type:        schema.TypeList,
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
+				Required: true,
+			},
+		},
+	}
+}
+
+func resourceIBMAppIDApplicationRolesCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	appIDClient, err := meta.(ClientSession).AppIDAPI()
+
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	tenantID := d.Get("tenant_id").(string)
+	clientID := d.Get("client_id").(string)
+	roles := expandStringList(d.Get("roles").([]interface{}))
+
+	roleOpts := &appid.PutApplicationsRolesOptions{
+		TenantID: &tenantID,
+		ClientID: &clientID,
+		Roles: &appid.UpdateUserRolesParamsRoles{
+			Ids: roles,
+		},
+	}
+
+	_, _, err = appIDClient.PutApplicationsRolesWithContext(ctx, roleOpts)
+
+	if err != nil {
+		return diag.Errorf("Error setting application roles: %s", err)
+	}
+
+	d.SetId(fmt.Sprintf("%s/%s", tenantID, clientID))
+
+	return resourceIBMAppIDApplicationRolesRead(ctx, d, meta)
+}
+
+func resourceIBMAppIDApplicationRolesRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	appIDClient, err := meta.(ClientSession).AppIDAPI()
+
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	id := d.Id()
+	idParts := strings.Split(id, "/")
+
+	if len(idParts) < 2 {
+		return diag.Errorf("Incorrect ID %s: ID should be a combination of tenantID/clientID", d.Id())
+	}
+
+	tenantID := idParts[0]
+	clientID := idParts[1]
+
+	roles, resp, err := appIDClient.GetApplicationRolesWithContext(ctx, &appid.GetApplicationRolesOptions{
+		TenantID: &tenantID,
+		ClientID: &clientID,
+	})
+
+	if err != nil {
+		if resp != nil && resp.StatusCode == 404 {
+			log.Printf("[WARN] AppID application '%s' is not found, removing roles from state", clientID)
+			d.SetId("")
+			return nil
+		}
+
+		return diag.Errorf("Error getting AppID application roles: %s", err)
+	}
+
+	var appRoles []interface{}
+
+	if roles.Roles != nil {
+		for _, v := range roles.Roles {
+			appRoles = append(appRoles, *v.ID)
+		}
+	}
+
+	if err := d.Set("roles", appRoles); err != nil {
+		return diag.Errorf("Error setting application roles: %s", err)
+	}
+
+	d.Set("tenant_id", tenantID)
+	d.Set("client_id", clientID)
+
+	return nil
+}
+
+func resourceIBMAppIDApplicationRolesUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	appIDClient, err := meta.(ClientSession).AppIDAPI()
+
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	tenantID := d.Get("tenant_id").(string)
+	clientID := d.Get("client_id").(string)
+	roles := expandStringList(d.Get("roles").([]interface{}))
+
+	roleOpts := &appid.PutApplicationsRolesOptions{
+		TenantID: &tenantID,
+		ClientID: &clientID,
+		Roles: &appid.UpdateUserRolesParamsRoles{
+			Ids: roles,
+		},
+	}
+
+	_, _, err = appIDClient.PutApplicationsRolesWithContext(ctx, roleOpts)
+
+	if err != nil {
+		return diag.Errorf("Error setting application roles: %s", err)
+	}
+
+	return resourceIBMAppIDApplicationRolesRead(ctx, d, meta)
+}
+
+func resourceIBMAppIDApplicationRolesDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	appIDClient, err := meta.(ClientSession).AppIDAPI()
+
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	tenantID := d.Get("tenant_id").(string)
+	clientID := d.Get("client_id").(string)
+
+	roleOpts := &appid.PutApplicationsRolesOptions{
+		TenantID: &tenantID,
+		ClientID: &clientID,
+		Roles: &appid.UpdateUserRolesParamsRoles{
+			Ids: []string{},
+		},
+	}
+
+	_, _, err = appIDClient.PutApplicationsRolesWithContext(ctx, roleOpts)
+
+	if err != nil {
+		return diag.Errorf("Error clearing application roles: %s", err)
+	}
+
+	d.SetId("")
+
+	return nil
+}

--- a/ibm/resource_ibm_appid_application_roles_test.go
+++ b/ibm/resource_ibm_appid_application_roles_test.go
@@ -1,0 +1,82 @@
+package ibm
+
+import (
+	"fmt"
+	appid "github.com/IBM/appid-management-go-sdk/appidmanagementv4"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"strings"
+	"testing"
+)
+
+func TestAccIBMAppIDApplicationRoles_basic(t *testing.T) {
+	appName := fmt.Sprintf("tf_testacc_app_roles_%d", acctest.RandIntRange(10, 100))
+	roleName := fmt.Sprintf("tf_testacc_app_roles_%d", acctest.RandIntRange(10, 100))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckIBMAppIDApplicationRolesDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckIBMAppIDApplicationRolesConfig(appIDTenantID, appName, roleName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("ibm_appid_application_roles.roles", "roles.#", "1"),
+					resource.TestCheckResourceAttrPair("ibm_appid_role.role", "role_id", "ibm_appid_application_roles.roles", "roles.0"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckIBMAppIDApplicationRolesConfig(tenantID string, appName string, roleName string) string {
+	return fmt.Sprintf(`
+		resource "ibm_appid_application" "test_app" {
+			tenant_id = "%s"
+			name = "%s"  	
+		}
+
+		resource "ibm_appid_role" "role" {
+			tenant_id = ibm_appid_application.test_app.tenant_id
+			name = "%s"
+		}
+
+		resource "ibm_appid_application_roles" "roles" {
+			tenant_id = ibm_appid_application.test_app.tenant_id
+			client_id = ibm_appid_application.test_app.client_id
+			roles = [ibm_appid_role.role.role_id]        
+		}
+	`, tenantID, appName, roleName)
+}
+
+func testAccCheckIBMAppIDApplicationRolesDestroy(s *terraform.State) error {
+	appIDClient, err := testAccProvider.Meta().(ClientSession).AppIDAPI()
+
+	if err != nil {
+		return err
+	}
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "ibm_appid_application_roles" {
+			continue
+		}
+
+		id := rs.Primary.ID
+		idParts := strings.Split(id, "/")
+
+		tenantID := idParts[0]
+		clientID := idParts[1]
+
+		_, _, err := appIDClient.GetApplicationRoles(&appid.GetApplicationRolesOptions{
+			TenantID: &tenantID,
+			ClientID: &clientID,
+		})
+
+		if err == nil {
+			return fmt.Errorf("error checking if AppID application roles resource (%s) has been destroyed", rs.Primary.ID)
+		}
+	}
+
+	return nil
+}

--- a/ibm/resource_ibm_appid_token_config.go
+++ b/ibm/resource_ibm_appid_token_config.go
@@ -307,8 +307,6 @@ func tokenConfigDefaults(tenantID string) *appid.PutTokensConfigOptions {
 }
 
 func resourceIBMAppIDTokenConfigDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	var diags diag.Diagnostics
-
 	appidClient, err := meta.(ClientSession).AppIDAPI()
 
 	if err != nil {
@@ -326,5 +324,5 @@ func resourceIBMAppIDTokenConfigDelete(ctx context.Context, d *schema.ResourceDa
 
 	d.SetId("")
 
-	return diags
+	return nil
 }

--- a/website/docs/d/appid_application_roles.html.markdown
+++ b/website/docs/d/appid_application_roles.html.markdown
@@ -1,0 +1,34 @@
+---
+subcategory: "AppID Management"
+layout: "ibm"
+page_title: "IBM: AppID Application Roles"
+description: |-
+Retrieves AppID Application Roles.
+---
+
+# ibm_appid_application_roles
+Retrieve IBM Cloud AppID Management Services application roles.
+
+## Example usage
+
+```terraform
+data "ibm_appid_application_roles" "roles" {
+    tenant_id = var.tenant_id
+    client_id = var.client_id
+}
+```
+
+## Argument reference
+Review the argument references that you can specify for your data source.
+
+- `tenant_id` - (Required, String) The AppID instance GUID
+- `client_id` - (Required, String) The AppID application identifier
+
+## Attribute reference
+In addition to all argument reference list, you can access the following attribute references after your data source is created
+
+- `roles` - (Set of Object) A set of roles that are assigned to the application
+
+  Nested scheme for `roles`:
+    - `id` - (String) AppID role ID
+    - `name` - (String) AppID role name

--- a/website/docs/r/appid_application_roles.html.markdown
+++ b/website/docs/r/appid_application_roles.html.markdown
@@ -1,0 +1,46 @@
+---
+subcategory: "AppID Management"
+layout: "ibm"
+page_title: "IBM: AppID Application Roles"
+description: |-
+Provides AppID Application Roles resource.
+---
+
+# ibm_appid_application_roles
+
+Create, update, or delete an IBM Cloud AppID Management Services application roles resource.
+
+## Example usage
+
+```terraform
+resource "ibm_appid_application_roles" "roles" {
+  tenant_id = var.tenant_id
+  client_id = var.client_id // AppID application client_id
+  roles = [
+    "cf9bb562-8639-46f0-aa8c-0068e4162519", 
+    "a330db5f-fa42-4c42-9134-821535728f57"
+  ]
+}
+```
+
+## Argument reference
+Review the argument references that you can specify for your resource.
+
+- `tenant_id` - (Required, String) The AppID instance GUID
+- `client_id` - (Required, String) The AppID application identifier
+- `roles` - (Required, List of String) A list of AppID role identifiers
+
+## Import
+
+The `ibm_appid_application_roles` resource can be imported by using the AppID tenant ID and application client ID.
+
+**Syntax**
+
+```bash
+$ terraform import ibm_appid_application_roles.roles <tenant_id>/<client_id>
+```
+**Example**
+
+```bash
+$ terraform import ibm_appid_application_roles.roles 4be72312-63b7-45fa-9b58-3ae6cd2c90e7/ace469ef-5e1a-4991-8a65-2201b1c5c362
+```

--- a/website/docs/r/appid_application_scopes.html.markdown
+++ b/website/docs/r/appid_application_scopes.html.markdown
@@ -24,7 +24,7 @@ resource "ibm_appid_application_scopes" "scopes" {
 Review the argument references that you can specify for your resource.
 
 - `tenant_id` - (Required, String) The AppID instance GUID
-- `name` - (Required, String) The AppID application name
+- `client_id` - (Required, String) The AppID application identifier
 - `scopes` - (Required, List of String) A `scope` is a runtime action in your application that you register with IBM Cloud App ID to create access permission
 
 ## Import


### PR DESCRIPTION
## New AppID Application Roles Data Source and Resource

Reopening this with cleaner history

AppID Swagger UI: https://us-south.appid.cloud.ibm.com/swagger-ui

<!--- See what makes a good Pull Request at : https://github.com/IBM-Cloud/terraform-provider-ibm/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test $(go list ./... |grep -v 'vendor') -v -run TestAccIBMAppIDApplicationRoles* -timeout 700m
=== RUN   TestAccIBMAppIDApplicationRolesDataSource_basic
--- PASS: TestAccIBMAppIDApplicationRolesDataSource_basic (48.50s)
=== RUN   TestAccIBMAppIDApplicationRoles_basic
--- PASS: TestAccIBMAppIDApplicationRoles_basic (44.81s)
PASS
```
