### PR TITLE
AppID redirect urls datasource/resource

### DIFF
--- a/ibm/data_source_ibm_appid_redirect_urls.go
+++ b/ibm/data_source_ibm_appid_redirect_urls.go
@@ -1,0 +1,55 @@
+package ibm
+
+import (
+	"context"
+	appid "github.com/IBM/appid-management-go-sdk/appidmanagementv4"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+func dataSourceIBMAppIDRedirectURLs() *schema.Resource {
+	return &schema.Resource{
+		Description: "Redirect URIs that can be used as callbacks of App ID authentication flow",
+		ReadContext: dataSourceIBMAppIDRedirectURLsRead,
+		Schema: map[string]*schema.Schema{
+			"tenant_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "The service `tenantId`",
+			},
+			"urls": {
+				Description: "A list of redirect URLs",
+				Type:        schema.TypeList,
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
+				Computed: true,
+			},
+		},
+	}
+}
+
+func dataSourceIBMAppIDRedirectURLsRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	appidClient, err := meta.(ClientSession).AppIDAPI()
+
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	tenantID := d.Get("tenant_id").(string)
+
+	urls, _, err := appidClient.GetRedirectUrisWithContext(ctx, &appid.GetRedirectUrisOptions{
+		TenantID: &tenantID,
+	})
+	if err != nil {
+		return diag.Errorf("Error loading Cloud Directory AppID redirect urls: %s", err)
+	}
+
+	if err := d.Set("urls", urls.RedirectUris); err != nil {
+		return diag.Errorf("Error setting Cloud Directory AppID redirect URLs: %s", err)
+	}
+
+	d.SetId(tenantID)
+
+	return nil
+}

--- a/ibm/data_source_ibm_appid_redirect_urls_test.go
+++ b/ibm/data_source_ibm_appid_redirect_urls_test.go
@@ -1,0 +1,47 @@
+package ibm
+
+import (
+	"fmt"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"testing"
+)
+
+func TestAccIBMAppIDRedirectURLsDataSource_basic(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckIBMAppIDRedirectURLsDataSourceConfig(appIDTenantID),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("data.ibm_appid_redirect_urls.urls", "urls.#", "3"),
+					resource.TestCheckResourceAttr("data.ibm_appid_redirect_urls.urls", "urls.0", "https://test-url-1.com"),
+					resource.TestCheckResourceAttr("data.ibm_appid_redirect_urls.urls", "urls.1", "https://test-url-2.com"),
+					resource.TestCheckResourceAttr("data.ibm_appid_redirect_urls.urls", "urls.2", "https://test-url-3.com"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckIBMAppIDRedirectURLsDataSourceConfig(tenantID string) string {
+	return fmt.Sprintf(`
+		resource "ibm_appid_redirect_urls" "urls" {
+			tenant_id = "%s"
+			urls = [
+				"https://test-url-1.com",
+				"https://test-url-2.com",
+				"https://test-url-3.com",
+			]
+		}
+
+		data "ibm_appid_redirect_urls" "urls" {
+			tenant_id = ibm_appid_redirect_urls.urls.tenant_id
+
+			depends_on = [
+				ibm_appid_redirect_urls.urls
+			]
+		}
+		
+	`, tenantID)
+}

--- a/ibm/provider.go
+++ b/ibm/provider.go
@@ -176,6 +176,7 @@ func Provider() *schema.Provider {
 			"ibm_appid_application":        dataSourceIBMAppIDApplication(),
 			"ibm_appid_application_scopes": dataSourceIBMAppIDApplicationScopes(),
 			"ibm_appid_token_config":       dataSourceIBMAppIDTokenConfig(),
+			"ibm_appid_redirect_urls":      dataSourceIBMAppIDRedirectURLs(),
 			"ibm_appid_role":               dataSourceIBMAppIDRole(),
 
 			"ibm_function_action":                    dataSourceIBMFunctionAction(),
@@ -437,6 +438,7 @@ func Provider() *schema.Provider {
 			"ibm_appid_application":        resourceIBMAppIDApplication(),
 			"ibm_appid_application_scopes": resourceIBMAppIDApplicationScopes(),
 			"ibm_appid_token_config":       resourceIBMAppIDTokenConfig(),
+			"ibm_appid_redirect_urls":      resourceIBMAppIDRedirectURLs(),
 			"ibm_appid_role":               resourceIBMAppIDRole(),
 
 			"ibm_function_action":                                resourceIBMFunctionAction(),

--- a/ibm/resource_ibm_appid_redirect_urls.go
+++ b/ibm/resource_ibm_appid_redirect_urls.go
@@ -1,0 +1,138 @@
+package ibm
+
+import (
+	"context"
+	appid "github.com/IBM/appid-management-go-sdk/appidmanagementv4"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+func resourceIBMAppIDRedirectURLs() *schema.Resource {
+	return &schema.Resource{
+		Description:   "Redirect URIs that can be used as callbacks of App ID authentication flow",
+		CreateContext: resourceIBMAppIDRedirectURLsCreate,
+		ReadContext:   resourceIBMAppIDRedirectURLsRead,
+		UpdateContext: resourceIBMAppIDRedirectURLsUpdate,
+		DeleteContext: resourceIBMAppIDRedirectURLsDelete,
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
+		Schema: map[string]*schema.Schema{
+			"tenant_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: "The service `tenantId`",
+			},
+			"urls": {
+				Description: "A list of redirect URLs",
+				Type:        schema.TypeList,
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
+				Required: true,
+			},
+		},
+	}
+}
+
+func resourceIBMAppIDRedirectURLsRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	appIDClient, err := meta.(ClientSession).AppIDAPI()
+
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	tenantID := d.Id()
+
+	urls, _, err := appIDClient.GetRedirectUrisWithContext(ctx, &appid.GetRedirectUrisOptions{
+		TenantID: &tenantID,
+	})
+	if err != nil {
+		return diag.Errorf("Error loading AppID Cloud Directory redirect urls: %s", err)
+	}
+
+	if err := d.Set("urls", urls.RedirectUris); err != nil {
+		return diag.Errorf("Error setting AppID Cloud Directory redirect urls: %s", err)
+	}
+
+	d.Set("tenant_id", tenantID)
+
+	return nil
+}
+
+func resourceIBMAppIDRedirectURLsCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	appIDClient, err := meta.(ClientSession).AppIDAPI()
+
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	tenantID := d.Get("tenant_id").(string)
+	urls := d.Get("urls")
+
+	redirectURLs := expandStringList(urls.([]interface{}))
+	_, err = appIDClient.UpdateRedirectUrisWithContext(ctx, &appid.UpdateRedirectUrisOptions{
+		TenantID: &tenantID,
+		RedirectUrisArray: &appid.RedirectURIConfig{
+			RedirectUris: redirectURLs,
+		},
+	})
+
+	if err != nil {
+		return diag.Errorf("Error updating AppID Cloud Directory redirect URLs: %s", err)
+	}
+
+	d.SetId(tenantID)
+	return resourceIBMAppIDRedirectURLsRead(ctx, d, meta)
+}
+
+func resourceIBMAppIDRedirectURLsUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	appIDClient, err := meta.(ClientSession).AppIDAPI()
+
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	tenantID := d.Get("tenant_id").(string)
+	urls := d.Get("urls")
+
+	redirectURLs := expandStringList(urls.([]interface{}))
+	_, err = appIDClient.UpdateRedirectUrisWithContext(ctx, &appid.UpdateRedirectUrisOptions{
+		TenantID: &tenantID,
+		RedirectUrisArray: &appid.RedirectURIConfig{
+			RedirectUris: redirectURLs,
+		},
+	})
+
+	if err != nil {
+		return diag.Errorf("Error updating AppID Cloud Directory redirect URLs: %s", err)
+	}
+
+	return resourceIBMAppIDRedirectURLsRead(ctx, d, meta)
+}
+
+func resourceIBMAppIDRedirectURLsDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	appIDClient, err := meta.(ClientSession).AppIDAPI()
+
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	tenantID := d.Get("tenant_id").(string)
+
+	_, err = appIDClient.UpdateRedirectUrisWithContext(ctx, &appid.UpdateRedirectUrisOptions{
+		TenantID: &tenantID,
+		RedirectUrisArray: &appid.RedirectURIConfig{
+			RedirectUris: []string{},
+		},
+	})
+
+	if err != nil {
+		return diag.Errorf("Error resetting AppID Cloud Directory redirect URLs: %s", err)
+	}
+
+	d.SetId("")
+
+	return nil
+}

--- a/ibm/resource_ibm_appid_redirect_urls_test.go
+++ b/ibm/resource_ibm_appid_redirect_urls_test.go
@@ -1,0 +1,67 @@
+package ibm
+
+import (
+	"fmt"
+	appid "github.com/IBM/appid-management-go-sdk/appidmanagementv4"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"testing"
+)
+
+func TestAccIBMAppIDRedirectURLs_basic(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckIBMAppIDRedirectURLsDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckIBMAppIDRedirectURLsConfig(appIDTenantID),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("ibm_appid_redirect_urls.urls", "urls.#", "3"),
+					resource.TestCheckResourceAttr("ibm_appid_redirect_urls.urls", "urls.0", "https://test-url-1.com"),
+					resource.TestCheckResourceAttr("ibm_appid_redirect_urls.urls", "urls.1", "https://test-url-2.com"),
+					resource.TestCheckResourceAttr("ibm_appid_redirect_urls.urls", "urls.2", "https://test-url-3.com"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckIBMAppIDRedirectURLsConfig(tenantID string) string {
+	return fmt.Sprintf(`
+		resource "ibm_appid_redirect_urls" "urls" {
+			tenant_id = "%s"
+			urls = [
+				"https://test-url-1.com",
+				"https://test-url-2.com",
+				"https://test-url-3.com",
+			]
+		}
+	`, tenantID)
+}
+
+func testAccCheckIBMAppIDRedirectURLsDestroy(s *terraform.State) error {
+	appIDClient, err := testAccProvider.Meta().(ClientSession).AppIDAPI()
+
+	if err != nil {
+		return err
+	}
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "ibm_appid_redirect_urls" {
+			continue
+		}
+
+		tenantID := rs.Primary.ID
+
+		urls, _, err := appIDClient.GetRedirectUris(&appid.GetRedirectUrisOptions{
+			TenantID: &tenantID,
+		})
+
+		if err != nil || len(urls.RedirectUris) != 0 {
+			return fmt.Errorf("error checking if AppID redirect URLs resource (%s) has been destroyed", rs.Primary.ID)
+		}
+	}
+
+	return nil
+}

--- a/website/docs/d/appid_redirect_urls.html.markdown
+++ b/website/docs/d/appid_redirect_urls.html.markdown
@@ -1,0 +1,28 @@
+---
+subcategory: "AppID Management"
+layout: "ibm"
+page_title: "IBM: AppID Cloud Directory Redirect URLs"
+description: |-
+Retrieves AppID Cloud Directory Redirect URLs.
+---
+
+# ibm_appid_redirect_urls
+Retrieve IBM Cloud AppID Management Services Cloud Directory redirect URLs.
+
+## Example usage
+
+```terraform
+data "ibm_appid_redirect_urls" "urls" {
+    tenant_id = var.tenant_id   
+}
+```
+
+## Argument reference
+Review the argument references that you can specify for your data source.
+
+- `tenant_id` - (Required, String) The AppID instance GUID
+
+## Attribute reference
+In addition to all argument reference list, you can access the following attribute references after your data source is created
+
+- `urls` - (List of String) A list of redirect URLs

--- a/website/docs/r/appid_redirect_urls.html.markdown
+++ b/website/docs/r/appid_redirect_urls.html.markdown
@@ -1,0 +1,44 @@
+---
+subcategory: "AppID Management"
+layout: "ibm"
+page_title: "IBM: AppID Cloud Directory Redirect URLs"
+description: |-
+Provides AppID Cloud Directory Redirect URLs resource.
+---
+
+# ibm_appid_redirect_urls
+Create, update, or delete an IBM Cloud AppID Management Services Cloud Directory redirect URLs.
+
+## Example usage
+
+```terraform
+resource "ibm_appid_redirect_urls" "urls" {
+    tenant_id = var.tenant_id 
+    urls = [
+      "https://test-application-1.com/login",
+      "https://test-application-2.com/login",
+      "https://test-application-3.com/login"
+    ]
+}
+```
+
+## Argument reference
+Review the argument references that you can specify for your resource.
+
+- `tenant_id` - (Required, String) The AppID instance GUID
+- `urls` - (Required, List of String) A list of redirect URLs
+
+## Import
+
+The `ibm_appid_redirect_urls` resource can be imported by using the AppID tenant ID.
+
+**Syntax**
+
+```bash
+$ terraform import ibm_appid_redirect_urls.urls <tenant_id>
+```
+**Example**
+
+```bash
+$ terraform import ibm_appid_redirect_urls.urls 5fa344a8-d361-4bc2-9051-58ca253f4b2b
+```


### PR DESCRIPTION
## New AppID Redirect URLs Data Source and Resource

AppID Swagger UI: https://us-south.appid.cloud.ibm.com/swagger-ui

<!--- See what makes a good Pull Request at : https://github.com/IBM-Cloud/terraform-provider-ibm/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test $(go list ./... |grep -v 'vendor') -v -run TestAccIBMAppIDRedirectURLs* -timeout 700m
=== RUN   TestAccIBMAppIDRedirectURLsDataSource_basic
--- PASS: TestAccIBMAppIDRedirectURLsDataSource_basic (45.57s)
=== RUN   TestAccIBMAppIDRedirectURLs_basic
--- PASS: TestAccIBMAppIDRedirectURLs_basic (43.03s)
PASS
```
