### PR TITLE
Include the IBM ID in the ibm_iam_user_profile data source #2940

### DIFF
--- a/ibm/data_source_ibm_iam_user_profile.go
+++ b/ibm/data_source_ibm_iam_user_profile.go
@@ -75,6 +75,11 @@ func dataSourceIBMIAMUserProfile() *schema.Resource {
 				Computed:    true,
 				Description: "An alphanumeric value identifying the account ID. ",
 			},
+			"ibm_id": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "An alphanumeric value identifying the user's IAM ID.",
+			},
 		},
 	}
 }
@@ -111,6 +116,7 @@ func dataSourceIBMIAMUserProfileRead(d *schema.ResourceData, meta interface{}) e
 	d.Set("phonenumber", userInfo.Phonenumber)
 	d.Set("altphonenumber", userInfo.Altphonenumber)
 	d.Set("account_id", userInfo.AccountID)
+	d.Set("ibm_id", userInfo.IamID)
 
 	UserSettings, UserSettingError := client.GetUserSettings(accountID, iamID)
 	if UserSettingError != nil {

--- a/website/docs/d/iam_user_profile.html.markdown
+++ b/website/docs/d/iam_user_profile.html.markdown
@@ -37,6 +37,7 @@ In addition to the argument reference list, you can access the following attribu
 - `allowed_ip_addresses` (List) List of invited users IP's to access the IBM cloud console.
 - `email` - (String) The email address of the user.
 - `firstname`-  (String) The first name of the user.
+- `ibm_id` - (String) An alphanumeric value identifying the user's IAM ID.
 - `id` - (String) The unique identifier or email address of the IAM user.
 - `lastname`-  (String) The last name of the user.
 - `phonenumber` - (String) The contact number of the user.


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/IBM-Cloud/terraform-provider-ibm/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #2940

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```data "ibm_iam_user_profile" "user_profle" {
    account_id           = "XXX"
    allowed_ip_addresses = [
        "",
    ]
    email                = "XX@in.ibm.com"
    firstname            = "XX"
    iam_id               = "XX@in.ibm.com"
    ibm_id               = "IBMid-XXX"
    id                   = "XX@in.ibm.com"
    lastname             = "YY"
    phonenumber          = "XXX"
    state                = "ACTIVE"
    user_id              = "XX@in.ibm.com"
}
...
```
