### PR TITLE
Add AppID APM datasource and resource

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "go.sum|^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2021-08-09T09:00:17Z",
+  "generated_at": "2021-08-18T17:54:03Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -25,6 +25,7 @@
       "name": "CloudantDetector"
     },
     {
+      "ghe_instance": "github.ibm.com",
       "name": "GheDetector"
     },
     {
@@ -515,7 +516,7 @@
         "hashed_secret": "c427f185ddcb2440be9b77c8e45f1cd487a2e790",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1111,
+        "line_number": 1110,
         "type": "Base64 High Entropy String",
         "verified_result": null
       },
@@ -523,7 +524,7 @@
         "hashed_secret": "1f614c2eb6b3da22d89bd1b9fd47d7cb7c8fc670",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2156,
+        "line_number": 2167,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -531,7 +532,7 @@
         "hashed_secret": "7abfce65b8504403afc25c9790f358d513dfbcc6",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2169,
+        "line_number": 2180,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -539,7 +540,17 @@
         "hashed_secret": "0c2d85bf9a9b1579b16f220a4ea8c3d62b2e24b1",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2205,
+        "line_number": 2216,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "ibm/data_source_ibm_appid_apm.go": [
+      {
+        "hashed_secret": "84a3a4ff86292fad58ec0eec3a93709800529589",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 208,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -699,7 +710,7 @@
         "hashed_secret": "c8b6f5ef11b9223ac35a5663975a466ebe7ebba9",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 851,
+        "line_number": 876,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -707,7 +718,7 @@
         "hashed_secret": "8abf4899c01104241510ba87685ad4de76b0c437",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 857,
+        "line_number": 882,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -717,7 +728,7 @@
         "hashed_secret": "813274ccae5b6b509379ab56982d862f7b5969b6",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 513,
+        "line_number": 519,
         "type": "Base64 High Entropy String",
         "verified_result": null
       }
@@ -943,7 +954,7 @@
         "hashed_secret": "b02fa7fd7ca08b5dc86c2548e40f8a21171ef977",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 408,
+        "line_number": 413,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -963,7 +974,7 @@
         "hashed_secret": "7deb7557ec8b36e7d5958afe3e08959e7f1ba813",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1093,
+        "line_number": 1089,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -971,7 +982,7 @@
         "hashed_secret": "b62aab00e3bf482bfb75e3e42fd5d1be72f33ec0",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1188,
+        "line_number": 1184,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -979,7 +990,7 @@
         "hashed_secret": "b732fb611fd46a38e8667f9972e0cde777fbe37f",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1634,
+        "line_number": 1630,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -987,7 +998,7 @@
         "hashed_secret": "1f5e25be9b575e9f5d39c82dfd1d9f4d73f1975c",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1743,
+        "line_number": 1739,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -1067,7 +1078,7 @@
         "hashed_secret": "b02fa7fd7ca08b5dc86c2548e40f8a21171ef977",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 223,
+        "line_number": 233,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1075,7 +1086,7 @@
         "hashed_secret": "d4c3d66fd0c38547a3c7a4c6bdc29c36911bc030",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 267,
+        "line_number": 277,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -1597,7 +1608,7 @@
       }
     ]
   },
-  "version": "0.13.1+ibm.34.dss",
+  "version": "0.13.1+ibm.45.dss",
   "word_list": {
     "file": null,
     "hash": null

--- a/ibm/data_source_ibm_appid_apm.go
+++ b/ibm/data_source_ibm_appid_apm.go
@@ -1,0 +1,212 @@
+package ibm
+
+import (
+	"context"
+	appid "github.com/IBM/appid-management-go-sdk/appidmanagementv4"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+func dataSourceIBMAppIDAPM() *schema.Resource {
+	return &schema.Resource{
+		Description: "AppID advanced password management configuration (available for graduated tier only)",
+		ReadContext: dataSourceIBMAppIDAPMRead,
+		Schema: map[string]*schema.Schema{
+			"tenant_id": {
+				Description: "The AppID instance GUID",
+				Type:        schema.TypeString,
+				Required:    true,
+			},
+			"enabled": {
+				Description: "`true` if APM is enabled",
+				Type:        schema.TypeBool,
+				Computed:    true,
+			},
+			"prevent_password_with_username": {
+				Type:     schema.TypeBool,
+				Computed: true,
+			},
+			"password_reuse": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"enabled": {
+							Type:     schema.TypeBool,
+							Computed: true,
+						},
+						"max_password_reuse": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+					},
+				},
+			},
+			"password_expiration": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"enabled": {
+							Type:     schema.TypeBool,
+							Computed: true,
+						},
+						"days_to_expire": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+					},
+				},
+			},
+			"lockout_policy": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"enabled": {
+							Type:     schema.TypeBool,
+							Computed: true,
+						},
+						"lockout_time_sec": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						"num_of_attempts": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+					},
+				},
+			},
+			"min_password_change_interval": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"enabled": {
+							Type:     schema.TypeBool,
+							Computed: true,
+						},
+						"min_hours_to_change_password": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func dataSourceIBMAppIDAPMRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	appIDClient, err := meta.(ClientSession).AppIDAPI()
+
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	tenantID := d.Get("tenant_id").(string)
+
+	apm, _, err := appIDClient.GetCloudDirectoryAdvancedPasswordManagementWithContext(ctx, &appid.GetCloudDirectoryAdvancedPasswordManagementOptions{
+		TenantID: &tenantID,
+	})
+
+	if err != nil {
+		return diag.Errorf("Error getting AppID APM configuration: %s", err)
+	}
+
+	if apm.AdvancedPasswordManagement != nil {
+		d.Set("enabled", *apm.AdvancedPasswordManagement.Enabled)
+
+		if err := d.Set("password_reuse", flattenAppIDAPMPasswordReuse(apm.AdvancedPasswordManagement.PasswordReuse)); err != nil {
+			return diag.Errorf("Failed setting AppID APM password_reuse: %s", err)
+		}
+
+		if apm.AdvancedPasswordManagement.PreventPasswordWithUsername != nil {
+			d.Set("prevent_password_with_username", *apm.AdvancedPasswordManagement.PreventPasswordWithUsername.Enabled)
+		}
+
+		if err := d.Set("password_expiration", flattenAppIDAPMPasswordExpiration(apm.AdvancedPasswordManagement.PasswordExpiration)); err != nil {
+			return diag.Errorf("Failed setting AppID APM password_expiration: %s", err)
+		}
+
+		if err := d.Set("lockout_policy", flattenAppIDAPMLockoutPolicy(apm.AdvancedPasswordManagement.LockOutPolicy)); err != nil {
+			return diag.Errorf("Failed setting AppID APM lockout_policy: %s", err)
+		}
+		if err := d.Set("min_password_change_interval", flattenAppIDAPMPasswordChangeInterval(apm.AdvancedPasswordManagement.MinPasswordChangeInterval)); err != nil {
+			return diag.Errorf("Failed setting AppID APM min_password_change_interval: %s", err)
+		}
+
+	}
+
+	d.SetId(tenantID)
+	return nil
+}
+
+func flattenAppIDAPMPasswordReuse(reuse *appid.ApmSchemaAdvancedPasswordManagementPasswordReuse) []interface{} {
+	if reuse == nil {
+		return []interface{}{}
+	}
+
+	mReuse := map[string]interface{}{}
+
+	mReuse["enabled"] = *reuse.Enabled
+
+	if reuse.Config != nil && reuse.Config.MaxPasswordReuse != nil {
+		mReuse["max_password_reuse"] = *reuse.Config.MaxPasswordReuse
+	}
+
+	return []interface{}{mReuse}
+}
+
+func flattenAppIDAPMPasswordExpiration(exp *appid.ApmSchemaAdvancedPasswordManagementPasswordExpiration) []interface{} {
+	if exp == nil {
+		return []interface{}{}
+	}
+
+	mExp := map[string]interface{}{}
+
+	mExp["enabled"] = *exp.Enabled
+
+	if exp.Config != nil && exp.Config.DaysToExpire != nil {
+		mExp["days_to_expire"] = *exp.Config.DaysToExpire
+	}
+
+	return []interface{}{mExp}
+}
+
+func flattenAppIDAPMLockoutPolicy(pol *appid.ApmSchemaAdvancedPasswordManagementLockOutPolicy) []interface{} {
+	if pol == nil {
+		return []interface{}{}
+	}
+
+	mPol := map[string]interface{}{}
+
+	mPol["enabled"] = *pol.Enabled
+
+	if pol.Config != nil && pol.Config.LockOutTimeSec != nil {
+		mPol["lockout_time_sec"] = *pol.Config.LockOutTimeSec
+	}
+
+	if pol.Config != nil && pol.Config.NumOfAttempts != nil {
+		mPol["num_of_attempts"] = *pol.Config.NumOfAttempts
+	}
+
+	return []interface{}{mPol}
+}
+
+func flattenAppIDAPMPasswordChangeInterval(in *appid.ApmSchemaAdvancedPasswordManagementMinPasswordChangeInterval) []interface{} {
+	if in == nil {
+		return []interface{}{}
+	}
+
+	mIn := map[string]interface{}{}
+
+	mIn["enabled"] = *in.Enabled
+
+	if in.Config != nil && in.Config.MinHoursToChangePassword != nil {
+		mIn["min_hours_to_change_password"] = *in.Config.MinHoursToChangePassword
+	}
+
+	return []interface{}{mIn}
+}

--- a/ibm/data_source_ibm_appid_apm_test.go
+++ b/ibm/data_source_ibm_appid_apm_test.go
@@ -1,0 +1,72 @@
+package ibm
+
+import (
+	"fmt"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"testing"
+)
+
+func TestAccIBMAppIDAPMDataSource_basic(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: setupIBMAppIDAPMDataSourceConfig(appIDTenantID),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("data.ibm_appid_apm.apm", "tenant_id", appIDTenantID),
+					resource.TestCheckResourceAttr("data.ibm_appid_apm.apm", "enabled", "true"),
+					resource.TestCheckResourceAttr("data.ibm_appid_apm.apm", "prevent_password_with_username", "true"),
+					resource.TestCheckResourceAttr("data.ibm_appid_apm.apm", "password_reuse.0.enabled", "true"),
+					resource.TestCheckResourceAttr("data.ibm_appid_apm.apm", "password_reuse.0.max_password_reuse", "4"),
+					resource.TestCheckResourceAttr("data.ibm_appid_apm.apm", "password_expiration.0.enabled", "true"),
+					resource.TestCheckResourceAttr("data.ibm_appid_apm.apm", "password_expiration.0.days_to_expire", "25"),
+					resource.TestCheckResourceAttr("data.ibm_appid_apm.apm", "lockout_policy.0.enabled", "true"),
+					resource.TestCheckResourceAttr("data.ibm_appid_apm.apm", "lockout_policy.0.lockout_time_sec", "2600"),
+					resource.TestCheckResourceAttr("data.ibm_appid_apm.apm", "lockout_policy.0.num_of_attempts", "4"),
+					resource.TestCheckResourceAttr("data.ibm_appid_apm.apm", "min_password_change_interval.0.enabled", "true"),
+					resource.TestCheckResourceAttr("data.ibm_appid_apm.apm", "min_password_change_interval.0.min_hours_to_change_password", "1"),
+				),
+			},
+		},
+	})
+}
+
+func setupIBMAppIDAPMDataSourceConfig(tenantID string) string {
+	return fmt.Sprintf(`
+		resource "ibm_appid_apm" "apm" {
+			tenant_id = "%s"
+			enabled = true
+			prevent_password_with_username = true
+		
+			password_reuse {
+				enabled = true
+				max_password_reuse = 4
+			}
+		
+			password_expiration {
+				enabled = true
+				days_to_expire = 25
+			}
+		
+			lockout_policy {
+				enabled = true
+				lockout_time_sec = 2600
+				num_of_attempts = 4
+			}
+		
+			min_password_change_interval {
+				enabled = true
+				min_hours_to_change_password = 1
+			}
+		}
+
+		data "ibm_appid_apm" "apm" {
+			tenant_id = ibm_appid_apm.apm.tenant_id
+
+			depends_on = [
+				ibm_appid_apm.apm
+			]
+		}
+	`, tenantID)
+}

--- a/ibm/provider.go
+++ b/ibm/provider.go
@@ -173,6 +173,7 @@ func Provider() *schema.Provider {
 			"ibm_app_route":          dataSourceIBMAppRoute(),
 
 			// AppID
+			"ibm_appid_apm":                 dataSourceIBMAppIDAPM(),
 			"ibm_appid_application":         dataSourceIBMAppIDApplication(),
 			"ibm_appid_application_scopes":  dataSourceIBMAppIDApplicationScopes(),
 			"ibm_appid_application_roles":   dataSourceIBMAppIDApplicationRoles(),
@@ -436,7 +437,7 @@ func Provider() *schema.Provider {
 			"ibm_app_route":                         resourceIBMAppRoute(),
 
 			// AppID
-
+			"ibm_appid_apm":                 resourceIBMAppIDAPM(),
 			"ibm_appid_application":         resourceIBMAppIDApplication(),
 			"ibm_appid_application_scopes":  resourceIBMAppIDApplicationScopes(),
 			"ibm_appid_application_roles":   resourceIBMAppIDApplicationRoles(),

--- a/ibm/resource_ibm_appid_apm.go
+++ b/ibm/resource_ibm_appid_apm.go
@@ -25,6 +25,7 @@ func resourceIBMAppIDAPM() *schema.Resource {
 				Description: "The AppID instance GUID",
 				Type:        schema.TypeString,
 				Required:    true,
+				ForceNew:    true,
 			},
 			"enabled": {
 				Description: "`true` if APM is enabled",

--- a/ibm/resource_ibm_appid_apm.go
+++ b/ibm/resource_ibm_appid_apm.go
@@ -1,0 +1,330 @@
+package ibm
+
+import (
+	"context"
+	"github.com/IBM-Cloud/bluemix-go/helpers"
+	appid "github.com/IBM/appid-management-go-sdk/appidmanagementv4"
+	"github.com/IBM/go-sdk-core/v5/core"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"log"
+)
+
+func resourceIBMAppIDAPM() *schema.Resource {
+	return &schema.Resource{
+		Description:   "AppID advanced password management configuration (available for graduated tier only)",
+		ReadContext:   resourceIBMAppIDAPMRead,
+		CreateContext: resourceIBMAppIDAPMCreate,
+		UpdateContext: resourceIBMAppIDAPMCreate,
+		DeleteContext: resourceIBMAppIDAPMDelete,
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
+		Schema: map[string]*schema.Schema{
+			"tenant_id": {
+				Description: "The AppID instance GUID",
+				Type:        schema.TypeString,
+				Required:    true,
+			},
+			"enabled": {
+				Description: "`true` if APM is enabled",
+				Type:        schema.TypeBool,
+				Required:    true,
+			},
+			"prevent_password_with_username": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  false,
+			},
+			"password_reuse": {
+				Type:     schema.TypeList,
+				Required: true,
+				MaxItems: 1,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"enabled": {
+							Type:     schema.TypeBool,
+							Required: true,
+						},
+						"max_password_reuse": {
+							Type:     schema.TypeInt,
+							Optional: true,
+							Default:  8,
+						},
+					},
+				},
+			},
+			"password_expiration": {
+				Type:     schema.TypeList,
+				Required: true,
+				MaxItems: 1,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"enabled": {
+							Type:     schema.TypeBool,
+							Required: true,
+						},
+						"days_to_expire": {
+							Type:     schema.TypeInt,
+							Optional: true,
+							Default:  30,
+						},
+					},
+				},
+			},
+			"lockout_policy": {
+				Type:     schema.TypeList,
+				Required: true,
+				MaxItems: 1,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"enabled": {
+							Type:     schema.TypeBool,
+							Required: true,
+						},
+						"lockout_time_sec": {
+							Type:     schema.TypeInt,
+							Optional: true,
+							Default:  1800,
+						},
+						"num_of_attempts": {
+							Type:     schema.TypeInt,
+							Optional: true,
+							Default:  3,
+						},
+					},
+				},
+			},
+			"min_password_change_interval": {
+				Type:     schema.TypeList,
+				Required: true,
+				MaxItems: 1,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"enabled": {
+							Type:     schema.TypeBool,
+							Required: true,
+						},
+						"min_hours_to_change_password": {
+							Type:     schema.TypeInt,
+							Optional: true,
+							Default:  0,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func resourceIBMAppIDAPMRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	appIDClient, err := meta.(ClientSession).AppIDAPI()
+
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	tenantID := d.Id()
+
+	apm, resp, err := appIDClient.GetCloudDirectoryAdvancedPasswordManagementWithContext(ctx, &appid.GetCloudDirectoryAdvancedPasswordManagementOptions{
+		TenantID: &tenantID,
+	})
+
+	if err != nil {
+		if resp != nil && resp.StatusCode == 404 {
+			log.Printf("[WARN] AppID instance '%s' is not found, removing APM configuration from state", tenantID)
+			d.SetId("")
+			return nil
+		}
+
+		return diag.Errorf("Error getting AppID APM configuration: %s", err)
+	}
+
+	if apm.AdvancedPasswordManagement != nil {
+		d.Set("enabled", *apm.AdvancedPasswordManagement.Enabled)
+
+		if err := d.Set("password_reuse", flattenAppIDAPMPasswordReuse(apm.AdvancedPasswordManagement.PasswordReuse)); err != nil {
+			return diag.Errorf("Failed setting AppID APM password_reuse: %s", err)
+		}
+
+		if apm.AdvancedPasswordManagement.PreventPasswordWithUsername != nil {
+			d.Set("prevent_password_with_username", *apm.AdvancedPasswordManagement.PreventPasswordWithUsername.Enabled)
+		}
+
+		if err := d.Set("password_expiration", flattenAppIDAPMPasswordExpiration(apm.AdvancedPasswordManagement.PasswordExpiration)); err != nil {
+			return diag.Errorf("Failed setting AppID APM password_expiration: %s", err)
+		}
+
+		if err := d.Set("lockout_policy", flattenAppIDAPMLockoutPolicy(apm.AdvancedPasswordManagement.LockOutPolicy)); err != nil {
+			return diag.Errorf("Failed setting AppID APM lockout_policy: %s", err)
+		}
+		if err := d.Set("min_password_change_interval", flattenAppIDAPMPasswordChangeInterval(apm.AdvancedPasswordManagement.MinPasswordChangeInterval)); err != nil {
+			return diag.Errorf("Failed setting AppID APM min_password_change_interval: %s", err)
+		}
+
+	}
+
+	d.Set("tenant_id", tenantID)
+	return nil
+}
+
+func resourceIBMAppIDAPMCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	appIDClient, err := meta.(ClientSession).AppIDAPI()
+
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	tenantID := d.Get("tenant_id").(string)
+	enabled := d.Get("enabled").(bool)
+
+	config := &appid.SetCloudDirectoryAdvancedPasswordManagementOptions{
+		TenantID: &tenantID,
+		AdvancedPasswordManagement: &appid.ApmSchemaAdvancedPasswordManagement{
+			Enabled:                   &enabled,
+			PasswordReuse:             expandAppIDAPMPasswordReuse(d.Get("password_reuse").([]interface{})),
+			PasswordExpiration:        expandAppIDAPMPasswordExpiration(d.Get("password_expiration").([]interface{})),
+			LockOutPolicy:             expandAppIDAPMLockoutPolicy(d.Get("lockout_policy").([]interface{})),
+			MinPasswordChangeInterval: expandAppIDAPMMinPasswordChangeInterval(d.Get("min_password_change_interval").([]interface{})),
+			PreventPasswordWithUsername: &appid.ApmSchemaAdvancedPasswordManagementPreventPasswordWithUsername{
+				Enabled: helpers.Bool(d.Get("prevent_password_with_username").(bool)),
+			},
+		},
+	}
+
+	_, _, err = appIDClient.SetCloudDirectoryAdvancedPasswordManagementWithContext(ctx, config)
+
+	if err != nil {
+		return diag.Errorf("Error updating AppID APM configuration: %s", err)
+	}
+
+	d.SetId(tenantID)
+	return resourceIBMAppIDAPMRead(ctx, d, meta)
+}
+
+func expandAppIDAPMPasswordReuse(reuse []interface{}) *appid.ApmSchemaAdvancedPasswordManagementPasswordReuse {
+	if len(reuse) == 0 || reuse[0] == nil {
+		return nil
+	}
+
+	mReuse := reuse[0].(map[string]interface{})
+
+	result := &appid.ApmSchemaAdvancedPasswordManagementPasswordReuse{
+		Enabled: helpers.Bool(mReuse["enabled"].(bool)),
+		Config: &appid.ApmSchemaAdvancedPasswordManagementPasswordReuseConfig{
+			MaxPasswordReuse: core.Int64Ptr(int64(mReuse["max_password_reuse"].(int))),
+		},
+	}
+
+	return result
+}
+
+func expandAppIDAPMPasswordExpiration(exp []interface{}) *appid.ApmSchemaAdvancedPasswordManagementPasswordExpiration {
+	if len(exp) == 0 || exp[0] == nil {
+		return nil
+	}
+
+	mExp := exp[0].(map[string]interface{})
+
+	result := &appid.ApmSchemaAdvancedPasswordManagementPasswordExpiration{
+		Enabled: helpers.Bool(mExp["enabled"].(bool)),
+		Config: &appid.ApmSchemaAdvancedPasswordManagementPasswordExpirationConfig{
+			DaysToExpire: core.Int64Ptr(int64(mExp["days_to_expire"].(int))),
+		},
+	}
+
+	return result
+}
+
+func expandAppIDAPMLockoutPolicy(loc []interface{}) *appid.ApmSchemaAdvancedPasswordManagementLockOutPolicy {
+	if len(loc) == 0 || loc[0] == nil {
+		return nil
+	}
+
+	mLock := loc[0].(map[string]interface{})
+
+	result := &appid.ApmSchemaAdvancedPasswordManagementLockOutPolicy{
+		Enabled: helpers.Bool(mLock["enabled"].(bool)),
+		Config: &appid.ApmSchemaAdvancedPasswordManagementLockOutPolicyConfig{
+			LockOutTimeSec: core.Int64Ptr(int64(mLock["lockout_time_sec"].(int))),
+			NumOfAttempts:  core.Int64Ptr(int64(mLock["num_of_attempts"].(int))),
+		},
+	}
+
+	return result
+}
+
+func expandAppIDAPMMinPasswordChangeInterval(chg []interface{}) *appid.ApmSchemaAdvancedPasswordManagementMinPasswordChangeInterval {
+	if len(chg) == 0 || chg[0] == nil {
+		return nil
+	}
+
+	mChg := chg[0].(map[string]interface{})
+
+	result := &appid.ApmSchemaAdvancedPasswordManagementMinPasswordChangeInterval{
+		Enabled: helpers.Bool(mChg["enabled"].(bool)),
+		Config: &appid.ApmSchemaAdvancedPasswordManagementMinPasswordChangeIntervalConfig{
+			MinHoursToChangePassword: core.Int64Ptr(int64(mChg["min_hours_to_change_password"].(int))),
+		},
+	}
+
+	return result
+}
+
+func resourceIBMAppIDAPMDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	appIDClient, err := meta.(ClientSession).AppIDAPI()
+
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	tenantID := d.Get("tenant_id").(string)
+	config := getDefaultAppIDAPMConfig()
+
+	_, _, err = appIDClient.SetCloudDirectoryAdvancedPasswordManagementWithContext(ctx, &appid.SetCloudDirectoryAdvancedPasswordManagementOptions{
+		TenantID:                   &tenantID,
+		AdvancedPasswordManagement: config,
+	})
+
+	if err != nil {
+		return diag.Errorf("Error resetting AppID APM configuration: %s", err)
+	}
+
+	d.SetId("")
+
+	return nil
+}
+
+func getDefaultAppIDAPMConfig() *appid.ApmSchemaAdvancedPasswordManagement {
+	return &appid.ApmSchemaAdvancedPasswordManagement{
+		Enabled: helpers.Bool(false),
+		PasswordReuse: &appid.ApmSchemaAdvancedPasswordManagementPasswordReuse{
+			Enabled: helpers.Bool(false),
+			Config: &appid.ApmSchemaAdvancedPasswordManagementPasswordReuseConfig{
+				MaxPasswordReuse: core.Int64Ptr(8),
+			},
+		},
+		PasswordExpiration: &appid.ApmSchemaAdvancedPasswordManagementPasswordExpiration{
+			Enabled: helpers.Bool(false),
+			Config: &appid.ApmSchemaAdvancedPasswordManagementPasswordExpirationConfig{
+				DaysToExpire: core.Int64Ptr(30),
+			},
+		},
+		MinPasswordChangeInterval: &appid.ApmSchemaAdvancedPasswordManagementMinPasswordChangeInterval{
+			Enabled: helpers.Bool(false),
+			Config: &appid.ApmSchemaAdvancedPasswordManagementMinPasswordChangeIntervalConfig{
+				MinHoursToChangePassword: core.Int64Ptr(0),
+			},
+		},
+		LockOutPolicy: &appid.ApmSchemaAdvancedPasswordManagementLockOutPolicy{
+			Enabled: helpers.Bool(false),
+			Config: &appid.ApmSchemaAdvancedPasswordManagementLockOutPolicyConfig{
+				LockOutTimeSec: core.Int64Ptr(1800),
+				NumOfAttempts:  core.Int64Ptr(3),
+			},
+		},
+		PreventPasswordWithUsername: &appid.ApmSchemaAdvancedPasswordManagementPreventPasswordWithUsername{
+			Enabled: helpers.Bool(false),
+		},
+	}
+}

--- a/ibm/resource_ibm_appid_apm_test.go
+++ b/ibm/resource_ibm_appid_apm_test.go
@@ -1,0 +1,135 @@
+package ibm
+
+import (
+	"fmt"
+	"github.com/IBM-Cloud/bluemix-go/helpers"
+	appid "github.com/IBM/appid-management-go-sdk/appidmanagementv4"
+	"github.com/IBM/go-sdk-core/v5/core"
+	"github.com/google/go-cmp/cmp"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"testing"
+)
+
+func TestAccIBMAppIDAPM_basic(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckIBMAppIDAPMDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: setupIBMAppIDAPMResourceConfig(appIDTenantID),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("ibm_appid_apm.apm", "tenant_id", appIDTenantID),
+					resource.TestCheckResourceAttr("ibm_appid_apm.apm", "enabled", "true"),
+					resource.TestCheckResourceAttr("ibm_appid_apm.apm", "prevent_password_with_username", "true"),
+					resource.TestCheckResourceAttr("ibm_appid_apm.apm", "password_reuse.0.enabled", "true"),
+					resource.TestCheckResourceAttr("ibm_appid_apm.apm", "password_reuse.0.max_password_reuse", "4"),
+					resource.TestCheckResourceAttr("ibm_appid_apm.apm", "password_expiration.0.enabled", "true"),
+					resource.TestCheckResourceAttr("ibm_appid_apm.apm", "password_expiration.0.days_to_expire", "25"),
+					resource.TestCheckResourceAttr("ibm_appid_apm.apm", "lockout_policy.0.enabled", "true"),
+					resource.TestCheckResourceAttr("ibm_appid_apm.apm", "lockout_policy.0.lockout_time_sec", "2600"),
+					resource.TestCheckResourceAttr("ibm_appid_apm.apm", "lockout_policy.0.num_of_attempts", "4"),
+					resource.TestCheckResourceAttr("ibm_appid_apm.apm", "min_password_change_interval.0.enabled", "true"),
+					resource.TestCheckResourceAttr("ibm_appid_apm.apm", "min_password_change_interval.0.min_hours_to_change_password", "1"),
+				),
+			},
+		},
+	})
+}
+
+func setupIBMAppIDAPMResourceConfig(tenantID string) string {
+	return fmt.Sprintf(`
+		resource "ibm_appid_apm" "apm" {
+			tenant_id = "%s"
+			enabled = true
+			prevent_password_with_username = true
+		
+			password_reuse {
+				enabled = true
+				max_password_reuse = 4
+			}
+		
+			password_expiration {
+				enabled = true
+				days_to_expire = 25
+			}
+		
+			lockout_policy {
+				enabled = true
+				lockout_time_sec = 2600
+				num_of_attempts = 4
+			}
+		
+			min_password_change_interval {
+				enabled = true
+				min_hours_to_change_password = 1
+			}
+		}
+	`, tenantID)
+}
+
+func testAccCheckIBMAppIDAPMDestroy(s *terraform.State) error {
+	appIDClient, err := testAccProvider.Meta().(ClientSession).AppIDAPI()
+
+	if err != nil {
+		return err
+	}
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "ibm_appid_apm" {
+			continue
+		}
+
+		tenantID := rs.Primary.ID
+
+		config, _, err := appIDClient.GetCloudDirectoryAdvancedPasswordManagement(&appid.GetCloudDirectoryAdvancedPasswordManagementOptions{
+			TenantID: &tenantID,
+		})
+
+		if err != nil {
+			return fmt.Errorf("Error checking if AppID APM configuration was reset: %s", err)
+		}
+
+		// verify that configuration is reset to defaults
+		defaults := &appid.ApmSchemaAdvancedPasswordManagement{
+			Enabled: helpers.Bool(false),
+			PasswordReuse: &appid.ApmSchemaAdvancedPasswordManagementPasswordReuse{
+				Enabled: helpers.Bool(false),
+				Config: &appid.ApmSchemaAdvancedPasswordManagementPasswordReuseConfig{
+					MaxPasswordReuse: core.Int64Ptr(8),
+				},
+			},
+			PasswordExpiration: &appid.ApmSchemaAdvancedPasswordManagementPasswordExpiration{
+				Enabled: helpers.Bool(false),
+				Config: &appid.ApmSchemaAdvancedPasswordManagementPasswordExpirationConfig{
+					DaysToExpire: core.Int64Ptr(30),
+				},
+			},
+			MinPasswordChangeInterval: &appid.ApmSchemaAdvancedPasswordManagementMinPasswordChangeInterval{
+				Enabled: helpers.Bool(false),
+				Config: &appid.ApmSchemaAdvancedPasswordManagementMinPasswordChangeIntervalConfig{
+					MinHoursToChangePassword: core.Int64Ptr(0),
+				},
+			},
+			LockOutPolicy: &appid.ApmSchemaAdvancedPasswordManagementLockOutPolicy{
+				Enabled: helpers.Bool(false),
+				Config: &appid.ApmSchemaAdvancedPasswordManagementLockOutPolicyConfig{
+					LockOutTimeSec: core.Int64Ptr(1800),
+					NumOfAttempts:  core.Int64Ptr(3),
+				},
+			},
+			PreventPasswordWithUsername: &appid.ApmSchemaAdvancedPasswordManagementPreventPasswordWithUsername{
+				Enabled: helpers.Bool(false),
+			},
+		}
+
+		diff := cmp.Diff(config.AdvancedPasswordManagement, defaults)
+
+		if config == nil || diff != "" {
+			return fmt.Errorf("Error checking if AppID APM configuration was reset: %s", diff)
+		}
+	}
+
+	return nil
+}

--- a/ibm/resource_ibm_appid_token_config.go
+++ b/ibm/resource_ibm_appid_token_config.go
@@ -7,15 +7,12 @@ import (
 	"context"
 	"github.com/IBM-Cloud/bluemix-go/helpers"
 	appid "github.com/IBM/appid-management-go-sdk/appidmanagementv4"
+	"github.com/IBM/go-sdk-core/v5/core"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"log"
 )
-
-func int64Ptr(v int64) *int64 {
-	return &v
-}
 
 func resourceIBMAppIDTokenConfig() *schema.Resource {
 	return &schema.Resource{
@@ -237,19 +234,19 @@ func expandTokenConfig(d *schema.ResourceData) *appid.PutTokensConfigOptions {
 
 	if accessExpiresIn, ok := d.GetOk("access_token_expires_in"); ok {
 		config.Access = &appid.AccessTokenConfigParams{
-			ExpiresIn: int64Ptr(int64(accessExpiresIn.(int))),
+			ExpiresIn: core.Int64Ptr(int64(accessExpiresIn.(int))),
 		}
 	}
 
 	if anonymousExpiresIn, ok := d.GetOk("anonymous_token_expires_in"); ok {
 		config.AnonymousAccess = &appid.TokenConfigParams{
-			ExpiresIn: int64Ptr(int64(anonymousExpiresIn.(int))),
+			ExpiresIn: core.Int64Ptr(int64(anonymousExpiresIn.(int))),
 		}
 	}
 
 	if refreshExpiresIn, ok := d.GetOk("refresh_token_expires_in"); ok {
 		config.Refresh = &appid.TokenConfigParams{
-			ExpiresIn: int64Ptr(int64(refreshExpiresIn.(int))),
+			ExpiresIn: core.Int64Ptr(int64(refreshExpiresIn.(int))),
 		}
 	}
 
@@ -293,15 +290,15 @@ func tokenConfigDefaults(tenantID string) *appid.PutTokensConfigOptions {
 	return &appid.PutTokensConfigOptions{
 		TenantID: helpers.String(tenantID),
 		Access: &appid.AccessTokenConfigParams{
-			ExpiresIn: int64Ptr(3600),
+			ExpiresIn: core.Int64Ptr(3600),
 		},
 		Refresh: &appid.TokenConfigParams{
 			Enabled:   helpers.Bool(false),
-			ExpiresIn: int64Ptr(2592000),
+			ExpiresIn: core.Int64Ptr(2592000),
 		},
 		AnonymousAccess: &appid.TokenConfigParams{
 			Enabled:   helpers.Bool(true),
-			ExpiresIn: int64Ptr(2592000),
+			ExpiresIn: core.Int64Ptr(2592000),
 		},
 	}
 }

--- a/website/docs/d/appid_apm.html.markdown
+++ b/website/docs/d/appid_apm.html.markdown
@@ -3,7 +3,7 @@ subcategory: "AppID Management"
 layout: "ibm"
 page_title: "IBM: AppID APM"
 description: |-
-Retrieves AppID information for Advanced Password Management.
+    Retrieves AppID information for Advanced Password Management.
 ---
 
 # ibm_appid_apm

--- a/website/docs/d/appid_apm.html.markdown
+++ b/website/docs/d/appid_apm.html.markdown
@@ -1,0 +1,52 @@
+---
+subcategory: "AppID Management"
+layout: "ibm"
+page_title: "IBM: AppID APM"
+description: |-
+Retrieves AppID information for Advanced Password Management.
+---
+
+# ibm_appid_apm
+Retrieve information about an IBM Cloud AppID Management Services APM.
+
+~> **WARNING:** This feature is only available for AppID graduated tier plans.
+
+## Example usage
+
+```terraform
+data "ibm_appid_apm" "app" {
+    tenant_id = var.tenant_id   
+}
+```
+
+## Argument reference
+Review the argument references that you can specify for your data source.
+
+- `tenant_id` - (Required, String) The AppID instance GUID
+
+## Attribute reference
+In addition to all argument reference list, you can access the following attribute references after your data source is created
+
+- `enabled` (Boolean) `true` if APM is enabled
+- `lockout_policy` (List of Object)
+    Nested scheme for `lockout_policy`:
+    - `enabled` - (Bool) Enable lockout policy
+    - `lockout_time_sec` - (Int) Lockout timeout in seconds
+    - `num_of_attempts` - (Int) Number of invalid attempts before lockout
+
+- `min_password_change_interval` (List of Object)
+    Nested scheme for `min_password_change_interval`:
+    - `enabled` - (Bool) Enable minimum password change interval policy
+    - `min_hours_to_change_password` (Int) Min amount of hours between password changes
+
+- `password_expiration` (List of Object)
+    Nested scheme for `password_expiration`:
+    - `enabled` - (Bool) Enable password expiration policy
+    - `days_to_expire` - (Int) Days until password expires
+
+- `password_reuse` (List of Object)
+    Nested scheme for `password_reuse`:
+    - `enabled` - (Bool) Enable password reuse policy
+    - `max_password_reuse` (Int) Maximum password reuse
+
+- `prevent_password_with_username` (Boolean) `true` to prevent username in passwords

--- a/website/docs/r/appid_apm.html.markdown
+++ b/website/docs/r/appid_apm.html.markdown
@@ -1,0 +1,88 @@
+---
+subcategory: "AppID Management"
+layout: "ibm"
+page_title: "IBM: AppID APM"
+description: |-
+Provides AppID Advanced Password Management resource.
+---
+
+# ibm_appid_apm
+
+Update or reset an IBM Cloud AppID Management Services APM configuration.
+
+~> **WARNING:** This feature is only available for AppID graduated tier plans.
+
+## Example usage
+
+```terraform
+resource "ibm_appid_apm" "apm" {
+  tenant_id = var.tenant_id
+  enabled = true
+  prevent_password_with_username = true
+
+  password_reuse {
+    enabled = true
+    max_password_reuse = 4
+  }
+
+  password_expiration {
+    enabled = true
+    days_to_expire = 25
+  }
+
+  lockout_policy {
+    enabled = true
+    lockout_time_sec = 2600
+    num_of_attempts = 4
+  }
+
+  min_password_change_interval {
+    enabled = true
+    min_hours_to_change_password = 1
+  }
+}
+```
+
+## Argument reference
+Review the argument references that you can specify for your resource.
+
+- `tenant_id` - (Required, String) The AppID instance GUID
+- `enabled` (Required, Boolean) `true` if APM is enabled
+- `lockout_policy` (Required, List of Object, Max: 1)
+  Nested scheme for `lockout_policy`:
+    - `enabled` - (Required, Bool) Enable lockout policy
+    - `lockout_time_sec` - (Optional, Int) Lockout timeout in seconds (Default: 1800)
+    - `num_of_attempts` - (Optional, Int) Number of invalid attempts before lockout (Default: 3)
+
+- `min_password_change_interval` (Required, List of Object, Max: 1)
+  Nested scheme for `min_password_change_interval`:
+    - `enabled` - (Required, Bool) Enable minimum password change interval policy
+    - `min_hours_to_change_password` (Optional, Int) Min amount of hours between password changes
+
+- `password_expiration` (Required, List of Object, Max: 1)
+  Nested scheme for `password_expiration`:
+    - `enabled` - (Required, Bool) Enable password expiration policy
+    - `days_to_expire` - (Optional, Int) Days until password expires (Default: 30)
+
+- `password_reuse` (Required, List of Object, Max: 1)
+  Nested scheme for `password_reuse`:
+    - `enabled` - (Required, Bool) Enable password reuse policy
+    - `max_password_reuse` (Optional, Int) Maximum password reuse (Default: 8)
+
+- `prevent_password_with_username` (Optional, Boolean) `true` to prevent username in passwords (Default: false)
+
+
+## Import
+
+The `ibm_appid_apm` resource can be imported by using the AppID tenant ID.
+
+**Syntax**
+
+```bash
+$ terraform import ibm_appid_apm.apm <tenant_id>
+```
+**Example**
+
+```bash
+$ terraform import ibm_appid_apm.apm 5fa344a8-d361-4bc2-9051-58ca253f4b2b
+```

--- a/website/docs/r/appid_apm.html.markdown
+++ b/website/docs/r/appid_apm.html.markdown
@@ -3,7 +3,7 @@ subcategory: "AppID Management"
 layout: "ibm"
 page_title: "IBM: AppID APM"
 description: |-
-Provides AppID Advanced Password Management resource.
+  Provides AppID Advanced Password Management resource.
 ---
 
 # ibm_appid_apm


### PR DESCRIPTION
## New AppID APM (Advanced Password Management) Data Source and Resource

AppID Swagger UI: https://us-south.appid.cloud.ibm.com/swagger-ui

APM documentation: https://cloud.ibm.com/apidocs/app-id/management#get-cloud-directory-advanced-password-management

<!--- See what makes a good Pull Request at : https://github.com/IBM-Cloud/terraform-provider-ibm/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test $(go list ./... |grep -v 'vendor') -v -run TestAccIBMAppIDAPM* -timeout 700m
=== RUN   TestAccIBMAppIDAPMDataSource_basic
--- PASS: TestAccIBMAppIDAPMDataSource_basic (49.38s)
=== RUN   TestAccIBMAppIDAPM_basic
--- PASS: TestAccIBMAppIDAPM_basic (48.13s)
PASS
```
