### PR TITLE
feature: added support for identifier in is_image datasource

### DIFF
--- a/website/docs/d/is_image.html.markdown
+++ b/website/docs/d/is_image.html.markdown
@@ -17,13 +17,21 @@ Retrieve information of an existing IBM Cloud Infrastructure image as a read-onl
 data "ibm_is_image" "ds_image" {
   name = "centos-7.x-amd64"
 }
+```
+```terraform
 
+data "ibm_is_image" "ds_image1" {
+  identifier = "d7bec597-4726-451f-8a63-e62e6f121c32c"
+}
 ```
 
 ## Argument reference
 Review the argument references that you can specify for your data source.
 
-- `name` - (Required, String) The name of the image.
+- `identifier` - (Optional, String) The id of the image.
+    **NOTE** : One of `identifier` or  `name` is required
+- `name` - (Optional, String) The name of the image.
+    **NOTE** : One of `identifier` or  `name` is required
 - `visibility` - (Optional, String) The visibility of the image. Accepted values are `public` or `private`.
 
 ## Attribute reference


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/IBM-Cloud/terraform-provider-ibm/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #3009 

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```
