### PR TITLE
feat: add debugger integration

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -83,6 +83,14 @@
         "line_number": 70,
         "type": "Secret Keyword",
         "verified_result": null
+      },
+      {
+        "hashed_secret": "ce03478fd8ebabb095987a34c2f8405b76ea66d2",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 161,
+        "type": "Base64 High Entropy String",
+        "verified_result": null
       }
     ],
     "examples/ansible/examples/simple-vm-power-vs/README.md": [

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -15,6 +15,9 @@ tools:
 build: fmtcheck vet
 	go install
 
+build-dbg:
+	go install -gcflags "all=-N -l"
+
 bin: fmtcheck vet tools
 	@TF_RELEASE=1 sh -c "'$(CURDIR)/scripts/build.sh'"
 

--- a/README.md
+++ b/README.md
@@ -120,6 +120,47 @@ You will also need to export the following environment variables for running the
 
 Additional environment variables may be required depending on the tests being run. Check console log for warning messages about required variables. 
 
+## Debugging the Provider
+
+First, build the provider for debugging: `make build-dbg`
+
+Run your debugger (eg. [delve](https://github.com/go-delve/delve)), and pass it the provider binary as the command to run, specifying whatever flags, environment variables, or other input is necessary to start the provider in debug mode
+
+Example for `VSCode`:
+
+```bash
+dlv exec --listen=:54526 --headless $GOPATH/bin/terraform-provider-ibm -- --debug
+```
+
+Example for `IntelliJ`:
+
+```bash
+dlv exec --api-version=2 --listen=:54526 --headless $GOPATH/bin/terraform-provider-ibm -- --debug
+```
+
+Connect your debugger (whether it's your IDE or the debugger client) to the debugger server. Example launch configuration for VSCode:
+
+```json
+{
+    "apiVersion": 1,
+    "name": "Debug",
+    "type": "go",
+    "request": "attach",
+    "mode": "remote",
+    "port": 54526, 
+    "host": "127.0.0.1",
+    "showLog": true
+}
+```
+
+Let it continue execution, it will print output like the following to stdout:
+
+```bash
+Provider started, to attach Terraform set the TF_REATTACH_PROVIDERS env var:
+
+        TF_REATTACH_PROVIDERS='{"IBM-Cloud/ibm":{"Protocol":"grpc","ProtocolVersion":5,"Pid":55933,"Test":true,"Addr":{"Network":"unix","String":"/var/folders/mq/00hw97gj08323ybqfm763plr0000gn/T/plugin816369936"}}}'
+```
+Copy the line starting with `TF_REATTACH_PROVIDERS` from your provider's output. Either export it, or prefix every Terraform command with it. Run Terraform as usual. Any breakpoints you have set will halt execution and show you the current variable values.
 
 # IBM Cloud Ansible Modules
 

--- a/main.go
+++ b/main.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"context"
+	"flag"
 	"log"
 
 	"github.com/IBM-Cloud/terraform-provider-ibm/ibm"
@@ -9,8 +11,24 @@ import (
 )
 
 func main() {
+	var debugMode bool
+
 	log.Println("IBM Cloud Provider version", version.Version, version.VersionPrerelease, version.GitCommit)
-	plugin.Serve(&plugin.ServeOpts{
+
+	flag.BoolVar(&debugMode, "debug", false, "set to true to run the IBM terraform provider with support for debuggers like delve")
+	flag.Parse()
+
+	opts := &plugin.ServeOpts{
 		ProviderFunc: ibm.Provider,
-	})
+	}
+
+	if debugMode {
+		err := plugin.Debug(context.Background(), "registry.terraform.io/IBM-Cloud/ibm", opts)
+		if err != nil {
+			log.Fatal(err.Error())
+		}
+		return
+	}
+
+	plugin.Serve(opts)
 }


### PR DESCRIPTION
Terraform supports using debuggers like `delve` to debug providers, this is following their examples on how to integrate it:

https://www.terraform.io/docs/extend/debugging.html

<!--- See what makes a good Pull Request at : https://github.com/IBM-Cloud/terraform-provider-ibm/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Output from acceptance testing:

This does not affect any resources or data sources, it only adds `debug` flag support in main function
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
