### PR TITLE
feat: add appid action url datasource and resource

### DIFF
--- a/ibm/data_source_ibm_appid_action_url.go
+++ b/ibm/data_source_ibm_appid_action_url.go
@@ -1,0 +1,63 @@
+package ibm
+
+import (
+	"context"
+	"fmt"
+	appid "github.com/IBM/appid-management-go-sdk/appidmanagementv4"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+)
+
+func dataSourceIBMAppIDActionURL() *schema.Resource {
+	return &schema.Resource{
+		Description: "The custom url to redirect to when Cloud Directory action is executed.",
+		ReadContext: dataSourceIBMAppIDActionURLRead,
+		Schema: map[string]*schema.Schema{
+			"tenant_id": {
+				Description: "The AppID instance GUID",
+				Type:        schema.TypeString,
+				Required:    true,
+			},
+			"action": {
+				Description:  "The type of the action: `on_user_verified` - the URL of your custom user verified page, `on_reset_password` - the URL of your custom reset password page",
+				Type:         schema.TypeString,
+				ValidateFunc: validation.StringInSlice([]string{"on_user_verified", "on_reset_password"}, false),
+				Required:     true,
+			},
+			"url": {
+				Description: "The action URL",
+				Type:        schema.TypeString,
+				Computed:    true,
+			},
+		},
+	}
+}
+
+func dataSourceIBMAppIDActionURLRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	appIDClient, err := meta.(ClientSession).AppIDAPI()
+
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	tenantID := d.Get("tenant_id").(string)
+	action := d.Get("action").(string)
+
+	resp, _, err := appIDClient.GetCloudDirectoryActionURLWithContext(ctx, &appid.GetCloudDirectoryActionURLOptions{
+		TenantID: &tenantID,
+		Action:   &action,
+	})
+
+	if err != nil {
+		return diag.Errorf("Error getting AppID actionURL: %s", err)
+	}
+
+	if resp.ActionURL != nil {
+		d.Set("url", *resp.ActionURL)
+	}
+
+	d.SetId(fmt.Sprintf("%s/%s", tenantID, action))
+
+	return nil
+}

--- a/ibm/data_source_ibm_appid_action_url_test.go
+++ b/ibm/data_source_ibm_appid_action_url_test.go
@@ -1,0 +1,43 @@
+package ibm
+
+import (
+	"fmt"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"testing"
+)
+
+func TestAccIBMAppIDActionURLDataSource_basic(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: setupAppIDActionURLDataSourceConfig(appIDTenantID),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("data.ibm_appid_action_url.url", "tenant_id", appIDTenantID),
+					resource.TestCheckResourceAttr("data.ibm_appid_action_url.url", "action", "on_user_verified"),
+					resource.TestCheckResourceAttr("data.ibm_appid_action_url.url", "url", "https://www.example.com/?user=verified"),
+				),
+			},
+		},
+	})
+}
+
+func setupAppIDActionURLDataSourceConfig(tenantID string) string {
+	return fmt.Sprintf(`
+		resource "ibm_appid_action_url" "url" {
+			tenant_id = "%s"
+			action = "on_user_verified"
+			url = "https://www.example.com/?user=verified"
+		}
+
+		data "ibm_appid_action_url" "url" {
+			tenant_id = ibm_appid_action_url.url.tenant_id
+			action = "on_user_verified"
+
+			depends_on = [
+				ibm_appid_action_url.url
+			]
+		}
+	`, tenantID)
+}

--- a/ibm/provider.go
+++ b/ibm/provider.go
@@ -173,6 +173,7 @@ func Provider() *schema.Provider {
 			"ibm_app_route":          dataSourceIBMAppRoute(),
 
 			// AppID
+			"ibm_appid_action_url":          dataSourceIBMAppIDActionURL(),
 			"ibm_appid_apm":                 dataSourceIBMAppIDAPM(),
 			"ibm_appid_application":         dataSourceIBMAppIDApplication(),
 			"ibm_appid_application_scopes":  dataSourceIBMAppIDApplicationScopes(),
@@ -438,6 +439,7 @@ func Provider() *schema.Provider {
 			"ibm_app_route":                         resourceIBMAppRoute(),
 
 			// AppID
+			"ibm_appid_action_url":          resourceIBMAppIDActionURL(),
 			"ibm_appid_apm":                 resourceIBMAppIDAPM(),
 			"ibm_appid_application":         resourceIBMAppIDApplication(),
 			"ibm_appid_application_scopes":  resourceIBMAppIDApplicationScopes(),

--- a/ibm/resource_ibm_appid_action_url.go
+++ b/ibm/resource_ibm_appid_action_url.go
@@ -1,0 +1,143 @@
+package ibm
+
+import (
+	"context"
+	"fmt"
+	appid "github.com/IBM/appid-management-go-sdk/appidmanagementv4"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	"log"
+	"strings"
+)
+
+func resourceIBMAppIDActionURL() *schema.Resource {
+	return &schema.Resource{
+		Description:   "The custom url to redirect to when Cloud Directory action is executed.",
+		CreateContext: resourceIBMAppIDActionURLCreate,
+		ReadContext:   resourceIBMAppIDActionURLRead,
+		DeleteContext: resourceIBMAppIDActionURLDelete,
+		UpdateContext: resourceIBMAppIDActionURLUpdate,
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
+		Schema: map[string]*schema.Schema{
+			"tenant_id": {
+				Description: "The AppID instance GUID",
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+			},
+			"action": {
+				Description:  "The type of the action: `on_user_verified` - the URL of your custom user verified page, `on_reset_password` - the URL of your custom reset password page",
+				Type:         schema.TypeString,
+				ValidateFunc: validation.StringInSlice([]string{"on_user_verified", "on_reset_password"}, false),
+				Required:     true,
+				ForceNew:     true,
+			},
+			"url": {
+				Description: "The action URL",
+				Type:        schema.TypeString,
+				Required:    true,
+			},
+		},
+	}
+}
+
+func resourceIBMAppIDActionURLRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	appIDClient, err := meta.(ClientSession).AppIDAPI()
+
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	id := d.Id()
+	idParts := strings.Split(id, "/")
+
+	if len(idParts) < 2 {
+		return diag.Errorf("Incorrect ID %s: AppID action URL ID should be a combination of tenantID/action", id)
+	}
+
+	tenantID := idParts[0]
+	action := idParts[1]
+
+	cfg, resp, err := appIDClient.GetCloudDirectoryActionURLWithContext(ctx, &appid.GetCloudDirectoryActionURLOptions{
+		TenantID: &tenantID,
+		Action:   &action,
+	})
+
+	if err != nil {
+		if resp != nil && resp.StatusCode == 404 {
+			log.Printf("[WARN] AppID instance '%s' is not found, removing Action URL from state", tenantID)
+			d.SetId("")
+			return nil
+		}
+
+		return diag.Errorf("Error getting AppID actionURL: %s", err)
+	}
+
+	if cfg.ActionURL != nil {
+		d.Set("url", *cfg.ActionURL)
+	}
+
+	d.Set("tenant_id", tenantID)
+	d.Set("action", action)
+
+	return nil
+}
+
+func resourceIBMAppIDActionURLCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	appIDClient, err := meta.(ClientSession).AppIDAPI()
+
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	tenantID := d.Get("tenant_id").(string)
+	action := d.Get("action").(string)
+	actionURL := d.Get("url").(string)
+
+	input := &appid.SetCloudDirectoryActionOptions{
+		TenantID:  &tenantID,
+		Action:    &action,
+		ActionURL: &actionURL,
+	}
+
+	_, _, err = appIDClient.SetCloudDirectoryActionWithContext(ctx, input)
+
+	if err != nil {
+		return diag.Errorf("Error setting AppID Cloud Directory action URL: %s", err)
+	}
+
+	d.SetId(fmt.Sprintf("%s/%s", tenantID, action))
+
+	return resourceIBMAppIDActionURLRead(ctx, d, meta)
+}
+
+func resourceIBMAppIDActionURLDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	appIDClient, err := meta.(ClientSession).AppIDAPI()
+
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	tenantID := d.Get("tenant_id").(string)
+	action := d.Get("action").(string)
+
+	_, err = appIDClient.DeleteActionURLWithContext(ctx, &appid.DeleteActionURLOptions{
+		TenantID: &tenantID,
+		Action:   &action,
+	})
+
+	if err != nil {
+		return diag.Errorf("Error deleting AppID Cloud Directory action URL: %s", err)
+	}
+
+	d.SetId("")
+
+	return nil
+}
+
+func resourceIBMAppIDActionURLUpdate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	return resourceIBMAppIDActionURLCreate(ctx, d, m)
+}

--- a/ibm/resource_ibm_appid_action_url_test.go
+++ b/ibm/resource_ibm_appid_action_url_test.go
@@ -1,0 +1,70 @@
+package ibm
+
+import (
+	"fmt"
+	appid "github.com/IBM/appid-management-go-sdk/appidmanagementv4"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"strings"
+	"testing"
+)
+
+func TestAccIBMAppIDActionURL_basic(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckIBMAppIDActionURLDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: setupAppIDActionURLConfig(appIDTenantID),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("ibm_appid_action_url.url", "tenant_id", appIDTenantID),
+					resource.TestCheckResourceAttr("ibm_appid_action_url.url", "action", "on_reset_password"),
+					resource.TestCheckResourceAttr("ibm_appid_action_url.url", "url", "https://www.example.com/psw-reset"),
+				),
+			},
+		},
+	})
+}
+
+func setupAppIDActionURLConfig(tenantID string) string {
+	return fmt.Sprintf(`
+		resource "ibm_appid_action_url" "url" {
+			tenant_id = "%s"
+			action = "on_reset_password"
+			url = "https://www.example.com/psw-reset"
+		}	
+	`, tenantID)
+}
+
+func testAccCheckIBMAppIDActionURLDestroy(s *terraform.State) error {
+	appIDClient, err := testAccProvider.Meta().(ClientSession).AppIDAPI()
+
+	if err != nil {
+		return err
+	}
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "ibm_appid_action_url" {
+			continue
+		}
+
+		id := rs.Primary.ID
+		idParts := strings.Split(id, "/")
+
+		tenantID := idParts[0]
+		action := idParts[1]
+
+		cfg, _, err := appIDClient.GetCloudDirectoryActionURL(&appid.GetCloudDirectoryActionURLOptions{
+			TenantID: &tenantID,
+			Action:   &action,
+		})
+
+		// when action URL is deleted it is returned as an empty string e.g. `{ actionUrl: "" }`
+		if err != nil || (cfg.ActionURL != nil && *cfg.ActionURL != "") {
+			return fmt.Errorf("error checking if AppID action URL (%s) has been destroyed", rs.Primary.ID)
+		}
+	}
+
+	return nil
+}

--- a/website/docs/d/appid_action_url.html.markdown
+++ b/website/docs/d/appid_action_url.html.markdown
@@ -1,0 +1,30 @@
+---
+subcategory: "AppID Management"
+layout: "ibm"
+page_title: "IBM: AppID Action URL"
+description: |-
+Retrieves AppID Action URL.
+---
+
+# ibm_appid_action_url
+Retrieve an IBM Cloud AppID Management Services action URL - the custom url to redirect to when Cloud Directory action is executed
+
+## Example usage
+
+```terraform
+data "ibm_appid_action_url" "url" {
+    tenant_id = var.tenant_id
+    action = "on_user_verified" 
+}
+```
+
+## Argument reference
+Review the argument references that you can specify for your data source.
+
+- `tenant_id` - (Required, String) The AppID instance GUID
+- `action` - (Required, String) The type of the action: `on_user_verified` - the URL of your custom user verified page, `on_reset_password` - the URL of your custom reset password page
+
+## Attribute reference
+In addition to all argument reference list, you can access the following attribute references after your data source is created
+
+- `url` - (String) The action URL

--- a/website/docs/r/appid_action_url.html.markdown
+++ b/website/docs/r/appid_action_url.html.markdown
@@ -1,0 +1,42 @@
+---
+subcategory: "AppID Management"
+layout: "ibm"
+page_title: "IBM: AppID Action URL"
+description: |-
+Provides AppID Action URL resource.
+---
+
+# ibm_appid_action_url
+
+Create, update, or delete an IBM Cloud AppID Management Services Action URL.
+
+## Example usage
+
+```terraform
+resource "ibm_appid_action_url" "url" {
+  tenant_id = var.tenant_id
+  action = "on_user_verified"
+}
+```
+
+## Argument reference
+Review the argument references that you can specify for your resource.
+
+- `tenant_id` - (Required, String) The AppID instance GUID
+- `action` - (Required, String) The type of the action: `on_user_verified` - the URL of your custom user verified page, `on_reset_password` - the URL of your custom reset password page
+- `url` - (String) The action URL
+
+## Import
+
+The `ibm_appid_action_url` resource can be imported by using the AppID tenant ID and action type string.
+
+**Syntax**
+
+```bash
+$ terraform import ibm_appid_action_url.url <tenant_id>/<action_type>
+```
+**Example**
+
+```bash
+$ terraform import ibm_appid_action_url.url 5fa344a8-d361-4bc2-9051-58ca253f4b2b/on_reset_password
+```


### PR DESCRIPTION
## New AppID Action URL Data Source and Resource

AppID Swagger UI: https://us-south.appid.cloud.ibm.com/swagger-ui

<!--- See what makes a good Pull Request at : https://github.com/IBM-Cloud/terraform-provider-ibm/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test $(go list ./... |grep -v 'vendor') -v -run TestAccIBMAppIDActionURL* -timeout 700m
=== RUN   TestAccIBMAppIDActionURLDataSource_basic
--- PASS: TestAccIBMAppIDActionURLDataSource_basic (40.67s)
=== RUN   TestAccIBMAppIDActionURL_basic
--- PASS: TestAccIBMAppIDActionURL_basic (38.56s)
PASS
```
