### PR TITLE
added forcenew for address_prefix_management in ibm_is_vpc

### DIFF
--- a/ibm/resource_ibm_is_vpc.go
+++ b/ibm/resource_ibm_is_vpc.go
@@ -81,12 +81,12 @@ func resourceIBMISVPC() *schema.Resource {
 
 		Schema: map[string]*schema.Schema{
 			isVPCAddressPrefixManagement: {
-				Type:             schema.TypeString,
-				Optional:         true,
-				Default:          "auto",
-				DiffSuppressFunc: applyOnce,
-				ValidateFunc:     InvokeValidator("ibm_is_vpc", isVPCAddressPrefixManagement),
-				Description:      "Address Prefix management value",
+				Type:         schema.TypeString,
+				Optional:     true,
+				Default:      "auto",
+				ForceNew:     true,
+				ValidateFunc: InvokeValidator("ibm_is_vpc", isVPCAddressPrefixManagement),
+				Description:  "Address Prefix management value",
 			},
 
 			isVPCDefaultNetworkACL: {

--- a/ibm/resource_ibm_is_vpc_test.go
+++ b/ibm/resource_ibm_is_vpc_test.go
@@ -67,6 +67,41 @@ func TestAccIBMISVPC_basic(t *testing.T) {
 	})
 }
 
+func TestAccIBMISVPC_basic_apm(t *testing.T) {
+	var vpc string
+	name := fmt.Sprintf("terraformvpcuat-%d", acctest.RandIntRange(10, 100))
+	apm1 := "auto"
+	apm2 := "manual"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckIBMISVPCDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckIBMISVPCConfig2(name, apm1),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckIBMISVPCExists("ibm_is_vpc.testacc_vpc1", vpc),
+					resource.TestCheckResourceAttr(
+						"ibm_is_vpc.testacc_vpc1", "name", name),
+					resource.TestCheckResourceAttr(
+						"ibm_is_vpc.testacc_vpc1", "address_prefix_management", apm1),
+				),
+			},
+			{
+				Config: testAccCheckIBMISVPCConfig2(name, apm2),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckIBMISVPCExists("ibm_is_vpc.testacc_vpc1", vpc),
+					resource.TestCheckResourceAttr(
+						"ibm_is_vpc.testacc_vpc1", "name", name),
+					resource.TestCheckResourceAttr(
+						"ibm_is_vpc.testacc_vpc1", "address_prefix_management", apm2),
+				),
+			},
+		},
+	})
+}
+
 func TestAccIBMISVPC_securityGroups(t *testing.T) {
 	var vpc string
 	vpcname := fmt.Sprintf("terraformvpcuat-%d", acctest.RandIntRange(10, 100))
@@ -137,33 +172,40 @@ func testAccCheckIBMISVPCExists(n, vpcID string) resource.TestCheckFunc {
 
 func testAccCheckIBMISVPCConfig(name string) string {
 	return fmt.Sprintf(`
-resource "ibm_is_vpc" "testacc_vpc" {
-	name = "%s"
-	default_network_acl_name = "dnwacln"
-    default_security_group_name = "dsgn"
-    default_routing_table_name = "drtn"
-	tags = ["Tag1", "tag2"]
-}`, name)
+	resource "ibm_is_vpc" "testacc_vpc" {
+		name = "%s"
+		default_network_acl_name = "dnwacln"
+		default_security_group_name = "dsgn"
+		default_routing_table_name = "drtn"
+		tags = ["Tag1", "tag2"]
+	}`, name)
 
 }
 
 func testAccCheckIBMISVPCConfigUpdate(name string) string {
 	return fmt.Sprintf(`
-resource "ibm_is_vpc" "testacc_vpc" {
-	name = "%s"
-	tags = ["tag1"]
-}`, name)
+	resource "ibm_is_vpc" "testacc_vpc" {
+		name = "%s"
+		tags = ["tag1"]
+	}`, name)
 
 }
 
 func testAccCheckIBMISVPCConfig1(name string, apm string) string {
 	return fmt.Sprintf(`
-resource "ibm_is_vpc" "testacc_vpc1" {
-	name = "%s"
-	address_prefix_management = "%s"
-	tags = ["Tag1", "tag2"]
-}`, name, apm)
+	resource "ibm_is_vpc" "testacc_vpc1" {
+		name = "%s"
+		address_prefix_management = "%s"
+		tags = ["Tag1", "tag2"]
+	}`, name, apm)
 
+}
+func testAccCheckIBMISVPCConfig2(name string, apm string) string {
+	return fmt.Sprintf(`
+	resource "ibm_is_vpc" "testacc_vpc1" {
+		name = "%s"
+		address_prefix_management = "%s"
+	}`, name, apm)
 }
 
 func testAccCheckIBMISVPCSgConfig(vpcname string, sgname string) string {

--- a/website/docs/r/is_vpc.html.markdown
+++ b/website/docs/r/is_vpc.html.markdown
@@ -30,7 +30,7 @@ The `ibm_is_vpc` resource provides the following [[Timeouts](https://www.terrafo
 ## Argument reference
 Review the argument references that you can specify for your resource. 
 
-- `address_prefix_management` - (Optional, String) Indicates whether a default address prefix should be created automatically `auto` or manually `manual` for each zone in this VPC. Default value is `auto`.
+- `address_prefix_management` - (Optional, Forces new resource, String) Indicates whether a default address prefix should be created automatically `auto` or manually `manual` for each zone in this VPC. Default value is `auto`.
 - `classic_access` - (Optional, Bool) Specify if you want to create a VPC that can connect to classic infrastructure resources. Enter **true** to set up private network connectivity from your VPC to classic infrastructure resources that are created in the same IBM Cloud account, and **false** to disable this access. If you choose to not set up this access, you cannot enable it after the VPC is created. Make sure to review the [prerequisites](https://cloud.ibm.com/docs/vpc-on-classic-network?topic=vpc-on-classic-setting-up-access-to-your-classic-infrastructure-from-vpc#vpc-prerequisites) before you create a VPC with classic infrastructure access. Note that you can enable one VPC for classic infrastructure access per IBM Cloud account only.
 - `default_network_acl`- (Deprecated, String) The ID of the default network ACL.
 - `default_network_acl_name` - (Optional, String) Enter the name of the default network access control list (ACL).


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/IBM-Cloud/terraform-provider-ibm/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->



<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #2994

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
=== RUN   TestAccIBMISVPC_basic
--- PASS: TestAccIBMISVPC_basic (228.74s)
=== RUN   TestAccIBMISVPC_basic_apm
--- PASS: TestAccIBMISVPC_basic_apm (162.74s)
PASS
ok      github.com/IBM-Cloud/terraform-provider-ibm/ibm 395.146s
```
