### PR TITLE
feat: add appid theme color datasource and resource

### DIFF
--- a/ibm/data_source_ibm_appid_theme_color.go
+++ b/ibm/data_source_ibm_appid_theme_color.go
@@ -1,0 +1,52 @@
+package ibm
+
+import (
+	"context"
+	appid "github.com/IBM/appid-management-go-sdk/appidmanagementv4"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+func dataSourceIBMAppIDThemeColor() *schema.Resource {
+	return &schema.Resource{
+		Description: "Colors of the App ID login widget",
+		ReadContext: dataSourceIBMAppIDThemeColorRead,
+		Schema: map[string]*schema.Schema{
+			"tenant_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "The AppID instance GUID",
+			},
+			"header_color": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func dataSourceIBMAppIDThemeColorRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	appIDClient, err := meta.(ClientSession).AppIDAPI()
+
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	tenantID := d.Get("tenant_id").(string)
+
+	colors, _, err := appIDClient.GetThemeColorWithContext(ctx, &appid.GetThemeColorOptions{
+		TenantID: &tenantID,
+	})
+
+	if err != nil {
+		return diag.Errorf("Error getting AppID theme colors: %s", err)
+	}
+
+	if colors.HeaderColor != nil {
+		d.Set("header_color", *colors.HeaderColor)
+	}
+
+	d.SetId(tenantID)
+
+	return nil
+}

--- a/ibm/data_source_ibm_appid_theme_color_test.go
+++ b/ibm/data_source_ibm_appid_theme_color_test.go
@@ -1,0 +1,40 @@
+package ibm
+
+import (
+	"fmt"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"testing"
+)
+
+func TestAccThemeColorDataSource_basic(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: setupAppIDThemeColorDataSourceConfig(appIDTenantID),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("data.ibm_appid_theme_color.color", "tenant_id", appIDTenantID),
+					resource.TestCheckResourceAttr("data.ibm_appid_theme_color.color", "header_color", "#000000"),
+				),
+			},
+		},
+	})
+}
+
+func setupAppIDThemeColorDataSourceConfig(tenantID string) string {
+	return fmt.Sprintf(`
+		resource "ibm_appid_theme_color" "color" {
+			tenant_id = "%s"
+			header_color = "#000000"
+		}
+
+		data "ibm_appid_theme_color" "color" {
+			tenant_id = ibm_appid_theme_color.color.tenant_id
+
+			depends_on = [
+				ibm_appid_theme_color.color
+			]
+		}
+	`, tenantID)
+}

--- a/ibm/provider.go
+++ b/ibm/provider.go
@@ -186,6 +186,7 @@ func Provider() *schema.Provider {
 			"ibm_appid_token_config":        dataSourceIBMAppIDTokenConfig(),
 			"ibm_appid_redirect_urls":       dataSourceIBMAppIDRedirectURLs(),
 			"ibm_appid_role":                dataSourceIBMAppIDRole(),
+			"ibm_appid_theme_color":         dataSourceIBMAppIDThemeColor(),
 			"ibm_appid_theme_text":          dataSourceIBMAppIDThemeText(),
 
 			"ibm_function_action":                    dataSourceIBMFunctionAction(),
@@ -456,6 +457,7 @@ func Provider() *schema.Provider {
 			"ibm_appid_token_config":        resourceIBMAppIDTokenConfig(),
 			"ibm_appid_redirect_urls":       resourceIBMAppIDRedirectURLs(),
 			"ibm_appid_role":                resourceIBMAppIDRole(),
+			"ibm_appid_theme_color":         resourceIBMAppIDThemeColor(),
 			"ibm_appid_theme_text":          resourceIBMAppIDThemeText(),
 
 			"ibm_function_action":                                resourceIBMFunctionAction(),

--- a/ibm/resource_ibm_appid_theme_color.go
+++ b/ibm/resource_ibm_appid_theme_color.go
@@ -1,0 +1,123 @@
+package ibm
+
+import (
+	"context"
+	"github.com/IBM-Cloud/bluemix-go/helpers"
+	appid "github.com/IBM/appid-management-go-sdk/appidmanagementv4"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"log"
+)
+
+const defaultHeaderColor = "#EEF2F5" // AppID default
+
+func resourceIBMAppIDThemeColor() *schema.Resource {
+	return &schema.Resource{
+		Description:   "Colors of the App ID login widget",
+		CreateContext: resourceIBMAppIDThemeColorCreate,
+		UpdateContext: resourceIBMAppIDThemeColorUpdate,
+		ReadContext:   resourceIBMAppIDThemeColorRead,
+		DeleteContext: resourceIBMAppIDThemeColorDelete,
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
+		Schema: map[string]*schema.Schema{
+			"tenant_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: "The AppID instance GUID",
+			},
+			"header_color": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+		},
+	}
+}
+
+func resourceIBMAppIDThemeColorRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	appIDClient, err := meta.(ClientSession).AppIDAPI()
+
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	tenantID := d.Id()
+
+	colors, resp, err := appIDClient.GetThemeColorWithContext(ctx, &appid.GetThemeColorOptions{
+		TenantID: &tenantID,
+	})
+
+	if err != nil {
+		if resp != nil && resp.StatusCode == 404 {
+			log.Printf("[WARN] AppID instance '%s' is not found, removing AppID theme color configuration from state", tenantID)
+			d.SetId("")
+			return nil
+		}
+
+		return diag.Errorf("Error getting AppID theme colors: %s", err)
+	}
+
+	if colors.HeaderColor != nil {
+		d.Set("header_color", *colors.HeaderColor)
+	}
+
+	d.Set("tenant_id", tenantID)
+
+	return nil
+}
+
+func resourceIBMAppIDThemeColorCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	appIDClient, err := meta.(ClientSession).AppIDAPI()
+
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	tenantID := d.Get("tenant_id").(string)
+
+	input := &appid.PostThemeColorOptions{
+		TenantID:    &tenantID,
+		HeaderColor: helpers.String(d.Get("header_color").(string)),
+	}
+
+	_, err = appIDClient.PostThemeColorWithContext(ctx, input)
+
+	if err != nil {
+		return diag.Errorf("Error setting AppID theme color: %s", err)
+	}
+
+	d.SetId(tenantID)
+
+	return resourceIBMAppIDThemeColorRead(ctx, d, meta)
+}
+
+func resourceIBMAppIDThemeColorUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	return resourceIBMAppIDThemeColorCreate(ctx, d, meta)
+}
+
+func resourceIBMAppIDThemeColorDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	appIDClient, err := meta.(ClientSession).AppIDAPI()
+
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	tenantID := d.Get("tenant_id").(string)
+
+	input := &appid.PostThemeColorOptions{
+		TenantID:    &tenantID,
+		HeaderColor: helpers.String(defaultHeaderColor),
+	}
+
+	_, err = appIDClient.PostThemeColorWithContext(ctx, input)
+
+	if err != nil {
+		return diag.Errorf("Error resetting AppID theme color: %s", err)
+	}
+
+	d.SetId("")
+
+	return nil
+}

--- a/ibm/resource_ibm_appid_theme_color_test.go
+++ b/ibm/resource_ibm_appid_theme_color_test.go
@@ -1,0 +1,62 @@
+package ibm
+
+import (
+	"fmt"
+	appid "github.com/IBM/appid-management-go-sdk/appidmanagementv4"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"testing"
+)
+
+func TestAccThemeColor_basic(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckIBMAppIDThemeColorDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: setupAppIDThemeColorConfig(appIDTenantID),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("ibm_appid_theme_color.color", "tenant_id", appIDTenantID),
+					resource.TestCheckResourceAttr("ibm_appid_theme_color.color", "header_color", "#000000"),
+				),
+			},
+		},
+	})
+}
+
+func setupAppIDThemeColorConfig(tenantID string) string {
+	return fmt.Sprintf(`
+		resource "ibm_appid_theme_color" "color" {
+			tenant_id = "%s"
+			header_color = "#000000"
+		}
+	`, tenantID)
+}
+
+func testAccCheckIBMAppIDThemeColorDestroy(s *terraform.State) error {
+	appIDClient, err := testAccProvider.Meta().(ClientSession).AppIDAPI()
+
+	if err != nil {
+		return err
+	}
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "ibm_appid_theme_color" {
+			continue
+		}
+
+		tenantID := rs.Primary.ID
+
+		cfg, _, err := appIDClient.GetThemeColor(&appid.GetThemeColorOptions{
+			TenantID: &tenantID,
+		})
+
+		// AppID default default #EEF2F5
+		if err != nil || (cfg.HeaderColor != nil && *cfg.HeaderColor != "#EEF2F5") {
+			return fmt.Errorf("error checking if AppID theme color configuration (%s) has been reset", rs.Primary.ID)
+		}
+	}
+
+	return nil
+}

--- a/website/docs/d/appid_theme_color.html.markdown
+++ b/website/docs/d/appid_theme_color.html.markdown
@@ -1,0 +1,28 @@
+---
+subcategory: "AppID Management"
+layout: "ibm"
+page_title: "IBM: AppID Theme Color"
+description: |-
+    Retrieves AppID Theme Color information.
+---
+
+# ibm_appid_theme_color
+Retrieve an IBM Cloud AppID Management Services theme color configuration.
+
+## Example usage
+
+```terraform
+data "ibm_appid_theme_color" "theme" {
+    tenant_id = var.tenant_id
+}
+```
+
+## Argument reference
+Review the argument references that you can specify for your data source.
+
+- `tenant_id` - (Required, String) The AppID instance GUID
+
+## Attribute reference
+In addition to all argument reference list, you can access the following attribute references after your data source is created
+
+- `header_color` - (String) Header color for AppID login screen

--- a/website/docs/r/appid_theme_color.html.markdown
+++ b/website/docs/r/appid_theme_color.html.markdown
@@ -1,0 +1,41 @@
+---
+subcategory: "AppID Management"
+layout: "ibm"
+page_title: "IBM: AppID Theme Color"
+description: |-
+    Provides AppID Theme Color resource.
+---
+
+# ibm_appid_theme_color
+
+Create, update, or delete an IBM Cloud AppID Management Services theme color resource.
+
+## Example usage
+
+```terraform
+resource "ibm_appid_theme_color" "theme" {
+  tenant_id = var.tenant_id
+  header_color = "#000000"
+}
+```
+
+## Argument reference
+Review the argument references that you can specify for your resource.
+
+- `tenant_id` - (Required, String) The AppID instance GUID
+- `header_color` - (Required, String) Header color for AppID login screen
+
+## Import
+
+The `ibm_appid_theme_color` resource can be imported by using the AppID tenant ID.
+
+**Syntax**
+
+```bash
+$ terraform import ibm_appid_theme_color.theme <tenant_id>
+```
+**Example**
+
+```bash
+$ terraform import ibm_appid_theme_color.theme 5fa344a8-d361-4bc2-9051-58ca253f4b2b
+```


### PR DESCRIPTION
## New AppID Theme Color Data Source and Resource

AppID Swagger UI: https://us-south.appid.cloud.ibm.com/swagger-ui

<!--- See what makes a good Pull Request at : https://github.com/IBM-Cloud/terraform-provider-ibm/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test $(go list ./... |grep -v 'vendor') -v -run TestAccThemeColor* -timeout 700m
=== RUN   TestAccThemeColorDataSource_basic
--- PASS: TestAccThemeColorDataSource_basic (51.48s)
=== RUN   TestAccThemeColor_basic
--- PASS: TestAccThemeColor_basic (41.76s)
PASS

```