### PR TITLE
feat: add appid theme text datasource and resource

### DIFF
--- a/ibm/data_source_ibm_appid_theme_text.go
+++ b/ibm/data_source_ibm_appid_theme_text.go
@@ -1,0 +1,60 @@
+package ibm
+
+import (
+	"context"
+	appid "github.com/IBM/appid-management-go-sdk/appidmanagementv4"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+func dataSourceIBMAppIDThemeText() *schema.Resource {
+	return &schema.Resource{
+		Description: "The theme texts of the App ID login widget",
+		ReadContext: dataSourceIBMAppIDThemeTextRead,
+		Schema: map[string]*schema.Schema{
+			"tenant_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "The AppID instance GUID",
+			},
+			"tab_title": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"footnote": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func dataSourceIBMAppIDThemeTextRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	appIDClient, err := meta.(ClientSession).AppIDAPI()
+
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	tenantID := d.Get("tenant_id").(string)
+
+	text, _, err := appIDClient.GetThemeTextWithContext(ctx, &appid.GetThemeTextOptions{
+		TenantID: &tenantID,
+	})
+
+	if err != nil {
+		return diag.Errorf("Error getting AppID theme text: %s", err)
+	}
+
+	if text.TabTitle != nil {
+		d.Set("tab_title", *text.TabTitle)
+	}
+
+	if text.Footnote != nil {
+		d.Set("footnote", *text.Footnote)
+	}
+
+	d.SetId(tenantID)
+
+	return nil
+}

--- a/ibm/data_source_ibm_appid_theme_text_test.go
+++ b/ibm/data_source_ibm_appid_theme_text_test.go
@@ -1,0 +1,40 @@
+package ibm
+
+import (
+	"fmt"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"testing"
+)
+
+func TestAccThemeTextDataSource_basic(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: setupAppIDThemeTextDataSourceConfig(appIDTenantID),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("data.ibm_appid_theme_text.text", "tenant_id", appIDTenantID),
+					resource.TestCheckResourceAttr("data.ibm_appid_theme_text.text", "tab_title", "test title"),
+					resource.TestCheckResourceAttr("data.ibm_appid_theme_text.text", "footnote", "test footnote"),
+				),
+			},
+		},
+	})
+}
+
+func setupAppIDThemeTextDataSourceConfig(tenantID string) string {
+	return fmt.Sprintf(`
+		resource "ibm_appid_theme_text" "text" {
+			tenant_id = "%s"
+			tab_title = "test title"
+			footnote = "test footnote"
+		}
+		data "ibm_appid_theme_text" "text" {
+			tenant_id = ibm_appid_theme_text.text.tenant_id
+			depends_on = [
+				ibm_appid_theme_text.text
+			]
+		}
+	`, tenantID)
+}

--- a/ibm/provider.go
+++ b/ibm/provider.go
@@ -180,6 +180,7 @@ func Provider() *schema.Provider {
 			"ibm_appid_token_config":        dataSourceIBMAppIDTokenConfig(),
 			"ibm_appid_redirect_urls":       dataSourceIBMAppIDRedirectURLs(),
 			"ibm_appid_role":                dataSourceIBMAppIDRole(),
+			"ibm_appid_theme_text":          dataSourceIBMAppIDThemeText(),
 
 			"ibm_function_action":                    dataSourceIBMFunctionAction(),
 			"ibm_function_package":                   dataSourceIBMFunctionPackage(),
@@ -444,6 +445,7 @@ func Provider() *schema.Provider {
 			"ibm_appid_token_config":        resourceIBMAppIDTokenConfig(),
 			"ibm_appid_redirect_urls":       resourceIBMAppIDRedirectURLs(),
 			"ibm_appid_role":                resourceIBMAppIDRole(),
+			"ibm_appid_theme_text":          resourceIBMAppIDThemeText(),
 
 			"ibm_function_action":                                resourceIBMFunctionAction(),
 			"ibm_function_package":                               resourceIBMFunctionPackage(),

--- a/ibm/resource_ibm_appid_theme_text.go
+++ b/ibm/resource_ibm_appid_theme_text.go
@@ -1,0 +1,128 @@
+package ibm
+
+import (
+	"context"
+	"github.com/IBM-Cloud/bluemix-go/helpers"
+	appid "github.com/IBM/appid-management-go-sdk/appidmanagementv4"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"log"
+)
+
+func resourceIBMAppIDThemeText() *schema.Resource {
+	return &schema.Resource{
+		Description:   "Update theme texts of the App ID login widget",
+		CreateContext: resourceIBMAppIDThemeTextCreate,
+		ReadContext:   resourceIBMAppIDThemeTextRead,
+		UpdateContext: resourceIBMAppIDThemeTextUpdate,
+		DeleteContext: resourceIBMAppIDThemeTextDelete,
+		Schema: map[string]*schema.Schema{
+			"tenant_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: "The AppID instance GUID",
+			},
+			"tab_title": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"footnote": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+		},
+	}
+}
+
+func resourceIBMAppIDThemeTextRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	appIDClient, err := meta.(ClientSession).AppIDAPI()
+
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	tenantID := d.Id()
+
+	text, resp, err := appIDClient.GetThemeTextWithContext(ctx, &appid.GetThemeTextOptions{
+		TenantID: &tenantID,
+	})
+
+	if err != nil {
+		if resp != nil && resp.StatusCode == 404 {
+			log.Printf("[WARN] AppID instance '%s' is not found, removing AppID theme text configuration from state", tenantID)
+			d.SetId("")
+			return nil
+		}
+
+		return diag.Errorf("Error getting AppID theme text: %s", err)
+	}
+
+	if text.TabTitle != nil {
+		d.Set("tab_title", *text.TabTitle)
+	}
+
+	if text.Footnote != nil {
+		d.Set("footnote", *text.Footnote)
+	}
+
+	d.Set("tenant_id", tenantID)
+
+	return nil
+}
+
+func resourceIBMAppIDThemeTextCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	appIDClient, err := meta.(ClientSession).AppIDAPI()
+
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	tenantID := d.Get("tenant_id").(string)
+
+	input := &appid.PostThemeTextOptions{
+		TenantID: &tenantID,
+		TabTitle: helpers.String(d.Get("tab_title").(string)),
+		Footnote: helpers.String(d.Get("footnote").(string)),
+	}
+
+	_, err = appIDClient.PostThemeTextWithContext(ctx, input)
+
+	if err != nil {
+		return diag.Errorf("Error setting AppID theme text: %s", err)
+	}
+
+	d.SetId(tenantID)
+
+	return resourceIBMAppIDThemeTextRead(ctx, d, meta)
+}
+
+func resourceIBMAppIDThemeTextUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	return resourceIBMAppIDThemeTextCreate(ctx, d, meta)
+}
+
+func resourceIBMAppIDThemeTextDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	appIDClient, err := meta.(ClientSession).AppIDAPI()
+
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	tenantID := d.Get("tenant_id").(string)
+
+	input := &appid.PostThemeTextOptions{
+		TenantID: &tenantID,
+		TabTitle: helpers.String("Login"),
+		Footnote: helpers.String("Powered by App ID"),
+	}
+
+	_, err = appIDClient.PostThemeTextWithContext(ctx, input)
+
+	if err != nil {
+		return diag.Errorf("Error resetting AppID theme text: %s", err)
+	}
+
+	d.SetId("")
+
+	return nil
+}

--- a/ibm/resource_ibm_appid_theme_text_test.go
+++ b/ibm/resource_ibm_appid_theme_text_test.go
@@ -1,0 +1,63 @@
+package ibm
+
+import (
+	"fmt"
+	appid "github.com/IBM/appid-management-go-sdk/appidmanagementv4"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"testing"
+)
+
+func TestAccThemeText_basic(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckIBMAppIDThemeTextDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: setupAppIDThemeTextConfig(appIDTenantID),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("ibm_appid_theme_text.text", "tenant_id", appIDTenantID),
+					resource.TestCheckResourceAttr("ibm_appid_theme_text.text", "tab_title", "resource test title"),
+					resource.TestCheckResourceAttr("ibm_appid_theme_text.text", "footnote", "resource test footnote"),
+				),
+			},
+		},
+	})
+}
+
+func setupAppIDThemeTextConfig(tenantID string) string {
+	return fmt.Sprintf(`
+		resource "ibm_appid_theme_text" "text" {
+			tenant_id = "%s"
+			tab_title = "resource test title"
+			footnote = "resource test footnote"
+		}
+	`, tenantID)
+}
+
+func testAccCheckIBMAppIDThemeTextDestroy(s *terraform.State) error {
+	appIDClient, err := testAccProvider.Meta().(ClientSession).AppIDAPI()
+
+	if err != nil {
+		return err
+	}
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "ibm_appid_theme_text" {
+			continue
+		}
+
+		tenantID := rs.Primary.ID
+
+		cfg, _, err := appIDClient.GetThemeText(&appid.GetThemeTextOptions{
+			TenantID: &tenantID,
+		})
+
+		if err != nil || (cfg.TabTitle != nil && *cfg.TabTitle != "Login") || (cfg.Footnote != nil && *cfg.Footnote != "Powered by App ID") {
+			return fmt.Errorf("error checking if AppID theme text configuration (%s) has been reset", rs.Primary.ID)
+		}
+	}
+
+	return nil
+}

--- a/website/docs/d/appid_theme_text.html.markdown
+++ b/website/docs/d/appid_theme_text.html.markdown
@@ -1,0 +1,30 @@
+---
+subcategory: "AppID Management"
+layout: "ibm"
+page_title: "IBM: AppID Theme Text"
+description: |-
+    Retrieves AppID Theme Text configuration.
+---
+
+# ibm_appid_theme_text
+
+Retrieve an IBM Cloud AppID Management Services theme text configuration.
+
+## Example usage
+
+```terraform
+data "ibm_appid_theme_text" "text" {
+    tenant_id = var.tenant_id
+}
+```
+
+## Argument reference
+Review the argument references that you can specify for your data source.
+
+- `tenant_id` - (Required, String) The AppID instance GUID
+
+## Attribute reference
+In addition to all argument reference list, you can access the following attribute references after your data source is created
+
+- `tab_title` - (String) The tab name that will be displayed in the browser
+- `footnote` - (String) Footnote

--- a/website/docs/r/appid_theme_text.html.markdown
+++ b/website/docs/r/appid_theme_text.html.markdown
@@ -1,0 +1,43 @@
+---
+subcategory: "AppID Management"
+layout: "ibm"
+page_title: "IBM: AppID Theme Text"
+description: |-
+    Provides AppID Theme Text resource.
+---
+
+# ibm_appid_theme_text
+
+Create, update, or delete an IBM Cloud AppID Management Services theme text resource.
+
+## Example usage
+
+```terraform
+resource "ibm_appid_theme_text" "text" {
+  tenant_id = var.tenant_id
+  tab_title = "App Login"
+  footnote = "Powered by IBM AppID"
+}
+```
+
+## Argument reference
+Review the argument references that you can specify for your resource.
+
+- `tenant_id` - (Required, String) The AppID instance GUID
+- `tab_title` - (Optional, String) The tab name that will be displayed in the browser
+- `footnote` - (Optional, String) Footnote
+
+## Import
+
+The `ibm_appid_theme_text` resource can be imported by using the AppID tenant ID.
+
+**Syntax**
+
+```bash
+$ terraform import ibm_appid_theme_text.text <tenant_id>
+```
+**Example**
+
+```bash
+$ terraform import ibm_appid_theme_text.text 5fa344a8-d361-4bc2-9051-58ca253f4b2b
+```


### PR DESCRIPTION
## New AppID Theme Text Data Source and Resource

AppID Swagger UI: https://us-south.appid.cloud.ibm.com/swagger-ui

<!--- See what makes a good Pull Request at : https://github.com/IBM-Cloud/terraform-provider-ibm/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test $(go list ./... |grep -v 'vendor') -v -run TestAccThemeText* -timeout 700m
=== RUN   TestAccThemeTextDataSource_basic
--- PASS: TestAccThemeTextDataSource_basic (52.34s)
=== RUN   TestAccThemeText_basic
--- PASS: TestAccThemeText_basic (49.51s)
PASS
```