### PR TITLE
feat: add appid roles datasource

### DIFF
--- a/ibm/data_source_ibm_appid_roles.go
+++ b/ibm/data_source_ibm_appid_roles.go
@@ -1,0 +1,117 @@
+package ibm
+
+import (
+	"context"
+	"fmt"
+	appid "github.com/IBM/appid-management-go-sdk/appidmanagementv4"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"sort"
+)
+
+func dataSourceIBMAppIDRoles() *schema.Resource {
+	return &schema.Resource{
+		Description: "A list of AppID roles",
+		ReadContext: dataSourceIBMAppIDRolesRead,
+		Schema: map[string]*schema.Schema{
+			"tenant_id": {
+				Description: "The AppID instance GUID",
+				Type:        schema.TypeString,
+				Required:    true,
+			},
+			"roles": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"role_id": {
+							Description: "Role ID",
+							Type:        schema.TypeString,
+							Computed:    true,
+						},
+						"name": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "Unique role name",
+						},
+						"description": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "Optional role description",
+						},
+						"access": {
+							Type:     schema.TypeSet,
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"application_id": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"scopes": {
+										Type: schema.TypeList,
+										Elem: &schema.Schema{
+											Type: schema.TypeString,
+										},
+										Computed: true,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func dataSourceIBMAppIDRolesRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	appIDClient, err := meta.(ClientSession).AppIDAPI()
+
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	tenantID := d.Get("tenant_id").(string)
+
+	roles, _, err := appIDClient.ListRolesWithContext(ctx, &appid.ListRolesOptions{
+		TenantID: &tenantID,
+	})
+
+	if err != nil {
+		return diag.Errorf("Error listing AppID roles: %s", err)
+	}
+
+	roleList := make([]interface{}, len(roles.Roles))
+
+	for index, role := range roles.Roles {
+		rMap := map[string]interface{}{
+			"role_id": *role.ID,
+		}
+
+		if role.Name != nil {
+			rMap["name"] = *role.Name
+		}
+
+		if role.Description != nil {
+			rMap["description"] = *role.Description
+		}
+
+		rMap["access"] = flattenAppIDRoleAccess(role.Access)
+		roleList[index] = rMap
+	}
+
+	// make this predictable for easier testing
+	sort.Slice(roleList, func(a, b int) bool {
+		roleA := roleList[a].(map[string]interface{})
+		roleB := roleList[b].(map[string]interface{})
+		return roleA["name"].(string) < roleB["name"].(string)
+	})
+
+	if err := d.Set("roles", roleList); err != nil {
+		return diag.Errorf("Error setting AppID roles: %s", err)
+	}
+
+	d.SetId(fmt.Sprintf("%s/roles", tenantID))
+	return nil
+}

--- a/ibm/data_source_ibm_appid_roles_test.go
+++ b/ibm/data_source_ibm_appid_roles_test.go
@@ -1,0 +1,59 @@
+package ibm
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+func TestAccIBMAppIDRolesDataSource_basic(t *testing.T) {
+	roleName1 := fmt.Sprintf("tf_testacc_role_1_%d", acctest.RandIntRange(10, 100))
+	roleName2 := fmt.Sprintf("tf_testacc_role_2_%d", acctest.RandIntRange(10, 100))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: setupAppIDRolesConfig(appIDTenantID, roleName1, roleName2),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("data.ibm_appid_roles.roles", "roles.#", "2"),
+					resource.TestCheckResourceAttrSet("data.ibm_appid_roles.roles", "roles.0.role_id"),
+					resource.TestCheckResourceAttr("data.ibm_appid_roles.roles", "roles.0.name", roleName1),
+					resource.TestCheckResourceAttr("data.ibm_appid_roles.roles", "roles.0.description", "test role 1"),
+					resource.TestCheckResourceAttrSet("data.ibm_appid_roles.roles", "roles.1.role_id"),
+					resource.TestCheckResourceAttr("data.ibm_appid_roles.roles", "roles.1.name", roleName2),
+					resource.TestCheckResourceAttr("data.ibm_appid_roles.roles", "roles.1.description", "test role 2"),
+				),
+			},
+		},
+	})
+}
+
+// Test assumes there are no pre-existing roles
+func setupAppIDRolesConfig(tenantID string, roleName1 string, roleName2 string) string {
+	return fmt.Sprintf(`	
+		resource "ibm_appid_role" "role1" {
+			tenant_id = "%s"
+			name = "%s"
+			description = "test role 1"	
+		}
+
+		resource "ibm_appid_role" "role2" {
+			tenant_id = ibm_appid_role.role1.tenant_id
+			name = "%s"
+			description = "test role 2"	
+		}
+
+		data "ibm_appid_roles" "roles" {
+			tenant_id = ibm_appid_role.role1.tenant_id
+			
+			depends_on = [
+				ibm_appid_role.role1,
+				ibm_appid_role.role2
+			]
+		}
+	`, tenantID, roleName1, roleName2)
+}

--- a/ibm/provider.go
+++ b/ibm/provider.go
@@ -188,6 +188,7 @@ func Provider() *schema.Provider {
 			"ibm_appid_token_config":             dataSourceIBMAppIDTokenConfig(),
 			"ibm_appid_redirect_urls":            dataSourceIBMAppIDRedirectURLs(),
 			"ibm_appid_role":                     dataSourceIBMAppIDRole(),
+			"ibm_appid_roles":                    dataSourceIBMAppIDRoles(),
 			"ibm_appid_theme_color":              dataSourceIBMAppIDThemeColor(),
 			"ibm_appid_theme_text":               dataSourceIBMAppIDThemeText(),
 

--- a/website/docs/d/appid_roles.html.markdown
+++ b/website/docs/d/appid_roles.html.markdown
@@ -1,0 +1,38 @@
+---
+subcategory: "AppID Management"
+layout: "ibm"
+page_title: "IBM: AppID Roles"
+description: |-
+    Retrieves a list of AppID Roles.
+---
+
+# ibm_appid_roles
+Retrieve information about an IBM Cloud AppID Management Services roles.
+
+## Example usage
+
+```terraform
+data "ibm_appid_roles" "roles" {
+    tenant_id = var.tenant_id
+}
+```
+
+## Argument reference
+Review the argument references that you can specify for your data source.
+
+- `tenant_id` - (Required, String) The AppID instance GUID
+
+## Attribute reference
+In addition to all argument reference list, you can access the following attribute references after your data source is created
+
+- `roles` - (List of Object) A list of AppID roles
+    
+  Nested scheme for `roles`:
+
+  - `name` - (String) Role name
+  - `description` - (String) Role description
+  - `access` - (Set of Object) A set of access policies that bind specific application scopes to the role
+
+    Nested scheme for `access`:
+      - `application_id` - (String) AppID application identifier
+      - `scopes` - (List of String) A list of AppID application scopes


### PR DESCRIPTION
## New AppID Roles Data Source

AppID Swagger UI: https://us-south.appid.cloud.ibm.com/swagger-ui

<!--- See what makes a good Pull Request at : https://github.com/IBM-Cloud/terraform-provider-ibm/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test $(go list ./... |grep -v 'vendor') -v -run TestAccIBMAppIDRolesDataSource_basic -timeout 700m
=== RUN   TestAccIBMAppIDRolesDataSource_basic
--- PASS: TestAccIBMAppIDRolesDataSource_basic (37.83s)
PASS
```