### PR TITLE
feat: add appid applications datasource

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "go.sum|^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2021-08-18T17:54:03Z",
+  "generated_at": "2021-09-01T19:48:08Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -555,6 +555,16 @@
         "verified_result": null
       }
     ],
+    "ibm/data_source_ibm_appid_applications.go": [
+      {
+        "hashed_secret": "b6122eb93901a6a608aa89377c682fbd5b16747a",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 93,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
     "ibm/data_source_ibm_atracker_routes_test.go": [
       {
         "hashed_secret": "33da8d0e8af2efc260f01d8e5edfcc5c5aba44ad",
@@ -710,7 +720,7 @@
         "hashed_secret": "c8b6f5ef11b9223ac35a5663975a466ebe7ebba9",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 876,
+        "line_number": 895,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -718,7 +728,7 @@
         "hashed_secret": "8abf4899c01104241510ba87685ad4de76b0c437",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 882,
+        "line_number": 901,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -1268,7 +1278,7 @@
         "hashed_secret": "3c2ecad9b250fd6d99893e4d05ec02ca19aa95d0",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 324,
+        "line_number": 335,
         "type": "Secret Keyword",
         "verified_result": null
       }

--- a/ibm/data_source_ibm_appid_applications.go
+++ b/ibm/data_source_ibm_appid_applications.go
@@ -1,0 +1,127 @@
+package ibm
+
+import (
+	"context"
+	"fmt"
+	appid "github.com/IBM/appid-management-go-sdk/appidmanagementv4"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"sort"
+)
+
+func dataSourceIBMAppIDApplications() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceIBMAppIDApplicationsRead,
+		Schema: map[string]*schema.Schema{
+			"tenant_id": {
+				Description: "The AppID instance GUID",
+				Type:        schema.TypeString,
+				Required:    true,
+			},
+			"applications": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"client_id": {
+							Description: "The `client_id` is a public identifier for applications",
+							Type:        schema.TypeString,
+							Required:    true,
+						},
+						"name": {
+							Description: "The application name",
+							Type:        schema.TypeString,
+							Computed:    true,
+						},
+						"secret": {
+							Description: "The `secret` is a secret known only to the application and the authorization server",
+							Type:        schema.TypeString,
+							Computed:    true,
+							Sensitive:   true,
+						},
+						"oauth_server_url": {
+							Description: "Base URL for common OAuth endpoints, like `/authorization`, `/token` and `/publickeys`",
+							Type:        schema.TypeString,
+							Computed:    true,
+						},
+						"profiles_url": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"discovery_endpoint": {
+							Description: "This URL returns OAuth Authorization Server Metadata",
+							Type:        schema.TypeString,
+							Computed:    true,
+						},
+						"type": {
+							Description: "The type of application to be registered. Allowed types are `regularwebapp` and `singlepageapp`.",
+							Type:        schema.TypeString,
+							Computed:    true,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func dataSourceIBMAppIDApplicationsRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	appIDClient, err := meta.(ClientSession).AppIDAPI()
+
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	tenantID := d.Get("tenant_id").(string)
+
+	apps, _, err := appIDClient.ListApplicationsWithContext(ctx, &appid.ListApplicationsOptions{
+		TenantID: &tenantID,
+	})
+
+	if err != nil {
+		return diag.Errorf("Error listing AppID applications: %s", err)
+	}
+
+	applicationList := make([]interface{}, len(apps.Applications))
+
+	for index, app := range apps.Applications {
+		application := map[string]interface{}{}
+		application["client_id"] = *app.ClientID
+		application["name"] = *app.Name
+
+		if app.Secret != nil {
+			application["secret"] = *app.Secret
+		}
+
+		if app.OAuthServerURL != nil {
+			application["oauth_server_url"] = *app.OAuthServerURL
+		}
+
+		if app.ProfilesURL != nil {
+			application["profiles_url"] = *app.ProfilesURL
+		}
+
+		if app.DiscoveryEndpoint != nil {
+			application["discovery_endpoint"] = *app.DiscoveryEndpoint
+		}
+
+		if app.Type != nil {
+			application["type"] = *app.Type
+		}
+
+		applicationList[index] = application
+	}
+
+	sort.Slice(applicationList, func(a, b int) bool {
+		appA := applicationList[a].(map[string]interface{})
+		appB := applicationList[b].(map[string]interface{})
+		return appA["name"].(string) < appB["name"].(string)
+	})
+
+	if err := d.Set("applications", applicationList); err != nil {
+		return diag.FromErr(err)
+	}
+
+	d.SetId(fmt.Sprintf("%s/applications", tenantID))
+	return nil
+}

--- a/ibm/data_source_ibm_appid_applications_test.go
+++ b/ibm/data_source_ibm_appid_applications_test.go
@@ -1,0 +1,53 @@
+package ibm
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+func TestAccIBMAppIDApplicationsDataSource_basic(t *testing.T) {
+	appName1 := fmt.Sprintf("tf_testacc_app_1_%d", acctest.RandIntRange(10, 100))
+	appName2 := fmt.Sprintf("tf_testacc_app_2_%d", acctest.RandIntRange(10, 100))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckIBMAppIDApplicationsDataSourceConfig(appIDTenantID, appName1, appName2),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("data.ibm_appid_applications.apps", "applications.#", "2"),
+					resource.TestCheckResourceAttr("data.ibm_appid_applications.apps", "applications.0.name", appName1),
+					resource.TestCheckResourceAttr("data.ibm_appid_applications.apps", "applications.1.name", appName2),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckIBMAppIDApplicationsDataSourceConfig(tenantID, appName1, appName2 string) string {
+	return fmt.Sprintf(`
+		resource "ibm_appid_application" "app1" {
+			tenant_id = "%s"
+			name = "%s"  
+			type = "singlepageapp"
+		}
+
+		resource "ibm_appid_application" "app2" {
+			tenant_id = ibm_appid_application.app1.tenant_id
+			name = "%s"
+		}
+
+		data "ibm_appid_applications" "apps" {
+			tenant_id = ibm_appid_application.app1.tenant_id	
+
+			depends_on = [
+				ibm_appid_application.app1,
+				ibm_appid_application.app2,
+			]
+		}
+	`, tenantID, appName1, appName2)
+}

--- a/ibm/provider.go
+++ b/ibm/provider.go
@@ -178,6 +178,7 @@ func Provider() *schema.Provider {
 			"ibm_appid_application":              dataSourceIBMAppIDApplication(),
 			"ibm_appid_application_scopes":       dataSourceIBMAppIDApplicationScopes(),
 			"ibm_appid_application_roles":        dataSourceIBMAppIDApplicationRoles(),
+			"ibm_appid_applications":             dataSourceIBMAppIDApplications(),
 			"ibm_appid_audit_status":             dataSourceIBMAppIDAuditStatus(),
 			"ibm_appid_cloud_directory_template": dataSourceIBMAppIDCloudDirectoryTemplate(),
 			"ibm_appid_idp_cloud_directory":      dataSourceIBMAppIDIDPCloudDirectory(),

--- a/website/docs/d/appid_applications.html.markdown
+++ b/website/docs/d/appid_applications.html.markdown
@@ -1,0 +1,37 @@
+---
+subcategory: "AppID Management"
+layout: "ibm"
+page_title: "IBM: AppID Applications"
+description: |-
+    Retrieves a list of AppID Applications.
+---
+
+# ibm_appid_applications
+Retrieve information about an IBM Cloud AppID Management Services applications.
+
+## Example usage
+
+```terraform
+data "ibm_appid_applications" "apps" {
+    tenant_id = var.tenant_id
+}
+```
+
+## Argument reference
+Review the argument references that you can specify for your data source.
+
+- `tenant_id` - (Required, String) The AppID instance GUID
+
+## Attribute reference
+In addition to all argument reference list, you can access the following attribute references after your data source is created
+
+- `applications` - (String) The list of AppID applications
+
+    Nested scheme for `applications`:
+
+  - `discovery_endpoint` - (String) This URL returns OAuth Authorization Server Metadata
+  - `name` - (String) The application name
+  - `oauth_server_url` - (String) Base URL for common OAuth endpoints, like `/authorization`, `/token` and `/publickeys`
+  - `profiles_url` - (String) Base AppID API endpoint
+  - `type` - (String) The application type. Supported types are `regularwebapp` and `singlepageapp`.
+  - `secret` - (String, Sensitive) The `secret` is a secret known only to the application and the authorization server


### PR DESCRIPTION
## New AppID Applications Data Source

AppID Swagger UI: https://us-south.appid.cloud.ibm.com/swagger-ui

<!--- See what makes a good Pull Request at : https://github.com/IBM-Cloud/terraform-provider-ibm/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test $(go list ./... |grep -v 'vendor') -v -run TestAccIBMAppIDApplicationsDataSource_basic -timeout 700m
=== RUN   TestAccIBMAppIDApplicationsDataSource_basic
--- PASS: TestAccIBMAppIDApplicationsDataSource_basic (41.78s)
PASS
```