### PR TITLE
Removed dereferencing in resource group name for is_volume resource and datasource which was throwing nil pointer dereference

### DIFF
--- a/ibm/data_source_ibm_is_volume.go
+++ b/ibm/data_source_ibm_is_volume.go
@@ -235,7 +235,7 @@ func volumeGet(d *schema.ResourceData, meta interface{}, name string) error {
 		d.Set(ResourceCRN, *vol.CRN)
 		d.Set(ResourceStatus, *vol.Status)
 		if vol.ResourceGroup != nil {
-			d.Set(ResourceGroupName, *vol.ResourceGroup.Name)
+			d.Set(ResourceGroupName, vol.ResourceGroup.Name)
 			d.Set(isVolumeResourceGroup, *vol.ResourceGroup.ID)
 		}
 		return nil

--- a/ibm/resource_ibm_is_volume.go
+++ b/ibm/resource_ibm_is_volume.go
@@ -368,7 +368,7 @@ func volGet(d *schema.ResourceData, meta interface{}, id string) error {
 	d.Set(ResourceCRN, *vol.CRN)
 	d.Set(ResourceStatus, *vol.Status)
 	if vol.ResourceGroup != nil {
-		d.Set(ResourceGroupName, *vol.ResourceGroup.Name)
+		d.Set(ResourceGroupName, vol.ResourceGroup.Name)
 		d.Set(isVolumeResourceGroup, *vol.ResourceGroup.ID)
 	}
 	return nil


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/IBM-Cloud/terraform-provider-ibm/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->


Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
=== RUN   TestAccIBMISVolume_basic
--- PASS: TestAccIBMISVolume_basic (194.51s)
PASS
ok      github.com/IBM-Cloud/terraform-provider-ibm/ibm 197.854s
```
