### PR TITLE
added crn for is_vpc resource and datasource in default sg and network acl

### DIFF
--- a/ibm/data_source_ibm_is_vpc.go
+++ b/ibm/data_source_ibm_is_vpc.go
@@ -51,6 +51,18 @@ func dataSourceIBMISVPC() *schema.Resource {
 				Description: "Default security group name",
 			},
 
+			isVPCDefaultSecurityGroupCRN: {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "Default security group CRN",
+			},
+
+			isVPCDefaultNetworkACLCRN: {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "Default Network ACL CRN",
+			},
+
 			isVPCDefaultRoutingTableName: {
 				Type:        schema.TypeString,
 				Computed:    true,
@@ -316,6 +328,7 @@ func vpcGetByName(d *schema.ResourceData, meta interface{}, name string) error {
 			if vpc.DefaultNetworkACL != nil {
 				d.Set(isVPCDefaultNetworkACLName, *vpc.DefaultNetworkACL.Name)
 				d.Set(isVPCDefaultNetworkACL, *vpc.DefaultNetworkACL.ID)
+				d.Set(isVPCDefaultNetworkACLCRN, vpc.DefaultNetworkACL.CRN)
 			} else {
 				d.Set(isVPCDefaultNetworkACL, nil)
 			}
@@ -326,6 +339,7 @@ func vpcGetByName(d *schema.ResourceData, meta interface{}, name string) error {
 			if vpc.DefaultSecurityGroup != nil {
 				d.Set(isVPCDefaultSecurityGroupName, *vpc.DefaultSecurityGroup.Name)
 				d.Set(isVPCDefaultSecurityGroup, *vpc.DefaultSecurityGroup.ID)
+				d.Set(isVPCDefaultSecurityGroupCRN, vpc.DefaultSecurityGroup.CRN)
 			} else {
 				d.Set(isVPCDefaultSecurityGroup, nil)
 			}

--- a/ibm/data_source_ibm_is_vpcs.go
+++ b/ibm/data_source_ibm_is_vpcs.go
@@ -71,6 +71,18 @@ func dataSourceIBMISVPCs() *schema.Resource {
 							Description: "Default security group name",
 						},
 
+						isVPCDefaultSecurityGroupCRN: {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "Default security group CRN",
+						},
+
+						isVPCDefaultNetworkACLCRN: {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "Default Network ACL CRN",
+						},
+
 						isVPCDefaultRoutingTableName: {
 							Type:        schema.TypeString,
 							Computed:    true,
@@ -328,6 +340,7 @@ func dataSourceIBMISVPCListRead(context context.Context, d *schema.ResourceData,
 		if vpc.DefaultNetworkACL != nil {
 			l[isVPCDefaultNetworkACL] = *vpc.DefaultNetworkACL.ID
 			l[isVPCDefaultNetworkACLName] = *vpc.DefaultNetworkACL.Name
+			l[isVPCDefaultNetworkACLCRN] = vpc.DefaultNetworkACL.CRN
 		}
 		if vpc.DefaultRoutingTable != nil {
 			l[isVPCDefaultRoutingTable] = *vpc.DefaultRoutingTable.ID
@@ -336,6 +349,7 @@ func dataSourceIBMISVPCListRead(context context.Context, d *schema.ResourceData,
 		if vpc.DefaultSecurityGroup != nil {
 			l[isVPCDefaultSecurityGroup] = *vpc.DefaultSecurityGroup.ID
 			l[isVPCDefaultSecurityGroupName] = *vpc.DefaultSecurityGroup.Name
+			l[isVPCDefaultSecurityGroupCRN] = vpc.DefaultSecurityGroup.CRN
 		}
 		tags, err := GetTagsUsingCRN(meta, *vpc.CRN)
 		if err != nil {

--- a/ibm/resource_ibm_is_vpc.go
+++ b/ibm/resource_ibm_is_vpc.go
@@ -27,7 +27,9 @@ const (
 	isVPCDefaultRoutingTable        = "default_routing_table"
 	isVPCName                       = "name"
 	isVPCDefaultNetworkACLName      = "default_network_acl_name"
+	isVPCDefaultNetworkACLCRN       = "default_network_acl_crn"
 	isVPCDefaultSecurityGroupName   = "default_security_group_name"
+	isVPCDefaultSecurityGroupCRN    = "default_security_group_crn"
 	isVPCDefaultRoutingTableName    = "default_routing_table_name"
 	isVPCResourceGroup              = "resource_group"
 	isVPCStatus                     = "status"
@@ -134,6 +136,18 @@ func resourceIBMISVPC() *schema.Resource {
 				Computed:     true,
 				ValidateFunc: InvokeValidator("ibm_is_vpc", isVPCDefaultSecurityGroupName),
 				Description:  "Default security group name",
+			},
+
+			isVPCDefaultSecurityGroupCRN: {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "Default security group CRN",
+			},
+
+			isVPCDefaultNetworkACLCRN: {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "Default Network ACL CRN",
 			},
 
 			isVPCDefaultRoutingTableName: {
@@ -561,6 +575,7 @@ func vpcGet(d *schema.ResourceData, meta interface{}, id string) error {
 		log.Printf("[DEBUG] vpc default network acl is not null :%s", *vpc.DefaultNetworkACL.ID)
 		d.Set(isVPCDefaultNetworkACL, *vpc.DefaultNetworkACL.ID)
 		d.Set(isVPCDefaultNetworkACLName, *vpc.DefaultNetworkACL.Name)
+		d.Set(isVPCDefaultNetworkACLCRN, vpc.DefaultNetworkACL.CRN)
 	} else {
 		log.Printf("[DEBUG] vpc default network acl is  null")
 		d.Set(isVPCDefaultNetworkACL, nil)
@@ -568,6 +583,7 @@ func vpcGet(d *schema.ResourceData, meta interface{}, id string) error {
 	if vpc.DefaultSecurityGroup != nil {
 		d.Set(isVPCDefaultSecurityGroup, *vpc.DefaultSecurityGroup.ID)
 		d.Set(isVPCDefaultSecurityGroupName, *vpc.DefaultSecurityGroup.Name)
+		d.Set(isVPCDefaultSecurityGroupCRN, vpc.DefaultSecurityGroup.CRN)
 	} else {
 		d.Set(isVPCDefaultSecurityGroup, nil)
 	}

--- a/website/docs/d/is_vpc.html.markdown
+++ b/website/docs/d/is_vpc.html.markdown
@@ -40,8 +40,10 @@ In addition to all argument reference list, you can access the following attribu
 	- `address` - (String) The IP address of the cloud service endpoint.
 	- `zone_name` - (String) The zone where the cloud service endpoint is located.
 - `default_network_acl` - (String) The ID of the default network ACL.
+- `default_network_acl_crn` - (String)  The CRN of the default network ACL.
 - `default_network_acl_name` - (String)  The name of the default network ACL.
 - `default_security_group`-  (String) The unique identifier of the VPC default security group.
+- `default_security_group_crn` - (String) The CRN of the default security group.
 - `default_security_group_name` - (String) The name of the default security group.
 - `default_routing_table`-  (String) The unique identifier of the VPC default routing table.
 - `default_routing_table_name` - (String) The name of the default routing table.

--- a/website/docs/d/is_vpcs.html.markdown
+++ b/website/docs/d/is_vpcs.html.markdown
@@ -35,8 +35,10 @@ You can access the following attribute references after your data source is crea
       - `address` - (String) The IP address of the cloud service endpoint.
       - `zone_name` - (String) The zone where the cloud service endpoint is located.
     - `default_network_acl` - (String) The ID of the default network ACL.
+    - `default_network_acl_crn` - (String) The CRN of the default network ACL.
     - `default_network_acl_name` - (String) The name of the default network ACL.
     - `default_security_group`-  (String) The unique identifier of the VPC default security group.
+    - `default_security_group_crn` - (String) The CRN of the default security group.
     - `default_security_group_name` - (String) The name of the default security group.
     - `default_routing_table`-  (String) The unique identifier of the VPC default routing table.
     - `default_routing_table_name` - (String) The name of the default routing table.

--- a/website/docs/r/is_vpc.html.markdown
+++ b/website/docs/r/is_vpc.html.markdown
@@ -48,7 +48,9 @@ In addition to all argument reference list, you can access the following attribu
 - `cse_source_addresses`- (List) A list of the cloud service endpoints that are associated with your VPC, including their source IP address and zone.
 	- `address` - (String) The IP address of the cloud service endpoint.
 	- `zone_name` - (String) The zone where the cloud service endpoint is located.
+- `default_security_group_crn` - (String) CRN of the default security group created and attached to the VPC. 
 - `default_security_group` - (String) The default security group ID created and attached to the VPC. 
+- `default_network_acl_crn`-  (String) CRN of the default network ACL ID created and attached to the VPC.
 - `default_network_acl`-  (String) The default network ACL ID created and attached to the VPC.
 - `default_routing_table`-  (String) The unique identifier of the VPC default routing table.
 - `id` - (String) The unique identifier of the VPC that you created.


### PR DESCRIPTION


<!--- See what makes a good Pull Request at : https://github.com/IBM-Cloud/terraform-provider-ibm/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #3029

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```
