### PR TITLE
Adding Steering_Policy property

### DIFF
--- a/ibm/data_source_ibm_cis_global_load_balancers.go
+++ b/ibm/data_source_ibm_cis_global_load_balancers.go
@@ -71,6 +71,11 @@ func dataSourceIBMCISGlbs() *schema.Resource {
 							Computed:    true,
 							Description: "TTL value",
 						},
+						cisGLBSteeringPolicy: {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "Steering policy info",
+						},
 						cisGLBProxied: {
 							Type:        schema.TypeBool,
 							Computed:    true,
@@ -178,6 +183,7 @@ func dataSourceCISGlbsRead(d *schema.ResourceData, meta interface{}) error {
 		glbOutput[cisGLBDesc] = *glbObj.Description
 		glbOutput[cisGLBFallbackPoolID] = convertCisToTfTwoVar(*glbObj.FallbackPool, crn)
 		glbOutput[cisGLBTTL] = *glbObj.TTL
+		glbOutput[cisGLBSteeringPolicy] = *glbObj.SteeringPolicy
 		glbOutput[cisGLBProxied] = *glbObj.Proxied
 		glbOutput[cisGLBEnabled] = *glbObj.Enabled
 		glbOutput[cisGLBSessionAffinity] = *glbObj.SessionAffinity

--- a/ibm/resource_ibm_cis_global_load_balancer.go
+++ b/ibm/resource_ibm_cis_global_load_balancer.go
@@ -84,7 +84,7 @@ func resourceIBMCISGlb() *schema.Resource {
 			},
 			cisGLBSteeringPolicy: {
 				Type:         schema.TypeString,
-				Required:     true,
+				Optional:     true,
 				ValidateFunc: validateAllowedStringValue([]string{"off", "geo", "random", "dynamic_latency"}),
 				Description:  "Steering policy info",
 			},

--- a/ibm/resource_ibm_cis_global_load_balancer.go
+++ b/ibm/resource_ibm_cis_global_load_balancer.go
@@ -84,8 +84,7 @@ func resourceIBMCISGlb() *schema.Resource {
 			},
 			cisGLBSteeringPolicy: {
 				Type:         schema.TypeString,
-				Optional:     true,
-				Default:      "random",
+				Required:     true,
 				ValidateFunc: validateAllowedStringValue([]string{"off", "geo", "random", "dynamic_latency"}),
 				Description:  "Steering policy info",
 			},

--- a/ibm/resource_ibm_cis_global_load_balancer_test.go
+++ b/ibm/resource_ibm_cis_global_load_balancer_test.go
@@ -34,6 +34,7 @@ func TestAccIBMCisGlb_Basic(t *testing.T) {
 					resource.TestCheckResourceAttr(name, "pop_pools.#", "0"),
 					resource.TestCheckResourceAttr(name, "region_pools.#", "0"),
 					resource.TestCheckResourceAttr(name, "proxied", "false"), // default value
+					resource.TestCheckResourceAttr(name, "steering_policy", "dynamic_latency"),
 				),
 			},
 			{
@@ -45,6 +46,7 @@ func TestAccIBMCisGlb_Basic(t *testing.T) {
 					resource.TestCheckResourceAttr(name, "pop_pools.#", "1"),
 					resource.TestCheckResourceAttr(name, "region_pools.#", "1"),
 					resource.TestCheckResourceAttr(name, "proxied", "false"), // default value
+					resource.TestCheckResourceAttr(name, "steering_policy", "dynamic_latency"),
 				),
 			},
 		},
@@ -283,6 +285,7 @@ func testAccCheckCisGlbConfigCisDSBasic(id string, cisDomain string) string {
 		name             = "%[2]s"
 		fallback_pool_id = ibm_cis_origin_pool.origin_pool.id
 		default_pool_ids = [ibm_cis_origin_pool.origin_pool.id]
+		steering_policy = "dynamic_latency" 
 	  }
 	`, id, cisDomainStatic)
 }
@@ -295,6 +298,7 @@ func testAccCheckCisGlbConfigCisDSUpdate(id string, cisDomain string) string {
 		name             = "%[2]s"
 		fallback_pool_id = ibm_cis_origin_pool.origin_pool.id
 		default_pool_ids = [ibm_cis_origin_pool.origin_pool.id]
+		steering_policy = "dynamic_latency"
 		region_pools{
 			region="WEU"
 			pool_ids = [ibm_cis_origin_pool.origin_pool.id]
@@ -315,6 +319,7 @@ func testAccCheckCisGlbConfigCisRIBasic(id string, cisDomain string) string {
 		name             = "%[2]s"
 		fallback_pool_id = ibm_cis_origin_pool.origin_pool.id
 		default_pool_ids = [ibm_cis_origin_pool.origin_pool.id]
+		steering_policy = "dynamic_latency" 
 	  }
 	`, id, cisDomain, "testacc_ds_cis")
 }
@@ -328,6 +333,7 @@ func testAccCheckCisGlbConfigSessionAffinity(id string, cisDomainStatic string) 
 		fallback_pool_id = ibm_cis_origin_pool.origin_pool.id
 		default_pool_ids = [ibm_cis_origin_pool.origin_pool.id]
 		session_affinity = "cookie"
+		steering_policy = "dynamic_latency" 
 	  }
 	`, id, cisDomainStatic)
 }

--- a/website/docs/d/cis_global_load_balancers.html.markdown
+++ b/website/docs/d/cis_global_load_balancers.html.markdown
@@ -50,5 +50,5 @@ In addition to all argument reference list, you can access the following attribu
 	- `region` - (String) A region code. Multiple entries is not allowed with the same region.
 	- `pool_ids` - (String) A list of pool IDs in failover priority to use in the given region.
 - `session_affinity` - (String) Associates all requests coming from an end-user with a single origin. IBM will set a cookie on the initial response to the client, such that consequent requests with the cookie in the request will go to the same origin, as long as it is available.
-- `steering_policy` - (Required, String) Steering Policy which allows off,geo,random,dynamic_latency.
+- `steering_policy` - (String) Steering Policy which allows off,geo,random,dynamic_latency.
 - `ttl` - (String) Time to live (TTL) of the DNS entry for the IP address returned by this Load Balancer.P.

--- a/website/docs/d/cis_global_load_balancers.html.markdown
+++ b/website/docs/d/cis_global_load_balancers.html.markdown
@@ -50,4 +50,5 @@ In addition to all argument reference list, you can access the following attribu
 	- `region` - (String) A region code. Multiple entries is not allowed with the same region.
 	- `pool_ids` - (String) A list of pool IDs in failover priority to use in the given region.
 - `session_affinity` - (String) Associates all requests coming from an end-user with a single origin. IBM will set a cookie on the initial response to the client, such that consequent requests with the cookie in the request will go to the same origin, as long as it is available.
+- `steering_policy` - (Required, String) Steering Policy which allows off,geo,random,dynamic_latency.
 - `ttl` - (String) Time to live (TTL) of the DNS entry for the IP address returned by this Load Balancer.P.

--- a/website/docs/r/cis_global_load_balancer.html.markdown
+++ b/website/docs/r/cis_global_load_balancer.html.markdown
@@ -71,7 +71,7 @@ Review the argument references that you can specify for your resource.
   - `region` - (Required, String) Enter a region code. Should not specify the multiple entries with the same region.
   - `pool_ids` - (Required, String) A list of pool IDs in failover priority for the provided region.
 - `session_affinity` - (Optional, String) Associates all requests from an end-user with a single origin. IBM sets a cookie on the initial response to the client, so that the consequent requests with the cookie in the request use the same origin, as long as it is available.
-- `steering_policy` - (Required, String) Steering Policy which allows off,geo,random,dynamic_latency.
+- `steering_policy` - (Optional, String) Steering Policy which allows off,geo,random,dynamic_latency.
 - `ttl` - (Optional, Integer) The time to live (TTL) in seconds for how long the load balancer must cache a resolved IP address for a DNS entry before the load balancer must look up the IP address again. If your global load balancer is proxied, this value is automatically set and cannot be changed. If your global load balancer is not in proxy, you can enter a value that is 120 or greater.
 
 

--- a/website/docs/r/cis_global_load_balancer.html.markdown
+++ b/website/docs/r/cis_global_load_balancer.html.markdown
@@ -26,6 +26,7 @@ resource "ibm_cis_global_load_balancer" "example" {
   default_pool_ids = [ibm_cis_origin_pool.example.id]
   description      = "example load balancer using geo-balancing"
   proxied          = true
+  steering_policy = "dynamic_latency"
   region_pools{
 			region="WEU"
 			pool_ids = [ibm_cis_origin_pool.example.id]
@@ -70,6 +71,7 @@ Review the argument references that you can specify for your resource.
   - `region` - (Required, String) Enter a region code. Should not specify the multiple entries with the same region.
   - `pool_ids` - (Required, String) A list of pool IDs in failover priority for the provided region.
 - `session_affinity` - (Optional, String) Associates all requests from an end-user with a single origin. IBM sets a cookie on the initial response to the client, so that the consequent requests with the cookie in the request use the same origin, as long as it is available.
+- `steering_policy` - (Required, String) Steering Policy which allows off,geo,random,dynamic_latency.
 - `ttl` - (Optional, Integer) The time to live (TTL) in seconds for how long the load balancer must cache a resolved IP address for a DNS entry before the load balancer must look up the IP address again. If your global load balancer is proxied, this value is automatically set and cannot be changed. If your global load balancer is not in proxy, you can enter a value that is 120 or greater.
 
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/IBM-Cloud/terraform-provider-ibm/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./ibm -v -run=TestAccIBMCisGlb_CreateAfterManualDestroy -timeout 700m
[WARN] Set the environment variable IBM_APPID_TENANT_ID for testing AppID resources, AppID tests will fail if this is not set
[WARN] Set the environment variable IBM_ORG for testing ibm_org  resource Some tests for that resource will fail if this is not set correctly
[WARN] Set the environment variable IBM_SPACE for testing ibm_space  resource Some tests for that resource will fail if this is not set correctly
[WARN] Set the environment variable IBM_ID1 for testing ibm_space resource Some tests for that resource will fail if this is not set correctly
[WARN] Set the environment variable IBM_ID2 for testing ibm_space resource Some tests for that resource will fail if this is not set correctly
[WARN] Set the environment variable IBM_IAMUSER for testing ibm_iam_user_policy resource Some tests for that resource will fail if this is not set correctly
[WARN] Set the environment variable IBM_DATACENTER for testing ibm_container_cluster resource else it is set to default value 'par01'
[WARN] Set the environment variable IBM_MACHINE_TYPE for testing ibm_container_cluster resource else it is set to default value 'u2c.2x4'
[WARN] Set the environment variable IBM_CERT_CRN for testing ibm_container_alb_cert resource else it is set to default value
[WARN] Set the environment variable IBM_UPDATE_CERT_CRN for testing ibm_container_alb_cert resource else it is set to default value
[WARN] Set the environment variable IBM_CONTAINER_REGION for testing ibm_container resources else it is set to default value 'eu-de'
[WARN] Set the environment variable IBM_COS_CRN with a VALID COS instance CRN for testing ibm_cos_* resources
[WARN] Set the environment variable IBM_TRUSTED_MACHINE_TYPE for testing ibm_container_cluster resource else it is set to default value 'mb1c.16x64'
[WARN] Set the environment variable IBM_BM_EXTENDED_HW_TESTING to true/false for testing ibm_compute_bare_metal resource else it is set to default value 'false'
[WARN] Set the environment variable IBM_PUBLIC_VLAN_ID for testing ibm_container_cluster resource else it is set to default value '2393319'
[WARN] Set the environment variable IBM_PRIVATE_VLAN_ID for testing ibm_container_cluster resource else it is set to default value '2393321'
[WARN] Set the environment variable IBM_KUBE_VERSION for testing ibm_container_cluster resource else it is set to default value '1.18.14'
[WARN] Set the environment variable IBM_KUBE_UPDATE_VERSION for testing ibm_container_cluster resource else it is set to default value '1.19.6'
[WARN] Set the environment variable IBM_PRIVATE_SUBNET_ID for testing ibm_container_cluster resource else it is set to default value '1636107'
[WARN] Set the environment variable IBM_PUBLIC_SUBNET_ID for testing ibm_container_cluster resource else it is set to default value '1165645'
[WARN] Set the environment variable IBM_SUBNET_ID for testing ibm_container_cluster resource else it is set to default value '1165645'
[INFO] Set the environment variable IBM_IPSEC_DATACENTER for testing ibm_ipsec_vpn resource else it is set to default value 'tok02'
[INFO] Set the environment variable IBM_IPSEC_CUSTOMER_SUBNET_ID for testing ibm_ipsec_vpn resource else it is set to default value '123456'
[INFO] Set the environment variable IBM_IPSEC_CUSTOMER_PEER_IP for testing ibm_ipsec_vpn resource else it is set to default value '192.168.0.1'
[WARN] Set the environment variable IBM_LBAAS_DATACENTER for testing ibm_lbaas resource else it is set to default value 'dal13'
[WARN] Set the environment variable IBM_LBAAS_SUBNETID for testing ibm_lbaas resource else it is set to default value '2144241'
[WARN] Set the environment variable IBM_DEDICATED_HOSTNAME for testing ibm_compute_vm_instance resource else it is set to default value 'terraform-dedicatedhost'
[WARN] Set the environment variable IBM_DEDICATED_HOST_ID for testing ibm_compute_vm_instance resource else it is set to default value '30301'
[WARN] Set the environment variable IBM_WORKER_POOL_ZONE for testing ibm_container_worker_pool_zone_attachment resource else it is set to default value 'ams03'
[WARN] Set the environment variable IBM_WORKER_POOL_ZONE_PRIVATE_VLAN for testing ibm_container_worker_pool_zone_attachment resource else it is set to default value '2538975'
[WARN] Set the environment variable IBM_WORKER_POOL_ZONE_PUBLIC_VLAN for testing ibm_container_worker_pool_zone_attachment resource else it is set to default value '2538967'
[WARN] Set the environment variable IBM_WORKER_POOL_ZONE_UPDATE_PRIVATE_VLAN for testing ibm_container_worker_pool_zone_attachment resource else it is set to default value '2388377'
[WARN] Set the environment variable IBM_WORKER_POOL_ZONE_UPDATE_PUBLIC_VLAN for testing ibm_container_worker_pool_zone_attachment resource else it is set to default value '2388375'
[WARN] Set the environment variable IBM_PLACEMENT_GROUP_NAME for testing ibm_compute_vm_instance resource else it is set to default value 'terraform-group'
[INFO] Set the environment variable SL_REGION for testing ibm_is_region datasource else it is set to default value 'us-south'
[INFO] Set the environment variable SL_ZONE for testing ibm_is_zone datasource else it is set to default value 'us-south-1'
[INFO] Set the environment variable SL_CIDR for testing ibm_is_subnet else it is set to default value '10.240.0.0/24'
[INFO] Set the environment variable SL_ADDRESS_PREFIX_CIDR for testing ibm_is_vpc_address_prefix else it is set to default value '10.120.0.0/24'
[INFO] Set the environment variable IS_IMAGE for testing ibm_is_instance, ibm_is_floating_ip else it is set to default value 'r006-ed3f775f-ad7e-4e37-ae62-7199b4988b00'
[INFO] Set the environment variable IS_WIN_IMAGE for testing ibm_is_instance data source else it is set to default value 'r006-5f9568ae-792e-47e1-a710-5538b2bdfca7'
[INFO] Set the environment variable SL_INSTANCE_PROFILE for testing ibm_is_instance resource else it is set to default value 'cx2-2x4'
[INFO] Set the environment variable SL_INSTANCE_PROFILE_UPDATE for testing ibm_is_instance resource else it is set to default value 'cx2-4x8'
[INFO] Set the environment variable IS_DEDICATED_HOST_NAME for testing ibm_is_instance resource else it is set to default value 'tf-dhost-01'
[INFO] Set the environment variable IS_DEDICATED_HOST_GROUP_ID for testing ibm_is_instance resource else it is set to default value '0717-9104e7b5-77ad-44ad-9eaa-091e6b6efce1'
[INFO] Set the environment variable IS_DEDICATED_HOST_PROFILE for testing ibm_is_instance resource else it is set to default value 'bx2d-host-152x608'
[INFO] Set the environment variable IS_DEDICATED_HOST_GROUP_CLASS for testing ibm_is_instance resource else it is set to default value 'bx2d'
[INFO] Set the environment variable IS_DEDICATED_HOST_GROUP_FAMILY for testing ibm_is_instance resource else it is set to default value 'balanced'
[INFO] Set the environment variable SL_INSTANCE_PROFILE for testing ibm_is_instance resource else it is set to default value 'bx2d-16x64'
[INFO] Set the environment variable IS_VOLUME_PROFILE for testing ibm_is_volume_profile else it is set to default value 'general-purpose'
[INFO] Set the environment variable SL_ROUTE_DESTINATION for testing ibm_is_vpc_route else it is set to default value '192.168.4.0/24'
[INFO] Set the environment variable SL_ROUTE_NEXTHOP for testing ibm_is_vpc_route else it is set to default value '10.0.0.4'
[INFO] Set the environment variable PI_IMAGE for testing ibm_pi_image resource else it is set to default value '7200-03-03'
[INFO] Set the environment variable PI_KEY_NAME for testing ibm_pi_key_name resource else it is set to default value 'terraform-test-power'
[INFO] Set the environment variable PI_NETWORK_NAME for testing ibm_pi_network_name resource else it is set to default value 'terraform-test-power'
[INFO] Set the environment variable PI_VOLUME_NAME for testing ibm_pi_network_name resource else it is set to default value 'terraform-test-power'
[INFO] Set the environment variable PI_CLOUDINSTANCE_ID for testing ibm_pi_image resource else it is set to default value 'd16705bd-7f1a-48c9-9e0e-1c17b71e7331'
[INFO] Set the environment variable PI_PVM_INSTANCE_ID for testing pi_instance_name resource else it is set to default value 'terraform-test-power'
[INFO] Set the environment variable SCHEMATICS_WORKSPACE_ID for testing schematics resources else it is set to default value
[INFO] Set the environment variable SCHEMATICS_TEMPLATE_ID for testing schematics resources else it is set to default value
[INFO] Set the environment variable SCHEMATICS_ACTION_ID for testing schematics resources else it is set to default value
[WARN] Set the environment variable IMAGE_COS_URL with a VALID COS Image SQL URL for testing ibm_is_image resources on staging/test
[WARN] Set the environment variable IMAGE_COS_URL_ENCRYPTED with a VALID COS Image SQL URL for testing ibm_is_image resources on staging/test
[WARN] Set the environment variable IMAGE_OPERATING_SYSTEM with a VALID Operating system for testing ibm_is_image resources on staging/test
[INFO] Set the environment variable IS_IMAGE_NAME for testing data source ibm_is_image else it is set to default value `ibm-ubuntu-18-04-1-minimal-amd64-2`
[INFO] Set the environment variable IS_IMAGE_ENCRYPTED_DATA_KEY for testing resource ibm_is_image else it is set to default value
[INFO] Set the environment variable IS_IMAGE_ENCRYPTION_KEY for testing resource ibm_is_image else it is set to default value
[INFO] Set the environment variable IBM_FUNCTION_NAMESPACE for testing ibm_function_package, ibm_function_action, ibm_function_rule, ibm_function_trigger resource else  tests will fail if this is not set correctly
[INFO] Set the environment variable HPCS_INSTANCE_ID for testing data_source_ibm_kms_key_test else it is set to default value
[INFO] Set the environment variable SECRETS_MANAGER_INSTANCE_ID for testing data_source_ibm_secrets_manager_secrets_test else tests will fail if this is not set correctly
[INFO] Set the environment variable SECRETS_MANAGER_SECRET_TYPE for testing data_source_ibm_secrets_manager_secrets_test, else it is set to default value. For data_source_ibm_secrets_manager_secret_test, tests will fail if this is not set correctly
[WARN] Set the environment variable SECRETS_MANAGER_SECRET_ID for testing data_source_ibm_secrets_manager_secret_test else tests will fail if this is not set correctly
[INFO] Set the environment variable IBM_TG_CROSS_ACCOUNT_ID for testing ibm_tg_connection resource else  tests will fail if this is not set correctly
[INFO] Set the environment variable IBM_TG_CROSS_NETWORK_ID for testing ibm_tg_connection resource else  tests will fail if this is not set correctly
[INFO] Set the environment variable ACCOUNT_TO_BE_IMPORTED for testing import enterprise account resource else  tests will fail if this is not set correctly
[WARN] Set the environment variable IBM_HPCS_ADMIN1 with a VALID HPCS Admin Key1 Path
[WARN] Set the environment variable IBM_HPCS_TOKEN1 with a VALID token for HPCS Admin Key1
[WARN] Set the environment variable IBM_HPCS_ADMIN2 with a VALID HPCS Admin Key2 Path
[WARN] Set the environment variable IBM_HPCS_TOKEN2 with a VALID token for HPCS Admin Key2
=== RUN   TestAccIBMCisGlb_CreateAfterManualDestroy
    resource_ibm_cis_global_load_balancer_test.go:58: 
--- SKIP: TestAccIBMCisGlb_CreateAfterManualDestroy (0.00s)
PASS
ok  	github.com/IBM-Cloud/terraform-provider-ibm/ibm	121.963s
