### PR TITLE
fix: make sure appid action url label is properly indented

### DIFF
--- a/website/docs/d/appid_action_url.html.markdown
+++ b/website/docs/d/appid_action_url.html.markdown
@@ -3,7 +3,7 @@ subcategory: "AppID Management"
 layout: "ibm"
 page_title: "IBM: AppID Action URL"
 description: |-
-Retrieves AppID Action URL.
+    Retrieves AppID Action URL.
 ---
 
 # ibm_appid_action_url

--- a/website/docs/r/appid_action_url.html.markdown
+++ b/website/docs/r/appid_action_url.html.markdown
@@ -3,7 +3,7 @@ subcategory: "AppID Management"
 layout: "ibm"
 page_title: "IBM: AppID Action URL"
 description: |-
-Provides AppID Action URL resource.
+    Provides AppID Action URL resource.
 ---
 
 # ibm_appid_action_url


### PR DESCRIPTION
Fix AppID action_url links in documentation

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000