### PR TITLE
Add AppID user roles datasource and resource

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "go.sum|^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2021-09-24T02:55:46Z",
+  "generated_at": "2021-09-28T17:14:30Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -346,7 +346,7 @@
         "hashed_secret": "1f1c2ad5fded044aae42281c1fd4253dd624bf65",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 304,
+        "line_number": 321,
         "type": "Hex High Entropy String",
         "verified_result": null
       },
@@ -354,7 +354,7 @@
         "hashed_secret": "ece6e4a51cf5a18845f07c95832586a96d5fcf4c",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 339,
+        "line_number": 356,
         "type": "Hex High Entropy String",
         "verified_result": null
       },
@@ -362,7 +362,7 @@
         "hashed_secret": "4fa34387af5471f6ee44b12c663122418ba7085a",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 348,
+        "line_number": 365,
         "type": "Hex High Entropy String",
         "verified_result": null
       },
@@ -370,7 +370,7 @@
         "hashed_secret": "9addbf544119efa4a64223b649750a510f0d463f",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 369,
+        "line_number": 386,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -588,7 +588,7 @@
         "hashed_secret": "9184b0c38101bf24d78b2bb0d044deb1d33696fc",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 108,
+        "line_number": 111,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -596,7 +596,7 @@
         "hashed_secret": "c427f185ddcb2440be9b77c8e45f1cd487a2e790",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1146,
+        "line_number": 1185,
         "type": "Base64 High Entropy String",
         "verified_result": null
       },
@@ -604,7 +604,7 @@
         "hashed_secret": "1f614c2eb6b3da22d89bd1b9fd47d7cb7c8fc670",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2286,
+        "line_number": 2381,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -612,7 +612,7 @@
         "hashed_secret": "7abfce65b8504403afc25c9790f358d513dfbcc6",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2299,
+        "line_number": 2394,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -620,7 +620,7 @@
         "hashed_secret": "0c2d85bf9a9b1579b16f220a4ea8c3d62b2e24b1",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2335,
+        "line_number": 2430,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -650,7 +650,7 @@
         "hashed_secret": "57b2ad99044d337197c0c39fd3823568ff81e48a",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 53,
+        "line_number": 54,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -711,6 +711,16 @@
         "is_secret": false,
         "is_verified": false,
         "line_number": 37,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "ibm/data_source_ibm_appid_user_roles_test.go": [
+      {
+        "hashed_secret": "57b2ad99044d337197c0c39fd3823568ff81e48a",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 45,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -916,7 +926,7 @@
         "hashed_secret": "c8b6f5ef11b9223ac35a5663975a466ebe7ebba9",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 933,
+        "line_number": 948,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -924,7 +934,7 @@
         "hashed_secret": "8abf4899c01104241510ba87685ad4de76b0c437",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 939,
+        "line_number": 954,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -934,7 +944,7 @@
         "hashed_secret": "813274ccae5b6b509379ab56982d862f7b5969b6",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 523,
+        "line_number": 534,
         "type": "Base64 High Entropy String",
         "verified_result": null
       }
@@ -970,7 +980,7 @@
         "hashed_secret": "20a25bac21219ffff1904bde871ded4027eca2f8",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 288,
+        "line_number": 319,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -1029,6 +1039,16 @@
         "is_secret": false,
         "is_verified": false,
         "line_number": 40,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "ibm/resource_ibm_appid_user_roles_test.go": [
+      {
+        "hashed_secret": "57b2ad99044d337197c0c39fd3823568ff81e48a",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 48,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -1440,7 +1460,7 @@
         "hashed_secret": "d4c3d66fd0c38547a3c7a4c6bdc29c36911bc030",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 277,
+        "line_number": 270,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -1808,7 +1828,7 @@
         "hashed_secret": "57b2ad99044d337197c0c39fd3823568ff81e48a",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 27,
+        "line_number": 29,
         "type": "Secret Keyword",
         "verified_result": null
       }

--- a/ibm/data_source_ibm_appid_cloud_directory_user_test.go
+++ b/ibm/data_source_ibm_appid_cloud_directory_user_test.go
@@ -25,6 +25,7 @@ func TestAccIBMAppIDCloudDirectoryUserDataSource_basic(t *testing.T) {
 					resource.TestCheckResourceAttr("data.ibm_appid_cloud_directory_user.user", "active", "false"),
 					resource.TestCheckResourceAttr("data.ibm_appid_cloud_directory_user.user", "locked_until", strconv.Itoa(int(lockedUntil))),
 					resource.TestCheckResourceAttrSet("data.ibm_appid_cloud_directory_user.user", "user_id"),
+					resource.TestCheckResourceAttrSet("data.ibm_appid_cloud_directory_user.user", "subject"),
 					resource.TestCheckResourceAttr("data.ibm_appid_cloud_directory_user.user", "display_name", "Test TF User"),
 					resource.TestCheckResourceAttr("data.ibm_appid_cloud_directory_user.user", "status", "PENDING"),
 					resource.TestCheckResourceAttr("data.ibm_appid_cloud_directory_user.user", "email.#", "1"),

--- a/ibm/data_source_ibm_appid_user_roles.go
+++ b/ibm/data_source_ibm_appid_user_roles.go
@@ -1,0 +1,96 @@
+package ibm
+
+import (
+	"context"
+	"fmt"
+	appid "github.com/IBM/appid-management-go-sdk/appidmanagementv4"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"log"
+)
+
+func dataSourceIBMAppIDUserRoles() *schema.Resource {
+	return &schema.Resource{
+		Description: "Get a list of AppID user roles",
+		ReadContext: dataSourceIBMAppIDUserRolesRead,
+		Schema: map[string]*schema.Schema{
+			"tenant_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "The AppID instance GUID",
+			},
+			"subject": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "The user's identifier ('subject' in identity token)",
+			},
+			"roles": {
+				Description: "A set of user roles",
+				Type:        schema.TypeSet,
+				Computed:    true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"id": {
+							Description: "Role ID",
+							Type:        schema.TypeString,
+							Computed:    true,
+						},
+						"name": {
+							Description: "Role name",
+							Type:        schema.TypeString,
+							Computed:    true,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func dataSourceIBMAppIDUserRolesRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	appIDClient, err := meta.(ClientSession).AppIDAPI()
+
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	tenantID := d.Get("tenant_id").(string)
+	subject := d.Get("subject").(string)
+
+	roles, resp, err := appIDClient.GetUserRolesWithContext(ctx, &appid.GetUserRolesOptions{
+		TenantID: &tenantID,
+		ID:       &subject,
+	})
+
+	if err != nil {
+		log.Printf("[DEBUG] Error getting AppID user roles: %s\n%s", err, resp)
+		return diag.Errorf("Error getting AppID user roles: %s", err)
+	}
+
+	if roles.Roles != nil {
+		if err := d.Set("roles", flattenAppIDUserRoles(roles.Roles)); err != nil {
+			return diag.Errorf("Error setting AppID user roles: %s", err)
+		}
+	}
+
+	d.SetId(fmt.Sprintf("%s/%s", tenantID, subject))
+	return nil
+}
+
+func flattenAppIDUserRoles(r []appid.GetUserRolesResponseRolesItem) []interface{} {
+	var result []interface{}
+
+	for _, v := range r {
+		role := map[string]interface{}{
+			"id": *v.ID,
+		}
+
+		if v.Name != nil {
+			role["name"] = *v.Name
+		}
+
+		result = append(result, role)
+	}
+
+	return result
+}

--- a/ibm/data_source_ibm_appid_user_roles_test.go
+++ b/ibm/data_source_ibm_appid_user_roles_test.go
@@ -1,0 +1,64 @@
+package ibm
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+func TestAccIBMAppIDUserRolesRolesDataSource_basic(t *testing.T) {
+	roleName := fmt.Sprintf("tf_testacc_role_%d", acctest.RandIntRange(10, 100))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: setupAppIDUserRolesDataSourceConfig(appIDTenantID, roleName, appIDTestUserEmail),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("data.ibm_appid_user_roles.roles", "roles.#", "1"),
+					resource.TestCheckResourceAttrPair("data.ibm_appid_user_roles.roles", "roles.0.id", "ibm_appid_role.role", "role_id"),
+					resource.TestCheckResourceAttrPair("data.ibm_appid_user_roles.roles", "roles.0.name", "ibm_appid_role.role", "name"),
+				),
+			},
+		},
+	})
+}
+
+// Test assumes there are no pre-existing roles
+func setupAppIDUserRolesDataSourceConfig(tenantID string, roleName string, email string) string {
+	return fmt.Sprintf(`	
+		resource "ibm_appid_role" "role" {
+			tenant_id = "%s"
+			name = "%s"
+			description = "test role"
+		}
+
+		resource "ibm_appid_cloud_directory_user" "test_user" {
+			tenant_id = ibm_appid_role.role.tenant_id
+			email {
+				value = "%s"
+				primary = true
+			}
+			password = "P@ssw0rd"
+			status = "PENDING"
+		}
+
+		resource "ibm_appid_user_roles" "roles" {
+			tenant_id = ibm_appid_role.role.tenant_id
+			subject = ibm_appid_cloud_directory_user.test_user.subject
+			role_ids = [ibm_appid_role.role.role_id]
+		}
+
+		data "ibm_appid_user_roles" "roles" {
+			tenant_id = ibm_appid_role.role.tenant_id
+			subject = ibm_appid_cloud_directory_user.test_user.subject
+
+			depends_on = [
+				ibm_appid_user_roles.roles
+			]
+		}
+	`, tenantID, roleName, email)
+}

--- a/ibm/provider.go
+++ b/ibm/provider.go
@@ -198,6 +198,7 @@ func Provider() *schema.Provider {
 			"ibm_appid_roles":                    dataSourceIBMAppIDRoles(),
 			"ibm_appid_theme_color":              dataSourceIBMAppIDThemeColor(),
 			"ibm_appid_theme_text":               dataSourceIBMAppIDThemeText(),
+			"ibm_appid_user_roles":               dataSourceIBMAppIDUserRoles(),
 
 			"ibm_function_action":                    dataSourceIBMFunctionAction(),
 			"ibm_function_package":                   dataSourceIBMFunctionPackage(),
@@ -497,6 +498,7 @@ func Provider() *schema.Provider {
 			"ibm_appid_role":                     resourceIBMAppIDRole(),
 			"ibm_appid_theme_color":              resourceIBMAppIDThemeColor(),
 			"ibm_appid_theme_text":               resourceIBMAppIDThemeText(),
+			"ibm_appid_user_roles":               resourceIBMAppIDUserRoles(),
 
 			"ibm_function_action":                                resourceIBMFunctionAction(),
 			"ibm_function_package":                               resourceIBMFunctionPackage(),

--- a/ibm/provider_test.go
+++ b/ibm/provider_test.go
@@ -13,6 +13,7 @@ import (
 )
 
 var appIDTenantID string
+var appIDTestUserEmail string
 var cfOrganization string
 var cfSpace string
 var cisDomainStatic string
@@ -120,6 +121,11 @@ func init() {
 	appIDTenantID = os.Getenv("IBM_APPID_TENANT_ID")
 	if appIDTenantID == "" {
 		fmt.Println("[WARN] Set the environment variable IBM_APPID_TENANT_ID for testing AppID resources, AppID tests will fail if this is not set")
+	}
+
+	appIDTestUserEmail = os.Getenv("IBM_APPID_TEST_USER_EMAIL")
+	if appIDTestUserEmail == "" {
+		fmt.Println("[WARN] Set the environment variable IBM_APPID_TEST_USER_EMAIL for testing AppID user resources, the tests will fail if this is not set")
 	}
 
 	cfOrganization = os.Getenv("IBM_ORG")

--- a/ibm/resource_ibm_appid_cloud_directory_user.go
+++ b/ibm/resource_ibm_appid_cloud_directory_user.go
@@ -16,7 +16,7 @@ import (
 
 func resourceIBMAppIDCloudDirectoryUser() *schema.Resource {
 	return &schema.Resource{
-		Description: "Manage AppID Cloud Directory user",
+		Description:   "Manage AppID Cloud Directory user",
 		CreateContext: resourceIBMAppIDCloudDirectoryUserCreate,
 		ReadContext:   resourceIBMAppIDCloudDirectoryUserRead,
 		DeleteContext: resourceIBMAppIDCloudDirectoryUserDelete,
@@ -51,6 +51,11 @@ func resourceIBMAppIDCloudDirectoryUser() *schema.Resource {
 			},
 			"user_id": {
 				Description: "Cloud Directory user ID",
+				Type:        schema.TypeString,
+				Computed:    true,
+			},
+			"subject": {
+				Description: "The user's identifier ('subject' in identity token)",
 				Type:        schema.TypeString,
 				Computed:    true,
 			},
@@ -185,6 +190,20 @@ func resourceIBMAppIDCloudDirectoryUserRead(ctx context.Context, d *schema.Resou
 		if err := d.Set("meta", flattenAppIDUserMetadata(user.Meta)); err != nil {
 			return diag.Errorf("Error setting AppID user metadata: %s", err)
 		}
+	}
+
+	attr, resp, err := appIDClient.CloudDirectoryGetUserinfoWithContext(ctx, &appid.CloudDirectoryGetUserinfoOptions{
+		TenantID: &tenantID,
+		UserID:   &userID,
+	})
+
+	if err != nil {
+		log.Printf("[DEBUG] Error getting AppID user attributes: %s\n%s", err, resp)
+		return diag.Errorf("Error getting AppID user attributes: %s", err)
+	}
+
+	if attr.Sub != nil {
+		d.Set("subject", *attr.Sub)
 	}
 
 	return nil

--- a/ibm/resource_ibm_appid_cloud_directory_user.go
+++ b/ibm/resource_ibm_appid_cloud_directory_user.go
@@ -50,6 +50,7 @@ func resourceIBMAppIDCloudDirectoryUser() *schema.Resource {
 				Description: "Cloud Directory user display name",
 				Type:        schema.TypeString,
 				Optional:    true,
+				Computed:    true,
 			},
 			"user_name": {
 				Description: "Optional username",

--- a/ibm/resource_ibm_appid_cloud_directory_user_test.go
+++ b/ibm/resource_ibm_appid_cloud_directory_user_test.go
@@ -14,7 +14,6 @@ import (
 
 func TestAccIBMAppIDCloudDirectoryUser_basic(t *testing.T) {
 	userName := fmt.Sprintf("tf_testacc_user_%d", acctest.RandIntRange(10, 100))
-	email := fmt.Sprintf("%s@mail.com", userName)
 	lockedUntil := time.Now().Add(time.Hour*2).UnixNano() / int64(time.Millisecond)
 
 	resource.Test(t, resource.TestCase{
@@ -23,15 +22,16 @@ func TestAccIBMAppIDCloudDirectoryUser_basic(t *testing.T) {
 		CheckDestroy: testAccCheckIBMAppIDCloudDirectoryUserDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckIBMAppIDCloudDirectoryUserConfig(appIDTenantID, userName, email, lockedUntil),
+				Config: testAccCheckIBMAppIDCloudDirectoryUserConfig(appIDTenantID, userName, appIDTestUserEmail, lockedUntil),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("ibm_appid_cloud_directory_user.user", "active", "false"),
 					resource.TestCheckResourceAttr("ibm_appid_cloud_directory_user.user", "locked_until", strconv.Itoa(int(lockedUntil))),
 					resource.TestCheckResourceAttrSet("ibm_appid_cloud_directory_user.user", "user_id"),
+					resource.TestCheckResourceAttrSet("ibm_appid_cloud_directory_user.user", "subject"),
 					resource.TestCheckResourceAttr("ibm_appid_cloud_directory_user.user", "display_name", "Test TF User"),
 					resource.TestCheckResourceAttr("ibm_appid_cloud_directory_user.user", "status", "PENDING"),
 					resource.TestCheckResourceAttr("ibm_appid_cloud_directory_user.user", "email.#", "1"),
-					resource.TestCheckResourceAttr("ibm_appid_cloud_directory_user.user", "email.0.value", email),
+					resource.TestCheckResourceAttr("ibm_appid_cloud_directory_user.user", "email.0.value", appIDTestUserEmail),
 					resource.TestCheckResourceAttr("ibm_appid_cloud_directory_user.user", "email.0.primary", "true"),
 				),
 			},

--- a/ibm/resource_ibm_appid_user_roles.go
+++ b/ibm/resource_ibm_appid_user_roles.go
@@ -1,0 +1,154 @@
+package ibm
+
+import (
+	"context"
+	"fmt"
+	appid "github.com/IBM/appid-management-go-sdk/appidmanagementv4"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"log"
+	"strings"
+)
+
+func resourceIBMAppIDUserRoles() *schema.Resource {
+	return &schema.Resource{
+		Description:   "Manage AppID user roles",
+		ReadContext:   resourceIBMAppIDUserRolesRead,
+		CreateContext: resourceIBMAppIDUserRolesCreate,
+		DeleteContext: resourceIBMAppIDUserRolesDelete,
+		UpdateContext: resourceIBMAppIDUserRolesUpdate,
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
+		Schema: map[string]*schema.Schema{
+			"tenant_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: "The AppID instance GUID",
+			},
+			"subject": {
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: "The user's identifier ('subject' in identity token)",
+			},
+			"role_ids": {
+				Description: "A set of AppID role IDs that should be assigned to the user",
+				Type:        schema.TypeSet,
+				Required:    true,
+				Elem:        &schema.Schema{Type: schema.TypeString},
+			},
+		},
+	}
+}
+
+func resourceIBMAppIDUserRolesRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	appIDClient, err := meta.(ClientSession).AppIDAPI()
+
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	id := d.Id()
+	idParts := strings.Split(id, "/")
+
+	if len(idParts) < 2 {
+		return diag.Errorf("Incorrect ID %s: ID should be a combination of tenantID/subject", id)
+	}
+
+	tenantID := idParts[0]
+	subject := idParts[1]
+
+	d.Set("tenant_id", tenantID)
+	d.Set("subject", subject)
+
+	roles, resp, err := appIDClient.GetUserRolesWithContext(ctx, &appid.GetUserRolesOptions{
+		TenantID: &tenantID,
+		ID:       &subject,
+	})
+
+	if err != nil {
+		log.Printf("[DEBUG] Error getting AppID user roles: %s\n%s", err, resp)
+		return diag.Errorf("Error getting AppID user roles: %s", err)
+	}
+
+	if roles.Roles != nil {
+		if err := d.Set("role_ids", flattenAppIDUserRoleIDs(roles.Roles)); err != nil {
+			return diag.Errorf("Error setting AppID user role_ids: %s", err)
+		}
+	}
+
+	return nil
+}
+
+func resourceIBMAppIDUserRolesCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	appIDClient, err := meta.(ClientSession).AppIDAPI()
+
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	tenantID := d.Get("tenant_id").(string)
+	subject := d.Get("subject").(string)
+	roleIds := d.Get("role_ids").(*schema.Set)
+
+	input := &appid.UpdateUserRolesOptions{
+		TenantID: &tenantID,
+		ID:       &subject,
+		Roles: &appid.UpdateUserRolesParamsRoles{
+			Ids: expandStringList(roleIds.List()),
+		},
+	}
+
+	_, resp, err := appIDClient.UpdateUserRolesWithContext(ctx, input)
+
+	if err != nil {
+		log.Printf("[DEBUG] Error updating AppID user roles: %s\n%s", err, resp)
+		return diag.Errorf("Error updating AppID user roles: %s", err)
+	}
+
+	d.SetId(fmt.Sprintf("%s/%s", tenantID, subject))
+	return resourceIBMAppIDUserRolesRead(ctx, d, meta)
+}
+
+func resourceIBMAppIDUserRolesDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	appIDClient, err := meta.(ClientSession).AppIDAPI()
+
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	tenantID := d.Get("tenant_id").(string)
+	subject := d.Get("subject").(string)
+
+	input := &appid.UpdateUserRolesOptions{
+		TenantID: &tenantID,
+		ID:       &subject,
+		Roles: &appid.UpdateUserRolesParamsRoles{
+			Ids: []string{},
+		},
+	}
+
+	_, resp, err := appIDClient.UpdateUserRolesWithContext(ctx, input)
+
+	if err != nil {
+		log.Printf("[DEBUG] Error deleting AppID user roles: %s\n%s", err, resp)
+		return diag.Errorf("Error deleting AppID user roles: %s", err)
+	}
+
+	d.SetId("")
+	return nil
+}
+
+func resourceIBMAppIDUserRolesUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	return resourceIBMAppIDUserRolesCreate(ctx, d, meta)
+}
+
+func flattenAppIDUserRoleIDs(r []appid.GetUserRolesResponseRolesItem) []string {
+	result := make([]string, len(r))
+	for i, role := range r {
+		result[i] = *role.ID
+	}
+	return result
+}

--- a/ibm/resource_ibm_appid_user_roles_test.go
+++ b/ibm/resource_ibm_appid_user_roles_test.go
@@ -1,0 +1,93 @@
+package ibm
+
+import (
+	"fmt"
+	appid "github.com/IBM/appid-management-go-sdk/appidmanagementv4"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+func TestAccIBMAppIDUserRolesRoles_basic(t *testing.T) {
+	roleName := fmt.Sprintf("tf_testacc_role_%d", acctest.RandIntRange(10, 100))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckIBMAppIDUserRolesDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: setupAppIDUserRolesConfig(appIDTenantID, roleName, appIDTestUserEmail),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("ibm_appid_user_roles.roles", "role_ids.#", "1"),
+					resource.TestCheckResourceAttrPair("ibm_appid_user_roles.roles", "role_ids.0", "ibm_appid_role.role", "role_id"),
+				),
+			},
+		},
+	})
+}
+
+// Test assumes there are no pre-existing roles
+func setupAppIDUserRolesConfig(tenantID string, roleName string, email string) string {
+	return fmt.Sprintf(`	
+		resource "ibm_appid_role" "role" {
+			tenant_id = "%s"
+			name = "%s"
+			description = "test role"
+		}
+
+		resource "ibm_appid_cloud_directory_user" "test_user" {
+			tenant_id = ibm_appid_role.role.tenant_id
+			email {
+				value = "%s"
+				primary = true
+			}
+			password = "P@ssw0rd"
+			status = "PENDING"
+		}
+
+		resource "ibm_appid_user_roles" "roles" {
+			tenant_id = ibm_appid_role.role.tenant_id
+			subject = ibm_appid_cloud_directory_user.test_user.subject
+			role_ids = [ibm_appid_role.role.role_id]
+		}
+	`, tenantID, roleName, email)
+}
+
+func testAccCheckIBMAppIDUserRolesDestroy(s *terraform.State) error {
+	appIDClient, err := testAccProvider.Meta().(ClientSession).AppIDAPI()
+
+	if err != nil {
+		return err
+	}
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "ibm_appid_user_roles" {
+			continue
+		}
+
+		id := rs.Primary.ID
+		idParts := strings.Split(id, "/")
+
+		tenantID := idParts[0]
+		subject := idParts[1]
+
+		roles, _, err := appIDClient.GetUserRoles(&appid.GetUserRolesOptions{
+			TenantID: &tenantID,
+			ID:       &subject,
+		})
+
+		if err != nil {
+			return fmt.Errorf("error checking if AppID user roles have been destroyed: %s", err)
+		}
+
+		if roles.Roles != nil && len(roles.Roles) > 0 {
+			return fmt.Errorf("error checking if AppID user roles have been destroyed")
+		}
+	}
+
+	return nil
+}

--- a/website/docs/d/appid_cloud_directory_user.html.markdown
+++ b/website/docs/d/appid_cloud_directory_user.html.markdown
@@ -30,6 +30,7 @@ In addition to all argument reference list, you can access the following attribu
 - `active` - (Boolean) Determines if the user account is active or not
 - `locked_until` - (Integer) Epoch time in milliseconds, determines till when the user account will be locked
 - `display_name` - (String) Optional user's display name
+- `subject` - (String) The user's identifier ('subject' in identity token)
 - `user_name` - (String) Username
 - `status` - (String) `PENDING` or `CONFIRMED`
 - `email` - (Set of Object) A set of user emails

--- a/website/docs/d/appid_user_roles.html.markdown
+++ b/website/docs/d/appid_user_roles.html.markdown
@@ -1,0 +1,34 @@
+---
+subcategory: "AppID Management"
+layout: "ibm"
+page_title: "IBM: AppID User Roles"
+description: |-
+    Retrieves AppID User Role information.
+---
+
+# ibm_appid_user_roles
+Retrieve information about an IBM Cloud AppID Management Services user roles.
+
+## Example usage
+
+```terraform
+data "ibm_appid_user_roles" "roles" {
+  tenant_id = var.tenant_id
+  subject = ibm_appid_cloud_directory_user.test_user.subject
+}
+```
+
+## Argument reference
+Review the argument references that you can specify for your data source.
+
+- `tenant_id` - (Required, String) The AppID instance GUID
+- `subject` - (Required, String) The user's identifier ('subject' in identity token)
+
+## Attribute reference
+In addition to all argument reference list, you can access the following attribute references after your data source is created
+
+- `roles` - (Set of Object) A set of AppID user roles
+
+  Nested scheme for `access`:
+    - `id` - (String) Role ID
+    - `name` - (String) Role name

--- a/website/docs/r/appid_cloud_directory_user.html.markdown
+++ b/website/docs/r/appid_cloud_directory_user.html.markdown
@@ -10,6 +10,8 @@ description: |-
 
 Create, update, or delete an IBM Cloud AppID Management Services Cloud Directory user resource.
 
+Note: depending on your AppID Cloud Directory settings, new user creation may trigger user verification email.
+
 ## Example usage
 
 ```terraform
@@ -35,6 +37,7 @@ Review the argument references that you can specify for your resource.
 
 - `tenant_id` - (Required, String) The AppID instance GUID
 - `active` - (Optional, Boolean) Determines if the user account is active or not (Default: true)
+- `create_profile` - (Optional, Boolean) A boolean indication if a profile should be created for the Cloud Directory user
 - `locked_until` - (Optional, Integer) Epoch time in milliseconds, determines till when the user account will be locked
 - `display_name` - (Optional, String) Optional user's display name, defaults to user's email
 - `user_name` - (Optional, String) Username
@@ -50,6 +53,7 @@ Review the argument references that you can specify for your resource.
 In addition to all argument reference list, you can access the following attribute references after your resource is created
 
 - `user_id` - (String) User identifier
+- `subject` - (String) The user's identifier ('subject' in identity token)
 - `meta` - (List of Object) User metadata
 
   Nested scheme for `meta`:

--- a/website/docs/r/appid_user_roles.html.markdown
+++ b/website/docs/r/appid_user_roles.html.markdown
@@ -1,0 +1,43 @@
+---
+subcategory: "AppID Management"
+layout: "ibm"
+page_title: "IBM: AppID User Roles"
+description: |-
+    Provides AppID User Roles resource.
+---
+
+# ibm_appid_user_roles
+
+Create, update, or delete an IBM Cloud AppID Management Services user roles resource.
+
+## Example usage
+
+```terraform
+resource "ibm_appid_user_roles" "roles" {
+  tenant_id = var.tenant_id
+  subject = ibm_appid_cloud_directory_user.test_user.subject
+  role_ids = [ibm_appid_role.test_role.role_id]
+}
+```
+
+## Argument reference
+Review the argument references that you can specify for your resource.
+
+- `tenant_id` - (Required, String) The AppID instance GUID
+- `subject` - (Required, String) The user's identifier ('subject' in identity token)
+- `role_ids` - (Required, List of String) The list of AppID role ids that you would like to assign to the user
+
+## Import
+
+The `ibm_appid_user_roles` resource can be imported by using the AppID tenant ID and user subject string.
+
+**Syntax**
+
+```bash
+$ terraform import ibm_appid_user_roles.roles <tenant_id>/<subject>
+```
+**Example**
+
+```bash
+$ terraform import ibm_appid_user_roles.roles 5fa344a8-d361-4bc2-9051-58ca253f4b2b/03cd638a-b35a-43f2-a58a-c2d3fe26aaea
+```


### PR DESCRIPTION
* Add AppID user roles datasource and resource
* Switch original user creation API to `signup` api, this allows creating user's profile at the same time. Without user profile there is no way to assign user roles
* Add new computed property `subject` to user resource. This identifier is used when modifying user roles
* Fix user `display_name` property type, set computed flag

<!--- See what makes a good Pull Request at : https://github.com/IBM-Cloud/terraform-provider-ibm/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
TF_ACC=1 go test $(go list ./... |grep -v 'vendor') -v -run TestAccIBMAppIDUserRolesRoles* -timeout 700m

=== RUN   TestAccIBMAppIDUserRolesRolesDataSource_basic
--- PASS: TestAccIBMAppIDUserRolesRolesDataSource_basic (43.04s)
=== RUN   TestAccIBMAppIDUserRolesRoles_basic
--- PASS: TestAccIBMAppIDUserRolesRoles_basic (39.44s)

TF_ACC=1 go test $(go list ./... |grep -v 'vendor') -v -run TestAccIBMAppIDCloudDirectoryUser* -timeout 700m

=== RUN   TestAccIBMAppIDCloudDirectoryUserDataSource_basic
--- PASS: TestAccIBMAppIDCloudDirectoryUserDataSource_basic (42.53s)
=== RUN   TestAccIBMAppIDCloudDirectoryUser_basic
--- PASS: TestAccIBMAppIDCloudDirectoryUser_basic (37.10s)

...
```
