### PR TITLE
fix: appid token config destination_claim should be optional

### DIFF
--- a/ibm/resource_ibm_appid_token_config.go
+++ b/ibm/resource_ibm_appid_token_config.go
@@ -78,7 +78,7 @@ func resourceIBMAppIDTokenConfig() *schema.Resource {
 						"destination_claim": {
 							Description: "Optional: Defines the custom attribute that can override the current claim in token.",
 							Type:        schema.TypeString,
-							Required:    true,
+							Optional:    true,
 						},
 					},
 				},


### PR DESCRIPTION
Fix for AppID token configuration resource, destination_claim property was wrongly marked as required

<!--- See what makes a good Pull Request at : https://github.com/IBM-Cloud/terraform-provider-ibm/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
TF_ACC=1 go test $(go list ./... |grep -v 'vendor') -v -run TestAccIBMAppIDTokenConfigDataSource_basic -timeout 700m
=== RUN   TestAccIBMAppIDTokenConfigDataSource_basic
--- PASS: TestAccIBMAppIDTokenConfigDataSource_basic (38.40s)
PASS

...
```
