### PR TITLE
datasource for network acl and network acl collection

### DIFF
--- a/examples/ibm-is-ng/main.tf
+++ b/examples/ibm-is-ng/main.tf
@@ -370,6 +370,7 @@ resource "ibm_is_volume" "vol2" {
 
 resource "ibm_is_network_acl" "isExampleACL" {
   name = "is-example-acl"
+  vpc = ibm_is_vpc.vpc1.id
   rules {
     name        = "outbound"
     action      = "allow"
@@ -418,6 +419,18 @@ data "ibm_is_network_acl_rule" "testacc_dsnaclrule" {
 
 data "ibm_is_network_acl_rules" "testacc_dsnaclrules" {
   network_acl = ibm_is_network_acl.isExampleACL.id
+}
+
+data "ibm_is_network_acl" "is_network_acl" {
+	network_acl = ibm_is_network_acl.isExampleACL.id
+}
+
+data "ibm_is_network_acl" "is_network_acl1" {
+	name = ibm_is_network_acl.isExampleACL.name
+	vpc_name = ibm_is_vpc.vpc1.name
+}
+
+data "ibm_is_network_acls" "is_network_acls" {
 }
 
 resource "ibm_is_public_gateway" "publicgateway1" {

--- a/ibm/data_source_ibm_is_network_acl.go
+++ b/ibm/data_source_ibm_is_network_acl.go
@@ -1,0 +1,704 @@
+// Copyright IBM Corp. 2021 All Rights Reserved.
+// Licensed under the Mozilla Public License v2.0
+
+package ibm
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"reflect"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/IBM/vpc-go-sdk/vpcv1"
+)
+
+func dataSourceIBMIsNetworkACL() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceIBMIsNetworkACLRead,
+
+		Schema: map[string]*schema.Schema{
+			isNetworkACLName: {
+				Type:         schema.TypeString,
+				Optional:     true,
+				RequiredWith: []string{"vpc_name"},
+				ExactlyOneOf: []string{"name", "network_acl"},
+				Description:  "The network acl name.",
+			},
+			"vpc_name": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				RequiredWith: []string{isNetworkACLName},
+				Description:  "The name of the vpc the network acl resides in.",
+			},
+			"network_acl": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ExactlyOneOf: []string{"name", "network_acl"},
+				Description:  "The network acl id.",
+			},
+			"created_at": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The date and time that the network ACL was created.",
+			},
+			"crn": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The CRN for this network ACL.",
+			},
+			"href": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The URL for this network ACL.",
+			},
+			isNetworkACLResourceGroup: {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Description: "The resource group for this network ACL.",
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"href": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "The URL for this resource group.",
+						},
+						"id": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "The unique identifier for this resource group.",
+						},
+						"name": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "The user-defined name for this resource group.",
+						},
+					},
+				},
+			},
+			isNetworkACLRules: {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Description: "The ordered rules for this network ACL. If no rules exist, all traffic will be denied.",
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						isNetworkACLRuleAction: {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "Whether to allow or deny matching traffic.",
+						},
+						"before": {
+							Type:        schema.TypeList,
+							Computed:    true,
+							Description: "The rule that this rule is immediately before. In a rule collection, this alwaysrefers to the next item in the collection. If absent, this is the last rule.",
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"deleted": {
+										Type:        schema.TypeList,
+										Computed:    true,
+										Description: "If present, this property indicates the referenced resource has been deleted and providessome supplementary information.",
+										Elem: &schema.Resource{
+											Schema: map[string]*schema.Schema{
+												"more_info": {
+													Type:        schema.TypeString,
+													Computed:    true,
+													Description: "Link to documentation about deleted resources.",
+												},
+											},
+										},
+									},
+									"href": {
+										Type:        schema.TypeString,
+										Computed:    true,
+										Description: "The URL for this network ACL rule.",
+									},
+									"id": {
+										Type:        schema.TypeString,
+										Computed:    true,
+										Description: "The unique identifier for this network ACL rule.",
+									},
+									"name": {
+										Type:        schema.TypeString,
+										Computed:    true,
+										Description: "The user-defined name for this network ACL rule.",
+									},
+								},
+							},
+						},
+						"created_at": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "The date and time that the rule was created.",
+						},
+						isNetworkACLRuleDestination: {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "The destination CIDR block. The CIDR block `0.0.0.0/0` applies to all addresses.",
+						},
+						isNetworkACLRuleDirection: {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "Whether the traffic to be matched is `inbound` or `outbound`.",
+						},
+						"href": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "The URL for this network ACL rule.",
+						},
+						isNetworkACLRuleID: {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "The unique identifier for this network ACL rule.",
+						},
+						isNetworkACLRuleIPVersion: {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "The IP version for this rule.",
+						},
+						isNetworkACLRuleName: {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "The user-defined name for this rule. Names must be unique within the network ACL the rule resides in. If unspecified, the name will be a hyphenated list of randomly-selected words.",
+						},
+						isNetworkACLRuleProtocol: {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "The protocol to enforce.",
+						},
+						isNetworkACLRuleSource: {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "The source CIDR block. The CIDR block `0.0.0.0/0` applies to all addresses.",
+						},
+						isNetworkACLRuleICMP: {
+							Type:        schema.TypeList,
+							Computed:    true,
+							Description: "The protocol ICMP",
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									isNetworkACLRuleICMPCode: {
+										Type:        schema.TypeInt,
+										Computed:    true,
+										Description: "The ICMP traffic code to allow. Valid values from 0 to 255.",
+									},
+									isNetworkACLRuleICMPType: {
+										Type:        schema.TypeInt,
+										Computed:    true,
+										Description: "The ICMP traffic type to allow. Valid values from 0 to 254.",
+									},
+								},
+							},
+						},
+
+						isNetworkACLRuleTCP: {
+							Type:        schema.TypeList,
+							Computed:    true,
+							Description: "TCP protocol",
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									isNetworkACLRulePortMax: {
+										Type:        schema.TypeInt,
+										Computed:    true,
+										Description: "The highest port in the range of ports to be matched",
+									},
+									isNetworkACLRulePortMin: {
+										Type:        schema.TypeInt,
+										Computed:    true,
+										Description: "The lowest port in the range of ports to be matched",
+									},
+									isNetworkACLRuleSourcePortMax: {
+										Type:        schema.TypeInt,
+										Computed:    true,
+										Description: "The highest port in the range of ports to be matched",
+									},
+									isNetworkACLRuleSourcePortMin: {
+										Type:        schema.TypeInt,
+										Computed:    true,
+										Description: "The lowest port in the range of ports to be matched",
+									},
+								},
+							},
+						},
+
+						isNetworkACLRuleUDP: {
+							Type:        schema.TypeList,
+							Computed:    true,
+							Description: "UDP protocol",
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									isNetworkACLRulePortMax: {
+										Type:        schema.TypeInt,
+										Computed:    true,
+										Description: "The highest port in the range of ports to be matched",
+									},
+									isNetworkACLRulePortMin: {
+										Type:        schema.TypeInt,
+										Computed:    true,
+										Description: "The lowest port in the range of ports to be matched",
+									},
+									isNetworkACLRuleSourcePortMax: {
+										Type:        schema.TypeInt,
+										Computed:    true,
+										Description: "The highest port in the range of ports to be matched",
+									},
+									isNetworkACLRuleSourcePortMin: {
+										Type:        schema.TypeInt,
+										Computed:    true,
+										Description: "The lowest port in the range of ports to be matched",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			"subnets": {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Description: "The subnets to which this network ACL is attached.",
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"crn": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "The CRN for this subnet.",
+						},
+						"deleted": {
+							Type:        schema.TypeList,
+							Computed:    true,
+							Description: "If present, this property indicates the referenced resource has been deleted and providessome supplementary information.",
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"more_info": {
+										Type:        schema.TypeString,
+										Computed:    true,
+										Description: "Link to documentation about deleted resources.",
+									},
+								},
+							},
+						},
+						"href": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "The URL for this subnet.",
+						},
+						"id": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "The unique identifier for this subnet.",
+						},
+						"name": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "The user-defined name for this subnet.",
+						},
+					},
+				},
+			},
+			"vpc": {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Description: "The VPC this network ACL is a part of.",
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"crn": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "The CRN for this VPC.",
+						},
+						"deleted": {
+							Type:        schema.TypeList,
+							Computed:    true,
+							Description: "If present, this property indicates the referenced resource has been deleted and providessome supplementary information.",
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"more_info": {
+										Type:        schema.TypeString,
+										Computed:    true,
+										Description: "Link to documentation about deleted resources.",
+									},
+								},
+							},
+						},
+						"href": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "The URL for this VPC.",
+						},
+						"id": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "The unique identifier for this VPC.",
+						},
+						"name": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "The unique user-defined name for this VPC.",
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func dataSourceIBMIsNetworkACLRead(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	vpcClient, err := meta.(ClientSession).VpcV1API()
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	vpc_name_str := ""
+	network_acl_name := ""
+	if vpc, ok := d.GetOk("vpc_name"); ok {
+		vpc_name_str = vpc.(string)
+	}
+	networkACL := &vpcv1.NetworkACL{}
+	if vpc_name_str != "" {
+		network_acl_name = d.Get(isNetworkACLName).(string)
+
+		start := ""
+		allrecs := []vpcv1.NetworkACL{}
+		for {
+			listNetworkAclsOptions := &vpcv1.ListNetworkAclsOptions{}
+			if start != "" {
+				listNetworkAclsOptions.Start = &start
+			}
+			networkACLCollection, response, err := vpcClient.ListNetworkAclsWithContext(context, listNetworkAclsOptions)
+			if err != nil || networkACLCollection == nil {
+				log.Printf("[DEBUG] ListNetworkAclsWithContext failed %s\n%s", err, response)
+				return diag.FromErr(fmt.Errorf("ListNetworkAclsWithContext failed %s\n%s", err, response))
+			}
+			start = GetNext(networkACLCollection.Next)
+			allrecs = append(allrecs, networkACLCollection.NetworkAcls...)
+			if start == "" {
+				break
+			}
+		}
+		acl_found := false
+		for _, networkAcl := range allrecs {
+			if *networkAcl.VPC.Name == vpc_name_str && network_acl_name == *networkAcl.Name {
+				networkACL = &networkAcl
+				acl_found = true
+				break
+			}
+		}
+
+		if !acl_found {
+			log.Printf("[DEBUG] No networkACL found with given VPC %s and ACL name %s", vpc_name_str, network_acl_name)
+			return diag.FromErr(fmt.Errorf("No networkACL found with given VPC %s and ACL name %s", vpc_name_str, network_acl_name))
+		}
+	} else {
+
+		getNetworkACLOptions := &vpcv1.GetNetworkACLOptions{}
+
+		getNetworkACLOptions.SetID(d.Get("network_acl").(string))
+
+		networkACLInst, response, err := vpcClient.GetNetworkACLWithContext(context, getNetworkACLOptions)
+		if err != nil || networkACLInst == nil {
+			log.Printf("[DEBUG] GetNetworkACLWithContext failed %s\n%s", err, response)
+			return diag.FromErr(fmt.Errorf("GetNetworkACLWithContext failed %s\n%s", err, response))
+		}
+		networkACL = networkACLInst
+	}
+	d.SetId(*networkACL.ID)
+	if err = d.Set("created_at", dateTimeToString(networkACL.CreatedAt)); err != nil {
+		return diag.FromErr(fmt.Errorf("Error setting created_at: %s", err))
+	}
+	if err = d.Set("crn", networkACL.CRN); err != nil {
+		return diag.FromErr(fmt.Errorf("Error setting crn: %s", err))
+	}
+	if err = d.Set("href", networkACL.Href); err != nil {
+		return diag.FromErr(fmt.Errorf("Error setting href: %s", err))
+	}
+	if err = d.Set("name", networkACL.Name); err != nil {
+		return diag.FromErr(fmt.Errorf("Error setting name: %s", err))
+	}
+
+	if networkACL.ResourceGroup != nil {
+		err = d.Set(isNetworkACLResourceGroup, dataSourceNetworkACLFlattenResourceGroup(*networkACL.ResourceGroup))
+		if err != nil {
+			return diag.FromErr(fmt.Errorf("Error setting resource_group %s", err))
+		}
+	}
+
+	if networkACL.Rules != nil {
+		err = d.Set(isNetworkACLRules, dataSourceNetworkACLFlattenRules(networkACL.Rules))
+		if err != nil {
+			return diag.FromErr(fmt.Errorf("Error setting rules %s", err))
+		}
+	}
+
+	if networkACL.Subnets != nil {
+		err = d.Set("subnets", dataSourceNetworkACLFlattenSubnets(networkACL.Subnets))
+		if err != nil {
+			return diag.FromErr(fmt.Errorf("Error setting subnets %s", err))
+		}
+	}
+
+	if networkACL.VPC != nil {
+		err = d.Set("vpc", dataSourceNetworkACLFlattenVPC(*networkACL.VPC))
+		if err != nil {
+			return diag.FromErr(fmt.Errorf("Error setting vpc %s", err))
+		}
+	}
+
+	return nil
+}
+
+func dataSourceNetworkACLFlattenResourceGroup(result vpcv1.ResourceGroupReference) (finalList []map[string]interface{}) {
+	finalList = []map[string]interface{}{}
+	finalMap := dataSourceNetworkACLResourceGroupToMap(result)
+	finalList = append(finalList, finalMap)
+
+	return finalList
+}
+
+func dataSourceNetworkACLResourceGroupToMap(resourceGroupItem vpcv1.ResourceGroupReference) (resourceGroupMap map[string]interface{}) {
+	resourceGroupMap = map[string]interface{}{}
+
+	if resourceGroupItem.Href != nil {
+		resourceGroupMap["href"] = resourceGroupItem.Href
+	}
+	if resourceGroupItem.ID != nil {
+		resourceGroupMap["id"] = resourceGroupItem.ID
+	}
+	if resourceGroupItem.Name != nil {
+		resourceGroupMap["name"] = resourceGroupItem.Name
+	}
+
+	return resourceGroupMap
+}
+
+func dataSourceNetworkACLFlattenRules(result []vpcv1.NetworkACLRuleItemIntf) (rules []map[string]interface{}) {
+	for _, rulesItem := range result {
+		rules = append(rules, dataSourceNetworkACLRulesToMap(rulesItem))
+	}
+
+	return rules
+}
+
+func dataSourceNetworkACLRulesToMap(rule vpcv1.NetworkACLRuleItemIntf) (rulesMap map[string]interface{}) {
+	rulesMap = map[string]interface{}{}
+
+	switch reflect.TypeOf(rule).String() {
+	case "*vpcv1.NetworkACLRuleItemNetworkACLRuleProtocolIcmp":
+		{
+			rulex := rule.(*vpcv1.NetworkACLRuleItemNetworkACLRuleProtocolIcmp)
+			rulesMap["id"] = *rulex.ID
+			rulesMap[isNetworkACLRuleHref] = *rulex.Href
+			rulesMap[isNetworkACLRuleProtocol] = *rulex.Protocol
+			if rulex.Before != nil {
+				beforeList := []map[string]interface{}{}
+				beforeMap := dataSourceNetworkACLRulesBeforeToMap(*rulex.Before)
+				beforeList = append(beforeList, beforeMap)
+				rulesMap["before"] = beforeList
+			}
+			rulesMap["created_at"] = dateTimeToString(rulex.CreatedAt)
+			rulesMap[isNetworkACLRuleName] = *rulex.Name
+			rulesMap[isNetworkACLRuleAction] = *rulex.Action
+			rulesMap[isNetworkACLRuleIPVersion] = *rulex.IPVersion
+			rulesMap[isNetworkACLRuleSource] = *rulex.Source
+			rulesMap[isNetworkACLRuleDestination] = *rulex.Destination
+			rulesMap[isNetworkACLRuleDirection] = *rulex.Direction
+			rulesMap[isNetworkACLRuleTCP] = make([]map[string]int, 0, 0)
+			rulesMap[isNetworkACLRuleUDP] = make([]map[string]int, 0, 0)
+			icmp := make([]map[string]int, 1, 1)
+			if rulex.Code != nil && rulex.Type != nil {
+				icmp[0] = map[string]int{
+					isNetworkACLRuleICMPCode: int(*rulex.Code),
+					isNetworkACLRuleICMPType: int(*rulex.Type),
+				}
+			}
+			rulesMap[isNetworkACLRuleICMP] = icmp
+		}
+	case "*vpcv1.NetworkACLRuleItemNetworkACLRuleProtocolTcpudp":
+		{
+			rulex := rule.(*vpcv1.NetworkACLRuleItemNetworkACLRuleProtocolTcpudp)
+			rulesMap["id"] = *rulex.ID
+			rulesMap[isNetworkACLRuleHref] = *rulex.Href
+			rulesMap[isNetworkACLRuleProtocol] = *rulex.Protocol
+			if rulex.Before != nil {
+				beforeList := []map[string]interface{}{}
+				beforeMap := dataSourceNetworkACLRulesBeforeToMap(*rulex.Before)
+				beforeList = append(beforeList, beforeMap)
+				rulesMap["before"] = beforeList
+			}
+			rulesMap["created_at"] = dateTimeToString(rulex.CreatedAt)
+			rulesMap[isNetworkACLRuleName] = *rulex.Name
+			rulesMap[isNetworkACLRuleAction] = *rulex.Action
+			rulesMap[isNetworkACLRuleIPVersion] = *rulex.IPVersion
+			rulesMap[isNetworkACLRuleSource] = *rulex.Source
+			rulesMap[isNetworkACLRuleDestination] = *rulex.Destination
+			rulesMap[isNetworkACLRuleDirection] = *rulex.Direction
+			if *rulex.Protocol == "tcp" {
+				rulesMap[isNetworkACLRuleICMP] = make([]map[string]int, 0, 0)
+				rulesMap[isNetworkACLRuleUDP] = make([]map[string]int, 0, 0)
+				tcp := make([]map[string]int, 1, 1)
+				tcp[0] = map[string]int{
+					isNetworkACLRuleSourcePortMax: checkNetworkACLNil(rulex.SourcePortMax),
+					isNetworkACLRuleSourcePortMin: checkNetworkACLNil(rulex.SourcePortMin),
+				}
+				tcp[0][isNetworkACLRulePortMax] = checkNetworkACLNil(rulex.DestinationPortMax)
+				tcp[0][isNetworkACLRulePortMin] = checkNetworkACLNil(rulex.DestinationPortMin)
+				rulesMap[isNetworkACLRuleTCP] = tcp
+			} else if *rulex.Protocol == "udp" {
+				rulesMap[isNetworkACLRuleICMP] = make([]map[string]int, 0, 0)
+				rulesMap[isNetworkACLRuleTCP] = make([]map[string]int, 0, 0)
+				udp := make([]map[string]int, 1, 1)
+				udp[0] = map[string]int{
+					isNetworkACLRuleSourcePortMax: checkNetworkACLNil(rulex.SourcePortMax),
+					isNetworkACLRuleSourcePortMin: checkNetworkACLNil(rulex.SourcePortMin),
+				}
+				udp[0][isNetworkACLRulePortMax] = checkNetworkACLNil(rulex.DestinationPortMax)
+				udp[0][isNetworkACLRulePortMin] = checkNetworkACLNil(rulex.DestinationPortMin)
+				rulesMap[isNetworkACLRuleUDP] = udp
+			}
+		}
+	case "*vpcv1.NetworkACLRuleItemNetworkACLRuleProtocolAll":
+		{
+			rulex := rule.(*vpcv1.NetworkACLRuleItemNetworkACLRuleProtocolAll)
+			rulesMap["id"] = *rulex.ID
+			rulesMap[isNetworkACLRuleHref] = *rulex.Href
+			rulesMap[isNetworkACLRuleProtocol] = *rulex.Protocol
+			if rulex.Before != nil {
+				beforeList := []map[string]interface{}{}
+				beforeMap := dataSourceNetworkACLRulesBeforeToMap(*rulex.Before)
+				beforeList = append(beforeList, beforeMap)
+				rulesMap["before"] = beforeList
+			}
+			rulesMap["created_at"] = dateTimeToString(rulex.CreatedAt)
+			rulesMap[isNetworkACLRuleName] = *rulex.Name
+			rulesMap[isNetworkACLRuleAction] = *rulex.Action
+			rulesMap[isNetworkACLRuleIPVersion] = *rulex.IPVersion
+			rulesMap[isNetworkACLRuleSource] = *rulex.Source
+			rulesMap[isNetworkACLRuleDestination] = *rulex.Destination
+			rulesMap[isNetworkACLRuleDirection] = *rulex.Direction
+			rulesMap[isNetworkACLRuleICMP] = make([]map[string]int, 0, 0)
+			rulesMap[isNetworkACLRuleTCP] = make([]map[string]int, 0, 0)
+			rulesMap[isNetworkACLRuleUDP] = make([]map[string]int, 0, 0)
+		}
+	}
+
+	return rulesMap
+}
+
+func dataSourceNetworkACLRulesBeforeToMap(beforeItem vpcv1.NetworkACLRuleReference) (beforeMap map[string]interface{}) {
+	beforeMap = map[string]interface{}{}
+
+	if beforeItem.Deleted != nil {
+		deletedList := []map[string]interface{}{}
+		deletedMap := dataSourceNetworkACLBeforeDeletedToMap(*beforeItem.Deleted)
+		deletedList = append(deletedList, deletedMap)
+		beforeMap["deleted"] = deletedList
+	}
+	if beforeItem.Href != nil {
+		beforeMap["href"] = beforeItem.Href
+	}
+	if beforeItem.ID != nil {
+		beforeMap["id"] = beforeItem.ID
+	}
+	if beforeItem.Name != nil {
+		beforeMap["name"] = beforeItem.Name
+	}
+
+	return beforeMap
+}
+
+func dataSourceNetworkACLBeforeDeletedToMap(deletedItem vpcv1.NetworkACLRuleReferenceDeleted) (deletedMap map[string]interface{}) {
+	deletedMap = map[string]interface{}{}
+
+	if deletedItem.MoreInfo != nil {
+		deletedMap["more_info"] = deletedItem.MoreInfo
+	}
+
+	return deletedMap
+}
+
+func dataSourceNetworkACLFlattenSubnets(result []vpcv1.SubnetReference) (subnets []map[string]interface{}) {
+	for _, subnetsItem := range result {
+		subnets = append(subnets, dataSourceNetworkACLSubnetsToMap(subnetsItem))
+	}
+
+	return subnets
+}
+
+func dataSourceNetworkACLSubnetsToMap(subnetsItem vpcv1.SubnetReference) (subnetsMap map[string]interface{}) {
+	subnetsMap = map[string]interface{}{}
+
+	if subnetsItem.CRN != nil {
+		subnetsMap["crn"] = subnetsItem.CRN
+	}
+	if subnetsItem.Deleted != nil {
+		deletedList := []map[string]interface{}{}
+		deletedMap := dataSourceNetworkACLSubnetsDeletedToMap(*subnetsItem.Deleted)
+		deletedList = append(deletedList, deletedMap)
+		subnetsMap["deleted"] = deletedList
+	}
+	if subnetsItem.Href != nil {
+		subnetsMap["href"] = subnetsItem.Href
+	}
+	if subnetsItem.ID != nil {
+		subnetsMap["id"] = subnetsItem.ID
+	}
+	if subnetsItem.Name != nil {
+		subnetsMap["name"] = subnetsItem.Name
+	}
+
+	return subnetsMap
+}
+
+func dataSourceNetworkACLSubnetsDeletedToMap(deletedItem vpcv1.SubnetReferenceDeleted) (deletedMap map[string]interface{}) {
+	deletedMap = map[string]interface{}{}
+
+	if deletedItem.MoreInfo != nil {
+		deletedMap["more_info"] = deletedItem.MoreInfo
+	}
+
+	return deletedMap
+}
+
+func dataSourceNetworkACLFlattenVPC(result vpcv1.VPCReference) (finalList []map[string]interface{}) {
+	finalList = []map[string]interface{}{}
+	finalMap := dataSourceNetworkACLVPCToMap(result)
+	finalList = append(finalList, finalMap)
+
+	return finalList
+}
+
+func dataSourceNetworkACLVPCToMap(vpcItem vpcv1.VPCReference) (vpcMap map[string]interface{}) {
+	vpcMap = map[string]interface{}{}
+
+	if vpcItem.CRN != nil {
+		vpcMap["crn"] = vpcItem.CRN
+	}
+	if vpcItem.Deleted != nil {
+		deletedList := []map[string]interface{}{}
+		deletedMap := dataSourceNetworkACLVPCDeletedToMap(*vpcItem.Deleted)
+		deletedList = append(deletedList, deletedMap)
+		vpcMap["deleted"] = deletedList
+	}
+	if vpcItem.Href != nil {
+		vpcMap["href"] = vpcItem.Href
+	}
+	if vpcItem.ID != nil {
+		vpcMap["id"] = vpcItem.ID
+	}
+	if vpcItem.Name != nil {
+		vpcMap["name"] = vpcItem.Name
+	}
+
+	return vpcMap
+}
+
+func dataSourceNetworkACLVPCDeletedToMap(deletedItem vpcv1.VPCReferenceDeleted) (deletedMap map[string]interface{}) {
+	deletedMap = map[string]interface{}{}
+
+	if deletedItem.MoreInfo != nil {
+		deletedMap["more_info"] = deletedItem.MoreInfo
+	}
+
+	return deletedMap
+}

--- a/ibm/data_source_ibm_is_network_acl_test.go
+++ b/ibm/data_source_ibm_is_network_acl_test.go
@@ -1,0 +1,81 @@
+// Copyright IBM Corp. 2021 All Rights Reserved.
+// Licensed under the Mozilla Public License v2.0
+
+package ibm
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+func TestAccIBMIsNetworkACLDataSourceBasic(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckIBMIsNetworkACLDataSourceConfigBasic(),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet("data.ibm_is_network_acl.is_network_acl", "id"),
+					resource.TestCheckResourceAttrSet("data.ibm_is_network_acl.is_network_acl", "created_at"),
+					resource.TestCheckResourceAttrSet("data.ibm_is_network_acl.is_network_acl", "crn"),
+					resource.TestCheckResourceAttrSet("data.ibm_is_network_acl.is_network_acl", "href"),
+					resource.TestCheckResourceAttrSet("data.ibm_is_network_acl.is_network_acl", "name"),
+					resource.TestCheckResourceAttrSet("data.ibm_is_network_acl.is_network_acl", "resource_group.#"),
+					resource.TestCheckResourceAttrSet("data.ibm_is_network_acl.is_network_acl", "rules.#"),
+					resource.TestCheckResourceAttrSet("data.ibm_is_network_acl.is_network_acl", "subnets.#"),
+					resource.TestCheckResourceAttrSet("data.ibm_is_network_acl.is_network_acl", "vpc.#"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckIBMIsNetworkACLDataSourceConfigBasic() string {
+	return fmt.Sprintf(`
+
+	resource "ibm_is_vpc" "testacc_vpc" {
+		name = "tf-nwacl-vpc"
+	  }
+
+	resource "ibm_is_network_acl" "isExampleACL" {
+		name = "is-example-acl"
+		vpc  = ibm_is_vpc.testacc_vpc.id
+		rules {
+		  name        = "outbound"
+		  action      = "allow"
+		  source      = "0.0.0.0/0"
+		  destination = "0.0.0.0/0"
+		  direction   = "outbound"
+		  icmp {
+			code = 8
+			type = 1
+		  }
+		  # Optionals :
+		  # port_max =
+		  # port_min =
+		}
+		rules {
+		  name        = "inbound"
+		  action      = "allow"
+		  source      = "0.0.0.0/0"
+		  destination = "0.0.0.0/0"
+		  direction   = "inbound"
+		  icmp {
+			code = 8
+			type = 1
+		  }
+		  # Optionals :
+		  # port_max =
+		  # port_min =
+		}
+	  }
+	
+      data "ibm_is_network_acl" "is_network_acl" {
+    	vpc_name = ibm_is_vpc.testacc_vpc.name
+		name = ibm_is_network_acl.isExampleACL.name
+      }
+	`)
+}

--- a/ibm/data_source_ibm_is_network_acls.go
+++ b/ibm/data_source_ibm_is_network_acls.go
@@ -1,0 +1,567 @@
+// Copyright IBM Corp. 2021 All Rights Reserved.
+// Licensed under the Mozilla Public License v2.0
+
+package ibm
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"time"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/IBM/vpc-go-sdk/vpcv1"
+)
+
+func dataSourceIBMIsNetworkAcls() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceIBMIsNetworkAclsRead,
+
+		Schema: map[string]*schema.Schema{
+			"resource_group": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "Resource group identifier.",
+			},
+			"network_acls": {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Description: "Collection of network ACLs.",
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"created_at": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "The date and time that the network ACL was created.",
+						},
+						"crn": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "The CRN for this network ACL.",
+						},
+						"href": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "The URL for this network ACL.",
+						},
+						"id": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "The unique identifier for this network ACL.",
+						},
+						"name": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "The user-defined name for this network ACL.",
+						},
+						"resource_group": {
+							Type:        schema.TypeList,
+							Computed:    true,
+							Description: "The resource group for this network ACL.",
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"href": {
+										Type:        schema.TypeString,
+										Computed:    true,
+										Description: "The URL for this resource group.",
+									},
+									"id": {
+										Type:        schema.TypeString,
+										Computed:    true,
+										Description: "The unique identifier for this resource group.",
+									},
+									"name": {
+										Type:        schema.TypeString,
+										Computed:    true,
+										Description: "The user-defined name for this resource group.",
+									},
+								},
+							},
+						},
+						isNetworkACLRules: {
+							Type:        schema.TypeList,
+							Computed:    true,
+							Description: "The ordered rules for this network ACL. If no rules exist, all traffic will be denied.",
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									isNetworkACLRuleAction: {
+										Type:        schema.TypeString,
+										Computed:    true,
+										Description: "Whether to allow or deny matching traffic.",
+									},
+									"before": {
+										Type:        schema.TypeList,
+										Computed:    true,
+										Description: "The rule that this rule is immediately before. In a rule collection, this alwaysrefers to the next item in the collection. If absent, this is the last rule.",
+										Elem: &schema.Resource{
+											Schema: map[string]*schema.Schema{
+												"deleted": {
+													Type:        schema.TypeList,
+													Computed:    true,
+													Description: "If present, this property indicates the referenced resource has been deleted and providessome supplementary information.",
+													Elem: &schema.Resource{
+														Schema: map[string]*schema.Schema{
+															"more_info": {
+																Type:        schema.TypeString,
+																Computed:    true,
+																Description: "Link to documentation about deleted resources.",
+															},
+														},
+													},
+												},
+												"href": {
+													Type:        schema.TypeString,
+													Computed:    true,
+													Description: "The URL for this network ACL rule.",
+												},
+												"id": {
+													Type:        schema.TypeString,
+													Computed:    true,
+													Description: "The unique identifier for this network ACL rule.",
+												},
+												"name": {
+													Type:        schema.TypeString,
+													Computed:    true,
+													Description: "The user-defined name for this network ACL rule.",
+												},
+											},
+										},
+									},
+									"created_at": {
+										Type:        schema.TypeString,
+										Computed:    true,
+										Description: "The date and time that the rule was created.",
+									},
+									isNetworkACLRuleDestination: {
+										Type:        schema.TypeString,
+										Computed:    true,
+										Description: "The destination CIDR block. The CIDR block `0.0.0.0/0` applies to all addresses.",
+									},
+									isNetworkACLRuleDirection: {
+										Type:        schema.TypeString,
+										Computed:    true,
+										Description: "Whether the traffic to be matched is `inbound` or `outbound`.",
+									},
+									"href": {
+										Type:        schema.TypeString,
+										Computed:    true,
+										Description: "The URL for this network ACL rule.",
+									},
+									isNetworkACLRuleID: {
+										Type:        schema.TypeString,
+										Computed:    true,
+										Description: "The unique identifier for this network ACL rule.",
+									},
+									isNetworkACLRuleIPVersion: {
+										Type:        schema.TypeString,
+										Computed:    true,
+										Description: "The IP version for this rule.",
+									},
+									isNetworkACLRuleName: {
+										Type:        schema.TypeString,
+										Computed:    true,
+										Description: "The user-defined name for this rule. Names must be unique within the network ACL the rule resides in. If unspecified, the name will be a hyphenated list of randomly-selected words.",
+									},
+									isNetworkACLRuleProtocol: {
+										Type:        schema.TypeString,
+										Computed:    true,
+										Description: "The protocol to enforce.",
+									},
+									isNetworkACLRuleSource: {
+										Type:        schema.TypeString,
+										Computed:    true,
+										Description: "The source CIDR block. The CIDR block `0.0.0.0/0` applies to all addresses.",
+									},
+									isNetworkACLRuleICMP: {
+										Type:        schema.TypeList,
+										Computed:    true,
+										Description: "The protocol ICMP",
+										Elem: &schema.Resource{
+											Schema: map[string]*schema.Schema{
+												isNetworkACLRuleICMPCode: {
+													Type:        schema.TypeInt,
+													Computed:    true,
+													Description: "The ICMP traffic code to allow. Valid values from 0 to 255.",
+												},
+												isNetworkACLRuleICMPType: {
+													Type:        schema.TypeInt,
+													Computed:    true,
+													Description: "The ICMP traffic type to allow. Valid values from 0 to 254.",
+												},
+											},
+										},
+									},
+
+									isNetworkACLRuleTCP: {
+										Type:        schema.TypeList,
+										Computed:    true,
+										Description: "TCP protocol",
+										Elem: &schema.Resource{
+											Schema: map[string]*schema.Schema{
+												isNetworkACLRulePortMax: {
+													Type:        schema.TypeInt,
+													Computed:    true,
+													Description: "The highest port in the range of ports to be matched",
+												},
+												isNetworkACLRulePortMin: {
+													Type:        schema.TypeInt,
+													Computed:    true,
+													Description: "The lowest port in the range of ports to be matched",
+												},
+												isNetworkACLRuleSourcePortMax: {
+													Type:        schema.TypeInt,
+													Computed:    true,
+													Description: "The highest port in the range of ports to be matched",
+												},
+												isNetworkACLRuleSourcePortMin: {
+													Type:        schema.TypeInt,
+													Computed:    true,
+													Description: "The lowest port in the range of ports to be matched",
+												},
+											},
+										},
+									},
+
+									isNetworkACLRuleUDP: {
+										Type:        schema.TypeList,
+										Computed:    true,
+										Description: "UDP protocol",
+										Elem: &schema.Resource{
+											Schema: map[string]*schema.Schema{
+												isNetworkACLRulePortMax: {
+													Type:        schema.TypeInt,
+													Computed:    true,
+													Description: "The highest port in the range of ports to be matched",
+												},
+												isNetworkACLRulePortMin: {
+													Type:        schema.TypeInt,
+													Computed:    true,
+													Description: "The lowest port in the range of ports to be matched",
+												},
+												isNetworkACLRuleSourcePortMax: {
+													Type:        schema.TypeInt,
+													Computed:    true,
+													Description: "The highest port in the range of ports to be matched",
+												},
+												isNetworkACLRuleSourcePortMin: {
+													Type:        schema.TypeInt,
+													Computed:    true,
+													Description: "The lowest port in the range of ports to be matched",
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+						"subnets": {
+							Type:        schema.TypeList,
+							Computed:    true,
+							Description: "The subnets to which this network ACL is attached.",
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"crn": {
+										Type:        schema.TypeString,
+										Computed:    true,
+										Description: "The CRN for this subnet.",
+									},
+									"deleted": {
+										Type:        schema.TypeList,
+										Computed:    true,
+										Description: "If present, this property indicates the referenced resource has been deleted and providessome supplementary information.",
+										Elem: &schema.Resource{
+											Schema: map[string]*schema.Schema{
+												"more_info": {
+													Type:        schema.TypeString,
+													Computed:    true,
+													Description: "Link to documentation about deleted resources.",
+												},
+											},
+										},
+									},
+									"href": {
+										Type:        schema.TypeString,
+										Computed:    true,
+										Description: "The URL for this subnet.",
+									},
+									"id": {
+										Type:        schema.TypeString,
+										Computed:    true,
+										Description: "The unique identifier for this subnet.",
+									},
+									"name": {
+										Type:        schema.TypeString,
+										Computed:    true,
+										Description: "The user-defined name for this subnet.",
+									},
+								},
+							},
+						},
+						"vpc": {
+							Type:        schema.TypeList,
+							Computed:    true,
+							Description: "The VPC this network ACL is a part of.",
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"crn": {
+										Type:        schema.TypeString,
+										Computed:    true,
+										Description: "The CRN for this VPC.",
+									},
+									"deleted": {
+										Type:        schema.TypeList,
+										Computed:    true,
+										Description: "If present, this property indicates the referenced resource has been deleted and providessome supplementary information.",
+										Elem: &schema.Resource{
+											Schema: map[string]*schema.Schema{
+												"more_info": {
+													Type:        schema.TypeString,
+													Computed:    true,
+													Description: "Link to documentation about deleted resources.",
+												},
+											},
+										},
+									},
+									"href": {
+										Type:        schema.TypeString,
+										Computed:    true,
+										Description: "The URL for this VPC.",
+									},
+									"id": {
+										Type:        schema.TypeString,
+										Computed:    true,
+										Description: "The unique identifier for this VPC.",
+									},
+									"name": {
+										Type:        schema.TypeString,
+										Computed:    true,
+										Description: "The unique user-defined name for this VPC.",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func dataSourceIBMIsNetworkAclsRead(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	vpcClient, err := meta.(ClientSession).VpcV1API()
+	if err != nil {
+		return diag.FromErr(err)
+	}
+	resource_group_id := d.Get("resource_group").(string)
+	start := ""
+	allrecs := []vpcv1.NetworkACL{}
+	listNetworkAclsOptions := &vpcv1.ListNetworkAclsOptions{}
+	if resource_group_id != "" {
+		listNetworkAclsOptions.ResourceGroupID = &resource_group_id
+	}
+	for {
+		if start != "" {
+			listNetworkAclsOptions.Start = &start
+		}
+		networkACLCollection, response, err := vpcClient.ListNetworkAclsWithContext(context, listNetworkAclsOptions)
+		if err != nil || networkACLCollection == nil {
+			log.Printf("[DEBUG] ListNetworkAclsWithContext failed %s\n%s", err, response)
+			return diag.FromErr(fmt.Errorf("ListNetworkAclsWithContext failed %s\n%s", err, response))
+		}
+		start = GetNext(networkACLCollection.Next)
+		allrecs = append(allrecs, networkACLCollection.NetworkAcls...)
+		if start == "" {
+			break
+		}
+	}
+
+	d.SetId(dataSourceIBMIsNetworkAclsID(d))
+
+	err = d.Set("network_acls", dataSourceNetworkACLCollectionFlattenNetworkAcls(allrecs))
+	if err != nil {
+		return diag.FromErr(fmt.Errorf("Error setting network_acls %s", err))
+	}
+
+	return nil
+}
+
+// dataSourceIBMIsNetworkAclsID returns a reasonable ID for the list.
+func dataSourceIBMIsNetworkAclsID(d *schema.ResourceData) string {
+	return time.Now().UTC().String()
+}
+
+func dataSourceNetworkACLCollectionFlattenNetworkAcls(result []vpcv1.NetworkACL) (networkAcls []map[string]interface{}) {
+	for _, networkAclsItem := range result {
+		networkAcls = append(networkAcls, dataSourceNetworkACLCollectionNetworkAclsToMap(networkAclsItem))
+	}
+
+	return networkAcls
+}
+
+func dataSourceNetworkACLCollectionNetworkAclsToMap(networkAclsItem vpcv1.NetworkACL) (networkAclsMap map[string]interface{}) {
+	networkAclsMap = map[string]interface{}{}
+
+	if networkAclsItem.CreatedAt != nil {
+		networkAclsMap["created_at"] = networkAclsItem.CreatedAt.String()
+	}
+	if networkAclsItem.CRN != nil {
+		networkAclsMap["crn"] = networkAclsItem.CRN
+	}
+	if networkAclsItem.Href != nil {
+		networkAclsMap["href"] = networkAclsItem.Href
+	}
+	if networkAclsItem.ID != nil {
+		networkAclsMap["id"] = networkAclsItem.ID
+	}
+	if networkAclsItem.Name != nil {
+		networkAclsMap["name"] = networkAclsItem.Name
+	}
+	if networkAclsItem.ResourceGroup != nil {
+		resourceGroupList := []map[string]interface{}{}
+		resourceGroupMap := dataSourceNetworkACLCollectionNetworkAclsResourceGroupToMap(*networkAclsItem.ResourceGroup)
+		resourceGroupList = append(resourceGroupList, resourceGroupMap)
+		networkAclsMap["resource_group"] = resourceGroupList
+	}
+	if networkAclsItem.Rules != nil {
+		rulesList := []map[string]interface{}{}
+		for _, rulesItem := range networkAclsItem.Rules {
+			rulesList = append(rulesList, dataSourceNetworkACLRulesToMap(rulesItem))
+		}
+		networkAclsMap[isNetworkACLRules] = rulesList
+	}
+	if networkAclsItem.Subnets != nil {
+		subnetsList := []map[string]interface{}{}
+		for _, subnetsItem := range networkAclsItem.Subnets {
+			subnetsList = append(subnetsList, dataSourceNetworkACLCollectionNetworkAclsSubnetsToMap(subnetsItem))
+		}
+		networkAclsMap["subnets"] = subnetsList
+	}
+	if networkAclsItem.VPC != nil {
+		vpcList := []map[string]interface{}{}
+		vpcMap := dataSourceNetworkACLCollectionNetworkAclsVPCToMap(*networkAclsItem.VPC)
+		vpcList = append(vpcList, vpcMap)
+		networkAclsMap["vpc"] = vpcList
+	}
+
+	return networkAclsMap
+}
+
+func dataSourceNetworkACLCollectionNetworkAclsResourceGroupToMap(resourceGroupItem vpcv1.ResourceGroupReference) (resourceGroupMap map[string]interface{}) {
+	resourceGroupMap = map[string]interface{}{}
+
+	if resourceGroupItem.Href != nil {
+		resourceGroupMap["href"] = resourceGroupItem.Href
+	}
+	if resourceGroupItem.ID != nil {
+		resourceGroupMap["id"] = resourceGroupItem.ID
+	}
+	if resourceGroupItem.Name != nil {
+		resourceGroupMap["name"] = resourceGroupItem.Name
+	}
+
+	return resourceGroupMap
+}
+
+func dataSourceNetworkACLCollectionRulesBeforeToMap(beforeItem vpcv1.NetworkACLRuleReference) (beforeMap map[string]interface{}) {
+	beforeMap = map[string]interface{}{}
+
+	if beforeItem.Deleted != nil {
+		deletedList := []map[string]interface{}{}
+		deletedMap := dataSourceNetworkACLCollectionBeforeDeletedToMap(*beforeItem.Deleted)
+		deletedList = append(deletedList, deletedMap)
+		beforeMap["deleted"] = deletedList
+	}
+	if beforeItem.Href != nil {
+		beforeMap["href"] = beforeItem.Href
+	}
+	if beforeItem.ID != nil {
+		beforeMap["id"] = beforeItem.ID
+	}
+	if beforeItem.Name != nil {
+		beforeMap["name"] = beforeItem.Name
+	}
+
+	return beforeMap
+}
+
+func dataSourceNetworkACLCollectionBeforeDeletedToMap(deletedItem vpcv1.NetworkACLRuleReferenceDeleted) (deletedMap map[string]interface{}) {
+	deletedMap = map[string]interface{}{}
+
+	if deletedItem.MoreInfo != nil {
+		deletedMap["more_info"] = deletedItem.MoreInfo
+	}
+
+	return deletedMap
+}
+
+func dataSourceNetworkACLCollectionNetworkAclsSubnetsToMap(subnetsItem vpcv1.SubnetReference) (subnetsMap map[string]interface{}) {
+	subnetsMap = map[string]interface{}{}
+
+	if subnetsItem.CRN != nil {
+		subnetsMap["crn"] = subnetsItem.CRN
+	}
+	if subnetsItem.Deleted != nil {
+		deletedList := []map[string]interface{}{}
+		deletedMap := dataSourceNetworkACLCollectionSubnetsDeletedToMap(*subnetsItem.Deleted)
+		deletedList = append(deletedList, deletedMap)
+		subnetsMap["deleted"] = deletedList
+	}
+	if subnetsItem.Href != nil {
+		subnetsMap["href"] = subnetsItem.Href
+	}
+	if subnetsItem.ID != nil {
+		subnetsMap["id"] = subnetsItem.ID
+	}
+	if subnetsItem.Name != nil {
+		subnetsMap["name"] = subnetsItem.Name
+	}
+
+	return subnetsMap
+}
+
+func dataSourceNetworkACLCollectionSubnetsDeletedToMap(deletedItem vpcv1.SubnetReferenceDeleted) (deletedMap map[string]interface{}) {
+	deletedMap = map[string]interface{}{}
+
+	if deletedItem.MoreInfo != nil {
+		deletedMap["more_info"] = deletedItem.MoreInfo
+	}
+
+	return deletedMap
+}
+
+func dataSourceNetworkACLCollectionNetworkAclsVPCToMap(vpcItem vpcv1.VPCReference) (vpcMap map[string]interface{}) {
+	vpcMap = map[string]interface{}{}
+
+	if vpcItem.CRN != nil {
+		vpcMap["crn"] = vpcItem.CRN
+	}
+	if vpcItem.Deleted != nil {
+		deletedList := []map[string]interface{}{}
+		deletedMap := dataSourceNetworkACLCollectionVPCDeletedToMap(*vpcItem.Deleted)
+		deletedList = append(deletedList, deletedMap)
+		vpcMap["deleted"] = deletedList
+	}
+	if vpcItem.Href != nil {
+		vpcMap["href"] = vpcItem.Href
+	}
+	if vpcItem.ID != nil {
+		vpcMap["id"] = vpcItem.ID
+	}
+	if vpcItem.Name != nil {
+		vpcMap["name"] = vpcItem.Name
+	}
+
+	return vpcMap
+}
+
+func dataSourceNetworkACLCollectionVPCDeletedToMap(deletedItem vpcv1.VPCReferenceDeleted) (deletedMap map[string]interface{}) {
+	deletedMap = map[string]interface{}{}
+
+	if deletedItem.MoreInfo != nil {
+		deletedMap["more_info"] = deletedItem.MoreInfo
+	}
+
+	return deletedMap
+}

--- a/ibm/data_source_ibm_is_network_acls_test.go
+++ b/ibm/data_source_ibm_is_network_acls_test.go
@@ -1,0 +1,34 @@
+// Copyright IBM Corp. 2021 All Rights Reserved.
+// Licensed under the Mozilla Public License v2.0
+
+package ibm
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+func TestAccIBMIsNetworkAclsDataSourceBasic(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckIBMIsNetworkAclsDataSourceConfigBasic(),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet("data.ibm_is_network_acls.is_network_acls", "id"),
+					resource.TestCheckResourceAttrSet("data.ibm_is_network_acls.is_network_acls", "network_acls.#"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckIBMIsNetworkAclsDataSourceConfigBasic() string {
+	return fmt.Sprintf(`
+		data "ibm_is_network_acls" "is_network_acls" {
+		}
+	`)
+}

--- a/ibm/provider.go
+++ b/ibm/provider.go
@@ -337,6 +337,8 @@ func Provider() *schema.Provider {
 			"ibm_is_zones":                           dataSourceIBMISZones(),
 			"ibm_is_operating_system":                dataSourceIBMISOperatingSystem(),
 			"ibm_is_operating_systems":               dataSourceIBMISOperatingSystems(),
+			"ibm_is_network_acls":                    dataSourceIBMIsNetworkAcls(),
+			"ibm_is_network_acl":                     dataSourceIBMIsNetworkACL(),
 			"ibm_is_network_acl_rule":                dataSourceIBMISNetworkACLRule(),
 			"ibm_is_network_acl_rules":               dataSourceIBMISNetworkACLRules(),
 			"ibm_lbaas":                              dataSourceIBMLbaas(),

--- a/website/docs/d/is_network_acl.html.markdown
+++ b/website/docs/d/is_network_acl.html.markdown
@@ -1,0 +1,99 @@
+---
+subcategory: "VPC infrastructure"
+layout: "ibm"
+page_title: "IBM : network_acl"
+description: |-
+  Get information about IBM Network Acl.
+---
+
+# ibm_is_network_acl
+
+Provides a read-only data source for NetworkACL. You can then reference the fields of the data source in other resources within the same configuration using interpolation syntax.
+
+## Example Usage
+
+```hcl
+resource "ibm_is_vpc" "example" {
+  name = "vpctest"
+}
+
+resource "ibm_is_network_acl" "example" {
+  name = "is-example-acl"
+  vpc  = ibm_is_vpc.example.id
+}  
+
+data "ibm_is_network_acl" "example" {
+  network_acl = ibm_is_network_acl.example.id
+}
+
+data "ibm_is_network_acl" "is_network_acl1" {
+  name = ibm_is_network_acl.example.name
+  vpc_name = ibm_is_vpc.example.name
+}
+```
+
+## Argument Reference
+
+Review the argument reference that you can specify for your data source.
+
+- `name` - (Optional, String) The name of the network acl.
+- `network_acl` - (Optional, String) The network acl identifier.
+- `vpc_name` - (Optional, String) The name of the VPC.
+  **Note** Provide `network_acl` or the combination of `vpc_name` and `name`
+
+## Attribute Reference
+
+In addition to all argument references listed, you can access the following attribute references after your data source is created.
+
+- `created_at` - (String) The date and time that the network ACL was created.
+- `crn` - (String) The CRN for this network ACL.
+- `href` - (String) The URL for this network ACL.
+- `id` - The unique identifier of the NetworkACL.
+- `name` - (String) The user-defined name for this network ACL.
+- `resource_group` - (List) The resource group for this network ACL.
+  Nested scheme for `resource_group`:
+	- `href` - (String) The URL for this resource group.
+	- `id` - (String) The unique identifier for this resource group.
+	- `name` - (String) The user-defined name for this resource group.
+- `rules`- (Array of Strings) A list of rules for a network ACL. The order in which the rules are added to the list determines the priority of the rules. For example, the first rule that you want to enforce must be specified as the first rule in this list.
+  Nested scheme for `rules`:
+  - `name` - (String) The user-defined name for this rule.
+  - `action` - (String)  `Allow` or `deny` matching network traffic.
+  - `source` - (String) The source IP address or CIDR block.
+  - `destination` - (String) The destination IP address or CIDR block.
+  - `direction` - (String) Indicates whether the traffic to be matched is `inbound` or `outbound`.
+  - `icmp`- (List) The protocol ICMP.
+    Nested scheme for `icmp`:
+    - `code` - (Integer) The ICMP traffic code to allow. Valid values from 0 to 255. If unspecified, all codes are allowed. This can only be specified if type is also specified.
+    - `type` - (Integer) The ICMP traffic type to allow. Valid values from 0 to 254. If unspecified, all types are allowed by this rule.
+  - `tcp`- (List) The TCP protocol.
+    Nested scheme for `tcp`:
+    - `port_max` - (Integer) The highest port in the range of ports to be matched; if unspecified, 65535 is used.
+    - `port_min` - (Integer) The lowest port in the range of ports to be matched, if unspecified, 1 is used as default.
+    - `source_port_max` - (Integer) The highest port in the range of ports to be matched; if unspecified, 65535 is used as default.
+    - `source_port_min` - (Integer) The lowest port in the range of ports to be matched; if unspecified, 1 is used as default.
+  - `udp`- (List) The UDP protocol.
+    Nested scheme for `udp`:
+    - `port_max` - (Integer) The highest port in the range of ports to be matched; if unspecified, 65535 is used.
+    - `port_min` - (Integer) The lowest port in the range of ports to be matched; if unspecified, 1 is used.
+    - `source_port_max` - (Integer) The highest port in the range of ports to be matched; if unspecified, 65535 is used.
+    - `source_port_min` - (Integer) The lowest port in the range of ports to be matched; if unspecified, 1 is used.
+- `subnets` - (List) The subnets to which this network ACL is attached.
+  Nested scheme for **subnets**:
+	- `crn` - (String) The CRN for this subnet.
+	- `deleted` - (List) If present, this property indicates the referenced resource has been deleted and providessome supplementary information.
+	  Nested scheme for **deleted**:
+		- `more_info` - (String) Link to documentation about deleted resources.
+	- `href` - (String) The URL for this subnet.
+	- `id` - (String) The unique identifier for this subnet.
+	- `name` - (String) The user-defined name for this subnet.
+- `vpc` - (List) The VPC this network ACL is a part of.
+  Nested scheme for **vpc**:
+	- `crn` - (String) The CRN for this VPC.
+	- `deleted` - (List) If present, this property indicates the referenced resource has been deleted and providessome supplementary information.
+	  Nested scheme for **deleted**:
+		- `more_info` - (String) Link to documentation about deleted resources.
+	- `href` - (String) The URL for this VPC.
+	- `id` - (String) The unique identifier for this VPC.
+	- `name` - (String) The unique user-defined name for this VPC.
+

--- a/website/docs/d/is_network_acls.html.markdown
+++ b/website/docs/d/is_network_acls.html.markdown
@@ -1,0 +1,90 @@
+---
+subcategory: "VPC infrastructure"
+layout: "ibm"
+page_title: "IBM : network_acls"
+description: |-
+  Get information about IBM NetworkACLCollection.
+---
+
+# ibm_is_network_acls
+
+Provides a read-only data source for NetworkACLCollection. You can then reference the fields of the data source in other resources within the same configuration using interpolation syntax.
+
+## Example Usage
+
+```hcl
+resource "ibm_is_vpc" "example" {
+  name = "vpctest"
+}
+
+resource "ibm_is_network_acl" "example" {
+  name = "is-example-acl"
+  vpc  = ibm_is_vpc.example.id
+}  
+
+data "ibm_is_network_acls" "example" {
+}
+```
+
+## Argument Reference
+
+- `resource_group` - (Optional, String) Filters the collection to resources within one of the resource groups identified in a comma-separated list of resource group identifiers
+
+## Attribute Reference
+
+In addition to all argument references listed, you can access the following attribute references after your data source is created.
+
+- `network_acls` - (List) Collection of network ACLs.
+  Nested scheme for `network_acls`:
+  - `created_at` - (String) The date and time that the network ACL was created.
+  - `crn` - (String) The CRN for this network ACL.
+  - `href` - (String) The URL for this network ACL.
+  - `id` - (String) The unique identifier for this network ACL.
+  - `name` - (String) The user-defined name for this network ACL.
+  - `resource_group` - (List) The resource group for this network ACL.
+  	Nested scheme for `resource_group`:
+  	- `href` - (String) The URL for this resource group.
+  	- `id` - (String) The unique identifier for this resource group.
+  	- `name` - (String) The user-defined name for this resource group.
+  - `rules` - (Array of Strings) A list of rules for a network ACL.
+    Nested scheme for `rules`:
+	- `name` - (String) The user-defined name for this rule.
+  	- `action` - (String)  `Allow` or `deny` matching network traffic.
+  	- `source` - (String) The source IP address or CIDR block.
+  	- `destination` - (String) The destination IP address or CIDR block.
+  	- `direction` - (String) Indicates whether the traffic to be matched is `inbound` or `outbound`.
+  	- `icmp`- (List) The protocol ICMP.
+   	  Nested scheme for `icmp`:
+	  - `code` - (Integer) The ICMP traffic code to allow. Valid values from 0 to 255. If unspecified, all codes are allowed. This can only be specified if type is also specified.
+   	  - `type` - (Integer) The ICMP traffic type to allow. Valid values from 0 to 254. If unspecified, all types are allowed by this rule.
+   	- `tcp`- (List) The TCP protocol.
+  	  Nested scheme for `tcp`:
+	  - `port_max` - (Integer) The highest port in the range of ports to be matched; if unspecified, 65535 is used.
+  	  - `port_min` - (Integer) The lowest port in the range of ports to be matched, if unspecified, 1 is used as default.
+  	  - `source_port_max` - (Integer) The highest port in the range of ports to be matched; if unspecified, 65535 is used as default.
+  	  - `source_port_min` - (Integer) The lowest port in the range of ports to be matched; if unspecified, 1 is used as default.
+  	- `udp`- (List) The UDP protocol.
+	  Nested scheme for `udp`:
+	  - `port_max` - (Integer) The highest port in the range of ports to be matched; if unspecified, 65535 is used.
+  	  - `port_min` - (Integer) The lowest port in the range of ports to be matched; if unspecified, 1 is used.
+  	  - `source_port_max` - (Integer) The highest port in the range of ports to be matched; if unspecified, 65535 is used.
+  	  - `source_port_min` - (Integer) The lowest port in the range of ports to be matched; if unspecified, 1 is used.
+  - `subnets` - (List) The subnets to which this network ACL is attached.
+  	Nested scheme for `subnets`:
+  	- `crn` - (String) The CRN for this subnet.
+  	- `deleted` - (List) If present, this property indicates the referenced resource has been deleted and providessome supplementary information.
+  		Nested scheme for `deleted`:
+  		- `more_info` - (String) Link to documentation about deleted resources.
+  	- `href` - (String) The URL for this subnet.
+  	- `id` - (String) The unique identifier for this subnet.
+  	- `name` - (String) The user-defined name for this subnet.
+  - `vpc` - (List) The VPC this network ACL is a part of.
+  	Nested scheme for `vpc`:
+  	- `crn` - (String) The CRN for this VPC.
+  	- `deleted` - (List) If present, this property indicates the referenced resource has been deleted and providessome supplementary information.
+  		Nested scheme for `deleted`:
+  		- `more_info` - (String) Link to documentation about deleted resources.
+  	- `href` - (String) The URL for this VPC.
+  	- `id` - (String) The unique identifier for this VPC.
+  	- `name` - (String) The unique user-defined name for this VPC.
+


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/IBM-Cloud/terraform-provider-ibm/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccIBMIsNetworkACLDataSourceBasic'
=== RUN   TestAccIBMIsNetworkACLDataSourceBasic
--- PASS: TestAccIBMIsNetworkACLDataSourceBasic (93.58s)
PASS
ok      github.com/IBM-Cloud/terraform-provider-ibm/ibm 95.790s

$ make testacc TESTARGS='-run=TestAccIBMIsNetworkAclsDataSourceBasic'
=== RUN   TestAccIBMIsNetworkAclsDataSourceBasic
--- PASS: TestAccIBMIsNetworkAclsDataSourceBasic (29.89s)
PASS
ok      github.com/IBM-Cloud/terraform-provider-ibm/ibm 32.679s
...
```
Terraform show -> https://ibm.box.com/s/a6pb24owm4ellha1dj1m5k3p0w5uihug