### PR TITLE
Removing CisAP Blumix Dependency

### DIFF
--- a/examples/ibm-cis/main.tf
+++ b/examples/ibm-cis/main.tf
@@ -29,6 +29,7 @@ resource "ibm_cis_domain_settings" "web_domain" {
   waf             = "on"
   ssl             = "full"
   min_tls_version = "1.2"
+  brotli					= "on"
 }
 
 #Adding valid Domain for IBM CIS instance

--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/IBM/ibm-cos-sdk-go-config v1.2.0
 	github.com/IBM/ibm-hpcs-tke-sdk v0.0.0-20210723145459-a232c3f3ac91
 	github.com/IBM/keyprotect-go-client v0.7.0
-	github.com/IBM/networking-go-sdk v0.20.0
+	github.com/IBM/networking-go-sdk v0.22.0
 	github.com/IBM/platform-services-go-sdk v0.19.3
 	github.com/IBM/push-notifications-go-sdk v0.0.0-20210310100607-5790b96c47f5
 	github.com/IBM/scc-go-sdk v1.2.0

--- a/go.sum
+++ b/go.sum
@@ -35,8 +35,6 @@ dmitri.shuralyov.com/gpu/mtl v0.0.0-20190408044501-666a987793e9/go.mod h1:H6x//7
 github.com/BurntSushi/toml v0.3.1 h1:WXkYYl6Yr3qBf1K79EBnL4mak0OimBfB0XUf9Vl28OQ=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
-github.com/IBM-Cloud/bluemix-go v0.0.0-20210903091337-e7648c203ed5 h1:bqcjvy0tnQjaNxFpg84aJiGF+jBnlEjC9zc2rmy8z+c=
-github.com/IBM-Cloud/bluemix-go v0.0.0-20210903091337-e7648c203ed5/go.mod h1:q0fXFSbum/16D8Mgn1ROSfSyX4BmvBCm/hHdcXz0wCU=
 github.com/IBM-Cloud/bluemix-go v0.0.0-20210922131713-7a9d25e2f1dd h1:mAku/r+LpGN4gJJAig22SQ443GoF1aVo/NQfv6MzwqQ=
 github.com/IBM-Cloud/bluemix-go v0.0.0-20210922131713-7a9d25e2f1dd/go.mod h1:q0fXFSbum/16D8Mgn1ROSfSyX4BmvBCm/hHdcXz0wCU=
 github.com/IBM-Cloud/container-services-go-sdk v0.0.0-20210705152127-41ca00fc9a62 h1:MOkcr6qQGk4tY542ZJ1DggVh2WUP72EEyLB79llFVH8=
@@ -83,8 +81,8 @@ github.com/IBM/ibm-hpcs-tke-sdk v0.0.0-20210723145459-a232c3f3ac91 h1:8ICDvg7YM+
 github.com/IBM/ibm-hpcs-tke-sdk v0.0.0-20210723145459-a232c3f3ac91/go.mod h1:M2JyuyeWHPtgGNeezr6YqVRuaav2MpY8Ha4QrEYvMoI=
 github.com/IBM/keyprotect-go-client v0.7.0 h1:JstSHD14Lp6ihwQseyPuGcs1AjOBjAmcisP0dTBA6A0=
 github.com/IBM/keyprotect-go-client v0.7.0/go.mod h1:SVr2ylV/fhSQPDiUjWirN9fsyWFCNNbt8GIT8hPJVjE=
-github.com/IBM/networking-go-sdk v0.20.0 h1:DSqjcNNyWSOiett7aM0sTbPhNgcnLgC8cc+VQ5ZJFXA=
-github.com/IBM/networking-go-sdk v0.20.0/go.mod h1:nViqUm1Bv+ke8dyOhjQ6e+2U1XeqZX2y4bQbR8Od3Hc=
+github.com/IBM/networking-go-sdk v0.22.0 h1:qOvb7sBj8cVbddqUmn4XRCmARSly069okcnR7cDOXrE=
+github.com/IBM/networking-go-sdk v0.22.0/go.mod h1:nViqUm1Bv+ke8dyOhjQ6e+2U1XeqZX2y4bQbR8Od3Hc=
 github.com/IBM/platform-services-go-sdk v0.19.3 h1:lB8Xsnhwt82z2i2AI4GBb2Tdxn3TuveAsjwk7p6R/sY=
 github.com/IBM/platform-services-go-sdk v0.19.3/go.mod h1:E9HQN/MKeVqo3IRmfcCMw9/yq/QHmRvb/4FzxXQsfOk=
 github.com/IBM/push-notifications-go-sdk v0.0.0-20210310100607-5790b96c47f5 h1:NPUhkoOCRuv3OFWt19PmwjXGGTKlvmbuPg9fUrBUNe4=

--- a/ibm/config.go
+++ b/ibm/config.go
@@ -194,7 +194,6 @@ type ClientSession interface {
 	ContainerAPI() (containerv1.ContainerServiceAPI, error)
 	VpcContainerAPI() (containerv2.ContainerServiceAPI, error)
 	ContainerRegistryV1() (*containerregistryv1.ContainerRegistryV1, error)
-	CisAPI() (cisv1.CisServiceAPI, error)
 	FunctionClient() (*whisk.Client, error)
 	GlobalSearchAPI() (globalsearchv2.GlobalSearchServiceAPI, error)
 	GlobalTaggingAPI() (globaltaggingv3.GlobalTaggingServiceAPI, error)
@@ -573,11 +572,6 @@ func (session clientSession) ContainerRegistryV1() (*containerregistryv1.Contain
 // SchematicsAPI provides schematics Service APIs ...
 func (sess clientSession) SchematicsV1() (*schematicsv1.SchematicsV1, error) {
 	return sess.schematicsClient, sess.schematicsClientErr
-}
-
-// CisAPI provides Cloud Internet Services APIs ...
-func (sess clientSession) CisAPI() (cisv1.CisServiceAPI, error) {
-	return sess.cisServiceAPI, sess.cisConfigErr
 }
 
 // FunctionClient ...
@@ -1468,12 +1462,6 @@ func (c *Config) ClientSession() (interface{}, error) {
 		session.cosConfigErr = fmt.Errorf("Error occured while configuring COS config service: %q", err)
 	}
 	session.cosConfigAPI = cosconfigclient
-
-	cisAPI, err := cisv1.New(sess.BluemixSession)
-	if err != nil {
-		session.cisConfigErr = fmt.Errorf("Error occured while configuring Cloud Internet Services: %q", err)
-	}
-	session.cisServiceAPI = cisAPI
 
 	globalSearchAPI, err := globalsearchv2.New(sess.BluemixSession)
 	if err != nil {

--- a/ibm/resource_ibm_cis_dns_record_test.go
+++ b/ibm/resource_ibm_cis_dns_record_test.go
@@ -278,18 +278,6 @@ func testAccCheckIBMCisDNSRecordConfigCisDSBasic(resourceID string, cisDomain st
 	  `, resourceID)
 }
 
-func testAccCheckIBMCisDNSRecordConfigCisRIBasic(resourceID string, cisDomain string) string {
-	return testAccCheckIBMCisDomainDataSourceConfigBasic1() + fmt.Sprintf(`
-	resource "ibm_cis_dns_record" "%[1]s" {
-		cis_id    = ibm_cis.cis.id
-		domain_id = ibm_cis_domain.cis_domain.domain_id
-		name    = "%[1]s"
-		content = "192.168.0.10"
-		type    = "A"
-	  }
-`, resourceID)
-}
-
 func testAccCheckIBMCisDNSRecordConfigPTR(resourceID string, cisDomainStatic string) string {
 	return testAccCheckIBMCisDomainDataSourceConfigBasic1() + fmt.Sprintf(`
 	resource "ibm_cis_dns_record" "%[1]s" {

--- a/ibm/resource_ibm_cis_domain_settings.go
+++ b/ibm/resource_ibm_cis_domain_settings.go
@@ -637,6 +637,14 @@ func resourceCISSettingsUpdate(d *schema.ResourceData, meta interface{}) error {
 					_, resp, err = cisClient.UpdateMinTlsVersion(opt)
 				}
 			}
+		case cisDomainSettingsBrotli:
+			if d.HasChange(item) {
+				if v, ok := d.GetOk(item); ok {
+					opt := cisClient.NewUpdateBrotliOptions()
+					opt.SetValue(v.(string))
+					_, resp, err = cisClient.UpdateBrotli(opt)
+				}
+			}
 		case cisDomainSettingsCNAMEFlattening:
 			if d.HasChange(item) {
 				if v, ok := d.GetOk(item); ok {
@@ -942,16 +950,12 @@ func resourceCISSettingsRead(d *schema.ResourceData, meta interface{}) error {
 			settingErr = err
 
 		case cisDomainSettingsBrotli:
-			cisClient, err := meta.(ClientSession).CisAPI()
-			if err != nil {
-				return err
-			}
-			settingsResult, err := cisClient.Settings().GetSetting(crn, zoneID, item)
+			opt := cisClient.NewGetBrotliOptions()
+			result, resp, err := cisClient.GetBrotli(opt)
 			if err == nil {
-				settingsObj := *settingsResult
-				d.Set(item, settingsObj.Value)
+				d.Set(cisDomainSettingsBrotli, result.Result.Value)
 			}
-			settingErr = err
+			settingResponse = resp
 
 		case cisDomainSettingsMinTLSVersion:
 			opt := cisClient.NewGetMinTlsVersionOptions()

--- a/ibm/resource_ibm_cis_domain_settings_test.go
+++ b/ibm/resource_ibm_cis_domain_settings_test.go
@@ -129,6 +129,7 @@ func testAccCheckCisSettingsConfigBasic4(id string, cisDomainStatic string) stri
 		image_size_optimization     = "lossless"
 		ip_geolocation              = "on"
 		origin_error_page_pass_thru = "on"
+		brotli                      = "off"
 		pseudo_ipv4              = "off"
 		prefetch_preload         = "on"
 		response_buffering       = "on"

--- a/ibm/resource_ibm_cis_global_load_balancer_test.go
+++ b/ibm/resource_ibm_cis_global_load_balancer_test.go
@@ -248,19 +248,6 @@ func testAccCheckCisGlbConfigCisDSUpdate(id string, cisDomain string) string {
 	`, id, cisDomainStatic)
 }
 
-func testAccCheckCisGlbConfigCisRIBasic(id string, cisDomain string) string {
-	return testAccCheckCisPoolConfigCisRIBasic(id, cisDomain) + fmt.Sprintf(`
-	resource "ibm_cis_global_load_balancer" "%[1]s" {
-		cis_id           = ibm_cis.cis.id
-		domain_id        = ibm_cis_domain.cis_domain.id
-		name             = "%[2]s"
-		fallback_pool_id = ibm_cis_origin_pool.origin_pool.id
-		default_pool_ids = [ibm_cis_origin_pool.origin_pool.id]
-		steering_policy = "dynamic_latency" 
-	  }
-	`, id, cisDomain, "testacc_ds_cis")
-}
-
 func testAccCheckCisGlbConfigSessionAffinity(id string, cisDomainStatic string) string {
 	return testAccCheckCisPoolConfigFullySpecified(id, cisDomainStatic) + fmt.Sprintf(`
 	resource "ibm_cis_global_load_balancer" "%[1]s" {

--- a/ibm/resource_ibm_cis_healthcheck_test.go
+++ b/ibm/resource_ibm_cis_healthcheck_test.go
@@ -5,7 +5,6 @@ package ibm
 
 import (
 	"fmt"
-	"log"
 	"testing"
 
 	"github.com/IBM/go-sdk-core/v5/core"
@@ -99,59 +98,6 @@ func TestAccIBMCisHealthcheck_CreateAfterManualDestroy(t *testing.T) {
 			},
 			{
 				Config: testAccCheckCisHealthcheckConfigCisDSBasic("test", cisDomainStatic),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckCisHealthcheckExists(name, &monitorTwo),
-					func(state *terraform.State) error {
-						if monitorOne == monitorTwo {
-							return fmt.Errorf("load balancer monitor id is unchanged even after we thought we deleted it ( %s )",
-								monitorTwo)
-						}
-						return nil
-					},
-				),
-			},
-		},
-	})
-}
-
-func TestAccIBMCisHealthcheck_CreateAfterCisRIManualDestroy(t *testing.T) {
-	t.Skip()
-	var monitorOne, monitorTwo string
-	name := "ibm_cis_healthcheck.health_check"
-
-	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckCisMonitorDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccCheckCisHealthcheckConfigCisRIBasic("test", cisDomainTest),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckCisHealthcheckExists(name, &monitorOne),
-					testAccCisMonitorManuallyDelete(&monitorOne),
-					func(state *terraform.State) error {
-						cisClient, err := testAccProvider.Meta().(ClientSession).CisAPI()
-						if err != nil {
-							return err
-						}
-						for _, r := range state.RootModule().Resources {
-							if r.Type == "ibm_cis_domain" {
-								log.Printf("[WARN] Manually removing domain")
-								zoneID, cisID, _ := convertTftoCisTwoVar(r.Primary.ID)
-								_ = cisClient.Zones().DeleteZone(cisID, zoneID)
-								cisPtr := &cisID
-								log.Printf("[WARN]  Manually removing Cis Instance")
-								_ = testAccCisInstanceManuallyDeleteUnwrapped(state, cisPtr)
-							}
-
-						}
-						return nil
-					},
-				),
-				ExpectNonEmptyPlan: true,
-			},
-			{
-				Config: testAccCheckCisHealthcheckConfigCisRIBasic("test", cisDomainTest),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckCisHealthcheckExists(name, &monitorTwo),
 					func(state *terraform.State) error {

--- a/ibm/resource_ibm_cis_healthcheck_test.go
+++ b/ibm/resource_ibm_cis_healthcheck_test.go
@@ -188,16 +188,6 @@ func testAccCheckCisHealthcheckConfigCisDSBasic(resourceID string, cisDomain str
 	`)
 }
 
-func testAccCheckCisHealthcheckConfigCisRIBasic(resourceID string, cisDomain string) string {
-	return testAccCheckCisDomainConfigCisRIbasic(resourceID, cisDomain) + fmt.Sprintf(`
-	resource "ibm_cis_healthcheck" "health_check" {
-		cis_id         = ibm_cis.cis.id
-		expected_body  = "alive"
-		expected_codes = "2xx"
-	  }
-	`)
-}
-
 func testAccCheckCisHealthcheckConfigFullySpecified(resourceID string, cisDomain string) string {
 	return testAccCheckIBMCisDomainDataSourceConfigBasic1() + fmt.Sprintf(`
 	resource "ibm_cis_healthcheck" "health_check" {

--- a/ibm/resource_ibm_cis_origin_pool_test.go
+++ b/ibm/resource_ibm_cis_origin_pool_test.go
@@ -243,24 +243,6 @@ func testAccCheckCisPoolConfigCisDSUpdate(resourceID string, cisDomainStatic str
 	  `, resourceID)
 }
 
-func testAccCheckCisPoolConfigCisRIBasic(resourceID string, cisDomain string) string {
-	return testAccCheckCisDomainConfigCisRIbasic(resourceID, cisDomain) + fmt.Sprintf(`
-	resource "ibm_cis_origin_pool" "origin_pool" {
-		cis_id        = ibm_cis.cis.id
-		name          = "my-tf-pool-basic-%[1]s"
-		check_regions = ["WEU"]
-		description   = "tfacc-fully-specified"
-		origins {
-		  name    = "example-1"
-		  address = "www.google.com"
-		  enabled = true
-		  weight  = 1
-		}
-		enabled = false
-	  }
-	`, resourceID)
-}
-
 func testAccCheckCisPoolConfigFullySpecified(resourceID string, cisDomainStatic string) string {
 	return testAccCheckCisHealthcheckConfigCisDSBasic(resourceID, cisDomainStatic) + fmt.Sprintf(`
 	resource "ibm_cis_origin_pool" "origin_pool" {


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/IBM-Cloud/terraform-provider-ibm/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```
