### PR TITLE
Fix: trusted profiles

### DIFF
--- a/ibm/data_source_ibm_iam_trusted_profile_claim_rule.go
+++ b/ibm/data_source_ibm_iam_trusted_profile_claim_rule.go
@@ -114,9 +114,6 @@ func dataSourceIBMIamTrustedProfileClaimRuleRead(context context.Context, d *sch
 		return diag.FromErr(fmt.Errorf("GetClaimRule failed %s\n%s", err, response))
 	}
 	d.SetId(fmt.Sprintf("%s/%s", *getClaimRuleOptions.ProfileID, *profileClaimRule.ID))
-	if err = d.Set("id", profileClaimRule.ID); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting id: %s", err))
-	}
 	if err = d.Set("entity_tag", profileClaimRule.EntityTag); err != nil {
 		return diag.FromErr(fmt.Errorf("Error setting entity_tag: %s", err))
 	}

--- a/ibm/data_source_ibm_iam_trusted_profile_claim_rule_test.go
+++ b/ibm/data_source_ibm_iam_trusted_profile_claim_rule_test.go
@@ -11,16 +11,15 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 )
 
-func TestAccIBMIamTrustedProfileClaimRuleDataSourceBasic(t *testing.T) {
-	profileClaimRuleProfileID := fmt.Sprintf("tf_profile_id_%d", acctest.RandIntRange(10, 100))
-	profileClaimRuleType := fmt.Sprintf("tf_type_%d", acctest.RandIntRange(10, 100))
+func TestAccIBMIAMTrustedProfileClaimRuleDataSourceBasic(t *testing.T) {
+	profileClaimRuleProfileID := fmt.Sprintf("tf_profile_%d", acctest.RandIntRange(10, 100))
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { testAccPreCheck(t) },
+		PreCheck:  func() { testAccPreCheckIAMTrustedProfile(t) },
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			resource.TestStep{
-				Config: testAccCheckIBMIamTrustedProfileClaimRuleDataSourceConfigBasic(profileClaimRuleProfileID, profileClaimRuleType),
+				Config: testAccCheckIBMIamTrustedProfileClaimRuleDataSourceConfigBasic(profileClaimRuleProfileID),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrSet("data.ibm_iam_trusted_profile_claim_rule.iam_trusted_profile_claim_rule", "id"),
 					resource.TestCheckResourceAttrSet("data.ibm_iam_trusted_profile_claim_rule.iam_trusted_profile_claim_rule", "entity_tag"),
@@ -34,20 +33,15 @@ func TestAccIBMIamTrustedProfileClaimRuleDataSourceBasic(t *testing.T) {
 	})
 }
 
-func TestAccIBMIamTrustedProfileClaimRuleDataSourceAllArgs(t *testing.T) {
+func TestAccIBMIAMTrustedProfileClaimRuleDataSourceAllArgs(t *testing.T) {
 	profileClaimRuleProfileID := fmt.Sprintf("tf_profile_id_%d", acctest.RandIntRange(10, 100))
-	profileClaimRuleType := fmt.Sprintf("tf_type_%d", acctest.RandIntRange(10, 100))
 	profileClaimRuleName := fmt.Sprintf("tf_name_%d", acctest.RandIntRange(10, 100))
-	profileClaimRuleRealmName := fmt.Sprintf("tf_realm_name_%d", acctest.RandIntRange(10, 100))
-	profileClaimRuleCrType := fmt.Sprintf("tf_cr_type_%d", acctest.RandIntRange(10, 100))
-	profileClaimRuleExpiration := fmt.Sprintf("%d", acctest.RandIntRange(10, 100))
-
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { testAccPreCheck(t) },
+		PreCheck:  func() { testAccPreCheckIAMTrustedProfile(t) },
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			resource.TestStep{
-				Config: testAccCheckIBMIamTrustedProfileClaimRuleDataSourceConfig(profileClaimRuleProfileID, profileClaimRuleType, profileClaimRuleName, profileClaimRuleRealmName, profileClaimRuleCrType, profileClaimRuleExpiration),
+				Config: testAccCheckIBMIamTrustedProfileClaimRuleDataSourceConfig(profileClaimRuleProfileID, profileClaimRuleName),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrSet("data.ibm_iam_trusted_profile_claim_rule.iam_trusted_profile_claim_rule", "id"),
 					resource.TestCheckResourceAttrSet("data.ibm_iam_trusted_profile_claim_rule.iam_trusted_profile_claim_rule", "entity_tag"),
@@ -55,70 +49,57 @@ func TestAccIBMIamTrustedProfileClaimRuleDataSourceAllArgs(t *testing.T) {
 					resource.TestCheckResourceAttrSet("data.ibm_iam_trusted_profile_claim_rule.iam_trusted_profile_claim_rule", "modified_at"),
 					resource.TestCheckResourceAttrSet("data.ibm_iam_trusted_profile_claim_rule.iam_trusted_profile_claim_rule", "name"),
 					resource.TestCheckResourceAttrSet("data.ibm_iam_trusted_profile_claim_rule.iam_trusted_profile_claim_rule", "type"),
-					resource.TestCheckResourceAttrSet("data.ibm_iam_trusted_profile_claim_rule.iam_trusted_profile_claim_rule", "realm_name"),
-					resource.TestCheckResourceAttrSet("data.ibm_iam_trusted_profile_claim_rule.iam_trusted_profile_claim_rule", "expiration"),
-					resource.TestCheckResourceAttrSet("data.ibm_iam_trusted_profile_claim_rule.iam_trusted_profile_claim_rule", "cr_type"),
 					resource.TestCheckResourceAttrSet("data.ibm_iam_trusted_profile_claim_rule.iam_trusted_profile_claim_rule", "conditions.#"),
-					resource.TestCheckResourceAttrSet("data.ibm_iam_trusted_profile_claim_rule.iam_trusted_profile_claim_rule", "conditions.0.claim"),
-					resource.TestCheckResourceAttrSet("data.ibm_iam_trusted_profile_claim_rule.iam_trusted_profile_claim_rule", "conditions.0.operator"),
-					resource.TestCheckResourceAttrSet("data.ibm_iam_trusted_profile_claim_rule.iam_trusted_profile_claim_rule", "conditions.0.value"),
 				),
 			},
 		},
 	})
 }
 
-func testAccCheckIBMIamTrustedProfileClaimRuleDataSourceConfigBasic(profileClaimRuleProfileID string, profileClaimRuleType string) string {
+func testAccCheckIBMIamTrustedProfileClaimRuleDataSourceConfigBasic(profileClaimRuleProfileID string) string {
 	return fmt.Sprintf(`
+		resource "ibm_iam_trusted_profile" "iam_trusted_profile" {
+			name = "%s"
+		}
 		resource "ibm_iam_trusted_profile_claim_rule" "iam_trusted_profile_claim_rule" {
-			profile_id = "%s"
-			type = "%s"
+			profile_id = ibm_iam_trusted_profile.iam_trusted_profile.id 
+			type = "Profile-SAML"
+			name = "%[1]s"
+			realm_name = "%s"
+			expiration = 43200
 			conditions {
-				claim = "claim"
-				operator = "operator"
-				value = "value"
+				claim = "blueGroups"
+				operator = "NOT_EQUALS_IGNORE_CASE"
+				value = "\"cloud-docs-dev\""
 			}
 		}
-
 		data "ibm_iam_trusted_profile_claim_rule" "iam_trusted_profile_claim_rule" {
 			profile_id = ibm_iam_trusted_profile_claim_rule.iam_trusted_profile_claim_rule.profile_id
-			rule_id = "rule-id"
+			rule_id = ibm_iam_trusted_profile_claim_rule.iam_trusted_profile_claim_rule.rule_id
 		}
-	`, profileClaimRuleProfileID, profileClaimRuleType)
+	`, profileClaimRuleProfileID, realmName)
 }
 
-func testAccCheckIBMIamTrustedProfileClaimRuleDataSourceConfig(profileClaimRuleProfileID string, profileClaimRuleType string, profileClaimRuleName string, profileClaimRuleRealmName string, profileClaimRuleCrType string, profileClaimRuleExpiration string) string {
+func testAccCheckIBMIamTrustedProfileClaimRuleDataSourceConfig(profileClaimRuleProfileID string, profileClaimRuleName string) string {
 	return fmt.Sprintf(`
-		resource "ibm_iam_trusted_profile_claim_rule" "iam_trusted_profile_claim_rule" {
-			profile_id = "%s"
-			type = "%s"
-			conditions {
-				claim = "claim"
-				operator = "operator"
-				value = "value"
-			}
-			context {
-				transaction_id = "transaction_id"
-				operation = "operation"
-				user_agent = "user_agent"
-				url = "url"
-				instance_id = "instance_id"
-				thread_id = "thread_id"
-				host = "host"
-				start_time = "start_time"
-				end_time = "end_time"
-				elapsed_time = "elapsed_time"
-				cluster_name = "cluster_name"
-			}
-			name = "%s"
-			realm_name = "%s"
-			cr_type = "%s"
-			expiration = %s
+	resource "ibm_iam_trusted_profile" "iam_trusted_profile" {
+		name = "%s"
+	}
+	resource "ibm_iam_trusted_profile_claim_rule" "iam_trusted_profile_claim_rule" {
+		profile_id = ibm_iam_trusted_profile.iam_trusted_profile.id
+		type = "Profile-CR"
+		conditions {
+			claim = "blueGroups"
+			operator = "CONTAINS"
+			value = "\"cloud-docs-dev\""
 		}
+		name = "%s"
+		cr_type = "IKS_SA"
+	}
 
 		data "ibm_iam_trusted_profile_claim_rule" "iam_trusted_profile_claim_rule" {
 			profile_id = ibm_iam_trusted_profile_claim_rule.iam_trusted_profile_claim_rule.profile_id
-			rule_id = "rule-id"
+			rule_id = ibm_iam_trusted_profile_claim_rule.iam_trusted_profile_claim_rule.rule_id
 		}
-	`, profileClaimRuleProfileID, profileClaimRuleType, profileClaimRuleName, profileClaimRuleRealmName, profileClaimRuleCrType, profileClaimRuleExpiration)
+	`, profileClaimRuleProfileID, profileClaimRuleName)
 }

--- a/ibm/data_source_ibm_iam_trusted_profile_link_test.go
+++ b/ibm/data_source_ibm_iam_trusted_profile_link_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 )
 
-func TestAccIBMIamTrustedProfileLinkDataSourceBasic(t *testing.T) {
+func TestAccIBMIAMTrustedProfileLinkDataSourceBasic(t *testing.T) {
 	profileLinkProfileName := fmt.Sprintf("tf_profile_%d", acctest.RandIntRange(10, 100))
 	profileLinkCrType := "IKS_SA"
 
@@ -36,7 +36,7 @@ func TestAccIBMIamTrustedProfileLinkDataSourceBasic(t *testing.T) {
 	})
 }
 
-func TestAccIBMIamTrustedProfileLinkDataSourceAllArgs(t *testing.T) {
+func TestAccIBMIAMTrustedProfileLinkDataSourceAllArgs(t *testing.T) {
 	profileLinkProfileName := fmt.Sprintf("tf_profile_%d", acctest.RandIntRange(10, 100))
 	profileLinkCrType := "IKS_SA"
 	profileLinkName := fmt.Sprintf("tf_name_%d", acctest.RandIntRange(10, 100))
@@ -72,7 +72,7 @@ func testAccCheckIBMIamTrustedProfileLinkDataSourceConfigBasic(profileLinkProfil
 			profile_id = ibm_iam_trusted_profile.iam_trusted_profile.id
 			cr_type = "%s"
 			link {
-				crn = "crn:v1:bluemix:public:containers-kubernetes:us-south:a/4448261269a14562b839e0a3019ed980:c2047t5d0hfu7oe0emm0::"
+				crn = "%s"
 				namespace = "namespace"
 				name = "name"
 			}
@@ -82,7 +82,7 @@ func testAccCheckIBMIamTrustedProfileLinkDataSourceConfigBasic(profileLinkProfil
 			profile_id = ibm_iam_trusted_profile_link.iam_trusted_profile_link.profile_id
 			link_id = ibm_iam_trusted_profile_link.iam_trusted_profile_link.link_id
 		}
-	`, profileLinkProfileName, profileLinkCrType)
+	`, profileLinkProfileName, profileLinkCrType, iksSa)
 }
 
 func testAccCheckIBMIamTrustedProfileLinkDataSourceConfig(profileLinkProfileName string, profileLinkCrType string, profileLinkName string) string {
@@ -94,7 +94,7 @@ func testAccCheckIBMIamTrustedProfileLinkDataSourceConfig(profileLinkProfileName
 			profile_id = ibm_iam_trusted_profile.iam_trusted_profile.id
 			cr_type = "%s"
 			link {
-				crn = "crn:v1:bluemix:public:containers-kubernetes:us-south:a/4448261269a14562b839e0a3019ed980:c2047t5d0hfu7oe0emm0::"
+				crn = "%s"
 				namespace = "namespace"
 				name = "name"
 			}
@@ -105,5 +105,5 @@ func testAccCheckIBMIamTrustedProfileLinkDataSourceConfig(profileLinkProfileName
 			profile_id = ibm_iam_trusted_profile_link.iam_trusted_profile_link.profile_id
 			link_id = ibm_iam_trusted_profile_link.iam_trusted_profile_link.link_id
 		}
-	`, profileLinkProfileName, profileLinkCrType, profileLinkName)
+	`, profileLinkProfileName, profileLinkCrType, iksSa, profileLinkName)
 }

--- a/ibm/data_source_ibm_iam_trusted_profile_test.go
+++ b/ibm/data_source_ibm_iam_trusted_profile_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 )
 
-func TestAccIBMIamTrustedProfileDataSourceBasic(t *testing.T) {
+func TestAccIBMIAMTrustedProfileDataSourceBasic(t *testing.T) {
 	trustedProfileName := fmt.Sprintf("tf_name_%d", acctest.RandIntRange(10, 100))
 
 	resource.Test(t, resource.TestCase{
@@ -35,7 +35,7 @@ func TestAccIBMIamTrustedProfileDataSourceBasic(t *testing.T) {
 	})
 }
 
-func TestAccIBMIamTrustedProfileDataSourceAllArgs(t *testing.T) {
+func TestAccIBMIAMTrustedProfileDataSourceAllArgs(t *testing.T) {
 	trustedProfileName := fmt.Sprintf("tf_name_%d", acctest.RandIntRange(10, 100))
 	trustedProfileDescription := fmt.Sprintf("tf_description_%d", acctest.RandIntRange(10, 100))
 

--- a/ibm/provider_test.go
+++ b/ibm/provider_test.go
@@ -81,6 +81,8 @@ var hpcsAdmin1 string
 var hpcsToken1 string
 var hpcsAdmin2 string
 var hpcsToken2 string
+var realmName string
+var iksSa string
 
 // For Power Colo
 
@@ -593,6 +595,16 @@ func init() {
 	if hpcsAdmin2 == "" {
 		fmt.Println("[WARN] Set the environment variable IBM_HPCS_ADMIN2 with a VALID HPCS Admin Key2 Path")
 	}
+	realmName = os.Getenv("IBM_IAM_REALM_NAME")
+	if realmName == "" {
+		fmt.Println("[WARN] Set the environment variable IBM_IAM_REALM_NAME with a VALID realm name for iam trusted profile claim rule")
+	}
+
+	iksSa = os.Getenv("IBM_IAM_IKS_SA")
+	if iksSa == "" {
+		fmt.Println("[WARN] Set the environment variable IBM_IAM_IKS_SA with a VALID realm name for iam trusted profile link")
+	}
+
 	hpcsToken2 = os.Getenv("IBM_HPCS_TOKEN2")
 	if hpcsToken2 == "" {
 		fmt.Println("[WARN] Set the environment variable IBM_HPCS_TOKEN2 with a VALID token for HPCS Admin Key2")
@@ -708,6 +720,15 @@ func testAccPreCheckHPCS(t *testing.T) {
 	}
 	if hpcsToken2 == "" {
 		t.Fatal("IBM_HPCS_TOKEN2 must be set for acceptance tests")
+	}
+}
+func testAccPreCheckIAMTrustedProfile(t *testing.T) {
+	testAccPreCheck(t)
+	if realmName == "" {
+		t.Fatal("IBM_IAM_REALM_NAME must be set for acceptance tests")
+	}
+	if iksSa == "" {
+		t.Fatal("IBM_IAM_IKS_SA must be set for acceptance tests")
 	}
 }
 

--- a/ibm/resource_ibm_iam_trusted_profile_claim_rule_test.go
+++ b/ibm/resource_ibm_iam_trusted_profile_claim_rule_test.go
@@ -14,72 +14,42 @@ import (
 	"github.com/IBM/platform-services-go-sdk/iamidentityv1"
 )
 
-func TestAccIBMIamTrustedProfileClaimRuleBasic(t *testing.T) {
+func TestAccIBMIAMTrustedProfileClaimRuleBasic(t *testing.T) {
 	var conf iamidentityv1.ProfileClaimRule
 	profileName := fmt.Sprintf("tf_profile_%d", acctest.RandIntRange(10, 100))
-	typeVar := "Profile-SAML"
-	typeVarUpdate := "Profile-CR"
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheckIAMTrustedProfile(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckIBMIamTrustedProfileClaimRuleDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
-				Config: testAccCheckIBMIamTrustedProfileClaimRuleConfigBasic(profileName, typeVar),
+				Config: testAccCheckIBMIamTrustedProfileClaimRuleConfigBasic(profileName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckIBMIamTrustedProfileClaimRuleExists("ibm_iam_trusted_profile_claim_rule.iam_trusted_profile_claim_rule", conf),
-					resource.TestCheckResourceAttr("ibm_iam_trusted_profile_claim_rule.iam_trusted_profile_claim_rule", "type", typeVar),
-				),
-			},
-			resource.TestStep{
-				Config: testAccCheckIBMIamTrustedProfileClaimRuleConfigBasic(profileName, typeVarUpdate),
-				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr("ibm_iam_trusted_profile_claim_rule.iam_trusted_profile_claim_rule", "type", typeVarUpdate),
+					resource.TestCheckResourceAttr("ibm_iam_trusted_profile_claim_rule.iam_trusted_profile_claim_rule", "type", "Profile-SAML"),
 				),
 			},
 		},
 	})
 }
 
-func TestAccIBMIamTrustedProfileClaimRuleAllArgs(t *testing.T) {
+func TestAccIBMIAMTrustedProfileClaimRuleAllArgs(t *testing.T) {
 	var conf iamidentityv1.ProfileClaimRule
 	profileName := fmt.Sprintf("tf_profile_%d", acctest.RandIntRange(10, 100))
-	typeVar := "Profile-SAML"
 	name := fmt.Sprintf("tf_name_%d", acctest.RandIntRange(10, 100))
-	realmName := fmt.Sprintf("tf_realm_name_%d", acctest.RandIntRange(10, 100))
-	crType := "VSI"
-	expiration := fmt.Sprintf("%d", acctest.RandIntRange(10, 100))
-	typeVarUpdate := "Profile-CR"
-	nameUpdate := fmt.Sprintf("tf_name_%d", acctest.RandIntRange(10, 100))
-	realmNameUpdate := fmt.Sprintf("tf_realm_name_%d", acctest.RandIntRange(10, 100))
-	crTypeUpdate := "IKS_SA"
-	expirationUpdate := fmt.Sprintf("%d", acctest.RandIntRange(10, 100))
-
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheckIAMTrustedProfile(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckIBMIamTrustedProfileClaimRuleDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
-				Config: testAccCheckIBMIamTrustedProfileClaimRuleConfig(profileName, typeVar, name, realmName, crType, expiration),
+				Config: testAccCheckIBMIamTrustedProfileClaimRuleConfig(profileName, name),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckIBMIamTrustedProfileClaimRuleExists("ibm_iam_trusted_profile_claim_rule.iam_trusted_profile_claim_rule", conf),
-					resource.TestCheckResourceAttr("ibm_iam_trusted_profile_claim_rule.iam_trusted_profile_claim_rule", "type", typeVar),
+					resource.TestCheckResourceAttr("ibm_iam_trusted_profile_claim_rule.iam_trusted_profile_claim_rule", "type", "Profile-CR"),
 					resource.TestCheckResourceAttr("ibm_iam_trusted_profile_claim_rule.iam_trusted_profile_claim_rule", "name", name),
-					resource.TestCheckResourceAttr("ibm_iam_trusted_profile_claim_rule.iam_trusted_profile_claim_rule", "realm_name", realmName),
-					resource.TestCheckResourceAttr("ibm_iam_trusted_profile_claim_rule.iam_trusted_profile_claim_rule", "cr_type", crType),
-					resource.TestCheckResourceAttr("ibm_iam_trusted_profile_claim_rule.iam_trusted_profile_claim_rule", "expiration", expiration),
-				),
-			},
-			resource.TestStep{
-				Config: testAccCheckIBMIamTrustedProfileClaimRuleConfig(profileName, typeVarUpdate, nameUpdate, realmNameUpdate, crTypeUpdate, expirationUpdate),
-				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr("ibm_iam_trusted_profile_claim_rule.iam_trusted_profile_claim_rule", "type", typeVarUpdate),
-					resource.TestCheckResourceAttr("ibm_iam_trusted_profile_claim_rule.iam_trusted_profile_claim_rule", "name", nameUpdate),
-					resource.TestCheckResourceAttr("ibm_iam_trusted_profile_claim_rule.iam_trusted_profile_claim_rule", "realm_name", realmNameUpdate),
-					resource.TestCheckResourceAttr("ibm_iam_trusted_profile_claim_rule.iam_trusted_profile_claim_rule", "cr_type", crTypeUpdate),
-					resource.TestCheckResourceAttr("ibm_iam_trusted_profile_claim_rule.iam_trusted_profile_claim_rule", "expiration", expirationUpdate),
+					resource.TestCheckResourceAttr("ibm_iam_trusted_profile_claim_rule.iam_trusted_profile_claim_rule", "cr_type", "IKS_SA"),
 				),
 			},
 			resource.TestStep{
@@ -91,42 +61,43 @@ func TestAccIBMIamTrustedProfileClaimRuleAllArgs(t *testing.T) {
 	})
 }
 
-func testAccCheckIBMIamTrustedProfileClaimRuleConfigBasic(profileName string, typeVar string) string {
+func testAccCheckIBMIamTrustedProfileClaimRuleConfigBasic(profileName string) string {
 	return fmt.Sprintf(`
 		resource "ibm_iam_trusted_profile" "iam_trusted_profile" {
 			name = "%s"
 		}
 		resource "ibm_iam_trusted_profile_claim_rule" "iam_trusted_profile_claim_rule" {
-			profile_id = ibm_iam_trusted_profile.iam_trusted_profile.id
-			type = "%s"
+			profile_id = ibm_iam_trusted_profile.iam_trusted_profile.id 
+			type = "Profile-SAML"
+			name = "%[1]s"
+			realm_name = "%s"
+			expiration = 43200
 			conditions {
-				claim = "claim"
-				operator = "CONTAINS"
-				value = "value"
+				claim = "blueGroups"
+				operator = "NOT_EQUALS_IGNORE_CASE"
+				value = "\"cloud-docs-dev\""
 			}
 		}
-	`, profileName, typeVar)
+	`, profileName, realmName)
 }
 
-func testAccCheckIBMIamTrustedProfileClaimRuleConfig(profileName string, typeVar string, name string, realmName string, crType string, expiration string) string {
+func testAccCheckIBMIamTrustedProfileClaimRuleConfig(profileName string, name string) string {
 	return fmt.Sprintf(`
 		resource "ibm_iam_trusted_profile" "iam_trusted_profile" {
 			name = "%s"
 		}
 		resource "ibm_iam_trusted_profile_claim_rule" "iam_trusted_profile_claim_rule" {
 			profile_id = ibm_iam_trusted_profile.iam_trusted_profile.id
-			type = "%s"
+			type = "Profile-CR"
 			conditions {
-				claim = "claim"
+				claim = "blueGroups"
 				operator = "CONTAINS"
-				value = "value"
+				value = "\"cloud-docs-dev\""
 			}
 			name = "%s"
-			realm_name = "%s"
-			cr_type = "%s"
-			expiration = %s
+			cr_type = "IKS_SA"
 		}
-	`, profileName, typeVar, name, realmName, crType, expiration)
+	`, profileName, name)
 }
 
 func testAccCheckIBMIamTrustedProfileClaimRuleExists(n string, obj iamidentityv1.ProfileClaimRule) resource.TestCheckFunc {

--- a/ibm/resource_ibm_iam_trusted_profile_link_test.go
+++ b/ibm/resource_ibm_iam_trusted_profile_link_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/IBM/platform-services-go-sdk/iamidentityv1"
 )
 
-func TestAccIBMIamTrustedProfileLinkBasic(t *testing.T) {
+func TestAccIBMIAMTrustedProfileLinkBasic(t *testing.T) {
 	var conf iamidentityv1.ProfileLink
 	profileName := fmt.Sprintf("tf_profile_%d", acctest.RandIntRange(10, 100))
 	crType := "IKS_SA"
@@ -35,7 +35,7 @@ func TestAccIBMIamTrustedProfileLinkBasic(t *testing.T) {
 	})
 }
 
-func TestAccIBMIamTrustedProfileLinkAllArgs(t *testing.T) {
+func TestAccIBMIAMTrustedProfileLinkAllArgs(t *testing.T) {
 	var conf iamidentityv1.ProfileLink
 	profileName := fmt.Sprintf("tf_profile_%d", acctest.RandIntRange(10, 100))
 	crType := "IKS_SA"
@@ -72,12 +72,12 @@ func testAccCheckIBMIamTrustedProfileLinkConfigBasic(profileName string, crType 
 			profile_id = ibm_iam_trusted_profile.iam_trusted_profile.id
 			cr_type = "%s"
 			link {
-				crn = "crn:v1:bluemix:public:containers-kubernetes:us-south:a/4448261269a14562b839e0a3019ed980:c2047t5d0hfu7oe0emm0::"
+				crn = "%s"
 				namespace = "namespace"
 				name = "name"
 			}
 		}
-	`, profileName, crType)
+	`, profileName, crType, iksSa)
 }
 
 func testAccCheckIBMIamTrustedProfileLinkConfig(profileName string, crType string, name string) string {
@@ -89,13 +89,13 @@ func testAccCheckIBMIamTrustedProfileLinkConfig(profileName string, crType strin
 			profile_id = ibm_iam_trusted_profile.iam_trusted_profile.id
 			cr_type = "%s"
 			link {
-				crn = "crn:v1:bluemix:public:containers-kubernetes:us-south:a/4448261269a14562b839e0a3019ed980:c2047t5d0hfu7oe0emm0::"
+				crn = "%s"
 				namespace = "namespace"
 				name = "name"
 			}
 			name = "%s"
 		}
-	`, profileName, crType, name)
+	`, profileName, crType, iksSa, name)
 }
 
 func testAccCheckIBMIamTrustedProfileLinkExists(n string, obj iamidentityv1.ProfileLink) resource.TestCheckFunc {

--- a/ibm/resource_ibm_iam_trusted_profile_test.go
+++ b/ibm/resource_ibm_iam_trusted_profile_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/IBM/platform-services-go-sdk/iamidentityv1"
 )
 
-func TestAccIBMIamTrustedProfileBasic(t *testing.T) {
+func TestAccIBMIAMTrustedProfileBasic(t *testing.T) {
 	var conf iamidentityv1.TrustedProfile
 	name := fmt.Sprintf("tf_name_%d", acctest.RandIntRange(10, 100))
 	nameUpdate := fmt.Sprintf("tf_name_%d", acctest.RandIntRange(10, 100))
@@ -41,7 +41,7 @@ func TestAccIBMIamTrustedProfileBasic(t *testing.T) {
 	})
 }
 
-func TestAccIBMIamTrustedProfileAllArgs(t *testing.T) {
+func TestAccIBMIAMTrustedProfileAllArgs(t *testing.T) {
 	var conf iamidentityv1.TrustedProfile
 	name := fmt.Sprintf("tf_name_%d", acctest.RandIntRange(10, 100))
 	description := fmt.Sprintf("tf_description_%d", acctest.RandIntRange(10, 100))


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/IBM-Cloud/terraform-provider-ibm/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
make testacc TEST=./ibm TESTARGS='-run=TestAccIBMIAMTrustedProfile'
=== RUN   TestAccIBMIAMTrustedProfileClaimRuleDataSourceBasic
--- PASS: TestAccIBMIAMTrustedProfileClaimRuleDataSourceBasic (45.54s)
=== RUN   TestAccIBMIAMTrustedProfileClaimRuleDataSourceAllArgs
--- PASS: TestAccIBMIAMTrustedProfileClaimRuleDataSourceAllArgs (43.57s)
=== RUN   TestAccIBMIAMTrustedProfileLinkDataSourceBasic
--- PASS: TestAccIBMIAMTrustedProfileLinkDataSourceBasic (39.89s)
=== RUN   TestAccIBMIAMTrustedProfileLinkDataSourceAllArgs
--- PASS: TestAccIBMIAMTrustedProfileLinkDataSourceAllArgs (42.79s)
=== RUN   TestAccIBMIAMTrustedProfilePolicyDataSource_Basic
--- PASS: TestAccIBMIAMTrustedProfilePolicyDataSource_Basic (73.68s)
=== RUN   TestAccIBMIAMTrustedProfilePolicyDataSource_Multiple_Policies
--- PASS: TestAccIBMIAMTrustedProfilePolicyDataSource_Multiple_Policies (70.10s)
=== RUN   TestAccIBMIAMTrustedProfileDataSourceBasic
--- PASS: TestAccIBMIAMTrustedProfileDataSourceBasic (38.57s)
=== RUN   TestAccIBMIAMTrustedProfileDataSourceAllArgs
--- PASS: TestAccIBMIAMTrustedProfileDataSourceAllArgs (39.47s)
=== RUN   TestAccIBMIAMTrustedProfileClaimRuleBasic
--- PASS: TestAccIBMIAMTrustedProfileClaimRuleBasic (37.88s)
=== RUN   TestAccIBMIAMTrustedProfileClaimRuleAllArgs
--- PASS: TestAccIBMIAMTrustedProfileClaimRuleAllArgs (48.86s)
=== RUN   TestAccIBMIAMTrustedProfileLinkBasic
--- PASS: TestAccIBMIAMTrustedProfileLinkBasic (38.58s)
=== RUN   TestAccIBMIAMTrustedProfileLinkAllArgs
--- PASS: TestAccIBMIAMTrustedProfileLinkAllArgs (46.59s)
=== RUN   TestAccIBMIAMTrustedProfilePolicyBasic
--- PASS: TestAccIBMIAMTrustedProfilePolicyBasic (81.33s)
=== RUN   TestAccIBMIAMTrustedProfilePolicy_With_Service
--- PASS: TestAccIBMIAMTrustedProfilePolicy_With_Service (80.20s)
=== RUN   TestAccIBMIAMTrustedProfilePolicy_With_ResourceInstance
--- PASS: TestAccIBMIAMTrustedProfilePolicy_With_ResourceInstance (68.64s)
=== RUN   TestAccIBMIAMTrustedProfilePolicy_With_Resource_Group
--- PASS: TestAccIBMIAMTrustedProfilePolicy_With_Resource_Group (56.44s)
=== RUN   TestAccIBMIAMTrustedProfilePolicy_With_Resource_Type
--- PASS: TestAccIBMIAMTrustedProfilePolicy_With_Resource_Type (64.47s)
=== RUN   TestAccIBMIAMTrustedProfilePolicy_import
--- PASS: TestAccIBMIAMTrustedProfilePolicy_import (53.87s)
=== RUN   TestAccIBMIAMTrustedProfilePolicy_account_management
--- PASS: TestAccIBMIAMTrustedProfilePolicy_account_management (43.26s)
=== RUN   TestAccIBMIAMTrustedProfilePolicyWithCustomRole
--- PASS: TestAccIBMIAMTrustedProfilePolicyWithCustomRole (49.03s)
=== RUN   TestAccIBMIAMTrustedProfilePolicy_With_Resource_Attributes
--- PASS: TestAccIBMIAMTrustedProfilePolicy_With_Resource_Attributes (84.76s)
=== RUN   TestAccIBMIAMTrustedProfileBasic
--- PASS: TestAccIBMIAMTrustedProfileBasic (62.59s)
=== RUN   TestAccIBMIAMTrustedProfileAllArgs
--- PASS: TestAccIBMIAMTrustedProfileAllArgs (66.69s)
PASS
ok  	github.com/IBM-Cloud/terraform-provider-ibm/ibm	1279.812s
...
```
