### PR TITLE
added support for range of ports for NLB vnf

### DIFF
--- a/ibm/data_source_ibm_is_lb.go
+++ b/ibm/data_source_ibm_is_lb.go
@@ -291,7 +291,9 @@ func lbGetByName(d *schema.ResourceData, meta interface{}, name string) error {
 				d.Set(isLBType, "private")
 			}
 			d.Set(isLBStatus, *lb.ProvisioningStatus)
-			d.Set(isLBRouteMode, *lb.RouteMode)
+			if lb.RouteMode != nil {
+				d.Set(isLBRouteMode, *lb.RouteMode)
+			}
 			d.Set(isLBCrn, *lb.CRN)
 			d.Set(isLBOperatingStatus, *lb.OperatingStatus)
 			publicIpList := make([]string, 0)

--- a/ibm/data_source_ibm_is_lb_profiles.go
+++ b/ibm/data_source_ibm_is_lb_profiles.go
@@ -103,13 +103,19 @@ func dataSourceIBMISLbProfilesRead(d *schema.ResourceData, meta interface{}) err
 			case "*vpcv1.LoadBalancerProfileRouteModeSupportedDependent":
 				{
 					rms := routeMode.(*vpcv1.LoadBalancerProfileRouteModeSupportedDependent)
-					l["route_mode_type"] = *rms.Type
+					if rms.Type != nil {
+						l["route_mode_type"] = *rms.Type
+					}
 				}
 			case "*vpcv1.LoadBalancerProfileRouteModeSupported":
 				{
 					rms := routeMode.(*vpcv1.LoadBalancerProfileRouteModeSupported)
-					l["route_mode_type"] = *rms.Type
-					l["route_mode_supported"] = *rms.Value
+					if rms.Type != nil {
+						l["route_mode_type"] = *rms.Type
+					}
+					if rms.Value != nil {
+						l["route_mode_supported"] = *rms.Value
+					}
 				}
 			}
 		}

--- a/ibm/data_source_ibm_is_lbs.go
+++ b/ibm/data_source_ibm_is_lbs.go
@@ -255,7 +255,9 @@ func getLbs(d *schema.ResourceData, meta interface{}) error {
 		//	log.Printf("******* lb ******** : (%+v)", lb)
 		lbInfo[ID] = *lb.ID
 		lbInfo[isLBName] = *lb.Name
-		lbInfo[isLBRouteMode] = *lb.RouteMode
+		if lb.RouteMode != nil {
+			lbInfo[isLBRouteMode] = *lb.RouteMode
+		}
 		lbInfo[CRN] = *lb.CRN
 		lbInfo[ProvisioningStatus] = *lb.ProvisioningStatus
 

--- a/ibm/resource_ibm_is_lb.go
+++ b/ibm/resource_ibm_is_lb.go
@@ -402,7 +402,9 @@ func lbGet(d *schema.ResourceData, meta interface{}, id string) error {
 	} else {
 		d.Set(isLBType, "private")
 	}
-	d.Set(isLBRouteMode, *lb.RouteMode)
+	if lb.RouteMode != nil {
+		d.Set(isLBRouteMode, *lb.RouteMode)
+	}
 	d.Set(isLBStatus, *lb.ProvisioningStatus)
 	d.Set(isLBCrn, *lb.CRN)
 	d.Set(isLBOperatingStatus, *lb.OperatingStatus)

--- a/website/docs/r/is_lb_listener.html.markdown
+++ b/website/docs/r/is_lb_listener.html.markdown
@@ -61,7 +61,7 @@ resource "ibm_is_lb_listener" "lb_listener1"{
   lb       = ibm_is_lb.lb2.id
   port     = "9086"
   protocol = "https"
-  certificate_instance="crn:v1:staging:public:cloudcerts:us-south:a2d1bace7b46e4815a81e52c6ffeba5cf:af925157-b125-4db2-b642-adacb8b9c7f5:certificate:c81627a1bf6f766379cc4b98fd2a44ed"
+  certificate_instance="crn:v1:bluemix:public:cloudcerts:us-south:a2d1bace7b46e4815a81e52c6ffeba5cf:af925157-b125-4db2-b642-adacb8b9c7f5:certificate:c81627a1bf6f766379cc4b98fd2a44ed"
 }
 
 resource "ibm_is_lb_listener" "lb_listener2"{
@@ -71,6 +71,35 @@ resource "ibm_is_lb_listener" "lb_listener2"{
   https_redirect_listener = ibm_is_lb_listener.lb_listener1.listener_id
   https_redirect_status_code = 301
   https_redirect_uri = "/example?doc=geta" 
+}
+```
+
+### Sample to create a load balancer listener for a route mode enabled private network load balancer.
+
+```terraform
+
+resource "ibm_is_vpc" "vpc" {
+  name = "test-vpc"
+}
+
+resource "ibm_is_subnet" "subnet" {
+  name 			= "test-subnet"
+  vpc 			= "${ibm_is_vpc.vpc.id}"
+  zone 			= "us-south-2"
+  ipv4_cidr_block = "10.240.68.0/24"
+}
+
+resource "ibm_is_lb" "nlb" {
+  name           = "test-nlb"
+  subnets        = [ibm_is_subnet.subnet.id]
+  profile        = "network-fixed"
+  type           = "private"
+  route_mode     = "true"
+}
+
+resource "ibm_is_lb_listener" "nlbHttpListener1" {
+  lb           = ibm_is_lb.nlb.id
+  protocol     = "tcp"
 }
 ```
 
@@ -87,7 +116,12 @@ Review the argument references that you can specify for your resource.
 
 - `accept_proxy_protocol`- (Optional, Bool)  If set to **true**, listener forwards proxy protocol information that are supported by load balancers in the application family. Default value is **false**.
 - `lb` - (Required, Forces new resource, String) The load balancer unique identifier.
-- `port`- (Required, Integer) The listener port number. Valid range 1 to 65535.
+- `port`- (Optional, Deprecated Integer) The listener port number. Valid range `1` to `65535`.
+
+  **NOTE**:
+    - Private network load balancers with `route_mode` enabled don't support `port`, they support `port` range from `port_min`(1) - `port_max`(65535).
+    - Only accepted value of `port` for `route_mode` enabled private network load balancer is `1`. Any other value will show change or update-in-place and returns an error.
+
 - `protocol` - (Required, String) The listener protocol. Enumeration type are `http`, `tcp`, and `https`. Network load balancer supports only `tcp` protocol.
 - `default_pool` - (Optional, String) The load balancer pool unique identifier.
 - `certificate_instance` - (Optional, String) The CRN of the certificate instance, it is applicable(mandatory) only to https protocol.
@@ -100,6 +134,16 @@ Review the argument references that you can specify for your resource.
 In addition to all argument reference list, you can access the following attribute reference after your resource is created.
 
 - `id` - (String) The unique identifier of the load balancer listener.
+- `port_min`- (Integer) The inclusive lower bound of the range of ports used by this listener.
+
+  **NOTE**
+    - Only load balancers in the `network` family support more than one port per listener.
+    - Currently, only load balancers operating with route mode enabled support different values for `port_min` and port_max. When route mode is enabled, only a value of `1` is supported for `port_min`.
+- `port_max`- (Integer) The inclusive upper bound of the range of ports used by this listener.
+
+  **NOTE**
+    - Only load balancers in the `network` family support more than one port per listener.
+    - Currently, only load balancers operating with `route_mode` enabled support different values for `port_min` and `port_max`. When `route mode` is enabled, only a value of `65535` is supported for port_max.
 - `status` - (String) The status of load balancer listener.
 
 ## Import


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/IBM-Cloud/terraform-provider-ibm/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
=== RUN   TestAccIBMISNLBRouteModeListener_basic
--- PASS: TestAccIBMISNLBRouteModeListener_basic (730.28s)
PASS
ok      github.com/IBM-Cloud/terraform-provider-ibm/ibm 734.523s
```
```
=== RUN   TestAccIBMISLBListener_basic
--- PASS: TestAccIBMISLBListener_basic (713.72s)
PASS
ok      github.com/IBM-Cloud/terraform-provider-ibm/ibm 717.230s
```