### PR TITLE
added pagination support for members list in access group and removed deprecated function …

### DIFF
--- a/ibm/data_source_ibm_iam_access_group.go
+++ b/ibm/data_source_ibm_iam_access_group.go
@@ -15,10 +15,7 @@ import (
 
 func dataSourceIBMIAMAccessGroup() *schema.Resource {
 	return &schema.Resource{
-		Read:     dataIBMIAMAccessGroupRead,
-		Exists:   resourceIBMIAMAccessGroupExists,
-		Importer: &schema.ResourceImporter{},
-
+		Read: dataIBMIAMAccessGroupRead,
 		Schema: map[string]*schema.Schema{
 			"access_group_name": {
 				Type:        schema.TypeString,
@@ -197,7 +194,7 @@ func dataIBMIAMAccessGroupRead(d *schema.ResourceData, meta interface{}) error {
 		if err != nil {
 			log.Printf("Error retrieving access group rules: %s. API Response: %s", err, detailedResponse)
 		}
-		ibmID, serviceID := flattenMembersData(members, res, allrecs)
+		ibmID, serviceID := flattenMembersData(members.Members, res, allrecs)
 
 		grpInstance := map[string]interface{}{
 			"id":              grp.ID,

--- a/ibm/resource_ibm_iam_access_group_members.go
+++ b/ibm/resource_ibm_iam_access_group_members.go
@@ -34,6 +34,7 @@ func resourceIBMIAMAccessGroupMembers() *schema.Resource {
 				Type:     schema.TypeSet,
 				Optional: true,
 				Elem:     &schema.Schema{Type: schema.TypeString},
+				Set:      resourceIBMVPCHash,
 			},
 
 			"iam_service_ids": {
@@ -124,9 +125,24 @@ func resourceIBMIAMAccessGroupMembersRead(context context.Context, d *schema.Res
 
 	grpID := parts[0]
 	listAccessGroupMembersOptions := iamAccessGroupsClient.NewListAccessGroupMembersOptions(grpID)
+	offset := int64(0)
+	// lets fetch 100 in a single pagination
+	limit := int64(100)
+	listAccessGroupMembersOptions.SetLimit(limit)
 	members, detailedResponse, err := iamAccessGroupsClient.ListAccessGroupMembers(listAccessGroupMembersOptions)
 	if err != nil {
 		return diag.FromErr(fmt.Errorf("[ERROR] Error retrieving access group members: %s. API Response: %s", err, detailedResponse))
+	}
+	allMembers := members.Members
+	totalMembers := intValue(members.TotalCount)
+	for len(allMembers) < totalMembers {
+		offset = offset + limit
+		listAccessGroupMembersOptions.SetOffset(offset)
+		members, detailedResponse, err = iamAccessGroupsClient.ListAccessGroupMembers(listAccessGroupMembersOptions)
+		if err != nil {
+			return diag.FromErr(fmt.Errorf("[ERROR] Error retrieving access group members: %s. API Response: %s", err, detailedResponse))
+		}
+		allMembers = append(allMembers, members.Members...)
 	}
 
 	d.Set("access_group_id", grpID)
@@ -176,8 +192,8 @@ func resourceIBMIAMAccessGroupMembersRead(context context.Context, d *schema.Res
 		}
 	}
 
-	d.Set("members", flattenAccessGroupMembers(members.Members, res, allrecs))
-	ibmID, serviceID := flattenMembersData(members, res, allrecs)
+	d.Set("members", flattenAccessGroupMembers(allMembers, res, allrecs))
+	ibmID, serviceID := flattenMembersData(allMembers, res, allrecs)
 	if len(ibmID) > 0 {
 		d.Set("ibm_ids", ibmID)
 	}

--- a/ibm/structures.go
+++ b/ibm/structures.go
@@ -1288,10 +1288,10 @@ func StringContains(s []string, str string) bool {
 	return false
 }
 
-func flattenMembersData(list *iamaccessgroupsv2.GroupMembersList, users []usermanagementv2.UserInfo, serviceids []iamidentityv1.ServiceID) ([]string, []string) {
+func flattenMembersData(list []iamaccessgroupsv2.ListGroupMembersResponseMember, users []usermanagementv2.UserInfo, serviceids []iamidentityv1.ServiceID) ([]string, []string) {
 	var ibmid []string
 	var serviceid []string
-	for _, m := range list.Members {
+	for _, m := range list {
 		if *m.Type == "user" {
 			for _, user := range users {
 				if user.IamID == *m.IamID {


### PR DESCRIPTION
…with context resource func

<!--- See what makes a good Pull Request at : https://github.com/IBM-Cloud/terraform-provider-ibm/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #3189

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccIBMIAMAccessGroupMember_Basic'


--- PASS: TestAccIBMIAMAccessGroupMember_Basic (88.92s)
PASS
ok      github.com/IBM-Cloud/terraform-provider-ibm/ibm 92.120s
testing: warning: no tests to run
PASS
ok      github.com/IBM-Cloud/terraform-provider-ibm/ibm/internal/hashcode       (cached) [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/IBM-Cloud/terraform-provider-ibm/ibm/internal/mutexkv        (cached) [no tests to run]
?       github.com/IBM-Cloud/terraform-provider-ibm/version     [no test files]

...
```
