### PR TITLE
Add satellite dns suport

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -25,7 +25,6 @@
       "name": "CloudantDetector"
     },
     {
-      "ghe_instance": "github.ibm.com",
       "name": "GheDetector"
     },
     {
@@ -926,7 +925,7 @@
         "hashed_secret": "c8b6f5ef11b9223ac35a5663975a466ebe7ebba9",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 985,
+        "line_number": 972,
         "type": "Secret Keyword",
         "verified_result": null
       },

--- a/examples/ibm-satellite/README.md
+++ b/examples/ibm-satellite/README.md
@@ -10,15 +10,9 @@ This example uses below modules to set up the satellite location with IBM enviro
 4. [satellite-link](modules/link) This module will create satellite link.
 5. [satellite-route](modules/route) This module will create openshift route.
 6. [satellite-endpoint](modules/endpoint) This module will create satellite endpoint.
+7. [satellite-dns](modules/dns) This module will register public IPs to control plane & open-shit cluster subdomain DNS records.
  
-## Prerequisite
-
-* Set up the IBM Cloud command line interface (CLI), the Satellite plug-in, and other related CLIs.
-* Install cli and plugin package
-```console
-    ibmcloud plugin install container-service
-```
-* Follow the Host [requirements](https://cloud.ibm.com/docs/satellite?topic=satellite-host-reqs) 
+ 
 ## Usage
 
 ```
@@ -77,6 +71,15 @@ module "satellite-cluster" {
   host_labels          = var.host_labels
 }
 
+module "satellite-dns" {
+  source = "./modules/dns"
+
+  location          = var.location
+  cluster           = var.cluster_server_url
+  control_plane_ips = var.control_plane_ips
+  cluster_ips       = var.cluster_ips
+}
+
 module "satellite-link" {
   source = "./modules/link"
 
@@ -128,9 +131,9 @@ module "satellite-endpoint" {
 | Name                           | Description                                                       | Type     | Default | Required |
 |--------------------------------|-------------------------------------------------------------------|----------|---------|----------|
 | ibmcloud_api_key               | IBM Cloud API Key.                                                | string   | n/a     | yes      |
-| resource_group                 | Resource Group Name that has to be targeted.                      | string   | n/a     | no       |
-| ibm_region                     | The location or the region in which VM instance exists.           | string   | us-east | yes      |
-| location                       | Name of the Location that has to be created                       | string   | satellite-ibm      | yes |
+| resource_group                 | Resource Group Name that has to be targeted.                      | string   | n/a     | yes      |
+| ibm_region                     | The location or the region in which VM instance exists.           | string   | us-east | no       |
+| location                       | Name of the Location that has to be created                       | string   | satellite-ibm      | no  |
 | managed_from                   | The IBM Cloud region to manage your Satellite location from.      | string   | n/a     | yes      |
 | location_zones                 | Allocate your hosts across these three zones                      | list     | ["us-east-1", "us-east-2", "us-east-3"]     | no       |
 | location_bucket                | COS bucket name                                                   | string   | n/a     | no       |
@@ -155,8 +158,8 @@ module "satellite-endpoint" {
 | server_protocol                | The protocol in the server application side. This parameter will change to default value if it is omitted even when using PATCH API. If client_protocol is 'udp', server_protocol must be 'udp'. If client_protocol is 'tcp'/'http', server_protocol could be 'tcp'/'tls' and default to 'tcp'. If client_protocol is 'tls'/'https', server_protocol could be 'tcp'/'tls' and default to 'tls'. If client_protocol is 'http-tunnel', server_protocol must be 'tcp'. | string | n/a | no |
 | server_mutual_auth             | Whether enable mutual auth in the server application side, when client_protocol is 'tls', this field is required. | bool | n/a | no |
 | reject_unauth                  | Whether reject any connection to the server application which is not authorized with the list of supplied CAs in the fields certs.server_cert. | bool | n/a | no |
-| timeout                        | The inactivity timeout in the Endpoint side. | number | n/a | no |
+| timeout                        | The inactivity timeout in the Endpoint side.                                      | number | n/a | no  |
 | created_by                     | The service or person who created the endpoint. Must be 1000 characters or fewer. | string | n/a | no |
-| client_certificate | The certs.| string | n/a | no |
+| client_certificate             | The certs.                                                                        | string | n/a | no |
 
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/examples/ibm-satellite/cluster.tf
+++ b/examples/ibm-satellite/cluster.tf
@@ -2,7 +2,7 @@ module "satellite-cluster" {
   source = "./modules/cluster"
 
   cluster           = var.cluster
-  location          = module.satellite-host.location
+  location          = module.satellite-location.location_id
   kube_version      = var.kube_version
   default_wp_labels = var.default_wp_labels
   zones             = var.cluster_zones
@@ -12,4 +12,6 @@ module "satellite-cluster" {
   workerpool_labels = var.workerpool_labels
   cluster_tags      = var.cluster_tags
   host_labels       = var.host_labels
+
+  depends_on = [module.satellite-host]
 }

--- a/examples/ibm-satellite/dns.tf
+++ b/examples/ibm-satellite/dns.tf
@@ -1,0 +1,10 @@
+module "satellite-dns" {
+  source = "./modules/dns"
+
+  location          = module.satellite-location.location_id
+  cluster           = module.satellite-cluster.cluster_id
+  control_plane_ips = slice(ibm_is_floating_ip.satellite_ip[*].address, 0, var.host_count)
+  cluster_ips       = slice(ibm_is_floating_ip.satellite_ip[*].address, var.host_count, (var.host_count + var.addl_host_count))
+  resource_group    = var.resource_group
+  depends_on        = [module.satellite-cluster]
+}

--- a/examples/ibm-satellite/instance.tf
+++ b/examples/ibm-satellite/instance.tf
@@ -6,17 +6,110 @@ data "ibm_is_image" "rhel7" {
   name = "ibm-redhat-7-9-minimal-amd64-3"
 }
 
-resource "ibm_is_vpc" "satellite_vpc" {
+resource "ibm_is_vpc" "vpc" {
   name = "${var.is_prefix}-vpc"
 }
 
 resource "ibm_is_subnet" "satellite_subnet" {
   count                    = 3
   name                     = "${var.is_prefix}-subnet-${count.index}"
-  vpc                      = ibm_is_vpc.satellite_vpc.id
+  vpc                      = ibm_is_vpc.vpc.id
   total_ipv4_address_count = 256
   zone                     = "${var.ibm_region}-${count.index + 1}"
 }
+
+resource "ibm_is_security_group_rule" "sg-rule-inbound-ssh" {
+  group     = ibm_is_vpc.vpc.default_security_group
+  direction = "inbound"
+  remote    = "0.0.0.0/0"
+
+  tcp {
+    port_min = 22
+    port_max = 22
+  }
+}
+
+# Port 80 is needed for default routes into OpenShift. A TODO is to figure out
+# how to do this securely using HTTPS instead.
+resource "ibm_is_security_group_rule" "sg-rule-inbound-http" {
+  group     = ibm_is_vpc.vpc.default_security_group
+  direction = "inbound"
+  remote    = "0.0.0.0/0"
+
+  tcp {
+    port_min = 80
+    port_max = 80
+  }
+}
+
+resource "ibm_is_security_group_rule" "sg-rule-inbound-https" {
+  group     = ibm_is_vpc.vpc.default_security_group
+  direction = "inbound"
+  remote    = "0.0.0.0/0"
+
+  tcp {
+    port_min = 443
+    port_max = 443
+  }
+}
+
+resource "ibm_is_security_group_rule" "sg-rule-inbound-api" {
+  group     = ibm_is_vpc.vpc.default_security_group
+  direction = "inbound"
+  remote    = "0.0.0.0/0"
+
+  tcp {
+    port_min = 30000
+    port_max = 32767
+  }
+}
+
+resource "ibm_is_security_group_rule" "sg-rule-inbound-api2" {
+  group     = ibm_is_vpc.vpc.default_security_group
+  direction = "inbound"
+  remote    = "0.0.0.0/0"
+
+  udp {
+    port_min = 30000
+    port_max = 32767
+  }
+}
+
+resource "ibm_is_security_group_rule" "sg-rule-inbound-icmp" {
+  group     = ibm_is_vpc.vpc.default_security_group
+  direction = "inbound"
+  remote    = "0.0.0.0/0"
+
+  icmp {
+    type = 8
+  }
+}
+
+resource "ibm_is_security_group_rule" "sg-rule-outbound" {
+  group     = ibm_is_vpc.vpc.default_security_group
+  direction = "outbound"
+  remote    = "0.0.0.0/0"
+
+  tcp {
+    port_min = 1
+    port_max = 65535
+  }
+}
+
+# Hosts must have TCP/UDP/ICMP Layer 3 connectivity for all ports across hosts.
+# You cannot block access to certain ports that might block communication across hosts.
+resource "ibm_is_security_group_rule" "sg-rule-inbound-from-the-group" {
+  group     = ibm_is_vpc.vpc.default_security_group
+  direction = "inbound"
+  remote    = ibm_is_vpc.vpc.default_security_group
+}
+
+resource "ibm_is_security_group_rule" "sg-rule-outbound-to-the-group" {
+  group     = ibm_is_vpc.vpc.default_security_group
+  direction = "outbound"
+  remote    = ibm_is_vpc.vpc.default_security_group
+}
+
 
 resource "tls_private_key" "example" {
   algorithm = "RSA"
@@ -39,7 +132,7 @@ resource "ibm_is_instance" "satellite_instance" {
   count = var.host_count + var.addl_host_count
 
   name           = "${var.is_prefix}-instance-${count.index}"
-  vpc            = ibm_is_vpc.satellite_vpc.id
+  vpc            = ibm_is_vpc.vpc.id
   zone           = element(local.zones, count.index)
   image          = data.ibm_is_image.rhel7.id
   profile        = "mx2-8x64"

--- a/examples/ibm-satellite/link.tf
+++ b/examples/ibm-satellite/link.tf
@@ -1,7 +1,13 @@
+data "ibm_satellite_location" "ds_location" {
+  location = var.location
+
+  depends_on = [module.satellite-dns]
+}
+
 module "satellite-link" {
   source = "./modules/link"
 
   location   = module.satellite-location.location_id
-  crn        = module.satellite-location.location_crn
+  crn        = data.ibm_satellite_location.ds_location.crn
   depends_on = [module.satellite-cluster]
 }

--- a/examples/ibm-satellite/main.tf
+++ b/examples/ibm-satellite/main.tf
@@ -10,5 +10,4 @@ module "satellite-location" {
   ibm_region        = var.ibm_region
   resource_group    = var.resource_group
   host_labels       = var.host_labels
-  tags              = var.tags
 }

--- a/examples/ibm-satellite/modules/cluster/main.tf
+++ b/examples/ibm-satellite/modules/cluster/main.tf
@@ -1,64 +1,53 @@
 data "ibm_resource_group" "rg" {
-	name = var.resource_group
+  name = var.resource_group
 }
 
 resource "ibm_satellite_cluster" "create_cluster" {
-	name                   = var.cluster
-	location               = var.location
-	resource_group_id      = data.ibm_resource_group.rg.id
-	enable_config_admin    = true
-	kube_version           = var.kube_version
-	wait_for_worker_update = true
-	worker_count		   = var.worker_count 
-	host_labels        	   = var.host_labels
-	
-	dynamic "zones" {
-		for_each = var.zones
-		content {
-			id	= zones.value
-		}
-	}
+  name                   = var.cluster
+  location               = var.location
+  resource_group_id      = data.ibm_resource_group.rg.id
+  enable_config_admin    = true
+  kube_version           = var.kube_version
+  wait_for_worker_update = true
+  worker_count           = var.worker_count
+  host_labels            = var.host_labels
 
-	default_worker_pool_labels = var.default_wp_labels
-	tags = var.cluster_tags
+  dynamic "zones" {
+    for_each = var.zones
+    content {
+      id = zones.value
+    }
+  }
+
+  default_worker_pool_labels = var.default_wp_labels
+  tags                       = var.cluster_tags
 }
 
 data "ibm_satellite_cluster" "read_cluster" {
-	name	= ibm_satellite_cluster.create_cluster.id
+  name = ibm_satellite_cluster.create_cluster.id
 }
 
 resource "ibm_satellite_cluster_worker_pool" "create_cluster_wp" {
-	name               = var.worker_pool_name
-	cluster	           = data.ibm_satellite_cluster.read_cluster.id
-	resource_group_id  = data.ibm_resource_group.rg.id
-	worker_count       = var.worker_count 
-	host_labels        = var.host_labels
+  name              = var.worker_pool_name
+  cluster           = data.ibm_satellite_cluster.read_cluster.id
+  resource_group_id = data.ibm_resource_group.rg.id
+  worker_count      = var.worker_count
+  host_labels       = var.host_labels
 
-	dynamic "zones" {
-	for_each = var.zones
-		content {
-			id	= zones.value
-		}
-	}
+  dynamic "zones" {
+    for_each = var.zones
+    content {
+      id = zones.value
+    }
+  }
 
-	worker_pool_labels = var.workerpool_labels
-}	
+  worker_pool_labels = var.workerpool_labels
+}
 
 data "ibm_satellite_cluster_worker_pool" "read_cluster_wp" {
-	name	= ibm_satellite_cluster_worker_pool.create_cluster_wp.name
-	cluster	= data.ibm_satellite_cluster.read_cluster.id
+  name    = ibm_satellite_cluster_worker_pool.create_cluster_wp.name
+  cluster = data.ibm_satellite_cluster.read_cluster.id
 
-	depends_on = [ibm_satellite_cluster_worker_pool.create_cluster_wp]
+  depends_on = [ibm_satellite_cluster_worker_pool.create_cluster_wp]
 }
 
-output "cluster_id" {
-  value  = data.ibm_satellite_cluster.read_cluster.id
-}
-
-output "master_url" {
-  value  = data.ibm_satellite_cluster.read_cluster.server_url
-}
-
-output "worker_pool_id" {
-  value  = data.ibm_satellite_cluster_worker_pool.read_cluster_wp.id
-}

--- a/examples/ibm-satellite/modules/cluster/outputs.tf
+++ b/examples/ibm-satellite/modules/cluster/outputs.tf
@@ -1,0 +1,11 @@
+output "cluster_id" {
+  value = data.ibm_satellite_cluster.read_cluster.id
+}
+
+output "master_url" {
+  value = data.ibm_satellite_cluster.read_cluster.server_url
+}
+
+output "worker_pool_id" {
+  value = data.ibm_satellite_cluster_worker_pool.read_cluster_wp.id
+}

--- a/examples/ibm-satellite/modules/cluster/variables.tf
+++ b/examples/ibm-satellite/modules/cluster/variables.tf
@@ -1,11 +1,11 @@
 variable "cluster" {
   description = "Satellite Location Name"
-  type         = string
+  type        = string
 }
 
 variable "location" {
   description = "Satellite Location Name"
-  type         = string
+  type        = string
 }
 
 variable "kube_version" {
@@ -14,40 +14,40 @@ variable "kube_version" {
 
 variable "resource_group" {
   description = "Resource Group Name that has to be targeted"
-  type         = string
+  type        = string
 }
 
 variable "zones" {
-  type        = list(string)
-  default     = ["us-east-1", "us-east-2", "us-east-3"]
+  type    = list(string)
+  default = ["us-east-1", "us-east-2", "us-east-3"]
 }
 
 variable "worker_pool_name" {
   description = "Worker Pool Name"
-  type         = string
+  type        = string
 }
 
 variable "worker_count" {
   description = "Worker Count for default pool"
-  type         = number
-  default      = 1
+  type        = number
+  default     = 1
 }
 
 variable "default_wp_labels" {
   description = "Label to add default worker pool"
-  type        = map
+  type        = map(any)
 
   default = {
-    "poolname"  = "default-worker-pool"
+    "poolname" = "default-worker-pool"
   }
 }
 
 variable "workerpool_labels" {
   description = "Label to add to workerpool"
-  type        = map
+  type        = map(any)
 
   default = {
-    "poolname"  = "worker-pool"
+    "poolname" = "worker-pool"
   }
 }
 
@@ -59,5 +59,5 @@ variable "host_labels" {
 variable "cluster_tags" {
   description = "List of tags associated with this resource."
   type        = list(string)
-  default     = [ "env:cluster" ]
+  default     = ["env:cluster"]
 }

--- a/examples/ibm-satellite/modules/dns/README.md
+++ b/examples/ibm-satellite/modules/dns/README.md
@@ -1,0 +1,46 @@
+# This Module is used to register public IP address to satellite location & cluster dns records.
+
+This module register public IP address to control plane & openshift cluster subdomain DNS records.
+ 
+## Usage
+
+```
+terraform init
+```
+```
+terraform plan
+```
+```
+terraform apply
+```
+```
+terraform destroy
+```
+## Example Usage
+
+``` hcl
+module "satellite-dns" {
+  source = "./modules/dns"
+
+  location          = var.location
+  cluster           = var.cluster
+  control_plane_ips = var.control_plane_ips
+  cluster_ips       = var.cluster_ips
+}
+```
+
+<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+## Inputs
+
+| Name              | Description                                                       | Type     | Default | Required |
+|-------------------|-------------------------------------------------------------------|----------|---------|----------|
+| location          | Name of the Location                                              | string   | n/a     | yes      |
+| cluster           | Name of the cluster                                               | string   | n/a     | yes      |
+| control_plane_ips | Public IP addresses                                               | list     | n/a     | yes      |
+| cluster_ips       | Public IP addresses                                               | list     | n/a     | yes      |
+
+<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+## Note
+
+All optional fields are given value `null` in varaible.tf file. User can configure the same by overwriting with appropriate values.
+

--- a/examples/ibm-satellite/modules/dns/main.tf
+++ b/examples/ibm-satellite/modules/dns/main.tf
@@ -1,0 +1,23 @@
+data "ibm_resource_group" "resource_group" {
+  name = var.resource_group
+}
+
+resource "ibm_satellite_location_nlb_dns" "location_dns_instance" {
+  location = var.location
+  ips      = var.control_plane_ips
+}
+
+data "ibm_satellite_location_nlb_dns" "location_dns_instance" {
+  location = ibm_satellite_location_nlb_dns.location_dns_instance.location
+}
+
+data "ibm_container_nlb_dns" "dns" {
+  cluster = var.cluster
+}
+
+resource "ibm_container_nlb_dns" "container_nlb_dns" {
+  cluster           = var.cluster
+  nlb_host          = data.ibm_container_nlb_dns.dns.nlb_config.0.nlb_sub_domain
+  nlb_ips           = var.cluster_ips
+  resource_group_id = data.ibm_resource_group.resource_group.id
+}

--- a/examples/ibm-satellite/modules/dns/variables.tf
+++ b/examples/ibm-satellite/modules/dns/variables.tf
@@ -1,0 +1,23 @@
+variable "resource_group" {
+  description = "resource group"
+  type        = string
+}
+
+variable "location" {
+  description = "Satellite Location Name"
+  type        = string
+}
+
+variable "cluster" {
+  description = "Cluster name"
+}
+
+variable "control_plane_ips" {
+  description = "public ips to register for control plane"
+  type        = list(string)
+}
+
+variable "cluster_ips" {
+  description = "public ips to register for ROKS cluster"
+  type        = list(string)
+}

--- a/examples/ibm-satellite/modules/dns/versions.tf
+++ b/examples/ibm-satellite/modules/dns/versions.tf
@@ -1,0 +1,7 @@
+terraform {
+  required_providers {
+    ibm = {
+      source = "ibm-cloud/ibm"
+    }
+  }
+} 

--- a/examples/ibm-satellite/modules/endpoint/main.tf
+++ b/examples/ibm-satellite/modules/endpoint/main.tf
@@ -1,7 +1,7 @@
 // Provision satellite_endpoint resource instance
 resource "ibm_satellite_endpoint" "instance" {
   count = var.is_endpoint_provision ? 1 : 0
-  
+
   location           = var.location
   connection_type    = var.connection_type
   display_name       = var.display_name
@@ -16,12 +16,5 @@ resource "ibm_satellite_endpoint" "instance" {
   timeout            = var.timeout
   created_by         = var.created_by
 
-  certs {
-    client {
-      cert {
-        filename      = "client.pem"
-        file_contents = var.client_certificate
-      }
-    }
-  }
+
 }

--- a/examples/ibm-satellite/modules/location/main.tf
+++ b/examples/ibm-satellite/modules/location/main.tf
@@ -1,10 +1,10 @@
 
 data "ibm_resource_group" "resource_group" {
-   name = var.resource_group
+  name = var.resource_group
 }
 
 resource "ibm_satellite_location" "create_location" {
-  count             = var.is_location_exist == false ? 1 : 0
+  count = var.is_location_exist == false ? 1 : 0
 
   location          = var.location
   managed_from      = var.managed_from
@@ -12,31 +12,31 @@ resource "ibm_satellite_location" "create_location" {
   resource_group_id = data.ibm_resource_group.resource_group.id
 
   cos_config {
-    bucket  = var.location_bucket != null ? var.location_bucket : null
+    bucket = var.location_bucket != null ? var.location_bucket : null
   }
 
   tags = var.tags
 }
 
 data "ibm_satellite_location" "location" {
-  location      = var.is_location_exist == false ? ibm_satellite_location.create_location.0.id : var.location
-  depends_on    = [ ibm_satellite_location.create_location ]
+  location   = var.is_location_exist == false ? ibm_satellite_location.create_location.0.id : var.location
+  depends_on = [ibm_satellite_location.create_location]
 }
 
 data "ibm_satellite_attach_host_script" "script" {
-  location          = data.ibm_satellite_location.location.id
-  labels            = var.host_labels
-  host_provider     = var.host_provider
+  location      = data.ibm_satellite_location.location.id
+  labels        = var.host_labels
+  host_provider = var.host_provider
 }
 
 output "location_id" {
-  value  = data.ibm_satellite_location.location.id
+  value = data.ibm_satellite_location.location.id
 }
 
 output "location_crn" {
-  value  = data.ibm_satellite_location.location.crn
+  value = data.ibm_satellite_location.location.crn
 }
 
 output "host_script" {
-  value  = data.ibm_satellite_attach_host_script.script.host_script
+  value = data.ibm_satellite_attach_host_script.script.host_script
 }

--- a/examples/ibm-satellite/modules/location/variables.tf
+++ b/examples/ibm-satellite/modules/location/variables.tf
@@ -5,14 +5,13 @@
 
 variable "location" {
   description = "Location Name"
-  type         = string
-  default = "sat-loc-1031"
+  type        = string
 }
 
 variable "managed_from" {
   description = "The IBM Cloud region to manage your Satellite location from. Choose a region close to your on-prem data center for better performance."
-  type         = string
-  default = "wdc"
+  type        = string
+  default     = "wdc"
 }
 
 variable "location_zones" {
@@ -23,8 +22,8 @@ variable "location_zones" {
 
 variable "is_location_exist" {
   description = "Location Name"
-  type         = bool
-  default      = false
+  type        = bool
+  default     = false
 }
 
 variable "location_bucket" {
@@ -51,19 +50,19 @@ variable "host_labels" {
   default     = ["env:prod"]
 
   validation {
-      condition     = can([for s in var.host_labels : regex("^[a-zA-Z0-9:]+$", s)])
-      error_message = "A `host_labels` can include only alphanumeric characters and with one colon."
+    condition     = can([for s in var.host_labels : regex("^[a-zA-Z0-9:]+$", s)])
+    error_message = "A `host_labels` can include only alphanumeric characters and with one colon."
   }
 }
 
 variable "host_provider" {
-    description  = "The cloud provider of host|vms"
-    type         = string
-    default      = "ibm"
+  description = "The cloud provider of host|vms"
+  type        = string
+  default     = "ibm"
 }
 
 variable "tags" {
   description = "List of tags associated with this satellite."
   type        = list(string)
-  default     = [ "env:dev" ]
+  default     = ["env:dev"]
 }

--- a/examples/ibm-satellite/modules/route/main.tf
+++ b/examples/ibm-satellite/modules/route/main.tf
@@ -1,18 +1,26 @@
 resource "null_resource" "get_oc_token" {
   count = var.is_endpoint_provision ? 1 : 0
+
   provisioner "local-exec" {
+    when        = create
     interpreter = ["/bin/bash", "-c"]
     command     = <<-EOT
+      sleep 200
       curl -u "apikey:${var.ibmcloud_api_key}" -H "X-CSRF-Token: a" "$(curl ${var.cluster_master_url}/.well-known/oauth-authorization-server | jq -r .issuer)/oauth/authorize?client_id=openshift-challenging-client&response_type=token" -vvv &> /dev/stdout | tee -a resp.log
       token=$(awk -v FS="(#access_token=|&expires_in)" '{print $2}' resp.log)
       echo $token > token.log
       rm -f resp.log
     EOT
   }
+
+  provisioner "local-exec" {
+    when    = destroy
+    command = "rm -f token.log"
+  }
 }
 
 data "local_file" "token_file" {
-  count = var.is_endpoint_provision ? 1 : 0
+  count    = var.is_endpoint_provision ? 1 : 0
   filename = "token.log"
 
   depends_on = [null_resource.get_oc_token]
@@ -26,7 +34,7 @@ resource "restapi_object" "create_route" {
   path      = "/apis/route.openshift.io/v1/namespaces/default/routes"
   data      = "{ \"kind\":\"Route\",\"apiVersion\": \"route.openshift.io/v1\", \"metadata\": { \"name\": \"${var.route_name}\", \"creationTimestamp\":null }, \"spec\": { \"to\": { \"kind\": \"\", \"name\": \"nginx-service\", \"weight\": null}, \"port\": { \"targetPort\": \"https\"}, \"tls\": { \"termination\": \"passthrough\"}}, \"status\":{} }"
 
-  depends_on = [ null_resource.get_oc_token ]
+  depends_on = [null_resource.get_oc_token]
 }
 
 output "token_data" {

--- a/examples/ibm-satellite/modules/route/variables.tf
+++ b/examples/ibm-satellite/modules/route/variables.tf
@@ -1,6 +1,6 @@
 variable "ibmcloud_api_key" {
   description = "IBM Cloud api key"
-  type         = string
+  type        = string
 }
 
 variable "is_endpoint_provision" {
@@ -10,8 +10,8 @@ variable "is_endpoint_provision" {
 
 variable "cluster_master_url" {
   description = "Satellite Cluster URL"
-  type         = string
-  default      = "test.com"
+  type        = string
+  default     = "test.com"
 }
 
 variable "route_name" {

--- a/examples/ibm-satellite/modules/route/versions.tf
+++ b/examples/ibm-satellite/modules/route/versions.tf
@@ -14,9 +14,6 @@ provider "restapi" {
   uri   = fileexists("token.log") ? var.cluster_master_url : "test.com"
   debug = true
   headers = {
-    Authorization = var.is_endpoint_provision ? format("Bearer %v",chomp(element(tolist(data.local_file.token_file.*.content), 0))) : ""
+    Authorization = var.is_endpoint_provision ? format("Bearer %v", chomp(element(tolist(data.local_file.token_file.*.content), 0))) : ""
   }
-}
-
-provider "ibm" {
 }

--- a/examples/ibm-satellite/route.tf
+++ b/examples/ibm-satellite/route.tf
@@ -1,8 +1,13 @@
+data "ibm_satellite_cluster" "ds_cluster" {
+  name       = var.cluster
+  depends_on = [module.satellite-dns]
+}
+
 module "satellite-route" {
-  source                = "./modules/route"
-  
+  source = "./modules/route"
+
   is_endpoint_provision = var.is_endpoint_provision
   ibmcloud_api_key      = var.ibmcloud_api_key
-  cluster_master_url    = module.satellite-cluster.master_url
+  cluster_master_url    = data.ibm_satellite_cluster.ds_cluster.server_url
   route_name            = var.route_name
 }

--- a/examples/ibm-satellite/variables.tf
+++ b/examples/ibm-satellite/variables.tf
@@ -9,6 +9,7 @@ variable "ibmcloud_api_key" {
 
 variable "ibm_region" {
   description = "Region of the IBM Cloud account. Currently supported regions for satellite are us-east and eu-gb region."
+  default     = "us-east"
 }
 
 variable "resource_group" {
@@ -74,13 +75,13 @@ variable "host_count" {
 variable "addl_host_count" {
   description = "The total number of additional host for cluster assignment"
   type        = number
-  default     = 6
+  default     = 3
 }
 
 variable "is_prefix" {
   description = "Prefix to the Names of the VPC Infrastructure resources"
   type        = string
-  default     = "satellite-ibm"
+  default     = "satellite-ibm-eb"
 }
 
 variable "public_key" {
@@ -106,7 +107,7 @@ variable "cluster_zones" {
 
 variable "default_wp_labels" {
   description = "Label to add default worker pool"
-  type        = map
+  type        = map(any)
 
   default = {
     "pool_name" = "default-worker-pool"
@@ -127,7 +128,7 @@ variable "worker_pool_name" {
 
 variable "workerpool_labels" {
   description = "Label to add to workerpool"
-  type        = map
+  type        = map(any)
 
   default = {
     "pool_name" = "worker-pool"
@@ -162,9 +163,16 @@ variable "is_provision_link" {
   description = "Determines if the link has to be created or not"
 }
 
+variable "namespace" {
+  type        = string
+  description = "Namespace name"
+  default     = "default"
+}
+
 variable "route_name" {
   type        = string
   description = "Cluster route name."
+  default     = "sat-route-01"
 }
 
 // Resource arguments for satellite_link
@@ -183,12 +191,13 @@ variable "connection_type" {
 variable "display_name" {
   description = "The display name of the endpoint. Endpoint names must start with a letter and end with an alphanumeric character, can contain letters, numbers, and hyphen (-), and must be 63 characters or fewer."
   type        = string
+  default     = "ds-01"
 }
 
 variable "server_host" {
   description = "The host name or IP address of the server endpoint. For 'http-tunnel' protocol, server_host can start with '*.' , which means a wildcard to it's sub domains. Such as '*.example.com' can accept request to 'api.example.com' and 'www.example.com'."
   type        = string
-  default = "cloud.ibm.com"
+  default     = "cloud.ibm.com"
 }
 
 variable "server_port" {
@@ -248,5 +257,5 @@ variable "created_by" {
 variable "client_certificate" {
   description = "The certs."
   type        = string
-  default     = "-----BEGIN CERTIFICATE-----\nMIIDmzCCAoOgAwIBAgIUMVdDe4IYAIMKRixT4v+bbvkXhxMwDQYJKoZIhvcNAQEL\nBQAwHTEbMBkGA1UEAxMScm9vdC1jYS0xNjI2OTYyMzg0MB4XDTIxMDcyMjEzNTYw\nMFoXDTIzMTAyNTEzNTYwMFowYjELMAkGA1UEBhMCVVMxFjAUBgNVBAgTDVNhbiBG\ncmFuY2lzY28xCzAJBgNVBAcTAkNBMRcwFQYDVQQKEw5zeXN0ZW06bWFzdGVyczEV\nMBMGA1UEAxMMc3lzdGVtOmFkbWluMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIB\nCgKCAQEAuJ5VeZGEA10qgnqhSSeBtEFxrxCDRvXyY7NFw9NYvwy6ihTPpWAISSs6\nHsH1jlXuXgXtizru8QQ4HSGXyYNvFqVreZgrseUE08B3sL9FTzAehO3Q/azm5jTX\nFLTseUE2mSfSeWPMIYTWgvwMBl1DGRO3GATsp7Ep4uRN4zWIOC94JD76rk8HZSn6\nBVcvOyQT4XcyD9xYRcmztUoQjd92OAbI362OdjrJd/GaOFXSMYsK5MqhT/R/5p/I\nkDP+tHcp4m8ECI55//ztZvmxWAZsVymsvtU0HombLGSGO6WHcdqwenDyqX1toq+t\nVmgmkdzglV34dZkz7jxtS3j3GdzpDQIDAQABo4GNMIGKMA4GA1UdDwEB/wQEAwIF\noDAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDAYDVR0TAQH/BAIwADAd\nBgNVHQ4EFgQU4V3A7K5Fe2cO2XesFhvtiwe2QTowHwYDVR0jBBgwFoAUHpq8RvCW\n/vJ31q3868e5CyhhLiAwCwYDVR0RBAQwAoIAMA0GCSqGSIb3DQEBCwUAA4IBAQB0\n0H+QlV6QlALq3tKwPkYaBkYW2m403T/pBtziaxKI5d1GOx4AR4per3IASVWOQYJE\nmA6Iur5dmfKasUJXFZada7KseGFSdrEqG8bhghwn3O0TvCeINgwaiOSS2PRLsIg3\nGo9ErbdhiJgvZ7fSy9B3Gd9SlJpKMNiWrPwyhyv5yGdgxwnKO0hn994eMziag1AH\nfvuIBU0MRYCF3+lq6Nn+ZyUE4H3zv2bvMc9SzRlhDOg6cQUjGWYVTBszR9UmPnC9\nIAzW51A7d2MIEI5Nt7dsuCnnT/TLMOZG4mDnLXrCulvCnaRfk64jq9oUs+K9cYAM\ns3v73KPkn8OrZRh2CKbF\n-----END CERTIFICATE-----"
+  default     = null
 }

--- a/examples/ibm-satellite/versions.tf
+++ b/examples/ibm-satellite/versions.tf
@@ -3,6 +3,10 @@ terraform {
     ibm = {
       source = "IBM-Cloud/ibm"
     }
+    restapi = {
+      source  = "fmontezuma/restapi"
+      version = "1.14.1"
+    }
   }
 }
 

--- a/ibm/provider.go
+++ b/ibm/provider.go
@@ -580,6 +580,7 @@ func Provider() *schema.Provider {
 			"ibm_container_worker_pool":                          resourceIBMContainerWorkerPool(),
 			"ibm_container_worker_pool_zone_attachment":          resourceIBMContainerWorkerPoolZoneAttachment(),
 			"ibm_container_storage_attachment":                   resourceIBMContainerVpcWorkerVolumeAttachment(),
+			"ibm_container_nlb_dns":                              resourceIbmContainerNlbDns(),
 			"ibm_cr_namespace":                                   resourceIBMCrNamespace(),
 			"ibm_cr_retention_policy":                            resourceIBMCrRetentionPolicy(),
 			"ibm_ob_logging":                                     resourceIBMObLogging(),
@@ -763,6 +764,7 @@ func Provider() *schema.Provider {
 			"ibm_satellite_cluster_worker_pool": resourceIBMSatelliteClusterWorkerPool(),
 			"ibm_satellite_link":                resourceIbmSatelliteLink(),
 			"ibm_satellite_endpoint":            resourceIbmSatelliteEndpoint(),
+			"ibm_satellite_location_nlb_dns":    resourceIbmSatelliteLocationNlbDns(),
 
 			//Added for Resource Tag
 			"ibm_resource_tag": resourceIBMResourceTag(),

--- a/ibm/provider_test.go
+++ b/ibm/provider_test.go
@@ -122,6 +122,9 @@ var scc_posture_scope_id string
 var scc_posture_scan_id string
 var scc_posture_profile_id string
 
+//ROKS Cluster
+var clusterName string
+
 func init() {
 	appIDTenantID = os.Getenv("IBM_APPID_TENANT_ID")
 	if appIDTenantID == "" {
@@ -650,6 +653,11 @@ func init() {
 	cloudShellAccountID = os.Getenv("IBM_CLOUD_SHELL_ACCOUNT_ID")
 	if cloudShellAccountID == "" {
 		fmt.Println("[INFO] Set the environment variable IBM_CLOUD_SHELL_ACCOUNT_ID for ibm-cloud-shell resource or datasource else tests will fail if this is not set correctly")
+	}
+
+	clusterName = os.Getenv("IBM_CONTAINER_CLUSTER_NAME")
+	if clusterName == "" {
+		fmt.Println("[INFO] Set the environment variable IBM_CONTAINER_CLUSTER_NAME for ibm_container_nlb_dns resource or datasource else tests will fail if this is not set correctly")
 	}
 
 }

--- a/ibm/resource_ibm_container_nlb_dns.go
+++ b/ibm/resource_ibm_container_nlb_dns.go
@@ -1,0 +1,235 @@
+// Copyright IBM Corp. 2021 All Rights Reserved.
+// Licensed under the Mozilla Public License v2.0
+
+package ibm
+
+import (
+	"context"
+	"fmt"
+	"log"
+
+	"github.com/IBM-Cloud/container-services-go-sdk/kubernetesserviceapiv1"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+func resourceIbmContainerNlbDns() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceIbmContainerNlbDnsCreate,
+		ReadContext:   resourceIbmContainerNlbDnsRead,
+		UpdateContext: resourceIbmContainerNlbDnsUpdate,
+		DeleteContext: resourceIbmContainerNlbDnsDelete,
+
+		Schema: map[string]*schema.Schema{
+			"cluster": &schema.Schema{
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: "The name or ID of the cluster. To list the clusters that you have access to, use the `GET /v1/clusters` API or run `ibmcloud ks cluster ls`.",
+			},
+			"nlb_host": &schema.Schema{
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"nlb_ips": &schema.Schema{
+				Type:     schema.TypeSet,
+				Required: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+			"nlb_dns_type": &schema.Schema{
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"nlb_monitor_state": &schema.Schema{
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"nlb_ssl_secret_name": &schema.Schema{
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"nlb_ssl_secret_status": &schema.Schema{
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"nlb_type": &schema.Schema{
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"secret_namespace": &schema.Schema{
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"resource_group_id": &schema.Schema{
+				Type:             schema.TypeString,
+				Optional:         true,
+				DiffSuppressFunc: applyOnce,
+				Description:      "The ID of the resource group that the cluster is in. To check the resource group ID of the cluster, use the GET /v1/clusters/idOrName API. To list available resource group IDs, run ibmcloud resource groups.",
+			},
+		},
+	}
+}
+
+func resourceIbmContainerNlbDnsCreate(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	satClient, err := meta.(ClientSession).SatelliteClientSession()
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	registerDNSWithIPOptions := &kubernetesserviceapiv1.UpdateDNSWithIPOptions{}
+	registerDNSWithIPOptions.SetIdOrName(d.Get("cluster").(string))
+
+	if res, ok := d.GetOk("resource_group_id"); ok {
+		header := map[string]string{}
+		header["X-Auth-Resource-Group"] = res.(string)
+		registerDNSWithIPOptions.SetHeaders(header)
+	}
+	if _, ok := d.GetOk("nlb_host"); ok {
+		registerDNSWithIPOptions.SetNlbHost(d.Get("nlb_host").(string))
+	}
+	if _, ok := d.GetOk("nlb_ips"); ok {
+		ips := []string{}
+		for _, segmentsItem := range d.Get("nlb_ips").(*schema.Set).List() {
+			ips = append(ips, segmentsItem.(string))
+		}
+		registerDNSWithIPOptions.SetNlbIPArray(ips)
+	}
+	response, err := satClient.UpdateDNSWithIPWithContext(context, registerDNSWithIPOptions)
+	if err != nil {
+		log.Printf("[DEBUG] RegisterDNSWithIPWithContext failed %s\n%s", err, response)
+		return diag.FromErr(fmt.Errorf("RegisterDNSWithIPWithContext failed %s\n%s", err, response))
+	}
+
+	d.SetId(*registerDNSWithIPOptions.IdOrName)
+
+	return resourceIbmContainerNlbDnsRead(context, d, meta)
+}
+
+func resourceIbmContainerNlbDnsRead(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+
+	kubeClient, err := meta.(ClientSession).VpcContainerAPI()
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	nlbData, err := kubeClient.NlbDns().GetNLBDNSList(d.Id())
+	if err != nil || nlbData == nil || len(nlbData) < 1 {
+		return diag.FromErr(fmt.Errorf("[ERROR] Error Listing NLB DNS (%s): %s", name, err))
+	}
+
+	if nlbData != nil {
+		for _, nlbConfig := range nlbData {
+			if err = d.Set("cluster", d.Id()); err != nil {
+				return diag.FromErr(fmt.Errorf("Error setting cluster: %s", err))
+			}
+			if err = d.Set("nlb_dns_type", nlbConfig.Nlb.DnsType); err != nil {
+				return diag.FromErr(fmt.Errorf("Error setting nlb_dns_type: %s", err))
+			}
+			if err = d.Set("nlb_host", nlbConfig.Nlb.NlbSubdomain); err != nil {
+				return diag.FromErr(fmt.Errorf("Error setting nlb_host: %s", err))
+			}
+			if err = d.Set("nlb_ssl_secret_name", nlbConfig.SecretName); err != nil {
+				return diag.FromErr(fmt.Errorf("Error setting nlb_ssl_secret_name: %s", err))
+			}
+			if err = d.Set("nlb_ssl_secret_status", nlbConfig.SecretStatus); err != nil {
+				return diag.FromErr(fmt.Errorf("Error setting nlb_ssl_secret_status: %s", err))
+			}
+			if err = d.Set("nlb_type", nlbConfig.Nlb.Type); err != nil {
+				return diag.FromErr(fmt.Errorf("Error setting nlb_type: %s", err))
+			}
+			if err = d.Set("secret_namespace", nlbConfig.Nlb.SecretNamespace); err != nil {
+				return diag.FromErr(fmt.Errorf("Error setting secret_namespace: %s", err))
+			}
+		}
+	}
+
+	return nil
+}
+
+func resourceIbmContainerNlbDnsUpdate(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	satClient, err := meta.(ClientSession).SatelliteClientSession()
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	updateDNSWithIPOptions := &kubernetesserviceapiv1.UpdateDNSWithIPOptions{}
+
+	updateDNSWithIPOptions.SetIdOrName(d.Id())
+	nlbHost := d.Get("nlb_host").(string)
+
+	updateDNSWithIPOptions.NlbHost = ptrToString(nlbHost)
+
+	if d.HasChange("nlb_ips") {
+		var remove, add []string
+		o, n := d.GetChange("nlb_ips")
+		os := o.(*schema.Set)
+		ns := n.(*schema.Set)
+
+		remove = expandStringList(os.Difference(ns).List())
+		add = expandStringList(ns.Difference(os).List())
+
+		if len(remove) > 0 {
+			unregisterDNSWithIPOptions := &kubernetesserviceapiv1.UnregisterDNSWithIPOptions{}
+			unregisterDNSWithIPOptions.SetIdOrName(d.Id())
+			unregisterDNSWithIPOptions.SetNlbHost(nlbHost)
+			for _, r := range remove {
+				unregisterDNSWithIPOptions.SetNlbIP(r)
+				response, err := satClient.UnregisterDNSWithIPWithContext(context, unregisterDNSWithIPOptions)
+				if err != nil {
+					log.Printf("[DEBUG] UnregisterDNSWithIPWithContext failed %s\n%s", err, response)
+					return diag.FromErr(fmt.Errorf("UnregisterDNSWithIPWithContext failed %s\n%s", err, response))
+				}
+			}
+		}
+
+		if len(add) > 0 {
+			if res, ok := d.GetOk("resource_group_id"); ok {
+				header := map[string]string{}
+				header["X-Auth-Resource-Group"] = res.(string)
+				updateDNSWithIPOptions.SetHeaders(header)
+			}
+			updateDNSWithIPOptions.SetNlbIPArray(add)
+			response, err := satClient.UpdateDNSWithIPWithContext(context, updateDNSWithIPOptions)
+			if err != nil {
+				log.Printf("[DEBUG] RegisterDNSWithIPWithContext failed %s\n%s", err, response)
+				return diag.FromErr(fmt.Errorf("RegisterDNSWithIPWithContext failed %s\n%s", err, response))
+			}
+		}
+	}
+
+	return resourceIbmContainerNlbDnsRead(context, d, meta)
+}
+
+func resourceIbmContainerNlbDnsDelete(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	satClient, err := meta.(ClientSession).SatelliteClientSession()
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	unregisterDNSWithIPOptions := &kubernetesserviceapiv1.UnregisterDNSWithIPOptions{}
+	unregisterDNSWithIPOptions.SetIdOrName(d.Id())
+	if res, ok := d.GetOk("resource_group_id"); ok {
+		header := map[string]string{}
+		header["X-Auth-Resource-Group"] = res.(string)
+		unregisterDNSWithIPOptions.SetHeaders(header)
+	}
+	if nlbHost, ok := d.GetOk("nlb_host"); ok && nlbHost != nil {
+		unregisterDNSWithIPOptions.SetNlbHost(nlbHost.(string))
+	}
+
+	if ips, ok := d.GetOk("nlb_ips"); ok && ips != nil {
+		for _, i := range ips.(*schema.Set).List() {
+			unregisterDNSWithIPOptions.SetNlbIP(i.(string))
+			response, err := satClient.UnregisterDNSWithIPWithContext(context, unregisterDNSWithIPOptions)
+			if err != nil {
+				log.Printf("[DEBUG] UnregisterDNSWithIPWithContext failed %s\n%s", err, response)
+				return diag.FromErr(fmt.Errorf("UnregisterDNSWithIPWithContext failed %s\n%s", err, response))
+			}
+		}
+	}
+
+	d.SetId("")
+
+	return nil
+}

--- a/ibm/resource_ibm_container_nlb_dns_test.go
+++ b/ibm/resource_ibm_container_nlb_dns_test.go
@@ -1,0 +1,73 @@
+// Copyright IBM Corp. 2021 All Rights Reserved.
+// Licensed under the Mozilla Public License v2.0
+
+package ibm
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/IBM-Cloud/container-services-go-sdk/kubernetesserviceapiv1"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+)
+
+func TestAccIbmContainerNlbDnsBasic(t *testing.T) {
+	var conf kubernetesserviceapiv1.NlbVPCListConfig
+	clusterIps := "[ \"168.1.1.1\", \"168.1.1.2\", \"168.1.1.3\" ]"
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccCheckIbmContainerNlbDnsConfigBasic(clusterIps),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckIbmContainerNlbDnsExists("ibm_container_nlb_dns.container_nlb_dns", conf),
+					resource.TestCheckResourceAttr("ibm_container_nlb_dns.container_nlb_dns", "cluster", clusterName),
+					resource.TestCheckResourceAttr("ibm_container_nlb_dns.container_nlb_dns", "nlb_ips.#", "3"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckIbmContainerNlbDnsConfigBasic(clusterIps string) string {
+	return fmt.Sprintf(`
+
+	  data "ibm_container_nlb_dns" "dns" {
+		cluster = "%s"
+	  }
+
+	  resource "ibm_container_nlb_dns" "container_nlb_dns" {
+		cluster 		= data.ibm_container_nlb_dns.dns.cluster
+		nlb_host	    = data.ibm_container_nlb_dns.dns.nlb_config.0.nlb_sub_domain
+		nlb_ips  		= %s
+	  }
+	`, clusterName, clusterIps)
+}
+
+func testAccCheckIbmContainerNlbDnsExists(n string, obj kubernetesserviceapiv1.NlbVPCListConfig) resource.TestCheckFunc {
+
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+
+		satClient, err := testAccProvider.Meta().(ClientSession).SatelliteClientSession()
+		if err != nil {
+			return err
+		}
+
+		getNlbDNSListOptions := &kubernetesserviceapiv1.GetNlbDNSListOptions{}
+		getNlbDNSListOptions.Cluster = ptrToString(rs.Primary.ID)
+
+		nlbConfigList, _, err := satClient.GetNlbDNSList(getNlbDNSListOptions)
+		if err != nil {
+			return err
+		}
+
+		obj = nlbConfigList[0]
+		return nil
+	}
+}

--- a/ibm/resource_ibm_satellite_location_nlb_dns.go
+++ b/ibm/resource_ibm_satellite_location_nlb_dns.go
@@ -1,0 +1,99 @@
+// Copyright IBM Corp. 2021 All Rights Reserved.
+// Licensed under the Mozilla Public License v2.0
+
+package ibm
+
+import (
+	"context"
+	"fmt"
+	"log"
+
+	"github.com/IBM-Cloud/container-services-go-sdk/kubernetesserviceapiv1"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+func resourceIbmSatelliteLocationNlbDns() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceIbmSatelliteLocationNlbDnsCreate,
+		ReadContext:   resourceIbmSatelliteLocationNlbDnsRead,
+		DeleteContext: resourceIbmSatelliteLocationNlbDnsDelete,
+		Importer:      &schema.ResourceImporter{},
+
+		Schema: map[string]*schema.Schema{
+			"location": &schema.Schema{
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"ips": &schema.Schema{
+				Type:     schema.TypeSet,
+				Required: true,
+				ForceNew: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+				Set:      schema.HashString,
+			},
+		},
+	}
+}
+
+func resourceIbmSatelliteLocationNlbDnsCreate(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	satClient, err := meta.(ClientSession).SatelliteClientSession()
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	bmxSess, err := meta.(ClientSession).BluemixSession()
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	registerMultishiftClusterOptions := &kubernetesserviceapiv1.RegisterMultishiftClusterOptions{}
+
+	registerMultishiftClusterOptions.SetXAuthRefreshToken(bmxSess.Config.IAMRefreshToken)
+	if controller, ok := d.GetOk("location"); ok {
+		registerMultishiftClusterOptions.SetController(controller.(string))
+	}
+	if _, ok := d.GetOk("ips"); ok {
+		ips := []string{}
+		for _, segmentsItem := range d.Get("ips").(*schema.Set).List() {
+			ips = append(ips, segmentsItem.(string))
+		}
+		registerMultishiftClusterOptions.SetIps(ips)
+	}
+
+	mscRegisterResp, response, err := satClient.RegisterMultishiftClusterWithContext(context, registerMultishiftClusterOptions)
+	if err != nil {
+		log.Printf("[DEBUG] RegisterMultishiftClusterWithContext failed %s\n%s", err, response)
+		return diag.FromErr(fmt.Errorf("RegisterMultishiftClusterWithContext failed %s\n%s", err, response))
+	}
+	d.SetId(*mscRegisterResp.Controller)
+
+	return resourceIbmSatelliteLocationNlbDnsRead(context, d, meta)
+}
+
+func resourceIbmSatelliteLocationNlbDnsRead(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	ID := d.Id()
+	nlbClient, err := meta.(ClientSession).VpcContainerAPI()
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	nlbAPI := nlbClient.NlbDns()
+	getSatLocationNlbDNSListOptions := &kubernetesserviceapiv1.GetSatLocationNlbDNSListOptions{}
+	getSatLocationNlbDNSListOptions.Controller = ptrToString(ID)
+
+	_, err = nlbAPI.GetLocationNLBDNSList(ID)
+	if err != nil {
+		log.Printf("[DEBUG] GetSatLocationNlbDNSListWithContext failed %s\n", err)
+		return diag.FromErr(fmt.Errorf("GetSatLocationNlbDNSListWithContext failed %s\n", err))
+	}
+
+	return nil
+}
+
+func resourceIbmSatelliteLocationNlbDnsDelete(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	d.SetId("")
+
+	return nil
+}

--- a/ibm/resource_ibm_satellite_location_nlb_dns_test.go
+++ b/ibm/resource_ibm_satellite_location_nlb_dns_test.go
@@ -1,0 +1,145 @@
+// Copyright IBM Corp. 2021 All Rights Reserved.
+// Licensed under the Mozilla Public License v2.0
+
+package ibm
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/IBM-Cloud/bluemix-go/api/container/containerv2"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+)
+
+func TestAccIbmSatelliteLocationNlbDnsBasic(t *testing.T) {
+	var conf containerv2.ExtendedNlbVPCConfig
+	location := fmt.Sprintf("tf-satellitelocation-%d", acctest.RandIntRange(10, 100))
+	resource_prefix := "tf-satellite"
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccCheckIbmSatelliteLocationNlbDnsConfigBasic(location, resource_prefix),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckIbmSatelliteLocationNlbDnsExists("ibm_satellite_location_nlb_dns.satellite_location_dns", conf),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckIbmSatelliteLocationNlbDnsConfigBasic(location, resource_prefix string) string {
+	return fmt.Sprintf(`
+
+	provider "ibm" {
+		region = "us-east"
+	}
+
+	variable "location_zones" {
+		description = "Allocate your hosts across these three zones"
+		type        = list(string)
+		default     = ["us-east-1", "us-east-2", "us-east-3"]
+	}
+
+	resource "ibm_satellite_location" "location" {
+		location      = "%s"
+		managed_from  = "wdc04"
+		zones		  = var.location_zones
+	}
+
+	data "ibm_satellite_attach_host_script" "script" {
+		location          = ibm_satellite_location.location.id
+		labels            = ["env:prod"]
+		host_provider     = "ibm"
+	}
+
+	data "ibm_resource_group" "resource_group" {
+		is_default = true
+	}
+	  
+	resource "ibm_is_vpc" "satellite_vpc" {
+		name = "%s-vpc-1"
+	}
+	  
+	resource "ibm_is_subnet" "satellite_subnet" {
+		count                    = 3
+
+		name                     = "%s-subnet-${count.index}"
+		vpc                      = ibm_is_vpc.satellite_vpc.id
+		total_ipv4_address_count = 256
+		zone                     = "us-east-${count.index + 1}"
+	  }
+	  
+	  resource "ibm_is_ssh_key" "satellite_ssh" {  
+		name        = "%s-ibm-ssh"
+		public_key  = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCKVmnMOlHKcZK8tpt3MP1lqOLAcqcJzhsvJcjscgVERRN7/9484SOBJ3HSKxxNG5JN8owAjy5f9yYwcUg+JaUVuytn5Pv3aeYROHGGg+5G346xaq3DAwX6Y5ykr2fvjObgncQBnuU5KHWCECO/4h8uWuwh/kfniXPVjFToc+gnkqA+3RKpAecZhFXwfalQ9mMuYGFxn+fwn8cYEApsJbsEmb0iJwPiZ5hjFC8wREuiTlhPHDgkBLOiycd20op2nXzDbHfCHInquEe/gYxEitALONxm0swBOwJZwlTDOB7C6y2dzlrtxr1L59m7pCkWI4EtTRLvleehBoj3u7jB4usR"
+	  }
+	  
+	  resource "ibm_is_instance" "satellite_instance" {
+		count          = 3
+
+		name           = "%s-instance-${count.index}"
+		vpc            = ibm_is_vpc.satellite_vpc.id
+		zone           = "us-east-${count.index + 1}"
+		image          = "r014-931515d2-fcc3-11e9-896d-3baa2797200f"
+		profile        = "mx2-8x64"
+		keys           = [ibm_is_ssh_key.satellite_ssh.id]
+		resource_group = data.ibm_resource_group.resource_group.id
+		user_data      = data.ibm_satellite_attach_host_script.script.host_script
+		
+		primary_network_interface {
+		  subnet = ibm_is_subnet.satellite_subnet[count.index].id
+		}
+	  }
+	  
+	  resource "ibm_is_floating_ip" "satellite_ip" {
+		count  = 3
+
+		name   = "%s-fip-${count.index}"
+		target = ibm_is_instance.satellite_instance[count.index].primary_network_interface[0].id
+	  }
+	  
+	  resource "ibm_satellite_host" "assign_host" {
+		count  = 3
+	  
+		location      = ibm_satellite_location.location.id
+		host_id       = element(ibm_is_instance.satellite_instance[*].name, count.index)
+		labels        = ["env:prod"]
+		zone          = element(var.location_zones, count.index)
+		host_provider = "ibm"
+	  }
+
+	  resource "ibm_satellite_location_nlb_dns" "satellite_location_dns" {
+		location 			 = ibm_satellite_host.assign_host[1].location
+		ips 	   			 = ibm_is_floating_ip.satellite_ip[*].address
+	  }
+
+	`, location, resource_prefix, resource_prefix, resource_prefix, resource_prefix, resource_prefix)
+}
+
+func testAccCheckIbmSatelliteLocationNlbDnsExists(n string, obj containerv2.ExtendedNlbVPCConfig) resource.TestCheckFunc {
+
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+
+		nlbClient, err := testAccProvider.Meta().(ClientSession).VpcContainerAPI()
+		if err != nil {
+			return err
+		}
+
+		nlbAPI := nlbClient.NlbDns()
+		dnsList, err := nlbAPI.GetLocationNLBDNSList(rs.Primary.ID)
+		if err != nil {
+			return err
+		}
+
+		obj = dnsList[0].Nlb
+		return nil
+	}
+}

--- a/website/docs/r/container_nlb_dns.html.markdown
+++ b/website/docs/r/container_nlb_dns.html.markdown
@@ -1,0 +1,50 @@
+---
+subcategory: "Kubernetes Service"
+layout: "ibm"
+page_title: "IBM : ibm_container_nlb_dns"
+description: |-
+  Manages IBM Container Nlb
+---
+
+# ibm_container_nlb_dns
+
+Provides a resource for container_nlb_dns. This allows to add an NLB IP's to an existing host name that you created with 'ibmcloud ks nlb-dns create'.
+
+## Example Usage
+
+```hcl
+data "ibm_container_nlb_dns" "dns" {
+  cluster = var.cluster
+}
+
+resource "ibm_container_nlb_dns" "container_nlb_dns" {
+  cluster 	= var.cluster
+  nlb_host	= data.ibm_container_nlb_dns.dns.nlb_config.0.nlb_sub_domain
+  nlb_ips 	= var.cluster_ips
+}
+```
+
+## Argument Reference
+
+Review the argument reference that you can specify for your resource.
+
+* `cluster` - (Required, Forces new resource, String) The name or ID of the cluster. To list the clusters that you have access to, use the `GET /v1/clusters` API or run `ibmcloud ks cluster ls`.
+* `nlb_host` - (Required, Forces new resource, String) Host Name of load Balancer.
+* `nlb_ips` - (Required, Set)  NLB IPs.
+
+## Attribute Reference
+
+In addition to all argument references listed, you can access the following attribute references after your resource is created.
+
+* `id` - The unique identifier of the container_nlb_dns.
+* `nlb_dns_type` - Type of DNS.
+* `nlb_monitor_state` -  Nlb monitor state.
+* `nlb_ssl_secret_name` - Name of SSL Secret.
+* `nlb_ssl_secret_status` - Status of SSL Secret.
+* `nlb_type` - Nlb Type.
+* `secret_namespace` - Namespace of Secret.
+* `resource_group_id` - The ID of the resource group that the cluster is in. To check the resource group ID of the cluster, use the GET /v1/clusters/idOrName API. To list available resource group IDs, run ibmcloud resource groups.
+
+## Import
+
+The import functionality is not supported for this resource.

--- a/website/docs/r/satellite_location_nlb_dns.html.markdown
+++ b/website/docs/r/satellite_location_nlb_dns.html.markdown
@@ -1,0 +1,37 @@
+---
+subcategory: "Satellite"
+layout: "ibm"
+page_title: "IBM : satellite_location_nlb_dns"
+description: |-
+  Managed satellite location nlb dns.
+---
+
+# ibm\_satellite\_location\_nlb\_dns
+
+Provides a resource to register public ip address to satellite dns records. This allows satellite dns register to be created, updated and deleted.
+
+## Example Usage
+
+```hcl
+resource "ibm_satellite_location_nlb_dns" "satellite_dns" {
+  location = "satellite-ibm"
+  ips      = ["52.116.125.50","169.62.17.178","169.63.178.155"]
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `ips` - (Required, Forces new resource, List) Public IP address of satellite location DNS records.
+* `location` - (Required, Forces new resource, string) The name or ID of the Satellite location.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The unique identifier of the ibm_satellite_location_nlb_dns.
+
+## Import
+
+The import functionality is not supported for this resource.


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/IBM-Cloud/terraform-provider-ibm/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Output from acceptance testing:

anilkumarnagaraj@anis-MacBook-Pro terraform-provider-ibm % make testacc TEST=./ibm TESTARGS='-run=TestAccIbmContainerNlbDnsBasic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./ibm -v -run=TestAccIbmContainerNlbDnsBasic -timeout 700m
[WARN] Set the environment variable IBM_APPID_TENANT_ID for testing AppID resources, AppID tests will fail if this is not set
[WARN] Set the environment variable IBM_APPID_TEST_USER_EMAIL for testing AppID user resources, the tests will fail if this is not set
[WARN] Set the environment variable IBM_ORG for testing ibm_org  resource Some tests for that resource will fail if this is not set correctly
[WARN] Set the environment variable IBM_SPACE for testing ibm_space  resource Some tests for that resource will fail if this is not set correctly
[WARN] Set the environment variable IBM_ID1 for testing ibm_space resource Some tests for that resource will fail if this is not set correctly
[WARN] Set the environment variable IBM_ID2 for testing ibm_space resource Some tests for that resource will fail if this is not set correctly
[WARN] Set the environment variable IBM_IAMUSER for testing ibm_iam_user_policy resource Some tests for that resource will fail if this is not set correctly
[WARN] Set the environment variable IBM_DATACENTER for testing ibm_container_cluster resource else it is set to default value 'par01'
[WARN] Set the environment variable IBM_MACHINE_TYPE for testing ibm_container_cluster resource else it is set to default value 'u2c.2x4'
[WARN] Set the environment variable IBM_CERT_CRN for testing ibm_container_alb_cert resource else it is set to default value
[WARN] Set the environment variable IBM_UPDATE_CERT_CRN for testing ibm_container_alb_cert resource else it is set to default value
[WARN] Set the environment variable IBM_CONTAINER_REGION for testing ibm_container resources else it is set to default value 'eu-de'
[WARN] Set the environment variable IBM_CIS_INSTANCE with a VALID CIS Instance NAME for testing ibm_cis resources on staging/test
[WARN] Set the environment variable IBM_CIS_DOMAIN_STATIC with the Domain name registered with the CIS instance on test/staging. Domain must be predefined in CIS to avoid CIS billing costs due to domain delete/create
[WARN] Set the environment variable IBM_CIS_DOMAIN_TEST with a VALID Domain name for testing the one time create and delete of a domain in CIS. Note each create/delete will trigger a monthly billing instance. Only to be run in staging/test
[WARN] Set the environment variable IBM_CIS_RESOURCE_GROUP with the resource group for the CIS Instance
[WARN] Set the environment variable IBM_COS_CRN with a VALID COS instance CRN for testing ibm_cos_* resources
[WARN] Set the environment variable IBM_TRUSTED_MACHINE_TYPE for testing ibm_container_cluster resource else it is set to default value 'mb1c.16x64'
[WARN] Set the environment variable IBM_BM_EXTENDED_HW_TESTING to true/false for testing ibm_compute_bare_metal resource else it is set to default value 'false'
[WARN] Set the environment variable IBM_PUBLIC_VLAN_ID for testing ibm_container_cluster resource else it is set to default value '2393319'
[WARN] Set the environment variable IBM_PRIVATE_VLAN_ID for testing ibm_container_cluster resource else it is set to default value '2393321'
[WARN] Set the environment variable IBM_KUBE_VERSION for testing ibm_container_cluster resource else it is set to default value '1.18.14'
[WARN] Set the environment variable IBM_KUBE_UPDATE_VERSION for testing ibm_container_cluster resource else it is set to default value '1.19.6'
[WARN] Set the environment variable IBM_PRIVATE_SUBNET_ID for testing ibm_container_cluster resource else it is set to default value '1636107'
[WARN] Set the environment variable IBM_PUBLIC_SUBNET_ID for testing ibm_container_cluster resource else it is set to default value '1165645'
[WARN] Set the environment variable IBM_SUBNET_ID for testing ibm_container_cluster resource else it is set to default value '1165645'
[INFO] Set the environment variable IBM_IPSEC_DATACENTER for testing ibm_ipsec_vpn resource else it is set to default value 'tok02'
[INFO] Set the environment variable IBM_IPSEC_CUSTOMER_SUBNET_ID for testing ibm_ipsec_vpn resource else it is set to default value '123456'
[INFO] Set the environment variable IBM_IPSEC_CUSTOMER_PEER_IP for testing ibm_ipsec_vpn resource else it is set to default value '192.168.0.1'
[WARN] Set the environment variable IBM_LBAAS_DATACENTER for testing ibm_lbaas resource else it is set to default value 'dal13'
[WARN] Set the environment variable IBM_LBAAS_SUBNETID for testing ibm_lbaas resource else it is set to default value '2144241'
[WARN] Set the environment variable IBM_LB_LISTENER_CERTIFICATE_INSTANCE for testing ibm_is_lb_listener resource for https redirect else it is set to default value 'crn:v1:staging:public:cloudcerts:us-south:a/2d1bace7b46e4815a81e52c6ffeba5cf:af925157-b125-4db2-b642-adacb8b9c7f5:certificate:c81627a1bf6f766379cc4b98fd2a44ed'
[WARN] Set the environment variable IBM_DEDICATED_HOSTNAME for testing ibm_compute_vm_instance resource else it is set to default value 'terraform-dedicatedhost'
[WARN] Set the environment variable IBM_DEDICATED_HOST_ID for testing ibm_compute_vm_instance resource else it is set to default value '30301'
[WARN] Set the environment variable IBM_WORKER_POOL_ZONE for testing ibm_container_worker_pool_zone_attachment resource else it is set to default value 'ams03'
[WARN] Set the environment variable IBM_WORKER_POOL_ZONE_PRIVATE_VLAN for testing ibm_container_worker_pool_zone_attachment resource else it is set to default value '2538975'
[WARN] Set the environment variable IBM_WORKER_POOL_ZONE_PUBLIC_VLAN for testing ibm_container_worker_pool_zone_attachment resource else it is set to default value '2538967'
[WARN] Set the environment variable IBM_WORKER_POOL_ZONE_UPDATE_PRIVATE_VLAN for testing ibm_container_worker_pool_zone_attachment resource else it is set to default value '2388377'
[WARN] Set the environment variable IBM_WORKER_POOL_ZONE_UPDATE_PUBLIC_VLAN for testing ibm_container_worker_pool_zone_attachment resource else it is set to default value '2388375'
[WARN] Set the environment variable IBM_PLACEMENT_GROUP_NAME for testing ibm_compute_vm_instance resource else it is set to default value 'terraform-group'
[INFO] Set the environment variable SL_REGION for testing ibm_is_region datasource else it is set to default value 'us-south'
[INFO] Set the environment variable SL_ZONE for testing ibm_is_zone datasource else it is set to default value 'us-south-1'
[INFO] Set the environment variable SL_CIDR for testing ibm_is_subnet else it is set to default value '10.240.0.0/24'
[INFO] Set the environment variable SL_ADDRESS_PREFIX_CIDR for testing ibm_is_vpc_address_prefix else it is set to default value '10.120.0.0/24'
[INFO] Set the environment variable IS_IMAGE for testing ibm_is_instance, ibm_is_floating_ip else it is set to default value 'r006-ed3f775f-ad7e-4e37-ae62-7199b4988b00'
[INFO] Set the environment variable IS_WIN_IMAGE for testing ibm_is_instance data source else it is set to default value 'r006-5f9568ae-792e-47e1-a710-5538b2bdfca7'
[INFO] Set the environment variable SL_INSTANCE_PROFILE for testing ibm_is_instance resource else it is set to default value 'cx2-2x4'
[INFO] Set the environment variable SL_INSTANCE_PROFILE_UPDATE for testing ibm_is_instance resource else it is set to default value 'cx2-4x8'
[INFO] Set the environment variable IS_DEDICATED_HOST_NAME for testing ibm_is_instance resource else it is set to default value 'tf-dhost-01'
[INFO] Set the environment variable IS_DEDICATED_HOST_GROUP_ID for testing ibm_is_instance resource else it is set to default value '0717-9104e7b5-77ad-44ad-9eaa-091e6b6efce1'
[INFO] Set the environment variable IS_DEDICATED_HOST_PROFILE for testing ibm_is_instance resource else it is set to default value 'bx2d-host-152x608'
[INFO] Set the environment variable IS_DEDICATED_HOST_GROUP_CLASS for testing ibm_is_instance resource else it is set to default value 'bx2d'
[INFO] Set the environment variable IS_DEDICATED_HOST_GROUP_FAMILY for testing ibm_is_instance resource else it is set to default value 'balanced'
[INFO] Set the environment variable SL_INSTANCE_PROFILE for testing ibm_is_instance resource else it is set to default value 'bx2d-16x64'
[INFO] Set the environment variable IS_VOLUME_PROFILE for testing ibm_is_volume_profile else it is set to default value 'general-purpose'
[INFO] Set the environment variable SL_ROUTE_DESTINATION for testing ibm_is_vpc_route else it is set to default value '192.168.4.0/24'
[INFO] Set the environment variable SL_ROUTE_NEXTHOP for testing ibm_is_vpc_route else it is set to default value '10.0.0.4'
[INFO] Set the environment variable PI_IMAGE for testing ibm_pi_image resource else it is set to default value '7200-03-03'
[INFO] Set the environment variable PI_IMAGE_BUCKET_NAME for testing ibm_pi_image resource else it is set to default value 'images-public-bucket'
[INFO] Set the environment variable PI_IMAGE_BUCKET_FILE_NAME for testing ibm_pi_image resource else it is set to default value 'rhel.ova.gz'
[INFO] Set the environment variable PI_KEY_NAME for testing ibm_pi_key_name resource else it is set to default value 'terraform-test-power'
[INFO] Set the environment variable PI_NETWORK_NAME for testing ibm_pi_network_name resource else it is set to default value 'terraform-test-power'
[INFO] Set the environment variable PI_VOLUME_NAME for testing ibm_pi_network_name resource else it is set to default value 'terraform-test-power'
[INFO] Set the environment variable PI_CLOUDINSTANCE_ID for testing ibm_pi_image resource else it is set to default value 'd16705bd-7f1a-48c9-9e0e-1c17b71e7331'
[INFO] Set the environment variable PI_PVM_INSTANCE_ID for testing pi_instance_name resource else it is set to default value 'terraform-test-power'
[INFO] Set the environment variable SCHEMATICS_WORKSPACE_ID for testing schematics resources else it is set to default value
[INFO] Set the environment variable SCHEMATICS_TEMPLATE_ID for testing schematics resources else it is set to default value
[INFO] Set the environment variable SCHEMATICS_ACTION_ID for testing schematics resources else it is set to default value
[WARN] Set the environment variable IMAGE_COS_URL with a VALID COS Image SQL URL for testing ibm_is_image resources on staging/test
[WARN] Set the environment variable IMAGE_COS_URL_ENCRYPTED with a VALID COS Image SQL URL for testing ibm_is_image resources on staging/test
[WARN] Set the environment variable IMAGE_OPERATING_SYSTEM with a VALID Operating system for testing ibm_is_image resources on staging/test
[INFO] Set the environment variable IS_IMAGE_NAME for testing data source ibm_is_image else it is set to default value `ibm-ubuntu-18-04-1-minimal-amd64-2`
[INFO] Set the environment variable IS_IMAGE_ENCRYPTED_DATA_KEY for testing resource ibm_is_image else it is set to default value
[INFO] Set the environment variable IS_IMAGE_ENCRYPTION_KEY for testing resource ibm_is_image else it is set to default value
[INFO] Set the environment variable IBM_FUNCTION_NAMESPACE for testing ibm_function_package, ibm_function_action, ibm_function_rule, ibm_function_trigger resource else  tests will fail if this is not set correctly
[INFO] Set the environment variable HPCS_INSTANCE_ID for testing data_source_ibm_kms_key_test else it is set to default value
[INFO] Set the environment variable SECRETS_MANAGER_INSTANCE_ID for testing data_source_ibm_secrets_manager_secrets_test else tests will fail if this is not set correctly
[INFO] Set the environment variable SECRETS_MANAGER_SECRET_TYPE for testing data_source_ibm_secrets_manager_secrets_test, else it is set to default value. For data_source_ibm_secrets_manager_secret_test, tests will fail if this is not set correctly
[WARN] Set the environment variable SECRETS_MANAGER_SECRET_ID for testing data_source_ibm_secrets_manager_secret_test else tests will fail if this is not set correctly
[INFO] Set the environment variable IBM_TG_CROSS_ACCOUNT_ID for testing ibm_tg_connection resource else  tests will fail if this is not set correctly
[INFO] Set the environment variable IBM_TG_CROSS_NETWORK_ID for testing ibm_tg_connection resource else  tests will fail if this is not set correctly
[INFO] Set the environment variable ACCOUNT_TO_BE_IMPORTED for testing import enterprise account resource else  tests will fail if this is not set correctly
[WARN] Set the environment variable IBM_HPCS_ADMIN1 with a VALID HPCS Admin Key1 Path
[WARN] Set the environment variable IBM_HPCS_TOKEN1 with a VALID token for HPCS Admin Key1
[WARN] Set the environment variable IBM_HPCS_ADMIN2 with a VALID HPCS Admin Key2 Path
[WARN] Set the environment variable IBM_IAM_REALM_NAME with a VALID realm name for iam trusted profile claim rule
[WARN] Set the environment variable IBM_IAM_IKS_SA with a VALID realm name for iam trusted profile link
[WARN] Set the environment variable IBM_HPCS_TOKEN2 with a VALID token for HPCS Admin Key2
[INFO] Set the environment variable SCC_SI_ACCOUNT for testing SCC SI resources resource else  tests will fail if this is not set correctly
[INFO] Set the environment variable SCC_POSTURE_SCOPE_ID for testing SCC Posture resources or datasource resource else  tests will fail if this is not set correctly
[INFO] Set the environment variable SCC_POSTURE_SCAN_ID for testing SCC Posture resource or datasource else  tests will fail if this is not set correctly
[INFO] Set the environment variable SCC_POSTURE_PROFILE_ID for testing SCC Posture resource or datasource else  tests will fail if this is not set correctly
[INFO] Set the environment variable IBM_CLOUD_SHELL_ACCOUNT_ID for ibm-cloud-shell resource or datasource else tests will fail if this is not set correctly
=== RUN   TestAccIbmContainerNlbDnsBasic
--- PASS: TestAccIbmContainerNlbDnsBasic (39.71s)
PASS
ok  	github.com/IBM-Cloud/terraform-provider-ibm/ibm	42.672s


anilkumarnagaraj@anis-MacBook-Pro terraform-provider-ibm % make testacc TEST=./ibm TESTARGS='-run=TestAccIbmSatelliteLocationNlbDnsBasic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./ibm -v -run=TestAccIbmSatelliteLocationNlbDnsBasic -timeout 700m
[WARN] Set the environment variable IBM_APPID_TENANT_ID for testing AppID resources, AppID tests will fail if this is not set
[WARN] Set the environment variable IBM_APPID_TEST_USER_EMAIL for testing AppID user resources, the tests will fail if this is not set
[WARN] Set the environment variable IBM_ORG for testing ibm_org  resource Some tests for that resource will fail if this is not set correctly
[WARN] Set the environment variable IBM_SPACE for testing ibm_space  resource Some tests for that resource will fail if this is not set correctly
[WARN] Set the environment variable IBM_ID1 for testing ibm_space resource Some tests for that resource will fail if this is not set correctly
[WARN] Set the environment variable IBM_ID2 for testing ibm_space resource Some tests for that resource will fail if this is not set correctly
[WARN] Set the environment variable IBM_IAMUSER for testing ibm_iam_user_policy resource Some tests for that resource will fail if this is not set correctly
[WARN] Set the environment variable IBM_DATACENTER for testing ibm_container_cluster resource else it is set to default value 'par01'
[WARN] Set the environment variable IBM_MACHINE_TYPE for testing ibm_container_cluster resource else it is set to default value 'u2c.2x4'
[WARN] Set the environment variable IBM_CERT_CRN for testing ibm_container_alb_cert resource else it is set to default value
[WARN] Set the environment variable IBM_UPDATE_CERT_CRN for testing ibm_container_alb_cert resource else it is set to default value
[WARN] Set the environment variable IBM_CONTAINER_REGION for testing ibm_container resources else it is set to default value 'eu-de'
[WARN] Set the environment variable IBM_CIS_INSTANCE with a VALID CIS Instance NAME for testing ibm_cis resources on staging/test
[WARN] Set the environment variable IBM_CIS_DOMAIN_STATIC with the Domain name registered with the CIS instance on test/staging. Domain must be predefined in CIS to avoid CIS billing costs due to domain delete/create
[WARN] Set the environment variable IBM_CIS_DOMAIN_TEST with a VALID Domain name for testing the one time create and delete of a domain in CIS. Note each create/delete will trigger a monthly billing instance. Only to be run in staging/test
[WARN] Set the environment variable IBM_CIS_RESOURCE_GROUP with the resource group for the CIS Instance
[WARN] Set the environment variable IBM_COS_CRN with a VALID COS instance CRN for testing ibm_cos_* resources
[WARN] Set the environment variable IBM_TRUSTED_MACHINE_TYPE for testing ibm_container_cluster resource else it is set to default value 'mb1c.16x64'
[WARN] Set the environment variable IBM_BM_EXTENDED_HW_TESTING to true/false for testing ibm_compute_bare_metal resource else it is set to default value 'false'
[WARN] Set the environment variable IBM_PUBLIC_VLAN_ID for testing ibm_container_cluster resource else it is set to default value '2393319'
[WARN] Set the environment variable IBM_PRIVATE_VLAN_ID for testing ibm_container_cluster resource else it is set to default value '2393321'
[WARN] Set the environment variable IBM_KUBE_VERSION for testing ibm_container_cluster resource else it is set to default value '1.18.14'
[WARN] Set the environment variable IBM_KUBE_UPDATE_VERSION for testing ibm_container_cluster resource else it is set to default value '1.19.6'
[WARN] Set the environment variable IBM_PRIVATE_SUBNET_ID for testing ibm_container_cluster resource else it is set to default value '1636107'
[WARN] Set the environment variable IBM_PUBLIC_SUBNET_ID for testing ibm_container_cluster resource else it is set to default value '1165645'
[WARN] Set the environment variable IBM_SUBNET_ID for testing ibm_container_cluster resource else it is set to default value '1165645'
[INFO] Set the environment variable IBM_IPSEC_DATACENTER for testing ibm_ipsec_vpn resource else it is set to default value 'tok02'
[INFO] Set the environment variable IBM_IPSEC_CUSTOMER_SUBNET_ID for testing ibm_ipsec_vpn resource else it is set to default value '123456'
[INFO] Set the environment variable IBM_IPSEC_CUSTOMER_PEER_IP for testing ibm_ipsec_vpn resource else it is set to default value '192.168.0.1'
[WARN] Set the environment variable IBM_LBAAS_DATACENTER for testing ibm_lbaas resource else it is set to default value 'dal13'
[WARN] Set the environment variable IBM_LBAAS_SUBNETID for testing ibm_lbaas resource else it is set to default value '2144241'
[WARN] Set the environment variable IBM_LB_LISTENER_CERTIFICATE_INSTANCE for testing ibm_is_lb_listener resource for https redirect else it is set to default value 'crn:v1:staging:public:cloudcerts:us-south:a/2d1bace7b46e4815a81e52c6ffeba5cf:af925157-b125-4db2-b642-adacb8b9c7f5:certificate:c81627a1bf6f766379cc4b98fd2a44ed'
[WARN] Set the environment variable IBM_DEDICATED_HOSTNAME for testing ibm_compute_vm_instance resource else it is set to default value 'terraform-dedicatedhost'
[WARN] Set the environment variable IBM_DEDICATED_HOST_ID for testing ibm_compute_vm_instance resource else it is set to default value '30301'
[WARN] Set the environment variable IBM_WORKER_POOL_ZONE for testing ibm_container_worker_pool_zone_attachment resource else it is set to default value 'ams03'
[WARN] Set the environment variable IBM_WORKER_POOL_ZONE_PRIVATE_VLAN for testing ibm_container_worker_pool_zone_attachment resource else it is set to default value '2538975'
[WARN] Set the environment variable IBM_WORKER_POOL_ZONE_PUBLIC_VLAN for testing ibm_container_worker_pool_zone_attachment resource else it is set to default value '2538967'
[WARN] Set the environment variable IBM_WORKER_POOL_ZONE_UPDATE_PRIVATE_VLAN for testing ibm_container_worker_pool_zone_attachment resource else it is set to default value '2388377'
[WARN] Set the environment variable IBM_WORKER_POOL_ZONE_UPDATE_PUBLIC_VLAN for testing ibm_container_worker_pool_zone_attachment resource else it is set to default value '2388375'
[WARN] Set the environment variable IBM_PLACEMENT_GROUP_NAME for testing ibm_compute_vm_instance resource else it is set to default value 'terraform-group'
[INFO] Set the environment variable SL_REGION for testing ibm_is_region datasource else it is set to default value 'us-south'
[INFO] Set the environment variable SL_ZONE for testing ibm_is_zone datasource else it is set to default value 'us-south-1'
[INFO] Set the environment variable SL_CIDR for testing ibm_is_subnet else it is set to default value '10.240.0.0/24'
[INFO] Set the environment variable SL_ADDRESS_PREFIX_CIDR for testing ibm_is_vpc_address_prefix else it is set to default value '10.120.0.0/24'
[INFO] Set the environment variable IS_IMAGE for testing ibm_is_instance, ibm_is_floating_ip else it is set to default value 'r006-ed3f775f-ad7e-4e37-ae62-7199b4988b00'
[INFO] Set the environment variable IS_WIN_IMAGE for testing ibm_is_instance data source else it is set to default value 'r006-5f9568ae-792e-47e1-a710-5538b2bdfca7'
[INFO] Set the environment variable SL_INSTANCE_PROFILE for testing ibm_is_instance resource else it is set to default value 'cx2-2x4'
[INFO] Set the environment variable SL_INSTANCE_PROFILE_UPDATE for testing ibm_is_instance resource else it is set to default value 'cx2-4x8'
[INFO] Set the environment variable IS_DEDICATED_HOST_NAME for testing ibm_is_instance resource else it is set to default value 'tf-dhost-01'
[INFO] Set the environment variable IS_DEDICATED_HOST_GROUP_ID for testing ibm_is_instance resource else it is set to default value '0717-9104e7b5-77ad-44ad-9eaa-091e6b6efce1'
[INFO] Set the environment variable IS_DEDICATED_HOST_PROFILE for testing ibm_is_instance resource else it is set to default value 'bx2d-host-152x608'
[INFO] Set the environment variable IS_DEDICATED_HOST_GROUP_CLASS for testing ibm_is_instance resource else it is set to default value 'bx2d'
[INFO] Set the environment variable IS_DEDICATED_HOST_GROUP_FAMILY for testing ibm_is_instance resource else it is set to default value 'balanced'
[INFO] Set the environment variable SL_INSTANCE_PROFILE for testing ibm_is_instance resource else it is set to default value 'bx2d-16x64'
[INFO] Set the environment variable IS_VOLUME_PROFILE for testing ibm_is_volume_profile else it is set to default value 'general-purpose'
[INFO] Set the environment variable SL_ROUTE_DESTINATION for testing ibm_is_vpc_route else it is set to default value '192.168.4.0/24'
[INFO] Set the environment variable SL_ROUTE_NEXTHOP for testing ibm_is_vpc_route else it is set to default value '10.0.0.4'
[INFO] Set the environment variable PI_IMAGE for testing ibm_pi_image resource else it is set to default value '7200-03-03'
[INFO] Set the environment variable PI_IMAGE_BUCKET_NAME for testing ibm_pi_image resource else it is set to default value 'images-public-bucket'
[INFO] Set the environment variable PI_IMAGE_BUCKET_FILE_NAME for testing ibm_pi_image resource else it is set to default value 'rhel.ova.gz'
[INFO] Set the environment variable PI_KEY_NAME for testing ibm_pi_key_name resource else it is set to default value 'terraform-test-power'
[INFO] Set the environment variable PI_NETWORK_NAME for testing ibm_pi_network_name resource else it is set to default value 'terraform-test-power'
[INFO] Set the environment variable PI_VOLUME_NAME for testing ibm_pi_network_name resource else it is set to default value 'terraform-test-power'
[INFO] Set the environment variable PI_CLOUDINSTANCE_ID for testing ibm_pi_image resource else it is set to default value 'd16705bd-7f1a-48c9-9e0e-1c17b71e7331'
[INFO] Set the environment variable PI_PVM_INSTANCE_ID for testing pi_instance_name resource else it is set to default value 'terraform-test-power'
[INFO] Set the environment variable SCHEMATICS_WORKSPACE_ID for testing schematics resources else it is set to default value
[INFO] Set the environment variable SCHEMATICS_TEMPLATE_ID for testing schematics resources else it is set to default value
[INFO] Set the environment variable SCHEMATICS_ACTION_ID for testing schematics resources else it is set to default value
[WARN] Set the environment variable IMAGE_COS_URL with a VALID COS Image SQL URL for testing ibm_is_image resources on staging/test
[WARN] Set the environment variable IMAGE_COS_URL_ENCRYPTED with a VALID COS Image SQL URL for testing ibm_is_image resources on staging/test
[WARN] Set the environment variable IMAGE_OPERATING_SYSTEM with a VALID Operating system for testing ibm_is_image resources on staging/test
[INFO] Set the environment variable IS_IMAGE_NAME for testing data source ibm_is_image else it is set to default value `ibm-ubuntu-18-04-1-minimal-amd64-2`
[INFO] Set the environment variable IS_IMAGE_ENCRYPTED_DATA_KEY for testing resource ibm_is_image else it is set to default value
[INFO] Set the environment variable IS_IMAGE_ENCRYPTION_KEY for testing resource ibm_is_image else it is set to default value
[INFO] Set the environment variable IBM_FUNCTION_NAMESPACE for testing ibm_function_package, ibm_function_action, ibm_function_rule, ibm_function_trigger resource else  tests will fail if this is not set correctly
[INFO] Set the environment variable HPCS_INSTANCE_ID for testing data_source_ibm_kms_key_test else it is set to default value
[INFO] Set the environment variable SECRETS_MANAGER_INSTANCE_ID for testing data_source_ibm_secrets_manager_secrets_test else tests will fail if this is not set correctly
[INFO] Set the environment variable SECRETS_MANAGER_SECRET_TYPE for testing data_source_ibm_secrets_manager_secrets_test, else it is set to default value. For data_source_ibm_secrets_manager_secret_test, tests will fail if this is not set correctly
[WARN] Set the environment variable SECRETS_MANAGER_SECRET_ID for testing data_source_ibm_secrets_manager_secret_test else tests will fail if this is not set correctly
[INFO] Set the environment variable IBM_TG_CROSS_ACCOUNT_ID for testing ibm_tg_connection resource else  tests will fail if this is not set correctly
[INFO] Set the environment variable IBM_TG_CROSS_NETWORK_ID for testing ibm_tg_connection resource else  tests will fail if this is not set correctly
[INFO] Set the environment variable ACCOUNT_TO_BE_IMPORTED for testing import enterprise account resource else  tests will fail if this is not set correctly
[WARN] Set the environment variable IBM_HPCS_ADMIN1 with a VALID HPCS Admin Key1 Path
[WARN] Set the environment variable IBM_HPCS_TOKEN1 with a VALID token for HPCS Admin Key1
[WARN] Set the environment variable IBM_HPCS_ADMIN2 with a VALID HPCS Admin Key2 Path
[WARN] Set the environment variable IBM_IAM_REALM_NAME with a VALID realm name for iam trusted profile claim rule
[WARN] Set the environment variable IBM_IAM_IKS_SA with a VALID realm name for iam trusted profile link
[WARN] Set the environment variable IBM_HPCS_TOKEN2 with a VALID token for HPCS Admin Key2
[INFO] Set the environment variable SCC_SI_ACCOUNT for testing SCC SI resources resource else  tests will fail if this is not set correctly
[INFO] Set the environment variable SCC_POSTURE_SCOPE_ID for testing SCC Posture resources or datasource resource else  tests will fail if this is not set correctly
[INFO] Set the environment variable SCC_POSTURE_SCAN_ID for testing SCC Posture resource or datasource else  tests will fail if this is not set correctly
[INFO] Set the environment variable SCC_POSTURE_PROFILE_ID for testing SCC Posture resource or datasource else  tests will fail if this is not set correctly
[INFO] Set the environment variable IBM_CLOUD_SHELL_ACCOUNT_ID for ibm-cloud-shell resource or datasource else tests will fail if this is not set correctly
=== RUN   TestAccIbmSatelliteLocationNlbDnsBasic
no message sent
no message sent
no message sent
no message sent
no message sent
no message sent
no message sent
no message sent
no message sent
no message sent
no message sent
no message sent
no message sent
no message sent
no message sent
no message sent
no message sent
no message sent
no message sent
no message sent
no message sent
no message sent
no message sent
no message sent
no message sent
no message sent
no message sent
no message sent
no message sent
no message sent
no message sent
no message sent
no message sent
no message sent
no message sent
no message sent
no message sent
no message sent
no message sent
no message sent
no message sent
no message sent
no message sent
no message sent
no message sent
no message sent
no message sent
no message sent
no message sent
no message sent
no message sent
no message sent
no message sent
no message sent
no message sent
no message sent
no message sent
no message sent
no message sent
no message sent
no message sent
no message sent
--- PASS: TestAccIbmSatelliteLocationNlbDnsBasic (2315.16s)
PASS
ok  	github.com/IBM-Cloud/terraform-provider-ibm/ibm	2317.844s