### PR TITLE
Support direct endpoints for cos_bucket

### DIFF
--- a/ibm/data_source_ibm_cos_bucket.go
+++ b/ibm/data_source_ibm_cos_bucket.go
@@ -45,7 +45,7 @@ func dataSourceIBMCosBucket() *schema.Resource {
 			"endpoint_type": {
 				Type:         schema.TypeString,
 				Optional:     true,
-				ValidateFunc: validateAllowedStringValue([]string{"public", "private"}),
+				ValidateFunc: validateAllowedStringValue([]string{"public", "private", "direct"}),
 				Description:  "public or private",
 				Default:      "public",
 			},
@@ -254,9 +254,12 @@ func dataSourceIBMCosBucketRead(d *schema.ResourceData, meta interface{}) error 
 	bucketType := d.Get("bucket_type").(string)
 	bucketRegion := d.Get("bucket_region").(string)
 	var endpointType = d.Get("endpoint_type").(string)
-	apiEndpoint, apiEndpointPrivate := selectCosApi(bucketLocationConvert(bucketType), bucketRegion)
+	apiEndpoint, apiEndpointPrivate, directApiEndpoint := selectCosApi(bucketLocationConvert(bucketType), bucketRegion)
 	if endpointType == "private" {
 		apiEndpoint = apiEndpointPrivate
+	}
+	if endpointType == "direct" {
+		apiEndpoint = directApiEndpoint
 	}
 	apiEndpoint = envFallBack([]string{"IBMCLOUD_COS_ENDPOINT"}, apiEndpoint)
 	if apiEndpoint == "" {

--- a/website/docs/d/cos_bucket.html.markdown
+++ b/website/docs/d/cos_bucket.html.markdown
@@ -41,7 +41,7 @@ Review the argument references that you can specify for your data source.
 - `bucket_name` - (Required, String) The name of the bucket.
 - `bucket_region` - (Required, String) The region of the bucket.
 - `bucket_type` - (Required, String) The type of the bucket. Supported values are `single_site_location`, `region_location`, and `cross_region_location`.
-- `endpoint_type` - (Optional, String) The type of the endpoint either public or private to be used for the buckets. Default value is `public`.
+- `endpoint_type` - (Optional, String) The type of the endpoint either `public` or `private` or `direct` to be used for the buckets. Default value is `public`.
 - `resource_instance_id` - (Required, String) The ID of the IBM Cloud Object Storage service instance for which you want to create a bucket.
 - `storage_class`- (Required, String)  Storage class of the bucket. Supported values are `standard`, `vault`, `cold`, `flex`, `smart`.
 

--- a/website/docs/r/cos_bucket.html.markdown
+++ b/website/docs/r/cos_bucket.html.markdown
@@ -196,7 +196,7 @@ Review the argument references that you can specify for your resource.
 
 - `bucket_name` - (Required, String) The name of the bucket.
 - `cross_region_location` - (Optional, String) Specify the cross-regional bucket location. Supported values are `us`, `eu`, and `ap`. If you use this parameter, do not set `single_site_location` or `region_location` at the same time.
-- `endpoint_type`- (Optional, String) The type of the endpoint either public or private to be used for buckets. Default value is `public`.
+- `endpoint_type`- (Optional, String) The type of the endpoint either `public` or `private` or `direct` to be used for buckets. Default value is `public`.
 - `resource_instance_id` - (Required, String) The ID of the IBM Cloud Object Storage service instance for which you want to create a bucket.
 - `region_location` - (Optional, String) The location of a regional bucket. Supported values are `au-syd`, `eu-de`, `eu-gb`, `jp-tok`, `us-east`, `us-south`, `ca-tor`, `jp-osa`, `br-sao`. If you set this parameter, do not set `single_site_location` or `cross_region_location` at the same time.
 - `single_site_location` - (Optional, String) The location for a single site bucket. Supported values are: `ams03`, `che01`, `hkg02`, `mel01`, `mex01`, `mil01`, `mon01`, `osl01`, `par01`, `sjc04`, `sao01`, `seo01`, `sng01`, and `tor01`. If you set this parameter, do not set `region_location` or `cross_region_location` at the same time.


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/IBM-Cloud/terraform-provider-ibm/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #3230

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
=== RUN   TestAccIBMCosBucket_Basic
--- PASS: TestAccIBMCosBucket_Basic (100.73s)
=== RUN   TestAccIBMCosBucket_ActivityTracker_Monitor
--- PASS: TestAccIBMCosBucket_ActivityTracker_Monitor (99.11s)
=== RUN   TestAccIBMCosBucket_Retention
--- PASS: TestAccIBMCosBucket_Retention (67.45s)
=== RUN   TestAccIBMCosBucket_Object_Versioning
--- PASS: TestAccIBMCosBucket_Object_Versioning (57.64s)
=== RUN   TestAccIBMCosBucket_Hard_Quota
--- PASS: TestAccIBMCosBucket_Hard_Quota (63.92s)
=== RUN   TestAccIBMCosBucket_Smart_Type
--- PASS: TestAccIBMCosBucket_Smart_Type (96.51s)
=== RUN   TestAccIBMCosBucket_import
--- PASS: TestAccIBMCosBucket_import (76.97s)

...
```
```
resource "ibm_cos_bucket" "standard-ams03" {
  bucket_name          = "kavya1234ndard-bucket-at-ams"
  resource_instance_id = ibm_resource_instance.cos_instance.id
  single_site_location = "ams03"
  storage_class        = "standard"
  endpoint_type = "direct"
}
```
```
ibm_cos_bucket.standard-ams03: Creating...
ibm_cos_bucket.standard-ams03: Creation complete after 8s [id=crn:v1:bluemix:public:cloud-object-storage:global:a/4448261269a14562b839e0a3019ed980:0652d66d-503e-404a-9d9c-973bb5137d2f:bucket:kavya1234ndard-bucket-at-ams:meta:ssl:ams03:direct]

Apply complete! Resources: 1 added, 0 changed, 0 destroyed.
```
