### PR TITLE
Bump cr SDK version, hygiene and br-sao support

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,7 +11,7 @@ repos:
   # You are encouraged to use static refs such as tags, instead of branch name
   #
   # Running "pre-commit autoupdate" would automatically updates rev to latest tag
-  rev: 0.13.1+ibm.34.dss
+  rev: 0.13.1+ibm.46.dss
   hooks:
     - id: detect-secrets # pragma: whitelist secret
       # Add options for detect-secrets-hook binary. You can run `detect-secrets-hook --help` to list out all possible options.

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "go.sum|^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2021-10-07T13:44:08Z",
+  "generated_at": "2021-10-26T10:08:15Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -588,7 +588,7 @@
         "hashed_secret": "9184b0c38101bf24d78b2bb0d044deb1d33696fc",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 114,
+        "line_number": 115,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -596,7 +596,7 @@
         "hashed_secret": "c427f185ddcb2440be9b77c8e45f1cd487a2e790",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1211,
+        "line_number": 1220,
         "type": "Base64 High Entropy String",
         "verified_result": null
       },
@@ -604,7 +604,7 @@
         "hashed_secret": "1f614c2eb6b3da22d89bd1b9fd47d7cb7c8fc670",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2500,
+        "line_number": 2530,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -612,7 +612,7 @@
         "hashed_secret": "7abfce65b8504403afc25c9790f358d513dfbcc6",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2513,
+        "line_number": 2543,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -620,7 +620,7 @@
         "hashed_secret": "0c2d85bf9a9b1579b16f220a4ea8c3d62b2e24b1",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2550,
+        "line_number": 2580,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -926,7 +926,7 @@
         "hashed_secret": "c8b6f5ef11b9223ac35a5663975a466ebe7ebba9",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 962,
+        "line_number": 985,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -934,7 +934,7 @@
         "hashed_secret": "8abf4899c01104241510ba87685ad4de76b0c437",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 968,
+        "line_number": 991,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -944,7 +944,7 @@
         "hashed_secret": "813274ccae5b6b509379ab56982d862f7b5969b6",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 534,
+        "line_number": 542,
         "type": "Base64 High Entropy String",
         "verified_result": null
       }
@@ -2047,16 +2047,6 @@
         "verified_result": null
       }
     ],
-    "website/docs/r/iam_trusted_profile_policy.html.markdown": [
-      {
-        "hashed_secret": "19463ab0c6cf2c8f229c8c9666f2f784edf6bb4f",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 159,
-        "type": "Secret Keyword",
-        "verified_result": null
-      }
-    ],
     "website/docs/r/lb_vpx.html.markdown": [
       {
         "hashed_secret": "7f9e9d60560fbad72688c82e68cf42157a61bcad",
@@ -2088,7 +2078,7 @@
       }
     ]
   },
-  "version": "0.13.1+ibm.40.dss",
+  "version": "0.13.1+ibm.46.dss",
   "word_list": {
     "file": null,
     "hash": null

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/IBM/appconfiguration-go-admin-sdk v0.1.0
 	github.com/IBM/appid-management-go-sdk v0.0.0-20210908164609-dd0e0eaf732f
 	github.com/IBM/cloudant-go-sdk v0.0.36
-	github.com/IBM/container-registry-go-sdk v0.0.13
+	github.com/IBM/container-registry-go-sdk v0.0.14
 	github.com/IBM/event-notifications-go-admin-sdk v0.0.2
 	github.com/IBM/eventstreams-go-sdk v1.2.0
 	github.com/IBM/go-sdk-core/v4 v4.10.0

--- a/go.sum
+++ b/go.sum
@@ -52,8 +52,8 @@ github.com/IBM/appid-management-go-sdk v0.0.0-20210908164609-dd0e0eaf732f h1:4c1
 github.com/IBM/appid-management-go-sdk v0.0.0-20210908164609-dd0e0eaf732f/go.mod h1:d22kTYY7RYBWcQlZpqrSdshpB/lJ16viWS5Sbjtlc8s=
 github.com/IBM/cloudant-go-sdk v0.0.36 h1:h14ORyRs2pi2RtuqOGB+y9gWytRfQKnne2lMhl2MCws=
 github.com/IBM/cloudant-go-sdk v0.0.36/go.mod h1:04hA+Ok9aLYvnMEG4dMHTzU1W5b5tnl+Ddkdz4Z+xGs=
-github.com/IBM/container-registry-go-sdk v0.0.13 h1:nifb9L0dpMaECkZy7MsNvXaH8vxRW2ARBRbF8cV7S5g=
-github.com/IBM/container-registry-go-sdk v0.0.13/go.mod h1:GYi1VN59VaJWWq2xP06o9Vpi6+K8V5vtmji6WjMJf0w=
+github.com/IBM/container-registry-go-sdk v0.0.14 h1:UOA2SIQ0WKWOTFMScKJ3hXw61c6OaMx0tPaMACt5Mp0=
+github.com/IBM/container-registry-go-sdk v0.0.14/go.mod h1:KqSZFO4VIK9QAyF8O1JW6jkyzkfE/BNKUIo+OdzIDk4=
 github.com/IBM/event-notifications-go-admin-sdk v0.0.2 h1:53guiGbjLcrO26NhPv+Xf0Sbgn/DPlfPwek9s6YlIg8=
 github.com/IBM/event-notifications-go-admin-sdk v0.0.2/go.mod h1:VCtV/cAN8qSPeWEjIWeXOQGTq6LCWP9yZEk7wt3g0HM=
 github.com/IBM/eventstreams-go-sdk v1.2.0 h1:eP0afHArMGjwhGqvZAhhu/3EDKRch2JehpveqF1TUjs=


### PR DESCRIPTION
Signed-off-by: James Hart <jhart@uk.ibm.com>

<!--- See what makes a good Pull Request at : https://github.com/IBM-Cloud/terraform-provider-ibm/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Updates the container-registry-go-sdk dependency to 0.0.14. This is partially a hygiene update, but also adds support for the br.icr.io registry instance in `br-sao`.
I've also updated the pre-commit hook config and secrets baseline to use the latest version of the detect-secrets tool.

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```bash
$ make testacc TEST=./ibm TESTARGS='-run="TestAccIBMCr.*"'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./ibm -v -run="TestAccIBMCr.*" -timeout 700m
............
=== RUN   TestAccIBMCrNamespacesDataSourceBasic
--- PASS: TestAccIBMCrNamespacesDataSourceBasic (37.85s)
=== RUN   TestAccIBMCrNamespaceBasic
--- PASS: TestAccIBMCrNamespaceBasic (60.14s)
=== RUN   TestAccIBMCrNamespaceAllArgs
--- PASS: TestAccIBMCrNamespaceAllArgs (63.54s)
=== RUN   TestAccIBMCrRetentionPolicyAllArgs
--- PASS: TestAccIBMCrRetentionPolicyAllArgs (50.39s)
PASS
```
