### PR TITLE
removed deprecated from lb listeners

### DIFF
--- a/ibm/resource_ibm_is_lb_listener.go
+++ b/ibm/resource_ibm_is_lb_listener.go
@@ -65,7 +65,6 @@ func resourceIBMISLBListener() *schema.Resource {
 				ValidateFunc: validateLBListenerPort,
 				Computed:     true,
 				Description:  "Loadbalancer listener port",
-				Deprecated:   "This field will be deprecated in future and we will be using range of ports using port_min and port_max",
 			},
 			isLBListenerPortMin: {
 				Type:        schema.TypeInt,

--- a/website/docs/r/is_lb_listener.html.markdown
+++ b/website/docs/r/is_lb_listener.html.markdown
@@ -116,7 +116,7 @@ Review the argument references that you can specify for your resource.
 
 - `accept_proxy_protocol`- (Optional, Bool)  If set to **true**, listener forwards proxy protocol information that are supported by load balancers in the application family. Default value is **false**.
 - `lb` - (Required, Forces new resource, String) The load balancer unique identifier.
-- `port`- (Optional, Deprecated Integer) The listener port number. Valid range `1` to `65535`.
+- `port`- (Optional, Integer) The listener port number. Valid range `1` to `65535`.
 
   **NOTE**:
     - Private network load balancers with `route_mode` enabled don't support `port`, they support `port` range from `port_min`(1) - `port_max`(65535).


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/IBM-Cloud/terraform-provider-ibm/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```
