### PR TITLE
Support storage pool and affinity for instance and volume

### DIFF
--- a/ibm/data_source_ibm_pi_catalog_images.go
+++ b/ibm/data_source_ibm_pi_catalog_images.go
@@ -57,6 +57,10 @@ func dataSourceIBMPICatalogImages() *schema.Resource {
 							Type:     schema.TypeString,
 							Computed: true,
 						},
+						"storage_pool": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
 						"creation_date": {
 							Type:     schema.TypeString,
 							Computed: true,
@@ -136,6 +140,9 @@ func dataSourceIBMPICatalogImagesRead(d *schema.ResourceData, meta interface{}) 
 		}
 		if i.StorageType != nil {
 			image["storage_type"] = *i.StorageType
+		}
+		if i.StoragePool != nil {
+			image["storage_pool"] = *i.StoragePool
 		}
 		if i.CreationDate != nil {
 			image["creation_date"] = i.CreationDate.String()

--- a/ibm/data_source_ibm_pi_image.go
+++ b/ibm/data_source_ibm_pi_image.go
@@ -54,6 +54,10 @@ func dataSourceIBMPIImage() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
+			"storage_pool": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
 		},
 	}
 }
@@ -82,6 +86,7 @@ func dataSourceIBMPIImagesRead(d *schema.ResourceData, meta interface{}) error {
 	d.Set("hypervisor", imagedata.Specifications.HypervisorType)
 	d.Set("operatingsystem", imagedata.Specifications.OperatingSystem)
 	d.Set("storage_type", imagedata.StorageType)
+	d.Set("storage_pool", imagedata.StoragePool)
 
 	return nil
 

--- a/ibm/data_source_ibm_pi_images.go
+++ b/ibm/data_source_ibm_pi_images.go
@@ -64,6 +64,10 @@ func dataSourceIBMPIImages() *schema.Resource {
 							Type:     schema.TypeString,
 							Computed: true,
 						},
+						"storage_pool": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
 					},
 				},
 			},
@@ -107,6 +111,7 @@ func flattenStockImages(list []*models.ImageReference) []map[string]interface{} 
 			"href":         *i.Href,
 			"name":         *i.Name,
 			"storage_type": *i.StorageType,
+			"storage_pool": *i.StoragePool,
 		}
 
 		result = append(result, l)

--- a/ibm/data_source_ibm_pi_instance.go
+++ b/ibm/data_source_ibm_pi_instance.go
@@ -126,6 +126,14 @@ func dataSourceIBMPIInstance() *schema.Resource {
 				Type:     schema.TypeInt,
 				Computed: true,
 			},
+			"storage_type": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"storage_pool": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
 		},
 	}
 }
@@ -162,6 +170,8 @@ func dataSourceIBMPIInstancesRead(d *schema.ResourceData, meta interface{}) erro
 	d.Set("virtual_cores_assigned", powervmdata.VirtualCores.Assigned)
 	d.Set("max_virtual_cores", powervmdata.VirtualCores.Max)
 	d.Set("min_virtual_cores", powervmdata.VirtualCores.Min)
+	d.Set("storage_type", powervmdata.StorageType)
+	d.Set("storage_pool", powervmdata.StoragePool)
 
 	if powervmdata.Addresses != nil {
 		pvmaddress := make([]map[string]interface{}, len(powervmdata.Addresses))

--- a/ibm/data_source_ibm_pi_instance_volumes.go
+++ b/ibm/data_source_ibm_pi_instance_volumes.go
@@ -68,6 +68,10 @@ func dataSourceIBMPIInstanceVolumes() *schema.Resource {
 							Type:     schema.TypeString,
 							Computed: true,
 						},
+						"pool": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
 						"shareable": {
 							Type:     schema.TypeBool,
 							Computed: true,
@@ -117,6 +121,7 @@ func flattenVolumesInstances(list []*models.VolumeReference) []map[string]interf
 			"name":      *i.Name,
 			"size":      *i.Size,
 			"type":      *i.DiskType,
+			"pool":      i.VolumePool,
 			"shareable": *i.Shareable,
 			"bootable":  *i.Bootable,
 		}

--- a/ibm/data_source_ibm_pi_volume.go
+++ b/ibm/data_source_ibm_pi_volume.go
@@ -45,21 +45,15 @@ func dataSourceIBMPIVolume() *schema.Resource {
 				Type:     schema.TypeBool,
 				Computed: true,
 			},
-			"name": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-
 			"bootable": {
 				Type:     schema.TypeBool,
 				Computed: true,
 			},
-			"creation_date": {
+			"disk_type": {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
-
-			"disk_type": {
+			"volume_pool": {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
@@ -86,21 +80,13 @@ func dataSourceIBMPIVolumeRead(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	d.SetId(*volumedata.VolumeID)
-	if volumedata.Size != nil {
-		d.Set("size", volumedata.Size)
-	}
-	if &volumedata.DiskType != nil {
-		d.Set("disk_type", volumedata.DiskType)
-	}
-	if &volumedata.Bootable != nil {
-		d.Set("bootable", volumedata.Bootable)
-	}
-	if &volumedata.State != nil {
-		d.Set("state", volumedata.State)
-	}
-	if &volumedata.Wwn != nil {
-		d.Set("wwn", volumedata.Wwn)
-	}
+	d.Set("size", volumedata.Size)
+	d.Set("state", volumedata.State)
+	d.Set("shareable", volumedata.Shareable)
+	d.Set("bootable", volumedata.Bootable)
+	d.Set("disk_type", volumedata.DiskType)
+	d.Set("volume_pool", volumedata.VolumePool)
+	d.Set("wwn", volumedata.Wwn)
 	return nil
 
 }

--- a/ibm/resource_ibm_pi_instance.go
+++ b/ibm/resource_ibm_pi_instance.go
@@ -30,8 +30,9 @@ const (
 	warningTimeOut = 30 * time.Second
 	activeTimeOut  = 2 * time.Minute
 	// power service instance capabilities
-	CUSTOM_VIRTUAL_CORES = "custom-virtualcores"
-	PIInstanceNetwork    = "pi_network"
+	CUSTOM_VIRTUAL_CORES  = "custom-virtualcores"
+	PIInstanceNetwork     = "pi_network"
+	PIInstanceStoragePool = "pi_storage_pool"
 )
 
 func resourceIBMPIInstance() *schema.Resource {
@@ -124,6 +125,44 @@ func resourceIBMPIInstance() *schema.Resource {
 				Optional:    true,
 				Computed:    true,
 				Description: "Storage type for server deployment",
+			},
+			PIInstanceStoragePool: {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				Description: "Storage Pool for server deployment; if provided then pi_affinity_policy and pi_storage_type will be ignored",
+			},
+			PIAffinityPolicy: {
+				Type:         schema.TypeString,
+				Optional:     true,
+				Description:  "Affinity policy for pvm instance being created; ignored if pi_storage_pool provided; for policy affinity requires one of pi_affinity_instance or pi_affinity_volume to be specified; for policy anti-affinity requires one of pi_anti_affinity_instances or pi_anti_affinity_volumes to be specified",
+				ValidateFunc: validateAllowedStringValue([]string{"affinity", "anti-affinity"}),
+			},
+			PIAffinityVolume: {
+				Type:          schema.TypeString,
+				Optional:      true,
+				Description:   "Volume (ID or Name) to base storage affinity policy against; required if requesting affinity and pi_affinity_instance is not provided",
+				ConflictsWith: []string{PIAffinityInstance},
+			},
+			PIAffinityInstance: {
+				Type:          schema.TypeString,
+				Optional:      true,
+				Description:   "PVM Instance (ID or Name) to base storage affinity policy against; required if requesting storage affinity and pi_affinity_volume is not provided",
+				ConflictsWith: []string{PIAffinityVolume},
+			},
+			PIAntiAffinityVolumes: {
+				Type:          schema.TypeList,
+				Optional:      true,
+				Elem:          &schema.Schema{Type: schema.TypeString},
+				Description:   "List of volumes to base storage anti-affinity policy against; required if requesting anti-affinity and pi_anti_affinity_instances is not provided",
+				ConflictsWith: []string{PIAntiAffinityInstances},
+			},
+			PIAntiAffinityInstances: {
+				Type:          schema.TypeList,
+				Optional:      true,
+				Elem:          &schema.Schema{Type: schema.TypeString},
+				Description:   "List of pvmInstances to base storage anti-affinity policy against; required if requesting anti-affinity and pi_anti_affinity_volumes is not provided",
+				ConflictsWith: []string{PIAntiAffinityVolumes},
 			},
 
 			helpers.PIInstanceStorageConnection: {
@@ -441,6 +480,37 @@ func resourceIBMPIInstanceCreate(d *schema.ResourceData, meta interface{}) error
 	if st, ok := d.GetOk(helpers.PIInstanceStorageType); ok {
 		body.StorageType = st.(string)
 	}
+	if sp, ok := d.GetOk(PIInstanceStoragePool); ok {
+		body.StoragePool = sp.(string)
+	}
+
+	if ap, ok := d.GetOk(PIAffinityPolicy); ok {
+		policy := ap.(string)
+		affinity := &models.StorageAffinity{
+			AffinityPolicy: &policy,
+		}
+
+		if policy == "affinity" {
+			if av, ok := d.GetOk(PIAffinityVolume); ok {
+				afvol := av.(string)
+				affinity.AffinityVolume = &afvol
+			}
+			if ai, ok := d.GetOk(PIAffinityInstance); ok {
+				afins := ai.(string)
+				affinity.AffinityPVMInstance = &afins
+			}
+		} else {
+			if avs, ok := d.GetOk(PIAntiAffinityVolumes); ok {
+				afvols := expandStringList(avs.([]interface{}))
+				affinity.AntiAffinityVolumes = afvols
+			}
+			if ais, ok := d.GetOk(PIAntiAffinityInstances); ok {
+				afinss := expandStringList(ais.([]interface{}))
+				affinity.AntiAffinityPVMInstances = afinss
+			}
+		}
+		body.StorageAffinity = affinity
+	}
 
 	if sc, ok := d.GetOk(helpers.PIInstanceStorageConnection); ok {
 		body.StorageConnection = sc.(string)
@@ -512,6 +582,7 @@ func resourceIBMPIInstanceRead(d *schema.ResourceData, meta interface{}) error {
 	if powervmdata.StorageType != nil {
 		d.Set(helpers.PIInstanceStorageType, powervmdata.StorageType)
 	}
+	d.Set(helpers.PIInstanceStoragePool, powervmdata.StoragePool)
 	d.Set(helpers.PICloudInstanceId, powerinstanceid)
 	d.Set("instance_id", powervmdata.PvmInstanceID)
 	d.Set(helpers.PIInstanceName, powervmdata.ServerName)

--- a/ibm/resource_ibm_pi_volume_test.go
+++ b/ibm/resource_ibm_pi_volume_test.go
@@ -101,3 +101,35 @@ func testAccCheckIBMPIVolumeConfig(name string) string {
 	  }
 	`, name, pi_cloud_instance_id)
 }
+
+func TestAccIBMPIVolumePool(t *testing.T) {
+	name := fmt.Sprintf("tf-pi-volume-%d", acctest.RandIntRange(10, 100))
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckIBMPIVolumeDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckIBMPIVolumePoolConfig(name),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckIBMPIVolumeExists("ibm_pi_volume.power_volume"),
+					resource.TestCheckResourceAttr(
+						"ibm_pi_volume.power_volume", "pi_volume_name", name),
+					resource.TestCheckResourceAttr(
+						"ibm_pi_volume.power_volume", "pi_volume_pool", "Tier3-Flash-1"),
+				),
+			},
+		},
+	})
+}
+func testAccCheckIBMPIVolumePoolConfig(name string) string {
+	return fmt.Sprintf(`
+	resource "ibm_pi_volume" "power_volume"{
+		pi_volume_size       = 20
+		pi_volume_name       = "%s"
+		pi_volume_pool       = "Tier3-Flash-1"
+		pi_volume_shareable  = true
+		pi_cloud_instance_id = "%s"
+	  }
+	`, name, pi_cloud_instance_id)
+}

--- a/website/docs/d/pi_catalog_images.html.markdown
+++ b/website/docs/d/pi_catalog_images.html.markdown
@@ -51,10 +51,11 @@ In addition to the argument reference list, you can access the following attribu
 	- `endianness` - (String) The `Endianness` order.
 	- `hypervisor_type` - (String) Hypervisor type.
 	- `href` - (String) The `href` of an image.
-  - `image_id` - (String) The unique identifier of an image.
+	- `image_id` - (String) The unique identifier of an image.
 	- `image_type` - (String) The type of the format.
 	- `last_update_date` - (String) The last updated date of an image.
 	- `name` - (String) The name of the image.
 	- `operating_system` - (String)  Operating System.
-  - `storage_type` - (String) The storage type of an image.
+	- `storage_pool` - (String) Storage pool where image resides.
+	- `storage_type` - (String) The storage type of an image.
 	- `state` - (String) The state of an Operating System.

--- a/website/docs/d/pi_image.html.markdown
+++ b/website/docs/d/pi_image.html.markdown
@@ -49,3 +49,4 @@ In addition to all argument reference list, you can access the following attribu
 - `size` - (String) The size of the image in megabytes.
 - `state` - (String) The state for this image. 
 - `storage_type` - (String) The storage type for this image.
+- `storage_pool` - (String) Storage pool where image resides.

--- a/website/docs/d/pi_images.html.markdown
+++ b/website/docs/d/pi_images.html.markdown
@@ -46,6 +46,7 @@ In addition to all argument reference list, you can access the following attribu
   Nested scheme for `image_info`:
 	- `href` - (String) The hyper link of an image. 
 	- `id` - (String) The unique identifier of an image. 
-    - `name`-  (String) The name of an image.
+	- `name`-  (String) The name of an image.
 	- `state` - (String) The state of an image.
+	- `storage_pool` - (String) Storage pool where image resides.
 	- `storage_type` - (String) The storage type of an image.

--- a/website/docs/d/pi_instance.html.markdown
+++ b/website/docs/d/pi_instance.html.markdown
@@ -65,5 +65,7 @@ In addition to all argument reference list, you can access the following attribu
 - `processors` - (Float) The number of processors that are allocated to the instance.
 - `proctype` - (String) The procurement type of the instance. Supported values are `shared` and `dedicated`.
 - `status` - (String) The status of the instance.
+- `storage_pool`- (String) Storage Pool where server is deployed.
+- `storage_type` - (String) Storage type where server is deployed.
 - `virtual_cores_assigned` - (Integer) The virtual cores that are assigned to the instance.
 - `volumes`- (List of strings) The list of volume IDs that are attached to the instance.

--- a/website/docs/d/pi_instance_volumes.html.markdown
+++ b/website/docs/d/pi_instance_volumes.html.markdown
@@ -52,6 +52,7 @@ In addition to all argument reference list, you can access the following attribu
 	- `href` - (String) The hyper link of the volume.
 	- `id` - (String) The unique identifier of the volume.
 	- `name` - (String) The name of the volume.
+	- `pool` - (String) Volume pool, name of storage pool where the volume is located.
 	- `shareable` -  (Bool) If set to **true**, the volume can be shared across multiple Power Systems Virtual Server instances. If set to **false**, the volume can be mounted to one instance only.
 	- `size` - (Integer) The size of this volume in gigabytes.
 	- `state` - (String) The state of the volume.

--- a/website/docs/d/pi_volume.html.markdown
+++ b/website/docs/d/pi_volume.html.markdown
@@ -42,9 +42,11 @@ Review the argument references that you can specify for your data source.
 ## Attribute reference
 In addition to all argument reference list, you can access the following attribute references after your data source is created. 
 
-- `bootable` -  (Bool) If set to **true**, the Power Systems Virtual Server instance can boot from this volume. If set to **false**, this volume is not used during the boot process of the instance.
+- `disk_type` - (String) The disk type that is used for the volume.
+- `bootable` -  (Bool) Indicates if the volume is boot capable.
 - `id` - (String) The unique identifier of the volume.
+- `shareable` - (String) Indicates if the volume is shareable between VMs. 
 - `size` - (Integer) The size of the volume in gigabytes.
 - `state` - (String) The state of the volume.
-- `type` - (String) The disk type that is used for the volume.
+- `volume_pool` - (String) Volume pool, name of storage pool where the volume is located.
 - `wwn` - (String) The world wide name of the volume.

--- a/website/docs/r/pi_instance.html.markdown
+++ b/website/docs/r/pi_instance.html.markdown
@@ -57,6 +57,11 @@ The `ibm_pi_instance` provides the following [timeouts](https://www.terraform.io
 ## Argument reference
 Review the argument references that you can specify for your resource. 
 
+- `pi_affinity_instance` - (Optional, String) PVM Instance (ID or Name) to base storage affinity policy against; required if requesting `affinity` and `pi_affinity_volume` is not provided.
+- `pi_affinity_policy` - (Optional, String) Affinity policy for pvm instance being created; ignored if `pi_storage_pool` provided; for policy affinity requires one of `pi_affinity_instance` or `pi_affinity_volume` to be specified; for policy anti-affinity requires one of `pi_anti_affinity_instances` or `pi_anti_affinity_volumes` to be specified; Allowable values: `affinity`, `anti-affinity`
+- `pi_affinity_volume`- (Optional, String) Volume (ID or Name) to base storage affinity policy against; required if requesting `affinity` and `pi_affinity_instance` is not provided.
+- `pi_anti_affinity_instances` - (Optional, String) List of pvmInstances to base storage anti-affinity policy against; required if requesting `anti-affinity` and `pi_anti_affinity_volumes` is not provided.
+- `pi_anti_affinity_volumes`- (Optional, String) List of volumes to base storage anti-affinity policy against; required if requesting `anti-affinity` and `pi_anti_affinity_instances` is not provided.
 - `pi_cloud_instance_id` - (Required, String) The GUID of the service instance associated with an account.
 - `pi_health_status` - (Optional, String) Specifies if Terraform should poll for the health status to be `OK` or `WARNING`. The default value is `OK`.
 - `pi_image_id` - (Required, String) The ID of the image that you want to use for your Power Systems Virtual Server instance. The image determines the operating system that is installed in your instance. To list available images, run the `ibmcloud pi images` command.
@@ -72,6 +77,7 @@ Review the argument references that you can specify for your resource.
 - `pi_replicants` - (Optional, Float) The number of instances that you want to provision with the same configuration. If this parameter is not set,  `1` is used by default.
 - `pi_replication_policy` - (Optional, String) The replication policy that you want to use. If this parameter is not set, `none` is used by default. 
 - `pi_replication_scheme` - (Optional, String) The replication scheme that you want to set, either `prefix` or `suffix`.
+- `pi_storage_pool` - (Optional, String) Storage Pool for server deployment; if provided then `pi_affinity_policy` and `pi_storage_type` will be ignored.
 - `pi_storage_type` - (Optional, String) - Storage type for server deployment. Only valid when you deploy one of the IBM supplied stock images. Storage type for a custom image (an imported image or an image that is created from a VM capture) defaults to the storage type the image was created in
 - `pi_storage_connection` - (Optional, String) - Storage Connectivity Group (SCG) for server deployment. Only supported value is `vSCSI`.
 - `pi_sys_type` - (Required, String) The type of system on which to create the VM (s922/e880/any). 

--- a/website/docs/r/pi_volume.html.markdown
+++ b/website/docs/r/pi_volume.html.markdown
@@ -47,21 +47,26 @@ ibm_pi_volume provides the following [timeouts](https://www.terraform.io/docs/la
 
 ## Argument reference 
 Review the argument references that you can specify for your resource. 
-- `pi_affinity_instance` - (Optional, String) PVM Instance (ID or Name) to base volume affinity policy against. This argument is Required if `pi_affinity_policy` is provided and Conflicts with `pi_affinity_volume`.
-- `pi_affinity_policy` - (Optional, String) Affinity policy for data volume being created; requires `pi_affinity_instance` or `pi_affinity_volume` to be specified; Allowable values: `affinity`, `anti-affinity`
-- `pi_affinity_volume`- (Optional, String) Volume (ID or Name) to base volume affinity policy against; required if pi_affinity_policy is provided and Conflicts with `pi_affinity_instance`.
+
+- `pi_affinity_instance` - (Optional, String) PVM Instance (ID or Name) to base volume affinity policy against; required if requesting `affinity` and `pi_affinity_volume` is not provided.
+- `pi_affinity_policy` - (Optional, String) Affinity policy for data volume being created; ignored if `pi_volume_pool` provided; for policy 'affinity' requires one of `pi_affinity_instance` or `pi_affinity_volume` to be specified; for policy 'anti-affinity' requires one of `pi_anti_affinity_instances` or `pi_anti_affinity_volumes` to be specified; Allowable values: `affinity`, `anti-affinity`
+- `pi_affinity_volume`- (Optional, String) Volume (ID or Name) to base volume affinity policy against; required if requesting `affinity` and `pi_affinity_instance` is not provided.
+- `pi_anti_affinity_instances` - (Optional, String) List of pvmInstances to base volume anti-affinity policy against; required if requesting `anti-affinity` and `pi_anti_affinity_volumes` is not provided.
+- `pi_anti_affinity_volumes`- (Optional, String) List of volumes to base volume anti-affinity policy against; required if requesting `anti-affinity` and `pi_anti_affinity_instances` is not provided.
 - `pi_cloud_instance_id` - (Required, String) The GUID of the service instance associated with an account.
 - `pi_volume_name` - (Required, String) The name of the volume.
+- `pi_volume_pool` - (Optional, String) Volume pool where the volume will be created; if provided then `pi_volume_type` and `pi_affinity_policy` values will be ignored.
 - `pi_volume_shareable` - (Required, Bool) If set to **true**, the volume can be shared across Power Systems Virtual Server instances. If set to **false**, you can attach it only to one instance. 
 - `pi_volume_size`  - (Required, Integer) The size of the volume in gigabytes. 
-- `pi_volume_type` - (Optional, String) The type of volume that you want to create. Supported values are `ssd`, `standard`, `tier1`, and `tier3`.
+- `pi_volume_type` - (Optional, String) Type of Disk, required if `pi_affinity_policy` and `pi_volume_pool` not provided, otherwise ignored. Supported values are `ssd`, `standard`, `tier1`, and `tier3`.
 
 ## Attribute reference
 In addition to all argument reference list, you can access the following attribute reference after your resource is created.
 
-- `id` - (String) The unique identifier of the volume. The ID is composed of `<power_instance_id>/<volume_id>`. 
-- `status` - (String) The status of the volume. 
+- `delete_on_termination` - (Bool) Indicates if the volume should be deleted when the server terminates.
+- `id` - (String) The unique identifier of the volume. The ID is composed of `<power_instance_id>/<volume_id>`.
 - `volume_id` - (String) The unique identifier of the volume.
+- `volume_status` - (String) The status of the volume.
 - `wwn` - (String) The world wide name of the volume.
 
 ## Import


### PR DESCRIPTION
Signed-off-by: Yussuf Shaikh <yussuf.shaikh@ibm.com>

<!--- See what makes a good Pull Request at : https://github.com/IBM-Cloud/terraform-provider-ibm/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #3266

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
=== RUN   TestAccIBMPIInstanceNetwork
--- PASS: TestAccIBMPIInstanceNetwork (1063.70s)
PASS
=== RUN   TestAccIBMPIInstanceDataSource_basic
--- PASS: TestAccIBMPIInstanceDataSource_basic (61.89s)
PASS
=== RUN   TestAccIBMPICatalogImagesDataSource_basic
--- PASS: TestAccIBMPICatalogImagesDataSource_basic (41.71s)
PASS
=== RUN   TestAccIBMPIImageDataSource_basic
--- PASS: TestAccIBMPIImageDataSource_basic (28.12s)
PASS
=== RUN   TestAccIBMPIImagesDataSource_basic
--- PASS: TestAccIBMPIImagesDataSource_basic (32.90s)
PASS
=== RUN   TestAccIBMPIVolumesDataSource_basic
--- PASS: TestAccIBMPIVolumesDataSource_basic (33.38s)
PASS
=== RUN   TestAccIBMPIVolumebasic
--- PASS: TestAccIBMPIVolumebasic (82.34s)
PASS
=== RUN   TestAccIBMPIVolumePool
--- PASS: TestAccIBMPIVolumebasic (78.29s)
PASS
=== RUN   TestAccIBMPIVolumeDataSource_basic
--- PASS: TestAccIBMPIVolumeDataSource_basic (26.41s)
PASS

...
```
