### PR TITLE
add resource group to cm_catalog resource and datasource

### DIFF
--- a/ibm/data_source_ibm_cm_catalog.go
+++ b/ibm/data_source_ibm_cm_catalog.go
@@ -66,6 +66,11 @@ func dataSourceIBMCmCatalog() *schema.Resource {
 				Computed:    true,
 				Description: "URL path to offerings.",
 			},
+			"resource_group_id": &schema.Schema{
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "Resource Group ID",
+			},
 		},
 	}
 }
@@ -111,5 +116,9 @@ func dataSourceIBMCmCatalogRead(context context.Context, d *schema.ResourceData,
 	if err = d.Set("kind", catalog.Kind); err != nil {
 		return diag.FromErr(fmt.Errorf("Error setting kind: %s", err))
 	}
+	if err = d.Set("resource_group_id", catalog.ResourceGroupID); err != nil {
+		return diag.FromErr(fmt.Errorf("Error setting resource_group_id: %s", err))
+	}
+
 	return nil
 }

--- a/ibm/data_source_ibm_cm_catalog_test.go
+++ b/ibm/data_source_ibm_cm_catalog_test.go
@@ -5,23 +5,26 @@ package ibm
 
 import (
 	"fmt"
+	"os"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 )
 
 func TestAccIBMCmCatalogDataSource(t *testing.T) {
+	ResourceGroupID := os.Getenv("CATMGMT_RESOURCE_GROUP_ID")
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t) },
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			resource.TestStep{
-				Config: testAccCheckIBMCmCatalogDataSourceConfig(),
+				Config: testAccCheckIBMCmCatalogDataSourceConfig(ResourceGroupID),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrSet("data.ibm_cm_catalog.cm_catalog_data", "label"),
 					resource.TestCheckResourceAttrSet("data.ibm_cm_catalog.cm_catalog_data", "crn"),
 					resource.TestCheckResourceAttrSet("data.ibm_cm_catalog.cm_catalog_data", "kind"),
+					resource.TestCheckResourceAttrSet("ibm_cm_catalog.cm_catalog", "resource_group_id"),
 				),
 			},
 			resource.TestStep{
@@ -30,24 +33,26 @@ func TestAccIBMCmCatalogDataSource(t *testing.T) {
 					resource.TestCheckResourceAttrSet("data.ibm_cm_catalog.cm_catalog_data", "label"),
 					resource.TestCheckResourceAttrSet("data.ibm_cm_catalog.cm_catalog_data", "crn"),
 					resource.TestCheckResourceAttrSet("data.ibm_cm_catalog.cm_catalog_data", "kind"),
+					resource.TestCheckResourceAttrSet("ibm_cm_catalog.cm_catalog", "resource_group_id"),
 				),
 			},
 		},
 	})
 }
 
-func testAccCheckIBMCmCatalogDataSourceConfig() string {
+func testAccCheckIBMCmCatalogDataSourceConfig(resourceGroupID string) string {
 	return fmt.Sprintf(`
 
 		resource "ibm_cm_catalog" "cm_catalog" {
 			label = "tf_test_datasource_catalog"
 			short_description = "testing terraform provider with catalog"
+			resource_group_id = "%s"
 		}
 		
 		data "ibm_cm_catalog" "cm_catalog_data" {
 			catalog_identifier = ibm_cm_catalog.cm_catalog.id
 		}
-		`)
+		`, resourceGroupID)
 }
 
 func testAccCheckIBMCmCatalogDataSourceConfigDefault() string {

--- a/ibm/resource_ibm_cm_catalog.go
+++ b/ibm/resource_ibm_cm_catalog.go
@@ -67,6 +67,13 @@ func resourceIBMCmCatalog() *schema.Resource {
 				Computed:    true,
 				Description: "URL path to offerings.",
 			},
+			"resource_group_id": &schema.Schema{
+				Type:        schema.TypeString,
+				Computed:    true,
+				ForceNew:    true,
+				Optional:    true,
+				Description: "Resource Group ID",
+			},
 		},
 	}
 }
@@ -93,6 +100,9 @@ func resourceIBMCmCatalogCreate(d *schema.ResourceData, meta interface{}) error 
 	}
 	if _, ok := d.GetOk("kind"); ok {
 		createCatalogOptions.SetKind(d.Get("kind").(string))
+	}
+	if _, ok := d.GetOk("resource_group_id"); ok {
+		createCatalogOptions.SetResourceGroupID(d.Get("resource_group_id").(string))
 	}
 
 	catalog, response, err := catalogManagementClient.CreateCatalog(createCatalogOptions)
@@ -151,6 +161,9 @@ func resourceIBMCmCatalogRead(d *schema.ResourceData, meta interface{}) error {
 	}
 	if err = d.Set("kind", catalog.Kind); err != nil {
 		return fmt.Errorf("Error setting kind: %s", err)
+	}
+	if err = d.Set("resource_group_id", catalog.ResourceGroupID); err != nil {
+		return fmt.Errorf("Error setting resource_group_id: %s", err)
 	}
 
 	return nil

--- a/ibm/resource_ibm_cm_catalog_test.go
+++ b/ibm/resource_ibm_cm_catalog_test.go
@@ -25,6 +25,7 @@ func TestAccIBMCmCatalog(t *testing.T) {
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckIBMCmCatalogExists("ibm_cm_catalog.cm_catalog"),
 					resource.TestCheckResourceAttrSet("ibm_cm_catalog.cm_catalog", "label"),
+					resource.TestCheckResourceAttrSet("ibm_cm_catalog.cm_catalog", "resource_group_id"),
 				),
 			},
 			resource.TestStep{

--- a/website/docs/d/cm_catalog.html.markdown
+++ b/website/docs/d/cm_catalog.html.markdown
@@ -31,9 +31,10 @@ In addition to the argument reference list, you can access the following attribu
 - `catalog_icon_url` - (String) The URL for an icon associated with the catalog.
 - `crn` - (String) The CRN associated with the catalog.
 - `id` - (String) The unique identifier of the `ibm_cm_catalog`.
-- `label` - (String) Display the name in the requested language.
 - `kind` - (String) Kind of catalog, offering or vpe.
+- `label` - (String) Display the name in the requested language.
 - `offerings_url` - (String) URL path to the offerings.
+- `resource_group_id` - (String) The ID of the resource group this catalog is in
 - `short_description` - (String) The description in the requested language.
 - `tags` - (String) The list of tags associated with this catalog.
 - `url` - (String) The URL for the specific catalog.

--- a/website/docs/r/cm_catalog.html.markdown
+++ b/website/docs/r/cm_catalog.html.markdown
@@ -25,8 +25,9 @@ resource "ibm_cm_catalog" "cm_catalog" {
 Review the argument reference that you can specify for your resource. 
 
 - `label` - (Required, Forces new resource, String) The display name in the requested language.
-- `short_description` - (Optional, Forces new resource, String) The short description in the requested language.
 - `kind` - (Optional, Forces new resource, Defaults to offering, String) The kind of the catalog, offering or vpe.
+- `resource_group_id` - (Optional, Forces new resource, String) The ID of the resource group this catalog will be provisioned in
+- `short_description` - (Optional, Forces new resource, String) The short description in the requested language.
 
 
 ## Attribute reference


### PR DESCRIPTION
Support resource groups in catalog resources

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

Output from acceptance testing:

```
 make testacc
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test $(go list ./... |grep -v 'vendor') -v -run TestAccIBMCmCatalog -timeout 700m
?       github.com/IBM-Cloud/terraform-provider-ibm     [no test files]
[WARN] Set the environment variable IBM_APPID_TENANT_ID for testing AppID resources, AppID tests will fail if this is not set
[WARN] Set the environment variable IBM_APPID_TEST_USER_EMAIL for testing AppID user resources, the tests will fail if this is not set
[WARN] Set the environment variable IBM_ORG for testing ibm_org  resource Some tests for that resource will fail if this is not set correctly
[WARN] Set the environment variable IBM_SPACE for testing ibm_space  resource Some tests for that resource will fail if this is not set correctly
[WARN] Set the environment variable IBM_ID1 for testing ibm_space resource Some tests for that resource will fail if this is not set correctly
[WARN] Set the environment variable IBM_ID2 for testing ibm_space resource Some tests for that resource will fail if this is not set correctly
[WARN] Set the environment variable IBM_IAMUSER for testing ibm_iam_user_policy resource Some tests for that resource will fail if this is not set correctly
[WARN] Set the environment variable IBM_DATACENTER for testing ibm_container_cluster resource else it is set to default value 'par01'
[WARN] Set the environment variable IBM_MACHINE_TYPE for testing ibm_container_cluster resource else it is set to default value 'u2c.2x4'
[WARN] Set the environment variable IBM_CERT_CRN for testing ibm_container_alb_cert resource else it is set to default value
[WARN] Set the environment variable IBM_UPDATE_CERT_CRN for testing ibm_container_alb_cert resource else it is set to default value
[WARN] Set the environment variable IBM_CONTAINER_REGION for testing ibm_container resources else it is set to default value 'eu-de'
[WARN] Set the environment variable IBM_CIS_INSTANCE with a VALID CIS Instance NAME for testing ibm_cis resources on staging/test
[WARN] Set the environment variable IBM_CIS_DOMAIN_STATIC with the Domain name registered with the CIS instance on test/staging. Domain must be predefined in CIS to avoid CIS billing costs due to domain delete/create
[WARN] Set the environment variable IBM_CIS_DOMAIN_TEST with a VALID Domain name for testing the one time create and delete of a domain in CIS. Note each create/delete will trigger a monthly billing instance. Only to be run in staging/test
[WARN] Set the environment variable IBM_CIS_RESOURCE_GROUP with the resource group for the CIS Instance 
[WARN] Set the environment variable IBM_COS_CRN with a VALID COS instance CRN for testing ibm_cos_* resources
[WARN] Set the environment variable IBM_TRUSTED_MACHINE_TYPE for testing ibm_container_cluster resource else it is set to default value 'mb1c.16x64'
[WARN] Set the environment variable IBM_BM_EXTENDED_HW_TESTING to true/false for testing ibm_compute_bare_metal resource else it is set to default value 'false'
[WARN] Set the environment variable IBM_PUBLIC_VLAN_ID for testing ibm_container_cluster resource else it is set to default value '2393319'
[WARN] Set the environment variable IBM_PRIVATE_VLAN_ID for testing ibm_container_cluster resource else it is set to default value '2393321'
[WARN] Set the environment variable IBM_KUBE_VERSION for testing ibm_container_cluster resource else it is set to default value '1.18.14'
[WARN] Set the environment variable IBM_KUBE_UPDATE_VERSION for testing ibm_container_cluster resource else it is set to default value '1.19.6'
[WARN] Set the environment variable IBM_PRIVATE_SUBNET_ID for testing ibm_container_cluster resource else it is set to default value '1636107'
[WARN] Set the environment variable IBM_PUBLIC_SUBNET_ID for testing ibm_container_cluster resource else it is set to default value '1165645'
[WARN] Set the environment variable IBM_SUBNET_ID for testing ibm_container_cluster resource else it is set to default value '1165645'
[INFO] Set the environment variable IBM_IPSEC_DATACENTER for testing ibm_ipsec_vpn resource else it is set to default value 'tok02'
[INFO] Set the environment variable IBM_IPSEC_CUSTOMER_SUBNET_ID for testing ibm_ipsec_vpn resource else it is set to default value '123456'
[INFO] Set the environment variable IBM_IPSEC_CUSTOMER_PEER_IP for testing ibm_ipsec_vpn resource else it is set to default value '192.168.0.1'
[WARN] Set the environment variable IBM_LBAAS_DATACENTER for testing ibm_lbaas resource else it is set to default value 'dal13'
[WARN] Set the environment variable IBM_LBAAS_SUBNETID for testing ibm_lbaas resource else it is set to default value '2144241'
[WARN] Set the environment variable IBM_LB_LISTENER_CERTIFICATE_INSTANCE for testing ibm_is_lb_listener resource for https redirect else it is set to default value 'crn:v1:staging:public:cloudcerts:us-south:a/2d1bace7b46e4815a81e52c6ffeba5cf:af925157-b125-4db2-b642-adacb8b9c7f5:certificate:c81627a1bf6f766379cc4b98fd2a44ed'
[WARN] Set the environment variable IBM_DEDICATED_HOSTNAME for testing ibm_compute_vm_instance resource else it is set to default value 'terraform-dedicatedhost'
[WARN] Set the environment variable IBM_DEDICATED_HOST_ID for testing ibm_compute_vm_instance resource else it is set to default value '30301'
[WARN] Set the environment variable IBM_WORKER_POOL_ZONE for testing ibm_container_worker_pool_zone_attachment resource else it is set to default value 'ams03'
[WARN] Set the environment variable IBM_WORKER_POOL_ZONE_PRIVATE_VLAN for testing ibm_container_worker_pool_zone_attachment resource else it is set to default value '2538975'
[WARN] Set the environment variable IBM_WORKER_POOL_ZONE_PUBLIC_VLAN for testing ibm_container_worker_pool_zone_attachment resource else it is set to default value '2538967'
[WARN] Set the environment variable IBM_WORKER_POOL_ZONE_UPDATE_PRIVATE_VLAN for testing ibm_container_worker_pool_zone_attachment resource else it is set to default value '2388377'
[WARN] Set the environment variable IBM_WORKER_POOL_ZONE_UPDATE_PUBLIC_VLAN for testing ibm_container_worker_pool_zone_attachment resource else it is set to default value '2388375'
[WARN] Set the environment variable IBM_PLACEMENT_GROUP_NAME for testing ibm_compute_vm_instance resource else it is set to default value 'terraform-group'
[INFO] Set the environment variable SL_REGION for testing ibm_is_region datasource else it is set to default value 'us-south'
[INFO] Set the environment variable SL_ZONE for testing ibm_is_zone datasource else it is set to default value 'us-south-1'
[INFO] Set the environment variable SL_CIDR for testing ibm_is_subnet else it is set to default value '10.240.0.0/24'
[INFO] Set the environment variable SL_ADDRESS_PREFIX_CIDR for testing ibm_is_vpc_address_prefix else it is set to default value '10.120.0.0/24'
[INFO] Set the environment variable IS_IMAGE for testing ibm_is_instance, ibm_is_floating_ip else it is set to default value 'r006-ed3f775f-ad7e-4e37-ae62-7199b4988b00'
[INFO] Set the environment variable IS_WIN_IMAGE for testing ibm_is_instance data source else it is set to default value 'r006-5f9568ae-792e-47e1-a710-5538b2bdfca7'
[INFO] Set the environment variable SL_INSTANCE_PROFILE for testing ibm_is_instance resource else it is set to default value 'cx2-2x4'
[INFO] Set the environment variable SL_INSTANCE_PROFILE_UPDATE for testing ibm_is_instance resource else it is set to default value 'cx2-4x8'
[INFO] Set the environment variable IS_DEDICATED_HOST_NAME for testing ibm_is_instance resource else it is set to default value 'tf-dhost-01'
[INFO] Set the environment variable IS_DEDICATED_HOST_GROUP_ID for testing ibm_is_instance resource else it is set to default value '0717-9104e7b5-77ad-44ad-9eaa-091e6b6efce1'
[INFO] Set the environment variable IS_DEDICATED_HOST_PROFILE for testing ibm_is_instance resource else it is set to default value 'bx2d-host-152x608'
[INFO] Set the environment variable IS_DEDICATED_HOST_GROUP_CLASS for testing ibm_is_instance resource else it is set to default value 'bx2d'
[INFO] Set the environment variable IS_DEDICATED_HOST_GROUP_FAMILY for testing ibm_is_instance resource else it is set to default value 'balanced'
[INFO] Set the environment variable SL_INSTANCE_PROFILE for testing ibm_is_instance resource else it is set to default value 'bx2d-16x64'
[INFO] Set the environment variable IS_VOLUME_PROFILE for testing ibm_is_volume_profile else it is set to default value 'general-purpose'
[INFO] Set the environment variable SL_ROUTE_DESTINATION for testing ibm_is_vpc_route else it is set to default value '192.168.4.0/24'
[INFO] Set the environment variable SL_ROUTE_NEXTHOP for testing ibm_is_vpc_route else it is set to default value '10.0.0.4'
[INFO] Set the environment variable PI_IMAGE for testing ibm_pi_image resource else it is set to default value '7200-03-03'
[INFO] Set the environment variable PI_KEY_NAME for testing ibm_pi_key_name resource else it is set to default value 'terraform-test-power'
[INFO] Set the environment variable PI_NETWORK_NAME for testing ibm_pi_network_name resource else it is set to default value 'terraform-test-power'
[INFO] Set the environment variable PI_VOLUME_NAME for testing ibm_pi_network_name resource else it is set to default value 'terraform-test-power'
[INFO] Set the environment variable PI_CLOUDINSTANCE_ID for testing ibm_pi_image resource else it is set to default value 'd16705bd-7f1a-48c9-9e0e-1c17b71e7331'
[INFO] Set the environment variable PI_PVM_INSTANCE_ID for testing pi_instance_name resource else it is set to default value 'terraform-test-power'
[INFO] Set the environment variable SCHEMATICS_WORKSPACE_ID for testing schematics resources else it is set to default value
[INFO] Set the environment variable SCHEMATICS_TEMPLATE_ID for testing schematics resources else it is set to default value
[INFO] Set the environment variable SCHEMATICS_ACTION_ID for testing schematics resources else it is set to default value
[WARN] Set the environment variable IMAGE_COS_URL with a VALID COS Image SQL URL for testing ibm_is_image resources on staging/test
[WARN] Set the environment variable IMAGE_COS_URL_ENCRYPTED with a VALID COS Image SQL URL for testing ibm_is_image resources on staging/test
[WARN] Set the environment variable IMAGE_OPERATING_SYSTEM with a VALID Operating system for testing ibm_is_image resources on staging/test
[INFO] Set the environment variable IS_IMAGE_NAME for testing data source ibm_is_image else it is set to default value `ibm-ubuntu-18-04-1-minimal-amd64-2`
[INFO] Set the environment variable IS_IMAGE_ENCRYPTED_DATA_KEY for testing resource ibm_is_image else it is set to default value
[INFO] Set the environment variable IS_IMAGE_ENCRYPTION_KEY for testing resource ibm_is_image else it is set to default value
[INFO] Set the environment variable IBM_FUNCTION_NAMESPACE for testing ibm_function_package, ibm_function_action, ibm_function_rule, ibm_function_trigger resource else  tests will fail if this is not set correctly
[INFO] Set the environment variable HPCS_INSTANCE_ID for testing data_source_ibm_kms_key_test else it is set to default value
[INFO] Set the environment variable SECRETS_MANAGER_INSTANCE_ID for testing data_source_ibm_secrets_manager_secrets_test else tests will fail if this is not set correctly
[INFO] Set the environment variable SECRETS_MANAGER_SECRET_TYPE for testing data_source_ibm_secrets_manager_secrets_test, else it is set to default value. For data_source_ibm_secrets_manager_secret_test, tests will fail if this is not set correctly
[WARN] Set the environment variable SECRETS_MANAGER_SECRET_ID for testing data_source_ibm_secrets_manager_secret_test else tests will fail if this is not set correctly
[INFO] Set the environment variable IBM_TG_CROSS_ACCOUNT_ID for testing ibm_tg_connection resource else  tests will fail if this is not set correctly
[INFO] Set the environment variable IBM_TG_CROSS_NETWORK_ID for testing ibm_tg_connection resource else  tests will fail if this is not set correctly
[INFO] Set the environment variable ACCOUNT_TO_BE_IMPORTED for testing import enterprise account resource else  tests will fail if this is not set correctly
[WARN] Set the environment variable IBM_HPCS_ADMIN1 with a VALID HPCS Admin Key1 Path
[WARN] Set the environment variable IBM_HPCS_TOKEN1 with a VALID token for HPCS Admin Key1
[WARN] Set the environment variable IBM_HPCS_ADMIN2 with a VALID HPCS Admin Key2 Path
[WARN] Set the environment variable IBM_IAM_REALM_NAME with a VALID realm name for iam trusted profile claim rule
[WARN] Set the environment variable IBM_IAM_IKS_SA with a VALID realm name for iam trusted profile link
[WARN] Set the environment variable IBM_HPCS_TOKEN2 with a VALID token for HPCS Admin Key2
[INFO] Set the environment variable SCC_SI_ACCOUNT for testing SCC SI resources resource else  tests will fail if this is not set correctly
[INFO] Set the environment variable SCC_POSTURE_SCOPE_ID for testing SCC Posture resources or datasource resource else  tests will fail if this is not set correctly
[INFO] Set the environment variable SCC_POSTURE_SCAN_ID for testing SCC Posture resource or datasource else  tests will fail if this is not set correctly
[INFO] Set the environment variable SCC_POSTURE_PROFILE_ID for testing SCC Posture resource or datasource else  tests will fail if this is not set correctly
[INFO] Set the environment variable IBM_CLOUD_SHELL_ACCOUNT_ID for ibm-cloud-shell resource or datasource else tests will fail if this is not set correctly
=== RUN   TestAccIBMCmCatalogDataSource
2021/11/03 17:03:23 Configuring SoftLayer Session with token
2021/11/03 17:03:23 Configuring SoftLayer Session with API key
2021/11/03 17:03:23 Configuring IBM Cloud Session with token
2021/11/03 17:03:23 Configuring IBM Cloud Session with API key
2021/11/03 17:03:23 [INFO] Configured Region: us-south
2021/11/03 17:03:25 Configuring SoftLayer Session with token
2021/11/03 17:03:25 Configuring SoftLayer Session with API key
2021/11/03 17:03:25 Configuring IBM Cloud Session with token
2021/11/03 17:03:25 Configuring IBM Cloud Session with API key
2021/11/03 17:03:25 [INFO] Configured Region: us-south
2021/11/03 17:03:26 Configuring SoftLayer Session with token
2021/11/03 17:03:26 Configuring SoftLayer Session with API key
2021/11/03 17:03:26 Configuring IBM Cloud Session with token
2021/11/03 17:03:26 Configuring IBM Cloud Session with API key
2021/11/03 17:03:26 [INFO] Configured Region: us-south
2021/11/03 17:03:30 [DEBUG] client is a nil pointer: false
2021/11/03 17:03:31 Configuring SoftLayer Session with token
2021/11/03 17:03:31 Configuring SoftLayer Session with API key
2021/11/03 17:03:31 Configuring IBM Cloud Session with token
2021/11/03 17:03:31 Configuring IBM Cloud Session with API key
2021/11/03 17:03:31 [INFO] Configured Region: us-south
2021/11/03 17:03:33 Configuring SoftLayer Session with token
2021/11/03 17:03:33 Configuring SoftLayer Session with API key
2021/11/03 17:03:33 Configuring IBM Cloud Session with token
2021/11/03 17:03:33 Configuring IBM Cloud Session with API key
2021/11/03 17:03:33 [INFO] Configured Region: us-south
2021/11/03 17:03:34 [DEBUG] client is a nil pointer: false
2021/11/03 17:03:35 Configuring SoftLayer Session with token
2021/11/03 17:03:35 Configuring SoftLayer Session with API key
2021/11/03 17:03:35 Configuring IBM Cloud Session with token
2021/11/03 17:03:35 Configuring IBM Cloud Session with API key
2021/11/03 17:03:35 [INFO] Configured Region: us-south
2021/11/03 17:03:37 Configuring SoftLayer Session with token
2021/11/03 17:03:37 Configuring SoftLayer Session with API key
2021/11/03 17:03:37 Configuring IBM Cloud Session with token
2021/11/03 17:03:37 Configuring IBM Cloud Session with API key
2021/11/03 17:03:37 [INFO] Configured Region: us-south
2021/11/03 17:03:38 [DEBUG] client is a nil pointer: false
2021/11/03 17:03:39 Configuring SoftLayer Session with token
2021/11/03 17:03:39 Configuring SoftLayer Session with API key
2021/11/03 17:03:39 Configuring IBM Cloud Session with token
2021/11/03 17:03:39 Configuring IBM Cloud Session with API key
2021/11/03 17:03:39 [INFO] Configured Region: us-south
2021/11/03 17:03:41 Configuring SoftLayer Session with token
2021/11/03 17:03:41 Configuring SoftLayer Session with API key
2021/11/03 17:03:41 Configuring IBM Cloud Session with token
2021/11/03 17:03:41 Configuring IBM Cloud Session with API key
2021/11/03 17:03:41 [INFO] Configured Region: us-south
2021/11/03 17:03:43 Configuring SoftLayer Session with token
2021/11/03 17:03:43 Configuring SoftLayer Session with API key
2021/11/03 17:03:43 Configuring IBM Cloud Session with token
2021/11/03 17:03:43 Configuring IBM Cloud Session with API key
2021/11/03 17:03:43 [INFO] Configured Region: us-south
2021/11/03 17:03:44 [DEBUG] client is a nil pointer: false
2021/11/03 17:03:45 Configuring SoftLayer Session with token
2021/11/03 17:03:45 Configuring SoftLayer Session with API key
2021/11/03 17:03:45 Configuring IBM Cloud Session with token
2021/11/03 17:03:45 Configuring IBM Cloud Session with API key
2021/11/03 17:03:45 [INFO] Configured Region: us-south
2021/11/03 17:03:47 Configuring SoftLayer Session with token
2021/11/03 17:03:47 Configuring SoftLayer Session with API key
2021/11/03 17:03:47 Configuring IBM Cloud Session with token
2021/11/03 17:03:47 Configuring IBM Cloud Session with API key
2021/11/03 17:03:47 [INFO] Configured Region: us-south
--- PASS: TestAccIBMCmCatalogDataSource (27.47s)
=== RUN   TestAccIBMCmCatalog
2021/11/03 17:03:51 Configuring SoftLayer Session with token
2021/11/03 17:03:51 Configuring SoftLayer Session with API key
2021/11/03 17:03:51 Configuring IBM Cloud Session with token
2021/11/03 17:03:51 Configuring IBM Cloud Session with API key
2021/11/03 17:03:51 [INFO] Configured Region: us-south
2021/11/03 17:03:52 Configuring SoftLayer Session with token
2021/11/03 17:03:52 Configuring SoftLayer Session with API key
2021/11/03 17:03:52 Configuring IBM Cloud Session with token
2021/11/03 17:03:52 Configuring IBM Cloud Session with API key
2021/11/03 17:03:52 [INFO] Configured Region: us-south
2021/11/03 17:03:53 Configuring SoftLayer Session with token
2021/11/03 17:03:53 Configuring SoftLayer Session with API key
2021/11/03 17:03:53 Configuring IBM Cloud Session with token
2021/11/03 17:03:53 Configuring IBM Cloud Session with API key
2021/11/03 17:03:53 [INFO] Configured Region: us-south
2021/11/03 17:03:58 [DEBUG] client is a nil pointer: false
2021/11/03 17:03:59 Configuring SoftLayer Session with token
2021/11/03 17:03:59 Configuring SoftLayer Session with API key
2021/11/03 17:03:59 Configuring IBM Cloud Session with token
2021/11/03 17:03:59 Configuring IBM Cloud Session with API key
2021/11/03 17:03:59 [INFO] Configured Region: us-south
2021/11/03 17:04:00 Configuring SoftLayer Session with token
2021/11/03 17:04:00 Configuring SoftLayer Session with API key
2021/11/03 17:04:00 Configuring IBM Cloud Session with token
2021/11/03 17:04:00 Configuring IBM Cloud Session with API key
2021/11/03 17:04:00 [INFO] Configured Region: us-south
2021/11/03 17:04:02 [DEBUG] client is a nil pointer: false
2021/11/03 17:04:03 Configuring SoftLayer Session with token
2021/11/03 17:04:03 Configuring SoftLayer Session with API key
2021/11/03 17:04:03 Configuring IBM Cloud Session with token
2021/11/03 17:04:03 Configuring IBM Cloud Session with API key
2021/11/03 17:04:03 [INFO] Configured Region: us-south
2021/11/03 17:04:05 Configuring SoftLayer Session with token
2021/11/03 17:04:05 Configuring SoftLayer Session with API key
2021/11/03 17:04:05 Configuring IBM Cloud Session with token
2021/11/03 17:04:05 Configuring IBM Cloud Session with API key
2021/11/03 17:04:05 [INFO] Configured Region: us-south
2021/11/03 17:04:06 [DEBUG] client is a nil pointer: false
2021/11/03 17:04:07 Configuring SoftLayer Session with token
2021/11/03 17:04:07 Configuring SoftLayer Session with API key
2021/11/03 17:04:07 Configuring IBM Cloud Session with token
2021/11/03 17:04:07 Configuring IBM Cloud Session with API key
2021/11/03 17:04:07 [INFO] Configured Region: us-south
--- PASS: TestAccIBMCmCatalog (20.62s)
PASS
ok      github.com/IBM-Cloud/terraform-provider-ibm/ibm 49.546s
testing: warning: no tests to run
PASS
ok      github.com/IBM-Cloud/terraform-provider-ibm/ibm/internal/hashcode       (cached) [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/IBM-Cloud/terraform-provider-ibm/ibm/internal/mutexkv        (cached) [no tests to run]
?       github.com/IBM-Cloud/terraform-provider-ibm/version     [no test files]
```
