### PR TITLE
Added support for resource access tag

### DIFF
--- a/ibm/provider/provider.go
+++ b/ibm/provider/provider.go
@@ -1306,7 +1306,8 @@ func Provider() *schema.Provider {
 			"ibm_satellite_cluster_worker_pool_zone_attachment": satellite.ResourceIbmSatelliteClusterWorkerPoolZoneAttachment(),
 
 			// Added for Resource Tag
-			"ibm_resource_tag": globaltagging.ResourceIBMResourceTag(),
+			"ibm_resource_tag":        globaltagging.ResourceIBMResourceTag(),
+			"ibm_resource_access_tag": globaltagging.ResourceIBMResourceAccessTag(),
 
 			// Atracker
 			"ibm_atracker_target":   atracker.ResourceIBMAtrackerTarget(),
@@ -1600,6 +1601,7 @@ func Validator() validate.ValidatorDict {
 				"ibm_resource_key":                        resourcecontroller.ResourceIBMResourceKeyValidator(),
 				"ibm_is_virtual_endpoint_gateway":         vpc.ResourceIBMISEndpointGatewayValidator(),
 				"ibm_resource_tag":                        globaltagging.ResourceIBMResourceTagValidator(),
+				"ibm_resource_access_tag":                 globaltagging.ResourceIBMResourceAccessTagValidator(),
 				"ibm_satellite_location":                  satellite.ResourceIBMSatelliteLocationValidator(),
 				"ibm_satellite_cluster":                   satellite.ResourceIBMSatelliteClusterValidator(),
 				"ibm_pi_volume":                           power.ResourceIBMPIVolumeValidator(),

--- a/ibm/service/globaltagging/resource_ibm_resource_access_tag.go
+++ b/ibm/service/globaltagging/resource_ibm_resource_access_tag.go
@@ -1,0 +1,165 @@
+// Copyright IBM Corp. 2017, 2021 All Rights Reserved.
+// Licensed under the Mozilla Public License v2.0
+
+package globaltagging
+
+import (
+	"encoding/json"
+	"fmt"
+	"log"
+
+	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/conns"
+	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/flex"
+	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/validate"
+	"github.com/IBM/platform-services-go-sdk/globaltaggingv1"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+func ResourceIBMResourceAccessTag() *schema.Resource {
+	return &schema.Resource{
+		Create:   resourceIBMResourceAccessTagCreate,
+		Read:     resourceIBMResourceAccessTagRead,
+		Delete:   resourceIBMResourceAccessTagDelete,
+		Importer: &schema.ResourceImporter{},
+
+		Schema: map[string]*schema.Schema{
+
+			"name": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: validate.InvokeValidator("ibm_resource_access_tag", "name"),
+				Set:          flex.ResourceIBMVPCHash,
+				Description:  "Name of the access tag",
+			},
+			tagType: {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "Type of the tag(access)",
+			},
+		},
+	}
+}
+
+func ResourceIBMResourceAccessTagValidator() *validate.ResourceValidator {
+
+	validateSchema := make([]validate.ValidateSchema, 0)
+
+	validateSchema = append(validateSchema,
+		validate.ValidateSchema{
+			Identifier:                 "name",
+			ValidateFunctionIdentifier: validate.ValidateRegexpLen,
+			Type:                       validate.TypeString,
+			Required:                   true,
+			Regexp:                     `^([A-Za-z0-9_.-]|[A-Za-z0-9_.-][A-Za-z0-9_ .-]*[A-Za-z0-9_.-]):([A-Za-z0-9_.-]|[A-Za-z0-9_.-][A-Za-z0-9_ .-]*[A-Za-z0-9_.-])$`,
+			MinValueLength:             1,
+			MaxValueLength:             128})
+
+	ibmResourceAccessTagValidator := validate.ResourceValidator{ResourceName: "ibm_resource_access_tag", Schema: validateSchema}
+	return &ibmResourceAccessTagValidator
+}
+
+func resourceIBMResourceAccessTagCreate(d *schema.ResourceData, meta interface{}) error {
+
+	gtClient, err := meta.(conns.ClientSession).GlobalTaggingAPIv1()
+	if err != nil {
+		return fmt.Errorf("Error getting global tagging client settings: %s", err)
+	}
+
+	tagName := d.Get("name").(string)
+	add := make([]string, 0)
+	add = append(add, tagName)
+	accessTagType := "access"
+	createTagOptions := &globaltaggingv1.CreateTagOptions{
+		TagType:  &accessTagType,
+		TagNames: add,
+	}
+	results, _, err := gtClient.CreateTag(createTagOptions)
+	if err != nil {
+		return err
+	}
+	if results != nil {
+		errMap := make([]globaltaggingv1.CreateTagResultsResultsItem, 0)
+		for _, res := range results.Results {
+			if res.IsError != nil && *res.IsError {
+				errMap = append(errMap, res)
+			}
+		}
+		if len(errMap) > 0 {
+			output, err := json.MarshalIndent(errMap, "", "    ")
+			log.Printf("err is %s", err)
+			return fmt.Errorf("[ERROR] Error while creating access tag(%s) : %s", tagName, string(output))
+		}
+	}
+
+	d.SetId(tagName)
+	d.Set(tagType, accessTagType)
+
+	return nil
+}
+
+func resourceIBMResourceAccessTagRead(d *schema.ResourceData, meta interface{}) error {
+	tagName := d.Id()
+	gtClient, err := meta.(conns.ClientSession).GlobalTaggingAPIv1()
+	if err != nil {
+		return fmt.Errorf("Error getting global tagging client settings: %s", err)
+	}
+	accessTagType := "access"
+	listTagsOptions := &globaltaggingv1.ListTagsOptions{
+		TagType: &accessTagType,
+	}
+	taggingResult, _, err := gtClient.ListTags(listTagsOptions)
+	if err != nil {
+		return err
+	}
+
+	var taglist []string
+	for _, item := range taggingResult.Items {
+		taglist = append(taglist, *item.Name)
+	}
+	existingAccessTags := flex.NewStringSet(flex.ResourceIBMVPCHash, taglist)
+	if !existingAccessTags.Contains(tagName) {
+		d.SetId("")
+		return nil
+	}
+	d.Set("name", tagName)
+	d.Set(tagType, accessTagType)
+	return nil
+}
+
+func resourceIBMResourceAccessTagDelete(d *schema.ResourceData, meta interface{}) error {
+
+	gtClient, err := meta.(conns.ClientSession).GlobalTaggingAPIv1()
+	if err != nil {
+		return fmt.Errorf("[ERROR] Error getting global tagging client settings: %s", err)
+	}
+	tagName := d.Get("name").(string)
+	accessTagType := "access"
+
+	deleteTagOptions := &globaltaggingv1.DeleteTagOptions{
+		TagName: &tagName,
+		TagType: &accessTagType,
+	}
+
+	results, resp, err := gtClient.DeleteTag(deleteTagOptions)
+
+	if err != nil {
+		return fmt.Errorf("[ERROR] Error while deleting access tag(%s) : %v\n%v", tagName, err, resp)
+	}
+	if results != nil {
+		errMap := make([]globaltaggingv1.DeleteTagResultsItem, 0)
+		for _, res := range results.Results {
+			if res.IsError != nil && *res.IsError {
+				errMap = append(errMap, res)
+			}
+		}
+		if len(errMap) > 0 {
+			output, err := json.MarshalIndent(errMap, "", "    ")
+			log.Printf("err is %s", err)
+			return fmt.Errorf("[ERROR] Error while deleting access tag(%s) : %s", tagName, string(output))
+		}
+	}
+
+	d.SetId("")
+	return nil
+}

--- a/ibm/service/globaltagging/resource_ibm_resource_access_tag_test.go
+++ b/ibm/service/globaltagging/resource_ibm_resource_access_tag_test.go
@@ -1,0 +1,143 @@
+// Copyright IBM Corp. 2017, 2021 All Rights Reserved.
+// Licensed under the Mozilla Public License v2.0
+
+package globaltagging_test
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+	"testing"
+
+	acc "github.com/IBM-Cloud/terraform-provider-ibm/ibm/acctest"
+	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/conns"
+	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/flex"
+	"github.com/IBM/platform-services-go-sdk/globaltaggingv1"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+)
+
+const (
+	accessTagRegex = "^([A-Za-z0-9_.-]|[A-Za-z0-9_.-][A-Za-z0-9_ .-]*[A-Za-z0-9_.-]):([A-Za-z0-9_.-]|[A-Za-z0-9_.-][A-Za-z0-9_ .-]*[A-Za-z0-9_.-])$"
+)
+
+func TestAccResourceAccessTag_Basic(t *testing.T) {
+	name := fmt.Sprintf("tf%d:access%d", acctest.RandIntRange(10, 100), acctest.RandIntRange(10, 100))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { acc.TestAccPreCheck(t) },
+		Providers: acc.TestAccProviders,
+		Steps: []resource.TestStep{
+
+			resource.TestStep{
+				Config: testAccCheckResourceAccessTagCreate(name),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckResourceAccessTagExists("ibm_resource_access_tag.tag"),
+					resource.TestCheckResourceAttr("ibm_resource_access_tag.tag", "id", name),
+					resource.TestCheckResourceAttr("ibm_resource_access_tag.tag", "name", name),
+					resource.TestCheckResourceAttr("ibm_resource_access_tag.tag", "tag_type", "access"),
+				),
+			},
+		},
+	})
+}
+func TestAccResourceAccessTag_Usage(t *testing.T) {
+	name := fmt.Sprintf("tf%d:access%d", acctest.RandIntRange(10, 100), acctest.RandIntRange(10, 100))
+	publicKey := strings.TrimSpace(`
+ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCKVmnMOlHKcZK8tpt3MP1lqOLAcqcJzhsvJcjscgVERRN7/9484SOBJ3HSKxxNG5JN8owAjy5f9yYwcUg+JaUVuytn5Pv3aeYROHGGg+5G346xaq3DAwX6Y5ykr2fvjObgncQBnuU5KHWCECO/4h8uWuwh/kfniXPVjFToc+gnkqA+3RKpAecZhFXwfalQ9mMuYGFxn+fwn8cYEApsJbsEmb0iJwPiZ5hjFC8wREuiTlhPHDgkBLOiycd20op2nXzDbHfCHInquEe/gYxEitALONxm0swBOwJZwlTDOB7C6y2dzlrtxr1L59m7pCkWI4EtTRLvleehBoj3u7jB4usR
+`)
+	sshkeyname := fmt.Sprintf("tfssh-createname-%d", acctest.RandIntRange(10, 100))
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { acc.TestAccPreCheck(t) },
+		Providers: acc.TestAccProviders,
+		Steps: []resource.TestStep{
+
+			resource.TestStep{
+				Config: testAccCheckResourceAccessTagCreate(name),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckResourceAccessTagExists("ibm_resource_access_tag.tag"),
+					resource.TestCheckResourceAttr("ibm_resource_access_tag.tag", "id", name),
+					resource.TestCheckResourceAttr("ibm_resource_access_tag.tag", "name", name),
+					resource.TestCheckResourceAttr("ibm_resource_access_tag.tag", "tag_type", "access"),
+				),
+			},
+			resource.TestStep{
+				Config: testAccCheckResourceAccessTagUsage(name, sshkeyname, publicKey),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckResourceAccessTagExists("ibm_resource_access_tag.tag"),
+					resource.TestCheckResourceAttr("ibm_resource_access_tag.tag", "id", name),
+					resource.TestCheckResourceAttr("ibm_resource_access_tag.tag", "name", name),
+					resource.TestCheckResourceAttr("ibm_resource_access_tag.tag", "tag_type", "access"),
+					resource.TestCheckResourceAttr("ibm_is_ssh_key.key", "name", sshkeyname),
+					resource.TestCheckResourceAttrSet("ibm_is_ssh_key.key", "access_tags.#"),
+					resource.TestCheckResourceAttr("ibm_is_ssh_key.key", "access_tags.0", name),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckResourceAccessTagExists(n string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		var tagName string
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+
+		accessTagRegex, err := regexp.Compile(accessTagRegex)
+		if err != nil {
+			return err
+		}
+
+		if accessTagRegex.MatchString(rs.Primary.ID) {
+			tagName = rs.Primary.ID
+		}
+
+		gtClient, err := acc.TestAccProvider.Meta().(conns.ClientSession).GlobalTaggingAPIv1()
+		if err != nil {
+			return fmt.Errorf("Error getting global tagging client settings: %s", err)
+		}
+		accessTagType := "access"
+		listTagsOptions := &globaltaggingv1.ListTagsOptions{
+			TagType: &accessTagType,
+		}
+		taggingResult, _, err := gtClient.ListTags(listTagsOptions)
+		if err != nil {
+			return err
+		}
+
+		var taglist []string
+		for _, item := range taggingResult.Items {
+			taglist = append(taglist, *item.Name)
+		}
+		existingAccessTags := flex.NewStringSet(flex.ResourceIBMVPCHash, taglist)
+		if !existingAccessTags.Contains(tagName) {
+			return fmt.Errorf(
+				"Error on get of resource tags (%s) : %s", tagName, err)
+		}
+		return nil
+	}
+}
+
+func testAccCheckResourceAccessTagCreate(name string) string {
+	return fmt.Sprintf(`
+	resource ibm_resource_access_tag tag {
+		name = "%s"
+	  }
+`, name)
+}
+func testAccCheckResourceAccessTagUsage(name, sshkeyname, publicKey string) string {
+	return fmt.Sprintf(`
+	resource ibm_resource_access_tag tag {
+		name = "%s"
+	}
+	resource "ibm_is_ssh_key" "key" {
+		name = "%s"
+		public_key = "%s"
+		access_tags = [ibm_resource_access_tag.tag.name]
+	}
+
+`, name, sshkeyname, publicKey)
+}

--- a/ibm/service/globaltagging/resource_ibm_resource_tag.go
+++ b/ibm/service/globaltagging/resource_ibm_resource_tag.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2017, 2021 All Rights Reserved.
+// Copyright IBM Corp. 2017, 2024 All Rights Reserved.
 // Licensed under the Mozilla Public License v2.0
 
 package globaltagging

--- a/ibm/service/globaltagging/resource_ibm_resource_tag_test.go
+++ b/ibm/service/globaltagging/resource_ibm_resource_tag_test.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2017, 2021 All Rights Reserved.
+// Copyright IBM Corp. 2017, 2024 All Rights Reserved.
 // Licensed under the Mozilla Public License v2.0
 
 package globaltagging_test

--- a/ibm/service/vpc/resource_ibm_is_ssh_key.go
+++ b/ibm/service/vpc/resource_ibm_is_ssh_key.go
@@ -143,7 +143,7 @@ func ResourceIBMISSSHKey() *schema.Resource {
 				Type:        schema.TypeSet,
 				Optional:    true,
 				Computed:    true,
-				Elem:        &schema.Schema{Type: schema.TypeString, ValidateFunc: validate.InvokeValidator("ibm_is_ssh_key", "accesstag")},
+				Elem:        &schema.Schema{Type: schema.TypeString, ValidateFunc: validate.InvokeValidator("ibm_is_ssh_key", "access_tag")},
 				Set:         flex.ResourceIBMVPCHash,
 				Description: "List of access management tags for SSH key",
 			},

--- a/website/docs/r/resource_access_tag.html.markdown
+++ b/website/docs/r/resource_access_tag.html.markdown
@@ -1,12 +1,12 @@
 ---
 subcategory: "Global Tagging"
 layout: "ibm"
-page_title: "IBM : resource_tag"
+page_title: "IBM : resource_access_tag"
 description: |-
-  Manages resource tags.
+  Manages resource access tags.
 ---
 
-# ibm_resource_tag
+# ibm_resource_access_tag
 
 Create, update, or delete IBM Cloud access management tags. For more information, about tagging, see [IBM Cloud access management tags](https://cloud.ibm.com/apidocs/tagging#create-tag).
 
@@ -36,18 +36,18 @@ In addition to all argument reference list, you can access the following attribu
 
 ## Import
 
-The `ibm_resource_tag` resource can be imported by using the resource CRN.
+The `ibm_resource_access_tag` resource can be imported by using the resource CRN.
 
 **Syntax**
 
 ```
-$ terraform import ibm_resource_tag.tag tag_name
+$ terraform import ibm_resource_access_tag.tag tag_name
 ```
 
 **Example**
 
 ```
-$ terraform import ibm_resource_tag.tag  crn:v1:bluemix:public:satellite:us-east:a/ab3ed67929c2a81285fbb5f9eb22800a:c1ga7h9w0angomd44654::
+$ terraform import ibm_resource_access_tag.tag  crn:v1:bluemix:public:satellite:us-east:a/ab3ed67929c2a81285fbb5f9eb22800a:c1ga7h9w0angomd44654::
 
 ```
 

--- a/website/docs/r/resource_access_tag.html.markdown
+++ b/website/docs/r/resource_access_tag.html.markdown
@@ -1,0 +1,66 @@
+---
+subcategory: "Global Tagging"
+layout: "ibm"
+page_title: "IBM : resource_tag"
+description: |-
+  Manages resource tags.
+---
+
+# ibm_resource_tag
+
+Create, update, or delete IBM Cloud access management tags. For more information, about tagging, see [IBM Cloud access management tags](https://cloud.ibm.com/apidocs/tagging#create-tag).
+
+
+## Example usage
+The following example enables you to create access management tags
+
+```terraform
+resource "ibm_resource_access_tag" "example" {
+	name        = "example:tag"
+}
+
+```
+
+## Argument reference
+Review the argument references that you can specify for your resource.
+
+- `name` - (Required, String) The name of the access management tag.
+
+
+## Attributes reference
+In addition to all argument reference list, you can access the following attribute reference after your resource is created.
+
+- `id` - (String) The unique identifier of the resource tag. Same as `name`.
+- `tag_type` - (String) Type of the tag(`access`)
+
+
+## Import
+
+The `ibm_resource_tag` resource can be imported by using the resource CRN.
+
+**Syntax**
+
+```
+$ terraform import ibm_resource_tag.tag tag_name
+```
+
+**Example**
+
+```
+$ terraform import ibm_resource_tag.tag  crn:v1:bluemix:public:satellite:us-east:a/ab3ed67929c2a81285fbb5f9eb22800a:c1ga7h9w0angomd44654::
+
+```
+
+Example for importing access tags.
+
+**Syntax**
+
+```
+$ terraform import ibm_resource_access_tag.tag tag_name
+```
+
+**Example**
+
+```
+$ terraform import ibm_resource_access_tag.tag example:test
+```


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/IBM-Cloud/terraform-provider-ibm/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TEST=./ibm/service/globaltagging TESTARGS='-run=TestAccResourceAccessTag_Basic'
=== RUN   TestAccResourceAccessTag_Basic
--- PASS: TestAccResourceAccessTag_Basic (38.14s)
PASS
ok      github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/globaltagging   39.706s
```
```
$ make testacc TEST=./ibm/service/globaltagging  TESTARGS='-run=TestAccResourceAccessTag_Usage
=== RUN   TestAccResourceAccessTag_Usage
--- PASS: TestAccResourceAccessTag_Usage (68.24s)
PASS
ok      github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/globaltagging   70.522s
```