### PR TITLE
Allow volume update when in-use

### DIFF
--- a/ibm/resource_ibm_pi_instance.go
+++ b/ibm/resource_ibm_pi_instance.go
@@ -582,7 +582,7 @@ func resourceIBMPIInstanceRead(d *schema.ResourceData, meta interface{}) error {
 	if powervmdata.StorageType != nil {
 		d.Set(helpers.PIInstanceStorageType, powervmdata.StorageType)
 	}
-	d.Set(helpers.PIInstanceStoragePool, powervmdata.StoragePool)
+	d.Set(PIInstanceStoragePool, powervmdata.StoragePool)
 	d.Set(helpers.PICloudInstanceId, powerinstanceid)
 	d.Set("instance_id", powervmdata.PvmInstanceID)
 	d.Set(helpers.PIInstanceName, powervmdata.ServerName)

--- a/ibm/resource_ibm_pi_volume_test.go
+++ b/ibm/resource_ibm_pi_volume_test.go
@@ -31,6 +31,16 @@ func TestAccIBMPIVolumebasic(t *testing.T) {
 						"ibm_pi_volume.power_volume", "pi_volume_name", name),
 				),
 			},
+			{
+				Config: testAccCheckIBMPIVolumeSizeConfig(name),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckIBMPIVolumeExists("ibm_pi_volume.power_volume"),
+					resource.TestCheckResourceAttr(
+						"ibm_pi_volume.power_volume", "pi_volume_name", name),
+					resource.TestCheckResourceAttr(
+						"ibm_pi_volume.power_volume", "pi_volume_size", "30"),
+				),
+			},
 		},
 	})
 }
@@ -102,6 +112,18 @@ func testAccCheckIBMPIVolumeConfig(name string) string {
 	`, name, pi_cloud_instance_id)
 }
 
+func testAccCheckIBMPIVolumeSizeConfig(name string) string {
+	return fmt.Sprintf(`
+	resource "ibm_pi_volume" "power_volume"{
+		pi_volume_size       = 30
+		pi_volume_name       = "%s"
+		pi_volume_type       = "tier1"
+		pi_volume_shareable  = true
+		pi_cloud_instance_id = "%s"
+	  }
+	`, name, pi_cloud_instance_id)
+}
+
 func TestAccIBMPIVolumePool(t *testing.T) {
 	name := fmt.Sprintf("tf-pi-volume-%d", acctest.RandIntRange(10, 100))
 	resource.Test(t, resource.TestCase{
@@ -122,6 +144,7 @@ func TestAccIBMPIVolumePool(t *testing.T) {
 		},
 	})
 }
+
 func testAccCheckIBMPIVolumePoolConfig(name string) string {
 	return fmt.Sprintf(`
 	resource "ibm_pi_volume" "power_volume"{


### PR DESCRIPTION
Signed-off-by: Yussuf Shaikh <yussuf.shaikh@ibm.com>

<!--- See what makes a good Pull Request at : https://github.com/IBM-Cloud/terraform-provider-ibm/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #3322

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
=== RUN   TestAccIBMPIVolumebasic
--- PASS: TestAccIBMPIVolumebasic (494.91s)
PASS

...
```
