### PR TITLE
Add support for VTL

### DIFF
--- a/ibm/data_source_ibm_pi_catalog_images.go
+++ b/ibm/data_source_ibm_pi_catalog_images.go
@@ -119,24 +119,22 @@ func dataSourceIBMPICatalogImagesRead(d *schema.ResourceData, meta interface{}) 
 	if err != nil {
 		return err
 	}
-	sap := false
-	vtl := false
 	powerinstanceid := d.Get(helpers.PICloudInstanceId).(string)
-	if v, ok := d.GetOk("sap"); ok {
-		sap = v.(bool)
+	includeSAP := false
+	if s, ok := d.GetOk("sap"); ok {
+		includeSAP = s.(bool)
 	}
+	includeVTL := false
 	if v, ok := d.GetOk("vtl"); ok {
-		vtl = v.(bool)
+		includeVTL = v.(bool)
 	}
-
 	imageC := instance.NewIBMPIImageClient(sess, powerinstanceid)
-	result, err := imageC.GetAllStockImages(powerinstanceid, sap, vtl)
+	stockImages, err := imageC.GetAllStockImages(powerinstanceid, includeSAP, includeVTL)
 	if err != nil {
 		return err
 	}
-	imageData := result.Images
 	images := make([]map[string]interface{}, 0)
-	for _, i := range imageData {
+	for _, i := range stockImages.Images {
 		image := make(map[string]interface{})
 		image["image_id"] = *i.ImageID
 		image["name"] = *i.Name

--- a/ibm/data_source_ibm_pi_catalog_images_test.go
+++ b/ibm/data_source_ibm_pi_catalog_images_test.go
@@ -10,27 +10,98 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 )
 
-func TestAccIBMPICatalogImagesDataSource_basic(t *testing.T) {
+func testAccCheckIBMPICatalogImagesDataSourceBasicConfig() string {
+	return fmt.Sprintf(`
+	data "ibm_pi_catalog_images" "power_catalog_images_basic" {
+		pi_cloud_instance_id = "%s"
+	}
+	`, pi_cloud_instance_id)
+}
 
+func testAccCheckIBMPICatalogImagesDataSourceSAPConfig() string {
+	return fmt.Sprintf(`
+	data "ibm_pi_catalog_images" "power_catalog_images_sap" {
+		pi_cloud_instance_id = "%s"
+		sap = "true"
+	}
+	`, pi_cloud_instance_id)
+}
+
+func testAccCheckIBMPICatalogImagesDataSourceVTLConfig() string {
+	return fmt.Sprintf(`
+	data "ibm_pi_catalog_images" "power_catalog_images_vtl" {
+		pi_cloud_instance_id = "%s"
+		vtl = "true"
+	}
+	`, pi_cloud_instance_id)
+}
+
+func testAccCheckIBMPICatalogImagesDataSourceSAP_And_VTLConfig() string {
+	return fmt.Sprintf(`
+	data "ibm_pi_catalog_images" "power_catalog_images_sap_and_vtl" {
+		pi_cloud_instance_id = "%s"
+		sap = "true"
+		vtl = "true"
+	}
+	`, pi_cloud_instance_id)
+}
+
+func TestAccIBMPICatalogImagesDataSourceBasic(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t) },
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckIBMPICatalogImagesDataSourceConfig(),
+				Config: testAccCheckIBMPICatalogImagesDataSourceBasicConfig(),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttrSet("data.ibm_pi_catalog_images.power_catalog_images", "id"),
+					resource.TestCheckResourceAttrSet("data.ibm_pi_catalog_images.power_catalog_images_basic", "id"),
 				),
 			},
 		},
 	})
 }
 
-func testAccCheckIBMPICatalogImagesDataSourceConfig() string {
-	return fmt.Sprintf(`
-	
-data "ibm_pi_catalog_images" "power_catalog_images" {
-    pi_cloud_instance_id = "%s"
-}`, pi_cloud_instance_id)
+func TestAccIBMPICatalogImagesDataSourceSAP(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckIBMPICatalogImagesDataSourceSAPConfig(),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet("data.ibm_pi_catalog_images.power_catalog_images_sap", "id"),
+				),
+			},
+		},
+	})
+}
 
+func TestAccIBMPICatalogImagesDataSourceVTL(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckIBMPICatalogImagesDataSourceVTLConfig(),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet("data.ibm_pi_catalog_images.power_catalog_images_vtl", "id"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccIBMPICatalogImagesDataSourceSAPAndVTL(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckIBMPICatalogImagesDataSourceSAP_And_VTLConfig(),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet("data.ibm_pi_catalog_images.power_catalog_images_sap_and_vtl", "id"),
+				),
+			},
+		},
+	})
 }

--- a/ibm/data_source_ibm_pi_image.go
+++ b/ibm/data_source_ibm_pi_image.go
@@ -58,6 +58,10 @@ func dataSourceIBMPIImage() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
+			"image_type": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
 		},
 	}
 }
@@ -87,6 +91,7 @@ func dataSourceIBMPIImagesRead(d *schema.ResourceData, meta interface{}) error {
 	d.Set("operatingsystem", imagedata.Specifications.OperatingSystem)
 	d.Set("storage_type", imagedata.StorageType)
 	d.Set("storage_pool", imagedata.StoragePool)
+	d.Set("image_type", imagedata.Specifications.ImageType)
 
 	return nil
 

--- a/ibm/data_source_ibm_pi_images.go
+++ b/ibm/data_source_ibm_pi_images.go
@@ -24,13 +24,6 @@ func dataSourceIBMPIImages() *schema.Resource {
 		Read: dataSourceIBMPIImagesAllRead,
 		Schema: map[string]*schema.Schema{
 
-			helpers.PIImageName: {
-				Type:         schema.TypeString,
-				Optional:     true,
-				Description:  "Imagename Name to be used for pvminstances",
-				ValidateFunc: validation.NoZeroValues,
-				Deprecated:   "This field is deprectaed.",
-			},
 			helpers.PICloudInstanceId: {
 				Type:         schema.TypeString,
 				Required:     true,
@@ -65,6 +58,10 @@ func dataSourceIBMPIImages() *schema.Resource {
 							Computed: true,
 						},
 						"storage_pool": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"image_type": {
 							Type:     schema.TypeString,
 							Computed: true,
 						},
@@ -112,6 +109,7 @@ func flattenStockImages(list []*models.ImageReference) []map[string]interface{} 
 			"name":         *i.Name,
 			"storage_type": *i.StorageType,
 			"storage_pool": *i.StoragePool,
+			"image_type":   i.Specifications.ImageType,
 		}
 
 		result = append(result, l)

--- a/ibm/data_source_ibm_pi_instance.go
+++ b/ibm/data_source_ibm_pi_instance.go
@@ -176,10 +176,8 @@ func dataSourceIBMPIInstancesRead(d *schema.ResourceData, meta interface{}) erro
 	d.Set("min_virtual_cores", powervmdata.VirtualCores.Min)
 	d.Set("storage_type", powervmdata.StorageType)
 	d.Set("storage_pool", powervmdata.StoragePool)
+	d.Set("license_repository_capacity", powervmdata.LicenseRepositoryCapacity)
 
-	if &powervmdata.LicenseRepositoryCapacity != nil {
-		d.Set("license_repository_capacity", powervmdata.LicenseRepositoryCapacity)
-	}
 	if powervmdata.Addresses != nil {
 		pvmaddress := make([]map[string]interface{}, len(powervmdata.Addresses))
 		for i, pvmip := range powervmdata.Addresses {

--- a/ibm/data_source_ibm_pi_instance.go
+++ b/ibm/data_source_ibm_pi_instance.go
@@ -134,6 +134,10 @@ func dataSourceIBMPIInstance() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
+			"license_repository_capacity": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
 		},
 	}
 }
@@ -173,6 +177,9 @@ func dataSourceIBMPIInstancesRead(d *schema.ResourceData, meta interface{}) erro
 	d.Set("storage_type", powervmdata.StorageType)
 	d.Set("storage_pool", powervmdata.StoragePool)
 
+	if &powervmdata.LicenseRepositoryCapacity != nil {
+		d.Set("license_repository_capacity", powervmdata.LicenseRepositoryCapacity)
+	}
 	if powervmdata.Addresses != nil {
 		pvmaddress := make([]map[string]interface{}, len(powervmdata.Addresses))
 		for i, pvmip := range powervmdata.Addresses {

--- a/ibm/resource_ibm_pi_instance.go
+++ b/ibm/resource_ibm_pi_instance.go
@@ -540,7 +540,7 @@ func resourceIBMPIInstanceCreate(d *schema.ResourceData, meta interface{}) error
 		if imageData.Specifications.ImageType == "stock-vtl" {
 			body.LicenseRepositoryCapacity = int64(lrc.(int))
 		} else {
-			return fmt.Errorf("license_repository_capacity should only be used when creating VTL instances. %e", err)
+			return fmt.Errorf("pi_license_repository_capacity should only be used when creating VTL instances. %e", err)
 		}
 	}
 	client := st.NewIBMPIInstanceClient(sess, powerinstanceid)
@@ -687,13 +687,9 @@ func resourceIBMPIInstanceRead(d *schema.ResourceData, meta interface{}) error {
 	if &powervmdata.VirtualCores.Min != nil {
 		d.Set("min_virtual_cores", powervmdata.VirtualCores.Min)
 	}
-	// if &powervmdata.LicenseRepositoryCapacity != nil {
-	// 	d.Set("license_repository_capacity", powervmdata.LicenseRepositoryCapacity)
-	// }
-	d.Set("license_repository_capacity", powervmdata.LicenseRepositoryCapacity)
+	d.Set(helpers.PIInstanceLicenseRepositoryCapacity, powervmdata.LicenseRepositoryCapacity)
 
 	return nil
-
 }
 
 func resourceIBMPIInstanceUpdate(d *schema.ResourceData, meta interface{}) error {

--- a/ibm/resource_ibm_pi_instance.go
+++ b/ibm/resource_ibm_pi_instance.go
@@ -691,9 +691,10 @@ func resourceIBMPIInstanceRead(d *schema.ResourceData, meta interface{}) error {
 	if &powervmdata.VirtualCores.Min != nil {
 		d.Set("min_virtual_cores", powervmdata.VirtualCores.Min)
 	}
-	if &powervmdata.LicenseRepositoryCapacity != nil {
-		d.Set("license_repository_capacity", powervmdata.LicenseRepositoryCapacity)
-	}
+	// if &powervmdata.LicenseRepositoryCapacity != nil {
+	// 	d.Set("license_repository_capacity", powervmdata.LicenseRepositoryCapacity)
+	// }
+	d.Set("license_repository_capacity", powervmdata.LicenseRepositoryCapacity)
 
 	return nil
 
@@ -849,7 +850,7 @@ func resourceIBMPIInstanceUpdate(d *schema.ResourceData, meta interface{}) error
 	}
 
 	// License repository capacity will be updated only if service instance is a vtl instance
-	// might need to check if lrc was ser
+	// might need to check if lrc was set
 	if d.HasChange(helpers.PIInstanceLicenseRepositoryCapacity) {
 
 		lrc := d.Get(helpers.PIInstanceLicenseRepositoryCapacity).(int64)

--- a/ibm/resource_ibm_pi_instance.go
+++ b/ibm/resource_ibm_pi_instance.go
@@ -60,10 +60,6 @@ func resourceIBMPIInstance() *schema.Resource {
 			helpers.PIInstanceLicenseRepositoryCapacity: {
 				Type:        schema.TypeInt,
 				Optional:    true,
-				Description: "The VTL license repository capacity TB value",
-			},
-			"license_repository_capacity": {
-				Type:        schema.TypeInt,
 				Computed:    true,
 				Description: "The VTL license repository capacity TB value",
 			},

--- a/ibm/resource_ibm_pi_instance_test.go
+++ b/ibm/resource_ibm_pi_instance_test.go
@@ -212,8 +212,7 @@ func TestAccIBMPIInstanceVTL(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckIBMPIInstanceExists(instanceRes),
 					resource.TestCheckResourceAttr(instanceRes, "pi_instance_name", name),
-					resource.TestCheckResourceAttrSet(instanceRes, "license_repository_capacity"),
-					resource.TestCheckResourceAttr(instanceRes, "license_repository_capacity", "3"),
+					resource.TestCheckResourceAttr(instanceRes, "pi_license_repository_capacity", "3"),
 				),
 			},
 		},

--- a/ibm/resource_ibm_pi_instance_test.go
+++ b/ibm/resource_ibm_pi_instance_test.go
@@ -15,25 +15,92 @@ import (
 	st "github.com/IBM-Cloud/power-go-client/clients/instance"
 )
 
-func TestAccIBMPIInstancebasic(t *testing.T) {
-
-	name := fmt.Sprintf("tf-pi-instance-%d", acctest.RandIntRange(10, 100))
-	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckIBMPIInstanceDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccCheckIBMPIInstanceConfig(name),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckIBMPIInstanceExists("ibm_pi_instance.power_instance"),
-					resource.TestCheckResourceAttr(
-						"ibm_pi_instance.power_instance", "pi_instance_name", name),
-				),
-			},
-		},
-	})
+func testAccCheckIBMPIInstanceConfig(name string) string {
+	return fmt.Sprintf(`
+	resource "ibm_pi_key" "key" {
+		pi_cloud_instance_id = "%[1]s"
+		pi_key_name          = "%[2]s"
+		pi_ssh_key           = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCKVmnMOlHKcZK8tpt3MP1lqOLAcqcJzhsvJcjscgVERRN7/9484SOBJ3HSKxxNG5JN8owAjy5f9yYwcUg+JaUVuytn5Pv3aeYROHGGg+5G346xaq3DAwX6Y5ykr2fvjObgncQBnuU5KHWCECO/4h8uWuwh/kfniXPVjFToc+gnkqA+3RKpAecZhFXwfalQ9mMuYGFxn+fwn8cYEApsJbsEmb0iJwPiZ5hjFC8wREuiTlhPHDgkBLOiycd20op2nXzDbHfCHInquEe/gYxEitALONxm0swBOwJZwlTDOB7C6y2dzlrtxr1L59m7pCkWI4EtTRLvleehBoj3u7jB4usR"
+	  }
+	  
+	  resource "ibm_pi_volume" "power_volume" {
+		pi_volume_size       = 20
+		pi_volume_name       = "%[2]s"
+		pi_volume_type       = "tier3"
+		pi_volume_shareable  = true
+		pi_cloud_instance_id = "%[1]s"
+	  }
+	  resource "ibm_pi_instance" "power_instance" {
+		pi_memory             = "4"
+		pi_processors         = "2"
+		pi_instance_name      = "%[2]s"
+		pi_proc_type          = "shared"
+		pi_image_id           = "f4501cad-d0f4-4517-9eea-85402309d90d"
+		pi_network_ids        = ["1bfad140-588f-45d3-aaaa-a3f0abbd441f"]
+		pi_key_pair_name      = ibm_pi_key.key.key_id
+		pi_sys_type           = "s922"
+		pi_cloud_instance_id  = "%[1]s"
+		pi_volume_ids         = [ibm_pi_volume.power_volume.volume_id]
+	  }
+	`, pi_cloud_instance_id, name)
 }
+
+func testAccIBMPIInstanceNetworkConfig(name, privateNetIP string) string {
+	return fmt.Sprintf(`
+	resource "ibm_pi_key" "key" {
+		pi_cloud_instance_id = "%[1]s"
+		pi_key_name          = "%[2]s"
+		pi_ssh_key           = "ssh-rsa AAAAB3NzaC1yc2EAAAABJQAAAQEArb2aK0mekAdbYdY9rwcmeNSxqVCwez3WZTYEq+1Nwju0x5/vQFPSD2Kp9LpKBbxx3OVLN4VffgGUJznz9DAr7veLkWaf3iwEil6U4rdrhBo32TuDtoBwiczkZ9gn1uJzfIaCJAJdnO80Kv9k0smbQFq5CSb9H+F5VGyFue/iVd5/b30MLYFAz6Jg1GGWgw8yzA4Gq+nO7HtyuA2FnvXdNA3yK/NmrTiPCdJAtEPZkGu9LcelkQ8y90ArlKfjtfzGzYDE4WhOufFxyWxciUePh425J2eZvElnXSdGha+FCfYjQcvqpCVoBAG70U4fJBGjB+HL/GpCXLyiYXPrSnzC9w=="
+	}
+	resource "ibm_pi_instance" "power_instance" {
+		pi_memory             = "2"
+		pi_processors         = "0.25"
+		pi_instance_name      = "%[2]s"
+		pi_proc_type          = "shared"
+		pi_image_id           = "f4501cad-d0f4-4517-9eea-85402309d90d"
+		pi_key_pair_name      = ibm_pi_key.key.key_id
+		pi_sys_type           = "e980"
+		pi_storage_type 	  = "tier3"
+		pi_cloud_instance_id  = "%[1]s"
+		pi_network {
+			network_id = "tf-cloudconnection-23"
+			ip_address = "%[3]s"
+		}
+	}
+	`, pi_cloud_instance_id, name, privateNetIP)
+}
+
+func testAccIBMPIInstanceVTLConfig(name string) string {
+	return fmt.Sprintf(`
+	resource "ibm_pi_key" "vtl_key" {
+		pi_cloud_instance_id = "%[1]s"
+		pi_key_name          = "%[2]s"
+		pi_ssh_key           = "ssh-rsa AAAAB3NzaC1yc2EAAAABJQAAAQEArb2aK0mekAdbYdY9rwcmeNSxqVCwez3WZTYEq+1Nwju0x5/vQFPSD2Kp9LpKBbxx3OVLN4VffgGUJznz9DAr7veLkWaf3iwEil6U4rdrhBo32TuDtoBwiczkZ9gn1uJzfIaCJAJdnO80Kv9k0smbQFq5CSb9H+F5VGyFue/iVd5/b30MLYFAz6Jg1GGWgw8yzA4Gq+nO7HtyuA2FnvXdNA3yK/NmrTiPCdJAtEPZkGu9LcelkQ8y90ArlKfjtfzGzYDE4WhOufFxyWxciUePh425J2eZvElnXSdGha+FCfYjQcvqpCVoBAG70U4fJBGjB+HL/GpCXLyiYXPrSnzC9w=="
+	}
+	
+	resource "ibm_pi_network" "vtl_network" {
+		pi_cloud_instance_id = "%[1]s"
+		pi_network_name      = "%[2]s"
+		pi_network_type      = "pub-vlan"
+	}
+
+	resource "ibm_pi_instance" "vtl_instance" {
+		pi_memory             = "22"
+		pi_processors         = "2"
+		pi_instance_name      = "%[2]s"
+		pi_license_repository_capacity = "3"
+		pi_proc_type          = "shared"
+		pi_image_id           = "ca4ea55f-b329-4cf5-bdce-d2f38cfc6da3"
+		pi_network_ids        = [ibm_pi_network.vtl_network.network_id]
+		pi_key_pair_name      = ibm_pi_key.vtl_key.key_id
+		pi_sys_type           = "s922"
+		pi_cloud_instance_id  = "%[1]s"
+		pi_storage_type 	  = "tier1"
+	  }
+	
+	`, pi_cloud_instance_id, name)
+}
+
 func testAccCheckIBMPIInstanceDestroy(s *terraform.State) error {
 
 	sess, err := testAccProvider.Meta().(ClientSession).IBMPISession()
@@ -89,43 +156,23 @@ func testAccCheckIBMPIInstanceExists(n string) resource.TestCheckFunc {
 	}
 }
 
-func testAccCheckIBMPIInstanceConfig(name string) string {
-	return fmt.Sprintf(`
-	resource "ibm_pi_key" "key" {
-		pi_cloud_instance_id = "%[1]s"
-		pi_key_name          = "%[2]s"
-		pi_ssh_key           = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCKVmnMOlHKcZK8tpt3MP1lqOLAcqcJzhsvJcjscgVERRN7/9484SOBJ3HSKxxNG5JN8owAjy5f9yYwcUg+JaUVuytn5Pv3aeYROHGGg+5G346xaq3DAwX6Y5ykr2fvjObgncQBnuU5KHWCECO/4h8uWuwh/kfniXPVjFToc+gnkqA+3RKpAecZhFXwfalQ9mMuYGFxn+fwn8cYEApsJbsEmb0iJwPiZ5hjFC8wREuiTlhPHDgkBLOiycd20op2nXzDbHfCHInquEe/gYxEitALONxm0swBOwJZwlTDOB7C6y2dzlrtxr1L59m7pCkWI4EtTRLvleehBoj3u7jB4usR"
-	  }
-	  resource "ibm_pi_image" "power_image" {
-		pi_image_name       = "%[2]s"
-		pi_image_id         = "f31da27a-b634-45e5-913a-3f4d964e5a02"
-		pi_cloud_instance_id = "%[1]s"
-	  }
-	  resource "ibm_pi_network" "power_networks" {
-		pi_cloud_instance_id = "%[1]s"
-		pi_network_name      = "%[2]s"
-		pi_network_type      = "pub-vlan"
-	  }
-	  resource "ibm_pi_volume" "power_volume" {
-		pi_volume_size       = 20
-		pi_volume_name       = "%[2]s"
-		pi_volume_type       = "tier1"
-		pi_volume_shareable  = true
-		pi_cloud_instance_id = "%[1]s"
-	  }
-	  resource "ibm_pi_instance" "power_instance" {
-		pi_memory             = "4"
-		pi_processors         = "2"
-		pi_instance_name      = "%[2]s"
-		pi_proc_type          = "shared"
-		pi_image_id           = ibm_pi_image.power_image.image_id
-		pi_network_ids        = [ibm_pi_network.power_networks.network_id]
-		pi_key_pair_name      = ibm_pi_key.key.key_id
-		pi_sys_type           = "s922"
-		pi_cloud_instance_id  = "%[1]s"
-		pi_volume_ids         = [ibm_pi_volume.power_volume.volume_id]
-	  }
-	`, pi_cloud_instance_id, name)
+func TestAccIBMPIInstanceBasic(t *testing.T) {
+	instanceRes := "ibm_pi_instance.power_instance"
+	name := fmt.Sprintf("tf-pi-instance-%d", acctest.RandIntRange(10, 100))
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckIBMPIInstanceDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckIBMPIInstanceConfig(name),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckIBMPIInstanceExists(instanceRes),
+					resource.TestCheckResourceAttr(instanceRes, "pi_instance_name", name),
+				),
+			},
+		},
+	})
 }
 
 func TestAccIBMPIInstanceNetwork(t *testing.T) {
@@ -152,27 +199,23 @@ func TestAccIBMPIInstanceNetwork(t *testing.T) {
 	})
 }
 
-func testAccIBMPIInstanceNetworkConfig(name, privateNetIP string) string {
-	return fmt.Sprintf(`
-	resource "ibm_pi_key" "key" {
-		pi_cloud_instance_id = "%[1]s"
-		pi_key_name          = "%[2]s"
-		pi_ssh_key           = "ssh-rsa AAAAB3NzaC1yc2EAAAABJQAAAQEArb2aK0mekAdbYdY9rwcmeNSxqVCwez3WZTYEq+1Nwju0x5/vQFPSD2Kp9LpKBbxx3OVLN4VffgGUJznz9DAr7veLkWaf3iwEil6U4rdrhBo32TuDtoBwiczkZ9gn1uJzfIaCJAJdnO80Kv9k0smbQFq5CSb9H+F5VGyFue/iVd5/b30MLYFAz6Jg1GGWgw8yzA4Gq+nO7HtyuA2FnvXdNA3yK/NmrTiPCdJAtEPZkGu9LcelkQ8y90ArlKfjtfzGzYDE4WhOufFxyWxciUePh425J2eZvElnXSdGha+FCfYjQcvqpCVoBAG70U4fJBGjB+HL/GpCXLyiYXPrSnzC9w=="
-	}
-	resource "ibm_pi_instance" "power_instance" {
-		pi_memory             = "2"
-		pi_processors         = "0.25"
-		pi_instance_name      = "%[2]s"
-		pi_proc_type          = "shared"
-		pi_image_id           = "f4501cad-d0f4-4517-9eea-85402309d90d"
-		pi_key_pair_name      = ibm_pi_key.key.key_id
-		pi_sys_type           = "e980"
-		pi_storage_type 	  = "tier3"
-		pi_cloud_instance_id  = "%[1]s"
-		pi_network {
-			network_id = "tf-cloudconnection-23"
-			ip_address = "%[3]s"
-		}
-	}
-	`, pi_cloud_instance_id, name, privateNetIP)
+func TestAccIBMPIInstanceVTL(t *testing.T) {
+	instanceRes := "ibm_pi_instance.vtl_instance"
+	name := fmt.Sprintf("tf-pi-vtl-instance-%d", acctest.RandIntRange(10, 100))
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckIBMPIInstanceDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccIBMPIInstanceVTLConfig(name),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckIBMPIInstanceExists(instanceRes),
+					resource.TestCheckResourceAttr(instanceRes, "pi_instance_name", name),
+					resource.TestCheckResourceAttrSet(instanceRes, "license_repository_capacity"),
+					resource.TestCheckResourceAttr(instanceRes, "license_repository_capacity", "3"),
+				),
+			},
+		},
+	})
 }

--- a/website/docs/d/pi_catalog_images.html.markdown
+++ b/website/docs/d/pi_catalog_images.html.markdown
@@ -37,8 +37,8 @@ data "ibm_pi_catalog_images" "ds_images" {
 Review the argument reference that you can specify for your data source. 
 
 - `pi_cloud_instance_id` - (Required, String) The GUID of the service instance associated with an account.
-- `sap` - (Required, Bool) Include SAP images with available stock images.
-- `vtl` - (Required, Bool) Include VTL images with available stock images.
+- `sap` - (Optional, Bool) Set `true` to include SAP images. The default value is `false`.
+- `vtl` - (Optional, Bool) Set `true` to include VTL images. The default value is `false`.
 
 ## Attribute reference
 In addition to the argument reference list, you can access the following attribute references after your data source is created.

--- a/website/docs/d/pi_image.html.markdown
+++ b/website/docs/d/pi_image.html.markdown
@@ -50,3 +50,4 @@ In addition to all argument reference list, you can access the following attribu
 - `state` - (String) The state for this image. 
 - `storage_type` - (String) The storage type for this image.
 - `storage_pool` - (String) Storage pool where image resides.
+- `image_type` - (String) The identifier of this image type.

--- a/website/docs/d/pi_images.html.markdown
+++ b/website/docs/d/pi_images.html.markdown
@@ -45,8 +45,9 @@ In addition to all argument reference list, you can access the following attribu
 
   Nested scheme for `image_info`:
 	- `href` - (String) The hyper link of an image. 
-	- `id` - (String) The unique identifier of an image. 
-	- `name`-  (String) The name of an image.
+	- `id` - (String) The unique identifier of an image.
+   - `name`-  (String) The name of an image.
 	- `state` - (String) The state of an image.
 	- `storage_pool` - (String) Storage pool where image resides.
 	- `storage_type` - (String) The storage type of an image.
+  - `image_type` - (String) The identifier of this image type.

--- a/website/docs/d/pi_instance.html.markdown
+++ b/website/docs/d/pi_instance.html.markdown
@@ -54,6 +54,7 @@ In addition to all argument reference list, you can access the following attribu
 - `maxmem`- (Float) The maximum amount of memory that can be allocated to the instance without shutting down or rebooting the `LPAR`.
 - `min_virtual_cores` - (Integer) The minimum cores assigned to an instance.
 - `addresses` - List of objects - The address associated with this instance.
+- `license_repository_capacity` - The VTL license repository capacity TB value. Only available with VTL instances.
 
   Nested scheme for `addresses`:
   - `ip` - (String) The IP address of the instance.

--- a/website/docs/r/pi_instance.html.markdown
+++ b/website/docs/r/pi_instance.html.markdown
@@ -112,7 +112,6 @@ In addition to all argument reference list, you can access the following attribu
 - `min_memory` - (Float) The minimum memory that was allocated to the instance.
 - `max_memory`- (Float) The maximum amount of memory that can be allocated to the instance without shut down or reboot the `LPAR`.
 - `min_virtual_cores` - (Integer) The minimum number of virtual cores.
-- `pi_license_repository_capacity` - (Integer) The VTL license repository capacity TB value. Only available with VTL instances.
 - `status` - (String) The status of the instance.
 - `pin_policy`  - (String) The pinning policy of the instance.
 - `progress` - (Float) - Specifies the overall progress of the instance deployment process in percentage.

--- a/website/docs/r/pi_instance.html.markdown
+++ b/website/docs/r/pi_instance.html.markdown
@@ -112,7 +112,7 @@ In addition to all argument reference list, you can access the following attribu
 - `min_memory` - (Float) The minimum memory that was allocated to the instance.
 - `max_memory`- (Float) The maximum amount of memory that can be allocated to the instance without shut down or reboot the `LPAR`.
 - `min_virtual_cores` - (Integer) The minimum number of virtual cores.
-- `license_repository_capacity` - (Integer) The VTL license repository capacity TB value. Only available with VTL instances.
+- `pi_license_repository_capacity` - (Integer) The VTL license repository capacity TB value. Only available with VTL instances.
 - `status` - (String) The status of the instance.
 - `pin_policy`  - (String) The pinning policy of the instance.
 - `progress` - (Float) - Specifies the overall progress of the instance deployment process in percentage.

--- a/website/docs/r/pi_instance.html.markdown
+++ b/website/docs/r/pi_instance.html.markdown
@@ -64,9 +64,10 @@ Review the argument references that you can specify for your resource.
 - `pi_anti_affinity_volumes`- (Optional, String) List of volumes to base storage anti-affinity policy against; required if requesting `anti-affinity` and `pi_anti_affinity_instances` is not provided.
 - `pi_cloud_instance_id` - (Required, String) The GUID of the service instance associated with an account.
 - `pi_health_status` - (Optional, String) Specifies if Terraform should poll for the health status to be `OK` or `WARNING`. The default value is `OK`.
-- `pi_image_id` - (Required, String) The ID of the image that you want to use for your Power Systems Virtual Server instance. The image determines the operating system that is installed in your instance. To list available images, run the `ibmcloud pi images` command.
+- `pi_image_id` - (Required, String) The ID of the image that you want to use for your Power Systems Virtual Server instance. The image determines the operating system that is installed in your instance. To list available images, run the `ibmcloud pi images` command. To provision a VTL instance you must use a VTL image. To list available catalog VTL images, run the `ibmcloud pi image-list-catalog` command.
 - `pi_instance_name` - (Required, String) The name of the Power Systems Virtual Server instance. 
 - `pi_key_pair_name` - (Required, String) The name of the SSH key that you want to use to access your Power Systems Virtual Server instance. The SSH key must be uploaded to IBM Cloud.
+- `pi_license_repository_capacity` - (Optional, Integer) The VTL license repository capacity TB value. Only use with VTL instances. `pi_memory >= 16 + (2 * pi_license_repository_capacity)`.
 - `pi_memory` - (Required, Float) The amount of memory that you want to assign to your instance in gigabytes.
 - `pi_migratable`- (Optional, Bool) Indicates the VM is migrated or not.
 - `pi_network_ids` - (Required, List of String) The list of network IDs that you want to assign to the instance. This attribute is **Deprecated** use `pi_network` instead.
@@ -111,6 +112,7 @@ In addition to all argument reference list, you can access the following attribu
 - `min_memory` - (Float) The minimum memory that was allocated to the instance.
 - `max_memory`- (Float) The maximum amount of memory that can be allocated to the instance without shut down or reboot the `LPAR`.
 - `min_virtual_cores` - (Integer) The minimum number of virtual cores.
+- `license_repository_capacity` - (Integer) The VTL license repository capacity TB value. Only available with VTL instances.
 - `status` - (String) The status of the instance.
 - `pin_policy`  - (String) The pinning policy of the instance.
 - `progress` - (Float) - Specifies the overall progress of the instance deployment process in percentage.


### PR DESCRIPTION
Signed-off-by: Chase Austin [chase@ibm.com](mailto:chase@ibm.com)
### Community Note
* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

Output from acceptance testing:
```
=== RUN   TestAccIBMPIInstanceBasic
--- PASS: TestAccIBMPIInstanceBasic (1032.71s)
PASS
=== RUN   TestAccIBMPIInstanceNetwork
--- PASS: TestAccIBMPIInstanceNetwork (1001.32s)
PASS
=== RUN   TestAccIBMPIInstanceVTL
--- PASS: TestAccIBMPIInstanceVTL (754.28s)
PASS

=== RUN   TestAccIBMPICatalogImagesDataSourceBasic
--- PASS: TestAccIBMPICatalogImagesDataSourceBasic (11.74s)
PASS
=== RUN   TestAccIBMPICatalogImagesDataSourceSAP
--- PASS: TestAccIBMPICatalogImagesDataSourceSAP (10.89s)
PASS
=== RUN   TestAccIBMPICatalogImagesDataSourceVTL
--- PASS: TestAccIBMPICatalogImagesDataSourceVTL (10.40s)
PASS
=== RUN   TestAccIBMPICatalogImagesDataSourceSAPAndVTL
--- PASS: TestAccIBMPICatalogImagesDataSourceSAPAndVTL (10.40s)
PASS
...
```