### PR TITLE
fix: set network acl in subnet network acl attachment

### DIFF
--- a/ibm/resource_ibm_is_subnet_network_acl_attachment.go
+++ b/ibm/resource_ibm_is_subnet_network_acl_attachment.go
@@ -246,6 +246,7 @@ func resourceIBMISSubnetNetworkACLAttachmentRead(d *schema.ResourceData, meta in
 	d.Set(isNetworkACLName, *nwacl.Name)
 	d.Set(isNetworkACLCRN, *nwacl.CRN)
 	d.Set(isNetworkACLVPC, *nwacl.VPC.ID)
+	d.Set(isNetworkACLID, *nwacl.ID)
 	if nwacl.ResourceGroup != nil {
 		d.Set(isNetworkACLResourceGroup, *nwacl.ResourceGroup.ID)
 	}


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/IBM-Cloud/terraform-provider-ibm/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #3277

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
=== RUN   TestAccIBMISSubnetNetworkACLAttachment_basic
--- PASS: TestAccIBMISSubnetNetworkACLAttachment_basic (116.18s)
PASS
ok      github.com/IBM-Cloud/terraform-provider-ibm/ibm 119.621s
```
