### PR TITLE
IBM SCC SI - Docs Correction

### DIFF
--- a/website/docs/d/scc_si_notes.html.markdown
+++ b/website/docs/d/scc_si_notes.html.markdown
@@ -14,7 +14,7 @@ Provides a read-only data source for scc_si_notes. You can then reference the fi
 
 ```hcl
 data "ibm_scc_si_notes" "notes" {
-  page_size = 3
+  provider_id = "tf-test"
 }
 ```
 
@@ -23,6 +23,7 @@ data "ibm_scc_si_notes" "notes" {
 Review the argument reference that you can specify for your data source.
 
 * `account_id` - (Optional, String) Account ID is optional, if not provided value will be inferred from the token retrieved from the IBM Cloud API key.
+* `provider_id` - (Required, Forces new resource, String) Part of the parent. This field contains the provider ID. For example: providers/{provider_id}.
 * `pages_size` - (Optional, String) Number of notes to return in the list.
 * `page_token` - (Optional, String) Token to provide to skip to a particular spot in the list.
 

--- a/website/docs/d/scc_si_occurrences.html.markdown
+++ b/website/docs/d/scc_si_occurrences.html.markdown
@@ -14,7 +14,7 @@ Provides a read-only data source for scc_si_occurences. You can then reference t
 
 ```hcl
 data "ibm_scc_si_occurences" "scc_si_occurences" {
-  page_size = 3
+  provider_id = "tf-test"
 }
 ```
 

--- a/website/docs/r/scc_si_note.html.markdown
+++ b/website/docs/r/scc_si_note.html.markdown
@@ -191,5 +191,5 @@ The `note_id` property can be formed from `account_id`, `provider_id`, and `note
 
 # Syntax
 ```
-$ terraform import ibm_scc_si_note.scc_si_note <provider_id>/<note_id>
+$ terraform import ibm_scc_si_note.scc_si_note <account_id>/<provider_id>/<note_id>
 ```

--- a/website/docs/r/scc_si_occurrence.html.markdown
+++ b/website/docs/r/scc_si_occurrence.html.markdown
@@ -1,14 +1,14 @@
 ---
 layout: "ibm"
 subcategory: "Security and Compliance Center"
-page_title: "IBM : ibm_scc_si_occurence"
+page_title: "IBM : ibm_scc_si_occurrence"
 description: |-
-  Manages scc_si_occurence.
+  Manages scc_si_occurrence.
 ---
 
-# ibm_scc_si_occurence
+# ibm_scc_si_occurrence
 
-Provides a resource for scc_si_occurence. This allows scc_si_occurence to be created, updated and deleted.
+Provides a resource for scc_si_occurrence. This allows scc_si_occurrence to be created, updated and deleted.
 
 ## Example Usage
 
@@ -94,7 +94,7 @@ Nested scheme for **finding**:
 		* `url` - (Optional, String) The URL associated to this next steps.
 	* `severity` - (Optional, String) Note provider-assigned severity/impact ranking- LOW&#58; Low Impact- MEDIUM&#58; Medium Impact- HIGH&#58; High Impact- CRITICAL&#58; Critical Impact.
 	  * Constraints: Allowable values are: `LOW`, `MEDIUM`, `HIGH`, `CRITICAL`.
-* `kind` - (Required, String) The type of note. Use this field to filter notes and occurences by kind. - FINDING&#58; The note and occurrence represent a finding. - KPI&#58; The note and occurrence represent a KPI value. - CARD&#58; The note represents a card showing findings and related metric values. - CARD_CONFIGURED&#58; The note represents a card configured for a user account. - SECTION&#58; The note represents a section in a dashboard.
+* `kind` - (Required, String) The type of note. Use this field to filter notes and occurrences by kind. - FINDING&#58; The note and occurrence represent a finding. - KPI&#58; The note and occurrence represent a KPI value. - CARD&#58; The note represents a card showing findings and related metric values. - CARD_CONFIGURED&#58; The note represents a card configured for a user account. - SECTION&#58; The note represents a section in a dashboard.
   * Constraints: Allowable values are: `FINDING`, `KPI`, `CARD`, `CARD_CONFIGURED`, `SECTION`.
 * `kpi` - (Optional, List) Kpi provides details about a KPI occurrence.
 Nested scheme for **kpi**:
@@ -112,13 +112,13 @@ Nested scheme for **kpi**:
 
 In addition to all argument references listed, you can access the following attribute references after your resource is created.
 
-* `id` - The unique identifier of the scc_si_occurence.
+* `id` - The unique identifier of the scc_si_occurrence.
 * `create_time` - (Optional, String) Output only. The time this `Occurrence` was created.
 * `update_time` - (Optional, String) Output only. The time this `Occurrence` was last updated.
 
 ## Import
 
-You can import the `ibm_scc_si_occurence` resource by using `id`.
+You can import the `ibm_scc_si_occurrence` resource by using `id`.
 The `id` property can be formed from `provider_id`, and `occurrence_id` in the following format:
 
 ```
@@ -130,5 +130,5 @@ The `id` property can be formed from `provider_id`, and `occurrence_id` in the f
 
 # Syntax
 ```
-$ terraform import ibm_scc_si_occurence.scc_si_occurence <provider_id>/<occurrence_id>
+$ terraform import ibm_scc_si_occurrence.scc_si_occurrence <account_id>/<provider_id>/<occurrence_id>
 ```


### PR DESCRIPTION
Community Note
Please vote on this pull request by adding a 👍 reaction to the original pull request comment to help the community and maintainers prioritize this request
Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request
Relates OR Closes #0

Output from acceptance testing:
```
$ make testacc TESTARGS='-run=TestAccIBMSccSi'
...

==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test $(go list ./... |grep -v 'vendor') -v -run=TestAccIBMSccSi -timeout 700m
?       github.com/IBM-Cloud/terraform-provider-ibm     [no test files]
=== RUN   TestAccIBMSccSiNoteDataSourceBasic
--- PASS: TestAccIBMSccSiNoteDataSourceBasic (23.33s)
=== RUN   TestAccIBMSccSiNoteDataSourceAllArgs
--- PASS: TestAccIBMSccSiNoteDataSourceAllArgs (19.71s)
=== RUN   TestAccIBMSccSiNotesDataSourceBasic
--- PASS: TestAccIBMSccSiNotesDataSourceBasic (22.57s)
=== RUN   TestAccIBMSccSiNotesDataSourceAllArgs
--- PASS: TestAccIBMSccSiNotesDataSourceAllArgs (18.37s)
=== RUN   TestAccIBMSccSiOccurrenceDataSourceBasic
--- PASS: TestAccIBMSccSiOccurrenceDataSourceBasic (25.62s)
=== RUN   TestAccIBMSccSiOccurrenceDataSourceAllArgs
--- PASS: TestAccIBMSccSiOccurrenceDataSourceAllArgs (25.42s)
=== RUN   TestAccIBMSccSiOccurrencesDataSourceBasic
--- PASS: TestAccIBMSccSiOccurrencesDataSourceBasic (28.71s)
=== RUN   TestAccIBMSccSiOccurrencesDataSourceAllArgs
--- PASS: TestAccIBMSccSiOccurrencesDataSourceAllArgs (25.12s)
=== RUN   TestAccIBMSccSiProvidersDataSourceBasic
--- PASS: TestAccIBMSccSiProvidersDataSourceBasic (14.71s)
=== RUN   TestAccIBMSccSiNoteCardNumeric
--- PASS: TestAccIBMSccSiNoteCardNumeric (16.07s)
=== RUN   TestAccIBMSccSiNoteCardBreakdown
--- PASS: TestAccIBMSccSiNoteCardBreakdown (17.04s)
=== RUN   TestAccIBMSccSiNoteCardTimeSeries
--- PASS: TestAccIBMSccSiNoteCardTimeSeries (18.55s)
=== RUN   TestAccIBMSccSiNoteBasic
--- PASS: TestAccIBMSccSiNoteBasic (31.36s)
=== RUN   TestAccIBMSccSiNoteAllArgs
--- PASS: TestAccIBMSccSiNoteAllArgs (33.84s)
=== RUN   TestAccIBMSccSiNoteInvalid
--- PASS: TestAccIBMSccSiNoteInvalid (0.77s)
=== RUN   TestAccIBMSccSiNoteEmpty
--- PASS: TestAccIBMSccSiNoteEmpty (0.73s)
=== RUN   TestAccIBMSccSiOccurrenceBasic
--- PASS: TestAccIBMSccSiOccurrenceBasic (35.37s)
=== RUN   TestAccIBMSccSiOccurrenceKpiBasic
--- PASS: TestAccIBMSccSiOccurrenceKpiBasic (33.17s)
=== RUN   TestAccIBMSccSiOccurrenceFindingNoteOccurrenceKPI
--- PASS: TestAccIBMSccSiOccurrenceFindingNoteOccurrenceKPI (12.85s)
=== RUN   TestAccIBMSccSiOccurrenceKPINoteOccurrenceFinding
--- PASS: TestAccIBMSccSiOccurrenceKPINoteOccurrenceFinding (12.52s)
=== RUN   TestAccIBMSccSiOccurrenceValidNoteNoOccurrence
--- PASS: TestAccIBMSccSiOccurrenceValidNoteNoOccurrence (0.69s)
=== RUN   TestAccIBMSccSiOccurrenceValidNoteKpiFindingOccurrence
--- PASS: TestAccIBMSccSiOccurrenceValidNoteKpiFindingOccurrence (0.69s)
=== RUN   TestAccIBMSccSiOccurrenceAllArgs
--- PASS: TestAccIBMSccSiOccurrenceAllArgs (40.72s)
PASS
ok      github.com/IBM-Cloud/terraform-provider-ibm/ibm 461.215s
testing: warning: no tests to run
PASS
ok      github.com/IBM-Cloud/terraform-provider-ibm/ibm/internal/hashcode       (cached) [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/IBM-Cloud/terraform-provider-ibm/ibm/internal/mutexkv        (cached) [no tests to run]
?       github.com/IBM-Cloud/terraform-provider-ibm/version     [no test files]
```