### PR TITLE
COS: Added support for Noncurrent version expiration, EODM & abort incomplete MPU

### DIFF
--- a/examples/ibm-cos-bucket/README.md
+++ b/examples/ibm-cos-bucket/README.md
@@ -96,6 +96,62 @@ resource "ibm_cos_bucket" "archive_expire_rule_cos" {
     prefix  = "logs/"
   }
 }
+resource "ibm_cos_bucket" "expirebucket" {
+  bucket_name          = "a-bucket-expiredat"
+  resource_instance_id = ibm_resource_instance.cos_instance.id
+  region_location      = "us-south"
+  storage_class        = "standard"
+  force_delete         = true
+  object_versioning {
+    enable  = true
+  }
+  expire_rule {
+    rule_id = "a-bucket-expire-rule"
+    enable  = true
+    date    = "2021-11-18"
+    prefix  = "logs/"
+  }
+  noncurrent_version_expiration {
+    rule_id = "my-rule-id-bucket-ncversion"
+    enable  = true
+    prefix  = ""
+    noncurrent_days = 1
+  }
+}
+
+resource "ibm_cos_bucket" "cos_bucket" {
+  bucket_name           = "a-bucket-expireddelemarkertest"
+  resource_instance_id  = ibm_resource_instance.cos_instance.id
+  region_location       = "us-south"
+  storage_class         = "standard"
+  object_versioning {
+    enable  = true
+  }
+  expire_rule {
+    rule_id = "my-rule-id-bucket-expired"
+    enable  = true
+    expired_object_delete_marker = true
+  }
+  noncurrent_version_expiration {
+    rule_id = "my-rule-id-bucket-ncversion"
+    enable  = true
+    prefix  = ""
+    noncurrent_days = 1
+  }
+}
+
+resource "ibm_cos_bucket" "cos_bucket" {
+  bucket_name           = "a-bucket-multipartupload"
+  resource_instance_id  = ibm_resource_instance.cos_instance.id
+  region_location       = "us-south"
+  storage_class         = "standard"
+  abort_incomplete_multipart_upload_days {
+    rule_id = var.abort_mpu_ruleid
+    enable  = true
+    prefix  = ""
+    days_after_initiation = 1
+  }
+}
 
 resource "ibm_cos_bucket" "retention_cos" {
   bucket_name          = "a-bucket-retention"
@@ -171,13 +227,15 @@ data "ibm_cos_bucket" "standard-ams03" {
 | usage_metrics_enabled | Specify true or false to set usage metrics (i.e. bytes_used). | `bool` | no
 | request_metrics_enabled | Specify true or false to set cos request metrics (i.e. get,put,post request). | `bool` | no
 | metrics_monitoring_crn | Required the first time metrics_monitoring is configured. The instance of IBM Cloud Monitoring that will receive the bucket metrics. | `string` | yes
-| archive_ruleid | Unique identifier for the rule. | `string` | no
 | regional_loc | The location for a regional bucket. Supported values are au-syd, eu-de, eu-gb, jp-tok,,us-east,us-south. | `string` | no
-| archive_days | Specifies the number of days when the specific archive rule action takes effect. | `int` | yes
-| archive_types | Specifies the archive type to which you want the object to transition. Supported values are  Glacier or Accelerated. | `string` | yes
-| expire_ruleid | Unique identifier for the rule. | `string` | no
-| expire_days | Specifies the number of days when the specific expire rule action takes effect. | `int` | yes
-| expire_prefix | Specifies a prefix filter to apply to only a subset of objects with names that match the prefix. | `string` | no
+| type | Specifies the archive type to which you want the object to transition. Supported values are  Glacier or Accelerated. | `string` |yes
+| rule_id | Unique identifier for the rule. | `string` | no
+| days | Specifies the number of days when the specific expire rule action takes effect. | `int` | no
+| date | After the specifies date , the current version of objects in your bucket expires.. | `string` | no
+| expired_object_delete_marker | Expired object delete markers can be automatically cleaned up to improve performance in bucket. This cannot be used alongside version expiration. | `bool` | no
+| prefix | Specifies a prefix filter to apply to only a subset of objects with names that match the prefix. | `string` | no
+| noncurrent_days | Configuration parameter in your policy that says how long to retain a non-current version before deleting it. | `int` | no
+| days_after_initiation | Specifies the number of days that govern the automatic cancellation of part upload. Clean up incomplete multi-part uploads after a period of time. | `int` | no
 | default | Specifies a default retention period to apply in all objects in the bucket. | `int` | yes
 | maximum | Specifies maximum duration of time an object can be kept unmodified in the bucket. | `int` | yes
 | minimum | Specifies minimum duration of time an object must be kept unmodified in the bucket. | `int` | yes

--- a/examples/ibm-cos-bucket/main.tf
+++ b/examples/ibm-cos-bucket/main.tf
@@ -13,14 +13,14 @@ resource "ibm_resource_instance" "activity_tracker" {
   resource_group_id = data.ibm_resource_group.cos_group.id
   service           = "logdnaat"
   plan              = "lite"
-  location          = "us-south"
+  location          =  var.regional_loc
 }
 resource "ibm_resource_instance" "metrics_monitor" {
   name              = "metrics_monitor"
   resource_group_id = data.ibm_resource_group.cos_group.id
   service           = "sysdig-monitor"
   plan              = "graduated-tier"
-  location          = "us-south"
+  location          = var.regional_loc
   parameters        = {
     default_receiver = true
   }
@@ -78,6 +78,24 @@ resource "ibm_cos_bucket" "cos_bucket" {
   hard_quota            = var.quota
   object_versioning {
     enable  = true
+  }
+  abort_incomplete_multipart_upload_days {
+    rule_id = var.abort_mpu_ruleid
+    enable  = true
+    prefix  = var.abort_mpu_prefix
+    days_after_initiation = var.abort_mpu_days_init
+  }
+  expire_rule {
+    rule_id = var.expire_ruleid
+    enable  = true
+    date    = var.expire_date
+    prefix  = var.expire_prefix
+  }
+  noncurrent_version_expiration {
+    rule_id = var.nc_exp_ruleid
+    enable  = true
+    prefix  = var.nc_exp_prefix
+    noncurrent_days = var.nc_exp_days
   }
 }
 

--- a/examples/ibm-cos-bucket/variables.tf
+++ b/examples/ibm-cos-bucket/variables.tf
@@ -42,7 +42,35 @@ variable "expire_days" {
   default = 1
 }
 
+variable "expire_date" {
+  default = ""
+}
+
 variable "expire_prefix" {
+  default = ""
+}
+
+variable "nc_exp_ruleid" {
+  default = "test-obj-ver-exp-3"
+}
+
+variable "nc_exp_days" {
+  default = 1
+}
+
+variable "nc_exp_prefix" {
+  default = ""
+}
+
+variable "abort_mpu_ruleid" {
+  default = "test-abort_mpu-5"
+}
+
+variable "abort_mpu_days_init" {
+  default = 1
+}
+
+variable "abort_mpu_prefix" {
   default = ""
 }
 

--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/IBM/event-notifications-go-admin-sdk v0.0.2
 	github.com/IBM/eventstreams-go-sdk v1.2.0
 	github.com/IBM/go-sdk-core/v5 v5.7.2
-	github.com/IBM/ibm-cos-sdk-go v1.7.0
+	github.com/IBM/ibm-cos-sdk-go v1.8.0
 	github.com/IBM/ibm-cos-sdk-go-config v1.2.0
 	github.com/IBM/ibm-hpcs-tke-sdk v0.0.0-20211109141421-a4b61b05f7d1
 	github.com/IBM/keyprotect-go-client v0.7.0

--- a/go.sum
+++ b/go.sum
@@ -78,6 +78,8 @@ github.com/IBM/go-sdk-core/v5 v5.7.2/go.mod h1:+YbdhrjCHC84ls4MeBp+Hj4NZCni+tDAc
 github.com/IBM/ibm-cos-sdk-go v1.3.1/go.mod h1:YLBAYobEA8bD27P7xpMwSQeNQu6W3DNBtBComXrRzRY=
 github.com/IBM/ibm-cos-sdk-go v1.7.0 h1:3DZULY/D5WzjlIm+Iaj6h0surEjQs65EZk1YAe8+rj0=
 github.com/IBM/ibm-cos-sdk-go v1.7.0/go.mod h1:Oi8AC5WNDhmUJgbo1GL2FtBdo0nRgbzE/1HmCL1SERU=
+github.com/IBM/ibm-cos-sdk-go v1.8.0 h1:6d3BY+jo71JvQoyUwdtv4pemEfbnK/XSKQCKOEuWmks=
+github.com/IBM/ibm-cos-sdk-go v1.8.0/go.mod h1:Oi8AC5WNDhmUJgbo1GL2FtBdo0nRgbzE/1HmCL1SERU=
 github.com/IBM/ibm-cos-sdk-go-config v1.2.0 h1:1E93234yZgVS0ntm7eUwVb3h0AAayPGcxEhhizEN1LE=
 github.com/IBM/ibm-cos-sdk-go-config v1.2.0/go.mod h1:Wetfgv6m1xyuzpZLQTTLIBsWstxjYa15h+Utj7x53Dk=
 github.com/IBM/ibm-hpcs-tke-sdk v0.0.0-20211109141421-a4b61b05f7d1 h1:T5UwRKKd+BoaPZ7UIlpJrzXzVTUEs8HcxwQ3pCIbORs=

--- a/ibm/data_source_ibm_cos_bucket.go
+++ b/ibm/data_source_ibm_cos_bucket.go
@@ -137,6 +137,34 @@ func dataSourceIBMCosBucket() *schema.Resource {
 					},
 				},
 			},
+			"abort_incomplete_multipart_upload_days": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"rule_id": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "Unique identifier for the rule. Rules allow you to set a specific time frame after which objects are deleted. Set Rule ID for cos bucket",
+						},
+						"enable": {
+							Type:        schema.TypeBool,
+							Computed:    true,
+							Description: "Enable or disable rule for a bucket",
+						},
+						"prefix": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "The rule applies to any objects with keys that match this prefix",
+						},
+						"days_after_initiation": {
+							Type:        schema.TypeInt,
+							Computed:    true,
+							Description: "Specifies the number of days when the specific rule action takes effect.",
+						},
+					},
+				},
+			},
 			"archive_rule": {
 				Type:        schema.TypeList,
 				Computed:    true,
@@ -178,6 +206,11 @@ func dataSourceIBMCosBucket() *schema.Resource {
 							Computed:    true,
 							Description: "Enable or disable an archive rule for a bucket",
 						},
+						"date": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "Specifies the date when the specific rule action takes effect.",
+						},
 						"days": {
 							Type:        schema.TypeInt,
 							Computed:    true,
@@ -187,6 +220,11 @@ func dataSourceIBMCosBucket() *schema.Resource {
 							Type:        schema.TypeString,
 							Computed:    true,
 							Description: "The rule applies to any objects with keys that match this prefix",
+						},
+						"expired_object_delete_marker": {
+							Type:        schema.TypeBool,
+							Computed:    true,
+							Description: "Expired object delete markers can be automatically cleaned up to improve performance in bucket. This cannot be used alongside version expiration.",
 						},
 					},
 				},
@@ -230,6 +268,35 @@ func dataSourceIBMCosBucket() *schema.Resource {
 							Type:        schema.TypeBool,
 							Computed:    true,
 							Description: "Enable or suspend the versioning for objects in the bucket",
+						},
+					},
+				},
+			},
+			"noncurrent_version_expiration": {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Description: "Enable configuration expire_rule to COS Bucket after a defined period of time",
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"rule_id": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "Unique identifier for the rule.Expire rules allow you to set a specific time frame after which objects are deleted. Set Rule ID for cos bucket",
+						},
+						"enable": {
+							Type:        schema.TypeBool,
+							Computed:    true,
+							Description: "Enable or disable an expire rule for a bucket",
+						},
+						"prefix": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "The rule applies to any objects with keys that match this prefix",
+						},
+						"noncurrent_days": {
+							Type:        schema.TypeInt,
+							Computed:    true,
+							Description: "Specifies the number of days when the specific rule action takes effect.",
 						},
 					},
 				},
@@ -381,7 +448,7 @@ func dataSourceIBMCosBucketRead(d *schema.ResourceData, meta interface{}) error 
 
 	}
 
-	// Read the lifecycle configuration (archive)
+	// Read the lifecycle configuration
 
 	gInput := &s3.GetBucketLifecycleConfigurationInput{
 		Bucket: aws.String(bucketName),
@@ -397,11 +464,19 @@ func dataSourceIBMCosBucketRead(d *schema.ResourceData, meta interface{}) error 
 		if len(lifecycleptr.Rules) > 0 {
 			archiveRules := archiveRuleGet(lifecycleptr.Rules)
 			expireRules := expireRuleGet(lifecycleptr.Rules)
+			nc_expRules := nc_exp_RuleGet(lifecycleptr.Rules)
+			abort_mpuRules := abort_mpu_RuleGet(lifecycleptr.Rules)
 			if len(archiveRules) > 0 {
 				d.Set("archive_rule", archiveRules)
 			}
 			if len(expireRules) > 0 {
 				d.Set("expire_rule", expireRules)
+			}
+			if len(nc_expRules) > 0 {
+				d.Set("noncurrent_version_expiration", nc_expRules)
+			}
+			if len(abort_mpuRules) > 0 {
+				d.Set("abort_incomplete_multipart_upload_days", abort_mpuRules)
 			}
 		}
 	}

--- a/ibm/resource_ibm_cos_bucket.go
+++ b/ibm/resource_ibm_cos_bucket.go
@@ -4,6 +4,7 @@
 package ibm
 
 import (
+	"context"
 	"fmt"
 	"log"
 	"regexp"
@@ -43,12 +44,13 @@ const (
 
 func resourceIBMCOSBucket() *schema.Resource {
 	return &schema.Resource{
-		Read:     resourceIBMCOSBucketRead,
-		Create:   resourceIBMCOSBucketCreate,
-		Update:   resourceIBMCOSBucketUpdate,
-		Delete:   resourceIBMCOSBucketDelete,
-		Exists:   resourceIBMCOSBucketExists,
-		Importer: &schema.ResourceImporter{},
+		Read:          resourceIBMCOSBucketRead,
+		Create:        resourceIBMCOSBucketCreate,
+		Update:        resourceIBMCOSBucketUpdate,
+		Delete:        resourceIBMCOSBucketDelete,
+		Exists:        resourceIBMCOSBucketExists,
+		Importer:      &schema.ResourceImporter{},
+		CustomizeDiff: resourceExpiryValidate,
 
 		Timeouts: &schema.ResourceTimeout{
 			Create: schema.DefaultTimeout(60 * time.Minute),
@@ -190,6 +192,39 @@ func resourceIBMCOSBucket() *schema.Resource {
 					},
 				},
 			},
+			"abort_incomplete_multipart_upload_days": {
+				Type:        schema.TypeList,
+				Optional:    true,
+				MaxItems:    1,
+				Description: "Enable abort incomplete multipart upload to COS Bucket after a defined period of time",
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"rule_id": {
+							Type:        schema.TypeString,
+							Optional:    true,
+							Computed:    true,
+							Description: "Unique identifier for the rule. Rules allow you to set a specific time frame after which objects are deleted. Set Rule ID for cos bucket",
+						},
+						"enable": {
+							Type:        schema.TypeBool,
+							Required:    true,
+							Description: "Enable or disable rule for a bucket",
+						},
+						"prefix": {
+							Type:        schema.TypeString,
+							Optional:    true,
+							Computed:    true,
+							Description: "The rule applies to any objects with keys that match this prefix",
+						},
+						"days_after_initiation": {
+							Type:         schema.TypeInt,
+							Optional:     true,
+							ValidateFunc: validateAllowedRangeInt(1, 3650),
+							Description:  "Specifies the number of days when the specific rule action takes effect.",
+						},
+					},
+				},
+			},
 			"archive_rule": {
 				Type:        schema.TypeList,
 				Optional:    true,
@@ -248,11 +283,22 @@ func resourceIBMCOSBucket() *schema.Resource {
 							Computed:    true,
 							Description: "The rule applies to any objects with keys that match this prefix",
 						},
+						"date": {
+							Type:         schema.TypeString,
+							Optional:     true,
+							ValidateFunc: validBucketLifecycleTimestamp,
+							Description:  "Specify a rule to expire the current version of objects in bucket after a specific date.",
+						},
 						"days": {
 							Type:         schema.TypeInt,
-							Required:     true,
-							ValidateFunc: validateAllowedRangeInt(0, 3650),
+							Optional:     true,
+							ValidateFunc: validateAllowedRangeInt(1, 3650),
 							Description:  "Specifies the number of days when the specific rule action takes effect.",
+						},
+						"expired_object_delete_marker": {
+							Type:        schema.TypeBool,
+							Optional:    true,
+							Description: "Expired object delete markers can be automatically cleaned up to improve performance in bucket. This cannot be used alongside version expiration.",
 						},
 					},
 				},
@@ -299,7 +345,7 @@ func resourceIBMCOSBucket() *schema.Resource {
 				Type:          schema.TypeList,
 				Optional:      true,
 				MaxItems:      1,
-				ConflictsWith: []string{"retention_rule", "expire_rule"},
+				ConflictsWith: []string{"retention_rule"},
 				Description:   "Protect objects from accidental deletion or overwrites. Versioning allows you to keep multiple versions of an object protecting from unintentional data loss.",
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
@@ -308,6 +354,39 @@ func resourceIBMCOSBucket() *schema.Resource {
 							Optional:    true,
 							Default:     false,
 							Description: "Enable or suspend the versioning for objects in the bucket",
+						},
+					},
+				},
+			},
+			"noncurrent_version_expiration": {
+				Type:        schema.TypeList,
+				Optional:    true,
+				MaxItems:    1,
+				Description: "Enable configuration expire_rule to COS Bucket after a defined period of time",
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"rule_id": {
+							Type:        schema.TypeString,
+							Optional:    true,
+							Computed:    true,
+							Description: "Unique identifier for the rule.Expire rules allow you to set a specific time frame after which objects are deleted. Set Rule ID for cos bucket",
+						},
+						"enable": {
+							Type:        schema.TypeBool,
+							Required:    true,
+							Description: "Enable or disable an expire rule for a bucket",
+						},
+						"prefix": {
+							Type:        schema.TypeString,
+							Optional:    true,
+							Computed:    true,
+							Description: "The rule applies to any objects with keys that match this prefix",
+						},
+						"noncurrent_days": {
+							Type:         schema.TypeInt,
+							Optional:     true,
+							ValidateFunc: validateAllowedRangeInt(1, 3650),
+							Description:  "Specifies the number of days when the specific rule action takes effect.",
 						},
 					},
 				},
@@ -377,9 +456,107 @@ func archiveRuleList(archiveList []interface{}) []*s3.LifecycleRule {
 	return rules
 }
 
+func nc_expRuleList(nc_expList []interface{}) []*s3.LifecycleRule {
+	var nc_exp_prefix, nc_exp_status, rule_id string
+	var nc_days int64
+	var rules []*s3.LifecycleRule
+
+	for _, l := range nc_expList {
+		nc_expMap, _ := l.(map[string]interface{})
+		//Rule ID
+		if rule_idSet, exist := nc_expMap["rule_id"]; exist {
+			id := rule_idSet.(string)
+			rule_id = id
+		}
+
+		//Status Enable/Disable
+		if nc_exp_statusSet, exist := nc_expMap["enable"]; exist {
+			nc_expStatusEnabled := nc_exp_statusSet.(bool)
+			if nc_expStatusEnabled == true {
+				nc_exp_status = "Enabled"
+			} else {
+				nc_exp_status = "Disabled"
+			}
+		}
+		//Days
+		if nc_exp_daySet, exist := nc_expMap["noncurrent_days"]; exist {
+			nc_exp_days := int64(nc_exp_daySet.(int))
+			nc_days = nc_exp_days
+		}
+		//Expire Prefix
+		if nc_expPrefixClassSet, exist := nc_expMap["prefix"]; exist {
+			prefix_check := nc_expPrefixClassSet.(string)
+			nc_exp_prefix = prefix_check
+		}
+
+		nc_exp_rule := s3.LifecycleRule{
+			ID:     aws.String(rule_id),
+			Status: aws.String(nc_exp_status),
+			Filter: &s3.LifecycleRuleFilter{
+				Prefix: aws.String(nc_exp_prefix),
+			},
+			NoncurrentVersionExpiration: &s3.NoncurrentVersionExpiration{
+				NoncurrentDays: aws.Int64(nc_days),
+			},
+		}
+		rules = append(rules, &nc_exp_rule)
+	}
+	return rules
+}
+
+func abortmpuRuleList(abortmpuList []interface{}) []*s3.LifecycleRule {
+	var abort_mpu_prefix, abort_mpu_status, rule_id string
+	var abort_mpu_days_init int64
+	var rules []*s3.LifecycleRule
+
+	for _, l := range abortmpuList {
+		abortmpuMap, _ := l.(map[string]interface{})
+		//Rule ID
+		if rule_idSet, exist := abortmpuMap["rule_id"]; exist {
+			id := rule_idSet.(string)
+			rule_id = id
+		}
+
+		//Status Enable/Disable
+		if abort_mpu_statusSet, exist := abortmpuMap["enable"]; exist {
+			abort_mpuStatusEnabled := abort_mpu_statusSet.(bool)
+			if abort_mpuStatusEnabled == true {
+				abort_mpu_status = "Enabled"
+			} else {
+				abort_mpu_status = "Disabled"
+			}
+		}
+		//Days
+		if abort_mpu_daySet, exist := abortmpuMap["days_after_initiation"]; exist {
+			abort_mpu_days := int64(abort_mpu_daySet.(int))
+			abort_mpu_days_init = abort_mpu_days
+		}
+		//Expire Prefix
+		if abort_mpuPrefixClassSet, exist := abortmpuMap["prefix"]; exist {
+			prefix_check := abort_mpuPrefixClassSet.(string)
+			abort_mpu_prefix = prefix_check
+		}
+
+		abort_mpu_rule := s3.LifecycleRule{
+			ID:     aws.String(rule_id),
+			Status: aws.String(abort_mpu_status),
+			Filter: &s3.LifecycleRuleFilter{
+				Prefix: aws.String(abort_mpu_prefix),
+			},
+			AbortIncompleteMultipartUpload: &s3.AbortIncompleteMultipartUpload{
+				DaysAfterInitiation: aws.Int64(abort_mpu_days_init),
+			},
+		}
+		rules = append(rules, &abort_mpu_rule)
+	}
+	return rules
+}
+
 func expireRuleList(expireList []interface{}) []*s3.LifecycleRule {
 	var expire_prefix, expire_status, rule_id string
+	var expire_date time.Time
 	var days int64
+	var expired_object_del_marker bool
 	var rules []*s3.LifecycleRule
 
 	for _, l := range expireList {
@@ -392,8 +569,8 @@ func expireRuleList(expireList []interface{}) []*s3.LifecycleRule {
 
 		//Status Enable/Disable
 		if expire_statusSet, exist := expireMap["enable"]; exist {
-			archiveStatusEnabled := expire_statusSet.(bool)
-			if archiveStatusEnabled == true {
+			expireStatusEnabled := expire_statusSet.(bool)
+			if expireStatusEnabled == true {
 				expire_status = "Enabled"
 			} else {
 				expire_status = "Disabled"
@@ -404,22 +581,44 @@ func expireRuleList(expireList []interface{}) []*s3.LifecycleRule {
 			daysexpire := int64(daysexpireSet.(int))
 			days = daysexpire
 		}
+		//Date
+		if dateexpireSet, exist := expireMap["date"]; exist {
+			expiredatevalue := dateexpireSet.(string)
+			expire_date, _ = time.Parse(time.RFC3339, fmt.Sprintf("%sT00:00:00Z", expiredatevalue))
+		}
 		//Expire Prefix
 		if expirePrefixClassSet, exist := expireMap["prefix"]; exist {
-			expire_prefix = expirePrefixClassSet.(string)
+			prefix := expirePrefixClassSet.(string)
+			expire_prefix = prefix
 		}
+		// Expired Object Delete Marker
+		if expireObjectDelMarkerSet, exist := expireMap["expired_object_delete_marker"]; exist {
+			expired_object_del_marker = expireObjectDelMarkerSet.(bool)
+		}
+		var i *s3.LifecycleExpiration
 
+		if expired_object_del_marker == true {
+			i = &s3.LifecycleExpiration{
+				ExpiredObjectDeleteMarker: aws.Bool(expired_object_del_marker),
+			}
+		} else if days > 0 {
+			i = &s3.LifecycleExpiration{
+				Days: aws.Int64(days),
+			}
+		} else if !expire_date.IsZero() {
+			i = &s3.LifecycleExpiration{
+				Date: aws.Time(expire_date),
+			}
+		}
 		expire_rule := s3.LifecycleRule{
 			ID:     aws.String(rule_id),
 			Status: aws.String(expire_status),
 			Filter: &s3.LifecycleRuleFilter{
 				Prefix: aws.String(expire_prefix),
 			},
-			Expiration: &s3.LifecycleExpiration{
-				Days: aws.Int64(days),
-			},
-		}
 
+			Expiration: i,
+		}
 		rules = append(rules, &expire_rule)
 	}
 	return rules
@@ -466,28 +665,36 @@ func resourceIBMCOSBucketUpdate(d *schema.ResourceData, meta interface{}) error 
 	s3Sess := session.Must(session.NewSession())
 	s3Client := s3.New(s3Sess, s3Conf)
 
-	//// Update  the lifecycle (Archive or Expire)
-	if d.HasChange("archive_rule") || d.HasChange("expire_rule") {
+	//// Update  the lifecycle (Archive or Expire or Non Current version or Abort incomplete Multipart Upload)
+	if d.HasChange("archive_rule") || d.HasChange("expire_rule") || d.HasChange("noncurrent_version_expiration") || d.HasChange("abort_incomplete_multipart_upload_days") {
 		var archive, archive_ok = d.GetOk("archive_rule")
 		var expire, expire_ok = d.GetOk("expire_rule")
+		var noncurrentverexp, nc_exp_ok = d.GetOk("noncurrent_version_expiration")
+		var abortmpu, abort_mpu_ok = d.GetOk("abort_incomplete_multipart_upload_days")
 		var rules []*s3.LifecycleRule
-		if archive_ok || expire_ok {
-			if expire_ok {
-				rules = append(rules, expireRuleList(expire.([]interface{}))...)
-			}
+		if archive_ok || expire_ok || nc_exp_ok || abort_mpu_ok {
 			if archive_ok {
 				rules = append(rules, archiveRuleList(archive.([]interface{}))...)
 			}
-
+			if nc_exp_ok {
+				rules = append(rules, nc_expRuleList(noncurrentverexp.([]interface{}))...)
+			}
+			if abort_mpu_ok {
+				rules = append(rules, abortmpuRuleList(abortmpu.([]interface{}))...)
+			}
+			if expire_ok {
+				rules = append(rules, expireRuleList(expire.([]interface{}))...)
+			}
 			lInput := &s3.PutBucketLifecycleConfigurationInput{
 				Bucket: aws.String(bucketName),
 				LifecycleConfiguration: &s3.LifecycleConfiguration{
 					Rules: rules,
 				},
 			}
+
 			_, err := s3Client.PutBucketLifecycleConfiguration(lInput)
 			if err != nil {
-				return fmt.Errorf("failed to update the archive rule on COS bucket %s, %v", bucketName, err)
+				return fmt.Errorf("failed to update the lifecyle rule on COS bucket %s, %v", bucketName, err)
 			}
 
 		} else {
@@ -819,7 +1026,7 @@ func resourceIBMCOSBucketRead(d *schema.ResourceData, meta interface{}) error {
 			d.Set("hard_quota", bucketPtr.HardQuota)
 		}
 	}
-	// Read the lifecycle configuration (archive & expiration)
+	// Read the lifecycle configuration (archive & expiration or non current version or abort incomplete multipart upload)
 
 	gInput := &s3.GetBucketLifecycleConfigurationInput{
 		Bucket: aws.String(bucketName),
@@ -830,15 +1037,22 @@ func resourceIBMCOSBucketRead(d *schema.ResourceData, meta interface{}) error {
 	if (err != nil && !strings.Contains(err.Error(), "NoSuchLifecycleConfiguration: The lifecycle configuration does not exist")) && (err != nil && bucketPtr != nil && bucketPtr.Firewall != nil && !strings.Contains(err.Error(), "AccessDenied: Access Denied")) {
 		return err
 	}
-
 	if lifecycleptr != nil {
 		archiveRules := archiveRuleGet(lifecycleptr.Rules)
 		expireRules := expireRuleGet(lifecycleptr.Rules)
+		nc_expRules := nc_exp_RuleGet(lifecycleptr.Rules)
+		abort_mpuRules := abort_mpu_RuleGet(lifecycleptr.Rules)
 		if len(archiveRules) > 0 {
 			d.Set("archive_rule", archiveRules)
 		}
 		if len(expireRules) > 0 {
 			d.Set("expire_rule", expireRules)
+		}
+		if len(nc_expRules) > 0 {
+			d.Set("noncurrent_version_expiration", nc_expRules)
+		}
+		if len(abort_mpuRules) > 0 {
+			d.Set("abort_incomplete_multipart_upload_days", abort_mpuRules)
 		}
 	}
 
@@ -1160,4 +1374,28 @@ func parseBucketId(id string, info string) string {
 
 	}
 	return ""
+}
+
+func resourceExpiryValidate(_ context.Context, diff *schema.ResourceDiff, meta interface{}) error {
+	if expire, ok := diff.GetOk("expire_rule"); ok {
+		expire_list := expire.([]interface{})
+		for _, l := range expire_list {
+			expireMap, _ := l.(map[string]interface{})
+			ctr := 0
+			if val, days_exist := expireMap["days"]; days_exist && val.(int) != 0 {
+				ctr++
+			}
+			if val, date_exist := expireMap["date"]; date_exist && val != "" {
+				ctr++
+			}
+			if val, expired_object_delete_marker_exist := expireMap["expired_object_delete_marker"]; expired_object_delete_marker_exist && val.(bool) != false {
+				ctr++
+			}
+			if ctr > 1 {
+				return fmt.Errorf("The expiry 3 action elements (Days, Date, ExpiredObjectDeleteMarker) are all mutually exclusive. These can not be used with each other. Please set one expiry element on the same rule of expiration.")
+			}
+			return nil
+		}
+	}
+	return nil
 }

--- a/ibm/resource_ibm_cos_bucket_test.go
+++ b/ibm/resource_ibm_cos_bucket_test.go
@@ -85,7 +85,7 @@ func TestAccIBMCosBucket_ActivityTracker_Monitor(t *testing.T) {
 	activityServiceName := fmt.Sprintf("activity_tracker_%d", acctest.RandIntRange(10, 100))
 	monitorServiceName := fmt.Sprintf("metrics_monitor_%d", acctest.RandIntRange(10, 100))
 	bucketName := fmt.Sprintf("tf-bucket%d", acctest.RandIntRange(10, 100))
-	bucketRegion := "sjc04"
+	bucketRegion := "ams03"
 	bucketClass := "standard"
 	bucketRegionType := "single_site_location"
 
@@ -119,6 +119,7 @@ func TestAccIBMCosBucket_ActivityTracker_Monitor(t *testing.T) {
 		},
 	})
 }
+
 func TestAccIBMCosBucket_Archive_Expiration(t *testing.T) {
 
 	cosServiceName := fmt.Sprintf("cos_instance_%d", acctest.RandIntRange(10, 100))
@@ -231,14 +232,14 @@ func TestAccIBMCosBucket_Archive(t *testing.T) {
 	})
 }
 
-func TestAccIBMCosBucket_Expire(t *testing.T) {
+func TestAccIBMCosBucket_Expiredays(t *testing.T) {
 
 	cosServiceName := fmt.Sprintf("cos_instance_%d", acctest.RandIntRange(10, 100))
 	bucketName := fmt.Sprintf("terraform%d", acctest.RandIntRange(10, 100))
 	bucketRegion := "us-south"
 	bucketClass := "standard"
 	bucketRegionType := "region_location"
-	ruleId := "my-rule-id-bucket-expire"
+	ruleId := "my-rule-id-bucket-expiredays"
 	enable := true
 	expireDays := 2
 	prefix := "prefix/"
@@ -250,7 +251,7 @@ func TestAccIBMCosBucket_Expire(t *testing.T) {
 		CheckDestroy: testAccCheckIBMCosBucketDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
-				Config: testAccCheckIBMCosBucket_expire(cosServiceName, bucketName, bucketRegionType, bucketRegion, bucketClass, ruleId, enable, expireDays, prefix),
+				Config: testAccCheckIBMCosBucket_expiredays(cosServiceName, bucketName, bucketRegionType, bucketRegion, bucketClass, ruleId, enable, expireDays, prefix),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckIBMCosBucketExists("ibm_resource_instance.instance", "ibm_cos_bucket.bucket", bucketRegionType, bucketRegion, bucketName),
 					resource.TestCheckResourceAttr("ibm_cos_bucket.bucket", "bucket_name", bucketName),
@@ -270,13 +271,178 @@ func TestAccIBMCosBucket_Expire(t *testing.T) {
 				),
 			},
 			resource.TestStep{
-				Config: testAccCheckIBMCosBucket_update_expire(cosServiceName, bucketName, bucketRegionType, bucketRegion, bucketClass, ruleId, enable, expireDays, prefix),
+				Config: testAccCheckIBMCosBucket_update_expiredays(cosServiceName, bucketName, bucketRegionType, bucketRegion, bucketClass, ruleId, enable, expireDays, prefix),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckIBMCosBucketExists("ibm_resource_instance.instance", "ibm_cos_bucket.bucket", bucketRegionType, bucketRegion, bucketName),
 					resource.TestCheckResourceAttr("ibm_cos_bucket.bucket", "bucket_name", bucketName),
 					resource.TestCheckResourceAttr("ibm_cos_bucket.bucket", "storage_class", bucketClass),
 					resource.TestCheckResourceAttr("ibm_cos_bucket.bucket", "region_location", bucketRegion),
 					resource.TestCheckResourceAttr("ibm_cos_bucket.bucket", "expire_rule.#", "0"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccIBMCosBucket_Expiredate(t *testing.T) {
+
+	cosServiceName := fmt.Sprintf("cos_instance_%d", acctest.RandIntRange(10, 100))
+	bucketName := fmt.Sprintf("terraform%d", acctest.RandIntRange(10, 100))
+	bucketRegion := "us-south"
+	bucketClass := "standard"
+	bucketRegionType := "region_location"
+	ruleId := "my-rule-id-bucket-expiredate"
+	enable := true
+	expireDate := "2021-11-28"
+	prefix := ""
+	expireDateUpdate := "2021-11-30"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckIBMCosBucketDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccCheckIBMCosBucket_expiredate(cosServiceName, bucketName, bucketRegionType, bucketRegion, bucketClass, ruleId, enable, expireDate, prefix),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckIBMCosBucketExists("ibm_resource_instance.instance", "ibm_cos_bucket.bucket", bucketRegionType, bucketRegion, bucketName),
+					resource.TestCheckResourceAttr("ibm_cos_bucket.bucket", "bucket_name", bucketName),
+					resource.TestCheckResourceAttr("ibm_cos_bucket.bucket", "storage_class", bucketClass),
+					resource.TestCheckResourceAttr("ibm_cos_bucket.bucket", "region_location", bucketRegion),
+					resource.TestCheckResourceAttr("ibm_cos_bucket.bucket", "expire_rule.#", "1"),
+				),
+			},
+			resource.TestStep{
+				Config: testAccCheckIBMCosBucket_expire_updateDate(cosServiceName, bucketName, bucketRegionType, bucketRegion, bucketClass, ruleId, enable, expireDateUpdate, prefix),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckIBMCosBucketExists("ibm_resource_instance.instance", "ibm_cos_bucket.bucket", bucketRegionType, bucketRegion, bucketName),
+					resource.TestCheckResourceAttr("ibm_cos_bucket.bucket", "bucket_name", bucketName),
+					resource.TestCheckResourceAttr("ibm_cos_bucket.bucket", "storage_class", bucketClass),
+					resource.TestCheckResourceAttr("ibm_cos_bucket.bucket", "region_location", bucketRegion),
+					resource.TestCheckResourceAttr("ibm_cos_bucket.bucket", "expire_rule.0.date", expireDateUpdate),
+				),
+			},
+			resource.TestStep{
+				Config: testAccCheckIBMCosBucket_update_expiredate(cosServiceName, bucketName, bucketRegionType, bucketRegion, bucketClass, ruleId, enable, expireDate, prefix),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckIBMCosBucketExists("ibm_resource_instance.instance", "ibm_cos_bucket.bucket", bucketRegionType, bucketRegion, bucketName),
+					resource.TestCheckResourceAttr("ibm_cos_bucket.bucket", "bucket_name", bucketName),
+					resource.TestCheckResourceAttr("ibm_cos_bucket.bucket", "storage_class", bucketClass),
+					resource.TestCheckResourceAttr("ibm_cos_bucket.bucket", "region_location", bucketRegion),
+					resource.TestCheckResourceAttr("ibm_cos_bucket.bucket", "expire_rule.#", "0"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccIBMCosBucket_Expireddeletemarker(t *testing.T) {
+
+	cosServiceName := fmt.Sprintf("cos_instance_%d", acctest.RandIntRange(10, 100))
+	bucketName := fmt.Sprintf("terraform%d", acctest.RandIntRange(10, 100))
+	bucketRegion := "us-south"
+	bucketClass := "standard"
+	bucketRegionType := "region_location"
+	ruleId := "my-rule-id-bucket-expireddeletemarker"
+	enable := true
+	prefix := ""
+	expiredObjectDeleteMarker := false
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckIBMCosBucketDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccCheckIBMCosBucket_expiredeletemarker(cosServiceName, bucketName, bucketRegionType, bucketRegion, bucketClass, ruleId, enable, expiredObjectDeleteMarker, prefix),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckIBMCosBucketExists("ibm_resource_instance.instance", "ibm_cos_bucket.bucket", bucketRegionType, bucketRegion, bucketName),
+					resource.TestCheckResourceAttr("ibm_cos_bucket.bucket", "bucket_name", bucketName),
+					resource.TestCheckResourceAttr("ibm_cos_bucket.bucket", "storage_class", bucketClass),
+					resource.TestCheckResourceAttr("ibm_cos_bucket.bucket", "region_location", bucketRegion),
+					resource.TestCheckResourceAttr("ibm_cos_bucket.bucket", "expire_rule.#", "1"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccIBMCosBucket_AbortIncompeleteMPU(t *testing.T) {
+
+	cosServiceName := fmt.Sprintf("cos_instance_%d", acctest.RandIntRange(10, 100))
+	bucketName := fmt.Sprintf("terraform%d", acctest.RandIntRange(10, 100))
+	bucketRegion := "us-south"
+	bucketClass := "standard"
+	bucketRegionType := "region_location"
+	ruleId := "my-rule-id-bucket-abortmpu"
+	enable := true
+	prefix := ""
+	daysAfterInitiation := 1
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckIBMCosBucketDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccCheckIBMCosBucket_abortincompletempu(cosServiceName, bucketName, bucketRegionType, bucketRegion, bucketClass, ruleId, enable, daysAfterInitiation, prefix),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckIBMCosBucketExists("ibm_resource_instance.instance", "ibm_cos_bucket.bucket", bucketRegionType, bucketRegion, bucketName),
+					resource.TestCheckResourceAttr("ibm_cos_bucket.bucket", "bucket_name", bucketName),
+					resource.TestCheckResourceAttr("ibm_cos_bucket.bucket", "storage_class", bucketClass),
+					resource.TestCheckResourceAttr("ibm_cos_bucket.bucket", "region_location", bucketRegion),
+					resource.TestCheckResourceAttr("ibm_cos_bucket.bucket", "abort_incomplete_multipart_upload_days.#", "1"),
+				),
+			},
+			resource.TestStep{
+				Config: testAccCheckIBMCosBucket_update_abortincompletempu(cosServiceName, bucketName, bucketRegionType, bucketRegion, bucketClass, ruleId, enable, daysAfterInitiation, prefix),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckIBMCosBucketExists("ibm_resource_instance.instance", "ibm_cos_bucket.bucket", bucketRegionType, bucketRegion, bucketName),
+					resource.TestCheckResourceAttr("ibm_cos_bucket.bucket", "bucket_name", bucketName),
+					resource.TestCheckResourceAttr("ibm_cos_bucket.bucket", "storage_class", bucketClass),
+					resource.TestCheckResourceAttr("ibm_cos_bucket.bucket", "region_location", bucketRegion),
+					resource.TestCheckResourceAttr("ibm_cos_bucket.bucket", "abort_incomplete_multipart_upload_days.#", "0"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccIBMCosBucket_noncurrentversion(t *testing.T) {
+
+	cosServiceName := fmt.Sprintf("cos_instance_%d", acctest.RandIntRange(10, 100))
+	bucketName := fmt.Sprintf("terraform%d", acctest.RandIntRange(10, 100))
+	bucketRegion := "us-south"
+	bucketClass := "standard"
+	bucketRegionType := "region_location"
+	ruleId := "my-rule-id-bucket-ncversion"
+	enable := true
+	prefix := ""
+	noncurrentDays := 1
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckIBMCosBucketDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccCheckIBMCosBucket_noncurrentversion(cosServiceName, bucketName, bucketRegionType, bucketRegion, bucketClass, ruleId, enable, noncurrentDays, prefix),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckIBMCosBucketExists("ibm_resource_instance.instance", "ibm_cos_bucket.bucket", bucketRegionType, bucketRegion, bucketName),
+					resource.TestCheckResourceAttr("ibm_cos_bucket.bucket", "bucket_name", bucketName),
+					resource.TestCheckResourceAttr("ibm_cos_bucket.bucket", "storage_class", bucketClass),
+					resource.TestCheckResourceAttr("ibm_cos_bucket.bucket", "region_location", bucketRegion),
+					resource.TestCheckResourceAttr("ibm_cos_bucket.bucket", "noncurrent_version_expiration.#", "1"),
+				),
+			},
+			resource.TestStep{
+				Config: testAccCheckIBMCosBucket_update_noncurrentversion(cosServiceName, bucketName, bucketRegionType, bucketRegion, bucketClass, ruleId, enable, noncurrentDays, prefix),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckIBMCosBucketExists("ibm_resource_instance.instance", "ibm_cos_bucket.bucket", bucketRegionType, bucketRegion, bucketName),
+					resource.TestCheckResourceAttr("ibm_cos_bucket.bucket", "bucket_name", bucketName),
+					resource.TestCheckResourceAttr("ibm_cos_bucket.bucket", "storage_class", bucketClass),
+					resource.TestCheckResourceAttr("ibm_cos_bucket.bucket", "region_location", bucketRegion),
+					resource.TestCheckResourceAttr("ibm_cos_bucket.bucket", "noncurrent_version_expiration.#", "0"),
 				),
 			},
 		},
@@ -806,7 +972,7 @@ func testAccCheckIBMCosBucket_update_archive(cosServiceName string, bucketName s
 	`, cosServiceName, bucketName, region, storageClass)
 }
 
-func testAccCheckIBMCosBucket_expire(cosServiceName string, bucketName string, regiontype string, region string, storageClass string, ruleId string, enable bool, expireDays int, prefix string) string {
+func testAccCheckIBMCosBucket_expiredays(cosServiceName string, bucketName string, regiontype string, region string, storageClass string, ruleId string, enable bool, expireDays int, prefix string) string {
 
 	return fmt.Sprintf(`
 	data "ibm_resource_group" "cos_group" {
@@ -866,7 +1032,7 @@ func testAccCheckIBMCosBucket_expire_updateDays(cosServiceName string, bucketNam
 
 }
 
-func testAccCheckIBMCosBucket_update_expire(cosServiceName string, bucketName string, regiontype string, region string, storageClass string, ruleId string, enable bool, expireDays int, prefix string) string {
+func testAccCheckIBMCosBucket_update_expiredays(cosServiceName string, bucketName string, regiontype string, region string, storageClass string, ruleId string, enable bool, expireDays int, prefix string) string {
 
 	return fmt.Sprintf(`
 	data "ibm_resource_group" "cos_group" {
@@ -888,6 +1054,120 @@ func testAccCheckIBMCosBucket_update_expire(cosServiceName string, bucketName st
 		storage_class         = "%s"
 	}
 	`, cosServiceName, bucketName, region, storageClass)
+}
+
+func testAccCheckIBMCosBucket_expiredate(cosServiceName string, bucketName string, regiontype string, region string, storageClass string, ruleId string, enable bool, expireDate string, prefix string) string {
+
+	return fmt.Sprintf(`
+	data "ibm_resource_group" "cos_group" {
+		is_default=true
+	}
+
+	resource "ibm_resource_instance" "instance" {
+		name              = "%s"
+		service           = "cloud-object-storage"
+		plan              = "standard"
+		location          = "global"
+		resource_group_id = data.ibm_resource_group.cos_group.id
+	}
+
+	resource "ibm_cos_bucket" "bucket" {
+		bucket_name           = "%s"
+		resource_instance_id  = ibm_resource_instance.instance.id
+	    region_location       = "%s"
+		storage_class         = "%s"
+		expire_rule {
+			rule_id             = "%s"
+			enable              = true
+			date                = "%s"
+			prefix              = "%s"
+		}
+	}
+	`, cosServiceName, bucketName, region, storageClass, ruleId, expireDate, prefix)
+}
+
+func testAccCheckIBMCosBucket_expire_updateDate(cosServiceName string, bucketName string, regiontype string, region string, storageClass string, ruleId string, enable bool, expireDateUpdate string, prefix string) string {
+
+	return fmt.Sprintf(`
+	data "ibm_resource_group" "cos_group" {
+		is_default=true
+	}
+
+	resource "ibm_resource_instance" "instance" {
+		name              = "%s"
+		service           = "cloud-object-storage"
+		plan              = "standard"
+		location          = "global"
+		resource_group_id = data.ibm_resource_group.cos_group.id
+	}
+	resource "ibm_cos_bucket" "bucket" {
+		bucket_name           = "%s"
+		resource_instance_id  = ibm_resource_instance.instance.id
+	    region_location       = "%s"
+		storage_class         = "%s"
+		expire_rule {
+			rule_id             = "%s"
+			enable              = true
+			date                = "%s"
+			prefix              = "%s"
+		}
+	}
+	`, cosServiceName, bucketName, region, storageClass, ruleId, expireDateUpdate, prefix)
+
+}
+
+func testAccCheckIBMCosBucket_update_expiredate(cosServiceName string, bucketName string, regiontype string, region string, storageClass string, ruleId string, enable bool, expireDate string, prefix string) string {
+
+	return fmt.Sprintf(`
+	data "ibm_resource_group" "cos_group" {
+		is_default=true
+	}
+
+	resource "ibm_resource_instance" "instance" {
+		name              = "%s"
+		service           = "cloud-object-storage"
+		plan              = "standard"
+		location          = "global"
+		resource_group_id = data.ibm_resource_group.cos_group.id
+	}
+
+	resource "ibm_cos_bucket" "bucket" {
+		bucket_name           = "%s"
+		resource_instance_id  = ibm_resource_instance.instance.id
+	    region_location       = "%s"
+		storage_class         = "%s"
+	}
+	`, cosServiceName, bucketName, region, storageClass)
+}
+
+func testAccCheckIBMCosBucket_expiredeletemarker(cosServiceName string, bucketName string, regiontype string, region string, storageClass string, ruleId string, enable bool, expiredObjectDeleteMarker bool, prefix string) string {
+
+	return fmt.Sprintf(`
+	data "ibm_resource_group" "cos_group" {
+		is_default=true
+	}
+
+	resource "ibm_resource_instance" "instance" {
+		name              = "%s"
+		service           = "cloud-object-storage"
+		plan              = "standard"
+		location          = "global"
+		resource_group_id = data.ibm_resource_group.cos_group.id
+	}
+
+	resource "ibm_cos_bucket" "bucket" {
+		bucket_name           = "%s"
+		resource_instance_id  = ibm_resource_instance.instance.id
+	    region_location       = "%s"
+		storage_class         = "%s"
+		expire_rule {
+			rule_id                     = "%s"
+			enable                      = true
+			expired_object_delete_marker = true
+			prefix                       = "%s"
+		}
+	}
+	`, cosServiceName, bucketName, region, storageClass, ruleId, prefix)
 }
 
 func testAccCheckIBMCosBucket_archive_expire(cosServiceName string, bucketName string, regiontype string, region string, storageClass string, arch_ruleId string, arch_enable bool, archiveDays int, ruleType string, exp_ruleId string, exp_enable bool, expireDays int, prefix string) string {
@@ -1062,4 +1342,137 @@ func testAccCheckIBMCosBucket_hard_quota(cosServiceName string, bucketName strin
 		hard_quota			  = %d
 	}
 	`, cosServiceName, bucketName, region, storageClass, hardQuota)
+}
+
+func testAccCheckIBMCosBucket_abortincompletempu(cosServiceName string, bucketName string, regiontype string, region string, storageClass string, ruleId string, enable bool, daysAfterInitiation int, prefix string) string {
+	return fmt.Sprintf(`
+	data "ibm_resource_group" "cos_group" {
+		is_default=true
+	}
+
+	resource "ibm_resource_instance" "instance" {
+		name              = "%s"
+		service           = "cloud-object-storage"
+		plan              = "standard"
+		location          = "global"
+		resource_group_id = data.ibm_resource_group.cos_group.id
+	}
+
+	resource "ibm_cos_bucket" "bucket" {
+		bucket_name           = "%s"
+		resource_instance_id  = ibm_resource_instance.instance.id
+	    region_location       = "%s"
+		storage_class         = "%s"
+		abort_incomplete_multipart_upload_days {
+			rule_id             	= "%s"
+			enable              	= true
+			days_after_initiation   = %d
+			prefix                  = "%s"
+		}
+	}
+	`, cosServiceName, bucketName, region, storageClass, ruleId, daysAfterInitiation, prefix)
+}
+
+func testAccCheckIBMCosBucket_abortincompletempu_updateDays(cosServiceName string, bucketName string, regiontype string, region string, storageClass string, ruleId string, enable bool, daysAfterInitiationUpdate int, prefix string) string {
+	return fmt.Sprintf(`
+	data "ibm_resource_group" "cos_group" {
+		is_default=true
+	}
+
+	resource "ibm_resource_instance" "instance" {
+		name              = "%s"
+		service           = "cloud-object-storage"
+		plan              = "standard"
+		location          = "global"
+		resource_group_id = data.ibm_resource_group.cos_group.id
+	}
+	resource "ibm_cos_bucket" "bucket" {
+		bucket_name           = "%s"
+		resource_instance_id  = ibm_resource_instance.instance.id
+	    region_location       = "%s"
+		storage_class         = "%s"
+		abort_incomplete_multipart_upload_days {
+			rule_id            	    = "%s"
+			enable              	= true
+			days_after_initiation   = %d
+			prefix                  = "%s"
+		  }
+	}
+	`, cosServiceName, bucketName, region, storageClass, ruleId, daysAfterInitiationUpdate, prefix)
+
+}
+
+func testAccCheckIBMCosBucket_update_abortincompletempu(cosServiceName string, bucketName string, regiontype string, region string, storageClass string, ruleId string, enable bool, daysAfterInitiation int, prefix string) string {
+	return fmt.Sprintf(`
+	data "ibm_resource_group" "cos_group" {
+		is_default=true
+	}
+
+	resource "ibm_resource_instance" "instance" {
+		name              = "%s"
+		service           = "cloud-object-storage"
+		plan              = "standard"
+		location          = "global"
+		resource_group_id = data.ibm_resource_group.cos_group.id
+	}
+
+	resource "ibm_cos_bucket" "bucket" {
+		bucket_name           = "%s"
+		resource_instance_id  = ibm_resource_instance.instance.id
+	    region_location       = "%s"
+		storage_class         = "%s"
+	}
+	`, cosServiceName, bucketName, region, storageClass)
+}
+
+func testAccCheckIBMCosBucket_noncurrentversion(cosServiceName string, bucketName string, regiontype string, region string, storageClass string, ruleId string, enable bool, noncurrentDays int, prefix string) string {
+	return fmt.Sprintf(`
+	data "ibm_resource_group" "cos_group" {
+		is_default=true
+	}
+
+	resource "ibm_resource_instance" "instance" {
+		name              = "%s"
+		service           = "cloud-object-storage"
+		plan              = "standard"
+		location          = "global"
+		resource_group_id = data.ibm_resource_group.cos_group.id
+	}
+
+	resource "ibm_cos_bucket" "bucket" {
+		bucket_name           = "%s"
+		resource_instance_id  = ibm_resource_instance.instance.id
+	    region_location       = "%s"
+		storage_class         = "%s"
+		noncurrent_version_expiration {
+			rule_id             	= "%s"
+			enable              	= true
+			noncurrent_days  		= %d
+			prefix                  = "%s"
+		}
+	}
+	`, cosServiceName, bucketName, region, storageClass, ruleId, noncurrentDays, prefix)
+}
+
+func testAccCheckIBMCosBucket_update_noncurrentversion(cosServiceName string, bucketName string, regiontype string, region string, storageClass string, ruleId string, enable bool, noncurrentDays int, prefix string) string {
+	return fmt.Sprintf(`
+	data "ibm_resource_group" "cos_group" {
+		is_default=true
+	}
+
+	resource "ibm_resource_instance" "instance" {
+		name              = "%s"
+		service           = "cloud-object-storage"
+		plan              = "standard"
+		location          = "global"
+		resource_group_id = data.ibm_resource_group.cos_group.id
+	}
+
+	resource "ibm_cos_bucket" "bucket" {
+		bucket_name           = "%s"
+		resource_instance_id  = ibm_resource_instance.instance.id
+	    region_location       = "%s"
+		storage_class         = "%s"
+	}
+	`, cosServiceName, bucketName, region, storageClass)
 }

--- a/ibm/validators.go
+++ b/ibm/validators.go
@@ -12,6 +12,7 @@ import (
 	"regexp"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
@@ -64,6 +65,17 @@ func validateAllowedStringValue(validValues []string) schema.SchemaValidateFunc 
 		return
 
 	}
+}
+
+func validBucketLifecycleTimestamp(v interface{}, k string) (ws []string, errors []error) {
+	value := v.(string)
+	_, err := time.Parse(time.RFC3339, fmt.Sprintf("%sT00:00:00Z", value))
+	if err != nil {
+		errors = append(errors, fmt.Errorf(
+			"%q cannot be parsed as RFC3339 Timestamp Format", value))
+	}
+
+	return
 }
 
 func validateRegexpLen(min, max int, regex string) schema.SchemaValidateFunc {

--- a/website/docs/d/cos_bucket.html.markdown
+++ b/website/docs/d/cos_bucket.html.markdown
@@ -47,7 +47,6 @@ Review the argument references that you can specify for your data source.
 
 ## Attribute reference
 In addition to all argument reference list, you can access the following attribute references after your data source is created. 
-
 - `allowed_ip`-  (String) List of `IPv4` or `IPv6` addresses in CIDR notation to be affected by firewall.
 - `activity_tracking` (List) Nested block with the following structure.
 
@@ -60,25 +59,42 @@ In addition to all argument reference list, you can access the following attribu
   Nested scheme for `archive_rule`:
   - `days` - (String)  Specifies the number of days when the specific rule action takes effect.
   - `enable`- (Bool) Specifies archive rule status either `enable` or `disable` for a bucket.
-  - `type` - (String)  Specifies the storage class or archive type to which you want the object to transition. Supported values are `Glacier` or `Accelerated`.
   - `rule_id` - (String)  Unique identifier for the rule. Archive rules allow you to set a specific time frame after which objects transition to archive.
+  - `type` - (String)  Specifies the storage class or archive type to which you want the object to transition. Supported values are `Glacier` or `Accelerated`.
+- `abort_incomplete_multipart_upload_days` (List) Nested block with the following structure.
+  
+  Nested scheme for `abort_incomplete_multipart_upload_days`:
+  - `days_after_initiation` - (String) Specifies the number of days that govern the automatic cancellation of part upload. Clean up incomplete multi-part uploads after a period of time. Must be a value greater than 0.
+  - `enable` - (Bool) A rule can either be `enabled` or `disabled`. A rule is active only when enabled.
+  - `prefix` - (String)  A rule with a prefix will only apply to the objects that match. You can use multiple rules for different actions for different prefixes within the same bucket.
+  - `rule_id` - (String) Unique identifier for the rule. Rules allow you to set a specific time frame after which objects are deleted. Set Rule ID for cos bucket.
 - `crn` - (String) The CRN of the bucket.
 - `cross_region_location` - (String) The location to create a cross-regional bucket.
 - `expire_rule` (List) Nested block with the following structure.
 
   Nested scheme for `expire_rule`:
   - `days` - (String)  Specifies the number of days when the specific rule action takes effect.
+  - `date` - (String)  After the specifies date , the current version of objects in your bucket expires.
   - `enable`- (Bool) Specifies expire rule status either `enable` or `disable` for a bucket.
+  - `expired_object_delete_marker` - (Bool) Expired object delete markers can be automatically cleaned up to improve performance in your bucket. This cannot be used alongside version expiration.
   - `prefix` - (String)  Specifies a prefix filter to apply to only a subset of objects with names that match the prefix.
   - `rule_id` - (String)  Unique identifier for the rule. Expire rules allow you to set a specific time frame after which objects are deleted.
-- `id` - (String) The ID of the bucket. 
-- `key_protect` - (String) The CRN of the IBM Key Protect instance where a root key is already provisioned.
+- `hard_quota` - (String) Maximum bytes for the bucket.
+- `id` - (String) The ID of the bucket.
+- `key_protect` - (String) The CRN of the IBM Key Protect instance where a root key is already provisioned. 
 - `metrics_monitoring`- (List) Nested block with the following structure.
    
-   Nested scheme for `metrics_monitoring`:
-    - `metrics_monitoring_crn` - (String) The first time `metrics_monitoring` is configured. The instance of IBM Cloud monitoring that will receive the bucket metrics.
-    -	`request_metrics_enabled` - (Bool) If set to `true`, all request metrics `ibm_cos_bucket_all_request` is sent to the monitoring service at 1 minute (`@1mins`) granularity.
-    - `usage_metrics_enabled`- (Bool) If set to **true**, all usage metrics (that is `bytes_used`) is sent to the monitoring service.
+  Nested scheme for `metrics_monitoring`:
+  - `metrics_monitoring_crn` - (String) The first time `metrics_monitoring` is configured. The instance of IBM Cloud monitoring that will receive the bucket metrics.
+  -	`request_metrics_enabled` - (Bool) If set to `true`, all request metrics `ibm_cos_bucket_all_request` is sent to the monitoring service at 1 minute (`@1mins`) granularity.
+  - `usage_metrics_enabled`- (Bool) If set to **true**, all usage metrics (that is `bytes_used`) is sent to the monitoring service.
+- `noncurrent_version_expiration` (List) Nested block with the following structure.
+  
+  Nested scheme for `noncurrent_version_expiration`:
+  - `enable` - (Bool) A rule can either be `enabled` or `disabled`. A rule is active only when enabled.
+  - `noncurrent_days` - (Int) Configuration parameter in your policy that says how long to retain a non-current version before deleting it. Must be greater than 0.
+  - `prefix` - (String) The rule applies to any objects with keys that match this prefix. You can use multiple rules for different actions for different prefixes within the same bucket.
+  - `rule_id` - (String) Unique identifier for the rule. Rules allow you to remove versions from objects. Set Rule ID for cos bucket.
 - `object_versioning` - (List) Nestedblock have the following structure:
 
   Nested scheme for `object_verionining`:
@@ -92,6 +108,5 @@ In addition to all argument reference list, you can access the following attribu
   - `maximum` - (String) Specifies maximum duration of time an object can be kept unmodified in the bucket.
   - `minimum` - (String) Specifies minimum duration of time an object must be kept unmodified in the bucket.
   - `permanent` - (String) Specifies a permanent retention status either enable or disable for a bucket.
-- `hard_quota` - (String) Maximum bytes for the bucket.
 - `single_site_location` - (String) The location to create a single site bucket.
 - `storage_class` - (String) The storage class of the bucket.

--- a/website/docs/r/cos_bucket.html.markdown
+++ b/website/docs/r/cos_bucket.html.markdown
@@ -158,6 +158,69 @@ resource "ibm_cos_bucket" "expire_rule_cos" {
   }
 }
 
+### Configure expire date/days with non current version expiration enabled on COS bucket
+
+resource "ibm_cos_bucket" "expirebucket" {
+  bucket_name          = "a-bucket-expiredat"
+  resource_instance_id = ibm_resource_instance.cos_instance.id
+  region_location      = "us-south"
+  storage_class        = "standard"
+  force_delete         = true
+  object_versioning {
+    enable  = true
+  }
+  expire_rule {
+    rule_id = "a-bucket-expire-rule"
+    enable  = true
+    date    = "2021-11-18"
+    prefix  = "logs/"
+  }
+  noncurrent_version_expiration {
+    rule_id = "my-rule-id-bucket-ncversion"
+    enable  = true
+    prefix  = ""
+    noncurrent_days = 1
+  }
+}
+
+### Configure clean up expired object delete markers  on COS bucket
+
+resource "ibm_cos_bucket" "cos_bucket" {
+  bucket_name           = "a-bucket-expireddelemarkertest"
+  resource_instance_id  = ibm_resource_instance.cos_instance.id
+  region_location       = "us-south"
+  storage_class         = "standard"
+  object_versioning {
+    enable  = true
+  }
+  expire_rule {
+    rule_id = "my-rule-id-bucket-expired"
+    enable  = true
+    expired_object_delete_marker = true
+  }
+  noncurrent_version_expiration {
+    rule_id = "my-rule-id-bucket-ncversion"
+    enable  = true
+    prefix  = ""
+    noncurrent_days = 1
+  }
+}
+
+### Configure abort incomplete multipart upload on COS bucket
+
+resource "ibm_cos_bucket" "cos_bucket" {
+  bucket_name           = "a-bucket-multipartupload"
+  resource_instance_id  = ibm_resource_instance.cos_instance.id
+  region_location       = "us-south"
+  storage_class         = "standard"
+  abort_incomplete_multipart_upload_days {
+    rule_id = var.abort_mpu_ruleid
+    enable  = true
+    prefix  = ""
+    days_after_initiation = 1
+  }
+}
+
 ### Configure retention rule on COS bucket
 
 resource "ibm_cos_bucket" "retention_cos" {
@@ -194,53 +257,66 @@ resource "ibm_cos_bucket" "objectversioning" {
 ## Argument reference
 Review the argument references that you can specify for your resource. 
 
-- `bucket_name` - (Required, String) The name of the bucket.
-- `cross_region_location` - (Optional, String) Specify the cross-regional bucket location. Supported values are `us`, `eu`, and `ap`. If you use this parameter, do not set `single_site_location` or `region_location` at the same time.
-- `endpoint_type`- (Optional, String) The type of the endpoint either `public` or `private` or `direct` to be used for buckets. Default value is `public`.
-- `resource_instance_id` - (Required, String) The ID of the IBM Cloud Object Storage service instance for which you want to create a bucket.
-- `region_location` - (Optional, String) The location of a regional bucket. Supported values are `au-syd`, `eu-de`, `eu-gb`, `jp-tok`, `us-east`, `us-south`, `ca-tor`, `jp-osa`, `br-sao`. If you set this parameter, do not set `single_site_location` or `cross_region_location` at the same time.
-- `single_site_location` - (Optional, String) The location for a single site bucket. Supported values are: `ams03`, `che01`, `hkg02`, `mel01`, `mex01`, `mil01`, `mon01`, `osl01`, `par01`, `sjc04`, `sao01`, `seo01`, `sng01`, and `tor01`. If you set this parameter, do not set `region_location` or `cross_region_location` at the same time.
-- `storage_class` - (Required, String) The storage class that you want to use for the bucket. Supported values are `standard`, `vault`, `cold`, `flex`, and `smart`. For more information, about storage classes, see [Use storage classes](https://cloud.ibm.com/docs/cloud-object-storage?topic=cloud-object-storage-classes).
 - `allowed_ip` - (Optional, Array of string)  A list of IPv4 or IPv6 addresses in CIDR notation that you want to allow access to your IBM Cloud Object Storage bucket.
 - `activity_tracking`- (List of objects) Object to enable auditing with IBM Cloud Activity Tracker - Optional - Configure your IBM Cloud Activity Tracker service instance and the type of events that you want to send to your service to audit activity against your bucket. For a list of supported actions, see [Bucket actions](https://cloud.ibm.com/docs/cloud-object-storage?topic=cloud-object-storage-at-events#at-actions-mngt-2).
 
   Nested scheme for `activity_tracking`:
+  - `activity_tracker_crn`-  (Required, String) The CRN of your IBM Cloud Activity Tracker service instance that you want to send your events to. This value is required only when you configure your instance for the first time. 
   - `read_data_events`-  (Required, Bool)  If set to **true**, all read events against a bucket are sent to your IBM Cloud Activity Tracker service instance.
   - `write_data_events`-  (Required, Bool) If set to **true**, all write events against a bucket are sent to your IBM Cloud Activity Tracker service instance.
-  - `activity_tracker_crn`-  (Required, String) The CRN of your IBM Cloud Activity Tracker service instance that you want to send your events to. This value is required only when you configure your instance for the first time. 
-- `metrics_monitoring`- (Object) to enable metrics tracking with IBM Cloud Monitoring - Optional- Set up your IBM Cloud Monitoring service instance to receive metrics for your IBM Cloud Object Storage bucket.
-
-  Nested scheme for `metrics_monitoring`:
-  - `usage_metrics_enabled` : (Optional, Bool) If set to **true**, all usage metrics that is `bytes_used` is sent to the monitoring service.e.
-  - `request_metrics_enabled` : (Optional, Bool) If set to **true**, all request metrics `ibm_cos_bucket_all_request` is sent to the monitoring service `@1mins` granulatiy.
-  - `metrics_monitoring_crn` - (Required, string) Required the first time `metrics_monitoring` is configured. The instance of IBM Cloud Monitoring receives the bucket metrics. 
-
-    **Note:** 
-    - Request metrics are supported in all regions and console has the support. For more details check the [cloud documention](https://cloud.ibm.com/docs/cloud-object-storage?topic=cloud-object-storage-mm-cos-integration).
-    - One of the location option must be present. 
 - `archive_rule` - (Required, List) Nested archive_rule block has following structure.
   
   Nested scheme for `archive_rule`:
-  - `days` - (Required, String) Specifies the number of days when the specific rule action takes effect.
+  - `days` - (Required, Integer) Specifies the number of days when the specific rule action takes effect.
   - `enable` - (Required, Bool) Specifies archive rule status either `enable` or `disable` for a bucket.
   - `rule_id` -  (Optional, Computed, String) The unique ID for the rule. Archive rules allow you to set a specific time frame after the objects transition to the archive.
   - `type` - (Required, String) Specifies the storage class or archive type to which you want the object to transition. Allowed values are `Glacier` or `Accelerated`. 
   
-    **Note:** Archive is available in certain regions only. For more information, see [Integrated Services](https://cloud.ibm.com/docs/cloud-object-storage/basics?topic=cloud-object-storage-service-availability).
-- `expire_rule` - (Required, List) Nested expire_rule block has following structure.
+    **Note:** 
+    - Archive is available in certain regions only. For more information, see [Integrated Services](https://cloud.ibm.com/docs/cloud-object-storage/basics?topic=cloud-object-storage-service-availability).
+    - Restoring object once archive is not supported yet.
+- `bucket_name` - (Required, String) The name of the bucket.
+- `cross_region_location` - (Optional, String) Specify the cross-regional bucket location. Supported values are `us`, `eu`, and `ap`. If you use this parameter, do not set `single_site_location` or `region_location` at the same time.
+- `endpoint_type`- (Optional, String) The type of the endpoint either `public` or `private` or `direct` to be used for buckets. Default value is `public`.
+- `expire_rule` - (Required, List) An expiration rule deletes objects after a defined period (from the object creation date). see [lifecycle actions](https://cloud.ibm.com/docs/cloud-object-storage?topic=cloud-object-storage-versioning). Nested expire_rule block has following structure.
   
   Nested scheme for `expire_rule`:
-  - `rule_id` -  (Optional, Computed, String) Unique ID for the rule. Expire rules allow you to set a specific time frame after which objects are deleted.
+  - `days` - (Optional, Integer) Specifies the number of days when the specific rule action takes effect.
+  - `date` - (Optional, String) After the specifies date , the current version of objects in your bucket expires.
   - `enable` - (Required, Bool) Specifies expire rule status either `enable` or `disable` for a bucket.
-  - `days` - (Required, String) Specifies the number of days when the specific rule action takes effect.
+  - `expired_object_delete_marker` - (Optional, String) Expired object delete markers can be automatically cleaned up to improve performance in your bucket. This cannot be used alongside version expiration. This element for the Expiration action which will only remove delete markers that have no non-current versions at all & objects whose only version is a single delete marker.
   - `prefix` - (Optional, String) Specifies a prefix filter to apply to only a subset of objects with names that match the prefix.
+  - `rule_id` -  (Optional, Computed, String) Unique ID for the rule. Expire rules allow you to set a specific time frame after which objects are deleted.
 
-  **Note:** Both `archive_rule` and `expire_rule` must be managed by  Terraform as they use the same lifecycle configuration. If user creates any of the rule outside of  Terraform by using command line or console, you can see unexpected difference like removal of any of the rule or one rule overrides another. The policy cannot match as expected due to API limitations, as the lifecycle is a single API request for both archive and expire.
+    **Note:** 
+    - Both `archive_rule` and `expire_rule` must be managed by  Terraform as they use the same lifecycle configuration. If user creates any of the rule outside of  Terraform by using command line or console, you can see unexpected difference like removal of any of the rule or one rule overrides another. The policy cannot match as expected due to API limitations, as the lifecycle is a single API request for both archive and expire.
+    - When versioning is enabled/suspended, regular object expiration will no longer remove objects, instead it will create a delete marker, unless the current version is already a delete marker, then nothing happens. If the only version of the object is a delete marker, then the delete marker is removed after X days, or on a specific date.
+    - expired_object_delete_marker element can not be used in conjunction with other expiry action elements (Days or Date).
+    - The expiry 3 action elements (Days, Date, ExpiredObjectDeleteMarker) are all mutually exclusive.Anyone parameter can apply among 3 (Days, Date, ExpiredObjectDeleteMarker) in expire_rule.
+    - You cannot specify both a Days and ExpiredObjectDeleteMarker tag on the same rule. Specifying the Days tag will automatically perform ExpiredObjectDeleteMarker cleanup once delete markers are old enough to satisfy the age criteria. You can create a separate rule with only the tag ExpiredObjectDeleteMarker to clean up delete markers as soon as they become the only version.
 - `force_delete`- (Optional, Bool) As the default value set to **true**, it will delete all the objects in the COS Bucket and then delete the bucket. 
 
-  **Note:** `force_delete` will timeout on buckets with a large amount of objects. 24 hours before you delete the bucket you can set an expire rule to remove all the files over a day old.
+    **Note:** `force_delete` will timeout on buckets with a large amount of objects. 24 hours before you delete the bucket you can set an expire rule to remove all the files over a day old.
+- `hard_quota` - (Optional, Integer) Sets a maximum amount of storage (in bytes) available for a bucket. For more information, check the [cloud documention](https://cloud.ibm.com/docs/cloud-object-storage?topic=cloud-object-storage-quota).
 - `key_protect` - (Optional, String) The CRN of the IBM Key Protect root key that you want to use to encrypt data that is sent and stored in IBM Cloud Object Storage. Before you can enable IBM Key Protect encryption, you must provision an instance of IBM Key Protect and authorize the service to access IBM Cloud Object Storage. For more information, see [Server-Side Encryption with IBM Key Protect or Hyper Protect Crypto Services (SSE-KP)](https://cloud.ibm.com/docs/cloud-object-storage?topic=cloud-object-storage-encryption).
-- `object_versioning` - (List) Nested block have the following structure:
+- `metrics_monitoring`- (Object) to enable metrics tracking with IBM Cloud Monitoring - Optional- Set up your IBM Cloud Monitoring service instance to receive metrics for your IBM Cloud Object Storage bucket.
+
+  Nested scheme for `metrics_monitoring`:
+  - `metrics_monitoring_crn` - (Required, string) Required the first time `metrics_monitoring` is configured. The instance of IBM Cloud Monitoring receives the bucket metrics. 
+  - `request_metrics_enabled` : (Optional, Bool) If set to **true**, all request metrics `ibm_cos_bucket_all_request` is sent to the monitoring service `@1mins` granulatiy.
+  - `usage_metrics_enabled` : (Optional, Bool) If set to **true**, all usage metrics that is `bytes_used` is sent to the monitoring service.e.
+
+    **Note:** 
+    - Request metrics are supported in all regions and console has the support. For more details check the [cloud documention](https://cloud.ibm.com/docs/cloud-object-storage?topic=cloud-object-storage-mm-cos-integration).
+    - One of the location option must be present. 
+- `noncurrent_version_expiration` - (Required, List) lifecycle has a versioning related expiration action: non-current version expiration. This can remove old versions of objects after they've been non-current for a specified number of days which is specified with a NoncurrentDays parameter on the rule. see [lifecycle actions](https://cloud.ibm.com/docs/cloud-object-storage?topic=cloud-object-storage-versioning). Nested noncurrent_version_expiration block has following structure.
+
+  Nested scheme for `noncurrent_version_expiration`:
+  - `enable` - (Requried, Bool) A rule can either be `enabled` or `disabled`. A rule is active only when enabled.
+  - `noncurrent_days` - (Optional, Integer) Configuration parameter in your policy that says how long to retain a non-current version before deleting it. Must be greater than 0.
+  - `prefix` - (Optional, String) The rule applies to any objects with keys that match this prefix. You can use multiple rules for different actions for different prefixes within the same bucket.
+  - `rule_id` - (Optional, String) Unique identifier for the rule. Rules allow you to remove versions from objects. Set Rule ID for cos bucket.
+- `object_versioning` - (List) Object Versioning allows the COS user to keep multiple versions of an objet in a bucke to protect against accidental deletion or overwrites. With versioning, you can easilyrecover from both unintended user actions and application failure. Nested block have the following structure:
 
   Nested scheme for `object_versioning`:
   - `enable` : (Optional, Bool) Specifies Versioning status either enable or Suspended for the objects in the bucket.Default value set to false.
@@ -250,11 +326,12 @@ Review the argument references that you can specify for your resource.
     - If cos bucket has versioning enabled and set to false, versioning will be suspended.
     - Versioning can only be suspended, we cannot disabled once after it is enabled.
     - To permanently delete individual versions of an object, a delete request must specify a version ID.
-    - Containers with object expiry cannot have versioning enabled or suspended, and containers with versioning enabled or suspended cannot have expiry lifecycle actions enabled to them.
     - COS Object versioning and COS Bucket Protection `(WORM)` cannot be used together.
     - Containers with proxy configuration cannot use versioning and vice versa.
     - SoftLayer accounts cannot use versioning.
     - Currently, you cannot support `MFA_Delete`, that is a feature to add additional security to version delete.
+- `region_location` - (Optional, String) The location of a regional bucket. Supported values are `au-syd`, `eu-de`, `eu-gb`, `jp-tok`, `us-east`, `us-south`, `ca-tor`, `jp-osa`, `br-sao`. If you set this parameter, do not set `single_site_location` or `cross_region_location` at the same time.
+- `resource_instance_id` - (Required, String) The ID of the IBM Cloud Object Storage service instance for which you want to create a bucket.
 - `retention_rule` - (List) Nested block have the following structure:
   
   Nested scheme for `retention rule`:
@@ -268,7 +345,8 @@ Review the argument references that you can specify for your resource.
      - The minimum retention period must be less than or equal to the default retention period, that in turn must be less than or equal to the maximum retention period.
      - Permanent retention can only be enabled at a IBM Cloud Object Storage bucket level with retention policy enabled and users are able to select the permanent retention period option during object uploads. Once enabled, this process can't be reversed and objects uploaded that use a permanent retention period cannot be deleted. It's the responsibility of the users to validate at their end if there's a legitimate need to permanently store objects by using Object Storage buckets with a retention policy.
      - force deleting the bucket will not work if any object is still under retention. As objects cannot be deleted or overwritten until the retention period has expired and all the legal holds have been removed.
-- `hard_quota` - (Optional, Integer) Sets a maximum amount of storage (in bytes) available for a bucket. For more information, check the [cloud documention](https://cloud.ibm.com/docs/cloud-object-storage?topic=cloud-object-storage-quota).
+- `single_site_location` - (Optional, String) The location for a single site bucket. Supported values are: `ams03`, `che01`, `hkg02`, `mel01`, `mex01`, `mil01`, `mon01`, `osl01`, `par01`, `sjc04`, `sao01`, `seo01`, `sng01`, and `tor01`. If you set this parameter, do not set `region_location` or `cross_region_location` at the same time.
+- `storage_class` - (Required, String) The storage class that you want to use for the bucket. Supported values are `standard`, `vault`, `cold`, `flex`, and `smart`. For more information, about storage classes, see [Use storage classes](https://cloud.ibm.com/docs/cloud-object-storage?topic=cloud-object-storage-classes).
 
 ## Attribute reference
 In addition to all argument reference list, you can access the following attribute reference after your resource is created.


### PR DESCRIPTION
COS Objectversioning ph2 & abort incomplete MPU:----

-  Incomplete multi-part upload cleanup. 
-  Object Expiration for Versioned Buckets New Lifecycle Functionality
-  Non-Current Version Expiration Lifecycle
-  Expiration Lifecycle behavior on versioning-enabled buckets
-  Expired Object Delete Marker Lifecycle