### PR TITLE
ibm_cos_bucket: support regions with a numerical suffix

### DIFF
--- a/ibm/resource_ibm_cos_bucket.go
+++ b/ibm/resource_ibm_cos_bucket.go
@@ -962,7 +962,7 @@ func resourceIBMCOSBucketRead(d *schema.ResourceData, meta interface{}) error {
 	if err != nil {
 		return err
 	}
-	regionLocationRegex, err := regexp.Compile("^[a-z]{2}-[a-z]{2,5}-[a-z]{4,8}$")
+	regionLocationRegex, err := regexp.Compile("^[a-z]{2}-[a-z]{2,5}[0-9]?-[a-z]{4,8}$")
 	if err != nil {
 		return err
 	}

--- a/ibm/resource_ibm_cos_bucket.go
+++ b/ibm/resource_ibm_cos_bucket.go
@@ -38,6 +38,10 @@ var storageClass = []string{
 	"standard", "vault", "cold", "flex", "smart",
 }
 
+var singleSiteLocationRegex = regexp.MustCompile("^[a-z]{3}[0-9][0-9]-[a-z]{4,8}$")
+var regionLocationRegex = regexp.MustCompile("^[a-z]{2}-[a-z]{2,5}[0-9]?-[a-z]{4,8}$")
+var crossRegionLocationRegex = regexp.MustCompile("^[a-z]{2}-[a-z]{4,8}$")
+
 const (
 	keyAlgorithm = "AES256"
 )
@@ -956,19 +960,6 @@ func resourceIBMCOSBucketRead(d *schema.ResourceData, meta interface{}) error {
 		if *b.Name == bucketName {
 			bLocationConstraint = *b.LocationConstraint
 		}
-	}
-
-	singleSiteLocationRegex, err := regexp.Compile("^[a-z]{3}[0-9][0-9]-[a-z]{4,8}$")
-	if err != nil {
-		return err
-	}
-	regionLocationRegex, err := regexp.Compile("^[a-z]{2}-[a-z]{2,5}[0-9]?-[a-z]{4,8}$")
-	if err != nil {
-		return err
-	}
-	crossRegionLocationRegex, err := regexp.Compile("^[a-z]{2}-[a-z]{4,8}$")
-	if err != nil {
-		return err
 	}
 
 	if singleSiteLocationRegex.MatchString(bLocationConstraint) {


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/IBM-Cloud/terraform-provider-ibm/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
make test
==> Checking that code complies with gofmt requirements...
go test -i $(go list ./... |grep -v 'vendor') || exit 1
go test: -i flag is deprecated
echo $(go list ./... |grep -v 'vendor') | \
		xargs -t -n4 go test  -timeout=30s -parallel=4
go test -timeout=30s -parallel=4 github.com/IBM-Cloud/terraform-provider-ibm github.com/IBM-Cloud/terraform-provider-ibm/ibm github.com/IBM-Cloud/terraform-provider-ibm/ibm/internal/hashcode github.com/IBM-Cloud/terraform-provider-ibm/ibm/internal/mutexkv
?   	github.com/IBM-Cloud/terraform-provider-ibm	[no test files]
ok  	github.com/IBM-Cloud/terraform-provider-ibm/ibm	2.792s
ok  	github.com/IBM-Cloud/terraform-provider-ibm/ibm/internal/hashcode	(cached)
ok  	github.com/IBM-Cloud/terraform-provider-ibm/ibm/internal/mutexkv	(cached)
go test -timeout=30s -parallel=4 github.com/IBM-Cloud/terraform-provider-ibm/version
?   	github.com/IBM-Cloud/terraform-provider-ibm/version	[no test files]
```

Why:

Some IBM Cloud regions have numerical suffices. The `ibm_cos_bucket` resource attempts to extract the region and plan information from a combined `<region>-<plan>` string returned by the API. The regex match which extracts the region and plan type did not handle regions containing a numerical suffix, which prevented ibm_cos_bucket resources in those regions from being imported.

How:

- Update the regionLocationRegex regex in the ibm_cos_bucket resource to allow a numerical region suffix.
- Extract the location extraction regexes to package-level scope to make them testable.
- Add unit tests for the regexes, testing that they match the defined values for single site, regional and cross-regional locations combined with the available plan values.
