### PR TITLE
reuse the same regex expression defined for resource

### DIFF
--- a/ibm/data_source_ibm_cos_bucket.go
+++ b/ibm/data_source_ibm_cos_bucket.go
@@ -5,7 +5,6 @@ package ibm
 
 import (
 	"fmt"
-	"regexp"
 	"strings"
 	"time"
 
@@ -373,19 +372,6 @@ func dataSourceIBMCosBucketRead(d *schema.ResourceData, meta interface{}) error 
 		return err
 	}
 	bLocationConstraint := *bucketLocationConstraint.LocationConstraint
-
-	singleSiteLocationRegex, err := regexp.Compile("^[a-z]{3}[0-9][0-9]-[a-z]{4,8}$")
-	if err != nil {
-		return err
-	}
-	regionLocationRegex, err := regexp.Compile("^[a-z]{2}-[a-z]{2,5}-[a-z]{4,8}$")
-	if err != nil {
-		return err
-	}
-	crossRegionLocationRegex, err := regexp.Compile("^[a-z]{2}-[a-z]{4,8}$")
-	if err != nil {
-		return err
-	}
 
 	if singleSiteLocationRegex.MatchString(bLocationConstraint) {
 		d.Set("single_site_location", strings.Split(bLocationConstraint, "-")[0])


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/IBM-Cloud/terraform-provider-ibm/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```
