### PR TITLE
add workerpool zone attachment resource

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -486,7 +486,7 @@
         "hashed_secret": "91199272d5d6a574a51722ca6f3d1148edb1a0e7",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 93,
+        "line_number": 94,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -494,7 +494,7 @@
         "hashed_secret": "a8d42722d33725b90f8e5ca1ae8aed3edaac55bd",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 108,
+        "line_number": 109,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -502,7 +502,7 @@
         "hashed_secret": "5f28e11957b762c5558d22b7ad9b15d822cb856a",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 110,
+        "line_number": 111,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -510,7 +510,7 @@
         "hashed_secret": "c88488e962fe2062632f389e755794fc3c29ff0d",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 111,
+        "line_number": 112,
         "type": "Secret Keyword",
         "verified_result": null
       }

--- a/examples/ibm-satellite/README.md
+++ b/examples/ibm-satellite/README.md
@@ -6,7 +6,7 @@ This example uses below modules to set up the satellite location with IBM enviro
 
 1. [satellite-location](modules/location) This module `creates satellite location` for the specified zone|location|region and `generates script` named addhost.sh in the working directory by performing attach host.The generated script is used by `ibm_is_instance` as `user_data` and runs the script. At this stage all the VMs that has run addhost.sh will be attached to the satellite location and will be in unassigned state.
 2. [satellite-host](modules/host) This module assigns 3 host to setup the location control plane.
-3. [satellite-cluster](modules/cluster) This module will create ROKS satellite cluster and worker pool.
+3. [satellite-cluster](modules/cluster) This module will create ROKS satellite cluster and worker pool, attach zone to worker pool.
 4. [satellite-link](modules/link) This module will create satellite link.
 5. [satellite-route](modules/route) This module will create openshift route.
 6. [satellite-endpoint](modules/endpoint) This module will create satellite endpoint.
@@ -69,6 +69,7 @@ module "satellite-cluster" {
   workerpool_labels    = var.workerpool_labels
   cluster_tags         = var.cluster_tags
   host_labels          = var.host_labels
+  zone_name            = var.zone_name
 }
 
 module "satellite-dns" {
@@ -146,6 +147,7 @@ module "satellite-endpoint" {
 | default_wp_labels              | Labels on the default worker pool                                 | map      | n/a     | no       |
 | worker_pool_name               | Public SSH key used to provision Host/VSI                         | string   | satellite-ibm-cluster-wp     | no       |
 | workerpool_labels              | Labels on the worker pool                                         | map      | n/a     | no       |
+| zone_name                      | creates new zone on workerpool                                    | string   | n/a     | no       |
 | cluster_tags                   | List of tags for the cluster resource                             | list     | [ "env:cluster" ]     | no       |
 | connection_type                | The type of the endpoint.                                         | string   | n/a     | no |
 | is_endpoint_provision          | Determines if the route and endpoint has to be created or not.    | bool   | false |   no      |

--- a/examples/ibm-satellite/cluster.tf
+++ b/examples/ibm-satellite/cluster.tf
@@ -12,6 +12,7 @@ module "satellite-cluster" {
   workerpool_labels = var.workerpool_labels
   cluster_tags      = var.cluster_tags
   host_labels       = var.host_labels
+  zone_name         = var.zone_name
 
   depends_on = [module.satellite-host]
 }

--- a/examples/ibm-satellite/instance.tf
+++ b/examples/ibm-satellite/instance.tf
@@ -3,7 +3,7 @@ data "ibm_resource_group" "resource_group" {
 }
 
 data "ibm_is_image" "rhel7" {
-  name = "ibm-redhat-7-9-minimal-amd64-3"
+  name = "ibm-redhat-7-9-minimal-amd64-4"
 }
 
 resource "ibm_is_vpc" "vpc" {

--- a/examples/ibm-satellite/modules/cluster/README.md
+++ b/examples/ibm-satellite/modules/cluster/README.md
@@ -40,6 +40,7 @@ module "satellite-cluster" {
   workerpool_labels    = var.workerpool_labels
   cluster_tags         = var.cluster_tags
   host_labels          = var.host_labels
+  zone_name            = var.zone_name
 }
 ```
 <!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
@@ -61,6 +62,7 @@ module "satellite-cluster" {
 | host_labels                   | List of host labels to assign host to cluter                      | list     | n/a     | no       |
 | workerpool_labels             | Labels on the worker pool                                         | map      | n/a     | no       |
 | cluster_tags                  | List of tags for the cluster resource                             | list     | n/a     | no       |
+| zone_name                     | creates new zone on workerpool                                    | string   | n/a     | no       |
 
 
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/examples/ibm-satellite/modules/cluster/main.tf
+++ b/examples/ibm-satellite/modules/cluster/main.tf
@@ -51,3 +51,14 @@ data "ibm_satellite_cluster_worker_pool" "read_cluster_wp" {
   depends_on = [ibm_satellite_cluster_worker_pool.create_cluster_wp]
 }
 
+resource "ibm_satellite_cluster_worker_pool_zone_attachment" "create_worker_pool_zone" {
+  cluster     = data.ibm_satellite_cluster_worker_pool.read_cluster_wp.cluster
+  worker_pool = var.worker_pool_name
+  zone        = var.zone_name
+}
+
+data "ibm_satellite_cluster_worker_pool_zone_attachment" "read_worker_pool_zone_attachment" {
+  cluster     = ibm_satellite_cluster_worker_pool_zone_attachment.create_worker_pool_zone.cluster
+  worker_pool = var.worker_pool_name
+  zone        = var.zone_name
+}

--- a/examples/ibm-satellite/modules/cluster/variables.tf
+++ b/examples/ibm-satellite/modules/cluster/variables.tf
@@ -61,3 +61,8 @@ variable "cluster_tags" {
   type        = list(string)
   default     = ["env:cluster"]
 }
+
+variable "zone_name" {
+  description = "zone name"
+  type        = string
+}

--- a/examples/ibm-satellite/variables.tf
+++ b/examples/ibm-satellite/variables.tf
@@ -9,7 +9,7 @@ variable "ibmcloud_api_key" {
 
 variable "ibm_region" {
   description = "Region of the IBM Cloud account. Currently supported regions for satellite are us-east and eu-gb region."
-  default     = "us-east"
+  default = "us-east"
 }
 
 variable "resource_group" {
@@ -21,6 +21,7 @@ variable "resource_group" {
 ##################################################
 variable "location" {
   description = "Location Name"
+  default = "satelllite-ibm"
 }
 
 variable "managed_from" {
@@ -81,7 +82,7 @@ variable "addl_host_count" {
 variable "is_prefix" {
   description = "Prefix to the Names of the VPC Infrastructure resources"
   type        = string
-  default     = "satellite-ibm-eb"
+  default     = "satellite-ibm"
 }
 
 variable "public_key" {
@@ -117,7 +118,7 @@ variable "default_wp_labels" {
 variable "kube_version" {
   description = "Satellite Kube Version"
   type        = string
-  default     = "4.6_openshift"
+  default     = "4.7_openshift"
 }
 
 variable "worker_pool_name" {
@@ -145,6 +146,12 @@ variable "cluster_tags" {
   description = "List of tags associated with this resource."
   type        = list(string)
   default     = ["env:cluster"]
+}
+
+variable "zone_name" {
+  description = "zone name"
+  type        = string
+  default     = "test_zone"
 }
 
 ##################################################

--- a/ibm/data_source_ibm_satellite_cluster_worker_pool_zone_attachment.go
+++ b/ibm/data_source_ibm_satellite_cluster_worker_pool_zone_attachment.go
@@ -1,0 +1,97 @@
+package ibm
+
+import (
+	"context"
+	"fmt"
+	"log"
+
+	"github.com/IBM-Cloud/container-services-go-sdk/kubernetesserviceapiv1"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+func dataSourceIBMSatelliteClusterWorkerPoolAttachment() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceIBMSatelliteClusterWorkerPoolAttachmentRead,
+
+		Schema: map[string]*schema.Schema{
+			"cluster": &schema.Schema{
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "Name or id of the cluster",
+			},
+			"worker_pool": &schema.Schema{
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "worker pool name",
+			},
+			"zone": &schema.Schema{
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "worker pool zone name",
+			},
+			"resource_group_id": &schema.Schema{
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "The ID of the resource group that the Satellite location is in. To list the resource group ID of the location, use the `GET /v2/satellite/getController` API method.",
+			},
+			"worker_count": &schema.Schema{
+				Type:        schema.TypeInt,
+				Computed:    true,
+				Description: "Number of workers",
+			},
+			"autobalance_enabled": &schema.Schema{
+				Type:        schema.TypeBool,
+				Computed:    true,
+				Description: "Auto enabled status",
+			},
+			"messages": {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Description: "Filter features by a list of comma separated collections.",
+				Elem:        &schema.Schema{Type: schema.TypeString},
+			},
+		},
+	}
+}
+
+func dataSourceIBMSatelliteClusterWorkerPoolAttachmentRead(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	satClient, err := meta.(ClientSession).SatelliteClientSession()
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	cluster := d.Get("cluster").(string)
+	workerpool := d.Get("worker_pool").(string)
+	zone := d.Get("zone").(string)
+
+	getWorkerPoolOptions := &kubernetesserviceapiv1.GetWorkerPoolOptions{}
+	getWorkerPoolOptions.SetCluster(cluster)
+	getWorkerPoolOptions.SetWorkerpool(workerpool)
+
+	if v, ok := d.GetOk("resource_group_id"); ok {
+		getWorkerPoolOptions.SetXAuthResourceGroup(v.(string))
+	}
+
+	getWorkerPoolResponse, response, err := satClient.GetWorkerPoolWithContext(context, getWorkerPoolOptions)
+	if err != nil {
+		if response != nil && response.StatusCode == 404 {
+			log.Printf("[DEBUG] Satellite cluster workerpool zone attachment record is not found %s\n%s", err, response)
+			return diag.FromErr(fmt.Errorf("Satellite cluster workerpool zone attachment record is not found %s\n%s", err, response))
+		}
+		log.Printf("[DEBUG] GetWorkerPoolWithContext failed %s\n%s", err, response)
+		return diag.FromErr(fmt.Errorf("GetWorkerPoolWithContext failed %s\n%s", err, response))
+	}
+
+	if getWorkerPoolResponse != nil && getWorkerPoolResponse.Zones != nil {
+		for _, z := range getWorkerPoolResponse.Zones {
+			if zone == *z.ID {
+				d.Set("worker_count", *z.WorkerCount)
+				d.Set("autobalance_enabled", *z.AutobalanceEnabled)
+				d.Set("messages", *&z.Messages)
+				d.SetId(fmt.Sprintf("%s/%s/%s", cluster, workerpool, zone))
+			}
+		}
+	}
+	return nil
+}

--- a/ibm/data_source_ibm_satellite_cluster_worker_pool_zone_attachment_test.go
+++ b/ibm/data_source_ibm_satellite_cluster_worker_pool_zone_attachment_test.go
@@ -1,0 +1,149 @@
+// Copyright IBM Corp. 2017, 2021 All Rights Reserved.
+// Licensed under the Mozilla Public License v2.0
+
+package ibm
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+func TestAccIBMSatelliteClusterWorkerPoolZoneAttachmentDataSourceBasic(t *testing.T) {
+	clusterName := fmt.Sprintf("tf-satellitecluster-%d", acctest.RandIntRange(10, 100))
+	locationName := fmt.Sprintf("tf-satellitelocation-%d", acctest.RandIntRange(10, 100))
+	zone := fmt.Sprintf("tf-zone-%d", acctest.RandIntRange(10, 100))
+	resource_prefix := fmt.Sprintf("tf-satellite-%d", acctest.RandIntRange(10, 100))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckIBMSatelliteClusterorkerPoolZoneAttachmentDataSourceConfig(clusterName, locationName, resource_prefix, zone),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet("data.ibm_satellite_cluster_worker_pool_zone_attachment.read_worker_pool_zone_attachment", "id")),
+			},
+		},
+	})
+}
+
+func testAccCheckIBMSatelliteClusterorkerPoolZoneAttachmentDataSourceConfig(cluster, location, resource_prefix, zone string) string {
+	return fmt.Sprintf(`
+
+	provider "ibm" {
+		region = "us-south"
+	}
+
+	variable "location_zones" {
+		description = "Allocate your hosts across these three zones"
+		type        = list(string)
+		default     = ["us-south-1", "us-south-2", "us-south-3"]
+	}
+
+	resource "ibm_satellite_location" "location" {
+		location      = "%s"
+		managed_from  = "wdc04"
+		zones		  = var.location_zones
+	}
+
+	data "ibm_is_image" "rhel7" {
+		name = "ibm-redhat-7-9-minimal-amd64-4"
+	}
+
+	data "ibm_satellite_attach_host_script" "script" {
+		location          = ibm_satellite_location.location.id
+		labels            = ["env:prod"]
+		host_provider     = "ibm"
+	}
+
+	data "ibm_resource_group" "resource_group" {
+		is_default = true
+	}
+	  
+	resource "ibm_is_vpc" "satellite_vpc" {
+		name = "%s-vpc-1"
+	}
+	  
+	resource "ibm_is_subnet" "satellite_subnet" {
+		count                    = 3
+
+		name                     = "%s-subnet-${count.index}"
+		vpc                      = ibm_is_vpc.satellite_vpc.id
+		total_ipv4_address_count = 256
+		zone                     = "us-south-${count.index + 1}"
+	}
+	  
+	resource "ibm_is_ssh_key" "satellite_ssh" {	  
+		name        = "%s-ibm-ssh"
+		public_key  = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCKVmnMOlHKcZK8tpt3MP1lqOLAcqcJzhsvJcjscgVERRN7/9484SOBJ3HSKxxNG5JN8owAjy5f9yYwcUg+JaUVuytn5Pv3aeYROHGGg+5G346xaq3DAwX6Y5ykr2fvjObgncQBnuU5KHWCECO/4h8uWuwh/kfniXPVjFToc+gnkqA+3RKpAecZhFXwfalQ9mMuYGFxn+fwn8cYEApsJbsEmb0iJwPiZ5hjFC8wREuiTlhPHDgkBLOiycd20op2nXzDbHfCHInquEe/gYxEitALONxm0swBOwJZwlTDOB7C6y2dzlrtxr1L59m7pCkWI4EtTRLvleehBoj3u7jB4usR"
+	}
+	  
+	resource "ibm_is_instance" "satellite_instance" {
+		count          = 3
+
+		name           = "%s-instance-${count.index}"
+		vpc            = ibm_is_vpc.satellite_vpc.id
+		zone           = "us-south-${count.index + 1}"
+		image          = data.ibm_is_image.rhel7.id
+		profile        = "mx2-8x64"
+		keys           = [ibm_is_ssh_key.satellite_ssh.id]
+		resource_group = data.ibm_resource_group.resource_group.id
+		user_data      = data.ibm_satellite_attach_host_script.script.host_script
+		
+		primary_network_interface {
+		  subnet = ibm_is_subnet.satellite_subnet[count.index].id
+		}
+	}
+	  
+	resource "ibm_is_floating_ip" "satellite_ip" {
+		count  = 3
+
+		name   = "%s-fip-${count.index}"
+		target = ibm_is_instance.satellite_instance[count.index].primary_network_interface[0].id
+	}
+	  
+	resource "ibm_satellite_host" "assign_host" {
+		count  = 3
+	  
+		location      = ibm_satellite_location.location.id
+		host_id       = element(ibm_is_instance.satellite_instance[*].name, count.index)
+		labels        = ["env:prod"]
+		zone          = element(var.location_zones, count.index)
+		host_provider = "ibm"
+	}
+
+	resource "ibm_satellite_cluster" "create_cluster" {
+		name                   = "%s"  
+		location               = ibm_satellite_location.location.id
+		enable_config_admin    = true
+		kube_version           = "4.7_openshift"
+		wait_for_worker_update = true
+		dynamic "zones" {
+			for_each = var.location_zones
+			content {
+				id	= zones.value
+			}
+		}
+		default_worker_pool_labels = {
+			"test"  = "test-pool1" 
+			"test1" = "test-pool2"
+		}
+	}
+
+	resource "ibm_satellite_cluster_worker_pool_zone_attachment" "satellite_cluster_worker_pool_zone_attachment" {
+		cluster = ibm_satellite_cluster.create_cluster.id
+		worker_pool = "default"
+		zone = "%s"
+	}
+
+	data "ibm_satellite_cluster_worker_pool_zone_attachment" "read_worker_pool_zone_attachment" {
+		cluster = ibm_satellite_cluster_worker_pool_zone_attachment.satellite_cluster_worker_pool_zone_attachment.cluster
+		worker_pool = "default"
+		zone = "%s"
+	}
+
+	`, location, resource_prefix, resource_prefix, resource_prefix, resource_prefix, resource_prefix, cluster, zone, zone)
+}

--- a/ibm/provider.go
+++ b/ibm/provider.go
@@ -471,13 +471,14 @@ func Provider() *schema.Provider {
 			"ibm_secrets_manager_secret":  dataSourceIBMSecretsManagerSecret(),
 
 			//Added for Satellite
-			"ibm_satellite_location":            dataSourceIBMSatelliteLocation(),
-			"ibm_satellite_location_nlb_dns":    dataSourceIBMSatelliteLocationNLBDNS(),
-			"ibm_satellite_attach_host_script":  dataSourceIBMSatelliteAttachHostScript(),
-			"ibm_satellite_cluster":             dataSourceIBMSatelliteCluster(),
-			"ibm_satellite_cluster_worker_pool": dataSourceIBMSatelliteClusterWorkerPool(),
-			"ibm_satellite_link":                dataSourceIbmSatelliteLink(),
-			"ibm_satellite_endpoint":            dataSourceIbmSatelliteEndpoint(),
+			"ibm_satellite_location":                            dataSourceIBMSatelliteLocation(),
+			"ibm_satellite_location_nlb_dns":                    dataSourceIBMSatelliteLocationNLBDNS(),
+			"ibm_satellite_attach_host_script":                  dataSourceIBMSatelliteAttachHostScript(),
+			"ibm_satellite_cluster":                             dataSourceIBMSatelliteCluster(),
+			"ibm_satellite_cluster_worker_pool":                 dataSourceIBMSatelliteClusterWorkerPool(),
+			"ibm_satellite_link":                                dataSourceIbmSatelliteLink(),
+			"ibm_satellite_endpoint":                            dataSourceIbmSatelliteEndpoint(),
+			"ibm_satellite_cluster_worker_pool_zone_attachment": dataSourceIBMSatelliteClusterWorkerPoolAttachment(),
 
 			// Catalog related resources
 			"ibm_cm_catalog":           dataSourceIBMCmCatalog(),
@@ -806,13 +807,14 @@ func Provider() *schema.Provider {
 			"ibm_schematics_resource_query": resourceIBMSchematicsResourceQuery(),
 
 			//satellite  resources
-			"ibm_satellite_location":            resourceIBMSatelliteLocation(),
-			"ibm_satellite_host":                resourceIBMSatelliteHost(),
-			"ibm_satellite_cluster":             resourceIBMSatelliteCluster(),
-			"ibm_satellite_cluster_worker_pool": resourceIBMSatelliteClusterWorkerPool(),
-			"ibm_satellite_link":                resourceIbmSatelliteLink(),
-			"ibm_satellite_endpoint":            resourceIbmSatelliteEndpoint(),
-			"ibm_satellite_location_nlb_dns":    resourceIbmSatelliteLocationNlbDns(),
+			"ibm_satellite_location":                            resourceIBMSatelliteLocation(),
+			"ibm_satellite_host":                                resourceIBMSatelliteHost(),
+			"ibm_satellite_cluster":                             resourceIBMSatelliteCluster(),
+			"ibm_satellite_cluster_worker_pool":                 resourceIBMSatelliteClusterWorkerPool(),
+			"ibm_satellite_link":                                resourceIbmSatelliteLink(),
+			"ibm_satellite_endpoint":                            resourceIbmSatelliteEndpoint(),
+			"ibm_satellite_location_nlb_dns":                    resourceIbmSatelliteLocationNlbDns(),
+			"ibm_satellite_cluster_worker_pool_zone_attachment": resourceIbmSatelliteClusterWorkerPoolZoneAttachment(),
 
 			//Added for Resource Tag
 			"ibm_resource_tag": resourceIBMResourceTag(),

--- a/ibm/resource_ibm_satellite_cluster_worker_pool_zone_attachment.go
+++ b/ibm/resource_ibm_satellite_cluster_worker_pool_zone_attachment.go
@@ -1,0 +1,160 @@
+// Copyright IBM Corp. 2021 All Rights Reserved.
+// Licensed under the Mozilla Public License v2.0
+
+package ibm
+
+import (
+	"context"
+	"fmt"
+	"log"
+
+	"github.com/IBM-Cloud/container-services-go-sdk/kubernetesserviceapiv1"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+func resourceIbmSatelliteClusterWorkerPoolZoneAttachment() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceIbmSatelliteClusterWorkerPoolZoneAttachmentCreate,
+		ReadContext:   resourceIbmSatelliteClusterWorkerPoolZoneAttachmentRead,
+		DeleteContext: resourceIbmSatelliteClusterWorkerPoolZoneAttachmentDelete,
+		Importer:      &schema.ResourceImporter{},
+
+		Schema: map[string]*schema.Schema{
+			"cluster": &schema.Schema{
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"worker_pool": &schema.Schema{
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"zone": &schema.Schema{
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"resource_group_id": &schema.Schema{
+				Type:        schema.TypeString,
+				Optional:    true,
+				ForceNew:    true,
+				Description: "The ID of the resource group that the Satellite location is in. To list the resource group ID of the location, use the `GET /v2/satellite/getController` API method.",
+			},
+			"autobalance_enabled": &schema.Schema{
+				Type:     schema.TypeBool,
+				Computed: true,
+			},
+			"messages": {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Description: "Filter features by a list of comma separated collections.",
+				Elem:        &schema.Schema{Type: schema.TypeString},
+			},
+			"worker_count": {
+				Description: "Number of workers",
+				Type:        schema.TypeInt,
+				Computed:    true,
+			},
+		},
+	}
+}
+
+func resourceIbmSatelliteClusterWorkerPoolZoneAttachmentCreate(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	satClient, err := meta.(ClientSession).SatelliteClientSession()
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	cluster := d.Get("cluster").(string)
+	workerpool := d.Get("worker_pool").(string)
+	zone := d.Get("zone").(string)
+	createSatelliteWorkerPoolZoneOptions := &kubernetesserviceapiv1.CreateSatelliteWorkerPoolZoneOptions{}
+	createSatelliteWorkerPoolZoneOptions.SetCluster(cluster)
+	createSatelliteWorkerPoolZoneOptions.SetWorkerpool(workerpool)
+	createSatelliteWorkerPoolZoneOptions.SetID(zone)
+
+	if _, ok := d.GetOk("resource_group_id"); ok {
+		createSatelliteWorkerPoolZoneOptions.SetXAuthResourceGroup(d.Get("resource_group_id").(string))
+	}
+
+	response, err := satClient.CreateSatelliteWorkerPoolZone(createSatelliteWorkerPoolZoneOptions)
+	if err != nil {
+		log.Printf("[DEBUG] CreateSatelliteWorkerPoolZoneWithContext failed %s\n%s", err, response)
+		return diag.FromErr(fmt.Errorf("CreateSatelliteWorkerPoolZoneWithContext failed %s\n%s", err, response))
+	}
+
+	d.SetId(fmt.Sprintf("%s/%s/%s", cluster, workerpool, zone))
+
+	return resourceIbmSatelliteClusterWorkerPoolZoneAttachmentRead(context, d, meta)
+}
+
+func resourceIbmSatelliteClusterWorkerPoolZoneAttachmentRead(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	parts, err := idParts(d.Id())
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	satClient, err := meta.(ClientSession).SatelliteClientSession()
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	getWorkerPoolOptions := &kubernetesserviceapiv1.GetWorkerPoolOptions{}
+	getWorkerPoolOptions.SetCluster(parts[0])
+	getWorkerPoolOptions.SetWorkerpool(parts[1])
+
+	getWorkerPoolResponse, response, err := satClient.GetWorkerPoolWithContext(context, getWorkerPoolOptions)
+	if err != nil {
+		if response != nil && response.StatusCode == 404 {
+			d.SetId("")
+			return nil
+		}
+		log.Printf("[DEBUG] GetWorkerPool1WithContext failed %s\n%s", err, response)
+		return diag.FromErr(fmt.Errorf("GetWorkerPool1WithContext failed %s\n%s", err, response))
+	}
+
+	if getWorkerPoolResponse != nil && getWorkerPoolResponse.Zones != nil {
+		d.Set("cluster", parts[0])
+		d.Set("worker_pool", parts[1])
+
+		for _, z := range getWorkerPoolResponse.Zones {
+			if parts[2] == *z.ID {
+				d.Set("zone", *z.ID)
+				d.Set("autobalance_enabled", *z.AutobalanceEnabled)
+				d.Set("messages", *&z.Messages)
+				d.Set("worker_count", *z.WorkerCount)
+			}
+		}
+	}
+
+	return nil
+}
+
+func resourceIbmSatelliteClusterWorkerPoolZoneAttachmentDelete(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	parts, err := idParts(d.Id())
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	satClient, err := meta.(ClientSession).SatelliteClientSession()
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	removeWorkerPoolZoneOptions := &kubernetesserviceapiv1.RemoveWorkerPoolZoneOptions{}
+	removeWorkerPoolZoneOptions.SetIdOrName(parts[0])
+	removeWorkerPoolZoneOptions.SetPoolidOrName(parts[1])
+	removeWorkerPoolZoneOptions.SetZoneid(parts[2])
+
+	response, err := satClient.RemoveWorkerPoolZoneWithContext(context, removeWorkerPoolZoneOptions)
+	if err != nil {
+		log.Printf("[DEBUG] RemoveWorkerPoolZoneWithContext failed %s\n%s", err, response)
+		return diag.FromErr(fmt.Errorf("RemoveWorkerPoolZoneWithContext failed %s\n%s", err, response))
+	}
+
+	d.SetId("")
+
+	return nil
+}

--- a/ibm/resource_ibm_satellite_cluster_worker_pool_zone_attachment_test.go
+++ b/ibm/resource_ibm_satellite_cluster_worker_pool_zone_attachment_test.go
@@ -1,0 +1,324 @@
+// Copyright IBM Corp. 2021 All Rights Reserved.
+// Licensed under the Mozilla Public License v2.0
+
+package ibm
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/IBM-Cloud/container-services-go-sdk/kubernetesserviceapiv1"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+)
+
+func TestAccIbmSatelliteClusterWorkerPoolZoneAttachmentBasic(t *testing.T) {
+	var conf kubernetesserviceapiv1.GetWorkerPoolResponse
+	clusterName := fmt.Sprintf("tf-satellitecluster-%d", acctest.RandIntRange(10, 100))
+	locationName := fmt.Sprintf("tf-satellitelocation-%d", acctest.RandIntRange(10, 100))
+	zone := fmt.Sprintf("tf-zone-%d", acctest.RandIntRange(10, 100))
+	resource_prefix := fmt.Sprintf("tf-satellite-%d", acctest.RandIntRange(10, 100))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccCheckIbmSatelliteClusterWorkerPoolZoneAttachmentConfigBasic(locationName, clusterName, resource_prefix, zone),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckIbmSatelliteClusterWorkerPoolZoneAttachmentExists("ibm_satellite_cluster_worker_pool_zone_attachment.satellite_cluster_worker_pool_zone_attachment", conf),
+				),
+			},
+		},
+	})
+}
+
+func TestAccIbmSatelliteClusterWorkerPoolZoneAttachmentAllArgs(t *testing.T) {
+	var conf kubernetesserviceapiv1.GetWorkerPoolResponse
+	clusterName := fmt.Sprintf("tf-satellitecluster-%d", acctest.RandIntRange(10, 100))
+	locationName := fmt.Sprintf("tf-satellitelocation-%d", acctest.RandIntRange(10, 100))
+	zone := fmt.Sprintf("tf-zone-%d", acctest.RandIntRange(10, 100))
+	resource_prefix := fmt.Sprintf("tf-satellite-%d", acctest.RandIntRange(10, 100))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccCheckIbmSatelliteClusterWorkerPoolZoneAttachmentConfig(locationName, clusterName, resource_prefix, zone),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckIbmSatelliteClusterWorkerPoolZoneAttachmentExists("ibm_satellite_cluster_worker_pool_zone_attachment.satellite_cluster_worker_pool_zone_attachment", conf),
+					resource.TestCheckResourceAttr("ibm_satellite_cluster_worker_pool_zone_attachment.satellite_cluster_worker_pool_zone_attachment", "worker_pool", "default"),
+					resource.TestCheckResourceAttr("ibm_satellite_cluster_worker_pool_zone_attachment.satellite_cluster_worker_pool_zone_attachment", "zone", zone),
+				),
+			},
+			resource.TestStep{
+				ResourceName:      "ibm_satellite_cluster_worker_pool_zone_attachment.satellite_cluster_worker_pool_zone_attachment",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testAccCheckIbmSatelliteClusterWorkerPoolZoneAttachmentConfigBasic(location, cluster, resource_prefix, zone string) string {
+	return fmt.Sprintf(`
+
+	provider "ibm" {
+		region = "us-south"
+	}
+
+	variable "location_zones" {
+		description = "Allocate your hosts across these three zones"
+		type        = list(string)
+		default     = ["us-south-1", "us-south-2", "us-south-3"]
+	}
+
+	resource "ibm_satellite_location" "location" {
+		location      = "%s"
+		managed_from  = "wdc04"
+		zones		  = var.location_zones
+	}
+
+	data "ibm_is_image" "rhel7" {
+		name = "ibm-redhat-7-9-minimal-amd64-4"
+	}
+
+	data "ibm_satellite_attach_host_script" "script" {
+		location          = ibm_satellite_location.location.id
+		labels            = ["env:prod"]
+		host_provider     = "ibm"
+	}
+
+	data "ibm_resource_group" "resource_group" {
+		is_default = true
+	}
+	  
+	resource "ibm_is_vpc" "satellite_vpc" {
+		name = "%s-vpc-1"
+	}
+	  
+	resource "ibm_is_subnet" "satellite_subnet" {
+		count                    = 3
+
+		name                     = "%s-subnet-${count.index}"
+		vpc                      = ibm_is_vpc.satellite_vpc.id
+		total_ipv4_address_count = 256
+		zone                     = "us-south-${count.index + 1}"
+	}
+	  
+	resource "ibm_is_ssh_key" "satellite_ssh" {	  
+		name        = "%s-ibm-ssh"
+		public_key  = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCKVmnMOlHKcZK8tpt3MP1lqOLAcqcJzhsvJcjscgVERRN7/9484SOBJ3HSKxxNG5JN8owAjy5f9yYwcUg+JaUVuytn5Pv3aeYROHGGg+5G346xaq3DAwX6Y5ykr2fvjObgncQBnuU5KHWCECO/4h8uWuwh/kfniXPVjFToc+gnkqA+3RKpAecZhFXwfalQ9mMuYGFxn+fwn8cYEApsJbsEmb0iJwPiZ5hjFC8wREuiTlhPHDgkBLOiycd20op2nXzDbHfCHInquEe/gYxEitALONxm0swBOwJZwlTDOB7C6y2dzlrtxr1L59m7pCkWI4EtTRLvleehBoj3u7jB4usR"
+	}
+	  
+	resource "ibm_is_instance" "satellite_instance" {
+		count          = 3
+
+		name           = "%s-instance-${count.index}"
+		vpc            = ibm_is_vpc.satellite_vpc.id
+		zone           = "us-south-${count.index + 1}"
+		image          = data.ibm_is_image.rhel7.id
+		profile        = "mx2-8x64"
+		keys           = [ibm_is_ssh_key.satellite_ssh.id]
+		resource_group = data.ibm_resource_group.resource_group.id
+		user_data      = data.ibm_satellite_attach_host_script.script.host_script
+		
+		primary_network_interface {
+		  subnet = ibm_is_subnet.satellite_subnet[count.index].id
+		}
+	}
+	  
+	resource "ibm_is_floating_ip" "satellite_ip" {
+		count  = 3
+
+		name   = "%s-fip-${count.index}"
+		target = ibm_is_instance.satellite_instance[count.index].primary_network_interface[0].id
+	}
+	  
+	resource "ibm_satellite_host" "assign_host" {
+		count  = 3
+	  
+		location      = ibm_satellite_location.location.id
+		host_id       = element(ibm_is_instance.satellite_instance[*].name, count.index)
+		labels        = ["env:prod"]
+		zone          = element(var.location_zones, count.index)
+		host_provider = "ibm"
+	}
+
+	resource "ibm_satellite_cluster" "create_cluster" {
+		name                   = "%s"  
+		location               = ibm_satellite_location.location.id
+		enable_config_admin    = true
+		kube_version           = "4.6_openshift"
+		wait_for_worker_update = true
+		dynamic "zones" {
+			for_each = var.location_zones
+			content {
+				id	= zones.value
+			}
+		}
+		default_worker_pool_labels = {
+			"test"  = "test-pool1" 
+			"test1" = "test-pool2"
+		}
+	}
+
+	resource "ibm_satellite_cluster_worker_pool_zone_attachment" "satellite_cluster_worker_pool_zone_attachment" {
+		cluster = ibm_satellite_cluster.create_cluster.id
+		worker_pool = "default"
+		zone = "%s"
+	}
+	`, location, resource_prefix, resource_prefix, resource_prefix, resource_prefix, resource_prefix, cluster, zone)
+}
+
+func testAccCheckIbmSatelliteClusterWorkerPoolZoneAttachmentConfig(location, cluster, resource_prefix, zone string) string {
+	return fmt.Sprintf(`
+
+	provider "ibm" {
+		region = "us-south"
+	}
+
+	variable "location_zones" {
+		description = "Allocate your hosts across these three zones"
+		type        = list(string)
+		default     = ["us-south-1", "us-south-2", "us-south-3"]
+	}
+
+	resource "ibm_satellite_location" "location" {
+		location      = "%s"
+		managed_from  = "wdc04"
+		zones		  = var.location_zones
+	}
+
+	data "ibm_is_image" "rhel7" {
+		name = "ibm-redhat-7-9-minimal-amd64-4"
+	}
+
+	data "ibm_satellite_attach_host_script" "script" {
+		location          = ibm_satellite_location.location.id
+		labels            = ["env:prod"]
+		host_provider     = "ibm"
+	}
+
+	data "ibm_resource_group" "resource_group" {
+		is_default = true
+	}
+	  
+	resource "ibm_is_vpc" "satellite_vpc" {
+		name = "%s-vpc-1"
+	}
+	  
+	resource "ibm_is_subnet" "satellite_subnet" {
+		count                    = 3
+
+		name                     = "%s-subnet-${count.index}"
+		vpc                      = ibm_is_vpc.satellite_vpc.id
+		total_ipv4_address_count = 256
+		zone                     = "us-south-${count.index + 1}"
+	}
+	  
+	resource "ibm_is_ssh_key" "satellite_ssh" {	  
+		name        = "%s-ibm-ssh"
+		public_key  = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCKVmnMOlHKcZK8tpt3MP1lqOLAcqcJzhsvJcjscgVERRN7/9484SOBJ3HSKxxNG5JN8owAjy5f9yYwcUg+JaUVuytn5Pv3aeYROHGGg+5G346xaq3DAwX6Y5ykr2fvjObgncQBnuU5KHWCECO/4h8uWuwh/kfniXPVjFToc+gnkqA+3RKpAecZhFXwfalQ9mMuYGFxn+fwn8cYEApsJbsEmb0iJwPiZ5hjFC8wREuiTlhPHDgkBLOiycd20op2nXzDbHfCHInquEe/gYxEitALONxm0swBOwJZwlTDOB7C6y2dzlrtxr1L59m7pCkWI4EtTRLvleehBoj3u7jB4usR"
+	}
+	  
+	resource "ibm_is_instance" "satellite_instance" {
+		count          = 3
+
+		name           = "%s-instance-${count.index}"
+		vpc            = ibm_is_vpc.satellite_vpc.id
+		zone           = "us-south-${count.index + 1}"
+		image          = data.ibm_is_image.rhel7.id
+		profile        = "mx2-8x64"
+		keys           = [ibm_is_ssh_key.satellite_ssh.id]
+		resource_group = data.ibm_resource_group.resource_group.id
+		user_data      = data.ibm_satellite_attach_host_script.script.host_script
+		
+		primary_network_interface {
+		  subnet = ibm_is_subnet.satellite_subnet[count.index].id
+		}
+	}
+	  
+	resource "ibm_is_floating_ip" "satellite_ip" {
+		count  = 3
+
+		name   = "%s-fip-${count.index}"
+		target = ibm_is_instance.satellite_instance[count.index].primary_network_interface[0].id
+	}
+	  
+	resource "ibm_satellite_host" "assign_host" {
+		count  = 3
+	  
+		location      = ibm_satellite_location.location.id
+		host_id       = element(ibm_is_instance.satellite_instance[*].name, count.index)
+		labels        = ["env:prod"]
+		zone          = element(var.location_zones, count.index)
+		host_provider = "ibm"
+	}
+
+	resource "ibm_satellite_cluster" "create_cluster" {
+		name                   = "%s"  
+		location               = ibm_satellite_location.location.id
+		enable_config_admin    = true
+		kube_version           = "4.6_openshift"
+		wait_for_worker_update = true
+		dynamic "zones" {
+			for_each = var.location_zones
+			content {
+				id	= zones.value
+			}
+		}
+		default_worker_pool_labels = {
+			"test"  = "test-pool1" 
+			"test1" = "test-pool2"
+		}
+	}
+
+	resource "ibm_satellite_cluster_worker_pool_zone_attachment" "satellite_cluster_worker_pool_zone_attachment" {
+		cluster = ibm_satellite_cluster.create_cluster.id
+		worker_pool = "default"
+		zone = "%s"
+	}
+	`, location, resource_prefix, resource_prefix, resource_prefix, resource_prefix, resource_prefix, cluster, zone)
+}
+
+func testAccCheckIbmSatelliteClusterWorkerPoolZoneAttachmentExists(n string, obj kubernetesserviceapiv1.GetWorkerPoolResponse) resource.TestCheckFunc {
+
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+
+		parts, err := idParts(rs.Primary.ID)
+		if err != nil {
+			return err
+		}
+
+		satClient, err := testAccProvider.Meta().(ClientSession).SatelliteClientSession()
+		if err != nil {
+			return err
+		}
+
+		getWorkerPoolOptions := &kubernetesserviceapiv1.GetWorkerPoolOptions{}
+		getWorkerPoolOptions.SetCluster(parts[0])
+		getWorkerPoolOptions.SetWorkerpool(parts[1])
+
+		getWorkerPoolResponse, _, err := satClient.GetWorkerPool(getWorkerPoolOptions)
+		if err != nil {
+			return err
+		}
+
+		if getWorkerPoolResponse != nil && getWorkerPoolResponse.Zones != nil {
+			for _, zoneId := range getWorkerPoolResponse.Zones {
+				if parts[2] == *zoneId.ID {
+					obj = *getWorkerPoolResponse
+				}
+			}
+		}
+
+		return nil
+	}
+}

--- a/ibm/structures.go
+++ b/ibm/structures.go
@@ -2948,3 +2948,14 @@ func updatePrivateURL(kpURL string) (string, error) {
 	}
 	return kmsEndpointURL, nil
 }
+
+func flattenSatelliteClusterZones(list []string) []map[string]interface{} {
+	zones := make([]map[string]interface{}, len(list))
+	for i, zone := range list {
+		l := map[string]interface{}{
+			"id": zone,
+		}
+		zones[i] = l
+	}
+	return zones
+}

--- a/website/docs/d/satellite_cluster_worker_pool_zone_attachment.html.markdown
+++ b/website/docs/d/satellite_cluster_worker_pool_zone_attachment.html.markdown
@@ -1,0 +1,39 @@
+---
+subcategory: "Satellite"
+layout: "ibm"
+page_title: "IBM : satellite_cluster_worker_pool_zone_attachment"
+description: |-
+  Get information about IBM Cloud satellite cluster worker pool zone attachment.
+---
+
+# ibm_satellite_cluster_worker_pool_zone_attachment
+
+Import the details of an existing satellite cluster worker pool zone attached as a read-only data source. You can then reference the fields of the data source in other resources within the same configuration by using interpolation syntax.
+
+## Example Usage
+
+```hcl
+data "ibm_satellite_cluster_worker_pool_zone_attachment" "read_worker_pool_zone_attachment" {
+  cluster     = "satellite-cluster"
+  worker_pool = "default"
+  zone        = "zone-4"
+}
+```
+
+## Argument Reference
+
+Review the argument reference that you can specify for your resource.
+
+* `cluster` - (Required, String) The name or id of the cluster.
+* `resource_group_id` - The ID of the resource group that the Satellite location is in. To list the resource group ID of the location, use the `GET /v2/satellite/getController` API method.
+* `worker_pool` - (Required, String) The name of the worker pool.
+* `zone` - (Required, String) The name of the zone to attach.
+
+## Attribute Reference
+
+In addition to all argument references listed, you can access the following attribute references after your resource is created.
+
+* `id` - The unique identifier of the satellite_cluster_worker_pool_zone_attachment.
+* `autobalance_enabled` - Auto enabled status.
+* `messages` - Messages.
+* `worker_count` - Number of workers in worker pool.

--- a/website/docs/r/satellite_cluster_worker_pool_zone_attachment.html.markdown
+++ b/website/docs/r/satellite_cluster_worker_pool_zone_attachment.html.markdown
@@ -1,0 +1,55 @@
+---
+subcategory: "Satellite"
+layout: "ibm"
+page_title: "IBM : satellite_cluster_worker_pool_zone_attachment"
+description: |-
+  Manages IBM Cloud satellite cluster worker pool zone attachment.
+---
+
+# ibm_satellite_cluster_worker_pool_zone_attachment
+
+Provides a resource for satellite_cluster_worker_pool_zone_attachment. This allows satellite_cluster_worker_pool_zone_attachment to be created, updated and deleted.
+
+## Example Usage
+
+```hcl
+resource "ibm_satellite_cluster_worker_pool_zone_attachment" "satellite_cluster_worker_pool_zone_attachment" {
+  cluster     = var.cluster
+  worker_pool = var.worker_pool
+  zone        = var.zone_name
+}
+```
+
+## Argument Reference
+
+Review the argument reference that you can specify for your resource.
+
+* `cluster` - (Optional, Forces new resource, String) The name of the cluster.
+* `resource_group_id` - (Optional, Forces new resource, String) The ID of the resource group that the Satellite location is in. To list the resource group ID of the location, use the `GET /v2/satellite/getController` API method.
+* `worker_pool` - (Optional, Forces new resource, String) The name of the worker pool.
+* `zone` - (Optional, Forces new resource, String) (String) The name of the zone to attach.
+
+## Attribute Reference
+
+In addition to all argument references listed, you can access the following attribute references after your resource is created.
+
+* `id` - (String) The unique identifier of the satellite_cluster_worker_pool_zone_attachment.
+* `autobalance_enabled` - (Optional, Boolean) Auto enabled status.
+* `messages` - (Optional, List) Messages.
+* `worker_count` - (Optional, Integer) Number of workers in worker pool.
+
+## Import
+
+You can import the `ibm_satellite_cluster_worker_pool_zone_attachment` resource can be imported by using the `cluster` and `worker pool`, `zone name`.
+
+```
+<cluster>/<worker_pool>/<zone_name>
+```
+* `cluster`: A string. The cluster ID.
+* `worker_pool`: A string. The worker pool name.
+* `zone_name`: A string. The zone name.
+
+# Syntax
+```
+$ terraform import ibm_satellite_cluster_worker_pool_zone_attachment.satellite_cluster_worker_pool_zone_attachment <cluster>/<worker_pool>/<zone_name>
+```


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/IBM-Cloud/terraform-provider-ibm/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccIbmSatelliteClusterWorkerPoolZoneAttachmentAllArgs'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./ibm -v -run=TestAccIbmSatelliteClusterWorkerPoolZoneAttachmentAllArgs -timeout 700m
[WARN] Set the environment variable IBM_APPID_TENANT_ID for testing AppID resources, AppID tests will fail if this is not set
[WARN] Set the environment variable IBM_APPID_TEST_USER_EMAIL for testing AppID user resources, the tests will fail if this is not set
[WARN] Set the environment variable IBM_ORG for testing ibm_org  resource Some tests for that resource will fail if this is not set correctly
[WARN] Set the environment variable IBM_SPACE for testing ibm_space  resource Some tests for that resource will fail if this is not set correctly
[WARN] Set the environment variable IBM_ID1 for testing ibm_space resource Some tests for that resource will fail if this is not set correctly
[WARN] Set the environment variable IBM_ID2 for testing ibm_space resource Some tests for that resource will fail if this is not set correctly
[WARN] Set the environment variable IBM_IAMUSER for testing ibm_iam_user_policy resource Some tests for that resource will fail if this is not set correctly
[WARN] Set the environment variable IBM_DATACENTER for testing ibm_container_cluster resource else it is set to default value 'par01'
[WARN] Set the environment variable IBM_MACHINE_TYPE for testing ibm_container_cluster resource else it is set to default value 'u2c.2x4'
[WARN] Set the environment variable IBM_CERT_CRN for testing ibm_container_alb_cert resource else it is set to default value
[WARN] Set the environment variable IBM_UPDATE_CERT_CRN for testing ibm_container_alb_cert resource else it is set to default value
[WARN] Set the environment variable IBM_CONTAINER_REGION for testing ibm_container resources else it is set to default value 'eu-de'
[WARN] Set the environment variable IBM_CIS_INSTANCE with a VALID CIS Instance NAME for testing ibm_cis resources on staging/test
[WARN] Set the environment variable IBM_CIS_DOMAIN_STATIC with the Domain name registered with the CIS instance on test/staging. Domain must be predefined in CIS to avoid CIS billing costs due to domain delete/create
[WARN] Set the environment variable IBM_CIS_DOMAIN_TEST with a VALID Domain name for testing the one time create and delete of a domain in CIS. Note each create/delete will trigger a monthly billing instance. Only to be run in staging/test
[WARN] Set the environment variable IBM_CIS_RESOURCE_GROUP with the resource group for the CIS Instance
[WARN] Set the environment variable IBM_COS_CRN with a VALID COS instance CRN for testing ibm_cos_* resources
[WARN] Set the environment variable IBM_TRUSTED_MACHINE_TYPE for testing ibm_container_cluster resource else it is set to default value 'mb1c.16x64'
[WARN] Set the environment variable IBM_BM_EXTENDED_HW_TESTING to true/false for testing ibm_compute_bare_metal resource else it is set to default value 'false'
[WARN] Set the environment variable IBM_PUBLIC_VLAN_ID for testing ibm_container_cluster resource else it is set to default value '2393319'
[WARN] Set the environment variable IBM_PRIVATE_VLAN_ID for testing ibm_container_cluster resource else it is set to default value '2393321'
[WARN] Set the environment variable IBM_KUBE_VERSION for testing ibm_container_cluster resource else it is set to default value '1.18.14'
[WARN] Set the environment variable IBM_KUBE_UPDATE_VERSION for testing ibm_container_cluster resource else it is set to default value '1.19.6'
[WARN] Set the environment variable IBM_PRIVATE_SUBNET_ID for testing ibm_container_cluster resource else it is set to default value '1636107'
[WARN] Set the environment variable IBM_PUBLIC_SUBNET_ID for testing ibm_container_cluster resource else it is set to default value '1165645'
[WARN] Set the environment variable IBM_SUBNET_ID for testing ibm_container_cluster resource else it is set to default value '1165645'
[INFO] Set the environment variable IBM_IPSEC_DATACENTER for testing ibm_ipsec_vpn resource else it is set to default value 'tok02'
[INFO] Set the environment variable IBM_IPSEC_CUSTOMER_SUBNET_ID for testing ibm_ipsec_vpn resource else it is set to default value '123456'
[INFO] Set the environment variable IBM_IPSEC_CUSTOMER_PEER_IP for testing ibm_ipsec_vpn resource else it is set to default value '192.168.0.1'
[WARN] Set the environment variable IBM_LBAAS_DATACENTER for testing ibm_lbaas resource else it is set to default value 'dal13'
[WARN] Set the environment variable IBM_LBAAS_SUBNETID for testing ibm_lbaas resource else it is set to default value '2144241'
[WARN] Set the environment variable IBM_LB_LISTENER_CERTIFICATE_INSTANCE for testing ibm_is_lb_listener resource for https redirect else it is set to default value 'crn:v1:staging:public:cloudcerts:us-south:a/2d1bace7b46e4815a81e52c6ffeba5cf:af925157-b125-4db2-b642-adacb8b9c7f5:certificate:c81627a1bf6f766379cc4b98fd2a44ed'
[WARN] Set the environment variable IBM_DEDICATED_HOSTNAME for testing ibm_compute_vm_instance resource else it is set to default value 'terraform-dedicatedhost'
[WARN] Set the environment variable IBM_DEDICATED_HOST_ID for testing ibm_compute_vm_instance resource else it is set to default value '30301'
[WARN] Set the environment variable IBM_WORKER_POOL_ZONE for testing ibm_container_worker_pool_zone_attachment resource else it is set to default value 'ams03'
[WARN] Set the environment variable IBM_WORKER_POOL_ZONE_PRIVATE_VLAN for testing ibm_container_worker_pool_zone_attachment resource else it is set to default value '2538975'
[WARN] Set the environment variable IBM_WORKER_POOL_ZONE_PUBLIC_VLAN for testing ibm_container_worker_pool_zone_attachment resource else it is set to default value '2538967'
[WARN] Set the environment variable IBM_WORKER_POOL_ZONE_UPDATE_PRIVATE_VLAN for testing ibm_container_worker_pool_zone_attachment resource else it is set to default value '2388377'
[WARN] Set the environment variable IBM_WORKER_POOL_ZONE_UPDATE_PUBLIC_VLAN for testing ibm_container_worker_pool_zone_attachment resource else it is set to default value '2388375'
[WARN] Set the environment variable IBM_PLACEMENT_GROUP_NAME for testing ibm_compute_vm_instance resource else it is set to default value 'terraform-group'
[INFO] Set the environment variable SL_REGION for testing ibm_is_region datasource else it is set to default value 'us-south'
[INFO] Set the environment variable SL_ZONE for testing ibm_is_zone datasource else it is set to default value 'us-south-1'
[INFO] Set the environment variable SL_CIDR for testing ibm_is_subnet else it is set to default value '10.240.0.0/24'
[INFO] Set the environment variable SL_ADDRESS_PREFIX_CIDR for testing ibm_is_vpc_address_prefix else it is set to default value '10.120.0.0/24'
[INFO] Set the environment variable IS_IMAGE for testing ibm_is_instance, ibm_is_floating_ip else it is set to default value 'r006-ed3f775f-ad7e-4e37-ae62-7199b4988b00'
[INFO] Set the environment variable IS_WIN_IMAGE for testing ibm_is_instance data source else it is set to default value 'r006-5f9568ae-792e-47e1-a710-5538b2bdfca7'
[INFO] Set the environment variable IS_INSTANCE_NAME for testing ibm_is_instance resource else it is set to default value 'instance-01'
[INFO] Set the environment variable SL_INSTANCE_PROFILE for testing ibm_is_instance resource else it is set to default value 'cx2-2x4'
[INFO] Set the environment variable SL_INSTANCE_PROFILE_UPDATE for testing ibm_is_instance resource else it is set to default value 'cx2-4x8'
[INFO] Set the environment variable IS_DEDICATED_HOST_NAME for testing ibm_is_instance resource else it is set to default value 'tf-dhost-01'
[INFO] Set the environment variable IS_DEDICATED_HOST_GROUP_ID for testing ibm_is_instance resource else it is set to default value '0717-9104e7b5-77ad-44ad-9eaa-091e6b6efce1'
[INFO] Set the environment variable IS_DEDICATED_HOST_PROFILE for testing ibm_is_instance resource else it is set to default value 'bx2d-host-152x608'
[INFO] Set the environment variable IS_DEDICATED_HOST_GROUP_CLASS for testing ibm_is_instance resource else it is set to default value 'bx2d'
[INFO] Set the environment variable IS_DEDICATED_HOST_GROUP_FAMILY for testing ibm_is_instance resource else it is set to default value 'balanced'
[INFO] Set the environment variable SL_INSTANCE_PROFILE for testing ibm_is_instance resource else it is set to default value 'bx2d-16x64'
[INFO] Set the environment variable IS_VOLUME_PROFILE for testing ibm_is_volume_profile else it is set to default value 'general-purpose'
[INFO] Set the environment variable SL_ROUTE_DESTINATION for testing ibm_is_vpc_route else it is set to default value '192.168.4.0/24'
[INFO] Set the environment variable SL_ROUTE_NEXTHOP for testing ibm_is_vpc_route else it is set to default value '10.0.0.4'
[INFO] Set the environment variable PI_IMAGE for testing ibm_pi_image resource else it is set to default value '7200-03-03'
[INFO] Set the environment variable PI_IMAGE_BUCKET_NAME for testing ibm_pi_image resource else it is set to default value 'images-public-bucket'
[INFO] Set the environment variable PI_IMAGE_BUCKET_FILE_NAME for testing ibm_pi_image resource else it is set to default value 'rhel.ova.gz'
[INFO] Set the environment variable PI_KEY_NAME for testing ibm_pi_key_name resource else it is set to default value 'terraform-test-power'
[INFO] Set the environment variable PI_NETWORK_NAME for testing ibm_pi_network_name resource else it is set to default value 'terraform-test-power'
[INFO] Set the environment variable PI_VOLUME_NAME for testing ibm_pi_network_name resource else it is set to default value 'terraform-test-power'
[INFO] Set the environment variable PI_CLOUDINSTANCE_ID for testing ibm_pi_image resource else it is set to default value 'd16705bd-7f1a-48c9-9e0e-1c17b71e7331'
[INFO] Set the environment variable PI_PVM_INSTANCE_ID for testing pi_instance_name resource else it is set to default value 'terraform-test-power'
[INFO] Set the environment variable PI_DHCP_ID for testing ibm_pi_dhcp resource else it is set to default value 'terraform-test-power'
[INFO] Set the environment variable PI_CLOUD_CONNECTION_NAME for testing ibm_pi_cloud_connection resource else it is set to default value 'terraform-test-power'
[INFO] Set the environment variable SCHEMATICS_WORKSPACE_ID for testing schematics resources else it is set to default value
[INFO] Set the environment variable SCHEMATICS_TEMPLATE_ID for testing schematics resources else it is set to default value
[INFO] Set the environment variable SCHEMATICS_ACTION_ID for testing schematics resources else it is set to default value
[INFO] Set the environment variable SCHEMATICS_REPO_URL for testing schematics resources else tests will fail if this is not set correctly
[INFO] Set the environment variable SCHEMATICS_REPO_BRANCH for testing schematics resources else tests will fail if this is not set correctly
[WARN] Set the environment variable IMAGE_COS_URL with a VALID COS Image SQL URL for testing ibm_is_image resources on staging/test
[WARN] Set the environment variable IMAGE_COS_URL_ENCRYPTED with a VALID COS Image SQL URL for testing ibm_is_image resources on staging/test
[WARN] Set the environment variable IMAGE_OPERATING_SYSTEM with a VALID Operating system for testing ibm_is_image resources on staging/test
[INFO] Set the environment variable IS_IMAGE_NAME for testing data source ibm_is_image else it is set to default value `ibm-ubuntu-18-04-1-minimal-amd64-2`
[INFO] Set the environment variable IS_IMAGE_ENCRYPTED_DATA_KEY for testing resource ibm_is_image else it is set to default value
[INFO] Set the environment variable IS_IMAGE_ENCRYPTION_KEY for testing resource ibm_is_image else it is set to default value
[INFO] Set the environment variable IBM_FUNCTION_NAMESPACE for testing ibm_function_package, ibm_function_action, ibm_function_rule, ibm_function_trigger resource else  tests will fail if this is not set correctly
[INFO] Set the environment variable HPCS_INSTANCE_ID for testing data_source_ibm_kms_key_test else it is set to default value
[INFO] Set the environment variable SECRETS_MANAGER_INSTANCE_ID for testing data_source_ibm_secrets_manager_secrets_test else tests will fail if this is not set correctly
[INFO] Set the environment variable SECRETS_MANAGER_SECRET_TYPE for testing data_source_ibm_secrets_manager_secrets_test, else it is set to default value. For data_source_ibm_secrets_manager_secret_test, tests will fail if this is not set correctly
[WARN] Set the environment variable SECRETS_MANAGER_SECRET_ID for testing data_source_ibm_secrets_manager_secret_test else tests will fail if this is not set correctly
[INFO] Set the environment variable IBM_TG_CROSS_ACCOUNT_ID for testing ibm_tg_connection resource else  tests will fail if this is not set correctly
[INFO] Set the environment variable IBM_TG_CROSS_NETWORK_ID for testing ibm_tg_connection resource else  tests will fail if this is not set correctly
[INFO] Set the environment variable ACCOUNT_TO_BE_IMPORTED for testing import enterprise account resource else  tests will fail if this is not set correctly
[WARN] Set the environment variable IBM_HPCS_ADMIN1 with a VALID HPCS Admin Key1 Path
[WARN] Set the environment variable IBM_HPCS_TOKEN1 with a VALID token for HPCS Admin Key1
[WARN] Set the environment variable IBM_HPCS_ADMIN2 with a VALID HPCS Admin Key2 Path
[WARN] Set the environment variable IBM_IAM_REALM_NAME with a VALID realm name for iam trusted profile claim rule
[WARN] Set the environment variable IBM_IAM_IKS_SA with a VALID realm name for iam trusted profile link
[WARN] Set the environment variable IBM_HPCS_TOKEN2 with a VALID token for HPCS Admin Key2
[INFO] Set the environment variable SCC_SI_ACCOUNT for testing SCC SI resources resource else  tests will fail if this is not set correctly
[INFO] Set the environment variable SCC_POSTURE_SCOPE_ID for testing SCC Posture resources or datasource resource else  tests will fail if this is not set correctly
[INFO] Set the environment variable SCC_POSTURE_SCAN_ID for testing SCC Posture resource or datasource else  tests will fail if this is not set correctly
[INFO] Set the environment variable SCC_POSTURE_PROFILE_ID for testing SCC Posture resource or datasource else  tests will fail if this is not set correctly
[INFO] Set the environment variable IBM_CLOUD_SHELL_ACCOUNT_ID for ibm-cloud-shell resource or datasource else tests will fail if this is not set correctly
[INFO] Set the environment variable IBM_CONTAINER_CLUSTER_NAME for ibm_container_nlb_dns resource or datasource else tests will fail if this is not set correctly
=== RUN   TestAccIbmSatelliteClusterWorkerPoolZoneAttachmentAllArgs
no message sent
no message sent
no message sent
no message sent
no message sent
no message sent
no message sent
no message sent
no message sent
no message sent
no message sent
no message sent
no message sent
no message sent
no message sent
no message sent
no message sent
no message sent
no message sent
no message sent
no message sent
no message sent
no message sent
no message sent
no message sent
--- PASS: TestAccIbmSatelliteClusterWorkerPoolZoneAttachmentAllArgs (4980.95s)
PASS
ok  	github.com/IBM-Cloud/terraform-provider-ibm/ibm	4984.032s

...
```
