### PR TITLE
Refactor multiple pi resources with context awareness

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.16
 require (
 	github.com/IBM-Cloud/bluemix-go v0.0.0-20211109110327-8ef3d89514c8
 	github.com/IBM-Cloud/container-services-go-sdk v0.0.0-20210705152127-41ca00fc9a62
-	github.com/IBM-Cloud/power-go-client v1.0.83
+	github.com/IBM-Cloud/power-go-client v1.0.85
 	github.com/IBM/apigateway-go-sdk v0.0.0-20210714141226-a5d5d49caaca
 	github.com/IBM/appconfiguration-go-admin-sdk v0.1.0
 	github.com/IBM/appid-management-go-sdk v0.0.0-20210908164609-dd0e0eaf732f

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.16
 require (
 	github.com/IBM-Cloud/bluemix-go v0.0.0-20211109110327-8ef3d89514c8
 	github.com/IBM-Cloud/container-services-go-sdk v0.0.0-20210705152127-41ca00fc9a62
-	github.com/IBM-Cloud/power-go-client v1.0.82
+	github.com/IBM-Cloud/power-go-client v1.0.83
 	github.com/IBM/apigateway-go-sdk v0.0.0-20210714141226-a5d5d49caaca
 	github.com/IBM/appconfiguration-go-admin-sdk v0.1.0
 	github.com/IBM/appid-management-go-sdk v0.0.0-20210908164609-dd0e0eaf732f

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.16
 require (
 	github.com/IBM-Cloud/bluemix-go v0.0.0-20211109110327-8ef3d89514c8
 	github.com/IBM-Cloud/container-services-go-sdk v0.0.0-20210705152127-41ca00fc9a62
-	github.com/IBM-Cloud/power-go-client v1.0.79
+	github.com/IBM-Cloud/power-go-client v1.0.82
 	github.com/IBM/apigateway-go-sdk v0.0.0-20210714141226-a5d5d49caaca
 	github.com/IBM/appconfiguration-go-admin-sdk v0.1.0
 	github.com/IBM/appid-management-go-sdk v0.0.0-20210908164609-dd0e0eaf732f

--- a/go.sum
+++ b/go.sum
@@ -42,8 +42,8 @@ github.com/IBM-Cloud/bluemix-go v0.0.0-20211109110327-8ef3d89514c8/go.mod h1:q0f
 github.com/IBM-Cloud/container-services-go-sdk v0.0.0-20210705152127-41ca00fc9a62 h1:MOkcr6qQGk4tY542ZJ1DggVh2WUP72EEyLB79llFVH8=
 github.com/IBM-Cloud/container-services-go-sdk v0.0.0-20210705152127-41ca00fc9a62/go.mod h1:xUQL9SGAjoZFd4GNjrjjtEpjpkgU7RFXRyHesbKTjiY=
 github.com/IBM-Cloud/ibm-cloud-cli-sdk v0.5.3/go.mod h1:RiUvKuHKTBmBApDMUQzBL14pQUGKcx/IioKQPIcRQjs=
-github.com/IBM-Cloud/power-go-client v1.0.82 h1:FhFkUrJGs/gvwRLebI0HtLkeoI6rWCGwTwYzmlewk/c=
-github.com/IBM-Cloud/power-go-client v1.0.82/go.mod h1:YRBsrY+n1+3xMd6HzfG0VATkXZqOQktK5Yvjx9x6ACc=
+github.com/IBM-Cloud/power-go-client v1.0.83 h1:pVJtlefLGr4KO0ekqO2WXlYYGxKuvh8QVjRuUckCHfk=
+github.com/IBM-Cloud/power-go-client v1.0.83/go.mod h1:YRBsrY+n1+3xMd6HzfG0VATkXZqOQktK5Yvjx9x6ACc=
 github.com/IBM-Cloud/softlayer-go v1.0.5-tf h1:koUAyF9b6X78lLLruGYPSOmrfY2YcGYKOj/Ug9nbKNw=
 github.com/IBM-Cloud/softlayer-go v1.0.5-tf/go.mod h1:6HepcfAXROz0Rf63krk5hPZyHT6qyx2MNvYyHof7ik4=
 github.com/IBM/apigateway-go-sdk v0.0.0-20210714141226-a5d5d49caaca h1:crniVcf+YcmgF03NmmfonXwSQ73oJF+IohFYBwknMxs=

--- a/go.sum
+++ b/go.sum
@@ -42,8 +42,8 @@ github.com/IBM-Cloud/bluemix-go v0.0.0-20211109110327-8ef3d89514c8/go.mod h1:q0f
 github.com/IBM-Cloud/container-services-go-sdk v0.0.0-20210705152127-41ca00fc9a62 h1:MOkcr6qQGk4tY542ZJ1DggVh2WUP72EEyLB79llFVH8=
 github.com/IBM-Cloud/container-services-go-sdk v0.0.0-20210705152127-41ca00fc9a62/go.mod h1:xUQL9SGAjoZFd4GNjrjjtEpjpkgU7RFXRyHesbKTjiY=
 github.com/IBM-Cloud/ibm-cloud-cli-sdk v0.5.3/go.mod h1:RiUvKuHKTBmBApDMUQzBL14pQUGKcx/IioKQPIcRQjs=
-github.com/IBM-Cloud/power-go-client v1.0.79 h1:k++zgWtuHjq8csmr9VnzczKBRR4ubro7jb8PUfPwADU=
-github.com/IBM-Cloud/power-go-client v1.0.79/go.mod h1:YRBsrY+n1+3xMd6HzfG0VATkXZqOQktK5Yvjx9x6ACc=
+github.com/IBM-Cloud/power-go-client v1.0.82 h1:FhFkUrJGs/gvwRLebI0HtLkeoI6rWCGwTwYzmlewk/c=
+github.com/IBM-Cloud/power-go-client v1.0.82/go.mod h1:YRBsrY+n1+3xMd6HzfG0VATkXZqOQktK5Yvjx9x6ACc=
 github.com/IBM-Cloud/softlayer-go v1.0.5-tf h1:koUAyF9b6X78lLLruGYPSOmrfY2YcGYKOj/Ug9nbKNw=
 github.com/IBM-Cloud/softlayer-go v1.0.5-tf/go.mod h1:6HepcfAXROz0Rf63krk5hPZyHT6qyx2MNvYyHof7ik4=
 github.com/IBM/apigateway-go-sdk v0.0.0-20210714141226-a5d5d49caaca h1:crniVcf+YcmgF03NmmfonXwSQ73oJF+IohFYBwknMxs=

--- a/go.sum
+++ b/go.sum
@@ -42,8 +42,8 @@ github.com/IBM-Cloud/bluemix-go v0.0.0-20211109110327-8ef3d89514c8/go.mod h1:q0f
 github.com/IBM-Cloud/container-services-go-sdk v0.0.0-20210705152127-41ca00fc9a62 h1:MOkcr6qQGk4tY542ZJ1DggVh2WUP72EEyLB79llFVH8=
 github.com/IBM-Cloud/container-services-go-sdk v0.0.0-20210705152127-41ca00fc9a62/go.mod h1:xUQL9SGAjoZFd4GNjrjjtEpjpkgU7RFXRyHesbKTjiY=
 github.com/IBM-Cloud/ibm-cloud-cli-sdk v0.5.3/go.mod h1:RiUvKuHKTBmBApDMUQzBL14pQUGKcx/IioKQPIcRQjs=
-github.com/IBM-Cloud/power-go-client v1.0.83 h1:pVJtlefLGr4KO0ekqO2WXlYYGxKuvh8QVjRuUckCHfk=
-github.com/IBM-Cloud/power-go-client v1.0.83/go.mod h1:YRBsrY+n1+3xMd6HzfG0VATkXZqOQktK5Yvjx9x6ACc=
+github.com/IBM-Cloud/power-go-client v1.0.85 h1:5iiYEPNBgSEgTLXcfxXZmyOSKwQO8YbUJz4hBivYOV4=
+github.com/IBM-Cloud/power-go-client v1.0.85/go.mod h1:60o7AE2oDi/0CtoXlQhnCbC3o1fSRgaFCJO6DscmokA=
 github.com/IBM-Cloud/softlayer-go v1.0.5-tf h1:koUAyF9b6X78lLLruGYPSOmrfY2YcGYKOj/Ug9nbKNw=
 github.com/IBM-Cloud/softlayer-go v1.0.5-tf/go.mod h1:6HepcfAXROz0Rf63krk5hPZyHT6qyx2MNvYyHof7ik4=
 github.com/IBM/apigateway-go-sdk v0.0.0-20210714141226-a5d5d49caaca h1:crniVcf+YcmgF03NmmfonXwSQ73oJF+IohFYBwknMxs=
@@ -71,6 +71,7 @@ github.com/IBM/go-sdk-core/v5 v5.6.3/go.mod h1:tt/B9rxLkRtglE7pvqLuYikgCXaZFL3bt
 github.com/IBM/go-sdk-core/v5 v5.6.5/go.mod h1:tt/B9rxLkRtglE7pvqLuYikgCXaZFL3btdruJaoUeek=
 github.com/IBM/go-sdk-core/v5 v5.7.0/go.mod h1:+YbdhrjCHC84ls4MeBp+Hj4NZCni+tDAc0XQUqRO9Jc=
 github.com/IBM/go-sdk-core/v5 v5.7.2/go.mod h1:+YbdhrjCHC84ls4MeBp+Hj4NZCni+tDAc0XQUqRO9Jc=
+github.com/IBM/go-sdk-core/v5 v5.8.0/go.mod h1:+YbdhrjCHC84ls4MeBp+Hj4NZCni+tDAc0XQUqRO9Jc=
 github.com/IBM/go-sdk-core/v5 v5.8.2 h1:hbT9jU5o2Gxv0CmPHK8Z1i6CpBVHcVuEajDoXNLXQqU=
 github.com/IBM/go-sdk-core/v5 v5.8.2/go.mod h1:axE2JrRq79gIJTjKPBwV6gWHswvVptBjbcvvCPIxARM=
 github.com/IBM/ibm-cos-sdk-go v1.3.1/go.mod h1:YLBAYobEA8bD27P7xpMwSQeNQu6W3DNBtBComXrRzRY=

--- a/ibm/config.go
+++ b/ibm/config.go
@@ -1789,7 +1789,7 @@ func (c *Config) ClientSession() (interface{}, error) {
 	session.apigatewayAPI = apigatewayAPI
 
 	// POWER SYSTEMS Service
-	ibmpisession, err := ibmpisession.New(sess.BluemixSession.Config.IAMAccessToken, c.Region, false, 90000000000, session.bmxUserDetails.userAccount, c.Zone)
+	ibmpisession, err := ibmpisession.New(sess.BluemixSession.Config.IAMAccessToken, c.Region, false, session.bmxUserDetails.userAccount, c.Zone)
 	if err != nil {
 		session.ibmpiConfigErr = err
 		return nil, err

--- a/ibm/data_source_ibm_pi_cloud_connection.go
+++ b/ibm/data_source_ibm_pi_cloud_connection.go
@@ -123,7 +123,7 @@ func dataSourceIBMPICloudConnectionRead(ctx context.Context, d *schema.ResourceD
 
 	cloudInstanceID := d.Get(helpers.PICloudInstanceId).(string)
 	cloudConnectionName := d.Get(helpers.PICloudConnectionName).(string)
-	client := instance.NewIBMPICloudConnectionClient(sess, cloudInstanceID)
+	client := instance.NewIBMPICloudConnectionClient(ctx, sess, cloudInstanceID)
 
 	// Get API does not work with name for Cloud Connection hence using GetAll (max 2)
 	// TODO: Uncomment Get call below when avaiable and remove GetAll
@@ -132,10 +132,10 @@ func dataSourceIBMPICloudConnectionRead(ctx context.Context, d *schema.ResourceD
 	// 	log.Printf("[DEBUG] get cloud connection failed %v", err)
 	// 	return diag.Errorf(errors.GetCloudConnectionOperationFailed, cloudConnectionName, err)
 	// }
-	cloudConnections, err := client.GetAllWithContext(ctx, cloudInstanceID)
+	cloudConnections, err := client.GetAll()
 	if err != nil {
 		log.Printf("[DEBUG] get cloud connections failed %v", err)
-		return diag.Errorf("failed to perform get cloud connections operation with error %v", err)
+		return diag.FromErr(err)
 	}
 	var cloudConnection *models.CloudConnection
 	if cloudConnections != nil {

--- a/ibm/data_source_ibm_pi_cloud_connections.go
+++ b/ibm/data_source_ibm_pi_cloud_connections.go
@@ -120,12 +120,12 @@ func dataSourceIBMPICloudConnectionsRead(ctx context.Context, d *schema.Resource
 	}
 
 	cloudInstanceID := d.Get(helpers.PICloudInstanceId).(string)
-	client := st.NewIBMPICloudConnectionClient(sess, cloudInstanceID)
+	client := st.NewIBMPICloudConnectionClient(ctx, sess, cloudInstanceID)
 
-	cloudConnections, err := client.GetAllWithContext(ctx, cloudInstanceID)
-	if err != nil || cloudConnections == nil {
+	cloudConnections, err := client.GetAll()
+	if err != nil {
 		log.Printf("[DEBUG] get cloud connections failed %v", err)
-		return diag.Errorf("failed to perform get cloud connections operation with error %v", err)
+		return diag.FromErr(err)
 	}
 
 	result := make([]map[string]interface{}, 0, len(cloudConnections.CloudConnections))

--- a/ibm/data_source_ibm_pi_dhcp.go
+++ b/ibm/data_source_ibm_pi_dhcp.go
@@ -10,8 +10,6 @@ import (
 
 	st "github.com/IBM-Cloud/power-go-client/clients/instance"
 
-	"github.com/IBM-Cloud/power-go-client/errors"
-
 	"github.com/IBM-Cloud/power-go-client/helpers"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -81,11 +79,11 @@ func dataSourceIBMPIDhcpRead(ctx context.Context, d *schema.ResourceData, meta i
 	cloudInstanceID := d.Get(helpers.PICloudInstanceId).(string)
 	dhcpID := d.Get(PIDhcpId).(string)
 
-	client := st.NewIBMPIDhcpClient(sess, cloudInstanceID)
-	dhcpServer, err := client.GetWithContext(ctx, dhcpID, cloudInstanceID)
+	client := st.NewIBMPIDhcpClient(ctx, sess, cloudInstanceID)
+	dhcpServer, err := client.Get(dhcpID)
 	if err != nil {
 		log.Printf("[DEBUG] get DHCP failed %v", err)
-		return diag.Errorf(errors.GetDhcpOperationFailed, dhcpID, err)
+		return diag.FromErr(err)
 	}
 
 	d.SetId(*dhcpServer.ID)

--- a/ibm/data_source_ibm_pi_dhcp.go
+++ b/ibm/data_source_ibm_pi_dhcp.go
@@ -77,7 +77,7 @@ func dataSourceIBMPIDhcpRead(ctx context.Context, d *schema.ResourceData, meta i
 	}
 
 	cloudInstanceID := d.Get(helpers.PICloudInstanceId).(string)
-	dhcpID := d.Get(PIDhcpId).(string)
+	dhcpID := d.Get(PIDhcpID).(string)
 
 	client := st.NewIBMPIDhcpClient(ctx, sess, cloudInstanceID)
 	dhcpServer, err := client.Get(dhcpID)

--- a/ibm/data_source_ibm_pi_dhcps.go
+++ b/ibm/data_source_ibm_pi_dhcps.go
@@ -68,11 +68,11 @@ func dataSourceIBMPIDhcpServersRead(ctx context.Context, d *schema.ResourceData,
 
 	cloudInstanceID := d.Get(helpers.PICloudInstanceId).(string)
 
-	client := st.NewIBMPIDhcpClient(sess, cloudInstanceID)
-	dhcpServers, err := client.GetAllWithContext(ctx, cloudInstanceID)
+	client := st.NewIBMPIDhcpClient(ctx, sess, cloudInstanceID)
+	dhcpServers, err := client.GetAll()
 	if err != nil {
 		log.Printf("[DEBUG] get all DHCP failed %v", err)
-		return diag.Errorf("failed to perform get all DHCP operation with error %v", err)
+		return diag.FromErr(err)
 	}
 
 	result := make([]map[string]interface{}, 0, len(dhcpServers))

--- a/ibm/data_source_ibm_pi_image.go
+++ b/ibm/data_source_ibm_pi_image.go
@@ -4,7 +4,10 @@
 package ibm
 
 import (
+	"context"
+
 	"github.com/IBM-Cloud/power-go-client/helpers"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 
 	//"fmt"
@@ -15,7 +18,7 @@ import (
 func dataSourceIBMPIImage() *schema.Resource {
 
 	return &schema.Resource{
-		Read: dataSourceIBMPIImagesRead,
+		ReadContext: dataSourceIBMPIImagesRead,
 		Schema: map[string]*schema.Schema{
 
 			helpers.PIImageName: {
@@ -66,21 +69,18 @@ func dataSourceIBMPIImage() *schema.Resource {
 	}
 }
 
-func dataSourceIBMPIImagesRead(d *schema.ResourceData, meta interface{}) error {
-
+func dataSourceIBMPIImagesRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	sess, err := meta.(ClientSession).IBMPISession()
-
 	if err != nil {
-		return err
+		return diag.FromErr(err)
 	}
 
-	powerinstanceid := d.Get(helpers.PICloudInstanceId).(string)
+	cloudInstanceID := d.Get(helpers.PICloudInstanceId).(string)
 
-	imageC := instance.NewIBMPIImageClient(sess, powerinstanceid)
-	imagedata, err := imageC.Get(d.Get(helpers.PIImageName).(string), powerinstanceid)
-
+	imageC := instance.NewIBMPIImageClient(ctx, sess, cloudInstanceID)
+	imagedata, err := imageC.Get(d.Get(helpers.PIImageName).(string))
 	if err != nil {
-		return err
+		return diag.FromErr(err)
 	}
 
 	d.SetId(*imagedata.ImageID)

--- a/ibm/data_source_ibm_pi_instance.go
+++ b/ibm/data_source_ibm_pi_instance.go
@@ -153,9 +153,9 @@ func dataSourceIBMPIInstancesRead(ctx context.Context, d *schema.ResourceData, m
 		return diag.FromErr(err)
 	}
 
-	powerinstanceid := d.Get(helpers.PICloudInstanceId).(string)
+	cloudInstanceID := d.Get(helpers.PICloudInstanceId).(string)
 
-	powerC := instance.NewIBMPIInstanceClient(ctx, sess, powerinstanceid)
+	powerC := instance.NewIBMPIInstanceClient(ctx, sess, cloudInstanceID)
 	powervmdata, err := powerC.Get(d.Get(helpers.PIInstanceName).(string))
 
 	if err != nil {

--- a/ibm/data_source_ibm_pi_instance_volumes.go
+++ b/ibm/data_source_ibm_pi_instance_volumes.go
@@ -4,9 +4,12 @@
 package ibm
 
 import (
+	"context"
+
 	"github.com/IBM-Cloud/power-go-client/helpers"
 	"github.com/IBM-Cloud/power-go-client/power/models"
 	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 
 	"github.com/IBM-Cloud/power-go-client/clients/instance"
@@ -16,16 +19,14 @@ import (
 func dataSourceIBMPIInstanceVolumes() *schema.Resource {
 
 	return &schema.Resource{
-		Read: dataSourceIBMPIInstanceVolumesRead,
+		ReadContext: dataSourceIBMPIInstanceVolumesRead,
 		Schema: map[string]*schema.Schema{
-
 			helpers.PIInstanceName: {
 				Type:         schema.TypeString,
 				Required:     true,
 				Description:  "Instance Name to be used for pvminstances",
 				ValidateFunc: validation.NoZeroValues,
 			},
-
 			helpers.PICloudInstanceId: {
 				Type:         schema.TypeString,
 				Required:     true,
@@ -33,12 +34,10 @@ func dataSourceIBMPIInstanceVolumes() *schema.Resource {
 			},
 
 			//Computed Attributes
-
 			"boot_volume_id": {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
-
 			"instance_volumes": {
 				Type:     schema.TypeList,
 				Computed: true,
@@ -87,19 +86,18 @@ func dataSourceIBMPIInstanceVolumes() *schema.Resource {
 	}
 }
 
-func dataSourceIBMPIInstanceVolumesRead(d *schema.ResourceData, meta interface{}) error {
-
+func dataSourceIBMPIInstanceVolumesRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	sess, err := meta.(ClientSession).IBMPISession()
 	if err != nil {
-		return err
+		return diag.FromErr(err)
 	}
 
-	powerinstanceid := d.Get(helpers.PICloudInstanceId).(string)
-	volumeC := instance.NewIBMPIVolumeClient(sess, powerinstanceid)
-	volumedata, err := volumeC.GetAll(d.Get(helpers.PIInstanceName).(string), powerinstanceid, getTimeOut)
+	cloudInstanceID := d.Get(helpers.PICloudInstanceId).(string)
 
+	volumeC := instance.NewIBMPIVolumeClient(ctx, sess, cloudInstanceID)
+	volumedata, err := volumeC.GetAllInstanceVolumes(d.Get(helpers.PIInstanceName).(string))
 	if err != nil {
-		return err
+		return diag.FromErr(err)
 	}
 
 	var clientgenU, _ = uuid.GenerateUUID()

--- a/ibm/data_source_ibm_pi_key.go
+++ b/ibm/data_source_ibm_pi_key.go
@@ -4,6 +4,9 @@
 package ibm
 
 import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 
@@ -14,7 +17,7 @@ import (
 func dataSourceIBMPIKey() *schema.Resource {
 
 	return &schema.Resource{
-		Read: dataSourceIBMPIKeysRead,
+		ReadContext: dataSourceIBMPIKeysRead,
 		Schema: map[string]*schema.Schema{
 
 			helpers.PIKeyName: {
@@ -42,28 +45,24 @@ func dataSourceIBMPIKey() *schema.Resource {
 	}
 }
 
-func dataSourceIBMPIKeysRead(d *schema.ResourceData, meta interface{}) error {
-
+func dataSourceIBMPIKeysRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	sess, err := meta.(ClientSession).IBMPISession()
-
 	if err != nil {
-		return err
+		return diag.FromErr(err)
 	}
 
 	powerinstanceid := d.Get(helpers.PICloudInstanceId).(string)
-	sshkeyC := instance.NewIBMPIKeyClient(sess, powerinstanceid)
-	sshkeydata, err := sshkeyC.Get(d.Get(helpers.PIKeyName).(string), powerinstanceid)
 
+	sshkeyC := instance.NewIBMPIKeyClient(ctx, sess, powerinstanceid)
+	sshkeydata, err := sshkeyC.Get(d.Get(helpers.PIKeyName).(string))
 	if err != nil {
-		return err
+		return diag.FromErr(err)
 	}
 
 	d.SetId(*sshkeydata.Name)
 	d.Set("creation_date", sshkeydata.CreationDate.String())
 	d.Set("sshkey", sshkeydata.SSHKey)
 	d.Set(helpers.PIKeyName, sshkeydata.Name)
-	d.Set(helpers.PICloudInstanceId, powerinstanceid)
 
 	return nil
-
 }

--- a/ibm/data_source_ibm_pi_key.go
+++ b/ibm/data_source_ibm_pi_key.go
@@ -51,9 +51,9 @@ func dataSourceIBMPIKeysRead(ctx context.Context, d *schema.ResourceData, meta i
 		return diag.FromErr(err)
 	}
 
-	powerinstanceid := d.Get(helpers.PICloudInstanceId).(string)
+	cloudInstanceID := d.Get(helpers.PICloudInstanceId).(string)
 
-	sshkeyC := instance.NewIBMPIKeyClient(ctx, sess, powerinstanceid)
+	sshkeyC := instance.NewIBMPIKeyClient(ctx, sess, cloudInstanceID)
 	sshkeydata, err := sshkeyC.Get(d.Get(helpers.PIKeyName).(string))
 	if err != nil {
 		return diag.FromErr(err)

--- a/ibm/data_source_ibm_pi_snapshot.go
+++ b/ibm/data_source_ibm_pi_snapshot.go
@@ -91,9 +91,9 @@ func dataSourceIBMPISnapshotRead(ctx context.Context, d *schema.ResourceData, me
 		return diag.FromErr(err)
 	}
 
-	powerinstanceid := d.Get(helpers.PICloudInstanceId).(string)
+	cloudInstanceID := d.Get(helpers.PICloudInstanceId).(string)
 	powerinstancename := d.Get(helpers.PIInstanceName).(string)
-	snapshot := instance.NewIBMPIInstanceClient(ctx, sess, powerinstanceid)
+	snapshot := instance.NewIBMPIInstanceClient(ctx, sess, cloudInstanceID)
 	snapshotData, err := snapshot.GetSnapShotVM(powerinstancename)
 
 	if err != nil {

--- a/ibm/data_source_ibm_pi_snapshots_test.go
+++ b/ibm/data_source_ibm_pi_snapshots_test.go
@@ -17,7 +17,7 @@ func TestAccIBMPISnapshotsDataSource_basic(t *testing.T) {
 		PreCheck:  func() { testAccPreCheck(t) },
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: testAccCheckIBMPISnapshotsDataSourceConfig(),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("data.ibm_pi_pvminstance_snapshots.testacc_ds_snapshots", "pi_cloud_instance_id", pi_cloud_instance_id),

--- a/ibm/data_source_ibm_pi_volume.go
+++ b/ibm/data_source_ibm_pi_volume.go
@@ -6,6 +6,9 @@ package ibm
 import (
 	//"fmt"
 
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 
@@ -14,18 +17,15 @@ import (
 )
 
 func dataSourceIBMPIVolume() *schema.Resource {
-
 	return &schema.Resource{
-		Read: dataSourceIBMPIVolumeRead,
+		ReadContext: dataSourceIBMPIVolumeRead,
 		Schema: map[string]*schema.Schema{
-
 			helpers.PIVolumeName: {
 				Type:         schema.TypeString,
 				Required:     true,
 				Description:  "Volume Name to be used for pvminstances",
 				ValidateFunc: validation.NoZeroValues,
 			},
-
 			helpers.PICloudInstanceId: {
 				Type:         schema.TypeString,
 				Required:     true,
@@ -65,18 +65,17 @@ func dataSourceIBMPIVolume() *schema.Resource {
 	}
 }
 
-func dataSourceIBMPIVolumeRead(d *schema.ResourceData, meta interface{}) error {
-
+func dataSourceIBMPIVolumeRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	sess, err := meta.(ClientSession).IBMPISession()
 	if err != nil {
-		return err
+		return diag.FromErr(err)
 	}
 
-	powerinstanceid := d.Get(helpers.PICloudInstanceId).(string)
-	volumeC := instance.NewIBMPIVolumeClient(sess, powerinstanceid)
-	volumedata, err := volumeC.Get(d.Get(helpers.PIVolumeName).(string), powerinstanceid, getTimeOut)
+	cloudInstanceID := d.Get(helpers.PICloudInstanceId).(string)
+	volumeC := instance.NewIBMPIVolumeClient(ctx, sess, cloudInstanceID)
+	volumedata, err := volumeC.Get(d.Get(helpers.PIVolumeName).(string))
 	if err != nil {
-		return err
+		return diag.FromErr(err)
 	}
 
 	d.SetId(*volumedata.VolumeID)
@@ -87,6 +86,6 @@ func dataSourceIBMPIVolumeRead(d *schema.ResourceData, meta interface{}) error {
 	d.Set("disk_type", volumedata.DiskType)
 	d.Set("volume_pool", volumedata.VolumePool)
 	d.Set("wwn", volumedata.Wwn)
-	return nil
 
+	return nil
 }

--- a/ibm/resource_ibm_pi_cloud_connection.go
+++ b/ibm/resource_ibm_pi_cloud_connection.go
@@ -205,11 +205,12 @@ func resourceIBMPICloudConnectionCreate(ctx context.Context, d *schema.ResourceD
 		log.Printf("[DEBUG] create cloud connection failed %v", err)
 		return diag.FromErr(err)
 	}
-	var cloudConnectionID string
+
 	if cloudConnection != nil {
-		cloudConnectionID = *cloudConnection.CloudConnectionID
+		d.SetId(fmt.Sprintf("%s/%s", cloudInstanceID, *cloudConnection.CloudConnectionID))
 	} else if cloudConnectionJob != nil {
-		cloudConnectionID = *cloudConnectionJob.CloudConnectionID
+		d.SetId(fmt.Sprintf("%s/%s", cloudInstanceID, *cloudConnection.CloudConnectionID))
+
 		jobID := *cloudConnectionJob.JobRef.ID
 
 		client := st.NewIBMPIJobClient(ctx, sess, cloudInstanceID)
@@ -218,8 +219,6 @@ func resourceIBMPICloudConnectionCreate(ctx context.Context, d *schema.ResourceD
 			return diag.FromErr(err)
 		}
 	}
-
-	d.SetId(fmt.Sprintf("%s/%s", cloudInstanceID, cloudConnectionID))
 
 	return resourceIBMPICloudConnectionRead(ctx, d, meta)
 }

--- a/ibm/resource_ibm_pi_cloud_connection_test.go
+++ b/ibm/resource_ibm_pi_cloud_connection_test.go
@@ -4,6 +4,7 @@
 package ibm
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"testing"
@@ -46,14 +47,12 @@ func testAccCheckIBMPICloudConnectionDestroy(s *terraform.State) error {
 		if rs.Type != "ibm_pi_cloud_connection" {
 			continue
 		}
-		parts, err := idParts(rs.Primary.ID)
+		cloudInstanceID, cloudConnectionID, err := splitID(rs.Primary.ID)
 		if err != nil {
 			return err
 		}
-		cloudInstanceID := parts[0]
-		cloudConnectionID := parts[1]
-		client := st.NewIBMPICloudConnectionClient(sess, cloudInstanceID)
-		_, err = client.Get(cloudConnectionID, cloudInstanceID)
+		client := st.NewIBMPICloudConnectionClient(context.Background(), sess, cloudInstanceID)
+		_, err = client.Get(cloudConnectionID)
 		if err == nil {
 			return fmt.Errorf("Cloud Connection still exists: %s", rs.Primary.ID)
 		}
@@ -74,15 +73,13 @@ func testAccCheckIBMPICloudConnectionExists(n string) resource.TestCheckFunc {
 		if err != nil {
 			return err
 		}
-		parts, err := idParts(rs.Primary.ID)
+		cloudInstanceID, cloudConnectionID, err := splitID(rs.Primary.ID)
 		if err != nil {
 			return err
 		}
-		cloudInstanceID := parts[0]
-		cloudConnectionID := parts[1]
-		client := st.NewIBMPICloudConnectionClient(sess, cloudInstanceID)
+		client := st.NewIBMPICloudConnectionClient(context.Background(), sess, cloudInstanceID)
 
-		_, err = client.Get(cloudConnectionID, cloudInstanceID)
+		_, err = client.Get(cloudConnectionID)
 		if err != nil {
 			return err
 		}

--- a/ibm/resource_ibm_pi_dhcp_test.go
+++ b/ibm/resource_ibm_pi_dhcp_test.go
@@ -4,6 +4,7 @@
 package ibm
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"testing"
@@ -41,14 +42,14 @@ func testAccCheckIBMPIDhcpDestroy(s *terraform.State) error {
 		if rs.Type != "ibm_pi_dhcp" {
 			continue
 		}
-		parts, err := idParts(rs.Primary.ID)
+
+		cloudInstanceID, dhcpID, err := splitID(rs.Primary.ID)
 		if err != nil {
 			return err
 		}
-		cloudConnectionID := parts[0]
-		dhcpID := parts[1]
-		client := st.NewIBMPIDhcpClient(sess, cloudConnectionID)
-		_, err = client.Get(dhcpID, cloudConnectionID)
+
+		client := st.NewIBMPIDhcpClient(context.Background(), sess, cloudInstanceID)
+		_, err = client.Get(dhcpID)
 		if err == nil {
 			return fmt.Errorf("PI DHCP still exists: %s", rs.Primary.ID)
 		}
@@ -70,15 +71,14 @@ func testAccCheckIBMPIDhcpExists(n string) resource.TestCheckFunc {
 		if err != nil {
 			return err
 		}
-		parts, err := idParts(rs.Primary.ID)
+
+		cloudInstanceID, dhcpID, err := splitID(rs.Primary.ID)
 		if err != nil {
 			return err
 		}
-		cloudConnectionID := parts[0]
-		dhcpID := parts[1]
-		client := st.NewIBMPIDhcpClient(sess, cloudConnectionID)
+		client := st.NewIBMPIDhcpClient(context.Background(), sess, cloudInstanceID)
 
-		_, err = client.Get(dhcpID, cloudConnectionID)
+		_, err = client.Get(dhcpID)
 		if err != nil {
 			return err
 		}

--- a/ibm/resource_ibm_pi_ike_policy_test.go
+++ b/ibm/resource_ibm_pi_ike_policy_test.go
@@ -4,6 +4,7 @@
 package ibm
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"testing"
@@ -53,14 +54,12 @@ func testAccCheckIBMPIIKEPolicyDestroy(s *terraform.State) error {
 		if rs.Type != "ibm_pi_ike_policy" {
 			continue
 		}
-		parts, err := idParts(rs.Primary.ID)
+		cloudInstanceID, policyID, err := splitID(rs.Primary.ID)
 		if err != nil {
 			return err
 		}
-		cloudInstanceID := parts[0]
-		policyID := parts[1]
-		client := st.NewIBMPIVpnPolicyClient(sess, cloudInstanceID)
-		_, err = client.GetIKEPolicy(policyID, cloudInstanceID)
+		client := st.NewIBMPIVpnPolicyClient(context.Background(), sess, cloudInstanceID)
+		_, err = client.GetIKEPolicy(policyID)
 		if err == nil {
 			return fmt.Errorf("ike policy still exists: %s", rs.Primary.ID)
 		}
@@ -81,15 +80,13 @@ func testAccCheckIBMPIIKEPolicyExists(n string) resource.TestCheckFunc {
 		if err != nil {
 			return err
 		}
-		parts, err := idParts(rs.Primary.ID)
+		cloudInstanceID, policyID, err := splitID(rs.Primary.ID)
 		if err != nil {
 			return err
 		}
-		cloudInstanceID := parts[0]
-		policyID := parts[1]
-		client := st.NewIBMPIVpnPolicyClient(sess, cloudInstanceID)
+		client := st.NewIBMPIVpnPolicyClient(context.Background(), sess, cloudInstanceID)
 
-		_, err = client.GetIKEPolicy(policyID, cloudInstanceID)
+		_, err = client.GetIKEPolicy(policyID)
 		if err != nil {
 			return err
 		}

--- a/ibm/resource_ibm_pi_image.go
+++ b/ibm/resource_ibm_pi_image.go
@@ -134,11 +134,17 @@ func resourceIBMPIImageCreate(ctx context.Context, d *schema.ResourceData, meta 
 	cloudInstanceID := d.Get(helpers.PICloudInstanceId).(string)
 	imageName := d.Get(helpers.PIImageName).(string)
 
-	client := st.NewIBMPIImageClient(sess, cloudInstanceID)
+	client := st.NewIBMPIImageClient(ctx, sess, cloudInstanceID)
 	// image copy
 	if v, ok := d.GetOk(helpers.PIImageId); ok {
 		imageid := v.(string)
-		imageResponse, err := client.Create(imageName, imageid, cloudInstanceID)
+		source := "root-project"
+		var body = &models.CreateImage{
+			ImageName: imageName,
+			ImageID:   imageid,
+			Source:    &source,
+		}
+		imageResponse, err := client.Create(body)
 		if err != nil {
 			return diag.FromErr(err)
 		}
@@ -146,7 +152,7 @@ func resourceIBMPIImageCreate(ctx context.Context, d *schema.ResourceData, meta 
 		IBMPIImageID := imageResponse.ImageID
 		d.SetId(fmt.Sprintf("%s/%s", cloudInstanceID, *IBMPIImageID))
 
-		_, err = isWaitForIBMPIImageAvailable(ctx, client, *IBMPIImageID, d.Timeout(schema.TimeoutCreate), cloudInstanceID)
+		_, err = isWaitForIBMPIImageAvailable(ctx, client, *IBMPIImageID, d.Timeout(schema.TimeoutCreate))
 		if err != nil {
 			log.Printf("[DEBUG]  err %s", err)
 			return diag.FromErr(err)
@@ -177,7 +183,7 @@ func resourceIBMPIImageCreate(ctx context.Context, d *schema.ResourceData, meta 
 			body.SecretKey = v.(string)
 		}
 
-		imageResponse, err := client.CreateCosImageWithContext(ctx, body, cloudInstanceID)
+		imageResponse, err := client.CreateCosImage(body)
 		if err != nil {
 			return diag.FromErr(err)
 		}
@@ -189,7 +195,7 @@ func resourceIBMPIImageCreate(ctx context.Context, d *schema.ResourceData, meta 
 		}
 
 		// Once the job is completed find by name
-		image, err := client.GetWithContext(ctx, imageName, cloudInstanceID)
+		image, err := client.Get(imageName)
 		if err != nil {
 			return diag.FromErr(err)
 		}
@@ -205,16 +211,13 @@ func resourceIBMPIImageRead(ctx context.Context, d *schema.ResourceData, meta in
 		return diag.FromErr(err)
 	}
 
-	parts, err := idParts(d.Id())
+	cloudInstanceID, imageID, err := splitID(d.Id())
 	if err != nil {
 		return diag.FromErr(err)
 	}
 
-	cloudInstanceID := parts[0]
-	imageID := parts[1]
-
-	imageC := st.NewIBMPIImageClient(sess, cloudInstanceID)
-	imagedata, err := imageC.GetWithContext(ctx, imageID, cloudInstanceID)
+	imageC := st.NewIBMPIImageClient(ctx, sess, cloudInstanceID)
+	imagedata, err := imageC.Get(imageID)
 	if err != nil {
 		uErr := errors.Unwrap(err)
 		switch uErr.(type) {
@@ -244,30 +247,28 @@ func resourceIBMPIImageDelete(ctx context.Context, d *schema.ResourceData, meta 
 		return diag.FromErr(err)
 	}
 
-	parts, err := idParts(d.Id())
+	cloudInstanceID, imageID, err := splitID(d.Id())
 	if err != nil {
 		return diag.FromErr(err)
 	}
 
-	cloudInstanceID := parts[0]
-	imageID := parts[1]
-	imageC := st.NewIBMPIImageClient(sess, cloudInstanceID)
-	_, err = imageC.DeleteWithContext(ctx, imageID, cloudInstanceID)
+	imageC := st.NewIBMPIImageClient(ctx, sess, cloudInstanceID)
+	err = imageC.Delete(imageID)
 	if err != nil {
-		return diag.Errorf("Failed to Delete PI Image %s :%v", imageID, err)
+		return diag.FromErr(err)
 	}
 
 	d.SetId("")
 	return nil
 }
 
-func isWaitForIBMPIImageAvailable(ctx context.Context, client *st.IBMPIImageClient, id string, timeout time.Duration, powerinstanceid string) (interface{}, error) {
+func isWaitForIBMPIImageAvailable(ctx context.Context, client *st.IBMPIImageClient, id string, timeout time.Duration) (interface{}, error) {
 	log.Printf("Waiting for Power Image (%s) to be available.", id)
 
 	stateConf := &resource.StateChangeConf{
 		Pending:    []string{"retry", helpers.PIImageQueStatus},
 		Target:     []string{helpers.PIImageActiveStatus},
-		Refresh:    isIBMPIImageRefreshFunc(ctx, client, id, powerinstanceid),
+		Refresh:    isIBMPIImageRefreshFunc(ctx, client, id),
 		Timeout:    timeout,
 		Delay:      20 * time.Second,
 		MinTimeout: 10 * time.Second,
@@ -276,11 +277,11 @@ func isWaitForIBMPIImageAvailable(ctx context.Context, client *st.IBMPIImageClie
 	return stateConf.WaitForStateContext(ctx)
 }
 
-func isIBMPIImageRefreshFunc(ctx context.Context, client *st.IBMPIImageClient, id, powerinstanceid string) resource.StateRefreshFunc {
+func isIBMPIImageRefreshFunc(ctx context.Context, client *st.IBMPIImageClient, id string) resource.StateRefreshFunc {
 
 	log.Printf("Calling the isIBMPIImageRefreshFunc Refresh Function....")
 	return func() (interface{}, string, error) {
-		image, err := client.GetWithContext(ctx, id, powerinstanceid)
+		image, err := client.Get(id)
 		if err != nil {
 			return nil, "", err
 		}

--- a/ibm/resource_ibm_pi_instance.go
+++ b/ibm/resource_ibm_pi_instance.go
@@ -489,7 +489,7 @@ func resourceIBMPIInstanceUpdate(ctx context.Context, d *schema.ResourceData, me
 	client := st.NewIBMPIInstanceClient(ctx, sess, cloudInstanceID)
 
 	// Check if cloud instance is capable of changing virtual cores
-	cloudInstanceClient := st.NewIBMPICloudInstanceClient(sess, cloudInstanceID)
+	cloudInstanceClient := st.NewIBMPICloudInstanceClient(ctx, sess, cloudInstanceID)
 	cloudInstance, err := cloudInstanceClient.Get(cloudInstanceID)
 	if err != nil {
 		return diag.FromErr(err)

--- a/ibm/resource_ibm_pi_instance_test.go
+++ b/ibm/resource_ibm_pi_instance_test.go
@@ -49,6 +49,7 @@ func testAccCheckIBMPIInstanceConfig(name string) string {
 		pi_cloud_instance_id  = "%[1]s"
 		pi_storage_pool       = data.ibm_pi_image.power_image.storage_pool
 		pi_health_status      = "WARNING"
+		pi_volume_ids         = [ibm_pi_volume.power_volume.volume_id]
 		pi_network {
 			network_id = data.ibm_pi_network.power_networks.id
 		}

--- a/ibm/resource_ibm_pi_ipsec_policy_test.go
+++ b/ibm/resource_ibm_pi_ipsec_policy_test.go
@@ -4,6 +4,7 @@
 package ibm
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"testing"
@@ -44,14 +45,12 @@ func testAccCheckIBMPIIPSecPolicyDestroy(s *terraform.State) error {
 		if rs.Type != "ibm_pi_ipsec_policy" {
 			continue
 		}
-		parts, err := idParts(rs.Primary.ID)
+		cloudInstanceID, policyID, err := splitID(rs.Primary.ID)
 		if err != nil {
 			return err
 		}
-		cloudInstanceID := parts[0]
-		policyID := parts[1]
-		client := st.NewIBMPIVpnPolicyClient(sess, cloudInstanceID)
-		_, err = client.GetIPSecPolicy(policyID, cloudInstanceID)
+		client := st.NewIBMPIVpnPolicyClient(context.Background(), sess, cloudInstanceID)
+		_, err = client.GetIPSecPolicy(policyID)
 		if err == nil {
 			return fmt.Errorf("ipsec policy still exists: %s", rs.Primary.ID)
 		}
@@ -72,15 +71,13 @@ func testAccCheckIBMPIIPSecPolicyExists(n string) resource.TestCheckFunc {
 		if err != nil {
 			return err
 		}
-		parts, err := idParts(rs.Primary.ID)
+		cloudInstanceID, policyID, err := splitID(rs.Primary.ID)
 		if err != nil {
 			return err
 		}
-		cloudInstanceID := parts[0]
-		policyID := parts[1]
-		client := st.NewIBMPIVpnPolicyClient(sess, cloudInstanceID)
+		client := st.NewIBMPIVpnPolicyClient(context.Background(), sess, cloudInstanceID)
 
-		_, err = client.GetIPSecPolicy(policyID, cloudInstanceID)
+		_, err = client.GetIPSecPolicy(policyID)
 		if err != nil {
 			return err
 		}

--- a/ibm/resource_ibm_pi_key.go
+++ b/ibm/resource_ibm_pi_key.go
@@ -4,25 +4,26 @@
 package ibm
 
 import (
+	"context"
 	"fmt"
 	"log"
 	"time"
 
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 
-	"github.com/IBM-Cloud/bluemix-go/bmxerror"
 	st "github.com/IBM-Cloud/power-go-client/clients/instance"
 	"github.com/IBM-Cloud/power-go-client/helpers"
+	"github.com/IBM-Cloud/power-go-client/power/models"
 )
 
 func resourceIBMPIKey() *schema.Resource {
 	return &schema.Resource{
-		Create:   resourceIBMPIKeyCreate,
-		Read:     resourceIBMPIKeyRead,
-		Update:   resourceIBMPIKeyUpdate,
-		Delete:   resourceIBMPIKeyDelete,
-		Exists:   resourceIBMPIKeyExists,
-		Importer: &schema.ResourceImporter{},
+		CreateContext: resourceIBMPIKeyCreate,
+		ReadContext:   resourceIBMPIKeyRead,
+		UpdateContext: resourceIBMPIKeyUpdate,
+		DeleteContext: resourceIBMPIKeyDelete,
+		Importer:      &schema.ResourceImporter{},
 
 		Timeouts: &schema.ResourceTimeout{
 			Create: schema.DefaultTimeout(60 * time.Minute),
@@ -63,112 +64,77 @@ func resourceIBMPIKey() *schema.Resource {
 	}
 }
 
-func resourceIBMPIKeyCreate(d *schema.ResourceData, meta interface{}) error {
+func resourceIBMPIKeyCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	sess, err := meta.(ClientSession).IBMPISession()
 	if err != nil {
-		return err
+		return diag.FromErr(err)
 	}
 
-	powerinstanceid := d.Get(helpers.PICloudInstanceId).(string)
+	cloudInstanceID := d.Get(helpers.PICloudInstanceId).(string)
 	name := d.Get(helpers.PIKeyName).(string)
 	sshkey := d.Get(helpers.PIKey).(string)
-	client := st.NewIBMPIKeyClient(sess, powerinstanceid)
 
-	sshResponse, _, err := client.Create(name, sshkey, powerinstanceid)
+	client := st.NewIBMPIKeyClient(ctx, sess, cloudInstanceID)
+	body := &models.SSHKey{
+		Name:   &name,
+		SSHKey: &sshkey,
+	}
+	sshResponse, err := client.Create(body)
 	if err != nil {
 		log.Printf("[DEBUG]  err %s", err)
-		return fmt.Errorf("Failed to create the key %v", err)
-
+		return diag.FromErr(err)
 	}
 
-	log.Printf("Printing the sshkey %+v", &sshResponse)
+	log.Printf("Printing the sshkey %+v", *sshResponse)
 
-	d.SetId(fmt.Sprintf("%s/%s", powerinstanceid, name))
-	return resourceIBMPIKeyRead(d, meta)
+	d.SetId(fmt.Sprintf("%s/%s", cloudInstanceID, name))
+	return resourceIBMPIKeyRead(ctx, d, meta)
 }
 
-func resourceIBMPIKeyRead(d *schema.ResourceData, meta interface{}) error {
+func resourceIBMPIKeyRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 
 	sess, err := meta.(ClientSession).IBMPISession()
 	if err != nil {
-		return err
-	}
-	parts, err := idParts(d.Id())
-	if err != nil {
-		return fmt.Errorf("Failed to obtain the key %v", err)
+		return diag.FromErr(err)
 	}
 
-	powerinstanceid := parts[0]
-	sshkeyC := st.NewIBMPIKeyClient(sess, powerinstanceid)
-	sshkeydata, err := sshkeyC.Get(parts[1], powerinstanceid)
-
+	cloudInstanceID, key, err := splitID(d.Id())
 	if err != nil {
-		return err
+		return diag.FromErr(err)
+	}
+
+	sshkeyC := st.NewIBMPIKeyClient(ctx, sess, cloudInstanceID)
+	sshkeydata, err := sshkeyC.Get(key)
+	if err != nil {
+		return diag.FromErr(err)
 	}
 
 	d.Set(helpers.PIKeyName, sshkeydata.Name)
 	d.Set(helpers.PIKey, sshkeydata.SSHKey)
 	d.Set(helpers.PIKeyDate, sshkeydata.CreationDate.String())
 	d.Set("key_id", sshkeydata.Name)
-	d.Set(helpers.PICloudInstanceId, powerinstanceid)
 
 	return nil
 
 }
-
-func resourceIBMPIKeyUpdate(data *schema.ResourceData, meta interface{}) error {
-	return nil
+func resourceIBMPIKeyUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	return resourceIBMPIKeyRead(ctx, d, meta)
 }
-
-func resourceIBMPIKeyDelete(d *schema.ResourceData, meta interface{}) error {
+func resourceIBMPIKeyDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	sess, err := meta.(ClientSession).IBMPISession()
 	if err != nil {
-		return err
+		return diag.FromErr(err)
 	}
-	parts, err := idParts(d.Id())
+	cloudInstanceID, key, err := splitID(d.Id())
 	if err != nil {
-		return err
+		return diag.FromErr(err)
 	}
 
-	powerinstanceid := parts[0]
-	sshkeyC := st.NewIBMPIKeyClient(sess, powerinstanceid)
-	err = sshkeyC.Delete(parts[1], powerinstanceid)
-
+	sshkeyC := st.NewIBMPIKeyClient(ctx, sess, cloudInstanceID)
+	err = sshkeyC.Delete(key)
 	if err != nil {
-		return err
+		return diag.FromErr(err)
 	}
 	d.SetId("")
 	return nil
-}
-
-func resourceIBMPIKeyExists(d *schema.ResourceData, meta interface{}) (bool, error) {
-
-	sess, err := meta.(ClientSession).IBMPISession()
-	if err != nil {
-		return false, err
-	}
-	parts, err := idParts(d.Id())
-	if err != nil {
-		return false, err
-	}
-	if len(parts) < 2 {
-		return false, fmt.Errorf("Incorrect ID %s: Id should be a combination of powerInstanceID/keyName", d.Id())
-	}
-	name := parts[1]
-	powerinstanceid := parts[0]
-	client := st.NewIBMPIKeyClient(sess, powerinstanceid)
-
-	key, err := client.Get(parts[1], powerinstanceid)
-	if err != nil || key == nil {
-		if apiErr, ok := err.(bmxerror.RequestFailure); ok {
-			if apiErr.StatusCode() == 404 {
-				return false, nil
-			}
-		}
-		return false, fmt.Errorf("[ERROR] Error getting pi key: %s", err)
-	}
-	if key.Name != nil {
-		return *key.Name == name, nil
-	}
-	return false, nil
 }

--- a/ibm/resource_ibm_pi_network_port_attach_test.go
+++ b/ibm/resource_ibm_pi_network_port_attach_test.go
@@ -4,6 +4,7 @@
 package ibm
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"testing"
@@ -45,9 +46,14 @@ func testAccCheckIBMPINetworkPortAttachDestroy(s *terraform.State) error {
 			continue
 		}
 		parts, err := idParts(rs.Primary.ID)
-		powerinstanceid := parts[0]
-		networkC := st.NewIBMPINetworkClient(sess, powerinstanceid)
-		_, err = networkC.GetPort(parts[2], parts[1], powerinstanceid, getTimeOut)
+		if err != nil {
+			return err
+		}
+		cloudInstanceID := parts[0]
+		networkID := parts[1]
+		portID := parts[2]
+		networkC := st.NewIBMPINetworkClient(context.Background(), sess, cloudInstanceID)
+		_, err = networkC.GetPort(networkID, portID)
 		if err == nil {
 			return fmt.Errorf("PI Network Port still exists: %s", rs.Primary.ID)
 		}
@@ -76,10 +82,12 @@ func testAccCheckIBMPINetworkPortAttachExists(n string) resource.TestCheckFunc {
 		if err != nil {
 			return err
 		}
-		powerinstanceid := parts[0]
-		client := st.NewIBMPINetworkClient(sess, powerinstanceid)
+		cloudInstanceID := parts[0]
+		networkID := parts[1]
+		portID := parts[2]
+		client := st.NewIBMPINetworkClient(context.Background(), sess, cloudInstanceID)
 
-		network, err := client.GetPort(parts[2], powerinstanceid, parts[1], getTimeOut)
+		network, err := client.GetPort(networkID, portID)
 		if err != nil {
 			return err
 		}

--- a/ibm/resource_ibm_pi_snapshot.go
+++ b/ibm/resource_ibm_pi_snapshot.go
@@ -9,10 +9,10 @@ import (
 	"log"
 	"time"
 
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 
-	"github.com/IBM-Cloud/bluemix-go/bmxerror"
 	st "github.com/IBM-Cloud/power-go-client/clients/instance"
 	"github.com/IBM-Cloud/power-go-client/helpers"
 	"github.com/IBM-Cloud/power-go-client/power/models"
@@ -20,35 +20,29 @@ import (
 
 func resourceIBMPISnapshot() *schema.Resource {
 	return &schema.Resource{
-		Create:   resourceIBMPISnapshotCreate,
-		Read:     resourceIBMPISnapshotRead,
-		Update:   resourceIBMPISnapshotUpdate,
-		Delete:   resourceIBMPISnapshotDelete,
-		Exists:   resourceIBMPISnapshotExists,
-		Importer: &schema.ResourceImporter{},
+		CreateContext: resourceIBMPISnapshotCreate,
+		ReadContext:   resourceIBMPISnapshotRead,
+		UpdateContext: resourceIBMPISnapshotUpdate,
+		DeleteContext: resourceIBMPISnapshotDelete,
+		Importer:      &schema.ResourceImporter{},
 
 		Timeouts: &schema.ResourceTimeout{
 			Create: schema.DefaultTimeout(60 * time.Minute),
 			Update: schema.DefaultTimeout(60 * time.Minute),
-			Delete: schema.DefaultTimeout(60 * time.Minute),
+			Delete: schema.DefaultTimeout(10 * time.Minute),
 		},
 
 		Schema: map[string]*schema.Schema{
-
-			//Snapshots are created at the pvm instance level
-
 			helpers.PISnapshotName: {
 				Type:        schema.TypeString,
 				Required:    true,
 				Description: "Unique name of the snapshot",
 			},
-
 			helpers.PIInstanceName: {
 				Type:        schema.TypeString,
 				Required:    true,
 				Description: "Instance name / id of the pvm",
 			},
-
 			helpers.PIInstanceVolumeIds: {
 				Type:             schema.TypeSet,
 				Optional:         true,
@@ -57,26 +51,35 @@ func resourceIBMPISnapshot() *schema.Resource {
 				DiffSuppressFunc: applyOnce,
 				Description:      "List of PI volumes",
 			},
-
 			helpers.PICloudInstanceId: {
 				Type:        schema.TypeString,
 				Required:    true,
 				Description: " Cloud Instance ID - This is the service_instance_id.",
 			},
-
+			"pi_description": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "Description of the PVM instance snapshot",
+			},
 			"description": {
 				Type:        schema.TypeString,
 				Optional:    true,
 				Description: "Snapshot description",
+				Deprecated:  "This field is deprecated, use pi_description instead",
 			},
-			// Computed Attributes
 
+			// Computed Attributes
 			helpers.PISnapshot: {
 				Type:        schema.TypeString,
 				Computed:    true,
 				Description: "Id of the snapshot",
+				Deprecated:  "This field is deprecated, use snapshot_id instead",
 			},
-
+			"snapshot_id": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "ID of the PVM instance snapshot",
+			},
 			"status": {
 				Type:     schema.TypeString,
 				Computed: true,
@@ -85,7 +88,7 @@ func resourceIBMPISnapshot() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
-			"last_updated_date": {
+			"last_update_date": {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
@@ -97,22 +100,26 @@ func resourceIBMPISnapshot() *schema.Resource {
 	}
 }
 
-func resourceIBMPISnapshotCreate(d *schema.ResourceData, meta interface{}) error {
+func resourceIBMPISnapshotCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	sess, err := meta.(ClientSession).IBMPISession()
 	if err != nil {
-		return err
+		return diag.FromErr(err)
 	}
 
-	powerinstanceid := d.Get(helpers.PICloudInstanceId).(string)
+	cloudInstanceID := d.Get(helpers.PICloudInstanceId).(string)
 	instanceid := d.Get(helpers.PIInstanceName).(string)
 	volids := expandStringList((d.Get(helpers.PIInstanceVolumeIds).(*schema.Set)).List())
 	name := d.Get(helpers.PISnapshotName).(string)
-	description := d.Get("description").(string)
-	if d.Get(description) == "" {
-		description = "Testing from Terraform"
+
+	var description string
+	if v, ok := d.GetOk("description"); ok {
+		description = v.(string)
+	}
+	if v, ok := d.GetOk("pi_description"); ok {
+		description = v.(string)
 	}
 
-	client := st.NewIBMPIInstanceClient(context.Background(), sess, powerinstanceid)
+	client := st.NewIBMPIInstanceClient(context.Background(), sess, cloudInstanceID)
 
 	snapshotBody := &models.SnapshotCreate{Name: &name, Description: description}
 
@@ -123,48 +130,43 @@ func resourceIBMPISnapshotCreate(d *schema.ResourceData, meta interface{}) error
 	}
 
 	snapshotResponse, err := client.CreatePvmSnapShot(instanceid, snapshotBody)
-
 	if err != nil {
 		log.Printf("[DEBUG]  err %s", err)
-		return err
+		return diag.FromErr(err)
 	}
 
-	d.SetId(fmt.Sprintf("%s/%s", powerinstanceid, *snapshotResponse.SnapshotID))
+	d.SetId(fmt.Sprintf("%s/%s", cloudInstanceID, *snapshotResponse.SnapshotID))
+
+	pisnapclient := st.NewIBMPISnapshotClient(ctx, sess, cloudInstanceID)
+	_, err = isWaitForPIInstanceSnapshotAvailable(ctx, pisnapclient, *snapshotResponse.SnapshotID, d.Timeout(schema.TimeoutCreate))
 	if err != nil {
-		log.Printf("[DEBUG]  err %s", err)
-		return fmt.Errorf("failed to get the snapshotid %v", err)
+		return diag.FromErr(err)
 	}
 
-	pisnapclient := st.NewIBMPISnapshotClient(sess, powerinstanceid)
-	_, err = isWaitForPIInstanceSnapshotAvailable(pisnapclient, *snapshotResponse.SnapshotID, d.Timeout(schema.TimeoutCreate), powerinstanceid)
-	if err != nil {
-		return err
-	}
-
-	return resourceIBMPISnapshotRead(d, meta)
+	return resourceIBMPISnapshotRead(ctx, d, meta)
 }
 
-func resourceIBMPISnapshotRead(d *schema.ResourceData, meta interface{}) error {
+func resourceIBMPISnapshotRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	log.Printf("Calling the Snapshot Read function post create")
 	sess, err := meta.(ClientSession).IBMPISession()
 	if err != nil {
-		return err
-	}
-	parts, err := idParts(d.Id())
-	if err != nil {
-		return err
+		return diag.FromErr(err)
 	}
 
-	powerinstanceid := parts[0]
-	snapshot := st.NewIBMPISnapshotClient(sess, powerinstanceid)
-	snapshotdata, err := snapshot.Get(parts[1], powerinstanceid, getTimeOut)
-
+	cloudInstanceID, snapshotID, err := splitID(d.Id())
 	if err != nil {
-		return err
+		return diag.FromErr(err)
+	}
+
+	snapshot := st.NewIBMPISnapshotClient(ctx, sess, cloudInstanceID)
+	snapshotdata, err := snapshot.Get(snapshotID)
+	if err != nil {
+		return diag.FromErr(err)
 	}
 
 	d.Set(helpers.PISnapshotName, snapshotdata.Name)
 	d.Set(helpers.PISnapshot, *snapshotdata.SnapshotID)
+	d.Set("snapshot_id", *snapshotdata.SnapshotID)
 	d.Set("status", snapshotdata.Status)
 	d.Set("creation_date", snapshotdata.CreationDate.String())
 	d.Set("volume_snapshots", snapshotdata.VolumeSnapshots)
@@ -173,121 +175,94 @@ func resourceIBMPISnapshotRead(d *schema.ResourceData, meta interface{}) error {
 	return nil
 }
 
-func resourceIBMPISnapshotUpdate(d *schema.ResourceData, meta interface{}) error {
+func resourceIBMPISnapshotUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 
 	log.Printf("Calling the IBM Power Snapshot  update call")
-	sess, _ := meta.(ClientSession).IBMPISession()
-	parts, err := idParts(d.Id())
+	sess, err := meta.(ClientSession).IBMPISession()
 	if err != nil {
-		return err
+		return diag.FromErr(err)
 	}
-	powerinstanceid := parts[0]
-	client := st.NewIBMPISnapshotClient(sess, powerinstanceid)
+
+	cloudInstanceID, snapshotID, err := splitID(d.Id())
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	client := st.NewIBMPISnapshotClient(ctx, sess, cloudInstanceID)
 
 	if d.HasChange(helpers.PISnapshotName) || d.HasChange("description") {
 		name := d.Get(helpers.PISnapshotName).(string)
 		description := d.Get("description").(string)
 		snapshotBody := &models.SnapshotUpdate{Name: name, Description: description}
 
-		_, err := client.Update(parts[1], powerinstanceid, snapshotBody, 60)
-
+		_, err := client.Update(snapshotID, snapshotBody)
 		if err != nil {
-			return fmt.Errorf("failed to update the snapshot request %v", err)
-
+			return diag.FromErr(err)
 		}
 
-		_, err = isWaitForPIInstanceSnapshotAvailable(client, parts[1], d.Timeout(schema.TimeoutCreate), powerinstanceid)
+		_, err = isWaitForPIInstanceSnapshotAvailable(ctx, client, snapshotID, d.Timeout(schema.TimeoutCreate))
 		if err != nil {
-			return err
+			return diag.FromErr(err)
 		}
 	}
 
-	return resourceIBMPISnapshotRead(d, meta)
+	return resourceIBMPISnapshotRead(ctx, d, meta)
 }
 
-func resourceIBMPISnapshotDelete(d *schema.ResourceData, meta interface{}) error {
-
-	sess, _ := meta.(ClientSession).IBMPISession()
-	parts, err := idParts(d.Id())
+func resourceIBMPISnapshotDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	sess, err := meta.(ClientSession).IBMPISession()
 	if err != nil {
-		return err
+		return diag.FromErr(err)
 	}
-	powerinstanceid := parts[0]
 
-	client := st.NewIBMPISnapshotClient(sess, powerinstanceid)
-
-	snapshot, err := client.Get(parts[1], powerinstanceid, getTimeOut)
+	cloudInstanceID, snapshotID, err := splitID(d.Id())
 	if err != nil {
-		return err
+		return diag.FromErr(err)
+	}
+
+	client := st.NewIBMPISnapshotClient(ctx, sess, cloudInstanceID)
+	snapshot, err := client.Get(snapshotID)
+	if err != nil {
+		// snapshot does not exist
+		d.SetId("")
+		return nil
 	}
 
 	log.Printf("The snapshot  to be deleted is in the following state .. %s", snapshot.Status)
 
-	snapshotdel_err := client.Delete(parts[1], powerinstanceid, deleteTimeOut)
-	if snapshotdel_err != nil {
-		return snapshotdel_err
+	err = client.Delete(snapshotID)
+	if err != nil {
+		return diag.FromErr(err)
 	}
 
-	_, err = isWaitForPIInstanceSnapshotDeleted(client, parts[1], d.Timeout(schema.TimeoutDelete), powerinstanceid)
+	_, err = isWaitForPIInstanceSnapshotDeleted(ctx, client, snapshotID, d.Timeout(schema.TimeoutDelete))
 	if err != nil {
-		return err
+		return diag.FromErr(err)
 	}
 
 	d.SetId("")
 	return nil
 }
-func resourceIBMPISnapshotExists(d *schema.ResourceData, meta interface{}) (bool, error) {
-
-	sess, err := meta.(ClientSession).IBMPISession()
-	if err != nil {
-		return false, err
-	}
-	parts, err := idParts(d.Id())
-	if err != nil {
-		return false, err
-	}
-	if len(parts) < 2 {
-		return false, fmt.Errorf("Incorrect ID %s: Id should be a combination of powerInstanceID/SnapshotID", d.Id())
-	}
-	powerinstanceid := parts[0]
-	client := st.NewIBMPISnapshotClient(sess, powerinstanceid)
-
-	snapshotdelete, err := client.Get(parts[1], powerinstanceid, getTimeOut)
-	if err != nil {
-		if apiErr, ok := err.(bmxerror.RequestFailure); ok {
-			if apiErr.StatusCode() == 404 {
-				return false, nil
-			}
-		}
-		return false, fmt.Errorf("[ERROR] Error getting pi snapshot: %s", err)
-	}
-
-	log.Printf("Calling the existing function.. %s", *(snapshotdelete.SnapshotID))
-
-	volumeid := *snapshotdelete.SnapshotID
-	return volumeid == parts[1], nil
-}
-
-func isWaitForPIInstanceSnapshotAvailable(client *st.IBMPISnapshotClient, id string, timeout time.Duration, powerinstanceid string) (interface{}, error) {
+func isWaitForPIInstanceSnapshotAvailable(ctx context.Context, client *st.IBMPISnapshotClient, id string, timeout time.Duration) (interface{}, error) {
 
 	log.Printf("Waiting for PIInstance Snapshot (%s) to be available and active ", id)
 
 	stateConf := &resource.StateChangeConf{
 		Pending:    []string{"in_progress", "BUILD"},
 		Target:     []string{"available", "ACTIVE"},
-		Refresh:    isPIInstanceSnapshotRefreshFunc(client, id, powerinstanceid),
+		Refresh:    isPIInstanceSnapshotRefreshFunc(client, id),
 		Delay:      30 * time.Second,
 		MinTimeout: 2 * time.Minute,
-		Timeout:    60 * time.Minute,
+		Timeout:    timeout,
 	}
 
-	return stateConf.WaitForState()
+	return stateConf.WaitForStateContext(ctx)
 }
 
-func isPIInstanceSnapshotRefreshFunc(client *st.IBMPISnapshotClient, id, powerinstanceid string) resource.StateRefreshFunc {
+func isPIInstanceSnapshotRefreshFunc(client *st.IBMPISnapshotClient, id string) resource.StateRefreshFunc {
 	return func() (interface{}, string, error) {
 
-		snapshotInfo, err := client.Get(id, powerinstanceid, getTimeOut)
+		snapshotInfo, err := client.Get(id)
 		if err != nil {
 			return nil, "", err
 		}
@@ -304,29 +279,28 @@ func isPIInstanceSnapshotRefreshFunc(client *st.IBMPISnapshotClient, id, powerin
 
 // Delete Snapshot
 
-func isWaitForPIInstanceSnapshotDeleted(client *st.IBMPISnapshotClient, id string, timeout time.Duration, powerinstanceid string) (interface{}, error) {
+func isWaitForPIInstanceSnapshotDeleted(ctx context.Context, client *st.IBMPISnapshotClient, id string, timeout time.Duration) (interface{}, error) {
 
-	log.Printf("Waiting for  (%s) to be deleted.", id)
+	log.Printf("Waiting for (%s) to be deleted.", id)
 
 	stateConf := &resource.StateChangeConf{
 		Pending:    []string{"retry", helpers.PIInstanceDeleting},
 		Target:     []string{"Not Found"},
-		Refresh:    isPIInstanceSnapshotDeleteRefreshFunc(client, id, powerinstanceid),
+		Refresh:    isPIInstanceSnapshotDeleteRefreshFunc(client, id),
 		Delay:      10 * time.Second,
 		MinTimeout: 10 * time.Second,
-		Timeout:    10 * time.Minute,
+		Timeout:    timeout,
 	}
 
-	return stateConf.WaitForState()
+	return stateConf.WaitForStateContext(ctx)
 }
 
-func isPIInstanceSnapshotDeleteRefreshFunc(client *st.IBMPISnapshotClient, id, powerinstanceid string) resource.StateRefreshFunc {
+func isPIInstanceSnapshotDeleteRefreshFunc(client *st.IBMPISnapshotClient, id string) resource.StateRefreshFunc {
 	return func() (interface{}, string, error) {
-		snapshot, err := client.Get(id, powerinstanceid, getTimeOut)
+		snapshot, err := client.Get(id)
 		if err != nil {
 			log.Printf("The snapshot is not found.")
 			return snapshot, helpers.PIInstanceNotFound, nil
-
 		}
 		return snapshot, helpers.PIInstanceNotFound, nil
 

--- a/ibm/resource_ibm_pi_volume.go
+++ b/ibm/resource_ibm_pi_volume.go
@@ -4,26 +4,22 @@
 package ibm
 
 import (
+	"context"
 	"fmt"
 	"log"
 	"strings"
 	"time"
 
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 
-	"github.com/IBM-Cloud/bluemix-go/bmxerror"
 	st "github.com/IBM-Cloud/power-go-client/clients/instance"
 	"github.com/IBM-Cloud/power-go-client/helpers"
-	"github.com/IBM-Cloud/power-go-client/power/client/p_cloud_volumes"
 	"github.com/IBM-Cloud/power-go-client/power/models"
 )
 
 const (
-	/* Power Volume creation depends on response from PowerVC */
-	volPostTimeOut          = 180 * time.Second
-	volGetTimeOut           = 180 * time.Second
-	volDeleteTimeOut        = 180 * time.Second
 	PIAffinityPolicy        = "pi_affinity_policy"
 	PIAffinityVolume        = "pi_affinity_volume"
 	PIAffinityInstance      = "pi_affinity_instance"
@@ -33,17 +29,16 @@ const (
 
 func resourceIBMPIVolume() *schema.Resource {
 	return &schema.Resource{
-		Create:   resourceIBMPIVolumeCreate,
-		Read:     resourceIBMPIVolumeRead,
-		Update:   resourceIBMPIVolumeUpdate,
-		Delete:   resourceIBMPIVolumeDelete,
-		Exists:   resourceIBMPIVolumeExists,
-		Importer: &schema.ResourceImporter{},
+		CreateContext: resourceIBMPIVolumeCreate,
+		ReadContext:   resourceIBMPIVolumeRead,
+		UpdateContext: resourceIBMPIVolumeUpdate,
+		DeleteContext: resourceIBMPIVolumeDelete,
+		Importer:      &schema.ResourceImporter{},
 
 		Timeouts: &schema.ResourceTimeout{
-			Create: schema.DefaultTimeout(60 * time.Minute),
-			Update: schema.DefaultTimeout(60 * time.Minute),
-			Delete: schema.DefaultTimeout(60 * time.Minute),
+			Create: schema.DefaultTimeout(30 * time.Minute),
+			Update: schema.DefaultTimeout(30 * time.Minute),
+			Delete: schema.DefaultTimeout(10 * time.Minute),
 		},
 
 		Schema: map[string]*schema.Schema{
@@ -161,10 +156,11 @@ func resourceIBMPIVolumeValidator() *ResourceValidator {
 		Schema:       validateSchema}
 	return &ibmPIVolumeResourceValidator
 }
-func resourceIBMPIVolumeCreate(d *schema.ResourceData, meta interface{}) error {
+
+func resourceIBMPIVolumeCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	sess, err := meta.(ClientSession).IBMPISession()
 	if err != nil {
-		return err
+		return diag.FromErr(err)
 	}
 
 	name := d.Get(helpers.PIVolumeName).(string)
@@ -173,8 +169,8 @@ func resourceIBMPIVolumeCreate(d *schema.ResourceData, meta interface{}) error {
 	if v, ok := d.GetOk(helpers.PIVolumeShareable); ok {
 		shared = v.(bool)
 	}
-	powerinstanceid := d.Get(helpers.PICloudInstanceId).(string)
-	body := models.CreateDataVolume{
+	cloudInstanceID := d.Get(helpers.PICloudInstanceId).(string)
+	body := &models.CreateDataVolume{
 		Name:      &name,
 		Shareable: &shared,
 		Size:      &size,
@@ -213,41 +209,39 @@ func resourceIBMPIVolumeCreate(d *schema.ResourceData, meta interface{}) error {
 
 	}
 
-	resquestParams := p_cloud_volumes.PcloudCloudinstancesVolumesPostParams{
-		Body:            &body,
-		CloudInstanceID: powerinstanceid,
-	}
-
-	client := st.NewIBMPIVolumeClient(sess, powerinstanceid)
-	vol, err := client.CreateVolume(&resquestParams, powerinstanceid, volPostTimeOut)
+	client := st.NewIBMPIVolumeClient(ctx, sess, cloudInstanceID)
+	vol, err := client.CreateVolume(body)
 	if err != nil {
-		return fmt.Errorf("Failed to Create the volume %v", err)
+		return diag.FromErr(err)
 	}
 
 	volumeid := *vol.VolumeID
-	d.SetId(fmt.Sprintf("%s/%s", powerinstanceid, volumeid))
+	d.SetId(fmt.Sprintf("%s/%s", cloudInstanceID, volumeid))
 
-	_, err = isWaitForIBMPIVolumeAvailable(client, volumeid, powerinstanceid, d.Timeout(schema.TimeoutCreate))
+	_, err = isWaitForIBMPIVolumeAvailable(ctx, client, volumeid, d.Timeout(schema.TimeoutCreate))
 	if err != nil {
-		return err
+		return diag.FromErr(err)
 	}
 
-	return resourceIBMPIVolumeRead(d, meta)
+	return resourceIBMPIVolumeRead(ctx, d, meta)
 }
 
-func resourceIBMPIVolumeRead(d *schema.ResourceData, meta interface{}) error {
-	sess, _ := meta.(ClientSession).IBMPISession()
-	parts, err := idParts(d.Id())
+func resourceIBMPIVolumeRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	sess, err := meta.(ClientSession).IBMPISession()
 	if err != nil {
-		return err
+		return diag.FromErr(err)
 	}
-	powerinstanceid := parts[0]
-	client := st.NewIBMPIVolumeClient(sess, powerinstanceid)
 
-	vol, err := client.Get(parts[1], powerinstanceid, volGetTimeOut)
+	cloudInstanceID, volumeID, err := splitID(d.Id())
 	if err != nil {
-		return fmt.Errorf("Failed to get the volume %v", err)
+		return diag.FromErr(err)
+	}
 
+	client := st.NewIBMPIVolumeClient(ctx, sess, cloudInstanceID)
+
+	vol, err := client.Get(volumeID)
+	if err != nil {
+		return diag.FromErr(err)
 	}
 	d.Set(helpers.PIVolumeName, vol.Name)
 	d.Set(helpers.PIVolumeSize, vol.Size)
@@ -264,19 +258,23 @@ func resourceIBMPIVolumeRead(d *schema.ResourceData, meta interface{}) error {
 		d.Set("delete_on_termination", vol.DeleteOnTermination)
 	}
 	d.Set("wwn", vol.Wwn)
-	d.Set(helpers.PICloudInstanceId, powerinstanceid)
+	d.Set(helpers.PICloudInstanceId, cloudInstanceID)
 
 	return nil
 }
 
-func resourceIBMPIVolumeUpdate(d *schema.ResourceData, meta interface{}) error {
-	sess, _ := meta.(ClientSession).IBMPISession()
-	parts, err := idParts(d.Id())
+func resourceIBMPIVolumeUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	sess, err := meta.(ClientSession).IBMPISession()
 	if err != nil {
-		return err
+		return diag.FromErr(err)
 	}
-	powerinstanceid := parts[0]
-	client := st.NewIBMPIVolumeClient(sess, powerinstanceid)
+
+	cloudInstanceID, volumeID, err := splitID(d.Id())
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	client := st.NewIBMPIVolumeClient(ctx, sess, cloudInstanceID)
 	name := d.Get(helpers.PIVolumeName).(string)
 	size := float64(d.Get(helpers.PIVolumeSize).(float64))
 	var shareable bool
@@ -284,98 +282,65 @@ func resourceIBMPIVolumeUpdate(d *schema.ResourceData, meta interface{}) error {
 		shareable = v.(bool)
 	}
 
-	body := models.UpdateVolume{
+	body := &models.UpdateVolume{
 		Name:      &name,
 		Shareable: &shareable,
 		Size:      size,
 	}
-	updateParams := p_cloud_volumes.PcloudCloudinstancesVolumesPutParams{
-		Body:            &body,
-		CloudInstanceID: powerinstanceid,
-	}
-	volrequest, err := client.UpdateVolume(&updateParams, parts[1], powerinstanceid, volPostTimeOut)
+	volrequest, err := client.UpdateVolume(volumeID, body)
 	if err != nil {
-		return err
+		return diag.FromErr(err)
 	}
-	_, err = isWaitForIBMPIVolumeAvailable(client, *volrequest.VolumeID, powerinstanceid, d.Timeout(schema.TimeoutUpdate))
+	_, err = isWaitForIBMPIVolumeAvailable(ctx, client, *volrequest.VolumeID, d.Timeout(schema.TimeoutUpdate))
 	if err != nil {
-		return err
+		return diag.FromErr(err)
 	}
 
-	return resourceIBMPIVolumeRead(d, meta)
+	return resourceIBMPIVolumeRead(ctx, d, meta)
 }
 
-func resourceIBMPIVolumeDelete(d *schema.ResourceData, meta interface{}) error {
-
-	sess, _ := meta.(ClientSession).IBMPISession()
-	parts, err := idParts(d.Id())
+func resourceIBMPIVolumeDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	sess, err := meta.(ClientSession).IBMPISession()
 	if err != nil {
-		return err
+		return diag.FromErr(err)
 	}
-	powerinstanceid := parts[0]
 
-	client := st.NewIBMPIVolumeClient(sess, powerinstanceid)
-	voldeleteErr := client.DeleteVolume(parts[1], powerinstanceid, deleteTimeOut)
-	if voldeleteErr != nil {
-		return voldeleteErr
-	}
-	_, err = isWaitForIBMPIVolumeDeleted(client, parts[1], powerinstanceid, d.Timeout(schema.TimeoutDelete))
+	cloudInstanceID, volumeID, err := splitID(d.Id())
 	if err != nil {
-		return err
+		return diag.FromErr(err)
+	}
+
+	client := st.NewIBMPIVolumeClient(ctx, sess, cloudInstanceID)
+	err = client.DeleteVolume(volumeID)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+	_, err = isWaitForIBMPIVolumeDeleted(ctx, client, volumeID, d.Timeout(schema.TimeoutDelete))
+	if err != nil {
+		return diag.FromErr(err)
 	}
 	d.SetId("")
 	return nil
 }
-func resourceIBMPIVolumeExists(d *schema.ResourceData, meta interface{}) (bool, error) {
 
-	sess, err := meta.(ClientSession).IBMPISession()
-	if err != nil {
-		return false, err
-	}
-	parts, err := idParts(d.Id())
-	if err != nil {
-		return false, err
-	}
-	if len(parts) < 2 {
-		return false, fmt.Errorf("Incorrect ID %s: Id should be a combination of powerInstanceID/VolumeID", d.Id())
-	}
-	powerinstanceid := parts[0]
-	client := st.NewIBMPIVolumeClient(sess, powerinstanceid)
-
-	vol, err := client.Get(parts[1], powerinstanceid, getTimeOut)
-	if err != nil {
-		if apiErr, ok := err.(bmxerror.RequestFailure); ok {
-			if apiErr.StatusCode() == 404 {
-				return false, nil
-			}
-		}
-		return false, fmt.Errorf("[ERROR] Error getting pi volume: %s", err)
-	}
-
-	log.Printf("Calling the existing function.. %s", *(vol.VolumeID))
-
-	volumeid := *vol.VolumeID
-	return volumeid == parts[1], nil
-}
-
-func isWaitForIBMPIVolumeAvailable(client *st.IBMPIVolumeClient, id, powerinstanceid string, timeout time.Duration) (interface{}, error) {
+func isWaitForIBMPIVolumeAvailable(ctx context.Context, client *st.IBMPIVolumeClient, id string, timeout time.Duration) (interface{}, error) {
 	log.Printf("Waiting for Volume (%s) to be available.", id)
 
 	stateConf := &resource.StateChangeConf{
 		Pending:    []string{"retry", helpers.PIVolumeProvisioning},
 		Target:     []string{helpers.PIVolumeProvisioningDone},
-		Refresh:    isIBMPIVolumeRefreshFunc(client, id, powerinstanceid),
+		Refresh:    isIBMPIVolumeRefreshFunc(client, id),
 		Delay:      10 * time.Second,
 		MinTimeout: 2 * time.Minute,
-		Timeout:    30 * time.Minute,
+		Timeout:    timeout,
 	}
 
-	return stateConf.WaitForState()
+	return stateConf.WaitForStateContext(ctx)
 }
 
-func isIBMPIVolumeRefreshFunc(client *st.IBMPIVolumeClient, id, powerinstanceid string) resource.StateRefreshFunc {
+func isIBMPIVolumeRefreshFunc(client *st.IBMPIVolumeClient, id string) resource.StateRefreshFunc {
 	return func() (interface{}, string, error) {
-		vol, err := client.Get(id, powerinstanceid, volGetTimeOut)
+		vol, err := client.Get(id)
 		if err != nil {
 			return nil, "", err
 		}
@@ -388,21 +353,21 @@ func isIBMPIVolumeRefreshFunc(client *st.IBMPIVolumeClient, id, powerinstanceid 
 	}
 }
 
-func isWaitForIBMPIVolumeDeleted(client *st.IBMPIVolumeClient, id, powerinstanceid string, timeout time.Duration) (interface{}, error) {
+func isWaitForIBMPIVolumeDeleted(ctx context.Context, client *st.IBMPIVolumeClient, id string, timeout time.Duration) (interface{}, error) {
 	stateConf := &resource.StateChangeConf{
 		Pending:    []string{"deleting", helpers.PIVolumeProvisioning},
 		Target:     []string{"deleted"},
-		Refresh:    isIBMPIVolumeDeleteRefreshFunc(client, id, powerinstanceid),
+		Refresh:    isIBMPIVolumeDeleteRefreshFunc(client, id),
 		Delay:      10 * time.Second,
 		MinTimeout: 2 * time.Minute,
-		Timeout:    30 * time.Minute,
+		Timeout:    timeout,
 	}
-	return stateConf.WaitForState()
+	return stateConf.WaitForStateContext(ctx)
 }
 
-func isIBMPIVolumeDeleteRefreshFunc(client *st.IBMPIVolumeClient, id, powerinstanceid string) resource.StateRefreshFunc {
+func isIBMPIVolumeDeleteRefreshFunc(client *st.IBMPIVolumeClient, id string) resource.StateRefreshFunc {
 	return func() (interface{}, string, error) {
-		vol, err := client.Get(id, powerinstanceid, volGetTimeOut)
+		vol, err := client.Get(id)
 		if err != nil {
 			if strings.Contains(err.Error(), "Resource not found") {
 				return vol, "deleted", nil

--- a/ibm/resource_ibm_pi_vpn_connection_test.go
+++ b/ibm/resource_ibm_pi_vpn_connection_test.go
@@ -4,6 +4,7 @@
 package ibm
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"testing"
@@ -56,14 +57,12 @@ func testAccCheckIBMPIVPNConnectionDestroy(s *terraform.State) error {
 		if rs.Type != "ibm_pi_vpn_connection" {
 			continue
 		}
-		parts, err := idParts(rs.Primary.ID)
+		cloudInstanceID, vpnConnectionID, err := splitID(rs.Primary.ID)
 		if err != nil {
 			return err
 		}
-		cloudInstanceID := parts[0]
-		vpnConnectionID := parts[1]
-		client := st.NewIBMPIVpnConnectionClient(sess, cloudInstanceID)
-		_, err = client.Get(vpnConnectionID, cloudInstanceID)
+		client := st.NewIBMPIVpnConnectionClient(context.Background(), sess, cloudInstanceID)
+		_, err = client.Get(vpnConnectionID)
 		if err == nil {
 			return fmt.Errorf("vpn connection still exists: %s", rs.Primary.ID)
 		}
@@ -84,15 +83,13 @@ func testAccCheckIBMPIVPNConnectionExists(n string) resource.TestCheckFunc {
 		if err != nil {
 			return err
 		}
-		parts, err := idParts(rs.Primary.ID)
+		cloudInstanceID, vpnConnectionID, err := splitID(rs.Primary.ID)
 		if err != nil {
 			return err
 		}
-		cloudInstanceID := parts[0]
-		vpnConnectionID := parts[1]
-		client := st.NewIBMPIVpnConnectionClient(sess, cloudInstanceID)
+		client := st.NewIBMPIVpnConnectionClient(context.Background(), sess, cloudInstanceID)
 
-		_, err = client.Get(vpnConnectionID, cloudInstanceID)
+		_, err = client.Get(vpnConnectionID)
 		if err != nil {
 			return err
 		}

--- a/website/docs/d/pi_cloud_instance.html.markdown
+++ b/website/docs/d/pi_cloud_instance.html.markdown
@@ -40,13 +40,23 @@ Review the argument reference that you can specify for your data source.
 ## Attribute reference
 In addition to the argument reference list, you can access the following attribute references after your data source is created.
 
-- `capabilities` -  (String) Lists the capabilities for this cloud instance.
-- `creation_date` - (String) The date on which the tenant was created.
-- `enabled` -  (Bool) Indicates whether the tenant is enabled.
+- `capabilities` - (String) Lists the capabilities for this cloud instance.
+- `enabled` - (Bool) Indicates whether the tenant is enabled.
 - `id` - (String) The unique identifier for this tenant.
-- `tenant_name` -  (String) The name of the tenant.
-- `total_instances` -  (String) The count of lpars that belong to this specific cloud instance.
-- `total_memory_consumed` -  (String) The total memory consumed by this service instance.
-- `total_processors_consumed` -  (String) The total processors consumed by this service instance.
-- `total_ssd_storage_consumed` -  (String) The total SSD Storage consumed by this service instance.
-- `total_standard_storage_consumed` -  (String) The total Standard Storage consumed by this service instance.
+- `pvm_instances` - (List) PVM instances owned by the Cloud Instance.
+
+  Nested scheme for `pvm_instances`:
+  - `creation_date` - (String) Date/Time of PVM creation.
+  - `href` - (String) Link to Cloud Instance resource.
+  - `id` - (String) PVM Instance ID.
+  - `name` - (String) Name of the server.
+  - `status` - (String) The status of the instance.
+  - `systype` - (string) System type used to host the instance.
+- `region` - (String) The region the cloud instance lives.
+- `tenant_id` - (String) The tenant ID that owns this cloud instance.
+- `total_instances` - (String) The count of lpars that belong to this specific cloud instance.
+- `total_memory_consumed` - (String) The total memory consumed by this service instance.
+- `total_processors_consumed` - (String) The total processors consumed by this service instance.
+- `total_ssd_storage_consumed` - (String) The total SSD Storage consumed by this service instance.
+- `total_standard_storage_consumed` - (String) The total Standard Storage consumed by this service instance.
+

--- a/website/docs/d/pi_images.html.markdown
+++ b/website/docs/d/pi_images.html.markdown
@@ -44,10 +44,10 @@ In addition to all argument reference list, you can access the following attribu
 - `image_info` - List of images - A list of all supported images. 
 
   Nested scheme for `image_info`:
-	- `href` - (String) The hyper link of an image. 
-	- `id` - (String) The unique identifier of an image.
-   - `name`-  (String) The name of an image.
-	- `state` - (String) The state of an image.
-	- `storage_pool` - (String) Storage pool where image resides.
-	- `storage_type` - (String) The storage type of an image.
+  - `href` - (String) The hyper link of an image. 
+  - `id` - (String) The unique identifier of an image.
+  - `name`-  (String) The name of an image.
+  - `state` - (String) The state of an image.
+  - `storage_pool` - (String) Storage pool where image resides.
+  - `storage_type` - (String) The storage type of an image.
   - `image_type` - (String) The identifier of this image type.

--- a/website/docs/d/pi_instance_ip.html.markdown
+++ b/website/docs/d/pi_instance_ip.html.markdown
@@ -44,8 +44,9 @@ Review the argument references that you can specify for your data source.
 In addition to all argument reference list, you can access the following attribute references after your data source is created. 
 
 - `external_ip` - (String) The external IP of the network that is attached to this instance.
-- `ip` - (String) The IP address that is attached to this instance from the subnet.
 - `id` - (String) The unique identifier of the network.
+- `ip` - (String) The IP address that is attached to this instance from the subnet.
 - `ipoctet` - (String) The IP octet of the network that is attached to this instance.
 - `macaddress` - (String) The MAC address of the network that is attached to this instance.
+- `network_id` - (String) ID of the network.
 - `type` - (String) The type of the network that is attached to this instance.

--- a/website/docs/d/pi_instance_volumes.html.markdown
+++ b/website/docs/d/pi_instance_volumes.html.markdown
@@ -48,12 +48,12 @@ In addition to all argument reference list, you can access the following attribu
 - `instance_volumes` - List of volumes - List of volumes attached to instance.
 
   Nested scheme for `instance_volumes`:
-    - `bootable`- (Bool) Indicates if the volume is bootable (**true**) or not (**false**).
-	- `href` - (String) The hyper link of the volume.
-	- `id` - (String) The unique identifier of the volume.
-	- `name` - (String) The name of the volume.
-	- `pool` - (String) Volume pool, name of storage pool where the volume is located.
-	- `shareable` -  (Bool) If set to **true**, the volume can be shared across multiple Power Systems Virtual Server instances. If set to **false**, the volume can be mounted to one instance only.
-	- `size` - (Integer) The size of this volume in gigabytes.
-	- `state` - (String) The state of the volume.
-	- `type` - (String) The disk type that is used for this volume.
+  - `bootable`- (Bool) Indicates if the volume is boot capable.
+  - `href` - (String) The hyper link of the volume.
+  - `id` - (String) The unique identifier of the volume.
+  - `name` - (String) The name of the volume.
+  - `pool` - (String) Volume pool, name of storage pool where the volume is located.
+  - `shareable` - (Bool) Indicates if the volume is shareable between VMs.
+  - `size` - (Integer) The size of this volume in gigabytes.
+  - `state` - (String) The state of the volume.
+  - `type` - (String) The disk type that is used for this volume.

--- a/website/docs/d/pi_public_network.html.markdown
+++ b/website/docs/d/pi_public_network.html.markdown
@@ -38,7 +38,6 @@ data "ibm_pi_public_network" "ds_public_network" {
 ## Argument reference
 Review the argument references that you can specify for your data source. 
 
-- `pi_network_name` - (Deprecated, string) The name of the network.
 - `pi_cloud_instance_id` - (Required, String) The GUID of the service instance associated with an account.
 
 ## Attribute reference

--- a/website/docs/d/pi_tenant.html.markdown
+++ b/website/docs/d/pi_tenant.html.markdown
@@ -44,11 +44,11 @@ Review the argument references that you can specify for your data source.
 In addition to all argument reference list, you can access the following attribute references after your data source is created. 
 
 - `creation_date` - (Timestamp) The timestamp when the tenant was created.
-- `cloudinstances` - (List) A list with the regions and Power Systems Virtual Server instance IDs that the tenant owns.
+- `cloud_instances` - (List) A list with the regions and Power Systems Virtual Server instance IDs that the tenant owns.
 
-  Nested scheme for `cloudinstances`:
+  Nested scheme for `cloud_instances`:
 	- `cloud_instance_id` - (String) The unique identifier of the cloud instance.
 	- `region` - (String) The region of the cloud instance.
-- `enabled` -  (Bool) If set to **true**, the tenant is enabled for the Power Systems Virtual Server instance ID. If set to **false**, the tenant is not enabled for the instance.
+- `enabled` - (Bool) Indicates if the tenant is enabled for the Power Systems Virtual Server instance ID.
 - `id` - (String) The ID of the tenant.
-- `tenantname` -  (String) The name of the tenant.
+- `tenant_name` -  (String) The name of the tenant.

--- a/website/docs/r/pi_instance.html.markdown
+++ b/website/docs/r/pi_instance.html.markdown
@@ -50,8 +50,9 @@ resource "ibm_pi_instance" "test-instance" {
 
 The `ibm_pi_instance` provides the following [timeouts](https://www.terraform.io/docs/language/resources/syntax.html) configuration options:
 
-- **create** - The creation of the instance is considered failed if no response is received for 60 minutes. 
-- **delete** - The deletion of the instance is considered failed if no response is received for 60 minutes. 
+- **create** - The creation of the instance is considered failed if no response is received for 120 minutes.
+- **Update** The updation of the instance is considered failed if no response is received for 60 minutes.
+- **delete** - The deletion of the instance is considered failed if no response is received for 60 minutes.
 
 
 ## Argument reference

--- a/website/docs/r/pi_network_port.html.markdown
+++ b/website/docs/r/pi_network_port.html.markdown
@@ -19,8 +19,8 @@ In the following example, you can create an network_port:
 ```terraform
 resource "ibm_pi_network_port" "test-network-port" {
     pi_network_name             = "Zone1-CFN"
-    pi_cloud_instance_id  = "51e1879c-bcbe-4ee1-a008-49cdba0eaf60"
-    pi_network_port_description         = "IP Reserved for Oracle RAC "
+    pi_cloud_instance_id        = "51e1879c-bcbe-4ee1-a008-49cdba0eaf60"
+    pi_network_port_description = "IP Reserved for Oracle RAC "
 }
 ```
 
@@ -47,17 +47,17 @@ ibm_pi_network_port provides the following [timeouts](https://www.terraform.io/d
 - **delete** - (Default 60 minutes) Used for deleting a network_port.
 
 ## Argument reference
-Review the argument references that you can specify for your resource. 
+Review the argument references that you can specify for your resource.
 
+- `pi_cloud_instance_id` - (Required, String) The GUID of the service instance associated with an account.
+- `pi_network_name` - (Required, String) Network ID or name.
 - `pi_network_port_description` - (Optional, String) The description for the Network Port.
-- `pi_cloud_instance_id` - (Required, String) The GUID of the service instance associated with an account. 
-- `pi_instance_name` - (Required, String) The name of the VM.
+- `pi_network_port_ipaddress` - (Optional, String) The requested ip address of this port.
 
 ## Attribute reference
 In addition to all argument reference list, you can access the following attribute reference after your resource is created.
 
-- `id` - (String) The unique identifier of the instance. The ID is composed of <power_network_port_id>/<id>.
-- `ipaddress` - (String) The unique identifier of the instance.
+- `id` - (String) The unique identifier of the instance. The ID is composed of `<pi_cloud_instance_id>/<power_network_port_id>/<id>`.
 - `macaddress` - (String) The MAC address of the port.
 - `portid` - (String) The ID of the port.
 - `public_ip` - (String) The public IP associated with the port.

--- a/website/docs/r/pi_snapshot.html.markdown
+++ b/website/docs/r/pi_snapshot.html.markdown
@@ -43,15 +43,15 @@ resource "ibm_pi_snapshot" "testacc_snapshot"{
 The `ibm_pi_snapshot` provides the following [Timeouts](https://www.terraform.io/docs/language/resources/syntax.html) configuration options:
 
 - **create** - (Default 60 minutes) Used for Creating snapshot.
-- **delete** - (Default 60 minutes) Used for Deleting snapshot.
 - **update** - (Default 60 minutes) Used for Updating snapshot.
+- **delete** - (Default 10 minutes) Used for Deleting snapshot.
 
 ## Argument reference
 Review the argument references that you can specify for your resource.
  
 - `pi_instance_name` - (Required, String) The name of the instance you want to take a snapshot of.
 - `pi_snapshot_name` - (Required, String) The unique name of the snapshot.
-- `description` - (Optional, String) The description for the snapshot.
+- `pi_description` - (Optional, String) Description of the PVM instance snapshot.
 - `pi_volume_ids` - (Optional, String) The volume ID, if none provided then all volumes of the instance will be part of the snapshot.
 - `pi_cloud_instance_id` - (Required, String) The GUID of the service instance associated with an account.
 
@@ -59,7 +59,11 @@ Review the argument references that you can specify for your resource.
 In addition to all argument reference list, you can access the following attribute reference after your resource is created.
 
 - `id` - (String) The unique identifier of the snapshot. The ID is composed of <power_instance_id>/<pi_snap_shot_id>.
-- `volume_snapshots` - (String) A map of the source and target volumes.
+- `snapshot_id` - (String) ID of the PVM instance snapshot.
+- `status` - (String) Status of the PVM instance snapshot.
+- `creation_date` - (String) Creation Date.
+- `last_update_date` - (String) Last Update Date.
+- `volume_snapshots` - (String) A map of volume snapshots included in the PVM instance snapshot.
 
 ## Import
 

--- a/website/docs/r/pi_volume.html.markdown
+++ b/website/docs/r/pi_volume.html.markdown
@@ -42,8 +42,9 @@ resource "ibm_pi_volume" "testacc_volume"{
 
 ibm_pi_volume provides the following [timeouts](https://www.terraform.io/docs/language/resources/syntax.html) configuration options:
 
-- **create** - (Default 60 minutes) Used for creating volume.
-- **delete** - (Default 60 minutes) Used for deleting volume.
+- **create** - (Default 30 minutes) Used for creating volume.
+- **update** - (Default 30 minutes) Used for updating volume.
+- **delete** - (Default 10 minutes) Used for deleting volume.
 
 ## Argument reference 
 Review the argument references that you can specify for your resource. 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/IBM-Cloud/terraform-provider-ibm/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
# data sources:
=== RUN   TestAccIBMPICatalogImagesDataSourceBasic
--- PASS: TestAccIBMPICatalogImagesDataSourceBasic (23.28s)
=== RUN   TestAccIBMPICatalogImagesDataSourceSAP
--- PASS: TestAccIBMPICatalogImagesDataSourceSAP (17.62s)
=== RUN   TestAccIBMPICatalogImagesDataSourceVTL
--- PASS: TestAccIBMPICatalogImagesDataSourceVTL (19.71s)
=== RUN   TestAccIBMPICatalogImagesDataSourceSAPAndVTL
--- PASS: TestAccIBMPICatalogImagesDataSourceSAPAndVTL (16.64s)
=== RUN   TestAccIBMPICloudConnectionDataSource_basic
--- PASS: TestAccIBMPICloudConnectionDataSource_basic (33.24s)
=== RUN   TestAccIBMPICloudConnectionsDataSourceBasic
--- PASS: TestAccIBMPICloudConnectionsDataSourceBasic (29.52s)
=== RUN   TestAccIBMPICloudInstanceDataSource_basic
--- PASS: TestAccIBMPICloudInstanceDataSource_basic (23.28s)
=== RUN   TestAccIBMPIDhcpDataSourceBasic
--- PASS: TestAccIBMPIDhcpDataSourceBasic (40.53s)
=== RUN   TestAccIBMPIDhcpServersDataSourceBasic
--- PASS: TestAccIBMPIDhcpServersDataSourceBasic (27.49s)
=== RUN   TestAccIBMPIImageDataSource_basic
--- PASS: TestAccIBMPIImageDataSource_basic (36.09s)
=== RUN   TestAccIBMPIImagesDataSource_basic
--- PASS: TestAccIBMPIImagesDataSource_basic (25.28s)
=== RUN   TestAccIBMPIInstanceIPDataSource_basic
--- PASS: TestAccIBMPIInstanceIPDataSource_basic (75.68s)
=== RUN   TestAccIBMPIInstanceDataSource_basic
--- PASS: TestAccIBMPIInstanceDataSource_basic (35.09s)
=== RUN   TestAccIBMPIVolumesDataSource_basic
--- PASS: TestAccIBMPIVolumesDataSource_basic (60.85s)
=== RUN   TestAccIBMPIKeyDataSource_basic
--- PASS: TestAccIBMPIKeyDataSource_basic (25.84s)
=== RUN   TestAccIBMPIKeysDataSourceBasic
--- PASS: TestAccIBMPIKeysDataSourceBasic (46.61s)
=== RUN   TestAccIBMPINetworkDataSource_basic
--- PASS: TestAccIBMPINetworkDataSource_basic (36.42s)
=== RUN   TestAccIBMPIPublicNetworkDataSource_basic
--- PASS: TestAccIBMPIPublicNetworkDataSource_basic (21.19s)
=== RUN   TestAccIBMPISAPProfileDataSourceBasic
--- PASS: TestAccIBMPISAPProfileDataSourceBasic (24.17s)
=== RUN   TestAccIBMPISAPProfilesDataSourceBasic
--- PASS: TestAccIBMPISAPProfilesDataSourceBasic (35.75s)
=== RUN   TestAccIBMPISnapshotDataSource_basic
=== RUN   TestAccIBMPITenantDataSource_basic
--- PASS: TestAccIBMPITenantDataSource_basic (44.59s)
=== RUN   TestAccIBMPIVolumeDataSource_basic
--- PASS: TestAccIBMPIVolumeDataSource_basic (39.81s)
=== RUN   TestAccIBMPIInstanceConsoleLanguages
--- PASS: TestAccIBMPIInstanceConsoleLanguages (70.88s)
PASS

#resources:
=== RUN   TestAccIBMPIDhcpbasic
--- PASS: TestAccIBMPIDhcpbasic (514.43s)
=== RUN   TestAccIBMPIImagebasic
--- PASS: TestAccIBMPIImagebasic (157.59s)
=== RUN   TestAccIBMPIImageCOSPublicImport
--- PASS: TestAccIBMPIImageCOSPublicImport (1090.90s)
=== RUN   TestAccIBMPIInstanceBasic
--- PASS: TestAccIBMPIInstanceBasic (1003.88s)
=== RUN   TestAccIBMPINetworkPortbasic
--- PASS: TestAccIBMPINetworkPortbasic (70.95s)
=== RUN   TestAccIBMPINetworkbasic
--- PASS: TestAccIBMPINetworkbasic (57.91s)
=== RUN   TestAccIBMPIInstanceSnapshotbasic
--- PASS: TestAccIBMPIInstanceSnapshotbasic (727.89s)
=== RUN   TestAccIBMPIKey_basic
--- PASS: TestAccIBMPIKey_basic (30.60s)
=== RUN   TestAccIBMPIVolumebasic
--- PASS: TestAccIBMPIVolumebasic (105.32s)
=== RUN   TestAccIBMPIVolumePool
--- PASS: TestAccIBMPIVolumePool (74.14s)
=== RUN   TestAccIBMPIIPSecPolicyBasic
--- PASS: TestAccIBMPIIPSecPolicyBasic (67.97s)
=== RUN   TestAccIBMPIKey_basic
--- PASS: TestAccIBMPIKey_basic (33.98s)
=== RUN   TestAccIBMPIVPNConnectionBasic
--- PASS: TestAccIBMPIVPNConnectionBasic (600.58s)
=== RUN   TestAccIBMPIInstanceConsoleLanguage
--- PASS: TestAccIBMPIInstanceConsoleLanguage (84.24s)
PASS
...
```
