### PR TITLE
Fix #3287: retrieve access_tags using ibm_resource_tag datasource

### DIFF
--- a/ibm/data_source_ibm_resource_tag.go
+++ b/ibm/data_source_ibm_resource_tag.go
@@ -5,6 +5,7 @@ package ibm
 
 import (
 	"fmt"
+	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
@@ -16,7 +17,7 @@ func dataSourceIBMResourceTag() *schema.Resource {
 		Schema: map[string]*schema.Schema{
 			"resource_id": {
 				Type:         schema.TypeString,
-				Required:     true,
+				Optional:     true,
 				ValidateFunc: InvokeValidator("ibm_resource_tag", resourceID),
 				Description:  "CRN of the resource on which the tags should be attached",
 			},
@@ -32,27 +33,41 @@ func dataSourceIBMResourceTag() *schema.Resource {
 				Optional:    true,
 				Description: "Resource type on which the tags should be fetched",
 			},
+			"tag_type": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: InvokeValidator("ibm_resource_tag", "tag_type"),
+				Description:  "Tag type on which the tags should be fetched",
+				Default:      "user",
+			},
 		},
 	}
 }
 
 func dataSourceIBMResourceTagRead(d *schema.ResourceData, meta interface{}) error {
 	var rID, rType string
-	rID = d.Get("resource_id").(string)
+
+	if r, ok := d.GetOk("resource_id"); ok && r != nil {
+		rID = r.(string)
+	}
 	if v, ok := d.GetOk(resourceType); ok && v != nil {
 		rType = v.(string)
 	}
+	tType := ""
+	if t, ok := d.GetOk("tag_type"); ok && t != nil {
+		tType = t.(string)
+	}
 
-	tags, err := GetGlobalTagsUsingCRN(meta, rID, rType, "")
+	tags, err := GetGlobalTagsUsingCRN(meta, rID, rType, tType)
 	if err != nil {
 		return fmt.Errorf(
 			"Error on get of resource tags (%s) tags: %s", d.Id(), err)
 	}
 
-	d.SetId(rID)
+	d.SetId(time.Now().UTC().String())
 	d.Set("resource_id", rID)
 	d.Set("resource_type", rType)
 	d.Set("tags", tags)
-
+	d.Set("tag_type", tType)
 	return nil
 }

--- a/ibm/data_source_ibm_resource_tag_test.go
+++ b/ibm/data_source_ibm_resource_tag_test.go
@@ -29,6 +29,31 @@ func TestAccResourceTagDataSource_basic(t *testing.T) {
 		},
 	})
 }
+func TestAccResourceTagDataSourceTagType(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckResourceTagwithTagType(),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet("data.ibm_resource_tag.access_tags", "id"),
+					resource.TestCheckResourceAttrSet("data.ibm_resource_tag.tags", "id"),
+				),
+			},
+		},
+	})
+}
+func testAccCheckResourceTagwithTagType() string {
+	return fmt.Sprintf(`
+
+	data "ibm_resource_tag" "access_tags" {
+        tag_type ="access"
+	}
+	data "ibm_resource_tag" "tags" {
+	}
+`)
+}
 
 func testAccCheckResourceTagReadDataSource(name, managed_from string) string {
 	return fmt.Sprintf(`

--- a/ibm/resource_ibm_resource_tag.go
+++ b/ibm/resource_ibm_resource_tag.go
@@ -65,7 +65,7 @@ func resourceIBMResourceTag() *schema.Resource {
 				Type:         schema.TypeString,
 				Optional:     true,
 				Computed:     true,
-				ValidateFunc: validateAllowedStringValue([]string{"service", "access", "user"}),
+				ValidateFunc: InvokeValidator("ibm_resource_tag", "tag_type"),
 				Description:  "Type of the tag. Only allowed values are: user, or service or access (default value : user)",
 			},
 			acccountID: {
@@ -78,7 +78,7 @@ func resourceIBMResourceTag() *schema.Resource {
 }
 
 func resourceIBMResourceTagValidator() *ResourceValidator {
-
+	tagTypeAllowedValues := "service,access,user"
 	validateSchema := make([]ValidateSchema, 0)
 
 	validateSchema = append(validateSchema,
@@ -99,6 +99,13 @@ func resourceIBMResourceTagValidator() *ResourceValidator {
 			Regexp:                     `^[A-Za-z0-9:_ .-]+$`,
 			MinValueLength:             1,
 			MaxValueLength:             128})
+	validateSchema = append(validateSchema,
+		ValidateSchema{
+			Identifier:                 "tag_type",
+			ValidateFunctionIdentifier: ValidateAllowedStringValue,
+			Type:                       TypeString,
+			Optional:                   true,
+			AllowedValues:              tagTypeAllowedValues})
 
 	ibmResourceTagValidator := ResourceValidator{ResourceName: "ibm_resource_tag", Schema: validateSchema}
 	return &ibmResourceTagValidator

--- a/ibm/structures.go
+++ b/ibm/structures.go
@@ -1859,7 +1859,9 @@ func GetGlobalTagsUsingCRN(meta interface{}, resourceID, resourceType, tagType s
 	}
 
 	ListTagsOptions := &globaltaggingv1.ListTagsOptions{}
-	ListTagsOptions.AttachedTo = &resourceID
+	if resourceID != "" {
+		ListTagsOptions.AttachedTo = &resourceID
+	}
 	ListTagsOptions.Providers = providers
 	if len(tagType) > 0 {
 		ListTagsOptions.TagType = ptrToString(tagType)

--- a/website/docs/d/resource_tag.html.markdown
+++ b/website/docs/d/resource_tag.html.markdown
@@ -3,12 +3,12 @@ subcategory: "Global Tagging"
 layout: "ibm"
 page_title: "IBM : resource_tag"
 description: |-
-  Manages resource tags.
+  Retrieve available tags on the account.
 ---
 
 # ibm_resource_tag
 
-Retreive information about an existing resource tags as a read-only data source. For more information, about resource tags, see [controlling access to resources by using tags](https://cloud.ibm.com/docs/account?topic=account-access-tags-tutorial).
+Retreive information about an existing resource or access tags as a read-only data source. For more information, about resource tags, see [controlling access to resources by using tags](https://cloud.ibm.com/docs/account?topic=account-access-tags-tutorial).
 
 ## Example usage
 
@@ -24,13 +24,26 @@ data "ibm_resource_tag" "read_tag" {
 	resource_id = data.ibm_satellite_location.location.crn
 }
 ```
+###  Retrieve access tags
+
+```terraform
+data "ibm_resource_tag" "access_tags" {
+  tag_type ="access"
+}
+```
+###  Retrieve user tags
+
+```terraform
+data "ibm_resource_tag" "user_tags" {
+}
+```
 
 ## Argument reference
 Review the argument references that you can specify for your data source. 
 
-- `resource_id` - (Required, String) The CRN of the resource on which the tags should be attached.
+- `resource_id` - (Optional, String) The CRN of the resource on which the tags should be attached.
 - `resource_type` - (Optional, String) The resource type on which the tags to be attached.
-
+- `tag_type` - (Optional, String) Type of the tag. Supported values are: `user`, `service`, or `access`. Default: `user`
 ## Attributes reference
 In addition to all argument reference list, you can access the following attribute references after your data source is created.
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/IBM-Cloud/terraform-provider-ibm/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #3287

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
--- PASS: TestAccResourceTagDataSourceTagType (14.07s)
PASS
ok  	github.com/IBM-Cloud/terraform-provider-ibm/ibm	16.807s
```
