### PR TITLE
Fix #2180 #1860 #1741: support credentials_json in resource_key resource and datasource

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "go.sum|^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2021-12-15T06:20:37Z",
+  "generated_at": "2021-12-15T08:46:00Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -867,6 +867,16 @@
         "verified_result": null
       }
     ],
+    "ibm/data_source_ibm_resource_key.go": [
+      {
+        "hashed_secret": "b732fb611fd46a38e8667f9972e0cde777fbe37f",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 146,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
     "ibm/data_source_ibm_satellite_endpoint.go": [
       {
         "hashed_secret": "3046d9f6cfaaeea6eed9bb7a4ab010fe49b0cfd4",
@@ -1681,6 +1691,16 @@
         "is_secret": false,
         "is_verified": false,
         "line_number": 51,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "ibm/resource_ibm_resource_key.go": [
+      {
+        "hashed_secret": "b732fb611fd46a38e8667f9972e0cde777fbe37f",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 291,
         "type": "Secret Keyword",
         "verified_result": null
       }

--- a/ibm/data_source_ibm_resource_key.go
+++ b/ibm/data_source_ibm_resource_key.go
@@ -4,6 +4,7 @@
 package ibm
 
 import (
+	"encoding/json"
 	"fmt"
 	"sort"
 	"strings"
@@ -55,6 +56,13 @@ func dataSourceIBMResourceKey() *schema.Resource {
 				Description: "Credentials asociated with the key",
 				Sensitive:   true,
 				Type:        schema.TypeMap,
+				Computed:    true,
+			},
+
+			"credentials_json": {
+				Description: "Credentials asociated with the key in json string",
+				Type:        schema.TypeString,
+				Sensitive:   true,
 				Computed:    true,
 			},
 
@@ -133,6 +141,13 @@ func dataSourceIBMResourceKeyRead(d *schema.ResourceData, meta interface{}) erro
 	}
 
 	d.Set("credentials", Flatten(key.Credentials))
+	creds, err := json.Marshal(key.Credentials)
+	if err != nil {
+		return fmt.Errorf("error marshalling resource key credentials: %s", err)
+	}
+	if err = d.Set("credentials_json", string(creds)); err != nil {
+		return fmt.Errorf("error setting the credentials json: %s", err)
+	}
 	d.Set("status", key.State)
 	d.Set("crn", key.Crn.String())
 	return nil

--- a/ibm/resource_ibm_resource_key.go
+++ b/ibm/resource_ibm_resource_key.go
@@ -77,7 +77,12 @@ func resourceIBMResourceKey() *schema.Resource {
 				Sensitive:   true,
 				Computed:    true,
 			},
-
+			"credentials_json": {
+				Description: "Credentials asociated with the key in json string",
+				Type:        schema.TypeString,
+				Sensitive:   true,
+				Computed:    true,
+			},
 			"status": {
 				Type:        schema.TypeString,
 				Computed:    true,
@@ -280,6 +285,14 @@ func resourceIBMResourceKeyRead(d *schema.ResourceData, meta interface{}) error 
 	cred, _ := json.Marshal(resourceKey.Credentials)
 	json.Unmarshal(cred, &credInterface)
 	d.Set("credentials", Flatten(credInterface))
+
+	creds, err := json.Marshal(resourceKey.Credentials)
+	if err != nil {
+		return fmt.Errorf("error marshalling resource key credentials: %s", err)
+	}
+	if err = d.Set("credentials_json", string(creds)); err != nil {
+		return fmt.Errorf("error setting the credentials json: %s", err)
+	}
 	d.Set("name", *resourceKey.Name)
 	d.Set("status", *resourceKey.State)
 	if resourceKey.Credentials != nil && resourceKey.Credentials.IamRoleCRN != nil {

--- a/ibm/resource_ibm_resource_key_test.go
+++ b/ibm/resource_ibm_resource_key_test.go
@@ -29,6 +29,7 @@ func TestAccIBMResourceKey_Basic(t *testing.T) {
 					testAccCheckIBMResourceKeyExists("ibm_resource_key.resourceKey"),
 					resource.TestCheckResourceAttr("ibm_resource_key.resourceKey", "name", resourceKey),
 					resource.TestCheckResourceAttr("ibm_resource_key.resourceKey", "credentials.%", "7"),
+					resource.TestCheckResourceAttrSet("ibm_resource_key.resourceKey", "credentials_json"),
 					resource.TestCheckResourceAttr("ibm_resource_key.resourceKey", "role", "Reader"),
 				),
 			},

--- a/website/docs/d/resource_key.html.markdown
+++ b/website/docs/d/resource_key.html.markdown
@@ -19,7 +19,7 @@ data "ibm_resource_key" "resourceKeydata" {
   resource_instance_id  = ibm_resource_instance.resource.id
 }
 ```
-### Example to access resource credentials using credentials:
+### Example to access resource credentials using credentials attribute:
 
 ```terraform
 data "ibm_resource_key" "key" {
@@ -33,7 +33,7 @@ output "secret_access_key" {
   value = data.ibm_resource_key.key.credentials["cos_hmac_keys.secret_access_key"]
 }
 ```
-### Example to access resource credentials:
+### Example to access resource credentials using credentials_json attribute:
 
 ```terraform
 data "ibm_resource_key" "key" {

--- a/website/docs/d/resource_key.html.markdown
+++ b/website/docs/d/resource_key.html.markdown
@@ -19,6 +19,37 @@ data "ibm_resource_key" "resourceKeydata" {
   resource_instance_id  = ibm_resource_instance.resource.id
 }
 ```
+### Example to access resource credentials using credentials:
+
+```terraform
+data "ibm_resource_key" "key" {
+  name                  = "myobjectKey"
+  resource_instance_id  = ibm_resource_instance.resource.id
+}
+output "access_key_id" {
+  value = data.ibm_resource_key.key.credentials["cos_hmac_keys.access_key_id"]
+}
+output "secret_access_key" {
+  value = data.ibm_resource_key.key.credentials["cos_hmac_keys.secret_access_key"]
+}
+```
+### Example to access resource credentials:
+
+```terraform
+data "ibm_resource_key" "key" {
+  name                  = "myobjectKey"
+  resource_instance_id  = ibm_resource_instance.resource.id
+}
+locals {
+  resource_credentials = jsondecode(data.ibm_resource_key.key.credentials_json)
+}
+output "access_key_id" {
+  value = local.resource_credentials.cos_hmac_keys.access_key_id
+}
+output "secret_access_key" {
+  value = local.resource_credentials.cos_hmac_keys.secret_access_key
+}
+```
 
 ## Argument reference
 Review the argument references that you can specify for your data source.
@@ -31,7 +62,9 @@ Review the argument references that you can specify for your data source.
 ## Attribute reference
 In addition to all argument reference list, you can access the following attribute references after your data source is created.
 
-- `credentials` - The credentials associated with the key.
-- `id` - The unique identifier of the resource key.
-- `role` - The user role.
-- `status` - The status of the resource key.  
+- `credentials` - (Map) The credentials associated with the key.
+- `credentials_json` - (String) The credentials associated with the key in json format.
+- `crn` - (String) CRN of resource key.
+- `id` - (String) The unique identifier of the resource key.
+- `role` - (String) The user role.
+- `status` - (String) The status of the resource key.  

--- a/website/docs/r/resource_key.html.markdown
+++ b/website/docs/r/resource_key.html.markdown
@@ -89,7 +89,7 @@ resource "ibm_resource_key" "resourceKey" {
 }
 
 ```
-### Example to access resource credentials using credentials:
+### Example to access resource credentials using credentials attribute:
 
 ```terraform
 resource "ibm_resource_key" "key" {
@@ -105,7 +105,7 @@ output "secret_access_key" {
 }
 ```
 
-### Example to access resource credentials using credentials_json:
+### Example to access resource credentials using credentials_json attribute:
 
 ```terraform
 resource "ibm_resource_key" "key" {

--- a/website/docs/r/resource_key.html.markdown
+++ b/website/docs/r/resource_key.html.markdown
@@ -89,6 +89,40 @@ resource "ibm_resource_key" "resourceKey" {
 }
 
 ```
+### Example to access resource credentials using credentials:
+
+```terraform
+resource "ibm_resource_key" "key" {
+  name                 = "my-cos-bucket-xx-key"
+  resource_instance_id = ibm_resource_instance.resource_instance.id
+  role                 = "Manager"
+}
+output "access_key_id" {
+  value = ibm_resource_key.key.credentials["cos_hmac_keys.access_key_id"]
+}
+output "secret_access_key" {
+  value = ibm_resource_key.key.credentials["cos_hmac_keys.secret_access_key"]
+}
+```
+
+### Example to access resource credentials using credentials_json:
+
+```terraform
+resource "ibm_resource_key" "key" {
+  name                 = "my-cos-bucket-xx-key"
+  resource_instance_id = ibm_resource_instance.resource_instance.id
+  role                 = "Manager"
+}
+locals {
+  resource_credentials =jsondecode(ibm_resource_key.key.credentials_json)
+}
+output "access_key_id" {
+  value = local.resource_credentials.cos_hmac_keys.access_key_id
+}
+output "secret_access_key" {
+  value = local.resource_credentials.cos_hmac_keys.secret_access_key
+}
+```
 
 ## Timeouts
 
@@ -113,7 +147,8 @@ Review the argument references that you can specify for your resource.
 In addition to all argument reference list, you can access the following attribute reference after your resource is created.
 
 - `account_id` - (String) An alpha-numeric value identifying the account ID.
-- `credentials` - (String) The credentials associated with the key.
+- `credentials` - (Map) The credentials associated with the key.
+- `credentials_json` - (String) The credentials associated with the key in json format.
 - `created_at` - (Timestamp) The date when the key was created.
 - `created_by` - (String) The subject who created the key.
 - `crn` - (String) The full Cloud Resource Name (CRN) associated with the key.


### PR DESCRIPTION

<!--- See what makes a good Pull Request at : https://github.com/IBM-Cloud/terraform-provider-ibm/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes  #2180 #1860 #1741

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
=== RUN   TestAccIBMResourceKey_Basic
--- PASS: TestAccIBMResourceKey_Basic (65.29s)
PASS
ok  	github.com/IBM-Cloud/terraform-provider-ibm/ibm	68.247s

...
```
