### PR TITLE
Fix #1387 #1232: made role as optional argument

### DIFF
--- a/ibm/resource_ibm_resource_key_test.go
+++ b/ibm/resource_ibm_resource_key_test.go
@@ -94,7 +94,7 @@ func TestAccIBMResourceKey_Parameters(t *testing.T) {
 	})
 }
 
-func TestAccIBMResourceKeyWithCustomRole(t *testing.T) {
+func TestAccIBMResourceKey_WithCustomRole(t *testing.T) {
 	resourceName := fmt.Sprintf("tf-cos-%d", acctest.RandIntRange(10, 100))
 	resourceKey := fmt.Sprintf("tf-cos-%d", acctest.RandIntRange(10, 100))
 	crName := fmt.Sprintf("Name%d", acctest.RandIntRange(10, 100))
@@ -111,7 +111,7 @@ func TestAccIBMResourceKeyWithCustomRole(t *testing.T) {
 					testAccCheckIBMResourceKeyExists("ibm_resource_key.resourceKey"),
 					resource.TestCheckResourceAttr("ibm_resource_key.resourceKey", "name", resourceKey),
 					resource.TestCheckResourceAttr("ibm_resource_key.resourceKey", "credentials.%", "7"),
-					resource.TestCheckResourceAttr("ibm_resource_key.resourceKey", "role", crName),
+					resource.TestCheckResourceAttr("ibm_resource_key.resourceKey", "role", displayName),
 				),
 			},
 		},

--- a/website/docs/r/resource_key.html.markdown
+++ b/website/docs/r/resource_key.html.markdown
@@ -103,7 +103,7 @@ Review the argument references that you can specify for your resource.
 
 - `name` - (Required, Forces new resource, String)  A descriptive name used to identify a resource key.
 - `parameters` (Optional, Map) Arbitrary parameters to pass to the resource in JSON format. If you want to create service credentials by using the private service endpoint, include the `service-endpoints =  "private"` parameter.
-- `role` - (Required, Forces new resource, String) The name of the user role. Valid roles are `Writer`, `Reader`, `Manager`, `Administrator`, `Operator`, `Viewer`, and `Editor`.
+- `role` - (Optional, Forces new resource, String) The name of the user role. Valid roles are `Writer`, `Reader`, `Manager`, `Administrator`, `Operator`, `Viewer`, and `Editor`. This argument is Optional only during creation of service credentials for Cloud Databases and other non-IAM-enabled services and is Required for all other IAM-enabled services.
 - `resource_instance_id` - (Optional, Forces new resource, String) The ID of the resource instance associated with the resource key. **Note** Conflicts with `resource_alias_id`.
 - `resource_alias_id` - (Optional, Forces new resource, String) The ID of the resource alias associated with the resource key. **Note** Conflicts with `resource_instance_id`.
 - `tags` (Optional, Array of strings) Tags associated with the resource key instance. **Note** Tags are managed locally and not stored on the IBM Cloud Service Endpoint at this moment.


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/IBM-Cloud/terraform-provider-ibm/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #1387 #1232

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
=== RUN   TestAccIBMResourceKey_Basic
--- PASS: TestAccIBMResourceKey_Basic (63.89s)
=== RUN   TestAccIBMResourceKey_With_Tags
--- PASS: TestAccIBMResourceKey_With_Tags (71.76s)
=== RUN   TestAccIBMResourceKey_Parameters
--- PASS: TestAccIBMResourceKey_Parameters (64.45s)
PASS
ok  	github.com/IBM-Cloud/terraform-provider-ibm/ibm	204.021s
=== RUN   TestAccIBMResourceKey_WithCustomRole
--- PASS: TestAccIBMResourceKey_WithCustomRole (59.89s)
PASS
ok  	github.com/IBM-Cloud/terraform-provider-ibm/ibm	63.241s
```
