### PR TITLE
enhancement(Cloud Databases): add support for User types, roles 

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "go.sum|^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2022-04-29T12:28:23Z",
+  "generated_at": "2022-05-10T13:45:58Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -692,7 +692,7 @@
         "hashed_secret": "c8b6f5ef11b9223ac35a5663975a466ebe7ebba9",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1229,
+        "line_number": 1232,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -700,7 +700,7 @@
         "hashed_secret": "8abf4899c01104241510ba87685ad4de76b0c437",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1235,
+        "line_number": 1238,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -1383,18 +1383,18 @@
     ],
     "ibm/service/database/resource_ibm_database.go": [
       {
-        "hashed_secret": "7deb7557ec8b36e7d5958afe3e08959e7f1ba813",
+        "hashed_secret": "deab23f996709b4e3d14e5499d1cc2de677bfaa8",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1403,
+        "line_number": 1431,
         "type": "Secret Keyword",
         "verified_result": null
       },
       {
-        "hashed_secret": "b62aab00e3bf482bfb75e3e42fd5d1be72f33ec0",
+        "hashed_secret": "20a25bac21219ffff1904bde871ded4027eca2f8",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1497,
+        "line_number": 2022,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1402,7 +1402,7 @@
         "hashed_secret": "b732fb611fd46a38e8667f9972e0cde777fbe37f",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2061,
+        "line_number": 2041,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1410,7 +1410,7 @@
         "hashed_secret": "1f5e25be9b575e9f5d39c82dfd1d9f4d73f1975c",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2178,
+        "line_number": 2313,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -1457,10 +1457,18 @@
     ],
     "ibm/service/database/resource_ibm_database_mongodb_enterprise_test.go": [
       {
+        "hashed_secret": "68ab9ef0953865fef0558010a9f7afcef110d5b8",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 199,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
         "hashed_secret": "10c28f9cf0668595d45c1090a7b4a2ae98edfa58",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 253,
+        "line_number": 257,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -2148,7 +2156,7 @@
         "hashed_secret": "10c28f9cf0668595d45c1090a7b4a2ae98edfa58",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 362,
+        "line_number": 372,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -2156,7 +2164,7 @@
         "hashed_secret": "91199272d5d6a574a51722ca6f3d1148edb1a0e7",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 404,
+        "line_number": 415,
         "type": "Secret Keyword",
         "verified_result": null
       }

--- a/ibm/service/database/resource_ibm_database_mongodb_enterprise_test.go
+++ b/ibm/service/database/resource_ibm_database_mongodb_enterprise_test.go
@@ -61,6 +61,7 @@ func TestAccIBMMongoDBEnterpriseDatabaseInstanceBasic(t *testing.T) {
 					resource.TestCheckResourceAttr(name, "service_endpoints", "public"),
 					resource.TestCheckResourceAttr(name, "whitelist.#", "2"),
 					resource.TestCheckResourceAttr(name, "users.#", "2"),
+					resource.TestCheckResourceAttr(name, "users.1.type", "ops_manager"),
 					resource.TestCheckResourceAttr(name, "connectionstrings.#", "3"),
 					resource.TestCheckResourceAttr(name, "connectionstrings.2.name", "admin"),
 					resource.TestCheckResourceAttr(name, "connectionstrings.0.hosts.#", "3"),
@@ -156,6 +157,7 @@ func testAccCheckIBMDatabaseInstanceMongoDBEnterpriseBasic(databaseResourceGroup
 		users {
 		  name     = "user123"
 		  password = "password12"
+		  type     = "database"
 		}
 		whitelist {
 		  address     = "172.168.1.2/32"
@@ -190,10 +192,12 @@ func testAccCheckIBMDatabaseInstanceMongoDBEnterpriseFullyspecified(databaseReso
 		users {
 		  name     = "user123"
 		  password = "password12"
+		  type     = "database"
 		}
 		users {
 		  name     = "user124"
-		  password = "password12"
+		  password = "password12$password"
+		  type     = "ops_manager"
 		}
 		whitelist {
 		  address     = "172.168.1.2/32"

--- a/website/docs/d/database.html.markdown
+++ b/website/docs/d/database.html.markdown
@@ -8,15 +8,13 @@ description: |-
 
 # ibm_database
 
-Create a read-only copy of an existing IBM Cloud database service. For more information, about an IBM Cloud datbase service instance, see [provisioning databases](https://cloud.ibm.com/docs/cloud-databases?topic=cloud-databases-provisioning).
+Retrieve information about an existing [IBM Cloud Database instance](https://cloud.ibm.com/docs/cloud-databases).
 
 **Note**
 Configuration of an IBM Cloud Databases `data_source` requires that the `region` parameter is set for the IBM provider in the `provider.tf`. The region must be the same as the `location` that the IBM Cloud Databases instance is deployed into. If not specified, `us-south` is used by default. A `terraform refresh` of the `data_source` fails if the region and the location differ.
 
-
 ## Example usage
-The following example creates a read-only copy of the `mydatabase` instance in `us-east`.  
-
+The following example retrieves information about the `mydatabase` instance in `us-east`.
 
 ```terraform
 data "ibm_database" "database" {
@@ -25,7 +23,6 @@ data "ibm_database" "database" {
 }
 ```
 
-
 ## Argument reference
 Review the argument reference that you can specify for your data source. 
 
@@ -33,7 +30,6 @@ Review the argument reference that you can specify for your data source.
 - `location` - (Optional, String) The location where the IBM Cloud Databases instance is deployed into.
 - `resource_group_id`- (Optional, String) The ID of the resource group where the IBM Cloud Databases instance is deployed into. The default is `default`.
 - `service` - (Optional, String) The service type of the instance. To retrieve this value, run `ibmcloud catalog service-marketplace` or `ibmcloud catalog search`.
-
 
 ## Attribute reference
 In addition to all argument references list, you can access the following attribute references after your data source is created. 
@@ -47,7 +43,6 @@ In addition to all argument references list, you can access the following attrib
 - `plan` - (String)  The service plan of the IBM Cloud Databases instance.
 - `location` - (String)  The location where the IBM Cloud Databases instance is deployed into.
 - `status` - (String)  The status of the IBM Cloud Databases instance.
-- `status` - (String)  The status of resource instance.
 - `version` - (String) The database version.
 - `platform_options`-  (String) The CRN of key protect key.
    

--- a/website/docs/r/database.html.markdown
+++ b/website/docs/r/database.html.markdown
@@ -37,6 +37,7 @@ resource "ibm_database" "<your_database>" {
   users {
     name     = "user123"
     password = "password12"
+    type     = "database"
   }
   whitelist {
     address     = "172.168.1.1/32"
@@ -71,8 +72,9 @@ resource "ibm_database" "<your_database>" {
   node_memory_allocation_mb = 1024
   node_disk_allocation_mb   = 20480
   users {
-    name     = "user123"
-    password = "password12"
+    name      = "user123"
+    password  = "password12"
+    type      = "database"
   }
   whitelist {
     address     = "172.168.1.1/32"
@@ -216,8 +218,9 @@ resource "ibm_database" "cassandra" {
   members_memory_allocation_mb = 36864
   members_disk_allocation_mb   = 61440
   users {
-    name     = "user123"
-    password = "password12"
+    name      = "user123"
+    password  = "password12"
+    type      = "database"
   }
   whitelist {
     address     = "172.168.1.2/32"
@@ -252,8 +255,15 @@ resource "ibm_database" "mongodb" {
   members_memory_allocation_mb = 43008
   tags                         = ["one:two"]
   users {
-    name     = "user123"
-    password = "password12"
+    name      = "dbuser"
+    password  = "password12"
+    type      = "database"
+  }
+  users {
+    name     = "opsmanageruser"
+    password = "$ecurepa$$word12"
+    type     = "ops_manager"
+    role     = "group_read_only"
   }
   whitelist {
     address     = "172.168.1.2/32"
@@ -358,8 +368,9 @@ resource "ibm_database" "edb" {
   members_disk_allocation_mb   = 61440
   tags                         = ["one:two"]
   users {
-    name     = "user123"
-    password = "password12"
+    name      = "user123"
+    password  = "password12"
+    type      = "database"
   }
   whitelist {
     address     = "172.168.1.2/32"
@@ -510,8 +521,11 @@ Review the argument reference that you can specify for your resource.
 - `users` - (Optional, List of Objects) A list of users that you want to create on the database. Multiple blocks are allowed.
 
   Nested scheme for `users`:
-  - `name` - (Optional, String) The user ID to add to the database instance. The user ID must be in the range 5 - 32 characters.
-  - `password` - (Optional, String) The password for the user ID. The password must be in the range 10 - 32 characters.
+  - `name` - (Required, String) The user name to add to the database instance. The user name must be in the range 5 - 32 characters.
+  - `password` - (Required, String) The password for the user. The password must be in the range 10 - 32 characters. Users 
+  - `type` - (Optional, String) The type for the user. Examples: `database`, `ops_manager`, `read_only_replica`. The default value is `database`.
+  - `role` - (Optional, String) The role for the user. Only available for `ops_manager` user type. Examples: `group_read_only`, `group_data_access_admin`.
+
 - `whitelist` - (Optional, List of Objects) A list of allowed IP addresses for the database. Multiple blocks are allowed.
 
   Nested scheme for `whitelist`:


### PR DESCRIPTION
Adds support for multiple user types (`database`, `ops_manager`, `read_only_replica`) for the IBM Database Resource 
See https://cloud.ibm.com/apidocs/cloud-databases-api/cloud-databases-api-v5#createdatabaseuser

<!--- See what makes a good Pull Request at : https://github.com/IBM-Cloud/terraform-provider-ibm/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->

Output from acceptance testing: 

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```sh
$ make testacc TESTARGS='-run=TestAccIBMMongoDBEnterprise'
...
--- PASS: TestAccIBMMongoDBEnterpriseDatabaseInstanceGroupBasic (5207.81s)
--- PASS: TestAccIBMMongoDBEnterpriseDatabaseInstanceBasic (27551.47s)
...
$ make testacc TESTARGS='-run=TestAccIBMDatabaseInstance'
...
--- PASS: TestAccIBMDatabaseInstanceElasticsearchImport (465.51s)
--- PASS: TestAccIBMDatabaseInstanceEtcdImport (870.41s)
--- PASS: TestAccIBMDatabaseInstanceMongodbBasic (1534.00s)
--- PASS: TestAccIBMDatabaseInstanceMongodbImport (1152.09s)
--- PASS: TestAccIBMDatabaseInstancePostgresBasic (2373.14s)
--- PASS: TestAccIBMDatabaseInstancePostgresGroup (2593.68s)
--- PASS: TestAccIBMDatabaseInstancePostgresImport (944.31s)
--- PASS: TestAccIBMDatabaseInstancePostgresNode (2270.03s)
--- PASS: TestAccIBMDatabaseInstanceRabbitmqImport (809.02s)
--- PASS: TestAccIBMDatabaseInstanceRedisImport (661.52s)
--- PASS: TestAccIBMDatabaseInstance_Cassandra_Group (6637.37s)
--- PASS: TestAccIBMDatabaseInstance_Cassandra_Node (4408.87s)
--- PASS: TestAccIBMDatabaseInstance_Elasticsearch_Basic (854.69s)
--- PASS: TestAccIBMDatabaseInstance_Elasticsearch_Group (1522.81s)
--- PASS: TestAccIBMDatabaseInstance_Elasticsearch_Node (789.75s)
--- PASS: TestAccIBMDatabaseInstance_Etcd_Basic (873.66s)
--- PASS: TestAccIBMDatabaseInstance_Rabbitmq_Basic (1422.83s)
--- PASS: TestAccIBMDatabaseInstance_Redis_Basic (705.72s)
...
```
