### PR TITLE
added nil value to id in case of 404 in read context of ag #3476

### DIFF
--- a/ibm/resource_ibm_iam_access_group.go
+++ b/ibm/resource_ibm_iam_access_group.go
@@ -83,6 +83,7 @@ func resourceIBMIAMAccessGroupRead(context context.Context, d *schema.ResourceDa
 	agrp, detailedResponse, err := iamAccessGroupsClient.GetAccessGroup(getAccessGroupOptions)
 	if err != nil || agrp == nil {
 		if detailedResponse != nil && detailedResponse.StatusCode == 404 {
+			d.SetId("")
 			return nil
 		}
 		return diag.FromErr(fmt.Errorf("Error retrieving access group: %s. API Response: %s", err, detailedResponse))

--- a/ibm/resource_ibm_iam_access_group_test.go
+++ b/ibm/resource_ibm_iam_access_group_test.go
@@ -95,8 +95,7 @@ func testAccCheckIBMIAMAccessGroupDestroy(s *terraform.State) error {
 		getAccessGroupOptions := &iamaccessgroupsv2.GetAccessGroupOptions{
 			AccessGroupID: &agID,
 		}
-		_, detailResponse, _ := accClient.GetAccessGroup(getAccessGroupOptions)
-
+		_, detailResponse, err := accClient.GetAccessGroup(getAccessGroupOptions)
 		if err == nil {
 			return fmt.Errorf("Access group still exists: %s", rs.Primary.ID)
 		} else if detailResponse.StatusCode != 404 {


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/IBM-Cloud/terraform-provider-ibm/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #3476

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccXXX'


=== RUN   TestAccIBMIAMAccessGroup_Basic
--- PASS: TestAccIBMIAMAccessGroup_Basic (46.91s)
PASS
ok      github.com/IBM-Cloud/terraform-provider-ibm/ibm 49.282s
testing: warning: no tests to run
PASS
ok      github.com/IBM-Cloud/terraform-provider-ibm/ibm/internal/hashcode       (cached) [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/IBM-Cloud/terraform-provider-ibm/ibm/internal/mutexkv        (cached) [no tests to run]
?       github.com/IBM-Cloud/terraform-provider-ibm/version     [no test files]
...
```
