### PR TITLE
fix(sg-rule): added a check to check if remote sg id exists in is_security_group_rule

### DIFF
--- a/ibm/service/vpc/resource_ibm_is_security_group_rule.go
+++ b/ibm/service/vpc/resource_ibm_is_security_group_rule.go
@@ -589,6 +589,18 @@ func parseIBMISSecurityGroupRuleDictionary(d *schema.ResourceData, tag string, s
 		} else if parsed.remoteSecGrpID != "" {
 			remoteTemplate.ID = &parsed.remoteSecGrpID
 			remoteTemplateUpdate.ID = &parsed.remoteSecGrpID
+
+			// check if remote is actually a SG identifier
+			getSecurityGroupOptions := &vpcv1.GetSecurityGroupOptions{
+				ID: &parsed.remoteSecGrpID,
+			}
+			sg, res, err := sess.GetSecurityGroup(getSecurityGroupOptions)
+			if err != nil || sg == nil {
+				if res != nil && res.StatusCode == 404 {
+					return nil, nil, nil, err
+				}
+				return nil, nil, nil, fmt.Errorf("Error getting Security Group in remote (%s): %s\n%s", parsed.remoteSecGrpID, err, res)
+			}
 		}
 		sgTemplate.Remote = remoteTemplate
 		securityGroupRulePatchModel.Remote = remoteTemplateUpdate


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/IBM-Cloud/terraform-provider-ibm/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
--- PASS: TestAccIBMISSecurityGroupRule_basic (117.41s)
PASS
ok      github.com/IBM-Cloud/terraform-provider-ibm/ibm 121.412s
```
