### PR TITLE
schema and test fix for instance group manager action

### DIFF
--- a/ibm/resource_ibm_is_instance_group_manager_action.go
+++ b/ibm/resource_ibm_is_instance_group_manager_action.go
@@ -75,6 +75,7 @@ func resourceIBMISInstanceGroupManagerAction() *schema.Resource {
 				ValidateFunc:  InvokeValidator("ibm_is_instance_group_manager_action", "membership_count"),
 				Description:   "The number of members the instance group should have at the scheduled time.",
 				ConflictsWith: []string{"target_manager", "max_membership_count", "min_membership_count"},
+				AtLeastOneOf:  []string{"target_manager", "membership_count"},
 			},
 
 			"max_membership_count": {
@@ -101,6 +102,7 @@ func resourceIBMISInstanceGroupManagerAction() *schema.Resource {
 				Description:   "The unique identifier for this instance group manager of type autoscale.",
 				ConflictsWith: []string{"membership_count"},
 				RequiredWith:  []string{"min_membership_count", "max_membership_count"},
+				AtLeastOneOf:  []string{"target_manager", "membership_count"},
 			},
 
 			"target_manager_name": {

--- a/ibm/resource_ibm_is_instance_group_manager_action_test.go
+++ b/ibm/resource_ibm_is_instance_group_manager_action_test.go
@@ -58,6 +58,7 @@ func TestAccIBMISInstanceGroupManagerAction_basic_autoscale(t *testing.T) {
 	instanceGroupManager := fmt.Sprintf("testinstancegroupmanager%d", randInt)
 	instanceGroupManagerAutoscale := fmt.Sprintf("testinstancegroupmanagerautoscale%d", randInt)
 	instanceGroupManagerAction := fmt.Sprintf("testinstancegroupmanageraction%d", randInt)
+	instanceGroupManagerPolicyAction := fmt.Sprintf("testinstancegroupmanagerpolicy%d", randInt)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -65,7 +66,7 @@ func TestAccIBMISInstanceGroupManagerAction_basic_autoscale(t *testing.T) {
 		CheckDestroy: testAccCheckIBMISInstanceGroupManagerActionDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckIBMISInstanceGroupManagerActionAutoscaleConfig(vpcName, subnetName, sshKeyName, publicKey, templateName, instanceGroupName, instanceGroupManager, instanceGroupManagerAutoscale, instanceGroupManagerAction),
+				Config: testAccCheckIBMISInstanceGroupManagerActionAutoscaleConfig(vpcName, subnetName, sshKeyName, publicKey, templateName, instanceGroupName, instanceGroupManager, instanceGroupManagerAutoscale, instanceGroupManagerPolicyAction, instanceGroupManagerAction),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(
 						"ibm_is_instance_group_manager.instance_group_manager", "name", instanceGroupManager),
@@ -132,7 +133,7 @@ func testAccCheckIBMISInstanceGroupManagerActionConfig(vpcName, subnetName, sshK
 
 	resource "ibm_is_instance_template" "instancetemplate1" {
 	   name    = "%s"
-	   image   = "r006-14140f94-fcc4-11e9-96e7-a72723715315"
+	   image   = "%s"
 	   profile = "bx2-8x32"
 
 	   primary_network_interface {
@@ -166,11 +167,11 @@ func testAccCheckIBMISInstanceGroupManagerActionConfig(vpcName, subnetName, sshK
 		membership_count = 1
 	}
 
-	`, vpcName, subnetName, sshKeyName, publicKey, templateName, instanceGroupName, instanceGroupManager, instanceGroupManagerAction)
+	`, vpcName, subnetName, sshKeyName, publicKey, templateName, isImage, instanceGroupName, instanceGroupManager, instanceGroupManagerAction)
 
 }
 
-func testAccCheckIBMISInstanceGroupManagerActionAutoscaleConfig(vpcName, subnetName, sshKeyName, publicKey, templateName, instanceGroupName, instanceGroupManager, instanceGroupManagerAutoscale, instanceGroupManagerAction string) string {
+func testAccCheckIBMISInstanceGroupManagerActionAutoscaleConfig(vpcName, subnetName, sshKeyName, publicKey, templateName, instanceGroupName, instanceGroupManager, instanceGroupManagerAutoscale, instanceGroupManagerPolicyAction, instanceGroupManagerAction string) string {
 	return fmt.Sprintf(`
 	provider "ibm" {
 		generation = 2
@@ -194,7 +195,7 @@ func testAccCheckIBMISInstanceGroupManagerActionAutoscaleConfig(vpcName, subnetN
 
 	resource "ibm_is_instance_template" "instancetemplate1" {
 	   name    = "%s"
-	   image   = "r006-14140f94-fcc4-11e9-96e7-a72723715315"
+	   image   = "%s"
 	   profile = "bx2-8x32"
 
 	   primary_network_interface {
@@ -237,7 +238,7 @@ func testAccCheckIBMISInstanceGroupManagerActionAutoscaleConfig(vpcName, subnetN
 		metric_type = "cpu"
 		metric_value = 70
 		policy_type = "target"
-		name = "instancegrouppolicysunitha"
+		name = "%s"
 	}
 
 	resource "ibm_is_instance_group_manager_action" "instance_group_manager_action" {
@@ -250,6 +251,6 @@ func testAccCheckIBMISInstanceGroupManagerActionAutoscaleConfig(vpcName, subnetN
 		max_membership_count   = 2
 	  }
 
-	`, vpcName, subnetName, sshKeyName, publicKey, templateName, instanceGroupName, instanceGroupManager, instanceGroupManagerAutoscale, instanceGroupManagerAction)
+	`, vpcName, subnetName, sshKeyName, publicKey, templateName, isImage, instanceGroupName, instanceGroupManager, instanceGroupManagerAutoscale, instanceGroupManagerPolicyAction, instanceGroupManagerAction)
 
 }


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/IBM-Cloud/terraform-provider-ibm/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TEST=./ibm TESTARGS='-run=TestAccIBMISInstanceGroupManagerAction_basic_autoscale'
=== RUN   TestAccIBMISInstanceGroupManagerAction_basic_autoscale
--- PASS: TestAccIBMISInstanceGroupManagerAction_basic_autoscale (305.20s)
PASS
ok      github.com/IBM-Cloud/terraform-provider-ibm/ibm 307.856s

$ make testacc TEST=./ibm TESTARGS='-run=TestAccIBMISInstanceGroupManagerAction_basic'
=== RUN   TestAccIBMISInstanceGroupManagerAction_basic
--- PASS: TestAccIBMISInstanceGroupManagerAction_basic (287.46s)
=== RUN   TestAccIBMISInstanceGroupManagerAction_basic_autoscale
--- PASS: TestAccIBMISInstanceGroupManagerAction_basic_autoscale (306.13s)
PASS
ok      github.com/IBM-Cloud/terraform-provider-ibm/ibm 596.471s

...
```
