### PR TITLE
fix: panic while creating cloud connections

### DIFF
--- a/ibm/service/power/resource_ibm_pi_cloud_connection.go
+++ b/ibm/service/power/resource_ibm_pi_cloud_connection.go
@@ -212,7 +212,7 @@ func resourceIBMPICloudConnectionCreate(ctx context.Context, d *schema.ResourceD
 	if cloudConnection != nil {
 		d.SetId(fmt.Sprintf("%s/%s", cloudInstanceID, *cloudConnection.CloudConnectionID))
 	} else if cloudConnectionJob != nil {
-		d.SetId(fmt.Sprintf("%s/%s", cloudInstanceID, *cloudConnection.CloudConnectionID))
+		d.SetId(fmt.Sprintf("%s/%s", cloudInstanceID, *cloudConnectionJob.CloudConnectionID))
 
 		jobID := *cloudConnectionJob.JobRef.ID
 


### PR DESCRIPTION
Signed-off-by: Yussuf Shaikh <yussuf.shaikh@ibm.com>

<!--- See what makes a good Pull Request at : https://github.com/IBM-Cloud/terraform-provider-ibm/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #3497 

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
=== RUN   TestAccIBMPICloudConnectionbasic
--- PASS: TestAccIBMPICloudConnectionbasic (617.65s)
=== RUN   TestAccIBMPICloudConnectionNetworks
--- PASS: TestAccIBMPICloudConnectionNetworks (871.92s)
PASS
```
