### PR TITLE
fix(is_vpc) : Subnet pagination fix in is_vpc datasource

### DIFF
--- a/ibm/service/vpc/data_source_ibm_is_vpc.go
+++ b/ibm/service/vpc/data_source_ibm_is_vpc.go
@@ -386,13 +386,13 @@ func vpcGetByName(d *schema.ResourceData, meta interface{}, name string) error {
 
 			for {
 				if startSub != "" {
-					options.Start = &start
+					options.Start = &startSub
 				}
 				s, response, err := sess.ListSubnets(options)
 				if err != nil {
 					return fmt.Errorf("[ERROR] Error fetching subnets %s\n%s", err, response)
 				}
-				start = flex.GetNext(s.Next)
+				startSub = flex.GetNext(s.Next)
 				allrecsSub = append(allrecsSub, s.Subnets...)
 				if startSub == "" {
 					break
@@ -416,7 +416,7 @@ func vpcGetByName(d *schema.ResourceData, meta interface{}, name string) error {
 				d.Set(subnetsList, subnetsInfo)
 			}
 
-			// adding pagination support for subnets inside vpc
+			// adding pagination support for sg inside vpc
 
 			startSg := ""
 			allrecsSg := []vpcv1.SecurityGroup{}


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/IBM-Cloud/terraform-provider-ibm/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #3506

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
--- PASS: TestAccIBMISVPCDatasource_basic (110.15s)
PASS
ok      github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/vpc     112.334s
```
