### PR TITLE
add image security enforcement functionality

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/IBM-Cloud/terraform-provider-ibm
 go 1.16
 
 require (
-	github.com/IBM-Cloud/bluemix-go v0.0.0-20211223094327-0da2539481f7
+	github.com/IBM-Cloud/bluemix-go v0.0.0-20220118060915-c07e2089bd3b
 	github.com/IBM-Cloud/container-services-go-sdk v0.0.0-20210705152127-41ca00fc9a62
 	github.com/IBM-Cloud/power-go-client v1.0.87
 	github.com/IBM/apigateway-go-sdk v0.0.0-20210714141226-a5d5d49caaca

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/IBM-Cloud/terraform-provider-ibm
 go 1.16
 
 require (
-	github.com/IBM-Cloud/bluemix-go v0.0.0-20220118060915-c07e2089bd3b
+	github.com/IBM-Cloud/bluemix-go v0.0.0-20220119131246-2af2dee48688
 	github.com/IBM-Cloud/container-services-go-sdk v0.0.0-20210705152127-41ca00fc9a62
 	github.com/IBM-Cloud/power-go-client v1.0.87
 	github.com/IBM/apigateway-go-sdk v0.0.0-20210714141226-a5d5d49caaca

--- a/go.sum
+++ b/go.sum
@@ -37,8 +37,8 @@ dmitri.shuralyov.com/gpu/mtl v0.0.0-20190408044501-666a987793e9/go.mod h1:H6x//7
 github.com/BurntSushi/toml v0.3.1 h1:WXkYYl6Yr3qBf1K79EBnL4mak0OimBfB0XUf9Vl28OQ=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
-github.com/IBM-Cloud/bluemix-go v0.0.0-20220118060915-c07e2089bd3b h1:ZYwsyXVeXnUktGPRA1kQOCMzB/mU34iSG/xMOBNGr50=
-github.com/IBM-Cloud/bluemix-go v0.0.0-20220118060915-c07e2089bd3b/go.mod h1:q0fXFSbum/16D8Mgn1ROSfSyX4BmvBCm/hHdcXz0wCU=
+github.com/IBM-Cloud/bluemix-go v0.0.0-20220119131246-2af2dee48688 h1:5ALK84zg9m4WTLusG+4RziEQsO2TDSs0Z1jeCRgQr34=
+github.com/IBM-Cloud/bluemix-go v0.0.0-20220119131246-2af2dee48688/go.mod h1:q0fXFSbum/16D8Mgn1ROSfSyX4BmvBCm/hHdcXz0wCU=
 github.com/IBM-Cloud/container-services-go-sdk v0.0.0-20210705152127-41ca00fc9a62 h1:MOkcr6qQGk4tY542ZJ1DggVh2WUP72EEyLB79llFVH8=
 github.com/IBM-Cloud/container-services-go-sdk v0.0.0-20210705152127-41ca00fc9a62/go.mod h1:xUQL9SGAjoZFd4GNjrjjtEpjpkgU7RFXRyHesbKTjiY=
 github.com/IBM-Cloud/ibm-cloud-cli-sdk v0.5.3/go.mod h1:RiUvKuHKTBmBApDMUQzBL14pQUGKcx/IioKQPIcRQjs=

--- a/go.sum
+++ b/go.sum
@@ -37,8 +37,8 @@ dmitri.shuralyov.com/gpu/mtl v0.0.0-20190408044501-666a987793e9/go.mod h1:H6x//7
 github.com/BurntSushi/toml v0.3.1 h1:WXkYYl6Yr3qBf1K79EBnL4mak0OimBfB0XUf9Vl28OQ=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
-github.com/IBM-Cloud/bluemix-go v0.0.0-20211223094327-0da2539481f7 h1:XH//z3YFvgWzfZVScUkiT0KQHBWgcKozm3CAb8ujXPo=
-github.com/IBM-Cloud/bluemix-go v0.0.0-20211223094327-0da2539481f7/go.mod h1:q0fXFSbum/16D8Mgn1ROSfSyX4BmvBCm/hHdcXz0wCU=
+github.com/IBM-Cloud/bluemix-go v0.0.0-20220118060915-c07e2089bd3b h1:ZYwsyXVeXnUktGPRA1kQOCMzB/mU34iSG/xMOBNGr50=
+github.com/IBM-Cloud/bluemix-go v0.0.0-20220118060915-c07e2089bd3b/go.mod h1:q0fXFSbum/16D8Mgn1ROSfSyX4BmvBCm/hHdcXz0wCU=
 github.com/IBM-Cloud/container-services-go-sdk v0.0.0-20210705152127-41ca00fc9a62 h1:MOkcr6qQGk4tY542ZJ1DggVh2WUP72EEyLB79llFVH8=
 github.com/IBM-Cloud/container-services-go-sdk v0.0.0-20210705152127-41ca00fc9a62/go.mod h1:xUQL9SGAjoZFd4GNjrjjtEpjpkgU7RFXRyHesbKTjiY=
 github.com/IBM-Cloud/ibm-cloud-cli-sdk v0.5.3/go.mod h1:RiUvKuHKTBmBApDMUQzBL14pQUGKcx/IioKQPIcRQjs=

--- a/ibm/service/kubernetes/data_source_ibm_container_cluster.go
+++ b/ibm/service/kubernetes/data_source_ibm_container_cluster.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2017, 2021 All Rights Reserved.
+// Copyright IBM Corp. 2017, 2022 All Rights Reserved.
 // Licensed under the Mozilla Public License v2.0
 
 package kubernetes

--- a/ibm/service/kubernetes/data_source_ibm_container_cluster.go
+++ b/ibm/service/kubernetes/data_source_ibm_container_cluster.go
@@ -311,6 +311,11 @@ func DataSourceIBMContainerCluster() *schema.Resource {
 				Computed:    true,
 				Description: "email id of the key owner",
 			},
+			"image_security_enforcement": {
+				Type:        schema.TypeBool,
+				Computed:    true,
+				Description: "True if image security enforcement is enabled",
+			},
 			flex.ResourceControllerURL: {
 				Type:        schema.TypeString,
 				Computed:    true,
@@ -442,6 +447,7 @@ func dataSourceIBMContainerClusterRead(d *schema.ResourceData, meta interface{})
 	d.Set("api_key_id", apikeyConfig.ID)
 	d.Set("api_key_owner_name", apikeyConfig.Name)
 	d.Set("api_key_owner_email", apikeyConfig.Email)
+	d.Set("image_security_enforcement", clusterFields.ImageSecurityEnabled)
 	d.Set(flex.ResourceName, clusterFields.Name)
 	d.Set(flex.ResourceCRN, clusterFields.CRN)
 	d.Set(flex.ResourceStatus, clusterFields.State)

--- a/ibm/service/kubernetes/data_source_ibm_container_vpc_cluster.go
+++ b/ibm/service/kubernetes/data_source_ibm_container_vpc_cluster.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2017, 2021 All Rights Reserved.
+// Copyright IBM Corp. 2017, 2022 All Rights Reserved.
 // Licensed under the Mozilla Public License v2.0
 
 package kubernetes

--- a/ibm/service/kubernetes/data_source_ibm_container_vpc_cluster.go
+++ b/ibm/service/kubernetes/data_source_ibm_container_vpc_cluster.go
@@ -255,7 +255,11 @@ func DataSourceIBMContainerVPCCluster() *schema.Resource {
 				Computed:    true,
 				Description: "email id of the key owner",
 			},
-
+			"image_security_enforcement": {
+				Type:        schema.TypeBool,
+				Computed:    true,
+				Description: "True if image security enforcement is enabled",
+			},
 			flex.ResourceControllerURL: {
 				Type:        schema.TypeString,
 				Computed:    true,
@@ -402,6 +406,7 @@ func dataSourceIBMContainerClusterVPCRead(d *schema.ResourceData, meta interface
 			d.Set("api_key_owner_email", apikeyConfig.Email)
 		}
 	}
+	d.Set("image_security_enforcement", cls.ImageSecurityEnabled)
 	d.Set(flex.ResourceControllerURL, controller+"/kubernetes/clusters")
 	d.Set(flex.ResourceName, cls.Name)
 	d.Set(flex.ResourceCRN, cls.CRN)

--- a/ibm/service/kubernetes/resource_ibm_container_cluster.go
+++ b/ibm/service/kubernetes/resource_ibm_container_cluster.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2017, 2021 All Rights Reserved.
+// Copyright IBM Corp. 2017, 2022 All Rights Reserved.
 // Licensed under the Mozilla Public License v2.0
 
 package kubernetes

--- a/ibm/service/kubernetes/resource_ibm_container_cluster.go
+++ b/ibm/service/kubernetes/resource_ibm_container_cluster.go
@@ -575,7 +575,12 @@ func ResourceIBMContainerCluster() *schema.Resource {
 				Computed:    true,
 				Description: "CRN of resource instance",
 			},
-
+			"image_security_enforcement": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Default:     false,
+				Description: "Set true to enable image security enforcement policies",
+			},
 			flex.ResourceControllerURL: {
 				Type:        schema.TypeString,
 				Computed:    true,
@@ -638,6 +643,10 @@ func resourceIBMContainerClusterCreate(d *schema.ResourceData, meta interface{})
 	if err != nil {
 		return err
 	}
+	csClientV2, err := meta.(conns.ClientSession).VpcContainerAPI()
+	if err != nil {
+		return err
+	}
 
 	name := d.Get("name").(string)
 	datacenter := d.Get("datacenter").(string)
@@ -655,6 +664,7 @@ func resourceIBMContainerClusterCreate(d *schema.ResourceData, meta interface{})
 	case hardwareShared:
 		hardware = isolationPublic
 	}
+	imageSecurityEnabled := d.Get("image_security_enforcement").(bool)
 
 	params := v1.ClusterCreateRequest{
 		Name:           name,
@@ -711,6 +721,17 @@ func resourceIBMContainerClusterCreate(d *schema.ResourceData, meta interface{})
 		return err
 	}
 	d.SetId(cls.ID)
+
+	targetEnvV2, err := getVpcClusterTargetHeader(d, meta)
+	if err != nil {
+		return err
+	}
+	if imageSecurityEnabled {
+		err = csClientV2.Clusters().EnableImageSecurityEnforcement(cls.ID, targetEnvV2)
+		if err != nil {
+			return err
+		}
+	}
 
 	_, err = waitForClusterMasterAvailable(d, meta)
 	if err != nil {
@@ -874,6 +895,7 @@ func resourceIBMContainerClusterRead(d *schema.ResourceData, meta interface{}) e
 	if err != nil {
 		return err
 	}
+	d.Set("image_security_enforcement", cls.ImageSecurityEnabled)
 	d.Set(flex.ResourceControllerURL, controller+"/kubernetes/clusters")
 	d.Set(flex.ResourceName, cls.Name)
 	d.Set(flex.ResourceCRN, cls.CRN)
@@ -889,7 +911,17 @@ func resourceIBMContainerClusterUpdate(d *schema.ResourceData, meta interface{})
 		return err
 	}
 
+	csClientV2, err := meta.(conns.ClientSession).VpcContainerAPI()
+	if err != nil {
+		return err
+	}
+
 	targetEnv, err := getClusterTargetHeader(d, meta)
+	if err != nil {
+		return err
+	}
+
+	targetEnvV2, err := getVpcClusterTargetHeader(d, meta)
 	if err != nil {
 		return err
 	}
@@ -1271,6 +1303,19 @@ func resourceIBMContainerClusterUpdate(d *schema.ResourceData, meta interface{})
 				"An error occured during update of instance (%s) tags: %s", clusterID, err)
 		}
 
+	}
+
+	if d.HasChange("image_security_enforcement") {
+		var imageSecurity bool
+		if v, ok := d.GetOk("image_security_enforcement"); ok {
+			imageSecurity = v.(bool)
+		}
+		if imageSecurity {
+			csClientV2.Clusters().EnableImageSecurityEnforcement(clusterID, targetEnvV2)
+		} else {
+			csClientV2.Clusters().DisableImageSecurityEnforcement(clusterID, targetEnvV2)
+		}
+		d.Set("image_security_enforcement", imageSecurity)
 	}
 
 	return resourceIBMContainerClusterRead(d, meta)

--- a/ibm/service/kubernetes/resource_ibm_container_cluster.go
+++ b/ibm/service/kubernetes/resource_ibm_container_cluster.go
@@ -1305,7 +1305,7 @@ func resourceIBMContainerClusterUpdate(d *schema.ResourceData, meta interface{})
 
 	}
 
-	if d.HasChange("image_security_enforcement") {
+	if d.HasChange("image_security_enforcement") && !d.IsNewResource() {
 		var imageSecurity bool
 		if v, ok := d.GetOk("image_security_enforcement"); ok {
 			imageSecurity = v.(bool)
@@ -1315,7 +1315,6 @@ func resourceIBMContainerClusterUpdate(d *schema.ResourceData, meta interface{})
 		} else {
 			csClientV2.Clusters().DisableImageSecurityEnforcement(clusterID, targetEnvV2)
 		}
-		d.Set("image_security_enforcement", imageSecurity)
 	}
 
 	return resourceIBMContainerClusterRead(d, meta)

--- a/ibm/service/kubernetes/resource_ibm_container_cluster_test.go
+++ b/ibm/service/kubernetes/resource_ibm_container_cluster_test.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2017, 2021 All Rights Reserved.
+// Copyright IBM Corp. 2017, 2022 All Rights Reserved.
 // Licensed under the Mozilla Public License v2.0
 
 package kubernetes_test

--- a/ibm/service/kubernetes/resource_ibm_container_cluster_test.go
+++ b/ibm/service/kubernetes/resource_ibm_container_cluster_test.go
@@ -184,6 +184,26 @@ func TestAccIBMContainerClusterPrivateAndPublicSubnet(t *testing.T) {
 	})
 }
 
+func TestAccIBMContainerClusterImageSecuritySetting(t *testing.T) {
+	clusterName := fmt.Sprintf("tf-cluster-%d", acctest.RandIntRange(10, 100))
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { acc.TestAccPreCheck(t) },
+		Providers:    acc.TestAccProviders,
+		CheckDestroy: testAccCheckIBMContainerClusterDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckIBMContainerClusterImageSecuritySetting(clusterName, "true"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(
+						"ibm_container_cluster.testacc_cluster", "name", clusterName),
+					resource.TestCheckResourceAttr(
+						"ibm_container_cluster.testacc_cluster", "image_security_enforcement", "true"),
+				),
+			},
+		},
+	})
+}
+
 func testAccCheckIBMContainerClusterDestroy(s *terraform.State) error {
 	csClient, err := acc.TestAccProvider.Meta().(conns.ClientSession).ContainerAPI()
 	if err != nil {
@@ -357,4 +377,18 @@ resource "ibm_container_cluster" "testacc_cluster" {
   no_subnet       = true
   subnet_id       = ["%s"]
 }	`, clusterName, acc.Datacenter, acc.MachineType, acc.PublicVlanID, acc.PrivateVlanID, acc.PrivateSubnetID)
+}
+
+func testAccCheckIBMContainerClusterImageSecuritySetting(clusterName string, imageSecuritySetting string) string {
+	return fmt.Sprintf(`
+
+resource "ibm_container_cluster" "testacc_cluster" {
+  name       = "%s"
+  datacenter = "%s"
+  machine_type    = "%s"
+  hardware        = "shared"
+  public_vlan_id  = "%s"
+  private_vlan_id = "%s"
+  image_security_enforcement = %s
+}	`, clusterName, acc.Datacenter, acc.MachineType, acc.PublicVlanID, acc.PrivateVlanID, imageSecuritySetting)
 }

--- a/ibm/service/kubernetes/resource_ibm_container_vpc_cluster.go
+++ b/ibm/service/kubernetes/resource_ibm_container_vpc_cluster.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2017, 2021 All Rights Reserved.
+// Copyright IBM Corp. 2017, 2022 All Rights Reserved.
 // Licensed under the Mozilla Public License v2.0
 
 package kubernetes

--- a/ibm/service/kubernetes/resource_ibm_container_vpc_cluster.go
+++ b/ibm/service/kubernetes/resource_ibm_container_vpc_cluster.go
@@ -844,7 +844,7 @@ func resourceIBMContainerVpcClusterUpdate(d *schema.ResourceData, meta interface
 		d.Set("force_delete_storage", forceDeleteStorage)
 	}
 
-	if d.HasChange("image_security_enforcement") {
+	if d.HasChange("image_security_enforcement") && !d.IsNewResource() {
 		var imageSecurity bool
 		if v, ok := d.GetOk("image_security_enforcement"); ok {
 			imageSecurity = v.(bool)
@@ -854,7 +854,6 @@ func resourceIBMContainerVpcClusterUpdate(d *schema.ResourceData, meta interface
 		} else {
 			csClient.Clusters().DisableImageSecurityEnforcement(clusterID, targetEnv)
 		}
-		d.Set("image_security_enforcement", imageSecurity)
 	}
 
 	return resourceIBMContainerVpcClusterRead(d, meta)

--- a/ibm/service/kubernetes/resource_ibm_container_vpc_cluster.go
+++ b/ibm/service/kubernetes/resource_ibm_container_vpc_cluster.go
@@ -366,6 +366,13 @@ func ResourceIBMContainerVpcCluster() *schema.Resource {
 				Sensitive: true,
 			},
 
+			"image_security_enforcement": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Default:     false,
+				Description: "Set true to enable image security enforcement policies",
+			},
+
 			flex.ResourceName: {
 				Type:        schema.TypeString,
 				Computed:    true,
@@ -442,6 +449,7 @@ func resourceIBMContainerVpcClusterCreate(d *schema.ResourceData, meta interface
 	vpcID := d.Get("vpc_id").(string)
 	flavor := d.Get("flavor").(string)
 	workerCount := d.Get("worker_count").(int)
+	imageSecurityEnabled := d.Get("image_security_enforcement").(bool)
 
 	// timeoutStage will define the timeout stage
 	var timeoutStage string
@@ -505,11 +513,19 @@ func resourceIBMContainerVpcClusterCreate(d *schema.ResourceData, meta interface
 	}
 
 	cls, err := csClient.Clusters().Create(params, targetEnv)
-
 	if err != nil {
 		return err
 	}
+
 	d.SetId(cls.ID)
+
+	if imageSecurityEnabled {
+		err = csClient.Clusters().EnableImageSecurityEnforcement(cls.ID, targetEnv)
+		if err != nil {
+			return err
+		}
+	}
+
 	switch strings.ToLower(timeoutStage) {
 
 	case strings.ToLower(masterNodeReady):
@@ -828,6 +844,19 @@ func resourceIBMContainerVpcClusterUpdate(d *schema.ResourceData, meta interface
 		d.Set("force_delete_storage", forceDeleteStorage)
 	}
 
+	if d.HasChange("image_security_enforcement") {
+		var imageSecurity bool
+		if v, ok := d.GetOk("image_security_enforcement"); ok {
+			imageSecurity = v.(bool)
+		}
+		if imageSecurity {
+			csClient.Clusters().EnableImageSecurityEnforcement(clusterID, targetEnv)
+		} else {
+			csClient.Clusters().DisableImageSecurityEnforcement(clusterID, targetEnv)
+		}
+		d.Set("image_security_enforcement", imageSecurity)
+	}
+
 	return resourceIBMContainerVpcClusterRead(d, meta)
 }
 func WaitForV2WorkerZoneDeleted(clusterNameOrID, workerPoolNameOrID, zone string, meta interface{}, timeout time.Duration, target v2.ClusterTargetHeader) (interface{}, error) {
@@ -942,6 +971,7 @@ func resourceIBMContainerVpcClusterRead(d *schema.ResourceData, meta interface{}
 	} else {
 		d.Set("disable_public_service_endpoint", true)
 	}
+	d.Set("image_security_enforcement", cls.ImageSecurityEnabled)
 
 	tags, err := flex.GetTagsUsingCRN(meta, cls.CRN)
 	if err != nil {

--- a/ibm/service/kubernetes/resource_ibm_container_vpc_cluster_test.go
+++ b/ibm/service/kubernetes/resource_ibm_container_vpc_cluster_test.go
@@ -102,6 +102,27 @@ func TestAccIBMContainerOpenshiftClusterBasic(t *testing.T) {
 		},
 	})
 }
+
+func TestAccIBMContainerVpcClusterImageSecuritySetting(t *testing.T) {
+	clusterName := fmt.Sprintf("tf-vpc-cluster-%d", acctest.RandIntRange(10, 100))
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { acc.TestAccPreCheck(t) },
+		Providers:    acc.TestAccProviders,
+		CheckDestroy: testAccCheckIBMContainerVpcClusterDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckIBMContainerVpcClusterImageSecuritySetting(clusterName, "true"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(
+						"ibm_container_vpc_cluster.testacc_vpc_cluster", "name", clusterName),
+					resource.TestCheckResourceAttr(
+						"ibm_container_vpc_cluster.testacc_vpc_cluster", "image_security_enforcement", "true"),
+				),
+			},
+		},
+	})
+}
+
 func testAccCheckIBMContainerVpcClusterDestroy(s *terraform.State) error {
 	csClient, err := acc.TestAccProvider.Meta().(conns.ClientSession).VpcContainerAPI()
 	if err != nil {
@@ -327,4 +348,20 @@ resource "ibm_container_vpc_cluster" "cluster" {
   }
   `, name, openshiftFlavour, openShiftworkerCount)
 
+}
+
+func testAccCheckIBMContainerVpcClusterImageSecuritySetting(name, setting string) string {
+	return fmt.Sprintf(`
+	resource "ibm_container_vpc_cluster" "testacc_vpc_cluster" {
+		name              = "%s"
+		vpc_id            = "%s"
+		flavor            = "bx2.2x8"
+		worker_count      = "1"
+		resource_group_id = "%s"
+		zones {
+			subnet_id = "%s"
+			name      = "us-south-1"
+		  }
+		image_security_enforcement = %s
+	  }`, name, acc.IksClusterVpcID, acc.IksClusterResourceGroupID, acc.SubnetID, setting)
 }

--- a/ibm/service/kubernetes/resource_ibm_container_vpc_cluster_test.go
+++ b/ibm/service/kubernetes/resource_ibm_container_vpc_cluster_test.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2017, 2021 All Rights Reserved.
+// Copyright IBM Corp. 2017, 2022 All Rights Reserved.
 // Licensed under the Mozilla Public License v2.0
 
 package kubernetes_test

--- a/website/docs/d/container_cluster.html.markdown
+++ b/website/docs/d/container_cluster.html.markdown
@@ -64,6 +64,7 @@ In addition to all argument reference list, you can access the following attribu
 - `bounded_services` - List of strings - A list of IBM Cloud services that are bounded to the cluster.
 - `crn` - (String) The CRN of the cluster.
 - `id` - (String) The unique identifier of the cluster.
+- `image_security_enforcement` - (Bool) Indicates if image security enforcement policies are enabled in a cluster.
 - `ingress_hostname` - (String) The Ingress host name.
 - `ingress_secret` - (String) The name of the Ingress secret.
 - `name` - (String) The name of the cluster.

--- a/website/docs/d/container_vpc_cluster.html.markdown
+++ b/website/docs/d/container_vpc_cluster.html.markdown
@@ -46,6 +46,7 @@ In addition to all argument reference list, you can access the following attribu
 - `crn` - (String) The CRN of the cluster.
 - `health` - (String) The health of the cluster master.
 - `id` - (String) The unique identifier of the cluster.
+- `image_security_enforcement` - (Bool) Indicates if image security enforcement policies are enabled in a cluster.
 - `ingress_hostname`-  (String) The hostname that was assigned to your Ingress subdomain. 
 - `ingress_secret` - (String) The name of the Kubernetes secret that was created for your Ingress subdomain.
 - `kube_version` - (String) The Kubernetes version of the cluster, including the major.minor version.

--- a/website/docs/r/container_cluster.html.markdown
+++ b/website/docs/r/container_cluster.html.markdown
@@ -201,6 +201,7 @@ Review the argument references that you can specify for your resource.
   2. Set this argument to `cloud_pak` only if you use this cluster with a Cloud Pak that has an OpenShift entitlement.
 - `force_delete_storage` - (Optional, Bool) If set to **true**,force the removal of persistent storage associated with the cluster during cluster deletion. Default value is **false**. **NOTE** If `force_delete_storage` parameter is used after provisioning the cluster, then, you need to execute `terraform apply` before `terraform destroy` for `force_delete_storage` parameter to take effect.
 - `hardware` - (Optional, Forces new resource, String) The level of hardware isolation for your worker node. Use `dedicated` to have available physical resources dedicated to you only, or `shared` to allow physical resources to be shared with other IBM customers. This option is available for virtual machine worker node flavors only.
+- `image_security_enforcement` - (Optional, Bool) Set to **true** to enable image security enforcement policies in a cluster.
 - `gateway_enabled` - (Optional, Bool) Set to **true** if you want to automatically create a gateway-enabled cluster. If `gateway_enabled` is set to **true**, then `private_service_endpoint` must be set to **true** at the same time.
 - `kms_config` - (Optional, List) Used to attach a Key Protect instance to a cluster. Nested `kms_config` block have `instance_id`, `crk_id`, `private_endpoint` structure.
 

--- a/website/docs/r/container_vpc_cluster.html.markdown
+++ b/website/docs/r/container_vpc_cluster.html.markdown
@@ -156,6 +156,7 @@ Review the argument references that you can specify for your resource.
 - `entitlement` - (Optional, String) Entitlement reduces additional OCP Licence cost in OpenShift clusters. Use Cloud Pak with OCP Licence entitlement to create the OpenShift cluster. **Note** <ul><li> It is set only when the first time creation of the cluster, further modifications are not impacted. </li></ul> <ul><li> Set this argument to `cloud_pak` only if you use the cluster with a Cloud Pak that has an OpenShift entitlement.</li></ul>.
 - `force_delete_storage` - (Optional, Bool) If set to **true**,force the removal of persistent storage associated with the cluster during cluster deletion. Default value is **false**. **Note** If `force_delete_storage` parameter is used after provisioning the cluster, then, you need to execute `terraform apply` before `terraform destroy` for `force_delete_storage` parameter to take effect.
 - `flavor` - (Required, Forces new resource, String) The flavor of the VPC worker node that you want to use.
+- `image_security_enforcement` - (Optional, Bool) Set to **true** to enable image security enforcement policies in a cluster.
 - `name` - (Required, Forces new resource, String) The name of the cluster.
 - `kms_config` - (Optional, String) Use to attach a Key Protect instance to a cluster. Nested `kms_config` block has an `instance_id`, `crk_id`, `private_endpoint`.
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/IBM-Cloud/terraform-provider-ibm/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Output from acceptance testing:

```
=== RUN   TestAccIBMContainerClusterImageSecuritySetting
--- PASS: TestAccIBMContainerClusterImageSecuritySetting (5032.82s)
PASS
ok      github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/kubernetes    5033.837s

=== RUN   TestAccIBMContainerVpcClusterImageSecuritySetting
--- PASS: TestAccIBMContainerVpcClusterImageSecuritySetting (4837.91s)
PASS
ok      github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/kubernetes    4843.296s
```
