### PR TITLE
Add support to use the new IAMAuthenticatior for token

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "go.sum|^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2022-01-17T16:39:02Z",
+  "generated_at": "2022-02-04T06:19:16Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -624,15 +624,23 @@
         "hashed_secret": "c427f185ddcb2440be9b77c8e45f1cd487a2e790",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1275,
+        "line_number": 1268,
         "type": "Base64 High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "1f7e33de15e22de9d2eaf502df284ed25ca40018",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 1336,
+        "type": "Secret Keyword",
         "verified_result": null
       },
       {
         "hashed_secret": "1f614c2eb6b3da22d89bd1b9fd47d7cb7c8fc670",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2816,
+        "line_number": 2827,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -640,7 +648,7 @@
         "hashed_secret": "7abfce65b8504403afc25c9790f358d513dfbcc6",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2829,
+        "line_number": 2840,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -648,7 +656,7 @@
         "hashed_secret": "0c2d85bf9a9b1579b16f220a4ea8c3d62b2e24b1",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2870,
+        "line_number": 2881,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -668,7 +676,7 @@
         "hashed_secret": "c8b6f5ef11b9223ac35a5663975a466ebe7ebba9",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1113,
+        "line_number": 1118,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -676,7 +684,7 @@
         "hashed_secret": "8abf4899c01104241510ba87685ad4de76b0c437",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1119,
+        "line_number": 1124,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -1566,7 +1574,7 @@
         "hashed_secret": "b732fb611fd46a38e8667f9972e0cde777fbe37f",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1257,
+        "line_number": 1289,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -2078,7 +2086,7 @@
       }
     ]
   },
-  "version": "0.13.1+ibm.40.dss",
+  "version": "0.13.1+ibm.47.dss",
   "word_list": {
     "file": null,
     "hash": null

--- a/ibm/conns/config.go
+++ b/ibm/conns/config.go
@@ -1322,10 +1322,20 @@ func (c *Config) ClientSession() (interface{}, error) {
 
 	var authenticator core.Authenticator
 
-	if c.BluemixAPIKey != "" {
-		authenticator = &core.IamAuthenticator{
-			ApiKey: c.BluemixAPIKey,
-			URL:    EnvFallBack([]string{"IBMCLOUD_IAM_API_ENDPOINT"}, iamURL) + "/identity/token",
+	if c.BluemixAPIKey != "" || sess.BluemixSession.Config.IAMRefreshToken != "" {
+		if c.BluemixAPIKey != "" {
+			authenticator = &core.IamAuthenticator{
+				ApiKey: c.BluemixAPIKey,
+				URL:    EnvFallBack([]string{"IBMCLOUD_IAM_API_ENDPOINT"}, iamURL),
+			}
+		} else {
+			// Construct the IamAuthenticator with the IAM refresh token.
+			authenticator = &core.IamAuthenticator{
+				RefreshToken: sess.BluemixSession.Config.IAMRefreshToken,
+				ClientId:     "bx",
+				ClientSecret: "bx",
+				URL:          EnvFallBack([]string{"IBMCLOUD_IAM_API_ENDPOINT"}, iamURL),
+			}
 		}
 	} else if strings.HasPrefix(sess.BluemixSession.Config.IAMAccessToken, "Bearer") {
 		authenticator = &core.BearerTokenAuthenticator{


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/IBM-Cloud/terraform-provider-ibm/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```
