### PR TITLE
Support storage pool and affinity while importing image

### DIFF
--- a/ibm/service/power/resource_ibm_pi_image.go
+++ b/ibm/service/power/resource_ibm_pi_image.go
@@ -27,7 +27,6 @@ func ResourceIBMPIImage() *schema.Resource {
 	return &schema.Resource{
 		CreateContext: resourceIBMPIImageCreate,
 		ReadContext:   resourceIBMPIImageRead,
-		UpdateContext: resourceIBMPIImageUpdate,
 		DeleteContext: resourceIBMPIImageDelete,
 		Importer:      &schema.ResourceImporter{},
 
@@ -41,12 +40,14 @@ func ResourceIBMPIImage() *schema.Resource {
 				Type:        schema.TypeString,
 				Required:    true,
 				Description: "PI cloud instance ID",
+				ForceNew:    true,
 			},
 			helpers.PIImageName: {
 				Type:             schema.TypeString,
 				Required:         true,
 				Description:      "Image name",
 				DiffSuppressFunc: flex.ApplyOnce,
+				ForceNew:         true,
 			},
 			helpers.PIImageId: {
 				Type:             schema.TypeString,
@@ -110,11 +111,53 @@ func ResourceIBMPIImage() *schema.Resource {
 				ForceNew:      true,
 			},
 			helpers.PIImageStorageType: {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "Type of storage",
+				ForceNew:    true,
+			},
+			helpers.PIImageStoragePool: {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "Storage pool where the image will be loaded, if provided then pi_image_storage_type and pi_affinity_policy will be ignored",
+				ForceNew:    true,
+			},
+			PIAffinityPolicy: {
 				Type:         schema.TypeString,
 				Optional:     true,
-				Description:  "Type of storage",
-				RequiredWith: []string{helpers.PIImageBucketName},
+				Description:  "Affinity policy for image; ignored if pi_image_storage_pool provided; for policy affinity requires one of pi_affinity_instance or pi_affinity_volume to be specified; for policy anti-affinity requires one of pi_anti_affinity_instances or pi_anti_affinity_volumes to be specified",
+				ValidateFunc: validate.ValidateAllowedStringValues([]string{"affinity", "anti-affinity"}),
 				ForceNew:     true,
+			},
+			PIAffinityVolume: {
+				Type:          schema.TypeString,
+				Optional:      true,
+				Description:   "Volume (ID or Name) to base storage affinity policy against; required if requesting affinity and pi_affinity_instance is not provided",
+				ConflictsWith: []string{PIAffinityInstance},
+				ForceNew:      true,
+			},
+			PIAffinityInstance: {
+				Type:          schema.TypeString,
+				Optional:      true,
+				Description:   "PVM Instance (ID or Name) to base storage affinity policy against; required if requesting storage affinity and pi_affinity_volume is not provided",
+				ConflictsWith: []string{PIAffinityVolume},
+				ForceNew:      true,
+			},
+			PIAntiAffinityVolumes: {
+				Type:          schema.TypeList,
+				Optional:      true,
+				Elem:          &schema.Schema{Type: schema.TypeString},
+				Description:   "List of volumes to base storage anti-affinity policy against; required if requesting anti-affinity and pi_anti_affinity_instances is not provided",
+				ConflictsWith: []string{PIAntiAffinityInstances},
+				ForceNew:      true,
+			},
+			PIAntiAffinityInstances: {
+				Type:          schema.TypeList,
+				Optional:      true,
+				Elem:          &schema.Schema{Type: schema.TypeString},
+				Description:   "List of pvmInstances to base storage anti-affinity policy against; required if requesting anti-affinity and pi_anti_affinity_volumes is not provided",
+				ConflictsWith: []string{PIAntiAffinityVolumes},
+				ForceNew:      true,
 			},
 
 			// Computed Attribute
@@ -168,7 +211,6 @@ func resourceIBMPIImageCreate(ctx context.Context, d *schema.ResourceData, meta 
 		bucketImageFileName := d.Get(helpers.PIImageBucketFileName).(string)
 		bucketRegion := d.Get(helpers.PIImageBucketRegion).(string)
 		bucketAccess := d.Get(helpers.PIImageBucketAccess).(string)
-		storageType := d.Get(helpers.PIImageStorageType).(string)
 
 		body := &models.CreateCosImageImportJob{
 			ImageName:     &imageName,
@@ -176,7 +218,6 @@ func resourceIBMPIImageCreate(ctx context.Context, d *schema.ResourceData, meta 
 			BucketAccess:  &bucketAccess,
 			ImageFilename: &bucketImageFileName,
 			Region:        &bucketRegion,
-			StorageType:   storageType,
 		}
 
 		if v, ok := d.GetOk(helpers.PIImageAccessKey); ok {
@@ -186,6 +227,39 @@ func resourceIBMPIImageCreate(ctx context.Context, d *schema.ResourceData, meta 
 			body.SecretKey = v.(string)
 		}
 
+		if v, ok := d.GetOk(helpers.PIImageStorageType); ok {
+			body.StorageType = v.(string)
+		}
+		if v, ok := d.GetOk(helpers.PIImageStoragePool); ok {
+			body.StoragePool = v.(string)
+		}
+		if ap, ok := d.GetOk(PIAffinityPolicy); ok {
+			policy := ap.(string)
+			affinity := &models.StorageAffinity{
+				AffinityPolicy: &policy,
+			}
+
+			if policy == "affinity" {
+				if av, ok := d.GetOk(PIAffinityVolume); ok {
+					afvol := av.(string)
+					affinity.AffinityVolume = &afvol
+				}
+				if ai, ok := d.GetOk(PIAffinityInstance); ok {
+					afins := ai.(string)
+					affinity.AffinityPVMInstance = &afins
+				}
+			} else {
+				if avs, ok := d.GetOk(PIAntiAffinityVolumes); ok {
+					afvols := flex.ExpandStringList(avs.([]interface{}))
+					affinity.AntiAffinityVolumes = afvols
+				}
+				if ais, ok := d.GetOk(PIAntiAffinityInstances); ok {
+					afinss := flex.ExpandStringList(ais.([]interface{}))
+					affinity.AntiAffinityPVMInstances = afinss
+				}
+			}
+			body.StorageAffinity = affinity
+		}
 		imageResponse, err := client.CreateCosImage(body)
 		if err != nil {
 			return diag.FromErr(err)
@@ -237,10 +311,6 @@ func resourceIBMPIImageRead(ctx context.Context, d *schema.ResourceData, meta in
 	d.Set("image_id", imageid)
 	d.Set(helpers.PICloudInstanceId, cloudInstanceID)
 
-	return nil
-}
-
-func resourceIBMPIImageUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	return nil
 }
 

--- a/website/docs/r/pi_image.html.markdown
+++ b/website/docs/r/pi_image.html.markdown
@@ -58,6 +58,11 @@ The   ibm_pi_image   provides the following [timeouts](https://www.terraform.io/
 ## Argument reference
 Review the argument references that you can specify for your resource. 
 
+- `pi_affinity_instance` - (Optional, String) PVM Instance (ID or Name) to base storage affinity policy against; required if requesting `affinity` and `pi_affinity_volume` is not provided.
+- `pi_affinity_policy` - (Optional, String) Affinity policy for image; ignored if `pi_image_storage_pool` provided; for policy affinity requires one of `pi_affinity_instance` or `pi_affinity_volume` to be specified; for policy anti-affinity requires one of `pi_anti_affinity_instances` or `pi_anti_affinity_volumes` to be specified; Allowable values: `affinity`, `anti-affinity`
+- `pi_affinity_volume`- (Optional, String) Volume (ID or Name) to base storage affinity policy against; required if requesting `affinity` and `pi_affinity_instance` is not provided.
+- `pi_anti_affinity_instances` - (Optional, String) List of pvmInstances to base storage anti-affinity policy against; required if requesting `anti-affinity` and `pi_anti_affinity_volumes` is not provided.
+- `pi_anti_affinity_volumes`- (Optional, String) List of volumes to base storage anti-affinity policy against; required if requesting `anti-affinity` and `pi_anti_affinity_instances` is not provided.
 - `pi_cloud_instance_id` - (Required, String) The GUID of the service instance associated with an account.
 - `pi_image_name` - (Required, String) The name of an image.
 - `pi_image_id` - (Optional, String) Image ID of existing source image; required for copy image.
@@ -73,8 +78,8 @@ Review the argument references that you can specify for your resource.
   - `pi_image_bucket_region` is required with `pi_image_bucket_name`
 - `pi_image_secret_key` - (Optional, String, Sensitive) Cloud Object Storage secret key; required for buckets with private access.
   - `pi_image_secret_key` is required with `pi_image_access_key`
-- `pi_image_storage_type` - (Optional, String) Type of storage.
-  - `pi_image_storage_type` is required with `pi_image_bucket_name`
+- `pi_image_storage_pool` - (Optional, String) Storage pool where the image will be loaded, if provided then `pi_image_storage_type` and `pi_affinity_policy` will be ignored.
+- `pi_image_storage_type` - (Optional, String) Type of storage. Will be ignored if `pi_image_storage_pool` or `pi_affinity_policy` is provided. If only using `pi_image_storage_type` for storage selection then the storage pool with the most available space will be selected.
 
 
 ## Attribute reference

--- a/website/docs/r/pi_instance.html.markdown
+++ b/website/docs/r/pi_instance.html.markdown
@@ -72,7 +72,11 @@ Review the argument references that you can specify for your resource.
 - `pi_memory` - (Optional, Float) The amount of memory that you want to assign to your instance in gigabytes.
   - Required when not creating SAP instances. Conflicts with `pi_sap_profile_id`.
 - `pi_migratable`- (Optional, Bool) Indicates the VM is migrated or not.
-- `pi_network` - (Required, List of Map) List of one or more networks to attach to the instance. The `pi_network` object structure is documented below.
+- `pi_network` - (Required, List of Map) List of one or more networks to attach to the instance.
+
+  The `pi_network` block supports:
+  - `network_id` - (String) The network ID to assign to the instance.
+  - `ip_address` - (String) The ip address to be used of this network.
 - `pi_pin_policy` - (Optional, String) Select the pinning policy for your Power Systems Virtual Server instance. Supported values are `soft`, `hard`, and `none`.    **Note** You can choose to soft pin (`soft`) or hard pin (`hard`) a virtual server to the physical host where it runs. When you soft pin an instance for high availability, the instance automatically migrates back to the original host once the host is back to its operating state. If the instance has a licensing restriction with the host, the hard pin option restricts the movement of the instance during remote restart, automated remote restart, DRO, and live partition migration. The default pinning policy is `none`. 
 - `pi_placement_group_id`- (Optional, String) The ID of the placement group that the instance is in if any or empty quotes `""` to also indicate it is not in a placement group.
 - `pi_processors` - (Optional, Float) The number of vCPUs to assign to the VM as visible within the guest Operating System.
@@ -93,10 +97,6 @@ Review the argument references that you can specify for your resource.
 - `pi_user_data` - (Optional, String) The base64 encoded form of the user data `cloud-init` to pass to the instance during creation. 
 - `pi_virtual_cores_assigned`  - (Optional, Integer) Specify the number of virtual cores to be assigned.
 - `pi_volume_ids` - (Optional, List of String) The list of volume IDs that you want to attach to the instance during creation.
-
-The `pi_network` block supports:
-  - `network_id` - (String) The network ID to assign to the instance.
-  - `ip_address` - (String) The ip address to be used of this network.
 
 ## Attribute reference
 In addition to all argument reference list, you can access the following attribute reference after your resource is created.


### PR DESCRIPTION
Signed-off-by: Yussuf Shaikh <yussuf.shaikh@ibm.com>

<!--- See what makes a good Pull Request at : https://github.com/IBM-Cloud/terraform-provider-ibm/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
=== RUN   TestAccIBMPIImagebasic
--- PASS: TestAccIBMPIImagebasic (220.52s)
=== RUN   TestAccIBMPIImageCOSPublicImport
--- PASS: TestAccIBMPIImageCOSPublicImport (1863.67s)
PASS

```
