### PR TITLE
Allow passing cloud connection while creating DHCP server

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.16
 require (
 	github.com/IBM-Cloud/bluemix-go v0.0.0-20220119131246-2af2dee48688
 	github.com/IBM-Cloud/container-services-go-sdk v0.0.0-20210705152127-41ca00fc9a62
-	github.com/IBM-Cloud/power-go-client v1.1.0
+	github.com/IBM-Cloud/power-go-client v1.1.2
 	github.com/IBM/apigateway-go-sdk v0.0.0-20210714141226-a5d5d49caaca
 	github.com/IBM/appconfiguration-go-admin-sdk v0.1.0
 	github.com/IBM/appid-management-go-sdk v0.0.0-20210908164609-dd0e0eaf732f

--- a/go.sum
+++ b/go.sum
@@ -42,8 +42,8 @@ github.com/IBM-Cloud/bluemix-go v0.0.0-20220119131246-2af2dee48688/go.mod h1:q0f
 github.com/IBM-Cloud/container-services-go-sdk v0.0.0-20210705152127-41ca00fc9a62 h1:MOkcr6qQGk4tY542ZJ1DggVh2WUP72EEyLB79llFVH8=
 github.com/IBM-Cloud/container-services-go-sdk v0.0.0-20210705152127-41ca00fc9a62/go.mod h1:xUQL9SGAjoZFd4GNjrjjtEpjpkgU7RFXRyHesbKTjiY=
 github.com/IBM-Cloud/ibm-cloud-cli-sdk v0.5.3/go.mod h1:RiUvKuHKTBmBApDMUQzBL14pQUGKcx/IioKQPIcRQjs=
-github.com/IBM-Cloud/power-go-client v1.1.0 h1:wHkQsiiHDG1/g4MnLiiZjFwu+fSqGxoLCrTEm4LFppY=
-github.com/IBM-Cloud/power-go-client v1.1.0/go.mod h1:Ky1qQYJ7WPS4OO3J80sTf+sMcBb92bulVwsDg1cPCuI=
+github.com/IBM-Cloud/power-go-client v1.1.2 h1:qTRRNQivJeBsizb4QGak6DEgJc2j7YFKL0O5Gy4pNgw=
+github.com/IBM-Cloud/power-go-client v1.1.2/go.mod h1:Ky1qQYJ7WPS4OO3J80sTf+sMcBb92bulVwsDg1cPCuI=
 github.com/IBM-Cloud/softlayer-go v1.0.5-tf h1:koUAyF9b6X78lLLruGYPSOmrfY2YcGYKOj/Ug9nbKNw=
 github.com/IBM-Cloud/softlayer-go v1.0.5-tf/go.mod h1:6HepcfAXROz0Rf63krk5hPZyHT6qyx2MNvYyHof7ik4=
 github.com/IBM/apigateway-go-sdk v0.0.0-20210714141226-a5d5d49caaca h1:crniVcf+YcmgF03NmmfonXwSQ73oJF+IohFYBwknMxs=

--- a/ibm/service/power/resource_ibm_pi_cloud_connection.go
+++ b/ibm/service/power/resource_ibm_pi_cloud_connection.go
@@ -71,6 +71,7 @@ func ResourceIBMPICloudConnection() *schema.Resource {
 			helpers.PICloudConnectionNetworks: {
 				Type:        schema.TypeSet,
 				Optional:    true,
+				Computed:    true,
 				Elem:        &schema.Schema{Type: schema.TypeString},
 				Description: "Set of Networks to attach to this cloud connection",
 			},

--- a/ibm/service/power/resource_ibm_pi_dhcp.go
+++ b/ibm/service/power/resource_ibm_pi_dhcp.go
@@ -17,6 +17,7 @@ import (
 	"github.com/IBM-Cloud/power-go-client/errors"
 	"github.com/IBM-Cloud/power-go-client/helpers"
 	"github.com/IBM-Cloud/power-go-client/power/client/p_cloud_service_d_h_c_p"
+	"github.com/IBM-Cloud/power-go-client/power/models"
 	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/conns"
 )
 
@@ -53,6 +54,13 @@ func ResourceIBMPIDhcp() *schema.Resource {
 				Description: "PI cloud instance ID",
 				ForceNew:    true,
 			},
+			helpers.PICloudConnectionId: {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "The cloud connection uuid to connect with DHCP private network",
+				ForceNew:    true,
+			},
+
 			//Computed Attributes
 			PIDhcpId: {
 				Type:        schema.TypeString,
@@ -100,8 +108,13 @@ func resourceIBMPIDhcpCreate(ctx context.Context, d *schema.ResourceData, meta i
 
 	cloudInstanceID := d.Get(helpers.PICloudInstanceId).(string)
 
+	body := &models.DHCPServerCreate{}
+	if c, ok := d.GetOk(helpers.PICloudConnectionId); ok {
+		body.CloudConnectionID = c.(string)
+	}
+
 	client := st.NewIBMPIDhcpClient(ctx, sess, cloudInstanceID)
-	dhcpServer, err := client.Create()
+	dhcpServer, err := client.Create(body)
 	if err != nil {
 		log.Printf("[DEBUG] create DHCP failed %v", err)
 		return diag.FromErr(err)

--- a/website/docs/r/pi_dhcp.html.markdown
+++ b/website/docs/r/pi_dhcp.html.markdown
@@ -48,6 +48,7 @@ The `ibm_pi_dhcp` provides the following [timeouts](https://www.terraform.io/doc
 Review the argument references that you can specify for your resource. 
 
 - `pi_cloud_instance_id` - (Required, String) The GUID of the service instance associated with an account.
+- `pi_cloud_connection_id` - (Optional, String) The Cloud Connection UUID to connect with DHCP private network.
 
 ## Attribute reference
 


### PR DESCRIPTION
Signed-off-by: Yussuf Shaikh <yussuf.shaikh@ibm.com>

<!--- See what makes a good Pull Request at : https://github.com/IBM-Cloud/terraform-provider-ibm/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
=== RUN   TestAccIBMPIDhcpWithCloudConnection
--- PASS: TestAccIBMPIDhcpWithCloudConnection (920.69s)
PASS

```
