### PR TITLE
Add gateway & ip_address_range attribute for network resource

### DIFF
--- a/ibm/service/power/resource_ibm_pi_network.go
+++ b/ibm/service/power/resource_ibm_pi_network.go
@@ -63,11 +63,10 @@ func ResourceIBMPINetwork() *schema.Resource {
 				Description: "PI network CIDR",
 			},
 			helpers.PINetworkGateway: {
-				Type:         schema.TypeString,
-				Optional:     true,
-				Computed:     true,
-				RequiredWith: []string{helpers.PINetworkIPAddressRange},
-				Description:  "PI network gateway",
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				Description: "PI network gateway",
 			},
 			helpers.PINetworkJumbo: {
 				Type:        schema.TypeBool,
@@ -81,11 +80,10 @@ func ResourceIBMPINetwork() *schema.Resource {
 				Description: "PI cloud instance ID",
 			},
 			helpers.PINetworkIPAddressRange: {
-				Type:         schema.TypeList,
-				Optional:     true,
-				Computed:     true,
-				RequiredWith: []string{helpers.PINetworkGateway},
-				Description:  "List of one or more ip address range(s)",
+				Type:        schema.TypeList,
+				Optional:    true,
+				Computed:    true,
+				Description: "List of one or more ip address range(s)",
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"ending_ip_address": {
@@ -156,10 +154,17 @@ func resourceIBMPINetworkCreate(ctx context.Context, d *schema.ResourceData, met
 			ipBodyRanges = getIPAddressRanges(ips.([]interface{}))
 		}
 
-		if len(gateway) == 0 || len(ipBodyRanges) == 0 {
-			log.Printf("[INFO] Either %v or %v is empty, calacultaing %v and %v",
-				helpers.PINetworkGateway, helpers.PINetworkIPAddressRange, helpers.PINetworkGateway, helpers.PINetworkIPAddressRange)
-			gateway, firstip, lastip, err = generateIPData(networkcidr)
+		if len(gateway) == 0 {
+			log.Printf("[INFO] %v is empty, calacultaing %v", helpers.PINetworkGateway, helpers.PINetworkGateway)
+			gateway, _, _, err = generateIPData(networkcidr)
+			if err != nil {
+				return diag.FromErr(err)
+			}
+		}
+
+		if len(ipBodyRanges) == 0 {
+			log.Printf("[INFO] %v is empty, calacultaing %v", helpers.PINetworkIPAddressRange, helpers.PINetworkIPAddressRange)
+			_, firstip, lastip, err = generateIPData(networkcidr)
 			if err != nil {
 				return diag.FromErr(err)
 			}

--- a/ibm/service/power/resource_ibm_pi_network_test.go
+++ b/ibm/service/power/resource_ibm_pi_network_test.go
@@ -32,6 +32,9 @@ func TestAccIBMPINetworkbasic(t *testing.T) {
 					testAccCheckIBMPINetworkExists("ibm_pi_network.power_networks"),
 					resource.TestCheckResourceAttr(
 						"ibm_pi_network.power_networks", "pi_network_name", name),
+					resource.TestCheckResourceAttrSet("ibm_pi_network.power_networks", "id"),
+					resource.TestCheckResourceAttrSet("ibm_pi_network.power_networks", "pi_gateway"),
+					resource.TestCheckResourceAttrSet("ibm_pi_network.power_networks", "pi_ipaddress_range.#"),
 				),
 			},
 			{
@@ -42,6 +45,9 @@ func TestAccIBMPINetworkbasic(t *testing.T) {
 						"ibm_pi_network.power_networks", "pi_network_name", name),
 					resource.TestCheckResourceAttr(
 						"ibm_pi_network.power_networks", "pi_dns.#", "1"),
+					resource.TestCheckResourceAttrSet("ibm_pi_network.power_networks", "id"),
+					resource.TestCheckResourceAttrSet("ibm_pi_network.power_networks", "pi_gateway"),
+					resource.TestCheckResourceAttrSet("ibm_pi_network.power_networks", "pi_ipaddress_range.#"),
 				),
 			},
 		},
@@ -74,9 +80,9 @@ func TestAccIBMPINetworkGatewaybasic(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"ibm_pi_network.power_networks", "pi_gateway", "192.168.17.2"),
 					resource.TestCheckResourceAttr(
-						"ibm_pi_network.power_networks", "pi_ipaddress_range.0.ending_ip_address", "192.168.17.254"),
+						"ibm_pi_network.power_networks", "pi_ipaddress_range.0.pi_ending_ip_address", "192.168.17.254"),
 					resource.TestCheckResourceAttr(
-						"ibm_pi_network.power_networks", "pi_ipaddress_range.0.starting_ip_address", "192.168.17.3"),
+						"ibm_pi_network.power_networks", "pi_ipaddress_range.0.pi_starting_ip_address", "192.168.17.3"),
 				),
 			},
 		},
@@ -178,8 +184,8 @@ func testAccCheckIBMPINetworkConfigGatewayUpdateDNS(name string) string {
 			pi_gateway           = "192.168.17.2"
 			pi_cidr              = "192.168.17.0/24"
 			pi_ipaddress_range {
-				ending_ip_address = "192.168.17.254"
-				starting_ip_address = "192.168.17.3"
+				pi_ending_ip_address = "192.168.17.254"
+				pi_starting_ip_address = "192.168.17.3"
 			}
 		}
 	`, acc.Pi_cloud_instance_id, name)

--- a/ibm/service/power/resource_ibm_pi_network_test.go
+++ b/ibm/service/power/resource_ibm_pi_network_test.go
@@ -47,6 +47,41 @@ func TestAccIBMPINetworkbasic(t *testing.T) {
 		},
 	})
 }
+func TestAccIBMPINetworkGatewaybasic(t *testing.T) {
+	name := fmt.Sprintf("tf-pi-network-%d", acctest.RandIntRange(10, 100))
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { acc.TestAccPreCheck(t) },
+		Providers:    acc.TestAccProviders,
+		CheckDestroy: testAccCheckIBMPINetworkDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckIBMPINetworkGatewayConfig(name),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckIBMPINetworkExists("ibm_pi_network.power_networks"),
+					resource.TestCheckResourceAttr(
+						"ibm_pi_network.power_networks", "pi_network_name", name),
+					resource.TestCheckResourceAttrSet("ibm_pi_network.power_networks", "pi_gateway"),
+					resource.TestCheckResourceAttrSet("ibm_pi_network.power_networks", "id"),
+					resource.TestCheckResourceAttrSet("ibm_pi_network.power_networks", "pi_ipaddress_range.#"),
+				),
+			},
+			{
+				Config: testAccCheckIBMPINetworkConfigGatewayUpdateDNS(name),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckIBMPINetworkExists("ibm_pi_network.power_networks"),
+					resource.TestCheckResourceAttr(
+						"ibm_pi_network.power_networks", "pi_network_name", name),
+					resource.TestCheckResourceAttr(
+						"ibm_pi_network.power_networks", "pi_gateway", "192.168.17.2"),
+					resource.TestCheckResourceAttr(
+						"ibm_pi_network.power_networks", "pi_ipaddress_range.0.ending_ip_address", "192.168.17.254"),
+					resource.TestCheckResourceAttr(
+						"ibm_pi_network.power_networks", "pi_ipaddress_range.0.starting_ip_address", "192.168.17.3"),
+				),
+			},
+		},
+	})
+}
 func testAccCheckIBMPINetworkDestroy(s *terraform.State) error {
 
 	sess, err := acc.TestAccProvider.Meta().(conns.ClientSession).IBMPISession()
@@ -118,6 +153,34 @@ func testAccCheckIBMPINetworkConfigUpdateDNS(name string) string {
 			pi_network_name      = "%s"
 			pi_network_type      = "pub-vlan"
 			pi_dns               = ["127.0.0.1"]
+		}
+	`, acc.Pi_cloud_instance_id, name)
+}
+
+func testAccCheckIBMPINetworkGatewayConfig(name string) string {
+	return fmt.Sprintf(`
+		resource "ibm_pi_network" "power_networks" {
+			pi_cloud_instance_id = "%s"
+			pi_network_name      = "%s"
+			pi_network_type      = "vlan"
+			pi_cidr              = "192.168.17.0/24"
+		}
+	`, acc.Pi_cloud_instance_id, name)
+}
+
+func testAccCheckIBMPINetworkConfigGatewayUpdateDNS(name string) string {
+	return fmt.Sprintf(`
+		resource "ibm_pi_network" "power_networks" {
+			pi_cloud_instance_id = "%s"
+			pi_network_name      = "%s"
+			pi_network_type      = "vlan"
+			pi_dns               = ["127.0.0.1"]
+			pi_gateway           = "192.168.17.2"
+			pi_cidr              = "192.168.17.0/24"
+			pi_ipaddress_range {
+				ending_ip_address = "192.168.17.254"
+				starting_ip_address = "192.168.17.3"
+			}
 		}
 	`, acc.Pi_cloud_instance_id, name)
 }

--- a/website/docs/r/pi_network.html.markdown
+++ b/website/docs/r/pi_network.html.markdown
@@ -61,9 +61,7 @@ Review the argument references that you can specify for your resource.
 - `pi_dns` - (Optional, Set of String) The DNS Servers for the network. Required for `vlan` network type.
 - `pi_cidr` - (Optional, String) The network CIDR. Required for `vlan` network type.
 - `pi_gateway` - (Optional, String) The gateway ip address.
-  - `pi_gateway` is required with `pi_ipaddress_range`
-- `pi_ipaddress_range` - (Optional, List of Map) List of one or more ip address range. The `pi_ipaddress_range` object structure is documented below.
-  - `pi_ipaddress_range` is required with `pi_gateway`. **Note** if any one of the `pi_gateway` or `pi_ipaddress_range` is found to be empty, it will ignore both the inputs and calculate the new values for `pi_gateway` and `pi_ipaddress_range`.
+- `pi_ipaddress_range` - (Optional, List of Map) List of one or more ip address range. The `pi_ipaddress_range` object structure is documented below. **Note** if the `pi_gateway` or `pi_ipaddress_range` is not provided, it will calculate the value based on CIDR respectively.
 - `pi_network_jumbo` - (Optional, Bool) MTU Jumbo option of the network.
 
 The `pi_ipaddress_range` block supports:

--- a/website/docs/r/pi_network.html.markdown
+++ b/website/docs/r/pi_network.html.markdown
@@ -21,6 +21,11 @@ resource "ibm_pi_network" "power_networks" {
   pi_network_type      = "vlan"
   pi_cidr              = "<Network in CIDR notation (192.168.0.0/24)>"
   pi_dns               = [<"DNS Servers">]
+  pi_gateway           = "192.168.0.1"
+  pi_ipaddress_range {
+    starting_ip_address  = "192.168.0.2"
+    ending_ip_address    = "192.168.0.254"
+  }
 }
 ```
 
@@ -55,7 +60,15 @@ Review the argument references that you can specify for your resource.
 - `pi_network_type` - (Required, String) The type of network that you want to create, such as `pub-vlan` or `vlan`.
 - `pi_dns` - (Optional, Set of String) The DNS Servers for the network. Required for `vlan` network type.
 - `pi_cidr` - (Optional, String) The network CIDR. Required for `vlan` network type.
+- `pi_gateway` - (Optional, String) The gateway ip address.
+  - `pi_gateway` is required with `pi_ipaddress_range`
+- `pi_ipaddress_range` - (Optional, List of Map) List of one or more ip address range. The `pi_ipaddress_range` object structure is documented below.
+  - `pi_ipaddress_range` is required with `pi_gateway`. **Note** if any one of the `pi_gateway` or `pi_ipaddress_range` is found to be empty, it will ignore both the inputs and calculate the new values for `pi_gateway` and `pi_ipaddress_range`.
 - `pi_network_jumbo` - (Optional, Bool) MTU Jumbo option of the network.
+
+The `pi_ipaddress_range` block supports:
+  - `ending_ip_address` - (Required, String) The ending ip address.
+  - `starting_ip_address` - (Required, String) The staring ip address.
 
 ## Attribute reference
 In addition to all argument reference list, you can access the following attribute reference after your resource is created.

--- a/website/docs/r/pi_network.html.markdown
+++ b/website/docs/r/pi_network.html.markdown
@@ -23,8 +23,8 @@ resource "ibm_pi_network" "power_networks" {
   pi_dns               = [<"DNS Servers">]
   pi_gateway           = "192.168.0.1"
   pi_ipaddress_range {
-    starting_ip_address  = "192.168.0.2"
-    ending_ip_address    = "192.168.0.254"
+    pi_starting_ip_address  = "192.168.0.2"
+    pi_ending_ip_address    = "192.168.0.254"
   }
 }
 ```
@@ -61,12 +61,11 @@ Review the argument references that you can specify for your resource.
 - `pi_dns` - (Optional, Set of String) The DNS Servers for the network. Required for `vlan` network type.
 - `pi_cidr` - (Optional, String) The network CIDR. Required for `vlan` network type.
 - `pi_gateway` - (Optional, String) The gateway ip address.
-- `pi_ipaddress_range` - (Optional, List of Map) List of one or more ip address range. The `pi_ipaddress_range` object structure is documented below. **Note** if the `pi_gateway` or `pi_ipaddress_range` is not provided, it will calculate the value based on CIDR respectively.
+- `pi_ipaddress_range` - (Optional, List of Map) List of one or more ip address range. The `pi_ipaddress_range` object structure is documented below. 
+  The `pi_ipaddress_range` block supports:
+  - `pi_ending_ip_address` - (Required, String) The ending ip address.
+  - `pi_starting_ip_address` - (Required, String) The staring ip address. **Note** if the `pi_gateway` or `pi_ipaddress_range` is not provided, it will calculate the value based on CIDR respectively.
 - `pi_network_jumbo` - (Optional, Bool) MTU Jumbo option of the network.
-
-The `pi_ipaddress_range` block supports:
-  - `ending_ip_address` - (Required, String) The ending ip address.
-  - `starting_ip_address` - (Required, String) The staring ip address.
 
 ## Attribute reference
 In addition to all argument reference list, you can access the following attribute reference after your resource is created.


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/IBM-Cloud/terraform-provider-ibm/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
=== RUN   TestAccIBMPINetworkbasic
--- PASS: TestAccIBMPINetworkbasic (48.84s)
PASS
=== RUN   TestAccIBMPINetworkGatewaybasic
--- PASS: TestAccIBMPINetworkGatewaybasic (54.00s)
PASS
...
```
