### PR TITLE
Add a check for "Deleted" status of the VPC worker pool

### DIFF
--- a/ibm/service/kubernetes/resource_ibm_container_vpc_worker_pool.go
+++ b/ibm/service/kubernetes/resource_ibm_container_vpc_worker_pool.go
@@ -531,6 +531,9 @@ func resourceIBMContainerVpcWorkerPoolExists(d *schema.ResourceData, meta interf
 		}
 		return false, fmt.Errorf("[ERROR] Error getting container vpc workerpool: %s", err)
 	}
+	if strings.Compare(workerPool.Lifecycle.ActualState, "deleted") == 0 {
+		return false, nil
+	}
 
 	return workerPool.ID == workerPoolID, nil
 }


### PR DESCRIPTION
Hello. This change has been added so that Terraform can detect when a workerk pool is removed, but its information is still returned if you check through the ID.

## Details
Even after deleting a worker pool, GetWorkerPool is not returned error, because the [API](ttps://containers.cloud.ibm.com/global/v2/vpc/getWorkerPool) continues to respond with 200 and pass JSON in this kind:
<details>

```json
{
  "id": "[PRIVATE DATA HIDDEN]-2f686a6",
  "poolName": "test-pool",
  "flavor": "bx2.4x16",
  "labels": {
    "ibm-cloud.kubernetes.io/worker-pool-id": "[PRIVATE DATA HIDDEN]-2f686a6",
    "test": "test"
  },
  "taints": null,
  "workerCount": 1,
  "isolation": "public",
  "provider": "vpc-gen2",
  "isBalanced": true,
  "autoscaleEnabled": false,
  "openshiftLicense": "",
  "lifecycle": {
    "desiredState": "deleted",
    "actualState": "deleted"
  },
  "zones": [],
  "vpcID": "[PRIVATE DATA HIDDEN]"
}
```

</details>

## Steps for reproduce
1. Creating a worker pool using Terraform:
<details>

```
# ibm_container_vpc_worker_pool.pool1[0] will be created
+ resource "ibm_container_vpc_worker_pool" "pool1" {
    + cluster                 = "test-cluster"
    + flavor                  = "bx2.4x16"
    + id                      = (known after apply)
    + labels                  = {
        + "test" = "test"
      }
    + resource_controller_url = (known after apply)
    + resource_group_id       = "[PRIVATE DATA HIDDEN]"
    + vpc_id                  = "[PRIVATE DATA HIDDEN]"
    + worker_count            = 1
    + worker_pool_id          = (known after apply)
    + worker_pool_name        = "test-pool"

    + timeouts {
        + create = "240m"
        + delete = "240m"
    }
    + zones {
        + name      = "us-east-1"
        + subnet_id = "[PRIVATE DATA HIDDEN]"
    }
}
```
</details>

2. List of the details of the created worker pool
<details>

```
Retrieving worker pool [PRIVATE DATA HIDDEN]-2f686a6 from cluster [PRIVATE DATA HIDDEN]...
OK

Name:               test-pool
ID:                 [PRIVATE DATA HIDDEN]-2f686a6
State:              active
Hardware:           shared
VPC:                [PRIVATE DATA HIDDEN]
Flavor:             bx2.4x16
Labels:             ibm-cloud.kubernetes.io/worker-pool-id=[PRIVATE DATA HIDDEN]-2f686a6,test=test
Workers per Zone:   1
Total Workers:      1

Zones
Zone        Workers   Subnets
us-east-1   1         [PRIVATE DATA HIDDEN]
```

</details>

3. Manually removing the worker pool
4. List of the details of the deleted worker pool
<details>

```
Retrieving worker pool [PRIVATE DATA HIDDEN]-2f686a6 from cluster [PRIVATE DATA HIDDEN]...
OK

Name:               test-pool
ID:                 [PRIVATE DATA HIDDEN]-2f686a6
State:              deleted
Hardware:           shared
VPC:                [PRIVATE DATA HIDDEN]
Flavor:             bx2.4x16
Labels:             ibm-cloud.kubernetes.io/worker-pool-id=[PRIVATE DATA HIDDEN]-2f686a6,test=test
Workers per Zone:   1
Total Workers:      0

Zones
Zone   Workers   Subnets
```

</details>

5. Getting a Terraform plan(note that the pool is deleted, but Terrform does not notice it):
<details>

```
# ibm_container_vpc_worker_pool.pool1[0] will be updated in-place
~ resource "ibm_container_vpc_worker_pool" "pool1" {
      id                      = "test-cluster/[PRIVATE DATA HIDDEN]-2f686a6"
      # (9 unchanged attributes hidden)
      + zones {
            + name      = "us-east-1"
            + subnet_id = "[PRIVATE DATA HIDDEN]"
      }
      # (1 unchanged block hidden)
}

Plan: 0 to add, 1 to change, 0 to destroy.
```

</details>

6. Trying to recreate the worker pool, get an error:
<details>

```
ibm_container_vpc_worker_pool.pool1[0]: Modifying... [id=[PRIVATE DATA HIDDEN]]

Error: Error adding zone to conatiner vpc cluster: Request failed with status code: 404, ServerErrorResponse:
{"incidentID":"[PRIVATE DATA HIDDEN]","code":"E5da2","description":
"The specified worker pool could not be found.","type":"Provisioning",
"recoveryCLI":"To list all worker pools in the cluster,
run 'ibmcloud ks worker-pools --cluster \u003ccluster_name_or_ID\u003e'."}

with ibm_container_vpc_worker_pool.pool1[0],
on main.tf line 16, in resource "ibm_container_vpc_worker_pool" "pool1":
16: resource "ibm_container_vpc_worker_pool" "pool1" {
```

</details>

## Affected versions
I tried `1.30.2` and `1.39.0-beta0`, but the results are the same.