### PR TITLE
IBM Security and Compliance Center Update(SCC) Admin Update

### DIFF
--- a/examples/ibm-scc/admin/main.tf
+++ b/examples/ibm-scc/admin/main.tf
@@ -4,7 +4,14 @@ provider "ibm" {
 
 // Update the current account settings
 resource "ibm_scc_account_settings" "ibm_scc_account_settings_instance" {
-  location_id = var.ibm_scc_account_settings_location_id
+  // Optional input of location
+  location {
+    location_id = "us"
+  }
+  // Optional input of event_notifications
+  event_notifications {
+    // instance_crn = "instance_crn"
+  }
 }
 
 // Read the current account location settings

--- a/ibm/provider/provider.go
+++ b/ibm/provider/provider.go
@@ -559,14 +559,15 @@ func Provider() *schema.Provider {
 			"ibm_atracker_endpoints": atracker.DataSourceIBMAtrackerEndpoints(),
 
 			//Security and Compliance Center
-			"ibm_scc_si_providers":      scc.DataSourceIBMSccSiProviders(),
-			"ibm_scc_si_note":           scc.DataSourceIBMSccSiNote(),
-			"ibm_scc_si_notes":          scc.DataSourceIBMSccSiNotes(),
-			"ibm_scc_account_location":  scc.DataSourceIBMSccAccountLocation(),
-			"ibm_scc_account_locations": scc.DataSourceIBMSccAccountLocations(),
-			"ibm_scc_account_settings":  scc.DataSourceIBMSccAccountLocationSettings(),
-			"ibm_scc_si_occurrence":     scc.DataSourceIBMSccSiOccurrence(),
-			"ibm_scc_si_occurrences":    scc.DataSourceIBMSccSiOccurrences(),
+			"ibm_scc_si_providers":                  scc.DataSourceIBMSccSiProviders(),
+			"ibm_scc_si_note":                       scc.DataSourceIBMSccSiNote(),
+			"ibm_scc_si_notes":                      scc.DataSourceIBMSccSiNotes(),
+			"ibm_scc_account_location":              scc.DataSourceIBMSccAccountLocation(),
+			"ibm_scc_account_locations":             scc.DataSourceIBMSccAccountLocations(),
+			"ibm_scc_account_location_settings":     scc.DataSourceIBMSccAccountLocationSettings(),
+			"ibm_scc_account_notification_settings": scc.DataSourceIBMSccNotificationSettings(),
+			"ibm_scc_si_occurrence":                 scc.DataSourceIBMSccSiOccurrence(),
+			"ibm_scc_si_occurrences":                scc.DataSourceIBMSccSiOccurrences(),
 
 			// Compliance Posture Management
 			"ibm_scc_posture_scopes":            scc.DataSourceIBMSccPostureScopes(),

--- a/ibm/service/scc/data_source_ibm_scc_account_location_settings.go
+++ b/ibm/service/scc/data_source_ibm_scc_account_location_settings.go
@@ -52,6 +52,7 @@ func dataSourceIbmSccAccountLocationSettingsRead(context context.Context, d *sch
 	}
 
 	locationSettings := accountSettings.Location
+	d.SetId(*accountSettings.Location.ID)
 
 	if err = d.Set("id", locationSettings.ID); err != nil {
 		return diag.FromErr(fmt.Errorf("Error setting id: %s", err))

--- a/ibm/service/scc/data_source_ibm_scc_account_location_settings.go
+++ b/ibm/service/scc/data_source_ibm_scc_account_location_settings.go
@@ -21,7 +21,7 @@ func DataSourceIBMSccAccountLocationSettings() *schema.Resource {
 		ReadContext: dataSourceIbmSccAccountLocationSettingsRead,
 
 		Schema: map[string]*schema.Schema{
-			"location_id": &schema.Schema{
+			"id": &schema.Schema{
 				Type:        schema.TypeString,
 				Computed:    true,
 				Description: "The programatic ID of the location that you want to work in.",
@@ -53,7 +53,7 @@ func dataSourceIbmSccAccountLocationSettingsRead(context context.Context, d *sch
 
 	locationSettings := accountSettings.Location
 
-	if err = d.Set("location_id", locationSettings.ID); err != nil {
+	if err = d.Set("id", locationSettings.ID); err != nil {
 		return diag.FromErr(fmt.Errorf("Error setting id: %s", err))
 	}
 

--- a/ibm/service/scc/data_source_ibm_scc_account_location_settings_test.go
+++ b/ibm/service/scc/data_source_ibm_scc_account_location_settings_test.go
@@ -19,7 +19,7 @@ func TestAccIbmSccAccountLocationSettingsDataSourceBasic(t *testing.T) {
 			resource.TestStep{
 				Config: testAccCheckIbmSccAccountLocationSettingsDataSourceConfigBasic(),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttrSet("data.ibm_scc_account_location_settings.scc_account_location_settings", "location_id"),
+					resource.TestCheckResourceAttrSet("data.ibm_scc_account_location_settings.scc_account_location_settings", "id"),
 				),
 			},
 		},

--- a/ibm/service/scc/data_source_ibm_scc_account_location_settings_test.go
+++ b/ibm/service/scc/data_source_ibm_scc_account_location_settings_test.go
@@ -1,13 +1,13 @@
-// Copyright IBM Corp. 2021 All Rights Reserved.
+// Copyright IBM Corp. 2022 All Rights Reserved.
 // Licensed under the Mozilla Public License v2.0
 
 package scc_test
 
 import (
+	"fmt"
 	"testing"
 
 	acc "github.com/IBM-Cloud/terraform-provider-ibm/ibm/acctest"
-
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 )
 
@@ -16,11 +16,10 @@ func TestAccIbmSccAccountLocationSettingsDataSourceBasic(t *testing.T) {
 		PreCheck:  func() { acc.TestAccPreCheck(t) },
 		Providers: acc.TestAccProviders,
 		Steps: []resource.TestStep{
-			{
+			resource.TestStep{
 				Config: testAccCheckIbmSccAccountLocationSettingsDataSourceConfigBasic(),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttrSet("data.ibm_scc_account_settings.scc_account_location_settings", "id"),
-					resource.TestCheckResourceAttrSet("data.ibm_scc_account_settings.scc_account_location_settings", "id"),
+					resource.TestCheckResourceAttrSet("data.ibm_scc_account_location_settings.scc_account_location_settings", "location_id"),
 				),
 			},
 		},
@@ -28,8 +27,8 @@ func TestAccIbmSccAccountLocationSettingsDataSourceBasic(t *testing.T) {
 }
 
 func testAccCheckIbmSccAccountLocationSettingsDataSourceConfigBasic() string {
-	return `
-		data "ibm_scc_account_settings" "scc_account_location_settings" {
+	return fmt.Sprintf(`
+		data "ibm_scc_account_location_settings" "scc_account_location_settings" {
 		}
-	`
+	`)
 }

--- a/ibm/service/scc/data_source_ibm_scc_account_locations.go
+++ b/ibm/service/scc/data_source_ibm_scc_account_locations.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2021 All Rights Reserved.
+// Copyright IBM Corp. 2022 All Rights Reserved.
 // Licensed under the Mozilla Public License v2.0
 
 package scc
@@ -21,52 +21,52 @@ func DataSourceIBMSccAccountLocations() *schema.Resource {
 		ReadContext: dataSourceIbmSccAccountLocationsRead,
 
 		Schema: map[string]*schema.Schema{
-			"locations": {
+			"locations": &schema.Schema{
 				Type:     schema.TypeList,
 				Computed: true,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
-						"id": {
+						"id": &schema.Schema{
 							Type:        schema.TypeString,
 							Computed:    true,
 							Description: "The programatic ID of the location that you want to work in.",
 						},
-						"main_endpoint_url": {
+						"main_endpoint_url": &schema.Schema{
 							Type:        schema.TypeString,
 							Computed:    true,
 							Description: "The base URL for the service.",
 						},
-						"governance_endpoint_url": {
+						"governance_endpoint_url": &schema.Schema{
 							Type:        schema.TypeString,
 							Computed:    true,
 							Description: "The endpoint that is used to call the Configuration Governance APIs.",
 						},
-						"results_endpoint_url": {
+						"results_endpoint_url": &schema.Schema{
 							Type:        schema.TypeString,
 							Computed:    true,
 							Description: "The endpoint that is used to get the results for the Configuration Governance component.",
 						},
-						"compliance_endpoint_url": {
+						"compliance_endpoint_url": &schema.Schema{
 							Type:        schema.TypeString,
 							Computed:    true,
 							Description: "The endpoint that is used to call the Posture Management APIs.",
 						},
-						"analytics_endpoint_url": {
+						"analytics_endpoint_url": &schema.Schema{
 							Type:        schema.TypeString,
 							Computed:    true,
 							Description: "The endpoint that is used to generate analytics for the Posture Management component.",
 						},
-						"si_endpoint_url": {
+						"si_endpoint_url": &schema.Schema{
 							Type:        schema.TypeString,
 							Computed:    true,
 							Description: "The endpoint that is used to call the Security Insights APIs.",
 						},
-						"regions": {
+						"regions": &schema.Schema{
 							Type:     schema.TypeList,
 							Computed: true,
 							Elem: &schema.Resource{
 								Schema: map[string]*schema.Schema{
-									"id": {
+									"id": &schema.Schema{
 										Type:        schema.TypeString,
 										Computed:    true,
 										Description: "The programatic ID of the available regions.",
@@ -97,11 +97,18 @@ func dataSourceIbmSccAccountLocationsRead(context context.Context, d *schema.Res
 
 	d.SetId(dataSourceIbmSccAccountLocationsID(d))
 
+	locations_lst := []map[string]interface{}{}
 	if locations.Locations != nil {
-		err = d.Set("locations", dataSourceLocationsFlattenLocations(locations.Locations))
-		if err != nil {
-			return diag.FromErr(fmt.Errorf("[ERROR] Error setting locations %s", err))
+		for _, modelItem := range locations.Locations {
+			modelMap, err := dataSourceIbmSccAccountLocationsLocationToMap(&modelItem)
+			if err != nil {
+				return diag.FromErr(err)
+			}
+			locations_lst = append(locations_lst, modelMap)
 		}
+	}
+	if err = d.Set("locations", locations_lst); err != nil {
+		return diag.FromErr(fmt.Errorf("Error setting locations %s", err))
 	}
 
 	return nil
@@ -112,55 +119,47 @@ func dataSourceIbmSccAccountLocationsID(d *schema.ResourceData) string {
 	return time.Now().UTC().String()
 }
 
-func dataSourceLocationsFlattenLocations(result []adminserviceapiv1.Location) (locations []map[string]interface{}) {
-	for _, locationsItem := range result {
-		locations = append(locations, dataSourceLocationsLocationsToMap(locationsItem))
+func dataSourceIbmSccAccountLocationsLocationToMap(model *adminserviceapiv1.Location) (map[string]interface{}, error) {
+	modelMap := make(map[string]interface{})
+	if model.ID != nil {
+		modelMap["id"] = *model.ID
 	}
-
-	return locations
-}
-
-func dataSourceLocationsLocationsToMap(locationsItem adminserviceapiv1.Location) (locationsMap map[string]interface{}) {
-	locationsMap = map[string]interface{}{}
-
-	if locationsItem.ID != nil {
-		locationsMap["id"] = locationsItem.ID
+	if model.MainEndpointURL != nil {
+		modelMap["main_endpoint_url"] = *model.MainEndpointURL
 	}
-	if locationsItem.MainEndpointURL != nil {
-		locationsMap["main_endpoint_url"] = locationsItem.MainEndpointURL
+	if model.GovernanceEndpointURL != nil {
+		modelMap["governance_endpoint_url"] = *model.GovernanceEndpointURL
 	}
-	if locationsItem.GovernanceEndpointURL != nil {
-		locationsMap["governance_endpoint_url"] = locationsItem.GovernanceEndpointURL
+	if model.ResultsEndpointURL != nil {
+		modelMap["results_endpoint_url"] = *model.ResultsEndpointURL
 	}
-	if locationsItem.ResultsEndpointURL != nil {
-		locationsMap["results_endpoint_url"] = locationsItem.ResultsEndpointURL
+	if model.ComplianceEndpointURL != nil {
+		modelMap["compliance_endpoint_url"] = *model.ComplianceEndpointURL
 	}
-	if locationsItem.ComplianceEndpointURL != nil {
-		locationsMap["compliance_endpoint_url"] = locationsItem.ComplianceEndpointURL
+	if model.AnalyticsEndpointURL != nil {
+		modelMap["analytics_endpoint_url"] = *model.AnalyticsEndpointURL
 	}
-	if locationsItem.AnalyticsEndpointURL != nil {
-		locationsMap["analytics_endpoint_url"] = locationsItem.AnalyticsEndpointURL
+	if model.SiEndpointURL != nil {
+		modelMap["si_endpoint_url"] = *model.SiEndpointURL
 	}
-	if locationsItem.SiEndpointURL != nil {
-		locationsMap["si_endpoint_url"] = locationsItem.SiEndpointURL
-	}
-	if locationsItem.Regions != nil {
-		regionsList := []map[string]interface{}{}
-		for _, regionsItem := range locationsItem.Regions {
-			regionsList = append(regionsList, dataSourceLocationsLocationsRegionsToMap(regionsItem))
+	if model.Regions != nil {
+		regions := []map[string]interface{}{}
+		for _, regionsItem := range model.Regions {
+			regionsItemMap, err := dataSourceIbmSccAccountLocationsRegionToMap(&regionsItem)
+			if err != nil {
+				return modelMap, err
+			}
+			regions = append(regions, regionsItemMap)
 		}
-		locationsMap["regions"] = regionsList
+		modelMap["regions"] = regions
 	}
-
-	return locationsMap
+	return modelMap, nil
 }
 
-func dataSourceLocationsLocationsRegionsToMap(regionsItem adminserviceapiv1.Region) (regionsMap map[string]interface{}) {
-	regionsMap = map[string]interface{}{}
-
-	if regionsItem.ID != nil {
-		regionsMap["id"] = regionsItem.ID
+func dataSourceIbmSccAccountLocationsRegionToMap(model *adminserviceapiv1.Region) (map[string]interface{}, error) {
+	modelMap := make(map[string]interface{})
+	if model.ID != nil {
+		modelMap["id"] = *model.ID
 	}
-
-	return regionsMap
+	return modelMap, nil
 }

--- a/ibm/service/scc/data_source_ibm_scc_account_locations_test.go
+++ b/ibm/service/scc/data_source_ibm_scc_account_locations_test.go
@@ -19,7 +19,6 @@ func TestAccIbmSccAccountLocationsDataSourceBasic(t *testing.T) {
 			resource.TestStep{
 				Config: testAccCheckIbmSccAccountLocationsDataSourceConfigBasic(),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttrSet("data.ibm_scc_account_locations.scc_account_locations", "id"),
 					resource.TestCheckResourceAttrSet("data.ibm_scc_account_locations.scc_account_locations", "locations.#"),
 				),
 			},

--- a/ibm/service/scc/data_source_ibm_scc_account_notification_settings.go
+++ b/ibm/service/scc/data_source_ibm_scc_account_notification_settings.go
@@ -55,9 +55,8 @@ func dataSourceIbmSccAccountNotificationSettingsRead(context context.Context, d 
 	if err = d.Set("instance_crn", notificationsSettings.InstanceCrn); err != nil {
 		return diag.FromErr(fmt.Errorf("Error setting instance_crn: %s", err))
 	}
-	if d.HasChanges() {
-		d.SetId(dataSourceIbmSccAccountNotificationSettingsID(d))
-	}
+
+	d.SetId("scc_admin_notification_settings")
 
 	return nil
 }

--- a/ibm/service/scc/data_source_ibm_scc_account_notification_settings.go
+++ b/ibm/service/scc/data_source_ibm_scc_account_notification_settings.go
@@ -16,21 +16,21 @@ import (
 	"github.com/IBM/scc-go-sdk/v3/adminserviceapiv1"
 )
 
-func DataSourceIBMSccAccountLocationSettings() *schema.Resource {
+func DataSourceIBMSccNotificationSettings() *schema.Resource {
 	return &schema.Resource{
-		ReadContext: dataSourceIbmSccAccountLocationSettingsRead,
+		ReadContext: dataSourceIbmSccAccountNotificationSettingsRead,
 
 		Schema: map[string]*schema.Schema{
-			"location_id": &schema.Schema{
+			"instance_crn": &schema.Schema{
 				Type:        schema.TypeString,
 				Computed:    true,
-				Description: "The programatic ID of the location that you want to work in.",
+				Description: "The Cloud Resource Name (CRN) of the Event Notifications instance that you want to connect.",
 			},
 		},
 	}
 }
 
-func dataSourceIbmSccAccountLocationSettingsRead(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func dataSourceIbmSccAccountNotificationSettingsRead(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	adminServiceApiClient, err := meta.(conns.ClientSession).AdminServiceApiV1()
 	if err != nil {
 		return diag.FromErr(err)
@@ -50,20 +50,19 @@ func dataSourceIbmSccAccountLocationSettingsRead(context context.Context, d *sch
 		log.Printf("[DEBUG] GetSettingsWithContext failed %s\n%s", err, response)
 		return diag.FromErr(fmt.Errorf("GetSettingsWithContext failed %s\n%s", err, response))
 	}
+	notificationsSettings := accountSettings.EventNotifications
 
-	locationSettings := accountSettings.Location
-
-	if err = d.Set("location_id", locationSettings.ID); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting id: %s", err))
+	if err = d.Set("instance_crn", notificationsSettings.InstanceCrn); err != nil {
+		return diag.FromErr(fmt.Errorf("Error setting instance_crn: %s", err))
 	}
-
 	if d.HasChanges() {
-		d.SetId(dataSourceIbmSccAccountLocationSettingsID(d))
+		d.SetId(dataSourceIbmSccAccountNotificationSettingsID(d))
 	}
 
 	return nil
 }
 
-func dataSourceIbmSccAccountLocationSettingsID(d *schema.ResourceData) string {
+// dataSourceIbmSccAccountNotificationSettingsID returns a reasonable ID for the list.
+func dataSourceIbmSccAccountNotificationSettingsID(d *schema.ResourceData) string {
 	return time.Now().UTC().String()
 }

--- a/ibm/service/scc/data_source_ibm_scc_account_notification_settings_test.go
+++ b/ibm/service/scc/data_source_ibm_scc_account_notification_settings_test.go
@@ -11,25 +11,24 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 )
 
-func TestAccIbmSccAccountLocationsDataSourceBasic(t *testing.T) {
+func TestAccIbmSccAccountNotificationSettingsDataSourceBasic(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:  func() { acc.TestAccPreCheck(t) },
 		Providers: acc.TestAccProviders,
 		Steps: []resource.TestStep{
 			resource.TestStep{
-				Config: testAccCheckIbmSccAccountLocationsDataSourceConfigBasic(),
+				Config: testAccCheckIbmSccAccountNotificationSettingsDataSourceConfigBasic(),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttrSet("data.ibm_scc_account_locations.scc_account_locations", "id"),
-					resource.TestCheckResourceAttrSet("data.ibm_scc_account_locations.scc_account_locations", "locations.#"),
+					resource.TestCheckResourceAttrSet("data.ibm_scc_account_notification_settings.scc_account_notification_settings", "id"),
 				),
 			},
 		},
 	})
 }
 
-func testAccCheckIbmSccAccountLocationsDataSourceConfigBasic() string {
+func testAccCheckIbmSccAccountNotificationSettingsDataSourceConfigBasic() string {
 	return fmt.Sprintf(`
-		data "ibm_scc_account_locations" "scc_account_locations" {
+		data "ibm_scc_account_notification_settings" "scc_account_notification_settings" {
 		}
 	`)
 }

--- a/ibm/service/scc/resource_ibm_scc_account_settings.go
+++ b/ibm/service/scc/resource_ibm_scc_account_settings.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2017, 2021 All Rights Reserved.
+// Copyright IBM Corp. 2022 All Rights Reserved.
 // Licensed under the Mozilla Public License v2.0
 
 package scc
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"time"
 
 	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/conns"
 	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/validate"
@@ -19,100 +20,267 @@ import (
 
 func ResourceIBMSccAccountSettings() *schema.Resource {
 	return &schema.Resource{
-		CreateContext: resourceIbmSccAccountSettingsUpdate,
+		CreateContext: resourceIbmSccAccountSettingsCreate,
 		ReadContext:   resourceIbmSccAccountSettingsRead,
 		UpdateContext: resourceIbmSccAccountSettingsUpdate,
 		DeleteContext: resourceIbmSccAccountSettingsDelete,
 		Importer:      &schema.ResourceImporter{},
 
 		Schema: map[string]*schema.Schema{
-			"location_id": {
-				Type:         schema.TypeString,
-				Required:     true,
-				ValidateFunc: validate.InvokeValidator("ibm_scc_account_settings", "location_id"),
-				Description:  "The programatic ID of the location that you want to work in.",
+			"location": &schema.Schema{
+				Type:        schema.TypeList,
+				MaxItems:    1,
+				Required:    true, // Made this Required to avoid drift
+				Description: "Location Settings.",
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"location_id": &schema.Schema{
+							Type:         schema.TypeString,
+							Required:     true,
+							Description:  "The programatic ID of the location that you want to work in.",
+							ValidateFunc: validate.InvokeValidator("ibm_scc_account_settings", "location_id"),
+						},
+					},
+				},
+			},
+			"event_notifications": &schema.Schema{
+				Type:        schema.TypeList,
+				MaxItems:    1,
+				Required:    true, // Made this Required to avoid drift during testing
+				Description: "The Event Notification settings to register.",
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"instance_crn": &schema.Schema{
+							Type:        schema.TypeString,
+							Optional:    true,
+							Default:     "",
+							Description: "The Cloud Resource Name (CRN) of the Event Notifications instance that you want to connect.",
+						},
+					},
+				},
 			},
 		},
 	}
 }
 
-func resourceIbmSccAccountSettingsRead(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	adminServiceClient, err := meta.(conns.ClientSession).AdminServiceApiV1()
+func resourceIbmSccAccountSettingsCreate(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	log.Printf("[DEBUG] Starting resourceIbmSccAccountSettings%s \n", "Create")
+	adminServiceApiClient, err := meta.(conns.ClientSession).AdminServiceApiV1()
 	if err != nil {
 		return diag.FromErr(err)
 	}
 
-	getAccountSettingsOption := &adminserviceapiv1.GetSettingsOptions{}
+	// Get the available body that you can put from the SDK
+	patchAccountSettingsOptions := &adminserviceapiv1.PatchAccountSettingsOptions{}
 
 	userDetails, err := meta.(conns.ClientSession).BluemixUserDetails()
 	if err != nil {
 		return diag.FromErr(err)
 	}
-	accountID := userDetails.UserAccount
 
-	getAccountSettingsOption.SetAccountID(accountID)
+	// Set the patchSettings to use userAccount tied to the API_KEY
+	patchAccountSettingsOptions.SetAccountID(userDetails.UserAccount)
 
-	accountSettings, response, err := adminServiceClient.GetSettingsWithContext(context, getAccountSettingsOption)
+	getSettingsOptions := &adminserviceapiv1.GetSettingsOptions{}
+	getSettingsOptions.SetAccountID(userDetails.UserAccount)
+
+	// Check with GetSettings what the current setting is
+	accountSettings, response, err := adminServiceApiClient.GetSettingsWithContext(context, getSettingsOptions)
+
+	hasChange := false
+	// check from the local tf file is location is defined
+	if _, ok := d.GetOk("location"); ok {
+		location, err := resourceIbmSccAccountSettingsMapToLocationID(d.Get("location.0").(map[string]interface{}))
+		if err != nil {
+			return diag.FromErr(err)
+		}
+		// if GetSettings is different than the terrafrom config file, prepare a PATCH call
+		if location.ID != accountSettings.Location.ID {
+			patchAccountSettingsOptions.SetLocation(location)
+			hasChange = true
+		}
+	}
+
+	// check from the local tf file if event_notifications is defined
+	event_obj := d.Get("event_notifications.0").(map[string]interface{})
+	if _, ok := d.GetOk("event_notifications"); ok && event_obj["instance_crn"] != nil {
+		eventNotifications, err := resourceIbmSccAccountSettingsMapToNotificationsRegistration(d.Get("event_notifications.0").(map[string]interface{}))
+		if err != nil {
+			return diag.FromErr(err)
+		}
+		// if GetSettings is different than the terrafrom config file, prepare a PATCH call
+		if eventNotifications.InstanceCrn != event_obj["instance_crn"] {
+			patchAccountSettingsOptions.SetEventNotifications(eventNotifications)
+			hasChange = true
+		}
+	}
+
+	// use scc-go-sdk to send the PATCH request if there is a change
+	if hasChange {
+		_, response, err = adminServiceApiClient.PatchAccountSettingsWithContext(context, patchAccountSettingsOptions)
+		if err != nil {
+			log.Printf("[DEBUG] PatchAccountSettingsWithContext failed %s\n%s", err, response)
+			return diag.FromErr(fmt.Errorf("PatchAccountSettingsWithContext failed %s\n%s", err, response))
+		}
+		// Set the ID of the Terraform object to the current timestamp
+		d.SetId(resourceIbmSccAccountSettingID(d))
+	}
+
+	return resourceIbmSccAccountSettingsRead(context, d, meta)
+}
+
+func resourceIbmSccAccountSettingID(d *schema.ResourceData) string {
+	// make a unique ID according to the timestamp
+	return time.Now().UTC().String()
+}
+
+func resourceIbmSccAccountSettingsRead(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	log.Printf("[DEBUG] Starting resourceIbmSccAccountSettings%s \n", "Read")
+	adminServiceApiClient, err := meta.(conns.ClientSession).AdminServiceApiV1()
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	// Get the Settings to call GetSettings
+	getSettingsOptions := &adminserviceapiv1.GetSettingsOptions{}
+
+	userDetails, err := meta.(conns.ClientSession).BluemixUserDetails()
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	getSettingsOptions.SetAccountID(userDetails.UserAccount)
+
+	// Return back the current Settings according to GetSettings
+	accountSettings, response, err := adminServiceApiClient.GetSettingsWithContext(context, getSettingsOptions)
 	if err != nil {
 		if response != nil && response.StatusCode == 404 {
+			d.SetId("")
 			return nil
 		}
 		log.Printf("[DEBUG] GetSettingsWithContext failed %s\n%s", err, response)
 		return diag.FromErr(fmt.Errorf("GetSettingsWithContext failed %s\n%s", err, response))
 	}
 
-	d.SetId(*accountSettings.Location.ID)
+	if accountSettings.Location != nil {
+		locationMap, err := resourceIbmSccAccountSettingsLocationIDToMap(accountSettings.Location)
+		if err != nil {
+			return diag.FromErr(err)
+		}
+		if err = d.Set("location", []map[string]interface{}{locationMap}); err != nil {
+			return diag.FromErr(fmt.Errorf("Error setting location: %s", err))
+		}
+	}
+	if accountSettings.EventNotifications != nil {
+		eventNotificationsMap, err := resourceIbmSccAccountSettingsNotificationsRegistrationToMap(accountSettings.EventNotifications)
+		if err != nil {
+			return diag.FromErr(err)
+		}
+		if err = d.Set("event_notifications", []map[string]interface{}{eventNotificationsMap}); err != nil {
+			return diag.FromErr(fmt.Errorf("Error setting event_notifications during the read: %s", err))
+		}
+	}
 
 	return nil
-
 }
 
 func resourceIbmSccAccountSettingsUpdate(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	adminServiceClient, err := meta.(conns.ClientSession).AdminServiceApiV1()
+	log.Printf("[DEBUG] Starting resourceIbmSccAccountSettings%s \n", "Update")
+	adminServiceApiClient, err := meta.(conns.ClientSession).AdminServiceApiV1()
 	if err != nil {
 		return diag.FromErr(err)
 	}
+
+	// Use the same logic as resourceIbmSccAccountSettingsCreate
+	patchAccountSettingsOptions := &adminserviceapiv1.PatchAccountSettingsOptions{}
 
 	userDetails, err := meta.(conns.ClientSession).BluemixUserDetails()
 	if err != nil {
 		return diag.FromErr(err)
 	}
-	accountID := userDetails.UserAccount
+	patchAccountSettingsOptions.SetAccountID(userDetails.UserAccount)
 
-	locationID := d.Get("location_id").(string)
-	updateAccountSettingsOption := &adminserviceapiv1.PatchAccountSettingsOptions{}
-	updateAccountSettingsOption.SetAccountID(accountID)
-	updateAccountSettingsOption.SetLocation(&adminserviceapiv1.LocationID{
-		ID: core.StringPtr(locationID),
-	})
+	// Flag to see if anything has been changed from the Update(terraform apply)
+	hasChange := false
 
-	_, response, err := adminServiceClient.PatchAccountSettingsWithContext(context, updateAccountSettingsOption)
-	if err != nil {
-		log.Printf("[DEBUG] PatchAccountSettingsWithContext failed %s\n%s", err, response)
-		return diag.FromErr(fmt.Errorf("PatchAccountSettingsWithContext failed %s\n%s", err, response))
+	if d.HasChange("location") {
+		location, err := resourceIbmSccAccountSettingsMapToLocationID(d.Get("location.0").(map[string]interface{}))
+		if err != nil {
+			return diag.FromErr(err)
+		}
+		patchAccountSettingsOptions.SetLocation(location)
+		hasChange = true
 	}
 
-	d.SetId(locationID)
+	if d.HasChange("event_notifications") {
+		eventNotifications, err := resourceIbmSccAccountSettingsMapToNotificationsRegistration(d.Get("event_notifications.0").(map[string]interface{}))
+		if err != nil {
+			return diag.FromErr(err)
+		}
+		patchAccountSettingsOptions.SetEventNotifications(eventNotifications)
+		hasChange = true
+	}
+
+	if hasChange {
+		_, response, err := adminServiceApiClient.PatchAccountSettingsWithContext(context, patchAccountSettingsOptions)
+		if err != nil {
+			log.Printf("[DEBUG] PatchAccountSettingsWithContext failed %s\n%s", err, response)
+			return diag.FromErr(fmt.Errorf("PatchAccountSettingsWithContext failed %s\n%s", err, response))
+		}
+		// Change the id of the this object only if anything has changed
+		d.SetId(resourceIbmSccAccountSettingID(d))
+	}
 
 	return resourceIbmSccAccountSettingsRead(context, d, meta)
 }
 
-func ResourceIBMSccAccountSettingsValidator() *validate.ResourceValidator {
-	validateSchema := make([]validate.ValidateSchema, 2)
-	validateSchema = append(validateSchema,
-		validate.ValidateSchema{
-			Identifier:                 "location_id",
-			ValidateFunctionIdentifier: validate.ValidateAllowedStringValue,
-			Type:                       validate.TypeString,
-			Required:                   true,
-			AllowedValues:              "us, eu, uk",
-		},
-	)
+func resourceIbmSccAccountSettingsDelete(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	// Use GetSettings since there is no API to delete the configuration of the AccountSettings and avoid compiler warnings
+	adminServiceApiClient, err := meta.(conns.ClientSession).AdminServiceApiV1()
+	if err != nil {
+		return diag.FromErr(err)
+	}
 
-	resourceValidator := validate.ResourceValidator{ResourceName: "ibm_scc_account_settings", Schema: validateSchema}
-	return &resourceValidator
+	getSettingsOptions := &adminserviceapiv1.GetSettingsOptions{}
+
+	userDetails, err := meta.(conns.ClientSession).BluemixUserDetails()
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	getSettingsOptions.SetAccountID(userDetails.UserAccount)
+
+	_, response, err := adminServiceApiClient.GetSettingsWithContext(context, getSettingsOptions)
+	if err != nil {
+		log.Printf("[DEBUG] PatchAccountSettingsWithContext failed %s\n%s", err, response)
+		return diag.FromErr(fmt.Errorf("PatchAccountSettingsWithContext failed %s\n%s", err, response))
+	}
+	// Set the object to a empty string so Terraform deletes the object
+	d.SetId("")
+
+	return nil
 }
 
-func resourceIbmSccAccountSettingsDelete(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	return nil
+func resourceIbmSccAccountSettingsMapToLocationID(modelMap map[string]interface{}) (*adminserviceapiv1.LocationID, error) {
+	model := &adminserviceapiv1.LocationID{}
+	model.ID = core.StringPtr(modelMap["location_id"].(string))
+	return model, nil
+}
+
+func resourceIbmSccAccountSettingsMapToNotificationsRegistration(modelMap map[string]interface{}) (*adminserviceapiv1.NotificationsRegistration, error) {
+	model := &adminserviceapiv1.NotificationsRegistration{}
+	model.InstanceCrn = core.StringPtr(modelMap["instance_crn"].(string))
+	return model, nil
+}
+
+func resourceIbmSccAccountSettingsLocationIDToMap(model *adminserviceapiv1.LocationID) (map[string]interface{}, error) {
+	modelMap := make(map[string]interface{})
+	modelMap["location_id"] = model.ID
+	return modelMap, nil
+}
+
+func resourceIbmSccAccountSettingsNotificationsRegistrationToMap(model *adminserviceapiv1.NotificationsRegistration) (map[string]interface{}, error) {
+	modelMap := make(map[string]interface{})
+	modelMap["instance_crn"] = model.InstanceCrn
+	return modelMap, nil
 }

--- a/ibm/service/scc/resource_ibm_scc_account_settings.go
+++ b/ibm/service/scc/resource_ibm_scc_account_settings.go
@@ -32,7 +32,7 @@ func ResourceIBMSccAccountSettings() *schema.Resource {
 				Optional:     true,
 				ValidateFunc: validate.InvokeValidator("ibm_scc_account_settings", "location_id"),
 				Description:  "The programatic ID of the location that you want to work in.",
-				Deprecated:   "use location instead",
+				Deprecated:   "The attribute location_id will soon be deprecated. Please use location instead. See https://registry.terraform.io/providers/IBM-Cloud/ibm/latest/docs/resources/scc_account_settings for details",
 			},
 			"location": &schema.Schema{
 				Type:          schema.TypeList,

--- a/ibm/service/scc/resource_ibm_scc_account_settings.go
+++ b/ibm/service/scc/resource_ibm_scc_account_settings.go
@@ -27,10 +27,18 @@ func ResourceIBMSccAccountSettings() *schema.Resource {
 		Importer:      &schema.ResourceImporter{},
 
 		Schema: map[string]*schema.Schema{
+			"location_id": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validate.InvokeValidator("ibm_scc_account_settings", "location_id"),
+				Description:  "The programatic ID of the location that you want to work in.",
+				Deprecated:   "use location instead",
+			},
 			"location": &schema.Schema{
 				Type:        schema.TypeList,
 				MaxItems:    1,
 				Required:    true, // Made this Required to avoid drift
+				ConflictsWith: []string{"location_id"},
 				Description: "Location Settings.",
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{

--- a/ibm/service/scc/resource_ibm_scc_account_settings.go
+++ b/ibm/service/scc/resource_ibm_scc_account_settings.go
@@ -35,11 +35,11 @@ func ResourceIBMSccAccountSettings() *schema.Resource {
 				Deprecated:   "use location instead",
 			},
 			"location": &schema.Schema{
-				Type:        schema.TypeList,
-				MaxItems:    1,
-				Required:    true, // Made this Required to avoid drift
+				Type:          schema.TypeList,
+				MaxItems:      1,
+				Required:      true, // Made this Required to avoid drift
 				ConflictsWith: []string{"location_id"},
-				Description: "Location Settings.",
+				Description:   "Location Settings.",
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"location_id": &schema.Schema{

--- a/ibm/service/scc/resource_ibm_scc_account_settings_validator.go
+++ b/ibm/service/scc/resource_ibm_scc_account_settings_validator.go
@@ -1,0 +1,24 @@
+// Copyright IBM Corp. 2022 All Rights Reserved.
+// Licensed under the Mozilla Public License v2.0
+
+package scc
+
+import (
+	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/validate"
+)
+
+func ResourceIBMSccAccountSettingsValidator() *validate.ResourceValidator {
+	validateSchema := make([]validate.ValidateSchema, 2)
+	validateSchema = append(validateSchema,
+		validate.ValidateSchema{
+			Identifier:                 "location_id",
+			ValidateFunctionIdentifier: validate.ValidateAllowedStringValue,
+			Type:                       validate.TypeString,
+			Required:                   true,
+			AllowedValues:              "us, eu, uk",
+		},
+	)
+
+	resourceValidator := validate.ResourceValidator{ResourceName: "ibm_scc_account_settings", Schema: validateSchema}
+	return &resourceValidator
+}

--- a/website/docs/d/scc_account_location.html.markdown
+++ b/website/docs/d/scc_account_location.html.markdown
@@ -10,6 +10,7 @@ description: |-
 
 Provides a read-only data source for scc_account_location. You can then reference the fields of the data source in other resources within the same configuration using interpolation syntax.
 
+~> **NOTE**: exporting out the environmental variable `IBM_CLOUD_SCC_ADMIN_API_ENDPOINT` will help out if the account fails to resolve.
 ## Example usage
 
 ```terraform
@@ -29,24 +30,23 @@ Review the argument reference that you can specify for your data source.
 
 In addition to all argument references listed, you can access the following attribute references after your data source is created.
 
-* `id` - The unique identifier of the scc_account_location.
+* `id` - The unique identifier of the scc_account_location_properties.
 
-* `analytics_endpoint_url` - (String) The endpoint that is used to generate analytics for the Posture Management component.
-
-* `compliance_endpoint_url` - (String) The endpoint that is used to call the Posture Management APIs.
-
-* `governance_endpoint_url` - (String) The endpoint that is used to call the Configuration Governance APIs.
-
-* `id` - (String) The programatic ID of the location that you want to work in.
+* `location_id` - (Required, String) The programatic ID of the location that you want to work in.
   * Constraints: Allowable values are: `us`, `eu`, `uk`.
 
-* `main_endpoint_url` - (String) The base URL for the service.
+* `analytics_endpoint_url` - (Optional, String) The endpoint that is used to generate analytics for the Posture Management component.
 
-* `regions` - (List)
-Nested scheme for **regions**:
+* `compliance_endpoint_url` - (Optional, String) The endpoint that is used to call the Posture Management APIs.
+
+* `governance_endpoint_url` - (Optional, String) The endpoint that is used to call the Configuration Governance APIs.
+
+* `main_endpoint_url` - (Optional, String) The base URL for the service.
+
+* `results_endpoint_url` - (Optional, String) The endpoint that is used to get the results for the Configuration Governance component.
+
+* `si_endpoint_url` - (Optional, String) The endpoint that is used to call the Security Insights APIs.
+
+* `regions` - (Optional, List) Nested scheme for **regions**:
 	* `id` - (Required, String) The programatic ID of the available regions.
 	  * Constraints: Allowable values are: `us`, `eu`, `uk`.
-
-* `results_endpoint_url` - (String) The endpoint that is used to get the results for the Configuration Governance component.
-
-* `si_endpoint_url` - (String) The endpoint that is used to call the Security Insights APIs.

--- a/website/docs/d/scc_account_location_settings.html.markdown
+++ b/website/docs/d/scc_account_location_settings.html.markdown
@@ -10,6 +10,7 @@ description: |-
 
 Provides a read-only data source for scc_account_location_settings. You can then reference the fields of the data source in other resources within the same configuration using interpolation syntax.
 
+~> **NOTE**: exporting out the environmental variable `IBM_CLOUD_SCC_ADMIN_API_ENDPOINT` will help out if the account fails to resolve.
 ## Example usage
 
 ```terraform

--- a/website/docs/d/scc_account_notification_settings.html.markdown
+++ b/website/docs/d/scc_account_notification_settings.html.markdown
@@ -1,0 +1,27 @@
+---
+layout: "ibm"
+page_title: "IBM : ibm_scc_account_notification_settings"
+description: |-
+  Get information about scc_account_notification_settings
+subcategory: "Admin Service API"
+---
+
+# ibm_scc_account_notification_settings
+
+Provides a read-only data source for scc_account_notification_settings. You can then reference the fields of the data source in other resources within the same configuration using interpolation syntax.
+
+~> **NOTE**: exporting out the environmental variable `IBM_CLOUD_SCC_ADMIN_API_ENDPOINT` will help out if the account fails to resolve.
+
+## Example Usage
+
+```hcl
+data "ibm_scc_account_notification_settings" "scc_account_notification_settings" {
+}
+```
+
+
+## Attribute Reference
+
+In addition to all argument references listed, you can access the following attribute references after your data source is created.
+
+* `instance_crn` - (Optional, String) The Cloud Resource Name (CRN) of the Event Notifications instance that you want to connect.

--- a/website/docs/d/scc_account_notification_settings.html.markdown
+++ b/website/docs/d/scc_account_notification_settings.html.markdown
@@ -3,7 +3,7 @@ layout: "ibm"
 page_title: "IBM : ibm_scc_account_notification_settings"
 description: |-
   Get information about scc_account_notification_settings
-subcategory: "Admin Service API"
+subcategory: "Security and Compliance Center"
 ---
 
 # ibm_scc_account_notification_settings

--- a/website/docs/r/scc_account_settings.html.markdown
+++ b/website/docs/r/scc_account_settings.html.markdown
@@ -28,7 +28,8 @@ resource "ibm_scc_account_settings" "scc_account_settings" {
 ## Argument Reference
 
 Review the argument reference that you can specify for your resource.
-
+* `location_id` **Deprecated** - (Required, Forces new resource, String) The programatic ID of the location that you want to work in.
+  * Constraints: Allowable values are: `us`, `eu`, `uk`.
 * `event_notifications` - (Required, List) The Event Notification settings to register.
 Nested scheme for **event_notifications**:
 	* `instance_crn` - (Optional, String) The Cloud Resource Name (CRN) of the Event Notifications instance that you want to connect. If this field is left blank, no Event Notifications instance will be used.

--- a/website/docs/r/scc_account_settings.html.markdown
+++ b/website/docs/r/scc_account_settings.html.markdown
@@ -1,34 +1,53 @@
 ---
 layout: "ibm"
-subcategory: "Security and Compliance Center"
 page_title: "IBM : ibm_scc_account_settings"
 description: |-
   Manages the account settings scc_account_settings
+subcategory: "SCC Admin Service API"
 ---
 
 # ibm_scc_account_settings
 
-Provides a resource for the scc_account_settings. This allows the scc_account_settings to be updated.
+Provides a resource for scc_account_settings. This allows scc_account_settings to be created, updated and deleted.
 
-## Example usage
+~> **NOTE**: exporting out the environmental variable `IBM_CLOUD_SCC_ADMIN_API_ENDPOINT` will help out if the account fails to resolve(e.g. `export IBMCLOUD_SCC_ADMIN_API_ENDPOINT=https://compliance.cloud.ibm.com`)
+
+## Example Usage
 
 ```terraform
-resource "ibm_scc_account_settings" "ibm_scc_account_settings_instance" {
-  location_id = var.ibm_scc_account_settings_location_id
+resource "ibm_scc_account_settings" "scc_account_settings" {
+    location {
+        location_id = "uk"
+    }
+    event_notifications {
+        instance_crn        = "<instance_crn for event_notifications>" // Optional field
+    }
 }
 ```
 
-## Argument reference
+## Argument Reference
 
-Review the argument reference that you can specify for your data source.
+Review the argument reference that you can specify for your resource.
 
-* `location_id` - (Required, Forces new resource, String) The programatic ID of the location that you want to work in.
-  * Constraints: Allowable values are: `us`, `eu`, `uk`.
+* `event_notifications` - (Required, List) The Event Notification settings to register.
+Nested scheme for **event_notifications**:
+	* `instance_crn` - (Optional, String) The Cloud Resource Name (CRN) of the Event Notifications instance that you want to connect. If this field is left blank, no Event Notifications instance will be used.
+* `location` - (Required, List) Location Settings.
+Nested scheme for **location**:
+	* `location_id` - (Required, String) The programatic ID of the location that you want to work in.
+	  * Constraints: Allowable values are: `us`, `eu`, `uk`.
 
-## Attribute reference
+## Attribute Reference
 
-In addition to all argument references listed, you can access the following attribute references after your data source is created.
+In addition to all argument references listed, you can access the following attribute references after your resource is created.
 
 * `id` - The unique identifier of the scc_account_settings.
-* `location_id` - (String) The programatic ID of the location that you want to work in.
-  * Constraints: Allowable values are: `us`, `eu`, `uk`.
+
+## Import
+
+You can import the `ibm_scc_account_settings` resource by using `terraform import <string>`, with the `<string>` being anything you want.
+
+# Syntax
+```
+$ terraform import ibm_scc_account_settings.scc_account_settings <string>
+```

--- a/website/docs/r/scc_account_settings.html.markdown
+++ b/website/docs/r/scc_account_settings.html.markdown
@@ -30,12 +30,12 @@ resource "ibm_scc_account_settings" "scc_account_settings" {
 Review the argument reference that you can specify for your resource.
 
 > `location_id` will be Deprecated in the near future. Please adjust to using the argument `location`
-* `location_id` **Deprecated** - (Required, Forces new resource, String) The programatic ID of the location that you want to work in.
+* `location_id` **Deprecated** - (Optional, Forces new resource, String) The programatic ID of the location that you want to work in.
   * Constraints: Allowable values are: `us`, `eu`, `uk`.
-* `event_notifications` - (Required, List) The Event Notification settings to register.
+* `event_notifications` - (Optional, List) The Event Notification settings to register.
 Nested scheme for **event_notifications**:
 	* `instance_crn` - (Optional, String) The Cloud Resource Name (CRN) of the Event Notifications instance that you want to connect. If this field is left blank, no Event Notifications instance will be used.
-* `location` - (Required, List) Location Settings.
+* `location` - (Optional, List) Location Settings.
 Nested scheme for **location**:
 	* `location_id` - (Required, String) The programatic ID of the location that you want to work in.
 	  * Constraints: Allowable values are: `us`, `eu`, `uk`.

--- a/website/docs/r/scc_account_settings.html.markdown
+++ b/website/docs/r/scc_account_settings.html.markdown
@@ -3,7 +3,7 @@ layout: "ibm"
 page_title: "IBM : ibm_scc_account_settings"
 description: |-
   Manages the account settings scc_account_settings
-subcategory: "SCC Admin Service API"
+subcategory: "Security and Compliance Center"
 ---
 
 # ibm_scc_account_settings

--- a/website/docs/r/scc_account_settings.html.markdown
+++ b/website/docs/r/scc_account_settings.html.markdown
@@ -28,6 +28,8 @@ resource "ibm_scc_account_settings" "scc_account_settings" {
 ## Argument Reference
 
 Review the argument reference that you can specify for your resource.
+
+> `location_id` will be Deprecated in the near future. Please adjust to using the argument `location`
 * `location_id` **Deprecated** - (Required, Forces new resource, String) The programatic ID of the location that you want to work in.
   * Constraints: Allowable values are: `us`, `eu`, `uk`.
 * `event_notifications` - (Required, List) The Event Notification settings to register.


### PR DESCRIPTION
- changed the provider to accommodate the changes needed for the service scc
- added the better validation for the testing
- added a new datasource named notification_settings

<!--- See what makes a good Pull Request at : https://github.com/IBM-Cloud/terraform-provider-ibm/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccXXX'

==> Checking that code complies with gofmt requirements...
go test -i $(go list ./... |grep -v 'vendor') || exit 1
echo $(go list ./... |grep -v 'vendor') | \
		xargs -t -n4 go test  -timeout=30s -parallel=4
?   	github.com/IBM-Cloud/terraform-provider-ibm	[no test files]
?   	github.com/IBM-Cloud/terraform-provider-ibm/ibm/acctest	[no test files]
ok  	github.com/IBM-Cloud/terraform-provider-ibm/ibm/conns	(cached)
?   	github.com/IBM-Cloud/terraform-provider-ibm/ibm/flex	[no test files]
?   	github.com/IBM-Cloud/terraform-provider-ibm/ibm/provider	[no test files]
ok  	github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/apigateway	(cached)
ok  	github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/appconfiguration	(cached)
ok  	github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/appid	(cached)
ok  	github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/atracker	(cached)
ok  	github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/catalogmanagement	(cached)
ok  	github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/certificatemanager	(cached)
ok  	github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/cis	(cached)
ok  	github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/classicinfrastructure	(cached)
ok  	github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/cloudant	(cached)
ok  	github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/cloudfoundry	(cached)
ok  	github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/cloudshell	(cached)
ok  	github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/contextbasedrestrictions	(cached)
ok  	github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/cos	(cached)
ok  	github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/database	(cached)
ok  	github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/directlink	(cached)
ok  	github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/dnsservices	(cached)
ok  	github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/enterprise	(cached)
ok  	github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/eventnotification	(cached)
ok  	github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/eventstreams	(cached)
ok  	github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/functions	(cached)
ok  	github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/globaltagging	(cached)
ok  	github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/hpcs	(cached)
ok  	github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/iamaccessgroup	(cached)
ok  	github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/iamidentity	(cached)
ok  	github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/iampolicy	(cached)
ok  	github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/kms	(cached)
ok  	github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/kubernetes	(cached)
ok  	github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/power	(cached)
ok  	github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/pushnotification	(cached)
ok  	github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/registry	(cached)
ok  	github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/resourcecontroller	(cached)
ok  	github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/resourcemanager	(cached)
ok  	github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/satellite	(cached)
ok  	github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/scc	(cached)
ok  	github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/schematics	(cached)
ok  	github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/secretsmanager	(cached)
ok  	github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/transitgateway	(cached)
ok  	github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/vpc	(cached)
?   	github.com/IBM-Cloud/terraform-provider-ibm/ibm/validate	[no test files]
?   	github.com/IBM-Cloud/terraform-provider-ibm/version	[no test files]

...
```
