### PR TITLE
 enhancement(subnet): added support for ibm_is_subnet_routing_table_attachment

### DIFF
--- a/ibm/provider/provider.go
+++ b/ibm/provider/provider.go
@@ -791,6 +791,7 @@ func Provider() *schema.Provider {
 			"ibm_is_subnet_reserved_ip":                          vpc.ResourceIBMISReservedIP(),
 			"ibm_is_subnet_network_acl_attachment":               vpc.ResourceIBMISSubnetNetworkACLAttachment(),
 			"ibm_is_subnet_public_gateway_attachment":            vpc.ResourceIBMISSubnetPublicGatewayAttachment(),
+			"ibm_is_subnet_routing_table_attachment":             vpc.ResourceIBMISSubnetRoutingTableAttachment(),
 			"ibm_is_ssh_key":                                     vpc.ResourceIBMISSSHKey(),
 			"ibm_is_snapshot":                                    vpc.ResourceIBMSnapshot(),
 			"ibm_is_volume":                                      vpc.ResourceIBMISVolume(),

--- a/ibm/service/vpc/resource_ibm_is_subnet_routing_table_attachment.go
+++ b/ibm/service/vpc/resource_ibm_is_subnet_routing_table_attachment.go
@@ -1,0 +1,296 @@
+// Copyright IBM Corp. 2017, 2021 All Rights Reserved.
+// Licensed under the Mozilla Public License v2.0
+
+package vpc
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"time"
+
+	"github.com/IBM/vpc-go-sdk/vpcv1"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+func ResourceIBMISSubnetRoutingTableAttachment() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceIBMISSubnetRoutingTableAttachmentCreate,
+		ReadContext:   resourceIBMISSubnetRoutingTableAttachmentRead,
+		UpdateContext: resourceIBMISSubnetRoutingTableAttachmentUpdate,
+		DeleteContext: resourceIBMISSubnetRoutingTableAttachmentDelete,
+		Importer:      &schema.ResourceImporter{},
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(10 * time.Minute),
+			Update: schema.DefaultTimeout(10 * time.Minute),
+			Delete: schema.DefaultTimeout(10 * time.Minute),
+		},
+
+		Schema: map[string]*schema.Schema{
+
+			isSubnetID: {
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: "The subnet identifier",
+			},
+
+			isRoutingTableID: {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "The unique identifier of routing table",
+			},
+
+			rtRouteDirectLinkIngress: {
+				Type:        schema.TypeBool,
+				Computed:    true,
+				Description: "If true, this routing table will be used to route traffic that originates from Direct Link to this VPC.",
+			},
+
+			rtIsDefault: {
+				Type:        schema.TypeBool,
+				Computed:    true,
+				Description: "Indicates whether this is the default routing table for this VPC",
+			},
+			rtLifecycleState: {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "he lifecycle state of the routing table [ deleting, failed, pending, stable, suspended, updating, waiting ]",
+			},
+
+			isRoutingTableName: {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The name of the routing table",
+			},
+			isRoutingTableResourceType: {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The resource type",
+			},
+
+			rtRouteTransitGatewayIngress: {
+				Type:        schema.TypeBool,
+				Computed:    true,
+				Description: "If true, this routing table will be used to route traffic that originates from Transit Gateway to this VPC.",
+			},
+
+			rtRouteVPCZoneIngress: {
+				Type:        schema.TypeBool,
+				Computed:    true,
+				Description: "If true, this routing table will be used to route traffic that originates from subnets in other zones in this VPC.",
+			},
+
+			rtSubnets: {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						rtName: {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "Subnet name",
+						},
+						"id": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "Subnet ID",
+						},
+					},
+				},
+			},
+
+			rtRoutes: {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						rtName: {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "route name",
+						},
+						"id": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "route ID",
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func resourceIBMISSubnetRoutingTableAttachmentCreate(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	sess, err := vpcClient(meta)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	subnet := d.Get(isSubnetID).(string)
+	routingTable := d.Get(isRoutingTableID).(string)
+
+	// Construct an instance of the RoutingTableIdentityByID model
+	routingTableIdentityModel := new(vpcv1.RoutingTableIdentityByID)
+	routingTableIdentityModel.ID = &routingTable
+
+	// Construct an instance of the ReplaceSubnetRoutingTableOptions model
+	replaceSubnetRoutingTableOptionsModel := new(vpcv1.ReplaceSubnetRoutingTableOptions)
+	replaceSubnetRoutingTableOptionsModel.ID = &subnet
+	replaceSubnetRoutingTableOptionsModel.RoutingTableIdentity = routingTableIdentityModel
+	resultRT, response, err := sess.ReplaceSubnetRoutingTableWithContext(context, replaceSubnetRoutingTableOptionsModel)
+
+	if err != nil {
+		log.Printf("[DEBUG] Error while attaching a routing table to a subnet %s\n%s", err, response)
+		return diag.FromErr(fmt.Errorf("[ERROR] Error while attaching a routing table to a subnet %s\n%s", err, response))
+	}
+	d.SetId(subnet)
+	log.Printf("[INFO] Routing Table : %s", *resultRT.ID)
+	log.Printf("[INFO] Subnet ID : %s", subnet)
+
+	return resourceIBMISSubnetRoutingTableAttachmentRead(context, d, meta)
+}
+
+func resourceIBMISSubnetRoutingTableAttachmentRead(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	id := d.Id()
+	sess, err := vpcClient(meta)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	getSubnetRoutingTableOptionsModel := &vpcv1.GetSubnetRoutingTableOptions{
+		ID: &id,
+	}
+	subRT, response, err := sess.GetSubnetRoutingTableWithContext(context, getSubnetRoutingTableOptionsModel)
+
+	if err != nil {
+		if response != nil && response.StatusCode == 404 {
+			d.SetId("")
+			return nil
+		}
+		return diag.FromErr(fmt.Errorf("[ERROR] Error getting subnet's (%s) attached routing table: %s\n%s", id, err, response))
+	}
+	d.Set(isRoutingTableName, *subRT.Name)
+	d.Set(isSubnetID, id)
+	d.Set(isRoutingTableID, *subRT.ID)
+	d.Set(isRoutingTableResourceType, *subRT.ResourceType)
+	d.Set(rtRouteDirectLinkIngress, *subRT.RouteDirectLinkIngress)
+	d.Set(rtIsDefault, *subRT.IsDefault)
+	d.Set(rtLifecycleState, *subRT.LifecycleState)
+	d.Set(isRoutingTableResourceType, *subRT.ResourceType)
+	d.Set(rtRouteTransitGatewayIngress, *subRT.RouteTransitGatewayIngress)
+	d.Set(rtRouteVPCZoneIngress, *subRT.RouteVPCZoneIngress)
+	subnets := make([]map[string]interface{}, 0)
+
+	for _, s := range subRT.Subnets {
+		subnet := make(map[string]interface{})
+		subnet[ID] = *s.ID
+		subnet["name"] = *s.Name
+		subnets = append(subnets, subnet)
+	}
+	d.Set(rtSubnets, subnets)
+
+	routes := make([]map[string]interface{}, 0)
+	for _, s := range subRT.Routes {
+		route := make(map[string]interface{})
+		route[ID] = *s.ID
+		route["name"] = *s.Name
+		routes = append(routes, route)
+	}
+	d.Set(rtRoutes, routes)
+	return nil
+}
+
+func resourceIBMISSubnetRoutingTableAttachmentUpdate(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+
+	sess, err := vpcClient(meta)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+	if d.HasChange(isRoutingTableID) {
+		subnet := d.Get(isSubnetID).(string)
+		routingTable := d.Get(isRoutingTableID).(string)
+
+		// Construct an instance of the RoutingTableIdentityByID model
+		routingTableIdentityModel := new(vpcv1.RoutingTableIdentityByID)
+		routingTableIdentityModel.ID = &routingTable
+
+		// Construct an instance of the ReplaceSubnetRoutingTableOptions model
+		replaceSubnetRoutingTableOptionsModel := new(vpcv1.ReplaceSubnetRoutingTableOptions)
+		replaceSubnetRoutingTableOptionsModel.ID = &subnet
+		replaceSubnetRoutingTableOptionsModel.RoutingTableIdentity = routingTableIdentityModel
+		resultRT, response, err := sess.ReplaceSubnetRoutingTableWithContext(context, replaceSubnetRoutingTableOptionsModel)
+
+		if err != nil {
+			log.Printf("[DEBUG] Error while attaching a routing table to a subnet %s\n%s", err, response)
+			return diag.FromErr(fmt.Errorf("[ERROR] Error while attaching a routing table to a subnet %s\n%s", err, response))
+		}
+		log.Printf("[INFO] Updated subnet %s with Routing Table : %s", subnet, *resultRT.ID)
+
+		d.SetId(subnet)
+		return resourceIBMISSubnetRoutingTableAttachmentRead(context, d, meta)
+	}
+
+	return resourceIBMISSubnetRoutingTableAttachmentRead(context, d, meta)
+}
+
+func resourceIBMISSubnetRoutingTableAttachmentDelete(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	id := d.Id()
+	sess, err := vpcClient(meta)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+	// Set the subnet with VPC default routing table
+	getSubnetOptions := &vpcv1.GetSubnetOptions{
+		ID: &id,
+	}
+	subnet, response, err := sess.GetSubnetWithContext(context, getSubnetOptions)
+	if err != nil {
+		if response != nil && response.StatusCode == 404 {
+			d.SetId("")
+			return nil
+		}
+		return diag.FromErr(fmt.Errorf("[ERROR] Error Getting Subnet (%s): %s\n%s", id, err, response))
+	}
+	// Fetch VPC
+	vpcID := *subnet.VPC.ID
+
+	getvpcOptions := &vpcv1.GetVPCOptions{
+		ID: &vpcID,
+	}
+	vpc, response, err := sess.GetVPCWithContext(context, getvpcOptions)
+	if err != nil {
+		if response != nil && response.StatusCode == 404 {
+			d.SetId("")
+			return nil
+		}
+		return diag.FromErr(fmt.Errorf("[ERROR] Error getting VPC : %s\n%s", err, response))
+	}
+
+	// Fetch default routing table
+	if vpc.DefaultRoutingTable != nil {
+		log.Printf("[DEBUG] vpc default routing table is not null :%s", *vpc.DefaultRoutingTable.ID)
+		// Construct an instance of the RoutingTableIdentityByID model
+		routingTableIdentityModel := new(vpcv1.RoutingTableIdentityByID)
+		routingTableIdentityModel.ID = vpc.DefaultRoutingTable.ID
+
+		// Construct an instance of the ReplaceSubnetRoutingTableOptions model
+		replaceSubnetRoutingTableOptionsModel := new(vpcv1.ReplaceSubnetRoutingTableOptions)
+		replaceSubnetRoutingTableOptionsModel.ID = &id
+		replaceSubnetRoutingTableOptionsModel.RoutingTableIdentity = routingTableIdentityModel
+		resultRT, response, err := sess.ReplaceSubnetRoutingTableWithContext(context, replaceSubnetRoutingTableOptionsModel)
+
+		if err != nil {
+			log.Printf("[DEBUG] Error while attaching a routing table to a subnet %s\n%s", err, response)
+			return diag.FromErr(fmt.Errorf("[ERROR] Error while attaching a routing table to a subnet %s\n%s", err, response))
+		}
+		log.Printf("[INFO] Updated subnet %s with VPC default Routing Table : %s", id, *resultRT.ID)
+	} else {
+		log.Printf("[DEBUG] vpc default routing table is  null")
+	}
+
+	d.SetId("")
+	return nil
+}

--- a/ibm/service/vpc/resource_ibm_is_subnet_routing_table_attachment_test.go
+++ b/ibm/service/vpc/resource_ibm_is_subnet_routing_table_attachment_test.go
@@ -1,0 +1,116 @@
+// Copyright IBM Corp. 2017, 2021 All Rights Reserved.
+// Licensed under the Mozilla Public License v2.0
+
+package vpc_test
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	acc "github.com/IBM-Cloud/terraform-provider-ibm/ibm/acctest"
+	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/conns"
+
+	"github.com/IBM/vpc-go-sdk/vpcv1"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+)
+
+func TestAccIBMISSubnetRoutingTableAttachment_basic(t *testing.T) {
+	var subnetRT string
+	rtname := fmt.Sprintf("tfrt-%d", acctest.RandIntRange(10, 100))
+	vpcname := fmt.Sprintf("tfvpc-vpc-%d", acctest.RandIntRange(10, 100))
+	subnetname := fmt.Sprintf("tfsubnet-vpc-%d", acctest.RandIntRange(10, 100))
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { acc.TestAccPreCheck(t) },
+		Providers:    acc.TestAccProviders,
+		CheckDestroy: checkSubnetRoutingTableAttachmentDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccCheckIBMISSubnetRoutingTableAttachmentConfig(rtname, subnetname, vpcname, acc.ISZoneName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckIBMISSubnetRoutingTableAttachmentExists("ibm_is_subnet_routing_table_attachment.attach", subnetRT),
+					resource.TestCheckResourceAttrSet(
+						"ibm_is_subnet_routing_table_attachment.attach", "lifecycle_state"),
+					resource.TestCheckResourceAttrSet(
+						"ibm_is_subnet_routing_table_attachment.attach", "resource_type"),
+					resource.TestCheckResourceAttrSet(
+						"ibm_is_subnet_routing_table_attachment.attach", "id"),
+				),
+			},
+		},
+	})
+}
+
+func checkSubnetRoutingTableAttachmentDestroy(s *terraform.State) error {
+
+	sess, _ := acc.TestAccProvider.Meta().(conns.ClientSession).VpcV1API()
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "ibm_is_subnet_routing_table_attachment" {
+			continue
+		}
+
+		getSubnetRoutingTableOptionsModel := &vpcv1.GetSubnetRoutingTableOptions{
+			ID: &rs.Primary.ID,
+		}
+		_, _, err := sess.GetSubnetRoutingTable(getSubnetRoutingTableOptionsModel)
+
+		if err == nil {
+			return fmt.Errorf("subnet routing table attachment still exists: %s", rs.Primary.ID)
+		}
+	}
+	return nil
+}
+
+func testAccCheckIBMISSubnetRoutingTableAttachmentExists(n, subnetRT string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+
+		rs, ok := s.RootModule().Resources[n]
+
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return errors.New("No Record ID is set")
+		}
+
+		sess, _ := acc.TestAccProvider.Meta().(conns.ClientSession).VpcV1API()
+		getSubnetRoutingTableOptionsModel := &vpcv1.GetSubnetRoutingTableOptions{
+			ID: &rs.Primary.ID,
+		}
+		foundsubnetRT, _, err := sess.GetSubnetRoutingTable(getSubnetRoutingTableOptionsModel)
+		if err != nil {
+			return err
+		}
+		subnetRT = *foundsubnetRT.ID
+		return nil
+	}
+}
+
+func testAccCheckIBMISSubnetRoutingTableAttachmentConfig(rtname, subnetname, vpcname, zone string) string {
+	return fmt.Sprintf(`
+	resource "ibm_is_vpc" "testacc_vpc" {
+		name = "%s"
+	}
+	resource "ibm_is_vpc_routing_table" "testacc_vpc_routing_table" {
+		vpc = ibm_is_vpc.testacc_vpc.id
+		name = "%s"
+	}
+
+	resource "ibm_is_subnet" "testacc_subnet" {
+		name = "%s"
+		vpc = ibm_is_vpc.testacc_vpc.id
+		zone = "%s"
+		total_ipv4_address_count  = 16
+	}
+
+	resource "ibm_is_subnet_routing_table_attachment" "attach" {
+		depends_on = [ibm_is_vpc_routing_table.testacc_vpc_routing_table, ibm_is_subnet.testacc_subnet]
+		subnet      = ibm_is_subnet.testacc_subnet.id
+		routing_table = ibm_is_vpc_routing_table.testacc_vpc_routing_table.routing_table
+	  }
+
+	`, vpcname, rtname, subnetname, zone)
+}

--- a/website/docs/r/is_subnet_routing_table_attachment.html.markdown
+++ b/website/docs/r/is_subnet_routing_table_attachment.html.markdown
@@ -1,0 +1,96 @@
+---
+
+subcategory: "VPC infrastructure"
+layout: "ibm"
+page_title: "IBM : subnet_routing_table_attachment"
+description: |-
+  Manages IBM subnet routing table attachment.
+---
+
+# ibm_is_subnet_routing_table_attachment
+Create, update, or delete a subnet routing table attachment resource. For more information, about subnet routing table attachment, see [setting up routing tables](https://cloud.ibm.com/docs/vpc?topic=vpc-attach-subnets-routing-table).
+
+**Note:** 
+VPC infrastructure services are a regional specific based endpoint, by default targets to `us-south`. Please make sure to target right region in the provider block as shown in the `provider.tf` file, if VPC service is created in region other than `us-south`.
+
+**provider.tf**
+
+```terraform
+provider "ibm" {
+  region = "eu-gb"
+}
+```
+
+## Example usage
+
+```terraform
+resource "ibm_is_vpc" "example" {
+  name = "example-vpc"
+}
+resource "ibm_is_vpc_routing_table" "example" {
+  vpc   = ibm_is_vpc.example.id
+  name  = "example-rt"
+}
+
+resource "ibm_is_subnet" "example" {
+  name                        = "example-subnet"
+  vpc                         = ibm_is_vpc.example.id
+  zone                        = "eu-gb-1"
+  total_ipv4_address_count    = 16
+}
+
+resource "ibm_is_subnet_routing_table_attachment" "example" {
+  subnet        = ibm_is_subnet.example.id
+  routing_table = ibm_is_vpc_routing_table.example.routing_table
+}
+
+```
+## Argument reference
+Review the argument references that you can specify for your resource. 
+
+- `routing_table` - (Required, String) The routing table identity.
+- `subnet` - (Required, Forces new resource, String) The subnet identifier.
+
+
+## Attribute reference
+In addition to all argument reference list, you can access the following attribute reference after your resource is created.
+
+- `created_at` - (Timestamp) The creation date and time the routing table.
+- `href` - (String) The URL of this routing table.
+- `id` - (String) The unique identifier of the subnet.
+- `is_default` - (Boolean) Indicates whether this is the default routing table for this VPC.
+- `lifecycle_state` - (String) The lifecycle state of the routing table.
+- `name` - (String) The user-defined name of this routing table.
+- `resource_type` - (String) The resource type.
+- `route_direct_link_ingress` - (Boolean) Indicates whether this routing table is used to route traffic that originates from [Direct Link](https://cloud.ibm.com/docs/dl/) to this VPC. Incoming traffic will be routed according to the routing table with one exception: routes with an action of deliver are treated as drop unless the next_hop is an IP address within the VPC's address prefix ranges. Therefore, if an incoming packet matches a route with a next_hop of an internet-bound IP address or a VPN gateway connection, the packet will be dropped..
+- `route_transit_gateway_ingress` - (Boolean) Indicates whether this routing table is used to route traffic that originates from from [Transit Gateway](https://cloud.ibm.com/cloud/transit-gateway/) to this VPC.
+Incoming traffic will be routed according to the routing table with one exception: routes with an action of deliver are treated as drop unless the next_hop is an IP address within the VPC's address prefix ranges. Therefore, if an incoming packet matches a route with a next_hop of an internet-bound IP address or a VPN gateway connection, the packet will be dropped.
+- `route_vpc_zone_ingress` - (Boolean) Indicates whether this routing table is used to route traffic that originates from subnets in other zones in this VPC. Incoming traffic will be routed according to the routing table with one exception: routes with an action of deliver are treated as drop unless the next_hop is an IP address within the VPC's address prefix ranges. Therefore, if an incoming packet matches a route with a next_hop of an internet-bound IP address or a VPN gateway connection, the packet will be dropped..
+- `routes` - (List) The routes for this routing table.
+	
+  Nested scheme for `routes`:
+  - `href` - (List) The URL for this route.
+  - `id` - (List) The unique identifier for this route.
+  - `name` - (List) The user-defined name for this route.
+
+- `subnets` - (List) The subnets to which this routing table is attached.
+
+  Nested scheme for `subnets`:
+	- `id` - (String) The unique identifier for this subnet.
+	- `name` - (String) The user-defined name for this subnet.
+
+
+## Import
+The `ibm_is_subnet_routing_table_attachment` resource can be imported by using the subnet ID. 
+
+**Syntax**
+
+```
+$ terraform import ibm_is_subnet_routing_table_attachment.example <subnet_ID>
+```
+
+**Example**
+
+```
+$ terraform import ibm_is_subnet_routing_table_attachment.example d7bec597-4726-451f-8a63-1111e6f19c32c
+```


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/IBM-Cloud/terraform-provider-ibm/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
--- PASS: TestAccIBMISSubnetRoutingTableAttachment_basic (112.57s)
PASS
ok      github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/vpc     115.989s
```
