### PR TITLE
Fixing resource_attributes to support the service specific roles

### DIFF
--- a/ibm/flex/structures.go
+++ b/ibm/flex/structures.go
@@ -2902,6 +2902,9 @@ func GeneratePolicyOptions(d *schema.ResourceData, meta interface{}) (iampolicym
 			name := a["name"].(string)
 			value := a["value"].(string)
 			operator := a["operator"].(string)
+			if name == "serviceName" {
+				serviceName = value
+			}
 			at := iampolicymanagementv1.ResourceAttribute{
 				Name:     &name,
 				Value:    &value,

--- a/ibm/service/iampolicy/resource_ibm_iam_access_group_policy_test.go
+++ b/ibm/service/iampolicy/resource_ibm_iam_access_group_policy_test.go
@@ -266,6 +266,27 @@ func TestAccIBMIAMAccessGroupPolicy_With_Resource_Attributes(t *testing.T) {
 	})
 }
 
+func TestAccIBMIAMAccessGroupPolicy_With_Service_Specific_Roles(t *testing.T) {
+	var conf iampolicymanagementv1.Policy
+	name := fmt.Sprintf("terraform_%d", acctest.RandIntRange(10, 100))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { acc.TestAccPreCheck(t) },
+		Providers:    acc.TestAccProviders,
+		CheckDestroy: testAccCheckIBMIAMAccessGroupPolicyDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckIBMIAMAccessGroupPolicyServiceSpecificRoles(name),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckIBMIAMAccessGroupPolicyExists("ibm_iam_access_group_policy.policy", conf),
+					resource.TestCheckResourceAttr("ibm_iam_access_group.accgrp", "name", name),
+					resource.TestCheckResourceAttr("ibm_iam_access_group_policy.policy", "resource_attributes.#", "2"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccIBMIAMAccessGroupPolicy_WithCustomRole(t *testing.T) {
 	var conf iampolicymanagementv1.Policy
 	name := fmt.Sprintf("terraform_%d", acctest.RandIntRange(10, 100))
@@ -666,6 +687,27 @@ func testAccCheckIBMIAMAccessGroupPolicyResourceAttributesUpdate(name string) st
 			resource_attributes {
 				name     = "serviceName"
 				value    = "messagehub"
+			}
+	  	}
+	`, name)
+}
+
+func testAccCheckIBMIAMAccessGroupPolicyServiceSpecificRoles(name string) string {
+	return fmt.Sprintf(`
+		resource "ibm_iam_access_group" "accgrp" {
+			name = "%s"
+	  	}
+	  
+	  	resource "ibm_iam_access_group_policy" "policy" {
+			access_group_id = ibm_iam_access_group.accgrp.id
+			roles           = ["Satellite Link Source and Endpoint Controller"]
+			resource_attributes {
+				name     = "resource"
+				value    = "test*"
+			}
+			resource_attributes {
+				name     = "serviceName"
+				value    = "satellite"
 			}
 	  	}
 	`, name)


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/IBM-Cloud/terraform-provider-ibm/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #3646 

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
**satellite service specific role "Satellite Link Source and Endpoint Controller" using resource_attributes argument**
![image](https://user-images.githubusercontent.com/78408189/157179228-05dafa55-7ecb-4941-ace9-ba083d39eb35.png)

**Access-Group policies**
![image](https://user-images.githubusercontent.com/78408189/157183973-71536769-9dfe-4791-84a1-7e7a8b07b4c7.png)


**User Policies**
![image](https://user-images.githubusercontent.com/78408189/157187376-87638fa0-9f2f-42aa-9f0b-704ecc9c1c48.png)

**Service Policies**
![image](https://user-images.githubusercontent.com/78408189/157191071-1b488c4c-e1cd-403d-ad4d-9fe41640072a.png)

**Trusted Policies**
![image](https://user-images.githubusercontent.com/78408189/157195798-4b9eb9c1-9f13-49db-9ca5-10eb487448a9.png)
