### PR TITLE
Support dynamic network type address

### DIFF
--- a/ibm/service/power/data_source_ibm_pi_instance.go
+++ b/ibm/service/power/data_source_ibm_pi_instance.go
@@ -233,7 +233,7 @@ func dataSourceIBMPIInstancesRead(ctx context.Context, d *schema.ResourceData, m
 		for i, pvmip := range powervmdata.Addresses {
 
 			p := make(map[string]interface{})
-			p["ip"] = pvmip.IP
+			p["ip"] = pvmip.IPAddress
 			p["network_name"] = pvmip.NetworkName
 			p["network_id"] = pvmip.NetworkID
 			p["macaddress"] = pvmip.MacAddress

--- a/ibm/service/power/data_source_ibm_pi_instance_ip.go
+++ b/ibm/service/power/data_source_ibm_pi_instance_ip.go
@@ -83,19 +83,20 @@ func dataSourceIBMPIInstancesIPRead(ctx context.Context, d *schema.ResourceData,
 		return diag.FromErr(err)
 	}
 
-	for _, address := range powervmdata.Addresses {
-		if address.NetworkName == networkName {
-			log.Printf("Printing the ip %s", address.IP)
-			d.SetId(address.NetworkID)
-			d.Set("ip", address.IP)
-			d.Set("network_id", address.NetworkID)
-			d.Set("macaddress", address.MacAddress)
-			d.Set("external_ip", address.ExternalIP)
-			d.Set("type", address.Type)
+	for _, network := range powervmdata.Networks {
+		if network.NetworkName == networkName {
+			log.Printf("Printing the ip %s", network.IPAddress)
+			d.SetId(network.NetworkID)
+			d.Set("ip", network.IPAddress)
+			d.Set("network_id", network.NetworkID)
+			d.Set("macaddress", network.MacAddress)
+			d.Set("external_ip", network.ExternalIP)
+			d.Set("type", network.Type)
 
-			IPObject := net.ParseIP(address.IP).To4()
-
-			d.Set("ipoctet", strconv.Itoa(int(IPObject[3])))
+			IPObject := net.ParseIP(network.IPAddress).To4()
+			if len(IPObject) > 0 {
+				d.Set("ipoctet", strconv.Itoa(int(IPObject[3])))
+			}
 
 			return nil
 		}

--- a/ibm/service/power/data_source_ibm_pi_instances.go
+++ b/ibm/service/power/data_source_ibm_pi_instances.go
@@ -217,7 +217,7 @@ func flattenPvmInstanceNetworks(list []*models.PVMInstanceNetwork) (networks []m
 		for i, pvmip := range list {
 
 			p := make(map[string]interface{})
-			p["ip"] = pvmip.IP
+			p["ip"] = pvmip.IPAddress
 			p["network_name"] = pvmip.NetworkName
 			p["network_id"] = pvmip.NetworkID
 			p["macaddress"] = pvmip.MacAddress


### PR DESCRIPTION
1. Removed deprecated attributes:

- `Addresses`->`Networks`
- `IP`->`IPAddress`

2. Additional check for dynamic network address where IPAddress is " ".

Signed-off-by: Yussuf Shaikh <yussuf.shaikh@ibm.com>

<!--- See what makes a good Pull Request at : https://github.com/IBM-Cloud/terraform-provider-ibm/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
=== RUN   TestAccIBMPIInstanceIPDataSource_basic
--- PASS: TestAccIBMPIInstanceIPDataSource_basic (82.78s)
PASS


```
