### PR TITLE
feature(lb) : support for port range for public network load balancers

### DIFF
--- a/ibm/service/vpc/resource_ibm_is_lb_listener.go
+++ b/ibm/service/vpc/resource_ibm_is_lb_listener.go
@@ -70,14 +70,19 @@ func ResourceIBMISLBListener() *schema.Resource {
 				Description:  "Loadbalancer listener port",
 			},
 			isLBListenerPortMin: {
-				Type:        schema.TypeInt,
-				Computed:    true,
-				Description: "The inclusive lower bound of the range of ports used by this listener. Only load balancers in the `network` family support more than one port per listener.",
+				Type:         schema.TypeInt,
+				Optional:     true,
+				ValidateFunc: validate.ValidateLBListenerPort,
+				Computed:     true,
+				Description:  "The inclusive lower bound of the range of ports used by this listener. Only load balancers in the `network` family support more than one port per listener.",
 			},
+
 			isLBListenerPortMax: {
-				Type:        schema.TypeInt,
-				Computed:    true,
-				Description: "The inclusive upper bound of the range of ports used by this listener. Only load balancers in the `network` family support more than one port per listener",
+				Type:         schema.TypeInt,
+				Optional:     true,
+				ValidateFunc: validate.ValidateLBListenerPort,
+				Computed:     true,
+				Description:  "The inclusive upper bound of the range of ports used by this listener. Only load balancers in the `network` family support more than one port per listener",
 			},
 
 			isLBListenerProtocol: {
@@ -194,6 +199,8 @@ func resourceIBMISLBListenerCreate(d *schema.ResourceData, meta interface{}) err
 	log.Printf("[DEBUG] LB Listener create")
 	lbID := d.Get(isLBListenerLBID).(string)
 	port := int64(d.Get(isLBListenerPort).(int))
+	portMin := int64(d.Get(isLBListenerPortMin).(int))
+	portMax := int64(d.Get(isLBListenerPortMax).(int))
 	protocol := d.Get(isLBListenerProtocol).(string)
 	var defPool, certificateCRN string
 	if pool, ok := d.GetOk(isLBListenerDefaultPool); ok {
@@ -236,7 +243,7 @@ func resourceIBMISLBListenerCreate(d *schema.ResourceData, meta interface{}) err
 	conns.IbmMutexKV.Lock(isLBKey)
 	defer conns.IbmMutexKV.Unlock(isLBKey)
 
-	err := lbListenerCreate(d, meta, lbID, protocol, defPool, certificateCRN, listener, uri, port, connLimit, httpStatusCode)
+	err := lbListenerCreate(d, meta, lbID, protocol, defPool, certificateCRN, listener, uri, port, portMin, portMax, connLimit, httpStatusCode)
 	if err != nil {
 		return err
 	}
@@ -244,7 +251,7 @@ func resourceIBMISLBListenerCreate(d *schema.ResourceData, meta interface{}) err
 	return resourceIBMISLBListenerRead(d, meta)
 }
 
-func lbListenerCreate(d *schema.ResourceData, meta interface{}, lbID, protocol, defPool, certificateCRN, listener, uri string, port, connLimit, httpStatusCode int64) error {
+func lbListenerCreate(d *schema.ResourceData, meta interface{}, lbID, protocol, defPool, certificateCRN, listener, uri string, port, portMin, portMax, connLimit, httpStatusCode int64) error {
 	sess, err := vpcClient(meta)
 	if err != nil {
 		return err
@@ -263,15 +270,38 @@ func lbListenerCreate(d *schema.ResourceData, meta interface{}, lbID, protocol, 
 	if err != nil || lb == nil {
 		return fmt.Errorf("[ERROR] Error getting Load Balancer : %s\n%s", err, response)
 	}
-
 	if lb != nil && *lb.RouteMode && lb.Profile != nil && *lb.Profile.Name == "network-fixed" {
-		portMin := int64(1)
-		portMax := int64(65535)
+		if portMin > 0 && portMax > 0 && portMin != 1 && portMax != 65535 {
+			return fmt.Errorf("[ERROR] Only acceptable value for port_min is 1 and port_max is 65535 for route_mode enabled private network load balancer")
+		}
+		pmin := int64(1)
+		pmax := int64(65535)
 
-		options.PortMin = &portMin
-		options.PortMax = &portMax
-	} else {
-		options.Port = &port
+		options.PortMin = &pmin
+		options.PortMax = &pmax
+	} else if lb != nil && lb.Profile != nil {
+		if strings.EqualFold(*lb.Profile.Family, "network") && *lb.IsPublic {
+			if port == 0 && (portMin == 0 || portMax == 0) {
+				return fmt.Errorf(
+					"[ERROR] Error port_min(%d)/port_max(%d) for public network load balancer(%s) needs to be in between 1-65335", portMin, portMax, lbID)
+			} else {
+				if port != 0 {
+					options.Port = &port
+				} else {
+					options.PortMin = &portMin
+					options.PortMax = &portMax
+				}
+			}
+		} else if portMin != portMax {
+			return fmt.Errorf("[ERROR] Listener port_min and port_max values have to be equal for ALB and private NLB (excluding route mode)")
+		} else {
+			if port != 0 && (portMin == 0 || port == portMin) {
+				options.Port = &port
+			} else {
+				options.PortMin = &portMin
+				options.PortMax = &portMax
+			}
+		}
 	}
 
 	if app, ok := d.GetOk(isLBListenerAcceptProxyProtocol); ok {
@@ -517,9 +547,19 @@ func lbListenerUpdate(d *schema.ResourceData, meta interface{}, lbID, lbListener
 			loadBalancerListenerPatchModel.HTTPSRedirect = HTTPSRedirect
 		}
 	}
-	if d.HasChange(isLBListenerPort) {
+	if _, ok := d.GetOk(isLBListenerPort); ok && d.HasChange(isLBListenerPort) {
 		port = int64(d.Get(isLBListenerPort).(int))
 		loadBalancerListenerPatchModel.Port = &port
+		hasChanged = true
+	}
+	if d.HasChange(isLBListenerPortMin) {
+		portMin := int64(d.Get(isLBListenerPortMin).(int))
+		loadBalancerListenerPatchModel.PortMin = &portMin
+		hasChanged = true
+	}
+	if d.HasChange(isLBListenerPortMax) {
+		portMax := int64(d.Get(isLBListenerPortMax).(int))
+		loadBalancerListenerPatchModel.PortMax = &portMax
 		hasChanged = true
 	}
 

--- a/ibm/service/vpc/resource_ibm_is_lb_listener_test.go
+++ b/ibm/service/vpc/resource_ibm_is_lb_listener_test.go
@@ -107,6 +107,66 @@ func TestAccIBMISNLBRouteModeListener_basic(t *testing.T) {
 		},
 	})
 }
+func TestAccIBMISNLBPortRangeListener_basic(t *testing.T) {
+	var lb string
+	vpcname := fmt.Sprintf("tflblis-vpc-%d", acctest.RandIntRange(10, 100))
+	subnetname := fmt.Sprintf("tflblis-subnet-%d", acctest.RandIntRange(10, 100))
+	lbname := fmt.Sprintf("tflblis%d", acctest.RandIntRange(10, 100))
+
+	protocol1 := "tcp"
+	portMin := "20"
+	portMax := "40"
+	portMin1 := "20"
+	portMax2 := "40"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { acc.TestAccPreCheck(t) },
+		Providers:    acc.TestAccProviders,
+		CheckDestroy: testAccCheckIBMISLBListenerDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckIBMISNLBPortRangeListenerConfig(vpcname, subnetname, acc.ISZoneName, acc.ISCIDR, lbname, portMin, portMax, protocol1),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckIBMISLBListenerExists("ibm_is_lb_listener.testacc_lb_listener", lb),
+					resource.TestCheckResourceAttr(
+						"ibm_is_lb.testacc_LB", "name", lbname),
+					resource.TestCheckResourceAttr(
+						"ibm_is_lb.testacc_LB", "type", "public"),
+					resource.TestCheckResourceAttr(
+						"ibm_is_lb.testacc_LB", "route_mode", "false"),
+					resource.TestCheckResourceAttr(
+						"ibm_is_lb_listener.testacc_lb_listener", "port", portMin),
+					resource.TestCheckResourceAttr(
+						"ibm_is_lb_listener.testacc_lb_listener", "port_min", portMin),
+					resource.TestCheckResourceAttr(
+						"ibm_is_lb_listener.testacc_lb_listener", "port_max", portMax),
+					resource.TestCheckResourceAttr(
+						"ibm_is_lb_listener.testacc_lb_listener", "protocol", protocol1),
+				),
+			},
+			{
+				Config: testAccCheckIBMISNLBPortRangeListenerConfig(vpcname, subnetname, acc.ISZoneName, acc.ISCIDR, lbname, portMin1, portMax2, protocol1),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckIBMISLBListenerExists("ibm_is_lb_listener.testacc_lb_listener", lb),
+					resource.TestCheckResourceAttr(
+						"ibm_is_lb.testacc_LB", "name", lbname),
+					resource.TestCheckResourceAttr(
+						"ibm_is_lb.testacc_LB", "type", "public"),
+					resource.TestCheckResourceAttr(
+						"ibm_is_lb.testacc_LB", "route_mode", "false"),
+					resource.TestCheckResourceAttr(
+						"ibm_is_lb_listener.testacc_lb_listener", "port", portMin1),
+					resource.TestCheckResourceAttr(
+						"ibm_is_lb_listener.testacc_lb_listener", "port_min", portMin1),
+					resource.TestCheckResourceAttr(
+						"ibm_is_lb_listener.testacc_lb_listener", "port_max", portMax2),
+					resource.TestCheckResourceAttr(
+						"ibm_is_lb_listener.testacc_lb_listener", "protocol", protocol1),
+				),
+			},
+		},
+	})
+}
 
 func TestAccIBMISLBListenerHttpRedirect_basic(t *testing.T) {
 	var lb string
@@ -372,6 +432,32 @@ func testAccCheckIBMISNLBRouteModeListenerConfig(vpcname, subnetname, zone, cidr
 		port 		= %s
 		protocol 	= "%s"
 }`, vpcname, subnetname, zone, cidr, lbname, port, protocol)
+
+}
+func testAccCheckIBMISNLBPortRangeListenerConfig(vpcname, subnetname, zone, cidr, lbname, portMin, portMax, protocol string) string {
+	return fmt.Sprintf(`
+	resource "ibm_is_vpc" "testacc_vpc" {
+		name = "%s"
+	}
+
+	resource "ibm_is_subnet" "testacc_subnet" {
+		name 			= "%s"
+		vpc 			= "${ibm_is_vpc.testacc_vpc.id}"
+		zone 			= "%s"
+		ipv4_cidr_block = "%s"
+	}
+	resource "ibm_is_lb" "testacc_LB" {
+		name			= "%s"
+		subnets 		= ["${ibm_is_subnet.testacc_subnet.id}"]
+		profile 		= "network-fixed"
+		type 			= "public"
+	}
+	resource "ibm_is_lb_listener" "testacc_lb_listener" {
+		lb 			= "${ibm_is_lb.testacc_LB.id}"
+		port_min 	= %s
+		port_max 	= %s
+		protocol 	= "%s"
+}`, vpcname, subnetname, zone, cidr, lbname, portMin, portMax, protocol)
 
 }
 

--- a/website/docs/r/is_lb.html.markdown
+++ b/website/docs/r/is_lb.html.markdown
@@ -59,7 +59,8 @@ Review the argument references that you can specify for your resource.
 - `profile` - (Optional, Forces new resource, String) For a Network Load Balancer, this attribute is required and should be set to `network-fixed`. For Application Load Balancer, profile is not a required attribute.
 - `resource_group` - (Optional, Forces new resource, String) The resource group where the load balancer to be created.
 - `route_mode` - (Optional, Forces new resource, Bool) Indicates whether route mode is enabled for this load balancer.
-  ~> **NOTE:** Currently, public load balancers are not supported with `route_mode` enabled.
+
+  ~> **NOTE:** Currently, `route_mode` enabled is supported only by private network load balancers.
 - `security_groups`  (Optional, List) A list of security groups to use for this load balancer. This option is supported only for application load balancers.
 - `subnets` - (Required, Forces new resource, List) List of the subnets IDs to connect to the load balancer.
 - `tags` (Optional, Array of Strings) A list of tags that you want to add to your load balancer. Tags can help you find the load balancer more easily later.

--- a/website/docs/r/is_lb_listener.html.markdown
+++ b/website/docs/r/is_lb_listener.html.markdown
@@ -112,6 +112,41 @@ resource "ibm_is_lb_listener" "example" {
 }
 ```
 
+### Sample to create a public load balancer listener with range of ports.
+
+```terraform
+resource "ibm_is_vpc" "example" {
+  name = "example-vpc"
+}
+
+resource "ibm_is_subnet" "example" {
+  name            = "example-subnet"
+  vpc             = ibm_is_vpc.example.id
+  zone            = "us-south-2"
+  ipv4_cidr_block = "10.240.68.0/24"
+}
+
+resource "ibm_is_lb" "example" {
+  name       = "example-lb"
+  subnets    = [ibm_is_subnet.example.id]
+  profile    = "network-fixed"
+  type       = "public"
+}
+
+resource "ibm_is_lb_listener" "example1" {
+  lb        = ibm_is_lb.example.id
+  protocol  = "tcp"
+  port_min 	= 100
+  port_max 	= 200
+}
+resource "ibm_is_lb_listener" "example2" {
+  lb        = ibm_is_lb.example.id
+  protocol  = "tcp"
+  port_min 	= 300
+  port_max 	= 400
+}
+```
+
 ## Timeouts
 The `ibm_is_lb_listener` resource provides the following [Timeouts](https://www.terraform.io/docs/language/resources/syntax.html) configuration options:
 
@@ -125,11 +160,23 @@ Review the argument references that you can specify for your resource.
 
 - `accept_proxy_protocol`- (Optional, Bool)  If set to **true**, listener forwards proxy protocol information that are supported by load balancers in the application family. Default value is **false**.
 - `lb` - (Required, Forces new resource, String) The load balancer unique identifier.
+
 - `port`- (Optional, Integer) The listener port number. Valid range `1` to `65535`.
 
-  ~> **NOTE:**:
-    - Private network load balancers with `route_mode` enabled don't support `port`, they support `port` range from `port_min`(1) - `port_max`(65535).
-    - Only accepted value of `port` for `route_mode` enabled private network load balancer is `1`. Any other value will show change or update-in-place and returns an error.
+  ~> **NOTE**
+    Private network load balancers with `route_mode` enabled don't support `port`, they support only one port range from `port_min (1)` - `port_max (65535)`. Only accepted value of `port` for `route_mode` enabled private network load balancer is `1`. Any other value will show change or update-in-place and returns an error.
+
+  ~> **NOTE**
+    Either use `port` or (`port_min`-`port_max`) for public network load balancers 
+- `port_min`- (Optional, Integer) The inclusive lower bound of the range of ports used by this listener.
+
+  ~> **NOTE**
+    Only load balancers in the `network` family support more than one port per listener. When route mode is enabled, only a value of `1` is supported for `port_min`.
+
+- `port_max`- (Optional, Integer) The inclusive upper bound of the range of ports used by this listener.
+
+  ~> **NOTE**
+    Only load balancers in the `network` family support more than one port per listener. When `route mode` is enabled, only a value of `65535` is supported for port_max.
 
 - `protocol` - (Required, String) The listener protocol. Enumeration type are `http`, `tcp`, and `https`. Network load balancer supports only `tcp` protocol.
 - `default_pool` - (Optional, String) The load balancer pool unique identifier.
@@ -143,16 +190,6 @@ Review the argument references that you can specify for your resource.
 In addition to all argument reference list, you can access the following attribute reference after your resource is created.
 
 - `id` - (String) The unique identifier of the load balancer listener.
-- `port_min`- (Integer) The inclusive lower bound of the range of ports used by this listener.
-
-  ~> **NOTE:**
-    - Only load balancers in the `network` family support more than one port per listener.
-    - Currently, only load balancers operating with route mode enabled support different values for `port_min` and port_max. When route mode is enabled, only a value of `1` is supported for `port_min`.
-- `port_max`- (Integer) The inclusive upper bound of the range of ports used by this listener.
-
-  ~> **NOTE:**
-    - Only load balancers in the `network` family support more than one port per listener.
-    - Currently, only load balancers operating with `route_mode` enabled support different values for `port_min` and `port_max`. When `route mode` is enabled, only a value of `65535` is supported for port_max.
 - `status` - (String) The status of load balancer listener.
 
 ## Import


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/IBM-Cloud/terraform-provider-ibm/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
--- PASS: TestAccIBMISNLBPortRangeListener_basic (975.93s)
PASS
ok      github.com/IBM-Cloud/terraform-provider-ibm/ibm 980.482s
```
```
--- PASS: TestAccIBMISNLBRouteModeListener_basic (820.60s)
PASS
ok      github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/vpc     824.920s
```