### PR TITLE
Send the entire JSON payload for PUT HTTP call to update a Schematics…

### DIFF
--- a/ibm/service/schematics/resource_ibm_schematics_inventory.go
+++ b/ibm/service/schematics/resource_ibm_schematics_inventory.go
@@ -213,37 +213,43 @@ func resourceIBMSchematicsInventoryUpdate(context context.Context, d *schema.Res
 
 	hasChange := false
 
+	/*************************************************************************************** /
+	 * The Schematics Inventory PATCH API is not currently working, so I changed here to     *
+	 * send the complete payload to the Replace Inventory API (PUT method) once there is a   *
+	 * change identified by this plugin.                                                     *
+	 ****************************************************************************************/
 	if d.HasChange("name") {
-		updateInventoryOptions.SetName(d.Get("name").(string))
 		hasChange = true
 	}
 	if d.HasChange("description") {
-		updateInventoryOptions.SetDescription(d.Get("description").(string))
 		hasChange = true
 	}
 	if d.HasChange("location") {
-		updateInventoryOptions.SetLocation(d.Get("location").(string))
 		hasChange = true
 	}
 	if d.HasChange("resource_group") {
-		updateInventoryOptions.SetResourceGroup(d.Get("resource_group").(string))
 		hasChange = true
 	}
 	if d.HasChange("inventories_ini") {
-		updateInventoryOptions.SetInventoriesIni(d.Get("inventories_ini").(string))
 		hasChange = true
 	}
 	if d.HasChange("resource_queries") {
-		resourceQueriesAttr := d.Get("resource_queries").([]string)
-		if len(resourceQueriesAttr) > 0 {
-			resourceQueries := d.Get("resource_queries").([]string)
-			updateInventoryOptions.SetResourceQueries(resourceQueries)
-		}
-
 		hasChange = true
 	}
 
 	if hasChange {
+		updateInventoryOptions.SetName(d.Get("name").(string))
+		updateInventoryOptions.SetDescription(d.Get("description").(string))
+		updateInventoryOptions.SetLocation(d.Get("location").(string))
+		updateInventoryOptions.SetResourceGroup(d.Get("resource_group").(string))
+		updateInventoryOptions.SetInventoriesIni(d.Get("inventories_ini").(string))
+
+		resourceQueriesAttr := d.Get("resource_queries").([]interface{})
+		if len(resourceQueriesAttr) > 0 {
+			// resourceQueries := d.Get("resource_queries").([]string)
+			updateInventoryOptions.SetResourceQueries(flex.ExpandStringList(d.Get("resource_queries").([]interface{})))
+		}
+
 		_, response, err := schematicsClient.ReplaceInventoryWithContext(context, updateInventoryOptions)
 		if err != nil {
 			log.Printf("[DEBUG] UpdateInventoryWithContext failed %s\n%s", err, response)


### PR DESCRIPTION
… Inventory

<!--- See what makes a good Pull Request at : https://github.com/IBM-Cloud/terraform-provider-ibm/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #3678

Output from acceptance testing:
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test $(go list ./... |grep -v 'vendor') -v -run=TestAccIBMSchematicsInventoryBasic -timeout 700m
......
[WARN] Set the environment variable IBM_CLUSTER_VPC_RESOURCE_GROUP_ID for testing ibm_container_vpc_alb_create resources, ibm_container_vpc_alb_creates tests will fail if this is not set
[INFO] Set the environment variable IBM_CONTAINER_CLUSTER_NAME for ibm_container_nlb_dns resource or datasource else tests will fail if this is not set correctly
=== RUN   TestAccIBMSchematicsInventoryBasic
--- PASS: TestAccIBMSchematicsInventoryBasic (12.88s)
PASS
ok      github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/schematics      (cached)
[WARN] Set the environment variable IBM_APPID_TENANT_ID for testing AppID resources, AppID tests will fail if this is not set
....


==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test $(go list ./... |grep -v 'vendor') -v -run=TestAccIBMSchematicsInventoryAllArgs -timeout 700m
.......
[WARN] Set the environment variable IBM_CLUSTER_VPC_RESOURCE_GROUP_ID for testing ibm_container_vpc_alb_create resources, ibm_container_vpc_alb_creates tests will fail if this is not set
[INFO] Set the environment variable IBM_CONTAINER_CLUSTER_NAME for ibm_container_nlb_dns resource or datasource else tests will fail if this is not set correctly
=== RUN   TestAccIBMSchematicsInventoryAllArgs
--- PASS: TestAccIBMSchematicsInventoryAllArgs (26.19s)
PASS
ok      github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/schematics      30.412s
[WARN] Set the environment variable IBM_APPID_TENANT_ID for testing AppID resources, AppID tests will fail if this is not set
[WARN] Set the environment variable IBM_APPID_TEST_USER_EMAIL for testing AppID user resources, the tests will fail if this is not set


<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```
