### PR TITLE
Added fix for lb pool member weight (optional attribute)  assigned 0 when not provided

### DIFF
--- a/ibm/service/vpc/resource_ibm_is_lb_pool_member.go
+++ b/ibm/service/vpc/resource_ibm_is_lb_pool_member.go
@@ -213,9 +213,7 @@ func lbpMemberCreate(d *schema.ResourceData, meta interface{}, lbID, lbPoolID st
 	}
 	if w, ok := d.GetOkExists(isLBPoolMemberWeight); ok {
 		weight = int64(w.(int))
-		if ok {
-			options.Weight = &weight
-		}
+		options.Weight = &weight
 	}
 
 	lbPoolMember, response, err := sess.CreateLoadBalancerPoolMember(options)

--- a/ibm/service/vpc/resource_ibm_is_lb_pool_member.go
+++ b/ibm/service/vpc/resource_ibm_is_lb_pool_member.go
@@ -164,9 +164,7 @@ func resourceIBMISLBPoolMemberCreate(d *schema.ResourceData, meta interface{}) e
 	port64 := int64(port)
 
 	var weight int64
-	if w, ok := d.GetOkExists(isLBPoolMemberWeight); ok {
-		weight = int64(w.(int))
-	}
+
 	isLBKey := "load_balancer_key_" + lbID
 	conns.IbmMutexKV.Lock(isLBKey)
 	defer conns.IbmMutexKV.Unlock(isLBKey)
@@ -213,7 +211,12 @@ func lbpMemberCreate(d *schema.ResourceData, meta interface{}, lbID, lbPoolID st
 		}
 		options.Target = target
 	}
-	options.Weight = &weight
+	if w, ok := d.GetOkExists(isLBPoolMemberWeight); ok {
+		weight = int64(w.(int))
+		if ok {
+			options.Weight = &weight
+		}
+	}
 
 	lbPoolMember, response, err := sess.CreateLoadBalancerPoolMember(options)
 	if err != nil {

--- a/ibm/service/vpc/resource_ibm_is_lb_pool_member_test.go
+++ b/ibm/service/vpc/resource_ibm_is_lb_pool_member_test.go
@@ -70,8 +70,7 @@ func TestAccIBMISLBPoolMember_basic_network(t *testing.T) {
 	nlbName := fmt.Sprintf("tfnlbcreate%d", acctest.RandIntRange(10, 100))
 	nlbName1 := fmt.Sprintf("tfnlbupdate%d", acctest.RandIntRange(10, 100))
 
-	// sshname := "terraform-test-ssh-key"
-	sshname := "ssh-test-bhavesh"
+	sshname := "terraform-test-ssh-key"
 	vsiName := fmt.Sprintf("tf-instance-%d", acctest.RandIntRange(10, 100))
 
 	resource.Test(t, resource.TestCase{

--- a/website/docs/r/is_lb_pool_member.html.markdown
+++ b/website/docs/r/is_lb_pool_member.html.markdown
@@ -63,7 +63,7 @@ Review the argument references that you can specify for your resource.
 - `port`- (Required, Integer) The port number of the application running in the server member.
 - `target_address` - (Required, String) The IP address of the pool member.
 - `target_id` - (Required, String) The unique identifier for the virtual server instance pool member. Required for network load balancer.
-- `weight` - (Optional, Integer) Weight of the server member. This option takes effect only when the load-balancing algorithm of its belonging pool is `weighted_round_robin`, Minimum allowed weight is `0` and Maximum allowed weight is `100`.
+- `weight` - (Optional, Integer) Weight of the server member. This option takes effect only when the load-balancing algorithm of its belonging pool is `weighted_round_robin`, Minimum allowed weight is `0` and Maximum allowed weight is `100`. When weight is not provided a default of 40 is returned.
 
 ## Attribute reference
 In addition to all argument reference list, you can access the following attribute reference after your resource is created.


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/IBM-Cloud/terraform-provider-ibm/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TEST=./ibm/service/vpc TESTARGS='-run=TestAccIBMISLBPoolMember_basic_opt_weight_check'
=== RUN   TestAccIBMISLBPoolMember_basic_opt_weight_check
--- PASS: TestAccIBMISLBPoolMember_basic_opt_weight_check (807.13s)
PASS
ok  	github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/vpc	808.130s

make testacc TEST=./ibm/service/vpc TESTARGS='-run=TestAccIBMISLBPoolMember_basic'
=== RUN   TestAccIBMISLBPoolMember_basic
--- PASS: TestAccIBMISLBPoolMember_basic (1068.65s)

make testacc TEST=./ibm/service/vpc TESTARGS='-run=TestAccIBMISLBPoolMember_basic_network'
--- PASS: TestAccIBMISLBPoolMember_basic_network (1045.05s)
PASS
ok  	github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/vpc	1046.405s

...
```
