### PR TITLE
fix(sshkey): add DiffSuppressFunc for public key for ibm_is_ssh_key resource

### DIFF
--- a/ibm/service/vpc/resource_ibm_is_ssh_key.go
+++ b/ibm/service/vpc/resource_ibm_is_ssh_key.go
@@ -5,15 +5,19 @@ package vpc
 
 import (
 	"context"
+	"encoding/base64"
+	"errors"
 	"fmt"
 	"log"
 	"os"
+	"strings"
 
 	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/flex"
 	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/validate"
 	"github.com/IBM/vpc-go-sdk/vpcv1"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/customdiff"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"golang.org/x/crypto/ssh"
 )
 
 const (
@@ -52,10 +56,11 @@ func ResourceIBMISSSHKey() *schema.Resource {
 			},
 
 			isKeyPublicKey: {
-				Type:        schema.TypeString,
-				Required:    true,
-				ForceNew:    true,
-				Description: "SSH Public key data",
+				Type:             schema.TypeString,
+				Required:         true,
+				ForceNew:         true,
+				DiffSuppressFunc: suppressPublicKeyDiff,
+				Description:      "SSH Public key data",
 			},
 
 			isKeyType: {
@@ -373,4 +378,59 @@ func keyExists(d *schema.ResourceData, meta interface{}, id string) (bool, error
 		return false, fmt.Errorf("[ERROR] Error getting SSH Key: %s\n%s", err, response)
 	}
 	return true, nil
+}
+
+// to suppress any change shown when keys are same
+func suppressPublicKeyDiff(k, old, new string, d *schema.ResourceData) bool {
+	// if there are extra spaces or new lines, suppress that change
+	if strings.Compare(strings.TrimSpace(old), strings.TrimSpace(new)) != 0 {
+		// if old is empty
+		if old != "" {
+			//create a new piblickey object from the string
+			usePK, error := parseKey(new)
+			if error != nil {
+				return false
+			}
+			// returns the key in byte format with an extra added new line at the end
+			newkey := strings.TrimRight(string(ssh.MarshalAuthorizedKey(usePK)), "\n")
+			// check if both keys are same, if yes suppress the change
+			return strings.TrimSpace(strings.TrimPrefix(newkey, old)) == ""
+		} else {
+			return strings.TrimSpace(strings.TrimPrefix(new, old)) == ""
+		}
+	} else {
+		return true
+	}
+}
+
+// takes a string and returns public key object
+func parseKey(s string) (ssh.PublicKey, error) {
+	keyBytes := []byte(s)
+
+	// Accepts formats of PublicKey:
+	// - <base64 key>
+	// - ssh-rsa <base64 key>
+	// - ssh-rsa <base64 key> <comment>
+	// if PublicKey provides other than just base64 key, then first part must be "ssh-rsa"
+	if subStrs := strings.Split(s, " "); len(subStrs) > 1 && subStrs[0] != "ssh-rsa" {
+		return nil, errors.New("not an RSA key")
+	}
+
+	pk, _, _, _, e := ssh.ParseAuthorizedKey(keyBytes)
+	if e == nil {
+		return pk, nil
+	}
+
+	decodedKey := make([]byte, base64.StdEncoding.DecodedLen(len(keyBytes)))
+	n, e := base64.StdEncoding.Decode(decodedKey, keyBytes)
+	if e != nil {
+		return nil, e
+	}
+	decodedKey = decodedKey[:n]
+
+	pk, e = ssh.ParsePublicKey(decodedKey)
+	if e == nil {
+		return pk, nil
+	}
+	return nil, e
 }

--- a/ibm/service/vpc/resource_ibm_is_ssh_key_test.go
+++ b/ibm/service/vpc/resource_ibm_is_ssh_key_test.go
@@ -40,6 +40,35 @@ ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCKVmnMOlHKcZK8tpt3MP1lqOLAcqcJzhsvJcjscgVE
 		},
 	})
 }
+func TestAccIBMISSSHKey_Newlinebasic(t *testing.T) {
+	var key, key1 string
+	publicKeyTrim := strings.TrimSpace(`ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQDKd3e4uoENwyLGDxpUyxkeC008r6JOHGkeF4HxEUrE2ZkTXvuOyRaF8Utyv12U5Jvpf/NQVGmdlG3rQPY5VRELthr8mhNWexY5WYo/zXSZNjHCjozpL101bcxfNG498y6uv6UoTk6geJcmckVjOYY/2T9F2B1q6dQxIsYIghjfZBFM6+wA136Nx0nof2lZiK7KAIzIlgUY3g3hhno0x5FmJHM9waoHXFLgQA0psz8XUcSt2Zr0JGFOm5U6HV/tvoP4AVB5YrhRatHry2Ulfh4acy0wswgRM0zieU0U/nLJbCgDVLwZyABEC6WcLTfrkkI53I9oYb8XyeWpyRFQLfT7AIIjfgT7q0q4gzSKTJSDR85SHhOmC/bhCDBuJ9s1ICyschF1y8lPjL/maxweNorg3RfuqsZZdmNHR9RKSxt7CPM98Z6yu5wMWRVLC6Ux5MGp6m0mDIJOfaZla6uvp8d/G6cjWCdU5eCeBh6XdQn4UDXwEB/s86lpgbDsPLMCleP8J+w8uZPQA1KZ+uWGBjoswhtOCa6bU/6ZuTqGpQVOGjVOWUGOq/ocvR03ucj6fBKViFWxV75ABXfJLarKkkIMlv9IeJ05NZG6kQjiCRN4T2I0gd9lAm0YqcITEqcN4Wgbm1z2zPwvMyWuMCW3LY4932JHKQkCEXgGBAtsnrXhZw==`)
+	publicKeyTrim1 := strings.TrimSpace(`ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCKVmnMOlHKcZK8tpt3MP1lqOLAcqcJzhsvJcjscgVERRN7/9484SOBJ3HSKxxNG5JN8owAjy5f9yYwcUg+JaUVuytn5Pv3aeYROHGGg+5G346xaq3DAwX6Y5ykr2fvjObgncQBnuU5KHWCECO/4h8uWuwh/kfniXPVjFToc+gnkqA+3RKpAecZhFXwfalQ9mMuYGFxn+fwn8cYEApsJbsEmb0iJwPiZ5hjFC8wREuiTlhPHDgkBLOiycd20op2nXzDbHfCHInquEe/gYxEitALONxm0swBOwJZwlTDOB7C6y2dzlrtxr1L59m7pCkWI4EtTRLvleehBoj3u7jB4usR`)
+	name := fmt.Sprintf("tfssh-createname-%d", acctest.RandIntRange(10, 100))
+	name1 := fmt.Sprintf("tfssh-withsignaturename-%d", acctest.RandIntRange(10, 100))
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { acc.TestAccPreCheck(t) },
+		Providers:    acc.TestAccProviders,
+		CheckDestroy: checkKeyDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckIBMISKeyNewlineConfig(name, name1),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckIBMISKeyExists("ibm_is_ssh_key.isExampleKey", key),
+					testAccCheckIBMISKeyExists("ibm_is_ssh_key.isExampleKeyWithSignature", key1),
+					resource.TestCheckResourceAttr(
+						"ibm_is_ssh_key.isExampleKey", "name", name),
+					resource.TestCheckResourceAttr(
+						"ibm_is_ssh_key.isExampleKey", "public_key", publicKeyTrim),
+					resource.TestCheckResourceAttr(
+						"ibm_is_ssh_key.isExampleKeyWithSignature", "name", name1),
+					resource.TestCheckResourceAttr(
+						"ibm_is_ssh_key.isExampleKeyWithSignature", "public_key", publicKeyTrim1),
+				),
+			},
+		},
+	})
+}
 
 func checkKeyDestroy(s *terraform.State) error {
 	sess, _ := acc.TestAccProvider.Meta().(conns.ClientSession).VpcV1API()
@@ -93,4 +122,20 @@ func testAccCheckIBMISKeyConfig(publicKey, name string) string {
 			public_key = "%s"
 		}
 	`, name, publicKey)
+}
+func testAccCheckIBMISKeyNewlineConfig(name, name1 string) string {
+	return fmt.Sprintf(`
+		resource "ibm_is_ssh_key" "isExampleKey" {
+			name = "%s"
+			public_key = <<-EOT
+            ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQDKd3e4uoENwyLGDxpUyxkeC008r6JOHGkeF4HxEUrE2ZkTXvuOyRaF8Utyv12U5Jvpf/NQVGmdlG3rQPY5VRELthr8mhNWexY5WYo/zXSZNjHCjozpL101bcxfNG498y6uv6UoTk6geJcmckVjOYY/2T9F2B1q6dQxIsYIghjfZBFM6+wA136Nx0nof2lZiK7KAIzIlgUY3g3hhno0x5FmJHM9waoHXFLgQA0psz8XUcSt2Zr0JGFOm5U6HV/tvoP4AVB5YrhRatHry2Ulfh4acy0wswgRM0zieU0U/nLJbCgDVLwZyABEC6WcLTfrkkI53I9oYb8XyeWpyRFQLfT7AIIjfgT7q0q4gzSKTJSDR85SHhOmC/bhCDBuJ9s1ICyschF1y8lPjL/maxweNorg3RfuqsZZdmNHR9RKSxt7CPM98Z6yu5wMWRVLC6Ux5MGp6m0mDIJOfaZla6uvp8d/G6cjWCdU5eCeBh6XdQn4UDXwEB/s86lpgbDsPLMCleP8J+w8uZPQA1KZ+uWGBjoswhtOCa6bU/6ZuTqGpQVOGjVOWUGOq/ocvR03ucj6fBKViFWxV75ABXfJLarKkkIMlv9IeJ05NZG6kQjiCRN4T2I0gd9lAm0YqcITEqcN4Wgbm1z2zPwvMyWuMCW3LY4932JHKQkCEXgGBAtsnrXhZw==
+        EOT
+		}
+		resource "ibm_is_ssh_key" "isExampleKeyWithSignature" {
+			name = "%s"
+			public_key = <<-EOT
+            ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCKVmnMOlHKcZK8tpt3MP1lqOLAcqcJzhsvJcjscgVERRN7/9484SOBJ3HSKxxNG5JN8owAjy5f9yYwcUg+JaUVuytn5Pv3aeYROHGGg+5G346xaq3DAwX6Y5ykr2fvjObgncQBnuU5KHWCECO/4h8uWuwh/kfniXPVjFToc+gnkqA+3RKpAecZhFXwfalQ9mMuYGFxn+fwn8cYEApsJbsEmb0iJwPiZ5hjFC8wREuiTlhPHDgkBLOiycd20op2nXzDbHfCHInquEe/gYxEitALONxm0swBOwJZwlTDOB7C6y2dzlrtxr1L59m7pCkWI4EtTRLvleehBoj3u7jB4usR  abc@abc-MacBook-Pro.local
+        EOT
+		}
+	`, name, name1)
 }


### PR DESCRIPTION

<!--- See what makes a good Pull Request at : https://github.com/IBM-Cloud/terraform-provider-ibm/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #3639

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
--- PASS: TestAccIBMISSSHKey_Newlinebasic (49.17s)
PASS
ok      github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/vpc     50.847s
```
```
--- PASS: TestAccIBMISSSHKey_basic (61.91s)
PASS
ok      github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/vpc     63.003s
```