### PR TITLE
Relocating all power constants to one file

### DIFF
--- a/ibm/service/power/data_source_ibm_pi_keys.go
+++ b/ibm/service/power/data_source_ibm_pi_keys.go
@@ -17,13 +17,6 @@ import (
 	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/conns"
 )
 
-const (
-	PIKeys    = "keys"
-	PIKeyName = "name"
-	PIKey     = "ssh_key"
-	PIKeyDate = "creation_date"
-)
-
 func DataSourceIBMPIKeys() *schema.Resource {
 	return &schema.Resource{
 		ReadContext: dataSourceIBMPIKeysRead,

--- a/ibm/service/power/data_source_ibm_pi_sap_profiles.go
+++ b/ibm/service/power/data_source_ibm_pi_sap_profiles.go
@@ -17,15 +17,6 @@ import (
 	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/conns"
 )
 
-const (
-	PISAPProfiles         = "profiles"
-	PISAPProfileCertified = "certified"
-	PISAPProfileCores     = "cores"
-	PISAPProfileMemory    = "memory"
-	PISAPProfileID        = "profile_id"
-	PISAPProfileType      = "type"
-)
-
 func DataSourceIBMPISAPProfiles() *schema.Resource {
 	return &schema.Resource{
 		ReadContext: dataSourceIBMPISAPProfilesRead,

--- a/ibm/service/power/ibm_pi_constants.go
+++ b/ibm/service/power/ibm_pi_constants.go
@@ -1,0 +1,64 @@
+package power
+
+import "time"
+
+const (
+
+	// Keys
+	PIKeys    = "keys"
+	PIKeyName = "name"
+	PIKey     = "ssh_key"
+	PIKeyDate = "creation_date"
+
+	// SAP Profile
+	PISAPProfiles         = "profiles"
+	PISAPProfileCertified = "certified"
+	PISAPProfileCores     = "cores"
+	PISAPProfileMemory    = "memory"
+	PISAPProfileID        = "profile_id"
+	PISAPProfileType      = "type"
+
+	// DHCP
+	PIDhcpStatusBuilding = "Building"
+	PIDhcpStatusActive   = "ACTIVE"
+	PIDhcpDeleting       = "Deleting"
+	PIDhcpDeleted        = "Deleted"
+	PIDhcpId             = "dhcp_id"
+	PIDhcpStatus         = "status"
+	PIDhcpNetwork        = "network"
+	PIDhcpLeases         = "leases"
+	PIDhcpInstanceIp     = "instance_ip"
+	PIDhcpInstanceMac    = "instance_mac"
+
+	// Instance
+	//Added timeout values for warning  and active status
+	warningTimeOut = 60 * time.Second
+	activeTimeOut  = 2 * time.Minute
+	// power service instance capabilities
+	CUSTOM_VIRTUAL_CORES          = "custom-virtualcores"
+	PIInstanceNetwork             = "pi_network"
+	PIInstanceStoragePool         = "pi_storage_pool"
+	PISAPInstanceProfileID        = "pi_sap_profile_id"
+	PIInstanceStoragePoolAffinity = "pi_storage_pool_affinity"
+
+	// Placement Group
+	PIPlacementGroupID      = "placement_group_id"
+	PIPlacementGroupMembers = "members"
+
+	// Volume
+	PIAffinityPolicy        = "pi_affinity_policy"
+	PIAffinityVolume        = "pi_affinity_volume"
+	PIAffinityInstance      = "pi_affinity_instance"
+	PIAntiAffinityInstances = "pi_anti_affinity_instances"
+	PIAntiAffinityVolumes   = "pi_anti_affinity_volumes"
+
+	// VPN
+	PIVPNConnectionId                         = "connection_id"
+	PIVPNConnectionStatus                     = "connection_status"
+	PIVPNConnectionDeadPeerDetection          = "dead_peer_detections"
+	PIVPNConnectionDeadPeerDetectionAction    = "action"
+	PIVPNConnectionDeadPeerDetectionInterval  = "interval"
+	PIVPNConnectionDeadPeerDetectionThreshold = "threshold"
+	PIVPNConnectionLocalGatewayAddress        = "local_gateway_address"
+	PIVPNConnectionVpnGatewayAddress          = "gateway_address"
+)

--- a/ibm/service/power/resource_ibm_pi_dhcp.go
+++ b/ibm/service/power/resource_ibm_pi_dhcp.go
@@ -21,19 +21,6 @@ import (
 	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/conns"
 )
 
-const (
-	PIDhcpStatusBuilding = "Building"
-	PIDhcpStatusActive   = "ACTIVE"
-	PIDhcpDeleting       = "Deleting"
-	PIDhcpDeleted        = "Deleted"
-	PIDhcpId             = "dhcp_id"
-	PIDhcpStatus         = "status"
-	PIDhcpNetwork        = "network"
-	PIDhcpLeases         = "leases"
-	PIDhcpInstanceIp     = "instance_ip"
-	PIDhcpInstanceMac    = "instance_mac"
-)
-
 func ResourceIBMPIDhcp() *schema.Resource {
 	return &schema.Resource{
 		CreateContext: resourceIBMPIDhcpCreate,

--- a/ibm/service/power/resource_ibm_pi_instance.go
+++ b/ibm/service/power/resource_ibm_pi_instance.go
@@ -23,18 +23,6 @@ import (
 	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/validate"
 )
 
-const (
-	//Added timeout values for warning  and active status
-	warningTimeOut = 60 * time.Second
-	activeTimeOut  = 2 * time.Minute
-	// power service instance capabilities
-	CUSTOM_VIRTUAL_CORES          = "custom-virtualcores"
-	PIInstanceNetwork             = "pi_network"
-	PIInstanceStoragePool         = "pi_storage_pool"
-	PISAPInstanceProfileID        = "pi_sap_profile_id"
-	PIInstanceStoragePoolAffinity = "pi_storage_pool_affinity"
-)
-
 func ResourceIBMPIInstance() *schema.Resource {
 	return &schema.Resource{
 		CreateContext: resourceIBMPIInstanceCreate,

--- a/ibm/service/power/resource_ibm_pi_placement_group.go
+++ b/ibm/service/power/resource_ibm_pi_placement_group.go
@@ -20,11 +20,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 )
 
-const (
-	PIPlacementGroupID      = "placement_group_id"
-	PIPlacementGroupMembers = "members"
-)
-
 func ResourceIBMPIPlacementGroup() *schema.Resource {
 	return &schema.Resource{
 		CreateContext: resourceIBMPIPlacementGroupCreate,

--- a/ibm/service/power/resource_ibm_pi_volume.go
+++ b/ibm/service/power/resource_ibm_pi_volume.go
@@ -22,14 +22,6 @@ import (
 	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/validate"
 )
 
-const (
-	PIAffinityPolicy        = "pi_affinity_policy"
-	PIAffinityVolume        = "pi_affinity_volume"
-	PIAffinityInstance      = "pi_affinity_instance"
-	PIAntiAffinityInstances = "pi_anti_affinity_instances"
-	PIAntiAffinityVolumes   = "pi_anti_affinity_volumes"
-)
-
 func ResourceIBMPIVolume() *schema.Resource {
 	return &schema.Resource{
 		CreateContext: resourceIBMPIVolumeCreate,

--- a/ibm/service/power/resource_ibm_pi_vpn_connection.go
+++ b/ibm/service/power/resource_ibm_pi_vpn_connection.go
@@ -23,17 +23,6 @@ import (
 	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/validate"
 )
 
-const (
-	PIVPNConnectionId                         = "connection_id"
-	PIVPNConnectionStatus                     = "connection_status"
-	PIVPNConnectionDeadPeerDetection          = "dead_peer_detections"
-	PIVPNConnectionDeadPeerDetectionAction    = "action"
-	PIVPNConnectionDeadPeerDetectionInterval  = "interval"
-	PIVPNConnectionDeadPeerDetectionThreshold = "threshold"
-	PIVPNConnectionLocalGatewayAddress        = "local_gateway_address"
-	PIVPNConnectionVpnGatewayAddress          = "gateway_address"
-)
-
 func ResourceIBMPIVPNConnection() *schema.Resource {
 	return &schema.Resource{
 		CreateContext: resourceIBMPIVPNConnectionCreate,


### PR DESCRIPTION
Most of the argument/attribute names for the power package are defined in an external helpers package.
Some of these constants are currently being defined in specific data_source files.

This PR moves the power argument/attribute constants defined in the terraform repo  to a singular constant file.
In the future, more PR's will consolidate all external/internal power argument/attribute constants into the new constants file

Files affected
 - data_source_ibm_pi_keys.go
 - data_source_ibm_pi_sap_profiles.go
 - resource_ibm_pi_dhcp.go
 - resource_ibm_pi_instance.go
 - resource_ibm_pi_placement_group.go
 - resource_ibm_pi_volume.go
 - resource_ibm_pi_vpn_connection.go

<!--- See what makes a good Pull Request at : https://github.com/IBM-Cloud/terraform-provider-ibm/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

Relates OR Closes #3600



