### PR TITLE
Allow any valid string for description in ibm_cis_filter/firewall_rules

### DIFF
--- a/ibm/service/cis/resource_ibm_cis_filter.go
+++ b/ibm/service/cis/resource_ibm_cis_filter.go
@@ -224,8 +224,7 @@ func ResourceIBMCISFilterValidator() *validate.ResourceValidator {
 			Identifier:                 cisFilterDescription,
 			ValidateFunctionIdentifier: validate.ValidateAllowedStringValue,
 			Type:                       validate.TypeString,
-			Required:                   true,
-			AllowedValues:              "Filter-creation"})
+			Required:                   true})
 
 	ibmCISFiltersResourceValidator := validate.ResourceValidator{ResourceName: ibmCISFilters, Schema: validateSchema}
 	return &ibmCISFiltersResourceValidator

--- a/ibm/service/cis/resource_ibm_cis_firewall_rules.go
+++ b/ibm/service/cis/resource_ibm_cis_firewall_rules.go
@@ -256,8 +256,7 @@ func ResourceIBMCISFirewallrulesValidator() *validate.ResourceValidator {
 			Identifier:                 cisFirewallrulesDescription,
 			ValidateFunctionIdentifier: validate.ValidateAllowedStringValue,
 			Type:                       validate.TypeString,
-			Required:                   true,
-			AllowedValues:              "Firewallrules-creation"})
+			Required:                   true})
 
 	validateSchema = append(validateSchema,
 		validate.ValidateSchema{


### PR DESCRIPTION
The description field is supposed to be free form string, however the
terraform provider requires it to be a single piece of example text
which makes it useless. Remove that incorrect validation constraint.

<!--- See what makes a good Pull Request at : https://github.com/IBM-Cloud/terraform-provider-ibm/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```
