### PR TITLE
Consolidate power image argument/attribute constants

### DIFF
--- a/ibm/service/power/data_source_ibm_pi_catalog_images.go
+++ b/ibm/service/power/data_source_ibm_pi_catalog_images.go
@@ -12,7 +12,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 
 	"github.com/IBM-Cloud/power-go-client/clients/instance"
-	"github.com/IBM-Cloud/power-go-client/helpers"
 	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/conns"
 )
 
@@ -26,85 +25,85 @@ func DataSourceIBMPICatalogImages() *schema.Resource {
 		ReadContext: dataSourceIBMPICatalogImagesRead,
 		Schema: map[string]*schema.Schema{
 
-			helpers.PICloudInstanceId: {
+			PICloudInstanceID: {
 				Type:         schema.TypeString,
 				Required:     true,
 				ValidateFunc: validation.NoZeroValues,
 			},
-			"sap": {
+			CatalogImagesSAP: {
 				Type:     schema.TypeBool,
 				Optional: true,
 			},
-			"vtl": {
+			CatalogImagesVTL: {
 				Type:     schema.TypeBool,
 				Optional: true,
 			},
-			"images": {
+			CatalogImages: {
 				Type:     schema.TypeList,
 				Computed: true,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
-						"image_id": {
+						ImageID: {
 							Type:     schema.TypeString,
 							Computed: true,
 						},
-						"name": {
+						ImageName: {
 							Type:     schema.TypeString,
 							Computed: true,
 						},
-						"state": {
+						ImageState: {
 							Type:     schema.TypeString,
 							Computed: true,
 						},
-						"description": {
+						ImageDescription: {
 							Type:     schema.TypeString,
 							Computed: true,
 						},
-						"storage_type": {
+						ImageStorageType: {
 							Type:     schema.TypeString,
 							Computed: true,
 						},
-						"storage_pool": {
+						ImageStoragePool: {
 							Type:     schema.TypeString,
 							Computed: true,
 						},
-						"creation_date": {
+						ImageCreationDate: {
 							Type:     schema.TypeString,
 							Computed: true,
 						},
-						"last_update_date": {
+						ImageLastUpdateDate: {
 							Type:     schema.TypeString,
 							Computed: true,
 						},
-						"image_type": {
+						ImageType: {
 							Type:     schema.TypeString,
 							Computed: true,
 						},
-						"container_format": {
+						ImageContainerFormat: {
 							Type:     schema.TypeString,
 							Computed: true,
 						},
-						"disk_format": {
+						ImageDiskFormat: {
 							Type:     schema.TypeString,
 							Computed: true,
 						},
-						"operating_system": {
+						CatalogImageOperatingSystem: {
 							Type:     schema.TypeString,
 							Computed: true,
 						},
-						"hypervisor_type": {
+						ImageHypervisorType: {
 							Type:     schema.TypeString,
 							Computed: true,
 						},
-						"architecture": {
+						ImageArchitecture: {
 							Type:     schema.TypeString,
 							Computed: true,
 						},
-						"endianness": {
+						ImageEndianness: {
 							Type:     schema.TypeString,
 							Computed: true,
 						},
-						"href": {
+						ImageHref: {
 							Type:     schema.TypeString,
 							Computed: true,
 						},
@@ -121,13 +120,13 @@ func dataSourceIBMPICatalogImagesRead(ctx context.Context, d *schema.ResourceDat
 		return diag.FromErr(err)
 	}
 
-	cloudInstanceID := d.Get(helpers.PICloudInstanceId).(string)
+	cloudInstanceID := d.Get(PICloudInstanceID).(string)
 	includeSAP := false
-	if s, ok := d.GetOk("sap"); ok {
+	if s, ok := d.GetOk(CatalogImagesSAP); ok {
 		includeSAP = s.(bool)
 	}
 	includeVTL := false
-	if v, ok := d.GetOk("vtl"); ok {
+	if v, ok := d.GetOk(CatalogImagesVTL); ok {
 		includeVTL = v.(bool)
 	}
 	imageC := instance.NewIBMPIImageClient(ctx, sess, cloudInstanceID)
@@ -139,57 +138,57 @@ func dataSourceIBMPICatalogImagesRead(ctx context.Context, d *schema.ResourceDat
 	images := make([]map[string]interface{}, 0)
 	for _, i := range stockImages.Images {
 		image := make(map[string]interface{})
-		image["image_id"] = *i.ImageID
-		image["name"] = *i.Name
+		image[ImageID] = *i.ImageID
+		image[ImageName] = *i.Name
 		if i.State != nil {
-			image["state"] = *i.State
+			image[ImageState] = *i.State
 		}
 		if i.Description != nil {
-			image["description"] = *i.Description
+			image[ImageDescription] = *i.Description
 		}
 		if i.StorageType != nil {
-			image["storage_type"] = *i.StorageType
+			image[ImageStorageType] = *i.StorageType
 		}
 		if i.StoragePool != nil {
-			image["storage_pool"] = *i.StoragePool
+			image[ImageStoragePool] = *i.StoragePool
 		}
 		if i.CreationDate != nil {
-			image["creation_date"] = i.CreationDate.String()
+			image[ImageCreationDate] = i.CreationDate.String()
 		}
 		if i.LastUpdateDate != nil {
-			image["last_update_date"] = i.LastUpdateDate.String()
+			image[ImageLastUpdateDate] = i.LastUpdateDate.String()
 		}
 		if i.Href != nil {
-			image["href"] = *i.Href
+			image[ImageHref] = *i.Href
 		}
 		if i.Specifications != nil {
 			s := i.Specifications
 			if &s.ImageType != nil {
-				image["image_type"] = s.ImageType
+				image[ImageType] = s.ImageType
 			}
 			if &s.ContainerFormat != nil {
-				image["container_format"] = s.ContainerFormat
+				image[ImageContainerFormat] = s.ContainerFormat
 			}
 			if &s.DiskFormat != nil {
-				image["disk_format"] = s.DiskFormat
+				image[ImageDiskFormat] = s.DiskFormat
 			}
 			if &s.OperatingSystem != nil {
-				image["operating_system"] = s.OperatingSystem
+				image[CatalogImageOperatingSystem] = s.OperatingSystem
 			}
 			if &s.HypervisorType != nil {
-				image["hypervisor_type"] = s.HypervisorType
+				image[ImageHypervisorType] = s.HypervisorType
 			}
 			if &s.Architecture != nil {
-				image["architecture"] = s.Architecture
+				image[ImageArchitecture] = s.Architecture
 			}
 			if &s.Endianness != nil {
-				image["endianness"] = s.Endianness
+				image[ImageEndianness] = s.Endianness
 			}
 		}
 		images = append(images, image)
 	}
 	d.SetId(time.Now().UTC().String())
-	d.Set("images", images)
+	d.Set(CatalogImages, images)
 	return nil
 
 }

--- a/ibm/service/power/data_source_ibm_pi_image.go
+++ b/ibm/service/power/data_source_ibm_pi_image.go
@@ -22,47 +22,47 @@ func DataSourceIBMPIImage() *schema.Resource {
 		ReadContext: dataSourceIBMPIImagesRead,
 		Schema: map[string]*schema.Schema{
 
-			helpers.PIImageName: {
+			PIImageName: {
 				Type:         schema.TypeString,
 				Required:     true,
 				Description:  "Imagename Name to be used for pvminstances",
 				ValidateFunc: validation.NoZeroValues,
 			},
-			helpers.PICloudInstanceId: {
+			PICloudInstanceID: {
 				Type:         schema.TypeString,
 				Required:     true,
 				ValidateFunc: validation.NoZeroValues,
 			},
 
-			"state": {
+			ImageState: {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
-			"size": {
+			ImageSize: {
 				Type:     schema.TypeInt,
 				Computed: true,
 			},
-			"architecture": {
+			ImageArchitecture: {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
-			"operatingsystem": {
+			ImageOperatingSystem: {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
-			"hypervisor": {
+			ImageHyperVisor: {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
-			"storage_type": {
+			ImageStorageType: {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
-			"storage_pool": {
+			ImageStoragePool: {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
-			"image_type": {
+			ImageType: {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
@@ -85,14 +85,14 @@ func dataSourceIBMPIImagesRead(ctx context.Context, d *schema.ResourceData, meta
 	}
 
 	d.SetId(*imagedata.ImageID)
-	d.Set("state", imagedata.State)
-	d.Set("size", imagedata.Size)
-	d.Set("architecture", imagedata.Specifications.Architecture)
-	d.Set("hypervisor", imagedata.Specifications.HypervisorType)
-	d.Set("operatingsystem", imagedata.Specifications.OperatingSystem)
-	d.Set("storage_type", imagedata.StorageType)
-	d.Set("storage_pool", imagedata.StoragePool)
-	d.Set("image_type", imagedata.Specifications.ImageType)
+	d.Set(ImageState, imagedata.State)
+	d.Set(ImageSize, imagedata.Size)
+	d.Set(ImageArchitecture, imagedata.Specifications.Architecture)
+	d.Set(ImageHyperVisor, imagedata.Specifications.HypervisorType)
+	d.Set(ImageOperatingSystem, imagedata.Specifications.OperatingSystem)
+	d.Set(ImageStorageType, imagedata.StorageType)
+	d.Set(ImageStoragePool, imagedata.StoragePool)
+	d.Set(ImageType, imagedata.Specifications.ImageType)
 
 	return nil
 

--- a/ibm/service/power/data_source_ibm_pi_images.go
+++ b/ibm/service/power/data_source_ibm_pi_images.go
@@ -6,7 +6,6 @@ package power
 import (
 	"context"
 
-	"github.com/IBM-Cloud/power-go-client/helpers"
 	"github.com/IBM-Cloud/power-go-client/power/models"
 	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/conns"
 	"github.com/hashicorp/go-uuid"
@@ -28,7 +27,7 @@ func DataSourceIBMPIImages() *schema.Resource {
 		ReadContext: dataSourceIBMPIImagesAllRead,
 		Schema: map[string]*schema.Schema{
 
-			helpers.PICloudInstanceId: {
+			PICloudInstanceID: {
 				Type:         schema.TypeString,
 				Required:     true,
 				ValidateFunc: validation.NoZeroValues,
@@ -36,36 +35,36 @@ func DataSourceIBMPIImages() *schema.Resource {
 
 			// Computed Attributes
 
-			"image_info": {
+			Images: {
 				Type:     schema.TypeList,
 				Computed: true,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
-						"id": {
+						ImagesID: {
 							Type:     schema.TypeString,
 							Computed: true,
 						},
-						"name": {
+						ImageName: {
 							Type:     schema.TypeString,
 							Computed: true,
 						},
-						"href": {
+						ImageHref: {
 							Type:     schema.TypeString,
 							Computed: true,
 						},
-						"state": {
+						ImageState: {
 							Type:     schema.TypeString,
 							Computed: true,
 						},
-						"storage_type": {
+						ImageStorageType: {
 							Type:     schema.TypeString,
 							Computed: true,
 						},
-						"storage_pool": {
+						ImageStoragePool: {
 							Type:     schema.TypeString,
 							Computed: true,
 						},
-						"image_type": {
+						ImageType: {
 							Type:     schema.TypeString,
 							Computed: true,
 						},
@@ -82,7 +81,7 @@ func dataSourceIBMPIImagesAllRead(ctx context.Context, d *schema.ResourceData, m
 		return diag.FromErr(err)
 	}
 
-	cloudInstanceID := d.Get(helpers.PICloudInstanceId).(string)
+	cloudInstanceID := d.Get(PICloudInstanceID).(string)
 
 	imageC := instance.NewIBMPIImageClient(ctx, sess, cloudInstanceID)
 	imagedata, err := imageC.GetAll()
@@ -92,7 +91,7 @@ func dataSourceIBMPIImagesAllRead(ctx context.Context, d *schema.ResourceData, m
 
 	var clientgenU, _ = uuid.GenerateUUID()
 	d.SetId(clientgenU)
-	d.Set("image_info", flattenStockImages(imagedata.Images))
+	d.Set(Images, flattenStockImages(imagedata.Images))
 
 	return nil
 
@@ -103,13 +102,13 @@ func flattenStockImages(list []*models.ImageReference) []map[string]interface{} 
 	for _, i := range list {
 
 		l := map[string]interface{}{
-			"id":           *i.ImageID,
-			"state":        *i.State,
-			"href":         *i.Href,
-			"name":         *i.Name,
-			"storage_type": *i.StorageType,
-			"storage_pool": *i.StoragePool,
-			"image_type":   i.Specifications.ImageType,
+			ImagesID:         *i.ImageID,
+			ImageState:       *i.State,
+			ImageHref:        *i.Href,
+			ImageName:        *i.Name,
+			ImageStorageType: *i.StorageType,
+			ImageStoragePool: *i.StoragePool,
+			ImageType:        i.Specifications.ImageType,
 		}
 
 		result = append(result, l)

--- a/ibm/service/power/ibm_pi_constants.go
+++ b/ibm/service/power/ibm_pi_constants.go
@@ -61,4 +61,58 @@ const (
 	PIVPNConnectionDeadPeerDetectionThreshold = "threshold"
 	PIVPNConnectionLocalGatewayAddress        = "local_gateway_address"
 	PIVPNConnectionVpnGatewayAddress          = "gateway_address"
+
+	PICloudInstanceID = "pi_cloud_instance_id"
+
+	// ---------- Image ----------
+	// Arguments
+	PIImageName                  = "pi_image_name"
+	PIImageAffinityInstance      = "pi_affinity_instance"
+	PIImageAffinityPolicy        = "pi_affinity_policy"
+	PIImageAffinityVolume        = "pi_affinity_volume"
+	PIImageAntiAffinityInstances = "pi_anti_affinity_instances"
+	PIImageAntiAffinityVolumes   = "pi_anti_affinity_volumes"
+	PIImageID                    = "pi_image_id"
+	PIImageBucketName            = "pi_image_bucket_name"
+	PIImageAccessKey             = "pi_image_access_key"
+	PIImageBucketAccess          = "pi_image_bucket_access"
+	PIImageBucketFile            = "pi_image_bucket_file_name"
+	PIImageBucketRegion          = "pi_image_bucket_region"
+	PIImageSecretKey             = "pi_image_secret_key"
+	PIImageStoragePool           = "pi_image_storage_pool"
+	PIImageStorageType           = "pi_image_storage_type"
+	CatalogImagesSAP             = "sap"
+	CatalogImagesVTL             = "vtl"
+
+	// Attributes
+	Images               = "image_info"
+	CatalogImages        = "images"
+	ImagesID             = "id"
+	ImageName            = "name"
+	ImageID              = "image_id"
+	ImageArchitecture    = "architecture"
+	ImageOperatingSystem = "operatingsystem"
+	ImageSize            = "size"
+	ImageState           = "state"
+	ImageHyperVisor      = "hypervisor"
+	ImageStorageType     = "storage_type"
+	ImageStoragePool     = "storage_pool"
+	ImageType            = "image_type"
+	ImageCreationDate    = "creation_date"
+	ImageDescription     = "description"
+	ImageDiskFormat      = "disk_format"
+	ImageEndianness      = "endianness"
+	ImageHref            = "href"
+	ImageLastUpdateDate  = "last_update_date"
+	ImageContainerFormat = "container_format"
+
+	// Misc
+	ImageRetry  = "retry"
+	ImageQueued = "queued"
+	ImageActive = "active"
+
+	// Attributes need to fix
+	ImageHypervisorType         = "hypervisor_type"
+	CatalogImageOperatingSystem = "operating_system"
+	// ---------------------------
 )

--- a/ibm/service/power/resource_ibm_pi_image.go
+++ b/ibm/service/power/resource_ibm_pi_image.go
@@ -15,7 +15,6 @@ import (
 
 	st "github.com/IBM-Cloud/power-go-client/clients/instance"
 	"github.com/IBM-Cloud/power-go-client/errors"
-	"github.com/IBM-Cloud/power-go-client/helpers"
 	"github.com/IBM-Cloud/power-go-client/power/client/p_cloud_images"
 	"github.com/IBM-Cloud/power-go-client/power/models"
 	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/conns"
@@ -36,114 +35,114 @@ func ResourceIBMPIImage() *schema.Resource {
 		},
 
 		Schema: map[string]*schema.Schema{
-			helpers.PICloudInstanceId: {
+			PICloudInstanceID: {
 				Type:        schema.TypeString,
 				Required:    true,
 				Description: "PI cloud instance ID",
 				ForceNew:    true,
 			},
-			helpers.PIImageName: {
+			PIImageName: {
 				Type:             schema.TypeString,
 				Required:         true,
 				Description:      "Image name",
 				DiffSuppressFunc: flex.ApplyOnce,
 				ForceNew:         true,
 			},
-			helpers.PIImageId: {
+			PIImageID: {
 				Type:             schema.TypeString,
 				Optional:         true,
-				ExactlyOneOf:     []string{helpers.PIImageId, helpers.PIImageBucketName},
+				ExactlyOneOf:     []string{PIImageID, PIImageBucketName},
 				Description:      "Instance image id",
 				DiffSuppressFunc: flex.ApplyOnce,
-				ConflictsWith:    []string{helpers.PIImageBucketName},
+				ConflictsWith:    []string{PIImageBucketName},
 				ForceNew:         true,
 			},
 
 			// COS import variables
-			helpers.PIImageBucketName: {
+			PIImageBucketName: {
 				Type:          schema.TypeString,
 				Optional:      true,
-				ExactlyOneOf:  []string{helpers.PIImageId, helpers.PIImageBucketName},
+				ExactlyOneOf:  []string{PIImageID, PIImageBucketName},
 				Description:   "Cloud Object Storage bucket name; bucket-name[/optional/folder]",
-				ConflictsWith: []string{helpers.PIImageId},
-				RequiredWith:  []string{helpers.PIImageBucketRegion, helpers.PIImageBucketFileName},
+				ConflictsWith: []string{PIImageID},
+				RequiredWith:  []string{PIImageBucketRegion, PIImageBucketFile},
 				ForceNew:      true,
 			},
-			helpers.PIImageBucketAccess: {
+			PIImageBucketAccess: {
 				Type:          schema.TypeString,
 				Optional:      true,
 				Description:   "Indicates if the bucket has public or private access",
 				Default:       "public",
 				ValidateFunc:  validate.ValidateAllowedStringValues([]string{"public", "private"}),
-				ConflictsWith: []string{helpers.PIImageId},
+				ConflictsWith: []string{PIImageID},
 				ForceNew:      true,
 			},
-			helpers.PIImageAccessKey: {
+			PIImageAccessKey: {
 				Type:         schema.TypeString,
 				Optional:     true,
 				Description:  "Cloud Object Storage access key; required for buckets with private access",
 				ForceNew:     true,
 				Sensitive:    true,
-				RequiredWith: []string{helpers.PIImageSecretKey},
+				RequiredWith: []string{PIImageSecretKey},
 			},
-			helpers.PIImageSecretKey: {
+			PIImageSecretKey: {
 				Type:         schema.TypeString,
 				Optional:     true,
 				Description:  "Cloud Object Storage secret key; required for buckets with private access",
 				ForceNew:     true,
 				Sensitive:    true,
-				RequiredWith: []string{helpers.PIImageAccessKey},
+				RequiredWith: []string{PIImageAccessKey},
 			},
-			helpers.PIImageBucketRegion: {
+			PIImageBucketRegion: {
 				Type:          schema.TypeString,
 				Optional:      true,
 				Description:   "Cloud Object Storage region",
-				ConflictsWith: []string{helpers.PIImageId},
-				RequiredWith:  []string{helpers.PIImageBucketName},
+				ConflictsWith: []string{PIImageID},
+				RequiredWith:  []string{PIImageBucketName},
 				ForceNew:      true,
 			},
-			helpers.PIImageBucketFileName: {
+			PIImageBucketFile: {
 				Type:          schema.TypeString,
 				Optional:      true,
 				Description:   "Cloud Object Storage image filename",
-				ConflictsWith: []string{helpers.PIImageId},
-				RequiredWith:  []string{helpers.PIImageBucketName},
+				ConflictsWith: []string{PIImageID},
+				RequiredWith:  []string{PIImageBucketName},
 				ForceNew:      true,
 			},
-			helpers.PIImageStorageType: {
+			PIImageStorageType: {
 				Type:        schema.TypeString,
 				Optional:    true,
 				Description: "Type of storage",
 				ForceNew:    true,
 			},
-			helpers.PIImageStoragePool: {
+			PIImageStoragePool: {
 				Type:        schema.TypeString,
 				Optional:    true,
 				Description: "Storage pool where the image will be loaded, if provided then pi_image_storage_type and pi_affinity_policy will be ignored",
 				ForceNew:    true,
 			},
-			PIAffinityPolicy: {
+			PIImageAffinityPolicy: {
 				Type:         schema.TypeString,
 				Optional:     true,
 				Description:  "Affinity policy for image; ignored if pi_image_storage_pool provided; for policy affinity requires one of pi_affinity_instance or pi_affinity_volume to be specified; for policy anti-affinity requires one of pi_anti_affinity_instances or pi_anti_affinity_volumes to be specified",
 				ValidateFunc: validate.ValidateAllowedStringValues([]string{"affinity", "anti-affinity"}),
 				ForceNew:     true,
 			},
-			PIAffinityVolume: {
+			PIImageAffinityVolume: {
 				Type:          schema.TypeString,
 				Optional:      true,
 				Description:   "Volume (ID or Name) to base storage affinity policy against; required if requesting affinity and pi_affinity_instance is not provided",
 				ConflictsWith: []string{PIAffinityInstance},
 				ForceNew:      true,
 			},
-			PIAffinityInstance: {
+			PIImageAffinityInstance: {
 				Type:          schema.TypeString,
 				Optional:      true,
 				Description:   "PVM Instance (ID or Name) to base storage affinity policy against; required if requesting storage affinity and pi_affinity_volume is not provided",
 				ConflictsWith: []string{PIAffinityVolume},
 				ForceNew:      true,
 			},
-			PIAntiAffinityVolumes: {
+			PIImageAntiAffinityVolumes: {
 				Type:          schema.TypeList,
 				Optional:      true,
 				Elem:          &schema.Schema{Type: schema.TypeString},
@@ -151,7 +150,7 @@ func ResourceIBMPIImage() *schema.Resource {
 				ConflictsWith: []string{PIAntiAffinityInstances},
 				ForceNew:      true,
 			},
-			PIAntiAffinityInstances: {
+			PIImageAntiAffinityInstances: {
 				Type:          schema.TypeList,
 				Optional:      true,
 				Elem:          &schema.Schema{Type: schema.TypeString},
@@ -161,7 +160,7 @@ func ResourceIBMPIImage() *schema.Resource {
 			},
 
 			// Computed Attribute
-			"image_id": {
+			ImageID: {
 				Type:        schema.TypeString,
 				Computed:    true,
 				Description: "Image ID",
@@ -177,12 +176,12 @@ func resourceIBMPIImageCreate(ctx context.Context, d *schema.ResourceData, meta 
 		return diag.FromErr(err)
 	}
 
-	cloudInstanceID := d.Get(helpers.PICloudInstanceId).(string)
-	imageName := d.Get(helpers.PIImageName).(string)
+	cloudInstanceID := d.Get(PICloudInstanceID).(string)
+	imageName := d.Get(PIImageName).(string)
 
 	client := st.NewIBMPIImageClient(ctx, sess, cloudInstanceID)
 	// image copy
-	if v, ok := d.GetOk(helpers.PIImageId); ok {
+	if v, ok := d.GetOk(PIImageID); ok {
 		imageid := v.(string)
 		source := "root-project"
 		var body = &models.CreateImage{
@@ -206,11 +205,11 @@ func resourceIBMPIImageCreate(ctx context.Context, d *schema.ResourceData, meta 
 	}
 
 	// COS image import
-	if v, ok := d.GetOk(helpers.PIImageBucketName); ok {
+	if v, ok := d.GetOk(PIImageBucketName); ok {
 		bucketName := v.(string)
-		bucketImageFileName := d.Get(helpers.PIImageBucketFileName).(string)
-		bucketRegion := d.Get(helpers.PIImageBucketRegion).(string)
-		bucketAccess := d.Get(helpers.PIImageBucketAccess).(string)
+		bucketImageFileName := d.Get(PIImageBucketFile).(string)
+		bucketRegion := d.Get(PIImageBucketRegion).(string)
+		bucketAccess := d.Get(PIImageBucketAccess).(string)
 
 		body := &models.CreateCosImageImportJob{
 			ImageName:     &imageName,
@@ -220,40 +219,40 @@ func resourceIBMPIImageCreate(ctx context.Context, d *schema.ResourceData, meta 
 			Region:        &bucketRegion,
 		}
 
-		if v, ok := d.GetOk(helpers.PIImageAccessKey); ok {
+		if v, ok := d.GetOk(PIImageAccessKey); ok {
 			body.AccessKey = v.(string)
 		}
-		if v, ok := d.GetOk(helpers.PIImageSecretKey); ok {
+		if v, ok := d.GetOk(PIImageSecretKey); ok {
 			body.SecretKey = v.(string)
 		}
 
-		if v, ok := d.GetOk(helpers.PIImageStorageType); ok {
+		if v, ok := d.GetOk(PIImageStorageType); ok {
 			body.StorageType = v.(string)
 		}
-		if v, ok := d.GetOk(helpers.PIImageStoragePool); ok {
+		if v, ok := d.GetOk(PIImageStoragePool); ok {
 			body.StoragePool = v.(string)
 		}
-		if ap, ok := d.GetOk(PIAffinityPolicy); ok {
+		if ap, ok := d.GetOk(PIImageAffinityPolicy); ok {
 			policy := ap.(string)
 			affinity := &models.StorageAffinity{
 				AffinityPolicy: &policy,
 			}
 
 			if policy == "affinity" {
-				if av, ok := d.GetOk(PIAffinityVolume); ok {
+				if av, ok := d.GetOk(PIImageAffinityVolume); ok {
 					afvol := av.(string)
 					affinity.AffinityVolume = &afvol
 				}
-				if ai, ok := d.GetOk(PIAffinityInstance); ok {
+				if ai, ok := d.GetOk(PIImageAffinityInstance); ok {
 					afins := ai.(string)
 					affinity.AffinityPVMInstance = &afins
 				}
 			} else {
-				if avs, ok := d.GetOk(PIAntiAffinityVolumes); ok {
+				if avs, ok := d.GetOk(PIImageAntiAffinityVolumes); ok {
 					afvols := flex.ExpandStringList(avs.([]interface{}))
 					affinity.AntiAffinityVolumes = afvols
 				}
-				if ais, ok := d.GetOk(PIAntiAffinityInstances); ok {
+				if ais, ok := d.GetOk(PIImageAntiAffinityInstances); ok {
 					afinss := flex.ExpandStringList(ais.([]interface{}))
 					affinity.AntiAffinityPVMInstances = afinss
 				}
@@ -308,8 +307,8 @@ func resourceIBMPIImageRead(ctx context.Context, d *schema.ResourceData, meta in
 	}
 
 	imageid := *imagedata.ImageID
-	d.Set("image_id", imageid)
-	d.Set(helpers.PICloudInstanceId, cloudInstanceID)
+	d.Set(ImageID, imageid)
+	d.Set(PICloudInstanceID, cloudInstanceID)
 
 	return nil
 }
@@ -339,8 +338,8 @@ func isWaitForIBMPIImageAvailable(ctx context.Context, client *st.IBMPIImageClie
 	log.Printf("Waiting for Power Image (%s) to be available.", id)
 
 	stateConf := &resource.StateChangeConf{
-		Pending:    []string{"retry", helpers.PIImageQueStatus},
-		Target:     []string{helpers.PIImageActiveStatus},
+		Pending:    []string{ImageRetry, ImageQueued},
+		Target:     []string{ImageActive},
 		Refresh:    isIBMPIImageRefreshFunc(ctx, client, id),
 		Timeout:    timeout,
 		Delay:      20 * time.Second,
@@ -359,18 +358,18 @@ func isIBMPIImageRefreshFunc(ctx context.Context, client *st.IBMPIImageClient, i
 			return nil, "", err
 		}
 
-		if image.State == "active" {
-			return image, helpers.PIImageActiveStatus, nil
+		if image.State == ImageActive {
+			return image, ImageActive, nil
 		}
 
-		return image, helpers.PIImageQueStatus, nil
+		return image, ImageQueued, nil
 	}
 }
 
 func waitForIBMPIJobCompleted(ctx context.Context, client *st.IBMPIJobClient, jobID string, timeout time.Duration) (interface{}, error) {
 	stateConf := &resource.StateChangeConf{
-		Pending: []string{helpers.JobStatusQueued, helpers.JobStatusReadyForProcessing, helpers.JobStatusInProgress, helpers.JobStatusRunning, helpers.JobStatusWaiting},
-		Target:  []string{helpers.JobStatusCompleted, helpers.JobStatusFailed},
+		Pending: []string{"queued", "readyForProcessing", "inProgress", "running", "waiting"},
+		Target:  []string{"completed", "failed"},
 		Refresh: func() (interface{}, string, error) {
 			job, err := client.Get(jobID)
 			if err != nil {
@@ -381,9 +380,9 @@ func waitForIBMPIJobCompleted(ctx context.Context, client *st.IBMPIJobClient, jo
 				log.Printf("[DEBUG] get job failed with empty response")
 				return nil, "", fmt.Errorf("failed to get job status for job id %s", jobID)
 			}
-			if *job.Status.State == helpers.JobStatusFailed {
+			if *job.Status.State == "failed" {
 				log.Printf("[DEBUG] job status failed with message: %v", job.Status.Message)
-				return nil, helpers.JobStatusFailed, fmt.Errorf("job status failed for job id %s with message: %v", jobID, job.Status.Message)
+				return nil, "failed", fmt.Errorf("job status failed for job id %s with message: %v", jobID, job.Status.Message)
 			}
 			return job, *job.Status.State, nil
 		},

--- a/ibm/service/power/resource_ibm_pi_image_export.go
+++ b/ibm/service/power/resource_ibm_pi_image_export.go
@@ -13,7 +13,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 
 	st "github.com/IBM-Cloud/power-go-client/clients/instance"
-	"github.com/IBM-Cloud/power-go-client/helpers"
 	"github.com/IBM-Cloud/power-go-client/power/models"
 	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/conns"
 	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/flex"
@@ -32,41 +31,40 @@ func ResourceIBMPIImageExport() *schema.Resource {
 
 		Schema: map[string]*schema.Schema{
 			//required attributes
-			helpers.PICloudInstanceId: {
+			PICloudInstanceID: {
 				Type:        schema.TypeString,
 				Required:    true,
 				Description: "PI cloud instance ID",
 				ForceNew:    true,
 			},
-			helpers.PIImageId: {
+			PIImageID: {
 				Type:             schema.TypeString,
 				Required:         true,
 				Description:      "Instance image id",
 				DiffSuppressFunc: flex.ApplyOnce,
 				ForceNew:         true,
 			},
-			helpers.PIImageBucketName: {
+			PIImageBucketName: {
 				Type:        schema.TypeString,
 				Required:    true,
 				Description: "Cloud Object Storage bucket name; bucket-name[/optional/folder]",
 				ForceNew:    true,
 			},
-			helpers.PIImageAccessKey: {
+			PIImageAccessKey: {
 				Type:        schema.TypeString,
 				Required:    true,
 				Description: "Cloud Object Storage access key; required for buckets with private access",
 				Sensitive:   true,
 				ForceNew:    true,
 			},
-
-			helpers.PIImageSecretKey: {
+			PIImageSecretKey: {
 				Type:        schema.TypeString,
 				Required:    true,
 				Description: "Cloud Object Storage secret key; required for buckets with private access",
 				Sensitive:   true,
 				ForceNew:    true,
 			},
-			helpers.PIImageBucketRegion: {
+			PIImageBucketRegion: {
 				Type:        schema.TypeString,
 				Description: "Cloud Object Storage region",
 				ForceNew:    true,
@@ -83,10 +81,10 @@ func resourceIBMPIImageExportCreate(ctx context.Context, d *schema.ResourceData,
 		return diag.FromErr(err)
 	}
 
-	cloudInstanceID := d.Get(helpers.PICloudInstanceId).(string)
-	imageid := d.Get(helpers.PIImageId).(string)
-	bucketName := d.Get(helpers.PIImageBucketName).(string)
-	accessKey := d.Get(helpers.PIImageAccessKey).(string)
+	cloudInstanceID := d.Get(PICloudInstanceID).(string)
+	imageid := d.Get(PIImageID).(string)
+	bucketName := d.Get(PIImageBucketName).(string)
+	accessKey := d.Get(PIImageAccessKey).(string)
 
 	client := st.NewIBMPIImageClient(ctx, sess, cloudInstanceID)
 
@@ -94,15 +92,15 @@ func resourceIBMPIImageExportCreate(ctx context.Context, d *schema.ResourceData,
 	var body = &models.ExportImage{
 		BucketName: &bucketName,
 		AccessKey:  &accessKey,
-		Region:     d.Get(helpers.PIImageBucketRegion).(string),
-		SecretKey:  d.Get(helpers.PIImageSecretKey).(string),
+		Region:     d.Get(PIImageBucketRegion).(string),
+		SecretKey:  d.Get(PIImageSecretKey).(string),
 	}
 
 	imageResponse, err := client.ExportImage(imageid, body)
 	if err != nil {
 		return diag.FromErr(err)
 	}
-	d.SetId(fmt.Sprintf("%s/%s/%s", imageid, bucketName, d.Get(helpers.PIImageBucketRegion).(string)))
+	d.SetId(fmt.Sprintf("%s/%s/%s", imageid, bucketName, d.Get(PIImageBucketRegion).(string)))
 
 	jobClient := st.NewIBMPIJobClient(ctx, sess, cloudInstanceID)
 	_, err = waitForIBMPIJobCompleted(ctx, jobClient, *imageResponse.ID, d.Timeout(schema.TimeoutCreate))


### PR DESCRIPTION
Move image argument/attribute constants defined in the power-go-client into ibm_pi_constants.go.

Files affected:
 - data_source_ibm_pi_catalog_images.go
 - data_source_ibm_pi_image.go
 - data_source_ibm_pi_images.go
 - resource_ibm_pi_image.go
 - resource_ibm_pi_image_export.go

<!--- See what makes a good Pull Request at : https://github.com/IBM-Cloud/terraform-provider-ibm/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #3704

