### PR TITLE
Added CRUD operation for sat in cos

### DIFF
--- a/examples/ibm-cos-bucket/main.tf
+++ b/examples/ibm-cos-bucket/main.tf
@@ -1,114 +1,132 @@
-data "ibm_resource_group" "cos_group" {
-  name = var.resource_group_name
-}
-resource "ibm_resource_instance" "cos_instance" {
-  name              = "cos-instance"
-  resource_group_id = data.ibm_resource_group.cos_group.id
-  service           = "cloud-object-storage"
-  plan              = "standard"
-  location          = "global"
-}
-resource "ibm_resource_instance" "activity_tracker" {
-  name              = "activity_tracker"
-  resource_group_id = data.ibm_resource_group.cos_group.id
-  service           = "logdnaat"
-  plan              = "lite"
-  location          =  var.regional_loc
-}
-resource "ibm_resource_instance" "metrics_monitor" {
-  name              = "metrics_monitor"
-  resource_group_id = data.ibm_resource_group.cos_group.id
-  service           = "sysdig-monitor"
-  plan              = "graduated-tier"
-  location          = var.regional_loc
-  parameters        = {
-    default_receiver = true
-  }
-}
-resource "ibm_cos_bucket" "standard-ams03" {
-  bucket_name           = var.bucket_name
-  resource_instance_id  = ibm_resource_instance.cos_instance.id
-  single_site_location  = var.single_site_loc
-  storage_class         = var.storage
-  hard_quota            = var.quota
-  activity_tracking {
-    read_data_events     = true
-    write_data_events    = true
-    activity_tracker_crn = ibm_resource_instance.activity_tracker.id
-  }
-  metrics_monitoring {
-    usage_metrics_enabled  = true
-    request_metrics_enabled = true
-    metrics_monitoring_crn = ibm_resource_instance.metrics_monitor.id
-  }
-  allowed_ip = ["223.196.168.27", "223.196.161.38", "192.168.0.1"]
-}
-
-resource "ibm_cos_bucket" "lifecycle_rule_cos" {
-  bucket_name          = var.bucket_name
-  resource_instance_id = ibm_resource_instance.cos_instance.id
-  region_location      = var.regional_loc
-  storage_class        = var.storage
-  hard_quota           = var.quota
-  archive_rule {
-    rule_id = var.archive_ruleid
-    enable  = true
-    days    = var.archive_days
-    type    = var.archive_types
-  }
-  expire_rule {
-    rule_id = var.expire_ruleid
-    enable  = true
-    days    = var.expire_days
-    prefix  = var.expire_prefix
-  }
-  retention_rule {
-    default = var.default_retention
-    maximum = var.maximum_retention
-    minimum = var.minimum_retention
-    permanent = false
-  }
-}
-
 resource "ibm_cos_bucket" "cos_bucket" {
-  bucket_name           = var.bucket_name
-  resource_instance_id  = ibm_resource_instance.cos_instance.id
-  region_location       = var.regional_loc
-  storage_class         = var.storage
-  hard_quota            = var.quota
+  bucket_name           = "tf4-listbuckettest4"
+  resource_instance_id  = "crn:v1:bluemix:public:cloud-object-storage:satloc_wdc_c8jh7hfw0ppoapdqrmpg:a/d0c259a490e4488c83b62707ad3f5182:756ad6b6-72a6-4e55-8c94-b02e51e708b3::"
+  satellite_location_id  = "c8jh7hfw0ppoapdqrmpg"
+  force_delete = true
+  //allowed_ip = ["223.196.168.27", "223.196.161.38", "192.168.0.1"]
   object_versioning {
     enable  = true
   }
-  abort_incomplete_multipart_upload_days {
-    rule_id = var.abort_mpu_ruleid
-    enable  = true
-    prefix  = var.abort_mpu_prefix
-    days_after_initiation = var.abort_mpu_days_init
-  }
   expire_rule {
-    rule_id = var.expire_ruleid
+    rule_id = "bucket-tf-rule"
     enable  = true
-    date    = var.expire_date
-    prefix  = var.expire_prefix
-  }
-  noncurrent_version_expiration {
-    rule_id = var.nc_exp_ruleid
-    enable  = true
-    prefix  = var.nc_exp_prefix
-    noncurrent_days = var.nc_exp_days
+    days    = 30
+    prefix  = "logs/"
   }
 }
 
-resource "ibm_cos_bucket_object" "plaintext" {
-  bucket_crn      = ibm_cos_bucket.cos_bucket.crn
-  bucket_location = ibm_cos_bucket.cos_bucket.region_location
-  content         = "Hello World"
-  key             = "plaintext.txt"
-}
 
-resource "ibm_cos_bucket_object" "base64" {
-  bucket_crn      = ibm_cos_bucket.cos_bucket.crn
-  bucket_location = ibm_cos_bucket.cos_bucket.region_location
-  content_base64  = "RW5jb2RlZCBpbiBiYXNlNjQ="
-  key             = "base64.txt"
-}
+# data "ibm_resource_group" "cos_group" {
+#   name = var.resource_group_name
+# }
+# resource "ibm_resource_instance" "cos_instance" {
+#   name              = "cos-instance"
+#   resource_group_id = data.ibm_resource_group.cos_group.id
+#   service           = "cloud-object-storage"
+#   plan              = "standard"
+#   location          = "global"
+# }
+# resource "ibm_resource_instance" "activity_tracker" {
+#   name              = "activity_tracker"
+#   resource_group_id = data.ibm_resource_group.cos_group.id
+#   service           = "logdnaat"
+#   plan              = "lite"
+#   location          =  var.regional_loc
+# }
+# resource "ibm_resource_instance" "metrics_monitor" {
+#   name              = "metrics_monitor"
+#   resource_group_id = data.ibm_resource_group.cos_group.id
+#   service           = "sysdig-monitor"
+#   plan              = "graduated-tier"
+#   location          = var.regional_loc
+#   parameters        = {
+#     default_receiver = true
+#   }
+# }
+# resource "ibm_cos_bucket" "standard-ams03" {
+#   bucket_name           = var.bucket_name
+#   resource_instance_id  = ibm_resource_instance.cos_instance.id
+#   single_site_location  = var.single_site_loc
+#   storage_class         = var.storage
+#   hard_quota            = var.quota
+#   activity_tracking {
+#     read_data_events     = true
+#     write_data_events    = true
+#     activity_tracker_crn = ibm_resource_instance.activity_tracker.id
+#   }
+#   metrics_monitoring {
+#     usage_metrics_enabled  = true
+#     request_metrics_enabled = true
+#     metrics_monitoring_crn = ibm_resource_instance.metrics_monitor.id
+#   }
+#   allowed_ip = ["223.196.168.27", "223.196.161.38", "192.168.0.1"]
+# }
+
+# resource "ibm_cos_bucket" "lifecycle_rule_cos" {
+#   bucket_name          = var.bucket_name
+#   resource_instance_id = ibm_resource_instance.cos_instance.id
+#   region_location      = var.regional_loc
+#   storage_class        = var.storage
+#   hard_quota           = var.quota
+#   archive_rule {
+#     rule_id = var.archive_ruleid
+#     enable  = true
+#     days    = var.archive_days
+#     type    = var.archive_types
+#   }
+#   expire_rule {
+#     rule_id = var.expire_ruleid
+#     enable  = true
+#     days    = var.expire_days
+#     prefix  = var.expire_prefix
+#   }
+#   retention_rule {
+#     default = var.default_retention
+#     maximum = var.maximum_retention
+#     minimum = var.minimum_retention
+#     permanent = false
+#   }
+# }
+
+# resource "ibm_cos_bucket" "cos_bucket" {
+#   bucket_name           = var.bucket_name
+#   resource_instance_id  = ibm_resource_instance.cos_instance.id
+#   region_location       = var.regional_loc
+#   storage_class         = var.storage
+#   hard_quota            = var.quota
+#   object_versioning {
+#     enable  = true
+#   }
+#   abort_incomplete_multipart_upload_days {
+#     rule_id = var.abort_mpu_ruleid
+#     enable  = true
+#     prefix  = var.abort_mpu_prefix
+#     days_after_initiation = var.abort_mpu_days_init
+#   }
+#   expire_rule {
+#     rule_id = var.expire_ruleid
+#     enable  = true
+#     date    = var.expire_date
+#     prefix  = var.expire_prefix
+#   }
+#   noncurrent_version_expiration {
+#     rule_id = var.nc_exp_ruleid
+#     enable  = true
+#     prefix  = var.nc_exp_prefix
+#     noncurrent_days = var.nc_exp_days
+#   }
+# }
+
+# resource "ibm_cos_bucket_object" "plaintext" {
+#   bucket_crn      = ibm_cos_bucket.cos_bucket.crn
+#   bucket_location = ibm_cos_bucket.cos_bucket.region_location
+#   content         = "Hello World"
+#   key             = "plaintext.txt"
+# }
+
+# resource "ibm_cos_bucket_object" "base64" {
+#   bucket_crn      = ibm_cos_bucket.cos_bucket.crn
+#   bucket_location = ibm_cos_bucket.cos_bucket.region_location
+#   content_base64  = "RW5jb2RlZCBpbiBiYXNlNjQ="
+#   key             = "base64.txt"
+# }

--- a/examples/ibm-cos-bucket/versions.tf
+++ b/examples/ibm-cos-bucket/versions.tf
@@ -1,12 +1,23 @@
-###############################
-# IBM Cloud Copyright 2020 IBM
-###############################
+# ###############################
+# # IBM Cloud Copyright 2020 IBM
+# ###############################
+
+# terraform {
+# required_version = ">=1.0.0, <2.0"
+#   required_providers {
+#     ibm = {
+#       source = "IBM-Cloud/ibm"
+#     }
+#   }
+# }
+
 
 terraform {
 required_version = ">=1.0.0, <2.0"
   required_providers {
     ibm = {
       source = "IBM-Cloud/ibm"
+      version = "1.39.2"
     }
   }
 }


### PR DESCRIPTION
Need to check for Object versioning and existing:--

1. I am able to enable object versioning in tfstate and seeing Status: ENABLED in read operation ....though it is not entering to Flatten method.....and UI still show disabled.

2. If bucket "t1" already exist in cos instance UI and we will try to create from terraform....it did not throw error "Bucket already exists" instead of this able to create the bucket with same name...


```
versioningData := flex.FlattenCosObejctVersioning(versionPtr)
log.Println("Read ..Set versiononh data .....",versioningData)
if len(versioningData) > 0 {
            d.Set("object_versioning", versioningData)
            log.Println("versioning is.....",versioningData)
        } else {
			d.Set("object_versioning", nil)
			log.Println("Read versioning is null..")
		}
}
```

```
Output:--- 
 Read ..Set versiononh data ..... [map[enable:true]]: timestamp=2022-04-06T11:09:27.019Z
versioning is..... [map[enable:true]]: timestamp=2022-04-06T11:09:27.019Z
```