### PR TITLE
fix(Cloud Databases): fix group scaling crash during provisioning

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "go.sum|^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2022-03-23T07:53:32Z",
+  "generated_at": "2022-04-21T20:34:10Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -622,7 +622,7 @@
         "hashed_secret": "813274ccae5b6b509379ab56982d862f7b5969b6",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 694,
+        "line_number": 705,
         "type": "Base64 High Entropy String",
         "verified_result": null
       }
@@ -632,7 +632,7 @@
         "hashed_secret": "9184b0c38101bf24d78b2bb0d044deb1d33696fc",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 121,
+        "line_number": 122,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -640,7 +640,7 @@
         "hashed_secret": "c427f185ddcb2440be9b77c8e45f1cd487a2e790",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1323,
+        "line_number": 1334,
         "type": "Base64 High Entropy String",
         "verified_result": null
       },
@@ -648,7 +648,7 @@
         "hashed_secret": "1f7e33de15e22de9d2eaf502df284ed25ca40018",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1391,
+        "line_number": 1402,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -656,7 +656,7 @@
         "hashed_secret": "1f614c2eb6b3da22d89bd1b9fd47d7cb7c8fc670",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2958,
+        "line_number": 2998,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -664,7 +664,7 @@
         "hashed_secret": "7abfce65b8504403afc25c9790f358d513dfbcc6",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2971,
+        "line_number": 3011,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -672,7 +672,7 @@
         "hashed_secret": "0c2d85bf9a9b1579b16f220a4ea8c3d62b2e24b1",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 3012,
+        "line_number": 3052,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -692,7 +692,7 @@
         "hashed_secret": "c8b6f5ef11b9223ac35a5663975a466ebe7ebba9",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1187,
+        "line_number": 1221,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -700,7 +700,7 @@
         "hashed_secret": "8abf4899c01104241510ba87685ad4de76b0c437",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1193,
+        "line_number": 1227,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -1368,7 +1368,7 @@
         "hashed_secret": "3046d9f6cfaaeea6eed9bb7a4ab010fe49b0cfd4",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1349,
+        "line_number": 1565,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1376,7 +1376,7 @@
         "hashed_secret": "2c7d1e61c036dc18b2e9b3e6392c8e59c8437f23",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1655,
+        "line_number": 1895,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -1386,7 +1386,7 @@
         "hashed_secret": "7deb7557ec8b36e7d5958afe3e08959e7f1ba813",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1149,
+        "line_number": 1403,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1394,7 +1394,7 @@
         "hashed_secret": "b62aab00e3bf482bfb75e3e42fd5d1be72f33ec0",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1244,
+        "line_number": 1497,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1402,7 +1402,7 @@
         "hashed_secret": "b732fb611fd46a38e8667f9972e0cde777fbe37f",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1729,
+        "line_number": 2061,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1410,7 +1410,7 @@
         "hashed_secret": "1f5e25be9b575e9f5d39c82dfd1d9f4d73f1975c",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1846,
+        "line_number": 2178,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -1420,7 +1420,7 @@
         "hashed_secret": "10c28f9cf0668595d45c1090a7b4a2ae98edfa58",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 443,
+        "line_number": 726,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -1440,7 +1440,7 @@
         "hashed_secret": "10c28f9cf0668595d45c1090a7b4a2ae98edfa58",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 448,
+        "line_number": 729,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -1455,12 +1455,12 @@
         "verified_result": null
       }
     ],
-    "ibm/service/database/resource_ibm_database_mogodb_enterprise_test.go": [
+    "ibm/service/database/resource_ibm_database_mongodb_enterprise_test.go": [
       {
         "hashed_secret": "10c28f9cf0668595d45c1090a7b4a2ae98edfa58",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 188,
+        "line_number": 253,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -1490,7 +1490,7 @@
         "hashed_secret": "10c28f9cf0668595d45c1090a7b4a2ae98edfa58",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 576,
+        "line_number": 825,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -1510,7 +1510,7 @@
         "hashed_secret": "10c28f9cf0668595d45c1090a7b4a2ae98edfa58",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 213,
+        "line_number": 212,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -1790,7 +1790,7 @@
         "hashed_secret": "0c0aa212475d8c2a2e0c559fcfc5a67cae2af9ba",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 235,
+        "line_number": 240,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -1800,7 +1800,7 @@
         "hashed_secret": "90e44ac970207581d8b44f5e5aeae6f5ad903e74",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 78,
+        "line_number": 77,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -2118,7 +2118,7 @@
         "hashed_secret": "10c28f9cf0668595d45c1090a7b4a2ae98edfa58",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 238,
+        "line_number": 344,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -2126,7 +2126,7 @@
         "hashed_secret": "91199272d5d6a574a51722ca6f3d1148edb1a0e7",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 280,
+        "line_number": 386,
         "type": "Secret Keyword",
         "verified_result": null
       }

--- a/ibm/service/database/resource_ibm_database.go
+++ b/ibm/service/database/resource_ibm_database.go
@@ -882,7 +882,7 @@ type GroupResource struct {
 	CanScaleDown bool
 }
 
-func getDefaultScalingGroups(_service string, meta interface{}) (groups []clouddatabasesv5.Group, err error) {
+func getDefaultScalingGroups(_service string, _plan string, meta interface{}) (groups []clouddatabasesv5.Group, err error) {
 	cloudDatabasesClient, err := meta.(conns.ClientSession).CloudDatabasesV5()
 	if err != nil {
 		return groups, fmt.Errorf("[ERROR] Error getting database client settings: %s", err)
@@ -899,6 +899,10 @@ func getDefaultScalingGroups(_service string, meta interface{}) (groups []cloudd
 
 	if service == "cassandra" {
 		service = "datastax_enterprise_full"
+	}
+
+	if service == "mongodb" && _plan == "enterprise" {
+		service = "mongodbee"
 	}
 
 	getDefaultScalingGroupsOptions := cloudDatabasesClient.NewGetDefaultScalingGroupsOptions(service)
@@ -933,8 +937,8 @@ func getDatabaseServiceDefaults(service string, meta interface{}) (*icdv4.Group,
 	return &groupDefaults.Groups[0], nil
 }
 
-func getInitialNodeCount(service string, meta interface{}) (int, error) {
-	groups, err := getDefaultScalingGroups(service, meta)
+func getInitialNodeCount(service string, plan string, meta interface{}) (int, error) {
+	groups, err := getDefaultScalingGroups(service, plan, meta)
 
 	if err != nil {
 		return 0, err
@@ -1196,7 +1200,7 @@ func resourceIBMDatabaseInstanceCreate(context context.Context, d *schema.Resour
 		rsInst.ResourceGroup = &defaultRg
 	}
 
-	initialNodeCount, err := getInitialNodeCount(serviceName, meta)
+	initialNodeCount, err := getInitialNodeCount(serviceName, plan, meta)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -1311,44 +1315,59 @@ func resourceIBMDatabaseInstanceCreate(context context.Context, d *schema.Resour
 
 	if group, ok := d.GetOk("group"); ok {
 		groups := expandGroups(group.(*schema.Set).List())
+		groupsResponse, err := getGroups(*instance.ID, meta)
+		if err != nil {
+			return diag.FromErr(err)
+		}
+		currentGroups := normalizeGroups(groupsResponse)
+
 		for _, g := range groups {
 			groupScaling := &clouddatabasesv5.GroupScaling{}
-			nodeCount := initialNodeCount
+			var currentGroup *Group
+			var nodeCount int
 
-			if (g.ID == "member") &&
-				(g.Members != nil) &&
-				(nodeCount == g.Members.Allocation) {
+			for _, cg := range currentGroups {
+				if cg.ID == g.ID {
+					currentGroup = &cg
+					nodeCount = currentGroup.Members.Allocation
+				}
+			}
+
+			if g.ID == "member" && (g.Members == nil || g.Members.Allocation == nodeCount) {
 				// No Horizontal Scaling needed
 				continue
 			}
-			if g.Members != nil {
+
+			if g.Members != nil && g.Members.Allocation != currentGroup.Members.Allocation {
 				groupScaling.Members = &clouddatabasesv5.GroupScalingMembers{AllocationCount: core.Int64Ptr(int64(g.Members.Allocation))}
 				nodeCount = g.Members.Allocation
 			}
-			if g.Memory != nil {
+			if g.Memory != nil && g.Memory.Allocation != currentGroup.Memory.Allocation {
 				groupScaling.Memory = &clouddatabasesv5.GroupScalingMemory{AllocationMb: core.Int64Ptr(int64(g.Memory.Allocation * nodeCount))}
 			}
-			if g.Disk != nil {
+			if g.Disk != nil && g.Disk.Allocation != currentGroup.Disk.Allocation {
 				groupScaling.Disk = &clouddatabasesv5.GroupScalingDisk{AllocationMb: core.Int64Ptr(int64(g.Disk.Allocation * nodeCount))}
 			}
-			if g.CPU != nil {
+			if g.CPU != nil && g.CPU.Allocation != currentGroup.CPU.Allocation {
 				groupScaling.CPU = &clouddatabasesv5.GroupScalingCPU{AllocationCount: core.Int64Ptr(int64(g.CPU.Allocation * nodeCount))}
 			}
 
-			setDeploymentScalingGroupOptions := &clouddatabasesv5.SetDeploymentScalingGroupOptions{
-				ID:      instance.ID,
-				GroupID: &g.ID,
-				Group:   groupScaling,
-			}
+			if groupScaling.Members != nil || groupScaling.Memory != nil || groupScaling.Disk != nil || groupScaling.CPU != nil {
+				setDeploymentScalingGroupOptions := &clouddatabasesv5.SetDeploymentScalingGroupOptions{
+					ID:      instance.ID,
+					GroupID: &g.ID,
+					Group:   groupScaling,
+				}
 
-			setDeploymentScalingGroupResponse, _, err := cloudDatabasesClient.SetDeploymentScalingGroup(setDeploymentScalingGroupOptions)
+				setDeploymentScalingGroupResponse, _, err := cloudDatabasesClient.SetDeploymentScalingGroup(setDeploymentScalingGroupOptions)
 
-			taskIDLink := *setDeploymentScalingGroupResponse.Task.ID
+				taskIDLink := *setDeploymentScalingGroupResponse.Task.ID
 
-			_, err = waitForDatabaseTaskComplete(taskIDLink, d, meta, d.Timeout(schema.TimeoutCreate))
+				_, err = waitForDatabaseTaskComplete(taskIDLink, d, meta, d.Timeout(schema.TimeoutCreate))
 
-			if err != nil {
-				return diag.FromErr(err)
+				if err != nil {
+					return diag.FromErr(err)
+				}
 			}
 		}
 	}
@@ -2666,6 +2685,7 @@ func expandGroups(_groups []interface{}) []*Group {
 func checkV5Groups(_ context.Context, diff *schema.ResourceDiff, meta interface{}) (err error) {
 	instanceID := diff.Id()
 	service := diff.Get("service").(string)
+	plan := diff.Get("plan").(string)
 
 	if group, ok := diff.GetOk("group"); ok {
 		var currentGroups []Group
@@ -2675,7 +2695,7 @@ func checkV5Groups(_ context.Context, diff *schema.ResourceDiff, meta interface{
 		if instanceID != "" {
 			groupList, err = getGroups(instanceID, meta)
 		} else {
-			groupList, err = getDefaultScalingGroups(service, meta)
+			groupList, err = getDefaultScalingGroups(service, plan, meta)
 		}
 
 		if err != nil {
@@ -2722,6 +2742,7 @@ func checkV5Groups(_ context.Context, diff *schema.ResourceDiff, meta interface{
 				if err != nil {
 					return err
 				}
+				nodeCount = group.Members.Allocation
 			}
 
 			if group.Memory != nil {

--- a/ibm/service/database/resource_ibm_database_mongodb_enterprise_test.go
+++ b/ibm/service/database/resource_ibm_database_mongodb_enterprise_test.go
@@ -98,12 +98,51 @@ func TestAccIBMMongoDBEnterpriseDatabaseInstanceBasic(t *testing.T) {
 	})
 }
 
+func TestAccIBMMongoDBEnterpriseDatabaseInstanceGroupBasic(t *testing.T) {
+	t.Parallel()
+	databaseResourceGroup := "default"
+	var databaseInstanceOne string
+	rnd := fmt.Sprintf("tf-mongoEnterprise-%d", acctest.RandIntRange(10, 100))
+	testName := rnd
+	name := "ibm_database." + testName
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { acc.TestAccPreCheck(t) },
+		Providers:    acc.TestAccProviders,
+		CheckDestroy: testAccCheckIBMDatabaseInstanceDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckIBMDatabaseInstanceMongoDBEnterpriseGroupBasic(databaseResourceGroup, testName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckIBMDatabaseInstanceExists(name, &databaseInstanceOne),
+					resource.TestCheckResourceAttr(name, "name", testName),
+					resource.TestCheckResourceAttr(name, "service", "databases-for-mongodb"),
+					resource.TestCheckResourceAttr(name, "plan", "enterprise"),
+					resource.TestCheckResourceAttr(name, "location", acc.IcdDbRegion),
+					resource.TestCheckResourceAttr(name, "adminuser", "admin"),
+					resource.TestCheckResourceAttr(name, "members_memory_allocation_mb", "43008"),
+					resource.TestCheckResourceAttr(name, "members_disk_allocation_mb", "61440"),
+					resource.TestCheckResourceAttr(name, "service_endpoints", "public"),
+					resource.TestCheckResourceAttr(name, "connectionstrings.#", "1"),
+					resource.TestCheckResourceAttr(name, "connectionstrings.0.name", "admin"),
+					resource.TestCheckResourceAttr(name, "groups.0.count", "3"),
+					resource.TestCheckResourceAttr(name, "groups.1.count", "1"),
+					resource.TestCheckResourceAttr(name, "groups.2.count", "1"),
+					resource.TestMatchResourceAttr(name, "connectionstrings.0.certname", regexp.MustCompile("[-a-z0-9]*")),
+					resource.TestMatchResourceAttr(name, "connectionstrings.0.certbase64", regexp.MustCompile("^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$")),
+					resource.TestCheckResourceAttr(name, "tags.#", "1"),
+				),
+			},
+		},
+	})
+}
+
 func testAccCheckIBMDatabaseInstanceMongoDBEnterpriseBasic(databaseResourceGroup string, name string) string {
 	return fmt.Sprintf(`
 	data "ibm_resource_group" "test_acc" {
 		name = "%[1]s"
 	}
-	  
+
 	resource "ibm_database" "%[2]s" {
 		resource_group_id            = data.ibm_resource_group.test_acc.id
 		name                         = "%[2]s"
@@ -136,7 +175,7 @@ func testAccCheckIBMDatabaseInstanceMongoDBEnterpriseFullyspecified(databaseReso
 	data "ibm_resource_group" "test_acc" {
 		name = "%[1]s"
 	}
-	  
+
 	resource "ibm_database" "%[2]s" {
 		resource_group_id            = data.ibm_resource_group.test_acc.id
 		name                         = "%[2]s"
@@ -178,7 +217,7 @@ func testAccCheckIBMDatabaseInstanceMongoDBEnterpriseReduced(databaseResourceGro
 	data "ibm_resource_group" "test_acc" {
 		name = "%[1]s"
 	  }
-	  
+
 	  resource "ibm_database" "%[2]s" {
 		resource_group_id            = data.ibm_resource_group.test_acc.id
 		name                         = "%[2]s"
@@ -196,5 +235,56 @@ func testAccCheckIBMDatabaseInstanceMongoDBEnterpriseReduced(databaseResourceGro
 			delete = "15m"
 		}
 	  }
+				`, databaseResourceGroup, name, acc.IcdDbRegion)
+}
+
+func testAccCheckIBMDatabaseInstanceMongoDBEnterpriseGroupBasic(databaseResourceGroup string, name string) string {
+	return fmt.Sprintf(`
+	data "ibm_resource_group" "test_acc" {
+		name = "%[1]s"
+	}
+
+	resource "ibm_database" "%[2]s" {
+		resource_group_id            = data.ibm_resource_group.test_acc.id
+		name                         = "%[2]s"
+		service                      = "databases-for-mongodb"
+		plan                         = "enterprise"
+		location                     = "%[3]s"
+		adminpassword                = "password12"
+		tags                         = ["one:two"]
+
+		group {
+			group_id = "member"
+
+			memory {
+				allocation_mb = 14336
+			}
+			 disk {
+				allocation_mb = 20480
+			}
+		}
+
+		group {
+			group_id = "bi_connector"
+
+			members {
+				allocation_count = 1
+			}
+		}
+
+		group {
+			group_id = "analytics"
+
+			members {
+				allocation_count = 1
+			}
+		}
+
+		timeouts {
+			create = "4h"
+			update = "4h"
+			delete = "15m"
+		}
+	}
 				`, databaseResourceGroup, name, acc.IcdDbRegion)
 }

--- a/website/docs/r/database.html.markdown
+++ b/website/docs/r/database.html.markdown
@@ -198,8 +198,8 @@ resource "ibm_database" "autoscale" {
     }
 }
 ```
-### Sample cassandra database instance
-Cassandra takes more time than expected. It is always advisible to extend timeouts using timeouts block
+### Sample Cassandra database instance
+Cassandra takes more time than expected to provision. It is always advisible to extend timeouts using timeouts block
 
 ```terraform
 data "ibm_resource_group" "test_acc" {
@@ -231,10 +231,10 @@ resource "ibm_database" "cassandra" {
   }
 }
 ```
-### Sample enterprise mongo database instance
-* Enterprise MongoDB takes more time than expected. It is always advisible to extend timeouts using timeouts block.
+### Sample MongoDB Enterprise database instance
+* MongoDB Enterprise takes more time than expected to provision. It is always advisible to extend timeouts using timeouts block.
 * Please make sure your resources meet minimum requirements of scaling. Please refer [docs](https://cloud.ibm.com/docs/databases-for-mongodb?topic=databases-for-mongodb-pricing#scaling-per-member) for more info.
-* `serive_endpoints` cannot be updated on this instance.
+* `service_endpoints` cannot be updated on this instance.
 
 ```terraform
 data "ibm_resource_group" "test_acc" {
@@ -266,6 +266,61 @@ resource "ibm_database" "mongodb" {
   }
 }
 ```
+
+### Sample MongoDB Enterprise database instance with BI Connector and Analytics
+* To enable Analytics and/or BI Connector for MongoDB Enterprise, a `group` attribute must be defined for each group type with `members` scaled to at exactly `1`.
+* MongoDB Enterprise provisioning takes more time than expected to provision. It is always advisible to extend timeouts using `timeouts` block.
+
+```terraform
+data "ibm_resource_group" "test_acc" {
+  is_default = true
+}
+
+resource "ibm_database" "mongodb_enterprise" {
+  resource_group_id            = data.ibm_resource_group.test_acc.id
+  name                         = "test"
+  service                      = "databases-for-mongodb"
+  plan                         = "enterprise"
+  location                     = "us-south"
+  adminpassword                = "password12"
+  tags                         = ["one:two"]
+
+  group {
+    group_id = "member"
+    
+    memory { 
+      allocation_mb = 14336
+    }
+    
+    disk { 
+      allocation_mb = 20480
+    }
+  }
+  
+  group {
+    group_id = "analytics"
+    
+    members { 
+      allocation_count = 1
+    }
+  }
+  
+  group {
+    group_id = "bi_connector"
+    
+    members { 
+      allocation_count = 1
+    }
+  }
+    
+  timeouts {
+    create = "120m"
+    update = "120m"
+    delete = "15m"
+  }
+}
+```
+
 ### Sample EDB instance
 EDB takes more time than expected. It is always advisible to extend timeouts using timeouts block
 


### PR DESCRIPTION
A MongoDB Enterprise will crash at provision time if groups with a `group_id` other than `member` (`bi_connector`, `analytics`) is defined. 

This PR will
- use the correct deployment type (`mongodbee`) for MongoDB enterprise
- fix provisioning scaling math with correct nodeCount per group
- add test case for MongoDB Enterprise Edition with scaled bi_connector, analytics groups  

Example: 
```hcl
resource "ibm_database" "mongo_test" {
  name                = "testing-mongo-db-enterprise"
  service             = "databases-for-mongodb"
  plan                = "enterprise"
  location            = "us-east"

  group {
    group_id = "analytics"

    members {
      allocation_count = 1
    }
  }
  
  group {
    group_id = "bi_connector"

    members {
      allocation_count = 1
    }
  }

  timeouts {
    create = "3h"
    delete = "2h"
  }
}
```

```sh
$ terraform plan
╷
│ Error: Plugin did not respond
│ 
│   with data.ibm_resource_group.icd_dev,
│   on main.tf line 19, in data "ibm_resource_group" "icd_dev":
│   19: data "ibm_resource_group" "icd_dev" {
│ 
│ The plugin encountered an error, and failed to respond to the plugin.(*GRPCProvider).ReadDataSource call. The plugin logs may
│ contain more details.
╵
╷
│ Error: Request cancelled
│ 
│   with ibm_database.mongo_alex,
│   on main.tf line 23, in resource "ibm_database" "mongo_alex":
│   23: resource "ibm_database" "mongo_alex" {
│ 
│ The plugin.(*GRPCProvider).PlanResourceChange request was cancelled.
╵

Stack trace from the terraform-provider-ibm_v1.41.0-beta0 plugin:

panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x10 pc=0x1db885b]

goroutine 126 [running]:
github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/database.checkV5Groups(0x330b1b8, 0xc000710740, 0xc0010f8a80, 0x2dce700, 0xc000245b00, 0x0, 0x0)
	github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/database/resource_ibm_database.go:2718 +0x3db
github.com/hashicorp/terraform-plugin-sdk/v2/helper/customdiff.All.func1(0x330b1b8, 0xc000710740, 0xc0010f8a80, 0x2dce700, 0xc000245b00, 0x3317e90, 0xc00146d400)
	github.com/hashicorp/terraform-plugin-sdk/v2@v2.10.1/helper/customdiff/compose.go:51 +0xb8
github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema.schemaMap.Diff(0xc000aef140, 0x330b1b8, 0xc000710740, 0xc000d092b0, 0xc000e32ae0, 0xc00056af80, 0x2dce700, 0xc000245b00, 0x4315800, 0x2808ee0, ...)
	github.com/hashicorp/terraform-plugin-sdk/v2@v2.10.1/helper/schema/schema.go:543 +0xbc9
github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema.(*Resource).SimpleDiff(0xc000b241c0, 0x330b1b8, 0xc000710740, 0xc000d092b0, 0xc000e32ae0, 0x2dce700, 0xc000245b00, 0x0, 0x0, 0x0)
	github.com/hashicorp/terraform-plugin-sdk/v2@v2.10.1/helper/schema/resource.go:517 +0xa5
github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema.(*GRPCProviderServer).PlanResourceChange(0xc0000cecc0, 0x330b1b8, 0xc000710740, 0xc00146a230, 0x2dfdaee, 0x12, 0x0)
	github.com/hashicorp/terraform-plugin-sdk/v2@v2.10.1/helper/schema/grpc_provider.go:703 +0x9cc
github.com/hashicorp/terraform-plugin-go/tfprotov5/tf5server.(*server).PlanResourceChange(0xc0001d8280, 0x330b260, 0xc000710740, 0xc0005300e0, 0x0, 0x0, 0x0)
	github.com/hashicorp/terraform-plugin-go@v0.5.0/tfprotov5/tf5server/server.go:578 +0x465
github.com/hashicorp/terraform-plugin-go/tfprotov5/internal/tfplugin5._Provider_PlanResourceChange_Handler(0x2d002a0, 0xc0001d8280, 0x330b260, 0xc001466000, 0xc001430300, 0x0, 0x330b260, 0xc001466000, 0xc00145c000, 0x762)
	github.com/hashicorp/terraform-plugin-go@v0.5.0/tfprotov5/internal/tfplugin5/tfplugin5_grpc.pb.go:362 +0x214
google.golang.org/grpc.(*Server).processUnaryRPC(0xc000180fc0, 0x3325258, 0xc000550f00, 0xc00019e500, 0xc0001cec30, 0x42b6148, 0x0, 0x0, 0x0)
	google.golang.org/grpc@v1.32.0/server.go:1194 +0x52b
google.golang.org/grpc.(*Server).handleStream(0xc000180fc0, 0x3325258, 0xc000550f00, 0xc00019e500, 0x0)
	google.golang.org/grpc@v1.32.0/server.go:1517 +0xd0c
google.golang.org/grpc.(*Server).serveStreams.func1.2(0xc0005040d0, 0xc000180fc0, 0x3325258, 0xc000550f00, 0xc00019e500)
	google.golang.org/grpc@v1.32.0/server.go:859 +0xab
created by google.golang.org/grpc.(*Server).serveStreams.func1
	google.golang.org/grpc@v1.32.0/server.go:857 +0x1fd

Error: The terraform-provider-ibm_v1.41.0-beta0 plugin crashed!

This is always indicative of a bug within the plugin. It would be immensely
helpful if you could report the crash with the plugin's maintainers so that it
can be fixed. The output above should help diagnose the issue.

```
### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
TESTARGS="-run '^TestAccIBMMongoDBEnterpriseDatabase'" make testacc
...
--- PASS: TestAccIBMMongoDBEnterpriseDatabaseInstanceGroupBasic (2601.33s)
--- PASS: TestAccIBMMongoDBEnterpriseDatabaseInstanceBasic (7138.41s)

```
