### PR TITLE
fix(Cloud Databases): remove nodeCount update during group validation

### DIFF
--- a/ibm/service/database/resource_ibm_database.go
+++ b/ibm/service/database/resource_ibm_database.go
@@ -2742,7 +2742,6 @@ func checkV5Groups(_ context.Context, diff *schema.ResourceDiff, meta interface{
 				if err != nil {
 					return err
 				}
-				nodeCount = group.Members.Allocation
 			}
 
 			if group.Memory != nil {

--- a/ibm/service/database/resource_ibm_database_postgresql_test.go
+++ b/ibm/service/database/resource_ibm_database_postgresql_test.go
@@ -797,7 +797,7 @@ func testAccCheckIBMDatabaseInstancePostgresGroupReduced(databaseResourceGroup s
 				allocation_count = 2
 			}
 			memory {
-				allocation_mb = 512
+				allocation_mb = 1024
 			}
 			 disk {
 				allocation_mb = 7168

--- a/website/docs/r/database.html.markdown
+++ b/website/docs/r/database.html.markdown
@@ -199,7 +199,7 @@ resource "ibm_database" "autoscale" {
 }
 ```
 ### Sample Cassandra database instance
-Cassandra takes more time than expected to provision. It is always advisible to extend timeouts using timeouts block
+* Cassandra provisioning may require more time than the default timeout. A longer timeout value can be set with using the `timeouts` attribute.
 
 ```terraform
 data "ibm_resource_group" "test_acc" {
@@ -232,7 +232,7 @@ resource "ibm_database" "cassandra" {
 }
 ```
 ### Sample MongoDB Enterprise database instance
-* MongoDB Enterprise takes more time than expected to provision. It is always advisible to extend timeouts using timeouts block.
+* MongoDB Enterprise provisioning may require more time than the default timeout. A longer timeout value can be set with using the `timeouts` attribute.
 * Please make sure your resources meet minimum requirements of scaling. Please refer [docs](https://cloud.ibm.com/docs/databases-for-mongodb?topic=databases-for-mongodb-pricing#scaling-per-member) for more info.
 * `service_endpoints` cannot be updated on this instance.
 
@@ -268,8 +268,8 @@ resource "ibm_database" "mongodb" {
 ```
 
 ### Sample MongoDB Enterprise database instance with BI Connector and Analytics
-* To enable Analytics and/or BI Connector for MongoDB Enterprise, a `group` attribute must be defined for each group type with `members` scaled to at exactly `1`.
-* MongoDB Enterprise provisioning takes more time than expected to provision. It is always advisible to extend timeouts using `timeouts` block.
+* To enable Analytics and/or BI Connector for MongoDB Enterprise, a `group` attribute must be defined for the `analytics` and `bi_connector` group types with `members` scaled to at exactly `1`.
+* MongoDB Enterprise provisioning may require more time than the default timeout. A longer timeout value can be set with using the `timeouts` attribute.
 
 ```terraform
 data "ibm_resource_group" "test_acc" {
@@ -277,13 +277,13 @@ data "ibm_resource_group" "test_acc" {
 }
 
 resource "ibm_database" "mongodb_enterprise" {
-  resource_group_id            = data.ibm_resource_group.test_acc.id
-  name                         = "test"
-  service                      = "databases-for-mongodb"
-  plan                         = "enterprise"
-  location                     = "us-south"
-  adminpassword                = "password12"
-  tags                         = ["one:two"]
+  resource_group_id = data.ibm_resource_group.test_acc.id
+  name              = "test"
+  service           = "databases-for-mongodb"
+  plan              = "enterprise"
+  location          = "us-south"
+  adminpassword     = "password12"
+  tags              = ["one:two"]
 
   group {
     group_id = "member"
@@ -319,6 +319,24 @@ resource "ibm_database" "mongodb_enterprise" {
     delete = "15m"
   }
 }
+
+data "ibm_database_connection" "mongodb_conn" {
+  deployment_id = ibm_database.mongodb_enterprise.id
+  user_type     = "database"
+  user_id       = "admin"
+  endpoint_type = "public"
+}
+
+output "bi_connector_connection" {
+  description = "BI Connector connection string"
+  value       = data.ibm_database_connection.mongodb_conn.bi_connector.0.composed.0
+}
+
+output "analytics_connection" {
+  description = "Analytics Node connection string"
+  value       = data.ibm_database_connection.mongodb_conn.analytics.0.composed.0
+}
+
 ```
 
 ### Sample EDB instance


### PR DESCRIPTION
totals should be calculated based on current member nodeCount

<!--- See what makes a good Pull Request at : https://github.com/IBM-Cloud/terraform-provider-ibm/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccIBMDatabaseInstance.*Group'
--- PASS: TestAccIBMDatabaseInstance_Elasticsearch_Group (1255.33s)
--- PASS: TestAccIBMDatabaseInstancePostgresGroup (2314.72s)
--- PASS: TestAccIBMDatabaseInstance_Cassandra_Group (6947.09s)

...
```
