### PR TITLE
Bug route by name

### DIFF
--- a/ibm/service/vpc/data_source_ibm_is_vpc_routing_table_route.go
+++ b/ibm/service/vpc/data_source_ibm_is_vpc_routing_table_route.go
@@ -198,7 +198,8 @@ func dataSourceIBMIBMIsVPCRoutingTableRouteRead(context context.Context, d *sche
 
 		for _, r := range allrecs {
 			if *r.Name == routeName {
-				route = &r
+				temp := r
+				route = &temp
 			}
 		}
 	}

--- a/ibm/service/vpc/data_source_ibm_is_vpc_routing_table_route.go
+++ b/ibm/service/vpc/data_source_ibm_is_vpc_routing_table_route.go
@@ -198,8 +198,8 @@ func dataSourceIBMIBMIsVPCRoutingTableRouteRead(context context.Context, d *sche
 
 		for _, r := range allrecs {
 			if *r.Name == routeName {
-				temp := r
-				route = &temp
+				route = &r
+				break
 			}
 		}
 	}

--- a/ibm/service/vpc/data_source_ibm_is_vpc_routing_table_route.go
+++ b/ibm/service/vpc/data_source_ibm_is_vpc_routing_table_route.go
@@ -202,6 +202,9 @@ func dataSourceIBMIBMIsVPCRoutingTableRouteRead(context context.Context, d *sche
 				break
 			}
 		}
+		if route == nil {
+			return diag.FromErr(fmt.Errorf("[ERROR] Route not found with name: %s", routeName))
+		}
 	}
 
 	d.SetId(*route.ID)


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/IBM-Cloud/terraform-provider-ibm/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TEST=./ibm/service/vpc TESTARGS='-run=TestAccIBMIBMIsVPCRoutingTableRouteDataSourceBasic'
=== RUN   TestAccIBMIBMIsVPCRoutingTableRouteDataSourceBasic
--- PASS: TestAccIBMIBMIsVPCRoutingTableRouteDataSourceBasic (83.64s)
PASS
ok  	github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/vpc	84.577s

...
```

TF Config: 
```
data "ibm_is_vpc_routing_table_route" "this" {
  vpc           = "r134-f5f85d66-938b-4f87-90cb-a8a02d39d02a"
  routing_table = "r134-b11762f4-0578-4c4b-ad64-8c8c70387f89"
  name          = "porridge-calamity-entreaty-emoticon"

}

output "route" {
  value = data.ibm_is_vpc_routing_table_route.this
}
```

Response:
```
Changes to Outputs:
  + route = {
      + action          = "deliver"
      + created_at      = "2022-04-25T07:34:00.000Z"
      + destination     = "172.31.0.0/24"
      + href            = "https://us-south-stage01.iaasdev.cloud.ibm.com/v1/vpcs/r134-f5f85d66-938b-4f87-90cb-a8a02d39d02a/routing_tables/r134-b11762f4-0578-4c4b-ad64-8c8c70387f89/routes/r134-0e4345e8-1169-4842-ba88-7c1b1befd7f8"
      + id              = "r134-0e4345e8-1169-4842-ba88-7c1b1befd7f8"
      + lifecycle_state = "stable"
      + name            = "porridge-calamity-entreaty-emoticon"
      + next_hop        = [
          + {
              + address       = "10.241.1.4"
              + deleted       = []
              + href          = ""
              + id            = ""
              + name          = ""
              + resource_type = ""
            },
        ]
      + route_id        = "r134-0e4345e8-1169-4842-ba88-7c1b1befd7f8"
      + routing_table   = "r134-b11762f4-0578-4c4b-ad64-8c8c70387f89"
      + vpc             = "r134-f5f85d66-938b-4f87-90cb-a8a02d39d02a"
      + zone            = [
          + {
              + href = "https://us-south-stage01.iaasdev.cloud.ibm.com/v1/regions/us-south/zones/us-south-2"
              + name = "us-south-2"
            },
        ]
    }
```

TF Config-2: 
```
data "ibm_is_vpc_routing_table_route" "this" {
  vpc           = "r134-f5f85d66-938b-4f87-90cb-a8a02d39d02a"
  routing_table = "r134-b11762f4-0578-4c4b-ad64-8c8c70387f89"
  name          = "maybe-statistic-underrate-cache"
}

output "route" {
  value = data.ibm_is_vpc_routing_table_route.this
}
```

Response:
```
Changes to Outputs:
  + route = {
      + action          = "deliver"
      + created_at      = "2022-04-25T07:34:50.000Z"
      + destination     = "192.168.0.0/24"
      + href            = "https://us-south-stage01.iaasdev.cloud.ibm.com/v1/vpcs/r134-f5f85d66-938b-4f87-90cb-a8a02d39d02a/routing_tables/r134-b11762f4-0578-4c4b-ad64-8c8c70387f89/routes/r134-52c7d054-e51b-4882-b2cf-e15940032500"
      + id              = "r134-52c7d054-e51b-4882-b2cf-e15940032500"
      + lifecycle_state = "stable"
      + name            = "maybe-statistic-underrate-cache"
      + next_hop        = [
          + {
              + address       = "10.241.1.4"
              + deleted       = []
              + href          = ""
              + id            = ""
              + name          = ""
              + resource_type = ""
            },
        ]
      + route_id        = "r134-52c7d054-e51b-4882-b2cf-e15940032500"
      + routing_table   = "r134-b11762f4-0578-4c4b-ad64-8c8c70387f89"
      + vpc             = "r134-f5f85d66-938b-4f87-90cb-a8a02d39d02a"
      + zone            = [
          + {
              + href = "https://us-south-stage01.iaasdev.cloud.ibm.com/v1/regions/us-south/zones/us-south-2"
              + name = "us-south-2"
            },
        ]
    }
```
