### PR TITLE
added docs & enhanced network-port-attach resource

### DIFF
--- a/ibm/service/power/resource_ibm_pi_network_port.go
+++ b/ibm/service/power/resource_ibm_pi_network_port.go
@@ -71,6 +71,7 @@ func ResourceIBMPINetworkPort() *schema.Resource {
 				Computed: true,
 			},
 		},
+		DeprecationMessage: "Resource ibm_pi_network_port is deprecated. Use ibm_pi_network_port_attach to create & attach a network port to a pvm instance",
 	}
 }
 

--- a/ibm/service/power/resource_ibm_pi_network_port_attach_test.go
+++ b/ibm/service/power/resource_ibm_pi_network_port_attach_test.go
@@ -21,7 +21,6 @@ import (
 )
 
 func TestAccIBMPINetworkPortAttachbasic(t *testing.T) {
-	t.Skip()
 	name := fmt.Sprintf("tf-pi-network-port-attach-%d", acctest.RandIntRange(10, 100))
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { acc.TestAccPreCheck(t) },
@@ -34,13 +33,57 @@ func TestAccIBMPINetworkPortAttachbasic(t *testing.T) {
 					testAccCheckIBMPINetworkPortAttachExists("ibm_pi_network_port_attach.power_network_port_attach"),
 					resource.TestCheckResourceAttr(
 						"ibm_pi_network_port_attach.power_network_port_attach", "pi_network_name", name),
+					resource.TestCheckResourceAttrSet("ibm_pi_network_port_attach.power_network_port_attach", "id"),
+					resource.TestCheckResourceAttrSet("ibm_pi_network_port_attach.power_network_port_attach", "portid"),
+					resource.TestCheckResourceAttrSet("ibm_pi_network_port_attach.power_network_port_attach", "public_ip"),
+				),
+			},
+			{
+				Config: testAccCheckIBMPINetworkPortAttachUpdateConfig(name),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckIBMPINetworkPortAttachExists("ibm_pi_network_port_attach.power_network_port_attach"),
+					resource.TestCheckResourceAttr(
+						"ibm_pi_network_port_attach.power_network_port_attach", "pi_network_name", name),
+					resource.TestCheckResourceAttrSet("ibm_pi_network_port_attach.power_network_port_attach", "id"),
+					resource.TestCheckResourceAttrSet("ibm_pi_network_port_attach.power_network_port_attach", "portid"),
+					resource.TestCheckResourceAttrSet("ibm_pi_network_port_attach.power_network_port_attach", "public_ip"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccIBMPINetworkPortAttachVlanbasic(t *testing.T) {
+	name := fmt.Sprintf("tf-pi-network-port-attach-%d", acctest.RandIntRange(10, 100))
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { acc.TestAccPreCheck(t) },
+		Providers:    acc.TestAccProviders,
+		CheckDestroy: testAccCheckIBMPINetworkPortAttachDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckIBMPINetworkPortAttachVlanConfig(name),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckIBMPINetworkPortAttachExists("ibm_pi_network_port_attach.power_network_port_attach"),
+					resource.TestCheckResourceAttr(
+						"ibm_pi_network_port_attach.power_network_port_attach", "pi_network_name", name),
+					resource.TestCheckResourceAttrSet("ibm_pi_network_port_attach.power_network_port_attach", "id"),
+					resource.TestCheckResourceAttrSet("ibm_pi_network_port_attach.power_network_port_attach", "portid"),
+				),
+			},
+			{
+				Config: testAccCheckIBMPINetworkPortAttachVlanUpdateConfig(name),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckIBMPINetworkPortAttachExists("ibm_pi_network_port_attach.power_network_port_attach"),
+					resource.TestCheckResourceAttr(
+						"ibm_pi_network_port_attach.power_network_port_attach", "pi_network_name", name),
+					resource.TestCheckResourceAttrSet("ibm_pi_network_port_attach.power_network_port_attach", "id"),
+					resource.TestCheckResourceAttrSet("ibm_pi_network_port_attach.power_network_port_attach", "portid"),
 				),
 			},
 		},
 	})
 }
 func testAccCheckIBMPINetworkPortAttachDestroy(s *terraform.State) error {
-
 	sess, err := acc.TestAccProvider.Meta().(conns.ClientSession).IBMPISession()
 	if err != nil {
 		return err
@@ -54,10 +97,10 @@ func testAccCheckIBMPINetworkPortAttachDestroy(s *terraform.State) error {
 			return err
 		}
 		cloudInstanceID := parts[0]
-		networkID := parts[1]
+		networkname := parts[1]
 		portID := parts[2]
 		networkC := st.NewIBMPINetworkClient(context.Background(), sess, cloudInstanceID)
-		_, err = networkC.GetPort(networkID, portID)
+		_, err = networkC.GetPort(networkname, portID)
 		if err == nil {
 			return fmt.Errorf("PI Network Port still exists: %s", rs.Primary.ID)
 		}
@@ -87,27 +130,59 @@ func testAccCheckIBMPINetworkPortAttachExists(n string) resource.TestCheckFunc {
 			return err
 		}
 		cloudInstanceID := parts[0]
-		networkID := parts[1]
+		networkname := parts[1]
 		portID := parts[2]
 		client := st.NewIBMPINetworkClient(context.Background(), sess, cloudInstanceID)
 
-		network, err := client.GetPort(networkID, portID)
+		_, err = client.GetPort(networkname, portID)
 		if err != nil {
 			return err
 		}
-		parts[1] = *network.PortID
 		return nil
 
 	}
 }
 
 func testAccCheckIBMPINetworkPortAttachConfig(name string) string {
-	return testAccCheckIBMPINetworkPortConfig(name) + fmt.Sprintf(`
+	return testAccCheckIBMPINetworkConfig(name) + fmt.Sprintf(`
 	resource "ibm_pi_network_port_attach" "power_network_port_attach" {
 		pi_cloud_instance_id  = "%s"
 		pi_network_name       = ibm_pi_network.power_networks.pi_network_name
 		pi_network_port_description = "IP Reserved for Test UAT"
-		port_id=ibm_pi_network_port.power_network_port.id
+		pi_instance_id = "%s"
 	}
-	`, acc.Pi_cloud_instance_id)
+	`, acc.Pi_cloud_instance_id, acc.Pi_instance_name)
+}
+
+func testAccCheckIBMPINetworkPortAttachUpdateConfig(name string) string {
+	return testAccCheckIBMPINetworkConfig(name) + fmt.Sprintf(`
+	resource "ibm_pi_network_port_attach" "power_network_port_attach" {
+		pi_cloud_instance_id  = "%s"
+		pi_network_name       = ibm_pi_network.power_networks.pi_network_name
+		pi_network_port_description = "IP Reserved for TF Test"
+		pi_instance_id = "%s"
+	}
+	`, acc.Pi_cloud_instance_id, acc.Pi_instance_name)
+}
+
+func testAccCheckIBMPINetworkPortAttachVlanConfig(name string) string {
+	return testAccCheckIBMPINetworkGatewayConfig(name) + fmt.Sprintf(`
+	resource "ibm_pi_network_port_attach" "power_network_port_attach" {
+		pi_cloud_instance_id  = "%s"
+		pi_network_name       = ibm_pi_network.power_networks.pi_network_name
+		pi_network_port_description = "IP Reserved for Test UAT"
+		pi_instance_id = "%s"
+	}
+	`, acc.Pi_cloud_instance_id, acc.Pi_instance_name)
+}
+
+func testAccCheckIBMPINetworkPortAttachVlanUpdateConfig(name string) string {
+	return testAccCheckIBMPINetworkGatewayConfig(name) + fmt.Sprintf(`
+	resource "ibm_pi_network_port_attach" "power_network_port_attach" {
+		pi_cloud_instance_id  = "%s"
+		pi_network_name       = ibm_pi_network.power_networks.pi_network_name
+		pi_network_port_description = "IP Reserved for TF Test"
+		pi_instance_id = "%s"
+	}
+	`, acc.Pi_cloud_instance_id, acc.Pi_instance_name)
 }

--- a/ibm/service/power/resource_ibm_pi_network_port_attach_test.go
+++ b/ibm/service/power/resource_ibm_pi_network_port_attach_test.go
@@ -34,18 +34,7 @@ func TestAccIBMPINetworkPortAttachbasic(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"ibm_pi_network_port_attach.power_network_port_attach", "pi_network_name", name),
 					resource.TestCheckResourceAttrSet("ibm_pi_network_port_attach.power_network_port_attach", "id"),
-					resource.TestCheckResourceAttrSet("ibm_pi_network_port_attach.power_network_port_attach", "portid"),
-					resource.TestCheckResourceAttrSet("ibm_pi_network_port_attach.power_network_port_attach", "public_ip"),
-				),
-			},
-			{
-				Config: testAccCheckIBMPINetworkPortAttachUpdateConfig(name),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckIBMPINetworkPortAttachExists("ibm_pi_network_port_attach.power_network_port_attach"),
-					resource.TestCheckResourceAttr(
-						"ibm_pi_network_port_attach.power_network_port_attach", "pi_network_name", name),
-					resource.TestCheckResourceAttrSet("ibm_pi_network_port_attach.power_network_port_attach", "id"),
-					resource.TestCheckResourceAttrSet("ibm_pi_network_port_attach.power_network_port_attach", "portid"),
+					resource.TestCheckResourceAttrSet("ibm_pi_network_port_attach.power_network_port_attach", "network_port_id"),
 					resource.TestCheckResourceAttrSet("ibm_pi_network_port_attach.power_network_port_attach", "public_ip"),
 				),
 			},
@@ -67,17 +56,7 @@ func TestAccIBMPINetworkPortAttachVlanbasic(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"ibm_pi_network_port_attach.power_network_port_attach", "pi_network_name", name),
 					resource.TestCheckResourceAttrSet("ibm_pi_network_port_attach.power_network_port_attach", "id"),
-					resource.TestCheckResourceAttrSet("ibm_pi_network_port_attach.power_network_port_attach", "portid"),
-				),
-			},
-			{
-				Config: testAccCheckIBMPINetworkPortAttachVlanUpdateConfig(name),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckIBMPINetworkPortAttachExists("ibm_pi_network_port_attach.power_network_port_attach"),
-					resource.TestCheckResourceAttr(
-						"ibm_pi_network_port_attach.power_network_port_attach", "pi_network_name", name),
-					resource.TestCheckResourceAttrSet("ibm_pi_network_port_attach.power_network_port_attach", "id"),
-					resource.TestCheckResourceAttrSet("ibm_pi_network_port_attach.power_network_port_attach", "portid"),
+					resource.TestCheckResourceAttrSet("ibm_pi_network_port_attach.power_network_port_attach", "network_port_id"),
 				),
 			},
 		},
@@ -154,34 +133,12 @@ func testAccCheckIBMPINetworkPortAttachConfig(name string) string {
 	`, acc.Pi_cloud_instance_id, acc.Pi_instance_name)
 }
 
-func testAccCheckIBMPINetworkPortAttachUpdateConfig(name string) string {
-	return testAccCheckIBMPINetworkConfig(name) + fmt.Sprintf(`
-	resource "ibm_pi_network_port_attach" "power_network_port_attach" {
-		pi_cloud_instance_id  = "%s"
-		pi_network_name       = ibm_pi_network.power_networks.pi_network_name
-		pi_network_port_description = "IP Reserved for TF Test"
-		pi_instance_id = "%s"
-	}
-	`, acc.Pi_cloud_instance_id, acc.Pi_instance_name)
-}
-
 func testAccCheckIBMPINetworkPortAttachVlanConfig(name string) string {
 	return testAccCheckIBMPINetworkGatewayConfig(name) + fmt.Sprintf(`
 	resource "ibm_pi_network_port_attach" "power_network_port_attach" {
 		pi_cloud_instance_id  = "%s"
 		pi_network_name       = ibm_pi_network.power_networks.pi_network_name
 		pi_network_port_description = "IP Reserved for Test UAT"
-		pi_instance_id = "%s"
-	}
-	`, acc.Pi_cloud_instance_id, acc.Pi_instance_name)
-}
-
-func testAccCheckIBMPINetworkPortAttachVlanUpdateConfig(name string) string {
-	return testAccCheckIBMPINetworkGatewayConfig(name) + fmt.Sprintf(`
-	resource "ibm_pi_network_port_attach" "power_network_port_attach" {
-		pi_cloud_instance_id  = "%s"
-		pi_network_name       = ibm_pi_network.power_networks.pi_network_name
-		pi_network_port_description = "IP Reserved for TF Test"
 		pi_instance_id = "%s"
 	}
 	`, acc.Pi_cloud_instance_id, acc.Pi_instance_name)

--- a/website/docs/r/pi_network_port_attach.html.markdown
+++ b/website/docs/r/pi_network_port_attach.html.markdown
@@ -62,14 +62,14 @@ In addition to all argument reference list, you can access the following attribu
 
 - `id` - (String) The unique identifier of the instance. The ID is composed of `<pi_cloud_instance_id>/<power_network_port_id>/<id>`.
 - `macaddress` - (String) The MAC address of the port.
-- `portid` - (String) The ID of the port.
+- `network_port_id` - (String) The ID of the port.
 - `public_ip` - (String) The public IP associated with the port.
 - `status` - (String) The status of the port.
 
 
 ## Import
 
-The `ibm_pi_network_port` resource can be imported by using `power_instance_id`, `port_id` and `pi_network_name`.
+The `ibm_pi_network_port` resource can be imported by using `power_instance_id`, `network_port_id` and `pi_network_name`.
 
 **Example**
 

--- a/website/docs/r/pi_network_port_attach.html.markdown
+++ b/website/docs/r/pi_network_port_attach.html.markdown
@@ -2,26 +2,25 @@
 
 subcategory: "Power Systems"
 layout: "ibm"
-page_title: "IBM: pi_network_port"
+page_title: "IBM: pi_network_port_attach"
 description: |-
-  Manages an Network Port Attachments in the Power Virtual Server Cloud. A network port is equivalent to reserving an IP in the subnet.
-  When the port is created the status will be "DOWN". This network port however is not attached to an instance. 
+  Manages an Network Port Attachments in the Power Virtual Server Cloud.
 ---
 
-# ibm_pi_network_port
-Creates & Attaches network port in the Power Virtual Server Cloud. For more information, about network in IBM power virutal server, see [adding or removing a public network
+# ibm_pi_network_port_attach
+Attaches network port in the Power Virtual Server Cloud. For more information, about network in IBM power virutal server, see [adding or removing a public network
 ](https://cloud.ibm.com/docs/power-iaas?topic=power-iaas-modifying-server#adding-removing-network)..
 
 ## Example usage
 
-In the following example, you can create an network_port & attach it to pvm instance:
+In the following example, you can create an network_port_attach resource:
 
 ```terraform
-resource "ibm_pi_network_port" "test-network-port" {
-    pi_network_name             = "Zone1-CFN"
-    pi_cloud_instance_id        = "51e1879c-bcbe-4ee1-a008-49cdba0eaf60"
+resource "ibm_pi_network_port_attach" "test-network-port-attach" {
+    pi_cloud_instance_id        = "<value of the cloud_instance_id>"
     pi_instance_id              = "<pvm instance id>"
-    pi_network_port_description = "IP Reserved for Oracle RAC "
+    pi_network_name             = "<network name>"
+    pi_network_port_description = "<description>"
 }
 ```
 
@@ -42,18 +41,17 @@ resource "ibm_pi_network_port" "test-network-port" {
   
 ## Timeouts
 
-ibm_pi_network_port provides the following [timeouts](https://www.terraform.io/docs/language/resources/syntax.html) configuration options:
+ibm_pi_network_port_attach provides the following [timeouts](https://www.terraform.io/docs/language/resources/syntax.html) configuration options:
 
-- **create** - (Default 60 minutes) Used for creating a network_port.
-- **update** - (Default 60 minutes) Used for updating a network_port.
-- **delete** - (Default 60 minutes) Used for deleting a network_port.
+- **create** - (Default 60 minutes) Used for attaching a network port.
+- **delete** - (Default 60 minutes) Used for detaching a network port.
 
 ## Argument reference
 Review the argument references that you can specify for your resource.
 
 - `pi_cloud_instance_id` - (Required, String) The GUID of the service instance associated with an account.
-- `pi_instance_id` - (Required, String)  The ID of the pvm instance to attach the network port to.
-- `pi_network_name` - (Required, String) Network ID or name.
+- `pi_instance_id` - (Required, String) The ID of the pvm instance to attach the network port to.
+- `pi_network_name` - (Required, String) The network ID or name.
 - `pi_network_port_description` - (Optional, String) The description for the Network Port.
 - `pi_network_port_ipaddress` - (Optional, String) The requested ip address of this port.
 
@@ -63,16 +61,17 @@ In addition to all argument reference list, you can access the following attribu
 - `id` - (String) The unique identifier of the instance. The ID is composed of `<pi_cloud_instance_id>/<power_network_port_id>/<id>`.
 - `macaddress` - (String) The MAC address of the port.
 - `network_port_id` - (String) The ID of the port.
+- `portid` - (Deprecated, String) The ID of the port.
 - `public_ip` - (String) The public IP associated with the port.
 - `status` - (String) The status of the port.
 
 
 ## Import
 
-The `ibm_pi_network_port` resource can be imported by using `power_instance_id`, `network_port_id` and `pi_network_name`.
+The `ibm_pi_network_port` resource can be imported by using `power_instance_id`, `pi_network_name`  and `port_id`.
 
 **Example**
 
 ```
-$ terraform import ibm_pi_network_port.example d7bec597-4726-451f-8a63-e62e6f19c32c/cea6651a-bc0a-4438-9f8a-a0770bbf3ebb/network-name
+$ terraform import ibm_pi_network_port_attach.example d7bec597-4726-451f-8a63-e62e6f19c32c/network-name/cea6651a-bc0a-4438-9f8a-a0770bbf3ebb
 ```

--- a/website/docs/r/pi_network_port_attach.html.markdown
+++ b/website/docs/r/pi_network_port_attach.html.markdown
@@ -1,0 +1,78 @@
+---
+
+subcategory: "Power Systems"
+layout: "ibm"
+page_title: "IBM: pi_network_port"
+description: |-
+  Manages an Network Port Attachments in the Power Virtual Server Cloud. A network port is equivalent to reserving an IP in the subnet.
+  When the port is created the status will be "DOWN". This network port however is not attached to an instance. 
+---
+
+# ibm_pi_network_port
+Creates & Attaches network port in the Power Virtual Server Cloud. For more information, about network in IBM power virutal server, see [adding or removing a public network
+](https://cloud.ibm.com/docs/power-iaas?topic=power-iaas-modifying-server#adding-removing-network)..
+
+## Example usage
+
+In the following example, you can create an network_port & attach it to pvm instance:
+
+```terraform
+resource "ibm_pi_network_port" "test-network-port" {
+    pi_network_name             = "Zone1-CFN"
+    pi_cloud_instance_id        = "51e1879c-bcbe-4ee1-a008-49cdba0eaf60"
+    pi_instance_id              = "<pvm instance id>"
+    pi_network_port_description = "IP Reserved for Oracle RAC "
+}
+```
+
+**Note**
+* Please find [supported Regions](https://cloud.ibm.com/apidocs/power-cloud#endpoint) for endpoints.
+* If a Power cloud instance is provisioned at `lon04`, The provider level attributes should be as follows:
+  * `region` - `lon`
+  * `zone` - `lon04`
+  
+  Example usage:
+
+  ```terraform
+    provider "ibm" {
+      region    =   "lon"
+      zone      =   "lon04"
+    }
+  ```
+  
+## Timeouts
+
+ibm_pi_network_port provides the following [timeouts](https://www.terraform.io/docs/language/resources/syntax.html) configuration options:
+
+- **create** - (Default 60 minutes) Used for creating a network_port.
+- **update** - (Default 60 minutes) Used for updating a network_port.
+- **delete** - (Default 60 minutes) Used for deleting a network_port.
+
+## Argument reference
+Review the argument references that you can specify for your resource.
+
+- `pi_cloud_instance_id` - (Required, String) The GUID of the service instance associated with an account.
+- `pi_instance_id` - (Required, String)  The ID of the pvm instance to attach the network port to.
+- `pi_network_name` - (Required, String) Network ID or name.
+- `pi_network_port_description` - (Optional, String) The description for the Network Port.
+- `pi_network_port_ipaddress` - (Optional, String) The requested ip address of this port.
+
+## Attribute reference
+In addition to all argument reference list, you can access the following attribute reference after your resource is created.
+
+- `id` - (String) The unique identifier of the instance. The ID is composed of `<pi_cloud_instance_id>/<power_network_port_id>/<id>`.
+- `macaddress` - (String) The MAC address of the port.
+- `portid` - (String) The ID of the port.
+- `public_ip` - (String) The public IP associated with the port.
+- `status` - (String) The status of the port.
+
+
+## Import
+
+The `ibm_pi_network_port` resource can be imported by using `power_instance_id`, `port_id` and `pi_network_name`.
+
+**Example**
+
+```
+$ terraform import ibm_pi_network_port.example d7bec597-4726-451f-8a63-e62e6f19c32c/cea6651a-bc0a-4438-9f8a-a0770bbf3ebb/network-name
+```


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/IBM-Cloud/terraform-provider-ibm/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccXXX'
=== RUN   TestAccIBMPINetworkPortAttachbasic
--- PASS: TestAccIBMPINetworkPortAttachbasic (84.91s)
PASS
=== RUN   TestAccIBMPINetworkPortAttachVlanbasic
--- PASS: TestAccIBMPINetworkPortAttachVlanbasic (792.61s)
PASS
...
```
