### PR TITLE
Added error output on failed bucket parsing

### DIFF
--- a/ibm/service/cos/resource_ibm_cos_bucket.go
+++ b/ibm/service/cos/resource_ibm_cos_bucket.go
@@ -1286,6 +1286,10 @@ func resourceIBMCOSBucketExists(d *schema.ResourceData, meta interface{}) (bool,
 	if err != nil {
 		return false, err
 	}
+	bucket_meta := strings.Split(d.Id(), ":meta:")
+	if len(bucket_meta) < 2 || len(strings.Split(bucket_meta[1], ":")) < 2 {
+		return false, fmt.Errorf("[ERROR] Error parsing bucket ID. Bucket ID format must be: $CRN:meta:$buckettype:$bucketlocation")
+	}
 
 	bucketName := parseBucketId(d.Id(), "bucketName")
 	serviceID := parseBucketId(d.Id(), "serviceID")


### PR DESCRIPTION
Hello. Not so long ago I encountered the same problem described in issue #2630. I think using bucket ID, instead of CRN, is not very intuitive for someone who has not read the documentation before importing. I suggest adding an error output that can be used in a search query to get a link to the documentation, issue and the answer in Stackoverflow.

### Details
When I try to import the COS bucket, I get an error:
<details>

```
$ terraform import ibm_cos_bucket.bucket crn:v1:bluemix:public:cloud-object-storage:global:a/[PRIVATE DATA HIDDEN]:bucket:bucketname

ibm_cos_bucket.bucket: Importing from ID "crn:v1:bluemix:public:cloud-object-storage:global:a/[PRIVATE DATA HIDDEN]:bucket:bucketname"...
ibm_cos_bucket.bucket: Import prepared!
  Prepared ibm_cos_bucket for import
ibm_cos_bucket.bucket: Refreshing state... [id=crn:v1:bluemix:public:cloud-object-storage:global:a/[PRIVATE DATA HIDDEN]:bucket:bucketname]
╷
│ Error: Plugin did not respond
│ 
│ The plugin encountered an error, and failed to respond to the plugin.(*GRPCProvider).ReadResource call. The plugin logs may contain more details.
╵

Stack trace from the terraform-provider-ibm_v1.41.0 plugin:

panic: runtime error: index out of range [1] with length 1

goroutine 90 [running]:
github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/cos.parseBucketId(0xc000050320, 0x96, 0x2deeb28, 0xa, 0xc000187200, 0x0)
	github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/cos/resource_ibm_cos_bucket.go:1358 +0x52f
github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/cos.resourceIBMCOSBucketExists(0xc00049fd00, 0x2dd3e20, 0xc000187200, 0x0, 0x0, 0x1)
	github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/cos/resource_ibm_cos_bucket.go:1290 +0xf8
github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema.(*Resource).RefreshWithoutUpgrade(0xc0005e70a0, 0x3311958, 0xc0001fb7c0, 0xc0009612b0, 0x2dd3e20, 0xc000187200, 0xc0000aa750, 0x0, 0x0, 0x0)
	github.com/hashicorp/terraform-plugin-sdk/v2@v2.10.1/helper/schema/resource.go:615 +0x3d5
github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema.(*GRPCProviderServer).ReadResource(0xc0004932f0, 0x3311958, 0xc0001fb7c0, 0xc0001fb800, 0x2e03222, 0x12, 0x0)
	github.com/hashicorp/terraform-plugin-sdk/v2@v2.10.1/helper/schema/grpc_provider.go:576 +0x47d
github.com/hashicorp/terraform-plugin-go/tfprotov5/tf5server.(*server).ReadResource(0xc0000be200, 0x3311a00, 0xc0001fb7c0, 0xc001056fc0, 0x0, 0x0, 0x0)
	github.com/hashicorp/terraform-plugin-go@v0.5.0/tfprotov5/tf5server/server.go:553 +0x322
github.com/hashicorp/terraform-plugin-go/tfprotov5/internal/tfplugin5._Provider_ReadResource_Handler(0x2d059c0, 0xc0000be200, 0x3311a00, 0xc001053f50, 0xc001056f60, 0x0, 0x3311a00, 0xc001053f50, 0xc001038a80, 0x302)
	github.com/hashicorp/terraform-plugin-go@v0.5.0/tfprotov5/internal/tfplugin5/tfplugin5_grpc.pb.go:344 +0x214
google.golang.org/grpc.(*Server).processUnaryRPC(0xc00018cfc0, 0x332b9f8, 0xc000373e00, 0xc0012c8600, 0xc000b5d0b0, 0x42be130, 0x0, 0x0, 0x0)
	google.golang.org/grpc@v1.32.0/server.go:1194 +0x52b
google.golang.org/grpc.(*Server).handleStream(0xc00018cfc0, 0x332b9f8, 0xc000373e00, 0xc0012c8600, 0x0)
	google.golang.org/grpc@v1.32.0/server.go:1517 +0xd0c
google.golang.org/grpc.(*Server).serveStreams.func1.2(0xc00048c4a0, 0xc00018cfc0, 0x332b9f8, 0xc000373e00, 0xc0012c8600)
	google.golang.org/grpc@v1.32.0/server.go:859 +0xab
created by google.golang.org/grpc.(*Server).serveStreams.func1
	google.golang.org/grpc@v1.32.0/server.go:857 +0x1fd

Error: The terraform-provider-ibm_v1.41.0 plugin crashed!

This is always indicative of a bug within the plugin. It would be immensely
helpful if you could report the crash with the plugin's maintainers so that it
can be fixed. The output above should help diagnose the issue.
```

</details>

### Steps for reproduce

1. Create a COS
2. Create a bucket
3. Get bucket instance CRN from the configuration menu(example in Details)
4. Try importing using `terraform import <CRN>` command.

### Justification for PR

Now when you try to import a CRN, instead of an ID, you get an error:
```
$ terraform import crn:v1:bluemix:public:cloud-object-storage:global:a/[PRIVATE DATA HIDDEN]:bucket:bucketname
ibm_cos_bucket.bucket: Importing from ID "crn:v1:bluemix:public:cloud-object-storage:global:a/[PRIVATE DATA HIDDEN]:bucket:bucketname"...
ibm_cos_bucket.bucket: Import prepared!
  Prepared ibm_cos_bucket for import
ibm_cos_bucket.bucket: Refreshing state... [id=crn:v1:bluemix:public:cloud-object-storage:global:a/[PRIVATE DATA HIDDEN]:bucket:bucketname]
╷
│ Error: [ERROR] Error parsing bucket ID. Bucket ID format must be: $CRN:meta:$buckettype:$bucketlocation
│ 
│ 
╵
```

I thought about using `$CRN:meta:$buckettype:$bucketlocation:$endpoint_type`, but since `endpoint_type` is optional(`public` by default), I decided not to add it.
I also added a second check: `len(strings.Split(bucket_meta[1], ":")) < 2`, because without it you might get a stacktrace(example in Details) when trying to import `$CRN:meta:`.

### Acceptance test

```
$ make testacc TESTARGS='-run TestAccIBMCosBucket_Basic'
=== RUN   TestAccIBMCosBucket_Basic
--- PASS: TestAccIBMCosBucket_Basic (84.44s)
PASS
ok      github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/cos     84.512s

$ make testacc TESTARGS='-run TestAccIBMCosBucket_import'
=== RUN   TestAccIBMCosBucket_import
--- PASS: TestAccIBMCosBucket_import (68.90s)
PASS
ok      github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/cos     69.018s
```
