### PR TITLE
Remove Power Cloud Connection helpers

### DIFF
--- a/ibm/service/power/data_source_ibm_pi_cloud_connection.go
+++ b/ibm/service/power/data_source_ibm_pi_cloud_connection.go
@@ -12,39 +12,20 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 
 	"github.com/IBM-Cloud/power-go-client/clients/instance"
-	"github.com/IBM-Cloud/power-go-client/helpers"
 	"github.com/IBM-Cloud/power-go-client/power/models"
 	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/conns"
-)
-
-const (
-	PICloudConnectionId               = "cloud_connection_id"
-	PICloudConnectionName             = "name"
-	PICloudConnectionSpeed            = "speed"
-	PICloudConnectionGlobalRouting    = "global_routing"
-	PICloudConnectionMetered          = "metered"
-	PICloudConnectionStatus           = "status"
-	PICloudConnectionClassicEnabled   = "classic_enabled"
-	PICloudConnectionUserIPAddress    = "user_ip_address"
-	PICloudConnectionIBMIPAddress     = "ibm_ip_address"
-	PICloudConnectionPort             = "port"
-	PICloudConnectionNetworks         = "networks"
-	PICloudConnectionClassicGreDest   = "gre_destination_address"
-	PICloudConnectionClassicGreSource = "gre_source_address"
-	PICloudConnectionVPCEnabled       = "vpc_enabled"
-	PICloudConnectionVPCCRNs          = "vpc_crns"
 )
 
 func DataSourceIBMPICloudConnection() *schema.Resource {
 	return &schema.Resource{
 		ReadContext: dataSourceIBMPICloudConnectionRead,
 		Schema: map[string]*schema.Schema{
-			helpers.PICloudInstanceId: {
+			Arg_CloudInstanceID: {
 				Type:         schema.TypeString,
 				Required:     true,
 				ValidateFunc: validation.NoZeroValues,
 			},
-			helpers.PICloudConnectionName: {
+			Arg_CloudConnectionName: {
 				Type:         schema.TypeString,
 				Required:     true,
 				Description:  "Cloud Connection Name to be used",
@@ -52,61 +33,61 @@ func DataSourceIBMPICloudConnection() *schema.Resource {
 			},
 
 			// Computed Attributes
-			PICloudConnectionSpeed: {
+			Attr_CloudConnectionSpeed: {
 				Type:     schema.TypeInt,
 				Computed: true,
 			},
-			PICloudConnectionGlobalRouting: {
+			Attr_CloudConnectionRouting: {
 				Type:     schema.TypeBool,
 				Computed: true,
 			},
-			PICloudConnectionMetered: {
+			Attr_CloudConnectionMetered: {
 				Type:     schema.TypeBool,
 				Computed: true,
 			},
-			PICloudConnectionStatus: {
+			Attr_CloudConnectionStatus: {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
-			PICloudConnectionIBMIPAddress: {
+			Attr_CloudConnectionIbmIP: {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
-			PICloudConnectionUserIPAddress: {
+			Attr_CloudConnectionUserIP: {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
-			PICloudConnectionPort: {
+			Attr_CloudConnectionPort: {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
-			PICloudConnectionNetworks: {
+			Attr_CloudConnectionNetworks: {
 				Type:        schema.TypeSet,
 				Computed:    true,
 				Elem:        &schema.Schema{Type: schema.TypeString},
 				Description: "Set of Networks attached to this cloud connection",
 			},
-			PICloudConnectionClassicEnabled: {
+			Attr_CloudConnectionClassic: {
 				Type:        schema.TypeBool,
 				Computed:    true,
 				Description: "Enable classic endpoint destination",
 			},
-			PICloudConnectionClassicGreDest: {
+			AttrCloudConnectionGreDestAddr: {
 				Type:        schema.TypeString,
 				Computed:    true,
 				Description: "GRE destination IP address",
 			},
-			PICloudConnectionClassicGreSource: {
+			Attr_CloudConnectionSourceGreAddr: {
 				Type:        schema.TypeString,
 				Computed:    true,
 				Description: "GRE auto-assigned source IP address",
 			},
-			PICloudConnectionVPCEnabled: {
+			Attr_CloudConnectionVPC: {
 				Type:        schema.TypeBool,
 				Computed:    true,
 				Description: "Enable VPC for this cloud connection",
 			},
-			PICloudConnectionVPCCRNs: {
+			Attr_CloudConnectionVPCCrns: {
 				Type:        schema.TypeSet,
 				Computed:    true,
 				Elem:        &schema.Schema{Type: schema.TypeString},
@@ -122,8 +103,8 @@ func dataSourceIBMPICloudConnectionRead(ctx context.Context, d *schema.ResourceD
 		return diag.FromErr(err)
 	}
 
-	cloudInstanceID := d.Get(helpers.PICloudInstanceId).(string)
-	cloudConnectionName := d.Get(helpers.PICloudConnectionName).(string)
+	cloudInstanceID := d.Get(Arg_CloudInstanceID).(string)
+	cloudConnectionName := d.Get(Arg_CloudConnectionName).(string)
 	client := instance.NewIBMPICloudConnectionClient(ctx, sess, cloudInstanceID)
 
 	// Get API does not work with name for Cloud Connection hence using GetAll (max 2)
@@ -159,15 +140,15 @@ func dataSourceIBMPICloudConnectionRead(ctx context.Context, d *schema.ResourceD
 	}
 
 	d.SetId(*cloudConnection.CloudConnectionID)
-	d.Set(helpers.PICloudConnectionName, cloudConnection.Name)
-	d.Set(PICloudConnectionGlobalRouting, cloudConnection.GlobalRouting)
-	d.Set(PICloudConnectionMetered, cloudConnection.Metered)
-	d.Set(PICloudConnectionIBMIPAddress, cloudConnection.IbmIPAddress)
-	d.Set(PICloudConnectionUserIPAddress, cloudConnection.UserIPAddress)
-	d.Set(PICloudConnectionStatus, cloudConnection.LinkStatus)
-	d.Set(PICloudConnectionPort, cloudConnection.Port)
-	d.Set(PICloudConnectionSpeed, cloudConnection.Speed)
-	d.Set(helpers.PICloudInstanceId, cloudInstanceID)
+	d.Set(Arg_CloudConnectionName, cloudConnection.Name)
+	d.Set(Attr_CloudConnectionRouting, cloudConnection.GlobalRouting)
+	d.Set(Attr_CloudConnectionMetered, cloudConnection.Metered)
+	d.Set(Attr_CloudConnectionIbmIP, cloudConnection.IbmIPAddress)
+	d.Set(Attr_CloudConnectionUserIP, cloudConnection.UserIPAddress)
+	d.Set(Attr_CloudConnectionStatus, cloudConnection.LinkStatus)
+	d.Set(Attr_CloudConnectionPort, cloudConnection.Port)
+	d.Set(Attr_CloudConnectionSpeed, cloudConnection.Speed)
+	d.Set(Arg_CloudInstanceID, cloudInstanceID)
 	if cloudConnection.Networks != nil {
 		networks := make([]string, len(cloudConnection.Networks))
 		for i, ccNetwork := range cloudConnection.Networks {
@@ -175,23 +156,23 @@ func dataSourceIBMPICloudConnectionRead(ctx context.Context, d *schema.ResourceD
 				networks[i] = *ccNetwork.NetworkID
 			}
 		}
-		d.Set(PICloudConnectionNetworks, networks)
+		d.Set(Attr_CloudConnectionNetworks, networks)
 	}
 	if cloudConnection.Classic != nil {
-		d.Set(PICloudConnectionClassicEnabled, cloudConnection.Classic.Enabled)
+		d.Set(Attr_CloudConnectionClassic, cloudConnection.Classic.Enabled)
 		if cloudConnection.Classic.Gre != nil {
-			d.Set(PICloudConnectionClassicGreDest, cloudConnection.Classic.Gre.DestIPAddress)
-			d.Set(PICloudConnectionClassicGreSource, cloudConnection.Classic.Gre.SourceIPAddress)
+			d.Set(AttrCloudConnectionGreDestAddr, cloudConnection.Classic.Gre.DestIPAddress)
+			d.Set(Attr_CloudConnectionSourceGreAddr, cloudConnection.Classic.Gre.SourceIPAddress)
 		}
 	}
 	if cloudConnection.Vpc != nil {
-		d.Set(PICloudConnectionVPCEnabled, cloudConnection.Vpc.Enabled)
+		d.Set(Attr_CloudConnectionVPC, cloudConnection.Vpc.Enabled)
 		if cloudConnection.Vpc.Vpcs != nil && len(cloudConnection.Vpc.Vpcs) > 0 {
 			vpcCRNs := make([]string, len(cloudConnection.Vpc.Vpcs))
 			for i, vpc := range cloudConnection.Vpc.Vpcs {
 				vpcCRNs[i] = *vpc.VpcID
 			}
-			d.Set(PICloudConnectionVPCCRNs, vpcCRNs)
+			d.Set(Attr_CloudConnectionVPCCrns, vpcCRNs)
 		}
 	}
 

--- a/ibm/service/power/data_source_ibm_pi_cloud_connections.go
+++ b/ibm/service/power/data_source_ibm_pi_cloud_connections.go
@@ -8,7 +8,6 @@ import (
 	"log"
 
 	st "github.com/IBM-Cloud/power-go-client/clients/instance"
-	"github.com/IBM-Cloud/power-go-client/helpers"
 	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/conns"
 	"github.com/hashicorp/go-uuid"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
@@ -28,7 +27,7 @@ func DataSourceIBMPICloudConnections() *schema.Resource {
 	return &schema.Resource{
 		ReadContext: dataSourceIBMPICloudConnectionsRead,
 		Schema: map[string]*schema.Schema{
-			helpers.PICloudInstanceId: {
+			Arg_CloudInstanceID: {
 				Type:         schema.TypeString,
 				Required:     true,
 				ValidateFunc: validation.NoZeroValues,
@@ -39,69 +38,69 @@ func DataSourceIBMPICloudConnections() *schema.Resource {
 				Computed: true,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
-						PICloudConnectionId: {
+						Attr_CloudConnectionID: {
 							Type:     schema.TypeString,
 							Computed: true,
 						},
-						PICloudConnectionName: {
+						Attr_CloudConnectionName: {
 							Type:     schema.TypeString,
 							Computed: true,
 						},
-						PICloudConnectionSpeed: {
+						Attr_CloudConnectionSpeed: {
 							Type:     schema.TypeInt,
 							Computed: true,
 						},
-						PICloudConnectionGlobalRouting: {
+						Attr_CloudConnectionRouting: {
 							Type:     schema.TypeBool,
 							Computed: true,
 						},
-						PICloudConnectionMetered: {
+						Attr_CloudConnectionMetered: {
 							Type:     schema.TypeBool,
 							Computed: true,
 						},
-						PICloudConnectionStatus: {
+						Attr_CloudConnectionStatus: {
 							Type:     schema.TypeString,
 							Computed: true,
 						},
-						PICloudConnectionIBMIPAddress: {
+						Attr_CloudConnectionIbmIP: {
 							Type:     schema.TypeString,
 							Computed: true,
 						},
-						PICloudConnectionUserIPAddress: {
+						Attr_CloudConnectionUserIP: {
 							Type:     schema.TypeString,
 							Computed: true,
 						},
-						PICloudConnectionPort: {
+						Attr_CloudConnectionPort: {
 							Type:     schema.TypeString,
 							Computed: true,
 						},
-						PICloudConnectionNetworks: {
+						Attr_CloudConnectionNetworks: {
 							Type:        schema.TypeSet,
 							Computed:    true,
 							Elem:        &schema.Schema{Type: schema.TypeString},
 							Description: "Set of Networks attached to this cloud connection",
 						},
-						PICloudConnectionClassicEnabled: {
+						Attr_CloudConnectionClassic: {
 							Type:        schema.TypeBool,
 							Computed:    true,
 							Description: "Enable classic endpoint destination",
 						},
-						PICloudConnectionClassicGreDest: {
+						AttrCloudConnectionGreDestAddr: {
 							Type:        schema.TypeString,
 							Computed:    true,
 							Description: "GRE destination IP address",
 						},
-						PICloudConnectionClassicGreSource: {
+						Attr_CloudConnectionSourceGreAddr: {
 							Type:        schema.TypeString,
 							Computed:    true,
 							Description: "GRE auto-assigned source IP address",
 						},
-						PICloudConnectionVPCEnabled: {
+						Attr_CloudConnectionVPC: {
 							Type:        schema.TypeBool,
 							Computed:    true,
 							Description: "Enable VPC for this cloud connection",
 						},
-						PICloudConnectionVPCCRNs: {
+						Attr_CloudConnectionVPCCrns: {
 							Type:        schema.TypeSet,
 							Computed:    true,
 							Elem:        &schema.Schema{Type: schema.TypeString},
@@ -120,7 +119,7 @@ func dataSourceIBMPICloudConnectionsRead(ctx context.Context, d *schema.Resource
 		return diag.FromErr(err)
 	}
 
-	cloudInstanceID := d.Get(helpers.PICloudInstanceId).(string)
+	cloudInstanceID := d.Get(Arg_CloudInstanceID).(string)
 	client := st.NewIBMPICloudConnectionClient(ctx, sess, cloudInstanceID)
 
 	cloudConnections, err := client.GetAll()
@@ -132,15 +131,15 @@ func dataSourceIBMPICloudConnectionsRead(ctx context.Context, d *schema.Resource
 	result := make([]map[string]interface{}, 0, len(cloudConnections.CloudConnections))
 	for _, cloudConnection := range cloudConnections.CloudConnections {
 		cc := map[string]interface{}{
-			PICloudConnectionId:            *cloudConnection.CloudConnectionID,
-			PICloudConnectionName:          *cloudConnection.Name,
-			PICloudConnectionGlobalRouting: *cloudConnection.GlobalRouting,
-			PICloudConnectionMetered:       *cloudConnection.Metered,
-			PICloudConnectionIBMIPAddress:  *cloudConnection.IbmIPAddress,
-			PICloudConnectionUserIPAddress: *cloudConnection.UserIPAddress,
-			PICloudConnectionStatus:        *cloudConnection.LinkStatus,
-			PICloudConnectionPort:          *cloudConnection.Port,
-			PICloudConnectionSpeed:         *cloudConnection.Speed,
+			Attr_CloudConnectionID:      *cloudConnection.CloudConnectionID,
+			Attr_CloudConnectionName:    *cloudConnection.Name,
+			Attr_CloudConnectionRouting: *cloudConnection.GlobalRouting,
+			Attr_CloudConnectionMetered: *cloudConnection.Metered,
+			Attr_CloudConnectionIbmIP:   *cloudConnection.IbmIPAddress,
+			Attr_CloudConnectionUserIP:  *cloudConnection.UserIPAddress,
+			Attr_CloudConnectionStatus:  *cloudConnection.LinkStatus,
+			Attr_CloudConnectionPort:    *cloudConnection.Port,
+			Attr_CloudConnectionSpeed:   *cloudConnection.Speed,
 		}
 
 		if cloudConnection.Networks != nil {
@@ -150,23 +149,23 @@ func dataSourceIBMPICloudConnectionsRead(ctx context.Context, d *schema.Resource
 					networks[i] = *ccNetwork.NetworkID
 				}
 			}
-			cc[PICloudConnectionNetworks] = networks
+			cc[Attr_CloudConnectionNetworks] = networks
 		}
 		if cloudConnection.Classic != nil {
-			cc[PICloudConnectionClassicEnabled] = cloudConnection.Classic.Enabled
+			cc[Attr_CloudConnectionClassic] = cloudConnection.Classic.Enabled
 			if cloudConnection.Classic.Gre != nil {
-				cc[PICloudConnectionClassicGreDest] = cloudConnection.Classic.Gre.DestIPAddress
-				cc[PICloudConnectionClassicGreSource] = cloudConnection.Classic.Gre.SourceIPAddress
+				cc[AttrCloudConnectionGreDestAddr] = cloudConnection.Classic.Gre.DestIPAddress
+				cc[Attr_CloudConnectionSourceGreAddr] = cloudConnection.Classic.Gre.SourceIPAddress
 			}
 		}
 		if cloudConnection.Vpc != nil {
-			cc[PICloudConnectionVPCEnabled] = cloudConnection.Vpc.Enabled
+			cc[Attr_CloudConnectionVPC] = cloudConnection.Vpc.Enabled
 			if cloudConnection.Vpc.Vpcs != nil && len(cloudConnection.Vpc.Vpcs) > 0 {
 				vpcCRNs := make([]string, len(cloudConnection.Vpc.Vpcs))
 				for i, vpc := range cloudConnection.Vpc.Vpcs {
 					vpcCRNs[i] = *vpc.VpcID
 				}
-				cc[PICloudConnectionVPCCRNs] = vpcCRNs
+				cc[Attr_CloudConnectionVPCCrns] = vpcCRNs
 			}
 		}
 

--- a/ibm/service/power/ibm_pi_constants.go
+++ b/ibm/service/power/ibm_pi_constants.go
@@ -4,21 +4,51 @@ import "time"
 
 const (
 
-	// Keys
-	PIKeys    = "keys"
-	PIKeyName = "name"
-	PIKey     = "ssh_key"
-	PIKeyDate = "creation_date"
+	// -- Capture -------------------------------------------------------------
 
-	// SAP Profile
-	PISAPProfiles         = "profiles"
-	PISAPProfileCertified = "certified"
-	PISAPProfileCores     = "cores"
-	PISAPProfileMemory    = "memory"
-	PISAPProfileID        = "profile_id"
-	PISAPProfileType      = "type"
+	// -- Cloud Connection ----------------------------------------------------
+	// Required Arguments
+	Arg_CloudConnectionID        = "pi_cloud_connection_id"
+	Arg_CloudConnectionName      = "pi_cloud_connection_name"
+	Arg_CloudConnectionSpeed     = "pi_cloud_connection_speed"
+	Arg_CloudConnectionNetworkID = "pi_network_id"
 
-	// DHCP
+	// Optional Arguments
+	Arg_CloudConnectionRouting  = "pi_cloud_connection_global_routing"
+	Arg_CloudConnectionMetered  = "pi_cloud_connection_metered"
+	Arg_CloudConnectionNetworks = "pi_cloud_connection_networks"
+	Arg_CloudConnectionClassic  = "pi_cloud_connection_classic_enabled"
+	Arg_CloudConnectionGreCIDR  = "pi_cloud_connection_gre_cidr"
+	Arg_CloudConnectionGreDest  = "pi_cloud_connection_gre_destination_address"
+	Arg_CloudConnectionVPC      = "pi_cloud_connection_vpc_enabled"
+	Arg_CloudConnectionVPCCrns  = "pi_cloud_connection_vpc_crns"
+	Arg_CloudConnection         = "pi_cloud_connection_"
+
+	// Attributes
+	Attr_CloudConnectionSpeed         = "speed"
+	Attr_CloudConnectionID            = "cloud_connection_id"
+	Attr_CloudConnectionStatus        = "status"
+	Attr_CloudConnectionIbmIP         = "ibm_ip_address"
+	Attr_CloudConnectionUserIP        = "user_ip_address"
+	Attr_CloudConnectionPort          = "port"
+	Attr_CloudConnectionSourceGreAddr = "gre_source_address"
+	AttrCloudConnectionGreDestAddr    = "gre_destination_address"
+	Attr_CloudConnectionRouting       = "global_routing"
+	Attr_CloudConnectionMetered       = "metered"
+	Attr_CloudConnectionNetworks      = "networks"
+	Attr_CloudConnectionClassic       = "classic_enabled"
+	Attr_CloudConnectionVPC           = "vpc_enabled"
+	Attr_CloudConnectionVPCCrns       = "vpc_crns"
+	Attr_CloudConnectionName          = "name"
+
+	// need to fix
+
+	// -- Cloud Instance ------------------------------------------------------
+	Arg_CloudInstanceID = "pi_cloud_instance_id"
+
+	// -- Console Language ----------------------------------------------------
+
+	// -- DHCP ----------------------------------------------------------------
 	PIDhcpStatusBuilding = "Building"
 	PIDhcpStatusActive   = "ACTIVE"
 	PIDhcpDeleting       = "Deleting"
@@ -30,7 +60,10 @@ const (
 	PIDhcpInstanceIp     = "instance_ip"
 	PIDhcpInstanceMac    = "instance_mac"
 
-	// Instance
+	// -- Image ---------------------------------------------------------------
+
+	// -- Instance ------------------------------------------------------------
+
 	//Added timeout values for warning  and active status
 	warningTimeOut = 60 * time.Second
 	activeTimeOut  = 2 * time.Minute
@@ -41,18 +74,44 @@ const (
 	PISAPInstanceProfileID        = "pi_sap_profile_id"
 	PIInstanceStoragePoolAffinity = "pi_storage_pool_affinity"
 
-	// Placement Group
+	// -- Key -----------------------------------------------------------------
+	PIKeys    = "keys"
+	PIKeyName = "name"
+	PIKey     = "ssh_key"
+	PIKeyDate = "creation_date"
+
+	// -- Network -------------------------------------------------------------
+
+	// -- Operations ----------------------------------------------------------
+
+	// -- Placement Group -----------------------------------------------------
 	PIPlacementGroupID      = "placement_group_id"
 	PIPlacementGroupMembers = "members"
 
-	// Volume
+	// -- SAP -----------------------------------------------------------------
+	PISAPProfiles         = "profiles"
+	PISAPProfileCertified = "certified"
+	PISAPProfileCores     = "cores"
+	PISAPProfileMemory    = "memory"
+	PISAPProfileID        = "profile_id"
+	PISAPProfileType      = "type"
+
+	// -- Snapshot ------------------------------------------------------------
+
+	// -- Storage Pool --------------------------------------------------------
+
+	// -- Storage Type --------------------------------------------------------
+
+	// -- Tenant --------------------------------------------------------------
+
+	// -- Volume --------------------------------------------------------------
 	PIAffinityPolicy        = "pi_affinity_policy"
 	PIAffinityVolume        = "pi_affinity_volume"
 	PIAffinityInstance      = "pi_affinity_instance"
 	PIAntiAffinityInstances = "pi_anti_affinity_instances"
 	PIAntiAffinityVolumes   = "pi_anti_affinity_volumes"
 
-	// VPN
+	// -- VPN -----------------------------------------------------------------
 	PIVPNConnectionId                         = "connection_id"
 	PIVPNConnectionStatus                     = "connection_status"
 	PIVPNConnectionDeadPeerDetection          = "dead_peer_detections"
@@ -61,4 +120,9 @@ const (
 	PIVPNConnectionDeadPeerDetectionThreshold = "threshold"
 	PIVPNConnectionLocalGatewayAddress        = "local_gateway_address"
 	PIVPNConnectionVpnGatewayAddress          = "gateway_address"
+
+	// -- VPN Policy ----------------------------------------------------------
+
+	// Health
+	HealthOk = "OK"
 )

--- a/ibm/service/power/resource_ibm_pi_cloud_connection.go
+++ b/ibm/service/power/resource_ibm_pi_cloud_connection.go
@@ -14,7 +14,6 @@ import (
 
 	st "github.com/IBM-Cloud/power-go-client/clients/instance"
 	"github.com/IBM-Cloud/power-go-client/errors"
-	"github.com/IBM-Cloud/power-go-client/helpers"
 	"github.com/IBM-Cloud/power-go-client/power/client/p_cloud_cloud_connections"
 	"github.com/IBM-Cloud/power-go-client/power/models"
 	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/conns"
@@ -38,17 +37,17 @@ func ResourceIBMPICloudConnection() *schema.Resource {
 
 		Schema: map[string]*schema.Schema{
 			// Required Attributes
-			helpers.PICloudInstanceId: {
+			Arg_CloudInstanceID: {
 				Type:        schema.TypeString,
 				Required:    true,
 				Description: "PI cloud instance ID",
 			},
-			helpers.PICloudConnectionName: {
+			Arg_CloudConnectionName: {
 				Type:        schema.TypeString,
 				Required:    true,
 				Description: "Name of the cloud connection",
 			},
-			helpers.PICloudConnectionSpeed: {
+			Arg_CloudConnectionSpeed: {
 				Type:         schema.TypeInt,
 				Required:     true,
 				ValidateFunc: validate.ValidateAllowedIntValues([]int{50, 100, 200, 500, 1000, 2000, 5000, 10000}),
@@ -56,85 +55,85 @@ func ResourceIBMPICloudConnection() *schema.Resource {
 			},
 
 			// Optional Attributes
-			helpers.PICloudConnectionGlobalRouting: {
+			Arg_CloudConnectionRouting: {
 				Type:        schema.TypeBool,
 				Optional:    true,
 				Default:     false,
 				Description: "Enable global routing for this cloud connection",
 			},
-			helpers.PICloudConnectionMetered: {
+			Arg_CloudConnectionMetered: {
 				Type:        schema.TypeBool,
 				Optional:    true,
 				Default:     false,
 				Description: "Enable metered for this cloud connection",
 			},
-			helpers.PICloudConnectionNetworks: {
+			Arg_CloudConnectionNetworks: {
 				Type:        schema.TypeSet,
 				Optional:    true,
 				Computed:    true,
 				Elem:        &schema.Schema{Type: schema.TypeString},
 				Description: "Set of Networks to attach to this cloud connection",
 			},
-			helpers.PICloudConnectionClassicEnabled: {
+			Arg_CloudConnectionClassic: {
 				Type:        schema.TypeBool,
 				Optional:    true,
 				Default:     false,
 				Description: "Enable classic endpoint destination",
 			},
-			helpers.PICloudConnectionClassicGreCidr: {
+			Arg_CloudConnectionGreCIDR: {
 				Type:         schema.TypeString,
 				Optional:     true,
-				RequiredWith: []string{helpers.PICloudConnectionClassicEnabled, helpers.PICloudConnectionClassicGreDest},
+				RequiredWith: []string{Arg_CloudConnectionClassic, Arg_CloudConnectionGreDest},
 				Description:  "GRE network in CIDR notation",
 			},
-			helpers.PICloudConnectionClassicGreDest: {
+			Arg_CloudConnectionGreDest: {
 				Type:         schema.TypeString,
 				Optional:     true,
-				RequiredWith: []string{helpers.PICloudConnectionClassicEnabled, helpers.PICloudConnectionClassicGreCidr},
+				RequiredWith: []string{Arg_CloudConnectionClassic, Arg_CloudConnectionGreCIDR},
 				Description:  "GRE destination IP address",
 			},
-			helpers.PICloudConnectionVPCEnabled: {
+			Arg_CloudConnectionVPC: {
 				Type:         schema.TypeBool,
 				Optional:     true,
 				Default:      false,
-				RequiredWith: []string{helpers.PICloudConnectionVPCCRNs},
+				RequiredWith: []string{Arg_CloudConnectionVPCCrns},
 				Description:  "Enable VPC for this cloud connection",
 			},
-			helpers.PICloudConnectionVPCCRNs: {
+			Arg_CloudConnectionVPCCrns: {
 				Type:         schema.TypeSet,
 				Optional:     true,
 				Elem:         &schema.Schema{Type: schema.TypeString},
-				RequiredWith: []string{helpers.PICloudConnectionVPCEnabled},
+				RequiredWith: []string{Arg_CloudConnectionVPC},
 				Description:  "Set of VPCs to attach to this cloud connection",
 			},
 
 			//Computed Attributes
-			PICloudConnectionId: {
+			Attr_CloudConnectionID: {
 				Type:        schema.TypeString,
 				Computed:    true,
 				Description: "Cloud connection ID",
 			},
-			PICloudConnectionStatus: {
+			Attr_CloudConnectionStatus: {
 				Type:        schema.TypeString,
 				Computed:    true,
 				Description: "Link status",
 			},
-			PICloudConnectionIBMIPAddress: {
+			Attr_CloudConnectionIbmIP: {
 				Type:        schema.TypeString,
 				Computed:    true,
 				Description: "IBM IP address",
 			},
-			PICloudConnectionUserIPAddress: {
+			Attr_CloudConnectionUserIP: {
 				Type:        schema.TypeString,
 				Computed:    true,
 				Description: "User IP address",
 			},
-			PICloudConnectionPort: {
+			Attr_CloudConnectionPort: {
 				Type:        schema.TypeString,
 				Computed:    true,
 				Description: "Port",
 			},
-			PICloudConnectionClassicGreSource: {
+			Attr_CloudConnectionSourceGreAddr: {
 				Type:        schema.TypeString,
 				Computed:    true,
 				Description: "GRE auto-assigned source IP address",
@@ -149,35 +148,35 @@ func resourceIBMPICloudConnectionCreate(ctx context.Context, d *schema.ResourceD
 		return diag.FromErr(err)
 	}
 
-	cloudInstanceID := d.Get(helpers.PICloudInstanceId).(string)
-	name := d.Get(helpers.PICloudConnectionName).(string)
-	speed := int64(d.Get(helpers.PICloudConnectionSpeed).(int))
+	cloudInstanceID := d.Get(Arg_CloudInstanceID).(string)
+	name := d.Get(Arg_CloudConnectionName).(string)
+	speed := int64(d.Get(Arg_CloudConnectionSpeed).(int))
 
 	body := &models.CloudConnectionCreate{
 		Name:  &name,
 		Speed: &speed,
 	}
-	if v, ok := d.GetOk(helpers.PICloudConnectionGlobalRouting); ok {
+	if v, ok := d.GetOk(Arg_CloudConnectionRouting); ok {
 		body.GlobalRouting = v.(bool)
 	}
-	if v, ok := d.GetOk(helpers.PICloudConnectionMetered); ok {
+	if v, ok := d.GetOk(Arg_CloudConnectionMetered); ok {
 		body.Metered = v.(bool)
 	}
 	// networks
-	if v, ok := d.GetOk(helpers.PICloudConnectionNetworks); ok && v.(*schema.Set).Len() > 0 {
+	if v, ok := d.GetOk(Arg_CloudConnectionNetworks); ok && v.(*schema.Set).Len() > 0 {
 		body.Subnets = flex.ExpandStringList(v.(*schema.Set).List())
 	}
 	// classic
-	if v, ok := d.GetOk(helpers.PICloudConnectionClassicEnabled); ok {
+	if v, ok := d.GetOk(Arg_CloudConnectionClassic); ok {
 		classicEnabled := v.(bool)
 		classic := &models.CloudConnectionEndpointClassicUpdate{
 			Enabled: classicEnabled,
 		}
-		if v, ok := d.GetOk(helpers.PICloudConnectionClassicGreCidr); ok {
+		if v, ok := d.GetOk(Arg_CloudConnectionGreCIDR); ok {
 			greCIDR := v.(string)
 			classic.Gre.Cidr = &greCIDR
 		}
-		if v, ok := d.GetOk(helpers.PICloudConnectionClassicGreDest); ok {
+		if v, ok := d.GetOk(Arg_CloudConnectionGreDest); ok {
 			greDest := v.(string)
 			classic.Gre.DestIPAddress = &greDest
 		}
@@ -185,12 +184,12 @@ func resourceIBMPICloudConnectionCreate(ctx context.Context, d *schema.ResourceD
 	}
 
 	// VPC
-	if v, ok := d.GetOk(helpers.PICloudConnectionVPCEnabled); ok {
+	if v, ok := d.GetOk(Arg_CloudConnectionVPC); ok {
 		vpcEnabled := v.(bool)
 		vpc := &models.CloudConnectionEndpointVPC{
 			Enabled: vpcEnabled,
 		}
-		if v, ok := d.GetOk(helpers.PICloudConnectionVPCCRNs); ok && v.(*schema.Set).Len() > 0 {
+		if v, ok := d.GetOk(Arg_CloudConnectionVPCCrns); ok && v.(*schema.Set).Len() > 0 {
 			vpcIds := flex.ExpandStringList(v.(*schema.Set).List())
 			vpcs := make([]*models.CloudConnectionVPC, len(vpcIds))
 			for i, vpcId := range vpcIds {
@@ -239,39 +238,39 @@ func resourceIBMPICloudConnectionUpdate(ctx context.Context, d *schema.ResourceD
 	}
 
 	cloudInstanceID := parts[0]
-	cloudConnectionID := parts[1]
+	Attr_CloudConnectionID := parts[1]
 
-	ccName := d.Get(helpers.PICloudConnectionName).(string)
-	ccSpeed := int64(d.Get(helpers.PICloudConnectionSpeed).(int))
+	ccName := d.Get(Arg_CloudConnectionName).(string)
+	ccSpeed := int64(d.Get(Arg_CloudConnectionSpeed).(int))
 
 	client := st.NewIBMPICloudConnectionClient(ctx, sess, cloudInstanceID)
 	jobClient := st.NewIBMPIJobClient(ctx, sess, cloudInstanceID)
 
-	if d.HasChangesExcept(helpers.PICloudConnectionNetworks) {
+	if d.HasChangesExcept(Arg_CloudConnectionNetworks) {
 
 		body := &models.CloudConnectionUpdate{
 			Name:  &ccName,
 			Speed: &ccSpeed,
 		}
-		if v, ok := d.GetOk(helpers.PICloudConnectionGlobalRouting); ok {
+		if v, ok := d.GetOk(Arg_CloudConnectionRouting); ok {
 			globalRouting := v.(bool)
 			body.GlobalRouting = &globalRouting
 		}
-		if v, ok := d.GetOk(helpers.PICloudConnectionMetered); ok {
+		if v, ok := d.GetOk(Arg_CloudConnectionMetered); ok {
 			metered := v.(bool)
 			body.Metered = &metered
 		}
 		// classic
-		if v, ok := d.GetOk(helpers.PICloudConnectionClassicEnabled); ok {
+		if v, ok := d.GetOk(Arg_CloudConnectionClassic); ok {
 			classicEnabled := v.(bool)
 			classic := &models.CloudConnectionEndpointClassicUpdate{
 				Enabled: classicEnabled,
 			}
-			if v, ok := d.GetOk(helpers.PICloudConnectionClassicGreCidr); ok {
+			if v, ok := d.GetOk(Arg_CloudConnectionGreCIDR); ok {
 				greCIDR := v.(string)
 				classic.Gre.Cidr = &greCIDR
 			}
-			if v, ok := d.GetOk(helpers.PICloudConnectionClassicGreDest); ok {
+			if v, ok := d.GetOk(Arg_CloudConnectionGreDest); ok {
 				greDest := v.(string)
 				classic.Gre.DestIPAddress = &greDest
 			}
@@ -284,12 +283,12 @@ func resourceIBMPICloudConnectionUpdate(ctx context.Context, d *schema.ResourceD
 			body.Classic = classic
 		}
 		// vpc
-		if v, ok := d.GetOk(helpers.PICloudConnectionVPCEnabled); ok {
+		if v, ok := d.GetOk(Arg_CloudConnectionVPC); ok {
 			vpcEnabled := v.(bool)
 			vpc := &models.CloudConnectionEndpointVPC{
 				Enabled: vpcEnabled,
 			}
-			if v, ok := d.GetOk(helpers.PICloudConnectionVPCCRNs); ok && v.(*schema.Set).Len() > 0 {
+			if v, ok := d.GetOk(Arg_CloudConnectionVPCCrns); ok && v.(*schema.Set).Len() > 0 {
 				vpcIds := flex.ExpandStringList(v.(*schema.Set).List())
 				vpcs := make([]*models.CloudConnectionVPC, len(vpcIds))
 				for i, vpcId := range vpcIds {
@@ -308,7 +307,7 @@ func resourceIBMPICloudConnectionUpdate(ctx context.Context, d *schema.ResourceD
 			body.Vpc = vpc
 		}
 
-		_, cloudConnectionJob, err := client.Update(cloudConnectionID, body)
+		_, cloudConnectionJob, err := client.Update(Attr_CloudConnectionID, body)
 		if err != nil {
 			return diag.FromErr(err)
 		}
@@ -319,8 +318,8 @@ func resourceIBMPICloudConnectionUpdate(ctx context.Context, d *schema.ResourceD
 			}
 		}
 	}
-	if d.HasChange(helpers.PICloudConnectionNetworks) {
-		oldRaw, newRaw := d.GetChange(helpers.PICloudConnectionNetworks)
+	if d.HasChange(Arg_CloudConnectionNetworks) {
+		oldRaw, newRaw := d.GetChange(Arg_CloudConnectionNetworks)
 		old := oldRaw.(*schema.Set)
 		new := newRaw.(*schema.Set)
 
@@ -329,7 +328,7 @@ func resourceIBMPICloudConnectionUpdate(ctx context.Context, d *schema.ResourceD
 
 		// call network add api for each toAdd
 		for _, n := range flex.ExpandStringList(toAdd.List()) {
-			_, jobReference, err := client.AddNetwork(cloudConnectionID, n)
+			_, jobReference, err := client.AddNetwork(Attr_CloudConnectionID, n)
 			if err != nil {
 				return diag.FromErr(err)
 			}
@@ -343,7 +342,7 @@ func resourceIBMPICloudConnectionUpdate(ctx context.Context, d *schema.ResourceD
 
 		// call network delete api for each toRemove
 		for _, n := range flex.ExpandStringList(toRemove.List()) {
-			_, jobReference, err := client.DeleteNetwork(cloudConnectionID, n)
+			_, jobReference, err := client.DeleteNetwork(Attr_CloudConnectionID, n)
 			if err != nil {
 				return diag.FromErr(err)
 			}
@@ -371,10 +370,10 @@ func resourceIBMPICloudConnectionRead(ctx context.Context, d *schema.ResourceDat
 	}
 
 	cloudInstanceID := parts[0]
-	cloudConnectionID := parts[1]
+	Attr_CloudConnectionID := parts[1]
 
 	client := st.NewIBMPICloudConnectionClient(ctx, sess, cloudInstanceID)
-	cloudConnection, err := client.Get(cloudConnectionID)
+	cloudConnection, err := client.Get(Attr_CloudConnectionID)
 	if err != nil {
 		uErr := errors.Unwrap(err)
 		switch uErr.(type) {
@@ -387,16 +386,16 @@ func resourceIBMPICloudConnectionRead(ctx context.Context, d *schema.ResourceDat
 		return diag.FromErr(err)
 	}
 
-	d.Set(PICloudConnectionId, cloudConnection.CloudConnectionID)
-	d.Set(helpers.PICloudConnectionName, cloudConnection.Name)
-	d.Set(helpers.PICloudConnectionGlobalRouting, cloudConnection.GlobalRouting)
-	d.Set(helpers.PICloudConnectionMetered, cloudConnection.Metered)
-	d.Set(PICloudConnectionIBMIPAddress, cloudConnection.IbmIPAddress)
-	d.Set(PICloudConnectionUserIPAddress, cloudConnection.UserIPAddress)
-	d.Set(PICloudConnectionStatus, cloudConnection.LinkStatus)
-	d.Set(PICloudConnectionPort, cloudConnection.Port)
-	d.Set(helpers.PICloudConnectionSpeed, cloudConnection.Speed)
-	d.Set(helpers.PICloudInstanceId, cloudInstanceID)
+	d.Set(Attr_CloudConnectionID, cloudConnection.CloudConnectionID)
+	d.Set(Arg_CloudConnectionName, cloudConnection.Name)
+	d.Set(Arg_CloudConnectionRouting, cloudConnection.GlobalRouting)
+	d.Set(Arg_CloudConnectionMetered, cloudConnection.Metered)
+	d.Set(Attr_CloudConnectionIbmIP, cloudConnection.IbmIPAddress)
+	d.Set(Attr_CloudConnectionUserIP, cloudConnection.UserIPAddress)
+	d.Set(Attr_CloudConnectionStatus, cloudConnection.LinkStatus)
+	d.Set(Attr_CloudConnectionPort, cloudConnection.Port)
+	d.Set(Arg_CloudConnectionSpeed, cloudConnection.Speed)
+	d.Set(Arg_CloudInstanceID, cloudInstanceID)
 	if cloudConnection.Networks != nil {
 		networks := make([]string, 0)
 		for _, ccNetwork := range cloudConnection.Networks {
@@ -404,23 +403,23 @@ func resourceIBMPICloudConnectionRead(ctx context.Context, d *schema.ResourceDat
 				networks = append(networks, *ccNetwork.NetworkID)
 			}
 		}
-		d.Set(helpers.PICloudConnectionNetworks, networks)
+		d.Set(Arg_CloudConnectionNetworks, networks)
 	}
 	if cloudConnection.Classic != nil {
-		d.Set(helpers.PICloudConnectionClassicEnabled, cloudConnection.Classic.Enabled)
+		d.Set(Arg_CloudConnectionClassic, cloudConnection.Classic.Enabled)
 		if cloudConnection.Classic.Gre != nil {
-			d.Set(helpers.PICloudConnectionClassicGreDest, cloudConnection.Classic.Gre.DestIPAddress)
-			d.Set(PICloudConnectionClassicGreSource, cloudConnection.Classic.Gre.SourceIPAddress)
+			d.Set(Arg_CloudConnectionGreDest, cloudConnection.Classic.Gre.DestIPAddress)
+			d.Set(Attr_CloudConnectionSourceGreAddr, cloudConnection.Classic.Gre.SourceIPAddress)
 		}
 	}
 	if cloudConnection.Vpc != nil {
-		d.Set(helpers.PICloudConnectionVPCEnabled, cloudConnection.Vpc.Enabled)
+		d.Set(Arg_CloudConnectionVPC, cloudConnection.Vpc.Enabled)
 		if cloudConnection.Vpc.Vpcs != nil && len(cloudConnection.Vpc.Vpcs) > 0 {
 			vpcCRNs := make([]string, len(cloudConnection.Vpc.Vpcs))
 			for i, vpc := range cloudConnection.Vpc.Vpcs {
 				vpcCRNs[i] = *vpc.VpcID
 			}
-			d.Set(helpers.PICloudConnectionVPCCRNs, vpcCRNs)
+			d.Set(Arg_CloudConnectionVPCCrns, vpcCRNs)
 		}
 	}
 
@@ -438,10 +437,10 @@ func resourceIBMPICloudConnectionDelete(ctx context.Context, d *schema.ResourceD
 	}
 
 	cloudInstanceID := parts[0]
-	cloudConnectionID := parts[1]
+	Attr_CloudConnectionID := parts[1]
 
 	client := st.NewIBMPICloudConnectionClient(ctx, sess, cloudInstanceID)
-	_, err = client.Get(cloudConnectionID)
+	_, err = client.Get(Attr_CloudConnectionID)
 	if err != nil {
 		uErr := errors.Unwrap(err)
 		switch uErr.(type) {
@@ -453,9 +452,9 @@ func resourceIBMPICloudConnectionDelete(ctx context.Context, d *schema.ResourceD
 		log.Printf("[DEBUG] get cloud connection failed %v", err)
 		return diag.FromErr(err)
 	}
-	log.Printf("[INFO] Found cloud connection with id %s", cloudConnectionID)
+	log.Printf("[INFO] Found cloud connection with id %s", Attr_CloudConnectionID)
 
-	deleteJob, err := client.Delete(cloudConnectionID)
+	deleteJob, err := client.Delete(Attr_CloudConnectionID)
 	if err != nil {
 		log.Printf("[DEBUG] delete cloud connection failed %v", err)
 		return diag.FromErr(err)

--- a/ibm/service/power/resource_ibm_pi_cloud_connection_network_attach.go
+++ b/ibm/service/power/resource_ibm_pi_cloud_connection_network_attach.go
@@ -13,13 +13,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 
 	st "github.com/IBM-Cloud/power-go-client/clients/instance"
-	"github.com/IBM-Cloud/power-go-client/helpers"
 	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/conns"
 	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/flex"
-)
-
-const (
-	PICloudConnectionNetworkId = "pi_network_id"
 )
 
 func ResourceIBMPICloudConnectionNetworkAttach() *schema.Resource {
@@ -36,19 +31,19 @@ func ResourceIBMPICloudConnectionNetworkAttach() *schema.Resource {
 
 		Schema: map[string]*schema.Schema{
 			// Required Attributes
-			helpers.PICloudInstanceId: {
+			Arg_CloudInstanceID: {
 				Type:        schema.TypeString,
 				Required:    true,
 				ForceNew:    true,
 				Description: "PI cloud instance ID",
 			},
-			helpers.PICloudConnectionId: {
+			Arg_CloudConnectionID: {
 				Type:        schema.TypeString,
 				Required:    true,
 				ForceNew:    true,
 				Description: "Cloud Connection ID",
 			},
-			PICloudConnectionNetworkId: {
+			Arg_CloudConnectionNetworkID: {
 				Type:        schema.TypeString,
 				Required:    true,
 				ForceNew:    true,
@@ -64,9 +59,9 @@ func resourceIBMPICloudConnectionNetworkAttachCreate(ctx context.Context, d *sch
 		return diag.FromErr(err)
 	}
 
-	cloudInstanceID := d.Get(helpers.PICloudInstanceId).(string)
-	cloudConnectionID := d.Get(helpers.PICloudConnectionId).(string)
-	networkID := d.Get(PICloudConnectionNetworkId).(string)
+	cloudInstanceID := d.Get(Arg_CloudInstanceID).(string)
+	cloudConnectionID := d.Get(Arg_CloudConnectionID).(string)
+	networkID := d.Get(Arg_CloudConnectionNetworkID).(string)
 
 	client := st.NewIBMPICloudConnectionClient(ctx, sess, cloudInstanceID)
 	jobClient := st.NewIBMPIJobClient(ctx, sess, cloudInstanceID)
@@ -97,9 +92,9 @@ func resourceIBMPICloudConnectionNetworkAttachRead(ctx context.Context, d *schem
 	cloudConnectionID := parts[1]
 	networkID := parts[2]
 
-	d.Set(helpers.PICloudInstanceId, cloudInstanceID)
-	d.Set(helpers.PICloudConnectionId, cloudConnectionID)
-	d.Set(PICloudConnectionNetworkId, networkID)
+	d.Set(Arg_CloudInstanceID, cloudInstanceID)
+	d.Set(Arg_CloudConnectionID, cloudConnectionID)
+	d.Set(Arg_CloudConnectionNetworkID, networkID)
 
 	return nil
 }

--- a/ibm/service/power/resource_ibm_pi_cloud_connection_network_attach_test.go
+++ b/ibm/service/power/resource_ibm_pi_cloud_connection_network_attach_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	acc "github.com/IBM-Cloud/terraform-provider-ibm/ibm/acctest"
+	vars "github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/power"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
@@ -24,7 +25,7 @@ func TestAccIBMPICloudConnectionNetworkAttachBasic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckIBMPICloudConnectionExists("ibm_pi_cloud_connection.cloud_connection"),
 					resource.TestCheckResourceAttr("ibm_pi_cloud_connection.cloud_connection",
-						"pi_cloud_connection_name", name),
+						vars.Arg_CloudConnectionName, name),
 					resource.TestCheckResourceAttr("data.ibm_pi_cloud_connection.cloud_connection",
 						"networks.#", "1"),
 				),

--- a/ibm/service/power/resource_ibm_pi_cloud_connection_test.go
+++ b/ibm/service/power/resource_ibm_pi_cloud_connection_test.go
@@ -12,6 +12,7 @@ import (
 	acc "github.com/IBM-Cloud/terraform-provider-ibm/ibm/acctest"
 	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/conns"
 	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/flex"
+	vars "github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/power"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
@@ -32,9 +33,9 @@ func TestAccIBMPICloudConnectionbasic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckIBMPICloudConnectionExists("ibm_pi_cloud_connection.cloud_connection"),
 					resource.TestCheckResourceAttr("ibm_pi_cloud_connection.cloud_connection",
-						"pi_cloud_connection_name", name),
+						vars.Arg_CloudConnectionName, name),
 					resource.TestCheckResourceAttr("ibm_pi_cloud_connection.cloud_connection",
-						"pi_cloud_connection_speed", "100"),
+						vars.Arg_CloudConnectionSpeed, "100"),
 					resource.TestCheckResourceAttr("ibm_pi_cloud_connection.cloud_connection",
 						"pi_cloud_connection_networks.#", "1"),
 				),
@@ -129,7 +130,7 @@ func TestAccIBMPICloudConnectionNetworks(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckIBMPICloudConnectionExists("ibm_pi_cloud_connection.cc_network"),
 					resource.TestCheckResourceAttr("ibm_pi_cloud_connection.cc_network",
-						"pi_cloud_connection_name", name),
+						vars.Arg_CloudConnectionName, name),
 					resource.TestCheckResourceAttr("ibm_pi_cloud_connection.cc_network",
 						"pi_cloud_connection_networks.#", "1"),
 				),
@@ -139,7 +140,7 @@ func TestAccIBMPICloudConnectionNetworks(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckIBMPICloudConnectionExists("ibm_pi_cloud_connection.cc_network"),
 					resource.TestCheckResourceAttr("ibm_pi_cloud_connection.cc_network",
-						"pi_cloud_connection_name", name),
+						vars.Arg_CloudConnectionName, name),
 					resource.TestCheckResourceAttr("ibm_pi_cloud_connection.cc_network",
 						"pi_cloud_connection_networks.#", "1"),
 				),
@@ -206,13 +207,13 @@ func TestAccIBMPICloudConnectionClassic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckIBMPICloudConnectionExists("ibm_pi_cloud_connection.classic"),
 					resource.TestCheckResourceAttr("ibm_pi_cloud_connection.classic",
-						"pi_cloud_connection_name", name),
+						vars.Arg_CloudConnectionName, name),
 					resource.TestCheckResourceAttr("ibm_pi_cloud_connection.classic",
 						"pi_cloud_connection_networks.#", "0"),
 					resource.TestCheckResourceAttr("ibm_pi_cloud_connection.classic",
-						"pi_cloud_connection_classic_enabled", "true"),
+						vars.Arg_CloudConnectionClassic, "true"),
 					resource.TestCheckResourceAttr("ibm_pi_cloud_connection.classic",
-						"pi_cloud_connection_vpc_enabled", "false"),
+						vars.Arg_CloudConnectionVPC, "false"),
 				),
 			},
 		},
@@ -241,13 +242,13 @@ func TestAccIBMPICloudConnectionVPC(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckIBMPICloudConnectionExists("ibm_pi_cloud_connection.vpc"),
 					resource.TestCheckResourceAttr("ibm_pi_cloud_connection.vpc",
-						"pi_cloud_connection_name", name),
+						vars.Arg_CloudConnectionName, name),
 					resource.TestCheckResourceAttr("ibm_pi_cloud_connection.vpc",
 						"pi_cloud_connection_networks.#", "0"),
 					resource.TestCheckResourceAttr("ibm_pi_cloud_connection.vpc",
-						"pi_cloud_connection_classic_enabled", "false"),
+						vars.Arg_CloudConnectionClassic, "false"),
 					resource.TestCheckResourceAttr("ibm_pi_cloud_connection.vpc",
-						"pi_cloud_connection_vpc_enabled", "true"),
+						vars.Arg_CloudConnectionVPC, "true"),
 					resource.TestCheckResourceAttr("ibm_pi_cloud_connection.vpc",
 						"pi_cloud_connection_vpc_crns.#", "1"),
 				),


### PR DESCRIPTION
Removed power-go-client constants from cloud connection files.
Defined arguments and attributes in ibm_pi_constants.go.

