### PR TITLE
update to ensure v1 behaviour for atracker

### DIFF
--- a/ibm/service/atracker/atracker_utils.go
+++ b/ibm/service/atracker/atracker_utils.go
@@ -7,7 +7,8 @@ import (
 )
 
 const (
-	REDACTED_TEXT = "REDACTED"
+	REDACTED_TEXT       = "REDACTED"
+	BLOCKED_V1_RESOURCE = "v2_resource_exists_v1_api_is_not_accessible"
 )
 
 func getAtrackerClients(meta interface{}) (

--- a/ibm/service/atracker/data_source_ibm_atracker_targets.go
+++ b/ibm/service/atracker/data_source_ibm_atracker_targets.go
@@ -7,11 +7,13 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"strings"
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 
+	"github.com/IBM/platform-services-go-sdk/atrackerv1"
 	"github.com/IBM/platform-services-go-sdk/atrackerv2"
 )
 
@@ -207,61 +209,102 @@ func DataSourceIBMAtrackerTargets() *schema.Resource {
 }
 
 func DataSourceIBMAtrackerTargetsRead(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	_, atrackerClient, err := getAtrackerClients(meta)
+	atrackerClientv1, atrackerClientv2, err := getAtrackerClients(meta)
 	if err != nil {
 		return diag.FromErr(err)
 	}
+	// TODO: Remove after deprecation
+	listTargetsOptions := &atrackerv1.ListTargetsOptions{}
+	targetListV1, responseV1, err := atrackerClientv1.ListTargetsWithContext(context, listTargetsOptions)
+	if err == nil {
+		// Use the provided filter argument and construct a new list with only the requested resource(s)
+		var matchTargets []atrackerv1.Target
+		var name string
+		var suppliedFilter bool
 
-	listTargetsOptions := &atrackerv2.ListTargetsOptions{}
-
-	targetList, response, err := atrackerClient.ListTargetsWithContext(context, listTargetsOptions)
-	if err != nil {
-		log.Printf("[DEBUG] ListTargetsWithContext failed %s\n%s", err, response)
-		return diag.FromErr(fmt.Errorf("ListTargetsWithContext failed %s\n%s", err, response))
-	}
-
-	// Use the provided filter argument and construct a new list with only the requested resource(s)
-	var matchTargets []atrackerv2.Target
-	var name string
-	var suppliedFilter bool
-
-	if v, ok := d.GetOk("name"); ok {
-		name = v.(string)
-		suppliedFilter = true
-		for _, data := range targetList.Targets {
-			if *data.Name == name {
-				matchTargets = append(matchTargets, data)
+		if v, ok := d.GetOk("name"); ok {
+			name = v.(string)
+			suppliedFilter = true
+			for _, data := range targetListV1.Targets {
+				if *data.Name == name {
+					matchTargets = append(matchTargets, data)
+				}
 			}
+		} else {
+			matchTargets = targetListV1.Targets
 		}
-	} else {
-		matchTargets = targetList.Targets
-	}
-	targetList.Targets = matchTargets
+		targetListV1.Targets = matchTargets
 
-	if suppliedFilter {
-		if len(targetList.Targets) == 0 {
-			return diag.FromErr(fmt.Errorf("no Targets found with name %s", name))
+		if suppliedFilter {
+			if len(targetListV1.Targets) == 0 {
+				return diag.FromErr(fmt.Errorf("no Targets found with name %s", name))
+			}
+			d.SetId(name)
+		} else {
+			d.SetId(DataSourceIBMAtrackerTargetsID(d))
 		}
-		d.SetId(name)
-	} else {
-		d.SetId(DataSourceIBMAtrackerTargetsID(d))
-	}
 
-	targets := []map[string]interface{}{}
-	if targetList.Targets != nil {
-		for _, modelItem := range targetList.Targets {
-			modelMap, err := DataSourceIBMAtrackerTargetsTargetToMap(&modelItem)
+		if targetListV1.Targets != nil {
+			err = d.Set("targets", dataSourceTargetListFlattenTargetsV1(targetListV1.Targets))
 			if err != nil {
-				return diag.FromErr(err)
+				return diag.FromErr(fmt.Errorf("[ERROR] Error setting targets %s", err))
 			}
-			targets = append(targets, modelMap)
 		}
-	}
-	if err = d.Set("targets", targets); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting targets %s", err))
+		return nil
+	} else if err != nil && responseV1 != nil && strings.Contains(responseV1.String(), BLOCKED_V1_RESOURCE) {
+		listTargetsOptions := &atrackerv2.ListTargetsOptions{}
+
+		targetList, response, err := atrackerClientv2.ListTargetsWithContext(context, listTargetsOptions)
+		if err != nil {
+			log.Printf("[DEBUG] ListTargetsWithContext failed %s\n%s", err, response)
+			return diag.FromErr(fmt.Errorf("ListTargetsWithContext failed %s\n%s", err, response))
+		}
+
+		// Use the provided filter argument and construct a new list with only the requested resource(s)
+		var matchTargets []atrackerv2.Target
+		var name string
+		var suppliedFilter bool
+
+		if v, ok := d.GetOk("name"); ok {
+			name = v.(string)
+			suppliedFilter = true
+			for _, data := range targetList.Targets {
+				if *data.Name == name {
+					matchTargets = append(matchTargets, data)
+				}
+			}
+		} else {
+			matchTargets = targetList.Targets
+		}
+		targetList.Targets = matchTargets
+
+		if suppliedFilter {
+			if len(targetList.Targets) == 0 {
+				return diag.FromErr(fmt.Errorf("no Targets found with name %s", name))
+			}
+			d.SetId(name)
+		} else {
+			d.SetId(DataSourceIBMAtrackerTargetsID(d))
+		}
+
+		targets := []map[string]interface{}{}
+		if targetList.Targets != nil {
+			for _, modelItem := range targetList.Targets {
+				modelMap, err := DataSourceIBMAtrackerTargetsTargetToMap(&modelItem)
+				if err != nil {
+					return diag.FromErr(err)
+				}
+				targets = append(targets, modelMap)
+			}
+		}
+		if err = d.Set("targets", targets); err != nil {
+			return diag.FromErr(fmt.Errorf("Error setting targets %s", err))
+		}
+		return nil
 	}
 
-	return nil
+	log.Printf("[DEBUG] ListTargetsWithContext failed %s\n%s", err, responseV1)
+	return diag.FromErr(fmt.Errorf("ListTargetsWithContext failed %s\n%s", err, responseV1))
 }
 
 // DataSourceIBMAtrackerTargetsID returns a reasonable ID for the list.
@@ -332,7 +375,9 @@ func DataSourceIBMAtrackerTargetsCosEndpointToMap(model *atrackerv2.CosEndpoint)
 	if model.Bucket != nil {
 		modelMap["bucket"] = *model.Bucket
 	}
-	modelMap["service_to_service_enabled"] = *model.ServiceToServiceEnabled
+	if model.ServiceToServiceEnabled != nil {
+		modelMap["service_to_service_enabled"] = *model.ServiceToServiceEnabled
+	}
 	return modelMap, nil
 }
 
@@ -356,4 +401,87 @@ func DataSourceIBMAtrackerTargetsWriteStatusToMap(model *atrackerv2.WriteStatus)
 		modelMap["reason_for_last_failure"] = *model.ReasonForLastFailure
 	}
 	return modelMap, nil
+}
+
+func dataSourceTargetListFlattenTargetsV1(result []atrackerv1.Target) (targets []map[string]interface{}) {
+	for _, targetsItem := range result {
+		targets = append(targets, dataSourceTargetListTargetsToMapV1(targetsItem))
+	}
+
+	return targets
+}
+
+func dataSourceTargetListTargetsToMapV1(targetsItem atrackerv1.Target) (targetsMap map[string]interface{}) {
+	targetsMap = map[string]interface{}{}
+
+	if targetsItem.ID != nil {
+		targetsMap["id"] = targetsItem.ID
+	}
+	if targetsItem.Name != nil {
+		targetsMap["name"] = targetsItem.Name
+	}
+	if targetsItem.CRN != nil {
+		targetsMap["crn"] = targetsItem.CRN
+	}
+	if targetsItem.TargetType != nil {
+		targetsMap["target_type"] = targetsItem.TargetType
+	}
+	if targetsItem.EncryptKey != nil {
+		targetsMap["encrypt_key"] = targetsItem.EncryptKey
+	}
+	if targetsItem.CosEndpoint != nil {
+		cosEndpointList := []map[string]interface{}{}
+		cosEndpointMap := dataSourceTargetListTargetsCosEndpointToMapV1(*targetsItem.CosEndpoint)
+		cosEndpointList = append(cosEndpointList, cosEndpointMap)
+		targetsMap["cos_endpoint"] = cosEndpointList
+	}
+	if targetsItem.CosWriteStatus != nil {
+		cosWriteStatusList := []map[string]interface{}{}
+		cosWriteStatusMap := dataSourceTargetListTargetsCosWriteStatusToMapV1(*targetsItem.CosWriteStatus)
+		cosWriteStatusList = append(cosWriteStatusList, cosWriteStatusMap)
+		targetsMap["cos_write_status"] = cosWriteStatusList
+	}
+	if targetsItem.Created != nil {
+		targetsMap["created"] = targetsItem.Created.String()
+	}
+	if targetsItem.Updated != nil {
+		targetsMap["updated"] = targetsItem.Updated.String()
+	}
+
+	return targetsMap
+}
+
+func dataSourceTargetListTargetsCosEndpointToMapV1(cosEndpointItem atrackerv1.CosEndpoint) (cosEndpointMap map[string]interface{}) {
+	cosEndpointMap = map[string]interface{}{}
+
+	if cosEndpointItem.Endpoint != nil {
+		cosEndpointMap["endpoint"] = cosEndpointItem.Endpoint
+	}
+	if cosEndpointItem.TargetCRN != nil {
+		cosEndpointMap["target_crn"] = cosEndpointItem.TargetCRN
+	}
+	if cosEndpointItem.Bucket != nil {
+		cosEndpointMap["bucket"] = cosEndpointItem.Bucket
+	}
+	if cosEndpointItem.APIKey != nil {
+		cosEndpointMap["api_key"] = cosEndpointItem.APIKey
+	}
+
+	return cosEndpointMap
+}
+
+func dataSourceTargetListTargetsCosWriteStatusToMapV1(cosWriteStatusItem atrackerv1.CosWriteStatus) (cosWriteStatusMap map[string]interface{}) {
+	cosWriteStatusMap = map[string]interface{}{}
+
+	if cosWriteStatusItem.Status != nil {
+		cosWriteStatusMap["status"] = cosWriteStatusItem.Status
+	}
+	if cosWriteStatusItem.LastFailure != nil {
+		cosWriteStatusMap["last_failure"] = cosWriteStatusItem.LastFailure.String()
+	}
+	if cosWriteStatusItem.ReasonForLastFailure != nil {
+		cosWriteStatusMap["reason_for_last_failure"] = cosWriteStatusItem.ReasonForLastFailure
+	}
+
+	return cosWriteStatusMap
 }


### PR DESCRIPTION
### What has been done?
Fixes some of the datasources not returning the correct results between the two api versions.  Now explicitly calls the api for targets (since the version 2 version returns all targets across regions where as version 1 only returns current region).  Routes fixed to ensure that it doesn't crash on version 1.

<!--- See what makes a good Pull Request at : https://github.com/IBM-Cloud/terraform-provider-ibm/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
Vans-MacBook-Pro:terraform-provider-ibm vbui$ make fmt && make testacc TEST=./ibm/service/atracker TESTARGS='-run=TestAccIBMAtracker.*'
gofmt -w $(find .  -path ./.direnv -prune -false -o -name '*.go' |grep -v vendor)
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./ibm/service/atracker -v -run=TestAccIBMAtracker.* -timeout 700m
[WARN] Set the environment variable IBM_APPID_TENANT_ID for testing AppID resources, AppID tests will fail if this is not set
[WARN] Set the environment variable IBM_APPID_TEST_USER_EMAIL for testing AppID user resources, the tests will fail if this is not set
[WARN] Set the environment variable IBM_ORG for testing ibm_org  resource Some tests for that resource will fail if this is not set correctly
[WARN] Set the environment variable IBM_SPACE for testing ibm_space  resource Some tests for that resource will fail if this is not set correctly
[WARN] Set the environment variable IBM_ID1 for testing ibm_space resource Some tests for that resource will fail if this is not set correctly
[WARN] Set the environment variable IBM_ID2 for testing ibm_space resource Some tests for that resource will fail if this is not set correctly
[WARN] Set the environment variable IBM_IAMUSER for testing ibm_iam_user_policy resource Some tests for that resource will fail if this is not set correctly
[WARN] Set the environment variable IBM_DATACENTER for testing ibm_container_cluster resource else it is set to default value 'par01'
[WARN] Set the environment variable IBM_MACHINE_TYPE for testing ibm_container_cluster resource else it is set to default value 'b3c.4x16'
[WARN] Set the environment variable IBM_CERT_CRN for testing ibm_container_alb_cert resource else it is set to default value
[WARN] Set the environment variable IBM_UPDATE_CERT_CRN for testing ibm_container_alb_cert resource else it is set to default value
[WARN] Set the environment variable IBM_CONTAINER_REGION for testing ibm_container resources else it is set to default value 'eu-de'
[WARN] Set the environment variable IBM_CIS_INSTANCE with a VALID CIS Instance NAME for testing ibm_cis resources on staging/test
[WARN] Set the environment variable IBM_CIS_DOMAIN_STATIC with the Domain name registered with the CIS instance on test/staging. Domain must be predefined in CIS to avoid CIS billing costs due to domain delete/create
[WARN] Set the environment variable IBM_CIS_DOMAIN_TEST with a VALID Domain name for testing the one time create and delete of a domain in CIS. Note each create/delete will trigger a monthly billing instance. Only to be run in staging/test
[WARN] Set the environment variable IBM_CIS_RESOURCE_GROUP with the resource group for the CIS Instance 
[WARN] Set the environment variable IBM_COS_CRN with a VALID COS instance CRN for testing ibm_cos_* resources
[WARN] Set the environment variable IBM_TRUSTED_MACHINE_TYPE for testing ibm_container_cluster resource else it is set to default value 'mb1c.16x64'
[WARN] Set the environment variable IBM_BM_EXTENDED_HW_TESTING to true/false for testing ibm_compute_bare_metal resource else it is set to default value 'false'
[WARN] Set the environment variable IBM_PUBLIC_VLAN_ID for testing ibm_container_cluster resource else it is set to default value '2393319'
[WARN] Set the environment variable IBM_PRIVATE_VLAN_ID for testing ibm_container_cluster resource else it is set to default value '2393321'
[WARN] Set the environment variable IBM_KUBE_VERSION for testing ibm_container_cluster resource else it is set to default value '1.18.14'
[WARN] Set the environment variable IBM_KUBE_UPDATE_VERSION for testing ibm_container_cluster resource else it is set to default value '1.19.6'
[WARN] Set the environment variable IBM_PRIVATE_SUBNET_ID for testing ibm_container_cluster resource else it is set to default value '1636107'
[WARN] Set the environment variable IBM_PUBLIC_SUBNET_ID for testing ibm_container_cluster resource else it is set to default value '1165645'
[WARN] Set the environment variable IBM_SUBNET_ID for testing ibm_container_cluster resource else it is set to default value '1165645'
[INFO] Set the environment variable IBM_IPSEC_DATACENTER for testing ibm_ipsec_vpn resource else it is set to default value 'tok02'
[INFO] Set the environment variable IBM_IPSEC_CUSTOMER_SUBNET_ID for testing ibm_ipsec_vpn resource else it is set to default value '123456'
[INFO] Set the environment variable IBM_IPSEC_CUSTOMER_PEER_IP for testing ibm_ipsec_vpn resource else it is set to default value '192.168.0.1'
[WARN] Set the environment variable IBM_LBAAS_DATACENTER for testing ibm_lbaas resource else it is set to default value 'dal13'
[WARN] Set the environment variable IBM_LBAAS_SUBNETID for testing ibm_lbaas resource else it is set to default value '2144241'
[WARN] Set the environment variable IBM_LB_LISTENER_CERTIFICATE_INSTANCE for testing ibm_is_lb_listener resource for https redirect else it is set to default value 'crn:v1:staging:public:cloudcerts:us-south:a/2d1bace7b46e4815a81e52c6ffeba5cf:af925157-b125-4db2-b642-adacb8b9c7f5:certificate:c81627a1bf6f766379cc4b98fd2a44ed'
[WARN] Set the environment variable IBM_DEDICATED_HOSTNAME for testing ibm_compute_vm_instance resource else it is set to default value 'terraform-dedicatedhost'
[WARN] Set the environment variable IBM_DEDICATED_HOST_ID for testing ibm_compute_vm_instance resource else it is set to default value '30301'
[WARN] Set the environment variable IBM_WORKER_POOL_ZONE for testing ibm_container_worker_pool_zone_attachment resource else it is set to default value 'ams03'
[WARN] Set the environment variable IBM_WORKER_POOL_ZONE_PRIVATE_VLAN for testing ibm_container_worker_pool_zone_attachment resource else it is set to default value '2538975'
[WARN] Set the environment variable IBM_WORKER_POOL_ZONE_PUBLIC_VLAN for testing ibm_container_worker_pool_zone_attachment resource else it is set to default value '2538967'
[WARN] Set the environment variable IBM_WORKER_POOL_ZONE_UPDATE_PRIVATE_VLAN for testing ibm_container_worker_pool_zone_attachment resource else it is set to default value '2388377'
[WARN] Set the environment variable IBM_WORKER_POOL_ZONE_UPDATE_PUBLIC_VLAN for testing ibm_container_worker_pool_zone_attachment resource else it is set to default value '2388375'
[WARN] Set the environment variable IBM_PLACEMENT_GROUP_NAME for testing ibm_compute_vm_instance resource else it is set to default value 'terraform-group'
[INFO] Set the environment variable SL_REGION for testing ibm_is_region datasource else it is set to default value 'us-south'
[INFO] Set the environment variable SL_ZONE for testing ibm_is_zone datasource else it is set to default value 'us-south-1'
[INFO] Set the environment variable SL_CIDR for testing ibm_is_subnet else it is set to default value '10.240.0.0/24'
[INFO] Set the environment variable SL_ADDRESS_PREFIX_CIDR for testing ibm_is_vpc_address_prefix else it is set to default value '10.120.0.0/24'
[INFO] Set the environment variable IS_IMAGE for testing ibm_is_instance, ibm_is_floating_ip else it is set to default value 'r006-ed3f775f-ad7e-4e37-ae62-7199b4988b00'
[INFO] Set the environment variable IS_WIN_IMAGE for testing ibm_is_instance data source else it is set to default value 'r006-5f9568ae-792e-47e1-a710-5538b2bdfca7'
[INFO] Set the environment variable IS_INSTANCE_NAME for testing ibm_is_instance resource else it is set to default value 'instance-01'
[INFO] Set the environment variable SL_INSTANCE_PROFILE for testing ibm_is_instance resource else it is set to default value 'cx2-2x4'
[INFO] Set the environment variable SL_INSTANCE_PROFILE_UPDATE for testing ibm_is_instance resource else it is set to default value 'cx2-4x8'
[INFO] Set the environment variable IS_BARE_METAL_SERVER_PROFILE for testing ibm_is_bare_metal_server resource else it is set to default value 'bx2-metal-192x768'
[INFO] Set the environment variable IsBareMetalServerImage for testing ibm_is_bare_metal_server resource else it is set to default value 'r006-2d1f36b0-df65-4570-82eb-df7ae5f778b1'
[INFO] Set the environment variable IS_DEDICATED_HOST_NAME for testing ibm_is_instance resource else it is set to default value 'tf-dhost-01'
[INFO] Set the environment variable IS_DEDICATED_HOST_GROUP_ID for testing ibm_is_instance resource else it is set to default value '0717-9104e7b5-77ad-44ad-9eaa-091e6b6efce1'
[INFO] Set the environment variable IS_DEDICATED_HOST_PROFILE for testing ibm_is_instance resource else it is set to default value 'bx2d-host-152x608'
[INFO] Set the environment variable IS_DEDICATED_HOST_GROUP_CLASS for testing ibm_is_instance resource else it is set to default value 'bx2d'
[INFO] Set the environment variable IS_DEDICATED_HOST_GROUP_FAMILY for testing ibm_is_instance resource else it is set to default value 'balanced'
[INFO] Set the environment variable SL_INSTANCE_PROFILE for testing ibm_is_instance resource else it is set to default value 'bx2d-16x64'
[INFO] Set the environment variable IS_VOLUME_PROFILE for testing ibm_is_volume_profile else it is set to default value 'general-purpose'
[INFO] Set the environment variable SL_ROUTE_DESTINATION for testing ibm_is_vpc_route else it is set to default value '192.168.4.0/24'
[INFO] Set the environment variable SL_ROUTE_NEXTHOP for testing ibm_is_vpc_route else it is set to default value '10.0.0.4'
[INFO] Set the environment variable ICD_DB_REGION for testing ibm_cloud_databases else it is set to default value 'eu-gb'
[INFO] Set the environment variable PI_IMAGE for testing ibm_pi_image resource else it is set to default value '7200-03-03'
[INFO] Set the environment variable PI_SAP_IMAGE for testing ibm_pi_image resource else it is set to default value 'Linux-RHEL-SAP-8-2'
[INFO] Set the environment variable PI_IMAGE_BUCKET_NAME for testing ibm_pi_image resource else it is set to default value 'images-public-bucket'
[INFO] Set the environment variable PI_IMAGE_BUCKET_FILE_NAME for testing ibm_pi_image resource else it is set to default value 'rhel.ova.gz'
[INFO] Set the environment variable PI_IMAGE_BUCKET_ACCESS_KEY for testing ibm_pi_image_export resource else it is set to default value 'images-bucket-access-key'
[INFO] Set the environment variable PI_IMAGE_BUCKET_SECRET_KEY for testing ibm_pi_image_export resource else it is set to default value 'PI_IMAGE_BUCKET_SECRET_KEY'
[INFO] Set the environment variable PI_IMAGE_BUCKET_REGION for testing ibm_pi_image_export resource else it is set to default value 'us-east'
[INFO] Set the environment variable PI_KEY_NAME for testing ibm_pi_key_name resource else it is set to default value 'terraform-test-power'
[INFO] Set the environment variable PI_NETWORK_NAME for testing ibm_pi_network_name resource else it is set to default value 'terraform-test-power'
[INFO] Set the environment variable PI_VOLUME_NAME for testing ibm_pi_network_name resource else it is set to default value 'terraform-test-power'
[INFO] Set the environment variable PI_CLOUDINSTANCE_ID for testing ibm_pi_image resource else it is set to default value 'd16705bd-7f1a-48c9-9e0e-1c17b71e7331'
[INFO] Set the environment variable PI_PVM_INSTANCE_ID for testing Pi_instance_name resource else it is set to default value 'terraform-test-power'
[INFO] Set the environment variable PI_DHCP_ID for testing ibm_pi_dhcp resource else it is set to default value 'terraform-test-power'
[INFO] Set the environment variable PI_CLOUD_CONNECTION_NAME for testing ibm_pi_cloud_connection resource else it is set to default value 'terraform-test-power'
[INFO] Set the environment variable PI_SAP_PROFILE_ID for testing ibm_pi_sap_profile resource else it is set to default value 'terraform-test-power'
[WARN] Set the environment variable PI_PLACEMENT_GROUP_NAME for testing ibm_pi_placement_group resource else it is set to default value 'tf-pi-placement-group'
[INFO] Set the environment variable PI_STORAGE_POOL for testing ibm_pi_storage_pool_capacity else it is set to default value 'terraform-test-power'
[INFO] Set the environment variable PI_STORAGE_TYPE for testing ibm_pi_storage_type_capacity else it is set to default value 'terraform-test-power'
[INFO] Set the environment variable PI_CAPTURE_STORAGE_IMAGE_PATH for testing Pi_capture_storage_image_path resource else it is set to default value 'terraform-test-power'
[INFO] Set the environment variable PI_CAPTURE_CLOUD_STORAGE_ACCESS_KEY for testing Pi_capture_cloud_storage_access_key resource else it is set to default value 'terraform-test-power'
[INFO] Set the environment variable PI_CAPTURE_CLOUD_STORAGE_SECRET_KEY for testing Pi_capture_cloud_storage_secret_key resource else it is set to default value 'terraform-test-power'
[INFO] Set the environment variable SCHEMATICS_WORKSPACE_ID for testing schematics resources else it is set to default value
[INFO] Set the environment variable SCHEMATICS_TEMPLATE_ID for testing schematics resources else it is set to default value
[INFO] Set the environment variable SCHEMATICS_ACTION_ID for testing schematics resources else it is set to default value
[INFO] Set the environment variable SCHEMATICS_JOB_ID for testing schematics resources else it is set to default value
[INFO] Set the environment variable SCHEMATICS_REPO_URL for testing schematics resources else tests will fail if this is not set correctly
[INFO] Set the environment variable SCHEMATICS_REPO_BRANCH for testing schematics resources else tests will fail if this is not set correctly
[WARN] Set the environment variable IMAGE_COS_URL with a VALID COS Image SQL URL for testing ibm_is_image resources on staging/test
[WARN] Set the environment variable IMAGE_COS_URL_ENCRYPTED with a VALID COS Image SQL URL for testing ibm_is_image resources on staging/test
[WARN] Set the environment variable IMAGE_OPERATING_SYSTEM with a VALID Operating system for testing ibm_is_image resources on staging/test
[INFO] Set the environment variable IS_IMAGE_NAME for testing data source ibm_is_image else it is set to default value `ibm-ubuntu-18-04-1-minimal-amd64-2`
[INFO] Set the environment variable IS_IMAGE_ENCRYPTED_DATA_KEY for testing resource ibm_is_image else it is set to default value
[INFO] Set the environment variable IS_IMAGE_ENCRYPTION_KEY for testing resource ibm_is_image else it is set to default value
[INFO] Set the environment variable IBM_FUNCTION_NAMESPACE for testing ibm_function_package, ibm_function_action, ibm_function_rule, ibm_function_trigger resource else  tests will fail if this is not set correctly
[INFO] Set the environment variable HPCS_INSTANCE_ID for testing data_source_ibm_kms_key_test else it is set to default value
[INFO] Set the environment variable SECRETS_MANAGER_INSTANCE_ID for testing data_source_ibm_secrets_manager_secrets_test else tests will fail if this is not set correctly
[INFO] Set the environment variable SECRETS_MANAGER_SECRET_TYPE for testing data_source_ibm_secrets_manager_secrets_test, else it is set to default value. For data_source_ibm_secrets_manager_secret_test, tests will fail if this is not set correctly
[WARN] Set the environment variable SECRETS_MANAGER_SECRET_ID for testing data_source_ibm_secrets_manager_secret_test else tests will fail if this is not set correctly
[INFO] Set the environment variable IBM_TG_CROSS_ACCOUNT_ID for testing ibm_tg_connection resource else  tests will fail if this is not set correctly
[INFO] Set the environment variable IBM_TG_CROSS_NETWORK_ID for testing ibm_tg_connection resource else  tests will fail if this is not set correctly
[INFO] Set the environment variable ACCOUNT_TO_BE_IMPORTED for testing import enterprise account resource else  tests will fail if this is not set correctly
[WARN] Set the environment variable IBM_HPCS_ADMIN1 with a VALID HPCS Admin Key1 Path
[WARN] Set the environment variable IBM_HPCS_TOKEN1 with a VALID token for HPCS Admin Key1
[WARN] Set the environment variable IBM_HPCS_ADMIN2 with a VALID HPCS Admin Key2 Path
[WARN] Set the environment variable IBM_IAM_REALM_NAME with a VALID realm name for iam trusted profile claim rule
[WARN] Set the environment variable IBM_IAM_IKS_SA with a VALID realm name for iam trusted profile link
[WARN] Set the environment variable IBM_HPCS_TOKEN2 with a VALID token for HPCS Admin Key2
[WARN] Set the environment variable SCC_GOVERNANCE_ACCOUNT_ID with a VALID account name
[WARN] Set the environment variable IBM_SCC_RESOURCE_GROUP with a VALID resource group id
[INFO] Set the environment variable SCC_SI_ACCOUNT for testing SCC SI resources resource else  tests will fail if this is not set correctly
[INFO] Set the environment variable SCC_POSTURE_SCOPE_ID for testing SCC Posture resources or datasource resource else  tests will fail if this is not set correctly
[INFO] Set the environment variable SCC_POSTURE_SCAN_ID for testing SCC Posture resource or datasource else  tests will fail if this is not set correctly
[INFO] Set the environment variable SCC_POSTURE_PROFILE_ID for testing SCC Posture resource or datasource else  tests will fail if this is not set correctly
[INFO] Set the environment variable SCC_POSTURE_GROUP_PROFILE_ID for testing SCC Posture resource or datasource else  tests will fail if this is not set correctly
[INFO] Set the environment variable SCC_POSTURE_CORRELATION_ID for testing SCC Posture resource or datasource else  tests will fail if this is not set correctly
[INFO] Set the environment variable SCC_POSTURE_REPORT_SETTING_ID for testing SCC Posture resource or datasource else  tests will fail if this is not set correctly
[INFO] Set the environment variable SCC_POSTURE_PROFILE_ID_SCANSUMMARY for testing SCC Posture resource or datasource else  tests will fail if this is not set correctly
[INFO] Set the environment variable SCC_POSTURE_SCAN_ID_SCANSUMMARY for testing SCC Posture resource or datasource else  tests will fail if this is not set correctly
[INFO] Set the environment variable SCC_POSTURE_CREDENTIAL_ID_SCOPE for testing SCC Posture resource or datasource else  tests will fail if this is not set correctly
[INFO] Set the environment variable SCC_POSTURE_CREDENTIAL_ID_SCOPE_UPDATE for testing SCC Posture resource or datasource else  tests will fail if this is not set correctly
[INFO] Set the environment variable SCC_POSTURE_COLLECTOR_ID_SCOPE for testing SCC Posture resource or datasource else  tests will fail if this is not set correctly
[INFO] Set the environment variable SCC_POSTURE_COLLECTOR_ID_SCOPE_UPDATE for testing SCC Posture resource or datasource else  tests will fail if this is not set correctly
[INFO] Set the environment variable IBM_CLOUD_SHELL_ACCOUNT_ID for ibm-cloud-shell resource or datasource else tests will fail if this is not set correctly
[WARN] Set the environment variable IBM_CLUSTER_VPC_ID for testing ibm_container_vpc_alb_create resources, ibm_container_vpc_alb_create tests will fail if this is not set
[WARN] Set the environment variable IBM_CLUSTER_VPC_SUBNET_ID for testing ibm_container_vpc_alb_create resources, ibm_container_vpc_alb_creates tests will fail if this is not set
[WARN] Set the environment variable IBM_CLUSTER_VPC_RESOURCE_GROUP_ID for testing ibm_container_vpc_alb_create resources, ibm_container_vpc_alb_creates tests will fail if this is not set
[INFO] Set the environment variable IBM_CONTAINER_CLUSTER_NAME for ibm_container_nlb_dns resource or datasource else tests will fail if this is not set correctly
=== RUN   TestAccIBMAtrackerEndpointsDataSourceBasic
--- PASS: TestAccIBMAtrackerEndpointsDataSourceBasic (13.21s)
=== RUN   TestAccIBMAtrackerRoutesDataSourceBasic
--- PASS: TestAccIBMAtrackerRoutesDataSourceBasic (32.84s)
=== RUN   TestAccIBMAtrackerTargetsDataSourceBasic
--- PASS: TestAccIBMAtrackerTargetsDataSourceBasic (16.45s)
=== RUN   TestAccIBMAtrackerTargetsDataSourceAllArgs
--- PASS: TestAccIBMAtrackerTargetsDataSourceAllArgs (13.88s)
=== RUN   TestAccIBMAtrackerRouteBasic
--- PASS: TestAccIBMAtrackerRouteBasic (24.93s)
=== RUN   TestAccIBMAtrackerSettingsBasic
--- PASS: TestAccIBMAtrackerSettingsBasic (44.80s)
=== RUN   TestAccIBMAtrackerTargetBasic
--- PASS: TestAccIBMAtrackerTargetBasic (27.31s)
PASS
ok      github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/atracker        174.781s
...
```
