### PR TITLE
fix : ibm_dns_custom_resolver locations 

### DIFF
--- a/ibm/service/dnsservices/resource_ibm_private_dns_custom_resolver.go
+++ b/ibm/service/dnsservices/resource_ibm_private_dns_custom_resolver.go
@@ -98,7 +98,7 @@ func ResourceIBMPrivateDNSCustomResolver() *schema.Resource {
 				Description: "Healthy state of the custom resolver",
 			},
 			pdnsCustomResolverLocations: {
-				Type:             schema.TypeSet,
+				Type:             schema.TypeList,
 				Description:      "Locations on which the custom resolver will be running",
 				Optional:         true,
 				DiffSuppressFunc: flex.ApplyOnce,
@@ -210,8 +210,8 @@ func resouceIBMPrivateDNSCustomResolverCreate(context context.Context, d *schema
 	crLocationCreate := false
 	if _, ok := d.GetOk(pdnsCustomResolverLocations); ok {
 		crLocationCreate = true
-		crLocations := d.Get(pdnsCustomResolverLocations).(*schema.Set)
-		if cr_highaval && crLocations.Len() <= 1 {
+		crLocations := d.Get(pdnsCustomResolverLocations).([]interface{})
+		if cr_highaval && len(crLocations) <= 1 {
 			return diag.FromErr(fmt.Errorf("To meet high availability status, configure custom resolvers with a minimum of two resolver locations. A maximum of four locations can be configured within the same subnet location."))
 		}
 		customResolverOption.SetLocations(expandPdnsCRLocations(crLocations))
@@ -401,8 +401,8 @@ func flattenPdnsCRLocations(crLocation []dnssvcsv1.Location) interface{} {
 	return flattened
 }
 
-func expandPdnsCRLocations(crLocList *schema.Set) (crLocations []dnssvcsv1.LocationInput) {
-	for _, iface := range crLocList.List() {
+func expandPdnsCRLocations(crLocList []interface{}) (crLocations []dnssvcsv1.LocationInput) {
+	for _, iface := range crLocList {
 		var locOpt dnssvcsv1.LocationInput
 		loc := iface.(map[string]interface{})
 		locOpt.SubnetCrn = core.StringPtr(loc[pdnsCRLocationSubnetCrn].(string))

--- a/website/docs/r/dns_custom_resolver.html.markdown
+++ b/website/docs/r/dns_custom_resolver.html.markdown
@@ -67,7 +67,7 @@ Review the argument reference that you can specify for your resource.
 - `enabled`- (Optional, Bool) To make custom resolver enabled/disable.
 - `description` - (Optional, String) Descriptive text of the custom resolver.
 - `high_availability` - (Optional, Bool) High Availability is enabled by Default, Need to add two or more locations.
-- `locations`- (Optional, Set) The list of locations where this custom resolver is deployed. There is no update for location argument in resolver resource.
+- `locations`- (Optional, List) The list of locations where this custom resolver is deployed. There is no update for location argument in resolver resource.
 
 ## Attribute reference
 In addition to all argument reference list, you can access the following attribute references after your resource is created. 
@@ -76,7 +76,7 @@ In addition to all argument reference list, you can access the following attribu
 - `custom_resolver_id` - (String) The unique ID of the private DNS custom resolver.
 - `modified_on` - (Timestamp) The time (modified On) of the DNS Custom Resolver.
 - `health`- (String) The status of DNS Custom Resolver's health. Possible values are `DEGRADED`, `CRITICAL`, `HEALTHY`.
-- `locations` - (Set) Locations on which the custom resolver will be running.
+- `locations` - (List) Locations on which the custom resolver will be running.
 
   Nested scheme for `locations`:
   - `healthy`- (String) The health status.


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/IBM-Cloud/terraform-provider-ibm/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```
