### PR TITLE
host pool ID for worker pool resource and data source

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/IBM-Cloud/terraform-provider-ibm
 go 1.16
 
 require (
-	github.com/IBM-Cloud/bluemix-go v0.0.0-20220407050707-b4cd0d4da813
+	github.com/IBM-Cloud/bluemix-go v0.0.0-20220523145737-34645883de47
 	github.com/IBM-Cloud/container-services-go-sdk v0.0.0-20210705152127-41ca00fc9a62
 	github.com/IBM-Cloud/power-go-client v1.1.8
 	github.com/IBM/apigateway-go-sdk v0.0.0-20210714141226-a5d5d49caaca

--- a/go.sum
+++ b/go.sum
@@ -39,6 +39,8 @@ github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
 github.com/IBM-Cloud/bluemix-go v0.0.0-20220407050707-b4cd0d4da813 h1:UgPApMMM6SglqB+U/EaFHyaoyaEM16RzxyiVah70g4o=
 github.com/IBM-Cloud/bluemix-go v0.0.0-20220407050707-b4cd0d4da813/go.mod h1:UOhxo7T8CdX6sdTY9Dn7rJSgyoTlz1KM9641XcPraH0=
+github.com/IBM-Cloud/bluemix-go v0.0.0-20220523145737-34645883de47 h1:lpClRYyGuSXX4m3PRO2fruDQiesshUrObgbnPi+Xbxk=
+github.com/IBM-Cloud/bluemix-go v0.0.0-20220523145737-34645883de47/go.mod h1:tfNN3lCKuA2+SQvndt0+5CjPr2qn/wdNLjrue1GrOhY=
 github.com/IBM-Cloud/container-services-go-sdk v0.0.0-20210705152127-41ca00fc9a62 h1:MOkcr6qQGk4tY542ZJ1DggVh2WUP72EEyLB79llFVH8=
 github.com/IBM-Cloud/container-services-go-sdk v0.0.0-20210705152127-41ca00fc9a62/go.mod h1:xUQL9SGAjoZFd4GNjrjjtEpjpkgU7RFXRyHesbKTjiY=
 github.com/IBM-Cloud/ibm-cloud-cli-sdk v0.5.3/go.mod h1:RiUvKuHKTBmBApDMUQzBL14pQUGKcx/IioKQPIcRQjs=

--- a/ibm/acctest/acctest.go
+++ b/ibm/acctest/acctest.go
@@ -901,6 +901,7 @@ func init() {
 	HostPoolID = os.Getenv("IBM_CONTAINER_DEDICATEDHOST_POOL_ID")
 	if HostPoolID == "" {
 		fmt.Println("[INFO] Set the environment variable IBM_CONTAINER_DEDICATEDHOST_POOL_ID for ibm_container_vpc_cluster resource to test dedicated host functionality")
+	}
 
 	KmsInstanceID = os.Getenv("IBM_KMS_INSTANCE_ID")
 	if KmsInstanceID == "" {
@@ -916,6 +917,7 @@ func init() {
 	if IksClusterID == "" {
 		fmt.Println("[INFO] Set the environment variable IBM_CLUSTER_ID for ibm_container_vpc_worker_pool resource or datasource else tests will fail if this is not set correctly")
 	}
+
 }
 
 var TestAccProviders map[string]*schema.Provider

--- a/ibm/acctest/acctest.go
+++ b/ibm/acctest/acctest.go
@@ -164,6 +164,9 @@ var Scc_posture_collector_id_scope_update []string
 //ROKS Cluster
 var ClusterName string
 
+//Dedicated host
+var HostPoolID string
+
 func init() {
 	testlogger := os.Getenv("TF_LOG")
 	if testlogger != "" {
@@ -890,6 +893,11 @@ func init() {
 	ClusterName = os.Getenv("IBM_CONTAINER_CLUSTER_NAME")
 	if ClusterName == "" {
 		fmt.Println("[INFO] Set the environment variable IBM_CONTAINER_CLUSTER_NAME for ibm_container_nlb_dns resource or datasource else tests will fail if this is not set correctly")
+	}
+
+	HostPoolID = os.Getenv("IBM_CONTAINER_DEDICATEDHOST_POOL_ID")
+	if HostPoolID == "" {
+		fmt.Println("[INFO] Set the environment variable IBM_CONTAINER_DEDICATEDHOST_POOL_ID for ibm_container_vpc_cluster resource to test dedicated host functionality")
 	}
 }
 

--- a/ibm/service/kubernetes/data_source_ibm_container_vpc_worker_pool.go
+++ b/ibm/service/kubernetes/data_source_ibm_container_vpc_worker_pool.go
@@ -64,6 +64,10 @@ func DataSourceIBMContainerVpcClusterWorkerPool() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
+			"host_pool_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
 		},
 	}
 }
@@ -98,13 +102,13 @@ func dataSourceIBMContainerVpcClusterWorkerPoolRead(d *schema.ResourceData, meta
 	d.Set("worker_pool_name", workerPool.PoolName)
 	d.Set("flavor", workerPool.Flavor)
 	d.Set("worker_count", workerPool.WorkerCount)
-	d.Set("provider", workerPool.Provider)
 	d.Set("labels", workerPool.Labels)
 	d.Set("zones", zones)
 	d.Set("cluster", clusterName)
 	d.Set("vpc_id", workerPool.VpcID)
 	d.Set("isolation", workerPool.Isolation)
 	d.Set("resource_group_id", targetEnv.ResourceGroup)
+	d.Set("host_pool_id", workerPool.HostPoolID)
 	d.SetId(workerPool.ID)
 	return nil
 }

--- a/ibm/service/kubernetes/data_source_ibm_container_vpc_worker_pool_test.go
+++ b/ibm/service/kubernetes/data_source_ibm_container_vpc_worker_pool_test.go
@@ -29,6 +29,23 @@ func TestAccIBMContainerVPCClusterWorkerPoolDataSource_basic(t *testing.T) {
 	})
 }
 
+func TestAccIBMContainerVPCClusterWorkerPoolDataSource_dedicatedhost(t *testing.T) {
+	name := fmt.Sprintf("tf-vpc-worker-%d", acctest.RandIntRange(10, 100))
+	hostpoolID := acc.HostPoolID
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { acc.TestAccPreCheck(t) },
+		Providers: acc.TestAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckIBMContainerVPCClusterWorkerPoolDataSourceConfigDedicatedHost(name, hostpoolID),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("data.ibm_container_vpc_worker_pool.vpc_worker_pool", "host_pool_id", hostpoolID),
+				),
+			},
+		},
+	})
+}
+
 func testAccCheckIBMContainerVPCClusterWorkerPoolDataSourceConfig(name string) string {
 	return testAccCheckIBMVpcContainerWorkerPoolBasic(name) + `
 	data "ibm_container_vpc_cluster_worker_pool" "testacc_ds_worker_pool" {
@@ -36,4 +53,18 @@ func testAccCheckIBMContainerVPCClusterWorkerPoolDataSourceConfig(name string) s
 	    worker_pool_name = "${ibm_container_vpc_worker_pool.test_pool.worker_pool_name}"
 	}
 `
+}
+
+func testAccCheckIBMContainerVPCClusterWorkerPoolDataSourceConfigDedicatedHost(name, hostpoolID string) string {
+	return testAccCheckIBMVpcContainerWorkerPoolDedicatedHostCreate(
+		acc.ClusterName, name, "bx2d.4x16", acc.IksClusterSubnetID, acc.IksClusterVpcID, acc.IksClusterResourceGroupID, hostpoolID) +
+		fmt.Sprintf(`
+	data "ibm_container_vpc_worker_pool" "vpc_worker_pool" {
+	    cluster = "%s"
+	    worker_pool_name = "%s"
+		depends_on = [
+			ibm_container_vpc_worker_pool.vpc_worker_pool
+		]
+	}
+	`, acc.ClusterName, name)
 }

--- a/ibm/service/kubernetes/data_source_ibm_container_vpc_worker_pool_test.go
+++ b/ibm/service/kubernetes/data_source_ibm_container_vpc_worker_pool_test.go
@@ -75,16 +75,15 @@ func TestAccIBMContainerVPCClusterWorkerPoolDataSourceEnvvar(t *testing.T) {
 
 func testAccCheckIBMContainerVPCClusterWorkerPoolDataSourceConfigDedicatedHost(name, hostpoolID string) string {
 	return testAccCheckIBMVpcContainerWorkerPoolDedicatedHostCreate(
-		acc.ClusterName, name, "bx2d.4x16", acc.IksClusterSubnetID, acc.IksClusterVpcID, acc.IksClusterResourceGroupID, hostpoolID) +
-		fmt.Sprintf(`
+		acc.ClusterName, name, "bx2d.4x16", acc.IksClusterSubnetID, acc.IksClusterVpcID, acc.IksClusterResourceGroupID, hostpoolID) + `
 	data "ibm_container_vpc_worker_pool" "vpc_worker_pool" {
-	    cluster = "%s"
-	    worker_pool_name = "%s"
+	    cluster = "${ibm_container_vpc_worker_pool.vpc_worker_pool.cluster}"
+	    worker_pool_name = "${ibm_container_vpc_worker_pool.vpc_worker_pool.worker_pool_name}"
 		depends_on = [
 			ibm_container_vpc_worker_pool.vpc_worker_pool
 		]
 	}
-	`, acc.ClusterName, name)
+`
 }
 
 func testAccCheckIBMContainerVPCClusterWorkerPoolDataSourceEnvvar(name string) string {

--- a/ibm/service/kubernetes/resource_ibm_container_vpc_worker_pool.go
+++ b/ibm/service/kubernetes/resource_ibm_container_vpc_worker_pool.go
@@ -229,7 +229,7 @@ func resourceIBMContainerVpcWorkerPoolCreate(d *schema.ResourceData, meta interf
 			KmsInstanceID:     v.(string),
 			WorkerVolumeCRKID: crk,
 		}
-		workerPoolConfig.WorkerVolumeEncryption = &wve
+		params.WorkerVolumeEncryption = &wve
 	}
 
 	if l, ok := d.GetOk("labels"); ok {

--- a/ibm/service/kubernetes/resource_ibm_container_vpc_worker_pool_test.go
+++ b/ibm/service/kubernetes/resource_ibm_container_vpc_worker_pool_test.go
@@ -58,6 +58,33 @@ func TestAccIBMContainerVpcClusterWorkerPoolBasic(t *testing.T) {
 	})
 }
 
+func TestAccIBMContainerVpcClusterWorkerPoolDedicatedHost(t *testing.T) {
+
+	name := fmt.Sprintf("tf-vpc-worker-%d", acctest.RandIntRange(10, 100))
+	hostpoolID := acc.HostPoolID
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { acc.TestAccPreCheck(t) },
+		Providers: acc.TestAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckIBMVpcContainerWorkerPoolDedicatedHostCreate(
+					acc.ClusterName,
+					name,
+					"bx2d.4x16",
+					acc.IksClusterSubnetID,
+					acc.IksClusterVpcID,
+					acc.IksClusterResourceGroupID,
+					hostpoolID,
+				),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(
+						"ibm_container_vpc_worker_pool.vpc_worker_pool", "host_pool_id", hostpoolID),
+				),
+			},
+		},
+	})
+}
+
 func testAccCheckIBMVpcContainerWorkerPoolDestroy(s *terraform.State) error {
 
 	wpClient, err := acc.TestAccProvider.Meta().(conns.ClientSession).VpcContainerAPI()
@@ -206,4 +233,22 @@ func testAccCheckIBMVpcContainerWorkerPoolUpdate(name string) string {
 	  }
 	}
 		`, name)
+}
+
+func testAccCheckIBMVpcContainerWorkerPoolDedicatedHostCreate(clusterName, name, flavor, subnetID, vpcID, rgroupID, hostpoolID string) string {
+	return fmt.Sprintf(`
+	resource "ibm_container_vpc_worker_pool" "vpc_worker_pool" {
+		cluster = "%s"
+		flavor = "%s"
+		worker_pool_name = "%s"
+		zones {
+		  subnet_id = "%s"
+		  name      = "us-south-1"
+		}
+		worker_count      = 1
+		vpc_id = "%s"
+		resource_group_id = "%s"
+		host_pool_id      = "%s"
+	  }
+	`, clusterName, flavor, name, subnetID, vpcID, rgroupID, hostpoolID)
 }

--- a/website/docs/d/container_vpc_cluster_worker_pool.html.markdown
+++ b/website/docs/d/container_vpc_cluster_worker_pool.html.markdown
@@ -30,6 +30,7 @@ Review the argument references that you can specify for your data source.
 In addition to all argument reference list, you can access the following attribute references after your data source is created. 
 
 - `flavor` - (String) The flavour of the worker node.
+- `host_pool_id` -(String) The ID of the dedicated host pool the worker pool is associated with.
 - `id` - (String) The unique identifier of the worker pool resource, as <cluster_name_id>/<worker_pool_id>.
 - `isolation` - (String) Isolation for the worker node.
 - `labels` - (String) Labels on all the workers in the worker pool. 

--- a/website/docs/r/container_vpc_worker_pool.html.markdown
+++ b/website/docs/r/container_vpc_worker_pool.html.markdown
@@ -80,6 +80,7 @@ Review the argument references that you can specify for your resource.
 - `cluster` - (Required, Forces new resource, String) The name or ID of the cluster.
 - `entitlement`- (Optional, String) The OpenShift cluster entitlement avoids incurred OCP license charges and use cloud pak with OCP license entitlement to add the OpenShift cluster worker pool. **Note** <ul><li> It is set as one time creation of the worker pool. There is no impacts on any modification.</li><li> Set the argument to `entitlement` only when you use cluster with a cloud pak that has an OpenShift entitlement. </li></ul>
 - `flavor` - (Required, Forces new resource, String) The flavor of the worker node.
+- `host_pool_id` - (Optional, String) The ID of the dedicated host pool the worker pool is associated with.
 - `labels` (Optional, Map) A list of labels that you want to add to all the worker nodes in the worker pool.
 - `resource_group_id` - (Optional, Forces new resource, String) The ID of the resource group. To retrieve the ID, run `ibmcloud resource groups` or use the `ibm_resource_group` data source. If no value is provided, the `default` resource group is used.
 - `taints` - (Optional, Set) A nested block that sets or removes Kubernetes taints for all worker nodes in a worker pool


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/IBM-Cloud/terraform-provider-ibm/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
=== RUN   TestAccIBMContainerVpcClusterWorkerPoolDedicatedHost
--- PASS: TestAccIBMContainerVpcClusterWorkerPoolDedicatedHost (585.88s)
PASS
ok  	github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/kubernetes	586.976s

=== RUN   TestAccIBMContainerVPCClusterWorkerPoolDataSource_dedicatedhost
--- PASS: TestAccIBMContainerVPCClusterWorkerPoolDataSource_dedicatedhost (654.21s)
PASS
ok  	github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/kubernetes	659.548s

...
```
