### PR TITLE
Add host pool ID to VPC worker data source

### DIFF
--- a/ibm/service/kubernetes/data_source_ibm_container_vpc_cluster_worker.go
+++ b/ibm/service/kubernetes/data_source_ibm_container_vpc_cluster_worker.go
@@ -76,6 +76,11 @@ func DataSourceIBMContainerVPCClusterWorker() *schema.Resource {
 				Optional:    true,
 				Description: "ID of the resource group.",
 			},
+			"host_pool_id": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "ID of the dedicated host pool this worker is associated with",
+			},
 			flex.ResourceControllerURL: {
 				Type:        schema.TypeString,
 				Computed:    true,
@@ -111,6 +116,7 @@ func dataSourceIBMContainerVPCClusterWorkerRead(d *schema.ResourceData, meta int
 	d.Set("state", workerFields.Health.State)
 	d.Set("pool_id", workerFields.PoolID)
 	d.Set("pool_name", workerFields.PoolName)
+	d.Set("host_pool_id", workerFields.HostPoolID)
 	d.Set("network_interfaces", flex.FlattenNetworkInterfaces(workerFields.NetworkInterfaces))
 	controller, err := flex.GetBaseController(meta)
 	if err != nil {

--- a/ibm/service/kubernetes/data_source_ibm_container_vpc_cluster_worker_test.go
+++ b/ibm/service/kubernetes/data_source_ibm_container_vpc_cluster_worker_test.go
@@ -29,6 +29,23 @@ func TestAccIBMContainerVPCClusterWorkerDataSource_basic(t *testing.T) {
 	})
 }
 
+func TestAccIBMContainerVPCClusterWorkerDataSource_dedicatedhost(t *testing.T) {
+	clusterName := acc.ClusterName
+	hostpoolID := acc.HostPoolID
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { acc.TestAccPreCheck(t) },
+		Providers: acc.TestAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckIBMContainerVPCClusterWorkerDataSourceDedicatedHostConfig(clusterName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("data.ibm_container_vpc_cluster_worker.dhost_vpc_worker", "host_pool_id", hostpoolID),
+				),
+			},
+		},
+	})
+}
+
 func testAccCheckIBMContainerVPCClusterWorkerDataSourceConfig(name string) string {
 	return testAccCheckIBMVpcContainerWorkerPoolBasic(name) + `
 	data "ibm_container_vpc_cluster" "testacc_ds_cluster" {
@@ -39,4 +56,16 @@ func testAccCheckIBMContainerVPCClusterWorkerDataSourceConfig(name string) strin
 	    worker_id = data.ibm_container_vpc_cluster.testacc_ds_cluster.workers[0]
 	}
 `
+}
+
+func testAccCheckIBMContainerVPCClusterWorkerDataSourceDedicatedHostConfig(clusterName string) string {
+	return fmt.Sprintf(`
+	data "ibm_container_vpc_cluster" "dhost_vpc_cluster" {
+		cluster_name_id = "%s"
+	}
+	data "ibm_container_vpc_cluster_worker" "dhost_vpc_worker" {
+	    cluster_name_id = "%s"
+	    worker_id = data.ibm_container_vpc_cluster.dhost_vpc_cluster.workers[0]
+	}
+	`, clusterName, clusterName)
 }

--- a/website/docs/d/container_vpc_cluster_worker.html.markdown
+++ b/website/docs/d/container_vpc_cluster_worker.html.markdown
@@ -13,7 +13,7 @@ Retrieve information about the worker nodes of your IBM Cloud Kubernetes Service
 The following example retrieves information about a worker node with the ID in the cluster. 
 
 ```terraform
-data "ibm_container_cluster_worker" "worker_foo" {
+data "ibm_container_vpc_cluster_worker" "worker_foo" {
   worker_id       = "dev-mex10-pa70c4414695c041518603bfd0cd6e333a-w1"
   cluster_name_id = "test"
 }
@@ -31,6 +31,7 @@ Review the argument references that you can specify for your data source.
 In addition to all argument reference list, you can access the following attribute references after your data source is created. 
 
 - `cidr` - (String) The CIDR of the network.
+- `host_pool_id` - (String) The ID of the dedicated host pool the worker is associated with.
 - `ip_address` - (String) The IP address of the worker pool that the worker node belongs to.
 - `network_interfaces` - (String) The network interface of the cluster.
 - `pool_id` - (String) The ID of the worker pool that the worker node belongs to.


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/IBM-Cloud/terraform-provider-ibm/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
❯ make testacc TEST=./ibm/service/kubernetes TESTARGS='-run=TestAccIBMContainerVPCClusterWorkerDataSource_dedicatedhost'
=== RUN   TestAccIBMContainerVPCClusterWorkerDataSource_dedicatedhost
--- PASS: TestAccIBMContainerVPCClusterWorkerDataSource_dedicatedhost (54.33s)
PASS
ok  	github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/kubernetes	55.138s
...
```
