### PR TITLE
clean up pi_key resource and data source

### DIFF
--- a/ibm/service/power/data_source_ibm_pi_key.go
+++ b/ibm/service/power/data_source_ibm_pi_key.go
@@ -33,14 +33,20 @@ func DataSourceIBMPIKey() *schema.Resource {
 				ValidateFunc: validation.NoZeroValues,
 			},
 			//Computed Attributes
-			"creation_date": {
+			PIKeyDate: {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
-			"sshkey": {
+			PIKey: {
 				Type:      schema.TypeString,
 				Sensitive: true,
 				Computed:  true,
+			},
+			"sshkey": {
+				Type:       schema.TypeString,
+				Sensitive:  true,
+				Computed:   true,
+				Deprecated: "This field is deprecated, use ssh_key instead",
 			},
 		},
 	}
@@ -61,7 +67,9 @@ func dataSourceIBMPIKeyRead(ctx context.Context, d *schema.ResourceData, meta in
 	}
 
 	d.SetId(*sshkeydata.Name)
-	d.Set("creation_date", sshkeydata.CreationDate.String())
+	d.Set(PIKeyDate, sshkeydata.CreationDate.String())
+	d.Set(PIKey, sshkeydata.SSHKey)
+	// TODO: deprecated, to remove
 	d.Set("sshkey", sshkeydata.SSHKey)
 	d.Set(helpers.PIKeyName, sshkeydata.Name)
 

--- a/ibm/service/power/ibm_pi_constants.go
+++ b/ibm/service/power/ibm_pi_constants.go
@@ -9,6 +9,7 @@ const (
 	PIKeyName = "name"
 	PIKey     = "ssh_key"
 	PIKeyDate = "creation_date"
+	PIKeyID   = "key_id"
 
 	// SAP Profile
 	PISAPProfiles         = "profiles"

--- a/ibm/service/power/resource_ibm_pi_key.go
+++ b/ibm/service/power/resource_ibm_pi_key.go
@@ -32,31 +32,28 @@ func ResourceIBMPIKey() *schema.Resource {
 		},
 
 		Schema: map[string]*schema.Schema{
-
-			helpers.PIKeyName: {
-				Type:        schema.TypeString,
-				Required:    true,
-				Description: "Key name in the PI instance",
-			},
-
-			helpers.PIKey: {
-				Type:        schema.TypeString,
-				Required:    true,
-				Description: "PI instance key info",
-			},
-			helpers.PIKeyDate: {
-				Type:        schema.TypeString,
-				Computed:    true,
-				Description: "Date info",
-			},
-
 			helpers.PICloudInstanceId: {
 				Type:        schema.TypeString,
 				Required:    true,
 				Description: "PI cloud instance ID",
 			},
-
-			"key_id": {
+			helpers.PIKeyName: {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "Key name in the PI instance",
+			},
+			helpers.PIKey: {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "PI instance key info",
+			},
+			// Computed Attributes
+			PIKeyDate: {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "Date of sshkey creation",
+			},
+			PIKeyID: {
 				Type:        schema.TypeString,
 				Computed:    true,
 				Description: "Key ID in the PI instance",
@@ -112,8 +109,8 @@ func resourceIBMPIKeyRead(ctx context.Context, d *schema.ResourceData, meta inte
 
 	d.Set(helpers.PIKeyName, sshkeydata.Name)
 	d.Set(helpers.PIKey, sshkeydata.SSHKey)
-	d.Set(helpers.PIKeyDate, sshkeydata.CreationDate.String())
-	d.Set("key_id", sshkeydata.Name)
+	d.Set(PIKeyDate, sshkeydata.CreationDate.String())
+	d.Set(PIKeyID, sshkeydata.Name)
 
 	return nil
 

--- a/website/docs/d/pi_key.html.markdown
+++ b/website/docs/d/pi_key.html.markdown
@@ -46,4 +46,4 @@ In addition to all argument reference list, you can access the following attribu
 
 - `creation_date` - Timestamp - The timestamp when the SSH key was created.
 - `id` - (String) The unique identifier of the SSH key.
-- `sshkey` - (String) The public SSH key value.
+- `ssh_key` - (String) The public SSH key value.

--- a/website/docs/r/pi_key.html.markdown
+++ b/website/docs/r/pi_key.html.markdown
@@ -48,7 +48,6 @@ ibm_pi_key provides the following [timeouts](https://www.terraform.io/docs/langu
 Review the argument references that you can specify for your resource. 
 
 - `pi_cloud_instance_id` - (Required, String) The GUID of the service instance associated with an account.
-- `pi_creation_date` - (Optional, String) The date when the SSH key was created. 
 - `pi_key_name`  - (Required, Integer) The name of the SSH key that you uploaded to IBM Cloud. 
 - `pi_ssh_key` - (Required, String) The value of the public SSH key. 
 
@@ -56,12 +55,13 @@ Review the argument references that you can specify for your resource.
 ## Attribute reference
  In addition to all argument reference list, you can access the following attribute reference after your resource is created.
 
-- `id` - (String) The unique identifier of the key. The ID is composed of `<power_instance_id>/<key_name>`.
+- `creation_date` - (String) The date when the SSH key was created. 
+- `id` - (String) The unique identifier of the key. The ID is composed of `<pi_cloud_instance_id>/<pi_key_name>`.
 - `key_id` - (String) The unique identifier of the key.
 
 ## Import
 
-The `ibm_pi_key` resource can be imported by using `power_instance_id` and `ssh_key_name`.
+The `ibm_pi_key` resource can be imported by using `pi_cloud_instance_id` and `pi_key_name`.
 
 **Example**
 


### PR DESCRIPTION
Fixes #3770

Signed-off-by: Yussuf Shaikh <yussuf.shaikh1@ibm.com>

<!--- See what makes a good Pull Request at : https://github.com/IBM-Cloud/terraform-provider-ibm/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #3770

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
=== RUN TestAccIBMPIKeyDataSource_basic 
--- PASS: TestAccIBMPIKeyDataSource_basic (15.12s) 
=== RUN TestAccIBMPIKey _basic 
--- PASS: TestAccIBMPIKey_basic (49.23s) 
PASS

```
