### PR TITLE
fix(ibm_is_security_group_rule): ignore 404 during destroy

### DIFF
--- a/ibm/service/vpc/resource_ibm_is_security_group_rule.go
+++ b/ibm/service/vpc/resource_ibm_is_security_group_rule.go
@@ -459,7 +459,7 @@ func resourceIBMISSecurityGroupRuleDelete(d *schema.ResourceData, meta interface
 		ID:              &ruleID,
 	}
 	response, err = sess.DeleteSecurityGroupRule(deleteSecurityGroupRuleOptions)
-	if err != nil {
+	if err != nil && response.StatusCode != 404 {
 		return fmt.Errorf("[ERROR] Error Deleting Security Group Rule : %s\n%s", err, response)
 	}
 	d.SetId("")


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/IBM-Cloud/terraform-provider-ibm/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```
