### PR TITLE
Enabled argument of glb resource was not mentioned in the doc

### DIFF
--- a/examples/ibm-private-dns/main.tf
+++ b/examples/ibm-private-dns/main.tf
@@ -174,6 +174,7 @@ resource "ibm_dns_glb" "test_pdns_glb" {
   zone_id       = ibm_dns_zone.test-pdns-zone.zone_id
   description   = "new glb"
   ttl           = 120
+  enabled       = true
   fallback_pool = ibm_dns_glb_pool.test-pdns-pool-nw.pool_id
   default_pools = [ibm_dns_glb_pool.test-pdns-pool-nw.pool_id]
   az_pools {

--- a/examples/ibm-private-dns/main.tf
+++ b/examples/ibm-private-dns/main.tf
@@ -174,7 +174,6 @@ resource "ibm_dns_glb" "test_pdns_glb" {
   zone_id       = ibm_dns_zone.test-pdns-zone.zone_id
   description   = "new glb"
   ttl           = 120
-  enabled       = true
   fallback_pool = ibm_dns_glb_pool.test-pdns-pool-nw.pool_id
   default_pools = [ibm_dns_glb_pool.test-pdns-pool-nw.pool_id]
   az_pools {

--- a/website/docs/r/dns_glb.html.markdown
+++ b/website/docs/r/dns_glb.html.markdown
@@ -21,6 +21,7 @@ resource "ibm_dns_glb" "test_pdns_glb" {
   zone_id       = ibm_dns_zone.test_pdns_glb_zone.zone_id
   description   = "new glb"
   ttl           = 120
+  enabled       = true
   fallback_pool = ibm_dns_glb_pool.test_pdns_glb_pool.pool_id
   default_pools = [ibm_dns_glb_pool.test_pdns_glb_pool.pool_id]
   az_pools {
@@ -45,6 +46,7 @@ Review the argument reference that you can specify for your resource.
 - `name` - (Required, String) The name of the Load Balancer.
 - `ttl` - (Optional, Integer) The time to live (TTL) in seconds.
 - `zone_id` - (Required, Forces new resource, String) The ID of the private DNS Zone.
+- `enabled` - (Optional, Bool) Whether the load balancer is enabled.
 
 ## Attribute reference
 In addition to all argument reference list, you can access the following attribute references after your resource is created. 

--- a/website/docs/r/dns_glb.html.markdown
+++ b/website/docs/r/dns_glb.html.markdown
@@ -21,7 +21,6 @@ resource "ibm_dns_glb" "test_pdns_glb" {
   zone_id       = ibm_dns_zone.test_pdns_glb_zone.zone_id
   description   = "new glb"
   ttl           = 120
-  enabled       = true
   fallback_pool = ibm_dns_glb_pool.test_pdns_glb_pool.pool_id
   default_pools = [ibm_dns_glb_pool.test_pdns_glb_pool.pool_id]
   az_pools {
@@ -46,7 +45,6 @@ Review the argument reference that you can specify for your resource.
 - `name` - (Required, String) The name of the Load Balancer.
 - `ttl` - (Optional, Integer) The time to live (TTL) in seconds.
 - `zone_id` - (Required, Forces new resource, String) The ID of the private DNS Zone.
-- `enabled` - (Optional, Bool) Whether the load balancer is enabled.
 
 ## Attribute reference
 In addition to all argument reference list, you can access the following attribute references after your resource is created. 


### PR DESCRIPTION
Enabled argument of glb resource was not mentioned in the doc.
Original Issue# https://github.com/IBM-Cloud/terraform-provider-ibm/issues/3818

**Testing**
**1st.** Build was successful
  Log : 
rahul.gahlautibm.com@Rahuls-MacBook-Pro terraform-provider-ibm % git branch
  master
* pdns_doc_rg
rahul.gahlautibm.com@Rahuls-MacBook-Pro terraform-provider-ibm % make fmt
gofmt -w $(find .  -path ./.direnv -prune -false -o -name '*.go' |grep -v vendor)
rahul.gahlautibm.com@Rahuls-MacBook-Pro terraform-provider-ibm % make build
==> Checking that code complies with gofmt requirements...
go vet .
go install
rahul.gahlautibm.com@Rahuls-MacBook-Pro terraform-provider-ibm % 

**2nd.** Tested the enabled flag with true and false and without mentioning it in tf.
   Result : expected.
 when not mentioned by default it is treated as default and glb will be disabled.

Note : To enable glb, set enabled to true as given in examples
