### PR TITLE
enhancement: filter by status in IS images data source

### DIFF
--- a/ibm/provider/provider.go
+++ b/ibm/provider/provider.go
@@ -1144,6 +1144,7 @@ func Validator() validate.ValidatorDict {
 			DataSourceValidatorDictionary: map[string]*validate.ResourceValidator{
 				"ibm_is_subnet":          vpc.DataSourceIBMISSubnetValidator(),
 				"ibm_is_snapshot":        vpc.DataSourceIBMISSnapshotValidator(),
+				"ibm_is_images":          vpc.DataSourceIBMISImagesValidator(),
 				"ibm_dl_offering_speeds": directlink.DataSourceIBMDLOfferingSpeedsValidator(),
 				"ibm_dl_routers":         directlink.DataSourceIBMDLRoutersValidator(),
 

--- a/ibm/service/vpc/data_source_ibm_is_images_test.go
+++ b/ibm/service/vpc/data_source_ibm_is_images_test.go
@@ -49,6 +49,24 @@ func TestAccIBMISImageDataSource_With_FilterVisibilty(t *testing.T) {
 	})
 }
 
+func TestAccIBMISImageDataSource_With_FilterStatus(t *testing.T) {
+	resName := "data.ibm_is_images.test1"
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { acc.TestAccPreCheck(t) },
+		Providers: acc.TestAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckIBMISImagesDataSourceWithStatusPublic("available"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet(resName, "images.0.name"),
+					resource.TestCheckResourceAttrSet(resName, "images.0.status"),
+					resource.TestCheckResourceAttrSet(resName, "images.0.architecture"),
+				),
+			},
+		},
+	})
+}
+
 func testAccCheckIBMISImagesDataSourceConfig() string {
 	// status filter defaults to empty
 	return fmt.Sprintf(`
@@ -62,4 +80,12 @@ func testAccCheckIBMISImagesDataSourceWithVisibilityPublic(visibility string) st
 		visibility = "%s"
 	}
 	`, visibility)
+}
+
+func testAccCheckIBMISImagesDataSourceWithStatusPublic(status string) string {
+	return fmt.Sprintf(`
+	data "ibm_is_images" "test1" {
+		status = "%s"
+	}
+	`, status)
 }

--- a/website/docs/d/is_images.html.markdown
+++ b/website/docs/d/is_images.html.markdown
@@ -39,6 +39,7 @@ Review the argument references that you can specify for your data source.
 * `resource_group` - (Optional, string) The id of the resource group.
 * `name` - (Optional, string) The name of the image.
 * `visibility` - (Optional, string) Visibility of the image.
+* `status` - (Optional, string) Status of the image.
 
 ## Attribute reference
 You can access the following attribute references after your data source is created. 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/IBM-Cloud/terraform-provider-ibm/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TEST=./ibm/service/vpc TESTARGS='-run=TestAccIBMISImageDataSource_With_FilterStatus'
=== RUN   TestAccIBMISImageDataSource_With_FilterStatus
--- PASS: TestAccIBMISImageDataSource_With_FilterStatus (44.18s)
PASS
ok      github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/vpc     45.700s
```
