### PR TITLE
fix ibm_container_storage_attachment import

### DIFF
--- a/ibm/service/kubernetes/resource_ibm_container_storage_attachment.go
+++ b/ibm/service/kubernetes/resource_ibm_container_storage_attachment.go
@@ -151,16 +151,17 @@ func resourceIBMContainerVpcWorkerVolumeAttachmentRead(context context.Context, 
 	workerID := parts[1]
 	volumeAttachmentID := parts[2]
 
-	volume, err := workersAPI.GetStorageAttachment(clusterNameorID, workerID, volumeAttachmentID, target)
+	volumeAttachment, err := workersAPI.GetStorageAttachment(clusterNameorID, workerID, volumeAttachmentID, target)
 	if err != nil {
 		return diag.FromErr(err)
 	}
 	d.Set("cluster", clusterNameorID)
 	d.Set("worker", workerID)
+	d.Set("volume", volumeAttachment.Volume.Id)
 	d.Set("volume_attachment_id", volumeAttachmentID)
-	d.Set("volume_attachment_name", volume.Name)
-	d.Set("status", volume.Status)
-	d.Set("volume_type", volume.Type)
+	d.Set("volume_attachment_name", volumeAttachment.Name)
+	d.Set("status", volumeAttachment.Status)
+	d.Set("volume_type", volumeAttachment.Type)
 	return nil
 }
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/IBM-Cloud/terraform-provider-ibm/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ export TESTARGS="-run TestAccIBMContainerVpcClusterWorkerVolumeAttachment_Basic"
$ make testacc
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test $(go list ./... |grep -v 'vendor') -v -run TestAccIBMContainerVpcClusterWorkerVolumeAttachment_Basic -timeout 700m
...
=== RUN   TestAccIBMContainerVpcClusterWorkerVolumeAttachment_Basic
--- PASS: TestAccIBMContainerVpcClusterWorkerVolumeAttachment_Basic (1526.43s)
PASS
ok  	github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/kubernetes	1526.458s
```
