### PR TITLE
add vpc cluster and workerpool to the dhost example

### DIFF
--- a/examples/ibm-dedicated-host/main.tf
+++ b/examples/ibm-dedicated-host/main.tf
@@ -16,13 +16,21 @@ resource "ibm_container_dedicated_host" "dhost" {
   zone         = var.zone
 }
 
+data "ibm_is_vpc" "vpc" {
+  name = var.vpc_name
+}
+
+data "ibm_is_subnet" "subnet" {
+  name = var.subnet_name
+}
+
 resource "ibm_container_vpc_cluster" "dhost_vpc_cluster" {
   name   = var.cluster_name
-  vpc_id = var.vpc_id
+  vpc_id = data.ibm_is_vpc.vpc.id
   flavor = var.flavor
   zones {
     name      = var.zone
-    subnet_id = var.subnet_id
+    subnet_id = data.ibm_is_subnet.subnet.id
   }
   worker_count      = var.worker_count
   resource_group_id = var.resource_group_id
@@ -43,7 +51,7 @@ resource "ibm_container_vpc_worker_pool" "dhost_vpc_worker_pool" {
   worker_count     = var.worker_count
   zones {
     name      = var.zone
-    subnet_id = var.subnet_id
+    subnet_id = data.ibm_is_subnet.subnet.id
   }
   depends_on = [
     ibm_container_dedicated_host.dhost

--- a/examples/ibm-dedicated-host/variables.tf
+++ b/examples/ibm-dedicated-host/variables.tf
@@ -30,12 +30,12 @@ variable "worker_pool_name" {
   default = "tf-dhost-vpc-worker-pool"
 }
 
-variable "vpc_id" {
-  default = "1234-a1b2c3d4-abcd-1234-abcd-123456789012"
+variable "vpc_name" {
+  default = "tf-vpc"
 }
 
-variable "subnet_id" {
-  default = "1234-a1b2c3d4-abcd-1234-abcd-123456789012"
+variable "subnet_name" {
+  default = "tf-subnet"
 }
 
 variable "flavor" {


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/IBM-Cloud/terraform-provider-ibm/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ terraform apply

Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  + create

Terraform will perform the following actions:

  # ibm_container_dedicated_host.dhost will be created
  + resource "ibm_container_dedicated_host" "dhost" {
...
    }

  # ibm_container_dedicated_host_pool.dhostpool will be created
  + resource "ibm_container_dedicated_host_pool" "dhostpool" {
...
    }

  # ibm_container_vpc_cluster.dhost_vpc_cluster will be created
  + resource "ibm_container_vpc_cluster" "dhost_vpc_cluster" {
...
    }

  # ibm_container_vpc_worker_pool.dhost_vpc_worker_pool will be created
  + resource "ibm_container_vpc_worker_pool" "dhost_vpc_worker_pool" {
...
    }

Plan: 4 to add, 0 to change, 0 to destroy.

Do you want to perform these actions?
  Terraform will perform the actions described above.
  Only 'yes' will be accepted to approve.

  Enter a value: yes

ibm_container_dedicated_host_pool.dhostpool: Creating...
ibm_container_dedicated_host_pool.dhostpool: Still creating... [10s elapsed]
ibm_container_dedicated_host_pool.dhostpool: Creation complete after 12s [id=...]
ibm_container_dedicated_host.dhost: Creating...
...
ibm_container_dedicated_host.dhost: Creation complete after 1m52s [id=...]
ibm_container_vpc_cluster.dhost_vpc_cluster: Creating...
...
ibm_container_vpc_cluster.dhost_vpc_cluster: Creation complete after 17m56s [id=...]
ibm_container_vpc_worker_pool.dhost_vpc_worker_pool: Creating...
...
ibm_container_vpc_worker_pool.dhost_vpc_worker_pool: Creation complete after 6m29s [id=...]

Apply complete! Resources: 4 added, 0 changed, 0 destroyed.

$ terraform destroy

ibm_container_dedicated_host_pool.dhostpool: Refreshing state... [id=...]
ibm_container_dedicated_host.dhost: Refreshing state... [id=...]
ibm_container_vpc_cluster.dhost_vpc_cluster: Refreshing state... [id=...]
ibm_container_vpc_worker_pool.dhost_vpc_worker_pool: Refreshing state... [id=...]

Note: Objects have changed outside of Terraform

Terraform detected the following changes made outside of Terraform since the last "terraform apply":

  # ibm_container_dedicated_host.dhost has been changed
  ~ resource "ibm_container_dedicated_host" "dhost" {
...
    }
  # ibm_container_dedicated_host_pool.dhostpool has been changed
  ~ resource "ibm_container_dedicated_host_pool" "dhostpool" {
...
    }
  # ibm_container_vpc_cluster.dhost_vpc_cluster has been changed
  ~ resource "ibm_container_vpc_cluster" "dhost_vpc_cluster" {
...
    }

...

Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  - destroy

Terraform will perform the following actions:

  # ibm_container_dedicated_host.dhost will be destroyed
  - resource "ibm_container_dedicated_host" "dhost" {
...
    }

  # ibm_container_vpc_cluster.dhost_vpc_cluster will be destroyed
  - resource "ibm_container_vpc_cluster" "dhost_vpc_cluster" {
...
    }

  # ibm_container_vpc_worker_pool.dhost_vpc_worker_pool will be destroyed
  - resource "ibm_container_vpc_worker_pool" "dhost_vpc_worker_pool" {
...
    }

Plan: 0 to add, 0 to change, 4 to destroy.

Do you really want to destroy all resources?
  Terraform will destroy all your managed infrastructure, as shown above.
  There is no undo. Only 'yes' will be accepted to confirm.
    Enter a value: yes

ibm_container_vpc_worker_pool.dhost_vpc_worker_pool: Destroying... [id=...]
...
ibm_container_vpc_worker_pool.dhost_vpc_worker_pool: Destruction complete after 4m19s
ibm_container_vpc_cluster.dhost_vpc_cluster: Destroying... [id=...]
...
ibm_container_vpc_cluster.dhost_vpc_cluster: Destruction complete after 5m5s
ibm_container_dedicated_host.dhost: Destroying... [id=...]
...
ibm_container_dedicated_host.dhost: Destruction complete after 2m8s
ibm_container_dedicated_host_pool.dhostpool: Destroying... [id=...]
...
ibm_container_dedicated_host_pool.dhostpool: Destruction complete after 1m55s

Destroy complete! Resources: 4 destroyed.

...
```
