### PR TITLE
Backup as a Service: Backup Policies and Backup Plans

### DIFF
--- a/examples/ibm-is-ng/main.tf
+++ b/examples/ibm-is-ng/main.tf
@@ -584,12 +584,14 @@ resource "ibm_is_instance" "instance4" {
 resource "ibm_is_snapshot" "b_snapshot" {
   name          = "my-snapshot-boot"
   source_volume = ibm_is_instance.instance4.volume_attachments[0].volume_id
+  tags          = ["tags1"]
 }
 
 // creating a snapshot from data volume
 resource "ibm_is_snapshot" "d_snapshot" {
   name          = "my-snapshot-data"
   source_volume = ibm_is_instance.instance4.volume_attachments[1].volume_id
+  tags          = ["tags1"]
 }
 
 // data source for snapshot by name
@@ -623,6 +625,7 @@ resource "ibm_is_volume" "vol5" {
   name    = "vol5"
   profile = "10iops-tier"
   zone    = "us-south-2"
+  tags    = ["tag1"]
 }
 
 // creating a volume attachment on an existing instance using an existing volume
@@ -1032,4 +1035,39 @@ data "ibm_is_volumes" "example" {
 # List Volumes by Zone name
 data "ibm_is_volumes" "example" {
   zone_name = "us-south-1"
+}
+
+## Backup Policy
+resource "ibm_is_backup_policy" "is_backup_policy" {
+  match_user_tags = ["tag1"]
+  name            = "my-backup-policy"
+}
+
+resource "ibm_is_backup_policy_plan" "is_backup_policy_plan" {
+  backup_policy_id = ibm_is_backup_policy.is_backup_policy.id
+  cron_spec        = "30 09 * * *"
+  active           = false
+  attach_user_tags = ["tag2"]
+  copy_user_tags = true
+  deletion_trigger {
+    delete_after      = 20
+    delete_over_count = 20
+  }
+  name = "my-backup-policy-plan-1"
+}
+
+data "ibm_is_backup_policies" "is_backup_policies" {
+}
+
+data "ibm_is_backup_policy" "is_backup_policy" {
+  name = "my-backup-policy"
+}
+
+data "ibm_is_backup_policy_plans" "is_backup_policy_plans" {
+  backup_policy_id = ibm_is_backup_policy.is_backup_policy.id
+}
+
+data "ibm_is_backup_policy_plan" "is_backup_policy_plan" {
+  backup_policy_id = ibm_is_backup_policy.is_backup_policy.id
+  name             = "my-backup-policy-plan"
 }

--- a/go.mod
+++ b/go.mod
@@ -28,7 +28,7 @@ require (
 	github.com/IBM/scc-go-sdk/v3 v3.1.6
 	github.com/IBM/schematics-go-sdk v0.1.3
 	github.com/IBM/secrets-manager-go-sdk v0.1.19
-	github.com/IBM/vpc-go-sdk v0.20.0
+	github.com/IBM/vpc-go-sdk v0.21.0
 	github.com/PromonLogicalis/asn1 v0.0.0-20190312173541-d60463189a56 // indirect
 	github.com/ScaleFT/sshkeys v0.0.0-20200327173127-6142f742bca5
 	github.com/Shopify/sarama v1.29.1
@@ -56,5 +56,6 @@ require (
 )
 
 replace github.com/softlayer/softlayer-go v1.0.3 => github.com/IBM-Cloud/softlayer-go v1.0.5-tf
+
 
 replace github.com/dgrijalva/jwt-go v3.2.0+incompatible => github.com/golang-jwt/jwt v3.2.1+incompatible

--- a/go.sum
+++ b/go.sum
@@ -36,6 +36,7 @@ github.com/IBM/go-sdk-core/v3 v3.2.4 h1:WKYJYYKlZnw1y/gM+Qbf5EQVAL9xaoD54+ooJZz/
 github.com/IBM/go-sdk-core/v3 v3.2.4/go.mod h1:lk9eOzNbNltPf3CBpcg1Ewkhw4qC3u2QCCKDRsUA2M0=
 github.com/IBM/go-sdk-core/v5 v5.0.0/go.mod h1:vyNdbFujJtdTj9HbihtvKwwS3k/GKSKpOx9ZIQ6MWDY=
 github.com/IBM/go-sdk-core/v5 v5.1.0/go.mod h1:vyNdbFujJtdTj9HbihtvKwwS3k/GKSKpOx9ZIQ6MWDY=
+github.com/IBM/go-sdk-core/v5 v5.4.2/go.mod h1:Sn+z+qTDREQvCr+UFa22TqqfXNxx3o723y8GsfLV8e0=
 github.com/IBM/go-sdk-core/v5 v5.5.1/go.mod h1:Sn+z+qTDREQvCr+UFa22TqqfXNxx3o723y8GsfLV8e0=
 github.com/IBM/go-sdk-core/v5 v5.6.3/go.mod h1:tt/B9rxLkRtglE7pvqLuYikgCXaZFL3btdruJaoUeek=
 github.com/IBM/go-sdk-core/v5 v5.6.5/go.mod h1:tt/B9rxLkRtglE7pvqLuYikgCXaZFL3btdruJaoUeek=
@@ -77,6 +78,8 @@ github.com/IBM/secrets-manager-go-sdk v0.1.19 h1:0GPs5EoTaWNsjo4QPj64GNxlWfN8VHJ
 github.com/IBM/secrets-manager-go-sdk v0.1.19/go.mod h1:eO3dBhzPrHkkt+yPex/jB2xD6qHZxBko+Aw+0tfqHeA=
 github.com/IBM/vpc-go-sdk v0.20.0 h1:xetXFYv/GDSOVTm2h7MSki2D9x2dpNsiwHVRmdSIrPc=
 github.com/IBM/vpc-go-sdk v0.20.0/go.mod h1:YPyIfI+/qhPqlYp+I7dyx2U1GLcXgp/jzVvsZfUH4y8=
+github.com/IBM/vpc-go-sdk v0.21.0 h1:yBvhY0GM6Vpud7JpM1gqry6+4exbd4tfE0xIF8rTwaU=
+github.com/IBM/vpc-go-sdk v0.21.0/go.mod h1:YPyIfI+/qhPqlYp+I7dyx2U1GLcXgp/jzVvsZfUH4y8=
 github.com/Logicalis/asn1 v0.0.0-20190312173541-d60463189a56 h1:vuquMR410psHNax14XKNWa0Ae/kYgWJcXi0IFuX60N0=
 github.com/Logicalis/asn1 v0.0.0-20190312173541-d60463189a56/go.mod h1:Zb3OT4l0mf7P/GOs2w2Ilj5sdm5Whoq3pa24dAEBHFc=
 github.com/Microsoft/go-winio v0.4.14/go.mod h1:qXqCSQ3Xa7+6tgxaGTIe4Kpcdsi+P8jBhyzoq1bpyYA=
@@ -639,6 +642,7 @@ github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81P
 github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+github.com/stretchr/testify v1.7.1 h1:5TQK59W5E3v0r2duFAb7P95B6hEeOyEnHRa8MjYSMTY=
 github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/tidwall/pretty v1.0.0 h1:HsD+QiTn7sK6flMKIvNmpqz1qrpP3Ps6jOKIKMooyg4=
 github.com/tidwall/pretty v1.0.0/go.mod h1:XNkn88O1ChpSDQmQeStsy+sBenx6DDtFZJxhVysOjyk=
@@ -802,7 +806,6 @@ golang.org/x/sys v0.0.0-20210423082822-04245dca01da/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20210502180810-71e4cd670f79/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20211216021012-1d35b9e2eb4e/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.0.0-20220114195835-da31bd327af9 h1:XfKQ4OlFl8okEOr5UvAqFRVj8pY/4yfcXrddB8qAbU0=
 golang.org/x/sys v0.0.0-20220114195835-da31bd327af9/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220330033206-e17cdc41300f h1:rlezHXNlxYWvBCzNses9Dlc7nGFaNMJeqLolcmQSSZY=
 golang.org/x/sys v0.0.0-20220330033206-e17cdc41300f/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=

--- a/ibm/provider/provider.go
+++ b/ibm/provider/provider.go
@@ -356,6 +356,12 @@ func Provider() *schema.Provider {
 			"ibm_iam_trusted_profiles":              iamidentity.DataSourceIBMIamTrustedProfiles(),
 			"ibm_iam_trusted_profile_policy":        iampolicy.DataSourceIBMIAMTrustedProfilePolicy(),
 
+			//backup as Service
+			"ibm_is_backup_policy":       vpc.DataSourceIBMIsBackupPolicy(),
+			"ibm_is_backup_policies":     vpc.DataSourceIBMIsBackupPolicies(),
+			"ibm_is_backup_policy_plan":  vpc.DataSourceIBMIsBackupPolicyPlan(),
+			"ibm_is_backup_policy_plans": vpc.DataSourceIBMIsBackupPolicyPlans(),
+
 			// bare_metal_server
 			"ibm_is_bare_metal_server_disk":                           vpc.DataSourceIBMIsBareMetalServerDisk(),
 			"ibm_is_bare_metal_server_disks":                          vpc.DataSourceIBMIsBareMetalServerDisks(),
@@ -835,6 +841,9 @@ func Provider() *schema.Provider {
 			"ibm_iam_trusted_profile_policy":            iampolicy.ResourceIBMIAMTrustedProfilePolicy(),
 			"ibm_ipsec_vpn":                             classicinfrastructure.ResourceIBMIPSecVPN(),
 
+			"ibm_is_backup_policy":      vpc.ResourceIBMIsBackupPolicy(),
+			"ibm_is_backup_policy_plan": vpc.ResourceIBMIsBackupPolicyPlan(),
+
 			// bare_metal_server
 			"ibm_is_bare_metal_server_action":                        vpc.ResourceIBMIsBareMetalServerAction(),
 			"ibm_is_bare_metal_server_disk":                          vpc.ResourceIBMIsBareMetalServerDisk(),
@@ -1150,6 +1159,9 @@ func Validator() validate.ValidatorDict {
 				"ibm_hpcs_keystore":               hpcs.ResourceIbmKeystoreValidator(),
 				"ibm_hpcs_key_template":           hpcs.ResourceIbmKeyTemplateValidator(),
 				"ibm_hpcs_vault":                  hpcs.ResourceIbmVaultValidator(),
+
+				"ibm_is_backup_policy":      vpc.ResourceIBMIsBackupPolicyValidator(),
+				"ibm_is_backup_policy_plan": vpc.ResourceIBMIsBackupPolicyPlanValidator(),
 
 				// bare_metal_server
 				"ibm_is_bare_metal_server_disk":              vpc.ResourceIBMIsBareMetalServerDiskValidator(),

--- a/ibm/service/vpc/data_source_ibm_is_backup_policies.go
+++ b/ibm/service/vpc/data_source_ibm_is_backup_policies.go
@@ -1,0 +1,357 @@
+// Copyright IBM Corp. 2021 All Rights Reserved.
+// Licensed under the Mozilla Public License v2.0
+
+package vpc
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"time"
+
+	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/flex"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/IBM/vpc-go-sdk/vpcv1"
+)
+
+func DataSourceIBMIsBackupPolicies() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceIBMIsBackupPoliciesRead,
+
+		Schema: map[string]*schema.Schema{
+			"resource_group": {
+				Type:        schema.TypeString,
+				Description: "Filters the collection to resources in the resource group with the specified identifier",
+				Optional:    true,
+			},
+			"name": {
+				Type:        schema.TypeString,
+				Description: "Filters the collection to resources with the exact specified name",
+				Optional:    true,
+			},
+			"tag": {
+				Type:        schema.TypeString,
+				Description: "Filters the collection to resources with the exact tag value",
+				Optional:    true,
+			},
+
+			"backup_policies": &schema.Schema{
+				Type:        schema.TypeList,
+				Computed:    true,
+				Description: "Collection of backup policies.",
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"created_at": &schema.Schema{
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "The date and time that the backup policy was created.",
+						},
+						"crn": &schema.Schema{
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "The CRN for this backup policy.",
+						},
+						"href": &schema.Schema{
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "The URL for this backup policy.",
+						},
+						"id": &schema.Schema{
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "The unique identifier for this backup policy.",
+						},
+						"lifecycle_state": &schema.Schema{
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "The lifecycle state of the backup policy.",
+						},
+						"last_job_completed_at": &schema.Schema{
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "The date and time that the most recent job for this backup policy completed.",
+						},
+						"match_resource_types": &schema.Schema{
+							Type:        schema.TypeList,
+							Computed:    true,
+							Description: "A resource type this backup policy applies to. Resources that have both a matching type and a matching user tag will be subject to the backup policy.",
+							Elem: &schema.Schema{
+								Type: schema.TypeString,
+							},
+						},
+						"match_user_tags": &schema.Schema{
+							Type:        schema.TypeList,
+							Computed:    true,
+							Description: "The user tags this backup policy applies to. Resources that have both a matching user tag and a matching type will be subject to the backup policy.",
+							Elem: &schema.Schema{
+								Type: schema.TypeString,
+							},
+						},
+						"name": &schema.Schema{
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "The unique user-defined name for this backup policy.",
+						},
+						"plans": &schema.Schema{
+							Type:        schema.TypeList,
+							Computed:    true,
+							Description: "The plans for the backup policy.",
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"deleted": &schema.Schema{
+										Type:        schema.TypeList,
+										Computed:    true,
+										Description: "If present, this property indicates the referenced resource has been deleted and providessome supplementary information.",
+										Elem: &schema.Resource{
+											Schema: map[string]*schema.Schema{
+												"more_info": &schema.Schema{
+													Type:        schema.TypeString,
+													Computed:    true,
+													Description: "Link to documentation about deleted resources.",
+												},
+											},
+										},
+									},
+									"href": &schema.Schema{
+										Type:        schema.TypeString,
+										Computed:    true,
+										Description: "The URL for this backup policy plan.",
+									},
+									"id": &schema.Schema{
+										Type:        schema.TypeString,
+										Computed:    true,
+										Description: "The unique identifier for this backup policy plan.",
+									},
+									"name": &schema.Schema{
+										Type:        schema.TypeString,
+										Computed:    true,
+										Description: "The unique user-defined name for this backup policy plan.",
+									},
+									"resource_type": &schema.Schema{
+										Type:        schema.TypeString,
+										Computed:    true,
+										Description: "The type of resource referenced.",
+									},
+								},
+							},
+						},
+						"resource_group": &schema.Schema{
+							Type:        schema.TypeList,
+							Computed:    true,
+							Description: "The resource group for this backup policy.",
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"href": &schema.Schema{
+										Type:        schema.TypeString,
+										Computed:    true,
+										Description: "The URL for this resource group.",
+									},
+									"id": &schema.Schema{
+										Type:        schema.TypeString,
+										Computed:    true,
+										Description: "The unique identifier for this resource group.",
+									},
+									"name": &schema.Schema{
+										Type:        schema.TypeString,
+										Computed:    true,
+										Description: "The user-defined name for this resource group.",
+									},
+								},
+							},
+						},
+						"resource_type": &schema.Schema{
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "The type of resource referenced.",
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func dataSourceIBMIsBackupPoliciesRead(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	sess, err := vpcClient(meta)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	start := ""
+	matchBackupPolicies := []vpcv1.BackupPolicy{}
+
+	var resourceGroup string
+	if v, ok := d.GetOk("resource_group"); ok {
+		resourceGroup = v.(string)
+	}
+
+	var name string
+	if v, ok := d.GetOk("name"); ok {
+		name = v.(string)
+	}
+
+	var tag string
+	if v, ok := d.GetOk("tag"); ok {
+		tag = v.(string)
+	}
+
+	for {
+		listBackupPoliciesOptions := &vpcv1.ListBackupPoliciesOptions{}
+		if start != "" {
+			listBackupPoliciesOptions.Start = &start
+		}
+		if resourceGroup != "" {
+			listBackupPoliciesOptions.SetResourceGroupID(resourceGroup)
+		}
+		if name != "" {
+			listBackupPoliciesOptions.SetName(name)
+		}
+		if tag != "" {
+			listBackupPoliciesOptions.SetTag(tag)
+		}
+		backupPolicyCollection, response, err := sess.ListBackupPoliciesWithContext(context, listBackupPoliciesOptions)
+		if err != nil {
+			log.Printf("[DEBUG] ListBackupPoliciesWithContext failed %s\n%s", err, response)
+			return diag.FromErr(fmt.Errorf("[ERROR] ListBackupPoliciesWithContext failed %s\n%s", err, response))
+		}
+		if backupPolicyCollection != nil && *backupPolicyCollection.TotalCount == int64(0) {
+			break
+		}
+		start = flex.GetNext(backupPolicyCollection.Next)
+		matchBackupPolicies = append(matchBackupPolicies, backupPolicyCollection.BackupPolicies...)
+		if start == "" {
+			break
+		}
+
+	}
+	if len(matchBackupPolicies) == 0 {
+		return diag.FromErr(fmt.Errorf("[ERROR] no BackupPolicies found"))
+	}
+
+	d.SetId(dataSourceIBMIsBackupPoliciesID(d))
+
+	if matchBackupPolicies != nil {
+		err = d.Set("backup_policies", dataSourceBackupPolicyCollectionFlattenBackupPolicies(matchBackupPolicies))
+		if err != nil {
+			return diag.FromErr(fmt.Errorf("[ERROR] Error setting backup_policies %s", err))
+		}
+	}
+
+	return nil
+}
+
+// dataSourceIBMIsBackupPoliciesID returns a reasonable ID for the list.
+func dataSourceIBMIsBackupPoliciesID(d *schema.ResourceData) string {
+	return time.Now().UTC().String()
+}
+
+func dataSourceBackupPolicyCollectionFlattenBackupPolicies(result []vpcv1.BackupPolicy) (backupPolicies []map[string]interface{}) {
+	for _, backupPoliciesItem := range result {
+		backupPolicies = append(backupPolicies, dataSourceBackupPolicyCollectionBackupPoliciesToMap(backupPoliciesItem))
+	}
+
+	return backupPolicies
+}
+
+func dataSourceBackupPolicyCollectionBackupPoliciesToMap(backupPoliciesItem vpcv1.BackupPolicy) (backupPoliciesMap map[string]interface{}) {
+	backupPoliciesMap = map[string]interface{}{}
+
+	if backupPoliciesItem.CreatedAt != nil {
+		backupPoliciesMap["created_at"] = backupPoliciesItem.CreatedAt.String()
+	}
+	if backupPoliciesItem.CRN != nil {
+		backupPoliciesMap["crn"] = backupPoliciesItem.CRN
+	}
+	if backupPoliciesItem.Href != nil {
+		backupPoliciesMap["href"] = backupPoliciesItem.Href
+	}
+	if backupPoliciesItem.ID != nil {
+		backupPoliciesMap["id"] = backupPoliciesItem.ID
+	}
+	if backupPoliciesItem.LifecycleState != nil {
+		backupPoliciesMap["lifecycle_state"] = backupPoliciesItem.LifecycleState
+	}
+	if backupPoliciesItem.LastJobCompletedAt != nil {
+		backupPoliciesMap["last_job_completed_at"] = flex.DateTimeToString(backupPoliciesItem.LastJobCompletedAt)
+	}
+	if backupPoliciesItem.MatchResourceTypes != nil {
+		backupPoliciesMap["match_resource_types"] = backupPoliciesItem.MatchResourceTypes
+	}
+	if backupPoliciesItem.MatchUserTags != nil {
+		backupPoliciesMap["match_user_tags"] = backupPoliciesItem.MatchUserTags
+	}
+	if backupPoliciesItem.Name != nil {
+		backupPoliciesMap["name"] = backupPoliciesItem.Name
+	}
+	if backupPoliciesItem.Plans != nil {
+		plansList := []map[string]interface{}{}
+		for _, plansItem := range backupPoliciesItem.Plans {
+			plansList = append(plansList, dataSourceBackupPolicyCollectionBackupPoliciesPlansToMap(plansItem))
+		}
+		backupPoliciesMap["plans"] = plansList
+	}
+	if backupPoliciesItem.ResourceGroup != nil {
+		resourceGroupList := []map[string]interface{}{}
+		resourceGroupMap := dataSourceBackupPolicyCollectionBackupPoliciesResourceGroupToMap(*backupPoliciesItem.ResourceGroup)
+		resourceGroupList = append(resourceGroupList, resourceGroupMap)
+		backupPoliciesMap["resource_group"] = resourceGroupList
+	}
+	if backupPoliciesItem.ResourceType != nil {
+		backupPoliciesMap["resource_type"] = backupPoliciesItem.ResourceType
+	}
+
+	return backupPoliciesMap
+}
+
+func dataSourceBackupPolicyCollectionBackupPoliciesPlansToMap(plansItem vpcv1.BackupPolicyPlanReference) (plansMap map[string]interface{}) {
+	plansMap = map[string]interface{}{}
+
+	if plansItem.Deleted != nil {
+		deletedList := []map[string]interface{}{}
+		deletedMap := dataSourceBackupPolicyCollectionPlansDeletedToMap(*plansItem.Deleted)
+		deletedList = append(deletedList, deletedMap)
+		plansMap["deleted"] = deletedList
+	}
+	if plansItem.Href != nil {
+		plansMap["href"] = plansItem.Href
+	}
+	if plansItem.ID != nil {
+		plansMap["id"] = plansItem.ID
+	}
+	if plansItem.Name != nil {
+		plansMap["name"] = plansItem.Name
+	}
+	if plansItem.ResourceType != nil {
+		plansMap["resource_type"] = plansItem.ResourceType
+	}
+
+	return plansMap
+}
+
+func dataSourceBackupPolicyCollectionPlansDeletedToMap(deletedItem vpcv1.BackupPolicyPlanReferenceDeleted) (deletedMap map[string]interface{}) {
+	deletedMap = map[string]interface{}{}
+
+	if deletedItem.MoreInfo != nil {
+		deletedMap["more_info"] = deletedItem.MoreInfo
+	}
+
+	return deletedMap
+}
+
+func dataSourceBackupPolicyCollectionBackupPoliciesResourceGroupToMap(resourceGroupItem vpcv1.ResourceGroupReference) (resourceGroupMap map[string]interface{}) {
+	resourceGroupMap = map[string]interface{}{}
+
+	if resourceGroupItem.Href != nil {
+		resourceGroupMap["href"] = resourceGroupItem.Href
+	}
+	if resourceGroupItem.ID != nil {
+		resourceGroupMap["id"] = resourceGroupItem.ID
+	}
+	if resourceGroupItem.Name != nil {
+		resourceGroupMap["name"] = resourceGroupItem.Name
+	}
+
+	return resourceGroupMap
+}

--- a/ibm/service/vpc/data_source_ibm_is_backup_policies_test.go
+++ b/ibm/service/vpc/data_source_ibm_is_backup_policies_test.go
@@ -1,0 +1,63 @@
+// Copyright IBM Corp. 2021 All Rights Reserved.
+// Licensed under the Mozilla Public License v2.0
+
+package vpc_test
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	acc "github.com/IBM-Cloud/terraform-provider-ibm/ibm/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+func TestAccIBMIsBackupPoliciesDataSourceBasic(t *testing.T) {
+	vpcname := fmt.Sprintf("tf-vpc-%d", acctest.RandIntRange(10, 100))
+	name := fmt.Sprintf("tf-instnace-%d", acctest.RandIntRange(10, 100))
+	subnetname := fmt.Sprintf("tf-subnet-%d", acctest.RandIntRange(10, 100))
+	sshname := fmt.Sprintf("tf-ssh-%d", acctest.RandIntRange(10, 100))
+	volname := fmt.Sprintf("tf-vol-%d", acctest.RandIntRange(10, 100))
+	bakupPolicyName := fmt.Sprintf("tfbakuppolicyname%d", acctest.RandIntRange(10, 100))
+	bakupPolicyPlanName := fmt.Sprintf("tfbakuppolicyplanname%d", acctest.RandIntRange(10, 100))
+	cronSpec := strings.TrimSpace(strconv.Itoa(time.Now().UTC().Minute()) + " " + strconv.Itoa(time.Now().UTC().Hour()) + " " + "*" + " " + "*" + " " + "*")
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { acc.TestAccPreCheck(t) },
+		Providers: acc.TestAccProviders,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccCheckIBMIsBackupPoliciesDataSourceConfigBasic(bakupPolicyName, vpcname, subnetname, sshname, volname, name, cronSpec, bakupPolicyPlanName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet("data.ibm_is_backup_policies.is_backup_policies", "id"),
+					resource.TestCheckResourceAttrSet("data.ibm_is_backup_policies.is_backup_policies", "backup_policies.#"),
+					resource.TestCheckResourceAttrSet("data.ibm_is_backup_policies.is_backup_policies", "backup_policies.0.created_at"),
+					resource.TestCheckResourceAttrSet("data.ibm_is_backup_policies.is_backup_policies", "backup_policies.0.crn"),
+					resource.TestCheckResourceAttrSet("data.ibm_is_backup_policies.is_backup_policies", "backup_policies.0.href"),
+					resource.TestCheckResourceAttrSet("data.ibm_is_backup_policies.is_backup_policies", "backup_policies.0.lifecycle_state"),
+					resource.TestCheckResourceAttrSet("data.ibm_is_backup_policies.is_backup_policies", "backup_policies.0.match_resource_types.#"),
+					resource.TestCheckResourceAttrSet("data.ibm_is_backup_policies.is_backup_policies", "backup_policies.0.name"),
+					resource.TestCheckResourceAttrSet("data.ibm_is_backup_policies.is_backup_policies", "backup_policies.0.resource_group.#"),
+					resource.TestCheckResourceAttrSet("data.ibm_is_backup_policies.is_backup_policies", "backup_policies.0.resource_type"),
+					resource.TestCheckResourceAttrSet("data.ibm_is_backup_policies.is_backup_policies", "backup_policies.0.plans.0.deleted.#"),
+					resource.TestCheckResourceAttrSet("data.ibm_is_backup_policies.is_backup_policies", "backup_policies.0.plans.0.href"),
+					resource.TestCheckResourceAttrSet("data.ibm_is_backup_policies.is_backup_policies", "backup_policies.0.plans.0.id"),
+					resource.TestCheckResourceAttrSet("data.ibm_is_backup_policies.is_backup_policies", "backup_policies.0.plans.0.name"),
+					resource.TestCheckResourceAttrSet("data.ibm_is_backup_policies.is_backup_policies", "backup_policies.0.plans.0.resource_type"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckIBMIsBackupPoliciesDataSourceConfigBasic(backupPolicyName, vpcname, subnetname, sshname, volName, name, cronSpec, bakupPolicyPlanName string) string {
+
+	return testAccCheckIBMIsBackupPolicyPlanConfigBasic(backupPolicyName, vpcname, subnetname, sshname, volName, name, cronSpec, bakupPolicyPlanName) + fmt.Sprintf(`
+		data "ibm_is_backup_policies" "is_backup_policies" {
+			depends_on  = [ibm_is_backup_policy_plan.is_backup_policy_plan]
+		}
+	`)
+}

--- a/ibm/service/vpc/data_source_ibm_is_backup_policy.go
+++ b/ibm/service/vpc/data_source_ibm_is_backup_policy.go
@@ -1,0 +1,334 @@
+// Copyright IBM Corp. 2021 All Rights Reserved.
+// Licensed under the Mozilla Public License v2.0
+
+package vpc
+
+import (
+	"context"
+	"fmt"
+	"log"
+
+	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/flex"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/IBM/vpc-go-sdk/vpcv1"
+)
+
+func DataSourceIBMIsBackupPolicy() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceIBMIsBackupPolicyRead,
+
+		Schema: map[string]*schema.Schema{
+
+			"identifier": &schema.Schema{
+				Type:         schema.TypeString,
+				Optional:     true,
+				ExactlyOneOf: []string{"name", "identifier"},
+				Description:  "The backup policy identifier.",
+			},
+
+			"name": {
+				Type:         schema.TypeString,
+				Computed:     true,
+				Optional:     true,
+				ExactlyOneOf: []string{"name", "identifier"},
+				Description:  "The unique user-defined name for this backup policy.",
+			},
+
+			"created_at": &schema.Schema{
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The date and time that the backup policy was created.",
+			},
+			"crn": &schema.Schema{
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The CRN for this backup policy.",
+			},
+			"href": &schema.Schema{
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The URL for this backup policy.",
+			},
+			"last_job_completed_at": &schema.Schema{
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The date and time that the most recent job for this backup policy completed.",
+			},
+			"lifecycle_state": &schema.Schema{
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The lifecycle state of the backup policy.",
+			},
+			"match_resource_types": &schema.Schema{
+				Type:        schema.TypeList,
+				Computed:    true,
+				Description: "A resource type this backup policy applies to. Resources that have both a matching type and a matching user tag will be subject to the backup policy.",
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
+			},
+			"match_user_tags": &schema.Schema{
+				Type:        schema.TypeList,
+				Computed:    true,
+				Description: "The user tags this backup policy applies to. Resources that have both a matching user tag and a matching type will be subject to the backup policy.",
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
+			},
+			"plans": &schema.Schema{
+				Type:        schema.TypeList,
+				Computed:    true,
+				Description: "The plans for the backup policy.",
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"deleted": &schema.Schema{
+							Type:        schema.TypeList,
+							Computed:    true,
+							Description: "If present, this property indicates the referenced resource has been deleted and providessome supplementary information.",
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"more_info": &schema.Schema{
+										Type:        schema.TypeString,
+										Computed:    true,
+										Description: "Link to documentation about deleted resources.",
+									},
+								},
+							},
+						},
+						"href": &schema.Schema{
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "The URL for this backup policy plan.",
+						},
+						"id": &schema.Schema{
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "The unique identifier for this backup policy plan.",
+						},
+						"name": &schema.Schema{
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "The unique user-defined name for this backup policy plan.",
+						},
+						"resource_type": &schema.Schema{
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "The type of resource referenced.",
+						},
+					},
+				},
+			},
+			"resource_group": &schema.Schema{
+				Type:        schema.TypeList,
+				Computed:    true,
+				Description: "The resource group for this backup policy.",
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"href": &schema.Schema{
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "The URL for this resource group.",
+						},
+						"id": &schema.Schema{
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "The unique identifier for this resource group.",
+						},
+						"name": &schema.Schema{
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "The user-defined name for this resource group.",
+						},
+					},
+				},
+			},
+			"resource_type": &schema.Schema{
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The type of resource referenced.",
+			},
+		},
+	}
+}
+
+func dataSourceIBMIsBackupPolicyRead(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	sess, err := vpcClient(meta)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+	var backupPolicy *vpcv1.BackupPolicy
+
+	if v, ok := d.GetOk("identifier"); ok {
+
+		id := v.(string)
+		getBackupPolicyOptions := &vpcv1.GetBackupPolicyOptions{}
+		getBackupPolicyOptions.SetID(id)
+		backupPolicyInfo, response, err := sess.GetBackupPolicyWithContext(context, getBackupPolicyOptions)
+		if err != nil {
+			log.Printf("[DEBUG] GetBackupPolicyWithContext failed %s\n%s", err, response)
+			return diag.FromErr(fmt.Errorf("[ERROR] GetBackupPolicyWithContext failed %s\n%s", err, response))
+		}
+		backupPolicy = backupPolicyInfo
+
+	} else if v, ok := d.GetOk("name"); ok {
+
+		name := v.(string)
+		start := ""
+		allrecs := []vpcv1.BackupPolicy{}
+		for {
+			listBackupPoliciesOptions := &vpcv1.ListBackupPoliciesOptions{}
+			if start != "" {
+				listBackupPoliciesOptions.Start = &start
+			}
+			backupPolicyCollection, response, err := sess.ListBackupPoliciesWithContext(context, listBackupPoliciesOptions)
+			if err != nil {
+				log.Printf("[DEBUG] ListBackupPoliciesWithContext failed %s\n%s", err, response)
+				return diag.FromErr(fmt.Errorf("[ERROR] ListBackupPoliciesWithContext failed %s\n%s", err, response))
+			}
+			if backupPolicyCollection != nil && *backupPolicyCollection.TotalCount == int64(0) {
+				break
+			}
+			start = flex.GetNext(backupPolicyCollection.Next)
+			allrecs = append(allrecs, backupPolicyCollection.BackupPolicies...)
+			if start == "" {
+				break
+			}
+		}
+		for _, backupPolicyInfo := range allrecs {
+			if *backupPolicyInfo.Name == name {
+				backupPolicy = &backupPolicyInfo
+				break
+			}
+		}
+		if backupPolicy == nil {
+			return diag.FromErr(fmt.Errorf("[ERROR] No backup policy found with name (%s)", name))
+		}
+	}
+
+	d.SetId(*backupPolicy.ID)
+
+	if err = d.Set("created_at", backupPolicy.CreatedAt.String()); err != nil {
+		return diag.FromErr(fmt.Errorf("[ERROR] Error setting created_at: %s", err))
+	}
+	if err = d.Set("crn", backupPolicy.CRN); err != nil {
+		return diag.FromErr(fmt.Errorf("[ERROR] Error setting crn: %s", err))
+	}
+	if err = d.Set("href", backupPolicy.Href); err != nil {
+		return diag.FromErr(fmt.Errorf("[ERROR] Error setting href: %s", err))
+	}
+	if backupPolicy.LastJobCompletedAt != nil {
+		if err = d.Set("last_job_completed_at", backupPolicy.LastJobCompletedAt.String()); err != nil {
+			return diag.FromErr(fmt.Errorf("[ERROR] Error setting last_job_completed_at: %s", err))
+		}
+	}
+	if err = d.Set("lifecycle_state", backupPolicy.LifecycleState); err != nil {
+		return diag.FromErr(fmt.Errorf("[ERROR] Error setting lifecycle_state: %s", err))
+	}
+	if err = d.Set("name", backupPolicy.Name); err != nil {
+		return diag.FromErr(fmt.Errorf("[ERROR] Error setting name: %s", err))
+	}
+
+	if backupPolicy.Plans != nil {
+		err = d.Set("plans", dataSourceBackupPolicyFlattenPlans(backupPolicy.Plans))
+		if err != nil {
+			return diag.FromErr(fmt.Errorf("[ERROR] Error setting plans %s", err))
+		}
+	}
+
+	matchResourceType := make([]string, 0)
+	if backupPolicy.MatchResourceTypes != nil {
+		for _, matchResourceTyp := range backupPolicy.MatchResourceTypes {
+			matchResourceType = append(matchResourceType, matchResourceTyp)
+		}
+	}
+	d.Set("match_resource_types", matchResourceType)
+
+	matchUserTags := make([]string, 0)
+	if backupPolicy.MatchUserTags != nil {
+		for _, matchUserTag := range backupPolicy.MatchUserTags {
+			matchUserTags = append(matchUserTags, matchUserTag)
+		}
+	}
+	d.Set("match_user_tags", matchUserTags)
+
+	if backupPolicy.ResourceGroup != nil {
+		err = d.Set("resource_group", dataSourceBackupPolicyFlattenResourceGroup(*backupPolicy.ResourceGroup))
+		if err != nil {
+			return diag.FromErr(fmt.Errorf("[ERROR] Error setting resource_group %s", err))
+		}
+	}
+	if err = d.Set("resource_type", backupPolicy.ResourceType); err != nil {
+		return diag.FromErr(fmt.Errorf("[ERROR] Error setting resource_type: %s", err))
+	}
+
+	return nil
+}
+
+func dataSourceBackupPolicyFlattenPlans(result []vpcv1.BackupPolicyPlanReference) (plans []map[string]interface{}) {
+	for _, plansItem := range result {
+		plans = append(plans, dataSourceBackupPolicyPlansToMap(plansItem))
+	}
+
+	return plans
+}
+
+func dataSourceBackupPolicyPlansToMap(plansItem vpcv1.BackupPolicyPlanReference) (plansMap map[string]interface{}) {
+	plansMap = map[string]interface{}{}
+
+	if plansItem.Deleted != nil {
+		deletedList := []map[string]interface{}{}
+		deletedMap := dataSourceBackupPolicyPlansDeletedToMap(*plansItem.Deleted)
+		deletedList = append(deletedList, deletedMap)
+		plansMap["deleted"] = deletedList
+	}
+	if plansItem.Href != nil {
+		plansMap["href"] = plansItem.Href
+	}
+	if plansItem.ID != nil {
+		plansMap["id"] = plansItem.ID
+	}
+	if plansItem.Name != nil {
+		plansMap["name"] = plansItem.Name
+	}
+	if plansItem.ResourceType != nil {
+		plansMap["resource_type"] = plansItem.ResourceType
+	}
+
+	return plansMap
+}
+
+func dataSourceBackupPolicyPlansDeletedToMap(deletedItem vpcv1.BackupPolicyPlanReferenceDeleted) (deletedMap map[string]interface{}) {
+	deletedMap = map[string]interface{}{}
+
+	if deletedItem.MoreInfo != nil {
+		deletedMap["more_info"] = deletedItem.MoreInfo
+	}
+
+	return deletedMap
+}
+
+func dataSourceBackupPolicyFlattenResourceGroup(result vpcv1.ResourceGroupReference) (finalList []map[string]interface{}) {
+	finalList = []map[string]interface{}{}
+	finalMap := dataSourceBackupPolicyResourceGroupToMap(result)
+	finalList = append(finalList, finalMap)
+
+	return finalList
+}
+
+func dataSourceBackupPolicyResourceGroupToMap(resourceGroupItem vpcv1.ResourceGroupReference) (resourceGroupMap map[string]interface{}) {
+	resourceGroupMap = map[string]interface{}{}
+
+	if resourceGroupItem.Href != nil {
+		resourceGroupMap["href"] = resourceGroupItem.Href
+	}
+	if resourceGroupItem.ID != nil {
+		resourceGroupMap["id"] = resourceGroupItem.ID
+	}
+	if resourceGroupItem.Name != nil {
+		resourceGroupMap["name"] = resourceGroupItem.Name
+	}
+
+	return resourceGroupMap
+}

--- a/ibm/service/vpc/data_source_ibm_is_backup_policy_plan.go
+++ b/ibm/service/vpc/data_source_ibm_is_backup_policy_plan.go
@@ -1,0 +1,208 @@
+// Copyright IBM Corp. 2021 All Rights Reserved.
+// Licensed under the Mozilla Public License v2.0
+
+package vpc
+
+import (
+	"context"
+	"fmt"
+	"log"
+
+	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/flex"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/IBM/vpc-go-sdk/vpcv1"
+)
+
+func DataSourceIBMIsBackupPolicyPlan() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceIBMIsBackupPolicyPlanRead,
+
+		Schema: map[string]*schema.Schema{
+			"backup_policy_id": &schema.Schema{
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "The backup policy identifier.",
+			},
+			"identifier": &schema.Schema{
+				Type:         schema.TypeString,
+				Optional:     true,
+				ExactlyOneOf: []string{"name", "identifier"},
+				Description:  "The backup policy plan identifier.",
+			},
+			"name": {
+				Type:         schema.TypeString,
+				Computed:     true,
+				Optional:     true,
+				ExactlyOneOf: []string{"name", "identifier"},
+				Description:  "The unique user-defined name for this backup policy plan.",
+			},
+			"active": &schema.Schema{
+				Type:        schema.TypeBool,
+				Computed:    true,
+				Description: "Indicates whether the plan is active.",
+			},
+			"attach_user_tags": &schema.Schema{
+				Type:        schema.TypeList,
+				Computed:    true,
+				Description: "User tags to attach to each resource created by this plan.",
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
+			},
+			"copy_user_tags": &schema.Schema{
+				Type:        schema.TypeBool,
+				Computed:    true,
+				Description: "Indicates whether to copy the source's user tags to the created resource.",
+			},
+			"created_at": &schema.Schema{
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The date and time that the backup policy plan was created.",
+			},
+			"cron_spec": &schema.Schema{
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The cron specification for the backup schedule.",
+			},
+			"deletion_trigger": &schema.Schema{
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"delete_after": &schema.Schema{
+							Type:        schema.TypeInt,
+							Optional:    true,
+							Description: "The maximum number of days to keep each backup after creation.",
+						},
+						"delete_over_count": &schema.Schema{
+							Type:        schema.TypeInt,
+							Computed:    true,
+							Description: "The maximum number of recent backups to keep. If absent, there is no maximum.",
+						},
+					},
+				},
+			},
+			"href": &schema.Schema{
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The URL for this backup policy plan.",
+			},
+			"lifecycle_state": &schema.Schema{
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The lifecycle state of this backup policy plan.",
+			},
+			"resource_type": &schema.Schema{
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The type of resource referenced.",
+			},
+		},
+	}
+}
+
+func dataSourceIBMIsBackupPolicyPlanRead(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	sess, err := vpcClient(meta)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+	var backupPolicyPlan *vpcv1.BackupPolicyPlan
+
+	if v, ok := d.GetOk("identifier"); ok {
+		id := v.(string)
+		getBackupPolicyPlanOptions := &vpcv1.GetBackupPolicyPlanOptions{}
+
+		getBackupPolicyPlanOptions.SetBackupPolicyID(d.Get("backup_policy_id").(string))
+		getBackupPolicyPlanOptions.SetID(id)
+
+		backupPolicyPlanInfo, response, err := sess.GetBackupPolicyPlanWithContext(context, getBackupPolicyPlanOptions)
+		if err != nil {
+			log.Printf("[DEBUG] GetBackupPolicyPlanWithContext failed %s\n%s", err, response)
+			return diag.FromErr(fmt.Errorf("[ERROR] GetBackupPolicyPlanWithContext failed %s\n%s", err, response))
+		}
+		backupPolicyPlan = backupPolicyPlanInfo
+	} else if v, ok := d.GetOk("name"); ok {
+
+		name := v.(string)
+		listBackupPolicyPlansOptions := &vpcv1.ListBackupPolicyPlansOptions{}
+
+		listBackupPolicyPlansOptions.SetBackupPolicyID(d.Get("backup_policy_id").(string))
+
+		backupPolicyPlanCollection, response, err := sess.ListBackupPolicyPlansWithContext(context, listBackupPolicyPlansOptions)
+		if err != nil {
+			log.Printf("[DEBUG] ListBackupPolicyPlansWithContext failed %s\n%s", err, response)
+			return diag.FromErr(fmt.Errorf("[ERROR] ListBackupPolicyPlansWithContext failed %s\n%s", err, response))
+		}
+		for _, backupPolicyPlanInfo := range backupPolicyPlanCollection.Plans {
+			if *backupPolicyPlanInfo.Name == name {
+				backupPolicyPlan = &backupPolicyPlanInfo
+				break
+			}
+		}
+		if backupPolicyPlan == nil {
+			return diag.FromErr(fmt.Errorf("[ERROR] No backup policy plan found with name (%s)", name))
+		}
+	}
+
+	d.SetId(*backupPolicyPlan.ID)
+
+	if err = d.Set("active", backupPolicyPlan.Active); err != nil {
+		return diag.FromErr(fmt.Errorf("[ERROR] Error setting active: %s", err))
+	}
+	if err = d.Set("attach_user_tags", backupPolicyPlan.AttachUserTags); err != nil {
+		return diag.FromErr(fmt.Errorf("[ERROR] Error setting attach_user_tags: %s", err))
+	}
+	if err = d.Set("copy_user_tags", backupPolicyPlan.CopyUserTags); err != nil {
+		return diag.FromErr(fmt.Errorf("[ERROR] Error setting copy_user_tags: %s", err))
+	}
+	if err = d.Set("created_at", flex.DateTimeToString(backupPolicyPlan.CreatedAt)); err != nil {
+		return diag.FromErr(fmt.Errorf("[ERROR] Error setting created_at: %s", err))
+	}
+	if err = d.Set("cron_spec", backupPolicyPlan.CronSpec); err != nil {
+		return diag.FromErr(fmt.Errorf("[ERROR] Error setting cron_spec: %s", err))
+	}
+
+	if backupPolicyPlan.DeletionTrigger != nil {
+		err = d.Set("deletion_trigger", dataSourceBackupPolicyPlanFlattenDeletionTrigger(*backupPolicyPlan.DeletionTrigger))
+		if err != nil {
+			return diag.FromErr(fmt.Errorf("[ERROR] Error setting deletion_trigger %s", err))
+		}
+	}
+	if err = d.Set("href", backupPolicyPlan.Href); err != nil {
+		return diag.FromErr(fmt.Errorf("[ERROR] Error setting href: %s", err))
+	}
+	if err = d.Set("lifecycle_state", backupPolicyPlan.LifecycleState); err != nil {
+		return diag.FromErr(fmt.Errorf("[ERROR] Error setting lifecycle_state: %s", err))
+	}
+	if err = d.Set("name", backupPolicyPlan.Name); err != nil {
+		return diag.FromErr(fmt.Errorf("[ERROR] Error setting name: %s", err))
+	}
+	if err = d.Set("resource_type", backupPolicyPlan.ResourceType); err != nil {
+		return diag.FromErr(fmt.Errorf("[ERROR] Error setting resource_type: %s", err))
+	}
+
+	return nil
+}
+
+func dataSourceBackupPolicyPlanFlattenDeletionTrigger(result vpcv1.BackupPolicyPlanDeletionTrigger) (finalList []map[string]interface{}) {
+	finalList = []map[string]interface{}{}
+	finalMap := dataSourceBackupPolicyPlanDeletionTriggerToMap(result)
+	finalList = append(finalList, finalMap)
+
+	return finalList
+}
+
+func dataSourceBackupPolicyPlanDeletionTriggerToMap(deletionTriggerItem vpcv1.BackupPolicyPlanDeletionTrigger) (deletionTriggerMap map[string]interface{}) {
+	deletionTriggerMap = map[string]interface{}{}
+
+	if deletionTriggerItem.DeleteAfter != nil {
+		deletionTriggerMap["delete_after"] = deletionTriggerItem.DeleteAfter
+	}
+	if deletionTriggerItem.DeleteOverCount != nil {
+		deletionTriggerMap["delete_over_count"] = deletionTriggerItem.DeleteOverCount
+	}
+
+	return deletionTriggerMap
+}

--- a/ibm/service/vpc/data_source_ibm_is_backup_policy_plan_test.go
+++ b/ibm/service/vpc/data_source_ibm_is_backup_policy_plan_test.go
@@ -1,0 +1,60 @@
+// Copyright IBM Corp. 2021 All Rights Reserved.
+// Licensed under the Mozilla Public License v2.0
+
+package vpc_test
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	acc "github.com/IBM-Cloud/terraform-provider-ibm/ibm/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+func TestAccIBMIsBackupPolicyPlanDataSourceBasic(t *testing.T) {
+	vpcname := fmt.Sprintf("tf-vpc-%d", acctest.RandIntRange(10, 100))
+	name := fmt.Sprintf("tf-instnace-%d", acctest.RandIntRange(10, 100))
+	subnetname := fmt.Sprintf("tf-subnet-%d", acctest.RandIntRange(10, 100))
+	sshname := fmt.Sprintf("tf-ssh-%d", acctest.RandIntRange(10, 100))
+	volname := fmt.Sprintf("tf-vol-%d", acctest.RandIntRange(10, 100))
+	bakupPolicyName := fmt.Sprintf("tfbakuppolicyname%d", acctest.RandIntRange(10, 100))
+	bakupPolicyPlanName := fmt.Sprintf("tfbakuppolicyplanname%d", acctest.RandIntRange(10, 100))
+	cronSpec := strings.TrimSpace(strconv.Itoa(time.Now().UTC().Minute()) + " " + strconv.Itoa(time.Now().UTC().Hour()) + " " + "*" + " " + "*" + " " + "*")
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { acc.TestAccPreCheck(t) },
+		Providers: acc.TestAccProviders,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccCheckIBMIsBackupPolicyPlanDataSourceConfigBasic(bakupPolicyName, vpcname, subnetname, sshname, volname, name, cronSpec, bakupPolicyPlanName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet("data.ibm_is_backup_policy_plan.is_backup_policy_plan", "id"),
+					resource.TestCheckResourceAttrSet("data.ibm_is_backup_policy_plan.is_backup_policy_plan", "backup_policy_id"),
+					resource.TestCheckResourceAttrSet("data.ibm_is_backup_policy_plan.is_backup_policy_plan", "active"),
+					resource.TestCheckResourceAttrSet("data.ibm_is_backup_policy_plan.is_backup_policy_plan", "attach_user_tags.#"),
+					resource.TestCheckResourceAttrSet("data.ibm_is_backup_policy_plan.is_backup_policy_plan", "copy_user_tags"),
+					resource.TestCheckResourceAttrSet("data.ibm_is_backup_policy_plan.is_backup_policy_plan", "created_at"),
+					resource.TestCheckResourceAttrSet("data.ibm_is_backup_policy_plan.is_backup_policy_plan", "cron_spec"),
+					resource.TestCheckResourceAttrSet("data.ibm_is_backup_policy_plan.is_backup_policy_plan", "deletion_trigger.0.delete_after"),
+					resource.TestCheckResourceAttrSet("data.ibm_is_backup_policy_plan.is_backup_policy_plan", "href"),
+					resource.TestCheckResourceAttrSet("data.ibm_is_backup_policy_plan.is_backup_policy_plan", "lifecycle_state"),
+					resource.TestCheckResourceAttrSet("data.ibm_is_backup_policy_plan.is_backup_policy_plan", "name"),
+					resource.TestCheckResourceAttrSet("data.ibm_is_backup_policy_plan.is_backup_policy_plan", "resource_type"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckIBMIsBackupPolicyPlanDataSourceConfigBasic(backupPolicyName, vpcname, subnetname, sshname, volName, name, cronSpec, bakupPolicyPlanName string) string {
+
+	return testAccCheckIBMIsBackupPolicyPlanConfigBasic(backupPolicyName, vpcname, subnetname, sshname, volName, name, cronSpec, bakupPolicyPlanName) + fmt.Sprintf(`
+		data "ibm_is_backup_policy_plan" "is_backup_policy_plan" {
+			backup_policy_id = ibm_is_backup_policy.is_backup_policy.id
+			identifier = ibm_is_backup_policy_plan.is_backup_policy_plan[0].backup_policy_plan_id
+		}
+	`)
+}

--- a/ibm/service/vpc/data_source_ibm_is_backup_policy_plans.go
+++ b/ibm/service/vpc/data_source_ibm_is_backup_policy_plans.go
@@ -1,0 +1,247 @@
+// Copyright IBM Corp. 2021 All Rights Reserved.
+// Licensed under the Mozilla Public License v2.0
+
+package vpc
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"time"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/IBM/vpc-go-sdk/vpcv1"
+)
+
+func DataSourceIBMIsBackupPolicyPlans() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceIBMIsBackupPolicyPlansRead,
+
+		Schema: map[string]*schema.Schema{
+			"backup_policy_id": &schema.Schema{
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "The backup policy identifier.",
+			},
+			"name": &schema.Schema{
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "The unique user-defined name for this backup policy plan.",
+			},
+			"plans": &schema.Schema{
+				Type:        schema.TypeList,
+				Computed:    true,
+				Description: "Collection of backup policy plans.",
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"active": &schema.Schema{
+							Type:        schema.TypeBool,
+							Computed:    true,
+							Description: "Indicates whether the plan is active.",
+						},
+						"attach_user_tags": &schema.Schema{
+							Type:        schema.TypeList,
+							Computed:    true,
+							Description: "The user tags to attach to backups (snapshots) created by this plan.",
+							Elem: &schema.Schema{
+								Type: schema.TypeString,
+							},
+						},
+						"copy_user_tags": &schema.Schema{
+							Type:        schema.TypeBool,
+							Computed:    true,
+							Description: "Indicates whether to copy the source's user tags to the created backups (snapshots).",
+						},
+						"created_at": &schema.Schema{
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "The date and time that the backup policy plan was created.",
+						},
+						"cron_spec": &schema.Schema{
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "The cron specification for the backup schedule.",
+						},
+						"deletion_trigger": &schema.Schema{
+							Type:     schema.TypeList,
+							Optional: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"delete_after": &schema.Schema{
+										Type:        schema.TypeInt,
+										Optional:    true,
+										Description: "The maximum number of days to keep each backup after creation.",
+									},
+									"delete_over_count": &schema.Schema{
+										Type:        schema.TypeInt,
+										Optional:    true,
+										Description: "The maximum number of recent backups to keep. If absent, there is no maximum.",
+									},
+								},
+							},
+						},
+						"href": &schema.Schema{
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "The URL for this backup policy plan.",
+						},
+						"id": &schema.Schema{
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "The unique identifier for this backup policy plan.",
+						},
+						"lifecycle_state": &schema.Schema{
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "The lifecycle state of this backup policy plan.",
+						},
+						"name": &schema.Schema{
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "The unique user-defined name for this backup policy plan.",
+						},
+						"resource_type": &schema.Schema{
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "The resource type.",
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func dataSourceIBMIsBackupPolicyPlansRead(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	vpcClient, err := vpcClient(meta)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	listBackupPolicyPlansOptions := &vpcv1.ListBackupPolicyPlansOptions{}
+
+	listBackupPolicyPlansOptions.SetBackupPolicyID(d.Get("backup_policy_id").(string))
+
+	backupPolicyPlanCollection, response, err := vpcClient.ListBackupPolicyPlansWithContext(context, listBackupPolicyPlansOptions)
+	if err != nil {
+		log.Printf("[DEBUG] ListBackupPolicyPlansWithContext failed %s\n%s", err, response)
+		return diag.FromErr(fmt.Errorf("[ERROR] ListBackupPolicyPlansWithContext failed %s\n%s", err, response))
+	}
+
+	// Use the provided filter argument and construct a new list with only the requested resource(s)
+	var matchPlans []vpcv1.BackupPolicyPlan
+	var name string
+	var suppliedFilter bool
+
+	if v, ok := d.GetOk("name"); ok {
+		name = v.(string)
+		suppliedFilter = true
+		for _, data := range backupPolicyPlanCollection.Plans {
+			if *data.Name == name {
+				matchPlans = append(matchPlans, data)
+			}
+		}
+		backupPolicyPlanCollection.Plans = matchPlans
+	}
+	if suppliedFilter {
+		if len(backupPolicyPlanCollection.Plans) == 0 {
+			return diag.FromErr(fmt.Errorf("[ERROR] no plans found with name %s", name))
+		}
+		d.SetId(name)
+	} else {
+		d.SetId(dataSourceIBMIsBackupPolicyPlansID(d))
+	}
+
+	if backupPolicyPlanCollection.Plans != nil {
+		err = d.Set("plans", dataSourceBackupPolicyPlanCollectionFlattenPlans(backupPolicyPlanCollection.Plans))
+		if err != nil {
+			return diag.FromErr(fmt.Errorf("[ERROR] Error setting plans %s", err))
+		}
+	}
+
+	return nil
+}
+
+// dataSourceIBMIsBackupPolicyPlansID returns a reasonable ID for the list.
+func dataSourceIBMIsBackupPolicyPlansID(d *schema.ResourceData) string {
+	return time.Now().UTC().String()
+}
+
+func dataSourceBackupPolicyPlanCollectionFlattenPlans(result []vpcv1.BackupPolicyPlan) (plans []map[string]interface{}) {
+	for _, plansItem := range result {
+		plans = append(plans, dataSourceBackupPolicyPlanCollectionPlansToMap(plansItem))
+	}
+
+	return plans
+}
+
+func dataSourceBackupPolicyPlanCollectionPlansToMap(plansItem vpcv1.BackupPolicyPlan) (plansMap map[string]interface{}) {
+	plansMap = map[string]interface{}{}
+
+	if plansItem.Active != nil {
+		plansMap["active"] = plansItem.Active
+	}
+	if plansItem.AttachUserTags != nil {
+		plansMap["attach_user_tags"] = plansItem.AttachUserTags
+	}
+	if plansItem.CopyUserTags != nil {
+		plansMap["copy_user_tags"] = plansItem.CopyUserTags
+	}
+	if plansItem.CreatedAt != nil {
+		plansMap["created_at"] = plansItem.CreatedAt.String()
+	}
+	if plansItem.CronSpec != nil {
+		plansMap["cron_spec"] = plansItem.CronSpec
+	}
+	if plansItem.DeletionTrigger != nil {
+		deletionTriggerList := []map[string]interface{}{}
+		deletionTriggerMap := dataSourceBackupPolicyPlanCollectionPlansDeletionTriggerToMap(*plansItem.DeletionTrigger)
+		deletionTriggerList = append(deletionTriggerList, deletionTriggerMap)
+		plansMap["deletion_trigger"] = deletionTriggerList
+	}
+	if plansItem.Href != nil {
+		plansMap["href"] = plansItem.Href
+	}
+	if plansItem.ID != nil {
+		plansMap["id"] = plansItem.ID
+	}
+	if plansItem.LifecycleState != nil {
+		plansMap["lifecycle_state"] = plansItem.LifecycleState
+	}
+	if plansItem.Name != nil {
+		plansMap["name"] = plansItem.Name
+	}
+	if plansItem.ResourceType != nil {
+		plansMap["resource_type"] = plansItem.ResourceType
+	}
+
+	return plansMap
+}
+
+func dataSourceBackupPolicyPlanCollectionClonePolicyZonesToMap(zonesItem vpcv1.ZoneReference) (zonesMap map[string]interface{}) {
+	zonesMap = map[string]interface{}{}
+
+	if zonesItem.Href != nil {
+		zonesMap["href"] = zonesItem.Href
+	}
+	if zonesItem.Name != nil {
+		zonesMap["name"] = zonesItem.Name
+	}
+
+	return zonesMap
+}
+
+func dataSourceBackupPolicyPlanCollectionPlansDeletionTriggerToMap(deletionTriggerItem vpcv1.BackupPolicyPlanDeletionTrigger) (deletionTriggerMap map[string]interface{}) {
+	deletionTriggerMap = map[string]interface{}{}
+
+	if deletionTriggerItem.DeleteAfter != nil {
+		deletionTriggerMap["delete_after"] = deletionTriggerItem.DeleteAfter
+	}
+	if deletionTriggerItem.DeleteOverCount != nil {
+		deletionTriggerMap["delete_over_count"] = deletionTriggerItem.DeleteOverCount
+	}
+
+	return deletionTriggerMap
+}

--- a/ibm/service/vpc/data_source_ibm_is_backup_policy_plans_test.go
+++ b/ibm/service/vpc/data_source_ibm_is_backup_policy_plans_test.go
@@ -1,0 +1,63 @@
+// Copyright IBM Corp. 2021 All Rights Reserved.
+// Licensed under the Mozilla Public License v2.0
+
+package vpc_test
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	acc "github.com/IBM-Cloud/terraform-provider-ibm/ibm/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+func TestAccIBMIsBackupPolicyPlansDataSourceBasic(t *testing.T) {
+	vpcname := fmt.Sprintf("tf-vpc-%d", acctest.RandIntRange(10, 100))
+	name := fmt.Sprintf("tf-instnace-%d", acctest.RandIntRange(10, 100))
+	subnetname := fmt.Sprintf("tf-subnet-%d", acctest.RandIntRange(10, 100))
+	sshname := fmt.Sprintf("tf-ssh-%d", acctest.RandIntRange(10, 100))
+	volname := fmt.Sprintf("tf-vol-%d", acctest.RandIntRange(10, 100))
+	bakupPolicyName := fmt.Sprintf("tfbakuppolicyname%d", acctest.RandIntRange(10, 100))
+	bakupPolicyPlanName := fmt.Sprintf("tfbakuppolicyplanname%d", acctest.RandIntRange(10, 100))
+	cronSpec := strings.TrimSpace(strconv.Itoa(time.Now().UTC().Minute()) + " " + strconv.Itoa(time.Now().UTC().Hour()) + " " + "*" + " " + "*" + " " + "*")
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { acc.TestAccPreCheck(t) },
+		Providers: acc.TestAccProviders,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccCheckIBMIsBackupPolicyPlansDataSourceConfigBasic(bakupPolicyName, vpcname, subnetname, sshname, volname, name, cronSpec, bakupPolicyPlanName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet("data.ibm_is_backup_policy_plans.is_backup_policy_plans", "id"),
+					resource.TestCheckResourceAttrSet("data.ibm_is_backup_policy_plans.is_backup_policy_plans", "backup_policy_id"),
+					resource.TestCheckResourceAttrSet("data.ibm_is_backup_policy_plans.is_backup_policy_plans", "plans.#"),
+					resource.TestCheckResourceAttrSet("data.ibm_is_backup_policy_plans.is_backup_policy_plans", "plans.0.active"),
+					resource.TestCheckResourceAttrSet("data.ibm_is_backup_policy_plans.is_backup_policy_plans", "plans.0.attach_user_tags.#"),
+					resource.TestCheckResourceAttrSet("data.ibm_is_backup_policy_plans.is_backup_policy_plans", "plans.0.copy_user_tags"),
+					resource.TestCheckResourceAttrSet("data.ibm_is_backup_policy_plans.is_backup_policy_plans", "plans.0.created_at"),
+					resource.TestCheckResourceAttrSet("data.ibm_is_backup_policy_plans.is_backup_policy_plans", "plans.0.cron_spec"),
+					resource.TestCheckResourceAttrSet("data.ibm_is_backup_policy_plans.is_backup_policy_plans", "plans.0.deletion_trigger.0.delete_after"),
+					resource.TestCheckResourceAttrSet("data.ibm_is_backup_policy_plans.is_backup_policy_plans", "plans.0.href"),
+					resource.TestCheckResourceAttrSet("data.ibm_is_backup_policy_plans.is_backup_policy_plans", "plans.0.id"),
+					resource.TestCheckResourceAttrSet("data.ibm_is_backup_policy_plans.is_backup_policy_plans", "plans.0.lifecycle_state"),
+					resource.TestCheckResourceAttrSet("data.ibm_is_backup_policy_plans.is_backup_policy_plans", "plans.0.name"),
+					resource.TestCheckResourceAttrSet("data.ibm_is_backup_policy_plans.is_backup_policy_plans", "plans.0.resource_type"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckIBMIsBackupPolicyPlansDataSourceConfigBasic(backupPolicyName, vpcname, subnetname, sshname, volName, name, cronSpec, bakupPolicyPlanName string) string {
+
+	return testAccCheckIBMIsBackupPolicyPlanConfigBasic(backupPolicyName, vpcname, subnetname, sshname, volName, name, cronSpec, bakupPolicyPlanName) + fmt.Sprintf(`
+		data "ibm_is_backup_policy_plans" "is_backup_policy_plans" {
+			depends_on  = [ibm_is_backup_policy_plan.is_backup_policy_plan]
+			backup_policy_id = ibm_is_backup_policy.is_backup_policy.id
+			name = "%s"
+		}
+	`, bakupPolicyPlanName+"-1")
+}

--- a/ibm/service/vpc/data_source_ibm_is_backup_policy_test.go
+++ b/ibm/service/vpc/data_source_ibm_is_backup_policy_test.go
@@ -1,0 +1,65 @@
+// Copyright IBM Corp. 2021 All Rights Reserved.
+// Licensed under the Mozilla Public License v2.0
+
+package vpc_test
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	acc "github.com/IBM-Cloud/terraform-provider-ibm/ibm/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+func TestAccIBMIsBackupPolicyDataSourceBasic(t *testing.T) {
+	vpcname := fmt.Sprintf("tf-vpc-%d", acctest.RandIntRange(10, 100))
+	name := fmt.Sprintf("tf-instnace-%d", acctest.RandIntRange(10, 100))
+	subnetname := fmt.Sprintf("tf-subnet-%d", acctest.RandIntRange(10, 100))
+	sshname := fmt.Sprintf("tf-ssh-%d", acctest.RandIntRange(10, 100))
+	volname := fmt.Sprintf("tf-vol-%d", acctest.RandIntRange(10, 100))
+	bakupPolicyName := fmt.Sprintf("tfbakuppolicyname%d", acctest.RandIntRange(10, 100))
+	bakupPolicyPlanName := fmt.Sprintf("tfbakuppolicyplanname%d", acctest.RandIntRange(10, 100))
+	cronSpec := strings.TrimSpace(strconv.Itoa(time.Now().UTC().Minute()) + " " + strconv.Itoa(time.Now().UTC().Hour()) + " " + "*" + " " + "*" + " " + "*")
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { acc.TestAccPreCheck(t) },
+		Providers: acc.TestAccProviders,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccCheckIBMIsBackupPolicyDataSourceConfigBasic(bakupPolicyName, vpcname, subnetname, sshname, volname, name, cronSpec, bakupPolicyPlanName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet("data.ibm_is_backup_policy.is_backup_policy", "created_at"),
+					resource.TestCheckResourceAttrSet("data.ibm_is_backup_policy.is_backup_policy", "crn"),
+					resource.TestCheckResourceAttrSet("data.ibm_is_backup_policy.is_backup_policy", "href"),
+					resource.TestCheckResourceAttrSet("data.ibm_is_backup_policy.is_backup_policy", "lifecycle_state"),
+					resource.TestCheckResourceAttrSet("data.ibm_is_backup_policy.is_backup_policy", "match_resource_types.#"),
+					resource.TestCheckResourceAttrSet("data.ibm_is_backup_policy.is_backup_policy", "match_user_tags.#"),
+					resource.TestCheckResourceAttrSet("data.ibm_is_backup_policy.is_backup_policy", "name"),
+					resource.TestCheckResourceAttrSet("data.ibm_is_backup_policy.is_backup_policy", "plans.#"),
+					// resource.TestCheckResourceAttrSet("data.ibm_is_backup_policy.is_backup_policy", "plans.0.href"),
+					resource.TestCheckResourceAttrSet("data.ibm_is_backup_policy.is_backup_policy", "plans.0.id"),
+					resource.TestCheckResourceAttrSet("data.ibm_is_backup_policy.is_backup_policy", "plans.0.name"),
+					// resource.TestCheckResourceAttrSet("data.ibm_is_backup_policy.is_backup_policy", "plans.0.resource_type"),
+					resource.TestCheckResourceAttrSet("data.ibm_is_backup_policy.is_backup_policy", "resource_group.#"),
+					resource.TestCheckResourceAttrSet("data.ibm_is_backup_policy.is_backup_policy", "resource_group.0.href"),
+					resource.TestCheckResourceAttrSet("data.ibm_is_backup_policy.is_backup_policy", "resource_group.0.id"),
+					resource.TestCheckResourceAttrSet("data.ibm_is_backup_policy.is_backup_policy", "resource_group.0.name"),
+					resource.TestCheckResourceAttrSet("data.ibm_is_backup_policy.is_backup_policy", "resource_type"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckIBMIsBackupPolicyDataSourceConfigBasic(backupPolicyName, vpcname, subnetname, sshname, volName, name, cronSpec, bakupPolicyPlanName string) string {
+
+	return testAccCheckIBMIsBackupPolicyPlanConfigBasic(backupPolicyName, vpcname, subnetname, sshname, volName, name, cronSpec, bakupPolicyPlanName) + fmt.Sprintf(`
+		data "ibm_is_backup_policy" "is_backup_policy" {
+			depends_on  = [ibm_is_backup_policy_plan.is_backup_policy_plan]
+			identifier = ibm_is_backup_policy.is_backup_policy.id
+		}
+	`)
+}

--- a/ibm/service/vpc/data_source_ibm_is_snapshot.go
+++ b/ibm/service/vpc/data_source_ibm_is_snapshot.go
@@ -6,6 +6,7 @@ package vpc
 import (
 	"fmt"
 
+	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/flex"
 	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/validate"
 	"github.com/IBM/vpc-go-sdk/vpcv1"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -104,6 +105,58 @@ func DataSourceSnapshot() *schema.Resource {
 				Computed:    true,
 				Description: "The date and time that this snapshot was created",
 			},
+
+			isSnapshotUserTags: {
+				Type:        schema.TypeSet,
+				Computed:    true,
+				Elem:        &schema.Schema{Type: schema.TypeString},
+				Set:         flex.ResourceIBMVPCHash,
+				Description: "User Tags for the snapshot",
+			},
+
+			isSnapshotBackupPolicyPlan: {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Description: "If present, the backup policy plan which created this snapshot.",
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"deleted": &schema.Schema{
+							Type:        schema.TypeList,
+							Computed:    true,
+							Description: "If present, this property indicates the referenced resource has been deleted and provides some supplementary information.",
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"more_info": &schema.Schema{
+										Type:        schema.TypeString,
+										Computed:    true,
+										Description: "Link to documentation about deleted resources.",
+									},
+								},
+							},
+						},
+						"href": &schema.Schema{
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "The URL for this backup policy plan.",
+						},
+						"id": &schema.Schema{
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "The unique identifier for this backup policy plan.",
+						},
+						"name": &schema.Schema{
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "The unique user-defined name for this backup policy plan.",
+						},
+						"resource_type": &schema.Schema{
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "The type of resource referenced",
+						},
+					},
+				},
+			},
 		},
 	}
 }
@@ -142,46 +195,74 @@ func snapshotGetByNameOrID(d *schema.ResourceData, meta interface{}, name, id st
 		return err
 	}
 	if name != "" {
-		listSnapshotOptions := &vpcv1.ListSnapshotsOptions{
-			Name: &name,
+		start := ""
+		allrecs := []vpcv1.Snapshot{}
+		for {
+			listSnapshotOptions := &vpcv1.ListSnapshotsOptions{
+				Name: &name,
+			}
+			if start != "" {
+				listSnapshotOptions.Start = &start
+			}
+			snapshots, response, err := sess.ListSnapshots(listSnapshotOptions)
+			if err != nil {
+				return fmt.Errorf("[ERROR] Error Fetching snapshots %s\n%s", err, response)
+			}
+			start = flex.GetNext(snapshots.Next)
+			allrecs = append(allrecs, snapshots.Snapshots...)
+			if start == "" {
+				break
+			}
 		}
 
-		snapshots, response, err := sess.ListSnapshots(listSnapshotOptions)
-		if err != nil {
-			return fmt.Errorf("[ERROR] Error Fetching snapshots %s\n%s", err, response)
+		for _, snapshot := range allrecs {
+			if *snapshot.Name == name || *snapshot.ID == id {
+				d.SetId(*snapshot.ID)
+				d.Set(isSnapshotName, *snapshot.Name)
+				d.Set(isSnapshotHref, *snapshot.Href)
+				d.Set(isSnapshotCRN, *snapshot.CRN)
+				d.Set(isSnapshotMinCapacity, *snapshot.MinimumCapacity)
+				d.Set(isSnapshotSize, *snapshot.Size)
+				d.Set(isSnapshotEncryption, *snapshot.Encryption)
+				d.Set(isSnapshotLCState, *snapshot.LifecycleState)
+				d.Set(isSnapshotResourceType, *snapshot.ResourceType)
+				d.Set(isSnapshotBootable, *snapshot.Bootable)
+				if snapshot.UserTags != nil {
+					if err = d.Set(isSnapshotUserTags, snapshot.UserTags); err != nil {
+						return fmt.Errorf("Error setting user tags: %s", err)
+					}
+				}
+				if snapshot.ResourceGroup != nil && snapshot.ResourceGroup.ID != nil {
+					d.Set(isSnapshotResourceGroup, *snapshot.ResourceGroup.ID)
+				}
+				if snapshot.SourceVolume != nil && snapshot.SourceVolume.ID != nil {
+					d.Set(isSnapshotSourceVolume, *snapshot.SourceVolume.ID)
+				}
+				if snapshot.SourceImage != nil && snapshot.SourceImage.ID != nil {
+					d.Set(isSnapshotSourceImage, *snapshot.SourceImage.ID)
+				}
+				if snapshot.OperatingSystem != nil && snapshot.OperatingSystem.Name != nil {
+					d.Set(isSnapshotOperatingSystem, *snapshot.OperatingSystem.Name)
+				}
+				backupPolicyPlanList := []map[string]interface{}{}
+				if snapshot.BackupPolicyPlan != nil {
+					backupPolicyPlan := map[string]interface{}{}
+					if snapshot.BackupPolicyPlan.Deleted != nil {
+						snapshotBackupPolicyPlanDeletedMap := map[string]interface{}{}
+						snapshotBackupPolicyPlanDeletedMap["more_info"] = snapshot.BackupPolicyPlan.Deleted.MoreInfo
+						backupPolicyPlan["deleted"] = []map[string]interface{}{snapshotBackupPolicyPlanDeletedMap}
+					}
+					backupPolicyPlan["href"] = snapshot.BackupPolicyPlan.Href
+					backupPolicyPlan["id"] = snapshot.BackupPolicyPlan.ID
+					backupPolicyPlan["name"] = snapshot.BackupPolicyPlan.Name
+					backupPolicyPlan["resource_type"] = snapshot.BackupPolicyPlan.ResourceType
+					backupPolicyPlanList = append(backupPolicyPlanList, backupPolicyPlan)
+				}
+				d.Set(isSnapshotBackupPolicyPlan, backupPolicyPlanList)
+				return nil
+			}
 		}
-		allrecs := snapshots.Snapshots
-
-		if len(allrecs) == 0 {
-			return fmt.Errorf("[ERROR] No snapshot found with name %s", name)
-		}
-		snapshot := allrecs[0]
-		d.SetId(*snapshot.ID)
-		d.Set(isSnapshotName, *snapshot.Name)
-		d.Set(isSnapshotHref, *snapshot.Href)
-		d.Set(isSnapshotCRN, *snapshot.CRN)
-		d.Set(isSnapshotMinCapacity, *snapshot.MinimumCapacity)
-		d.Set(isSnapshotSize, *snapshot.Size)
-		d.Set(isSnapshotEncryption, *snapshot.Encryption)
-		d.Set(isSnapshotLCState, *snapshot.LifecycleState)
-		d.Set(isSnapshotResourceType, *snapshot.ResourceType)
-		d.Set(isSnapshotBootable, *snapshot.Bootable)
-		if snapshot.CapturedAt != nil {
-			d.Set(isSnapshotCapturedAt, (*snapshot.CapturedAt).String())
-		}
-		if snapshot.ResourceGroup != nil && snapshot.ResourceGroup.ID != nil {
-			d.Set(isSnapshotResourceGroup, *snapshot.ResourceGroup.ID)
-		}
-		if snapshot.SourceVolume != nil && snapshot.SourceVolume.ID != nil {
-			d.Set(isSnapshotSourceVolume, *snapshot.SourceVolume.ID)
-		}
-		if snapshot.SourceImage != nil && snapshot.SourceImage.ID != nil {
-			d.Set(isSnapshotSourceImage, *snapshot.SourceImage.ID)
-		}
-		if snapshot.OperatingSystem != nil && snapshot.OperatingSystem.Name != nil {
-			d.Set(isSnapshotOperatingSystem, *snapshot.OperatingSystem.Name)
-		}
-		return nil
+		return fmt.Errorf("[ERROR] No snapshot found with name %s", name)
 	} else {
 		getSnapshotOptions := &vpcv1.GetSnapshotOptions{
 			ID: &id,
@@ -206,6 +287,11 @@ func snapshotGetByNameOrID(d *schema.ResourceData, meta interface{}, name, id st
 		if snapshot.CapturedAt != nil {
 			d.Set(isSnapshotCapturedAt, (*snapshot.CapturedAt).String())
 		}
+		if snapshot.UserTags != nil {
+			if err = d.Set(isSnapshotUserTags, snapshot.UserTags); err != nil {
+				return fmt.Errorf("Error setting user tags: %s", err)
+			}
+		}
 		if snapshot.ResourceGroup != nil && snapshot.ResourceGroup.ID != nil {
 			d.Set(isSnapshotResourceGroup, *snapshot.ResourceGroup.ID)
 		}
@@ -218,6 +304,21 @@ func snapshotGetByNameOrID(d *schema.ResourceData, meta interface{}, name, id st
 		if snapshot.OperatingSystem != nil && snapshot.OperatingSystem.Name != nil {
 			d.Set(isSnapshotOperatingSystem, *snapshot.OperatingSystem.Name)
 		}
+		backupPolicyPlanList := []map[string]interface{}{}
+		if snapshot.BackupPolicyPlan != nil {
+			backupPolicyPlan := map[string]interface{}{}
+			if snapshot.BackupPolicyPlan.Deleted != nil {
+				snapshotBackupPolicyPlanDeletedMap := map[string]interface{}{}
+				snapshotBackupPolicyPlanDeletedMap["more_info"] = snapshot.BackupPolicyPlan.Deleted.MoreInfo
+				backupPolicyPlan["deleted"] = []map[string]interface{}{snapshotBackupPolicyPlanDeletedMap}
+			}
+			backupPolicyPlan["href"] = snapshot.BackupPolicyPlan.Href
+			backupPolicyPlan["id"] = snapshot.BackupPolicyPlan.ID
+			backupPolicyPlan["name"] = snapshot.BackupPolicyPlan.Name
+			backupPolicyPlan["resource_type"] = snapshot.BackupPolicyPlan.ResourceType
+			backupPolicyPlanList = append(backupPolicyPlanList, backupPolicyPlan)
+		}
+		d.Set(isSnapshotBackupPolicyPlan, backupPolicyPlanList)
 		return nil
 	}
 }

--- a/ibm/service/vpc/data_source_ibm_is_snapshot_test.go
+++ b/ibm/service/vpc/data_source_ibm_is_snapshot_test.go
@@ -42,7 +42,7 @@ ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCKVmnMOlHKcZK8tpt3MP1lqOLAcqcJzhsvJcjscgVE
 					resource.TestCheckResourceAttrSet(snpName, "crn"),
 					resource.TestCheckResourceAttrSet(snpName, "lifecycle_state"),
 					resource.TestCheckResourceAttrSet(snpName, "encryption"),
-					resource.TestCheckResourceAttrSet(snpName, "captured_at"),
+					// resource.TestCheckResourceAttrSet(snpName, "captured_at"), // Commented as the attribute is optional.
 				),
 			},
 		},

--- a/ibm/service/vpc/data_source_ibm_is_volume.go
+++ b/ibm/service/vpc/data_source_ibm_is_volume.go
@@ -5,7 +5,6 @@ package vpc
 
 import (
 	"fmt"
-	"log"
 
 	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/flex"
 	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/validate"
@@ -240,15 +239,23 @@ func volumeGet(d *schema.ResourceData, meta interface{}, name string) error {
 				}
 				statusReasonsList = append(statusReasonsList, currentSR)
 			}
+			d.Set(isVolumeStatusReasons, statusReasonsList)
+		}
+		d.Set(isVolumeTags, vol.UserTags)
+		controller, err := flex.GetBaseController(meta)
+		if err != nil {
+			return err
+		}
+		d.Set(flex.ResourceControllerURL, controller+"/vpc-ext/storage/storageVolumes")
+		d.Set(flex.ResourceName, *vol.Name)
+		d.Set(flex.ResourceCRN, *vol.CRN)
+		d.Set(flex.ResourceStatus, *vol.Status)
+		if vol.ResourceGroup != nil {
+			d.Set(flex.ResourceGroupName, vol.ResourceGroup.Name)
+			d.Set(isVolumeResourceGroup, *vol.ResourceGroup.ID)
 		}
 		d.Set(isVolumeStatusReasons, statusReasonsList)
 	}
-	tags, err := flex.GetTagsUsingCRN(meta, *vol.CRN)
-	if err != nil {
-		log.Printf(
-			"Error on get of resource vpc volume (%s) tags: %s", d.Id(), err)
-	}
-	d.Set(isVolumeTags, tags)
 	controller, err := flex.GetBaseController(meta)
 	if err != nil {
 		return err

--- a/ibm/service/vpc/data_source_ibm_is_volumes.go
+++ b/ibm/service/vpc/data_source_ibm_is_volumes.go
@@ -480,6 +480,13 @@ func DataSourceIBMIsVolumes() *schema.Resource {
 								},
 							},
 						},
+						isVolumeTags: {
+							Type:        schema.TypeSet,
+							Computed:    true,
+							Elem:        &schema.Schema{Type: schema.TypeString},
+							Set:         flex.ResourceIBMVPCHash,
+							Description: "User Tags for the Volume",
+						},
 					},
 				},
 			},
@@ -645,7 +652,9 @@ func dataSourceVolumeCollectionVolumesToMap(volumesItem vpcv1.Volume) (volumesMa
 		zoneList = append(zoneList, zoneMap)
 		volumesMap[isVolumesZone] = zoneList
 	}
-
+	if volumesItem.UserTags != nil {
+		volumesMap[isVolumeTags] = volumesItem.UserTags
+	}
 	return volumesMap
 }
 

--- a/ibm/service/vpc/resource_ibm_is_backup_policy.go
+++ b/ibm/service/vpc/resource_ibm_is_backup_policy.go
@@ -1,0 +1,299 @@
+// Copyright IBM Corp. 2021 All Rights Reserved.
+// Licensed under the Mozilla Public License v2.0
+
+package vpc
+
+import (
+	"context"
+	"fmt"
+	"log"
+
+	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/flex"
+	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/validate"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/IBM/go-sdk-core/v5/core"
+	"github.com/IBM/vpc-go-sdk/vpcv1"
+)
+
+func ResourceIBMIsBackupPolicy() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceIBMIsBackupPolicyCreate,
+		ReadContext:   resourceIBMIsBackupPolicyRead,
+		UpdateContext: resourceIBMIsBackupPolicyUpdate,
+		DeleteContext: resourceIBMIsBackupPolicyDelete,
+		Importer:      &schema.ResourceImporter{},
+
+		Schema: map[string]*schema.Schema{
+			"match_resource_types": &schema.Schema{
+				Type:        schema.TypeSet,
+				Optional:    true,
+				Computed:    true,
+				Set:         schema.HashString,
+				Description: "A resource type this backup policy applies to. Resources that have both a matching type and a matching user tag will be subject to the backup policy.",
+				Elem:        &schema.Schema{Type: schema.TypeString},
+			},
+			"match_user_tags": &schema.Schema{
+				Type:        schema.TypeSet,
+				Required:    true,
+				Description: "The user tags this backup policy applies to. Resources that have both a matching user tag and a matching type will be subject to the backup policy.",
+				Elem:        &schema.Schema{Type: schema.TypeString},
+				Set:         schema.HashString,
+			},
+			"name": &schema.Schema{
+				Type:         schema.TypeString,
+				Required:     true,
+				ValidateFunc: validate.InvokeValidator("ibm_is_backup_policy", "name"),
+				Description:  "The user-defined name for this backup policy. Names must be unique within the region this backup policy resides in. If unspecified, the name will be a hyphenated list of randomly-selected words.",
+			},
+			"resource_group": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				ForceNew:    true,
+				Computed:    true,
+				Description: "The unique identifier of the resource group to use. If unspecified, the account's [default resourcegroup](https://cloud.ibm.com/apidocs/resource-manager#introduction) is used.",
+			},
+			"created_at": &schema.Schema{
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The date and time that the backup policy was created.",
+			},
+			"crn": &schema.Schema{
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The CRN for this backup policy.",
+			},
+			"href": &schema.Schema{
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The URL for this backup policy.",
+			},
+			"last_job_completed_at": &schema.Schema{
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The date and time that the most recent job for this backup policy completed.",
+			},
+			"lifecycle_state": &schema.Schema{
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The lifecycle state of the backup policy.",
+			},
+			"resource_type": &schema.Schema{
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The resource type.",
+			},
+			"version": &schema.Schema{
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func ResourceIBMIsBackupPolicyValidator() *validate.ResourceValidator {
+	validateSchema := make([]validate.ValidateSchema, 0)
+	validateSchema = append(validateSchema,
+		validate.ValidateSchema{
+			Identifier:                 "name",
+			ValidateFunctionIdentifier: validate.ValidateRegexpLen,
+			Type:                       validate.TypeString,
+			Optional:                   true,
+			Regexp:                     `^([a-z]|[a-z][-a-z0-9]*[a-z0-9]|[0-9][-a-z0-9]*([a-z]|[-a-z][-a-z0-9]*[a-z0-9]))$`,
+			MinValueLength:             1,
+			MaxValueLength:             63,
+		},
+	)
+	validateSchema = append(validateSchema,
+		validate.ValidateSchema{
+			Identifier:                 "match_user_tags",
+			ValidateFunctionIdentifier: validate.ValidateRegexpLen,
+			Type:                       validate.TypeString,
+			Optional:                   true,
+			Regexp:                     `^[A-Za-z0-9:_ .-]+$`,
+			MinValueLength:             1,
+			MaxValueLength:             128,
+		},
+	)
+	validateSchema = append(validateSchema,
+		validate.ValidateSchema{
+			Identifier:                 "match_resource_types",
+			ValidateFunctionIdentifier: validate.ValidateRegexpLen,
+			Type:                       validate.TypeString,
+			Optional:                   true,
+			Regexp:                     `^[a-z][a-z0-9]*(_[a-z0-9]+)*$`,
+			MinValueLength:             1,
+			MaxValueLength:             128,
+		},
+	)
+	resourceValidator := validate.ResourceValidator{ResourceName: "ibm_is_backup_policy", Schema: validateSchema}
+	return &resourceValidator
+}
+
+func resourceIBMIsBackupPolicyCreate(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	vpcClient, err := vpcClient(meta)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	createBackupPolicyOptions := &vpcv1.CreateBackupPolicyOptions{}
+
+	if _, ok := d.GetOk("match_resource_types"); ok {
+		createBackupPolicyOptions.SetMatchResourceTypes(flex.ExpandStringList((d.Get("match_resource_types").(*schema.Set)).List()))
+	}
+	if _, ok := d.GetOk("match_user_tags"); ok {
+		createBackupPolicyOptions.SetMatchUserTags((flex.ExpandStringList((d.Get("match_user_tags").(*schema.Set)).List())))
+	}
+	if _, ok := d.GetOk("name"); ok {
+		createBackupPolicyOptions.SetName(d.Get("name").(string))
+	}
+	if resGroup, ok := d.GetOk("resource_group"); ok {
+		resourceGroupStr := resGroup.(string)
+		resourceGroup := vpcv1.ResourceGroupIdentity{
+			ID: &resourceGroupStr,
+		}
+		createBackupPolicyOptions.SetResourceGroup(&resourceGroup)
+	}
+
+	backupPolicy, response, err := vpcClient.CreateBackupPolicyWithContext(context, createBackupPolicyOptions)
+	if err != nil {
+		log.Printf("[DEBUG] CreateBackupPolicyWithContext failed %s\n%s", err, response)
+		return diag.FromErr(fmt.Errorf("[ERROR] CreateBackupPolicyWithContext failed %s\n%s", err, response))
+	}
+
+	d.SetId(*backupPolicy.ID)
+
+	return resourceIBMIsBackupPolicyRead(context, d, meta)
+}
+
+func resourceIBMIsBackupPolicyRead(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	vpcClient, err := vpcClient(meta)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	getBackupPolicyOptions := &vpcv1.GetBackupPolicyOptions{}
+
+	getBackupPolicyOptions.SetID(d.Id())
+
+	backupPolicy, response, err := vpcClient.GetBackupPolicyWithContext(context, getBackupPolicyOptions)
+	if err != nil {
+		if response != nil && response.StatusCode == 404 {
+			d.SetId("")
+			return nil
+		}
+		log.Printf("[DEBUG] GetBackupPolicyWithContext failed %s\n%s", err, response)
+		return diag.FromErr(fmt.Errorf("[ERROR] GetBackupPolicyWithContext failed %s\n%s", err, response))
+	}
+
+	if backupPolicy.MatchResourceTypes != nil {
+		if err = d.Set("match_resource_types", backupPolicy.MatchResourceTypes); err != nil {
+			return diag.FromErr(fmt.Errorf("[ERROR] Error setting match_resource_types: %s", err))
+		}
+	}
+	if backupPolicy.MatchUserTags != nil {
+		if err = d.Set("match_user_tags", backupPolicy.MatchUserTags); err != nil {
+			return diag.FromErr(fmt.Errorf("[ERROR] Error setting match_user_tags: %s", err))
+		}
+	}
+	if backupPolicy.Name != nil {
+		if err = d.Set("name", backupPolicy.Name); err != nil {
+			return diag.FromErr(fmt.Errorf("[ERROR] Error setting name: %s", err))
+		}
+	}
+	if backupPolicy.ResourceGroup != nil {
+		resourceGroupID := *backupPolicy.ResourceGroup.ID
+		if err = d.Set("resource_group", resourceGroupID); err != nil {
+			return diag.FromErr(fmt.Errorf("[ERROR] Error setting resource_group: %s", err))
+		}
+	}
+	if backupPolicy.CreatedAt != nil {
+		if err = d.Set("created_at", flex.DateTimeToString(backupPolicy.CreatedAt)); err != nil {
+			return diag.FromErr(fmt.Errorf("[ERROR] Error setting created_at: %s", err))
+		}
+	}
+
+	if backupPolicy.CRN != nil {
+		if err = d.Set("crn", backupPolicy.CRN); err != nil {
+			return diag.FromErr(fmt.Errorf("[ERROR] Error setting crn: %s", err))
+		}
+	}
+
+	if backupPolicy.Href != nil {
+		if err = d.Set("href", backupPolicy.Href); err != nil {
+			return diag.FromErr(fmt.Errorf("[ERROR] Error setting href: %s", err))
+		}
+	}
+
+	if backupPolicy.LastJobCompletedAt != nil {
+		if err = d.Set("last_job_completed_at", flex.DateTimeToString(backupPolicy.LastJobCompletedAt)); err != nil {
+			return diag.FromErr(fmt.Errorf("[ERROR] Error setting last_job_completed_at: %s", err))
+		}
+	}
+
+	if backupPolicy.LifecycleState != nil {
+		if err = d.Set("lifecycle_state", backupPolicy.LifecycleState); err != nil {
+			return diag.FromErr(fmt.Errorf("[ERROR] Error setting lifecycle_state: %s", err))
+		}
+	}
+
+	if backupPolicy.ResourceType != nil {
+		if err = d.Set("resource_type", backupPolicy.ResourceType); err != nil {
+			return diag.FromErr(fmt.Errorf("[ERROR] Error setting resource_type: %s", err))
+		}
+	}
+
+	if err = d.Set("version", response.Headers.Get("Etag")); err != nil {
+		return diag.FromErr(fmt.Errorf("[ERROR] Error setting version: %s", err))
+	}
+
+	return nil
+}
+
+func resourceIBMIsBackupPolicyUpdate(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	vpcClient, err := vpcClient(meta)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+	updateBackupPolicyOptions := &vpcv1.UpdateBackupPolicyOptions{}
+	updateBackupPolicyOptions.SetID(d.Id())
+	hasChange := false
+	patchVals := &vpcv1.BackupPolicyPatch{}
+	if d.HasChange("match_user_tags") {
+		patchVals.MatchUserTags = (flex.ExpandStringList((d.Get("match_user_tags").(*schema.Set)).List()))
+		hasChange = true
+	}
+	if d.HasChange("name") {
+		patchVals.Name = core.StringPtr(d.Get("name").(string))
+		hasChange = true
+	}
+	updateBackupPolicyOptions.SetIfMatch(d.Get("version").(string))
+	if hasChange {
+		updateBackupPolicyOptions.BackupPolicyPatch, _ = patchVals.AsPatch()
+		_, response, err := vpcClient.UpdateBackupPolicyWithContext(context, updateBackupPolicyOptions)
+		if err != nil {
+			log.Printf("[DEBUG] UpdateBackupPolicyWithContext failed %s\n%s", err, response)
+			return diag.FromErr(fmt.Errorf("[ERROR] UpdateBackupPolicyWithContext failed %s\n%s", err, response))
+		}
+	}
+
+	return resourceIBMIsBackupPolicyRead(context, d, meta)
+}
+
+func resourceIBMIsBackupPolicyDelete(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	vpcClient, err := vpcClient(meta)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+	deleteBackupPolicyOptions := &vpcv1.DeleteBackupPolicyOptions{}
+	deleteBackupPolicyOptions.SetID(d.Id())
+	deleteBackupPolicyOptions.SetIfMatch(d.Get("version").(string))
+	_, response, err := vpcClient.DeleteBackupPolicyWithContext(context, deleteBackupPolicyOptions)
+	if err != nil {
+		log.Printf("[DEBUG] DeleteBackupPolicyWithContext failed %s\n%s", err, response)
+		return diag.FromErr(fmt.Errorf("[ERROR] DeleteBackupPolicyWithContext failed %s\n%s", err, response))
+	}
+	d.SetId("")
+	return nil
+}

--- a/ibm/service/vpc/resource_ibm_is_backup_policy_plan.go
+++ b/ibm/service/vpc/resource_ibm_is_backup_policy_plan.go
@@ -1,0 +1,437 @@
+// Copyright IBM Corp. 2021 All Rights Reserved.
+// Licensed under the Mozilla Public License v2.0
+
+package vpc
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"strconv"
+
+	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/flex"
+	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/validate"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/IBM/go-sdk-core/v5/core"
+	"github.com/IBM/vpc-go-sdk/vpcv1"
+)
+
+func ResourceIBMIsBackupPolicyPlan() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceIBMIsBackupPolicyPlanCreate,
+		ReadContext:   resourceIBMIsBackupPolicyPlanRead,
+		UpdateContext: resourceIBMIsBackupPolicyPlanUpdate,
+		DeleteContext: resourceIBMIsBackupPolicyPlanDelete,
+		Importer:      &schema.ResourceImporter{},
+
+		Schema: map[string]*schema.Schema{
+			"backup_policy_id": &schema.Schema{
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: "The backup policy identifier.",
+			},
+			"backup_policy_plan_id": &schema.Schema{
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The backup policy identifier.",
+			},
+			"cron_spec": &schema.Schema{
+				Type:         schema.TypeString,
+				Required:     true,
+				ValidateFunc: validate.InvokeValidator("ibm_is_backup_policy_plan", "cron_spec"),
+				Description:  "The cron specification for the backup schedule.",
+			},
+			"active": &schema.Schema{
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Computed:    true,
+				Description: "Indicates whether the plan is active.",
+			},
+			"attach_user_tags": &schema.Schema{
+				Type:        schema.TypeSet,
+				Optional:    true,
+				Set:         schema.HashString,
+				Description: "User tags to attach to each backup (snapshot) created by this plan. If unspecified, no user tags will be attached.",
+				Elem:        &schema.Schema{Type: schema.TypeString},
+			},
+			"copy_user_tags": &schema.Schema{
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Default:     true,
+				Description: "Indicates whether to copy the source's user tags to the created backups (snapshots).",
+			},
+			"deletion_trigger": &schema.Schema{
+				Type:     schema.TypeList,
+				MaxItems: 1,
+				Optional: true,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"delete_after": &schema.Schema{
+							Type:        schema.TypeInt,
+							Optional:    true,
+							Default:     30,
+							Description: "The maximum number of days to keep each backup after creation.",
+						},
+						"delete_over_count": &schema.Schema{
+							Type:        schema.TypeString,
+							Optional:    true,
+							Computed:    true,
+							Description: "The maximum number of recent backups to keep. If unspecified, there will be no maximum.",
+						},
+					},
+				},
+			},
+			"name": &schema.Schema{
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validate.InvokeValidator("ibm_is_backup_policy_plan", "name"),
+				Description:  "The user-defined name for this backup policy plan. Names must be unique within the backup policy this plan resides in. If unspecified, the name will be a hyphenated list of randomly-selected words.",
+			},
+			"created_at": &schema.Schema{
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The date and time that the backup policy plan was created.",
+			},
+			"href": &schema.Schema{
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The URL for this backup policy plan.",
+			},
+			"lifecycle_state": &schema.Schema{
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The lifecycle state of this backup policy plan.",
+			},
+			"resource_type": &schema.Schema{
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The resource type.",
+			},
+			"version": &schema.Schema{
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "Version of the BackupPolicyPlan.",
+			},
+		},
+	}
+}
+
+func ResourceIBMIsBackupPolicyPlanValidator() *validate.ResourceValidator {
+	validateSchema := make([]validate.ValidateSchema, 0)
+	validateSchema = append(validateSchema,
+		validate.ValidateSchema{
+			Identifier:                 "cron_spec",
+			ValidateFunctionIdentifier: validate.ValidateRegexpLen,
+			Type:                       validate.TypeString,
+			Required:                   true,
+			Regexp:                     `^((((\d+,)+\d+|([\d\*]+(\/|-)\d+)|\d+|\*) ?){5,7})$`,
+			MinValueLength:             9,
+			MaxValueLength:             63,
+		},
+		validate.ValidateSchema{
+			Identifier:                 "name",
+			ValidateFunctionIdentifier: validate.ValidateRegexpLen,
+			Type:                       validate.TypeString,
+			Optional:                   true,
+			Regexp:                     `^([a-z]|[a-z][-a-z0-9]*[a-z0-9]|[0-9][-a-z0-9]*([a-z]|[-a-z][-a-z0-9]*[a-z0-9]))$`,
+			MinValueLength:             1,
+			MaxValueLength:             63,
+		},
+	)
+
+	resourceValidator := validate.ResourceValidator{ResourceName: "ibm_is_backup_policy_plan", Schema: validateSchema}
+	return &resourceValidator
+}
+
+func resourceIBMIsBackupPolicyPlanCreate(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	vpcClient, err := vpcClient(meta)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	createBackupPolicyPlanOptions := &vpcv1.CreateBackupPolicyPlanOptions{}
+
+	createBackupPolicyPlanOptions.SetBackupPolicyID(d.Get("backup_policy_id").(string))
+	createBackupPolicyPlanOptions.SetCronSpec(d.Get("cron_spec").(string))
+	if _, ok := d.GetOk("active"); ok {
+		createBackupPolicyPlanOptions.SetActive(d.Get("active").(bool))
+	}
+	if _, ok := d.GetOk("attach_user_tags"); ok {
+		createBackupPolicyPlanOptions.SetAttachUserTags((flex.ExpandStringList((d.Get("attach_user_tags").(*schema.Set)).List())))
+	}
+	if _, ok := d.GetOk("copy_user_tags"); ok {
+		createBackupPolicyPlanOptions.SetCopyUserTags(d.Get("copy_user_tags").(bool))
+	}
+	if _, ok := d.GetOk("deletion_trigger"); ok {
+		backupPolicyPlanDeletionTriggerPrototypeMap := d.Get("deletion_trigger.0").(map[string]interface{})
+		backupPolicyPlanDeletionTriggerPrototype := vpcv1.BackupPolicyPlanDeletionTriggerPrototype{}
+
+		if backupPolicyPlanDeletionTriggerPrototypeMap["delete_after"] != nil {
+			backupPolicyPlanDeletionTriggerPrototype.DeleteAfter = core.Int64Ptr(int64(backupPolicyPlanDeletionTriggerPrototypeMap["delete_after"].(int)))
+		}
+		log.Println("backupPolicyPlanDeletionTriggerPrototypeMap[delete_over_count] Inside")
+		log.Println(backupPolicyPlanDeletionTriggerPrototypeMap["delete_over_count"])
+		if backupPolicyPlanDeletionTriggerPrototypeMap["delete_over_count"] != nil {
+			deleteOverCountString := backupPolicyPlanDeletionTriggerPrototypeMap["delete_over_count"].(string)
+			if deleteOverCountString != "" {
+				deleteOverCount, err := strconv.ParseInt(backupPolicyPlanDeletionTriggerPrototypeMap["delete_over_count"].(string), 10, 64)
+				if err != nil {
+					return diag.FromErr(fmt.Errorf("[ERROR] Error setting delete_over_count: %s", err))
+				}
+				deleteOverCountint := int64(deleteOverCount)
+				if deleteOverCountint >= int64(0) {
+					backupPolicyPlanDeletionTriggerPrototype.DeleteOverCount = core.Int64Ptr(deleteOverCountint)
+				}
+			}
+		}
+		createBackupPolicyPlanOptions.SetDeletionTrigger(&backupPolicyPlanDeletionTriggerPrototype)
+	}
+	if _, ok := d.GetOk("name"); ok {
+		createBackupPolicyPlanOptions.SetName(d.Get("name").(string))
+	}
+
+	backupPolicyPlan, response, err := vpcClient.CreateBackupPolicyPlanWithContext(context, createBackupPolicyPlanOptions)
+	if err != nil {
+		log.Printf("[DEBUG] CreateBackupPolicyPlanWithContext failed %s\n%s", err, response)
+		return diag.FromErr(fmt.Errorf("[ERROR] CreateBackupPolicyPlanWithContext failed %s\n%s", err, response))
+	}
+
+	d.SetId(fmt.Sprintf("%s/%s", *createBackupPolicyPlanOptions.BackupPolicyID, *backupPolicyPlan.ID))
+
+	return resourceIBMIsBackupPolicyPlanRead(context, d, meta)
+}
+
+func resourceIBMIsBackupPolicyPlanRead(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	vpcClient, err := vpcClient(meta)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	getBackupPolicyPlanOptions := &vpcv1.GetBackupPolicyPlanOptions{}
+
+	parts, err := flex.SepIdParts(d.Id(), "/")
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	getBackupPolicyPlanOptions.SetBackupPolicyID(parts[0])
+	getBackupPolicyPlanOptions.SetID(parts[1])
+
+	backupPolicyPlan, response, err := vpcClient.GetBackupPolicyPlanWithContext(context, getBackupPolicyPlanOptions)
+	if err != nil {
+		if response != nil && response.StatusCode == 404 {
+			d.SetId("")
+			return nil
+		}
+		log.Printf("[DEBUG] GetBackupPolicyPlanWithContext failed %s\n%s", err, response)
+		return diag.FromErr(fmt.Errorf("[ERROR] GetBackupPolicyPlanWithContext failed %s\n%s", err, response))
+	}
+
+	if getBackupPolicyPlanOptions.BackupPolicyID != nil {
+		if err = d.Set("backup_policy_id", getBackupPolicyPlanOptions.BackupPolicyID); err != nil {
+			return diag.FromErr(fmt.Errorf("[ERROR] Error setting backup_policy_id: %s", err))
+		}
+	}
+
+	if getBackupPolicyPlanOptions.ID != nil {
+		if err = d.Set("backup_policy_plan_id", getBackupPolicyPlanOptions.ID); err != nil {
+			return diag.FromErr(fmt.Errorf("[ERROR] Error setting backup_policy_plan_id: %s", err))
+		}
+	}
+
+	if backupPolicyPlan.CronSpec != nil {
+		if err = d.Set("cron_spec", backupPolicyPlan.CronSpec); err != nil {
+			return diag.FromErr(fmt.Errorf("[ERROR] Error setting cron_spec: %s", err))
+		}
+	}
+
+	if backupPolicyPlan.Active != nil {
+		if err = d.Set("active", backupPolicyPlan.Active); err != nil {
+			return diag.FromErr(fmt.Errorf("[ERROR] Error setting active: %s", err))
+		}
+	}
+
+	if backupPolicyPlan.AttachUserTags != nil {
+		if err = d.Set("attach_user_tags", backupPolicyPlan.AttachUserTags); err != nil {
+			return diag.FromErr(fmt.Errorf("[ERROR] Error setting attach_user_tags: %s", err))
+		}
+	}
+
+	if backupPolicyPlan.CopyUserTags != nil {
+		if err = d.Set("copy_user_tags", backupPolicyPlan.CopyUserTags); err != nil {
+			return diag.FromErr(fmt.Errorf("[ERROR] Error setting copy_user_tags: %s", err))
+		}
+	}
+
+	if backupPolicyPlan.DeletionTrigger != nil {
+		deletionTriggerMap := resourceIBMIsBackupPolicyPlanBackupPolicyPlanDeletionTriggerPrototypeToMap(*backupPolicyPlan.DeletionTrigger)
+		if err = d.Set("deletion_trigger", []map[string]interface{}{deletionTriggerMap}); err != nil {
+			return diag.FromErr(fmt.Errorf("[ERROR] Error setting deletion_trigger: %s", err))
+		}
+	}
+
+	if backupPolicyPlan.Name != nil {
+		if err = d.Set("name", backupPolicyPlan.Name); err != nil {
+			return diag.FromErr(fmt.Errorf("[ERROR] Error setting name: %s", err))
+		}
+	}
+
+	if backupPolicyPlan.CreatedAt != nil {
+		if err = d.Set("created_at", flex.DateTimeToString(backupPolicyPlan.CreatedAt)); err != nil {
+			return diag.FromErr(fmt.Errorf("[ERROR] Error setting created_at: %s", err))
+		}
+	}
+
+	if err = d.Set("href", backupPolicyPlan.Href); err != nil {
+		return diag.FromErr(fmt.Errorf("[ERROR] Error setting href: %s", err))
+	}
+	if err = d.Set("lifecycle_state", backupPolicyPlan.LifecycleState); err != nil {
+		return diag.FromErr(fmt.Errorf("[ERROR] Error setting lifecycle_state: %s", err))
+	}
+	if err = d.Set("resource_type", backupPolicyPlan.ResourceType); err != nil {
+		return diag.FromErr(fmt.Errorf("[ERROR] Error setting resource_type: %s", err))
+	}
+	if err = d.Set("version", response.Headers.Get("Etag")); err != nil {
+		return diag.FromErr(fmt.Errorf("[ERROR] Error setting version: %s", err))
+	}
+
+	return nil
+}
+
+func resourceIBMIsBackupPolicyPlanBackupPolicyPlanDeletionTriggerPrototypeToMap(backupPolicyPlanDeletionTriggerPrototype vpcv1.BackupPolicyPlanDeletionTrigger) map[string]interface{} {
+	backupPolicyPlanDeletionTriggerPrototypeMap := map[string]interface{}{}
+
+	if backupPolicyPlanDeletionTriggerPrototype.DeleteAfter != nil {
+		backupPolicyPlanDeletionTriggerPrototypeMap["delete_after"] = flex.IntValue(backupPolicyPlanDeletionTriggerPrototype.DeleteAfter)
+	}
+	if backupPolicyPlanDeletionTriggerPrototype.DeleteOverCount != nil {
+		backupPolicyPlanDeletionTriggerPrototypeMap["delete_over_count"] = strconv.FormatInt(*backupPolicyPlanDeletionTriggerPrototype.DeleteOverCount, 10)
+	}
+
+	return backupPolicyPlanDeletionTriggerPrototypeMap
+}
+
+func resourceIBMIsBackupPolicyPlanUpdate(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	vpcClient, err := vpcClient(meta)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	updateBackupPolicyPlanOptions := &vpcv1.UpdateBackupPolicyPlanOptions{}
+
+	parts, err := flex.SepIdParts(d.Id(), "/")
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	updateBackupPolicyPlanOptions.SetBackupPolicyID(parts[0])
+	updateBackupPolicyPlanOptions.SetID(parts[1])
+
+	hasChange := false
+
+	patchVals := &vpcv1.BackupPolicyPlanPatch{}
+	if d.HasChange("cron_spec") {
+		patchVals.CronSpec = core.StringPtr(d.Get("cron_spec").(string))
+		hasChange = true
+	}
+	if d.HasChange("active") {
+		patchVals.Active = core.BoolPtr(d.Get("active").(bool))
+		hasChange = true
+	}
+	if d.HasChange("attach_user_tags") {
+		patchVals.AttachUserTags = (flex.ExpandStringList((d.Get("attach_user_tags").(*schema.Set)).List()))
+		hasChange = true
+	}
+	if d.HasChange("copy_user_tags") {
+		patchVals.CopyUserTags = core.BoolPtr(d.Get("copy_user_tags").(bool))
+		hasChange = true
+	}
+
+	deleteOverCountBool := false
+	if d.HasChange("deletion_trigger") {
+		backupPolicyPlanDeletionTriggerPrototype := vpcv1.BackupPolicyPlanDeletionTriggerPatch{}
+		backupPolicyPlanDeletionTriggerPrototypeMap := d.Get("deletion_trigger.0").(map[string]interface{})
+		if backupPolicyPlanDeletionTriggerPrototypeMap["delete_after"] != nil {
+			backupPolicyPlanDeletionTriggerPrototype.DeleteAfter = core.Int64Ptr(int64(backupPolicyPlanDeletionTriggerPrototypeMap["delete_after"].(int)))
+		}
+		if backupPolicyPlanDeletionTriggerPrototypeMap["delete_over_count"] != nil {
+			deleteOverCountString := backupPolicyPlanDeletionTriggerPrototypeMap["delete_over_count"].(string)
+			if deleteOverCountString != "" {
+				deleteOverCount, err := strconv.ParseInt(backupPolicyPlanDeletionTriggerPrototypeMap["delete_over_count"].(string), 10, 64)
+				if err != nil {
+					return diag.FromErr(fmt.Errorf("[ERROR] Error setting delete_over_count: %s", err))
+				}
+				deleteOverCountint := int64(deleteOverCount)
+				if deleteOverCountint >= int64(0) {
+					backupPolicyPlanDeletionTriggerPrototype.DeleteOverCount = core.Int64Ptr(deleteOverCountint)
+				}
+			} else {
+				deleteOverCountBool = true
+			}
+		}
+		patchVals.DeletionTrigger = &backupPolicyPlanDeletionTriggerPrototype
+		hasChange = true
+	}
+
+	if d.HasChange("name") {
+		patchVals.Name = core.StringPtr(d.Get("name").(string))
+		hasChange = true
+	}
+	updateBackupPolicyPlanOptions.SetIfMatch(d.Get("version").(string))
+
+	if hasChange {
+		backupPolicyPlanPatch, err := patchVals.AsPatch()
+		if err != nil {
+			return diag.FromErr(fmt.Errorf("[ERROR] [ERROR] Error calling asPatch for BackupPolicyPlanPatch: %s", err))
+		}
+
+		if deleteOverCountBool {
+			backupPolicyPlanDeletionTriggerMap := backupPolicyPlanPatch["deletion_trigger"]
+			backupPolicyPlanDeletionTrigger := backupPolicyPlanDeletionTriggerMap.(map[string]interface{})
+			backupPolicyPlanDeletionTrigger["delete_over_count"] = nil
+			backupPolicyPlanPatch["deletion_trigger"] = backupPolicyPlanDeletionTrigger
+		}
+
+		updateBackupPolicyPlanOptions.BackupPolicyPlanPatch = backupPolicyPlanPatch
+		_, response, err := vpcClient.UpdateBackupPolicyPlanWithContext(context, updateBackupPolicyPlanOptions)
+		if err != nil {
+			log.Printf("[DEBUG] UpdateBackupPolicyPlanWithContext failed %s\n%s", err, response)
+			return diag.FromErr(fmt.Errorf("[ERROR] UpdateBackupPolicyPlanWithContext failed %s\n%s", err, response))
+		}
+	}
+
+	return resourceIBMIsBackupPolicyPlanRead(context, d, meta)
+}
+
+func resourceIBMIsBackupPolicyPlanDelete(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	vpcClient, err := vpcClient(meta)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	deleteBackupPolicyPlanOptions := &vpcv1.DeleteBackupPolicyPlanOptions{}
+
+	parts, err := flex.SepIdParts(d.Id(), "/")
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	deleteBackupPolicyPlanOptions.SetBackupPolicyID(parts[0])
+	deleteBackupPolicyPlanOptions.SetID(parts[1])
+
+	deleteBackupPolicyPlanOptions.SetIfMatch(d.Get("version").(string))
+
+	_, response, err := vpcClient.DeleteBackupPolicyPlanWithContext(context, deleteBackupPolicyPlanOptions)
+	if err != nil {
+		log.Printf("[DEBUG] DeleteBackupPolicyPlanWithContext failed %s\n%s", err, response)
+		return diag.FromErr(fmt.Errorf("[ERROR] DeleteBackupPolicyPlanWithContext failed %s\n%s", err, response))
+	}
+
+	d.SetId("")
+
+	return nil
+}

--- a/ibm/service/vpc/resource_ibm_is_backup_policy_plan_test.go
+++ b/ibm/service/vpc/resource_ibm_is_backup_policy_plan_test.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2021 All Rights Reserved.
+// Copyright IBM Corp. 2021, 2022 All Rights Reserved.
 // Licensed under the Mozilla Public License v2.0
 
 package vpc_test

--- a/ibm/service/vpc/resource_ibm_is_backup_policy_plan_test.go
+++ b/ibm/service/vpc/resource_ibm_is_backup_policy_plan_test.go
@@ -1,0 +1,213 @@
+// Copyright IBM Corp. 2021 All Rights Reserved.
+// Licensed under the Mozilla Public License v2.0
+
+package vpc_test
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	acc "github.com/IBM-Cloud/terraform-provider-ibm/ibm/acctest"
+	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/conns"
+	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/flex"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	"github.com/IBM/vpc-go-sdk/vpcv1"
+)
+
+func TestAccIBMIsBackupPolicyPlanBasic(t *testing.T) {
+	var conf vpcv1.BackupPolicyPlan
+	vpcname := fmt.Sprintf("tf-vpc-%d", acctest.RandIntRange(10, 100))
+	name := fmt.Sprintf("tf-instnace-%d", acctest.RandIntRange(10, 100))
+	subnetname := fmt.Sprintf("tf-subnet-%d", acctest.RandIntRange(10, 100))
+	sshname := fmt.Sprintf("tf-ssh-%d", acctest.RandIntRange(10, 100))
+	volname := fmt.Sprintf("tf-vol-%d", acctest.RandIntRange(10, 100))
+	bakupPolicyName := fmt.Sprintf("tfbakuppolicyname%d", acctest.RandIntRange(10, 100))
+	bakupPolicyPlanName := fmt.Sprintf("tfbakuppolicyplanname%d", acctest.RandIntRange(10, 100))
+	bakupPolicyPlanNameUpdate := fmt.Sprintf("tfbakuppolicyplannameupdate%d", acctest.RandIntRange(10, 100))
+	cronSpec := strings.TrimSpace(strconv.Itoa(time.Now().UTC().Minute()) + " " + strconv.Itoa(time.Now().UTC().Hour()) + " " + "*" + " " + "*" + " " + "*")
+	cronSpecUpdate := strings.TrimSpace(strconv.Itoa(time.Now().UTC().Minute()+1) + " " + strconv.Itoa(time.Now().UTC().Hour()) + " " + "*" + " " + "*" + " " + "*")
+	if strings.TrimSpace(strconv.Itoa(time.Now().UTC().Minute())) == "61" {
+		cronSpecUpdate = strings.TrimSpace(("1") + " " + strconv.Itoa(time.Now().UTC().Hour()+1) + " " + "*" + " " + "*" + " " + "*")
+	}
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { acc.TestAccPreCheck(t) },
+		Providers:    acc.TestAccProviders,
+		CheckDestroy: testAccCheckIBMIsBackupPolicyPlanDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccCheckIBMIsBackupPolicyPlanConfigBasic(bakupPolicyName, vpcname, subnetname, sshname, volname, name, cronSpec, bakupPolicyPlanName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckIBMIsBackupPolicyPlanExists("ibm_is_backup_policy_plan.is_backup_policy_plan.0", conf),
+					resource.TestCheckResourceAttr("ibm_is_backup_policy_plan.is_backup_policy_plan.0", "name", bakupPolicyPlanName+"-1"),
+					resource.TestCheckResourceAttr("ibm_is_backup_policy_plan.is_backup_policy_plan.0", "cron_spec", cronSpec),
+					resource.TestCheckResourceAttrSet("ibm_is_backup_policy_plan.is_backup_policy_plan.0", "backup_policy_id"),
+					resource.TestCheckResourceAttrSet("ibm_is_backup_policy_plan.is_backup_policy_plan.0", "backup_policy_plan_id"),
+					resource.TestCheckResourceAttrSet("ibm_is_backup_policy_plan.is_backup_policy_plan.0", "active"),
+					resource.TestCheckResourceAttrSet("ibm_is_backup_policy_plan.is_backup_policy_plan.0", "copy_user_tags"),
+					resource.TestCheckResourceAttrSet("ibm_is_backup_policy_plan.is_backup_policy_plan.0", "deletion_trigger.#"),
+					resource.TestCheckResourceAttrSet("ibm_is_backup_policy_plan.is_backup_policy_plan.0", "created_at"),
+					resource.TestCheckResourceAttrSet("ibm_is_backup_policy_plan.is_backup_policy_plan.0", "href"),
+					resource.TestCheckResourceAttrSet("ibm_is_backup_policy_plan.is_backup_policy_plan.0", "lifecycle_state"),
+					resource.TestCheckResourceAttrSet("ibm_is_backup_policy_plan.is_backup_policy_plan.0", "resource_type"),
+					resource.TestCheckResourceAttrSet("ibm_is_backup_policy_plan.is_backup_policy_plan.0", "version"),
+				),
+			},
+			resource.TestStep{
+				Config: testAccCheckIBMIsBackupPolicyPlanConfigBasic(bakupPolicyName, vpcname, subnetname, sshname, volname, name, cronSpecUpdate, bakupPolicyPlanNameUpdate),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckIBMIsBackupPolicyPlanExists("ibm_is_backup_policy_plan.is_backup_policy_plan.0", conf),
+					resource.TestCheckResourceAttr("ibm_is_backup_policy_plan.is_backup_policy_plan.0", "name", bakupPolicyPlanNameUpdate+"-1"),
+					resource.TestCheckResourceAttr("ibm_is_backup_policy_plan.is_backup_policy_plan.0", "cron_spec", cronSpecUpdate),
+					resource.TestCheckResourceAttrSet("ibm_is_backup_policy_plan.is_backup_policy_plan.0", "backup_policy_id"),
+					resource.TestCheckResourceAttrSet("ibm_is_backup_policy_plan.is_backup_policy_plan.0", "backup_policy_plan_id"),
+					resource.TestCheckResourceAttrSet("ibm_is_backup_policy_plan.is_backup_policy_plan.0", "active"),
+					resource.TestCheckResourceAttrSet("ibm_is_backup_policy_plan.is_backup_policy_plan.0", "copy_user_tags"),
+					resource.TestCheckResourceAttrSet("ibm_is_backup_policy_plan.is_backup_policy_plan.0", "deletion_trigger.#"),
+					resource.TestCheckResourceAttrSet("ibm_is_backup_policy_plan.is_backup_policy_plan.0", "created_at"),
+					resource.TestCheckResourceAttrSet("ibm_is_backup_policy_plan.is_backup_policy_plan.0", "href"),
+					resource.TestCheckResourceAttrSet("ibm_is_backup_policy_plan.is_backup_policy_plan.0", "lifecycle_state"),
+					resource.TestCheckResourceAttrSet("ibm_is_backup_policy_plan.is_backup_policy_plan.0", "resource_type"),
+					resource.TestCheckResourceAttrSet("ibm_is_backup_policy_plan.is_backup_policy_plan.0", "version"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccIBMIsBackupPolicyPlanImport(t *testing.T) {
+	var conf vpcv1.BackupPolicyPlan
+	vpcname := fmt.Sprintf("tf-vpc-%d", acctest.RandIntRange(10, 100))
+	name := fmt.Sprintf("tf-instnace-%d", acctest.RandIntRange(10, 100))
+	subnetname := fmt.Sprintf("tf-subnet-%d", acctest.RandIntRange(10, 100))
+	sshname := fmt.Sprintf("tf-ssh-%d", acctest.RandIntRange(10, 100))
+	volname := fmt.Sprintf("tf-vol-%d", acctest.RandIntRange(10, 100))
+	bakupPolicyName := fmt.Sprintf("tfbakuppolicynameimport%d", acctest.RandIntRange(10, 100))
+	bakupPolicyPlanName := fmt.Sprintf("tfbakuppolicyplannameimport%d", acctest.RandIntRange(10, 100))
+	// bakupPolicyPlanNameUpdate := fmt.Sprintf("tfbakuppolicyplannameupdate%d", acctest.RandIntRange(10, 100))
+	cronSpec := strings.TrimSpace(strconv.Itoa(time.Now().UTC().Minute()) + " " + strconv.Itoa(time.Now().UTC().Hour()) + " " + "*" + " " + "*" + " " + "*")
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { acc.TestAccPreCheck(t) },
+		Providers:    acc.TestAccProviders,
+		CheckDestroy: testAccCheckIBMIsBackupPolicyPlanDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccCheckIBMIsBackupPolicyPlanConfigImport(bakupPolicyName, vpcname, subnetname, sshname, volname, name, cronSpec, bakupPolicyPlanName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckIBMIsBackupPolicyPlanExists("ibm_is_backup_policy_plan.is_backup_policy_plan_import", conf),
+					resource.TestCheckResourceAttr("ibm_is_backup_policy_plan.is_backup_policy_plan_import", "name", bakupPolicyPlanName+"-import"),
+					resource.TestCheckResourceAttr("ibm_is_backup_policy_plan.is_backup_policy_plan_import", "cron_spec", cronSpec),
+					resource.TestCheckResourceAttrSet("ibm_is_backup_policy_plan.is_backup_policy_plan_import", "backup_policy_id"),
+					resource.TestCheckResourceAttrSet("ibm_is_backup_policy_plan.is_backup_policy_plan_import", "backup_policy_plan_id"),
+					resource.TestCheckResourceAttrSet("ibm_is_backup_policy_plan.is_backup_policy_plan_import", "active"),
+					resource.TestCheckResourceAttrSet("ibm_is_backup_policy_plan.is_backup_policy_plan_import", "copy_user_tags"),
+					resource.TestCheckResourceAttrSet("ibm_is_backup_policy_plan.is_backup_policy_plan_import", "deletion_trigger.#"),
+					resource.TestCheckResourceAttrSet("ibm_is_backup_policy_plan.is_backup_policy_plan_import", "created_at"),
+					resource.TestCheckResourceAttrSet("ibm_is_backup_policy_plan.is_backup_policy_plan_import", "href"),
+					resource.TestCheckResourceAttrSet("ibm_is_backup_policy_plan.is_backup_policy_plan_import", "lifecycle_state"),
+					resource.TestCheckResourceAttrSet("ibm_is_backup_policy_plan.is_backup_policy_plan_import", "resource_type"),
+					resource.TestCheckResourceAttrSet("ibm_is_backup_policy_plan.is_backup_policy_plan_import", "version"),
+				),
+			},
+			resource.TestStep{
+				ResourceName:      "ibm_is_backup_policy_plan.is_backup_policy_plan_import",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testAccCheckIBMIsBackupPolicyPlanConfigBasic(backupPolicyName, vpcname, subnetname, sshname, volName, name, cronSpec, bakupPolicyPlanName string) string {
+
+	return testAccCheckIBMIsBackupPolicyConfigBasic(backupPolicyName, vpcname, subnetname, sshname, volName, name) + fmt.Sprintf(`
+		resource "ibm_is_backup_policy_plan" "is_backup_policy_plan" {
+			count  = 2
+			backup_policy_id = ibm_is_backup_policy.is_backup_policy.id
+			name = "%s-${count.index+1}"
+			cron_spec = "%s"
+		}
+	`, bakupPolicyPlanName, cronSpec)
+}
+
+func testAccCheckIBMIsBackupPolicyPlanConfigImport(backupPolicyName, vpcname, subnetname, sshname, volName, name, cronSpec, bakupPolicyPlanName string) string {
+
+	return testAccCheckIBMIsBackupPolicyConfigBasic(backupPolicyName, vpcname, subnetname, sshname, volName, name) + fmt.Sprintf(`
+		resource "ibm_is_backup_policy_plan" "is_backup_policy_plan_import" {
+			backup_policy_id = ibm_is_backup_policy.is_backup_policy.id
+			name = "%s-import"
+			cron_spec = "%s"
+		}
+	`, bakupPolicyPlanName, cronSpec)
+}
+
+func testAccCheckIBMIsBackupPolicyPlanExists(n string, obj vpcv1.BackupPolicyPlan) resource.TestCheckFunc {
+
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+
+		vpcClient, err := acc.TestAccProvider.Meta().(conns.ClientSession).VpcV1API()
+		if err != nil {
+			return err
+		}
+
+		getBackupPolicyPlanOptions := &vpcv1.GetBackupPolicyPlanOptions{}
+
+		parts, err := flex.SepIdParts(rs.Primary.ID, "/")
+		if err != nil {
+			return err
+		}
+
+		getBackupPolicyPlanOptions.SetBackupPolicyID(parts[0])
+		getBackupPolicyPlanOptions.SetID(parts[1])
+
+		backupPolicyPlan, _, err := vpcClient.GetBackupPolicyPlan(getBackupPolicyPlanOptions)
+		if err != nil {
+			return err
+		}
+
+		obj = *backupPolicyPlan
+		return nil
+	}
+}
+
+func testAccCheckIBMIsBackupPolicyPlanDestroy(s *terraform.State) error {
+	vpcClient, err := acc.TestAccProvider.Meta().(conns.ClientSession).VpcV1API()
+	if err != nil {
+		return err
+	}
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "ibm_is_backup_policy_plan" {
+			continue
+		}
+
+		getBackupPolicyPlanOptions := &vpcv1.GetBackupPolicyPlanOptions{}
+
+		parts, err := flex.SepIdParts(rs.Primary.ID, "/")
+		if err != nil {
+			return err
+		}
+
+		getBackupPolicyPlanOptions.SetBackupPolicyID(parts[0])
+		getBackupPolicyPlanOptions.SetID(parts[1])
+
+		// Try to find the key
+		_, response, err := vpcClient.GetBackupPolicyPlan(getBackupPolicyPlanOptions)
+
+		if err == nil {
+			return fmt.Errorf("BackupPolicyPlan still exists: %s", rs.Primary.ID)
+		} else if response.StatusCode != 404 {
+			return fmt.Errorf("Error checking for BackupPolicyPlan (%s) has been destroyed: %s", rs.Primary.ID, err)
+		}
+	}
+
+	return nil
+}

--- a/ibm/service/vpc/resource_ibm_is_backup_policy_test.go
+++ b/ibm/service/vpc/resource_ibm_is_backup_policy_test.go
@@ -1,0 +1,145 @@
+// Copyright IBM Corp. 2021 All Rights Reserved.
+// Licensed under the Mozilla Public License v2.0
+
+package vpc_test
+
+import (
+	"fmt"
+	"testing"
+
+	acc "github.com/IBM-Cloud/terraform-provider-ibm/ibm/acctest"
+	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/conns"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	"github.com/IBM/vpc-go-sdk/vpcv1"
+)
+
+func TestAccIBMIsBackupPolicyBasic(t *testing.T) {
+	vpcname := fmt.Sprintf("tf-vpc-%d", acctest.RandIntRange(10, 100))
+	name := fmt.Sprintf("tf-instnace-%d", acctest.RandIntRange(10, 100))
+	subnetname := fmt.Sprintf("tf-subnet-%d", acctest.RandIntRange(10, 100))
+	sshname := fmt.Sprintf("tf-ssh-%d", acctest.RandIntRange(10, 100))
+	volname := fmt.Sprintf("tf-vol-%d", acctest.RandIntRange(10, 100))
+	backupPolicyName := fmt.Sprintf("tfbakuppolicyname%d", acctest.RandIntRange(10, 100))
+	backupPolicyNameUpdate := fmt.Sprintf("tfbakuppolicyname%d", acctest.RandIntRange(10, 100))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { acc.TestAccPreCheck(t) },
+		Providers:    acc.TestAccProviders,
+		CheckDestroy: testAccCheckIBMIsBackupPolicyDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccCheckIBMIsBackupPolicyConfigBasic(backupPolicyName, vpcname, subnetname, sshname, volname, name),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("ibm_is_backup_policy.is_backup_policy", "name", backupPolicyName),
+					resource.TestCheckResourceAttrSet("ibm_is_backup_policy.is_backup_policy", "match_resource_types.#"),
+					resource.TestCheckResourceAttrSet("ibm_is_backup_policy.is_backup_policy", "match_user_tags.#"),
+					resource.TestCheckResourceAttrSet("ibm_is_backup_policy.is_backup_policy", "resource_group"),
+					resource.TestCheckResourceAttrSet("ibm_is_backup_policy.is_backup_policy", "created_at"),
+					resource.TestCheckResourceAttrSet("ibm_is_backup_policy.is_backup_policy", "crn"),
+					resource.TestCheckResourceAttrSet("ibm_is_backup_policy.is_backup_policy", "href"),
+					resource.TestCheckResourceAttrSet("ibm_is_backup_policy.is_backup_policy", "lifecycle_state"),
+					resource.TestCheckResourceAttrSet("ibm_is_backup_policy.is_backup_policy", "resource_type"),
+					resource.TestCheckResourceAttrSet("ibm_is_backup_policy.is_backup_policy", "version"),
+				),
+			},
+			resource.TestStep{
+				Config: testAccCheckIBMIsBackupPolicyConfigBasic(backupPolicyNameUpdate, vpcname, subnetname, sshname, volname, name),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("ibm_is_backup_policy.is_backup_policy", "name", backupPolicyNameUpdate),
+					resource.TestCheckResourceAttrSet("ibm_is_backup_policy.is_backup_policy", "match_resource_types.#"),
+					resource.TestCheckResourceAttrSet("ibm_is_backup_policy.is_backup_policy", "match_user_tags.#"),
+					resource.TestCheckResourceAttrSet("ibm_is_backup_policy.is_backup_policy", "resource_group"),
+					resource.TestCheckResourceAttrSet("ibm_is_backup_policy.is_backup_policy", "created_at"),
+					resource.TestCheckResourceAttrSet("ibm_is_backup_policy.is_backup_policy", "crn"),
+					resource.TestCheckResourceAttrSet("ibm_is_backup_policy.is_backup_policy", "href"),
+					resource.TestCheckResourceAttrSet("ibm_is_backup_policy.is_backup_policy", "lifecycle_state"),
+					resource.TestCheckResourceAttrSet("ibm_is_backup_policy.is_backup_policy", "resource_type"),
+					resource.TestCheckResourceAttrSet("ibm_is_backup_policy.is_backup_policy", "version"),
+				),
+			},
+			{
+				ResourceName:      "ibm_is_backup_policy.is_backup_policy",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testAccCheckIBMIsBackupPolicyConfigBasic(backupPolicyName string, vpcname, subnetname, sshname, volName, name string) string {
+	return fmt.Sprintf(`
+	resource "ibm_is_vpc" "testacc_vpc" {
+		name = "%s"
+	  }
+
+	  resource "ibm_is_subnet" "testacc_subnet" {
+		name            = "%s"
+		vpc             = ibm_is_vpc.testacc_vpc.id
+		zone            = "%s"
+		ipv4_cidr_block = "%s"
+	  }
+
+	  resource "ibm_is_ssh_key" "testacc_sshkey" {
+		name       = "%s"
+		// public_key = file("../../test-fixtures/.ssh/id_rsa")
+		public_key = file("~/.ssh/id_rsa.pub")
+	  }
+
+	  resource "ibm_is_volume" "storage" {
+		name    = "%s"
+		profile = "10iops-tier"
+		zone    = "%s"
+		# capacity= 200
+		user_tags 	= ["tag-0"]
+	  }
+
+	  resource "ibm_is_instance" "testacc_instance" {
+		name    = "%s"
+		image   = "%s"
+		profile = "%s"
+		primary_network_interface {
+		  subnet = ibm_is_subnet.testacc_subnet.id
+		}
+		vpc     = ibm_is_vpc.testacc_vpc.id
+		zone    = "%s"
+		keys    = [ibm_is_ssh_key.testacc_sshkey.id]
+		volumes = [ibm_is_volume.storage.id]
+	  }
+
+	  resource "ibm_is_backup_policy" "is_backup_policy" {
+		depends_on  = [ibm_is_instance.testacc_instance]
+		match_user_tags = ["tag-0"]
+		name            = "%s"
+	}`, vpcname, subnetname, acc.ISZoneName, acc.ISCIDR, sshname, volName, acc.ISZoneName, name, acc.IsImage, acc.InstanceProfileName, acc.ISZoneName, backupPolicyName)
+}
+
+func testAccCheckIBMIsBackupPolicyDestroy(s *terraform.State) error {
+	vpcClient, err := acc.TestAccProvider.Meta().(conns.ClientSession).VpcV1API()
+
+	if err != nil {
+		return err
+	}
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "ibm_is_backup_policy" {
+			continue
+		}
+
+		getBackupPolicyOptions := &vpcv1.GetBackupPolicyOptions{}
+
+		getBackupPolicyOptions.SetID(rs.Primary.ID)
+
+		// Try to find the key
+		_, response, err := vpcClient.GetBackupPolicy(getBackupPolicyOptions)
+
+		if err == nil {
+			return fmt.Errorf("BackupPolicy still exists: %s", rs.Primary.ID)
+		} else if response.StatusCode != 404 {
+			return fmt.Errorf("Error checking for BackupPolicy (%s) has been destroyed: %s", rs.Primary.ID, err)
+		}
+	}
+
+	return nil
+}

--- a/ibm/service/vpc/resource_ibm_is_backup_policy_test.go
+++ b/ibm/service/vpc/resource_ibm_is_backup_policy_test.go
@@ -93,7 +93,7 @@ func testAccCheckIBMIsBackupPolicyConfigBasic(backupPolicyName string, vpcname, 
 		profile = "10iops-tier"
 		zone    = "%s"
 		# capacity= 200
-		user_tags 	= ["tag-0"]
+		tags 	= ["tag-0"]
 	  }
 
 	  resource "ibm_is_instance" "testacc_instance" {

--- a/ibm/service/vpc/resource_ibm_is_snapshot.go
+++ b/ibm/service/vpc/resource_ibm_is_snapshot.go
@@ -7,6 +7,8 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"os"
+	"strings"
 	"time"
 
 	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/flex"
@@ -18,30 +20,31 @@ import (
 )
 
 const (
-	isSnapshotName            = "name"
-	isSnapshotResourceGroup   = "resource_group"
-	isSnapshotSourceVolume    = "source_volume"
-	isSnapshotSourceImage     = "source_image"
-	isSnapshotUserTags        = "user_tags"
-	isSnapshotCRN             = "crn"
-	isSnapshotHref            = "href"
-	isSnapshotEncryption      = "encryption"
-	isSnapshotEncryptionKey   = "encryption_key"
-	isSnapshotOperatingSystem = "operating_system"
-	isSnapshotLCState         = "lifecycle_state"
-	isSnapshotMinCapacity     = "minimum_capacity"
-	isSnapshotResourceType    = "resource_type"
-	isSnapshotSize            = "size"
-	isSnapshotBootable        = "bootable"
-	isSnapshotDeleting        = "deleting"
-	isSnapshotDeleted         = "deleted"
-	isSnapshotAvailable       = "stable"
-	isSnapshotFailed          = "failed"
-	isSnapshotPending         = "pending"
-	isSnapshotSuspended       = "suspended"
-	isSnapshotUpdating        = "updating"
-	isSnapshotWaiting         = "waiting"
-	isSnapshotCapturedAt      = "captured_at"
+	isSnapshotName             = "name"
+	isSnapshotResourceGroup    = "resource_group"
+	isSnapshotSourceVolume     = "source_volume"
+	isSnapshotSourceImage      = "source_image"
+	isSnapshotUserTags         = "tags"
+	isSnapshotCRN              = "crn"
+	isSnapshotHref             = "href"
+	isSnapshotEncryption       = "encryption"
+	isSnapshotEncryptionKey    = "encryption_key"
+	isSnapshotOperatingSystem  = "operating_system"
+	isSnapshotLCState          = "lifecycle_state"
+	isSnapshotMinCapacity      = "minimum_capacity"
+	isSnapshotResourceType     = "resource_type"
+	isSnapshotSize             = "size"
+	isSnapshotBootable         = "bootable"
+	isSnapshotDeleting         = "deleting"
+	isSnapshotDeleted          = "deleted"
+	isSnapshotAvailable        = "stable"
+	isSnapshotFailed           = "failed"
+	isSnapshotPending          = "pending"
+	isSnapshotSuspended        = "suspended"
+	isSnapshotUpdating         = "updating"
+	isSnapshotWaiting          = "waiting"
+	isSnapshotCapturedAt       = "captured_at"
+	isSnapshotBackupPolicyPlan = "backup_policy_plan"
 )
 
 func ResourceIBMSnapshot() *schema.Resource {
@@ -150,6 +153,59 @@ func ResourceIBMSnapshot() *schema.Resource {
 				Computed:    true,
 				Description: "The size of the snapshot",
 			},
+
+			isSnapshotUserTags: {
+				Type:        schema.TypeSet,
+				Optional:    true,
+				Computed:    true,
+				Elem:        &schema.Schema{Type: schema.TypeString, ValidateFunc: validate.InvokeValidator("ibm_is_snapshot", isSnapshotUserTags)},
+				Set:         flex.ResourceIBMVPCHash,
+				Description: "User Tags for the snapshot",
+			},
+
+			isSnapshotBackupPolicyPlan: {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Description: "If present, the backup policy plan which created this snapshot.",
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"deleted": &schema.Schema{
+							Type:        schema.TypeList,
+							Computed:    true,
+							Description: "If present, this property indicates the referenced resource has been deleted and provides some supplementary information.",
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"more_info": &schema.Schema{
+										Type:        schema.TypeString,
+										Computed:    true,
+										Description: "Link to documentation about deleted resources.",
+									},
+								},
+							},
+						},
+						"href": &schema.Schema{
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "The URL for this backup policy plan.",
+						},
+						"id": &schema.Schema{
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "The unique identifier for this backup policy plan.",
+						},
+						"name": &schema.Schema{
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "The unique user-defined name for this backup policy plan.",
+						},
+						"resource_type": &schema.Schema{
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "The type of resource referenced",
+						},
+					},
+				},
+			},
 		},
 	}
 }
@@ -166,6 +222,15 @@ func ResourceIBMISSnapshotValidator() *validate.ResourceValidator {
 			Regexp:                     `^([a-z]|[a-z][-a-z0-9]*[a-z0-9])$`,
 			MinValueLength:             1,
 			MaxValueLength:             63})
+	validateSchema = append(validateSchema,
+		validate.ValidateSchema{
+			Identifier:                 isSnapshotUserTags,
+			ValidateFunctionIdentifier: validate.ValidateRegexpLen,
+			Type:                       validate.TypeString,
+			Optional:                   true,
+			Regexp:                     `^[A-Za-z0-9:_ .-]+$`,
+			MinValueLength:             1,
+			MaxValueLength:             128})
 	ibmISSnapshotResourceValidator := validate.ResourceValidator{ResourceName: "ibm_is_snapshot", Schema: validateSchema}
 	return &ibmISSnapshotResourceValidator
 }
@@ -191,6 +256,25 @@ func resourceIBMISSnapshotCreate(d *schema.ResourceData, meta interface{}) error
 		rg := grp.(string)
 		snapshotprototypeoptions.ResourceGroup = &vpcv1.ResourceGroupIdentity{
 			ID: &rg,
+		}
+	}
+
+	var userTags *schema.Set
+	if v, ok := d.GetOk(isSnapshotUserTags); ok {
+		userTags = v.(*schema.Set)
+		if userTags != nil && userTags.Len() != 0 {
+			userTagsArray := make([]string, userTags.Len())
+			for i, userTag := range userTags.List() {
+				userTagStr := userTag.(string)
+				userTagsArray[i] = userTagStr
+			}
+			schematicTags := os.Getenv("IC_ENV_TAGS")
+			var envTags []string
+			if schematicTags != "" {
+				envTags = strings.Split(schematicTags, ",")
+				userTagsArray = append(userTagsArray, envTags...)
+			}
+			snapshotprototypeoptions.UserTags = userTagsArray
 		}
 	}
 	options.SnapshotPrototype = snapshotprototypeoptions
@@ -285,6 +369,11 @@ func snapshotGet(d *schema.ResourceData, meta interface{}, id string) error {
 	d.Set(isSnapshotLCState, *snapshot.LifecycleState)
 	d.Set(isSnapshotResourceType, *snapshot.ResourceType)
 	d.Set(isSnapshotBootable, *snapshot.Bootable)
+	if snapshot.UserTags != nil {
+		if err = d.Set(isSnapshotUserTags, snapshot.UserTags); err != nil {
+			return fmt.Errorf("Error setting user tags: %s", err)
+		}
+	}
 	if snapshot.ResourceGroup != nil && snapshot.ResourceGroup.ID != nil {
 		d.Set(isSnapshotResourceGroup, *snapshot.ResourceGroup.ID)
 	}
@@ -299,6 +388,21 @@ func snapshotGet(d *schema.ResourceData, meta interface{}, id string) error {
 	if snapshot.OperatingSystem != nil && snapshot.OperatingSystem.Name != nil {
 		d.Set(isSnapshotOperatingSystem, *snapshot.OperatingSystem.Name)
 	}
+	backupPolicyPlanList := []map[string]interface{}{}
+	if snapshot.BackupPolicyPlan != nil {
+		backupPolicyPlan := map[string]interface{}{}
+		if snapshot.BackupPolicyPlan.Deleted != nil {
+			snapshotBackupPolicyPlanDeletedMap := map[string]interface{}{}
+			snapshotBackupPolicyPlanDeletedMap["more_info"] = snapshot.BackupPolicyPlan.Deleted.MoreInfo
+			backupPolicyPlan["deleted"] = []map[string]interface{}{snapshotBackupPolicyPlanDeletedMap}
+		}
+		backupPolicyPlan["href"] = snapshot.BackupPolicyPlan.Href
+		backupPolicyPlan["id"] = snapshot.BackupPolicyPlan.ID
+		backupPolicyPlan["name"] = snapshot.BackupPolicyPlan.Name
+		backupPolicyPlan["resource_type"] = snapshot.BackupPolicyPlan.ResourceType
+		backupPolicyPlanList = append(backupPolicyPlanList, backupPolicyPlan)
+	}
+	d.Set(isSnapshotBackupPolicyPlan, backupPolicyPlanList)
 	return nil
 }
 
@@ -324,6 +428,62 @@ func snapshotUpdate(d *schema.ResourceData, meta interface{}, id, name string, h
 	if err != nil {
 		return err
 	}
+
+	getSnapshotOptions := &vpcv1.GetSnapshotOptions{
+		ID: &id,
+	}
+	_, response, err := sess.GetSnapshot(getSnapshotOptions)
+	if err != nil {
+		if response != nil && response.StatusCode == 404 {
+			d.SetId("")
+			return nil
+		}
+		return fmt.Errorf("Error getting Snapshot : %s\n%s", err, response)
+	}
+	eTag := response.Headers.Get("ETag")
+
+	updateSnapshotOptions := &vpcv1.UpdateSnapshotOptions{
+		ID: &id,
+	}
+	updateSnapshotOptions.IfMatch = &eTag
+
+	// user tags update
+	if d.HasChange(isSnapshotUserTags) {
+		var userTags *schema.Set
+		if v, ok := d.GetOk(isSnapshotUserTags); ok {
+
+			userTags = v.(*schema.Set)
+			if userTags != nil && userTags.Len() != 0 {
+				userTagsArray := make([]string, userTags.Len())
+				for i, userTag := range userTags.List() {
+					userTagStr := userTag.(string)
+					userTagsArray[i] = userTagStr
+				}
+				schematicTags := os.Getenv("IC_ENV_TAGS")
+				var envTags []string
+				if schematicTags != "" {
+					envTags = strings.Split(schematicTags, ",")
+					userTagsArray = append(userTagsArray, envTags...)
+				}
+				snapshotPatchModel := &vpcv1.SnapshotPatch{}
+				snapshotPatchModel.UserTags = userTagsArray
+				snapshotPatch, err := snapshotPatchModel.AsPatch()
+				if err != nil {
+					return fmt.Errorf("Error calling asPatch for SnapshotPatch: %s", err)
+				}
+				updateSnapshotOptions.SnapshotPatch = snapshotPatch
+				_, response, err := sess.UpdateSnapshot(updateSnapshotOptions)
+				if err != nil {
+					return fmt.Errorf("Error updating Snapshot : %s\n%s", err, response)
+				}
+				_, err = isWaitForSnapshotUpdate(sess, d.Id(), d.Timeout(schema.TimeoutCreate))
+				if err != nil {
+					return err
+				}
+			}
+		}
+	}
+
 	if d.HasChange(isSnapshotName) {
 		updateSnapshotOptions := &vpcv1.UpdateSnapshotOptions{
 			ID: &id,

--- a/ibm/service/vpc/resource_ibm_is_snapshot_test.go
+++ b/ibm/service/vpc/resource_ibm_is_snapshot_test.go
@@ -56,6 +56,54 @@ ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCKVmnMOlHKcZK8tpt3MP1lqOLAcqcJzhsvJcjscgVE
 	})
 }
 
+func TestAccIBMISSnapshotUsertag_basic(t *testing.T) {
+	var snapshot string
+	vpcname := fmt.Sprintf("tf-vpc-%d", acctest.RandIntRange(10, 100))
+	name := fmt.Sprintf("tf-instnace-%d", acctest.RandIntRange(10, 100))
+	subnetname := fmt.Sprintf("tf-subnet-%d", acctest.RandIntRange(10, 100))
+	publicKey := strings.TrimSpace(`
+ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCKVmnMOlHKcZK8tpt3MP1lqOLAcqcJzhsvJcjscgVERRN7/9484SOBJ3HSKxxNG5JN8owAjy5f9yYwcUg+JaUVuytn5Pv3aeYROHGGg+5G346xaq3DAwX6Y5ykr2fvjObgncQBnuU5KHWCECO/4h8uWuwh/kfniXPVjFToc+gnkqA+3RKpAecZhFXwfalQ9mMuYGFxn+fwn8cYEApsJbsEmb0iJwPiZ5hjFC8wREuiTlhPHDgkBLOiycd20op2nXzDbHfCHInquEe/gYxEitALONxm0swBOwJZwlTDOB7C6y2dzlrtxr1L59m7pCkWI4EtTRLvleehBoj3u7jB4usR
+`)
+	sshname := fmt.Sprintf("tf-ssh-%d", acctest.RandIntRange(10, 100))
+	volname := fmt.Sprintf("tf-vol-%d", acctest.RandIntRange(10, 100))
+	name1 := fmt.Sprintf("tfsnapshotuat-%d", acctest.RandIntRange(10, 100))
+	// name2 := fmt.Sprintf("tfsnapshotuat-%d", acctest.RandIntRange(10, 100))
+	tagname := fmt.Sprintf("tfusertag%d", acctest.RandIntRange(10, 100))
+	tagnameupdate := fmt.Sprintf("tfusertagupd%d", acctest.RandIntRange(10, 100))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { acc.TestAccPreCheck(t) },
+		Providers:    acc.TestAccProviders,
+		CheckDestroy: testAccCheckIBMISSnapshotDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckIBMISSnapshotConfigUsertag(vpcname, subnetname, sshname, publicKey, volname, name, name1, tagname),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckIBMISSnapshotExists("ibm_is_snapshot.testacc_snapshot", snapshot),
+					resource.TestCheckResourceAttrSet(
+						"ibm_is_snapshot.testacc_snapshot", "tags.#"),
+					resource.TestCheckResourceAttrSet(
+						"ibm_is_snapshot.testacc_snapshot", "tags.0"),
+					resource.TestCheckResourceAttr(
+						"ibm_is_snapshot.testacc_snapshot", "tags.0", tagname),
+				),
+			},
+			{
+				Config: testAccCheckIBMISSnapshotConfigUsertag(vpcname, subnetname, sshname, publicKey, volname, name, name1, tagnameupdate),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckIBMISSnapshotExists("ibm_is_snapshot.testacc_snapshot", snapshot),
+					resource.TestCheckResourceAttrSet(
+						"ibm_is_snapshot.testacc_snapshot", "tags.#"),
+					resource.TestCheckResourceAttrSet(
+						"ibm_is_snapshot.testacc_snapshot", "tags.0"),
+					resource.TestCheckResourceAttr(
+						"ibm_is_snapshot.testacc_snapshot", "tags.0", tagnameupdate),
+				),
+			},
+		},
+	})
+}
+
 func testAccCheckIBMISSnapshotDestroy(s *terraform.State) error {
 	sess, _ := acc.TestAccProvider.Meta().(conns.ClientSession).VpcV1API()
 	for _, rs := range s.RootModule().Resources {
@@ -177,5 +225,46 @@ func testAccCheckIBMISSnapshotConfigUpdate(vpcname, subnetname, sshname, publicK
 		source_volume 	= ibm_is_instance.testacc_instance.volume_attachments[0].volume_id
 	  }
 `, vpcname, subnetname, acc.ISZoneName, sshname, publicKey, name, acc.IsImage, acc.InstanceProfileName, acc.ISZoneName, sname)
+
+}
+
+func testAccCheckIBMISSnapshotConfigUsertag(vpcname, subnetname, sshname, publicKey, volname, name, sname, usertag string) string {
+	return fmt.Sprintf(`
+		resource "ibm_is_vpc" "testacc_vpc" {
+			name = "%s"
+		  }
+
+		  resource "ibm_is_subnet" "testacc_subnet" {
+			name           				= "%s"
+			vpc             			= ibm_is_vpc.testacc_vpc.id
+			zone            			= "%s"
+			total_ipv4_address_count 	= 16
+		  }
+
+		  resource "ibm_is_ssh_key" "testacc_sshkey" {
+			name       = "%s"
+			public_key = "%s"
+		  }
+
+		  resource "ibm_is_instance" "testacc_instance" {
+			name    = "%s"
+			image   = "%s"
+			profile = "%s"
+			primary_network_interface {
+			  subnet     = ibm_is_subnet.testacc_subnet.id
+			}
+			vpc  = ibm_is_vpc.testacc_vpc.id
+			zone = "%s"
+			keys = [ibm_is_ssh_key.testacc_sshkey.id]
+			network_interfaces {
+			  subnet = ibm_is_subnet.testacc_subnet.id
+			  name   = "eth1"
+			}
+		  }
+		resource "ibm_is_snapshot" "testacc_snapshot" {
+			name 			= "%s"
+			source_volume 	= ibm_is_instance.testacc_instance.volume_attachments[0].volume_id
+			tags = ["%s"]
+	}`, vpcname, subnetname, acc.ISZoneName, sshname, publicKey, name, acc.IsImage, acc.InstanceProfileName, acc.ISZoneName, sname, usertag)
 
 }

--- a/ibm/service/vpc/resource_ibm_is_volume.go
+++ b/ibm/service/vpc/resource_ibm_is_volume.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"log"
 	"os"
+	"strings"
 	"time"
 
 	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/flex"
@@ -180,7 +181,7 @@ func ResourceIBMISVolume() *schema.Resource {
 				Computed:    true,
 				Elem:        &schema.Schema{Type: schema.TypeString, ValidateFunc: validate.InvokeValidator("ibm_is_volume", "tags")},
 				Set:         flex.ResourceIBMVPCHash,
-				Description: "Tags for the volume instance",
+				Description: "UserTags for the volume instance",
 			},
 
 			flex.ResourceControllerURL: {
@@ -329,6 +330,25 @@ func volCreate(d *schema.ResourceData, meta interface{}, volName, profile, zone 
 		volTemplate.Iops = &iops
 	}
 
+	var userTags *schema.Set
+	if v, ok := d.GetOk(isVolumeTags); ok {
+		userTags = v.(*schema.Set)
+		if userTags != nil && userTags.Len() != 0 {
+			userTagsArray := make([]string, userTags.Len())
+			for i, userTag := range userTags.List() {
+				userTagStr := userTag.(string)
+				userTagsArray[i] = userTagStr
+			}
+			schematicTags := os.Getenv("IC_ENV_TAGS")
+			var envTags []string
+			if schematicTags != "" {
+				envTags = strings.Split(schematicTags, ",")
+				userTagsArray = append(userTagsArray, envTags...)
+			}
+			volTemplate.UserTags = userTagsArray
+		}
+	}
+
 	vol, response, err := sess.CreateVolume(options)
 	if err != nil {
 		return fmt.Errorf("[DEBUG] Create volume err %s\n%s", err, response)
@@ -338,15 +358,6 @@ func volCreate(d *schema.ResourceData, meta interface{}, volName, profile, zone 
 	_, err = isWaitForVolumeAvailable(sess, d.Id(), d.Timeout(schema.TimeoutCreate))
 	if err != nil {
 		return err
-	}
-	v := os.Getenv("IC_ENV_TAGS")
-	if _, ok := d.GetOk(isVolumeTags); ok || v != "" {
-		oldList, newList := d.GetChange(isVolumeTags)
-		err = flex.UpdateTagsUsingCRN(oldList, newList, meta, *vol.CRN)
-		if err != nil {
-			log.Printf(
-				"Error on create of resource Volume (%s) tags: %s", d.Id(), err)
-		}
 	}
 	return nil
 }
@@ -411,12 +422,11 @@ func volGet(d *schema.ResourceData, meta interface{}, id string) error {
 		}
 		d.Set(isVolumeStatusReasons, statusReasonsList)
 	}
-	tags, err := flex.GetTagsUsingCRN(meta, *vol.CRN)
-	if err != nil {
-		log.Printf(
-			"Error on get of resource vpc volume (%s) tags: %s", d.Id(), err)
+	if vol.UserTags != nil {
+		if err = d.Set(isVolumeTags, vol.UserTags); err != nil {
+			return fmt.Errorf("Error setting user tags: %s", err)
+		}
 	}
-	d.Set(isVolumeTags, tags)
 	controller, err := flex.GetBaseController(meta)
 	if err != nil {
 		return err
@@ -465,26 +475,22 @@ func volUpdate(d *schema.ResourceData, meta interface{}, id, name string, hasNam
 		deleteAllSnapshots(sess, id)
 	}
 
-	// tags update
-	if d.HasChange(isVolumeTags) {
-		options := &vpcv1.GetVolumeOptions{
-			ID: &id,
-		}
-		vol, response, err := sess.GetVolume(options)
-		if err != nil {
-			return fmt.Errorf("[ERROR] Error getting Volume : %s\n%s", err, response)
-		}
-		oldList, newList := d.GetChange(isVolumeTags)
-		err = flex.UpdateTagsUsingCRN(oldList, newList, meta, *vol.CRN)
-		if err != nil {
-			log.Printf(
-				"Error on update of resource vpc volume (%s) tags: %s", id, err)
-		}
+	optionsget := &vpcv1.GetVolumeOptions{
+		ID: &id,
 	}
-
+	_, response, err := sess.GetVolume(optionsget)
+	if err != nil {
+		if response != nil && response.StatusCode == 404 {
+			d.SetId("")
+			return nil
+		}
+		return fmt.Errorf("Error getting Volume (%s): %s\n%s", id, err, response)
+	}
+	eTag := response.Headers.Get("ETag")
 	options := &vpcv1.UpdateVolumeOptions{
 		ID: &id,
 	}
+	options.IfMatch = &eTag
 
 	//name update
 	volumeNamePatchModel := &vpcv1.VolumePatch{}
@@ -622,6 +628,43 @@ func volUpdate(d *schema.ResourceData, meta interface{}, id, name string, hasNam
 		_, err = isWaitForVolumeAvailable(sess, d.Id(), d.Timeout(schema.TimeoutCreate))
 		if err != nil {
 			return err
+		}
+	}
+
+	// user tags update
+	if d.HasChange(isVolumeTags) {
+		var userTags *schema.Set
+		if v, ok := d.GetOk(isVolumeTags); ok {
+			userTags = v.(*schema.Set)
+			if userTags != nil && userTags.Len() != 0 {
+				userTagsArray := make([]string, userTags.Len())
+				for i, userTag := range userTags.List() {
+					userTagStr := userTag.(string)
+					userTagsArray[i] = userTagStr
+				}
+				schematicTags := os.Getenv("IC_ENV_TAGS")
+				var envTags []string
+				if schematicTags != "" {
+					envTags = strings.Split(schematicTags, ",")
+					userTagsArray = append(userTagsArray, envTags...)
+				}
+				volumeNamePatchModel := &vpcv1.VolumePatch{}
+				volumeNamePatchModel.UserTags = userTagsArray
+				volumeNamePatch, err := volumeNamePatchModel.AsPatch()
+				if err != nil {
+					return fmt.Errorf("Error calling asPatch for volumeNamePatch: %s", err)
+				}
+				options.IfMatch = &eTag
+				options.VolumePatch = volumeNamePatch
+				_, response, err := sess.UpdateVolume(options)
+				if err != nil {
+					return fmt.Errorf("Error updating volume : %s\n%s", err, response)
+				}
+				_, err = isWaitForVolumeAvailable(sess, d.Id(), d.Timeout(schema.TimeoutCreate))
+				if err != nil {
+					return err
+				}
+			}
 		}
 	}
 

--- a/ibm/service/vpc/resource_ibm_is_volume_test.go
+++ b/ibm/service/vpc/resource_ibm_is_volume_test.go
@@ -49,6 +49,48 @@ func TestAccIBMISVolume_basic(t *testing.T) {
 	})
 }
 
+func TestAccIBMISVolumeUsertag_basic(t *testing.T) {
+	var vol string
+	name := fmt.Sprintf("tf-vol-%d", acctest.RandIntRange(10, 100))
+	tagname := fmt.Sprintf("tfusertag%d", acctest.RandIntRange(10, 100))
+	tagnameupdate := fmt.Sprintf("tfusertagupd%d", acctest.RandIntRange(10, 100))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { acc.TestAccPreCheck(t) },
+		Providers:    acc.TestAccProviders,
+		CheckDestroy: testAccCheckIBMISVolumeDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccCheckIBMISVolumeUsertagConfig(name, tagname),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckIBMISVolumeExists("ibm_is_volume.storage", vol),
+					resource.TestCheckResourceAttr(
+						"ibm_is_volume.storage", "name", name),
+					resource.TestCheckResourceAttrSet(
+						"ibm_is_volume.storage", "tags.#"),
+					resource.TestCheckResourceAttrSet(
+						"ibm_is_volume.storage", "tags.0"),
+					resource.TestCheckResourceAttr(
+						"ibm_is_volume.storage", "tags.0", tagname),
+				),
+			},
+
+			resource.TestStep{
+				Config: testAccCheckIBMISVolumeUsertagConfig(name, tagnameupdate),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckIBMISVolumeExists("ibm_is_volume.storage", vol),
+					resource.TestCheckResourceAttrSet(
+						"ibm_is_volume.storage", "tags.#"),
+					resource.TestCheckResourceAttrSet(
+						"ibm_is_volume.storage", "tags.0"),
+					resource.TestCheckResourceAttr(
+						"ibm_is_volume.storage", "tags.0", tagnameupdate),
+				),
+			},
+		},
+	})
+}
+
 func TestAccIBMISVolumeUpdateCustom_basic(t *testing.T) {
 	var vol string
 	vpcname := fmt.Sprintf("tf-vpc-%d", acctest.RandIntRange(10, 100))
@@ -449,5 +491,19 @@ func testAccCheckIBMISVolumeCapacityConfig(vpcname, subnetname, sshname, publicK
 		}	
 
 `, vpcname, subnetname, acc.ISZoneName, sshname, publicKey, volName, acc.ISZoneName, capacity, name, acc.IsImage, acc.InstanceProfileName, acc.ISZoneName)
+
+}
+
+func testAccCheckIBMISVolumeUsertagConfig(name, usertag string) string {
+	return fmt.Sprintf(
+		`
+    resource "ibm_is_volume" "storage"{
+        name = "%s"
+        profile = "10iops-tier"
+        zone = "us-south-1"
+        # capacity= 200
+        tags = ["%s"]
+    }
+`, name, usertag)
 
 }

--- a/website/docs/d/is_backup_policies.html.markdown
+++ b/website/docs/d/is_backup_policies.html.markdown
@@ -1,0 +1,73 @@
+---
+subcategory: "VPC infrastructure"
+layout: "ibm"
+page_title: "IBM : is_backup_policies"
+description: |-
+  Get information about backup policies.
+---
+
+# ibm_is_backup_policies
+
+Provides a read-only data source for BackupPolicyCollection. For more information, about backup policy in your IBM Cloud VPC, see [Backup policy](https://cloud.ibm.com/docs/vpc?topic=vpc-backup-view-policies).
+
+**Note:** 
+VPC infrastructure services are a regional specific based endpoint, by default targets to `us-south`. Please make sure to target right region in the provider block as shown in the `provider.tf` file, if VPC service is created in region other than `us-south`.
+
+**provider.tf**
+
+```terraform
+provider "ibm" {
+  region = "eu-gb"
+}
+```
+
+## Example Usage
+
+```terraform
+data "ibm_is_backup_policies" "example" {
+}
+```
+ 
+## Argument Reference
+
+Review the argument reference that you can specify for your data source.
+
+- `name` - (Optional, String) Filters the collection to resources with the exact specified name.
+- `resource_group` - (Optional, String) Filters the collection to resources in the resource group with the specified identifier.
+- `tag` - (Optional, String) Filters the collection to resources with the exact tag value.
+
+## Attribute Reference
+In addition to all argument reference list, you can access the following attribute references after your data source is created.
+
+- `id` - The unique identifier of the BackupPolicyCollection.
+- `backup_policies` - (List) Collection of backup policies. 
+  
+  Nested `backup_policies` blocks have the following structure:
+  - `created_at` -  (String) The date and time that the backup policy was created.
+  - `crn` - (String) The CRN for this backup policy.
+  - `href` - (String) The URL for this backup policy.
+  - `id` - (String) The unique identifier for this backup policy.
+  - `last_job_completed_at` - (String) he date and time that the most recent job for this backup policy completed.
+  - `lifecycle_state` - (String) The lifecycle state of the backup policy.
+  - `match_resource_types` - (List) A resource type this backup policy applies to. Resources that have both a matching type and a matching user tag will be subject to the backup policy.
+  - `match_user_tags` - (List) The user tags this backup policy applies to. Resources that have both a matching user tag and a matching type will be subject to the backup policy.
+  - `name` - (String) The unique user-defined name for this backup policy.
+  - `plans` - (List) The plans for the backup policy. 
+    
+      Nested `plans` blocks have the following structure:
+      - `deleted` - (List) If present, this property indicates the referenced resource has been deleted and provides some supplementary information.
+        
+          Nested `deleted` blocks have the following structure: 
+          - `more_info` - (String) Link to documentation about deleted resources.
+      - `href` - (String) The URL for this backup policy plan.
+      - `id` - (String) The unique identifier for this backup policy plan.
+      - `name` - (String) The unique user-defined name for this backup policy plan.
+      - `resource_type` - (String) The type of resource referenced.
+    - `resource_group` - (List) The resource group for this backup policy. 
+    
+      Nested `resource_group` blocks have the following structure:
+        - `href` - (String) The URL for this resource group.
+        - `id` - (String) The unique identifier for this resource group.
+        - `name` - (String) The user-defined name for this resource group.
+
+

--- a/website/docs/d/is_backup_policy.html.markdown
+++ b/website/docs/d/is_backup_policy.html.markdown
@@ -1,0 +1,69 @@
+---
+subcategory: "VPC infrastructure"
+layout: "ibm"
+page_title: "IBM : ibm_is_backup_policy"
+description: |-
+  Get information about backup policy.
+---
+
+# ibm_is_backup_policy
+
+Provides a read-only data source for BackupPolicy. For more information, about backup policy in your IBM Cloud VPC, see [Backup policy](https://cloud.ibm.com/docs/vpc?topic=vpc-backup-view-policies).
+
+**Note:** 
+VPC infrastructure services are a regional specific based endpoint, by default targets to `us-south`. Please make sure to target right region in the provider block as shown in the `provider.tf` file, if VPC service is created in region other than `us-south`.
+
+**provider.tf**
+
+```terraform
+provider "ibm" {
+  region = "eu-gb"
+}
+```
+
+## Example Usage
+
+```terraform
+data "ibm_is_backup_policy" "example" {
+  identifier = ibm_is_backup_policy.example.id
+}
+```
+
+## Argument Reference
+Review the argument references that you can specify for your data source. 
+
+- `backup_policy_id` - (Optional, string) Filters the collection to backup policy jobs with the backup plan with the specified identifier.
+- `identifier` - (Optional, string) The backup policy identifier, `identifier` and `name` are mutually exclusive.
+- `name` - (Optional, string) The unique user-defined name for backup policy, `identifier` and `name` are mutually exclusive.
+
+## Attribute Reference
+In addition to all argument reference list, you can access the following attribute references after your data source is created.
+
+- `id` - The unique identifier of the BackupPolicy.
+- `created_at` - (String) The date and time that the backup policy was created.
+- `crn` - (String) The CRN for this backup policy.
+- `href` - (String) The URL for this backup policy.
+- `last_job_completed_at` - (String) he date and time that the most recent job for this backup policy completed.
+- `lifecycle_state` - (String) The lifecycle state of the backup policy.
+- `match_resource_types` - (List) A resource type this backup policy applies to. Resources that have both a matching type and a matching user tag will be subject to the backup policy.
+- `match_user_tags` - (List) The user tags this backup policy applies to. Resources that have both a matching user tag and a matching type will be subject to the backup policy.
+- `name` - (String) The unique user-defined name for this backup policy.
+- `plans` - (List) The plans for the backup policy.
+  
+  Nested `plans` blocks have the following structure:
+  - `deleted` - (List) If present, this property indicates the referenced resource has been deleted and provides some supplementary information. 
+    
+    Nested `deleted` blocks have the following structure:
+    - `more_info` - (String) Link to documentation about deleted resources.
+  - `href` - (String) The URL for this backup policy plan.
+  - `id` - (String) The unique identifier for this backup policy plan.
+  - `name` - (String) The unique user-defined name for this backup policy plan.
+  - `resource_type` - (String) The type of resource referenced.
+- `resource_group` - (List) The resource group for this backup policy.
+  
+  Nested `resource_group` blocks have the following structure:
+  - `href` - (String) The URL for this resource group.
+  - `id` - (String) The unique identifier for this resource group.
+  - `name` - (String) The user-defined name for this resource group.
+- `resource_type` - (String) The type of resource referenced.
+

--- a/website/docs/d/is_backup_policy_plan.html.markdown
+++ b/website/docs/d/is_backup_policy_plan.html.markdown
@@ -1,0 +1,61 @@
+---
+subcategory: "VPC infrastructure"
+layout: "ibm"
+page_title: "IBM : is_backup_policy_plan"
+description: |-
+  Get information about backup policy plan.
+---
+
+# ibm_is_backup_policy_plan
+
+Provides a read-only data source for BackupPolicyPlan. You can then reference the fields of the data source in other resources within the same configuration using interpolation syntax.
+
+**Note:** 
+VPC infrastructure services are a regional specific based endpoint, by default targets to `us-south`. Please make sure to target right region in the provider block as shown in the `provider.tf` file, if VPC service is created in region other than `us-south`.
+
+**provider.tf**
+
+```terraform
+provider "ibm" {
+  region = "eu-gb"
+}
+```
+
+## Example Usage
+
+```terraform
+data "ibm_is_backup_policy_plan" "example" {
+  backup_policy_id = ibm_is_backup_policy.example.id
+  identifier       = ibm_is_backup_policy_plan.example.backup_policy_plan_id
+}
+```
+
+->**Note:**  Backup Policy Jobs are getting enhanced, will be available soon.
+
+## Argument Reference
+Review the argument references that you can specify for your data source. 
+
+- `backup_policy_id` - (Required, String) The backup policy identifier.
+- `identifier` - (Optional, String) The backup policy plan identifier, `identifier` and `name` are mutually exclusive.
+- `name` - (Optional, String) The unique user-defined name for backup policy, `identifier` and `name` are mutually exclusive.
+
+## Attribute Reference
+In addition to all argument reference list, you can access the following attribute references after your data source is created.
+
+- `id` -  The unique identifier of the BackupPolicyPlan.
+- `active` - (Boolean) Indicates whether the plan is active.
+- `attach_user_tags` - (List) User tags to attach to each resource created by this plan.
+- `copy_user_tags` - (Boolean) Indicates whether to copy the source's user tags to the created resource.
+- `created_at` - (String) The date and time that the backup policy plan was created.
+- `cron_spec` - (String) The cron specification for the backup schedule.
+
+	->**Note** The backup policy jobs (which create and delete backups for this plan) will not start until this time, and may start for up to 90 minutes after this time.All backup schedules for plans in the same policy must be at least an hour apart.
+	
+- `deletion_trigger` (List) `deletion_trigger` block has the following structure:
+	
+	Nested scheme for `deletion_trigger`:
+	- `delete_after` - (Integer) The maximum number of days to keep each backup after creation.
+	- `delete_over_count` - (Integer) The maximum number of recent backups to keep. If absent, there is no maximum.
+- `href` - (String) The URL for this backup policy plan.
+- `lifecycle_state` - (String) The lifecycle state of this backup policy plan.
+- `resource_type` - (String) The type of resource referenced.

--- a/website/docs/d/is_backup_policy_plans.html.markdown
+++ b/website/docs/d/is_backup_policy_plans.html.markdown
@@ -1,0 +1,65 @@
+---
+subcategory: "VPC infrastructure"
+layout: "ibm"
+page_title: "IBM : is_backup_policy_plans"
+description: |-
+  Get information about backup policy plans.
+---
+
+# ibm_is_backup_policy_plans
+
+Provides a read-only data source for BackupPolicyPlanCollection. You can then reference the fields of the data source in other resources within the same configuration using interpolation syntax.
+
+**Note:** 
+VPC infrastructure services are a regional specific based endpoint, by default targets to `us-south`. Please make sure to target right region in the provider block as shown in the `provider.tf` file, if VPC service is created in region other than `us-south`.
+
+**provider.tf**
+
+```terraform
+provider "ibm" {
+  region = "eu-gb"
+}
+```
+
+## Example Usage
+
+```terraform
+data "ibm_is_backup_policy_plans" "example" {
+  backup_policy_id = ibm_is_backup_policy.example.id
+  name             = "example-backup-policy-plan"
+}
+```
+
+->**Note:**  Backup Policy Jobs are getting enhanced, will be available soon.
+
+## Argument Reference
+Review the argument references that you can specify for your data source. 
+
+- `backup_policy_id` - (Required, string) The backup policy identifier.
+- `name` - (Optional, string) The unique user-defined name for this backup policy plan.
+
+## Attribute Reference
+In addition to all argument reference list, you can access the following attribute references after your data source is created.
+
+- `id` - The unique identifier of the BackupPolicyPlanCollection.
+- `plans` - (List) Collection of backup policy plans. 
+	
+	Nested `plans` blocks have the following structure:
+	- `active` - (Boolean) Indicates whether the plan is active.
+	- `attach_user_tags` - (List) User tags to attach to each resource created by this plan.
+	- `copy_user_tags` - (Boolean) Indicates whether to copy the source's user tags to the created resource.
+	- `created_at` - (String) The date and time that the backup policy plan was created.
+	- `cron_spec` - (String) The cron specification for the backup schedule.
+
+		->**Note** The backup policy jobs (which create and delete backups for this plan) will not start until this time, and may start for up to 90 minutes after this time.All backup schedules for plans in the same policy must be at least an hour apart.
+		
+	- `deletion_trigger` (List) `deletion_trigger` block has the following structure:
+		
+		Nested scheme for `deletion_trigger`:
+		- `delete_after` - (Integer) The maximum number of days to keep each backup after creation.
+		- `delete_over_count` - (Integer) The maximum number of recent backups to keep. If absent, there is no maximum.
+	- `href` - (String) The URL for this backup policy plan.
+	- `id` - (String) The unique identifier for this backup policy plan.
+	- `lifecycle_state` - (String) The lifecycle state of this backup policy plan.
+	- `name` - (String) The unique user-defined name for this backup policy plan.
+	- `resource_type` - (String) The type of resource referenced.

--- a/website/docs/d/is_snapshot.html.markdown
+++ b/website/docs/d/is_snapshot.html.markdown
@@ -90,6 +90,17 @@ Review the argument references that you can specify for your data source.
 ## Attribute reference
 In addition to all argument reference list, you can access the following attribute reference after your data source is created.
 
+- `backup_policy_plan` - (List) If present, the backup policy plan which created this snapshot.
+  
+   Nested scheme for `backup_policy_plan`:
+    - `deleted` - (List) If present, this property indicates the referenced resource has been deleted and provides some supplementary information.
+   
+      Nested scheme for `deleted`:
+      - `more_info` - (String) Link to documentation about deleted resources.
+    - `href` - (String) The URL for this backup policy plan.
+    - `id` - (String) The unique identifier for this backup policy plan.
+    - `name` - (String) The unique user defined name for this backup policy plan. If unspecified, the name will be a hyphenated list of randomly selected words.
+    - `resource_type` - (String) The type of resource referenced.
 - `bootable` - (Bool) Indicates if a boot volume attachment can be created with a volume created from this snapshot.
 - `crn` - (String) The CRN for this snapshot.
 - `encryption` - (String) The type of encryption used on the source volume. Supported values are **provider_managed**, **user_managed**.
@@ -101,3 +112,4 @@ In addition to all argument reference list, you can access the following attribu
 - `size` - (Integer) The size of this snapshot rounded up to the next gigabyte.
 - `source_image` - (String) If present, the unique identifier for the image from which the data on this volume was most directly provisioned.
 - `captured_at` - (String) The date and time that this snapshot was captured.
+- `tags` - (String) Tags associated with the snapshot.

--- a/website/docs/d/is_snapshots.html.markdown
+++ b/website/docs/d/is_snapshots.html.markdown
@@ -37,6 +37,8 @@ Review the argument references that you can specify for your data source.
 - `resource_group` - (Optional, String) Filter snapshot collection by resource group id of the snapshot.
 - `source_image` - (Optional, String) Filter snapshot collection by source image of the snapshot.
 - `source_volume` - (Optional, String) Filter snapshot collection by source volume of the snapshot.
+- `backup_policy_plan_tag` - Filters the collection to resources with the exact tag value.
+- `backup_policy_plan_id` - Filters the collection to backup policy jobs with the backup plan with the specified identifier
 
 
 ## Attribute reference
@@ -46,6 +48,17 @@ In addition to all argument reference list, you can access the following attribu
   
   Nested scheme for `snapshots`:
   - `id` - (String) The unique identifier for this snapshot.
+  - `backup_policy_plan` - (List) If present, the backup policy plan which created this snapshot.
+  
+   Nested scheme for `backup_policy_plan`:
+    - `deleted` - (List) If present, this property indicates the referenced resource has been deleted and provides some supplementary information.
+   
+      Nested scheme for `deleted`:
+      - `more_info` - (String) Link to documentation about deleted resources.
+    - `href` - (String) The URL for this backup policy plan.
+    - `id` - (String) The unique identifier for this backup policy plan.
+    - `name` - (String) The unique user defined name for this backup policy plan. If unspecified, the name will be a hyphenated list of randomly selected words.
+    - `resource_type` - (String) The type of resource referenced.
   - `bootable` - (Bool) Indicates if a boot volume attachment can be created with a volume created from this snapshot.
   - `crn` - (String) The CRN for this snapshot.
   - `encryption` - (String) The type of encryption used on the source volume. Supported values are **provider_managed**, **user_managed** ]).
@@ -57,4 +70,6 @@ In addition to all argument reference list, you can access the following attribu
   - `size` - (Integer) The size of this snapshot rounded up to the next gigabyte.
   - `source_image` - (String) If present, the unique identifier for the image from which the data on this volume was most directly provisioned.
   - `captured_at` - (String) The date and time that this snapshot was captured.
+  - `tags` - (String) Tags associated with the snapshot.
+
 

--- a/website/docs/d/is_volume.html.markdown
+++ b/website/docs/d/is_volume.html.markdown
@@ -59,4 +59,4 @@ In addition to all argument reference list, you can access the following attribu
   - `code` - (String)  A snake case string identifying the status reason.
   - `message` - (String)  An explanation of the status reason
   - `more_info` - (String) Link to documentation about this status reason
-- `tags` - (String) Tags associated with the volume.
+- `tags` - (String) User Tags associated with the volume. (https://cloud.ibm.com/apidocs/tagging#types-of-tags)

--- a/website/docs/d/is_volumes.html.markdown
+++ b/website/docs/d/is_volumes.html.markdown
@@ -24,7 +24,7 @@ In addition to all argument references listed, you can access the following attr
 
 - `id` - The unique identifier of the VolumeCollection.
 - `volumes` - (List) Collection of volumes.
-Nested scheme for **volumes**:
+	Nested scheme for **volumes**:
 	- `active` - (Boolean) Indicates whether a running virtual server instance has an attachment to this volume.
 	- `bandwidth` - (Integer) The maximum bandwidth (in megabits per second) for the volume.
 	- `busy` - (Boolean) Indicates whether this volume is performing an operation that must be serialized. If an operation specifies that it requires serialization, the operation will fail unless this property is `false`.
@@ -45,13 +45,13 @@ Nested scheme for **volumes**:
 	- `name` - (String) The unique user-defined name for this volume.
 	  - Constraints: The maximum length is `63` characters. The minimum length is `1` character. The value must match regular expression `/^-?([a-z]|[a-z][-a-z0-9]*[a-z0-9]|[0-9][-a-z0-9]*([a-z]|[-a-z][-a-z0-9]*[a-z0-9]))$/`.
 	- `operating_system` - (Optional, List) The operating system associated with this volume. If absent, this volume was notcreated from an image, or the image did not include an operating system.
-	Nested scheme for **operating_system**:
+		Nested scheme for **operating_system**:
 		- `href` - (String) The URL for this operating system.
 		  - Constraints: The value must match regular expression `/^http(s)?:\/\/([^\/?#]*)([^?#]*)(\\?([^#]*))?(#(.*))?$/`.
 		- `name` - (String) The globally unique name for this operating system.
 		  - Constraints: The maximum length is `63` characters. The minimum length is `1` character. The value must match regular expression `/^([a-z]|[a-z][-a-z0-9]*[a-z0-9]|[0-9][-a-z0-9]*([a-z]|[-a-z][-a-z0-9]*[a-z0-9]))$/`.
 	- `profile` - (List) The profile this volume uses.
-	Nested scheme for **profile**:
+		Nested scheme for **profile**:
 		- `href` - (String) The URL for this volume profile.
 		  - Constraints: The value must match regular expression `/^http(s)?:\/\/([^\/?#]*)([^?#]*)(\\?([^#]*))?(#(.*))?$/`.
 		- `name` - (String) The globally unique name for this volume profile.
@@ -65,7 +65,7 @@ Nested scheme for **volumes**:
 		- `name` - (String) The user-defined name for this resource group.
 		  - Constraints: The maximum length is `40` characters. The minimum length is `1` character. The value must match regular expression `/^[a-zA-Z0-9-_ ]+$/`.
 	- `source_image` - (Optional, List) The image from which this volume was created (this may be[deleted](https://cloud.ibm.com/apidocs/vpc#deleted-resources)).If absent, this volume was not created from an image.
-	Nested scheme for **source_image**:
+		Nested scheme for **source_image**:
 		- `crn` - (String) The CRN for this image.
 		- `deleted` - (Optional, List) If present, this property indicates the referenced resource has been deleted and providessome supplementary information.
 		Nested scheme for **deleted**:
@@ -78,7 +78,7 @@ Nested scheme for **volumes**:
 		- `name` - (String) The user-defined or system-provided name for this image.
 		  - Constraints: The maximum length is `63` characters. The minimum length is `1` character. The value must match regular expression `/^-?([a-z]|[a-z][-a-z0-9]*[a-z0-9]|[0-9][-a-z0-9]*([a-z]|[-a-z][-a-z0-9]*[a-z0-9]))$/`.
 	- `source_snapshot` - (Optional, List) The snapshot from which this volume was cloned.
-	Nested scheme for **source_snapshot**:
+		Nested scheme for **source_snapshot**:
 		- `crn` - (String) The CRN for this snapshot.
 		- `deleted` - (Optional, List) If present, this property indicates the referenced resource has been deleted and providessome supplementary information.
 		Nested scheme for **deleted**:
@@ -95,28 +95,29 @@ Nested scheme for **volumes**:
 	- `status` - (String) The status of the volume.The enumerated values for this property will expand in the future. When processing this property, check for and log unknown values. Optionally halt processing and surface the error, or bypass the volume on which the unexpected property value was encountered.
 	  - Constraints: Allowable values are: `available`, `failed`, `pending`, `pending_deletion`, `unusable`.
 	- `status_reasons` - (List) The reasons for the current status (if any).The enumerated reason code values for this property will expand in the future. When processing this property, check for and log unknown values. Optionally halt processing and surface the error, or bypass the resource on which the unexpected reason code was encountered.
-	Nested scheme for **status_reasons**:
+		Nested scheme for **status_reasons**:
 		- `code` - (String) A snake case string succinctly identifying the status reason.
 		  - Constraints: Allowable values are: `encryption_key_deleted`. The value must match regular expression `/^[a-z]+(_[a-z]+)*$/`.
 		- `message` - (String) An explanation of the status reason.
 		- `more_info` - (Optional, String) Link to documentation about this status reason.
 		  - Constraints: The value must match regular expression `/^http(s)?:\/\/([^\/?#]*)([^?#]*)(\\?([^#]*))?(#(.*))?$/`.
+	- `tags` - (String) User Tags associated with the volume. (https://cloud.ibm.com/apidocs/tagging#types-of-tags)
 	- `volume_attachments` - (List) The volume attachments for this volume.
-	Nested scheme for **volume_attachments**:
+		Nested scheme for **volume_attachments**:
 		- `delete_volume_on_instance_delete` - (Boolean) If set to true, when deleting the instance the volume will also be deleted.
 		- `deleted` - (Optional, List) If present, this property indicates the referenced resource has been deleted and providessome supplementary information.
 		Nested scheme for **deleted**:
 			- `more_info` - (String) Link to documentation about deleted resources.
 			  - Constraints: The value must match regular expression `/^http(s)?:\/\/([^\/?#]*)([^?#]*)(\\?([^#]*))?(#(.*))?$/`.
 		- `device` - (Optional, List) Information about how the volume is exposed to the instance operating system.This property may be absent if the volume attachment's `status` is not `attached`.
-		Nested scheme for **device**:
+			Nested scheme for **device**:
 			- `id` - (Optional, String) A unique identifier for the device which is exposed to the instance operating system.
 		- `href` - (String) The URL for this volume attachment.
 		  - Constraints: The value must match regular expression `/^http(s)?:\/\/([^\/?#]*)([^?#]*)(\\?([^#]*))?(#(.*))?$/`.
 		- `id` - (String) The unique identifier for this volume attachment.
 		  - Constraints: The maximum length is `64` characters. The minimum length is `1` character. The value must match regular expression `/^[-0-9a-z_]+$/`.
 		- `instance` - (List) The attached instance.
-		Nested scheme for **instance**:
+			Nested scheme for **instance**:
 			- `crn` - (String) The CRN for this virtual server instance.
 			- `deleted` - (Optional, List) If present, this property indicates the referenced resource has been deleted and providessome supplementary information.
 			Nested scheme for **deleted**:
@@ -133,7 +134,7 @@ Nested scheme for **volumes**:
 		- `type` - (String) The type of volume attachment.
 		  - Constraints: Allowable values are: `boot`, `data`.
 	- `zone` - (List) The zone this volume resides in.
-	Nested scheme for **zone**:
+		Nested scheme for **zone**:
 		- `name` - (String) The globally unique name for this zone.
 		  - Constraints: The maximum length is `63` characters. The minimum length is `1` character. The value must match regular expression `/^([a-z]|[a-z][-a-z0-9]*[a-z0-9]|[0-9][-a-z0-9]*([a-z]|[-a-z][-a-z0-9]*[a-z0-9]))$/`.
 

--- a/website/docs/r/is_backup_policy.html.markdown
+++ b/website/docs/r/is_backup_policy.html.markdown
@@ -1,0 +1,72 @@
+---
+subcategory: "VPC infrastructure"
+layout: "ibm"
+page_title: "IBM : ibm_is_backup_policy"
+description: |-
+  Manages BackupPolicy.
+---
+
+# ibm_is_backup_policy
+
+Provides a resource for BackupPolicy. This allows BackupPolicy to be created, updated and deleted. For more information, about backup policy in your IBM Cloud VPC, see [Backup policy](https://cloud.ibm.com/docs/vpc?topic=vpc-backup-policy-create).
+
+**Note:** 
+VPC infrastructure services are a regional specific based endpoint, by default targets to `us-south`. Please make sure to target right region in the provider block as shown in the `provider.tf` file, if VPC service is created in region other than `us-south`.
+
+
+**provider.tf**
+
+```terraform
+provider "ibm" {
+  region = "eu-gb"
+}
+```
+
+## Example Usage
+
+```terraform
+resource "ibm_is_backup_policy_plan" "example" {
+  backup_policy_id = "backup_policy_id"
+  cron_spec        = "0 12 * * *"
+  name             = "example-backup-policy-plan"
+}
+```
+
+## Argument Reference
+
+Review the argument reference that you can specify for your resource.
+
+- `match_resource_types` - (Optional, List) A resource type this backup policy applies to. Resources that have both a matching type and a matching user tag will be subject to the backup policy. The default value is `["volume"]`.
+- `match_user_tags` - (Required, List) The user tags this backup policy applies to. Resources that have both a matching user tag and a matching type will be subject to the backup policy.
+- `name` - (Required, String) The user-defined name for this backup policy. Names must be unique within the region this backup policy resides in. 
+- `resource_group` - (Optional, List) The resource group to use. If unspecified, the account's [default resource group](https://cloud.ibm.com/apidocs/resource-manager#introduction) is used.
+
+  Nested scheme for `resource_group`: 
+  - `id` - (Optional, String) The unique identifier for this resource group.
+  
+## Attribute Reference
+
+In addition to all argument references listed, you can access the following attribute references after your resource is created.
+
+- `id` - The unique identifier of the BackupPolicy.
+- `created_at` - (String) The date and time that the backup policy was created.
+- `crn` - (String) The CRN for this backup policy.
+- `href` - (String) The URL for this backup policy.
+- `last_job_completed_at` - (String) The date and time that the most recent job for this backup policy completed.
+- `lifecycle_state` - (String) The lifecycle state of the backup policy.
+- `resource_type` - (String) The resource type.
+- `version` - Version of the BackupPolicy.
+
+## Import
+
+You can import the `ibm_is_backup_policy` resource by using `id`. The unique identifier for this backup policy.
+
+# Syntax
+```
+$ terraform import ibm_is_backup_policy.is_backup_policy <id>
+```
+
+# Example
+```
+$ terraform import ibm_is_backup_policy.is_backup_policy 0fe9e5d8-0a4d-4818-96ec-e99708644a58
+```

--- a/website/docs/r/is_backup_policy_plan.html.markdown
+++ b/website/docs/r/is_backup_policy_plan.html.markdown
@@ -1,0 +1,84 @@
+---
+subcategory: "VPC infrastructure"
+layout: "ibm"
+page_title: "IBM : ibm_is_backup_policy_plan"
+description: |-
+  Manages Backup Policy Plan.
+---
+
+# ibm_is_backup_policy_plan
+
+Provides a resource for BackupPolicyPlan. This allows BackupPolicyPlan to be created, updated and deleted.For more information, about backup policy plan in your IBM Cloud VPC, see [Backup policy plan](https://cloud.ibm.com/docs/vpc?topic=vpc-backup-policy-create).
+
+**Note:** 
+VPC infrastructure services are a regional specific based endpoint, by default targets to `us-south`. Please make sure to target right region in the provider block as shown in the `provider.tf` file, if VPC service is created in region other than `us-south`.
+
+
+**provider.tf**
+
+```terraform
+provider "ibm" {
+  region = "eu-gb"
+}
+```
+
+## Example Usage
+
+```terraform
+resource "ibm_is_backup_policy_plan" "example" {
+  backup_policy_id = "backup_policy_id"
+  cron_spec        = "0 12 * * *"
+  name             = "example-backup-policy-plan"
+}
+```
+
+->**Note:**  Backup Policy Jobs are getting enhanced, will be available soon.
+
+## Argument Reference
+
+Review the argument reference that you can specify for your resource.
+
+- `active` - (Optional, Boolean) Indicates whether the plan is active.
+- `attach_user_tags` - (Optional, List) User tags to attach to each backup (snapshot) created by this plan. If unspecified, no user tags will be attached.
+- `backup_policy_id` - (Required, Forces new resource, String) The backup policy identifier.
+backup_policy_plan_id
+- `copy_user_tags` - (Optional, Boolean) Indicates whether to copy the source's user tags to the created backups (snapshots). The default value is `true`.
+- `cron_spec` - (Required, String) The cron specification for the backup schedule. The value must match regular expression `^((((\d+,)+\d+|([\d\*]+(\/|-)\d+)|\d+|\*) ?){5,7})$`.
+
+	->**Note** The backup policy jobs (which create and delete backups for this plan) will not start until this time, and may start for up to 90 minutes after this time.All backup schedules for plans in the same policy must be at least an hour apart.
+		
+- `deletion_trigger` - (Optional, List)
+  
+  Nested scheme for `deletion_trigger`:
+  - `delete_after` - (Optional, Integer) The maximum number of days to keep each backup after creation. Default value is 30.
+  - `delete_over_count` - (Optional, Integer) The maximum number of recent backups to keep. If unspecified, there will be no maximum.
+- `name` - (Optional, String) The user-defined name for this backup policy plan. Names must be unique within the backup policy this plan resides in. If unspecified, the name will be a hyphenated list of randomly-selected words.
+
+## Attribute Reference
+
+In addition to all argument references listed, you can access the following attribute references after your resource is created.
+
+- `id` - The unique identifier of the BackupPolicyPlan.
+- `backup_policy_id` - (String) The backup policy identifier.
+- `created_at` - (String) The date and time that the backup policy plan was created.
+- `href` - (String) The URL for this backup policy plan.
+- `lifecycle_state` - (String) The lifecycle state of this backup policy plan.
+- `resource_type` - (String) The resource type.
+- `version` - Version of the BackupPolicyPlan.
+
+## Import
+
+You can import the `ibm_is_backup_policy_plan` resource by using `id`.
+The `id` property can be formed from `backup_policy_id`, and `id` in the following format:
+
+```
+<0fe9e5d8-0a4d-4818-96ec-e99708644a58>/<0fg9e5d8-0a4d-4818-96ec-e99708634a58>
+```
+- `backup_policy_id`: A string. The backup policy identifier.
+- `id`: A string. The backup policy plan identifier.
+
+# Syntax
+```
+$ terraform import ibm_is_backup_policy_plan.is_backup_policy_plan <0fe9e5d8-0a4d-4818-96ec-e99708644a58>/<0fg9e5d8-0a4d-4818-96ec-e99708634a58>
+
+```

--- a/website/docs/r/is_snapshot.html.markdown
+++ b/website/docs/r/is_snapshot.html.markdown
@@ -81,10 +81,22 @@ Review the argument references that you can specify for your resource.
 - `name` - (Optional, String) The name of the snapshot.
 - `resource_group` - (Optional, Forces new resource, String) The resource group ID where the snapshot is to be created
 - `source_volume` - (Required, Forces new resource, String) The unique identifier for the volume for which snapshot is to be created. 
+- `tags`- (Optional, Array of Strings) A list of user tags that you want to add to your snapshot. (https://cloud.ibm.com/apidocs/tagging#types-of-tags)
+
 
 ## Attribute reference
 In addition to all argument reference list, you can access the following attribute reference after your resource is created.
-
+- `backup_policy_plan` - (List) If present, the backup policy plan which created this snapshot.
+  
+   Nested scheme for `backup_policy_plan`:
+    - `deleted` - (List) If present, this property indicates the referenced resource has been deleted and provides some supplementary information.
+   
+      Nested scheme for `deleted`:
+      - `more_info` - (String) Link to documentation about deleted resources.
+    - `href` - (String) The URL for this backup policy plan.
+    - `id` - (String) The unique identifier for this backup policy plan.
+    - `name` - (String) The unique user defined name for this backup policy plan. If unspecified, the name will be a hyphenated list of randomly selected words.
+    - `resource_type` - (String) The type of resource referenced.
 - `bootable` - (Bool) Indicates if a boot volume attachment can be created with a volume created from this snapshot.
 - `crn` - (String) The CRN for this snapshot.
 - `encryption` - (String) The type of encryption used on the source volume. Supported values are **provider_managed**, **user_managed**.

--- a/website/docs/r/is_volume.html.markdown
+++ b/website/docs/r/is_volume.html.markdown
@@ -90,13 +90,13 @@ Review the argument references that you can specify for your resource.
     - tiered profiles [`general-purpose`, `5iops-tier`, `10iops-tier`] can be upgraded and downgraded into each other if volume is attached to an running virtual server instance. Stopped instances will be started on update of volume.
 - `resource_group` - (Optional, Forces new resource, String) The resource group ID for this volume.
 - `resource_controller_url` - (Optional, Forces new resource, String) The URL of the IBM Cloud dashboard that can be used to explore and view details about this instance.
-- `tags`- (Optional, Array of Strings) A list of tags that you want to add to your volume. Tags can help you find your volume more easily later.No.
+- `tags`- (Optional, Array of Strings) A list of user tags that you want to add to your volume. (https://cloud.ibm.com/apidocs/tagging#types-of-tags)
 - `zone` - (Required, Forces new resource, String) The location of the volume.
 
 ## Attribute reference
 In addition to all argument reference list, you can access the following attribute reference after your resource is created.
 
-- `encryption_type` - (String) The type of ecryption used in the volume [**provider_managed**, **user_managed**].
+- `encryption_type` - (String) The type of encryption used in the volume [**provider_managed**, **user_managed**].
 - `id` - (String) The unique identifier of the volume.
 - `source_snapshot` - ID of the snapshot, if volume was created from it.
 - `status` - (String) The status of volume. Supported values are **available**, **failed**, **pending**, **unusable**, or **pending_deletion**.


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/IBM-Cloud/terraform-provider-ibm/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TEST=./ibm/service/vpc TESTARGS='-run=TestAccIBMIsBackupPoliciesDataSourceBasic'
=== RUN   TestAccIBMIsBackupPoliciesDataSourceBasic
no message sent
no message sent
no message sent
no message sent
no message sent
no message sent
no message sent
no message sent
no message sent
no message sent
no message sent
no message sent
--- PASS: TestAccIBMIsBackupPoliciesDataSourceBasic (388.02s)
PASS
ok  	github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/vpc	389.757s



$ make testacc TEST=./ibm/service/vpc TESTARGS='-run=TestAccIBMIsBackupPolicyPlanDataSourceBasic'
=== RUN   TestAccIBMIsBackupPolicyPlanDataSourceBasic
no message sent
no message sent
no message sent
no message sent
no message sent
no message sent
no message sent
no message sent
no message sent
no message sent
--- PASS: TestAccIBMIsBackupPolicyPlanDataSourceBasic (358.09s)
PASS
ok  	github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/vpc	359.250s

$ make testacc TEST=./ibm/service/vpc TESTARGS='-run=TestAccIBMIsBackupPolicyPlansDataSourceBasic'
=== RUN   TestAccIBMIsBackupPolicyPlansDataSourceBasic
no message sent
no message sent
no message sent
no message sent
no message sent
no message sent
no message sent
no message sent
no message sent
no message sent
no message sent
--- PASS: TestAccIBMIsBackupPolicyPlansDataSourceBasic (379.03s)
PASS
ok  	github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/vpc	380.278s

$ make testacc TEST=./ibm/service/vpc TESTARGS='-run=TestAccIBMIsBackupPolicyDataSourceBasic'
=== RUN   TestAccIBMIsBackupPolicyDataSourceBasic
no message sent
no message sent
no message sent
no message sent
no message sent
no message sent
no message sent
no message sent
no message sent
no message sent
no message sent
no message sent
no message sent
no message sent
no message sent
no message sent
--- PASS: TestAccIBMIsBackupPolicyDataSourceBasic (444.20s)
PASS
ok  	github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/vpc	445.316s

$ make testacc TEST=./ibm/service/vpc TESTARGS='-run=TestAccIBMIsBackupPolicyPlanBasic'
=== RUN   TestAccIBMIsBackupPolicyPlanBasic
no message sent
no message sent
no message sent
no message sent
no message sent
no message sent
no message sent
no message sent
no message sent
no message sent
no message sent
no message sent
--- PASS: TestAccIBMIsBackupPolicyPlanBasic (438.60s)
PASS
ok  	github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/vpc	439.745s

$ make testacc TEST=./ibm/service/vpc TESTARGS='-run=TestAccIBMIsBackupPolicyBasic'
=== RUN   TestAccIBMIsBackupPolicyBasic
no message sent
no message sent
no message sent
no message sent
no message sent
no message sent
no message sent
no message sent
no message sent
no message sent
no message sent
--- PASS: TestAccIBMIsBackupPolicyBasic (416.61s)
PASS
ok  	github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/vpc	417.692s

...
```

