### PR TITLE
Made Changes to PI Keys

### DIFF
--- a/ibm/service/power/data_source_ibm_pi_keys.go
+++ b/ibm/service/power/data_source_ibm_pi_keys.go
@@ -21,29 +21,33 @@ func DataSourceIBMPIKeys() *schema.Resource {
 	return &schema.Resource{
 		ReadContext: dataSourceIBMPIKeysRead,
 		Schema: map[string]*schema.Schema{
-			helpers.PICloudInstanceId: {
+
+			// Arguments
+			Arg_CloudInstanceID: {
 				Type:         schema.TypeString,
 				Required:     true,
 				Description:  "PI cloud instance ID",
 				ValidateFunc: validation.NoZeroValues,
 			},
-			// Computed Attributes
-			PIKeys: {
-				Type:     schema.TypeList,
-				Computed: true,
+
+			// Attributes
+			Attr_Keys: {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Description: "SSH Keys",
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
-						PIKeyName: {
+						Attr_KeyName: {
 							Type:        schema.TypeString,
 							Computed:    true,
 							Description: "User defined name for the SSH key",
 						},
-						PIKey: {
+						Attr_Key: {
 							Type:        schema.TypeString,
 							Computed:    true,
 							Description: "SSH RSA key",
 						},
-						PIKeyDate: {
+						Attr_KeyCreationDate: {
 							Type:        schema.TypeString,
 							Computed:    true,
 							Description: "Date of SSH key creation",
@@ -56,13 +60,17 @@ func DataSourceIBMPIKeys() *schema.Resource {
 }
 
 func dataSourceIBMPIKeysRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+
+	// session
 	sess, err := meta.(conns.ClientSession).IBMPISession()
 	if err != nil {
 		return diag.FromErr(err)
 	}
 
+	// arguments
 	cloudInstanceID := d.Get(helpers.PICloudInstanceId).(string)
 
+	// get keys
 	client := st.NewIBMPIKeyClient(ctx, sess, cloudInstanceID)
 	sshKeys, err := client.GetAll()
 	if err != nil {
@@ -70,19 +78,19 @@ func dataSourceIBMPIKeysRead(ctx context.Context, d *schema.ResourceData, meta i
 		return diag.FromErr(err)
 	}
 
+	// set attributes
 	result := make([]map[string]interface{}, 0, len(sshKeys.SSHKeys))
 	for _, sshKey := range sshKeys.SSHKeys {
 		key := map[string]interface{}{
-			PIKeyName: sshKey.Name,
-			PIKey:     sshKey.SSHKey,
-			PIKeyDate: sshKey.CreationDate.String(),
+			Attr_KeyName:         sshKey.Name,
+			Attr_Key:             sshKey.SSHKey,
+			Attr_KeyCreationDate: sshKey.CreationDate.String(),
 		}
 		result = append(result, key)
 	}
-
 	var genID, _ = uuid.GenerateUUID()
 	d.SetId(genID)
-	d.Set(PIKeys, result)
+	d.Set(Attr_Keys, result)
 
 	return nil
 }

--- a/ibm/service/power/ibm_pi_constants.go
+++ b/ibm/service/power/ibm_pi_constants.go
@@ -3,13 +3,17 @@ package power
 import "time"
 
 const (
+	Arg_CloudInstanceID = "pi_cloud_instance_id"
 
 	// Keys
-	PIKeys    = "keys"
-	PIKeyName = "name"
-	PIKey     = "ssh_key"
-	PIKeyDate = "creation_date"
-	PIKeyID   = "key_id"
+	Arg_KeyName = "pi_key_name"
+	Arg_Key     = "pi_ssh_key"
+
+	Attr_KeyID           = "key_id"
+	Attr_Keys            = "keys"
+	Attr_KeyCreationDate = "creation_date"
+	Attr_Key             = "ssh_key"
+	Attr_KeyName         = "name"
 
 	// SAP Profile
 	PISAPProfiles         = "profiles"

--- a/ibm/service/power/resource_ibm_pi_key.go
+++ b/ibm/service/power/resource_ibm_pi_key.go
@@ -53,7 +53,7 @@ func ResourceIBMPIKey() *schema.Resource {
 			Attr_KeyCreationDate: {
 				Type:        schema.TypeString,
 				Computed:    true,
-				Description: "Date of sshkey creation",
+				Description: "Date of SSH Key creation",
 			},
 			Attr_KeyID: {
 				Type:       schema.TypeString,

--- a/ibm/service/power/resource_ibm_pi_key.go
+++ b/ibm/service/power/resource_ibm_pi_key.go
@@ -13,7 +13,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 
 	st "github.com/IBM-Cloud/power-go-client/clients/instance"
-	"github.com/IBM-Cloud/power-go-client/helpers"
 	"github.com/IBM-Cloud/power-go-client/power/models"
 	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/conns"
 )
@@ -32,46 +31,63 @@ func ResourceIBMPIKey() *schema.Resource {
 		},
 
 		Schema: map[string]*schema.Schema{
-			helpers.PICloudInstanceId: {
+
+			// Arguments
+			Arg_CloudInstanceID: {
 				Type:        schema.TypeString,
 				Required:    true,
 				Description: "PI cloud instance ID",
 			},
-			helpers.PIKeyName: {
+			Arg_KeyName: {
 				Type:        schema.TypeString,
 				Required:    true,
-				Description: "Key name in the PI instance",
+				Description: "User defined name for the SSH key",
 			},
-			helpers.PIKey: {
+			Arg_Key: {
 				Type:        schema.TypeString,
 				Required:    true,
-				Description: "PI instance key info",
+				Description: "SSH RSA key",
 			},
-			// Computed Attributes
-			PIKeyDate: {
+
+			// Attributes
+			Attr_KeyCreationDate: {
 				Type:        schema.TypeString,
 				Computed:    true,
 				Description: "Date of sshkey creation",
 			},
-			PIKeyID: {
+			Attr_KeyID: {
+				Type:       schema.TypeString,
+				Computed:   true,
+				Deprecated: "User defined name for the SSH key (deprecated - replaced by name)",
+			},
+			Attr_KeyName: {
 				Type:        schema.TypeString,
 				Computed:    true,
-				Description: "Key ID in the PI instance",
+				Description: "User defined name for the SSH key",
+			},
+			Attr_Key: {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "SSH RSA key",
 			},
 		},
 	}
 }
 
 func resourceIBMPIKeyCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+
+	// session
 	sess, err := meta.(conns.ClientSession).IBMPISession()
 	if err != nil {
 		return diag.FromErr(err)
 	}
 
-	cloudInstanceID := d.Get(helpers.PICloudInstanceId).(string)
-	name := d.Get(helpers.PIKeyName).(string)
-	sshkey := d.Get(helpers.PIKey).(string)
+	// arguments
+	cloudInstanceID := d.Get(Arg_CloudInstanceID).(string)
+	name := d.Get(Arg_KeyName).(string)
+	sshkey := d.Get(Arg_Key).(string)
 
+	// create key
 	client := st.NewIBMPIKeyClient(ctx, sess, cloudInstanceID)
 	body := &models.SSHKey{
 		Name:   &name,
@@ -84,50 +100,57 @@ func resourceIBMPIKeyCreate(ctx context.Context, d *schema.ResourceData, meta in
 	}
 
 	log.Printf("Printing the sshkey %+v", *sshResponse)
-
 	d.SetId(fmt.Sprintf("%s/%s", cloudInstanceID, name))
 	return resourceIBMPIKeyRead(ctx, d, meta)
 }
 
 func resourceIBMPIKeyRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 
+	// session
 	sess, err := meta.(conns.ClientSession).IBMPISession()
 	if err != nil {
 		return diag.FromErr(err)
 	}
 
+	// arguments
 	cloudInstanceID, key, err := splitID(d.Id())
 	if err != nil {
 		return diag.FromErr(err)
 	}
 
+	// get key
 	sshkeyC := st.NewIBMPIKeyClient(ctx, sess, cloudInstanceID)
 	sshkeydata, err := sshkeyC.Get(key)
 	if err != nil {
 		return diag.FromErr(err)
 	}
 
-	d.Set(helpers.PIKeyName, sshkeydata.Name)
-	d.Set(helpers.PIKey, sshkeydata.SSHKey)
-	d.Set(PIKeyDate, sshkeydata.CreationDate.String())
-	d.Set(PIKeyID, sshkeydata.Name)
+	// set attributes
+	d.Set(Attr_KeyName, sshkeydata.Name)
+	d.Set(Attr_KeyID, sshkeydata.Name)
+	d.Set(Attr_Key, sshkeydata.SSHKey)
+	d.Set(Attr_KeyCreationDate, sshkeydata.CreationDate.String())
 
 	return nil
-
 }
 func resourceIBMPIKeyUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	return resourceIBMPIKeyRead(ctx, d, meta)
 }
 func resourceIBMPIKeyDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+
+	// session
 	sess, err := meta.(conns.ClientSession).IBMPISession()
 	if err != nil {
 		return diag.FromErr(err)
 	}
+
+	// arguments
 	cloudInstanceID, key, err := splitID(d.Id())
 	if err != nil {
 		return diag.FromErr(err)
 	}
 
+	// delete key
 	sshkeyC := st.NewIBMPIKeyClient(ctx, sess, cloudInstanceID)
 	err = sshkeyC.Delete(key)
 	if err != nil {

--- a/website/docs/d/pi_key.html.markdown
+++ b/website/docs/d/pi_key.html.markdown
@@ -18,6 +18,19 @@ data "ibm_pi_key" "ds_instance" {
   pi_cloud_instance_id = "49fba6c9-23f8-40bc-9899-aca322ee7d5b"
 }
 ```
+  
+## Argument reference
+Review the argument references that you can specify for your data source. 
+
+- `pi_cloud_instance_id` - (Required, String) Cloud Instance ID of a PCloud Instance.
+- `pi_key_name`  - (Required, String) User defined name for the SSH key. 
+
+## Attribute reference
+In addition to all argument reference list, you can access the following attribute references after your data source is created. 
+
+- `id` - (String) User defined name for the SSH key
+- `creation_date` - (String) Date of sshkey creation. 
+- `ssh_key` - (String) SSH RSA key.
 
 **Notes**
 
@@ -34,16 +47,3 @@ Example usage:
       zone      =   "lon04"
     }
   ```
-  
-## Argument reference
-Review the argument references that you can specify for your data source. 
-
-- `pi_cloud_instance_id` - (Required, String) The GUID of the service instance associated with an account.
-- `pi_key_name` - (Required, String) The name of the key.
-
-## Attribute reference
-In addition to all argument reference list, you can access the following attribute references after your data source is created. 
-
-- `creation_date` - Timestamp - The timestamp when the SSH key was created.
-- `id` - (String) The unique identifier of the SSH key.
-- `ssh_key` - (String) The public SSH key value.

--- a/website/docs/d/pi_key.html.markdown
+++ b/website/docs/d/pi_key.html.markdown
@@ -29,7 +29,7 @@ Review the argument references that you can specify for your data source.
 In addition to all argument reference list, you can access the following attribute references after your data source is created. 
 
 - `id` - (String) User defined name for the SSH key
-- `creation_date` - (String) Date of sshkey creation. 
+- `creation_date` - (String) Date of SSH Key creation. 
 - `ssh_key` - (String) SSH RSA key.
 
 **Notes**

--- a/website/docs/d/pi_keys.html.markdown
+++ b/website/docs/d/pi_keys.html.markdown
@@ -30,7 +30,7 @@ In addition to all argument reference list, you can access the following attribu
 
   Nested scheme for `keys`:
   - `name` - (String) User defined name for the SSH key
-  - `creation_date` - (String) Date of sshkey creation. 
+  - `creation_date` - (String) Date of SSH Key creation. 
   - `ssh_key` - (String) SSH RSA key.
 
 **Notes**

--- a/website/docs/d/pi_keys.html.markdown
+++ b/website/docs/d/pi_keys.html.markdown
@@ -17,6 +17,21 @@ data "ibm_pi_keys" "example" {
   pi_cloud_instance_id = "<value of the cloud_instance_id>"
 }
 ```
+  
+## Argument reference
+Review the argument references that you can specify for your data source.
+
+- `pi_cloud_instance_id` - (Required, String) Cloud Instance ID of a PCloud Instance.
+
+## Attribute reference
+In addition to all argument reference list, you can access the following attribute references after your data source is created.
+
+- `keys` - (List) List of all the SSH keys.
+
+  Nested scheme for `keys`:
+  - `name` - (String) User defined name for the SSH key
+  - `creation_date` - (String) Date of sshkey creation. 
+  - `ssh_key` - (String) SSH RSA key.
 
 **Notes**
 
@@ -33,18 +48,3 @@ Example usage:
       zone      =   "lon04"
     }
   ```
-  
-## Argument reference
-Review the argument references that you can specify for your data source.
-
-- `pi_cloud_instance_id` - (Required, String) The GUID of the service instance associated with an account.
-
-## Attribute reference
-In addition to all argument reference list, you can access the following attribute references after your data source is created.
-
-- `keys` - (List) List of all the SSH keys.
-
-  Nested scheme for `keys`:
-  - `creation_date` - (String) Date of SSH key creation.
-  - `name` - (String) User defined name for the SSH key.
-  - `ssh_key` - (String) SSH RSA key.

--- a/website/docs/r/pi_key.html.markdown
+++ b/website/docs/r/pi_key.html.markdown
@@ -21,6 +21,29 @@ resource "ibm_pi_key" "testacc_sshkey" {
 }
 ```
 
+## Argument reference
+Review the argument references that you can specify for your resource. 
+
+- `pi_cloud_instance_id` - (Required, String) Cloud Instance ID of a PCloud Instance.
+- `pi_key_name`  - (Required, String) User defined name for the SSH key. 
+- `pi_ssh_key` - (Required, String) SSH RSA key. 
+
+## Attribute reference
+ In addition to all argument reference list, you can access the following attribute reference after your resource is created.
+
+- `id` - (String) The unique identifier of the key. The ID is composed of `<pi_cloud_instance_id>/<pi_key_name>`.
+- `key_id` - (String) User defined name for the SSH key (deprecated - replaced by `name`).
+- `name` - (String) User defined name for the SSH key
+- `creation_date` - (String) Date of sshkey creation. 
+- `ssh_key` - (String) SSH RSA key.
+
+## Timeouts
+
+ibm_pi_key provides the following [timeouts](https://www.terraform.io/docs/language/resources/syntax.html) configuration options:
+
+- **create** - (Default 60 minutes) Used for creating a SSH key.
+- **delete** - (Default 60 minutes) Used for deleting a SSH key.
+
 **Note**
 * Please find [supported Regions](https://cloud.ibm.com/apidocs/power-cloud#endpoint) for endpoints.
 * If a Power cloud instance is provisioned at `lon04`, The provider level attributes should be as follows:
@@ -35,30 +58,6 @@ resource "ibm_pi_key" "testacc_sshkey" {
       zone      =   "lon04"
     }
   ```
-
-## Timeouts
-
-ibm_pi_key provides the following [timeouts](https://www.terraform.io/docs/language/resources/syntax.html) configuration options:
-
-- **create** - (Default 60 minutes) Used for creating a SSH key.
-- **delete** - (Default 60 minutes) Used for deleting a SSH key.
-
-
-## Argument reference
-Review the argument references that you can specify for your resource. 
-
-- `pi_cloud_instance_id` - (Required, String) The GUID of the service instance associated with an account.
-- `pi_key_name`  - (Required, Integer) The name of the SSH key that you uploaded to IBM Cloud. 
-- `pi_ssh_key` - (Required, String) The value of the public SSH key. 
-
-
-## Attribute reference
- In addition to all argument reference list, you can access the following attribute reference after your resource is created.
-
-- `creation_date` - (String) The date when the SSH key was created. 
-- `id` - (String) The unique identifier of the key. The ID is composed of `<pi_cloud_instance_id>/<pi_key_name>`.
-- `key_id` - (String) The unique identifier of the key.
-
 ## Import
 
 The `ibm_pi_key` resource can be imported by using `pi_cloud_instance_id` and `pi_key_name`.

--- a/website/docs/r/pi_key.html.markdown
+++ b/website/docs/r/pi_key.html.markdown
@@ -34,7 +34,7 @@ Review the argument references that you can specify for your resource.
 - `id` - (String) The unique identifier of the key. The ID is composed of `<pi_cloud_instance_id>/<pi_key_name>`.
 - `key_id` - (String) User defined name for the SSH key (deprecated - replaced by `name`).
 - `name` - (String) User defined name for the SSH key
-- `creation_date` - (String) Date of sshkey creation. 
+- `creation_date` - (String) Date of SSH Key creation. 
 - `ssh_key` - (String) SSH RSA key.
 
 ## Timeouts


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/IBM-Cloud/terraform-provider-ibm/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
=== RUN   TestAccIBMPIKeyDataSource_basic
--- PASS: TestAccIBMPIKeyDataSource_basic (9.88s)
=== RUN   TestAccIBMPIKeysDataSourceBasic
--- PASS: TestAccIBMPIKeysDataSourceBasic (9.32s)
=== RUN   TestAccIBMPIKey_basic
--- PASS: TestAccIBMPIKey_basic (11.11s)
```

- Using new Argument/Attribute naming convention
- Started deprecation process of resource `key_id`
   - `name` should be used instead. Matches Service Broker API docs
