### PR TITLE
fix(bare_metal_server_network_interface_allow_float) : updated GetOk to GetOkExists for nat and allow ip spoofing

### DIFF
--- a/ibm/service/vpc/resource_ibm_is_bare_metal_server_network_interface_allow_float.go
+++ b/ibm/service/vpc/resource_ibm_is_bare_metal_server_network_interface_allow_float.go
@@ -226,16 +226,16 @@ func createVlanTypeNetworkInterfaceAllowFloat(context context.Context, d *schema
 	}
 	nicOptions.InterfaceType = &interfaceType
 
-	if ais, ok := d.GetOk(isBareMetalServerNicAllowIPSpoofing); ok {
-		allowIPSpoofing := ais.(bool)
-		if allowIPSpoofing {
-			nicOptions.AllowIPSpoofing = &allowIPSpoofing
-		}
+	if aisOk, ok := d.GetOkExists(isBareMetalServerNicAllowIPSpoofing); ok {
+		allowIPSpoofing := aisOk.(bool)
+		nicOptions.AllowIPSpoofing = &allowIPSpoofing
 	}
-	if ein, ok := d.GetOk(isBareMetalServerNicEnableInfraNAT); ok {
+
+	if ein, ok := d.GetOkExists(isBareMetalServerNicEnableInfraNAT); ok {
 		enableInfrastructureNat := ein.(bool)
 		nicOptions.EnableInfrastructureNat = &enableInfrastructureNat
 	}
+
 	if subnetOk, ok := d.GetOk(isBareMetalServerNicSubnet); ok {
 		subnet := subnetOk.(string)
 		nicOptions.Subnet = &vpcv1.SubnetIdentity{

--- a/ibm/service/vpc/resource_ibm_is_bare_metal_server_network_interface_allow_float_test.go
+++ b/ibm/service/vpc/resource_ibm_is_bare_metal_server_network_interface_allow_float_test.go
@@ -19,7 +19,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 )
 
-func TestAccIBMISBareMetalServerNetworkInterfaceAllowFloat_basic(t *testing.T) {
+func TestAccIBMISBareMetalServerNetworkInterfaceAllowFloat_rip_basic(t *testing.T) {
 	var server string
 	vpcname := fmt.Sprintf("tf-vpc-%d", acctest.RandIntRange(10, 100))
 	name := fmt.Sprintf("tf-server-%d", acctest.RandIntRange(10, 100))
@@ -43,12 +43,22 @@ ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCKVmnMOlHKcZK8tpt3MP1lqOLAcqcJzhsvJcjscgVE
 						"ibm_is_bare_metal_server.testacc_bms", "name", name),
 					resource.TestCheckResourceAttr(
 						"ibm_is_bare_metal_server.testacc_bms", "zone", acc.ISZoneName),
+					resource.TestCheckResourceAttr(
+						"ibm_is_subnet_reserved_ip.testacc_rip", "name", subnetreservedipname),
+					resource.TestCheckResourceAttr(
+						"ibm_is_bare_metal_server_network_interface_allow_float.bms_nic", "interface_type", "vlan"),
+					resource.TestCheckResourceAttr(
+						"ibm_is_bare_metal_server_network_interface_allow_float.bms_nic", "allow_ip_spoofing", "false"),
+					resource.TestCheckResourceAttr(
+						"ibm_is_bare_metal_server_network_interface_allow_float.bms_nic", "enable_infrastructure_nat", "true"),
+					resource.TestCheckResourceAttr(
+						"ibm_is_bare_metal_server_network_interface_allow_float.bms_nic", "name", "eth21"),
 				),
 			},
 		},
 	})
 }
-func TestAccIBMISBareMetalServerNetworkInterfaceAllowFloat_basic_rip(t *testing.T) {
+func TestAccIBMISBareMetalServerNetworkInterfaceAllowFloat_basic(t *testing.T) {
 	var server string
 	vpcname := fmt.Sprintf("tf-vpc-%d", acctest.RandIntRange(10, 100))
 	name := fmt.Sprintf("tf-server-%d", acctest.RandIntRange(10, 100))
@@ -71,6 +81,12 @@ ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCKVmnMOlHKcZK8tpt3MP1lqOLAcqcJzhsvJcjscgVE
 						"ibm_is_bare_metal_server.testacc_bms", "name", name),
 					resource.TestCheckResourceAttr(
 						"ibm_is_bare_metal_server.testacc_bms", "zone", acc.ISZoneName),
+					resource.TestCheckResourceAttr(
+						"ibm_is_bare_metal_server_network_interface_allow_float.bms_nic", "allow_ip_spoofing", "false"),
+					resource.TestCheckResourceAttr(
+						"ibm_is_bare_metal_server_network_interface_allow_float.bms_nic", "allow_interface_to_float", "true"),
+					resource.TestCheckResourceAttr(
+						"ibm_is_bare_metal_server_network_interface_allow_float.bms_nic", "enable_infrastructure_nat", "false"),
 				),
 			},
 		},
@@ -155,6 +171,8 @@ func testAccCheckIBMISBareMetalServerNetworkInterfaceAllowFloatConfig(vpcname, s
 			subnet 				= ibm_is_subnet.testacc_subnet.id
 			name   				= "eth21"
 			vlan 				= 101
+			allow_ip_spoofing 	= false
+			enable_infrastructure_nat = false
 			}
 
 		


### PR DESCRIPTION


<!--- See what makes a good Pull Request at : https://github.com/IBM-Cloud/terraform-provider-ibm/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
=== RUN   TestAccIBMISBareMetalServerNetworkInterfaceAllowFloat_basic
--- PASS: TestAccIBMISBareMetalServerNetworkInterfaceAllowFloat_basic (47.90s)
PASS
ok      github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/vpc     49.662s
```
```

=== RUN   TestAccIBMISBareMetalServerNetworkInterfaceAllowFloat_rip_basic
--- PASS: TestAccIBMISBareMetalServerNetworkInterfaceAllowFloat_rip_basic (66.51s)
PASS
ok      github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/vpc     68.287s
```
