### PR TITLE
Add SNAT enabled bool for DHCP create function

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.16
 require (
 	github.com/IBM-Cloud/bluemix-go v0.0.0-20220523145737-34645883de47
 	github.com/IBM-Cloud/container-services-go-sdk v0.0.0-20220622142911-811d18c8c775
-	github.com/IBM-Cloud/power-go-client v1.1.10
+	github.com/IBM-Cloud/power-go-client v1.1.11
 	github.com/IBM/apigateway-go-sdk v0.0.0-20210714141226-a5d5d49caaca
 	github.com/IBM/appconfiguration-go-admin-sdk v0.2.3
 	github.com/IBM/appid-management-go-sdk v0.0.0-20210908164609-dd0e0eaf732f

--- a/go.sum
+++ b/go.sum
@@ -11,6 +11,8 @@ github.com/IBM-Cloud/container-services-go-sdk v0.0.0-20220622142911-811d18c8c77
 github.com/IBM-Cloud/ibm-cloud-cli-sdk v0.5.3/go.mod h1:RiUvKuHKTBmBApDMUQzBL14pQUGKcx/IioKQPIcRQjs=
 github.com/IBM-Cloud/power-go-client v1.1.10 h1:NUGZwF5V0j2lFurA5LaigsYyOKDKwz4M0sCpm+YIbig=
 github.com/IBM-Cloud/power-go-client v1.1.10/go.mod h1:Qfx0fNi+9hms+xu9Z6Euhu9088ByW6C/TCMLECTRWNE=
+github.com/IBM-Cloud/power-go-client v1.1.11 h1:/qTWCCuSZsmiksvQSfhM+mZKkY/Vli/W6b82WoYD2NM=
+github.com/IBM-Cloud/power-go-client v1.1.11/go.mod h1:Qfx0fNi+9hms+xu9Z6Euhu9088ByW6C/TCMLECTRWNE=
 github.com/IBM-Cloud/softlayer-go v1.0.5-tf h1:koUAyF9b6X78lLLruGYPSOmrfY2YcGYKOj/Ug9nbKNw=
 github.com/IBM-Cloud/softlayer-go v1.0.5-tf/go.mod h1:6HepcfAXROz0Rf63krk5hPZyHT6qyx2MNvYyHof7ik4=
 github.com/IBM/apigateway-go-sdk v0.0.0-20210714141226-a5d5d49caaca h1:crniVcf+YcmgF03NmmfonXwSQ73oJF+IohFYBwknMxs=

--- a/ibm/service/power/ibm_pi_constants.go
+++ b/ibm/service/power/ibm_pi_constants.go
@@ -30,6 +30,7 @@ const (
 	Arg_DhcpCloudConnectionID = "pi_cloud_connection_id"
 	Arg_DhcpDnsServer         = "pi_dns_server"
 	Arg_DhcpName              = "pi_dhcp_name"
+	Arg_DhcpSnatEnabled       = "pi_dhcp_snat_enabled"
 
 	Attr_DhcpServers           = "servers"
 	Attr_DhcpID                = "dhcp_id"

--- a/ibm/service/power/resource_ibm_pi_dhcp.go
+++ b/ibm/service/power/resource_ibm_pi_dhcp.go
@@ -65,6 +65,13 @@ func ResourceIBMPIDhcp() *schema.Resource {
 				Description: "Optional name of DHCP Service (will be prefixed by DHCP identifier)",
 				ForceNew:    true,
 			},
+			Arg_DhcpSnatEnabled: {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Default:     true,
+				Description: "Indicates if SNAT will be enabled for the DHCP service",
+				ForceNew:    true,
+			},
 
 			// Attributes
 			Attr_DhcpID: {
@@ -144,6 +151,8 @@ func resourceIBMPIDhcpCreate(ctx context.Context, d *schema.ResourceData, meta i
 		n := name.(string)
 		body.Name = &n
 	}
+	snatEnabled := d.Get(Arg_DhcpSnatEnabled).(bool)
+	body.SnatEnabled = &snatEnabled
 
 	// create dhcp
 	client := st.NewIBMPIDhcpClient(ctx, sess, cloudInstanceID)

--- a/ibm/service/power/resource_ibm_pi_dhcp_test.go
+++ b/ibm/service/power/resource_ibm_pi_dhcp_test.go
@@ -133,3 +133,30 @@ func testAccCheckIBMPIDhcpWithCidrNameConfig(name string) string {
 		}
 	`, acc.Pi_cloud_instance_id, name)
 }
+
+func TestAccIBMPIDhcpSNAT(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { acc.TestAccPreCheck(t) },
+		Providers:    acc.TestAccProviders,
+		CheckDestroy: testAccCheckIBMPIDhcpDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckIBMPIDhcpConfigWithSNATDisabled(),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckIBMPIDhcpExists("ibm_pi_dhcp.dhcp_service"),
+					resource.TestCheckResourceAttrSet(
+						"ibm_pi_dhcp.dhcp_service", "dhcp_id"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckIBMPIDhcpConfigWithSNATDisabled() string {
+	return fmt.Sprintf(`
+	resource "ibm_pi_dhcp" "dhcp_service" {
+		pi_cloud_instance_id = "%s"
+		pi_dhcp_snat_enabled = false
+	}
+	`, acc.Pi_cloud_instance_id)
+}

--- a/website/docs/r/pi_dhcp.html.markdown
+++ b/website/docs/r/pi_dhcp.html.markdown
@@ -23,15 +23,19 @@ resource "ibm_pi_dhcp" "example" {
 
 Review the argument references that you can specify for your resource. 
 
+- `pi_cidr` - (Optional, String) The CIDR for the DHCP private network.
+- `pi_cloud_connection_id` - (Optional, String) The Cloud Connection UUID to connect with the DHCP private network.
 - `pi_cloud_instance_id` - (Required, String) The GUID of the service instance associated with an account.
-- `pi_cloud_connection_id` - (Optional, String) The Cloud Connection UUID to connect with DHCP private network.
+- `pi_dhcp_name` - (Optional, String) The name of the DHCP Service that will be prefixed by the DHCP identifier.
+- `pi_dhcp_snat_enabled` - (Optional, Bool) Indicates if SNAT will be enabled for the DHCP service. The default value is **true**.
+- `pi_dns_server` - (Optional, String) The DNS Server for the DHCP service.
 
 ## Attribute reference
 
 In addition to all argument reference list, you can access the following attribute reference after your resource is created.
 
-- `id` - (String) The unique identifier of the DHCP Server. The ID is composed of `<power_instance_id>/<dhcp_id>`.
 - `dhcp_id` - (String) The ID of the DHCP Server.
+- `id` - (String) The unique identifier of the DHCP Server. The ID is composed of `<power_instance_id>/<dhcp_id>`.
 - `leases` - (List) The list of DHCP Server PVM Instance leases.
   Nested scheme for `leases`:
   - `instance_ip` - (String) The IP of the PVM Instance.


### PR DESCRIPTION
Add SNAP enabled bool for DHCP create function

<!--- See what makes a good Pull Request at : https://github.com/IBM-Cloud/terraform-provider-ibm/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Output from acceptance testing:

=== RUN   TestAccIBMPIDhcpSNAT
--- PASS: TestAccIBMPIDhcpSNAT (374.02s)
PASS
```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```
