### PR TITLE
New access group setting resource

### DIFF
--- a/examples/ibm-iam-accessgroups/README.md
+++ b/examples/ibm-iam-accessgroups/README.md
@@ -1,0 +1,54 @@
+# Example for IBM IAM Access Group Account Settings
+
+This example illustrates how to use the IAM Access Group Account  Settings to configure public access on groups.
+
+These types of resources are supported:
+
+* ibm_iam_access_group_account_settings
+
+## Usage
+
+To run this example you need to execute:
+
+```bash
+$ terraform init
+$ terraform plan
+$ terraform apply
+```
+
+Run `terraform destroy` when you don't need these resources.
+
+
+## IAM Access Group Account Setting Resource
+
+Access Group Account Setting Resource:
+
+```hcl
+resource "ibm_iam_access_group_account_settings" "iam_access_groups_account_settings_instance" {
+  public_access_enabled = true
+}
+```
+
+## Requirements
+
+| Name | Version |
+|------|---------|
+| terraform | ~> 0.12 |
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| ibm | n/a |
+
+## Inputs
+
+| Name                  | Description                                 | Type      | Required |
+|-----------------------|---------------------------------------------|-----------|----------|
+| public_access_enabled | Defines if public access groups are enabled | `boolean` | true     |                                                                                                                  | `string` | false |
+
+## Outputs
+
+| Name | Description   |
+|------|---------------|
+| public_access_enabled | boolean |

--- a/examples/ibm-iam-accessgroups/main.tf
+++ b/examples/ibm-iam-accessgroups/main.tf
@@ -2,7 +2,7 @@ provider "ibm" {
 }
 
 resource "ibm_iam_access_group" "accgroup" {
-  		name = var.ag_name
+	name = var.ag_name
 }
 
 resource "ibm_iam_access_group_account_settings" "ag_account_setting"{

--- a/examples/ibm-iam-accessgroups/main.tf
+++ b/examples/ibm-iam-accessgroups/main.tf
@@ -1,0 +1,10 @@
+provider "ibm" {
+}
+
+resource "ibm_iam_access_group" "accgroup" {
+  		name = var.ag_name
+}
+
+resource "ibm_iam_access_group_account_settings" "ag_account_setting"{
+	public_access_enabled = true
+}

--- a/examples/ibm-iam-accessgroups/variables.tf
+++ b/examples/ibm-iam-accessgroups/variables.tf
@@ -1,0 +1,7 @@
+variable "ag_name" {
+  description = "Enter the IBM ID of the user"
+}
+
+variable "resource_group" {
+  description = "Enter the resource group name"
+}

--- a/examples/ibm-iam-accessgroups/variables.tf
+++ b/examples/ibm-iam-accessgroups/variables.tf
@@ -1,5 +1,5 @@
 variable "ag_name" {
-  description = "Enter the IBM ID of the user"
+  description = "Enter the name of the access group"
 }
 
 variable "resource_group" {

--- a/examples/ibm-iam-accessgroups/versions.tf
+++ b/examples/ibm-iam-accessgroups/versions.tf
@@ -1,0 +1,4 @@
+
+terraform {
+  required_version = ">= 0.12"
+}

--- a/go.sum
+++ b/go.sum
@@ -40,7 +40,6 @@ github.com/IBM/go-sdk-core/v5 v5.5.1/go.mod h1:Sn+z+qTDREQvCr+UFa22TqqfXNxx3o723
 github.com/IBM/go-sdk-core/v5 v5.6.3/go.mod h1:tt/B9rxLkRtglE7pvqLuYikgCXaZFL3btdruJaoUeek=
 github.com/IBM/go-sdk-core/v5 v5.6.5/go.mod h1:tt/B9rxLkRtglE7pvqLuYikgCXaZFL3btdruJaoUeek=
 github.com/IBM/go-sdk-core/v5 v5.7.0/go.mod h1:+YbdhrjCHC84ls4MeBp+Hj4NZCni+tDAc0XQUqRO9Jc=
-github.com/IBM/go-sdk-core/v5 v5.7.2/go.mod h1:+YbdhrjCHC84ls4MeBp+Hj4NZCni+tDAc0XQUqRO9Jc=
 github.com/IBM/go-sdk-core/v5 v5.8.0/go.mod h1:+YbdhrjCHC84ls4MeBp+Hj4NZCni+tDAc0XQUqRO9Jc=
 github.com/IBM/go-sdk-core/v5 v5.9.1/go.mod h1:axE2JrRq79gIJTjKPBwV6gWHswvVptBjbcvvCPIxARM=
 github.com/IBM/go-sdk-core/v5 v5.9.2/go.mod h1:YlOwV9LeuclmT/qi/LAK2AsobbAP42veV0j68/rlZsE=

--- a/ibm/provider/provider.go
+++ b/ibm/provider/provider.go
@@ -836,6 +836,7 @@ func Provider() *schema.Provider {
 			"ibm_hpcs_keystore":                         hpcs.ResourceIbmKeystore(),
 			"ibm_hpcs_vault":                            hpcs.ResourceIbmVault(),
 			"ibm_iam_access_group":                      iamaccessgroup.ResourceIBMIAMAccessGroup(),
+			"ibm_iam_access_group_account_settings":     iamaccessgroup.ResourceIBMIAMAccessGroupAccountSettings(),
 			"ibm_iam_account_settings":                  iamidentity.ResourceIBMIAMAccountSettings(),
 			"ibm_iam_custom_role":                       iampolicy.ResourceIBMIAMCustomRole(),
 			"ibm_iam_access_group_dynamic_rule":         iamaccessgroup.ResourceIBMIAMDynamicRule(),

--- a/ibm/service/iamaccessgroup/resource_ibm_iam_access_group_account_settings.go
+++ b/ibm/service/iamaccessgroup/resource_ibm_iam_access_group_account_settings.go
@@ -19,8 +19,13 @@ func ResourceIBMIAMAccessGroupAccountSettings() *schema.Resource {
 		Schema: map[string]*schema.Schema{
 			"public_access_enabled": {
 				Type:        schema.TypeBool,
-				Optional:    true,
+				Required:    true,
 				Description: "Flag to enable/disable public access groups",
+			},
+			"account_id": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "Id of the account",
 			},
 		},
 	}
@@ -42,10 +47,11 @@ func resourceIBMIAMAccessGroupAccountSettingGet(context context.Context, d *sche
 			d.SetId("")
 			return nil
 		}
-		return diag.FromErr(fmt.Errorf("[ERROR] Error retrieving access group: %s. API Response: %s", err, detailedResponse))
+		return diag.FromErr(fmt.Errorf("[ERROR] Error retrieving access group account setting: %s. API Response: %s", err, detailedResponse))
 	}
 	d.SetId(*accountSetting.AccountID)
 	d.Set("public_access_enabled", accountSetting.PublicAccessEnabled)
+	d.Set("account_id", accountSetting.AccountID)
 	return nil
 }
 
@@ -65,7 +71,7 @@ func resourceIBMIAMAccessGroupAccountSettingSet(context context.Context, d *sche
 	updateAccountSettingsOptions.PublicAccessEnabled = core.BoolPtr(publicAccessEnabled)
 	accountSetting, detailedResponse, err := iamAccessGroupsClient.UpdateAccountSettings(updateAccountSettingsOptions)
 	if err != nil || accountSetting == nil {
-		return diag.FromErr(fmt.Errorf("[ERROR] Error updating access group public account setting: %s. API Response: %s", err, detailedResponse))
+		return diag.FromErr(fmt.Errorf("[ERROR] Error updating access public account setting: %s. API Response: %s", err, detailedResponse))
 	}
 	d.SetId(*accountSetting.AccountID)
 	d.Set("public_access_enabled", *accountSetting.PublicAccessEnabled)
@@ -76,6 +82,5 @@ func resourceIBMIAMAccessGroupAccountSettingUnSet(context context.Context, d *sc
 
 	// DELETE NOT SUPPORTED
 	d.SetId("")
-
 	return nil
 }

--- a/ibm/service/iamaccessgroup/resource_ibm_iam_access_group_account_settings.go
+++ b/ibm/service/iamaccessgroup/resource_ibm_iam_access_group_account_settings.go
@@ -1,0 +1,81 @@
+package iamaccessgroup
+
+import (
+	"context"
+	"fmt"
+	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/conns"
+	"github.com/IBM/go-sdk-core/v5/core"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+func ResourceIBMIAMAccessGroupAccountSettings() *schema.Resource {
+	return &schema.Resource{
+		ReadContext:   resourceIBMIAMAccessGroupAccountSettingGet,
+		UpdateContext: resourceIBMIAMAccessGroupAccountSettingSet,
+		CreateContext: resourceIBMIAMAccessGroupAccountSettingSet,
+		DeleteContext: resourceIBMIAMAccessGroupAccountSettingUnSet,
+		Importer:      &schema.ResourceImporter{},
+		Schema: map[string]*schema.Schema{
+			"public_access_enabled": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Description: "Flag to enable/disable public access groups",
+			},
+		},
+	}
+}
+
+func resourceIBMIAMAccessGroupAccountSettingGet(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	iamAccessGroupsClient, err := meta.(conns.ClientSession).IAMAccessGroupsV2()
+	if err != nil {
+		return diag.FromErr(err)
+	}
+	userDetails, err := meta.(conns.ClientSession).BluemixUserDetails()
+	if err != nil {
+		return diag.FromErr(err)
+	}
+	getAccessGroupOptions := iamAccessGroupsClient.NewGetAccountSettingsOptions(userDetails.UserAccount)
+	accountSetting, detailedResponse, err := iamAccessGroupsClient.GetAccountSettings(getAccessGroupOptions)
+	if err != nil || accountSetting == nil {
+		if detailedResponse != nil && detailedResponse.StatusCode == 404 {
+			d.SetId("")
+			return nil
+		}
+		return diag.FromErr(fmt.Errorf("[ERROR] Error retrieving access group: %s. API Response: %s", err, detailedResponse))
+	}
+	d.SetId(*accountSetting.AccountID)
+	d.Set("public_access_enabled", accountSetting.PublicAccessEnabled)
+	return nil
+}
+
+func resourceIBMIAMAccessGroupAccountSettingSet(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	iamAccessGroupsClient, err := meta.(conns.ClientSession).IAMAccessGroupsV2()
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	userDetails, err := meta.(conns.ClientSession).BluemixUserDetails()
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	updateAccountSettingsOptions := iamAccessGroupsClient.NewUpdateAccountSettingsOptions(userDetails.UserAccount)
+	publicAccessEnabled := d.Get("public_access_enabled").(bool)
+	updateAccountSettingsOptions.PublicAccessEnabled = core.BoolPtr(publicAccessEnabled)
+	accountSetting, detailedResponse, err := iamAccessGroupsClient.UpdateAccountSettings(updateAccountSettingsOptions)
+	if err != nil || accountSetting == nil {
+		return diag.FromErr(fmt.Errorf("[ERROR] Error updating access group public account setting: %s. API Response: %s", err, detailedResponse))
+	}
+	d.SetId(*accountSetting.AccountID)
+	d.Set("public_access_enabled", *accountSetting.PublicAccessEnabled)
+	return resourceIBMIAMAccessGroupAccountSettingGet(context, d, meta)
+}
+
+func resourceIBMIAMAccessGroupAccountSettingUnSet(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+
+	// DELETE NOT SUPPORTED
+	d.SetId("")
+
+	return nil
+}

--- a/ibm/service/iamaccessgroup/resource_ibm_iam_access_group_account_settings_test.go
+++ b/ibm/service/iamaccessgroup/resource_ibm_iam_access_group_account_settings_test.go
@@ -71,6 +71,7 @@ func testAccCheckIbmIamAccessGroupAccountSettingsConfigBasic() string {
 	return `
 
 		resource "ibm_iam_access_group_account_settings" "iam_access_group_account_settings" {
+			public_access_enabled = true
 		}
 	`
 }

--- a/ibm/service/iamaccessgroup/resource_ibm_iam_access_group_account_settings_test.go
+++ b/ibm/service/iamaccessgroup/resource_ibm_iam_access_group_account_settings_test.go
@@ -1,0 +1,111 @@
+// Copyright IBM Corp. 2021 All Rights Reserved.
+// Licensed under the Mozilla Public License v2.0
+
+package iamaccessgroup_test
+
+import (
+	"fmt"
+	iamaccessgroups "github.com/IBM/platform-services-go-sdk/iamaccessgroupsv2"
+	"testing"
+
+	acc "github.com/IBM-Cloud/terraform-provider-ibm/ibm/acctest"
+	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/conns"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+)
+
+func TestAccIBMIAMAccessGroupAccountSettingsBasic(t *testing.T) {
+	var conf iamaccessgroups.AccountSettings
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { acc.TestAccPreCheck(t) },
+		Providers: acc.TestAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckIbmIamAccessGroupAccountSettingsConfigBasic(),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckIbmIamAccountSettingsExists("ibm_iam_access_group_account_settings.iam_access_group_account_settings", conf),
+				),
+			},
+			{
+				Config: testAccCheckIbmIamAccessGroupAccountSettingsConfigBasic(),
+				Check:  resource.ComposeAggregateTestCheckFunc(),
+			},
+		},
+	})
+}
+
+func TestAccIBMIAMAccessGroupAccountSettingsUpdates(t *testing.T) {
+	var conf iamaccessgroups.AccountSettings
+	publicAccessEnabled := "false"
+	publicAccessEnabledUpdated := "true"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { acc.TestAccPreCheck(t) },
+		Providers: acc.TestAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckIbmIamAccessGroupAccountSettingsConfig(publicAccessEnabled),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckIbmIamAccountSettingsExists("ibm_iam_access_group_account_settings.iam_access_group_account_settings", conf),
+					resource.TestCheckResourceAttr("ibm_iam_access_group_account_settings.iam_access_group_account_settings", "public_access_enabled", publicAccessEnabled),
+				),
+			},
+			{
+				Config: testAccCheckIbmIamAccessGroupAccountSettingsConfig(publicAccessEnabledUpdated),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("ibm_iam_access_group_account_settings.iam_access_group_account_settings", "public_access_enabled", publicAccessEnabledUpdated),
+				),
+			},
+			{
+				ResourceName:      "ibm_iam_access_group_account_settings.iam_access_group_account_settings",
+				ImportState:       true,
+				ImportStateVerify: false,
+			},
+		},
+	})
+}
+
+func testAccCheckIbmIamAccessGroupAccountSettingsConfigBasic() string {
+	return `
+
+		resource "ibm_iam_access_group_account_settings" "iam_access_group_account_settings" {
+		}
+	`
+}
+
+func testAccCheckIbmIamAccessGroupAccountSettingsConfig(publicAccessEnabled string) string {
+	return fmt.Sprintf(`
+
+		resource "ibm_iam_access_group_account_settings" "iam_access_group_account_settings" {
+			public_access_enabled = %s
+		}
+	`, publicAccessEnabled)
+}
+
+func testAccCheckIbmIamAccountSettingsExists(n string, obj iamaccessgroups.AccountSettings) resource.TestCheckFunc {
+
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+
+		iamAccessGroupsClient, err := acc.TestAccProvider.Meta().(conns.ClientSession).IAMAccessGroupsV2()
+		if err != nil {
+			return err
+		}
+
+		getAccountSettingsOptions := iamAccessGroupsClient.NewGetAccountSettingsOptions(rs.Primary.ID)
+
+		accountSettingsResponse, _, err := iamAccessGroupsClient.GetAccountSettings(getAccountSettingsOptions)
+		if err != nil {
+			return err
+		}
+
+		obj = *accountSettingsResponse
+
+		return nil
+	}
+}

--- a/website/docs/r/iam_access_group_account_settings.html.markdown
+++ b/website/docs/r/iam_access_group_account_settings.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "IAM Access Groups"
+subcategory: "Identity & Access Management (IAM)"
 layout: "ibm"
 page_title: "IBM : iam_access_group_account_settings"
 description: |-

--- a/website/docs/r/iam_access_group_account_settings.html.markdown
+++ b/website/docs/r/iam_access_group_account_settings.html.markdown
@@ -1,0 +1,33 @@
+---
+subcategory: "IAM Access Groups"
+layout: "ibm"
+page_title: "IBM : iam_access_group_account_settings"
+description: |-
+  Manages IAM Access Groups account level settings.
+---
+
+# ibm_iam_access_group_account_settings
+
+Create, modify, or delete an `iam_access_group_account_settings` resources. Access groups can be used to define a set of permissions that you want to grant to a group of users. For more information, about IAM account settings, refer to [setting up your IBM Cloud](https://cloud.ibm.com/docs/account?topic=account-account-getting-started).
+
+## Example usage
+
+```terraform
+resource "ibm_iam_access_group_account_settings" "iam_access_group_account_settings" {
+  public_access_enabled = true
+}
+```
+
+
+## Argument reference
+Review the argument references that you can specify for your resource. 
+
+- `public_access_enabled` - (Optional, Bool) Defines if the public groups are included in the response for access group listing.
+
+
+## Attribute reference
+In addition to all argument reference list, you can access the following attribute reference after your resource is created.
+
+- `account_id` - (String) Unique ID of an account.
+- `public_access_enabled` - (Bool) if the public groups are enabled for access group listing.
+


### PR DESCRIPTION
This PR creates a new resource for access group account settings.

<!--- See what makes a good Pull Request at : https://github.com/IBM-Cloud/terraform-provider-ibm/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccIBMIAMAccessGroupAccountSettingsBasic'
$ make testacc TESTARGS='-run=TestAccIBMIAMAccessGroupAccountSettingsUpdates'
```

<img width="775" alt="Screenshot 2022-07-27 at 12 41 32 PM" src="https://user-images.githubusercontent.com/9041167/181184585-fa472f25-7a11-41f6-84e4-15ad073221b7.png">
<img width="1203" alt="Screenshot 2022-07-27 at 11 54 01 AM" src="https://user-images.githubusercontent.com/9041167/181184600-fa2fb13b-b5cd-4cfc-a07d-8336f61cfa8c.png">


...
```
resource "ibm_iam_access_group_account_settings" "ag_account_setting"{
	public_access_enabled = true
}