### PR TITLE
 fix(is_bare_metal_server): removed nics with allow float from server nics

### DIFF
--- a/ibm/service/vpc/resource_ibm_is_bare_metal_server.go
+++ b/ibm/service/vpc/resource_ibm_is_bare_metal_server.go
@@ -1231,6 +1231,7 @@ func bareMetalServerGet(context context.Context, d *schema.ResourceData, meta in
 	if bms.NetworkInterfaces != nil {
 		interfacesList := make([]map[string]interface{}, 0)
 		for _, intfc := range bms.NetworkInterfaces {
+			flagAllowFloat := false
 			if *intfc.ID != *bms.PrimaryNetworkInterface.ID {
 				currentNic := map[string]interface{}{}
 				subnetId := *intfc.Subnet.ID
@@ -1309,6 +1310,9 @@ func bareMetalServerGet(context context.Context, d *schema.ResourceData, meta in
 				case "*vpcv1.BareMetalServerNetworkInterfaceByVlan":
 					{
 						bmsnic := bmsnicintf.(*vpcv1.BareMetalServerNetworkInterfaceByVlan)
+						if bmsnic.AllowInterfaceToFloat != nil {
+							flagAllowFloat = *bmsnic.AllowInterfaceToFloat
+						}
 						currentNic[isBareMetalServerNicAllowIPSpoofing] = *bmsnic.AllowIPSpoofing
 						currentNic[isBareMetalServerNicEnableInfraNAT] = *bmsnic.EnableInfrastructureNat
 						currentNic[isBareMetalServerNicPortSpeed] = *bmsnic.PortSpeed
@@ -1325,7 +1329,9 @@ func bareMetalServerGet(context context.Context, d *schema.ResourceData, meta in
 						}
 					}
 				}
-				interfacesList = append(interfacesList, currentNic)
+				if !flagAllowFloat {
+					interfacesList = append(interfacesList, currentNic)
+				}
 			}
 		}
 		d.Set(isBareMetalServerNetworkInterfaces, interfacesList)

--- a/ibm/service/vpc/resource_ibm_is_bare_metal_server_test.go
+++ b/ibm/service/vpc/resource_ibm_is_bare_metal_server_test.go
@@ -76,6 +76,44 @@ ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCKVmnMOlHKcZK8tpt3MP1lqOLAcqcJzhsvJcjscgVE
 		},
 	})
 }
+func TestAccIBMISBareMetalServer_multi_nic_with_allow_float(t *testing.T) {
+	var server string
+	vpcname := fmt.Sprintf("tf-vpc-%d", acctest.RandIntRange(10, 100))
+	name := fmt.Sprintf("tf-server-%d", acctest.RandIntRange(10, 100))
+	subnetname := fmt.Sprintf("tfip-subnet-%d", acctest.RandIntRange(10, 100))
+	publicKey := strings.TrimSpace(`
+ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCKVmnMOlHKcZK8tpt3MP1lqOLAcqcJzhsvJcjscgVERRN7/9484SOBJ3HSKxxNG5JN8owAjy5f9yYwcUg+JaUVuytn5Pv3aeYROHGGg+5G346xaq3DAwX6Y5ykr2fvjObgncQBnuU5KHWCECO/4h8uWuwh/kfniXPVjFToc+gnkqA+3RKpAecZhFXwfalQ9mMuYGFxn+fwn8cYEApsJbsEmb0iJwPiZ5hjFC8wREuiTlhPHDgkBLOiycd20op2nXzDbHfCHInquEe/gYxEitALONxm0swBOwJZwlTDOB7C6y2dzlrtxr1L59m7pCkWI4EtTRLvleehBoj3u7jB4usR
+`)
+	sshname := fmt.Sprintf("tf-sshname-%d", acctest.RandIntRange(10, 100))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { acc.TestAccPreCheck(t) },
+		Providers:    acc.TestAccProviders,
+		CheckDestroy: testAccCheckIBMISBareMetalServerDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckIBMISBareMetalServerMultiNicWithAllowFloatConfig(vpcname, subnetname, sshname, publicKey, name),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckIBMISBareMetalServerExists("ibm_is_bare_metal_server.testacc_bms", server),
+					resource.TestCheckResourceAttr(
+						"ibm_is_bare_metal_server.testacc_bms", "name", name),
+					resource.TestCheckResourceAttr(
+						"ibm_is_bare_metal_server.testacc_bms", "zone", acc.ISZoneName),
+					resource.TestCheckResourceAttr(
+						"ibm_is_bare_metal_server.testacc_bms", "network_interfaces.0.vlan", "102"),
+					resource.TestCheckResourceAttr(
+						"ibm_is_bare_metal_server_network_interface_allow_float.bms_nic", "name", "eth21"),
+					resource.TestCheckResourceAttr(
+						"ibm_is_bare_metal_server_network_interface_allow_float.bms_nic", "allow_ip_spoofing", "false"),
+					resource.TestCheckResourceAttr(
+						"ibm_is_bare_metal_server_network_interface_allow_float.bms_nic", "allow_interface_to_float", "true"),
+					resource.TestCheckResourceAttr(
+						"ibm_is_bare_metal_server_network_interface_allow_float.bms_nic", "enable_infrastructure_nat", "true"),
+				),
+			},
+		},
+	})
+}
 func TestAccIBMISBareMetalServer_basic_reserved_ip(t *testing.T) {
 	var server string
 	vpcname := fmt.Sprintf("tf-vpc-%d", acctest.RandIntRange(10, 100))
@@ -215,6 +253,52 @@ func testAccCheckIBMISBareMetalServerMultiNicConfig(vpcname, subnetname, sshname
 			}
 			vpc 				= ibm_is_vpc.testacc_vpc.id
 		}
+`, vpcname, subnetname, acc.ISZoneName, sshname, publicKey, acc.IsBareMetalServerProfileName, name, acc.IsBareMetalServerImage, acc.ISZoneName)
+}
+func testAccCheckIBMISBareMetalServerMultiNicWithAllowFloatConfig(vpcname, subnetname, sshname, publicKey, name string) string {
+	return fmt.Sprintf(`
+		resource "ibm_is_vpc" "testacc_vpc" {
+			name = "%s"
+		}
+	  
+		resource "ibm_is_subnet" "testacc_subnet" {
+			name            			= "%s"
+			vpc             			= ibm_is_vpc.testacc_vpc.id
+			zone            			= "%s"
+			total_ipv4_address_count 	= 16
+		}
+	  
+		resource "ibm_is_ssh_key" "testacc_sshkey" {
+			name       			= "%s"
+			public_key 			= "%s"
+		}
+	  
+		resource "ibm_is_bare_metal_server" "testacc_bms" {
+			profile 			= "%s"
+			name 				= "%s"
+			image 				= "%s"
+			zone 				= "%s"
+			keys 				= [ibm_is_ssh_key.testacc_sshkey.id]
+			primary_network_interface {
+				subnet     		= ibm_is_subnet.testacc_subnet.id
+				allowed_vlans                     = [101,102,103]
+			}
+			network_interfaces {
+				name			= "eth20"
+				subnet     		= ibm_is_subnet.testacc_subnet.id
+				vlan            = 102
+			}
+			vpc 				= ibm_is_vpc.testacc_vpc.id
+		}
+
+		resource ibm_is_bare_metal_server_network_interface_allow_float bms_nic {
+			bare_metal_server 	= ibm_is_bare_metal_server.testacc_bms.id
+			
+			subnet 				= ibm_is_subnet.testacc_subnet.id
+			name   				= "eth21"
+			vlan 				= 101
+		}
+
 `, vpcname, subnetname, acc.ISZoneName, sshname, publicKey, acc.IsBareMetalServerProfileName, name, acc.IsBareMetalServerImage, acc.ISZoneName)
 }
 func testAccCheckIBMISBareMetalServerReservedIpConfig(vpcname, subnetname, sshname, publicKey, name string) string {

--- a/website/docs/r/is_bare_metal_server.markdown
+++ b/website/docs/r/is_bare_metal_server.markdown
@@ -26,7 +26,7 @@ provider "ibm" {
 
 In the following example, you can create a Bare Metal Server:
 
-### Basic Example Using AMI Lookup
+### Basic Example
 ```terraform
 
 resource "ibm_is_vpc" "example" {
@@ -97,7 +97,28 @@ Review the argument references that you can specify for your resource.
 - `name` - (Optional, String) The bare metal server name.
 
   -> **NOTE:**
-    a bare metal server can take up to 30 mins to clean up on delete, replacement/re-creation using the same name will return error
+    a bare metal server can take up to 30 mins to clean up on delete, replacement/re-creation using the same name may return error
+
+- `network_interfaces` - (Optional, List) The additional network interfaces to create for the bare metal server to this bare metal server. Use `ibm_is_bare_metal_server_network_interface` &  `ibm_is_bare_metal_server_network_interface_allow_float` resource for network interfaces.
+
+  ~> **NOTE:**
+    creating network interfaces both inline with `ibm_is_bare_metal_server` & as a separate `ibm_is_bare_metal_server_network_interface` resource, will show change alternatively on both resources, to avoid this use `ibm_is_bare_metal_server_network_interface` for creating network interfaces.
+  
+  Nested scheme for `network_interfaces`:
+    - `allow_ip_spoofing` - (Optional, Boolean) Indicates whether IP spoofing is allowed on this interface. If false, IP spoofing is prevented on this interface. If true, IP spoofing is allowed on this interface. [default : `false`]
+    - `allowed_vlans` - (Optional, Array) Comma separated VLANs, Indicates what VLAN IDs (for VLAN type only) can use this physical (`PCI` type) interface. A given VLAN can only be in the `allowed_vlans` array for one PCI type adapter per bare metal server.  [ conflicts with `vlan`]
+    - `enable_infrastructure_nat` - (Optional, Boolean) If true, the VPC infrastructure performs any needed NAT operations. If false, the packet is passed unmodified to/from the network interface, allowing the workload to perform any needed NAT operations. [default : `true`]
+    - `name` - (Required, String) The name of the network interface.
+    - `primary_ip` - (Optional, List) The primary IP address to bind to the network interface. This can be specified using an existing reserved IP, or a prototype object for a new reserved IP.
+
+      Nested scheme for `primary_ip`:
+        - `address` - (Optional, String) title: IPv4 The IP address. This property may add support for IPv6 addresses in the future. When processing a value in this property, verify that the address is in an expected format. If it is not, log an error. Optionally halt processing and surface the error, or bypass the resource on which the unexpected IP address format was encountered.
+        - `reserved_ip`- (Optional, String) The unique identifier for this reserved IP.
+        - `name`- (Optional, String) The user-defined or system-provided name for this reserved IP
+      
+    - `security_groups` - (Optional, Array) Comma separated IDs of security groups.
+    - `subnet` -  (Required, String) ID of the subnet to associate with.
+    - `vlan` -  (Optional, Integer) Indicates the 802.1Q VLAN ID tag that must be used for all traffic on this interface. [ conflicts with `allowed_vlans`]
 
 - `primary_network_interface` - (Required, List) A nested block describing the primary network interface of this bare metal server. We can have only one primary network interface.
   


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/IBM-Cloud/terraform-provider-ibm/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```
