### PR TITLE
Deprecate key_protect_key_id

### DIFF
--- a/ibm/flex/structures.go
+++ b/ibm/flex/structures.go
@@ -1664,7 +1664,6 @@ func FlattenWhitelist(whitelist icdv4.Whitelist) []map[string]interface{} {
 	return entries
 }
 
-// Cloud Internet Services
 func ExpandPlatformOptions(platformOptions icdv4.PlatformOptions) []map[string]interface{} {
 	pltOptions := make([]map[string]interface{}, 0, 1)
 	pltOption := make(map[string]interface{})

--- a/ibm/flex/structures.go
+++ b/ibm/flex/structures.go
@@ -1664,6 +1664,17 @@ func FlattenWhitelist(whitelist icdv4.Whitelist) []map[string]interface{} {
 	return entries
 }
 
+// Cloud Internet Services
+func ExpandPlatformOptions(platformOptions icdv4.PlatformOptions) []map[string]interface{} {
+	pltOptions := make([]map[string]interface{}, 0, 1)
+	pltOption := make(map[string]interface{})
+	pltOption["key_protect_key_id"] = platformOptions.KeyProtectKey
+	pltOption["disk_encryption_key_crn"] = platformOptions.DiskENcryptionKeyCrn
+	pltOption["backup_encryption_key_crn"] = platformOptions.BackUpEncryptionKeyCrn
+	pltOptions = append(pltOptions, pltOption)
+	return pltOptions
+}
+
 func expandStringMap(inVal interface{}) map[string]string {
 	outVal := make(map[string]string)
 	if inVal == nil {

--- a/ibm/service/database/data_source_ibm_database.go
+++ b/ibm/service/database/data_source_ibm_database.go
@@ -19,7 +19,6 @@ import (
 	"github.com/IBM-Cloud/bluemix-go/models"
 	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/conns"
 	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/flex"
-	// "github.com/IBM/cloud-databases-go-sdk/clouddatabasesv5"
 )
 
 func DataSourceIBMDatabaseInstance() *schema.Resource {

--- a/ibm/service/database/data_source_ibm_database.go
+++ b/ibm/service/database/data_source_ibm_database.go
@@ -105,7 +105,7 @@ func DataSourceIBMDatabaseInstance() *schema.Resource {
 							Description: "Key protect key id",
 							Type:        schema.TypeString,
 							Computed:    true,
-							Deprecated:  "This field is deprecated please use disk_encryption_key_crn",
+							Deprecated:  "This field is deprecated and has been replaced by disk_encryption_key_crn",
 						},
 						"disk_encryption_key_crn": {
 							Description: "Disk encryption key crn",

--- a/website/docs/d/database.html.markdown
+++ b/website/docs/d/database.html.markdown
@@ -47,7 +47,7 @@ In addition to all argument references list, you can access the following attrib
 - `platform_options`-  (String) The CRN of key protect key.
    
    Nested scheme for `platform_options`:
-   - `key_protect_key_id`-  **Deprecated** - (String) The CRN of key protect key.
+   - `key_protect_key_id`-  **Deprecated** - (String) The CRN of key protect key. - replaced by `backup_encryption_key_crn`
    - `disk_encryption_key_crn`-  (String) The CRN of disk encryption key.
    - `backup_encryption_key_crn`-  (String) The CRN of backup encryption key.
    

--- a/website/docs/d/database.html.markdown
+++ b/website/docs/d/database.html.markdown
@@ -47,7 +47,7 @@ In addition to all argument references list, you can access the following attrib
 - `platform_options`-  (String) The CRN of key protect key.
    
    Nested scheme for `platform_options`:
-   - `key_protect_key_id`-  (String) The CRN of key protect key.
+   - `key_protect_key_id`-  **Deprecated** - (String) The CRN of key protect key.
    - `disk_encryption_key_crn`-  (String) The CRN of disk encryption key.
    - `backup_encryption_key_crn`-  (String) The CRN of backup encryption key.
    


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/IBM-Cloud/terraform-provider-ibm/blob/master/.github/CONTRIBUTING.md --->

`key_protect_key_id` is deprecated and has been replaced by `backup_encryption_key_crn`. Refactored code to add deprecated to `key_protect_key_id`. Updated docs as well.

Note that functionally no changes have been made.

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccXXX'
--- PASS: TestAccIBMDatabaseDataSource_basic (585.66s)
PASS
ok  	github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/database	586.688s
...
```

---------------------------------------------------------------------
Commands being run:
```
data "ibm_database" "test" {
  name = "20-056 Lorna Databases for MongoDB-iy"
  location = "us-south"
}

output "the_good_stuff" {
  value = data.ibm_database.test.platform_options
}
```

Before the changes
```
Changes to Outputs:
  + the_good_stuff = [
      + {
          + backup_encryption_key_crn = ""
          + disk_encryption_key_crn   = "crn:v1:bluemix:public:kms:au-syd:a/40ddc34a953a8c02f10987b59085b60e:673d0877-db09-4b48-ace8-28e677705ca2:key:8c80be4e-482a-42c3-803b-54f4d84abf85"
          + key_protect_key_id        = "crn:v1:bluemix:public:kms:au-syd:a/40ddc34a953a8c02f10987b59085b60e:673d0877-db09-4b48-ace8-28e677705ca2:key:8c80be4e-482a-42c3-803b-54f4d84abf85"
        },
    ]
```

After the changes
```
Changes to Outputs:
  + the_good_stuff = [
      + {
          + backup_encryption_key_crn = ""
          + disk_encryption_key_crn   = "crn:v1:bluemix:public:kms:au-syd:a/40ddc34a953a8c02f10987b59085b60e:673d0877-db09-4b48-ace8-28e677705ca2:key:8c80be4e-482a-42c3-803b-54f4d84abf85"
          + key_protect_key_id        = "crn:v1:bluemix:public:kms:au-syd:a/40ddc34a953a8c02f10987b59085b60e:673d0877-db09-4b48-ace8-28e677705ca2:key:8c80be4e-482a-42c3-803b-54f4d84abf85"
        },
    ]
```