### PR TITLE
Delete Over Count Bug Fix

### DIFF
--- a/examples/ibm-is-ng/main.tf
+++ b/examples/ibm-is-ng/main.tf
@@ -1051,7 +1051,7 @@ resource "ibm_is_backup_policy_plan" "is_backup_policy_plan" {
   copy_user_tags = true
   deletion_trigger {
     delete_after      = 20
-    delete_over_count = 20
+    delete_over_count = "20"
   }
   name = "my-backup-policy-plan-1"
 }

--- a/ibm/service/vpc/resource_ibm_is_backup_policy_plan.go
+++ b/ibm/service/vpc/resource_ibm_is_backup_policy_plan.go
@@ -173,11 +173,9 @@ func resourceIBMIsBackupPolicyPlanCreate(context context.Context, d *schema.Reso
 		if backupPolicyPlanDeletionTriggerPrototypeMap["delete_after"] != nil {
 			backupPolicyPlanDeletionTriggerPrototype.DeleteAfter = core.Int64Ptr(int64(backupPolicyPlanDeletionTriggerPrototypeMap["delete_after"].(int)))
 		}
-		log.Println("backupPolicyPlanDeletionTriggerPrototypeMap[delete_over_count] Inside")
-		log.Println(backupPolicyPlanDeletionTriggerPrototypeMap["delete_over_count"])
 		if backupPolicyPlanDeletionTriggerPrototypeMap["delete_over_count"] != nil {
 			deleteOverCountString := backupPolicyPlanDeletionTriggerPrototypeMap["delete_over_count"].(string)
-			if deleteOverCountString != "" {
+			if deleteOverCountString != "" && deleteOverCountString != "null" {
 				deleteOverCount, err := strconv.ParseInt(backupPolicyPlanDeletionTriggerPrototypeMap["delete_over_count"].(string), 10, 64)
 				if err != nil {
 					return diag.FromErr(fmt.Errorf("[ERROR] Error setting delete_over_count: %s", err))
@@ -185,6 +183,8 @@ func resourceIBMIsBackupPolicyPlanCreate(context context.Context, d *schema.Reso
 				deleteOverCountint := int64(deleteOverCount)
 				if deleteOverCountint >= int64(0) {
 					backupPolicyPlanDeletionTriggerPrototype.DeleteOverCount = core.Int64Ptr(deleteOverCountint)
+				} else {
+					return diag.FromErr(fmt.Errorf("[ERROR] Error setting delete_over_count: Retention count and days cannot be both zero"))
 				}
 			}
 		}
@@ -310,6 +310,8 @@ func resourceIBMIsBackupPolicyPlanBackupPolicyPlanDeletionTriggerPrototypeToMap(
 	}
 	if backupPolicyPlanDeletionTriggerPrototype.DeleteOverCount != nil {
 		backupPolicyPlanDeletionTriggerPrototypeMap["delete_over_count"] = strconv.FormatInt(*backupPolicyPlanDeletionTriggerPrototype.DeleteOverCount, 10)
+	} else {
+		backupPolicyPlanDeletionTriggerPrototypeMap["delete_over_count"] = "null"
 	}
 
 	return backupPolicyPlanDeletionTriggerPrototypeMap
@@ -360,7 +362,7 @@ func resourceIBMIsBackupPolicyPlanUpdate(context context.Context, d *schema.Reso
 		}
 		if backupPolicyPlanDeletionTriggerPrototypeMap["delete_over_count"] != nil {
 			deleteOverCountString := backupPolicyPlanDeletionTriggerPrototypeMap["delete_over_count"].(string)
-			if deleteOverCountString != "" {
+			if deleteOverCountString != "" && deleteOverCountString != "null" {
 				deleteOverCount, err := strconv.ParseInt(backupPolicyPlanDeletionTriggerPrototypeMap["delete_over_count"].(string), 10, 64)
 				if err != nil {
 					return diag.FromErr(fmt.Errorf("[ERROR] Error setting delete_over_count: %s", err))

--- a/website/docs/r/is_backup_policy_plan.html.markdown
+++ b/website/docs/r/is_backup_policy_plan.html.markdown
@@ -51,7 +51,10 @@ backup_policy_plan_id
   
   Nested scheme for `deletion_trigger`:
   - `delete_after` - (Optional, Integer) The maximum number of days to keep each backup after creation. Default value is 30.
-  - `delete_over_count` - (Optional, Integer) The maximum number of recent backups to keep. If unspecified, there will be no maximum.
+  - `delete_over_count` - (Optional, String) The maximum number of recent backups to keep. If unspecified, there will be no maximum.
+    
+      ->**Note** Assign back to "null" to reset to no maximum.
+
 - `name` - (Optional, String) The user-defined name for this backup policy plan. Names must be unique within the backup policy this plan resides in. If unspecified, the name will be a hyphenated list of randomly-selected words.
 
 ## Attribute Reference


### PR DESCRIPTION

<!--- See what makes a good Pull Request at : https://github.com/IBM-Cloud/terraform-provider-ibm/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

Relates OR Closes #0000
`delete_over_count` cannot be `0, is allowed to set to `null`.

Output testing:


```
resource "ibm_is_backup_policy" "is_backup_policy" {
  match_user_tags = ["tag-0"]
  name            = "backup-policy"
}

resource "ibm_is_backup_policy_plan" "is_backup_policy_plan_import" {
  backup_policy_id = ibm_is_backup_policy.is_backup_policy.id
  name             = "backup-policy-plan"
  cron_spec        = "40 2 * * *"
  deletion_trigger {
    delete_over_count = "50"
  }
}
```

<img width="1280" alt="Screenshot 2022-08-03 at 5 21 17 PM" src="https://user-images.githubusercontent.com/78336632/182601153-34b392a3-6a54-4835-b128-5591c6947520.png">