### PR TITLE
fix(security_group): added wait logic to wait for target removal to avoid 409

### DIFF
--- a/ibm/service/vpc/resource_ibm_is_security_group_test.go
+++ b/ibm/service/vpc/resource_ibm_is_security_group_test.go
@@ -6,6 +6,7 @@ package vpc_test
 import (
 	"errors"
 	"fmt"
+	"strings"
 	"testing"
 
 	acc "github.com/IBM-Cloud/terraform-provider-ibm/ibm/acctest"
@@ -47,6 +48,48 @@ func TestAccIBMISSecurityGroup_basic(t *testing.T) {
 						"ibm_is_security_group.testacc_security_group", "name", name1),
 					resource.TestCheckResourceAttr(
 						"ibm_is_security_group.testacc_security_group", "tags.#", "1"),
+				),
+			},
+		},
+	})
+}
+func TestAccIBMISSecurityGroup_wait(t *testing.T) {
+	var securityGroup string
+
+	vpcname := fmt.Sprintf("tfsg-vpc-%d", acctest.RandIntRange(10, 100))
+	subnetname := fmt.Sprintf("tfsg-subnet-%d", acctest.RandIntRange(10, 100))
+	sshname := fmt.Sprintf("tfsg-ssh-%d", acctest.RandIntRange(10, 100))
+	vsiname := fmt.Sprintf("tfsg-vsi-%d", acctest.RandIntRange(10, 100))
+	bmname := fmt.Sprintf("tfsg-bm-%d", acctest.RandIntRange(10, 100))
+	name1 := fmt.Sprintf("tfsg-createname-%d", acctest.RandIntRange(10, 100))
+	publickey := strings.TrimSpace(`
+	ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCKVmnMOlHKcZK8tpt3MP1lqOLAcqcJzhsvJcjscgVERRN7/9484SOBJ3HSKxxNG5JN8owAjy5f9yYwcUg+JaUVuytn5Pv3aeYROHGGg+5G346xaq3DAwX6Y5ykr2fvjObgncQBnuU5KHWCECO/4h8uWuwh/kfniXPVjFToc+gnkqA+3RKpAecZhFXwfalQ9mMuYGFxn+fwn8cYEApsJbsEmb0iJwPiZ5hjFC8wREuiTlhPHDgkBLOiycd20op2nXzDbHfCHInquEe/gYxEitALONxm0swBOwJZwlTDOB7C6y2dzlrtxr1L59m7pCkWI4EtTRLvleehBoj3u7jB4usR
+	`)
+	//name2 := fmt.Sprintf("tfsg-updatename-%d", acctest.RandIntRange(10, 100))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { acc.TestAccPreCheck(t) },
+		Providers:    acc.TestAccProviders,
+		CheckDestroy: testAccCheckIBMISSecurityGroupDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckIBMISsecurityGroupWaitConfig(name1, vpcname, subnetname, sshname, publickey, vsiname, bmname),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckIBMISSecurityGroupExists("ibm_is_security_group.testacc_security_group", securityGroup),
+					resource.TestCheckResourceAttr(
+						"ibm_is_security_group.testacc_security_group", "name", name1),
+					resource.TestCheckResourceAttr(
+						"ibm_is_security_group.testacc_security_group", "tags.#", "2"),
+					resource.TestCheckResourceAttr(
+						"ibm_is_vpc.testacc_vpc", "name", vpcname),
+					resource.TestCheckResourceAttr(
+						"ibm_is_subnet.testacc_subnet", "name", subnetname),
+					resource.TestCheckResourceAttr(
+						"ibm_is_ssh_key.testacc_sshkey", "name", sshname),
+					resource.TestCheckResourceAttr(
+						"ibm_is_instance.testacc_instance", "name", vsiname),
+					resource.TestCheckResourceAttr(
+						"ibm_is_bare_metal_server.testacc_bms", "name", bmname),
 				),
 			},
 		},
@@ -110,6 +153,64 @@ resource "ibm_is_security_group" "testacc_security_group" {
 	vpc = "${ibm_is_vpc.testacc_vpc.id}"
 	tags = ["Tag1", "tag2"]
 }`, vpcname, name)
+
+}
+func testAccCheckIBMISsecurityGroupWaitConfig(name, vpcname, subnetname, sshname, publicKey, vsiname, bmname string) string {
+	return fmt.Sprintf(`
+resource "ibm_is_vpc" "testacc_vpc" {
+	name = "%s"
+}
+
+resource ibm_is_subnet testacc_subnet {
+	name = "%s"
+	zone = "%s"
+	vpc = "${ibm_is_vpc.testacc_vpc.id}"
+	total_ipv4_address_count = 16
+}
+
+resource "ibm_is_security_group" "testacc_security_group" {
+	name = "%s"
+	vpc = "${ibm_is_vpc.testacc_vpc.id}"
+	tags = ["tag1", "tag2"]
+}
+
+
+resource "ibm_is_ssh_key" "testacc_sshkey" {
+	name       = "%s"
+	public_key = "%s"
+}
+  
+resource "ibm_is_instance" "testacc_instance" {
+	name    = "%s"
+	image   = "%s"
+	profile = "%s"
+	primary_network_interface {
+		subnet     = ibm_is_subnet.testacc_subnet.id
+		security_groups = [ibm_is_security_group.testacc_security_group.id]
+	}
+	vpc  = ibm_is_vpc.testacc_vpc.id
+	zone = "%s"
+	keys = [ibm_is_ssh_key.testacc_sshkey.id]
+	network_interfaces {
+		subnet = ibm_is_subnet.testacc_subnet.id
+		name   = "eth12"
+		security_groups = [ibm_is_security_group.testacc_security_group.id]
+	}
+}
+
+resource "ibm_is_bare_metal_server" "testacc_bms" {
+	profile 			= "%s"
+	name 				= "%s"
+	image 				= "%s"
+	zone 				= "%s"
+	keys 				= [ibm_is_ssh_key.testacc_sshkey.id]
+	primary_network_interface {
+		subnet     		= ibm_is_subnet.testacc_subnet.id
+		security_groups = [ibm_is_security_group.testacc_security_group.id]
+	}
+	vpc 				= ibm_is_vpc.testacc_vpc.id
+}
+`, vpcname, subnetname, acc.ISZoneName, name, sshname, publicKey, vsiname, acc.IsImage, acc.InstanceProfileName, acc.ISZoneName, acc.IsBareMetalServerProfileName, bmname, acc.IsBareMetalServerImage, acc.ISZoneName)
 
 }
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/IBM-Cloud/terraform-provider-ibm/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
--- PASS: TestAccIBMISSecurityGroup_basic (113.34s)
PASS
ok      github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/vpc     116.254s
```
