### PR TITLE
Fix duplicate VPC entries in cloud conn create

### DIFF
--- a/ibm/service/power/resource_ibm_pi_cloud_connection.go
+++ b/ibm/service/power/resource_ibm_pi_cloud_connection.go
@@ -145,6 +145,11 @@ func ResourceIBMPICloudConnection() *schema.Resource {
 				Computed:    true,
 				Description: "GRE auto-assigned source IP address",
 			},
+			PICloudConnectionConnectionMode: {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "Type of service the gateway is attached to",
+			},
 		},
 	}
 }
@@ -200,8 +205,9 @@ func resourceIBMPICloudConnectionCreate(ctx context.Context, d *schema.ResourceD
 			vpcIds := flex.ExpandStringList(v.(*schema.Set).List())
 			vpcs := make([]*models.CloudConnectionVPC, len(vpcIds))
 			for i, vpcId := range vpcIds {
+				vpcIdCopy := vpcId[0:]
 				vpcs[i] = &models.CloudConnectionVPC{
-					VpcID: &vpcId,
+					VpcID: &vpcIdCopy,
 				}
 			}
 			vpc.Vpcs = vpcs

--- a/website/docs/d/pi_cloud_connection.html.markdown
+++ b/website/docs/d/pi_cloud_connection.html.markdown
@@ -49,6 +49,7 @@ In addition to all argument reference list, you can access the following attribu
 
 - `id` - (String) The unique identifier of the cloud connection.
 - `classic_enabled` - (Bool) Is classic endpoint destination enabled?
+- `connection_mode` - (String) Type of service the gateway is attached to.
 - `global_routing` - (String) Is global routing enabled for this cloud connection.
 - `gre_destination_address` - (String) The GRE destination IP address.
 - `gre_source_address` - (String) The GRE auto-assigned source IP address.
@@ -61,4 +62,3 @@ In addition to all argument reference list, you can access the following attribu
 - `user_ip_address` - (String) User IP address.
 - `vpc_crns` - (Set of String) Set of VPCs attached to this cloud connection.
 - `vpc_enabled` - (Bool) Is VPC enabled for this cloud connection?
-- `connection_mode` - (String) Type of service the gateway is attached to.

--- a/website/docs/r/pi_cloud_connection.html.markdown
+++ b/website/docs/r/pi_cloud_connection.html.markdown
@@ -70,6 +70,7 @@ In addition to all argument reference list, you can access the following attribu
 
 - `id` - (String) The unique identifier of cloud connection.
 - `cloud_connection_id` - (String) The cloud connection ID.
+- `connection_mode` - (String) Type of service the gateway is attached to.
 - `gre_source_address` - (String) The GRE auto-assigned source IP address.
 - `ibm_ip_address` - (String) The IBM IP address.
 - `port` - (String) Port.


### PR DESCRIPTION
Fix duplicate VPC entries in cloud connection create
operation.

<!--- See what makes a good Pull Request at : https://github.com/IBM-Cloud/terraform-provider-ibm/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Output from acceptance testing:
=== RUN   TestAccIBMPICloudConnectionVPC
--- PASS: TestAccIBMPICloudConnectionVPC (376.75s)
PASS
...
```
