### PR TITLE
Update datasource to return nil if resource group does not exist instead of error

### DIFF
--- a/ibm/service/resourcemanager/data_source_ibm_resource_group.go
+++ b/ibm/service/resourcemanager/data_source_ibm_resource_group.go
@@ -123,7 +123,21 @@ func dataSourceIBMResourceGroupRead(d *schema.ResourceData, meta interface{}) er
 		return fmt.Errorf("[ERROR] Error retrieving resource group: %s %s", err, resp)
 	}
 	if len(rg.Resources) < 1 {
-		return fmt.Errorf("[ERROR] Given Resource Group is not found in the account : %s %s", err, resp)
+		fmt.Printf("[WARNING] Given Resource Group is not found in the account : %s %s\n", err, resp)
+		d.Set("name", nil)
+		d.Set("is_default", nil)
+		d.Set("state", nil)
+		d.Set("crn", nil)
+		d.Set("created_at", nil)
+		d.Set("updated_at", nil)
+		d.Set("teams_url", nil)
+		d.Set("payment_methods_url", nil)
+		d.Set("quota_url", nil)
+		d.Set("quota_id", nil)
+		d.Set("account_id", nil)
+		d.Set("resource_linkages", nil)
+
+		return nil
 	}
 	resourceGroup := rg.Resources[0]
 	d.SetId(*resourceGroup.ID)


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/IBM-Cloud/terraform-provider-ibm/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->

Resolves https://github.com/IBM-Cloud/terraform-provider-ibm/issues/3960

Output from acceptance testing:

```golang
 make testacc TEST=./ibm/service/resourcemanager TESTARGS='-run=TestAccIBMResourceGroupDataSource*'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./ibm/service/resourcemanager -v -run=TestAccIBMResourceGroupDataSource* -timeout 700m
=== RUN   TestAccIBMResourceGroupDataSource_Basic
--- PASS: TestAccIBMResourceGroupDataSource_Basic (20.37s)
=== RUN   TestAccIBMResourceGroupDataSource_Default_false
--- PASS: TestAccIBMResourceGroupDataSource_Default_false (1.63s)
PASS

```
