### PR TITLE
Add Cloudant IAM minimum role notes

### DIFF
--- a/examples/ibm-cloudant-database/README.md
+++ b/examples/ibm-cloudant-database/README.md
@@ -48,6 +48,11 @@ module "cloudant-database" {
 
 ```
 
+## Notes
+
+1. The credentials used by the Terraform provider must at a minimum have these roles or equivalent actions:
+    - `Manager` role for Cloudant Service
+
 ## Requirements
 
 | Name | Version |

--- a/examples/ibm-cloudant/README.md
+++ b/examples/ibm-cloudant/README.md
@@ -24,6 +24,9 @@ Examples can be found in the subfolders along with the instructions how to run t
 
 ## Notes
 
+1. The credentials used by the Terraform provider must at a minimum have these roles or equivalent actions:
+    - `Administrator` role for Cloudant Platform
+    - `Viewer` role for the resource group that the resources will be in
 1. With `Lite` plan `capacity` can be set no more than 1 throughput blocks.
 1. `parameters` can overwrite the previously set arguments named the same way.
 1. With [`Standard` plan on dedicated hardware](standard-plan-on-dedicated-hw) the hardware must be ordered separately and provisioning should be completed before using Terraform on it


### PR DESCRIPTION
Document the minimum necessary IAM roles to use the `ibm_cloudant` resource/data-source and `ibm_cloudant_database` resource/data-source.

<!--- See what makes a good Pull Request at : https://github.com/IBM-Cloud/terraform-provider-ibm/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

