### PR TITLE
CIS - Delete filter on deletion of Firewall Rules 

### DIFF
--- a/ibm/service/cis/data_source_ibm_cis_domain.go
+++ b/ibm/service/cis/data_source_ibm_cis_domain.go
@@ -58,10 +58,12 @@ func DataSourceIBMCISDomain() *schema.Resource {
 			cisDomainVerificationKey: {
 				Type:     schema.TypeString,
 				Computed: true,
+				Optional: true,
 			},
 			cisDomainCnameSuffix: {
 				Type:     schema.TypeString,
 				Computed: true,
+				Optional: true,
 			},
 		},
 	}
@@ -98,8 +100,11 @@ func dataSourceIBMCISDomainRead(d *schema.ResourceData, meta interface{}) error 
 			d.Set(cisDomainOriginalNameServers, zone.OriginalNameServers)
 			d.Set(cisDomainID, *zone.ID)
 			d.Set(cisDomainType, *zone.Type)
-			d.Set(cisDomainVerificationKey, *zone.VerificationKey)
-			d.Set(cisDomainCnameSuffix, *zone.CnameSuffix)
+
+			if cisDomainType == "partial" {
+				d.Set(cisDomainVerificationKey, *zone.VerificationKey)
+				d.Set(cisDomainCnameSuffix, *zone.CnameSuffix)
+			}
 			zoneFound = true
 		}
 	}

--- a/ibm/service/cis/resource_ibm_cis_domain.go
+++ b/ibm/service/cis/resource_ibm_cis_domain.go
@@ -71,12 +71,10 @@ func ResourceIBMCISDomain() *schema.Resource {
 			cisDomainVerificationKey: {
 				Type:     schema.TypeString,
 				Computed: true,
-				Optional: true,
 			},
 			cisDomainCnameSuffix: {
 				Type:     schema.TypeString,
 				Computed: true,
-				Optional: true,
 			},
 		},
 		Create:   resourceCISdomainCreate,

--- a/ibm/service/cis/resource_ibm_cis_domain.go
+++ b/ibm/service/cis/resource_ibm_cis_domain.go
@@ -71,10 +71,12 @@ func ResourceIBMCISDomain() *schema.Resource {
 			cisDomainVerificationKey: {
 				Type:     schema.TypeString,
 				Computed: true,
+				Optional: true,
 			},
 			cisDomainCnameSuffix: {
 				Type:     schema.TypeString,
 				Computed: true,
+				Optional: true,
 			},
 		},
 		Create:   resourceCISdomainCreate,
@@ -135,8 +137,11 @@ func resourceCISdomainRead(d *schema.ResourceData, meta interface{}) error {
 	d.Set(cisDomainNameServers, result.Result.NameServers)
 	d.Set(cisDomainOriginalNameServers, result.Result.OriginalNameServers)
 	d.Set(cisDomainType, result.Result.Type)
-	d.Set(cisDomainVerificationKey, result.Result.VerificationKey)
-	d.Set(cisDomainCnameSuffix, result.Result.CnameSuffix)
+
+	if cisDomainType == "partial" {
+		d.Set(cisDomainVerificationKey, result.Result.VerificationKey)
+		d.Set(cisDomainCnameSuffix, result.Result.CnameSuffix)
+	}
 
 	return nil
 }
@@ -207,7 +212,7 @@ func ResourceIBMCISDomainValidator() *validate.ResourceValidator {
 			ValidateFunctionIdentifier: validate.ValidateAllowedStringValue,
 			Type:                       validate.TypeString,
 			Optional:                   true,
-			AllowedValues:              "full, parital"})
+			AllowedValues:              "full, partial"})
 
 	ibmCISDomainResourceValidator := validate.ResourceValidator{
 		ResourceName: ibmCISDomain,

--- a/ibm/service/cis/resource_ibm_cis_firewall_rules.go
+++ b/ibm/service/cis/resource_ibm_cis_firewall_rules.go
@@ -238,6 +238,21 @@ func ResourceIBMCISFirewallrulesDelete(context context.Context, d *schema.Resour
 		return diag.FromErr(fmt.Errorf("[ERROR] Error deleting the  custom resolver %s:%s", err, response))
 	}
 
+	if id, ok := d.GetOk(cisFilterID); ok {
+
+		cisFilterClient, err := meta.(conns.ClientSession).CisFiltersSession()
+		if err != nil {
+			return nil
+		}
+
+		filter_id := id.(string)
+		filterOpt := cisFilterClient.NewDeleteFiltersOptions(xAuthtoken, crn, zoneID, filter_id)
+		_, _, err = cisFilterClient.DeleteFilters(filterOpt)
+		if err != nil {
+			return diag.FromErr(fmt.Errorf("[ERROR] Error deleting Filter: %s", err))
+		}
+	}
+
 	d.SetId("")
 	return nil
 }

--- a/website/docs/r/cis_firewall_rules.html.markdown
+++ b/website/docs/r/cis_firewall_rules.html.markdown
@@ -10,7 +10,7 @@ description: |-
 # ibm_cis_firewall_rules
 
 
-Create, update, or delete a firewall rules for a domain that you included in your IBM Cloud Internet Services instance and a CIS domain resource. For more information, about CIS firewall rules resource, see [using fields, functions, and expressions](https://cloud.ibm.com/docs/cis?topic=cis-fields-and-expressions).
+Create, update, or delete a firewall rules for a domain that you included in your IBM Cloud Internet Services instance and a CIS domain resource. For more information, about CIS firewall rules resource, see [using fields, functions, and expressions](https://cloud.ibm.com/docs/cis?topic=cis-fields-and-expressions). Note - Deletion of Firewall Rules will result in deletion of the respective Filter too.
 
 ## Example usage
 


### PR DESCRIPTION
Problem statement - 
- On deletion of Firewall Rules, the filter is not removed automatically.

Issue - https://github.ibm.com/NetworkTribe/CIS_Support/issues/2515
