### PR TITLE
key_protect_key_id doc typo fix

### DIFF
--- a/website/docs/d/database.html.markdown
+++ b/website/docs/d/database.html.markdown
@@ -47,7 +47,7 @@ In addition to all argument references list, you can access the following attrib
 - `platform_options`-  (String) The CRN of key protect key.
    
    Nested scheme for `platform_options`:
-   - `key_protect_key_id`-  **Deprecated** - (String) The CRN of key protect key. - replaced by `backup_encryption_key_crn`
+   - `key_protect_key_id`-  **Deprecated** - (String) The CRN of key protect key. - replaced by `disk_encryption_key_crn`
    - `disk_encryption_key_crn`-  (String) The CRN of disk encryption key.
    - `backup_encryption_key_crn`-  (String) The CRN of backup encryption key.
    


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/IBM-Cloud/terraform-provider-ibm/blob/master/.github/CONTRIBUTING.md --->

Typo in the key_protect_key_id deprecation docs

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
N/A
