### PR TITLE
instance template vol attachment fix with doc

### DIFF
--- a/ibm/service/vpc/resource_ibm_is_instance_template.go
+++ b/ibm/service/vpc/resource_ibm_is_instance_template.go
@@ -189,7 +189,7 @@ func ResourceIBMISInstanceTemplate() *schema.Resource {
 			isInstanceTemplateVolumeAttachments: {
 				Type:     schema.TypeList,
 				Optional: true,
-				Computed: true,
+				ForceNew: true,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						isInstanceTemplateVolumeDeleteOnInstanceDelete: {

--- a/ibm/service/vpc/resource_ibm_is_instance_template_test.go
+++ b/ibm/service/vpc/resource_ibm_is_instance_template_test.go
@@ -384,8 +384,8 @@ func testAccCheckIBMISInstanceTemplateWithVolume(vpcName, subnetName, sshKeyName
         delete_volume_on_instance_delete = true
         name                             = "%s"
 			volume_prototype {
-				iops = 9000
-				profile = "general-purpose"
+				iops = 6000
+				profile = "custom"
 				capacity = 100
 			}   
     	}

--- a/website/docs/r/is_instance_template.html.markdown
+++ b/website/docs/r/is_instance_template.html.markdown
@@ -10,7 +10,7 @@ description: |-
 # ibm_is_instance_template
 Create, update, or delete an instance template on VPC. For more information, about instance template, see [managing an instance template](https://cloud.ibm.com/docs/vpc?topic=vpc-managing-instance-template).
 
-**Note:** 
+~>**Note:** 
 VPC infrastructure services are a regional specific based endpoint, by default targets to `us-south`. Please make sure to target right region in the provider block as shown in the `provider.tf` file, if VPC service is created in region other than `us-south`.
 
 **provider.tf**
@@ -94,7 +94,7 @@ resource "ibm_is_instance_template" "example" {
     name                             = "example-volume-att-01"
     volume_prototype {
       iops     = 3000
-      profile  = "general-purpose"
+      profile  = "custom"
       capacity = 200
     }
   }
@@ -185,13 +185,13 @@ Review the argument references that you can specify for your resource.
 - `total_volume_bandwidth` - (Optional, int) The amount of bandwidth (in megabits per second) allocated exclusively to instance storage volumes
 - `dedicated_host` - (Optional, Force new resource,String) The placement restrictions to use for the virtual server instance. Unique Identifier of the dedicated host where the instance is placed.
 
-  **Note:**
-    - only one of [**dedicated_host**, **dedicated_host_group**, **placement_group**] can be used
+  ~>**Note:** 
+    only one of [**dedicated_host**, **dedicated_host_group**, **placement_group**] can be used
 
 - `dedicated_host_group` - (Optional, Force new resource, String) The placement restrictions to use for the virtual server instance. Unique Identifier of the dedicated host group where the instance is placed.
 
-  **Note:**
-    - only one of [**dedicated_host**, **dedicated_host_group**, **placement_group**] can be used
+  ~>**Note:** 
+    only one of [**dedicated_host**, **dedicated_host_group**, **placement_group**] can be used
 
 - `default_trusted_profile_auto_link` - (Optional, Forces new resource, Boolean) If set to `true`, the system will create a link to the specified `target` trusted profile during instance creation. Regardless of whether a link is created by the system or manually using the IAM Identity service, it will be automatically deleted when the instance is deleted. Default value : **true**
 - `default_trusted_profile_target` - (Optional, Forces new resource, String) The unique identifier or CRN of the default IAM trusted profile to use for this virtual server instance.
@@ -201,8 +201,8 @@ Review the argument references that you can specify for your resource.
 - `name` - (Optional, String) The name of the instance template.
 - `placement_group` - (Optional, Force new resource, String) The placement restrictions to use for the virtual server instance. Unique Identifier of the placement group where the instance is placed.
 
-  **Note:**
-    - only one of [**dedicated_host**, **dedicated_host_group**, **placement_group**] can be used
+  ~>**Note:** 
+    only one of [**dedicated_host**, **dedicated_host_group**, **placement_group**] can be used
 - `profile` - (Required, String) The number of instances created in the instance group.
 - `primary_network_interfaces` (Required, List) A nested block describes the primary network interface for the template.
 
@@ -221,23 +221,23 @@ Review the argument references that you can specify for your resource.
   - `security_groups` - (Optional, List) List of security groups of the subnet.
   - `subnet` - (Required, Forces new resource, String) The VPC subnet to assign to the interface.
 - `resource_group` - (Optional, Forces new resource, String) The resource group ID.
-- `volume_attachments` - (Optional, List) A nested block describes the storage volume configuration for the template.
+- `volume_attachments` - (Optional, Force new resource, List) A nested block describes the storage volume configuration for the template. 
 
   Nested scheme for `volume_attachments`:
-	- `name` - (Required, String) The name of the boot volume.
-	- `volume` - (Required, String) The storage volume ID created in VPC.
-  - `delete_volume_on_instance_delete`- (Required, Bool) You can configure to delete the storage volume to delete based on instance deletion.
-  - `volume_prototype` - (Optional, Force new resource, List)
+	- `delete_volume_on_instance_delete`- (Required, Bool) You can configure to delete the storage volume to delete based on instance deletion.
+  - `name` - (Required, String) The name of the boot volume.
+	- `volume` - (Optional, Forces new resource, String) The storage volume ID created in VPC.
+  - `volume_prototype` - (Optional, Forces new resource, List)
 
-    Nested scheme for `volume_prototype`:
-    - `capacity` - (Optional, Integer) The capacity of the volume in gigabytes. The specified minimum and maximum capacity values for creating or updating volumes may expand in the future.
-    - `encryption_key` - (Optional, String) The CRN of the [Key Protect Root Key](https://cloud.ibm.com/docs/key-protect?topic=key-protect-getting-started-tutorial) or [Hyper Protect Crypto Service Root Key](https://cloud.ibm.com/docs/hs-crypto?topic=hs-crypto-get-started) for the resource.
-    - `iops` - (Optional, Integer) The maximum input and output operations per second (IOPS) for the volume.
-    - `profile` - (Optional, String) The global unique name for the volume profile to use for the volume.
-    - `tags`- (Optional, Array of Strings) A list of user tags that you want to add to your volume. (https://cloud.ibm.com/apidocs/tagging#types-of-tags)
-    
-    ~>**Note:** 
-    `volume_attachments` provides either `volume` with a storage volume ID, or `volume_prototype` to create a new volume. If you plan to use this template with instance group, provide the `volume_prototype`. Instance group does not support template with existing storage volume IDs.
+      Nested scheme for `volume_prototype`:
+      - `capacity` - (Required, Forces new resource, Integer) The capacity of the volume in gigabytes. The specified minimum and maximum capacity values for creating or updating volumes may expand in the future.
+      - `encryption_key` - (Optional, Forces new resource, String) The CRN of the [Key Protect Root Key](https://cloud.ibm.com/docs/key-protect?topic=key-protect-getting-started-tutorial) or [Hyper Protect Crypto Service Root Key](https://cloud.ibm.com/docs/hs-crypto?topic=hs-crypto-get-started) for the resource.
+      - `iops` - (Optional, Forces new resource, Integer) The maximum input and output operations per second (IOPS) for the volume.
+      - `profile` - (Required, Forces new resource, String) The global unique name for the volume profile to use for the volume. Allowed values areFor more information, about volume profiles, see [volume profiles](https://cloud.ibm.com/docs/vpc?topic=vpc-block-storage-profiles)
+      - `tags`- (Optional, Array of Strings) A list of user tags that you want to add to your volume. (https://cloud.ibm.com/apidocs/tagging#types-of-tags)
+      
+      ~>**Note:** 
+      `volume_attachments` provides either `volume` with a storage volume ID, or `volume_prototype` to create a new volume. If you plan to use this template with instance group, provide the `volume_prototype`. Instance group does not support template with existing storage volume IDs.
 - `vpc` - (Required, String) The VPC ID that the instance templates needs to be created.
 - `user_data` -  (Optional, String) The user data provided for the instance.
 - `zone` - (Required, String) The name of the zone.

--- a/website/docs/r/is_instance_volume_attachment.html.markdown
+++ b/website/docs/r/is_instance_volume_attachment.html.markdown
@@ -10,7 +10,7 @@ description: |-
 # ibm_is_instance_volume_attachment
 Create, update, or delete a volume attachment on an existing instance. For more information, about VPC virtual server instances, see [Managing virtual server instances](https://cloud.ibm.com/docs/vpc?topic=vpc-managing-virtual-server-instances).
 
-**Note:** 
+~> **NOTE**
 VPC infrastructure services are a regional specific based endpoint, by default targets to `us-south`. Please make sure to target right region in the provider block as shown in the `provider.tf` file, if VPC service is created in region other than `us-south`.
 
 **provider.tf**
@@ -144,7 +144,7 @@ resource "ibm_is_instance_volume_attachment" "example-vol-3" {
 
 ## Timeouts
 
-The `ibm_is_instance_volume_attachment` resource provides the following [[Timeouts](https://www.terraform.io/docs/language/resources/syntax.html) configuration options:
+The `ibm_is_instance_volume_attachment` resource provides the following [Timeouts](https://www.terraform.io/docs/language/resources/syntax.html) configuration options:
 
 
 - **create**: The creation of the instance volume attachment is considered failed when no response is received for 10 minutes.
@@ -157,13 +157,7 @@ Review the argument references that you can specify for your resource.
 - `capacity` - (Optional, Integer) The capacity of the volume in gigabytes.
 
   ~> **NOTE**
-        <ul>
-        <li> The specified minimum and maximum capacity values for creating or updating volumes may expand in the future. Accepted value is in [10-16000].</li>
-        <li> If unspecified, the capacity will be the source snapshot's `minimum_capacity` when `snapshot` is provided.</li>
-        <li> Supports only expansion on update (must not be less than the current volume capacity)</li>
-        <li> Can be updated only if volume is attached to an running virtual server instance.</li>
-        <li> Stopped instance will be started on update of capacity of the volume.</li>
-        </ul>
+  **&#x2022;** The specified minimum and maximum capacity values for creating or updating volumes may expand in the future. Accepted value is in [10-16000]. </br>**&#x2022;** If unspecified, the capacity will be the source snapshot's `minimum_capacity` when `snapshot` is provided.</br>**&#x2022;** Supports only expansion on update (must not be less than the current volume capacity)</br>**&#x2022;** Can be updated only if volume is attached to an running virtual server instance.</br>**&#x2022;** Stopped instance will be started on update of capacity of the volume.</br>
 
 - `delete_volume_on_attachment_delete` - (Optional, Bool) If set to **true**, when deleting the attachment, the volume will also be deleted. By default it is **true**
 - `delete_volume_on_instance_delete` - (Optional, Bool) If set to **true**, when deleting the instance, the volume will also be deleted. By default it is **false**
@@ -172,8 +166,8 @@ Review the argument references that you can specify for your resource.
 - `iops` - (Optional, Integer) The bandwidth for the new volume.  This value is required for `custom` storage profiles only.
 
   ~> **NOTE**
-      `iops` value can be upgraded and downgraged if volume is attached to an running virtual server instance. Stopped instances will be started on update of volume.
-      - This table shows how storage size affects the `iops` ranges:
+      **&#x2022;** `iops` value can be upgraded and downgraged if volume is attached to an running virtual server instance. Stopped instances will be started on update of volume.</br>
+      **&#x2022;** This table shows how storage size affects the `iops` ranges:
 
                 |   Size range (GB)  |   IOPS range   |
                 |--------------------|----------------|
@@ -187,24 +181,23 @@ Review the argument references that you can specify for your resource.
                 |  4000  -   1999    |  100  -  40000 |
                 |  8000  -   1999    |  100  -  48000 |
                 | 10000  -  16000    |  100  -  48000 |
+      </br>
 
 - `name` - (Required, String) The name of the volume attachment.
 - `profile` - (Optional, String) The globally unique name for this volume profile.
 
   ~> **NOTE**
-        <ul>
-        <li> Allowed values are : [`general-purpose`, `5iops-tier`, `10iops-tier`, `custom`].</li>
-        <li> If `iops` is not present, `general-purpose` is taken as the volume profile.</li>
-        <li> If `iops` is present, `custom` is taken as the volume profile.</li>
-        Tiered profiles [`general-purpose`, `5iops-tier`, `10iops-tier`] can be upgraded and downgraded into each other.</li>
-        <li> Can be updated only if volume is attached to an running virtual server instance.</li>
-        <li> Stopped instances will be started on update of volume.</li></ul>
+        **&#x2022;**  Allowed values are : [`general-purpose`, `5iops-tier`, `10iops-tier`, `custom`].</br>
+        **&#x2022;** If `iops` is not present, `general-purpose` is taken as the volume profile.</br>
+        **&#x2022;** If `iops` is present, `custom` is taken as the volume profile.</br>
+        **&#x2022;** Tiered profiles [`general-purpose`, `5iops-tier`, `10iops-tier`] can be upgraded and downgraded into each other.</br>
+        **&#x2022;** Can be updated only if volume is attached to an running virtual server instance.</br>
+        **&#x2022;** Stopped instances will be started on update of volume.</br>
 - `snapshot` - (Optional, String) The unique identifier for this snapshot from which to clone the new volume. 
 
   ~> **NOTE**
-        <ul>
-        <li> one of `capacity` or `snapshot` must be present for volume creation.</li>
-        <li> If `capacity` is not present or less than `minimum_capacity` of the snapshot, `minimum_capacity` is taken as the volume capacity.</li></ul>
+        **&#x2022;** one of `capacity` or `snapshot` must be present for volume creation.</br>
+        **&#x2022;** If `capacity` is not present or less than `minimum_capacity` of the snapshot, `minimum_capacity` is taken as the volume capacity.</br>
 - `volume` - (Optional, String) The unique identifier for the existing volume
 - `volume_name` - (Optional, String) The unique user-defined name for this new volume.
 - `tags`- (Optional, Array of Strings) A list of user tags that you want to add to your volume. (https://cloud.ibm.com/apidocs/tagging#types-of-tags)

--- a/website/docs/r/is_volume.html.markdown
+++ b/website/docs/r/is_volume.html.markdown
@@ -10,7 +10,7 @@ description: |-
 # ibm_is_volume
 Create, update, or delete a VPC block storage volume. For more information, about the VPC block storage volume, see [getting started with VPC](https://cloud.ibm.com/docs/vpc).
 
-**Note:** 
+~> **NOTE:**
 VPC infrastructure services are a regional specific based endpoint, by default targets to `us-south`. Please make sure to target right region in the provider block as shown in the `provider.tf` file, if VPC service is created in region other than `us-south`.
 
 **provider.tf**


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/IBM-Cloud/terraform-provider-ibm/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
make testacc TEST=./ibm/service/vpc TESTARGS='-run=TestAccIBMISInstanceTemplate_basic'
=== RUN   TestAccIBMISInstanceTemplate_basic
--- PASS: TestAccIBMISInstanceTemplate_basic (154.13s)
PASS
ok  	github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/vpc	155.995s


make testacc TEST=./ibm/service/vpc TESTARGS='-run=TestAccIBMISInstanceTemplate_WithVolumeAttachment'
# Failed as the previous subnet exist
# passed with the image id:export IS_IMAGE="r134-2630c3c2-ed8a-4d82-89b2-facea89d49d3"

=== RUN   TestAccIBMISInstanceTemplate_WithVolumeAttachment
--- PASS: TestAccIBMISInstanceTemplate_WithVolumeAttachment (107.54s)
PASS
ok  	github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/vpc	108.770s

# Other tests
make testacc TEST=./ibm/service/vpc TESTARGS='-run=TestAccIBMISInstanceTemplate_basic'
=== RUN   TestAccIBMISInstanceTemplate_basic
--- PASS: TestAccIBMISInstanceTemplate_basic (154.13s)
PASS
ok  	github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/vpc	(cached)


make testacc TEST=./ibm/service/vpc TESTARGS='-run=TestAccIBMISInstanceTemplate_Reserved_IP_basic'
=== RUN   TestAccIBMISInstanceTemplate_Reserved_IP_basic
--- PASS: TestAccIBMISInstanceTemplate_Reserved_IP_basic (153.84s)
PASS
ok  	github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/vpc	155.115s


make testacc TEST=./ibm/service/vpc TESTARGS='-run=TestAccIBMISInstanceTemplate_metadata_service'
=== RUN   TestAccIBMISInstanceTemplate_metadata_service
--- PASS: TestAccIBMISInstanceTemplate_metadata_service (143.96s)
PASS
ok  	github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/vpc	145.322s

make testacc TEST=./ibm/service/vpc TESTARGS='-run=TestAccIBMISInstanceTemplate_withAvailabilityPolicy'
=== RUN   TestAccIBMISInstanceTemplate_withAvailabilityPolicy
--- PASS: TestAccIBMISInstanceTemplate_withAvailabilityPolicy (146.12s)
PASS
ok  	github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/vpc	148.019s


...
```
