### PR TITLE
fix(Cloud Databases): use V5 total math for group update request

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "go.sum|^.secrets.baseline$|metadata",
     "lines": null
   },
-  "generated_at": "2022-08-18T09:44:33Z",
+  "generated_at": "2022-08-24T16:50:18Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -1720,7 +1720,7 @@
         "hashed_secret": "10c28f9cf0668595d45c1090a7b4a2ae98edfa58",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 729,
+        "line_number": 779,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -1778,7 +1778,7 @@
         "hashed_secret": "10c28f9cf0668595d45c1090a7b4a2ae98edfa58",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 825,
+        "line_number": 871,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -1798,7 +1798,7 @@
         "hashed_secret": "10c28f9cf0668595d45c1090a7b4a2ae98edfa58",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 212,
+        "line_number": 243,
         "type": "Secret Keyword",
         "verified_result": null
       }

--- a/ibm/service/database/resource_ibm_database.go
+++ b/ibm/service/database/resource_ibm_database.go
@@ -206,7 +206,7 @@ func ResourceIBMDatabaseInstance() *schema.Resource {
 				Optional:      true,
 				Computed:      true,
 				ConflictsWith: []string{"node_count", "node_memory_allocation_mb", "node_disk_allocation_mb", "node_cpu_allocation_count", "group"},
-				Deprecated:    "This field is deprecated please use groups",
+				Deprecated:    "use group instead",
 			},
 			"members_disk_allocation_mb": {
 				Description:   "Disk allocation required for cluster",
@@ -214,7 +214,7 @@ func ResourceIBMDatabaseInstance() *schema.Resource {
 				Optional:      true,
 				Computed:      true,
 				ConflictsWith: []string{"node_count", "node_memory_allocation_mb", "node_disk_allocation_mb", "node_cpu_allocation_count", "group"},
-				Deprecated:    "This field is deprecated please use groups",
+				Deprecated:    "use group instead",
 			},
 			"members_cpu_allocation_count": {
 				Description:   "CPU allocation required for cluster",
@@ -222,7 +222,7 @@ func ResourceIBMDatabaseInstance() *schema.Resource {
 				Optional:      true,
 				Computed:      true,
 				ConflictsWith: []string{"node_count", "node_memory_allocation_mb", "node_disk_allocation_mb", "node_cpu_allocation_count", "group"},
-				Deprecated:    "This field is deprecated please use groups",
+				Deprecated:    "use group instead",
 			},
 			"node_count": {
 				Description:   "Total number of nodes in the cluster",
@@ -230,7 +230,7 @@ func ResourceIBMDatabaseInstance() *schema.Resource {
 				Optional:      true,
 				Computed:      true,
 				ConflictsWith: []string{"members_memory_allocation_mb", "members_disk_allocation_mb", "members_cpu_allocation_count", "group"},
-				Deprecated:    "This field is deprecated please use groups",
+				Deprecated:    "use group instead",
 			},
 			"node_memory_allocation_mb": {
 				Description:   "Memory allocation per node",
@@ -238,7 +238,7 @@ func ResourceIBMDatabaseInstance() *schema.Resource {
 				Optional:      true,
 				Computed:      true,
 				ConflictsWith: []string{"members_memory_allocation_mb", "members_disk_allocation_mb", "members_cpu_allocation_count", "group"},
-				Deprecated:    "This field is deprecated please use groups",
+				Deprecated:    "use group instead",
 			},
 			"node_disk_allocation_mb": {
 				Description:   "Disk allocation per node",
@@ -246,7 +246,7 @@ func ResourceIBMDatabaseInstance() *schema.Resource {
 				Optional:      true,
 				Computed:      true,
 				ConflictsWith: []string{"members_memory_allocation_mb", "members_disk_allocation_mb", "members_cpu_allocation_count", "group"},
-				Deprecated:    "This field is deprecated please use groups",
+				Deprecated:    "use group instead",
 			},
 			"node_cpu_allocation_count": {
 				Description:   "CPU allocation per node",
@@ -254,7 +254,7 @@ func ResourceIBMDatabaseInstance() *schema.Resource {
 				Optional:      true,
 				Computed:      true,
 				ConflictsWith: []string{"members_memory_allocation_mb", "members_disk_allocation_mb", "members_cpu_allocation_count", "group"},
-				Deprecated:    "This field is deprecated please use groups",
+				Deprecated:    "use group instead",
 			},
 			"plan_validation": {
 				Description: "For elasticsearch and postgres perform database parameter validation during the plan phase. Otherwise, database parameter validation happens in apply phase.",
@@ -1363,14 +1363,14 @@ func resourceIBMDatabaseInstanceCreate(context context.Context, d *schema.Resour
 				continue
 			}
 
-			if g.Members != nil && g.Members.Allocation != currentGroup.Members.Allocation {
+			if g.Members != nil && g.Members.Allocation*nodeCount != currentGroup.Members.Allocation {
 				groupScaling.Members = &clouddatabasesv5.GroupScalingMembers{AllocationCount: core.Int64Ptr(int64(g.Members.Allocation))}
 				nodeCount = g.Members.Allocation
 			}
-			if g.Memory != nil && g.Memory.Allocation != currentGroup.Memory.Allocation {
+			if g.Memory != nil && g.Memory.Allocation*nodeCount != currentGroup.Memory.Allocation {
 				groupScaling.Memory = &clouddatabasesv5.GroupScalingMemory{AllocationMb: core.Int64Ptr(int64(g.Memory.Allocation * nodeCount))}
 			}
-			if g.Disk != nil && g.Disk.Allocation != currentGroup.Disk.Allocation {
+			if g.Disk != nil && g.Disk.Allocation*nodeCount != currentGroup.Disk.Allocation {
 				groupScaling.Disk = &clouddatabasesv5.GroupScalingDisk{AllocationMb: core.Int64Ptr(int64(g.Disk.Allocation * nodeCount))}
 			}
 			if g.CPU != nil && g.CPU.Allocation != currentGroup.CPU.Allocation {
@@ -1926,14 +1926,14 @@ func resourceIBMDatabaseInstanceUpdate(context context.Context, d *schema.Resour
 			}
 			nodeCount := currentGroup.Members.Allocation
 
-			if group.Members != nil && group.Members.Allocation != currentGroup.Members.Allocation {
+			if group.Members != nil && group.Members.Allocation*nodeCount != currentGroup.Members.Allocation {
 				groupScaling.Members = &clouddatabasesv5.GroupScalingMembers{AllocationCount: core.Int64Ptr(int64(group.Members.Allocation))}
 				nodeCount = group.Members.Allocation
 			}
-			if group.Memory != nil && group.Memory.Allocation != currentGroup.Memory.Allocation {
+			if group.Memory != nil && group.Memory.Allocation*nodeCount != currentGroup.Memory.Allocation {
 				groupScaling.Memory = &clouddatabasesv5.GroupScalingMemory{AllocationMb: core.Int64Ptr(int64(group.Memory.Allocation * nodeCount))}
 			}
-			if group.Disk != nil && group.Disk.Allocation != currentGroup.Disk.Allocation {
+			if group.Disk != nil && group.Disk.Allocation*nodeCount != currentGroup.Disk.Allocation {
 				groupScaling.Disk = &clouddatabasesv5.GroupScalingDisk{AllocationMb: core.Int64Ptr(int64(group.Disk.Allocation * nodeCount))}
 			}
 			if group.CPU != nil && group.CPU.Allocation != currentGroup.CPU.Allocation {
@@ -1950,7 +1950,7 @@ func resourceIBMDatabaseInstanceUpdate(context context.Context, d *schema.Resour
 				setDeploymentScalingGroupResponse, response, err := cloudDatabasesClient.SetDeploymentScalingGroup(setDeploymentScalingGroupOptions)
 
 				if response.StatusCode > 300 {
-					return diag.FromErr(err)
+					return diag.FromErr(fmt.Errorf("[ERROR] SetDeploymentScalingGroup (%s) failed %s\n%s", group.ID, err, response))
 				}
 
 				taskIDLink := *setDeploymentScalingGroupResponse.Task.ID

--- a/ibm/service/database/resource_ibm_database_elasticsearch_test.go
+++ b/ibm/service/database/resource_ibm_database_elasticsearch_test.go
@@ -76,6 +76,21 @@ func TestAccIBMDatabaseInstance_Elasticsearch_Basic(t *testing.T) {
 					resource.TestCheckResourceAttr(name, "connectionstrings.#", "1"),
 				),
 			},
+			{
+				Config: testAccCheckIBMDatabaseInstanceElasticsearchGroupMigration(databaseResourceGroup, testName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckIBMDatabaseInstanceExists(name, &databaseInstanceOne),
+					resource.TestCheckResourceAttr(name, "name", testName),
+					resource.TestCheckResourceAttr(name, "service", "databases-for-elasticsearch"),
+					resource.TestCheckResourceAttr(name, "plan", "standard"),
+					resource.TestCheckResourceAttr(name, "location", acc.IcdDbRegion),
+					resource.TestCheckResourceAttr(name, "groups.0.memory.0.allocation_mb", "3072"),
+					resource.TestCheckResourceAttr(name, "groups.0.disk.0.allocation_mb", "18432"),
+					resource.TestCheckResourceAttr(name, "whitelist.#", "0"),
+					resource.TestCheckResourceAttr(name, "users.#", "0"),
+					resource.TestCheckResourceAttr(name, "connectionstrings.#", "1"),
+				),
+			},
 			// {
 			// 	ResourceName:      name,
 			// 	ImportState:       true,
@@ -400,7 +415,7 @@ func testAccCheckIBMDatabaseInstanceElasticsearchFullyspecified(databaseResource
 			delete = "15m"
 		}
 	}
-	  
+
 				`, databaseResourceGroup, name, acc.IcdDbRegion)
 }
 
@@ -420,6 +435,41 @@ func testAccCheckIBMDatabaseInstanceElasticsearchReduced(databaseResourceGroup s
 		adminpassword                = "password12"
 		members_memory_allocation_mb = 3072
 		members_disk_allocation_mb   = 18432
+
+		timeouts {
+			create = "120m"
+			update = "120m"
+			delete = "15m"
+		}
+	}
+				`, databaseResourceGroup, name, acc.IcdDbRegion)
+}
+
+func testAccCheckIBMDatabaseInstanceElasticsearchGroupMigration(databaseResourceGroup string, name string) string {
+	return fmt.Sprintf(`
+	data "ibm_resource_group" "test_acc" {
+		is_default = true
+		# name = "%[1]s"
+	}
+
+	resource "ibm_database" "%[2]s" {
+		resource_group_id            = data.ibm_resource_group.test_acc.id
+		name                         = "%[2]s"
+		service                      = "databases-for-elasticsearch"
+		plan                         = "standard"
+		location                     = "%[3]s"
+		adminpassword                = "password12"
+
+		group {
+		  group_id = "member"
+
+		  memory {
+		    allocation_mb = 1024
+		  }
+		  disk {
+		    allocation_mb = 6144
+		  }
+		}
 
 		timeouts {
 			create = "120m"

--- a/ibm/service/database/resource_ibm_database_redis_test.go
+++ b/ibm/service/database/resource_ibm_database_redis_test.go
@@ -69,6 +69,18 @@ func TestAccIBMDatabaseInstance_Redis_Basic(t *testing.T) {
 					resource.TestCheckResourceAttr(name, "whitelist.#", "0"),
 				),
 			},
+			{
+				Config: testAccCheckIBMDatabaseInstanceRedisGroupMigration(databaseResourceGroup, testName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(name, "name", testName),
+					resource.TestCheckResourceAttr(name, "service", "databases-for-redis"),
+					resource.TestCheckResourceAttr(name, "plan", "standard"),
+					resource.TestCheckResourceAttr(name, "location", acc.IcdDbRegion),
+					resource.TestCheckResourceAttr(name, "groups.0.memory.0.allocation_mb", "2048"),
+					resource.TestCheckResourceAttr(name, "groups.0.disk.0.allocation_mb", "4096"),
+					resource.TestCheckResourceAttr(name, "whitelist.#", "0"),
+				),
+			},
 		},
 	})
 }
@@ -150,7 +162,7 @@ func testAccCheckIBMDatabaseInstanceRedisBasic(databaseResourceGroup string, nam
 		is_default = true
 		# name = "%[1]s"
 	  }
-	  
+
 	  resource "ibm_database" "%[2]s" {
 		resource_group_id            = data.ibm_resource_group.test_acc.id
 		name                         = "%[2]s"
@@ -173,9 +185,9 @@ func testAccCheckIBMDatabaseInstanceRedisFullyspecified(databaseResourceGroup st
 	data "ibm_resource_group" "test_acc" {
 		is_default = true
 		# name = "%[1]s"
-	  }
-	  
-	  resource "ibm_database" "%[2]s" {
+	}
+
+	resource "ibm_database" "%[2]s" {
 		resource_group_id            = data.ibm_resource_group.test_acc.id
 		name                         = "%[2]s"
 		service                      = "databases-for-redis"
@@ -192,7 +204,7 @@ func testAccCheckIBMDatabaseInstanceRedisFullyspecified(databaseResourceGroup st
 		  address     = "172.168.1.1/32"
 		  description = "desc"
 		}
-	  }
+	}
 				`, databaseResourceGroup, name, acc.IcdDbRegion)
 }
 
@@ -202,7 +214,7 @@ func testAccCheckIBMDatabaseInstanceRedisReduced(databaseResourceGroup string, n
 		is_default = true
 		# name = "%[1]s"
 	  }
-	  
+
 	  resource "ibm_database" "%[2]s" {
 		resource_group_id            = data.ibm_resource_group.test_acc.id
 		name                         = "%[2]s"
@@ -216,13 +228,41 @@ func testAccCheckIBMDatabaseInstanceRedisReduced(databaseResourceGroup string, n
 				`, databaseResourceGroup, name, acc.IcdDbRegion)
 }
 
+func testAccCheckIBMDatabaseInstanceRedisGroupMigration(databaseResourceGroup string, name string) string {
+	return fmt.Sprintf(`
+	data "ibm_resource_group" "test_acc" {
+		is_default = true
+	}
+
+	resource "ibm_database" "%[2]s" {
+		resource_group_id            = data.ibm_resource_group.test_acc.id
+		name                         = "%[2]s"
+		service                      = "databases-for-redis"
+		plan                         = "standard"
+		location                     = "%[3]s"
+		adminpassword                = "password12"
+
+		group {
+			group_id = "member"
+
+			memory {
+				allocation_mb = 1024
+			}
+			 disk {
+				allocation_mb = 2048
+			}
+	  }
+  }
+				`, databaseResourceGroup, name, acc.IcdDbRegion)
+}
+
 func testAccCheckIBMDatabaseInstanceRedisImport(databaseResourceGroup string, name string) string {
 	return fmt.Sprintf(`
 	data "ibm_resource_group" "test_acc" {
 		is_default = true
 		# name = "%[1]s"
 	  }
-	  
+
 	  resource "ibm_database" "%[2]s" {
 		resource_group_id = data.ibm_resource_group.test_acc.id
 		name              = "%[2]s"


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/IBM-Cloud/terraform-provider-ibm/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #3964

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccIBMDatabaseInstance'
...
--- PASS: TestAccIBMDatabaseInstanceRabbitmqImport (417.42s)
--- PASS: TestAccIBMDatabaseInstanceRedisImport (578.39s)
--- PASS: TestAccIBMDatabaseInstance_Redis_Basic (648.49s)
--- PASS: TestAccIBMDatabaseInstancePostgresImport (1056.90s)
--- PASS: TestAccIBMDatabaseInstance_Etcd_Basic (1123.47s)
--- PASS: TestAccIBMDatabaseInstance_Rabbitmq_Basic (1138.22s)
--- PASS: TestAccIBMDatabaseInstanceEtcdImport (601.54s)
--- PASS: TestAccIBMDatabaseInstanceMongodbImport (783.94s)
--- PASS: TestAccIBMDatabaseInstanceElasticsearchImport (508.76s)
--- PASS: TestAccIBMDatabaseInstanceMongodbBasic (1729.37s)
--- PASS: TestAccIBMDatabaseInstance_Elasticsearch_Basic (1096.79s)
--- PASS: TestAccIBMDatabaseInstancePostgresGroup (3181.92s)
--- PASS: TestAccIBMDatabaseInstance_Elasticsearch_Group (3558.91s)
--- PASS: TestAccIBMDatabaseInstancePostgresBasic (3556.10s)
--- PASS: TestAccIBMDatabaseInstancePostgresNode (1018.99s)
--- PASS: TestAccIBMDatabaseInstance_Elasticsearch_Node (3671.21s)
--- PASS: TestAccIBMDatabaseInstance_Cassandra_Node (8019.51s)
```
