### PR TITLE
User Tags in Instance, Inst Temp, Inst Vol Attmnt

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -27,7 +27,7 @@ require (
 	github.com/IBM/scc-go-sdk/v3 v3.1.6
 	github.com/IBM/schematics-go-sdk v0.2.1
 	github.com/IBM/secrets-manager-go-sdk v0.1.19
-	github.com/IBM/vpc-go-sdk v0.22.0
+	github.com/IBM/vpc-go-sdk v0.23.0
 	github.com/PromonLogicalis/asn1 v0.0.0-20190312173541-d60463189a56 // indirect
 	github.com/ScaleFT/sshkeys v0.0.0-20200327173127-6142f742bca5
 	github.com/Shopify/sarama v1.29.1
@@ -57,3 +57,4 @@ require (
 replace github.com/softlayer/softlayer-go v1.0.3 => github.com/IBM-Cloud/softlayer-go v1.0.5-tf
 
 replace github.com/dgrijalva/jwt-go v3.2.0+incompatible => github.com/golang-jwt/jwt v3.2.1+incompatible
+

--- a/go.sum
+++ b/go.sum
@@ -72,6 +72,8 @@ github.com/IBM/secrets-manager-go-sdk v0.1.19 h1:0GPs5EoTaWNsjo4QPj64GNxlWfN8VHJ
 github.com/IBM/secrets-manager-go-sdk v0.1.19/go.mod h1:eO3dBhzPrHkkt+yPex/jB2xD6qHZxBko+Aw+0tfqHeA=
 github.com/IBM/vpc-go-sdk v0.22.0 h1:jo2WMfiFXhAyJkdJeCVHwvT6kgTg2tg8sDeP9zrMFVg=
 github.com/IBM/vpc-go-sdk v0.22.0/go.mod h1:YPyIfI+/qhPqlYp+I7dyx2U1GLcXgp/jzVvsZfUH4y8=
+github.com/IBM/vpc-go-sdk v0.23.0 h1:C26g02pPtTEWyLHNKK0mlFdpHeb9+noku9Q6qJLmdkc=
+github.com/IBM/vpc-go-sdk v0.23.0/go.mod h1:YPyIfI+/qhPqlYp+I7dyx2U1GLcXgp/jzVvsZfUH4y8=
 github.com/Logicalis/asn1 v0.0.0-20190312173541-d60463189a56 h1:vuquMR410psHNax14XKNWa0Ae/kYgWJcXi0IFuX60N0=
 github.com/Logicalis/asn1 v0.0.0-20190312173541-d60463189a56/go.mod h1:Zb3OT4l0mf7P/GOs2w2Ilj5sdm5Whoq3pa24dAEBHFc=
 github.com/Microsoft/go-winio v0.4.14/go.mod h1:qXqCSQ3Xa7+6tgxaGTIe4Kpcdsi+P8jBhyzoq1bpyYA=

--- a/ibm/service/vpc/data_source_ibm_is_instance_template.go
+++ b/ibm/service/vpc/data_source_ibm_is_instance_template.go
@@ -167,6 +167,13 @@ func DataSourceIBMISInstanceTemplate() *schema.Resource {
 										Computed:    true,
 										Description: "The CRN of the [Key Protect Root Key](https://cloud.ibm.com/docs/key-protect?topic=key-protect-getting-started-tutorial) or [Hyper Protect Crypto Service Root Key](https://cloud.ibm.com/docs/hs-crypto?topic=hs-crypto-get-started) for this resource.",
 									},
+									isInstanceTemplateVolAttTags: {
+										Type:        schema.TypeSet,
+										Computed:    true,
+										Elem:        &schema.Schema{Type: schema.TypeString},
+										Set:         flex.ResourceIBMVPCHash,
+										Description: "The user tags associated with this volume.",
+									},
 								},
 							},
 						},
@@ -306,6 +313,13 @@ func DataSourceIBMISInstanceTemplate() *schema.Resource {
 						isInstanceTemplateBootProfile: {
 							Type:     schema.TypeString,
 							Computed: true,
+						},
+						isInstanceTemplateBootVolumeTags: {
+							Type:        schema.TypeSet,
+							Computed:    true,
+							Elem:        &schema.Schema{Type: schema.TypeString},
+							Set:         flex.ResourceIBMVPCHash,
+							Description: "The user tags associated with this volume.",
 						},
 					},
 				},
@@ -574,6 +588,9 @@ func dataSourceIBMISInstanceTemplateRead(context context.Context, d *schema.Reso
 					encryptionKey := volumeInst.EncryptionKey.(*vpcv1.EncryptionKeyIdentity)
 					newVolume[isInstanceTemplateVolAttVolEncryptionKey] = *encryptionKey.CRN
 				}
+				if volumeInst.UserTags != nil {
+					newVolume[isInstanceTemplateVolAttTags] = instance.BootVolumeAttachment.Volume.UserTags
+				}
 				newVolumeArr = append(newVolumeArr, newVolume)
 				volumeAttach[isInstanceTemplateVolAttVolPrototype] = newVolumeArr
 
@@ -596,6 +613,9 @@ func dataSourceIBMISInstanceTemplateRead(context context.Context, d *schema.Reso
 					volProfIntf := instance.BootVolumeAttachment.Volume.Profile
 					volProfInst := volProfIntf.(*vpcv1.VolumeProfileIdentity)
 					bootVol[isInstanceTemplateBootProfile] = volProfInst.Name
+				}
+				if instance.BootVolumeAttachment.Volume.UserTags != nil {
+					bootVol[isInstanceTemplateBootVolumeTags] = instance.BootVolumeAttachment.Volume.UserTags
 				}
 			}
 			bootVolList = append(bootVolList, bootVol)
@@ -820,6 +840,9 @@ func dataSourceIBMISInstanceTemplateRead(context context.Context, d *schema.Reso
 							encryptionKey := volumeInst.EncryptionKey.(*vpcv1.EncryptionKeyIdentity)
 							newVolume[isInstanceTemplateVolAttVolEncryptionKey] = *encryptionKey.CRN
 						}
+						if volumeInst.UserTags != nil {
+							newVolume[isInstanceTemplateVolAttTags] = volumeInst.UserTags
+						}
 						newVolumeArr = append(newVolumeArr, newVolume)
 						volumeAttach[isInstanceTemplateVolAttVolPrototype] = newVolumeArr
 
@@ -842,6 +865,9 @@ func dataSourceIBMISInstanceTemplateRead(context context.Context, d *schema.Reso
 							volProfIntf := instance.BootVolumeAttachment.Volume.Profile
 							volProfInst := volProfIntf.(*vpcv1.VolumeProfileIdentity)
 							bootVol[isInstanceTemplateBootProfile] = volProfInst.Name
+						}
+						if instance.BootVolumeAttachment.Volume.UserTags != nil {
+							bootVol[isInstanceTemplateBootVolumeTags] = instance.BootVolumeAttachment.Volume.UserTags
 						}
 					}
 					bootVolList = append(bootVolList, bootVol)

--- a/ibm/service/vpc/data_source_ibm_is_instance_templates.go
+++ b/ibm/service/vpc/data_source_ibm_is_instance_templates.go
@@ -193,6 +193,13 @@ func DataSourceIBMISInstanceTemplates() *schema.Resource {
 													Computed:    true,
 													Description: "The CRN of the [Key Protect Root Key](https://cloud.ibm.com/docs/key-protect?topic=key-protect-getting-started-tutorial) or [Hyper Protect Crypto Service Root Key](https://cloud.ibm.com/docs/hs-crypto?topic=hs-crypto-get-started) for this resource.",
 												},
+												isInstanceTemplateVolAttTags: {
+													Type:        schema.TypeSet,
+													Computed:    true,
+													Elem:        &schema.Schema{Type: schema.TypeString},
+													Set:         flex.ResourceIBMVPCHash,
+													Description: "The user tags associated with this volume.",
+												},
 											},
 										},
 									},
@@ -358,6 +365,13 @@ func DataSourceIBMISInstanceTemplates() *schema.Resource {
 									isInstanceTemplateBootProfile: {
 										Type:     schema.TypeString,
 										Computed: true,
+									},
+									isInstanceTemplateBootVolumeTags: {
+										Type:        schema.TypeSet,
+										Computed:    true,
+										Elem:        &schema.Schema{Type: schema.TypeString},
+										Set:         flex.ResourceIBMVPCHash,
+										Description: "The user tags associated with this volume.",
 									},
 								},
 							},
@@ -598,6 +612,9 @@ func dataSourceIBMISInstanceTemplatesRead(d *schema.ResourceData, meta interface
 					encryptionKey := volumeInst.EncryptionKey.(*vpcv1.EncryptionKeyIdentity)
 					newVolume[isInstanceTemplateVolAttVolEncryptionKey] = *encryptionKey.CRN
 				}
+				if volumeInst.UserTags != nil {
+					newVolume[isInstanceTemplateVolAttTags] = instance.BootVolumeAttachment.Volume.UserTags
+				}
 				newVolumeArr = append(newVolumeArr, newVolume)
 				volumeAttach[isInstanceTemplateVolAttVolPrototype] = newVolumeArr
 
@@ -620,6 +637,9 @@ func dataSourceIBMISInstanceTemplatesRead(d *schema.ResourceData, meta interface
 					volProfIntf := instance.BootVolumeAttachment.Volume.Profile
 					volProfInst := volProfIntf.(*vpcv1.VolumeProfileIdentity)
 					bootVol[isInstanceTemplateBootProfile] = volProfInst.Name
+				}
+				if instance.BootVolumeAttachment.Volume.UserTags != nil {
+					bootVol[isInstanceTemplateBootVolumeTags] = instance.BootVolumeAttachment.Volume.UserTags
 				}
 			}
 			bootVolList = append(bootVolList, bootVol)

--- a/ibm/service/vpc/resource_ibm_is_instance.go
+++ b/ibm/service/vpc/resource_ibm_is_instance.go
@@ -25,6 +25,7 @@ const (
 	IsInstanceCRN                     = "crn"
 	isInstanceKeys                    = "keys"
 	isInstanceTags                    = "tags"
+	isInstanceBootVolumeTags          = "tags"
 	isInstanceNetworkInterfaces       = "network_interfaces"
 	isInstancePrimaryNetworkInterface = "primary_network_interface"
 	isInstanceNicName                 = "name"
@@ -603,6 +604,14 @@ func ResourceIBMISInstance() *schema.Resource {
 							Type:     schema.TypeString,
 							Computed: true,
 						},
+						isInstanceBootVolumeTags: {
+							Type:        schema.TypeSet,
+							Optional:    true,
+							Computed:    true,
+							Elem:        &schema.Schema{Type: schema.TypeString, ValidateFunc: validate.InvokeValidator("ibm_is_instance", "tags")},
+							Set:         flex.ResourceIBMVPCHash,
+							Description: "UserTags for the volume instance",
+						},
 					},
 				},
 			},
@@ -1013,6 +1022,18 @@ func instanceCreateByImage(d *schema.ResourceData, meta interface{}, profile, na
 		volTemplate.Profile = &vpcv1.VolumeProfileIdentity{
 			Name: &volprof,
 		}
+		var userTags *schema.Set
+		if v, ok := bootvol[isInstanceBootVolumeTags]; ok {
+			userTags = v.(*schema.Set)
+			if userTags != nil && userTags.Len() != 0 {
+				userTagsArray := make([]string, userTags.Len())
+				for i, userTag := range userTags.List() {
+					userTagStr := userTag.(string)
+					userTagsArray[i] = userTagStr
+				}
+				volTemplate.UserTags = userTagsArray
+			}
+		}
 		deletebool := true
 		instanceproto.BootVolumeAttachment = &vpcv1.VolumeAttachmentPrototypeInstanceByImageContext{
 			DeleteVolumeOnInstanceDelete: &deletebool,
@@ -1367,6 +1388,18 @@ func instanceCreateByTemplate(d *schema.ResourceData, meta interface{}, profile,
 		volTemplate.Profile = &vpcv1.VolumeProfileIdentity{
 			Name: &volprof,
 		}
+		var userTags *schema.Set
+		if v, ok := bootvol[isInstanceBootVolumeTags]; ok {
+			userTags = v.(*schema.Set)
+			if userTags != nil && userTags.Len() != 0 {
+				userTagsArray := make([]string, userTags.Len())
+				for i, userTag := range userTags.List() {
+					userTagStr := userTag.(string)
+					userTagsArray[i] = userTagStr
+				}
+				volTemplate.UserTags = userTagsArray
+			}
+		}
 		deletebool := true
 
 		instanceproto.BootVolumeAttachment = &vpcv1.VolumeAttachmentPrototypeInstanceByImageContext{
@@ -1704,6 +1737,18 @@ func instanceCreateByVolume(d *schema.ResourceData, meta interface{}, profile, n
 		volprof := "general-purpose"
 		volTemplate.Profile = &vpcv1.VolumeProfileIdentity{
 			Name: &volprof,
+		}
+		var userTags *schema.Set
+		if v, ok := bootvol[isInstanceBootVolumeTags]; ok {
+			userTags = v.(*schema.Set)
+			if userTags != nil && userTags.Len() != 0 {
+				userTagsArray := make([]string, userTags.Len())
+				for i, userTag := range userTags.List() {
+					userTagStr := userTag.(string)
+					userTagsArray[i] = userTagStr
+				}
+				volTemplate.UserTags = userTagsArray
+			}
 		}
 		snapshotId, ok := bootvol[isInstanceVolumeSnapshot]
 		snapshotIdStr := snapshotId.(string)
@@ -2391,6 +2436,9 @@ func instanceGet(d *schema.ResourceData, meta interface{}, id string) error {
 				if vol.SourceSnapshot != nil {
 					bootVol[isInstanceVolumeSnapshot] = vol.SourceSnapshot.ID
 				}
+				if vol.UserTags != nil {
+					bootVol[isInstanceBootVolumeTags] = vol.UserTags
+				}
 			}
 		}
 		bootVolList = append(bootVolList, bootVol)
@@ -2481,6 +2529,49 @@ func instanceUpdate(d *schema.ResourceData, meta interface{}) error {
 			return err
 		}
 	}
+	bootVolTags := "boot_volume.0.tags"
+	if d.HasChange(bootVolTags) && !d.IsNewResource() {
+		var userTags *schema.Set
+		if v, ok := d.GetOk("boot_volume.0.tags"); ok {
+			volId := d.Get("boot_volume.0.volume_id").(string)
+			updateVolumeOptions := &vpcv1.UpdateVolumeOptions{
+				ID: &volId,
+			}
+			userTags = v.(*schema.Set)
+			if userTags != nil && userTags.Len() != 0 {
+				userTagsArray := make([]string, userTags.Len())
+				for i, userTag := range userTags.List() {
+					userTagStr := userTag.(string)
+					userTagsArray[i] = userTagStr
+				}
+				volumePatchModel := &vpcv1.VolumePatch{}
+				volumePatchModel.UserTags = userTagsArray
+				volumePatch, err := volumePatchModel.AsPatch()
+				if err != nil {
+					return fmt.Errorf("[ERROR] Error encountered while apply as patch for boot volume of instance %s", err)
+				}
+				optionsget := &vpcv1.GetVolumeOptions{
+					ID: &volId,
+				}
+				_, response, err := instanceC.GetVolume(optionsget)
+				if err != nil {
+					return fmt.Errorf("[ERROR] Error getting Boot Volume (%s): %s\n%s", id, err, response)
+				}
+				eTag := response.Headers.Get("ETag")
+				updateVolumeOptions.IfMatch = &eTag
+				updateVolumeOptions.VolumePatch = volumePatch
+				vol, res, err := instanceC.UpdateVolume(updateVolumeOptions)
+				if vol == nil || err != nil {
+					return (fmt.Errorf("[ERROR] Error encountered while applying tags for boot volume of instance %s/n%s", err, res))
+				}
+				_, err = isWaitForVolumeAvailable(instanceC, volId, d.Timeout(schema.TimeoutCreate))
+				if err != nil {
+					return err
+				}
+			}
+		}
+	}
+
 	if d.HasChange(isPlacementTargetDedicatedHost) || d.HasChange(isPlacementTargetDedicatedHostGroup) && !d.IsNewResource() {
 		dedicatedHost := d.Get(isPlacementTargetDedicatedHost).(string)
 		dedicatedHostGroup := d.Get(isPlacementTargetDedicatedHostGroup).(string)

--- a/ibm/service/vpc/resource_ibm_is_instance_template_test.go
+++ b/ibm/service/vpc/resource_ibm_is_instance_template_test.go
@@ -115,6 +115,16 @@ func TestAccIBMISInstanceTemplate_withAvailabilityPolicy(t *testing.T) {
 		CheckDestroy: testAccCheckIBMISInstanceTemplateDestroy,
 		Steps: []resource.TestStep{
 			{
+				Config: testAccCheckIBMISInstanceTemplateConfigAvailablePolicyHostFailure_Default(vpcName, subnetName, sshKeyName, publicKey, templateName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(
+						"ibm_is_instance_template.instancetemplate1", "name", templateName),
+					resource.TestCheckResourceAttrSet(
+						"ibm_is_instance_template.instancetemplate1", "profile"),
+					resource.TestCheckResourceAttr("ibm_is_instance_template.instancetemplate1", "availability_policy_host_failure", "stop"),
+				),
+			},
+			{
 				Config: testAccCheckIBMISInstanceTemplateConfigAvailablePolicyHostFailure_Updated(vpcName, subnetName, sshKeyName, publicKey, templateName),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(
@@ -151,6 +161,38 @@ func TestAccIBMISInstanceTemplate_WithVolumeAttachment(t *testing.T) {
 						"ibm_is_instance_template.instancetemplate1", "name", templateName),
 					resource.TestCheckResourceAttrSet(
 						"ibm_is_instance_template.instancetemplate1", "profile"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccIBMISInstanceTemplate_WithVolumeAttachmentUserTag(t *testing.T) {
+	randInt := acctest.RandIntRange(10, 100)
+
+	publicKey := strings.TrimSpace(`
+	ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDVtuCfWKVGKaRmaRG6JQZY8YdxnDgGzVOK93IrV9R5Hl0JP1oiLLWlZQS2reAKb8lBqyDVEREpaoRUDjqDqXG8J/kR42FKN51su914pjSBc86wJ02VtT1Wm1zRbSg67kT+g8/T1jCgB5XBODqbcICHVP8Z1lXkgbiHLwlUrbz6OZkGJHo/M/kD1Eme8lctceIYNz/Ilm7ewMXZA4fsidpto9AjyarrJLufrOBl4MRVcZTDSJ7rLP982aHpu9pi5eJAjOZc7Og7n4ns3NFppiCwgVMCVUQbN5GBlWhZ1OsT84ZiTf+Zy8ew+Yg5T7Il8HuC7loWnz+esQPf0s3xhC/kTsGgZreIDoh/rxJfD67wKXetNSh5RH/n5BqjaOuXPFeNXmMhKlhj9nJ8scayx/wsvOGuocEIkbyJSLj3sLUU403OafgatEdnJOwbqg6rUNNF5RIjpJpL7eEWlKIi1j9LyhmPJ+fEO7TmOES82VpCMHpLbe4gf/MhhJ/Xy8DKh9s= root@ffd8363b1226
+	`)
+	vpcName := fmt.Sprintf("tf-testvpc%d", randInt)
+	subnetName := fmt.Sprintf("tf-testsubnet%d", randInt)
+	templateName := fmt.Sprintf("tf-testtemplate%d", randInt)
+	volAttachName := fmt.Sprintf("tf-testvolattach%d", randInt)
+	sshKeyName := fmt.Sprintf("tf-testsshkey%d", randInt)
+	userTag := "tag-0"
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { acc.TestAccPreCheck(t) },
+		Providers:    acc.TestAccProviders,
+		CheckDestroy: testAccCheckIBMISInstanceTemplateDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckIBMISInstanceTemplateWithVolumeUserTag(vpcName, subnetName, sshKeyName, publicKey, templateName, volAttachName, userTag),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(
+						"ibm_is_instance_template.instancetemplate1", "name", templateName),
+					resource.TestCheckResourceAttrSet(
+						"ibm_is_instance_template.instancetemplate1", "profile"),
+					resource.TestCheckResourceAttr(
+						"ibm_is_instance_template.instancetemplate1", "boot_volume.0.tags.0", userTag),
 				),
 			},
 		},
@@ -354,6 +396,49 @@ func testAccCheckIBMISInstanceTemplateWithVolume(vpcName, subnetName, sshKeyName
 		
 	
 	`, vpcName, subnetName, sshKeyName, publicKey, templateName, acc.IsImage, volAttachName)
+
+}
+
+func testAccCheckIBMISInstanceTemplateWithVolumeUserTag(vpcName, subnetName, sshKeyName, publicKey, templateName, volAttachName, userTag string) string {
+	return fmt.Sprintf(`
+	provider "ibm" {
+		generation = 2
+	}
+	
+	resource "ibm_is_vpc" "vpc2" {
+	  name = "%s"
+	}
+	
+	resource "ibm_is_subnet" "subnet2" {
+	  name            = "%s"
+	  vpc             = ibm_is_vpc.vpc2.id
+	  zone            = "us-south-2"
+	  ipv4_cidr_block = "10.240.64.0/28"
+	}
+	
+	resource "ibm_is_ssh_key" "sshkey" {
+	  name       = "%s"
+	  public_key = "%s"
+	}
+
+	resource "ibm_is_instance_template" "instancetemplate1" {
+	   name    = "%s"
+	   image   = "%s"
+	   profile = "bx2-8x32"
+	
+	   primary_network_interface {
+		 subnet = ibm_is_subnet.subnet2.id
+	   }
+	   boot_volume{
+		tags = ["%s"]
+	   }
+	   vpc       = ibm_is_vpc.vpc2.id
+	   zone      = "us-south-2"
+	   keys      = [ibm_is_ssh_key.sshkey.id]
+	 }
+		
+	
+	`, vpcName, subnetName, sshKeyName, publicKey, templateName, acc.IsImage, userTag)
 
 }
 

--- a/ibm/service/vpc/resource_ibm_is_instance_test.go
+++ b/ibm/service/vpc/resource_ibm_is_instance_test.go
@@ -146,6 +146,44 @@ ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCKVmnMOlHKcZK8tpt3MP1lqOLAcqcJzhsvJcjscgVE
 		},
 	})
 }
+
+func TestAccIBMISInstance_bootVolumeUserTags(t *testing.T) {
+	var instance string
+	vpcname := fmt.Sprintf("tf-vpc-%d", acctest.RandIntRange(10, 100))
+	name := fmt.Sprintf("tf-instnace-%d", acctest.RandIntRange(10, 100))
+	subnetname := fmt.Sprintf("tf-subnet-%d", acctest.RandIntRange(10, 100))
+	publicKey := strings.TrimSpace(`
+ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCKVmnMOlHKcZK8tpt3MP1lqOLAcqcJzhsvJcjscgVERRN7/9484SOBJ3HSKxxNG5JN8owAjy5f9yYwcUg+JaUVuytn5Pv3aeYROHGGg+5G346xaq3DAwX6Y5ykr2fvjObgncQBnuU5KHWCECO/4h8uWuwh/kfniXPVjFToc+gnkqA+3RKpAecZhFXwfalQ9mMuYGFxn+fwn8cYEApsJbsEmb0iJwPiZ5hjFC8wREuiTlhPHDgkBLOiycd20op2nXzDbHfCHInquEe/gYxEitALONxm0swBOwJZwlTDOB7C6y2dzlrtxr1L59m7pCkWI4EtTRLvleehBoj3u7jB4usR
+`)
+	sshname := fmt.Sprintf("tf-ssh-%d", acctest.RandIntRange(10, 100))
+	userData1 := "a"
+	userTags1 := "tags-0"
+	userTags2 := "tags-1"
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { acc.TestAccPreCheck(t) },
+		Providers:    acc.TestAccProviders,
+		CheckDestroy: testAccCheckIBMISInstanceDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckIBMISInstanceUserTagConfig(vpcname, subnetname, sshname, publicKey, name, userData1, userTags1),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckIBMISInstanceExists("ibm_is_instance.testacc_instance", instance),
+					resource.TestCheckResourceAttr(
+						"ibm_is_instance.testacc_instance", "boot_volume.0.tags.0", userTags1),
+				),
+			},
+			{
+				Config: testAccCheckIBMISInstanceUserTagConfig(vpcname, subnetname, sshname, publicKey, name, userData1, userTags2),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckIBMISInstanceExists("ibm_is_instance.testacc_instance", instance),
+					resource.TestCheckResourceAttr(
+						"ibm_is_instance.testacc_instance", "boot_volume.0.tags.0", userTags2),
+				),
+			},
+		},
+	})
+}
+
 func TestAccIBMISInstance_withAvailablePolicy(t *testing.T) {
 	var instance string
 	vpcname := fmt.Sprintf("tf-vpc-%d", acctest.RandIntRange(10, 100))
@@ -1666,4 +1704,39 @@ func testAccCheckIBMISInstanceConfigWithAvailablePolicyHostFailure_WithTemplate(
 		name              = "%s"
   		instance_template   = ibm_is_instance_template.instancetemplate1.id
 	  }`, vpcname, subnetname, acc.ISZoneName, acc.ISCIDR, sshname, publicKey, templateName, acc.ISZoneName, name)
+}
+
+func testAccCheckIBMISInstanceUserTagConfig(vpcname, subnetname, sshname, publicKey, name, userData, userTags1 string) string {
+	return fmt.Sprintf(`
+	resource "ibm_is_vpc" "testacc_vpc" {
+		name = "%s"
+	  }
+
+	  resource "ibm_is_subnet" "testacc_subnet" {
+		name            = "%s"
+		vpc             = ibm_is_vpc.testacc_vpc.id
+		zone            = "%s"
+		ipv4_cidr_block = "%s"
+	  }
+
+	  resource "ibm_is_ssh_key" "testacc_sshkey" {
+		name       = "%s"
+		public_key = "%s"
+	  }
+
+	  resource "ibm_is_instance" "testacc_instance" {
+		name    = "%s"
+		image   = "%s"
+		profile = "%s"
+		boot_volume {
+			tags = ["%s"]
+		}
+		primary_network_interface {
+		  subnet     = ibm_is_subnet.testacc_subnet.id
+		}
+		user_data = "%s"
+		vpc  = ibm_is_vpc.testacc_vpc.id
+		zone = "%s"
+		keys = [ibm_is_ssh_key.testacc_sshkey.id]
+	  }`, vpcname, subnetname, acc.ISZoneName, acc.ISCIDR, sshname, publicKey, name, acc.IsImage, acc.InstanceProfileName, userTags1, userData, acc.ISZoneName)
 }

--- a/ibm/service/vpc/resource_ibm_is_instance_volume_attachment.go
+++ b/ibm/service/vpc/resource_ibm_is_instance_volume_attachment.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"os"
 	"strings"
 	"time"
 
@@ -21,6 +22,7 @@ import (
 const (
 	isInstanceId                             = "instance"
 	isInstanceVolAttVol                      = "volume"
+	isInstanceVolAttTags                     = "tags"
 	isInstanceVolAttId                       = "volume_attachment_id"
 	isInstanceVolAttIops                     = "volume_iops"
 	isInstanceExistingVolume                 = "existing"
@@ -52,6 +54,10 @@ func ResourceIBMISInstanceVolumeAttachment() *schema.Resource {
 			customdiff.Sequence(
 				func(_ context.Context, diff *schema.ResourceDiff, v interface{}) error {
 					return flex.ResourceVolumeValidate(diff)
+				}),
+			customdiff.Sequence(
+				func(_ context.Context, diff *schema.ResourceDiff, v interface{}) error {
+					return flex.ResourceTagsCustomizeDiff(diff)
 				}),
 		),
 		Schema: map[string]*schema.Schema{
@@ -93,7 +99,7 @@ func ResourceIBMISInstanceVolumeAttachment() *schema.Resource {
 				Optional:      true,
 				Computed:      true,
 				ForceNew:      true,
-				ConflictsWith: []string{isInstanceVolIops, isInstanceVolumeAttVolumeReferenceName, isInstanceVolProfile, isInstanceVolCapacity, isInstanceVolumeSnapshot},
+				ConflictsWith: []string{isInstanceVolIops, isInstanceVolumeAttVolumeReferenceName, isInstanceVolProfile, isInstanceVolCapacity, isInstanceVolumeSnapshot, isInstanceVolAttTags},
 				ValidateFunc:  validate.InvokeValidator("ibm_is_instance_volume_attachment", isInstanceName),
 				Description:   "Instance id",
 			},
@@ -112,6 +118,16 @@ func ResourceIBMISInstanceVolumeAttachment() *schema.Resource {
 				Computed:     true,
 				ValidateFunc: validate.InvokeValidator("ibm_is_instance_volume_attachment", isInstanceVolumeAttVolumeReferenceName),
 				Description:  "The unique user-defined name for this volume",
+			},
+
+			isInstanceVolAttTags: {
+				Type:          schema.TypeSet,
+				Optional:      true,
+				Computed:      true,
+				ConflictsWith: []string{isInstanceVolAttVol},
+				Elem:          &schema.Schema{Type: schema.TypeString, ValidateFunc: validate.InvokeValidator("ibm_is_instance_volume_attachment", "tags")},
+				Set:           flex.ResourceIBMVPCHash,
+				Description:   "UserTags for the volume instance",
 			},
 
 			isInstanceVolProfile: {
@@ -187,6 +203,11 @@ func ResourceIBMISInstanceVolumeAttachment() *schema.Resource {
 				Computed:    true,
 				Description: "The type of volume attachment one of [ boot, data ]",
 			},
+
+			"version": &schema.Schema{
+				Type:     schema.TypeString,
+				Computed: true,
+			},
 		},
 	}
 }
@@ -235,6 +256,15 @@ func ResourceIBMISInstanceVolumeAttachmentValidator() *validate.ResourceValidato
 			Optional:                   true,
 			AllowedValues:              "general-purpose, 5iops-tier, 10iops-tier, custom",
 		})
+	validateSchema = append(validateSchema,
+		validate.ValidateSchema{
+			Identifier:                 "tags",
+			ValidateFunctionIdentifier: validate.ValidateRegexpLen,
+			Type:                       validate.TypeString,
+			Optional:                   true,
+			Regexp:                     `^[A-Za-z0-9:_ .-]+$`,
+			MinValueLength:             1,
+			MaxValueLength:             128})
 
 	ibmISInstanceVolumeAttachmentValidator := validate.ResourceValidator{ResourceName: "ibm_is_instance_volume_attachment", Schema: validateSchema}
 	return &ibmISInstanceVolumeAttachmentValidator
@@ -263,7 +293,24 @@ func instanceVolAttachmentCreate(d *schema.ResourceData, meta interface{}, insta
 			volnamestr := volname.(string)
 			volProtoVol.Name = &volnamestr
 		}
-
+		var userTags *schema.Set
+		if v, ok := d.GetOk(isInstanceVolAttTags); ok {
+			userTags = v.(*schema.Set)
+			if userTags != nil && userTags.Len() != 0 {
+				userTagsArray := make([]string, userTags.Len())
+				for i, userTag := range userTags.List() {
+					userTagStr := userTag.(string)
+					userTagsArray[i] = userTagStr
+				}
+				schematicTags := os.Getenv("IC_ENV_TAGS")
+				var envTags []string
+				if schematicTags != "" {
+					envTags = strings.Split(schematicTags, ",")
+					userTagsArray = append(userTagsArray, envTags...)
+				}
+				volProtoVol.UserTags = userTagsArray
+			}
+		}
 		volSnapshotStr := ""
 		if volSnapshot, ok := d.GetOk(isInstanceVolumeSnapshot); ok {
 			volSnapshotStr = volSnapshot.(string)
@@ -407,7 +454,9 @@ func instanceVolumeAttachmentGet(d *schema.ResourceData, meta interface{}, insta
 	d.Set(isInstanceVolAttId, *volumeAtt.ID)
 	d.Set(isInstanceVolumeAttStatus, *volumeAtt.Status)
 	d.Set(isInstanceVolumeAttType, *volumeAtt.Type)
-
+	if err = d.Set("version", response.Headers.Get("Etag")); err != nil {
+		return fmt.Errorf("Error setting version: %s", err)
+	}
 	volId := *volumeAtt.Volume.ID
 	getVolOptions := &vpcv1.GetVolumeOptions{
 		ID: &volId,
@@ -499,7 +548,7 @@ func instanceVolAttUpdate(d *schema.ResourceData, meta interface{}) error {
 		volId = volIdOk.(string)
 	}
 
-	if volId != "" && (d.HasChange(isInstanceVolIops) || d.HasChange(isInstanceVolProfile)) {
+	if volId != "" && (d.HasChange(isInstanceVolIops) || d.HasChange(isInstanceVolProfile) || d.HasChange(isInstanceVolAttTags)) {
 		insId := d.Get(isInstanceId).(string)
 		getinsOptions := &vpcv1.GetInstanceOptions{
 			ID: &insId,
@@ -541,15 +590,44 @@ func instanceVolAttUpdate(d *schema.ResourceData, meta interface{}) error {
 			iops := int64(d.Get(isVolumeIops).(int))
 			volumeProfilePatchModel.Iops = &iops
 		}
+		if d.HasChange(isInstanceVolAttTags) && !d.IsNewResource() {
+			if v, ok := d.GetOk(isInstanceVolAttTags); ok {
+				userTags := v.(*schema.Set)
+				if userTags != nil && userTags.Len() != 0 {
+					userTagsArray := make([]string, userTags.Len())
+					for i, userTag := range userTags.List() {
+						userTagStr := userTag.(string)
+						userTagsArray[i] = userTagStr
+					}
+					schematicTags := os.Getenv("IC_ENV_TAGS")
+					var envTags []string
+					if schematicTags != "" {
+						envTags = strings.Split(schematicTags, ",")
+						userTagsArray = append(userTagsArray, envTags...)
+					}
+					volumeProfilePatchModel.UserTags = userTagsArray
+				}
+			}
+
+		}
 
 		volumeProfilePatch, err := volumeProfilePatchModel.AsPatch()
 		if err != nil {
 			return fmt.Errorf("[ERROR] Error calling asPatch for volumeProfilePatch: %s", err)
 		}
+		optionsget := &vpcv1.GetVolumeOptions{
+			ID: &volId,
+		}
+		_, response, err = instanceC.GetVolume(optionsget)
+		if err != nil {
+			return fmt.Errorf("[ERROR] Error getting Boot Volume (%s): %s\n%s", id, err, response)
+		}
+		eTag := response.Headers.Get("ETag")
+		updateVolumeProfileOptions.IfMatch = &eTag
 		updateVolumeProfileOptions.VolumePatch = volumeProfilePatch
 		_, response, err = instanceC.UpdateVolume(updateVolumeProfileOptions)
 		if err != nil {
-			return fmt.Errorf("[ERROR] Error updating volume profile/iops: %s\n%s", err, response)
+			return fmt.Errorf("[ERROR] Error updating volume profile/iops/userTags: %s\n%s", err, response)
 		}
 		isWaitForVolumeAvailable(instanceC, volId, d.Timeout(schema.TimeoutCreate))
 	}

--- a/ibm/service/vpc/resource_ibm_is_instance_volume_attachment_test.go
+++ b/ibm/service/vpc/resource_ibm_is_instance_volume_attachment_test.go
@@ -86,6 +86,58 @@ ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCKVmnMOlHKcZK8tpt3MP1lqOLAcqcJzhsvJcjscgVE
 	})
 }
 
+func TestAccIBMISInstanceVolumeAttachment_userTag(t *testing.T) {
+	var instanceVolAtt string
+	vpcname := fmt.Sprintf("tf-vpc-%d", acctest.RandIntRange(10, 100))
+	name := fmt.Sprintf("tf-instnace-%d", acctest.RandIntRange(10, 100))
+	subnetname := fmt.Sprintf("tf-subnet-%d", acctest.RandIntRange(10, 100))
+	publicKey := strings.TrimSpace(`
+ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCKVmnMOlHKcZK8tpt3MP1lqOLAcqcJzhsvJcjscgVERRN7/9484SOBJ3HSKxxNG5JN8owAjy5f9yYwcUg+JaUVuytn5Pv3aeYROHGGg+5G346xaq3DAwX6Y5ykr2fvjObgncQBnuU5KHWCECO/4h8uWuwh/kfniXPVjFToc+gnkqA+3RKpAecZhFXwfalQ9mMuYGFxn+fwn8cYEApsJbsEmb0iJwPiZ5hjFC8wREuiTlhPHDgkBLOiycd20op2nXzDbHfCHInquEe/gYxEitALONxm0swBOwJZwlTDOB7C6y2dzlrtxr1L59m7pCkWI4EtTRLvleehBoj3u7jB4usR
+`)
+	sshname := fmt.Sprintf("tf-ssh-%d", acctest.RandIntRange(10, 100))
+	attName := fmt.Sprintf("tf-volatt-%d", acctest.RandIntRange(10, 100))
+	autoDelete := true
+	volName := fmt.Sprintf("tf-vol-%d", acctest.RandIntRange(10, 100))
+	iops1 := int64(600)
+	capacity1 := int64(20)
+	userTag1 := "tag-0"
+	userTag2 := "tag-1"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { acc.TestAccPreCheck(t) },
+		Providers:    acc.TestAccProviders,
+		CheckDestroy: testAccCheckIBMISInstanceDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckIBMISInstanceVolumeAttachmentUsertagConfig(vpcname, subnetname, sshname, publicKey, name, attName, volName, userTag1, autoDelete, capacity1, iops1),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckIBMISInstanceVolumeAttachmentExists("ibm_is_instance_volume_attachment.testacc_att", instanceVolAtt),
+					resource.TestCheckResourceAttr(
+						"ibm_is_instance_volume_attachment.testacc_att", "name", attName),
+					resource.TestCheckResourceAttr(
+						"ibm_is_instance_volume_attachment.testacc_att", "delete_volume_on_instance_delete", fmt.Sprintf("%t", autoDelete)),
+					resource.TestCheckResourceAttr(
+						"ibm_is_instance_volume_attachment.testacc_att", "capacity", fmt.Sprintf("%d", capacity1)),
+					resource.TestCheckResourceAttr(
+						"ibm_is_instance_volume_attachment.testacc_att", "tags.0", userTag1),
+				),
+			},
+			{
+				Config: testAccCheckIBMISInstanceVolumeAttachmentUsertagConfig(vpcname, subnetname, sshname, publicKey, name, attName, volName, userTag2, autoDelete, capacity1, iops1),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckIBMISInstanceVolumeAttachmentExists("ibm_is_instance_volume_attachment.testacc_att", instanceVolAtt),
+					resource.TestCheckResourceAttr(
+						"ibm_is_instance_volume_attachment.testacc_att", "name", attName),
+					resource.TestCheckResourceAttr(
+						"ibm_is_instance_volume_attachment.testacc_att", "delete_volume_on_instance_delete", fmt.Sprintf("%t", autoDelete)),
+					resource.TestCheckResourceAttr(
+						"ibm_is_instance_volume_attachment.testacc_att", "tags.0", userTag2),
+				),
+			},
+		},
+	})
+}
+
 func testAccCheckIBMISInstanceVolumeAttachmentDestroy(s *terraform.State) error {
 
 	instanceC, _ := acc.TestAccProvider.Meta().(conns.ClientSession).VpcV1API()
@@ -188,4 +240,53 @@ func testAccCheckIBMISInstanceVolumeAttachmentConfig(vpcname, subnetname, sshnam
 	  }
 	 
 	  `, vpcname, subnetname, acc.ISZoneName, sshname, publicKey, name, acc.IsImage, acc.InstanceProfileName, acc.ISZoneName, attName, capacity, iops, autoDelete, volName)
+}
+
+func testAccCheckIBMISInstanceVolumeAttachmentUsertagConfig(vpcname, subnetname, sshname, publicKey, name, attName, volName, usertag string, autoDelete bool, capacity, iops int64) string {
+	return fmt.Sprintf(`
+	resource "ibm_is_vpc" "testacc_vpc" {
+		name = "%s"
+	  }
+	  
+	  resource "ibm_is_subnet" "testacc_subnet" {
+		name            			= "%s"
+		vpc             			= ibm_is_vpc.testacc_vpc.id
+		zone            			= "%s"
+		total_ipv4_address_count 	= 16
+	  }
+	  
+	  resource "ibm_is_ssh_key" "testacc_sshkey" {
+		name       = "%s"
+		public_key = "%s"
+	  }
+	  
+	  resource "ibm_is_instance" "testacc_instance" {
+		name    = "%s"
+		image   = "%s"
+		profile = "%s"
+		primary_network_interface {
+		  subnet     = ibm_is_subnet.testacc_subnet.id
+		}
+		vpc  = ibm_is_vpc.testacc_vpc.id
+		zone = "%s"
+		keys = [ibm_is_ssh_key.testacc_sshkey.id]
+		network_interfaces {
+		  subnet = ibm_is_subnet.testacc_subnet.id
+		  name   = "eth1"
+		}
+	  }
+	  resource "ibm_is_instance_volume_attachment" "testacc_att" {
+		instance = ibm_is_instance.testacc_instance.id
+	
+		name 			= "%s"
+		profile 		= "custom"
+		capacity	 	= %d
+		iops			= %d
+		tags = ["%s"]
+	
+		delete_volume_on_instance_delete = %t
+		volume_name = "%s"
+	  }
+	 
+	  `, vpcname, subnetname, acc.ISZoneName, sshname, publicKey, name, acc.IsImage, acc.InstanceProfileName, acc.ISZoneName, attName, capacity, iops, usertag, autoDelete, volName)
 }

--- a/website/docs/d/is_instance_template.html.markdown
+++ b/website/docs/d/is_instance_template.html.markdown
@@ -56,6 +56,7 @@ You can access the following attribute references after your data source is crea
 	- `name` - (String) The name of the boot volume.
 	- `profile` - (String) The profile for the boot volume configuration.
 	- `size` - (String) The boot volume size to configure in giga bytes.
+	- `tags` - (String) User Tags associated with the boot_volume. (https://cloud.ibm.com/apidocs/tagging#types-of-tags)
 - `crn` - (String) The CRN of the instance template.
 - `default_trusted_profile_auto_link` - (Boolean) If set to `true`, the system will create a link to the specified `target` trusted profile during instance creation. Regardless of whether a link is created by the system or manually using the IAM Identity service, it will be automatically deleted when the instance is deleted. Default is true. 
 - `default_trusted_profile_target` - (String) The unique identifier or CRN of the default IAM trusted profile to use for this virtual server instance.
@@ -103,5 +104,6 @@ You can access the following attribute references after your data source is crea
 		- `encryption_key` - (String) The CRN of the [Key Protect Root Key](https://cloud.ibm.com/docs/key-protect?topic=key-protect-getting-started-tutorial) or [Hyper Protect Crypto Service Root Key](https://cloud.ibm.com/docs/hs-crypto?topic=hs-crypto-get-started) for this resource.
 		- `iops` - (String) The maximum input/output operations per second (IOPS) for the volume.
 		- `profile` - (String) The global unique name for the volume profile to use for the volume.
+		- `tags` - (String) User Tags associated with the volume. (https://cloud.ibm.com/apidocs/tagging#types-of-tags)
 - `vpc` - (String) The VPC ID that the instance templates needs to be created.
 - `zone` - (String) The name of the zone.

--- a/website/docs/d/is_instance_templates.html.markdown
+++ b/website/docs/d/is_instance_templates.html.markdown
@@ -43,6 +43,7 @@ You can access the following attribute references after your data source is crea
 		- `name` - (String) The name of the boot volume.
 		- `profile` - (String) The profile for the boot volume configuration.
 		- `size` - (String) The boot volume size to configure in giga bytes.
+		- `tags` - (String) User Tags associated with the volume. (https://cloud.ibm.com/apidocs/tagging#types-of-tags).
 	- `crn` - (String) The CRN of the instance template.
 	- `default_trusted_profile_auto_link` - (Boolean) If set to `true`, the system will create a link to the specified `target` trusted profile during instance creation. Regardless of whether a link is created by the system or manually using the IAM Identity service, it will be automatically deleted when the instance is deleted. Default is true. 
 	- `default_trusted_profile_target` - (String) The unique identifier or CRN of the default IAM trusted profile to use for this virtual server instance.
@@ -88,5 +89,6 @@ You can access the following attribute references after your data source is crea
 		  - `encryption_key` - (String) The CRN of the [Key Protect Root Key](https://cloud.ibm.com/docs/key-protect?topic=key-protect-getting-started-tutorial) or [Hyper Protect Crypto Service Root Key](https://cloud.ibm.com/docs/hs-crypto?topic=hs-crypto-get-started) for this resource.
 		  - `iops` - (String) The maximum input/output operations per second (IOPS) for the volume.
 		  - `profile` - (String) The global unique name for the volume profile to use for the volume.
+		  - `tags` - (String) User Tags associated with the volume. (https://cloud.ibm.com/apidocs/tagging#types-of-tags)
 	- `vpc` - (String) The VPC ID that the instance templates needs to be created.
 	- `zone` - (String) The name of the zone.

--- a/website/docs/r/is_instance.html.markdown
+++ b/website/docs/r/is_instance.html.markdown
@@ -276,6 +276,7 @@ resource "ibm_is_instance" "example" {
   boot_volume {
     name     = "boot-restore"
     snapshot = ibm_is_snapshot.example.id
+    tags     = ["tags-0"]
   }
   primary_network_interface {
     subnet = ibm_is_subnet.example.id
@@ -322,6 +323,7 @@ Review the argument references that you can specify for your resource.
     
     ~> **Note:**
     `snapshot` conflicts with `image` id and `instance_template`
+  - `tags`- (Optional, Array of Strings) A list of user tags that you want to add to your volume. (https://cloud.ibm.com/apidocs/tagging#types-of-tags)
 - `dedicated_host` - (Optional, String) The placement restrictions to use the virtual server instance. Unique ID of the dedicated host where the instance id placed.
 - `dedicated_host_group` - (Optional, String) The placement restrictions to use for the virtual server instance. Unique ID of the dedicated host group where the instance is placed.
 

--- a/website/docs/r/is_instance_template.html.markdown
+++ b/website/docs/r/is_instance_template.html.markdown
@@ -181,6 +181,7 @@ Review the argument references that you can specify for your resource.
 	- `delete_volume_on_instance_delete` - (Optional, Bool) You can configure to delete the boot volume based on instance deletion.
 	- `encryption` - (Optional, String) The encryption key CRN to encrypt the boot volume attached.
 	- `name` - (Optional, String) The name of the boot volume.
+  - `tags`- (Optional, Array of Strings) A list of user tags that you want to add to your volume. (https://cloud.ibm.com/apidocs/tagging#types-of-tags)
 - `total_volume_bandwidth` - (Optional, int) The amount of bandwidth (in megabits per second) allocated exclusively to instance storage volumes
 - `dedicated_host` - (Optional, Force new resource,String) The placement restrictions to use for the virtual server instance. Unique Identifier of the dedicated host where the instance is placed.
 
@@ -233,9 +234,9 @@ Review the argument references that you can specify for your resource.
     - `encryption_key` - (Optional, String) The CRN of the [Key Protect Root Key](https://cloud.ibm.com/docs/key-protect?topic=key-protect-getting-started-tutorial) or [Hyper Protect Crypto Service Root Key](https://cloud.ibm.com/docs/hs-crypto?topic=hs-crypto-get-started) for the resource.
     - `iops` - (Optional, Integer) The maximum input and output operations per second (IOPS) for the volume.
     - `profile` - (Optional, String) The global unique name for the volume profile to use for the volume.
+    - `tags`- (Optional, Array of Strings) A list of user tags that you want to add to your volume. (https://cloud.ibm.com/apidocs/tagging#types-of-tags)
     
     ~>**Note:** 
-    
     `volume_attachments` provides either `volume` with a storage volume ID, or `volume_prototype` to create a new volume. If you plan to use this template with instance group, provide the `volume_prototype`. Instance group does not support template with existing storage volume IDs.
 - `vpc` - (Required, String) The VPC ID that the instance templates needs to be created.
 - `user_data` -  (Optional, String) The user data provided for the instance.

--- a/website/docs/r/is_instance_volume_attachment.html.markdown
+++ b/website/docs/r/is_instance_volume_attachment.html.markdown
@@ -207,6 +207,8 @@ Review the argument references that you can specify for your resource.
         <li> If `capacity` is not present or less than `minimum_capacity` of the snapshot, `minimum_capacity` is taken as the volume capacity.</li></ul>
 - `volume` - (Optional, String) The unique identifier for the existing volume
 - `volume_name` - (Optional, String) The unique user-defined name for this new volume.
+- `tags`- (Optional, Array of Strings) A list of user tags that you want to add to your volume. (https://cloud.ibm.com/apidocs/tagging#types-of-tags)
+
 
 ## Attribute reference
 In addition to all argument reference list, you can access the following attribute references after your data source is created.


### PR DESCRIPTION
### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request


Relates OR Closes #0000

Output from acceptance testing:


```
$ make testacc TEST=./ibm/service/vpc TESTARGS='-run=TestAccIBMISInstanceTemplate_WithVolumeAttachmentUserTag'
$ make testacc TEST=./ibm/service/vpc TESTARGS='-run=TestAccIBMISInstance_bootVolumeUserTags'
$ make testacc TEST=./ibm/service/vpc TESTARGS='-run=TestAccIBMISInstanceVolumeAttachment_userTag'
```

```
resource "ibm_is_instance" "testacc_instance" {
  name    = "sunitha-instance-new"
  image   = "r134-c31deded-722d-4950-9d05-862fecb831b1"
  profile = "cx2-2x4"
  boot_volume {
    size = 220
    tags = ["tag-0", "tag-1"]
  }
  primary_network_interface {
    subnet = "0716-4b83a399-a222-4736-a0e0-44cd802a7e64"
  }
  user_data = "a"
  vpc       = "r134-060fbfe6-4d0f-47b0-b9c5-94da8e719e22"
  zone      = "us-south-1"
  keys      = ["r134-8ddfdc65-73ac-48e1-864b-870f29bd35ca"]
}

resource "ibm_is_instance_volume_attachment" "testacc_att" {
  instance = ibm_is_instance.testacc_instance.id

  name     = "volume-attachment"
  profile  = "custom"
  capacity = 20
  iops     = 600
  tags     = ["tag-sunitha","test"]

  delete_volume_on_instance_delete = true
  volume_name                      = "sunitha-volume-inst-vol-attmnt"
}
```


```
sunitha@dhcp-9-239-8-182 vpc-ibm-lb-config % terraform apply -auto-approve
ibm_is_instance.testacc_instance: Refreshing state... [id=0716_c8a9c7f3-bbec-4994-87f1-21096566acd6]
ibm_is_instance_volume_attachment.testacc_att: Refreshing state... [id=0716_c8a9c7f3-bbec-4994-87f1-21096566acd6/0716-9bd05fef-6920-48f7-8c50-a9cea3d47ade]

Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  ~ update in-place

Terraform will perform the following actions:

  # ibm_is_instance_volume_attachment.testacc_att will be updated in-place
  ~ resource "ibm_is_instance_volume_attachment" "testacc_att" {
        id                                 = "0716_c8a9c7f3-bbec-4994-87f1-21096566acd6/0716-9bd05fef-6920-48f7-8c50-a9cea3d47ade"
        name                               = "volume-attachment"
      ~ tags                               = [
          + "test",
            # (1 unchanged element hidden)
        ]
        # (15 unchanged attributes hidden)
    }

Plan: 0 to add, 1 to change, 0 to destroy.
ibm_is_instance_volume_attachment.testacc_att: Modifying... [id=0716_c8a9c7f3-bbec-4994-87f1-21096566acd6/0716-9bd05fef-6920-48f7-8c50-a9cea3d47ade]
ibm_is_instance_volume_attachment.testacc_att: Still modifying... [id=0716_c8a9c7f3-bbec-4994-87f1-21096566ac...6-9bd05fef-6920-48f7-8c50-a9cea3d47ade, 10s elapsed]
ibm_is_instance_volume_attachment.testacc_att: Still modifying... [id=0716_c8a9c7f3-bbec-4994-87f1-21096566ac...6-9bd05fef-6920-48f7-8c50-a9cea3d47ade, 20s elapsed]
ibm_is_instance_volume_attachment.testacc_att: Modifications complete after 27s [id=0716_c8a9c7f3-bbec-4994-87f1-21096566acd6/0716-9bd05fef-6920-48f7-8c50-a9cea3d47ade]

Apply complete! Resources: 0 added, 1 changed, 0 destroyed.
```


<img width="662" alt="screen1" src="https://user-images.githubusercontent.com/78336632/187027661-55adc5e6-9fc7-4c9a-a33f-f54c227005ec.png">
<img width="630" alt="screen2" src="https://user-images.githubusercontent.com/78336632/187027663-2e7fb537-5b43-4f21-8a8b-e0d2c7333bfe.png">
<img width="625" alt="screen3" src="https://user-images.githubusercontent.com/78336632/187027664-b2509e0e-82a2-47e2-839a-6cb327834a5a.png">


data "ibm_is_instance_template" "instance_template_data" {
name = "cli-tpl-1"
}
data "ibm_is_instance_templates" "instance_templates_data" {
}

<img width="758" alt="screen5" src="https://user-images.githubusercontent.com/78336632/187027709-82b27927-ea4f-4bbd-b3d8-0a47cd1c50ad.png">

<img width="730" alt="screen4" src="https://user-images.githubusercontent.com/78336632/187027894-7df7c9ff-beeb-4a9d-ba40-75f23581cf15.png">

