### PR TITLE
feature(is_instance) : added support for catalog images for enterprises

### DIFF
--- a/examples/ibm-is-ng/main.tf
+++ b/examples/ibm-is-ng/main.tf
@@ -718,6 +718,31 @@ resource "ibm_is_instance" "instance7" {
   keys = [ibm_is_ssh_key.sshkey.id]
 }
 
+// catalog images 
+
+data "ibm_is_images" "imageslist" {
+  catalog_managed = true
+}
+resource "ibm_is_instance" "instance8" {
+  name    = "instance8"
+  profile = var.profile
+  auto_delete_volume = true
+  primary_network_interface {
+    primary_ip {
+      name = "example-reserved-ip"
+      auto_delete = true
+    } 
+    name        = "test-reserved-ip"
+    subnet      = ibm_is_subnet.subnet2.id
+  }
+  catalog_offering {
+    version_crn = data.ibm_is_images.imageslist.images.0.catalog_offering.0.version.0.crn
+  }
+  vpc  = ibm_is_vpc.vpc2.id
+  zone = "us-south-2"
+  keys = [ibm_is_ssh_key.sshkey.id]
+}
+
 
 data "ibm_is_instance_network_interface_reserved_ip" "data_reserved_ip" {
   instance = ibm_is_instance.test_instance.id

--- a/ibm/service/vpc/data_source_ibm_is_image.go
+++ b/ibm/service/vpc/data_source_ibm_is_image.go
@@ -11,6 +11,15 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
+const (
+	isImageCatalogOffering         = "catalog_offering"
+	isImageCatalogOfferingManaged  = "managed"
+	isImageCatalogOfferingVersion  = "version"
+	isImageCatalogOfferingCrn      = "crn"
+	isImageCatalogOfferingDeleted  = "deleted"
+	isImageCatalogOfferingMoreInfo = "more_info"
+)
+
 func DataSourceIBMISImage() *schema.Resource {
 	return &schema.Resource{
 		Read: dataSourceIBMISImageRead,
@@ -78,6 +87,47 @@ func DataSourceIBMISImage() *schema.Resource {
 				Type:        schema.TypeString,
 				Computed:    true,
 				Description: "Source volume id of the image",
+			},
+			isImageCatalogOffering: {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						isImageCatalogOfferingManaged: {
+							Type:        schema.TypeBool,
+							Computed:    true,
+							Description: "Indicates whether this image is managed as part of a catalog offering. A managed image can be provisioned using its catalog offering CRN or catalog offering version CRN.",
+						},
+						isImageCatalogOfferingVersion: {
+							Type:        schema.TypeList,
+							Computed:    true,
+							Description: "The catalog offering version associated with this image.",
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									// isImageCatalogOfferingDeleted: {
+									// 	Type:        schema.TypeList,
+									// 	Computed:    true,
+									// 	Description: "If present, this property indicates the referenced resource has been deleted and providessome supplementary information.",
+									// 	Elem: &schema.Resource{
+									// 		Schema: map[string]*schema.Schema{
+									// 			isImageCatalogOfferingMoreInfo: {
+									// 				Type:        schema.TypeString,
+									// 				Computed:    true,
+									// 				Description: "Link to documentation about deleted resources.",
+									// 			},
+									// 		},
+									// 	},
+									// },
+									isImageCatalogOfferingCrn: {
+										Type:        schema.TypeString,
+										Computed:    true,
+										Description: "The CRN for this version of the IBM Cloud catalog offering.",
+									},
+								},
+							},
+						},
+					},
+				},
 			},
 		},
 	}
@@ -150,6 +200,12 @@ func imageGetByName(d *schema.ResourceData, meta interface{}, name, visibility s
 	if image.SourceVolume != nil {
 		d.Set("source_volume", *image.SourceVolume.ID)
 	}
+	if image.CatalogOffering != nil {
+		catalogOfferingList := []map[string]interface{}{}
+		catalogOfferingMap := dataSourceImageCollectionCatalogOfferingToMap(*image.CatalogOffering)
+		catalogOfferingList = append(catalogOfferingList, catalogOfferingMap)
+		d.Set(isImageCatalogOffering, catalogOfferingList)
+	}
 	return nil
 
 }
@@ -193,5 +249,35 @@ func imageGetById(d *schema.ResourceData, meta interface{}, identifier string) e
 	if image.SourceVolume != nil {
 		d.Set("source_volume", *image.SourceVolume.ID)
 	}
+	if image.CatalogOffering != nil {
+		catalogOfferingList := []map[string]interface{}{}
+		catalogOfferingMap := dataSourceImageCollectionCatalogOfferingToMap(*image.CatalogOffering)
+		catalogOfferingList = append(catalogOfferingList, catalogOfferingMap)
+		d.Set(isImageCatalogOffering, catalogOfferingList)
+	}
 	return nil
+}
+
+func dataSourceImageCollectionCatalogOfferingToMap(imageCatalogOfferingItem vpcv1.ImageCatalogOffering) (imageCatalogOfferingMap map[string]interface{}) {
+	imageCatalogOfferingMap = map[string]interface{}{}
+	if imageCatalogOfferingItem.Managed != nil {
+		imageCatalogOfferingMap[isImageCatalogOfferingManaged] = imageCatalogOfferingItem.Managed
+	}
+	if imageCatalogOfferingItem.Version != nil {
+		imageCatalogOfferingVersionList := []map[string]interface{}{}
+		imageCatalogOfferingVersionMap := map[string]interface{}{}
+		imageCatalogOfferingVersionMap[isImageCatalogOfferingCrn] = imageCatalogOfferingItem.Version.CRN
+
+		// if imageCatalogOfferingItem.Version.Deleted != nil {
+		// 	imageCatalogOfferingVersionDeletedList := []map[string]interface{}{}
+		// 	imageCatalogOfferingVersionDeletedMap := map[string]interface{}{}
+		// 	imageCatalogOfferingVersionDeletedMap[isImageCatalogOfferingMoreInfo] = imageCatalogOfferingItem.Version.Deleted.MoreInfo
+		// 	imageCatalogOfferingVersionDeletedList = append(imageCatalogOfferingVersionDeletedList, imageCatalogOfferingVersionDeletedMap)
+		// 	imageCatalogOfferingVersionMap[isImageCatalogOfferingDeleted] = imageCatalogOfferingVersionDeletedList
+		// }
+		imageCatalogOfferingVersionList = append(imageCatalogOfferingVersionList, imageCatalogOfferingVersionMap)
+		imageCatalogOfferingMap[isImageCatalogOfferingVersion] = imageCatalogOfferingVersionList
+	}
+
+	return imageCatalogOfferingMap
 }

--- a/ibm/service/vpc/data_source_ibm_is_image_test.go
+++ b/ibm/service/vpc/data_source_ibm_is_image_test.go
@@ -34,6 +34,36 @@ func TestAccIBMISImageDataSource_basic(t *testing.T) {
 		},
 	})
 }
+func TestAccIBMISImageDataSource_catalog(t *testing.T) {
+	resName := "data.ibm_is_image.test1"
+	resName1 := "data.ibm_is_image.test1"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { acc.TestAccPreCheck(t) },
+		Providers: acc.TestAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckIBMISCatalogImageDataSourceConfig(),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet(resName, "name"),
+					resource.TestCheckResourceAttrSet(resName, "os"),
+					resource.TestCheckResourceAttrSet(resName, "architecture"),
+					resource.TestCheckResourceAttrSet(resName, "visibility"),
+					resource.TestCheckResourceAttrSet(resName, "status"),
+					resource.TestCheckResourceAttr(resName, "catalog_offering.0.managed", "true"),
+					resource.TestCheckResourceAttrSet(resName, "catalog_offering.0.version.0.crn"),
+					resource.TestCheckResourceAttrSet(resName1, "name"),
+					resource.TestCheckResourceAttrSet(resName1, "os"),
+					resource.TestCheckResourceAttrSet(resName1, "architecture"),
+					resource.TestCheckResourceAttrSet(resName1, "visibility"),
+					resource.TestCheckResourceAttrSet(resName1, "status"),
+					resource.TestCheckResourceAttr(resName1, "catalog_offering.0.managed", "true"),
+					resource.TestCheckResourceAttrSet(resName1, "catalog_offering.0.version.0.crn"),
+				),
+			},
+		},
+	})
+}
 
 func TestAccIBMISImageDataSource_With_VisibiltyPublic(t *testing.T) {
 	resName := "data.ibm_is_image.test1"
@@ -88,6 +118,18 @@ func testAccCheckIBMISImageDataSourceConfig(imageName string) string {
 	data "ibm_is_image" "test1" {
 		name = ibm_is_image.isExampleImage.name
 	}`, acc.Image_cos_url, imageName, acc.Image_operating_system)
+}
+func testAccCheckIBMISCatalogImageDataSourceConfig() string {
+	return fmt.Sprintf(`
+	data "ibm_is_images" "test1" {
+		catalog_managed = true
+	}
+	data "ibm_is_image" "test1" {
+		name = data.ibm_is_images.test1.images.0.name
+	}
+	data "ibm_is_image" "test2" {
+		identifier = data.ibm_is_images.test1.images.0.id
+	}`)
 }
 
 func testAccCheckIBMISImageDataSourceWithVisibilityPublic(visibility string) string {

--- a/ibm/service/vpc/data_source_ibm_is_images_test.go
+++ b/ibm/service/vpc/data_source_ibm_is_images_test.go
@@ -30,6 +30,25 @@ func TestAccIBMISImagesDataSource_basic(t *testing.T) {
 		},
 	})
 }
+func TestAccIBMISImagesDataSource_catalog(t *testing.T) {
+	resName := "data.ibm_is_images.test1"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { acc.TestAccPreCheck(t) },
+		Providers: acc.TestAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckIBMISCatalogImagesDataSourceConfig(),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet(resName, "images.0.name"),
+					resource.TestCheckResourceAttr(resName, "images.0.catalog_offering.0.managed", "true"),
+					resource.TestCheckResourceAttrSet(resName, "images.0.status"),
+					resource.TestCheckResourceAttrSet(resName, "images.0.architecture"),
+				),
+			},
+		},
+	})
+}
 
 func TestAccIBMISImageDataSource_With_FilterVisibilty(t *testing.T) {
 	resName := "data.ibm_is_images.test1"
@@ -71,6 +90,13 @@ func testAccCheckIBMISImagesDataSourceConfig() string {
 	// status filter defaults to empty
 	return fmt.Sprintf(`
       data "ibm_is_images" "test1" {
+      }`)
+}
+func testAccCheckIBMISCatalogImagesDataSourceConfig() string {
+	// status filter defaults to empty
+	return fmt.Sprintf(`
+      data "ibm_is_images" "test1" {
+		catalog_managed = true
       }`)
 }
 

--- a/ibm/service/vpc/data_source_ibm_is_instance.go
+++ b/ibm/service/vpc/data_source_ibm_is_instance.go
@@ -215,6 +215,26 @@ func DataSourceIBMISInstance() *schema.Resource {
 				},
 			},
 
+			isInstanceCatalogOffering: {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Description: "The catalog offering or offering version to use when provisioning this virtual server instance. If an offering is specified, the latest version of that offering will be used. The specified offering or offering version may be in a different account in the same enterprise, subject to IAM policies.",
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						isInstanceCatalogOfferingOfferingCrn: {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "Identifies a catalog offering by a unique CRN property",
+						},
+						isInstanceCatalogOfferingVersionCrn: {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "Identifies a version of a catalog offering by a unique CRN property",
+						},
+					},
+				},
+			},
+
 			isInstanceVolumeAttachments: {
 				Type:        schema.TypeList,
 				Computed:    true,
@@ -669,6 +689,17 @@ func instanceGetByName(d *schema.ResourceData, meta interface{}, name string) er
 	instance := allrecs[0]
 	d.SetId(*instance.ID)
 	id := *instance.ID
+
+	// catalog
+	if instance.CatalogOffering != nil {
+		versionCrn := *instance.CatalogOffering.Version.CRN
+		catalogList := make([]map[string]interface{}, 0)
+		catalogMap := map[string]interface{}{}
+		catalogMap[isInstanceCatalogOfferingVersionCrn] = versionCrn
+		catalogList = append(catalogList, catalogMap)
+		d.Set(isInstanceCatalogOffering, catalogList)
+	}
+
 	d.Set(isInstanceName, *instance.Name)
 	if instance.Profile != nil {
 		d.Set(isInstanceProfile, *instance.Profile.Name)

--- a/ibm/service/vpc/data_source_ibm_is_instances.go
+++ b/ibm/service/vpc/data_source_ibm_is_instances.go
@@ -200,6 +200,27 @@ func DataSourceIBMISInstances() *schema.Resource {
 							Computed:    true,
 							Description: "vpc attached to the instance",
 						},
+
+						isInstanceCatalogOffering: {
+							Type:        schema.TypeList,
+							Computed:    true,
+							Description: "The catalog offering or offering version to use when provisioning this virtual server instance. If an offering is specified, the latest version of that offering will be used. The specified offering or offering version may be in a different account in the same enterprise, subject to IAM policies.",
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									isInstanceCatalogOfferingOfferingCrn: {
+										Type:        schema.TypeString,
+										Computed:    true,
+										Description: "Identifies a catalog offering by a unique CRN property",
+									},
+									isInstanceCatalogOfferingVersionCrn: {
+										Type:        schema.TypeString,
+										Computed:    true,
+										Description: "Identifies a version of a catalog offering by a unique CRN property",
+									},
+								},
+							},
+						},
+
 						"boot_volume": {
 							Type:        schema.TypeList,
 							Computed:    true,
@@ -793,6 +814,16 @@ func instancesList(d *schema.ResourceData, meta interface{}) error {
 
 		if instance.TotalVolumeBandwidth != nil {
 			l[isInstanceTotalVolumeBandwidth] = int(*instance.TotalVolumeBandwidth)
+		}
+
+		// catalog
+		if instance.CatalogOffering != nil {
+			versionCrn := *instance.CatalogOffering.Version.CRN
+			catalogList := make([]map[string]interface{}, 0)
+			catalogMap := map[string]interface{}{}
+			catalogMap[isInstanceCatalogOfferingVersionCrn] = versionCrn
+			catalogList = append(catalogList, catalogMap)
+			l[isInstanceCatalogOffering] = catalogList
 		}
 
 		if instance.BootVolumeAttachment != nil {

--- a/ibm/service/vpc/resource_ibm_is_instance_network_interface.go
+++ b/ibm/service/vpc/resource_ibm_is_instance_network_interface.go
@@ -551,7 +551,7 @@ func resourceIBMIsInstanceNetworkInterfaceUpdate(context context.Context, d *sch
 		patchVals.Name = core.StringPtr(d.Get(isInstanceNicName).(string))
 		hasChange = true
 	}
-	if d.HasChange("primary_network_interface.0.primary_ip.0.name") || d.HasChange("primary_network_interface.0.primary_ip.0.auto_delete") {
+	if !d.IsNewResource() && (d.HasChange("primary_network_interface.0.primary_ip.0.name") || d.HasChange("primary_network_interface.0.primary_ip.0.auto_delete")) {
 		subnetId := d.Get(isBareMetalServerNicSubnet).(string)
 		ripId := d.Get("primary_network_interface.0.primary_ip.0.reserved_ip").(string)
 		updateripoptions := &vpcv1.UpdateSubnetReservedIPOptions{

--- a/ibm/service/vpc/resource_ibm_is_instance_test.go
+++ b/ibm/service/vpc/resource_ibm_is_instance_test.go
@@ -981,6 +981,7 @@ func testAccCheckIBMISInstanceConfig(vpcname, subnetname, sshname, publicKey, na
 		}
 	  }`, vpcname, subnetname, acc.ISZoneName, acc.ISCIDR, sshname, publicKey, name, acc.IsImage, acc.InstanceProfileName, userData, acc.ISZoneName)
 }
+
 func testAccCheckIBMISInstanceRipConfig(vpcname, subnetname, subnetripname, sshname, publicKey, name, userData string) string {
 	return fmt.Sprintf(`
 	resource "ibm_is_vpc" "testacc_vpc" {
@@ -1793,4 +1794,82 @@ func testAccCheckIBMISInstanceUserTagConfig(vpcname, subnetname, sshname, public
 		zone = "%s"
 		keys = [ibm_is_ssh_key.testacc_sshkey.id]
 	  }`, vpcname, subnetname, acc.ISZoneName, acc.ISCIDR, sshname, publicKey, name, acc.IsImage, acc.InstanceProfileName, userTags1, userData, acc.ISZoneName)
+}
+
+func TestAccIBMISInstance_catalog(t *testing.T) {
+	var instance string
+	vpcname := fmt.Sprintf("tf-vpc-%d", acctest.RandIntRange(10, 100))
+	name := fmt.Sprintf("tf-instnace-%d", acctest.RandIntRange(10, 100))
+	subnetname := fmt.Sprintf("tf-subnet-%d", acctest.RandIntRange(10, 100))
+	publicKey := strings.TrimSpace(`
+ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCKVmnMOlHKcZK8tpt3MP1lqOLAcqcJzhsvJcjscgVERRN7/9484SOBJ3HSKxxNG5JN8owAjy5f9yYwcUg+JaUVuytn5Pv3aeYROHGGg+5G346xaq3DAwX6Y5ykr2fvjObgncQBnuU5KHWCECO/4h8uWuwh/kfniXPVjFToc+gnkqA+3RKpAecZhFXwfalQ9mMuYGFxn+fwn8cYEApsJbsEmb0iJwPiZ5hjFC8wREuiTlhPHDgkBLOiycd20op2nXzDbHfCHInquEe/gYxEitALONxm0swBOwJZwlTDOB7C6y2dzlrtxr1L59m7pCkWI4EtTRLvleehBoj3u7jB4usR
+`)
+	sshname := fmt.Sprintf("tf-ssh-%d", acctest.RandIntRange(10, 100))
+	userData1 := "a"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { acc.TestAccPreCheck(t) },
+		Providers:    acc.TestAccProviders,
+		CheckDestroy: testAccCheckIBMISInstanceDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckIBMISInstanceCatalogImageConfig(vpcname, subnetname, sshname, publicKey, name, userData1),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckIBMISInstanceExists("ibm_is_instance.testacc_instance", instance),
+					resource.TestCheckResourceAttr(
+						"ibm_is_instance.testacc_instance", "name", name),
+					resource.TestCheckResourceAttr(
+						"ibm_is_instance.testacc_instance", "user_data", userData1),
+					resource.TestCheckResourceAttr(
+						"ibm_is_instance.testacc_instance", "zone", acc.ISZoneName),
+					resource.TestCheckResourceAttrSet(
+						"ibm_is_instance.testacc_instance", "catalog_offering.0.version_crn"),
+					resource.TestCheckResourceAttrSet(
+						"data.ibm_is_images.testacc_images", "images.0.name"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckIBMISInstanceCatalogImageConfig(vpcname, subnetname, sshname, publicKey, name, userData string) string {
+	return fmt.Sprintf(`
+	resource "ibm_is_vpc" "testacc_vpc" {
+		name = "%s"
+	  }
+	  
+	  resource "ibm_is_subnet" "testacc_subnet" {
+		name            = "%s"
+		vpc             = ibm_is_vpc.testacc_vpc.id
+		zone            = "%s"
+		ipv4_cidr_block = "%s"
+	  }
+	  
+	  resource "ibm_is_ssh_key" "testacc_sshkey" {
+		name       = "%s"
+		public_key = "%s"
+	  }
+
+	  data "ibm_is_images" "testacc_images" {
+		catalog_managed = true
+	  }
+	  
+	  resource "ibm_is_instance" "testacc_instance" {
+		name    = "%s"
+		profile = "%s"
+		primary_network_interface {
+		  subnet     = ibm_is_subnet.testacc_subnet.id
+		}
+		user_data = "%s"
+		vpc  = ibm_is_vpc.testacc_vpc.id
+		zone = "%s"
+		keys = [ibm_is_ssh_key.testacc_sshkey.id]
+		network_interfaces {
+		  subnet = ibm_is_subnet.testacc_subnet.id
+		  name   = "eth1"
+		}
+		catalog_offering {
+			version_crn = data.ibm_is_images.testacc_images.images.0.catalog_offering.0.version.0.crn
+		}
+	  }`, vpcname, subnetname, acc.ISZoneName, acc.ISCIDR, sshname, publicKey, name, acc.InstanceProfileName, userData, acc.ISZoneName)
 }

--- a/ibm/service/vpc/resource_ibm_is_snapshot.go
+++ b/ibm/service/vpc/resource_ibm_is_snapshot.go
@@ -277,10 +277,9 @@ func resourceIBMISSnapshotCreate(d *schema.ResourceData, meta interface{}) error
 			snapshotprototypeoptions.UserTags = userTagsArray
 		}
 	}
-	options.SnapshotPrototype = snapshotprototypeoptions
 
 	log.Printf("[DEBUG] Snapshot create")
-
+	options.SnapshotPrototype = snapshotprototypeoptions
 	snapshot, response, err := sess.CreateSnapshot(options)
 	if err != nil || snapshot == nil {
 		return fmt.Errorf("[ERROR] Error creating Snapshot %s\n%s", err, response)

--- a/website/docs/d/is_image.html.markdown
+++ b/website/docs/d/is_image.html.markdown
@@ -47,6 +47,12 @@ Review the argument references that you can specify for your data source.
 In addition to all argument reference list, you can access the following attribute references after your data source is created.
 
 - `architecture` - (String) The architecture of the image.
+- `catalog_offering` - (List) The catalog offering for this image.
+  Nested scheme for **catalog_offering**:
+  - `managed` - (Bool) Indicates whether this image is managed as part of a catalog offering. If an image is managed, accounts in the same enterprise with access to that catalog can specify the image's catalog offering version CRN to provision virtual server instances using the image.
+  - `version` - (List) The catalog offering version associated with this image. If absent, this image is not associated with a cloud catalog offering.
+      Nested scheme for **version**:
+        - `crn` - (String) The CRN for this version of a catalog offering
 - `checksum`-  (String) The `SHA256` checksum of the image.
 - `crn` - (String) The CRN for this image.
 - `encryption` - (String) The type of encryption used of the image.

--- a/website/docs/d/is_images.html.markdown
+++ b/website/docs/d/is_images.html.markdown
@@ -36,6 +36,7 @@ data "ibm_is_images" "ds_images" {
 
 Review the argument references that you can specify for your data source. 
 
+* `catalog_managed` - (Optional, bool) Lists only those images which are managed as part of a catalog offering.
 * `resource_group` - (Optional, string) The id of the resource group.
 * `name` - (Optional, string) The name of the image.
 * `visibility` - (Optional, string) Visibility of the image.
@@ -49,6 +50,12 @@ You can access the following attribute references after your data source is crea
   Nested scheme for `images`:
   - `architecture` - (String) The architecture for this image.
   - `crn` - (String) The CRN for this image.
+  - `catalog_offering` - (List) The catalog offering for this image.
+    Nested scheme for **catalog_offering**:
+    - `managed` - (Bool) Indicates whether this image is managed as part of a catalog offering. If an image is managed, accounts in the same enterprise with access to that catalog can specify the image's catalog offering version CRN to provision virtual server instances using the image.
+    - `version` - (List) The catalog offering version associated with this image. If absent, this image is not associated with a cloud catalog offering.
+        Nested scheme for **version**:
+          - `crn` - (String) The CRN for this version of a catalog offering
   - `checksum` - (String) TThe SHA256 checksum for this image.
   - `encryption` - (String) The type of encryption used on the image.
   - `encryption_key` - (String) The CRN of the Key Protect Root Key or Hyper Protect Crypto Service Root Key for this resource.

--- a/website/docs/d/is_instance.html.markdown
+++ b/website/docs/d/is_instance.html.markdown
@@ -94,6 +94,13 @@ In addition to all argument reference list, you can access the following attribu
   - `device` - (String) The name of the device that is associated with the boot volume.
   - `volume_id` - (String) The ID of the volume that is associated with the boot volume attachment.
   - `volume_crn` - (String) The CRN of the volume that is associated with the boot volume attachment.
+
+- `catalog_offering` - (List) The [catalog](https://cloud.ibm.com/docs/account?topic=account-restrict-by-user&interface=ui) offering or offering version to use when provisioning this virtual server instance. If an offering is specified, the latest version of that offering will be used. The specified offering or offering version may be in a different account in the same [enterprise](https://cloud.ibm.com/docs/account?topic=account-what-is-enterprise), subject to IAM policies.
+
+  Nested scheme for `catalog_offering`:
+    - `offering_crn` - (String) The CRN for this catalog offering. Identifies a catalog offering by this unique property
+    - `version_crn` - (String) The CRN for this version of a catalog offering. Identifies a version of a catalog offering by this unique property
+   
 - `crn` - (String) The CRN of the instance.
 - `disks` - (List) Collection of the instance's disks. Nested `disks` blocks has the following structure:
 

--- a/website/docs/d/is_instances.html.markdown
+++ b/website/docs/d/is_instances.html.markdown
@@ -67,6 +67,12 @@ In addition to all argument reference list, you can access the following attribu
 		- `name` - (String) The name of the boot volume.
 		- `volume_id` - (String) The ID of the volume that is associated with the boot volume attachment.
 		- `volume_crn` - (String) The CRN of the volume that is associated with the boot volume attachment.
+	- `catalog_offering` - (List) The [catalog](https://cloud.ibm.com/docs/account?topic=account-restrict-by-user&interface=ui) offering or offering version to use when provisioning this virtual server instance. If an offering is specified, the latest version of that offering will be used. The specified offering or offering version may be in a different account in the same [enterprise](https://cloud.ibm.com/docs/account?topic=account-what-is-enterprise), subject to IAM policies.
+
+	  Nested scheme for `catalog_offering`:
+		- `offering_crn` - (String) The CRN for this catalog offering. Identifies a catalog offering by this unique property
+		- `version_crn` - (String) The CRN for this version of a catalog offering. Identifies a version of a catalog offering by this unique property
+ 	
 	- `crn` - (String) The CRN of the instance.
 	- `disks` - (List) Collection of the instance's disks. Nested `disks` blocks has the following structure:
 

--- a/website/docs/r/is_instance.html.markdown
+++ b/website/docs/r/is_instance.html.markdown
@@ -225,7 +225,7 @@ resource "ibm_is_dedicated_host" "example" {
   resource_group = ibm_resource_group.example.id
 }
 
-// Example to provision instance in a dedicated host
+// Example to provision an instance in a dedicated host
 resource "ibm_is_instance" "example1" {
   name    = "example-instance-1"
   image   = ibm_is_image.example.id
@@ -249,7 +249,7 @@ resource "ibm_is_instance" "example1" {
   }
 }
 
-// Example to provision instance in a dedicated host that belongs to the provided dedicated host group
+// Example to provision an instance in a dedicated host that belongs to the provided dedicated host group
 resource "ibm_is_instance" "example2" {
   name    = "example-instance-2"
   image   = ibm_is_image.example.id
@@ -273,7 +273,7 @@ resource "ibm_is_instance" "example2" {
   }
 }
 
-// Example to provision instance from a snapshot, restoring boot volume from an existing snapshot
+// Example to provision an instance from a snapshot, restoring boot volume from an existing snapshot
 
 resource "ibm_is_snapshot" "example" {
   name          = "example-snapshot"
@@ -300,6 +300,30 @@ resource "ibm_is_instance" "example" {
   }
 }
 
+
+// Example to provision an instance using an enterprise managed catalog image
+
+data ibm_is_images example {
+  catalog_managed = true
+}
+
+resource "ibm_is_instance" "example" {
+  name    = "example-vsi-catalog"
+  profile = "cx2-2x4"
+  catalog_offering {
+    version_crn = data.ibm_is_images.example.images.0.catalog_offering.0.version.0.crn
+  }
+  primary_network_interface {
+    subnet = ibm_is_subnet.example.id
+  }
+  vpc  = ibm_is_vpc.example.id
+  zone = "us-south-1"
+  keys = [ibm_is_ssh_key.example.id]
+  network_interfaces {
+    subnet = ibm_is_subnet.example.id
+    name   = "eth1"
+  }
+}
 ```
 
 ## Timeouts
@@ -332,8 +356,16 @@ Review the argument references that you can specify for your resource.
   - `snapshot` - (Optional, Forces new resource, String) The snapshot id of the volume to be used for creating boot volume attachment
     
     ~> **Note:**
-    `snapshot` conflicts with `image` id and `instance_template`
+    `snapshot` conflicts with `image` id, `instance_template` and `catalog_offering`
   - `tags`- (Optional, Array of Strings) A list of user tags that you want to add to your volume. (https://cloud.ibm.com/apidocs/tagging#types-of-tags)
+- `catalog_offering` - (Optional, List) The [catalog](https://cloud.ibm.com/docs/account?topic=account-restrict-by-user&interface=ui) offering or offering version to use when provisioning this virtual server instance. If an offering is specified, the latest version of that offering will be used. The specified offering or offering version may be in a different account in the same [enterprise](https://cloud.ibm.com/docs/account?topic=account-what-is-enterprise), subject to IAM policies.
+  Nested scheme for `catalog_offering`:
+  - `offering_crn` - (Optional, String) The CRN for this catalog offering. Identifies a catalog offering by this unique property
+  - `version_crn` - (Optional, String) The CRN for this version of a catalog offering. Identifies a version of a catalog offering by this unique property
+ 
+    ~> **Note:**
+    `offering_crn` conflicts with `version_crn`, both are mutually exclusive. `catalog_offering` and `image` id are mutually exclusive.
+    `snapshot` conflicts with `image` id and `instance_template`
 - `dedicated_host` - (Optional, String) The placement restrictions to use the virtual server instance. Unique ID of the dedicated host where the instance id placed.
 - `dedicated_host_group` - (Optional, String) The placement restrictions to use for the virtual server instance. Unique ID of the dedicated host group where the instance is placed.
 
@@ -349,7 +381,7 @@ Review the argument references that you can specify for your resource.
 - `image` - (Required, String) The ID of the virtual server image that you want to use. To list supported images, run `ibmcloud is images` or use `ibm_is_images` datasource.
   
   ~> **Note:**
-  `image` conflicts with `boot_volume.0.snapshot`, not required when creating instance using `instance_template`
+  `image` conflicts with `boot_volume.0.snapshot` and `catalog_offering`, not required when creating instance using `instance_template` or `catalog_offering`
 - `keys` - (Required, List) A comma-separated list of SSH keys that you want to add to your instance.
 - `lifecycle_reasons`- (List) The reasons for the current lifecycle_state (if any).
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/IBM-Cloud/terraform-provider-ibm/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
=== RUN   TestAccIBMISImageDataSource_catalog
--- PASS: TestAccIBMISImageDataSource_catalog (69.42s)
PASS
ok      github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/vpc     71.190s
```
```
--- PASS: TestAccIBMISInstance_catalog (208.08s)
PASS
ok      github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/vpc     209.659s
```
```
=== RUN   TestAccIBMISImagesDataSource_catalog
--- PASS: TestAccIBMISImagesDataSource_catalog (45.84s)
PASS
ok      github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/vpc     47.475s
```