### PR TITLE
removed deprecation message for default_network_acl

### DIFF
--- a/ibm/service/vpc/resource_ibm_is_vpc.go
+++ b/ibm/service/vpc/resource_ibm_is_vpc.go
@@ -93,11 +93,8 @@ func ResourceIBMISVPC() *schema.Resource {
 
 			isVPCDefaultNetworkACL: {
 				Type:        schema.TypeString,
-				Optional:    true,
-				Default:     nil,
 				Computed:    true,
-				Deprecated:  "This field is deprecated",
-				Description: "Default network ACL",
+				Description: "Default network ACL ID",
 			},
 
 			isVPCDefaultRoutingTable: {

--- a/website/docs/r/is_vpc.html.markdown
+++ b/website/docs/r/is_vpc.html.markdown
@@ -43,7 +43,6 @@ Review the argument references that you can specify for your resource.
 
 - `address_prefix_management` - (Optional, Forces new resource, String) Indicates whether a default address prefix should be created automatically `auto` or manually `manual` for each zone in this VPC. Default value is `auto`.
 - `classic_access` - (Optional, Bool) Specify if you want to create a VPC that can connect to classic infrastructure resources. Enter **true** to set up private network connectivity from your VPC to classic infrastructure resources that are created in the same IBM Cloud account, and **false** to disable this access. If you choose to not set up this access, you cannot enable it after the VPC is created. Make sure to review the [prerequisites](https://cloud.ibm.com/docs/vpc-on-classic-network?topic=vpc-on-classic-setting-up-access-to-your-classic-infrastructure-from-vpc#vpc-prerequisites) before you create a VPC with classic infrastructure access. Note that you can enable one VPC for classic infrastructure access per IBM Cloud account only.
-- `default_network_acl`- (Deprecated, String) The ID of the default network ACL.
 - `default_network_acl_name` - (Optional, String) Enter the name of the default network access control list (ACL).
 - `default_security_group_name` - (Optional, String) Enter the name of the default security group.
 - `default_routing_table_name` - (Optional, String) Enter the name of the default routing table.


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/IBM-Cloud/terraform-provider-ibm/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TEST=./ibm/service/vpc TESTARGS='-run=TestAccIBMISVPC_basic'
=== RUN   TestAccIBMISVPC_basic
--- PASS: TestAccIBMISVPC_basic (127.63s)
=== RUN   TestAccIBMISVPC_basic_apm
--- PASS: TestAccIBMISVPC_basic_apm (93.25s)
PASS
ok      github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/vpc     221.888s
...
```
