### PR TITLE
fix(Cloud Databases): fix Members & CPU update checks

### DIFF
--- a/ibm/service/database/resource_ibm_database.go
+++ b/ibm/service/database/resource_ibm_database.go
@@ -1363,7 +1363,7 @@ func resourceIBMDatabaseInstanceCreate(context context.Context, d *schema.Resour
 				continue
 			}
 
-			if g.Members != nil && g.Members.Allocation*nodeCount != currentGroup.Members.Allocation {
+			if g.Members != nil && g.Members.Allocation != currentGroup.Members.Allocation {
 				groupScaling.Members = &clouddatabasesv5.GroupScalingMembers{AllocationCount: core.Int64Ptr(int64(g.Members.Allocation))}
 				nodeCount = g.Members.Allocation
 			}
@@ -1373,7 +1373,7 @@ func resourceIBMDatabaseInstanceCreate(context context.Context, d *schema.Resour
 			if g.Disk != nil && g.Disk.Allocation*nodeCount != currentGroup.Disk.Allocation {
 				groupScaling.Disk = &clouddatabasesv5.GroupScalingDisk{AllocationMb: core.Int64Ptr(int64(g.Disk.Allocation * nodeCount))}
 			}
-			if g.CPU != nil && g.CPU.Allocation != currentGroup.CPU.Allocation {
+			if g.CPU != nil && g.CPU.Allocation*nodeCount != currentGroup.CPU.Allocation {
 				groupScaling.CPU = &clouddatabasesv5.GroupScalingCPU{AllocationCount: core.Int64Ptr(int64(g.CPU.Allocation * nodeCount))}
 			}
 
@@ -1930,7 +1930,7 @@ func resourceIBMDatabaseInstanceUpdate(context context.Context, d *schema.Resour
 			}
 			nodeCount := currentGroup.Members.Allocation
 
-			if group.Members != nil && group.Members.Allocation*nodeCount != currentGroup.Members.Allocation {
+			if group.Members != nil && group.Members.Allocation != currentGroup.Members.Allocation {
 				groupScaling.Members = &clouddatabasesv5.GroupScalingMembers{AllocationCount: core.Int64Ptr(int64(group.Members.Allocation))}
 				nodeCount = group.Members.Allocation
 			}
@@ -1940,7 +1940,7 @@ func resourceIBMDatabaseInstanceUpdate(context context.Context, d *schema.Resour
 			if group.Disk != nil && group.Disk.Allocation*nodeCount != currentGroup.Disk.Allocation {
 				groupScaling.Disk = &clouddatabasesv5.GroupScalingDisk{AllocationMb: core.Int64Ptr(int64(group.Disk.Allocation * nodeCount))}
 			}
-			if group.CPU != nil && group.CPU.Allocation != currentGroup.CPU.Allocation {
+			if group.CPU != nil && group.CPU.Allocation*nodeCount != currentGroup.CPU.Allocation {
 				groupScaling.CPU = &clouddatabasesv5.GroupScalingCPU{AllocationCount: core.Int64Ptr(int64(group.CPU.Allocation * nodeCount))}
 			}
 

--- a/ibm/service/database/resource_ibm_database.go
+++ b/ibm/service/database/resource_ibm_database.go
@@ -1953,16 +1953,19 @@ func resourceIBMDatabaseInstanceUpdate(context context.Context, d *schema.Resour
 
 				setDeploymentScalingGroupResponse, response, err := cloudDatabasesClient.SetDeploymentScalingGroup(setDeploymentScalingGroupOptions)
 
-				if response.StatusCode > 300 {
+				if err != nil {
 					return diag.FromErr(fmt.Errorf("[ERROR] SetDeploymentScalingGroup (%s) failed %s\n%s", group.ID, err, response))
 				}
 
-				taskIDLink := *setDeploymentScalingGroupResponse.Task.ID
+				// API may return HTTP 204 No Content if no change made
+				if response.StatusCode == 200 {
+					taskIDLink := *setDeploymentScalingGroupResponse.Task.ID
 
-				_, err = waitForDatabaseTaskComplete(taskIDLink, d, meta, d.Timeout(schema.TimeoutCreate))
+					_, err = waitForDatabaseTaskComplete(taskIDLink, d, meta, d.Timeout(schema.TimeoutCreate))
 
-				if err != nil {
-					return diag.FromErr(err)
+					if err != nil {
+						return diag.FromErr(err)
+					}
 				}
 			}
 		}


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/IBM-Cloud/terraform-provider-ibm/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes https://github.com/IBM-Cloud/terraform-provider-ibm/issues/3964

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccIBMDatabaseInstance'

--- PASS: TestAccIBMDatabaseInstanceElasticsearchImport (472.41s)
--- PASS: TestAccIBMDatabaseInstanceEtcdImport (726.60s)
--- PASS: TestAccIBMDatabaseInstanceMongodbBasic (1102.86s)
--- PASS: TestAccIBMDatabaseInstanceMongodbImport (953.78s)
--- PASS: TestAccIBMDatabaseInstancePostgresBasic (1021.66s)
--- PASS: TestAccIBMDatabaseInstancePostgresGroup (1381.63s)
--- PASS: TestAccIBMDatabaseInstancePostgresGroupMigration (651.41s)
--- PASS: TestAccIBMDatabaseInstancePostgresImport (638.78s)
--- PASS: TestAccIBMDatabaseInstancePostgresNode (2232.39s)
--- PASS: TestAccIBMDatabaseInstanceRabbitmqImport (1143.36s)
--- PASS: TestAccIBMDatabaseInstanceRedisImport (613.91s)
--- PASS: TestAccIBMDatabaseInstance_Cassandra_Node (5193.62s)
--- PASS: TestAccIBMDatabaseInstance_Elasticsearch_Basic (972.75s)
--- PASS: TestAccIBMDatabaseInstance_Elasticsearch_Group (2376.58s)
--- PASS: TestAccIBMDatabaseInstance_Elasticsearch_Node (940.05s)
--- PASS: TestAccIBMDatabaseInstance_Etcd_Basic (840.39s)
--- PASS: TestAccIBMDatabaseInstance_Rabbitmq_Basic (1195.95s)
--- PASS: TestAccIBMDatabaseInstance_Redis_Basic (976.86s)

...
```
