### PR TITLE
Add replication enabled attribute in pi volume resource

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.16
 require (
 	github.com/IBM-Cloud/bluemix-go v0.0.0-20220523145737-34645883de47
 	github.com/IBM-Cloud/container-services-go-sdk v0.0.0-20220728135852-60ff775f7a8d
-	github.com/IBM-Cloud/power-go-client v1.1.12
+	github.com/IBM-Cloud/power-go-client v1.2.0
 	github.com/IBM/apigateway-go-sdk v0.0.0-20210714141226-a5d5d49caaca
 	github.com/IBM/appconfiguration-go-admin-sdk v0.3.0
 	github.com/IBM/appid-management-go-sdk v0.0.0-20210908164609-dd0e0eaf732f

--- a/go.sum
+++ b/go.sum
@@ -7,8 +7,8 @@ github.com/IBM-Cloud/bluemix-go v0.0.0-20220523145737-34645883de47/go.mod h1:tfN
 github.com/IBM-Cloud/container-services-go-sdk v0.0.0-20220728135852-60ff775f7a8d h1:cHu5Iev9ggo1fktwmHbmPqDOkt3VYmdUGn1U7/Zb238=
 github.com/IBM-Cloud/container-services-go-sdk v0.0.0-20220728135852-60ff775f7a8d/go.mod h1:xUQL9SGAjoZFd4GNjrjjtEpjpkgU7RFXRyHesbKTjiY=
 github.com/IBM-Cloud/ibm-cloud-cli-sdk v0.5.3/go.mod h1:RiUvKuHKTBmBApDMUQzBL14pQUGKcx/IioKQPIcRQjs=
-github.com/IBM-Cloud/power-go-client v1.1.12 h1:zL8Br83MHe1mDhFI+2YenQsHeYUtPzqw9oeFL9fmguE=
-github.com/IBM-Cloud/power-go-client v1.1.12/go.mod h1:Qfx0fNi+9hms+xu9Z6Euhu9088ByW6C/TCMLECTRWNE=
+github.com/IBM-Cloud/power-go-client v1.2.0 h1:0A3sSOC0d/P4IUAj4YGthA0g4liMaJpWvyBx50Z6/Ck=
+github.com/IBM-Cloud/power-go-client v1.2.0/go.mod h1:Qfx0fNi+9hms+xu9Z6Euhu9088ByW6C/TCMLECTRWNE=
 github.com/IBM-Cloud/softlayer-go v1.0.5-tf h1:koUAyF9b6X78lLLruGYPSOmrfY2YcGYKOj/Ug9nbKNw=
 github.com/IBM-Cloud/softlayer-go v1.0.5-tf/go.mod h1:6HepcfAXROz0Rf63krk5hPZyHT6qyx2MNvYyHof7ik4=
 github.com/IBM/apigateway-go-sdk v0.0.0-20210714141226-a5d5d49caaca h1:crniVcf+YcmgF03NmmfonXwSQ73oJF+IohFYBwknMxs=

--- a/ibm/service/power/resource_ibm_pi_volume.go
+++ b/ibm/service/power/resource_ibm_pi_volume.go
@@ -109,6 +109,12 @@ func ResourceIBMPIVolume() *schema.Resource {
 				Description:      "List of pvmInstances to base volume anti-affinity policy against; required if requesting anti-affinity and pi_anti_affinity_volumes is not provided",
 				ConflictsWith:    []string{PIAntiAffinityVolumes},
 			},
+			helpers.PIReplicationEnabled: {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Computed:    true,
+				Description: "Indicates if the volume should be replication enabled or not",
+			},
 
 			// Computed Attributes
 			"volume_id": {
@@ -131,6 +137,51 @@ func ResourceIBMPIVolume() *schema.Resource {
 				Type:        schema.TypeString,
 				Computed:    true,
 				Description: "WWN Of the volume",
+			},
+			"auxiliary": {
+				Type:        schema.TypeBool,
+				Computed:    true,
+				Description: "true if volume is auxiliary otherwise false",
+			},
+			"consistency_group_name": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "Consistency Group Name if volume is a part of volume group",
+			},
+			"group_id": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "Volume Group ID",
+			},
+			"replication_type": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "Replication type(metro,global)",
+			},
+			"replication_status": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "Replication status of a volume",
+			},
+			"mirroring_state": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "Mirroring state for replication enabled volume",
+			},
+			"primary_role": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "Indicates whether master/aux volume is playing the primary role",
+			},
+			"aux_volume_name": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "Indicates auxiliary volume name",
+			},
+			"master_volume_name": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "Indicates master volume name",
 			},
 		},
 	}
@@ -177,6 +228,10 @@ func resourceIBMPIVolumeCreate(ctx context.Context, d *schema.ResourceData, meta
 	if v, ok := d.GetOk(helpers.PIVolumePool); ok {
 		volumePool := v.(string)
 		body.VolumePool = volumePool
+	}
+	if v, ok := d.GetOk(helpers.PIReplicationEnabled); ok {
+		replicationEnabled := v.(bool)
+		body.ReplicationEnabled = &replicationEnabled
 	}
 	if ap, ok := d.GetOk(PIAffinityPolicy); ok {
 		policy := ap.(string)
@@ -249,6 +304,16 @@ func resourceIBMPIVolumeRead(ctx context.Context, d *schema.ResourceData, meta i
 	if vol.VolumeID != nil {
 		d.Set("volume_id", vol.VolumeID)
 	}
+	d.Set(helpers.PIReplicationEnabled, vol.ReplicationEnabled)
+	d.Set("auxiliary", vol.Auxiliary)
+	d.Set("consistency_group_name", vol.ConsistencyGroupName)
+	d.Set("group_id", vol.GroupID)
+	d.Set("replication_type", vol.ReplicationType)
+	d.Set("replication_status", vol.ReplicationStatus)
+	d.Set("mirroring_state", vol.MirroringState)
+	d.Set("primary_role", vol.PrimaryRole)
+	d.Set("master_volume_name", vol.MasterVolumeName)
+	d.Set("aux_volume_name", vol.AuxVolumeName)
 	if vol.DeleteOnTermination != nil {
 		d.Set("delete_on_termination", vol.DeleteOnTermination)
 	}
@@ -289,6 +354,22 @@ func resourceIBMPIVolumeUpdate(ctx context.Context, d *schema.ResourceData, meta
 	_, err = isWaitForIBMPIVolumeAvailable(ctx, client, *volrequest.VolumeID, d.Timeout(schema.TimeoutUpdate))
 	if err != nil {
 		return diag.FromErr(err)
+	}
+
+	if d.HasChange(helpers.PIReplicationEnabled) {
+		replicationEnabled := d.Get(helpers.PIReplicationEnabled).(bool)
+		volActionBody := models.VolumeAction{
+			ReplicationEnabled: &replicationEnabled,
+		}
+
+		err = client.VolumeAction(volumeID, &volActionBody)
+		if err != nil {
+			return diag.FromErr(err)
+		}
+		_, err = isWaitForIBMPIVolumeAvailable(ctx, client, volumeID, d.Timeout(schema.TimeoutUpdate))
+		if err != nil {
+			return diag.FromErr(err)
+		}
 	}
 
 	return resourceIBMPIVolumeRead(ctx, d, meta)

--- a/ibm/service/power/resource_ibm_pi_volume_test.go
+++ b/ibm/service/power/resource_ibm_pi_volume_test.go
@@ -160,3 +160,64 @@ func testAccCheckIBMPIVolumePoolConfig(name string) string {
 	  }
 	`, name, acc.Pi_cloud_instance_id)
 }
+
+func TestAccIBMPIVolumeGRS(t *testing.T) {
+	name := fmt.Sprintf("tf-pi-volume-%d", acctest.RandIntRange(10, 100))
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { acc.TestAccPreCheck(t) },
+		Providers:    acc.TestAccProviders,
+		CheckDestroy: testAccCheckIBMPIVolumeDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckIBMPIVolumeGRSConfig(name),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckIBMPIVolumeExists("ibm_pi_volume.power_volume"),
+					resource.TestCheckResourceAttr(
+						"ibm_pi_volume.power_volume", "pi_volume_name", name),
+					resource.TestCheckResourceAttr(
+						"ibm_pi_volume.power_volume", "pi_replication_enabled", "true"),
+					resource.TestCheckResourceAttr(
+						"ibm_pi_volume.power_volume", "replication_type", "global"),
+				),
+			},
+			{
+				Config: testAccCheckIBMPIVolumeGRSUpdateConfig(name),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckIBMPIVolumeExists("ibm_pi_volume.power_volume"),
+					resource.TestCheckResourceAttr(
+						"ibm_pi_volume.power_volume", "pi_volume_name", name),
+					resource.TestCheckResourceAttr(
+						"ibm_pi_volume.power_volume", "pi_replication_enabled", "false"),
+					resource.TestCheckResourceAttr(
+						"ibm_pi_volume.power_volume", "replication_type", ""),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckIBMPIVolumeGRSConfig(name string) string {
+	return fmt.Sprintf(`
+	resource "ibm_pi_volume" "power_volume"{
+		pi_volume_size       = 20
+		pi_volume_name       = "%[1]s"
+		pi_volume_pool       = "%[3]s"
+		pi_volume_shareable  = true
+		pi_cloud_instance_id = "%[2]s"
+		pi_replication_enabled = true
+	  }
+	`, name, acc.Pi_cloud_instance_id, acc.PiStoragePool)
+}
+
+func testAccCheckIBMPIVolumeGRSUpdateConfig(name string) string {
+	return fmt.Sprintf(`
+	resource "ibm_pi_volume" "power_volume"{
+		pi_volume_size       = 20
+		pi_volume_name       = "%[1]s"
+		pi_volume_pool       = "%[3]s"
+		pi_volume_shareable  = true
+		pi_cloud_instance_id = "%[2]s"
+		pi_replication_enabled = false
+	  }
+	`, name, acc.Pi_cloud_instance_id, acc.PiStoragePool)
+}

--- a/ibm/service/power/resource_ibm_pi_volume_test.go
+++ b/ibm/service/power/resource_ibm_pi_volume_test.go
@@ -161,6 +161,7 @@ func testAccCheckIBMPIVolumePoolConfig(name string) string {
 	`, name, acc.Pi_cloud_instance_id)
 }
 
+//TestAccIBMPIVolumeGRS test the volume replication feature which is part of global replication service(GRS)
 func TestAccIBMPIVolumeGRS(t *testing.T) {
 	name := fmt.Sprintf("tf-pi-volume-%d", acctest.RandIntRange(10, 100))
 	resource.Test(t, resource.TestCase{
@@ -197,19 +198,14 @@ func TestAccIBMPIVolumeGRS(t *testing.T) {
 }
 
 func testAccCheckIBMPIVolumeGRSConfig(name string) string {
-	return fmt.Sprintf(`
-	resource "ibm_pi_volume" "power_volume"{
-		pi_volume_size       = 20
-		pi_volume_name       = "%[1]s"
-		pi_volume_pool       = "%[3]s"
-		pi_volume_shareable  = true
-		pi_cloud_instance_id = "%[2]s"
-		pi_replication_enabled = true
-	  }
-	`, name, acc.Pi_cloud_instance_id, acc.PiStoragePool)
+	return testAccCheckIBMPIVolumeGRSBasicConfig(name, acc.Pi_cloud_instance_id, acc.PiStoragePool, true)
 }
 
 func testAccCheckIBMPIVolumeGRSUpdateConfig(name string) string {
+	return testAccCheckIBMPIVolumeGRSBasicConfig(name, acc.Pi_cloud_instance_id, acc.PiStoragePool, false)
+}
+
+func testAccCheckIBMPIVolumeGRSBasicConfig(name, piCloudInstanceId, piStoragePool string, replicationEnabled bool) string {
 	return fmt.Sprintf(`
 	resource "ibm_pi_volume" "power_volume"{
 		pi_volume_size       = 20
@@ -217,7 +213,7 @@ func testAccCheckIBMPIVolumeGRSUpdateConfig(name string) string {
 		pi_volume_pool       = "%[3]s"
 		pi_volume_shareable  = true
 		pi_cloud_instance_id = "%[2]s"
-		pi_replication_enabled = false
+		pi_replication_enabled = %[4]v
 	  }
-	`, name, acc.Pi_cloud_instance_id, acc.PiStoragePool)
+	`, name, piCloudInstanceId, piStoragePool, replicationEnabled)
 }

--- a/website/docs/r/pi_volume.html.markdown
+++ b/website/docs/r/pi_volume.html.markdown
@@ -55,6 +55,7 @@ Review the argument references that you can specify for your resource.
 - `pi_anti_affinity_instances` - (Optional, String) List of pvmInstances to base volume anti-affinity policy against; required if requesting `anti-affinity` and `pi_anti_affinity_volumes` is not provided.
 - `pi_anti_affinity_volumes`- (Optional, String) List of volumes to base volume anti-affinity policy against; required if requesting `anti-affinity` and `pi_anti_affinity_instances` is not provided.
 - `pi_cloud_instance_id` - (Required, String) The GUID of the service instance associated with an account.
+- `pi_replication_enabled` - (Opttional, Bool) Indicates if the volume should be replication enabled or not.
 - `pi_volume_name` - (Required, String) The name of the volume.
 - `pi_volume_pool` - (Optional, String) Volume pool where the volume will be created; if provided then `pi_volume_type` and `pi_affinity_policy` values will be ignored.
 - `pi_volume_shareable` - (Required, Bool) If set to **true**, the volume can be shared across Power Systems Virtual Server instances. If set to **false**, you can attach it only to one instance. 
@@ -64,8 +65,17 @@ Review the argument references that you can specify for your resource.
 ## Attribute reference
 In addition to all argument reference list, you can access the following attribute reference after your resource is created.
 
+- `auxiliary` - (Bool) Indicates if the volume is auxiliary or not.
+- `aux_volume_name` - (String) The auxiliary volume name.
+- `consistency_group_name` - (String) The consistency group name if volume is a part of volume group.
 - `delete_on_termination` - (Bool) Indicates if the volume should be deleted when the server terminates.
+- `group_id` - (String) The volume group id in which the volume belongs.
 - `id` - (String) The unique identifier of the volume. The ID is composed of `<power_instance_id>/<volume_id>`.
+- `master_volume_name` - (String) The master volume name.
+- `mirroring_state` - (String) The mirroring state for replication enabled volume.
+- `primary_role` - (String) Indicates whether `master`/`auxiliary` volume is playing the primary role.
+- `replication_status` - (String) The replication status of the volume.
+- `replication_type` - (String) The replication type of the volume `metro` or `global`.
 - `volume_id` - (String) The unique identifier of the volume.
 - `volume_status` - (String) The status of the volume.
 - `wwn` - (String) The world wide name of the volume.


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/IBM-Cloud/terraform-provider-ibm/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccXXX'

=== RUN   TestAccIBMPIVolumebasic
--- PASS: TestAccIBMPIVolumebasic (130.20s)
PASS
=== RUN   TestAccIBMPIVolumePool
--- PASS: TestAccIBMPIVolumePool (94.04s)
PASS
=== RUN   TestAccIBMPIVolumeGRS
--- PASS: TestAccIBMPIVolumeGRS (188.75s)
PASS
```
