### PR TITLE
Add shared processor pool & SPP placement groups

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.16
 require (
 	github.com/IBM-Cloud/bluemix-go v0.0.0-20220523145737-34645883de47
 	github.com/IBM-Cloud/container-services-go-sdk v0.0.0-20220728135852-60ff775f7a8d
-	github.com/IBM-Cloud/power-go-client v1.2.0
+	github.com/IBM-Cloud/power-go-client v1.2.1
 	github.com/IBM/apigateway-go-sdk v0.0.0-20210714141226-a5d5d49caaca
 	github.com/IBM/appconfiguration-go-admin-sdk v0.3.0
 	github.com/IBM/appid-management-go-sdk v0.0.0-20210908164609-dd0e0eaf732f
@@ -51,6 +51,8 @@ require (
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/softlayer/softlayer-go v1.0.3
 	golang.org/x/crypto v0.0.0-20220622213112-05595931fe9d
+	golang.org/x/net v0.0.0-20220722155237-a158d28d115b // indirect
+	golang.org/x/sys v0.0.0-20220907062415-87db552b00fd // indirect
 	google.golang.org/genproto v0.0.0-20200904004341-0bd0a958aa1d // indirect
 	gotest.tools v2.2.0+incompatible
 )

--- a/go.sum
+++ b/go.sum
@@ -7,8 +7,8 @@ github.com/IBM-Cloud/bluemix-go v0.0.0-20220523145737-34645883de47/go.mod h1:tfN
 github.com/IBM-Cloud/container-services-go-sdk v0.0.0-20220728135852-60ff775f7a8d h1:cHu5Iev9ggo1fktwmHbmPqDOkt3VYmdUGn1U7/Zb238=
 github.com/IBM-Cloud/container-services-go-sdk v0.0.0-20220728135852-60ff775f7a8d/go.mod h1:xUQL9SGAjoZFd4GNjrjjtEpjpkgU7RFXRyHesbKTjiY=
 github.com/IBM-Cloud/ibm-cloud-cli-sdk v0.5.3/go.mod h1:RiUvKuHKTBmBApDMUQzBL14pQUGKcx/IioKQPIcRQjs=
-github.com/IBM-Cloud/power-go-client v1.2.0 h1:0A3sSOC0d/P4IUAj4YGthA0g4liMaJpWvyBx50Z6/Ck=
-github.com/IBM-Cloud/power-go-client v1.2.0/go.mod h1:Qfx0fNi+9hms+xu9Z6Euhu9088ByW6C/TCMLECTRWNE=
+github.com/IBM-Cloud/power-go-client v1.2.1 h1:21z0hxZLgM9npv6u2IvKCHxhfbwxQM/q8ULV+pua5Sk=
+github.com/IBM-Cloud/power-go-client v1.2.1/go.mod h1:Qfx0fNi+9hms+xu9Z6Euhu9088ByW6C/TCMLECTRWNE=
 github.com/IBM-Cloud/softlayer-go v1.0.5-tf h1:koUAyF9b6X78lLLruGYPSOmrfY2YcGYKOj/Ug9nbKNw=
 github.com/IBM-Cloud/softlayer-go v1.0.5-tf/go.mod h1:6HepcfAXROz0Rf63krk5hPZyHT6qyx2MNvYyHof7ik4=
 github.com/IBM/apigateway-go-sdk v0.0.0-20210714141226-a5d5d49caaca h1:crniVcf+YcmgF03NmmfonXwSQ73oJF+IohFYBwknMxs=
@@ -38,7 +38,6 @@ github.com/IBM/go-sdk-core/v5 v5.5.1/go.mod h1:Sn+z+qTDREQvCr+UFa22TqqfXNxx3o723
 github.com/IBM/go-sdk-core/v5 v5.6.3/go.mod h1:tt/B9rxLkRtglE7pvqLuYikgCXaZFL3btdruJaoUeek=
 github.com/IBM/go-sdk-core/v5 v5.6.5/go.mod h1:tt/B9rxLkRtglE7pvqLuYikgCXaZFL3btdruJaoUeek=
 github.com/IBM/go-sdk-core/v5 v5.7.0/go.mod h1:+YbdhrjCHC84ls4MeBp+Hj4NZCni+tDAc0XQUqRO9Jc=
-github.com/IBM/go-sdk-core/v5 v5.7.2/go.mod h1:+YbdhrjCHC84ls4MeBp+Hj4NZCni+tDAc0XQUqRO9Jc=
 github.com/IBM/go-sdk-core/v5 v5.8.0/go.mod h1:+YbdhrjCHC84ls4MeBp+Hj4NZCni+tDAc0XQUqRO9Jc=
 github.com/IBM/go-sdk-core/v5 v5.9.1/go.mod h1:axE2JrRq79gIJTjKPBwV6gWHswvVptBjbcvvCPIxARM=
 github.com/IBM/go-sdk-core/v5 v5.9.2/go.mod h1:YlOwV9LeuclmT/qi/LAK2AsobbAP42veV0j68/rlZsE=
@@ -71,10 +70,6 @@ github.com/IBM/schematics-go-sdk v0.2.1 h1:byATysGD+Z1k/wdtNqQmKALcAPjgSLuSyzcab
 github.com/IBM/schematics-go-sdk v0.2.1/go.mod h1:Tw2OSAPdpC69AxcwoyqcYYaGTTW6YpERF9uNEU+BFRQ=
 github.com/IBM/secrets-manager-go-sdk v0.1.19 h1:0GPs5EoTaWNsjo4QPj64GNxlWfN8VHJy4RDFLqddSe8=
 github.com/IBM/secrets-manager-go-sdk v0.1.19/go.mod h1:eO3dBhzPrHkkt+yPex/jB2xD6qHZxBko+Aw+0tfqHeA=
-github.com/IBM/vpc-go-sdk v0.22.0 h1:jo2WMfiFXhAyJkdJeCVHwvT6kgTg2tg8sDeP9zrMFVg=
-github.com/IBM/vpc-go-sdk v0.22.0/go.mod h1:YPyIfI+/qhPqlYp+I7dyx2U1GLcXgp/jzVvsZfUH4y8=
-github.com/IBM/vpc-go-sdk v0.23.0 h1:C26g02pPtTEWyLHNKK0mlFdpHeb9+noku9Q6qJLmdkc=
-github.com/IBM/vpc-go-sdk v0.23.0/go.mod h1:YPyIfI+/qhPqlYp+I7dyx2U1GLcXgp/jzVvsZfUH4y8=
 github.com/IBM/vpc-go-sdk v0.24.0 h1:YelLUm9eo6NchQmPmUrg6I1p2tamR1FxcvZp6aHtJzE=
 github.com/IBM/vpc-go-sdk v0.24.0/go.mod h1:YPyIfI+/qhPqlYp+I7dyx2U1GLcXgp/jzVvsZfUH4y8=
 github.com/Logicalis/asn1 v0.0.0-20190312173541-d60463189a56 h1:vuquMR410psHNax14XKNWa0Ae/kYgWJcXi0IFuX60N0=
@@ -760,8 +755,9 @@ golang.org/x/net v0.0.0-20210614182718-04defd469f4e/go.mod h1:9nx3DQGgdP8bBQD5qx
 golang.org/x/net v0.0.0-20211112202133-69e39bad7dc2/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/net v0.0.0-20220114011407-0dd24b26b47d/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/net v0.0.0-20220127200216-cd36cc0744dd/go.mod h1:CfG3xpIq0wQ8r1q4Su4UZFWDARRcnwPjda9FqA0JpMk=
-golang.org/x/net v0.0.0-20220225172249-27dd8689420f h1:oA4XRj0qtSt8Yo1Zms0CUlsT3KG69V2UGQWPBxujDmc=
 golang.org/x/net v0.0.0-20220225172249-27dd8689420f/go.mod h1:CfG3xpIq0wQ8r1q4Su4UZFWDARRcnwPjda9FqA0JpMk=
+golang.org/x/net v0.0.0-20220722155237-a158d28d115b h1:PxfKdU9lEEDYjdIzOtC4qFWgkU2rGHdKlKowJSMN9h0=
+golang.org/x/net v0.0.0-20220722155237-a158d28d115b/go.mod h1:XRhObCWvk6IyKnWLug+ECip1KBveYUHfp+8e9klMJ9c=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
 golang.org/x/oauth2 v0.0.0-20190604053449-0f29369cfe45/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
 golang.org/x/oauth2 v0.0.0-20200107190931-bf48bf16ab8d/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
@@ -813,8 +809,10 @@ golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20211216021012-1d35b9e2eb4e/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220114195835-da31bd327af9/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220330033206-e17cdc41300f/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.0.0-20220817070843-5a390386f1f2 h1:fqTvyMIIj+HRzMmnzr9NtpHP6uVpvB5fkHcgPDC4nu8=
+golang.org/x/sys v0.0.0-20220520151302-bc2c85ada10a/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220817070843-5a390386f1f2/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20220907062415-87db552b00fd h1:AZeIEzg+8RCELJYq8w+ODLVxFgLMMigSwO/ffKPEd9U=
+golang.org/x/sys v0.0.0-20220907062415-87db552b00fd/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.0.0-20201117132131-f5c789dd3221/go.mod h1:Nr5EML6q2oocZ2LXRh80K7BxOlk5/8JxuGnuhpl+muw=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/term v0.0.0-20210927222741-03fcf44c2211 h1:JGgROgKl9N8DuW20oFS5gxc+lE67/N3FcwmBPMe7ArY=

--- a/ibm/acctest/acctest.go
+++ b/ibm/acctest/acctest.go
@@ -121,8 +121,10 @@ var Pi_dhcp_id string
 var PiCloudConnectionName string
 var PiSAPProfileID string
 var Pi_placement_group_name string
+var Pi_spp_placement_group_id string
 var PiStoragePool string
 var PiStorageType string
+var Pi_shared_processor_pool_id string
 
 var Pi_capture_storage_image_path string
 var Pi_capture_cloud_storage_access_key string
@@ -674,6 +676,11 @@ func init() {
 		Pi_placement_group_name = "tf-pi-placement-group"
 		fmt.Println("[WARN] Set the environment variable PI_PLACEMENT_GROUP_NAME for testing ibm_pi_placement_group resource else it is set to default value 'tf-pi-placement-group'")
 	}
+	Pi_spp_placement_group_id = os.Getenv("PI_SPP_PLACEMENT_GROUP_ID")
+	if Pi_spp_placement_group_id == "" {
+		Pi_spp_placement_group_id = "tf-pi-spp-placement-group"
+		fmt.Println("[WARN] Set the environment variable PI_SPP_PLACEMENT_GROUP_ID for testing ibm_pi_spp_placement_group resource else it is set to default value 'tf-pi-spp-placement-group'")
+	}
 	PiStoragePool = os.Getenv("PI_STORAGE_POOL")
 	if PiStoragePool == "" {
 		PiStoragePool = "terraform-test-power"
@@ -701,6 +708,12 @@ func init() {
 	if Pi_capture_cloud_storage_secret_key == "" {
 		Pi_capture_cloud_storage_secret_key = "terraform-test-power"
 		fmt.Println("[INFO] Set the environment variable PI_CAPTURE_CLOUD_STORAGE_SECRET_KEY for testing Pi_capture_cloud_storage_secret_key resource else it is set to default value 'terraform-test-power'")
+	}
+
+	Pi_shared_processor_pool_id = os.Getenv("PI_SHARED_PROCESSOR_POOL_ID")
+	if Pi_shared_processor_pool_id == "" {
+		Pi_shared_processor_pool_id = "tf-pi-shared-processor-pool"
+		fmt.Println("[WARN] Set the environment variable PI_SHARED_PROCESSOR_POOL_ID for testing ibm_pi_shared_processor_pool resource else it is set to default value 'tf-pi-shared-processor-pool'")
 	}
 
 	WorkspaceID = os.Getenv("SCHEMATICS_WORKSPACE_ID")

--- a/ibm/provider/provider.go
+++ b/ibm/provider/provider.go
@@ -558,6 +558,10 @@ func Provider() *schema.Provider {
 			"ibm_pi_pvm_snapshots":          power.DataSourceIBMPISnapshot(),
 			"ibm_pi_sap_profile":            power.DataSourceIBMPISAPProfile(),
 			"ibm_pi_sap_profiles":           power.DataSourceIBMPISAPProfiles(),
+			"ibm_pi_shared_processor_pool":  power.DataSourceIBMPISharedProcessorPool(),
+			"ibm_pi_shared_processor_pools": power.DataSourceIBMPISharedProcessorPools(),
+			"ibm_pi_spp_placement_group":    power.DataSourceIBMPISPPPlacementGroup(),
+			"ibm_pi_spp_placement_groups":   power.DataSourceIBMPISPPPlacementGroups(),
 			"ibm_pi_storage_pool_capacity":  power.DataSourceIBMPIStoragePoolCapacity(),
 			"ibm_pi_storage_pools_capacity": power.DataSourceIBMPIStoragePoolsCapacity(),
 			"ibm_pi_storage_type_capacity":  power.DataSourceIBMPIStorageTypeCapacity(),
@@ -994,6 +998,8 @@ func Provider() *schema.Provider {
 			"ibm_pi_vpn_connection":                  power.ResourceIBMPIVPNConnection(),
 			"ibm_pi_console_language":                power.ResourceIBMPIInstanceConsoleLanguage(),
 			"ibm_pi_placement_group":                 power.ResourceIBMPIPlacementGroup(),
+			"ibm_pi_spp_placement_group":             power.ResourceIBMPISPPPlacementGroup(),
+			"ibm_pi_shared_processor_pool":           power.ResourceIBMPISharedProcessorPool(),
 
 			// //Private DNS related resources
 			"ibm_dns_zone":              dnsservices.ResourceIBMPrivateDNSZone(),

--- a/ibm/service/power/data_source_ibm_pi_instance.go
+++ b/ibm/service/power/data_source_ibm_pi_instance.go
@@ -187,6 +187,14 @@ func DataSourceIBMPIInstance() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
+			Attr_PIInstanceSharedProcessorPool: {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			Attr_PIInstanceSharedProcessorPoolID: {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
 		},
 	}
 }
@@ -232,6 +240,8 @@ func dataSourceIBMPIInstancesRead(ctx context.Context, d *schema.ResourceData, m
 	if *powervmdata.PlacementGroup != "none" {
 		d.Set(PIPlacementGroupID, powervmdata.PlacementGroup)
 	}
+	d.Set(Attr_PIInstanceSharedProcessorPool, powervmdata.SharedProcessorPool)
+	d.Set(Attr_PIInstanceSharedProcessorPoolID, powervmdata.SharedProcessorPoolID)
 
 	if powervmdata.Addresses != nil {
 		pvmaddress := make([]map[string]interface{}, len(powervmdata.Addresses))

--- a/ibm/service/power/data_source_ibm_pi_shared_processor_pool.go
+++ b/ibm/service/power/data_source_ibm_pi_shared_processor_pool.go
@@ -1,0 +1,183 @@
+// Copyright IBM Corp. 2021 All Rights Reserved.
+// Licensed under the Mozilla Public License v2.0
+
+package power
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	st "github.com/IBM-Cloud/power-go-client/clients/instance"
+	"github.com/IBM-Cloud/power-go-client/helpers"
+	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/conns"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+)
+
+func DataSourceIBMPISharedProcessorPool() *schema.Resource {
+
+	return &schema.Resource{
+		ReadContext: dataSourceIBMPISharedProcessorPoolRead,
+		Schema: map[string]*schema.Schema{
+			Arg_SharedProcessorPoolID: {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+
+			Arg_CloudInstanceID: {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "PI cloud instance ID",
+			},
+
+			Attr_SharedProcessorPoolName: {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "Name of the shared processor pool",
+			},
+
+			Attr_SharedProcessorPoolHostID: {
+				Type:        schema.TypeInt,
+				Computed:    true,
+				Description: "The host ID where the shared processor pool resides",
+			},
+
+			Attr_SharedProcessorPoolReservedCores: {
+				Type:        schema.TypeInt,
+				Computed:    true,
+				Description: "The amount of reserved cores for the shared processor pool",
+			},
+
+			Attr_SharedProcessorPoolAvailableCores: {
+				Type:        schema.TypeFloat,
+				Computed:    true,
+				Description: "Shared processor pool available cores",
+			},
+
+			Attr_SharedProcessorPoolAllocatedCores: {
+				Type:        schema.TypeFloat,
+				Computed:    true,
+				Description: "Shared processor pool allocated cores",
+			},
+
+			Attr_SharedProcessorPoolStatus: {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The status of the shared processor pool",
+			},
+
+			Attr_SharedProcessorPoolStatusDetail: {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The status details of the shared processor pool",
+			},
+
+			Attr_SharedProcessorPoolInstances: {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Description: "List of server instances deployed in the shared processor pool",
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						Attr_SharedProcessorPoolInstanceCpus: {
+							Type:        schema.TypeInt,
+							Optional:    true,
+							Computed:    true,
+							Description: "The amount of cpus for the server instance",
+						},
+						Attr_SharedProcessorPoolInstanceUncapped: {
+							Type:        schema.TypeBool,
+							Optional:    true,
+							Computed:    true,
+							Description: "Identifies if uncapped or not",
+						},
+						Attr_SharedProcessorPoolInstanceAvailabilityZone: {
+							Type:        schema.TypeString,
+							Optional:    true,
+							Computed:    true,
+							Description: "Availability zone for the server instances",
+						},
+						Attr_SharedProcessorPoolInstanceId: {
+							Type:        schema.TypeString,
+							Optional:    true,
+							Computed:    true,
+							Description: "The server instance ID",
+						},
+						Attr_SharedProcessorPoolInstanceMemory: {
+							Type:        schema.TypeInt,
+							Optional:    true,
+							Computed:    true,
+							Description: "The amount of memory for the server instance",
+						},
+						Attr_SharedProcessorPoolInstanceName: {
+							Type:        schema.TypeString,
+							Optional:    true,
+							Computed:    true,
+							Description: "The server instance name",
+						},
+						Attr_SharedProcessorPoolInstanceStatus: {
+							Type:        schema.TypeString,
+							Optional:    true,
+							Computed:    true,
+							Description: "Status of the server",
+						},
+						Attr_SharedProcessorPoolInstanceVcpus: {
+							Type:        schema.TypeFloat,
+							Optional:    true,
+							Computed:    true,
+							Description: "The amout of vcpus for the server instance",
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func dataSourceIBMPISharedProcessorPoolRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+
+	sess, err := meta.(conns.ClientSession).IBMPISession()
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	cloudInstanceID := d.Get(helpers.PICloudInstanceId).(string)
+	poolID := d.Get(Arg_SharedProcessorPoolID).(string)
+	client := st.NewIBMPISharedProcessorPoolClient(ctx, sess, cloudInstanceID)
+
+	response, err := client.Get(poolID)
+	if err != nil || response == nil {
+		return diag.FromErr(fmt.Errorf("error fetching the shared processor pool: %s", err))
+	}
+
+	d.SetId(*response.SharedProcessorPool.ID)
+	d.Set(Attr_SharedProcessorPoolName, response.SharedProcessorPool.Name)
+	d.Set(Attr_SharedProcessorPoolReservedCores, response.SharedProcessorPool.ReservedCores)
+	d.Set(Attr_SharedProcessorPoolAllocatedCores, response.SharedProcessorPool.AllocatedCores)
+	d.Set(Attr_SharedProcessorPoolAvailableCores, response.SharedProcessorPool.AvailableCores)
+	d.Set(Attr_SharedProcessorPoolHostID, response.SharedProcessorPool.HostID)
+	d.Set(Attr_SharedProcessorPoolStatus, response.SharedProcessorPool.Status)
+	d.Set(Attr_SharedProcessorPoolStatusDetail, response.SharedProcessorPool.StatusDetail)
+
+	serversMap := []map[string]interface{}{}
+	if response.Servers != nil {
+		for _, s := range response.Servers {
+			if s != nil {
+				v := map[string]interface{}{
+					Attr_SharedProcessorPoolInstanceCpus:             s.Cpus,
+					Attr_SharedProcessorPoolInstanceUncapped:         s.Uncapped,
+					Attr_SharedProcessorPoolInstanceAvailabilityZone: s.AvailabilityZone,
+					Attr_SharedProcessorPoolInstanceId:               s.ID,
+					Attr_SharedProcessorPoolInstanceMemory:           s.Memory,
+					Attr_SharedProcessorPoolInstanceName:             s.Name,
+					Attr_SharedProcessorPoolInstanceStatus:           s.Status,
+					Attr_SharedProcessorPoolInstanceVcpus:            s.Vcpus,
+				}
+				serversMap = append(serversMap, v)
+			}
+		}
+	}
+	d.Set(Attr_SharedProcessorPoolInstances, serversMap)
+
+	return nil
+}

--- a/ibm/service/power/data_source_ibm_pi_shared_processor_pool.go
+++ b/ibm/service/power/data_source_ibm_pi_shared_processor_pool.go
@@ -5,7 +5,6 @@ package power
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 
@@ -147,7 +146,7 @@ func dataSourceIBMPISharedProcessorPoolRead(ctx context.Context, d *schema.Resou
 
 	response, err := client.Get(poolID)
 	if err != nil || response == nil {
-		return diag.FromErr(fmt.Errorf("error fetching the shared processor pool: %s", err))
+		return diag.Errorf("error fetching the shared processor pool: %v", err)
 	}
 
 	d.SetId(*response.SharedProcessorPool.ID)

--- a/ibm/service/power/data_source_ibm_pi_shared_processor_pool_test.go
+++ b/ibm/service/power/data_source_ibm_pi_shared_processor_pool_test.go
@@ -1,0 +1,36 @@
+// Copyright IBM Corp. 2022 All Rights Reserved.
+// Licensed under the Mozilla Public License v2.0
+
+package power_test
+
+import (
+	"fmt"
+	"testing"
+
+	acc "github.com/IBM-Cloud/terraform-provider-ibm/ibm/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+func TestAccIBMPIPISharedProcessorPoolDataSource_basic(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { acc.TestAccPreCheck(t) },
+		Providers: acc.TestAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckIBMPIPISharedProcessorPoolDataSourceConfig(),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet("data.ibm_pi_shared_processor_pool.test_pool", "id"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckIBMPIPISharedProcessorPoolDataSourceConfig() string {
+	return fmt.Sprintf(`
+data "ibm_pi_shared_processor_pool" "test_pool" {
+	pi_shared_processor_pool_id = "%s"
+    pi_cloud_instance_id = "%s"
+}`, acc.Pi_shared_processor_pool_id, acc.Pi_cloud_instance_id)
+
+}

--- a/ibm/service/power/data_source_ibm_pi_shared_processor_pools.go
+++ b/ibm/service/power/data_source_ibm_pi_shared_processor_pools.go
@@ -5,7 +5,6 @@ package power
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/hashicorp/go-uuid"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
@@ -87,7 +86,7 @@ func dataSourceIBMPISharedProcessorPoolsRead(ctx context.Context, d *schema.Reso
 	client := st.NewIBMPISharedProcessorPoolClient(ctx, sess, cloudInstanceID)
 	pools, err := client.GetAll()
 	if err != nil || pools == nil {
-		return diag.FromErr(fmt.Errorf("error fetching shared processor pools: %s", err))
+		return diag.Errorf("error fetching shared processor pools: %v", err)
 	}
 
 	result := make([]map[string]interface{}, 0, len(pools.SharedProcessorPools))

--- a/ibm/service/power/data_source_ibm_pi_shared_processor_pools.go
+++ b/ibm/service/power/data_source_ibm_pi_shared_processor_pools.go
@@ -1,0 +1,113 @@
+// Copyright IBM Corp. 2021 All Rights Reserved.
+// Licensed under the Mozilla Public License v2.0
+
+package power
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+
+	st "github.com/IBM-Cloud/power-go-client/clients/instance"
+	"github.com/IBM-Cloud/power-go-client/helpers"
+	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/conns"
+)
+
+const (
+	PISharedProcessorPools = "shared_processor_pools"
+)
+
+func DataSourceIBMPISharedProcessorPools() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceIBMPISharedProcessorPoolsRead,
+		Schema: map[string]*schema.Schema{
+			helpers.PICloudInstanceId: {
+				Type:         schema.TypeString,
+				Required:     true,
+				Description:  "PI cloud instance ID",
+				ValidateFunc: validation.NoZeroValues,
+			},
+			// Computed Attributes
+			PISharedProcessorPools: {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						Attr_SharedProcessorPoolID: {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						Attr_SharedProcessorPoolAllocatedCores: {
+							Type:     schema.TypeFloat,
+							Computed: true,
+						},
+						Attr_SharedProcessorPoolAvailableCores: {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						Attr_SharedProcessorPoolName: {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						Attr_SharedProcessorPoolReservedCores: {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						Attr_SharedProcessorPoolHostID: {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						Attr_SharedProcessorPoolStatus: {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						Attr_SharedProcessorPoolStatusDetail: {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func dataSourceIBMPISharedProcessorPoolsRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	sess, err := meta.(conns.ClientSession).IBMPISession()
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	cloudInstanceID := d.Get(helpers.PICloudInstanceId).(string)
+
+	client := st.NewIBMPISharedProcessorPoolClient(ctx, sess, cloudInstanceID)
+	pools, err := client.GetAll()
+	if err != nil || pools == nil {
+		return diag.FromErr(fmt.Errorf("error fetching shared processor pools: %s", err))
+	}
+
+	result := make([]map[string]interface{}, 0, len(pools.SharedProcessorPools))
+	for _, pool := range pools.SharedProcessorPools {
+		key := map[string]interface{}{
+			Attr_SharedProcessorPoolID:             *pool.ID,
+			Attr_SharedProcessorPoolName:           *pool.Name,
+			Attr_SharedProcessorPoolAllocatedCores: *pool.AllocatedCores,
+			Attr_SharedProcessorPoolAvailableCores: *pool.AvailableCores,
+			Attr_SharedProcessorPoolReservedCores:  *pool.ReservedCores,
+			Attr_SharedProcessorPoolHostID:         pool.HostID,
+			Attr_SharedProcessorPoolStatus:         pool.Status,
+			Attr_SharedProcessorPoolStatusDetail:   pool.StatusDetail,
+		}
+		result = append(result, key)
+	}
+
+	var genID, _ = uuid.GenerateUUID()
+	d.SetId(genID)
+	d.Set(PISharedProcessorPools, result)
+
+	return nil
+}

--- a/ibm/service/power/data_source_ibm_pi_shared_processor_pools_test.go
+++ b/ibm/service/power/data_source_ibm_pi_shared_processor_pools_test.go
@@ -1,0 +1,35 @@
+// Copyright IBM Corp. 2022 All Rights Reserved.
+// Licensed under the Mozilla Public License v2.0
+
+package power_test
+
+import (
+	"fmt"
+	"testing"
+
+	acc "github.com/IBM-Cloud/terraform-provider-ibm/ibm/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+func TestAccIBMPISharedProcessorPoolsDataSourceBasic(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { acc.TestAccPreCheck(t) },
+		Providers: acc.TestAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckIBMPISharedProcessorPoolsDataSourceConfig(),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet("data.ibm_pi_shared_processor_pools.test", "id"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckIBMPISharedProcessorPoolsDataSourceConfig() string {
+	return fmt.Sprintf(`
+		data "ibm_pi_shared_processor_pools" "test" {
+			pi_cloud_instance_id = "%s"
+		}
+	`, acc.Pi_cloud_instance_id)
+}

--- a/ibm/service/power/data_source_ibm_pi_spp_placement_group.go
+++ b/ibm/service/power/data_source_ibm_pi_spp_placement_group.go
@@ -1,0 +1,76 @@
+// Copyright IBM Corp. 2022 All Rights Reserved.
+// Licensed under the Mozilla Public License v2.0
+
+package power
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	st "github.com/IBM-Cloud/power-go-client/clients/instance"
+	"github.com/IBM-Cloud/power-go-client/helpers"
+	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/conns"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+)
+
+func DataSourceIBMPISPPPlacementGroup() *schema.Resource {
+
+	return &schema.Resource{
+		ReadContext: dataSourceIBMPISPPPlacementGroupRead,
+		Schema: map[string]*schema.Schema{
+			Arg_SPPPlacementGroupID: {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+
+			Attr_SPPPlacementGroupName: {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+
+			Attr_SPPPlacementGroupPolicy: {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+
+			helpers.PICloudInstanceId: {
+				Type:         schema.TypeString,
+				Required:     true,
+				ValidateFunc: validation.NoZeroValues,
+			},
+
+			Attr_SPPPlacementGroupMembers: {
+				Type:     schema.TypeList,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+				Computed: true,
+			},
+		},
+	}
+}
+
+func dataSourceIBMPISPPPlacementGroupRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+
+	sess, err := meta.(conns.ClientSession).IBMPISession()
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	cloudInstanceID := d.Get(helpers.PICloudInstanceId).(string)
+	placementGroupID := d.Get(Arg_SPPPlacementGroupID).(string)
+	client := st.NewIBMPISPPPlacementGroupClient(ctx, sess, cloudInstanceID)
+
+	response, err := client.Get(placementGroupID)
+	if err != nil || response == nil {
+		return diag.FromErr(fmt.Errorf("error fetching the spp placement group: %s", err))
+	}
+
+	d.SetId(*response.ID)
+	d.Set(Attr_SPPPlacementGroupName, response.Name)
+	d.Set(Attr_SPPPlacementGroupPolicy, response.Policy)
+	d.Set(Attr_SPPPlacementGroupMembers, response.MemberSharedProcessorPools)
+
+	return nil
+}

--- a/ibm/service/power/data_source_ibm_pi_spp_placement_group.go
+++ b/ibm/service/power/data_source_ibm_pi_spp_placement_group.go
@@ -5,7 +5,6 @@ package power
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 
@@ -64,7 +63,7 @@ func dataSourceIBMPISPPPlacementGroupRead(ctx context.Context, d *schema.Resourc
 
 	response, err := client.Get(placementGroupID)
 	if err != nil || response == nil {
-		return diag.FromErr(fmt.Errorf("error fetching the spp placement group: %s", err))
+		return diag.Errorf("error fetching the spp placement group: %v", err)
 	}
 
 	d.SetId(*response.ID)

--- a/ibm/service/power/data_source_ibm_pi_spp_placement_group_test.go
+++ b/ibm/service/power/data_source_ibm_pi_spp_placement_group_test.go
@@ -1,0 +1,36 @@
+// Copyright IBM Corp. 2022 All Rights Reserved.
+// Licensed under the Mozilla Public License v2.0
+
+package power_test
+
+import (
+	"fmt"
+	"testing"
+
+	acc "github.com/IBM-Cloud/terraform-provider-ibm/ibm/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+func TestAccIBMPISPPPlacementGroupDataSource_basic(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { acc.TestAccPreCheck(t) },
+		Providers: acc.TestAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckIBMPISPPPlacementGroupDataSourceConfig(),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet("data.ibm_pi_spp_placement_group.testacc_ds_spp_placement_group", "id"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckIBMPISPPPlacementGroupDataSourceConfig() string {
+	return fmt.Sprintf(`
+data "ibm_pi_spp_placement_group" "testacc_ds_spp_placement_group" {
+	pi_spp_placement_group_id = "%s"
+    pi_cloud_instance_id = "%s"
+}`, acc.Pi_spp_placement_group_id, acc.Pi_cloud_instance_id)
+
+}

--- a/ibm/service/power/data_source_ibm_pi_spp_placement_groups.go
+++ b/ibm/service/power/data_source_ibm_pi_spp_placement_groups.go
@@ -5,7 +5,6 @@ package power
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/hashicorp/go-uuid"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
@@ -72,7 +71,7 @@ func dataSourceIBMPISPPPlacementGroupsRead(ctx context.Context, d *schema.Resour
 	client := st.NewIBMPISPPPlacementGroupClient(ctx, sess, cloudInstanceID)
 	groups, err := client.GetAll()
 	if err != nil || groups == nil {
-		return diag.FromErr(fmt.Errorf("error fetching spp placement groups: %s", err))
+		return diag.Errorf("error fetching spp placement groups: %v", err)
 	}
 
 	result := make([]map[string]interface{}, 0, len(groups.SppPlacementGroups))

--- a/ibm/service/power/data_source_ibm_pi_spp_placement_groups.go
+++ b/ibm/service/power/data_source_ibm_pi_spp_placement_groups.go
@@ -1,0 +1,94 @@
+// Copyright IBM Corp. 2022 All Rights Reserved.
+// Licensed under the Mozilla Public License v2.0
+
+package power
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+
+	st "github.com/IBM-Cloud/power-go-client/clients/instance"
+	"github.com/IBM-Cloud/power-go-client/helpers"
+	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/conns"
+)
+
+const (
+	PISPPPlacementGroups = "spp_placement_groups"
+)
+
+func DataSourceIBMPISPPPlacementGroups() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceIBMPISPPPlacementGroupsRead,
+		Schema: map[string]*schema.Schema{
+			helpers.PICloudInstanceId: {
+				Type:         schema.TypeString,
+				Required:     true,
+				Description:  "PI cloud instance ID",
+				ValidateFunc: validation.NoZeroValues,
+			},
+			// Computed Attributes
+			PISPPPlacementGroups: {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						Attr_SPPPlacementGroupID: {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						Attr_SPPPlacementGroupName: {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						Attr_SPPPlacementGroupMembers: {
+							Type:     schema.TypeList,
+							Elem:     &schema.Schema{Type: schema.TypeString},
+							Computed: true,
+						},
+						Attr_SPPPlacementGroupPolicy: {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func dataSourceIBMPISPPPlacementGroupsRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	sess, err := meta.(conns.ClientSession).IBMPISession()
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	cloudInstanceID := d.Get(helpers.PICloudInstanceId).(string)
+
+	client := st.NewIBMPISPPPlacementGroupClient(ctx, sess, cloudInstanceID)
+	groups, err := client.GetAll()
+	if err != nil || groups == nil {
+		return diag.FromErr(fmt.Errorf("error fetching spp placement groups: %s", err))
+	}
+
+	result := make([]map[string]interface{}, 0, len(groups.SppPlacementGroups))
+	for _, placementGroup := range groups.SppPlacementGroups {
+		key := map[string]interface{}{
+			Attr_SPPPlacementGroupID:      placementGroup.ID,
+			Attr_SPPPlacementGroupName:    placementGroup.Name,
+			Attr_SPPPlacementGroupMembers: placementGroup.MemberSharedProcessorPools,
+			Attr_SPPPlacementGroupPolicy:  placementGroup.Policy,
+		}
+		result = append(result, key)
+	}
+
+	var genID, _ = uuid.GenerateUUID()
+	d.SetId(genID)
+	d.Set(PISPPPlacementGroups, result)
+
+	return nil
+}

--- a/ibm/service/power/data_source_ibm_pi_spp_placement_groups_test.go
+++ b/ibm/service/power/data_source_ibm_pi_spp_placement_groups_test.go
@@ -1,0 +1,35 @@
+// Copyright IBM Corp. 2022 All Rights Reserved.
+// Licensed under the Mozilla Public License v2.0
+
+package power_test
+
+import (
+	"fmt"
+	"testing"
+
+	acc "github.com/IBM-Cloud/terraform-provider-ibm/ibm/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+func TestAccIBMPISPPPlacementGroupsDataSourceBasic(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { acc.TestAccPreCheck(t) },
+		Providers: acc.TestAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckIBMPISPPPlacementGroupsDataSourceConfig(),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet("data.ibm_pi_spp_placement_groups.test", "id"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckIBMPISPPPlacementGroupsDataSourceConfig() string {
+	return fmt.Sprintf(`
+		data "ibm_pi_spp_placement_groups" "test" {
+			pi_cloud_instance_id = "%s"
+		}
+	`, acc.Pi_cloud_instance_id)
+}

--- a/ibm/service/power/ibm_pi_constants.go
+++ b/ibm/service/power/ibm_pi_constants.go
@@ -58,13 +58,16 @@ const (
 	warningTimeOut = 60 * time.Second
 	activeTimeOut  = 2 * time.Minute
 	// power service instance capabilities
-	CUSTOM_VIRTUAL_CORES          = "custom-virtualcores"
-	PIInstanceDeploymentType      = "pi_deployment_type"
-	PIInstanceNetwork             = "pi_network"
-	PIInstanceStoragePool         = "pi_storage_pool"
-	PISAPInstanceProfileID        = "pi_sap_profile_id"
-	PISAPInstanceDeploymentType   = "pi_sap_deployment_type"
-	PIInstanceStoragePoolAffinity = "pi_storage_pool_affinity"
+	CUSTOM_VIRTUAL_CORES                 = "custom-virtualcores"
+	PIInstanceDeploymentType             = "pi_deployment_type"
+	PIInstanceNetwork                    = "pi_network"
+	PIInstanceStoragePool                = "pi_storage_pool"
+	PISAPInstanceProfileID               = "pi_sap_profile_id"
+	PISAPInstanceDeploymentType          = "pi_sap_deployment_type"
+	PIInstanceStoragePoolAffinity        = "pi_storage_pool_affinity"
+	Arg_PIInstanceSharedProcessorPool    = "pi_shared_processor_pool"
+	Attr_PIInstanceSharedProcessorPool   = "shared_processor_pool"
+	Attr_PIInstanceSharedProcessorPoolID = "shared_processor_pool_id"
 
 	// Placement Group
 	PIPlacementGroupID      = "placement_group_id"
@@ -89,6 +92,40 @@ const (
 
 	// Cloud Connections
 	PICloudConnectionTransitEnabled = "pi_cloud_connection_transit_enabled"
+
+	// Shared Processor Pool
+	Arg_SharedProcessorPoolName                      = "pi_shared_processor_pool_name"
+	Arg_SharedProcessorPoolHostGroup                 = "pi_shared_processor_pool_host_group"
+	Arg_SharedProcessorPoolPlacementGroupID          = "pi_shared_processor_pool_placement_group_id"
+	Arg_SharedProcessorPoolReservedCores             = "pi_shared_processor_pool_reserved_cores"
+	Arg_SharedProcessorPoolID                        = "pi_shared_processor_pool_id"
+	Attr_SharedProcessorPoolID                       = "shared_processor_pool_id"
+	Attr_SharedProcessorPoolName                     = "name"
+	Attr_SharedProcessorPoolReservedCores            = "reserved_cores"
+	Attr_SharedProcessorPoolAvailableCores           = "available_cores"
+	Attr_SharedProcessorPoolAllocatedCores           = "allocated_cores"
+	Attr_SharedProcessorPoolHostID                   = "host_id"
+	Attr_SharedProcessorPoolStatus                   = "status"
+	Attr_SharedProcessorPoolStatusDetail             = "status_detail"
+	Attr_SharedProcessorPoolPlacementGroups          = "spp_placement_groups"
+	Attr_SharedProcessorPoolInstances                = "instances"
+	Attr_SharedProcessorPoolInstanceCpus             = "cpus"
+	Attr_SharedProcessorPoolInstanceUncapped         = "uncapped"
+	Attr_SharedProcessorPoolInstanceAvailabilityZone = "availability_zone"
+	Attr_SharedProcessorPoolInstanceId               = "id"
+	Attr_SharedProcessorPoolInstanceMemory           = "memory"
+	Attr_SharedProcessorPoolInstanceName             = "name"
+	Attr_SharedProcessorPoolInstanceStatus           = "status"
+	Attr_SharedProcessorPoolInstanceVcpus            = "vcpus"
+
+	// SPP Placement Group
+	Arg_SPPPlacementGroupName     = "pi_spp_placement_group_name"
+	Arg_SPPPlacementGroupPolicy   = "pi_spp_placement_group_policy"
+	Attr_SPPPlacementGroupID      = "spp_placement_group_id"
+	Attr_SPPPlacementGroupMembers = "members"
+	Arg_SPPPlacementGroupID       = "pi_spp_placement_group_id"
+	Attr_SPPPlacementGroupPolicy  = "policy"
+	Attr_SPPPlacementGroupName    = "name"
 
 	// status
 	// common status states

--- a/ibm/service/power/resource_ibm_pi_instance.go
+++ b/ibm/service/power/resource_ibm_pi_instance.go
@@ -193,6 +193,17 @@ func ResourceIBMPIInstance() *schema.Resource {
 				Optional:    true,
 				Description: "Placement group ID",
 			},
+			Arg_PIInstanceSharedProcessorPool: {
+				Type:          schema.TypeString,
+				Optional:      true,
+				ConflictsWith: []string{PISAPInstanceProfileID},
+				Description:   "Shared Processor Pool the instance is deployed on",
+			},
+			Attr_PIInstanceSharedProcessorPoolID: {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "Shared Processor Pool ID the instance is deployed on",
+			},
 			"health_status": {
 				Type:        schema.TypeString,
 				Computed:    true,
@@ -440,6 +451,8 @@ func resourceIBMPIInstanceRead(ctx context.Context, d *schema.ResourceData, meta
 	if *powervmdata.PlacementGroup != "none" {
 		d.Set(helpers.PIPlacementGroupID, powervmdata.PlacementGroup)
 	}
+	d.Set(Arg_PIInstanceSharedProcessorPool, powervmdata.SharedProcessorPool)
+	d.Set(Attr_PIInstanceSharedProcessorPoolID, powervmdata.SharedProcessorPoolID)
 
 	networksMap := []map[string]interface{}{}
 	if powervmdata.Networks != nil {
@@ -1002,6 +1015,7 @@ func checkCloudInstanceCapability(cloudInstance *models.CloudInstance, custom_ca
 	}
 	return false
 }
+
 func createSAPInstance(d *schema.ResourceData, sapClient *st.IBMPISAPInstanceClient) (*models.PVMInstanceList, error) {
 
 	name := d.Get(helpers.PIInstanceName).(string)
@@ -1118,6 +1132,7 @@ func createSAPInstance(d *schema.ResourceData, sapClient *st.IBMPISAPInstanceCli
 
 	return pvmList, nil
 }
+
 func createPVMInstance(d *schema.ResourceData, client *st.IBMPIInstanceClient, imageClient *st.IBMPIImageClient) (*models.PVMInstanceList, error) {
 
 	name := d.Get(helpers.PIInstanceName).(string)
@@ -1265,6 +1280,10 @@ func createPVMInstance(d *schema.ResourceData, client *st.IBMPIInstanceClient, i
 
 	if pg, ok := d.GetOk(helpers.PIPlacementGroupID); ok {
 		body.PlacementGroup = pg.(string)
+	}
+
+	if spp, ok := d.GetOk(Arg_PIInstanceSharedProcessorPool); ok {
+		body.SharedProcessorPool = spp.(string)
 	}
 
 	if lrc, ok := d.GetOk(helpers.PIInstanceLicenseRepositoryCapacity); ok {

--- a/ibm/service/power/resource_ibm_pi_instance.go
+++ b/ibm/service/power/resource_ibm_pi_instance.go
@@ -196,6 +196,7 @@ func ResourceIBMPIInstance() *schema.Resource {
 			Arg_PIInstanceSharedProcessorPool: {
 				Type:          schema.TypeString,
 				Optional:      true,
+				ForceNew:      true,
 				ConflictsWith: []string{PISAPInstanceProfileID},
 				Description:   "Shared Processor Pool the instance is deployed on",
 			},

--- a/ibm/service/power/resource_ibm_pi_instance_test.go
+++ b/ibm/service/power/resource_ibm_pi_instance_test.go
@@ -102,6 +102,18 @@ func testAccIBMPIInstanceNetworkConfig(name, privateNetIP string) string {
 		pi_key_name          = "%[2]s"
 		pi_ssh_key           = "ssh-rsa AAAAB3NzaC1yc2EAAAABJQAAAQEArb2aK0mekAdbYdY9rwcmeNSxqVCwez3WZTYEq+1Nwju0x5/vQFPSD2Kp9LpKBbxx3OVLN4VffgGUJznz9DAr7veLkWaf3iwEil6U4rdrhBo32TuDtoBwiczkZ9gn1uJzfIaCJAJdnO80Kv9k0smbQFq5CSb9H+F5VGyFue/iVd5/b30MLYFAz6Jg1GGWgw8yzA4Gq+nO7HtyuA2FnvXdNA3yK/NmrTiPCdJAtEPZkGu9LcelkQ8y90ArlKfjtfzGzYDE4WhOufFxyWxciUePh425J2eZvElnXSdGha+FCfYjQcvqpCVoBAG70U4fJBGjB+HL/GpCXLyiYXPrSnzC9w=="
 	}
+	resource "ibm_pi_network" "power_networks" {
+		pi_cloud_instance_id = "%[1]s"
+		pi_network_name      = "%[2]s"
+		pi_network_type      = "vlan"
+		pi_dns               = ["127.0.0.1"]
+		pi_gateway           = "192.168.17.2"
+		pi_cidr              = "192.168.17.0/24"
+		pi_ipaddress_range {
+			pi_ending_ip_address = "192.168.17.254"
+			pi_starting_ip_address = "192.168.17.3"
+		}
+	}
 	resource "ibm_pi_instance" "power_instance" {
 		pi_memory             = "2"
 		pi_processors         = "0.25"
@@ -113,7 +125,7 @@ func testAccIBMPIInstanceNetworkConfig(name, privateNetIP string) string {
 		pi_storage_type 	  = "tier3"
 		pi_cloud_instance_id  = "%[1]s"
 		pi_network {
-			network_id = "tf-cloudconnection-23"
+			network_id = resource.ibm_pi_network.power_networks.id
 			ip_address = "%[3]s"
 		}
 	}
@@ -140,7 +152,7 @@ func testAccIBMPIInstanceVTLConfig(name string) string {
 		pi_instance_name      = "%[2]s"
 		pi_license_repository_capacity = "3"
 		pi_proc_type          = "shared"
-		pi_image_id           = "ca4ea55f-b329-4cf5-bdce-d2f38cfc6da3"
+		pi_image_id           = "%[3]s"
 		pi_key_pair_name      = ibm_pi_key.vtl_key.key_id
 		pi_sys_type           = "s922"
 		pi_cloud_instance_id  = "%[1]s"
@@ -150,7 +162,7 @@ func testAccIBMPIInstanceVTLConfig(name string) string {
 		}
 	  }
 	
-	`, acc.Pi_cloud_instance_id, name)
+	`, acc.Pi_cloud_instance_id, name, acc.Pi_image)
 }
 
 func testAccCheckIBMPIInstanceDestroy(s *terraform.State) error {
@@ -247,7 +259,7 @@ func TestAccIBMPIInstanceDeploymentType(t *testing.T) {
 func TestAccIBMPIInstanceNetwork(t *testing.T) {
 	instanceRes := "ibm_pi_instance.power_instance"
 	name := fmt.Sprintf("tf-pi-instance-%d", acctest.RandIntRange(10, 100))
-	privateNetIP := "192.112.111.220"
+	privateNetIP := "192.168.17.253"
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { acc.TestAccPreCheck(t) },
@@ -327,14 +339,14 @@ func testAccIBMPISAPInstanceConfig(name, sapProfile string) string {
 		pi_cloud_instance_id  	= "%[1]s"
 		pi_instance_name      	= "%[2]s"
 		pi_sap_profile_id       = "%[3]s"
-		pi_image_id           	= "ef9a2f2e-6b36-48cb-aa06-223040ddb9d2"
+		pi_image_id           	= "%[4]s"
 		pi_storage_type			= "tier1"
 		pi_network {
 			network_id = ibm_pi_network.power_network.network_id
 		}
 		pi_health_status		= "OK"
 	}
-	`, acc.Pi_cloud_instance_id, name, sapProfile)
+	`, acc.Pi_cloud_instance_id, name, sapProfile, acc.Pi_sap_image)
 }
 
 func TestAccIBMPIInstanceMixedStorage(t *testing.T) {

--- a/ibm/service/power/resource_ibm_pi_network.go
+++ b/ibm/service/power/resource_ibm_pi_network.go
@@ -58,6 +58,7 @@ func ResourceIBMPINetwork() *schema.Resource {
 			helpers.PINetworkDNS: {
 				Type:        schema.TypeSet,
 				Optional:    true,
+				Computed:    true,
 				Elem:        &schema.Schema{Type: schema.TypeString},
 				Description: "List of PI network DNS name",
 			},

--- a/ibm/service/power/resource_ibm_pi_shared_processor_pool.go
+++ b/ibm/service/power/resource_ibm_pi_shared_processor_pool.go
@@ -1,0 +1,440 @@
+// Copyright IBM Corp. 2022 All Rights Reserved.
+// Licensed under the Mozilla Public License v2.0
+
+package power
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"strings"
+	"time"
+
+	st "github.com/IBM-Cloud/power-go-client/clients/instance"
+	"github.com/IBM-Cloud/power-go-client/helpers"
+	models "github.com/IBM-Cloud/power-go-client/power/models"
+	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/conns"
+	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/flex"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+func ResourceIBMPISharedProcessorPool() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceIBMPISharedProcessorPoolCreate,
+		ReadContext:   resourceIBMPISharedProcessorPoolRead,
+		UpdateContext: resourceIBMPISharedProcessorPoolUpdate,
+		DeleteContext: resourceIBMPISharedProcessorPoolDelete,
+		Importer:      &schema.ResourceImporter{},
+
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(60 * time.Minute),
+			Update: schema.DefaultTimeout(60 * time.Minute),
+			Delete: schema.DefaultTimeout(60 * time.Minute),
+		},
+
+		Schema: map[string]*schema.Schema{
+
+			// Required Arguments
+			Arg_SharedProcessorPoolName: {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "Name of the shared processor pool",
+			},
+
+			Arg_SharedProcessorPoolHostGroup: {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "Host group of the shared processor pool",
+			},
+
+			Arg_SharedProcessorPoolReservedCores: {
+				Type:        schema.TypeInt,
+				Required:    true,
+				Description: "The amount of reserved cores for the shared processor pool",
+			},
+
+			Arg_CloudInstanceID: {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "PI cloud instance ID",
+			},
+
+			// Optional Arguments
+			Arg_SharedProcessorPoolPlacementGroupID: {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "Placement group the shared processor pool is created in",
+			},
+
+			// Attributes
+			Attr_SharedProcessorPoolID: {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "Shared processor pool ID",
+			},
+
+			Attr_SharedProcessorPoolAvailableCores: {
+				Type:        schema.TypeInt,
+				Computed:    true,
+				Description: "Shared processor pool available cores",
+			},
+
+			Attr_SharedProcessorPoolAllocatedCores: {
+				Type:        schema.TypeFloat,
+				Computed:    true,
+				Description: "Shared processor pool allocated cores",
+			},
+
+			Attr_SharedProcessorPoolHostID: {
+				Type:        schema.TypeInt,
+				Computed:    true,
+				Description: "The host ID where the shared processor pool resides",
+			},
+
+			Attr_SharedProcessorPoolStatus: {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The status of the shared processor pool",
+			},
+
+			Attr_SharedProcessorPoolStatusDetail: {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The status details of the shared processor pool",
+			},
+
+			Attr_SharedProcessorPoolPlacementGroups: {
+				Type:        schema.TypeList,
+				Optional:    true,
+				Elem:        &schema.Schema{Type: schema.TypeString},
+				Description: "SPP placement groups the shared processor pool are in",
+			},
+
+			Attr_SharedProcessorPoolInstances: {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Description: "List of server instances deployed in the shared processor pool",
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						Attr_SharedProcessorPoolInstanceCpus: {
+							Type:        schema.TypeInt,
+							Optional:    true,
+							Computed:    true,
+							Description: "The amount of cpus for the server instance",
+						},
+						Attr_SharedProcessorPoolInstanceUncapped: {
+							Type:        schema.TypeBool,
+							Optional:    true,
+							Computed:    true,
+							Description: "Identifies if uncapped or not",
+						},
+						Attr_SharedProcessorPoolInstanceAvailabilityZone: {
+							Type:        schema.TypeString,
+							Optional:    true,
+							Computed:    true,
+							Description: "Availability zone for the server instances",
+						},
+						Attr_SharedProcessorPoolInstanceId: {
+							Type:        schema.TypeString,
+							Optional:    true,
+							Computed:    true,
+							Description: "The server instance ID",
+						},
+						Attr_SharedProcessorPoolInstanceMemory: {
+							Type:        schema.TypeInt,
+							Optional:    true,
+							Computed:    true,
+							Description: "The amount of memory for the server instance",
+						},
+						Attr_SharedProcessorPoolInstanceName: {
+							Type:        schema.TypeString,
+							Optional:    true,
+							Computed:    true,
+							Description: "The server instance name",
+						},
+						Attr_SharedProcessorPoolInstanceStatus: {
+							Type:        schema.TypeString,
+							Optional:    true,
+							Computed:    true,
+							Description: "Status of the server",
+						},
+						Attr_SharedProcessorPoolInstanceVcpus: {
+							Type:        schema.TypeFloat,
+							Optional:    true,
+							Computed:    true,
+							Description: "The amout of vcpus for the server instance",
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func resourceIBMPISharedProcessorPoolCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	sess, err := meta.(conns.ClientSession).IBMPISession()
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	cloudInstanceID := d.Get(helpers.PICloudInstanceId).(string)
+	name := d.Get(Arg_SharedProcessorPoolName).(string)
+	hostGroup := d.Get(Arg_SharedProcessorPoolHostGroup).(string)
+	reservedCores := d.Get(Arg_SharedProcessorPoolReservedCores).(int)
+	cores := int64(reservedCores)
+	client := st.NewIBMPISharedProcessorPoolClient(ctx, sess, cloudInstanceID)
+	body := &models.SharedProcessorPoolCreate{
+		Name:          &name,
+		HostGroup:     &hostGroup,
+		ReservedCores: &cores,
+	}
+
+	if pg, ok := d.GetOk(Arg_SharedProcessorPoolPlacementGroupID); ok {
+		body.PlacementGroupID = pg.(string)
+	}
+
+	spp, err := client.Create(body)
+	if err != nil || spp == nil {
+		return diag.FromErr(fmt.Errorf("error creating the shared processor pool: %s", err))
+	}
+
+	var sharedProcessorPoolReadyStatus string
+	if r, ok := d.GetOk(Attr_SharedProcessorPoolInstanceStatus); ok {
+		sharedProcessorPoolReadyStatus = r.(string)
+	}
+	d.SetId(fmt.Sprintf("%s/%s", cloudInstanceID, *spp.ID))
+
+	if sharedProcessorPoolReadyStatus != "active" {
+		_, err = isWaitForPISharedProcessorPoolAvailable(ctx, client, *spp.ID, sharedProcessorPoolReadyStatus)
+		if err != nil {
+			return diag.FromErr(err)
+		}
+	}
+
+	log.Printf("Printing the shared processor pool %+v", &spp)
+
+	return resourceIBMPISharedProcessorPoolRead(ctx, d, meta)
+
+}
+
+func isWaitForPISharedProcessorPoolAvailable(ctx context.Context, client *st.IBMPISharedProcessorPoolClient, id string, sharedProcessorPoolReadyStatus string) (interface{}, error) {
+	log.Printf("Waiting for PISharedProcessorPool (%s) to be active ", id)
+
+	stateConf := &resource.StateChangeConf{
+		Pending:    []string{"configuring"},
+		Target:     []string{"active", "error", ""},
+		Refresh:    isPISharedProcessorPoolRefreshFunc(client, id, sharedProcessorPoolReadyStatus),
+		Delay:      20 * time.Second,
+		MinTimeout: activeTimeOut,
+		Timeout:    120 * time.Minute,
+	}
+
+	return stateConf.WaitForStateContext(ctx)
+}
+
+func isPISharedProcessorPoolRefreshFunc(client *st.IBMPISharedProcessorPoolClient, id, sharedProcessorPoolReadyStatus string) resource.StateRefreshFunc {
+	return func() (interface{}, string, error) {
+
+		pool, err := client.Get(id)
+		if err != nil {
+			return nil, "", err
+		}
+		// Check for `sharedProcessorPoolReadyStatus` status
+		if pool.SharedProcessorPool.Status == "active" {
+			return pool, "active", nil
+		}
+		if pool.SharedProcessorPool.Status == "failed" {
+			err = fmt.Errorf("failed to create the shared processor pool")
+			return pool, pool.SharedProcessorPool.Status, err
+		}
+
+		return pool, "configuring", nil
+	}
+}
+
+func resourceIBMPISharedProcessorPoolRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+
+	sess, err := meta.(conns.ClientSession).IBMPISession()
+	if err != nil {
+		return diag.FromErr(err)
+	}
+	parts, err := flex.IdParts(d.Id())
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	cloudInstanceID := parts[0]
+	client := st.NewIBMPISharedProcessorPoolClient(ctx, sess, cloudInstanceID)
+
+	response, err := client.Get(parts[1])
+	if err != nil || response == nil {
+		return diag.FromErr(fmt.Errorf("error reading the shared processor pool: %s", err))
+	}
+
+	if response.SharedProcessorPool.Name != nil {
+		d.Set(Arg_SharedProcessorPoolName, response.SharedProcessorPool.Name)
+	}
+	if response.SharedProcessorPool.ID != nil {
+		d.Set(Attr_SharedProcessorPoolID, response.SharedProcessorPool.ID)
+	}
+	if response.SharedProcessorPool.ReservedCores != nil {
+		d.Set(Arg_SharedProcessorPoolReservedCores, response.SharedProcessorPool.ReservedCores)
+	}
+	if response.SharedProcessorPool.AllocatedCores != nil {
+		d.Set(Attr_SharedProcessorPoolAllocatedCores, response.SharedProcessorPool.AllocatedCores)
+	}
+	if response.SharedProcessorPool.AvailableCores != nil {
+		d.Set(Attr_SharedProcessorPoolAvailableCores, response.SharedProcessorPool.AvailableCores)
+	}
+	if response.SharedProcessorPool.AvailableCores != nil {
+		d.Set(Attr_SharedProcessorPoolAvailableCores, response.SharedProcessorPool.AvailableCores)
+	}
+	if response.SharedProcessorPool.SharedProcessorPoolPlacementGroups != nil {
+		pgIDs := make([]string, len(response.SharedProcessorPool.SharedProcessorPoolPlacementGroups))
+		for i, pg := range response.SharedProcessorPool.SharedProcessorPoolPlacementGroups {
+			pgIDs[i] = *pg.ID
+		}
+		d.Set(Attr_SharedProcessorPoolPlacementGroups, pgIDs)
+	}
+	d.Set(Attr_SharedProcessorPoolHostID, response.SharedProcessorPool.HostID)
+	d.Set(Attr_SharedProcessorPoolStatus, response.SharedProcessorPool.Status)
+	d.Set(Attr_SharedProcessorPoolStatusDetail, response.SharedProcessorPool.StatusDetail)
+
+	serversMap := []map[string]interface{}{}
+	if response.Servers != nil {
+		for _, s := range response.Servers {
+			if s != nil {
+				v := map[string]interface{}{
+					Attr_SharedProcessorPoolInstanceCpus:             s.Cpus,
+					Attr_SharedProcessorPoolInstanceUncapped:         s.Uncapped,
+					Attr_SharedProcessorPoolInstanceAvailabilityZone: s.AvailabilityZone,
+					Attr_SharedProcessorPoolInstanceId:               s.ID,
+					Attr_SharedProcessorPoolInstanceMemory:           s.Memory,
+					Attr_SharedProcessorPoolInstanceName:             s.Name,
+					Attr_SharedProcessorPoolInstanceStatus:           s.Status,
+					Attr_SharedProcessorPoolInstanceVcpus:            s.Vcpus,
+				}
+				serversMap = append(serversMap, v)
+			}
+		}
+	}
+	d.Set(Attr_SharedProcessorPoolInstances, serversMap)
+
+	return nil
+}
+
+func resourceIBMPISharedProcessorPoolUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	sess, err := meta.(conns.ClientSession).IBMPISession()
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	cloudInstanceID, sppID, err := splitID(d.Id())
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	client := st.NewIBMPISharedProcessorPoolClient(ctx, sess, cloudInstanceID)
+	body := &models.SharedProcessorPoolUpdate{}
+
+	if d.HasChange(Arg_SharedProcessorPoolName) {
+		name := d.Get(Arg_SharedProcessorPoolName).(string)
+		body.Name = name
+	}
+	if d.HasChange(Arg_SharedProcessorPoolReservedCores) {
+		reservedCores := int64(d.Get(Arg_SharedProcessorPoolReservedCores).(int))
+		body.ReservedCores = reservedCores
+	}
+
+	_, err = client.Update(sppID, body)
+	if err != nil {
+		return diag.FromErr(fmt.Errorf("error updating the shared processor pool: %s", err))
+	}
+
+	if d.HasChange(Attr_SharedProcessorPoolPlacementGroups) {
+
+		pgClient := st.NewIBMPISPPPlacementGroupClient(ctx, sess, cloudInstanceID)
+
+		oldRaw, newRaw := d.GetChange(Attr_SharedProcessorPoolPlacementGroups)
+		old := oldRaw.([]interface{})
+		new := newRaw.([]interface{})
+
+		var oldPGs []string
+		for _, o := range old {
+			oldPGs = append(oldPGs, o.(string))
+		}
+		var newPGs []string
+		for _, n := range new {
+			newPGs = append(newPGs, n.(string))
+		}
+		// find removed pgs and remove them
+		pgsToRemove := getDifferences(oldPGs, newPGs)
+
+		for _, pgToRemove := range pgsToRemove {
+			if len(strings.TrimSpace(pgToRemove)) > 0 {
+				placementGroupID := pgToRemove
+				//remove spp from old placement group
+				_, err := pgClient.DeleteMember(placementGroupID, sppID)
+				if err != nil {
+					// ignore delete member error where the spp is already not in the PG
+					if !strings.Contains(err.Error(), "is not part of spp placement group") {
+						return diag.FromErr(err)
+					}
+				}
+			}
+		}
+
+		// find added pgs and then add them
+		pgsToAdd := getDifferences(newPGs, oldPGs)
+
+		for _, pgToAdd := range pgsToAdd {
+			if len(strings.TrimSpace(pgToAdd)) > 0 {
+				placementGroupID := pgToAdd
+				// add spp to a new placement group
+				_, err := pgClient.AddMember(placementGroupID, sppID)
+				if err != nil {
+					return diag.FromErr(err)
+				}
+			}
+		}
+	}
+
+	return resourceIBMPISharedProcessorPoolRead(ctx, d, meta)
+}
+
+// returns the elements in string array a that are not in array z
+func getDifferences(a, z []string) []string {
+	mb := make(map[string]struct{}, len(z))
+	for _, x := range z {
+		mb[x] = struct{}{}
+	}
+	var diff []string
+	for _, x := range a {
+		if _, found := mb[x]; !found {
+			diff = append(diff, x)
+		}
+	}
+	return diff
+}
+
+func resourceIBMPISharedProcessorPoolDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	sess, err := meta.(conns.ClientSession).IBMPISession()
+	if err != nil {
+		return diag.FromErr(err)
+	}
+	parts, err := flex.IdParts(d.Id())
+	if err != nil {
+		return diag.FromErr(err)
+	}
+	cloudInstanceID := parts[0]
+	client := st.NewIBMPISharedProcessorPoolClient(ctx, sess, cloudInstanceID)
+	err = client.Delete(parts[1])
+
+	if err != nil {
+		return diag.FromErr(fmt.Errorf("error deleting the shared processor pool: %s", err))
+	}
+	d.SetId("")
+	return nil
+}

--- a/ibm/service/power/resource_ibm_pi_shared_processor_pool.go
+++ b/ibm/service/power/resource_ibm_pi_shared_processor_pool.go
@@ -197,7 +197,7 @@ func resourceIBMPISharedProcessorPoolCreate(ctx context.Context, d *schema.Resou
 
 	spp, err := client.Create(body)
 	if err != nil || spp == nil {
-		return diag.FromErr(fmt.Errorf("error creating the shared processor pool: %s", err))
+		return diag.Errorf("error creating the shared processor pool: %v", err)
 	}
 
 	var sharedProcessorPoolReadyStatus string
@@ -270,7 +270,7 @@ func resourceIBMPISharedProcessorPoolRead(ctx context.Context, d *schema.Resourc
 
 	response, err := client.Get(parts[1])
 	if err != nil || response == nil {
-		return diag.FromErr(fmt.Errorf("error reading the shared processor pool: %s", err))
+		return diag.Errorf("error reading the shared processor pool: %v", err)
 	}
 
 	if response.SharedProcessorPool.Name != nil {
@@ -350,7 +350,7 @@ func resourceIBMPISharedProcessorPoolUpdate(ctx context.Context, d *schema.Resou
 
 	_, err = client.Update(sppID, body)
 	if err != nil {
-		return diag.FromErr(fmt.Errorf("error updating the shared processor pool: %s", err))
+		return diag.Errorf("error updating the shared processor pool: %v", err)
 	}
 
 	if d.HasChange(Attr_SharedProcessorPoolPlacementGroups) {
@@ -433,7 +433,7 @@ func resourceIBMPISharedProcessorPoolDelete(ctx context.Context, d *schema.Resou
 	err = client.Delete(parts[1])
 
 	if err != nil {
-		return diag.FromErr(fmt.Errorf("error deleting the shared processor pool: %s", err))
+		return diag.Errorf("error deleting the shared processor pool: %v", err)
 	}
 	d.SetId("")
 	return nil

--- a/ibm/service/power/resource_ibm_pi_spp_placement_group.go
+++ b/ibm/service/power/resource_ibm_pi_spp_placement_group.go
@@ -114,6 +114,7 @@ func resourceIBMPISPPPlacementGroupRead(ctx context.Context, d *schema.ResourceD
 		return diag.Errorf("error reading the spp placement group: %v", err)
 	}
 
+	d.Set(Arg_CloudInstanceID, cloudInstanceID)
 	d.Set(Arg_SPPPlacementGroupName, response.Name)
 	d.Set(Attr_SPPPlacementGroupID, response.ID)
 	d.Set(Arg_SPPPlacementGroupPolicy, response.Policy)

--- a/ibm/service/power/resource_ibm_pi_spp_placement_group.go
+++ b/ibm/service/power/resource_ibm_pi_spp_placement_group.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2021 All Rights Reserved.
+// Copyright IBM Corp. 2022 All Rights Reserved.
 // Licensed under the Mozilla Public License v2.0
 
 package power
@@ -6,7 +6,6 @@ package power
 import (
 	"context"
 	"fmt"
-	"log"
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -20,84 +19,83 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 )
 
-func ResourceIBMPIPlacementGroup() *schema.Resource {
+func ResourceIBMPISPPPlacementGroup() *schema.Resource {
 	return &schema.Resource{
-		CreateContext: resourceIBMPIPlacementGroupCreate,
-		ReadContext:   resourceIBMPIPlacementGroupRead,
-		UpdateContext: resourceIBMPIPlacementGroupUpdate,
-		DeleteContext: resourceIBMPIPlacementGroupDelete,
+		CreateContext: resourceIBMPISPPPlacementGroupCreate,
+		ReadContext:   resourceIBMPISPPPlacementGroupRead,
+		DeleteContext: resourceIBMPISPPPlacementGroupDelete,
 		Importer:      &schema.ResourceImporter{},
 
 		Timeouts: &schema.ResourceTimeout{
 			Create: schema.DefaultTimeout(60 * time.Minute),
-			Update: schema.DefaultTimeout(60 * time.Minute),
 			Delete: schema.DefaultTimeout(60 * time.Minute),
 		},
 
 		Schema: map[string]*schema.Schema{
 
-			helpers.PIPlacementGroupName: {
+			Arg_SPPPlacementGroupName: {
 				Type:        schema.TypeString,
 				Required:    true,
-				Description: "Name of the placement group",
+				ForceNew:    true,
+				Description: "Name of the SPP placement group",
 			},
 
-			helpers.PIPlacementGroupPolicy: {
+			Arg_SPPPlacementGroupPolicy: {
 				Type:         schema.TypeString,
 				Required:     true,
+				ForceNew:     true,
 				ValidateFunc: validate.ValidateAllowedStringValues([]string{"affinity", "anti-affinity"}),
-				Description:  "Policy of the placement group",
+				Description:  "Policy of the SPP placement group",
 			},
 
 			helpers.PICloudInstanceId: {
 				Type:        schema.TypeString,
 				Required:    true,
+				ForceNew:    true,
 				Description: "PI cloud instance ID",
 			},
 
-			PIPlacementGroupMembers: {
+			Attr_SPPPlacementGroupMembers: {
 				Type:        schema.TypeSet,
 				Computed:    true,
 				Elem:        &schema.Schema{Type: schema.TypeString},
-				Description: "Server IDs that are the placement group members",
+				Description: "Member SPP IDs that are the SPP placement group members",
 			},
 
-			PIPlacementGroupID: {
+			Attr_SPPPlacementGroupID: {
 				Type:        schema.TypeString,
 				Computed:    true,
-				Description: "PI placement group ID",
+				Description: "SPP placement group ID",
 			},
 		},
 	}
 }
 
-func resourceIBMPIPlacementGroupCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceIBMPISPPPlacementGroupCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	sess, err := meta.(conns.ClientSession).IBMPISession()
 	if err != nil {
 		return diag.FromErr(err)
 	}
 
 	cloudInstanceID := d.Get(helpers.PICloudInstanceId).(string)
-	name := d.Get(helpers.PIPlacementGroupName).(string)
-	policy := d.Get(helpers.PIPlacementGroupPolicy).(string)
-	client := st.NewIBMPIPlacementGroupClient(ctx, sess, cloudInstanceID)
-	body := &models.PlacementGroupCreate{
+	name := d.Get(Arg_SPPPlacementGroupName).(string)
+	policy := d.Get(Arg_SPPPlacementGroupPolicy).(string)
+	client := st.NewIBMPISPPPlacementGroupClient(ctx, sess, cloudInstanceID)
+	body := &models.SPPPlacementGroupCreate{
 		Name:   &name,
 		Policy: &policy,
 	}
 
 	response, err := client.Create(body)
 	if err != nil || response == nil {
-		return diag.FromErr(fmt.Errorf("error creating the shared processor pool: %s", err))
+		return diag.FromErr(fmt.Errorf("error creating the spp placement group: %s", err))
 	}
 
-	log.Printf("Printing the placement group %+v", &response)
-
 	d.SetId(fmt.Sprintf("%s/%s", cloudInstanceID, *response.ID))
-	return resourceIBMPIPlacementGroupRead(ctx, d, meta)
+	return resourceIBMPISPPPlacementGroupRead(ctx, d, meta)
 }
 
-func resourceIBMPIPlacementGroupRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceIBMPISPPPlacementGroupRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 
 	sess, err := meta.(conns.ClientSession).IBMPISession()
 	if err != nil {
@@ -109,28 +107,23 @@ func resourceIBMPIPlacementGroupRead(ctx context.Context, d *schema.ResourceData
 	}
 
 	cloudInstanceID := parts[0]
-	client := st.NewIBMPIPlacementGroupClient(ctx, sess, cloudInstanceID)
+	client := st.NewIBMPISPPPlacementGroupClient(ctx, sess, cloudInstanceID)
 
 	response, err := client.Get(parts[1])
-	if err != nil {
-		log.Printf("[DEBUG]  err %s", err)
-		return diag.FromErr(err)
+	if err != nil || response == nil {
+		return diag.FromErr(fmt.Errorf("error reading the spp placement group: %s", err))
 	}
 
-	d.Set(helpers.PIPlacementGroupName, response.Name)
-	d.Set(PIPlacementGroupID, response.ID)
-	d.Set(helpers.PIPlacementGroupPolicy, response.Policy)
-	d.Set(PIPlacementGroupMembers, response.Members)
+	d.Set(Arg_SPPPlacementGroupName, response.Name)
+	d.Set(Attr_SPPPlacementGroupID, response.ID)
+	d.Set(Arg_SPPPlacementGroupPolicy, response.Policy)
+	d.Set(Attr_SPPPlacementGroupMembers, response.MemberSharedProcessorPools)
 
 	return nil
 
 }
 
-func resourceIBMPIPlacementGroupUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	return resourceIBMPIPlacementGroupRead(ctx, d, meta)
-}
-
-func resourceIBMPIPlacementGroupDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceIBMPISPPPlacementGroupDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	sess, err := meta.(conns.ClientSession).IBMPISession()
 	if err != nil {
 		return diag.FromErr(err)
@@ -140,11 +133,11 @@ func resourceIBMPIPlacementGroupDelete(ctx context.Context, d *schema.ResourceDa
 		return diag.FromErr(err)
 	}
 	cloudInstanceID := parts[0]
-	client := st.NewIBMPIPlacementGroupClient(ctx, sess, cloudInstanceID)
+	client := st.NewIBMPISPPPlacementGroupClient(ctx, sess, cloudInstanceID)
 	err = client.Delete(parts[1])
 
 	if err != nil {
-		return diag.FromErr(err)
+		return diag.FromErr(fmt.Errorf("error deleting the spp placement group: %s", err))
 	}
 	d.SetId("")
 	return nil

--- a/ibm/service/power/resource_ibm_pi_spp_placement_group.go
+++ b/ibm/service/power/resource_ibm_pi_spp_placement_group.go
@@ -88,7 +88,7 @@ func resourceIBMPISPPPlacementGroupCreate(ctx context.Context, d *schema.Resourc
 
 	response, err := client.Create(body)
 	if err != nil || response == nil {
-		return diag.FromErr(fmt.Errorf("error creating the spp placement group: %s", err))
+		return diag.Errorf("error creating the spp placement group: %v", err)
 	}
 
 	d.SetId(fmt.Sprintf("%s/%s", cloudInstanceID, *response.ID))
@@ -111,7 +111,7 @@ func resourceIBMPISPPPlacementGroupRead(ctx context.Context, d *schema.ResourceD
 
 	response, err := client.Get(parts[1])
 	if err != nil || response == nil {
-		return diag.FromErr(fmt.Errorf("error reading the spp placement group: %s", err))
+		return diag.Errorf("error reading the spp placement group: %v", err)
 	}
 
 	d.Set(Arg_SPPPlacementGroupName, response.Name)
@@ -137,7 +137,7 @@ func resourceIBMPISPPPlacementGroupDelete(ctx context.Context, d *schema.Resourc
 	err = client.Delete(parts[1])
 
 	if err != nil {
-		return diag.FromErr(fmt.Errorf("error deleting the spp placement group: %s", err))
+		return diag.Errorf("error deleting the spp placement group: %v", err)
 	}
 	d.SetId("")
 	return nil

--- a/ibm/service/power/resource_ibm_pi_spp_placement_group_test.go
+++ b/ibm/service/power/resource_ibm_pi_spp_placement_group_test.go
@@ -1,0 +1,666 @@
+// Copyright IBM Corp. 2022 All Rights Reserved.
+// Licensed under the Mozilla Public License v2.0
+
+package power_test
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	st "github.com/IBM-Cloud/power-go-client/clients/instance"
+	acc "github.com/IBM-Cloud/terraform-provider-ibm/ibm/acctest"
+	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/conns"
+	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/flex"
+)
+
+func TestAccIBMPISPPPlacementGroupBasic(t *testing.T) {
+	name := fmt.Sprintf("tfspp%d", acctest.RandIntRange(10, 100))
+	policy := "affinity"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { acc.TestAccPreCheck(t) },
+		Providers:    acc.TestAccProviders,
+		CheckDestroy: testAccCheckIBMPISPPPlacementGroupDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccCheckIBMPICreateSAPInstanceWithSPP(name, policy, "tinytest-1x4"),
+				ExpectError: regexp.MustCompile("\"pi_shared_processor_pool\": conflicts with pi_sap_profile_id"),
+			},
+			{
+				Config:       testAccCheckIBMPISPPPlacementGroupConfig(name, policy),
+				ResourceName: "ibm_pi_spp_placement_group.spp_placement_group",
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckIBMPISPPPlacementGroupExists("ibm_pi_spp_placement_group.spp_placement_group"),
+					resource.TestCheckResourceAttr(
+						"ibm_pi_spp_placement_group.spp_placement_group", "pi_spp_placement_group_name", name+"pg"),
+					resource.TestCheckResourceAttr(
+						"ibm_pi_spp_placement_group.spp_placement_group", "pi_spp_placement_group_policy", policy),
+				),
+			},
+			{
+				Config: testAccCheckIBMPISPPPlacementGroupAddMemberConfig(name, policy),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet(
+						"ibm_pi_shared_processor_pool.spp_pool", "pi_shared_processor_pool_placement_group_id"),
+					testAccCheckIBMPISPPPlacementGroupMemberExists("ibm_pi_spp_placement_group.spp_placement_group", "ibm_pi_shared_processor_pool.spp_pool"),
+				),
+			},
+			{
+				Config: testAccCheckIBMPISPPPlacementGroupUpdateMemberConfig(name, policy),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet(
+						"ibm_pi_shared_processor_pool.spp_pool", "spp_placement_groups.0"),
+					testAccCheckIBMPISPPPlacementGroupMemberExists("ibm_pi_spp_placement_group.spp_placement_group_another", "ibm_pi_shared_processor_pool.spp_pool"),
+				),
+			},
+			{
+				Config: testAccCheckIBMPISPPPlacementGroupRemoveMemberConfig(name, policy),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckIBMPISPPPlacementGroupMemberDoesNotExist("ibm_pi_spp_placement_group.spp_placement_group", "ibm_pi_shared_processor_pool.spp_pool"),
+				),
+			},
+			{
+				Config: testAccCheckIBMPICreateSPPInPlacementGroup(name, policy),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckNoResourceAttr(
+						"ibm_pi_shared_processor_pool.spp_pool", "spp_placement_groups.0"),
+					resource.TestCheckResourceAttrSet(
+						"ibm_pi_shared_processor_pool.spp_pool_2", "pi_shared_processor_pool_placement_group_id"),
+					testAccCheckIBMPISPPPlacementGroupMemberExistsFromSPPCreate("ibm_pi_spp_placement_group.spp_placement_group", "ibm_pi_shared_processor_pool.spp_pool_2"),
+				),
+			},
+			{
+				Config: testAccCheckIBMPIDeleteSPPPlacementGroup(name, policy),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckIBMPISPPPlacementGroupDelete("ibm_pi_spp_placement_group.spp_placement_group_another", "ibm_pi_shared_processor_pool.spp_pool", "ibm_pi_shared_processor_pool.spp_pool_2"),
+				),
+			},
+			{
+				Config: testAccCheckIBMPICreateInstanceWithSPP(name, policy),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckIBMPIInstanceInSPP("ibm_pi_shared_processor_pool.spp_pool", "ibm_pi_instance.power_instance"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckIBMPISPPPlacementGroupDestroy(s *terraform.State) error {
+
+	sess, err := acc.TestAccProvider.Meta().(conns.ClientSession).IBMPISession()
+	if err != nil {
+		return err
+	}
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "ibm_pi_spp_placement_group" {
+			continue
+		}
+		parts, _ := flex.IdParts(rs.Primary.ID)
+		cloudpoolid := parts[0]
+		placementGroupC := st.NewIBMPISPPPlacementGroupClient(context.Background(), sess, cloudpoolid)
+		_, err = placementGroupC.Get(parts[1])
+		if err == nil {
+			return fmt.Errorf("PI SPP placement group still exists: %s", rs.Primary.ID)
+		}
+	}
+
+	return nil
+}
+func testAccCheckIBMPISPPPlacementGroupExists(n string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+
+		rs, ok := s.RootModule().Resources[n]
+
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return errors.New("No Record ID is set")
+		}
+
+		sess, err := acc.TestAccProvider.Meta().(conns.ClientSession).IBMPISession()
+		if err != nil {
+			return err
+		}
+		parts, err := flex.IdParts(rs.Primary.ID)
+		if err != nil {
+			return err
+		}
+		cloudpoolid := parts[0]
+		client := st.NewIBMPISPPPlacementGroupClient(context.Background(), sess, cloudpoolid)
+
+		placementGroup, err := client.Get(parts[1])
+		if err != nil {
+			return err
+		}
+		parts[1] = *placementGroup.ID
+		return nil
+	}
+}
+
+func testAccCheckIBMPISPPPlacementGroupMemberExists(sppPG string, pool string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+
+		pgResource, ok := s.RootModule().Resources[sppPG]
+
+		if !ok {
+			return fmt.Errorf("Not found: %s", sppPG)
+		}
+
+		if pgResource.Primary.ID == "" {
+			return errors.New("No Record ID is set")
+		}
+
+		// refresh placement group info since a spp should be in the placement group
+		sess, err := acc.TestAccProvider.Meta().(conns.ClientSession).IBMPISession()
+		if err != nil {
+			return err
+		}
+		parts, err := flex.IdParts(pgResource.Primary.ID)
+		if err != nil {
+			return err
+		}
+		cloudpoolid := parts[0]
+		client := st.NewIBMPISPPPlacementGroupClient(context.Background(), sess, cloudpoolid)
+
+		pg, err := client.Get(parts[1])
+		if err != nil {
+			return err
+		}
+
+		poolResource, ok := s.RootModule().Resources[pool]
+		if !ok {
+			return fmt.Errorf("Not found: %s", pool)
+		}
+		poolName := poolResource.Primary.Attributes["pi_shared_processor_pool_name"]
+
+		var isPoolFound bool = false
+		for _, x := range pg.MemberSharedProcessorPools {
+			if x == poolName {
+				isPoolFound = true
+				break
+			}
+		}
+		if !isPoolFound {
+			return fmt.Errorf("Expected pool ID %s in the PG members field but found %s", poolName, strings.Join(pg.MemberSharedProcessorPools[:], ","))
+		}
+		return nil
+	}
+}
+
+func testAccCheckIBMPISPPPlacementGroupMemberDoesNotExist(n string, pool string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+
+		rs, ok := s.RootModule().Resources[n]
+
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return errors.New("No Record ID is set")
+		}
+
+		// refresh placement group info since a server should be in the placement group
+		sess, err := acc.TestAccProvider.Meta().(conns.ClientSession).IBMPISession()
+		if err != nil {
+			return err
+		}
+		parts, err := flex.IdParts(rs.Primary.ID)
+		if err != nil {
+			return err
+		}
+		cloudpoolid := parts[0]
+		client := st.NewIBMPISPPPlacementGroupClient(context.Background(), sess, cloudpoolid)
+
+		pg, err := client.Get(parts[1])
+		if err != nil {
+			return err
+		}
+
+		poolrs, ok := s.RootModule().Resources[pool]
+		if !ok {
+			return fmt.Errorf("Not found: %s", pool)
+		}
+		instanccParts, err := flex.IdParts(poolrs.Primary.ID)
+		if err != nil {
+			return err
+		}
+		if len(pg.MemberSharedProcessorPools) > 0 {
+			return fmt.Errorf("Expected pool ID %s to be removed so that the PG members field is empty but foumd %s", instanccParts[1], pg.MemberSharedProcessorPools[0])
+		}
+
+		return nil
+	}
+}
+
+func containsMemberPool(s []string, str string) bool {
+	for _, v := range s {
+		if v == str {
+			return true
+		}
+	}
+
+	return false
+}
+
+func testAccCheckIBMPISPPPlacementGroupMemberExistsFromSPPCreate(n string, pool string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+
+		rs, ok := s.RootModule().Resources[n]
+
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return errors.New("No Record ID is set")
+		}
+
+		// refresh placement group info since a pool should be in the placement group
+		sess, err := acc.TestAccProvider.Meta().(conns.ClientSession).IBMPISession()
+		if err != nil {
+			return err
+		}
+		parts, err := flex.IdParts(rs.Primary.ID)
+		if err != nil {
+			return err
+		}
+		cloudpoolid := parts[0]
+		client := st.NewIBMPISPPPlacementGroupClient(context.Background(), sess, cloudpoolid)
+
+		pg, err := client.Get(parts[1])
+		if err != nil {
+			return err
+		}
+
+		poolrs, ok := s.RootModule().Resources[pool]
+		if !ok {
+			return fmt.Errorf("Not found: %s", pool)
+		}
+		poolName := poolrs.Primary.Attributes["pi_shared_processor_pool_name"]
+
+		if !containsMemberPool(pg.MemberSharedProcessorPools, poolName) {
+			return fmt.Errorf("Expected pool %s in the PG members field", poolName)
+		}
+		return nil
+	}
+}
+
+func testAccCheckIBMPISPPPlacementGroupDelete(n string, pool string, newPool string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		sess, err := acc.TestAccProvider.Meta().(conns.ClientSession).IBMPISession()
+		if err != nil {
+			return err
+		}
+
+		poolrs, ok := s.RootModule().Resources[pool]
+		if !ok {
+			return fmt.Errorf("Not found: %s", pool)
+		}
+		poolParts, err := flex.IdParts(poolrs.Primary.ID)
+		if err != nil {
+			return err
+		}
+
+		newpoolrs, ok := s.RootModule().Resources[newPool]
+		if !ok {
+			return fmt.Errorf("Not found: %s", newPool)
+		}
+		newpoolParts, err := flex.IdParts(newpoolrs.Primary.ID)
+		if err != nil {
+			return err
+		}
+		cloudpoolid := poolParts[0]
+		spp_client := st.NewIBMPISharedProcessorPoolClient(context.Background(), sess, cloudpoolid)
+
+		pool, err := spp_client.Get(poolParts[1])
+		if err != nil {
+			return err
+		}
+
+		if len(pool.SharedProcessorPool.SharedProcessorPoolPlacementGroups) > 0 {
+			return fmt.Errorf("Expected no spp placement group ID in the spp placement groups array but found %s", *pool.SharedProcessorPool.SharedProcessorPoolPlacementGroups[0].ID)
+		}
+		newpool, err := spp_client.Get(newpoolParts[1])
+		if err != nil {
+			return err
+		}
+		if len(newpool.SharedProcessorPool.SharedProcessorPoolPlacementGroups) > 0 {
+			return fmt.Errorf("Expected no spp placement group ID in the spp placement groups array but found %s", *newpool.SharedProcessorPool.SharedProcessorPoolPlacementGroups[0].ID)
+		}
+		return nil
+	}
+}
+
+func testAccCheckIBMPIInstanceInSPP(spp string, instance string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+
+		sppResource, ok := s.RootModule().Resources[spp]
+
+		if !ok {
+			return fmt.Errorf("Not found: %s", spp)
+		}
+
+		if sppResource.Primary.ID == "" {
+			return errors.New("No Record ID is set")
+		}
+
+		// refresh shared processor pool info since a instance should be in the spp
+		sess, err := acc.TestAccProvider.Meta().(conns.ClientSession).IBMPISession()
+		if err != nil {
+			return err
+		}
+		parts, err := flex.IdParts(sppResource.Primary.ID)
+		if err != nil {
+			return err
+		}
+		cloudpoolid := parts[0]
+		client := st.NewIBMPISharedProcessorPoolClient(context.Background(), sess, cloudpoolid)
+
+		sppFromSB, err := client.Get(parts[1])
+		if err != nil {
+			return err
+		}
+
+		instanceResource, ok := s.RootModule().Resources[instance]
+		if !ok {
+			return fmt.Errorf("Instance not found: %s", instance)
+		}
+		instanceName := instanceResource.Primary.Attributes["pi_instance_name"]
+
+		var isInstanceFoundInSPPServersList bool = false
+		for _, s := range sppFromSB.Servers {
+			if s.Name == instanceName {
+				isInstanceFoundInSPPServersList = true
+				break
+			}
+		}
+		if !isInstanceFoundInSPPServersList {
+			return fmt.Errorf("Expected instance name %s in the SPP servers object but found %v", instanceName, sppFromSB.Servers)
+		}
+		return nil
+	}
+}
+
+func testAccCheckIBMPISPPPlacementGroupConfig(name string, policy string) string {
+	return fmt.Sprintf(`
+		resource "ibm_pi_shared_processor_pool" "spp_pool" {
+			pi_cloud_instance_id  = "%[1]s"
+			pi_shared_processor_pool_name = "%[2]s"
+			pi_shared_processor_pool_host_group       = "s922"
+			pi_shared_processor_pool_reserved_cores = "2"
+		}
+		resource "ibm_pi_spp_placement_group" "spp_placement_group" {
+			pi_cloud_instance_id      = "%[1]s"
+			pi_spp_placement_group_name   = "%[2]spg"
+			pi_spp_placement_group_policy = "%[3]s"
+		}
+	`, acc.Pi_cloud_instance_id, name, policy)
+}
+
+func testAccCheckIBMPISPPPlacementGroupAddMemberConfig(name string, policy string) string {
+	return fmt.Sprintf(`
+		resource "ibm_pi_shared_processor_pool" "spp_pool" {
+			pi_cloud_instance_id  = "%[1]s"
+			pi_shared_processor_pool_name = "%[2]s"
+			pi_shared_processor_pool_host_group       = "s922"
+			pi_shared_processor_pool_reserved_cores = "2"
+			pi_shared_processor_pool_placement_group_id = ibm_pi_spp_placement_group.spp_placement_group.spp_placement_group_id
+			spp_placement_groups = [ibm_pi_spp_placement_group.spp_placement_group.spp_placement_group_id]
+		}
+		resource "ibm_pi_spp_placement_group" "spp_placement_group" {
+			pi_cloud_instance_id      = "%[1]s"
+			pi_spp_placement_group_name   = "%[2]spg"
+			pi_spp_placement_group_policy = "%[3]s"
+		}
+	`, acc.Pi_cloud_instance_id, name, policy)
+}
+
+func testAccCheckIBMPISPPPlacementGroupUpdateMemberConfig(name string, policy string) string {
+	return fmt.Sprintf(`
+		resource "ibm_pi_shared_processor_pool" "spp_pool" {
+			pi_cloud_instance_id  = "%[1]s"
+			pi_shared_processor_pool_name = "%[2]s"
+			pi_shared_processor_pool_host_group       = "s922"
+			pi_shared_processor_pool_reserved_cores = "2"
+			spp_placement_groups = [ibm_pi_spp_placement_group.spp_placement_group_another.spp_placement_group_id]
+		}
+		resource "ibm_pi_spp_placement_group" "spp_placement_group" {
+			pi_cloud_instance_id      = "%[1]s"
+			pi_spp_placement_group_name   = "%[2]spg"
+			pi_spp_placement_group_policy = "%[3]s"
+		}
+		resource "ibm_pi_spp_placement_group" "spp_placement_group_another" {
+			pi_cloud_instance_id      = "%[1]s"
+			pi_spp_placement_group_name   = "%[2]s2pg"
+			pi_spp_placement_group_policy = "%[3]s"
+		}
+	`, acc.Pi_cloud_instance_id, name, policy)
+}
+
+func testAccCheckIBMPISPPPlacementGroupRemoveMemberConfig(name string, policy string) string {
+	return fmt.Sprintf(`
+		resource "ibm_pi_shared_processor_pool" "spp_pool" {
+			pi_cloud_instance_id  = "%[1]s"
+			pi_shared_processor_pool_name = "%[2]s"
+			pi_shared_processor_pool_host_group       = "s922"
+			pi_shared_processor_pool_reserved_cores = "2"
+			spp_placement_groups = []
+		}
+		resource "ibm_pi_spp_placement_group" "spp_placement_group" {
+			pi_cloud_instance_id      = "%[1]s"
+			pi_spp_placement_group_name   = "%[2]spg"
+			pi_spp_placement_group_policy = "%[3]s"
+		}
+		resource "ibm_pi_spp_placement_group" "spp_placement_group_another" {
+			pi_cloud_instance_id      = "%[1]s"
+			pi_spp_placement_group_name   = "%[2]s2pg"
+			pi_spp_placement_group_policy = "%[3]s"
+		}
+	`, acc.Pi_cloud_instance_id, name, policy)
+}
+
+func testAccCheckIBMPICreateSPPInPlacementGroup(name string, policy string) string {
+	return fmt.Sprintf(`
+		resource "ibm_pi_shared_processor_pool" "spp_pool" {
+			pi_cloud_instance_id  = "%[1]s"
+			pi_shared_processor_pool_name = "%[2]s"
+			pi_shared_processor_pool_host_group       = "s922"
+			pi_shared_processor_pool_reserved_cores = "2"
+			spp_placement_groups = []
+		}
+		resource "ibm_pi_shared_processor_pool" "spp_pool_2" {
+			pi_cloud_instance_id  = "%[1]s"
+			pi_shared_processor_pool_name = "%[2]s2"
+			pi_shared_processor_pool_host_group       = "e980"
+			pi_shared_processor_pool_reserved_cores = "1"
+			pi_shared_processor_pool_placement_group_id = ibm_pi_spp_placement_group.spp_placement_group.spp_placement_group_id
+			spp_placement_groups = [ibm_pi_spp_placement_group.spp_placement_group.spp_placement_group_id]
+		}
+		resource "ibm_pi_spp_placement_group" "spp_placement_group" {
+			pi_cloud_instance_id      = "%[1]s"
+			pi_spp_placement_group_name   = "%[2]spg"
+			pi_spp_placement_group_policy = "%[3]s"
+		}
+		resource "ibm_pi_spp_placement_group" "spp_placement_group_another" {
+			pi_cloud_instance_id      = "%[1]s"
+			pi_spp_placement_group_name   = "%[2]s2pg"
+			pi_spp_placement_group_policy = "%[3]s"
+		}
+	`, acc.Pi_cloud_instance_id, name, policy)
+}
+
+func testAccCheckIBMPIDeleteSPPPlacementGroup(name string, policy string) string {
+	return fmt.Sprintf(`
+		resource "ibm_pi_shared_processor_pool" "spp_pool" {
+			pi_cloud_instance_id  = "%[1]s"
+			pi_shared_processor_pool_name = "%[2]s"
+			pi_shared_processor_pool_host_group       = "s922"
+			pi_shared_processor_pool_reserved_cores = "2"
+		}
+		resource "ibm_pi_shared_processor_pool" "spp_pool_2" {
+			pi_cloud_instance_id  = "%[1]s"
+			pi_shared_processor_pool_name = "%[2]s2"
+			pi_shared_processor_pool_host_group       = "e980"
+			pi_shared_processor_pool_reserved_cores = "1"
+		}
+		resource "ibm_pi_spp_placement_group" "spp_placement_group" {
+			pi_cloud_instance_id      = "%[1]s"
+			pi_spp_placement_group_name   = "%[2]spg"
+			pi_spp_placement_group_policy = "%[3]s"
+		}
+		resource "ibm_pi_spp_placement_group" "spp_placement_group_another" {
+			pi_cloud_instance_id      = "%[1]s"
+			pi_spp_placement_group_name   = "%[2]s2pg"
+			pi_spp_placement_group_policy = "%[3]s"
+		}
+	`, acc.Pi_cloud_instance_id, name, policy)
+}
+
+func testAccCheckIBMPICreateInstanceWithSPP(name string, policy string) string {
+	return fmt.Sprintf(`
+		resource "ibm_pi_shared_processor_pool" "spp_pool" {
+			pi_cloud_instance_id  = "%[1]s"
+			pi_shared_processor_pool_name = "%[2]s"
+			pi_shared_processor_pool_host_group       = "s922"
+			pi_shared_processor_pool_reserved_cores = "2"
+		}
+		resource "ibm_pi_shared_processor_pool" "spp_pool_2" {
+			pi_cloud_instance_id  = "%[1]s"
+			pi_shared_processor_pool_name = "%[2]s2"
+			pi_shared_processor_pool_host_group       = "e980"
+			pi_shared_processor_pool_reserved_cores = "1"
+		}
+		resource "ibm_pi_spp_placement_group" "spp_placement_group" {
+			pi_cloud_instance_id      = "%[1]s"
+			pi_spp_placement_group_name   = "%[2]spg"
+			pi_spp_placement_group_policy = "%[3]s"
+		}
+		resource "ibm_pi_spp_placement_group" "spp_placement_group_another" {
+			pi_cloud_instance_id      = "%[1]s"
+			pi_spp_placement_group_name   = "%[2]s2pg"
+			pi_spp_placement_group_policy = "%[3]s"
+		}
+
+		resource "ibm_pi_key" "key" {
+			pi_cloud_instance_id = "%[1]s"
+			pi_key_name          = "%[2]s"
+			pi_ssh_key           = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCKVmnMOlHKcZK8tpt3MP1lqOLAcqcJzhsvJcjscgVERRN7/9484SOBJ3HSKxxNG5JN8owAjy5f9yYwcUg+JaUVuytn5Pv3aeYROHGGg+5G346xaq3DAwX6Y5ykr2fvjObgncQBnuU5KHWCECO/4h8uWuwh/kfniXPVjFToc+gnkqA+3RKpAecZhFXwfalQ9mMuYGFxn+fwn8cYEApsJbsEmb0iJwPiZ5hjFC8wREuiTlhPHDgkBLOiycd20op2nXzDbHfCHInquEe/gYxEitALONxm0swBOwJZwlTDOB7C6y2dzlrtxr1L59m7pCkWI4EtTRLvleehBoj3u7jB4usR"
+		}
+		data "ibm_pi_image" "power_image" {
+			pi_image_name        = "%[4]s"
+			pi_cloud_instance_id = "%[1]s"
+		}
+		data "ibm_pi_network" "power_networks" {
+			pi_cloud_instance_id = "%[1]s"
+			pi_network_name      = "%[5]s"
+		}
+		resource "ibm_pi_volume" "power_volume" {
+			pi_volume_size       = 20
+			pi_volume_name       = "%[2]s"
+			pi_volume_shareable  = true
+			pi_volume_pool       = data.ibm_pi_image.power_image.storage_pool
+			pi_cloud_instance_id = "%[1]s"
+		}
+		resource "ibm_pi_instance" "power_instance" {
+			pi_memory             = "2"
+			pi_processors         = "0.25"
+			pi_instance_name      = "%[2]s"
+			pi_proc_type          = "shared"
+			pi_image_id           = data.ibm_pi_image.power_image.id
+			pi_sys_type           = "s922"
+			pi_cloud_instance_id  = "%[1]s"
+			pi_storage_pool       = data.ibm_pi_image.power_image.storage_pool
+			pi_volume_ids         = [ibm_pi_volume.power_volume.volume_id]
+			pi_network {
+				network_id = data.ibm_pi_network.power_networks.id
+			}
+			pi_shared_processor_pool = ibm_pi_shared_processor_pool.spp_pool.pi_shared_processor_pool_name
+		}
+	`, acc.Pi_cloud_instance_id, name, policy, acc.Pi_image, acc.Pi_network_name)
+}
+
+func testAccCheckIBMPICreateSAPInstanceWithSPP(name string, policy string, sapProfile string) string {
+	return fmt.Sprintf(`
+		resource "ibm_pi_shared_processor_pool" "spp_pool" {
+			pi_cloud_instance_id  = "%[1]s"
+			pi_shared_processor_pool_name = "%[2]s"
+			pi_shared_processor_pool_host_group       = "s922"
+			pi_shared_processor_pool_reserved_cores = "2"
+		}
+		resource "ibm_pi_shared_processor_pool" "spp_pool_2" {
+			pi_cloud_instance_id  = "%[1]s"
+			pi_shared_processor_pool_name = "%[2]s2"
+			pi_shared_processor_pool_host_group       = "e980"
+			pi_shared_processor_pool_reserved_cores = "1"
+		}
+		resource "ibm_pi_spp_placement_group" "spp_placement_group" {
+			pi_cloud_instance_id      = "%[1]s"
+			pi_spp_placement_group_name   = "%[2]spg"
+			pi_spp_placement_group_policy = "%[3]s"
+		}
+		resource "ibm_pi_spp_placement_group" "spp_placement_group_another" {
+			pi_cloud_instance_id      = "%[1]s"
+			pi_spp_placement_group_name   = "%[2]s2pg"
+			pi_spp_placement_group_policy = "%[3]s"
+		}
+
+		resource "ibm_pi_key" "key" {
+			pi_cloud_instance_id = "%[1]s"
+			pi_key_name          = "%[2]s"
+			pi_ssh_key           = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCKVmnMOlHKcZK8tpt3MP1lqOLAcqcJzhsvJcjscgVERRN7/9484SOBJ3HSKxxNG5JN8owAjy5f9yYwcUg+JaUVuytn5Pv3aeYROHGGg+5G346xaq3DAwX6Y5ykr2fvjObgncQBnuU5KHWCECO/4h8uWuwh/kfniXPVjFToc+gnkqA+3RKpAecZhFXwfalQ9mMuYGFxn+fwn8cYEApsJbsEmb0iJwPiZ5hjFC8wREuiTlhPHDgkBLOiycd20op2nXzDbHfCHInquEe/gYxEitALONxm0swBOwJZwlTDOB7C6y2dzlrtxr1L59m7pCkWI4EtTRLvleehBoj3u7jB4usR"
+		}
+		data "ibm_pi_image" "power_image" {
+			pi_image_name        = "%[4]s"
+			pi_cloud_instance_id = "%[1]s"
+		}
+		data "ibm_pi_network" "power_networks" {
+			pi_cloud_instance_id = "%[1]s"
+			pi_network_name      = "%[5]s"
+		}
+		resource "ibm_pi_volume" "power_volume" {
+			pi_volume_size       = 20
+			pi_volume_name       = "%[2]s"
+			pi_volume_shareable  = true
+			pi_volume_pool       = data.ibm_pi_image.power_image.storage_pool
+			pi_cloud_instance_id = "%[1]s"
+		}
+		resource "ibm_pi_instance" "power_instance" {
+			pi_memory             = "2"
+			pi_processors         = "0.25"
+			pi_instance_name      = "%[2]s"
+			pi_proc_type          = "shared"
+			pi_image_id           = data.ibm_pi_image.power_image.id
+			pi_sys_type           = "s922"
+			pi_cloud_instance_id  = "%[1]s"
+			pi_storage_pool       = data.ibm_pi_image.power_image.storage_pool
+			pi_volume_ids         = [ibm_pi_volume.power_volume.volume_id]
+			pi_network {
+				network_id = data.ibm_pi_network.power_networks.id
+			}
+			pi_shared_processor_pool = ibm_pi_shared_processor_pool.spp_pool.pi_shared_processor_pool_name
+		}
+		resource "ibm_pi_instance" "sap" {
+			pi_cloud_instance_id  	= "%[1]s"
+			pi_instance_name      	= "%[2]sSAP"
+			pi_sap_profile_id       = "%[7]s"
+			pi_image_id           	= "%[6]s"
+			pi_storage_type			= "tier1"
+			pi_network {
+				network_id = data.ibm_pi_network.power_networks.id
+			}
+			pi_health_status		= "OK"
+			pi_shared_processor_pool = ibm_pi_shared_processor_pool.spp_pool_2.pi_shared_processor_pool_name
+		}
+	`, acc.Pi_cloud_instance_id, name, policy, acc.Pi_image, acc.Pi_network_name, acc.Pi_sap_image, sapProfile)
+}

--- a/website/docs/d/pi_instance.html.markdown
+++ b/website/docs/d/pi_instance.html.markdown
@@ -76,6 +76,8 @@ In addition to all argument reference list, you can access the following attribu
 - `placement_group_id`- (String) The ID of the placement group that the instance is a member.
 - `processors` - (Float) The number of processors that are allocated to the instance.
 - `proctype` - (String) The procurement type of the instance. Supported values are `shared` and `dedicated`.
+- `shared_processor_pool`- (String) The name of the shared processor pool for the instance.
+- `shared_processor_pool_id` - (String)  The ID of the shared processor pool for the instance.
 - `status` - (String) The status of the instance.
 - `storage_pool` - (String) The storage Pool where server is deployed.
 - `storage_pool_affinity` - (Bool) Indicates if all volumes attached to the server must reside in the same storage pool.

--- a/website/docs/d/pi_instances.html.markdown
+++ b/website/docs/d/pi_instances.html.markdown
@@ -68,6 +68,8 @@ In addition to all argument reference list, you can access the following attribu
   - `processors` - (Float) The number of processors that are allocated to the instance.
   - `proctype` - (String) The procurement type of the instance. Supported values are `shared` and `dedicated`.
   - `pvm_instance_id` - (String) The unique identifier of the instance.
+  - `shared_processor_pool`- (String) The name of the shared processor pool for the instance.
+  - `shared_processor_pool_id` - (String)  The ID of the shared processor pool for the instance.
   - `status` - (String) The status of the instance.
   - `storage_pool` - (String) The storage Pool where server is deployed.
   - `storage_pool_affinity` - (Bool) Indicates if all volumes attached to the server must reside in the same storage pool.

--- a/website/docs/d/pi_shared_processor_pool.html.markdown
+++ b/website/docs/d/pi_shared_processor_pool.html.markdown
@@ -1,0 +1,64 @@
+---
+
+subcategory: "Power Systems"
+layout: "ibm"
+page_title: "IBM: pi_shared_processor_pool"
+description: |-
+  Manages a shared processor pool in the Power Virtual Server cloud.
+---
+
+# ibm_pi_shared_processor_pool
+Retrieve information about a shared processor pool. For more information, see [getting started with IBM Power Systems Virtual Servers](https://cloud.ibm.com/docs/power-iaas?topic=power-iaas-getting-started).
+
+## Example Usage
+
+```terraform
+data "ibm_pi_shared_processor_pool" "ds_pool" {
+  pi_shared_processor_pool_id   = "my-spp"
+  pi_cloud_instance_id = "49fba6c9-23f8-40bc-9899-aca322ee7d5b"
+}
+```
+
+**Notes**
+* Please find [supported Regions](https://cloud.ibm.com/apidocs/power-cloud#endpoint) for endpoints.
+* If a Power cloud instance is provisioned at `lon04`, The provider level attributes should be as follows:
+  * `region` - `lon`
+  * `zone` - `lon04`
+  
+  Example usage:
+  
+  ```terraform
+    provider "ibm" {
+      region    =   "lon"
+      zone      =   "lon04"
+    }
+  ```
+  
+
+## Argument reference
+Review the argument references that you can specify for your data source. 
+
+- `pi_cloud_instance_id` - (Required, String) The GUID of the service instance associated with an account.
+- `pi_shared_processor_pool_id` - (Required, String) The ID of the shared processor pool.
+
+## Attribute reference
+In addition to all argument reference list, you can access the following attribute references after your data source is created. 
+
+- `allocated_cores` - (Float) The allocated cores in the shared processor pool.
+- `available_cores` - (Integer) The available cores in the shared processor pool.
+- `host_id` - (Integer) The host ID where the shared processor pool resides.
+- `id` - (String) The shared processor pool's unique ID.
+- `instances` - (List of Map) The list of server instances that are deployed in the shared processor pool.
+  Nested scheme for `instances`:
+  - `availability_zone` - (String) Availability zone for the server instances.
+  - `cpus` - (Integer) The amount of cpus for the server instance.
+  - `id` - (String) The server instance ID.
+  - `memory` - (Integer) The amount of memory for the server instance.
+  - `name` - (String) The server instance name.
+  - `status` - (String) Status of the instance.
+  - `uncapped` - (Bool) Identifies if uncapped or not.
+  - `vcpus` - (Float) The amout of vcpus for the server instance.
+- `name` - (String) The name of the shared processor pool.
+- `reserved_cores` - (Integer) The amount of reserved cores for the shared processor pool.
+- `status` - (String) The status of the shared processor pool.
+- `status_detail` - (String) The status details of the shared processor pool.

--- a/website/docs/d/pi_shared_processor_pools.html.markdown
+++ b/website/docs/d/pi_shared_processor_pools.html.markdown
@@ -1,0 +1,55 @@
+---
+
+subcategory: "Power Systems"
+layout: "ibm"
+page_title: "IBM: pi_shared_processor_pools"
+description: |-
+  Manages the shared processor pools in the Power Virtual Server cloud.
+---
+
+# ibm_pi_shared_processor_pools
+Retrieve information about all shared processor pools. For more information, see [getting started with IBM Power Systems Virtual Servers](https://cloud.ibm.com/docs/power-iaas?topic=power-iaas-getting-started).
+
+## Example usage
+
+```terraform
+data "ibm_pi_shared_processor_pools" "example" {
+  pi_cloud_instance_id = "<value of the cloud_instance_id>"
+}
+```
+
+**Notes**
+
+* Please find [supported Regions](https://cloud.ibm.com/apidocs/power-cloud#endpoint) for endpoints.
+* If a Power cloud instance is provisioned at `lon04`, The provider level attributes should be as follows:
+  * `region` - `lon`
+  * `zone` - `lon04`
+
+Example usage:
+
+  ```terraform
+    provider "ibm" {
+      region    =   "lon"
+      zone      =   "lon04"
+    }
+  ```
+  
+## Argument reference
+Review the argument references that you can specify for your data source.
+
+- `pi_cloud_instance_id` - (Required, String) The GUID of the service instance associated with an account.
+
+## Attribute reference
+In addition to all argument reference list, you can access the following attribute references after your data source is created.
+
+- `shared_processor_pools` - (List) List of all the shared processor pools.
+
+  Nested scheme for `shared_processor_pools`:
+  - `allocated_cores` - (Float) The allocated cores in the shared processor pool.
+  - `available_cores` - (Integer) The available cores in the shared processor pool.
+  - `host_id` - (Integer) The host ID where the shared processor pool resides.
+  - `name` - (String) The name of the shared processor pool.
+  - `reserved_cores` - (Integer) The amount of reserved cores for the shared processor pool.
+  - `shared_processor_pool_id` - (String) The shared processor pool's unique ID.
+  - `status` - (String) The status of the shared processor pool.
+  - `status_detail` - (String) The status details of the shared processor pool.

--- a/website/docs/d/pi_spp_placement_group.html.markdown
+++ b/website/docs/d/pi_spp_placement_group.html.markdown
@@ -1,0 +1,49 @@
+---
+
+subcategory: "Power Systems"
+layout: "ibm"
+page_title: "IBM: pi_spp_placement_group"
+description: |-
+  Manages a shared processor pool placement group in the Power Virtual Server cloud.
+---
+
+# ibm_pi_spp_placement_group
+Retrieve information about a shared processor pool placement group. For more information, see [getting started with IBM Power Systems Virtual Servers](https://cloud.ibm.com/docs/power-iaas?topic=power-iaas-getting-started).
+
+## Example Usage
+
+```terraform
+data "ibm_pi_spp_placement_group" "ds_placement_group" {
+  pi_spp_placement_group_id   = "my-spppg"
+  pi_cloud_instance_id = "49fba6c9-23f8-40bc-9899-aca322ee7d5b"
+}
+```
+
+**Notes**
+* Please find [supported Regions](https://cloud.ibm.com/apidocs/power-cloud#endpoint) for endpoints.
+* If a Power cloud instance is provisioned at `lon04`, The provider level attributes should be as follows:
+  * `region` - `lon`
+  * `zone` - `lon04`
+  
+  Example usage:
+  
+  ```terraform
+    provider "ibm" {
+      region    =   "lon"
+      zone      =   "lon04"
+    }
+  ```
+  
+
+## Argument reference
+Review the argument references that you can specify for your data source. 
+
+- `pi_cloud_instance_id` - (Required, String) The GUID of the service instance associated with an account.
+- `pi_spp_placement_group_id` - (Required, String) The ID of the shared processor pool placement group.
+
+## Attribute reference
+In addition to all argument reference list, you can access the following attribute references after your data source is created. 
+
+- `members` - (List of strings) The list of shared processor pool IDs that are members of the placement group.
+- `name` - (String) The name of the shared processor pool placement group.
+- `policy` - (String) The value of the group's affinity policy. Valid values are affinity and anti-affinity.

--- a/website/docs/d/pi_spp_placement_groups.html.markdown
+++ b/website/docs/d/pi_spp_placement_groups.html.markdown
@@ -1,0 +1,51 @@
+---
+
+subcategory: "Power Systems"
+layout: "ibm"
+page_title: "IBM: pi_spp_placement_groups"
+description: |-
+  Manages the shared processor pool placement groups in the Power Virtual Server cloud.
+---
+
+# ibm_pi_spp_placement_groups
+Retrieve information about all shared processor pool placement groups. For more information, see [getting started with IBM Power Systems Virtual Servers](https://cloud.ibm.com/docs/power-iaas?topic=power-iaas-getting-started).
+
+## Example usage
+
+```terraform
+data "ibm_pi_spp_placement_groups" "example" {
+  pi_cloud_instance_id = "<value of the cloud_instance_id>"
+}
+```
+
+**Notes**
+
+* Please find [supported Regions](https://cloud.ibm.com/apidocs/power-cloud#endpoint) for endpoints.
+* If a Power cloud instance is provisioned at `lon04`, The provider level attributes should be as follows:
+  * `region` - `lon`
+  * `zone` - `lon04`
+
+Example usage:
+
+  ```terraform
+    provider "ibm" {
+      region    =   "lon"
+      zone      =   "lon04"
+    }
+  ```
+  
+## Argument reference
+Review the argument references that you can specify for your data source.
+
+- `pi_cloud_instance_id` - (Required, String) The GUID of the service instance associated with an account.
+
+## Attribute reference
+In addition to all argument reference list, you can access the following attribute references after your data source is created.
+
+- `spp_placement_groups` - (List) List of all the shared processor pool placement groups.
+
+  Nested scheme for `spp_placement_groups`:
+  - `name` - (String) User defined name for the shared processor pool placement group.
+  - `members` - (List of strings) The list of shared processor pool IDs that are members of the shared processor pool placement group.
+  - `policy` - (String) The value of the group's affinity policy. Valid values are affinity and anti-affinity.
+  - `spp_placement_group_id` - (String) The ID of the shared processor pool placement group.

--- a/website/docs/r/pi_instance.html.markdown
+++ b/website/docs/r/pi_instance.html.markdown
@@ -91,6 +91,7 @@ Review the argument references that you can specify for your resource.
 - `pi_sap_profile_id` - (Optional, String) SAP Profile ID for the amount of cores and memory.
   - Required only when creating SAP instances.
 - `pi_sap_deployment_type` - (Optional, String) Custom SAP deployment type information (For Internal Use Only).
+- `pi_shared_processor_pool` - (Optional, String) The shared processor pool for instance deployment. Conflicts with `pi_sap_profile_id`.
 - `pi_storage_pool` - (Optional, String) Storage Pool for server deployment; if provided then `pi_affinity_policy` and `pi_storage_type` will be ignored.
 - `pi_storage_pool_affinity` - (Optional, Bool) Indicates if all volumes attached to the server must reside in the same storage pool. The default value is `true`. To attach data volumes from a different storage pool (mixed storage) set to `false` and use `pi_volume_attach` resource. Once set to `false`, cannot be set back to `true` unless all volumes attached reside in the same storage type and pool.
 - `pi_storage_type` - (Optional, String) - Storage type for server deployment. Only valid when you deploy one of the IBM supplied stock images. Storage type for a custom image (an imported image or an image that is created from a VM capture) defaults to the storage type the image was created in
@@ -112,11 +113,8 @@ In addition to all argument reference list, you can access the following attribu
 - `min_memory` - (Float) The minimum memory that was allocated to the instance.
 - `max_memory`- (Float) The maximum amount of memory that can be allocated to the instance without shut down or reboot the `LPAR`.
 - `min_virtual_cores` - (Integer) The minimum number of virtual cores.
-- `status` - (String) The status of the instance.
 - `pin_policy`  - (String) The pinning policy of the instance.
-- `progress` - (Float) - Specifies the overall progress of the instance deployment process in percentage.
 - `pi_network` - (List of Map) - A list of networks that are assigned to the instance.
-
   Nested scheme for `pi_network`:
   - `ip_address` - (String) The IP address of the network.
   - `mac_address` - (String) The MAC address of the network.
@@ -124,7 +122,9 @@ In addition to all argument reference list, you can access the following attribu
   - `network_name` - (String) The name of the network.
   - `type` - (String) The type of network.
   - `external_ip` - (String) The external IP address of the network.
-
+- `progress` - (Float) - Specifies the overall progress of the instance deployment process in percentage.
+- `shared_processor_pool_id` - (String)  The ID of the shared processor pool for the instance.
+- `status` - (String) The status of the instance.
 ## Import
 
 The `ibm_pi_instance` can be imported using `power_instance_id` and `instance_id`.

--- a/website/docs/r/pi_shared_processor_pool.html.markdown
+++ b/website/docs/r/pi_shared_processor_pool.html.markdown
@@ -1,0 +1,85 @@
+---
+
+subcategory: "Power Systems"
+layout: "ibm"
+page_title: "IBM: pi_shared_processor_pool"
+description: |-
+  Manages a shared processor pool in the Power Virtual Server cloud.
+---
+
+# ibm_pi_shared_processor_pool
+Create, update or delete a shared processor pool.
+
+## Example usage
+The following example enables you to create a shared processor pool with a group 2 reserved cores on a s922 host group:
+
+```terraform
+resource "ibm_pi_shared_processor_pool" "testacc_shared_processor_pool" {
+  pi_shared_processor_pool_name   = "my_spp"
+  pi_shared_processor_pool_host_group = "s922"
+  pi_shared_processor_pool_reserved_cores = "2"
+  pi_cloud_instance_id      = "<value of the cloud_instance_id>"
+}
+```
+
+**Note**
+* Please find [supported Regions](https://cloud.ibm.com/apidocs/power-cloud#endpoint) for endpoints.
+* If a Power cloud instance is provisioned at `lon04`, The provider level attributes should be as follows:
+  * `region` - `lon`
+  * `zone` - `lon04`
+  
+  Example usage:
+
+  ```terraform
+    provider "ibm" {
+      region    =   "lon"
+      zone      =   "lon04"
+    }
+  ```
+
+## Timeouts
+
+ibm_pi_shared_processor_pool provides the following [timeouts](https://www.terraform.io/docs/language/resources/syntax.html) configuration options:
+
+- **create** - (Default 60 minutes) Used for creating a shared processor pool placement group.
+- **delete** - (Default 60 minutes) Used for deleting a shared processor pool placement group.
+- **update** - (Default 60 minutes) Used for updating a shared processor pool placement group.
+
+## Argument reference
+Review the argument references that you can specify for your resource. 
+
+- `pi_cloud_instance_id` - (Required, String) The GUID of the service instance associated with an account.
+- `pi_shared_processor_pool_host_group` - (Required, String) Host group of the shared processor pool. Valid values are 's922' and 'e980'.
+- `pi_shared_processor_pool_name` - (Required, String) The name of the shared processor pool.
+- `pi_shared_processor_pool_reserved_cores` - (Required, Integer) The amount of reserved cores for the shared processor pool.
+- `pi_shared_processor_pool_placement_group_id` - (Optional, String) The ID of the placement group the shared processor pool is created in.
+
+## Attribute reference
+ In addition to all argument reference list, you can access the following attribute reference after your resource is created.
+
+- `allocated_cores` - (Float) The allocated cores in the shared processor pool.
+- `available_cores` - (Integer) The available cores in the shared processor pool.
+- `host_id` - (Integer) The host ID where the shared processor pool resides.
+- `instances` - (List of Map) The list of server instances that are deployed in the shared processor pool.
+  Nested scheme for `instances`:
+  - `availability_zone` - (String) Availability zone for the server instances.
+  - `cpus` - (Integer) The amount of cpus for the server instance.
+  - `id` - (String) The server instance ID.
+  - `memory` - (Integer) The amount of memory for the server instance.
+  - `name` - (String) The server instance name.
+  - `status` - (String) Status of the instance.
+  - `uncapped` - (Bool) Identifies if uncapped or not.
+  - `vcpus` - (Float) The amout of vcpus for the server instance.
+- `shared_processor_pool_id` - (String) The shared processor pool's unique ID.
+- `status` - (String) The status of the shared processor pool.
+- `status_detail` - (String) The status details of the shared processor pool.
+
+## Import
+
+The `ibm_pi_shared_processor_pool` resource can be imported by using `power_instance_id` and `shared_processor_pool_id`.
+
+**Example**
+
+```
+$ terraform import ibm_pi_shared_processor_pool.example d7bec597-4726-451f-8a63-e62e6f19c32c/b17a2b7f-77ab-491c-811e-495f8d4c8947
+```

--- a/website/docs/r/pi_spp_placement_group.html.markdown
+++ b/website/docs/r/pi_spp_placement_group.html.markdown
@@ -1,0 +1,69 @@
+---
+
+subcategory: "Power Systems"
+layout: "ibm"
+page_title: "IBM: pi_spp_placement_group"
+description: |-
+  Manages a shared processor pool placement group in the Power Virtual Server cloud.
+---
+
+# ibm_pi_spp_placement_group
+Create, update or delete a shared processor pool placement group.
+
+## Example usage
+The following example enables you to create a shared processor pool placement group with a group policy of affinity:
+
+```terraform
+resource "ibm_pi_spp_placement_group" "testacc_placement_group" {
+  pi_spp_placement_group_name   = "my_pg"
+  pi_spp_placement_group_policy = "affinity"
+  pi_cloud_instance_id      = "<value of the cloud_instance_id>"
+}
+```
+
+**Note**
+* Please find [supported Regions](https://cloud.ibm.com/apidocs/power-cloud#endpoint) for endpoints.
+* If a Power cloud instance is provisioned at `lon04`, The provider level attributes should be as follows:
+  * `region` - `lon`
+  * `zone` - `lon04`
+  
+  Example usage:
+
+  ```terraform
+    provider "ibm" {
+      region    =   "lon"
+      zone      =   "lon04"
+    }
+  ```
+
+## Timeouts
+
+ibm_pi_spp_placement_group provides the following [timeouts](https://www.terraform.io/docs/language/resources/syntax.html) configuration options:
+
+- **create** - (Default 60 minutes) Used for creating a shared processor pool placement group.
+- **delete** - (Default 60 minutes) Used for deleting a shared processor pool placement group.
+
+## Argument reference
+Review the argument references that you can specify for your resource. 
+
+- `pi_cloud_instance_id` - (Required, String) The GUID of the service instance associated with an account.
+- `pi_spp_placement_group_name`  - (Required, String) The name of the shared processor pool placement group. 
+- `pi_spp_placement_group_policy` - (Required, String) The value of the group's affinity policy. Valid values are `affinity` and `anti-affinity`. 
+
+
+## Attribute reference
+ In addition to all argument reference list, you can access the following attribute reference after your resource is created.
+
+- `id` - (String) The unique identifier of the placement group.
+- `members` - (List of strings) The list of server instances IDs that are members of the placement group.
+- `spp_placement_group_id` - (String) The placement group ID.
+
+## Import
+
+The `ibm_spp_pi_placement_group` resource can be imported by using `power_instance_id` and `spp_placement_group_id`.
+
+**Example**
+
+```
+$ terraform import ibm_pi_spp_placement_group.example d7bec597-4726-451f-8a63-e62e6f19c32c/b17a2b7f-77ab-491c-811e-495f8d4c8947
+```


### PR DESCRIPTION
Add shared processor pool & SPP placement groups
resource and data ebjects along with the ability
to add instances to a SPP

<!--- See what makes a good Pull Request at : https://github.com/IBM-Cloud/terraform-provider-ibm/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
=== RUN   TestAccIBMPISPPPlacementGroupBasic
--- PASS: TestAccIBMPISPPPlacementGroupBasic (2181.41s)
PASS

=== RUN   TestAccIBMPISharedProcessorPoolsDataSourceBasic
--- PASS: TestAccIBMPISharedProcessorPoolsDataSourceBasic (14.50s)
PASS

=== RUN   TestAccIBMPIPISharedProcessorPoolDataSource_basic
--- PASS: TestAccIBMPIPISharedProcessorPoolDataSource_basic (17.70s)
PASS

=== RUN   TestAccIBMPISPPPlacementGroupsDataSourceBasic
--- PASS: TestAccIBMPISPPPlacementGroupsDataSourceBasic (37.27s)
PASS

=== RUN   TestAccIBMPISPPPlacementGroupDataSource_basic
--- PASS: TestAccIBMPISPPPlacementGroupDataSource_basic (14.87s)
PASS


=== RUN   TestAccIBMPIInstancesDataSource_basic
--- PASS: TestAccIBMPIInstancesDataSource_basic (19.14s)
PASS

=== RUN   TestAccIBMPIInstanceDataSource_basic
--- PASS: TestAccIBMPIInstanceDataSource_basic (23.18s)
PASS

=== RUN   TestAccIBMPIInstanceBasic
--- PASS: TestAccIBMPIInstanceBasic (208.13s)
PASS

=== RUN   TestAccIBMPIInstanceDeploymentType
--- PASS: TestAccIBMPIInstanceDeploymentType (314.97s)
PASS

=== RUN   TestAccIBMPISAPInstance
--- PASS: TestAccIBMPISAPInstance (913.87s)
PASS

=== RUN   TestAccIBMPINetworkbasic
--- PASS: TestAccIBMPINetworkbasic (38.50s)
PASS

=== RUN   TestAccIBMPINetworkGatewaybasic
--- PASS: TestAccIBMPINetworkGatewaybasic (40.61s)
PASS
...
```
