### PR TITLE
Tekton provider - Update SDK version and some extra features

### DIFF
--- a/examples/ibm-cd-tekton-pipeline/README.md
+++ b/examples/ibm-cd-tekton-pipeline/README.md
@@ -163,7 +163,7 @@ data "cd_tekton_pipeline" "cd_tekton_pipeline_instance" {
 | value | Property value. | `string` | false |
 | enum | Options for `single_select` property type. Only needed for `single_select` property type. | `list(string)` | false |
 | type | Property type. | `string` | false |
-| path | A dot notation path for `integration` type properties to select a value from the tool integration. If left blank the full tool integration JSON will be selected. | `string` | false |
+| path | A dot notation path for `integration` type properties to select a value from the tool integration. If left blank the full tool integration data will be used. | `string` | false |
 | pipeline_id | The Tekton pipeline ID. | `string` | true |
 | name | Property name. | `string` | false |
 | value | Property value. | `string` | false |

--- a/examples/ibm-cd-tekton-pipeline/README.md
+++ b/examples/ibm-cd-tekton-pipeline/README.md
@@ -4,11 +4,11 @@ This example illustrates how to use the CdTektonPipelineV2
 
 These types of resources are supported:
 
+* cd_tekton_pipeline
 * cd_tekton_pipeline_definition
 * cd_tekton_pipeline_trigger_property
 * cd_tekton_pipeline_property
 * cd_tekton_pipeline_trigger
-* cd_tekton_pipeline
 
 ## Usage
 
@@ -22,192 +22,160 @@ $ terraform apply
 
 Run `terraform destroy` when you don't need these resources.
 
-
 ## CdTektonPipelineV2 resources
+
+cd_tekton_pipeline resource:
+
+```terraform
+resource "cd_tekton_pipeline" "cd_tekton_pipeline_instance" {
+  enable_slack_notifications = false
+  enable_partial_cloning = false
+  worker = var.cd_tekton_pipeline_worker
+}
+```
 
 cd_tekton_pipeline_definition resource:
 
-```hcl
+```terraform
 resource "cd_tekton_pipeline_definition" "cd_tekton_pipeline_definition_instance" {
-  pipeline_id = var.cd_tekton_pipeline_definition_pipeline_id
-  scm_source = var.cd_tekton_pipeline_definition_scm_source
+  pipeline_id = ibm_cd_tekton_pipeline.cd_pipeline_instance.pipeline_id
+  scm_source {
+    url = ibm_cd_toolchain_tool_hostedgit.tekton_repo.repo_url
+    branch = "master"
+    path = ".tekton"
+  }
 }
 ```
-cd_tekton_pipeline_trigger_property resource:
 
-```hcl
-resource "cd_tekton_pipeline_trigger_property" "cd_tekton_pipeline_trigger_property_instance" {
-  pipeline_id = var.cd_tekton_pipeline_trigger_property_pipeline_id
-  trigger_id = var.cd_tekton_pipeline_trigger_property_trigger_id
-  name = var.cd_tekton_pipeline_trigger_property_name
-  value = var.cd_tekton_pipeline_trigger_property_value
-  enum = var.cd_tekton_pipeline_trigger_property_enum
-  type = var.cd_tekton_pipeline_trigger_property_type
-  path = var.cd_tekton_pipeline_trigger_property_path
-}
-```
 cd_tekton_pipeline_property resource:
 
-```hcl
+```terraform
 resource "cd_tekton_pipeline_property" "cd_tekton_pipeline_property_instance" {
-  pipeline_id = var.cd_tekton_pipeline_property_pipeline_id
-  name = var.cd_tekton_pipeline_property_name
-  value = var.cd_tekton_pipeline_property_value
-  enum = var.cd_tekton_pipeline_property_enum
-  type = var.cd_tekton_pipeline_property_type
-  path = var.cd_tekton_pipeline_property_path
+  pipeline_id = ibm_cd_tekton_pipeline.cd_pipeline_instance.pipeline_id
+  name = "env-prop-1"
+  value = "Environment text property 1"
+  type = "text"
 }
 ```
+
 cd_tekton_pipeline_trigger resource:
 
-```hcl
+```terraform
 resource "cd_tekton_pipeline_trigger" "cd_tekton_pipeline_trigger_instance" {
-  pipeline_id = var.cd_tekton_pipeline_trigger_pipeline_id
-  type = var.cd_tekton_pipeline_trigger_type
-  name = var.cd_tekton_pipeline_trigger_name
-  event_listener = var.cd_tekton_pipeline_trigger_event_listener
-  tags = var.cd_tekton_pipeline_trigger_tags
-  worker = var.cd_tekton_pipeline_trigger_worker
-  max_concurrent_runs = var.cd_tekton_pipeline_trigger_max_concurrent_runs
-  disabled = var.cd_tekton_pipeline_trigger_disabled
-  secret = var.cd_tekton_pipeline_trigger_secret
-  cron = var.cd_tekton_pipeline_trigger_cron
-  timezone = var.cd_tekton_pipeline_trigger_timezone
-  scm_source = var.cd_tekton_pipeline_trigger_scm_source
-  events = var.cd_tekton_pipeline_trigger_events
+  pipeline_id = ibm_cd_tekton_pipeline.cd_pipeline_instance.pipeline_id
+  type = "manual"
+  name = "trigger1"
+  event_listener = "listener"
+  tags = [ "tag1", "tag2" ]
+  worker {
+    id = "public"
+  }
+  max_concurrent_runs = 1
 }
 ```
-cd_tekton_pipeline resource:
 
-```hcl
-resource "cd_tekton_pipeline" "cd_tekton_pipeline_instance" {
-  enable_slack_notifications = var.cd_tekton_pipeline_enable_slack_notifications
-  enable_partial_cloning = var.cd_tekton_pipeline_enable_partial_cloning
-  worker = var.cd_tekton_pipeline_worker
+cd_tekton_pipeline_trigger_property resource:
+
+```terraform
+resource "cd_tekton_pipeline_trigger_property" "cd_tekton_pipeline_trigger_property_instance" {
+  pipeline_id = ibm_cd_tekton_pipeline.cd_pipeline_instance.pipeline_id
+  trigger_id = ibm_cd_tekton_pipeline_trigger.cd_tekton_pipeline_trigger_instance.trigger_id
+  name = "trig-prop-1"
+  value = "trigger 1 text property"
+  type = "text"
 }
 ```
 
 ## CdTektonPipelineV2 Data sources
 
+cd_tekton_pipeline data source:
+
+```terraform
+data "cd_tekton_pipeline" "cd_tekton_pipeline_instance" {
+  id = var.cd_tekton_pipeline_id
+}
+```
+
 cd_tekton_pipeline_definition data source:
 
-```hcl
+```terraform
 data "cd_tekton_pipeline_definition" "cd_tekton_pipeline_definition_instance" {
   pipeline_id = var.cd_tekton_pipeline_definition_pipeline_id
   definition_id = var.cd_tekton_pipeline_definition_definition_id
 }
 ```
+
+cd_tekton_pipeline_property data source:
+
+```terraform
+data "cd_tekton_pipeline_property" "cd_tekton_pipeline_property_instance" {
+  pipeline_id = var.cd_tekton_pipeline_property_pipeline_id
+  property_name = var.cd_tekton_pipeline_property_property_name
+}
+```
+
+cd_tekton_pipeline_trigger data source:
+
+```terraform
+data "cd_tekton_pipeline_trigger" "cd_tekton_pipeline_trigger_instance" {
+  pipeline_id = var.cd_tekton_pipeline_trigger_pipeline_id
+  trigger_id = var.cd_tekton_pipeline_trigger_trigger_id
+}
+```
+
 cd_tekton_pipeline_trigger_property data source:
 
-```hcl
+```terraform
 data "cd_tekton_pipeline_trigger_property" "cd_tekton_pipeline_trigger_property_instance" {
   pipeline_id = var.cd_tekton_pipeline_trigger_property_pipeline_id
   trigger_id = var.cd_tekton_pipeline_trigger_property_trigger_id
   property_name = var.cd_tekton_pipeline_trigger_property_property_name
 }
 ```
-cd_tekton_pipeline_property data source:
-
-```hcl
-data "cd_tekton_pipeline_property" "cd_tekton_pipeline_property_instance" {
-  pipeline_id = var.cd_tekton_pipeline_property_pipeline_id
-  property_name = var.cd_tekton_pipeline_property_property_name
-}
-```
-cd_tekton_pipeline_trigger data source:
-
-```hcl
-data "cd_tekton_pipeline_trigger" "cd_tekton_pipeline_trigger_instance" {
-  pipeline_id = var.cd_tekton_pipeline_trigger_pipeline_id
-  trigger_id = var.cd_tekton_pipeline_trigger_trigger_id
-}
-```
-cd_tekton_pipeline data source:
-
-```hcl
-data "cd_tekton_pipeline" "cd_tekton_pipeline_instance" {
-  id = var.cd_tekton_pipeline_id
-}
-```
 
 ## Assumptions
 
-1. TODO
+1. Creating a Tekton Pipeline requires creating an IBM CD Toolchain (ibm_cd_toolchain) resource and a Tekton Pipeline tool resource instance (ibm_cd_toolchain_tool_pipeline) in that toolchain. These are included in the example in `main.tf`.
+2. The Tekton Pipeline resource also requires a repository to be included in the toolchain, which contains the Tekton Pipeline declaration. An example is included in the `main.tf`.
 
 ## Notes
 
-1. TODO
+1. Copy the `variables.tfvars.example` file to your own `terraform.tfvars` file and add values for the variables within.
+2. Use `terraform apply -var-file="terraform.tfvars"` to generate the toolchain and pipeline using your provided variables.
 
 ## Requirements
 
 | Name | Version |
 |------|---------|
-| terraform | ~> 0.12 |
+| terraform | >=1.0.0, <2.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| ibm | 1.13.1 |
+| ibm | >=1.45.0 |
 
 ## Inputs
 
 | Name | Description | Type | Required |
 |------|-------------|------|---------|
 | ibmcloud\_api\_key | IBM Cloud API key | `string` | true |
-| pipeline_id | The Tekton pipeline ID. | `string` | true |
-| scm_source | SCM source for Tekton pipeline definition. | `` | false |
-| pipeline_id | The Tekton pipeline ID. | `string` | true |
-| trigger_id | The trigger ID. | `string` | true |
-| name | Property name. | `string` | false |
-| value | Property value. | `string` | false |
-| enum | Options for `single_select` property type. Only needed for `single_select` property type. | `list(string)` | false |
-| type | Property type. | `string` | false |
-| path | A dot notation path for `integration` type properties to select a value from the tool integration. If left blank the full tool integration data will be used. | `string` | false |
-| pipeline_id | The Tekton pipeline ID. | `string` | true |
-| name | Property name. | `string` | false |
-| value | Property value. | `string` | false |
-| enum | Options for `single_select` property type. Only needed when using `single_select` property type. | `list(string)` | false |
-| type | Property type. | `string` | false |
-| path | A dot notation path for `integration` type properties to select a value from the tool integration. | `string` | false |
-| pipeline_id | The Tekton pipeline ID. | `string` | true |
-| type | Trigger type. | `string` | false |
-| name | Trigger name. | `string` | false |
-| event_listener | Event listener name. The name of the event listener to which the trigger is associated. The event listeners are defined in the definition repositories of the Tekton pipeline. | `string` | false |
-| tags | Trigger tags array. | `list(string)` | false |
-| worker | Worker used to run the trigger. If not specified the trigger will use the default pipeline worker. | `` | false |
-| max_concurrent_runs | Defines the maximum number of concurrent runs for this trigger. Omit this property to disable the concurrency limit. | `number` | false |
-| disabled | Flag whether the trigger is disabled. If omitted the trigger is enabled by default. | `bool` | false |
-| secret | Only needed for generic webhook trigger type. Secret used to start generic webhook trigger. | `` | false |
-| cron | Only needed for timer triggers. Cron expression for timer trigger. | `string` | false |
-| timezone | Only needed for timer triggers. Timezone for timer trigger. | `string` | false |
-| scm_source | SCM source repository for a Git trigger. Only needed for Git triggers. | `` | false |
-| events | Only needed for Git triggers. Events object defines the events to which this Git trigger listens. | `` | false |
-| enable_slack_notifications | Flag whether to enable slack notifications for this pipeline. When enabled, pipeline run events will be published on all slack integration specified channels in the enclosing toolchain. | `bool` | false |
-| enable_partial_cloning | Flag whether to enable partial cloning for this pipeline. When partial clone is enabled, only the files contained within the paths specified in definition repositories will be read and cloned. This means symbolic links may not work. | `bool` | false |
-| worker | Worker object containing worker ID only. If omitted the IBM Managed shared workers are used by default. | `` | false |
-| pipeline_id | The Tekton pipeline ID. | `string` | true |
-| definition_id | The definition ID. | `string` | true |
-| pipeline_id | The Tekton pipeline ID. | `string` | true |
-| trigger_id | The trigger ID. | `string` | true |
-| property_name | The property name. | `string` | true |
-| pipeline_id | The Tekton pipeline ID. | `string` | true |
-| property_name | The property name. | `string` | true |
-| pipeline_id | The Tekton pipeline ID. | `string` | true |
-| trigger_id | The trigger ID. | `string` | true |
-| id | ID of current instance. | `string` | true |
+| resource\_group | Resource group within which toolchain will be created | `string` | true |
+| region | IBM Cloud region where your toolchain will be created | `string` | true |
+| toolchain\_name | Name of the Toolchain | `string` | true |
+| toolchain\_description | Description for the Toolchain | `string` | true |
+| clone\_repo | URL of the tekton repo to clone, e.g. `https://github.com/open-toolchain/hello-tekton` | `string` | true |
+| repo\_name | Name of the new repo that will be created in the toolchain | `string` | true |
+| cluster | Name of the cluster where the app will be deployed | `string` | true |
+| cluster_namespace | Namespace in the cluster where the app will be deployed. Default = `prod` | `string` | false |
+| registry_namespace | IBM Cloud Container Registry namespace where the app image will be built and stored | `string` | true |
 
 ## Outputs
 
 | Name | Description |
 |------|-------------|
-| cd_tekton_pipeline_definition | cd_tekton_pipeline_definition object |
-| cd_tekton_pipeline_trigger_property | cd_tekton_pipeline_trigger_property object |
-| cd_tekton_pipeline_property | cd_tekton_pipeline_property object |
-| cd_tekton_pipeline_trigger | cd_tekton_pipeline_trigger object |
 | cd_tekton_pipeline | cd_tekton_pipeline object |
 | cd_tekton_pipeline_definition | cd_tekton_pipeline_definition object |
-| cd_tekton_pipeline_trigger_property | cd_tekton_pipeline_trigger_property object |
 | cd_tekton_pipeline_property | cd_tekton_pipeline_property object |
 | cd_tekton_pipeline_trigger | cd_tekton_pipeline_trigger object |
-| cd_tekton_pipeline | cd_tekton_pipeline object |
+| cd_tekton_pipeline_trigger_property | cd_tekton_pipeline_trigger_property object |

--- a/examples/ibm-cd-tekton-pipeline/main.tf
+++ b/examples/ibm-cd-tekton-pipeline/main.tf
@@ -44,7 +44,7 @@ resource "ibm_cd_tekton_pipeline_trigger" "cd_tekton_pipeline_trigger_instance" 
   tags = var.cd_tekton_pipeline_trigger_tags
   worker {
     name = "name"
-    type = "private"
+    type = "public "
     id = "id"
   }
   max_concurrent_runs = var.cd_tekton_pipeline_trigger_max_concurrent_runs
@@ -62,9 +62,6 @@ resource "ibm_cd_tekton_pipeline_trigger" "cd_tekton_pipeline_trigger_instance" 
     url = "url"
     branch = "branch"
     pattern = "pattern"
-    blind_connection = true
-    hook_id = "hook_id"
-    service_instance_id = "service_instance_id"
   }
   events {
     push = true
@@ -78,7 +75,7 @@ resource "ibm_cd_tekton_pipeline" "cd_tekton_pipeline_instance" {
   enable_slack_notifications = var.cd_tekton_pipeline_enable_slack_notifications
   enable_partial_cloning = var.cd_tekton_pipeline_enable_partial_cloning
   worker {
-    id = "id"
+    id = "public"
   }
 }
 

--- a/examples/ibm-cd-tekton-pipeline/main.tf
+++ b/examples/ibm-cd-tekton-pipeline/main.tf
@@ -1,103 +1,158 @@
+// Base resources
 provider "ibm" {
   ibmcloud_api_key = var.ibmcloud_api_key
+}
+data "ibm_resource_group" "resource_group" {
+  name = var.resource_group
+}
+
+// Create toolchain instance
+resource "ibm_cd_toolchain" "toolchain_instance" {
+  name        = var.toolchain_name
+  description = var.toolchain_description
+  resource_group_id = data.ibm_resource_group.resource_group.id
+}
+
+// Create git repo tool instance
+resource "ibm_cd_toolchain_tool_hostedgit" "tekton_repo" {
+  toolchain_id = ibm_cd_toolchain.toolchain_instance.id
+  name         = "tekton-repo"
+  initialization {
+    type = "clone"
+    source_repo_url = var.clone_repo
+    private_repo = false
+    repo_name = var.repo_name
+  }  
+  parameters {
+    has_issues          = false
+    enable_traceability = false
+  }
+}
+
+// Create tekton pipeline instance
+resource "ibm_cd_toolchain_tool_pipeline" "cd_pipeline" {
+  toolchain_id = ibm_cd_toolchain.toolchain_instance.id
+  parameters {
+    name = "tf-pipeline"
+    type = "tekton"
+  }
+}
+resource "ibm_cd_tekton_pipeline" "cd_pipeline_instance" {
+  pipeline_id = ibm_cd_toolchain_tool_pipeline.cd_pipeline.tool_id
+  enable_slack_notifications = false
+  enable_partial_cloning = false
+  worker {
+    id = "public"
+  }
 }
 
 // Provision cd_tekton_pipeline_definition resource instance
 resource "ibm_cd_tekton_pipeline_definition" "cd_tekton_pipeline_definition_instance" {
-  pipeline_id = var.cd_tekton_pipeline_definition_pipeline_id
+  pipeline_id = ibm_cd_tekton_pipeline.cd_pipeline_instance.pipeline_id
   scm_source {
-    url = "url"
-    branch = "branch"
-    path = "path"
+    url = ibm_cd_toolchain_tool_hostedgit.tekton_repo.parameters[0].repo_url
+    branch = "master"
+    path = ".tekton"
   }
-}
-
-// Provision cd_tekton_pipeline_trigger_property resource instance
-resource "ibm_cd_tekton_pipeline_trigger_property" "cd_tekton_pipeline_trigger_property_instance" {
-  pipeline_id = var.cd_tekton_pipeline_trigger_property_pipeline_id
-  trigger_id = var.cd_tekton_pipeline_trigger_property_trigger_id
-  name = var.cd_tekton_pipeline_trigger_property_name
-  value = var.cd_tekton_pipeline_trigger_property_value
-  type = var.cd_tekton_pipeline_trigger_property_type
 }
 
 // Provision cd_tekton_pipeline_property resource instance
 resource "ibm_cd_tekton_pipeline_property" "cd_tekton_pipeline_property_instance" {
-  pipeline_id = var.cd_tekton_pipeline_property_pipeline_id
-  name = var.cd_tekton_pipeline_property_name
-  value = var.cd_tekton_pipeline_property_value
-  type = var.cd_tekton_pipeline_property_type
+  pipeline_id = ibm_cd_tekton_pipeline.cd_pipeline_instance.pipeline_id
+  name = "env-prop-1"
+  value = "Environment text property 1"
+  type = "text"
+}
+
+// Provision pipeline properties
+resource "ibm_cd_tekton_pipeline_property" "apikey" {
+  pipeline_id = ibm_cd_tekton_pipeline.cd_pipeline_instance.pipeline_id
+  name = "apikey"
+  value = var.ibmcloud_api_key
+  type = "secure"
+}
+resource "ibm_cd_tekton_pipeline_property" "cluster_property" {
+  pipeline_id = ibm_cd_tekton_pipeline.cd_pipeline_instance.pipeline_id
+  name = "cluster"
+  value = var.cluster
+  type = "text"
+}
+resource "ibm_cd_tekton_pipeline_property" "cluster_namespace_property" {
+  pipeline_id = ibm_cd_tekton_pipeline.cd_pipeline_instance.pipeline_id
+  name = "clusterNamespace"
+  value = var.cluster_namespace
+  type = "text"
+}
+resource "ibm_cd_tekton_pipeline_property" "cluster_region_property" {
+  pipeline_id = ibm_cd_tekton_pipeline.cd_pipeline_instance.pipeline_id
+  name = "clusterRegion"
+  value = var.region
+  type = "text"
+}
+resource "ibm_cd_tekton_pipeline_property" "registry_region_property" {
+  pipeline_id = ibm_cd_tekton_pipeline.cd_pipeline_instance.pipeline_id
+  name = "registryRegion"
+  value = var.region
+  type = "text"
+}
+resource "ibm_cd_tekton_pipeline_property" "registry_namespace_property" {
+  pipeline_id = ibm_cd_tekton_pipeline.cd_pipeline_instance.pipeline_id
+  name = "registryNamespace"
+  value = var.registry_namespace
+  type = "text"
+}
+resource "ibm_cd_tekton_pipeline_property" "repository_property" {
+  pipeline_id = ibm_cd_tekton_pipeline.cd_pipeline_instance.pipeline_id
+  name = "repository"
+  value = ibm_cd_toolchain_tool_hostedgit.tekton_repo.parameters[0].repo_url
+  type = "text"
 }
 
 // Provision cd_tekton_pipeline_trigger resource instance
 resource "ibm_cd_tekton_pipeline_trigger" "cd_tekton_pipeline_trigger_instance" {
-  pipeline_id = var.cd_tekton_pipeline_trigger_pipeline_id
-  type = var.cd_tekton_pipeline_trigger_type
-  name = var.cd_tekton_pipeline_trigger_name
-  event_listener = var.cd_tekton_pipeline_trigger_event_listener
-  tags = var.cd_tekton_pipeline_trigger_tags
+  pipeline_id = ibm_cd_tekton_pipeline.cd_pipeline_instance.pipeline_id
+  type = "manual"
+  name = "trigger1"
+  event_listener = "listener"
+  tags = [ "tag1", "tag2" ]
   worker {
     id = "public"
   }
-  max_concurrent_runs = var.cd_tekton_pipeline_trigger_max_concurrent_runs
-  disabled = var.cd_tekton_pipeline_trigger_disabled
+  max_concurrent_runs = 1
 }
 
-// Provision cd_tekton_pipeline resource instance
-resource "ibm_cd_tekton_pipeline" "cd_tekton_pipeline_instance" {
-  enable_slack_notifications = var.cd_tekton_pipeline_enable_slack_notifications
-  enable_partial_cloning = var.cd_tekton_pipeline_enable_partial_cloning
-  worker {
-    id = "public"
-  }
+// Provision cd_tekton_pipeline_trigger_property resource instance
+resource "ibm_cd_tekton_pipeline_trigger_property" "cd_tekton_pipeline_trigger_property_instance" {
+  pipeline_id = ibm_cd_tekton_pipeline.cd_pipeline_instance.pipeline_id
+  trigger_id = ibm_cd_tekton_pipeline_trigger.cd_tekton_pipeline_trigger_instance.trigger_id
+  name = "trig-prop-1"
+  value = "trigger 1 text property"
+  type = "text"
 }
 
-// Data source is not linked to a resource instance
-// Uncomment if an existing data source instance exists
-/*
+// Data sources
 // Create cd_tekton_pipeline_definition data source
 data "ibm_cd_tekton_pipeline_definition" "cd_tekton_pipeline_definition_instance" {
-  pipeline_id = var.cd_tekton_pipeline_definition_pipeline_id
-  definition_id = var.cd_tekton_pipeline_definition_definition_id
+  pipeline_id = ibm_cd_tekton_pipeline.cd_pipeline_instance.pipeline_id
+  definition_id = ibm_cd_tekton_pipeline_definition.cd_tekton_pipeline_definition_instance.definition_id
 }
-*/
-
-// Data source is not linked to a resource instance
-// Uncomment if an existing data source instance exists
-/*
-// Create cd_tekton_pipeline_trigger_property data source
-data "ibm_cd_tekton_pipeline_trigger_property" "cd_tekton_pipeline_trigger_property_instance" {
-  pipeline_id = var.cd_tekton_pipeline_trigger_property_pipeline_id
-  trigger_id = var.cd_tekton_pipeline_trigger_property_trigger_id
-  property_name = var.cd_tekton_pipeline_trigger_property_property_name
-}
-*/
-
-// Data source is not linked to a resource instance
-// Uncomment if an existing data source instance exists
-/*
-// Create cd_tekton_pipeline_property data source
-data "ibm_cd_tekton_pipeline_property" "cd_tekton_pipeline_property_instance" {
-  pipeline_id = var.cd_tekton_pipeline_property_pipeline_id
-  property_name = var.cd_tekton_pipeline_property_property_name
-}
-*/
-
-// Data source is not linked to a resource instance
-// Uncomment if an existing data source instance exists
-/*
 // Create cd_tekton_pipeline_trigger data source
 data "ibm_cd_tekton_pipeline_trigger" "cd_tekton_pipeline_trigger_instance" {
-  pipeline_id = var.cd_tekton_pipeline_trigger_pipeline_id
-  trigger_id = var.cd_tekton_pipeline_trigger_trigger_id
+  pipeline_id = ibm_cd_tekton_pipeline.cd_pipeline_instance.pipeline_id
+  trigger_id = ibm_cd_tekton_pipeline_trigger.cd_tekton_pipeline_trigger_instance.trigger_id
 }
-*/
-
-// Data source is not linked to a resource instance
-// Uncomment if an existing data source instance exists
-/*
+// Create cd_tekton_pipeline_trigger_property data source
+data "ibm_cd_tekton_pipeline_trigger_property" "cd_tekton_pipeline_trigger_property_instance" {
+  pipeline_id = ibm_cd_tekton_pipeline.cd_pipeline_instance.pipeline_id
+  trigger_id = ibm_cd_tekton_pipeline_trigger.cd_tekton_pipeline_trigger_instance.trigger_id
+  property_name = ibm_cd_tekton_pipeline_trigger_property.cd_tekton_pipeline_trigger_property_instance.name
+}
+// Create cd_tekton_pipeline_property data source
+data "ibm_cd_tekton_pipeline_property" "cd_tekton_pipeline_property_instance" {
+  pipeline_id = ibm_cd_tekton_pipeline.cd_pipeline_instance.pipeline_id
+  property_name = ibm_cd_tekton_pipeline_property.cd_tekton_pipeline_property_instance.name
+}
 // Create cd_tekton_pipeline data source
 data "ibm_cd_tekton_pipeline" "cd_tekton_pipeline_instance" {
-  id = var.cd_tekton_pipeline_id
+  pipeline_id = ibm_cd_tekton_pipeline.cd_pipeline_instance.pipeline_id
 }
-*/

--- a/examples/ibm-cd-tekton-pipeline/main.tf
+++ b/examples/ibm-cd-tekton-pipeline/main.tf
@@ -8,9 +8,7 @@ resource "ibm_cd_tekton_pipeline_definition" "cd_tekton_pipeline_definition_inst
   scm_source {
     url = "url"
     branch = "branch"
-    tag = "tag"
     path = "path"
-    service_instance_id = "service_instance_id"
   }
 }
 
@@ -20,9 +18,7 @@ resource "ibm_cd_tekton_pipeline_trigger_property" "cd_tekton_pipeline_trigger_p
   trigger_id = var.cd_tekton_pipeline_trigger_property_trigger_id
   name = var.cd_tekton_pipeline_trigger_property_name
   value = var.cd_tekton_pipeline_trigger_property_value
-  enum = var.cd_tekton_pipeline_trigger_property_enum
   type = var.cd_tekton_pipeline_trigger_property_type
-  path = var.cd_tekton_pipeline_trigger_property_path
 }
 
 // Provision cd_tekton_pipeline_property resource instance
@@ -30,9 +26,7 @@ resource "ibm_cd_tekton_pipeline_property" "cd_tekton_pipeline_property_instance
   pipeline_id = var.cd_tekton_pipeline_property_pipeline_id
   name = var.cd_tekton_pipeline_property_name
   value = var.cd_tekton_pipeline_property_value
-  enum = var.cd_tekton_pipeline_property_enum
   type = var.cd_tekton_pipeline_property_type
-  path = var.cd_tekton_pipeline_property_path
 }
 
 // Provision cd_tekton_pipeline_trigger resource instance
@@ -47,25 +41,6 @@ resource "ibm_cd_tekton_pipeline_trigger" "cd_tekton_pipeline_trigger_instance" 
   }
   max_concurrent_runs = var.cd_tekton_pipeline_trigger_max_concurrent_runs
   disabled = var.cd_tekton_pipeline_trigger_disabled
-  secret {
-    type = "token_matches"
-    value = "value"
-    source = "header"
-    key_name = "key_name"
-    algorithm = "md4"
-  }
-  cron = var.cd_tekton_pipeline_trigger_cron
-  timezone = var.cd_tekton_pipeline_trigger_timezone
-  scm_source {
-    url = "url"
-    branch = "branch"
-    pattern = "pattern"
-  }
-  events {
-    push = true
-    pull_request_closed = true
-    pull_request = true
-  }
 }
 
 // Provision cd_tekton_pipeline resource instance

--- a/examples/ibm-cd-tekton-pipeline/main.tf
+++ b/examples/ibm-cd-tekton-pipeline/main.tf
@@ -43,9 +43,7 @@ resource "ibm_cd_tekton_pipeline_trigger" "cd_tekton_pipeline_trigger_instance" 
   event_listener = var.cd_tekton_pipeline_trigger_event_listener
   tags = var.cd_tekton_pipeline_trigger_tags
   worker {
-    name = "name"
-    type = "public "
-    id = "id"
+    id = "public"
   }
   max_concurrent_runs = var.cd_tekton_pipeline_trigger_max_concurrent_runs
   disabled = var.cd_tekton_pipeline_trigger_disabled

--- a/examples/ibm-cd-tekton-pipeline/outputs.tf
+++ b/examples/ibm-cd-tekton-pipeline/outputs.tf
@@ -1,3 +1,9 @@
+// This allows cd_tekton_pipeline data to be referenced by other resources and the terraform CLI
+// Modify this if only certain data should be exposed"
+output "ibm_cd_tekton_pipeline" {
+  value       = ibm_cd_tekton_pipeline.cd_pipeline_instance
+  description = "cd_pipeline_instance resource instance"
+}
 // This allows cd_tekton_pipeline_definition data to be referenced by other resources and the terraform CLI
 // Modify this if only certain data should be exposed
 output "ibm_cd_tekton_pipeline_definition" {
@@ -21,10 +27,4 @@ output "ibm_cd_tekton_pipeline_property" {
 output "ibm_cd_tekton_pipeline_trigger" {
   value       = ibm_cd_tekton_pipeline_trigger.cd_tekton_pipeline_trigger_instance
   description = "cd_tekton_pipeline_trigger resource instance"
-}
-// This allows cd_tekton_pipeline data to be referenced by other resources and the terraform CLI
-// Modify this if only certain data should be exposed
-output "ibm_cd_tekton_pipeline" {
-  value       = ibm_cd_tekton_pipeline.cd_tekton_pipeline_instance
-  description = "cd_tekton_pipeline resource instance"
 }

--- a/examples/ibm-cd-tekton-pipeline/variables.tf
+++ b/examples/ibm-cd-tekton-pipeline/variables.tf
@@ -3,197 +3,54 @@ variable "ibmcloud_api_key" {
   type        = string
 }
 
-// Resource arguments for cd_tekton_pipeline_definition
-variable "cd_tekton_pipeline_definition_pipeline_id" {
-  description = "The Tekton pipeline ID."
+variable "resource_group" {
   type        = string
-  default     = "94619026-912b-4d92-8f51-6c74f0692d90"
+  description = "Resource group within which toolchain will be created"
+  default     = "Default"
 }
 
-// Resource arguments for cd_tekton_pipeline_trigger_property
-variable "cd_tekton_pipeline_trigger_property_pipeline_id" {
-  description = "The Tekton pipeline ID."
+variable "clone_repo" {
   type        = string
-  default     = "94619026-912b-4d92-8f51-6c74f0692d90"
-}
-variable "cd_tekton_pipeline_trigger_property_trigger_id" {
-  description = "The trigger ID."
-  type        = string
-  default     = "1bb892a1-2e04-4768-a369-b1159eace147"
-}
-variable "cd_tekton_pipeline_trigger_property_name" {
-  description = "Property name."
-  type        = string
-  default     = "key1"
-}
-variable "cd_tekton_pipeline_trigger_property_value" {
-  description = "Property value."
-  type        = string
-  default     = "https://github.com/IBM/tekton-tutorial.git"
-}
-variable "cd_tekton_pipeline_trigger_property_enum" {
-  description = "Options for `single_select` property type. Only needed for `single_select` property type."
-  type        = list(string)
-  default     = [ "enum" ]
-}
-variable "cd_tekton_pipeline_trigger_property_type" {
-  description = "Property type."
-  type        = string
-  default     = "text"
-}
-variable "cd_tekton_pipeline_trigger_property_path" {
-  description = "A dot notation path for `integration` type properties to select a value from the tool integration. If left blank the full tool integration data will be used."
-  type        = string
-  default     = "path"
+  description = "URL of the tekton repo to clone"
+  default     = "https://github.com/open-toolchain/hello-tekton"
 }
 
-// Resource arguments for cd_tekton_pipeline_property
-variable "cd_tekton_pipeline_property_pipeline_id" {
-  description = "The Tekton pipeline ID."
+variable "repo_name" {
   type        = string
-  default     = "94619026-912b-4d92-8f51-6c74f0692d90"
-}
-variable "cd_tekton_pipeline_property_name" {
-  description = "Property name."
-  type        = string
-  default     = "key1"
-}
-variable "cd_tekton_pipeline_property_value" {
-  description = "Property value."
-  type        = string
-  default     = "https://github.com/IBM/tekton-tutorial.git"
-}
-variable "cd_tekton_pipeline_property_enum" {
-  description = "Options for `single_select` property type. Only needed when using `single_select` property type."
-  type        = list(string)
-  default     = [ "enum" ]
-}
-variable "cd_tekton_pipeline_property_type" {
-  description = "Property type."
-  type        = string
-  default     = "text"
-}
-variable "cd_tekton_pipeline_property_path" {
-  description = "A dot notation path for `integration` type properties to select a value from the tool integration."
-  type        = string
-  default     = "path"
+  description = "Name of the new repo that will be created in the toolchain"
+  default     = "simple-tekton"
 }
 
-// Resource arguments for cd_tekton_pipeline_trigger
-variable "cd_tekton_pipeline_trigger_pipeline_id" {
-  description = "The Tekton pipeline ID."
+variable "region" {
   type        = string
-  default     = "94619026-912b-4d92-8f51-6c74f0692d90"
-}
-variable "cd_tekton_pipeline_trigger_type" {
-  description = "Trigger type."
-  type        = string
-  default     = "manual"
-}
-variable "cd_tekton_pipeline_trigger_name" {
-  description = "Trigger name."
-  type        = string
-  default     = "Manual Trigger"
-}
-variable "cd_tekton_pipeline_trigger_event_listener" {
-  description = "Event listener name. The name of the event listener to which the trigger is associated. The event listeners are defined in the definition repositories of the Tekton pipeline."
-  type        = string
-  default     = "pr-listener"
-}
-variable "cd_tekton_pipeline_trigger_tags" {
-  description = "Trigger tags array."
-  type        = list(string)
-  default     = [ "tags" ]
-}
-variable "cd_tekton_pipeline_trigger_max_concurrent_runs" {
-  description = "Defines the maximum number of concurrent runs for this trigger. Omit this property to disable the concurrency limit."
-  type        = number
-  default     = 3
-}
-variable "cd_tekton_pipeline_trigger_disabled" {
-  description = "Flag whether the trigger is disabled. If omitted the trigger is enabled by default."
-  type        = bool
-  default     = false
-}
-variable "cd_tekton_pipeline_trigger_cron" {
-  description = "Only needed for timer triggers. Cron expression for timer trigger."
-  type        = string
-  default     = "cron"
-}
-variable "cd_tekton_pipeline_trigger_timezone" {
-  description = "Only needed for timer triggers. Timezone for timer trigger."
-  type        = string
-  default     = "timezone"
+  description = "IBM Cloud region where your toolchain will be created"
+  default     = "us-south"
 }
 
-// Resource arguments for cd_tekton_pipeline
-variable "cd_tekton_pipeline_enable_slack_notifications" {
-  description = "Flag whether to enable slack notifications for this pipeline. When enabled, pipeline run events will be published on all slack integration specified channels in the enclosing toolchain."
-  type        = bool
-  default     = true
-}
-variable "cd_tekton_pipeline_enable_partial_cloning" {
-  description = "Flag whether to enable partial cloning for this pipeline. When partial clone is enabled, only the files contained within the paths specified in definition repositories will be read and cloned. This means symbolic links may not work."
-  type        = bool
-  default     = true
+variable "toolchain_name" {
+  type        = string
+  description = "Name of the Toolchain"
+  default     = "Simple Helm Toolchain"
 }
 
-// Data source arguments for cd_tekton_pipeline_definition
-variable "cd_tekton_pipeline_definition_pipeline_id" {
-  description = "The Tekton pipeline ID."
+variable "toolchain_description" {
   type        = string
-  default     = "94619026-912b-4d92-8f51-6c74f0692d90"
-}
-variable "cd_tekton_pipeline_definition_definition_id" {
-  description = "The definition ID."
-  type        = string
-  default     = "94299034-d45f-4e9a-8ed5-6bd5c7bb7ada"
+  description = "Description for the Toolchain"
+  default     = "Toolchain created using IBM Cloud Continuous Delivery Service"
 }
 
-// Data source arguments for cd_tekton_pipeline_trigger_property
-variable "cd_tekton_pipeline_trigger_property_pipeline_id" {
-  description = "The Tekton pipeline ID."
+variable "cluster" {
   type        = string
-  default     = "94619026-912b-4d92-8f51-6c74f0692d90"
-}
-variable "cd_tekton_pipeline_trigger_property_trigger_id" {
-  description = "The trigger ID."
-  type        = string
-  default     = "1bb892a1-2e04-4768-a369-b1159eace147"
-}
-variable "cd_tekton_pipeline_trigger_property_property_name" {
-  description = "The property name."
-  type        = string
-  default     = "debug-pipeline"
+  description = "The name of your IKS cluster where you will be deploying the sample app"
 }
 
-// Data source arguments for cd_tekton_pipeline_property
-variable "cd_tekton_pipeline_property_pipeline_id" {
-  description = "The Tekton pipeline ID."
+variable "cluster_namespace" {
   type        = string
-  default     = "94619026-912b-4d92-8f51-6c74f0692d90"
-}
-variable "cd_tekton_pipeline_property_property_name" {
-  description = "The property name."
-  type        = string
-  default     = "debug-pipeline"
+  description = "The namespace in your cluster where the app will be deployed"
+  default     = "prod"
 }
 
-// Data source arguments for cd_tekton_pipeline_trigger
-variable "cd_tekton_pipeline_trigger_pipeline_id" {
-  description = "The Tekton pipeline ID."
+variable "registry_namespace" {
   type        = string
-  default     = "94619026-912b-4d92-8f51-6c74f0692d90"
-}
-variable "cd_tekton_pipeline_trigger_trigger_id" {
-  description = "The trigger ID."
-  type        = string
-  default     = "1bb892a1-2e04-4768-a369-b1159eace147"
-}
-
-// Data source arguments for cd_tekton_pipeline
-variable "cd_tekton_pipeline_id" {
-  description = "ID of current instance."
-  type        = string
-  default     = "94619026-912b-4d92-8f51-6c74f0692d90"
+  description = "The IBM Cloud Container Registry namespace where the app image will be built and stored."
 }

--- a/examples/ibm-cd-tekton-pipeline/variables.tf
+++ b/examples/ibm-cd-tekton-pipeline/variables.tf
@@ -42,7 +42,7 @@ variable "cd_tekton_pipeline_trigger_property_type" {
   default     = "text"
 }
 variable "cd_tekton_pipeline_trigger_property_path" {
-  description = "A dot notation path for `integration` type properties to select a value from the tool integration. If left blank the full tool integration JSON will be selected."
+  description = "A dot notation path for `integration` type properties to select a value from the tool integration. If left blank the full tool integration data will be used."
   type        = string
   default     = "path"
 }

--- a/examples/ibm-cd-tekton-pipeline/variables.tfvars.example
+++ b/examples/ibm-cd-tekton-pipeline/variables.tfvars.example
@@ -1,0 +1,13 @@
+/*****************************************************/
+/* Variables for Module "Main"                       */
+/*****************************************************/
+resource_group                  = "<ibm-cloud-resource-group>"
+ibmcloud_api_key                = "<ibm-cloud-api-key>"
+region                          = "<ibm-cloud-region>"
+toolchain_name                  = "some name for toolchain"
+toolchain_description           = "some description for toolchain"
+clone_repo                      = "URL for the Tekton repo to clone, e.g. 'https://github.com/open-toolchain/hello-tekton'"
+repo_name                       = "some name for the repository that will be created in the toolchain"
+cluster                         = "<ibm-cloud-cluster-name> where the app will be deployed"
+cluster_namespace               = "<ibm-cloud-cluster-namespace> in the cluster where the app will be deployed"
+registry_namespace              = "<ibm-cloud-container-registry-namespace> where the app image will be built and stored"

--- a/examples/ibm-cd-tekton-pipeline/versions.tf
+++ b/examples/ibm-cd-tekton-pipeline/versions.tf
@@ -1,3 +1,12 @@
+###############################
+# IBM Cloud Copyright 2022 IBM
+###############################
+
 terraform {
-  required_version = ">= 0.12"
+  required_providers {
+    ibm = {
+      source = "IBM-Cloud/ibm"
+      version = ">=1.45.0"
+    }
+  }
 }

--- a/examples/ibm-cd-toolchain-empty/versions.tf
+++ b/examples/ibm-cd-toolchain-empty/versions.tf
@@ -6,7 +6,7 @@ terraform {
   required_providers {
     ibm = {
       source = "IBM-Cloud/ibm"
-      version = "1.43.0-beta0"
+      version = ">=1.45.0"
     }
   }
 }

--- a/examples/ibm-cd-toolchain-simple-helm/integrations/versions.tf
+++ b/examples/ibm-cd-toolchain-simple-helm/integrations/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     ibm = {
       source = "IBM-Cloud/ibm"
-      version = "1.43.0-beta0"
+      version = ">=1.45.0"
     }
   }
 }

--- a/examples/ibm-cd-toolchain-simple-helm/pipeline-ci/environments.tf
+++ b/examples/ibm-cd-toolchain-simple-helm/pipeline-ci/environments.tf
@@ -1,97 +1,97 @@
 resource "ibm_cd_tekton_pipeline_property" "ci_env_apikey" {
   name           = "apikey"
-  type           = "SECURE"
+  type           = "secure"
   value          = format("{vault::%s.ibmcloud-api-key}", var.kp_integration_name)
   pipeline_id    = var.pipeline_id           
 }
 
 resource "ibm_cd_tekton_pipeline_property" "ci_env_app_name" {
   name           = "app-name"
-  type           = "TEXT"
+  type           = "text"
   value          = var.app_name
   pipeline_id    = var.pipeline_id         
 }
 
 resource "ibm_cd_tekton_pipeline_property" "ci_env_branch" {
   name           = "branch"
-  type           = "TEXT"
+  type           = "text"
   value          = "main"
   pipeline_id    = var.pipeline_id         
 }
 
 resource "ibm_cd_tekton_pipeline_property" "ci_env_cluster_name" {
   name           = "cluster-name"
-  type           = "TEXT"
+  type           = "text"
   value          = var.cluster_name
   pipeline_id    = var.pipeline_id         
 }
 
 resource "ibm_cd_tekton_pipeline_property" "ci_env_commons_hosted_region" {
   name           = "commons-hosted-region"
-  type           = "TEXT"
+  type           = "text"
   value          = "https://raw.githubusercontent.com/open-toolchain/commons/master"
   pipeline_id    = var.pipeline_id         
 }
 
 resource "ibm_cd_tekton_pipeline_property" "ci_env_dev_cluster_namespace" {
   name           = "dev-cluster-namespace"
-  type           = "TEXT"
+  type           = "text"
   value          = var.cluster_namespace
   pipeline_id    = var.pipeline_id         
 }
 
 resource "ibm_cd_tekton_pipeline_property" "ci_env_dev_region" {
   name           = "dev-region"
-  type           = "TEXT"
+  type           = "text"
   value          = var.cluster_region
   pipeline_id    = var.pipeline_id         
 }
 
 resource "ibm_cd_tekton_pipeline_property" "ci_env_dev_resource_group" {
   name           = "dev-resource-group"
-  type           = "TEXT"
+  type           = "text"
   value          = var.resource_group
   pipeline_id    = var.pipeline_id         
 }
 
 resource "ibm_cd_tekton_pipeline_property" "ci_env_image_name" {
   name           = "image-name"
-  type           = "TEXT"
+  type           = "text"
   value          = var.app_image_name
   pipeline_id    = var.pipeline_id         
 }
 
 resource "ibm_cd_tekton_pipeline_property" "ci_env_registry_namespace" {
   name           = "registry-namespace"
-  type           = "TEXT"
+  type           = "text"
   value          = var.registry_namespace
   pipeline_id    = var.pipeline_id         
 }
 
 resource "ibm_cd_tekton_pipeline_property" "ci_env_registry_region" {
   name           = "registry-region"
-  type           = "TEXT"
+  type           = "text"
   value          = var.registry_region
   pipeline_id    = var.pipeline_id         
 }
 
 resource "ibm_cd_tekton_pipeline_property" "ci_env_toolchain_apikey" {
   name           = "toolchain-apikey"
-  type           = "SECURE"
+  type           = "secure"
   value          = format("{vault::%s.ibmcloud-api-key}", var.kp_integration_name)
   pipeline_id    = var.pipeline_id         
 }
 
 resource "ibm_cd_tekton_pipeline_property" "ci_env_repository" {
   name           = "repository"
-  type           = "TEXT"
+  type           = "text"
   value          = var.app_repo
   pipeline_id    = var.pipeline_id         
 }
 
 resource "ibm_cd_tekton_pipeline_property" "ci_env_ibmcloud-api" {
   name           = "ibmcloud-api"
-  type           = "TEXT"
+  type           = "text"
   value          = "https://cloud.ibm.com"
   pipeline_id    = var.pipeline_id         
 }

--- a/examples/ibm-cd-toolchain-simple-helm/pipeline-ci/pipeline-ci.tf
+++ b/examples/ibm-cd-toolchain-simple-helm/pipeline-ci/pipeline-ci.tf
@@ -9,7 +9,7 @@ resource "ibm_cd_tekton_pipeline_definition" "ci_pipeline_def" {
   pipeline_id  = ibm_cd_tekton_pipeline.ci_pipeline_instance.pipeline_id
   scm_source {
     url = var.pipeline_repo
-    branch = "main"
+    branch = "master"
     path = ".pipeline"
   }
 }
@@ -18,7 +18,7 @@ resource "ibm_cd_tekton_pipeline_definition" "ci_git_task_def" {
   pipeline_id  = ibm_cd_tekton_pipeline.ci_pipeline_instance.pipeline_id
   scm_source {
     url = var.tekton_tasks_catalog_repo
-    branch = "main"
+    branch = "master"
     path = "git"
   }
 }
@@ -27,7 +27,7 @@ resource "ibm_cd_tekton_pipeline_definition" "ci_cr_task_def" {
   pipeline_id  = ibm_cd_tekton_pipeline.ci_pipeline_instance.pipeline_id
   scm_source {
     url = var.tekton_tasks_catalog_repo
-    branch = "main"
+    branch = "master"
     path = "container-registry"
   }
 }
@@ -36,7 +36,7 @@ resource "ibm_cd_tekton_pipeline_definition" "ci_kube_task_def" {
   pipeline_id  = ibm_cd_tekton_pipeline.ci_pipeline_instance.pipeline_id
   scm_source {
     url = var.tekton_tasks_catalog_repo
-    branch = "main"
+    branch = "master"
     path = "kubernetes-service"
   }
 }
@@ -45,7 +45,7 @@ resource "ibm_cd_tekton_pipeline_definition" "ci_toolchain_task_def" {
   pipeline_id  = ibm_cd_tekton_pipeline.ci_pipeline_instance.pipeline_id
   scm_source {
     url = var.tekton_tasks_catalog_repo
-    branch = "main"
+    branch = "master"
     path = "toolchain"
   }
 }
@@ -54,7 +54,7 @@ resource "ibm_cd_tekton_pipeline_definition" "ci_insights_task_def" {
   pipeline_id  = ibm_cd_tekton_pipeline.ci_pipeline_instance.pipeline_id
   scm_source {
     url = var.tekton_tasks_catalog_repo
-    branch = "main"
+    branch = "master"
     path = "devops-insights"
   }
 }
@@ -63,7 +63,7 @@ resource "ibm_cd_tekton_pipeline_definition" "ci_linter_task_def" {
   pipeline_id  = ibm_cd_tekton_pipeline.ci_pipeline_instance.pipeline_id
   scm_source {
     url = var.tekton_tasks_catalog_repo
-    branch = "main"
+    branch = "master"
     path = "linter"
   }
 }
@@ -72,7 +72,7 @@ resource "ibm_cd_tekton_pipeline_definition" "ci_tester_task_def" {
   pipeline_id   = ibm_cd_tekton_pipeline.ci_pipeline_instance.pipeline_id
   scm_source {
     url = var.tekton_tasks_catalog_repo
-    branch = "main"
+    branch = "master"
     path = "tester"
   }
 }
@@ -81,38 +81,32 @@ resource "ibm_cd_tekton_pipeline_definition" "ci_utils_task_def" {
   pipeline_id  = ibm_cd_tekton_pipeline.ci_pipeline_instance.pipeline_id
   scm_source {
     url = var.tekton_tasks_catalog_repo
-    branch = "main"
+    branch = "master"
     path = "utils"
   }
 }
 
 resource "ibm_cd_tekton_pipeline_trigger" "ci_pipeline_scm_trigger" {
-  pipeline_id       = ibm_cd_tekton_pipeline.ci_pipeline_instance.pipeline_id
-  trigger {
-    type            = var.ci_pipeline_scm_trigger_type
-    name            = var.ci_pipeline_scm_trigger_name
-    event_listener  = var.ci_pipeline_scm_trigger_listener_name
-    scm_source {
-      url     = var.app_repo
-      branch  = "main"
-    }
-    events {
-      push                = false
-      pull_request_closed = true
-      pull_request        = false
-    } 
-    disabled         = var.ci_pipeline_scm_trigger_disabled 
-    concurrency {
-      max_concurrent_runs = var.ci_pipeline_max_concurrent_runs
-    }
+  pipeline_id     = ibm_cd_tekton_pipeline.ci_pipeline_instance.pipeline_id
+  type            = var.ci_pipeline_scm_trigger_type
+  name            = var.ci_pipeline_scm_trigger_name
+  event_listener  = var.ci_pipeline_scm_trigger_listener_name
+  scm_source {
+    url     = var.app_repo
+    branch  = "master"
   }
+  events {
+    push                = false
+    pull_request_closed = true
+    pull_request        = false
+  } 
+  disabled         = var.ci_pipeline_scm_trigger_disabled
+  max_concurrent_runs = var.ci_pipeline_max_concurrent_runs
 }
 
 resource "ibm_cd_tekton_pipeline_trigger" "ci_pipeline_manual_trigger" {
-  pipeline_id       = var.pipeline_id
-  trigger {
-    type            = "manual"
-    name            = "manual-run"
-    event_listener  = "manual-run"
-  }
+  pipeline_id     = var.pipeline_id
+  type            = "manual"
+  name            = "manual-run"
+  event_listener  = "manual-run"
 }

--- a/examples/ibm-cd-toolchain-simple-helm/pipeline-ci/versions.tf
+++ b/examples/ibm-cd-toolchain-simple-helm/pipeline-ci/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     ibm = {
       source = "IBM-Cloud/ibm"
-      version = "1.43.0-beta0"
+      version = ">=1.45.0"
     }
   }
 }

--- a/examples/ibm-cd-toolchain-simple-helm/pipeline-pr/environments.tf
+++ b/examples/ibm-cd-toolchain-simple-helm/pipeline-pr/environments.tf
@@ -1,20 +1,20 @@
 resource "ibm_cd_tekton_pipeline_property" "pr_env_apikey" {
   name           = "apikey"
-  type           = "SECURE"
+  type           = "secure"
   value          = format("{vault::%s.ibmcloud-api-key}", var.kp_integration_name)
   pipeline_id    = var.pipeline_id           
 }
 
 resource "ibm_cd_tekton_pipeline_property" "pr_env_ibmcloud-api" {
   name           = "ibmcloud-api"
-  type           = "TEXT"
+  type           = "text"
   value          = "https://cloud.ibm.com"
   pipeline_id    = var.pipeline_id         
 }
 
 resource "ibm_cd_tekton_pipeline_property" "pr_env_pipeline-debug" {
   name           = "pipeline-debug"
-  type           = "TEXT"
+  type           = "text"
   value          = "0"
   pipeline_id    = var.pipeline_id         
 }

--- a/examples/ibm-cd-toolchain-simple-helm/pipeline-pr/pipeline-pr.tf
+++ b/examples/ibm-cd-toolchain-simple-helm/pipeline-pr/pipeline-pr.tf
@@ -18,7 +18,7 @@ resource "ibm_cd_tekton_pipeline_definition" "pr_git_task_def" {
   pipeline_id   = ibm_cd_tekton_pipeline.pr_pipeline_instance.pipeline_id
   scm_source {
     url         = var.tekton_tasks_catalog_repo
-    branch      = "main"
+    branch      = "master"
     path        = "git"
   }
 }
@@ -27,7 +27,7 @@ resource "ibm_cd_tekton_pipeline_definition" "pr_toolchain_task_def" {
   pipeline_id   = ibm_cd_tekton_pipeline.pr_pipeline_instance.pipeline_id
   scm_source {
     url         = var.tekton_tasks_catalog_repo
-    branch      = "main"
+    branch      = "master"
     path        = "toolchain"
   }
 }
@@ -36,7 +36,7 @@ resource "ibm_cd_tekton_pipeline_definition" "pr_linter_task_def" {
   pipeline_id   = ibm_cd_tekton_pipeline.pr_pipeline_instance.pipeline_id
   scm_source {
     url         = var.tekton_tasks_catalog_repo
-    branch      = "main"
+    branch      = "master"
     path        = "linter"
   }
 }
@@ -45,7 +45,7 @@ resource "ibm_cd_tekton_pipeline_definition" "pr_tester_task_def" {
   pipeline_id   = ibm_cd_tekton_pipeline.pr_pipeline_instance.pipeline_id
   scm_source {
     url         = var.tekton_tasks_catalog_repo
-    branch      = "main"
+    branch      = "master"
     path        = "tester"
   }
 }
@@ -54,28 +54,24 @@ resource "ibm_cd_tekton_pipeline_definition" "pr_utils_task_def" {
   pipeline_id   = ibm_cd_tekton_pipeline.pr_pipeline_instance.pipeline_id
   scm_source {
     url         = var.tekton_tasks_catalog_repo
-    branch      = "main"
+    branch      = "master"
     path        = "utils"
   }
 }
 
 resource "ibm_cd_tekton_pipeline_trigger" "pr_pipeline_scm_trigger" {
-  pipeline_id       = ibm_cd_tekton_pipeline.pr_pipeline_instance.pipeline_id
-  trigger {
-    type            = var.pr_pipeline_scm_trigger_type
-    name            = var.pr_pipeline_scm_trigger_name
-    event_listener  = var.pr_pipeline_scm_trigger_listener_name
-    scm_source {
-      url       = var.app_repo
-      branch    = "main"
-    }
-    events {
-      push                = true
-      pull_request_closed = true
-      pull_request        = true
-    } 
-    concurrency {
-      max_concurrent_runs = var.pr_pipeline_max_concurrent_runs
-    }
+  pipeline_id     = ibm_cd_tekton_pipeline.pr_pipeline_instance.pipeline_id
+  type            = var.pr_pipeline_scm_trigger_type
+  name            = var.pr_pipeline_scm_trigger_name
+  event_listener  = var.pr_pipeline_scm_trigger_listener_name
+  scm_source {
+    url       = var.app_repo
+    branch    = "master"
   }
+  events {
+    push                = true
+    pull_request_closed = true
+    pull_request        = true
+  } 
+  max_concurrent_runs = var.pr_pipeline_max_concurrent_runs
 }

--- a/examples/ibm-cd-toolchain-simple-helm/pipeline-pr/versions.tf
+++ b/examples/ibm-cd-toolchain-simple-helm/pipeline-pr/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     ibm = {
       source = "IBM-Cloud/ibm"
-      version = "1.43.0-beta0"
+      version = ">=1.45.0"
     }
   }
 }

--- a/examples/ibm-cd-toolchain-simple-helm/repositories/versions.tf
+++ b/examples/ibm-cd-toolchain-simple-helm/repositories/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     ibm = {
       source = "IBM-Cloud/ibm"
-      version = "1.43.0-beta0"
+      version = ">=1.45.0"
     }
   }
 }

--- a/examples/ibm-cd-toolchain-simple-helm/services/versions.tf
+++ b/examples/ibm-cd-toolchain-simple-helm/services/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     ibm = {
       source = "IBM-Cloud/ibm"
-      version = "1.43.0-beta0"
+      version = ">=1.45.0"
     }
   }
 }

--- a/examples/ibm-cd-toolchain-simple-helm/variables.tf
+++ b/examples/ibm-cd-toolchain-simple-helm/variables.tf
@@ -60,7 +60,7 @@ variable "cluster_namespace" {
 variable "cluster_region" {
   type        = string
   description = "Region of the kubernetes cluster where the application will be deployed."
-  default     = "ibm:yp1:us-south"
+  default     = "ibm:yp:us-south"
 }
 
 variable "registry_namespace" {
@@ -72,7 +72,7 @@ variable "registry_namespace" {
 variable "registry_region" {
   type        = string
   description = "IBM Cloud Region where the IBM Cloud Container Registry where registry is to be created."
-  default     = "ibm:yp1:us-south"
+  default     = "ibm:yp:us-south"
 }
 
 variable "kp_name" {
@@ -84,7 +84,7 @@ variable "kp_name" {
 variable "kp_region" {
   type        = string
   description = "IBM Cloud Region where the Key Protect Instance is created."
-  default     = "ibm:yp1:us-south"
+  default     = "ibm:yp:us-south"
 }
 
 variable "app_repo" {

--- a/examples/ibm-cd-toolchain-simple-helm/versions.tf
+++ b/examples/ibm-cd-toolchain-simple-helm/versions.tf
@@ -6,7 +6,7 @@ terraform {
   required_providers {
     ibm = {
       source = "IBM-Cloud/ibm"
-      version = "1.43.0-beta0"
+      version = ">=1.45.0"
     }
   }
 }

--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/IBM/cloud-databases-go-sdk v0.2.0
 	github.com/IBM/cloudant-go-sdk v0.0.43
 	github.com/IBM/container-registry-go-sdk v0.0.15
-	github.com/IBM/continuous-delivery-go-sdk v0.1.0
+	github.com/IBM/continuous-delivery-go-sdk v0.1.1
 	github.com/IBM/event-notifications-go-admin-sdk v0.1.2
 	github.com/IBM/eventstreams-go-sdk v1.2.0
 	github.com/IBM/go-sdk-core/v5 v5.10.2

--- a/go.sum
+++ b/go.sum
@@ -23,8 +23,8 @@ github.com/IBM/cloudant-go-sdk v0.0.43 h1:YxTy4RpAEezX32YIWnds76hrBREmO4u6IkBz1W
 github.com/IBM/cloudant-go-sdk v0.0.43/go.mod h1:WeYrJPaHTw19943ndWnVfwMIlZ5z0XUM2uEXNBrwZ1M=
 github.com/IBM/container-registry-go-sdk v0.0.15 h1:sfEXm4qNj9ZCwTlFOsdjF5P/lvajU/Sc22yNlzg0F9I=
 github.com/IBM/container-registry-go-sdk v0.0.15/go.mod h1:KqSZFO4VIK9QAyF8O1JW6jkyzkfE/BNKUIo+OdzIDk4=
-github.com/IBM/continuous-delivery-go-sdk v0.1.0 h1:myQ1UT0IGYl7pkGvuqvlN8PM3oP9TZWke+pJ37+vJgc=
-github.com/IBM/continuous-delivery-go-sdk v0.1.0/go.mod h1:u63XH83hLREOAeGs+/nbe3BEn21udFP9dddryP24OGM=
+github.com/IBM/continuous-delivery-go-sdk v0.1.1 h1:9OHBVd0Z1k9WbJ63IgLh4St9+rtWEXGaTCChKjJOKmo=
+github.com/IBM/continuous-delivery-go-sdk v0.1.1/go.mod h1:u63XH83hLREOAeGs+/nbe3BEn21udFP9dddryP24OGM=
 github.com/IBM/event-notifications-go-admin-sdk v0.1.2 h1:LLA12WFqSD0+Uf16SNdErcu2MVK4EnyXHJmDIkKkudE=
 github.com/IBM/event-notifications-go-admin-sdk v0.1.2/go.mod h1:VCtV/cAN8qSPeWEjIWeXOQGTq6LCWP9yZEk7wt3g0HM=
 github.com/IBM/eventstreams-go-sdk v1.2.0 h1:eP0afHArMGjwhGqvZAhhu/3EDKRch2JehpveqF1TUjs=

--- a/ibm/service/cdtektonpipeline/data_source_ibm_cd_tekton_pipeline.go
+++ b/ibm/service/cdtektonpipeline/data_source_ibm_cd_tekton_pipeline.go
@@ -218,7 +218,7 @@ func DataSourceIBMCdTektonPipeline() *schema.Resource {
 									"path": &schema.Schema{
 										Type:        schema.TypeString,
 										Computed:    true,
-										Description: "A dot notation path for `integration` type properties to select a value from the tool integration. If left blank the full tool integration JSON will be selected.",
+										Description: "A dot notation path for `integration` type properties to select a value from the tool integration. If left blank the full tool integration data will be used.",
 									},
 									"href": &schema.Schema{
 										Type:        schema.TypeString,

--- a/ibm/service/cdtektonpipeline/data_source_ibm_cd_tekton_pipeline.go
+++ b/ibm/service/cdtektonpipeline/data_source_ibm_cd_tekton_pipeline.go
@@ -377,6 +377,11 @@ func DataSourceIBMCdTektonPipeline() *schema.Resource {
 								},
 							},
 						},
+						"webhook_url": &schema.Schema{
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "Webhook URL that can be used to trigger pipeline runs.",
+						},
 					},
 				},
 			},
@@ -477,7 +482,7 @@ func dataSourceIBMCdTektonPipelineRead(context context.Context, d *schema.Resour
 
 	definitions := []map[string]interface{}{}
 	if tektonPipeline.Definitions != nil {
-		for _, modelItem := range tektonPipeline.Definitions {
+		for _, modelItem := range tektonPipeline.Definitions { 
 			modelMap, err := dataSourceIBMCdTektonPipelineDefinitionToMap(&modelItem)
 			if err != nil {
 				return diag.FromErr(err)
@@ -491,7 +496,7 @@ func dataSourceIBMCdTektonPipelineRead(context context.Context, d *schema.Resour
 
 	properties := []map[string]interface{}{}
 	if tektonPipeline.Properties != nil {
-		for _, modelItem := range tektonPipeline.Properties {
+		for _, modelItem := range tektonPipeline.Properties { 
 			modelMap, err := dataSourceIBMCdTektonPipelinePropertyToMap(&modelItem)
 			if err != nil {
 				return diag.FromErr(err)
@@ -513,7 +518,7 @@ func dataSourceIBMCdTektonPipelineRead(context context.Context, d *schema.Resour
 
 	triggers := []map[string]interface{}{}
 	if tektonPipeline.Triggers != nil {
-		for _, modelItem := range tektonPipeline.Triggers {
+		for _, modelItem := range tektonPipeline.Triggers { 
 			modelMap, err := dataSourceIBMCdTektonPipelineTriggerToMap(modelItem)
 			if err != nil {
 				return diag.FromErr(err)
@@ -706,6 +711,9 @@ func dataSourceIBMCdTektonPipelineTriggerToMap(model cdtektonpipelinev2.TriggerI
 				return modelMap, err
 			}
 			modelMap["secret"] = []map[string]interface{}{secretMap}
+		}
+		if model.WebhookURL != nil {
+			modelMap["webhook_url"] = *model.WebhookURL
 		}
 		return modelMap, nil
 	} else {
@@ -1087,6 +1095,9 @@ func dataSourceIBMCdTektonPipelineTriggerGenericTriggerToMap(model *cdtektonpipe
 			return modelMap, err
 		}
 		modelMap["secret"] = []map[string]interface{}{secretMap}
+	}
+	if model.WebhookURL != nil {
+		modelMap["webhook_url"] = *model.WebhookURL
 	}
 	return modelMap, nil
 }

--- a/ibm/service/cdtektonpipeline/data_source_ibm_cd_tekton_pipeline.go
+++ b/ibm/service/cdtektonpipeline/data_source_ibm_cd_tekton_pipeline.go
@@ -482,7 +482,7 @@ func dataSourceIBMCdTektonPipelineRead(context context.Context, d *schema.Resour
 
 	definitions := []map[string]interface{}{}
 	if tektonPipeline.Definitions != nil {
-		for _, modelItem := range tektonPipeline.Definitions { 
+		for _, modelItem := range tektonPipeline.Definitions {
 			modelMap, err := dataSourceIBMCdTektonPipelineDefinitionToMap(&modelItem)
 			if err != nil {
 				return diag.FromErr(err)
@@ -496,7 +496,7 @@ func dataSourceIBMCdTektonPipelineRead(context context.Context, d *schema.Resour
 
 	properties := []map[string]interface{}{}
 	if tektonPipeline.Properties != nil {
-		for _, modelItem := range tektonPipeline.Properties { 
+		for _, modelItem := range tektonPipeline.Properties {
 			modelMap, err := dataSourceIBMCdTektonPipelinePropertyToMap(&modelItem)
 			if err != nil {
 				return diag.FromErr(err)
@@ -518,7 +518,7 @@ func dataSourceIBMCdTektonPipelineRead(context context.Context, d *schema.Resour
 
 	triggers := []map[string]interface{}{}
 	if tektonPipeline.Triggers != nil {
-		for _, modelItem := range tektonPipeline.Triggers { 
+		for _, modelItem := range tektonPipeline.Triggers {
 			modelMap, err := dataSourceIBMCdTektonPipelineTriggerToMap(modelItem)
 			if err != nil {
 				return diag.FromErr(err)

--- a/ibm/service/cdtektonpipeline/data_source_ibm_cd_tekton_pipeline_trigger.go
+++ b/ibm/service/cdtektonpipeline/data_source_ibm_cd_tekton_pipeline_trigger.go
@@ -281,6 +281,11 @@ func dataSourceIBMCdTektonPipelineTriggerRead(context context.Context, d *schema
 	if err = d.Set("event_listener", trigger.EventListener); err != nil {
 		return diag.FromErr(fmt.Errorf("Error setting event_listener: %s", err))
 	}
+	if trigger.Tags != nil {
+		if err = d.Set("tags", trigger.Tags); err != nil {
+			return diag.FromErr(fmt.Errorf("Error setting tags: %s", err))
+		}
+	}
 
 	properties := []map[string]interface{}{}
 	if trigger.Properties != nil {

--- a/ibm/service/cdtektonpipeline/data_source_ibm_cd_tekton_pipeline_trigger.go
+++ b/ibm/service/cdtektonpipeline/data_source_ibm_cd_tekton_pipeline_trigger.go
@@ -286,11 +286,6 @@ func dataSourceIBMCdTektonPipelineTriggerRead(context context.Context, d *schema
 	if err = d.Set("event_listener", trigger.EventListener); err != nil {
 		return diag.FromErr(fmt.Errorf("Error setting event_listener: %s", err))
 	}
-	if trigger.Tags != nil {
-		if err = d.Set("tags", trigger.Tags); err != nil {
-			return diag.FromErr(fmt.Errorf("Error setting tags: %s", err))
-		}
-	}
 
 	if trigger.Tags != nil {
 		if err = d.Set("tags", trigger.Tags); err != nil {

--- a/ibm/service/cdtektonpipeline/data_source_ibm_cd_tekton_pipeline_trigger.go
+++ b/ibm/service/cdtektonpipeline/data_source_ibm_cd_tekton_pipeline_trigger.go
@@ -83,7 +83,7 @@ func DataSourceIBMCdTektonPipelineTrigger() *schema.Resource {
 						"path": &schema.Schema{
 							Type:        schema.TypeString,
 							Computed:    true,
-							Description: "A dot notation path for `integration` type properties to select a value from the tool integration. If left blank the full tool integration JSON will be selected.",
+							Description: "A dot notation path for `integration` type properties to select a value from the tool integration. If left blank the full tool integration data will be used.",
 						},
 						"href": &schema.Schema{
 							Type:        schema.TypeString,

--- a/ibm/service/cdtektonpipeline/data_source_ibm_cd_tekton_pipeline_trigger.go
+++ b/ibm/service/cdtektonpipeline/data_source_ibm_cd_tekton_pipeline_trigger.go
@@ -242,6 +242,11 @@ func DataSourceIBMCdTektonPipelineTrigger() *schema.Resource {
 					},
 				},
 			},
+			"webhook_url": &schema.Schema{
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "Webhook URL that can be used to trigger pipeline runs.",
+			},
 		},
 	}
 }
@@ -281,6 +286,12 @@ func dataSourceIBMCdTektonPipelineTriggerRead(context context.Context, d *schema
 	if err = d.Set("event_listener", trigger.EventListener); err != nil {
 		return diag.FromErr(fmt.Errorf("Error setting event_listener: %s", err))
 	}
+	if trigger.Tags != nil {
+		if err = d.Set("tags", trigger.Tags); err != nil {
+			return diag.FromErr(fmt.Errorf("Error setting tags: %s", err))
+		}
+	}
+
 	if trigger.Tags != nil {
 		if err = d.Set("tags", trigger.Tags); err != nil {
 			return diag.FromErr(fmt.Errorf("Error setting tags: %s", err))
@@ -363,6 +374,10 @@ func dataSourceIBMCdTektonPipelineTriggerRead(context context.Context, d *schema
 	}
 	if err = d.Set("secret", secret); err != nil {
 		return diag.FromErr(fmt.Errorf("Error setting secret %s", err))
+	}
+
+	if err = d.Set("webhook_url", trigger.WebhookURL); err != nil {
+		return diag.FromErr(fmt.Errorf("Error setting webhook_url: %s", err))
 	}
 
 	return nil

--- a/ibm/service/cdtektonpipeline/data_source_ibm_cd_tekton_pipeline_trigger_property.go
+++ b/ibm/service/cdtektonpipeline/data_source_ibm_cd_tekton_pipeline_trigger_property.go
@@ -61,7 +61,7 @@ func DataSourceIBMCdTektonPipelineTriggerProperty() *schema.Resource {
 			"path": &schema.Schema{
 				Type:        schema.TypeString,
 				Computed:    true,
-				Description: "A dot notation path for `integration` type properties to select a value from the tool integration. If left blank the full tool integration JSON will be selected.",
+				Description: "A dot notation path for `integration` type properties to select a value from the tool integration. If left blank the full tool integration data will be used.",
 			},
 		},
 	}

--- a/ibm/service/cdtektonpipeline/resource_ibm_cd_tekton_pipeline.go
+++ b/ibm/service/cdtektonpipeline/resource_ibm_cd_tekton_pipeline.go
@@ -46,8 +46,9 @@ func ResourceIBMCdTektonPipeline() *schema.Resource {
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"id": &schema.Schema{
-							Type:     schema.TypeString,
-							Required: true,
+							Type:        schema.TypeString,
+							Required:    true,
+							Description: "ID of the worker.",
 						},
 					},
 				},
@@ -253,7 +254,7 @@ func ResourceIBMCdTektonPipeline() *schema.Resource {
 									"path": &schema.Schema{
 										Type:        schema.TypeString,
 										Optional:    true,
-										Description: "A dot notation path for `integration` type properties to select a value from the tool integration. If left blank the full tool integration JSON will be selected.",
+										Description: "A dot notation path for `integration` type properties to select a value from the tool integration. If left blank the full tool integration data will be used.",
 									},
 									"href": &schema.Schema{
 										Type:        schema.TypeString,

--- a/ibm/service/cdtektonpipeline/resource_ibm_cd_tekton_pipeline.go
+++ b/ibm/service/cdtektonpipeline/resource_ibm_cd_tekton_pipeline.go
@@ -19,11 +19,11 @@ import (
 
 func ResourceIBMCdTektonPipeline() *schema.Resource {
 	return &schema.Resource{
-		CreateContext:   resourceIBMCdTektonPipelineCreate,
-		ReadContext:     resourceIBMCdTektonPipelineRead,
-		UpdateContext:   resourceIBMCdTektonPipelineUpdate,
-		DeleteContext:   resourceIBMCdTektonPipelineDelete,
-		Importer: &schema.ResourceImporter{},
+		CreateContext: resourceIBMCdTektonPipelineCreate,
+		ReadContext:   resourceIBMCdTektonPipelineRead,
+		UpdateContext: resourceIBMCdTektonPipelineUpdate,
+		DeleteContext: resourceIBMCdTektonPipelineDelete,
+		Importer:      &schema.ResourceImporter{},
 
 		Schema: map[string]*schema.Schema{
 			"enable_slack_notifications": &schema.Schema{
@@ -157,10 +157,10 @@ func ResourceIBMCdTektonPipeline() *schema.Resource {
 							Description: "Property name.",
 						},
 						"value": &schema.Schema{
-							Type:        schema.TypeString,
-							Optional:    true,
+							Type:             schema.TypeString,
+							Optional:         true,
 							DiffSuppressFunc: flex.SuppressPipelinePropertyRawSecret,
-							Description: "Property value.",
+							Description:      "Property value.",
 						},
 						"enum": &schema.Schema{
 							Type:        schema.TypeList,
@@ -235,10 +235,10 @@ func ResourceIBMCdTektonPipeline() *schema.Resource {
 										Description: "Property name.",
 									},
 									"value": &schema.Schema{
-										Type:        schema.TypeString,
-										Optional:    true,
+										Type:             schema.TypeString,
+										Optional:         true,
 										DiffSuppressFunc: flex.SuppressTriggerPropertyRawSecret,
-										Description: "Property value. Can be empty and should be omitted for `single_select` property type.",
+										Description:      "Property value. Can be empty and should be omitted for `single_select` property type.",
 									},
 									"enum": &schema.Schema{
 										Type:        schema.TypeList,
@@ -395,10 +395,10 @@ func ResourceIBMCdTektonPipeline() *schema.Resource {
 										Description: "Secret type.",
 									},
 									"value": &schema.Schema{
-										Type:        schema.TypeString,
-										Optional:    true,
+										Type:             schema.TypeString,
+										Optional:         true,
 										DiffSuppressFunc: flex.SuppressGenericWebhookRawSecret,
-										Description: "Secret value, not needed if secret type is `internal_validation`.",
+										Description:      "Secret value, not needed if secret type is `internal_validation`.",
 									},
 									"source": &schema.Schema{
 										Type:        schema.TypeString,

--- a/ibm/service/cdtektonpipeline/resource_ibm_cd_tekton_pipeline.go
+++ b/ibm/service/cdtektonpipeline/resource_ibm_cd_tekton_pipeline.go
@@ -19,11 +19,11 @@ import (
 
 func ResourceIBMCdTektonPipeline() *schema.Resource {
 	return &schema.Resource{
-		CreateContext: resourceIBMCdTektonPipelineCreate,
-		ReadContext:   resourceIBMCdTektonPipelineRead,
-		UpdateContext: resourceIBMCdTektonPipelineUpdate,
-		DeleteContext: resourceIBMCdTektonPipelineDelete,
-		Importer:      &schema.ResourceImporter{},
+		CreateContext:   resourceIBMCdTektonPipelineCreate,
+		ReadContext:     resourceIBMCdTektonPipelineRead,
+		UpdateContext:   resourceIBMCdTektonPipelineUpdate,
+		DeleteContext:   resourceIBMCdTektonPipelineDelete,
+		Importer: &schema.ResourceImporter{},
 
 		Schema: map[string]*schema.Schema{
 			"enable_slack_notifications": &schema.Schema{
@@ -157,10 +157,10 @@ func ResourceIBMCdTektonPipeline() *schema.Resource {
 							Description: "Property name.",
 						},
 						"value": &schema.Schema{
-							Type:             schema.TypeString,
-							Optional:         true,
+							Type:        schema.TypeString,
+							Optional:    true,
 							DiffSuppressFunc: flex.SuppressPipelinePropertyRawSecret,
-							Description:      "Property value.",
+							Description: "Property value.",
 						},
 						"enum": &schema.Schema{
 							Type:        schema.TypeList,
@@ -235,10 +235,10 @@ func ResourceIBMCdTektonPipeline() *schema.Resource {
 										Description: "Property name.",
 									},
 									"value": &schema.Schema{
-										Type:             schema.TypeString,
-										Optional:         true,
+										Type:        schema.TypeString,
+										Optional:    true,
 										DiffSuppressFunc: flex.SuppressTriggerPropertyRawSecret,
-										Description:      "Property value. Can be empty and should be omitted for `single_select` property type.",
+										Description: "Property value. Can be empty and should be omitted for `single_select` property type.",
 									},
 									"enum": &schema.Schema{
 										Type:        schema.TypeList,
@@ -395,10 +395,10 @@ func ResourceIBMCdTektonPipeline() *schema.Resource {
 										Description: "Secret type.",
 									},
 									"value": &schema.Schema{
-										Type:             schema.TypeString,
-										Optional:         true,
+										Type:        schema.TypeString,
+										Optional:    true,
 										DiffSuppressFunc: flex.SuppressGenericWebhookRawSecret,
-										Description:      "Secret value, not needed if secret type is `internal_validation`.",
+										Description: "Secret value, not needed if secret type is `internal_validation`.",
 									},
 									"source": &schema.Schema{
 										Type:        schema.TypeString,
@@ -417,6 +417,11 @@ func ResourceIBMCdTektonPipeline() *schema.Resource {
 									},
 								},
 							},
+						},
+						"webhook_url": &schema.Schema{
+							Type:        schema.TypeString,
+							Optional:    true,
+							Description: "Webhook URL that can be used to trigger pipeline runs.",
 						},
 					},
 				},
@@ -791,6 +796,9 @@ func resourceIBMCdTektonPipelineTriggerToMap(model cdtektonpipelinev2.TriggerInt
 			}
 			modelMap["secret"] = []map[string]interface{}{secretMap}
 		}
+		if model.WebhookURL != nil {
+			modelMap["webhook_url"] = model.WebhookURL
+		}
 		return modelMap, nil
 	} else {
 		return nil, fmt.Errorf("Unrecognized cdtektonpipelinev2.TriggerIntf subtype encountered")
@@ -1119,6 +1127,9 @@ func resourceIBMCdTektonPipelineTriggerGenericTriggerToMap(model *cdtektonpipeli
 			return modelMap, err
 		}
 		modelMap["secret"] = []map[string]interface{}{secretMap}
+	}
+	if model.WebhookURL != nil {
+		modelMap["webhook_url"] = model.WebhookURL
 	}
 	return modelMap, nil
 }

--- a/ibm/service/cdtektonpipeline/resource_ibm_cd_tekton_pipeline_test.go
+++ b/ibm/service/cdtektonpipeline/resource_ibm_cd_tekton_pipeline_test.go
@@ -11,9 +11,9 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 
+	acc "github.com/IBM-Cloud/terraform-provider-ibm/ibm/acctest"
 	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/conns"
 	"github.com/IBM/continuous-delivery-go-sdk/cdtektonpipelinev2"
-	acc "github.com/IBM-Cloud/terraform-provider-ibm/ibm/acctest"
 )
 
 func TestAccIBMCdTektonPipelineBasic(t *testing.T) {

--- a/ibm/service/cdtektonpipeline/resource_ibm_cd_tekton_pipeline_test.go
+++ b/ibm/service/cdtektonpipeline/resource_ibm_cd_tekton_pipeline_test.go
@@ -81,7 +81,7 @@ func testAccCheckIBMCdTektonPipelineConfigBasic() string {
 		resource "ibm_cd_toolchain_tool_pipeline" "ibm_cd_toolchain_tool_pipeline" {
 			toolchain_id = ibm_cd_toolchain.cd_toolchain.id
 			parameters {
-				name = "name"
+				name = "pipeline-name"
 				type = "tekton"
 				ui_pipeline = true
 			}
@@ -109,7 +109,7 @@ func testAccCheckIBMCdTektonPipelineConfig(enableSlackNotifications string, enab
 		resource "ibm_cd_toolchain_tool_pipeline" "ibm_cd_toolchain_tool_pipeline" {
 			toolchain_id = ibm_cd_toolchain.cd_toolchain.id
 			parameters {
-				name = "name"
+				name = "pipeline-name"
 				type = "tekton"
 				ui_pipeline = true
 			}

--- a/ibm/service/cdtektonpipeline/resource_ibm_cd_tekton_pipeline_trigger.go
+++ b/ibm/service/cdtektonpipeline/resource_ibm_cd_tekton_pipeline_trigger.go
@@ -257,6 +257,11 @@ func ResourceIBMCdTektonPipelineTrigger() *schema.Resource {
 					},
 				},
 			},
+			"webhook_url": &schema.Schema{
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "Webhook URL that can be used to trigger pipeline runs.",
+			},
 			"trigger_id": &schema.Schema{
 				Type:        schema.TypeString,
 				Computed:    true,
@@ -512,6 +517,9 @@ func resourceIBMCdTektonPipelineTriggerRead(context context.Context, d *schema.R
 	}
 	if err = d.Set("properties", properties); err != nil {
 		return diag.FromErr(fmt.Errorf("Error setting properties: %s", err))
+	}
+	if err = d.Set("webhook_url", trigger.WebhookURL); err != nil {
+		return diag.FromErr(fmt.Errorf("Error setting webhook_url: %s", err))
 	}
 	if err = d.Set("trigger_id", trigger.ID); err != nil {
 		return diag.FromErr(fmt.Errorf("Error setting trigger_id: %s", err))

--- a/ibm/service/cdtektonpipeline/resource_ibm_cd_tekton_pipeline_trigger.go
+++ b/ibm/service/cdtektonpipeline/resource_ibm_cd_tekton_pipeline_trigger.go
@@ -139,9 +139,10 @@ func ResourceIBMCdTektonPipelineTrigger() *schema.Resource {
 				Description:  "Only needed for timer triggers. Cron expression for timer trigger.",
 			},
 			"timezone": &schema.Schema{
-				Type:        schema.TypeString,
-				Optional:    true,
-				Description: "Only needed for timer triggers. Timezone for timer trigger.",
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validate.InvokeValidator("ibm_cd_tekton_pipeline_trigger", "timezone"),
+				Description:  "Only needed for timer triggers. Timezone for timer trigger.",
 			},
 			"scm_source": &schema.Schema{
 				Type:        schema.TypeList,
@@ -246,7 +247,7 @@ func ResourceIBMCdTektonPipelineTrigger() *schema.Resource {
 						"path": &schema.Schema{
 							Type:        schema.TypeString,
 							Optional:    true,
-							Description: "A dot notation path for `integration` type properties to select a value from the tool integration. If left blank the full tool integration JSON will be selected.",
+							Description: "A dot notation path for `integration` type properties to select a value from the tool integration. If left blank the full tool integration data will be used.",
 						},
 						"href": &schema.Schema{
 							Type:        schema.TypeString,
@@ -309,6 +310,15 @@ func ResourceIBMCdTektonPipelineTriggerValidator() *validate.ResourceValidator {
 			Optional:                   true,
 			Regexp:                     `^(\*|([0-9]|1[0-9]|2[0-9]|3[0-9]|4[0-9]|5[0-9])|\*\/([0-9]|1[0-9]|2[0-9]|3[0-9]|4[0-9]|5[0-9])) (\*|([0-9]|1[0-9]|2[0-3])|\*\/([0-9]|1[0-9]|2[0-3])) (\*|([1-9]|1[0-9]|2[0-9]|3[0-1])|\*\/([1-9]|1[0-9]|2[0-9]|3[0-1])) (\*|([1-9]|1[0-2])|\*\/([1-9]|1[0-2])) (\*|([0-6])|\*\/([0-6]))$`,
 			MinValueLength:             5,
+			MaxValueLength:             253,
+		},
+		validate.ValidateSchema{
+			Identifier:                 "timezone",
+			ValidateFunctionIdentifier: validate.ValidateRegexpLen,
+			Type:                       validate.TypeString,
+			Optional:                   true,
+			Regexp:                     `^[-0-9a-zA-Z_., \/]{1,234}$`,
+			MinValueLength:             1,
 			MaxValueLength:             253,
 		},
 	)

--- a/ibm/service/cdtektonpipeline/resource_ibm_cd_tekton_pipeline_trigger_property.go
+++ b/ibm/service/cdtektonpipeline/resource_ibm_cd_tekton_pipeline_trigger_property.go
@@ -70,7 +70,7 @@ func ResourceIBMCdTektonPipelineTriggerProperty() *schema.Resource {
 				Type:         schema.TypeString,
 				Optional:     true,
 				ValidateFunc: validate.InvokeValidator("ibm_cd_tekton_pipeline_trigger_property", "path"),
-				Description:  "A dot notation path for `integration` type properties to select a value from the tool integration. If left blank the full tool integration JSON will be selected.",
+				Description:  "A dot notation path for `integration` type properties to select a value from the tool integration. If left blank the full tool integration data will be used.",
 			},
 		},
 	}

--- a/website/docs/d/cd_tekton_pipeline.html.markdown
+++ b/website/docs/d/cd_tekton_pipeline.html.markdown
@@ -158,6 +158,8 @@ Nested scheme for **triggers**:
 	  * Constraints: The maximum length is `253` characters. The minimum length is `1` character. The value must match regular expression `/^[-0-9a-zA-Z_., \/]{1,234}$/`.
 	* `type` - (String) Trigger type.
 	  * Constraints: Allowable values are: .
+	* `webhook_url` - (String) Webhook URL that can be used to trigger pipeline runs.
+	  * Constraints: The maximum length is `2048` characters. The minimum length is `10` characters. The value must match regular expression `/^http(s)?:\/\/([^\/?#]*)([^?#]*)(\\?([^#]*))?(#(.*))?$/`.
 	* `worker` - (List) Worker used to run the trigger. If not specified the trigger will use the default pipeline worker.
 	Nested scheme for **worker**:
 		* `id` - (Forces new resource, String) ID of the worker.

--- a/website/docs/d/cd_tekton_pipeline.html.markdown
+++ b/website/docs/d/cd_tekton_pipeline.html.markdown
@@ -36,6 +36,7 @@ In addition to all argument references listed, you can access the following attr
 * `created_at` - (String) Standard RFC 3339 Date Time String.
 
 * `definitions` - (List) Definition list.
+  * Constraints: The maximum length is `128` items. The minimum length is `0` items.
 Nested scheme for **definitions**:
 	* `id` - (String) UUID.
 	  * Constraints: The maximum length is `36` characters. The minimum length is `36` characters. The value must match regular expression `/^[-0-9a-z]+$/`.
@@ -62,9 +63,10 @@ Nested scheme for **definitions**:
   * Constraints: The maximum length is `253` characters. The minimum length is `1` character. The value must match regular expression `/^[a-zA-Z0-9][-0-9a-zA-Z_. ]{1,235}[a-zA-Z0-9]$/`.
 
 * `properties` - (List) Tekton pipeline's environment properties.
+  * Constraints: The maximum length is `128` items. The minimum length is `0` items.
 Nested scheme for **properties**:
 	* `enum` - (List) Options for `single_select` property type. Only needed when using `single_select` property type.
-	  * Constraints: The list items must match regular expression `/^[-0-9a-zA-Z_.]{1,235}$/`.
+	  * Constraints: The list items must match regular expression `/^[-0-9a-zA-Z_.]{1,235}$/`. The maximum length is `128` items. The minimum length is `0` items.
 	* `name` - (Forces new resource, String) Property name.
 	  * Constraints: The maximum length is `253` characters. The minimum length is `1` character. The value must match regular expression `/^[-0-9a-zA-Z_.]{1,234}$/`.
 	* `path` - (String) A dot notation path for `integration` type properties to select a value from the tool integration.
@@ -91,6 +93,7 @@ Nested scheme for **toolchain**:
 	  * Constraints: The maximum length is `36` characters. The minimum length is `36` characters. The value must match regular expression `/^[-0-9a-z]+$/`.
 
 * `triggers` - (List) Tekton pipeline triggers list.
+  * Constraints: The maximum length is `128` items. The minimum length is `0` items.
 Nested scheme for **triggers**:
 	* `cron` - (String) Only needed for timer triggers. Cron expression for timer trigger. Maximum frequency is every 5 minutes.
 	  * Constraints: The maximum length is `253` characters. The minimum length is `5` characters. The value must match regular expression `/^(\\*|([0-9]|1[0-9]|2[0-9]|3[0-9]|4[0-9]|5[0-9])|\\*\/([0-9]|1[0-9]|2[0-9]|3[0-9]|4[0-9]|5[0-9])) (\\*|([0-9]|1[0-9]|2[0-3])|\\*\/([0-9]|1[0-9]|2[0-3])) (\\*|([1-9]|1[0-9]|2[0-9]|3[0-1])|\\*\/([1-9]|1[0-9]|2[0-9]|3[0-1])) (\\*|([1-9]|1[0-2])|\\*\/([1-9]|1[0-2])) (\\*|([0-6])|\\*\/([0-6]))$/`.
@@ -110,14 +113,15 @@ Nested scheme for **triggers**:
 	* `name` - (String) Trigger name.
 	  * Constraints: The maximum length is `253` characters. The minimum length is `1` character. The value must match regular expression `/^[a-zA-Z0-9][-0-9a-zA-Z_. ]{1,235}[a-zA-Z0-9]$/`.
 	* `properties` - (List) Trigger properties.
+	  * Constraints: The maximum length is `128` items. The minimum length is `0` items.
 	Nested scheme for **properties**:
 		* `enum` - (List) Options for `single_select` property type. Only needed for `single_select` property type.
-		  * Constraints: The list items must match regular expression `/^[-0-9a-zA-Z_.]{1,235}$/`.
+		  * Constraints: The list items must match regular expression `/^[-0-9a-zA-Z_.]{1,235}$/`. The maximum length is `128` items. The minimum length is `0` items.
 		* `href` - (String) API URL for interacting with the trigger property.
 		  * Constraints: The maximum length is `2048` characters. The minimum length is `10` characters. The value must match regular expression `/^http(s)?:\/\/([^\/?#]*)([^?#]*)(\\?([^#]*))?(#(.*))?$/`.
 		* `name` - (Forces new resource, String) Property name.
 		  * Constraints: The maximum length is `253` characters. The minimum length is `1` character. The value must match regular expression `/^[-0-9a-zA-Z_.]{1,234}$/`.
-		* `path` - (String) A dot notation path for `integration` type properties to select a value from the tool integration. If left blank the full tool integration JSON will be selected.
+		* `path` - (String) A dot notation path for `integration` type properties to select a value from the tool integration. If left blank the full tool integration data will be used.
 		  * Constraints: The maximum length is `4096` characters. The minimum length is `1` character. The value must match regular expression `/./`.
 		* `type` - (String) Property type.
 		  * Constraints: Allowable values are: `secure`, `text`, `integration`, `single_select`, `appconfig`.
@@ -149,25 +153,28 @@ Nested scheme for **triggers**:
 		* `value` - (String) Secret value, not needed if secret type is `internal_validation`.
 		  * Constraints: The maximum length is `4096` characters. The minimum length is `0` characters. The value must match regular expression `/./`.
 	* `tags` - (List) Trigger tags array.
-	  * Constraints: The list items must match regular expression `/^[-0-9a-zA-Z_.]{1,235}$/`.
+	  * Constraints: The list items must match regular expression `/^[-0-9a-zA-Z_.]{1,235}$/`. The maximum length is `128` items. The minimum length is `0` items.
 	* `timezone` - (String) Only needed for timer triggers. Timezone for timer trigger.
+	  * Constraints: The maximum length is `253` characters. The minimum length is `1` character. The value must match regular expression `/^[-0-9a-zA-Z_., \/]{1,234}$/`.
 	* `type` - (String) Trigger type.
 	  * Constraints: Allowable values are: .
 	* `worker` - (List) Worker used to run the trigger. If not specified the trigger will use the default pipeline worker.
 	Nested scheme for **worker**:
 		* `id` - (Forces new resource, String) ID of the worker.
+		  * Constraints: The maximum length is `36` characters. The minimum length is `1` character. The value must match regular expression `/^(public)|(preview)|([-0-9a-fA-F]{36})$/`.
 		* `name` - (String) Name of the worker. Computed based on the worker ID.
 		  * Constraints: The maximum length is `253` characters. The minimum length is `1` character. The value must match regular expression `/^[-0-9a-zA-Z_. \\(\\)\\[\\]]{1,235}$/`.
 		* `type` - (String) Type of the worker. Computed based on the worker ID.
-		  * Constraints: Allowable values are: `private`, `public`.
+		  * Constraints: The maximum length is `253` characters. The minimum length is `1` character. The value must match regular expression `/^[-0-9a-zA-Z_.]{1,235}$/`.
 
 * `updated_at` - (String) Standard RFC 3339 Date Time String.
 
 * `worker` - (List) Default pipeline worker used to run the pipeline.
 Nested scheme for **worker**:
 	* `id` - (Forces new resource, String) ID of the worker.
+	  * Constraints: The maximum length is `36` characters. The minimum length is `1` character. The value must match regular expression `/^(public)|(preview)|([-0-9a-fA-F]{36})$/`.
 	* `name` - (String) Name of the worker. Computed based on the worker ID.
 	  * Constraints: The maximum length is `253` characters. The minimum length is `1` character. The value must match regular expression `/^[-0-9a-zA-Z_. \\(\\)\\[\\]]{1,235}$/`.
 	* `type` - (String) Type of the worker. Computed based on the worker ID.
-	  * Constraints: Allowable values are: `private`, `public`.
+	  * Constraints: The maximum length is `253` characters. The minimum length is `1` character. The value must match regular expression `/^[-0-9a-zA-Z_.]{1,235}$/`.
 

--- a/website/docs/d/cd_tekton_pipeline_property.html.markdown
+++ b/website/docs/d/cd_tekton_pipeline_property.html.markdown
@@ -34,7 +34,7 @@ In addition to all argument references listed, you can access the following attr
 
 * `id` - The unique identifier of the cd_tekton_pipeline_property.
 * `enum` - (List) Options for `single_select` property type. Only needed when using `single_select` property type.
-  * Constraints: The list items must match regular expression `/^[-0-9a-zA-Z_.]{1,235}$/`.
+  * Constraints: The list items must match regular expression `/^[-0-9a-zA-Z_.]{1,235}$/`. The maximum length is `128` items. The minimum length is `0` items.
 
 * `name` - (Forces new resource, String) Property name.
   * Constraints: The maximum length is `253` characters. The minimum length is `1` character. The value must match regular expression `/^[-0-9a-zA-Z_.]{1,234}$/`.

--- a/website/docs/d/cd_tekton_pipeline_trigger.html.markdown
+++ b/website/docs/d/cd_tekton_pipeline_trigger.html.markdown
@@ -107,6 +107,9 @@ Nested scheme for **secret**:
 * `type` - (String) Trigger type.
   * Constraints: Allowable values are: .
 
+* `webhook_url` - (String) Webhook URL that can be used to trigger pipeline runs.
+  * Constraints: The maximum length is `2048` characters. The minimum length is `10` characters. The value must match regular expression `/^http(s)?:\/\/([^\/?#]*)([^?#]*)(\\?([^#]*))?(#(.*))?$/`.
+
 * `worker` - (List) Worker used to run the trigger. If not specified the trigger will use the default pipeline worker.
 Nested scheme for **worker**:
 	* `id` - (Forces new resource, String) ID of the worker.

--- a/website/docs/d/cd_tekton_pipeline_trigger.html.markdown
+++ b/website/docs/d/cd_tekton_pipeline_trigger.html.markdown
@@ -56,14 +56,15 @@ Nested scheme for **events**:
   * Constraints: The maximum length is `253` characters. The minimum length is `1` character. The value must match regular expression `/^[a-zA-Z0-9][-0-9a-zA-Z_. ]{1,235}[a-zA-Z0-9]$/`.
 
 * `properties` - (List) Trigger properties.
+  * Constraints: The maximum length is `128` items. The minimum length is `0` items.
 Nested scheme for **properties**:
 	* `enum` - (List) Options for `single_select` property type. Only needed for `single_select` property type.
-	  * Constraints: The list items must match regular expression `/^[-0-9a-zA-Z_.]{1,235}$/`.
+	  * Constraints: The list items must match regular expression `/^[-0-9a-zA-Z_.]{1,235}$/`. The maximum length is `128` items. The minimum length is `0` items.
 	* `href` - (String) API URL for interacting with the trigger property.
 	  * Constraints: The maximum length is `2048` characters. The minimum length is `10` characters. The value must match regular expression `/^http(s)?:\/\/([^\/?#]*)([^?#]*)(\\?([^#]*))?(#(.*))?$/`.
 	* `name` - (Forces new resource, String) Property name.
 	  * Constraints: The maximum length is `253` characters. The minimum length is `1` character. The value must match regular expression `/^[-0-9a-zA-Z_.]{1,234}$/`.
-	* `path` - (String) A dot notation path for `integration` type properties to select a value from the tool integration. If left blank the full tool integration JSON will be selected.
+	* `path` - (String) A dot notation path for `integration` type properties to select a value from the tool integration. If left blank the full tool integration data will be used.
 	  * Constraints: The maximum length is `4096` characters. The minimum length is `1` character. The value must match regular expression `/./`.
 	* `type` - (String) Property type.
 	  * Constraints: Allowable values are: `secure`, `text`, `integration`, `single_select`, `appconfig`.
@@ -98,9 +99,10 @@ Nested scheme for **secret**:
 	  * Constraints: The maximum length is `4096` characters. The minimum length is `0` characters. The value must match regular expression `/./`.
 
 * `tags` - (List) Trigger tags array.
-  * Constraints: The list items must match regular expression `/^[-0-9a-zA-Z_.]{1,235}$/`.
+  * Constraints: The list items must match regular expression `/^[-0-9a-zA-Z_.]{1,235}$/`. The maximum length is `128` items. The minimum length is `0` items.
 
 * `timezone` - (String) Only needed for timer triggers. Timezone for timer trigger.
+  * Constraints: The maximum length is `253` characters. The minimum length is `1` character. The value must match regular expression `/^[-0-9a-zA-Z_., \/]{1,234}$/`.
 
 * `type` - (String) Trigger type.
   * Constraints: Allowable values are: .
@@ -108,8 +110,9 @@ Nested scheme for **secret**:
 * `worker` - (List) Worker used to run the trigger. If not specified the trigger will use the default pipeline worker.
 Nested scheme for **worker**:
 	* `id` - (Forces new resource, String) ID of the worker.
+	  * Constraints: The maximum length is `36` characters. The minimum length is `1` character. The value must match regular expression `/^(public)|(preview)|([-0-9a-fA-F]{36})$/`.
 	* `name` - (String) Name of the worker. Computed based on the worker ID.
 	  * Constraints: The maximum length is `253` characters. The minimum length is `1` character. The value must match regular expression `/^[-0-9a-zA-Z_. \\(\\)\\[\\]]{1,235}$/`.
 	* `type` - (String) Type of the worker. Computed based on the worker ID.
-	  * Constraints: Allowable values are: `private`, `public`.
+	  * Constraints: The maximum length is `253` characters. The minimum length is `1` character. The value must match regular expression `/^[-0-9a-zA-Z_.]{1,235}$/`.
 

--- a/website/docs/d/cd_tekton_pipeline_trigger_property.html.markdown
+++ b/website/docs/d/cd_tekton_pipeline_trigger_property.html.markdown
@@ -37,12 +37,12 @@ In addition to all argument references listed, you can access the following attr
 
 * `id` - The unique identifier of the cd_tekton_pipeline_trigger_property.
 * `enum` - (List) Options for `single_select` property type. Only needed for `single_select` property type.
-  * Constraints: The list items must match regular expression `/^[-0-9a-zA-Z_.]{1,235}$/`.
+  * Constraints: The list items must match regular expression `/^[-0-9a-zA-Z_.]{1,235}$/`. The maximum length is `128` items. The minimum length is `0` items.
 
 * `name` - (Forces new resource, String) Property name.
   * Constraints: The maximum length is `253` characters. The minimum length is `1` character. The value must match regular expression `/^[-0-9a-zA-Z_.]{1,234}$/`.
 
-* `path` - (String) A dot notation path for `integration` type properties to select a value from the tool integration. If left blank the full tool integration JSON will be selected.
+* `path` - (String) A dot notation path for `integration` type properties to select a value from the tool integration. If left blank the full tool integration data will be used.
   * Constraints: The maximum length is `4096` characters. The minimum length is `1` character. The value must match regular expression `/./`.
 
 * `type` - (String) Property type.

--- a/website/docs/r/cd_tekton_pipeline.html.markdown
+++ b/website/docs/r/cd_tekton_pipeline.html.markdown
@@ -152,6 +152,8 @@ Nested scheme for **triggers**:
 	  * Constraints: The maximum length is `253` characters. The minimum length is `1` character. The value must match regular expression `/^[-0-9a-zA-Z_., \/]{1,234}$/`.
 	* `type` - (String) Trigger type.
 	  * Constraints: Allowable values are: .
+	* `webhook_url` - (String) Webhook URL that can be used to trigger pipeline runs.
+	  * Constraints: The maximum length is `2048` characters. The minimum length is `10` characters. The value must match regular expression `/^http(s)?:\/\/([^\/?#]*)([^?#]*)(\\?([^#]*))?(#(.*))?$/`.
 	* `worker` - (List) Worker used to run the trigger. If not specified the trigger will use the default pipeline worker.
 	Nested scheme for **worker**:
 		* `id` - (Forces new resource, String) ID of the worker.

--- a/website/docs/r/cd_tekton_pipeline.html.markdown
+++ b/website/docs/r/cd_tekton_pipeline.html.markdown
@@ -30,7 +30,8 @@ Review the argument reference that you can specify for your resource.
   * Constraints: The default value is `false`.
 * `worker` - (Optional, List) Worker object containing worker ID only. If omitted the IBM Managed shared workers are used by default.
 Nested scheme for **worker**:
-	* `id` - (Required, String)
+	* `id` - (Required, String) ID of the worker.
+	  * Constraints: The maximum length is `253` characters. The minimum length is `1` character. The value must match regular expression `/^(public)|(preview)|([-0-9a-fA-F]{36})$/`.
 
 ## Attribute Reference
 
@@ -41,6 +42,7 @@ In addition to all argument references listed, you can access the following attr
   * Constraints: The minimum value is `1`.
 * `created_at` - (String) Standard RFC 3339 Date Time String.
 * `definitions` - (List) Definition list.
+  * Constraints: The maximum length is `128` items. The minimum length is `0` items.
 Nested scheme for **definitions**:
 	* `id` - (String) UUID.
 	  * Constraints: The maximum length is `36` characters. The minimum length is `36` characters. The value must match regular expression `/^[-0-9a-z]+$/`.
@@ -60,9 +62,10 @@ Nested scheme for **definitions**:
 * `name` - (String) String.
   * Constraints: The maximum length is `253` characters. The minimum length is `1` character. The value must match regular expression `/^[a-zA-Z0-9][-0-9a-zA-Z_. ]{1,235}[a-zA-Z0-9]$/`.
 * `properties` - (List) Tekton pipeline's environment properties.
+  * Constraints: The maximum length is `128` items. The minimum length is `0` items.
 Nested scheme for **properties**:
 	* `enum` - (List) Options for `single_select` property type. Only needed when using `single_select` property type.
-	  * Constraints: The list items must match regular expression `/^[-0-9a-zA-Z_.]{1,235}$/`.
+	  * Constraints: The list items must match regular expression `/^[-0-9a-zA-Z_.]{1,235}$/`. The maximum length is `128` items. The minimum length is `0` items.
 	* `name` - (Forces new resource, String) Property name.
 	  * Constraints: The maximum length is `253` characters. The minimum length is `1` character. The value must match regular expression `/^[-0-9a-zA-Z_.]{1,234}$/`.
 	* `path` - (String) A dot notation path for `integration` type properties to select a value from the tool integration.
@@ -84,6 +87,7 @@ Nested scheme for **toolchain**:
 	* `id` - (String) UUID.
 	  * Constraints: The maximum length is `36` characters. The minimum length is `36` characters. The value must match regular expression `/^[-0-9a-z]+$/`.
 * `triggers` - (List) Tekton pipeline triggers list.
+  * Constraints: The maximum length is `128` items. The minimum length is `0` items.
 Nested scheme for **triggers**:
 	* `cron` - (String) Only needed for timer triggers. Cron expression for timer trigger. Maximum frequency is every 5 minutes.
 	  * Constraints: The maximum length is `253` characters. The minimum length is `5` characters. The value must match regular expression `/^(\\*|([0-9]|1[0-9]|2[0-9]|3[0-9]|4[0-9]|5[0-9])|\\*\/([0-9]|1[0-9]|2[0-9]|3[0-9]|4[0-9]|5[0-9])) (\\*|([0-9]|1[0-9]|2[0-3])|\\*\/([0-9]|1[0-9]|2[0-3])) (\\*|([1-9]|1[0-9]|2[0-9]|3[0-1])|\\*\/([1-9]|1[0-9]|2[0-9]|3[0-1])) (\\*|([1-9]|1[0-2])|\\*\/([1-9]|1[0-2])) (\\*|([0-6])|\\*\/([0-6]))$/`.
@@ -103,14 +107,15 @@ Nested scheme for **triggers**:
 	* `name` - (String) Trigger name.
 	  * Constraints: The maximum length is `253` characters. The minimum length is `1` character. The value must match regular expression `/^[a-zA-Z0-9][-0-9a-zA-Z_. ]{1,235}[a-zA-Z0-9]$/`.
 	* `properties` - (List) Trigger properties.
+	  * Constraints: The maximum length is `128` items. The minimum length is `0` items.
 	Nested scheme for **properties**:
 		* `enum` - (List) Options for `single_select` property type. Only needed for `single_select` property type.
-		  * Constraints: The list items must match regular expression `/^[-0-9a-zA-Z_.]{1,235}$/`.
+		  * Constraints: The list items must match regular expression `/^[-0-9a-zA-Z_.]{1,235}$/`. The maximum length is `128` items. The minimum length is `0` items.
 		* `href` - (String) API URL for interacting with the trigger property.
 		  * Constraints: The maximum length is `2048` characters. The minimum length is `10` characters. The value must match regular expression `/^http(s)?:\/\/([^\/?#]*)([^?#]*)(\\?([^#]*))?(#(.*))?$/`.
 		* `name` - (Forces new resource, String) Property name.
 		  * Constraints: The maximum length is `253` characters. The minimum length is `1` character. The value must match regular expression `/^[-0-9a-zA-Z_.]{1,234}$/`.
-		* `path` - (String) A dot notation path for `integration` type properties to select a value from the tool integration. If left blank the full tool integration JSON will be selected.
+		* `path` - (String) A dot notation path for `integration` type properties to select a value from the tool integration. If left blank the full tool integration data will be used.
 		  * Constraints: The maximum length is `4096` characters. The minimum length is `1` character. The value must match regular expression `/./`.
 		* `type` - (String) Property type.
 		  * Constraints: Allowable values are: `secure`, `text`, `integration`, `single_select`, `appconfig`.
@@ -142,17 +147,19 @@ Nested scheme for **triggers**:
 		* `value` - (String) Secret value, not needed if secret type is `internal_validation`.
 		  * Constraints: The maximum length is `4096` characters. The minimum length is `0` characters. The value must match regular expression `/./`.
 	* `tags` - (List) Trigger tags array.
-	  * Constraints: The list items must match regular expression `/^[-0-9a-zA-Z_.]{1,235}$/`.
+	  * Constraints: The list items must match regular expression `/^[-0-9a-zA-Z_.]{1,235}$/`. The maximum length is `128` items. The minimum length is `0` items.
 	* `timezone` - (String) Only needed for timer triggers. Timezone for timer trigger.
+	  * Constraints: The maximum length is `253` characters. The minimum length is `1` character. The value must match regular expression `/^[-0-9a-zA-Z_., \/]{1,234}$/`.
 	* `type` - (String) Trigger type.
 	  * Constraints: Allowable values are: .
 	* `worker` - (List) Worker used to run the trigger. If not specified the trigger will use the default pipeline worker.
 	Nested scheme for **worker**:
 		* `id` - (Forces new resource, String) ID of the worker.
+		  * Constraints: The maximum length is `36` characters. The minimum length is `1` character. The value must match regular expression `/^(public)|(preview)|([-0-9a-fA-F]{36})$/`.
 		* `name` - (String) Name of the worker. Computed based on the worker ID.
 		  * Constraints: The maximum length is `253` characters. The minimum length is `1` character. The value must match regular expression `/^[-0-9a-zA-Z_. \\(\\)\\[\\]]{1,235}$/`.
 		* `type` - (String) Type of the worker. Computed based on the worker ID.
-		  * Constraints: Allowable values are: `private`, `public`.
+		  * Constraints: The maximum length is `253` characters. The minimum length is `1` character. The value must match regular expression `/^[-0-9a-zA-Z_.]{1,235}$/`.
 * `updated_at` - (String) Standard RFC 3339 Date Time String.
 
 ## Provider Configuration

--- a/website/docs/r/cd_tekton_pipeline_property.html.markdown
+++ b/website/docs/r/cd_tekton_pipeline_property.html.markdown
@@ -26,7 +26,7 @@ resource "ibm_cd_tekton_pipeline_property" "cd_tekton_pipeline_property" {
 Review the argument reference that you can specify for your resource.
 
 * `enum` - (Optional, List) Options for `single_select` property type. Only needed when using `single_select` property type.
-  * Constraints: The list items must match regular expression `/^[-0-9a-zA-Z_.]{1,235}$/`.
+  * Constraints: The list items must match regular expression `/^[-0-9a-zA-Z_.]{1,235}$/`. The maximum length is `128` items. The minimum length is `0` items.
 * `name` - (Optional, Forces new resource, String) Property name.
   * Constraints: The maximum length is `253` characters. The minimum length is `1` character. The value must match regular expression `/^[-0-9a-zA-Z_.]{1,234}$/`.
 * `path` - (Optional, String) A dot notation path for `integration` type properties to select a value from the tool integration.

--- a/website/docs/r/cd_tekton_pipeline_trigger.html.markdown
+++ b/website/docs/r/cd_tekton_pipeline_trigger.html.markdown
@@ -125,6 +125,8 @@ Nested scheme for **properties**:
 	  * Constraints: The maximum length is `4096` characters. The minimum length is `1` character. The value must match regular expression `/./`.
 * `trigger_id` - (String) ID.
   * Constraints: The maximum length is `36` characters. The minimum length is `36` characters. The value must match regular expression `/^[-0-9a-z]+$/`.
+* `webhook_url` - (String) Webhook URL that can be used to trigger pipeline runs.
+  * Constraints: The maximum length is `2048` characters. The minimum length is `10` characters. The value must match regular expression `/^http(s)?:\/\/([^\/?#]*)([^?#]*)(\\?([^#]*))?(#(.*))?$/`.
 
 ## Provider Configuration
 

--- a/website/docs/r/cd_tekton_pipeline_trigger.html.markdown
+++ b/website/docs/r/cd_tekton_pipeline_trigger.html.markdown
@@ -14,7 +14,6 @@ Provides a resource for cd_tekton_pipeline_trigger. This allows cd_tekton_pipeli
 
 ```hcl
 resource "ibm_cd_tekton_pipeline_trigger" "cd_tekton_pipeline_trigger" {
-  disabled = false
   event_listener = "pr-listener"
   events {
 		push = true
@@ -28,9 +27,6 @@ resource "ibm_cd_tekton_pipeline_trigger" "cd_tekton_pipeline_trigger" {
 		url = "url"
 		branch = "branch"
 		pattern = "pattern"
-		blind_connection = true
-		hook_id = "hook_id"
-		service_instance_id = "service_instance_id"
   }
   secret {
 		type = "token_matches"
@@ -41,9 +37,7 @@ resource "ibm_cd_tekton_pipeline_trigger" "cd_tekton_pipeline_trigger" {
   }
   type = "manual"
   worker {
-		name = "name"
-		type = "private"
-		id = "id"
+		id = "public"
   }
 }
 ```
@@ -93,17 +87,19 @@ Nested scheme for **secret**:
 	* `value` - (Optional, String) Secret value, not needed if secret type is `internal_validation`.
 	  * Constraints: The maximum length is `4096` characters. The minimum length is `0` characters. The value must match regular expression `/./`.
 * `tags` - (Optional, List) Trigger tags array.
-  * Constraints: The list items must match regular expression `/^[-0-9a-zA-Z_.]{1,235}$/`.
+  * Constraints: The list items must match regular expression `/^[-0-9a-zA-Z_.]{1,235}$/`. The maximum length is `128` items. The minimum length is `0` items.
 * `timezone` - (Optional, String) Only needed for timer triggers. Timezone for timer trigger.
+  * Constraints: The maximum length is `253` characters. The minimum length is `1` character. The value must match regular expression `/^[-0-9a-zA-Z_., \/]{1,234}$/`.
 * `type` - (Optional, String) Trigger type.
   * Constraints: Allowable values are: `manual`, `scm`, `timer`, `generic`.
 * `worker` - (Optional, List) Worker used to run the trigger. If not specified the trigger will use the default pipeline worker.
 Nested scheme for **worker**:
 	* `id` - (Required, Forces new resource, String) ID of the worker.
+	  * Constraints: The maximum length is `36` characters. The minimum length is `1` character. The value must match regular expression `/^(public)|(preview)|([-0-9a-fA-F]{36})$/`.
 	* `name` - (Optional, String) Name of the worker. Computed based on the worker ID.
 	  * Constraints: The maximum length is `253` characters. The minimum length is `1` character. The value must match regular expression `/^[-0-9a-zA-Z_. \\(\\)\\[\\]]{1,235}$/`.
 	* `type` - (Optional, String) Type of the worker. Computed based on the worker ID.
-	  * Constraints: Allowable values are: `private`, `public`.
+	  * Constraints: The maximum length is `253` characters. The minimum length is `1` character. The value must match regular expression `/^[-0-9a-zA-Z_.]{1,235}$/`.
 
 ## Attribute Reference
 
@@ -113,14 +109,15 @@ In addition to all argument references listed, you can access the following attr
 * `href` - (String) API URL for interacting with the trigger.
   * Constraints: The maximum length is `2048` characters. The minimum length is `10` characters. The value must match regular expression `/^http(s)?:\/\/([^\/?#]*)([^?#]*)(\\?([^#]*))?(#(.*))?$/`.
 * `properties` - (List) Trigger properties.
+  * Constraints: The maximum length is `128` items. The minimum length is `0` items.
 Nested scheme for **properties**:
 	* `enum` - (List) Options for `single_select` property type. Only needed for `single_select` property type.
-	  * Constraints: The list items must match regular expression `/^[-0-9a-zA-Z_.]{1,235}$/`.
+	  * Constraints: The list items must match regular expression `/^[-0-9a-zA-Z_.]{1,235}$/`. The maximum length is `128` items. The minimum length is `0` items.
 	* `href` - (String) API URL for interacting with the trigger property.
 	  * Constraints: The maximum length is `2048` characters. The minimum length is `10` characters. The value must match regular expression `/^http(s)?:\/\/([^\/?#]*)([^?#]*)(\\?([^#]*))?(#(.*))?$/`.
 	* `name` - (Forces new resource, String) Property name.
 	  * Constraints: The maximum length is `253` characters. The minimum length is `1` character. The value must match regular expression `/^[-0-9a-zA-Z_.]{1,234}$/`.
-	* `path` - (String) A dot notation path for `integration` type properties to select a value from the tool integration. If left blank the full tool integration JSON will be selected.
+	* `path` - (String) A dot notation path for `integration` type properties to select a value from the tool integration. If left blank the full tool integration data will be used.
 	  * Constraints: The maximum length is `4096` characters. The minimum length is `1` character. The value must match regular expression `/./`.
 	* `type` - (String) Property type.
 	  * Constraints: Allowable values are: `secure`, `text`, `integration`, `single_select`, `appconfig`.

--- a/website/docs/r/cd_tekton_pipeline_trigger_property.html.markdown
+++ b/website/docs/r/cd_tekton_pipeline_trigger_property.html.markdown
@@ -27,10 +27,10 @@ resource "ibm_cd_tekton_pipeline_trigger_property" "cd_tekton_pipeline_trigger_p
 Review the argument reference that you can specify for your resource.
 
 * `enum` - (Optional, List) Options for `single_select` property type. Only needed for `single_select` property type.
-  * Constraints: The list items must match regular expression `/^[-0-9a-zA-Z_.]{1,235}$/`.
+  * Constraints: The list items must match regular expression `/^[-0-9a-zA-Z_.]{1,235}$/`. The maximum length is `128` items. The minimum length is `0` items.
 * `name` - (Optional, Forces new resource, String) Property name.
   * Constraints: The maximum length is `253` characters. The minimum length is `1` character. The value must match regular expression `/^[-0-9a-zA-Z_.]{1,234}$/`.
-* `path` - (Optional, String) A dot notation path for `integration` type properties to select a value from the tool integration. If left blank the full tool integration JSON will be selected.
+* `path` - (Optional, String) A dot notation path for `integration` type properties to select a value from the tool integration. If left blank the full tool integration data will be used.
   * Constraints: The maximum length is `4096` characters. The minimum length is `1` character. The value must match regular expression `/./`.
 * `pipeline_id` - (Required, Forces new resource, String) The Tekton pipeline ID.
   * Constraints: The maximum length is `36` characters. The minimum length is `36` characters. The value must match regular expression `/^[-0-9a-z]+$/`.


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/IBM-Cloud/terraform-provider-ibm/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

### Changes

After running openapi validator on the original API spec, some updates were required in the APIs and then the generated GO SDK and generated Terraform provider. Those minor updates are included in this PR
- Bump `github.com/IBM/continuous-delivery-go-sdk` to `v0.1.1`
- String updates
- Add support for `webhook_url` in trigger schema
- Added validator for `timezone` property
- A minor test refactor, no functional change
- Markdown updates
- Update `ibm-cd-toolchain-simple-helm` example to work with updated tekton schema
- Update `ibm-cd-tekton-pipeline` example to full working version

### Output from acceptance testing:
```
$ make testacc TEST=./ibm/service/cdtektonpipeline TESTARGS='-run=TestAccIBMCdTektonPipeline*'
==> Checking that code complies with gofmt requirements...
=== RUN   TestAccIBMCdTektonPipelineBasic
--- PASS: TestAccIBMCdTektonPipelineBasic (80.89s)
=== RUN   TestAccIBMCdTektonPipelineAllArgs
--- PASS: TestAccIBMCdTektonPipelineAllArgs (129.23s)
PASS
ok      github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/cdtektonpipeline        214.370s
```