### PR TITLE
space is missing after the description for segment

### DIFF
--- a/website/docs/d/app_config_segment.html.markdown
+++ b/website/docs/d/app_config_segment.html.markdown
@@ -3,7 +3,7 @@ subcategory: 'App Configuration'
 layout: 'ibm'
 page_title: 'IBM : App Configuration segment'
 description: |-
-Get information about segment
+  Get information about segment
 ---
 
 # ibm_app_config_segment

--- a/website/docs/d/app_config_segments.html.markdown
+++ b/website/docs/d/app_config_segments.html.markdown
@@ -3,7 +3,7 @@ subcategory: 'App Configuration'
 layout: 'ibm'
 page_title: 'IBM : App Configuration segments'
 description: |-
-List all the segments.
+  List all the segments.
 ---
 
 # ibm_app_config_segments

--- a/website/docs/r/app_config_segment.html.markdown
+++ b/website/docs/r/app_config_segment.html.markdown
@@ -3,7 +3,7 @@ subcategory: 'App Configuration'
 layout: 'ibm'
 page_title: 'IBM : App Configuration segment'
 description: |-
-Manages segment.
+  Manages segment.
 ---
 
 # ibm_app_config_segment


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/IBM-Cloud/terraform-provider-ibm/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```

The appconfig segments docs the resource and datasource is created outside the subcategory In external DOC
https://registry.terraform.io/providers/IBM-Cloud/ibm/latest/docs/data-sources/app_config_segment

<img width="312" alt="image" src="https://user-images.githubusercontent.com/94357468/190098453-fa882d96-cb18-4504-95c4-b31dcb8832ac.png">


the segment should be subcategory of the appconfig resource and datasource
