### PR TITLE
fix(ibm_is_vpn_gateway): reordered the setting of id in ibm_is_vpn_gateway resource to taint the resource properly

### DIFF
--- a/ibm/service/vpc/resource_ibm_is_vpn_gateway.go
+++ b/ibm/service/vpc/resource_ibm_is_vpn_gateway.go
@@ -328,13 +328,13 @@ func vpngwCreate(d *schema.ResourceData, meta interface{}, name, subnetID, mode 
 	}
 	vpnGateway := vpnGatewayIntf.(*vpcv1.VPNGateway)
 
+	d.SetId(*vpnGateway.ID)
+	log.Printf("[INFO] VPNGateway : %s", *vpnGateway.ID)
+
 	_, err = isWaitForVpnGatewayAvailable(sess, *vpnGateway.ID, d.Timeout(schema.TimeoutCreate))
 	if err != nil {
 		return err
 	}
-
-	d.SetId(*vpnGateway.ID)
-	log.Printf("[INFO] VPNGateway : %s", *vpnGateway.ID)
 
 	v := os.Getenv("IC_ENV_TAGS")
 	if _, ok := d.GetOk(isVPNGatewayTags); ok || v != "" {

--- a/ibm/service/vpc/resource_ibm_is_vpn_gateway_test.go
+++ b/ibm/service/vpc/resource_ibm_is_vpn_gateway_test.go
@@ -6,6 +6,7 @@ package vpc_test
 import (
 	"errors"
 	"fmt"
+	"regexp"
 	"testing"
 
 	acc "github.com/IBM-Cloud/terraform-provider-ibm/ibm/acctest"
@@ -158,4 +159,84 @@ func testAccCheckIBMISVPNGatewayRouteConfig(vpc, subnet, name string) string {
 	mode = "route"
 	}`, vpc, subnet, acc.ISZoneName, acc.ISCIDR, name)
 
+}
+
+func testAccCheckIBMISVPNGatewayTaintConfig(vpc, subnet, name string) string {
+	return fmt.Sprintf(`
+	resource "ibm_is_vpc" "testacc_vpc" {
+		name = "%s"
+	}
+
+	resource "ibm_is_subnet" "testacc_subnet" {
+		name = "%s"
+		vpc = "${ibm_is_vpc.testacc_vpc.id}"
+		zone = "%s"
+		ipv4_cidr_block = "%s"
+	}
+
+	resource "ibm_is_vpn_gateway" "testacc_vpnGateway" {
+		name 	= "%s"
+		subnet 	= "${ibm_is_subnet.testacc_subnet.id}"
+		mode 	= "policy"
+		timeouts{
+			create = "2m"
+		}
+		lifecycle {
+			create_before_destroy = true
+		}
+	}`, vpc, subnet, acc.ISZoneName, acc.ISCIDR, name)
+
+}
+func testAccCheckIBMISVPNGatewayTaintConfig2(vpc, subnet, name string) string {
+	return fmt.Sprintf(`
+	resource "ibm_is_vpc" "testacc_vpc" {
+		name = "%s"
+	}
+
+	resource "ibm_is_subnet" "testacc_subnet" {
+		name = "%s"
+		vpc = "${ibm_is_vpc.testacc_vpc.id}"
+		zone = "%s"
+		ipv4_cidr_block = "%s"
+	}
+
+	resource "ibm_is_vpn_gateway" "testacc_vpnGateway" {
+		name 	= "%s"
+		subnet 	= "${ibm_is_subnet.testacc_subnet.id}"
+		mode 	= "policy"
+		timeouts{
+			create = "12m"
+		}
+		lifecycle {
+			create_before_destroy = true
+		}
+	}`, vpc, subnet, acc.ISZoneName, acc.ISCIDR, name)
+
+}
+
+func TestAccIBMISVPNGateway_taint(t *testing.T) {
+	var vpnGateway string
+	vpcname := fmt.Sprintf("tfvpnuat-vpc-%d", acctest.RandIntRange(10, 100))
+	subnetname := fmt.Sprintf("tfvpnuat-subnet-%d", acctest.RandIntRange(10, 100))
+	name1 := fmt.Sprintf("tfvpnuat-taintname-%d", acctest.RandIntRange(10, 100))
+	name2 := fmt.Sprintf("tfvpnuat-createname-%d", acctest.RandIntRange(10, 100))
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { acc.TestAccPreCheck(t) },
+		Providers:    acc.TestAccProviders,
+		CheckDestroy: testAccCheckIBMISVPNGatewayDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccCheckIBMISVPNGatewayTaintConfig(vpcname, subnetname, name1),
+				ExpectError: regexp.MustCompile(fmt.Sprintf("timeout while waiting for state to become 'done,")),
+			},
+			{
+				Config: testAccCheckIBMISVPNGatewayTaintConfig2(vpcname, subnetname, name2),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckIBMISVPNGatewayExists("ibm_is_vpn_gateway.testacc_vpnGateway", vpnGateway),
+					resource.TestCheckResourceAttr(
+						"ibm_is_vpn_gateway.testacc_vpnGateway", "name", name2),
+				),
+			},
+		},
+	})
 }


### PR DESCRIPTION
fix(ibm_is_vpn_gateway): reordered the setting of id in ibm_is_vpn_gateway resource to taint the resource properly


<!--- See what makes a good Pull Request at : https://github.com/IBM-Cloud/terraform-provider-ibm/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
--- PASS: TestAccIBMISVPNGateway_taint (765.14s)
PASS
ok      github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/vpc     767.070s
```
```
--- PASS: TestAccIBMISVPNGateway_basic (587.40s)
PASS
ok      github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/vpc     588.735s
```
