### PR TITLE
 fix(vpn_gateway_connection): adding support to null patch ike_policy and ipsec_policy on vpn_gateway_connection

### DIFF
--- a/ibm/service/vpc/resource_ibm_is_vpn_gateway_connections.go
+++ b/ibm/service/vpc/resource_ibm_is_vpn_gateway_connections.go
@@ -508,8 +508,13 @@ func vpngwconUpdate(d *schema.ResourceData, meta interface{}, gID, gConnID strin
 
 	if d.HasChange(isVPNGatewayConnectionIKEPolicy) {
 		ikePolicyIdentity := d.Get(isVPNGatewayConnectionIKEPolicy).(string)
-		vpnGatewayConnectionPatchModel.IkePolicy = &vpcv1.VPNGatewayConnectionIkePolicyPatch{
-			ID: &ikePolicyIdentity,
+		if ikePolicyIdentity == "" {
+			var nullPatch *vpcv1.VPNGatewayConnectionIkePolicyPatch
+			vpnGatewayConnectionPatchModel.IkePolicy = nullPatch
+		} else {
+			vpnGatewayConnectionPatchModel.IkePolicy = &vpcv1.VPNGatewayConnectionIkePolicyPatch{
+				ID: &ikePolicyIdentity,
+			}
 		}
 		hasChanged = true
 	} else {
@@ -518,8 +523,13 @@ func vpngwconUpdate(d *schema.ResourceData, meta interface{}, gID, gConnID strin
 
 	if d.HasChange(isVPNGatewayConnectionIPSECPolicy) {
 		ipsecPolicyIdentity := d.Get(isVPNGatewayConnectionIPSECPolicy).(string)
-		vpnGatewayConnectionPatchModel.IpsecPolicy = &vpcv1.VPNGatewayConnectionIPsecPolicyPatch{
-			ID: &ipsecPolicyIdentity,
+		if ipsecPolicyIdentity == "" {
+			var nullPatch *vpcv1.VPNGatewayConnectionIPsecPolicyPatch
+			vpnGatewayConnectionPatchModel.IpsecPolicy = nullPatch
+		} else {
+			vpnGatewayConnectionPatchModel.IpsecPolicy = &vpcv1.VPNGatewayConnectionIPsecPolicyPatch{
+				ID: &ipsecPolicyIdentity,
+			}
 		}
 		hasChanged = true
 	} else {

--- a/website/docs/r/is_vpn_gateway_connection.html.markdown
+++ b/website/docs/r/is_vpn_gateway_connection.html.markdown
@@ -60,6 +60,26 @@ resource "ibm_is_vpn_gateway_connection" "example" {
 }
 
 ```
+## Example usage ( policy mode with an active peer VPN gateway )
+The following example creates a VPN gateway:
+
+```terraform
+resource "ibm_is_vpn_gateway" "example" {
+  name   = "example-vpn-gateway"
+  subnet = ibm_is_subnet.example.id
+  mode   = "policy"
+}
+
+resource "ibm_is_vpn_gateway_connection" "example" {
+  name          = "example-vpn-gateway-connection"
+  vpn_gateway   = ibm_is_vpn_gateway.example.id
+  peer_address  = ibm_is_vpn_gateway.example.public_ip_address != "0.0.0.0" ? ibm_is_vpn_gateway.example.public_ip_address : ibm_is_vpn_gateway.example.public_ip_address2
+  preshared_key = "VPNDemoPassword"
+  local_cidrs   = [ibm_is_subnet.example.ipv4_cidr_block]
+  peer_cidrs    = [ibm_is_subnet.example2.ipv4_cidr_block]
+}
+
+```
 
 ## Timeouts
 The `ibm_is_vpn_gateway_connection` resource provides the following [Timeouts](https://www.terraform.io/docs/language/resources/syntax.html) configuration options:
@@ -72,9 +92,9 @@ Review the argument references that you can specify for your resource.
 
 - `action` - (Optional, String)  Dead peer detection actions. Supported values are **restart**, **clear**, **hold**, or **none**. Default value is `restart`.
 - `admin_state_up` - (Optional, Bool) The VPN gateway connection status. Default value is **false**. If set to false, the VPN gateway connection is shut down.
-- `ike_policy` - (Optional, String) The ID of the IKE policy.
+- `ike_policy` - (Optional, String) The ID of the IKE policy. Updating value from ID to `""` or making it `null` or removing it  will remove the existing policy.
 - `interval` - (Optional, Integer) Dead peer detection interval in seconds. Default value is 2.
-- `ipsec_policy` - (Optional, String) The ID of the IPSec policy.
+- `ipsec_policy` - (Optional, String) The ID of the IPSec policy. Updating value from ID to `""` or making it `null` or removing it  will remove the existing policy.
 - `local_cidrs` - (Optional, Forces new resource, List) List of local CIDRs for this resource.
 - `name` - (Required, String) The name of the VPN gateway connection.
 - `peer_cidrs` - (Optional, Forces new resource, List) List of peer CIDRs for this resource.


### PR DESCRIPTION


<!--- See what makes a good Pull Request at : https://github.com/IBM-Cloud/terraform-provider-ibm/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
--- PASS: TestAccIBMISVPNGatewayConnection_ike_ipsec_null_patch (544.89s)
PASS
ok      github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/vpc     546.422s
```
