### PR TITLE
Update schema validation to latest schema methods

### DIFF
--- a/ibm/service/database/data_source_ibm_database_connection.go
+++ b/ibm/service/database/data_source_ibm_database_connection.go
@@ -1627,7 +1627,7 @@ func DataSourceIBMDatabaseConnectionValidator() *validate.ResourceValidator {
 			ValidateFunctionIdentifier: validate.ValidateAllowedStringValue,
 			Type:                       validate.TypeString,
 			Required:                   true,
-			CloudDataType:              "public, private, public-and-private"})
+			AllowedValues:              "public, private, public-and-private"})
 
 	iBMDatabaseConnectionsValidator := validate.ResourceValidator{ResourceName: "ibm_database_connection", Schema: validateSchema}
 	return &iBMDatabaseConnectionsValidator

--- a/ibm/service/database/data_source_ibm_database_connection.go
+++ b/ibm/service/database/data_source_ibm_database_connection.go
@@ -42,10 +42,12 @@ func DataSourceIBMDatabaseConnection() *schema.Resource {
 				Description: "User ID.",
 			},
 			"endpoint_type": &schema.Schema{
-				Type:         schema.TypeString,
-				Required:     true,
-				Description:  "Endpoint Type. The endpoint must be enabled on the deployment before its connection information can be fetched.",
-				ValidateFunc: validate.ValidateAllowedStringValues([]string{"public", "private", "public-and-private"}),
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "Endpoint Type. The endpoint must be enabled on the deployment before its connection information can be fetched.",
+				ValidateFunc: validate.InvokeDataSourceValidator(
+					"ibm_database_connection",
+					"endpoint_type"),
 			},
 			"postgres": &schema.Schema{
 				Type:     schema.TypeList,
@@ -1619,6 +1621,13 @@ func DataSourceIBMDatabaseConnectionValidator() *validate.ResourceValidator {
 			Required:                   true,
 			CloudDataType:              "cloud-database",
 			CloudDataRange:             []string{"resolved_to:id"}})
+	validateSchema = append(validateSchema,
+		validate.ValidateSchema{
+			Identifier:                 "endpoint_type",
+			ValidateFunctionIdentifier: validate.ValidateAllowedStringValue,
+			Type:                       validate.TypeString,
+			Required:                   true,
+			CloudDataType:              "public, private, public-and-private"})
 
 	iBMDatabaseConnectionsValidator := validate.ResourceValidator{ResourceName: "ibm_database_connection", Schema: validateSchema}
 	return &iBMDatabaseConnectionsValidator

--- a/ibm/service/database/resource_ibm_database.go
+++ b/ibm/service/database/resource_ibm_database.go
@@ -145,13 +145,13 @@ func ResourceIBMDatabaseInstance() *schema.Resource {
 				Type:         schema.TypeString,
 				Required:     true,
 				ForceNew:     true,
-				ValidateFunc: validate.ValidateAllowedStringValues([]string{"databases-for-etcd", "databases-for-postgresql", "databases-for-redis", "databases-for-elasticsearch", "databases-for-mongodb", "messages-for-rabbitmq", "databases-for-mysql", "databases-for-cassandra", "databases-for-enterprisedb"}),
+				ValidateFunc: validate.InvokeValidator("ibm_database", "service"),
 			},
 			"plan": {
 				Description:  "The plan type of the Database instance",
 				Type:         schema.TypeString,
 				Required:     true,
-				ValidateFunc: validate.ValidateAllowedStringValues([]string{"standard", "enterprise"}),
+				ValidateFunc: validate.InvokeValidator("ibm_database", "plan"),
 				ForceNew:     true,
 			},
 
@@ -279,7 +279,7 @@ func ResourceIBMDatabaseInstance() *schema.Resource {
 				Type:         schema.TypeString,
 				Optional:     true,
 				Default:      "public",
-				ValidateFunc: validate.ValidateAllowedStringValues([]string{"public", "private", "public-and-private"}),
+				ValidateFunc: validate.InvokeValidator("ibm_database", "service_endpoints"),
 			},
 			"backup_id": {
 				Description: "The CRN of backup source database",
@@ -476,7 +476,7 @@ func ResourceIBMDatabaseInstance() *schema.Resource {
 						"group_id": {
 							Required:     true,
 							Type:         schema.TypeString,
-							ValidateFunc: validate.ValidateAllowedStringValues([]string{"member", "analytics", "bi_connector", "search"}),
+							ValidateFunc: validate.InvokeValidator("ibm_database", "group.group_id"),
 						},
 						"members": {
 							Optional: true,
@@ -889,6 +889,34 @@ func ResourceIBMICDValidator() *validate.ResourceValidator {
 			ValidateFunctionIdentifier: validate.ValidateCloudData,
 			Type:                       validate.TypeString,
 			CloudDataType:              "region",
+			Required:                   true})
+	validateSchema = append(validateSchema,
+		validate.ValidateSchema{
+			Identifier:                 "service",
+			ValidateFunctionIdentifier: validate.ValidateAllowedStringValue,
+			Type:                       validate.TypeString,
+			AllowedValues:              "databases-for-etcd, databases-for-postgresql, databases-for-redis, databases-for-elasticsearch, databases-for-mongodb, messages-for-rabbitmq, databases-for-mysql, databases-for-cassandra, databases-for-enterprisedb",
+			Required:                   true})
+	validateSchema = append(validateSchema,
+		validate.ValidateSchema{
+			Identifier:                 "plan",
+			ValidateFunctionIdentifier: validate.ValidateAllowedStringValue,
+			Type:                       validate.TypeString,
+			AllowedValues:              "standard, enterprise",
+			Required:                   true})
+	validateSchema = append(validateSchema,
+		validate.ValidateSchema{
+			Identifier:                 "service_endpoints",
+			ValidateFunctionIdentifier: validate.ValidateAllowedStringValue,
+			Type:                       validate.TypeString,
+			AllowedValues:              "public, private, public-and-private",
+			Required:                   true})
+	validateSchema = append(validateSchema,
+		validate.ValidateSchema{
+			Identifier:                 "group.group_id",
+			ValidateFunctionIdentifier: validate.ValidateAllowedStringValue,
+			Type:                       validate.TypeString,
+			AllowedValues:              "member, analytics, bi_connector, search",
 			Required:                   true})
 
 	ibmICDResourceValidator := validate.ResourceValidator{ResourceName: "ibm_database", Schema: validateSchema}

--- a/ibm/service/database/resource_ibm_database.go
+++ b/ibm/service/database/resource_ibm_database.go
@@ -476,7 +476,7 @@ func ResourceIBMDatabaseInstance() *schema.Resource {
 						"group_id": {
 							Required:     true,
 							Type:         schema.TypeString,
-							ValidateFunc: validate.InvokeValidator("ibm_database", "group.group_id"),
+							ValidateFunc: validate.InvokeValidator("ibm_database", "group_id"),
 						},
 						"members": {
 							Optional: true,
@@ -913,7 +913,7 @@ func ResourceIBMICDValidator() *validate.ResourceValidator {
 			Required:                   true})
 	validateSchema = append(validateSchema,
 		validate.ValidateSchema{
-			Identifier:                 "group.group_id",
+			Identifier:                 "group_id",
 			ValidateFunctionIdentifier: validate.ValidateAllowedStringValue,
 			Type:                       validate.TypeString,
 			AllowedValues:              "member, analytics, bi_connector, search",


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/IBM-Cloud/terraform-provider-ibm/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes [#4014](https://github.com/IBM-Cloud/terraform-provider-ibm/issues/4014)
- Update validation schema to latest validation methods

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$make test
go test -timeout=30s -parallel=4 github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/database github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/directlink github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/dnsservices github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/enterprise
ok      github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/database        1.968s
ok      github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/directlink      1.878s
ok      github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/dnsservices     1.938s
ok      github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/enterprise      2.505s
```

```
$ make testacc TESTARGS='-run=TestAccIBMDatabaseDataSource_basic'
=== RUN   TestAccIBMDatabaseDataSource_basic
=== PAUSE TestAccIBMDatabaseDataSource_basic
=== CONT  TestAccIBMDatabaseDataSource_basic
--- PASS: TestAccIBMDatabaseDataSource_basic (621.72s)
PASS
ok      github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/database        622.694s

...
```

Screenshots of invalid inputs
![Screenshot 2022-09-28 at 15 50 44](https://user-images.githubusercontent.com/10575510/192811357-533b5e5f-7196-449a-a387-c5fabe488dc0.png)
![Screenshot 2022-09-28 at 15 50 59](https://user-images.githubusercontent.com/10575510/192811410-de112442-46ea-41e8-915b-92a852d2543b.png)


