### PR TITLE
Add fix for storage capacity & system pool output

### DIFF
--- a/ibm/flex/flatten.go
+++ b/ibm/flex/flatten.go
@@ -41,6 +41,7 @@ func flatten(result map[string]string, prefix string, v reflect.Value) {
 			result[prefix] = "false"
 		}
 	case reflect.Int:
+	case reflect.Int64:
 		result[prefix] = fmt.Sprintf("%d", v.Int())
 	case reflect.Map:
 		flattenMap(result, prefix, v)

--- a/ibm/service/power/data_source_ibm_pi_storage_pool_capacity.go
+++ b/ibm/service/power/data_source_ibm_pi_storage_pool_capacity.go
@@ -76,7 +76,7 @@ func dataSourceIBMPIStoragePoolCapacityRead(ctx context.Context, d *schema.Resou
 
 	d.SetId(fmt.Sprintf("%s/%s", cloudInstanceID, storagePool))
 
-	d.Set(MaxAllocationSize, sp.MaxAllocationSize)
+	d.Set(MaxAllocationSize, *sp.MaxAllocationSize)
 	d.Set(StorageType, sp.StorageType)
 	d.Set(TotalCapacity, sp.TotalCapacity)
 

--- a/ibm/service/power/data_source_ibm_pi_storage_pools_capacity.go
+++ b/ibm/service/power/data_source_ibm_pi_storage_pools_capacity.go
@@ -99,22 +99,22 @@ func dataSourceIBMPIStoragePoolsCapacityRead(ctx context.Context, d *schema.Reso
 	if spc.MaximumStorageAllocation != nil {
 		msa := spc.MaximumStorageAllocation
 		data := map[string]interface{}{
-			MaxAllocationSize: msa.MaxAllocationSize,
-			StoragePool:       msa.StoragePool,
-			StorageType:       msa.StorageType,
+			MaxAllocationSize: *msa.MaxAllocationSize,
+			StoragePool:       *msa.StoragePool,
+			StorageType:       *msa.StorageType,
 		}
 		d.Set(MaximumStorageAllocation, flex.Flatten(data))
 	}
 
-	result := make([]map[string]string, 0, len(spc.StoragePoolsCapacity))
+	result := make([]map[string]interface{}, 0, len(spc.StoragePoolsCapacity))
 	for _, sp := range spc.StoragePoolsCapacity {
 		data := map[string]interface{}{
-			MaxAllocationSize: sp.MaxAllocationSize,
+			MaxAllocationSize: *sp.MaxAllocationSize,
 			PoolName:          sp.PoolName,
 			StorageType:       sp.StorageType,
 			TotalCapacity:     sp.TotalCapacity,
 		}
-		result = append(result, flex.Flatten(data))
+		result = append(result, data)
 	}
 	d.Set(StoragePoolsCapacity, result)
 

--- a/ibm/service/power/data_source_ibm_pi_storage_type_capacity.go
+++ b/ibm/service/power/data_source_ibm_pi_storage_type_capacity.go
@@ -99,22 +99,22 @@ func dataSourceIBMPIStorageTypeCapacityRead(ctx context.Context, d *schema.Resou
 	if stc.MaximumStorageAllocation != nil {
 		msa := stc.MaximumStorageAllocation
 		data := map[string]interface{}{
-			MaxAllocationSize: msa.MaxAllocationSize,
-			StoragePool:       msa.StoragePool,
-			StorageType:       msa.StorageType,
+			MaxAllocationSize: *msa.MaxAllocationSize,
+			StoragePool:       *msa.StoragePool,
+			StorageType:       *msa.StorageType,
 		}
 		d.Set(MaximumStorageAllocation, flex.Flatten(data))
 	}
 
-	result := make([]map[string]string, 0, len(stc.StoragePoolsCapacity))
+	result := make([]map[string]interface{}, 0, len(stc.StoragePoolsCapacity))
 	for _, sp := range stc.StoragePoolsCapacity {
 		data := map[string]interface{}{
-			MaxAllocationSize: sp.MaxAllocationSize,
+			MaxAllocationSize: *sp.MaxAllocationSize,
 			PoolName:          sp.PoolName,
 			StorageType:       sp.StorageType,
 			TotalCapacity:     sp.TotalCapacity,
 		}
-		result = append(result, flex.Flatten(data))
+		result = append(result, data)
 	}
 	d.Set(StoragePoolsCapacity, result)
 

--- a/ibm/service/power/data_source_ibm_pi_storage_types_capacity.go
+++ b/ibm/service/power/data_source_ibm_pi_storage_types_capacity.go
@@ -112,9 +112,9 @@ func dataSourceIBMPIStorageTypesCapacityRead(ctx context.Context, d *schema.Reso
 	if stc.MaximumStorageAllocation != nil {
 		msa := stc.MaximumStorageAllocation
 		data := map[string]interface{}{
-			MaxAllocationSize: msa.MaxAllocationSize,
-			StoragePool:       msa.StoragePool,
-			StorageType:       msa.StorageType,
+			MaxAllocationSize: *msa.MaxAllocationSize,
+			StoragePool:       *msa.StoragePool,
+			StorageType:       *msa.StorageType,
 		}
 		d.Set(MaximumStorageAllocation, flex.Flatten(data))
 	}
@@ -124,21 +124,21 @@ func dataSourceIBMPIStorageTypesCapacityRead(ctx context.Context, d *schema.Reso
 		if st.MaximumStorageAllocation != nil {
 			msa := st.MaximumStorageAllocation
 			data := map[string]interface{}{
-				MaxAllocationSize: msa.MaxAllocationSize,
-				StoragePool:       msa.StoragePool,
-				StorageType:       msa.StorageType,
+				MaxAllocationSize: *msa.MaxAllocationSize,
+				StoragePool:       *msa.StoragePool,
+				StorageType:       *msa.StorageType,
 			}
 			stResult[MaximumStorageAllocation] = flex.Flatten(data)
 		}
-		spc := make([]map[string]string, 0, len(st.StoragePoolsCapacity))
+		spc := make([]map[string]interface{}, 0, len(st.StoragePoolsCapacity))
 		for _, sp := range st.StoragePoolsCapacity {
 			data := map[string]interface{}{
-				MaxAllocationSize: sp.MaxAllocationSize,
+				MaxAllocationSize: *sp.MaxAllocationSize,
 				PoolName:          sp.PoolName,
 				StorageType:       sp.StorageType,
 				TotalCapacity:     sp.TotalCapacity,
 			}
-			spc = append(spc, flex.Flatten(data))
+			spc = append(spc, data)
 		}
 		stResult[StoragePoolsCapacity] = spc
 		stResult[StorageType] = st.StorageType

--- a/ibm/service/power/data_source_ibm_pi_system_pools.go
+++ b/ibm/service/power/data_source_ibm_pi_system_pools.go
@@ -150,11 +150,11 @@ func dataSourceIBMPISystemPoolsRead(ctx context.Context, d *schema.ResourceData,
 	for s, sp := range sps {
 		data := map[string]interface{}{
 			SystemPoolName:     s,
-			Capacity:           flattenSystem(sp.Capacity),
+			Capacity:           flattenMax(sp.Capacity),
 			CoreMemoryRatio:    sp.CoreMemoryRatio,
-			MaxAvailable:       flattenSystem(sp.MaxAvailable),
-			MaxCoresAvailable:  flattenSystem(sp.MaxCoresAvailable),
-			MaxMemoryAvailable: flattenSystem(sp.MaxMemoryAvailable),
+			MaxAvailable:       flattenMax(sp.MaxAvailable),
+			MaxCoresAvailable:  flattenMax(sp.MaxCoresAvailable),
+			MaxMemoryAvailable: flattenMax(sp.MaxMemoryAvailable),
 			SharedCoreRatio:    flattenSharedCoreRatio(sp.SharedCoreRatio),
 			Type:               sp.Type,
 			Systems:            flattenSystems(sp.Systems),
@@ -167,18 +167,26 @@ func dataSourceIBMPISystemPoolsRead(ctx context.Context, d *schema.ResourceData,
 	return nil
 }
 
+func flattenMax(s *models.System) map[string]string {
+	ret := map[string]interface{}{
+		Cores:  *s.Cores,
+		Memory: *s.Memory,
+	}
+	return flex.Flatten(ret)
+}
+
 func flattenSystem(s *models.System) map[string]string {
 	ret := map[string]interface{}{
-		Cores:  s.Cores,
+		Cores:  *s.Cores,
 		ID:     s.ID,
-		Memory: s.Memory,
+		Memory: *s.Memory,
 	}
 	return flex.Flatten(ret)
 }
 
 func flattenSystems(sl []*models.System) (systems []map[string]string) {
 	if sl != nil {
-		systems = make([]map[string]string, len(sl))
+		systems = make([]map[string]string, 0, len(sl))
 		for _, s := range sl {
 			systems = append(systems, flattenSystem(s))
 		}

--- a/website/docs/d/pi_system_pools.markdown
+++ b/website/docs/d/pi_system_pools.markdown
@@ -50,7 +50,6 @@ In addition to all argument reference list, you can access the following attribu
 
     Nested scheme for `capacity`:
     - `cores` - (String) The host available Processor units.
-    - `id` - (String) The host identifier.
     - `memory`- (String) The host available RAM memory in GiB.
 
   - `core_memory_ratio` - (Float) Processor to Memory (GB) Ratio.
@@ -58,21 +57,18 @@ In addition to all argument reference list, you can access the following attribu
 
     Nested scheme for `max_available`:
     - `cores` - (String) The host available Processor units.
-    - `id` - (String) The host identifier.
     - `memory`- (String) The host available RAM memory in GiB.
 
   - `max_cores_available` - (Map) Maximum configurable cores available combined with available memory of that host.
 
     Nested scheme for `max_cores_available`:
     - `cores` - (String) The host available Processor units.
-    - `id` - (String) The host identifier.
     - `memory`- (String) The host available RAM memory in GiB.
 
   - `max_memory_available` - (Map) Maximum configurable memory available combined with available cores of that host.
 
     Nested scheme for `max_memory_available`:
     - `cores` - (String) The host available Processor units.
-    - `id` - (String) The host identifier.
     - `memory`- (String) The host available RAM memory in GiB.
 
   - `shared_core_ratio` - (Map) The min-max-default allocation percentage of shared core per vCPU.


### PR DESCRIPTION
Add fix for storage capacity & system pool output

<!--- See what makes a good Pull Request at : https://github.com/IBM-Cloud/terraform-provider-ibm/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Output from acceptance testing:

<!--
=== RUN   TestAccIBMPIStorageTypeCapacityDataSourceBasic
--- PASS: TestAccIBMPIStorageTypeCapacityDataSourceBasic (20.74s)
PASS


=== RUN   TestAccIBMPISystemPoolsDataSourceBasic
--- PASS: TestAccIBMPISystemPoolsDataSourceBasic (11.97s)
PASS

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
=== RUN   TestAccIBMPIStorageTypeCapacityDataSourceBasic
--- PASS: TestAccIBMPIStorageTypeCapacityDataSourceBasic (20.74s)
PASS


=== RUN   TestAccIBMPISystemPoolsDataSourceBasic
--- PASS: TestAccIBMPISystemPoolsDataSourceBasic (11.97s)
PASS

```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```
