### PR TITLE
enhancement(bare_metal_server_network_interface_allow_float) : added new floating_bare_metal_server attribute

### DIFF
--- a/ibm/service/vpc/resource_ibm_is_bare_metal_server_network_interface_allow_float_test.go
+++ b/ibm/service/vpc/resource_ibm_is_bare_metal_server_network_interface_allow_float_test.go
@@ -59,6 +59,14 @@ ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCKVmnMOlHKcZK8tpt3MP1lqOLAcqcJzhsvJcjscgVE
 						}
 						return nil
 					}),
+					resource.TestCheckResourceAttrSet(
+						"ibm_is_bare_metal_server.testacc_bms", "floating_bare_metal_server"),
+					resource.TestCheckResourceAttrWith("ibm_is_bare_metal_server_network_interface_allow_float.bms_nic", "floating_bare_metal_server", func(v string) error {
+						if v == "" {
+							return fmt.Errorf("Attribute 'floating_bare_metal_server' %s is not populated", v)
+						}
+						return nil
+					}),
 				),
 			},
 		},
@@ -96,6 +104,14 @@ ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCKVmnMOlHKcZK8tpt3MP1lqOLAcqcJzhsvJcjscgVE
 					resource.TestCheckResourceAttrWith("ibm_is_bare_metal_server_network_interface_allow_float.bms_nic", "primary_ip.0.address", func(v string) error {
 						if v == "0.0.0.0" {
 							return fmt.Errorf("Attribute 'address' %s is not updated", v)
+						}
+						return nil
+					}),
+					resource.TestCheckResourceAttrSet(
+						"ibm_is_bare_metal_server.testacc_bms", "floating_bare_metal_server"),
+					resource.TestCheckResourceAttrWith("ibm_is_bare_metal_server_network_interface_allow_float.bms_nic", "floating_bare_metal_server", func(v string) error {
+						if v == "" {
+							return fmt.Errorf("Attribute 'floating_bare_metal_server' %s is not populated", v)
 						}
 						return nil
 					}),

--- a/website/docs/r/is_bare_metal_server_network_interface_allow_float.markdown
+++ b/website/docs/r/is_bare_metal_server_network_interface_allow_float.markdown
@@ -103,6 +103,7 @@ Review the argument references that you can specify for your resource.
 In addition to the argument reference list, you can access the following attribute references after your data source is created. 
 
 - `allow_interface_to_float` - (Boolean) Indicates if the interface can float to any other server within the same resource_group. The interface will float automatically if the network detects a GARP or RARP on another bare metal server in the resource group. Applies only to vlan type interfaces.
+- `floating_bare_metal_server` - (String) Bare metal server id of the server to which the network interface is floating to. (Same as `bare_metal_server` if its not floating)
 - `floating_ips` - (List) The floating IPs associated with this network interface.
 
   Nested scheme for `floating_ips`:

--- a/website/docs/r/is_bare_metal_server_network_interface_floating_ip.markdown
+++ b/website/docs/r/is_bare_metal_server_network_interface_floating_ip.markdown
@@ -75,6 +75,32 @@ resource "ibm_is_bare_metal_server_network_interface_floating_ip" "bms_nic_fip" 
 
 ```
 
+## Example usage
+The following example shows how to create a allow float network interface and associate a floating IP address to an allow float network interface on the server. 
+
+```
+resource "ibm_is_floating_ip" "fip2" {
+  name        = "testfip2"
+  zone        = "us-south-3"
+}
+
+resource "ibm_is_bare_metal_server_network_interface_allow_float" "allow_float" {
+  bare_metal_server = ibm_is_bare_metal_server.bms.id
+  subnet            = ibm_is_subnet.subnet.id
+  name              = "eth2"
+  allow_ip_spoofing = false
+  vlan              = 101
+}
+
+resource "ibm_is_bare_metal_server_network_interface_floating_ip" "bms_nic_fip" {
+  bare_metal_server = ibm_is_bare_metal_server_network_interface_allow_float.allow_float.floating_bare_metal_server
+  network_interface = ibm_is_bare_metal_server_network_interface_allow_float.allow_float.network_interface
+  floating_ip       = ibm_is_floating_ip.fip2.id
+}
+
+```
+
+
 ## Timeouts
 The `ibm_is_bare_metal_server_network_interface_floating_ip` provides the following [Timeouts](https://www.terraform.io/docs/language/resources/syntax.html) configuration options:
 


### PR DESCRIPTION

<!--- See what makes a good Pull Request at : https://github.com/IBM-Cloud/terraform-provider-ibm/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```
