### PR TITLE
Added support for Event streams targets

### DIFF
--- a/examples/ibm-atracker/main.tf
+++ b/examples/ibm-atracker/main.tf
@@ -12,10 +12,22 @@ resource "ibm_atracker_target" "atracker_target_instance" {
     bucket = "my-atracker-bucket"
     api_key = "xxxxxxxxxxxxxx"
   }
+  region = var.atracker_target_region
+}
+
+resource "ibm_atracker_target" "atracker_target_logdna_instance" {
+  name = var.atracker_target_name
+  target_type = "logdna"
   logdna_endpoint {
     target_crn = "crn:v1:bluemix:public:logdna:us-south:a/11111111111111111111111111111111:22222222-2222-2222-2222-222222222222::"
     ingestion_key = "xxxxxxxxxxxxxx"
   }
+  region = var.atracker_target_region
+}
+
+resource "ibm_atracker_target" atracker_target_eventstreams_instance {
+  name = var.atracker_target_name
+  target_type = "event_streams" 
   eventstreams_endpoint {
     target_crn = "crn:v1:bluemix:public:messagehub:us-south:a/11111111111111111111111111111111:22222222-2222-2222-2222-222222222222::"
     brokers = [ "kafka-x:9094" ]

--- a/examples/ibm-atracker/main.tf
+++ b/examples/ibm-atracker/main.tf
@@ -12,19 +12,19 @@ resource "ibm_atracker_target" "atracker_target_instance" {
     bucket = "my-atracker-bucket"
     api_key = "xxxxxxxxxxxxxx"
   }
-  region = var.atracker_target_region
-}
-
-// Provision atracker_target resource instance for logdna
-resource "ibm_atracker_target" "atracker_target_logdna_instance" {
-  name = var.atracker_target_name
-  target_type = "logdna"
   logdna_endpoint {
     target_crn = "crn:v1:bluemix:public:logdna:us-south:a/11111111111111111111111111111111:22222222-2222-2222-2222-222222222222::"
     ingestion_key = "xxxxxxxxxxxxxx"
   }
+  eventstreams_endpoint {
+    target_crn = "crn:v1:bluemix:public:messagehub:us-south:a/11111111111111111111111111111111:22222222-2222-2222-2222-222222222222::"
+    brokers = [ "kafka-x:9094" ]
+    topic = "my-topic"
+    password = "xxxxxxxxxxxxxx"
+  }
   region = var.atracker_target_region
 }
+
 
 // Provision atracker_route resource instance
 resource "ibm_atracker_route" "atracker_route_instance" {

--- a/go.mod
+++ b/go.mod
@@ -22,7 +22,7 @@ require (
 	github.com/IBM/ibm-hpcs-uko-sdk v0.0.4
 	github.com/IBM/keyprotect-go-client v0.7.0
 	github.com/IBM/networking-go-sdk v0.33.0
-	github.com/IBM/platform-services-go-sdk v0.28.5
+	github.com/IBM/platform-services-go-sdk v0.29.2
 	github.com/IBM/push-notifications-go-sdk v0.0.0-20210310100607-5790b96c47f5
 	github.com/IBM/scc-go-sdk/v3 v3.1.6
 	github.com/IBM/scc-go-sdk/v4 v4.0.0
@@ -145,7 +145,7 @@ require (
 	github.com/vmihailenco/msgpack/v4 v4.3.12 // indirect
 	github.com/vmihailenco/tagparser v0.1.1 // indirect
 	github.com/zclconf/go-cty v1.10.0 // indirect
-	go.mongodb.org/mongo-driver v1.10.0 // indirect
+	go.mongodb.org/mongo-driver v1.11.0 // indirect
 	golang.org/x/net v0.0.0-20220722155237-a158d28d115b // indirect
 	golang.org/x/oauth2 v0.0.0-20211104180415-d3ed0bb246c8 // indirect
 	golang.org/x/sys v0.0.0-20221006211917-84dc82d7e875 // indirect

--- a/go.sum
+++ b/go.sum
@@ -91,6 +91,8 @@ github.com/IBM/networking-go-sdk v0.33.0 h1:+e4Q/io0y/I+LHKSa95gUM+CJfya6gHOelSW
 github.com/IBM/networking-go-sdk v0.33.0/go.mod h1:7b/E21A6BmfycDuNmHjA+EhFm9iM8Wm4ULF9g93J+KE=
 github.com/IBM/platform-services-go-sdk v0.28.5 h1:wVwapdVU3+J/JtS0P6WYi21gqsm1pX/MH4UX69c3+5E=
 github.com/IBM/platform-services-go-sdk v0.28.5/go.mod h1:jy0Ahvj5Gkkua3Gd7t22bo0GfmHRQaPZcaqwfVgEY7k=
+github.com/IBM/platform-services-go-sdk v0.29.2 h1:eZ5hFVQrVDUxiGztsX7Cz2DmiF3tFSqTe1Ew/lkCSOM=
+github.com/IBM/platform-services-go-sdk v0.29.2/go.mod h1:jy0Ahvj5Gkkua3Gd7t22bo0GfmHRQaPZcaqwfVgEY7k=
 github.com/IBM/push-notifications-go-sdk v0.0.0-20210310100607-5790b96c47f5 h1:NPUhkoOCRuv3OFWt19PmwjXGGTKlvmbuPg9fUrBUNe4=
 github.com/IBM/push-notifications-go-sdk v0.0.0-20210310100607-5790b96c47f5/go.mod h1:b07XHUVh0XYnQE9s2mqgjYST1h9buaQNqN4EcKhOsX0=
 github.com/IBM/scc-go-sdk/v3 v3.1.6 h1:wg7yujuJJ1O1pcGrIn8ITq6i6GeXb7GRBPNq6kLrkMU=
@@ -783,6 +785,8 @@ go.mongodb.org/mongo-driver v1.7.3/go.mod h1:NqaYOwnXWr5Pm7AOpO5QFxKJ503nbMse/R7
 go.mongodb.org/mongo-driver v1.7.5/go.mod h1:VXEWRZ6URJIkUq2SCAyapmhH0ZLRBP+FT4xhp5Zvxng=
 go.mongodb.org/mongo-driver v1.10.0 h1:UtV6N5k14upNp4LTduX0QCufG124fSu25Wz9tu94GLg=
 go.mongodb.org/mongo-driver v1.10.0/go.mod h1:wsihk0Kdgv8Kqu1Anit4sfK+22vSFbUrAVEYRhCXrA8=
+go.mongodb.org/mongo-driver v1.11.0 h1:FZKhBSTydeuffHj9CBjXlR8vQLee1cQyTWYPA6/tqiE=
+go.mongodb.org/mongo-driver v1.11.0/go.mod h1:s7p5vEtfbeR1gYi6pnj3c3/urpbLv2T5Sfd6Rp2HBB8=
 go.opencensus.io v0.21.0/go.mod h1:mSImk1erAIZhrmZN+AvHh14ztQfjbGwt4TtuofqLduU=
 go.opencensus.io v0.22.0/go.mod h1:+kGneAE2xo2IficOXnaByMWTGM9T73dGwxeWcUqIpI8=
 go.opencensus.io v0.22.2/go.mod h1:yxeiOL68Rb0Xd1ddK5vPZ/oVn4vY4Ynel7k9FzqtOIw=

--- a/ibm/acctest/acctest.go
+++ b/ibm/acctest/acctest.go
@@ -192,6 +192,11 @@ var ISClientCaCrn string
 // COS Replication Bucket
 var IBM_AccountID_REPL string
 
+// Atracker
+var IesApiKey string
+var IngestionKey string
+var COSApiKey string
+
 func init() {
 	testlogger := os.Getenv("TF_LOG")
 	if testlogger != "" {
@@ -1010,6 +1015,24 @@ func init() {
 	IBM_AccountID_REPL = os.Getenv("IBM_AccountID_REPL")
 	if IBM_AccountID_REPL == "" {
 		fmt.Println("[INFO] Set the environment variable IBM_AccountID_REPL for setting up authorization policy to enable replication feature resource or datasource else tests will fail if this is not set correctly")
+	}
+
+	COSApiKey = os.Getenv("COS_API_KEY")
+	if COSApiKey == "" {
+		COSApiKey = "xxxxxxxxxxxx"
+		fmt.Println("[WARN] Set the environment variable COS_API_KEY for testing COS targets, the tests will fail if this is not set")
+	}
+
+	IngestionKey = os.Getenv("INGESTION_KEY")
+	if IngestionKey == "" {
+		IngestionKey = "xxxxxxxxxxxx"
+		fmt.Println("[WARN] Set the environment variable INGESTION_KEY for testing Logdna targets, the tests will fail if this is not set")
+	}
+
+	IesApiKey = os.Getenv("IES_API_KEY")
+	if IesApiKey == "" {
+		IesApiKey = "xxxxxxxxxxxx"
+		fmt.Println("[WARN] Set the environment variable IES_API_KEY for testing Event streams targets, the tests will fail if this is not set")
 	}
 }
 

--- a/ibm/service/atracker/README.md
+++ b/ibm/service/atracker/README.md
@@ -3,6 +3,11 @@
 This area is primarily for IBM provider contributors and maintainers. For information on _using_ Terraform and the IBM provider, see the links below.
 
 
+## Environment variables to set for the tests
+* COS_API_KEY   : API Key used for creating COS targets
+* INGESTION_KEY : LogDNA Ingestion Key used for creating Logdna targets
+* IES_API_KEY   : Event streams password used for creating Event streams targets
+
 ## Handy Links
 * [Find out about contributing](../../../CONTRIBUTING.md) to the IBM provider!
 * IBM Provider Docs: [Home](https://registry.terraform.io/providers/IBM-Cloud/ibm/latest/docs)

--- a/ibm/service/atracker/data_source_ibm_atracker_targets.go
+++ b/ibm/service/atracker/data_source_ibm_atracker_targets.go
@@ -440,8 +440,8 @@ func DataSourceIBMAtrackerTargetsEventstreamsEndpointToMap(model *atrackerv2.Eve
 	if model.Topic != nil {
 		modelMap["topic"] = *model.Topic
 	}
-	if model.Password != nil {
-		modelMap["password"] = *model.Password
+	if model.APIKey != nil {
+		modelMap["api_key"] = *model.APIKey
 	}
 	return modelMap, nil
 }

--- a/ibm/service/atracker/data_source_ibm_atracker_targets.go
+++ b/ibm/service/atracker/data_source_ibm_atracker_targets.go
@@ -152,7 +152,33 @@ func DataSourceIBMAtrackerTargets() *schema.Resource {
 									"password": &schema.Schema{
 										Type:        schema.TypeString,
 										Computed:    true,
+										Sensitive:   true,
 										Description: "The user password (api key) for the message hub topic in the Event Streams instance.",
+									},
+								},
+							},
+						},
+						"cos_write_status": {
+							Type:        schema.TypeList,
+							Computed:    true,
+							Deprecated:  "use write_status instead",
+							Description: "The status of the write attempt with the provided cos_endpoint parameters.",
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"status": {
+										Type:        schema.TypeString,
+										Computed:    true,
+										Description: "The status such as failed or success.",
+									},
+									"last_failure": {
+										Type:        schema.TypeString,
+										Computed:    true,
+										Description: "The timestamp of the failure.",
+									},
+									"reason_for_last_failure": {
+										Type:        schema.TypeString,
+										Computed:    true,
+										Description: "Detailed description of the cause of the failure.",
 									},
 								},
 							},
@@ -342,13 +368,6 @@ func DataSourceIBMAtrackerTargetsTargetToMap(model *atrackerv2.Target) (map[stri
 			return modelMap, err
 		}
 		modelMap["cos_endpoint"] = []map[string]interface{}{cosEndpointMap}
-	}
-	if model.LogdnaEndpoint != nil {
-		logdnaEndpointMap, err := DataSourceIBMAtrackerTargetsLogdnaEndpointToMap(model.LogdnaEndpoint)
-		if err != nil {
-			return modelMap, err
-		}
-		modelMap["logdna_endpoint"] = []map[string]interface{}{logdnaEndpointMap}
 	}
 	if model.LogdnaEndpoint != nil {
 		logdnaEndpointMap, err := DataSourceIBMAtrackerTargetsLogdnaEndpointToMap(model.LogdnaEndpoint)

--- a/ibm/service/atracker/data_source_ibm_atracker_targets.go
+++ b/ibm/service/atracker/data_source_ibm_atracker_targets.go
@@ -125,27 +125,34 @@ func DataSourceIBMAtrackerTargets() *schema.Resource {
 								},
 							},
 						},
-						"cos_write_status": {
+						"eventstreams_endpoint": &schema.Schema{
 							Type:        schema.TypeList,
 							Computed:    true,
-							Deprecated:  "use write_status instead",
-							Description: "The status of the write attempt with the provided cos_endpoint parameters.",
+							Description: "Property values for the Event Streams Endpoint in responses.",
 							Elem: &schema.Resource{
 								Schema: map[string]*schema.Schema{
-									"status": {
+									"target_crn": &schema.Schema{
 										Type:        schema.TypeString,
 										Computed:    true,
-										Description: "The status such as failed or success.",
+										Description: "The CRN of the Event Streams instance.",
 									},
-									"last_failure": {
-										Type:        schema.TypeString,
+									"brokers": &schema.Schema{
+										Type:        schema.TypeList,
 										Computed:    true,
-										Description: "The timestamp of the failure.",
+										Description: "List of broker endpoints.",
+										Elem: &schema.Schema{
+											Type: schema.TypeString,
+										},
 									},
-									"reason_for_last_failure": {
+									"topic": &schema.Schema{
 										Type:        schema.TypeString,
 										Computed:    true,
-										Description: "Detailed description of the cause of the failure.",
+										Description: "The messsage hub topic defined in the Event Streams instance.",
+									},
+									"password": &schema.Schema{
+										Type:        schema.TypeString,
+										Computed:    true,
+										Description: "The user password (api key) for the message hub topic in the Event Streams instance.",
 									},
 								},
 							},
@@ -343,6 +350,20 @@ func DataSourceIBMAtrackerTargetsTargetToMap(model *atrackerv2.Target) (map[stri
 		}
 		modelMap["logdna_endpoint"] = []map[string]interface{}{logdnaEndpointMap}
 	}
+	if model.LogdnaEndpoint != nil {
+		logdnaEndpointMap, err := DataSourceIBMAtrackerTargetsLogdnaEndpointToMap(model.LogdnaEndpoint)
+		if err != nil {
+			return modelMap, err
+		}
+		modelMap["logdna_endpoint"] = []map[string]interface{}{logdnaEndpointMap}
+	}
+	if model.EventstreamsEndpoint != nil {
+		eventstreamsEndpointMap, err := DataSourceIBMAtrackerTargetsEventstreamsEndpointToMap(model.EventstreamsEndpoint)
+		if err != nil {
+			return modelMap, err
+		}
+		modelMap["eventstreams_endpoint"] = []map[string]interface{}{eventstreamsEndpointMap}
+	}
 	if model.WriteStatus != nil {
 		writeStatusMap, err := DataSourceIBMAtrackerTargetsWriteStatusToMap(model.WriteStatus)
 		if err != nil {
@@ -385,6 +406,23 @@ func DataSourceIBMAtrackerTargetsLogdnaEndpointToMap(model *atrackerv2.LogdnaEnd
 	modelMap := make(map[string]interface{})
 	if model.TargetCRN != nil {
 		modelMap["target_crn"] = *model.TargetCRN
+	}
+	return modelMap, nil
+}
+
+func DataSourceIBMAtrackerTargetsEventstreamsEndpointToMap(model *atrackerv2.EventstreamsEndpoint) (map[string]interface{}, error) {
+	modelMap := make(map[string]interface{})
+	if model.TargetCRN != nil {
+		modelMap["target_crn"] = *model.TargetCRN
+	}
+	if model.Brokers != nil {
+		modelMap["brokers"] = model.Brokers
+	}
+	if model.Topic != nil {
+		modelMap["topic"] = *model.Topic
+	}
+	if model.Password != nil {
+		modelMap["password"] = *model.Password
 	}
 	return modelMap, nil
 }

--- a/ibm/service/atracker/data_source_ibm_atracker_targets_test.go
+++ b/ibm/service/atracker/data_source_ibm_atracker_targets_test.go
@@ -37,7 +37,7 @@ func TestAccIBMAtrackerTargetsDataSourceBasic(t *testing.T) {
 func TestAccIBMAtrackerTargetsDataSourceAllArgs(t *testing.T) {
 	targetName := fmt.Sprintf("tf_name_%d", acctest.RandIntRange(10, 100))
 	targetTargetType := "cloud_object_storage"
-	targetRegion := "us-south"
+	targetRegion := fmt.Sprintf("tf_region_%d", acctest.RandIntRange(10, 100))
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:  func() { acc.TestAccPreCheck(t) },
@@ -94,10 +94,20 @@ func testAccCheckIBMAtrackerTargetsDataSourceConfig(targetName string, targetTar
 				api_key = "xxxxxxxxxxxxxx"
 				service_to_service_enabled = true
 			}
+			logdna_endpoint {
+				target_crn = "crn:v1:bluemix:public:logdna:us-south:a/11111111111111111111111111111111:22222222-2222-2222-2222-222222222222::"
+				ingestion_key = "xxxxxxxxxxxxxx"
+			}
+			eventstreams_endpoint {
+				target_crn = "crn:v1:bluemix:public:messagehub:us-south:a/11111111111111111111111111111111:22222222-2222-2222-2222-222222222222::"
+				brokers = [ "kafka-x:9094" ]
+				topic = "my-topic"
+				password = "xxxxxxxxxxxxxx"
+			}
+			region = "%s"
 		}
-
 		data "ibm_atracker_targets" "atracker_targets" {
 			name = ibm_atracker_target.atracker_target.name
 		}
-	`, targetName, targetTargetType)
+	`, targetName, targetTargetType, targetRegion)
 }

--- a/ibm/service/atracker/data_source_ibm_atracker_targets_test.go
+++ b/ibm/service/atracker/data_source_ibm_atracker_targets_test.go
@@ -104,7 +104,7 @@ func testAccCheckIBMAtrackerTargetsDataSourceConfig(targetName string, targetTar
 				target_crn = "crn:v1:bluemix:public:messagehub:us-south:a/11111111111111111111111111111111:22222222-2222-2222-2222-222222222222::"
 				brokers = [ "kafka-x:9094" ]
 				topic = "my-topic"
-				password = "%s"
+				api_key = "%s"
 			}
 		}
 		data "ibm_atracker_targets" "atracker_targets" {

--- a/ibm/service/atracker/data_source_ibm_atracker_targets_test.go
+++ b/ibm/service/atracker/data_source_ibm_atracker_targets_test.go
@@ -72,7 +72,7 @@ func testAccCheckIBMAtrackerTargetsDataSourceConfigBasic(targetName string, targ
 				endpoint = "s3.private.us-east.cloud-object-storage.appdomain.cloud"
 				target_crn = "crn:v1:bluemix:public:cloud-object-storage:global:a/11111111111111111111111111111111:22222222-2222-2222-2222-222222222222::"
 				bucket = "my-atracker-bucket"
-				api_key = "xxxxxxxxxxxxxx"
+				api_key = "%s"
 				service_to_service_enabled = true
 			}
 		}
@@ -80,7 +80,7 @@ func testAccCheckIBMAtrackerTargetsDataSourceConfigBasic(targetName string, targ
 		data "ibm_atracker_targets" "atracker_targets" {
 			name = ibm_atracker_target.atracker_target.name
 		}
-	`, targetName, targetTargetType)
+	`, targetName, targetTargetType, acc.COSApiKey)
 }
 
 func testAccCheckIBMAtrackerTargetsDataSourceConfig(targetName string, targetTargetType string, targetRegion string) string {
@@ -88,27 +88,27 @@ func testAccCheckIBMAtrackerTargetsDataSourceConfig(targetName string, targetTar
 		resource "ibm_atracker_target" "atracker_target" {
 			name = "%s"
 			target_type = "%s"
+			region = "%s"
 			cos_endpoint {
 				endpoint = "s3.private.us-east.cloud-object-storage.appdomain.cloud"
 				target_crn = "crn:v1:bluemix:public:cloud-object-storage:global:a/11111111111111111111111111111111:22222222-2222-2222-2222-222222222222::"
 				bucket = "my-atracker-bucket"
-				api_key = "xxxxxxxxxxxxxx"
+				api_key = "%s"
 				service_to_service_enabled = true
 			}
 			logdna_endpoint {
 				target_crn = "crn:v1:bluemix:public:logdna:us-south:a/11111111111111111111111111111111:22222222-2222-2222-2222-222222222222::"
-				ingestion_key = "xxxxxxxxxxxxxx"
+				ingestion_key = "%s"
 			}
 			eventstreams_endpoint {
 				target_crn = "crn:v1:bluemix:public:messagehub:us-south:a/11111111111111111111111111111111:22222222-2222-2222-2222-222222222222::"
 				brokers = [ "kafka-x:9094" ]
 				topic = "my-topic"
-				password = "xxxxxxxxxxxxxx"
+				password = "%s"
 			}
-			region = "%s"
 		}
 		data "ibm_atracker_targets" "atracker_targets" {
 			name = ibm_atracker_target.atracker_target.name
 		}
-	`, targetName, targetTargetType, targetRegion)
+	`, targetName, targetTargetType, targetRegion, acc.COSApiKey, acc.IngestionKey, acc.IesApiKey)
 }

--- a/ibm/service/atracker/data_source_ibm_atracker_targets_test.go
+++ b/ibm/service/atracker/data_source_ibm_atracker_targets_test.go
@@ -37,7 +37,7 @@ func TestAccIBMAtrackerTargetsDataSourceBasic(t *testing.T) {
 func TestAccIBMAtrackerTargetsDataSourceAllArgs(t *testing.T) {
 	targetName := fmt.Sprintf("tf_name_%d", acctest.RandIntRange(10, 100))
 	targetTargetType := "cloud_object_storage"
-	targetRegion := fmt.Sprintf("tf_region_%d", acctest.RandIntRange(10, 100))
+	targetRegion := "us-south"
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:  func() { acc.TestAccPreCheck(t) },
@@ -73,6 +73,7 @@ func testAccCheckIBMAtrackerTargetsDataSourceConfigBasic(targetName string, targ
 				target_crn = "crn:v1:bluemix:public:cloud-object-storage:global:a/11111111111111111111111111111111:22222222-2222-2222-2222-222222222222::"
 				bucket = "my-atracker-bucket"
 				api_key = "xxxxxxxxxxxxxx"
+				service_to_service_enabled = true
 			}
 		}
 

--- a/ibm/service/atracker/resource_ibm_atracker_target.go
+++ b/ibm/service/atracker/resource_ibm_atracker_target.go
@@ -41,7 +41,7 @@ func ResourceIBMAtrackerTarget() *schema.Resource {
 				Required:         true,
 				ForceNew:         true,
 				ValidateFunc:     validate.InvokeValidator("ibm_atracker_target", "target_type"),
-				Description:      "The type of the target. It can be cloud_object_storage or logdna. Based on this type you must include cos_endpoint or logdna_endpoint.",
+				Description:      "The type of the target. It can be cloud_object_storage, logdna or event_streams. Based on this type you must include cos_endpoint, logdna_endpoint or eventstreams_endpoint.",
 			},
 			"cos_endpoint": {
 				Type:        schema.TypeList,
@@ -98,6 +98,37 @@ func ResourceIBMAtrackerTarget() *schema.Resource {
 							Sensitive:        true,
 							DiffSuppressFunc: flex.ApplyOnce,
 							Description:      "The LogDNA ingestion key is used for routing logs to a specific LogDNA instance.",
+						},
+					},
+				},
+			},
+			"eventstreams_endpoint": &schema.Schema{
+				Type:        schema.TypeList,
+				MaxItems:    1,
+				Optional:    true,
+				Description: "Property values for an Event Streams Endpoint in requests.",
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"target_crn": &schema.Schema{
+							Type:        schema.TypeString,
+							Required:    true,
+							Description: "The CRN of the Event Streams instance.",
+						},
+						"brokers": &schema.Schema{
+							Type:        schema.TypeList,
+							Required:    true,
+							Description: "List of broker endpoints.",
+							Elem:        &schema.Schema{Type: schema.TypeString},
+						},
+						"topic": &schema.Schema{
+							Type:        schema.TypeString,
+							Required:    true,
+							Description: "The messsage hub topic defined in the Event Streams instance.",
+						},
+						"password": &schema.Schema{
+							Type:        schema.TypeString,
+							Required:    true,
+							Description: "The user password (api key) for the message hub topic in the Event Streams instance.",
 						},
 					},
 				},
@@ -222,7 +253,7 @@ func ResourceIBMAtrackerTargetValidator() *validate.ResourceValidator {
 			ValidateFunctionIdentifier: validate.ValidateAllowedStringValue,
 			Type:                       validate.TypeString,
 			Required:                   true,
-			AllowedValues:              "cloud_object_storage, logdna",
+			AllowedValues:              "cloud_object_storage, logdna, event_streams",
 		},
 		validate.ValidateSchema{
 			Identifier:                 "region",
@@ -263,8 +294,12 @@ func resourceIBMAtrackerTargetCreate(context context.Context, d *schema.Resource
 		}
 		createTargetOptions.SetLogdnaEndpoint(logdnaEndpointModel)
 	}
-	if _, ok := d.GetOk("region"); ok {
-		createTargetOptions.SetRegion(d.Get("region").(string))
+	if _, ok := d.GetOk("eventstreams_endpoint"); ok {
+		eventstreamsEndpointModel, err := resourceIBMAtrackerTargetMapToEventstreamsEndpointPrototype(d.Get("eventstreams_endpoint.0").(map[string]interface{}))
+		if err != nil {
+			return diag.FromErr(err)
+		}
+		createTargetOptions.SetEventstreamsEndpoint(eventstreamsEndpointModel)
 	}
 
 	target, response, err := atrackerClient.CreateTargetWithContext(context, createTargetOptions)
@@ -340,6 +375,15 @@ func resourceIBMAtrackerTargetRead(context context.Context, d *schema.ResourceDa
 			return diag.FromErr(fmt.Errorf("Error setting logdna_endpoint: %s", err))
 		}
 	}
+	if target.EventstreamsEndpoint != nil {
+		eventstreamsEndpointMap, err := resourceIBMAtrackerTargetEventstreamsEndpointPrototypeToMap(target.EventstreamsEndpoint)
+		if err != nil {
+			return diag.FromErr(err)
+		}
+		if err = d.Set("eventstreams_endpoint", []map[string]interface{}{eventstreamsEndpointMap}); err != nil {
+			return diag.FromErr(fmt.Errorf("Error setting eventstreams_endpoint: %s", err))
+		}
+	}
 
 	if target.CRN != nil {
 		if err = d.Set("crn", target.CRN); err != nil {
@@ -394,7 +438,7 @@ func resourceIBMAtrackerTargetUpdate(context context.Context, d *schema.Resource
 
 	hasChange := false
 
-	if d.HasChange("name") || d.HasChange("cos_endpoint") || d.HasChange("region") || d.HasChange("logdna_endpoint") {
+	if d.HasChange("name") || d.HasChange("cos_endpoint") || d.HasChange("region") || d.HasChange("logdna_endpoint") || d.HasChange("eventstreams_endpoint") {
 		replaceTargetOptions.SetName(d.Get("name").(string))
 
 		_, hasCosEndpoint := d.GetOk("cos_endpoint.0")
@@ -414,6 +458,15 @@ func resourceIBMAtrackerTargetUpdate(context context.Context, d *schema.Resource
 			}
 			replaceTargetOptions.SetLogdnaEndpoint(logdnaEndpoint)
 		}
+		_, hasEventstreamsEndpoint := d.GetOk("eventstreams_endpoint.0")
+		if hasEventstreamsEndpoint {
+			eventstreamsEndpoint, err := resourceIBMAtrackerTargetMapToEventstreamsEndpointPrototype(d.Get("eventstreams_endpoint.0").(map[string]interface{}))
+			if err != nil {
+				return diag.FromErr(err)
+			}
+			replaceTargetOptions.SetEventstreamsEndpoint(eventstreamsEndpoint)
+		}
+
 		hasChange = true
 	}
 
@@ -468,6 +521,19 @@ func resourceIBMAtrackerTargetMapToLogdnaEndpointPrototype(modelMap map[string]i
 	return model, nil
 }
 
+func resourceIBMAtrackerTargetMapToEventstreamsEndpointPrototype(modelMap map[string]interface{}) (*atrackerv2.EventstreamsEndpointPrototype, error) {
+	model := &atrackerv2.EventstreamsEndpointPrototype{}
+	model.TargetCRN = core.StringPtr(modelMap["target_crn"].(string))
+	model.Topic = core.StringPtr(modelMap["topic"].(string))
+	brokers := []string{}
+	for _, brokersItem := range modelMap["brokers"].([]interface{}) {
+		brokers = append(brokers, brokersItem.(string))
+	}
+	model.Brokers = brokers
+	model.Password = core.StringPtr(modelMap["password"].(string)) // pragma: whitelist secret
+	return model, nil
+}
+
 func resourceIBMAtrackerTargetCosEndpointPrototypeToMap(model *atrackerv2.CosEndpoint) (map[string]interface{}, error) {
 	modelMap := make(map[string]interface{})
 	modelMap["endpoint"] = model.Endpoint
@@ -484,6 +550,16 @@ func resourceIBMAtrackerTargetLogdnaEndpointPrototypeToMap(model *atrackerv2.Log
 	modelMap := make(map[string]interface{})
 	modelMap["target_crn"] = model.TargetCRN
 	modelMap["ingestion_key"] = REDACTED_TEXT // pragma: whitelist secret
+	return modelMap, nil
+}
+
+func resourceIBMAtrackerTargetEventstreamsEndpointPrototypeToMap(model *atrackerv2.EventstreamsEndpoint) (map[string]interface{}, error) {
+	modelMap := make(map[string]interface{})
+	modelMap["target_crn"] = model.TargetCRN
+	modelMap["brokers"] = model.Brokers
+	modelMap["topic"] = model.Topic
+	// TODO: remove after deprecation
+	modelMap["password"] = REDACTED_TEXT // pragma: whitelist secret
 	return modelMap, nil
 }
 

--- a/ibm/service/atracker/resource_ibm_atracker_target.go
+++ b/ibm/service/atracker/resource_ibm_atracker_target.go
@@ -125,7 +125,7 @@ func ResourceIBMAtrackerTarget() *schema.Resource {
 							Required:    true,
 							Description: "The messsage hub topic defined in the Event Streams instance.",
 						},
-						"password": &schema.Schema{
+						"api_key": &schema.Schema{
 							Type:             schema.TypeString,
 							Required:         true,
 							Sensitive:        true,
@@ -535,7 +535,7 @@ func resourceIBMAtrackerTargetMapToEventstreamsEndpointPrototype(modelMap map[st
 		brokers = append(brokers, brokersItem.(string))
 	}
 	model.Brokers = brokers
-	model.Password = core.StringPtr(modelMap["password"].(string)) // pragma: whitelist secret
+	model.APIKey = core.StringPtr(modelMap["api_key"].(string)) // pragma: whitelist secret
 	return model, nil
 }
 
@@ -564,7 +564,7 @@ func resourceIBMAtrackerTargetEventstreamsEndpointPrototypeToMap(model *atracker
 	modelMap["brokers"] = model.Brokers
 	modelMap["topic"] = model.Topic
 	// TODO: remove after deprecation
-	modelMap["password"] = REDACTED_TEXT // pragma: whitelist secret
+	modelMap["api_key"] = REDACTED_TEXT // pragma: whitelist secret
 	return modelMap, nil
 }
 

--- a/ibm/service/atracker/resource_ibm_atracker_target.go
+++ b/ibm/service/atracker/resource_ibm_atracker_target.go
@@ -126,9 +126,11 @@ func ResourceIBMAtrackerTarget() *schema.Resource {
 							Description: "The messsage hub topic defined in the Event Streams instance.",
 						},
 						"password": &schema.Schema{
-							Type:        schema.TypeString,
-							Required:    true,
-							Description: "The user password (api key) for the message hub topic in the Event Streams instance.",
+							Type:             schema.TypeString,
+							Required:         true,
+							Sensitive:        true,
+							DiffSuppressFunc: flex.ApplyOnce,
+							Description:      "The user password (api key) for the message hub topic in the Event Streams instance.",
 						},
 					},
 				},
@@ -300,6 +302,9 @@ func resourceIBMAtrackerTargetCreate(context context.Context, d *schema.Resource
 			return diag.FromErr(err)
 		}
 		createTargetOptions.SetEventstreamsEndpoint(eventstreamsEndpointModel)
+	}
+	if _, ok := d.GetOk("region"); ok {
+		createTargetOptions.SetRegion(d.Get("region").(string))
 	}
 
 	target, response, err := atrackerClient.CreateTargetWithContext(context, createTargetOptions)

--- a/ibm/service/atracker/resource_ibm_atracker_target_test.go
+++ b/ibm/service/atracker/resource_ibm_atracker_target_test.go
@@ -81,16 +81,6 @@ func testAccCheckIBMAtrackerTargetConfig(name string, targetType string, region 
 				api_key = "xxxxxxxxxxxxxx"
 				service_to_service_enabled = true
 			}
-			logdna_endpoint {
-				target_crn = "crn:v1:bluemix:public:logdna:us-south:a/11111111111111111111111111111111:22222222-2222-2222-2222-222222222222::"
-				ingestion_key = "xxxxxxxxxxxxxx"
-			}
-			eventstreams_endpoint {
-				target_crn = "crn:v1:bluemix:public:messagehub:us-south:a/11111111111111111111111111111111:22222222-2222-2222-2222-222222222222::"
-				brokers = [ "kafka-x:9094" ]
-				topic = "my-topic"
-				password = "xxxxxxxxxxxxxx"
-			}
 			region = "%s"
 		}
 	`, name, targetType, region)

--- a/ibm/service/atracker/resource_ibm_atracker_target_test.go
+++ b/ibm/service/atracker/resource_ibm_atracker_target_test.go
@@ -51,6 +51,45 @@ func TestAccIBMAtrackerTargetBasic(t *testing.T) {
 	})
 }
 
+func TestAccIBMAtrackerTargetAllArgs(t *testing.T) {
+	var conf atrackerv2.Target
+	name := fmt.Sprintf("tf_name_%d", acctest.RandIntRange(10, 100))
+	targetType := "cloud_object_storage"
+	region := fmt.Sprintf("tf_region_%d", acctest.RandIntRange(10, 100))
+	nameUpdate := fmt.Sprintf("tf_name_%d", acctest.RandIntRange(10, 100))
+	regionUpdate := fmt.Sprintf("tf_region_%d", acctest.RandIntRange(10, 100))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { acc.TestAccPreCheck(t) },
+		Providers:    acc.TestAccProviders,
+		CheckDestroy: testAccCheckIBMAtrackerTargetDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccCheckIBMAtrackerTargetConfig(name, targetType, region),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckIBMAtrackerTargetExists("ibm_atracker_target.atracker_target", conf),
+					resource.TestCheckResourceAttr("ibm_atracker_target.atracker_target", "name", name),
+					resource.TestCheckResourceAttr("ibm_atracker_target.atracker_target", "target_type", targetType),
+					resource.TestCheckResourceAttr("ibm_atracker_target.atracker_target", "region", region),
+				),
+			},
+			resource.TestStep{
+				Config: testAccCheckIBMAtrackerTargetConfig(nameUpdate, targetType, regionUpdate),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("ibm_atracker_target.atracker_target", "name", nameUpdate),
+					resource.TestCheckResourceAttr("ibm_atracker_target.atracker_target", "target_type", targetType),
+					resource.TestCheckResourceAttr("ibm_atracker_target.atracker_target", "region", regionUpdate),
+				),
+			},
+			resource.TestStep{
+				ResourceName:      "ibm_atracker_target.atracker_target",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
 func testAccCheckIBMAtrackerTargetConfigBasic(name string, targetType string) string {
 	return fmt.Sprintf(`
 
@@ -66,6 +105,24 @@ func testAccCheckIBMAtrackerTargetConfigBasic(name string, targetType string) st
 			}
 		}
 	`, name, targetType)
+}
+
+func testAccCheckIBMAtrackerTargetConfig(name string, targetType string, region string) string {
+	return fmt.Sprintf(`
+
+		resource "ibm_atracker_target" "atracker_target" {
+			name = "%s"
+			target_type = "%s"
+			cos_endpoint {
+				endpoint = "s3.private.us-east.cloud-object-storage.appdomain.cloud"
+				target_crn = "crn:v1:bluemix:public:cloud-object-storage:global:a/11111111111111111111111111111111:22222222-2222-2222-2222-222222222222::"
+				bucket = "my-atracker-bucket"
+				api_key = "xxxxxxxxxxxxxx"
+				service_to_service_enabled = true
+			}
+			region = "%s"
+		}
+	`, name, targetType, region)
 }
 
 func testAccCheckIBMAtrackerTargetExists(n string, obj atrackerv2.Target) resource.TestCheckFunc {

--- a/ibm/service/atracker/resource_ibm_atracker_target_test.go
+++ b/ibm/service/atracker/resource_ibm_atracker_target_test.go
@@ -51,45 +51,6 @@ func TestAccIBMAtrackerTargetBasic(t *testing.T) {
 	})
 }
 
-func TestAccIBMAtrackerTargetAllArgs(t *testing.T) {
-	var conf atrackerv2.Target
-	name := fmt.Sprintf("tf_name_%d", acctest.RandIntRange(10, 100))
-	targetType := "cloud_object_storage"
-	region := fmt.Sprintf("tf_region_%d", acctest.RandIntRange(10, 100))
-	nameUpdate := fmt.Sprintf("tf_name_%d", acctest.RandIntRange(10, 100))
-	regionUpdate := fmt.Sprintf("tf_region_%d", acctest.RandIntRange(10, 100))
-
-	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { acc.TestAccPreCheck(t) },
-		Providers:    acc.TestAccProviders,
-		CheckDestroy: testAccCheckIBMAtrackerTargetDestroy,
-		Steps: []resource.TestStep{
-			resource.TestStep{
-				Config: testAccCheckIBMAtrackerTargetConfig(name, targetType, region),
-				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckIBMAtrackerTargetExists("ibm_atracker_target.atracker_target", conf),
-					resource.TestCheckResourceAttr("ibm_atracker_target.atracker_target", "name", name),
-					resource.TestCheckResourceAttr("ibm_atracker_target.atracker_target", "target_type", targetType),
-					resource.TestCheckResourceAttr("ibm_atracker_target.atracker_target", "region", region),
-				),
-			},
-			resource.TestStep{
-				Config: testAccCheckIBMAtrackerTargetConfig(nameUpdate, targetType, regionUpdate),
-				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr("ibm_atracker_target.atracker_target", "name", nameUpdate),
-					resource.TestCheckResourceAttr("ibm_atracker_target.atracker_target", "target_type", targetType),
-					resource.TestCheckResourceAttr("ibm_atracker_target.atracker_target", "region", regionUpdate),
-				),
-			},
-			resource.TestStep{
-				ResourceName:      "ibm_atracker_target.atracker_target",
-				ImportState:       true,
-				ImportStateVerify: true,
-			},
-		},
-	})
-}
-
 func testAccCheckIBMAtrackerTargetConfigBasic(name string, targetType string) string {
 	return fmt.Sprintf(`
 
@@ -97,11 +58,11 @@ func testAccCheckIBMAtrackerTargetConfigBasic(name string, targetType string) st
 			name = "%s"
 			target_type = "%s"
 			cos_endpoint {
-				endpoint = "s3.private.us-east.cloud-object-storage.appdomain.cloud"
-				target_crn = "crn:v1:bluemix:public:cloud-object-storage:global:a/11111111111111111111111111111111:22222222-2222-2222-2222-222222222222::"
-				bucket = "my-atracker-bucket"
-				api_key = "xxxxxxxxxxxxxx"
-				service_to_service_enabled = false
+					endpoint = "s3.private.us-east.cloud-object-storage.appdomain.cloud"
+					target_crn = "crn:v1:bluemix:public:cloud-object-storage:global:a/11111111111111111111111111111111:22222222-2222-2222-2222-222222222222::"
+					bucket = "my-atracker-bucket"
+					api_key = "xxxxxxxxxxxxxx"
+					service_to_service_enabled = true
 			}
 		}
 	`, name, targetType)
@@ -119,6 +80,16 @@ func testAccCheckIBMAtrackerTargetConfig(name string, targetType string, region 
 				bucket = "my-atracker-bucket"
 				api_key = "xxxxxxxxxxxxxx"
 				service_to_service_enabled = true
+			}
+			logdna_endpoint {
+				target_crn = "crn:v1:bluemix:public:logdna:us-south:a/11111111111111111111111111111111:22222222-2222-2222-2222-222222222222::"
+				ingestion_key = "xxxxxxxxxxxxxx"
+			}
+			eventstreams_endpoint {
+				target_crn = "crn:v1:bluemix:public:messagehub:us-south:a/11111111111111111111111111111111:22222222-2222-2222-2222-222222222222::"
+				brokers = [ "kafka-x:9094" ]
+				topic = "my-topic"
+				password = "xxxxxxxxxxxxxx"
 			}
 			region = "%s"
 		}

--- a/website/docs/d/atracker_targets.html.markdown
+++ b/website/docs/d/atracker_targets.html.markdown
@@ -35,7 +35,7 @@ Nested scheme for **targets**:
 	* `name` - (String) The name of the target resource.
 	* `crn` - (String) The crn of the target resource.
 	* `target_type` - (String) The type of the target.
-	  * Constraints: Allowable values are: `cloud_object_storage`, `logdna`.
+	  * Constraints: Allowable values are: `cloud_object_storage`, `logdna`, `event_streams`.
 	* `encrypt_key` - (String) The encryption key that is used to encrypt events before Activity Tracker services buffer them on storage. This credential is masked in the response.
 	* `region` - (String) Included this optional field if you used it to create a target in a different region other than the one you are connected.
 	* `cos_endpoint` - (List) Property values for a Cloud Object Storage Endpoint.
@@ -55,7 +55,17 @@ Nested scheme for **targets**:
 		  * Constraints: The maximum length is `1000` characters. The minimum length is `3` characters. The value must match regular expression `/^[a-zA-Z0-9 -._:\/]+$/`.
 		* `target_crn` - (String) The CRN of the LogDNA instance.
 		  * Constraints: The maximum length is `1000` characters. The minimum length is `3` characters. The value must match regular expression `/^[a-zA-Z0-9 -._:\/]+$/`.
-	* `write_status` - (List) The status of the write attempt to the target with the provided endpoint parameters.
+  * `eventstreams_endpoint` - (List) Property values for Event streams Endpoint.
+  Nested scheme for **eventstreams_endpoint**:
+    * `api_key` - (String) The IAM API key that has access to the Event streams instance.
+      * Constraints: The maximum length is `1000` characters. The minimum length is `3` characters. The value must match regular expression `/^[a-zA-Z0-9 -._:]+$/`.
+    * `topic` - (String) The topic name defined under the Event streams instance.
+      * Constraints: The maximum length is `1000` characters. The minimum length is `3` characters. The value must match regular expression `/^[a-zA-Z0-9 -._:\/]+$/`.
+    * `brokers` - (List) The list of brokers defined under the Event streams instance and used in the event streams endpoint.
+      * Constraints: The list items must match regular expression `/^[a-zA-Z0-9 -._:]+$/`.
+    * `target_crn` - (String) The CRN of the Event streams instance.
+      * Constraints: The maximum length is `1000` characters. The minimum length is `3` characters. The value must match regular expression `/^[a-zA-Z0-9 -._:\/]+$/`.
+  * `write_status` - (List) The status of the write attempt to the target with the provided endpoint parameters.
 	Nested scheme for **write_status**:
   	* `last_failure` - (String) The timestamp of the failure.
   	* `reason_for_last_failure` - (String) Detailed description of the cause of the failure.
@@ -70,4 +80,3 @@ Nested scheme for **targets**:
 		* `reason_for_last_failure` - (String) Detailed description of the cause of the failure.
 	* `created` - **DEPRECATED** (String) The timestamp of the target creation time.
 	* `updated` - **DEPRECATED** (String) The timestamp of the target last updated time.
-

--- a/website/docs/r/atracker_target.html.markdown
+++ b/website/docs/r/atracker_target.html.markdown
@@ -14,10 +14,10 @@ Provides a resource for Activity Tracker Target. This allows Activity Tracker Ta
 
 ```terraform
 resource "ibm_atracker_target" "atracker_target" {
-  cos_endpoint { 
-     endpoint = "endpoint" 
-     target_crn = "target_crn" 
-     bucket = "bucket" 
+  cos_endpoint {
+     endpoint = "endpoint"
+     target_crn = "target_crn"
+     bucket = "bucket"
      api_key = "api_key"
   }
   name = "my-cos-target"
@@ -35,6 +35,20 @@ resource "ibm_atracker_target" "atracker_logdna_target" {
   target_type = "logdna"
   region = "us-south"
 }
+
+resource "ibm_atracker_target" "atracker_eventstreams_target" {
+  target_type = "event_streams"
+  eventstreams_endpoint {
+    target_crn = "crn:v1:bluemix:public:logdna:us-south:a/11111111111111111111111111111111:22222222-2222-2222-2222-222222222222::"
+    "brokers": ["xxxxx.cloud.ibm.com:9093","yyyyy.cloud.ibm.com:9093"]
+    "topic": "my-topic"
+    "api_key": "api-key"
+  }
+  name = "my-eventstreams-target"
+  target_type = "event_streams"
+  region = "us-south"
+}
+
 ```
 
 ## Argument reference
@@ -58,12 +72,22 @@ Nested scheme for **logdna_endpoint**:
 	  * Constraints: The maximum length is `1000` characters. The minimum length is `3` characters. The value must match regular expression `/^[a-zA-Z0-9 -._:\/]+$/`.
 	* `target_crn` - (Required, String) The CRN of the LogDNA instance.
 	  * Constraints: The maximum length is `1000` characters. The minimum length is `3` characters. The value must match regular expression `/^[a-zA-Z0-9 -._:\/]+$/`.
+* `eventstreams_endpoint` - (List) Property values for Event streams Endpoint.
+Nested scheme for **eventstreams_endpoint**:
+  * `api_key` - (String) The IAM API key that has access to the Event streams instance.
+    * Constraints: The maximum length is `1000` characters. The minimum length is `3` characters. The value must match regular expression `/^[a-zA-Z0-9 -._:]+$/`.
+  * `topic` - (String) The topic name defined under the Event streams instance.
+    * Constraints: The maximum length is `1000` characters. The minimum length is `3` characters. The value must match regular expression `/^[a-zA-Z0-9 -._:\/]+$/`.
+  * `brokers` - (List) The list of brokers defined under the Event streams instance and used in the event streams endpoint.
+    * Constraints: The list items must match regular expression `/^[a-zA-Z0-9 -._:]+$/`.
+  * `target_crn` - (String) The CRN of the Event streams instance.
+    * Constraints: The maximum length is `1000` characters. The minimum length is `3` characters. The value must match regular expression `/^[a-zA-Z0-9 -._:\/]+$/`.
 * `name` - (Required, String) The name of the target. The name must be 1000 characters or less, and cannot include any special characters other than `(space) - . _ :`.
   * Constraints: The maximum length is `1000` characters. The minimum length is `1` character. The value must match regular expression `/^[a-zA-Z0-9 -._:]+$/`.
 * `region` - (Optional, String) Include this optional field if you want to create a target in a different region other than the one you are connected.
   * Constraints: The maximum length is `1000` characters. The minimum length is `3` characters. The value must match regular expression `/^[a-zA-Z0-9 -._:]+$/`.
-* `target_type` - (Required, Forces new resource, String) The type of the target. It can be cloud_object_storage or logdna. Based on this type you must include cos_endpoint or logdna_endpoint.
-  * Constraints: Allowable values are: `cloud_object_storage`, `logdna`.
+* `target_type` - (Required, Forces new resource, String) The type of the target. It can be cloud_object_storage, logdna or event_streams. Based on this type you must include cos_endpoint, logdna_endpoint or eventstreams_endpoint.
+  * Constraints: Allowable values are: `cloud_object_storage`, `logdna`, `event_streams`.
 
 ## Attribute reference
 


### PR DESCRIPTION
### What has been done?
* Added support for new target type (`event_streams`) to be able to send Atracker events to Event streams.

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Output from acceptance testing:
```
Veenas-MacBook-Pro:terraform-provider-ibm veenarao$ make fmt && make testacc TEST=./ibm/service/atracker TESTARGS='-run=TestAccIBMAtracker.*'
gofmt -w $(find .  -path ./.direnv -prune -false -o -name '*.go' |grep -v vendor)

==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./ibm/service/atracker -v -run=TestAccIBMAtracker.* -timeout 700m
[WARN] Set the environment variable IBM_APPID_TENANT_ID for testing AppID resources, AppID tests will fail if this is not set
[WARN] Set the environment variable IBM_APPID_TEST_USER_EMAIL for testing AppID user resources, the tests will fail if this is not set
[WARN] Set the environment variable IBM_ORG for testing ibm_org  resource Some tests for that resource will fail if this is not set correctly
[WARN] Set the environment variable IBM_SPACE for testing ibm_space  resource Some tests for that resource will fail if this is not set correctly
[WARN] Set the environment variable IBM_ID1 for testing ibm_space resource Some tests for that resource will fail if this is not set correctly
[WARN] Set the environment variable IBM_ID2 for testing ibm_space resource Some tests for that resource will fail if this is not set correctly
[WARN] Set the environment variable IBM_IAMUSER for testing ibm_iam_user_policy resource Some tests for that resource will fail if this is not set correctly
[WARN] Set the environment variable IBM_DATACENTER for testing ibm_container_cluster resource else it is set to default value 'par01'
[WARN] Set the environment variable IBM_MACHINE_TYPE for testing ibm_container_cluster resource else it is set to default value 'b3c.4x16'
[WARN] Set the environment variable IBM_CERT_CRN for testing ibm_container_alb_cert resource else it is set to default value
[WARN] Set the environment variable IBM_UPDATE_CERT_CRN for testing ibm_container_alb_cert resource else it is set to default value
[WARN] Set the environment variable IBM_CONTAINER_REGION for testing ibm_container resources else it is set to default value 'eu-de'
[WARN] Set the environment variable IBM_CIS_INSTANCE with a VALID CIS Instance NAME for testing ibm_cis resources on staging/test
[WARN] Set the environment variable IBM_CIS_DOMAIN_STATIC with the Domain name registered with the CIS instance on test/staging. Domain must be predefined in CIS to avoid CIS billing costs due to domain delete/create
[WARN] Set the environment variable IBM_CIS_DOMAIN_TEST with a VALID Domain name for testing the one time create and delete of a domain in CIS. Note each create/delete will trigger a monthly billing instance. Only to be run in staging/test
[WARN] Set the environment variable IBM_CIS_RESOURCE_GROUP with the resource group for the CIS Instance
[WARN] Set the environment variable IBM_COS_CRN with a VALID COS instance CRN for testing ibm_cos_* resources
[WARN] Set the environment variable IBM_TRUSTED_MACHINE_TYPE for testing ibm_container_cluster resource else it is set to default value 'mb1c.16x64'
[WARN] Set the environment variable IBM_BM_EXTENDED_HW_TESTING to true/false for testing ibm_compute_bare_metal resource else it is set to default value 'false'
[WARN] Set the environment variable IBM_PUBLIC_VLAN_ID for testing ibm_container_cluster resource else it is set to default value '2393319'
[WARN] Set the environment variable IBM_PRIVATE_VLAN_ID for testing ibm_container_cluster resource else it is set to default value '2393321'
[WARN] Set the environment variable IBM_KUBE_VERSION for testing ibm_container_cluster resource else it is set to default value '1.18.14'
[WARN] Set the environment variable IBM_KUBE_UPDATE_VERSION for testing ibm_container_cluster resource else it is set to default value '1.19.6'
[WARN] Set the environment variable IBM_PRIVATE_SUBNET_ID for testing ibm_container_cluster resource else it is set to default value '1636107'
[WARN] Set the environment variable IBM_PUBLIC_SUBNET_ID for testing ibm_container_cluster resource else it is set to default value '1165645'
[WARN] Set the environment variable IBM_SUBNET_ID for testing ibm_container_cluster resource else it is set to default value '1165645'
[INFO] Set the environment variable IBM_IPSEC_DATACENTER for testing ibm_ipsec_vpn resource else it is set to default value 'tok02'
[INFO] Set the environment variable IBM_IPSEC_CUSTOMER_SUBNET_ID for testing ibm_ipsec_vpn resource else it is set to default value '123456'
[INFO] Set the environment variable IBM_IPSEC_CUSTOMER_PEER_IP for testing ibm_ipsec_vpn resource else it is set to default value '192.168.0.1'
[WARN] Set the environment variable IBM_LBAAS_DATACENTER for testing ibm_lbaas resource else it is set to default value 'dal13'
[WARN] Set the environment variable IBM_LBAAS_SUBNETID for testing ibm_lbaas resource else it is set to default value '2144241'
[WARN] Set the environment variable IBM_LB_LISTENER_CERTIFICATE_INSTANCE for testing ibm_is_lb_listener resource for https redirect else it is set to default value 'crn:v1:staging:public:cloudcerts:us-south:a/2d1bace7b46e4815a81e52c6ffeba5cf:af925157-b125-4db2-b642-adacb8b9c7f5:certificate:c81627a1bf6f766379cc4b98fd2a44ed'
[WARN] Set the environment variable IBM_DEDICATED_HOSTNAME for testing ibm_compute_vm_instance resource else it is set to default value 'terraform-dedicatedhost'
[WARN] Set the environment variable IBM_DEDICATED_HOST_ID for testing ibm_compute_vm_instance resource else it is set to default value '30301'
[WARN] Set the environment variable IBM_WORKER_POOL_ZONE for testing ibm_container_worker_pool_zone_attachment resource else it is set to default value 'ams03'
[WARN] Set the environment variable IBM_WORKER_POOL_ZONE_PRIVATE_VLAN for testing ibm_container_worker_pool_zone_attachment resource else it is set to default value '2538975'
[WARN] Set the environment variable IBM_WORKER_POOL_ZONE_PUBLIC_VLAN for testing ibm_container_worker_pool_zone_attachment resource else it is set to default value '2538967'
[WARN] Set the environment variable IBM_WORKER_POOL_ZONE_UPDATE_PRIVATE_VLAN for testing ibm_container_worker_pool_zone_attachment resource else it is set to default value '2388377'
[WARN] Set the environment variable IBM_WORKER_POOL_ZONE_UPDATE_PUBLIC_VLAN for testing ibm_container_worker_pool_zone_attachment resource else it is set to default value '2388375'
[WARN] Set the environment variable IBM_PLACEMENT_GROUP_NAME for testing ibm_compute_vm_instance resource else it is set to default value 'terraform-group'
[INFO] Set the environment variable SL_REGION for testing ibm_is_region datasource else it is set to default value 'us-south'
[INFO] Set the environment variable SL_ZONE for testing ibm_is_zone datasource else it is set to default value 'us-south-1'
[INFO] Set the environment variable SL_ZONE_2 for testing ibm_is_zone datasource else it is set to default value 'us-south-2'
[INFO] Set the environment variable SL_CIDR for testing ibm_is_subnet else it is set to default value '10.240.0.0/24'
[INFO] Set the environment variable SL_CIDR_2 for testing ibm_is_subnet else it is set to default value '10.240.64.0/24'
[INFO] Set the environment variable SL_ADDRESS_PREFIX_CIDR for testing ibm_is_vpc_address_prefix else it is set to default value '10.120.0.0/24'
[INFO] Set the environment variable IS_IMAGE for testing ibm_is_instance, ibm_is_floating_ip else it is set to default value 'r006-ed3f775f-ad7e-4e37-ae62-7199b4988b00'
[INFO] Set the environment variable IS_WIN_IMAGE for testing ibm_is_instance data source else it is set to default value 'r006-5f9568ae-792e-47e1-a710-5538b2bdfca7'
[INFO] Set the environment variable IS_INSTANCE_NAME for testing ibm_is_instance resource else it is set to default value 'instance-01'
[INFO] Set the environment variable SL_INSTANCE_PROFILE for testing ibm_is_instance resource else it is set to default value 'cx2-2x4'
[INFO] Set the environment variable SL_INSTANCE_PROFILE_UPDATE for testing ibm_is_instance resource else it is set to default value 'cx2-4x8'
[INFO] Set the environment variable IS_BARE_METAL_SERVER_PROFILE for testing ibm_is_bare_metal_server resource else it is set to default value 'bx2-metal-192x768'
[INFO] Set the environment variable IsBareMetalServerImage for testing ibm_is_bare_metal_server resource else it is set to default value 'r006-2d1f36b0-df65-4570-82eb-df7ae5f778b1'
[INFO] Set the environment variable IS_DEDICATED_HOST_NAME for testing ibm_is_instance resource else it is set to default value 'tf-dhost-01'
[INFO] Set the environment variable IS_DEDICATED_HOST_GROUP_ID for testing ibm_is_instance resource else it is set to default value '0717-9104e7b5-77ad-44ad-9eaa-091e6b6efce1'
[INFO] Set the environment variable IS_DEDICATED_HOST_PROFILE for testing ibm_is_instance resource else it is set to default value 'bx2d-host-152x608'
[INFO] Set the environment variable IS_DEDICATED_HOST_GROUP_CLASS for testing ibm_is_instance resource else it is set to default value 'bx2d'
[INFO] Set the environment variable IS_DEDICATED_HOST_GROUP_FAMILY for testing ibm_is_instance resource else it is set to default value 'balanced'
[INFO] Set the environment variable SL_INSTANCE_PROFILE for testing ibm_is_instance resource else it is set to default value 'bx2d-16x64'
[INFO] Set the environment variable IS_VOLUME_PROFILE for testing ibm_is_volume_profile else it is set to default value 'general-purpose'
[INFO] Set the environment variable SL_ROUTE_DESTINATION for testing ibm_is_vpc_route else it is set to default value '192.168.4.0/24'
[INFO] Set the environment variable SL_ROUTE_NEXTHOP for testing ibm_is_vpc_route else it is set to default value '10.0.0.4'
[INFO] Set the environment variable ICD_DB_REGION for testing ibm_cloud_databases else it is set to default value 'eu-gb'
[INFO] Set the environment variable ICD_DB_DEPLOYMENT_ID for testing ibm_cloud_databases else it is set to default value 'crn:v1:bluemix:public:databases-for-redis:au-syd:a/40ddc34a953a8c02f10987b59085b60e:5042afe1-72c2-4231-89cc-c949e5d56251::'
[INFO] Set the environment variable ICD_DB_BACKUP_ID for testing ibm_cloud_databases else it is set to default value 'crn:v1:bluemix:public:databases-for-redis:au-syd:a/40ddc34a953a8c02f10987b59085b60e:5042afe1-72c2-4231-89cc-c949e5d56251:backup:0d862fdb-4faa-42e5-aecb-5057f4d399c3'
[INFO] Set the environment variable ICD_DB_TASK_ID for testing ibm_cloud_databases else it is set to default value 'crn:v1:bluemix:public:databases-for-redis:au-syd:a/40ddc34a953a8c02f10987b59085b60e:367b0a22-05bb-41e3-a1ed-ded1ff0889e5:task:882013a6-2751-4df7-a77a-98d258638704'
[INFO] Set the environment variable PI_IMAGE for testing ibm_pi_image resource else it is set to default value '7200-03-03'
[INFO] Set the environment variable PI_SAP_IMAGE for testing ibm_pi_image resource else it is set to default value 'Linux-RHEL-SAP-8-2'
[INFO] Set the environment variable PI_IMAGE_BUCKET_NAME for testing ibm_pi_image resource else it is set to default value 'images-public-bucket'
[INFO] Set the environment variable PI_IMAGE_BUCKET_FILE_NAME for testing ibm_pi_image resource else it is set to default value 'rhel.ova.gz'
[INFO] Set the environment variable PI_IMAGE_BUCKET_ACCESS_KEY for testing ibm_pi_image_export resource else it is set to default value 'images-bucket-access-key'
[INFO] Set the environment variable PI_IMAGE_BUCKET_SECRET_KEY for testing ibm_pi_image_export resource else it is set to default value 'PI_IMAGE_BUCKET_SECRET_KEY'
[INFO] Set the environment variable PI_IMAGE_BUCKET_REGION for testing ibm_pi_image_export resource else it is set to default value 'us-east'
[INFO] Set the environment variable PI_KEY_NAME for testing ibm_pi_key_name resource else it is set to default value 'terraform-test-power'
[INFO] Set the environment variable PI_NETWORK_NAME for testing ibm_pi_network_name resource else it is set to default value 'terraform-test-power'
[INFO] Set the environment variable PI_VOLUME_NAME for testing ibm_pi_network_name resource else it is set to default value 'terraform-test-power'
[INFO] Set the environment variable PI_CLOUDINSTANCE_ID for testing ibm_pi_image resource else it is set to default value 'd16705bd-7f1a-48c9-9e0e-1c17b71e7331'
[INFO] Set the environment variable PI_PVM_INSTANCE_ID for testing Pi_instance_name resource else it is set to default value 'terraform-test-power'
[INFO] Set the environment variable PI_DHCP_ID for testing ibm_pi_dhcp resource else it is set to default value 'terraform-test-power'
[INFO] Set the environment variable PI_CLOUD_CONNECTION_NAME for testing ibm_pi_cloud_connection resource else it is set to default value 'terraform-test-power'
[INFO] Set the environment variable PI_SAP_PROFILE_ID for testing ibm_pi_sap_profile resource else it is set to default value 'terraform-test-power'
[WARN] Set the environment variable PI_PLACEMENT_GROUP_NAME for testing ibm_pi_placement_group resource else it is set to default value 'tf-pi-placement-group'
[WARN] Set the environment variable PI_SPP_PLACEMENT_GROUP_ID for testing ibm_pi_spp_placement_group resource else it is set to default value 'tf-pi-spp-placement-group'
[INFO] Set the environment variable PI_STORAGE_POOL for testing ibm_pi_storage_pool_capacity else it is set to default value 'terraform-test-power'
[INFO] Set the environment variable PI_STORAGE_TYPE for testing ibm_pi_storage_type_capacity else it is set to default value 'terraform-test-power'
[INFO] Set the environment variable PI_CAPTURE_STORAGE_IMAGE_PATH for testing Pi_capture_storage_image_path resource else it is set to default value 'terraform-test-power'
[INFO] Set the environment variable PI_CAPTURE_CLOUD_STORAGE_ACCESS_KEY for testing Pi_capture_cloud_storage_access_key resource else it is set to default value 'terraform-test-power'
[INFO] Set the environment variable PI_CAPTURE_CLOUD_STORAGE_SECRET_KEY for testing Pi_capture_cloud_storage_secret_key resource else it is set to default value 'terraform-test-power'
[WARN] Set the environment variable PI_SHARED_PROCESSOR_POOL_ID for testing ibm_pi_shared_processor_pool resource else it is set to default value 'tf-pi-shared-processor-pool'
[INFO] Set the environment variable SCHEMATICS_WORKSPACE_ID for testing schematics resources else it is set to default value
[INFO] Set the environment variable SCHEMATICS_TEMPLATE_ID for testing schematics resources else it is set to default value
[INFO] Set the environment variable SCHEMATICS_ACTION_ID for testing schematics resources else it is set to default value
[INFO] Set the environment variable SCHEMATICS_JOB_ID for testing schematics resources else it is set to default value
[INFO] Set the environment variable SCHEMATICS_REPO_URL for testing schematics resources else tests will fail if this is not set correctly
[INFO] Set the environment variable SCHEMATICS_REPO_BRANCH for testing schematics resources else tests will fail if this is not set correctly
[WARN] Set the environment variable IMAGE_COS_URL with a VALID COS Image SQL URL for testing ibm_is_image resources on staging/test
[WARN] Set the environment variable IMAGE_COS_URL_ENCRYPTED with a VALID COS Image SQL URL for testing ibm_is_image resources on staging/test
[WARN] Set the environment variable IMAGE_OPERATING_SYSTEM with a VALID Operating system for testing ibm_is_image resources on staging/test
[INFO] Set the environment variable IS_IMAGE_NAME for testing data source ibm_is_image else it is set to default value `ibm-ubuntu-18-04-1-minimal-amd64-2`
[INFO] Set the environment variable IS_IMAGE_ENCRYPTED_DATA_KEY for testing resource ibm_is_image else it is set to default value
[INFO] Set the environment variable IS_IMAGE_ENCRYPTION_KEY for testing resource ibm_is_image else it is set to default value
[INFO] Set the environment variable IBM_FUNCTION_NAMESPACE for testing ibm_function_package, ibm_function_action, ibm_function_rule, ibm_function_trigger resource else  tests will fail if this is not set correctly
[INFO] Set the environment variable HPCS_INSTANCE_ID for testing data_source_ibm_kms_key_test else it is set to default value
[INFO] Set the environment variable SECRETS_MANAGER_INSTANCE_ID for testing data_source_ibm_secrets_manager_secrets_test else tests will fail if this is not set correctly
[INFO] Set the environment variable SECRETS_MANAGER_SECRET_TYPE for testing data_source_ibm_secrets_manager_secrets_test, else it is set to default value. For data_source_ibm_secrets_manager_secret_test, tests will fail if this is not set correctly
[WARN] Set the environment variable SECRETS_MANAGER_SECRET_ID for testing data_source_ibm_secrets_manager_secret_test else tests will fail if this is not set correctly
[INFO] Set the environment variable IBM_TG_CROSS_ACCOUNT_ID for testing ibm_tg_connection resource else  tests will fail if this is not set correctly
[INFO] Set the environment variable IBM_TG_CROSS_NETWORK_ID for testing ibm_tg_connection resource else  tests will fail if this is not set correctly
[INFO] Set the environment variable ACCOUNT_TO_BE_IMPORTED for testing import enterprise account resource else  tests will fail if this is not set correctly
[WARN] Set the environment variable IBM_HPCS_ADMIN1 with a VALID HPCS Admin Key1 Path
[WARN] Set the environment variable IBM_HPCS_TOKEN1 with a VALID token for HPCS Admin Key1
[WARN] Set the environment variable IBM_HPCS_ADMIN2 with a VALID HPCS Admin Key2 Path
[WARN] Set the environment variable IBM_IAM_REALM_NAME with a VALID realm name for iam trusted profile claim rule
[WARN] Set the environment variable IBM_IAM_IKS_SA with a VALID realm name for iam trusted profile link
[WARN] Set the environment variable IBM_HPCS_TOKEN2 with a VALID token for HPCS Admin Key2
[WARN] Set the environment variable IBM_HPCS_ROOTKEY_CRN with a VALID CRN for a root key created in the HPCS instance
[WARN] Set the environment variable SCC_GOVERNANCE_ACCOUNT_ID with a VALID account name
[WARN] Set the environment variable IBM_SCC_RESOURCE_GROUP with a VALID resource group id
[INFO] Set the environment variable SCC_SI_ACCOUNT for testing SCC SI resources resource else  tests will fail if this is not set correctly
[INFO] Set the environment variable SCC_POSTURE_SCOPE_ID for testing SCC Posture resources or datasource resource else  tests will fail if this is not set correctly
[INFO] Set the environment variable SCC_POSTURE_SCAN_ID for testing SCC Posture resource or datasource else  tests will fail if this is not set correctly
[INFO] Set the environment variable SCC_POSTURE_PROFILE_ID for testing SCC Posture resource or datasource else  tests will fail if this is not set correctly
[INFO] Set the environment variable SCC_POSTURE_GROUP_PROFILE_ID for testing SCC Posture resource or datasource else  tests will fail if this is not set correctly
[INFO] Set the environment variable SCC_POSTURE_CORRELATION_ID for testing SCC Posture resource or datasource else  tests will fail if this is not set correctly
[INFO] Set the environment variable SCC_POSTURE_REPORT_SETTING_ID for testing SCC Posture resource or datasource else  tests will fail if this is not set correctly
[INFO] Set the environment variable SCC_POSTURE_PROFILE_ID_SCANSUMMARY for testing SCC Posture resource or datasource else  tests will fail if this is not set correctly
[INFO] Set the environment variable SCC_POSTURE_SCAN_ID_SCANSUMMARY for testing SCC Posture resource or datasource else  tests will fail if this is not set correctly
[INFO] Set the environment variable SCC_POSTURE_CREDENTIAL_ID_SCOPE for testing SCC Posture resource or datasource else  tests will fail if this is not set correctly
[INFO] Set the environment variable SCC_POSTURE_CREDENTIAL_ID_SCOPE_UPDATE for testing SCC Posture resource or datasource else  tests will fail if this is not set correctly
[INFO] Set the environment variable SCC_POSTURE_COLLECTOR_ID_SCOPE for testing SCC Posture resource or datasource else  tests will fail if this is not set correctly
[INFO] Set the environment variable SCC_POSTURE_COLLECTOR_ID_SCOPE_UPDATE for testing SCC Posture resource or datasource else  tests will fail if this is not set correctly
[INFO] Set the environment variable SCC_POSTURE_COLLECTOR_ID for testing SCC Posture resources or datasource resource else  tests will fail if this is not set correctly
[INFO] Set the environment variable SCC_POSTURE_CREDENTIAL_ID for testing SCC Posture resources or datasource resource else  tests will fail if this is not set correctly
[INFO] Set the environment variable IBM_CLOUD_SHELL_ACCOUNT_ID for ibm-cloud-shell resource or datasource else tests will fail if this is not set correctly
[WARN] Set the environment variable IBM_CLUSTER_VPC_ID for testing ibm_container_vpc_alb_create resources, ibm_container_vpc_alb_create tests will fail if this is not set
[WARN] Set the environment variable IBM_CLUSTER_VPC_SUBNET_ID for testing ibm_container_vpc_alb_create resources, ibm_container_vpc_alb_creates tests will fail if this is not set
[WARN] Set the environment variable IBM_CLUSTER_VPC_RESOURCE_GROUP_ID for testing ibm_container_vpc_alb_create resources, ibm_container_vpc_alb_creates tests will fail if this is not set
[INFO] Set the environment variable IBM_CONTAINER_CLUSTER_NAME for ibm_container_nlb_dns resource or datasource else tests will fail if this is not set correctly
[INFO] Set the environment variable SATELLITE_LOCATION_ID for ibm_cos_bucket satellite location resource or datasource else tests will fail if this is not set correctly
[INFO] Set the environment variable SATELLITE_RESOURCE_INSTANCE_ID for ibm_cos_bucket satellite location resource or datasource else tests will fail if this is not set correctly
[INFO] Set the environment variable IBM_CONTAINER_DEDICATEDHOST_POOL_ID for ibm_container_vpc_cluster resource to test dedicated host functionality
[INFO] Set the environment variable IBM_KMS_INSTANCE_ID for ibm_container_vpc_cluster resource or datasource else tests will fail if this is not set correctly
[INFO] Set the environment variable IBM_CRK_ID for ibm_container_vpc_cluster resource or datasource else tests will fail if this is not set correctly
[INFO] Set the environment variable IBM_CLUSTER_ID for ibm_container_vpc_worker_pool resource or datasource else tests will fail if this is not set correctly
[WARN] Set the environment variable IBM_CD_RESOURCE_GROUP_ID for testing CD resources, CD tests will fail if this is not set
[INFO] Set the environment variable IS_CERTIFICATE_CRN for testing ibm_is_vpn_server resource
[INFO] Set the environment variable IS_CLIENT_CA_CRN for testing ibm_is_vpn_server resource
[INFO] Set the environment variable IBM_AccountID_REPL for setting up authorization policy to enable replication feature resource or datasource else tests will fail if this is not set correctly
=== RUN   TestAccIBMAtrackerEndpointsDataSourceBasic
--- PASS: TestAccIBMAtrackerEndpointsDataSourceBasic (10.18s)
=== RUN   TestAccIBMAtrackerRoutesDataSourceBasic
--- PASS: TestAccIBMAtrackerRoutesDataSourceBasic (12.06s)
=== RUN   TestAccIBMAtrackerTargetsDataSourceBasic
--- PASS: TestAccIBMAtrackerTargetsDataSourceBasic (11.68s)
=== RUN   TestAccIBMAtrackerTargetsDataSourceAllArgs
--- PASS: TestAccIBMAtrackerTargetsDataSourceAllArgs (11.62s)
=== RUN   TestAccIBMAtrackerRouteBasic
--- PASS: TestAccIBMAtrackerRouteBasic (22.40s)
=== RUN   TestAccIBMAtrackerSettingsBasic
--- PASS: TestAccIBMAtrackerSettingsBasic (18.67s)
=== RUN   TestAccIBMAtrackerTargetBasic
--- PASS: TestAccIBMAtrackerTargetBasic (20.96s)
PASS
ok  	github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/atracker	108.912s
```

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```
