### PR TITLE
Fix endpoint URL

### DIFF
--- a/ibm/service/kms/resource_ibm_kms_key.go
+++ b/ibm/service/kms/resource_ibm_kms_key.go
@@ -409,6 +409,9 @@ func KmsEndpointURL(kpAPI *kp.Client, endpointType string, extensions map[string
 	endpointURL := fmt.Sprintf("%s/api/v2/keys", exturl.(string))
 
 	url1 := conns.EnvFallBack([]string{"IBMCLOUD_KP_API_ENDPOINT"}, endpointURL)
+	if !strings.HasSuffix(url1, "/api/v2/keys") {
+		url1 = url1 + "/api/v2/keys"
+	}
 	u, err := url.Parse(url1)
 	if err != nil {
 		return nil, fmt.Errorf("[ERROR] Error Parsing KMS EndpointURL")


### PR DESCRIPTION
Description: This fix would allow users to provide endpoint url without "/api/v2/keys" without breaking backward compatibility.
Signed-off-by: Siddharth Mishra <siddharth.mishra2@ibm.com>

<!--- See what makes a good Pull Request at : https://github.com/IBM-Cloud/terraform-provider-ibm/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```
