### PR TITLE
fix(bm-nic): added check for 0.0.0.0 reserved ip on nic availability

### DIFF
--- a/ibm/service/vpc/data_source_ibm_is_bare_metal_server_network_interface.go
+++ b/ibm/service/vpc/data_source_ibm_is_bare_metal_server_network_interface.go
@@ -18,6 +18,7 @@ import (
 const (
 	isBareMetalServerNicEnableInfraNAT        = "enable_infrastructure_nat"
 	isBareMetalServerNicFloatingIPs           = "floating_ips"
+	isBareMetalServerNicFloatingIPId          = "id"
 	isBareMetalServerNicIpAddress             = "address"
 	isBareMetalServerNicIpCRN                 = "crn"
 	isBareMetalServerNicIpHref                = "href"
@@ -91,8 +92,15 @@ func DataSourceIBMIsBareMetalServerNetworkInterface() *schema.Resource {
 						isBareMetalServerNicIpID: {
 							Type:        schema.TypeString,
 							Computed:    true,
+							Deprecated:  "This field is deprecated - replaced by id",
 							Description: "The unique identifier for this floating IP",
 						},
+						isBareMetalServerNicFloatingIPId: {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "The unique identifier for this floating IP",
+						},
+
 						isBareMetalServerNicIpName: {
 							Type:        schema.TypeString,
 							Computed:    true,
@@ -243,8 +251,9 @@ func dataSourceIBMISBareMetalServerNetworkInterfaceRead(context context.Context,
 			if nic.FloatingIps != nil {
 				for _, ip := range nic.FloatingIps {
 					currentIP := map[string]interface{}{
-						isBareMetalServerNicIpID:      *ip.ID,
-						isBareMetalServerNicIpAddress: *ip.Address,
+						isBareMetalServerNicIpID:         *ip.ID,
+						isBareMetalServerNicFloatingIPId: *ip.ID,
+						isBareMetalServerNicIpAddress:    *ip.Address,
 					}
 					floatingIPList = append(floatingIPList, currentIP)
 				}
@@ -316,8 +325,9 @@ func dataSourceIBMISBareMetalServerNetworkInterfaceRead(context context.Context,
 			if nic.FloatingIps != nil {
 				for _, ip := range nic.FloatingIps {
 					currentIP := map[string]interface{}{
-						isBareMetalServerNicIpID:      *ip.ID,
-						isBareMetalServerNicIpAddress: *ip.Address,
+						isBareMetalServerNicIpID:         *ip.ID,
+						isBareMetalServerNicFloatingIPId: *ip.ID,
+						isBareMetalServerNicIpAddress:    *ip.Address,
 					}
 					floatingIPList = append(floatingIPList, currentIP)
 				}

--- a/ibm/service/vpc/data_source_ibm_is_bare_metal_server_network_interfaces.go
+++ b/ibm/service/vpc/data_source_ibm_is_bare_metal_server_network_interfaces.go
@@ -69,6 +69,12 @@ func DataSourceIBMIsBareMetalServerNetworkInterfaces() *schema.Resource {
 									isBareMetalServerNicIpID: {
 										Type:        schema.TypeString,
 										Computed:    true,
+										Deprecated:  "This field is deprecated - replaced by id",
+										Description: "The unique identifier for this floating IP",
+									},
+									isBareMetalServerNicFloatingIPId: {
+										Type:        schema.TypeString,
+										Computed:    true,
 										Description: "The unique identifier for this floating IP",
 									},
 									isBareMetalServerNicIpName: {
@@ -231,8 +237,9 @@ func dataSourceIBMISBareMetalServerNetworkInterfacesRead(context context.Context
 					floatingIPList := make([]map[string]interface{}, 0)
 					for _, ip := range nic.FloatingIps {
 						currentIP := map[string]interface{}{
-							isBareMetalServerNicIpID:      *ip.ID,
-							isBareMetalServerNicIpAddress: *ip.Address,
+							isBareMetalServerNicIpID:         *ip.ID,
+							isBareMetalServerNicFloatingIPId: *ip.ID,
+							isBareMetalServerNicIpAddress:    *ip.Address,
 						}
 						floatingIPList = append(floatingIPList, currentIP)
 					}
@@ -297,8 +304,9 @@ func dataSourceIBMISBareMetalServerNetworkInterfacesRead(context context.Context
 					floatingIPList := make([]map[string]interface{}, 0)
 					for _, ip := range nic.FloatingIps {
 						currentIP := map[string]interface{}{
-							isBareMetalServerNicIpID:      *ip.ID,
-							isBareMetalServerNicIpAddress: *ip.Address,
+							isBareMetalServerNicIpID:         *ip.ID,
+							isBareMetalServerNicFloatingIPId: *ip.ID,
+							isBareMetalServerNicIpAddress:    *ip.Address,
 						}
 						floatingIPList = append(floatingIPList, currentIP)
 					}

--- a/ibm/service/vpc/resource_ibm_is_bare_metal_server_network_interface.go
+++ b/ibm/service/vpc/resource_ibm_is_bare_metal_server_network_interface.go
@@ -85,6 +85,11 @@ func ResourceIBMIsBareMetalServerNetworkInterface() *schema.Resource {
 							Computed:    true,
 							Description: "The globally unique IP address",
 						},
+						isBareMetalServerNicFloatingIPId: {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "The globally unique IP identifier",
+						},
 					},
 				},
 			},
@@ -602,8 +607,8 @@ func bareMetalServerNICGet(d *schema.ResourceData, meta interface{}, sess *vpcv1
 			if nic.FloatingIps != nil {
 				for _, ip := range nic.FloatingIps {
 					currentIP := map[string]interface{}{
-						isBareMetalServerNicIpID:      *ip.ID,
-						isBareMetalServerNicIpAddress: *ip.Address,
+						isBareMetalServerNicFloatingIPId: *ip.ID,
+						isBareMetalServerNicIpAddress:    *ip.Address,
 					}
 					floatingIPList = append(floatingIPList, currentIP)
 				}
@@ -680,8 +685,8 @@ func bareMetalServerNICGet(d *schema.ResourceData, meta interface{}, sess *vpcv1
 			if nic.FloatingIps != nil {
 				for _, ip := range nic.FloatingIps {
 					currentIP := map[string]interface{}{
-						isBareMetalServerNicIpID:      *ip.ID,
-						isBareMetalServerNicIpAddress: *ip.Address,
+						isBareMetalServerNicFloatingIPId: *ip.ID,
+						isBareMetalServerNicIpAddress:    *ip.Address,
 					}
 					floatingIPList = append(floatingIPList, currentIP)
 				}

--- a/ibm/service/vpc/resource_ibm_is_bare_metal_server_network_interface_allow_float.go
+++ b/ibm/service/vpc/resource_ibm_is_bare_metal_server_network_interface_allow_float.go
@@ -324,12 +324,12 @@ func createVlanTypeNetworkInterfaceAllowFloat(context context.Context, d *schema
 	}
 
 	log.Printf("[INFO] Bare Metal Server Network Interface : %s", d.Id())
-	_, err = isWaitForBareMetalServerNetworkInterfaceAvailable(sess, bareMetalServerId, nicId, d.Timeout(schema.TimeoutCreate), d)
+	nicAfterWait, err := isWaitForBareMetalServerNetworkInterfaceAvailable(sess, bareMetalServerId, nicId, d.Timeout(schema.TimeoutCreate), d)
 	if err != nil {
 		return err
 	}
 
-	err = bareMetalServerNICAllowFloatGet(d, meta, sess, nic, bareMetalServerId)
+	err = bareMetalServerNICAllowFloatGet(d, meta, sess, nicAfterWait, bareMetalServerId)
 	if err != nil {
 		return err
 	}

--- a/ibm/service/vpc/resource_ibm_is_bare_metal_server_network_interface_allow_float.go
+++ b/ibm/service/vpc/resource_ibm_is_bare_metal_server_network_interface_allow_float.go
@@ -77,6 +77,11 @@ func ResourceIBMIsBareMetalServerNetworkInterfaceAllowFloat() *schema.Resource {
 							Computed:    true,
 							Description: "The globally unique IP address",
 						},
+						isBareMetalServerNicFloatingIPId: {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "The globally unique IP identifier",
+						},
 					},
 				},
 			},
@@ -429,8 +434,8 @@ func bareMetalServerNICAllowFloatGet(d *schema.ResourceData, meta interface{}, s
 			if nic.FloatingIps != nil {
 				for _, ip := range nic.FloatingIps {
 					currentIP := map[string]interface{}{
-						isBareMetalServerNicIpID:      *ip.ID,
-						isBareMetalServerNicIpAddress: *ip.Address,
+						isBareMetalServerNicFloatingIPId: *ip.ID,
+						isBareMetalServerNicIpAddress:    *ip.Address,
 					}
 					floatingIPList = append(floatingIPList, currentIP)
 				}
@@ -502,8 +507,8 @@ func bareMetalServerNICAllowFloatGet(d *schema.ResourceData, meta interface{}, s
 			if nic.FloatingIps != nil {
 				for _, ip := range nic.FloatingIps {
 					currentIP := map[string]interface{}{
-						isBareMetalServerNicIpID:      *ip.ID,
-						isBareMetalServerNicIpAddress: *ip.Address,
+						isBareMetalServerNicFloatingIPId: *ip.ID,
+						isBareMetalServerNicIpAddress:    *ip.Address,
 					}
 					floatingIPList = append(floatingIPList, currentIP)
 				}

--- a/ibm/service/vpc/resource_ibm_is_bare_metal_server_network_interface_allow_float_test.go
+++ b/ibm/service/vpc/resource_ibm_is_bare_metal_server_network_interface_allow_float_test.go
@@ -60,7 +60,7 @@ ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCKVmnMOlHKcZK8tpt3MP1lqOLAcqcJzhsvJcjscgVE
 						return nil
 					}),
 					resource.TestCheckResourceAttrSet(
-						"ibm_is_bare_metal_server.testacc_bms", "floating_bare_metal_server"),
+						"ibm_is_bare_metal_server_network_interface_allow_float.bms_nic", "floating_bare_metal_server"),
 					resource.TestCheckResourceAttrWith("ibm_is_bare_metal_server_network_interface_allow_float.bms_nic", "floating_bare_metal_server", func(v string) error {
 						if v == "" {
 							return fmt.Errorf("Attribute 'floating_bare_metal_server' %s is not populated", v)
@@ -108,7 +108,7 @@ ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCKVmnMOlHKcZK8tpt3MP1lqOLAcqcJzhsvJcjscgVE
 						return nil
 					}),
 					resource.TestCheckResourceAttrSet(
-						"ibm_is_bare_metal_server.testacc_bms", "floating_bare_metal_server"),
+						"ibm_is_bare_metal_server_network_interface_allow_float.bms_nic", "floating_bare_metal_server"),
 					resource.TestCheckResourceAttrWith("ibm_is_bare_metal_server_network_interface_allow_float.bms_nic", "floating_bare_metal_server", func(v string) error {
 						if v == "" {
 							return fmt.Errorf("Attribute 'floating_bare_metal_server' %s is not populated", v)


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/IBM-Cloud/terraform-provider-ibm/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
=== RUN   TestAccIBMISBareMetalServerNetworkInterfaceAllowFloat_rip_basic
--- PASS: TestAccIBMISBareMetalServerNetworkInterfaceAllowFloat_rip_basic (59.70s)
PASS
ok      github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/vpc     62.540s
```
```
=== RUN   TestAccIBMISBareMetalServerNetworkInterfaceAllowFloat_basic
--- PASS: TestAccIBMISBareMetalServerNetworkInterfaceAllowFloat_basic (44.58s)
PASS
ok      github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/vpc     46.873s
```
