### PR TITLE
Access Tags for Volumes

### DIFF
--- a/ibm/flex/structures.go
+++ b/ibm/flex/structures.go
@@ -2327,6 +2327,42 @@ func ResourceTagsCustomizeDiff(diff *schema.ResourceDiff) error {
 	return nil
 }
 
+func ResourceValidateAccessTags(diff *schema.ResourceDiff, meta interface{}) error {
+
+	if value, ok := diff.GetOkExists("access_tags"); ok {
+		tagSet := value.(*schema.Set)
+		newTagList := tagSet.List()
+		tagType := "access"
+		gtClient, err := meta.(conns.ClientSession).GlobalTaggingAPIv1()
+		if err != nil {
+			return fmt.Errorf("Error getting global tagging client settings: %s", err)
+		}
+
+		listTagsOptions := &globaltaggingv1.ListTagsOptions{
+			TagType: &tagType,
+		}
+		taggingResult, _, err := gtClient.ListTags(listTagsOptions)
+		if err != nil {
+			return err
+		}
+		var taglist []string
+		for _, item := range taggingResult.Items {
+			taglist = append(taglist, *item.Name)
+		}
+		existingAccessTags := NewStringSet(ResourceIBMVPCHash, taglist)
+		errStatement := ""
+		for _, tag := range newTagList {
+			if !existingAccessTags.Contains(tag) {
+				errStatement = errStatement + " " + tag.(string)
+			}
+		}
+		if errStatement != "" {
+			return fmt.Errorf("[ERROR] Error : Access tag(s) %s does not exist", errStatement)
+		}
+	}
+	return nil
+}
+
 func ResourceLBListenerPolicyCustomizeDiff(diff *schema.ResourceDiff) error {
 	policyActionIntf, _ := diff.GetOk(isLBListenerPolicyAction)
 	policyAction := policyActionIntf.(string)

--- a/ibm/service/vpc/data_source_ibm_is_volume.go
+++ b/ibm/service/vpc/data_source_ibm_is_volume.go
@@ -5,6 +5,7 @@ package vpc
 
 import (
 	"fmt"
+	"log"
 
 	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/flex"
 	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/validate"
@@ -118,6 +119,14 @@ func DataSourceIBMISVolume() *schema.Resource {
 				Elem:        &schema.Schema{Type: schema.TypeString},
 				Set:         flex.ResourceIBMVPCHash,
 				Description: "Tags for the volume instance",
+			},
+
+			isVolumeAccessTags: {
+				Type:        schema.TypeSet,
+				Computed:    true,
+				Elem:        &schema.Schema{Type: schema.TypeString},
+				Set:         flex.ResourceIBMVPCHash,
+				Description: "Access management tags for the volume instance",
 			},
 
 			isVolumeSourceSnapshot: {
@@ -242,6 +251,12 @@ func volumeGet(d *schema.ResourceData, meta interface{}, name string) error {
 			d.Set(isVolumeStatusReasons, statusReasonsList)
 		}
 		d.Set(isVolumeTags, vol.UserTags)
+		accesstags, err := flex.GetGlobalTagsUsingCRN(meta, *vol.CRN, "", isVolumeAccessTagType)
+		if err != nil {
+			log.Printf(
+				"Error on get of resource vpc volume (%s) access tags: %s", d.Id(), err)
+		}
+		d.Set(isVolumeAccessTags, accesstags)
 		controller, err := flex.GetBaseController(meta)
 		if err != nil {
 			return err

--- a/website/docs/d/is_volume.html.markdown
+++ b/website/docs/d/is_volume.html.markdown
@@ -43,6 +43,7 @@ Review the argument references that you can specify for your data source.
 ## Attribute reference
 In addition to all argument reference list, you can access the following attribute references after your data source is created.
 
+- `access_tags`  - (List) Access management tags associated for the volume.
 - `bandwidth` - The maximum bandwidth (in megabits per second) for the volume
 - `capacity` - (String) The capacity of the volume in gigabytes.
 - `crn` - (String) The crn of this volume.

--- a/website/docs/d/is_volumes.html.markdown
+++ b/website/docs/d/is_volumes.html.markdown
@@ -25,6 +25,7 @@ In addition to all argument references listed, you can access the following attr
 - `id` - The unique identifier of the VolumeCollection.
 - `volumes` - (List) Collection of volumes.
 	Nested scheme for **volumes**:
+	- `access_tags`  - (List) Access management tags associated for the volume.
 	- `active` - (Boolean) Indicates whether a running virtual server instance has an attachment to this volume.
 	- `bandwidth` - (Integer) The maximum bandwidth (in megabits per second) for the volume.
 	- `busy` - (Boolean) Indicates whether this volume is performing an operation that must be serialized. If an operation specifies that it requires serialization, the operation will fail unless this property is `false`.

--- a/website/docs/r/is_volume.html.markdown
+++ b/website/docs/r/is_volume.html.markdown
@@ -55,6 +55,13 @@ The `ibm_is_volume` resource provides the following [Timeouts](https://www.terra
 ## Argument reference
 Review the argument references that you can specify for your resource. 
 
+- `access_tags`  - (Optional, List of Strings) A list of access management tags to attach to the bare metal server.
+
+  ~> **Note:** 
+  **&#x2022;** You can attach only those access tags that already exists.</br>
+  **&#x2022;** For more information, about creating access tags, see [working with tags](https://cloud.ibm.com/docs/account?topic=account-tag&interface=ui#create-access-console).</br>
+  **&#x2022;** You must have the access listed in the [Granting users access to tag resources](https://cloud.ibm.com/docs/account?topic=account-access) for `access_tags`</br>
+  **&#x2022;** `access_tags` must be in the format `key:value`.
 - `capacity` - (Optional, Integer) (The capacity of the volume in gigabytes. This defaults to `100`, minimum to `10 ` and maximum to `16000`.
 
   ~> **NOTE:** Supports only expansion on update (must be attached to a running instance and must not be less than the current volume capacity). Can be updated only if volume is attached to an running virtual server instance. Stopped instance will be started on update of capacity of the volume.


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/IBM-Cloud/terraform-provider-ibm/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
Please fine the test results :

```
make testacc TEST=./ibm/service/vpc TESTARGS='-run=TestAccIBMISVolume_basic'

```
<img width="624" alt="Screenshot 2022-11-17 at 3 18 54 PM" src="https://user-images.githubusercontent.com/78336632/202413315-fea8a111-63ac-4d68-b0de-c71dee549cd4.png">


```
resource "ibm_is_volume" "storage" {
  name        = "volume-access-tags-testing"
  profile     = "10iops-tier"
  zone        = "us-south-1"
  access_tags = ["tfp:ussouth", "tfp:eude"]
  # capacity= 200
}
data "ibm_is_volumes" "is_volumes" {
  volume_name = "volume-access-tags-testing"
}
data "ibm_is_volume" "testacc_dsvol" {
  name = "volume-access-tags-testing"
}

```
<img width="1149" alt="Screenshot 2022-10-19 at 4 40 48 PM" src="https://user-images.githubusercontent.com/78336632/196675375-0c0dd40b-78e0-4cfe-a65a-d463395d7fdd.png">
<img width="1163" alt="Screenshot 2022-10-19 at 4 40 59 PM" src="https://user-images.githubusercontent.com/78336632/196675437-316c2438-5ba8-4fc6-8dde-25802ac0574d.png">
<img width="1242" alt="Screenshot 2022-10-19 at 4 41 18 PM" src="https://user-images.githubusercontent.com/78336632/196675489-b7d0d025-51c4-4057-8c09-8b6abee3b9d3.png">

