### PR TITLE
LoadBalancerPool HealthMonitor Port Nullable

### DIFF
--- a/ibm/service/power/resource_ibm_pi_volume_test.go
+++ b/ibm/service/power/resource_ibm_pi_volume_test.go
@@ -161,7 +161,7 @@ func testAccCheckIBMPIVolumePoolConfig(name string) string {
 	`, name, acc.Pi_cloud_instance_id)
 }
 
-//TestAccIBMPIVolumeGRS test the volume replication feature which is part of global replication service(GRS)
+// TestAccIBMPIVolumeGRS test the volume replication feature which is part of global replication service(GRS)
 func TestAccIBMPIVolumeGRS(t *testing.T) {
 	name := fmt.Sprintf("tf-pi-volume-%d", acctest.RandIntRange(10, 100))
 	resource.Test(t, resource.TestCase{

--- a/ibm/service/vpc/resource_ibm_is_lb_pool.go
+++ b/ibm/service/vpc/resource_ibm_is_lb_pool.go
@@ -468,6 +468,7 @@ func lbPoolUpdate(d *schema.ResourceData, meta interface{}, lbID, lbPoolID strin
 
 	loadBalancerPoolPatchModel := &vpcv1.LoadBalancerPoolPatch{}
 
+	lBPoolHealthMonitorPortRemoved := false
 	if d.HasChange(isLBPoolHealthDelay) || d.HasChange(isLBPoolHealthRetries) ||
 		d.HasChange(isLBPoolHealthTimeout) || d.HasChange(isLBPoolHealthType) || d.HasChange(isLBPoolHealthMonitorURL) || d.HasChange(isLBPoolHealthMonitorPort) {
 
@@ -486,6 +487,8 @@ func lbPoolUpdate(d *schema.ResourceData, meta interface{}, lbID, lbPoolID strin
 		port := int64(d.Get(isLBPoolHealthMonitorPort).(int))
 		if port > int64(0) {
 			healthMonitorTemplate.Port = &port
+		} else {
+			lBPoolHealthMonitorPortRemoved = true
 		}
 		loadBalancerPoolPatchModel.HealthMonitor = healthMonitorTemplate
 		hasChanged = true
@@ -547,6 +550,10 @@ func lbPoolUpdate(d *schema.ResourceData, meta interface{}, lbID, lbPoolID strin
 		if sessionPersistenceRemoved {
 			LoadBalancerPoolPatch["session_persistence"] = nil
 		}
+		if lBPoolHealthMonitorPortRemoved {
+			LoadBalancerPoolPatch["health_monitor"].(map[string]interface{})["port"] = nil
+		}
+
 		updateLoadBalancerPoolOptions.LoadBalancerPoolPatch = LoadBalancerPoolPatch
 
 		_, response, err := sess.UpdateLoadBalancerPool(updateLoadBalancerPoolOptions)

--- a/ibm/service/vpc/resource_ibm_is_lb_pool_test.go
+++ b/ibm/service/vpc/resource_ibm_is_lb_pool_test.go
@@ -212,6 +212,78 @@ func TestAccIBMISLBPool_port(t *testing.T) {
 	})
 }
 
+func TestAccIBMISLBPool_portnullable(t *testing.T) {
+	var lb string
+	vpcname := fmt.Sprintf("tflbp-vpc-%d", acctest.RandIntRange(10, 100))
+	subnetname := fmt.Sprintf("tflbp-subnet-%d", acctest.RandIntRange(10, 100))
+	name := fmt.Sprintf("tfcreate%d", acctest.RandIntRange(10, 100))
+	poolName := fmt.Sprintf("tflbpoolc%d", acctest.RandIntRange(10, 100))
+	alg1 := "round_robin"
+	protocol1 := "http"
+	proxyProtocol1 := "disabled"
+	delay1 := "45"
+	retries1 := "5"
+	timeout1 := "15"
+	healthType1 := "http"
+	port := "2554"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { acc.TestAccPreCheck(t) },
+		Providers:    acc.TestAccProviders,
+		CheckDestroy: testAccCheckIBMISLBPoolDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckIBMISLBPoolPortConfig(vpcname, subnetname, acc.ISZoneName, acc.ISCIDR, name, poolName, alg1, protocol1, delay1, retries1, timeout1, healthType1, port),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckIBMISLBPoolExists("ibm_is_lb_pool.testacc_lb_pool", lb),
+					resource.TestCheckResourceAttr(
+						"ibm_is_lb.testacc_LB", "name", name),
+					resource.TestCheckResourceAttr(
+						"ibm_is_lb_pool.testacc_lb_pool", "name", poolName),
+					resource.TestCheckResourceAttr(
+						"ibm_is_lb_pool.testacc_lb_pool", "algorithm", alg1),
+					resource.TestCheckResourceAttr(
+						"ibm_is_lb_pool.testacc_lb_pool", "protocol", protocol1),
+					resource.TestCheckResourceAttr(
+						"ibm_is_lb_pool.testacc_lb_pool", "proxy_protocol", proxyProtocol1),
+					resource.TestCheckResourceAttr(
+						"ibm_is_lb_pool.testacc_lb_pool", "health_delay", delay1),
+					resource.TestCheckResourceAttr(
+						"ibm_is_lb_pool.testacc_lb_pool", "health_retries", retries1),
+					resource.TestCheckResourceAttr(
+						"ibm_is_lb_pool.testacc_lb_pool", "health_timeout", timeout1),
+					resource.TestCheckResourceAttr(
+						"ibm_is_lb_pool.testacc_lb_pool", "health_type", healthType1),
+				),
+			},
+			{
+				Config: testAccCheckIBMISLBPoolPortConfig(vpcname, subnetname, acc.ISZoneName, acc.ISCIDR, name, poolName, alg1, protocol1, delay1, retries1, timeout1, healthType1, "0"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckIBMISLBPoolExists("ibm_is_lb_pool.testacc_lb_pool", lb),
+					resource.TestCheckResourceAttr(
+						"ibm_is_lb.testacc_LB", "name", name),
+					resource.TestCheckResourceAttr(
+						"ibm_is_lb_pool.testacc_lb_pool", "name", poolName),
+					resource.TestCheckResourceAttr(
+						"ibm_is_lb_pool.testacc_lb_pool", "algorithm", alg1),
+					resource.TestCheckResourceAttr(
+						"ibm_is_lb_pool.testacc_lb_pool", "protocol", protocol1),
+					resource.TestCheckResourceAttr(
+						"ibm_is_lb_pool.testacc_lb_pool", "proxy_protocol", proxyProtocol1),
+					resource.TestCheckResourceAttr(
+						"ibm_is_lb_pool.testacc_lb_pool", "health_delay", delay1),
+					resource.TestCheckResourceAttr(
+						"ibm_is_lb_pool.testacc_lb_pool", "health_retries", retries1),
+					resource.TestCheckResourceAttr(
+						"ibm_is_lb_pool.testacc_lb_pool", "health_timeout", timeout1),
+					resource.TestCheckResourceAttr(
+						"ibm_is_lb_pool.testacc_lb_pool", "health_type", healthType1),
+				),
+			},
+		},
+	})
+}
+
 func TestAccIBMISLBPool_SessionPersistence(t *testing.T) {
 	var lb string
 	vpcname := fmt.Sprintf("tflbp-vpc-%d", acctest.RandIntRange(10, 100))

--- a/website/docs/r/is_lb_pool.html.markdown
+++ b/website/docs/r/is_lb_pool.html.markdown
@@ -127,7 +127,7 @@ Review the argument references that you can specify for your resource.
 - `health_timeout`- (Required, Integer) The health check timeout in seconds.
 - `health_type` - (Required, String) The pool protocol. Enumeration type: `http`, `https`, `tcp` are supported.
 - `health_monitor_url` - (Optional, String) The health check URL. This option is applicable only to the HTTP `health-type`.
-- `health_monitor_port` - (Optional, Integer) The health check port number.
+- `health_monitor_port` - (Optional, Integer) The health check port number. Specify `0` to remove an existing health check port.
 - `lb`  - (Required, Forces new resource, String) The load balancer unique identifier.
 - `name` - (Required, String) The name of the pool.
 - `protocol` - (Required, String) The pool protocol. Enumeration type: `http`, `https`, `tcp`, `udp` are supported.


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/IBM-Cloud/terraform-provider-ibm/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request


Our team has internally reviewed the PR and please find the PR : https://github.com/ibm-vpc/terraform-provider-ibm/pull/186 for the results of the testing..

```
$ make testacc TEST=./ibm/service/vpc TESTARGS='-run=TestAccIBMISLBPool_portnullable'

```
<img width="615" alt="Screenshot 2022-10-10 at 11 29 24 AM" src="https://user-images.githubusercontent.com/78336632/194807087-0d8761a0-bcbe-467c-9de4-9cc5064fa25a.png">
