### PR TITLE
CIS Firewall Rules : added pause key in create

### DIFF
--- a/ibm/service/cis/resource_ibm_cis_firewall_rules.go
+++ b/ibm/service/cis/resource_ibm_cis_firewall_rules.go
@@ -103,6 +103,10 @@ func ResourceIBMCISFirewallrulesCreate(context context.Context, d *schema.Resour
 		action := a.(string)
 		newFirewallRules.Action = &action
 	}
+	if p, ok := d.GetOk(cisFirewallrulesPaused); ok {
+		paused := p.(bool)
+		newFirewallRules.Paused = &paused
+	}
 	if des, ok := d.GetOk(cisFilterDescription); ok {
 		description := des.(string)
 		newFirewallRules.Description = &description

--- a/ibm/service/cis/resource_ibm_cis_firewall_rules_test.go
+++ b/ibm/service/cis/resource_ibm_cis_firewall_rules_test.go
@@ -21,6 +21,7 @@ func TestAccIBMCisFirewallrules_Basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("ibm_cis_firewall_rule.firewall_rules_instance", "action", "allow"),
 					resource.TestCheckResourceAttr("ibm_cis_firewall_rule.firewall_rules_instance", "priority", "5"),
+					resource.TestCheckResourceAttr("ibm_cis_firewall_rule.firewall_rules_instance", "paused", "true"),
 				),
 			},
 		},
@@ -42,6 +43,7 @@ func testAccCheckCisFirewallrules_basic() string {
   		filter_id = ibm_cis_filter.test.filter_id
   		action = "allow"
   		priority = 5
+		paused = true
 	  }
 `
 }


### PR DESCRIPTION
Problem Statement -

- User was not able to update pause field in Firewall Rules while creating a resource. It worked perfectly fine while updating.

Issue - https://github.ibm.com/NetworkTribe/CIS_Support/issues/2718