### PR TITLE
AccessTags for DedicatedHost,Image,Instance,SSHKey

### DIFF
--- a/ibm/service/vpc/data_source_ibm_is_images.go
+++ b/ibm/service/vpc/data_source_ibm_is_images.go
@@ -5,6 +5,7 @@ package vpc
 
 import (
 	"fmt"
+	"log"
 	"time"
 
 	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/flex"
@@ -154,6 +155,13 @@ func DataSourceIBMISImages() *schema.Resource {
 								},
 							},
 						},
+						isImageAccessTags: {
+							Type:        schema.TypeSet,
+							Computed:    true,
+							Elem:        &schema.Schema{Type: schema.TypeString},
+							Set:         flex.ResourceIBMVPCHash,
+							Description: "List of access tags",
+						},
 					},
 				},
 			},
@@ -293,6 +301,12 @@ func imageList(d *schema.ResourceData, meta interface{}) error {
 			catalogOfferingList = append(catalogOfferingList, catalogOfferingMap)
 			l[isImageCatalogOffering] = catalogOfferingList
 		}
+		accesstags, err := flex.GetGlobalTagsUsingCRN(meta, *image.CRN, "", isImageAccessTagType)
+		if err != nil {
+			log.Printf(
+				"Error on get of resource image (%s) access tags: %s", d.Id(), err)
+		}
+		l[isImageAccessTags] = accesstags
 		imagesInfo = append(imagesInfo, l)
 	}
 	d.SetId(dataSourceIBMISImagesID(d))

--- a/ibm/service/vpc/data_source_ibm_is_instance.go
+++ b/ibm/service/vpc/data_source_ibm_is_instance.go
@@ -175,6 +175,13 @@ func DataSourceIBMISInstance() *schema.Resource {
 				Set:         flex.ResourceIBMVPCHash,
 				Description: "list of tags for the instance",
 			},
+			isInstanceAccessTags: {
+				Type:        schema.TypeSet,
+				Computed:    true,
+				Elem:        &schema.Schema{Type: schema.TypeString},
+				Set:         flex.ResourceIBMVPCHash,
+				Description: "list of access tags for the instance",
+			},
 			isInstanceBootVolume: {
 				Type:        schema.TypeList,
 				Computed:    true,
@@ -1027,12 +1034,18 @@ func instanceGetByName(d *schema.ResourceData, meta interface{}, name string) er
 		bootVolList = append(bootVolList, bootVol)
 		d.Set(isInstanceBootVolume, bootVolList)
 	}
-	tags, err := flex.GetTagsUsingCRN(meta, *instance.CRN)
+	tags, err := flex.GetGlobalTagsUsingCRN(meta, *instance.CRN, "", isInstanceUserTagType)
 	if err != nil {
 		log.Printf(
 			"[ERROR] Error on get of resource vpc Instance (%s) tags: %s", d.Id(), err)
 	}
 	d.Set(isInstanceTags, tags)
+	accesstags, err := flex.GetGlobalTagsUsingCRN(meta, *instance.CRN, "", isInstanceAccessTagType)
+	if err != nil {
+		log.Printf(
+			"Error on get of resource vpc Instance (%s) access tags: %s", d.Id(), err)
+	}
+	d.Set(isInstanceAccessTags, accesstags)
 
 	controller, err := flex.GetBaseController(meta)
 	if err != nil {

--- a/ibm/service/vpc/data_source_ibm_is_instances.go
+++ b/ibm/service/vpc/data_source_ibm_is_instances.go
@@ -5,6 +5,7 @@ package vpc
 
 import (
 	"fmt"
+	"log"
 	"time"
 
 	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/flex"
@@ -220,7 +221,21 @@ func DataSourceIBMISInstances() *schema.Resource {
 								},
 							},
 						},
+						isInstanceTags: {
+							Type:        schema.TypeSet,
+							Computed:    true,
+							Elem:        &schema.Schema{Type: schema.TypeString},
+							Set:         flex.ResourceIBMVPCHash,
+							Description: "list of tags for the instance",
+						},
 
+						isInstanceAccessTags: {
+							Type:        schema.TypeSet,
+							Computed:    true,
+							Elem:        &schema.Schema{Type: schema.TypeString},
+							Set:         flex.ResourceIBMVPCHash,
+							Description: "list of access tags for the instance",
+						},
 						"boot_volume": {
 							Type:        schema.TypeList,
 							Computed:    true,
@@ -841,6 +856,19 @@ func instancesList(d *schema.ResourceData, meta interface{}) error {
 			bootVolList = append(bootVolList, bootVol)
 			l["boot_volume"] = bootVolList
 		}
+		tags, err := flex.GetGlobalTagsUsingCRN(meta, *instance.CRN, "", isInstanceUserTagType)
+		if err != nil {
+			log.Printf(
+				"Error on get of resource vpc Instance (%s) tags: %s", d.Id(), err)
+		}
+		l[isInstanceTags] = tags
+
+		accesstags, err := flex.GetGlobalTagsUsingCRN(meta, *instance.CRN, "", isInstanceAccessTagType)
+		if err != nil {
+			log.Printf(
+				"Error on get of resource vpc Instance (%s) access tags: %s", d.Id(), err)
+		}
+		l[isInstanceAccessTags] = accesstags
 		//set the status reasons
 		statusReasonsList := make([]map[string]interface{}, 0)
 		if instance.StatusReasons != nil {

--- a/ibm/service/vpc/data_source_ibm_is_ssh_key.go
+++ b/ibm/service/vpc/data_source_ibm_is_ssh_key.go
@@ -5,6 +5,7 @@ package vpc
 
 import (
 	"fmt"
+	"log"
 
 	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/flex"
 	"github.com/IBM/vpc-go-sdk/vpcv1"
@@ -81,6 +82,14 @@ func DataSourceIBMISSSHKey() *schema.Resource {
 				Computed:    true,
 				Description: "The resource group name in which resource is provisioned",
 			},
+
+			isKeyAccessTags: {
+				Type:        schema.TypeSet,
+				Computed:    true,
+				Elem:        &schema.Schema{Type: schema.TypeString},
+				Set:         flex.ResourceIBMVPCHash,
+				Description: "List of access tags",
+			},
 		},
 	}
 }
@@ -141,6 +150,12 @@ func keyGetByName(d *schema.ResourceData, meta interface{}, name string) error {
 			if key.PublicKey != nil {
 				d.Set(isKeyPublicKey, *key.PublicKey)
 			}
+			accesstags, err := flex.GetGlobalTagsUsingCRN(meta, *key.CRN, "", isKeyAccessTagType)
+			if err != nil {
+				log.Printf(
+					"Error on get of resource SSH Key (%s) access tags: %s", d.Id(), err)
+			}
+			d.Set(isKeyAccessTags, accesstags)
 			return nil
 		}
 	}

--- a/ibm/service/vpc/resource_ibm_is_image.go
+++ b/ibm/service/vpc/resource_ibm_is_image.go
@@ -40,6 +40,10 @@ const (
 	isImageProvisioningDone = "done"
 	isImageDeleting         = "deleting"
 	isImageDeleted          = "done"
+
+	isImageAccessTags    = "access_tags"
+	isImageUserTagType   = "user"
+	isImageAccessTagType = "access"
 )
 
 func ResourceIBMISImage() *schema.Resource {
@@ -57,10 +61,16 @@ func ResourceIBMISImage() *schema.Resource {
 			Delete: schema.DefaultTimeout(10 * time.Minute),
 		},
 
-		CustomizeDiff: customdiff.Sequence(
-			func(_ context.Context, diff *schema.ResourceDiff, v interface{}) error {
-				return flex.ResourceTagsCustomizeDiff(diff)
-			},
+		CustomizeDiff: customdiff.All(
+			customdiff.Sequence(
+				func(_ context.Context, diff *schema.ResourceDiff, v interface{}) error {
+					return flex.ResourceTagsCustomizeDiff(diff)
+				},
+			),
+			customdiff.Sequence(
+				func(_ context.Context, diff *schema.ResourceDiff, v interface{}) error {
+					return flex.ResourceValidateAccessTags(diff, v)
+				}),
 		),
 
 		Schema: map[string]*schema.Schema{
@@ -198,6 +208,14 @@ func ResourceIBMISImage() *schema.Resource {
 				Computed:    true,
 				Description: "The resource group name in which resource is provisioned",
 			},
+			isImageAccessTags: {
+				Type:        schema.TypeSet,
+				Optional:    true,
+				Computed:    true,
+				Elem:        &schema.Schema{Type: schema.TypeString, ValidateFunc: validate.InvokeValidator("ibm_is_image", "accesstag")},
+				Set:         flex.ResourceIBMVPCHash,
+				Description: "List of access management tags",
+			},
 		},
 	}
 }
@@ -221,6 +239,15 @@ func ResourceIBMISImageValidator() *validate.ResourceValidator {
 			Type:                       validate.TypeString,
 			Optional:                   true,
 			Regexp:                     `^[A-Za-z0-9:_ .-]+$`,
+			MinValueLength:             1,
+			MaxValueLength:             128})
+	validateSchema = append(validateSchema,
+		validate.ValidateSchema{
+			Identifier:                 "accesstag",
+			ValidateFunctionIdentifier: validate.ValidateRegexpLen,
+			Type:                       validate.TypeString,
+			Optional:                   true,
+			Regexp:                     `^([A-Za-z0-9_.-]|[A-Za-z0-9_.-][A-Za-z0-9_ .-]*[A-Za-z0-9_.-]):([A-Za-z0-9_.-]|[A-Za-z0-9_.-][A-Za-z0-9_ .-]*[A-Za-z0-9_.-])$`,
 			MinValueLength:             1,
 			MaxValueLength:             128})
 	ibmISImageResourceValidator := validate.ResourceValidator{ResourceName: "ibm_is_image", Schema: validateSchema}
@@ -297,10 +324,18 @@ func imgCreateByFile(d *schema.ResourceData, meta interface{}, href, name, opera
 	v := os.Getenv("IC_ENV_TAGS")
 	if _, ok := d.GetOk(isImageTags); ok || v != "" {
 		oldList, newList := d.GetChange(isImageTags)
-		err = flex.UpdateTagsUsingCRN(oldList, newList, meta, *image.CRN)
+		err = flex.UpdateGlobalTagsUsingCRN(oldList, newList, meta, *image.CRN, "", isImageUserTagType)
 		if err != nil {
 			log.Printf(
 				"Error on create of resource vpc Image (%s) tags: %s", d.Id(), err)
+		}
+	}
+	if _, ok := d.GetOk(isImageAccessTags); ok {
+		oldList, newList := d.GetChange(isImageAccessTags)
+		err = flex.UpdateGlobalTagsUsingCRN(oldList, newList, meta, *image.CRN, "", isImageAccessTagType)
+		if err != nil {
+			log.Printf(
+				"Error on create of resource vpc Image (%s) access tags: %s", d.Id(), err)
 		}
 	}
 	return nil
@@ -386,10 +421,18 @@ func imgCreateByVolume(d *schema.ResourceData, meta interface{}, name, volume st
 	v := os.Getenv("IC_ENV_TAGS")
 	if _, ok := d.GetOk(isImageTags); ok || v != "" {
 		oldList, newList := d.GetChange(isImageTags)
-		err = flex.UpdateTagsUsingCRN(oldList, newList, meta, *image.CRN)
+		err = flex.UpdateGlobalTagsUsingCRN(oldList, newList, meta, *image.CRN, "", isImageUserTagType)
 		if err != nil {
 			log.Printf(
 				"Error on create of resource vpc Image (%s) tags: %s", d.Id(), err)
+		}
+	}
+	if _, ok := d.GetOk(isImageAccessTags); ok {
+		oldList, newList := d.GetChange(isImageAccessTags)
+		err = flex.UpdateGlobalTagsUsingCRN(oldList, newList, meta, *image.CRN, "", isImageAccessTagType)
+		if err != nil {
+			log.Printf(
+				"Error on create of resource vpc Image (%s) access tags: %s", d.Id(), err)
 		}
 	}
 	return nil
@@ -459,10 +502,25 @@ func imgUpdate(d *schema.ResourceData, meta interface{}, id, name string, hasCha
 			return fmt.Errorf("[ERROR] Error getting Image IP: %s\n%s", err, response)
 		}
 		oldList, newList := d.GetChange(isImageTags)
-		err = flex.UpdateTagsUsingCRN(oldList, newList, meta, *image.CRN)
+		err = flex.UpdateGlobalTagsUsingCRN(oldList, newList, meta, *image.CRN, "", isImageUserTagType)
 		if err != nil {
 			log.Printf(
 				"Error on update of resource vpc Image (%s) tags: %s", id, err)
+		}
+	}
+	if d.HasChange(isImageAccessTags) {
+		options := &vpcv1.GetImageOptions{
+			ID: &id,
+		}
+		image, response, err := sess.GetImage(options)
+		if err != nil {
+			return fmt.Errorf("Error getting Image IP: %s\n%s", err, response)
+		}
+		oldList, newList := d.GetChange(isImageAccessTags)
+		err = flex.UpdateGlobalTagsUsingCRN(oldList, newList, meta, *image.CRN, "", isImageAccessTagType)
+		if err != nil {
+			log.Printf(
+				"Error on update of resource vpc Image (%s) access tags: %s", id, err)
 		}
 	}
 	if hasChanged {
@@ -543,12 +601,18 @@ func imgGet(d *schema.ResourceData, meta interface{}, id string) error {
 	if image.File != nil && image.File.Checksums != nil {
 		d.Set(isImageCheckSum, *image.File.Checksums.Sha256)
 	}
-	tags, err := flex.GetTagsUsingCRN(meta, *image.CRN)
+	tags, err := flex.GetGlobalTagsUsingCRN(meta, *image.CRN, "", isImageUserTagType)
 	if err != nil {
 		log.Printf(
 			"Error on get of resource vpc Image (%s) tags: %s", d.Id(), err)
 	}
 	d.Set(isImageTags, tags)
+	accesstags, err := flex.GetGlobalTagsUsingCRN(meta, *image.CRN, "", isImageAccessTagType)
+	if err != nil {
+		log.Printf(
+			"Error on get of resource vpc Image (%s) access tags: %s", d.Id(), err)
+	}
+	d.Set(isImageAccessTags, accesstags)
 	controller, err := flex.GetBaseController(meta)
 	if err != nil {
 		return err

--- a/ibm/service/vpc/resource_ibm_is_instance.go
+++ b/ibm/service/vpc/resource_ibm_is_instance.go
@@ -116,6 +116,10 @@ const (
 	isInstanceDefaultTrustedProfileAutoLink = "default_trusted_profile_auto_link"
 	isInstanceDefaultTrustedProfileTarget   = "default_trusted_profile_target"
 	isInstanceMetadataServiceEnabled        = "metadata_service_enabled"
+
+	isInstanceAccessTags    = "access_tags"
+	isInstanceUserTagType   = "user"
+	isInstanceAccessTagType = "access"
 )
 
 func ResourceIBMISInstance() *schema.Resource {
@@ -172,6 +176,10 @@ func ResourceIBMISInstance() *schema.Resource {
 			customdiff.Sequence(
 				func(_ context.Context, diff *schema.ResourceDiff, v interface{}) error {
 					return flex.ResourceTagsCustomizeDiff(diff)
+				}),
+			customdiff.Sequence(
+				func(_ context.Context, diff *schema.ResourceDiff, v interface{}) error {
+					return flex.ResourceValidateAccessTags(diff, v)
 				}),
 		),
 
@@ -298,6 +306,15 @@ func ResourceIBMISInstance() *schema.Resource {
 				Elem:        &schema.Schema{Type: schema.TypeString, ValidateFunc: validate.InvokeValidator("ibm_is_instance", "tags")},
 				Set:         flex.ResourceIBMVPCHash,
 				Description: "list of tags for the instance",
+			},
+
+			isInstanceAccessTags: {
+				Type:        schema.TypeSet,
+				Optional:    true,
+				Computed:    true,
+				Elem:        &schema.Schema{Type: schema.TypeString, ValidateFunc: validate.InvokeValidator("ibm_is_instance", "accesstag")},
+				Set:         flex.ResourceIBMVPCHash,
+				Description: "list of access tags for the instance",
 			},
 
 			isEnableCleanDelete: {
@@ -991,6 +1008,16 @@ func ResourceIBMISInstanceValidator() *validate.ResourceValidator {
 			Optional:                   true,
 			AllowedValues:              host_failure})
 
+	validateSchema = append(validateSchema,
+		validate.ValidateSchema{
+			Identifier:                 "accesstag",
+			ValidateFunctionIdentifier: validate.ValidateRegexpLen,
+			Type:                       validate.TypeString,
+			Optional:                   true,
+			Regexp:                     `^([A-Za-z0-9_.-]|[A-Za-z0-9_.-][A-Za-z0-9_ .-]*[A-Za-z0-9_.-]):([A-Za-z0-9_.-]|[A-Za-z0-9_.-][A-Za-z0-9_ .-]*[A-Za-z0-9_.-])$`,
+			MinValueLength:             1,
+			MaxValueLength:             128})
+
 	ibmISInstanceValidator := validate.ResourceValidator{ResourceName: "ibm_is_instance", Schema: validateSchema}
 	return &ibmISInstanceValidator
 }
@@ -1344,10 +1371,18 @@ func instanceCreateByImage(d *schema.ResourceData, meta interface{}, profile, na
 	v := os.Getenv("IC_ENV_TAGS")
 	if _, ok := d.GetOk(isInstanceTags); ok || v != "" {
 		oldList, newList := d.GetChange(isInstanceTags)
-		err = flex.UpdateTagsUsingCRN(oldList, newList, meta, *instance.CRN)
+		err = flex.UpdateGlobalTagsUsingCRN(oldList, newList, meta, *instance.CRN, "", isInstanceUserTagType)
 		if err != nil {
 			log.Printf(
 				"Error on create of resource instance (%s) tags: %s", d.Id(), err)
+		}
+	}
+	if _, ok := d.GetOk(isInstanceAccessTags); ok {
+		oldList, newList := d.GetChange(isInstanceAccessTags)
+		err = flex.UpdateGlobalTagsUsingCRN(oldList, newList, meta, *instance.CRN, "", isInstanceAccessTagType)
+		if err != nil {
+			log.Printf(
+				"Error on create of resource instance (%s) access tags: %s", d.Id(), err)
 		}
 	}
 	return nil
@@ -2079,6 +2114,14 @@ func instanceCreateByTemplate(d *schema.ResourceData, meta interface{}, profile,
 				"Error on create of resource instance (%s) tags: %s", d.Id(), err)
 		}
 	}
+	if _, ok := d.GetOk(isInstanceAccessTags); ok {
+		oldList, newList := d.GetChange(isInstanceAccessTags)
+		err = flex.UpdateGlobalTagsUsingCRN(oldList, newList, meta, *instance.CRN, "", isInstanceAccessTagType)
+		if err != nil {
+			log.Printf(
+				"Error on create of resource instance (%s) access tags: %s", d.Id(), err)
+		}
+	}
 	return nil
 }
 
@@ -2434,10 +2477,18 @@ func instanceCreateByVolume(d *schema.ResourceData, meta interface{}, profile, n
 	v := os.Getenv("IC_ENV_TAGS")
 	if _, ok := d.GetOk(isInstanceTags); ok || v != "" {
 		oldList, newList := d.GetChange(isInstanceTags)
-		err = flex.UpdateTagsUsingCRN(oldList, newList, meta, *instance.CRN)
+		err = flex.UpdateGlobalTagsUsingCRN(oldList, newList, meta, *instance.CRN, "", isInstanceUserTagType)
 		if err != nil {
 			log.Printf(
 				"Error on create of resource instance (%s) tags: %s", d.Id(), err)
+		}
+	}
+	if _, ok := d.GetOk(isInstanceAccessTags); ok {
+		oldList, newList := d.GetChange(isInstanceAccessTags)
+		err = flex.UpdateGlobalTagsUsingCRN(oldList, newList, meta, *instance.CRN, "", isInstanceAccessTagType)
+		if err != nil {
+			log.Printf(
+				"Error on create of resource instance (%s) access tags: %s", d.Id(), err)
 		}
 	}
 	return nil
@@ -2898,13 +2949,18 @@ func instanceGet(d *schema.ResourceData, meta interface{}, id string) error {
 		bootVolList = append(bootVolList, bootVol)
 		d.Set(isInstanceBootVolume, bootVolList)
 	}
-	tags, err := flex.GetTagsUsingCRN(meta, *instance.CRN)
+	tags, err := flex.GetGlobalTagsUsingCRN(meta, *instance.CRN, "", isInstanceUserTagType)
 	if err != nil {
 		log.Printf(
 			"Error on get of resource Instance (%s) tags: %s", d.Id(), err)
 	}
 	d.Set(isInstanceTags, tags)
-
+	accesstags, err := flex.GetGlobalTagsUsingCRN(meta, *instance.CRN, "", isInstanceAccessTagType)
+	if err != nil {
+		log.Printf(
+			"Error on get of resource Instance (%s) access tags: %s", d.Id(), err)
+	}
+	d.Set(isInstanceAccessTags, accesstags)
 	controller, err := flex.GetBaseController(meta)
 	if err != nil {
 		return err
@@ -3592,6 +3648,14 @@ func instanceUpdate(d *schema.ResourceData, meta interface{}) error {
 		if err != nil {
 			log.Printf(
 				"Error on update of resource Instance (%s) tags: %s", d.Id(), err)
+		}
+	}
+	if d.HasChange(isInstanceAccessTags) {
+		oldList, newList := d.GetChange(isInstanceAccessTags)
+		err = flex.UpdateGlobalTagsUsingCRN(oldList, newList, meta, *instance.CRN, "", isInstanceAccessTagType)
+		if err != nil {
+			log.Printf(
+				"Error on update of resource Instance (%s) access tags: %s", d.Id(), err)
 		}
 	}
 	return nil

--- a/website/docs/d/is_dedicated_host.html.markdown
+++ b/website/docs/d/is_dedicated_host.html.markdown
@@ -41,6 +41,7 @@ Review the argument references that you can specify for your data source.
 ## Attribute reference
 In addition to all argument reference list, you can access the following attribute references after your data source is created. 
 
+- `access_tags`  - (List) Access management tags associated for dedicated host.
 - `available_memory` -  (String) The amount of memory in `GB` that is currently available for instances.
 - `available_vcpu` -  (List) The available `VCPU` for the dedicated host. 
 

--- a/website/docs/d/is_dedicated_hosts.html.markdown
+++ b/website/docs/d/is_dedicated_hosts.html.markdown
@@ -41,6 +41,7 @@ In addition to all argument reference list, you can access the following attribu
 - `dedicated_hosts` -  (List) Collection of dedicated hosts. Nested dedicated_hosts blocks have the following structure.
 
   Nested scheme for `dedicated_hosts`:
+  - `access_tags`  - (List) Access management tags associated for dedicated hosts.
   - `available_memory` -  (String) The amount of memory in GB that is currently available for 
   - `available_vcpu` -  (List) The available `VCPU` for the dedicated host. Nested available_vcpu blocks have the following structure.
 

--- a/website/docs/d/is_image.html.markdown
+++ b/website/docs/d/is_image.html.markdown
@@ -46,6 +46,7 @@ Review the argument references that you can specify for your data source.
 ## Attribute reference
 In addition to all argument reference list, you can access the following attribute references after your data source is created.
 
+- `access_tags`  - (List) Access management tags associated for image.
 - `architecture` - (String) The architecture of the image.
 - `catalog_offering` - (List) The catalog offering for this image.
   Nested scheme for **catalog_offering**:

--- a/website/docs/d/is_images.html.markdown
+++ b/website/docs/d/is_images.html.markdown
@@ -48,6 +48,7 @@ You can access the following attribute references after your data source is crea
 - `images` - (List) List of all images in the IBM Cloud Infrastructure.
 
   Nested scheme for `images`:
+  - `access_tags`  - (List) Access management tags associated for image.
   - `architecture` - (String) The architecture for this image.
   - `crn` - (String) The CRN for this image.
   - `catalog_offering` - (List) The catalog offering for this image.

--- a/website/docs/d/is_instance.html.markdown
+++ b/website/docs/d/is_instance.html.markdown
@@ -84,6 +84,7 @@ Review the argument references that you can specify for your data source.
 
 ## Attribute reference
 In addition to all argument reference list, you can access the following attribute references after your data source is created. 
+- `access_tags`  - (List) Access management tags associated for instance.
 - `availability_policy_host_failure` - (String) The availability policy for this virtual server instance. The action to perform if the compute host experiences a failure. 
 - `bandwidth` - (Integer) The total bandwidth (in megabits per second) shared across the instance's network interfaces and storage volumes
 - `boot_volume` - (List of Objects) A list of boot volumes that were created for the instance.

--- a/website/docs/d/is_instances.html.markdown
+++ b/website/docs/d/is_instances.html.markdown
@@ -57,6 +57,7 @@ In addition to all argument reference list, you can access the following attribu
 - `instances`- (List of Object) A list of Virtual Servers for VPC instances that exist in your account.
    
    Nested scheme for `instances`:
+    - `access_tags`  - (List) Access management tags associated for the instances.
     - `availability_policy_host_failure` - (String) The availability policy for this virtual server instance. The action to perform if the compute host experiences a failure. 
     - `bandwidth` - (Integer) The total bandwidth (in megabits per second) shared across the instance's network interfaces and storage volumes
 	- `boot_volume`- (List) A list of boot volumes that were created for the instance.

--- a/website/docs/d/is_ssh_key.html.markdown
+++ b/website/docs/d/is_ssh_key.html.markdown
@@ -38,6 +38,7 @@ Review the argument references that you can specify for your data source.
 ## Attribute reference
 In addition to all argument reference list, you can access the following attribute references after your data source is created. 
 
+- `access_tags`  - (List) Access management tags associated for the ssh key.
 - `crn` - (String) The CRN for this key.
 - `id` - (String) The ID of the SSH key.
 - `fingerprint`-  (String) The SHA256 fingerprint of the public key.

--- a/website/docs/d/is_ssh_keys.html.markdown
+++ b/website/docs/d/is_ssh_keys.html.markdown
@@ -25,6 +25,7 @@ In addition to all argument references listed, you can access the following attr
 - `id` - The unique identifier of the KeyCollection.
 - `keys` - (List) Collection of keys.
 	Nested scheme for **keys**:
+	- `access_tags`  - (List) Access management tags associated for the ssh key.
 	- `created_at` - (String) The date and time that the key was created.
 	- `crn` - (String) The CRN for this key.
 	- `fingerprint` - (String) The fingerprint for this key.  The value is returned base64-encoded and prefixed with the hash algorithm (always `SHA256`).

--- a/website/docs/r/is_dedicated_host.html.markdown
+++ b/website/docs/r/is_dedicated_host.html.markdown
@@ -41,6 +41,13 @@ resource "ibm_is_dedicated_host" "example" {
 ## Argument reference
 Review the argument reference that you can specify for your resource. 
 
+- `access_tags`  - (Optional, List of Strings) A list of access management tags to attach to the dedicated host.
+
+  ~> **Note:** 
+  **&#x2022;** You can attach only those access tags that already exists.</br>
+  **&#x2022;** For more information, about creating access tags, see [working with tags](https://cloud.ibm.com/docs/account?topic=account-tag&interface=ui#create-access-console).</br>
+  **&#x2022;** You must have the access listed in the [Granting users access to tag resources](https://cloud.ibm.com/docs/account?topic=account-access) for `access_tags`</br>
+  **&#x2022;** `access_tags` must be in the format `key:value`.
 - `host_group` - (Required, String)The unique ID of the dedicated host group for this dedicated host.
 - `instance_placement_enabled`- (Optional, Bool) If set to **true** instances can be placed on the dedicated host.
 - `name` - (Optional, String) The unique user-defined name for the dedicated host. If unspecified, the name will be a hyphenated list of randomly selected words.

--- a/website/docs/r/is_image.html.markdown
+++ b/website/docs/r/is_image.html.markdown
@@ -68,6 +68,13 @@ resource "ibm_is_image" "example" {
 ## Argument reference
 Review the argument references that you can specify for your resource. 
 
+- `access_tags`  - (Optional, List of Strings) A list of access management tags to attach to the image
+
+  ~> **Note:** 
+  **&#x2022;** You can attach only those access tags that already exists.</br>
+  **&#x2022;** For more information, about creating access tags, see [working with tags](https://cloud.ibm.com/docs/account?topic=account-tag&interface=ui#create-access-console).</br>
+  **&#x2022;** You must have the access listed in the [Granting users access to tag resources](https://cloud.ibm.com/docs/account?topic=account-access) for `access_tags`</br>
+  **&#x2022;** `access_tags` must be in the format `key:value`.
 - `encrypted_data_key` - (Optional, Forces new resource, String) A base64-encoded, encrypted representation of the key that was used to encrypt the data for this image.
 - `encryption_key` - (Optional, Forces new resource, String) The CRN of the Key Protect Root Key or Hyper Protect Crypto Service Root Key for this resource.
 - `href` - (Optional, String) The path of an image to be uploaded. The Cloud Object Store (COS) location of the image file.

--- a/website/docs/r/is_instance.html.markdown
+++ b/website/docs/r/is_instance.html.markdown
@@ -338,6 +338,14 @@ The `ibm_is_instance` resource provides the following [[Timeouts](https://www.te
 
 ## Argument reference
 Review the argument references that you can specify for your resource.
+
+- `access_tags`  - (Optional, List of Strings) A list of access management tags to attach to the instance.
+
+  ~> **Note:** 
+  **&#x2022;** You can attach only those access tags that already exists.</br>
+  **&#x2022;** For more information, about creating access tags, see [working with tags](https://cloud.ibm.com/docs/account?topic=account-tag&interface=ui#create-access-console).</br>
+  **&#x2022;** You must have the access listed in the [Granting users access to tag resources](https://cloud.ibm.com/docs/account?topic=account-access) for `access_tags`</br>
+  **&#x2022;** `access_tags` must be in the format `key:value`.
 - `action` - (Optional, String) Action to be taken on the instance. Supported values are `stop`, `start`, or `reboot`.
   
   ~> **Note** 

--- a/website/docs/r/is_ssh_key.html.markdown
+++ b/website/docs/r/is_ssh_key.html.markdown
@@ -33,6 +33,13 @@ resource "ibm_is_ssh_key" "example" {
 ## Argument reference
 Review the argument references that you can specify for your resource. 
 
+- `access_tags`  - (Optional, List of Strings) A list of access management tags to attach to the ssh key.
+
+  ~> **Note:** 
+  **&#x2022;** You can attach only those access tags that already exists.</br>
+  **&#x2022;** For more information, about creating access tags, see [working with tags](https://cloud.ibm.com/docs/account?topic=account-tag&interface=ui#create-access-console).</br>
+  **&#x2022;** You must have the access listed in the [Granting users access to tag resources](https://cloud.ibm.com/docs/account?topic=account-access) for `access_tags`</br>
+  **&#x2022;** `access_tags` must be in the format `key:value`.
 - `name` - (Required, String) The user-defined name for this key.
 - `public_key` - (Required, Forces new resource, String) The public SSH key.
 - `resource_group` - (Optional, Forces new resource, String) The resource group ID where the SSH is created.


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/IBM-Cloud/terraform-provider-ibm/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Output from acceptance testing:
Please find the test results here : https://github.com/ibm-vpc/terraform-provider-ibm/pull/175

```
make testacc TEST=./ibm/service/vpc TESTARGS='-run=TestAccIBMISSSHKey_basic'
make testacc TEST=./ibm/service/vpc TESTARGS='-run=TestAccIBMISInstance_basic'
make testacc TEST=./ibm/service/vpc TESTARGS='-run=TestAccIbmIsDedicatedHostBasic'
make testacc TEST=./ibm/service/vpc TESTARGS='-run=TestAccIBMISImage_fromVolume'

```
<img width="640" alt="Screenshot 2022-11-17 at 2 46 36 PM" src="https://user-images.githubusercontent.com/78336632/202405515-c2803598-3413-4418-a3e8-666ab8a5d4ba.png">

<img width="460" alt="Screenshot 2022-11-17 at 2 53 29 PM" src="https://user-images.githubusercontent.com/78336632/202407210-f0ad9c4b-8f96-4533-aa3b-c66cacc11091.png">

<img width="635" alt="Screenshot 2022-11-17 at 2 56 16 PM" src="https://user-images.githubusercontent.com/78336632/202409380-892c58f9-caed-4ace-9a68-3b3bbdaeb1fc.png">

<img width="739" alt="Screenshot 2022-11-17 at 3 03 13 PM" src="https://user-images.githubusercontent.com/78336632/202409489-49ac4dad-f627-4793-b26c-70aec59c6124.png">

```
resource "ibm_is_dedicated_host_group" "is_dedicated_host_group" {
  class  = "bx2d"
  family = "balanced"
  name   = "sunitha-dedicated-host"
  zone   = "us-south-1"
}

resource "ibm_is_dedicated_host" "dhost" {
  profile     = "bx2d-host-152x608"
  host_group  = ibm_is_dedicated_host_group.is_dedicated_host_group.id
  name        = "dedicated-host-profile-sunitha"
  access_tags = ["tfp:ussouth", "tfp:eude"]
}

data "ibm_is_dedicated_host" "dhost" {
  name       = "dedicated-host-profile-sunitha"
  host_group = ibm_is_dedicated_host.dhost.host_group
}

data "ibm_is_dedicated_hosts" "dhosts" {
}
```
<img width="618" alt="Screenshot 2022-10-26 at 10 21 34 AM" src="https://user-images.githubusercontent.com/78336632/197940510-327480b0-560e-4704-b6b3-2ad27aed5d00.png">
<img width="611" alt="Screenshot 2022-10-26 at 10 39 59 AM" src="https://user-images.githubusercontent.com/78336632/197940518-032011a5-9478-4179-9677-226db7f0c2d5.png">
<img width="627" alt="Screenshot 2022-10-26 at 10 41 36 AM" src="https://user-images.githubusercontent.com/78336632/197940522-c79535ec-9b94-4665-8668-16cf5a3c5fe1.png">

```
resource "ibm_is_image" "isExampleImageFromVolume" {
  name          = "sunitha-image"
  source_volume = "r006-23a40d78-8a8d-4510-ad21-24776abf5bba"
  timeouts {
    create = "45m"
  }
  access_tags = ["tfp:ussouth", "tfp:eude"]

}

data "ibm_is_images" "test1" {
  depends_on = [ibm_is_image.isExampleImageFromVolume]
  name       = "sunitha-image"
}

data "ibm_is_image" "test1" {
  name = "sunitha-image"
}
```

<img width="552" alt="Screenshot 2022-10-26 at 11 05 32 AM" src="https://user-images.githubusercontent.com/78336632/197944302-d8a1765a-1a01-4a04-a7eb-ce6009923e74.png">

<img width="534" alt="Screenshot 2022-10-26 at 11 11 16 AM" src="https://user-images.githubusercontent.com/78336632/197944310-4ac273ad-1b36-4647-b93a-b4862c690dea.png">

<img width="571" alt="Screenshot 2022-10-26 at 11 13 29 AM" src="https://user-images.githubusercontent.com/78336632/197944347-62941e9d-1df4-456b-981d-9e82b3bf3abe.png">

```
resource "ibm_is_ssh_key" "isExampleKeyWithSignature" {
  name        = "sunitha-ssh-key"
  access_tags = ["tfp:ussouth", "tfp:eude"]
  public_key  = <<-EOT
            ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCKVmnMOlHKcZK8tpt3MP1lqOLAcqcJzhsvJcjscgVERRN7/9484SOBJ3HSKxxNG5JN8owAjy5f9yYwcUg+JaUVuytn5Pv3aeYROHGGg+5G346xaq3DAwX6Y5ykr2fvjObgncQBnuU5KHWCECO/4h8uWuwh/kfniXPVjFToc+gnkqA+3RKpAecZhFXwfalQ9mMuYGFxn+fwn8cYEApsJbsEmb0iJwPiZ5hjFC8wREuiTlhPHDgkBLOiycd20op2nXzDbHfCHInquEe/gYxEitALONxm0swBOwJZwlTDOB7C6y2dzlrtxr1L59m7pCkWI4EtTRLvleehBoj3u7jB4usR  abc@abc-MacBook-Pro.local
        EOT
}

data "ibm_is_ssh_key" "ds_key" {
  name = ibm_is_ssh_key.isExampleKeyWithSignature.name
}

data "ibm_is_ssh_keys" "is_ssh_keys" {
    depends_on = [ibm_is_ssh_key.isExampleKeyWithSignature]
}
```
<img width="607" alt="Screenshot 2022-10-26 at 12 36 24 PM" src="https://user-images.githubusercontent.com/78336632/197957790-2bed2ec5-ac3d-4e54-b178-6966473a2
<img width="640" alt="Screenshot 2022-10-26 at 12 38 28 PM" src="https://user-images.githubusercontent.com/78336632/197958111-1dc6d902-f0b5-4a27-b05e-c79c49075691.png">
<img width="1072" alt="Screenshot 2022-11-03 at 11 45 18 AM" src="https://user-images.githubusercontent.com/78336632/199657914-8bbafb75-1d8d-4d4f-bbe3-0c4a181e23c2.png">

```
resource "ibm_is_instance" "testacc_instance" {
  name    = "sunitha-instance"
  image   = "r006-e0d3b6fb-5421-4421-9061-0ca9f79a4978"
  profile = "cx2-2x4"
  primary_network_interface {
    subnet = "0727-9447a2c3-efb8-44d2-a180-115531e0b0d3"
  }
  vpc     = "r006-0d37163a-701d-4ad6-9ece-a3e34cf28935"
  zone    = "us-south-2"
  keys    = ["r006-12a5ea50-4814-453e-aded-545a1f0a8bc0"]
#   volumes = [ibm_is_volume.storage.id]
  access_tags = ["tfp:ussouth", "tfp:eude"]
}

data "ibm_is_instance" "ds_instance" {
  name        = ibm_is_instance.testacc_instance.name
}

data "ibm_is_instances" "ds_instances" {
depends_on = [ibm_is_instance.testacc_instance]
}
```
<img width="572" alt="Screenshot 2022-10-27 at 9 03 29 AM" src="https://user-images.githubusercontent.com/78336632/198185061-12a31103-3534-4c24-b93c-8c8041c42eda.png">
<img width="584" alt="Screenshot 2022-10-27 at 9 05 26 AM" src="https://user-images.githubusercontent.com/78336632/198185291-7d85df52-b962-4a37-a0ba-deebca3b11b7.png">
<img width="676" alt="Screenshot 2022-10-27 at 9 08 46 AM" src="https://user-images.githubusercontent.com/78336632/198185634-4b5ff129-46ac-4018-b2e0-93728d628eff.png">

