### PR TITLE
Access management tags for Network resources

### DIFF
--- a/ibm/service/vpc/data_source_ibm_is_flow_log.go
+++ b/ibm/service/vpc/data_source_ibm_is_flow_log.go
@@ -192,6 +192,13 @@ func DataSourceIBMIsFlowLog() *schema.Resource {
 					},
 				},
 			},
+			isFlowLogAccessTags: {
+				Type:        schema.TypeSet,
+				Computed:    true,
+				Elem:        &schema.Schema{Type: schema.TypeString},
+				Set:         flex.ResourceIBMVPCHash,
+				Description: "List of access management tags",
+			},
 		},
 	}
 }
@@ -294,6 +301,16 @@ func dataSourceIBMIsFlowLogRead(context context.Context, d *schema.ResourceData,
 		}
 	}
 
+	accesstags, err := flex.GetGlobalTagsUsingCRN(meta, *flowLogCollector.CRN, "", isAccessTagType)
+	if err != nil {
+		log.Printf(
+			"Error on get of resource VPC Flow Log (%s) access tags: %s", d.Id(), err)
+	}
+
+	err = d.Set(isFlowLogAccessTags, accesstags)
+	if err != nil {
+		return diag.FromErr(fmt.Errorf("[ERROR] Error setting access tags %s", err))
+	}
 	return nil
 }
 

--- a/ibm/service/vpc/data_source_ibm_is_lb.go
+++ b/ibm/service/vpc/data_source_ibm_is_lb.go
@@ -131,6 +131,14 @@ func DataSourceIBMISLB() *schema.Resource {
 				Description: "Tags associated to Load Balancer",
 			},
 
+			isLBAccessTags: {
+				Type:        schema.TypeSet,
+				Computed:    true,
+				Elem:        &schema.Schema{Type: schema.TypeString},
+				Set:         flex.ResourceIBMVPCHash,
+				Description: "List of access tags",
+			},
+
 			isLBResourceGroup: {
 				Type:        schema.TypeString,
 				Computed:    true,
@@ -483,12 +491,18 @@ func lbGetByName(d *schema.ResourceData, meta interface{}, name string) error {
 
 			d.Set(isLBResourceGroup, *lb.ResourceGroup.ID)
 			d.Set(isLBHostName, *lb.Hostname)
-			tags, err := flex.GetTagsUsingCRN(meta, *lb.CRN)
+			tags, err := flex.GetGlobalTagsUsingCRN(meta, *lb.CRN, "", isUserTagType)
 			if err != nil {
 				log.Printf(
 					"Error on get of resource vpc Load Balancer (%s) tags: %s", d.Id(), err)
 			}
 			d.Set(isLBTags, tags)
+			accesstags, err := flex.GetGlobalTagsUsingCRN(meta, *lb.CRN, "", isAccessTagType)
+			if err != nil {
+				log.Printf(
+					"Error on get of resource Load Balancer (%s) access tags: %s", d.Id(), err)
+			}
+			d.Set(isLBAccessTags, accesstags)
 			controller, err := flex.GetBaseController(meta)
 			if err != nil {
 				return err

--- a/ibm/service/vpc/data_source_ibm_is_lbs.go
+++ b/ibm/service/vpc/data_source_ibm_is_lbs.go
@@ -170,6 +170,14 @@ func DataSourceIBMISLBS() *schema.Resource {
 							Description: "Tags associated to Load Balancer",
 						},
 
+						isLBAccessTags: {
+							Type:        schema.TypeSet,
+							Computed:    true,
+							Elem:        &schema.Schema{Type: schema.TypeString},
+							Set:         flex.ResourceIBMVPCHash,
+							Description: "List of access tags",
+						},
+
 						isLBResourceGroup: {
 							Type:        schema.TypeString,
 							Computed:    true,
@@ -405,12 +413,20 @@ func getLbs(d *schema.ResourceData, meta interface{}) error {
 		}
 		lbInfo[isLBResourceGroup] = *lb.ResourceGroup.ID
 		lbInfo[isLBHostName] = *lb.Hostname
-		tags, err := flex.GetTagsUsingCRN(meta, *lb.CRN)
+		tags, err := flex.GetGlobalTagsUsingCRN(meta, *lb.CRN, "", isUserTagType)
 		if err != nil {
 			log.Printf(
 				"Error on get of resource vpc Load Balancer (%s) tags: %s", d.Id(), err)
 		}
 		lbInfo[isLBTags] = tags
+
+		accesstags, err := flex.GetGlobalTagsUsingCRN(meta, *lb.CRN, "", isAccessTagType)
+		if err != nil {
+			log.Printf(
+				"Error on get of resource Load Balancer (%s) access tags: %s", d.Id(), err)
+		}
+		lbInfo[isLBAccessTags] = accesstags
+
 		controller, err := flex.GetBaseController(meta)
 		if err != nil {
 			return err

--- a/ibm/service/vpc/data_source_ibm_is_network_acl.go
+++ b/ibm/service/vpc/data_source_ibm_is_network_acl.go
@@ -342,6 +342,13 @@ func DataSourceIBMIsNetworkACL() *schema.Resource {
 					},
 				},
 			},
+			isNetworkACLAccessTags: {
+				Type:        schema.TypeSet,
+				Computed:    true,
+				Elem:        &schema.Schema{Type: schema.TypeString},
+				Set:         flex.ResourceIBMVPCHash,
+				Description: "List of access tags",
+			},
 		},
 	}
 }
@@ -446,6 +453,13 @@ func dataSourceIBMIsNetworkACLRead(context context.Context, d *schema.ResourceDa
 			return diag.FromErr(fmt.Errorf("[ERROR] Error setting vpc %s", err))
 		}
 	}
+
+	accesstags, err := flex.GetGlobalTagsUsingCRN(meta, *networkACL.CRN, "", isAccessTagType)
+	if err != nil {
+		log.Printf(
+			"Error on get of resource Network ACL (%s) access tags: %s", d.Id(), err)
+	}
+	d.Set(isNetworkACLAccessTags, accesstags)
 
 	return nil
 }

--- a/ibm/service/vpc/data_source_ibm_is_public_gateway.go
+++ b/ibm/service/vpc/data_source_ibm_is_public_gateway.go
@@ -62,6 +62,14 @@ func DataSourceIBMISPublicGateway() *schema.Resource {
 				Description: "Service tags for the public gateway instance",
 			},
 
+			isPublicGatewayAccessTags: {
+				Type:        schema.TypeSet,
+				Computed:    true,
+				Elem:        &schema.Schema{Type: schema.TypeString},
+				Set:         flex.ResourceIBMVPCHash,
+				Description: "List of access management tags",
+			},
+
 			flex.ResourceControllerURL: {
 				Type:        schema.TypeString,
 				Computed:    true,
@@ -146,12 +154,21 @@ func dataSourceIBMISPublicGatewayRead(d *schema.ResourceData, meta interface{}) 
 			d.Set(isPublicGatewayStatus, *publicgw.Status)
 			d.Set(isPublicGatewayZone, *publicgw.Zone.Name)
 			d.Set(isPublicGatewayVPC, *publicgw.VPC.ID)
-			tags, err := flex.GetTagsUsingCRN(meta, *publicgw.CRN)
+			tags, err := flex.GetGlobalTagsUsingCRN(meta, *publicgw.CRN, "", isUserTagType)
 			if err != nil {
 				log.Printf(
 					"Error on get of vpc public gateway (%s) tags: %s", *publicgw.ID, err)
 			}
 			d.Set(isPublicGatewayTags, tags)
+
+			accesstags, err := flex.GetGlobalTagsUsingCRN(meta, *publicgw.CRN, "", isAccessTagType)
+			if err != nil {
+				log.Printf(
+					"Error on get of vpc public gateway (%s) access tags: %s", d.Id(), err)
+			}
+
+			d.Set(isPublicGatewayAccessTags, accesstags)
+
 			controller, err := flex.GetBaseController(meta)
 			if err != nil {
 				return err

--- a/ibm/service/vpc/data_source_ibm_is_public_gateways.go
+++ b/ibm/service/vpc/data_source_ibm_is_public_gateways.go
@@ -77,6 +77,13 @@ func DataSourceIBMISPublicGateways() *schema.Resource {
 							Set:         flex.ResourceIBMVPCHash,
 							Description: "Service tags for the public gateway instance",
 						},
+						isPublicGatewayAccessTags: {
+							Type:        schema.TypeSet,
+							Computed:    true,
+							Elem:        &schema.Schema{Type: schema.TypeString},
+							Set:         flex.ResourceIBMVPCHash,
+							Description: "List of access management tags",
+						},
 
 						flex.ResourceControllerURL: {
 							Type:        schema.TypeString,
@@ -179,12 +186,21 @@ func publicGatewaysGet(d *schema.ResourceData, meta interface{}, name string) er
 			}
 			l[isPublicGatewayFloatingIP] = floatIP
 		}
-		tags, err := flex.GetTagsUsingCRN(meta, *publicgw.CRN)
+		tags, err := flex.GetGlobalTagsUsingCRN(meta, *publicgw.CRN, "", isUserTagType)
 		if err != nil {
 			log.Printf(
 				"Error on get of vpc public gateway (%s) tags: %s", *publicgw.ID, err)
 		}
 		l[isPublicGatewayTags] = tags
+
+		accesstags, err := flex.GetGlobalTagsUsingCRN(meta, *publicgw.CRN, "", isAccessTagType)
+		if err != nil {
+			log.Printf(
+				"Error on get of vpc public gateway (%s) access tags: %s", d.Id(), err)
+		}
+
+		l[isPublicGatewayAccessTags] = accesstags
+
 		controller, err := flex.GetBaseController(meta)
 		if err != nil {
 			return err

--- a/ibm/service/vpc/data_source_ibm_is_vpn_gateway.go
+++ b/ibm/service/vpc/data_source_ibm_is_vpn_gateway.go
@@ -249,6 +249,20 @@ func DataSourceIBMISVPNGateway() *schema.Resource {
 					},
 				},
 			},
+			isVPNGatewayTags: {
+				Type:        schema.TypeSet,
+				Computed:    true,
+				Elem:        &schema.Schema{Type: schema.TypeString},
+				Set:         flex.ResourceIBMVPCHash,
+				Description: "VPN Gateway tags list",
+			},
+			isVPNGatewayAccessTags: {
+				Type:        schema.TypeSet,
+				Computed:    true,
+				Elem:        &schema.Schema{Type: schema.TypeString},
+				Set:         flex.ResourceIBMVPCHash,
+				Description: "List of access management tags",
+			},
 		},
 	}
 }
@@ -361,6 +375,19 @@ func dataSourceIBMIsVPNGatewayRead(context context.Context, d *schema.ResourceDa
 			return diag.FromErr(fmt.Errorf("Error setting vpc: %s", err))
 		}
 	}
+	tags, err := flex.GetGlobalTagsUsingCRN(meta, *vpnGateway.CRN, "", isUserTagType)
+	if err != nil {
+		log.Printf(
+			"Error on get of resource vpc VPN Gateway (%s) tags: %s", d.Id(), err)
+	}
+	d.Set(isVPNGatewayTags, tags)
+
+	accesstags, err := flex.GetGlobalTagsUsingCRN(meta, *vpnGateway.CRN, "", isAccessTagType)
+	if err != nil {
+		log.Printf(
+			"Error on get of resource VPC VPN Gateway (%s) access tags: %s", d.Id(), err)
+	}
+	d.Set(isVPNGatewayAccessTags, accesstags)
 	return nil
 }
 

--- a/ibm/service/vpc/data_source_ibm_is_vpn_gateways.go
+++ b/ibm/service/vpc/data_source_ibm_is_vpn_gateways.go
@@ -5,6 +5,7 @@ package vpc
 
 import (
 	"fmt"
+	"log"
 	"time"
 
 	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/flex"
@@ -147,6 +148,20 @@ func DataSourceIBMISVPNGateways() *schema.Resource {
 								},
 							},
 						},
+						isVPNGatewayTags: {
+							Type:        schema.TypeSet,
+							Computed:    true,
+							Elem:        &schema.Schema{Type: schema.TypeString},
+							Set:         flex.ResourceIBMVPCHash,
+							Description: "VPN Gateway tags list",
+						},
+						isVPNGatewayAccessTags: {
+							Type:        schema.TypeSet,
+							Computed:    true,
+							Elem:        &schema.Schema{Type: schema.TypeString},
+							Set:         flex.ResourceIBMVPCHash,
+							Description: "List of access management tags",
+						},
 					},
 				},
 			},
@@ -192,7 +207,19 @@ func dataSourceIBMVPNGatewaysRead(d *schema.ResourceData, meta interface{}) erro
 		gateway[isVPNGatewayResourceGroup] = *data.ResourceGroup.ID
 		gateway[isVPNGatewaySubnet] = *data.Subnet.ID
 		gateway[isVPNGatewayCrn] = *data.CRN
+		tags, err := flex.GetGlobalTagsUsingCRN(meta, *data.CRN, "", isUserTagType)
+		if err != nil {
+			log.Printf(
+				"Error on get of resource vpc VPN Gateway (%s) tags: %s", d.Id(), err)
+		}
+		gateway[isVPNGatewayTags] = tags
 
+		accesstags, err := flex.GetGlobalTagsUsingCRN(meta, *data.CRN, "", isAccessTagType)
+		if err != nil {
+			log.Printf(
+				"Error on get of resource VPC VPN Gateway (%s) access tags: %s", d.Id(), err)
+		}
+		gateway[isVPNGatewayAccessTags] = accesstags
 		if data.Members != nil {
 			vpcMembersIpsList := make([]map[string]interface{}, 0)
 			for _, memberIP := range data.Members {

--- a/ibm/service/vpc/resource_ibm_is_floating_ip.go
+++ b/ibm/service/vpc/resource_ibm_is_floating_ip.go
@@ -34,6 +34,8 @@ const (
 	isFloatingIPAvailable = "available"
 	isFloatingIPDeleting  = "deleting"
 	isFloatingIPDeleted   = "done"
+
+	isFloatingIPAccessTags = "access_tags"
 )
 
 func ResourceIBMISFloatingIP() *schema.Resource {
@@ -54,6 +56,11 @@ func ResourceIBMISFloatingIP() *schema.Resource {
 			customdiff.Sequence(
 				func(_ context.Context, diff *schema.ResourceDiff, v interface{}) error {
 					return flex.ResourceTagsCustomizeDiff(diff)
+				},
+			),
+			customdiff.Sequence(
+				func(_ context.Context, diff *schema.ResourceDiff, v interface{}) error {
+					return flex.ResourceValidateAccessTags(diff, v)
 				},
 			),
 			customdiff.Sequence(
@@ -219,6 +226,15 @@ func ResourceIBMISFloatingIP() *schema.Resource {
 				Description: "Floating IP tags",
 			},
 
+			isFloatingIPAccessTags: {
+				Type:        schema.TypeSet,
+				Optional:    true,
+				Computed:    true,
+				Elem:        &schema.Schema{Type: schema.TypeString, ValidateFunc: validate.InvokeValidator("ibm_is_floating_ip", "accesstag")},
+				Set:         flex.ResourceIBMVPCHash,
+				Description: "List of access management tags",
+			},
+
 			flex.ResourceControllerURL: {
 				Type:        schema.TypeString,
 				Computed:    true,
@@ -282,6 +298,16 @@ func ResourceIBMISFloatingIPValidator() *validate.ResourceValidator {
 			Type:                       validate.TypeString,
 			Optional:                   true,
 			Regexp:                     `^[A-Za-z0-9:_ .-]+$`,
+			MinValueLength:             1,
+			MaxValueLength:             128})
+
+	validateSchema = append(validateSchema,
+		validate.ValidateSchema{
+			Identifier:                 "accesstag",
+			ValidateFunctionIdentifier: validate.ValidateRegexpLen,
+			Type:                       validate.TypeString,
+			Optional:                   true,
+			Regexp:                     `^([A-Za-z0-9_.-]|[A-Za-z0-9_.-][A-Za-z0-9_ .-]*[A-Za-z0-9_.-]):([A-Za-z0-9_.-]|[A-Za-z0-9_.-][A-Za-z0-9_ .-]*[A-Za-z0-9_.-])$`,
 			MinValueLength:             1,
 			MaxValueLength:             128})
 
@@ -352,10 +378,19 @@ func fipCreate(d *schema.ResourceData, meta interface{}, name string) error {
 	v := os.Getenv("IC_ENV_TAGS")
 	if _, ok := d.GetOk(isFloatingIPTags); ok || v != "" {
 		oldList, newList := d.GetChange(isFloatingIPTags)
-		err = flex.UpdateTagsUsingCRN(oldList, newList, meta, *floatingip.CRN)
+		err = flex.UpdateGlobalTagsUsingCRN(oldList, newList, meta, *floatingip.CRN, "", isUserTagType)
 		if err != nil {
 			log.Printf(
 				"Error on create of vpc Floating IP (%s) tags: %s", d.Id(), err)
+		}
+	}
+
+	if _, ok := d.GetOk(isFloatingIPAccessTags); ok {
+		oldList, newList := d.GetChange(isFloatingIPAccessTags)
+		err = flex.UpdateGlobalTagsUsingCRN(oldList, newList, meta, *floatingip.CRN, "", isAccessTagType)
+		if err != nil {
+			log.Printf(
+				"Error on create of resource Floating IP (%s) access tags: %s", d.Id(), err)
 		}
 	}
 	return nil
@@ -401,12 +436,21 @@ func fipGet(d *schema.ResourceData, meta interface{}, id string) error {
 	targetList := make([]map[string]interface{}, 0)
 	targetList = append(targetList, targetMap)
 	d.Set(floatingIPTargets, targetList)
-	tags, err := flex.GetTagsUsingCRN(meta, *floatingip.CRN)
+	tags, err := flex.GetGlobalTagsUsingCRN(meta, *floatingip.CRN, "", isUserTagType)
 	if err != nil {
 		log.Printf(
 			"Error on get of vpc Floating IP (%s) tags: %s", d.Id(), err)
 	}
 	d.Set(isFloatingIPTags, tags)
+
+	accesstags, err := flex.GetGlobalTagsUsingCRN(meta, *floatingip.CRN, "", isAccessTagType)
+	if err != nil {
+		log.Printf(
+			"Error on get of resource Floating IP (%s) access tags: %s", d.Id(), err)
+	}
+
+	d.Set(isFloatingIPAccessTags, accesstags)
+
 	controller, err := flex.GetBaseController(meta)
 	if err != nil {
 		return err
@@ -437,6 +481,7 @@ func fipUpdate(d *schema.ResourceData, meta interface{}, id string) error {
 	if err != nil {
 		return err
 	}
+
 	if d.HasChange(isFloatingIPTags) {
 		options := &vpcv1.GetFloatingIPOptions{
 			ID: &id,
@@ -445,13 +490,31 @@ func fipUpdate(d *schema.ResourceData, meta interface{}, id string) error {
 		if err != nil {
 			return fmt.Errorf("[ERROR] Error getting Floating IP: %s\n%s", err, response)
 		}
+
 		oldList, newList := d.GetChange(isFloatingIPTags)
-		err = flex.UpdateTagsUsingCRN(oldList, newList, meta, *fip.CRN)
+		err = flex.UpdateGlobalTagsUsingCRN(oldList, newList, meta, *fip.CRN, "", isUserTagType)
 		if err != nil {
 			log.Printf(
 				"Error on update of vpc Floating IP (%s) tags: %s", id, err)
 		}
 	}
+	if d.HasChange(isFloatingIPAccessTags) {
+		options := &vpcv1.GetFloatingIPOptions{
+			ID: &id,
+		}
+		fip, response, err := sess.GetFloatingIP(options)
+		if err != nil {
+			return fmt.Errorf("[ERROR] Error getting Floating IP: %s\n%s", err, response)
+		}
+
+		oldList, newList := d.GetChange(isFloatingIPAccessTags)
+		err = flex.UpdateGlobalTagsUsingCRN(oldList, newList, meta, *fip.CRN, "", isAccessTagType)
+		if err != nil {
+			log.Printf(
+				"Error on update of resource Floating IP (%s) access tags: %s", d.Id(), err)
+		}
+	}
+
 	hasChanged := false
 	options := &vpcv1.UpdateFloatingIPOptions{
 		ID: &id,

--- a/ibm/service/vpc/resource_ibm_is_lb.go
+++ b/ibm/service/vpc/resource_ibm_is_lb.go
@@ -42,6 +42,8 @@ const (
 	isLBLogging                 = "logging"
 	isLBSecurityGroups          = "security_groups"
 	isLBSecurityGroupsSupported = "security_group_supported"
+
+	isLBAccessTags = "access_tags"
 )
 
 func ResourceIBMISLB() *schema.Resource {
@@ -68,6 +70,10 @@ func ResourceIBMISLB() *schema.Resource {
 			customdiff.Sequence(
 				func(_ context.Context, diff *schema.ResourceDiff, v interface{}) error {
 					return flex.ResourceRouteModeValidate(diff)
+				}),
+			customdiff.Sequence(
+				func(_ context.Context, diff *schema.ResourceDiff, v interface{}) error {
+					return flex.ResourceValidateAccessTags(diff, v)
 				}),
 		),
 
@@ -196,6 +202,15 @@ func ResourceIBMISLB() *schema.Resource {
 				Set:      flex.ResourceIBMVPCHash,
 			},
 
+			isLBAccessTags: {
+				Type:        schema.TypeSet,
+				Optional:    true,
+				Computed:    true,
+				Elem:        &schema.Schema{Type: schema.TypeString, ValidateFunc: validate.InvokeValidator("ibm_is_lb", "accesstag")},
+				Set:         flex.ResourceIBMVPCHash,
+				Description: "List of access management tags",
+			},
+
 			isLBResourceGroup: {
 				Type:     schema.TypeString,
 				ForceNew: true,
@@ -292,6 +307,16 @@ func ResourceIBMISLBValidator() *validate.ResourceValidator {
 			Type:                       validate.TypeString,
 			Optional:                   true,
 			Regexp:                     `^[A-Za-z0-9:_ .-]+$`,
+			MinValueLength:             1,
+			MaxValueLength:             128})
+
+	validateSchema = append(validateSchema,
+		validate.ValidateSchema{
+			Identifier:                 "accesstag",
+			ValidateFunctionIdentifier: validate.ValidateRegexpLen,
+			Type:                       validate.TypeString,
+			Optional:                   true,
+			Regexp:                     `^([A-Za-z0-9_.-]|[A-Za-z0-9_.-][A-Za-z0-9_ .-]*[A-Za-z0-9_.-]):([A-Za-z0-9_.-]|[A-Za-z0-9_.-][A-Za-z0-9_ .-]*[A-Za-z0-9_.-])$`,
 			MinValueLength:             1,
 			MaxValueLength:             128})
 
@@ -411,10 +436,19 @@ func lbCreate(d *schema.ResourceData, meta interface{}, name, lbType, rg string,
 	v := os.Getenv("IC_ENV_TAGS")
 	if _, ok := d.GetOk(isLBTags); ok || v != "" {
 		oldList, newList := d.GetChange(isLBTags)
-		err = flex.UpdateTagsUsingCRN(oldList, newList, meta, *lb.CRN)
+		err = flex.UpdateGlobalTagsUsingCRN(oldList, newList, meta, *lb.CRN, "", isUserTagType)
 		if err != nil {
 			log.Printf(
 				"Error on create of resource vpc Load Balancer (%s) tags: %s", d.Id(), err)
+		}
+	}
+
+	if _, ok := d.GetOk(isLBAccessTags); ok {
+		oldList, newList := d.GetChange(isLBAccessTags)
+		err = flex.UpdateGlobalTagsUsingCRN(oldList, newList, meta, *lb.CRN, "", isAccessTagType)
+		if err != nil {
+			log.Printf(
+				"Error on create of resource load balancer (%s) access tags: %s", d.Id(), err)
 		}
 	}
 	return nil
@@ -539,12 +573,18 @@ func lbGet(d *schema.ResourceData, meta interface{}, id string) error {
 	if lb.UDPSupported != nil {
 		d.Set(isLBUdpSupported, *lb.UDPSupported)
 	}
-	tags, err := flex.GetTagsUsingCRN(meta, *lb.CRN)
+	tags, err := flex.GetGlobalTagsUsingCRN(meta, *lb.CRN, "", isUserTagType)
 	if err != nil {
 		log.Printf(
 			"Error on get of resource vpc Load Balancer (%s) tags: %s", d.Id(), err)
 	}
 	d.Set(isLBTags, tags)
+	accesstags, err := flex.GetGlobalTagsUsingCRN(meta, *lb.CRN, "", isAccessTagType)
+	if err != nil {
+		log.Printf(
+			"Error on get of resource load balancer (%s) access tags: %s", d.Id(), err)
+	}
+	d.Set(isLBAccessTags, accesstags)
 	controller, err := flex.GetBaseController(meta)
 	if err != nil {
 		return err
@@ -600,7 +640,7 @@ func lbUpdate(d *schema.ResourceData, meta interface{}, id, name string, hasChan
 	if err != nil {
 		return err
 	}
-	if d.HasChange(isLBTags) {
+	if d.HasChange(isLBTags) || d.HasChange(isLBAccessTags) {
 		getLoadBalancerOptions := &vpcv1.GetLoadBalancerOptions{
 			ID: &id,
 		}
@@ -608,11 +648,21 @@ func lbUpdate(d *schema.ResourceData, meta interface{}, id, name string, hasChan
 		if err != nil {
 			return fmt.Errorf("[ERROR] Error getting Load Balancer : %s\n%s", err, response)
 		}
-		oldList, newList := d.GetChange(isLBTags)
-		err = flex.UpdateTagsUsingCRN(oldList, newList, meta, *lb.CRN)
-		if err != nil {
-			log.Printf(
-				"Error on update of resource vpc Load Balancer (%s) tags: %s", d.Id(), err)
+		if d.HasChange(isLBTags) {
+			oldList, newList := d.GetChange(isLBTags)
+			err = flex.UpdateGlobalTagsUsingCRN(oldList, newList, meta, *lb.CRN, "", isUserTagType)
+			if err != nil {
+				log.Printf(
+					"Error on update of resource vpc Load Balancer (%s) tags: %s", d.Id(), err)
+			}
+		}
+		if d.HasChange(isLBAccessTags) {
+			oldList, newList := d.GetChange(isLBAccessTags)
+			err := flex.UpdateGlobalTagsUsingCRN(oldList, newList, meta, *lb.CRN, "", isAccessTagType)
+			if err != nil {
+				log.Printf(
+					"Error on update of resource load balancer (%s) access tags: %s", d.Id(), err)
+			}
 		}
 	}
 

--- a/ibm/service/vpc/resource_ibm_is_networkacls.go
+++ b/ibm/service/vpc/resource_ibm_is_networkacls.go
@@ -44,6 +44,7 @@ const (
 	isNetworkACLVPC               = "vpc"
 	isNetworkACLResourceGroup     = "resource_group"
 	isNetworkACLTags              = "tags"
+	isNetworkACLAccessTags        = "access_tags"
 	isNetworkACLCRN               = "crn"
 )
 
@@ -61,10 +62,16 @@ func ResourceIBMISNetworkACL() *schema.Resource {
 			Delete: schema.DefaultTimeout(10 * time.Minute),
 		},
 
-		CustomizeDiff: customdiff.Sequence(
-			func(_ context.Context, diff *schema.ResourceDiff, v interface{}) error {
-				return flex.ResourceTagsCustomizeDiff(diff)
-			},
+		CustomizeDiff: customdiff.All(
+			customdiff.Sequence(
+				func(_ context.Context, diff *schema.ResourceDiff, v interface{}) error {
+					return flex.ResourceTagsCustomizeDiff(diff)
+				},
+			),
+			customdiff.Sequence(
+				func(_ context.Context, diff *schema.ResourceDiff, v interface{}) error {
+					return flex.ResourceValidateAccessTags(diff, v)
+				}),
 		),
 
 		Schema: map[string]*schema.Schema{
@@ -95,6 +102,15 @@ func ResourceIBMISNetworkACL() *schema.Resource {
 				Elem:        &schema.Schema{Type: schema.TypeString, ValidateFunc: validate.InvokeValidator("ibm_is_network_acl", "tags")},
 				Set:         flex.ResourceIBMVPCHash,
 				Description: "List of tags",
+			},
+
+			isNetworkACLAccessTags: {
+				Type:        schema.TypeSet,
+				Optional:    true,
+				Computed:    true,
+				Elem:        &schema.Schema{Type: schema.TypeString, ValidateFunc: validate.InvokeValidator("ibm_is_network_acl", "accesstag")},
+				Set:         flex.ResourceIBMVPCHash,
+				Description: "List of access management tags",
 			},
 
 			isNetworkACLCRN: {
@@ -371,6 +387,15 @@ func ResourceIBMISNetworkACLValidator() *validate.ResourceValidator {
 			Regexp:                     `^[A-Za-z0-9:_ .-]+$`,
 			MinValueLength:             1,
 			MaxValueLength:             128})
+	validateSchema = append(validateSchema,
+		validate.ValidateSchema{
+			Identifier:                 "accesstag",
+			ValidateFunctionIdentifier: validate.ValidateRegexpLen,
+			Type:                       validate.TypeString,
+			Optional:                   true,
+			Regexp:                     `^([A-Za-z0-9_.-]|[A-Za-z0-9_.-][A-Za-z0-9_ .-]*[A-Za-z0-9_.-]):([A-Za-z0-9_.-]|[A-Za-z0-9_.-][A-Za-z0-9_ .-]*[A-Za-z0-9_.-])$`,
+			MinValueLength:             1,
+			MaxValueLength:             128})
 
 	ibmISNetworkACLResourceValidator := validate.ResourceValidator{ResourceName: "ibm_is_network_acl", Schema: validateSchema}
 	return &ibmISNetworkACLResourceValidator
@@ -447,10 +472,18 @@ func nwaclCreate(d *schema.ResourceData, meta interface{}, name string) error {
 	v := os.Getenv("IC_ENV_TAGS")
 	if _, ok := d.GetOk(isNetworkACLTags); ok || v != "" {
 		oldList, newList := d.GetChange(isNetworkACLTags)
-		err = flex.UpdateTagsUsingCRN(oldList, newList, meta, *nwacl.CRN)
+		err = flex.UpdateGlobalTagsUsingCRN(oldList, newList, meta, *nwacl.CRN, "", isUserTagType)
 		if err != nil {
 			log.Printf(
 				"Error on create of resource network acl (%s) tags: %s", d.Id(), err)
+		}
+	}
+	if _, ok := d.GetOk(isNetworkACLAccessTags); ok {
+		oldList, newList := d.GetChange(isNetworkACLAccessTags)
+		err = flex.UpdateGlobalTagsUsingCRN(oldList, newList, meta, *nwacl.CRN, "", isAccessTagType)
+		if err != nil {
+			log.Printf(
+				"Error on create of resource network acl (%s) access tags: %s", d.Id(), err)
 		}
 	}
 	return nil
@@ -487,12 +520,20 @@ func nwaclGet(d *schema.ResourceData, meta interface{}, id string) error {
 		d.Set(isNetworkACLResourceGroup, *nwacl.ResourceGroup.ID)
 		d.Set(flex.ResourceGroupName, *nwacl.ResourceGroup.Name)
 	}
-	tags, err := flex.GetTagsUsingCRN(meta, *nwacl.CRN)
+	tags, err := flex.GetGlobalTagsUsingCRN(meta, *nwacl.CRN, "", isUserTagType)
 	if err != nil {
 		log.Printf(
 			"Error on get of resource network acl (%s) tags: %s", d.Id(), err)
 	}
+
+	accesstags, err := flex.GetGlobalTagsUsingCRN(meta, *nwacl.CRN, "", isAccessTagType)
+	if err != nil {
+		log.Printf(
+			"Error on get of resource network acl (%s) access tags: %s", d.Id(), err)
+	}
+
 	d.Set(isNetworkACLTags, tags)
+	d.Set(isNetworkACLAccessTags, accesstags)
 	d.Set(isNetworkACLCRN, *nwacl.CRN)
 	rules := make([]interface{}, 0)
 	if len(nwacl.Rules) > 0 {
@@ -628,10 +669,18 @@ func nwaclUpdate(d *schema.ResourceData, meta interface{}, id, name string, hasC
 	}
 	if d.HasChange(isNetworkACLTags) {
 		oldList, newList := d.GetChange(isNetworkACLTags)
-		err = flex.UpdateTagsUsingCRN(oldList, newList, meta, d.Get(isNetworkACLCRN).(string))
+		err := flex.UpdateGlobalTagsUsingCRN(oldList, newList, meta, d.Get(isNetworkACLCRN).(string), "", isUserTagType)
 		if err != nil {
 			log.Printf(
 				"Error on update of resource network acl (%s) tags: %s", d.Id(), err)
+		}
+	}
+	if d.HasChange(isNetworkACLAccessTags) {
+		oldList, newList := d.GetChange(isNetworkACLAccessTags)
+		err := flex.UpdateGlobalTagsUsingCRN(oldList, newList, meta, d.Get(isNetworkACLCRN).(string), "", isAccessTagType)
+		if err != nil {
+			log.Printf(
+				"Error on update of resource network acl (%s) access tags: %s", d.Id(), err)
 		}
 	}
 	if d.HasChange(isNetworkACLRules) {

--- a/ibm/service/vpc/resource_ibm_is_virtual_endpoint_gateway.go
+++ b/ibm/service/vpc/resource_ibm_is_virtual_endpoint_gateway.go
@@ -40,6 +40,7 @@ const (
 	isVirtualEndpointGatewayVpcID              = "vpc"
 	isVirtualEndpointGatewayTags               = "tags"
 	isVirtualEndpointGatewaySecurityGroups     = "security_groups"
+	isVirtualEndpointGatewayAccessTags         = "access_tags"
 )
 
 func ResourceIBMISEndpointGateway() *schema.Resource {
@@ -53,10 +54,16 @@ func ResourceIBMISEndpointGateway() *schema.Resource {
 		Exists:   resourceIBMisVirtualEndpointGatewayExists,
 		Importer: &schema.ResourceImporter{},
 
-		CustomizeDiff: customdiff.Sequence(
-			func(_ context.Context, diff *schema.ResourceDiff, v interface{}) error {
-				return flex.ResourceTagsCustomizeDiff(diff)
-			},
+		CustomizeDiff: customdiff.All(
+			customdiff.Sequence(
+				func(_ context.Context, diff *schema.ResourceDiff, v interface{}) error {
+					return flex.ResourceTagsCustomizeDiff(diff)
+				},
+			),
+			customdiff.Sequence(
+				func(_ context.Context, diff *schema.ResourceDiff, v interface{}) error {
+					return flex.ResourceValidateAccessTags(diff, v)
+				}),
 		),
 
 		Timeouts: &schema.ResourceTimeout{
@@ -202,6 +209,14 @@ func ResourceIBMISEndpointGateway() *schema.Resource {
 				Set:         flex.ResourceIBMVPCHash,
 				Description: "List of tags for VPE",
 			},
+			isVirtualEndpointGatewayAccessTags: {
+				Type:        schema.TypeSet,
+				Optional:    true,
+				Computed:    true,
+				Elem:        &schema.Schema{Type: schema.TypeString, ValidateFunc: validate.InvokeValidator("ibm_is_virtual_endpoint_gateway", "accesstag")},
+				Set:         flex.ResourceIBMVPCHash,
+				Description: "List of access management tags",
+			},
 		},
 	}
 }
@@ -233,6 +248,16 @@ func ResourceIBMISEndpointGatewayValidator() *validate.ResourceValidator {
 			Type:                       validate.TypeString,
 			Required:                   true,
 			AllowedValues:              "provider_cloud_service, provider_infrastructure_service"})
+
+	validateSchema = append(validateSchema,
+		validate.ValidateSchema{
+			Identifier:                 "accesstag",
+			ValidateFunctionIdentifier: validate.ValidateRegexpLen,
+			Type:                       validate.TypeString,
+			Optional:                   true,
+			Regexp:                     `^([A-Za-z0-9_.-]|[A-Za-z0-9_.-][A-Za-z0-9_ .-]*[A-Za-z0-9_.-]):([A-Za-z0-9_.-]|[A-Za-z0-9_.-][A-Za-z0-9_ .-]*[A-Za-z0-9_.-])$`,
+			MinValueLength:             1,
+			MaxValueLength:             128})
 
 	ibmEndpointGatewayResourceValidator := validate.ResourceValidator{ResourceName: "ibm_is_virtual_endpoint_gateway", Schema: validateSchema}
 	return &ibmEndpointGatewayResourceValidator
@@ -300,22 +325,32 @@ func resourceIBMisVirtualEndpointGatewayCreate(d *schema.ResourceData, meta inte
 		opt.SetResourceGroup(resourceGroupOpt)
 
 	}
-	result, response, err := sess.CreateEndpointGateway(opt)
+	endpointGateway, response, err := sess.CreateEndpointGateway(opt)
 	if err != nil {
 		log.Printf("Create Endpoint Gateway failed: %v", response)
 		return fmt.Errorf("Create Endpoint Gateway failed %s\n%s", err, response)
 	}
 
-	d.SetId(*result.ID)
+	d.SetId(*endpointGateway.ID)
 	v := os.Getenv("IC_ENV_TAGS")
 	if _, ok := d.GetOk(isVirtualEndpointGatewayTags); ok || v != "" {
 		oldList, newList := d.GetChange(isVirtualEndpointGatewayTags)
-		err = flex.UpdateTagsUsingCRN(oldList, newList, meta, *result.CRN)
+		err = flex.UpdateGlobalTagsUsingCRN(oldList, newList, meta, *endpointGateway.CRN, "", isUserTagType)
 		if err != nil {
 			log.Printf(
 				"Error on create of VPE (%s) tags: %s", d.Id(), err)
 		}
 	}
+
+	if _, ok := d.GetOk(isVirtualEndpointGatewayAccessTags); ok {
+		oldList, newList := d.GetChange(isVirtualEndpointGatewayAccessTags)
+		err = flex.UpdateGlobalTagsUsingCRN(oldList, newList, meta, *endpointGateway.CRN, "", isAccessTagType)
+		if err != nil {
+			log.Printf(
+				"Error on create of VPE (%s) access tags: %s", d.Id(), err)
+		}
+	}
+
 	return resourceIBMisVirtualEndpointGatewayRead(d, meta)
 }
 
@@ -389,17 +424,28 @@ func resourceIBMisVirtualEndpointGatewayUpdate(d *schema.ResourceData, meta inte
 		}
 
 	}
-	if d.HasChange(isVirtualEndpointGatewayTags) {
+	if d.HasChange(isVirtualEndpointGatewayTags) || d.HasChange(isVirtualEndpointGatewayAccessTags) {
 		opt := sess.NewGetEndpointGatewayOptions(d.Id())
-		result, response, err := sess.GetEndpointGateway(opt)
+		endpointGateway, response, err := sess.GetEndpointGateway(opt)
 		if err != nil {
 			return fmt.Errorf("[ERROR] Error getting VPE: %s\n%s", err, response)
 		}
-		oldList, newList := d.GetChange(isVirtualEndpointGatewayTags)
-		err = flex.UpdateTagsUsingCRN(oldList, newList, meta, *result.CRN)
-		if err != nil {
-			log.Printf(
-				"Error on update of VPE (%s) tags: %s", d.Id(), err)
+		if d.HasChange(isVirtualEndpointGatewayTags) {
+			oldList, newList := d.GetChange(isVirtualEndpointGatewayTags)
+			err := flex.UpdateGlobalTagsUsingCRN(oldList, newList, meta, *endpointGateway.CRN, "", isUserTagType)
+			if err != nil {
+				log.Printf(
+					"Error on update of VPE (%s) tags: %s", d.Id(), err)
+			}
+		}
+
+		if d.HasChange(isVirtualEndpointGatewayAccessTags) {
+			oldList, newList := d.GetChange(isVirtualEndpointGatewayAccessTags)
+			err := flex.UpdateGlobalTagsUsingCRN(oldList, newList, meta, *endpointGateway.CRN, "", isAccessTagType)
+			if err != nil {
+				log.Printf(
+					"Error on update of VPE (%s) access tags: %s", d.Id(), err)
+			}
 		}
 	}
 	return resourceIBMisVirtualEndpointGatewayRead(d, meta)
@@ -412,7 +458,7 @@ func resourceIBMisVirtualEndpointGatewayRead(d *schema.ResourceData, meta interf
 	}
 	// read option
 	opt := sess.NewGetEndpointGatewayOptions(d.Id())
-	result, response, err := sess.GetEndpointGateway(opt)
+	endpointGateway, response, err := sess.GetEndpointGateway(opt)
 	if err != nil {
 		if response != nil && response.StatusCode == 404 {
 			d.SetId("")
@@ -421,26 +467,34 @@ func resourceIBMisVirtualEndpointGatewayRead(d *schema.ResourceData, meta interf
 		log.Printf("Get Endpoint Gateway failed: %v", response)
 		return fmt.Errorf("Get Endpoint Gateway failed %s\n%s", err, response)
 	}
-	d.Set(isVirtualEndpointGatewayName, result.Name)
-	d.Set(isVirtualEndpointGatewayHealthState, result.HealthState)
-	d.Set(isVirtualEndpointGatewayCreatedAt, result.CreatedAt.String())
-	d.Set(isVirtualEndpointGatewayLifecycleState, result.LifecycleState)
-	d.Set(isVirtualEndpointGatewayResourceType, result.ResourceType)
-	d.Set(isVirtualEndpointGatewayCRN, result.CRN)
-	d.Set(isVirtualEndpointGatewayIPs, flattenIPs(result.Ips))
-	d.Set(isVirtualEndpointGatewayResourceGroupID, result.ResourceGroup.ID)
+	d.Set(isVirtualEndpointGatewayName, endpointGateway.Name)
+	d.Set(isVirtualEndpointGatewayHealthState, endpointGateway.HealthState)
+	d.Set(isVirtualEndpointGatewayCreatedAt, endpointGateway.CreatedAt.String())
+	d.Set(isVirtualEndpointGatewayLifecycleState, endpointGateway.LifecycleState)
+	d.Set(isVirtualEndpointGatewayResourceType, endpointGateway.ResourceType)
+	d.Set(isVirtualEndpointGatewayCRN, endpointGateway.CRN)
+	d.Set(isVirtualEndpointGatewayIPs, flattenIPs(endpointGateway.Ips))
+	d.Set(isVirtualEndpointGatewayResourceGroupID, endpointGateway.ResourceGroup.ID)
 	d.Set(isVirtualEndpointGatewayTarget,
-		flattenEndpointGatewayTarget(result.Target.(*vpcv1.EndpointGatewayTarget)))
-	d.Set(isVirtualEndpointGatewayVpcID, result.VPC.ID)
-	if result.SecurityGroups != nil {
-		d.Set(isVirtualEndpointGatewaySecurityGroups, flattenDataSourceSecurityGroups(result.SecurityGroups))
+		flattenEndpointGatewayTarget(endpointGateway.Target.(*vpcv1.EndpointGatewayTarget)))
+	d.Set(isVirtualEndpointGatewayVpcID, endpointGateway.VPC.ID)
+	if endpointGateway.SecurityGroups != nil {
+		d.Set(isVirtualEndpointGatewaySecurityGroups, flattenDataSourceSecurityGroups(endpointGateway.SecurityGroups))
 	}
-	tags, err := flex.GetTagsUsingCRN(meta, *result.CRN)
+	tags, err := flex.GetGlobalTagsUsingCRN(meta, *endpointGateway.CRN, "", isUserTagType)
 	if err != nil {
 		log.Printf(
 			"Error on get of VPE (%s) tags: %s", d.Id(), err)
 	}
 	d.Set(isVirtualEndpointGatewayTags, tags)
+
+	accesstags, err := flex.GetGlobalTagsUsingCRN(meta, *endpointGateway.CRN, "", isAccessTagType)
+	if err != nil {
+		log.Printf(
+			"Error on get of VPE (%s) access tags: %s", d.Id(), err)
+	}
+	d.Set(isVirtualEndpointGatewayAccessTags, accesstags)
+
 	return nil
 }
 

--- a/ibm/service/vpc/resource_ibm_is_vpn_gateway.go
+++ b/ibm/service/vpc/resource_ibm_is_vpn_gateway.go
@@ -36,6 +36,7 @@ const (
 	isVPNGatewayPublicIPAddress2  = "public_ip_address2"
 	isVPNGatewayPrivateIPAddress  = "private_ip_address"
 	isVPNGatewayPrivateIPAddress2 = "private_ip_address2"
+	isVPNGatewayAccessTags        = "access_tags"
 )
 
 func ResourceIBMISVPNGateway() *schema.Resource {
@@ -52,10 +53,16 @@ func ResourceIBMISVPNGateway() *schema.Resource {
 			Delete: schema.DefaultTimeout(10 * time.Minute),
 		},
 
-		CustomizeDiff: customdiff.Sequence(
-			func(_ context.Context, diff *schema.ResourceDiff, v interface{}) error {
-				return flex.ResourceTagsCustomizeDiff(diff)
-			},
+		CustomizeDiff: customdiff.All(
+			customdiff.Sequence(
+				func(_ context.Context, diff *schema.ResourceDiff, v interface{}) error {
+					return flex.ResourceTagsCustomizeDiff(diff)
+				},
+			),
+			customdiff.Sequence(
+				func(_ context.Context, diff *schema.ResourceDiff, v interface{}) error {
+					return flex.ResourceValidateAccessTags(diff, v)
+				}),
 		),
 
 		Schema: map[string]*schema.Schema{
@@ -120,6 +127,15 @@ func ResourceIBMISVPNGateway() *schema.Resource {
 				Elem:        &schema.Schema{Type: schema.TypeString, ValidateFunc: validate.InvokeValidator("ibm_is_vpn_gateway", "tags")},
 				Set:         flex.ResourceIBMVPCHash,
 				Description: "VPN Gateway tags list",
+			},
+
+			isVPNGatewayAccessTags: {
+				Type:        schema.TypeSet,
+				Optional:    true,
+				Computed:    true,
+				Elem:        &schema.Schema{Type: schema.TypeString, ValidateFunc: validate.InvokeValidator("ibm_is_vpn_gateway", "accesstag")},
+				Set:         flex.ResourceIBMVPCHash,
+				Description: "List of access management tags",
 			},
 
 			flex.ResourceControllerURL: {
@@ -281,6 +297,16 @@ func ResourceIBMISVPNGatewayValidator() *validate.ResourceValidator {
 			MinValueLength:             1,
 			MaxValueLength:             128})
 
+	validateSchema = append(validateSchema,
+		validate.ValidateSchema{
+			Identifier:                 "accesstag",
+			ValidateFunctionIdentifier: validate.ValidateRegexpLen,
+			Type:                       validate.TypeString,
+			Optional:                   true,
+			Regexp:                     `^([A-Za-z0-9_.-]|[A-Za-z0-9_.-][A-Za-z0-9_ .-]*[A-Za-z0-9_.-]):([A-Za-z0-9_.-]|[A-Za-z0-9_.-][A-Za-z0-9_ .-]*[A-Za-z0-9_.-])$`,
+			MinValueLength:             1,
+			MaxValueLength:             128})
+
 	ibmISVPNGatewayResourceValidator := validate.ResourceValidator{ResourceName: "ibm_is_vpn_gateway", Schema: validateSchema}
 	return &ibmISVPNGatewayResourceValidator
 }
@@ -339,12 +365,22 @@ func vpngwCreate(d *schema.ResourceData, meta interface{}, name, subnetID, mode 
 	v := os.Getenv("IC_ENV_TAGS")
 	if _, ok := d.GetOk(isVPNGatewayTags); ok || v != "" {
 		oldList, newList := d.GetChange(isVPNGatewayTags)
-		err = flex.UpdateTagsUsingCRN(oldList, newList, meta, *vpnGateway.CRN)
+		err = flex.UpdateGlobalTagsUsingCRN(oldList, newList, meta, *vpnGateway.CRN, "", isUserTagType)
 		if err != nil {
 			log.Printf(
 				"Error on create of resource vpc VPN Gateway (%s) tags: %s", d.Id(), err)
 		}
 	}
+
+	if _, ok := d.GetOk(isVPNGatewayAccessTags); ok {
+		oldList, newList := d.GetChange(isVPNGatewayAccessTags)
+		err = flex.UpdateGlobalTagsUsingCRN(oldList, newList, meta, *vpnGateway.CRN, "", isAccessTagType)
+		if err != nil {
+			log.Printf(
+				"Error on create of resource VPN Gateway (%s) access tags: %s", d.Id(), err)
+		}
+	}
+
 	return nil
 }
 
@@ -430,12 +466,20 @@ func vpngwGet(d *schema.ResourceData, meta interface{}, id string) error {
 		}
 
 	}
-	tags, err := flex.GetTagsUsingCRN(meta, *vpnGateway.CRN)
+	tags, err := flex.GetGlobalTagsUsingCRN(meta, *vpnGateway.CRN, "", isUserTagType)
 	if err != nil {
 		log.Printf(
 			"Error on get of resource vpc VPN Gateway (%s) tags: %s", d.Id(), err)
 	}
 	d.Set(isVPNGatewayTags, tags)
+
+	accesstags, err := flex.GetGlobalTagsUsingCRN(meta, *vpnGateway.CRN, "", isAccessTagType)
+	if err != nil {
+		log.Printf(
+			"Error on get of resource VPC VPN Gateway (%s) access tags: %s", d.Id(), err)
+	}
+	d.Set(isVPNGatewayAccessTags, accesstags)
+
 	controller, err := flex.GetBaseController(meta)
 	if err != nil {
 		return err
@@ -513,10 +557,27 @@ func vpngwUpdate(d *schema.ResourceData, meta interface{}, id, name string, hasC
 		vpnGateway := vpnGatewayIntf.(*vpcv1.VPNGateway)
 
 		oldList, newList := d.GetChange(isVPNGatewayTags)
-		err = flex.UpdateTagsUsingCRN(oldList, newList, meta, *vpnGateway.CRN)
+		err = flex.UpdateGlobalTagsUsingCRN(oldList, newList, meta, *vpnGateway.CRN, "", isUserTagType)
 		if err != nil {
 			log.Printf(
 				"Error on update of resource vpc Vpn Gateway (%s) tags: %s", id, err)
+		}
+	}
+	if d.HasChange(isVPNGatewayAccessTags) {
+		getVpnGatewayOptions := &vpcv1.GetVPNGatewayOptions{
+			ID: &id,
+		}
+		vpnGatewayIntf, response, err := sess.GetVPNGateway(getVpnGatewayOptions)
+		if err != nil {
+			return fmt.Errorf("[ERROR] Error getting Volume : %s\n%s", err, response)
+		}
+		vpnGateway := vpnGatewayIntf.(*vpcv1.VPNGateway)
+
+		oldList, newList := d.GetChange(isVPNGatewayAccessTags)
+		err = flex.UpdateGlobalTagsUsingCRN(oldList, newList, meta, *vpnGateway.CRN, "", isAccessTagType)
+		if err != nil {
+			log.Printf(
+				"Error on update of resource VPC VPN Gateway  (%s) access tags: %s", d.Id(), err)
 		}
 	}
 	if hasChanged {

--- a/website/docs/d/is_floating_ip.html.markdown
+++ b/website/docs/d/is_floating_ip.html.markdown
@@ -36,6 +36,7 @@ Review the argument references that you can specify for your data source.
 ## Attribute reference
 In addition to the argument reference list, you can access the following attribute references after your data source is created. 
 
+- `access_tags`  - (String) Access management tags associated for the floating ip.
 - `address` - (String) The floating IP address that is created.
 - `crn` - (String) The CRN for this floating IP.
 - `id` - (String) The unique identifier of the floating IP.

--- a/website/docs/d/is_floating_ips.html.markdown
+++ b/website/docs/d/is_floating_ips.html.markdown
@@ -43,6 +43,7 @@ In addition to all argument references listed, you can access the following attr
 - `floating_ips` - (List) Collection of floating IPs.
   
     Nested scheme for **floating_ips**:
+	- `access_tags`  - (String) Access management tags associated for the floating ip.
     - `address` - (String) The globally unique IP address.
     - `created_at` - (String) The date and time that the floating IP was created.
     - `crn` - (String) The CRN for this floating IP.

--- a/website/docs/d/is_flow_log.html.markdown
+++ b/website/docs/d/is_flow_log.html.markdown
@@ -43,6 +43,7 @@ Review the argument reference that you can specify for your data source.
 In addition to all argument references listed, you can access the following attribute references after your data source is created.
 
 - `identifier` - The unique identifier of the FlowLogCollector.
+- `access_tags` - (String) Access management tags associated for flow log.
 - `active` - (Boolean) Indicates whether this collector is active.
 - `auto_delete` - (Boolean) If set to `true`, this flow log collector will be automatically deleted when the target is deleted.
 - `created_at` - (String) The date and time that the flow log collector was created.

--- a/website/docs/d/is_flow_logs.html.markdown
+++ b/website/docs/d/is_flow_logs.html.markdown
@@ -36,6 +36,7 @@ Review the attribute references that you can access after you retrieve your data
 - `flow_log_collectors` - (List) Lists all the flow logs in the IBM Cloud.
 
   Nested scheme for `flow_log_collectors`:
+    - `access_tags` - (String) Access management tags associated for flow log.
 	- `active` - (String) Indicates whether the collector is active.
 	- `created_at` - (Timestamp) The date and time the flow log created.
 	- `crn` - (String) The CRN of the flow log collector.

--- a/website/docs/d/is_lb.html.markdown
+++ b/website/docs/d/is_lb.html.markdown
@@ -52,6 +52,7 @@ Review the argument references that you can specify for your data source.
 ## Attribute reference
 In addition to all argument reference list, you can access the following attribute references after your data source is created. 
 
+- `access_tags`  - (String) Access management tags associated for the load balancer.
 - `crn` - (String) The CRN for this load balancer.
 - `hostname` - (String) Fully qualified domain name assigned to this load balancer.
 - `id` - (String) The ID of the load balancer.

--- a/website/docs/d/is_lbs.html.markdown
+++ b/website/docs/d/is_lbs.html.markdown
@@ -34,6 +34,7 @@ Review the attribute references that you can access after you retrieve your data
 - `load_balancers` - (List) The Collection of load balancers.
 
   Nested scheme for `load_balancers`:
+  	- `access_tags`  - (String) Access management tags associated for the load balancer.
 	- `id` - (String) The unique identifier of the load balancer.
 	- `created_at` - (String) The date and time this load balancer was created.
 	- `crn` - (String) The load balancer's CRN.

--- a/website/docs/d/is_public_gateway.html.markdown
+++ b/website/docs/d/is_public_gateway.html.markdown
@@ -48,6 +48,7 @@ Review the argument references that you can specify for your data source.
 ## Attribute reference
 In addition to all argument reference list, you can access the following attribute references after your data source is created. 
 
+- `access_tags`  - (List) Access management tags associated for the public gateway.
 - `crn` - (String) The CRN for this public gateway.
 - `floating_ip` - (List) List of the nested block describes the floating IP of the gateway with the **id** and **address** details.
 	

--- a/website/docs/d/is_public_gateways.html.markdown
+++ b/website/docs/d/is_public_gateways.html.markdown
@@ -34,6 +34,7 @@ Review the attribute references that you can access after you retrieve your data
 - `public_gateways` - (List) List of all Public Gateways in the IBM Cloud infrastructure region.
 
   Nested scheme for `public_gateways`:
+  - `access_tags`  - (List) Access management tags associated for the public gateway.
   - `crn` - (String) The CRN for this public gateway.
   - `id` - (String) The ID of the public gateway.
   - `status` - (String) The status of the public gateway.

--- a/website/docs/d/is_security_group.html.markdown
+++ b/website/docs/d/is_security_group.html.markdown
@@ -82,6 +82,7 @@ Review the argument references that you can specify for your resource.
 ## Attribute reference
 In addition to all argument reference list, you can access the following attribute references after your data source is created. 
 
+- `access_tags`  - (List) Access management tags associated for the security group.
 - `crn` - The CRN of the security group.
 - `id` - (String) The ID of the security group.
 - `rules` - (List of Objects) The rules associated with security group. Each rule has following attributes.

--- a/website/docs/d/is_security_groups.html.markdown
+++ b/website/docs/d/is_security_groups.html.markdown
@@ -63,6 +63,7 @@ In addition to all argument references listed, you can access the following attr
 - `resource_group` -  Filters the collection to resources in the resource group with the specified identifier
 - `security_groups` - (List) Collection of security groups.
 	Nested scheme for `security_groups`:
+	- `access_tags`  - (List) Access management tags associated for the security group.
 	- `created_at` - (String) The date and time that this security group was created.
 	- `crn` - (String) The security group's CRN.
 	- `href` - (String) The security group's canonical URL.

--- a/website/docs/d/is_virtual_endpoint_gateway.html.markdown
+++ b/website/docs/d/is_virtual_endpoint_gateway.html.markdown
@@ -36,6 +36,7 @@ Review the argument references that you can specify for your data source.
 ## Attribute reference
 In addition to the argument reference list, you can access the following attribute references after your data source is created. 
 
+- `access_tags`  - (List) Access management tags associated for the virtual endpoint gateway.
 - `created_at` - (Timestamp) The created date and time of the endpoint gateway.
 - `crn` - (String) The CRN for this endpoint gateway.
 - `health_state` - (String) Endpoint gateway health state. `ok: Healthy`, `degraded: Suffering from compromised performance, capacity, or connectivity`, `faulted: Completely unreachable, inoperative, or entirely incapacitated`, `inapplicable: The health state does not apply because of the current lifecycle state`. A resource with a lifecycle state of failed or deleting will have a health state of inapplicable. A pending resource may have this state.

--- a/website/docs/d/is_virtual_endpoint_gateways.html.markdown
+++ b/website/docs/d/is_virtual_endpoint_gateways.html.markdown
@@ -33,6 +33,7 @@ In addition to the argument reference list, you can access the following attribu
 - `virtual_endpoint_gateways` - (List) List of Endpoint Gateways in the IBM Cloud infrastructure region.
   
   Nested scheme for `virtual_endpoint_gateways`:
+  - `access_tags`  - (List) Access management tags associated for the virtual endpoint gateway.
   - `created_at` - (Timestamp) The created date and time of the endpoint gateway.
   - `crn` - (String) The CRN for this endpoint gateway.
   - `health_state` - (String) The endpoint gateway health state. **ok: Healthy**, **degraded: Suffering from compromised performance, capacity, or connectivity**, **faulted: Completely unreachable, inoperative, or entirely incapacitated**, **inapplicable: The health state does not apply because of the current lifecycle state**. A resource with a lifecycle state of failed or deleting will have a health state of inapplicable. A pending resource may have this state.

--- a/website/docs/d/is_vpn_gateway.html.markdown
+++ b/website/docs/d/is_vpn_gateway.html.markdown
@@ -35,6 +35,7 @@ Review the argument reference that you can specify for your data source.
 In addition to all argument references listed, you can access the following attribute references after your data source is created.
 
 - `id` - The unique identifier of the is_vpn_gateway.
+- `access_tags`  - (List) Access management tags associated for the vpn gateway.
 - `connections` - (List) Connections for this VPN gateway.
   Nested scheme for **connections**:
 	- `deleted` - (List) If present, this property indicates the referenced resource has been deleted and provides some supplementary information.
@@ -89,6 +90,7 @@ In addition to all argument references listed, you can access the following attr
 	- `href` - (String) The URL for this subnet.
 	- `id` - (String) The unique identifier for this subnet.
 	- `name` - (String) The user-defined name for this subnet.
+- `tags`- (Optional, Array of Strings) A list of tags associated with the instance.
 - `vpc` - (String) The VPC this VPN server resides in.
   Nested scheme for `vpc`:
   - `crn` - (String) The CRN for this VPC.

--- a/website/docs/d/is_vpn_gateways.html.markdown
+++ b/website/docs/d/is_vpn_gateways.html.markdown
@@ -35,6 +35,7 @@ In addition to all argument reference list, you can access the following attribu
 - `vpn_gateways` - (List) Collection of VPN Gateways.
 
   Nested scheme for `vpn_gateways`:
+  - `access_tags`  - (List) Access management tags associated for the vpn gateway.
   - `crn` - (String) The VPN gateway's CRN.
   - `created_at`- (Timestamp) The date and time the VPN gateway was created.
   - `id` - (String) The ID of the VPN gateway.
@@ -56,6 +57,7 @@ In addition to all argument reference list, you can access the following attribu
   - `resource_type` - (String) The resource type, supported value is `vpn_gateway`.
   - `status` - (String) The status of the VPN gateway, supported values are **available**, **deleting**, **failed**, **pending**.
   - `subnet` - (String) The VPN gateway subnet information.
+  - `tags`- (Optional, Array of Strings) A list of tags associated with the instance.
   - `vpc` - (String) 	The VPC this VPN server resides in.
     `Nested scheme for `vpc`:
     - `crn` - (String) The CRN for this VPC.
@@ -67,4 +69,3 @@ In addition to all argument reference list, you can access the following attribu
     - `name` - (String) - The unique user-defined name for this VPC.
   - `resource_group` - (String) The resource group ID.
   - `mode` - (String) The VPN gateway mode, supported values are `policy` and `route`.
-

--- a/website/docs/r/is_floating_ip.html.markdown
+++ b/website/docs/r/is_floating_ip.html.markdown
@@ -57,6 +57,13 @@ The `ibm_is_instance` provides the following [Timeouts](https://www.terraform.io
 ## Argument reference
 Review the argument references that you can specify for your resource. 
 
+- `access_tags`  - (Optional, List of Strings) A list of access management tags to attach to the floating ip.
+
+  ~> **Note:** 
+  **&#x2022;** You can attach only those access tags that already exists.</br>
+  **&#x2022;** For more information, about creating access tags, see [working with tags](https://cloud.ibm.com/docs/account?topic=account-tag&interface=ui#create-access-console).</br>
+  **&#x2022;** You must have the access listed in the [Granting users access to tag resources](https://cloud.ibm.com/docs/account?topic=account-access) for `access_tags`</br>
+  **&#x2022;** `access_tags` must be in the format `key:value`.
 - `name` - (Required, String) Enter a name for the floating IP address. 
 - `resource_group` - (Optional, String) The resource group ID where you want to create the floating IP.
 - `target` - (Optional, String) Enter the ID of the network interface that you want to use to allocate the IP address. If you specify this option, do not specify `zone` at the same time. 

--- a/website/docs/r/is_flow_log.html.markdown
+++ b/website/docs/r/is_flow_log.html.markdown
@@ -74,6 +74,13 @@ resource "ibm_is_flow_log" "example" {
 ## Argument reference
 Review the argument references that you can specify for your resource. 
 
+- `access_tags`  - (Optional, List of Strings) A list of access management tags to attach to the flow log.
+
+  ~> **Note:** 
+  **&#x2022;** You can attach only those access tags that already exists.</br>
+  **&#x2022;** For more information, about creating access tags, see [working with tags](https://cloud.ibm.com/docs/account?topic=account-tag&interface=ui#create-access-console).</br>
+  **&#x2022;** You must have the access listed in the [Granting users access to tag resources](https://cloud.ibm.com/docs/account?topic=account-access) for `access_tags`</br>
+  **&#x2022;** `access_tags` must be in the format `key:value`.
 - `name` - (Required, String) The unique user-defined name for the flow log collector.No.
 - `target` - (Required, Forces new resource, String) The ID of the target to collect flow logs. If the target is an instance, subnet, or VPC, flow logs is not collected for any network interfaces within the target that are more specific flow log collector.
 - `storage_bucket` - (Required, Forces new resource, String) The name of the IBM Cloud Object Storage bucket where the collected flows will be logged. The bucket must exist and an IAM service authorization must grant IBM Cloud flow logs resources of VPC infrastructure services writer access to the bucket.

--- a/website/docs/r/is_lb.html.markdown
+++ b/website/docs/r/is_lb.html.markdown
@@ -54,6 +54,13 @@ The `ibm_is_lb` resource provides the following [Timeouts](https://www.terraform
 ## Argument reference
 Review the argument references that you can specify for your resource. 
 
+- `access_tags`  - (Optional, List of Strings) A list of access management tags to attach to the load balancer.
+
+  ~> **Note:** 
+  **&#x2022;** You can attach only those access tags that already exists.</br>
+  **&#x2022;** For more information, about creating access tags, see [working with tags](https://cloud.ibm.com/docs/account?topic=account-tag&interface=ui#create-access-console).</br>
+  **&#x2022;** You must have the access listed in the [Granting users access to tag resources](https://cloud.ibm.com/docs/account?topic=account-access) for `access_tags`</br>
+  **&#x2022;** `access_tags` must be in the format `key:value`.
 - `logging`- (Optional, Bool) Enable or disable datapath logging for the load balancer. This is applicable only for application load balancer. Supported values are **true** or **false**. Default value is **false**.
 - `name` - (Required, String) The name of the VPC load balancer.
 - `profile` - (Optional, Forces new resource, String) For a Network Load Balancer, this attribute is required and should be set to `network-fixed`. For Application Load Balancer, profile is not a required attribute.

--- a/website/docs/r/is_network_acl.html.markdown
+++ b/website/docs/r/is_network_acl.html.markdown
@@ -59,6 +59,13 @@ resource "ibm_is_network_acl" "example" {
 ## Argument reference
 Review the argument references that you can specify for your resource. 
  
+- `access_tags`  - (Optional, List of Strings) A list of access management tags to attach to the network acl.
+
+  ~> **Note:** 
+  **&#x2022;** You can attach only those access tags that already exists.</br>
+  **&#x2022;** For more information, about creating access tags, see [working with tags](https://cloud.ibm.com/docs/account?topic=account-tag&interface=ui#create-access-console).</br>
+  **&#x2022;** You must have the access listed in the [Granting users access to tag resources](https://cloud.ibm.com/docs/account?topic=account-access) for `access_tags`</br>
+  **&#x2022;** `access_tags` must be in the format `key:value`.
 - `name` - (Required, String) The name of the network ACL.
 - `resource_group` - (Optional, Forces new resource, String) The ID of the resource group where you want to create the network ACL.
 - `rules`- (Optional, Array of Strings) A list of rules for a network ACL. The order in which the rules are added to the list determines the priority of the rules. For example, the first rule that you want to enforce must be specified as the first rule in this list.

--- a/website/docs/r/is_public_gateway.html.markdown
+++ b/website/docs/r/is_public_gateway.html.markdown
@@ -51,6 +51,13 @@ The `ibm_is_public_gateway` resource provides the following [Timeouts](https://w
 ## Argument reference
 Review the argument references that you can specify for your resource. 
 
+- `access_tags`  - (Optional, List of Strings) A list of access management tags to attach to the public gatewayr.
+
+  ~> **Note:** 
+  **&#x2022;** You can attach only those access tags that already exists.</br>
+  **&#x2022;** For more information, about creating access tags, see [working with tags](https://cloud.ibm.com/docs/account?topic=account-tag&interface=ui#create-access-console).</br>
+  **&#x2022;** You must have the access listed in the [Granting users access to tag resources](https://cloud.ibm.com/docs/account?topic=account-access) for `access_tags`</br>
+  **&#x2022;** `access_tags` must be in the format `key:value`.
 - `floating_ip` - (Optional, List) A list of floating IP addresses that you want to assign to the public gateway.
 	- `id` - (Optional, String) The unique identifier of the floating IP address. If you specify this parameter, do not specify `address` at the same time. 
 	- `address` - (Optional, String) The floating IP address. If you specify this parameter, do not specify `id` at the same time.

--- a/website/docs/r/is_security_group.html.markdown
+++ b/website/docs/r/is_security_group.html.markdown
@@ -38,6 +38,13 @@ resource "ibm_is_security_group" "example" {
 ## Argument reference
 Review the argument references that you can specify for your resource. 
 
+- `access_tags`  - (Optional, List of Strings) A list of access management tags to attach to the security group.
+
+  ~> **Note:** 
+  **&#x2022;** You can attach only those access tags that already exists.</br>
+  **&#x2022;** For more information, about creating access tags, see [working with tags](https://cloud.ibm.com/docs/account?topic=account-tag&interface=ui#create-access-console).</br>
+  **&#x2022;** You must have the access listed in the [Granting users access to tag resources](https://cloud.ibm.com/docs/account?topic=account-access) for `access_tags`</br>
+  **&#x2022;** `access_tags` must be in the format `key:value`.
 - `name` - (Optional, String) The security group name.
 - `resource_group` - (Optional, String) The resource group ID where the security group to be created.
 - `tags`- (Optional, List of Strings) The tags associated with an instance.

--- a/website/docs/r/is_virtual_endpoint_gateway.html.markdown
+++ b/website/docs/r/is_virtual_endpoint_gateway.html.markdown
@@ -81,7 +81,13 @@ resource "ibm_is_virtual_endpoint_gateway" "example4" {
 
 ## Argument reference
 Review the argument references that you can specify for your resource. 
+- `access_tags`  - (Optional, List of Strings) A list of access management tags to attach to the virtual endpoint gateway.
 
+  ~> **Note:** 
+  **&#x2022;** You can attach only those access tags that already exists.</br>
+  **&#x2022;** For more information, about creating access tags, see [working with tags](https://cloud.ibm.com/docs/account?topic=account-tag&interface=ui#create-access-console).</br>
+  **&#x2022;** You must have the access listed in the [Granting users access to tag resources](https://cloud.ibm.com/docs/account?topic=account-access) for `access_tags`</br>
+  **&#x2022;** `access_tags` must be in the format `key:value`.
 - `name` - (Required, Forces new resource, String) The endpoint gateway name.
 - `ips`  (Optional, List) The endpoint gateway resource group.
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/IBM-Cloud/terraform-provider-ibm/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
Our team has internally reviewed the PR and test Results are available here : https://github.com/ibm-vpc/terraform-provider-ibm/pull/110
```
make testacc TEST=./ibm/service/vpc TESTARGS='-run=TestAccIBMISVPNGateway_basic'
make testacc TEST=./ibm/service/vpc TESTARGS='-run=TestAccIBMISVirtualEndpointGateway_Basic'
make testacc TEST=./ibm/service/vpc TESTARGS='-run=TestAccIBMISSecurityGroup_basic'
make testacc TEST=./ibm/service/vpc TESTARGS='TestAccIBMISPublicGateway_basic'
```
<img width="632" alt="Screenshot 2022-11-17 at 2 07 43 PM" src="https://user-images.githubusercontent.com/78336632/202397330-e4859a42-aaf7-4fa5-b3e0-7094623c3167.png">
<img width="739" alt="Screenshot 2022-11-17 at 2 10 46 PM" src="https://user-images.githubusercontent.com/78336632/202397970-8ccd374e-407c-4739-83d6-40d6ea30a0a7.png">
<img width="684" alt="Screenshot 2022-11-17 at 2 13 13 PM" src="https://user-images.githubusercontent.com/78336632/202398644-b90033c7-457f-4254-8da7-80f61dd467c3.png">

```
resource "ibm_is_vpc" "testacc_vpc" {
  name = "sunitha-vpc"
}

resource "ibm_is_subnet" "testacc_subnet" {
  name            = "subnet-vpc"
  vpc             = ibm_is_vpc.testacc_vpc.id
  zone            = "us-south-1"
  ipv4_cidr_block = "10.240.0.0/24"
}
resource "ibm_is_lb" "testacc_LB" {
  name        = "load-balancer"
  subnets     = [ibm_is_subnet.testacc_subnet.id]
  access_tags = ["tfp:ussouth", "tfp:eude"]
}
data "ibm_is_lb" "ds_lb" {
  name = ibm_is_lb.testacc_LB.name
}
data "ibm_is_lbs" "test_lbs" {
}
```
<img width="836" alt="Screenshot 2022-10-19 at 6 51 31 PM" src="https://user-images.githubusercontent.com/78336632/196702872-a73a977a-cd6f-4ed2-a543-01b29c73bd23.png">
<img width="877" alt="Screenshot 2022-10-19 at 6 51 44 PM" src="https://user-images.githubusercontent.com/78336632/196702962-0fa625c8-4be9-4341-8277-610ea26f6261.png">
<img width="900" alt="Screenshot 2022-10-19 at 6 52 03 PM" src="https://user-images.githubusercontent.com/78336632/196703030-899302e7-395a-405a-b85c-b0d716c37301.png">


```
resource "ibm_is_vpc" "testacc_vpc" {
  name = "sunitha-vpc"
}

resource "ibm_is_subnet" "testacc_subnet" {
  name            = "subnet-vpc"
  vpc             = ibm_is_vpc.testacc_vpc.id
  zone            = "us-south-1"
  ipv4_cidr_block = "10.240.0.0/24"
}
resource "ibm_is_vpn_gateway" "testacc_vpnGateway" {
  name   = "vpn-gateway"
  subnet = ibm_is_subnet.testacc_subnet.id
  mode   = "policy"
  access_tags = ["tfp:ussouth", "tfp:eude"]
}

data "ibm_is_vpn_gateway" "example" {
  vpn_gateway = ibm_is_vpn_gateway.testacc_vpnGateway.id
}

data "ibm_is_vpn_gateways" "test1" {
depends_on = [ibm_is_vpn_gateway.testacc_vpnGateway]
}
```
<img width="1057" alt="Screenshot 2022-10-19 at 7 47 56 PM" src="https://user-images.githubusercontent.com/78336632/196717177-c67d046b-8a03-410d-b7d7-dd9862930a0c.png">

<img width="995" alt="Screenshot 2022-10-19 at 7 47 24 PM" src="https://user-images.githubusercontent.com/78336632/196717033-edcfac0a-aa87-4d7b-8fc4-b2d857bbbe0f.png">
<img width="1048" alt="Screenshot 2022-10-19 at 7 47 39 PM" src="https://user-images.githubusercontent.com/78336632/196717107-349c8966-d431-4b12-97a9-a6b3e73d9417.png">

```

resource "ibm_is_vpc" "testacc_vpc" {
  name = "sunitha-vpc"
}

resource "ibm_is_subnet" "testacc_subnet" {
  name            = "subnet-vpc"
  vpc             = ibm_is_vpc.testacc_vpc.id
  zone            = "us-south-1"
  ipv4_cidr_block = "10.240.0.0/24"
}

resource "ibm_is_virtual_endpoint_gateway" "endpoint_gateway" {
  name = "virtual-endpoint-gateway"
  target {
    name          = "ibm-dns-server2"
    resource_type = "provider_infrastructure_service"
  }
  vpc         = ibm_is_vpc.testacc_vpc.id
  access_tags = ["tfp:ussouth", "tfp:eude"]
}
data "ibm_is_virtual_endpoint_gateways" "test1" {
  depends_on = [ibm_is_virtual_endpoint_gateway.endpoint_gateway]
}

data "ibm_is_virtual_endpoint_gateway" "data_test" {
  name       = ibm_is_virtual_endpoint_gateway.endpoint_gateway.name
  depends_on = [ibm_is_virtual_endpoint_gateway.endpoint_gateway]
}
```
<img width="1081" alt="Screenshot 2022-10-19 at 8 35 21 PM" src="https://user-images.githubusercontent.com/78336632/196729565-a308880c-a773-468d-825d-86162f4d82e4.png">
<img width="1004" alt="Screenshot 2022-10-19 at 8 35 33 PM" src="https://user-images.githubusercontent.com/78336632/196729617-18a59c74-7317-4b31-9adc-687cd11b3f6d.png">
<img width="797" alt="Screenshot 2022-10-19 at 8 35 47 PM" src="https://user-images.githubusercontent.com/78336632/196729699-39472d70-bcde-4ef8-8f55-78833fdc1ae3.png">

```
resource "ibm_is_vpc" "testacc_vpc" {
  name = "sunitha-vpc"
}

resource "ibm_is_security_group" "testacc_security_group" {
  name        = "security-group-sunitha"
  vpc         = ibm_is_vpc.testacc_vpc.id
  tags        = ["Tag1", "tag2"]
  access_tags = ["tfp:ussouth", "tfp:eude"]
}

data "ibm_is_security_group" "sg1_rule" {
  name = ibm_is_security_group.testacc_security_group.name
}

data "ibm_is_security_groups" "example" {
}
```

<img width="671" alt="Screenshot 2022-10-25 at 9 27 12 AM" src="https://user-images.githubusercontent.com/78336632/197679608-b08e2889-d316-4ddf-8d95-2ac74b1f86c7.png">

<img width="760" alt="Screenshot 2022-10-25 at 9 31 24 AM" src="https://user-images.githubusercontent.com/78336632/197679617-11fa0392-c1f5-479c-8e0d-bcc84c2df733.png">

```
resource "ibm_is_vpc" "testacc_vpc" {
  name = "sunitha-vpc"
}

resource "ibm_is_public_gateway" "testacc_public_gateway" {
  name = "sunitha-public-gateway"
  vpc  = ibm_is_vpc.testacc_vpc.id
  zone = "us-south-1"
  access_tags = ["tfp:ussouth", "tfp:eude"]
}

data "ibm_is_public_gateway" "testacc_dspgw" {
  name = ibm_is_public_gateway.testacc_public_gateway.name
}
data "ibm_is_public_gateways" "test1" {
}
```

<img width="630" alt="Screenshot 2022-10-25 at 9 49 09 AM" src="https://user-images.githubusercontent.com/78336632/197681678-d0b26166-45a9-4eec-b829-0b26ba929179.png">

<img width="677" alt="Screenshot 2022-10-25 at 9 59 27 AM" src="https://user-images.githubusercontent.com/78336632/197682887-0fe9afca-f0b1-49a7-b93b-4bd3139b48af.png">


```
resource "ibm_is_vpc" "testacc_vpc" {
  name = "tf-nwacl-vpc"
}

resource "ibm_is_network_acl" "isExampleACL" {
  name = "is-example-acl"
  vpc  = ibm_is_vpc.testacc_vpc.id
  rules {
    name        = "outbound"
    action      = "allow"
    source      = "0.0.0.0/0"
    destination = "0.0.0.0/0"
    direction   = "outbound"
    icmp {
      code = 8
      type = 1
    }
    # Optionals :
    # port_max =
    # port_min =
  }
  rules {
    name        = "inbound"
    action      = "allow"
    source      = "0.0.0.0/0"
    destination = "0.0.0.0/0"
    direction   = "inbound"
    icmp {
      code = 8
      type = 1
    }
    # Optionals :
    # port_max =
    # port_min =
  }
  access_tags = ["tfp:ussouth", "tfp:eude"]
}
```

<img width="644" alt="Screenshot 2022-10-25 at 10 24 08 AM" src="https://user-images.githubusercontent.com/78336632/197686016-998c9a89-9d0d-4d09-afdd-c513dbfd85cc.png">

<img width="690" alt="Screenshot 2022-10-25 at 10 29 17 AM" src="https://user-images.githubusercontent.com/78336632/197686513-be829f76-a13d-4557-99c7-0a4fe150b5bf.png">

<img width="730" alt="Screenshot 2022-10-25 at 10 29 26 AM" src="https://user-images.githubusercontent.com/78336632/197686514-73c4b56d-f357-4276-9965-27e97c9b57a8.png">

```
resource "ibm_is_floating_ip" "testacc_fip" {
  name        = "sunitha-testing"
  zone        = "us-south-1"
  access_tags = ["tfp:ussouth", "tfp:eude"]
}

data "ibm_is_floating_ip" "test" {
  name = ibm_is_floating_ip.testacc_fip.name
}

data "ibm_is_floating_ips" "is_floating_ips" {
  name = ibm_is_floating_ip.testacc_fip.name
}
```
<img width="661" alt="Screenshot 2022-10-25 at 10 52 11 AM" src="https://user-images.githubusercontent.com/78336632/197689344-2513c11c-a1ba-4e3f-9d44-8f6cd6367cf1.png">

<img width="848" alt="Screenshot 2022-10-25 at 10 56 49 AM" src="https://user-images.githubusercontent.com/78336632/197689947-777080ae-3f02-4e77-b88d-cc69e4e69f35.png">

<img width="574" alt="Screenshot 2022-10-25 at 10 57 05 AM" src="https://user-images.githubusercontent.com/78336632/197689982-7a46c47c-5be3-44f4-8c19-76f1cf9757b3.png">

```
resource "ibm_resource_instance" "instance2" {
  name     = "sunitha-resource-instance"
  service  = "cloud-object-storage"
  plan     = "standard"
  location = "global"
}

resource "ibm_cos_bucket" "bucket2" {
  bucket_name          = "sunitha-cos-bucket"
  resource_instance_id = ibm_resource_instance.instance2.id
  region_location      = "us-south"
  storage_class        = "standard"
}

resource "ibm_is_flow_log" "test_flow_log" {
  name           = "sunitha-flow0log"
  target         = "0727_2ef72b3b-9eef-408d-b467-28224c828d9a"
  storage_bucket = ibm_cos_bucket.bucket2.bucket_name
  active         = true
  access_tags    = ["tfp:ussouth", "tfp:eude"]
}

data "ibm_is_flow_log" "is_flow_log_name" {
  name = ibm_is_flow_log.test_flow_log.name
}

data "ibm_is_flow_logs" "display_flow_logs" {
}
```

<img width="636" alt="Screenshot 2022-10-25 at 7 44 18 PM" src="https://user-images.githubusercontent.com/78336632/197799334-4fde6986-1a55-4dcc-adc4-fc69c47bc2b2.png">
<img width="654" alt="Screenshot 2022-10-25 at 7 48 44 PM" src="https://user-images.githubusercontent.com/78336632/197799351-bf88abfc-0e5b-4c04-9340-b8d317a8bf18.png">
<img width="628" alt="Screenshot 2022-10-25 at 7 49 53 PM" src="https://user-images.githubusercontent.com/78336632/197799359-133aeb75-b145-4b6b-b888-8cf6446e5847.png">


```
data "ibm_is_security_groups" "example" {
  vpc_name = "test-vpc-sunitha"
}
```

<img width="818" alt="Screenshot 2022-11-04 at 8 30 48 PM" src="https://user-images.githubusercontent.com/78336632/200007277-5bb45cbf-4fc9-493e-94cc-b4b437d46251.png">

```
data "ibm_is_public_gateways" "testacc_dspgws" {
  depends_on = [
    ibm_is_public_gateway.testacc_public_gateway
  ]
}
```
<img width="669" alt="Screenshot 2022-11-07 at 6 52 46 PM" src="https://user-images.githubusercontent.com/78336632/200321123-8bcc683b-c1c9-4f53-8a43-941a78109abf.png">