### PR TITLE
feat(Cloud Databases): Allow users to edit configuration on database creation

### DIFF
--- a/ibm/service/database/resource_ibm_database.go
+++ b/ibm/service/database/resource_ibm_database.go
@@ -1676,6 +1676,26 @@ func resourceIBMDatabaseInstanceCreate(context context.Context, d *schema.Resour
 		}
 	}
 
+	if config, ok := d.GetOk("configuration"); ok {
+		service := d.Get("service").(string)
+		if service == "databases-for-postgresql" || service == "databases-for-redis" || service == "databases-for-enterprisedb" {
+			var configuration interface{}
+			json.Unmarshal([]byte(config.(string)), &configuration)
+			configPayload := icdv4.ConfigurationReq{Configuration: configuration}
+			task, err := icdClient.Configurations().UpdateConfiguration(icdId, configPayload)
+			if err != nil {
+				return diag.FromErr(fmt.Errorf("[ERROR] Error updating database (%s) configuration: %s", icdId, err))
+			}
+			_, err = waitForDatabaseTaskComplete(task.Id, d, meta, d.Timeout(schema.TimeoutUpdate))
+			if err != nil {
+				return diag.FromErr(fmt.Errorf(
+					"[ERROR] Error waiting for database (%s) configuration update task to complete: %s", icdId, err))
+			}
+		} else {
+			return diag.FromErr(fmt.Errorf("[ERROR] given database type %s is not configurable", service))
+		}
+	}
+
 	return resourceIBMDatabaseInstanceRead(context, d, meta)
 }
 

--- a/ibm/service/database/resource_ibm_database.go
+++ b/ibm/service/database/resource_ibm_database.go
@@ -1232,6 +1232,12 @@ func resourceIBMDatabaseInstanceDiff(_ context.Context, diff *schema.ResourceDif
 		return fmt.Errorf("[ERROR] node_count, node_memory_allocation_mb, node_disk_allocation_mb, node_cpu_allocation_count only supported for postgresql, elasticsearch and cassandra")
 	}
 
+	_, configurationSet := diff.GetOk("configuration")
+
+	if (service != "databases-for-postgresql" && service != "databases-for-redis" && service != "databases-for-enterprisedb") && configurationSet {
+		return fmt.Errorf("[ERROR] configuration is not supported for %s", service)
+	}
+
 	return nil
 }
 

--- a/ibm/service/database/resource_ibm_database_postgresql_test.go
+++ b/ibm/service/database/resource_ibm_database_postgresql_test.go
@@ -589,6 +589,13 @@ func testAccCheckIBMDatabaseInstancePostgresBasic(databaseResourceGroup string, 
 			address     = "172.168.1.2/32"
 			description = "desc1"
 		}
+		configuration                = <<CONFIGURATION
+		{
+		  "wal_level": "logical",
+		  "max_replication_slots": 21,
+		  "max_wal_senders": 21
+		}
+		CONFIGURATION
 	}
 				`, databaseResourceGroup, name, acc.IcdDbRegion)
 }

--- a/ibm/service/database/resource_ibm_database_redis_test.go
+++ b/ibm/service/database/resource_ibm_database_redis_test.go
@@ -176,6 +176,11 @@ func testAccCheckIBMDatabaseInstanceRedisBasic(databaseResourceGroup string, nam
 		  address     = "172.168.1.2/32"
 		  description = "desc1"
 		}
+		configuration                = <<CONFIGURATION
+		{
+		  "maxmemory-policy": "allkeys-lru"
+		}
+		CONFIGURATION
 	  }
 				`, databaseResourceGroup, name, acc.IcdDbRegion)
 }


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/IBM-Cloud/terraform-provider-ibm/blob/master/.github/CONTRIBUTING.md --->

Users cannot edit their database configuration on database creation. This PR allows users to do so.

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TEST=./ibm/service/database TESTARGS='-run=TestAccIBMDatabaseInstancePostgresBasic'
--- PASS: TestAccIBMDatabaseInstancePostgresBasic
PASS
ok  	github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/database
```
```
$  make testacc TEST=./ibm/service/database TESTARGS='-run=TestAccIBMDatabaseInstanceMongodbBasic'
--- PASS: TestAccIBMDatabaseInstanceMongodbBasic (1138.88s)
PASS
ok      github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/database        1139.922s
```
```
make testacc TEST=./ibm/service/database TESTARGS='-run=TestAccIBMDatabaseInstance_Redis_Basic'
--- PASS: TestAccIBMDatabaseInstance_Redis_Basic (790.05s)
PASS
ok      github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/database        791.109s
```