### PR TITLE
fix: mark resource group name as computed

### DIFF
--- a/ibm/service/resourcemanager/resource_ibm_resource_group.go
+++ b/ibm/service/resourcemanager/resource_ibm_resource_group.go
@@ -26,6 +26,7 @@ func ResourceIBMResourceGroup() *schema.Resource {
 				Type:        schema.TypeString,
 				Required:    true,
 				Description: "The name of the resource group",
+				Computed:    true,
 			},
 			"default": {
 				Description: "Specifies whether its default resource group or not",


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/IBM-Cloud/terraform-provider-ibm/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #4170

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```
