### PR TITLE
Rename Artifactory param & description updates

### DIFF
--- a/ibm/service/cdtoolchain/data_source_ibm_cd_toolchain_tool_appconfig.go
+++ b/ibm/service/cdtoolchain/data_source_ibm_cd_toolchain_tool_appconfig.go
@@ -94,12 +94,12 @@ func DataSourceIBMCdToolchainToolAppconfig() *schema.Resource {
 						"location": &schema.Schema{
 							Type:        schema.TypeString,
 							Computed:    true,
-							Description: "The IBM Cloud location where the App Configuration service instance resides.",
+							Description: "The IBM Cloud location where the App Configuration service instance is located.",
 						},
 						"resource_group_name": &schema.Schema{
 							Type:        schema.TypeString,
 							Computed:    true,
-							Description: "The name of the resource group where the App Configuration service instance resides.",
+							Description: "The name of the resource group where the App Configuration service instance is located.",
 						},
 						"instance_id": &schema.Schema{
 							Type:        schema.TypeString,

--- a/ibm/service/cdtoolchain/data_source_ibm_cd_toolchain_tool_artifactory.go
+++ b/ibm/service/cdtoolchain/data_source_ibm_cd_toolchain_tool_artifactory.go
@@ -106,6 +106,12 @@ func DataSourceIBMCdToolchainToolArtifactory() *schema.Resource {
 							Computed:    true,
 							Description: "The User ID or email for your Artifactory repository.",
 						},
+						"token": &schema.Schema{
+							Type:        schema.TypeString,
+							Computed:    true,
+							Sensitive:   true,
+							Description: "The Identity Token or API key for your Artifactory repository. You can use a toolchain secret reference for this parameter. For more information, see [Protecting your sensitive data in Continuous Delivery](https://cloud.ibm.com/docs/ContinuousDelivery?topic=ContinuousDelivery-cd_data_security#cd_secure_credentials).",
+						},
 						"release_url": &schema.Schema{
 							Type:        schema.TypeString,
 							Computed:    true,
@@ -130,12 +136,6 @@ func DataSourceIBMCdToolchainToolArtifactory() *schema.Resource {
 							Type:        schema.TypeString,
 							Computed:    true,
 							Description: "The URL of your Artifactory repository where your docker images are located.",
-						},
-						"api_key": &schema.Schema{
-							Type:        schema.TypeString,
-							Computed:    true,
-							Sensitive:   true,
-							Description: "The Artifactory API key for your Artifactory repository. You can use a toolchain secret reference for this parameter. For more information, see [Protecting your sensitive data in Continuous Delivery](https://cloud.ibm.com/docs/ContinuousDelivery?topic=ContinuousDelivery-cd_data_security#cd_secure_credentials).",
 						},
 					},
 				},
@@ -210,10 +210,7 @@ func dataSourceIBMCdToolchainToolArtifactoryRead(context context.Context, d *sch
 
 	parameters := []map[string]interface{}{}
 	if toolchainTool.Parameters != nil {
-		remapFields := map[string]string{
-			"api_key": "token",
-		}
-		modelMap := GetParametersFromRead(toolchainTool.Parameters, DataSourceIBMCdToolchainToolArtifactory(), remapFields)
+		modelMap := GetParametersFromRead(toolchainTool.Parameters, DataSourceIBMCdToolchainToolArtifactory(), nil)
 		parameters = append(parameters, modelMap)
 	}
 	if err = d.Set("parameters", parameters); err != nil {

--- a/ibm/service/cdtoolchain/data_source_ibm_cd_toolchain_tool_artifactory_test.go
+++ b/ibm/service/cdtoolchain/data_source_ibm_cd_toolchain_tool_artifactory_test.go
@@ -94,7 +94,7 @@ func testAccCheckIBMCdToolchainToolArtifactoryDataSourceConfigBasic(tcName strin
 				snapshot_url = "snapshot_url"
 				repository_name = "default-docker-local"
 				repository_url = "https://mycompany.example.jfrog.io/artifactory/default-docker-local"
-				api_key = "<api_key>"
+				token = "<token>"
 			}
 		}
 
@@ -128,7 +128,7 @@ func testAccCheckIBMCdToolchainToolArtifactoryDataSourceConfig(tcName string, rg
 				snapshot_url = "snapshot_url"
 				repository_name = "default-docker-local"
 				repository_url = "https://mycompany.example.jfrog.io/artifactory/default-docker-local"
-				api_key = "<api_key>"
+				token = "<token>"
 			}
 			name = "%s"
 		}

--- a/ibm/service/cdtoolchain/data_source_ibm_cd_toolchain_tool_keyprotect.go
+++ b/ibm/service/cdtoolchain/data_source_ibm_cd_toolchain_tool_keyprotect.go
@@ -99,12 +99,12 @@ func DataSourceIBMCdToolchainToolKeyprotect() *schema.Resource {
 						"location": &schema.Schema{
 							Type:        schema.TypeString,
 							Computed:    true,
-							Description: "The IBM Cloud location where the Key Protect service instance resides.",
+							Description: "The IBM Cloud location where the Key Protect service instance is located.",
 						},
 						"resource_group_name": &schema.Schema{
 							Type:        schema.TypeString,
 							Computed:    true,
-							Description: "The name of the resource group where the Key Protect service instance resides.",
+							Description: "The name of the resource group where the Key Protect service instance is located.",
 						},
 					},
 				},

--- a/ibm/service/cdtoolchain/data_source_ibm_cd_toolchain_tool_secretsmanager.go
+++ b/ibm/service/cdtoolchain/data_source_ibm_cd_toolchain_tool_secretsmanager.go
@@ -99,12 +99,12 @@ func DataSourceIBMCdToolchainToolSecretsmanager() *schema.Resource {
 						"location": &schema.Schema{
 							Type:        schema.TypeString,
 							Computed:    true,
-							Description: "The IBM Cloud location where the Secrets Manager service instance resides.",
+							Description: "The IBM Cloud location where the Secrets Manager service instance is located.",
 						},
 						"resource_group_name": &schema.Schema{
 							Type:        schema.TypeString,
 							Computed:    true,
-							Description: "The name of the resource group where the Secrets Manager service instance resides.",
+							Description: "The name of the resource group where the Secrets Manager service instance is located.",
 						},
 					},
 				},

--- a/ibm/service/cdtoolchain/resource_ibm_cd_toolchain_tool_appconfig.go
+++ b/ibm/service/cdtoolchain/resource_ibm_cd_toolchain_tool_appconfig.go
@@ -49,12 +49,12 @@ func ResourceIBMCdToolchainToolAppconfig() *schema.Resource {
 						"location": &schema.Schema{
 							Type:        schema.TypeString,
 							Required:    true,
-							Description: "The IBM Cloud location where the App Configuration service instance resides.",
+							Description: "The IBM Cloud location where the App Configuration service instance is located.",
 						},
 						"resource_group_name": &schema.Schema{
 							Type:        schema.TypeString,
 							Required:    true,
-							Description: "The name of the resource group where the App Configuration service instance resides.",
+							Description: "The name of the resource group where the App Configuration service instance is located.",
 						},
 						"instance_id": &schema.Schema{
 							Type:        schema.TypeString,

--- a/ibm/service/cdtoolchain/resource_ibm_cd_toolchain_tool_artifactory.go
+++ b/ibm/service/cdtoolchain/resource_ibm_cd_toolchain_tool_artifactory.go
@@ -61,6 +61,13 @@ func ResourceIBMCdToolchainToolArtifactory() *schema.Resource {
 							Optional:    true,
 							Description: "The User ID or email for your Artifactory repository.",
 						},
+						"token": &schema.Schema{
+							Type:             schema.TypeString,
+							Optional:         true,
+							DiffSuppressFunc: flex.SuppressHashedRawSecret,
+							Sensitive:        true,
+							Description:      "The Identity Token or API key for your Artifactory repository. You can use a toolchain secret reference for this parameter. For more information, see [Protecting your sensitive data in Continuous Delivery](https://cloud.ibm.com/docs/ContinuousDelivery?topic=ContinuousDelivery-cd_data_security#cd_secure_credentials).",
+						},
 						"release_url": &schema.Schema{
 							Type:        schema.TypeString,
 							Optional:    true,
@@ -85,13 +92,6 @@ func ResourceIBMCdToolchainToolArtifactory() *schema.Resource {
 							Type:        schema.TypeString,
 							Optional:    true,
 							Description: "The URL of your Artifactory repository where your docker images are located.",
-						},
-						"api_key": &schema.Schema{
-							Type:             schema.TypeString,
-							Optional:         true,
-							DiffSuppressFunc: flex.SuppressHashedRawSecret,
-							Sensitive:        true,
-							Description:      "The Artifactory API key for your Artifactory repository. You can use a toolchain secret reference for this parameter. For more information, see [Protecting your sensitive data in Continuous Delivery](https://cloud.ibm.com/docs/ContinuousDelivery?topic=ContinuousDelivery-cd_data_security#cd_secure_credentials).",
 						},
 					},
 				},
@@ -197,10 +197,7 @@ func resourceIBMCdToolchainToolArtifactoryCreate(context context.Context, d *sch
 
 	createToolOptions.SetToolchainID(d.Get("toolchain_id").(string))
 	createToolOptions.SetToolTypeID("artifactory")
-	remapFields := map[string]string{
-		"api_key": "token",
-	}
-	parametersModel := GetParametersForCreate(d, ResourceIBMCdToolchainToolArtifactory(), remapFields)
+	parametersModel := GetParametersForCreate(d, ResourceIBMCdToolchainToolArtifactory(), nil)
 	createToolOptions.SetParameters(parametersModel)
 	if _, ok := d.GetOk("name"); ok {
 		createToolOptions.SetName(d.Get("name").(string))
@@ -246,10 +243,7 @@ func resourceIBMCdToolchainToolArtifactoryRead(context context.Context, d *schem
 	if err = d.Set("toolchain_id", toolchainTool.ToolchainID); err != nil {
 		return diag.FromErr(fmt.Errorf("Error setting toolchain_id: %s", err))
 	}
-	remapFields := map[string]string{
-		"api_key": "token",
-	}
-	parametersMap := GetParametersFromRead(toolchainTool.Parameters, ResourceIBMCdToolchainToolArtifactory(), remapFields)
+	parametersMap := GetParametersFromRead(toolchainTool.Parameters, ResourceIBMCdToolchainToolArtifactory(), nil)
 	if err = d.Set("parameters", []map[string]interface{}{parametersMap}); err != nil {
 		return diag.FromErr(fmt.Errorf("Error setting parameters: %s", err))
 	}
@@ -312,10 +306,7 @@ func resourceIBMCdToolchainToolArtifactoryUpdate(context context.Context, d *sch
 			" The resource must be re-created to update this property.", "toolchain_id"))
 	}
 	if d.HasChange("parameters") {
-		remapFields := map[string]string{
-			"api_key": "token",
-		}
-		parameters := GetParametersForUpdate(d, ResourceIBMCdToolchainToolArtifactory(), remapFields)
+		parameters := GetParametersForUpdate(d, ResourceIBMCdToolchainToolArtifactory(), nil)
 		patchVals.Parameters = parameters
 		hasChange = true
 	}

--- a/ibm/service/cdtoolchain/resource_ibm_cd_toolchain_tool_artifactory_test.go
+++ b/ibm/service/cdtoolchain/resource_ibm_cd_toolchain_tool_artifactory_test.go
@@ -97,7 +97,7 @@ func testAccCheckIBMCdToolchainToolArtifactoryConfigBasic(tcName string, rgName 
 				snapshot_url = "snapshot_url"
 				repository_name = "default-docker-local"
 				repository_url = "https://mycompany.example.jfrog.io/artifactory/default-docker-local"
-				api_key = "<api_key>"
+				token = "<token>"
 			}
 		}
 	`, rgName, tcName)
@@ -126,7 +126,7 @@ func testAccCheckIBMCdToolchainToolArtifactoryConfig(tcName string, rgName strin
 				snapshot_url = "snapshot_url"
 				repository_name = "default-docker-local"
 				repository_url = "https://mycompany.example.jfrog.io/artifactory/default-docker-local"
-				api_key = "<api_key>"
+				token = "<token>"
 			}
 			name = "%s"
 		}

--- a/ibm/service/cdtoolchain/resource_ibm_cd_toolchain_tool_keyprotect.go
+++ b/ibm/service/cdtoolchain/resource_ibm_cd_toolchain_tool_keyprotect.go
@@ -54,12 +54,12 @@ func ResourceIBMCdToolchainToolKeyprotect() *schema.Resource {
 						"location": &schema.Schema{
 							Type:        schema.TypeString,
 							Required:    true,
-							Description: "The IBM Cloud location where the Key Protect service instance resides.",
+							Description: "The IBM Cloud location where the Key Protect service instance is located.",
 						},
 						"resource_group_name": &schema.Schema{
 							Type:        schema.TypeString,
 							Required:    true,
-							Description: "The name of the resource group where the Key Protect service instance resides.",
+							Description: "The name of the resource group where the Key Protect service instance is located.",
 						},
 					},
 				},

--- a/ibm/service/cdtoolchain/resource_ibm_cd_toolchain_tool_secretsmanager.go
+++ b/ibm/service/cdtoolchain/resource_ibm_cd_toolchain_tool_secretsmanager.go
@@ -54,12 +54,12 @@ func ResourceIBMCdToolchainToolSecretsmanager() *schema.Resource {
 						"location": &schema.Schema{
 							Type:        schema.TypeString,
 							Required:    true,
-							Description: "The IBM Cloud location where the Secrets Manager service instance resides.",
+							Description: "The IBM Cloud location where the Secrets Manager service instance is located.",
 						},
 						"resource_group_name": &schema.Schema{
 							Type:        schema.TypeString,
 							Required:    true,
-							Description: "The name of the resource group where the Secrets Manager service instance resides.",
+							Description: "The name of the resource group where the Secrets Manager service instance is located.",
 						},
 					},
 				},

--- a/website/docs/d/cd_toolchain_tool_appconfig.html.markdown
+++ b/website/docs/d/cd_toolchain_tool_appconfig.html.markdown
@@ -49,9 +49,9 @@ Nested scheme for **parameters**:
 	  * Constraints: The value must match regular expression `/\\S/`.
 	* `instance_id` - (String) The guid of the App Configuration service instance.
 	  * Constraints: The value must match regular expression `/\\S/`.
-	* `location` - (String) The IBM Cloud location where the App Configuration service instance resides.
+	* `location` - (String) The IBM Cloud location where the App Configuration service instance is located.
 	* `name` - (String) The name used to identify this tool integration. App Configuration references include this name to identify the App Configuration instance where the configuration values reside. All App Configuration tools integrated into a toolchain should have a unique name to allow resolution to function properly.
-	* `resource_group_name` - (String) The name of the resource group where the App Configuration service instance resides.
+	* `resource_group_name` - (String) The name of the resource group where the App Configuration service instance is located.
 
 * `referent` - (List) Information on URIs to access this resource through the UI or API.
 Nested scheme for **referent**:

--- a/website/docs/d/cd_toolchain_tool_artifactory.html.markdown
+++ b/website/docs/d/cd_toolchain_tool_artifactory.html.markdown
@@ -43,7 +43,6 @@ In addition to all argument references listed, you can access the following attr
 
 * `parameters` - (List) Unique key-value pairs representing parameters to be used to create the tool. A list of parameters for each tool integration can be found in the <a href="https://cloud.ibm.com/docs/ContinuousDelivery?topic=ContinuousDelivery-integrations">Configuring tool integrations page</a>.
 Nested scheme for **parameters**:
-	* `api_key` - (String) The Artifactory API key for your Artifactory repository. You can use a toolchain secret reference for this parameter. For more information, see [Protecting your sensitive data in Continuous Delivery](https://cloud.ibm.com/docs/ContinuousDelivery?topic=ContinuousDelivery-cd_data_security#cd_secure_credentials).
 	* `dashboard_url` - (String) The URL of the Artifactory server dashboard for this integration. In the graphical UI, this is the dashboard that the browser will navigate to when you click the Artifactory integration tile.
 	* `mirror_url` - (String) The URL for your Artifactory virtual repository, which is a repository that can see your private repositories and a cache of the public repositories.
 	* `name` - (String) The name for this tool integration.
@@ -51,6 +50,7 @@ Nested scheme for **parameters**:
 	* `repository_name` - (String) The name of your Artifactory repository where your docker images are located.
 	* `repository_url` - (String) The URL of your Artifactory repository where your docker images are located.
 	* `snapshot_url` - (String) The URL for your Artifactory snapshot repository.
+	* `token` - (String) The Identity Token or API key for your Artifactory repository. You can use a toolchain secret reference for this parameter. For more information, see [Protecting your sensitive data in Continuous Delivery](https://cloud.ibm.com/docs/ContinuousDelivery?topic=ContinuousDelivery-cd_data_security#cd_secure_credentials).
 	* `type` - (String) The type of repository for your Artifactory integration.
 	  * Constraints: Allowable values are: `npm`, `maven`, `docker`.
 	* `user_id` - (String) The User ID or email for your Artifactory repository.

--- a/website/docs/d/cd_toolchain_tool_keyprotect.html.markdown
+++ b/website/docs/d/cd_toolchain_tool_keyprotect.html.markdown
@@ -45,9 +45,9 @@ In addition to all argument references listed, you can access the following attr
 Nested scheme for **parameters**:
 	* `instance_name` - (String) The name of the Key Protect service instance.
 	  * Constraints: The value must match regular expression `/\\S/`.
-	* `location` - (String) The IBM Cloud location where the Key Protect service instance resides.
+	* `location` - (String) The IBM Cloud location where the Key Protect service instance is located.
 	* `name` - (String) The name used to identify this tool integration. Secret references include this name to identify the secrets store where the secrets reside. All secrets store tools integrated into a toolchain should have a unique name to allow secret resolution to function properly.
-	* `resource_group_name` - (String) The name of the resource group where the Key Protect service instance resides.
+	* `resource_group_name` - (String) The name of the resource group where the Key Protect service instance is located.
 
 * `referent` - (List) Information on URIs to access this resource through the UI or API.
 Nested scheme for **referent**:

--- a/website/docs/d/cd_toolchain_tool_secretsmanager.html.markdown
+++ b/website/docs/d/cd_toolchain_tool_secretsmanager.html.markdown
@@ -45,9 +45,9 @@ In addition to all argument references listed, you can access the following attr
 Nested scheme for **parameters**:
 	* `instance_name` - (String) The name of the Secrets Manager service instance.
 	  * Constraints: The value must match regular expression `/\\S/`.
-	* `location` - (String) The IBM Cloud location where the Secrets Manager service instance resides.
+	* `location` - (String) The IBM Cloud location where the Secrets Manager service instance is located.
 	* `name` - (String) The name used to identify this tool integration. Secret references include this name to identify the secrets store where the secrets reside. All secrets store tools integrated into a toolchain should have a unique name to allow secret resolution to function properly.
-	* `resource_group_name` - (String) The name of the resource group where the Secrets Manager service instance resides.
+	* `resource_group_name` - (String) The name of the resource group where the Secrets Manager service instance is located.
 
 * `referent` - (List) Information on URIs to access this resource through the UI or API.
 Nested scheme for **referent**:

--- a/website/docs/r/cd_toolchain_tool_appconfig.html.markdown
+++ b/website/docs/r/cd_toolchain_tool_appconfig.html.markdown
@@ -42,9 +42,9 @@ Nested scheme for **parameters**:
 	  * Constraints: The value must match regular expression `/\\S/`.
 	* `instance_id` - (Required, String) The guid of the App Configuration service instance.
 	  * Constraints: The value must match regular expression `/\\S/`.
-	* `location` - (Required, String) The IBM Cloud location where the App Configuration service instance resides.
+	* `location` - (Required, String) The IBM Cloud location where the App Configuration service instance is located.
 	* `name` - (Required, String) The name used to identify this tool integration. App Configuration references include this name to identify the App Configuration instance where the configuration values reside. All App Configuration tools integrated into a toolchain should have a unique name to allow resolution to function properly.
-	* `resource_group_name` - (Required, String) The name of the resource group where the App Configuration service instance resides.
+	* `resource_group_name` - (Required, String) The name of the resource group where the App Configuration service instance is located.
 * `toolchain_id` - (Required, Forces new resource, String) ID of the toolchain to bind the tool to.
   * Constraints: The maximum length is `36` characters. The minimum length is `36` characters. The value must match regular expression `/^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-4[a-fA-F0-9]{3}-[89abAB][a-fA-F0-9]{3}-[a-fA-F0-9]{12}$/`.
 

--- a/website/docs/r/cd_toolchain_tool_artifactory.html.markdown
+++ b/website/docs/r/cd_toolchain_tool_artifactory.html.markdown
@@ -21,9 +21,9 @@ resource "ibm_cd_toolchain_tool_artifactory" "cd_toolchain_tool_artifactory_inst
 		dashboard_url = "https://mycompany.example.jfrog.io"
 		type = "docker"
 		user_id = "<user_id>"
+		token = "<token>"
 		repository_name = "default-docker-local"
 		repository_url = "https://mycompany.example.jfrog.io/artifactory/default-docker-local"
-		api_key = "<api_key>"
   }
   toolchain_id = ibm_cd_toolchain.cd_toolchain.id
 }
@@ -37,7 +37,6 @@ Review the argument reference that you can specify for your resource.
   * Constraints: The maximum length is `128` characters. The minimum length is `0` characters. The value must match regular expression `/^([^\\x00-\\x7F]|[a-zA-Z0-9-._ ])+$/`.
 * `parameters` - (Required, List) Unique key-value pairs representing parameters to be used to create the tool. A list of parameters for each tool integration can be found in the <a href="https://cloud.ibm.com/docs/ContinuousDelivery?topic=ContinuousDelivery-integrations">Configuring tool integrations page</a>.
 Nested scheme for **parameters**:
-	* `api_key` - (Optional, String) The Artifactory API key for your Artifactory repository. You can use a toolchain secret reference for this parameter. For more information, see [Protecting your sensitive data in Continuous Delivery](https://cloud.ibm.com/docs/ContinuousDelivery?topic=ContinuousDelivery-cd_data_security#cd_secure_credentials).
 	* `dashboard_url` - (Optional, String) The URL of the Artifactory server dashboard for this integration. In the graphical UI, this is the dashboard that the browser will navigate to when you click the Artifactory integration tile.
 	* `mirror_url` - (Optional, String) The URL for your Artifactory virtual repository, which is a repository that can see your private repositories and a cache of the public repositories.
 	* `name` - (Required, String) The name for this tool integration.
@@ -45,6 +44,7 @@ Nested scheme for **parameters**:
 	* `repository_name` - (Optional, String) The name of your Artifactory repository where your docker images are located.
 	* `repository_url` - (Optional, String) The URL of your Artifactory repository where your docker images are located.
 	* `snapshot_url` - (Optional, String) The URL for your Artifactory snapshot repository.
+	* `token` - (Optional, String) The Identity Token or API key for your Artifactory repository. You can use a toolchain secret reference for this parameter. For more information, see [Protecting your sensitive data in Continuous Delivery](https://cloud.ibm.com/docs/ContinuousDelivery?topic=ContinuousDelivery-cd_data_security#cd_secure_credentials).
 	* `type` - (Required, String) The type of repository for your Artifactory integration.
 	  * Constraints: Allowable values are: `npm`, `maven`, `docker`.
 	* `user_id` - (Optional, String) The User ID or email for your Artifactory repository.

--- a/website/docs/r/cd_toolchain_tool_keyprotect.html.markdown
+++ b/website/docs/r/cd_toolchain_tool_keyprotect.html.markdown
@@ -36,9 +36,9 @@ Review the argument reference that you can specify for your resource.
 Nested scheme for **parameters**:
 	* `instance_name` - (Required, String) The name of the Key Protect service instance.
 	  * Constraints: The value must match regular expression `/\\S/`.
-	* `location` - (Required, String) The IBM Cloud location where the Key Protect service instance resides.
+	* `location` - (Required, String) The IBM Cloud location where the Key Protect service instance is located.
 	* `name` - (Required, String) The name used to identify this tool integration. Secret references include this name to identify the secrets store where the secrets reside. All secrets store tools integrated into a toolchain should have a unique name to allow secret resolution to function properly.
-	* `resource_group_name` - (Required, String) The name of the resource group where the Key Protect service instance resides.
+	* `resource_group_name` - (Required, String) The name of the resource group where the Key Protect service instance is located.
 * `toolchain_id` - (Required, Forces new resource, String) ID of the toolchain to bind the tool to.
   * Constraints: The maximum length is `36` characters. The minimum length is `36` characters. The value must match regular expression `/^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-4[a-fA-F0-9]{3}-[89abAB][a-fA-F0-9]{3}-[a-fA-F0-9]{12}$/`.
 

--- a/website/docs/r/cd_toolchain_tool_secretsmanager.html.markdown
+++ b/website/docs/r/cd_toolchain_tool_secretsmanager.html.markdown
@@ -36,9 +36,9 @@ Review the argument reference that you can specify for your resource.
 Nested scheme for **parameters**:
 	* `instance_name` - (Required, String) The name of the Secrets Manager service instance.
 	  * Constraints: The value must match regular expression `/\\S/`.
-	* `location` - (Required, String) The IBM Cloud location where the Secrets Manager service instance resides.
+	* `location` - (Required, String) The IBM Cloud location where the Secrets Manager service instance is located.
 	* `name` - (Required, String) The name used to identify this tool integration. Secret references include this name to identify the secrets store where the secrets reside. All secrets store tools integrated into a toolchain should have a unique name to allow secret resolution to function properly.
-	* `resource_group_name` - (Required, String) The name of the resource group where the Secrets Manager service instance resides.
+	* `resource_group_name` - (Required, String) The name of the resource group where the Secrets Manager service instance is located.
 * `toolchain_id` - (Required, Forces new resource, String) ID of the toolchain to bind the tool to.
   * Constraints: The maximum length is `36` characters. The minimum length is `36` characters. The value must match regular expression `/^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-4[a-fA-F0-9]{3}-[89abAB][a-fA-F0-9]{3}-[a-fA-F0-9]{12}$/`.
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/IBM-Cloud/terraform-provider-ibm/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
make testacc TEST=./ibm/service/cdtoolchain TESTARGS='-run=TestAccIBMCdToolchainToolArtifactory*'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./ibm/service/cdtoolchain -v -run=TestAccIBMCdToolchainToolArtifactory* -timeout 700m
=== RUN   TestAccIBMCdToolchainToolArtifactoryDataSourceBasic
--- PASS: TestAccIBMCdToolchainToolArtifactoryDataSourceBasic (33.73s)
=== RUN   TestAccIBMCdToolchainToolArtifactoryDataSourceAllArgs
--- PASS: TestAccIBMCdToolchainToolArtifactoryDataSourceAllArgs (30.96s)
=== RUN   TestAccIBMCdToolchainToolArtifactoryBasic
--- PASS: TestAccIBMCdToolchainToolArtifactoryBasic (26.55s)
=== RUN   TestAccIBMCdToolchainToolArtifactoryAllArgs
--- PASS: TestAccIBMCdToolchainToolArtifactoryAllArgs (44.51s)
PASS
ok  	github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/cdtoolchain	139.222s
...
```
