### PR TITLE
Satellite attach script: set subscription manager release and disable eus

### DIFF
--- a/ibm/service/satellite/data_source_ibm_satellite_host_script.go
+++ b/ibm/service/satellite/data_source_ibm_satellite_host_script.go
@@ -185,8 +185,10 @@ if [[ "${OPERATING_SYSTEM}" == "RHEL7" ]]; then
 	subscription-manager repos --enable rhel-7-server-supplementary-rpms
 	subscription-manager repos --enable rhel-7-server-extras-rpms
 elif [[ "${OPERATING_SYSTEM}" == "RHEL8" ]]; then
+  subscription-manager release --set=8
 	subscription-manager repos --enable rhel-8-for-x86_64-baseos-rpms 
 	subscription-manager repos --enable rhel-8-for-x86_64-appstream-rpms;
+  subscription-manager repos --disable='*eus*'
 fi
 yum install container-selinux -y`
 					} else if strings.ToLower(hostProvider) == "azure" {


### PR DESCRIPTION
There was an issue with vpc rhel 8 hosts where eus repos were causing a kernel bump, so lock that down since its not needed to prevent unnecessary kernel bump. With the bump hosts never got out of provisioning for the control plane in satellite.