### PR TITLE
chore(tekton): clean up ibm-cd-tekton-pipeline example

### DIFF
--- a/examples/ibm-cd-tekton-pipeline/README.md
+++ b/examples/ibm-cd-tekton-pipeline/README.md
@@ -28,9 +28,12 @@ cd_tekton_pipeline resource:
 
 ```terraform
 resource "cd_tekton_pipeline" "cd_tekton_pipeline_instance" {
+  pipeline_id = ibm_cd_toolchain_tool_pipeline.cd_pipeline.tool_id
   enable_notifications = false
   enable_partial_cloning = false
-  worker = var.cd_tekton_pipeline_worker
+  worker {
+    id = "public"
+  }
 }
 ```
 
@@ -169,9 +172,6 @@ data "cd_tekton_pipeline_trigger_property" "cd_tekton_pipeline_trigger_property_
 | toolchain\_description | Description for the Toolchain | `string` | true |
 | clone\_repo | URL of the tekton repo to clone, e.g. `https://github.com/open-toolchain/hello-tekton` | `string` | true |
 | repo\_name | Name of the new repo that will be created in the toolchain | `string` | true |
-| cluster | Name of the cluster where the app will be deployed | `string` | true |
-| cluster_namespace | Namespace in the cluster where the app will be deployed. Default = `prod` | `string` | false |
-| registry_namespace | IBM Cloud Container Registry namespace where the app image will be built and stored | `string` | true |
 
 ## Outputs
 

--- a/examples/ibm-cd-tekton-pipeline/main.tf
+++ b/examples/ibm-cd-tekton-pipeline/main.tf
@@ -1,6 +1,7 @@
 // Base resources
 provider "ibm" {
   ibmcloud_api_key = var.ibmcloud_api_key
+  region = var.region
 }
 data "ibm_resource_group" "resource_group" {
   name = var.resource_group
@@ -18,7 +19,7 @@ resource "ibm_cd_toolchain_tool_hostedgit" "tekton_repo" {
   toolchain_id = ibm_cd_toolchain.toolchain_instance.id
   name         = "tekton-repo"
   initialization {
-    type = "clone"
+    type = "clone_if_not_exists"
     source_repo_url = var.clone_repo
     private_repo = false
     repo_name = var.repo_name

--- a/examples/ibm-cd-tekton-pipeline/variables.tf
+++ b/examples/ibm-cd-tekton-pipeline/variables.tf
@@ -30,27 +30,11 @@ variable "region" {
 variable "toolchain_name" {
   type        = string
   description = "Name of the Toolchain"
-  default     = "Simple Helm Toolchain"
+  default     = "Simple Terraform Toolchain"
 }
 
 variable "toolchain_description" {
   type        = string
   description = "Description for the Toolchain"
   default     = "Toolchain created using IBM Cloud Continuous Delivery Service"
-}
-
-variable "cluster" {
-  type        = string
-  description = "The name of your IKS cluster where you will be deploying the sample app"
-}
-
-variable "cluster_namespace" {
-  type        = string
-  description = "The namespace in your cluster where the app will be deployed"
-  default     = "prod"
-}
-
-variable "registry_namespace" {
-  type        = string
-  description = "The IBM Cloud Container Registry namespace where the app image will be built and stored."
 }


### PR DESCRIPTION
Small update to clean up the ibm-cd-tekton-pipeline example from the examples folder

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Output from acceptance testing:

```
$ make testacc TEST=./ibm/service/cdtektonpipeline TESTARGS='-run=TestAccIBMCdTekton*'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./ibm/service/cdtektonpipeline -v -run=TestAccIBMCdTekton* -timeout 700m
=== RUN   TestAccIBMCdTektonPipelineDefinitionDataSourceBasic
--- PASS: TestAccIBMCdTektonPipelineDefinitionDataSourceBasic (105.31s)
=== RUN   TestAccIBMCdTektonPipelinePropertyDataSourceBasic
--- PASS: TestAccIBMCdTektonPipelinePropertyDataSourceBasic (93.62s)
=== RUN   TestAccIBMCdTektonPipelinePropertyDataSourceAllArgs
--- PASS: TestAccIBMCdTektonPipelinePropertyDataSourceAllArgs (88.86s)
=== RUN   TestAccIBMCdTektonPipelineDataSourceBasic
--- PASS: TestAccIBMCdTektonPipelineDataSourceBasic (70.48s)
=== RUN   TestAccIBMCdTektonPipelineDataSourceAllArgs
--- PASS: TestAccIBMCdTektonPipelineDataSourceAllArgs (92.86s)
=== RUN   TestAccIBMCdTektonPipelineTriggerPropertyDataSourceBasic
--- PASS: TestAccIBMCdTektonPipelineTriggerPropertyDataSourceBasic (102.14s)
=== RUN   TestAccIBMCdTektonPipelineTriggerPropertyDataSourceAllArgs
--- PASS: TestAccIBMCdTektonPipelineTriggerPropertyDataSourceAllArgs (101.38s)
=== RUN   TestAccIBMCdTektonPipelineTriggerDataSourceBasic
--- PASS: TestAccIBMCdTektonPipelineTriggerDataSourceBasic (96.34s)
=== RUN   TestAccIBMCdTektonPipelineTriggerDataSourceAllArgs
--- PASS: TestAccIBMCdTektonPipelineTriggerDataSourceAllArgs (97.55s)
=== RUN   TestAccIBMCdTektonPipelineDefinitionBasic
--- PASS: TestAccIBMCdTektonPipelineDefinitionBasic (96.61s)
=== RUN   TestAccIBMCdTektonPipelinePropertyBasic
--- PASS: TestAccIBMCdTektonPipelinePropertyBasic (86.46s)
=== RUN   TestAccIBMCdTektonPipelinePropertyAllArgs
--- PASS: TestAccIBMCdTektonPipelinePropertyAllArgs (145.30s)
=== RUN   TestAccIBMCdTektonPipelineBasic
--- PASS: TestAccIBMCdTektonPipelineBasic (67.47s)
=== RUN   TestAccIBMCdTektonPipelineAllArgs
--- PASS: TestAccIBMCdTektonPipelineAllArgs (138.60s)
=== RUN   TestAccIBMCdTektonPipelineTriggerPropertyBasic
--- PASS: TestAccIBMCdTektonPipelineTriggerPropertyBasic (100.12s)
=== RUN   TestAccIBMCdTektonPipelineTriggerPropertyAllArgs
--- PASS: TestAccIBMCdTektonPipelineTriggerPropertyAllArgs (174.28s)
=== RUN   TestAccIBMCdTektonPipelineTriggerBasic
--- PASS: TestAccIBMCdTektonPipelineTriggerBasic (387.44s)
=== RUN   TestAccIBMCdTektonPipelineTriggerAllArgs
--- PASS: TestAccIBMCdTektonPipelineTriggerAllArgs (179.32s)
PASS
ok      github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/cdtektonpipeline        2236.756s
...