### PR TITLE
Clarify worker_pool host_label usage and fix blank entry in array

### DIFF
--- a/ibm/flex/structures.go
+++ b/ibm/flex/structures.go
@@ -3348,7 +3348,7 @@ func FlattenSatelliteHosts(hostList []kubernetesserviceapiv1.MultishiftQueueNode
 }
 
 func FlattenWorkerPoolHostLabels(hostLabels map[string]string) *schema.Set {
-	mapped := make([]string, len(hostLabels))
+	mapped := make([]string, len(hostLabels)-1)
 	idx := 0
 	for k, v := range hostLabels {
 		if strings.HasPrefix(k, "os") {

--- a/ibm/service/satellite/resource_ibm_satellite_cluster_test.go
+++ b/ibm/service/satellite/resource_ibm_satellite_cluster_test.go
@@ -23,9 +23,9 @@ func TestAccSatelliteCluster_Basic(t *testing.T) {
 	locationName := fmt.Sprintf("tf-satellitelocation-%d", acctest.RandIntRange(10, 100))
 	managed_from := "wdc04"
 	operatingSystem := "REDHAT_7_64"
-	zones := []string{"us-east-1", "us-east-2", "us-east-3"}
+	zones := []string{"us-south-1", "us-south-2", "us-south-3"}
 	resource_group := "default"
-	region := "us-east"
+	region := "us-south"
 	resource_prefix := "tf-satellite"
 	host_provider := "ibm"
 	publicKey := strings.TrimSpace(`
@@ -55,9 +55,9 @@ func TestAccSatelliteCluster_Import(t *testing.T) {
 	locationName := fmt.Sprintf("tf-satellitelocation-%d", acctest.RandIntRange(10, 100))
 	managed_from := "wdc04"
 	operatingSystem := "REDHAT_7_64"
-	zones := []string{"us-east-1", "us-east-2", "us-east-3"}
+	zones := []string{"us-south-1", "us-south-2", "us-south-3"}
 	resource_group := "default"
-	region := "us-east"
+	region := "us-south"
 	resource_prefix := "tf-satellite"
 	host_provider := "ibm"
 	publicKey := strings.TrimSpace(`
@@ -147,14 +147,10 @@ func testAccCheckSatelliteClusterDestroy(s *terraform.State) error {
 func testAccCheckSatelliteClusterCreate(clusterName, locationName, managed_from, operatingSystem, resource_group, resource_prefix, region, publicKey, host_provider string, zones []string) string {
 	return fmt.Sprintf(`
 
-	provider "ibm" {
-		region = "us-east"
-	}
-
 	variable "location_zones" {
 		description = "Allocate your hosts across these three zones"
 		type        = list(string)
-		default     = ["us-east-1", "us-east-2", "us-east-3"]
+		default     = ["us-south-1", "us-south-2", "us-south-3"]
 	}
 
 	data "ibm_is_image" "rhel7" {

--- a/ibm/service/satellite/resource_ibm_satellite_cluster_worker_pool.go
+++ b/ibm/service/satellite/resource_ibm_satellite_cluster_worker_pool.go
@@ -150,6 +150,7 @@ func ResourceIBMSatelliteClusterWorkerPool() *schema.Resource {
 				Type:        schema.TypeSet,
 				Optional:    true,
 				Computed:    true,
+				ForceNew:    true,
 				Elem:        &schema.Schema{Type: schema.TypeString},
 				Set:         flex.ResourceIBMVPCHash,
 				Description: "Labels that describe a Satellite host",

--- a/ibm/service/satellite/resource_ibm_satellite_cluster_worker_pool_test.go
+++ b/ibm/service/satellite/resource_ibm_satellite_cluster_worker_pool_test.go
@@ -146,14 +146,10 @@ func testAccCheckSatelliteClusterWorkerPoolDestroy(s *terraform.State) error {
 func testAccCheckSatelliteClusterWorkerPoolCreate(clusterName, locationName, operatingSystem, workerPoolName, resource_prefix string) string {
 	return fmt.Sprintf(`
 
-	provider "ibm" {
-		region = "us-east"
-	}
-
 	variable "location_zones" {
 		description = "Allocate your hosts across these three zones"
 		type        = list(string)
-		default     = ["us-east-1", "us-east-2", "us-east-3"]
+		default     = ["us-south-1", "us-south-2", "us-south-3"]
 	}
 
 	resource "ibm_satellite_location" "location" {
@@ -186,7 +182,7 @@ func testAccCheckSatelliteClusterWorkerPoolCreate(clusterName, locationName, ope
 		name                     = "%s-subnet-${count.index}"
 		vpc                      = ibm_is_vpc.satellite_vpc.id
 		total_ipv4_address_count = 256
-		zone                     = "us-east-${count.index + 1}"
+		zone                     = "us-south-${count.index + 1}"
 	}
 	  
 	resource "ibm_is_ssh_key" "satellite_ssh" {	  
@@ -199,7 +195,7 @@ func testAccCheckSatelliteClusterWorkerPoolCreate(clusterName, locationName, ope
 
 		name           = "%s-instance-${count.index}"
 		vpc            = ibm_is_vpc.satellite_vpc.id
-		zone           = "us-east-${count.index + 1}"
+		zone           = "us-south-${count.index + 1}"
 		image          = data.ibm_is_image.rhel7.id
 		profile        = "mx2-8x64"
 		keys           = [ibm_is_ssh_key.satellite_ssh.id]

--- a/website/docs/r/satellite_cluster.html.markdown
+++ b/website/docs/r/satellite_cluster.html.markdown
@@ -53,7 +53,7 @@ Review the argument references that you can specify for your resource.
 - `zones` - (Optional, Array of Strings)  The name of the zones to create the default worker pool.
 - `worker_count` - (Optional, String) The number of worker nodes to create per zone in the default worker pool.
 - `enable_config_admin` - (Optional, Bool) User provided value to indicate opt-in agreement to SatCon admin agent.
-- `host_labels` - (Optional, Array of Strings) Key-value pairs to label the host, such as `cpu=4` to describe the host capabilities.
+- `host_labels` - (Optional, Set(Strings)) Labels to add to the default worker pool, formatted as `cpu:4` key-value pairs. Satellite uses host labels to automatically assign hosts to worker pools with matching labels.
 - `default_worker_pool_labels` - (Optional, String) The labels on all the workers in the default worker pool.
 - `pull_secret` - (Optional, String) The Red Hat pull secret to create the OpenShift cluster.
 - `zone` - (Optional, List) The zone for the worker pool in a multi-zone cluster. 

--- a/website/docs/r/satellite_cluster_worker_pool.html.markdown
+++ b/website/docs/r/satellite_cluster_worker_pool.html.markdown
@@ -61,21 +61,18 @@ Review the argument references that you can specify for your resource.
 
 - `name` - (Required, Forces new resource, String) The name of the worker pool.
 - `cluster` - (Required, Forces new resource, String) The name or id of the cluster.
-- `entitlement` - (Optional, String) The openshift cluster entitlement avoids the OCP licence charges incurred. Use cloud paks with OCP Licence entitlement to add the Openshift cluster worker pool.
 - `operating_system` - (Optional, String) Operating system of the worker pool. Options are REDHAT_7_64, REDHAT_8_64, or RHCOS.
 - `worker_count` - (Optional, Integer) The number of worker nodes per zone in the worker pool.
 - `flavor` - (Optional, String) The flavor defines the amount of virtual CPU, memory, and disk space that is set up in each worker node.
 - `isolation` - (Optional, String) Isolation for the worker node.
 - `disk_encryption` - (Optional, String) Disk encryption for worker node.
-- `host_labels` - (Optional, Set(Strings)) Labels to add to the worker pool, formatted as `cpu:4` key-value pairs. Satellite uses host labels to automatically assign hosts to worker pools with matching labels.
-- `worker_pool_labels` - Labels on all the workers in the worker pool.
-
 - `zones` - (Required, List) A nested block describing the zones of this worker_pool. 
 
   Nested scheme for `zones`:
   - `id` - (Required, String) The name of the zone.
+- `host_labels` - (Optional, Set(Strings)) Labels to add to the worker pool, formatted as `cpu:4` key-value pairs. Satellite uses host labels to automatically assign hosts to worker pools with matching labels.- `worker_pool_labels` - Labels on all the workers in the worker pool.
 - `resource_group_id` - (Optional, Forces new resource, String) The ID of the resource group.  You can retrieve the value from data source 
-
+- `entitlement` - (Optional, String) The openshift cluster entitlement avoids the OCP licence charges incurred. Use cloud paks with OCP Licence entitlement to add the Openshift cluster worker pool.
 
 ## Attribute reference
 

--- a/website/docs/r/satellite_cluster_worker_pool.html.markdown
+++ b/website/docs/r/satellite_cluster_worker_pool.html.markdown
@@ -70,7 +70,8 @@ Review the argument references that you can specify for your resource.
 
   Nested scheme for `zones`:
   - `id` - (Required, String) The name of the zone.
-- `host_labels` - (Optional, Set(Strings)) Labels to add to the worker pool, formatted as `cpu:4` key-value pairs. Satellite uses host labels to automatically assign hosts to worker pools with matching labels.- `worker_pool_labels` - Labels on all the workers in the worker pool.
+- `host_labels` - (Optional, Set(Strings)) Labels to add to the worker pool, formatted as `cpu:4` key-value pairs. Satellite uses host labels to automatically assign hosts to worker pools with matching labels.
+- `worker_pool_labels` - Labels on all the workers in the worker pool.
 - `resource_group_id` - (Optional, Forces new resource, String) The ID of the resource group.  You can retrieve the value from data source 
 - `entitlement` - (Optional, String) The openshift cluster entitlement avoids the OCP licence charges incurred. Use cloud paks with OCP Licence entitlement to add the Openshift cluster worker pool.
 

--- a/website/docs/r/satellite_cluster_worker_pool.html.markdown
+++ b/website/docs/r/satellite_cluster_worker_pool.html.markdown
@@ -61,19 +61,21 @@ Review the argument references that you can specify for your resource.
 
 - `name` - (Required, Forces new resource, String) The name of the worker pool.
 - `cluster` - (Required, Forces new resource, String) The name or id of the cluster.
+- `entitlement` - (Optional, String) The openshift cluster entitlement avoids the OCP licence charges incurred. Use cloud paks with OCP Licence entitlement to add the Openshift cluster worker pool.
 - `operating_system` - (Optional, String) Operating system of the worker pool. Options are REDHAT_7_64, REDHAT_8_64, or RHCOS.
 - `worker_count` - (Optional, Integer) The number of worker nodes per zone in the worker pool.
 - `flavor` - (Optional, String) The flavor defines the amount of virtual CPU, memory, and disk space that is set up in each worker node.
 - `isolation` - (Optional, String) Isolation for the worker node.
 - `disk_encryption` - (Optional, String) Disk encryption for worker node.
+- `host_labels` - (Optional, Set(Strings)) Labels to add to the worker pool, formatted as `cpu:4` key-value pairs. Satellite uses host labels to automatically assign hosts to worker pools with matching labels.
+- `worker_pool_labels` - Labels on all the workers in the worker pool.
+
 - `zones` - (Required, List) A nested block describing the zones of this worker_pool. 
 
   Nested scheme for `zones`:
   - `id` - (Required, String) The name of the zone.
-- `host_labels` - (Optional, Array of Strings) Key-value pairs to label the host, such as cpu=4 to describe the host capabilities.
-- `worker_pool_labels` - Labels on all the workers in the worker pool.
 - `resource_group_id` - (Optional, Forces new resource, String) The ID of the resource group.  You can retrieve the value from data source 
-- `entitlement` - (Optional, String) The openshift cluster entitlement avoids the OCP licence charges incurred. Use cloud paks with OCP Licence entitlement to add the Openshift cluster worker pool.
+
 
 ## Attribute reference
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/IBM-Cloud/terraform-provider-ibm/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

Four main changes:
- change worker pool host label to force new. It is not possible to update host labels on an existing worker pool after creation,
- fix length of array that creates a blank entry on read. example:


```  # ibm_satellite_cluster_worker_pool.create_wp will be updated in-place
  ~ resource "ibm_satellite_cluster_worker_pool" "create_wp" {
      ~ host_labels        = [
          - "",
            # (2 unchanged elements hidden)
        ]
        id                 = "cdqf4juw0bl3s7phl9vg/cdqf4juw0bl3s7phl9vg-bddb143"
        name               = "test"
 ```
 
- update docs to clarify correct formatting of host labels
- update test due to errors w/duplicate ibm provider. since now using the default provider, switching regions to us-south

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
make testacc TEST=./ibm/service/satellite TESTARGS='-run=TestAccSatelliteClusterWorkerPool_Basic'
=== RUN   TestAccSatelliteClusterWorkerPool_Basic
--- PASS: TestAccSatelliteClusterWorkerPool_Basic (2176.31s)
PASS
ok      github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/satellite       2177.473s
```

```
make testacc TEST=./ibm/service/satellite TESTARGS='-run=TestAccSatelliteCluster_Basic'

==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./ibm/service/satellite -v -run=TestAccSatelliteCluster_Basic -timeout 700m
=== RUN   TestAccSatelliteCluster_Basic
--- PASS: TestAccSatelliteCluster_Basic (4162.49s)
PASS
ok      github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/satellite       4163.750s