### PR TITLE
added auto delete for vsi boot volume

### DIFF
--- a/ibm/service/vpc/resource_ibm_is_instance.go
+++ b/ibm/service/vpc/resource_ibm_is_instance.go
@@ -601,6 +601,12 @@ func ResourceIBMISInstance() *schema.Resource {
 				MaxItems: 1,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
+						isInstanceVolAttVolAutoDelete: {
+							Type:        schema.TypeBool,
+							Optional:    true,
+							Default:     true,
+							Description: "Auto delete boot volume along with instance",
+						},
 						isInstanceBootAttachmentName: {
 							Type:         schema.TypeString,
 							Optional:     true,
@@ -1102,7 +1108,8 @@ func instanceCreateByImage(d *schema.ResourceData, meta interface{}, profile, na
 				volTemplate.UserTags = userTagsArray
 			}
 		}
-		deletebool := true
+		deleteboolIntf := bootvol[isInstanceVolAttVolAutoDelete]
+		deletebool := deleteboolIntf.(bool)
 		instanceproto.BootVolumeAttachment = &vpcv1.VolumeAttachmentPrototypeInstanceByImageContext{
 			DeleteVolumeOnInstanceDelete: &deletebool,
 			Volume:                       volTemplate,
@@ -1462,7 +1469,8 @@ func instanceCreateByCatalogOffering(d *schema.ResourceData, meta interface{}, p
 		volTemplate.Profile = &vpcv1.VolumeProfileIdentity{
 			Name: &volprof,
 		}
-		deletebool := true
+		deleteboolIntf := bootvol[isInstanceVolAttVolAutoDelete]
+		deletebool := deleteboolIntf.(bool)
 		instanceproto.BootVolumeAttachment = &vpcv1.VolumeAttachmentPrototypeInstanceByImageContext{
 			DeleteVolumeOnInstanceDelete: &deletebool,
 			Volume:                       volTemplate,
@@ -1828,7 +1836,8 @@ func instanceCreateByTemplate(d *schema.ResourceData, meta interface{}, profile,
 				volTemplate.UserTags = userTagsArray
 			}
 		}
-		deletebool := true
+		deleteboolIntf := bootvol[isInstanceVolAttVolAutoDelete]
+		deletebool := deleteboolIntf.(bool)
 
 		instanceproto.BootVolumeAttachment = &vpcv1.VolumeAttachmentPrototypeInstanceByImageContext{
 			DeleteVolumeOnInstanceDelete: &deletebool,
@@ -2185,7 +2194,8 @@ func instanceCreateByVolume(d *schema.ResourceData, meta interface{}, profile, n
 				ID: &snapshotIdStr,
 			}
 		}
-		deletebool := true
+		deleteboolIntf := bootvol[isInstanceVolAttVolAutoDelete]
+		deletebool := deleteboolIntf.(bool)
 		instanceproto.BootVolumeAttachment = &vpcv1.VolumeAttachmentPrototypeInstanceBySourceSnapshotContext{
 			DeleteVolumeOnInstanceDelete: &deletebool,
 			Volume:                       volTemplate,
@@ -2873,6 +2883,19 @@ func instanceGet(d *schema.ResourceData, meta interface{}, id string) error {
 		if instance.BootVolumeAttachment.Volume != nil {
 			bootVol[isInstanceBootAttachmentName] = *instance.BootVolumeAttachment.Volume.Name
 			bootVol[isInstanceBootVolumeId] = *instance.BootVolumeAttachment.Volume.ID
+
+			instanceId := *instance.ID
+			bootVolID := *instance.BootVolumeAttachment.ID
+			getinsVolAttOptions := &vpcv1.GetInstanceVolumeAttachmentOptions{
+				InstanceID: &instanceId,
+				ID:         &bootVolID,
+			}
+			bootVolumeAtt, response, err := instanceC.GetInstanceVolumeAttachment(getinsVolAttOptions)
+			if err != nil {
+				return fmt.Errorf("[ERROR] Error getting Instance boot volume attachment : %s\n%s", err, response)
+			}
+
+			bootVol[isInstanceVolAttVolAutoDelete] = *bootVolumeAtt.DeleteVolumeOnInstanceDelete
 			options := &vpcv1.GetVolumeOptions{
 				ID: instance.BootVolumeAttachment.Volume.ID,
 			}
@@ -3025,7 +3048,41 @@ func instanceUpdate(d *schema.ResourceData, meta interface{}) error {
 			}
 		}
 	}
+	bootVolAutoDel := "boot_volume.0.auto_delete_volume"
+	if d.HasChange(bootVolAutoDel) && !d.IsNewResource() {
+		listvolattoptions := &vpcv1.ListInstanceVolumeAttachmentsOptions{
+			InstanceID: &id,
+		}
+		vols, _, err := instanceC.ListInstanceVolumeAttachments(listvolattoptions)
+		if err != nil {
+			return err
+		}
 
+		auto_delete := d.Get(bootVolAutoDel).(bool)
+		for _, vol := range vols.VolumeAttachments {
+			if *vol.Type == "boot" {
+				volAttachmentID := *vol.ID
+				updateInstanceVolAttOptions := &vpcv1.UpdateInstanceVolumeAttachmentOptions{
+					InstanceID: &id,
+					ID:         &volAttachmentID,
+				}
+				volAttNamePatchModel := &vpcv1.VolumeAttachmentPatch{
+					DeleteVolumeOnInstanceDelete: &auto_delete,
+				}
+				volAttNamePatchModelAsPatch, err := volAttNamePatchModel.AsPatch()
+				if err != nil || volAttNamePatchModelAsPatch == nil {
+					return fmt.Errorf("[ERROR] Error Instance volume attachment (%s) as patch : %s", id, err)
+				}
+				updateInstanceVolAttOptions.VolumeAttachmentPatch = volAttNamePatchModelAsPatch
+
+				instanceVolAttUpdate, response, err := instanceC.UpdateInstanceVolumeAttachment(updateInstanceVolAttOptions)
+				if err != nil || instanceVolAttUpdate == nil {
+					log.Printf("[DEBUG] Instance volume attachment updation err %s\n%s", err, response)
+					return err
+				}
+			}
+		}
+	}
 	if d.HasChange(isPlacementTargetDedicatedHost) || d.HasChange(isPlacementTargetDedicatedHostGroup) && !d.IsNewResource() {
 		dedicatedHost := d.Get(isPlacementTargetDedicatedHost).(string)
 		dedicatedHostGroup := d.Get(isPlacementTargetDedicatedHostGroup).(string)
@@ -3685,9 +3742,12 @@ func instanceDelete(d *schema.ResourceData, meta interface{}, id string) error {
 			return err
 		}
 		if _, ok := d.GetOk(isInstanceBootVolume); ok {
-			_, err = isWaitForVolumeDeleted(instanceC, bootvolid, d.Timeout(schema.TimeoutDelete))
-			if err != nil {
-				return err
+			autoDel := d.Get("boot_volume.0.auto_delete_volume").(bool)
+			if autoDel {
+				_, err = isWaitForVolumeDeleted(instanceC, bootvolid, d.Timeout(schema.TimeoutDelete))
+				if err != nil {
+					return err
+				}
 			}
 		}
 	}

--- a/website/docs/r/is_instance.html.markdown
+++ b/website/docs/r/is_instance.html.markdown
@@ -347,6 +347,7 @@ Review the argument references that you can specify for your resource.
 - `boot_volume`  (Optional, List) A list of boot volumes for an instance.
 
   Nested scheme for `boot_volume`:
+  - `auto_delete_volume` - (Optional, String) If set to **true**, when deleting the instance the volume will also be deleted
   - `encryption` - (Optional, String) The type of encryption to use for the boot volume.
   - `name` - (Optional, String) The name of the boot volume.
   - `size` - (Optional, Integer) The size of the boot volume.(The capacity of the volume in gigabytes. This defaults to minimum capacity of the image and maximum to `250`.


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/IBM-Cloud/terraform-provider-ibm/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```
