### PR TITLE
GRS Fix: fixed pi_volume_group_action, pi_volume_group & data pi_volume_group_storage_details resources

### DIFF
--- a/ibm/service/power/data_source_ibm_pi_volume_group_storage_details.go
+++ b/ibm/service/power/data_source_ibm_pi_volume_group_storage_details.go
@@ -90,12 +90,13 @@ func dataSourceIBMPIVolumeGroupStorageDetailsReads(ctx context.Context, d *schem
 
 	cloudInstanceID := d.Get(helpers.PICloudInstanceId).(string)
 	vgClient := instance.NewIBMPIVolumeGroupClient(ctx, sess, cloudInstanceID)
-	vgData, err := vgClient.GetVolumeGroupLiveDetails(d.Get(PIVolumeGroupID).(string))
+	vgID := d.Get(PIVolumeGroupID).(string)
+	vgData, err := vgClient.GetVolumeGroupLiveDetails(vgID)
 	if err != nil {
 		return diag.FromErr(err)
 	}
 
-	d.SetId(PIVolumeGroupID)
+	d.SetId(vgID)
 	d.Set("consistency_group_name", vgData.ConsistencyGroupName)
 	d.Set("cycle_period_seconds", vgData.CyclePeriodSeconds)
 	d.Set("cycling_mode", vgData.CyclingMode)

--- a/ibm/service/power/resource_ibm_pi_volume_group.go
+++ b/ibm/service/power/resource_ibm_pi_volume_group.go
@@ -134,7 +134,7 @@ func resourceIBMPIVolumeGroupRead(ctx context.Context, d *schema.ResourceData, m
 
 	client := st.NewIBMPIVolumeGroupClient(ctx, sess, cloudInstanceID)
 
-	vg, err := client.Get(vgID)
+	vg, err := client.GetDetails(vgID)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -144,6 +144,7 @@ func resourceIBMPIVolumeGroupRead(ctx context.Context, d *schema.ResourceData, m
 	d.Set("consistency_group_name", vg.ConsistencyGroupName)
 	d.Set("replication_status", vg.ReplicationStatus)
 	d.Set(PIVolumeGroupName, vg.Name)
+	d.Set(PIVolumeGroupsVolumeIds, vg.VolumeIDs)
 	d.Set("status_description_errors", flattenVolumeGroupStatusDescription(vg.StatusDescription.Errors))
 
 	return nil
@@ -196,16 +197,18 @@ func resourceIBMPIVolumeGroupDelete(ctx context.Context, d *schema.ResourceData,
 	client := st.NewIBMPIVolumeGroupClient(ctx, sess, cloudInstanceID)
 
 	volids := flex.ExpandStringList((d.Get(PIVolumeGroupsVolumeIds).(*schema.Set)).List())
-	body := &models.VolumeGroupUpdate{
-		RemoveVolumes: volids,
-	}
-	err = client.UpdateVolumeGroup(vgID, body)
-	if err != nil {
-		return diag.FromErr(err)
-	}
-	_, err = isWaitForIBMPIVolumeGroupAvailable(ctx, client, vgID, d.Timeout(schema.TimeoutUpdate))
-	if err != nil {
-		return diag.FromErr(err)
+	if len(volids) > 0 {
+		body := &models.VolumeGroupUpdate{
+			RemoveVolumes: volids,
+		}
+		err = client.UpdateVolumeGroup(vgID, body)
+		if err != nil {
+			return diag.FromErr(err)
+		}
+		_, err = isWaitForIBMPIVolumeGroupAvailable(ctx, client, vgID, d.Timeout(schema.TimeoutUpdate))
+		if err != nil {
+			return diag.FromErr(err)
+		}
 	}
 
 	err = client.DeleteVolumeGroup(vgID)

--- a/ibm/service/power/resource_ibm_pi_volume_group.go
+++ b/ibm/service/power/resource_ibm_pi_volume_group.go
@@ -220,6 +220,7 @@ func resourceIBMPIVolumeGroupDelete(ctx context.Context, d *schema.ResourceData,
 		return diag.FromErr(err)
 	}
 
+	d.SetId("")
 	return nil
 }
 func isWaitForIBMPIVolumeGroupAvailable(ctx context.Context, client *st.IBMPIVolumeGroupClient, id string, timeout time.Duration) (interface{}, error) {

--- a/ibm/service/power/resource_ibm_pi_volume_group_action.go
+++ b/ibm/service/power/resource_ibm_pi_volume_group_action.go
@@ -55,6 +55,7 @@ func ResourceIBMPIVolumeGroupAction() *schema.Resource {
 							Type:     schema.TypeList,
 							Optional: true,
 							MaxItems: 1,
+							ForceNew: true,
 							Elem: &schema.Resource{
 								Schema: map[string]*schema.Schema{
 									"source": {
@@ -69,6 +70,7 @@ func ResourceIBMPIVolumeGroupAction() *schema.Resource {
 							Type:     schema.TypeList,
 							Optional: true,
 							MaxItems: 1,
+							ForceNew: true,
 							Elem: &schema.Resource{
 								Schema: map[string]*schema.Schema{
 									"access": {
@@ -82,6 +84,7 @@ func ResourceIBMPIVolumeGroupAction() *schema.Resource {
 							Type:     schema.TypeList,
 							Optional: true,
 							MaxItems: 1,
+							ForceNew: true,
 							Elem: &schema.Resource{
 								Schema: map[string]*schema.Schema{
 									"status": {

--- a/ibm/service/power/resource_ibm_pi_volume_group_action_test.go
+++ b/ibm/service/power/resource_ibm_pi_volume_group_action_test.go
@@ -33,6 +33,14 @@ func TestAccIBMPIVolumeGroupActionbasic(t *testing.T) {
 					resource.TestCheckResourceAttrSet("ibm_pi_volume_group_action.power_volume_group_action", "volume_group_status"),
 				),
 			},
+			{
+				Config: testAccCheckIBMPIVolumeGroupStartActionConfig(name),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckIBMPIVolumeGroupActionExists("ibm_pi_volume_group_action.power_volume_group_action"),
+					resource.TestCheckResourceAttrSet("ibm_pi_volume_group_action.power_volume_group_action", "id"),
+					resource.TestCheckResourceAttrSet("ibm_pi_volume_group_action.power_volume_group_action", "volume_group_status"),
+				),
+			},
 		},
 	})
 }
@@ -78,6 +86,20 @@ func testAccCheckIBMPIVolumeGroupStopActionConfig(name string) string {
 		pi_volume_group_action {
 			stop {
 				access = true
+			}
+		}
+	  }
+	`, acc.Pi_cloud_instance_id)
+}
+
+func testAccCheckIBMPIVolumeGroupStartActionConfig(name string) string {
+	return testAccCheckIBMPIVolumeGroupConfig(name) + fmt.Sprintf(`
+	  resource "ibm_pi_volume_group_action" "power_volume_group_action" {
+		pi_cloud_instance_id   = "%[1]s"
+		pi_volume_group_id     = ibm_pi_volume_group.power_volume_group.volume_group_id
+		pi_volume_group_action {
+			start {
+				source = "master"
 			}
 		}
 	  }

--- a/ibm/service/power/resource_ibm_pi_volume_group_test.go
+++ b/ibm/service/power/resource_ibm_pi_volume_group_test.go
@@ -41,6 +41,14 @@ func TestAccIBMPIVolumeGroupUpdate(t *testing.T) {
 						"ibm_pi_volume_group.power_volume_group", "pi_volume_group_name", name),
 				),
 			},
+			{
+				Config: testAccCheckIBMPIVolumeGroupEmptyVolumeConfig(name),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckIBMPIVolumeGroupExists("ibm_pi_volume_group.power_volume_group"),
+					resource.TestCheckResourceAttr(
+						"ibm_pi_volume_group.power_volume_group", "pi_volume_group_name", name),
+				),
+			},
 		},
 	})
 }
@@ -117,6 +125,16 @@ func testAccCheckIBMPIVolumeGroupUpdateConfig(name string) string {
 		pi_volume_group_name       = "%[1]s"
 		pi_cloud_instance_id 	   = "%[2]s"
 		pi_volume_ids              = [ibm_pi_volume.power_volume[2].volume_id]
+	  }
+	`, name, acc.Pi_cloud_instance_id)
+}
+
+func testAccCheckIBMPIVolumeGroupEmptyVolumeConfig(name string) string {
+	return volumeConfig(name, acc.Pi_cloud_instance_id) + fmt.Sprintf(`
+	resource "ibm_pi_volume_group" "power_volume_group"{
+		pi_volume_group_name       = "%[1]s"
+		pi_cloud_instance_id 	   = "%[2]s"
+		pi_volume_ids              = []
 	  }
 	`, name, acc.Pi_cloud_instance_id)
 }

--- a/website/docs/r/pi_volume_group_action.html.markdown
+++ b/website/docs/r/pi_volume_group_action.html.markdown
@@ -54,15 +54,15 @@ Review the argument references that you can specify for your resource.
 - `pi_volume_group_action` - (Required, Forces new resource, List) Performs an action (`start` / `stop` / `reset`) on a volume group(one at a time).
   - Constraints: The maximum length is `1` items. The minimum length is `1` items.
   Nested scheme for **pi_volume_group_action**:
-    - `reset` - (Optional, List) Performs reset action on the volume group to update its status value.
+    - `reset` - (Optional, Forces new resource, List) Performs reset action on the volume group to update its status value.
       - Constraints: The maximum length is `1` items.
       Nested scheme for **reset**:
         - `status` - (Required, String) New status to be set for a volume group.
-    - `start` - (Optional, List) Performs start action on a volume group.
+    - `start` - (Optional, Forces new resource, List) Performs start action on a volume group.
       - Constraints: The maximum length is `1` items.
       Nested scheme for **start**:
         - `source` - (Required, String) Indicates the source of the action `master` or `aux`.
-    - `stop` - (Optional, List) Performs stop action on a volume group.
+    - `stop` - (Optional, Forces new resource, List) Performs stop action on a volume group.
       - Constraints: The maximum length is `1` items.
       Nested scheme for **reset**:
         - `access` - (Required, Boolean) Indicates the access mode of aux volumes.


### PR DESCRIPTION
…_source_ibm_pi_volume_group_storage_details resources

<!--- See what makes a good Pull Request at : https://github.com/IBM-Cloud/terraform-provider-ibm/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccXXX'

=== RUN   TestAccIBMPIVolumeGroupStorageDetailsDataSourceBasic
--- PASS: TestAccIBMPIVolumeGroupStorageDetailsDataSourceBasic (169.73s)
PASS
=== RUN   TestAccIBMPIVolumeGroupActionbasic
--- PASS: TestAccIBMPIVolumeGroupActionbasic (435.10s)
PASS
=== RUN   TestAccIBMPIVolumeGroupUpdate
--- PASS: TestAccIBMPIVolumeGroupUpdate (858.71s)
PASS
...
```
