### PR TITLE
Remove tags from toolchain

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/IBM/cloud-databases-go-sdk v0.2.0
 	github.com/IBM/cloudant-go-sdk v0.0.43
 	github.com/IBM/container-registry-go-sdk v0.0.15
-	github.com/IBM/continuous-delivery-go-sdk v0.1.5
+	github.com/IBM/continuous-delivery-go-sdk v0.1.9
 	github.com/IBM/event-notifications-go-admin-sdk v0.1.2
 	github.com/IBM/eventstreams-go-sdk v1.2.0
 	github.com/IBM/go-sdk-core/v5 v5.10.2

--- a/go.sum
+++ b/go.sum
@@ -57,6 +57,8 @@ github.com/IBM/container-registry-go-sdk v0.0.15 h1:sfEXm4qNj9ZCwTlFOsdjF5P/lvaj
 github.com/IBM/container-registry-go-sdk v0.0.15/go.mod h1:KqSZFO4VIK9QAyF8O1JW6jkyzkfE/BNKUIo+OdzIDk4=
 github.com/IBM/continuous-delivery-go-sdk v0.1.5 h1:WZEpdJwIV8mwGanhMM2gpiQAk2CvCFhooinyuXlGB1U=
 github.com/IBM/continuous-delivery-go-sdk v0.1.5/go.mod h1:Ck7caGZsolQa27xC6woFA5wgRhiUz/d9sSKRQGBBuqg=
+github.com/IBM/continuous-delivery-go-sdk v0.1.9 h1:KzKJmLzQ6NQcGqlLKDoiLRqoPVlx+Qwtkksh0hLsIrI=
+github.com/IBM/continuous-delivery-go-sdk v0.1.9/go.mod h1:/pSji7d4POPVd1tQA9CLrNT1XMsCJMGLqOtTwXbWAdE=
 github.com/IBM/event-notifications-go-admin-sdk v0.1.2 h1:LLA12WFqSD0+Uf16SNdErcu2MVK4EnyXHJmDIkKkudE=
 github.com/IBM/event-notifications-go-admin-sdk v0.1.2/go.mod h1:VCtV/cAN8qSPeWEjIWeXOQGTq6LCWP9yZEk7wt3g0HM=
 github.com/IBM/eventstreams-go-sdk v1.2.0 h1:eP0afHArMGjwhGqvZAhhu/3EDKRch2JehpveqF1TUjs=

--- a/ibm/service/cdtoolchain/data_source_ibm_cd_toolchain.go
+++ b/ibm/service/cdtoolchain/data_source_ibm_cd_toolchain.go
@@ -81,14 +81,6 @@ func DataSourceIBMCdToolchain() *schema.Resource {
 				Computed:    true,
 				Description: "Identity that created the toolchain.",
 			},
-			"tags": &schema.Schema{
-				Type:        schema.TypeList,
-				Computed:    true,
-				Description: "Tags associated with the toolchain.",
-				Elem: &schema.Schema{
-					Type: schema.TypeString,
-				},
-			},
 		},
 	}
 }

--- a/ibm/service/cdtoolchain/resource_ibm_cd_toolchain.go
+++ b/ibm/service/cdtoolchain/resource_ibm_cd_toolchain.go
@@ -85,12 +85,6 @@ func ResourceIBMCdToolchain() *schema.Resource {
 				Computed:    true,
 				Description: "Identity that created the toolchain.",
 			},
-			"tags": &schema.Schema{
-				Type:        schema.TypeList,
-				Computed:    true,
-				Description: "Tags associated with the toolchain.",
-				Elem:        &schema.Schema{Type: schema.TypeString},
-			},
 		},
 	}
 }
@@ -208,9 +202,6 @@ func resourceIBMCdToolchainRead(context context.Context, d *schema.ResourceData,
 	}
 	if err = d.Set("created_by", toolchain.CreatedBy); err != nil {
 		return diag.FromErr(fmt.Errorf("Error setting created_by: %s", err))
-	}
-	if err = d.Set("tags", toolchain.Tags); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting tags: %s", err))
 	}
 
 	return nil

--- a/website/docs/d/cd_toolchain.html.markdown
+++ b/website/docs/d/cd_toolchain.html.markdown
@@ -49,8 +49,6 @@ In addition to all argument references listed, you can access the following attr
 
 * `resource_group_id` - (String) Resource group where the toolchain is located.
 
-* `tags` - (List) Tags associated with the toolchain.
-
 * `ui_href` - (String) URL of a user-facing user interface for this toolchain.
 
 * `updated_at` - (String) Latest toolchain update timestamp.

--- a/website/docs/r/cd_toolchain.html.markdown
+++ b/website/docs/r/cd_toolchain.html.markdown
@@ -42,7 +42,6 @@ In addition to all argument references listed, you can access the following attr
 * `crn` - (String) Toolchain CRN.
 * `href` - (String) URI that can be used to retrieve toolchain.
 * `location` - (String) Toolchain region.
-* `tags` - (List) Tags associated with the toolchain.
 * `ui_href` - (String) URL of a user-facing user interface for this toolchain.
 * `updated_at` - (String) Latest toolchain update timestamp.
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/IBM-Cloud/terraform-provider-ibm/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
make testacc TEST=./ibm/service/cdtoolchain
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./ibm/service/cdtoolchain -v  -timeout 700m
=== RUN   TestAccIBMCdToolchainDataSourceBasic
--- PASS: TestAccIBMCdToolchainDataSourceBasic (48.55s)
=== RUN   TestAccIBMCdToolchainDataSourceAllArgs
--- PASS: TestAccIBMCdToolchainDataSourceAllArgs (42.41s)
=== RUN   TestAccIBMCdToolchainToolAppconfigDataSourceBasic
--- PASS: TestAccIBMCdToolchainToolAppconfigDataSourceBasic (49.57s)
=== RUN   TestAccIBMCdToolchainToolAppconfigDataSourceAllArgs
--- PASS: TestAccIBMCdToolchainToolAppconfigDataSourceAllArgs (40.74s)
=== RUN   TestAccIBMCdToolchainToolArtifactoryDataSourceBasic
--- PASS: TestAccIBMCdToolchainToolArtifactoryDataSourceBasic (26.07s)
=== RUN   TestAccIBMCdToolchainToolArtifactoryDataSourceAllArgs
--- PASS: TestAccIBMCdToolchainToolArtifactoryDataSourceAllArgs (29.48s)
=== RUN   TestAccIBMCdToolchainToolBitbucketgitDataSourceBasic
--- PASS: TestAccIBMCdToolchainToolBitbucketgitDataSourceBasic (28.99s)
=== RUN   TestAccIBMCdToolchainToolBitbucketgitDataSourceAllArgs
--- PASS: TestAccIBMCdToolchainToolBitbucketgitDataSourceAllArgs (24.85s)
=== RUN   TestAccIBMCdToolchainToolCustomDataSourceBasic
--- PASS: TestAccIBMCdToolchainToolCustomDataSourceBasic (23.20s)
=== RUN   TestAccIBMCdToolchainToolCustomDataSourceAllArgs
--- PASS: TestAccIBMCdToolchainToolCustomDataSourceAllArgs (23.75s)
=== RUN   TestAccIBMCdToolchainToolDevopsinsightsDataSourceBasic
--- PASS: TestAccIBMCdToolchainToolDevopsinsightsDataSourceBasic (26.46s)
=== RUN   TestAccIBMCdToolchainToolDevopsinsightsDataSourceAllArgs
--- PASS: TestAccIBMCdToolchainToolDevopsinsightsDataSourceAllArgs (21.88s)
=== RUN   TestAccIBMCdToolchainToolGithubconsolidatedDataSourceBasic
--- PASS: TestAccIBMCdToolchainToolGithubconsolidatedDataSourceBasic (28.35s)
=== RUN   TestAccIBMCdToolchainToolGithubconsolidatedDataSourceAllArgs
--- PASS: TestAccIBMCdToolchainToolGithubconsolidatedDataSourceAllArgs (26.60s)
=== RUN   TestAccIBMCdToolchainToolGitlabDataSourceBasic
--- PASS: TestAccIBMCdToolchainToolGitlabDataSourceBasic (26.64s)
=== RUN   TestAccIBMCdToolchainToolGitlabDataSourceAllArgs
--- PASS: TestAccIBMCdToolchainToolGitlabDataSourceAllArgs (22.49s)
=== RUN   TestAccIBMCdToolchainToolHashicorpvaultDataSourceBasic
--- PASS: TestAccIBMCdToolchainToolHashicorpvaultDataSourceBasic (28.59s)
=== RUN   TestAccIBMCdToolchainToolHashicorpvaultDataSourceAllArgs
--- PASS: TestAccIBMCdToolchainToolHashicorpvaultDataSourceAllArgs (24.91s)
=== RUN   TestAccIBMCdToolchainToolHostedgitDataSourceBasic
--- PASS: TestAccIBMCdToolchainToolHostedgitDataSourceBasic (25.09s)
=== RUN   TestAccIBMCdToolchainToolHostedgitDataSourceAllArgs
--- PASS: TestAccIBMCdToolchainToolHostedgitDataSourceAllArgs (27.95s)
=== RUN   TestAccIBMCdToolchainToolJenkinsDataSourceBasic
--- PASS: TestAccIBMCdToolchainToolJenkinsDataSourceBasic (28.61s)
=== RUN   TestAccIBMCdToolchainToolJenkinsDataSourceAllArgs
--- PASS: TestAccIBMCdToolchainToolJenkinsDataSourceAllArgs (32.09s)
=== RUN   TestAccIBMCdToolchainToolJiraDataSourceBasic
--- PASS: TestAccIBMCdToolchainToolJiraDataSourceBasic (24.86s)
=== RUN   TestAccIBMCdToolchainToolJiraDataSourceAllArgs
--- PASS: TestAccIBMCdToolchainToolJiraDataSourceAllArgs (27.44s)
=== RUN   TestAccIBMCdToolchainToolKeyprotectDataSourceBasic
--- PASS: TestAccIBMCdToolchainToolKeyprotectDataSourceBasic (26.44s)
=== RUN   TestAccIBMCdToolchainToolKeyprotectDataSourceAllArgs
--- PASS: TestAccIBMCdToolchainToolKeyprotectDataSourceAllArgs (28.96s)
=== RUN   TestAccIBMCdToolchainToolNexusDataSourceBasic
--- PASS: TestAccIBMCdToolchainToolNexusDataSourceBasic (26.19s)
=== RUN   TestAccIBMCdToolchainToolNexusDataSourceAllArgs
--- PASS: TestAccIBMCdToolchainToolNexusDataSourceAllArgs (37.65s)
=== RUN   TestAccIBMCdToolchainToolPagerdutyDataSourceBasic
--- PASS: TestAccIBMCdToolchainToolPagerdutyDataSourceBasic (29.39s)
=== RUN   TestAccIBMCdToolchainToolPagerdutyDataSourceAllArgs
--- PASS: TestAccIBMCdToolchainToolPagerdutyDataSourceAllArgs (24.73s)
=== RUN   TestAccIBMCdToolchainToolPipelineDataSourceBasic
--- PASS: TestAccIBMCdToolchainToolPipelineDataSourceBasic (34.41s)
=== RUN   TestAccIBMCdToolchainToolPipelineDataSourceAllArgs
--- PASS: TestAccIBMCdToolchainToolPipelineDataSourceAllArgs (23.09s)
=== RUN   TestAccIBMCdToolchainToolPrivateworkerDataSourceBasic
--- PASS: TestAccIBMCdToolchainToolPrivateworkerDataSourceBasic (25.10s)
=== RUN   TestAccIBMCdToolchainToolPrivateworkerDataSourceAllArgs
--- PASS: TestAccIBMCdToolchainToolPrivateworkerDataSourceAllArgs (23.28s)
=== RUN   TestAccIBMCdToolchainToolSaucelabsDataSourceBasic
--- PASS: TestAccIBMCdToolchainToolSaucelabsDataSourceBasic (29.31s)
=== RUN   TestAccIBMCdToolchainToolSaucelabsDataSourceAllArgs
--- PASS: TestAccIBMCdToolchainToolSaucelabsDataSourceAllArgs (28.22s)
=== RUN   TestAccIBMCdToolchainToolSecretsmanagerDataSourceBasic
--- PASS: TestAccIBMCdToolchainToolSecretsmanagerDataSourceBasic (29.44s)
=== RUN   TestAccIBMCdToolchainToolSecretsmanagerDataSourceAllArgs
--- PASS: TestAccIBMCdToolchainToolSecretsmanagerDataSourceAllArgs (26.95s)
=== RUN   TestAccIBMCdToolchainToolSecuritycomplianceDataSourceBasic
--- PASS: TestAccIBMCdToolchainToolSecuritycomplianceDataSourceBasic (28.04s)
=== RUN   TestAccIBMCdToolchainToolSecuritycomplianceDataSourceAllArgs
--- PASS: TestAccIBMCdToolchainToolSecuritycomplianceDataSourceAllArgs (22.52s)
=== RUN   TestAccIBMCdToolchainToolSlackDataSourceBasic
--- PASS: TestAccIBMCdToolchainToolSlackDataSourceBasic (24.84s)
=== RUN   TestAccIBMCdToolchainToolSlackDataSourceAllArgs
--- PASS: TestAccIBMCdToolchainToolSlackDataSourceAllArgs (23.75s)
=== RUN   TestAccIBMCdToolchainToolSonarqubeDataSourceBasic
--- PASS: TestAccIBMCdToolchainToolSonarqubeDataSourceBasic (23.31s)
=== RUN   TestAccIBMCdToolchainToolSonarqubeDataSourceAllArgs
--- PASS: TestAccIBMCdToolchainToolSonarqubeDataSourceAllArgs (23.24s)
=== RUN   TestAccIBMCdToolchainBasic
--- PASS: TestAccIBMCdToolchainBasic (31.01s)
=== RUN   TestAccIBMCdToolchainAllArgs
--- PASS: TestAccIBMCdToolchainAllArgs (32.74s)
=== RUN   TestAccIBMCdToolchainToolAppconfigBasic
--- PASS: TestAccIBMCdToolchainToolAppconfigBasic (29.40s)
=== RUN   TestAccIBMCdToolchainToolAppconfigAllArgs
--- PASS: TestAccIBMCdToolchainToolAppconfigAllArgs (55.54s)
=== RUN   TestAccIBMCdToolchainToolArtifactoryBasic
--- PASS: TestAccIBMCdToolchainToolArtifactoryBasic (26.48s)
=== RUN   TestAccIBMCdToolchainToolArtifactoryAllArgs
--- PASS: TestAccIBMCdToolchainToolArtifactoryAllArgs (36.63s)
=== RUN   TestAccIBMCdToolchainToolBitbucketgitBasic
--- PASS: TestAccIBMCdToolchainToolBitbucketgitBasic (23.23s)
=== RUN   TestAccIBMCdToolchainToolBitbucketgitAllArgs
--- PASS: TestAccIBMCdToolchainToolBitbucketgitAllArgs (47.22s)
=== RUN   TestAccIBMCdToolchainToolCustomBasic
--- PASS: TestAccIBMCdToolchainToolCustomBasic (21.42s)
=== RUN   TestAccIBMCdToolchainToolCustomAllArgs
--- PASS: TestAccIBMCdToolchainToolCustomAllArgs (40.73s)
=== RUN   TestAccIBMCdToolchainToolDevopsinsightsBasic
--- PASS: TestAccIBMCdToolchainToolDevopsinsightsBasic (22.80s)
=== RUN   TestAccIBMCdToolchainToolDevopsinsightsAllArgs
--- PASS: TestAccIBMCdToolchainToolDevopsinsightsAllArgs (41.89s)
=== RUN   TestAccIBMCdToolchainToolGithubconsolidatedBasic
--- PASS: TestAccIBMCdToolchainToolGithubconsolidatedBasic (23.74s)
=== RUN   TestAccIBMCdToolchainToolGithubconsolidatedAllArgs
--- PASS: TestAccIBMCdToolchainToolGithubconsolidatedAllArgs (40.22s)
=== RUN   TestAccIBMCdToolchainToolGitlabBasic
--- PASS: TestAccIBMCdToolchainToolGitlabBasic (23.94s)
=== RUN   TestAccIBMCdToolchainToolGitlabAllArgs
--- PASS: TestAccIBMCdToolchainToolGitlabAllArgs (44.28s)
=== RUN   TestAccIBMCdToolchainToolHashicorpvaultBasic
--- PASS: TestAccIBMCdToolchainToolHashicorpvaultBasic (22.88s)
=== RUN   TestAccIBMCdToolchainToolHashicorpvaultAllArgs
--- PASS: TestAccIBMCdToolchainToolHashicorpvaultAllArgs (38.49s)
=== RUN   TestAccIBMCdToolchainToolHostedgitBasic
--- PASS: TestAccIBMCdToolchainToolHostedgitBasic (23.97s)
=== RUN   TestAccIBMCdToolchainToolHostedgitAllArgs
--- PASS: TestAccIBMCdToolchainToolHostedgitAllArgs (38.40s)
=== RUN   TestAccIBMCdToolchainToolJenkinsBasic
--- PASS: TestAccIBMCdToolchainToolJenkinsBasic (23.22s)
=== RUN   TestAccIBMCdToolchainToolJenkinsAllArgs
--- PASS: TestAccIBMCdToolchainToolJenkinsAllArgs (38.87s)
=== RUN   TestAccIBMCdToolchainToolJiraBasic
--- PASS: TestAccIBMCdToolchainToolJiraBasic (22.17s)
=== RUN   TestAccIBMCdToolchainToolJiraAllArgs
--- PASS: TestAccIBMCdToolchainToolJiraAllArgs (41.69s)
=== RUN   TestAccIBMCdToolchainToolKeyprotectBasic
--- PASS: TestAccIBMCdToolchainToolKeyprotectBasic (33.14s)
=== RUN   TestAccIBMCdToolchainToolKeyprotectAllArgs
--- PASS: TestAccIBMCdToolchainToolKeyprotectAllArgs (37.25s)
=== RUN   TestAccIBMCdToolchainToolNexusBasic
--- PASS: TestAccIBMCdToolchainToolNexusBasic (20.76s)
=== RUN   TestAccIBMCdToolchainToolNexusAllArgs
--- PASS: TestAccIBMCdToolchainToolNexusAllArgs (38.22s)
=== RUN   TestAccIBMCdToolchainToolPagerdutyBasic
--- PASS: TestAccIBMCdToolchainToolPagerdutyBasic (21.93s)
=== RUN   TestAccIBMCdToolchainToolPagerdutyAllArgs
--- PASS: TestAccIBMCdToolchainToolPagerdutyAllArgs (39.03s)
=== RUN   TestAccIBMCdToolchainToolPipelineBasic
--- PASS: TestAccIBMCdToolchainToolPipelineBasic (21.35s)
=== RUN   TestAccIBMCdToolchainToolPipelineAllArgs
--- PASS: TestAccIBMCdToolchainToolPipelineAllArgs (38.59s)
=== RUN   TestAccIBMCdToolchainToolPrivateworkerBasic
--- PASS: TestAccIBMCdToolchainToolPrivateworkerBasic (24.03s)
=== RUN   TestAccIBMCdToolchainToolPrivateworkerAllArgs
--- PASS: TestAccIBMCdToolchainToolPrivateworkerAllArgs (46.90s)
=== RUN   TestAccIBMCdToolchainToolSaucelabsBasic
--- PASS: TestAccIBMCdToolchainToolSaucelabsBasic (24.30s)
=== RUN   TestAccIBMCdToolchainToolSaucelabsAllArgs
--- PASS: TestAccIBMCdToolchainToolSaucelabsAllArgs (39.15s)
=== RUN   TestAccIBMCdToolchainToolSecretsmanagerBasic
--- PASS: TestAccIBMCdToolchainToolSecretsmanagerBasic (22.60s)
=== RUN   TestAccIBMCdToolchainToolSecretsmanagerAllArgs
--- PASS: TestAccIBMCdToolchainToolSecretsmanagerAllArgs (38.37s)
=== RUN   TestAccIBMCdToolchainToolSecuritycomplianceBasic
--- PASS: TestAccIBMCdToolchainToolSecuritycomplianceBasic (20.63s)
=== RUN   TestAccIBMCdToolchainToolSecuritycomplianceAllArgs
--- PASS: TestAccIBMCdToolchainToolSecuritycomplianceAllArgs (38.15s)
=== RUN   TestAccIBMCdToolchainToolSlackBasic
--- PASS: TestAccIBMCdToolchainToolSlackBasic (22.54s)
=== RUN   TestAccIBMCdToolchainToolSlackAllArgs
--- PASS: TestAccIBMCdToolchainToolSlackAllArgs (39.90s)
=== RUN   TestAccIBMCdToolchainToolSonarqubeBasic
--- PASS: TestAccIBMCdToolchainToolSonarqubeBasic (22.04s)
=== RUN   TestAccIBMCdToolchainToolSonarqubeAllArgs
--- PASS: TestAccIBMCdToolchainToolSonarqubeAllArgs (38.78s)
PASS
ok  	github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/cdtoolchain	2670.986s

make testacc TEST=./ibm/service/cdtektonpipeline
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./ibm/service/cdtektonpipeline -v  -timeout 700m
=== RUN   TestAccIBMCdTektonPipelineDefinitionDataSourceBasic
--- PASS: TestAccIBMCdTektonPipelineDefinitionDataSourceBasic (35.15s)
=== RUN   TestAccIBMCdTektonPipelinePropertyDataSourceBasic
--- PASS: TestAccIBMCdTektonPipelinePropertyDataSourceBasic (34.00s)
=== RUN   TestAccIBMCdTektonPipelinePropertyDataSourceAllArgs
--- PASS: TestAccIBMCdTektonPipelinePropertyDataSourceAllArgs (35.46s)
=== RUN   TestAccIBMCdTektonPipelineDataSourceBasic
--- PASS: TestAccIBMCdTektonPipelineDataSourceBasic (40.10s)
=== RUN   TestAccIBMCdTektonPipelineDataSourceAllArgs
--- PASS: TestAccIBMCdTektonPipelineDataSourceAllArgs (37.62s)
=== RUN   TestAccIBMCdTektonPipelineTriggerPropertyDataSourceBasic
--- PASS: TestAccIBMCdTektonPipelineTriggerPropertyDataSourceBasic (42.02s)
=== RUN   TestAccIBMCdTektonPipelineTriggerPropertyDataSourceAllArgs
--- PASS: TestAccIBMCdTektonPipelineTriggerPropertyDataSourceAllArgs (41.05s)
=== RUN   TestAccIBMCdTektonPipelineTriggerDataSourceBasic
--- PASS: TestAccIBMCdTektonPipelineTriggerDataSourceBasic (39.19s)
=== RUN   TestAccIBMCdTektonPipelineTriggerDataSourceAllArgs
--- PASS: TestAccIBMCdTektonPipelineTriggerDataSourceAllArgs (37.96s)
=== RUN   TestAccIBMCdTektonPipelineDefinitionBasic
--- PASS: TestAccIBMCdTektonPipelineDefinitionBasic (38.26s)
=== RUN   TestAccIBMCdTektonPipelinePropertyBasic
--- PASS: TestAccIBMCdTektonPipelinePropertyBasic (35.66s)
=== RUN   TestAccIBMCdTektonPipelinePropertyAllArgs
--- PASS: TestAccIBMCdTektonPipelinePropertyAllArgs (58.46s)
=== RUN   TestAccIBMCdTektonPipelineBasic
--- PASS: TestAccIBMCdTektonPipelineBasic (31.08s)
=== RUN   TestAccIBMCdTektonPipelineAllArgs
--- PASS: TestAccIBMCdTektonPipelineAllArgs (54.02s)
=== RUN   TestAccIBMCdTektonPipelineTriggerPropertyBasic
--- PASS: TestAccIBMCdTektonPipelineTriggerPropertyBasic (35.25s)
=== RUN   TestAccIBMCdTektonPipelineTriggerPropertyAllArgs
--- PASS: TestAccIBMCdTektonPipelineTriggerPropertyAllArgs (68.06s)
=== RUN   TestAccIBMCdTektonPipelineTriggerBasic
--- PASS: TestAccIBMCdTektonPipelineTriggerBasic (37.00s)
=== RUN   TestAccIBMCdTektonPipelineTriggerAllArgs
--- PASS: TestAccIBMCdTektonPipelineTriggerAllArgs (62.45s)
PASS
ok  	github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/cdtektonpipeline	766.543s
...
```
