### PR TITLE
Removed usage of direct tags API for retrieving tags using resource CRN

### DIFF
--- a/ibm/service/globaltagging/resource_ibm_resource_tag.go
+++ b/ibm/service/globaltagging/resource_ibm_resource_tag.go
@@ -13,7 +13,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/customdiff"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 
-	"github.com/IBM-Cloud/bluemix-go/bmxerror"
 	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/conns"
 	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/flex"
 	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/validate"
@@ -208,8 +207,8 @@ func resourceIBMResourceTagRead(d *schema.ResourceData, meta interface{}) error 
 			d.Set(acccountID, acctID)
 		}
 	}
-	
-	tagList, err = flex.GetGlobalTagsUsingSearchAPI(meta, rID, rType, tType)
+
+	tagList, err := flex.GetGlobalTagsUsingSearchAPI(meta, rID, rType, tType)
 	if err != nil {
 		return fmt.Errorf("[ERROR] Error getting resource tags for: %s with error : %s", rID, err)
 	}

--- a/ibm/service/globaltagging/resource_ibm_resource_tag.go
+++ b/ibm/service/globaltagging/resource_ibm_resource_tag.go
@@ -208,21 +208,10 @@ func resourceIBMResourceTagRead(d *schema.ResourceData, meta interface{}) error 
 			d.Set(acccountID, acctID)
 		}
 	}
-	tagList, err := flex.GetGlobalTagsUsingCRN(meta, rID, rType, tType)
+	
+	tagList, err = flex.GetGlobalTagsUsingSearchAPI(meta, rID, rType, tType)
 	if err != nil {
-		if apierr, ok := err.(bmxerror.RequestFailure); ok && apierr.StatusCode() == 404 {
-			d.SetId("")
-			return nil
-		} else if strings.Contains(err.Error(), "Too Many Requests") {
-
-			tagList, err = flex.GetGlobalTagsUsingSearchAPI(meta, rID, rType, tType)
-			if err != nil {
-				return fmt.Errorf("[ERROR] Error getting resource tags for: %s with error : %s", rID, err)
-			}
-		} else {
-			return fmt.Errorf("[ERROR] Error getting resource tags for: %s with error : %s", rID, err)
-		}
-
+		return fmt.Errorf("[ERROR] Error getting resource tags for: %s with error : %s", rID, err)
 	}
 
 	d.Set(resourceID, rID)


### PR DESCRIPTION
Removed usage of direct tags API for retrieving tags using resource CRN

<!--- See what makes a good Pull Request at : https://github.com/IBM-Cloud/terraform-provider-ibm/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```
