### PR TITLE
Security Group Rule ICMP Type, Code -> Any

### DIFF
--- a/ibm/service/vpc/resource_ibm_is_security_group_rule_test.go
+++ b/ibm/service/vpc/resource_ibm_is_security_group_rule_test.go
@@ -148,6 +148,16 @@ func testAccCheckIBMISsecurityGroupRuleConfig(vpcname, name string) string {
 		  type = 30
 		}
 	  }
+
+	  resource "ibm_is_security_group_rule" "testacc_security_group_rule_icmp_code_any" {
+		depends_on = [ibm_is_security_group_rule.testacc_security_group_rule_icmp]
+		group      = ibm_is_security_group.testacc_security_group.id
+		direction  = "inbound"
+		remote     = "127.0.0.1"
+		icmp {
+		  type = 30
+		}
+	  }
 	  
 	  resource "ibm_is_security_group_rule" "testacc_security_group_rule_udp" {
 		depends_on = [ibm_is_security_group_rule.testacc_security_group_rule_icmp]

--- a/website/docs/r/is_security_group_rule.html.markdown
+++ b/website/docs/r/is_security_group_rule.html.markdown
@@ -105,8 +105,8 @@ Review the argument references that you can specify for your resource.
 - `icmp` - (Optional, List) A nested block describes the `icmp` protocol of this security group rule.
 
   Nested scheme for `icmp`:
-  - `type`- (Required, Integer) The ICMP traffic type to allow. Valid values from 0 to 254.
-  - `code` - (Optional, Integer) The ICMP traffic code to allow. Valid values from 0 to 255.
+  - `type`- (Optional, Integer) The ICMP traffic type to allow. Valid values from 0 to 254. If unspecified, all codes are allowed.
+  - `code` - (Optional, Integer) The ICMP traffic code to allow. Valid values from 0 to 255. If unspecified, all codes are allowed.
 - `remote` - (Optional, String) Security group ID, an IP address, a CIDR block, or a single security group identifier.
 - `tcp` - (Optional, List) A nested block describes the `tcp` protocol of this security group rule.
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/IBM-Cloud/terraform-provider-ibm/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #4051 

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TEST=./ibm/service/vpc TESTARGS='-run=TestAccIBMISSecurityGroupRule_basic'

```
<img width="710" alt="Screenshot 2022-11-22 at 12 33 16 PM" src="https://user-images.githubusercontent.com/78336632/203265639-a37a8260-2b80-4854-baeb-2c8c6ffc0504.png">

Error : Initially if code is not specified then the value would be `0` as shown below, instead it should be `any`
<img width="1519" alt="Screenshot 2022-12-16 at 12 58 05 PM" src="https://user-images.githubusercontent.com/78336632/208045911-9d203768-4184-4892-99ff-f82f076605d6.png">

There is no diff when compared with master branch binary
<img width="998" alt="Screenshot 2022-12-16 at 12 52 46 PM" src="https://user-images.githubusercontent.com/78336632/208045016-36e58697-70d6-48bf-b78f-3a7d7d82f166.png">

After changes the output:
<img width="1490" alt="Screenshot 2022-12-16 at 1 58 53 PM" src="https://user-images.githubusercontent.com/78336632/208056369-9d35500d-1b23-4b96-bf84-cef45d6e71ce.png">

```
resource "ibm_is_vpc" "testacc_vpc" {
  name = "sunitha"
}

resource "ibm_is_security_group" "testacc_security_group" {
  name = "sunitha-sg"
  vpc  = ibm_is_vpc.testacc_vpc.id
}

resource "ibm_is_security_group_rule" "testacc_security_group_rule_all" {
  group     = ibm_is_security_group.testacc_security_group.id
  direction = "inbound"
  remote    = "127.0.0.1"
}

resource "ibm_is_security_group_rule" "testacc_security_group_rule_icmp" {
  group     = ibm_is_security_group.testacc_security_group.id
  direction = "inbound"
  remote    = "127.0.0.1"
  icmp {
    code = 25
    type = 30
  }
}
resource "ibm_is_security_group_rule" "testacc_security_group_rule_icmp_any" {
  group     = ibm_is_security_group.testacc_security_group.id
  direction = "inbound"
  remote    = "127.0.0.1"
  icmp {
    # code = 256
    # type = 30
  }
}

resource "ibm_is_security_group_rule" "testacc_security_group_rule_tcp" {
  group     = ibm_is_security_group.testacc_security_group.id
  direction = "inbound"
  remote    = "127.0.0.1"
  tcp {
    # code = 256
    # type = 30
  }
}

resource "ibm_is_security_group_rule" "testacc_security_group_rule_icmp_type" {
  group     = ibm_is_security_group.testacc_security_group.id
  direction = "inbound"
  remote    = "127.0.0.1"
  icmp {
    # code = 25
    type = 30
  }
}

resource "ibm_is_security_group_rule" "testacc_security_group_rule_icmp_code" {
  group     = ibm_is_security_group.testacc_security_group.id
  direction = "inbound"
  remote    = "127.0.0.1"
  icmp {
    code = 25
    # type = 30
  }
}

```

Output :
```

# ibm_is_security_group_rule.testacc_security_group_rule_all:
resource "ibm_is_security_group_rule" "testacc_security_group_rule_all" {
    direction   = "inbound"
    group       = "r006-f356a2b2-8a2f-46fb-8366-a23aa931ed1e"
    id          = "r006-f356a2b2-8a2f-46fb-8366-a23aa931ed1e.r006-06cf6813-5ace-426d-b346-08df975f5738"
    ip_version  = "ipv4"
    protocol    = "all"
    related_crn = "crn:v1:bluemix:public:is:us-south:a/7f75c7b025e54bc5635f754b2f888665::security-group:r006-f356a2b2-8a2f-46fb-8366-a23aa931ed1e"
    remote      = "127.0.0.1"
    rule_id     = "r006-06cf6813-5ace-426d-b346-08df975f5738"
}

# ibm_is_security_group_rule.testacc_security_group_rule_icmp:
resource "ibm_is_security_group_rule" "testacc_security_group_rule_icmp" {
    direction   = "inbound"
    group       = "r006-f356a2b2-8a2f-46fb-8366-a23aa931ed1e"
    id          = "r006-f356a2b2-8a2f-46fb-8366-a23aa931ed1e.r006-3c5ad11c-fd2e-40fa-b903-a1e8bf1505aa"
    ip_version  = "ipv4"
    protocol    = "icmp"
    related_crn = "crn:v1:bluemix:public:is:us-south:a/7f75c7b025e54bc5635f754b2f888665::security-group:r006-f356a2b2-8a2f-46fb-8366-a23aa931ed1e"
    remote      = "127.0.0.1"
    rule_id     = "r006-3c5ad11c-fd2e-40fa-b903-a1e8bf1505aa"

    icmp {
        code = 25
        type = 30
    }
}

# ibm_is_security_group_rule.testacc_security_group_rule_icmp_any:
resource "ibm_is_security_group_rule" "testacc_security_group_rule_icmp_any" {
    direction   = "inbound"
    group       = "r006-f356a2b2-8a2f-46fb-8366-a23aa931ed1e"
    id          = "r006-f356a2b2-8a2f-46fb-8366-a23aa931ed1e.r006-928cfd72-036a-4d0d-bf8f-279114922b38"
    ip_version  = "ipv4"
    protocol    = "icmp"
    related_crn = "crn:v1:bluemix:public:is:us-south:a/7f75c7b025e54bc5635f754b2f888665::security-group:r006-f356a2b2-8a2f-46fb-8366-a23aa931ed1e"
    remote      = "127.0.0.1"
    rule_id     = "r006-928cfd72-036a-4d0d-bf8f-279114922b38"

    icmp {}
}

# ibm_is_security_group_rule.testacc_security_group_rule_icmp_code:
resource "ibm_is_security_group_rule" "testacc_security_group_rule_icmp_code" {
    direction   = "inbound"
    group       = "r006-f356a2b2-8a2f-46fb-8366-a23aa931ed1e"
    id          = "r006-f356a2b2-8a2f-46fb-8366-a23aa931ed1e.r006-4a021f35-1b6d-4298-913c-25772258c9dd"
    ip_version  = "ipv4"
    protocol    = "icmp"
    related_crn = "crn:v1:bluemix:public:is:us-south:a/7f75c7b025e54bc5635f754b2f888665::security-group:r006-f356a2b2-8a2f-46fb-8366-a23aa931ed1e"
    remote      = "127.0.0.1"
    rule_id     = "r006-4a021f35-1b6d-4298-913c-25772258c9dd"

    icmp {
        code = 25
        type = 0
    }
}

# ibm_is_security_group_rule.testacc_security_group_rule_icmp_type:
resource "ibm_is_security_group_rule" "testacc_security_group_rule_icmp_type" {
    direction   = "inbound"
    group       = "r006-f356a2b2-8a2f-46fb-8366-a23aa931ed1e"
    id          = "r006-f356a2b2-8a2f-46fb-8366-a23aa931ed1e.r006-365d502b-e6ad-438d-9008-9dff217eeea8"
    ip_version  = "ipv4"
    protocol    = "icmp"
    related_crn = "crn:v1:bluemix:public:is:us-south:a/7f75c7b025e54bc5635f754b2f888665::security-group:r006-f356a2b2-8a2f-46fb-8366-a23aa931ed1e"
    remote      = "127.0.0.1"
    rule_id     = "r006-365d502b-e6ad-438d-9008-9dff217eeea8"

    icmp {
        code = 0
        type = 30
    }
}

# ibm_is_security_group_rule.testacc_security_group_rule_tcp:
resource "ibm_is_security_group_rule" "testacc_security_group_rule_tcp" {
    direction   = "inbound"
    group       = "r006-f356a2b2-8a2f-46fb-8366-a23aa931ed1e"
    id          = "r006-f356a2b2-8a2f-46fb-8366-a23aa931ed1e.r006-2b7b77ef-805d-4a10-ab72-17b0e17e1c88"
    ip_version  = "ipv4"
    protocol    = "tcp"
    related_crn = "crn:v1:bluemix:public:is:us-south:a/7f75c7b025e54bc5635f754b2f888665::security-group:r006-f356a2b2-8a2f-46fb-8366-a23aa931ed1e"
    remote      = "127.0.0.1"
    rule_id     = "r006-2b7b77ef-805d-4a10-ab72-17b0e17e1c88"

    tcp {
        port_max = 65535
        port_min = 1
    }
}
```


