### PR TITLE
feat(Cloud Databases): remove bluemix-go dependency for allowlist

### DIFF
--- a/ibm/flex/structures.go
+++ b/ibm/flex/structures.go
@@ -1606,19 +1606,6 @@ func FlattenremoteSubnet(vpn *datatypes.Network_Tunnel_Module_Context) []map[str
 }
 
 // IBM Cloud Databases
-func ExpandWhitelist(whiteList *schema.Set) (whitelist []icdv4.WhitelistEntry) {
-	for _, iface := range whiteList.List() {
-		wlItem := iface.(map[string]interface{})
-		wlEntry := icdv4.WhitelistEntry{
-			Address:     wlItem["address"].(string),
-			Description: wlItem["description"].(string),
-		}
-		whitelist = append(whitelist, wlEntry)
-	}
-	return
-}
-
-// IBM Cloud Databases
 func ExpandAllowlist(allowList *schema.Set) (allowlist []clouddatabasesv5.AllowlistEntry) {
 	for _, iface := range allowList.List() {
 		alItem := iface.(map[string]interface{})
@@ -1631,28 +1618,15 @@ func ExpandAllowlist(allowList *schema.Set) (allowlist []clouddatabasesv5.Allowl
 	return
 }
 
-// Cloud Internet Services
-func FlattenWhitelist(whitelist icdv4.Whitelist) []map[string]interface{} {
-	entries := make([]map[string]interface{}, len(whitelist.WhitelistEntrys), len(whitelist.WhitelistEntrys))
-	for i, whitelistEntry := range whitelist.WhitelistEntrys {
-		l := map[string]interface{}{
-			"address":     whitelistEntry.Address,
-			"description": whitelistEntry.Description,
-		}
-		entries[i] = l
-	}
-	return entries
-}
-
-// Cloud Internet Services
-func FlattenGetAllowlist(allowlist clouddatabasesv5.GetAllowlistResponse) []map[string]interface{} {
-	entries := make([]map[string]interface{}, len(allowlist.IPAddresses), len(allowlist.IPAddresses))
-	for i, allowlistEntry := range allowlist.IPAddresses {
-		l := map[string]interface{}{
+// IBM Cloud Databases
+func FlattenAllowlist(allowlist []clouddatabasesv5.AllowlistEntry) []map[string]interface{} {
+	entries := make([]map[string]interface{}, 0, len(allowlist))
+	for _, allowlistEntry := range allowlist {
+		ip := map[string]interface{}{
 			"address":     allowlistEntry.Address,
 			"description": allowlistEntry.Description,
 		}
-		entries[i] = l
+		entries = append(entries, ip)
 	}
 	return entries
 }

--- a/ibm/flex/structures.go
+++ b/ibm/flex/structures.go
@@ -1606,14 +1606,15 @@ func FlattenremoteSubnet(vpn *datatypes.Network_Tunnel_Module_Context) []map[str
 }
 
 // IBM Cloud Databases
-func ExpandAllowlist(allowList *schema.Set) (allowlist []clouddatabasesv5.AllowlistEntry) {
+func ExpandAllowlist(allowList *schema.Set) (entries []clouddatabasesv5.AllowlistEntry) {
+	entries = make([]clouddatabasesv5.AllowlistEntry, 0, len(allowList.List()))
 	for _, iface := range allowList.List() {
 		alItem := iface.(map[string]interface{})
 		alEntry := &clouddatabasesv5.AllowlistEntry{
 			Address:     core.StringPtr(alItem["address"].(string)),
 			Description: core.StringPtr(alItem["description"].(string)),
 		}
-		allowlist = append(allowlist, *alEntry)
+		entries = append(entries, *alEntry)
 	}
 	return
 }
@@ -1621,12 +1622,12 @@ func ExpandAllowlist(allowList *schema.Set) (allowlist []clouddatabasesv5.Allowl
 // IBM Cloud Databases
 func FlattenAllowlist(allowlist []clouddatabasesv5.AllowlistEntry) []map[string]interface{} {
 	entries := make([]map[string]interface{}, 0, len(allowlist))
-	for _, allowlistEntry := range allowlist {
-		ip := map[string]interface{}{
-			"address":     allowlistEntry.Address,
-			"description": allowlistEntry.Description,
+	for _, ip := range allowlist {
+		entry := map[string]interface{}{
+			"address":     ip.Address,
+			"description": ip.Description,
 		}
-		entries = append(entries, ip)
+		entries = append(entries, entry)
 	}
 	return entries
 }


### PR DESCRIPTION
Related Issue: https://github.com/IBM-Cloud/terraform-provider-ibm/issues/4220

This PR:
- Removes the bluemix-go sdk dependency for supporting the deprecated whitelist attribute
- Uses `PUT /v5/ibm/deployments/{id}/allowlists/ip_addresses` endpoint for setting allowlists

<!--- See what makes a good Pull Request at : https://github.com/IBM-Cloud/terraform-provider-ibm/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
make testacc TEST=./ibm/service/database TESTARGS='-run=TestAccIBMDatabaseInstance'

...
PASS: TestAccIBMDatabaseInstanceElasticsearchImport 
PASS: TestAccIBMDatabaseInstanceEtcdImport 
PASS: TestAccIBMDatabaseInstanceMongodbBasic 
PASS: TestAccIBMDatabaseInstancePostgresAllowlistMigration 
PASS: TestAccIBMDatabaseInstancePostgresBasic 
PASS: TestAccIBMDatabaseInstancePostgresGroup
PASS: TestAccIBMDatabaseInstancePostgresGroupMigration 
PASS: TestAccIBMDatabaseInstancePostgresImport 
PASS: TestAccIBMDatabaseInstancePostgresNode 
PASS: TestAccIBMDatabaseInstance_Elasticsearch_Basic 
PASS: TestAccIBMDatabaseInstance_Elasticsearch_Group 
PASS: TestAccIBMDatabaseInstance_Elasticsearch_Node 
PASS: TestAccIBMDatabaseInstance_Etcd_Basic 
PASS: TestAccIBMDatabaseInstance_Rabbitmq_Basic 
PASS: TestAccIBMDatabaseInstance_Redis_Basic
PASS: TestAccIBMDatabaseInstance_Cassandra_Node
PASS: TestAccIBMDatabaseDataSource_basic
```
