### PR TITLE
fix: make resource_group_id optional for catalogs

### DIFF
--- a/ibm/service/catalogmanagement/resource_ibm_cm_catalog.go
+++ b/ibm/service/catalogmanagement/resource_ibm_cm_catalog.go
@@ -98,6 +98,8 @@ func ResourceIBMCmCatalog() *schema.Resource {
 			"resource_group_id": &schema.Schema{
 				Type:        schema.TypeString,
 				Computed:    true,
+				Optional:    true,
+				ForceNew:    true,
 				Description: "Resource group id the catalog is owned by.",
 			},
 			"owning_account": &schema.Schema{


### PR DESCRIPTION
This PR is fixing a regression in the catalog resource.  The `resource_group_id` field should be optional, this was changed when code was regenerated recently and we need to fix it as soon as possible because it is breaking teams. Thanks.

issue here: https://github.com/IBM-Cloud/terraform-provider-ibm/issues/4216