### PR TITLE
add critical as a pending cluster state

### DIFF
--- a/ibm/service/kubernetes/resource_ibm_container_cluster.go
+++ b/ibm/service/kubernetes/resource_ibm_container_cluster.go
@@ -31,6 +31,7 @@ const (
 	clusterDeploying     = "deploying"
 	clusterPending       = "pending"
 	clusterRequested     = "requested"
+	clusterCritical      = "critical"
 
 	workerNormal        = "normal"
 	subnetNormal        = "normal"
@@ -763,7 +764,7 @@ func resourceIBMContainerClusterCreate(d *schema.ResourceData, meta interface{})
 		}
 
 	case strings.ToLower(clusterNormal):
-		pendingStates := []string{clusterDeploying, clusterRequested, clusterPending, clusterDeployed}
+		pendingStates := []string{clusterDeploying, clusterRequested, clusterPending, clusterDeployed, clusterCritical}
 		_, err = waitForClusterState(d, meta, waitForState, pendingStates)
 		if err != nil {
 			return err

--- a/ibm/service/kubernetes/resource_ibm_container_vpc_cluster.go
+++ b/ibm/service/kubernetes/resource_ibm_container_vpc_cluster.go
@@ -591,7 +591,7 @@ func resourceIBMContainerVpcClusterCreate(d *schema.ResourceData, meta interface
 	switch timeoutStage {
 
 	case strings.ToLower(clusterNormal):
-		pendingStates := []string{clusterDeploying, clusterRequested, clusterPending, clusterDeployed}
+		pendingStates := []string{clusterDeploying, clusterRequested, clusterPending, clusterDeployed, clusterCritical}
 		_, err = waitForVpcClusterState(d, meta, clusterNormal, pendingStates)
 		if err != nil {
 			return err


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/IBM-Cloud/terraform-provider-ibm/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #4214

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
% make testacc TEST=./ibm/service/kubernetes TESTARGS='-run=TestAccIBMContainerVpcClusterEnvvar'
...
=== RUN   TestAccIBMContainerVpcClusterEnvvar
--- PASS: TestAccIBMContainerVpcClusterEnvvar (1493.94s)
PASS
ok      github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/kubernetes      1495.348s

% make testacc TEST=./ibm/service/kubernetes TESTARGS='-run=TestAccIBMContainer_ClusterConfigDataSourceVpcBasic'
...
=== RUN   TestAccIBMContainer_ClusterConfigDataSourceVpcBasic
--- PASS: TestAccIBMContainer_ClusterConfigDataSourceVpcBasic (1787.98s)
PASS
ok      github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/kubernetes      1789.338s

...
```
