### PR TITLE
Dont set python in rhel8 satellite script

### DIFF
--- a/ibm/service/satellite/data_source_ibm_satellite_host_script.go
+++ b/ibm/service/satellite/data_source_ibm_satellite_host_script.go
@@ -191,27 +191,27 @@ if [[ "${OPERATING_SYSTEM}" == "RHEL7" ]]; then
 	subscription-manager repos --enable rhel-7-server-supplementary-rpms
 	subscription-manager repos --enable rhel-7-server-extras-rpms
 elif [[ "${OPERATING_SYSTEM}" == "RHEL8" ]]; then
-  subscription-manager release --set=8
+	subscription-manager release --set=8
+	subscription-manager repos --disable='*eus*'
 	subscription-manager repos --enable rhel-8-for-x86_64-baseos-rpms 
 	subscription-manager repos --enable rhel-8-for-x86_64-appstream-rpms;
-  subscription-manager repos --disable='*eus*'
 fi
 yum install container-selinux -y
 `
 		case strings.ToLower(hostProvider) == "azure":
 			insertionText = `
-if [[ "${OPERATING_SYSTEM}" == "RHEL8" ]]; then
-	update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.8 1
-	update-alternatives --set python3 /usr/bin/python3.8
-fi
+#if [[ "${OPERATING_SYSTEM}" == "RHEL8" ]]; then
+#	update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.8 1
+#	update-alternatives --set python3 /usr/bin/python3.8
+#fi
 yum install container-selinux -y
 `
 		case strings.ToLower(hostProvider) == "google":
 			insertionText = `
-if [[ "${OPERATING_SYSTEM}" == "RHEL8" ]]; then
-	update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.8 1
-	update-alternatives --set python3 /usr/bin/python3.8
-fi
+#if [[ "${OPERATING_SYSTEM}" == "RHEL8" ]]; then
+#	update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.8 1
+#	update-alternatives --set python3 /usr/bin/python3.8
+#fi
 yum install container-selinux -y
 `
 		default:


### PR DESCRIPTION
The recent bom change for RHEL8 means we don't need to set the python version anymore. Comment it out because it's causing us issues (attach script uses 3.9, forcing it down to 3.8 is no good)