### PR TITLE
change from fixed to to append new line to slice

### DIFF
--- a/ibm/flex/structures.go
+++ b/ibm/flex/structures.go
@@ -3387,14 +3387,12 @@ func FlattenSatelliteHosts(hostList []kubernetesserviceapiv1.MultishiftQueueNode
 }
 
 func FlattenWorkerPoolHostLabels(hostLabels map[string]string) *schema.Set {
-	mapped := make([]string, len(hostLabels)-1)
-	idx := 0
+	mapped := make([]string, 0)
 	for k, v := range hostLabels {
 		if strings.HasPrefix(k, "os") {
 			continue
 		}
-		mapped[idx] = fmt.Sprintf("%s:%v", k, v)
-		idx++
+		mapped = append(mapped, fmt.Sprintf("%s:%v", k, v))
 	}
 
 	return NewStringSet(schema.HashString, mapped)


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/IBM-Cloud/terraform-provider-ibm/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->

Fixes issue with older worker pools that do not have os label applied and were hitting out of bounds error (because there were no host labels on the worker pool): `panic: runtime error: makeslice: len out of range`

Since we cannot know the number of labels, change is to start with a slice of size 0 and increase slice length as number of labels increases.

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
make testacc TEST=./ibm/service/satellite TESTARGS='-run=TestAccSatelliteCluster_Basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./ibm/service/satellite -v -run=TestAccSatelliteCluster_Basic -timeout 700m
--- PASS: TestAccSatelliteCluster_Basic (4573.43s)
PASS
ok      github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/satellite       4574.894s

```

```
make testacc TEST=./ibm/service/satellite TESTARGS='-run=TestAccSatelliteClusterWorkerPool_Basic'

==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./ibm/service/satellite -v -run=TestAccSatelliteClusterWorkerPool_Basic -timeout 700m
--- PASS: TestAccSatelliteClusterWorkerPool_Basic (4886.39s)
PASS
ok      github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/satellite       4887.689s
```

I also tested this locally and hit no issues - though I do not have a worker pool w/no host labels to truly replicate the error scenario.