### PR TITLE
fix(networkacl) : made name optional to allow create_before_destroy

### DIFF
--- a/ibm/acctest/acctest.go
+++ b/ibm/acctest/acctest.go
@@ -61,6 +61,7 @@ var UpdatedCertCRN string
 var RegionName string
 var ISZoneName string
 var ISZoneName2 string
+var IsResourceGroupID string
 var ISCIDR string
 var ISCIDR2 string
 var ISAddressPrefixCIDR string
@@ -498,6 +499,12 @@ func init() {
 	if ISAddressPrefixCIDR == "" {
 		ISAddressPrefixCIDR = "10.120.0.0/24"
 		fmt.Println("[INFO] Set the environment variable SL_ADDRESS_PREFIX_CIDR for testing ibm_is_vpc_address_prefix else it is set to default value '10.120.0.0/24'")
+	}
+
+	IsResourceGroupID = os.Getenv("SL_RESOURCE_GROUP_ID")
+	if IsResourceGroupID == "" {
+		IsResourceGroupID = "c01d34dff4364763476834c990398zz8"
+		fmt.Println("[INFO] Set the environment variable SL_RESOURCE_GROUP_ID for testing with different resource group id else it is set to default value 'c01d34dff4364763476834c990398zz8'")
 	}
 
 	IsImage = os.Getenv("IS_IMAGE")

--- a/ibm/service/vpc/resource_ibm_is_networkacls.go
+++ b/ibm/service/vpc/resource_ibm_is_networkacls.go
@@ -77,8 +77,8 @@ func ResourceIBMISNetworkACL() *schema.Resource {
 		Schema: map[string]*schema.Schema{
 			isNetworkACLName: {
 				Type:         schema.TypeString,
-				Required:     true,
-				ForceNew:     false,
+				Optional:     true,
+				Computed:     true,
 				ValidateFunc: validate.InvokeValidator("ibm_is_network_acl", isNetworkACLName),
 				Description:  "Network ACL name",
 			},
@@ -311,7 +311,7 @@ func ResourceIBMISNetworkACLValidator() *validate.ResourceValidator {
 			Identifier:                 isNetworkACLName,
 			ValidateFunctionIdentifier: validate.ValidateRegexpLen,
 			Type:                       validate.TypeString,
-			Required:                   true,
+			Required:                   false,
 			Regexp:                     `^([a-z]|[a-z][-a-z0-9]*[a-z0-9])$`,
 			MinValueLength:             1,
 			MaxValueLength:             63})
@@ -425,10 +425,12 @@ func nwaclCreate(d *schema.ResourceData, meta interface{}, name string) error {
 	}
 
 	nwaclTemplate := &vpcv1.NetworkACLPrototype{
-		Name: &name,
 		VPC: &vpcv1.VPCIdentity{
 			ID: &vpc,
 		},
+	}
+	if name != "" {
+		nwaclTemplate.Name = &name
 	}
 
 	if grp, ok := d.GetOk(isNetworkACLResourceGroup); ok {

--- a/website/docs/r/is_network_acl.html.markdown
+++ b/website/docs/r/is_network_acl.html.markdown
@@ -66,7 +66,7 @@ Review the argument references that you can specify for your resource.
   **&#x2022;** For more information, about creating access tags, see [working with tags](https://cloud.ibm.com/docs/account?topic=account-tag&interface=ui#create-access-console).</br>
   **&#x2022;** You must have the access listed in the [Granting users access to tag resources](https://cloud.ibm.com/docs/account?topic=account-access) for `access_tags`</br>
   **&#x2022;** `access_tags` must be in the format `key:value`.
-- `name` - (Required, String) The name of the network ACL.
+- `name` - (Optional, String) The name of the network ACL. If unspecified, the name will be a hyphenated list of randomly-selected words.
 - `resource_group` - (Optional, Forces new resource, String) The ID of the resource group where you want to create the network ACL.
 - `rules`- (Optional, Array of Strings) A list of rules for a network ACL. The order in which the rules are added to the list determines the priority of the rules. For example, the first rule that you want to enforce must be specified as the first rule in this list.
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/IBM-Cloud/terraform-provider-ibm/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
=== RUN   TestNetworkACLResourceGroupUpdate
--- PASS: TestNetworkACLResourceGroupUpdate (220.13s)
PASS
ok      github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/vpc     225.381s

```
