### PR TITLE
Fix ibm_appid_cloud_directory_user missing userName

### DIFF
--- a/ibm/service/appid/resource_ibm_appid_cloud_directory_user.go
+++ b/ibm/service/appid/resource_ibm_appid_cloud_directory_user.go
@@ -240,6 +240,10 @@ func resourceIBMAppIDCloudDirectoryUserCreate(ctx context.Context, d *schema.Res
 		input.LockedUntil = core.Int64Ptr(int64(lockedUntil.(int)))
 	}
 
+	if userName, ok := d.GetOk("user_name"); ok {
+		input.UserName = helpers.String(userName.(string))
+	}
+
 	user, resp, err := appIDClient.StartSignUpWithContext(ctx, input)
 
 	if err != nil {
@@ -304,6 +308,9 @@ func resourceIBMAppIDCloudDirectoryUserUpdate(ctx context.Context, d *schema.Res
 		input.LockedUntil = core.Int64Ptr(int64(lockedUntil.(int)))
 	}
 
+	if userName, ok := d.GetOk("user_name"); ok {
+		input.UserName = helpers.String(userName.(string))
+	}
 	_, resp, err := appIDClient.UpdateCloudDirectoryUserWithContext(ctx, input)
 
 	if err != nil {


### PR DESCRIPTION
Test results
```
harinireddy@Harinis-MacBook-Pro appid % terraform12-1 apply

An execution plan has been generated and is shown below.
Resource actions are indicated with the following symbols:
  + create

Terraform will perform the following actions:

  # ibm_appid_cloud_directory_user.user will be created
  + resource "ibm_appid_cloud_directory_user" "user" {
      + active         = true
      + create_profile = true
      + display_name   = (known after apply)
      + id             = (known after apply)
      + meta           = (known after apply)
      + password       = (sensitive value)
      + status         = "PENDING"
      + subject        = (known after apply)
      + tenant_id      = "fb3829f0-dc61-446e-b683-f89c22229fbb"
      + user_id        = (known after apply)
      + user_name      = "HariniReddy"

      + email {
          + primary = true
          + value   = "hkantare@in.ibm.com"
        }
    }

Plan: 1 to add, 0 to change, 0 to destroy.

Do you want to perform these actions?
  Terraform will perform the actions described above.
  Only 'yes' will be accepted to approve.

  Enter a value: yes

ibm_appid_cloud_directory_user.user: Creating...
ibm_appid_cloud_directory_user.user: Creation complete after 3s [id=fb3829f0-dc61-446e-b683-f89c22229fbb/d8c2f4d7-cf71-41f5-a16d-4039dcb7ea28]

Apply complete! Resources: 1 added, 0 changed, 0 destroyed.
harinireddy@Harinis-MacBook-Pro appid % terraform12-1 show 
# ibm_appid_cloud_directory_user.user:
resource "ibm_appid_cloud_directory_user" "user" {
    active         = true
    create_profile = true
    display_name   = "HariniReddy"
    id             = "fb3829f0-dc61-446e-b683-f89c22229fbb/d8c2f4d7-cf71-41f5-a16d-4039dcb7ea28"
    meta           = [
        {
            created       = "2023-01-20T14:18:45.043Z"
            last_modified = "2023-01-20T14:18:45.043Z"
        },
    ]
    password       = (sensitive value)
    status         = "PENDING"
    subject        = "7feb2219-6e87-4897-89c9-cb037f516f2d"
    tenant_id      = "fb3829f0-dc61-446e-b683-f89c22229fbb"
    user_id        = "d8c2f4d7-cf71-41f5-a16d-4039dcb7ea28"
    user_name      = "HariniReddy"

    email {
        primary = true
        value   = "hkantare@in.ibm.com"
    }
}
harinireddy@Harinis-MacBook-Pro appid % terraform12-1 plan
Refreshing Terraform state in-memory prior to plan...
The refreshed state will be used to calculate this plan, but will not be
persisted to local or remote state storage.

ibm_appid_cloud_directory_user.user: Refreshing state... [id=fb3829f0-dc61-446e-b683-f89c22229fbb/d8c2f4d7-cf71-41f5-a16d-4039dcb7ea28]

------------------------------------------------------------------------

No changes. Infrastructure is up-to-date.

This means that Terraform did not detect any differences between your
configuration and real physical resources that exist. As a result, no
actions need to be performed.
harinireddy@Harinis-MacBook-Pro appid % terraform12-1 destroy
ibm_appid_cloud_directory_user.user: Refreshing state... [id=fb3829f0-dc61-446e-b683-f89c22229fbb/d8c2f4d7-cf71-41f5-a16d-4039dcb7ea28]

An execution plan has been generated and is shown below.
Resource actions are indicated with the following symbols:
  - destroy

Terraform will perform the following actions:

  # ibm_appid_cloud_directory_user.user will be destroyed
  - resource "ibm_appid_cloud_directory_user" "user" {
      - active         = true -> null
      - create_profile = true -> null
      - display_name   = "HariniReddy" -> null
      - id             = "fb3829f0-dc61-446e-b683-f89c22229fbb/d8c2f4d7-cf71-41f5-a16d-4039dcb7ea28" -> null
      - meta           = [
          - {
              - created       = "2023-01-20T14:18:45.043Z"
              - last_modified = "2023-01-20T14:18:45.043Z"
            },
        ] -> null
      - password       = (sensitive value)
      - status         = "PENDING" -> null
      - subject        = "7feb2219-6e87-4897-89c9-cb037f516f2d" -> null
      - tenant_id      = "fb3829f0-dc61-446e-b683-f89c22229fbb" -> null
      - user_id        = "d8c2f4d7-cf71-41f5-a16d-4039dcb7ea28" -> null
      - user_name      = "HariniReddy" -> null

      - email {
          - primary = true -> null
          - value   = "hkantare@in.ibm.com" -> null
        }
    }

Plan: 0 to add, 0 to change, 1 to destroy.

Do you really want to destroy all resources?
  Terraform will destroy all your managed infrastructure, as shown above.
  There is no undo. Only 'yes' will be accepted to confirm.

  Enter a value: yes

ibm_appid_cloud_directory_user.user: Destroying... [id=fb3829f0-dc61-446e-b683-f89c22229fbb/d8c2f4d7-cf71-41f5-a16d-4039dcb7ea28]
ibm_appid_cloud_directory_user.user: Destruction complete after 1s

Destroy complete! Resources: 1 destroyed.
harinireddy@Harinis-MacBook-Pro appid % terraform12-1 apply  

An execution plan has been generated and is shown below.
Resource actions are indicated with the following symbols:
  + create

Terraform will perform the following actions:

  # ibm_appid_cloud_directory_user.user will be created
  + resource "ibm_appid_cloud_directory_user" "user" {
      + active         = true
      + create_profile = true
      + display_name   = (known after apply)
      + id             = (known after apply)
      + meta           = (known after apply)
      + password       = (sensitive value)
      + status         = "PENDING"
      + subject        = (known after apply)
      + tenant_id      = "fb3829f0-dc61-446e-b683-f89c22229fbb"
      + user_id        = (known after apply)
      + user_name      = "HariniReddy"

      + email {
          + primary = true
          + value   = "hkantare@in.ibm.com"
        }
    }

Plan: 1 to add, 0 to change, 0 to destroy.

Do you want to perform these actions?
  Terraform will perform the actions described above.
  Only 'yes' will be accepted to approve.

  Enter a value: yes

ibm_appid_cloud_directory_user.user: Creating...
ibm_appid_cloud_directory_user.user: Creation complete after 3s [id=fb3829f0-dc61-446e-b683-f89c22229fbb/23928436-7699-4250-9ca8-3cad37a3b9ca]

Apply complete! Resources: 1 added, 0 changed, 0 destroyed.
harinireddy@Harinis-MacBook-Pro appid % terraform12-1 show 
# ibm_appid_cloud_directory_user.user:
resource "ibm_appid_cloud_directory_user" "user" {
    active         = true
    create_profile = true
    display_name   = "hkantare@in.ibm.com"
    id             = "fb3829f0-dc61-446e-b683-f89c22229fbb/23928436-7699-4250-9ca8-3cad37a3b9ca"
    meta           = [
        {
            created       = "2023-01-20T14:23:23.933Z"
            last_modified = "2023-01-20T14:23:23.933Z"
        },
    ]
    password       = (sensitive value)
    status         = "PENDING"
    subject        = "613990dc-c04e-420a-83f4-bc35ca8e37e0"
    tenant_id      = "fb3829f0-dc61-446e-b683-f89c22229fbb"
    user_id        = "23928436-7699-4250-9ca8-3cad37a3b9ca"
    user_name      = "HariniReddy"

    email {
        primary = true
        value   = "hkantare@in.ibm.com"
    }
}
harinireddy@Harinis-MacBook-Pro appid % terraform12-1 plan
Refreshing Terraform state in-memory prior to plan...
The refreshed state will be used to calculate this plan, but will not be
persisted to local or remote state storage.

ibm_appid_cloud_directory_user.user: Refreshing state... [id=fb3829f0-dc61-446e-b683-f89c22229fbb/23928436-7699-4250-9ca8-3cad37a3b9ca]

------------------------------------------------------------------------

No changes. Infrastructure is up-to-date.

This means that Terraform did not detect any differences between your
configuration and real physical resources that exist. As a result, no
actions need to be performed.
harinireddy@Harinis-MacBook-Pro appid % terraform12-1 destroy
ibm_appid_cloud_directory_user.user: Refreshing state... [id=fb3829f0-dc61-446e-b683-f89c22229fbb/23928436-7699-4250-9ca8-3cad37a3b9ca]

An execution plan has been generated and is shown below.
Resource actions are indicated with the following symbols:
  - destroy

Terraform will perform the following actions:

  # ibm_appid_cloud_directory_user.user will be destroyed
  - resource "ibm_appid_cloud_directory_user" "user" {
      - active         = true -> null
      - create_profile = true -> null
      - display_name   = "hkantare@in.ibm.com" -> null
      - id             = "fb3829f0-dc61-446e-b683-f89c22229fbb/23928436-7699-4250-9ca8-3cad37a3b9ca" -> null
      - meta           = [
          - {
              - created       = "2023-01-20T14:23:23.933Z"
              - last_modified = "2023-01-20T14:23:23.933Z"
            },
        ] -> null
      - password       = (sensitive value)
      - status         = "PENDING" -> null
      - subject        = "613990dc-c04e-420a-83f4-bc35ca8e37e0" -> null
      - tenant_id      = "fb3829f0-dc61-446e-b683-f89c22229fbb" -> null
      - user_id        = "23928436-7699-4250-9ca8-3cad37a3b9ca" -> null
      - user_name      = "HariniReddy" -> null

      - email {
          - primary = true -> null
          - value   = "hkantare@in.ibm.com" -> null
        }
    }

Plan: 0 to add, 0 to change, 1 to destroy.

Do you really want to destroy all resources?
  Terraform will destroy all your managed infrastructure, as shown above.
  There is no undo. Only 'yes' will be accepted to confirm.

  Enter a value: yes

ibm_appid_cloud_directory_user.user: Destroying... [id=fb3829f0-dc61-446e-b683-f89c22229fbb/23928436-7699-4250-9ca8-3cad37a3b9ca]
ibm_appid_cloud_directory_user.user: Destruction complete after 2s

Destroy complete! Resources: 1 destroyed.
harinireddy@Harinis-MacBook-Pro appid % terraform12-1 plan   
Refreshing Terraform state in-memory prior to plan...
The refreshed state will be used to calculate this plan, but will not be
persisted to local or remote state storage.


------------------------------------------------------------------------

An execution plan has been generated and is shown below.
Resource actions are indicated with the following symbols:
  + create

Terraform will perform the following actions:

  # ibm_appid_cloud_directory_user.user will be created
  + resource "ibm_appid_cloud_directory_user" "user" {
      + active         = true
      + create_profile = true
      + display_name   = (known after apply)
      + id             = (known after apply)
      + meta           = (known after apply)
      + password       = (sensitive value)
      + status         = "PENDING"
      + subject        = (known after apply)
      + tenant_id      = "fb3829f0-dc61-446e-b683-f89c22229fbb"
      + user_id        = (known after apply)

      + email {
          + primary = true
          + value   = "hkantare@in.ibm.com"
        }
    }

Plan: 1 to add, 0 to change, 0 to destroy.

------------------------------------------------------------------------

Note: You didn't specify an "-out" parameter to save this plan, so Terraform
can't guarantee that exactly these actions will be performed if
"terraform apply" is subsequently run.

harinireddy@Harinis-MacBook-Pro appid % terraform12-1 apply  

An execution plan has been generated and is shown below.
Resource actions are indicated with the following symbols:
  + create

Terraform will perform the following actions:

  # ibm_appid_cloud_directory_user.user will be created
  + resource "ibm_appid_cloud_directory_user" "user" {
      + active         = true
      + create_profile = true
      + display_name   = (known after apply)
      + id             = (known after apply)
      + meta           = (known after apply)
      + password       = (sensitive value)
      + status         = "PENDING"
      + subject        = (known after apply)
      + tenant_id      = "fb3829f0-dc61-446e-b683-f89c22229fbb"
      + user_id        = (known after apply)

      + email {
          + primary = true
          + value   = "hkantare@in.ibm.com"
        }
    }

Plan: 1 to add, 0 to change, 0 to destroy.

Do you want to perform these actions?
  Terraform will perform the actions described above.
  Only 'yes' will be accepted to approve.

  Enter a value: yes

ibm_appid_cloud_directory_user.user: Creating...
ibm_appid_cloud_directory_user.user: Creation complete after 4s [id=fb3829f0-dc61-446e-b683-f89c22229fbb/6fafdb99-5046-4b77-a6a4-8c9cd75f44fd]

Apply complete! Resources: 1 added, 0 changed, 0 destroyed.
harinireddy@Harinis-MacBook-Pro appid % terraform12-1 show   
# ibm_appid_cloud_directory_user.user:
resource "ibm_appid_cloud_directory_user" "user" {
    active         = true
    create_profile = true
    display_name   = "hkantare@in.ibm.com"
    id             = "fb3829f0-dc61-446e-b683-f89c22229fbb/6fafdb99-5046-4b77-a6a4-8c9cd75f44fd"
    meta           = [
        {
            created       = "2023-01-20T14:25:39.159Z"
            last_modified = "2023-01-20T14:25:39.159Z"
        },
    ]
    password       = (sensitive value)
    status         = "PENDING"
    subject        = "3a8ad192-e34c-4005-b37a-9a2bb7263a62"
    tenant_id      = "fb3829f0-dc61-446e-b683-f89c22229fbb"
    user_id        = "6fafdb99-5046-4b77-a6a4-8c9cd75f44fd"

    email {
        primary = true
        value   = "hkantare@in.ibm.com"
    }
}
harinireddy@Harinis-MacBook-Pro appid % terraform12-1 show
# ibm_appid_cloud_directory_user.user:
resource "ibm_appid_cloud_directory_user" "user" {
    active         = true
    create_profile = true
    display_name   = "hkantare@in.ibm.com"
    id             = "fb3829f0-dc61-446e-b683-f89c22229fbb/6fafdb99-5046-4b77-a6a4-8c9cd75f44fd"
    meta           = [
        {
            created       = "2023-01-20T14:25:39.159Z"
            last_modified = "2023-01-20T14:25:39.159Z"
        },
    ]
    password       = (sensitive value)
    status         = "PENDING"
    subject        = "3a8ad192-e34c-4005-b37a-9a2bb7263a62"
    tenant_id      = "fb3829f0-dc61-446e-b683-f89c22229fbb"
    user_id        = "6fafdb99-5046-4b77-a6a4-8c9cd75f44fd"

    email {
        primary = true
        value   = "hkantare@in.ibm.com"
    }
}
harinireddy@Harinis-MacBook-Pro appid % terraform12-1 plan
Refreshing Terraform state in-memory prior to plan...
The refreshed state will be used to calculate this plan, but will not be
persisted to local or remote state storage.

ibm_appid_cloud_directory_user.user: Refreshing state... [id=fb3829f0-dc61-446e-b683-f89c22229fbb/6fafdb99-5046-4b77-a6a4-8c9cd75f44fd]

------------------------------------------------------------------------

No changes. Infrastructure is up-to-date.

This means that Terraform did not detect any differences between your
configuration and real physical resources that exist. As a result, no
actions need to be performed.
harinireddy@Harinis-MacBook-Pro appid % terraform12-1 apply
ibm_appid_cloud_directory_user.user: Refreshing state... [id=fb3829f0-dc61-446e-b683-f89c22229fbb/6fafdb99-5046-4b77-a6a4-8c9cd75f44fd]

Apply complete! Resources: 0 added, 0 changed, 0 destroyed.
```