### PR TITLE
fix: allow cm_object data to be set/updated when already unquoted

### DIFF
--- a/ibm/service/catalogmanagement/resource_ibm_cm_object.go
+++ b/ibm/service/catalogmanagement/resource_ibm_cm_object.go
@@ -260,7 +260,7 @@ func resourceIBMCmObjectCreate(context context.Context, d *schema.ResourceData, 
 		dataMap := make(map[string]interface{})
 		dataString, err := strconv.Unquote(d.Get("data").(string))
 		if err != nil {
-			return diag.FromErr(fmt.Errorf("error unquoting json string %s", err))
+			dataString = d.Get("data").(string)
 		}
 		err = json.Unmarshal([]byte(dataString), &dataMap)
 		if err != nil {
@@ -484,7 +484,7 @@ func resourceIBMCmObjectUpdate(context context.Context, d *schema.ResourceData, 
 		dataMap := make(map[string]interface{})
 		dataString, err := strconv.Unquote(d.Get("data").(string))
 		if err != nil {
-			return diag.FromErr(fmt.Errorf("error unquoting json string %s", err))
+			dataString = d.Get("data").(string)
 		}
 		err = json.Unmarshal([]byte(dataString), &dataMap)
 		if err != nil {


### PR DESCRIPTION
@vbontempi was getting an error when using the cm_object data field.  There was a bug where the provider code tried to unquote the data every single time, leading to errors.  This fix allows the data field to be set when it is already unquoted.