### PR TITLE
Remove deprecated resource notification for VPC route resource

### DIFF
--- a/ibm/service/vpc/resource_ibm_is_vpc_route.go
+++ b/ibm/service/vpc/resource_ibm_is_vpc_route.go
@@ -34,7 +34,7 @@ const (
 
 func ResourceIBMISVpcRoute() *schema.Resource {
 	return &schema.Resource{
-		DeprecationMessage: "This resource is deprecated, use ibm_is_vpc_routing_table_route instead.",
+		DeprecationMessage: "Resource Removal: Resource ibm_is_vpc_route is deprecated and being removed. Use ibm_is_vpc_routing_table_route for creating routes for VPC routing table.\n This resource will not be available from next release (v1.51.0).",
 		Create:             resourceIBMISVpcRouteCreate,
 		Read:               resourceIBMISVpcRouteRead,
 		Update:             resourceIBMISVpcRouteUpdate,

--- a/ibm/service/vpc/resource_ibm_is_vpc_route.go
+++ b/ibm/service/vpc/resource_ibm_is_vpc_route.go
@@ -34,7 +34,7 @@ const (
 
 func ResourceIBMISVpcRoute() *schema.Resource {
 	return &schema.Resource{
-		DeprecationMessage: "Resource Removal: Resource ibm_is_vpc_route is deprecated and being removed. Use ibm_is_vpc_routing_table_route for creating routes for VPC routing table.\n This resource will not be available from next release (v1.51.0).",
+		DeprecationMessage: "Resource Removal: Resource ibm_is_vpc_route is deprecated and being removed. Use ibm_is_vpc_routing_table_route for creating routes for VPC routing table.\n This resource will not be available from next release (v1.52.0).",
 		Create:             resourceIBMISVpcRouteCreate,
 		Read:               resourceIBMISVpcRouteRead,
 		Update:             resourceIBMISVpcRouteUpdate,

--- a/website/docs/r/is_vpc_route.html.markdown
+++ b/website/docs/r/is_vpc_route.html.markdown
@@ -7,7 +7,10 @@ description: |-
   Manages IBM IS VPC route.
 ---
 
-~>**Note**  This resource is deprecated, use `ibm_is_vpc_routing_table_route` instead.
+!> **Removal Notification** Resource `ibm_is_vpc_route` support will be stopped by terraform provider from `v1.51.0`; [releases](https://github.com/IBM-Cloud/terraform-provider-ibm/releases/), recommendation is to use `ibm_is_vpc_routing_table_route` instead. </br>
+**Documentation** on `ibm_is_vpc_routing_table_route` can be found [here](https://registry.terraform.io/providers/IBM-Cloud/ibm/latest/docs/resources/is_vpc_routing_table_route)
+
+
 # ibm_is_vpc_route
 Create, update, or delete a VPC route. For more information, about VPC routes, see [setting up advanced routing in VPC](https://cloud.ibm.com/docs/vpc?topic=vpc-about-custom-routes).
 

--- a/website/docs/r/is_vpc_route.html.markdown
+++ b/website/docs/r/is_vpc_route.html.markdown
@@ -7,7 +7,7 @@ description: |-
   Manages IBM IS VPC route.
 ---
 
-!> **Removal Notification** Resource `ibm_is_vpc_route` support will be stopped by terraform provider from `v1.51.0`; [releases](https://github.com/IBM-Cloud/terraform-provider-ibm/releases/), recommendation is to use `ibm_is_vpc_routing_table_route` instead. </br>
+!> **Removal Notification** Resource `ibm_is_vpc_route` support will be stopped by terraform provider from `v1.52.0`; [releases](https://github.com/IBM-Cloud/terraform-provider-ibm/releases/), recommendation is to use `ibm_is_vpc_routing_table_route` instead. </br>
 **Documentation** on `ibm_is_vpc_routing_table_route` can be found [here](https://registry.terraform.io/providers/IBM-Cloud/ibm/latest/docs/resources/is_vpc_routing_table_route)
 
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/IBM-Cloud/terraform-provider-ibm/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```
