### PR TITLE
enhancement(clone): support for backup policy plan clone

### DIFF
--- a/examples/ibm-is-ng/main.tf
+++ b/examples/ibm-is-ng/main.tf
@@ -1096,6 +1096,22 @@ resource "ibm_is_backup_policy_plan" "is_backup_policy_plan" {
   }
   name = "my-backup-policy-plan-1"
 }
+resource "ibm_is_backup_policy_plan" "is_backup_policy_plan_clone" {
+  backup_policy_id = ibm_is_backup_policy.is_backup_policy.id
+  cron_spec        = "30 09 * * *"
+  active           = false
+  attach_user_tags = ["tag2"]
+  copy_user_tags = true
+  deletion_trigger {
+    delete_after      = 20
+    delete_over_count = "20"
+  }
+  name = "my-backup-policy-plan-1"
+  clone_policy {
+    zones 			= ["us-south-1", "us-south-2"]
+    max_snapshots 	= 3
+  }
+}
 
 data "ibm_is_backup_policies" "is_backup_policies" {
 }

--- a/ibm/service/vpc/data_source_ibm_is_backup_policy_plan.go
+++ b/ibm/service/vpc/data_source_ibm_is_backup_policy_plan.go
@@ -94,6 +94,25 @@ func DataSourceIBMIsBackupPolicyPlan() *schema.Resource {
 				Computed:    true,
 				Description: "The lifecycle state of this backup policy plan.",
 			},
+			"clone_policy": &schema.Schema{
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"max_snapshots": &schema.Schema{
+							Type:        schema.TypeInt,
+							Computed:    true,
+							Description: "The maximum number of recent snapshots (per source) that will keep clones.",
+						},
+						"zones": &schema.Schema{
+							Type:        schema.TypeSet,
+							Elem:        &schema.Schema{Type: schema.TypeString},
+							Computed:    true,
+							Description: "The zone this backup policy plan will create snapshot clones in.",
+						},
+					},
+				},
+			},
 			"resource_type": &schema.Schema{
 				Type:        schema.TypeString,
 				Computed:    true,
@@ -169,6 +188,23 @@ func dataSourceIBMIsBackupPolicyPlanRead(context context.Context, d *schema.Reso
 		if err != nil {
 			return diag.FromErr(fmt.Errorf("[ERROR] Error setting deletion_trigger %s", err))
 		}
+	}
+	if backupPolicyPlan.ClonePolicy != nil {
+		backupPolicyPlanClonePolicyMap := []map[string]interface{}{}
+		finalList := map[string]interface{}{}
+
+		if backupPolicyPlan.ClonePolicy.MaxSnapshots != nil {
+			finalList["max_snapshots"] = flex.IntValue(backupPolicyPlan.ClonePolicy.MaxSnapshots)
+		}
+		if backupPolicyPlan.ClonePolicy.Zones != nil && len(backupPolicyPlan.ClonePolicy.Zones) != 0 {
+			zoneList := []string{}
+			for i := 0; i < len(backupPolicyPlan.ClonePolicy.Zones); i++ {
+				zoneList = append(zoneList, string(*(backupPolicyPlan.ClonePolicy.Zones[i].Name)))
+			}
+			finalList["zones"] = flex.NewStringSet(schema.HashString, zoneList)
+		}
+		backupPolicyPlanClonePolicyMap = append(backupPolicyPlanClonePolicyMap, finalList)
+		d.Set("clone_policy", backupPolicyPlanClonePolicyMap)
 	}
 	if err = d.Set("href", backupPolicyPlan.Href); err != nil {
 		return diag.FromErr(fmt.Errorf("[ERROR] Error setting href: %s", err))

--- a/ibm/service/vpc/data_source_ibm_is_backup_policy_plan_test.go
+++ b/ibm/service/vpc/data_source_ibm_is_backup_policy_plan_test.go
@@ -48,10 +48,56 @@ func TestAccIBMIsBackupPolicyPlanDataSourceBasic(t *testing.T) {
 		},
 	})
 }
+func TestAccIBMIsBackupPolicyPlanDataSourceClonesBasic(t *testing.T) {
+	vpcname := fmt.Sprintf("tf-vpc-%d", acctest.RandIntRange(10, 100))
+	name := fmt.Sprintf("tf-instnace-%d", acctest.RandIntRange(10, 100))
+	subnetname := fmt.Sprintf("tf-subnet-%d", acctest.RandIntRange(10, 100))
+	sshname := fmt.Sprintf("tf-ssh-%d", acctest.RandIntRange(10, 100))
+	volname := fmt.Sprintf("tf-vol-%d", acctest.RandIntRange(10, 100))
+	bakupPolicyName := fmt.Sprintf("tfbakuppolicyname%d", acctest.RandIntRange(10, 100))
+	bakupPolicyPlanName := fmt.Sprintf("tfbakuppolicyplanname%d", acctest.RandIntRange(10, 100))
+	cronSpec := strings.TrimSpace(strconv.Itoa(time.Now().UTC().Minute()) + " " + strconv.Itoa(time.Now().UTC().Hour()) + " " + "*" + " " + "*" + " " + "*")
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { acc.TestAccPreCheck(t) },
+		Providers: acc.TestAccProviders,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccCheckIBMIsBackupPolicyPlanDataSourceConfigClonesBasic(bakupPolicyName, vpcname, subnetname, sshname, volname, name, cronSpec, bakupPolicyPlanName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet("data.ibm_is_backup_policy_plan.is_backup_policy_plan", "id"),
+					resource.TestCheckResourceAttrSet("data.ibm_is_backup_policy_plan.is_backup_policy_plan", "backup_policy_id"),
+					resource.TestCheckResourceAttrSet("data.ibm_is_backup_policy_plan.is_backup_policy_plan", "active"),
+					resource.TestCheckResourceAttrSet("data.ibm_is_backup_policy_plan.is_backup_policy_plan", "attach_user_tags.#"),
+					resource.TestCheckResourceAttrSet("data.ibm_is_backup_policy_plan.is_backup_policy_plan", "copy_user_tags"),
+					resource.TestCheckResourceAttrSet("data.ibm_is_backup_policy_plan.is_backup_policy_plan", "created_at"),
+					resource.TestCheckResourceAttrSet("data.ibm_is_backup_policy_plan.is_backup_policy_plan", "cron_spec"),
+					resource.TestCheckResourceAttrSet("data.ibm_is_backup_policy_plan.is_backup_policy_plan", "deletion_trigger.0.delete_after"),
+					resource.TestCheckResourceAttrSet("data.ibm_is_backup_policy_plan.is_backup_policy_plan", "href"),
+					resource.TestCheckResourceAttrSet("data.ibm_is_backup_policy_plan.is_backup_policy_plan", "lifecycle_state"),
+					resource.TestCheckResourceAttrSet("data.ibm_is_backup_policy_plan.is_backup_policy_plan", "name"),
+					resource.TestCheckResourceAttrSet("data.ibm_is_backup_policy_plan.is_backup_policy_plan", "resource_type"),
+					resource.TestCheckResourceAttrSet("data.ibm_is_backup_policy_plan.is_backup_policy_plan", "clone_policy.0.max_snapshots"),
+					resource.TestCheckResourceAttrSet("data.ibm_is_backup_policy_plan.is_backup_policy_plan", "clone_policy.0.zones.#"),
+					resource.TestCheckResourceAttr("data.ibm_is_backup_policy_plan.is_backup_policy_plan", "clone_policy.0.zones.0", acc.ISZoneName),
+					resource.TestCheckResourceAttr("data.ibm_is_backup_policy_plan.is_backup_policy_plan", "clone_policy.0.zones.1", acc.ISZoneName2),
+				),
+			},
+		},
+	})
+}
 
 func testAccCheckIBMIsBackupPolicyPlanDataSourceConfigBasic(backupPolicyName, vpcname, subnetname, sshname, volName, name, cronSpec, bakupPolicyPlanName string) string {
 
 	return testAccCheckIBMIsBackupPolicyPlanConfigBasic(backupPolicyName, vpcname, subnetname, sshname, volName, name, cronSpec, bakupPolicyPlanName) + fmt.Sprintf(`
+		data "ibm_is_backup_policy_plan" "is_backup_policy_plan" {
+			backup_policy_id = ibm_is_backup_policy.is_backup_policy.id
+			identifier = ibm_is_backup_policy_plan.is_backup_policy_plan[0].backup_policy_plan_id
+		}
+	`)
+}
+func testAccCheckIBMIsBackupPolicyPlanDataSourceConfigClonesBasic(backupPolicyName, vpcname, subnetname, sshname, volName, name, cronSpec, bakupPolicyPlanName string) string {
+
+	return testAccCheckIBMIsBackupPolicyPlanConfigClonesBasic(backupPolicyName, vpcname, subnetname, sshname, volName, name, cronSpec, bakupPolicyPlanName) + fmt.Sprintf(`
 		data "ibm_is_backup_policy_plan" "is_backup_policy_plan" {
 			backup_policy_id = ibm_is_backup_policy.is_backup_policy.id
 			identifier = ibm_is_backup_policy_plan.is_backup_policy_plan[0].backup_policy_plan_id

--- a/ibm/service/vpc/data_source_ibm_is_backup_policy_plans_test.go
+++ b/ibm/service/vpc/data_source_ibm_is_backup_policy_plans_test.go
@@ -50,10 +50,59 @@ func TestAccIBMIsBackupPolicyPlansDataSourceBasic(t *testing.T) {
 		},
 	})
 }
+func TestAccIBMIsBackupPolicyPlansDataSourceClonesBasic(t *testing.T) {
+	vpcname := fmt.Sprintf("tf-vpc-%d", acctest.RandIntRange(10, 100))
+	name := fmt.Sprintf("tf-instnace-%d", acctest.RandIntRange(10, 100))
+	subnetname := fmt.Sprintf("tf-subnet-%d", acctest.RandIntRange(10, 100))
+	sshname := fmt.Sprintf("tf-ssh-%d", acctest.RandIntRange(10, 100))
+	volname := fmt.Sprintf("tf-vol-%d", acctest.RandIntRange(10, 100))
+	bakupPolicyName := fmt.Sprintf("tfbakuppolicyname%d", acctest.RandIntRange(10, 100))
+	bakupPolicyPlanName := fmt.Sprintf("tfbakuppolicyplanname%d", acctest.RandIntRange(10, 100))
+	cronSpec := strings.TrimSpace(strconv.Itoa(time.Now().UTC().Minute()) + " " + strconv.Itoa(time.Now().UTC().Hour()) + " " + "*" + " " + "*" + " " + "*")
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { acc.TestAccPreCheck(t) },
+		Providers: acc.TestAccProviders,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccCheckIBMIsBackupPolicyPlansDataSourceConfigClonesBasic(bakupPolicyName, vpcname, subnetname, sshname, volname, name, cronSpec, bakupPolicyPlanName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet("data.ibm_is_backup_policy_plans.is_backup_policy_plans", "id"),
+					resource.TestCheckResourceAttrSet("data.ibm_is_backup_policy_plans.is_backup_policy_plans", "backup_policy_id"),
+					resource.TestCheckResourceAttrSet("data.ibm_is_backup_policy_plans.is_backup_policy_plans", "plans.#"),
+					resource.TestCheckResourceAttrSet("data.ibm_is_backup_policy_plans.is_backup_policy_plans", "plans.0.active"),
+					resource.TestCheckResourceAttrSet("data.ibm_is_backup_policy_plans.is_backup_policy_plans", "plans.0.attach_user_tags.#"),
+					resource.TestCheckResourceAttrSet("data.ibm_is_backup_policy_plans.is_backup_policy_plans", "plans.0.copy_user_tags"),
+					resource.TestCheckResourceAttrSet("data.ibm_is_backup_policy_plans.is_backup_policy_plans", "plans.0.created_at"),
+					resource.TestCheckResourceAttrSet("data.ibm_is_backup_policy_plans.is_backup_policy_plans", "plans.0.cron_spec"),
+					resource.TestCheckResourceAttrSet("data.ibm_is_backup_policy_plans.is_backup_policy_plans", "plans.0.deletion_trigger.0.delete_after"),
+					resource.TestCheckResourceAttrSet("data.ibm_is_backup_policy_plans.is_backup_policy_plans", "plans.0.href"),
+					resource.TestCheckResourceAttrSet("data.ibm_is_backup_policy_plans.is_backup_policy_plans", "plans.0.id"),
+					resource.TestCheckResourceAttrSet("data.ibm_is_backup_policy_plans.is_backup_policy_plans", "plans.0.lifecycle_state"),
+					resource.TestCheckResourceAttrSet("data.ibm_is_backup_policy_plans.is_backup_policy_plans", "plans.0.name"),
+					resource.TestCheckResourceAttrSet("data.ibm_is_backup_policy_plans.is_backup_policy_plans", "plans.0.resource_type"),
+					resource.TestCheckResourceAttrSet("data.ibm_is_backup_policy_plans.is_backup_policy_plans", "plans.0.clone_policy.0.max_snapshots"),
+					resource.TestCheckResourceAttrSet("data.ibm_is_backup_policy_plans.is_backup_policy_plans", "plans.0.clone_policy.0.zones.#"),
+					resource.TestCheckResourceAttr("data.ibm_is_backup_policy_plans.is_backup_policy_plans", "plans.0.clone_policy.0.zones.0", acc.ISZoneName),
+					resource.TestCheckResourceAttr("data.ibm_is_backup_policy_plans.is_backup_policy_plans", "plans.0.clone_policy.0.zones.1", acc.ISZoneName2),
+				),
+			},
+		},
+	})
+}
 
 func testAccCheckIBMIsBackupPolicyPlansDataSourceConfigBasic(backupPolicyName, vpcname, subnetname, sshname, volName, name, cronSpec, bakupPolicyPlanName string) string {
 
 	return testAccCheckIBMIsBackupPolicyPlanConfigBasic(backupPolicyName, vpcname, subnetname, sshname, volName, name, cronSpec, bakupPolicyPlanName) + fmt.Sprintf(`
+		data "ibm_is_backup_policy_plans" "is_backup_policy_plans" {
+			depends_on  = [ibm_is_backup_policy_plan.is_backup_policy_plan]
+			backup_policy_id = ibm_is_backup_policy.is_backup_policy.id
+			name = "%s"
+		}
+	`, bakupPolicyPlanName+"-1")
+}
+func testAccCheckIBMIsBackupPolicyPlansDataSourceConfigClonesBasic(backupPolicyName, vpcname, subnetname, sshname, volName, name, cronSpec, bakupPolicyPlanName string) string {
+
+	return testAccCheckIBMIsBackupPolicyPlanConfigClonesBasic(backupPolicyName, vpcname, subnetname, sshname, volName, name, cronSpec, bakupPolicyPlanName) + fmt.Sprintf(`
 		data "ibm_is_backup_policy_plans" "is_backup_policy_plans" {
 			depends_on  = [ibm_is_backup_policy_plan.is_backup_policy_plan]
 			backup_policy_id = ibm_is_backup_policy.is_backup_policy.id

--- a/ibm/service/vpc/resource_ibm_is_backup_policy_plan.go
+++ b/ibm/service/vpc/resource_ibm_is_backup_policy_plan.go
@@ -85,6 +85,30 @@ func ResourceIBMIsBackupPolicyPlan() *schema.Resource {
 					},
 				},
 			},
+			"clone_policy": &schema.Schema{
+				Type:     schema.TypeList,
+				MaxItems: 1,
+				Optional: true,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"max_snapshots": &schema.Schema{
+							Type:        schema.TypeInt,
+							Optional:    true,
+							Computed:    true,
+							Description: "The maximum number of recent snapshots (per source) that will keep clones.",
+						},
+						"zones": &schema.Schema{
+							Type:        schema.TypeSet,
+							Optional:    true,
+							Elem:        &schema.Schema{Type: schema.TypeString},
+							Set:         flex.ResourceIBMVPCHash,
+							Computed:    true,
+							Description: "The zone this backup policy plan will create snapshot clones in.",
+						},
+					},
+				},
+			},
 			"name": &schema.Schema{
 				Type:         schema.TypeString,
 				Optional:     true,
@@ -162,6 +186,27 @@ func resourceIBMIsBackupPolicyPlanCreate(context context.Context, d *schema.Reso
 	}
 	if _, ok := d.GetOk("attach_user_tags"); ok {
 		createBackupPolicyPlanOptions.SetAttachUserTags((flex.ExpandStringList((d.Get("attach_user_tags").(*schema.Set)).List())))
+	}
+	if _, ok := d.GetOk("clone_policy"); ok {
+		backupPolicyPlanClonePolicyPrototype := &vpcv1.BackupPolicyPlanClonePolicyPrototype{}
+		if zonesOk, ok := d.GetOk("clone_policy.0.zones"); ok {
+			zonesSet := zonesOk.(*schema.Set)
+			if zonesSet.Len() != 0 {
+				zonesbjs := make([]vpcv1.ZoneIdentityIntf, zonesSet.Len())
+				for i, zone := range zonesSet.List() {
+					zonestr := zone.(string)
+					zonesbjs[i] = &vpcv1.ZoneIdentity{
+						Name: &zonestr,
+					}
+				}
+				backupPolicyPlanClonePolicyPrototype.Zones = zonesbjs
+			}
+		}
+		if maxSnapshotsOk, ok := d.GetOk("clone_policy.0.max_snapshots"); ok {
+			maxSnapshots := int64(maxSnapshotsOk.(int))
+			backupPolicyPlanClonePolicyPrototype.MaxSnapshots = &maxSnapshots
+		}
+		createBackupPolicyPlanOptions.SetClonePolicy(backupPolicyPlanClonePolicyPrototype)
 	}
 	if _, ok := d.GetOk("copy_user_tags"); ok {
 		createBackupPolicyPlanOptions.SetCopyUserTags(d.Get("copy_user_tags").(bool))
@@ -253,6 +298,24 @@ func resourceIBMIsBackupPolicyPlanRead(context context.Context, d *schema.Resour
 		if err = d.Set("active", backupPolicyPlan.Active); err != nil {
 			return diag.FromErr(fmt.Errorf("[ERROR] Error setting active: %s", err))
 		}
+	}
+
+	if backupPolicyPlan.ClonePolicy != nil {
+		backupPolicyPlanClonePolicyMap := []map[string]interface{}{}
+		finalList := map[string]interface{}{}
+
+		if backupPolicyPlan.ClonePolicy.MaxSnapshots != nil {
+			finalList["max_snapshots"] = flex.IntValue(backupPolicyPlan.ClonePolicy.MaxSnapshots)
+		}
+		if backupPolicyPlan.ClonePolicy.Zones != nil && len(backupPolicyPlan.ClonePolicy.Zones) != 0 {
+			zoneList := []string{}
+			for i := 0; i < len(backupPolicyPlan.ClonePolicy.Zones); i++ {
+				zoneList = append(zoneList, string(*(backupPolicyPlan.ClonePolicy.Zones[i].Name)))
+			}
+			finalList["zones"] = flex.NewStringSet(schema.HashString, zoneList)
+		}
+		backupPolicyPlanClonePolicyMap = append(backupPolicyPlanClonePolicyMap, finalList)
+		d.Set("clone_policy", backupPolicyPlanClonePolicyMap)
 	}
 
 	if backupPolicyPlan.AttachUserTags != nil {
@@ -377,6 +440,30 @@ func resourceIBMIsBackupPolicyPlanUpdate(context context.Context, d *schema.Reso
 		}
 		patchVals.DeletionTrigger = &backupPolicyPlanDeletionTriggerPrototype
 		hasChange = true
+	}
+
+	if d.HasChange("clone_policy") {
+		backupPolicyPlanClonePolicyPatch := &vpcv1.BackupPolicyPlanClonePolicyPatch{}
+		if d.HasChange("clone_policy.0.zones") {
+			zonesOk := d.Get("clone_policy.0.zones")
+			zonesSet := zonesOk.(*schema.Set)
+			if zonesSet.Len() != 0 {
+				zonesbjs := make([]vpcv1.ZoneIdentityIntf, zonesSet.Len())
+				for i, zone := range zonesSet.List() {
+					zonestr := zone.(string)
+					zonesbjs[i] = &vpcv1.ZoneIdentity{
+						Name: &zonestr,
+					}
+				}
+				backupPolicyPlanClonePolicyPatch.Zones = zonesbjs
+			}
+		}
+		if d.HasChange("clone_policy.0.zones") {
+			maxSnapshotsOk := d.Get("clone_policy.0.max_snapshots")
+			maxSnapshots := int64(maxSnapshotsOk.(int))
+			backupPolicyPlanClonePolicyPatch.MaxSnapshots = &maxSnapshots
+		}
+		patchVals.ClonePolicy = backupPolicyPlanClonePolicyPatch
 	}
 
 	if d.HasChange("name") {

--- a/ibm/service/vpc/resource_ibm_is_backup_policy_plan_test.go
+++ b/ibm/service/vpc/resource_ibm_is_backup_policy_plan_test.go
@@ -80,6 +80,76 @@ func TestAccIBMIsBackupPolicyPlanBasic(t *testing.T) {
 	})
 }
 
+func TestAccIBMIsBackupPolicyPlanClonesBasic(t *testing.T) {
+	var conf vpcv1.BackupPolicyPlan
+	vpcname := fmt.Sprintf("tf-vpc-%d", acctest.RandIntRange(10, 100))
+	name := fmt.Sprintf("tf-instnace-%d", acctest.RandIntRange(10, 100))
+	subnetname := fmt.Sprintf("tf-subnet-%d", acctest.RandIntRange(10, 100))
+	sshname := fmt.Sprintf("tf-ssh-%d", acctest.RandIntRange(10, 100))
+	volname := fmt.Sprintf("tf-vol-%d", acctest.RandIntRange(10, 100))
+	bakupPolicyName := fmt.Sprintf("tfbakuppolicyname%d", acctest.RandIntRange(10, 100))
+	bakupPolicyPlanName := fmt.Sprintf("tfbakuppolicyplanname%d", acctest.RandIntRange(10, 100))
+	bakupPolicyPlanNameUpdate := fmt.Sprintf("tfbakuppolicyplannameupdate%d", acctest.RandIntRange(10, 100))
+	cronSpec := strings.TrimSpace(strconv.Itoa(time.Now().UTC().Minute()) + " " + strconv.Itoa(time.Now().UTC().Hour()) + " " + "*" + " " + "*" + " " + "*")
+	cronSpecUpdate := strings.TrimSpace(strconv.Itoa(time.Now().UTC().Minute()+1) + " " + strconv.Itoa(time.Now().UTC().Hour()) + " " + "*" + " " + "*" + " " + "*")
+	if strings.TrimSpace(strconv.Itoa(time.Now().UTC().Minute())) == "61" {
+		cronSpecUpdate = strings.TrimSpace(("1") + " " + strconv.Itoa(time.Now().UTC().Hour()+1) + " " + "*" + " " + "*" + " " + "*")
+	}
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { acc.TestAccPreCheck(t) },
+		Providers:    acc.TestAccProviders,
+		CheckDestroy: testAccCheckIBMIsBackupPolicyPlanDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccCheckIBMIsBackupPolicyPlanConfigClonesBasic(bakupPolicyName, vpcname, subnetname, sshname, volname, name, cronSpec, bakupPolicyPlanName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckIBMIsBackupPolicyPlanExists("ibm_is_backup_policy_plan.is_backup_policy_plan.0", conf),
+					resource.TestCheckResourceAttr("ibm_is_backup_policy_plan.is_backup_policy_plan.0", "name", bakupPolicyPlanName+"-1"),
+					resource.TestCheckResourceAttr("ibm_is_backup_policy_plan.is_backup_policy_plan.0", "cron_spec", cronSpec),
+					resource.TestCheckResourceAttrSet("ibm_is_backup_policy_plan.is_backup_policy_plan.0", "backup_policy_id"),
+					resource.TestCheckResourceAttrSet("ibm_is_backup_policy_plan.is_backup_policy_plan.0", "backup_policy_plan_id"),
+					resource.TestCheckResourceAttrSet("ibm_is_backup_policy_plan.is_backup_policy_plan.0", "active"),
+					resource.TestCheckResourceAttrSet("ibm_is_backup_policy_plan.is_backup_policy_plan.0", "copy_user_tags"),
+					resource.TestCheckResourceAttrSet("ibm_is_backup_policy_plan.is_backup_policy_plan.0", "deletion_trigger.#"),
+					resource.TestCheckResourceAttrSet("ibm_is_backup_policy_plan.is_backup_policy_plan.0", "created_at"),
+					resource.TestCheckResourceAttrSet("ibm_is_backup_policy_plan.is_backup_policy_plan.0", "href"),
+					resource.TestCheckResourceAttrSet("ibm_is_backup_policy_plan.is_backup_policy_plan.0", "lifecycle_state"),
+					resource.TestCheckResourceAttrSet("ibm_is_backup_policy_plan.is_backup_policy_plan.0", "resource_type"),
+					resource.TestCheckResourceAttrSet("ibm_is_backup_policy_plan.is_backup_policy_plan.0", "version"),
+					resource.TestCheckResourceAttrSet("ibm_is_backup_policy_plan.is_backup_policy_plan.0", "clone_policy.0.max_snapshots"),
+					resource.TestCheckResourceAttrSet("ibm_is_backup_policy_plan.is_backup_policy_plan.0", "clone_policy.0.zones.#"),
+					resource.TestCheckResourceAttr("ibm_is_backup_policy_plan.is_backup_policy_plan.0", "clone_policy.0.zones.0", acc.ISZoneName),
+					resource.TestCheckResourceAttr("ibm_is_backup_policy_plan.is_backup_policy_plan.0", "clone_policy.0.zones.1", acc.ISZoneName2),
+				),
+			},
+			resource.TestStep{
+				Config: testAccCheckIBMIsBackupPolicyPlanConfigClonesBasic(bakupPolicyName, vpcname, subnetname, sshname, volname, name, cronSpecUpdate, bakupPolicyPlanNameUpdate),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckIBMIsBackupPolicyPlanExists("ibm_is_backup_policy_plan.is_backup_policy_plan.0", conf),
+					resource.TestCheckResourceAttr("ibm_is_backup_policy_plan.is_backup_policy_plan.0", "name", bakupPolicyPlanNameUpdate+"-1"),
+					resource.TestCheckResourceAttr("ibm_is_backup_policy_plan.is_backup_policy_plan.0", "cron_spec", cronSpecUpdate),
+					resource.TestCheckResourceAttrSet("ibm_is_backup_policy_plan.is_backup_policy_plan.0", "backup_policy_id"),
+					resource.TestCheckResourceAttrSet("ibm_is_backup_policy_plan.is_backup_policy_plan.0", "backup_policy_plan_id"),
+					resource.TestCheckResourceAttrSet("ibm_is_backup_policy_plan.is_backup_policy_plan.0", "active"),
+					resource.TestCheckResourceAttrSet("ibm_is_backup_policy_plan.is_backup_policy_plan.0", "copy_user_tags"),
+					resource.TestCheckResourceAttrSet("ibm_is_backup_policy_plan.is_backup_policy_plan.0", "deletion_trigger.#"),
+					resource.TestCheckResourceAttrSet("ibm_is_backup_policy_plan.is_backup_policy_plan.0", "created_at"),
+					resource.TestCheckResourceAttrSet("ibm_is_backup_policy_plan.is_backup_policy_plan.0", "href"),
+					resource.TestCheckResourceAttrSet("ibm_is_backup_policy_plan.is_backup_policy_plan.0", "lifecycle_state"),
+					resource.TestCheckResourceAttrSet("ibm_is_backup_policy_plan.is_backup_policy_plan.0", "resource_type"),
+					resource.TestCheckResourceAttrSet("ibm_is_backup_policy_plan.is_backup_policy_plan.0", "version"),
+					resource.TestCheckResourceAttrSet("ibm_is_backup_policy_plan.is_backup_policy_plan.0", "clone_policy.0.max_snapshots"),
+					resource.TestCheckResourceAttrSet("ibm_is_backup_policy_plan.is_backup_policy_plan.0", "clone_policy.0.zones.#"),
+					resource.TestCheckResourceAttrSet("ibm_is_backup_policy_plan.is_backup_policy_plan.0", "clone_policy.0.max_snapshots"),
+					resource.TestCheckResourceAttrSet("ibm_is_backup_policy_plan.is_backup_policy_plan.0", "clone_policy.0.zones.#"),
+					resource.TestCheckResourceAttr("ibm_is_backup_policy_plan.is_backup_policy_plan.0", "clone_policy.0.zones.0", acc.ISZoneName),
+					resource.TestCheckResourceAttr("ibm_is_backup_policy_plan.is_backup_policy_plan.0", "clone_policy.0.zones.1", acc.ISZoneName2),
+				),
+			},
+		},
+	})
+}
+
 func TestAccIBMIsBackupPolicyPlanImport(t *testing.T) {
 	var conf vpcv1.BackupPolicyPlan
 	vpcname := fmt.Sprintf("tf-vpc-%d", acctest.RandIntRange(10, 100))
@@ -133,6 +203,21 @@ func testAccCheckIBMIsBackupPolicyPlanConfigBasic(backupPolicyName, vpcname, sub
 			cron_spec = "%s"
 		}
 	`, bakupPolicyPlanName, cronSpec)
+}
+func testAccCheckIBMIsBackupPolicyPlanConfigClonesBasic(backupPolicyName, vpcname, subnetname, sshname, volName, name, cronSpec, backupPolicyPlanName string) string {
+
+	return testAccCheckIBMIsBackupPolicyConfigBasic(backupPolicyName, vpcname, subnetname, sshname, volName, name) + fmt.Sprintf(`
+		resource "ibm_is_backup_policy_plan" "is_backup_policy_plan" {
+			count  = 2
+			backup_policy_id = ibm_is_backup_policy.is_backup_policy.id
+			name = "%s-${count.index+1}"
+			cron_spec = "%s"
+			clone_policy {
+				zones 			= ["%s", "%s"]
+				max_snapshots 	= 3
+			}
+		}
+	`, backupPolicyPlanName, cronSpec, acc.ISZoneName, acc.ISZoneName2)
 }
 
 func testAccCheckIBMIsBackupPolicyPlanConfigImport(backupPolicyName, vpcname, subnetname, sshname, volName, name, cronSpec, bakupPolicyPlanName string) string {

--- a/website/docs/d/is_backup_policy_plan.html.markdown
+++ b/website/docs/d/is_backup_policy_plan.html.markdown
@@ -50,7 +50,11 @@ In addition to all argument reference list, you can access the following attribu
 - `cron_spec` - (String) The cron specification for the backup schedule.
 
 	->**Note** The backup policy jobs (which create and delete backups for this plan) will not start until this time, and may start for up to 90 minutes after this time.All backup schedules for plans in the same policy must be at least an hour apart.
-	
+- `clone_policy` - (List)
+  
+  Nested scheme for `clone_policy`:
+  - `max_snapshots` - (Integer) The maximum number of recent snapshots (per source) that will keep clones.
+  - `zones` - (List) The zone list this backup policy plan will create snapshot clones in.	
 - `deletion_trigger` (List) `deletion_trigger` block has the following structure:
 	
 	Nested scheme for `deletion_trigger`:

--- a/website/docs/d/is_backup_policy_plans.html.markdown
+++ b/website/docs/d/is_backup_policy_plans.html.markdown
@@ -52,7 +52,11 @@ In addition to all argument reference list, you can access the following attribu
 	- `cron_spec` - (String) The cron specification for the backup schedule.
 
 		->**Note** The backup policy jobs (which create and delete backups for this plan) will not start until this time, and may start for up to 90 minutes after this time.All backup schedules for plans in the same policy must be at least an hour apart.
-		
+	- `clone_policy` - (List)
+
+		Nested scheme for `clone_policy`:
+		- `max_snapshots` - (Integer) The maximum number of recent snapshots (per source) that will keep clones.
+		- `zones` - (List) The zone list this backup policy plan will create snapshot clones in.		
 	- `deletion_trigger` (List) `deletion_trigger` block has the following structure:
 		
 		Nested scheme for `deletion_trigger`:

--- a/website/docs/r/is_backup_policy_plan.html.markdown
+++ b/website/docs/r/is_backup_policy_plan.html.markdown
@@ -31,6 +31,19 @@ resource "ibm_is_backup_policy_plan" "example" {
   name             = "example-backup-policy-plan"
 }
 ```
+## Example Usage (clones)
+
+```terraform
+resource "ibm_is_backup_policy_plan" "example" {
+  backup_policy_id = "backup_policy_id"
+  cron_spec        = "0 12 * * *"
+  name             = "example-backup-policy-plan"
+  clone_policy {
+    zones 			    = ["us-south-1", "us-south-2"]
+    max_snapshots 	= 3
+  }
+}
+```
 
 ->**Note:**  Backup Policy Jobs are getting enhanced, will be available soon.
 
@@ -46,7 +59,12 @@ backup_policy_plan_id
 - `cron_spec` - (Required, String) The cron specification for the backup schedule. The value must match regular expression `^((((\d+,)+\d+|([\d\*]+(\/|-)\d+)|\d+|\*) ?){5,7})$`.
 
 	->**Note** The backup policy jobs (which create and delete backups for this plan) will not start until this time, and may start for up to 90 minutes after this time.All backup schedules for plans in the same policy must be at least an hour apart.
-		
+- `clone_policy` - (Optional, List)
+  
+  Nested scheme for `clone_policy`:
+  - `max_snapshots` - (Optional, Integer) The maximum number of recent snapshots (per source) that will keep clones.
+  - `zones` - (Optional, List) The zone list this backup policy plan will create snapshot clones in.
+
 - `deletion_trigger` - (Optional, List)
   
   Nested scheme for `deletion_trigger`:


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/IBM-Cloud/terraform-provider-ibm/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
=== RUN   TestAccIBMIsBackupPolicyPlanClonesBasic
no message sent
no message sent
no message sent
--- PASS: TestAccIBMIsBackupPolicyPlanClonesBasic (279.41s)
PASS
ok      github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/vpc     282.187s
```
```
=== RUN   TestAccIBMIsBackupPolicyPlanDataSourceClonesBasic
no message sent
no message sent
no message sent
--- PASS: TestAccIBMIsBackupPolicyPlanDataSourceClonesBasic (295.16s)
PASS
ok      github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/vpc     298.610s
```
```
=== RUN   TestAccIBMIsBackupPolicyPlansDataSourceClonesBasic
no message sent
no message sent
--- PASS: TestAccIBMIsBackupPolicyPlansDataSourceClonesBasic (201.86s)
PASS
ok      github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/vpc     203.466s
```