### PR TITLE
fix: add fields to version metadata for onboarding fix

### DIFF
--- a/ibm/service/catalogmanagement/data_source_ibm_cm_offering.go
+++ b/ibm/service/catalogmanagement/data_source_ibm_cm_offering.go
@@ -562,6 +562,107 @@ func DataSourceIBMCmOffering() *schema.Resource {
 													Computed:    true,
 													Description: "Version source URL.",
 												},
+												"working_directory": &schema.Schema{
+													Type:        schema.TypeString,
+													Optional:    true,
+													Computed:    true,
+													Description: "Working directory of source files.",
+												},
+												"example_name": &schema.Schema{
+													Type:        schema.TypeString,
+													Optional:    true,
+													Computed:    true,
+													Description: "Working directory of source files.",
+												},
+												"end_deploy_time": &schema.Schema{
+													Type:        schema.TypeString,
+													Optional:    true,
+													Computed:    true,
+													Description: "The time validation ended.",
+												},
+												"usage": &schema.Schema{
+													Type:        schema.TypeString,
+													Optional:    true,
+													Computed:    true,
+													Description: "Usage text for the version.",
+												},
+												"usage_template": &schema.Schema{
+													Type:        schema.TypeString,
+													Optional:    true,
+													Computed:    true,
+													Description: "Usage text for the version.",
+												},
+												"modules": &schema.Schema{
+													Type:        schema.TypeList,
+													Optional:    true,
+													Computed:    true,
+													Description: "Terraform modules.",
+													Elem: &schema.Resource{
+														Schema: map[string]*schema.Schema{
+															"name": &schema.Schema{
+																Type:        schema.TypeString,
+																Computed:    true,
+																Description: "Name of the module.",
+															},
+															"source": &schema.Schema{
+																Type:        schema.TypeString,
+																Computed:    true,
+																Description: "Source of the module.",
+															},
+															"offering_reference": &schema.Schema{
+																Type:        schema.TypeList,
+																Optional:    true,
+																Computed:    true,
+																Description: "Terraform modules.",
+																Elem: &schema.Resource{
+																	Schema: map[string]*schema.Schema{
+																		"name": &schema.Schema{
+																			Type:        schema.TypeString,
+																			Computed:    true,
+																			Description: "Name of the offering module.",
+																		},
+																		"id": &schema.Schema{
+																			Type:        schema.TypeString,
+																			Computed:    true,
+																			Description: "ID of the offering module.",
+																		},
+																		"kind": &schema.Schema{
+																			Type:        schema.TypeString,
+																			Computed:    true,
+																			Description: "Kind of the offeringmodule.",
+																		},
+																		"version": &schema.Schema{
+																			Type:        schema.TypeString,
+																			Computed:    true,
+																			Description: "Version of the offering module.",
+																		},
+																		"flavor": &schema.Schema{
+																			Type:        schema.TypeString,
+																			Computed:    true,
+																			Description: "Flavor of the module.",
+																		},
+																		"flavors": &schema.Schema{
+																			Type:        schema.TypeList,
+																			Computed:    true,
+																			Description: "Flavors of the module.",
+																			Elem:        &schema.Schema{Type: schema.TypeString},
+																		},
+																		"catalog_id": &schema.Schema{
+																			Type:        schema.TypeString,
+																			Computed:    true,
+																			Description: "Catalog ID of the module reference.",
+																		},
+																		"metadata": &schema.Schema{
+																			Type:        schema.TypeString,
+																			Computed:    true,
+																			Description: "Metadata of the module.",
+																		},
+																	},
+																},
+															},
+														},
+													},
+												},
 												"version_name": &schema.Schema{
 													Type:        schema.TypeString,
 													Computed:    true,

--- a/ibm/service/catalogmanagement/data_source_ibm_cm_offering.go
+++ b/ibm/service/catalogmanagement/data_source_ibm_cm_offering.go
@@ -564,37 +564,41 @@ func DataSourceIBMCmOffering() *schema.Resource {
 												},
 												"working_directory": &schema.Schema{
 													Type:        schema.TypeString,
-													Optional:    true,
 													Computed:    true,
 													Description: "Working directory of source files.",
 												},
 												"example_name": &schema.Schema{
 													Type:        schema.TypeString,
-													Optional:    true,
 													Computed:    true,
 													Description: "Working directory of source files.",
 												},
+												"start_deploy_time": &schema.Schema{
+													Type:        schema.TypeString,
+													Computed:    true,
+													Description: "The time validation started.",
+												},
 												"end_deploy_time": &schema.Schema{
 													Type:        schema.TypeString,
-													Optional:    true,
 													Computed:    true,
 													Description: "The time validation ended.",
 												},
+												"est_deploy_time": &schema.Schema{
+													Type:        schema.TypeString,
+													Computed:    true,
+													Description: "The estimated time validation takes.",
+												},
 												"usage": &schema.Schema{
 													Type:        schema.TypeString,
-													Optional:    true,
 													Computed:    true,
 													Description: "Usage text for the version.",
 												},
 												"usage_template": &schema.Schema{
 													Type:        schema.TypeString,
-													Optional:    true,
 													Computed:    true,
 													Description: "Usage text for the version.",
 												},
 												"modules": &schema.Schema{
 													Type:        schema.TypeList,
-													Optional:    true,
 													Computed:    true,
 													Description: "Terraform modules.",
 													Elem: &schema.Resource{
@@ -611,7 +615,6 @@ func DataSourceIBMCmOffering() *schema.Resource {
 															},
 															"offering_reference": &schema.Schema{
 																Type:        schema.TypeList,
-																Optional:    true,
 																Computed:    true,
 																Description: "Terraform modules.",
 																Elem: &schema.Resource{

--- a/ibm/service/catalogmanagement/data_source_ibm_cm_version.go
+++ b/ibm/service/catalogmanagement/data_source_ibm_cm_version.go
@@ -328,49 +328,52 @@ func DataSourceIBMCmVersion() *schema.Resource {
 			},
 			"metadata": &schema.Schema{
 				Type:        schema.TypeList,
-				MaxItems:    1,
-				Optional:    true,
+				Computed:    true,
 				Description: "Generic data to be included with content being onboarded. Required for virtual server image for VPC.",
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"source_url": &schema.Schema{
 							Type:        schema.TypeString,
-							Optional:    true,
+							Computed:    true,
 							Description: "Version source URL.",
 						},
 						"working_directory": &schema.Schema{
 							Type:        schema.TypeString,
-							Optional:    true,
 							Computed:    true,
 							Description: "Working directory of source files.",
 						},
 						"example_name": &schema.Schema{
 							Type:        schema.TypeString,
-							Optional:    true,
 							Computed:    true,
 							Description: "Working directory of source files.",
 						},
+						"start_deploy_time": &schema.Schema{
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "The time validation started.",
+						},
 						"end_deploy_time": &schema.Schema{
 							Type:        schema.TypeString,
-							Optional:    true,
 							Computed:    true,
 							Description: "The time validation ended.",
 						},
+						"est_deploy_time": &schema.Schema{
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "The estimated time validation takes.",
+						},
 						"usage": &schema.Schema{
 							Type:        schema.TypeString,
-							Optional:    true,
 							Computed:    true,
 							Description: "Usage text for the version.",
 						},
 						"usage_template": &schema.Schema{
 							Type:        schema.TypeString,
-							Optional:    true,
 							Computed:    true,
 							Description: "Usage text for the version.",
 						},
 						"modules": &schema.Schema{
 							Type:        schema.TypeList,
-							Optional:    true,
 							Computed:    true,
 							Description: "Terraform modules.",
 							Elem: &schema.Resource{
@@ -387,7 +390,6 @@ func DataSourceIBMCmVersion() *schema.Resource {
 									},
 									"offering_reference": &schema.Schema{
 										Type:        schema.TypeList,
-										Optional:    true,
 										Computed:    true,
 										Description: "Terraform modules.",
 										Elem: &schema.Resource{
@@ -441,17 +443,17 @@ func DataSourceIBMCmVersion() *schema.Resource {
 						},
 						"version_name": &schema.Schema{
 							Type:        schema.TypeString,
-							Optional:    true,
+							Computed:    true,
 							Description: "Version name.",
 						},
 						"terraform_version": &schema.Schema{
 							Type:        schema.TypeString,
-							Optional:    true,
+							Computed:    true,
 							Description: "Terraform version.",
 						},
 						"validated_terraform_version": &schema.Schema{
 							Type:        schema.TypeString,
-							Optional:    true,
+							Computed:    true,
 							Description: "Version name.",
 						},
 						"vsi_vpc": &schema.Schema{
@@ -462,49 +464,48 @@ func DataSourceIBMCmVersion() *schema.Resource {
 								Schema: map[string]*schema.Schema{
 									"operating_system": &schema.Schema{
 										Type:        schema.TypeList,
-										MaxItems:    1,
-										Optional:    true,
+										Computed:    true,
 										Description: "Operating system included in this image. Required for virtual server image for VPC.",
 										Elem: &schema.Resource{
 											Schema: map[string]*schema.Schema{
 												"dedicated_host_only": &schema.Schema{
 													Type:        schema.TypeBool,
-													Optional:    true,
+													Computed:    true,
 													Description: "Images with this operating system can only be used on dedicated hosts or dedicated host groups. Required for virtual server image for VPC.",
 												},
 												"vendor": &schema.Schema{
 													Type:        schema.TypeString,
-													Optional:    true,
+													Computed:    true,
 													Description: "Vendor of the operating system. Required for virtual server image for VPC.",
 												},
 												"name": &schema.Schema{
 													Type:        schema.TypeString,
-													Optional:    true,
+													Computed:    true,
 													Description: "Globally unique name for this operating system Required for virtual server image for VPC.",
 												},
 												"href": &schema.Schema{
 													Type:        schema.TypeString,
-													Optional:    true,
+													Computed:    true,
 													Description: "URL for this operating system. Required for virtual server image for VPC.",
 												},
 												"display_name": &schema.Schema{
 													Type:        schema.TypeString,
-													Optional:    true,
+													Computed:    true,
 													Description: "Unique, display-friendly name for the operating system. Required for virtual server image for VPC.",
 												},
 												"family": &schema.Schema{
 													Type:        schema.TypeString,
-													Optional:    true,
+													Computed:    true,
 													Description: "Software family for this operating system. Required for virtual server image for VPC.",
 												},
 												"version": &schema.Schema{
 													Type:        schema.TypeString,
-													Optional:    true,
+													Computed:    true,
 													Description: "Major release version of this operating system. Required for virtual server image for VPC.",
 												},
 												"architecture": &schema.Schema{
 													Type:        schema.TypeString,
-													Optional:    true,
+													Computed:    true,
 													Description: "Operating system architecture. Required for virtual server image for VPC.",
 												},
 											},
@@ -512,14 +513,13 @@ func DataSourceIBMCmVersion() *schema.Resource {
 									},
 									"file": &schema.Schema{
 										Type:        schema.TypeList,
-										MaxItems:    1,
-										Optional:    true,
+										Computed:    true,
 										Description: "Details for the stored image file. Required for virtual server image for VPC.",
 										Elem: &schema.Resource{
 											Schema: map[string]*schema.Schema{
 												"size": &schema.Schema{
 													Type:        schema.TypeInt,
-													Optional:    true,
+													Computed:    true,
 													Description: "Size of the stored image file rounded up to the next gigabyte. Required for virtual server image for VPC.",
 												},
 											},
@@ -527,28 +527,28 @@ func DataSourceIBMCmVersion() *schema.Resource {
 									},
 									"minimum_provisioned_size": &schema.Schema{
 										Type:        schema.TypeInt,
-										Optional:    true,
+										Computed:    true,
 										Description: "Minimum size (in gigabytes) of a volume onto which this image may be provisioned. Required for virtual server image for VPC.",
 									},
 									"images": &schema.Schema{
 										Type:        schema.TypeList,
-										Optional:    true,
+										Computed:    true,
 										Description: "Image operating system. Required for virtual server image for VPC.",
 										Elem: &schema.Resource{
 											Schema: map[string]*schema.Schema{
 												"id": &schema.Schema{
 													Type:        schema.TypeString,
-													Optional:    true,
+													Computed:    true,
 													Description: "Programmatic ID of virtual server image. Required for virtual server image for VPC.",
 												},
 												"name": &schema.Schema{
 													Type:        schema.TypeString,
-													Optional:    true,
+													Computed:    true,
 													Description: "Programmatic name of virtual server image. Required for virtual server image for VPC.",
 												},
 												"region": &schema.Schema{
 													Type:        schema.TypeString,
-													Optional:    true,
+													Computed:    true,
 													Description: "Region the virtual server image is available in. Required for virtual server image for VPC.",
 												},
 											},
@@ -559,49 +559,48 @@ func DataSourceIBMCmVersion() *schema.Resource {
 						},
 						"operating_system": &schema.Schema{
 							Type:        schema.TypeList,
-							MaxItems:    1,
-							Optional:    true,
+							Computed:    true,
 							Description: "Operating system included in this image. Required for virtual server image for VPC.",
 							Elem: &schema.Resource{
 								Schema: map[string]*schema.Schema{
 									"dedicated_host_only": &schema.Schema{
 										Type:        schema.TypeBool,
-										Optional:    true,
+										Computed:    true,
 										Description: "Images with this operating system can only be used on dedicated hosts or dedicated host groups. Required for virtual server image for VPC.",
 									},
 									"vendor": &schema.Schema{
 										Type:        schema.TypeString,
-										Optional:    true,
+										Computed:    true,
 										Description: "Vendor of the operating system. Required for virtual server image for VPC.",
 									},
 									"name": &schema.Schema{
 										Type:        schema.TypeString,
-										Optional:    true,
+										Computed:    true,
 										Description: "Globally unique name for this operating system Required for virtual server image for VPC.",
 									},
 									"href": &schema.Schema{
 										Type:        schema.TypeString,
-										Optional:    true,
+										Computed:    true,
 										Description: "URL for this operating system. Required for virtual server image for VPC.",
 									},
 									"display_name": &schema.Schema{
 										Type:        schema.TypeString,
-										Optional:    true,
+										Computed:    true,
 										Description: "Unique, display-friendly name for the operating system. Required for virtual server image for VPC.",
 									},
 									"family": &schema.Schema{
 										Type:        schema.TypeString,
-										Optional:    true,
+										Computed:    true,
 										Description: "Software family for this operating system. Required for virtual server image for VPC.",
 									},
 									"version": &schema.Schema{
 										Type:        schema.TypeString,
-										Optional:    true,
+										Computed:    true,
 										Description: "Major release version of this operating system. Required for virtual server image for VPC.",
 									},
 									"architecture": &schema.Schema{
 										Type:        schema.TypeString,
-										Optional:    true,
+										Computed:    true,
 										Description: "Operating system architecture. Required for virtual server image for VPC.",
 									},
 								},
@@ -609,14 +608,13 @@ func DataSourceIBMCmVersion() *schema.Resource {
 						},
 						"file": &schema.Schema{
 							Type:        schema.TypeList,
-							MaxItems:    1,
-							Optional:    true,
+							Computed:    true,
 							Description: "Details for the stored image file. Required for virtual server image for VPC.",
 							Elem: &schema.Resource{
 								Schema: map[string]*schema.Schema{
 									"size": &schema.Schema{
 										Type:        schema.TypeInt,
-										Optional:    true,
+										Computed:    true,
 										Description: "Size of the stored image file rounded up to the next gigabyte. Required for virtual server image for VPC.",
 									},
 								},
@@ -624,28 +622,28 @@ func DataSourceIBMCmVersion() *schema.Resource {
 						},
 						"minimum_provisioned_size": &schema.Schema{
 							Type:        schema.TypeInt,
-							Optional:    true,
+							Computed:    true,
 							Description: "Minimum size (in gigabytes) of a volume onto which this image may be provisioned. Required for virtual server image for VPC.",
 						},
 						"images": &schema.Schema{
 							Type:        schema.TypeList,
-							Optional:    true,
+							Computed:    true,
 							Description: "Image operating system. Required for virtual server image for VPC.",
 							Elem: &schema.Resource{
 								Schema: map[string]*schema.Schema{
 									"id": &schema.Schema{
 										Type:        schema.TypeString,
-										Optional:    true,
+										Computed:    true,
 										Description: "Programmatic ID of virtual server image. Required for virtual server image for VPC.",
 									},
 									"name": &schema.Schema{
 										Type:        schema.TypeString,
-										Optional:    true,
+										Computed:    true,
 										Description: "Programmatic name of virtual server image. Required for virtual server image for VPC.",
 									},
 									"region": &schema.Schema{
 										Type:        schema.TypeString,
-										Optional:    true,
+										Computed:    true,
 										Description: "Region the virtual server image is available in. Required for virtual server image for VPC.",
 									},
 								},

--- a/ibm/service/catalogmanagement/data_source_ibm_cm_version.go
+++ b/ibm/service/catalogmanagement/data_source_ibm_cm_version.go
@@ -338,6 +338,107 @@ func DataSourceIBMCmVersion() *schema.Resource {
 							Optional:    true,
 							Description: "Version source URL.",
 						},
+						"working_directory": &schema.Schema{
+							Type:        schema.TypeString,
+							Optional:    true,
+							Computed:    true,
+							Description: "Working directory of source files.",
+						},
+						"example_name": &schema.Schema{
+							Type:        schema.TypeString,
+							Optional:    true,
+							Computed:    true,
+							Description: "Working directory of source files.",
+						},
+						"end_deploy_time": &schema.Schema{
+							Type:        schema.TypeString,
+							Optional:    true,
+							Computed:    true,
+							Description: "The time validation ended.",
+						},
+						"usage": &schema.Schema{
+							Type:        schema.TypeString,
+							Optional:    true,
+							Computed:    true,
+							Description: "Usage text for the version.",
+						},
+						"usage_template": &schema.Schema{
+							Type:        schema.TypeString,
+							Optional:    true,
+							Computed:    true,
+							Description: "Usage text for the version.",
+						},
+						"modules": &schema.Schema{
+							Type:        schema.TypeList,
+							Optional:    true,
+							Computed:    true,
+							Description: "Terraform modules.",
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"name": &schema.Schema{
+										Type:        schema.TypeString,
+										Computed:    true,
+										Description: "Name of the module.",
+									},
+									"source": &schema.Schema{
+										Type:        schema.TypeString,
+										Computed:    true,
+										Description: "Source of the module.",
+									},
+									"offering_reference": &schema.Schema{
+										Type:        schema.TypeList,
+										Optional:    true,
+										Computed:    true,
+										Description: "Terraform modules.",
+										Elem: &schema.Resource{
+											Schema: map[string]*schema.Schema{
+												"name": &schema.Schema{
+													Type:        schema.TypeString,
+													Computed:    true,
+													Description: "Name of the offering module.",
+												},
+												"id": &schema.Schema{
+													Type:        schema.TypeString,
+													Computed:    true,
+													Description: "ID of the offering module.",
+												},
+												"kind": &schema.Schema{
+													Type:        schema.TypeString,
+													Computed:    true,
+													Description: "Kind of the offeringmodule.",
+												},
+												"version": &schema.Schema{
+													Type:        schema.TypeString,
+													Computed:    true,
+													Description: "Version of the offering module.",
+												},
+												"flavor": &schema.Schema{
+													Type:        schema.TypeString,
+													Computed:    true,
+													Description: "Flavor of the module.",
+												},
+												"flavors": &schema.Schema{
+													Type:        schema.TypeList,
+													Computed:    true,
+													Description: "Flavors of the module.",
+													Elem:        &schema.Schema{Type: schema.TypeString},
+												},
+												"catalog_id": &schema.Schema{
+													Type:        schema.TypeString,
+													Computed:    true,
+													Description: "Catalog ID of the module reference.",
+												},
+												"metadata": &schema.Schema{
+													Type:        schema.TypeString,
+													Computed:    true,
+													Description: "Metadata of the module.",
+												},
+											},
+										},
+									},
+								},
+							},
+						},
 						"version_name": &schema.Schema{
 							Type:        schema.TypeString,
 							Optional:    true,

--- a/ibm/service/catalogmanagement/resource_ibm_cm_offering.go
+++ b/ibm/service/catalogmanagement/resource_ibm_cm_offering.go
@@ -585,11 +585,20 @@ func ResourceIBMCmOffering() *schema.Resource {
 													Computed:    true,
 													Description: "Working directory of source files.",
 												},
+												"start_deploy_time": &schema.Schema{
+													Type:        schema.TypeString,
+													Computed:    true,
+													Description: "The time validation started.",
+												},
 												"end_deploy_time": &schema.Schema{
 													Type:        schema.TypeString,
-													Optional:    true,
 													Computed:    true,
 													Description: "The time validation ended.",
+												},
+												"est_deploy_time": &schema.Schema{
+													Type:        schema.TypeString,
+													Computed:    true,
+													Description: "The estimated time validation takes.",
 												},
 												"usage": &schema.Schema{
 													Type:        schema.TypeString,

--- a/ibm/service/catalogmanagement/resource_ibm_cm_offering.go
+++ b/ibm/service/catalogmanagement/resource_ibm_cm_offering.go
@@ -573,6 +573,107 @@ func ResourceIBMCmOffering() *schema.Resource {
 													Optional:    true,
 													Description: "Version source URL.",
 												},
+												"working_directory": &schema.Schema{
+													Type:        schema.TypeString,
+													Optional:    true,
+													Computed:    true,
+													Description: "Working directory of source files.",
+												},
+												"example_name": &schema.Schema{
+													Type:        schema.TypeString,
+													Optional:    true,
+													Computed:    true,
+													Description: "Working directory of source files.",
+												},
+												"end_deploy_time": &schema.Schema{
+													Type:        schema.TypeString,
+													Optional:    true,
+													Computed:    true,
+													Description: "The time validation ended.",
+												},
+												"usage": &schema.Schema{
+													Type:        schema.TypeString,
+													Optional:    true,
+													Computed:    true,
+													Description: "Usage text for the version.",
+												},
+												"usage_template": &schema.Schema{
+													Type:        schema.TypeString,
+													Optional:    true,
+													Computed:    true,
+													Description: "Usage text for the version.",
+												},
+												"modules": &schema.Schema{
+													Type:        schema.TypeList,
+													Optional:    true,
+													Computed:    true,
+													Description: "Terraform modules.",
+													Elem: &schema.Resource{
+														Schema: map[string]*schema.Schema{
+															"name": &schema.Schema{
+																Type:        schema.TypeString,
+																Computed:    true,
+																Description: "Name of the module.",
+															},
+															"source": &schema.Schema{
+																Type:        schema.TypeString,
+																Computed:    true,
+																Description: "Source of the module.",
+															},
+															"offering_reference": &schema.Schema{
+																Type:        schema.TypeList,
+																Optional:    true,
+																Computed:    true,
+																Description: "Terraform modules.",
+																Elem: &schema.Resource{
+																	Schema: map[string]*schema.Schema{
+																		"name": &schema.Schema{
+																			Type:        schema.TypeString,
+																			Computed:    true,
+																			Description: "Name of the offering module.",
+																		},
+																		"id": &schema.Schema{
+																			Type:        schema.TypeString,
+																			Computed:    true,
+																			Description: "ID of the offering module.",
+																		},
+																		"kind": &schema.Schema{
+																			Type:        schema.TypeString,
+																			Computed:    true,
+																			Description: "Kind of the offeringmodule.",
+																		},
+																		"version": &schema.Schema{
+																			Type:        schema.TypeString,
+																			Computed:    true,
+																			Description: "Version of the offering module.",
+																		},
+																		"flavor": &schema.Schema{
+																			Type:        schema.TypeString,
+																			Computed:    true,
+																			Description: "Flavor of the module.",
+																		},
+																		"flavors": &schema.Schema{
+																			Type:        schema.TypeList,
+																			Computed:    true,
+																			Description: "Flavors of the module.",
+																			Elem:        &schema.Schema{Type: schema.TypeString},
+																		},
+																		"catalog_id": &schema.Schema{
+																			Type:        schema.TypeString,
+																			Computed:    true,
+																			Description: "Catalog ID of the module reference.",
+																		},
+																		"metadata": &schema.Schema{
+																			Type:        schema.TypeString,
+																			Computed:    true,
+																			Description: "Metadata of the module.",
+																		},
+																	},
+																},
+															},
+														},
+													},
+												},
 												"version_name": &schema.Schema{
 													Type:        schema.TypeString,
 													Optional:    true,

--- a/ibm/service/catalogmanagement/resource_ibm_cm_version.go
+++ b/ibm/service/catalogmanagement/resource_ibm_cm_version.go
@@ -248,6 +248,89 @@ func ResourceIBMCmVersion() *schema.Resource {
 							Optional:    true,
 							Description: "Version source URL.",
 						},
+						"working_directory": &schema.Schema{
+							Type:        schema.TypeString,
+							Optional:    true,
+							Computed:    true,
+							Description: "Working directory of source files.",
+						},
+						"example_name": &schema.Schema{
+							Type:        schema.TypeString,
+							Optional:    true,
+							Computed:    true,
+							Description: "Working directory of source files.",
+						},
+						"modules": &schema.Schema{
+							Type:        schema.TypeList,
+							Optional:    true,
+							Computed:    true,
+							Description: "Terraform modules.",
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"name": &schema.Schema{
+										Type:        schema.TypeString,
+										Computed:    true,
+										Description: "Name of the module.",
+									},
+									"source": &schema.Schema{
+										Type:        schema.TypeString,
+										Computed:    true,
+										Description: "Source of the module.",
+									},
+									"offering_reference": &schema.Schema{
+										Type:        schema.TypeList,
+										Optional:    true,
+										Computed:    true,
+										Description: "Terraform modules.",
+										Elem: &schema.Resource{
+											Schema: map[string]*schema.Schema{
+												"name": &schema.Schema{
+													Type:        schema.TypeString,
+													Computed:    true,
+													Description: "Name of the offering module.",
+												},
+												"id": &schema.Schema{
+													Type:        schema.TypeString,
+													Computed:    true,
+													Description: "ID of the offering module.",
+												},
+												"kind": &schema.Schema{
+													Type:        schema.TypeString,
+													Computed:    true,
+													Description: "Kind of the offeringmodule.",
+												},
+												"version": &schema.Schema{
+													Type:        schema.TypeString,
+													Computed:    true,
+													Description: "Version of the offering module.",
+												},
+												"flavor": &schema.Schema{
+													Type:        schema.TypeString,
+													Computed:    true,
+													Description: "Flavor of the module.",
+												},
+												"flavors": &schema.Schema{
+													Type:        schema.TypeList,
+													Computed:    true,
+													Description: "Flavors of the module.",
+													Elem:        &schema.Schema{Type: schema.TypeString},
+												},
+												"catalog_id": &schema.Schema{
+													Type:        schema.TypeString,
+													Computed:    true,
+													Description: "Catalog ID of the module reference.",
+												},
+												"metadata": &schema.Schema{
+													Type:        schema.TypeString,
+													Computed:    true,
+													Description: "Metadata of the module.",
+												},
+											},
+										},
+									},
+								},
+							},
+						},
 						"version_name": &schema.Schema{
 							Type:        schema.TypeString,
 							Optional:    true,

--- a/ibm/service/catalogmanagement/resource_ibm_cm_version.go
+++ b/ibm/service/catalogmanagement/resource_ibm_cm_version.go
@@ -260,6 +260,24 @@ func ResourceIBMCmVersion() *schema.Resource {
 							Computed:    true,
 							Description: "Working directory of source files.",
 						},
+						"end_deploy_time": &schema.Schema{
+							Type:        schema.TypeString,
+							Optional:    true,
+							Computed:    true,
+							Description: "The time validation ended.",
+						},
+						"usage": &schema.Schema{
+							Type:        schema.TypeString,
+							Optional:    true,
+							Computed:    true,
+							Description: "Usage text for the version.",
+						},
+						"usage_template": &schema.Schema{
+							Type:        schema.TypeString,
+							Optional:    true,
+							Computed:    true,
+							Description: "Usage text for the version.",
+						},
 						"modules": &schema.Schema{
 							Type:        schema.TypeList,
 							Optional:    true,

--- a/ibm/service/catalogmanagement/resource_ibm_cm_version.go
+++ b/ibm/service/catalogmanagement/resource_ibm_cm_version.go
@@ -245,42 +245,46 @@ func ResourceIBMCmVersion() *schema.Resource {
 					Schema: map[string]*schema.Schema{
 						"source_url": &schema.Schema{
 							Type:        schema.TypeString,
-							Optional:    true,
+							Computed:    true,
 							Description: "Version source URL.",
 						},
 						"working_directory": &schema.Schema{
 							Type:        schema.TypeString,
-							Optional:    true,
 							Computed:    true,
 							Description: "Working directory of source files.",
 						},
 						"example_name": &schema.Schema{
 							Type:        schema.TypeString,
-							Optional:    true,
 							Computed:    true,
 							Description: "Working directory of source files.",
 						},
+						"start_deploy_time": &schema.Schema{
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "The time validation started.",
+						},
 						"end_deploy_time": &schema.Schema{
 							Type:        schema.TypeString,
-							Optional:    true,
 							Computed:    true,
 							Description: "The time validation ended.",
 						},
+						"est_deploy_time": &schema.Schema{
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "The estimated time validation takes.",
+						},
 						"usage": &schema.Schema{
 							Type:        schema.TypeString,
-							Optional:    true,
 							Computed:    true,
 							Description: "Usage text for the version.",
 						},
 						"usage_template": &schema.Schema{
 							Type:        schema.TypeString,
-							Optional:    true,
 							Computed:    true,
 							Description: "Usage text for the version.",
 						},
 						"modules": &schema.Schema{
 							Type:        schema.TypeList,
-							Optional:    true,
 							Computed:    true,
 							Description: "Terraform modules.",
 							Elem: &schema.Resource{
@@ -297,7 +301,6 @@ func ResourceIBMCmVersion() *schema.Resource {
 									},
 									"offering_reference": &schema.Schema{
 										Type:        schema.TypeList,
-										Optional:    true,
 										Computed:    true,
 										Description: "Terraform modules.",
 										Elem: &schema.Resource{
@@ -352,16 +355,19 @@ func ResourceIBMCmVersion() *schema.Resource {
 						"version_name": &schema.Schema{
 							Type:        schema.TypeString,
 							Optional:    true,
+							Computed:    true,
 							Description: "Version name.",
 						},
 						"terraform_version": &schema.Schema{
 							Type:        schema.TypeString,
 							Optional:    true,
+							Computed:    true,
 							Description: "Terraform version.",
 						},
 						"validated_terraform_version": &schema.Schema{
 							Type:        schema.TypeString,
 							Optional:    true,
+							Computed:    true,
 							Description: "Validated terraform version.",
 						},
 						"vsi_vpc": &schema.Schema{

--- a/website/docs/d/cm_version.html.markdown
+++ b/website/docs/d/cm_version.html.markdown
@@ -123,9 +123,28 @@ Nested scheme for **licenses**:
 
 * `long_description_i18n` - (Map) A map of translated strings, by language code.
 
-* `metadata` - (Forces new resource, List) Generic data to be included with content being onboarded. Required for virtual server image for VPC.
+* `metadata` - (List) Generic data to be included with content being onboarded. Required for virtual server image for VPC.
 Nested scheme for **metadata**:
 	* `source_url` - (String) Source URL for the version.
+    * `working_directory` - (String) Working directory of source files.
+	* `example_name` - (String) Name of example directory that contains source files in existing examples directory.
+	* `start_deploy_time` - (String) The time validation starts.
+	* `end_deploy_time` - (String) The time validation ends.
+	* `est_deploy_time` - (String) The estimated time validation takes.
+	* `usage` - (String) Usage text for the version.
+	* `usage_template` - (String) Usage text for the version.
+	Nested scheme for **modules**:
+		* `name` - (String) Name of the module.
+		* `source` - (String) Source of the module.
+		Nested scheme for **offering_reference**:
+			* `name` (String) Name of the offering.
+			* `id` (String) ID of the offering.
+			* `kind` (String) Kind of the offering.
+			* `version` (String) Version of the offering.
+			* `flavor` (String) Flavor of the offering.
+			* `flavors` (List) Flavors of the offering.
+			* `catalog_id` (String) Catalog ID of the offering.
+			* `metadata` (String) Metadata of the offering.
 	* `terraform_version` - (String) Version's terraform version.
 	* `validated_terraform_version` - (String) Version's validated terraform version.
 	* `version_name` - (String) Name of the version.

--- a/website/docs/r/cm_validation.html.markdown
+++ b/website/docs/r/cm_validation.html.markdown
@@ -1,0 +1,128 @@
+---
+layout: "ibm"
+page_title: "IBM : ibm_cm_validation"
+description: |-
+  Manages ibm_cm_validation.
+subcategory: "Catalog Management"
+---
+
+# ibm_cm_validation
+
+Provides a resource for ibm_cm_validation. This allows ibm_cm_validation to be created, updated and deleted.
+
+## Example Usage
+
+```hcl
+data "ibm_iam_auth_token" "tokendata" {}
+
+resource "ibm_cm_validation" "cm_version_validation" {
+  version_locator = ibm_cm_version.my_cm_version_tf.version_locator
+  x_auth_refresh_token = data.ibm_iam_auth_token.tokendata.iam_refresh_token
+  revalidate_if_validated = false
+  override_values = {
+    <example_override_key1> = <example_override_value1>
+    <example_override_key2> = <example_override_value2>
+  }
+  mark_version_consumable = true
+}
+```
+
+## Argument Reference
+
+Review the argument reference that you can specify for your resource.
+
+* `version_locator` - (Required, Forces new resource, String) Version locator - the version that will be validated.
+* `x_auth_refresh_token` - (Required, Sensitive, String) Authentication token used to submit validation job.
+* `region` - (Optional, Forces new resource, String) Validation region.
+* `override_values` - (Optional, Forces new resource, Map) Map of override values to be used in validation.
+Nested scheme for **environment_variables**:
+	* `name` - (Optional, String) Name of the environment variable.
+	* `value` - (Optional, String) Value of the environment variable.
+	* `secure` - (Optional, Bool) If the environment variablel should be secure.
+Nested scheme for **schematics**:
+	* `name` - (Optional, String) Name for the schematics workspace.
+	* `description` - (Optional, String) Description for the schematics workspace.
+	* `resource_group_id` - (Optional, String) The resource group ID.
+	* `terraform_version` - (Optional, String) Version of terraform to use in schematics.
+	* `region` - (Optional, String) Region to use for the schematics installation.
+	* `tags` - (Optional, List) List of tags for the schematics workspace.
+* `revalidate_if_validated` - (Optional, Forces new resource, Bool) If the version should be revalidated if it is already validated.
+* `mark_version_consumable` - (Optional, Bool) If the version should be marked as consumable after validation, aka \"ready to share\".
+
+## Attribute Reference
+
+In addition to all argument references listed, you can access the following attribute references after your resource is created.
+
+* `version_locator` - (String) Version locator - the version that will be validated.
+* `x_auth_refresh_token` - (String) Authentication token used to submit validation job.
+* `region` - (String) Validation region.
+* `override_values` - (Map) Map of override values to be used in validation.
+Nested scheme for **environment_variables**:
+	* `name` - (String) Name of the environment variable.
+	* `value` - (String) Value of the environment variable.
+	* `secure` - (Bool) If the environment variablel should be secure.
+Nested scheme for **schematics**:
+	* `name` - (String) Name for the schematics workspace.
+	* `description` - (String) Description for the schematics workspace.
+	* `resource_group_id` - (String) The resource group ID.
+	* `terraform_version` - (String) Version of terraform to use in schematics.
+	* `region` - (String) Region to use for the schematics installation.
+	* `tags` - (List) List of tags for the schematics workspace.
+* `validated` - (String) Data and time of last successful validation.
+* `requested` - (String) Data and time of last validation request.
+* `state` - (String) Current validation state - <empty>, in_progress, valid, invalid, expired.
+* `last_operation` - (String) Last operation (e.g. submit_deployment, generate_installer, install_offering.
+* `target` - (Map) Validation target information (e.g. cluster_id, region, namespace, etc).  Values will vary by Content type.
+* `message` - (String) Any message needing to be conveyed as part of the validation job.
+* `revalidate_if_validated` - (Bool) If the version should be revalidated if it is already validated.
+* `mark_version_consumable` - (Bool) If the version should be marked as consumable after validation, aka \"ready to share\".
+
+## Provider Configuration
+
+The IBM Cloud provider offers a flexible means of providing credentials for authentication. The following methods are supported, in this order, and explained below:
+
+- Static credentials
+- Environment variables
+
+To find which credentials are required for this resource, see the service table [here](https://cloud.ibm.com/docs/ibm-cloud-provider-for-terraform?topic=ibm-cloud-provider-for-terraform-provider-reference#required-parameters).
+
+### Static credentials
+
+You can provide your static credentials by adding the `ibmcloud_api_key`, `iaas_classic_username`, and `iaas_classic_api_key` arguments in the IBM Cloud provider block.
+
+Usage:
+```
+provider "ibm" {
+    ibmcloud_api_key = ""
+    iaas_classic_username = ""
+    iaas_classic_api_key = ""
+}
+```
+
+### Environment variables
+
+You can provide your credentials by exporting the `IC_API_KEY`, `IAAS_CLASSIC_USERNAME`, and `IAAS_CLASSIC_API_KEY` environment variables, representing your IBM Cloud platform API key, IBM Cloud Classic Infrastructure (SoftLayer) user name, and IBM Cloud infrastructure API key, respectively.
+
+```
+provider "ibm" {}
+```
+
+Usage:
+```
+export IC_API_KEY="api_key"
+export IAAS_CLASSIC_USERNAME="iaas_classic_username"
+export IAAS_CLASSIC_API_KEY="api_key"
+terraform plan
+```
+
+Note:
+
+1. Create or find your `ibmcloud_api_key` and `iaas_classic_api_key` [here](https://cloud.ibm.com/iam/apikeys).
+  - Select `My IBM Cloud API Keys` option from view dropdown for `ibmcloud_api_key`
+  - Select `Classic Infrastructure API Keys` option from view dropdown for `iaas_classic_api_key`
+2. For iaas_classic_username
+  - Go to [Users](https://cloud.ibm.com/iam/users)
+  - Click on user.
+  - Find user name in the `VPN password` section under `User Details` tab
+
+For more informaton, see [here](https://registry.terraform.io/providers/IBM-Cloud/ibm/latest/docs#authentication).

--- a/website/docs/r/cm_version.html.markdown
+++ b/website/docs/r/cm_version.html.markdown
@@ -110,6 +110,7 @@ Nested scheme for **metadata**:
 * `target_kinds` - (Optional, Forces new resource, List) Deployment target of the content being onboarded. Current valid values are iks, roks, vcenter, power-iaas, terraform, and vpc-x86. Required for virtual server image for VPC.
 * `target_version` - (Optional, Forces new resource, String) The semver value for this new version, if not found in the zip url package content.
 * `working_directory` - (Optional, Forces new resource, String) Optional - The sub-folder within the specified tgz file that contains the software being onboarded.
+* `x_auth_token` - (Optional, Forces new resource, String) The token to access the tgz in the repo.
 * `zipurl` - (Optional, Forces new resource, String) URL path to zip location.  If not specified, must provide content in the body of this call.
 
 ## Attribute Reference

--- a/website/docs/r/cm_version.html.markdown
+++ b/website/docs/r/cm_version.html.markdown
@@ -192,6 +192,25 @@ Nested scheme for **licenses**:
 * `metadata` - (Forces new resource, List) Generic data to be included with content being onboarded. Required for virtual server image for VPC.
 Nested scheme for **metadata**:
 	* `source_url` - (String) Source URL for the version.
+	* `working_directory` - (String) Working directory of source files.
+	* `example_name` - (String) Name of example directory that contains source files in existing examples directory.
+	* `start_deploy_time` - (String) The time validation starts.
+	* `end_deploy_time` - (String) The time validation ends.
+	* `est_deploy_time` - (String) The estimated time validation takes.
+	* `usage` - (String) Usage text for the version.
+	* `usage_template` - (String) Usage text for the version.
+	Nested scheme for **modules**:
+		* `name` - (String) Name of the module.
+		* `source` - (String) Source of the module.
+		Nested scheme for **offering_reference**:
+			* `name` (String) Name of the offering.
+			* `id` (String) ID of the offering.
+			* `kind` (String) Kind of the offering.
+			* `version` (String) Version of the offering.
+			* `flavor` (String) Flavor of the offering.
+			* `flavors` (List) Flavors of the offering.
+			* `catalog_id` (String) Catalog ID of the offering.
+			* `metadata` (String) Metadata of the offering.
 	* `terraform_version` - (String) Version's terraform version.
 	* `validated_terraform_version` - (String) Version's validated terraform version.
 	* `version_name` - (String) Name of the version.


### PR DESCRIPTION
Some products will be onboarded with a modules section that was not previously supported by the terraform provider, adding the parameters to the version resource metadata fixes the issue.

There were more metadata fields added by the API than expected, these have all been added to the resources and data sources to support cm onboarding.

Also added `x_auth_token` to the docs for the cm version resource, and created the `cm_validation` docs.