### PR TITLE
Object versioning and bucket replication fix

### DIFF
--- a/ibm/acctest/acctest.go
+++ b/ibm/acctest/acctest.go
@@ -25,6 +25,7 @@ var CisInstance string
 var CisResourceGroup string
 var CloudShellAccountID string
 var CosCRN string
+var BucketCRN string
 var CosName string
 var Ibmid1 string
 var Ibmid2 string
@@ -328,6 +329,11 @@ func init() {
 	if CosCRN == "" {
 		CosCRN = ""
 		fmt.Println("[WARN] Set the environment variable IBM_COS_CRN with a VALID COS instance CRN for testing ibm_cos_* resources")
+	}
+	BucketCRN = os.Getenv("IBM_COS_Bucket_CRN")
+	if BucketCRN == "" {
+		BucketCRN = ""
+		fmt.Println("[WARN] Set the environment variable IBM_COS_Bucket_CRN with a VALID BUCKET CRN for testing ibm_cos_bucket* resources")
 	}
 
 	CosName = os.Getenv("IBM_COS_NAME")

--- a/ibm/service/cos/resource_ibm_cos_bucket_object.go
+++ b/ibm/service/cos/resource_ibm_cos_bucket_object.go
@@ -150,16 +150,6 @@ func resourceIBMCOSBucketObjectCreate(ctx context.Context, d *schema.ResourceDat
 
 	objectKey := d.Get("key").(string)
 
-	// This check is to make sure new create does not
-	// overwrite objects that is not managed by Terraform
-	exists, err := objectExists(s3Client, bucketName, objectKey)
-	if err != nil {
-		return diag.FromErr(err)
-	}
-	if exists {
-		return diag.FromErr(fmt.Errorf("[ERROR] Error COS bucket (%s) object (%s) already exists", bucketName, objectKey))
-	}
-
 	var body io.ReadSeeker
 
 	if v, ok := d.GetOk("content"); ok {

--- a/ibm/service/cos/resource_ibm_cos_bucket_object_test.go
+++ b/ibm/service/cos/resource_ibm_cos_bucket_object_test.go
@@ -68,7 +68,7 @@ func TestAccIBMCOSBucketObject_basic(t *testing.T) {
 	})
 }
 
-func TestAccIBMCOSBucketObject_Versioning_Enabled(t *testing.T) {
+func TestAccIBMCOSBucketObject_VersioningEnabled(t *testing.T) {
 	name := fmt.Sprintf("tf-testacc-cos-%d", acctest.RandIntRange(10, 100))
 	key := "plaintext.txt"
 	instanceCRN := acc.CosCRN
@@ -82,6 +82,7 @@ func TestAccIBMCOSBucketObject_Versioning_Enabled(t *testing.T) {
 				Config: testAccIBMCOSBucketBucketObject_Versioning_Enabled(name, key, instanceCRN, objectBody1, objectBody2),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("ibm_cos_bucket.testacc", "object_versioning.#", "1"),
+					resource.TestCheckResourceAttr("ibm_cos_bucket.testacc", "object_versioning.0.enable", "true"),
 					resource.TestCheckResourceAttrSet("ibm_cos_bucket_object.testacc_object", "id"),
 					resource.TestCheckResourceAttrSet("ibm_cos_bucket_object.testacc_object", "content"),
 					resource.TestCheckResourceAttrSet("ibm_cos_bucket_object.testacc_object", "content_length"),
@@ -98,7 +99,7 @@ func TestAccIBMCOSBucketObject_Versioning_Enabled(t *testing.T) {
 	})
 }
 
-func TestAccIBMCOSBucketObject_Versioning_Enabled_Sequential_Upload(t *testing.T) {
+func TestAccIBMCOSBucketObject_Versioning_Enabled_Sequential_Upload_on_Existing_Bucket(t *testing.T) {
 	key := "plaintext.txt"
 	bucketCRN := acc.BucketCRN
 	objectBody1 := "Acceptance Testing"
@@ -108,7 +109,7 @@ func TestAccIBMCOSBucketObject_Versioning_Enabled_Sequential_Upload(t *testing.T
 		Providers: acc.TestAccProviders,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccIBMCOSBucketBucketObject_Versioning_Enabled_Upload1(bucketCRN, key, objectBody1),
+				Config: testAccIBMCOSBucketBucketObjectUpload(bucketCRN, key, objectBody1),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrSet("ibm_cos_bucket_object.testacc_object", "id"),
 					resource.TestCheckResourceAttrSet("ibm_cos_bucket_object.testacc_object", "content"),
@@ -118,20 +119,20 @@ func TestAccIBMCOSBucketObject_Versioning_Enabled_Sequential_Upload(t *testing.T
 				),
 			},
 			{
-				Config: testAccIBMCOSBucketBucketObject_Versioning_Enabled_Upload2(bucketCRN, key, objectBody2),
+				Config: testAccIBMCOSBucketBucketObjectUpload(bucketCRN, key, objectBody2),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttrSet("ibm_cos_bucket_object.testacc_object2", "id"),
-					resource.TestCheckResourceAttrSet("ibm_cos_bucket_object.testacc_object2", "content"),
-					resource.TestCheckResourceAttrSet("ibm_cos_bucket_object.testacc_object2", "content_length"),
-					resource.TestCheckResourceAttrSet("ibm_cos_bucket_object.testacc_object2", "content_type"),
-					resource.TestCheckResourceAttr("ibm_cos_bucket_object.testacc_object2", "content", objectBody2),
+					resource.TestCheckResourceAttrSet("ibm_cos_bucket_object.testacc_object", "id"),
+					resource.TestCheckResourceAttrSet("ibm_cos_bucket_object.testacc_object", "content"),
+					resource.TestCheckResourceAttrSet("ibm_cos_bucket_object.testacc_object", "content_length"),
+					resource.TestCheckResourceAttrSet("ibm_cos_bucket_object.testacc_object", "content_type"),
+					resource.TestCheckResourceAttr("ibm_cos_bucket_object.testacc_object", "content", objectBody2),
 				),
 			},
 		},
 	})
 }
 
-func TestAccIBMCOSBucketObject_Overwriting(t *testing.T) {
+func TestAccIBMCOSBucketObject_Uploading_Multile_Objects_on_Existing_Bucket_without_Versioning(t *testing.T) {
 	key := "plaintext.txt"
 	bucketCRN := acc.BucketCRN
 	objectBody1 := "Acceptance Testing"
@@ -141,7 +142,7 @@ func TestAccIBMCOSBucketObject_Overwriting(t *testing.T) {
 		Providers: acc.TestAccProviders,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccIBMCOSBucketBucketObject_Versioning_Enabled_Upload1(bucketCRN, key, objectBody1),
+				Config: testAccIBMCOSBucketBucketObjectUpload(bucketCRN, key, objectBody1),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrSet("ibm_cos_bucket_object.testacc_object", "id"),
 					resource.TestCheckResourceAttrSet("ibm_cos_bucket_object.testacc_object", "content"),
@@ -151,13 +152,13 @@ func TestAccIBMCOSBucketObject_Overwriting(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccIBMCOSBucketBucketObject_Versioning_Enabled_Upload2(bucketCRN, key, objectBody2),
+				Config: testAccIBMCOSBucketBucketObjectUpload(bucketCRN, key, objectBody2),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttrSet("ibm_cos_bucket_object.testacc_object2", "id"),
-					resource.TestCheckResourceAttrSet("ibm_cos_bucket_object.testacc_object2", "content"),
-					resource.TestCheckResourceAttrSet("ibm_cos_bucket_object.testacc_object2", "content_length"),
-					resource.TestCheckResourceAttrSet("ibm_cos_bucket_object.testacc_object2", "content_type"),
-					resource.TestCheckResourceAttr("ibm_cos_bucket_object.testacc_object2", "content", objectBody2),
+					resource.TestCheckResourceAttrSet("ibm_cos_bucket_object.testacc_object", "id"),
+					resource.TestCheckResourceAttrSet("ibm_cos_bucket_object.testacc_object", "content"),
+					resource.TestCheckResourceAttrSet("ibm_cos_bucket_object.testacc_object", "content_length"),
+					resource.TestCheckResourceAttrSet("ibm_cos_bucket_object.testacc_object", "content_type"),
+					resource.TestCheckResourceAttr("ibm_cos_bucket_object.testacc_object", "content", objectBody2),
 				),
 			},
 		},
@@ -237,22 +238,12 @@ func testAccIBMCOSBucketBucketObject_Versioning_Enabled(name string, key string,
 		}`, name, key, instanceCRN, objectBody1, objectBody2)
 }
 
-func testAccIBMCOSBucketBucketObject_Versioning_Enabled_Upload1(bucketCrn string, key string, objectBody1 string) string {
+func testAccIBMCOSBucketBucketObjectUpload(bucketCrn string, key string, objectBody1 string) string {
 	return fmt.Sprintf(`
 		resource "ibm_cos_bucket_object" "testacc_object" {
 			bucket_crn	    = "%[1]s"
-			bucket_location = "us"
+			bucket_location = "us-south"
 			key 			= "%[2]s"
 			content			= "%[3]s"
 		}`, bucketCrn, key, objectBody1)
-}
-
-func testAccIBMCOSBucketBucketObject_Versioning_Enabled_Upload2(bucketCrn string, key string, objectBody string) string {
-	return fmt.Sprintf(`
-		resource "ibm_cos_bucket_object" "testacc_object2" {
-			bucket_crn	    = "%[1]s"
-			bucket_location = "us"
-			key 					  = "%[2]s"
-			content			    = "%[3]s"
-		}`, bucketCrn, key, objectBody)
 }

--- a/ibm/service/cos/resource_ibm_cos_bucket_object_test.go
+++ b/ibm/service/cos/resource_ibm_cos_bucket_object_test.go
@@ -68,6 +68,102 @@ func TestAccIBMCOSBucketObject_basic(t *testing.T) {
 	})
 }
 
+func TestAccIBMCOSBucketObject_Versioning_Enabled(t *testing.T) {
+	name := fmt.Sprintf("tf-testacc-cos-%d", acctest.RandIntRange(10, 100))
+	key := "plaintext.txt"
+	instanceCRN := acc.CosCRN
+	objectBody1 := "Acceptance Testing"
+	objectBody2 := "Acceptance Testing object 2"
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { acc.TestAccPreCheckCOS(t) },
+		Providers: acc.TestAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccIBMCOSBucketBucketObject_Versioning_Enabled(name, key, instanceCRN, objectBody1, objectBody2),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("ibm_cos_bucket.testacc", "object_versioning.#", "1"),
+					resource.TestCheckResourceAttrSet("ibm_cos_bucket_object.testacc_object", "id"),
+					resource.TestCheckResourceAttrSet("ibm_cos_bucket_object.testacc_object", "content"),
+					resource.TestCheckResourceAttrSet("ibm_cos_bucket_object.testacc_object", "content_length"),
+					resource.TestCheckResourceAttrSet("ibm_cos_bucket_object.testacc_object", "content_type"),
+					resource.TestCheckResourceAttr("ibm_cos_bucket_object.testacc_object", "content", objectBody1),
+					resource.TestCheckResourceAttrSet("ibm_cos_bucket_object.testacc_object2", "id"),
+					resource.TestCheckResourceAttrSet("ibm_cos_bucket_object.testacc_object2", "content"),
+					resource.TestCheckResourceAttrSet("ibm_cos_bucket_object.testacc_object2", "content_length"),
+					resource.TestCheckResourceAttrSet("ibm_cos_bucket_object.testacc_object2", "content_type"),
+					resource.TestCheckResourceAttr("ibm_cos_bucket_object.testacc_object2", "content", objectBody2),
+				),
+			},
+		},
+	})
+}
+
+func TestAccIBMCOSBucketObject_Versioning_Enabled_Sequential_Upload(t *testing.T) {
+	key := "plaintext.txt"
+	bucketCRN := acc.BucketCRN
+	objectBody1 := "Acceptance Testing"
+	objectBody2 := "Acceptance Testing object 2"
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { acc.TestAccPreCheckCOS(t) },
+		Providers: acc.TestAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccIBMCOSBucketBucketObject_Versioning_Enabled_Upload1(bucketCRN, key, objectBody1),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet("ibm_cos_bucket_object.testacc_object", "id"),
+					resource.TestCheckResourceAttrSet("ibm_cos_bucket_object.testacc_object", "content"),
+					resource.TestCheckResourceAttrSet("ibm_cos_bucket_object.testacc_object", "content_length"),
+					resource.TestCheckResourceAttrSet("ibm_cos_bucket_object.testacc_object", "content_type"),
+					resource.TestCheckResourceAttr("ibm_cos_bucket_object.testacc_object", "content", objectBody1),
+				),
+			},
+			{
+				Config: testAccIBMCOSBucketBucketObject_Versioning_Enabled_Upload2(bucketCRN, key, objectBody2),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet("ibm_cos_bucket_object.testacc_object2", "id"),
+					resource.TestCheckResourceAttrSet("ibm_cos_bucket_object.testacc_object2", "content"),
+					resource.TestCheckResourceAttrSet("ibm_cos_bucket_object.testacc_object2", "content_length"),
+					resource.TestCheckResourceAttrSet("ibm_cos_bucket_object.testacc_object2", "content_type"),
+					resource.TestCheckResourceAttr("ibm_cos_bucket_object.testacc_object2", "content", objectBody2),
+				),
+			},
+		},
+	})
+}
+
+func TestAccIBMCOSBucketObject_Overwriting(t *testing.T) {
+	key := "plaintext.txt"
+	bucketCRN := "crn:v1:bluemix:public:cloud-object-storage:global:a/ee747e45752d4696b2d082bcf2357559:017d227c-fb2e-4260-8874-d53951eb50ad:bucket:object-versioning-tf-fix"
+	objectBody1 := "Acceptance Testing"
+	objectBody2 := "Acceptance Testing object 2"
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { acc.TestAccPreCheckCOS(t) },
+		Providers: acc.TestAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccIBMCOSBucketBucketObject_Versioning_Enabled_Upload1(bucketCRN, key, objectBody1),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet("ibm_cos_bucket_object.testacc_object", "id"),
+					resource.TestCheckResourceAttrSet("ibm_cos_bucket_object.testacc_object", "content"),
+					resource.TestCheckResourceAttrSet("ibm_cos_bucket_object.testacc_object", "content_length"),
+					resource.TestCheckResourceAttrSet("ibm_cos_bucket_object.testacc_object", "content_type"),
+					resource.TestCheckResourceAttr("ibm_cos_bucket_object.testacc_object", "content", objectBody1),
+				),
+			},
+			{
+				Config: testAccIBMCOSBucketBucketObject_Versioning_Enabled_Upload2(bucketCRN, key, objectBody2),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet("ibm_cos_bucket_object.testacc_object2", "id"),
+					resource.TestCheckResourceAttrSet("ibm_cos_bucket_object.testacc_object2", "content"),
+					resource.TestCheckResourceAttrSet("ibm_cos_bucket_object.testacc_object2", "content_length"),
+					resource.TestCheckResourceAttrSet("ibm_cos_bucket_object.testacc_object2", "content_type"),
+					resource.TestCheckResourceAttr("ibm_cos_bucket_object.testacc_object2", "content", objectBody2),
+				),
+			},
+		},
+	})
+}
+
 func testAccIBMCOSBucketObjectConfig_plaintext(name string, instanceCRN string, objectBody string) string {
 	return fmt.Sprintf(`
 		resource "ibm_cos_bucket" "testacc" {
@@ -114,4 +210,49 @@ func testAccIBMCOSBucketObjectConfig_file(name string, instanceCRN string, objec
 			key 					  = "%[1]s.txt"
 			content_file	  = "%[3]s"
 		}`, name, instanceCRN, objectFile)
+}
+
+func testAccIBMCOSBucketBucketObject_Versioning_Enabled(name string, key string, instanceCRN string, objectBody1 string, objectBody2 string) string {
+	return fmt.Sprintf(`
+		resource "ibm_cos_bucket" "testacc" {
+			bucket_name          = "%[1]s"
+			resource_instance_id = "%[3]s"
+			region_location      = "us-south"
+			storage_class        = "standard"
+			object_versioning {
+				enable  = true
+			  }
+		}
+		resource "ibm_cos_bucket_object" "testacc_object" {
+			bucket_crn	    = ibm_cos_bucket.testacc.crn
+			bucket_location = ibm_cos_bucket.testacc.region_location
+			key 			= "%[2]s"
+			content			= "%[4]s"
+		}
+		resource "ibm_cos_bucket_object" "testacc_object2" {
+			bucket_crn	    = ibm_cos_bucket.testacc.crn
+			bucket_location = ibm_cos_bucket.testacc.region_location
+			key 					  = "%[2]s"
+			content			    = "%[5]s"
+		}`, name, key, instanceCRN, objectBody1, objectBody2)
+}
+
+func testAccIBMCOSBucketBucketObject_Versioning_Enabled_Upload1(bucketCrn string, key string, objectBody1 string) string {
+	return fmt.Sprintf(`
+		resource "ibm_cos_bucket_object" "testacc_object" {
+			bucket_crn	    = "%[1]s"
+			bucket_location = "us"
+			key 			= "%[2]s"
+			content			= "%[3]s"
+		}`, bucketCrn, key, objectBody1)
+}
+
+func testAccIBMCOSBucketBucketObject_Versioning_Enabled_Upload2(bucketCrn string, key string, objectBody string) string {
+	return fmt.Sprintf(`
+		resource "ibm_cos_bucket_object" "testacc_object2" {
+			bucket_crn	    = "%[1]s"
+			bucket_location = "us"
+			key 					  = "%[2]s"
+			content			    = "%[3]s"
+		}`, bucketCrn, key, objectBody)
 }

--- a/ibm/service/cos/resource_ibm_cos_bucket_object_test.go
+++ b/ibm/service/cos/resource_ibm_cos_bucket_object_test.go
@@ -133,7 +133,7 @@ func TestAccIBMCOSBucketObject_Versioning_Enabled_Sequential_Upload(t *testing.T
 
 func TestAccIBMCOSBucketObject_Overwriting(t *testing.T) {
 	key := "plaintext.txt"
-	bucketCRN := "crn:v1:bluemix:public:cloud-object-storage:global:a/ee747e45752d4696b2d082bcf2357559:017d227c-fb2e-4260-8874-d53951eb50ad:bucket:object-versioning-tf-fix"
+	bucketCRN := acc.BucketCRN
 	objectBody1 := "Acceptance Testing"
 	objectBody2 := "Acceptance Testing object 2"
 	resource.Test(t, resource.TestCase{

--- a/ibm/service/cos/resource_ibm_cos_replication_configuration.go
+++ b/ibm/service/cos/resource_ibm_cos_replication_configuration.go
@@ -89,10 +89,9 @@ func ResourceIBMCOSBucketReplicationConfiguration() *schema.Resource {
 							Description: "Indicates whether to replicate delete markers. It should be either Enable or Disable",
 						},
 						"destination_bucket_crn": {
-							Type:         schema.TypeString,
-							Required:     true,
-							ValidateFunc: validate.ValidateRegexps(`^crn:.+:.+:.+:.+:.+:a\/[0-9a-f]{32}:[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}:bucket:[a-z-A-Z]*[0-9]*$`),
-							Description:  "The Cloud Resource Name (CRN) of the bucket where you want COS to store the results",
+							Type:        schema.TypeString,
+							Required:    true,
+							Description: "The Cloud Resource Name (CRN) of the bucket where you want COS to store the results",
 						},
 					},
 				},


### PR DESCRIPTION
--- PASS: TestAccIBMCOSBucketObject_Versioning_Enabled (28.20s)
PASS
ok  	github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/cos	29.700s


--- PASS: TestAccIBMCOSBucketObject_Versioning_Enabled_Sequential_Upload (31.11s)
PASS
ok  	github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/cos	32.475s



--- PASS: TestAccIBMCOSBucketObject_Overwriting (28.31s)
PASS
ok  	github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/cos	29.701s
