### PR TITLE
docs: small doc fix for validation resource

### DIFF
--- a/ibm/service/catalogmanagement/resource_ibm_cm_object.go
+++ b/ibm/service/catalogmanagement/resource_ibm_cm_object.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"log"
 	"strconv"
+	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -318,7 +319,13 @@ func resourceIBMCmObjectRead(context context.Context, d *schema.ResourceData, me
 		return diag.FromErr(fmt.Errorf("Error setting label: %s", err))
 	}
 	if catalogObject.Tags != nil {
-		if err = d.Set("tags", catalogObject.Tags); err != nil {
+		modifiedTags := []string{}
+		for _, tag := range catalogObject.Tags {
+			if !strings.HasPrefix(tag, "svc:") && !strings.HasPrefix(tag, "fqdn:") && tag != *catalogObject.ParentID {
+				modifiedTags = append(modifiedTags, tag)
+			}
+		}
+		if err = d.Set("tags", modifiedTags); err != nil {
 			return diag.FromErr(fmt.Errorf("Error setting tags: %s", err))
 		}
 	}

--- a/ibm/service/catalogmanagement/resource_ibm_cm_object_test.go
+++ b/ibm/service/catalogmanagement/resource_ibm_cm_object_test.go
@@ -19,10 +19,10 @@ import (
 func TestAccIBMCmObjectSimpleArgs(t *testing.T) {
 	var conf catalogmanagementv1.CatalogObject
 	name := fmt.Sprintf("tf_name_%d", acctest.RandIntRange(10, 100))
-	parentID := fmt.Sprintf("tf_parent_id_%d", acctest.RandIntRange(10, 100))
 	label := fmt.Sprintf("tf_label_%d", acctest.RandIntRange(10, 100))
 	shortDescription := fmt.Sprintf("tf_short_description_%d", acctest.RandIntRange(10, 100))
-	kind := "preset_configuration"
+	parentID := "us-south"
+	kind := "vpe"
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { acc.TestAccPreCheck(t) },
@@ -38,6 +38,8 @@ func TestAccIBMCmObjectSimpleArgs(t *testing.T) {
 					resource.TestCheckResourceAttr("ibm_cm_object.cm_object", "label", label),
 					resource.TestCheckResourceAttr("ibm_cm_object.cm_object", "short_description", shortDescription),
 					resource.TestCheckResourceAttr("ibm_cm_object.cm_object", "kind", kind),
+					resource.TestCheckResourceAttrSet("ibm_cm_object.cm_object", "data"),
+					resource.TestCheckResourceAttrSet("ibm_cm_object.cm_object", "tags.#"),
 				),
 			},
 		},
@@ -49,7 +51,16 @@ func testAccCheckIBMCmObjectConfig(name string, parentID string, label string, s
 
 		resource "ibm_cm_catalog" "cm_catalog" {
 			label = "test_preset_catalog_tf_test"
-			kind = "preset_configuration"
+			kind = "vpe"
+		}
+		
+		locals {
+			catalog_object_data = {
+				dns_domain = "test"
+				endpoint_type = "test"
+				fully_qualified_domain_names = ["test1.com", "test2.com", "test3.com"]
+				service_crn = "test"
+			}
 		}
 
 		resource "ibm_cm_object" "cm_object" {
@@ -59,6 +70,8 @@ func testAccCheckIBMCmObjectConfig(name string, parentID string, label string, s
 			label = "%s"
 			short_description = "%s"
 			kind = "%s"
+			tags = ["test1", "test2"]
+			data = jsonencode(local.catalog_object_data)
 		}
 	`, name, parentID, label, shortDescription, kind)
 }

--- a/website/docs/r/cm_validation.html.markdown
+++ b/website/docs/r/cm_validation.html.markdown
@@ -35,10 +35,12 @@ Review the argument reference that you can specify for your resource.
 * `x_auth_refresh_token` - (Required, Sensitive, String) Authentication token used to submit validation job.
 * `region` - (Optional, Forces new resource, String) Validation region.
 * `override_values` - (Optional, Forces new resource, Map) Map of override values to be used in validation.
+* `environment_variables` - (List) List of environment variables to pass to Schematics.
 Nested scheme for **environment_variables**:
 	* `name` - (Optional, String) Name of the environment variable.
 	* `value` - (Optional, String) Value of the environment variable.
 	* `secure` - (Optional, Bool) If the environment variablel should be secure.
+* `schematics` - (List) Other values to pass to Schematics.
 Nested scheme for **schematics**:
 	* `name` - (Optional, String) Name for the schematics workspace.
 	* `description` - (Optional, String) Description for the schematics workspace.
@@ -57,10 +59,12 @@ In addition to all argument references listed, you can access the following attr
 * `x_auth_refresh_token` - (String) Authentication token used to submit validation job.
 * `region` - (String) Validation region.
 * `override_values` - (Map) Map of override values to be used in validation.
+* `environment_variables` - (List) List of environment variables to pass to Schematics.
 Nested scheme for **environment_variables**:
 	* `name` - (String) Name of the environment variable.
 	* `value` - (String) Value of the environment variable.
 	* `secure` - (Bool) If the environment variablel should be secure.
+* `schematics` - (List) Other values to pass to Schematics.
 Nested scheme for **schematics**:
 	* `name` - (String) Name for the schematics workspace.
 	* `description` - (String) Description for the schematics workspace.


### PR DESCRIPTION
small doc fix for validation resource, I missed the parent parameter for the nested list.

Fix also includes a fix for tags not being idempotent when generated from api.  My last PR for this was closed somehow before being merged.