### PR TITLE
fix(clone): update on backup policy plan clone policy

### DIFF
--- a/ibm/acctest/acctest.go
+++ b/ibm/acctest/acctest.go
@@ -62,6 +62,7 @@ var UpdatedCertCRN string
 var RegionName string
 var ISZoneName string
 var ISZoneName2 string
+var ISZoneName3 string
 var IsResourceGroupID string
 var ISCIDR string
 var ISCIDR2 string
@@ -494,6 +495,12 @@ func init() {
 	if ISZoneName2 == "" {
 		ISZoneName2 = "us-south-2"
 		fmt.Println("[INFO] Set the environment variable SL_ZONE_2 for testing ibm_is_zone datasource else it is set to default value 'us-south-2'")
+	}
+
+	ISZoneName3 = os.Getenv("SL_ZONE_3")
+	if ISZoneName3 == "" {
+		ISZoneName3 = "us-south-3"
+		fmt.Println("[INFO] Set the environment variable SL_ZONE_3 for testing ibm_is_zone datasource else it is set to default value 'us-south-3'")
 	}
 
 	ISCIDR = os.Getenv("SL_CIDR")

--- a/ibm/service/vpc/resource_ibm_is_backup_policy_plan.go
+++ b/ibm/service/vpc/resource_ibm_is_backup_policy_plan.go
@@ -458,12 +458,13 @@ func resourceIBMIsBackupPolicyPlanUpdate(context context.Context, d *schema.Reso
 				backupPolicyPlanClonePolicyPatch.Zones = zonesbjs
 			}
 		}
-		if d.HasChange("clone_policy.0.zones") {
+		if d.HasChange("clone_policy.0.max_snapshots") {
 			maxSnapshotsOk := d.Get("clone_policy.0.max_snapshots")
 			maxSnapshots := int64(maxSnapshotsOk.(int))
 			backupPolicyPlanClonePolicyPatch.MaxSnapshots = &maxSnapshots
 		}
 		patchVals.ClonePolicy = backupPolicyPlanClonePolicyPatch
+		hasChange = true
 	}
 
 	if d.HasChange("name") {

--- a/ibm/service/vpc/resource_ibm_is_backup_policy_plan_test.go
+++ b/ibm/service/vpc/resource_ibm_is_backup_policy_plan_test.go
@@ -149,6 +149,85 @@ func TestAccIBMIsBackupPolicyPlanClonesBasic(t *testing.T) {
 		},
 	})
 }
+func TestAccIBMIsBackupPolicyPlanClonesUpdate(t *testing.T) {
+	var conf vpcv1.BackupPolicyPlan
+	vpcname := fmt.Sprintf("tf-vpc-%d", acctest.RandIntRange(10, 100))
+	name := fmt.Sprintf("tf-instnace-%d", acctest.RandIntRange(10, 100))
+	subnetname := fmt.Sprintf("tf-subnet-%d", acctest.RandIntRange(10, 100))
+	sshname := fmt.Sprintf("tf-ssh-%d", acctest.RandIntRange(10, 100))
+	volname := fmt.Sprintf("tf-vol-%d", acctest.RandIntRange(10, 100))
+	backupPolicyName := fmt.Sprintf("tfbakuppolicyname%d", acctest.RandIntRange(10, 100))
+	backupPolicyPlanName := fmt.Sprintf("tfbakuppolicyplanname%d", acctest.RandIntRange(10, 100))
+	backupPolicyPlanNameUpdate := fmt.Sprintf("tfbakuppolicyplannameupdate%d", acctest.RandIntRange(10, 100))
+	cronSpec := strings.TrimSpace(strconv.Itoa(time.Now().UTC().Minute()) + " " + strconv.Itoa(time.Now().UTC().Hour()) + " " + "*" + " " + "*" + " " + "*")
+	cronSpecUpdate := strings.TrimSpace(strconv.Itoa(time.Now().UTC().Minute()+1) + " " + strconv.Itoa(time.Now().UTC().Hour()) + " " + "*" + " " + "*" + " " + "*")
+	if strings.TrimSpace(strconv.Itoa(time.Now().UTC().Minute())) == "61" {
+		cronSpecUpdate = strings.TrimSpace(("1") + " " + strconv.Itoa(time.Now().UTC().Hour()+1) + " " + "*" + " " + "*" + " " + "*")
+	}
+	numberOfClones2 := 2
+	numberOfClones3 := 3
+	maxSnapshots3 := 3
+	maxSnapshots4 := 4
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { acc.TestAccPreCheck(t) },
+		Providers:    acc.TestAccProviders,
+		CheckDestroy: testAccCheckIBMIsBackupPolicyPlanDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccCheckIBMIsBackupPolicyPlanConfigClonesUpdate(backupPolicyName, vpcname, subnetname, sshname, volname, name, cronSpec, backupPolicyPlanName, numberOfClones2, maxSnapshots3),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckIBMIsBackupPolicyPlanExists("ibm_is_backup_policy_plan.is_backup_policy_plan.0", conf),
+					resource.TestCheckResourceAttr("ibm_is_backup_policy_plan.is_backup_policy_plan.0", "name", backupPolicyPlanName+"-1"),
+					resource.TestCheckResourceAttr("ibm_is_backup_policy_plan.is_backup_policy_plan.0", "cron_spec", cronSpec),
+					resource.TestCheckResourceAttrSet("ibm_is_backup_policy_plan.is_backup_policy_plan.0", "backup_policy_id"),
+					resource.TestCheckResourceAttrSet("ibm_is_backup_policy_plan.is_backup_policy_plan.0", "backup_policy_plan_id"),
+					resource.TestCheckResourceAttrSet("ibm_is_backup_policy_plan.is_backup_policy_plan.0", "active"),
+					resource.TestCheckResourceAttrSet("ibm_is_backup_policy_plan.is_backup_policy_plan.0", "copy_user_tags"),
+					resource.TestCheckResourceAttrSet("ibm_is_backup_policy_plan.is_backup_policy_plan.0", "deletion_trigger.#"),
+					resource.TestCheckResourceAttrSet("ibm_is_backup_policy_plan.is_backup_policy_plan.0", "created_at"),
+					resource.TestCheckResourceAttrSet("ibm_is_backup_policy_plan.is_backup_policy_plan.0", "href"),
+					resource.TestCheckResourceAttrSet("ibm_is_backup_policy_plan.is_backup_policy_plan.0", "lifecycle_state"),
+					resource.TestCheckResourceAttrSet("ibm_is_backup_policy_plan.is_backup_policy_plan.0", "resource_type"),
+					resource.TestCheckResourceAttrSet("ibm_is_backup_policy_plan.is_backup_policy_plan.0", "version"),
+					resource.TestCheckResourceAttrSet("ibm_is_backup_policy_plan.is_backup_policy_plan.0", "clone_policy.0.max_snapshots"),
+					resource.TestCheckResourceAttrSet("ibm_is_backup_policy_plan.is_backup_policy_plan.0", "clone_policy.0.zones.#"),
+					resource.TestCheckResourceAttr("ibm_is_backup_policy_plan.is_backup_policy_plan.0", "clone_policy.0.zones.#", fmt.Sprintf("%d", numberOfClones2)),
+					resource.TestCheckResourceAttr("ibm_is_backup_policy_plan.is_backup_policy_plan.0", "clone_policy.0.max_snapshots", fmt.Sprintf("%d", maxSnapshots3)),
+					resource.TestCheckResourceAttr("ibm_is_backup_policy_plan.is_backup_policy_plan.0", "clone_policy.0.zones.0", acc.ISZoneName),
+					resource.TestCheckResourceAttr("ibm_is_backup_policy_plan.is_backup_policy_plan.0", "clone_policy.0.zones.1", acc.ISZoneName2),
+				),
+			},
+			resource.TestStep{
+				Config: testAccCheckIBMIsBackupPolicyPlanConfigClonesUpdate(backupPolicyName, vpcname, subnetname, sshname, volname, name, cronSpecUpdate, backupPolicyPlanNameUpdate, numberOfClones3, maxSnapshots4),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckIBMIsBackupPolicyPlanExists("ibm_is_backup_policy_plan.is_backup_policy_plan.0", conf),
+					resource.TestCheckResourceAttr("ibm_is_backup_policy_plan.is_backup_policy_plan.0", "name", backupPolicyPlanNameUpdate+"-1"),
+					resource.TestCheckResourceAttr("ibm_is_backup_policy_plan.is_backup_policy_plan.0", "cron_spec", cronSpecUpdate),
+					resource.TestCheckResourceAttrSet("ibm_is_backup_policy_plan.is_backup_policy_plan.0", "backup_policy_id"),
+					resource.TestCheckResourceAttrSet("ibm_is_backup_policy_plan.is_backup_policy_plan.0", "backup_policy_plan_id"),
+					resource.TestCheckResourceAttrSet("ibm_is_backup_policy_plan.is_backup_policy_plan.0", "active"),
+					resource.TestCheckResourceAttrSet("ibm_is_backup_policy_plan.is_backup_policy_plan.0", "copy_user_tags"),
+					resource.TestCheckResourceAttrSet("ibm_is_backup_policy_plan.is_backup_policy_plan.0", "deletion_trigger.#"),
+					resource.TestCheckResourceAttrSet("ibm_is_backup_policy_plan.is_backup_policy_plan.0", "created_at"),
+					resource.TestCheckResourceAttrSet("ibm_is_backup_policy_plan.is_backup_policy_plan.0", "href"),
+					resource.TestCheckResourceAttrSet("ibm_is_backup_policy_plan.is_backup_policy_plan.0", "lifecycle_state"),
+					resource.TestCheckResourceAttrSet("ibm_is_backup_policy_plan.is_backup_policy_plan.0", "resource_type"),
+					resource.TestCheckResourceAttrSet("ibm_is_backup_policy_plan.is_backup_policy_plan.0", "version"),
+					resource.TestCheckResourceAttrSet("ibm_is_backup_policy_plan.is_backup_policy_plan.0", "clone_policy.0.max_snapshots"),
+					resource.TestCheckResourceAttrSet("ibm_is_backup_policy_plan.is_backup_policy_plan.0", "clone_policy.0.zones.#"),
+					resource.TestCheckResourceAttrSet("ibm_is_backup_policy_plan.is_backup_policy_plan.0", "clone_policy.0.max_snapshots"),
+					resource.TestCheckResourceAttrSet("ibm_is_backup_policy_plan.is_backup_policy_plan.0", "clone_policy.0.zones.#"),
+					resource.TestCheckResourceAttr("ibm_is_backup_policy_plan.is_backup_policy_plan.0", "clone_policy.0.zones.#", fmt.Sprintf("%d", numberOfClones3)),
+					resource.TestCheckResourceAttr("ibm_is_backup_policy_plan.is_backup_policy_plan.0", "clone_policy.0.max_snapshots", fmt.Sprintf("%d", maxSnapshots4)),
+					resource.TestCheckResourceAttr("ibm_is_backup_policy_plan.is_backup_policy_plan.0", "clone_policy.0.zones.0", acc.ISZoneName),
+					resource.TestCheckResourceAttr("ibm_is_backup_policy_plan.is_backup_policy_plan.0", "clone_policy.0.zones.1", acc.ISZoneName2),
+					resource.TestCheckResourceAttr("ibm_is_backup_policy_plan.is_backup_policy_plan.0", "clone_policy.0.zones.2", acc.ISZoneName3),
+				),
+			},
+		},
+	})
+}
 
 func TestAccIBMIsBackupPolicyPlanImport(t *testing.T) {
 	var conf vpcv1.BackupPolicyPlan
@@ -218,6 +297,21 @@ func testAccCheckIBMIsBackupPolicyPlanConfigClonesBasic(backupPolicyName, vpcnam
 			}
 		}
 	`, backupPolicyPlanName, cronSpec, acc.ISZoneName, acc.ISZoneName2)
+}
+func testAccCheckIBMIsBackupPolicyPlanConfigClonesUpdate(backupPolicyName, vpcname, subnetname, sshname, volName, name, cronSpec, backupPolicyPlanName string, numberOfClones, maxSnapshots int) string {
+
+	return testAccCheckIBMIsBackupPolicyConfigBasic(backupPolicyName, vpcname, subnetname, sshname, volName, name) + fmt.Sprintf(`
+		resource "ibm_is_backup_policy_plan" "is_backup_policy_plan" {
+			count  = 2
+			backup_policy_id = ibm_is_backup_policy.is_backup_policy.id
+			name = "%s-${count.index+1}"
+			cron_spec = "%s"
+			clone_policy {
+				zones 			= %d == 2 ?  ["%s", "%s"] :  ["%s", "%s", "%s"] 
+				max_snapshots 	= %d
+			}
+		}
+	`, backupPolicyPlanName, cronSpec, numberOfClones, acc.ISZoneName, acc.ISZoneName2, acc.ISZoneName, acc.ISZoneName2, acc.ISZoneName3, maxSnapshots)
 }
 
 func testAccCheckIBMIsBackupPolicyPlanConfigImport(backupPolicyName, vpcname, subnetname, sshname, volName, name, cronSpec, bakupPolicyPlanName string) string {


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/IBM-Cloud/terraform-provider-ibm/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
=== RUN   TestAccIBMIsBackupPolicyPlanClonesUpdate
no message sent
no message sent
no message sent
no message sent
--- PASS: TestAccIBMIsBackupPolicyPlanClonesUpdate (260.31s)
PASS
ok      github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/vpc     261.924s
```
