### PR TITLE
call WorkerPoolUpdate at the end of create

### DIFF
--- a/ibm/service/kubernetes/resource_ibm_container_worker_pool.go
+++ b/ibm/service/kubernetes/resource_ibm_container_worker_pool.go
@@ -275,7 +275,7 @@ func resourceIBMContainerWorkerPoolCreate(d *schema.ResourceData, meta interface
 
 	d.SetId(fmt.Sprintf("%s/%s", clusterNameorID, res.ID))
 
-	return resourceIBMContainerWorkerPoolRead(d, meta)
+	return resourceIBMContainerWorkerPoolUpdate(d, meta)
 }
 
 func resourceIBMContainerWorkerPoolRead(d *schema.ResourceData, meta interface{}) error {

--- a/ibm/service/kubernetes/resource_ibm_container_worker_pool.go
+++ b/ibm/service/kubernetes/resource_ibm_container_worker_pool.go
@@ -351,7 +351,7 @@ func resourceIBMContainerWorkerPoolUpdate(d *schema.ResourceData, meta interface
 		return err
 	}
 
-	if d.HasChange("size_per_zone") {
+	if d.HasChange("size_per_zone") && !d.IsNewResource() {
 		err = workerPoolsAPI.ResizeWorkerPool(clusterNameorID, workerPoolNameorID, d.Get("size_per_zone").(int), targetEnv)
 		if err != nil {
 			return err
@@ -362,7 +362,7 @@ func resourceIBMContainerWorkerPoolUpdate(d *schema.ResourceData, meta interface
 			return fmt.Errorf("[ERROR] Error waiting for workers of worker pool (%s) of cluster (%s) to become ready: %s", workerPoolNameorID, clusterNameorID, err)
 		}
 	}
-	if d.HasChange("labels") {
+	if d.HasChange("labels") && !d.IsNewResource() {
 		labels := make(map[string]string)
 		if l, ok := d.GetOk("labels"); ok {
 			for k, v := range l.(map[string]interface{}) {


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/IBM-Cloud/terraform-provider-ibm/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
% make testacc TEST=./ibm/service/kubernetes TESTARGS='-run=TestAccIBMContainerWorkerPoolBasic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./ibm/service/kubernetes -v -run=TestAccIBMContainerWorkerPoolBasic -timeout 700m
...
=== RUN   TestAccIBMContainerWorkerPoolBasic
--- PASS: TestAccIBMContainerWorkerPoolBasic (1462.79s)
PASS
ok      github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/kubernetes      1464.365s
...
```
