### PR TITLE
Fix to allow memory / processor updates to server instances in either shutdown or active state

### DIFF
--- a/ibm/service/power/resource_ibm_pi_instance.go
+++ b/ibm/service/power/resource_ibm_pi_instance.go
@@ -613,15 +613,16 @@ func resourceIBMPIInstanceUpdate(ctx context.Context, d *schema.ResourceData, me
 
 		//if d.GetOkExists("reboot_for_resource_change")
 
-		if mem > maxMemLpar || procs > maxCPULpar {
+		instanceState := d.Get("status")
+		log.Printf("the instance state is %s", instanceState)
 
+		if (mem > maxMemLpar || procs > maxCPULpar) && instanceState != "SHUTOFF" {
 			err = performChangeAndReboot(ctx, client, instanceID, cloudInstanceID, mem, procs)
 			if err != nil {
 				return diag.FromErr(err)
 			}
 
 		} else {
-
 			body := &models.PVMInstanceUpdate{
 				Memory:     mem,
 				Processors: procs,
@@ -641,9 +642,16 @@ func resourceIBMPIInstanceUpdate(ctx context.Context, d *schema.ResourceData, me
 			if err != nil {
 				return diag.Errorf("failed to update the lpar with the change %v", err)
 			}
-			_, err = isWaitforPIInstanceUpdate(ctx, client, instanceID)
-			if err != nil {
-				return diag.FromErr(err)
+			if instanceState == "SHUTOFF" {
+				_, err = isWaitforPIInstanceUpdate(ctx, client, instanceID)
+				if err != nil {
+					return diag.FromErr(err)
+				}
+			} else {
+				_, err = isWaitForPIInstanceAvailable(ctx, client, instanceID, "OK")
+				if err != nil {
+					return diag.FromErr(err)
+				}
 			}
 		}
 	}


### PR DESCRIPTION


<!--- See what makes a good Pull Request at : https://github.com/IBM-Cloud/terraform-provider-ibm/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
=== RUN   TestAccIBMPIInstanceBasic
--- PASS: TestAccIBMPIInstanceBasic (407.27s)
PASS
```
