### PR TITLE
Check for the existence of satellite endpoint bandwidth attributes

### DIFF
--- a/ibm/service/satellite/resource_ibm_satellite_endpoint.go
+++ b/ibm/service/satellite/resource_ibm_satellite_endpoint.go
@@ -815,8 +815,12 @@ func resourceIbmSatelliteEndpointEndpointPerformanceConnectorsItemToMap(endpoint
 
 	endpointPerformanceConnectorsItemMap["connector"] = endpointPerformanceConnectorsItem.Connector
 	endpointPerformanceConnectorsItemMap["connections"] = flex.IntValue(endpointPerformanceConnectorsItem.Connections)
-	endpointPerformanceConnectorsItemMap["rxBW"] = flex.IntValue(endpointPerformanceConnectorsItem.RxBW)
-	endpointPerformanceConnectorsItemMap["txBW"] = flex.IntValue(endpointPerformanceConnectorsItem.TxBW)
+	if endpointPerformanceConnectorsItem.RxBW != nil {
+		endpointPerformanceConnectorsItemMap["rxBW"] = flex.IntValue(endpointPerformanceConnectorsItem.RxBW)
+	}
+	if endpointPerformanceConnectorsItem.TxBW != nil {
+		endpointPerformanceConnectorsItemMap["txBW"] = flex.IntValue(endpointPerformanceConnectorsItem.TxBW)
+	}
 
 	return endpointPerformanceConnectorsItemMap
 }


### PR DESCRIPTION
Not all API responses include these fields so they should be conditionally added to the endpoint connectors map.

Closes: #4057

<!--- See what makes a good Pull Request at : https://github.com/IBM-Cloud/terraform-provider-ibm/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```
