### PR TITLE
No need to take instance action if already in state

### DIFF
--- a/ibm/service/power/resource_ibm_pi_instance_action.go
+++ b/ibm/service/power/resource_ibm_pi_instance_action.go
@@ -123,7 +123,10 @@ func resourceIBMPIInstanceActionRead(ctx context.Context, d *schema.ResourceData
 func resourceIBMPIInstanceActionUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 
 	if d.HasChange(Arg_PVMInstanceActionType) {
-		takeInstanceAction(ctx, d, meta, d.Timeout(schema.TimeoutUpdate))
+		adiag := takeInstanceAction(ctx, d, meta, d.Timeout(schema.TimeoutUpdate))
+		if adiag != nil {
+			return adiag
+		}
 	}
 
 	return resourceIBMPIInstanceActionRead(ctx, d, meta)
@@ -146,18 +149,6 @@ func takeInstanceAction(ctx context.Context, d *schema.ResourceData, meta interf
 	action := d.Get(Arg_PVMInstanceActionType).(string)
 	targetHealthStatus := d.Get(Arg_PVMInstanceHealthStatus).(string)
 
-	body := &models.PVMInstanceAction{Action: &action}
-	log.Printf("Calling the IBM PI Action %s on the instance %s", action, id)
-	client := st.NewIBMPIInstanceClient(ctx, sess, cloudInstanceID)
-
-	err = client.Action(id, body)
-	if err != nil {
-		log.Printf("[ERROR] failed to perform the action on the instance %v", err)
-		return diag.FromErr(err)
-	}
-
-	log.Printf("Executed the action on the instance")
-
 	var targetStatus string
 	if action == "stop" || action == "immediate-shutdown" {
 		targetStatus = "SHUTOFF"
@@ -168,6 +159,33 @@ func takeInstanceAction(ctx context.Context, d *schema.ResourceData, meta interf
 		// action is "start" or "soft-reboot" or "hard-reboot"
 		targetStatus = "ACTIVE"
 	}
+
+	client := st.NewIBMPIInstanceClient(ctx, sess, cloudInstanceID)
+
+	// special case for action "start", "stop", "immediate-shutdown"
+	// skip calling action if instance is already in desired state
+	if action == "start" || action == "stop" || action == "immediate-shutdown" {
+		pvm, err := client.Get(id)
+		if err != nil {
+			return diag.FromErr(err)
+		}
+
+		if *pvm.Status == targetStatus && pvm.Health != nil && (pvm.Health.Status == targetHealthStatus || pvm.Health.Status == PVMInstanceHealthOk) {
+			log.Printf("[DEBUG] skipping as action %s not needed on the instance %s", action, id)
+			return nil
+		}
+	}
+
+	body := &models.PVMInstanceAction{Action: &action}
+	log.Printf("Calling the IBM PI Action %s on the instance %s", action, id)
+
+	err = client.Action(id, body)
+	if err != nil {
+		log.Printf("[ERROR] failed to perform the action on the instance %v", err)
+		return diag.FromErr(err)
+	}
+
+	log.Printf("Executed the action on the instance")
 
 	log.Printf("Calling the check for %s opertion to check for status %s", action, targetStatus)
 	_, err = isWaitForPIInstanceActionStatus(ctx, client, id, timeout, targetStatus, targetHealthStatus)

--- a/ibm/service/power/resource_ibm_pi_instance_action_test.go
+++ b/ibm/service/power/resource_ibm_pi_instance_action_test.go
@@ -25,6 +25,22 @@ func TestAccIBMPIInstanceAction(t *testing.T) {
 				),
 			},
 			{
+				// Try to stop already stopped instance
+				Config: testAccCheckIBMPIInstanceActionConfig("stop"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(
+						"ibm_pi_instance_action.example", "status", "SHUTOFF"),
+				),
+			},
+			{
+				Config: testAccCheckIBMPIInstanceActionConfig("start"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(
+						"ibm_pi_instance_action.example", "status", "ACTIVE"),
+				),
+			},
+			{
+				// Try to start already started instance
 				Config: testAccCheckIBMPIInstanceActionConfig("start"),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/IBM-Cloud/terraform-provider-ibm/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #4400

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
=== RUN   TestAccIBMPIInstanceAction
--- PASS: TestAccIBMPIInstanceAction (278.82s)
PASS
=== RUN   TestAccIBMPIInstanceActionHardReboot
--- PASS: TestAccIBMPIInstanceActionHardReboot (109.64s)
PASS

...
```
