### PR TITLE
refactor how we set and update the taints on worker pools

### DIFF
--- a/ibm/service/kubernetes/resource_ibm_container_vpc_cluster.go
+++ b/ibm/service/kubernetes/resource_ibm_container_vpc_cluster.go
@@ -833,20 +833,14 @@ func resourceIBMContainerVpcClusterUpdate(d *schema.ResourceData, meta interface
 				"[ERROR] Error updating the labels: %s", err)
 		}
 	}
-	if d.HasChange("taints") {
-		taintParam := expandWorkerPoolTaints(d, meta, clusterID, "default")
 
-		targetEnv, err := getVpcClusterTargetHeader(d, meta)
-		if err != nil {
-			return err
+	if d.HasChange("taints") {
+		var taints []interface{}
+		if taintRes, ok := d.GetOk("taints"); ok {
+			taints = taintRes.(*schema.Set).List()
 		}
-		ClusterClient, err := meta.(conns.ClientSession).VpcContainerAPI()
-		if err != nil {
+		if err := updateWorkerpoolTaints(d, meta, clusterID, "default", taints); err != nil {
 			return err
-		}
-		err = ClusterClient.WorkerPools().UpdateWorkerPoolTaints(taintParam, targetEnv)
-		if err != nil {
-			return fmt.Errorf("[ERROR] Error updating the taints: %s", err)
 		}
 	}
 
@@ -864,6 +858,7 @@ func resourceIBMContainerVpcClusterUpdate(d *schema.ResourceData, meta interface
 				"[ERROR] Error updating the worker_count %d: %s", count, err)
 		}
 	}
+
 	if d.HasChange("zones") && !d.IsNewResource() {
 		oldList, newList := d.GetChange("zones")
 		if oldList == nil {

--- a/ibm/service/kubernetes/resource_ibm_container_vpc_cluster_test.go
+++ b/ibm/service/kubernetes/resource_ibm_container_vpc_cluster_test.go
@@ -410,6 +410,8 @@ func TestAccIBMContainerVpcClusterEnvvar(t *testing.T) {
 			"ibm_container_vpc_cluster.cluster", "name", name),
 		resource.TestCheckResourceAttr(
 			"ibm_container_vpc_cluster.cluster", "worker_count", "1"),
+		resource.TestCheckResourceAttr(
+			"ibm_container_vpc_cluster.cluster", "taints.#", "1"),
 	}
 	if acc.WorkerPoolSecondaryStorage != "" {
 		testChecks = append(testChecks, resource.TestCheckResourceAttr(
@@ -495,6 +497,11 @@ func testAccCheckIBMContainerVpcClusterEnvvar(name string) string {
 		crk = "%[6]s"
 		kms_account_id = "%[7]s"
 		secondary_storage = "%[8]s"
+		taints {
+			key    = "key1"
+			value  = "value1"
+			effect = "NoSchedule"
+		  }
 	}
 	`, name, acc.IksClusterVpcID, acc.IksClusterResourceGroupID, acc.IksClusterSubnetID, acc.KmsInstanceID, acc.CrkID, acc.KmsAccountID, acc.WorkerPoolSecondaryStorage)
 	fmt.Println(config)

--- a/ibm/service/kubernetes/resource_ibm_container_vpc_worker_pool_test.go
+++ b/ibm/service/kubernetes/resource_ibm_container_vpc_worker_pool_test.go
@@ -266,6 +266,13 @@ func TestAccIBMContainerVpcClusterWorkerPoolEnvvar(t *testing.T) {
 				Check:  resource.ComposeTestCheckFunc(testChecks...),
 			},
 			{
+				Config: testAccCheckIBMVpcContainerWorkerPoolEnvvarUpdate(name),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(
+						"ibm_container_vpc_worker_pool.test_pool", "taints.#", "0"),
+				),
+			},
+			{
 				ResourceName:      "ibm_container_vpc_worker_pool.test_pool",
 				ImportState:       true,
 				ImportStateVerify: true,
@@ -346,6 +353,25 @@ func testAccCheckIBMVpcContainerWorkerPoolEnvvar(name string) string {
 		value  = "value1"
 		effect = "NoSchedule"
 	  }
+	}
+		`, name, acc.IksClusterVpcID, acc.IksClusterSubnetID, acc.KmsInstanceID, acc.CrkID, acc.WorkerPoolSecondaryStorage)
+}
+
+func testAccCheckIBMVpcContainerWorkerPoolEnvvarUpdate(name string) string {
+	return fmt.Sprintf(testAccCheckIBMContainerVpcClusterEnvvar(name)+`
+	resource "ibm_container_vpc_worker_pool" "test_pool" {
+	  cluster           = ibm_container_vpc_cluster.cluster.id
+	  worker_pool_name  = "%[1]s"
+	  flavor            = "bx2.4x16"
+	  vpc_id            = "%[2]s"
+	  worker_count      = 1
+	  zones {
+		subnet_id = "%[3]s"
+		name      = "us-south-1"
+	  }
+	  kms_instance_id = "%[4]s"
+	  crk = "%[5]s"
+	  secondary_storage = "%[6]s"
 	}
 		`, name, acc.IksClusterVpcID, acc.IksClusterSubnetID, acc.KmsInstanceID, acc.CrkID, acc.WorkerPoolSecondaryStorage)
 }

--- a/ibm/service/kubernetes/resource_ibm_container_vpc_worker_pool_test.go
+++ b/ibm/service/kubernetes/resource_ibm_container_vpc_worker_pool_test.go
@@ -339,6 +339,11 @@ func testAccCheckIBMVpcContainerWorkerPoolEnvvar(name string) string {
 	  kms_instance_id = "%[4]s"
 	  crk = "%[5]s"
 	  secondary_storage = "%[6]s"
+	  taints {
+		key    = "key1"
+		value  = "value1"
+		effect = "NoSchedule"
+	  }
 	}
 		`, name, acc.IksClusterVpcID, acc.IksClusterSubnetID, acc.KmsInstanceID, acc.CrkID, acc.WorkerPoolSecondaryStorage)
 }

--- a/ibm/service/kubernetes/resource_ibm_container_vpc_worker_pool_test.go
+++ b/ibm/service/kubernetes/resource_ibm_container_vpc_worker_pool_test.go
@@ -240,6 +240,8 @@ func TestAccIBMContainerVpcClusterWorkerPoolEnvvar(t *testing.T) {
 			"ibm_container_vpc_worker_pool.test_pool", "flavor", "bx2.4x16"),
 		resource.TestCheckResourceAttr(
 			"ibm_container_vpc_worker_pool.test_pool", "zones.#", "1"),
+		resource.TestCheckResourceAttr(
+			"ibm_container_vpc_worker_pool.test_pool", "taints.#", "1"),
 	}
 	if acc.CrkID != "" {
 		testChecks = append(testChecks,

--- a/ibm/service/kubernetes/resource_ibm_container_worker_pool_test.go
+++ b/ibm/service/kubernetes/resource_ibm_container_worker_pool_test.go
@@ -136,6 +136,11 @@ resource "ibm_container_cluster" "testacc_cluster" {
   private_vlan_id = "%s"
   kube_version    = "%s"
   wait_till         = "OneWorkerNodeReady"
+  taints {
+	key    = "key1"
+	value  = "value1"
+	effect = "NoSchedule"
+  }
 }
 
 resource "ibm_container_worker_pool" "test_pool" {
@@ -148,6 +153,11 @@ resource "ibm_container_worker_pool" "test_pool" {
   labels = {
     "test"  = "test-pool"
     "test1" = "test-pool1"
+  }
+  taints {
+	key    = "key1"
+	value  = "value1"
+	effect = "NoSchedule"
   }
 }`, clusterName, acc.Datacenter, acc.MachineType, acc.PublicVlanID, acc.PrivateVlanID, acc.KubeVersion, workerPoolName, acc.MachineType)
 }


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/IBM-Cloud/terraform-provider-ibm/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
% make testacc TEST=./ibm/service/kubernetes TESTARGS='-run=TestAccIBMContainerVpcClusterEnvvar'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./ibm/service/kubernetes -v -run=TestAccIBMContainerVpcClusterEnvvar -timeout 700m
...
=== RUN   TestAccIBMContainerVpcClusterEnvvar

        resource "ibm_container_vpc_cluster" "cluster" {
                name              = "tf-vpc-cluster-69"
                vpc_id            = "<vpcid>"
                flavor            = "bx2.4x16"
                worker_count      = 1
                resource_group_id = "<rgid>"
                zones {
                        subnet_id = "<subnetid>"
                        name      = "us-south-1"
                }
                wait_till = "normal"
                kms_instance_id = ""
                crk = ""
                kms_account_id = ""
                secondary_storage = "900gb.5iops-tier"
                taints {
                        key    = "key1"
                        value  = "value1"
                        effect = "NoSchedule"
                  }
        }

--- PASS: TestAccIBMContainerVpcClusterEnvvar (1454.66s)
PASS
ok      github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/kubernetes      1456.638s


% make testacc TEST=./ibm/service/kubernetes TESTARGS='-run=TestAccIBMContainerVpcClusterWorkerPoolEnvvar'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./ibm/service/kubernetes -v -run=TestAccIBMContainerVpcClusterWorkerPoolEnvvar -timeout 700m
...
=== RUN   TestAccIBMContainerVpcClusterWorkerPoolEnvvar

        resource "ibm_container_vpc_cluster" "cluster" {
                name              = "tf-vpc-worker-28"
                vpc_id            = "<vpcid>"
                flavor            = "bx2.4x16"
                worker_count      = 1
                resource_group_id = "<rgid>"
                zones {
                        subnet_id = "<subnetid>"
                        name      = "us-south-1"
                }
                wait_till = "normal"
                kms_instance_id = ""
                crk = ""
                kms_account_id = ""
                secondary_storage = "900gb.5iops-tier"
                taints {
                        key    = "key1"
                        value  = "value1"
                        effect = "NoSchedule"
                  }
        }


--- PASS: TestAccIBMContainerVpcClusterWorkerPoolEnvvar (2343.59s)
PASS
ok      github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/kubernetes      2345.098s



% make testacc TEST=./ibm/service/kubernetes TESTARGS='-run=TestAccIBMContainerWorkerPoolBasic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./ibm/service/kubernetes -v -run=TestAccIBMContainerWorkerPoolBasic -timeout 700m
....
=== RUN   TestAccIBMContainerWorkerPoolBasic
--- PASS: TestAccIBMContainerWorkerPoolBasic (1418.02s)
PASS
ok      github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/kubernetes      1419.521s

```
