### PR TITLE
Remove Key Protect ID and Transition to v5 API

### DIFF
--- a/ibm/flex/structures.go
+++ b/ibm/flex/structures.go
@@ -1648,12 +1648,11 @@ func FlattenAllowlist(allowlist []clouddatabasesv5.AllowlistEntry) []map[string]
 	return entries
 }
 
-func ExpandPlatformOptions(platformOptions icdv4.PlatformOptions) []map[string]interface{} {
+func ExpandPlatformOptions(deployment clouddatabasesv5.Deployment) []map[string]interface{} {
 	pltOptions := make([]map[string]interface{}, 0, 1)
 	pltOption := make(map[string]interface{})
-	pltOption["key_protect_key_id"] = platformOptions.KeyProtectKey
-	pltOption["disk_encryption_key_crn"] = platformOptions.DiskENcryptionKeyCrn
-	pltOption["backup_encryption_key_crn"] = platformOptions.BackUpEncryptionKeyCrn
+	pltOption["disk_encryption_key_crn"] = deployment.PlatformOptions["disk_encryption_key_crn"]
+	pltOption["backup_encryption_key_crn"] = deployment.PlatformOptions["backup_encryption_key_crn"]
 	pltOptions = append(pltOptions, pltOption)
 	return pltOptions
 }

--- a/ibm/service/database/data_source_ibm_database.go
+++ b/ibm/service/database/data_source_ibm_database.go
@@ -18,7 +18,6 @@ import (
 
 	"github.com/IBM-Cloud/bluemix-go/api/icd/icdv4"
 	"github.com/IBM-Cloud/bluemix-go/api/resource/resourcev2/controllerv2"
-	"github.com/IBM-Cloud/bluemix-go/bmxerror"
 	"github.com/IBM-Cloud/bluemix-go/models"
 	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/conns"
 	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/flex"
@@ -113,12 +112,6 @@ func DataSourceIBMDatabaseInstance() *schema.Resource {
 				Computed:    true,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
-						"key_protect_key_id": {
-							Description: "Key protect key id",
-							Type:        schema.TypeString,
-							Computed:    true,
-							Deprecated:  "This field is deprecated and has been replaced by disk_encryption_key_crn",
-						},
 						"disk_encryption_key_crn": {
 							Description: "Disk encryption key crn",
 							Type:        schema.TypeString,
@@ -759,17 +752,25 @@ func dataSourceIBMDatabaseInstanceRead(d *schema.ResourceData, meta interface{})
 	}
 
 	icdId := flex.EscapeUrlParm(instance.ID)
-	cdb, err := icdClient.Cdbs().GetCdb(icdId)
+	getDeploymentInfoOptions := &clouddatabasesv5.GetDeploymentInfoOptions{
+		ID: core.StringPtr(instance.ID),
+	}
+	getDeploymentInfoResponse, response, err := cloudDatabasesClient.GetDeploymentInfo(getDeploymentInfoOptions)
 	if err != nil {
-		if apiErr, ok := err.(bmxerror.RequestFailure); ok && apiErr.StatusCode() == 404 {
+		if response.StatusCode == 404 {
 			return fmt.Errorf("[ERROR] The database instance was not found in the region set for the Provider, or the default of us-south. Specify the correct region in the provider definition, or create a provider alias for the correct region. %v", err)
 		}
-		return fmt.Errorf("[ERROR] Error getting database config for: %s with error %s\n", icdId, err)
+		return fmt.Errorf("[ERROR] Error getting database config while updating adminpassword for: %s with error %s", instance.ID, err)
 	}
-	d.Set("adminuser", cdb.AdminUser)
-	d.Set("version", cdb.Version)
-	if &cdb.PlatformOptions != nil {
-		d.Set("platform_options", flex.ExpandPlatformOptions(cdb.PlatformOptions))
+
+	deployment := getDeploymentInfoResponse.Deployment
+	adminUser := deployment.AdminUsernames["database"]
+
+	d.Set("adminuser", adminUser)
+	d.Set("version", deployment.Version)
+
+	if deployment.PlatformOptions != nil {
+		d.Set("platform_options", flex.ExpandPlatformOptions(*deployment))
 	}
 
 	groupList, err := icdClient.Groups().GetGroups(icdId)
@@ -819,7 +820,7 @@ func dataSourceIBMDatabaseInstanceRead(d *schema.ResourceData, meta interface{})
 	tfusers := d.Get("users").(*schema.Set)
 	users := flex.ExpandUsers(tfusers)
 	user := icdv4.User{
-		UserName: cdb.AdminUser,
+		UserName: adminUser,
 	}
 	users = append(users, user)
 	for _, user := range users {

--- a/website/docs/d/database.html.markdown
+++ b/website/docs/d/database.html.markdown
@@ -47,7 +47,6 @@ In addition to all argument references list, you can access the following attrib
 - `platform_options`-  (String) The CRN of key protect key.
    
    Nested scheme for `platform_options`:
-   - `key_protect_key_id`-  **Deprecated** - (String) The CRN of key protect key. - replaced by `disk_encryption_key_crn`
    - `disk_encryption_key_crn`-  (String) The CRN of disk encryption key.
    - `backup_encryption_key_crn`-  (String) The CRN of backup encryption key.
    


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/IBM-Cloud/terraform-provider-ibm/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->
We deprecated the `key_protect_key_id` in this PR: https://github.com/IBM-Cloud/terraform-provider-ibm/pull/3939
We will no long support the use of `key_protect_key_id` and we will remove it.

For more details please see the following blog post: https://www.ibm.com/cloud/blog/announcements/new-features-and-rearchitecturing-of-ibm-cloud-databasess-terraform-provider about deprecated attributes

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
--- PASS: TestAccIBMDatabaseDataSource_basic (640.51s)
PASS
ok  	github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/database	642.035s
```
