### PR TITLE
set instance_count in instance group read

### DIFF
--- a/ibm/service/vpc/resource_ibm_is_instance_group.go
+++ b/ibm/service/vpc/resource_ibm_is_instance_group.go
@@ -413,6 +413,7 @@ func resourceIBMISInstanceGroupRead(d *schema.ResourceData, meta interface{}) er
 	d.Set("name", *instanceGroup.Name)
 	d.Set("instance_template", *instanceGroup.InstanceTemplate.ID)
 	d.Set("instances", *instanceGroup.MembershipCount)
+	d.Set("instance_count", *instanceGroup.MembershipCount)
 	d.Set("resource_group", *instanceGroup.ResourceGroup.ID)
 	if instanceGroup.ApplicationPort != nil {
 		d.Set("application_port", *instanceGroup.ApplicationPort)

--- a/ibm/service/vpc/resource_ibm_is_instance_group_test.go
+++ b/ibm/service/vpc/resource_ibm_is_instance_group_test.go
@@ -161,7 +161,7 @@ func testAccCheckIBMISInstanceGrouplbConfig(vpcname, subnetname, zone, cidr, nam
 	
 	resource "ibm_is_instance_template" "instancetemplate1" {
 	   name    = "%s"
-	   image   = "r134-63363662-a4ee-4ba4-a6c4-92e6c78c6b58"
+	   image   = "%s"
 	   profile = "bx2-8x32"
 	
 	   primary_network_interface {
@@ -182,15 +182,13 @@ func testAccCheckIBMISInstanceGrouplbConfig(vpcname, subnetname, zone, cidr, nam
         load_balancer_pool = ibm_is_lb_pool.testacc_lb_pool.pool_id
         application_port = "2364"
 	}
-	`, vpcname, subnetname, zone, cidr, name, poolName, algorithm, protocol, delay, retries, timeout, healthType, sshKeyName, publicKey, templateName, zone, instanceGroupName)
+	`, vpcname, subnetname, zone, cidr, name, poolName, algorithm, protocol, delay, retries, timeout, healthType, sshKeyName, publicKey, templateName, acc.IsImage, zone, instanceGroupName)
 
 }
 
 func testAccCheckIBMISInstanceGroupConfig(vpcName, subnetName, sshKeyName, publicKey, templateName, instanceGroupName string) string {
 	return fmt.Sprintf(`
-	provider "ibm" {
-		generation = 2
-	}
+	
 	
 	resource "ibm_is_vpc" "vpc2" {
 	  name = "%s"


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/IBM-Cloud/terraform-provider-ibm/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccIBMISInstanceGroup_basic'
=== RUN   TestAccIBMISInstanceGroup_basic
--- PASS: TestAccIBMISInstanceGroup_basic (169.23s)
=== RUN   TestAccIBMISInstanceGroup_basic_loadbalancer
--- PASS: TestAccIBMISInstanceGroup_basic_loadbalancer (644.16s)
PASS
ok      github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/vpc     814.609s
...
```
