### PR TITLE
Secrets Manager - documentation corrections + check for wrong resource ID format on import

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,11 +3,8 @@
     "files": "go.mod|go.sum|.*.map|^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2023-03-17T12:44:55Z",
+  "generated_at": "2023-03-22T15:17:29Z",
   "plugins_used": [
-    {
-      "name": "AWSKeyDetector"
-    },
     {
       "name": "ArtifactoryDetector"
     },
@@ -20,12 +17,6 @@
     },
     {
       "name": "BasicAuthDetector"
-    },
-    {
-      "name": "BoxDetector"
-    },
-    {
-      "name": "CloudantDetector"
     },
     {
       "ghe_instance": "github.ibm.com",
@@ -52,9 +43,6 @@
       "name": "KeywordDetector"
     },
     {
-      "name": "MailchimpDetector"
-    },
-    {
       "name": "NpmDetector"
     },
     {
@@ -68,12 +56,6 @@
     },
     {
       "name": "SquareOAuthDetector"
-    },
-    {
-      "name": "StripeDetector"
-    },
-    {
-      "name": "TwilioKeyDetector"
     }
   ],
   "results": {
@@ -650,7 +632,7 @@
         "hashed_secret": "f4aa5360c26e2a4e2d45e095bd597e84c497fbcd",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 131,
+        "line_number": 130,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -658,7 +640,7 @@
         "hashed_secret": "912accc17209bb36cb22d76d430ef9e9ec99dd4c",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 164,
+        "line_number": 163,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -666,7 +648,7 @@
         "hashed_secret": "514edd121688f936809a62aecd24419c7eaa772b",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 251,
+        "line_number": 250,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -674,7 +656,7 @@
         "hashed_secret": "fa33d07da58b52eee9f13b88e9cda8b98f1c19b6",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 262,
+        "line_number": 261,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -682,7 +664,7 @@
         "hashed_secret": "5926151b9a84e25fbc262e88ef6c1d58f0c95548",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 274,
+        "line_number": 273,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -722,7 +704,7 @@
         "hashed_secret": "813274ccae5b6b509379ab56982d862f7b5969b6",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 907,
+        "line_number": 912,
         "type": "Base64 High Entropy String",
         "verified_result": null
       }
@@ -792,7 +774,7 @@
         "hashed_secret": "da8cae6284528565678de15e03d461e23fe22538",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1534,
+        "line_number": 1587,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -1826,7 +1808,7 @@
         "hashed_secret": "884a58e4c2c5d195d3876787bdc63af6c5af2924",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1537,
+        "line_number": 1560,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -1836,7 +1818,7 @@
         "hashed_secret": "b02fa7fd7ca08b5dc86c2548e40f8a21171ef977",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 405,
+        "line_number": 513,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -3050,7 +3032,7 @@
         "hashed_secret": "b732fb611fd46a38e8667f9972e0cde777fbe37f",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 150,
+        "line_number": 153,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -3078,7 +3060,7 @@
         "hashed_secret": "108b310facc1a193833fc2971fd83081f775ea0c",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 390,
+        "line_number": 393,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -3086,7 +3068,7 @@
         "hashed_secret": "b732fb611fd46a38e8667f9972e0cde777fbe37f",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 393,
+        "line_number": 396,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -3114,7 +3096,7 @@
         "hashed_secret": "b732fb611fd46a38e8667f9972e0cde777fbe37f",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 428,
+        "line_number": 431,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -3122,7 +3104,7 @@
         "hashed_secret": "9beb31de125498074813c6f31c0e4df3e54a5489",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 575,
+        "line_number": 578,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -3140,7 +3122,7 @@
         "hashed_secret": "b732fb611fd46a38e8667f9972e0cde777fbe37f",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 534,
+        "line_number": 537,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -3158,7 +3140,7 @@
         "hashed_secret": "9beb31de125498074813c6f31c0e4df3e54a5489",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 752,
+        "line_number": 755,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -3176,7 +3158,7 @@
         "hashed_secret": "9beb31de125498074813c6f31c0e4df3e54a5489",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 757,
+        "line_number": 760,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -3194,7 +3176,7 @@
         "hashed_secret": "b732fb611fd46a38e8667f9972e0cde777fbe37f",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 551,
+        "line_number": 554,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -3212,7 +3194,7 @@
         "hashed_secret": "b732fb611fd46a38e8667f9972e0cde777fbe37f",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 141,
+        "line_number": 144,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -3240,7 +3222,7 @@
         "hashed_secret": "b732fb611fd46a38e8667f9972e0cde777fbe37f",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 188,
+        "line_number": 191,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -3248,7 +3230,7 @@
         "hashed_secret": "3475f51e796d0881fb3e42f690c66ab3ecb217a1",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 235,
+        "line_number": 238,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -3266,7 +3248,7 @@
         "hashed_secret": "b732fb611fd46a38e8667f9972e0cde777fbe37f",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 191,
+        "line_number": 194,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -3274,7 +3256,7 @@
         "hashed_secret": "6b52786f527ade6e28a0b59df6b1367713f8851e",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 238,
+        "line_number": 241,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -3312,7 +3294,7 @@
         "hashed_secret": "b732fb611fd46a38e8667f9972e0cde777fbe37f",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 351,
+        "line_number": 354,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -4764,7 +4746,7 @@
       }
     ]
   },
-  "version": "0.13.1+ibm.46.dss",
+  "version": "0.13.1+ibm.56.dss",
   "word_list": {
     "file": null,
     "hash": null

--- a/ibm/service/secretsmanager/data_source_ibm_sm_public_certificate.go
+++ b/ibm/service/secretsmanager/data_source_ibm_sm_public_certificate.go
@@ -270,12 +270,12 @@ func DataSourceIbmSmPublicCertificate() *schema.Resource {
 			"ca": &schema.Schema{
 				Type:        schema.TypeString,
 				Computed:    true,
-				Description: "The name that is assigned to the certificate authority configuration.",
+				Description: "The name of the certificate authority configuration.",
 			},
 			"dns": &schema.Schema{
 				Type:        schema.TypeString,
 				Computed:    true,
-				Description: "The name that is assigned to the DNS provider configuration.",
+				Description: "The name of the DNS provider configuration.",
 			},
 			"certificate": &schema.Schema{
 				Type:        schema.TypeString,

--- a/ibm/service/secretsmanager/data_source_ibm_sm_public_certificate_metadata.go
+++ b/ibm/service/secretsmanager/data_source_ibm_sm_public_certificate_metadata.go
@@ -269,12 +269,12 @@ func DataSourceIbmSmPublicCertificateMetadata() *schema.Resource {
 			"ca": &schema.Schema{
 				Type:        schema.TypeString,
 				Computed:    true,
-				Description: "The name that is assigned to the certificate authority configuration.",
+				Description: "The name of the certificate authority configuration.",
 			},
 			"dns": &schema.Schema{
 				Type:        schema.TypeString,
 				Computed:    true,
-				Description: "The name that is assigned to the DNS provider configuration.",
+				Description: "The name of the DNS provider configuration.",
 			},
 		},
 	}

--- a/ibm/service/secretsmanager/resource_ibm_sm_arbitrary_secret.go
+++ b/ibm/service/secretsmanager/resource_ibm_sm_arbitrary_secret.go
@@ -219,6 +219,9 @@ func resourceIbmSmArbitrarySecretRead(context context.Context, d *schema.Resourc
 	}
 
 	id := strings.Split(d.Id(), "/")
+	if len(id) != 3 {
+		return diag.Errorf("Wrong format of resource ID. To import a secret use the format `<region>/<instance_id>/<secret_id>`")
+	}
 	region := id[0]
 	instanceId := id[1]
 	secretId := id[2]

--- a/ibm/service/secretsmanager/resource_ibm_sm_en_registration.go
+++ b/ibm/service/secretsmanager/resource_ibm_sm_en_registration.go
@@ -120,6 +120,9 @@ func resourceIbmSmEnRegistrationRead(context context.Context, d *schema.Resource
 	}
 
 	id := strings.Split(d.Id(), "/")
+	if len(id) != 2 {
+		return diag.Errorf("Wrong format of resource ID. To import event notification registration use the format `<region>/<instance_id>`")
+	}
 	region := id[0]
 	instanceId := id[1]
 	secretsManagerClient = getClientWithInstanceEndpoint(secretsManagerClient, instanceId, region, getEndpointType(secretsManagerClient, d))

--- a/ibm/service/secretsmanager/resource_ibm_sm_iam_credentials_configuration.go
+++ b/ibm/service/secretsmanager/resource_ibm_sm_iam_credentials_configuration.go
@@ -105,6 +105,9 @@ func resourceIbmSmIamCredentialsConfigurationRead(context context.Context, d *sc
 	}
 
 	id := strings.Split(d.Id(), "/")
+	if len(id) != 3 {
+		return diag.Errorf("Wrong format of resource ID. To import IAM credentials configuration use the format `<region>/<instance_id>/<name>`")
+	}
 	region := id[0]
 	instanceId := id[1]
 	configName := id[2]

--- a/ibm/service/secretsmanager/resource_ibm_sm_iam_credentials_secret.go
+++ b/ibm/service/secretsmanager/resource_ibm_sm_iam_credentials_secret.go
@@ -290,6 +290,9 @@ func resourceIbmSmIamCredentialsSecretRead(context context.Context, d *schema.Re
 	}
 
 	id := strings.Split(d.Id(), "/")
+	if len(id) != 3 {
+		return diag.Errorf("Wrong format of resource ID. To import a secret use the format `<region>/<instance_id>/<secret_id>`")
+	}
 	region := id[0]
 	instanceId := id[1]
 	secretId := id[2]

--- a/ibm/service/secretsmanager/resource_ibm_sm_imported_certificate.go
+++ b/ibm/service/secretsmanager/resource_ibm_sm_imported_certificate.go
@@ -306,6 +306,9 @@ func resourceIbmSmImportedCertificateRead(context context.Context, d *schema.Res
 	}
 
 	id := strings.Split(d.Id(), "/")
+	if len(id) != 3 {
+		return diag.Errorf("Wrong format of resource ID. To import a secret use the format `<region>/<instance_id>/<secret_id>`")
+	}
 	region := id[0]
 	instanceId := id[1]
 	secretId := id[2]

--- a/ibm/service/secretsmanager/resource_ibm_sm_kv_secret.go
+++ b/ibm/service/secretsmanager/resource_ibm_sm_kv_secret.go
@@ -212,6 +212,9 @@ func resourceIbmSmKvSecretRead(context context.Context, d *schema.ResourceData, 
 	}
 
 	id := strings.Split(d.Id(), "/")
+	if len(id) != 3 {
+		return diag.Errorf("Wrong format of resource ID. To import a secret use the format `<region>/<instance_id>/<secret_id>`")
+	}
 	region := id[0]
 	instanceId := id[1]
 	secretId := id[2]

--- a/ibm/service/secretsmanager/resource_ibm_sm_private_certificate.go
+++ b/ibm/service/secretsmanager/resource_ibm_sm_private_certificate.go
@@ -394,6 +394,9 @@ func resourceIbmSmPrivateCertificateRead(context context.Context, d *schema.Reso
 	}
 
 	id := strings.Split(d.Id(), "/")
+	if len(id) != 3 {
+		return diag.Errorf("Wrong format of resource ID. To import a secret use the format `<region>/<instance_id>/<secret_id>`")
+	}
 	region := id[0]
 	instanceId := id[1]
 	secretId := id[2]

--- a/ibm/service/secretsmanager/resource_ibm_sm_private_certificate_configuration_intermediate_ca.go
+++ b/ibm/service/secretsmanager/resource_ibm_sm_private_certificate_configuration_intermediate_ca.go
@@ -374,6 +374,9 @@ func resourceIbmSmPrivateCertificateConfigurationIntermediateCARead(context cont
 	}
 
 	id := strings.Split(d.Id(), "/")
+	if len(id) != 3 {
+		return diag.Errorf("Wrong format of resource ID. To import an intermediate CA use the format `<region>/<instance_id>/<name>`")
+	}
 	region := id[0]
 	instanceId := id[1]
 	configName := id[2]

--- a/ibm/service/secretsmanager/resource_ibm_sm_private_certificate_configuration_root_ca.go
+++ b/ibm/service/secretsmanager/resource_ibm_sm_private_certificate_configuration_root_ca.go
@@ -356,6 +356,9 @@ func resourceIbmSmPrivateCertificateConfigurationRootCARead(context context.Cont
 	}
 
 	id := strings.Split(d.Id(), "/")
+	if len(id) != 3 {
+		return diag.Errorf("Wrong format of resource ID. To import a root CA use the format `<region>/<instance_id>/<name>`")
+	}
 	region := id[0]
 	instanceId := id[1]
 	configName := id[2]

--- a/ibm/service/secretsmanager/resource_ibm_sm_private_certificate_configuration_template.go
+++ b/ibm/service/secretsmanager/resource_ibm_sm_private_certificate_configuration_template.go
@@ -358,6 +358,9 @@ func resourceIbmSmPrivateCertificateConfigurationTemplateRead(context context.Co
 	}
 
 	id := strings.Split(d.Id(), "/")
+	if len(id) != 3 {
+		return diag.Errorf("Wrong format of resource ID. To import a certificate template use the format `<region>/<instance_id>/<name>`")
+	}
 	region := id[0]
 	instanceId := id[1]
 	configName := id[2]

--- a/ibm/service/secretsmanager/resource_ibm_sm_public_certificate.go
+++ b/ibm/service/secretsmanager/resource_ibm_sm_public_certificate.go
@@ -84,13 +84,13 @@ func ResourceIbmSmPublicCertificate() *schema.Resource {
 				Type:        schema.TypeString,
 				ForceNew:    true,
 				Required:    true,
-				Description: "A human-readable unique name to assign to your configuration.To protect your privacy, do not use personal data, such as your name or location, as an name for your secret.",
+				Description: "The name of the certificate authority configuration.",
 			},
 			"dns": &schema.Schema{
 				Type:        schema.TypeString,
 				ForceNew:    true,
 				Required:    true,
-				Description: "A human-readable unique name to assign to your configuration.To protect your privacy, do not use personal data, such as your name or location, as an name for your secret.",
+				Description: "The name of the DNS provider configuration.",
 			},
 			"bundle_certs": &schema.Schema{
 				Type:        schema.TypeBool,

--- a/ibm/service/secretsmanager/resource_ibm_sm_public_certificate.go
+++ b/ibm/service/secretsmanager/resource_ibm_sm_public_certificate.go
@@ -406,6 +406,9 @@ func resourceIbmSmPublicCertificateRead(context context.Context, d *schema.Resou
 	}
 
 	id := strings.Split(d.Id(), "/")
+	if len(id) != 3 {
+		return diag.Errorf("Wrong format of resource ID. To import a secret use the format `<region>/<instance_id>/<secret_id>`")
+	}
 	region := id[0]
 	instanceId := id[1]
 	secretId := id[2]

--- a/ibm/service/secretsmanager/resource_ibm_sm_public_certificate_configuration_ca_lets_encrypt.go
+++ b/ibm/service/secretsmanager/resource_ibm_sm_public_certificate_configuration_ca_lets_encrypt.go
@@ -98,6 +98,9 @@ func resourceIbmSmPublicCertificateConfigurationCALetsEncryptRead(context contex
 	}
 
 	id := strings.Split(d.Id(), "/")
+	if len(id) != 3 {
+		return diag.Errorf("Wrong format of resource ID. To import a CA configuration use the format `<region>/<instance_id>/<name>`")
+	}
 	region := id[0]
 	instanceId := id[1]
 	configName := id[2]

--- a/ibm/service/secretsmanager/resource_ibm_sm_public_certificate_configuration_dns_cis.go
+++ b/ibm/service/secretsmanager/resource_ibm_sm_public_certificate_configuration_dns_cis.go
@@ -153,6 +153,9 @@ func resourceIbmSmConfigurationPublicCertificateDNSCisRead(context context.Conte
 	}
 
 	id := strings.Split(d.Id(), "/")
+	if len(id) != 3 {
+		return diag.Errorf("Wrong format of resource ID. To import a DNS configuration use the format `<region>/<instance_id>/<name>`")
+	}
 	region := id[0]
 	instanceId := id[1]
 	configName := id[2]

--- a/ibm/service/secretsmanager/resource_ibm_sm_public_certificate_configuration_dns_classic_infrastructure.go
+++ b/ibm/service/secretsmanager/resource_ibm_sm_public_certificate_configuration_dns_classic_infrastructure.go
@@ -151,6 +151,9 @@ func resourceIbmSmPublicCertificateConfigurationDNSClassicInfrastructureRead(con
 	}
 
 	id := strings.Split(d.Id(), "/")
+	if len(id) != 3 {
+		return diag.Errorf("Wrong format of resource ID. To import a DNS configuration use the format `<region>/<instance_id>/<name>`")
+	}
 	region := id[0]
 	instanceId := id[1]
 	configName := id[2]

--- a/ibm/service/secretsmanager/resource_ibm_sm_secret_group.go
+++ b/ibm/service/secretsmanager/resource_ibm_sm_secret_group.go
@@ -121,6 +121,9 @@ func resourceIbmSmSecretGroupRead(context context.Context, d *schema.ResourceDat
 	}
 
 	id := strings.Split(d.Id(), "/")
+	if len(id) != 3 {
+		return diag.Errorf("Wrong format of resource ID. To import a secret group use the format `<region>/<instance_id>/<secret_group_id>`")
+	}
 	region := id[0]
 	instanceId := id[1]
 	secretGroupId := id[2]

--- a/ibm/service/secretsmanager/resource_ibm_sm_username_password_secret.go
+++ b/ibm/service/secretsmanager/resource_ibm_sm_username_password_secret.go
@@ -255,6 +255,9 @@ func resourceIbmSmUsernamePasswordSecretRead(context context.Context, d *schema.
 	}
 
 	id := strings.Split(d.Id(), "/")
+	if len(id) != 3 {
+		return diag.Errorf("Wrong format of resource ID. To import a secret use the format `<region>/<instance_id>/<secret_id>`")
+	}
 	region := id[0]
 	instanceId := id[1]
 	secretId := id[2]

--- a/website/docs/d/sm_public_certificate.html.markdown
+++ b/website/docs/d/sm_public_certificate.html.markdown
@@ -41,7 +41,7 @@ In addition to all argument references listed, you can access the following attr
 
 * `bundle_certs` - (Boolean) Indicates whether the issued certificate is bundled with intermediate certificates.
 
-* `ca` - (String) The name that is assigned to the certificate authority configuration.
+* `ca` - (String) The name of the certificate authority configuration..
 
 * `certificate` - (String) The PEM-encoded contents of your certificate.
   * Constraints: The maximum length is `100000` characters. The minimum length is `50` characters. The value must match regular expression `/^(-{5}BEGIN.+?-{5}[\\s\\S]+-{5}END.+?-{5})$/`.
@@ -62,7 +62,7 @@ In addition to all argument references listed, you can access the following attr
 * `description` - (String) An extended description of your secret.To protect your privacy, do not use personal data, such as your name or location, as a description for your secret group.
   * Constraints: The maximum length is `1024` characters. The minimum length is `0` characters. The value must match regular expression `/(.*?)/`.
 
-* `dns` - (String) The name that is assigned to the DNS provider configuration.
+* `dns` - (String) The name of the DNS provider configuration.
 
 * `downloaded` - (Boolean) Indicates whether the secret data that is associated with a secret version was retrieved in a call to the service API.
 

--- a/website/docs/d/sm_public_certificate_metadata.html.markdown
+++ b/website/docs/d/sm_public_certificate_metadata.html.markdown
@@ -41,7 +41,7 @@ In addition to all argument references listed, you can access the following attr
 
 * `bundle_certs` - (Boolean) Indicates whether the issued certificate is bundled with intermediate certificates.
 
-* `ca` - (String) The name that is assigned to the certificate authority configuration.
+* `ca` - (String) The name of the certificate authority configuration.
 
 * `common_name` - (String) The Common Name (AKA CN) represents the server name protected by the SSL certificate.
   * Constraints: The maximum length is `64` characters. The minimum length is `4` characters. The value must match regular expression `/^(\\*\\.)?(([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\\-]*[a-zA-Z0-9])\\.)*([A-Za-z0-9]|[A-Za-z0-9][A-Za-z0-9\\-]*[A-Za-z0-9])\\.?$/`.
@@ -59,7 +59,7 @@ In addition to all argument references listed, you can access the following attr
 * `description` - (String) An extended description of your secret.To protect your privacy, do not use personal data, such as your name or location, as a description for your secret group.
   * Constraints: The maximum length is `1024` characters. The minimum length is `0` characters. The value must match regular expression `/(.*?)/`.
 
-* `dns` - (String) The name that is assigned to the DNS provider configuration.
+* `dns` - (String) The name of the DNS provider configuration.
 
 * `downloaded` - (Boolean) Indicates whether the secret data that is associated with a secret version was retrieved in a call to the service API.
 

--- a/website/docs/r/sm_arbitrary_secret.html.markdown
+++ b/website/docs/r/sm_arbitrary_secret.html.markdown
@@ -125,11 +125,11 @@ You can import the `ibm_sm_arbitrary_secret` resource by using `region`, `instan
 For more information, see [the documentation](https://cloud.ibm.com/docs/secrets-manager)
 
 # Syntax
-```
+```bash
 $ terraform import ibm_sm_arbitrary_secret.sm_arbitrary_secret <region>/<instance_id>/<secret_id>
 ```
 
 # Example
-```
+```bash
 $ terraform import ibm_sm_arbitrary_secret.sm_arbitrary_secret us-east/6ebc4224-e983-496a-8a54-f40a0bfa9175/b49ad24d-81d4-5ebc-b9b9-b0937d1c84d5
 ```

--- a/website/docs/r/sm_en_registration.html.markdown
+++ b/website/docs/r/sm_en_registration.html.markdown
@@ -103,11 +103,11 @@ the source name after the registration resource is created.
 For more information, see [the documentation](https://cloud.ibm.com/docs/secrets-manager).
 
 # Syntax
-```
+```bash
 $ terraform import ibm_sm_en_registration.sm_en_registration <region>/<instance_id>
 ```
 
 # Example
-```
+```bash
 $ terraform import ibm_sm_en_registration.sm_en_registration us-east/6ebc4224-e983-496a-8a54-f40a0bfa9175
 ```

--- a/website/docs/r/sm_en_registration.html.markdown
+++ b/website/docs/r/sm_en_registration.html.markdown
@@ -95,8 +95,12 @@ For more informaton, see [here](https://registry.terraform.io/providers/IBM-Clou
 
 ## Import
 
-You can import the `ibm_sm_en_registration` resource by using `region` and `instance_id`. A CRN that uniquely identifies an IBM Cloud resource.
-For more information, see [the documentation](https://cloud.ibm.com/docs/secrets-manager)
+You can import the `ibm_sm_en_registration` resource by using `region` and `instance_id`. Note that after the import, the value of the property `event_notifications_source_name`
+is `null` in the Terraform state file. Since this is a required property, you need to provide a value for it in
+the corresponding configuration block in your Terraform configuration file. If you don't know the actual name of the event notification source, 
+you can put any value. The value is ignored when Terraform updates the resource, because the Secrets Manager API does not modify
+the source name after the registration resource is created.
+For more information, see [the documentation](https://cloud.ibm.com/docs/secrets-manager).
 
 # Syntax
 ```

--- a/website/docs/r/sm_iam_credentials_configuration.html.markdown
+++ b/website/docs/r/sm_iam_credentials_configuration.html.markdown
@@ -103,11 +103,11 @@ You can import the `ibm_sm_iam_credentials_configuration` resource by using `reg
 For more information, see [the documentation](https://cloud.ibm.com/docs/secrets-manager)
 
 # Syntax
-```
+```bash
 $ terraform import ibm_sm_iam_credentials_configuration.sm_iam_credentials_configuration <region>/<instance_id>/<name>
 ```
 
 # Example
-```
+```bash
 $ terraform import ibm_sm_iam_credentials_configuration.sm_iam_credentials_configuration us-east/6ebc4224-e983-496a-8a54-f40a0bfa9175/my-secret-engine-config
 ```

--- a/website/docs/r/sm_iam_credentials_secret.html.markdown
+++ b/website/docs/r/sm_iam_credentials_secret.html.markdown
@@ -149,11 +149,11 @@ You can import the `ibm_sm_iam_credentials_secret` resource by using `region`, `
 For more information, see [the documentation](https://cloud.ibm.com/docs/secrets-manager)
 
 # Syntax
-```
+```bash
 $ terraform import ibm_sm_iam_credentials_secret.sm_iam_credentials_secret <region>/<instance_id>/<secret_id>
 ```
 
 # Example
-```
+```bash
 $ terraform import ibm_sm_iam_credentials_secret.sm_iam_credentials_secret us-east/6ebc4224-e983-496a-8a54-f40a0bfa9175/b49ad24d-81d4-5ebc-b9b9-b0937d1c84d5
 ```

--- a/website/docs/r/sm_imported_certificate.html.markdown
+++ b/website/docs/r/sm_imported_certificate.html.markdown
@@ -146,11 +146,11 @@ You can import the `ibm_sm_imported_certificate` resource by using `region`, `in
 For more information, see [the documentation](https://cloud.ibm.com/docs/secrets-manager)
 
 # Syntax
-```
+```bash
 $ terraform import ibm_sm_imported_certificate.sm_imported_certificate <region>/<instance_id>/<secret_id>
 ```
 
 # Example
-```
+```bash
 $ terraform import ibm_sm_imported_certificate.sm_imported_certificate us-east/6ebc4224-e983-496a-8a54-f40a0bfa9175/b49ad24d-81d4-5ebc-b9b9-b0937d1c84d5
 ```

--- a/website/docs/r/sm_kv_secret.html.markdown
+++ b/website/docs/r/sm_kv_secret.html.markdown
@@ -124,11 +124,11 @@ You can import the `ibm_sm_kv_secret` resource by using `region`, `instance_id`,
 For more information, see [the documentation](https://cloud.ibm.com/docs/secrets-manager)
 
 # Syntax
-```
+```bash
 $ terraform import ibm_sm_kv_secret.sm_kv_secret <region>/<instance_id>/<secret_id>
 ```
 
 # Example
-```
+```bash
 $ terraform import ibm_sm_kv_secret.sm_kv_secret us-east/6ebc4224-e983-496a-8a54-f40a0bfa9175/b49ad24d-81d4-5ebc-b9b9-b0937d1c84d5
 ```

--- a/website/docs/r/sm_private_certificate.html.markdown
+++ b/website/docs/r/sm_private_certificate.html.markdown
@@ -167,11 +167,11 @@ You can import the `ibm_sm_private_certificate` resource by using `region`, `ins
 For more information, see [the documentation](https://cloud.ibm.com/docs/secrets-manager)
 
 # Syntax
-```
+```bash
 $ terraform import ibm_sm_private_certificate.sm_private_certificate <region>/<instance_id>/<secret_id>
 ```
 
 # Example
-```
+```bash
 $ terraform import ibm_sm_private_certificate.sm_private_certificate us-east/6ebc4224-e983-496a-8a54-f40a0bfa9175/b49ad24d-81d4-5ebc-b9b9-b0937d1c84d5
 ```

--- a/website/docs/r/sm_private_certificate_configuration_intermediate_ca.html.markdown
+++ b/website/docs/r/sm_private_certificate_configuration_intermediate_ca.html.markdown
@@ -163,11 +163,11 @@ You can import the `ibm_sm_private_certificate_configuration_intermediate_ca` re
 For more information, see [the documentation](https://cloud.ibm.com/docs/secrets-manager)
 
 # Syntax
-```
+```bash
 $ terraform import ibm_sm_private_certificate_configuration_intermediate_ca.sm_private_certificate_configuration_intermediate_ca <region>/<instance_id>/<name>
 ```
 
 # Example
-```
+```bash
 $ terraform import ibm_sm_private_certificate_configuration_intermediate_ca.sm_private_certificate_configuration_intermediate_ca us-east/6ebc4224-e983-496a-8a54-f40a0bfa9175/my_intermediate_ca
 ```

--- a/website/docs/r/sm_private_certificate_configuration_intermediate_ca.html.markdown
+++ b/website/docs/r/sm_private_certificate_configuration_intermediate_ca.html.markdown
@@ -54,7 +54,7 @@ Review the argument reference that you can specify for your resource.
 * `locality` - (Optional, Forces new resource, List) The Locality (L) values to define in the subject field of the resulting certificate.
     * Constraints: The list items must match regular expression `/(.*?)/`. The maximum length is `10` items. The minimum length is `0` items.
 * `max_ttl` - (Required, String) The maximum time-to-live (TTL) for certificates that are created by this CA.
-* `name` - (Required, String) A human-readable unique name to assign to your configuration.
+* `name` - (Required, String) A human-readable unique name to assign to the intermediate CA configuration.
 * `organization` - (Optional, Forces new resource, List) The Organization (O) values to define in the subject field of the resulting certificate.
     * Constraints: The list items must match regular expression `/(.*?)/`. The maximum length is `10` items. The minimum length is `0` items.
 * `other_sans` - (Optional, Forces new resource, List) The custom Object Identifier (OID) or UTF8-string Subject Alternative Names to define for the CA certificate.The alternative names must match the values that are specified in the `allowed_other_sans` field in the associated certificate template. The format is the same as OpenSSL: `<oid>:<type>:<value>` where the current valid type is `UTF8`.

--- a/website/docs/r/sm_private_certificate_configuration_root_ca.html.markdown
+++ b/website/docs/r/sm_private_certificate_configuration_root_ca.html.markdown
@@ -52,7 +52,7 @@ Review the argument reference that you can specify for your resource.
     * Constraints: The list items must match regular expression `/(.*?)/`. The maximum length is `10` items. The minimum length is `0` items.
 * `max_path_length` - (Optional, Forces new resource, Integer) The maximum path length to encode in the generated certificate. `-1` means no limit.If the signing certificate has a maximum path length set, the path length is set to one less than that of the signing certificate. A limit of `0` means a literal path length of zero.
 * `max_ttl` - (Required, String) The maximum time-to-live (TTL) for certificates that are created by this CA.
-* `name` - (Required, String) A human-readable unique name to assign to your configuration.
+* `name` - (Required, String) A human-readable unique name to assign to the root CA configuration.
 * `organization` - (Optional, Forces new resource, List) The Organization (O) values to define in the subject field of the resulting certificate.
     * Constraints: The list items must match regular expression `/(.*?)/`. The maximum length is `10` items. The minimum length is `0` items.
 * `other_sans` - (Optional, Forces new resource, List) The custom Object Identifier (OID) or UTF8-string Subject Alternative Names to define for the CA certificate.The alternative names must match the values that are specified in the `allowed_other_sans` field in the associated certificate template. The format is the same as OpenSSL: `<oid>:<type>:<value>` where the current valid type is `UTF8`.

--- a/website/docs/r/sm_private_certificate_configuration_root_ca.html.markdown
+++ b/website/docs/r/sm_private_certificate_configuration_root_ca.html.markdown
@@ -165,11 +165,11 @@ You can import the `ibm_sm_private_certificate_configuration_root_ca` resource b
 For more information, see [the documentation](https://cloud.ibm.com/docs/secrets-manager)
 
 # Syntax
-```
+```bash
 $ terraform import ibm_sm_private_certificate_configuration_root_ca.sm_private_certificate_configuration_root_ca <region>/<instance_id>/<name>
 ```
 
 # Example
-```
+```bash
 $ terraform import ibm_sm_private_certificate_configuration_root_ca.sm_private_certificate_configuration_root_ca us-east/6ebc4224-e983-496a-8a54-f40a0bfa9175/my_root_ca
 ```

--- a/website/docs/r/sm_private_certificate_configuration_template.html.markdown
+++ b/website/docs/r/sm_private_certificate_configuration_template.html.markdown
@@ -157,11 +157,11 @@ You can import the `ibm_sm_private_certificate_configuration_template` resource 
 For more information, see [the documentation](https://cloud.ibm.com/docs/secrets-manager)
 
 # Syntax
-```
+```bash
 $ terraform import ibm_sm_private_certificate_configuration_template.sm_private_certificate_configuration_template <region>/<instance_id>/<name>
 ```
 
 # Example
-```
+```bash
 $ terraform import ibm_sm_private_certificate_configuration_template.sm_private_certificate_configuration_template us-east/6ebc4224-e983-496a-8a54-f40a0bfa9175/my_template
 ```

--- a/website/docs/r/sm_public_certificate.html.markdown
+++ b/website/docs/r/sm_public_certificate.html.markdown
@@ -177,11 +177,11 @@ You can import the `ibm_sm_public_certificate` resource by using `region`, `inst
 For more information, see [the documentation](https://cloud.ibm.com/docs/secrets-manager)
 
 # Syntax
-```
+```bash
 $ terraform import ibm_sm_public_certificate.sm_public_certificate <region>/<instance_id>/<secret_id>
 ```
 
 # Example
-```
+```bash
 $ terraform import ibm_sm_public_certificate.sm_public_certificate us-east/6ebc4224-e983-496a-8a54-f40a0bfa9175/b49ad24d-81d4-5ebc-b9b9-b0937d1c84d5
 ```

--- a/website/docs/r/sm_public_certificate.html.markdown
+++ b/website/docs/r/sm_public_certificate.html.markdown
@@ -41,13 +41,13 @@ Review the argument reference that you can specify for your resource.
 	* Constraints: Allowable values are: `private`, `public`.
 * `name` - (Required, String) The human-readable name of your secret.
   * Constraints: The maximum length is `256` characters. The minimum length is `2` characters. The value must match regular expression `/^\\w(([\\w-.]+)?\\w)?$/`.
-* `ca` - (Required, Forces new resource, String) The name that is assigned to the certificate authority configuration.
+* `ca` - (Required, Forces new resource, String) The name of the certificate authority configuration.
 * `common_name` - (Required, Forces new resource, String) The Common Name (AKA CN) represents the server name protected by the SSL certificate.
   * Constraints: The maximum length is `64` characters. The minimum length is `4` characters. The value must match regular expression `/^(\\*\\.)?(([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\\-]*[a-zA-Z0-9])\\.)*([A-Za-z0-9]|[A-Za-z0-9][A-Za-z0-9\\-]*[A-Za-z0-9])\\.?$/`.
 * `custom_metadata` - (Optional, Map) The secret metadata that a user can customize.
 * `description` - (Optional, String) An extended description of your secret.To protect your privacy, do not use personal data, such as your name or location, as a description for your secret group.
   * Constraints: The maximum length is `1024` characters. The minimum length is `0` characters. The value must match regular expression `/(.*?)/`.
-* `dns` - (Required, Forces new resource, String) The name that is assigned to the DNS provider configuration.
+* `dns` - (Required, Forces new resource, String) The name of the DNS provider configuration.
 * `expiration_date` - (Optional, Forces new resource, String) The date a secret is expired. The date format follows RFC 3339.
 * `labels` - (Optional, List) Labels that you can use to search for secrets in your instance.Up to 30 labels can be created.
   * Constraints: The list items must match regular expression `/(.*?)/`. The maximum length is `30` items. The minimum length is `0` items.

--- a/website/docs/r/sm_public_certificate_configuration_ca_lets_encrypt.html.markdown
+++ b/website/docs/r/sm_public_certificate_configuration_ca_lets_encrypt.html.markdown
@@ -108,11 +108,11 @@ You can import the `ibm_sm_public_certificate_configuration_ca_lets_encrypt` res
 For more information, see [the documentation](https://cloud.ibm.com/docs/secrets-manager)
 
 # Syntax
-```
+```bash
 $ terraform import ibm_sm_public_certificate_configuration_ca_lets_encrypt.sm_public_certificate_configuration_ca_lets_encrypt <region>/<instance_id>/<name>
 ```
 
 # Example
-```
+```bash
 $ terraform import ibm_sm_public_certificate_configuration_ca_lets_encrypt.sm_public_certificate_configuration_ca_lets_encrypt us-east/6ebc4224-e983-496a-8a54-f40a0bfa9175/lets-encrypt-config
 ```

--- a/website/docs/r/sm_public_certificate_configuration_dns_cis.html.markdown
+++ b/website/docs/r/sm_public_certificate_configuration_dns_cis.html.markdown
@@ -104,11 +104,11 @@ You can import the `ibm_sm_public_certificate_configuration_dns_cis` resource by
 For more information, see [the documentation](https://cloud.ibm.com/docs/secrets-manager)
 
 # Syntax
-```
+```bash
 $ terraform import ibm_sm_public_certificate_configuration_dns_cis.sm_public_certificate_configuration_dns_cis <region>/<instance_id>/<name>
 ```
 
 # Example
-```
+```bash
 $ terraform import ibm_sm_public_certificate_configuration_dns_cis.sm_public_certificate_configuration_dns_cis us-east/6ebc4224-e983-496a-8a54-f40a0bfa9175/my_DNS_CIS_config
 ```

--- a/website/docs/r/sm_public_certificate_configuration_dns_classic_infrastructure.html.markdown
+++ b/website/docs/r/sm_public_certificate_configuration_dns_classic_infrastructure.html.markdown
@@ -104,11 +104,11 @@ You can import the `ibm_sm_public_certificate_configuration_dns_classic_infrastr
 For more information, see [the documentation](https://cloud.ibm.com/docs/secrets-manager)
 
 # Syntax
-```
+```bash
 $ terraform import ibm_sm_public_certificate_configuration_dns_classic_infrastructure.sm_public_certificate_configuration_dns_classic_infrastructure <region>/<instance_id>/<name>
 ```
 
 # Example
-```
+```bash
 $ terraform import ibm_sm_public_certificate_configuration_dns_classic_infrastructure.sm_public_certificate_configuration_dns_classic_infrastructure us-east/6ebc4224-e983-496a-8a54-f40a0bfa9175/my_DNS_config
 ```

--- a/website/docs/r/sm_secret_group.html.markdown
+++ b/website/docs/r/sm_secret_group.html.markdown
@@ -98,11 +98,11 @@ You can import the `ibm_sm_secret_group` resource by using `region`, `instance_i
 For more information, see [the documentation](https://cloud.ibm.com/docs/secrets-manager)
 
 # Syntax
-```
+```bash
 $ terraform import ibm_sm_secret_group.sm_secret_group <region>/<instance_id>/<secret_group_id>
 ```
 
 # Example
-```
+```bash
 $ terraform import ibm_sm_secret_group.sm_secret_group us-east/6ebc4224-e983-496a-8a54-f40a0bfa9175/b49ad24d-81d4-5ebc-b9b9-b0937d1c84d5
 ```

--- a/website/docs/r/sm_username_password_secret.html.markdown
+++ b/website/docs/r/sm_username_password_secret.html.markdown
@@ -143,11 +143,11 @@ You can import the `ibm_sm_username_password_secret` resource by using `region`,
 For more information, see [the documentation](https://cloud.ibm.com/docs/secrets-manager)
 
 # Syntax
-```
+```bash
 $ terraform import ibm_sm_username_password_secret.sm_username_password_secret <region>/<instance_id>/<secret_id>
 ```
 
 # Example
-```
+```bash
 $ terraform import ibm_sm_username_password_secret.sm_username_password_secret us-east/6ebc4224-e983-496a-8a54-f40a0bfa9175/b49ad24d-81d4-5ebc-b9b9-b0937d1c84d5
 ```


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/IBM-Cloud/terraform-provider-ibm/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```
