### PR TITLE
fix: check state for ibm_tg_connection_action correctly

### DIFF
--- a/ibm/service/transitgateway/resource_ibm_tg_gateway_connection_action.go
+++ b/ibm/service/transitgateway/resource_ibm_tg_gateway_connection_action.go
@@ -119,11 +119,6 @@ func resourceIBMTransitGatewayConnectionActionCreate(d *schema.ResourceData, met
 }
 
 func resourceIBMTransitGatewayConnectionActionRead(d *schema.ResourceData, meta interface{}) error {
-
-	client, err := transitgatewayClient(meta)
-	if err != nil {
-		return err
-	}
 	parts, err := flex.IdParts(d.Id())
 	if err != nil {
 		return err
@@ -132,19 +127,7 @@ func resourceIBMTransitGatewayConnectionActionRead(d *schema.ResourceData, meta 
 	gatewayId := parts[0]
 	ID := parts[1]
 
-	getTransitGatewayConnectionOptions := &transitgatewayapisv1.GetTransitGatewayConnectionOptions{}
-	getTransitGatewayConnectionOptions.SetTransitGatewayID(gatewayId)
-	getTransitGatewayConnectionOptions.SetID(ID)
-	instance, response, err := client.GetTransitGatewayConnection(getTransitGatewayConnectionOptions)
-	if err != nil {
-		if response != nil && response.StatusCode == 404 {
-			d.SetId("")
-			return nil
-		}
-		return fmt.Errorf("Error Getting Transit Gateway Connection (%s): %s\n%s", ID, err, response)
-	}
-
-	d.Set(tgConnectionId, *instance.ID)
+	d.Set(tgConnectionId, ID)
 	d.Set(tgGatewayId, gatewayId)
 
 	return nil


### PR DESCRIPTION
This PR fixes a bug in ibm_tg_connection action. ibm_tg_connection_action was failing when the ibm_tg_connection involved was not created yet but worked for existing connections.

The bug was in a customdiff implementation that validates/checks for changes in the connection_action resource block. An action on a transit gateway can only be performed once. Once submitted, the cross account connection is either approved or rejected. This presented problems if the resource block changed, because the terraform state would delete but the backend would throw errors, and the terraform state would be out of sync. This background explains why a customdiff was needed.

A bug in connection action's customdiff was in how we are checking for action changes. Fixes were made so that:
- Creating a new connection and action works
- Expect failure when action changes on existing connection (Actions can only be performed once)
- Actions can change when connection is changed (This is performing an entirely new action on a different connection)

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #4445

Output from acceptance testing:
```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```
**Note:** The terraform acceptance test framework does not support multiple providers configs with differing api keys. We can not use the acceptance tests for this feature because it needs two accounts/apikeys.

### Manual tests
#### Create new connection and action
```
sarahulmer@sulmer macbook terraform % terraform apply        
ibm_tg_gateway.gw_test: Refreshing state... [id=de9c7237-367f-44d7-ae15-6dc79b5cd930]

Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  + create

Terraform will perform the following actions:

  # ibm_tg_connection.xac_connection will be created
  + resource "ibm_tg_connection" "xac_connection" {
      + base_connection_id = (known after apply)
      + base_network_type  = (known after apply)
      + connection_id      = (known after apply)
      + created_at         = (known after apply)
      + gateway            = "de9c7237-367f-44d7-ae15-6dc79b5cd930"
      + id                 = (known after apply)
      + local_gateway_ip   = (known after apply)
      + local_tunnel_ip    = (known after apply)
      + name               = "su-vpc-xac-conn"
      + network_account_id = (known after apply)
      + network_id         = "crn:v1:staging:public:is:us-south:a/3aa0a4551a1a46258064d84f7f447920::vpc:r134-426f83e2-e03a-4875-97cc-4168560d4d12"
      + network_type       = "vpc"
      + related_crn        = (known after apply)
      + remote_bgp_asn     = (known after apply)
      + remote_gateway_ip  = (known after apply)
      + remote_tunnel_ip   = (known after apply)
      + request_status     = (known after apply)
      + status             = (known after apply)
      + updated_at         = (known after apply)
      + zone               = (known after apply)
    }

  # ibm_tg_connection_action.xac_test will be created
  + resource "ibm_tg_connection_action" "xac_test" {
      + action        = "approve"
      + connection_id = (known after apply)
      + gateway       = "de9c7237-367f-44d7-ae15-6dc79b5cd930"
      + id            = (known after apply)
    }

Plan: 2 to add, 0 to change, 0 to destroy.

Do you want to perform these actions?
  Terraform will perform the actions described above.
  Only 'yes' will be accepted to approve.

  Enter a value: yes

ibm_tg_connection.xac_connection: Creating...
ibm_tg_connection.xac_connection: Creation complete after 6s [id=de9c7237-367f-44d7-ae15-6dc79b5cd930/ee5102ca-7bb5-4aae-86f9-c6a527eab240]
ibm_tg_connection_action.xac_test: Creating...
ibm_tg_connection_action.xac_test: Creation complete after 5s [id=de9c7237-367f-44d7-ae15-6dc79b5cd930/ee5102ca-7bb5-4aae-86f9-c6a527eab240]

Apply complete! Resources: 2 added, 0 changed, 0 destroyed.
```

#### Expect failure when changing action on existing connection
```
sarahulmer@sulmer macbook terraform % terraform apply
ibm_tg_gateway.gw_test: Refreshing state... [id=de9c7237-367f-44d7-ae15-6dc79b5cd930]
ibm_tg_connection.xac_connection: Refreshing state... [id=de9c7237-367f-44d7-ae15-6dc79b5cd930/ee5102ca-7bb5-4aae-86f9-c6a527eab240]
ibm_tg_connection_action.xac_test: Refreshing state... [id=de9c7237-367f-44d7-ae15-6dc79b5cd930/ee5102ca-7bb5-4aae-86f9-c6a527eab240]
╷
│ Error: 1 error occurred:
│ 	* The action for the transit gateway connection has already been performed and cannot be changed from approve to reject
│ 
│ 
│ 
│   with ibm_tg_connection_action.xac_test,
│   on main.tf line 15, in resource "ibm_tg_connection_action" "xac_test":
│   15: resource "ibm_tg_connection_action" "xac_test" {
│ 
╵
sarahulmer@sulmer macbook terraform %
```

#### Create new connection and reuse action resource block
```
sarahulmer@sulmer macbook terraform % terraform apply
ibm_tg_gateway.gw_test: Refreshing state... [id=de9c7237-367f-44d7-ae15-6dc79b5cd930]
ibm_tg_connection.xac_connection: Refreshing state... [id=de9c7237-367f-44d7-ae15-6dc79b5cd930/04491bba-e06a-4937-b621-e55015b825dc]
ibm_tg_connection_action.xac_test: Refreshing state... [id=de9c7237-367f-44d7-ae15-6dc79b5cd930/04491bba-e06a-4937-b621-e55015b825dc]

Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
-/+ destroy and then create replacement

Terraform will perform the following actions:

  # ibm_tg_connection.xac_connection must be replaced
-/+ resource "ibm_tg_connection" "xac_connection" {
      + base_connection_id = (known after apply)
      + base_network_type  = (known after apply)
      ~ connection_id      = "04491bba-e06a-4937-b621-e55015b825dc" -> (known after apply)
      ~ created_at         = "2023-03-28T21:46:51.711Z" -> (known after apply)
      ~ id                 = "de9c7237-367f-44d7-ae15-6dc79b5cd930/04491bba-e06a-4937-b621-e55015b825dc" -> (known after apply)
      + local_gateway_ip   = (known after apply)
      + local_tunnel_ip    = (known after apply)
        name               = "su-vpc-xac-conn"
      ~ network_account_id = "3aa0a4551a1a46258064d84f7f447920" -> (known after apply)
      ~ network_id         = "crn:v1:staging:public:is:us-south:a/3aa0a4551a1a46258064d84f7f447920::vpc:r134-a5fc11c6-165d-4854-a72a-ba7bfef9f48f" -> "crn:v1:staging:public:is:us-south:a/3aa0a4551a1a46258064d84f7f447920::vpc:r134-426f83e2-e03a-4875-97cc-4168560d4d12" # forces replacement
      ~ related_crn        = "crn:v1:staging:public:transit:us-south:a/55ab833681b04a00a78b07e8b4582246::gateway:de9c7237-367f-44d7-ae15-6dc79b5cd930" -> (known after apply)
      + remote_bgp_asn     = (known after apply)
      + remote_gateway_ip  = (known after apply)
      + remote_tunnel_ip   = (known after apply)
      ~ request_status     = "approved" -> (known after apply)
      ~ status             = "attached" -> (known after apply)
      ~ updated_at         = "2023-03-28T21:47:38.210Z" -> (known after apply)
      + zone               = (known after apply)
        # (2 unchanged attributes hidden)
    }

  # ibm_tg_connection_action.xac_test must be replaced
-/+ resource "ibm_tg_connection_action" "xac_test" {
      ~ connection_id = "04491bba-e06a-4937-b621-e55015b825dc" -> (known after apply) # forces replacement
      ~ id            = "de9c7237-367f-44d7-ae15-6dc79b5cd930/04491bba-e06a-4937-b621-e55015b825dc" -> (known after apply)
        # (2 unchanged attributes hidden)
    }

Plan: 2 to add, 0 to change, 2 to destroy.

Do you want to perform these actions?
  Terraform will perform the actions described above.
  Only 'yes' will be accepted to approve.

  Enter a value: yes

ibm_tg_connection_action.xac_test: Destroying... [id=de9c7237-367f-44d7-ae15-6dc79b5cd930/04491bba-e06a-4937-b621-e55015b825dc]
ibm_tg_connection_action.xac_test: Destruction complete after 0s
ibm_tg_connection.xac_connection: Destroying... [id=de9c7237-367f-44d7-ae15-6dc79b5cd930/04491bba-e06a-4937-b621-e55015b825dc]
ibm_tg_connection.xac_connection: Still destroying... [id=de9c7237-367f-44d7-ae15-6dc79b5cd930/04491bba-e06a-4937-b621-e55015b825dc, 10s elapsed]
ibm_tg_connection.xac_connection: Still destroying... [id=de9c7237-367f-44d7-ae15-6dc79b5cd930/04491bba-e06a-4937-b621-e55015b825dc, 20s elapsed]
ibm_tg_connection.xac_connection: Still destroying... [id=de9c7237-367f-44d7-ae15-6dc79b5cd930/04491bba-e06a-4937-b621-e55015b825dc, 30s elapsed]
ibm_tg_connection.xac_connection: Still destroying... [id=de9c7237-367f-44d7-ae15-6dc79b5cd930/04491bba-e06a-4937-b621-e55015b825dc, 40s elapsed]
ibm_tg_connection.xac_connection: Destruction complete after 48s
ibm_tg_connection.xac_connection: Creating...
ibm_tg_connection.xac_connection: Creation complete after 6s [id=de9c7237-367f-44d7-ae15-6dc79b5cd930/0e3e444f-58c3-4c24-b533-468ace3ad065]
ibm_tg_connection_action.xac_test: Creating...
ibm_tg_connection_action.xac_test: Creation complete after 7s [id=de9c7237-367f-44d7-ae15-6dc79b5cd930/0e3e444f-58c3-4c24-b533-468ace3ad065]

Apply complete! Resources: 2 added, 0 changed, 2 destroyed.
sarahulmer@sulmer macbook terraform % 
```

#### Create new connection and change action in resused resource block
```
sarahulmer@sulmer macbook terraform % terraform apply
ibm_tg_gateway.gw_test: Refreshing state... [id=de9c7237-367f-44d7-ae15-6dc79b5cd930]
ibm_tg_connection.xac_connection: Refreshing state... [id=de9c7237-367f-44d7-ae15-6dc79b5cd930/a2e6a33f-b869-4855-b911-e5f20d1b9c5d]
ibm_tg_connection_action.xac_test: Refreshing state... [id=de9c7237-367f-44d7-ae15-6dc79b5cd930/a2e6a33f-b869-4855-b911-e5f20d1b9c5d]

Note: Objects have changed outside of Terraform

Terraform detected the following changes made outside of Terraform since the last "terraform apply":

  # ibm_tg_connection.xac_connection has changed
  ~ resource "ibm_tg_connection" "xac_connection" {
        id                 = "de9c7237-367f-44d7-ae15-6dc79b5cd930/a2e6a33f-b869-4855-b911-e5f20d1b9c5d"
        name               = "su-vpc-xac-conn"
      ~ request_status     = "pending" -> "rejected"
      ~ status             = "pending" -> "detached"
      ~ updated_at         = "2023-03-28T22:28:09.998Z" -> "2023-03-28T22:28:19.719Z"
        # (7 unchanged attributes hidden)
    }


Unless you have made equivalent changes to your configuration, or ignored the relevant attributes using ignore_changes, the following plan may include actions to undo or
respond to these changes.

───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────

Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
-/+ destroy and then create replacement

Terraform will perform the following actions:

  # ibm_tg_connection.xac_connection must be replaced
-/+ resource "ibm_tg_connection" "xac_connection" {
      + base_connection_id = (known after apply)
      + base_network_type  = (known after apply)
      ~ connection_id      = "a2e6a33f-b869-4855-b911-e5f20d1b9c5d" -> (known after apply)
      ~ created_at         = "2023-03-28T22:28:09.998Z" -> (known after apply)
      ~ id                 = "de9c7237-367f-44d7-ae15-6dc79b5cd930/a2e6a33f-b869-4855-b911-e5f20d1b9c5d" -> (known after apply)
      + local_gateway_ip   = (known after apply)
      + local_tunnel_ip    = (known after apply)
        name               = "su-vpc-xac-conn"
      ~ network_account_id = "3aa0a4551a1a46258064d84f7f447920" -> (known after apply)
      ~ network_id         = "crn:v1:staging:public:is:us-south:a/3aa0a4551a1a46258064d84f7f447920::vpc:r134-a5fc11c6-165d-4854-a72a-ba7bfef9f48f" -> "crn:v1:staging:public:is:us-south:a/3aa0a4551a1a46258064d84f7f447920::vpc:r134-426f83e2-e03a-4875-97cc-4168560d4d12" # forces replacement
      ~ related_crn        = "crn:v1:staging:public:transit:us-south:a/55ab833681b04a00a78b07e8b4582246::gateway:de9c7237-367f-44d7-ae15-6dc79b5cd930" -> (known after apply)
      + remote_bgp_asn     = (known after apply)
      + remote_gateway_ip  = (known after apply)
      + remote_tunnel_ip   = (known after apply)
      ~ request_status     = "rejected" -> (known after apply)
      ~ status             = "detached" -> (known after apply)
      ~ updated_at         = "2023-03-28T22:28:19.719Z" -> (known after apply)
      + zone               = (known after apply)
        # (2 unchanged attributes hidden)
    }

  # ibm_tg_connection_action.xac_test must be replaced
-/+ resource "ibm_tg_connection_action" "xac_test" {
      ~ action        = "reject" -> "approve" # forces replacement
      ~ connection_id = "a2e6a33f-b869-4855-b911-e5f20d1b9c5d" -> (known after apply) # forces replacement
      ~ id            = "de9c7237-367f-44d7-ae15-6dc79b5cd930/a2e6a33f-b869-4855-b911-e5f20d1b9c5d" -> (known after apply)
        # (1 unchanged attribute hidden)
    }

Plan: 2 to add, 0 to change, 2 to destroy.

Do you want to perform these actions?
  Terraform will perform the actions described above.
  Only 'yes' will be accepted to approve.

  Enter a value: yes

ibm_tg_connection_action.xac_test: Destroying... [id=de9c7237-367f-44d7-ae15-6dc79b5cd930/a2e6a33f-b869-4855-b911-e5f20d1b9c5d]
ibm_tg_connection_action.xac_test: Destruction complete after 0s
ibm_tg_connection.xac_connection: Destroying... [id=de9c7237-367f-44d7-ae15-6dc79b5cd930/a2e6a33f-b869-4855-b911-e5f20d1b9c5d]
ibm_tg_connection.xac_connection: Still destroying... [id=de9c7237-367f-44d7-ae15-6dc79b5cd930/a2e6a33f-b869-4855-b911-e5f20d1b9c5d, 10s elapsed]
ibm_tg_connection.xac_connection: Destruction complete after 13s
ibm_tg_connection.xac_connection: Creating...
ibm_tg_connection.xac_connection: Creation complete after 8s [id=de9c7237-367f-44d7-ae15-6dc79b5cd930/5f1566da-742f-467b-8021-c5677e6e1bce]
ibm_tg_connection_action.xac_test: Creating...
ibm_tg_connection_action.xac_test: Creation complete after 5s [id=de9c7237-367f-44d7-ae15-6dc79b5cd930/5f1566da-742f-467b-8021-c5677e6e1bce]

Apply complete! Resources: 2 added, 0 changed, 2 destroyed.
sarahulmer@sulmer macbook terraform % terraform state show ibm_tg_connection_action.xac_test
# ibm_tg_connection_action.xac_test:
resource "ibm_tg_connection_action" "xac_test" {
    action        = "approve"
    connection_id = "5f1566da-742f-467b-8021-c5677e6e1bce"
    gateway       = "de9c7237-367f-44d7-ae15-6dc79b5cd930"
    id            = "de9c7237-367f-44d7-ae15-6dc79b5cd930/5f1566da-742f-467b-8021-c5677e6e1bce"
}
sarahulmer@sulmer macbook terraform % 
```
