### PR TITLE
Fix regex used for validating a secrer group name

### DIFF
--- a/ibm/service/secretsmanager/resource_ibm_sm_secret_group.go
+++ b/ibm/service/secretsmanager/resource_ibm_sm_secret_group.go
@@ -1,23 +1,23 @@
 // Copyright IBM Corp. 2022 All Rights Reserved.
 // Licensed under the Mozilla Public License v2.0
-
+​
 package secretsmanager
-
+​
 import (
 	"context"
 	"fmt"
 	"log"
 	"strings"
-
+​
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-
+​
 	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/conns"
 	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/flex"
 	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/validate"
 	"github.com/IBM/secrets-manager-go-sdk/secretsmanagerv2"
 )
-
+​
 func ResourceIbmSmSecretGroup() *schema.Resource {
 	return &schema.Resource{
 		CreateContext: resourceIbmSmSecretGroupCreate,
@@ -25,7 +25,7 @@ func ResourceIbmSmSecretGroup() *schema.Resource {
 		UpdateContext: resourceIbmSmSecretGroupUpdate,
 		DeleteContext: resourceIbmSmSecretGroupDelete,
 		Importer:      &schema.ResourceImporter{},
-
+​
 		Schema: map[string]*schema.Schema{
 			"secret_group_id": &schema.Schema{
 				Type:        schema.TypeString,
@@ -57,7 +57,7 @@ func ResourceIbmSmSecretGroup() *schema.Resource {
 		},
 	}
 }
-
+​
 func ResourceIbmSmSecretGroupValidator() *validate.ResourceValidator {
 	validateSchema := make([]validate.ValidateSchema, 0)
 	validateSchema = append(validateSchema,
@@ -66,7 +66,7 @@ func ResourceIbmSmSecretGroupValidator() *validate.ResourceValidator {
 			ValidateFunctionIdentifier: validate.ValidateRegexpLen,
 			Type:                       validate.TypeString,
 			Required:                   true,
-			Regexp:                     `^[A-Za-z][A-Za-z0-9]*(?:_?-?.?[A-Za-z0-9]+)*$`,
+			Regexp:                     `[A-Za-z0-9][A-Za-z0-9]*(?:_*-*\\.*[A-Za-z0-9]+)*$`,
 			MinValueLength:             2,
 			MaxValueLength:             64,
 		},
@@ -80,46 +80,46 @@ func ResourceIbmSmSecretGroupValidator() *validate.ResourceValidator {
 			MaxValueLength:             1024,
 		},
 	)
-
+​
 	resourceValidator := validate.ResourceValidator{ResourceName: "ibm_sm_secret_group", Schema: validateSchema}
 	return &resourceValidator
 }
-
+​
 func resourceIbmSmSecretGroupCreate(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	secretsManagerClient, err := meta.(conns.ClientSession).SecretsManagerV2()
 	if err != nil {
 		return diag.FromErr(err)
 	}
-
+​
 	region := getRegion(secretsManagerClient, d)
 	instanceId := d.Get("instance_id").(string)
 	secretsManagerClient = getClientWithInstanceEndpoint(secretsManagerClient, instanceId, region, getEndpointType(secretsManagerClient, d))
-
+​
 	createSecretGroupOptions := &secretsmanagerv2.CreateSecretGroupOptions{}
-
+​
 	createSecretGroupOptions.SetName(d.Get("name").(string))
 	if _, ok := d.GetOk("description"); ok {
 		createSecretGroupOptions.SetDescription(d.Get("description").(string))
 	}
-
+​
 	secretGroup, response, err := secretsManagerClient.CreateSecretGroupWithContext(context, createSecretGroupOptions)
 	if err != nil {
 		log.Printf("[DEBUG] CreateSecretGroupWithContext failed %s\n%s", err, response)
 		return diag.FromErr(fmt.Errorf("CreateSecretGroupWithContext failed %s\n%s", err, response))
 	}
-
+​
 	d.SetId(fmt.Sprintf("%s/%s/%s", region, instanceId, *secretGroup.ID))
 	d.Set("secret_group_id", *secretGroup.ID)
-
+​
 	return resourceIbmSmSecretGroupRead(context, d, meta)
 }
-
+​
 func resourceIbmSmSecretGroupRead(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	secretsManagerClient, err := meta.(conns.ClientSession).SecretsManagerV2()
 	if err != nil {
 		return diag.FromErr(err)
 	}
-
+​
 	id := strings.Split(d.Id(), "/")
 	if len(id) != 3 {
 		return diag.Errorf("Wrong format of resource ID. To import a secret group use the format `<region>/<instance_id>/<secret_group_id>`")
@@ -128,11 +128,11 @@ func resourceIbmSmSecretGroupRead(context context.Context, d *schema.ResourceDat
 	instanceId := id[1]
 	secretGroupId := id[2]
 	secretsManagerClient = getClientWithInstanceEndpoint(secretsManagerClient, instanceId, region, getEndpointType(secretsManagerClient, d))
-
+​
 	getSecretGroupOptions := &secretsmanagerv2.GetSecretGroupOptions{}
-
+​
 	getSecretGroupOptions.SetID(secretGroupId)
-
+​
 	secretGroup, response, err := secretsManagerClient.GetSecretGroupWithContext(context, getSecretGroupOptions)
 	if err != nil {
 		if response != nil && response.StatusCode == 404 {
@@ -142,7 +142,7 @@ func resourceIbmSmSecretGroupRead(context context.Context, d *schema.ResourceDat
 		log.Printf("[DEBUG] GetSecretGroupWithContext failed %s\n%s", err, response)
 		return diag.FromErr(fmt.Errorf("GetSecretGroupWithContext failed %s\n%s", err, response))
 	}
-
+​
 	if err = d.Set("secret_group_id", secretGroupId); err != nil {
 		return diag.FromErr(fmt.Errorf("Error setting secret_group_id: %s", err))
 	}
@@ -164,28 +164,28 @@ func resourceIbmSmSecretGroupRead(context context.Context, d *schema.ResourceDat
 	if err = d.Set("updated_at", flex.DateTimeToString(secretGroup.UpdatedAt)); err != nil {
 		return diag.FromErr(fmt.Errorf("Error setting updated_at: %s", err))
 	}
-
+​
 	return nil
 }
-
+​
 func resourceIbmSmSecretGroupUpdate(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	secretsManagerClient, err := meta.(conns.ClientSession).SecretsManagerV2()
 	if err != nil {
 		return diag.FromErr(err)
 	}
-
+​
 	id := strings.Split(d.Id(), "/")
 	region := id[0]
 	instanceId := id[1]
 	secretGroupId := id[2]
 	secretsManagerClient = getClientWithInstanceEndpoint(secretsManagerClient, instanceId, region, getEndpointType(secretsManagerClient, d))
-
+​
 	updateSecretGroupOptions := &secretsmanagerv2.UpdateSecretGroupOptions{}
-
+​
 	updateSecretGroupOptions.SetID(secretGroupId)
-
+​
 	hasChange := false
-
+​
 	patchVals := &secretsmanagerv2.SecretGroupPatch{}
 	if d.HasChange("name") {
 		newName := d.Get("name").(string)
@@ -197,7 +197,7 @@ func resourceIbmSmSecretGroupUpdate(context context.Context, d *schema.ResourceD
 		patchVals.Description = &newDescription
 		hasChange = true
 	}
-
+​
 	if hasChange {
 		updateSecretGroupOptions.SecretGroupPatch, _ = patchVals.AsPatch()
 		_, response, err := secretsManagerClient.UpdateSecretGroupWithContext(context, updateSecretGroupOptions)
@@ -206,33 +206,33 @@ func resourceIbmSmSecretGroupUpdate(context context.Context, d *schema.ResourceD
 			return diag.FromErr(fmt.Errorf("UpdateSecretGroupWithContext failed %s\n%s", err, response))
 		}
 	}
-
+​
 	return resourceIbmSmSecretGroupRead(context, d, meta)
 }
-
+​
 func resourceIbmSmSecretGroupDelete(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	secretsManagerClient, err := meta.(conns.ClientSession).SecretsManagerV2()
 	if err != nil {
 		return diag.FromErr(err)
 	}
-
+​
 	id := strings.Split(d.Id(), "/")
 	region := id[0]
 	instanceId := id[1]
 	secretGroupId := id[2]
 	secretsManagerClient = getClientWithInstanceEndpoint(secretsManagerClient, instanceId, region, getEndpointType(secretsManagerClient, d))
-
+​
 	deleteSecretGroupOptions := &secretsmanagerv2.DeleteSecretGroupOptions{}
-
+​
 	deleteSecretGroupOptions.SetID(secretGroupId)
-
+​
 	response, err := secretsManagerClient.DeleteSecretGroupWithContext(context, deleteSecretGroupOptions)
 	if err != nil {
 		log.Printf("[DEBUG] DeleteSecretGroupWithContext failed %s\n%s", err, response)
 		return diag.FromErr(fmt.Errorf("DeleteSecretGroupWithContext failed %s\n%s", err, response))
 	}
-
+​
 	d.SetId("")
-
+​
 	return nil
 }

--- a/ibm/service/secretsmanager/resource_ibm_sm_secret_group.go
+++ b/ibm/service/secretsmanager/resource_ibm_sm_secret_group.go
@@ -1,23 +1,23 @@
 // Copyright IBM Corp. 2022 All Rights Reserved.
 // Licensed under the Mozilla Public License v2.0
-​
+
 package secretsmanager
-​
+
 import (
 	"context"
 	"fmt"
 	"log"
 	"strings"
-​
+
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-​
+
 	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/conns"
 	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/flex"
 	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/validate"
 	"github.com/IBM/secrets-manager-go-sdk/secretsmanagerv2"
 )
-​
+
 func ResourceIbmSmSecretGroup() *schema.Resource {
 	return &schema.Resource{
 		CreateContext: resourceIbmSmSecretGroupCreate,
@@ -25,7 +25,7 @@ func ResourceIbmSmSecretGroup() *schema.Resource {
 		UpdateContext: resourceIbmSmSecretGroupUpdate,
 		DeleteContext: resourceIbmSmSecretGroupDelete,
 		Importer:      &schema.ResourceImporter{},
-​
+
 		Schema: map[string]*schema.Schema{
 			"secret_group_id": &schema.Schema{
 				Type:        schema.TypeString,
@@ -57,7 +57,7 @@ func ResourceIbmSmSecretGroup() *schema.Resource {
 		},
 	}
 }
-​
+
 func ResourceIbmSmSecretGroupValidator() *validate.ResourceValidator {
 	validateSchema := make([]validate.ValidateSchema, 0)
 	validateSchema = append(validateSchema,
@@ -80,46 +80,46 @@ func ResourceIbmSmSecretGroupValidator() *validate.ResourceValidator {
 			MaxValueLength:             1024,
 		},
 	)
-​
+
 	resourceValidator := validate.ResourceValidator{ResourceName: "ibm_sm_secret_group", Schema: validateSchema}
 	return &resourceValidator
 }
-​
+
 func resourceIbmSmSecretGroupCreate(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	secretsManagerClient, err := meta.(conns.ClientSession).SecretsManagerV2()
 	if err != nil {
 		return diag.FromErr(err)
 	}
-​
+
 	region := getRegion(secretsManagerClient, d)
 	instanceId := d.Get("instance_id").(string)
 	secretsManagerClient = getClientWithInstanceEndpoint(secretsManagerClient, instanceId, region, getEndpointType(secretsManagerClient, d))
-​
+
 	createSecretGroupOptions := &secretsmanagerv2.CreateSecretGroupOptions{}
-​
+
 	createSecretGroupOptions.SetName(d.Get("name").(string))
 	if _, ok := d.GetOk("description"); ok {
 		createSecretGroupOptions.SetDescription(d.Get("description").(string))
 	}
-​
+
 	secretGroup, response, err := secretsManagerClient.CreateSecretGroupWithContext(context, createSecretGroupOptions)
 	if err != nil {
 		log.Printf("[DEBUG] CreateSecretGroupWithContext failed %s\n%s", err, response)
 		return diag.FromErr(fmt.Errorf("CreateSecretGroupWithContext failed %s\n%s", err, response))
 	}
-​
+
 	d.SetId(fmt.Sprintf("%s/%s/%s", region, instanceId, *secretGroup.ID))
 	d.Set("secret_group_id", *secretGroup.ID)
-​
+
 	return resourceIbmSmSecretGroupRead(context, d, meta)
 }
-​
+
 func resourceIbmSmSecretGroupRead(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	secretsManagerClient, err := meta.(conns.ClientSession).SecretsManagerV2()
 	if err != nil {
 		return diag.FromErr(err)
 	}
-​
+
 	id := strings.Split(d.Id(), "/")
 	if len(id) != 3 {
 		return diag.Errorf("Wrong format of resource ID. To import a secret group use the format `<region>/<instance_id>/<secret_group_id>`")
@@ -128,11 +128,11 @@ func resourceIbmSmSecretGroupRead(context context.Context, d *schema.ResourceDat
 	instanceId := id[1]
 	secretGroupId := id[2]
 	secretsManagerClient = getClientWithInstanceEndpoint(secretsManagerClient, instanceId, region, getEndpointType(secretsManagerClient, d))
-​
+
 	getSecretGroupOptions := &secretsmanagerv2.GetSecretGroupOptions{}
-​
+
 	getSecretGroupOptions.SetID(secretGroupId)
-​
+
 	secretGroup, response, err := secretsManagerClient.GetSecretGroupWithContext(context, getSecretGroupOptions)
 	if err != nil {
 		if response != nil && response.StatusCode == 404 {
@@ -142,7 +142,7 @@ func resourceIbmSmSecretGroupRead(context context.Context, d *schema.ResourceDat
 		log.Printf("[DEBUG] GetSecretGroupWithContext failed %s\n%s", err, response)
 		return diag.FromErr(fmt.Errorf("GetSecretGroupWithContext failed %s\n%s", err, response))
 	}
-​
+
 	if err = d.Set("secret_group_id", secretGroupId); err != nil {
 		return diag.FromErr(fmt.Errorf("Error setting secret_group_id: %s", err))
 	}
@@ -164,28 +164,28 @@ func resourceIbmSmSecretGroupRead(context context.Context, d *schema.ResourceDat
 	if err = d.Set("updated_at", flex.DateTimeToString(secretGroup.UpdatedAt)); err != nil {
 		return diag.FromErr(fmt.Errorf("Error setting updated_at: %s", err))
 	}
-​
+
 	return nil
 }
-​
+
 func resourceIbmSmSecretGroupUpdate(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	secretsManagerClient, err := meta.(conns.ClientSession).SecretsManagerV2()
 	if err != nil {
 		return diag.FromErr(err)
 	}
-​
+
 	id := strings.Split(d.Id(), "/")
 	region := id[0]
 	instanceId := id[1]
 	secretGroupId := id[2]
 	secretsManagerClient = getClientWithInstanceEndpoint(secretsManagerClient, instanceId, region, getEndpointType(secretsManagerClient, d))
-​
+
 	updateSecretGroupOptions := &secretsmanagerv2.UpdateSecretGroupOptions{}
-​
+
 	updateSecretGroupOptions.SetID(secretGroupId)
-​
+
 	hasChange := false
-​
+
 	patchVals := &secretsmanagerv2.SecretGroupPatch{}
 	if d.HasChange("name") {
 		newName := d.Get("name").(string)
@@ -197,7 +197,7 @@ func resourceIbmSmSecretGroupUpdate(context context.Context, d *schema.ResourceD
 		patchVals.Description = &newDescription
 		hasChange = true
 	}
-​
+
 	if hasChange {
 		updateSecretGroupOptions.SecretGroupPatch, _ = patchVals.AsPatch()
 		_, response, err := secretsManagerClient.UpdateSecretGroupWithContext(context, updateSecretGroupOptions)
@@ -206,33 +206,33 @@ func resourceIbmSmSecretGroupUpdate(context context.Context, d *schema.ResourceD
 			return diag.FromErr(fmt.Errorf("UpdateSecretGroupWithContext failed %s\n%s", err, response))
 		}
 	}
-​
+
 	return resourceIbmSmSecretGroupRead(context, d, meta)
 }
-​
+
 func resourceIbmSmSecretGroupDelete(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	secretsManagerClient, err := meta.(conns.ClientSession).SecretsManagerV2()
 	if err != nil {
 		return diag.FromErr(err)
 	}
-​
+
 	id := strings.Split(d.Id(), "/")
 	region := id[0]
 	instanceId := id[1]
 	secretGroupId := id[2]
 	secretsManagerClient = getClientWithInstanceEndpoint(secretsManagerClient, instanceId, region, getEndpointType(secretsManagerClient, d))
-​
+
 	deleteSecretGroupOptions := &secretsmanagerv2.DeleteSecretGroupOptions{}
-​
+
 	deleteSecretGroupOptions.SetID(secretGroupId)
-​
+
 	response, err := secretsManagerClient.DeleteSecretGroupWithContext(context, deleteSecretGroupOptions)
 	if err != nil {
 		log.Printf("[DEBUG] DeleteSecretGroupWithContext failed %s\n%s", err, response)
 		return diag.FromErr(fmt.Errorf("DeleteSecretGroupWithContext failed %s\n%s", err, response))
 	}
-​
+
 	d.SetId("")
-​
+
 	return nil
 }


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/IBM-Cloud/terraform-provider-ibm/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```
