### PR TITLE
Added certificate_root for data_source_ibm_database_connection

### DIFF
--- a/ibm/service/database/data_source_ibm_database_connection.go
+++ b/ibm/service/database/data_source_ibm_database_connection.go
@@ -49,6 +49,11 @@ func DataSourceIBMDatabaseConnection() *schema.Resource {
 					"ibm_database_connection",
 					"endpoint_type"),
 			},
+			"certificate_root": &schema.Schema{
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "Optional certificate root path to prepend certificate names. Certificates would be stored in this directory for use by other commands.",
+			},
 			"postgres": &schema.Schema{
 				Type:     schema.TypeList,
 				Computed: true,
@@ -1645,6 +1650,10 @@ func DataSourceIBMDatabaseConnectionRead(context context.Context, d *schema.Reso
 	getConnectionOptions.SetUserType(d.Get("user_type").(string))
 	getConnectionOptions.SetUserID(d.Get("user_id").(string))
 	getConnectionOptions.SetEndpointType(d.Get("endpoint_type").(string))
+
+	if _, ok := d.GetOk("certificate_root"); ok {
+		getConnectionOptions.SetCertificateRoot(d.Get("certificate_root").(string))
+	}
 
 	connection, response, err := cloudDatabasesClient.GetConnectionWithContext(context, getConnectionOptions)
 	if err != nil {

--- a/ibm/service/database/data_source_ibm_database_connection_test.go
+++ b/ibm/service/database/data_source_ibm_database_connection_test.go
@@ -27,6 +27,7 @@ func TestAccIBMDatabaseConnectionDataSourceBasic(t *testing.T) {
 					resource.TestCheckResourceAttrSet("data.ibm_database_connection.database_connection", "user_type"),
 					resource.TestCheckResourceAttrSet("data.ibm_database_connection.database_connection", "user_id"),
 					resource.TestCheckResourceAttrSet("data.ibm_database_connection.database_connection", "endpoint_type"),
+					resource.TestCheckResourceAttrSet("data.ibm_database_connection.database_connection", "certificate_root"),
 				),
 			},
 		},
@@ -63,6 +64,7 @@ func testAccCheckIBMDatabaseInstancePostgresql(name string) string {
 			user_type = "database"
 			user_id = "user_id"
 			endpoint_type = "public"
+			certificate_root = "./test/path"
 		}
 	  `
 }

--- a/website/docs/d/database_connection.html.markdown
+++ b/website/docs/d/database_connection.html.markdown
@@ -30,6 +30,7 @@ Review the argument reference that you can specify for your data source.
 * `deployment_id` - (Required, String) Deployment ID.
 * `user_id` - (Required, String) User ID.
 * `user_type` - (Required, String) User type.
+* `certificate_root` - (Optional, String) Optional certificate root path to prepend certificate names. Certificates would be stored in this directory for use by other commands.
 
 ## Attribute Reference
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/IBM-Cloud/terraform-provider-ibm/blob/master/.github/CONTRIBUTING.md --->

`certificate_root` is a part of the getconnection API in the IBM Cloud Databases API v5 as seen here: https://cloud.ibm.com/apidocs/cloud-databases-api/cloud-databases-api-v4#getconnection

We need to incorporate this within our Terraform Provider so that users could use this parameter.

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccIBMDatabaseConnectionDataSourceBasic'
--- PASS: TestAccIBMDatabaseConnectionDataSourceBasic (936.52s)
PASS
ok  	github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/database	937.505s
```
