### PR TITLE
fix(tekton): sorting issue for events

### DIFF
--- a/ibm/flex/diff_supress_funcs.go
+++ b/ibm/flex/diff_supress_funcs.go
@@ -7,9 +7,11 @@ import (
 	"crypto/hmac"
 	"encoding/hex"
 	"encoding/json"
+	"fmt"
 	"log"
 	"reflect"
 	"regexp"
+	"sort"
 	"strings"
 
 	"golang.org/x/crypto/sha3"
@@ -99,6 +101,38 @@ func SuppressGenericWebhookRawSecret(k, old, new string, d *schema.ResourceData)
 	mac.Write([]byte(new))
 	secureHmac := hex.EncodeToString(mac.Sum(nil))
 	return cmp.Equal(strings.Join([]string{"hash", "SHA3-512", secureHmac}, ":"), old)
+}
+
+func SuppressTriggerEvents(key, oldValue, newValue string, d *schema.ResourceData) bool {
+	// The key is a path not the list itself, e.g. "events.0"
+	lastDotIndex := strings.LastIndex(key, ".")
+	if lastDotIndex != -1 {
+		key = string(key[:lastDotIndex])
+	}
+	oldData, newData := d.GetChange(key)
+	if oldData == nil || newData == nil {
+		return false
+	}
+	oldArray := oldData.([]interface{})
+	newArray := newData.([]interface{})
+	if len(oldArray) != len(newArray) {
+		// Items added or removed, always detect as changed
+		return false
+	}
+
+	// Convert data to string arrays
+	oldEvents := make([]string, len(oldArray))
+	newEvents := make([]string, len(newArray))
+	for i, oldEvt := range oldArray {
+		oldEvents[i] = fmt.Sprint(oldEvt)
+	}
+	for j, newEvt := range newArray {
+		newEvents[j] = fmt.Sprint(newEvt)
+	}
+	// Ensure consistent sorting before comparison, to suppress unnecessary change detections
+	sort.Strings(oldEvents)
+	sort.Strings(newEvents)
+	return reflect.DeepEqual(oldEvents, newEvents)
 }
 
 func SuppressAllowBlank(k, old, new string, d *schema.ResourceData) bool {

--- a/ibm/service/cdtektonpipeline/resource_ibm_cd_tekton_pipeline.go
+++ b/ibm/service/cdtektonpipeline/resource_ibm_cd_tekton_pipeline.go
@@ -423,10 +423,11 @@ func ResourceIBMCdTektonPipeline() *schema.Resource {
 							},
 						},
 						"events": &schema.Schema{
-							Type:        schema.TypeList,
-							Optional:    true,
-							Description: "Only needed for Git triggers. List of events to which a Git trigger listens. Choose one or more from: 'push', 'pull_request' and 'pull_request_closed'. For SCM repositories that use 'merge request' events, such events map to the equivalent 'pull request' events.",
-							Elem:        &schema.Schema{Type: schema.TypeString},
+							Type:             schema.TypeList,
+							Optional:         true,
+							DiffSuppressFunc: flex.SuppressTriggerEvents,
+							Description:      "Only needed for Git triggers. List of events to which a Git trigger listens. Choose one or more from: 'push', 'pull_request' and 'pull_request_closed'. For SCM repositories that use 'merge request' events, such events map to the equivalent 'pull request' events.",
+							Elem:             &schema.Schema{Type: schema.TypeString},
 						},
 						"cron": &schema.Schema{
 							Type:        schema.TypeString,

--- a/ibm/service/cdtektonpipeline/resource_ibm_cd_tekton_pipeline_trigger.go
+++ b/ibm/service/cdtektonpipeline/resource_ibm_cd_tekton_pipeline_trigger.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"sort"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -175,10 +176,11 @@ func ResourceIBMCdTektonPipelineTrigger() *schema.Resource {
 				},
 			},
 			"events": &schema.Schema{
-				Type:        schema.TypeList,
-				Optional:    true,
-				Description: "Only needed for Git triggers. List of events to which a Git trigger listens. Choose one or more from: 'push', 'pull_request' and 'pull_request_closed'. For SCM repositories that use 'merge request' events, such events map to the equivalent 'pull request' events.",
-				Elem:        &schema.Schema{Type: schema.TypeString},
+				Type:             schema.TypeList,
+				Optional:         true,
+				DiffSuppressFunc: flex.SuppressTriggerEvents,
+				Description:      "Only needed for Git triggers. List of events to which a Git trigger listens. Choose one or more from: 'push', 'pull_request' and 'pull_request_closed'. For SCM repositories that use 'merge request' events, such events map to the equivalent 'pull request' events.",
+				Elem:             &schema.Schema{Type: schema.TypeString},
 			},
 			"href": &schema.Schema{
 				Type:        schema.TypeString,
@@ -360,6 +362,7 @@ func resourceIBMCdTektonPipelineTriggerCreate(context context.Context, d *schema
 		for i, v := range eventsInterface {
 			events[i] = fmt.Sprint(v)
 		}
+		sort.Strings(events)
 		createTektonPipelineTriggerOptions.SetEvents(events)
 	}
 
@@ -593,6 +596,7 @@ func resourceIBMCdTektonPipelineTriggerUpdate(context context.Context, d *schema
 		for _, eventsItem := range d.Get("events").([]interface{}) {
 			events = append(events, eventsItem.(string))
 		}
+		sort.Strings(events)
 		patchVals.Events = events
 		hasChange = true
 	}


### PR DESCRIPTION
## Description
Suppress change detection for Tekton Trigger Events that occurs due to the order of items in the array being inconsistent.

Making use of this workaround: https://github.com/hashicorp/terraform-plugin-sdk/issues/477#issuecomment-1238807249

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TEST=./ibm/service/cdtektonpipeline TESTARGS='-run=TestAccIBMCdTekton*'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./ibm/service/cdtektonpipeline -v -run=TestAccIBMCdTekton* -timeout 700m
=== RUN   TestAccIBMCdTektonPipelineDefinitionDataSourceBasic
--- PASS: TestAccIBMCdTektonPipelineDefinitionDataSourceBasic (94.68s)
=== RUN   TestAccIBMCdTektonPipelinePropertyDataSourceBasic
--- PASS: TestAccIBMCdTektonPipelinePropertyDataSourceBasic (90.20s)
=== RUN   TestAccIBMCdTektonPipelinePropertyDataSourceAllArgs
--- PASS: TestAccIBMCdTektonPipelinePropertyDataSourceAllArgs (89.42s)
=== RUN   TestAccIBMCdTektonPipelineDataSourceBasic
--- PASS: TestAccIBMCdTektonPipelineDataSourceBasic (70.55s)
=== RUN   TestAccIBMCdTektonPipelineDataSourceAllArgs
--- PASS: TestAccIBMCdTektonPipelineDataSourceAllArgs (90.07s)
=== RUN   TestAccIBMCdTektonPipelineTriggerPropertyDataSourceBasic
--- PASS: TestAccIBMCdTektonPipelineTriggerPropertyDataSourceBasic (101.87s)
=== RUN   TestAccIBMCdTektonPipelineTriggerPropertyDataSourceAllArgs
--- PASS: TestAccIBMCdTektonPipelineTriggerPropertyDataSourceAllArgs (102.41s)
=== RUN   TestAccIBMCdTektonPipelineTriggerDataSourceBasic
--- PASS: TestAccIBMCdTektonPipelineTriggerDataSourceBasic (95.49s)
=== RUN   TestAccIBMCdTektonPipelineTriggerDataSourceAllArgs
--- PASS: TestAccIBMCdTektonPipelineTriggerDataSourceAllArgs (93.35s)
=== RUN   TestAccIBMCdTektonPipelineDefinitionBasic
--- PASS: TestAccIBMCdTektonPipelineDefinitionBasic (88.83s)
=== RUN   TestAccIBMCdTektonPipelinePropertyBasic
--- PASS: TestAccIBMCdTektonPipelinePropertyBasic (121.00s)
=== RUN   TestAccIBMCdTektonPipelinePropertyAllArgs
--- PASS: TestAccIBMCdTektonPipelinePropertyAllArgs (144.00s)
=== RUN   TestAccIBMCdTektonPipelineBasic
--- PASS: TestAccIBMCdTektonPipelineBasic (78.74s)
=== RUN   TestAccIBMCdTektonPipelineAllArgs
--- PASS: TestAccIBMCdTektonPipelineAllArgs (119.48s)
=== RUN   TestAccIBMCdTektonPipelineTriggerPropertyBasic
--- PASS: TestAccIBMCdTektonPipelineTriggerPropertyBasic (151.01s)
=== RUN   TestAccIBMCdTektonPipelineTriggerPropertyAllArgs
--- PASS: TestAccIBMCdTektonPipelineTriggerPropertyAllArgs (178.44s)
=== RUN   TestAccIBMCdTektonPipelineTriggerBasic
--- PASS: TestAccIBMCdTektonPipelineTriggerBasic (132.65s)
=== RUN   TestAccIBMCdTektonPipelineTriggerAllArgs
--- PASS: TestAccIBMCdTektonPipelineTriggerAllArgs (173.53s)
PASS
ok      github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/cdtektonpipeline        2016.140s
...
```
