### PR TITLE
don't throw exception for list TP datsource when there is no TP in the account

### DIFF
--- a/ibm/acctest/acctest.go
+++ b/ibm/acctest/acctest.go
@@ -30,6 +30,7 @@ var CosName string
 var Ibmid1 string
 var Ibmid2 string
 var IAMUser string
+var IAMAccountId string
 var Datacenter string
 var MachineType string
 var trustedMachineType string
@@ -287,6 +288,11 @@ func init() {
 	IAMUser = os.Getenv("IBM_IAMUSER")
 	if IAMUser == "" {
 		fmt.Println("[WARN] Set the environment variable IBM_IAMUSER for testing ibm_iam_user_policy resource Some tests for that resource will fail if this is not set correctly")
+	}
+
+	IAMAccountId = os.Getenv("IBM_IAMACCOUNTID")
+	if IAMAccountId == "" {
+		fmt.Println("[WARN] Set the environment variable IBM_IAMACCOUNTID for testing ibm_iam_trusted_profile resource Some tests for that resource will fail if this is not set correctly")
 	}
 
 	Datacenter = os.Getenv("IBM_DATACENTER")

--- a/ibm/service/iamidentity/data_source_ibm_iam_trusted_profiles.go
+++ b/ibm/service/iamidentity/data_source_ibm_iam_trusted_profiles.go
@@ -213,10 +213,6 @@ func dataSourceIBMIamTrustedProfileListRead(context context.Context, d *schema.R
 			break
 		}
 	}
-	if len(allrecs) == 0 {
-		return diag.FromErr(fmt.Errorf("[ERROR] No profiles found [%s]", accountID))
-
-	}
 
 	d.SetId(dataSourceIBMIamTrustedProfileListID(d))
 

--- a/ibm/service/iamidentity/data_source_ibm_iam_trusted_profiles_test.go
+++ b/ibm/service/iamidentity/data_source_ibm_iam_trusted_profiles_test.go
@@ -4,6 +4,7 @@
 package iamidentity_test
 
 import (
+	"fmt"
 	"testing"
 
 	acc "github.com/IBM-Cloud/terraform-provider-ibm/ibm/acctest"
@@ -30,9 +31,11 @@ func TestAccIBMIamTrustedProfilesDataSourceBasic(t *testing.T) {
 }
 
 func testAccCheckIBMIamTrustedProfilesDataSourceConfigBasic() string {
-	return `
+	return fmt.Sprintf(`
+
 		data "ibm_iam_trusted_profiles" "iam_trusted_profiles" {
+			account_id = "%s"
 			name = "name"
 		}
-	`
+	`, acc.IAMAccountId)
 }


### PR DESCRIPTION

<!--- See what makes a good Pull Request at : https://github.com/IBM-Cloud/terraform-provider-ibm/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```
