### PR TITLE
Add sample Elasticsearch enterprise instance for Docs

### DIFF
--- a/website/docs/r/database.html.markdown
+++ b/website/docs/r/database.html.markdown
@@ -460,7 +460,8 @@ resource "ibm_database" "edb" {
 ```
 
 ### Sample Elasticsearch Enterprise instance
-```
+
+```terraform
 	data "ibm_resource_group" "test_acc" {
 		is_default = true
 	}

--- a/website/docs/r/database.html.markdown
+++ b/website/docs/r/database.html.markdown
@@ -462,48 +462,48 @@ resource "ibm_database" "edb" {
 ### Sample Elasticsearch Enterprise instance
 
 ```terraform
-	data "ibm_resource_group" "test_acc" {
-		is_default = true
-	}
+data "ibm_resource_group" "test_acc" {
+  is_default = true
+}
 
-	resource "ibm_database" "es" {
-		resource_group_id            = data.ibm_resource_group.test_acc.id
-		name                         = "es-enterprise"
-		service                      = "databases-for-elasticsearch"
-		plan                         = "enterprise"
-		location                     = "eu-gb"
-		adminpassword                = "password12"
-		version                      = "7.17"
-		group {
-			group_id = "member"
-			members {
-			  allocation_count = 3
-			}
-			memory {
-			  allocation_mb = 1024
-			}
-			disk {
-			  allocation_mb = 5120
-			}
-			cpu {
-			  allocation_count = 3
-			}
-		}
-		users {
-		  name     = "user123"
-		  password = "password12"
-		}
-		allowlist {
-		  address     = "172.168.1.2/32"
-		  description = "desc1"
-		}
+resource "ibm_database" "es" {
+  resource_group_id            = data.ibm_resource_group.test_acc.id
+  name                         = "es-enterprise"
+  service                      = "databases-for-elasticsearch"
+  plan                         = "enterprise"
+  location                     = "eu-gb"
+  adminpassword                = "password12"
+  version                      = "7.17"
+  group {
+    group_id = "member"
+    members {
+      allocation_count = 3
+    }
+    memory {
+      allocation_mb = 1024
+    }
+    disk {
+      allocation_mb = 5120
+    }
+    cpu {
+      allocation_count = 3
+    }
+  }
+  users {
+    name     = "user123"
+    password = "password12"
+  }
+  allowlist {
+    address     = "172.168.1.2/32"
+    description = "desc1"
+  }
 
-		timeouts {
-			create = "120m"
-			update = "120m"
-			delete = "15m"
-		}
-	}
+  timeouts {
+    create = "120m"
+    update = "120m"
+    delete = "15m"
+  }
+}
 ```
 ### Updating configuration for postgres database
 

--- a/website/docs/r/database.html.markdown
+++ b/website/docs/r/database.html.markdown
@@ -458,6 +458,52 @@ resource "ibm_database" "edb" {
   }
 }
 ```
+
+### Sample Elasticsearch Enterprise instance
+```
+	data "ibm_resource_group" "test_acc" {
+		is_default = true
+	}
+
+	resource "ibm_database" "es" {
+		resource_group_id            = data.ibm_resource_group.test_acc.id
+		name                         = "es-enterprise"
+		service                      = "databases-for-elasticsearch"
+		plan                         = "enterprise"
+		location                     = "eu-gb"
+		adminpassword                = "password12"
+    version                      = "7.17"
+		group {
+			group_id = "member"
+			members {
+			  allocation_count = 3
+			}
+			memory {
+			  allocation_mb = 1024
+			}
+			disk {
+			  allocation_mb = 5120
+			}
+			cpu {
+			  allocation_count = 3
+			}
+		}
+		users {
+		  name     = "user123"
+		  password = "password12"
+		}
+		allowlist {
+		  address     = "172.168.1.2/32"
+		  description = "desc1"
+		}
+
+		timeouts {
+			create = "120m"
+			update = "120m"
+			delete = "15m"
+		}
+	}
+```
 ### Updating configuration for postgres database
 
 ```terraform

--- a/website/docs/r/database.html.markdown
+++ b/website/docs/r/database.html.markdown
@@ -473,7 +473,7 @@ resource "ibm_database" "edb" {
 		plan                         = "enterprise"
 		location                     = "eu-gb"
 		adminpassword                = "password12"
-    version                      = "7.17"
+		version                      = "7.17"
 		group {
 			group_id = "member"
 			members {


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/IBM-Cloud/terraform-provider-ibm/blob/master/.github/CONTRIBUTING.md --->

As part of elasticsearch enterprise GA we need to add a sample in our docs so users know how to provision an elasticsearch enterprise instance.

I've gone ahead and added a working sample for users.

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000
