### PR TITLE
Add Code engine secret resource

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "go.mod|go.sum|.*.map|^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2023-04-14T18:19:39Z",
+  "generated_at": "2023-04-14T18:34:02Z",
   "plugins_used": [
     {
       "name": "ArtifactoryDetector"
@@ -1734,6 +1734,36 @@
         "is_verified": false,
         "line_number": 604,
         "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "ibm/service/codeengine/resource_ibm_code_engine_secret_test.go": [
+      {
+        "hashed_secret": "05f899c96f7e8d7874797a5fa19902a12bd47b79",
+        "is_verified": false,
+        "line_number": 80,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "b10b32fc1b6d1a4a455c44de75d5a8ab9386068d",
+        "is_verified": false,
+        "line_number": 128,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "a2ff1f57ccf7131152dd24b9360d2c02b87e2166",
+        "is_verified": false,
+        "line_number": 135,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "1348b145fa1a555461c1b790a2f66614781091e9",
+        "is_verified": false,
+        "line_number": 276,
+        "type": "Private Key",
         "verified_result": null
       }
     ],

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -1740,6 +1740,7 @@
     "ibm/service/codeengine/resource_ibm_code_engine_secret_test.go": [
       {
         "hashed_secret": "05f899c96f7e8d7874797a5fa19902a12bd47b79",
+        "is_secret": false,
         "is_verified": false,
         "line_number": 80,
         "type": "Secret Keyword",
@@ -1747,6 +1748,7 @@
       },
       {
         "hashed_secret": "b10b32fc1b6d1a4a455c44de75d5a8ab9386068d",
+        "is_secret": false,
         "is_verified": false,
         "line_number": 128,
         "type": "Secret Keyword",
@@ -1754,6 +1756,7 @@
       },
       {
         "hashed_secret": "a2ff1f57ccf7131152dd24b9360d2c02b87e2166",
+        "is_secret": false,
         "is_verified": false,
         "line_number": 135,
         "type": "Secret Keyword",
@@ -1761,6 +1764,7 @@
       },
       {
         "hashed_secret": "1348b145fa1a555461c1b790a2f66614781091e9",
+        "is_secret": false,
         "is_verified": false,
         "line_number": 276,
         "type": "Private Key",

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "go.mod|go.sum|.*.map|^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2023-04-10T12:58:09Z",
+  "generated_at": "2023-04-14T18:19:39Z",
   "plugins_used": [
     {
       "name": "ArtifactoryDetector"
@@ -410,7 +410,7 @@
         "hashed_secret": "dc61ac50e6f36d09340d8ca062da1f0d4215004f",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 59,
+        "line_number": 60,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -704,7 +704,7 @@
         "hashed_secret": "813274ccae5b6b509379ab56982d862f7b5969b6",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 925,
+        "line_number": 965,
         "type": "Base64 High Entropy String",
         "verified_result": null
       }
@@ -714,7 +714,7 @@
         "hashed_secret": "9184b0c38101bf24d78b2bb0d044deb1d33696fc",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 132,
+        "line_number": 131,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -722,7 +722,7 @@
         "hashed_secret": "c427f185ddcb2440be9b77c8e45f1cd487a2e790",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1437,
+        "line_number": 1426,
         "type": "Base64 High Entropy String",
         "verified_result": null
       },
@@ -730,7 +730,7 @@
         "hashed_secret": "1f7e33de15e22de9d2eaf502df284ed25ca40018",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1505,
+        "line_number": 1494,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -738,7 +738,7 @@
         "hashed_secret": "1f614c2eb6b3da22d89bd1b9fd47d7cb7c8fc670",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 3335,
+        "line_number": 3318,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -746,7 +746,7 @@
         "hashed_secret": "7abfce65b8504403afc25c9790f358d513dfbcc6",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 3348,
+        "line_number": 3331,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -754,7 +754,7 @@
         "hashed_secret": "0c2d85bf9a9b1579b16f220a4ea8c3d62b2e24b1",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 3389,
+        "line_number": 3372,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -784,7 +784,7 @@
         "hashed_secret": "c8b6f5ef11b9223ac35a5663975a466ebe7ebba9",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1646,
+        "line_number": 1657,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -792,7 +792,7 @@
         "hashed_secret": "8abf4899c01104241510ba87685ad4de76b0c437",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1652,
+        "line_number": 1663,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -1368,7 +1368,7 @@
         "hashed_secret": "563feb86d4a90eb00c8d274d0aa8528b929f21d3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 194,
+        "line_number": 196,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -1646,7 +1646,7 @@
         "hashed_secret": "b732fb611fd46a38e8667f9972e0cde777fbe37f",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 583,
+        "line_number": 582,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1654,7 +1654,7 @@
         "hashed_secret": "3c956707ac29b4a200e47fceffa923341eed7e4f",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 768,
+        "line_number": 771,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -4282,7 +4282,7 @@
         "hashed_secret": "10c28f9cf0668595d45c1090a7b4a2ae98edfa58",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 445,
+        "line_number": 494,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -4290,7 +4290,7 @@
         "hashed_secret": "e407cbe1c64cadb886be6f42907e2dd1c06ca080",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 512,
+        "line_number": 559,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -4298,7 +4298,7 @@
         "hashed_secret": "91199272d5d6a574a51722ca6f3d1148edb1a0e7",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 536,
+        "line_number": 583,
         "type": "Secret Keyword",
         "verified_result": null
       }

--- a/examples/ibm-code-engine/README.md
+++ b/examples/ibm-code-engine/README.md
@@ -9,6 +9,7 @@ These types of resources are supported:
 * code_engine_build
 * code_engine_config_map
 * code_engine_job
+* code_engine_secret
 
 ## Usage
 
@@ -89,6 +90,17 @@ resource "ibm_code_engine_job" "code_engine_job_instance" {
 
 ```
 
+code_engine_secret resource:
+
+```hcl
+resource "code_engine_secret" "code_engine_secret_instance" {
+  project_id = var.code_engine_secret_project_id
+  format     = var.code_engine_secret_format
+  name       = var.code_engine_secret_name
+  data       = var.code_engine_secret_data
+}
+```
+
 ## CodeEngineV2 Data sources
 
 code_engine_project data source:
@@ -139,7 +151,7 @@ data "code_engine_project" "code_engine_project_instance" {
 | project_id | The ID of the project. | `string` | true |
 | data | The key-value pair for the config map. Values must be specified in `KEY=VALUE` format. Each `KEY` field must consist of alphanumeric characters, `-`, `_` or `.` and must not be exceed a max length of 253 characters. Each `VALUE` field can consists of any character and must not be exceed a max length of 1048576 characters. | `map(string)` | false |
 | project_id | The ID of the project. | `string` | true |
-| image_reference | The name of the image that is used for this app/job. The format is `REGISTRY/NAMESPACE/REPOSITORY:TAG` where `REGISTRY` and `TAG` are optional. If `REGISTRY` is not specified, the default is `docker.io`. If `TAG` is not specified, the default is `latest`. If the image reference points to a registry that requires authentication, make sure to also specify the property `image_secret`. | `string` | true |
+| image_reference | The name of the image that is used for this job. The format is `REGISTRY/NAMESPACE/REPOSITORY:TAG` where `REGISTRY` and `TAG` are optional. If `REGISTRY` is not specified, the default is `docker.io`. If `TAG` is not specified, the default is `latest`. If the image reference points to a registry that requires authentication, make sure to also specify the property `image_secret`. | `string` | true |
 | image_secret | The name of the image registry access secret. The image registry access secret is used to authenticate with a private registry when you download the container image. If the image reference points to a registry that requires authentication, the job / job runs will be created but submitted job runs will fail, until this property is provided, too. This property must not be set on a job run, which references a job template. | `string` | false |
 | run_arguments | Set arguments for the job that are passed to start job run containers. If not specified an empty string array will be applied and the arguments specified by the container image, will be used to start the container. | `list(string)` | false |
 | run_as_user | The user ID (UID) to run the application (e.g., 1001). | `number` | false |
@@ -157,6 +169,7 @@ data "code_engine_project" "code_engine_project_instance" {
 | resource_group_id | Optional ID of the resource group for your project deployment. If this field is not defined, the default resource group of the account will be used. | `string` | false |
 | project_id | The ID of the project. | `string` | true |
 | data | Data container that allows to specify config parameters and their values as a key-value map. Each key field must consist of alphanumeric characters, `-`, `_` or `.` and must not be exceed a max length of 253 characters. Each value field can consists of any character and must not be exceed a max length of 1048576 characters. | `map(string)` | false |
+| format | Specify the format of the secret. | `string` | true |
 
 ## Outputs
 
@@ -167,3 +180,4 @@ data "code_engine_project" "code_engine_project_instance" {
 | code_engine_build | code_engine_build object |
 | code_engine_config_map | code_engine_config_map object |
 | code_engine_job | code_engine_job object |
+| code_engine_secret | code_engine_secret object |

--- a/examples/ibm-code-engine/main.tf
+++ b/examples/ibm-code-engine/main.tf
@@ -10,6 +10,14 @@ resource "ibm_code_engine_config_map" "code_engine_config_map_instance" {
   data       = var.code_engine_config_map_data
 }
 
+// Provision code_engine_secret resource instance
+resource "ibm_code_engine_secret" "code_engine_secret_instance" {
+  project_id = ibm_code_engine_project.code_engine_project_instance.project_id
+  name       = var.code_engine_secret_name
+  format     = var.code_engine_secret_format
+  data       = var.code_engine_secret_data
+}
+
 // Provision code_engine_app resource instance
 resource "ibm_code_engine_app" "code_engine_app_instance" {
   project_id      = ibm_code_engine_project.code_engine_project_instance.project_id

--- a/examples/ibm-code-engine/outputs.tf
+++ b/examples/ibm-code-engine/outputs.tf
@@ -23,6 +23,12 @@ output "ibm_code_engine_config_map" {
   value       = ibm_code_engine_config_map.code_engine_config_map_instance
   description = "code_engine_config_map resource instance"
 }
+// This allows code_engine_secret data to be referenced by other resources and the terraform CLI
+// Modify this if only certain data should be exposed
+output "ibm_code_engine_secret" {
+  value       = ibm_code_engine_secret.code_engine_secret_instance
+  description = "code_engine_secret resource instance"
+}
 // This allows code_engine_job data to be referenced by other resources and the terraform CLI
 // Modify this if only certain data should be exposed
 output "ibm_code_engine_job" {

--- a/examples/ibm-code-engine/variables.tf
+++ b/examples/ibm-code-engine/variables.tf
@@ -61,6 +61,23 @@ variable "code_engine_config_map_data" {
   default     = { "key" = "inner" }
 }
 
+// Resource arguments for code_engine_secret
+variable "code_engine_secret_name" {
+  description = "The name of the secret. Use a name that is unique within the project."
+  type        = string
+  default     = "my-secret"
+}
+variable "code_engine_secret_format" {
+  description = "The format of the secret. Use a name that is unique within the project."
+  type        = string
+  default     = "generic"
+}
+variable "code_engine_secret_data" {
+  description = "The key-value pair for the secret. Values must be specified in `KEY=VALUE` format. Each `KEY` field must consist of alphanumeric characters, `-`, `_` or `.` and must not be exceed a max length of 253 characters. Each `VALUE` field can consists of any character and must not be exceed a max length of 1048576 characters."
+  type        = map(string)
+  default     = { "key" = "inner" }
+}
+
 // Resource arguments for code_engine_job
 variable "code_engine_job_image_reference" {
   description = "The name of the image that is used for this job. The format is `REGISTRY/NAMESPACE/REPOSITORY:TAG` where `REGISTRY` and `TAG` are optional. If `REGISTRY` is not specified, the default is `docker.io`. If `TAG` is not specified, the default is `latest`. If the image reference points to a registry that requires authentication, make sure to also specify the property `image_secret`."

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/IBM/appid-management-go-sdk v0.0.0-20210908164609-dd0e0eaf732f
 	github.com/IBM/cloud-databases-go-sdk v0.3.1
 	github.com/IBM/cloudant-go-sdk v0.0.43
-	github.com/IBM/code-engine-go-sdk v0.0.0-20221209153711-82472bae75eb
+	github.com/IBM/code-engine-go-sdk v0.0.0-20230324212854-743a707334f6
 	github.com/IBM/container-registry-go-sdk v0.0.15
 	github.com/IBM/continuous-delivery-go-sdk v1.1.0
 	github.com/IBM/event-notifications-go-admin-sdk v0.2.1

--- a/go.sum
+++ b/go.sum
@@ -53,8 +53,8 @@ github.com/IBM/cloud-databases-go-sdk v0.3.1 h1:wmR9RX9aFUtW1EPrgHGvE6nruGilW8Xr
 github.com/IBM/cloud-databases-go-sdk v0.3.1/go.mod h1:o05Dt04BOr+0ArQPeAEeZBBYK3Fe7vQwShX/6PJvh4Q=
 github.com/IBM/cloudant-go-sdk v0.0.43 h1:YxTy4RpAEezX32YIWnds76hrBREmO4u6IkBz1WylNuQ=
 github.com/IBM/cloudant-go-sdk v0.0.43/go.mod h1:WeYrJPaHTw19943ndWnVfwMIlZ5z0XUM2uEXNBrwZ1M=
-github.com/IBM/code-engine-go-sdk v0.0.0-20221209153711-82472bae75eb h1:lBjqyTOY0qhAmmZLT4ERQbW90FUEH6MyQAM2DUNuC94=
-github.com/IBM/code-engine-go-sdk v0.0.0-20221209153711-82472bae75eb/go.mod h1:X2Qj8n5L7Y47y8GR5Pxr/nxwOWhefGebRC8GGiOTvdk=
+github.com/IBM/code-engine-go-sdk v0.0.0-20230324212854-743a707334f6 h1:PlYtJ+VZ1CLuhDiB1ldGW5uJBbnKG6CBIEblgU5b5mY=
+github.com/IBM/code-engine-go-sdk v0.0.0-20230324212854-743a707334f6/go.mod h1:IP6U/1NxgxzPeYdyiEwMaZyzelTw82JGHWl7bY78eQM=
 github.com/IBM/container-registry-go-sdk v0.0.15 h1:sfEXm4qNj9ZCwTlFOsdjF5P/lvajU/Sc22yNlzg0F9I=
 github.com/IBM/container-registry-go-sdk v0.0.15/go.mod h1:KqSZFO4VIK9QAyF8O1JW6jkyzkfE/BNKUIo+OdzIDk4=
 github.com/IBM/continuous-delivery-go-sdk v1.1.0 h1:E0hPM4H7Bmn31+4UAMavBngRjTMoqbjkBb4AlIgi0tA=

--- a/ibm/provider/provider.go
+++ b/ibm/provider/provider.go
@@ -1256,6 +1256,7 @@ func Provider() *schema.Provider {
 			"ibm_code_engine_config_map": codeengine.ResourceIbmCodeEngineConfigMap(),
 			"ibm_code_engine_job":        codeengine.ResourceIbmCodeEngineJob(),
 			"ibm_code_engine_project":    codeengine.ResourceIbmCodeEngineProject(),
+			"ibm_code_engine_secret":     codeengine.ResourceIbmCodeEngineSecret(),
 		},
 
 		ConfigureFunc: providerConfigure,
@@ -1489,6 +1490,7 @@ func Validator() validate.ValidatorDict {
 				"ibm_code_engine_config_map": codeengine.ResourceIbmCodeEngineConfigMapValidator(),
 				"ibm_code_engine_job":        codeengine.ResourceIbmCodeEngineJobValidator(),
 				"ibm_code_engine_project":    codeengine.ResourceIbmCodeEngineProjectValidator(),
+				"ibm_code_engine_secret":     codeengine.ResourceIbmCodeEngineSecretValidator(),
 			},
 			DataSourceValidatorDictionary: map[string]*validate.ResourceValidator{
 				"ibm_is_subnet":          vpc.DataSourceIBMISSubnetValidator(),

--- a/ibm/service/codeengine/resource_ibm_code_engine_app.go
+++ b/ibm/service/codeengine/resource_ibm_code_engine_app.go
@@ -751,10 +751,6 @@ func resourceIbmCodeEngineAppUpdate(context context.Context, d *schema.ResourceD
 	hasChange := false
 
 	patchVals := &codeenginev2.AppPatch{}
-	if d.HasChange("project_id") {
-		return diag.FromErr(fmt.Errorf("Cannot update resource property \"%s\" with the ForceNew annotation."+
-			" The resource must be re-created to update this property.", "project_id"))
-	}
 	if d.HasChange("image_reference") || d.HasChange("name") {
 		newImageReference := d.Get("image_reference").(string)
 		patchVals.ImageReference = &newImageReference

--- a/ibm/service/codeengine/resource_ibm_code_engine_app.go
+++ b/ibm/service/codeengine/resource_ibm_code_engine_app.go
@@ -83,7 +83,6 @@ func ResourceIbmCodeEngineApp() *schema.Resource {
 			"run_as_user": &schema.Schema{
 				Type:        schema.TypeInt,
 				Optional:    true,
-				Default:     0,
 				Description: "Optional user ID (UID) to run the app (e.g., `1001`).",
 			},
 			"run_commands": &schema.Schema{
@@ -515,7 +514,7 @@ func waitForIbmCodeEngineAppCreate(d *schema.ResourceData, meta interface{}) (in
 
 	stateConf := &resource.StateChangeConf{
 		Pending: []string{"deploying"},
-		Target:  []string{"ready"},
+		Target:  []string{"ready", "failed", "warning"},
 		Refresh: func() (interface{}, string, error) {
 			stateObj, response, err := codeEngineClient.GetApp(getAppOptions)
 			if err != nil {
@@ -524,15 +523,15 @@ func waitForIbmCodeEngineAppCreate(d *schema.ResourceData, meta interface{}) (in
 				}
 				return nil, "", err
 			}
-			failStates := map[string]bool{"failed": true, "warning": true}
+			failStates := map[string]bool{"failure": true, "failed": true}
 			if failStates[*stateObj.Status] {
 				return stateObj, *stateObj.Status, fmt.Errorf("The instance %s failed: %s\n%s", "getAppOptions", err, response)
 			}
 			return stateObj, *stateObj.Status, nil
 		},
 		Timeout:    d.Timeout(schema.TimeoutCreate),
-		Delay:      20 * time.Second,
-		MinTimeout: 20 * time.Second,
+		Delay:      60 * time.Second,
+		MinTimeout: 60 * time.Second,
 	}
 
 	return stateConf.WaitForState()
@@ -752,6 +751,10 @@ func resourceIbmCodeEngineAppUpdate(context context.Context, d *schema.ResourceD
 	hasChange := false
 
 	patchVals := &codeenginev2.AppPatch{}
+	if d.HasChange("project_id") {
+		return diag.FromErr(fmt.Errorf("Cannot update resource property \"%s\" with the ForceNew annotation."+
+			" The resource must be re-created to update this property.", "project_id"))
+	}
 	if d.HasChange("image_reference") || d.HasChange("name") {
 		newImageReference := d.Get("image_reference").(string)
 		patchVals.ImageReference = &newImageReference

--- a/ibm/service/codeengine/resource_ibm_code_engine_secret.go
+++ b/ibm/service/codeengine/resource_ibm_code_engine_secret.go
@@ -255,10 +255,6 @@ func resourceIbmCodeEngineSecretUpdate(context context.Context, d *schema.Resour
 
 	hasChange := false
 
-	if d.HasChange("project_id") {
-		return diag.FromErr(fmt.Errorf("Cannot update resource property \"%s\" with the ForceNew annotation."+
-			" The resource must be re-created to update this property.", "project_id"))
-	}
 	if d.HasChange("format") {
 		return diag.FromErr(fmt.Errorf("Cannot update resource property \"%s\" with the ForceNew annotation."+
 			" The resource must be re-created to update this property.", "format"))

--- a/ibm/service/codeengine/resource_ibm_code_engine_secret.go
+++ b/ibm/service/codeengine/resource_ibm_code_engine_secret.go
@@ -1,0 +1,328 @@
+// Copyright IBM Corp. 2023 All Rights Reserved.
+// Licensed under the Mozilla Public License v2.0
+
+package codeengine
+
+import (
+	"context"
+	"fmt"
+	"log"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/conns"
+	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/flex"
+	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/validate"
+	"github.com/IBM/code-engine-go-sdk/codeenginev2"
+	"github.com/IBM/go-sdk-core/v5/core"
+)
+
+func ResourceIbmCodeEngineSecret() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceIbmCodeEngineSecretCreate,
+		ReadContext:   resourceIbmCodeEngineSecretRead,
+		UpdateContext: resourceIbmCodeEngineSecretUpdate,
+		DeleteContext: resourceIbmCodeEngineSecretDelete,
+		Importer:      &schema.ResourceImporter{},
+
+		Schema: map[string]*schema.Schema{
+			"project_id": &schema.Schema{
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: validate.InvokeValidator("ibm_code_engine_secret", "project_id"),
+				Description:  "The ID of the project.",
+			},
+			"format": &schema.Schema{
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: validate.InvokeValidator("ibm_code_engine_secret", "format"),
+				Description:  "Specify the format of the secret.",
+			},
+			"name": &schema.Schema{
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: validate.InvokeValidator("ibm_code_engine_secret", "name"),
+				Description:  "The name of the secret.",
+			},
+			"data": &schema.Schema{
+				Type:      schema.TypeMap,
+				Optional:  true,
+				Sensitive: true,
+				Elem:      &schema.Schema{Type: schema.TypeString},
+			},
+			"created_at": &schema.Schema{
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The timestamp when the resource was created.",
+			},
+			"entity_tag": &schema.Schema{
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The version of the secret instance, which is used to achieve optimistic locking.",
+			},
+			"href": &schema.Schema{
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "When you provision a new secret,  a URL is created identifying the location of the instance.",
+			},
+			"id": &schema.Schema{
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The identifier of the resource.",
+			},
+			"resource_type": &schema.Schema{
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The type of the secret.",
+			},
+			"secret_id": &schema.Schema{
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The identifier of the resource.",
+			},
+			"etag": &schema.Schema{
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func ResourceIbmCodeEngineSecretValidator() *validate.ResourceValidator {
+	validateSchema := make([]validate.ValidateSchema, 0)
+	validateSchema = append(validateSchema,
+		validate.ValidateSchema{
+			Identifier:                 "project_id",
+			ValidateFunctionIdentifier: validate.ValidateRegexpLen,
+			Type:                       validate.TypeString,
+			Required:                   true,
+			Regexp:                     `^[0-9a-z]{8}-[0-9a-z]{4}-[0-9a-z]{4}-[0-9a-z]{4}-[0-9a-z]{12}$`,
+			MinValueLength:             36,
+			MaxValueLength:             36,
+		},
+		validate.ValidateSchema{
+			Identifier:                 "format",
+			ValidateFunctionIdentifier: validate.ValidateAllowedStringValue,
+			Type:                       validate.TypeString,
+			Required:                   true,
+			AllowedValues:              "basic_auth, generic, registry, ssh_auth, tls",
+			Regexp:                     `^(generic|ssh_auth|basic_auth|tls|registry)$`,
+		},
+		validate.ValidateSchema{
+			Identifier:                 "name",
+			ValidateFunctionIdentifier: validate.ValidateRegexpLen,
+			Type:                       validate.TypeString,
+			Required:                   true,
+			Regexp:                     `^[a-z0-9]([\-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([\-a-z0-9]*[a-z0-9])?)*$`,
+			MinValueLength:             1,
+			MaxValueLength:             253,
+		},
+	)
+
+	resourceValidator := validate.ResourceValidator{ResourceName: "ibm_code_engine_secret", Schema: validateSchema}
+	return &resourceValidator
+}
+
+func resourceIbmCodeEngineSecretCreate(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	codeEngineClient, err := meta.(conns.ClientSession).CodeEngineV2()
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	createSecretOptions := &codeenginev2.CreateSecretOptions{}
+
+	createSecretOptions.SetProjectID(d.Get("project_id").(string))
+	createSecretOptions.SetFormat(d.Get("format").(string))
+	createSecretOptions.SetName(d.Get("name").(string))
+	if _, ok := d.GetOk("data"); ok {
+		dataModel, err := resourceIbmCodeEngineSecretMapToSecretData(d.Get("data").(map[string]interface{}))
+		if err != nil {
+			return diag.FromErr(err)
+		}
+		createSecretOptions.SetData(dataModel)
+	}
+
+	secret, response, err := codeEngineClient.CreateSecretWithContext(context, createSecretOptions)
+	if err != nil {
+		log.Printf("[DEBUG] CreateSecretWithContext failed %s\n%s", err, response)
+		return diag.FromErr(fmt.Errorf("CreateSecretWithContext failed %s\n%s", err, response))
+	}
+
+	d.SetId(fmt.Sprintf("%s/%s", *createSecretOptions.ProjectID, *secret.Name))
+
+	return resourceIbmCodeEngineSecretRead(context, d, meta)
+}
+
+func resourceIbmCodeEngineSecretRead(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	codeEngineClient, err := meta.(conns.ClientSession).CodeEngineV2()
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	getSecretOptions := &codeenginev2.GetSecretOptions{}
+
+	parts, err := flex.SepIdParts(d.Id(), "/")
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	getSecretOptions.SetProjectID(parts[0])
+	getSecretOptions.SetName(parts[1])
+
+	secret, response, err := codeEngineClient.GetSecretWithContext(context, getSecretOptions)
+	if err != nil {
+		if response != nil && response.StatusCode == 404 {
+			d.SetId("")
+			return nil
+		}
+		log.Printf("[DEBUG] GetSecretWithContext failed %s\n%s", err, response)
+		return diag.FromErr(fmt.Errorf("GetSecretWithContext failed %s\n%s", err, response))
+	}
+
+	if err = d.Set("project_id", secret.ProjectID); err != nil {
+		return diag.FromErr(fmt.Errorf("Error setting project_id: %s", err))
+	}
+	if err = d.Set("format", secret.Format); err != nil {
+		return diag.FromErr(fmt.Errorf("Error setting format: %s", err))
+	}
+	if err = d.Set("name", secret.Name); err != nil {
+		return diag.FromErr(fmt.Errorf("Error setting name: %s", err))
+	}
+	if !core.IsNil(secret.Data) {
+		data := make(map[string]string)
+		for k, v := range secret.Data {
+			data[k] = string(v)
+		}
+		if err = d.Set("data", data); err != nil {
+			return diag.FromErr(fmt.Errorf("Error setting data: %s", err))
+		}
+	}
+	if !core.IsNil(secret.CreatedAt) {
+		if err = d.Set("created_at", secret.CreatedAt); err != nil {
+			return diag.FromErr(fmt.Errorf("Error setting created_at: %s", err))
+		}
+	}
+	if err = d.Set("entity_tag", secret.EntityTag); err != nil {
+		return diag.FromErr(fmt.Errorf("Error setting entity_tag: %s", err))
+	}
+	if !core.IsNil(secret.Href) {
+		if err = d.Set("href", secret.Href); err != nil {
+			return diag.FromErr(fmt.Errorf("Error setting href: %s", err))
+		}
+	}
+	if !core.IsNil(secret.ID) {
+		if err = d.Set("id", secret.ID); err != nil {
+			return diag.FromErr(fmt.Errorf("Error setting id: %s", err))
+		}
+	}
+	if !core.IsNil(secret.ResourceType) {
+		if err = d.Set("resource_type", secret.ResourceType); err != nil {
+			return diag.FromErr(fmt.Errorf("Error setting resource_type: %s", err))
+		}
+	}
+	if !core.IsNil(secret.ID) {
+		if err = d.Set("secret_id", secret.ID); err != nil {
+			return diag.FromErr(fmt.Errorf("Error setting secret_id: %s", err))
+		}
+	}
+	if err = d.Set("etag", response.Headers.Get("Etag")); err != nil {
+		return diag.FromErr(fmt.Errorf("Error setting etag: %s", err))
+	}
+
+	return nil
+}
+
+func resourceIbmCodeEngineSecretUpdate(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	codeEngineClient, err := meta.(conns.ClientSession).CodeEngineV2()
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	replaceSecretOptions := &codeenginev2.ReplaceSecretOptions{}
+
+	parts, err := flex.SepIdParts(d.Id(), "/")
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	replaceSecretOptions.SetProjectID(parts[0])
+	replaceSecretOptions.SetName(parts[1])
+	replaceSecretOptions.SetFormat(d.Get("format").(string))
+
+	hasChange := false
+
+	if d.HasChange("project_id") {
+		return diag.FromErr(fmt.Errorf("Cannot update resource property \"%s\" with the ForceNew annotation."+
+			" The resource must be re-created to update this property.", "project_id"))
+	}
+	if d.HasChange("format") {
+		return diag.FromErr(fmt.Errorf("Cannot update resource property \"%s\" with the ForceNew annotation."+
+			" The resource must be re-created to update this property.", "format"))
+	}
+	if d.HasChange("name") {
+		replaceSecretOptions.SetName(d.Get("name").(string))
+		hasChange = true
+	}
+	if d.HasChange("data") {
+		data, err := resourceIbmCodeEngineSecretMapToSecretData(d.Get("data").(map[string]interface{}))
+		if err != nil {
+			return diag.FromErr(err)
+		}
+		replaceSecretOptions.SetData(data)
+		hasChange = true
+	}
+	replaceSecretOptions.SetIfMatch(d.Get("etag").(string))
+
+	if hasChange {
+		_, response, err := codeEngineClient.ReplaceSecretWithContext(context, replaceSecretOptions)
+		if err != nil {
+			log.Printf("[DEBUG] ReplaceSecretWithContext failed %s\n%s", err, response)
+			return diag.FromErr(fmt.Errorf("ReplaceSecretWithContext failed %s\n%s", err, response))
+		}
+	}
+
+	return resourceIbmCodeEngineSecretRead(context, d, meta)
+}
+
+func resourceIbmCodeEngineSecretDelete(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	codeEngineClient, err := meta.(conns.ClientSession).CodeEngineV2()
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	deleteSecretOptions := &codeenginev2.DeleteSecretOptions{}
+
+	parts, err := flex.SepIdParts(d.Id(), "/")
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	deleteSecretOptions.SetProjectID(parts[0])
+	deleteSecretOptions.SetName(parts[1])
+
+	response, err := codeEngineClient.DeleteSecretWithContext(context, deleteSecretOptions)
+	if err != nil {
+		log.Printf("[DEBUG] DeleteSecretWithContext failed %s\n%s", err, response)
+		return diag.FromErr(fmt.Errorf("DeleteSecretWithContext failed %s\n%s", err, response))
+	}
+
+	d.SetId("")
+
+	return nil
+}
+
+func resourceIbmCodeEngineSecretMapToSecretData(modelMap map[string]interface{}) (codeenginev2.SecretDataIntf, error) {
+	model := &codeenginev2.SecretData{}
+
+	for key, value := range modelMap {
+		strKey := fmt.Sprintf("%v", key)
+		strValue := fmt.Sprintf("%v", value)
+
+		model.SetProperty(strKey, &strValue)
+	}
+	return model, nil
+}

--- a/ibm/service/codeengine/resource_ibm_code_engine_secret_test.go
+++ b/ibm/service/codeengine/resource_ibm_code_engine_secret_test.go
@@ -1,0 +1,368 @@
+// Copyright IBM Corp. 2023 All Rights Reserved.
+// Licensed under the Mozilla Public License v2.0
+
+package codeengine_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	acc "github.com/IBM-Cloud/terraform-provider-ibm/ibm/acctest"
+	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/conns"
+	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/flex"
+	"github.com/IBM/code-engine-go-sdk/codeenginev2"
+)
+
+func TestAccIbmCodeEngineSecretGeneric(t *testing.T) {
+	var conf codeenginev2.Secret
+	format := "generic"
+	name := fmt.Sprintf("tf-secret-generic-%d", acctest.RandIntRange(10, 1000))
+	data := `{ "key" = "value" }`
+	nameUpdate := fmt.Sprintf("tf-secret-generic-update-%d", acctest.RandIntRange(10, 1000))
+	dataUpdate := `{
+		"key1" = "value1"
+		"key2" = "value2"
+	}`
+
+	projectID := acc.CeProjectId
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { acc.TestAccPreCheck(t) },
+		Providers:    acc.TestAccProviders,
+		CheckDestroy: testAccCheckIbmCodeEngineSecretDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccCheckIbmCodeEngineSecretConfig(projectID, format, name, data),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckIbmCodeEngineSecretExists("ibm_code_engine_secret.code_engine_secret_instance", conf),
+					resource.TestCheckResourceAttr("ibm_code_engine_secret.code_engine_secret_instance", "project_id", projectID),
+					resource.TestCheckResourceAttr("ibm_code_engine_secret.code_engine_secret_instance", "format", format),
+					resource.TestCheckResourceAttr("ibm_code_engine_secret.code_engine_secret_instance", "name", name),
+					resource.TestCheckResourceAttr("ibm_code_engine_secret.code_engine_secret_instance", "data.key", "value"),
+					resource.TestCheckResourceAttr("ibm_code_engine_secret.code_engine_secret_instance", "resource_type", "secret_generic_v2"),
+				),
+			},
+			resource.TestStep{
+				Config: testAccCheckIbmCodeEngineSecretConfig(projectID, format, nameUpdate, dataUpdate),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("ibm_code_engine_secret.code_engine_secret_instance", "project_id", projectID),
+					resource.TestCheckResourceAttr("ibm_code_engine_secret.code_engine_secret_instance", "format", format),
+					resource.TestCheckResourceAttr("ibm_code_engine_secret.code_engine_secret_instance", "name", nameUpdate),
+					resource.TestCheckResourceAttr("ibm_code_engine_secret.code_engine_secret_instance", "data.key1", "value1"),
+					resource.TestCheckResourceAttr("ibm_code_engine_secret.code_engine_secret_instance", "data.key2", "value2"),
+					resource.TestCheckResourceAttr("ibm_code_engine_secret.code_engine_secret_instance", "resource_type", "secret_generic_v2"),
+				),
+			},
+			resource.TestStep{
+				ResourceName:      "ibm_code_engine_secret.code_engine_secret_instance",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccIbmCodeEngineSecretBasicAuth(t *testing.T) {
+	var conf codeenginev2.Secret
+	format := "basic_auth"
+	name := fmt.Sprintf("tf-secret-basic-auth-%d", acctest.RandIntRange(10, 1000))
+	data := `{
+		"username" = "name"
+		"password" = "password"
+	}`
+	nameUpdate := fmt.Sprintf("tf-secret-basic-auth-update-%d", acctest.RandIntRange(10, 1000))
+	dataUpdate := `{
+		"username" = "name_update"
+		"password" = "password_update"
+	}`
+
+	projectID := acc.CeProjectId
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { acc.TestAccPreCheck(t) },
+		Providers:    acc.TestAccProviders,
+		CheckDestroy: testAccCheckIbmCodeEngineSecretDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccCheckIbmCodeEngineSecretConfig(projectID, format, name, data),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckIbmCodeEngineSecretExists("ibm_code_engine_secret.code_engine_secret_instance", conf),
+					resource.TestCheckResourceAttr("ibm_code_engine_secret.code_engine_secret_instance", "project_id", projectID),
+					resource.TestCheckResourceAttr("ibm_code_engine_secret.code_engine_secret_instance", "format", format),
+					resource.TestCheckResourceAttr("ibm_code_engine_secret.code_engine_secret_instance", "name", name),
+					resource.TestCheckResourceAttr("ibm_code_engine_secret.code_engine_secret_instance", "data.username", "name"),
+					resource.TestCheckResourceAttr("ibm_code_engine_secret.code_engine_secret_instance", "data.password", "password"),
+					resource.TestCheckResourceAttr("ibm_code_engine_secret.code_engine_secret_instance", "resource_type", "secret_basic_auth_v2"),
+				),
+			},
+			resource.TestStep{
+				Config: testAccCheckIbmCodeEngineSecretConfig(projectID, format, nameUpdate, dataUpdate),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("ibm_code_engine_secret.code_engine_secret_instance", "project_id", projectID),
+					resource.TestCheckResourceAttr("ibm_code_engine_secret.code_engine_secret_instance", "format", format),
+					resource.TestCheckResourceAttr("ibm_code_engine_secret.code_engine_secret_instance", "name", nameUpdate),
+					resource.TestCheckResourceAttr("ibm_code_engine_secret.code_engine_secret_instance", "data.username", "name_update"),
+					resource.TestCheckResourceAttr("ibm_code_engine_secret.code_engine_secret_instance", "data.password", "password_update"),
+					resource.TestCheckResourceAttr("ibm_code_engine_secret.code_engine_secret_instance", "resource_type", "secret_basic_auth_v2"),
+				),
+			},
+			resource.TestStep{
+				ResourceName:      "ibm_code_engine_secret.code_engine_secret_instance",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccIbmCodeEngineSecretRegistry(t *testing.T) {
+	var conf codeenginev2.Secret
+	format := "registry"
+	name := fmt.Sprintf("tf-secret-registry-%d", acctest.RandIntRange(10, 1000))
+	data := `{
+		"username" = "foo.bar"
+    "password" = "foouser"
+    "server"   = "foopass"
+    "email"    = "foo@mail.com"
+	}`
+	nameUpdate := fmt.Sprintf("tf-secret-registry-update-%d", acctest.RandIntRange(10, 1000))
+	dataUpdate := `{
+		"username" = "foo.update"
+    "password" = "foouser_update"
+    "server"   = "foopass_update"
+    "email"    = "foo@mail.co.uk"
+	}`
+
+	projectID := acc.CeProjectId
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { acc.TestAccPreCheck(t) },
+		Providers:    acc.TestAccProviders,
+		CheckDestroy: testAccCheckIbmCodeEngineSecretDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccCheckIbmCodeEngineSecretConfig(projectID, format, name, data),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckIbmCodeEngineSecretExists("ibm_code_engine_secret.code_engine_secret_instance", conf),
+					resource.TestCheckResourceAttr("ibm_code_engine_secret.code_engine_secret_instance", "project_id", projectID),
+					resource.TestCheckResourceAttr("ibm_code_engine_secret.code_engine_secret_instance", "format", format),
+					resource.TestCheckResourceAttr("ibm_code_engine_secret.code_engine_secret_instance", "name", name),
+					resource.TestCheckResourceAttr("ibm_code_engine_secret.code_engine_secret_instance", "data.username", "foo.bar"),
+					resource.TestCheckResourceAttr("ibm_code_engine_secret.code_engine_secret_instance", "data.password", "foouser"),
+					resource.TestCheckResourceAttr("ibm_code_engine_secret.code_engine_secret_instance", "data.server", "foopass"),
+					resource.TestCheckResourceAttr("ibm_code_engine_secret.code_engine_secret_instance", "data.email", "foo@mail.com"),
+					resource.TestCheckResourceAttr("ibm_code_engine_secret.code_engine_secret_instance", "resource_type", "secret_registry_v2"),
+				),
+			},
+			resource.TestStep{
+				Config: testAccCheckIbmCodeEngineSecretConfig(projectID, format, nameUpdate, dataUpdate),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("ibm_code_engine_secret.code_engine_secret_instance", "project_id", projectID),
+					resource.TestCheckResourceAttr("ibm_code_engine_secret.code_engine_secret_instance", "format", format),
+					resource.TestCheckResourceAttr("ibm_code_engine_secret.code_engine_secret_instance", "name", nameUpdate),
+					resource.TestCheckResourceAttr("ibm_code_engine_secret.code_engine_secret_instance", "data.username", "foo.update"),
+					resource.TestCheckResourceAttr("ibm_code_engine_secret.code_engine_secret_instance", "data.password", "foouser_update"),
+					resource.TestCheckResourceAttr("ibm_code_engine_secret.code_engine_secret_instance", "data.server", "foopass_update"),
+					resource.TestCheckResourceAttr("ibm_code_engine_secret.code_engine_secret_instance", "data.email", "foo@mail.co.uk"),
+					resource.TestCheckResourceAttr("ibm_code_engine_secret.code_engine_secret_instance", "resource_type", "secret_registry_v2"),
+				),
+			},
+			resource.TestStep{
+				ResourceName:      "ibm_code_engine_secret.code_engine_secret_instance",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccIbmCodeEngineSecretSSHAuth(t *testing.T) {
+	var conf codeenginev2.Secret
+	format := "ssh_auth"
+	name := fmt.Sprintf("tf-secret-ssh-auth-%d", acctest.RandIntRange(10, 1000))
+	data := `{
+		"ssh_key"     = "ssh-key",
+    "known_hosts" = "knownhosts",
+	}`
+	nameUpdate := fmt.Sprintf("tf-secret-ssh-auth-update-%d", acctest.RandIntRange(10, 1000))
+	dataUpdate := `{
+		"ssh_key"     = "ssh-key-update",
+    "known_hosts" = "knownhosts-update",
+	}`
+
+	projectID := acc.CeProjectId
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { acc.TestAccPreCheck(t) },
+		Providers:    acc.TestAccProviders,
+		CheckDestroy: testAccCheckIbmCodeEngineSecretDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccCheckIbmCodeEngineSecretConfig(projectID, format, name, data),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckIbmCodeEngineSecretExists("ibm_code_engine_secret.code_engine_secret_instance", conf),
+					resource.TestCheckResourceAttr("ibm_code_engine_secret.code_engine_secret_instance", "project_id", projectID),
+					resource.TestCheckResourceAttr("ibm_code_engine_secret.code_engine_secret_instance", "format", format),
+					resource.TestCheckResourceAttr("ibm_code_engine_secret.code_engine_secret_instance", "name", name),
+					resource.TestCheckResourceAttr("ibm_code_engine_secret.code_engine_secret_instance", "data.ssh_key", "ssh-key"),
+					resource.TestCheckResourceAttr("ibm_code_engine_secret.code_engine_secret_instance", "data.known_hosts", "knownhosts"),
+					resource.TestCheckResourceAttr("ibm_code_engine_secret.code_engine_secret_instance", "resource_type", "secret_auth_ssh_v2"),
+				),
+			},
+			resource.TestStep{
+				Config: testAccCheckIbmCodeEngineSecretConfig(projectID, format, nameUpdate, dataUpdate),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("ibm_code_engine_secret.code_engine_secret_instance", "project_id", projectID),
+					resource.TestCheckResourceAttr("ibm_code_engine_secret.code_engine_secret_instance", "format", format),
+					resource.TestCheckResourceAttr("ibm_code_engine_secret.code_engine_secret_instance", "name", nameUpdate),
+					resource.TestCheckResourceAttr("ibm_code_engine_secret.code_engine_secret_instance", "data.ssh_key", "ssh-key-update"),
+					resource.TestCheckResourceAttr("ibm_code_engine_secret.code_engine_secret_instance", "data.known_hosts", "knownhosts-update"),
+					resource.TestCheckResourceAttr("ibm_code_engine_secret.code_engine_secret_instance", "resource_type", "secret_auth_ssh_v2"),
+				),
+			},
+			resource.TestStep{
+				ResourceName:      "ibm_code_engine_secret.code_engine_secret_instance",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccIbmCodeEngineSecretTls(t *testing.T) {
+	var conf codeenginev2.Secret
+	format := "tls"
+	name := fmt.Sprintf("tf-secret-tls-%d", acctest.RandIntRange(10, 1000))
+	data := `{
+		"tls_cert" = "---BEGIN CERTIFICATE--- ---END CERTIFICATE---",
+    "tls_key"  = "---BEGIN PRIVATE KEY--- ---END PRIVATE KEY---",
+	}`
+	nameUpdate := fmt.Sprintf("tf-secret-tls-update-%d", acctest.RandIntRange(10, 1000))
+	dataUpdate := `{
+		"tls_cert" = "---BEGIN CERTIFICATE--- update ---END CERTIFICATE---",
+    "tls_key"  = "---BEGIN PRIVATE KEY--- update ---END PRIVATE KEY---",
+	}`
+
+	projectID := acc.CeProjectId
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { acc.TestAccPreCheck(t) },
+		Providers:    acc.TestAccProviders,
+		CheckDestroy: testAccCheckIbmCodeEngineSecretDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccCheckIbmCodeEngineSecretConfig(projectID, format, name, data),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckIbmCodeEngineSecretExists("ibm_code_engine_secret.code_engine_secret_instance", conf),
+					resource.TestCheckResourceAttr("ibm_code_engine_secret.code_engine_secret_instance", "project_id", projectID),
+					resource.TestCheckResourceAttr("ibm_code_engine_secret.code_engine_secret_instance", "format", format),
+					resource.TestCheckResourceAttr("ibm_code_engine_secret.code_engine_secret_instance", "name", name),
+					resource.TestCheckResourceAttr("ibm_code_engine_secret.code_engine_secret_instance", "data.tls_cert", "---BEGIN CERTIFICATE--- ---END CERTIFICATE---"),
+					resource.TestCheckResourceAttr("ibm_code_engine_secret.code_engine_secret_instance", "data.tls_key", "---BEGIN PRIVATE KEY--- ---END PRIVATE KEY---"),
+					resource.TestCheckResourceAttr("ibm_code_engine_secret.code_engine_secret_instance", "resource_type", "secret_tls_v2"),
+				),
+			},
+			resource.TestStep{
+				Config: testAccCheckIbmCodeEngineSecretConfig(projectID, format, nameUpdate, dataUpdate),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("ibm_code_engine_secret.code_engine_secret_instance", "project_id", projectID),
+					resource.TestCheckResourceAttr("ibm_code_engine_secret.code_engine_secret_instance", "format", format),
+					resource.TestCheckResourceAttr("ibm_code_engine_secret.code_engine_secret_instance", "name", nameUpdate),
+					resource.TestCheckResourceAttr("ibm_code_engine_secret.code_engine_secret_instance", "data.tls_cert", "---BEGIN CERTIFICATE--- update ---END CERTIFICATE---"),
+					resource.TestCheckResourceAttr("ibm_code_engine_secret.code_engine_secret_instance", "data.tls_key", "---BEGIN PRIVATE KEY--- update ---END PRIVATE KEY---"),
+					resource.TestCheckResourceAttr("ibm_code_engine_secret.code_engine_secret_instance", "resource_type", "secret_tls_v2"),
+				),
+			},
+			resource.TestStep{
+				ResourceName:      "ibm_code_engine_secret.code_engine_secret_instance",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testAccCheckIbmCodeEngineSecretConfig(projectID string, format string, name string, data string) string {
+	return fmt.Sprintf(`
+		data "ibm_code_engine_project" "code_engine_project_instance" {
+			project_id = "%s"
+		}
+
+		resource "ibm_code_engine_secret" "code_engine_secret_instance" {
+			project_id = data.ibm_code_engine_project.code_engine_project_instance.project_id
+			format = "%s"
+			name = "%s"
+			data = %s
+		}
+	`, projectID, format, name, data)
+}
+
+func testAccCheckIbmCodeEngineSecretExists(n string, obj codeenginev2.Secret) resource.TestCheckFunc {
+
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+
+		codeEngineClient, err := acc.TestAccProvider.Meta().(conns.ClientSession).CodeEngineV2()
+		if err != nil {
+			return err
+		}
+
+		getSecretOptions := &codeenginev2.GetSecretOptions{}
+
+		parts, err := flex.SepIdParts(rs.Primary.ID, "/")
+		if err != nil {
+			return err
+		}
+
+		getSecretOptions.SetProjectID(parts[0])
+		getSecretOptions.SetName(parts[1])
+
+		secret, _, err := codeEngineClient.GetSecret(getSecretOptions)
+		if err != nil {
+			return err
+		}
+
+		obj = *secret
+		return nil
+	}
+}
+
+func testAccCheckIbmCodeEngineSecretDestroy(s *terraform.State) error {
+	codeEngineClient, err := acc.TestAccProvider.Meta().(conns.ClientSession).CodeEngineV2()
+	if err != nil {
+		return err
+	}
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "ibm_code_engine_secret" {
+			continue
+		}
+
+		getSecretOptions := &codeenginev2.GetSecretOptions{}
+
+		parts, err := flex.SepIdParts(rs.Primary.ID, "/")
+		if err != nil {
+			return err
+		}
+
+		getSecretOptions.SetProjectID(parts[0])
+		getSecretOptions.SetName(parts[1])
+
+		// Try to find the key
+		_, response, err := codeEngineClient.GetSecret(getSecretOptions)
+
+		if err == nil {
+			return fmt.Errorf("code_engine_secret still exists: %s", rs.Primary.ID)
+		} else if response.StatusCode != 404 {
+			return fmt.Errorf("Error checking for code_engine_secret (%s) has been destroyed: %s", rs.Primary.ID, err)
+		}
+	}
+
+	return nil
+}

--- a/website/docs/r/code_engine_secret.html.markdown
+++ b/website/docs/r/code_engine_secret.html.markdown
@@ -1,0 +1,70 @@
+---
+layout: "ibm"
+page_title: "IBM : ibm_code_engine_secret"
+description: |-
+  Manages code_engine_secret.
+subcategory: "Code Engine"
+---
+
+# ibm_code_engine_secret
+
+Provides a resource for code_engine_secret. This allows code_engine_secret to be created, updated and deleted.
+
+## Example Usage
+
+```hcl
+resource "ibm_code_engine_secret" "code_engine_secret_instance" {
+  project_id = "15314cc3-85b4-4338-903f-c28cdee6d005"
+  name = "my-secret"
+  format = "generic"
+
+  data {
+		key1 = "value1"
+		key2 = "value2"
+  }
+}
+```
+
+## Argument Reference
+
+Review the argument reference that you can specify for your resource.
+
+* `data` - (Optional, Map) The key-value pair for the config map. Values must be specified in `KEY=VALUE` format. Each `KEY` field must consist of alphanumeric characters, `-`, `_` or `.` and must not be exceed a max length of 253 characters. Each `VALUE` field can consists of any character and must not be exceed a max length of 1048576 characters.
+* `format` - (Required, Forces new resource, String) Specify the format of the secret.
+  * Constraints: Allowable values are: `generic`, `ssh_auth`, `basic_auth`, `tls`, `registry`. The value must match regular expression `/^(generic|ssh_auth|basic_auth|tls|registry)$/`.
+* `name` - (Required, String) The name of the secret.
+  * Constraints: The maximum length is `253` characters. The minimum length is `1` character. The value must match regular expression `/^[a-z0-9]([\\-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([\\-a-z0-9]*[a-z0-9])?)*$/`.
+* `project_id` - (Required, Forces new resource, String) The ID of the project.
+  * Constraints: The maximum length is `36` characters. The minimum length is `36` characters. The value must match regular expression `/^[0-9a-z]{8}-[0-9a-z]{4}-[0-9a-z]{4}-[0-9a-z]{4}-[0-9a-z]{12}$/`.
+
+## Attribute Reference
+
+In addition to all argument references listed, you can access the following attribute references after your resource is created.
+
+* `secret_id` - (String) The identifier of the resource.
+  * Constraints: The maximum length is `36` characters. The minimum length is `36` characters. The value must match regular expression `/^[0-9a-z]{8}-[0-9a-z]{4}-[0-9a-z]{4}-[0-9a-z]{4}-[0-9a-z]{12}$/`.
+* `created_at` - (String) The timestamp when the resource was created.
+* `entity_tag` - (String) The version of the secret instance, which is used to achieve optimistic locking.
+  * Constraints: The maximum length is `63` characters. The minimum length is `1` character. The value must match regular expression `/^[\\*\\-a-z0-9]+$/`.
+* `href` - (String) When you provision a new secret,  a URL is created identifying the location of the instance.
+  * Constraints: The maximum length is `2048` characters. The minimum length is `0` characters. The value must match regular expression `/(([^:\/?#]+):)?(\/\/([^\/?#]*))?([^?#]*)(\\?([^#]*))?(#(.*))?$/`.
+* `id` - (String) The identifier of the resource.
+  * Constraints: The maximum length is `36` characters. The minimum length is `36` characters. The value must match regular expression `/^[0-9a-z]{8}-[0-9a-z]{4}-[0-9a-z]{4}-[0-9a-z]{4}-[0-9a-z]{12}$/`.
+* `resource_type` - (String) The type of the secret.
+* `etag` - ETag identifier for code_engine_secret.
+
+## Import
+
+You can import the `ibm_code_engine_secret` resource by using `name`.
+The `name` property can be formed from `project_id`, and `name` in the following format:
+
+```
+<project_id>/<name>
+```
+* `project_id`: A string in the format `15314cc3-85b4-4338-903f-c28cdee6d005`. The ID of the project.
+* `name`: A string in the format `my-secret`. The name of your secret.
+
+# Syntax
+```
+$ terraform import ibm_code_engine_secret.code_engine_secret <project_id>/<name>
+```

--- a/website/docs/r/code_engine_secret.html.markdown
+++ b/website/docs/r/code_engine_secret.html.markdown
@@ -29,7 +29,13 @@ resource "ibm_code_engine_secret" "code_engine_secret_instance" {
 
 Review the argument reference that you can specify for your resource.
 
-* `data` - (Optional, Map) The key-value pair for the config map. Values must be specified in `KEY=VALUE` format. Each `KEY` field must consist of alphanumeric characters, `-`, `_` or `.` and must not be exceed a max length of 253 characters. Each `VALUE` field can consists of any character and must not be exceed a max length of 1048576 characters.
+* `data` - (Optional, Map) The key-value pair for the secret. Values must be specified in `KEY=VALUE` format. Each `KEY` field must consist of alphanumeric characters, `-`, `_` or `.` and must not be exceed a max length of 253 characters. Each `VALUE` field can consists of any character and must not be exceed a max length of 1048576 characters. Depending on the `format`, certain `KEY=VALUE` are mandatory. For format `ssh_auth` you must provide the fields `ssh_key` and `known_hosts`. For format registry
+  * Constraints: Depending on the `format`, certain key-value pairs are mandatory:
+    * For format `generic` there are no constraints.
+    * For format `ssh_auth` you must provide the fields `ssh_key` and `known_hosts`.
+    * For format `basic_auth` you must provide the fields `username` and `password`.
+    * For format `tls` you must provide the fields `tls_cert` and `tls_key`.
+    * For format `registry` you must provide the fields `username`,  `password`, `server` and `email`.
 * `format` - (Required, Forces new resource, String) Specify the format of the secret.
   * Constraints: Allowable values are: `generic`, `ssh_auth`, `basic_auth`, `tls`, `registry`. The value must match regular expression `/^(generic|ssh_auth|basic_auth|tls|registry)$/`.
 * `name` - (Required, String) The name of the secret.


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/IBM-Cloud/terraform-provider-ibm/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #4431

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc                                                 
TF_ACC=1 go test -v $(go list ./... |grep -v 'vendor') 
?       github.com/IBM-Cloud/terraform-provider-ibm     [no test files]
?       github.com/IBM-Cloud/terraform-provider-ibm/ibm/acctest [no test files]
?       github.com/IBM-Cloud/terraform-provider-ibm/ibm/flex    [no test files]
?       github.com/IBM-Cloud/terraform-provider-ibm/ibm/provider        [no test files]
=== RUN   TestString
--- PASS: TestString (0.00s)
=== RUN   TestString_positiveIndex
--- PASS: TestString_positiveIndex (0.00s)
PASS
ok      github.com/IBM-Cloud/terraform-provider-ibm/ibm/conns   (cached)
?       github.com/IBM-Cloud/terraform-provider-ibm/ibm/validate        [no test files]
?       github.com/IBM-Cloud/terraform-provider-ibm/version     [no test files]
=== RUN   TestAccIbmCodeEngineProjectDataSourceBasic
--- PASS: TestAccIbmCodeEngineProjectDataSourceBasic (8.27s)
=== RUN   TestAccIbmCodeEngineAppBasic
--- PASS: TestAccIbmCodeEngineAppBasic (146.47s)
=== RUN   TestAccIbmCodeEngineAppExtended
--- PASS: TestAccIbmCodeEngineAppExtended (147.04s)
=== RUN   TestAccIbmCodeEngineBuildBasic
--- PASS: TestAccIbmCodeEngineBuildBasic (11.60s)
=== RUN   TestAccIbmCodeEngineConfigMapBasic
--- PASS: TestAccIbmCodeEngineConfigMapBasic (24.04s)
=== RUN   TestAccIbmCodeEngineJobBasic
--- PASS: TestAccIbmCodeEngineJobBasic (21.34s)
=== RUN   TestAccIbmCodeEngineJobExtended
--- PASS: TestAccIbmCodeEngineJobExtended (22.90s)
=== RUN   TestAccIbmCodeEngineSecretGeneric
--- PASS: TestAccIbmCodeEngineSecretGeneric (23.64s)
=== RUN   TestAccIbmCodeEngineSecretBasicAuth
--- PASS: TestAccIbmCodeEngineSecretBasicAuth (23.74s)
=== RUN   TestAccIbmCodeEngineSecretRegistry
--- PASS: TestAccIbmCodeEngineSecretRegistry (23.20s)
=== RUN   TestAccIbmCodeEngineSecretSSHAuth
--- PASS: TestAccIbmCodeEngineSecretSSHAuth (22.90s)
=== RUN   TestAccIbmCodeEngineSecretTls
--- PASS: TestAccIbmCodeEngineSecretTls (21.93s)
PASS
ok      github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/codeengine      497.660s
...
```
