### PR TITLE
enhancement(reserved_ips): added support for target crn

### DIFF
--- a/ibm/service/vpc/data_source_ibm_is_subnet_reserved_ip.go
+++ b/ibm/service/vpc/data_source_ibm_is_subnet_reserved_ip.go
@@ -99,6 +99,11 @@ func DataSourceIBMISReservedIP() *schema.Resource {
 				Computed:    true,
 				Description: "Reserved IP target id.",
 			},
+			isReservedIPTargetCrn: {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The crn for target.",
+			},
 		},
 	}
 }
@@ -138,6 +143,7 @@ func dataSdataSourceIBMISReservedIPRead(d *schema.ResourceData, meta interface{}
 		case "*vpcv1.ReservedIPTargetEndpointGatewayReference":
 			{
 				target := targetIntf.(*vpcv1.ReservedIPTargetEndpointGatewayReference)
+				d.Set(isReservedIPTargetCrn, target.CRN)
 				d.Set(isReservedIPTarget, target.ID)
 			}
 		case "*vpcv1.ReservedIPTargetNetworkInterfaceReferenceTargetContext":
@@ -148,17 +154,25 @@ func dataSdataSourceIBMISReservedIPRead(d *schema.ResourceData, meta interface{}
 		case "*vpcv1.ReservedIPTargetLoadBalancerReference":
 			{
 				target := targetIntf.(*vpcv1.ReservedIPTargetLoadBalancerReference)
+				d.Set(isReservedIPTargetCrn, target.CRN)
 				d.Set(isReservedIPTarget, target.ID)
 			}
 		case "*vpcv1.ReservedIPTargetVPNGatewayReference":
 			{
 				target := targetIntf.(*vpcv1.ReservedIPTargetVPNGatewayReference)
+				d.Set(isReservedIPTargetCrn, target.CRN)
 				d.Set(isReservedIPTarget, target.ID)
 			}
 		case "*vpcv1.ReservedIPTarget":
 			{
 				target := targetIntf.(*vpcv1.ReservedIPTarget)
+				d.Set(isReservedIPTargetCrn, target.CRN)
 				d.Set(isReservedIPTarget, target.ID)
+			}
+		case "*vpcv1.ReservedIPTargetGenericResourceReference":
+			{
+				target := targetIntf.(*vpcv1.ReservedIPTargetGenericResourceReference)
+				d.Set(isReservedIPTargetCrn, target.CRN)
 			}
 		}
 	}

--- a/ibm/service/vpc/data_source_ibm_is_subnet_reserved_ip_test.go
+++ b/ibm/service/vpc/data_source_ibm_is_subnet_reserved_ip_test.go
@@ -30,6 +30,33 @@ func TestAccIBMISSubnetReservedIP_basic(t *testing.T) {
 		},
 	})
 }
+func TestAccIBMISSubnetReservedIP_targetCrn(t *testing.T) {
+	vpcName := fmt.Sprintf("tfresip-vpc-%d", acctest.RandIntRange(10, 100))
+	subnetName := fmt.Sprintf("tfresip-subnet-%d", acctest.RandIntRange(10, 100))
+	resIPName := fmt.Sprintf("tfresip-reservedip-%d", acctest.RandIntRange(10, 100))
+	gatewayName := fmt.Sprintf("tfresip-egateway-%d", acctest.RandIntRange(10, 100))
+	terraformTag := "data.ibm_is_subnet_reserved_ip.data_resip1"
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { acc.TestAccPreCheck(t) },
+		Providers: acc.TestAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccIBMISReservedIPdataSoruceTargetCrnConfig(vpcName, subnetName, resIPName, gatewayName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(terraformTag, "name", resIPName),
+					resource.TestCheckResourceAttrSet(
+						terraformTag, "target_crn"),
+					resource.TestCheckResourceAttrSet(
+						terraformTag, "target"),
+					resource.TestCheckResourceAttrSet(
+						"ibm_is_virtual_endpoint_gateway_ip.example", "target.#"),
+					resource.TestCheckResourceAttrSet(
+						"ibm_is_virtual_endpoint_gateway.example", "target.#"),
+				),
+			},
+		},
+	})
+}
 
 func testAccIBMISReservedIPdataSoruceConfig(vpcName, subnetName, reservedIPName string) string {
 	return fmt.Sprintf(`
@@ -54,4 +81,48 @@ func testAccIBMISReservedIPdataSoruceConfig(vpcName, subnetName, reservedIPName 
 			reserved_ip = ibm_is_subnet_reserved_ip.resip1.reserved_ip
 		}
       `, vpcName, subnetName, reservedIPName)
+}
+func testAccIBMISReservedIPdataSoruceTargetCrnConfig(vpcName, subnetName, reservedIPName, gatewayName string) string {
+	return fmt.Sprintf(`
+		resource "ibm_is_vpc" "vpc1" {
+			name = "%s"
+		}
+
+		resource "ibm_is_subnet" "subnet1" {
+			name                     = "%s"
+			vpc                      = ibm_is_vpc.vpc1.id
+			zone                     = "us-south-1"
+			total_ipv4_address_count = 256
+		}
+
+		resource "ibm_is_subnet_reserved_ip" "resip1" {
+			subnet = ibm_is_subnet.subnet1.id
+			name = "%s"
+		}
+
+		resource "ibm_is_virtual_endpoint_gateway" "example" {
+
+			name = "%s"
+			target {
+			name          = "ibm-ntp-server"
+			resource_type = "provider_infrastructure_service"
+			}
+			vpc            = ibm_is_vpc.vpc1.id
+		}
+
+		resource "ibm_is_virtual_endpoint_gateway_ip" "example" {
+			gateway     = ibm_is_virtual_endpoint_gateway.example.id
+			reserved_ip = ibm_is_subnet_reserved_ip.resip1.reserved_ip
+		}
+  
+
+		data "ibm_is_subnet_reserved_ip" "data_resip1" {
+			subnet = ibm_is_subnet.subnet1.id
+			reserved_ip = ibm_is_subnet_reserved_ip.resip1.reserved_ip
+			depends_on 	= 	[
+	  				ibm_is_virtual_endpoint_gateway_ip.example
+							]
+		}
+
+      `, vpcName, subnetName, reservedIPName, gatewayName)
 }

--- a/ibm/service/vpc/data_source_ibm_is_subnet_reserved_ips.go
+++ b/ibm/service/vpc/data_source_ibm_is_subnet_reserved_ips.go
@@ -99,6 +99,11 @@ func DataSourceIBMISReservedIPs() *schema.Resource {
 							Computed:    true,
 							Description: "Reserved IP target id",
 						},
+						isReservedIPTargetCrn: {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "The crn for target.",
+						},
 					},
 				},
 			},
@@ -160,26 +165,35 @@ func dataSdataSourceIBMISReservedIPsRead(d *schema.ResourceData, meta interface{
 				{
 					target := targetIntf.(*vpcv1.ReservedIPTargetEndpointGatewayReference)
 					ipsOutput[isReservedIPTarget] = target.ID
+					ipsOutput[isReservedIPTargetCrn] = target.CRN
 				}
 			case "*vpcv1.ReservedIPTargetNetworkInterfaceReferenceTargetContext":
 				{
 					target := targetIntf.(*vpcv1.ReservedIPTargetNetworkInterfaceReferenceTargetContext)
 					ipsOutput[isReservedIPTarget] = target.ID
 				}
+			case "*vpcv1.ReservedIPTargetGenericResourceReference":
+				{
+					target := targetIntf.(*vpcv1.ReservedIPTargetGenericResourceReference)
+					ipsOutput[isReservedIPTargetCrn] = target.CRN
+				}
 			case "*vpcv1.ReservedIPTargetLoadBalancerReference":
 				{
 					target := targetIntf.(*vpcv1.ReservedIPTargetLoadBalancerReference)
 					ipsOutput[isReservedIPTarget] = target.ID
+					ipsOutput[isReservedIPTargetCrn] = target.CRN
 				}
 			case "*vpcv1.ReservedIPTargetVPNGatewayReference":
 				{
 					target := targetIntf.(*vpcv1.ReservedIPTargetVPNGatewayReference)
 					ipsOutput[isReservedIPTarget] = target.ID
+					ipsOutput[isReservedIPTargetCrn] = target.CRN
 				}
 			case "*vpcv1.ReservedIPTarget":
 				{
 					target := targetIntf.(*vpcv1.ReservedIPTarget)
 					ipsOutput[isReservedIPTarget] = target.ID
+					ipsOutput[isReservedIPTargetCrn] = target.CRN
 				}
 			}
 		}

--- a/ibm/service/vpc/resource_ibm_is_subnet_reserved_ip.go
+++ b/ibm/service/vpc/resource_ibm_is_subnet_reserved_ip.go
@@ -22,6 +22,7 @@ const (
 	isReservedIPProvisioningDone = "done"
 	isReservedIP                 = "reserved_ip"
 	isReservedIPTarget           = "target"
+	isReservedIPTargetCrn        = "target_crn"
 	isReservedIPLifecycleState   = "lifecycle_state"
 )
 
@@ -68,6 +69,12 @@ func ResourceIBMISReservedIP() *schema.Resource {
 				Computed:    true,
 				Optional:    true,
 				Description: "The unique identifier for target.",
+			},
+			isReservedIPTargetCrn: {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Optional:    true,
+				Description: "The crn for target.",
 			},
 			isReservedIPLifecycleState: {
 				Type:        schema.TypeString,
@@ -213,6 +220,12 @@ func resourceIBMISReservedIPRead(d *schema.ResourceData, meta interface{}) error
 				{
 					target := targetIntf.(*vpcv1.ReservedIPTargetEndpointGatewayReference)
 					d.Set(isReservedIPTarget, target.ID)
+					d.Set(isReservedIPTargetCrn, target.CRN)
+				}
+			case "*vpcv1.ReservedIPTargetGenericResourceReference":
+				{
+					target := targetIntf.(*vpcv1.ReservedIPTargetGenericResourceReference)
+					d.Set(isReservedIPTargetCrn, target.CRN)
 				}
 			case "*vpcv1.ReservedIPTargetNetworkInterfaceReferenceTargetContext":
 				{
@@ -223,16 +236,19 @@ func resourceIBMISReservedIPRead(d *schema.ResourceData, meta interface{}) error
 				{
 					target := targetIntf.(*vpcv1.ReservedIPTargetLoadBalancerReference)
 					d.Set(isReservedIPTarget, target.ID)
+					d.Set(isReservedIPTargetCrn, target.CRN)
 				}
 			case "*vpcv1.ReservedIPTargetVPNGatewayReference":
 				{
 					target := targetIntf.(*vpcv1.ReservedIPTargetVPNGatewayReference)
 					d.Set(isReservedIPTarget, target.ID)
+					d.Set(isReservedIPTargetCrn, target.CRN)
 				}
 			case "*vpcv1.ReservedIPTarget":
 				{
 					target := targetIntf.(*vpcv1.ReservedIPTarget)
 					d.Set(isReservedIPTarget, target.ID)
+					d.Set(isReservedIPTargetCrn, target.CRN)
 				}
 			}
 		}

--- a/website/docs/d/is_subnet_reserved_ip.html.markdown
+++ b/website/docs/d/is_subnet_reserved_ip.html.markdown
@@ -49,3 +49,4 @@ In addition to all argument reference list, you can access the following attribu
 - `resource_type` -  (String) The resource type.
 - `subnet` -  (String) The ID of the subnet for the reserved IP.
 - `target` - (String) The ID of the target for the reserved IP.
+- `target_crn` - (String) The crn of the target for the reserved IP.

--- a/website/docs/d/is_subnet_reserved_ips.html.markdown
+++ b/website/docs/d/is_subnet_reserved_ips.html.markdown
@@ -49,5 +49,6 @@ In addition to the argument reference list, you can access the following attribu
   - `owner` -  (String) The owner of a reserved IP, defining whether it is managed by the user or the provider.
   - `resource_type` -  (String) The resource type.
   - `target` - (String) The ID of the target for the reserved IP.
+  - `target_crn` - (String) The crn of the target for the reserved IP.
 - `total_count` -  (String) The total number of resources across all pages.
 

--- a/website/docs/r/is_subnet_reserved_ip.html.markdown
+++ b/website/docs/r/is_subnet_reserved_ip.html.markdown
@@ -109,6 +109,7 @@ In addition to all argument reference list, you can access the following attribu
 - `reserved_ip` - (String) The reserved IP.
 - `resource_type` - (String) The resource type.
 - `target` - (String) The ID for the target for the reserved IP.
+- `target_crn` - (String) The crn of the target for the reserved IP.
 
 ## Import
 The `ibm_is_subnet_reserved_ip` and `ibm_is_subnet` resource can be imported by using subnet ID and reserved IP ID separated by **/**.


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/IBM-Cloud/terraform-provider-ibm/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
=== RUN   TestAccIBMISSubnetReservedIP_targetCrn
--- PASS: TestAccIBMISSubnetReservedIP_targetCrn (130.95s)
PASS
ok      github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/vpc     133.121s
```
```
=== RUN   TestAccIBMISSubnetReservedIPResource_targetCrn
--- PASS: TestAccIBMISSubnetReservedIPResource_targetCrn (162.87s)
PASS
ok      github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/vpc     164.811s
```
