### PR TITLE
fix(vpc-rt-route): fixed changes shown on creator attribute

### DIFF
--- a/ibm/service/vpc/data_source_ibm_is_vpc_routing_table_route_test.go
+++ b/ibm/service/vpc/data_source_ibm_is_vpc_routing_table_route_test.go
@@ -75,7 +75,7 @@ func testAccCheckIBMIBMIsVPCRoutingTableRouteDataSourceConfigBasic(vpcname, rtna
 			name 			= "%s"
 			destination 	= "192.168.4.0/24"
 			action 			= "deliver"
-			next_hop 		= "0.0.0.0"
+			next_hop 		= "192.168.4.1"
 		  }
 		data "ibm_is_vpc_routing_table_route" "ibm_is_vpc_routing_table_route" {
 			vpc 			= ibm_is_vpc.test_route_vpc.id

--- a/ibm/service/vpc/resource_ibm_is_vpc_routing_table_route.go
+++ b/ibm/service/vpc/resource_ibm_is_vpc_routing_table_route.go
@@ -109,19 +109,18 @@ func ResourceIBMISVPCRoutingTableRoute() *schema.Resource {
 					Schema: map[string]*schema.Schema{
 						"crn": &schema.Schema{
 							Type:        schema.TypeString,
-							Optional:    true,
+							Computed:    true,
 							Description: "The VPN gateway's CRN.",
 						},
 						"deleted": &schema.Schema{
 							Type:        schema.TypeList,
-							MaxItems:    1,
-							Optional:    true,
+							Computed:    true,
 							Description: "If present, this property indicates the referenced resource has been deleted and providessome supplementary information.",
 							Elem: &schema.Resource{
 								Schema: map[string]*schema.Schema{
 									"more_info": &schema.Schema{
 										Type:        schema.TypeString,
-										Required:    true,
+										Computed:    true,
 										Description: "Link to documentation about deleted resources.",
 									},
 								},
@@ -129,22 +128,22 @@ func ResourceIBMISVPCRoutingTableRoute() *schema.Resource {
 						},
 						"href": &schema.Schema{
 							Type:        schema.TypeString,
-							Optional:    true,
+							Computed:    true,
 							Description: "The VPN gateway's canonical URL.",
 						},
 						"id": &schema.Schema{
 							Type:        schema.TypeString,
-							Optional:    true,
+							Computed:    true,
 							Description: "The unique identifier for this VPN gateway.",
 						},
 						"name": &schema.Schema{
 							Type:        schema.TypeString,
-							Optional:    true,
+							Computed:    true,
 							Description: "The user-defined name for this VPN gateway.",
 						},
 						"resource_type": &schema.Schema{
 							Type:        schema.TypeString,
-							Optional:    true,
+							Computed:    true,
 							Description: "The resource type.",
 						},
 					},
@@ -311,9 +310,8 @@ func resourceIBMISVPCRoutingTableRouteRead(d *schema.ResourceData, meta interfac
 			return err
 		}
 		creator = append(creator, mm)
-
-		d.Set("creator", creator)
 	}
+	d.Set("creator", creator)
 	d.Set("priority", route.Priority)
 	return nil
 }


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/IBM-Cloud/terraform-provider-ibm/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
=== RUN   TestAccIBMISVPCRoutingTableRoutesDataSource_basic
--- PASS: TestAccIBMISVPCRoutingTableRoutesDataSource_basic (113.38s)
PASS
ok      github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/vpc     115.492s
```
```
=== RUN   TestAccIBMIBMIsVPCRoutingTableRouteDataSourceBasic
--- PASS: TestAccIBMIBMIsVPCRoutingTableRouteDataSourceBasic (86.57s)
PASS
ok      github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/vpc     88.561s
```
```
=== RUN   TestAccIBMISVPCRoutingTableRoutesDataSource_basic
--- PASS: TestAccIBMISVPCRoutingTableRoutesDataSource_basic (105.74s)
PASS
ok      github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/vpc     107.293s
```