### PR TITLE
fix(bm) : pci nic deletion change

### DIFF
--- a/ibm/service/vpc/resource_ibm_is_bare_metal_server_network_interface_floating_ip_test.go
+++ b/ibm/service/vpc/resource_ibm_is_bare_metal_server_network_interface_floating_ip_test.go
@@ -20,7 +20,7 @@ import (
 )
 
 func TestAccIBMISBareMetalServerNetworkInterfaceFloatingIp_basic(t *testing.T) {
-	var server string
+	var serverNicFip string
 	vpcname := fmt.Sprintf("tf-vpc-%d", acctest.RandIntRange(10, 100))
 	name := fmt.Sprintf("tf-server-%d", acctest.RandIntRange(10, 100))
 	subnetname := fmt.Sprintf("tfip-subnet-%d", acctest.RandIntRange(10, 100))
@@ -32,12 +32,12 @@ ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCKVmnMOlHKcZK8tpt3MP1lqOLAcqcJzhsvJcjscgVE
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { acc.TestAccPreCheck(t) },
 		Providers:    acc.TestAccProviders,
-		CheckDestroy: testAccCheckIBMISBareMetalServerNetworkInterfaceDestroy,
+		CheckDestroy: testAccCheckIBMISBareMetalServerNetworkInterfaceFloatingIpDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccCheckIBMISBareMetalServerNetworkInterfaceFloatingIpConfig(vpcname, subnetname, sshname, publicKey, name),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckIBMISBareMetalServerNetworkInterfaceExists("ibm_is_bare_metal_server.testacc_bms", server),
+					testAccCheckIBMISBareMetalServerNetworkInterfaceFloatingIpExists("ibm_is_bare_metal_server_network_interface_floating_ip.bms_nic_fip", serverNicFip),
 					resource.TestCheckResourceAttr(
 						"ibm_is_bare_metal_server.testacc_bms", "name", name),
 					resource.TestCheckResourceAttr(


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/IBM-Cloud/terraform-provider-ibm/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
=== RUN   TestAccIBMISBareMetalServerNetworkInterface_pci_nic_delete
no message sent
no message sent
no message sent
--- PASS: TestAccIBMISBareMetalServerNetworkInterface_pci_nic_delete (1823.55s)
PASS
ok      github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/vpc     1826.228s
```
```
=== RUN   TestAccIBMISBareMetalServerNetworkInterface_sg_update
--- PASS: TestAccIBMISBareMetalServerNetworkInterface_sg_update (425.23s)
PASS
ok      github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/vpc     427.558s
```
```
=== RUN   TestAccIBMISBareMetalServerNetworkInterfaceAllowFloat_sg_update
--- PASS: TestAccIBMISBareMetalServerNetworkInterfaceAllowFloat_sg_update (102.37s)
PASS
ok      github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/vpc     104.357s
```
