### PR TITLE
suppress resize for autoscaled workerpools

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/IBM-Cloud/terraform-provider-ibm
 go 1.18
 
 require (
-	github.com/IBM-Cloud/bluemix-go v0.0.0-20230330100610-b58456b0d67e
+	github.com/IBM-Cloud/bluemix-go v0.0.0-20230426045943-5b1069b0d7ae
 	github.com/IBM-Cloud/container-services-go-sdk v0.0.0-20230118060037-101bda076037
 	github.com/IBM-Cloud/power-go-client v1.2.2
 	github.com/IBM/apigateway-go-sdk v0.0.0-20210714141226-a5d5d49caaca

--- a/go.sum
+++ b/go.sum
@@ -34,8 +34,8 @@ dmitri.shuralyov.com/gpu/mtl v0.0.0-20190408044501-666a987793e9/go.mod h1:H6x//7
 github.com/BurntSushi/toml v0.3.1 h1:WXkYYl6Yr3qBf1K79EBnL4mak0OimBfB0XUf9Vl28OQ=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
-github.com/IBM-Cloud/bluemix-go v0.0.0-20230330100610-b58456b0d67e h1:F1IY9ihqHFp2ppwbHAE9rokZaBm/SxQvo03WGqzSLzc=
-github.com/IBM-Cloud/bluemix-go v0.0.0-20230330100610-b58456b0d67e/go.mod h1:cO5KCpiop9eP/pM/5W07TprYUkv/kHtajW1FiZgE59k=
+github.com/IBM-Cloud/bluemix-go v0.0.0-20230426045943-5b1069b0d7ae h1:Bxw9iWkcbMrVKv3FtbzzPYwdWXWsODYTdOS1NxChuAE=
+github.com/IBM-Cloud/bluemix-go v0.0.0-20230426045943-5b1069b0d7ae/go.mod h1:cO5KCpiop9eP/pM/5W07TprYUkv/kHtajW1FiZgE59k=
 github.com/IBM-Cloud/container-services-go-sdk v0.0.0-20230118060037-101bda076037 h1:C1gOsj2A5ouRUXrmKHebXjs4FXRE8ApMUC3GBUpd9Co=
 github.com/IBM-Cloud/container-services-go-sdk v0.0.0-20230118060037-101bda076037/go.mod h1:xUQL9SGAjoZFd4GNjrjjtEpjpkgU7RFXRyHesbKTjiY=
 github.com/IBM-Cloud/ibm-cloud-cli-sdk v0.5.3/go.mod h1:RiUvKuHKTBmBApDMUQzBL14pQUGKcx/IioKQPIcRQjs=
@@ -101,8 +101,6 @@ github.com/IBM/scc-go-sdk/v4 v4.0.2 h1:8BHMRobCFurZwKaUhxWi8CdAA9+CvyzmlBOmo7KmX
 github.com/IBM/scc-go-sdk/v4 v4.0.2/go.mod h1:ufqf/kBtRn3Pq/pFXF6zQGHXV2P2EzPsntw1Sw19clE=
 github.com/IBM/schematics-go-sdk v0.2.1 h1:byATysGD+Z1k/wdtNqQmKALcAPjgSLuSyzcabh1jRAw=
 github.com/IBM/schematics-go-sdk v0.2.1/go.mod h1:Tw2OSAPdpC69AxcwoyqcYYaGTTW6YpERF9uNEU+BFRQ=
-github.com/IBM/secrets-manager-go-sdk v1.2.0 h1:bgFfBF+LjHLtUfV3hTLkfgE8EjFsJaeU2icA2Hg+M50=
-github.com/IBM/secrets-manager-go-sdk v1.2.0/go.mod h1:qv+tQg8Z3Vb11DQYxDjEGeROHDtTLQxUWuOIrIdWg6E=
 github.com/IBM/secrets-manager-go-sdk/v2 v2.0.0 h1:Lx4Bvim/MfoHEYR+n312bty5DirAJypBGGS9YZo3zCw=
 github.com/IBM/secrets-manager-go-sdk/v2 v2.0.0/go.mod h1:jagqWmjZ0zUEqh5jdGB42ApSQS40fu2LWw6pdg8JJko=
 github.com/IBM/vpc-beta-go-sdk v0.1.0 h1:+kdF+Y/0KY189HhpkqDrue9o0LluAr7rlOU5Zhu7hck=

--- a/ibm/service/kubernetes/data_source_ibm_container_vpc_worker_pool.go
+++ b/ibm/service/kubernetes/data_source_ibm_container_vpc_worker_pool.go
@@ -123,6 +123,11 @@ func DataSourceIBMContainerVpcClusterWorkerPool() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
+			"autoscale_enabled": {
+				Type:        schema.TypeBool,
+				Computed:    true,
+				Description: "Autoscaling is enabled on the workerpool",
+			},
 		},
 	}
 }
@@ -190,6 +195,8 @@ func dataSourceIBMContainerVpcClusterWorkerPoolRead(d *schema.ResourceData, meta
 	if workerPool.SecondaryStorageOption != nil {
 		d.Set("secondary_storage", flex.FlattenVpcWorkerPoolSecondaryDisk(*workerPool.SecondaryStorageOption))
 	}
+
+	d.Set("autoscale_enabled", workerPool.AutoscaleEnabled)
 
 	d.SetId(workerPool.ID)
 	return nil

--- a/ibm/service/kubernetes/data_source_ibm_container_vpc_worker_pool_test.go
+++ b/ibm/service/kubernetes/data_source_ibm_container_vpc_worker_pool_test.go
@@ -59,6 +59,7 @@ func TestAccIBMContainerVPCClusterWorkerPoolDataSourceEnvvar(t *testing.T) {
 	name := fmt.Sprintf("tf-vpc-wp-%d", acctest.RandIntRange(10, 100))
 	testChecks := []resource.TestCheckFunc{
 		resource.TestCheckResourceAttrSet("data.ibm_container_vpc_cluster_worker_pool.testacc_ds_worker_pool", "id"),
+		resource.TestCheckResourceAttr("data.ibm_container_vpc_cluster_worker_pool.testacc_ds_worker_pool", "autoscale_enabled", "false"),
 	}
 	if acc.CrkID != "" {
 		testChecks = append(testChecks,

--- a/ibm/service/kubernetes/data_source_ibm_container_worker_pool.go
+++ b/ibm/service/kubernetes/data_source_ibm_container_worker_pool.go
@@ -112,6 +112,12 @@ func DataSourceIBMContainerWorkerPool() *schema.Resource {
 				Computed:    true,
 				Description: "ID of the resource group.",
 			},
+
+			"autoscale_enabled": {
+				Type:        schema.TypeBool,
+				Computed:    true,
+				Description: "Autoscaling is enabled on the workerpool",
+			},
 		},
 	}
 }
@@ -174,5 +180,6 @@ func dataSourceIBMContainerWorkerPoolRead(d *schema.ResourceData, meta interface
 		d.Set("disk_encryption", false)
 	}
 	d.Set("resource_group_id", targetEnv.ResourceGroup)
+	d.Set("autoscale_enabled", workerPool.AutoscaleEnabled)
 	return nil
 }

--- a/ibm/service/kubernetes/data_source_ibm_container_worker_pool_test.go
+++ b/ibm/service/kubernetes/data_source_ibm_container_worker_pool_test.go
@@ -25,6 +25,8 @@ func TestAccIBMContainerWorkerPoolDataSource_basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrSet(
 						"data.ibm_container_worker_pool.testacc_ds_worker_pool", "id"),
+					resource.TestCheckResourceAttr(
+						"data.ibm_container_worker_pool.testacc_ds_worker_pool", "autoscale_enabled", "false"),
 				),
 			},
 		},

--- a/ibm/service/kubernetes/resource_ibm_container_vpc_worker_pool.go
+++ b/ibm/service/kubernetes/resource_ibm_container_vpc_worker_pool.go
@@ -141,9 +141,10 @@ func ResourceIBMContainerVpcWorkerPool() *schema.Resource {
 			},
 
 			"worker_count": {
-				Type:        schema.TypeInt,
-				Required:    true,
-				Description: "The number of workers",
+				Type:             schema.TypeInt,
+				Required:         true,
+				Description:      "The number of workers",
+				DiffSuppressFunc: SuppressResizeForAutoscaledWorkerpool,
 			},
 
 			"entitlement": {
@@ -197,6 +198,7 @@ func ResourceIBMContainerVpcWorkerPool() *schema.Resource {
 				Description:      "Root Key ID for boot volume encryption",
 				RequiredWith:     []string{"kms_instance_id"},
 			},
+
 			"kms_account_id": {
 				Type:             schema.TypeString,
 				Optional:         true,
@@ -204,9 +206,24 @@ func ResourceIBMContainerVpcWorkerPool() *schema.Resource {
 				Description:      "Account ID of kms instance holder - if not provided, defaults to the account in use",
 				RequiredWith:     []string{"kms_instance_id", "crk"},
 			},
+
+			"autoscale_enabled": {
+				Type:        schema.TypeBool,
+				Computed:    true,
+				Description: "Autoscaling is enabled on the workerpool",
+			},
 		},
 	}
 }
+
+func SuppressResizeForAutoscaledWorkerpool(key, oldValue, newValue string, d *schema.ResourceData) bool {
+	var autoscaleEnabled bool = false
+	if v, ok := d.GetOk("autoscale_enabled"); ok {
+		autoscaleEnabled = v.(bool)
+	}
+	return autoscaleEnabled
+}
+
 func ResourceIBMContainerVPCWorkerPoolValidator() *validate.ResourceValidator {
 	tainteffects := "NoSchedule,PreferNoSchedule,NoExecute"
 	validateSchema := make([]validate.ValidateSchema, 0)
@@ -570,6 +587,7 @@ func resourceIBMContainerVpcWorkerPoolRead(d *schema.ResourceData, meta interfac
 			d.Set("kms_account_id", workerPool.WorkerVolumeEncryption.KMSAccountID)
 		}
 	}
+	d.Set("autoscale_enabled", workerPool.AutoscaleEnabled)
 	controller, err := flex.GetBaseController(meta)
 	if err != nil {
 		return err

--- a/ibm/service/kubernetes/resource_ibm_container_vpc_worker_pool_test.go
+++ b/ibm/service/kubernetes/resource_ibm_container_vpc_worker_pool_test.go
@@ -269,6 +269,8 @@ func TestAccIBMContainerVpcClusterWorkerPoolEnvvar(t *testing.T) {
 				Config: testAccCheckIBMVpcContainerWorkerPoolEnvvarUpdate(name),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(
+						"ibm_container_vpc_worker_pool.test_pool", "worker_count", "2"),
+					resource.TestCheckResourceAttr(
 						"ibm_container_vpc_worker_pool.test_pool", "taints.#", "0"),
 				),
 			},
@@ -364,7 +366,7 @@ func testAccCheckIBMVpcContainerWorkerPoolEnvvarUpdate(name string) string {
 	  worker_pool_name  = "%[1]s"
 	  flavor            = "bx2.4x16"
 	  vpc_id            = "%[2]s"
-	  worker_count      = 1
+	  worker_count      = 2
 	  zones {
 		subnet_id = "%[3]s"
 		name      = "us-south-1"

--- a/ibm/service/kubernetes/resource_ibm_container_worker_pool.go
+++ b/ibm/service/kubernetes/resource_ibm_container_worker_pool.go
@@ -57,10 +57,11 @@ func ResourceIBMContainerWorkerPool() *schema.Resource {
 			},
 
 			"size_per_zone": {
-				Type:         schema.TypeInt,
-				Required:     true,
-				ValidateFunc: validate.ValidateSizePerZone,
-				Description:  "Number of nodes per zone",
+				Type:             schema.TypeInt,
+				Required:         true,
+				ValidateFunc:     validate.ValidateSizePerZone,
+				Description:      "Number of nodes per zone",
+				DiffSuppressFunc: SuppressResizeForAutoscaledWorkerpool,
 			},
 
 			"entitlement": {
@@ -184,10 +185,17 @@ func ResourceIBMContainerWorkerPool() *schema.Resource {
 				ForceNew:         true,
 				DiffSuppressFunc: flex.ApplyOnce,
 			},
+
 			flex.ResourceControllerURL: {
 				Type:        schema.TypeString,
 				Computed:    true,
 				Description: "The URL of the IBM Cloud dashboard that can be used to explore and view details about this cluster",
+			},
+
+			"autoscale_enabled": {
+				Type:        schema.TypeBool,
+				Computed:    true,
+				Description: "Autoscaling is enabled on the workerpool",
 			},
 		},
 	}
@@ -332,6 +340,7 @@ func resourceIBMContainerWorkerPoolRead(d *schema.ResourceData, meta interface{}
 	} else {
 		d.Set("disk_encryption", false)
 	}
+	d.Set("autoscale_enabled", workerPool.AutoscaleEnabled)
 	controller, err := flex.GetBaseController(meta)
 	if err != nil {
 		return err

--- a/website/docs/d/container_vpc_cluster_worker_pool.html.markdown
+++ b/website/docs/d/container_vpc_cluster_worker_pool.html.markdown
@@ -53,3 +53,4 @@ In addition to all argument reference list, you can access the following attribu
   Nested scheme for `zones`:
 	- `subnet-id` - (String) The worker pool subnet to assign the cluster.
 	- `subnet-name` - (String) Name of the zone.
+- `autoscale_enabled` - (Bool) Autoscaling is enabled on the workerpool

--- a/website/docs/d/container_worker_pool.html.markdown
+++ b/website/docs/d/container_worker_pool.html.markdown
@@ -44,3 +44,4 @@ Review the attribute references that are exported.
 - `crk` - Root Key ID for boot volume encryption.
 - `kms_instance_id` - Instance ID for boot volume encryption.
 - `kms_account_id` - Account ID for boot volume encryption, if other account is providing the kms.
+- `autoscale_enabled` - (Bool) Autoscaling is enabled on the workerpool

--- a/website/docs/r/container_vpc_worker_pool.html.markdown
+++ b/website/docs/r/container_vpc_worker_pool.html.markdown
@@ -110,6 +110,7 @@ In addition to all argument reference list, you can access the following attribu
 
 - `id` - (String) The unique identifier of the worker pool. The ID is composed of `<cluster_name_id>/<worker_pool_id>`.
 - `worker_pool_id` -  (String) The unique identifier of the worker pool.
+- `autoscale_enabled` - (Bool) Autoscaling is enabled on the workerpool
 
 ## Import
 

--- a/website/docs/r/container_worker_pool.html.markdown
+++ b/website/docs/r/container_worker_pool.html.markdown
@@ -98,6 +98,7 @@ In addition to all argument reference list, you can access the following attribu
   - `public_vlan` - (String) The ID of the public VLAN that is used in the zone. 
   - `worker_count` - (Integer) The number of worker nodes that are attached to the zone.
   - `zone` - (String) The name of the zone. 
+- `autoscale_enabled` - (Bool) Autoscaling is enabled on the workerpool
 
 ## Import
 The `ibm_container_worker_pool` can be imported by using `cluster_name_id`, `worker_pool_id`.


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/IBM-Cloud/terraform-provider-ibm/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
% make testacc TEST=./ibm/service/kubernetes TESTARGS='-run=TestAccIBMContainerVpcClusterWorkerPoolEnvvar'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./ibm/service/kubernetes -v -run=TestAccIBMContainerVpcClusterWorkerPoolEnvvar -timeout 700m
...
--- PASS: TestAccIBMContainerVpcClusterWorkerPoolEnvvar (2231.01s)
PASS
ok      github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/kubernetes      2232.690s



% make testacc TEST=./ibm/service/kubernetes TESTARGS='-run=TestAccIBMContainerWorkerPoolBasic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./ibm/service/kubernetes -v -run=TestAccIBMContainerWorkerPoolBasic -timeout 700m
...
=== RUN   TestAccIBMContainerWorkerPoolBasic
--- PASS: TestAccIBMContainerWorkerPoolBasic (1324.47s)
PASS
ok      github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/kubernetes      1325.922s


% make testacc TEST=./ibm/service/kubernetes TESTARGS='-run=TestAccIBMContainerVPCClusterWorkerPoolDataSourceEnvvar'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./ibm/service/kubernetes -v -run=TestAccIBMContainerVPCClusterWorkerPoolDataSourceEnvvar -timeout 700m
...
=== RUN   TestAccIBMContainerVPCClusterWorkerPoolDataSourceEnvvar
--- PASS: TestAccIBMContainerVPCClusterWorkerPoolDataSourceEnvvar (2128.07s)
PASS
ok      github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/kubernetes      2129.463s



% make testacc TEST=./ibm/service/kubernetes TESTARGS='-run=TestAccIBMContainerWorkerPoolDataSource_basic'          
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./ibm/service/kubernetes -v -run=TestAccIBMContainerWorkerPoolDataSource_basic -timeout 700m
...
=== RUN   TestAccIBMContainerWorkerPoolDataSource_basic
--- PASS: TestAccIBMContainerWorkerPoolDataSource_basic (1682.22s)
PASS
ok      github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/kubernetes      1683.884s
...
```
