### PR TITLE
Code engine add data sources

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "go.mod|go.sum|.*.map|^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2023-04-14T18:34:02Z",
+  "generated_at": "2023-05-12T11:45:47Z",
   "plugins_used": [
     {
       "name": "ArtifactoryDetector"
@@ -704,7 +704,7 @@
         "hashed_secret": "813274ccae5b6b509379ab56982d862f7b5969b6",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 965,
+        "line_number": 1008,
         "type": "Base64 High Entropy String",
         "verified_result": null
       }
@@ -714,7 +714,7 @@
         "hashed_secret": "9184b0c38101bf24d78b2bb0d044deb1d33696fc",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 131,
+        "line_number": 132,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -722,7 +722,7 @@
         "hashed_secret": "c427f185ddcb2440be9b77c8e45f1cd487a2e790",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1426,
+        "line_number": 1438,
         "type": "Base64 High Entropy String",
         "verified_result": null
       },
@@ -730,7 +730,7 @@
         "hashed_secret": "1f7e33de15e22de9d2eaf502df284ed25ca40018",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1494,
+        "line_number": 1506,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -738,7 +738,7 @@
         "hashed_secret": "1f614c2eb6b3da22d89bd1b9fd47d7cb7c8fc670",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 3318,
+        "line_number": 3357,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -746,8 +746,7 @@
         "hashed_secret": "7abfce65b8504403afc25c9790f358d513dfbcc6",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 3331,
-
+        "line_number": 3370,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -755,7 +754,7 @@
         "hashed_secret": "0c2d85bf9a9b1579b16f220a4ea8c3d62b2e24b1",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 3372,
+        "line_number": 3411,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -785,7 +784,7 @@
         "hashed_secret": "c8b6f5ef11b9223ac35a5663975a466ebe7ebba9",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1657,
+        "line_number": 1681,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -793,7 +792,7 @@
         "hashed_secret": "8abf4899c01104241510ba87685ad4de76b0c437",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1663,
+        "line_number": 1687,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -1171,7 +1170,7 @@
         "hashed_secret": "3046d9f6cfaaeea6eed9bb7a4ab010fe49b0cfd4",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 104,
+        "line_number": 125,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1179,7 +1178,7 @@
         "hashed_secret": "505032eaf8a3acf9b094a326dfb1cd0537c75a0d",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 200,
+        "line_number": 226,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -1267,7 +1266,7 @@
         "hashed_secret": "3046d9f6cfaaeea6eed9bb7a4ab010fe49b0cfd4",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 60,
+        "line_number": 81,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1275,7 +1274,7 @@
         "hashed_secret": "505032eaf8a3acf9b094a326dfb1cd0537c75a0d",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 305,
+        "line_number": 331,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -1634,6 +1633,96 @@
         "verified_result": null
       }
     ],
+    "ibm/service/codeengine/data_source_ibm_code_engine_app.go": [
+      {
+        "hashed_secret": "3046d9f6cfaaeea6eed9bb7a4ab010fe49b0cfd4",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 74,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "b732fb611fd46a38e8667f9972e0cde777fbe37f",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 313,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "ibm/service/codeengine/data_source_ibm_code_engine_build.go": [
+      {
+        "hashed_secret": "3046d9f6cfaaeea6eed9bb7a4ab010fe49b0cfd4",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 79,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "b732fb611fd46a38e8667f9972e0cde777fbe37f",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 193,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "ibm/service/codeengine/data_source_ibm_code_engine_build_test.go": [
+      {
+        "hashed_secret": "dbed861a9ba5e1ee2e3c039a16b0a68ac52f8f5b",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 19,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "347cd9c53ff77d41a7b22aa56c7b4efaf54658e3",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 55,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "ibm/service/codeengine/data_source_ibm_code_engine_job.go": [
+      {
+        "hashed_secret": "3046d9f6cfaaeea6eed9bb7a4ab010fe49b0cfd4",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 59,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "b732fb611fd46a38e8667f9972e0cde777fbe37f",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 242,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "ibm/service/codeengine/data_source_ibm_code_engine_secret_test.go": [
+      {
+        "hashed_secret": "b10b32fc1b6d1a4a455c44de75d5a8ab9386068d",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 75,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "1348b145fa1a555461c1b790a2f66614781091e9",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 153,
+        "type": "Private Key",
+        "verified_result": null
+      }
+    ],
     "ibm/service/codeengine/resource_ibm_code_engine_app.go": [
       {
         "hashed_secret": "3046d9f6cfaaeea6eed9bb7a4ab010fe49b0cfd4",
@@ -1655,7 +1744,7 @@
         "hashed_secret": "3c956707ac29b4a200e47fceffa923341eed7e4f",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 771,
+        "line_number": 767,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -3451,7 +3540,7 @@
         "hashed_secret": "f855f5027fd8fdb2df3f6a6f1cf858fffcbedb0c",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 84849,
+        "line_number": 85980,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -3459,7 +3548,7 @@
         "hashed_secret": "5fb0fa884132a8724a8d7cba55853737e442adbd",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 104163,
+        "line_number": 106299,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -3467,7 +3556,7 @@
         "hashed_secret": "1e5c2f367f02e47a8c160cda1cd9d91decbac441",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 131106,
+        "line_number": 133301,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -4129,7 +4218,7 @@
         "hashed_secret": "d47dcacc720a39e236679ac3e311a0d58bb6519e",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 103,
+        "line_number": 111,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -4137,7 +4226,7 @@
         "hashed_secret": "e66e7d67fdf3c596c435fc7828b13205e4950a0f",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 105,
+        "line_number": 113,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -4512,24 +4601,6 @@
         "verified_result": null
       }
     ],
-    "website/docs/r/project_instance.html.markdown": [
-      {
-        "hashed_secret": "d47dcacc720a39e236679ac3e311a0d58bb6519e",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 134,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "e66e7d67fdf3c596c435fc7828b13205e4950a0f",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 136,
-        "type": "Secret Keyword",
-        "verified_result": null
-      }
-    ],
     "website/docs/r/resource_instance.html.markdown": [
       {
         "hashed_secret": "d62552e3d0606ac398b6ee5cbd49e763ac9c3933",
@@ -4635,7 +4706,7 @@
         "hashed_secret": "d47dcacc720a39e236679ac3e311a0d58bb6519e",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 125,
+        "line_number": 126,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -4643,7 +4714,7 @@
         "hashed_secret": "e66e7d67fdf3c596c435fc7828b13205e4950a0f",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 127,
+        "line_number": 128,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -4725,7 +4796,7 @@
         "hashed_secret": "d47dcacc720a39e236679ac3e311a0d58bb6519e",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 136,
+        "line_number": 137,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -4733,7 +4804,7 @@
         "hashed_secret": "e66e7d67fdf3c596c435fc7828b13205e4950a0f",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 138,
+        "line_number": 139,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -4897,7 +4968,7 @@
       }
     ]
   },
-  "version": "0.13.1+ibm.56.dss",
+  "version": "0.13.1+ibm.60.dss",
   "word_list": {
     "file": null,
     "hash": null

--- a/examples/ibm-code-engine/README.md
+++ b/examples/ibm-code-engine/README.md
@@ -4,11 +4,11 @@ This example illustrates how to use the CodeEngineV2
 
 These types of resources are supported:
 
-* code_engine_project
 * code_engine_app
 * code_engine_build
 * code_engine_config_map
 * code_engine_job
+* code_engine_project
 * code_engine_secret
 
 ## Usage
@@ -111,12 +111,59 @@ data "code_engine_project" "code_engine_project_instance" {
 }
 ```
 
+code_engine_app data source:
+
+```hcl
+data "ibm_code_engine_app" "code_engine_app_instance" {
+  project_id = var.code_engine_project_id
+  name       = var.code_engine_app_name
+}
+```
+
+code_engine_build data source:
+
+```hcl
+data "ibm_code_engine_build" "code_engine_build_instance" {
+  project_id = var.code_engine_project_id
+  name       = var.code_engine_build_name
+}
+```
+
+code_engine_config_map data source:
+
+```hcl
+data "code_engine_config_map" "code_engine_config_map_instance" {
+  project_id = var.code_engine_project_id
+  name       = var.code_engine_config_map_name
+}
+```
+
+code_engine_job data source:
+
+```hcl
+data "ibm_code_engine_job" "code_engine_job_instance" {
+  project_id = var.code_engine_project_id
+  name       = var.code_engine_job_name
+}
+
+```
+
+code_engine_secret data source:
+
+```hcl
+data "code_engine_secret" "code_engine_secret_instance" {
+  project_id = var.code_engine_secret_project_id
+  name       = var.code_engine_secret_name
+}
+```
+
 ## Inputs
 
 | Name | Description | Type | Required |
 |------|-------------|------|---------|
 | ibmcloud\_api\_key | IBM Cloud API key | `string` | true |
 | project_id | The ID of the project. | `string` | true |
+| image_reference | The name of the image that is used for this job. The format is `REGISTRY/NAMESPACE/REPOSITORY:TAG` where `REGISTRY` and `TAG` are optional. If `REGISTRY` is not specified, the default is `docker.io`. If `TAG` is not specified, the default is `latest`. If the image reference points to a registry that requires authentication, make sure to also specify the property `image_secret`. | `string` | true |
 | name | The name of the resource. | `string` | true |
 | image_port | Optional port the app listens on. While the app will always be exposed via port `443` for end users, this port is used to connect to the port that is exposed by the container image. | `number` | false |
 | image_secret | Optional name of the image registry access secret. The image registry access secret is used to authenticate with a private registry when you download the container image. If the image reference points to a registry that requires authentication, the app will be created but cannot reach the ready status, until this property is provided, too. | `string` | false |
@@ -168,7 +215,6 @@ data "code_engine_project" "code_engine_project_instance" {
 | scale_retry_limit | The number of times to rerun an instance of the job before the job is marked as failed. This property can only be specified if `run_mode` is `task`. | `number` | false |
 | resource_group_id | Optional ID of the resource group for your project deployment. If this field is not defined, the default resource group of the account will be used. | `string` | false |
 | project_id | The ID of the project. | `string` | true |
-| data | Data container that allows to specify config parameters and their values as a key-value map. Each key field must consist of alphanumeric characters, `-`, `_` or `.` and must not be exceed a max length of 253 characters. Each value field can consists of any character and must not be exceed a max length of 1048576 characters. | `map(string)` | false |
 | format | Specify the format of the secret. | `string` | true |
 
 ## Outputs

--- a/examples/ibm-code-engine/main.tf
+++ b/examples/ibm-code-engine/main.tf
@@ -1,3 +1,6 @@
+//////////////////
+// Resources
+
 // Provision code_engine_project resource instance
 resource "ibm_code_engine_project" "code_engine_project_instance" {
   name = var.code_engine_project_name
@@ -11,7 +14,7 @@ resource "ibm_code_engine_config_map" "code_engine_config_map_instance" {
 }
 
 // Provision code_engine_secret resource instance
-resource "ibm_code_engine_secret" "code_engine_secret_instance" {
+resource "ibm_code_engine_secret" "code_engine_secret_generic" {
   project_id = ibm_code_engine_project.code_engine_project_instance.project_id
   name       = var.code_engine_secret_name
   format     = var.code_engine_secret_format
@@ -47,8 +50,40 @@ resource "ibm_code_engine_job" "code_engine_job_instance" {
   name            = var.code_engine_job_name
 }
 
+//////////////////
+// Data sources
+
 // Create code_engine_project data source
-data "ibm_code_engine_project" "code_engine_project_instance" {
+data "ibm_code_engine_project" "code_engine_project_data" {
   project_id = ibm_code_engine_project.code_engine_project_instance.project_id
 }
 
+// Create code_engine_config_map data source
+data "ibm_code_engine_config_map" "code_engine_config_map_data" {
+  project_id = data.ibm_code_engine_project.code_engine_project_data.project_id
+  name       = var.code_engine_config_map_name
+}
+
+// Create code_engine_secret data source
+data "ibm_code_engine_secret" "code_engine_secret_data" {
+  project_id = data.ibm_code_engine_project.code_engine_project_data.project_id
+  name       = var.code_engine_secret_name
+}
+
+// Create code_engine_app data source
+data "ibm_code_engine_app" "code_engine_app_data" {
+  project_id = data.ibm_code_engine_project.code_engine_project_data.project_id
+  name       = var.code_engine_app_name
+}
+
+// Create code_engine_build data source
+data "ibm_code_engine_build" "code_engine_build_data" {
+  project_id = data.ibm_code_engine_project.code_engine_project_data.project_id
+  name       = var.code_engine_build_name
+}
+
+// Create code_engine_job data source
+data "ibm_code_engine_job" "code_engine_job_data" {
+  project_id = data.ibm_code_engine_project.code_engine_project_data.project_id
+  name       = var.code_engine_job_name
+}

--- a/examples/ibm-code-engine/outputs.tf
+++ b/examples/ibm-code-engine/outputs.tf
@@ -23,15 +23,16 @@ output "ibm_code_engine_config_map" {
   value       = ibm_code_engine_config_map.code_engine_config_map_instance
   description = "code_engine_config_map resource instance"
 }
-// This allows code_engine_secret data to be referenced by other resources and the terraform CLI
-// Modify this if only certain data should be exposed
-output "ibm_code_engine_secret" {
-  value       = ibm_code_engine_secret.code_engine_secret_instance
-  description = "code_engine_secret resource instance"
-}
 // This allows code_engine_job data to be referenced by other resources and the terraform CLI
 // Modify this if only certain data should be exposed
 output "ibm_code_engine_job" {
   value       = ibm_code_engine_job.code_engine_job_instance
   description = "code_engine_job resource instance"
+}
+// This allows code_engine_secret data to be referenced by other resources and the terraform CLI
+// Modify this if only certain data should be exposed
+output "ibm_code_engine_secret" {
+  value       = ibm_code_engine_secret.code_engine_secret_generic
+  description = "code_engine_secret resource instance"
+  sensitive   = true
 }

--- a/examples/ibm-code-engine/variables.tf
+++ b/examples/ibm-code-engine/variables.tf
@@ -12,7 +12,7 @@ variable "code_engine_project_name" {
 
 // Resource arguments for code_engine_app
 variable "code_engine_app_image_reference" {
-  description = "The name of the image that is used for this app. The format is `REGISTRY/NAMESPACE/REPOSITORY:TAG` where `REGISTRY` and `TAG` are optional. If `REGISTRY` is not specified, the default is `docker.io`. If `TAG` is not specified, the default is `latest`. If the image reference points to a registry that requires authentication, make sure to also specify the property `image_secret`."
+  description = "The name of the image that is used for this job. The format is `REGISTRY/NAMESPACE/REPOSITORY:TAG` where `REGISTRY` and `TAG` are optional. If `REGISTRY` is not specified, the default is `docker.io`. If `TAG` is not specified, the default is `latest`. If the image reference points to a registry that requires authentication, make sure to also specify the property `image_secret`."
   type        = string
   default     = "icr.io/codeengine/helloworld"
 }
@@ -65,7 +65,7 @@ variable "code_engine_config_map_data" {
 variable "code_engine_secret_name" {
   description = "The name of the secret. Use a name that is unique within the project."
   type        = string
-  default     = "my-secret"
+  default     = "my-generic-secret"
 }
 variable "code_engine_secret_format" {
   description = "The format of the secret. Use a name that is unique within the project."

--- a/ibm/provider/provider.go
+++ b/ibm/provider/provider.go
@@ -796,7 +796,12 @@ func Provider() *schema.Provider {
 			"ibm_cd_tekton_pipeline":                  cdtektonpipeline.DataSourceIBMCdTektonPipeline(),
 
 			// Added for Code Engine
-			"ibm_code_engine_project": codeengine.DataSourceIbmCodeEngineProject(),
+			"ibm_code_engine_app":        codeengine.DataSourceIbmCodeEngineApp(),
+			"ibm_code_engine_build":      codeengine.DataSourceIbmCodeEngineBuild(),
+			"ibm_code_engine_config_map": codeengine.DataSourceIbmCodeEngineConfigMap(),
+			"ibm_code_engine_job":        codeengine.DataSourceIbmCodeEngineJob(),
+			"ibm_code_engine_project":    codeengine.DataSourceIbmCodeEngineProject(),
+			"ibm_code_engine_secret":     codeengine.DataSourceIbmCodeEngineSecret(),
 
 			// Added for Project
 			"ibm_project_event_notification": project.DataSourceIbmProjectEventNotification(),

--- a/ibm/service/codeengine/data_source_ibm_code_engine_app.go
+++ b/ibm/service/codeengine/data_source_ibm_code_engine_app.go
@@ -1,0 +1,457 @@
+// Copyright IBM Corp. 2023 All Rights Reserved.
+// Licensed under the Mozilla Public License v2.0
+
+package codeengine
+
+import (
+	"context"
+	"fmt"
+	"log"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/conns"
+	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/flex"
+	"github.com/IBM/code-engine-go-sdk/codeenginev2"
+)
+
+func DataSourceIbmCodeEngineApp() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceIbmCodeEngineAppRead,
+
+		Schema: map[string]*schema.Schema{
+			"project_id": &schema.Schema{
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "The ID of the project.",
+			},
+			"name": &schema.Schema{
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "The name of your application.",
+			},
+			"created_at": &schema.Schema{
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The timestamp when the resource was created.",
+			},
+			"endpoint": &schema.Schema{
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "Optional URL to invoke app. Depending on visibility this is accessible publicly or in the private network only. Empty in case 'managed_domain_mappings' is set to 'local'.",
+			},
+			"endpoint_internal": &schema.Schema{
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "URL to app that is only visible within the project.",
+			},
+			"entity_tag": &schema.Schema{
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The version of the app instance, which is used to achieve optimistic locking.",
+			},
+			"href": &schema.Schema{
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "When you provision a new app,  a URL is created identifying the location of the instance.",
+			},
+			"app_id": &schema.Schema{
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The identifier of the resource.",
+			},
+			"image_port": &schema.Schema{
+				Type:        schema.TypeInt,
+				Computed:    true,
+				Description: "Optional port the app listens on. While the app will always be exposed via port `443` for end users, this port is used to connect to the port that is exposed by the container image.",
+			},
+			"image_reference": &schema.Schema{
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The name of the image that is used for this app. The format is `REGISTRY/NAMESPACE/REPOSITORY:TAG` where `REGISTRY` and `TAG` are optional. If `REGISTRY` is not specified, the default is `docker.io`. If `TAG` is not specified, the default is `latest`. If the image reference points to a registry that requires authentication, make sure to also specify the property `image_secret`.",
+			},
+			"image_secret": &schema.Schema{
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "Optional name of the image registry access secret. The image registry access secret is used to authenticate with a private registry when you download the container image. If the image reference points to a registry that requires authentication, the app will be created but cannot reach the ready status, until this property is provided, too.",
+			},
+			"managed_domain_mappings": &schema.Schema{
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "Optional value controlling which of the system managed domain mappings will be setup for the application. Valid values are 'local_public', 'local_private' and 'local'. Visibility can only be 'local_private' if the project supports application private visibility.",
+			},
+			"resource_type": &schema.Schema{
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The type of the app.",
+			},
+			"run_arguments": &schema.Schema{
+				Type:        schema.TypeList,
+				Computed:    true,
+				Description: "Optional arguments for the app that are passed to start the container. If not specified an empty string array will be applied and the arguments specified by the container image, will be used to start the container.",
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
+			},
+			"run_as_user": &schema.Schema{
+				Type:        schema.TypeInt,
+				Computed:    true,
+				Description: "Optional user ID (UID) to run the app (e.g., `1001`).",
+			},
+			"run_commands": &schema.Schema{
+				Type:        schema.TypeList,
+				Computed:    true,
+				Description: "Optional commands for the app that are passed to start the container. If not specified an empty string array will be applied and the command specified by the container image, will be used to start the container.",
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
+			},
+			"run_env_variables": &schema.Schema{
+				Type:        schema.TypeList,
+				Computed:    true,
+				Description: "References to config maps, secrets or literal values, which are exposed as environment variables in the application.",
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"key": &schema.Schema{
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "The key to reference as environment variable.",
+						},
+						"name": &schema.Schema{
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "The name of the environment variable.",
+						},
+						"prefix": &schema.Schema{
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "A prefix that can be added to all keys of a full secret or config map reference.",
+						},
+						"reference": &schema.Schema{
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "The name of the secret or config map.",
+						},
+						"type": &schema.Schema{
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "Specify the type of the environment variable.",
+						},
+						"value": &schema.Schema{
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "The literal value of the environment variable.",
+						},
+					},
+				},
+			},
+			"run_service_account": &schema.Schema{
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "Optional name of the service account. For built-in service accounts, you can use the shortened names `manager` , `none`, `reader`, and `writer`.",
+			},
+			"run_volume_mounts": &schema.Schema{
+				Type:        schema.TypeList,
+				Computed:    true,
+				Description: "Mounts of config maps or secrets.",
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"mount_path": &schema.Schema{
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "The path that should be mounted.",
+						},
+						"name": &schema.Schema{
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "The name of the mount.",
+						},
+						"reference": &schema.Schema{
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "The name of the referenced secret or config map.",
+						},
+						"type": &schema.Schema{
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "Specify the type of the volume mount. Allowed types are: 'config_map', 'secret'.",
+						},
+					},
+				},
+			},
+			"scale_concurrency": &schema.Schema{
+				Type:        schema.TypeInt,
+				Computed:    true,
+				Description: "Optional maximum number of requests that can be processed concurrently per instance.",
+			},
+			"scale_concurrency_target": &schema.Schema{
+				Type:        schema.TypeInt,
+				Computed:    true,
+				Description: "Optional threshold of concurrent requests per instance at which one or more additional instances are created. Use this value to scale up instances based on concurrent number of requests. This option defaults to the value of the `scale_concurrency` option, if not specified.",
+			},
+			"scale_cpu_limit": &schema.Schema{
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "Optional number of CPU set for the instance of the app. For valid values see [Supported memory and CPU combinations](https://cloud.ibm.com/docs/codeengine?topic=codeengine-mem-cpu-combo).",
+			},
+			"scale_ephemeral_storage_limit": &schema.Schema{
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "Optional amount of ephemeral storage to set for the instance of the app. The amount specified as ephemeral storage, must not exceed the amount of `scale_memory_limit`. The units for specifying ephemeral storage are Megabyte (M) or Gigabyte (G), whereas G and M are the shorthand expressions for GB and MB. For more information see [Units of measurement](https://cloud.ibm.com/docs/codeengine?topic=codeengine-mem-cpu-combo#unit-measurements).",
+			},
+			"scale_initial_instances": &schema.Schema{
+				Type:        schema.TypeInt,
+				Computed:    true,
+				Description: "Optional initial number of instances that are created upon app creation or app update.",
+			},
+			"scale_max_instances": &schema.Schema{
+				Type:        schema.TypeInt,
+				Computed:    true,
+				Description: "Optional maximum number of instances for this app. If you set this value to `0`, this property does not set a upper scaling limit. However, the app scaling is still limited by the project quota for instances. See [Limits and quotas for Code Engine](https://cloud.ibm.com/docs/codeengine?topic=codeengine-limits).",
+			},
+			"scale_memory_limit": &schema.Schema{
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "Optional amount of memory set for the instance of the app. For valid values see [Supported memory and CPU combinations](https://cloud.ibm.com/docs/codeengine?topic=codeengine-mem-cpu-combo). The units for specifying memory are Megabyte (M) or Gigabyte (G), whereas G and M are the shorthand expressions for GB and MB. For more information see [Units of measurement](https://cloud.ibm.com/docs/codeengine?topic=codeengine-mem-cpu-combo#unit-measurements).",
+			},
+			"scale_min_instances": &schema.Schema{
+				Type:        schema.TypeInt,
+				Computed:    true,
+				Description: "Optional minimum number of instances for this app. If you set this value to `0`, the app will scale down to zero, if not hit by any request for some time.",
+			},
+			"scale_request_timeout": &schema.Schema{
+				Type:        schema.TypeInt,
+				Computed:    true,
+				Description: "Optional amount of time in seconds that is allowed for a running app to respond to a request.",
+			},
+			"status": &schema.Schema{
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The current status of the app.",
+			},
+			"status_details": &schema.Schema{
+				Type:        schema.TypeList,
+				Computed:    true,
+				Description: "The detailed status of the application.",
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"latest_created_revision": &schema.Schema{
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "Latest app revision that has been created.",
+						},
+						"latest_ready_revision": &schema.Schema{
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "Latest app revision that reached a ready state.",
+						},
+						"reason": &schema.Schema{
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "Optional information to provide more context in case of a 'failed' or 'warning' status.",
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func dataSourceIbmCodeEngineAppRead(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	codeEngineClient, err := meta.(conns.ClientSession).CodeEngineV2()
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	getAppOptions := &codeenginev2.GetAppOptions{}
+
+	getAppOptions.SetProjectID(d.Get("project_id").(string))
+	getAppOptions.SetName(d.Get("name").(string))
+
+	app, response, err := codeEngineClient.GetAppWithContext(context, getAppOptions)
+	if err != nil {
+		log.Printf("[DEBUG] GetAppWithContext failed %s\n%s", err, response)
+		return diag.FromErr(fmt.Errorf("GetAppWithContext failed %s\n%s", err, response))
+	}
+
+	d.SetId(fmt.Sprintf("%s/%s", *getAppOptions.ProjectID, *getAppOptions.Name))
+
+	if err = d.Set("created_at", app.CreatedAt); err != nil {
+		return diag.FromErr(fmt.Errorf("Error setting created_at: %s", err))
+	}
+
+	if err = d.Set("endpoint", app.Endpoint); err != nil {
+		return diag.FromErr(fmt.Errorf("Error setting endpoint: %s", err))
+	}
+
+	if err = d.Set("endpoint_internal", app.EndpointInternal); err != nil {
+		return diag.FromErr(fmt.Errorf("Error setting endpoint_internal: %s", err))
+	}
+
+	if err = d.Set("entity_tag", app.EntityTag); err != nil {
+		return diag.FromErr(fmt.Errorf("Error setting entity_tag: %s", err))
+	}
+
+	if err = d.Set("href", app.Href); err != nil {
+		return diag.FromErr(fmt.Errorf("Error setting href: %s", err))
+	}
+
+	if err = d.Set("app_id", app.ID); err != nil {
+		return diag.FromErr(fmt.Errorf("Error setting app_id: %s", err))
+	}
+
+	if err = d.Set("image_port", flex.IntValue(app.ImagePort)); err != nil {
+		return diag.FromErr(fmt.Errorf("Error setting image_port: %s", err))
+	}
+
+	if err = d.Set("image_reference", app.ImageReference); err != nil {
+		return diag.FromErr(fmt.Errorf("Error setting image_reference: %s", err))
+	}
+
+	if err = d.Set("image_secret", app.ImageSecret); err != nil {
+		return diag.FromErr(fmt.Errorf("Error setting image_secret: %s", err))
+	}
+
+	if err = d.Set("managed_domain_mappings", app.ManagedDomainMappings); err != nil {
+		return diag.FromErr(fmt.Errorf("Error setting managed_domain_mappings: %s", err))
+	}
+
+	if err = d.Set("resource_type", app.ResourceType); err != nil {
+		return diag.FromErr(fmt.Errorf("Error setting resource_type: %s", err))
+	}
+
+	if err = d.Set("run_as_user", flex.IntValue(app.RunAsUser)); err != nil {
+		return diag.FromErr(fmt.Errorf("Error setting run_as_user: %s", err))
+	}
+
+	runEnvVariables := []map[string]interface{}{}
+	if app.RunEnvVariables != nil {
+		for _, modelItem := range app.RunEnvVariables {
+			modelMap, err := dataSourceIbmCodeEngineAppEnvVarToMap(&modelItem)
+			if err != nil {
+				return diag.FromErr(err)
+			}
+			runEnvVariables = append(runEnvVariables, modelMap)
+		}
+	}
+	if err = d.Set("run_env_variables", runEnvVariables); err != nil {
+		return diag.FromErr(fmt.Errorf("Error setting run_env_variables %s", err))
+	}
+
+	if err = d.Set("run_service_account", app.RunServiceAccount); err != nil {
+		return diag.FromErr(fmt.Errorf("Error setting run_service_account: %s", err))
+	}
+
+	runVolumeMounts := []map[string]interface{}{}
+	if app.RunVolumeMounts != nil {
+		for _, modelItem := range app.RunVolumeMounts {
+			modelMap, err := dataSourceIbmCodeEngineAppVolumeMountToMap(&modelItem)
+			if err != nil {
+				return diag.FromErr(err)
+			}
+			runVolumeMounts = append(runVolumeMounts, modelMap)
+		}
+	}
+	if err = d.Set("run_volume_mounts", runVolumeMounts); err != nil {
+		return diag.FromErr(fmt.Errorf("Error setting run_volume_mounts %s", err))
+	}
+
+	if err = d.Set("scale_concurrency", flex.IntValue(app.ScaleConcurrency)); err != nil {
+		return diag.FromErr(fmt.Errorf("Error setting scale_concurrency: %s", err))
+	}
+
+	if err = d.Set("scale_concurrency_target", flex.IntValue(app.ScaleConcurrencyTarget)); err != nil {
+		return diag.FromErr(fmt.Errorf("Error setting scale_concurrency_target: %s", err))
+	}
+
+	if err = d.Set("scale_cpu_limit", app.ScaleCpuLimit); err != nil {
+		return diag.FromErr(fmt.Errorf("Error setting scale_cpu_limit: %s", err))
+	}
+
+	if err = d.Set("scale_ephemeral_storage_limit", app.ScaleEphemeralStorageLimit); err != nil {
+		return diag.FromErr(fmt.Errorf("Error setting scale_ephemeral_storage_limit: %s", err))
+	}
+
+	if err = d.Set("scale_initial_instances", flex.IntValue(app.ScaleInitialInstances)); err != nil {
+		return diag.FromErr(fmt.Errorf("Error setting scale_initial_instances: %s", err))
+	}
+
+	if err = d.Set("scale_max_instances", flex.IntValue(app.ScaleMaxInstances)); err != nil {
+		return diag.FromErr(fmt.Errorf("Error setting scale_max_instances: %s", err))
+	}
+
+	if err = d.Set("scale_memory_limit", app.ScaleMemoryLimit); err != nil {
+		return diag.FromErr(fmt.Errorf("Error setting scale_memory_limit: %s", err))
+	}
+
+	if err = d.Set("scale_min_instances", flex.IntValue(app.ScaleMinInstances)); err != nil {
+		return diag.FromErr(fmt.Errorf("Error setting scale_min_instances: %s", err))
+	}
+
+	if err = d.Set("scale_request_timeout", flex.IntValue(app.ScaleRequestTimeout)); err != nil {
+		return diag.FromErr(fmt.Errorf("Error setting scale_request_timeout: %s", err))
+	}
+
+	if err = d.Set("status", app.Status); err != nil {
+		return diag.FromErr(fmt.Errorf("Error setting status: %s", err))
+	}
+
+	statusDetails := []map[string]interface{}{}
+	if app.StatusDetails != nil {
+		modelMap, err := dataSourceIbmCodeEngineAppAppStatusToMap(app.StatusDetails)
+		if err != nil {
+			return diag.FromErr(err)
+		}
+		statusDetails = append(statusDetails, modelMap)
+	}
+	if err = d.Set("status_details", statusDetails); err != nil {
+		return diag.FromErr(fmt.Errorf("Error setting status_details %s", err))
+	}
+
+	return nil
+}
+
+func dataSourceIbmCodeEngineAppEnvVarToMap(model *codeenginev2.EnvVar) (map[string]interface{}, error) {
+	modelMap := make(map[string]interface{})
+	if model.Key != nil {
+		modelMap["key"] = model.Key
+	}
+	if model.Name != nil {
+		modelMap["name"] = model.Name
+	}
+	if model.Prefix != nil {
+		modelMap["prefix"] = model.Prefix
+	}
+	if model.Reference != nil {
+		modelMap["reference"] = model.Reference
+	}
+	modelMap["type"] = model.Type
+	if model.Value != nil {
+		modelMap["value"] = model.Value
+	}
+	return modelMap, nil
+}
+
+func dataSourceIbmCodeEngineAppVolumeMountToMap(model *codeenginev2.VolumeMount) (map[string]interface{}, error) {
+	modelMap := make(map[string]interface{})
+	modelMap["mount_path"] = model.MountPath
+	modelMap["name"] = model.Name
+	modelMap["reference"] = model.Reference
+	modelMap["type"] = model.Type
+	return modelMap, nil
+}
+
+func dataSourceIbmCodeEngineAppAppStatusToMap(model *codeenginev2.AppStatus) (map[string]interface{}, error) {
+	modelMap := make(map[string]interface{})
+	if model.LatestCreatedRevision != nil {
+		modelMap["latest_created_revision"] = model.LatestCreatedRevision
+	}
+	if model.LatestReadyRevision != nil {
+		modelMap["latest_ready_revision"] = model.LatestReadyRevision
+	}
+	if model.Reason != nil {
+		modelMap["reason"] = model.Reason
+	}
+	return modelMap, nil
+}

--- a/ibm/service/codeengine/data_source_ibm_code_engine_app_test.go
+++ b/ibm/service/codeengine/data_source_ibm_code_engine_app_test.go
@@ -1,0 +1,166 @@
+// Copyright IBM Corp. 2023 All Rights Reserved.
+// Licensed under the Mozilla Public License v2.0
+
+package codeengine_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	acc "github.com/IBM-Cloud/terraform-provider-ibm/ibm/acctest"
+)
+
+func TestAccIbmCodeEngineAppDataSourceBasic(t *testing.T) {
+	appName := fmt.Sprintf("tf-data-app-basic-%d", acctest.RandIntRange(10, 1000))
+	appImageReference := "icr.io/codeengine/helloworld"
+
+	projectID := acc.CeProjectId
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { acc.TestAccPreCheck(t) },
+		Providers: acc.TestAccProviders,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccCheckIbmCodeEngineAppDataSourceConfigBasic(projectID, appImageReference, appName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet("data.ibm_code_engine_app.code_engine_app_instance", "app_id"),
+					resource.TestCheckResourceAttr("data.ibm_code_engine_app.code_engine_app_instance", "project_id", projectID),
+					resource.TestCheckResourceAttr("data.ibm_code_engine_app.code_engine_app_instance", "resource_type", "app_v2"),
+					resource.TestCheckResourceAttr("data.ibm_code_engine_app.code_engine_app_instance", "image_reference", appImageReference),
+					resource.TestCheckResourceAttr("data.ibm_code_engine_app.code_engine_app_instance", "name", appName),
+					resource.TestCheckResourceAttr("data.ibm_code_engine_app.code_engine_app_instance", "image_port", "8080"),
+					resource.TestCheckResourceAttr("data.ibm_code_engine_app.code_engine_app_instance", "managed_domain_mappings", "local_public"),
+					resource.TestCheckResourceAttr("data.ibm_code_engine_app.code_engine_app_instance", "run_service_account", "default"),
+					resource.TestCheckResourceAttr("data.ibm_code_engine_app.code_engine_app_instance", "scale_concurrency", "100"),
+					resource.TestCheckResourceAttr("data.ibm_code_engine_app.code_engine_app_instance", "scale_cpu_limit", "1"),
+					resource.TestCheckResourceAttr("data.ibm_code_engine_app.code_engine_app_instance", "scale_ephemeral_storage_limit", "400M"),
+					resource.TestCheckResourceAttr("data.ibm_code_engine_app.code_engine_app_instance", "scale_initial_instances", "1"),
+					resource.TestCheckResourceAttr("data.ibm_code_engine_app.code_engine_app_instance", "scale_max_instances", "10"),
+					resource.TestCheckResourceAttr("data.ibm_code_engine_app.code_engine_app_instance", "scale_memory_limit", "4G"),
+					resource.TestCheckResourceAttr("data.ibm_code_engine_app.code_engine_app_instance", "scale_min_instances", "0"),
+					resource.TestCheckResourceAttr("data.ibm_code_engine_app.code_engine_app_instance", "scale_request_timeout", "300"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccIbmCodeEngineAppDataSourceExtended(t *testing.T) {
+	appImageReference := "icr.io/codeengine/helloworld"
+	appName := fmt.Sprintf("tf-data-app-extended-%d", acctest.RandIntRange(10, 1000))
+	appImagePort := "8080"
+	appManagedDomainMappings := "local_public"
+	appRunAsUser := "0"
+	appRunServiceAccount := "default"
+	appScaleConcurrency := fmt.Sprintf("%d", acctest.RandIntRange(50, 100))
+	appScaleConcurrencyTarget := fmt.Sprintf("%d", acctest.RandIntRange(20, 50))
+	appScaleCpuLimit := "0.5"
+	appScaleEphemeralStorageLimit := "500M"
+	appScaleInitialInstances := "2"
+	appScaleMaxInstances := "2"
+	appScaleMemoryLimit := "1G"
+	appScaleMinInstances := "1"
+	appScaleRequestTimeout := fmt.Sprintf("%d", acctest.RandIntRange(10, 30))
+
+	projectID := acc.CeProjectId
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { acc.TestAccPreCheck(t) },
+		Providers: acc.TestAccProviders,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccCheckIbmCodeEngineAppDataSourceConfig(projectID, appImageReference, appName, appImagePort, appManagedDomainMappings, appRunAsUser, appRunServiceAccount, appScaleConcurrency, appScaleConcurrencyTarget, appScaleCpuLimit, appScaleEphemeralStorageLimit, appScaleInitialInstances, appScaleMaxInstances, appScaleMemoryLimit, appScaleMinInstances, appScaleRequestTimeout),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("data.ibm_code_engine_app.code_engine_app_instance", "project_id", projectID),
+					resource.TestCheckResourceAttr("data.ibm_code_engine_app.code_engine_app_instance", "image_reference", appImageReference),
+					resource.TestCheckResourceAttr("data.ibm_code_engine_app.code_engine_app_instance", "name", appName),
+					resource.TestCheckResourceAttr("data.ibm_code_engine_app.code_engine_app_instance", "image_port", appImagePort),
+					resource.TestCheckResourceAttr("data.ibm_code_engine_app.code_engine_app_instance", "managed_domain_mappings", appManagedDomainMappings),
+					resource.TestCheckResourceAttr("data.ibm_code_engine_app.code_engine_app_instance", "run_as_user", appRunAsUser),
+					resource.TestCheckResourceAttr("data.ibm_code_engine_app.code_engine_app_instance", "run_service_account", appRunServiceAccount),
+					resource.TestCheckResourceAttr("data.ibm_code_engine_app.code_engine_app_instance", "scale_concurrency", appScaleConcurrency),
+					resource.TestCheckResourceAttr("data.ibm_code_engine_app.code_engine_app_instance", "scale_concurrency_target", appScaleConcurrencyTarget),
+					resource.TestCheckResourceAttr("data.ibm_code_engine_app.code_engine_app_instance", "scale_cpu_limit", appScaleCpuLimit),
+					resource.TestCheckResourceAttr("data.ibm_code_engine_app.code_engine_app_instance", "scale_ephemeral_storage_limit", appScaleEphemeralStorageLimit),
+					resource.TestCheckResourceAttr("data.ibm_code_engine_app.code_engine_app_instance", "scale_initial_instances", appScaleInitialInstances),
+					resource.TestCheckResourceAttr("data.ibm_code_engine_app.code_engine_app_instance", "scale_max_instances", appScaleMaxInstances),
+					resource.TestCheckResourceAttr("data.ibm_code_engine_app.code_engine_app_instance", "scale_memory_limit", appScaleMemoryLimit),
+					resource.TestCheckResourceAttr("data.ibm_code_engine_app.code_engine_app_instance", "scale_min_instances", appScaleMinInstances),
+					resource.TestCheckResourceAttr("data.ibm_code_engine_app.code_engine_app_instance", "scale_request_timeout", appScaleRequestTimeout),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckIbmCodeEngineAppDataSourceConfigBasic(projectID string, appImageReference string, appName string) string {
+	return fmt.Sprintf(`
+		data "ibm_code_engine_project" "code_engine_project_instance" {
+			project_id = "%s"
+		}
+
+		resource "ibm_code_engine_app" "code_engine_app_instance" {
+			project_id = data.ibm_code_engine_project.code_engine_project_instance.project_id
+			image_reference = "%s"
+			name = "%s"
+
+			lifecycle {
+				ignore_changes = [
+					run_env_variables
+				]
+			}
+		}
+
+		data "ibm_code_engine_app" "code_engine_app_instance" {
+			project_id = ibm_code_engine_app.code_engine_app_instance.project_id
+			name = ibm_code_engine_app.code_engine_app_instance.name
+		}
+	`, projectID, appImageReference, appName)
+}
+
+func testAccCheckIbmCodeEngineAppDataSourceConfig(projectID string, appImageReference string, appName string, appImagePort string, appManagedDomainMappings string, appRunAsUser string, appRunServiceAccount string, appScaleConcurrency string, appScaleConcurrencyTarget string, appScaleCpuLimit string, appScaleEphemeralStorageLimit string, appScaleInitialInstances string, appScaleMaxInstances string, appScaleMemoryLimit string, appScaleMinInstances string, appScaleRequestTimeout string) string {
+	return fmt.Sprintf(`
+		data "ibm_code_engine_project" "code_engine_project_instance" {
+			project_id = "%s"
+		}
+
+		resource "ibm_code_engine_app" "code_engine_app_instance" {
+			project_id = data.ibm_code_engine_project.code_engine_project_instance.project_id
+			image_reference = "%s"
+			name = "%s"
+			image_port = %s
+			managed_domain_mappings = "%s"
+			run_as_user = %s
+			run_service_account = "%s"
+			scale_concurrency = %s
+			scale_concurrency_target = %s
+			scale_cpu_limit = "%s"
+			scale_ephemeral_storage_limit = "%s"
+			scale_initial_instances = %s
+			scale_max_instances = %s
+			scale_memory_limit = "%s"
+			scale_min_instances = %s
+			scale_request_timeout = %s
+
+			run_env_variables {
+				type  = "literal"
+				name  = "name"
+				value = "value"
+			}
+
+			lifecycle {
+				ignore_changes = [
+					run_env_variables
+				]
+			}
+		}
+
+		data "ibm_code_engine_app" "code_engine_app_instance" {
+			project_id = ibm_code_engine_app.code_engine_app_instance.project_id
+			name = ibm_code_engine_app.code_engine_app_instance.name
+		}
+	`, projectID, appImageReference, appName, appImagePort, appManagedDomainMappings, appRunAsUser, appRunServiceAccount, appScaleConcurrency, appScaleConcurrencyTarget, appScaleCpuLimit, appScaleEphemeralStorageLimit, appScaleInitialInstances, appScaleMaxInstances, appScaleMemoryLimit, appScaleMinInstances, appScaleRequestTimeout)
+}

--- a/ibm/service/codeengine/data_source_ibm_code_engine_build.go
+++ b/ibm/service/codeengine/data_source_ibm_code_engine_build.go
@@ -1,0 +1,245 @@
+// Copyright IBM Corp. 2023 All Rights Reserved.
+// Licensed under the Mozilla Public License v2.0
+
+package codeengine
+
+import (
+	"context"
+	"fmt"
+	"log"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/conns"
+	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/flex"
+	"github.com/IBM/code-engine-go-sdk/codeenginev2"
+)
+
+func DataSourceIbmCodeEngineBuild() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceIbmCodeEngineBuildRead,
+
+		Schema: map[string]*schema.Schema{
+			"project_id": &schema.Schema{
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "The ID of the project.",
+			},
+			"name": &schema.Schema{
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "The name of your build.",
+			},
+			"created_at": &schema.Schema{
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The timestamp when the resource was created.",
+			},
+			"entity_tag": &schema.Schema{
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The version of the build instance, which is used to achieve optimistic locking.",
+			},
+			"href": &schema.Schema{
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "When you provision a new build,  a URL is created identifying the location of the instance.",
+			},
+			"build_id": &schema.Schema{
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The identifier of the resource.",
+			},
+			"output_image": &schema.Schema{
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The name of the image.",
+			},
+			"output_secret": &schema.Schema{
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The secret that is required to access the image registry. Make sure that the secret is granted with push permissions towards the specified container registry namespace.",
+			},
+			"resource_type": &schema.Schema{
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The type of the build.",
+			},
+			"source_context_dir": &schema.Schema{
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "Option directory in the repository that contains the buildpacks file or the Dockerfile.",
+			},
+			"source_revision": &schema.Schema{
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "Commit, tag, or branch in the source repository to pull. This field is optional if the `source_type` is `git` and uses the HEAD of default branch if not specified. If the `source_type` value is `local`, this field must be omitted.",
+			},
+			"source_secret": &schema.Schema{
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "Name of the secret that is used access the repository source. This field is optional if the `source_type` is `git`. Additionally, if the `source_url` points to a repository that requires authentication, the build will be created but cannot access any source code, until this property is provided, too. If the `source_type` value is `local`, this field must be omitted.",
+			},
+			"source_type": &schema.Schema{
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "Specifies the type of source to determine if your build source is in a repository or based on local source code.* local - For builds from local source code.* git - For builds from git version controlled source code.",
+			},
+			"source_url": &schema.Schema{
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The URL of the code repository. This field is required if the `source_type` is `git`. If the `source_type` value is `local`, this field must be omitted. If the repository is publicly available you can provide a 'https' URL like `https://github.com/IBM/CodeEngine`. If the repository requires authentication, you need to provide a 'ssh' URL like `git@github.com:IBM/CodeEngine.git` along with a `source_secret` that points to a secret of format `ssh_auth`.",
+			},
+			"status": &schema.Schema{
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The current status of the build.",
+			},
+			"status_details": &schema.Schema{
+				Type:        schema.TypeList,
+				Computed:    true,
+				Description: "The detailed status of the build.",
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"reason": &schema.Schema{
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "Optional information to provide more context in case of a 'failed' or 'warning' status.",
+						},
+					},
+				},
+			},
+			"strategy_size": &schema.Schema{
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "Optional size for the build, which determines the amount of resources used. Build sizes are `small`, `medium`, `large`, `xlarge`.",
+			},
+			"strategy_spec_file": &schema.Schema{
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "Optional path to the specification file that is used for build strategies for building an image.",
+			},
+			"strategy_type": &schema.Schema{
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The strategy to use for building the image.",
+			},
+			"timeout": &schema.Schema{
+				Type:        schema.TypeInt,
+				Computed:    true,
+				Description: "The maximum amount of time, in seconds, that can pass before the build must succeed or fail.",
+			},
+		},
+	}
+}
+
+func dataSourceIbmCodeEngineBuildRead(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	codeEngineClient, err := meta.(conns.ClientSession).CodeEngineV2()
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	getBuildOptions := &codeenginev2.GetBuildOptions{}
+
+	getBuildOptions.SetProjectID(d.Get("project_id").(string))
+	getBuildOptions.SetName(d.Get("name").(string))
+
+	build, response, err := codeEngineClient.GetBuildWithContext(context, getBuildOptions)
+	if err != nil {
+		log.Printf("[DEBUG] GetBuildWithContext failed %s\n%s", err, response)
+		return diag.FromErr(fmt.Errorf("GetBuildWithContext failed %s\n%s", err, response))
+	}
+
+	d.SetId(fmt.Sprintf("%s/%s", *getBuildOptions.ProjectID, *getBuildOptions.Name))
+
+	if err = d.Set("created_at", build.CreatedAt); err != nil {
+		return diag.FromErr(fmt.Errorf("Error setting created_at: %s", err))
+	}
+
+	if err = d.Set("entity_tag", build.EntityTag); err != nil {
+		return diag.FromErr(fmt.Errorf("Error setting entity_tag: %s", err))
+	}
+
+	if err = d.Set("href", build.Href); err != nil {
+		return diag.FromErr(fmt.Errorf("Error setting href: %s", err))
+	}
+
+	if err = d.Set("build_id", build.ID); err != nil {
+		return diag.FromErr(fmt.Errorf("Error setting build_id: %s", err))
+	}
+
+	if err = d.Set("output_image", build.OutputImage); err != nil {
+		return diag.FromErr(fmt.Errorf("Error setting output_image: %s", err))
+	}
+
+	if err = d.Set("output_secret", build.OutputSecret); err != nil {
+		return diag.FromErr(fmt.Errorf("Error setting output_secret: %s", err))
+	}
+
+	if err = d.Set("resource_type", build.ResourceType); err != nil {
+		return diag.FromErr(fmt.Errorf("Error setting resource_type: %s", err))
+	}
+
+	if err = d.Set("source_context_dir", build.SourceContextDir); err != nil {
+		return diag.FromErr(fmt.Errorf("Error setting source_context_dir: %s", err))
+	}
+
+	if err = d.Set("source_revision", build.SourceRevision); err != nil {
+		return diag.FromErr(fmt.Errorf("Error setting source_revision: %s", err))
+	}
+
+	if err = d.Set("source_secret", build.SourceSecret); err != nil {
+		return diag.FromErr(fmt.Errorf("Error setting source_secret: %s", err))
+	}
+
+	if err = d.Set("source_type", build.SourceType); err != nil {
+		return diag.FromErr(fmt.Errorf("Error setting source_type: %s", err))
+	}
+
+	if err = d.Set("source_url", build.SourceURL); err != nil {
+		return diag.FromErr(fmt.Errorf("Error setting source_url: %s", err))
+	}
+
+	if err = d.Set("status", build.Status); err != nil {
+		return diag.FromErr(fmt.Errorf("Error setting status: %s", err))
+	}
+
+	statusDetails := []map[string]interface{}{}
+	if build.StatusDetails != nil {
+		modelMap, err := dataSourceIbmCodeEngineBuildBuildStatusToMap(build.StatusDetails)
+		if err != nil {
+			return diag.FromErr(err)
+		}
+		statusDetails = append(statusDetails, modelMap)
+	}
+	if err = d.Set("status_details", statusDetails); err != nil {
+		return diag.FromErr(fmt.Errorf("Error setting status_details %s", err))
+	}
+
+	if err = d.Set("strategy_size", build.StrategySize); err != nil {
+		return diag.FromErr(fmt.Errorf("Error setting strategy_size: %s", err))
+	}
+
+	if err = d.Set("strategy_spec_file", build.StrategySpecFile); err != nil {
+		return diag.FromErr(fmt.Errorf("Error setting strategy_spec_file: %s", err))
+	}
+
+	if err = d.Set("strategy_type", build.StrategyType); err != nil {
+		return diag.FromErr(fmt.Errorf("Error setting strategy_type: %s", err))
+	}
+
+	if err = d.Set("timeout", flex.IntValue(build.Timeout)); err != nil {
+		return diag.FromErr(fmt.Errorf("Error setting timeout: %s", err))
+	}
+
+	return nil
+}
+
+func dataSourceIbmCodeEngineBuildBuildStatusToMap(model *codeenginev2.BuildStatus) (map[string]interface{}, error) {
+	modelMap := make(map[string]interface{})
+	if model.Reason != nil {
+		modelMap["reason"] = model.Reason
+	}
+	return modelMap, nil
+}

--- a/ibm/service/codeengine/data_source_ibm_code_engine_build_test.go
+++ b/ibm/service/codeengine/data_source_ibm_code_engine_build_test.go
@@ -1,0 +1,65 @@
+// Copyright IBM Corp. 2023 All Rights Reserved.
+// Licensed under the Mozilla Public License v2.0
+
+package codeengine_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	acc "github.com/IBM-Cloud/terraform-provider-ibm/ibm/acctest"
+)
+
+func TestAccIbmCodeEngineBuildDataSourceBasic(t *testing.T) {
+	buildName := fmt.Sprintf("tf-data-build-basic-%d", acctest.RandIntRange(10, 1000))
+	buildOutputImage := fmt.Sprintf("private.us.icr.io/ce-terraform-test/%s", buildName)
+	buildOutputSecret := "ce-terraform-test"
+	buildSourceURL := "https://github.com/IBM/CodeEngine"
+	buildStrategyType := "dockerfile"
+
+	projectID := acc.CeProjectId
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { acc.TestAccPreCheck(t) },
+		Providers: acc.TestAccProviders,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccCheckIbmCodeEngineBuildDataSourceConfigBasic(projectID, buildName, buildOutputImage, buildOutputSecret, buildSourceURL, buildStrategyType),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet("data.ibm_code_engine_build.code_engine_build_instance", "build_id"),
+					resource.TestCheckResourceAttr("data.ibm_code_engine_build.code_engine_build_instance", "project_id", projectID),
+					resource.TestCheckResourceAttr("data.ibm_code_engine_build.code_engine_build_instance", "name", buildName),
+					resource.TestCheckResourceAttr("data.ibm_code_engine_build.code_engine_build_instance", "output_image", buildOutputImage),
+					resource.TestCheckResourceAttr("data.ibm_code_engine_build.code_engine_build_instance", "output_secret", buildOutputSecret),
+					resource.TestCheckResourceAttr("data.ibm_code_engine_build.code_engine_build_instance", "source_url", buildSourceURL),
+					resource.TestCheckResourceAttr("data.ibm_code_engine_build.code_engine_build_instance", "strategy_type", buildStrategyType),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckIbmCodeEngineBuildDataSourceConfigBasic(projectID string, buildName string, buildOutputImage string, buildOutputSecret string, buildSourceURL string, buildStrategyType string) string {
+	return fmt.Sprintf(`
+		data "ibm_code_engine_project" "code_engine_project_instance" {
+			project_id = "%s"
+		}
+
+		resource "ibm_code_engine_build" "code_engine_build_instance" {
+			project_id = data.ibm_code_engine_project.code_engine_project_instance.project_id
+			name = "%s"
+			output_image = "%s"
+			output_secret = "%s"
+			source_url = "%s"
+			strategy_type = "%s"
+		}
+
+		data "ibm_code_engine_build" "code_engine_build_instance" {
+			project_id = ibm_code_engine_build.code_engine_build_instance.project_id
+			name = ibm_code_engine_build.code_engine_build_instance.name
+		}
+	`, projectID, buildName, buildOutputImage, buildOutputSecret, buildSourceURL, buildStrategyType)
+}

--- a/ibm/service/codeengine/data_source_ibm_code_engine_config_map.go
+++ b/ibm/service/codeengine/data_source_ibm_code_engine_config_map.go
@@ -1,0 +1,119 @@
+// Copyright IBM Corp. 2023 All Rights Reserved.
+// Licensed under the Mozilla Public License v2.0
+
+package codeengine
+
+import (
+	"context"
+	"fmt"
+	"log"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/conns"
+	"github.com/IBM/code-engine-go-sdk/codeenginev2"
+)
+
+func DataSourceIbmCodeEngineConfigMap() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceIbmCodeEngineConfigMapRead,
+
+		Schema: map[string]*schema.Schema{
+			"project_id": &schema.Schema{
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "The ID of the project.",
+			},
+			"name": &schema.Schema{
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "The name of your configmap.",
+			},
+			"created_at": &schema.Schema{
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The timestamp when the resource was created.",
+			},
+			"data": &schema.Schema{
+				Type:        schema.TypeMap,
+				Computed:    true,
+				Description: "The key-value pair for the config map. Values must be specified in `KEY=VALUE` format.",
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
+			},
+			"entity_tag": &schema.Schema{
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The version of the config map instance, which is used to achieve optimistic locking.",
+			},
+			"href": &schema.Schema{
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "When you provision a new config map,  a URL is created identifying the location of the instance.",
+			},
+			"config_map_id": &schema.Schema{
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The identifier of the resource.",
+			},
+			"resource_type": &schema.Schema{
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The type of the config map.",
+			},
+		},
+	}
+}
+
+func dataSourceIbmCodeEngineConfigMapRead(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	codeEngineClient, err := meta.(conns.ClientSession).CodeEngineV2()
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	getConfigMapOptions := &codeenginev2.GetConfigMapOptions{}
+
+	getConfigMapOptions.SetProjectID(d.Get("project_id").(string))
+	getConfigMapOptions.SetName(d.Get("name").(string))
+
+	configMap, response, err := codeEngineClient.GetConfigMapWithContext(context, getConfigMapOptions)
+	if err != nil {
+		log.Printf("[DEBUG] GetConfigMapWithContext failed %s\n%s", err, response)
+		return diag.FromErr(fmt.Errorf("GetConfigMapWithContext failed %s\n%s", err, response))
+	}
+
+	d.SetId(fmt.Sprintf("%s/%s", *getConfigMapOptions.ProjectID, *getConfigMapOptions.Name))
+
+	if err = d.Set("created_at", configMap.CreatedAt); err != nil {
+		return diag.FromErr(fmt.Errorf("Error setting created_at: %s", err))
+	}
+
+	if configMap.Data != nil {
+		if err = d.Set("data", configMap.Data); err != nil {
+			return diag.FromErr(fmt.Errorf("Error setting data: %s", err))
+		}
+		if err != nil {
+			return diag.FromErr(fmt.Errorf("Error setting data %s", err))
+		}
+	}
+
+	if err = d.Set("entity_tag", configMap.EntityTag); err != nil {
+		return diag.FromErr(fmt.Errorf("Error setting entity_tag: %s", err))
+	}
+
+	if err = d.Set("href", configMap.Href); err != nil {
+		return diag.FromErr(fmt.Errorf("Error setting href: %s", err))
+	}
+
+	if err = d.Set("config_map_id", configMap.ID); err != nil {
+		return diag.FromErr(fmt.Errorf("Error setting config_map_id: %s", err))
+	}
+
+	if err = d.Set("resource_type", configMap.ResourceType); err != nil {
+		return diag.FromErr(fmt.Errorf("Error setting resource_type: %s", err))
+	}
+
+	return nil
+}

--- a/ibm/service/codeengine/data_source_ibm_code_engine_config_map_test.go
+++ b/ibm/service/codeengine/data_source_ibm_code_engine_config_map_test.go
@@ -1,0 +1,57 @@
+// Copyright IBM Corp. 2023 All Rights Reserved.
+// Licensed under the Mozilla Public License v2.0
+
+package codeengine_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	acc "github.com/IBM-Cloud/terraform-provider-ibm/ibm/acctest"
+)
+
+func TestAccIbmCodeEngineConfigMapDataSourceBasic(t *testing.T) {
+	configMapName := fmt.Sprintf("tf-data-config-map-basic-%d", acctest.RandIntRange(10, 1000))
+	configMapData := `{ "key" = "inner" }`
+
+	projectID := acc.CeProjectId
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { acc.TestAccPreCheck(t) },
+		Providers: acc.TestAccProviders,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccCheckIbmCodeEngineConfigMapDataSourceConfigBasic(projectID, configMapName, configMapData),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet("data.ibm_code_engine_config_map.code_engine_config_map_instance", "config_map_id"),
+					resource.TestCheckResourceAttr("data.ibm_code_engine_config_map.code_engine_config_map_instance", "data.key", "inner"),
+					resource.TestCheckResourceAttr("data.ibm_code_engine_config_map.code_engine_config_map_instance", "project_id", projectID),
+					resource.TestCheckResourceAttr("data.ibm_code_engine_config_map.code_engine_config_map_instance", "name", configMapName),
+					resource.TestCheckResourceAttr("data.ibm_code_engine_config_map.code_engine_config_map_instance", "resource_type", "config_map_v2"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckIbmCodeEngineConfigMapDataSourceConfigBasic(projectID string, configMapName string, configMapData string) string {
+	return fmt.Sprintf(`
+		data "ibm_code_engine_project" "code_engine_project_instance" {
+			project_id = "%s"
+		}
+
+		resource "ibm_code_engine_config_map" "code_engine_config_map_instance" {
+			project_id = data.ibm_code_engine_project.code_engine_project_instance.project_id
+			name = "%s"
+			data = %s
+		}
+
+		data "ibm_code_engine_config_map" "code_engine_config_map_instance" {
+			project_id = ibm_code_engine_config_map.code_engine_config_map_instance.project_id
+			name = ibm_code_engine_config_map.code_engine_config_map_instance.name
+		}
+	`, projectID, configMapName, configMapData)
+}

--- a/ibm/service/codeengine/data_source_ibm_code_engine_job.go
+++ b/ibm/service/codeengine/data_source_ibm_code_engine_job.go
@@ -246,15 +246,13 @@ func dataSourceIbmCodeEngineJobRead(context context.Context, d *schema.ResourceD
 		return diag.FromErr(fmt.Errorf("Error setting resource_type: %s", err))
 	}
 
-
 	if err = d.Set("run_as_user", flex.IntValue(job.RunAsUser)); err != nil {
 		return diag.FromErr(fmt.Errorf("Error setting run_as_user: %s", err))
 	}
 
-
 	runEnvVariables := []map[string]interface{}{}
 	if job.RunEnvVariables != nil {
-		for _, modelItem := range job.RunEnvVariables { 
+		for _, modelItem := range job.RunEnvVariables {
 			modelMap, err := dataSourceIbmCodeEngineJobEnvVarToMap(&modelItem)
 			if err != nil {
 				return diag.FromErr(err)
@@ -276,7 +274,7 @@ func dataSourceIbmCodeEngineJobRead(context context.Context, d *schema.ResourceD
 
 	runVolumeMounts := []map[string]interface{}{}
 	if job.RunVolumeMounts != nil {
-		for _, modelItem := range job.RunVolumeMounts { 
+		for _, modelItem := range job.RunVolumeMounts {
 			modelMap, err := dataSourceIbmCodeEngineJobVolumeMountToMap(&modelItem)
 			if err != nil {
 				return diag.FromErr(err)

--- a/ibm/service/codeengine/data_source_ibm_code_engine_job.go
+++ b/ibm/service/codeengine/data_source_ibm_code_engine_job.go
@@ -1,0 +1,346 @@
+// Copyright IBM Corp. 2023 All Rights Reserved.
+// Licensed under the Mozilla Public License v2.0
+
+package codeengine
+
+import (
+	"context"
+	"fmt"
+	"log"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/conns"
+	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/flex"
+	"github.com/IBM/code-engine-go-sdk/codeenginev2"
+)
+
+func DataSourceIbmCodeEngineJob() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceIbmCodeEngineJobRead,
+
+		Schema: map[string]*schema.Schema{
+			"project_id": &schema.Schema{
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "The ID of the project.",
+			},
+			"name": &schema.Schema{
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "The name of your job.",
+			},
+			"created_at": &schema.Schema{
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The timestamp when the resource was created.",
+			},
+			"entity_tag": &schema.Schema{
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The version of the job instance, which is used to achieve optimistic locking.",
+			},
+			"href": &schema.Schema{
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "When you provision a new job,  a URL is created identifying the location of the instance.",
+			},
+			"job_id": &schema.Schema{
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The identifier of the resource.",
+			},
+			"image_reference": &schema.Schema{
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The name of the image that is used for this job. The format is `REGISTRY/NAMESPACE/REPOSITORY:TAG` where `REGISTRY` and `TAG` are optional. If `REGISTRY` is not specified, the default is `docker.io`. If `TAG` is not specified, the default is `latest`. If the image reference points to a registry that requires authentication, make sure to also specify the property `image_secret`.",
+			},
+			"image_secret": &schema.Schema{
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The name of the image registry access secret. The image registry access secret is used to authenticate with a private registry when you download the container image. If the image reference points to a registry that requires authentication, the job / job runs will be created but submitted job runs will fail, until this property is provided, too. This property must not be set on a job run, which references a job template.",
+			},
+			"resource_type": &schema.Schema{
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The type of the job.",
+			},
+			"run_arguments": &schema.Schema{
+				Type:        schema.TypeList,
+				Computed:    true,
+				Description: "Set arguments for the job that are passed to start job run containers. If not specified an empty string array will be applied and the arguments specified by the container image, will be used to start the container.",
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
+			},
+			"run_as_user": &schema.Schema{
+				Type:        schema.TypeInt,
+				Computed:    true,
+				Description: "The user ID (UID) to run the job (e.g., 1001).",
+			},
+			"run_commands": &schema.Schema{
+				Type:        schema.TypeList,
+				Computed:    true,
+				Description: "Set commands for the job that are passed to start job run containers. If not specified an empty string array will be applied and the command specified by the container image, will be used to start the container.",
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
+			},
+			"run_env_variables": &schema.Schema{
+				Type:        schema.TypeList,
+				Computed:    true,
+				Description: "References to config maps, secrets or literal values, which are exposed as environment variables in the job run.",
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"key": &schema.Schema{
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "The key to reference as environment variable.",
+						},
+						"name": &schema.Schema{
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "The name of the environment variable.",
+						},
+						"prefix": &schema.Schema{
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "A prefix that can be added to all keys of a full secret or config map reference.",
+						},
+						"reference": &schema.Schema{
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "The name of the secret or config map.",
+						},
+						"type": &schema.Schema{
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "Specify the type of the environment variable.",
+						},
+						"value": &schema.Schema{
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "The literal value of the environment variable.",
+						},
+					},
+				},
+			},
+			"run_mode": &schema.Schema{
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The mode for runs of the job. Valid values are `task` and `daemon`. In `task` mode, the `max_execution_time` and `retry_limit` properties apply. In `daemon` mode, since there is no timeout and failed instances are restarted indefinitely, the `max_execution_time` and `retry_limit` properties are not allowed.",
+			},
+			"run_service_account": &schema.Schema{
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The name of the service account. For built-in service accounts, you can use the shortened names `manager`, `none`, `reader`, and `writer`. This property must not be set on a job run, which references a job template.",
+			},
+			"run_volume_mounts": &schema.Schema{
+				Type:        schema.TypeList,
+				Computed:    true,
+				Description: "Optional mounts of config maps or a secrets.",
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"mount_path": &schema.Schema{
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "The path that should be mounted.",
+						},
+						"name": &schema.Schema{
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "The name of the mount.",
+						},
+						"reference": &schema.Schema{
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "The name of the referenced secret or config map.",
+						},
+						"type": &schema.Schema{
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "Specify the type of the volume mount. Allowed types are: 'config_map', 'secret'.",
+						},
+					},
+				},
+			},
+			"scale_array_spec": &schema.Schema{
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "Define a custom set of array indices as comma-separated list containing single values and hyphen-separated ranges like `5,12-14,23,27`. Each instance can pick up its array index via environment variable `JOB_INDEX`. The number of unique array indices specified here determines the number of job instances to run.",
+			},
+			"scale_cpu_limit": &schema.Schema{
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "Optional amount of CPU set for the instance of the job. For valid values see [Supported memory and CPU combinations](https://cloud.ibm.com/docs/codeengine?topic=codeengine-mem-cpu-combo).",
+			},
+			"scale_ephemeral_storage_limit": &schema.Schema{
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "Optional amount of ephemeral storage to set for the instance of the job. The amount specified as ephemeral storage, must not exceed the amount of `scale_memory_limit`. The units for specifying ephemeral storage are Megabyte (M) or Gigabyte (G), whereas G and M are the shorthand expressions for GB and MB. For more information see [Units of measurement](https://cloud.ibm.com/docs/codeengine?topic=codeengine-mem-cpu-combo#unit-measurements).",
+			},
+			"scale_max_execution_time": &schema.Schema{
+				Type:        schema.TypeInt,
+				Computed:    true,
+				Description: "The maximum execution time in seconds for runs of the job. This property can only be specified if `run_mode` is `task`.",
+			},
+			"scale_memory_limit": &schema.Schema{
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "Optional amount of memory set for the instance of the job. For valid values see [Supported memory and CPU combinations](https://cloud.ibm.com/docs/codeengine?topic=codeengine-mem-cpu-combo). The units for specifying memory are Megabyte (M) or Gigabyte (G), whereas G and M are the shorthand expressions for GB and MB. For more information see [Units of measurement](https://cloud.ibm.com/docs/codeengine?topic=codeengine-mem-cpu-combo#unit-measurements).",
+			},
+			"scale_retry_limit": &schema.Schema{
+				Type:        schema.TypeInt,
+				Computed:    true,
+				Description: "The number of times to rerun an instance of the job before the job is marked as failed. This property can only be specified if `run_mode` is `task`.",
+			},
+		},
+	}
+}
+
+func dataSourceIbmCodeEngineJobRead(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	codeEngineClient, err := meta.(conns.ClientSession).CodeEngineV2()
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	getJobOptions := &codeenginev2.GetJobOptions{}
+
+	getJobOptions.SetProjectID(d.Get("project_id").(string))
+	getJobOptions.SetName(d.Get("name").(string))
+
+	job, response, err := codeEngineClient.GetJobWithContext(context, getJobOptions)
+	if err != nil {
+		log.Printf("[DEBUG] GetJobWithContext failed %s\n%s", err, response)
+		return diag.FromErr(fmt.Errorf("GetJobWithContext failed %s\n%s", err, response))
+	}
+
+	d.SetId(fmt.Sprintf("%s/%s", *getJobOptions.ProjectID, *getJobOptions.Name))
+
+	if err = d.Set("created_at", job.CreatedAt); err != nil {
+		return diag.FromErr(fmt.Errorf("Error setting created_at: %s", err))
+	}
+
+	if err = d.Set("entity_tag", job.EntityTag); err != nil {
+		return diag.FromErr(fmt.Errorf("Error setting entity_tag: %s", err))
+	}
+
+	if err = d.Set("href", job.Href); err != nil {
+		return diag.FromErr(fmt.Errorf("Error setting href: %s", err))
+	}
+
+	if err = d.Set("job_id", job.ID); err != nil {
+		return diag.FromErr(fmt.Errorf("Error setting job_id: %s", err))
+	}
+
+	if err = d.Set("image_reference", job.ImageReference); err != nil {
+		return diag.FromErr(fmt.Errorf("Error setting image_reference: %s", err))
+	}
+
+	if err = d.Set("image_secret", job.ImageSecret); err != nil {
+		return diag.FromErr(fmt.Errorf("Error setting image_secret: %s", err))
+	}
+
+	if err = d.Set("resource_type", job.ResourceType); err != nil {
+		return diag.FromErr(fmt.Errorf("Error setting resource_type: %s", err))
+	}
+
+
+	if err = d.Set("run_as_user", flex.IntValue(job.RunAsUser)); err != nil {
+		return diag.FromErr(fmt.Errorf("Error setting run_as_user: %s", err))
+	}
+
+
+	runEnvVariables := []map[string]interface{}{}
+	if job.RunEnvVariables != nil {
+		for _, modelItem := range job.RunEnvVariables { 
+			modelMap, err := dataSourceIbmCodeEngineJobEnvVarToMap(&modelItem)
+			if err != nil {
+				return diag.FromErr(err)
+			}
+			runEnvVariables = append(runEnvVariables, modelMap)
+		}
+	}
+	if err = d.Set("run_env_variables", runEnvVariables); err != nil {
+		return diag.FromErr(fmt.Errorf("Error setting run_env_variables %s", err))
+	}
+
+	if err = d.Set("run_mode", job.RunMode); err != nil {
+		return diag.FromErr(fmt.Errorf("Error setting run_mode: %s", err))
+	}
+
+	if err = d.Set("run_service_account", job.RunServiceAccount); err != nil {
+		return diag.FromErr(fmt.Errorf("Error setting run_service_account: %s", err))
+	}
+
+	runVolumeMounts := []map[string]interface{}{}
+	if job.RunVolumeMounts != nil {
+		for _, modelItem := range job.RunVolumeMounts { 
+			modelMap, err := dataSourceIbmCodeEngineJobVolumeMountToMap(&modelItem)
+			if err != nil {
+				return diag.FromErr(err)
+			}
+			runVolumeMounts = append(runVolumeMounts, modelMap)
+		}
+	}
+	if err = d.Set("run_volume_mounts", runVolumeMounts); err != nil {
+		return diag.FromErr(fmt.Errorf("Error setting run_volume_mounts %s", err))
+	}
+
+	if err = d.Set("scale_array_spec", job.ScaleArraySpec); err != nil {
+		return diag.FromErr(fmt.Errorf("Error setting scale_array_spec: %s", err))
+	}
+
+	if err = d.Set("scale_cpu_limit", job.ScaleCpuLimit); err != nil {
+		return diag.FromErr(fmt.Errorf("Error setting scale_cpu_limit: %s", err))
+	}
+
+	if err = d.Set("scale_ephemeral_storage_limit", job.ScaleEphemeralStorageLimit); err != nil {
+		return diag.FromErr(fmt.Errorf("Error setting scale_ephemeral_storage_limit: %s", err))
+	}
+
+	if err = d.Set("scale_max_execution_time", flex.IntValue(job.ScaleMaxExecutionTime)); err != nil {
+		return diag.FromErr(fmt.Errorf("Error setting scale_max_execution_time: %s", err))
+	}
+
+	if err = d.Set("scale_memory_limit", job.ScaleMemoryLimit); err != nil {
+		return diag.FromErr(fmt.Errorf("Error setting scale_memory_limit: %s", err))
+	}
+
+	if err = d.Set("scale_retry_limit", flex.IntValue(job.ScaleRetryLimit)); err != nil {
+		return diag.FromErr(fmt.Errorf("Error setting scale_retry_limit: %s", err))
+	}
+
+	return nil
+}
+
+func dataSourceIbmCodeEngineJobEnvVarToMap(model *codeenginev2.EnvVar) (map[string]interface{}, error) {
+	modelMap := make(map[string]interface{})
+	if model.Key != nil {
+		modelMap["key"] = model.Key
+	}
+	if model.Name != nil {
+		modelMap["name"] = model.Name
+	}
+	if model.Prefix != nil {
+		modelMap["prefix"] = model.Prefix
+	}
+	if model.Reference != nil {
+		modelMap["reference"] = model.Reference
+	}
+	modelMap["type"] = model.Type
+	if model.Value != nil {
+		modelMap["value"] = model.Value
+	}
+	return modelMap, nil
+}
+
+func dataSourceIbmCodeEngineJobVolumeMountToMap(model *codeenginev2.VolumeMount) (map[string]interface{}, error) {
+	modelMap := make(map[string]interface{})
+	modelMap["mount_path"] = model.MountPath
+	modelMap["name"] = model.Name
+	modelMap["reference"] = model.Reference
+	modelMap["type"] = model.Type
+	return modelMap, nil
+}

--- a/ibm/service/codeengine/data_source_ibm_code_engine_job_test.go
+++ b/ibm/service/codeengine/data_source_ibm_code_engine_job_test.go
@@ -1,0 +1,126 @@
+// Copyright IBM Corp. 2023 All Rights Reserved.
+// Licensed under the Mozilla Public License v2.0
+
+package codeengine_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	acc "github.com/IBM-Cloud/terraform-provider-ibm/ibm/acctest"
+)
+
+func TestAccIbmCodeEngineJobDataSourceBasic(t *testing.T) {
+	jobName := fmt.Sprintf("tf-data-job-basic-%d", acctest.RandIntRange(10, 1000))
+	jobImageReference := "icr.io/codeengine/helloworld"
+
+	projectID := acc.CeProjectId
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { acc.TestAccPreCheck(t) },
+		Providers: acc.TestAccProviders,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccCheckIbmCodeEngineJobDataSourceConfigBasic(projectID, jobImageReference, jobName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet("data.ibm_code_engine_job.code_engine_job_instance", "job_id"),
+					resource.TestCheckResourceAttr("data.ibm_code_engine_job.code_engine_job_instance", "project_id", projectID),
+					resource.TestCheckResourceAttr("data.ibm_code_engine_job.code_engine_job_instance", "name", jobName),
+					resource.TestCheckResourceAttr("data.ibm_code_engine_job.code_engine_job_instance", "resource_type", "job_v2"),
+					resource.TestCheckResourceAttr("data.ibm_code_engine_job.code_engine_job_instance", "image_reference", jobImageReference),
+					resource.TestCheckResourceAttr("data.ibm_code_engine_job.code_engine_job_instance", "run_service_account", "default"),
+					resource.TestCheckResourceAttr("data.ibm_code_engine_job.code_engine_job_instance", "scale_cpu_limit", "1"),
+					resource.TestCheckResourceAttr("data.ibm_code_engine_job.code_engine_job_instance", "scale_ephemeral_storage_limit", "400M"),
+					resource.TestCheckResourceAttr("data.ibm_code_engine_job.code_engine_job_instance", "scale_max_execution_time", "7200"),
+					resource.TestCheckResourceAttr("data.ibm_code_engine_job.code_engine_job_instance", "scale_memory_limit", "4G"),
+					resource.TestCheckResourceAttr("data.ibm_code_engine_job.code_engine_job_instance", "scale_retry_limit", "3"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccIbmCodeEngineJobDataSourceExtended(t *testing.T) {
+	jobName := fmt.Sprintf("tf-data-job-extended-%d", acctest.RandIntRange(10, 1000))
+	jobImageReference := "icr.io/codeengine/helloworld"
+	jobRunMode := "task"
+	jobRunServiceAccount := "default"
+	jobScaleCpuLimit := "0.5"
+	jobScaleEphemeralStorageLimit := "500M"
+	jobScaleMaxExecutionTime := "3600"
+	jobScaleMemoryLimit := "1G"
+	jobScaleRetryLimit := "2"
+
+	projectID := acc.CeProjectId
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { acc.TestAccPreCheck(t) },
+		Providers: acc.TestAccProviders,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccCheckIbmCodeEngineJobDataSourceConfig(projectID, jobImageReference, jobName, jobRunMode, jobRunServiceAccount, jobScaleCpuLimit, jobScaleEphemeralStorageLimit, jobScaleMaxExecutionTime, jobScaleMemoryLimit, jobScaleRetryLimit),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet("data.ibm_code_engine_job.code_engine_job_instance", "job_id"),
+					resource.TestCheckResourceAttr("data.ibm_code_engine_job.code_engine_job_instance", "project_id", projectID),
+					resource.TestCheckResourceAttr("data.ibm_code_engine_job.code_engine_job_instance", "name", jobName),
+					resource.TestCheckResourceAttr("data.ibm_code_engine_job.code_engine_job_instance", "image_reference", jobImageReference),
+					resource.TestCheckResourceAttr("data.ibm_code_engine_job.code_engine_job_instance", "run_mode", jobRunMode),
+					resource.TestCheckResourceAttr("data.ibm_code_engine_job.code_engine_job_instance", "run_service_account", jobRunServiceAccount),
+					resource.TestCheckResourceAttr("data.ibm_code_engine_job.code_engine_job_instance", "scale_cpu_limit", jobScaleCpuLimit),
+					resource.TestCheckResourceAttr("data.ibm_code_engine_job.code_engine_job_instance", "scale_ephemeral_storage_limit", jobScaleEphemeralStorageLimit),
+					resource.TestCheckResourceAttr("data.ibm_code_engine_job.code_engine_job_instance", "scale_max_execution_time", jobScaleMaxExecutionTime),
+					resource.TestCheckResourceAttr("data.ibm_code_engine_job.code_engine_job_instance", "scale_memory_limit", jobScaleMemoryLimit),
+					resource.TestCheckResourceAttr("data.ibm_code_engine_job.code_engine_job_instance", "scale_retry_limit", jobScaleRetryLimit),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckIbmCodeEngineJobDataSourceConfigBasic(projectID string, jobImageReference string, jobName string) string {
+	return fmt.Sprintf(`
+		data "ibm_code_engine_project" "code_engine_project_instance" {
+			project_id = "%s"
+		}
+
+		resource "ibm_code_engine_job" "code_engine_job_instance" {
+			project_id = data.ibm_code_engine_project.code_engine_project_instance.project_id
+			image_reference = "%s"
+			name = "%s"
+		}
+
+		data "ibm_code_engine_job" "code_engine_job_instance" {
+			project_id = ibm_code_engine_job.code_engine_job_instance.project_id
+			name = ibm_code_engine_job.code_engine_job_instance.name
+		}
+	`, projectID, jobImageReference, jobName)
+}
+
+func testAccCheckIbmCodeEngineJobDataSourceConfig(projectID string, jobImageReference string, jobName string, jobRunMode string, jobRunServiceAccount string, jobScaleCpuLimit string, jobScaleEphemeralStorageLimit string, jobScaleMaxExecutionTime string, jobScaleMemoryLimit string, jobScaleRetryLimit string) string {
+	return fmt.Sprintf(`
+		data "ibm_code_engine_project" "code_engine_project_instance" {
+			project_id = "%s"
+		}
+
+		resource "ibm_code_engine_job" "code_engine_job_instance" {
+			project_id =  data.ibm_code_engine_project.code_engine_project_instance.project_id
+			image_reference = "%s"
+			name = "%s"
+			run_mode = "%s"
+			run_service_account = "%s"
+			scale_cpu_limit = "%s"
+			scale_ephemeral_storage_limit = "%s"
+			scale_max_execution_time = %s
+			scale_memory_limit = "%s"
+			scale_retry_limit = %s
+		}
+
+		data "ibm_code_engine_job" "code_engine_job_instance" {
+			project_id = ibm_code_engine_job.code_engine_job_instance.project_id
+			name = ibm_code_engine_job.code_engine_job_instance.name
+		}
+	`, projectID, jobImageReference, jobName, jobRunMode, jobRunServiceAccount, jobScaleCpuLimit, jobScaleEphemeralStorageLimit, jobScaleMaxExecutionTime, jobScaleMemoryLimit, jobScaleRetryLimit)
+}

--- a/ibm/service/codeengine/data_source_ibm_code_engine_secret.go
+++ b/ibm/service/codeengine/data_source_ibm_code_engine_secret.go
@@ -1,0 +1,128 @@
+// Copyright IBM Corp. 2023 All Rights Reserved.
+// Licensed under the Mozilla Public License v2.0
+
+package codeengine
+
+import (
+	"context"
+	"fmt"
+	"log"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/conns"
+	"github.com/IBM/code-engine-go-sdk/codeenginev2"
+)
+
+func DataSourceIbmCodeEngineSecret() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceIbmCodeEngineSecretRead,
+
+		Schema: map[string]*schema.Schema{
+			"project_id": &schema.Schema{
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "The ID of the project.",
+			},
+			"name": &schema.Schema{
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "The name of your secret.",
+			},
+			"created_at": &schema.Schema{
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The timestamp when the resource was created.",
+			},
+			"data": &schema.Schema{
+				Type:        schema.TypeMap,
+				Computed:    true,
+				Description: "Data container that allows to specify config parameters and their values as a key-value map. Each key field must consist of alphanumeric characters, `-`, `_` or `.` and must not be exceed a max length of 253 characters. Each value field can consists of any character and must not be exceed a max length of 1048576 characters.",
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
+			},
+			"entity_tag": &schema.Schema{
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The version of the secret instance, which is used to achieve optimistic locking.",
+			},
+			"format": &schema.Schema{
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "Specify the format of the secret.",
+			},
+			"href": &schema.Schema{
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "When you provision a new secret,  a URL is created identifying the location of the instance.",
+			},
+			"secret_id": &schema.Schema{
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The identifier of the resource.",
+			},
+			"resource_type": &schema.Schema{
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The type of the secret.",
+			},
+		},
+	}
+}
+
+func dataSourceIbmCodeEngineSecretRead(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	codeEngineClient, err := meta.(conns.ClientSession).CodeEngineV2()
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	getSecretOptions := &codeenginev2.GetSecretOptions{}
+
+	getSecretOptions.SetProjectID(d.Get("project_id").(string))
+	getSecretOptions.SetName(d.Get("name").(string))
+
+	secret, response, err := codeEngineClient.GetSecretWithContext(context, getSecretOptions)
+	if err != nil {
+		log.Printf("[DEBUG] GetSecretWithContext failed %s\n%s", err, response)
+		return diag.FromErr(fmt.Errorf("GetSecretWithContext failed %s\n%s", err, response))
+	}
+
+	d.SetId(fmt.Sprintf("%s/%s", *getSecretOptions.ProjectID, *getSecretOptions.Name))
+
+	if err = d.Set("created_at", secret.CreatedAt); err != nil {
+		return diag.FromErr(fmt.Errorf("Error setting created_at: %s", err))
+	}
+
+	if secret.Data != nil {
+		if err = d.Set("data", secret.Data); err != nil {
+			return diag.FromErr(fmt.Errorf("Error setting data: %s", err))
+		}
+		if err != nil {
+			return diag.FromErr(fmt.Errorf("Error setting data %s", err))
+		}
+	}
+
+	if err = d.Set("entity_tag", secret.EntityTag); err != nil {
+		return diag.FromErr(fmt.Errorf("Error setting entity_tag: %s", err))
+	}
+
+	if err = d.Set("format", secret.Format); err != nil {
+		return diag.FromErr(fmt.Errorf("Error setting format: %s", err))
+	}
+
+	if err = d.Set("href", secret.Href); err != nil {
+		return diag.FromErr(fmt.Errorf("Error setting href: %s", err))
+	}
+
+	if err = d.Set("secret_id", secret.ID); err != nil {
+		return diag.FromErr(fmt.Errorf("Error setting secret_id: %s", err))
+	}
+
+	if err = d.Set("resource_type", secret.ResourceType); err != nil {
+		return diag.FromErr(fmt.Errorf("Error setting resource_type: %s", err))
+	}
+
+	return nil
+}

--- a/ibm/service/codeengine/data_source_ibm_code_engine_secret_test.go
+++ b/ibm/service/codeengine/data_source_ibm_code_engine_secret_test.go
@@ -1,0 +1,179 @@
+// Copyright IBM Corp. 2023 All Rights Reserved.
+// Licensed under the Mozilla Public License v2.0
+
+package codeengine_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	acc "github.com/IBM-Cloud/terraform-provider-ibm/ibm/acctest"
+)
+
+func TestAccIbmCodeEngineSecretDataSourceGeneric(t *testing.T) {
+	secretFormat := "generic"
+	secretName := fmt.Sprintf("tf-data-secret-generic-%d", acctest.RandIntRange(10, 1000))
+	secretData := `{ "key" = "value" }`
+
+	projectID := acc.CeProjectId
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { acc.TestAccPreCheck(t) },
+		Providers: acc.TestAccProviders,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccCheckIbmCodeEngineSecretDataSourceConfigBasic(projectID, secretFormat, secretName, secretData),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("data.ibm_code_engine_secret.code_engine_secret_instance", "project_id", projectID),
+					resource.TestCheckResourceAttr("data.ibm_code_engine_secret.code_engine_secret_instance", "format", secretFormat),
+					resource.TestCheckResourceAttr("data.ibm_code_engine_secret.code_engine_secret_instance", "name", secretName),
+					resource.TestCheckResourceAttr("data.ibm_code_engine_secret.code_engine_secret_instance", "data.key", "value"),
+					resource.TestCheckResourceAttr("data.ibm_code_engine_secret.code_engine_secret_instance", "resource_type", "secret_generic_v2"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccIbmCodeEngineSecretDataSourceBasicAuth(t *testing.T) {
+	secretFormat := "basic_auth"
+	secretName := fmt.Sprintf("tf-data-secret-basic-auth-%d", acctest.RandIntRange(10, 1000))
+	secretData := `{
+		"username" = "name"
+		"password" = "password"
+	}`
+
+	projectID := acc.CeProjectId
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { acc.TestAccPreCheck(t) },
+		Providers: acc.TestAccProviders,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccCheckIbmCodeEngineSecretDataSourceConfigBasic(projectID, secretFormat, secretName, secretData),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("data.ibm_code_engine_secret.code_engine_secret_instance", "project_id", projectID),
+					resource.TestCheckResourceAttr("data.ibm_code_engine_secret.code_engine_secret_instance", "format", secretFormat),
+					resource.TestCheckResourceAttr("data.ibm_code_engine_secret.code_engine_secret_instance", "name", secretName),
+					resource.TestCheckResourceAttr("data.ibm_code_engine_secret.code_engine_secret_instance", "data.username", "name"),
+					resource.TestCheckResourceAttr("data.ibm_code_engine_secret.code_engine_secret_instance", "data.password", "password"),
+					resource.TestCheckResourceAttr("data.ibm_code_engine_secret.code_engine_secret_instance", "resource_type", "secret_basic_auth_v2"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccIbmCodeEngineSecretDataSourceRegistry(t *testing.T) {
+	secretFormat := "registry"
+	secretName := fmt.Sprintf("tf-data-secret-registry-%d", acctest.RandIntRange(10, 1000))
+	secretData := `{
+		"username" = "foo.bar"
+    "password" = "foouser"
+    "server"   = "foopass"
+    "email"    = "foo@mail.com"
+	}`
+
+	projectID := acc.CeProjectId
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { acc.TestAccPreCheck(t) },
+		Providers: acc.TestAccProviders,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccCheckIbmCodeEngineSecretDataSourceConfigBasic(projectID, secretFormat, secretName, secretData),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("data.ibm_code_engine_secret.code_engine_secret_instance", "project_id", projectID),
+					resource.TestCheckResourceAttr("data.ibm_code_engine_secret.code_engine_secret_instance", "format", secretFormat),
+					resource.TestCheckResourceAttr("data.ibm_code_engine_secret.code_engine_secret_instance", "name", secretName),
+					resource.TestCheckResourceAttr("data.ibm_code_engine_secret.code_engine_secret_instance", "data.username", "foo.bar"),
+					resource.TestCheckResourceAttr("data.ibm_code_engine_secret.code_engine_secret_instance", "data.password", "foouser"),
+					resource.TestCheckResourceAttr("data.ibm_code_engine_secret.code_engine_secret_instance", "data.server", "foopass"),
+					resource.TestCheckResourceAttr("data.ibm_code_engine_secret.code_engine_secret_instance", "data.email", "foo@mail.com"),
+					resource.TestCheckResourceAttr("data.ibm_code_engine_secret.code_engine_secret_instance", "resource_type", "secret_registry_v2"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccIbmCodeEngineSecretDataSourceSSHAuth(t *testing.T) {
+	secretFormat := "ssh_auth"
+	secretName := fmt.Sprintf("tf-data-secret-ssh-auth-%d", acctest.RandIntRange(10, 1000))
+	secretData := `{
+		"ssh_key"     = "ssh-key",
+    "known_hosts" = "knownhosts",
+	}`
+
+	projectID := acc.CeProjectId
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { acc.TestAccPreCheck(t) },
+		Providers: acc.TestAccProviders,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccCheckIbmCodeEngineSecretDataSourceConfigBasic(projectID, secretFormat, secretName, secretData),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("data.ibm_code_engine_secret.code_engine_secret_instance", "project_id", projectID),
+					resource.TestCheckResourceAttr("data.ibm_code_engine_secret.code_engine_secret_instance", "format", secretFormat),
+					resource.TestCheckResourceAttr("data.ibm_code_engine_secret.code_engine_secret_instance", "name", secretName),
+					resource.TestCheckResourceAttr("data.ibm_code_engine_secret.code_engine_secret_instance", "data.ssh_key", "ssh-key"),
+					resource.TestCheckResourceAttr("data.ibm_code_engine_secret.code_engine_secret_instance", "data.known_hosts", "knownhosts"),
+					resource.TestCheckResourceAttr("data.ibm_code_engine_secret.code_engine_secret_instance", "resource_type", "secret_auth_ssh_v2"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccIbmCodeEngineSecretDataSourceTls(t *testing.T) {
+	secretFormat := "tls"
+	secretName := fmt.Sprintf("tf-data-secret-tls-%d", acctest.RandIntRange(10, 1000))
+	secretData := `{
+		"tls_cert" = "---BEGIN CERTIFICATE--- ---END CERTIFICATE---",
+    "tls_key"  = "---BEGIN PRIVATE KEY--- ---END PRIVATE KEY---",
+	}`
+
+	projectID := acc.CeProjectId
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { acc.TestAccPreCheck(t) },
+		Providers: acc.TestAccProviders,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccCheckIbmCodeEngineSecretDataSourceConfigBasic(projectID, secretFormat, secretName, secretData),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("data.ibm_code_engine_secret.code_engine_secret_instance", "project_id", projectID),
+					resource.TestCheckResourceAttr("data.ibm_code_engine_secret.code_engine_secret_instance", "format", secretFormat),
+					resource.TestCheckResourceAttr("data.ibm_code_engine_secret.code_engine_secret_instance", "name", secretName),
+					resource.TestCheckResourceAttr("data.ibm_code_engine_secret.code_engine_secret_instance", "data.tls_cert", "---BEGIN CERTIFICATE--- ---END CERTIFICATE---"),
+					resource.TestCheckResourceAttr("data.ibm_code_engine_secret.code_engine_secret_instance", "data.tls_key", "---BEGIN PRIVATE KEY--- ---END PRIVATE KEY---"),
+					resource.TestCheckResourceAttr("data.ibm_code_engine_secret.code_engine_secret_instance", "resource_type", "secret_tls_v2"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckIbmCodeEngineSecretDataSourceConfigBasic(projectID string, secretFormat string, secretName string, secretData string) string {
+	return fmt.Sprintf(`
+		data "ibm_code_engine_project" "code_engine_project_instance" {
+			project_id = "%s"
+		}
+
+		resource "ibm_code_engine_secret" "code_engine_secret_instance" {
+			project_id = data.ibm_code_engine_project.code_engine_project_instance.project_id
+			format = "%s"
+			name = "%s"
+			data = %s
+		}
+
+		data "ibm_code_engine_secret" "code_engine_secret_instance" {
+			project_id = ibm_code_engine_secret.code_engine_secret_instance.project_id
+			name = ibm_code_engine_secret.code_engine_secret_instance.name
+		}
+	`, projectID, secretFormat, secretName, secretData)
+}

--- a/ibm/service/codeengine/resource_ibm_code_engine_app.go
+++ b/ibm/service/codeengine/resource_ibm_code_engine_app.go
@@ -95,7 +95,7 @@ func ResourceIbmCodeEngineApp() *schema.Resource {
 			"run_env_variables": &schema.Schema{
 				Type:        schema.TypeList,
 				Optional:    true,
-				Description: "Optional references to config maps, secrets or a literal values that are exposed as environment variables within the running application.",
+				Description: "Optional references to config maps, secrets or literal values that are exposed as environment variables within the running application.",
 				MinItems:    0,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{

--- a/website/docs/d/code_engine_app.html.markdown
+++ b/website/docs/d/code_engine_app.html.markdown
@@ -1,0 +1,137 @@
+---
+layout: "ibm"
+page_title: "IBM : ibm_code_engine_app"
+description: |-
+  Get information about code_engine_app
+subcategory: "Code Engine"
+---
+
+# ibm_code_engine_app
+
+Provides a read-only data source for code_engine_app. You can then reference the fields of the data source in other resources within the same configuration using interpolation syntax.
+
+## Example Usage
+
+```hcl
+data "ibm_code_engine_app" "code_engine_app" {
+	project_id = data.ibm_code_engine_project.code_engine_project.project_id
+	name       = "my-app"
+}
+```
+
+## Argument Reference
+
+Review the argument reference that you can specify for your data source.
+
+* `name` - (Required, Forces new resource, String) The name of your application.
+  * Constraints: The maximum length is `253` characters. The minimum length is `1` character. The value must match regular expression `/^[a-z0-9]([\\-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([\\-a-z0-9]*[a-z0-9])?)*$/`.
+* `project_id` - (Required, Forces new resource, String) The ID of the project.
+  * Constraints: The maximum length is `36` characters. The minimum length is `36` characters. The value must match regular expression `/^[0-9a-z]{8}-[0-9a-z]{4}-[0-9a-z]{4}-[0-9a-z]{4}-[0-9a-z]{12}$/`.
+
+## Attribute Reference
+
+In addition to all argument references listed, you can access the following attribute references after your data source is created.
+
+* `id` - The unique identifier of the code_engine_app.
+* `app_id` - (String) The identifier of the resource.
+  * Constraints: The maximum length is `36` characters. The minimum length is `36` characters. The value must match regular expression `/^[0-9a-z]{8}-[0-9a-z]{4}-[0-9a-z]{4}-[0-9a-z]{4}-[0-9a-z]{12}$/`.
+
+* `created_at` - (String) The timestamp when the resource was created.
+
+* `endpoint` - (String) Optional URL to invoke app. Depending on visibility this is accessible publicly or in the private network only. Empty in case 'managed_domain_mappings' is set to 'local'.
+
+* `endpoint_internal` - (String) URL to app that is only visible within the project.
+
+* `entity_tag` - (String) The version of the app instance, which is used to achieve optimistic locking.
+  * Constraints: The maximum length is `63` characters. The minimum length is `1` character. The value must match regular expression `/^[\\*\\-a-z0-9]+$/`.
+
+* `href` - (String) When you provision a new app,  a URL is created identifying the location of the instance.
+  * Constraints: The maximum length is `2048` characters. The minimum length is `0` characters. The value must match regular expression `/(([^:\/?#]+):)?(\/\/([^\/?#]*))?([^?#]*)(\\?([^#]*))?(#(.*))?$/`.
+
+* `image_port` - (Integer) Optional port the app listens on. While the app will always be exposed via port `443` for end users, this port is used to connect to the port that is exposed by the container image.
+
+* `image_reference` - (String) The name of the image that is used for this app. The format is `REGISTRY/NAMESPACE/REPOSITORY:TAG` where `REGISTRY` and `TAG` are optional. If `REGISTRY` is not specified, the default is `docker.io`. If `TAG` is not specified, the default is `latest`. If the image reference points to a registry that requires authentication, make sure to also specify the property `image_secret`.
+  * Constraints: The maximum length is `256` characters. The minimum length is `1` character. The value must match regular expression `/^([a-z0-9][a-z0-9\\-_.]+[a-z0-9][\/])?([a-z0-9][a-z0-9\\-_]+[a-z0-9][\/])?[a-z0-9][a-z0-9\\-_.\/]+[a-z0-9](:[\\w][\\w.\\-]{0,127})?(@sha256:[a-fA-F0-9]{64})?$/`.
+
+* `image_secret` - (String) Optional name of the image registry access secret. The image registry access secret is used to authenticate with a private registry when you download the container image. If the image reference points to a registry that requires authentication, the app will be created but cannot reach the ready status, until this property is provided, too.
+  * Constraints: The maximum length is `253` characters. The minimum length is `1` character. The value must match regular expression `/^[a-z0-9]([\\-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([\\-a-z0-9]*[a-z0-9])?)*$/`.
+
+* `managed_domain_mappings` - (String) Optional value controlling which of the system managed domain mappings will be setup for the application. Valid values are 'local_public', 'local_private' and 'local'. Visibility can only be 'local_private' if the project supports application private visibility.
+  * Constraints: The default value is `local_public`. Allowable values are: `local`, `local_private`, `local_public`.
+
+* `resource_type` - (String) The type of the app.
+  * Constraints: Allowable values are: `app_v2`.
+
+* `run_arguments` - (List) Optional arguments for the app that are passed to start the container. If not specified an empty string array will be applied and the arguments specified by the container image, will be used to start the container.
+  * Constraints: The list items must match regular expression `/^.*$/`. The maximum length is `100` items. The minimum length is `0` items.
+
+* `run_as_user` - (Integer) Optional user ID (UID) to run the app (e.g., `1001`).
+
+* `run_commands` - (List) Optional commands for the app that are passed to start the container. If not specified an empty string array will be applied and the command specified by the container image, will be used to start the container.
+  * Constraints: The list items must match regular expression `/^.*$/`. The maximum length is `100` items. The minimum length is `0` items.
+
+* `run_env_variables` - (List) References to config maps, secrets or literal values, which are exposed as environment variables in the application.
+  * Constraints: The maximum length is `100` items. The minimum length is `0` items.
+Nested scheme for **run_env_variables**:
+	* `key` - (String) The key to reference as environment variable.
+	  * Constraints: The maximum length is `253` characters. The minimum length is `1` character. The value must match regular expression `/^[\\-._a-zA-Z0-9]+$/`.
+	* `name` - (String) The name of the environment variable.
+	  * Constraints: The maximum length is `253` characters. The minimum length is `1` character. The value must match regular expression `/^[\\-._a-zA-Z0-9]+$/`.
+	* `prefix` - (String) A prefix that can be added to all keys of a full secret or config map reference.
+	  * Constraints: The maximum length is `253` characters. The minimum length is `0` characters. The value must match regular expression `/^[a-zA-Z_][a-zA-Z0-9_]*$/`.
+	* `reference` - (String) The name of the secret or config map.
+	  * Constraints: The maximum length is `253` characters. The minimum length is `1` character. The value must match regular expression `/^[a-z0-9]([\\-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([\\-a-z0-9]*[a-z0-9])?)*$/`.
+	* `type` - (String) Specify the type of the environment variable.
+	  * Constraints: The default value is `literal`. Allowable values are: `literal`, `config_map_full_reference`, `secret_full_reference`, `config_map_key_reference`, `secret_key_reference`. The value must match regular expression `/^(literal|config_map_full_reference|secret_full_reference|config_map_key_reference|secret_key_reference)$/`.
+	* `value` - (String) The literal value of the environment variable.
+	  * Constraints: The maximum length is `253` characters. The minimum length is `1` character. The value must match regular expression `/^[\\-._a-zA-Z0-9]+$/`.
+
+* `run_service_account` - (String) Optional name of the service account. For built-in service accounts, you can use the shortened names `manager` , `none`, `reader`, and `writer`.
+  * Constraints: The default value is `default`. Allowable values are: `default`, `manager`, `reader`, `writer`, `none`. The minimum length is `0` characters. The value must match regular expression `/^(manager|reader|writer|none|default)$/`.
+
+* `run_volume_mounts` - (List) Mounts of config maps or secrets.
+  * Constraints: The maximum length is `100` items. The minimum length is `0` items.
+Nested scheme for **run_volume_mounts**:
+	* `mount_path` - (String) The path that should be mounted.
+	  * Constraints: The maximum length is `256` characters. The minimum length is `1` character. The value must match regular expression `/^\/([^\/\\0]+\/?)+$/`.
+	* `name` - (String) The name of the mount.
+	  * Constraints: The maximum length is `63` characters. The minimum length is `0` characters. The value must match regular expression `/^[a-z]([-a-z0-9]*[a-z0-9])?$/`.
+	* `reference` - (String) The name of the referenced secret or config map.
+	  * Constraints: The maximum length is `253` characters. The minimum length is `1` character. The value must match regular expression `/^[a-z0-9]([\\-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([\\-a-z0-9]*[a-z0-9])?)*$/`.
+	* `type` - (String) Specify the type of the volume mount. Allowed types are: 'config_map', 'secret'.
+	  * Constraints: The default value is `secret`. Allowable values are: `config_map`, `secret`. The value must match regular expression `/^(config_map|secret)$/`.
+
+* `scale_concurrency` - (Integer) Optional maximum number of requests that can be processed concurrently per instance.
+
+* `scale_concurrency_target` - (Integer) Optional threshold of concurrent requests per instance at which one or more additional instances are created. Use this value to scale up instances based on concurrent number of requests. This option defaults to the value of the `scale_concurrency` option, if not specified.
+
+* `scale_cpu_limit` - (String) Optional number of CPU set for the instance of the app. For valid values see [Supported memory and CPU combinations](https://cloud.ibm.com/docs/codeengine?topic=codeengine-mem-cpu-combo).
+  * Constraints: The default value is `1`. The maximum length is `10` characters. The minimum length is `0` characters. The value must match regular expression `/^([0-9.]+)([eEinumkKMGTPB]*)$/`.
+
+* `scale_down_delay` - (Integer) Optional amount of time in seconds that delays the scale down behavior for an app instance.
+  * Constraints: The maximum value is `3600`. The minimum value is `0`.
+
+* `scale_ephemeral_storage_limit` - (String) Optional amount of ephemeral storage to set for the instance of the app. The amount specified as ephemeral storage, must not exceed the amount of `scale_memory_limit`. The units for specifying ephemeral storage are Megabyte (M) or Gigabyte (G), whereas G and M are the shorthand expressions for GB and MB. For more information see [Units of measurement](https://cloud.ibm.com/docs/codeengine?topic=codeengine-mem-cpu-combo#unit-measurements).
+  * Constraints: The default value is `400M`. The maximum length is `10` characters. The minimum length is `0` characters. The value must match regular expression `/^([0-9.]+)([eEinumkKMGTPB]*)$/`.
+
+* `scale_initial_instances` - (Integer) Optional initial number of instances that are created upon app creation or app update.
+
+* `scale_max_instances` - (Integer) Optional maximum number of instances for this app. If you set this value to `0`, this property does not set a upper scaling limit. However, the app scaling is still limited by the project quota for instances. See [Limits and quotas for Code Engine](https://cloud.ibm.com/docs/codeengine?topic=codeengine-limits).
+
+* `scale_memory_limit` - (String) Optional amount of memory set for the instance of the app. For valid values see [Supported memory and CPU combinations](https://cloud.ibm.com/docs/codeengine?topic=codeengine-mem-cpu-combo). The units for specifying memory are Megabyte (M) or Gigabyte (G), whereas G and M are the shorthand expressions for GB and MB. For more information see [Units of measurement](https://cloud.ibm.com/docs/codeengine?topic=codeengine-mem-cpu-combo#unit-measurements).
+  * Constraints: The default value is `4G`. The maximum length is `10` characters. The minimum length is `0` characters. The value must match regular expression `/^([0-9.]+)([eEinumkKMGTPB]*)$/`.
+
+* `scale_min_instances` - (Integer) Optional minimum number of instances for this app. If you set this value to `0`, the app will scale down to zero, if not hit by any request for some time.
+
+* `scale_request_timeout` - (Integer) Optional amount of time in seconds that is allowed for a running app to respond to a request.
+
+* `status` - (String) The current status of the app.
+  * Constraints: Allowable values are: `ready`, `deploying`, `failed`, `warning`.
+
+* `status_details` - (List) The detailed status of the application.
+Nested scheme for **status_details**:
+	* `latest_created_revision` - (String) Latest app revision that has been created.
+	* `latest_ready_revision` - (String) Latest app revision that reached a ready state.
+	* `reason` - (String) Optional information to provide more context in case of a 'failed' or 'warning' status.
+	  * Constraints: Allowable values are: `ready`, `deploying`, `waiting_for_resources`, `no_revision_ready`, `ready_but_latest_revision_failed`.
+

--- a/website/docs/d/code_engine_build.html.markdown
+++ b/website/docs/d/code_engine_build.html.markdown
@@ -1,0 +1,90 @@
+---
+layout: "ibm"
+page_title: "IBM : ibm_code_engine_build"
+description: |-
+  Get information about code_engine_build
+subcategory: "Code Engine"
+---
+
+# ibm_code_engine_build
+
+Provides a read-only data source for code_engine_build. You can then reference the fields of the data source in other resources within the same configuration using interpolation syntax.
+
+## Example Usage
+
+```hcl
+data "ibm_code_engine_build" "code_engine_build" {
+	project_id = data.ibm_code_engine_project.code_engine_project.project_id
+	name       = "my-build"
+}
+```
+
+## Argument Reference
+
+Review the argument reference that you can specify for your data source.
+
+* `name` - (Required, Forces new resource, String) The name of your build.
+  * Constraints: The maximum length is `253` characters. The minimum length is `1` character. The value must match regular expression `/^[a-z0-9]([\\-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([\\-a-z0-9]*[a-z0-9])?)*$/`.
+* `project_id` - (Required, Forces new resource, String) The ID of the project.
+  * Constraints: The maximum length is `36` characters. The minimum length is `36` characters. The value must match regular expression `/^[0-9a-z]{8}-[0-9a-z]{4}-[0-9a-z]{4}-[0-9a-z]{4}-[0-9a-z]{12}$/`.
+
+## Attribute Reference
+
+In addition to all argument references listed, you can access the following attribute references after your data source is created.
+
+* `id` - The unique identifier of the code_engine_build.
+* `build_id` - (String) The identifier of the resource.
+  * Constraints: The maximum length is `36` characters. The minimum length is `36` characters. The value must match regular expression `/^[0-9a-z]{8}-[0-9a-z]{4}-[0-9a-z]{4}-[0-9a-z]{4}-[0-9a-z]{12}$/`.
+
+* `created_at` - (String) The timestamp when the resource was created.
+
+* `entity_tag` - (String) The version of the build instance, which is used to achieve optimistic locking.
+  * Constraints: The maximum length is `63` characters. The minimum length is `1` character. The value must match regular expression `/^[\\*\\-a-z0-9]+$/`.
+
+* `href` - (String) When you provision a new build,  a URL is created identifying the location of the instance.
+  * Constraints: The maximum length is `2048` characters. The minimum length is `0` characters. The value must match regular expression `/(([^:\/?#]+):)?(\/\/([^\/?#]*))?([^?#]*)(\\?([^#]*))?(#(.*))?$/`.
+
+* `output_image` - (String) The name of the image.
+  * Constraints: The maximum length is `256` characters. The minimum length is `1` character. The value must match regular expression `/^([a-z0-9][a-z0-9\\-_.]+[a-z0-9][\/])?([a-z0-9][a-z0-9\\-_]+[a-z0-9][\/])?[a-z0-9][a-z0-9\\-_.\/]+[a-z0-9](:[\\w][\\w.\\-]{0,127})?(@sha256:[a-fA-F0-9]{64})?$/`.
+
+* `output_secret` - (String) The secret that is required to access the image registry. Make sure that the secret is granted with push permissions towards the specified container registry namespace.
+  * Constraints: The maximum length is `253` characters. The minimum length is `1` character. The value must match regular expression `/^[a-z0-9]([\\-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([\\-a-z0-9]*[a-z0-9])?)*$/`.
+
+* `resource_type` - (String) The type of the build.
+  * Constraints: Allowable values are: `build_v2`.
+
+* `source_context_dir` - (String) Option directory in the repository that contains the buildpacks file or the Dockerfile.
+  * Constraints: The maximum length is `253` characters. The minimum length is `0` characters. The value must match regular expression `/^(.*)+$/`.
+
+* `source_revision` - (String) Commit, tag, or branch in the source repository to pull. This field is optional if the `source_type` is `git` and uses the HEAD of default branch if not specified. If the `source_type` value is `local`, this field must be omitted.
+  * Constraints: The maximum length is `253` characters. The minimum length is `0` characters. The value must match regular expression `/^[\\S]*$/`.
+
+* `source_secret` - (String) Name of the secret that is used access the repository source. This field is optional if the `source_type` is `git`. Additionally, if the `source_url` points to a repository that requires authentication, the build will be created but cannot access any source code, until this property is provided, too. If the `source_type` value is `local`, this field must be omitted.
+  * Constraints: The maximum length is `253` characters. The minimum length is `1` character. The value must match regular expression `/^[a-z0-9]([\\-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([\\-a-z0-9]*[a-z0-9])?)*$/`.
+
+* `source_type` - (String) Specifies the type of source to determine if your build source is in a repository or based on local source code.* local - For builds from local source code.* git - For builds from git version controlled source code.
+  * Constraints: The default value is `git`. Allowable values are: `local`, `git`.
+
+* `source_url` - (String) The URL of the code repository. This field is required if the `source_type` is `git`. If the `source_type` value is `local`, this field must be omitted. If the repository is publicly available you can provide a 'https' URL like `https://github.com/IBM/CodeEngine`. If the repository requires authentication, you need to provide a 'ssh' URL like `git@github.com:IBM/CodeEngine.git` along with a `source_secret` that points to a secret of format `ssh_auth`.
+  * Constraints: The maximum length is `253` characters. The minimum length is `1` character. The value must match regular expression `/^((https:\/\/[a-z0-9]([\\-.]?[a-z0-9])+(:\\d{1,5})?)|((ssh:\/\/)?git@[a-z0-9]([\\-.]{0,1}[a-z0-9])+(:[a-zA-Z0-9\/][\\w\\-.]*)?))(\/([\\w\\-.]|%20)+)*$/`.
+
+* `status` - (String) The current status of the build.
+  * Constraints: Allowable values are: `ready`, `failed`.
+
+* `status_details` - (List) The detailed status of the build.
+Nested scheme for **status_details**:
+	* `reason` - (String) Optional information to provide more context in case of a 'failed' or 'warning' status.
+	  * Constraints: Allowable values are: `registered`, `strategy_not_found`, `cluster_build_strategy_not_found`, `set_owner_reference_failed`, `spec_source_secret_not_found`, `spec_output_secret_ref_not_found`, `spec_runtime_secret_ref_not_found`, `multiple_secret_ref_not_found`, `runtime_paths_can_not_be_empty`, `remote_repository_unreachable`, `failed`.
+
+* `strategy_size` - (String) Optional size for the build, which determines the amount of resources used. Build sizes are `small`, `medium`, `large`, `xlarge`.
+  * Constraints: The default value is `medium`. The maximum length is `253` characters. The minimum length is `1` character. The value must match regular expression `/[\\S]*/`.
+
+* `strategy_spec_file` - (String) Optional path to the specification file that is used for build strategies for building an image.
+  * Constraints: The default value is `Dockerfile`. The maximum length is `253` characters. The minimum length is `1` character. The value must match regular expression `/^[\\S]*$/`.
+
+* `strategy_type` - (String) The strategy to use for building the image.
+  * Constraints: The default value is `dockerfile`. The maximum length is `253` characters. The minimum length is `1` character. The value must match regular expression `/[\\S]*/`.
+
+* `timeout` - (Integer) The maximum amount of time, in seconds, that can pass before the build must succeed or fail.
+  * Constraints: The maximum value is `3600`. The minimum value is `1`.
+

--- a/website/docs/d/code_engine_config_map.html.markdown
+++ b/website/docs/d/code_engine_config_map.html.markdown
@@ -1,0 +1,50 @@
+---
+layout: "ibm"
+page_title: "IBM : ibm_code_engine_config_map"
+description: |-
+  Get information about code_engine_config_map
+subcategory: "Code Engine"
+---
+
+# ibm_code_engine_config_map
+
+Provides a read-only data source for code_engine_config_map. You can then reference the fields of the data source in other resources within the same configuration using interpolation syntax.
+
+## Example Usage
+
+```hcl
+data "ibm_code_engine_config_map" "code_engine_config_map" {
+	project_id = data.ibm_code_engine_project.code_engine_project.project_id
+	name       = "my-config-map"
+}
+```
+
+## Argument Reference
+
+Review the argument reference that you can specify for your data source.
+
+* `name` - (Required, Forces new resource, String) The name of your configmap.
+  * Constraints: The maximum length is `253` characters. The minimum length is `1` character. The value must match regular expression `/^[a-z0-9]([\\-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([\\-a-z0-9]*[a-z0-9])?)*$/`.
+* `project_id` - (Required, Forces new resource, String) The ID of the project.
+  * Constraints: The maximum length is `36` characters. The minimum length is `36` characters. The value must match regular expression `/^[0-9a-z]{8}-[0-9a-z]{4}-[0-9a-z]{4}-[0-9a-z]{4}-[0-9a-z]{12}$/`.
+
+## Attribute Reference
+
+In addition to all argument references listed, you can access the following attribute references after your data source is created.
+
+* `id` - The unique identifier of the code_engine_config_map.
+* `config_map_id` - (String) The identifier of the resource.
+  * Constraints: The maximum length is `36` characters. The minimum length is `36` characters. The value must match regular expression `/^[0-9a-z]{8}-[0-9a-z]{4}-[0-9a-z]{4}-[0-9a-z]{4}-[0-9a-z]{12}$/`.
+
+* `created_at` - (String) The timestamp when the resource was created.
+
+* `data` - (Map) The key-value pair for the config map. Values must be specified in `KEY=VALUE` format.
+
+* `entity_tag` - (String) The version of the config map instance, which is used to achieve optimistic locking.
+
+* `href` - (String) When you provision a new config map,  a URL is created identifying the location of the instance.
+  * Constraints: The maximum length is `2048` characters. The minimum length is `0` characters. The value must match regular expression `/(([^:\/?#]+):)?(\/\/([^\/?#]*))?([^?#]*)(\\?([^#]*))?(#(.*))?$/`.
+
+* `resource_type` - (String) The type of the config map.
+  * Constraints: Allowable values are: `config_map_v2`.
+

--- a/website/docs/d/code_engine_job.html.markdown
+++ b/website/docs/d/code_engine_job.html.markdown
@@ -1,0 +1,113 @@
+---
+layout: "ibm"
+page_title: "IBM : ibm_code_engine_job"
+description: |-
+  Get information about code_engine_job
+subcategory: "Code Engine"
+---
+
+# ibm_code_engine_job
+
+Provides a read-only data source for code_engine_job. You can then reference the fields of the data source in other resources within the same configuration using interpolation syntax.
+
+## Example Usage
+
+```hcl
+data "ibm_code_engine_job" "code_engine_job" {
+	project_id = data.ibm_code_engine_project.code_engine_project.project_id
+	name       = "my-job"
+}
+```
+
+## Argument Reference
+
+Review the argument reference that you can specify for your data source.
+
+* `name` - (Required, Forces new resource, String) The name of your job.
+  * Constraints: The maximum length is `253` characters. The minimum length is `1` character. The value must match regular expression `/^[a-z0-9]([\\-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([\\-a-z0-9]*[a-z0-9])?)*$/`.
+* `project_id` - (Required, Forces new resource, String) The ID of the project.
+  * Constraints: The maximum length is `36` characters. The minimum length is `36` characters. The value must match regular expression `/^[0-9a-z]{8}-[0-9a-z]{4}-[0-9a-z]{4}-[0-9a-z]{4}-[0-9a-z]{12}$/`.
+
+## Attribute Reference
+
+In addition to all argument references listed, you can access the following attribute references after your data source is created.
+
+* `id` - The unique identifier of the code_engine_job.
+* `created_at` - (String) The timestamp when the resource was created.
+
+* `entity_tag` - (String) The version of the job instance, which is used to achieve optimistic locking.
+  * Constraints: The maximum length is `63` characters. The minimum length is `1` character. The value must match regular expression `/^[\\*\\-a-z0-9]+$/`.
+
+* `href` - (String) When you provision a new job,  a URL is created identifying the location of the instance.
+  * Constraints: The maximum length is `2048` characters. The minimum length is `0` characters. The value must match regular expression `/(([^:\/?#]+):)?(\/\/([^\/?#]*))?([^?#]*)(\\?([^#]*))?(#(.*))?$/`.
+
+* `image_reference` - (String) The name of the image that is used for this job. The format is `REGISTRY/NAMESPACE/REPOSITORY:TAG` where `REGISTRY` and `TAG` are optional. If `REGISTRY` is not specified, the default is `docker.io`. If `TAG` is not specified, the default is `latest`. If the image reference points to a registry that requires authentication, make sure to also specify the property `image_secret`.
+  * Constraints: The maximum length is `256` characters. The minimum length is `1` character. The value must match regular expression `/^([a-z0-9][a-z0-9\\-_.]+[a-z0-9][\/])?([a-z0-9][a-z0-9\\-_]+[a-z0-9][\/])?[a-z0-9][a-z0-9\\-_.\/]+[a-z0-9](:[\\w][\\w.\\-]{0,127})?(@sha256:[a-fA-F0-9]{64})?$/`.
+
+* `image_secret` - (String) The name of the image registry access secret. The image registry access secret is used to authenticate with a private registry when you download the container image. If the image reference points to a registry that requires authentication, the job / job runs will be created but submitted job runs will fail, until this property is provided, too. This property must not be set on a job run, which references a job template.
+  * Constraints: The maximum length is `253` characters. The minimum length is `1` character. The value must match regular expression `/^[a-z0-9]([\\-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([\\-a-z0-9]*[a-z0-9])?)*$/`.
+
+* `job_id` - (String) The identifier of the resource.
+  * Constraints: The maximum length is `36` characters. The minimum length is `36` characters. The value must match regular expression `/^[0-9a-z]{8}-[0-9a-z]{4}-[0-9a-z]{4}-[0-9a-z]{4}-[0-9a-z]{12}$/`.
+
+* `resource_type` - (String) The type of the job.
+  * Constraints: Allowable values are: `job_v2`.
+
+* `run_arguments` - (List) Set arguments for the job that are passed to start job run containers. If not specified an empty string array will be applied and the arguments specified by the container image, will be used to start the container.
+  * Constraints: The list items must match regular expression `/^.*$/`. The maximum length is `100` items. The minimum length is `0` items.
+
+* `run_as_user` - (Integer) The user ID (UID) to run the job (e.g., 1001).
+
+* `run_commands` - (List) Set commands for the job that are passed to start job run containers. If not specified an empty string array will be applied and the command specified by the container image, will be used to start the container.
+  * Constraints: The list items must match regular expression `/^.*$/`. The maximum length is `100` items. The minimum length is `0` items.
+
+* `run_env_variables` - (List) References to config maps, secrets or literal values, which are exposed as environment variables in the job run.
+  * Constraints: The maximum length is `100` items. The minimum length is `0` items.
+Nested scheme for **run_env_variables**:
+	* `key` - (String) The key to reference as environment variable.
+	  * Constraints: The maximum length is `253` characters. The minimum length is `1` character. The value must match regular expression `/^[\\-._a-zA-Z0-9]+$/`.
+	* `name` - (String) The name of the environment variable.
+	  * Constraints: The maximum length is `253` characters. The minimum length is `1` character. The value must match regular expression `/^[\\-._a-zA-Z0-9]+$/`.
+	* `prefix` - (String) A prefix that can be added to all keys of a full secret or config map reference.
+	  * Constraints: The maximum length is `253` characters. The minimum length is `0` characters. The value must match regular expression `/^[a-zA-Z_][a-zA-Z0-9_]*$/`.
+	* `reference` - (String) The name of the secret or config map.
+	  * Constraints: The maximum length is `253` characters. The minimum length is `1` character. The value must match regular expression `/^[a-z0-9]([\\-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([\\-a-z0-9]*[a-z0-9])?)*$/`.
+	* `type` - (String) Specify the type of the environment variable.
+	  * Constraints: The default value is `literal`. Allowable values are: `literal`, `config_map_full_reference`, `secret_full_reference`, `config_map_key_reference`, `secret_key_reference`. The value must match regular expression `/^(literal|config_map_full_reference|secret_full_reference|config_map_key_reference|secret_key_reference)$/`.
+	* `value` - (String) The literal value of the environment variable.
+	  * Constraints: The maximum length is `253` characters. The minimum length is `1` character. The value must match regular expression `/^[\\-._a-zA-Z0-9]+$/`.
+
+* `run_mode` - (String) The mode for runs of the job. Valid values are `task` and `daemon`. In `task` mode, the `max_execution_time` and `retry_limit` properties apply. In `daemon` mode, since there is no timeout and failed instances are restarted indefinitely, the `max_execution_time` and `retry_limit` properties are not allowed.
+  * Constraints: The default value is `task`. Allowable values are: `task`, `daemon`. The minimum length is `0` characters. The value must match regular expression `/^(task|daemon)$/`.
+
+* `run_service_account` - (String) The name of the service account. For built-in service accounts, you can use the shortened names `manager`, `none`, `reader`, and `writer`. This property must not be set on a job run, which references a job template.
+  * Constraints: The default value is `default`. Allowable values are: `default`, `manager`, `reader`, `writer`, `none`. The minimum length is `0` characters. The value must match regular expression `/^(manager|reader|writer|none|default)$/`.
+
+* `run_volume_mounts` - (List) Optional mounts of config maps or a secrets.
+  * Constraints: The maximum length is `100` items. The minimum length is `0` items.
+Nested scheme for **run_volume_mounts**:
+	* `mount_path` - (String) The path that should be mounted.
+	  * Constraints: The maximum length is `256` characters. The minimum length is `1` character. The value must match regular expression `/^\/([^\/\\0]+\/?)+$/`.
+	* `name` - (String) The name of the mount.
+	  * Constraints: The maximum length is `63` characters. The minimum length is `0` characters. The value must match regular expression `/^[a-z]([-a-z0-9]*[a-z0-9])?$/`.
+	* `reference` - (String) The name of the referenced secret or config map.
+	  * Constraints: The maximum length is `253` characters. The minimum length is `1` character. The value must match regular expression `/^[a-z0-9]([\\-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([\\-a-z0-9]*[a-z0-9])?)*$/`.
+	* `type` - (String) Specify the type of the volume mount. Allowed types are: 'config_map', 'secret'.
+	  * Constraints: The default value is `secret`. Allowable values are: `config_map`, `secret`. The value must match regular expression `/^(config_map|secret)$/`.
+
+* `scale_array_spec` - (String) Define a custom set of array indices as comma-separated list containing single values and hyphen-separated ranges like `5,12-14,23,27`. Each instance can pick up its array index via environment variable `JOB_INDEX`. The number of unique array indices specified here determines the number of job instances to run.
+  * Constraints: The maximum length is `253` characters. The minimum length is `1` character. The value must match regular expression `/^(?:[1-9]\\d\\d\\d\\d\\d\\d|[1-9]\\d\\d\\d\\d\\d|[1-9]\\d\\d\\d\\d|[1-9]\\d\\d\\d|[1-9]\\d\\d|[1-9]?\\d)(?:-(?:[1-9]\\d\\d\\d\\d\\d\\d|[1-9]\\d\\d\\d\\d\\d|[1-9]\\d\\d\\d\\d|[1-9]\\d\\d\\d|[1-9]\\d\\d|[1-9]?\\d))?(?:,(?:[1-9]\\d\\d\\d\\d\\d\\d|[1-9]\\d\\d\\d\\d\\d|[1-9]\\d\\d\\d\\d|[1-9]\\d\\d\\d|[1-9]\\d\\d|[1-9]?\\d)(?:-(?:[1-9]\\d\\d\\d\\d\\d\\d|[1-9]\\d\\d\\d\\d\\d|[1-9]\\d\\d\\d\\d|[1-9]\\d\\d\\d|[1-9]\\d\\d|[1-9]?\\d))?)*$/`.
+
+* `scale_cpu_limit` - (String) Optional amount of CPU set for the instance of the job. For valid values see [Supported memory and CPU combinations](https://cloud.ibm.com/docs/codeengine?topic=codeengine-mem-cpu-combo).
+  * Constraints: The default value is `1`. The maximum length is `10` characters. The minimum length is `0` characters. The value must match regular expression `/^([0-9.]+)([eEinumkKMGTPB]*)$/`.
+
+* `scale_ephemeral_storage_limit` - (String) Optional amount of ephemeral storage to set for the instance of the job. The amount specified as ephemeral storage, must not exceed the amount of `scale_memory_limit`. The units for specifying ephemeral storage are Megabyte (M) or Gigabyte (G), whereas G and M are the shorthand expressions for GB and MB. For more information see [Units of measurement](https://cloud.ibm.com/docs/codeengine?topic=codeengine-mem-cpu-combo#unit-measurements).
+  * Constraints: The default value is `400M`. The maximum length is `10` characters. The minimum length is `0` characters. The value must match regular expression `/^([0-9.]+)([eEinumkKMGTPB]*)$/`.
+
+* `scale_max_execution_time` - (Integer) The maximum execution time in seconds for runs of the job. This property can only be specified if `run_mode` is `task`.
+
+* `scale_memory_limit` - (String) Optional amount of memory set for the instance of the job. For valid values see [Supported memory and CPU combinations](https://cloud.ibm.com/docs/codeengine?topic=codeengine-mem-cpu-combo). The units for specifying memory are Megabyte (M) or Gigabyte (G), whereas G and M are the shorthand expressions for GB and MB. For more information see [Units of measurement](https://cloud.ibm.com/docs/codeengine?topic=codeengine-mem-cpu-combo#unit-measurements).
+  * Constraints: The default value is `4G`. The maximum length is `10` characters. The minimum length is `0` characters. The value must match regular expression `/^([0-9.]+)([eEinumkKMGTPB]*)$/`.
+
+* `scale_retry_limit` - (Integer) The number of times to rerun an instance of the job before the job is marked as failed. This property can only be specified if `run_mode` is `task`.
+

--- a/website/docs/d/code_engine_project.html.markdown
+++ b/website/docs/d/code_engine_project.html.markdown
@@ -14,7 +14,7 @@ Provides a read-only data source for code_engine_project. You can then reference
 
 ```hcl
 data "ibm_code_engine_project" "code_engine_project" {
-	id = "15314cc3-85b4-4338-903f-c28cdee6d005"
+	project_id = "15314cc3-85b4-4338-903f-c28cdee6d005"
 }
 ```
 

--- a/website/docs/d/code_engine_secret.html.markdown
+++ b/website/docs/d/code_engine_secret.html.markdown
@@ -1,0 +1,53 @@
+---
+layout: "ibm"
+page_title: "IBM : ibm_code_engine_secret"
+description: |-
+  Get information about code_engine_secret
+subcategory: "Code Engine"
+---
+
+# ibm_code_engine_secret
+
+Provides a read-only data source for code_engine_secret. You can then reference the fields of the data source in other resources within the same configuration using interpolation syntax.
+
+## Example Usage
+
+```hcl
+data "ibm_code_engine_secret" "code_engine_secret" {
+	project_id = data.ibm_code_engine_project.code_engine_project.project_id
+	name       = "my-secret"
+}
+```
+
+## Argument Reference
+
+Review the argument reference that you can specify for your data source.
+
+* `name` - (Required, Forces new resource, String) The name of your secret.
+  * Constraints: The maximum length is `253` characters. The minimum length is `1` character. The value must match regular expression `/^[a-z0-9]([\\-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([\\-a-z0-9]*[a-z0-9])?)*$/`.
+* `project_id` - (Required, Forces new resource, String) The ID of the project.
+  * Constraints: The maximum length is `36` characters. The minimum length is `36` characters. The value must match regular expression `/^[0-9a-z]{8}-[0-9a-z]{4}-[0-9a-z]{4}-[0-9a-z]{4}-[0-9a-z]{12}$/`.
+
+## Attribute Reference
+
+In addition to all argument references listed, you can access the following attribute references after your data source is created.
+
+* `id` - The unique identifier of the code_engine_secret.
+* `created_at` - (String) The timestamp when the resource was created.
+
+* `data` - (Map) Data container that allows to specify config parameters and their values as a key-value map. Each key field must consist of alphanumeric characters, `-`, `_` or `.` and must not be exceed a max length of 253 characters. Each value field can consists of any character and must not be exceed a max length of 1048576 characters.
+
+* `entity_tag` - (String) The version of the secret instance, which is used to achieve optimistic locking.
+  * Constraints: The maximum length is `63` characters. The minimum length is `1` character. The value must match regular expression `/^[\\*\\-a-z0-9]+$/`.
+
+* `format` - (Forces new resource, String) Specify the format of the secret.
+  * Constraints: Allowable values are: `generic`, `ssh_auth`, `basic_auth`, `tls`, `service_access`, `registry`, `other`. The value must match regular expression `/^(generic|ssh_auth|basic_auth|tls|service_access|registry|other)$/`.
+
+* `href` - (String) When you provision a new secret,  a URL is created identifying the location of the instance.
+  * Constraints: The maximum length is `2048` characters. The minimum length is `0` characters. The value must match regular expression `/(([^:\/?#]+):)?(\/\/([^\/?#]*))?([^?#]*)(\\?([^#]*))?(#(.*))?$/`.
+
+* `resource_type` - (String) The type of the secret.
+
+* `secret_id` - (String) The identifier of the resource.
+  * Constraints: The maximum length is `36` characters. The minimum length is `36` characters. The value must match regular expression `/^[0-9a-z]{8}-[0-9a-z]{4}-[0-9a-z]{4}-[0-9a-z]{4}-[0-9a-z]{12}$/`.
+


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/IBM-Cloud/terraform-provider-ibm/blob/master/.github/CONTRIBUTING.md --->
This PR adds new data sources for IBM Cloud Code Engine for already existing resources:
- `apps`
- `builds`
- `config_maps`
- `jobs`
- `secrets`

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc                                                           
TF_ACC=1 go test -v $(go list ./... |grep -v 'vendor') 
?       github.com/IBM-Cloud/terraform-provider-ibm     [no test files]
?       github.com/IBM-Cloud/terraform-provider-ibm/ibm/acctest [no test files]
?       github.com/IBM-Cloud/terraform-provider-ibm/ibm/flex    [no test files]
?       github.com/IBM-Cloud/terraform-provider-ibm/ibm/provider        [no test files]
=== RUN   TestString
--- PASS: TestString (0.00s)
=== RUN   TestString_positiveIndex
--- PASS: TestString_positiveIndex (0.00s)
PASS
ok      github.com/IBM-Cloud/terraform-provider-ibm/ibm/conns   (cached)
?       github.com/IBM-Cloud/terraform-provider-ibm/ibm/validate        [no test files]
?       github.com/IBM-Cloud/terraform-provider-ibm/version     [no test files]
=== RUN   TestAccIbmCodeEngineAppDataSourceBasic
--- PASS: TestAccIbmCodeEngineAppDataSourceBasic (79.53s)
=== RUN   TestAccIbmCodeEngineAppDataSourceExtended
--- PASS: TestAccIbmCodeEngineAppDataSourceExtended (73.73s)
=== RUN   TestAccIbmCodeEngineBuildDataSourceBasic
--- PASS: TestAccIbmCodeEngineBuildDataSourceBasic (15.95s)
=== RUN   TestAccIbmCodeEngineConfigMapDataSourceBasic
--- PASS: TestAccIbmCodeEngineConfigMapDataSourceBasic (15.07s)
=== RUN   TestAccIbmCodeEngineJobDataSourceBasic
--- PASS: TestAccIbmCodeEngineJobDataSourceBasic (14.14s)
=== RUN   TestAccIbmCodeEngineJobDataSourceExtended
--- PASS: TestAccIbmCodeEngineJobDataSourceExtended (14.24s)
=== RUN   TestAccIbmCodeEngineProjectDataSourceBasic
--- PASS: TestAccIbmCodeEngineProjectDataSourceBasic (8.77s)
=== RUN   TestAccIbmCodeEngineSecretDataSourceGeneric
--- PASS: TestAccIbmCodeEngineSecretDataSourceGeneric (15.57s)
=== RUN   TestAccIbmCodeEngineSecretDataSourceBasicAuth
--- PASS: TestAccIbmCodeEngineSecretDataSourceBasicAuth (12.56s)
=== RUN   TestAccIbmCodeEngineSecretDataSourceRegistry
--- PASS: TestAccIbmCodeEngineSecretDataSourceRegistry (12.28s)
=== RUN   TestAccIbmCodeEngineSecretDataSourceSSHAuth
--- PASS: TestAccIbmCodeEngineSecretDataSourceSSHAuth (11.95s)
=== RUN   TestAccIbmCodeEngineSecretDataSourceTls
--- PASS: TestAccIbmCodeEngineSecretDataSourceTls (12.68s)
PASS
ok      github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/codeengine      286.747s
...
```
