### PR TITLE
Adding changes for replacement of key_protect parameter

### DIFF
--- a/examples/ibm-cos-bucket/main.tf
+++ b/examples/ibm-cos-bucket/main.tf
@@ -304,7 +304,7 @@ resource "ibm_cos_bucket" "hpcs-enabled" {
   resource_instance_id = ibm_resource_instance.cos_instance.id
   region_location       = var.regional_loc
   storage_class         = var.standard_storage_class
-  key_protect          = ibm_kms_key.key.id
+  kms_key_crn          = ibm_kms_key.key.id
 }
 
 //HPCS - UKO plan
@@ -314,7 +314,7 @@ resource "ibm_cos_bucket" "hpcs-uko-enabled" {
   resource_instance_id = ibm_resource_instance.cos_instance.id
   region_location       = var.regional_loc
   storage_class         = var.standard_storage_class
-  key_protect           = var.hpcs_uko_rootkeycrn
+  kms_key_crn           = var.hpcs_uko_rootkeycrn
 }
 resource "ibm_cos_bucket_object" "plaintext" {
   bucket_crn      = ibm_cos_bucket.cos_bucket.crn

--- a/ibm/service/cos/data_source_ibm_cos_bucket.go
+++ b/ibm/service/cos/data_source_ibm_cos_bucket.go
@@ -75,6 +75,11 @@ func DataSourceIBMCosBucket() *schema.Resource {
 				Computed:    true,
 				Description: "CRN of the key you want to use data at rest encryption",
 			},
+			"kms_key_crn": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "CRN of the key you want to use data at rest encryption",
+			},
 			"single_site_location": {
 				Type:     schema.TypeString,
 				Computed: true,
@@ -558,6 +563,7 @@ func dataSourceIBMCosBucketRead(d *schema.ResourceData, meta interface{}) error 
 	bucketID := fmt.Sprintf("%s:%s:%s:meta:%s:%s:%s", strings.Replace(serviceID, "::", "", -1), "bucket", bucketName, bucketLocationConvert(bucketType), bucketRegion, endpointType)
 	d.SetId(bucketID)
 	d.Set("key_protect", head.IBMSSEKPCrkId)
+	d.Set("kms_key_crn", head.IBMSSEKPCrkId)
 	bucketCRN := fmt.Sprintf("%s:%s:%s", strings.Replace(serviceID, "::", "", -1), "bucket", bucketName)
 	d.Set("crn", bucketCRN)
 	d.Set("resource_instance_id", serviceID)

--- a/ibm/service/cos/resource_ibm_cos_bucket.go
+++ b/ibm/service/cos/resource_ibm_cos_bucket.go
@@ -95,10 +95,18 @@ func ResourceIBMCOSBucket() *schema.Resource {
 				Description: "CRN of resource instance",
 			},
 			"key_protect": {
-				Type:        schema.TypeString,
-				ForceNew:    true,
-				Optional:    true,
-				Description: "CRN of the key you want to use data at rest encryption",
+				Type:          schema.TypeString,
+				ForceNew:      true,
+				Optional:      true,
+				ConflictsWith: []string{"kms_key_crn"},
+				Description:   "CRN of the key you want to use data at rest encryption",
+			},
+			"kms_key_crn": {
+				Type:          schema.TypeString,
+				ForceNew:      true,
+				Optional:      true,
+				ConflictsWith: []string{"key_protect"},
+				Description:   "CRN of the key you want to use data at rest encryption",
 			},
 			"satellite_location_id": {
 				Type:          schema.TypeString,

--- a/ibm/service/cos/resource_ibm_cos_bucket_test.go
+++ b/ibm/service/cos/resource_ibm_cos_bucket_test.go
@@ -1255,6 +1255,112 @@ func TestAccIBMCOSHPCS(t *testing.T) {
 	})
 }
 
+func TestAccIBMCOSKPKmsParamValid(t *testing.T) {
+
+	instanceName := fmt.Sprintf("kms_%d", acctest.RandIntRange(10, 100))
+	serviceName := fmt.Sprintf("terraform_%d", acctest.RandIntRange(10, 100))
+	bucketName := fmt.Sprintf("terraform%d", acctest.RandIntRange(10, 100))
+	keyName := fmt.Sprintf("key_%d", acctest.RandIntRange(10, 100))
+	bucketRegion := "us"
+	bucketClass := "standard"
+	bucketRegionType := "cross_region_location"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { acc.TestAccPreCheck(t) },
+		Providers: acc.TestAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckIBMKeyProtectRootkeyWithCOSBucketKmsParam(instanceName, keyName, serviceName, bucketName, bucketRegion, bucketClass),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckIBMCosBucketExists("ibm_resource_instance.instance", "ibm_cos_bucket.bucket", bucketRegionType, bucketRegion, bucketName),
+					resource.TestCheckResourceAttr("ibm_cos_bucket.bucket", "bucket_name", bucketName),
+				),
+			},
+		},
+	})
+}
+func TestAccIBMCOSKPKmsParamWithInvalidCRN(t *testing.T) {
+
+	instanceName := fmt.Sprintf("kms_%d", acctest.RandIntRange(10, 100))
+	serviceName := fmt.Sprintf("terraform_%d", acctest.RandIntRange(10, 100))
+	bucketName := fmt.Sprintf("terraform%d", acctest.RandIntRange(10, 100))
+	keyName := fmt.Sprintf("key_%d", acctest.RandIntRange(10, 100))
+	bucketRegion := "us"
+	bucketClass := "standard"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { acc.TestAccPreCheck(t) },
+		Providers: acc.TestAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccCheckIBMKeyProtectRootkeyWithCOSBucketKmsParamWithInvalidCRN(instanceName, keyName, serviceName, bucketName, bucketRegion, bucketClass),
+				ExpectError: regexp.MustCompile("InvalidArgument: Invalid ibm-sse-kp-customer-root-key-crn: received only 7 of required 10 segments"),
+			},
+		},
+	})
+}
+
+func TestAccIBMCOSHPCSKmsParam(t *testing.T) {
+	serviceName := fmt.Sprintf("terraform_%d", acctest.RandIntRange(10, 100))
+	bucketName := fmt.Sprintf("terraform%d", acctest.RandIntRange(10, 100))
+	keyName := fmt.Sprintf("key_%d", acctest.RandIntRange(10, 100))
+	bucketRegion := "us-south"
+	bucketClass := "standard"
+	bucketRegionType := "cross_region_location"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { acc.TestAccPreCheck(t) },
+		Providers: acc.TestAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckIBMHPCSRootkeyWithCOSBucketKmsParam(keyName, serviceName, bucketName, bucketRegion, bucketClass),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckIBMCosBucketExists("ibm_resource_instance.instance", "ibm_cos_bucket.bucket", bucketRegionType, bucketRegion, bucketName),
+					resource.TestCheckResourceAttr("ibm_cos_bucket.bucket", "bucket_name", bucketName),
+					resource.TestCheckResourceAttr("ibm_cos_bucket.bucket", "kms_key_crn", acc.HpcsRootKeyCrn),
+				),
+			},
+		},
+	})
+}
+
+func TestAccIBMCOSHPCSKmsParamWithInvalidCRN(t *testing.T) {
+	serviceName := fmt.Sprintf("terraform_%d", acctest.RandIntRange(10, 100))
+	bucketName := fmt.Sprintf("terraform%d", acctest.RandIntRange(10, 100))
+	keyName := fmt.Sprintf("key_%d", acctest.RandIntRange(10, 100))
+	bucketRegion := "us-south"
+	bucketClass := "standard"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { acc.TestAccPreCheck(t) },
+		Providers: acc.TestAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccCheckIBMHPCSRootkeyWithCOSBucketKmsParamWithInvalidCRN(keyName, serviceName, bucketName, bucketRegion, bucketClass),
+				ExpectError: regexp.MustCompile("InvalidArgument: Invalid ibm-sse-kp-customer-root-key-crn: received only 7 of required 10 segments"),
+			},
+		},
+	})
+}
+
+func TestAccIBMCOSKMSBothParamProvided(t *testing.T) {
+	serviceName := fmt.Sprintf("terraform_%d", acctest.RandIntRange(10, 100))
+	bucketName := fmt.Sprintf("terraform%d", acctest.RandIntRange(10, 100))
+	keyName := fmt.Sprintf("key_%d", acctest.RandIntRange(10, 100))
+	bucketRegion := "us-south"
+	bucketClass := "standard"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { acc.TestAccPreCheck(t) },
+		Providers: acc.TestAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccCheckIBMHPCSRootkeyWithCOSBucketKMSBothParamProvided(keyName, serviceName, bucketName, bucketRegion, bucketClass),
+				ExpectError: regexp.MustCompile("Error: Conflicting configuration arguments"),
+			},
+		},
+	})
+}
 func testAccCheckIBMCosBucket_basic(serviceName string, bucketName string, regiontype string, region string, storageClass string) string {
 
 	return fmt.Sprintf(`
@@ -2478,6 +2584,130 @@ func testAccCheckIBMHPCSRootkeyWithCOSBucket(KeyName, serviceName, bucketName, b
 		key_protect			= "%s"
 	}
 `, serviceName, bucketName, bucketRegion, bucketClass, acc.HpcsRootKeyCrn)
+}
+func testAccCheckIBMKeyProtectRootkeyWithCOSBucketKmsParam(instanceName, KeyName, serviceName, bucketName, bucketRegion, bucketClass string) string {
+	return fmt.Sprintf(`
+	data "ibm_resource_group" "group" {
+		is_default=true
+	}
+	resource "ibm_resource_instance" "kms_instance1" {
+		name              = "%s"
+		service           = "kms"
+		plan              = "tiered-pricing"
+		location          = "us-south"
+	  }
+
+	  resource "ibm_kms_key" "test" {
+		instance_id = "${ibm_resource_instance.kms_instance1.guid}"
+		key_name = "%s"
+		standard_key =  false
+		force_delete = true
+	}
+
+	resource "ibm_resource_instance" "instance" {
+		name     = "%s"
+		service  = "cloud-object-storage"
+		plan     = "standard"
+		location = "global"
+	}
+
+	resource "ibm_cos_bucket" "bucket" {
+		bucket_name          = "%s"
+		resource_instance_id = ibm_resource_instance.instance.id
+		cross_region_location = "%s"
+		storage_class        = "%s"
+		kms_key_crn          = ibm_kms_key.test.id
+	}
+`, instanceName, KeyName, serviceName, bucketName, bucketRegion, bucketClass)
+}
+func testAccCheckIBMKeyProtectRootkeyWithCOSBucketKmsParamWithInvalidCRN(instanceName, KeyName, serviceName, bucketName, bucketRegion, bucketClass string) string {
+	return fmt.Sprintf(`
+	data "ibm_resource_group" "group" {
+		is_default=true
+	}
+	
+	resource "ibm_resource_instance" "instance" {
+		name     = "%s"
+		service  = "cloud-object-storage"
+		plan     = "standard"
+		location = "global"
+	}
+
+	resource "ibm_cos_bucket" "bucket" {
+		bucket_name          = "%s"
+		resource_instance_id = ibm_resource_instance.instance.id
+		cross_region_location = "%s"
+		storage_class        = "%s"
+		kms_key_crn          = "crn:v1:staging:public:kms:us-south:invalid"
+	}
+`, instanceName, bucketName, bucketRegion, bucketClass)
+}
+
+func testAccCheckIBMHPCSRootkeyWithCOSBucketKmsParam(KeyName, serviceName, bucketName, bucketRegion, bucketClass string) string {
+	return fmt.Sprintf(`
+	data "ibm_resource_group" "group" {
+		is_default=true
+	}
+	resource "ibm_resource_instance" "instance" {
+		name     = "%s"
+		service  = "cloud-object-storage"
+		plan     = "standard"
+		location = "global"
+	}
+
+	resource "ibm_cos_bucket" "bucket" {
+		bucket_name          = "%s"
+		resource_instance_id = ibm_resource_instance.instance.id
+		region_location 	= "%s"
+		storage_class       = "%s"
+		kms_key_crn			= "%s"
+	}
+`, serviceName, bucketName, bucketRegion, bucketClass, acc.HpcsRootKeyCrn)
+}
+
+func testAccCheckIBMHPCSRootkeyWithCOSBucketKMSBothParamProvided(KeyName, serviceName, bucketName, bucketRegion, bucketClass string) string {
+	return fmt.Sprintf(`
+	data "ibm_resource_group" "group" {
+		is_default=true
+	}
+	resource "ibm_resource_instance" "instance" {
+		name     = "%s"
+		service  = "cloud-object-storage"
+		plan     = "standard"
+		location = "global"
+	}
+
+	resource "ibm_cos_bucket" "bucket" {
+		bucket_name          = "%s"
+		resource_instance_id = ibm_resource_instance.instance.id
+		region_location 	= "%s"
+		storage_class       = "%s"
+		kms_key_crn			= "%s"
+		key_protect 		= "%s"
+	}
+`, serviceName, bucketName, bucketRegion, bucketClass, acc.HpcsRootKeyCrn, acc.HpcsRootKeyCrn)
+}
+
+func testAccCheckIBMHPCSRootkeyWithCOSBucketKmsParamWithInvalidCRN(KeyName, serviceName, bucketName, bucketRegion, bucketClass string) string {
+	return fmt.Sprintf(`
+	data "ibm_resource_group" "group" {
+		is_default=true
+	}
+	resource "ibm_resource_instance" "instance" {
+		name     = "%s"
+		service  = "cloud-object-storage"
+		plan     = "standard"
+		location = "global"
+	}
+
+	resource "ibm_cos_bucket" "bucket" {
+		bucket_name          = "%s"
+		resource_instance_id = ibm_resource_instance.instance.id
+		region_location 	= "%s"
+		storage_class       = "%s"
+		kms_key_crn			= "crn:v1:staging:public:hs-crypto:us-south:invalid"
+	}
+`, serviceName, bucketName, bucketRegion, bucketClass)
 }
 
 func TestSingleSiteLocationRegex(t *testing.T) {

--- a/website/docs/d/cos_bucket.html.markdown
+++ b/website/docs/d/cos_bucket.html.markdown
@@ -95,7 +95,7 @@ resource "ibm_cos_bucket" "smart-us-south" {
   resource_instance_id = "cos-instance-id"
   region_location      = "us-south"
   storage_class        = "smart"
-  key_protect          = data.ibm_kms_key.test.key.0.crn
+  kms_key_crn          = data.ibm_kms_key.test.key.0.crn
 }
 
 ```
@@ -168,7 +168,7 @@ In addition to all argument reference list, you can access the following attribu
   - `rule_id` - (String)  Unique identifier for the rule. Expire rules allow you to set a specific time frame after which objects are deleted.
 - `hard_quota` - (String) Maximum bytes for the bucket.
 - `id` - (String) The ID of the bucket.
-- `key_protect` - (String) The CRN of the IBM Key Protect instance where a root key is already provisioned. 
+- `kms_key_crn` - (String) The CRN of the IBM Key Protect instance where a root key is already provisioned. 
 - `metrics_monitoring`- (List) Nested block with the following structure.
    
   Nested scheme for `metrics_monitoring`:


### PR DESCRIPTION
Test results :

--- PASS: TestAccIBMCOSKPKmsParamValid (84.76s)
PASS
ok 	[github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/cos](http://github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/cos)	86.384s
--- PASS: TestAccIBMCOSKPKmsParamWithInvalidCRN (49.70s)
PASS
ok 	[github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/cos](http://github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/cos)	51.390s

--- PASS: TestAccIBMCOSHPCSKmsParamWithInvalidCRN (44.35s)
PASS
ok 	[github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/cos](http://github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/cos)	114.080s
--- PASS: TestAccIBMCOSHPCSKmsParamWithInvalidCRN (44.35s)
PASS
ok 	[github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/cos](http://github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/cos)	(cached)

--- PASS: TestAccIBMCOSKMSBothParamProvided (0.34s)
PASS
ok 	[github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/cos](http://github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/cos)	1.835s