### PR TITLE
Tekton: Improved property type handling

### DIFF
--- a/examples/ibm-cd-tekton-pipeline/versions.tf
+++ b/examples/ibm-cd-tekton-pipeline/versions.tf
@@ -1,12 +1,9 @@
-###############################
-# IBM Cloud Copyright 2022 IBM
-###############################
-
 terraform {
+  required_version = ">= 1.0"
   required_providers {
     ibm = {
       source = "IBM-Cloud/ibm"
-      version = ">=1.48.0"
+      version = ">=1.53.0"
     }
   }
 }

--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/IBM/cloudant-go-sdk v0.0.43
 	github.com/IBM/code-engine-go-sdk v0.0.0-20230324212854-743a707334f6
 	github.com/IBM/container-registry-go-sdk v0.0.15
-	github.com/IBM/continuous-delivery-go-sdk v1.1.0
+	github.com/IBM/continuous-delivery-go-sdk v1.1.1
 	github.com/IBM/event-notifications-go-admin-sdk v0.2.2
 	github.com/IBM/eventstreams-go-sdk v1.2.0
 	github.com/IBM/go-sdk-core/v5 v5.13.4

--- a/go.sum
+++ b/go.sum
@@ -57,8 +57,8 @@ github.com/IBM/code-engine-go-sdk v0.0.0-20230324212854-743a707334f6 h1:PlYtJ+VZ
 github.com/IBM/code-engine-go-sdk v0.0.0-20230324212854-743a707334f6/go.mod h1:IP6U/1NxgxzPeYdyiEwMaZyzelTw82JGHWl7bY78eQM=
 github.com/IBM/container-registry-go-sdk v0.0.15 h1:sfEXm4qNj9ZCwTlFOsdjF5P/lvajU/Sc22yNlzg0F9I=
 github.com/IBM/container-registry-go-sdk v0.0.15/go.mod h1:KqSZFO4VIK9QAyF8O1JW6jkyzkfE/BNKUIo+OdzIDk4=
-github.com/IBM/continuous-delivery-go-sdk v1.1.0 h1:E0hPM4H7Bmn31+4UAMavBngRjTMoqbjkBb4AlIgi0tA=
-github.com/IBM/continuous-delivery-go-sdk v1.1.0/go.mod h1:JUHFfLCLDMtEQhfDvxBT79O2OcBmSV+is9bKRdnUF1o=
+github.com/IBM/continuous-delivery-go-sdk v1.1.1 h1:bYrK0+rJgoWfBmIJAlAfo/AxI5vOr8DSLJPrM3iEOzQ=
+github.com/IBM/continuous-delivery-go-sdk v1.1.1/go.mod h1:A9rI1HPbccBBFgwJxXB999yXXpj1l+MnlE+rsxKtxw0=
 github.com/IBM/event-notifications-go-admin-sdk v0.2.2 h1:Aww+OUcKgsbXyY7a/nlMH7nvZGn0sBTr6p6rUjOyy1Y=
 github.com/IBM/event-notifications-go-admin-sdk v0.2.2/go.mod h1:1TlGAFP47DybbovJfHtYYgSI8xpLL8Q0wao6vsAlb6c=
 github.com/IBM/eventstreams-go-sdk v1.2.0 h1:eP0afHArMGjwhGqvZAhhu/3EDKRch2JehpveqF1TUjs=

--- a/ibm/service/cdtektonpipeline/data_source_ibm_cd_tekton_pipeline_test.go
+++ b/ibm/service/cdtektonpipeline/data_source_ibm_cd_tekton_pipeline_test.go
@@ -35,7 +35,6 @@ func TestAccIBMCdTektonPipelineDataSourceBasic(t *testing.T) {
 					resource.TestCheckResourceAttrSet("data.ibm_cd_tekton_pipeline.cd_tekton_pipeline", "worker.#"),
 					resource.TestCheckResourceAttrSet("data.ibm_cd_tekton_pipeline.cd_tekton_pipeline", "runs_url"),
 					resource.TestCheckResourceAttrSet("data.ibm_cd_tekton_pipeline.cd_tekton_pipeline", "build_number"),
-					resource.TestCheckResourceAttrSet("data.ibm_cd_tekton_pipeline.cd_tekton_pipeline", "next_build_number"),
 					resource.TestCheckResourceAttrSet("data.ibm_cd_tekton_pipeline.cd_tekton_pipeline", "enable_notifications"),
 					resource.TestCheckResourceAttrSet("data.ibm_cd_tekton_pipeline.cd_tekton_pipeline", "enable_partial_cloning"),
 					resource.TestCheckResourceAttrSet("data.ibm_cd_tekton_pipeline.cd_tekton_pipeline", "enabled"),

--- a/ibm/service/cdtektonpipeline/resource_ibm_cd_tekton_pipeline.go
+++ b/ibm/service/cdtektonpipeline/resource_ibm_cd_tekton_pipeline.go
@@ -221,6 +221,7 @@ func ResourceIBMCdTektonPipeline() *schema.Resource {
 						"type": &schema.Schema{
 							Type:        schema.TypeString,
 							Required:    true,
+							ForceNew:    true,
 							Description: "Property type.",
 						},
 						"path": &schema.Schema{
@@ -304,6 +305,7 @@ func ResourceIBMCdTektonPipeline() *schema.Resource {
 									"type": &schema.Schema{
 										Type:        schema.TypeString,
 										Required:    true,
+										ForceNew:    true,
 										Description: "Property type.",
 									},
 									"path": &schema.Schema{

--- a/ibm/service/cdtektonpipeline/resource_ibm_cd_tekton_pipeline_property.go
+++ b/ibm/service/cdtektonpipeline/resource_ibm_cd_tekton_pipeline_property.go
@@ -44,6 +44,7 @@ func ResourceIBMCdTektonPipelineProperty() *schema.Resource {
 			"type": &schema.Schema{
 				Type:         schema.TypeString,
 				Required:     true,
+				ForceNew:     true,
 				ValidateFunc: validate.InvokeValidator("ibm_cd_tekton_pipeline_property", "type"),
 				Description:  "Property type.",
 			},
@@ -252,8 +253,8 @@ func resourceIBMCdTektonPipelinePropertyUpdate(context context.Context, d *schem
 			" The resource must be re-created to update this property.", "name"))
 	}
 	if d.HasChange("type") {
-		replaceTektonPipelinePropertyOptions.SetType(d.Get("type").(string))
-		hasChange = true
+		return diag.FromErr(fmt.Errorf("Cannot update resource property \"%s\" with the ForceNew annotation."+
+			" The resource must be re-created to update this property.", "type"))
 	}
 
 	if d.Get("type").(string) == "integration" {

--- a/ibm/service/cdtektonpipeline/resource_ibm_cd_tekton_pipeline_property_test.go
+++ b/ibm/service/cdtektonpipeline/resource_ibm_cd_tekton_pipeline_property_test.go
@@ -21,8 +21,6 @@ func TestAccIBMCdTektonPipelinePropertyBasic(t *testing.T) {
 	var conf cdtektonpipelinev2.Property
 	name := "property1"
 	typeVar := "text"
-	typeVarUpdate := "text"
-
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { acc.TestAccPreCheck(t) },
 		Providers:    acc.TestAccProviders,
@@ -36,13 +34,6 @@ func TestAccIBMCdTektonPipelinePropertyBasic(t *testing.T) {
 					resource.TestCheckResourceAttr("ibm_cd_tekton_pipeline_property.cd_tekton_pipeline_property", "type", typeVar),
 				),
 			},
-			resource.TestStep{
-				Config: testAccCheckIBMCdTektonPipelinePropertyConfigBasic("", name, typeVarUpdate),
-				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr("ibm_cd_tekton_pipeline_property.cd_tekton_pipeline_property", "name", name),
-					resource.TestCheckResourceAttr("ibm_cd_tekton_pipeline_property.cd_tekton_pipeline_property", "type", typeVarUpdate),
-				),
-			},
 		},
 	})
 }
@@ -53,7 +44,6 @@ func TestAccIBMCdTektonPipelinePropertyAllArgs(t *testing.T) {
 	typeVar := "text"
 	value := fmt.Sprintf("tf_value_%d", acctest.RandIntRange(10, 100))
 	path := fmt.Sprintf("tf_path_%d", acctest.RandIntRange(10, 100))
-	typeVarUpdate := "text"
 	valueUpdate := fmt.Sprintf("tf_value_%d", acctest.RandIntRange(10, 100))
 	pathUpdate := fmt.Sprintf("tf_path_%d", acctest.RandIntRange(10, 100))
 
@@ -72,10 +62,10 @@ func TestAccIBMCdTektonPipelinePropertyAllArgs(t *testing.T) {
 				),
 			},
 			resource.TestStep{
-				Config: testAccCheckIBMCdTektonPipelinePropertyConfig("", name, typeVarUpdate, valueUpdate, pathUpdate),
+				Config: testAccCheckIBMCdTektonPipelinePropertyConfig("", name, typeVar, valueUpdate, pathUpdate),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr("ibm_cd_tekton_pipeline_property.cd_tekton_pipeline_property", "name", name),
-					resource.TestCheckResourceAttr("ibm_cd_tekton_pipeline_property.cd_tekton_pipeline_property", "type", typeVarUpdate),
+					resource.TestCheckResourceAttr("ibm_cd_tekton_pipeline_property.cd_tekton_pipeline_property", "type", typeVar),
 					resource.TestCheckResourceAttr("ibm_cd_tekton_pipeline_property.cd_tekton_pipeline_property", "value", valueUpdate),
 				),
 			},

--- a/ibm/service/cdtektonpipeline/resource_ibm_cd_tekton_pipeline_trigger.go
+++ b/ibm/service/cdtektonpipeline/resource_ibm_cd_tekton_pipeline_trigger.go
@@ -219,6 +219,7 @@ func ResourceIBMCdTektonPipelineTrigger() *schema.Resource {
 						"type": &schema.Schema{
 							Type:        schema.TypeString,
 							Required:    true,
+							ForceNew:    true,
 							Description: "Property type.",
 						},
 						"path": &schema.Schema{

--- a/ibm/service/cdtektonpipeline/resource_ibm_cd_tekton_pipeline_trigger_property.go
+++ b/ibm/service/cdtektonpipeline/resource_ibm_cd_tekton_pipeline_trigger_property.go
@@ -51,6 +51,7 @@ func ResourceIBMCdTektonPipelineTriggerProperty() *schema.Resource {
 			"type": &schema.Schema{
 				Type:         schema.TypeString,
 				Required:     true,
+				ForceNew:     true,
 				ValidateFunc: validate.InvokeValidator("ibm_cd_tekton_pipeline_trigger_property", "type"),
 				Description:  "Property type.",
 			},
@@ -278,8 +279,8 @@ func resourceIBMCdTektonPipelineTriggerPropertyUpdate(context context.Context, d
 			" The resource must be re-created to update this property.", "name"))
 	}
 	if d.HasChange("type") {
-		replaceTektonPipelineTriggerPropertyOptions.SetType(d.Get("type").(string))
-		hasChange = true
+		return diag.FromErr(fmt.Errorf("Cannot update resource property \"%s\" with the ForceNew annotation."+
+			" The resource must be re-created to update this property.", "type"))
 	}
 
 	if d.Get("type").(string) == "integration" {

--- a/ibm/service/cdtektonpipeline/resource_ibm_cd_tekton_pipeline_trigger_property_test.go
+++ b/ibm/service/cdtektonpipeline/resource_ibm_cd_tekton_pipeline_trigger_property_test.go
@@ -21,8 +21,6 @@ func TestAccIBMCdTektonPipelineTriggerPropertyBasic(t *testing.T) {
 	var conf cdtektonpipelinev2.TriggerProperty
 	name := "trig-prop-1"
 	typeVar := "text"
-	typeVarUpdate := "text"
-
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { acc.TestAccPreCheck(t) },
 		Providers:    acc.TestAccProviders,
@@ -36,13 +34,6 @@ func TestAccIBMCdTektonPipelineTriggerPropertyBasic(t *testing.T) {
 					resource.TestCheckResourceAttr("ibm_cd_tekton_pipeline_trigger_property.cd_tekton_pipeline_trigger_property", "type", typeVar),
 				),
 			},
-			resource.TestStep{
-				Config: testAccCheckIBMCdTektonPipelineTriggerPropertyConfigBasic("", "", name, typeVarUpdate),
-				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr("ibm_cd_tekton_pipeline_trigger_property.cd_tekton_pipeline_trigger_property", "name", name),
-					resource.TestCheckResourceAttr("ibm_cd_tekton_pipeline_trigger_property.cd_tekton_pipeline_trigger_property", "type", typeVarUpdate),
-				),
-			},
 		},
 	})
 }
@@ -53,7 +44,6 @@ func TestAccIBMCdTektonPipelineTriggerPropertyAllArgs(t *testing.T) {
 	typeVar := "text"
 	value := fmt.Sprintf("tf_value_%d", acctest.RandIntRange(10, 100))
 	path := fmt.Sprintf("tf_path_%d", acctest.RandIntRange(10, 100))
-	typeVarUpdate := "text"
 	valueUpdate := fmt.Sprintf("tf_value_%d", acctest.RandIntRange(10, 100))
 	pathUpdate := fmt.Sprintf("tf_path_%d", acctest.RandIntRange(10, 100))
 
@@ -72,10 +62,10 @@ func TestAccIBMCdTektonPipelineTriggerPropertyAllArgs(t *testing.T) {
 				),
 			},
 			resource.TestStep{
-				Config: testAccCheckIBMCdTektonPipelineTriggerPropertyConfig("", "", name, typeVarUpdate, valueUpdate, pathUpdate),
+				Config: testAccCheckIBMCdTektonPipelineTriggerPropertyConfig("", "", name, typeVar, valueUpdate, pathUpdate),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr("ibm_cd_tekton_pipeline_trigger_property.cd_tekton_pipeline_trigger_property", "name", name),
-					resource.TestCheckResourceAttr("ibm_cd_tekton_pipeline_trigger_property.cd_tekton_pipeline_trigger_property", "type", typeVarUpdate),
+					resource.TestCheckResourceAttr("ibm_cd_tekton_pipeline_trigger_property.cd_tekton_pipeline_trigger_property", "type", typeVar),
 					resource.TestCheckResourceAttr("ibm_cd_tekton_pipeline_trigger_property.cd_tekton_pipeline_trigger_property", "value", valueUpdate),
 				),
 			},

--- a/website/docs/d/cd_tekton_pipeline.html.markdown
+++ b/website/docs/d/cd_tekton_pipeline.html.markdown
@@ -88,7 +88,7 @@ Nested scheme for **properties**:
 	  * Constraints: The maximum length is `253` characters. The minimum length is `1` character. The value must match regular expression `/^[-0-9a-zA-Z_.]{1,253}$/`.
 	* `path` - (String) A dot notation path for `integration` type properties only, that selects a value from the tool integration. If left blank the full tool integration data will be used.
 	  * Constraints: The maximum length is `4096` characters. The minimum length is `0` characters. The value must match regular expression `/^[-0-9a-zA-Z_.]*$/`.
-	* `type` - (String) Property type.
+	* `type` - (Forces new resource, String) Property type.
 	  * Constraints: Allowable values are: `secure`, `text`, `integration`, `single_select`, `appconfig`.
 	* `value` - (String) Property value. Any string value is valid.
 	  * Constraints: The maximum length is `4096` characters. The minimum length is `0` characters. The value must match regular expression `/^.*$/`.
@@ -140,7 +140,7 @@ Nested scheme for **triggers**:
 		  * Constraints: The maximum length is `253` characters. The minimum length is `1` character. The value must match regular expression `/^[-0-9a-zA-Z_.]{1,253}$/`.
 		* `path` - (String) A dot notation path for `integration` type properties only, that selects a value from the tool integration. If left blank the full tool integration data will be used.
 		  * Constraints: The maximum length is `4096` characters. The minimum length is `0` characters. The value must match regular expression `/^[-0-9a-zA-Z_.]*$/`.
-		* `type` - (String) Property type.
+		* `type` - (Forces new resource, String) Property type.
 		  * Constraints: Allowable values are: `secure`, `text`, `integration`, `single_select`, `appconfig`.
 		* `value` - (String) Property value. Any string value is valid.
 		  * Constraints: The maximum length is `4096` characters. The minimum length is `0` characters. The value must match regular expression `/^.*$/`.

--- a/website/docs/d/cd_tekton_pipeline_property.html.markdown
+++ b/website/docs/d/cd_tekton_pipeline_property.html.markdown
@@ -45,7 +45,7 @@ In addition to all argument references listed, you can access the following attr
 * `path` - (String) A dot notation path for `integration` type properties only, that selects a value from the tool integration. If left blank the full tool integration data will be used.
   * Constraints: The maximum length is `4096` characters. The minimum length is `0` characters. The value must match regular expression `/^[-0-9a-zA-Z_.]*$/`.
 
-* `type` - (String) Property type.
+* `type` - (Forces new resource, String) Property type.
   * Constraints: Allowable values are: `secure`, `text`, `integration`, `single_select`, `appconfig`.
 
 * `value` - (String) Property value. Any string value is valid.

--- a/website/docs/d/cd_tekton_pipeline_trigger.html.markdown
+++ b/website/docs/d/cd_tekton_pipeline_trigger.html.markdown
@@ -64,7 +64,7 @@ Nested scheme for **properties**:
 	  * Constraints: The maximum length is `253` characters. The minimum length is `1` character. The value must match regular expression `/^[-0-9a-zA-Z_.]{1,253}$/`.
 	* `path` - (String) A dot notation path for `integration` type properties only, that selects a value from the tool integration. If left blank the full tool integration data will be used.
 	  * Constraints: The maximum length is `4096` characters. The minimum length is `0` characters. The value must match regular expression `/^[-0-9a-zA-Z_.]*$/`.
-	* `type` - (String) Property type.
+	* `type` - (Forces new resource, String) Property type.
 	  * Constraints: Allowable values are: `secure`, `text`, `integration`, `single_select`, `appconfig`.
 	* `value` - (String) Property value. Any string value is valid.
 	  * Constraints: The maximum length is `4096` characters. The minimum length is `0` characters. The value must match regular expression `/^.*$/`.

--- a/website/docs/d/cd_tekton_pipeline_trigger_property.html.markdown
+++ b/website/docs/d/cd_tekton_pipeline_trigger_property.html.markdown
@@ -48,7 +48,7 @@ In addition to all argument references listed, you can access the following attr
 * `path` - (String) A dot notation path for `integration` type properties only, that selects a value from the tool integration. If left blank the full tool integration data will be used.
   * Constraints: The maximum length is `4096` characters. The minimum length is `0` characters. The value must match regular expression `/^[-0-9a-zA-Z_.]*$/`.
 
-* `type` - (String) Property type.
+* `type` - (Forces new resource, String) Property type.
   * Constraints: Allowable values are: `secure`, `text`, `integration`, `single_select`, `appconfig`.
 
 * `value` - (String) Property value. Any string value is valid.

--- a/website/docs/r/cd_tekton_pipeline.html.markdown
+++ b/website/docs/r/cd_tekton_pipeline.html.markdown
@@ -88,7 +88,7 @@ Nested scheme for **properties**:
 	  * Constraints: The maximum length is `253` characters. The minimum length is `1` character. The value must match regular expression `/^[-0-9a-zA-Z_.]{1,253}$/`.
 	* `path` - (String) A dot notation path for `integration` type properties only, that selects a value from the tool integration. If left blank the full tool integration data will be used.
 	  * Constraints: The maximum length is `4096` characters. The minimum length is `0` characters. The value must match regular expression `/^[-0-9a-zA-Z_.]*$/`.
-	* `type` - (String) Property type.
+	* `type` - (Forces new resource, String) Property type.
 	  * Constraints: Allowable values are: `secure`, `text`, `integration`, `single_select`, `appconfig`.
 	* `value` - (String) Property value. Any string value is valid.
 	  * Constraints: The maximum length is `4096` characters. The minimum length is `0` characters. The value must match regular expression `/^.*$/`.
@@ -135,7 +135,7 @@ Nested scheme for **triggers**:
 		  * Constraints: The maximum length is `253` characters. The minimum length is `1` character. The value must match regular expression `/^[-0-9a-zA-Z_.]{1,253}$/`.
 		* `path` - (String) A dot notation path for `integration` type properties only, that selects a value from the tool integration. If left blank the full tool integration data will be used.
 		  * Constraints: The maximum length is `4096` characters. The minimum length is `0` characters. The value must match regular expression `/^[-0-9a-zA-Z_.]*$/`.
-		* `type` - (String) Property type.
+		* `type` - (Forces new resource, String) Property type.
 		  * Constraints: Allowable values are: `secure`, `text`, `integration`, `single_select`, `appconfig`.
 		* `value` - (String) Property value. Any string value is valid.
 		  * Constraints: The maximum length is `4096` characters. The minimum length is `0` characters. The value must match regular expression `/^.*$/`.

--- a/website/docs/r/cd_tekton_pipeline_property.html.markdown
+++ b/website/docs/r/cd_tekton_pipeline_property.html.markdown
@@ -33,7 +33,7 @@ Review the argument reference that you can specify for your resource.
   * Constraints: The maximum length is `4096` characters. The minimum length is `0` characters. The value must match regular expression `/^[-0-9a-zA-Z_.]*$/`.
 * `pipeline_id` - (Required, Forces new resource, String) The Tekton pipeline ID.
   * Constraints: The maximum length is `36` characters. The minimum length is `36` characters. The value must match regular expression `/^[-0-9a-z]+$/`.
-* `type` - (Required, String) Property type.
+* `type` - (Required, Forces new resource, String) Property type.
   * Constraints: Allowable values are: `secure`, `text`, `integration`, `single_select`, `appconfig`.
 * `value` - (Optional, String) Property value. Any string value is valid.
   * Constraints: The maximum length is `4096` characters. The minimum length is `0` characters. The value must match regular expression `/^.*$/`.

--- a/website/docs/r/cd_tekton_pipeline_trigger.html.markdown
+++ b/website/docs/r/cd_tekton_pipeline_trigger.html.markdown
@@ -104,7 +104,7 @@ Nested scheme for **properties**:
 	  * Constraints: The maximum length is `253` characters. The minimum length is `1` character. The value must match regular expression `/^[-0-9a-zA-Z_.]{1,253}$/`.
 	* `path` - (String) A dot notation path for `integration` type properties only, that selects a value from the tool integration. If left blank the full tool integration data will be used.
 	  * Constraints: The maximum length is `4096` characters. The minimum length is `0` characters. The value must match regular expression `/^[-0-9a-zA-Z_.]*$/`.
-	* `type` - (String) Property type.
+	* `type` - (Forces new resource, String) Property type.
 	  * Constraints: Allowable values are: `secure`, `text`, `integration`, `single_select`, `appconfig`.
 	* `value` - (String) Property value. Any string value is valid.
 	  * Constraints: The maximum length is `4096` characters. The minimum length is `0` characters. The value must match regular expression `/^.*$/`.

--- a/website/docs/r/cd_tekton_pipeline_trigger_property.html.markdown
+++ b/website/docs/r/cd_tekton_pipeline_trigger_property.html.markdown
@@ -36,7 +36,7 @@ Review the argument reference that you can specify for your resource.
   * Constraints: The maximum length is `36` characters. The minimum length is `36` characters. The value must match regular expression `/^[-0-9a-z]+$/`.
 * `trigger_id` - (Required, Forces new resource, String) The trigger ID.
   * Constraints: The maximum length is `36` characters. The minimum length is `36` characters. The value must match regular expression `/^[-0-9a-z]+$/`.
-* `type` - (Required, String) Property type.
+* `type` - (Required, Forces new resource, String) Property type.
   * Constraints: Allowable values are: `secure`, `text`, `integration`, `single_select`, `appconfig`.
 * `value` - (Optional, String) Property value. Any string value is valid.
   * Constraints: The maximum length is `4096` characters. The minimum length is `0` characters. The value must match regular expression `/^.*$/`.


### PR DESCRIPTION
### Description
Add force new to `property` `type`field in Tekton 

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

### Output from acceptance testing:

```
$ make testacc TEST=./ibm/service/cdtektonpipeline TESTARGS='-run=TestAccIBMCdTekton*'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./ibm/service/cdtektonpipeline -v -run=TestAccIBMCdTekton* -timeout 700m
=== RUN   TestAccIBMCdTektonPipelineDefinitionDataSourceBasic
--- PASS: TestAccIBMCdTektonPipelineDefinitionDataSourceBasic (90.71s)
=== RUN   TestAccIBMCdTektonPipelinePropertyDataSourceBasic
--- PASS: TestAccIBMCdTektonPipelinePropertyDataSourceBasic (111.26s)
=== RUN   TestAccIBMCdTektonPipelinePropertyDataSourceAllArgs
--- PASS: TestAccIBMCdTektonPipelinePropertyDataSourceAllArgs (72.58s)
=== RUN   TestAccIBMCdTektonPipelineDataSourceBasic
--- PASS: TestAccIBMCdTektonPipelineDataSourceBasic (81.49s)
=== RUN   TestAccIBMCdTektonPipelineDataSourceAllArgs
--- PASS: TestAccIBMCdTektonPipelineDataSourceAllArgs (69.92s)
=== RUN   TestAccIBMCdTektonPipelineTriggerPropertyDataSourceBasic
--- PASS: TestAccIBMCdTektonPipelineTriggerPropertyDataSourceBasic (93.74s)
=== RUN   TestAccIBMCdTektonPipelineTriggerPropertyDataSourceAllArgs
--- PASS: TestAccIBMCdTektonPipelineTriggerPropertyDataSourceAllArgs (105.34s)
=== RUN   TestAccIBMCdTektonPipelineTriggerDataSourceBasic
--- PASS: TestAccIBMCdTektonPipelineTriggerDataSourceBasic (72.15s)
=== RUN   TestAccIBMCdTektonPipelineTriggerDataSourceAllArgs
--- PASS: TestAccIBMCdTektonPipelineTriggerDataSourceAllArgs (88.33s)
=== RUN   TestAccIBMCdTektonPipelineDefinitionBasic
--- PASS: TestAccIBMCdTektonPipelineDefinitionBasic (98.59s)
=== RUN   TestAccIBMCdTektonPipelinePropertyBasic
--- PASS: TestAccIBMCdTektonPipelinePropertyBasic (160.59s)
=== RUN   TestAccIBMCdTektonPipelinePropertyAllArgs
--- PASS: TestAccIBMCdTektonPipelinePropertyAllArgs (137.65s)
=== RUN   TestAccIBMCdTektonPipelineBasic
--- PASS: TestAccIBMCdTektonPipelineBasic (65.97s)
=== RUN   TestAccIBMCdTektonPipelineAllArgs
--- PASS: TestAccIBMCdTektonPipelineAllArgs (198.78s)
=== RUN   TestAccIBMCdTektonPipelineTriggerPropertyBasic
--- PASS: TestAccIBMCdTektonPipelineTriggerPropertyBasic (126.62s)
=== RUN   TestAccIBMCdTektonPipelineTriggerPropertyAllArgs
--- PASS: TestAccIBMCdTektonPipelineTriggerPropertyAllArgs (148.01s)
=== RUN   TestAccIBMCdTektonPipelineTriggerBasic
--- PASS: TestAccIBMCdTektonPipelineTriggerBasic (170.98s)
=== RUN   TestAccIBMCdTektonPipelineTriggerAllArgs
--- PASS: TestAccIBMCdTektonPipelineTriggerAllArgs (145.61s)
PASS
ok      github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/cdtektonpipeline        2039.418s
```
