### PR TITLE
feat(Cloud Databases): Deprecate auto_scaling cpu attribute

### DIFF
--- a/ibm/service/database/data_source_ibm_database.go
+++ b/ibm/service/database/data_source_ibm_database.go
@@ -538,6 +538,7 @@ func DataSourceIBMDatabaseInstance() *schema.Resource {
 							Type:        schema.TypeList,
 							Description: "CPU Auto Scaling",
 							Computed:    true,
+							Deprecated:  "This field is deprecated, auto scaling cpu is unsupported by IBM Cloud Databases",
 							Elem: &schema.Resource{
 								Schema: map[string]*schema.Schema{
 									"rate_increase_percent": {

--- a/ibm/service/database/resource_ibm_database.go
+++ b/ibm/service/database/resource_ibm_database.go
@@ -823,6 +823,7 @@ func ResourceIBMDatabaseInstance() *schema.Resource {
 						"cpu": {
 							Type:        schema.TypeList,
 							Description: "CPU Auto Scaling",
+							Deprecated:  "This field is deprecated, auto scaling cpu is unsupported by IBM Cloud Databases",
 							Optional:    true,
 							Computed:    true,
 							MaxItems:    1,

--- a/website/docs/d/database.html.markdown
+++ b/website/docs/d/database.html.markdown
@@ -54,14 +54,6 @@ In addition to all argument references list, you can access the following attrib
 - `auto_scaling` (List)Configure rules to allow your database to automatically increase its resources. Single block of autoscaling is allowed at once.
 
   Nested scheme for `auto_scaling`:
-  - `cpu` (List)Autoscaling CPU.
-  
-     Nested scheme for `cpu`:
-     - `rate_increase_percent`- (Integer) Auto scaling rate in increase percent.
-     - `rate_limit_count_per_member`- (Integer) Auto scaling rate limit in count per number.
-     - `rate_period_seconds`- (Integer) Auto scaling rate in period seconds.
-     - `rate_units` - (String) Auto scaling rate in units.
-  
   - `disk` (List) Disk auto scaling.
   
     Nested scheme for `disk`:

--- a/website/docs/r/database.html.markdown
+++ b/website/docs/r/database.html.markdown
@@ -189,12 +189,6 @@ resource "ibm_database" "autoscale" {
     location                     = "us-south"
     service_endpoints            = "private"
     auto_scaling {
-        cpu {
-            rate_increase_percent       = 20
-            rate_limit_count_per_member = 20
-            rate_period_seconds         = 900
-            rate_units                  = "count"
-        }
         disk {
             capacity_enabled             = true
             free_space_less_than_percent = 15
@@ -606,19 +600,13 @@ Review the argument reference that you can specify for your resource.
 - `auto_scaling` (List , Optional) Configure rules to allow your database to automatically increase its resources. Single block of autoscaling is allowed at once.
 
    - Nested scheme for `auto_scaling`:
-     - `cpu` (List , Optional) Single block of CPU is allowed at once by CPU autoscaling.
-       - Nested scheme for `cpu`:
-         - `rate_increase_percent` - (Optional, Integer) Auto scaling rate in increase percent.
-         - `rate_limit_count_per_member` - (Optional, Integer) Auto scaling rate limit in count per number.
-         - `rate_period_seconds` - (Optional, Integer) Period seconds of the auto scaling rate.
-         - `rate_units` - (Optional, String) Auto scaling rate in units.
-
      - `disk` (List , Optional) Single block of disk is allowed at once in disk auto scaling.
         - Nested scheme for `disk`:
           - `capacity_enabled` - (Optional, Bool) Auto scaling scalar enables or disables the scalar capacity.
           - `free_space_less_than_percent` - (Optional, Integer) Auto scaling scalar capacity free space less than percent.
           - `io_above_percent` - (Optional, Integer) Auto scaling scalar I/O utilization above percent.
           - `io_enabled` - (Optional, Bool) Auto scaling scalar I/O utilization enabled.`
+          - `io_over_period` - (Optional, String) Auto scaling scalar I/O utilization over period.
           - `rate_increase_percent` - (Optional, Integer) Auto scaling rate increase percent.
           - `rate_limit_mb_per_member` - (Optional, Integer) Auto scaling rate limit in megabytes per member.
           - `rate_period_seconds` - (Optional, Integer) Auto scaling rate period in seconds.


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/IBM-Cloud/terraform-provider-ibm/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates to: https://github.com/IBM-Cloud/terraform-provider-ibm/issues/4339

Deprecates `auto_scaling` `cpu`  from the `ibm_database` resource and data source, as this is not supported by Cloud Databases. This attribute will be removed in the future.

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccIBMDatabaseInstance_Redis_Basic'
...
--- PASS: TestAccIBMDatabaseInstance_Redis_Basic (741.61s)
```
