### PR TITLE
Adding changes for replacement of key_protect parameter and adding the fix for 3394

### DIFF
--- a/examples/ibm-cos-bucket/main.tf
+++ b/examples/ibm-cos-bucket/main.tf
@@ -304,7 +304,7 @@ resource "ibm_cos_bucket" "hpcs-enabled" {
   resource_instance_id = ibm_resource_instance.cos_instance.id
   region_location       = var.regional_loc
   storage_class         = var.standard_storage_class
-  key_protect          = ibm_kms_key.key.id
+  kms_key_crn          = ibm_kms_key.key.id
 }
 
 //HPCS - UKO plan
@@ -314,7 +314,7 @@ resource "ibm_cos_bucket" "hpcs-uko-enabled" {
   resource_instance_id = ibm_resource_instance.cos_instance.id
   region_location       = var.regional_loc
   storage_class         = var.standard_storage_class
-  key_protect           = var.hpcs_uko_rootkeycrn
+  kms_key_crn           = var.hpcs_uko_rootkeycrn
 }
 resource "ibm_cos_bucket_object" "plaintext" {
   bucket_crn      = ibm_cos_bucket.cos_bucket.crn

--- a/examples/ibm-key-protect/README.md
+++ b/examples/ibm-key-protect/README.md
@@ -4,6 +4,9 @@ This example shows how to Create a Key protect instance, generate a key and inte
 
 This sample configuration will create the key protect instance, cos-bucket instance, root key, and integrate the key with a cos bucket after creating the bucket.
 
+  **Note:**
+  
+ `key_protect` attribute to associate a kms_key with a COS bucket has been renamed as `kms_key_crn` , hence it is recommended to all the new users to use `kms_key_crn`.Although the support for older attribute name `key_protect` will be continued for existing custom
 
 To run, configure your IBM Cloud provider
 
@@ -63,7 +66,7 @@ resource "ibm_cos_bucket" "flex-us-south" {
   resource_instance_id = ibm_resource_instance.cos_instance.id
   region_location      = var.location
   storage_class        = "flex"
-  key_protect          = ibm_kp_key.test.id
+  kms_key_crn          = ibm_kp_key.test.id
 }
 
 ```
@@ -81,7 +84,7 @@ resource "ibm_cos_bucket" "flex-us-south" {
   resource_instance_id = var.cosinstance
   region_location      = var.location
   storage_class        = "flex"
-  key_protect          = data.ibm_kp_key.test.keys.0.crn
+  kms_key_crn         = data.ibm_kp_key.test.keys.0.crn
 }
 
 ```

--- a/examples/ibm-key-protect/main.tf
+++ b/examples/ibm-key-protect/main.tf
@@ -32,5 +32,5 @@ resource "ibm_cos_bucket" "flex-us-south" {
   resource_instance_id = ibm_resource_instance.cos_instance.id
   region_location      = "us-south"
   storage_class        = "flex"
-  key_protect          = ibm_kp_key.test.id
+  kms_key_crn          = ibm_kp_key.test.id
 }

--- a/examples/ibm-kms/README.md
+++ b/examples/ibm-kms/README.md
@@ -4,6 +4,9 @@ This example shows how to Create a Key protect instance, generate a key and inte
 
 This sample configuration will create the key protect instance, cos-bucket instance, root key, and integrate the key with a cos bucket after creating the bucket.
 
+  **Note:**
+  
+ `key_protect` attribute to associate a kms_key with a COS bucket has been renamed as `kms_key_crn` , hence it is recommended to all the new users to use `kms_key_crn`.Although the support for older attribute name `key_protect` will be continued for existing custom
 
 To run, configure your IBM Cloud provider
 
@@ -62,7 +65,7 @@ resource "ibm_cos_bucket" "flex-us-south" {
   resource_instance_id = ibm_resource_instance.cos_instance.id
   region_location      = var.location
   storage_class        = "flex"
-  key_protect          = ibm_kms_key.test.id
+  kms_key_crn          = ibm_kms_key.test.id
 }
 
 ```
@@ -80,11 +83,10 @@ resource "ibm_cos_bucket" "flex-us-south" {
   resource_instance_id = var.cosinstance
   region_location      = var.location
   storage_class        = "flex"
-  key_protect          = data.ibm_kms_keys.test.keys.0.crn
+  kms_key_crn         = data.ibm_kms_keys.test.keys.0.crn
 }
 
 ```
-
 ## Assumptions
 
 1. It's assumed that user has valid authorizations set for integrating kms keys with other services. This can be done using `ibm_iam_authorization_policy` resource

--- a/examples/ibm-kms/main.tf
+++ b/examples/ibm-kms/main.tf
@@ -34,5 +34,5 @@ resource "ibm_cos_bucket" "flex-us-south" {
   resource_instance_id = ibm_resource_instance.cos_instance.id
   region_location      = "us-south"
   storage_class        = "flex"
-  key_protect          = ibm_kms_key.test.id
+  kms_key_crn          = ibm_kms_key.test.id
 }

--- a/ibm/service/cos/data_source_ibm_cos_bucket.go
+++ b/ibm/service/cos/data_source_ibm_cos_bucket.go
@@ -572,9 +572,6 @@ func dataSourceIBMCosBucketRead(d *schema.ResourceData, meta interface{}) error 
 		} else {
 			d.Set("kms_key_crn", head.IBMSSEKPCrkId)
 		}
-	} else {
-		d.Set("kms_key_crn", "")
-		d.Set("key_protect", "")
 	}
 
 	bucketCRN := fmt.Sprintf("%s:%s:%s", strings.Replace(serviceID, "::", "", -1), "bucket", bucketName)

--- a/ibm/service/cos/resource_ibm_cos_bucket.go
+++ b/ibm/service/cos/resource_ibm_cos_bucket.go
@@ -1175,9 +1175,6 @@ func resourceIBMCOSBucketRead(d *schema.ResourceData, meta interface{}) error {
 		} else {
 			d.Set("kms_key_crn", head.IBMSSEKPCrkId)
 		}
-	} else {
-		d.Set("kms_key_crn", "")
-		d.Set("key_protect", "")
 	}
 
 	if bucketPtr != nil {

--- a/ibm/service/cos/resource_ibm_cos_bucket_test.go
+++ b/ibm/service/cos/resource_ibm_cos_bucket_test.go
@@ -1255,6 +1255,113 @@ func TestAccIBMCOSHPCS(t *testing.T) {
 	})
 }
 
+//new hpcs
+func TestAccIBMCOSKPKmsParamValid(t *testing.T) {
+
+	instanceName := fmt.Sprintf("kms_%d", acctest.RandIntRange(10, 100))
+	serviceName := fmt.Sprintf("terraform_%d", acctest.RandIntRange(10, 100))
+	bucketName := fmt.Sprintf("terraform%d", acctest.RandIntRange(10, 100))
+	keyName := fmt.Sprintf("key_%d", acctest.RandIntRange(10, 100))
+	bucketRegion := "us"
+	bucketClass := "standard"
+	bucketRegionType := "cross_region_location"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { acc.TestAccPreCheck(t) },
+		Providers: acc.TestAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckIBMKeyProtectRootkeyWithCOSBucketKmsParam(instanceName, keyName, serviceName, bucketName, bucketRegion, bucketClass),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckIBMCosBucketExists("ibm_resource_instance.instance", "ibm_cos_bucket.bucket", bucketRegionType, bucketRegion, bucketName),
+					resource.TestCheckResourceAttr("ibm_cos_bucket.bucket", "bucket_name", bucketName),
+				),
+			},
+		},
+	})
+}
+func TestAccIBMCOSKPKmsParamWithInvalidCRN(t *testing.T) {
+
+	instanceName := fmt.Sprintf("kms_%d", acctest.RandIntRange(10, 100))
+	serviceName := fmt.Sprintf("terraform_%d", acctest.RandIntRange(10, 100))
+	bucketName := fmt.Sprintf("terraform%d", acctest.RandIntRange(10, 100))
+	keyName := fmt.Sprintf("key_%d", acctest.RandIntRange(10, 100))
+	bucketRegion := "us"
+	bucketClass := "standard"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { acc.TestAccPreCheck(t) },
+		Providers: acc.TestAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccCheckIBMKeyProtectRootkeyWithCOSBucketKmsParamWithInvalidCRN(instanceName, keyName, serviceName, bucketName, bucketRegion, bucketClass),
+				ExpectError: regexp.MustCompile("InvalidArgument: Invalid ibm-sse-kp-customer-root-key-crn: received only 7 of required 10 segments"),
+			},
+		},
+	})
+}
+
+func TestAccIBMCOSHPCSKmsParam(t *testing.T) {
+	serviceName := fmt.Sprintf("terraform_%d", acctest.RandIntRange(10, 100))
+	bucketName := fmt.Sprintf("terraform%d", acctest.RandIntRange(10, 100))
+	keyName := fmt.Sprintf("key_%d", acctest.RandIntRange(10, 100))
+	bucketRegion := "us-south"
+	bucketClass := "standard"
+	bucketRegionType := "cross_region_location"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { acc.TestAccPreCheck(t) },
+		Providers: acc.TestAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckIBMHPCSRootkeyWithCOSBucketKmsParam(keyName, serviceName, bucketName, bucketRegion, bucketClass),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckIBMCosBucketExists("ibm_resource_instance.instance", "ibm_cos_bucket.bucket", bucketRegionType, bucketRegion, bucketName),
+					resource.TestCheckResourceAttr("ibm_cos_bucket.bucket", "bucket_name", bucketName),
+					resource.TestCheckResourceAttr("ibm_cos_bucket.bucket", "kms_key_crn", acc.HpcsRootKeyCrn),
+				),
+			},
+		},
+	})
+}
+
+func TestAccIBMCOSHPCSKmsParamWithInvalidCRN(t *testing.T) {
+	serviceName := fmt.Sprintf("terraform_%d", acctest.RandIntRange(10, 100))
+	bucketName := fmt.Sprintf("terraform%d", acctest.RandIntRange(10, 100))
+	keyName := fmt.Sprintf("key_%d", acctest.RandIntRange(10, 100))
+	bucketRegion := "us-south"
+	bucketClass := "standard"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { acc.TestAccPreCheck(t) },
+		Providers: acc.TestAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccCheckIBMHPCSRootkeyWithCOSBucketKmsParamWithInvalidCRN(keyName, serviceName, bucketName, bucketRegion, bucketClass),
+				ExpectError: regexp.MustCompile("InvalidArgument: Invalid ibm-sse-kp-customer-root-key-crn: received only 7 of required 10 segments"),
+			},
+		},
+	})
+}
+
+func TestAccIBMCOSKMSBothParamProvided(t *testing.T) {
+	serviceName := fmt.Sprintf("terraform_%d", acctest.RandIntRange(10, 100))
+	bucketName := fmt.Sprintf("terraform%d", acctest.RandIntRange(10, 100))
+	keyName := fmt.Sprintf("key_%d", acctest.RandIntRange(10, 100))
+	bucketRegion := "us-south"
+	bucketClass := "standard"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { acc.TestAccPreCheck(t) },
+		Providers: acc.TestAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccCheckIBMHPCSRootkeyWithCOSBucketKMSBothParamProvided(keyName, serviceName, bucketName, bucketRegion, bucketClass),
+				ExpectError: regexp.MustCompile("Error: Conflicting configuration arguments"),
+			},
+		},
+	})
+}
 func testAccCheckIBMCosBucket_basic(serviceName string, bucketName string, regiontype string, region string, storageClass string) string {
 
 	return fmt.Sprintf(`
@@ -2478,6 +2585,130 @@ func testAccCheckIBMHPCSRootkeyWithCOSBucket(KeyName, serviceName, bucketName, b
 		key_protect			= "%s"
 	}
 `, serviceName, bucketName, bucketRegion, bucketClass, acc.HpcsRootKeyCrn)
+}
+func testAccCheckIBMKeyProtectRootkeyWithCOSBucketKmsParam(instanceName, KeyName, serviceName, bucketName, bucketRegion, bucketClass string) string {
+	return fmt.Sprintf(`
+	data "ibm_resource_group" "group" {
+		is_default=true
+	}
+	resource "ibm_resource_instance" "kms_instance1" {
+		name              = "%s"
+		service           = "kms"
+		plan              = "tiered-pricing"
+		location          = "us-south"
+	  }
+
+	  resource "ibm_kms_key" "test" {
+		instance_id = "${ibm_resource_instance.kms_instance1.guid}"
+		key_name = "%s"
+		standard_key =  false
+		force_delete = true
+	}
+
+	resource "ibm_resource_instance" "instance" {
+		name     = "%s"
+		service  = "cloud-object-storage"
+		plan     = "standard"
+		location = "global"
+	}
+
+	resource "ibm_cos_bucket" "bucket" {
+		bucket_name          = "%s"
+		resource_instance_id = ibm_resource_instance.instance.id
+		cross_region_location = "%s"
+		storage_class        = "%s"
+		kms_key_crn          = ibm_kms_key.test.id
+	}
+`, instanceName, KeyName, serviceName, bucketName, bucketRegion, bucketClass)
+}
+func testAccCheckIBMKeyProtectRootkeyWithCOSBucketKmsParamWithInvalidCRN(instanceName, KeyName, serviceName, bucketName, bucketRegion, bucketClass string) string {
+	return fmt.Sprintf(`
+	data "ibm_resource_group" "group" {
+		is_default=true
+	}
+	
+	resource "ibm_resource_instance" "instance" {
+		name     = "%s"
+		service  = "cloud-object-storage"
+		plan     = "standard"
+		location = "global"
+	}
+
+	resource "ibm_cos_bucket" "bucket" {
+		bucket_name          = "%s"
+		resource_instance_id = ibm_resource_instance.instance.id
+		cross_region_location = "%s"
+		storage_class        = "%s"
+		kms_key_crn          = "crn:v1:staging:public:kms:us-south:invalid"
+	}
+`, instanceName, bucketName, bucketRegion, bucketClass)
+}
+
+func testAccCheckIBMHPCSRootkeyWithCOSBucketKmsParam(KeyName, serviceName, bucketName, bucketRegion, bucketClass string) string {
+	return fmt.Sprintf(`
+	data "ibm_resource_group" "group" {
+		is_default=true
+	}
+	resource "ibm_resource_instance" "instance" {
+		name     = "%s"
+		service  = "cloud-object-storage"
+		plan     = "standard"
+		location = "global"
+	}
+
+	resource "ibm_cos_bucket" "bucket" {
+		bucket_name          = "%s"
+		resource_instance_id = ibm_resource_instance.instance.id
+		region_location 	= "%s"
+		storage_class       = "%s"
+		kms_key_crn			= "%s"
+	}
+`, serviceName, bucketName, bucketRegion, bucketClass, acc.HpcsRootKeyCrn)
+}
+
+func testAccCheckIBMHPCSRootkeyWithCOSBucketKMSBothParamProvided(KeyName, serviceName, bucketName, bucketRegion, bucketClass string) string {
+	return fmt.Sprintf(`
+	data "ibm_resource_group" "group" {
+		is_default=true
+	}
+	resource "ibm_resource_instance" "instance" {
+		name     = "%s"
+		service  = "cloud-object-storage"
+		plan     = "standard"
+		location = "global"
+	}
+
+	resource "ibm_cos_bucket" "bucket" {
+		bucket_name          = "%s"
+		resource_instance_id = ibm_resource_instance.instance.id
+		region_location 	= "%s"
+		storage_class       = "%s"
+		kms_key_crn			= "%s"
+		key_protect 		= "%s"
+	}
+`, serviceName, bucketName, bucketRegion, bucketClass, acc.HpcsRootKeyCrn, acc.HpcsRootKeyCrn)
+}
+
+func testAccCheckIBMHPCSRootkeyWithCOSBucketKmsParamWithInvalidCRN(KeyName, serviceName, bucketName, bucketRegion, bucketClass string) string {
+	return fmt.Sprintf(`
+	data "ibm_resource_group" "group" {
+		is_default=true
+	}
+	resource "ibm_resource_instance" "instance" {
+		name     = "%s"
+		service  = "cloud-object-storage"
+		plan     = "standard"
+		location = "global"
+	}
+
+	resource "ibm_cos_bucket" "bucket" {
+		bucket_name          = "%s"
+		resource_instance_id = ibm_resource_instance.instance.id
+		region_location 	= "%s"
+		storage_class       = "%s"
+		kms_key_crn			= "crn:v1:staging:public:hs-crypto:us-south:invalid"
+	}
+`, serviceName, bucketName, bucketRegion, bucketClass)
 }
 
 func TestSingleSiteLocationRegex(t *testing.T) {

--- a/ibm/service/kms/resource_ibm_kms_key_test.go
+++ b/ibm/service/kms/resource_ibm_kms_key_test.go
@@ -214,7 +214,7 @@ func testAccCheckIBMKmsResourceRootkeyWithCOSConfig(instanceName, resource, KeyN
 		resource_instance_id = ibm_resource_instance.cos_instance.id
 		region_location      = "us-south"
 		storage_class        = "smart"
-		key_protect          = ibm_kms_key.test.id
+		kms_key_crn          = ibm_kms_key.test.id
 	}
 `, instanceName, resource, KeyName, cosInstanceName, bucketName)
 }

--- a/website/docs/d/cos_bucket.html.markdown
+++ b/website/docs/d/cos_bucket.html.markdown
@@ -95,7 +95,7 @@ resource "ibm_cos_bucket" "smart-us-south" {
   resource_instance_id = "cos-instance-id"
   region_location      = "us-south"
   storage_class        = "smart"
-  key_protect          = data.ibm_kms_key.test.key.0.crn
+  kms_key_crn          = data.ibm_kms_key.test.key.0.crn
 }
 
 ```
@@ -168,7 +168,11 @@ In addition to all argument reference list, you can access the following attribu
   - `rule_id` - (String)  Unique identifier for the rule. Expire rules allow you to set a specific time frame after which objects are deleted.
 - `hard_quota` - (String) Maximum bytes for the bucket.
 - `id` - (String) The ID of the bucket.
-- `key_protect` - (String) The CRN of the IBM Key Protect instance where a root key is already provisioned. 
+- `kms_key_crn` - (String) The CRN of the IBM Key Protect instance where a root key is already provisioned. 
+  **Note:**
+
+ `key_protect` attribute has been renamed as `kms_key_crn` , hence it is recommended to all the new users to use `kms_key_crn`.Although the support for older attribute name `key_protect` will be continued for existing customers.
+
 - `metrics_monitoring`- (List) Nested block with the following structure.
    
   Nested scheme for `metrics_monitoring`:

--- a/website/docs/d/kms_key.html.markdown
+++ b/website/docs/d/kms_key.html.markdown
@@ -32,7 +32,7 @@ resource "ibm_cos_bucket" "smart-us-south" {
   resource_instance_id = "cos-instance-id"
   region_location      = "us-south"
   storage_class        = "smart"
-  key_protect          = data.ibm_kms_key.test.key.0.crn
+  kms_key_crn          = data.ibm_kms_key.test.key.0.crn
 }
 ```
 
@@ -40,6 +40,8 @@ resource "ibm_cos_bucket" "smart-us-south" {
 
 1) Data of the key can be retrieved either using a key name or an alias name (if created for the key or keys) .
 2) limit is an optional parameter used with the keyname, which iterates and fetches the key till the limit given. When the limit is not passed then the first 2000 keys are fetched according to SDK default behaviour. 
+3) `key_protect` attribute has been renamed as `kms_key_crn` , hence it is recommended to all the new users to use `kms_key_crn`.Although the support for older attribute name `key_protect` will be continued for existing customers.
+
 
 ## Argument reference
 Review the argument references that you can specify for your data source.  

--- a/website/docs/d/kms_keys.html.markdown
+++ b/website/docs/d/kms_keys.html.markdown
@@ -22,9 +22,14 @@ resource "ibm_cos_bucket" "smart-us-south" {
   resource_instance_id = "cos-instance-id"
   region_location      = "us-south"
   storage_class        = "smart"
-  key_protect          = data.ibm_kms_keys.test.keys.0.crn
+  kms_key_crn          = data.ibm_kms_keys.test.keys.0.crn
 }
 ```
+
+  **Note:**
+
+ `key_protect` attribute has been renamed as `kms_key_crn` , hence it is recommended to all the new users to use `kms_key_crn`.Although the support for older attribute name `key_protect` will be continued for existing customers.
+
 
 ## Argument reference
 Review the argument references that you can specify for your resource.

--- a/website/docs/d/kp_key.html.markdown
+++ b/website/docs/d/kp_key.html.markdown
@@ -22,9 +22,15 @@ resource "ibm_cos_bucket" "smart-us-south" {
   resource_instance_id = "cos-instance-id"
   region_location      = "us-south"
   storage_class        = "smart"
-  key_protect          = data.ibm_kp_key.test.keys.0.crn
+  kms_key_crn          = data.ibm_kp_key.test.keys.0.crn
 }
 ```
+
+  **Note:**
+
+ `key_protect` attribute has been renamed as `kms_key_crn` , hence it is recommended to all the new users to use `kms_key_crn`.Although the support for older attribute name `key_protect` will be continued for existing customers.
+
+
 
 ## Argument reference
 Review the argument references that you can specify for your data source. 

--- a/website/docs/r/cos_bucket.html.markdown
+++ b/website/docs/r/cos_bucket.html.markdown
@@ -294,6 +294,11 @@ resource "ibm_cos_bucket" "cos_bucket" {
 
 Create or delete an COS bucket with a key protect root key.For more details about key protect see https://cloud.ibm.com/docs/key-protect?topic=key-protect-about  .We  need to create and manage root key using  **ibm_kms_key** resource. We are using existing cos instance to create bucket , so no need to create any cos instance via a terraform. https://registry.terraform.io/providers/IBM-Cloud/ibm/latest/docs/resources/kms_key
 
+  **Note:**
+
+ `key_protect` attribute has been renamed as `kms_key_crn` , hence it is recommended to all the new users to use `kms_key_crn`.Although the support for older attribute name `key_protect` will be continued for existing customers.
+
+
 ## Example usage
 
 ```terraform
@@ -320,7 +325,7 @@ resource "ibm_cos_bucket" "smart-us-south" {
   resource_instance_id = ibm_resource_instance.cos_instance.id
   region_location      = "us-south"
   storage_class        = "smart"
-  key_protect          = ibm_kms_key.test.id
+  kms_key_crn         = ibm_kms_key.test.id
 }
 ```
 
@@ -328,6 +333,10 @@ resource "ibm_cos_bucket" "smart-us-south" {
 # HPCS enabled COS bucket
 
 Create or delete a COS bucket with a Hyper Protect Crypto Services (HPCS) root key.For more details about HPCS see https://cloud.ibm.com/docs/hs-crypto?topic=hs-crypto-get-started .To enable HPCS on a COS bucket, an HPCS instance is required and needs to be initialized by loading the master key to create and manage HPCS keys. For more information on initializing the HPCS instance, see https://cloud.ibm.com/docs/hs-crypto?topic=hs-crypto-initialize-hsm-recovery-crypto-unit. To create an HPCS instance using terraform, see https://registry.terraform.io/providers/IBM-Cloud/ibm/latest/docs/resources/hpcs.
+
+  **Note:**
+
+`key_protect` attribute has been renamed as `kms_key_crn` , hence it is recommended to all the new users to use `kms_key_crn`.Although the support for older attribute name `key_protect` will be continued for existing customers.
 
 
 ## Example usage
@@ -369,7 +378,7 @@ resource "ibm_cos_bucket" "smart-us-south" {
   resource_instance_id = ibm_resource_instance.cos_instance.id
   region_location      = "us-south"
   storage_class        = "smart"
-  key_protect          = ibm_kms_key.key.id
+  kms_key_crn          = ibm_kms_key.key.id
 }
 
 ```
@@ -479,7 +488,11 @@ Review the argument references that you can specify for your resource.
 
     **Note:** `force_delete` will timeout on buckets with a large amount of objects. 24 hours before you delete the bucket you can set an expire rule to remove all the files over a day old.
 - `hard_quota` - (Optional, Integer) Sets a maximum amount of storage (in bytes) available for a bucket. For more information, check the [cloud documention](https://cloud.ibm.com/docs/cloud-object-storage?topic=cloud-object-storage-quota).
-- `key_protect` - (Optional, String) The CRN of the IBM Key Protect root key that you want to use to encrypt data that is sent and stored in IBM Cloud Object Storage. Before you can enable IBM Key Protect encryption, you must provision an instance of IBM Key Protect and authorize the service to access IBM Cloud Object Storage. For more information, see [Server-Side Encryption with IBM Key Protect or Hyper Protect Crypto Services (SSE-KP)](https://cloud.ibm.com/docs/cloud-object-storage?topic=cloud-object-storage-encryption).
+- `kms_key_crn` - (Optional, String) The CRN of the IBM Key Protect root key that you want to use to encrypt data that is sent and stored in IBM Cloud Object Storage. Before you can enable IBM Key Protect encryption, you must provision an instance of IBM Key Protect and authorize the service to access IBM Cloud Object Storage. For more information, see [Server-Side Encryption with IBM Key Protect or Hyper Protect Crypto Services (SSE-KP)](https://cloud.ibm.com/docs/cloud-object-storage?topic=cloud-object-storage-encryption).
+    **Note:**
+
+ `key_protect` attribute has been renamed as `kms_key_crn` , hence it is recommended to all the new users to use `kms_key_crn`.Although the support for older attribute name `key_protect` will be continued for existing customers.
+
 - `metrics_monitoring`- (Object) to enable metrics tracking with IBM Cloud Monitoring - Optional- Set up your IBM Cloud Monitoring service instance to receive metrics for your IBM Cloud Object Storage bucket.
 
   Nested scheme for `metrics_monitoring`:
@@ -541,7 +554,10 @@ In addition to all argument reference list, you can access the following attribu
 - `crn` - (String) The CRN of the bucket.
 - `cross_region_location` - (String) The location if you created a cross-regional bucket.
 - `id` - (String) The ID of the bucket. 
-- `key_protect` - (String) The CRN of the IBM Key Protect instance that you use to encrypt your data in IBM Cloud Object Storage.
+- `kms_key_crn` - (String) The CRN of the IBM Key Protect instance that you use to encrypt your data in IBM Cloud Object Storage.
+    **Note:**
+
+ `key_protect` attribute has been renamed as `kms_key_crn` , hence it is recommended to all the new users to use `kms_key_crn`.Although the support for older attribute name `key_protect` will be continued for existing customers.
 - `region_location` - (String) The location if you created a regional bucket.
 - `resource_instance_id` - (String) The ID of IBM Cloud Object Storage instance. 
 - `single_site_location` - (String) The location if you created a single site bucket.

--- a/website/docs/r/kms_key.html.markdown
+++ b/website/docs/r/kms_key.html.markdown
@@ -37,9 +37,13 @@ resource "ibm_cos_bucket" "smart-us-south" {
   resource_instance_id = "cos-instance-id"
   region_location      = "us-south"
   storage_class        = "smart"
-  key_protect          = ibm_kms_key.test.id
+  kms_key_crn          = ibm_kms_key.test.id
 }
 ```
+  **Note:**
+  
+ `key_protect` attribute to associate a kms_key with a COS bucket has been renamed as `kms_key_crn` , hence it is recommended to all the new users to use `kms_key_crn`.Although the support for older attribute name `key_protect` will be continued for existing customers.
+
 
 ## Example usage to provision HPCS service and key management
 

--- a/website/docs/r/kms_key_alias.html.markdown
+++ b/website/docs/r/kms_key_alias.html.markdown
@@ -41,13 +41,17 @@ resource "ibm_cos_bucket" "smart-us-south" {
   resource_instance_id = "cos-instance-id"
   region_location      = "us-south"
   storage_class        = "smart"
-  key_protect          = ibm_kms_key.test.id
+  kms_key_crn          = ibm_kms_key.test.id
 }
 ```
 
 **Note**
 
 An alias that identifies a key. Each alias is unique only within the given instance and is not reserved across the Key Protect service. Each key can have up to five aliases. There is a limit of 1000 aliases per instance. Alias must be alphanumeric and cannot contain spaces or special characters other than '-' or '_'.
+
+  **Note:**
+
+ `key_protect` attribute to associate a kms_key with a COS bucket has been renamed as `kms_key_crn` , hence it is recommended to all the new users to use `kms_key_crn`.Although the support for older attribute name `key_protect` will be continued for existing customers.
 
 ## Argument reference
 Review the argument references that you can specify for your resource.

--- a/website/docs/r/kms_key_with_policy_overrides.html.markdown
+++ b/website/docs/r/kms_key_with_policy_overrides.html.markdown
@@ -40,9 +40,12 @@ resource "ibm_cos_bucket" "smart-us-south" {
   resource_instance_id = "cos-instance-id"
   region_location      = "us-south"
   storage_class        = "smart"
-  key_protect          = ibm_kms_key_with_policy_overrides.test.id
+  kms_key_crn          = ibm_kms_key_with_policy_overrides.test.id
 }
 ```
+  **Note:**
+  
+ `key_protect` attribute to associate a kms_key with a COS bucket has been renamed as `kms_key_crn` , hence it is recommended to all the new users to use `kms_key_crn`.Although the support for older attribute name `key_protect` will be continued for existing customers.
 
 ## Example usage to provision HPCS service and KMS key with policy details
 

--- a/website/docs/r/kp_key.html.markdown
+++ b/website/docs/r/kp_key.html.markdown
@@ -35,9 +35,15 @@ resource "ibm_cos_bucket" "smart-us-south" {
   resource_instance_id = "cos-instance-id"
   region_location      = "us-south"
   storage_class        = "smart"
-  key_protect          = ibm_kp_key.test.id
+  kms_key_crn          = ibm_kp_key.test.id
 }
 ```
+
+  **Note:**
+  
+ `key_protect` attribute to associate a kms_key with a COS bucket has been renamed as `kms_key_crn` , hence it is recommended to all the new users to use `kms_key_crn`.Although the support for older attribute name `key_protect` will be continued for existing customers.
+
+
 ## Argument reference
 Review the argument references that you can specify for your resource.
 


### PR DESCRIPTION
Test results :

--- PASS: TestAccIBMCOSKPKmsParamValid (84.76s)
PASS
ok [github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/cos](https://github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/cos) 86.384s
--- PASS: TestAccIBMCOSKPKmsParamWithInvalidCRN (49.70s)
PASS
ok [github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/cos](https://github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/cos) 51.390s

--- PASS: TestAccIBMCOSHPCSKmsParamWithInvalidCRN (44.35s)
PASS
ok [github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/cos](https://github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/cos) 114.080s
--- PASS: TestAccIBMCOSHPCSKmsParamWithInvalidCRN (44.35s)
PASS

ok [github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/cos](https://github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/cos) (cached)

--- PASS: TestAccIBMCOSKMSBothParamProvided (0.34s)
PASS
ok [github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/cos](https://github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/cos) 1.835s

KMS test cases
=== RUN  TestAccIBMKMSResource_basic
--- PASS: TestAccIBMKMSResource_basic (242.06s)
PASS
ok 	[github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/kms](http://github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/kms)	244.089s