### PR TITLE
fix(4630): added computed to lb pool member target id and address

### DIFF
--- a/ibm/acctest/acctest.go
+++ b/ibm/acctest/acctest.go
@@ -1016,7 +1016,7 @@ func init() {
 	IsImageName = os.Getenv("IS_IMAGE_NAME")
 	if IsImageName == "" {
 		//IsImageName = "ibm-ubuntu-18-04-2-minimal-amd64-1" // for classic infrastructure
-		IsImageName = "ibm-ubuntu-18-04-1-minimal-amd64-2" // for next gen infrastructure
+		IsImageName = "ibm-ubuntu-22-04-1-minimal-amd64-4" // for next gen infrastructure
 		fmt.Println("[INFO] Set the environment variable IS_IMAGE_NAME for testing data source ibm_is_image else it is set to default value `ibm-ubuntu-18-04-1-minimal-amd64-2`")
 	}
 	IsImageEncryptedDataKey = os.Getenv("IS_IMAGE_ENCRYPTED_DATA_KEY")

--- a/ibm/service/vpc/resource_ibm_is_lb_pool_member.go
+++ b/ibm/service/vpc/resource_ibm_is_lb_pool_member.go
@@ -89,6 +89,7 @@ func ResourceIBMISLBPoolMember() *schema.Resource {
 			isLBPoolMemberTargetAddress: {
 				Type:         schema.TypeString,
 				Optional:     true,
+				Computed:     true,
 				ExactlyOneOf: []string{isLBPoolMemberTargetAddress, isLBPoolMemberTargetID},
 				Description:  "Load balancer pool member target address",
 			},
@@ -96,6 +97,7 @@ func ResourceIBMISLBPoolMember() *schema.Resource {
 			isLBPoolMemberTargetID: {
 				Type:         schema.TypeString,
 				Optional:     true,
+				Computed:     true,
 				ExactlyOneOf: []string{isLBPoolMemberTargetAddress, isLBPoolMemberTargetID},
 				Description:  "Load balancer pool member target id",
 			},
@@ -410,7 +412,7 @@ func lbpmemberUpdate(d *schema.ResourceData, meta interface{}, lbID, lbPoolID, l
 
 		if _, ok := d.GetOk(isLBPoolMemberTargetAddress); ok {
 			targetAddress := d.Get(isLBPoolMemberTargetAddress).(string)
-			target := &vpcv1.LoadBalancerPoolMemberTargetPrototype{
+			target := &vpcv1.LoadBalancerPoolMemberTargetPrototypeIP{
 				Address: &targetAddress,
 			}
 			loadBalancerPoolMemberPatchModel.Target = target

--- a/ibm/service/vpc/resource_ibm_is_lb_pool_member_test.go
+++ b/ibm/service/vpc/resource_ibm_is_lb_pool_member_test.go
@@ -6,6 +6,7 @@ package vpc_test
 import (
 	"errors"
 	"fmt"
+	"strings"
 	"testing"
 
 	acc "github.com/IBM-Cloud/terraform-provider-ibm/ibm/acctest"
@@ -91,6 +92,49 @@ func TestAccIBMISLBPoolMember_basic_network(t *testing.T) {
 			{
 				Config: testAccCheckIBMISLBPoolMemberIDConfig(
 					vpcname, subnetname, acc.ISZoneName, acc.ISCIDR, sshname, acc.IsImageName,
+					vsiName, nlbName1, nlbPoolName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckIBMISLBPoolMemberExists("ibm_is_lb_pool_member.testacc_nlb_mem", lb),
+					resource.TestCheckResourceAttr(
+						"ibm_is_lb_pool_member.testacc_nlb_mem", "port", "8080"),
+				),
+			},
+		},
+	})
+}
+func TestAccIBMISLBPoolMember_basic_network_target_address(t *testing.T) {
+	var lb string
+
+	vpcname := fmt.Sprintf("tflbpm-vpc-%d", acctest.RandIntRange(10, 100))
+	subnetname := fmt.Sprintf("tflbpmc-name-%d", acctest.RandIntRange(10, 100))
+	nlbPoolName := fmt.Sprintf("tfnlbpoolc%d", acctest.RandIntRange(10, 100))
+
+	nlbName := fmt.Sprintf("tfnlbcreate%d", acctest.RandIntRange(10, 100))
+	nlbName1 := fmt.Sprintf("tfnlbupdate%d", acctest.RandIntRange(10, 100))
+
+	sshname := "terraform-test-ssh-key"
+	vsiName := fmt.Sprintf("tf-instance-%d", acctest.RandIntRange(10, 100))
+	publicKey := strings.TrimSpace(`
+ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCKVmnMOlHKcZK8tpt3MP1lqOLAcqcJzhsvJcjscgVERRN7/9484SOBJ3HSKxxNG5JN8owAjy5f9yYwcUg+JaUVuytn5Pv3aeYROHGGg+5G346xaq3DAwX6Y5ykr2fvjObgncQBnuU5KHWCECO/4h8uWuwh/kfniXPVjFToc+gnkqA+3RKpAecZhFXwfalQ9mMuYGFxn+fwn8cYEApsJbsEmb0iJwPiZ5hjFC8wREuiTlhPHDgkBLOiycd20op2nXzDbHfCHInquEe/gYxEitALONxm0swBOwJZwlTDOB7C6y2dzlrtxr1L59m7pCkWI4EtTRLvleehBoj3u7jB4usR
+`)
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { acc.TestAccPreCheck(t) },
+		Providers:    acc.TestAccProviders,
+		CheckDestroy: testAccCheckIBMISLBPoolMemberDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckIBMISLBPoolMemberIDAddressConfig(
+					vpcname, subnetname, acc.ISZoneName, acc.ISCIDR, sshname, publicKey, acc.IsImageName,
+					vsiName, nlbName, nlbPoolName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckIBMISLBPoolMemberExists("ibm_is_lb_pool_member.testacc_nlb_mem", lb),
+					resource.TestCheckResourceAttr(
+						"ibm_is_lb_pool_member.testacc_nlb_mem", "weight", "20"),
+				),
+			},
+			{
+				Config: testAccCheckIBMISLBPoolMemberIDAddressConfig(
+					vpcname, subnetname, acc.ISZoneName, acc.ISCIDR, sshname, publicKey, acc.IsImageName,
 					vsiName, nlbName1, nlbPoolName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckIBMISLBPoolMemberExists("ibm_is_lb_pool_member.testacc_nlb_mem", lb),
@@ -282,6 +326,61 @@ func testAccCheckIBMISLBPoolMemberIDConfig(vpcname, subnetname, zone, cidr, sshn
 		target_id = "${ibm_is_instance.testacc_instance.id}"
 	}
 `, vpcname, subnetname, zone, cidr, sshname, isImageName, vsiName,
+		acc.InstanceProfileName, zone, nlbName, nlbPoolName)
+}
+func testAccCheckIBMISLBPoolMemberIDAddressConfig(vpcname, subnetname, zone, cidr, sshname, publickey,
+	isImageName, vsiName, nlbName, nlbPoolName string) string {
+	return fmt.Sprintf(`
+	resource "ibm_is_vpc" "testacc_vpc" {
+		name = "%s"
+	}
+	resource "ibm_is_subnet" "testacc_subnet" {
+		name = "%s"
+		vpc = "${ibm_is_vpc.testacc_vpc.id}"
+		zone = "%s"
+		ipv4_cidr_block = "%s"
+	}
+	resource "ibm_is_ssh_key" "testacc_sshkey" {
+		name       = "%s"
+		public_key = "%s"
+	  }
+	data "ibm_is_image" "ds_image" {
+        name = "%s"
+    }
+	resource "ibm_is_instance" "testacc_instance" {
+		name    = "%s"
+		image   = data.ibm_is_image.ds_image.id
+		profile = "%s"
+		primary_network_interface {
+		  subnet     = ibm_is_subnet.testacc_subnet.id
+		}
+		vpc  = ibm_is_vpc.testacc_vpc.id
+		zone = "%s"
+		keys = [ibm_is_ssh_key.testacc_sshkey.id]
+	}
+	resource "ibm_is_lb" "testacc_NLB" {
+		name = "%s"
+		subnets = ["${ibm_is_subnet.testacc_subnet.id}"]
+		profile = "network-fixed"
+	}
+	resource "ibm_is_lb_pool" "testacc_nlb_pool" {
+		name = "%s"
+		lb = "${ibm_is_lb.testacc_NLB.id}"
+		algorithm      = "weighted_round_robin"
+        protocol       = "tcp"
+        health_delay   = 60
+        health_retries = 5
+        health_timeout = 30
+        health_type    = "tcp"
+	}
+	resource "ibm_is_lb_pool_member" "testacc_nlb_mem" {
+		lb = "${ibm_is_lb.testacc_NLB.id}"
+		pool = "${element(split("/",ibm_is_lb_pool.testacc_nlb_pool.id),1)}"
+		port           = 8080
+        weight = 20
+		target_id = "${ibm_is_instance.testacc_instance.id}"
+	}
+`, vpcname, subnetname, zone, cidr, sshname, publickey, isImageName, vsiName,
 		acc.InstanceProfileName, zone, nlbName, nlbPoolName)
 }
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/IBM-Cloud/terraform-provider-ibm/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #4630

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
=== RUN   TestAccIBMISLBPoolMember_basic_network_target_address
--- PASS: TestAccIBMISLBPoolMember_basic_network_target_address (1278.09s)
PASS
ok      github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/vpc     1280.283s
```
