### PR TITLE
Fix unclosed code block in r/iam_access_group_policy docs

### DIFF
--- a/website/docs/r/iam_access_group_policy.html.markdown
+++ b/website/docs/r/iam_access_group_policy.html.markdown
@@ -265,6 +265,7 @@ resource "ibm_iam_access_group_policy" "policy" {
     value    = "IAM"
   }
 }
+```
 
 ## Argument reference
 Review the argument references that you can specify for your resource. 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/IBM-Cloud/terraform-provider-ibm/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #4540 

It looks like an unclosed code block was accidentally added to the docs for the `ibm_iam_service_policy` resource in PR #4455. This closes that code block to fix the formatting.
