### PR TITLE
handle nil network id in dhcp detail

### DIFF
--- a/ibm/service/power/data_source_ibm_pi_dhcp.go
+++ b/ibm/service/power/data_source_ibm_pi_dhcp.go
@@ -113,9 +113,13 @@ func dataSourceIBMPIDhcpRead(ctx context.Context, d *schema.ResourceData, meta i
 
 	if dhcpServer.Network != nil {
 		dhcpNetwork := dhcpServer.Network
-		d.Set(Attr_DhcpNetworkDeprecated, *dhcpNetwork.ID)
-		d.Set(Attr_DhcpNetworkID, *dhcpNetwork.ID)
-		d.Set(Attr_DhcpNetworkName, *dhcpNetwork.Name)
+		if dhcpNetwork.ID != nil {
+			d.Set(Attr_DhcpNetworkDeprecated, *dhcpNetwork.ID)
+			d.Set(Attr_DhcpNetworkID, *dhcpNetwork.ID)
+		}
+		if dhcpNetwork.Name != nil {
+			d.Set(Attr_DhcpNetworkName, *dhcpNetwork.Name)
+		}
 	}
 
 	if dhcpServer.Leases != nil {

--- a/ibm/service/power/data_source_ibm_pi_dhcps.go
+++ b/ibm/service/power/data_source_ibm_pi_dhcps.go
@@ -102,9 +102,13 @@ func dataSourceIBMPIDhcpServersRead(ctx context.Context, d *schema.ResourceData,
 		}
 		if dhcpServer.Network != nil {
 			dhcpNetwork := dhcpServer.Network
-			server[Attr_DhcpNetworkDeprecated] = *dhcpNetwork.ID
-			server[Attr_DhcpNetworkID] = *dhcpNetwork.ID
-			server[Attr_DhcpNetworkName] = *dhcpNetwork.Name
+			if dhcpNetwork.ID != nil {
+				d.Set(Attr_DhcpNetworkDeprecated, *dhcpNetwork.ID)
+				d.Set(Attr_DhcpNetworkID, *dhcpNetwork.ID)
+			}
+			if dhcpNetwork.Name != nil {
+				d.Set(Attr_DhcpNetworkName, *dhcpNetwork.Name)
+			}
 		}
 		servers = append(servers, server)
 	}

--- a/ibm/service/power/resource_ibm_pi_dhcp.go
+++ b/ibm/service/power/resource_ibm_pi_dhcp.go
@@ -209,9 +209,13 @@ func resourceIBMPIDhcpRead(ctx context.Context, d *schema.ResourceData, meta int
 
 	if dhcpServer.Network != nil {
 		dhcpNetwork := dhcpServer.Network
-		d.Set(Attr_DhcpNetworkDeprecated, *dhcpNetwork.ID)
-		d.Set(Attr_DhcpNetworkID, *dhcpNetwork.ID)
-		d.Set(Attr_DhcpNetworkName, *dhcpNetwork.Name)
+		if dhcpNetwork.ID != nil {
+			d.Set(Attr_DhcpNetworkDeprecated, *dhcpNetwork.ID)
+			d.Set(Attr_DhcpNetworkID, *dhcpNetwork.ID)
+		}
+		if dhcpNetwork.Name != nil {
+			d.Set(Attr_DhcpNetworkName, *dhcpNetwork.Name)
+		}
 	}
 
 	if dhcpServer.Leases != nil {


### PR DESCRIPTION
This will prevent plugin crashes on nil dhcp network id.

<!--- See what makes a good Pull Request at : https://github.com/IBM-Cloud/terraform-provider-ibm/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #4683

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
=== RUN   TestAccIBMPIDhcpServersDataSourceBasic
--- PASS: TestAccIBMPIDhcpServersDataSourceBasic (34.38s)
=== RUN   TestAccIBMPIDhcpDataSourceBasic
--- PASS: TestAccIBMPIDhcpDataSourceBasic (17.36s)
PASS
...
```
