### PR TITLE
added trait field in enterprise child account

### DIFF
--- a/examples/ibm-enterprise-management/README.md
+++ b/examples/ibm-enterprise-management/README.md
@@ -49,6 +49,7 @@ resource "enterprise_account" "enterprise_account_instance" {
   parent = var.enterprise_account_parent
   name = var.enterprise_account_name
   owner_iam_id = var.enterprise_account_owner_iam_id
+  traits = var.enterprise_account_traits
 }
 ```
 
@@ -114,6 +115,7 @@ data "accounts" "accounts_instance" {
 | name | The name of the enterprise. | `string` | false |
 | name | The name of the account group. | `string` | false |
 | name | The name of the account. | `string` | false |
+| traits | The traits object can be used to opt-out of Multi-Factor Authenticatin '`mfa` or for setting enterprise IAM settings `enterprise_iam_managed` setting when creating a child account in the enterprise. | `set` | false |
 
 ## Outputs
 

--- a/examples/ibm-enterprise-management/main.tf
+++ b/examples/ibm-enterprise-management/main.tf
@@ -30,6 +30,7 @@ resource "ibm_enterprise_account" "enterprise_account_instance" {
   parent = var.enterprise_account_parent
   name = var.enterprise_account_name
   owner_iam_id = var.enterprise_account_owner_iam_id
+  traits = var.enterprise_account_traits
 }
 
 //Import standalone account into enterprise
@@ -51,6 +52,7 @@ resource "ibm_enterprise_account" "enterprise_account_instance_example_1" {
   parent = ibm_enterprise_account_group.enterprise_account_group_instance_example_1.crn
   name = var.enterprise_account_name
   owner_iam_id = ibm_enterprise_account_group.enterprise_account_group_instance_example_1.primary_contact_iam_id
+  traits = var.enterprise_account_traits
 }
 
 //Import standalone account into enterprise using data source

--- a/examples/ibm-enterprise-management/variables.tf
+++ b/examples/ibm-enterprise-management/variables.tf
@@ -58,6 +58,11 @@ variable "enterprise_account_owner_iam_id" {
   type        = string
   default     = "owner_iam_id"
 }
+variable "enterprise_account_traits" {
+  description = "The traits object can be used to opt-out of Multi-Factor Authenticatin or for setting enterprise IAM settings setting when creating a child account in the enterprise."
+  type   = set()
+  default = { enterprise_iam_managed = false }
+}
 
 // Data source arguments for enterprises
 variable "enterprises_name" {

--- a/examples/test-enterprise/variables.tf
+++ b/examples/test-enterprise/variables.tf
@@ -58,6 +58,11 @@ variable "enterprise_account_owner_iam_id" {
   type        = string
   default     = "owner_iam_id"
 }
+variable "enterprise_account_traits" {
+  description = "The traits object can be used to opt-out of Multi-Factor Authenticatin or for setting enterprise IAM settings setting when creating a child account in the enterprise."
+  type   = set()
+  default = { enterprise_iam_managed = false }
+}
 
 // Data source arguments for enterprises
 variable "enterprises_name" {

--- a/go.mod
+++ b/go.mod
@@ -23,7 +23,7 @@ require (
 	github.com/IBM/ibm-hpcs-uko-sdk v0.0.20-beta
 	github.com/IBM/keyprotect-go-client v0.10.0
 	github.com/IBM/networking-go-sdk v0.42.2
-	github.com/IBM/platform-services-go-sdk v0.38.1
+	github.com/IBM/platform-services-go-sdk v0.41.0
 	github.com/IBM/push-notifications-go-sdk v0.0.0-20210310100607-5790b96c47f5
 	github.com/IBM/scc-go-sdk/v3 v3.1.6
 	github.com/IBM/scc-go-sdk/v4 v4.0.2

--- a/go.sum
+++ b/go.sum
@@ -156,6 +156,8 @@ github.com/IBM/networking-go-sdk v0.42.2 h1:caqjx4jyFHi10Vlf3skHvlL6K3YJRVstsmCB
 github.com/IBM/networking-go-sdk v0.42.2/go.mod h1:lTUZwtUkMANMnrLHFIgRhHrkBfwASY/Iho1fabaPHxo=
 github.com/IBM/platform-services-go-sdk v0.38.1 h1:wyjn61SLcoCvdRMZu7wZIkScaVswXwjrTl8Gif/uESc=
 github.com/IBM/platform-services-go-sdk v0.38.1/go.mod h1:rb1IaHGwT8QI8pCYgNbf2VbkuKMgOowl91pZ2QWZuJ4=
+github.com/IBM/platform-services-go-sdk v0.41.0 h1:2aeHcLnQgat7UAKrtIF6jGyFW2hwq4oroO26fIX94kA=
+github.com/IBM/platform-services-go-sdk v0.41.0/go.mod h1:rb1IaHGwT8QI8pCYgNbf2VbkuKMgOowl91pZ2QWZuJ4=
 github.com/IBM/project-go-sdk v0.0.10 h1:vHSuemwZ4S4c6BEb22tzsEcPTs/5LnZ0yKpP3GG/GL8=
 github.com/IBM/project-go-sdk v0.0.10/go.mod h1:lqe0M4cKvABI1iHR1b+KfasVcxQL6nl2VJ8eOyQs8Ig=
 github.com/IBM/push-notifications-go-sdk v0.0.0-20210310100607-5790b96c47f5 h1:NPUhkoOCRuv3OFWt19PmwjXGGTKlvmbuPg9fUrBUNe4=

--- a/ibm/service/enterprise/resource_ibm_enterprise_account.go
+++ b/ibm/service/enterprise/resource_ibm_enterprise_account.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/conns"
+	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/flex"
 	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/validate"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -50,6 +51,26 @@ func ResourceIBMEnterpriseAccount() *schema.Resource {
 				Computed:    true,
 				Description: "The IAM ID of the account owner, such as `IBMid-0123ABC`. The IAM ID must already exist.",
 				ForceNew:    true,
+			},
+			"traits": {
+				Type:             schema.TypeSet,
+				Description:      "The traits object can be used to set properties on child accounts of an enterprise. You can pass a field to opt-out of Multi-Factor Authentication setting or setup enterprise IAM settings when creating a child account in the enterprise. This is an optional field.",
+				Optional:         true,
+				DiffSuppressFunc: flex.ApplyOnce,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"mfa": {
+							Type:        schema.TypeString,
+							Optional:    true,
+							Description: "By default MFA will be enabled on a child account. To opt out, pass the traits object with the mfa field set to empty string. This is an optional field.",
+						},
+						"enterprise_iam_managed": {
+							Type:        schema.TypeBool,
+							Optional:    true,
+							Description: "The Enterprise IAM settings property will be turned off for a newly created child account by default. You can enable this property by passing 'true' in this boolean field. This is an optional field.",
+						},
+					},
+				},
 			},
 			"url": {
 				Type:        schema.TypeString,
@@ -168,6 +189,9 @@ func resourceIbmEnterpriseAccountCreate(context context.Context, d *schema.Resou
 		createAccountOptions.SetParent(d.Get("parent").(string))
 		createAccountOptions.SetName(d.Get("name").(string))
 		createAccountOptions.SetOwnerIamID(d.Get("owner_iam_id").(string))
+		if _, ok := d.GetOk("Traits"); ok {
+			createAccountOptions.SetTraits(d.Get("traits").(*enterprisemanagementv1.CreateAccountRequestTraits))
+		}
 		createAccountResponse, response, err := enterpriseManagementClient.CreateAccountWithContext(context, createAccountOptions)
 		if err != nil {
 			log.Printf("[DEBUG] CreateAccountWithContext failed %s\n%s", err, response)

--- a/ibm/service/enterprise/resource_ibm_enterprise_account_test.go
+++ b/ibm/service/enterprise/resource_ibm_enterprise_account_test.go
@@ -24,7 +24,7 @@ func TestAccIbmEnterpriseAccountBasic(t *testing.T) {
 	name := fmt.Sprintf("tf-gen-account-name_%d", acctest.RandIntRange(10, 100))
 	//ownerIamID := fmt.Sprintf("owner_iam_id_%d", acctest.RandIntRange(10, 100))
 	//parentUpdate := fmt.Sprintf("parent_%d", acctest.RandIntRange(10, 100))
-
+	another_acc_name := fmt.Sprintf("tf-gen-account-name_%d", acctest.RandIntRange(10, 100))
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { acc.TestAccPreCheckEnterprise(t) },
 		Providers:    acc.TestAccProviders,
@@ -48,9 +48,21 @@ func TestAccIbmEnterpriseAccountBasic(t *testing.T) {
 				),
 			},
 			{
-				ResourceName:      "ibm_enterprise_account.enterprise_account",
-				ImportState:       true,
-				ImportStateVerify: true,
+				Config: testAccCheckForTraitFieldIbmEnterpriseAccountConfigBasic(another_acc_name),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckIbmEnterpriseAccountExists("ibm_enterprise_account.enterprise_account", conf),
+					resource.TestCheckResourceAttrSet("ibm_enterprise_account.enterprise_account", "parent"),
+					resource.TestCheckResourceAttr("ibm_enterprise_account.enterprise_account", "name", another_acc_name),
+					resource.TestCheckResourceAttrSet("ibm_enterprise_account.enterprise_account", "owner_iam_id"),
+				),
+			},
+			{
+				Config: testAccCheckForTraitFieldIbmEnterpriseAccountConfigUpdateBasic(another_acc_name),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrSet("ibm_enterprise_account.enterprise_account", "parent"),
+					resource.TestCheckResourceAttrSet("ibm_enterprise_account.enterprise_account", "name"),
+					resource.TestCheckResourceAttrSet("ibm_enterprise_account.enterprise_account", "owner_iam_id"),
+				),
 			},
 		},
 	})
@@ -101,6 +113,36 @@ func testAccCheckIbmEnterpriseAccountConfigUpdateBasic(name string) string {
 			parent = data.ibm_enterprise_account_groups.account_groups_instance.account_groups[0].crn
 			name = "%s"
 			owner_iam_id = data.ibm_enterprise_account_groups.account_groups_instance.account_groups[0].primary_contact_iam_id
+		}
+	`, name)
+}
+
+func testAccCheckForTraitFieldIbmEnterpriseAccountConfigBasic(name string) string {
+	return fmt.Sprintf(`
+		data "ibm_enterprises" "enterprises_instance" {
+		}
+		resource "ibm_enterprise_account" "enterprise_account" {
+			parent = data.ibm_enterprises.enterprises_instance.enterprises[0].crn
+			name = "%s"
+			owner_iam_id = data.ibm_enterprises.enterprises_instance.enterprises[0].primary_contact_iam_id
+			traits {
+				mfa =  "NONE"
+			}
+		}
+	`, name)
+}
+
+func testAccCheckForTraitFieldIbmEnterpriseAccountConfigUpdateBasic(name string) string {
+	return fmt.Sprintf(`
+		data "ibm_enterprise_account_groups" "account_groups_instance" {
+		}
+		resource "ibm_enterprise_account" "enterprise_account" {
+			parent = data.ibm_enterprise_account_groups.account_groups_instance.account_groups[0].crn
+			name = "%s"
+			owner_iam_id = data.ibm_enterprise_account_groups.account_groups_instance.account_groups[0].primary_contact_iam_id
+			traits {
+				enterprise_iam_managed = true
+			}
 		}
 	`, name)
 }

--- a/website/docs/r/enterprise_account.html.markdown
+++ b/website/docs/r/enterprise_account.html.markdown
@@ -24,6 +24,10 @@ resource "ibm_enterprise_account" "enterprise_import_account"{
   parent = "parent"
   enterprise_id = "enterprise_id"
   account_id = "account_id"
+  traits {
+    mfa = "NONE"
+    enterprise_iam_managed = true
+  }
 }
 ```
 
@@ -34,6 +38,9 @@ Review the argument reference that you can specify to create a new account in an
 - `name` - (Required, String) The name of an enterprise. The minimum and maximum character should be from `3 to 60` characters.
 - `owneriam_id` - (Required, String) The IAM ID of an account owner, such as `IBMid-0123ABC.` The IAM ID must already exist.
 - `parent` - (Required, String) The CRN of the parent in which the account is created. The parent can be an existing account group or an enterprise itself.
+- `traits` - (Optional, Set) The traits object can be used to set properties on child accounts of an enterprise. 
+By default MFA will be enabled on a child account. To opt out, pass the traits object with the mfa field set to empty string `traits {mfa = "NONE"}` mfa is an optional property.
+The Enterprise IAM settings property will be turned off for a newly created child account by default. You can enable this property by passing 'true' in this boolean field `traits { enterprise_iam_managed = true }` enterprise_iam_managed an optional property.
 
 Review the argument reference that you can specify to import a new account in an enterprise resource. 
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/IBM-Cloud/terraform-provider-ibm/blob/master/.github/CONTRIBUTING.md --->

Added trait field in enterprise child account schema

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

make testacc TEST=./ibm/service/enterprise TESTARGS='-run=TestAccIbmEnterpriseAccountBasic'

...
![image (30)](https://github.com/IBM-Cloud/terraform-provider-ibm/assets/19454465/6e6338cb-b918-471d-812e-a55978621578)


make testacc TEST=./ibm/service/enterprise TESTARGS='-run=TestAccIbmEnterpriseImportAccountBasic'
![image (29)](https://github.com/IBM-Cloud/terraform-provider-ibm/assets/19454465/fd2933a5-6238-4a0e-9550-56f99e080571)


