### PR TITLE
always read and set datacentervalue

### DIFF
--- a/ibm/service/kubernetes/resource_ibm_container_cluster.go
+++ b/ibm/service/kubernetes/resource_ibm_container_cluster.go
@@ -852,7 +852,6 @@ func resourceIBMContainerClusterRead(d *schema.ResourceData, meta interface{}) e
 			d.Set("private_vlan_id", workersByPool[0].PrivateVlan)
 		}
 		d.Set("machine_type", strings.Split(workersByPool[0].MachineType, ".encrypted")[0])
-		d.Set("datacenter", cls.DataCenter)
 		if workersByPool[0].MachineType != "free" {
 			if strings.HasSuffix(workersByPool[0].MachineType, ".encrypted") {
 				d.Set("disk_encryption", true)
@@ -901,6 +900,7 @@ func resourceIBMContainerClusterRead(d *schema.ResourceData, meta interface{}) e
 	d.Set("ingress_hostname", cls.IngressHostname)
 	d.Set("ingress_secret", cls.IngressSecretName)
 	d.Set("region", cls.Region)
+	d.Set("datacenter", cls.DataCenter)
 	d.Set("service_subnet", cls.ServiceSubnet)
 	d.Set("pod_subnet", cls.PodSubnet)
 	d.Set("subnet_id", d.Get("subnet_id").(*schema.Set))


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/IBM-Cloud/terraform-provider-ibm/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
compiled a new version, created a classic cluster


```
2023-07-20T09:07:14.949+0200 [DEBUG] provider: plugin process exited: path=.terraform/providers/registry.terraform.io/ibm-cloud/ibm/1.55.0/darwin_amd64/terraform-provider-ibm_v1.55.0 pid=99995
2023-07-20T09:07:14.949+0200 [DEBUG] provider: plugin exited

Apply complete! Resources: 1 added, 0 changed, 0 destroyed.
```


