### PR TITLE
Doc Fix: Updated service name - IBM Cloud Metrics Routing

### DIFF
--- a/website/docs/d/metrics_router_targets.html.markdown
+++ b/website/docs/d/metrics_router_targets.html.markdown
@@ -3,7 +3,7 @@ layout: "ibm"
 page_title: "IBM : ibm_metrics_router_targets"
 description: |-
   Get information about metrics_router_targets
-subcategory: "IBM Cloud Metrics Routing API Version 3"
+subcategory: "IBM Cloud Metrics Routing"
 ---
 
 # ibm_metrics_router_targets

--- a/website/docs/r/metrics_router_route.html.markdown
+++ b/website/docs/r/metrics_router_route.html.markdown
@@ -3,7 +3,7 @@ layout: "ibm"
 page_title: "IBM : ibm_metrics_router_route"
 description: |-
   Manages metrics_router_route
-subcategory: "IBM Cloud Metrics Routing API Version 3"
+subcategory: "IBM Cloud Metrics Routing"
 ---
 
 # ibm_metrics_router_route

--- a/website/docs/r/metrics_router_settings.html.markdown
+++ b/website/docs/r/metrics_router_settings.html.markdown
@@ -3,7 +3,7 @@ layout: "ibm"
 page_title: "IBM : ibm_metrics_router_settings"
 description: |-
   Manages metrics_router_settings
-subcategory: "IBM Cloud Metrics Routing API Version 3"
+subcategory: "IBM Cloud Metrics Routing"
 ---
 
 # ibm_metrics_router_settings

--- a/website/docs/r/metrics_router_target.html.markdown
+++ b/website/docs/r/metrics_router_target.html.markdown
@@ -3,7 +3,7 @@ layout: "ibm"
 page_title: "IBM : ibm_metrics_router_target"
 description: |-
   Manages metrics_router_target
-subcategory: "IBM Cloud Metrics Routing API Version 3"
+subcategory: "IBM Cloud Metrics Routing"
 ---
 
 # ibm_metrics_router_target


### PR DESCRIPTION
As part of the PR, changing the subcategory from **IBM Cloud Metrics Routing API Version 3** to **IBM Cloud Metrics Routing**
Right now its like below - 
![image](https://github.com/IBM-Cloud/terraform-provider-ibm/assets/108253969/2948ec4f-b640-4da8-a9af-d44770182d10)

