### PR TITLE
fix(tekton): Trigger updates

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/IBM/cloudant-go-sdk v0.0.43
 	github.com/IBM/code-engine-go-sdk v0.0.0-20230606173928-4863db061918
 	github.com/IBM/container-registry-go-sdk v1.1.0
-	github.com/IBM/continuous-delivery-go-sdk v1.1.1
+	github.com/IBM/continuous-delivery-go-sdk v1.1.2
 	github.com/IBM/event-notifications-go-admin-sdk v0.2.4
 	github.com/IBM/eventstreams-go-sdk v1.2.0
 	github.com/IBM/go-sdk-core/v5 v5.13.4

--- a/go.sum
+++ b/go.sum
@@ -121,8 +121,8 @@ github.com/IBM/code-engine-go-sdk v0.0.0-20230606173928-4863db061918 h1:RfHezAVs
 github.com/IBM/code-engine-go-sdk v0.0.0-20230606173928-4863db061918/go.mod h1:IP6U/1NxgxzPeYdyiEwMaZyzelTw82JGHWl7bY78eQM=
 github.com/IBM/container-registry-go-sdk v1.1.0 h1:sYyknIod8R4RJZQqAheiduP6wbSTphE9Ag8ho28yXjc=
 github.com/IBM/container-registry-go-sdk v1.1.0/go.mod h1:4TwsCnQtVfZ4Vkapy/KPvQBKFc3VOyUZYkwRU4FTPrs=
-github.com/IBM/continuous-delivery-go-sdk v1.1.1 h1:bYrK0+rJgoWfBmIJAlAfo/AxI5vOr8DSLJPrM3iEOzQ=
-github.com/IBM/continuous-delivery-go-sdk v1.1.1/go.mod h1:A9rI1HPbccBBFgwJxXB999yXXpj1l+MnlE+rsxKtxw0=
+github.com/IBM/continuous-delivery-go-sdk v1.1.2 h1:UHwwak2RVTSZGtIV+SjH0vALqSvA+Vwkd1PHAbGgGrc=
+github.com/IBM/continuous-delivery-go-sdk v1.1.2/go.mod h1:A9rI1HPbccBBFgwJxXB999yXXpj1l+MnlE+rsxKtxw0=
 github.com/IBM/event-notifications-go-admin-sdk v0.2.4 h1:WWUxwrKQxvExEK+xaAQOs6gP54LvJDPi3KatDTMfwh0=
 github.com/IBM/event-notifications-go-admin-sdk v0.2.4/go.mod h1:1TlGAFP47DybbovJfHtYYgSI8xpLL8Q0wao6vsAlb6c=
 github.com/IBM/eventstreams-go-sdk v1.2.0 h1:eP0afHArMGjwhGqvZAhhu/3EDKRch2JehpveqF1TUjs=

--- a/ibm/service/cdtektonpipeline/data_source_ibm_cd_tekton_pipeline.go
+++ b/ibm/service/cdtektonpipeline/data_source_ibm_cd_tekton_pipeline.go
@@ -281,7 +281,7 @@ func DataSourceIBMCdTektonPipeline() *schema.Resource {
 						"worker": &schema.Schema{
 							Type:        schema.TypeList,
 							Computed:    true,
-							Description: "Worker used to run the trigger. If not specified the trigger will use the default pipeline worker.",
+							Description: "Details of the worker used to run the trigger.",
 							Elem: &schema.Resource{
 								Schema: map[string]*schema.Schema{
 									"name": &schema.Schema{
@@ -311,6 +311,11 @@ func DataSourceIBMCdTektonPipeline() *schema.Resource {
 							Type:        schema.TypeBool,
 							Computed:    true,
 							Description: "Flag whether the trigger is enabled.",
+						},
+						"favorite": &schema.Schema{
+							Type:        schema.TypeBool,
+							Computed:    true,
+							Description: "Mark the trigger as a favorite.",
 						},
 						"source": &schema.Schema{
 							Type:        schema.TypeList,
@@ -437,7 +442,7 @@ func DataSourceIBMCdTektonPipeline() *schema.Resource {
 			"worker": &schema.Schema{
 				Type:        schema.TypeList,
 				Computed:    true,
-				Description: "Default pipeline worker used to run the pipeline.",
+				Description: "Details of the worker used to run the pipeline.",
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"name": &schema.Schema{
@@ -779,6 +784,9 @@ func dataSourceIBMCdTektonPipelineTriggerToMap(model cdtektonpipelinev2.TriggerI
 		if model.Enabled != nil {
 			modelMap["enabled"] = model.Enabled
 		}
+		if model.Favorite != nil {
+			modelMap["favorite"] = model.Favorite
+		}
 		if model.Source != nil {
 			sourceMap, err := dataSourceIBMCdTektonPipelineTriggerSourceToMap(model.Source)
 			if err != nil {
@@ -928,6 +936,9 @@ func dataSourceIBMCdTektonPipelineTriggerManualTriggerToMap(model *cdtektonpipel
 		modelMap["max_concurrent_runs"] = flex.IntValue(model.MaxConcurrentRuns)
 	}
 	modelMap["enabled"] = model.Enabled
+	if model.Favorite != nil {
+		modelMap["favorite"] = model.Favorite
+	}
 	return modelMap, nil
 }
 
@@ -965,6 +976,9 @@ func dataSourceIBMCdTektonPipelineTriggerScmTriggerToMap(model *cdtektonpipeline
 		modelMap["max_concurrent_runs"] = flex.IntValue(model.MaxConcurrentRuns)
 	}
 	modelMap["enabled"] = model.Enabled
+	if model.Favorite != nil {
+		modelMap["favorite"] = model.Favorite
+	}
 	if model.Source != nil {
 		sourceMap, err := dataSourceIBMCdTektonPipelineTriggerSourceToMap(model.Source)
 		if err != nil {
@@ -1012,6 +1026,9 @@ func dataSourceIBMCdTektonPipelineTriggerTimerTriggerToMap(model *cdtektonpipeli
 		modelMap["max_concurrent_runs"] = flex.IntValue(model.MaxConcurrentRuns)
 	}
 	modelMap["enabled"] = model.Enabled
+	if model.Favorite != nil {
+		modelMap["favorite"] = model.Favorite
+	}
 	if model.Cron != nil {
 		modelMap["cron"] = model.Cron
 	}
@@ -1055,6 +1072,9 @@ func dataSourceIBMCdTektonPipelineTriggerGenericTriggerToMap(model *cdtektonpipe
 		modelMap["max_concurrent_runs"] = flex.IntValue(model.MaxConcurrentRuns)
 	}
 	modelMap["enabled"] = model.Enabled
+	if model.Favorite != nil {
+		modelMap["favorite"] = model.Favorite
+	}
 	if model.Secret != nil {
 		secretMap, err := dataSourceIBMCdTektonPipelineGenericSecretToMap(model.Secret)
 		if err != nil {

--- a/ibm/service/cdtektonpipeline/data_source_ibm_cd_tekton_pipeline_property_test.go
+++ b/ibm/service/cdtektonpipeline/data_source_ibm_cd_tekton_pipeline_property_test.go
@@ -37,8 +37,8 @@ func TestAccIBMCdTektonPipelinePropertyDataSourceBasic(t *testing.T) {
 
 func TestAccIBMCdTektonPipelinePropertyDataSourceAllArgs(t *testing.T) {
 	propertyName := fmt.Sprintf("tf_name_%d", acctest.RandIntRange(10, 100))
-	propertyType := "text"
 	propertyValue := fmt.Sprintf("tf_value_%d", acctest.RandIntRange(10, 100))
+	propertyType := "text"
 	propertyPath := fmt.Sprintf("tf_path_%d", acctest.RandIntRange(10, 100))
 
 	resource.Test(t, resource.TestCase{
@@ -46,7 +46,7 @@ func TestAccIBMCdTektonPipelinePropertyDataSourceAllArgs(t *testing.T) {
 		Providers: acc.TestAccProviders,
 		Steps: []resource.TestStep{
 			resource.TestStep{
-				Config: testAccCheckIBMCdTektonPipelinePropertyDataSourceConfig("", propertyName, propertyType, propertyValue, propertyPath),
+				Config: testAccCheckIBMCdTektonPipelinePropertyDataSourceConfig("", propertyName, propertyValue, propertyType, propertyPath),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrSet("data.ibm_cd_tekton_pipeline_property.cd_tekton_pipeline_property", "id"),
 					resource.TestCheckResourceAttrSet("data.ibm_cd_tekton_pipeline_property.cd_tekton_pipeline_property", "pipeline_id"),
@@ -104,7 +104,7 @@ func testAccCheckIBMCdTektonPipelinePropertyDataSourceConfigBasic(propertyPipeli
 	`, rgName, tcName)
 }
 
-func testAccCheckIBMCdTektonPipelinePropertyDataSourceConfig(propertyPipelineID string, propertyName string, propertyType string, propertyValue string, propertyPath string) string {
+func testAccCheckIBMCdTektonPipelinePropertyDataSourceConfig(propertyPipelineID string, propertyName string, propertyValue string, propertyType string, propertyPath string) string {
 	rgName := acc.CdResourceGroupName
 	tcName := fmt.Sprintf("tf_name_%d", acctest.RandIntRange(10, 100))
 	return fmt.Sprintf(`

--- a/ibm/service/cdtektonpipeline/data_source_ibm_cd_tekton_pipeline_trigger.go
+++ b/ibm/service/cdtektonpipeline/data_source_ibm_cd_tekton_pipeline_trigger.go
@@ -104,7 +104,7 @@ func DataSourceIBMCdTektonPipelineTrigger() *schema.Resource {
 			"worker": &schema.Schema{
 				Type:        schema.TypeList,
 				Computed:    true,
-				Description: "Worker used to run the trigger. If not specified the trigger will use the default pipeline worker.",
+				Description: "Details of the worker used to run the trigger.",
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"name": &schema.Schema{
@@ -134,6 +134,11 @@ func DataSourceIBMCdTektonPipelineTrigger() *schema.Resource {
 				Type:        schema.TypeBool,
 				Computed:    true,
 				Description: "Flag whether the trigger is enabled.",
+			},
+			"favorite": &schema.Schema{
+				Type:        schema.TypeBool,
+				Computed:    true,
+				Description: "Mark the trigger as a favorite.",
 			},
 			"source": &schema.Schema{
 				Type:        schema.TypeList,
@@ -338,6 +343,10 @@ func dataSourceIBMCdTektonPipelineTriggerRead(context context.Context, d *schema
 
 	if err = d.Set("enabled", trigger.Enabled); err != nil {
 		return diag.FromErr(fmt.Errorf("Error setting enabled: %s", err))
+	}
+
+	if err = d.Set("favorite", trigger.Favorite); err != nil {
+		return diag.FromErr(fmt.Errorf("Error setting favorite: %s", err))
 	}
 
 	source := []map[string]interface{}{}

--- a/ibm/service/cdtektonpipeline/data_source_ibm_cd_tekton_pipeline_trigger_property_test.go
+++ b/ibm/service/cdtektonpipeline/data_source_ibm_cd_tekton_pipeline_trigger_property_test.go
@@ -36,8 +36,8 @@ func TestAccIBMCdTektonPipelineTriggerPropertyDataSourceBasic(t *testing.T) {
 
 func TestAccIBMCdTektonPipelineTriggerPropertyDataSourceAllArgs(t *testing.T) {
 	triggerPropertyName := fmt.Sprintf("tf_name_%d", acctest.RandIntRange(10, 100))
-	triggerPropertyType := "text"
 	triggerPropertyValue := fmt.Sprintf("tf_value_%d", acctest.RandIntRange(10, 100))
+	triggerPropertyType := "text"
 	triggerPropertyPath := fmt.Sprintf("tf_path_%d", acctest.RandIntRange(10, 100))
 
 	resource.Test(t, resource.TestCase{
@@ -45,7 +45,7 @@ func TestAccIBMCdTektonPipelineTriggerPropertyDataSourceAllArgs(t *testing.T) {
 		Providers: acc.TestAccProviders,
 		Steps: []resource.TestStep{
 			resource.TestStep{
-				Config: testAccCheckIBMCdTektonPipelineTriggerPropertyDataSourceConfig("", "", triggerPropertyName, triggerPropertyType, triggerPropertyValue, triggerPropertyPath),
+				Config: testAccCheckIBMCdTektonPipelineTriggerPropertyDataSourceConfig("", "", triggerPropertyName, triggerPropertyValue, triggerPropertyType, triggerPropertyPath),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrSet("data.ibm_cd_tekton_pipeline_trigger_property.cd_tekton_pipeline_trigger_property", "id"),
 					resource.TestCheckResourceAttrSet("data.ibm_cd_tekton_pipeline_trigger_property.cd_tekton_pipeline_trigger_property", "property_name"),
@@ -133,7 +133,7 @@ func testAccCheckIBMCdTektonPipelineTriggerPropertyDataSourceConfigBasic(trigger
 	`, rgName, tcName)
 }
 
-func testAccCheckIBMCdTektonPipelineTriggerPropertyDataSourceConfig(triggerPropertyPipelineID string, triggerPropertyTriggerID string, triggerPropertyName string, triggerPropertyType string, triggerPropertyValue string, triggerPropertyPath string) string {
+func testAccCheckIBMCdTektonPipelineTriggerPropertyDataSourceConfig(triggerPropertyPipelineID string, triggerPropertyTriggerID string, triggerPropertyName string, triggerPropertyValue string, triggerPropertyType string, triggerPropertyPath string) string {
 	rgName := acc.CdResourceGroupName
 	tcName := fmt.Sprintf("tf_name_%d", acctest.RandIntRange(10, 100))
 	return fmt.Sprintf(`

--- a/ibm/service/cdtektonpipeline/data_source_ibm_cd_tekton_pipeline_trigger_test.go
+++ b/ibm/service/cdtektonpipeline/data_source_ibm_cd_tekton_pipeline_trigger_test.go
@@ -42,6 +42,7 @@ func TestAccIBMCdTektonPipelineTriggerDataSourceAllArgs(t *testing.T) {
 	triggerEventListener := fmt.Sprintf("tf_event_listener_%d", acctest.RandIntRange(10, 100))
 	triggerMaxConcurrentRuns := fmt.Sprintf("%d", acctest.RandIntRange(10, 100))
 	triggerEnabled := "false"
+	triggerFavorite := "true"
 	triggerCron := fmt.Sprintf("tf_cron_%d", acctest.RandIntRange(10, 100))
 	triggerTimezone := fmt.Sprintf("tf_timezone_%d", acctest.RandIntRange(10, 100))
 
@@ -50,7 +51,7 @@ func TestAccIBMCdTektonPipelineTriggerDataSourceAllArgs(t *testing.T) {
 		Providers: acc.TestAccProviders,
 		Steps: []resource.TestStep{
 			resource.TestStep{
-				Config: testAccCheckIBMCdTektonPipelineTriggerDataSourceConfig(triggerPipelineID, triggerType, triggerName, triggerEventListener, triggerMaxConcurrentRuns, triggerEnabled, triggerCron, triggerTimezone),
+				Config: testAccCheckIBMCdTektonPipelineTriggerDataSourceConfig(triggerPipelineID, triggerType, triggerName, triggerEventListener, triggerMaxConcurrentRuns, triggerEnabled, triggerFavorite, triggerCron, triggerTimezone),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrSet("data.ibm_cd_tekton_pipeline_trigger.cd_tekton_pipeline_trigger", "id"),
 					resource.TestCheckResourceAttrSet("data.ibm_cd_tekton_pipeline_trigger.cd_tekton_pipeline_trigger", "pipeline_id"),
@@ -63,6 +64,7 @@ func TestAccIBMCdTektonPipelineTriggerDataSourceAllArgs(t *testing.T) {
 					resource.TestCheckResourceAttrSet("data.ibm_cd_tekton_pipeline_trigger.cd_tekton_pipeline_trigger", "worker.#"),
 					resource.TestCheckResourceAttrSet("data.ibm_cd_tekton_pipeline_trigger.cd_tekton_pipeline_trigger", "max_concurrent_runs"),
 					resource.TestCheckResourceAttrSet("data.ibm_cd_tekton_pipeline_trigger.cd_tekton_pipeline_trigger", "enabled"),
+					resource.TestCheckResourceAttrSet("data.ibm_cd_tekton_pipeline_trigger.cd_tekton_pipeline_trigger", "favorite"),
 					resource.TestCheckResourceAttrSet("data.ibm_cd_tekton_pipeline_trigger.cd_tekton_pipeline_trigger", "source.#"),
 					resource.TestCheckResourceAttrSet("data.ibm_cd_tekton_pipeline_trigger.cd_tekton_pipeline_trigger", "secret.#"),
 				),
@@ -138,7 +140,7 @@ func testAccCheckIBMCdTektonPipelineTriggerDataSourceConfigBasic(triggerPipeline
 	`, rgName, tcName, triggerType, triggerName, triggerEventListener)
 }
 
-func testAccCheckIBMCdTektonPipelineTriggerDataSourceConfig(triggerPipelineID string, triggerType string, triggerName string, triggerEventListener string, triggerMaxConcurrentRuns string, triggerEnabled string, triggerCron string, triggerTimezone string) string {
+func testAccCheckIBMCdTektonPipelineTriggerDataSourceConfig(triggerPipelineID string, triggerType string, triggerName string, triggerEventListener string, triggerMaxConcurrentRuns string, triggerEnabled string, triggerFavorite string, triggerCron string, triggerTimezone string) string {
 	rgName := acc.CdResourceGroupName
 	tcName := fmt.Sprintf("tf_name_%d", acctest.RandIntRange(10, 100))
 	return fmt.Sprintf(`

--- a/ibm/service/cdtektonpipeline/resource_ibm_cd_tekton_pipeline_property.go
+++ b/ibm/service/cdtektonpipeline/resource_ibm_cd_tekton_pipeline_property.go
@@ -41,13 +41,6 @@ func ResourceIBMCdTektonPipelineProperty() *schema.Resource {
 				ValidateFunc: validate.InvokeValidator("ibm_cd_tekton_pipeline_property", "name"),
 				Description:  "Property name.",
 			},
-			"type": &schema.Schema{
-				Type:         schema.TypeString,
-				Required:     true,
-				ForceNew:     true,
-				ValidateFunc: validate.InvokeValidator("ibm_cd_tekton_pipeline_property", "type"),
-				Description:  "Property type.",
-			},
 			"value": &schema.Schema{
 				Type:             schema.TypeString,
 				Optional:         true,
@@ -61,11 +54,18 @@ func ResourceIBMCdTektonPipelineProperty() *schema.Resource {
 				Description: "Options for `single_select` property type. Only needed when using `single_select` property type.",
 				Elem:        &schema.Schema{Type: schema.TypeString},
 			},
+			"type": &schema.Schema{
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: validate.InvokeValidator("ibm_cd_tekton_pipeline_property", "type"),
+				Description:  "Property type.",
+			},
 			"path": &schema.Schema{
 				Type:         schema.TypeString,
 				Optional:     true,
 				ValidateFunc: validate.InvokeValidator("ibm_cd_tekton_pipeline_property", "path"),
-				Description:  "A dot notation path for `integration` type properties only, to select a value from the tool integration. If left blank the full tool integration data will be used.",
+				Description:  "A dot notation path for `integration` type properties only, that selects a value from the tool integration. If left blank the full tool integration data will be used.",
 			},
 			"href": &schema.Schema{
 				Type:        schema.TypeString,
@@ -98,13 +98,6 @@ func ResourceIBMCdTektonPipelinePropertyValidator() *validate.ResourceValidator 
 			MaxValueLength:             253,
 		},
 		validate.ValidateSchema{
-			Identifier:                 "type",
-			ValidateFunctionIdentifier: validate.ValidateAllowedStringValue,
-			Type:                       validate.TypeString,
-			Required:                   true,
-			AllowedValues:              "appconfig, integration, secure, single_select, text",
-		},
-		validate.ValidateSchema{
 			Identifier:                 "value",
 			ValidateFunctionIdentifier: validate.ValidateRegexpLen,
 			Type:                       validate.TypeString,
@@ -112,6 +105,13 @@ func ResourceIBMCdTektonPipelinePropertyValidator() *validate.ResourceValidator 
 			Regexp:                     `^.*$`,
 			MinValueLength:             0,
 			MaxValueLength:             4096,
+		},
+		validate.ValidateSchema{
+			Identifier:                 "type",
+			ValidateFunctionIdentifier: validate.ValidateAllowedStringValue,
+			Type:                       validate.TypeString,
+			Required:                   true,
+			AllowedValues:              "appconfig, integration, secure, single_select, text",
 		},
 		validate.ValidateSchema{
 			Identifier:                 "path",
@@ -197,9 +197,6 @@ func resourceIBMCdTektonPipelinePropertyRead(context context.Context, d *schema.
 	if err = d.Set("name", property.Name); err != nil {
 		return diag.FromErr(fmt.Errorf("Error setting name: %s", err))
 	}
-	if err = d.Set("type", property.Type); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting type: %s", err))
-	}
 	if !core.IsNil(property.Value) {
 		if err = d.Set("value", property.Value); err != nil {
 			return diag.FromErr(fmt.Errorf("Error setting value: %s", err))
@@ -209,6 +206,9 @@ func resourceIBMCdTektonPipelinePropertyRead(context context.Context, d *schema.
 		if err = d.Set("enum", property.Enum); err != nil {
 			return diag.FromErr(fmt.Errorf("Error setting enum: %s", err))
 		}
+	}
+	if err = d.Set("type", property.Type); err != nil {
+		return diag.FromErr(fmt.Errorf("Error setting type: %s", err))
 	}
 	if !core.IsNil(property.Path) {
 		if err = d.Set("path", property.Path); err != nil {

--- a/ibm/service/cdtektonpipeline/resource_ibm_cd_tekton_pipeline_property_test.go
+++ b/ibm/service/cdtektonpipeline/resource_ibm_cd_tekton_pipeline_property_test.go
@@ -41,8 +41,8 @@ func TestAccIBMCdTektonPipelinePropertyBasic(t *testing.T) {
 func TestAccIBMCdTektonPipelinePropertyAllArgs(t *testing.T) {
 	var conf cdtektonpipelinev2.Property
 	name := fmt.Sprintf("tf_name_%d", acctest.RandIntRange(10, 100))
-	typeVar := "text"
 	value := fmt.Sprintf("tf_value_%d", acctest.RandIntRange(10, 100))
+	typeVar := "text"
 	path := fmt.Sprintf("tf_path_%d", acctest.RandIntRange(10, 100))
 	valueUpdate := fmt.Sprintf("tf_value_%d", acctest.RandIntRange(10, 100))
 	pathUpdate := fmt.Sprintf("tf_path_%d", acctest.RandIntRange(10, 100))
@@ -53,20 +53,20 @@ func TestAccIBMCdTektonPipelinePropertyAllArgs(t *testing.T) {
 		CheckDestroy: testAccCheckIBMCdTektonPipelinePropertyDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
-				Config: testAccCheckIBMCdTektonPipelinePropertyConfig("", name, typeVar, value, path),
+				Config: testAccCheckIBMCdTektonPipelinePropertyConfig("", name, value, typeVar, path),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckIBMCdTektonPipelinePropertyExists("ibm_cd_tekton_pipeline_property.cd_tekton_pipeline_property", conf),
 					resource.TestCheckResourceAttr("ibm_cd_tekton_pipeline_property.cd_tekton_pipeline_property", "name", name),
-					resource.TestCheckResourceAttr("ibm_cd_tekton_pipeline_property.cd_tekton_pipeline_property", "type", typeVar),
 					resource.TestCheckResourceAttr("ibm_cd_tekton_pipeline_property.cd_tekton_pipeline_property", "value", value),
+					resource.TestCheckResourceAttr("ibm_cd_tekton_pipeline_property.cd_tekton_pipeline_property", "type", typeVar),
 				),
 			},
 			resource.TestStep{
-				Config: testAccCheckIBMCdTektonPipelinePropertyConfig("", name, typeVar, valueUpdate, pathUpdate),
+				Config: testAccCheckIBMCdTektonPipelinePropertyConfig("", name, valueUpdate, typeVar, pathUpdate),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr("ibm_cd_tekton_pipeline_property.cd_tekton_pipeline_property", "name", name),
-					resource.TestCheckResourceAttr("ibm_cd_tekton_pipeline_property.cd_tekton_pipeline_property", "type", typeVar),
 					resource.TestCheckResourceAttr("ibm_cd_tekton_pipeline_property.cd_tekton_pipeline_property", "value", valueUpdate),
+					resource.TestCheckResourceAttr("ibm_cd_tekton_pipeline_property.cd_tekton_pipeline_property", "type", typeVar),
 				),
 			},
 			resource.TestStep{
@@ -117,7 +117,7 @@ func testAccCheckIBMCdTektonPipelinePropertyConfigBasic(pipelineID string, name 
 	`, rgName, tcName)
 }
 
-func testAccCheckIBMCdTektonPipelinePropertyConfig(pipelineID string, name string, typeVar string, value string, path string) string {
+func testAccCheckIBMCdTektonPipelinePropertyConfig(pipelineID string, name string, value string, typeVar string, path string) string {
 	rgName := acc.CdResourceGroupName
 	tcName := fmt.Sprintf("tf_name_%d", acctest.RandIntRange(10, 100))
 	return fmt.Sprintf(`

--- a/ibm/service/cdtektonpipeline/resource_ibm_cd_tekton_pipeline_trigger_property.go
+++ b/ibm/service/cdtektonpipeline/resource_ibm_cd_tekton_pipeline_trigger_property.go
@@ -48,13 +48,6 @@ func ResourceIBMCdTektonPipelineTriggerProperty() *schema.Resource {
 				ValidateFunc: validate.InvokeValidator("ibm_cd_tekton_pipeline_trigger_property", "name"),
 				Description:  "Property name.",
 			},
-			"type": &schema.Schema{
-				Type:         schema.TypeString,
-				Required:     true,
-				ForceNew:     true,
-				ValidateFunc: validate.InvokeValidator("ibm_cd_tekton_pipeline_trigger_property", "type"),
-				Description:  "Property type.",
-			},
 			"value": &schema.Schema{
 				Type:             schema.TypeString,
 				Optional:         true,
@@ -68,11 +61,18 @@ func ResourceIBMCdTektonPipelineTriggerProperty() *schema.Resource {
 				Description: "Options for `single_select` property type. Only needed for `single_select` property type.",
 				Elem:        &schema.Schema{Type: schema.TypeString},
 			},
+			"type": &schema.Schema{
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: validate.InvokeValidator("ibm_cd_tekton_pipeline_trigger_property", "type"),
+				Description:  "Property type.",
+			},
 			"path": &schema.Schema{
 				Type:         schema.TypeString,
 				Optional:     true,
 				ValidateFunc: validate.InvokeValidator("ibm_cd_tekton_pipeline_trigger_property", "path"),
-				Description:  "A dot notation path for `integration` type properties only, to select a value from the tool integration. If left blank the full tool integration data will be used.",
+				Description:  "A dot notation path for `integration` type properties only, that selects a value from the tool integration. If left blank the full tool integration data will be used.",
 			},
 			"href": &schema.Schema{
 				Type:        schema.TypeString,
@@ -114,13 +114,6 @@ func ResourceIBMCdTektonPipelineTriggerPropertyValidator() *validate.ResourceVal
 			MaxValueLength:             253,
 		},
 		validate.ValidateSchema{
-			Identifier:                 "type",
-			ValidateFunctionIdentifier: validate.ValidateAllowedStringValue,
-			Type:                       validate.TypeString,
-			Required:                   true,
-			AllowedValues:              "appconfig, integration, secure, single_select, text",
-		},
-		validate.ValidateSchema{
 			Identifier:                 "value",
 			ValidateFunctionIdentifier: validate.ValidateRegexpLen,
 			Type:                       validate.TypeString,
@@ -128,6 +121,13 @@ func ResourceIBMCdTektonPipelineTriggerPropertyValidator() *validate.ResourceVal
 			Regexp:                     `^.*$`,
 			MinValueLength:             0,
 			MaxValueLength:             4096,
+		},
+		validate.ValidateSchema{
+			Identifier:                 "type",
+			ValidateFunctionIdentifier: validate.ValidateAllowedStringValue,
+			Type:                       validate.TypeString,
+			Required:                   true,
+			AllowedValues:              "appconfig, integration, secure, single_select, text",
 		},
 		validate.ValidateSchema{
 			Identifier:                 "path",
@@ -218,9 +218,6 @@ func resourceIBMCdTektonPipelineTriggerPropertyRead(context context.Context, d *
 	if err = d.Set("name", triggerProperty.Name); err != nil {
 		return diag.FromErr(fmt.Errorf("Error setting name: %s", err))
 	}
-	if err = d.Set("type", triggerProperty.Type); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting type: %s", err))
-	}
 	if !core.IsNil(triggerProperty.Value) {
 		if err = d.Set("value", triggerProperty.Value); err != nil {
 			return diag.FromErr(fmt.Errorf("Error setting value: %s", err))
@@ -230,6 +227,9 @@ func resourceIBMCdTektonPipelineTriggerPropertyRead(context context.Context, d *
 		if err = d.Set("enum", triggerProperty.Enum); err != nil {
 			return diag.FromErr(fmt.Errorf("Error setting enum: %s", err))
 		}
+	}
+	if err = d.Set("type", triggerProperty.Type); err != nil {
+		return diag.FromErr(fmt.Errorf("Error setting type: %s", err))
 	}
 	if !core.IsNil(triggerProperty.Path) {
 		if err = d.Set("path", triggerProperty.Path); err != nil {

--- a/ibm/service/cdtektonpipeline/resource_ibm_cd_tekton_pipeline_trigger_property_test.go
+++ b/ibm/service/cdtektonpipeline/resource_ibm_cd_tekton_pipeline_trigger_property_test.go
@@ -41,8 +41,8 @@ func TestAccIBMCdTektonPipelineTriggerPropertyBasic(t *testing.T) {
 func TestAccIBMCdTektonPipelineTriggerPropertyAllArgs(t *testing.T) {
 	var conf cdtektonpipelinev2.TriggerProperty
 	name := fmt.Sprintf("tf_name_%d", acctest.RandIntRange(10, 100))
-	typeVar := "text"
 	value := fmt.Sprintf("tf_value_%d", acctest.RandIntRange(10, 100))
+	typeVar := "text"
 	path := fmt.Sprintf("tf_path_%d", acctest.RandIntRange(10, 100))
 	valueUpdate := fmt.Sprintf("tf_value_%d", acctest.RandIntRange(10, 100))
 	pathUpdate := fmt.Sprintf("tf_path_%d", acctest.RandIntRange(10, 100))
@@ -53,20 +53,20 @@ func TestAccIBMCdTektonPipelineTriggerPropertyAllArgs(t *testing.T) {
 		CheckDestroy: testAccCheckIBMCdTektonPipelineTriggerPropertyDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
-				Config: testAccCheckIBMCdTektonPipelineTriggerPropertyConfig("", "", name, typeVar, value, path),
+				Config: testAccCheckIBMCdTektonPipelineTriggerPropertyConfig("", "", name, value, typeVar, path),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckIBMCdTektonPipelineTriggerPropertyExists("ibm_cd_tekton_pipeline_trigger_property.cd_tekton_pipeline_trigger_property", conf),
 					resource.TestCheckResourceAttr("ibm_cd_tekton_pipeline_trigger_property.cd_tekton_pipeline_trigger_property", "name", name),
-					resource.TestCheckResourceAttr("ibm_cd_tekton_pipeline_trigger_property.cd_tekton_pipeline_trigger_property", "type", typeVar),
 					resource.TestCheckResourceAttr("ibm_cd_tekton_pipeline_trigger_property.cd_tekton_pipeline_trigger_property", "value", value),
+					resource.TestCheckResourceAttr("ibm_cd_tekton_pipeline_trigger_property.cd_tekton_pipeline_trigger_property", "type", typeVar),
 				),
 			},
 			resource.TestStep{
-				Config: testAccCheckIBMCdTektonPipelineTriggerPropertyConfig("", "", name, typeVar, valueUpdate, pathUpdate),
+				Config: testAccCheckIBMCdTektonPipelineTriggerPropertyConfig("", "", name, valueUpdate, typeVar, pathUpdate),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr("ibm_cd_tekton_pipeline_trigger_property.cd_tekton_pipeline_trigger_property", "name", name),
-					resource.TestCheckResourceAttr("ibm_cd_tekton_pipeline_trigger_property.cd_tekton_pipeline_trigger_property", "type", typeVar),
 					resource.TestCheckResourceAttr("ibm_cd_tekton_pipeline_trigger_property.cd_tekton_pipeline_trigger_property", "value", valueUpdate),
+					resource.TestCheckResourceAttr("ibm_cd_tekton_pipeline_trigger_property.cd_tekton_pipeline_trigger_property", "type", typeVar),
 				),
 			},
 			resource.TestStep{
@@ -147,7 +147,7 @@ func testAccCheckIBMCdTektonPipelineTriggerPropertyConfigBasic(pipelineID string
 	`, rgName, tcName)
 }
 
-func testAccCheckIBMCdTektonPipelineTriggerPropertyConfig(pipelineID string, triggerID string, name string, typeVar string, value string, path string) string {
+func testAccCheckIBMCdTektonPipelineTriggerPropertyConfig(pipelineID string, triggerID string, name string, value string, typeVar string, path string) string {
 	rgName := acc.CdResourceGroupName
 	tcName := fmt.Sprintf("tf_name_%d", acctest.RandIntRange(10, 100))
 	return fmt.Sprintf(`

--- a/ibm/service/cdtektonpipeline/resource_ibm_cd_tekton_pipeline_trigger_test.go
+++ b/ibm/service/cdtektonpipeline/resource_ibm_cd_tekton_pipeline_trigger_test.go
@@ -62,6 +62,7 @@ func TestAccIBMCdTektonPipelineTriggerAllArgs(t *testing.T) {
 	eventListener := "listener"
 	maxConcurrentRuns := fmt.Sprintf("%d", acctest.RandIntRange(3, 4))
 	enabled := "false"
+	favorite := "false"
 	cron := fmt.Sprintf("*/5 10 10 %d *", acctest.RandIntRange(1, 12))
 	timezone := "Europe/London"
 	typeVarUpdate := "generic"
@@ -69,6 +70,7 @@ func TestAccIBMCdTektonPipelineTriggerAllArgs(t *testing.T) {
 	eventListenerUpdate := fmt.Sprintf("tf_event_listener_%d", acctest.RandIntRange(10, 100))
 	maxConcurrentRunsUpdate := fmt.Sprintf("%d", acctest.RandIntRange(1, 2))
 	enabledUpdate := "true"
+	favoriteUpdate := "true"
 	cronUpdate := fmt.Sprintf("*/10 %d 10 10 *", acctest.RandIntRange(1, 23))
 	timezoneUpdate := "America/New_York"
 
@@ -78,7 +80,7 @@ func TestAccIBMCdTektonPipelineTriggerAllArgs(t *testing.T) {
 		CheckDestroy: testAccCheckIBMCdTektonPipelineTriggerDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
-				Config: testAccCheckIBMCdTektonPipelineTriggerConfig(pipelineID, typeVar, name, eventListener, maxConcurrentRuns, enabled, cron, timezone),
+				Config: testAccCheckIBMCdTektonPipelineTriggerConfig(pipelineID, typeVar, name, eventListener, maxConcurrentRuns, enabled, favorite, cron, timezone),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckIBMCdTektonPipelineTriggerExists("ibm_cd_tekton_pipeline_trigger.cd_tekton_pipeline_trigger", conf),
 					testAccCheckIBMCdTektonPipelineTriggerExists("ibm_cd_tekton_pipeline_trigger.cd_tekton_pipeline_trigger2", conf),
@@ -86,6 +88,7 @@ func TestAccIBMCdTektonPipelineTriggerAllArgs(t *testing.T) {
 					resource.TestCheckResourceAttr("ibm_cd_tekton_pipeline_trigger.cd_tekton_pipeline_trigger", "name", name),
 					resource.TestCheckResourceAttr("ibm_cd_tekton_pipeline_trigger.cd_tekton_pipeline_trigger", "max_concurrent_runs", maxConcurrentRuns),
 					resource.TestCheckResourceAttr("ibm_cd_tekton_pipeline_trigger.cd_tekton_pipeline_trigger", "enabled", enabled),
+					resource.TestCheckResourceAttr("ibm_cd_tekton_pipeline_trigger.cd_tekton_pipeline_trigger", "favorite", favorite),
 					resource.TestCheckResourceAttr("ibm_cd_tekton_pipeline_trigger.cd_tekton_pipeline_trigger2", "cron", cron),
 					resource.TestCheckResourceAttr("ibm_cd_tekton_pipeline_trigger.cd_tekton_pipeline_trigger2", "timezone", timezone),
 					resource.TestCheckResourceAttrSet("ibm_cd_tekton_pipeline_trigger.cd_tekton_pipeline_trigger", "pipeline_id"),
@@ -103,11 +106,12 @@ func TestAccIBMCdTektonPipelineTriggerAllArgs(t *testing.T) {
 				),
 			},
 			resource.TestStep{
-				Config: testAccCheckIBMCdTektonPipelineTriggerConfig(pipelineID, typeVarUpdate, nameUpdate, eventListenerUpdate, maxConcurrentRunsUpdate, enabledUpdate, cronUpdate, timezoneUpdate),
+				Config: testAccCheckIBMCdTektonPipelineTriggerConfig(pipelineID, typeVarUpdate, nameUpdate, eventListenerUpdate, maxConcurrentRunsUpdate, enabledUpdate, favoriteUpdate, cronUpdate, timezoneUpdate),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr("ibm_cd_tekton_pipeline_trigger.cd_tekton_pipeline_trigger", "name", nameUpdate),
 					resource.TestCheckResourceAttr("ibm_cd_tekton_pipeline_trigger.cd_tekton_pipeline_trigger", "max_concurrent_runs", maxConcurrentRunsUpdate),
 					resource.TestCheckResourceAttr("ibm_cd_tekton_pipeline_trigger.cd_tekton_pipeline_trigger", "enabled", enabledUpdate),
+					resource.TestCheckResourceAttr("ibm_cd_tekton_pipeline_trigger.cd_tekton_pipeline_trigger", "favorite", favoriteUpdate),
 					resource.TestCheckResourceAttr("ibm_cd_tekton_pipeline_trigger.cd_tekton_pipeline_trigger2", "cron", cronUpdate),
 					resource.TestCheckResourceAttr("ibm_cd_tekton_pipeline_trigger.cd_tekton_pipeline_trigger2", "timezone", timezoneUpdate),
 					resource.TestCheckResourceAttrSet("ibm_cd_tekton_pipeline_trigger.cd_tekton_pipeline_trigger", "pipeline_id"),
@@ -195,7 +199,7 @@ func testAccCheckIBMCdTektonPipelineTriggerConfigBasic(pipelineID string, typeVa
 	`, rgName, tcName, typeVar, name, eventListener)
 }
 
-func testAccCheckIBMCdTektonPipelineTriggerConfig(pipelineID string, typeVar string, name string, eventListener string, maxConcurrentRuns string, enabled string, cron string, timezone string) string {
+func testAccCheckIBMCdTektonPipelineTriggerConfig(pipelineID string, typeVar string, name string, eventListener string, maxConcurrentRuns string, enabled string, favorite string, cron string, timezone string) string {
 	rgName := acc.CdResourceGroupName
 	tcName := fmt.Sprintf("tf_name_%d", acctest.RandIntRange(10, 100))
 	return fmt.Sprintf(`
@@ -256,6 +260,7 @@ func testAccCheckIBMCdTektonPipelineTriggerConfig(pipelineID string, typeVar str
 			tags = [ "tag1", "tag2" ]
 			max_concurrent_runs = %s
 			enabled = %s
+			favorite = %s
 		}
 		resource "ibm_cd_tekton_pipeline_trigger" "cd_tekton_pipeline_trigger2" {
 			pipeline_id = ibm_cd_toolchain_tool_pipeline.ibm_cd_toolchain_tool_pipeline.tool_id
@@ -284,7 +289,7 @@ func testAccCheckIBMCdTektonPipelineTriggerConfig(pipelineID string, typeVar str
 				algorithm = "md4"
 			}
 		}
-	`, rgName, tcName, name, maxConcurrentRuns, enabled, cron, timezone)
+	`, rgName, tcName, name, maxConcurrentRuns, enabled, favorite, cron, timezone)
 }
 
 func testAccCheckIBMCdTektonPipelineTriggerExists(n string, obj cdtektonpipelinev2.Trigger) resource.TestCheckFunc {

--- a/website/docs/d/cd_tekton_pipeline.html.markdown
+++ b/website/docs/d/cd_tekton_pipeline.html.markdown
@@ -8,7 +8,7 @@ subcategory: "Continuous Delivery"
 
 # ibm_cd_tekton_pipeline
 
-Provides a read-only data source for cd_tekton_pipeline. You can then reference the fields of the data source in other resources within the same configuration using interpolation syntax.
+Provides a read-only data source to retrieve information about a cd_tekton_pipeline. You can then reference the fields of the data source in other resources within the same configuration by using interpolation syntax.
 
 ## Example Usage
 
@@ -20,14 +20,14 @@ data "ibm_cd_tekton_pipeline" "cd_tekton_pipeline" {
 
 ## Argument Reference
 
-Review the argument reference that you can specify for your data source.
+You can specify the following arguments for this data source.
 
 * `pipeline_id` - (Required, Forces new resource, String) ID of current instance.
   * Constraints: The maximum length is `36` characters. The minimum length is `36` characters. The value must match regular expression `/^[-0-9a-z]+$/`.
 
 ## Attribute Reference
 
-In addition to all argument references listed, you can access the following attribute references after your data source is created.
+After your data source is created, you can read values from the following attributes.
 
 * `id` - The unique identifier of the cd_tekton_pipeline.
 * `build_number` - (Integer) The latest pipeline run build number. If this property is absent, the pipeline hasn't had any pipeline runs.
@@ -37,15 +37,15 @@ In addition to all argument references listed, you can access the following attr
 
 * `definitions` - (List) Definition list.
   * Constraints: The maximum length is `128` items. The minimum length is `0` items.
-Nested scheme for **definitions**:
+Nested schema for **definitions**:
 	* `href` - (String) API URL for interacting with the definition.
 	  * Constraints: The maximum length is `2048` characters. The minimum length is `10` characters. The value must match regular expression `/^http(s)?:\/\/([^\/?#]*)([^?#]*)(\\?([^#]*))?(#(.*))?$/`.
 	* `id` - (String) The aggregated definition ID.
 	  * Constraints: The maximum length is `36` characters. The minimum length is `36` characters. The value must match regular expression `/^[-0-9a-z]+$/`.
 	* `source` - (List) Source repository containing the Tekton pipeline definition.
-	Nested scheme for **source**:
+	Nested schema for **source**:
 		* `properties` - (List) Properties of the source, which define the URL of the repository and a branch or tag.
-		Nested scheme for **properties**:
+		Nested schema for **properties**:
 			* `branch` - (String) A branch from the repo, specify one of branch or tag only.
 			  * Constraints: The maximum length is `253` characters. The minimum length is `1` character. The value must match regular expression `/^[-0-9a-zA-Z_.]{1,253}$/`.
 			* `path` - (String) The path to the definition's YAML files.
@@ -53,7 +53,7 @@ Nested scheme for **definitions**:
 			* `tag` - (String) A tag from the repo, specify one of branch or tag only.
 			  * Constraints: The maximum length is `253` characters. The minimum length is `1` character. The value must match regular expression `/^[-0-9a-zA-Z_]{1,253}$/`.
 			* `tool` - (List) Reference to the repository tool in the parent toolchain.
-			Nested scheme for **tool**:
+			Nested schema for **tool**:
 				* `id` - (String) ID of the repository tool instance in the parent toolchain.
 				  * Constraints: The maximum length is `36` characters. The minimum length is `36` characters. The value must match regular expression `/^[-0-9a-z]+$/`.
 			* `url` - (Forces new resource, String) URL of the definition repository.
@@ -79,7 +79,7 @@ Nested scheme for **definitions**:
 
 * `properties` - (List) Tekton pipeline's environment properties.
   * Constraints: The maximum length is `1024` items. The minimum length is `0` items.
-Nested scheme for **properties**:
+Nested schema for **properties**:
 	* `enum` - (List) Options for `single_select` property type. Only needed when using `single_select` property type.
 	  * Constraints: The list items must match regular expression `/^[-0-9a-zA-Z_.]{1,253}$/`. The maximum length is `256` items. The minimum length is `0` items.
 	* `href` - (String) API URL for interacting with the property.
@@ -94,7 +94,7 @@ Nested scheme for **properties**:
 	  * Constraints: The maximum length is `4096` characters. The minimum length is `0` characters. The value must match regular expression `/^.*$/`.
 
 * `resource_group` - (List) The resource group in which the pipeline was created.
-Nested scheme for **resource_group**:
+Nested schema for **resource_group**:
 	* `id` - (String) ID.
 	  * Constraints: The maximum length is `64` characters. The minimum length is `1` character. The value must match regular expression `/^[-0-9a-zA-Z_]+$/`.
 
@@ -105,7 +105,7 @@ Nested scheme for **resource_group**:
   * Constraints: Allowable values are: `configured`, `configuring`.
 
 * `toolchain` - (List) Toolchain object containing references to the parent toolchain.
-Nested scheme for **toolchain**:
+Nested schema for **toolchain**:
 	* `crn` - (String) The CRN for the toolchain that contains the Tekton pipeline.
 	  * Constraints: The maximum length is `512` characters. The minimum length is `9` characters. The value must match regular expression `/^crn:v[0-9](:([A-Za-z0-9-._~!$&'()*+,;=@\/]|%[0-9A-Z]{2})*){8}$/`.
 	* `id` - (String) UUID.
@@ -113,7 +113,7 @@ Nested scheme for **toolchain**:
 
 * `triggers` - (List) Tekton pipeline triggers list.
   * Constraints: The maximum length is `1024` items. The minimum length is `0` items.
-Nested scheme for **triggers**:
+Nested schema for **triggers**:
 	* `cron` - (String) Only needed for timer triggers. Cron expression that indicates when this trigger will activate. Maximum frequency is every 5 minutes. The string is based on UNIX crontab syntax: minute, hour, day of month, month, day of week. Example: 0 *_/2 * * * - every 2 hours.
 	  * Constraints: The maximum length is `253` characters. The minimum length is `5` characters. The value must match regular expression `/^[-0-9a-zA-Z,\\*\/ ]{5,253}$/`.
 	* `enabled` - (Boolean) Flag whether the trigger is enabled.
@@ -122,6 +122,8 @@ Nested scheme for **triggers**:
 	  * Constraints: The maximum length is `253` characters. The minimum length is `1` character. The value must match regular expression `/^[-0-9a-zA-Z_.]{1,253}$/`.
 	* `events` - (List) Only needed for Git triggers. List of events to which a Git trigger listens. Choose one or more from: 'push', 'pull_request' and 'pull_request_closed'. For SCM repositories that use 'merge request' events, such events map to the equivalent 'pull request' events.
 	  * Constraints: Allowable list items are: `push`, `pull_request`, `pull_request_closed`. The maximum length is `3` items. The minimum length is `0` items.
+	* `favorite` - (Boolean) Mark the trigger as a favorite.
+	  * Constraints: The default value is `false`.
 	* `href` - (String) API URL for interacting with the trigger. Only included when fetching the list of pipeline triggers.
 	  * Constraints: The maximum length is `2048` characters. The minimum length is `10` characters. The value must match regular expression `/^http(s)?:\/\/([^\/?#]*)([^?#]*)(\\?([^#]*))?(#(.*))?$/`.
 	* `id` - (String) The Trigger ID.
@@ -131,7 +133,7 @@ Nested scheme for **triggers**:
 	  * Constraints: The maximum length is `253` characters. The minimum length is `1` character. The value must match regular expression `/^([a-zA-Z0-9]{1,2}|[a-zA-Z0-9][0-9a-zA-Z-_.: \/\\(\\)\\[\\]]{1,251}[a-zA-Z0-9])$/`.
 	* `properties` - (List) Optional trigger properties used to override or supplement the pipeline properties when triggering a pipeline run.
 	  * Constraints: The maximum length is `1024` items. The minimum length is `0` items.
-	Nested scheme for **properties**:
+	Nested schema for **properties**:
 		* `enum` - (List) Options for `single_select` property type. Only needed for `single_select` property type.
 		  * Constraints: The list items must match regular expression `/^[-0-9a-zA-Z_.]{1,253}$/`. The maximum length is `256` items. The minimum length is `0` items.
 		* `href` - (String) API URL for interacting with the trigger property.
@@ -145,7 +147,7 @@ Nested scheme for **triggers**:
 		* `value` - (String) Property value. Any string value is valid.
 		  * Constraints: The maximum length is `4096` characters. The minimum length is `0` characters. The value must match regular expression `/^.*$/`.
 	* `secret` - (List) Only needed for generic webhook trigger type. Secret used to start generic webhook trigger.
-	Nested scheme for **secret**:
+	Nested schema for **secret**:
 		* `algorithm` - (String) Algorithm used for `digest_matches` secret type. Only needed for `digest_matches` secret type.
 		  * Constraints: Allowable values are: `md4`, `md5`, `sha1`, `sha256`, `sha384`, `sha512`, `sha512_224`, `sha512_256`, `ripemd160`.
 		* `key_name` - (String) Secret name, not needed if type is `internal_validation`.
@@ -157,9 +159,9 @@ Nested scheme for **triggers**:
 		* `value` - (String) Secret value, not needed if secret type is `internal_validation`.
 		  * Constraints: The maximum length is `4096` characters. The minimum length is `0` characters. The value must match regular expression `/^.*$/`.
 	* `source` - (List) Source repository for a Git trigger. Only required for Git triggers. The referenced repository URL must match the URL of a repository tool integration in the parent toolchain. Obtain the list of integrations from the toolchain API https://cloud.ibm.com/apidocs/toolchain#list-tools.
-	Nested scheme for **source**:
+	Nested schema for **source**:
 		* `properties` - (List) Properties of the source, which define the URL of the repository and a branch or pattern.
-		Nested scheme for **properties**:
+		Nested schema for **properties**:
 			* `blind_connection` - (Boolean) True if the repository server is not addressable on the public internet. IBM Cloud will not be able to validate the connection details you provide.
 			* `branch` - (String) Name of a branch from the repo. One of branch or pattern must be specified, but only one or the other.
 			  * Constraints: The maximum length is `253` characters. The minimum length is `1` character. The value must match regular expression `/^[-0-9a-zA-Z_.]{1,253}$/`.
@@ -168,7 +170,7 @@ Nested scheme for **triggers**:
 			* `pattern` - (String) The pattern of Git branch or tag to which to listen. You can specify a glob pattern such as '!test' or '*master' to match against multiple tags/branches in the repository. The glob pattern used must conform to Bash 4.3 specifications, see bash documentation for more info: https://www.gnu.org/software/bash/manual/bash.html#Pattern-Matching. One of branch or pattern must be specified, but only one or the other.
 			  * Constraints: The maximum length is `253` characters. The minimum length is `1` character. The value must match regular expression `/^[-0-9a-zA-Z_.:@=$&^\/\\?\\!\\*\\+\\[\\]\\(\\)\\{\\}\\|\\\\]*$/`.
 			* `tool` - (List) Reference to the repository tool in the parent toolchain.
-			Nested scheme for **tool**:
+			Nested schema for **tool**:
 				* `id` - (String) ID of the repository tool instance in the parent toolchain.
 				  * Constraints: The maximum length is `36` characters. The minimum length is `36` characters. The value must match regular expression `/^[-0-9a-z]+$/`.
 			* `url` - (Forces new resource, String) URL of the repository to which the trigger is listening.
@@ -183,8 +185,8 @@ Nested scheme for **triggers**:
 	  * Constraints: Allowable values are: `manual`, `scm`, `timer`, `generic`.
 	* `webhook_url` - (String) Webhook URL that can be used to trigger pipeline runs.
 	  * Constraints: The maximum length is `2048` characters. The minimum length is `10` characters. The value must match regular expression `/^http(s)?:\/\/([^\/?#]*)([^?#]*)(\\?([^#]*))?(#(.*))?$/`.
-	* `worker` - (List) Worker used to run the trigger. If not specified the trigger will use the default pipeline worker.
-	Nested scheme for **worker**:
+	* `worker` - (List) Details of the worker used to run the trigger.
+	Nested schema for **worker**:
 		* `id` - (String) ID of the worker.
 		  * Constraints: The maximum length is `36` characters. The minimum length is `1` character. The value must match regular expression `/^[-0-9a-zA-Z]{1,36}$/`.
 		* `name` - (String) Name of the worker. Computed based on the worker ID.
@@ -194,8 +196,8 @@ Nested scheme for **triggers**:
 
 * `updated_at` - (String) Standard RFC 3339 Date Time String.
 
-* `worker` - (List) Default pipeline worker used to run the pipeline.
-Nested scheme for **worker**:
+* `worker` - (List) Details of the worker used to run the pipeline.
+Nested schema for **worker**:
 	* `id` - (String) ID of the worker.
 	  * Constraints: The maximum length is `36` characters. The minimum length is `1` character. The value must match regular expression `/^[-0-9a-zA-Z]{1,36}$/`.
 	* `name` - (String) Name of the worker. Computed based on the worker ID.

--- a/website/docs/d/cd_tekton_pipeline_definition.html.markdown
+++ b/website/docs/d/cd_tekton_pipeline_definition.html.markdown
@@ -8,7 +8,7 @@ subcategory: "Continuous Delivery"
 
 # ibm_cd_tekton_pipeline_definition
 
-Provides a read-only data source for cd_tekton_pipeline_definition. You can then reference the fields of the data source in other resources within the same configuration using interpolation syntax.
+Provides a read-only data source to retrieve information about a cd_tekton_pipeline_definition. You can then reference the fields of the data source in other resources within the same configuration by using interpolation syntax.
 
 ## Example Usage
 
@@ -21,7 +21,7 @@ data "ibm_cd_tekton_pipeline_definition" "cd_tekton_pipeline_definition" {
 
 ## Argument Reference
 
-Review the argument reference that you can specify for your data source.
+You can specify the following arguments for this data source.
 
 * `definition_id` - (Required, Forces new resource, String) The definition ID.
   * Constraints: The maximum length is `36` characters. The minimum length is `36` characters. The value must match regular expression `/^[-0-9a-z]+$/`.
@@ -30,16 +30,16 @@ Review the argument reference that you can specify for your data source.
 
 ## Attribute Reference
 
-In addition to all argument references listed, you can access the following attribute references after your data source is created.
+After your data source is created, you can read values from the following attributes.
 
 * `id` - The unique identifier of the cd_tekton_pipeline_definition.
 * `href` - (String) API URL for interacting with the definition.
   * Constraints: The maximum length is `2048` characters. The minimum length is `10` characters. The value must match regular expression `/^http(s)?:\/\/([^\/?#]*)([^?#]*)(\\?([^#]*))?(#(.*))?$/`.
 
 * `source` - (List) Source repository containing the Tekton pipeline definition.
-Nested scheme for **source**:
+Nested schema for **source**:
 	* `properties` - (List) Properties of the source, which define the URL of the repository and a branch or tag.
-	Nested scheme for **properties**:
+	Nested schema for **properties**:
 		* `branch` - (String) A branch from the repo, specify one of branch or tag only.
 		  * Constraints: The maximum length is `253` characters. The minimum length is `1` character. The value must match regular expression `/^[-0-9a-zA-Z_.]{1,253}$/`.
 		* `path` - (String) The path to the definition's YAML files.
@@ -47,7 +47,7 @@ Nested scheme for **source**:
 		* `tag` - (String) A tag from the repo, specify one of branch or tag only.
 		  * Constraints: The maximum length is `253` characters. The minimum length is `1` character. The value must match regular expression `/^[-0-9a-zA-Z_]{1,253}$/`.
 		* `tool` - (List) Reference to the repository tool in the parent toolchain.
-		Nested scheme for **tool**:
+		Nested schema for **tool**:
 			* `id` - (String) ID of the repository tool instance in the parent toolchain.
 			  * Constraints: The maximum length is `36` characters. The minimum length is `36` characters. The value must match regular expression `/^[-0-9a-z]+$/`.
 		* `url` - (Forces new resource, String) URL of the definition repository.

--- a/website/docs/d/cd_tekton_pipeline_property.html.markdown
+++ b/website/docs/d/cd_tekton_pipeline_property.html.markdown
@@ -8,7 +8,7 @@ subcategory: "Continuous Delivery"
 
 # ibm_cd_tekton_pipeline_property
 
-Provides a read-only data source for cd_tekton_pipeline_property. You can then reference the fields of the data source in other resources within the same configuration using interpolation syntax.
+Provides a read-only data source to retrieve information about a cd_tekton_pipeline_property. You can then reference the fields of the data source in other resources within the same configuration by using interpolation syntax.
 
 ## Example Usage
 
@@ -21,7 +21,7 @@ data "ibm_cd_tekton_pipeline_property" "cd_tekton_pipeline_property" {
 
 ## Argument Reference
 
-Review the argument reference that you can specify for your data source.
+You can specify the following arguments for this data source.
 
 * `pipeline_id` - (Required, Forces new resource, String) The Tekton pipeline ID.
   * Constraints: The maximum length is `36` characters. The minimum length is `36` characters. The value must match regular expression `/^[-0-9a-z]+$/`.
@@ -30,7 +30,7 @@ Review the argument reference that you can specify for your data source.
 
 ## Attribute Reference
 
-In addition to all argument references listed, you can access the following attribute references after your data source is created.
+After your data source is created, you can read values from the following attributes.
 
 * `id` - The unique identifier of the cd_tekton_pipeline_property.
 * `enum` - (List) Options for `single_select` property type. Only needed when using `single_select` property type.

--- a/website/docs/d/cd_tekton_pipeline_trigger.html.markdown
+++ b/website/docs/d/cd_tekton_pipeline_trigger.html.markdown
@@ -8,7 +8,7 @@ subcategory: "Continuous Delivery"
 
 # ibm_cd_tekton_pipeline_trigger
 
-Provides a read-only data source for cd_tekton_pipeline_trigger. You can then reference the fields of the data source in other resources within the same configuration using interpolation syntax.
+Provides a read-only data source to retrieve information about a cd_tekton_pipeline_trigger. You can then reference the fields of the data source in other resources within the same configuration by using interpolation syntax.
 
 ## Example Usage
 
@@ -21,7 +21,7 @@ data "ibm_cd_tekton_pipeline_trigger" "cd_tekton_pipeline_trigger" {
 
 ## Argument Reference
 
-Review the argument reference that you can specify for your data source.
+You can specify the following arguments for this data source.
 
 * `pipeline_id` - (Required, Forces new resource, String) The Tekton pipeline ID.
   * Constraints: The maximum length is `36` characters. The minimum length is `36` characters. The value must match regular expression `/^[-0-9a-z]+$/`.
@@ -30,7 +30,7 @@ Review the argument reference that you can specify for your data source.
 
 ## Attribute Reference
 
-In addition to all argument references listed, you can access the following attribute references after your data source is created.
+After your data source is created, you can read values from the following attributes.
 
 * `id` - The unique identifier of the cd_tekton_pipeline_trigger.
 * `cron` - (String) Only needed for timer triggers. Cron expression that indicates when this trigger will activate. Maximum frequency is every 5 minutes. The string is based on UNIX crontab syntax: minute, hour, day of month, month, day of week. Example: 0 *_/2 * * * - every 2 hours.
@@ -45,6 +45,9 @@ In addition to all argument references listed, you can access the following attr
 * `events` - (List) Only needed for Git triggers. List of events to which a Git trigger listens. Choose one or more from: 'push', 'pull_request' and 'pull_request_closed'. For SCM repositories that use 'merge request' events, such events map to the equivalent 'pull request' events.
   * Constraints: Allowable list items are: `push`, `pull_request`, `pull_request_closed`. The maximum length is `3` items. The minimum length is `0` items.
 
+* `favorite` - (Boolean) Mark the trigger as a favorite.
+  * Constraints: The default value is `false`.
+
 * `href` - (String) API URL for interacting with the trigger. Only included when fetching the list of pipeline triggers.
   * Constraints: The maximum length is `2048` characters. The minimum length is `10` characters. The value must match regular expression `/^http(s)?:\/\/([^\/?#]*)([^?#]*)(\\?([^#]*))?(#(.*))?$/`.
 
@@ -55,7 +58,7 @@ In addition to all argument references listed, you can access the following attr
 
 * `properties` - (List) Optional trigger properties used to override or supplement the pipeline properties when triggering a pipeline run.
   * Constraints: The maximum length is `1024` items. The minimum length is `0` items.
-Nested scheme for **properties**:
+Nested schema for **properties**:
 	* `enum` - (List) Options for `single_select` property type. Only needed for `single_select` property type.
 	  * Constraints: The list items must match regular expression `/^[-0-9a-zA-Z_.]{1,253}$/`. The maximum length is `256` items. The minimum length is `0` items.
 	* `href` - (String) API URL for interacting with the trigger property.
@@ -70,7 +73,7 @@ Nested scheme for **properties**:
 	  * Constraints: The maximum length is `4096` characters. The minimum length is `0` characters. The value must match regular expression `/^.*$/`.
 
 * `secret` - (List) Only needed for generic webhook trigger type. Secret used to start generic webhook trigger.
-Nested scheme for **secret**:
+Nested schema for **secret**:
 	* `algorithm` - (String) Algorithm used for `digest_matches` secret type. Only needed for `digest_matches` secret type.
 	  * Constraints: Allowable values are: `md4`, `md5`, `sha1`, `sha256`, `sha384`, `sha512`, `sha512_224`, `sha512_256`, `ripemd160`.
 	* `key_name` - (String) Secret name, not needed if type is `internal_validation`.
@@ -83,9 +86,9 @@ Nested scheme for **secret**:
 	  * Constraints: The maximum length is `4096` characters. The minimum length is `0` characters. The value must match regular expression `/^.*$/`.
 
 * `source` - (List) Source repository for a Git trigger. Only required for Git triggers. The referenced repository URL must match the URL of a repository tool integration in the parent toolchain. Obtain the list of integrations from the toolchain API https://cloud.ibm.com/apidocs/toolchain#list-tools.
-Nested scheme for **source**:
+Nested schema for **source**:
 	* `properties` - (List) Properties of the source, which define the URL of the repository and a branch or pattern.
-	Nested scheme for **properties**:
+	Nested schema for **properties**:
 		* `blind_connection` - (Boolean) True if the repository server is not addressable on the public internet. IBM Cloud will not be able to validate the connection details you provide.
 		* `branch` - (String) Name of a branch from the repo. One of branch or pattern must be specified, but only one or the other.
 		  * Constraints: The maximum length is `253` characters. The minimum length is `1` character. The value must match regular expression `/^[-0-9a-zA-Z_.]{1,253}$/`.
@@ -94,7 +97,7 @@ Nested scheme for **source**:
 		* `pattern` - (String) The pattern of Git branch or tag to which to listen. You can specify a glob pattern such as '!test' or '*master' to match against multiple tags/branches in the repository. The glob pattern used must conform to Bash 4.3 specifications, see bash documentation for more info: https://www.gnu.org/software/bash/manual/bash.html#Pattern-Matching. One of branch or pattern must be specified, but only one or the other.
 		  * Constraints: The maximum length is `253` characters. The minimum length is `1` character. The value must match regular expression `/^[-0-9a-zA-Z_.:@=$&^\/\\?\\!\\*\\+\\[\\]\\(\\)\\{\\}\\|\\\\]*$/`.
 		* `tool` - (List) Reference to the repository tool in the parent toolchain.
-		Nested scheme for **tool**:
+		Nested schema for **tool**:
 			* `id` - (String) ID of the repository tool instance in the parent toolchain.
 			  * Constraints: The maximum length is `36` characters. The minimum length is `36` characters. The value must match regular expression `/^[-0-9a-z]+$/`.
 		* `url` - (Forces new resource, String) URL of the repository to which the trigger is listening.
@@ -114,8 +117,8 @@ Nested scheme for **source**:
 * `webhook_url` - (String) Webhook URL that can be used to trigger pipeline runs.
   * Constraints: The maximum length is `2048` characters. The minimum length is `10` characters. The value must match regular expression `/^http(s)?:\/\/([^\/?#]*)([^?#]*)(\\?([^#]*))?(#(.*))?$/`.
 
-* `worker` - (List) Worker used to run the trigger. If not specified the trigger will use the default pipeline worker.
-Nested scheme for **worker**:
+* `worker` - (List) Details of the worker used to run the trigger.
+Nested schema for **worker**:
 	* `id` - (String) ID of the worker.
 	  * Constraints: The maximum length is `36` characters. The minimum length is `1` character. The value must match regular expression `/^[-0-9a-zA-Z]{1,36}$/`.
 	* `name` - (String) Name of the worker. Computed based on the worker ID.

--- a/website/docs/d/cd_tekton_pipeline_trigger_property.html.markdown
+++ b/website/docs/d/cd_tekton_pipeline_trigger_property.html.markdown
@@ -8,7 +8,7 @@ subcategory: "Continuous Delivery"
 
 # ibm_cd_tekton_pipeline_trigger_property
 
-Provides a read-only data source for cd_tekton_pipeline_trigger_property. You can then reference the fields of the data source in other resources within the same configuration using interpolation syntax.
+Provides a read-only data source to retrieve information about a cd_tekton_pipeline_trigger_property. You can then reference the fields of the data source in other resources within the same configuration by using interpolation syntax.
 
 ## Example Usage
 
@@ -22,7 +22,7 @@ data "ibm_cd_tekton_pipeline_trigger_property" "cd_tekton_pipeline_trigger_prope
 
 ## Argument Reference
 
-Review the argument reference that you can specify for your data source.
+You can specify the following arguments for this data source.
 
 * `pipeline_id` - (Required, Forces new resource, String) The Tekton pipeline ID.
   * Constraints: The maximum length is `36` characters. The minimum length is `36` characters. The value must match regular expression `/^[-0-9a-z]+$/`.
@@ -33,7 +33,7 @@ Review the argument reference that you can specify for your data source.
 
 ## Attribute Reference
 
-In addition to all argument references listed, you can access the following attribute references after your data source is created.
+After your data source is created, you can read values from the following attributes.
 
 * `id` - The unique identifier of the cd_tekton_pipeline_trigger_property.
 * `enum` - (List) Options for `single_select` property type. Only needed for `single_select` property type.

--- a/website/docs/r/cd_tekton_pipeline.html.markdown
+++ b/website/docs/r/cd_tekton_pipeline.html.markdown
@@ -8,7 +8,7 @@ subcategory: "Continuous Delivery"
 
 # ibm_cd_tekton_pipeline
 
-Provides a resource for cd_tekton_pipeline. This allows cd_tekton_pipeline to be created, updated and deleted.
+Create, update, and delete cd_tekton_pipelines with this resource.
 
 ## Example Usage
 
@@ -23,24 +23,26 @@ resource "ibm_cd_tekton_pipeline" "cd_tekton_pipeline_instance" {
 
 ## Argument Reference
 
-Review the argument reference that you can specify for your resource.
+You can specify the following arguments for this resource.
 
 * `pipeline_id` - (Required, String) ID of the pipeline tool in your toolchain. Can be referenced from your `ibm_cd_toolchain_tool_pipeline` resource, e.g. `pipeline_id = ibm_cd_toolchain_tool_pipeline.my_pipeline.tool_id`
   * Constraints: The maximum length is `36` characters. The minimum length is `36` characters. The value must match regular expression `/^[-0-9a-z]+$/`.
-* `enable_notifications` - (Optional, Boolean) Flag whether to enable notifications for this pipeline. When enabled, pipeline run events are published on all slack integration specified channels in the parent toolchain.
-  * Constraints: The default value is `false`.
-* `enable_partial_cloning` - (Optional, Boolean) Flag whether to enable partial cloning for this pipeline. When partial clone is enabled, only the files contained within the paths specified in definition repositories are read and cloned, this means that symbolic links might not work.
-  * Constraints: The default value is `false`.
-* `next_build_number` - (Optional, Integer) Specify the build number that will be used for the next pipeline run. Build numbers can be any positive whole number between 0 and 100000000000000.
+* `enable_notifications` - (Optional, Boolean) Flag whether to enable notifications for this pipeline. When enabled, pipeline run events will be published on all slack integration specified channels in the parent toolchain. If omitted, this feature is disabled by default.
+* `enable_partial_cloning` - (Optional, Boolean) Flag whether to enable partial cloning for this pipeline. When partial clone is enabled, only the files contained within the paths specified in definition repositories are read and cloned, this means that symbolic links might not work. If omitted, this feature is disabled by default.
+* `next_build_number` - (Optional, Integer) The build number that will be used for the next pipeline run.
   * Constraints: The maximum value is `99999999999999`. The minimum value is `1`.
-* `worker` - (Optional, List) Worker object containing worker ID only. If omitted the IBM Managed shared workers are used by default.
-Nested scheme for **worker**:
+* `worker` - (Optional, List) Details of the worker used to run the pipeline.
+Nested schema for **worker**:
 	* `id` - (Required, String) ID of the worker.
-	  * Constraints: The maximum length is `253` characters. The minimum length is `1` character. The value must match regular expression `/^[-0-9a-zA-Z]{1,253}$/`.
+	  * Constraints: The maximum length is `36` characters. The minimum length is `1` character. The value must match regular expression `/^[-0-9a-zA-Z]{1,36}$/`.
+	* `name` - (Computed, String) Name of the worker. Computed based on the worker ID.
+	  * Constraints: The maximum length is `253` characters. The minimum length is `1` character. The value must match regular expression `/^[-0-9a-zA-Z_. \\(\\)\\[\\]]{1,253}$/`.
+	* `type` - (Computed, String) Type of the worker. Computed based on the worker ID.
+	  * Constraints: The maximum length is `253` characters. The minimum length is `1` character. The value must match regular expression `/^[-0-9a-zA-Z_.]{1,253}$/`.
 
 ## Attribute Reference
 
-In addition to all argument references listed, you can access the following attribute references after your resource is created.
+After your resource is created, you can read values from the listed arguments and the following attributes.
 
 * `id` - The unique identifier of the cd_tekton_pipeline.
 * `build_number` - (Integer) The latest pipeline run build number. If this property is absent, the pipeline hasn't had any pipeline runs.
@@ -48,15 +50,15 @@ In addition to all argument references listed, you can access the following attr
 * `created_at` - (String) Standard RFC 3339 Date Time String.
 * `definitions` - (List) Definition list.
   * Constraints: The maximum length is `128` items. The minimum length is `0` items.
-Nested scheme for **definitions**:
+Nested schema for **definitions**:
 	* `href` - (String) API URL for interacting with the definition.
 	  * Constraints: The maximum length is `2048` characters. The minimum length is `10` characters. The value must match regular expression `/^http(s)?:\/\/([^\/?#]*)([^?#]*)(\\?([^#]*))?(#(.*))?$/`.
 	* `id` - (String) The aggregated definition ID.
 	  * Constraints: The maximum length is `36` characters. The minimum length is `36` characters. The value must match regular expression `/^[-0-9a-z]+$/`.
 	* `source` - (List) Source repository containing the Tekton pipeline definition.
-	Nested scheme for **source**:
+	Nested schema for **source**:
 		* `properties` - (List) Properties of the source, which define the URL of the repository and a branch or tag.
-		Nested scheme for **properties**:
+		Nested schema for **properties**:
 			* `branch` - (String) A branch from the repo, specify one of branch or tag only.
 			  * Constraints: The maximum length is `253` characters. The minimum length is `1` character. The value must match regular expression `/^[-0-9a-zA-Z_.]{1,253}$/`.
 			* `path` - (String) The path to the definition's YAML files.
@@ -64,7 +66,7 @@ Nested scheme for **definitions**:
 			* `tag` - (String) A tag from the repo, specify one of branch or tag only.
 			  * Constraints: The maximum length is `253` characters. The minimum length is `1` character. The value must match regular expression `/^[-0-9a-zA-Z_]{1,253}$/`.
 			* `tool` - (List) Reference to the repository tool in the parent toolchain.
-			Nested scheme for **tool**:
+			Nested schema for **tool**:
 				* `id` - (String) ID of the repository tool instance in the parent toolchain.
 				  * Constraints: The maximum length is `36` characters. The minimum length is `36` characters. The value must match regular expression `/^[-0-9a-z]+$/`.
 			* `url` - (Forces new resource, String) URL of the definition repository.
@@ -79,7 +81,7 @@ Nested scheme for **definitions**:
   * Constraints: The maximum length is `253` characters. The minimum length is `1` character. The value must match regular expression `/^[a-zA-Z0-9][-0-9a-zA-Z_. ]{1,251}[a-zA-Z0-9]$/`.
 * `properties` - (List) Tekton pipeline's environment properties.
   * Constraints: The maximum length is `1024` items. The minimum length is `0` items.
-Nested scheme for **properties**:
+Nested schema for **properties**:
 	* `enum` - (List) Options for `single_select` property type. Only needed when using `single_select` property type.
 	  * Constraints: The list items must match regular expression `/^[-0-9a-zA-Z_.]{1,253}$/`. The maximum length is `256` items. The minimum length is `0` items.
 	* `href` - (String) API URL for interacting with the property.
@@ -93,7 +95,7 @@ Nested scheme for **properties**:
 	* `value` - (String) Property value. Any string value is valid.
 	  * Constraints: The maximum length is `4096` characters. The minimum length is `0` characters. The value must match regular expression `/^.*$/`.
 * `resource_group` - (List) The resource group in which the pipeline was created.
-Nested scheme for **resource_group**:
+Nested schema for **resource_group**:
 	* `id` - (String) ID.
 	  * Constraints: The maximum length is `64` characters. The minimum length is `1` character. The value must match regular expression `/^[-0-9a-zA-Z_]+$/`.
 * `runs_url` - (String) URL for this pipeline showing the list of pipeline runs.
@@ -101,14 +103,14 @@ Nested scheme for **resource_group**:
 * `status` - (String) Pipeline status.
   * Constraints: Allowable values are: `configured`, `configuring`.
 * `toolchain` - (List) Toolchain object containing references to the parent toolchain.
-Nested scheme for **toolchain**:
+Nested schema for **toolchain**:
 	* `crn` - (String) The CRN for the toolchain that contains the Tekton pipeline.
 	  * Constraints: The maximum length is `512` characters. The minimum length is `9` characters. The value must match regular expression `/^crn:v[0-9](:([A-Za-z0-9-._~!$&'()*+,;=@\/]|%[0-9A-Z]{2})*){8}$/`.
 	* `id` - (String) UUID.
 	  * Constraints: The maximum length is `36` characters. The minimum length is `36` characters. The value must match regular expression `/^[-0-9a-z]+$/`.
 * `triggers` - (List) Tekton pipeline triggers list.
   * Constraints: The maximum length is `1024` items. The minimum length is `0` items.
-Nested scheme for **triggers**:
+Nested schema for **triggers**:
 	* `cron` - (String) Only needed for timer triggers. Cron expression that indicates when this trigger will activate. Maximum frequency is every 5 minutes. The string is based on UNIX crontab syntax: minute, hour, day of month, month, day of week. Example: 0 *_/2 * * * - every 2 hours.
 	  * Constraints: The maximum length is `253` characters. The minimum length is `5` characters. The value must match regular expression `/^[-0-9a-zA-Z,\\*\/ ]{5,253}$/`.
 	* `enabled` - (Boolean) Flag whether the trigger is enabled.
@@ -117,6 +119,8 @@ Nested scheme for **triggers**:
 	  * Constraints: The maximum length is `253` characters. The minimum length is `1` character. The value must match regular expression `/^[-0-9a-zA-Z_.]{1,253}$/`.
 	* `events` - (List) Only needed for Git triggers. List of events to which a Git trigger listens. Choose one or more from: 'push', 'pull_request' and 'pull_request_closed'. For SCM repositories that use 'merge request' events, such events map to the equivalent 'pull request' events.
 	  * Constraints: Allowable list items are: `push`, `pull_request`, `pull_request_closed`. The maximum length is `3` items. The minimum length is `0` items.
+	* `favorite` - (Boolean) Mark the trigger as a favorite.
+	  * Constraints: The default value is `false`.
 	* `href` - (String) API URL for interacting with the trigger. Only included when fetching the list of pipeline triggers.
 	  * Constraints: The maximum length is `2048` characters. The minimum length is `10` characters. The value must match regular expression `/^http(s)?:\/\/([^\/?#]*)([^?#]*)(\\?([^#]*))?(#(.*))?$/`.
 	* `id` - (String) The Trigger ID.
@@ -126,7 +130,7 @@ Nested scheme for **triggers**:
 	  * Constraints: The maximum length is `253` characters. The minimum length is `1` character. The value must match regular expression `/^([a-zA-Z0-9]{1,2}|[a-zA-Z0-9][0-9a-zA-Z-_.: \/\\(\\)\\[\\]]{1,251}[a-zA-Z0-9])$/`.
 	* `properties` - (List) Optional trigger properties used to override or supplement the pipeline properties when triggering a pipeline run.
 	  * Constraints: The maximum length is `1024` items. The minimum length is `0` items.
-	Nested scheme for **properties**:
+	Nested schema for **properties**:
 		* `enum` - (List) Options for `single_select` property type. Only needed for `single_select` property type.
 		  * Constraints: The list items must match regular expression `/^[-0-9a-zA-Z_.]{1,253}$/`. The maximum length is `256` items. The minimum length is `0` items.
 		* `href` - (String) API URL for interacting with the trigger property.
@@ -140,7 +144,7 @@ Nested scheme for **triggers**:
 		* `value` - (String) Property value. Any string value is valid.
 		  * Constraints: The maximum length is `4096` characters. The minimum length is `0` characters. The value must match regular expression `/^.*$/`.
 	* `secret` - (List) Only needed for generic webhook trigger type. Secret used to start generic webhook trigger.
-	Nested scheme for **secret**:
+	Nested schema for **secret**:
 		* `algorithm` - (String) Algorithm used for `digest_matches` secret type. Only needed for `digest_matches` secret type.
 		  * Constraints: Allowable values are: `md4`, `md5`, `sha1`, `sha256`, `sha384`, `sha512`, `sha512_224`, `sha512_256`, `ripemd160`.
 		* `key_name` - (String) Secret name, not needed if type is `internal_validation`.
@@ -152,9 +156,9 @@ Nested scheme for **triggers**:
 		* `value` - (String) Secret value, not needed if secret type is `internal_validation`.
 		  * Constraints: The maximum length is `4096` characters. The minimum length is `0` characters. The value must match regular expression `/^.*$/`.
 	* `source` - (List) Source repository for a Git trigger. Only required for Git triggers. The referenced repository URL must match the URL of a repository tool integration in the parent toolchain. Obtain the list of integrations from the toolchain API https://cloud.ibm.com/apidocs/toolchain#list-tools.
-	Nested scheme for **source**:
+	Nested schema for **source**:
 		* `properties` - (List) Properties of the source, which define the URL of the repository and a branch or pattern.
-		Nested scheme for **properties**:
+		Nested schema for **properties**:
 			* `blind_connection` - (Boolean) True if the repository server is not addressable on the public internet. IBM Cloud will not be able to validate the connection details you provide.
 			* `branch` - (String) Name of a branch from the repo. One of branch or pattern must be specified, but only one or the other.
 			  * Constraints: The maximum length is `253` characters. The minimum length is `1` character. The value must match regular expression `/^[-0-9a-zA-Z_.]{1,253}$/`.
@@ -163,7 +167,7 @@ Nested scheme for **triggers**:
 			* `pattern` - (String) The pattern of Git branch or tag to which to listen. You can specify a glob pattern such as '!test' or '*master' to match against multiple tags/branches in the repository. The glob pattern used must conform to Bash 4.3 specifications, see bash documentation for more info: https://www.gnu.org/software/bash/manual/bash.html#Pattern-Matching. One of branch or pattern must be specified, but only one or the other.
 			  * Constraints: The maximum length is `253` characters. The minimum length is `1` character. The value must match regular expression `/^[-0-9a-zA-Z_.:@=$&^\/\\?\\!\\*\\+\\[\\]\\(\\)\\{\\}\\|\\\\]*$/`.
 			* `tool` - (List) Reference to the repository tool in the parent toolchain.
-			Nested scheme for **tool**:
+			Nested schema for **tool**:
 				* `id` - (String) ID of the repository tool instance in the parent toolchain.
 				  * Constraints: The maximum length is `36` characters. The minimum length is `36` characters. The value must match regular expression `/^[-0-9a-z]+$/`.
 			* `url` - (Forces new resource, String) URL of the repository to which the trigger is listening.
@@ -178,8 +182,8 @@ Nested scheme for **triggers**:
 	  * Constraints: Allowable values are: `manual`, `scm`, `timer`, `generic`.
 	* `webhook_url` - (String) Webhook URL that can be used to trigger pipeline runs.
 	  * Constraints: The maximum length is `2048` characters. The minimum length is `10` characters. The value must match regular expression `/^http(s)?:\/\/([^\/?#]*)([^?#]*)(\\?([^#]*))?(#(.*))?$/`.
-	* `worker` - (List) Worker used to run the trigger. If not specified the trigger will use the default pipeline worker.
-	Nested scheme for **worker**:
+	* `worker` - (List) Details of the worker used to run the trigger.
+	Nested schema for **worker**:
 		* `id` - (String) ID of the worker.
 		  * Constraints: The maximum length is `36` characters. The minimum length is `1` character. The value must match regular expression `/^[-0-9a-zA-Z]{1,36}$/`.
 		* `name` - (String) Name of the worker. Computed based on the worker ID.

--- a/website/docs/r/cd_tekton_pipeline_definition.html.markdown
+++ b/website/docs/r/cd_tekton_pipeline_definition.html.markdown
@@ -8,7 +8,7 @@ subcategory: "Continuous Delivery"
 
 # ibm_cd_tekton_pipeline_definition
 
-Provides a resource for cd_tekton_pipeline_definition. This allows cd_tekton_pipeline_definition to be created, updated and deleted.
+Create, update, and delete cd_tekton_pipeline_definitions with this resource.
 
 ## Example Usage
 
@@ -32,14 +32,14 @@ resource "ibm_cd_tekton_pipeline_definition" "cd_tekton_pipeline_definition_inst
 
 ## Argument Reference
 
-Review the argument reference that you can specify for your resource.
+You can specify the following arguments for this resource.
 
 * `pipeline_id` - (Required, Forces new resource, String) The Tekton pipeline ID.
   * Constraints: The maximum length is `36` characters. The minimum length is `36` characters. The value must match regular expression `/^[-0-9a-z]+$/`.
 * `source` - (Required, List) Source repository containing the Tekton pipeline definition.
-Nested scheme for **source**:
+Nested schema for **source**:
 	* `properties` - (Required, List) Properties of the source, which define the URL of the repository and a branch or tag.
-	Nested scheme for **properties**:
+	Nested schema for **properties**:
 		* `branch` - (Optional, String) A branch from the repo, specify one of branch or tag only.
 		  * Constraints: The maximum length is `253` characters. The minimum length is `1` character. The value must match regular expression `/^[-0-9a-zA-Z_.]{1,253}$/`.
 		* `path` - (Required, String) The path to the definition's YAML files.
@@ -47,7 +47,7 @@ Nested scheme for **source**:
 		* `tag` - (Optional, String) A tag from the repo, specify one of branch or tag only.
 		  * Constraints: The maximum length is `253` characters. The minimum length is `1` character. The value must match regular expression `/^[-0-9a-zA-Z_]{1,253}$/`.
 		* `tool` - (Optional, List) Reference to the repository tool in the parent toolchain.
-		Nested scheme for **tool**:
+		Nested schema for **tool**:
 			* `id` - (Computed, String) ID of the repository tool instance in the parent toolchain.
 			  * Constraints: The maximum length is `36` characters. The minimum length is `36` characters. The value must match regular expression `/^[-0-9a-z]+$/`.
 		* `url` - (Required, Forces new resource, String) URL of the definition repository.
@@ -57,7 +57,7 @@ Nested scheme for **source**:
 
 ## Attribute Reference
 
-In addition to all argument references listed, you can access the following attribute references after your resource is created.
+After your resource is created, you can read values from the listed arguments and the following attributes.
 
 * `id` - The unique identifier of the cd_tekton_pipeline_definition.
 * `definition_id` - (String) The aggregated definition ID.

--- a/website/docs/r/cd_tekton_pipeline_property.html.markdown
+++ b/website/docs/r/cd_tekton_pipeline_property.html.markdown
@@ -8,7 +8,7 @@ subcategory: "Continuous Delivery"
 
 # ibm_cd_tekton_pipeline_property
 
-Provides a resource for cd_tekton_pipeline_property. This allows cd_tekton_pipeline_property to be created, updated and deleted.
+Create, update, and delete cd_tekton_pipeline_propertys with this resource.
 
 ## Example Usage
 
@@ -23,13 +23,13 @@ resource "ibm_cd_tekton_pipeline_property" "cd_tekton_pipeline_property_instance
 
 ## Argument Reference
 
-Review the argument reference that you can specify for your resource.
+You can specify the following arguments for this resource.
 
 * `enum` - (Optional, List) Options for `single_select` property type. Only needed when using `single_select` property type.
   * Constraints: The list items must match regular expression `/^[-0-9a-zA-Z_.]{1,253}$/`. The maximum length is `256` items. The minimum length is `0` items.
 * `name` - (Required, Forces new resource, String) Property name.
   * Constraints: The maximum length is `253` characters. The minimum length is `1` character. The value must match regular expression `/^[-0-9a-zA-Z_.]{1,253}$/`.
-* `path` - (Optional, String) A dot notation path for `integration` type properties only, to select a value from the tool integration. If left blank the full tool integration data will be used.
+* `path` - (Optional, String) A dot notation path for `integration` type properties only, that selects a value from the tool integration. If left blank the full tool integration data will be used.
   * Constraints: The maximum length is `4096` characters. The minimum length is `0` characters. The value must match regular expression `/^[-0-9a-zA-Z_.]*$/`.
 * `pipeline_id` - (Required, Forces new resource, String) The Tekton pipeline ID.
   * Constraints: The maximum length is `36` characters. The minimum length is `36` characters. The value must match regular expression `/^[-0-9a-z]+$/`.
@@ -40,7 +40,7 @@ Review the argument reference that you can specify for your resource.
 
 ## Attribute Reference
 
-In addition to all argument references listed, you can access the following attribute references after your resource is created.
+After your resource is created, you can read values from the listed arguments and the following attributes.
 
 * `id` - The unique identifier of the cd_tekton_pipeline_property.
 * `href` - (String) API URL for interacting with the property.

--- a/website/docs/r/cd_tekton_pipeline_trigger.html.markdown
+++ b/website/docs/r/cd_tekton_pipeline_trigger.html.markdown
@@ -8,7 +8,7 @@ subcategory: "Continuous Delivery"
 
 # ibm_cd_tekton_pipeline_trigger
 
-Provides a resource for cd_tekton_pipeline_trigger. This allows cd_tekton_pipeline_trigger to be created, updated and deleted.
+Create, update, and delete cd_tekton_pipeline_triggers with this resource.
 
 ## Example Usage
 
@@ -36,23 +36,25 @@ resource "ibm_cd_tekton_pipeline_trigger" "cd_tekton_pipeline_trigger_instance" 
 
 ## Argument Reference
 
-Review the argument reference that you can specify for your resource.
+You can specify the following arguments for this resource.
 
 * `cron` - (Optional, String) Only needed for timer triggers. Cron expression that indicates when this trigger will activate. Maximum frequency is every 5 minutes. The string is based on UNIX crontab syntax: minute, hour, day of month, month, day of week. Example: 0 *_/2 * * * - every 2 hours.
   * Constraints: The maximum length is `253` characters. The minimum length is `5` characters. The value must match regular expression `/^[-0-9a-zA-Z,\\*\/ ]{5,253}$/`.
-* `enabled` - (Optional, Boolean) Flag whether the trigger is enabled. If omitted the trigger is enabled by default.
+* `enabled` - (Optional, Boolean) Flag whether the trigger is enabled.
   * Constraints: The default value is `true`.
 * `event_listener` - (Required, String) Event listener name. The name of the event listener to which the trigger is associated. The event listeners are defined in the definition repositories of the Tekton pipeline.
   * Constraints: The maximum length is `253` characters. The minimum length is `1` character. The value must match regular expression `/^[-0-9a-zA-Z_.]{1,253}$/`.
 * `events` - (Optional, List) Only needed for Git triggers. List of events to which a Git trigger listens. Choose one or more from: 'push', 'pull_request' and 'pull_request_closed'. For SCM repositories that use 'merge request' events, such events map to the equivalent 'pull request' events.
   * Constraints: Allowable list items are: `push`, `pull_request`, `pull_request_closed`. The maximum length is `3` items. The minimum length is `0` items.
+* `favorite` - (Optional, Boolean) Mark the trigger as a favorite.
+  * Constraints: The default value is `false`.
 * `max_concurrent_runs` - (Optional, Integer) Defines the maximum number of concurrent runs for this trigger. If omitted then the concurrency limit is disabled for this trigger.
 * `name` - (Required, String) Trigger name.
   * Constraints: The maximum length is `253` characters. The minimum length is `1` character. The value must match regular expression `/^([a-zA-Z0-9]{1,2}|[a-zA-Z0-9][0-9a-zA-Z-_.: \/\\(\\)\\[\\]]{1,251}[a-zA-Z0-9])$/`.
 * `pipeline_id` - (Required, Forces new resource, String) The Tekton pipeline ID.
   * Constraints: The maximum length is `36` characters. The minimum length is `36` characters. The value must match regular expression `/^[-0-9a-z]+$/`.
 * `secret` - (Optional, List) Only needed for generic webhook trigger type. Secret used to start generic webhook trigger.
-Nested scheme for **secret**:
+Nested schema for **secret**:
 	* `algorithm` - (Optional, String) Algorithm used for `digest_matches` secret type. Only needed for `digest_matches` secret type.
 	  * Constraints: Allowable values are: `md4`, `md5`, `sha1`, `sha256`, `sha384`, `sha512`, `sha512_224`, `sha512_256`, `ripemd160`.
 	* `key_name` - (Optional, String) Secret name, not needed if type is `internal_validation`.
@@ -64,38 +66,49 @@ Nested scheme for **secret**:
 	* `value` - (Optional, String) Secret value, not needed if secret type is `internal_validation`.
 	  * Constraints: The maximum length is `4096` characters. The minimum length is `0` characters. The value must match regular expression `/^.*$/`.
 * `source` - (Optional, List) Source repository for a Git trigger. Only required for Git triggers. The referenced repository URL must match the URL of a repository tool integration in the parent toolchain. Obtain the list of integrations from the toolchain API https://cloud.ibm.com/apidocs/toolchain#list-tools.
-Nested scheme for **source**:
+Nested schema for **source**:
 	* `properties` - (Required, List) Properties of the source, which define the URL of the repository and a branch or pattern.
-	Nested scheme for **properties**:
+	Nested schema for **properties**:
+		* `blind_connection` - (Computed, Boolean) True if the repository server is not addressable on the public internet. IBM Cloud will not be able to validate the connection details you provide.
 		* `branch` - (Optional, String) Name of a branch from the repo. One of branch or pattern must be specified, but only one or the other.
+		  * Constraints: The maximum length is `253` characters. The minimum length is `1` character. The value must match regular expression `/^[-0-9a-zA-Z_.]{1,253}$/`.
+		* `hook_id` - (Computed, String) ID of the webhook from the repo. Computed upon creation of the trigger.
 		  * Constraints: The maximum length is `253` characters. The minimum length is `1` character. The value must match regular expression `/^[-0-9a-zA-Z_.]{1,253}$/`.
 		* `pattern` - (Optional, String) The pattern of Git branch or tag to which to listen. You can specify a glob pattern such as '!test' or '*master' to match against multiple tags/branches in the repository. The glob pattern used must conform to Bash 4.3 specifications, see bash documentation for more info: https://www.gnu.org/software/bash/manual/bash.html#Pattern-Matching. One of branch or pattern must be specified, but only one or the other.
 		  * Constraints: The maximum length is `253` characters. The minimum length is `1` character. The value must match regular expression `/^[-0-9a-zA-Z_.:@=$&^\/\\?\\!\\*\\+\\[\\]\\(\\)\\{\\}\\|\\\\]*$/`.
+		* `tool` - (Required, List) Reference to the repository tool in the parent toolchain.
+		Nested schema for **tool**:
+			* `id` - (Computed, String) ID of the repository tool instance in the parent toolchain.
+			  * Constraints: The maximum length is `36` characters. The minimum length is `36` characters. The value must match regular expression `/^[-0-9a-z]+$/`.
 		* `url` - (Required, Forces new resource, String) URL of the repository to which the trigger is listening.
 		  * Constraints: The maximum length is `2048` characters. The minimum length is `10` characters. The value must match regular expression `/^http(s)?:\/\/([^\/?#]*)([^?#]*)(\\?([^#]*))?(#(.*))?$/`.
 	* `type` - (Required, String) The only supported source type is "git", indicating that the source is a git repository.
 	  * Constraints: The maximum length is `253` characters. The minimum length is `1` character. The value must match regular expression `/^git$/`.
-* `tags` - (Optional, List) Trigger tags array.
+* `tags` - (Optional, List) Optional trigger tags array.
   * Constraints: The list items must match regular expression `/^[-0-9a-zA-Z_.]{1,253}$/`. The maximum length is `128` items. The minimum length is `0` items.
 * `timezone` - (Optional, String) Only used for timer triggers. Specify the timezone used for this timer trigger, which will ensure the cron activates this trigger relative to the specified timezone. If no timezone is specified, the default timezone used is UTC. Valid timezones are those listed in the IANA timezone database, https://www.iana.org/time-zones.
   * Constraints: The maximum length is `253` characters. The minimum length is `1` character. The value must match regular expression `/^[-0-9a-zA-Z+_., \/]{1,253}$/`.
 * `type` - (Required, String) Trigger type.
-  * Constraints: Allowable values are: `manual`, `scm`, `timer`, `generic`.
-* `worker` - (Optional, List) Worker used to run the trigger. If not specified the trigger will use the default pipeline worker.
-Nested scheme for **worker**:
+  * Constraints: Allowable values are: .
+* `worker` - (Optional, List) Details of the worker used to run the trigger.
+Nested schema for **worker**:
 	* `id` - (Required, String) ID of the worker.
-	  * Constraints: The maximum length is `253` characters. The minimum length is `1` character. The value must match regular expression `/^[-0-9a-zA-Z]{1,253}$/`.
+	  * Constraints: The maximum length is `36` characters. The minimum length is `1` character. The value must match regular expression `/^[-0-9a-zA-Z]{1,36}$/`.
+	* `name` - (Computed, String) Name of the worker. Computed based on the worker ID.
+	  * Constraints: The maximum length is `253` characters. The minimum length is `1` character. The value must match regular expression `/^[-0-9a-zA-Z_. \\(\\)\\[\\]]{1,253}$/`.
+	* `type` - (Computed, String) Type of the worker. Computed based on the worker ID.
+	  * Constraints: The maximum length is `253` characters. The minimum length is `1` character. The value must match regular expression `/^[-0-9a-zA-Z_.]{1,253}$/`.
 
 ## Attribute Reference
 
-In addition to all argument references listed, you can access the following attribute references after your resource is created.
+After your resource is created, you can read values from the listed arguments and the following attributes.
 
 * `id` - The unique identifier of the cd_tekton_pipeline_trigger.
 * `href` - (String) API URL for interacting with the trigger. Only included when fetching the list of pipeline triggers.
   * Constraints: The maximum length is `2048` characters. The minimum length is `10` characters. The value must match regular expression `/^http(s)?:\/\/([^\/?#]*)([^?#]*)(\\?([^#]*))?(#(.*))?$/`.
 * `properties` - (List) Optional trigger properties used to override or supplement the pipeline properties when triggering a pipeline run.
   * Constraints: The maximum length is `1024` items. The minimum length is `0` items.
-Nested scheme for **properties**:
+Nested schema for **properties**:
 	* `enum` - (List) Options for `single_select` property type. Only needed for `single_select` property type.
 	  * Constraints: The list items must match regular expression `/^[-0-9a-zA-Z_.]{1,253}$/`. The maximum length is `256` items. The minimum length is `0` items.
 	* `href` - (String) API URL for interacting with the trigger property.

--- a/website/docs/r/cd_tekton_pipeline_trigger_property.html.markdown
+++ b/website/docs/r/cd_tekton_pipeline_trigger_property.html.markdown
@@ -8,7 +8,7 @@ subcategory: "Continuous Delivery"
 
 # ibm_cd_tekton_pipeline_trigger_property
 
-Provides a resource for cd_tekton_pipeline_trigger_property. This allows cd_tekton_pipeline_trigger_property to be created, updated and deleted.
+Create, update, and delete cd_tekton_pipeline_trigger_propertys with this resource.
 
 ## Example Usage
 
@@ -24,13 +24,13 @@ resource "ibm_cd_tekton_pipeline_trigger_property" "cd_tekton_pipeline_trigger_p
 
 ## Argument Reference
 
-Review the argument reference that you can specify for your resource.
+You can specify the following arguments for this resource.
 
 * `enum` - (Optional, List) Options for `single_select` property type. Only needed for `single_select` property type.
   * Constraints: The list items must match regular expression `/^[-0-9a-zA-Z_.]{1,253}$/`. The maximum length is `256` items. The minimum length is `0` items.
 * `name` - (Required, Forces new resource, String) Property name.
   * Constraints: The maximum length is `253` characters. The minimum length is `1` character. The value must match regular expression `/^[-0-9a-zA-Z_.]{1,253}$/`.
-* `path` - (Optional, String) A dot notation path for `integration` type properties only, to select a value from the tool integration. If left blank the full tool integration data will be used.
+* `path` - (Optional, String) A dot notation path for `integration` type properties only, that selects a value from the tool integration. If left blank the full tool integration data will be used.
   * Constraints: The maximum length is `4096` characters. The minimum length is `0` characters. The value must match regular expression `/^[-0-9a-zA-Z_.]*$/`.
 * `pipeline_id` - (Required, Forces new resource, String) The Tekton pipeline ID.
   * Constraints: The maximum length is `36` characters. The minimum length is `36` characters. The value must match regular expression `/^[-0-9a-z]+$/`.
@@ -43,7 +43,7 @@ Review the argument reference that you can specify for your resource.
 
 ## Attribute Reference
 
-In addition to all argument references listed, you can access the following attribute references after your resource is created.
+After your resource is created, you can read values from the listed arguments and the following attributes.
 
 * `id` - The unique identifier of the cd_tekton_pipeline_trigger_property.
 * `href` - (String) API URL for interacting with the trigger property.


### PR DESCRIPTION
### Description
- Add support for favorite triggers in Tekton pipeline
- Also includes some documentation updates

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TEST=./ibm/service/cdtektonpipeline TESTARGS='-run=TestAccIBMCdTekton*'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./ibm/service/cdtektonpipeline -v -run=TestAccIBMCdTekton* -timeout 700m
[WARN] Set the environment variable IBM_CODE_ENGINE_SERVICE_INSTANCE_ID with the ID of a IBM Cloud service instance, e.g. for COS
[WARN] Set the environment variable IBM_CODE_ENGINE_RESOURCE_KEY_ID with the ID of a resource key to access a service instance
=== RUN   TestAccIBMCdTektonPipelineDefinitionDataSourceBasic
--- PASS: TestAccIBMCdTektonPipelineDefinitionDataSourceBasic (81.28s)
=== RUN   TestAccIBMCdTektonPipelinePropertyDataSourceBasic
--- PASS: TestAccIBMCdTektonPipelinePropertyDataSourceBasic (66.92s)
=== RUN   TestAccIBMCdTektonPipelinePropertyDataSourceAllArgs
--- PASS: TestAccIBMCdTektonPipelinePropertyDataSourceAllArgs (119.83s)
=== RUN   TestAccIBMCdTektonPipelineDataSourceBasic
--- PASS: TestAccIBMCdTektonPipelineDataSourceBasic (63.87s)
=== RUN   TestAccIBMCdTektonPipelineDataSourceAllArgs
--- PASS: TestAccIBMCdTektonPipelineDataSourceAllArgs (85.71s)
=== RUN   TestAccIBMCdTektonPipelineTriggerPropertyDataSourceBasic
--- PASS: TestAccIBMCdTektonPipelineTriggerPropertyDataSourceBasic (70.78s)
=== RUN   TestAccIBMCdTektonPipelineTriggerPropertyDataSourceAllArgs
--- PASS: TestAccIBMCdTektonPipelineTriggerPropertyDataSourceAllArgs (83.99s)
=== RUN   TestAccIBMCdTektonPipelineTriggerDataSourceBasic
--- PASS: TestAccIBMCdTektonPipelineTriggerDataSourceBasic (70.52s)
=== RUN   TestAccIBMCdTektonPipelineTriggerDataSourceAllArgs
--- PASS: TestAccIBMCdTektonPipelineTriggerDataSourceAllArgs (83.48s)
=== RUN   TestAccIBMCdTektonPipelineDefinitionBasic
--- PASS: TestAccIBMCdTektonPipelineDefinitionBasic (79.31s)
=== RUN   TestAccIBMCdTektonPipelinePropertyBasic
--- PASS: TestAccIBMCdTektonPipelinePropertyBasic (76.92s)
=== RUN   TestAccIBMCdTektonPipelinePropertyAllArgs
--- PASS: TestAccIBMCdTektonPipelinePropertyAllArgs (117.97s)
=== RUN   TestAccIBMCdTektonPipelineBasic
--- PASS: TestAccIBMCdTektonPipelineBasic (76.90s)
=== RUN   TestAccIBMCdTektonPipelineAllArgs
--- PASS: TestAccIBMCdTektonPipelineAllArgs (121.88s)
=== RUN   TestAccIBMCdTektonPipelineTriggerPropertyBasic
--- PASS: TestAccIBMCdTektonPipelineTriggerPropertyBasic (85.52s)
=== RUN   TestAccIBMCdTektonPipelineTriggerPropertyAllArgs
--- PASS: TestAccIBMCdTektonPipelineTriggerPropertyAllArgs (152.31s)
=== RUN   TestAccIBMCdTektonPipelineTriggerBasic
--- PASS: TestAccIBMCdTektonPipelineTriggerBasic (117.84s)
=== RUN   TestAccIBMCdTektonPipelineTriggerAllArgs
--- PASS: TestAccIBMCdTektonPipelineTriggerAllArgs (143.51s)
PASS
ok      github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/cdtektonpipeline        1704.221s
...
```
