### PR TITLE
fixed(backup_policy_plan): delete_over_count null issue fixed

### DIFF
--- a/ibm/service/vpc/resource_ibm_is_backup_policy_plan.go
+++ b/ibm/service/vpc/resource_ibm_is_backup_policy_plan.go
@@ -593,7 +593,10 @@ func resourceIBMIsBackupPolicyPlanDelete(context context.Context, d *schema.Reso
 func resourceIBMIsVPCBackupPolicyPlanMapToBackupPolicyPlanRemoteCopyPolicyPrototype(backupPolicyPlanRemoteCopyPolicyMap map[string]interface{}) (*vpcv1.BackupPolicyPlanRemoteRegionPolicyPrototype, error) {
 	BackupPolicyPlanRemoteCopyPolicy := &vpcv1.BackupPolicyPlanRemoteRegionPolicyPrototype{}
 	if backupPolicyPlanRemoteCopyPolicyMap["delete_over_count"] != nil {
-		BackupPolicyPlanRemoteCopyPolicy.DeleteOverCount = core.Int64Ptr(int64(backupPolicyPlanRemoteCopyPolicyMap["delete_over_count"].(int)))
+		deleteOverCount := int64(backupPolicyPlanRemoteCopyPolicyMap["delete_over_count"].(int))
+		if deleteOverCount != int64(0) {
+			BackupPolicyPlanRemoteCopyPolicy.DeleteOverCount = core.Int64Ptr(deleteOverCount)
+		}
 	}
 	if backupPolicyPlanRemoteCopyPolicyMap["encryption_key"] != nil && backupPolicyPlanRemoteCopyPolicyMap["encryption_key"] != "" {
 		encCrn := backupPolicyPlanRemoteCopyPolicyMap["encryption_key"].(string)

--- a/ibm/service/vpc/resource_ibm_is_backup_policy_plan.go
+++ b/ibm/service/vpc/resource_ibm_is_backup_policy_plan.go
@@ -137,10 +137,11 @@ func ResourceIBMIsBackupPolicyPlan() *schema.Resource {
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"delete_over_count": &schema.Schema{
-							Type:        schema.TypeInt,
-							Optional:    true,
-							Computed:    true,
-							Description: "The maximum number of recent remote copies to keep in this region.",
+							Type:         schema.TypeInt,
+							Optional:     true,
+							Computed:     true,
+							ValidateFunc: validate.InvokeValidator("ibm_is_backup_policy_plan", "delete_over_count"),
+							Description:  "The maximum number of recent remote copies to keep in this region.",
 						},
 						"encryption_key": {
 							Type:        schema.TypeString,
@@ -191,6 +192,13 @@ func ResourceIBMIsBackupPolicyPlanValidator() *validate.ResourceValidator {
 			Regexp:                     `^([a-z]|[a-z][-a-z0-9]*[a-z0-9]|[0-9][-a-z0-9]*([a-z]|[-a-z][-a-z0-9]*[a-z0-9]))$`,
 			MinValueLength:             1,
 			MaxValueLength:             63,
+		},
+		validate.ValidateSchema{
+			Identifier:                 "delete_over_count",
+			ValidateFunctionIdentifier: validate.IntBetween,
+			Type:                       validate.TypeInt,
+			MinValue:                   "1",
+			MaxValue:                   "100",
 		},
 	)
 

--- a/ibm/service/vpc/resource_ibm_is_backup_policy_plan_test.go
+++ b/ibm/service/vpc/resource_ibm_is_backup_policy_plan_test.go
@@ -291,7 +291,7 @@ func TestAccIBMIsBackupPolicyPlanCRC(t *testing.T) {
 				Config: testAccCheckIBMIsBackupPolicyPlanConfigRemoteCopyPolicies(bakupPolicyName, vpcname, subnetname, sshname, volname, name, cronSpec, bakupPolicyPlanName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckIBMIsBackupPolicyPlanExists("ibm_is_backup_policy_plan.is_backup_policy_plan_crc", conf),
-					resource.TestCheckResourceAttr("ibm_is_backup_policy_plan.is_backup_policy_plan_crc", "name", bakupPolicyPlanName+"-1"),
+					resource.TestCheckResourceAttr("ibm_is_backup_policy_plan.is_backup_policy_plan_crc", "name", bakupPolicyPlanName),
 					resource.TestCheckResourceAttr("ibm_is_backup_policy_plan.is_backup_policy_plan_crc", "cron_spec", cronSpec),
 					resource.TestCheckResourceAttrSet("ibm_is_backup_policy_plan.is_backup_policy_plan_crc", "backup_policy_id"),
 					resource.TestCheckResourceAttrSet("ibm_is_backup_policy_plan.is_backup_policy_plan_crc", "backup_policy_plan_id"),
@@ -305,8 +305,52 @@ func TestAccIBMIsBackupPolicyPlanCRC(t *testing.T) {
 					resource.TestCheckResourceAttrSet("ibm_is_backup_policy_plan.is_backup_policy_plan_crc", "version"),
 					resource.TestCheckResourceAttrSet("ibm_is_backup_policy_plan.is_backup_policy_plan_crc", "remote_region_policy.#"),
 					resource.TestCheckResourceAttrSet("ibm_is_backup_policy_plan.is_backup_policy_plan_crc", "remote_region_policy.0.delete_over_count"),
+					resource.TestCheckResourceAttr("ibm_is_backup_policy_plan.is_backup_policy_plan_crc", "remote_region_policy.0.delete_over_count", "1"),
 					resource.TestCheckResourceAttrSet("ibm_is_backup_policy_plan.is_backup_policy_plan_crc", "remote_region_policy.0.encryption_key"),
 					resource.TestCheckResourceAttrSet("ibm_is_backup_policy_plan.is_backup_policy_plan_crc", "remote_region_policy.0.region"),
+					resource.TestCheckResourceAttr("ibm_is_backup_policy_plan.is_backup_policy_plan_crc", "remote_region_policy.0.region", "us-east"),
+				),
+			},
+		},
+	})
+}
+func TestAccIBMIsBackupPolicyPlanCRCNullDeleteOverCount(t *testing.T) {
+	var conf vpcv1.BackupPolicyPlan
+	vpcname := fmt.Sprintf("tf-vpc-%d", acctest.RandIntRange(10, 100))
+	name := fmt.Sprintf("tf-instnace-%d", acctest.RandIntRange(10, 100))
+	subnetname := fmt.Sprintf("tf-subnet-%d", acctest.RandIntRange(10, 100))
+	sshname := fmt.Sprintf("tf-ssh-%d", acctest.RandIntRange(10, 100))
+	volname := fmt.Sprintf("tf-vol-%d", acctest.RandIntRange(10, 100))
+	bakupPolicyName := fmt.Sprintf("tfbakuppolicyname%d", acctest.RandIntRange(10, 100))
+	bakupPolicyPlanName := fmt.Sprintf("tfbakuppolicyplanname%d", acctest.RandIntRange(10, 100))
+	cronSpec := strings.TrimSpace(strconv.Itoa(time.Now().UTC().Minute()) + " " + strconv.Itoa(time.Now().UTC().Hour()) + " " + "*" + " " + "*" + " " + "*")
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { acc.TestAccPreCheck(t) },
+		Providers:    acc.TestAccProviders,
+		CheckDestroy: testAccCheckIBMIsBackupPolicyPlanDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccCheckIBMIsBackupPolicyPlanConfigRemoteCopyPoliciesNullDeleteOverCount(bakupPolicyName, vpcname, subnetname, sshname, volname, name, cronSpec, bakupPolicyPlanName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckIBMIsBackupPolicyPlanExists("ibm_is_backup_policy_plan.is_backup_policy_plan_crc", conf),
+					resource.TestCheckResourceAttr("ibm_is_backup_policy_plan.is_backup_policy_plan_crc", "name", bakupPolicyPlanName),
+					resource.TestCheckResourceAttr("ibm_is_backup_policy_plan.is_backup_policy_plan_crc", "cron_spec", cronSpec),
+					resource.TestCheckResourceAttrSet("ibm_is_backup_policy_plan.is_backup_policy_plan_crc", "backup_policy_id"),
+					resource.TestCheckResourceAttrSet("ibm_is_backup_policy_plan.is_backup_policy_plan_crc", "backup_policy_plan_id"),
+					resource.TestCheckResourceAttrSet("ibm_is_backup_policy_plan.is_backup_policy_plan_crc", "active"),
+					resource.TestCheckResourceAttrSet("ibm_is_backup_policy_plan.is_backup_policy_plan_crc", "copy_user_tags"),
+					resource.TestCheckResourceAttrSet("ibm_is_backup_policy_plan.is_backup_policy_plan_crc", "deletion_trigger.#"),
+					resource.TestCheckResourceAttrSet("ibm_is_backup_policy_plan.is_backup_policy_plan_crc", "created_at"),
+					resource.TestCheckResourceAttrSet("ibm_is_backup_policy_plan.is_backup_policy_plan_crc", "href"),
+					resource.TestCheckResourceAttrSet("ibm_is_backup_policy_plan.is_backup_policy_plan_crc", "lifecycle_state"),
+					resource.TestCheckResourceAttrSet("ibm_is_backup_policy_plan.is_backup_policy_plan_crc", "resource_type"),
+					resource.TestCheckResourceAttrSet("ibm_is_backup_policy_plan.is_backup_policy_plan_crc", "version"),
+					resource.TestCheckResourceAttrSet("ibm_is_backup_policy_plan.is_backup_policy_plan_crc", "remote_region_policy.#"),
+					resource.TestCheckResourceAttrSet("ibm_is_backup_policy_plan.is_backup_policy_plan_crc", "remote_region_policy.0.delete_over_count"),
+					resource.TestCheckResourceAttr("ibm_is_backup_policy_plan.is_backup_policy_plan_crc", "remote_region_policy.0.delete_over_count", "5"),
+					resource.TestCheckResourceAttrSet("ibm_is_backup_policy_plan.is_backup_policy_plan_crc", "remote_region_policy.0.encryption_key"),
+					resource.TestCheckResourceAttrSet("ibm_is_backup_policy_plan.is_backup_policy_plan_crc", "remote_region_policy.0.region"),
+					resource.TestCheckResourceAttr("ibm_is_backup_policy_plan.is_backup_policy_plan_crc", "remote_region_policy.0.region", "us-east"),
 				),
 			},
 		},
@@ -370,14 +414,29 @@ func testAccCheckIBMIsBackupPolicyPlanConfigRemoteCopyPolicies(backupPolicyName,
 	return testAccCheckIBMIsBackupPolicyConfigBasic(backupPolicyName, vpcname, subnetname, sshname, volName, name) + fmt.Sprintf(`
 	
 	  resource "ibm_is_backup_policy_plan" "is_backup_policy_plan_crc" {
-		depends_on  	= [ibm_is_instance.testacc_instance]
-		match_user_tags = ["tag-0"]
-		name            = "%s"
-		cron_spec 		= "%s"
+		depends_on  		= [ibm_is_instance.testacc_instance]
+		backup_policy_id 	= ibm_is_backup_policy.is_backup_policy.id
+		name            	= "%s"
+		cron_spec 			= "%s"
 		remote_region_policy {
 			delete_over_count 	= 1
 			encryption_key 		= "%s"
-			region 				= "us-south"
+			region 				= "us-east"
+		}
+	}`, bakupPolicyPlanName, cronSpec, acc.BaasEncryptionkeyCRN)
+}
+
+func testAccCheckIBMIsBackupPolicyPlanConfigRemoteCopyPoliciesNullDeleteOverCount(backupPolicyName, vpcname, subnetname, sshname, volName, name, cronSpec, bakupPolicyPlanName string) string {
+	return testAccCheckIBMIsBackupPolicyConfigBasic(backupPolicyName, vpcname, subnetname, sshname, volName, name) + fmt.Sprintf(`
+	
+	  resource "ibm_is_backup_policy_plan" "is_backup_policy_plan_crc" {
+		depends_on  		= [ibm_is_instance.testacc_instance]
+		backup_policy_id 	= ibm_is_backup_policy.is_backup_policy.id
+		name           		= "%s"
+		cron_spec 			= "%s"
+		remote_region_policy {
+			encryption_key 		= "%s"
+			region 				= "us-east"
 		}
 	}`, bakupPolicyPlanName, cronSpec, acc.BaasEncryptionkeyCRN)
 }

--- a/website/docs/r/is_backup_policy_plan.html.markdown
+++ b/website/docs/r/is_backup_policy_plan.html.markdown
@@ -96,7 +96,7 @@ backup_policy_plan_id
 - `remote_region_policy` - (Optional, List) Backup policy plan cross region rule.
 
   Nested scheme for `remote_region_policy`:
-	- `delete_over_count` - (Optional, Integer) The maximum number of recent remote copies to keep in this region.
+	- `delete_over_count` - (Optional, Integer) The maximum number of recent remote copies to keep in this region. If no value is passed, then by default `delete_over_count` is 5. Range for `delete_over_count` is [1-100].
 	- `encryption_key` - (Optional, String) The root key to use to rewrap the data encryption key for the snapshot.If unspecified, the source's `encryption_key` will be used.The specified key may be in a different account, subject to IAM policies. The CRN of the [Key Protect Root Key](https://cloud.ibm.com/docs/key-protect?topic=key-protect-getting-started-tutorial) or [Hyper Protect Crypto Services Root Key](https://cloud.ibm.com/docs/hs-crypto?topic=hs-crypto-get-started) for this resource.
 	- `region` - (Required, String) Identifies a region by a unique property. The globally unique name for this region.
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/IBM-Cloud/terraform-provider-ibm/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #4734

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
=== RUN   TestAccIBMIsBackupPolicyPlanCRC
no message sent
no message sent
--- PASS: TestAccIBMIsBackupPolicyPlanCRC (212.31s)
=== RUN   TestAccIBMIsBackupPolicyPlanCRCNullDeleteOverCount
no message sent
no message sent
no message sent
--- PASS: TestAccIBMIsBackupPolicyPlanCRCNullDeleteOverCount (202.16s)
PASS
ok      github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/vpc     420.000s
```
