### PR TITLE
Doc fix: Updated subcategory of ibm_metrics_router_targets

### DIFF
--- a/website/docs/d/metrics_router_routes.html.markdown
+++ b/website/docs/d/metrics_router_routes.html.markdown
@@ -3,7 +3,7 @@ layout: "ibm"
 page_title: "IBM : ibm_metrics_router_routes"
 description: |-
   Get information about metrics_router_routes
-subcategory: "IBM Cloud Metrics Routing API Version 3"
+subcategory: "IBM Cloud Metrics Routing"
 ---
 
 # ibm_metrics_router_routes


### PR DESCRIPTION
As part of the PR, changing the subcategory from IBM Cloud Metrics Routing API Version 3 to IBM Cloud Metrics Routing of ibm_metrics_router_targets
