### PR TITLE
allow ibm_schematics_workspace template_type 1.4

### DIFF
--- a/ibm/service/schematics/resource_ibm_schematics_workspace.go
+++ b/ibm/service/schematics/resource_ibm_schematics_workspace.go
@@ -576,7 +576,7 @@ func ResourceIBMSchematicsWorkspaceValidator() *validate.ResourceValidator {
 			Identifier:                 schematicsWorkspaceTemplateType,
 			ValidateFunctionIdentifier: validate.ValidateRegexp,
 			Type:                       validate.TypeString,
-			Regexp:                     `^terraform_v(?:0\.11|0\.12|0\.13|0\.14|0\.15|1\.0|1\.1|1\.2|1\.3)(?:\.\d+)?$`,
+			Regexp:                     `^terraform_v(?:0\.11|0\.12|0\.13|0\.14|0\.15|1\.0|1\.1|1\.2|1\.3|1\.4)(?:\.\d+)?$`,
 			Default:                    "[]",
 			Optional:                   true})
 


### PR DESCRIPTION
This allows for creation of workspaces with terraform version 1.4. 

Long term I'd argue that this regexp should validate that the version is structurally correct, but allow for any integer and then fail due to underlying API call, otherwise every new minor release of TF support in the service requires a change here

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request
