### PR TITLE
Retry cloud connection create/update when vpc is unavailable

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.18
 require (
 	github.com/IBM-Cloud/bluemix-go v0.0.0-20230601050310-eecebfbff63e
 	github.com/IBM-Cloud/container-services-go-sdk v0.0.0-20230118060037-101bda076037
-	github.com/IBM-Cloud/power-go-client v1.2.2
+	github.com/IBM-Cloud/power-go-client v1.2.4
 	github.com/IBM/apigateway-go-sdk v0.0.0-20210714141226-a5d5d49caaca
 	github.com/IBM/appconfiguration-go-admin-sdk v0.3.0
 	github.com/IBM/appid-management-go-sdk v0.0.0-20210908164609-dd0e0eaf732f

--- a/go.sum
+++ b/go.sum
@@ -105,6 +105,8 @@ github.com/IBM-Cloud/container-services-go-sdk v0.0.0-20230118060037-101bda07603
 github.com/IBM-Cloud/ibm-cloud-cli-sdk v0.5.3/go.mod h1:RiUvKuHKTBmBApDMUQzBL14pQUGKcx/IioKQPIcRQjs=
 github.com/IBM-Cloud/power-go-client v1.2.2 h1:VNlzizoG2x06c3nL1ZBILF701QcvXcu6nEH3hmEKCkw=
 github.com/IBM-Cloud/power-go-client v1.2.2/go.mod h1:Qfx0fNi+9hms+xu9Z6Euhu9088ByW6C/TCMLECTRWNE=
+github.com/IBM-Cloud/power-go-client v1.2.4 h1:4y/ubiOXpMg3xyBryfgfsa8hae/9Dn5WLdvphoxvgsQ=
+github.com/IBM-Cloud/power-go-client v1.2.4/go.mod h1:0YVWoIQN5I5IvyhO/m4yxgPJqCh9QjceN2FNlVpYlOQ=
 github.com/IBM-Cloud/softlayer-go v1.0.5-tf h1:koUAyF9b6X78lLLruGYPSOmrfY2YcGYKOj/Ug9nbKNw=
 github.com/IBM-Cloud/softlayer-go v1.0.5-tf/go.mod h1:6HepcfAXROz0Rf63krk5hPZyHT6qyx2MNvYyHof7ik4=
 github.com/IBM/apigateway-go-sdk v0.0.0-20210714141226-a5d5d49caaca h1:crniVcf+YcmgF03NmmfonXwSQ73oJF+IohFYBwknMxs=

--- a/ibm/service/power/resource_ibm_pi_cloud_connection.go
+++ b/ibm/service/power/resource_ibm_pi_cloud_connection.go
@@ -240,7 +240,7 @@ func resourceIBMPICloudConnectionCreate(ctx context.Context, d *schema.ResourceD
 			err = retryCloudConnectionsVPC(func() (err error) {
 				cloudConnection, cloudConnectionJob, err = client.Create(body)
 				return
-			}, vpcRetryCount, vpcRetryDuration, "create", err)
+			}, "create", err)
 		}
 		if err != nil {
 			log.Printf("[DEBUG] create cloud connection failed %v", err)
@@ -355,7 +355,7 @@ func resourceIBMPICloudConnectionUpdate(ctx context.Context, d *schema.ResourceD
 				err = retryCloudConnectionsVPC(func() (err error) {
 					_, cloudConnectionJob, err = client.Update(cloudConnectionID, body)
 					return
-				}, vpcRetryCount, vpcRetryDuration, "update", err)
+				}, "update", err)
 			}
 			if err != nil {
 				log.Printf("[DEBUG] update cloud connection failed %v", err)
@@ -525,10 +525,10 @@ func resourceIBMPICloudConnectionDelete(ctx context.Context, d *schema.ResourceD
 	return nil
 }
 
-func retryCloudConnectionsVPC(ccVPCRetry func() error, retryCount int, waitDuration time.Duration, operation string, errMsg error) (err error) {
-	for count := 0; count < retryCount; count++ {
+func retryCloudConnectionsVPC(ccVPCRetry func() error, operation string, errMsg error) (err error) {
+	for count := 0; count < vpcRetryCount && errMsg != nil; count++ {
 		log.Printf("[DEBUG] unable to get vpc details for cloud connection: %v", errMsg)
-		time.Sleep(waitDuration)
+		time.Sleep(vpcRetryDuration)
 		log.Printf("[DEBUG] retrying cloud connection %s, retry #%v", operation, count+1)
 		err = ccVPCRetry()
 	}

--- a/ibm/service/power/resource_ibm_pi_cloud_connection.go
+++ b/ibm/service/power/resource_ibm_pi_cloud_connection.go
@@ -525,12 +525,12 @@ func resourceIBMPICloudConnectionDelete(ctx context.Context, d *schema.ResourceD
 	return nil
 }
 
-func retryCloudConnectionsVPC(ccVPCRetry func() error, operation string, errMsg error) (err error) {
+func retryCloudConnectionsVPC(ccVPCRetry func() error, operation string, errMsg error) error {
 	for count := 0; count < vpcRetryCount && errMsg != nil; count++ {
 		log.Printf("[DEBUG] unable to get vpc details for cloud connection: %v", errMsg)
 		time.Sleep(vpcRetryDuration)
 		log.Printf("[DEBUG] retrying cloud connection %s, retry #%v", operation, count+1)
-		err = ccVPCRetry()
+		errMsg = ccVPCRetry()
 	}
-	return
+	return errMsg
 }


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/IBM-Cloud/terraform-provider-ibm/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```
