### PR TITLE
Feat: ReplicationEnabledField for Storage Pool

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.18
 require (
 	github.com/IBM-Cloud/bluemix-go v0.0.0-20230601050310-eecebfbff63e
 	github.com/IBM-Cloud/container-services-go-sdk v0.0.0-20230118060037-101bda076037
-	github.com/IBM-Cloud/power-go-client v1.2.2
+	github.com/IBM-Cloud/power-go-client v1.3.1-0.20230811154219-1b70021e9f3f
 	github.com/IBM/apigateway-go-sdk v0.0.0-20210714141226-a5d5d49caaca
 	github.com/IBM/appconfiguration-go-admin-sdk v0.3.0
 	github.com/IBM/appid-management-go-sdk v0.0.0-20210908164609-dd0e0eaf732f

--- a/go.sum
+++ b/go.sum
@@ -105,6 +105,8 @@ github.com/IBM-Cloud/container-services-go-sdk v0.0.0-20230118060037-101bda07603
 github.com/IBM-Cloud/ibm-cloud-cli-sdk v0.5.3/go.mod h1:RiUvKuHKTBmBApDMUQzBL14pQUGKcx/IioKQPIcRQjs=
 github.com/IBM-Cloud/power-go-client v1.2.2 h1:VNlzizoG2x06c3nL1ZBILF701QcvXcu6nEH3hmEKCkw=
 github.com/IBM-Cloud/power-go-client v1.2.2/go.mod h1:Qfx0fNi+9hms+xu9Z6Euhu9088ByW6C/TCMLECTRWNE=
+github.com/IBM-Cloud/power-go-client v1.3.1-0.20230811154219-1b70021e9f3f h1:oTcLx1f6kkZRco+QSEQ+gr7Ck3jNBILLRrhj3trgOHY=
+github.com/IBM-Cloud/power-go-client v1.3.1-0.20230811154219-1b70021e9f3f/go.mod h1:0YVWoIQN5I5IvyhO/m4yxgPJqCh9QjceN2FNlVpYlOQ=
 github.com/IBM-Cloud/softlayer-go v1.0.5-tf h1:koUAyF9b6X78lLLruGYPSOmrfY2YcGYKOj/Ug9nbKNw=
 github.com/IBM-Cloud/softlayer-go v1.0.5-tf/go.mod h1:6HepcfAXROz0Rf63krk5hPZyHT6qyx2MNvYyHof7ik4=
 github.com/IBM/apigateway-go-sdk v0.0.0-20210714141226-a5d5d49caaca h1:crniVcf+YcmgF03NmmfonXwSQ73oJF+IohFYBwknMxs=

--- a/ibm/service/power/data_source_ibm_pi_storage_pool_capacity.go
+++ b/ibm/service/power/data_source_ibm_pi_storage_pool_capacity.go
@@ -54,6 +54,11 @@ func DataSourceIBMPIStoragePoolCapacity() *schema.Resource {
 				Computed:    true,
 				Description: "Total pool capacity (GB)",
 			},
+			ReplicationEnabled: {
+				Type:        schema.TypeBool,
+				Computed:    true,
+				Description: "Replication status of the storage pool",
+			},
 		},
 	}
 }
@@ -75,10 +80,9 @@ func dataSourceIBMPIStoragePoolCapacityRead(ctx context.Context, d *schema.Resou
 	}
 
 	d.SetId(fmt.Sprintf("%s/%s", cloudInstanceID, storagePool))
-
 	d.Set(MaxAllocationSize, *sp.MaxAllocationSize)
 	d.Set(StorageType, sp.StorageType)
 	d.Set(TotalCapacity, sp.TotalCapacity)
-
+	d.Set(ReplicationEnabled, *sp.ReplicationEnabled)
 	return nil
 }

--- a/ibm/service/power/data_source_ibm_pi_storage_pools_capacity.go
+++ b/ibm/service/power/data_source_ibm_pi_storage_pools_capacity.go
@@ -28,6 +28,7 @@ const (
 	StoragePool              = "storage_pool"
 	StorageType              = "storage_type"
 	TotalCapacity            = "total_capacity"
+	ReplicationEnabled       = "replication_enabled"
 )
 
 func DataSourceIBMPIStoragePoolsCapacity() *schema.Resource {
@@ -71,6 +72,11 @@ func DataSourceIBMPIStoragePoolsCapacity() *schema.Resource {
 							Computed:    true,
 							Description: "Total pool capacity (GB)",
 						},
+						ReplicationEnabled: {
+							Type:        schema.TypeBool,
+							Computed:    true,
+							Description: "Replication status of the storage pool",
+						},
 					},
 				},
 			},
@@ -79,6 +85,7 @@ func DataSourceIBMPIStoragePoolsCapacity() *schema.Resource {
 }
 
 func dataSourceIBMPIStoragePoolsCapacityRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+
 	sess, err := meta.(conns.ClientSession).IBMPISession()
 	if err != nil {
 		return diag.FromErr(err)
@@ -109,11 +116,13 @@ func dataSourceIBMPIStoragePoolsCapacityRead(ctx context.Context, d *schema.Reso
 	result := make([]map[string]interface{}, 0, len(spc.StoragePoolsCapacity))
 	for _, sp := range spc.StoragePoolsCapacity {
 		data := map[string]interface{}{
-			MaxAllocationSize: *sp.MaxAllocationSize,
-			PoolName:          sp.PoolName,
-			StorageType:       sp.StorageType,
-			TotalCapacity:     sp.TotalCapacity,
+			MaxAllocationSize:  *sp.MaxAllocationSize,
+			PoolName:           sp.PoolName,
+			StorageType:        sp.StorageType,
+			TotalCapacity:      sp.TotalCapacity,
+			ReplicationEnabled: *sp.ReplicationEnabled,
 		}
+
 		result = append(result, data)
 	}
 	d.Set(StoragePoolsCapacity, result)

--- a/website/docs/d/pi_storage_pool_capacity.markdown
+++ b/website/docs/d/pi_storage_pool_capacity.markdown
@@ -47,3 +47,4 @@ In addition to all argument reference list, you can access the following attribu
 - `max_allocation_size` - (Integer) Maximum allocation storage size (GB).
 - `storage_type` - (String) Storage type of the storage pool.
 - `total_capacity` - (Integer) Total pool capacity (GB).
+- `replication_enabled` - (Boolean) "Replication status of the storage pool"

--- a/website/docs/d/pi_storage_pools_capacity.markdown
+++ b/website/docs/d/pi_storage_pools_capacity.markdown
@@ -56,3 +56,4 @@ In addition to all argument reference list, you can access the following attribu
   - `pool_name` - (String) The pool name.
   - `storage_type` - (String) Storage type of the storage pool.
   - `total_capacity` - (Integer) Total pool capacity (GB).
+  - `replication_enabled` - (Boolean) "Replication status of the storage pool"


### PR DESCRIPTION
With this PR, user will be able to see if storage pool is replication enabled or not while accessing storage pool/pools capacity APIs.


<!--- See what makes a good Pull Request at : https://github.com/IBM-Cloud/terraform-provider-ibm/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```
