### PR TITLE
add support for endpoint parameter in cluster_config

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -231,6 +231,8 @@ replace github.com/dgrijalva/jwt-go v3.2.0+incompatible => github.com/golang-jwt
 
 replace github.com/portworx/sched-ops v0.0.0-20200831185134-3e8010dc7056 => github.com/portworx/sched-ops v0.20.4-openstorage-rc3 // required by rook v1.7
 
+replace github.com/IBM-Cloud/bluemix-go v0.0.0-20230601050310-eecebfbff63e => github.com/mihivagyok/bluemix-go v0.0.0-20230908132747-880981f4c25b
+
 exclude (
 	github.com/kubernetes-incubator/external-storage v0.20.4-openstorage-rc2
 	k8s.io/client-go v11.0.1-0.20190409021438-1a26190bd76a+incompatible

--- a/go.mod
+++ b/go.mod
@@ -231,8 +231,6 @@ replace github.com/dgrijalva/jwt-go v3.2.0+incompatible => github.com/golang-jwt
 
 replace github.com/portworx/sched-ops v0.0.0-20200831185134-3e8010dc7056 => github.com/portworx/sched-ops v0.20.4-openstorage-rc3 // required by rook v1.7
 
-replace github.com/IBM-Cloud/bluemix-go v0.0.0-20230601050310-eecebfbff63e => github.com/mihivagyok/bluemix-go v0.0.0-20230908132747-880981f4c25b
-
 exclude (
 	github.com/kubernetes-incubator/external-storage v0.20.4-openstorage-rc2
 	k8s.io/client-go v11.0.1-0.20190409021438-1a26190bd76a+incompatible

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/IBM-Cloud/terraform-provider-ibm
 go 1.18
 
 require (
-	github.com/IBM-Cloud/bluemix-go v0.0.0-20230601050310-eecebfbff63e
+	github.com/IBM-Cloud/bluemix-go v0.0.0-20230914140903-40534e34a2a5
 	github.com/IBM-Cloud/container-services-go-sdk v0.0.0-20230822142550-30562e113de9
 	github.com/IBM-Cloud/power-go-client v1.2.4
 	github.com/IBM/apigateway-go-sdk v0.0.0-20210714141226-a5d5d49caaca
@@ -24,8 +24,8 @@ require (
 	github.com/IBM/ibm-hpcs-uko-sdk v0.0.20-beta
 	github.com/IBM/keyprotect-go-client v0.12.2
 	github.com/IBM/networking-go-sdk v0.42.2
-	github.com/IBM/project-go-sdk v0.0.10
 	github.com/IBM/platform-services-go-sdk v0.48.1
+	github.com/IBM/project-go-sdk v0.0.10
 	github.com/IBM/push-notifications-go-sdk v0.0.0-20210310100607-5790b96c47f5
 	github.com/IBM/scc-go-sdk/v5 v5.0.2
 	github.com/IBM/schematics-go-sdk v0.2.1
@@ -63,13 +63,6 @@ require (
 )
 
 require (
-	github.com/IBM/go-sdk-core/v3 v3.2.4
-	github.com/IBM/project-go-sdk v0.0.10
-	github.com/akamai/AkamaiOPEN-edgegrid-golang v1.2.2
-	github.com/akamai/AkamaiOPEN-edgegrid-golang/v5 v5.0.0
-	github.com/pkg/errors v0.9.1
-	github.com/rook/rook v1.11.4
-	gopkg.in/yaml.v3 v3.0.1
 	k8s.io/utils v0.0.0-20230313181309-38a27ef9d749
 	sigs.k8s.io/controller-runtime v0.14.1
 )

--- a/go.sum
+++ b/go.sum
@@ -98,13 +98,11 @@ github.com/DataDog/datadog-go v2.2.0+incompatible/go.mod h1:LButxg5PwREeZtORoXG3
 github.com/DataDog/datadog-go v3.2.0+incompatible h1:qSG2N4FghB1He/r2mFrWKCaL7dXCilEuNEeAn20fdD4=
 github.com/DataDog/datadog-go v3.2.0+incompatible/go.mod h1:LButxg5PwREeZtORoXG3tL4fMGNddJ+vMq1mwgfaqoQ=
 github.com/DataDog/zstd v1.4.4/go.mod h1:1jcaCB/ufaK+sKp1NBhlGmpz41jOoPQ35bpF36t7BBo=
-github.com/IBM-Cloud/bluemix-go v0.0.0-20230601050310-eecebfbff63e h1:0GNM+YmWoFcq8/cih+oZAv+cdvNt8ZdFO807QbBzm1Y=
-github.com/IBM-Cloud/bluemix-go v0.0.0-20230601050310-eecebfbff63e/go.mod h1:cO5KCpiop9eP/pM/5W07TprYUkv/kHtajW1FiZgE59k=
+github.com/IBM-Cloud/bluemix-go v0.0.0-20230914140903-40534e34a2a5 h1:1hjspcKEce53NnIT+byrqy6Bre1ZNmsbl+IZw8AqKsQ=
+github.com/IBM-Cloud/bluemix-go v0.0.0-20230914140903-40534e34a2a5/go.mod h1:cO5KCpiop9eP/pM/5W07TprYUkv/kHtajW1FiZgE59k=
 github.com/IBM-Cloud/container-services-go-sdk v0.0.0-20230822142550-30562e113de9 h1:sXRzCK3Glxpyu66Tu2NjztLdT5sDwj4qly+MJKRhdWY=
 github.com/IBM-Cloud/container-services-go-sdk v0.0.0-20230822142550-30562e113de9/go.mod h1:xUQL9SGAjoZFd4GNjrjjtEpjpkgU7RFXRyHesbKTjiY=
 github.com/IBM-Cloud/ibm-cloud-cli-sdk v0.5.3/go.mod h1:RiUvKuHKTBmBApDMUQzBL14pQUGKcx/IioKQPIcRQjs=
-github.com/IBM-Cloud/power-go-client v1.2.2 h1:VNlzizoG2x06c3nL1ZBILF701QcvXcu6nEH3hmEKCkw=
-github.com/IBM-Cloud/power-go-client v1.2.2/go.mod h1:Qfx0fNi+9hms+xu9Z6Euhu9088ByW6C/TCMLECTRWNE=
 github.com/IBM-Cloud/power-go-client v1.2.4 h1:4y/ubiOXpMg3xyBryfgfsa8hae/9Dn5WLdvphoxvgsQ=
 github.com/IBM-Cloud/power-go-client v1.2.4/go.mod h1:0YVWoIQN5I5IvyhO/m4yxgPJqCh9QjceN2FNlVpYlOQ=
 github.com/IBM-Cloud/softlayer-go v1.0.5-tf h1:koUAyF9b6X78lLLruGYPSOmrfY2YcGYKOj/Ug9nbKNw=
@@ -459,7 +457,6 @@ github.com/go-git/go-billy/v5 v5.2.0/go.mod h1:pmpqyWchKfYfrkb/UVH4otLvyi/5gJlGI
 github.com/go-git/go-billy/v5 v5.3.1 h1:CPiOUAzKtMRvolEKw+bG1PLRpT7D3LIs3/3ey4Aiu34=
 github.com/go-git/go-billy/v5 v5.3.1/go.mod h1:pmpqyWchKfYfrkb/UVH4otLvyi/5gJlGI4Hb3ZqZ3W0=
 github.com/go-git/go-git-fixtures/v4 v4.2.1/go.mod h1:K8zd3kDUAykwTdDCr+I0per6Y6vMiRR/nnVTBtavnB0=
-github.com/go-git/go-git/v5 v5.0.0/go.mod h1:oYD8y9kWsGINPFJoLdaScGCN6dlKg23blmClfZwtUVA=
 github.com/go-git/go-git/v5 v5.4.2 h1:BXyZu9t0VkbiHtqrsvdq39UDhGJTl1h55VW6CSC4aY4=
 github.com/go-git/go-git/v5 v5.4.2/go.mod h1:gQ1kArt6d+n+BGd+/B/I74HwRTLhth2+zti4ihgckDc=
 github.com/go-gl/glfw v0.0.0-20190409004039-e6da0acd62b1/go.mod h1:vR7hzQXu2zJy9AVAgeJqvqgH9Q5CA+iKCZ2gyEVpxRU=
@@ -1065,8 +1062,6 @@ github.com/jmespath/go-jmespath v0.4.0 h1:BEgLn5cpjn8UN1mAw4NjwDrS35OdebyEtFe+9Y
 github.com/jmespath/go-jmespath v0.4.0/go.mod h1:T8mJZnbsbmF+m6zOOFylbeCJqk5+pHWvzYPziyZiYoo=
 github.com/jmespath/go-jmespath/internal/testify v1.5.1 h1:shLQSRRSCCPj3f2gpwzGwWFoC7ycTf1rcQZHOlsJ6N8=
 github.com/jmespath/go-jmespath/internal/testify v1.5.1/go.mod h1:L3OGu8Wl2/fWfCI6z80xFu9LTZmf1ZRjMHUOPmWr69U=
-github.com/johnstarich/go/gopages v0.1.8/go.mod h1:OaSRjfHdFfN+LS7u6xqgNO7C2Uxjlvpm17DcKcvLBhY=
-github.com/johnstarich/go/pipe v0.2.0/go.mod h1:3X9IdVJJnI7pkpzEH6np98wqHl55zFmbilKG+9+koMo=
 github.com/joho/godotenv v1.3.0 h1:Zjp+RcGpHhGlrMbJzXTrZZPrWj+1vfm90La1wgB6Bhc=
 github.com/joho/godotenv v1.3.0/go.mod h1:7hK45KPybAkOC6peb+G5yklZfMxEjkZhHbwpqxOKXbg=
 github.com/jonboulle/clockwork v0.1.0/go.mod h1:Ii8DK3G1RaLaWxj9trq07+26W01tbo22gdxWY5EU2bo=
@@ -1096,7 +1091,6 @@ github.com/karrick/godirwalk v1.8.0/go.mod h1:H5KPZjojv4lE+QYImBI8xVtrBRgYrIVsaR
 github.com/karrick/godirwalk v1.10.3/go.mod h1:RoGL9dQei4vP9ilrpETWE8CLOZ1kiN0LhBygSwrAsHA=
 github.com/kelseyhightower/envconfig v1.3.0/go.mod h1:cccZRl6mQpaq41TPp5QxidR+Sa3axMbJDNb//FQX6Gg=
 github.com/kelseyhightower/envconfig v1.4.0 h1:Im6hONhd3pLkfDFsbRgu68RDNkGF1r3dvMUtDTo2cv8=
-github.com/kevinburke/ssh_config v0.0.0-20190725054713-01f96b0aa0cd/go.mod h1:CT57kijsi8u/K/BOFA39wgDQJ9CxiF4nAY/ojJ6r6mM=
 github.com/kevinburke/ssh_config v0.0.0-20201106050909-4977a11b4351 h1:DowS9hvgyYSX4TO5NpyC606/Z4SxnNYbT+WX27or6Ck=
 github.com/kevinburke/ssh_config v0.0.0-20201106050909-4977a11b4351/go.mod h1:CT57kijsi8u/K/BOFA39wgDQJ9CxiF4nAY/ojJ6r6mM=
 github.com/keybase/go-crypto v0.0.0-20190403132359-d65b6b94177f/go.mod h1:ghbZscTyKdM07+Fw3KSi0hcJm+AlEUWj8QLlPtijN/M=
@@ -1540,7 +1534,6 @@ github.com/vmihailenco/msgpack/v4 v4.3.12/go.mod h1:gborTTJjAo/GWTqqRjrLCn9pgNN+
 github.com/vmihailenco/tagparser v0.1.1 h1:quXMXlA39OCbd2wAdTsGDlK9RkOk6Wuw+x37wVyIuWY=
 github.com/vmihailenco/tagparser v0.1.1/go.mod h1:OeAg3pn3UbLjkWt+rN9oFYB6u/cQgqMEUPoW2WPyhdI=
 github.com/vmware/govmomi v0.18.0 h1:f7QxSmP7meCtoAmiKZogvVbLInT+CZx6Px6K5rYsJZo=
-github.com/xanzy/ssh-agent v0.2.1/go.mod h1:mLlQY/MoOhWBj+gOGMQkOeiEvkx+8pJSI+0Bx9h2kr4=
 github.com/xanzy/ssh-agent v0.3.0 h1:wUMzuKtKilRgBAD1sUb8gOwwRr2FGoBVumcjoOACClI=
 github.com/xanzy/ssh-agent v0.3.0/go.mod h1:3s9xbODqPuuhK9JV1R321M/FlMZSBvE5aY6eAcqrDh0=
 github.com/xdg-go/pbkdf2 v1.0.0/go.mod h1:jrpuAogTd400dnrH08LKmI/xc1MbPOebTwRqcT5RDeI=

--- a/go.sum
+++ b/go.sum
@@ -1192,8 +1192,6 @@ github.com/michaelklishin/rabbit-hole v0.0.0-20191008194146-93d9988f0cd5/go.mod 
 github.com/miekg/dns v1.0.14/go.mod h1:W1PPwlIAgtquWBMBEV9nkV9Cazfe8ScdGz/Lj7v3Nrg=
 github.com/miekg/dns v1.1.15/go.mod h1:W1PPwlIAgtquWBMBEV9nkV9Cazfe8ScdGz/Lj7v3Nrg=
 github.com/miekg/dns v1.1.41 h1:WMszZWJG0XmzbK9FEmzH2TVcqYzFesusSIB41b8KHxY=
-github.com/mihivagyok/bluemix-go v0.0.0-20230908132747-880981f4c25b h1:pEaN7CTx9EAckvc/Oga0bQpjMm/VEo+BsqPuSKkyyuY=
-github.com/mihivagyok/bluemix-go v0.0.0-20230908132747-880981f4c25b/go.mod h1:cO5KCpiop9eP/pM/5W07TprYUkv/kHtajW1FiZgE59k=
 github.com/minsikl/netscaler-nitro-go v0.0.0-20170827154432-5b14ce3643e3 h1:PHPBYVeLuR7/2XSOfVwDpW+70KNuxMWygsyOZSKK15Y=
 github.com/minsikl/netscaler-nitro-go v0.0.0-20170827154432-5b14ce3643e3/go.mod h1:jh28TRFZwBumf7OjMQbRb8TNtDuuX7QNAGRjFEt+h6I=
 github.com/mitchellh/cli v1.0.0/go.mod h1:hNIlj7HEI86fIcpObd7a0FcrxTWetlwJDGcceTlRvqc=

--- a/go.sum
+++ b/go.sum
@@ -1192,6 +1192,8 @@ github.com/michaelklishin/rabbit-hole v0.0.0-20191008194146-93d9988f0cd5/go.mod 
 github.com/miekg/dns v1.0.14/go.mod h1:W1PPwlIAgtquWBMBEV9nkV9Cazfe8ScdGz/Lj7v3Nrg=
 github.com/miekg/dns v1.1.15/go.mod h1:W1PPwlIAgtquWBMBEV9nkV9Cazfe8ScdGz/Lj7v3Nrg=
 github.com/miekg/dns v1.1.41 h1:WMszZWJG0XmzbK9FEmzH2TVcqYzFesusSIB41b8KHxY=
+github.com/mihivagyok/bluemix-go v0.0.0-20230908132747-880981f4c25b h1:pEaN7CTx9EAckvc/Oga0bQpjMm/VEo+BsqPuSKkyyuY=
+github.com/mihivagyok/bluemix-go v0.0.0-20230908132747-880981f4c25b/go.mod h1:cO5KCpiop9eP/pM/5W07TprYUkv/kHtajW1FiZgE59k=
 github.com/minsikl/netscaler-nitro-go v0.0.0-20170827154432-5b14ce3643e3 h1:PHPBYVeLuR7/2XSOfVwDpW+70KNuxMWygsyOZSKK15Y=
 github.com/minsikl/netscaler-nitro-go v0.0.0-20170827154432-5b14ce3643e3/go.mod h1:jh28TRFZwBumf7OjMQbRb8TNtDuuX7QNAGRjFEt+h6I=
 github.com/mitchellh/cli v1.0.0/go.mod h1:hNIlj7HEI86fIcpObd7a0FcrxTWetlwJDGcceTlRvqc=

--- a/ibm/service/kubernetes/data_source_ibm_container_cluster_config.go
+++ b/ibm/service/kubernetes/data_source_ibm_container_cluster_config.go
@@ -88,6 +88,12 @@ func DataSourceIBMContainerClusterConfig() *schema.Resource {
 				Optional:    true,
 				Default:     false,
 			},
+			"endpoint_type": {
+				Description: "",
+				Type:        schema.TypeString,
+				Optional:    true,
+				Default:     false,
+			},
 			"config_file_path": {
 				Description: "The absolute path to the kubernetes config yml file ",
 				Type:        schema.TypeString,
@@ -151,6 +157,7 @@ func dataSourceIBMContainerClusterConfigRead(d *schema.ResourceData, meta interf
 	admin := d.Get("admin").(bool)
 	configDir := d.Get("config_dir").(string)
 	network := d.Get("network").(bool)
+	endpointType := d.Get("endpoint_type").(string)
 
 	clusterId := "Cluster_Config_" + name
 	conns.IbmMutexKV.Lock(clusterId)
@@ -170,7 +177,7 @@ func dataSourceIBMContainerClusterConfigRead(d *schema.ResourceData, meta interf
 		expectedDir := v1.ComputeClusterConfigDir(configDir, name, admin)
 		configPath = filepath.Join(expectedDir, "config.yml")
 		if !helpers.FileExists(configPath) {
-			return fmt.Errorf(`[ERROR] Couldn't  find the cluster config at expected path %s. Please set "download" to true to download the new config`, configPath)
+			return fmt.Errorf(`[ERROR] Couldn't find the cluster config at expected path %s. Please set "download" to true to download the new config`, configPath)
 		}
 		d.Set("config_file_path", configPath)
 
@@ -185,7 +192,7 @@ func dataSourceIBMContainerClusterConfigRead(d *schema.ResourceData, meta interf
 			var clusterKeyDetails v1.ClusterKeyInfo
 			err = resource.Retry(5*time.Minute, func() *resource.RetryError {
 				var err error
-				calicoConfigFilePath, clusterKeyDetails, err = csAPI.StoreConfigDetail(name, configDir, admin || true, network, targetEnv)
+				calicoConfigFilePath, clusterKeyDetails, err = csAPI.StoreConfigDetail(name, configDir, admin || true, network, targetEnv, endpointType)
 				if err != nil {
 					log.Printf("[DEBUG] Failed to fetch cluster config err %s", err)
 					if strings.Contains(err.Error(), "Could not login to openshift account runtime error:") {
@@ -200,7 +207,7 @@ func dataSourceIBMContainerClusterConfigRead(d *schema.ResourceData, meta interf
 				return nil
 			})
 			if conns.IsResourceTimeoutError(err) {
-				calicoConfigFilePath, clusterKeyDetails, err = csAPI.StoreConfigDetail(name, configDir, admin || true, network, targetEnv)
+				calicoConfigFilePath, clusterKeyDetails, err = csAPI.StoreConfigDetail(name, configDir, admin || true, network, targetEnv, endpointType)
 			}
 			if err != nil {
 				return fmt.Errorf("[ERROR] Error downloading the cluster config [%s]: %s", name, err)
@@ -217,7 +224,7 @@ func dataSourceIBMContainerClusterConfigRead(d *schema.ResourceData, meta interf
 			var clusterKeyDetails v1.ClusterKeyInfo
 			err = resource.Retry(5*time.Minute, func() *resource.RetryError {
 				var err error
-				clusterKeyDetails, err = csAPI.GetClusterConfigDetail(name, configDir, admin, targetEnv)
+				clusterKeyDetails, err = csAPI.GetClusterConfigDetail(name, configDir, admin, targetEnv, endpointType)
 				if err != nil {
 					log.Printf("[DEBUG] Failed to fetch cluster config err %s", err)
 					if strings.Contains(err.Error(), "Could not login to openshift account runtime error:") {
@@ -232,7 +239,7 @@ func dataSourceIBMContainerClusterConfigRead(d *schema.ResourceData, meta interf
 				return nil
 			})
 			if conns.IsResourceTimeoutError(err) {
-				clusterKeyDetails, err = csAPI.GetClusterConfigDetail(name, configDir, admin, targetEnv)
+				clusterKeyDetails, err = csAPI.GetClusterConfigDetail(name, configDir, admin, targetEnv, endpointType)
 			}
 			if err != nil {
 				return fmt.Errorf("[ERROR] Error downloading the cluster config [%s]: %s", name, err)

--- a/ibm/service/kubernetes/data_source_ibm_container_cluster_config.go
+++ b/ibm/service/kubernetes/data_source_ibm_container_cluster_config.go
@@ -92,7 +92,6 @@ func DataSourceIBMContainerClusterConfig() *schema.Resource {
 				Description: "It can specify what kind of server URL will be used for the cluster context",
 				Type:        schema.TypeString,
 				Optional:    true,
-				Default:     false,
 			},
 			"config_file_path": {
 				Description: "The absolute path to the kubernetes config yml file ",

--- a/ibm/service/kubernetes/data_source_ibm_container_cluster_config.go
+++ b/ibm/service/kubernetes/data_source_ibm_container_cluster_config.go
@@ -89,7 +89,7 @@ func DataSourceIBMContainerClusterConfig() *schema.Resource {
 				Default:     false,
 			},
 			"endpoint_type": {
-				Description: "",
+				Description: "It can specify what kind of server URL will be used for the cluster context",
 				Type:        schema.TypeString,
 				Optional:    true,
 				Default:     false,

--- a/ibm/service/kubernetes/data_source_ibm_container_cluster_config_test.go
+++ b/ibm/service/kubernetes/data_source_ibm_container_cluster_config_test.go
@@ -5,6 +5,7 @@ package kubernetes_test
 
 import (
 	"fmt"
+	"regexp"
 	"testing"
 
 	acc "github.com/IBM-Cloud/terraform-provider-ibm/ibm/acctest"
@@ -76,6 +77,8 @@ func TestAccIBMContainer_ClusterConfigCalicoDataSourceBasic(t *testing.T) {
 						"data.ibm_container_cluster_config.testacc_ds_cluster", "config_file_path"),
 					resource.TestCheckResourceAttrSet(
 						"data.ibm_container_cluster_config.testacc_ds_cluster", "calico_config_file_path"),
+					resource.TestMatchResourceAttr(
+						"data.ibm_container_cluster_config.testacc_ds_cluster", "host", regexp.MustCompile("^https://.*private.*")),
 				),
 			},
 		},
@@ -129,10 +132,12 @@ resource "ibm_container_cluster" "testacc_cluster" {
   wait_till       = "Normal"
   public_vlan_id  = "%s"
   private_vlan_id = "%s"
+  private_service_endpoint = true
 }
 
 data "ibm_container_cluster_config" "testacc_ds_cluster" {
   cluster_name_id = ibm_container_cluster.testacc_cluster.id
   network         = true
+  endpoint_type   = "private"
 }`, clustername, acc.Datacenter, acc.MachineType, acc.PublicVlanID, acc.PrivateVlanID)
 }

--- a/website/docs/d/container_cluster_config.html.markdown
+++ b/website/docs/d/container_cluster_config.html.markdown
@@ -83,7 +83,7 @@ resource "kubernetes_namespace" "example" {
   }
 }
 ```
-## Example usage
+## Example usage5
 Example usage for connecting to Kubernetes provider for classic OpenShift cluster with host and token.
 
 ```terraform
@@ -103,6 +103,18 @@ resource "kubernetes_namespace" "example" {
 }
 ```
 
+## Example usage6
+Example for getting kubeconfig for VPC Kubernetes cluster with admin certificates and with VPE Gateway as server URL
+
+```terraform
+data "ibm_container_cluster_config" "cluster_foo" {
+  cluster_name_id = "FOO"
+  config_dir      = "/home/foo_config"
+  admint          = "true"
+  endpoint_type   = "vpe"
+}
+```
+
 
 ## Argument reference
 Review the argument references that you can specify for your data source. 
@@ -113,6 +125,7 @@ Review the argument references that you can specify for your data source.
 - `download` - (Optional, Bool) Set the value to **false** to skip downloading the configuration for the administrator. The default value is **true**. The configuration files and certificates are downloaded to the directory that you specified in `config_dir` every time that you run your infrastructure code.
 - `network` - (Optional, Bool) If set to **true**, the Calico configuration file, TLS certificates, and permission files that are required to run `calicoctl` commands in your cluster are downloaded in addition to the configuration files for the administrator. The default value is **false**. 
 - `resource_group_id` - (Optional, String) The ID of the resource group where your cluster is provisioned into. To find the resource group, run `ibmcloud resource groups` or use the `ibm_resource_group` data source. If this parameter is not provided, the `default` resource group is used.
+- `endpoint_type` - (Optional, String) The server URL for the cluster context. If you do not include this parameter, the default cluster service endpoint is used. Available options: `private`, `link` (Satellite), `vpe` (VPC). For Satellite clusters, the `link` endpoint is the default.
 
 **Deprecated reference**
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/IBM-Cloud/terraform-provider-ibm/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

Adding new parameter `endpoint_type` for cluster_config datasource (IBM Cloud Kubernetes Service). This parameter can set what kind of URL is generated into the kubeconfig. The default is public - if the cluster has public service endpoint enabled option.

Possible options: 
- empty
- private (works for classic and VPC infrastructure)
- vpe (only for VPC)
- link (only for Satellite)

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
changed tests:
```
$ make testacc TESTARGS='-run=TestAccIBMContainer_ClusterConfigCalicoDataSourceBasic'
--- PASS: TestAccIBMContainer_ClusterConfigCalicoDataSourceBasic (1074.02s)
PASS
ok      github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/kubernetes      1075.088s
```
default tests are passing too:
```
=== RUN   TestAccIBMContainer_ClusterConfigDataSourceBasic
--- PASS: TestAccIBMContainer_ClusterConfigDataSourceBasic (1315.53s)
PASS
ok      github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/kubernetes      1316.606s
...
```
