### PR TITLE
Adding support for COS Static Web hosting

### DIFF
--- a/examples/ibm-cos-bucket-object/README.md
+++ b/examples/ibm-cos-bucket-object/README.md
@@ -62,6 +62,17 @@ resource "ibm_cos_bucket_object" "object" {
   force_delete = true
 }
 ```
+## COS Website Redirect
+
+
+```hcl
+resource "ibm_cos_bucket_object" "object" {
+  bucket_crn      = ibm_cos_bucket.bucket.crn
+  bucket_location = ibm_cos_bucket.bucket.cross_region_location
+  key             = "page1.html"
+  website_redirect = "/page2.html"
+}
+```
 
 ## Requirements
 
@@ -90,6 +101,7 @@ resource "ibm_cos_bucket_object" "object" {
 | object_lock_legal_hold_status | An object lock configuration on the object, the valid states are ON/OFF. When ON prevents deletion of the object version. | `string` | false |
 | object_lock_mode | Retention modes apply different levels of protection to the objects. | `string` | false |
 | object_lock_legal_hold_status | An object cannot be deleted when the current time is earlier than the retainUntilDate. After this date, the object can be deleted. | `string` | false |
+| website_redirect | To redirect the request for a particular object. | `string` | false |
 
 ## Outputs
 

--- a/examples/ibm-cos-bucket-object/main.tf
+++ b/examples/ibm-cos-bucket-object/main.tf
@@ -62,3 +62,13 @@ resource "ibm_cos_bucket_object" "object_object_lock" {
   object_lock_legal_hold_status = "ON"
   force_delete = true
 }
+
+// COS static web hosting 
+
+resource "ibm_cos_bucket_object" "object" {
+  bucket_crn      = ibm_cos_bucket.object_lock.crn
+  bucket_location = ibm_cos_bucket.object_lock.cross_region_location
+  key             = "page1.html"
+  website_redirect = "page2.html"
+}
+

--- a/examples/ibm-cos-bucket/README.md
+++ b/examples/ibm-cos-bucket/README.md
@@ -399,6 +399,113 @@ resource ibm_cos_bucket_object_lock_configuration "objectlock" {
   }
 }
 ```
+
+
+## COS Static Webhosting
+
+Provides an  Static web hosting configuration resource. This resource is used to  configure the website to use your documents as an index for the site and to potentially display errors.It can also be used to configure more advanced options including routing rules and request redirect for your domain.
+
+## Example usage
+The following example creates an instance of IBM Cloud Object Storage, creates a bucket and adds a website configuration on the bucket.Along with the basic bucket configuration , example of redirect all requests and adding routing rules have been given below.
+
+```terraform
+
+# Create a bucket
+resource "ibm_cos_bucket" "cos_bucket_website_configuration" {
+  bucket_name           = var.bucket_name
+  resource_instance_id  = ibm_resource_instance.cos_instance.id
+  region_location       = var.regional_loc
+  storage_class         = var.standard_storage_class
+
+}
+# Give public access to above mentioned bucket
+resource "ibm_iam_access_group_policy" "policy" { 
+  depends_on = [ibm_cos_bucket.cos_bucket_website_configuration] 
+  access_group_id = data.ibm_iam_access_group.public_access_group.groups[0].id 
+  roles = ["Object Reader"] 
+
+  resources { 
+    service = "cloud-object-storage" 
+    resource_type = "bucket" 
+    resource_instance_id = "COS instance guid" 
+    resource = data.ibm_cos_bucket.cos_bucket_website_configuration.bucket_name 
+  } 
+} 
+
+# Add basic website configuration on a COS bucket
+resource ibm_cos_bucket_website_configuration "website_configuration" {
+  bucket_crn = "bucket_crn"
+  bucket_location = data.ibm_cos_bucket.cos_bucket_website_configuration.regional_location
+  website_configuration {
+    error_document{
+      key = "error.html"
+    }
+    index_document{
+      suffix = "index.html"
+    }
+  }
+}
+
+# Add a request redirect website configuration on a COS bucket
+resource ibm_cos_bucket_website_configuration "website_configuration" {
+  bucket_crn = "bucket_crn"
+  bucket_location = data.ibm_cos_bucket.cos_bucket_website_configuration.regional_location
+  website_configuration {
+    redirect_all_requests_to{
+			host_name = "exampleBucketName"
+			protocol = "https"
+		}
+  }
+}
+
+
+# Add a website configuration on a COS bucket with routing rule
+
+resource ibm_cos_bucket_website_configuration "website_configuration" {
+  bucket_crn = "bucket_crn"
+  bucket_location = data.ibm_cos_bucket.cos_bucket_website_configuration.regional_location
+  website_configuration {
+    error_document{
+      key = "error.html"
+    }
+    index_document{
+      suffix = "index.html"
+    }
+    routing_rule {
+      condition {
+        key_prefix_equals = "pages/"
+      }
+      redirect {
+        replace_key_prefix_with = "web_pages/"
+      }
+    }
+  }
+}
+
+# Add a website configuration on a COS bucket with JSON routing rule
+resource ibm_cos_bucket_website_configuration "website_configuration" {
+  bucket_crn = "bucket_crn"
+  bucket_location = data.ibm_cos_bucket.cos_bucket_website_configuration.regional_location
+  website_configuration {
+    error_document{
+      key = "error.html"
+      }
+    index_document{
+      suffix = "index.html"
+    }
+    routing_rules = <<EOF
+			[{
+			    "Condition": {
+			        "KeyPrefixEquals": "pages/"
+			     },
+			     "Redirect": {
+			        "ReplaceKeyPrefixWith": "webpages/"
+			     }
+			 }]
+			 EOF
+  }
+}
+```
 <!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 
 ## Requirements
@@ -459,4 +566,15 @@ resource ibm_cos_bucket_object_lock_configuration "objectlock" {
 | mode | Retention mode for the Object Lock configuration. | `String` | yes
 | years | Retention period in terms of years after which the object can be deleted. | `int` | no
 | days | Retention period in terms of days after which the object can be deleted. | `int` | no
+| key | Object key name to use when a 4XX class error occurs given as error document. | `String` | no
+| suffix | The home or default page of the website when static web hosting configuration is added. | `String` | Yes
+| hostname | Name of the host where requests are redirected. | `String` | Yes
+| protocol | Protocol to use when redirecting requests. The default is the protocol that is used in the original request. | `String` | No
+| http_error_code_returned_equals | HTTP error code when the redirect is applied. | `String` | No
+| key_prefix_equals | Object key name prefix when the redirect is applied. | `String` | No
+| host_name | Host name to use in the redirect request. | `String` | Yes
+| protocol | Protocol to use when redirecting requests. | `String` | No
+| http_redirect_code | HTTP redirect code to use on the response. | `String` | No
+| replace_key_with | Specific object key to use in the redirect request. | `String` | No
+| replace_key_prefix_with | Object key prefix to use in the redirect request. | `String` | No
 {: caption="inputs"}

--- a/examples/ibm-cos-bucket/main.tf
+++ b/examples/ibm-cos-bucket/main.tf
@@ -396,3 +396,103 @@ resource ibm_cos_bucket_object_lock_configuration "objectlock" {
     }
   }
 }
+
+
+
+#COS static webhosting
+
+
+# Create a bucket
+resource "ibm_cos_bucket" "cos_bucket_website_configuration" {
+  bucket_name           = var.bucket_name
+  resource_instance_id  = ibm_resource_instance.cos_instance.id
+  region_location       = var.regional_loc
+  storage_class         = var.standard_storage_class
+
+}
+# Give public access to above mentioned bucket
+resource "ibm_iam_access_group_policy" "policy" { 
+  depends_on = [ibm_cos_bucket.cos_bucket_website_configuration] 
+  access_group_id = data.ibm_iam_access_group.public_access_group.groups[0].id 
+  roles = ["Object Reader"] 
+
+  resources { 
+    service = "cloud-object-storage" 
+    resource_type = "bucket" 
+    resource_instance_id = "COS instance guid" 
+    resource = data.ibm_cos_bucket.cos_bucket_website_configuration.bucket_name 
+  } 
+} 
+
+# Add basic website configuration on a COS bucket
+resource ibm_cos_bucket_website_configuration "website_configuration" {
+  bucket_crn = "bucket_crn"
+  bucket_location = data.ibm_cos_bucket.cos_bucket_website_configuration.regional_location
+  website_configuration {
+    error_document{
+      key = "error.html"
+    }
+    index_document{
+      suffix = "index.html"
+    }
+  }
+}
+
+# Add a request redirect website configuration on a COS bucket
+resource ibm_cos_bucket_website_configuration "website_configuration" {
+  bucket_crn = "bucket_crn"
+  bucket_location = data.ibm_cos_bucket.cos_bucket_website_configuration.regional_location
+  website_configuration {
+    redirect_all_requests_to{
+			host_name = "exampleBucketName"
+			protocol = "https"
+		}
+  }
+}
+
+
+# Add a website configuration on a COS bucket with routing rule
+resource ibm_cos_bucket_website_configuration "website_configuration" {
+  bucket_crn = "bucket_crn"
+  bucket_location = data.ibm_cos_bucket.cos_bucket_website_configuration.regional_location
+  website_configuration {
+    error_document{
+      key = "error.html"
+    }
+    index_document{
+      suffix = "index.html"
+    }
+    routing_rule {
+      condition {
+        key_prefix_equals = "pages/"
+      }
+      redirect {
+        replace_key_prefix_with = "web_pages/"
+      }
+    }
+  }
+}
+
+# Add a website configuration on a COS bucket with JSON routing rule
+resource ibm_cos_bucket_website_configuration "website_configuration" {
+  bucket_crn = "bucket_crn"
+  bucket_location = data.ibm_cos_bucket.cos_bucket_website_configuration.regional_location
+  website_configuration {
+    error_document{
+      key = "error.html"
+      }
+    index_document{
+      suffix = "index.html"
+    }
+   routing_rules = <<EOF
+			[{
+			    "Condition": {
+			        "KeyPrefixEquals": "pages/"
+			     },
+			     "Redirect": {
+			        "ReplaceKeyPrefixWith": "webpages/"
+			     }
+			 }]
+			 EOF
+  }
+}

--- a/ibm/flex/structures.go
+++ b/ibm/flex/structures.go
@@ -945,6 +945,137 @@ func ObjectLockDefaultRetentionGet(in *s3.DefaultRetention) []map[string]interfa
 	}
 	return defaultRetention
 }
+
+func WebsiteConfigurationGet(in *s3.WebsiteConfiguration) []map[string]interface{} {
+	configuration := make([]map[string]interface{}, 0, 1)
+	if in != nil {
+		websiteConfig := make(map[string]interface{})
+
+		if in.ErrorDocument != nil {
+			websiteConfig["error_document"] = GetErrorDocument(in.ErrorDocument)
+		}
+		if in.IndexDocument != nil {
+			websiteConfig["index_document"] = GetIndexDocument(in.IndexDocument)
+		}
+		if in.RedirectAllRequestsTo != nil {
+			websiteConfig["redirect_all_requests_to"] = RedirectAllRequestsGet(in.RedirectAllRequestsTo)
+		}
+
+		if in.RoutingRules != nil {
+			websiteConfig["routing_rule"] = RoutingRulesGet(in.RoutingRules)
+		}
+
+		configuration = append(configuration, websiteConfig)
+	}
+	return configuration
+}
+
+func GetErrorDocument(in *s3.ErrorDocument) []map[string]interface{} {
+	errorDocumentMap := make([]map[string]interface{}, 0, 1)
+	if in != nil {
+		errorDocValue := make(map[string]interface{})
+
+		if in.Key != nil {
+			errorDocValue["key"] = aws.StringValue(in.Key)
+		}
+		errorDocumentMap = append(errorDocumentMap, errorDocValue)
+	}
+	return errorDocumentMap
+}
+
+func GetIndexDocument(in *s3.IndexDocument) []map[string]interface{} {
+	indexDocumentMap := make([]map[string]interface{}, 0, 1)
+	if in != nil {
+		indexDocumentValue := make(map[string]interface{})
+
+		if in.Suffix != nil {
+			indexDocumentValue["suffix"] = aws.StringValue(in.Suffix)
+		}
+		indexDocumentMap = append(indexDocumentMap, indexDocumentValue)
+	}
+	return indexDocumentMap
+}
+
+func RedirectAllRequestsGet(in *s3.RedirectAllRequestsTo) []map[string]interface{} {
+	redirectRequests := make([]map[string]interface{}, 0, 1)
+	if in != nil {
+		redirectRequestConfig := make(map[string]interface{})
+
+		if in.HostName != nil {
+			redirectRequestConfig["host_name"] = aws.StringValue(in.HostName)
+		}
+		if in.Protocol != nil {
+			redirectRequestConfig["protocol"] = aws.StringValue(in.Protocol)
+		}
+
+		redirectRequests = append(redirectRequests, redirectRequestConfig)
+	}
+	return redirectRequests
+}
+
+func RoutingRulesGet(in []*s3.RoutingRule) []map[string]interface{} {
+	routingRules := make([]map[string]interface{}, 0, len(in))
+	if in != nil {
+		for _, routingRuleValue := range in {
+			rule := make(map[string]interface{})
+
+			if routingRuleValue.Condition != nil {
+				rule["condition"] = RoutingRuleConditionGet(routingRuleValue.Condition)
+			}
+
+			if routingRuleValue.Redirect != nil {
+				rule["redirect"] = RoutingRuleRedirectGet(routingRuleValue.Redirect)
+			}
+
+			routingRules = append(routingRules, rule)
+		}
+	}
+	return routingRules
+}
+
+func RoutingRuleConditionGet(in *s3.Condition) []map[string]interface{} {
+	condition := make([]map[string]interface{}, 0, 1)
+	if in != nil {
+		conditionConfig := make(map[string]interface{})
+
+		if in.HttpErrorCodeReturnedEquals != nil {
+			conditionConfig["http_error_code_returned_equals"] = aws.StringValue(in.HttpErrorCodeReturnedEquals)
+		}
+		if in.KeyPrefixEquals != nil {
+			conditionConfig["key_prefix_equals"] = aws.StringValue(in.KeyPrefixEquals)
+		}
+
+		condition = append(condition, conditionConfig)
+	}
+	return condition
+}
+
+func RoutingRuleRedirectGet(in *s3.Redirect) []map[string]interface{} {
+	redirect := make([]map[string]interface{}, 0, 1)
+	if in != nil {
+		redirectConfig := make(map[string]interface{})
+
+		if in.HostName != nil {
+			redirectConfig["host_name"] = aws.StringValue(in.HostName)
+		}
+		if in.HttpRedirectCode != nil {
+			redirectConfig["http_redirect_code"] = aws.StringValue(in.HttpRedirectCode)
+		}
+		if in.Protocol != nil {
+			redirectConfig["protocol"] = aws.StringValue(in.Protocol)
+		}
+		if in.ReplaceKeyPrefixWith != nil {
+			redirectConfig["replace_key_prefix_with"] = aws.StringValue(in.ReplaceKeyPrefixWith)
+		}
+		if in.ReplaceKeyWith != nil {
+			redirectConfig["replace_key_with"] = aws.StringValue(in.ReplaceKeyWith)
+		}
+
+		redirect = append(redirect, redirectConfig)
+	}
+	return redirect
+}
+
 func FlattenLimits(in *whisk.Limits) []interface{} {
 	att := make(map[string]interface{})
 	if in.Timeout != nil {

--- a/ibm/provider/provider.go
+++ b/ibm/provider/provider.go
@@ -936,6 +936,7 @@ func Provider() *schema.Provider {
 			"ibm_cos_bucket_replication_rule":              cos.ResourceIBMCOSBucketReplicationConfiguration(),
 			"ibm_cos_bucket_object":                        cos.ResourceIBMCOSBucketObject(),
 			"ibm_cos_bucket_object_lock_configuration":     cos.ResourceIBMCOSBucketObjectlock(),
+			"ibm_cos_bucket_website_configuration":         cos.ResourceIBMCOSBucketWebsiteConfiguration(),
 			"ibm_dns_domain":                               classicinfrastructure.ResourceIBMDNSDomain(),
 			"ibm_dns_domain_registration_nameservers":      classicinfrastructure.ResourceIBMDNSDomainRegistrationNameservers(),
 			"ibm_dns_secondary":                            classicinfrastructure.ResourceIBMDNSSecondary(),

--- a/ibm/service/cos/data_source_ibm_cos_bucket.go
+++ b/ibm/service/cos/data_source_ibm_cos_bucket.go
@@ -860,8 +860,6 @@ func dataSourceIBMCosBucketRead(d *schema.ResourceData, meta interface{}) error 
 	}
 
 	if outputBucketWebsite != nil {
-		println("output is not nil")
-		fmt.Println(outputBucketWebsiteptr)
 		websiteConfiguration := flex.WebsiteConfigurationGet(outputBucketWebsiteptr)
 		if len(websiteConfiguration) > 0 {
 			d.Set("website_configuration", websiteConfiguration)

--- a/ibm/service/cos/data_source_ibm_cos_bucket.go
+++ b/ibm/service/cos/data_source_ibm_cos_bucket.go
@@ -18,6 +18,7 @@ import (
 	"github.com/IBM/ibm-cos-sdk-go/aws/session"
 	"github.com/IBM/ibm-cos-sdk-go/service/s3"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/structure"
 )
 
 var bucketTypes = []string{"single_site_location", "region_location", "cross_region_location"}
@@ -421,6 +422,130 @@ func DataSourceIBMCosBucket() *schema.Resource {
 					},
 				},
 			},
+			"website_configuration": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"error_document": {
+							Type:     schema.TypeList,
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"key": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+								},
+							},
+						},
+						"index_document": {
+							Type:     schema.TypeList,
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"suffix": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+								},
+							},
+						},
+						"redirect_all_requests_to": {
+							Type:     schema.TypeList,
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"host_name": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"protocol": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+								},
+							},
+						},
+						"routing_rule": {
+							Type:        schema.TypeList,
+							Computed:    true,
+							Description: "Rules that define when a redirect is applied and the redirect behavior.",
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"condition": {
+										Type:        schema.TypeList,
+										Computed:    true,
+										Description: "A condition that must be met for the specified redirect to be applie.",
+										Elem: &schema.Resource{
+											Schema: map[string]*schema.Schema{
+												"http_error_code_returned_equals": {
+													Type:        schema.TypeString,
+													Computed:    true,
+													Description: "The HTTP error code when the redirect is applied. Valid codes are 4XX or 5XX..",
+												},
+												"key_prefix_equals": {
+													Type:        schema.TypeString,
+													Computed:    true,
+													Description: "The object key name prefix when the redirect is applied..",
+												},
+											},
+										},
+									},
+									"redirect": {
+										Type:        schema.TypeList,
+										Computed:    true,
+										Description: ".",
+										Elem: &schema.Resource{
+											Schema: map[string]*schema.Schema{
+												"host_name": {
+													Type:        schema.TypeString,
+													Computed:    true,
+													Description: "The host name the request should be redirected to.",
+												},
+												"http_redirect_code": {
+													Type:        schema.TypeString,
+													Computed:    true,
+													Description: "The HTTP redirect code to use on the response. Valid codes are 3XX except 300..",
+												},
+												"protocol": {
+													Type:        schema.TypeString,
+													Computed:    true,
+													Description: "Protocol to be used in the Location header that is returned in the response.",
+												},
+												"replace_key_prefix_with": {
+													Type:        schema.TypeString,
+													Computed:    true,
+													Description: "The prefix of the object key name that replaces the value of KeyPrefixEquals in the redirect request.",
+												},
+												"replace_key_with": {
+													Type:        schema.TypeString,
+													Computed:    true,
+													Description: "The object key to be used in the Location header that is returned in the response.",
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+						"routing_rules": {
+							Type:        schema.TypeString,
+							Optional:    true,
+							Computed:    true,
+							Description: "Rules that define when a redirect is applied and the redirect behavior.",
+							StateFunc: func(v interface{}) string {
+								json, _ := structure.NormalizeJsonString(v)
+								return json
+							},
+						},
+					},
+				},
+			},
+			"website_endpoint": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
 		},
 	}
 }
@@ -722,6 +847,30 @@ func dataSourceIBMCosBucketRead(d *schema.ResourceData, meta interface{}) error 
 		if len(objectLockConfiguration) > 0 {
 			d.Set("object_lock_configuration", objectLockConfiguration)
 		}
+	} //getBucketConfiguration
+	getBucketWebsiteConfigurationInput := &s3.GetBucketWebsiteInput{
+		Bucket: aws.String(bucketName),
+	}
+
+	outputBucketWebsite, err := s3Client.GetBucketWebsite(getBucketWebsiteConfigurationInput)
+	var outputBucketWebsiteptr *s3.WebsiteConfiguration
+	outputBucketWebsiteptr = (*s3.WebsiteConfiguration)(outputBucketWebsite)
+	if err != nil && !strings.Contains(err.Error(), "AccessDenied: Access Denied") {
+		return err
+	}
+
+	if outputBucketWebsite != nil {
+		println("output is not nil")
+		fmt.Println(outputBucketWebsiteptr)
+		websiteConfiguration := flex.WebsiteConfigurationGet(outputBucketWebsiteptr)
+		if len(websiteConfiguration) > 0 {
+			d.Set("website_configuration", websiteConfiguration)
+		}
+		websiteEndpoint := getWebsiteEndpoint(bucketName, bucketRegion)
+		if websiteEndpoint != "" {
+			d.Set("website_endpoint", websiteEndpoint)
+		}
+
 	}
 
 	return nil

--- a/ibm/service/cos/data_source_ibm_cos_bucket_object.go
+++ b/ibm/service/cos/data_source_ibm_cos_bucket_object.go
@@ -91,6 +91,10 @@ func DataSourceIBMCosBucketObject() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
+			"website_redirect": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
 		},
 	}
 }
@@ -170,6 +174,9 @@ func dataSourceIBMCosBucketObjectRead(ctx context.Context, d *schema.ResourceDat
 	}
 	if out.ObjectLockLegalHoldStatus != nil {
 		d.Set("object_lock_legal_hold_status", out.ObjectLockLegalHoldStatus)
+	}
+	if out.WebsiteRedirectLocation != nil {
+		d.Set("website_redirect", out.WebsiteRedirectLocation)
 	}
 
 	objectID := getObjectId(bucketCRN, objectKey, bucketLocation)

--- a/ibm/service/cos/data_source_ibm_cos_bucket_object.go
+++ b/ibm/service/cos/data_source_ibm_cos_bucket_object.go
@@ -93,7 +93,7 @@ func DataSourceIBMCosBucketObject() *schema.Resource {
 			},
 			"website_redirect": {
 				Type:     schema.TypeString,
-				Optional: true,
+				Computed: true,
 			},
 		},
 	}

--- a/ibm/service/cos/resource_ibm_cos_bucket_website_configuration.go
+++ b/ibm/service/cos/resource_ibm_cos_bucket_website_configuration.go
@@ -1,0 +1,507 @@
+package cos
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/conns"
+	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/flex"
+	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/validate"
+	"github.com/IBM/ibm-cos-sdk-go/aws"
+	"github.com/IBM/ibm-cos-sdk-go/service/s3"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/structure"
+	validation "github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+)
+
+func ResourceIBMCOSBucketWebsiteConfiguration() *schema.Resource {
+	return &schema.Resource{
+		Create:   resourceIBMCOSBucketWebsiteConfigurationCreate,
+		Read:     resourceIBMCOSBucketWebsiteConfigurationRead,
+		Update:   resourceIBMCOSBucketWebsiteConfigurationUpdate,
+		Delete:   resourceIBMCOSBucketWebsiteConfigurationDelete,
+		Importer: &schema.ResourceImporter{},
+
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(60 * time.Minute),
+			Update: schema.DefaultTimeout(20 * time.Minute),
+			Delete: schema.DefaultTimeout(10 * time.Minute),
+		},
+		Schema: map[string]*schema.Schema{
+			"bucket_crn": {
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: "COS bucket CRN",
+			},
+			"bucket_location": {
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: "COS bucket location",
+			},
+			"endpoint_type": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validate.ValidateAllowedStringValues([]string{"public", "private", "direct"}),
+				Description:  "COS endpoint type: public, private, direct",
+				Default:      "public",
+			},
+			"website_configuration": {
+				Type:        schema.TypeList,
+				Required:    true,
+				MaxItems:    1,
+				Description: "Configuration for Hosting a static website on COS with public access.",
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"error_document": {
+							Type:        schema.TypeList,
+							Optional:    true,
+							MaxItems:    1,
+							Description: "This is returned when an error occurs.",
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"key": {
+										Type:     schema.TypeString,
+										Required: true,
+									},
+								},
+							},
+						},
+						"index_document": {
+							Type:        schema.TypeList,
+							Optional:    true,
+							MaxItems:    1,
+							Description: "Home or the default page of the website.",
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"suffix": {
+										Type:     schema.TypeString,
+										Required: true,
+									},
+								},
+							},
+						},
+						"redirect_all_requests_to": {
+							Type:          schema.TypeList,
+							Optional:      true,
+							MaxItems:      1,
+							Description:   "Redirect requests can be set to specific page documents, individual routing rules, or redirect all requests globally to one bucket or domain.",
+							ConflictsWith: []string{"website_configuration.0.error_document", "website_configuration.0.index_document", "website_configuration.0.routing_rule", "website_configuration.0.routing_rules"},
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"host_name": {
+										Type:     schema.TypeString,
+										Required: true,
+									},
+									"protocol": {
+										Type:         schema.TypeString,
+										Optional:     true,
+										ValidateFunc: validation.StringInSlice(s3.Protocol_Values(), false),
+									},
+								},
+							},
+						},
+						"routing_rule": {
+							Type:        schema.TypeList,
+							Optional:    true,
+							Computed:    true,
+							Description: "Rules that define when a redirect is applied and the redirect behavior.",
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"condition": {
+										Type:        schema.TypeList,
+										Optional:    true,
+										MaxItems:    1,
+										Description: "A condition that must be met for the specified redirect to be applie.",
+										Elem: &schema.Resource{
+											Schema: map[string]*schema.Schema{
+												"http_error_code_returned_equals": {
+													Type:        schema.TypeString,
+													Optional:    true,
+													Description: "The HTTP error code when the redirect is applied. Valid codes are 4XX or 5XX..",
+												},
+												"key_prefix_equals": {
+													Type:        schema.TypeString,
+													Optional:    true,
+													Description: "The object key name prefix when the redirect is applied..",
+												},
+											},
+										},
+									},
+									"redirect": {
+										Type:        schema.TypeList,
+										Required:    true,
+										MaxItems:    1,
+										Description: ".",
+										Elem: &schema.Resource{
+											Schema: map[string]*schema.Schema{
+												"host_name": {
+													Type:        schema.TypeString,
+													Optional:    true,
+													Description: "The host name the request should be redirected to.",
+												},
+												"http_redirect_code": {
+													Type:        schema.TypeString,
+													Optional:    true,
+													Description: "The HTTP redirect code to use on the response. Valid codes are 3XX except 300..",
+												},
+												"protocol": {
+													Type:         schema.TypeString,
+													Optional:     true,
+													ValidateFunc: validation.StringInSlice(s3.Protocol_Values(), false),
+													Description:  "Protocol to be used in the Location header that is returned in the response.",
+												},
+												"replace_key_prefix_with": {
+													Type:        schema.TypeString,
+													Optional:    true,
+													Description: "The prefix of the object key name that replaces the value of KeyPrefixEquals in the redirect request.",
+												},
+												"replace_key_with": {
+													Type:        schema.TypeString,
+													Optional:    true,
+													Description: "The object key to be used in the Location header that is returned in the response.",
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+						"routing_rules": {
+							Type:          schema.TypeString,
+							Optional:      true,
+							Computed:      true,
+							Description:   "Rules that define when a redirect is applied and the redirect behavior.",
+							ConflictsWith: []string{"website_configuration.0.routing_rule"},
+							ValidateFunc:  validation.StringIsJSON,
+							StateFunc: func(v interface{}) string {
+								json, _ := structure.NormalizeJsonString(v)
+								return json
+							},
+						},
+					},
+				},
+			},
+			"website_endpoint": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func errorDocumentSetFunction(errorDocument []interface{}) *s3.ErrorDocument {
+	var error_document *s3.ErrorDocument
+	errorDocumentValue := s3.ErrorDocument{}
+	if len(errorDocument) != 0 {
+		errorDocumentMap := errorDocument[0].(map[string]interface{})
+		if keyValue, ok := errorDocumentMap["key"].(string); ok && keyValue != "" {
+			errorDocumentValue.Key = aws.String(keyValue)
+		}
+		error_document = &errorDocumentValue
+		return error_document
+	} else {
+		return nil
+	}
+}
+
+func indexDocumentSetFunction(indexDocument []interface{}) *s3.IndexDocument {
+	var index_document *s3.IndexDocument
+	indexDocumentValue := s3.IndexDocument{}
+	if len(indexDocument) != 0 {
+		indexDocumentMap, _ := indexDocument[0].(map[string]interface{})
+
+		if suffixValue, ok := indexDocumentMap["suffix"].(string); ok && suffixValue != "" {
+			indexDocumentValue.Suffix = aws.String(suffixValue)
+		}
+		index_document = &indexDocumentValue
+		return index_document
+	} else {
+		return nil
+	}
+}
+
+func redirectAllRequestsSetFunction(redirectAllRequestsSet []interface{}) *s3.RedirectAllRequestsTo {
+	var redirect_all_requests *s3.RedirectAllRequestsTo
+	redirectAllRequestsValue := s3.RedirectAllRequestsTo{}
+	if len(redirectAllRequestsSet) != 0 {
+		redirectAllRequestsMap, _ := redirectAllRequestsSet[0].(map[string]interface{})
+		if hostName, ok := redirectAllRequestsMap["host_name"].(string); ok && hostName != "" {
+			redirectAllRequestsValue.HostName = aws.String(hostName)
+		}
+		if protocol, ok := redirectAllRequestsMap["protocol"].(string); ok && protocol != "" {
+			redirectAllRequestsValue.Protocol = aws.String(protocol)
+		}
+		redirect_all_requests = &redirectAllRequestsValue
+		return redirect_all_requests
+	} else {
+		return nil
+	}
+}
+
+func routingRouteConditionSet(routingRuleConditionSet []interface{}) *s3.Condition {
+	var routingRuleCondition *s3.Condition
+	conditionValue := s3.Condition{}
+	if len(routingRuleConditionSet) != 0 {
+		routingRuleConditionMap, _ := routingRuleConditionSet[0].(map[string]interface{})
+		if httpErrorCodeReturnedEquals, ok := routingRuleConditionMap["http_error_code_returned_equals"].(string); ok && httpErrorCodeReturnedEquals != "" {
+			conditionValue.HttpErrorCodeReturnedEquals = aws.String(httpErrorCodeReturnedEquals)
+		}
+		if keyPrefixEquals, ok := routingRuleConditionMap["key_prefix_equals"].(string); ok && keyPrefixEquals != "" {
+			conditionValue.KeyPrefixEquals = aws.String(keyPrefixEquals)
+		}
+		routingRuleCondition = &conditionValue
+		return routingRuleCondition
+	} else {
+		return nil
+	}
+}
+
+func routingRouteRedirectSet(routingRuleRedirectSet []interface{}) *s3.Redirect {
+	var routingRuleRedirect *s3.Redirect
+	redirectValue := s3.Redirect{}
+	if len(routingRuleRedirectSet) != 0 {
+		routingRuleRedirectMap, _ := routingRuleRedirectSet[0].(map[string]interface{})
+		if hostName, ok := routingRuleRedirectMap["host_name"].(string); ok && hostName != "" {
+			redirectValue.HostName = aws.String(hostName)
+		}
+		if httpRedirectCode, ok := routingRuleRedirectMap["http_redirect_code"].(string); ok && httpRedirectCode != "" {
+			redirectValue.HttpRedirectCode = aws.String(httpRedirectCode)
+		}
+		if protocol, ok := routingRuleRedirectMap["protocol"].(string); ok && protocol != "" {
+			redirectValue.Protocol = aws.String(protocol)
+		}
+		if replaceKeyPrefixWith, ok := routingRuleRedirectMap["replace_key_prefix_with"].(string); ok && replaceKeyPrefixWith != "" {
+			redirectValue.ReplaceKeyPrefixWith = aws.String(replaceKeyPrefixWith)
+		}
+		if replaceKeyWith, ok := routingRuleRedirectMap["replace_key_with"].(string); ok && replaceKeyWith != "" {
+			redirectValue.ReplaceKeyWith = aws.String(replaceKeyWith)
+		}
+		routingRuleRedirect = &redirectValue
+		return routingRuleRedirect
+	} else {
+		return nil
+	}
+}
+
+func routingRuleSetFunction(routingRuleSet []interface{}) []*s3.RoutingRule {
+	var rules []*s3.RoutingRule
+	for _, l := range routingRuleSet {
+		ruleMap, ok := l.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		routing_rule := s3.RoutingRule{}
+		if condition, ok := ruleMap["condition"].([]interface{}); ok && len(condition) > 0 && condition[0] != nil {
+			routing_rule.Condition = routingRouteConditionSet(condition)
+		}
+		if redirect, ok := ruleMap["redirect"].([]interface{}); ok && len(redirect) > 0 && redirect[0] != nil {
+			routing_rule.Redirect = routingRouteRedirectSet(redirect)
+		}
+		rules = append(rules, &routing_rule)
+	}
+	return rules
+}
+
+func websiteConfigurationSet(websiteConfigurationList []interface{}) (*s3.WebsiteConfiguration, error) {
+	var websiteConfig *s3.WebsiteConfiguration
+	website_configuration := s3.WebsiteConfiguration{}
+	configurationMap, _ := websiteConfigurationList[0].(map[string]interface{})
+	// error document is provided
+	if errorDocumentSet, exist := configurationMap["error_document"]; exist {
+		website_configuration.ErrorDocument = errorDocumentSetFunction(errorDocumentSet.([]interface{}))
+	}
+	//index document is provided
+	if indexDocumentSet, exist := configurationMap["index_document"]; exist {
+		website_configuration.IndexDocument = indexDocumentSetFunction(indexDocumentSet.([]interface{}))
+	}
+	//redirect_all_requests_to is provided
+	if redirectAllRequestsSet, exist := configurationMap["redirect_all_requests_to"]; exist {
+
+		website_configuration.RedirectAllRequestsTo = redirectAllRequestsSetFunction(redirectAllRequestsSet.([]interface{}))
+	}
+	// routing_rules provided
+	if routingRulesSet, exist := configurationMap["routing_rule"]; exist {
+		website_configuration.RoutingRules = routingRuleSetFunction(routingRulesSet.([]interface{}))
+	}
+	// if json routing routes are provided
+	if routingRulesJsonSet, exist := configurationMap["routing_rules"]; exist {
+		jsonValue := fmt.Sprint(configurationMap["routing_rules"])
+		if jsonValue != "" {
+			var unmarshalledRules []*s3.RoutingRule
+			if err := json.Unmarshal([]byte(routingRulesJsonSet.(string)), &unmarshalledRules); err != nil {
+				return nil, fmt.Errorf("failed to update the json routing rules in the website configuration : %v", err)
+			}
+			fmt.Println("unmarshal rules : ", unmarshalledRules)
+			website_configuration.RoutingRules = unmarshalledRules
+		}
+	}
+	websiteConfig = &website_configuration
+	return websiteConfig, nil
+}
+
+func resourceIBMCOSBucketWebsiteConfigurationCreate(d *schema.ResourceData, meta interface{}) error {
+	bucketCRN := d.Get("bucket_crn").(string)
+	bucketName := strings.Split(bucketCRN, ":bucket:")[1]
+	instanceCRN := fmt.Sprintf("%s::", strings.Split(bucketCRN, ":bucket:")[0])
+	bucketLocation := d.Get("bucket_location").(string)
+	endpointType := d.Get("endpoint_type").(string)
+	bxSession, err := meta.(conns.ClientSession).BluemixSession()
+	if err != nil {
+		return err
+	}
+	s3Client, err := getS3ClientSession(bxSession, bucketLocation, endpointType, instanceCRN)
+	var websiteConfiguration *s3.WebsiteConfiguration
+	configuration, ok := d.GetOk("website_configuration")
+	if ok {
+		websiteConfiguration, err = websiteConfigurationSet(configuration.([]interface{}))
+	}
+	if err != nil {
+		return fmt.Errorf("failed to read website configuration for COS bucket %s, %v", bucketName, err)
+	}
+	putBucketWebsiteConfigurationInput := s3.PutBucketWebsiteInput{
+		Bucket:               aws.String(bucketName),
+		WebsiteConfiguration: websiteConfiguration,
+	}
+	_, err = s3Client.PutBucketWebsite(&putBucketWebsiteConfigurationInput)
+
+	if err != nil {
+		return fmt.Errorf("failed to put website configuration on the COS bucket %s, %v", bucketName, err)
+	}
+	bktID := fmt.Sprintf("%s:%s:%s:meta:%s:%s", strings.Replace(instanceCRN, "::", "", -1), "bucket", bucketName, bucketLocation, endpointType)
+	d.SetId(bktID)
+	return resourceIBMCOSBucketWebsiteConfigurationUpdate(d, meta)
+}
+
+func resourceIBMCOSBucketWebsiteConfigurationUpdate(d *schema.ResourceData, meta interface{}) error {
+	bucketCRN := d.Get("bucket_crn").(string)
+	bucketName := strings.Split(bucketCRN, ":bucket:")[1]
+	instanceCRN := fmt.Sprintf("%s::", strings.Split(bucketCRN, ":bucket:")[0])
+	bucketLocation := d.Get("bucket_location").(string)
+	endpointType := d.Get("endpoint_type").(string)
+	bxSession, err := meta.(conns.ClientSession).BluemixSession()
+	if err != nil {
+		return err
+	}
+	s3Client, err := getS3ClientSession(bxSession, bucketLocation, endpointType, instanceCRN)
+	if err != nil {
+		return err
+	}
+	if d.HasChange("website_configuration") {
+		var websiteConfiguration *s3.WebsiteConfiguration
+		configuration, ok := d.GetOk("website_configuration")
+		if ok {
+			websiteConfiguration, err = websiteConfigurationSet(configuration.([]interface{}))
+
+		}
+		if err != nil {
+			return fmt.Errorf("failed to read website configuration for COS bucket %s, %v", bucketName, err)
+		}
+		putBucketWebsiteConfigurationInput := s3.PutBucketWebsiteInput{
+			Bucket:               aws.String(bucketName),
+			WebsiteConfiguration: websiteConfiguration,
+		}
+		_, err = s3Client.PutBucketWebsite(&putBucketWebsiteConfigurationInput)
+
+		if err != nil {
+			return fmt.Errorf("failed to update website configuration on the COS bucket %s, %v", bucketName, err)
+		}
+	}
+	return resourceIBMCOSBucketWebsiteConfigurationRead(d, meta)
+}
+
+func resourceIBMCOSBucketWebsiteConfigurationRead(d *schema.ResourceData, meta interface{}) error {
+	bucketCRN := parseWebsiteId(d.Id(), "bucketCRN")
+	bucketName := parseWebsiteId(d.Id(), "bucketName")
+	bucketLocation := parseWebsiteId(d.Id(), "bucketLocation")
+	instanceCRN := parseWebsiteId(d.Id(), "instanceCRN")
+	endpointType := parseWebsiteId(d.Id(), "endpointType")
+	d.Set("bucket_crn", bucketCRN)
+	d.Set("bucket_location", bucketLocation)
+	if endpointType != "" {
+		d.Set("endpoint_type", endpointType)
+	}
+	bxSession, err := meta.(conns.ClientSession).BluemixSession()
+	if err != nil {
+		return err
+	}
+	s3Client, err := getS3ClientSession(bxSession, bucketLocation, endpointType, instanceCRN)
+	if err != nil {
+		return err
+	}
+	//getBucketConfiguration
+	getBucketWebsiteConfigurationInput := &s3.GetBucketWebsiteInput{
+		Bucket: aws.String(bucketName),
+	}
+	output, err := s3Client.GetBucketWebsite(getBucketWebsiteConfigurationInput)
+	var outputptr *s3.WebsiteConfiguration
+	outputptr = (*s3.WebsiteConfiguration)(output)
+	if err != nil && !strings.Contains(err.Error(), "AccessDenied: Access Denied") {
+		return err
+	}
+	if output != nil {
+		websiteConfiguration := flex.WebsiteConfigurationGet(outputptr)
+		if len(websiteConfiguration) > 0 {
+			d.Set("website_configuration", websiteConfiguration)
+		}
+		websiteEndpoint := getWebsiteEndpoint(bucketName, bucketLocation)
+		if websiteEndpoint != "" {
+			d.Set("website_endpoint", websiteEndpoint)
+		}
+	}
+	return nil
+}
+
+func resourceIBMCOSBucketWebsiteConfigurationDelete(d *schema.ResourceData, meta interface{}) error {
+	bucketName := parseWebsiteId(d.Id(), "bucketName")
+	bucketLocation := parseWebsiteId(d.Id(), "bucketLocation")
+	instanceCRN := parseWebsiteId(d.Id(), "instanceCRN")
+	endpointType := parseWebsiteId(d.Id(), "endpointType")
+	bxSession, err := meta.(conns.ClientSession).BluemixSession()
+	if err != nil {
+		return err
+	}
+	s3Client, err := getS3ClientSession(bxSession, bucketLocation, endpointType, instanceCRN)
+	if err != nil {
+		return err
+	}
+	deleteBucketWebsiteInput := &s3.DeleteBucketWebsiteInput{
+		Bucket: aws.String(bucketName),
+	}
+	_, err = s3Client.DeleteBucketWebsite(deleteBucketWebsiteInput)
+	if err != nil {
+		return fmt.Errorf("failed to delete the objectlock configuration on the COS bucket %s, %v", bucketName, err)
+	}
+	return nil
+}
+
+func parseWebsiteId(id string, info string) string {
+	bucketCRN := strings.Split(id, ":meta:")[0]
+	meta := strings.Split(id, ":meta:")[1]
+	if info == "bucketName" {
+		return strings.Split(bucketCRN, ":bucket:")[1]
+	}
+	if info == "instanceCRN" {
+		return fmt.Sprintf("%s::", strings.Split(bucketCRN, ":bucket:")[0])
+	}
+	if info == "bucketCRN" {
+		return bucketCRN
+	}
+	if info == "bucketLocation" {
+		return strings.Split(meta, ":")[0]
+	}
+	if info == "endpointType" {
+		return strings.Split(meta, ":")[1]
+	}
+	if info == "keyName" {
+		return strings.Split(meta, ":key:")[1]
+	}
+	return parseBucketId(bucketCRN, info)
+}
+
+func getWebsiteEndpoint(bucketName string, bucketLocation string) string {
+	return fmt.Sprintf("https://%s.s3-web.%s.cloud-object-storage.appdomain.cloud", bucketName, bucketLocation)
+}

--- a/ibm/service/cos/resource_ibm_cos_bucket_website_configuration_test.go
+++ b/ibm/service/cos/resource_ibm_cos_bucket_website_configuration_test.go
@@ -1,0 +1,1004 @@
+package cos_test
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	acc "github.com/IBM-Cloud/terraform-provider-ibm/ibm/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+func TestAccIBMCosBucket_Website_Configuration_Bucket_Basic(t *testing.T) {
+	serviceName := fmt.Sprintf("terraform_%d", acctest.RandIntRange(10, 100))
+	bucketName := fmt.Sprintf("terraformStaticWebHosting%d", acctest.RandIntRange(10, 100))
+	bucketRegion := "us"
+	bucketClass := "standard"
+	bucketRegionType := "cross_region_location"
+	indexSuffix := "index.html"
+	errorKey := "error.html"
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { acc.TestAccPreCheck(t) },
+		Providers:    acc.TestAccProviders,
+		CheckDestroy: testAccCheckIBMCosBucketDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckIBMCosBucket_Website_Configuration_Bucket_Basic(serviceName, bucketName, bucketRegionType, bucketRegion, bucketClass, indexSuffix, errorKey),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckIBMCosBucketExists("ibm_resource_instance.instance", "ibm_cos_bucket.bucket", bucketRegionType, bucketRegion, bucketName),
+					resource.TestCheckResourceAttr("ibm_cos_bucket.bucket", "bucket_name", bucketName),
+					resource.TestCheckResourceAttr("ibm_cos_bucket.bucket", "storage_class", bucketClass),
+					resource.TestCheckResourceAttr("ibm_cos_bucket.bucket", "cross_region_location", bucketRegion),
+					resource.TestCheckResourceAttr("ibm_cos_bucket_website_configuration.website", "website_configuration.#", "1"),
+					resource.TestCheckResourceAttr("ibm_cos_bucket_website_configuration.website", "website_configuration.0.error_document.0.key", errorKey),
+					resource.TestCheckResourceAttr("ibm_cos_bucket_website_configuration.website", "website_configuration.0.index_document.0.suffix", indexSuffix),
+				),
+			},
+		},
+	})
+}
+
+func TestAccIBMCosBucket_Website_Configuration_Bucket_Without_Public_Access(t *testing.T) {
+	serviceName := fmt.Sprintf("terraform_%d", acctest.RandIntRange(10, 100))
+	bucketName := fmt.Sprintf("terraformStaticWebHosting%d", acctest.RandIntRange(10, 100))
+	bucketRegion := "us"
+	bucketClass := "standard"
+	bucketRegionType := "cross_region_location"
+	indexSuffix := "index.html"
+	errorKey := "error.html"
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { acc.TestAccPreCheck(t) },
+		Providers:    acc.TestAccProviders,
+		CheckDestroy: testAccCheckIBMCosBucketDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckIBMCosBucket_Website_Configuration_Bucket_Without_Public_Access(serviceName, bucketName, bucketRegionType, bucketRegion, bucketClass, indexSuffix, errorKey),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckIBMCosBucketExists("ibm_resource_instance.instance", "ibm_cos_bucket.bucket", bucketRegionType, bucketRegion, bucketName),
+					resource.TestCheckResourceAttr("ibm_cos_bucket.bucket", "bucket_name", bucketName),
+					resource.TestCheckResourceAttr("ibm_cos_bucket.bucket", "storage_class", bucketClass),
+					resource.TestCheckResourceAttr("ibm_cos_bucket.bucket", "cross_region_location", bucketRegion),
+					resource.TestCheckResourceAttr("ibm_cos_bucket_website_configuration.website", "website_configuration.#", "1"),
+					resource.TestCheckResourceAttr("ibm_cos_bucket_website_configuration.website", "website_configuration.0.error_document.0.key", errorKey),
+					resource.TestCheckResourceAttr("ibm_cos_bucket_website_configuration.website", "website_configuration.0.index_document.0.suffix", indexSuffix),
+				),
+			},
+		},
+	})
+}
+func TestAccIBMCosBucket_Website_Configuration_Bucket_Index_Document_Only(t *testing.T) {
+	serviceName := fmt.Sprintf("terraform_%d", acctest.RandIntRange(10, 100))
+	bucketName := fmt.Sprintf("terraformStaticWebHosting%d", acctest.RandIntRange(10, 100))
+	bucketRegion := "us"
+	bucketClass := "standard"
+	bucketRegionType := "cross_region_location"
+	indexSuffix := "index.html"
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { acc.TestAccPreCheck(t) },
+		Providers:    acc.TestAccProviders,
+		CheckDestroy: testAccCheckIBMCosBucketDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckIBMCosBucket_Website_Configuration_Bucket_Index_Document_Only(serviceName, bucketName, bucketRegionType, bucketRegion, bucketClass, indexSuffix),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckIBMCosBucketExists("ibm_resource_instance.instance", "ibm_cos_bucket.bucket", bucketRegionType, bucketRegion, bucketName),
+					resource.TestCheckResourceAttr("ibm_cos_bucket.bucket", "bucket_name", bucketName),
+					resource.TestCheckResourceAttr("ibm_cos_bucket.bucket", "storage_class", bucketClass),
+					resource.TestCheckResourceAttr("ibm_cos_bucket.bucket", "cross_region_location", bucketRegion),
+					resource.TestCheckResourceAttr("ibm_cos_bucket_website_configuration.website", "website_configuration.#", "1"),
+					resource.TestCheckResourceAttr("ibm_cos_bucket_website_configuration.website", "website_configuration.0.index_document.0.suffix", indexSuffix),
+				),
+			},
+		},
+	})
+}
+
+func TestAccIBMCosBucket_Website_Configuration_Bucket_With_Routing_Rule(t *testing.T) {
+	serviceName := fmt.Sprintf("terraform_%d", acctest.RandIntRange(10, 100))
+	bucketName := fmt.Sprintf("terraformStaticWebHosting%d", acctest.RandIntRange(10, 100))
+	bucketRegion := "us"
+	bucketClass := "standard"
+	bucketRegionType := "cross_region_location"
+	indexSuffix := "index.html"
+	errorKey := "error.html"
+	hostName := fmt.Sprintf(bucketName, ".s3-web.us-south.cloud-object-storage.appdomain.cloud")
+	protocol := "https"
+	routingRulehttpRedirectCode := "302"
+	routingRuleReplaceKeyWith := "error404.html"
+	routingRulehttpErrorCodeReturnedEquals := "404"
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { acc.TestAccPreCheck(t) },
+		Providers:    acc.TestAccProviders,
+		CheckDestroy: testAccCheckIBMCosBucketDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckIBMCosBucket_Website_Configuration_Bucket_With_Routing_Rule(serviceName, bucketName, bucketRegionType, bucketRegion, bucketClass, indexSuffix, errorKey, routingRulehttpErrorCodeReturnedEquals, hostName, protocol, routingRulehttpRedirectCode, routingRuleReplaceKeyWith),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckIBMCosBucketExists("ibm_resource_instance.instance", "ibm_cos_bucket.bucket", bucketRegionType, bucketRegion, bucketName),
+					resource.TestCheckResourceAttr("ibm_cos_bucket.bucket", "bucket_name", bucketName),
+					resource.TestCheckResourceAttr("ibm_cos_bucket.bucket", "storage_class", bucketClass),
+					resource.TestCheckResourceAttr("ibm_cos_bucket.bucket", "cross_region_location", bucketRegion),
+					resource.TestCheckResourceAttr("ibm_cos_bucket_website_configuration.website", "website_configuration.#", "1"),
+					resource.TestCheckResourceAttr("ibm_cos_bucket_website_configuration.website", "website_configuration.0.routing_rule.0.condition.0.http_error_code_returned_equals", routingRulehttpErrorCodeReturnedEquals),
+					resource.TestCheckResourceAttr("ibm_cos_bucket_website_configuration.website", "website_configuration.0.routing_rule.0.redirect.0.host_name", hostName),
+					resource.TestCheckResourceAttr("ibm_cos_bucket_website_configuration.website", "website_configuration.0.routing_rule.0.redirect.0.protocol", protocol),
+					resource.TestCheckResourceAttr("ibm_cos_bucket_website_configuration.website", "website_configuration.0.routing_rule.0.redirect.0.http_redirect_code", routingRulehttpRedirectCode),
+					resource.TestCheckResourceAttr("ibm_cos_bucket_website_configuration.website", "website_configuration.0.routing_rule.0.redirect.0.replace_key_with", routingRuleReplaceKeyWith),
+				),
+			},
+		},
+	})
+}
+
+func TestAccIBMCosBucket_Website_Configuration_Bucket_With_JSON_Routing_Rule(t *testing.T) {
+	serviceName := fmt.Sprintf("terraform_%d", acctest.RandIntRange(10, 100))
+	bucketName := fmt.Sprintf("terraformStaticWebHosting%d", acctest.RandIntRange(10, 100))
+	bucketRegion := "us"
+	bucketClass := "standard"
+	bucketRegionType := "cross_region_location"
+	routingRuleKeyPrefixEquals := "docs/"
+	indexSuffix := "index.html"
+	errorKey := "error.html"
+	routingRuleReplaceKeyPrefixWith := "documents/"
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { acc.TestAccPreCheck(t) },
+		Providers:    acc.TestAccProviders,
+		CheckDestroy: testAccCheckIBMCosBucketDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckIBMCosBucket_Website_Configuration_Bucket_With_JSON_Routing_Rule(serviceName, bucketName, bucketRegionType, bucketRegion, bucketClass, indexSuffix, errorKey),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckIBMCosBucketExists("ibm_resource_instance.instance", "ibm_cos_bucket.bucket", bucketRegionType, bucketRegion, bucketName),
+					resource.TestCheckResourceAttr("ibm_cos_bucket.bucket", "bucket_name", bucketName),
+					resource.TestCheckResourceAttr("ibm_cos_bucket.bucket", "storage_class", bucketClass),
+					resource.TestCheckResourceAttr("ibm_cos_bucket.bucket", "cross_region_location", bucketRegion),
+					resource.TestCheckResourceAttr("ibm_cos_bucket_website_configuration.website", "website_configuration.#", "1"),
+					resource.TestCheckResourceAttr("ibm_cos_bucket_website_configuration.website", "website_configuration.0.routing_rule.0.condition.0.key_prefix_equals", routingRuleKeyPrefixEquals),
+					resource.TestCheckResourceAttr("ibm_cos_bucket_website_configuration.website", "website_configuration.0.routing_rule.0.condition.0.key_prefix_equals", routingRuleReplaceKeyPrefixWith),
+				),
+			},
+		},
+	})
+}
+func TestAccIBMCosBucket_Website_Configuration_Bucket_With_Routing_Rule_Condition_Only(t *testing.T) {
+	serviceName := fmt.Sprintf("terraform_%d", acctest.RandIntRange(10, 100))
+	bucketName := fmt.Sprintf("terraformStaticWebHosting%d", acctest.RandIntRange(10, 100))
+	bucketRegion := "us"
+	bucketClass := "standard"
+	bucketRegionType := "cross_region_location"
+	indexSuffix := "index.html"
+	errorKey := "error.html"
+	routingRulehttpErrorCodeReturnedEquals := "404"
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { acc.TestAccPreCheck(t) },
+		Providers:    acc.TestAccProviders,
+		CheckDestroy: testAccCheckIBMCosBucketDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckIBMCosBucket_Website_Configuration_Bucket_With_Routing_Rule_Condition_Only(serviceName, bucketName, bucketRegionType, bucketRegion, bucketClass, indexSuffix, errorKey, routingRulehttpErrorCodeReturnedEquals),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckIBMCosBucketExists("ibm_resource_instance.instance", "ibm_cos_bucket.bucket", bucketRegionType, bucketRegion, bucketName),
+					resource.TestCheckResourceAttr("ibm_cos_bucket.bucket", "bucket_name", bucketName),
+					resource.TestCheckResourceAttr("ibm_cos_bucket.bucket", "storage_class", bucketClass),
+					resource.TestCheckResourceAttr("ibm_cos_bucket.bucket", "cross_region_location", bucketRegion),
+					resource.TestCheckResourceAttr("ibm_cos_bucket_website_configuration.website", "website_configuration.#", "1"),
+					resource.TestCheckResourceAttr("ibm_cos_bucket_website_configuration.website", "website_configuration.0.routing_rule.0.condition.0.http_error_code_returned_equals", routingRulehttpErrorCodeReturnedEquals),
+				),
+			},
+		},
+	})
+}
+
+func TestAccIBMCosBucket_Website_Configuration_Bucket_With_Routing_Rule_Redirect_Only(t *testing.T) {
+	serviceName := fmt.Sprintf("terraform_%d", acctest.RandIntRange(10, 100))
+	bucketName := fmt.Sprintf("terraformStaticWebHosting%d", acctest.RandIntRange(10, 100))
+	bucketRegion := "us"
+	bucketClass := "standard"
+	bucketRegionType := "cross_region_location"
+	indexSuffix := "index.html"
+	errorKey := "error.html"
+	hostName := fmt.Sprintf(bucketName, ".s3-web.us-south.cloud-object-storage.appdomain.cloud")
+	protocol := "https"
+	routingRuleHttpRedirectCode := "302"
+	routingRuleReplaceKeyWith := "error404.html"
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { acc.TestAccPreCheck(t) },
+		Providers:    acc.TestAccProviders,
+		CheckDestroy: testAccCheckIBMCosBucketDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckIBMCosBucket_Website_Configuration_Bucket_With_Routing_Rule_Redirect_Only(serviceName, bucketName, bucketRegionType, bucketRegion, bucketClass, indexSuffix, errorKey, hostName, protocol, routingRuleHttpRedirectCode, routingRuleReplaceKeyWith),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckIBMCosBucketExists("ibm_resource_instance.instance", "ibm_cos_bucket.bucket", bucketRegionType, bucketRegion, bucketName),
+					resource.TestCheckResourceAttr("ibm_cos_bucket.bucket", "bucket_name", bucketName),
+					resource.TestCheckResourceAttr("ibm_cos_bucket.bucket", "storage_class", bucketClass),
+					resource.TestCheckResourceAttr("ibm_cos_bucket.bucket", "cross_region_location", bucketRegion),
+					resource.TestCheckResourceAttr("ibm_cos_bucket_website_configuration.website", "website_configuration.#", "1"),
+					resource.TestCheckResourceAttr("ibm_cos_bucket_website_configuration.website", "website_configuration.0.routing_rule.0.redirect.0.host_name", hostName),
+					resource.TestCheckResourceAttr("ibm_cos_bucket_website_configuration.website", "website_configuration.0.routing_rule.0.redirect.0.protocol", protocol),
+					resource.TestCheckResourceAttr("ibm_cos_bucket_website_configuration.website", "website_configuration.0.routing_rule.0.redirect.0.http_redirect_code", routingRuleHttpRedirectCode),
+					resource.TestCheckResourceAttr("ibm_cos_bucket_website_configuration.website", "website_configuration.0.routing_rule.0.redirect.0.replace_key_with", routingRuleReplaceKeyWith),
+				),
+			},
+		},
+	})
+}
+
+func TestAccIBMCosBucket_Website_Configuration_Bucket_With_Multiple_Routing_Rules(t *testing.T) {
+	serviceName := fmt.Sprintf("terraform_%d", acctest.RandIntRange(10, 100))
+	bucketName := fmt.Sprintf("terraformStaticWebHosting%d", acctest.RandIntRange(10, 100))
+	bucketRegion := "us"
+	bucketClass := "standard"
+	bucketRegionType := "cross_region_location"
+	indexSuffix := "index.html"
+	errorKey := "error.html"
+	hostName := fmt.Sprintf(bucketName, ".s3-web.us-south.cloud-object-storage.appdomain.cloud")
+	protocol := "https"
+	routingRuleHttpRedirectCode := "302"
+	routingRuleReplaceKeyWith := "error404.html"
+	routingRuleHttpErrorCodeReturnedEquals := "404"
+	routingRuleHttpRedirectCode2 := "303"
+	routingRuleReplaceKeyWith2 := "error405.html"
+	routingRuleHttpErrorCodeReturnedEquals2 := "405"
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { acc.TestAccPreCheck(t) },
+		Providers:    acc.TestAccProviders,
+		CheckDestroy: testAccCheckIBMCosBucketDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckIBMCosBucket_Website_Configuration_Bucket_With_Multiple_Routing_Rule(serviceName, bucketName, bucketRegionType, bucketRegion, bucketClass, indexSuffix, errorKey, routingRuleHttpErrorCodeReturnedEquals, hostName, protocol, routingRuleHttpRedirectCode, routingRuleReplaceKeyWith, routingRuleHttpErrorCodeReturnedEquals2, routingRuleHttpRedirectCode2, routingRuleReplaceKeyWith2),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckIBMCosBucketExists("ibm_resource_instance.instance", "ibm_cos_bucket.bucket", bucketRegionType, bucketRegion, bucketName),
+					resource.TestCheckResourceAttr("ibm_cos_bucket.bucket", "bucket_name", bucketName),
+					resource.TestCheckResourceAttr("ibm_cos_bucket.bucket", "storage_class", bucketClass),
+					resource.TestCheckResourceAttr("ibm_cos_bucket.bucket", "cross_region_location", bucketRegion),
+					resource.TestCheckResourceAttr("ibm_cos_bucket_website_configuration.website", "website_configuration.#", "1"),
+					resource.TestCheckResourceAttr("ibm_cos_bucket_website_configuration.website", "website_configuration.0.routing_rule.#", "2"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccIBMCosBucket_Website_Configuration_Bucket_Upload_Object_With_Redirect(t *testing.T) {
+	serviceName := fmt.Sprintf("terraform_%d", acctest.RandIntRange(10, 100))
+	bucketName := fmt.Sprintf("terraformStaticWebHosting%d", acctest.RandIntRange(10, 100))
+	bucketRegion := "us"
+	bucketClass := "standard"
+	bucketRegionType := "cross_region_location"
+	indexSuffix := "index.html"
+	websiteRedirectLocation := "/redirect"
+	key := "key1"
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { acc.TestAccPreCheck(t) },
+		Providers:    acc.TestAccProviders,
+		CheckDestroy: testAccCheckIBMCosBucketDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckIBMCosBucket_Website_Configuration_Bucket_Upload_Object_With_Redirect(serviceName, bucketName, bucketRegionType, bucketRegion, bucketClass, indexSuffix, key, websiteRedirectLocation),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckIBMCosBucketExists("ibm_resource_instance.instance", "ibm_cos_bucket.bucket", bucketRegionType, bucketRegion, bucketName),
+					resource.TestCheckResourceAttr("ibm_cos_bucket.bucket", "bucket_name", bucketName),
+					resource.TestCheckResourceAttr("ibm_cos_bucket.bucket", "storage_class", bucketClass),
+					resource.TestCheckResourceAttr("ibm_cos_bucket.bucket", "cross_region_location", bucketRegion),
+					resource.TestCheckResourceAttr("ibm_cos_bucket_website_configuration.website", "website_configuration.#", "1"),
+					resource.TestCheckResourceAttr("ibm_cos_bucket_website_configuration.website", "website_configuration.0.index_document.0.suffix", indexSuffix),
+					resource.TestCheckResourceAttr("ibm_cos_bucket_object.object", "website_redirect", websiteRedirectLocation),
+				),
+			},
+		},
+	})
+}
+
+func TestAccIBMCosBucket_Website_Configuration_Bucket_Empty_Config(t *testing.T) {
+	serviceName := fmt.Sprintf("terraform_%d", acctest.RandIntRange(10, 100))
+	bucketName := fmt.Sprintf("terraformStaticWebHosting%d", acctest.RandIntRange(10, 100))
+	bucketRegion := "us"
+	bucketClass := "standard"
+	bucketRegionType := "cross_region_location"
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { acc.TestAccPreCheck(t) },
+		Providers:    acc.TestAccProviders,
+		CheckDestroy: testAccCheckIBMCosBucketDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccCheckIBMCosBucket_Website_Configuration_Bucket_Empty(serviceName, bucketName, bucketRegionType, bucketRegion, bucketClass),
+				ExpectError: regexp.MustCompile("Error: failed to put website configuration on the COS bucket"),
+			},
+		},
+	})
+}
+
+func TestAccIBMCosBucket_Website_Configuration_Bucket_Index_And_Redirect_Together(t *testing.T) {
+	serviceName := fmt.Sprintf("terraform_%d", acctest.RandIntRange(10, 100))
+	bucketName := fmt.Sprintf("terraformStaticWebHosting%d", acctest.RandIntRange(10, 100))
+	bucketRegion := "us"
+	bucketClass := "standard"
+	bucketRegionType := "cross_region_location"
+	indexSuffix := "index.html"
+	hostName := fmt.Sprintf(bucketName, ".s3-web.us-south.cloud-object-storage.appdomain.cloud")
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { acc.TestAccPreCheck(t) },
+		Providers:    acc.TestAccProviders,
+		CheckDestroy: testAccCheckIBMCosBucketDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccCheckIBMCosBucket_Website_Configuration_Bucket_Index_And_Redirect_Together(serviceName, bucketName, bucketRegionType, bucketRegion, bucketClass, indexSuffix, hostName),
+				ExpectError: regexp.MustCompile("Error: Conflicting configuration arguments"),
+			},
+		},
+	})
+}
+
+func TestAccIBMCosBucket_Website_Configuration_Bucket_No_Config(t *testing.T) {
+	serviceName := fmt.Sprintf("terraform_%d", acctest.RandIntRange(10, 100))
+	bucketName := fmt.Sprintf("terraformStaticWebHosting%d", acctest.RandIntRange(10, 100))
+	bucketRegion := "us"
+	bucketClass := "standard"
+	bucketRegionType := "cross_region_location"
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { acc.TestAccPreCheck(t) },
+		Providers:    acc.TestAccProviders,
+		CheckDestroy: testAccCheckIBMCosBucketDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccCheckIBMCosBucket_Website_Configuration_Bucket_No_Config(serviceName, bucketName, bucketRegionType, bucketRegion, bucketClass),
+				ExpectError: regexp.MustCompile("Error: Insufficient website_configuration blocks"),
+			},
+		},
+	})
+}
+
+func testAccCheckIBMCosBucket_Website_Configuration_Bucket_Basic(cosServiceName string, bucketName string, regiontype string, region string, storageClass string, indexSuffix string, errorKey string) string {
+
+	return fmt.Sprintf(`
+	data "ibm_resource_group" "cos_group" {
+		name = "Default"
+	}
+
+	resource "ibm_resource_instance" "instance" {
+		name              = "%s"
+		service           = "cloud-object-storage"
+		plan              = "standard"
+		location          = "global"
+		resource_group_id = data.ibm_resource_group.cos_group.id
+	}
+	resource "ibm_cos_bucket" "bucket" {
+		bucket_name           = "%s"
+		resource_instance_id  = ibm_resource_instance.instance.id
+	    cross_region_location = "%s"
+		storage_class         = "%s"
+	}
+	data "ibm_iam_access_group" "public_access_group" { 
+		access_group_name = "Public Access" 
+	} 
+	 
+	resource "ibm_iam_access_group_policy" "policy" { 
+		depends_on = [ibm_cos_bucket.bucket] 
+		access_group_id = data.ibm_iam_access_group.public_access_group.groups[0].id 
+		roles = ["Object Reader"]  
+		resources { 
+			service = "cloud-object-storage" 
+			resource_type = "bucket" 
+			resource_instance_id = "%s" 
+			resource = "%s"
+		} 
+	} 
+
+	resource ibm_cos_bucket_website_configuration "website" {
+		bucket_crn = ibm_cos_bucket.bucket.crn
+		bucket_location = ibm_cos_bucket.bucket.cross_region_location
+		website_configuration {
+		  error_document{
+		    key = "%s"
+		  }
+		  index_document{
+		    suffix = "%s"
+		  }
+		}
+	}
+	 
+	`, cosServiceName, bucketName, region, storageClass, cosServiceName, bucketName, errorKey, indexSuffix)
+}
+
+func testAccCheckIBMCosBucket_Website_Configuration_Bucket_Index_Document_Only(cosServiceName string, bucketName string, regiontype string, region string, storageClass string, indexSuffix string) string {
+
+	return fmt.Sprintf(`
+	data "ibm_resource_group" "cos_group" {
+		name = "Default"
+	}
+
+	resource "ibm_resource_instance" "instance" {
+		name              = "%s"
+		service           = "cloud-object-storage"
+		plan              = "standard"
+		location          = "global"
+		resource_group_id = data.ibm_resource_group.cos_group.id
+	}
+	resource "ibm_cos_bucket" "bucket" {
+		bucket_name           = "%s"
+		resource_instance_id  = ibm_resource_instance.instance.id
+	    cross_region_location = "%s"
+		storage_class         = "%s"
+	}
+	data "ibm_iam_access_group" "public_access_group" { 
+		access_group_name = "Public Access" 
+	} 
+	 
+	resource "ibm_iam_access_group_policy" "policy" { 
+		depends_on = [ibm_cos_bucket.bucket] 
+		access_group_id = data.ibm_iam_access_group.public_access_group.groups[0].id 
+		roles = ["Object Reader"]  
+		resources { 
+			service = "cloud-object-storage" 
+			resource_type = "bucket" 
+			resource_instance_id = "%s" 
+			resource = "%s"
+		} 
+	} 
+
+	resource ibm_cos_bucket_website_configuration "website" {
+		bucket_crn = ibm_cos_bucket.bucket.crn
+		bucket_location = ibm_cos_bucket.bucket.cross_region_location
+		website_configuration {
+		  index_document{
+		    suffix = "%s"
+		  }
+		}
+	}
+ 
+	`, cosServiceName, bucketName, region, storageClass, cosServiceName, bucketName, indexSuffix)
+}
+
+func testAccCheckIBMCosBucket_Website_Configuration_Bucket_With_Routing_Rule(cosServiceName string, bucketName string, regiontype string, region string, storageClass string, indexSuffix string, errorKey string, httpErrorCodeReturnedEquals string, hostName string, protocol string, httpsRedirectCode string, replaceKeyWith string) string {
+
+	return fmt.Sprintf(`
+	data "ibm_resource_group" "cos_group" {
+		name = "Default"
+	}
+
+	resource "ibm_resource_instance" "instance" {
+		name              = "%s"
+		service           = "cloud-object-storage"
+		plan              = "standard"
+		location          = "global"
+		resource_group_id = data.ibm_resource_group.cos_group.id
+	}
+	resource "ibm_cos_bucket" "bucket" {
+		bucket_name           = "%s"
+		resource_instance_id  = ibm_resource_instance.instance.id
+	    cross_region_location = "%s"
+		storage_class         = "%s"
+	}
+	data "ibm_iam_access_group" "public_access_group" { 
+		access_group_name = "Public Access" 
+	} 
+	 
+	resource "ibm_iam_access_group_policy" "policy" { 
+		depends_on = [ibm_cos_bucket.bucket] 
+		access_group_id = data.ibm_iam_access_group.public_access_group.groups[0].id 
+		roles = ["Object Reader"]  
+		resources { 
+			service = "cloud-object-storage" 
+			resource_type = "bucket" 
+			resource_instance_id = "%s" 
+			resource = "%s"
+		} 
+	} 
+	
+	resource ibm_cos_bucket_website_configuration "website" {
+		bucket_crn = ibm_cos_bucket.bucket.crn
+		bucket_location = ibm_cos_bucket.bucket.cross_region_location
+		website_configuration {
+			error_document{
+		      key = "%s"
+		    }
+		    index_document{
+		      suffix = "%s"
+		    }
+		    routing_rule{
+		      condition{
+		      http_error_code_returned_equals= "%s"
+		    }
+		    redirect{
+		      host_name= "%s"
+		      http_redirect_code= "%s"
+		      protocol = "%s"
+		      replace_key_with = "%s"
+		    	}
+		    }
+		}
+	}
+	 
+	`, cosServiceName, bucketName, region, storageClass, cosServiceName, bucketName, errorKey, indexSuffix, httpErrorCodeReturnedEquals, hostName, httpsRedirectCode, protocol, replaceKeyWith)
+}
+
+func testAccCheckIBMCosBucket_Website_Configuration_Bucket_With_JSON_Routing_Rule(cosServiceName string, bucketName string, regiontype string, region string, storageClass string, indexSuffix string, errorKey string) string {
+
+	return fmt.Sprintf(`
+	data "ibm_resource_group" "cos_group" {
+		name = "Default"
+	}
+
+	resource "ibm_resource_instance" "instance" {
+		name              = "%s"
+		service           = "cloud-object-storage"
+		plan              = "standard"
+		location          = "global"
+		resource_group_id = data.ibm_resource_group.cos_group.id
+	}
+	resource "ibm_cos_bucket" "bucket" {
+		bucket_name           = "%s"
+		resource_instance_id  = ibm_resource_instance.instance.id
+	    cross_region_location = "%s"
+		storage_class         = "%s"
+	}
+	data "ibm_iam_access_group" "public_access_group" { 
+		access_group_name = "Public Access" 
+	} 
+	 
+	resource "ibm_iam_access_group_policy" "policy" { 
+		depends_on = [ibm_cos_bucket.bucket] 
+		access_group_id = data.ibm_iam_access_group.public_access_group.groups[0].id 
+		roles = ["Object Reader"]  
+		resources { 
+			service = "cloud-object-storage" 
+			resource_type = "bucket" 
+			resource_instance_id = "%s" 
+			resource = "%s"
+		} 
+	} 
+
+	resource ibm_cos_bucket_website_configuration "website" {
+		bucket_crn = ibm_cos_bucket.bucket.crn
+		bucket_location = ibm_cos_bucket.bucket.cross_region_location
+		website_configuration {
+			error_document{
+		      key = "%s"
+		    }
+		    index_document{
+		      suffix = "%s"
+		    }
+			routing_rules = <<EOF
+			[{
+			    "Condition": {
+			        "KeyPrefixEquals": "docs/"
+			     },
+			     "Redirect": {
+			         "ReplaceKeyPrefixWith": "documents/"
+			     }
+			 }]
+			 EOF
+		}
+	}
+	 
+	`, cosServiceName, bucketName, region, storageClass, cosServiceName, bucketName, errorKey, indexSuffix)
+}
+
+func testAccCheckIBMCosBucket_Website_Configuration_Bucket_With_Routing_Rule_Condition_Only(cosServiceName string, bucketName string, regiontype string, region string, storageClass string, indexSuffix string, errorKey string, httpErrorCodeReturnedEquals string) string {
+
+	return fmt.Sprintf(`
+	data "ibm_resource_group" "cos_group" {
+		name = "Default"
+	}
+
+	resource "ibm_resource_instance" "instance" {
+		name              = "%s"
+		service           = "cloud-object-storage"
+		plan              = "standard"
+		location          = "global"
+		resource_group_id = data.ibm_resource_group.cos_group.id
+	}
+	resource "ibm_cos_bucket" "bucket" {
+		bucket_name           = "%s"
+		resource_instance_id  = ibm_resource_instance.instance.id
+	    cross_region_location = "%s"
+		storage_class         = "%s"
+	}
+	data "ibm_iam_access_group" "public_access_group" { 
+		access_group_name = "Public Access" 
+	} 
+	 
+	resource "ibm_iam_access_group_policy" "policy" { 
+		depends_on = [ibm_cos_bucket.bucket] 
+		access_group_id = data.ibm_iam_access_group.public_access_group.groups[0].id 
+		roles = ["Object Reader"]  
+		resources { 
+		service = "cloud-object-storage" 
+			resource_type = "bucket" 
+			resource_instance_id = "%s" 
+			resource = "%s"
+		} 
+	} 
+
+	resource ibm_cos_bucket_website_configuration "website" {
+		bucket_crn = ibm_cos_bucket.bucket.crn
+		bucket_location = ibm_cos_bucket.bucket.cross_region_location
+		website_configuration {
+			error_document{
+		      key = "%s"
+		    }
+		    index_document{
+		      suffix = "%s"
+		    }
+		    routing_rule{
+		      condition{
+		      http_error_code_returned_equals= "%s"
+			    }
+		    }
+		}
+	}
+	 
+	`, cosServiceName, bucketName, region, storageClass, cosServiceName, bucketName, errorKey, indexSuffix, httpErrorCodeReturnedEquals)
+}
+
+func testAccCheckIBMCosBucket_Website_Configuration_Bucket_With_Routing_Rule_Redirect_Only(cosServiceName string, bucketName string, regiontype string, region string, storageClass string, indexSuffix string, errorKey string, hostName string, protocol string, httpsRedirectCode string, replaceKeyWith string) string {
+
+	return fmt.Sprintf(`
+	data "ibm_resource_group" "cos_group" {
+		name = "Default"
+	}
+
+	resource "ibm_resource_instance" "instance" {
+		name              = "%s"
+		service           = "cloud-object-storage"
+		plan              = "standard"
+		location          = "global"
+		resource_group_id = data.ibm_resource_group.cos_group.id
+	}
+	resource "ibm_cos_bucket" "bucket" {
+		bucket_name           = "%s"
+		resource_instance_id  = ibm_resource_instance.instance.id
+	    cross_region_location = "%s"
+		storage_class         = "%s"
+	}
+	data "ibm_iam_access_group" "public_access_group" { 
+		access_group_name = "Public Access" 
+	} 
+	 
+	resource "ibm_iam_access_group_policy" "policy" { 
+		depends_on = [ibm_cos_bucket.bucket] 
+		access_group_id = data.ibm_iam_access_group.public_access_group.groups[0].id 
+		roles = ["Object Reader"]  
+		resources { 
+		service = "cloud-object-storage" 
+			resource_type = "bucket" 
+			resource_instance_id = "%s" 
+			resource = "%s"
+		} 
+	} 
+
+	resource ibm_cos_bucket_website_configuration "website" {
+		bucket_crn = ibm_cos_bucket.bucket.crn
+		bucket_location = ibm_cos_bucket.bucket.cross_region_location
+		website_configuration {
+			error_document{
+		      key = "%s"
+		    }
+		    index_document{
+		      suffix = "%s"
+		    }
+		    routing_rule{
+		    redirect{
+		      host_name= "%s"
+		      http_redirect_code= "%s"
+		      protocol = "%s"
+		      replace_key_with = "%s"
+		    	}
+		    }
+		}
+	}
+	 
+	`, cosServiceName, bucketName, region, storageClass, cosServiceName, bucketName, errorKey, indexSuffix, hostName, httpsRedirectCode, protocol, replaceKeyWith)
+}
+
+func testAccCheckIBMCosBucket_Website_Configuration_Bucket_With_Multiple_Routing_Rule(cosServiceName string, bucketName string, regiontype string, region string, storageClass string, indexSuffix string, errorKey string, httpErrorCodeReturnedEquals string, hostName string, protocol string, httpsRedirectCode string, replaceKeyWith string, httpErrorCodeReturnedEquals2 string, httpsRedirectCode2 string, replaceKeyWith2 string) string {
+
+	return fmt.Sprintf(`
+	data "ibm_resource_group" "cos_group" {
+		name = "Default"
+	}
+
+	resource "ibm_resource_instance" "instance" {
+		name              = "%s"
+		service           = "cloud-object-storage"
+		plan              = "standard"
+		location          = "global"
+		resource_group_id = data.ibm_resource_group.cos_group.id
+	}
+	resource "ibm_cos_bucket" "bucket" {
+		bucket_name           = "%s"
+		resource_instance_id  = ibm_resource_instance.instance.id
+	    cross_region_location = "%s"
+		storage_class         = "%s"
+	}
+	data "ibm_iam_access_group" "public_access_group" { 
+		access_group_name = "Public Access" 
+	} 
+	 
+	resource "ibm_iam_access_group_policy" "policy" { 
+		depends_on = [ibm_cos_bucket.bucket] 
+		access_group_id = data.ibm_iam_access_group.public_access_group.groups[0].id 
+		roles = ["Object Reader"]  
+		resources { 
+			service = "cloud-object-storage" 
+			resource_type = "bucket" 
+			resource_instance_id = "%s" 
+			resource = "%s"
+		} 
+	} 
+
+	resource ibm_cos_bucket_website_configuration "website" {
+		bucket_crn = ibm_cos_bucket.bucket.crn
+		bucket_location = ibm_cos_bucket.bucket.cross_region_location
+		website_configuration {
+			error_document{
+		      key = "%s"
+		    }
+		    index_document{
+		      suffix = "%s"
+		    }
+		    routing_rule{
+		      condition{
+		      http_error_code_returned_equals= "%s"
+		    }
+		    redirect{
+		      host_name= "%s"
+		      http_redirect_code= "%s"
+		      protocol = "%s"
+		      replace_key_with = "%s"
+		    	}
+		    }
+			routing_rule{
+				condition{
+				http_error_code_returned_equals= "%s"
+			  }
+			  redirect{
+				host_name= "%s"
+				http_redirect_code= "%s"
+				protocol = "%s"
+				replace_key_with = "%s"
+				  }
+			  }
+		}
+	}
+	 
+	`, cosServiceName, bucketName, region, storageClass, cosServiceName, bucketName, errorKey, indexSuffix, httpErrorCodeReturnedEquals, hostName, httpsRedirectCode, protocol, replaceKeyWith, httpErrorCodeReturnedEquals2, hostName, httpsRedirectCode2, protocol, replaceKeyWith2)
+}
+
+func testAccCheckIBMCosBucket_Website_Configuration_Bucket_Without_Public_Access(cosServiceName string, bucketName string, regiontype string, region string, storageClass string, indexSuffix string, errorKey string) string {
+
+	return fmt.Sprintf(`
+	data "ibm_resource_group" "cos_group" {
+		name = "Default"
+	}
+
+	resource "ibm_resource_instance" "instance" {
+		name              = "%s"
+		service           = "cloud-object-storage"
+		plan              = "standard"
+		location          = "global"
+		resource_group_id = data.ibm_resource_group.cos_group.id
+	}
+	resource "ibm_cos_bucket" "bucket" {
+		bucket_name           = "%s"
+		resource_instance_id  = ibm_resource_instance.instance.id
+	    cross_region_location = "%s"
+		storage_class         = "%s"
+	}
+	
+	resource ibm_cos_bucket_website_configuration "website" {
+		bucket_crn = ibm_cos_bucket.bucket.crn
+		bucket_location = ibm_cos_bucket.bucket.cross_region_location
+		website_configuration {
+		error_document{
+			key = "%s"
+		}
+		index_document{
+			suffix = "%s"
+		}
+		}
+	}
+	 
+	`, cosServiceName, bucketName, region, storageClass, errorKey, indexSuffix)
+}
+
+func testAccCheckIBMCosBucket_Website_Configuration_Bucket_Upload_Object_With_Redirect(cosServiceName string, bucketName string, regiontype string, region string, storageClass string, indexSuffix string, key string, websiteRedirectLocation string) string {
+
+	return fmt.Sprintf(`
+	data "ibm_resource_group" "cos_group" {
+		name = "Default"
+	}
+
+	resource "ibm_resource_instance" "instance" {
+		name              = "%s"
+		service           = "cloud-object-storage"
+		plan              = "standard"
+		location          = "global"
+		resource_group_id = data.ibm_resource_group.cos_group.id
+	}
+	resource "ibm_cos_bucket" "bucket" {
+		bucket_name           = "%s"
+		resource_instance_id  = ibm_resource_instance.instance.id
+	    cross_region_location = "%s"
+		storage_class         = "%s"
+	}
+	data "ibm_iam_access_group" "public_access_group" { 
+		access_group_name = "Public Access" 
+	} 
+	 
+	resource "ibm_iam_access_group_policy" "policy" { 
+		depends_on = [ibm_cos_bucket.bucket] 
+		access_group_id = data.ibm_iam_access_group.public_access_group.groups[0].id 
+		roles = ["Object Reader"]  
+		resources { 
+			service = "cloud-object-storage" 
+			resource_type = "bucket" 
+			resource_instance_id = "%s" 
+			resource = "%s"
+		} 
+	} 
+
+	resource ibm_cos_bucket_website_configuration "website" {
+		bucket_crn = ibm_cos_bucket.bucket.crn
+		bucket_location = ibm_cos_bucket.bucket.cross_region_location
+		website_configuration {
+		  index_document{
+		    suffix = "%s"
+		  }
+		}
+	}
+
+	resource "ibm_cos_bucket_object" "object" {
+		bucket_crn	    = ibm_cos_bucket.bucket.crn
+		bucket_location = ibm_cos_bucket.bucket.cross_region_location
+		key 					  = "%s"
+		content			    = "Acceptance testing"
+		website_redirect = "%s"
+	}
+	 
+	`, cosServiceName, bucketName, region, storageClass, cosServiceName, bucketName, indexSuffix, key, websiteRedirectLocation)
+}
+
+func testAccCheckIBMCosBucket_Website_Configuration_Bucket_Empty(cosServiceName string, bucketName string, regiontype string, region string, storageClass string) string {
+
+	return fmt.Sprintf(`
+	data "ibm_resource_group" "cos_group" {
+		name = "Default"
+	}
+
+	resource "ibm_resource_instance" "instance" {
+		name              = "%s"
+		service           = "cloud-object-storage"
+		plan              = "standard"
+		location          = "global"
+		resource_group_id = data.ibm_resource_group.cos_group.id
+	}
+	resource "ibm_cos_bucket" "bucket" {
+		bucket_name           = "%s"
+		resource_instance_id  = ibm_resource_instance.instance.id
+	    cross_region_location = "%s"
+		storage_class         = "%s"
+	}
+	data "ibm_iam_access_group" "public_access_group" { 
+		access_group_name = "Public Access" 
+	} 
+	 
+	resource "ibm_iam_access_group_policy" "policy" { 
+		depends_on = [ibm_cos_bucket.bucket] 
+		access_group_id = data.ibm_iam_access_group.public_access_group.groups[0].id 
+		roles = ["Object Reader"]  
+		resources { 
+			service = "cloud-object-storage" 
+			resource_type = "bucket" 
+			resource_instance_id = "%s" 
+			resource = "%s"
+		} 
+	} 
+
+	resource ibm_cos_bucket_website_configuration "website" {
+		bucket_crn = ibm_cos_bucket.bucket.crn
+		bucket_location = ibm_cos_bucket.bucket.cross_region_location
+		website_configuration {
+		}
+	}
+	 
+	`, cosServiceName, bucketName, region, storageClass, cosServiceName, bucketName)
+}
+
+func testAccCheckIBMCosBucket_Website_Configuration_Bucket_Index_And_Redirect_Together(cosServiceName string, bucketName string, regiontype string, region string, storageClass string, indexSuffix string, hostName string) string {
+
+	return fmt.Sprintf(`
+	data "ibm_resource_group" "cos_group" {
+		name = "Default"
+	}
+
+	resource "ibm_resource_instance" "instance" {
+		name              = "%s"
+		service           = "cloud-object-storage"
+		plan              = "standard"
+		location          = "global"
+		resource_group_id = data.ibm_resource_group.cos_group.id
+	}
+	resource "ibm_cos_bucket" "bucket" {
+		bucket_name           = "%s"
+		resource_instance_id  = ibm_resource_instance.instance.id
+	    cross_region_location = "%s"
+		storage_class         = "%s"
+	}
+	data "ibm_iam_access_group" "public_access_group" { 
+		access_group_name = "Public Access" 
+	} 
+	 
+	resource "ibm_iam_access_group_policy" "policy" { 
+		depends_on = [ibm_cos_bucket.bucket] 
+		access_group_id = data.ibm_iam_access_group.public_access_group.groups[0].id 
+		roles = ["Object Reader"]  
+		resources { 
+		service = "cloud-object-storage" 
+		resource_type = "bucket" 
+		resource_instance_id = "%s" 
+		resource = "%s"
+		} 
+	} 
+
+	resource ibm_cos_bucket_website_configuration "website" {
+		bucket_crn = ibm_cos_bucket.bucket.crn
+		bucket_location = ibm_cos_bucket.bucket.cross_region_location
+		website_configuration {
+		  index_document{
+		    suffix = "%s"
+		  }
+		  redirect_all_requests_to{
+			host_name = "%s"
+		}
+		}
+	}
+	 
+	`, cosServiceName, bucketName, region, storageClass, cosServiceName, bucketName, indexSuffix, hostName)
+}
+
+func testAccCheckIBMCosBucket_Website_Configuration_Bucket_No_Config(cosServiceName string, bucketName string, regiontype string, region string, storageClass string) string {
+
+	return fmt.Sprintf(`
+	data "ibm_resource_group" "cos_group" {
+		name = "Default"
+	}
+
+	resource "ibm_resource_instance" "instance" {
+		name              = "%s"
+		service           = "cloud-object-storage"
+		plan              = "standard"
+		location          = "global"
+		resource_group_id = data.ibm_resource_group.cos_group.id
+	}
+	resource "ibm_cos_bucket" "bucket" {
+		bucket_name           = "%s"
+		resource_instance_id  = ibm_resource_instance.instance.id
+	    cross_region_location = "%s"
+		storage_class         = "%s"
+	}
+	data "ibm_iam_access_group" "public_access_group" { 
+		access_group_name = "Public Access" 
+	} 
+	 
+	resource "ibm_iam_access_group_policy" "policy" { 
+		depends_on = [ibm_cos_bucket.bucket] 
+		access_group_id = data.ibm_iam_access_group.public_access_group.groups[0].id 
+		roles = ["Object Reader"]  
+		resources { 
+			service = "cloud-object-storage" 
+			resource_type = "bucket" 
+			resource_instance_id = "%s" 
+			resource = "%s"
+		} 
+	} 
+
+	resource ibm_cos_bucket_website_configuration "website" {
+		bucket_crn = ibm_cos_bucket.bucket.crn
+		bucket_location = ibm_cos_bucket.bucket.cross_region_location
+	}
+	 
+	`, cosServiceName, bucketName, region, storageClass, cosServiceName, bucketName)
+}

--- a/website/docs/d/cos_bucket.html.markdown
+++ b/website/docs/d/cos_bucket.html.markdown
@@ -120,6 +120,27 @@ data "ibm_cos_bucket" "object_lock_bucket" {
 
 ```
 
+
+# ibm_cos_bucket_website_configuration
+
+Retrieves an IBM Cloud Object Storage bucket with configuration added to static web hosting..
+
+## Example usage
+
+```terraform
+data "ibm_resource_group" "cos_group" {
+  name = "cos-resource-group"
+}
+
+data "ibm_cos_bucket" "static_website_bucket" {
+  bucket_name          = "bucket-name"
+  resource_instance_id = data.ibm_resource_instance.cos_instance.id
+  bucket_type          = "region_location"
+  bucket_region        = "bucket-region"
+}
+
+```
+
 ## Argument reference
 Review the argument references that you can specify for your data source. 
 
@@ -224,6 +245,8 @@ In addition to all argument reference list, you can access the following attribu
 **Note:**
 
  Either days or years should be provided for default retention, both cannot be used simultaneoulsy.
+
+ - `website_endpoint` - (String) Website endpoint, if the bucket is configured with a website. If not, this will be an empty string.
 
 - `single_site_location` - (String) The location to create a single site bucket.
 - `storage_class` - (String) The storage class of the bucket.

--- a/website/docs/d/cos_bucket.html.markdown
+++ b/website/docs/d/cos_bucket.html.markdown
@@ -120,27 +120,6 @@ data "ibm_cos_bucket" "object_lock_bucket" {
 
 ```
 
-
-# ibm_cos_bucket_website_configuration
-
-Retrieves an IBM Cloud Object Storage bucket with configuration added to static web hosting..
-
-## Example usage
-
-```terraform
-data "ibm_resource_group" "cos_group" {
-  name = "cos-resource-group"
-}
-
-data "ibm_cos_bucket" "static_website_bucket" {
-  bucket_name          = "bucket-name"
-  resource_instance_id = data.ibm_resource_instance.cos_instance.id
-  bucket_type          = "region_location"
-  bucket_region        = "bucket-region"
-}
-
-```
-
 ## Argument reference
 Review the argument references that you can specify for your data source. 
 

--- a/website/docs/d/cos_bucket_object.html.markdown
+++ b/website/docs/d/cos_bucket_object.html.markdown
@@ -57,3 +57,4 @@ In addition to all argument reference list, you can access the following attribu
 - `object_lock_mode` - (String) This is the retention mode for an object.
 - `object_lock_retain_until_date` - (String) A date after which the object can be deleted from the COS bucket.
 - `object_lock_legal_hold_status` - (String) If the value of this attribute is **ON**, then the object cannot be deleted from the COS bucket.
+- - `website_redirect` - (String) If this value is set then incoming request will be redirected to the set value..

--- a/website/docs/r/cos_bucket_object.html.markdown
+++ b/website/docs/r/cos_bucket_object.html.markdown
@@ -97,6 +97,25 @@ resource "ibm_cos_bucket_object" "cos_object_objectlock" {
 }
 ```
 
+# Website redirect 
+
+Requests can be redirected for an object to another object or URL by setting the website redirect location in the metadata of the object.
+
+**Note:**
+COS bucket with website configuration and public access enabled is a pre-requisite.For adding website configuration to a bucket please follow [static_web_hosting]()
+
+## Example usage
+
+```terraform
+
+resource "ibm_cos_bucket_object" "cos_object_objectlock" {
+  bucket_crn      = "bucket-crn"
+  bucket_location = "us-south"
+  key             = "page1.html"
+  website_redirect = "/page2.html"
+}
+```
+
 
 ## Argument reference
 Review the argument references that you can specify for your resource.
@@ -109,6 +128,7 @@ Review the argument references that you can specify for your resource.
 - `endpoint_type` - (Optional, String) The type of endpoint used to access COS. Supported values are `public`, `private`, or `direct`. Default value is `public`.
 - `etag` - (Optional, String) MD5 hexdigest used to trigger updates. The only meaningful value is `filemd5("path/to/file")`.
 - `key` - (Required, Forces new resource, String) The name of an object in the COS bucket.
+- `website_redirect` - (Optional, String) Target URL for website redirect.
 
 ## Attribute reference
 In addition to all argument reference list, you can access the following attribute reference after your resource is created.

--- a/website/docs/r/cos_bucket_website_configuration.html.markdown
+++ b/website/docs/r/cos_bucket_website_configuration.html.markdown
@@ -1,0 +1,234 @@
+---
+
+subcategory: "Object Storage"
+layout: "ibm"
+page_title: "IBM : Cloud Object Storage Static Web Hosting"
+description: 
+  "Manages IBM Cloud Object Storage Static Web Hosting"
+---
+
+# ibm_cos_bucket_website_configuration
+Provides an  Static web hosting configuration resource. This resource is used to  configure the website to use your documents as an index for the site and to potentially display errors.It can also be used to configure more advanced options including routing rules and request redirect for your domain.For more information about static web hosting please refer [Static web hsoting with COS](https://cloud.ibm.com/docs/cloud-object-storage?topic=cloud-object-storage-static-website-options) To configure a website_redirect for an object please refer [ibm_cos_bucket_object](https://registry.terraform.io/providers/IBM-Cloud/ibm/latest/docs/resources/cm_object).
+
+
+
+**Note:**
+Enabling public access to the COS bucket required to access the hosted website.Granting public access to this bucket will allow anyone to access the bucket.
+
+---
+
+## Example usage
+The following example demonstrates creating a bucket and adding the website configuration to host a static website.
+
+```terraform
+data "ibm_resource_group" "cos_group" {
+  name = "cos-resource-group"
+}
+
+resource "ibm_resource_instance" "cos_instance" {
+  name              = "cos-instance"
+  resource_group_id = data.ibm_resource_group.cos_group.id
+  service           = "cloud-object-storage"
+  plan              = "standard"
+  location          = "global"
+}
+
+resource "ibm_cos_bucket" "cos_bucket_website_configuration" {
+  bucket_name           = var.bucket_name
+  resource_instance_id  = ibm_resource_instance.cos_instance.id
+  region_location       = var.regional_loc
+  storage_class         = var.standard_storage_class
+
+}
+# Give public access to above mentioned bucket
+ 
+resource "ibm_iam_access_group_policy" "policy" { 
+  depends_on = [ibm_cos_bucket.cos_bucket_website_configuration] 
+  access_group_id = data.ibm_iam_access_group.public_access_group.groups[0].id 
+  roles = ["Object Reader"] 
+
+  resources { 
+    service = "cloud-object-storage" 
+    resource_type = "bucket" 
+    resource_instance_id = "COS instance guid" 
+    resource = data.ibm_cos_bucket.cos_bucket_website_configuration.bucket_name 
+  } 
+} 
+
+resource ibm_cos_bucket_website_configuration "website" {
+  bucket_crn = "bucket_crn"
+  bucket_location = data.ibm_cos_bucket.cos_bucket_website_configuration.regional_location
+  website_configuration {
+    error_document{
+      key = "error.html"
+    }
+    index_document{
+      suffix = "index.html"
+    }
+  }
+}
+
+```
+# Adding website configuration on a bucket with redirect requests.
+All the requests can be redirected to a specific host.To redirect the request , first create a COS bucket , grant public access to the bucket and  use the `redirect_all_requests_to` argument as shown in the example:
+
+## Example usage
+
+```terraform
+// To redirect all the incoming redirect requests
+
+resource ibm_cos_bucket_website_configuration "website" {
+  bucket_crn = "bucket_crn"
+  bucket_location = data.ibm_cos_bucket.cos_bucket_website_configuration.regional_location
+  website_configuration {
+      redirect_all_requests_to{
+			host_name = "exampleBucketName" or "www.domain.com"
+			protocol = "https"
+		}
+
+  }
+}
+```
+
+# Adding website configuration with routing_rule configured.
+Routing rules define the individual rules that process incoming requests for specific pages. To configure routinge rule, first create a COS bucket , grant public access to the bucket and  use the `routing_rule` argument as shown in the example: 
+
+## Example usage
+
+```terraform
+// To redirect all the incoming redirect requests
+
+resource ibm_cos_bucket_website_configuration "website" {
+  bucket_crn = "bucket_crn"
+  bucket_location = data.ibm_cos_bucket.cos_bucket_website_configuration.regional_location
+ website_configuration {
+    error_document{
+      key = "error.html"
+    }
+    index_document{
+      suffix = "index.html"
+    }
+   routing_rule {
+    condition {
+      key_prefix_equals = "pages/"
+    }
+    redirect {
+      replace_key_prefix_with = "web_pages/"
+    }
+  }
+  }
+}
+```
+
+
+# Adding website configuration with routing_rules configured.
+Routing rules can also be configured using the `routing_rules` argument as shown in the example:
+
+## Example usage
+
+```terraform
+// To redirect all the incoming redirect requests
+
+resource ibm_cos_bucket_website_configuration "website" {
+  bucket_crn = "bucket_crn"
+  bucket_location = data.ibm_cos_bucket.cos_bucket_website_configuration.regional_location
+ website_configuration {
+    error_document{
+      key = "error.html"
+    }
+    index_document{
+      suffix = "index.html"
+    }
+    routing_rules = <<EOF
+    [{
+        "Condition": {
+            "KeyPrefixEquals": "pages/"
+        },
+        "Redirect": {
+            "ReplaceKeyPrefixWith": "web_pages/"
+        }
+    }]
+    EOF
+  }
+}
+```
+
+
+## Argument reference
+Review the argument references that you can specify for your resource. 
+- `bucket_crn` - (Required, Forces new resource, String) The CRN of the COS bucket.
+- `bucket_location` - (Required, Forces new resource, String) The location of the COS bucket.
+- `endpoint_type`- (Optional, String) The type of the endpoint either `public` or `private` or `direct` to be used for buckets. Default value is `public`.
+- `website_configuration`- (Required, List) Nested block have the following structure:
+  
+  Nested scheme for `website_configuration`:
+  - `error_document`- (Optional , Conflicts with `redirect_all_requests_to`) When a static website bucket error occurs, an HTML page of the error provided by the configured `error_document` will be returned.
+  
+  Nested scheme for `error_document`:
+  - `key`- (Required,String) Object key name to use when a 4XX class error occurs.
+
+  - `index_document`- (Optional , Required if `redirect_all_requests_to` is not specified) This is the home or default page of the website.
+  
+  Nested scheme for `index_document`:
+  - `suffix`- (Required,String)- This suffix is the document that will be returned for requests made to the root of the website .For example, if the suffix is `index.html` and you make a request to `mywebsitedomain.s3-web.us-east.cloud-object-storage.appdomain.cloud`, the data that is returned will be for `mywebsitedomain.s3-web.us-east.cloud-object-storage.appdomain.cloud/index.html`.
+  **Note:**
+    The suffix must not be empty and must not include a slash character.
+
+  - `redirec_all_requests_to`- (Optional , Required if `index_document` is not specified) Specifies the redirect behavior for every request to the bucket's website endpoint.Conflicts with `error_document`, `index_document`, and `routing_rule`.
+  
+  Nested scheme for `redirec_all_requests_to`:
+   - `host_name`- (Required,String) Name of the host where requests are redirected.
+   - `protocol`- (Optional,String) Protocol to use when redirecting requests. The default is the protocol that is used in the original request. Valid values: http, https.
+
+  - `routing_rule`- (Optional , Conflicts with `redirect_all_requests_to` is not specified) List of rules that define when a redirect is applied and the redirect behavior.
+
+
+  Nested scheme for `routing_rule`:
+   - `condition`- (Optional) Configuration block for a condition to be satisfied for the redirect behaviour to be applied.
+
+
+  Nested scheme for `condition`:
+
+   - `http_error_code_returned_equals` - (Optional, Required if key_prefix_equals is not specified) HTTP error code when the redirect is applied. If specified with `key_prefix_equals`, then both must be true for the redirect to be applied.
+   - `key_prefix_equals` - (Optional, Required if http_error_code_returned_equals is not specified) Object key name prefix when the redirect is applied. If specified with `http_error_code_returned_equals`, then both must be true for the redirect to be applied.
+  
+   - `redirect`- (Required) Configuration block for redirect behaviour.
+  Nested scheme for `redirect`:
+   - `host_name` - (Optional) Host name to use in the redirect request.
+   - `http_redirect_code` - (Optional) HTTP redirect code to use on the response.
+   - `protocol` - (Optional) Protocol to use when redirecting requests. The default is the protocol that is used in the original request. Valid values: http, https.
+   - `replace_key_prefix_with` - (Optional, Conflicts with `replace_key_with`) Object key prefix to use in the redirect request. For example, to redirect requests for all pages with prefix docs/ (objects in the docs/ folder) to documents/, you can set a condition block with key_prefix_equals set to docs/ and in the redirect set replace_key_prefix_with to /documents.
+  - `replace_key_with` - (Optional, Conflicts with `replace_key_prefix_with`) Specific object key to use in the redirect request. For example, redirect request to error.html.
+
+  - `routing_rules` - (Optional, Conflicts with `routing_rule` and `redirect_all_requests_to`) JSON array containing routing rules describing redirect behavior and when redirects are applied. Use this parameter when your routing rules contain empty String values ("") as seen in the example above.
+  
+**Note:**
+ There is a limitation of 50 routing rules per website configuration.
+
+
+## Attribute reference
+In addition to all argument reference list, you can access the following attribute reference after your resource is created.
+
+- `crn` - (String) The CRN of the bucket.
+- `id` - (String) The ID of the bucket.
+- `website_endpoint` - (String) Endpoint of the website.
+
+## Import IBM COS Bucket
+The `ibm_cos_bucket_website_configuration` resource can be imported by using the `id`. The ID is formed from the `CRN` (Cloud Resource Name). The `CRN` and bucket location can be found on the portal.
+
+id = `$CRN:meta:$bucketlocation:$endpointtype`
+
+**Syntax**
+
+```
+$ terraform import ibm_cos_bucket_website_configuration.website  `$CRN:meta:$bucketlocation:public`
+
+```
+
+**Example**
+
+```
+
+$ terraform import ibm_cos_bucket_website_configuration.website crn:v1:bluemix:public:cloud-object-storage:global:a/ee858e45752d4696b2d082bcf2357559:84aaaaa4-3a22-477b-8635-75501eac96f7:bucket:bucketname:meta:us-south:public
+
+```


### PR DESCRIPTION
Acceptance testing :

--- PASS: TestAccIBMCosBucket_Website_Configuration_Bucket_Basic (106.76s)
PASS
ok [github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/cos](https://github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/cos) 109.208s
--- PASS: TestAccIBMCosBucket_Website_Configuration_Bucket_Basic (85.53s)
PASS
ok [github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/cos](https://github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/cos) 87.162s

--- PASS: TestAccIBMCosBucket_Website_Configuration_Bucket_Index_Document_Only (85.16s)
PASS
ok [github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/cos](https://github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/cos) 86.551s

--- PASS: TestAccIBMCosBucket_Website_Configuration_Bucket_With_Routing_Rules (93.82s)
PASS
ok [github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/cos](https://github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/cos) 95.500s

--- PASS: TestAccIBMCosBucket_Website_Configuration_Bucket_With_Multiple_Routing_Rules (83.87s)
PASS
ok [github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/cos](https://github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/cos) 85.232s

--- PASS: TestAccIBMCosBucket_Website_Configuration_Bucket_Without_Public_Access (74.83s)
PASS
ok [github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/cos](https://github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/cos) 76.360s

--- PASS: TestAccIBMCosBucket_Website_Configuration_Bucket_Without_Public_Access (74.83s)
PASS
ok [github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/cos](https://github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/cos) 76.360s

--- PASS: TestAccIBMCosBucket_Website_Configuration_Bucket_Upload_Object_With_Redirect (84.16s)
PASS
ok [github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/cos](https://github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/cos) 85.631s

--- PASS: TestAccIBMCosBucket_Website_Configuration_Bucket_Empty_Config (68.45s)
PASS
ok [github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/cos](https://github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/cos) 70.028s
--- PASS: TestAccIBMCosBucket_Website_Configuration_Bucket_Index_And_Redirect_Together (0.63s)
PASS
ok [github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/cos](https://github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/cos) 2.184s
--- PASS: TestAccIBMCosBucket_Website_Configuration_Bucket_No_Config (0.62s)
PASS
ok [github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/cos](https://github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/cos) 2.131s
Existing Test cases :

--- PASS: TestAccIBMCosBucket_Objectlock_Bucket_Enabled (102.15s)
PASS
ok github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/cos 103.910s

--- PASS: TestAccIBMCosBucket_Objectlock_Configuration_Without_Rule (107.24s)
PASS
ok github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/cos 108.964s

--- PASS: TestAccIBMCosBucket_Objectlock_Configuration_Valid_Mode_and_Days (102.76s)
PASS
ok github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/cos 104.278s

--- PASS: TestAccIBMCosBucket_Objectlock_Configuration_Valid_Mode_and_Years (101.39s)
PASS
ok github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/cos 103.337s

--- PASS: TestAccIBMCosBucket_Objectlock_Configuration_Without_Mode (0.55s)
PASS
ok github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/cos 2.236s

--- PASS: TestAccIBMCosBucket_Objectlock_Configuration_Empty (0.56s)
PASS
ok github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/cos 2.252s

--- PASS: TestAccIBMCosBucket_Objectlock_Configuration_With_Mode_Only (75.71s)
PASS
ok github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/cos 77.448s

--- PASS: TestAccIBMCosBucket_Objectlock_Configuration_With_Versioning_Not_Enabled (0.56s)
PASS
ok github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/cos 2.497s

--- PASS: TestAccIBMCosBucket_Objectlock_Configuration_Invalid_Mode (69.87s)
PASS
ok github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/cos 71.573s

--- PASS: TestAccIBMCosBucket_Objectlock_Configuration_Invalid_Days (72.86s)
PASS
ok github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/cos 74.739s

--- PASS: TestAccIBMCosBucket_Objectlock_Configuration_ExistingBucket (24.54s)
PASS
ok github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/cos 27.006s

--- PASS: TestAccIBMCosBucket_Objectlock_Configuration_Updating_Objectlockrule_Years (40.85s)
PASS
ok github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/cos 42.807s

--- PASS: TestAccIBMCosBucket_Objectlock_Configuration_Updating_Objectlockrule_Days (38.20s)
PASS
ok github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/cos 39.932s

retention
--- PASS: TestAccIBMCOSBucketObjectlock_Retention_Without_Mode (44.47s)
PASS
ok github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/cos 46.163s

--- PASS: TestAccIBMCOSBucketObjectlock_Retention_Invalid_Mode (38.96s)
PASS
ok github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/cos 41.438s

--- PASS: TestAccIBMCOSBucketObjectlock_Retention_Retainuntildate_Past (33.60s)
PASS
ok github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/cos 35.893s

--- PASS: TestAccIBMCOSBucketObjectlock_Retention_Without_Retainuntildate (34.54s)
PASS
ok github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/cos 36.336s

--- PASS: TestAccIBMCOSBucketObjectlock_retention_without_objectlock_enabled (17.84s)
PASS
ok github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/cos 19.052s

--- PASS: TestAccIBMCOSBucketObjectlock_legalhold_without_objectlock_enabled (16.81s)
PASS
ok github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/cos 18.395s

--- PASS: TestAccIBMCOSBucketObject_basic (125.13s)
PASS
ok github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/cos 126.343s
--- PASS: TestAccIBMCosBucket_Basic (157.04s)
PASS
ok github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/cos 158.507s

--- PASS: TestAccIBMCosBucket_AllowedIP (171.19s)
PASS
ok github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/cos 172.893s

--- PASS: TestAccIBMCosBucket_ActivityTracker_Monitor (171.19s)
PASS
ok github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/cos 107.838s

--- PASS: TestAccIBMCosBucket_Archive_Expiration (243.26s)
PASS
ok github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/cos 244.642s

--- PASS: TestAccIBMCosBucket_Archive (194.66s)

--- PASS: TestAccIBMCosBucket_Expiredays (219.85s)
PASS
ok github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/cos 221.3