### PR TITLE
feat: add default cluster versions to cluster versions data source

### DIFF
--- a/ibm/service/kubernetes/data_source_ibm_container_cluster_versions.go
+++ b/ibm/service/kubernetes/data_source_ibm_container_cluster_versions.go
@@ -57,6 +57,16 @@ func DataSourceIBMContainerClusterVersions() *schema.Resource {
 				Computed:    true,
 				Elem:        &schema.Schema{Type: schema.TypeString},
 			},
+			"default_openshift_version": {
+				Description: "Default openshift-version",
+				Type:        schema.TypeString,
+				Computed:    true,
+			},
+			"default_kube_version": {
+				Description: "Default kube-version",
+				Type:        schema.TypeString,
+				Computed:    true,
+			},
 		},
 	}
 }
@@ -74,16 +84,26 @@ func dataSourceIBMContainerClusterVersionsRead(d *schema.ResourceData, meta inte
 
 	availableVersions, _ := verAPI.ListV1(targetEnv)
 	versions := make([]string, len(availableVersions["kubernetes"]))
+	var defaultKubeVersion string
 	for i, version := range availableVersions["kubernetes"] {
 		versions[i] = fmt.Sprintf("%d%s%d%s%d", version.Major, ".", version.Minor, ".", version.Patch)
+		if version.Default {
+			defaultKubeVersion = fmt.Sprintf("%d%s%d%s%d", version.Major, ".", version.Minor, ".", version.Patch)
+		}
 	}
 
 	openshiftVersions := make([]string, len(availableVersions["openshift"]))
+	var defaultOpenshiftVersion string
 	for i, version := range availableVersions["openshift"] {
 		openshiftVersions[i] = fmt.Sprintf("%d%s%d%s%d", version.Major, ".", version.Minor, ".", version.Patch)
+		if version.Default {
+			defaultOpenshiftVersion = fmt.Sprintf("%d%s%d%s%d", version.Major, ".", version.Minor, ".", version.Patch)
+		}
 	}
 	d.SetId(time.Now().UTC().String())
 	d.Set("valid_kube_versions", versions)
 	d.Set("valid_openshift_versions", openshiftVersions)
+	d.Set("default_kube_version", defaultKubeVersion)
+	d.Set("default_openshift_version", defaultOpenshiftVersion)
 	return nil
 }

--- a/ibm/service/kubernetes/data_source_ibm_container_cluster_versions_test.go
+++ b/ibm/service/kubernetes/data_source_ibm_container_cluster_versions_test.go
@@ -22,6 +22,8 @@ func TestAccIBMContainerClusterVersionsDataSource_basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrSet("data.ibm_container_cluster_versions.versions", "valid_kube_versions.0"),
 					resource.TestCheckResourceAttrSet("data.ibm_container_cluster_versions.versions", "valid_openshift_versions.0"),
+					resource.TestCheckResourceAttrSet("data.ibm_container_cluster_versions.versions", "default_kube_version"),
+					resource.TestCheckResourceAttrSet("data.ibm_container_cluster_versions.versions", "default_openshift_version"),
 				),
 			},
 		},

--- a/website/docs/d/container_cluster_versions.html.markdown
+++ b/website/docs/d/container_cluster_versions.html.markdown
@@ -41,3 +41,5 @@ In addition to all argument reference list, you can access the following attribu
 - `id` - (String) The unique identifier of the cluster. 
 - `valid_kube_versions` - (String) The supported Kubernetes version in IBM Cloud Kubernetes Service clusters. 
 - `valid_openshift_versions` - (String) The supported OpenShift Container Platform version in Red Hat OpenShift on IBM Cloud clusters.
+- `default_kube_version` - (String) The default Kubernetes version in IBM Cloud Kubernetes Service clusters. 
+- `default_openshift_version` - (String) The default OpenShift Container Platform version in Red Hat OpenShift on IBM Cloud clusters.


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/IBM-Cloud/terraform-provider-ibm/blob/master/.github/CONTRIBUTING.md --->

Adding new 2 attribute references: `default_kube_version` and `default_openshift_version` to `ibm_container_cluster_versions` data lookup

These attributes have a value of default kube and ocp versions in IBM Cloud Kubernetes Service clusters.

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates  [#4720](https://github.com/IBM-Cloud/terraform-provider-ibm/issues/4720)

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccIBMContainerClusterVersionsDataSource_basic'
=== RUN   TestAccIBMContainerClusterVersionsDataSource_basic
--- PASS: TestAccIBMContainerClusterVersionsDataSource_basic (12.88s)
PASS
```
