### PR TITLE
fix(IAM Policy Management): allow sourceServiceName to be optional for authorization policy

### DIFF
--- a/ibm/service/iampolicy/resource_ibm_iam_authorization_policy.go
+++ b/ibm/service/iampolicy/resource_ibm_iam_authorization_policy.go
@@ -29,19 +29,21 @@ func ResourceIBMIAMAuthorizationPolicy() *schema.Resource {
 
 		Schema: map[string]*schema.Schema{
 			"source_service_name": {
-				Type:        schema.TypeString,
-				Optional:    true,
-				Computed:    true,
-				Description: "The source service name",
-				ForceNew:    true,
+				Type:          schema.TypeString,
+				Optional:      true,
+				Computed:      true,
+				ForceNew:      true,
+				ConflictsWith: []string{"subject_attributes"},
+				Description:   "The source service name",
 			},
 
 			"target_service_name": {
-				Type:        schema.TypeString,
-				Optional:    true,
-				Computed:    true,
-				ForceNew:    true,
-				Description: "The target service name",
+				Type:          schema.TypeString,
+				Optional:      true,
+				Computed:      true,
+				ForceNew:      true,
+				ConflictsWith: []string{"subject_attributes"},
+				Description:   "The target service name",
 			},
 
 			"roles": {
@@ -124,7 +126,7 @@ func ResourceIBMIAMAuthorizationPolicy() *schema.Resource {
 				Computed:      true,
 				ForceNew:      true,
 				Description:   "Set subject attributes.",
-				ConflictsWith: []string{"source_resource_instance_id", "source_resource_group_id", "source_resource_type", "source_service_account"},
+				ConflictsWith: []string{"source_service_name", "source_resource_instance_id", "source_resource_group_id", "source_resource_type", "source_service_account"},
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"name": {
@@ -147,7 +149,7 @@ func ResourceIBMIAMAuthorizationPolicy() *schema.Resource {
 				Computed:      true,
 				ForceNew:      true,
 				Description:   "Set resource attributes.",
-				ConflictsWith: []string{"target_resource_instance_id", "target_resource_group_id", "target_resource_type"},
+				ConflictsWith: []string{"target_service_name", "target_resource_instance_id", "target_resource_group_id", "target_resource_type"},
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"name": {

--- a/ibm/service/iampolicy/resource_ibm_iam_authorization_policy.go
+++ b/ibm/service/iampolicy/resource_ibm_iam_authorization_policy.go
@@ -29,21 +29,21 @@ func ResourceIBMIAMAuthorizationPolicy() *schema.Resource {
 
 		Schema: map[string]*schema.Schema{
 			"source_service_name": {
-				Type:          schema.TypeString,
-				Optional:      true,
-				Computed:      true,
-				ForceNew:      true,
-				AtLeastOneOf:  []string{"source_service_name", "source_resource_group_id", "subject_attributes"},
-				Description:   "The source service name",
+				Type:         schema.TypeString,
+				Optional:     true,
+				Computed:     true,
+				ForceNew:     true,
+				AtLeastOneOf: []string{"source_service_name", "source_resource_group_id", "subject_attributes"},
+				Description:  "The source service name",
 			},
 
 			"target_service_name": {
-				Type:          schema.TypeString,
-				Optional:      true,
-				Computed:      true,
-				ForceNew:      true,
-				AtLeastOneOf:  []string{"target_service_name", "target_resource_type", "resource_attributes"},
-				Description:   "The target service name",
+				Type:         schema.TypeString,
+				Optional:     true,
+				Computed:     true,
+				ForceNew:     true,
+				AtLeastOneOf: []string{"target_service_name", "target_resource_type", "resource_attributes"},
+				Description:  "The target service name",
 			},
 
 			"roles": {

--- a/ibm/service/iampolicy/resource_ibm_iam_authorization_policy.go
+++ b/ibm/service/iampolicy/resource_ibm_iam_authorization_policy.go
@@ -29,11 +29,11 @@ func ResourceIBMIAMAuthorizationPolicy() *schema.Resource {
 
 		Schema: map[string]*schema.Schema{
 			"source_service_name": {
-				Type:         schema.TypeString,
-				Optional:     true,
-				Computed:     true,
-				Description:  "The source service name",
-				ForceNew:     true,
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				Description: "The source service name",
+				ForceNew:    true,
 			},
 
 			"target_service_name": {

--- a/ibm/service/iampolicy/resource_ibm_iam_authorization_policy.go
+++ b/ibm/service/iampolicy/resource_ibm_iam_authorization_policy.go
@@ -33,7 +33,7 @@ func ResourceIBMIAMAuthorizationPolicy() *schema.Resource {
 				Optional:      true,
 				Computed:      true,
 				ForceNew:      true,
-				ConflictsWith: []string{"subject_attributes"},
+				AtLeastOneOf:  []string{"source_service_name", "source_resource_group_id", "subject_attributes"},
 				Description:   "The source service name",
 			},
 
@@ -42,7 +42,7 @@ func ResourceIBMIAMAuthorizationPolicy() *schema.Resource {
 				Optional:      true,
 				Computed:      true,
 				ForceNew:      true,
-				ConflictsWith: []string{"subject_attributes"},
+				AtLeastOneOf:  []string{"target_service_name", "target_resource_type", "resource_attributes"},
 				Description:   "The target service name",
 			},
 

--- a/ibm/service/iampolicy/resource_ibm_iam_authorization_policy.go
+++ b/ibm/service/iampolicy/resource_ibm_iam_authorization_policy.go
@@ -32,7 +32,6 @@ func ResourceIBMIAMAuthorizationPolicy() *schema.Resource {
 				Type:         schema.TypeString,
 				Optional:     true,
 				Computed:     true,
-				ExactlyOneOf: []string{"source_service_name", "subject_attributes"},
 				Description:  "The source service name",
 				ForceNew:     true,
 			},
@@ -249,13 +248,15 @@ func resourceIBMIAMAuthorizationPolicyCreate(d *schema.ResourceData, meta interf
 		}
 	} else {
 
-		sourceServiceName = d.Get("source_service_name").(string)
+		if name, ok := d.GetOk("source_service_name"); ok {
+			sourceServiceName = name.(string)
 
-		serviceNameSubjectAttribute := &iampolicymanagementv1.SubjectAttribute{
-			Name:  core.StringPtr("serviceName"),
-			Value: &sourceServiceName,
+			serviceNameSubjectAttribute := &iampolicymanagementv1.SubjectAttribute{
+				Name:  core.StringPtr("serviceName"),
+				Value: &sourceServiceName,
+			}
+			policySubject.Attributes = append(policySubject.Attributes, *serviceNameSubjectAttribute)
 		}
-		policySubject.Attributes = append(policySubject.Attributes, *serviceNameSubjectAttribute)
 
 		sourceServiceAccount := userDetails.UserAccount
 		if account, ok := d.GetOk("source_service_account"); ok {

--- a/ibm/service/iampolicy/resource_ibm_iam_authorization_policy_test.go
+++ b/ibm/service/iampolicy/resource_ibm_iam_authorization_policy_test.go
@@ -156,7 +156,6 @@ func TestAccIBMIAMAuthorizationPolicy_ResourceAttributes(t *testing.T) {
 
 func TestAccIBMIAMAuthorizationPolicy_SourceResourceGroupId(t *testing.T) {
 	var conf iampolicymanagementv1.PolicyTemplateMetaData
-	// sResourceGroup := fmt.Sprintf("terraform_%d", acctest.RandIntRange(10, 100))
 	resourceName := "ibm_iam_authorization_policy.policy"
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { acc.TestAccPreCheck(t) },
@@ -184,7 +183,6 @@ func TestAccIBMIAMAuthorizationPolicy_SourceResourceGroupId(t *testing.T) {
 
 func TestAccIBMIAMAuthorizationPolicy_SourceResourceGroupId_ResourceAttributes(t *testing.T) {
 	var conf iampolicymanagementv1.PolicyTemplateMetaData
-	// sServiceInstance := fmt.Sprintf("terraform_%d", acctest.RandIntRange(10, 100))
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { acc.TestAccPreCheck(t) },
@@ -198,6 +196,48 @@ func TestAccIBMIAMAuthorizationPolicy_SourceResourceGroupId_ResourceAttributes(t
 					resource.TestCheckResourceAttrSet("ibm_iam_authorization_policy.policy", "id"),
 					resource.TestCheckResourceAttr("ibm_iam_authorization_policy.policy", "source_service_name", ""),
 					resource.TestCheckResourceAttr("ibm_iam_authorization_policy.policy", "target_service_name", "cloud-object-storage"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccIBMIAMAuthorizationPolicy_TargetResourceType(t *testing.T) {
+	var conf iampolicymanagementv1.PolicyTemplateMetaData
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { acc.TestAccPreCheck(t) },
+		Providers:    acc.TestAccProviders,
+		CheckDestroy: testAccCheckIBMIAMAuthorizationPolicyDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckIBMIAMAuthorizationPolicyTargetResourceType(),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckIBMIAMAuthorizationPolicyExists("ibm_iam_authorization_policy.policy", conf),
+					resource.TestCheckResourceAttr("ibm_iam_authorization_policy.policy", "target_service_name", ""),
+					resource.TestCheckResourceAttr("ibm_iam_authorization_policy.policy", "source_service_name", "project"),
+					resource.TestCheckResourceAttr("ibm_iam_authorization_policy.policy", "target_resource_type", "resource-group"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccIBMIAMAuthorizationPolicy_TargetResourceTypeAndResourceAttributes(t *testing.T) {
+	var conf iampolicymanagementv1.PolicyTemplateMetaData
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { acc.TestAccPreCheck(t) },
+		Providers:    acc.TestAccProviders,
+		CheckDestroy: testAccCheckIBMIAMAuthorizationPolicyDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckIBMIAMAuthorizationPolicyResourceTypeAndResourceAttributes(acc.Tg_cross_network_account_id, acc.Tg_cross_network_account_id),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckIBMIAMAuthorizationPolicyExists("ibm_iam_authorization_policy.policy", conf),
+					resource.TestCheckResourceAttr("ibm_iam_authorization_policy.policy", "target_service_name", ""),
+					resource.TestCheckResourceAttr("ibm_iam_authorization_policy.policy", "source_service_name", "project"),
+					resource.TestCheckResourceAttr("ibm_iam_authorization_policy.policy", "target_resource_type", "resource-group"),
 				),
 			},
 		},
@@ -453,6 +493,44 @@ func testAccCheckIBMIAMAuthorizationPolicySourceResourceGroupIdResourceAttribute
 			name   = "accountId"
 			value  = "%s"
 		}
+	}
+	`, sAccountID, tAccountID)
+}
+
+func testAccCheckIBMIAMAuthorizationPolicyTargetResourceType() string {
+	return `
+	resource "ibm_iam_authorization_policy" "policy" {
+		source_service_name = "project"
+		target_resource_type  = "resource-group"
+		roles                = ["Viewer"]
+	  }
+	`
+}
+
+func testAccCheckIBMIAMAuthorizationPolicyResourceTypeAndResourceAttributes(sAccountID, tAccountID string) string {
+
+	return fmt.Sprintf(`
+
+	resource "ibm_iam_authorization_policy" "policy" {
+		roles    = ["Viewer"]
+		subject_attributes {
+			name   = "accountId"
+			value  = "%s"
+		}
+		subject_attributes {
+			name   = "serviceName"
+			value  = "project"
+		}
+
+		resource_attributes {
+			name   = "resourceType"
+			value  = "resource-group"
+		}
+		resource_attributes {
+			name   = "accountId"
+			value  = "%s"
+		}
+
 	}
 	`, sAccountID, tAccountID)
 }

--- a/ibm/service/iampolicy/resource_ibm_iam_authorization_policy_test.go
+++ b/ibm/service/iampolicy/resource_ibm_iam_authorization_policy_test.go
@@ -107,7 +107,7 @@ func TestAccIBMIAMAuthorizationPolicy_ResourceType(t *testing.T) {
 					testAccCheckIBMIAMAuthorizationPolicyExists("ibm_iam_authorization_policy.policy", conf),
 					resource.TestCheckResourceAttr("ibm_iam_authorization_policy.policy", "source_service_name", "is"),
 					resource.TestCheckResourceAttr("ibm_iam_authorization_policy.policy", "source_resource_type", "load-balancer"),
-					resource.TestCheckResourceAttr("ibm_iam_authorization_policy.policy", "target_service_name", "cloudcerts"),
+					resource.TestCheckResourceAttr("ibm_iam_authorization_policy.policy", "target_service_name", "hs-crypto"),
 				),
 			},
 		},
@@ -324,7 +324,7 @@ func testAccCheckIBMIAMAuthorizationPolicyResourceType() string {
 	resource "ibm_iam_authorization_policy" "policy" {
 		source_service_name  = "is"
 		source_resource_type = "load-balancer"
-		target_service_name  = "cloudcerts"
+		target_service_name  = "hs-crypto"
 		roles                = ["Reader"]
 	  }
 	`

--- a/website/docs/d/iam_authorization_policies.html.markdown
+++ b/website/docs/d/iam_authorization_policies.html.markdown
@@ -40,7 +40,7 @@ In addition to all argument reference list, you can access the following attribu
     Nested scheme for `resources`:
     - `source_service_account` - (Optional, Forces new resource, string) The account GUID of source service.
     - `source_service_name` - (Optional, Forces new resource, string) The source service name.
-    - `target_service_name` - (Required, Forces new resource, string) The target service name.
+    - `target_service_name` - (Optional, Forces new resource, string) The target service name.
     - `source_resource_instance_id` - (Optional, Forces new resource, string) The source resource instance id.
     - `target_resource_instance_id` - (Optional, Forces new resource, string) The target resource instance id.
     - `source_resource_type` - (Optional, Forces new resource, string) The resource type of source service.

--- a/website/docs/d/iam_authorization_policies.html.markdown
+++ b/website/docs/d/iam_authorization_policies.html.markdown
@@ -47,7 +47,3 @@ In addition to all argument reference list, you can access the following attribu
     - `target_resource_type` - (Optional, Forces new resource, string) The resource type of target service.
     - `source_resource_group_id` - (Optional, Forces new resource, string) The source resource group id.
     - `target_resource_group_id` - (Optional, Forces new resource, string) The target resource group id.
-
-**Note:**
-At least one of the following subject attributes is required: `source_service_name` or `source_resource_group_id`.
-Additionally, at least one of the following resource attributes is required: `target_service_name` or `target_resource_type`.

--- a/website/docs/d/iam_authorization_policies.html.markdown
+++ b/website/docs/d/iam_authorization_policies.html.markdown
@@ -47,3 +47,7 @@ In addition to all argument reference list, you can access the following attribu
     - `target_resource_type` - (Optional, Forces new resource, string) The resource type of target service.
     - `source_resource_group_id` - (Optional, Forces new resource, string) The source resource group id.
     - `target_resource_group_id` - (Optional, Forces new resource, string) The target resource group id.
+
+**Note:**
+At least one of the following subject attributes is required: `source_service_name` or `source_resource_group_id`.
+Additionally, at least one of the following resource attributes is required: `target_service_name` or `target_resource_type`.

--- a/website/docs/d/iam_authorization_policies.html.markdown
+++ b/website/docs/d/iam_authorization_policies.html.markdown
@@ -39,7 +39,7 @@ In addition to all argument reference list, you can access the following attribu
 
     Nested scheme for `resources`:
     - `source_service_account` - (Optional, Forces new resource, string) The account GUID of source service.
-    - `source_service_name` - (Required, Forces new resource, string) The source service name.
+    - `source_service_name` - (Optional, Forces new resource, string) The source service name.
     - `target_service_name` - (Required, Forces new resource, string) The target service name.
     - `source_resource_instance_id` - (Optional, Forces new resource, string) The source resource instance id.
     - `target_resource_instance_id` - (Optional, Forces new resource, string) The target resource instance id.

--- a/website/docs/d/iam_authorization_policies.html.markdown
+++ b/website/docs/d/iam_authorization_policies.html.markdown
@@ -38,12 +38,12 @@ In addition to all argument reference list, you can access the following attribu
   - `resources`- (List of objects) A nested block describes the resources in the policy.
 
     Nested scheme for `resources`:
-    - `source_service_account` - (Optional, Forces new resource, string) The account GUID of source service.
-    - `source_service_name` - (Optional, Forces new resource, string) The source service name.
-    - `target_service_name` - (Optional, Forces new resource, string) The target service name.
-    - `source_resource_instance_id` - (Optional, Forces new resource, string) The source resource instance id.
-    - `target_resource_instance_id` - (Optional, Forces new resource, string) The target resource instance id.
-    - `source_resource_type` - (Optional, Forces new resource, string) The resource type of source service.
-    - `target_resource_type` - (Optional, Forces new resource, string) The resource type of target service.
-    - `source_resource_group_id` - (Optional, Forces new resource, string) The source resource group id.
-    - `target_resource_group_id` - (Optional, Forces new resource, string) The target resource group id.
+    - `source_service_account` - (string) The account GUID of source service.
+    - `source_service_name` - (string) The source service name.
+    - `target_service_name` - (string) The target service name.
+    - `source_resource_instance_id` - (string) The source resource instance id.
+    - `target_resource_instance_id` - (string) The target resource instance id.
+    - `source_resource_type` - (string) The resource type of source service.
+    - `target_resource_type` - (string) The resource type of target service.
+    - `source_resource_group_id` - (string) The source resource group id.
+    - `target_resource_group_id` - (string) The target resource group id.

--- a/website/docs/r/iam_authorization_policy.html.markdown
+++ b/website/docs/r/iam_authorization_policy.html.markdown
@@ -230,7 +230,7 @@ Review the argument references that you can specify for your resource.
 
 - `source_service_account` - (Optional, Forces new resource, string) The account GUID of source service.**Note** Conflicts with `subject_attributes`.
 - `source_service_name` - (Optional, Forces new resource, string) The source service name.**Note** Conflicts with `subject_attributes`.
-- `target_service_name` - (Required, Forces new resource, string) The target service name.**Note** Conflicts with `resource_attributes`.
+- `target_service_name` - (Optional, Forces new resource, string) The target service name.**Note** Conflicts with `resource_attributes`.
 - `source_resource_instance_id` - (Optional, Forces new resource, string) The source resource instance id.**Note** Conflicts with `subject_attributes`.
 - `target_resource_instance_id` - (Optional, Forces new resource, string) The target resource instance id.**Note** Conflicts with `resource_attributes`.
 - `source_resource_type` - (Optional, Forces new resource, string) The resource type of source service.**Note** Conflicts with `subject_attributes`.

--- a/website/docs/r/iam_authorization_policy.html.markdown
+++ b/website/docs/r/iam_authorization_policy.html.markdown
@@ -115,6 +115,10 @@ resource "ibm_iam_authorization_policy" "policy" {
 
 ```terraform
 
+resource "ibm_resource_group" "source_resource_group" {
+  name     = "123123"
+}
+
 resource "ibm_iam_authorization_policy" "policy" {
     roles                  = [
         "Reader",
@@ -137,9 +141,46 @@ resource "ibm_iam_authorization_policy" "policy" {
     }
     subject_attributes {
         name  = "resourceGroupId"
-        value = "abcdef123456"
+        value = ibm_resource_group.source_resource_group.id
     }
 }
+```
+
+### Authorization policy between source service and target resource type "resource-group"
+
+```terraform
+resource "ibm_iam_authorization_policy" "policy" {
+		source_service_name = "project"
+		target_resource_type  = "resource-group"
+		roles                = ["Viewer"]
+	  }
+```
+
+
+### Authorization policy between source service and target resource type "resource-group" using resource attributes
+
+```terraform
+resource "ibm_iam_authorization_policy" "policy" {
+		roles    = ["Viewer"]
+		subject_attributes {
+			name   = "accountId"
+			value  = "12345"
+		}
+		subject_attributes {
+			name   = "serviceName"
+			value  = "project"
+		}
+
+		resource_attributes {
+			name   = "resourceType"
+			value  = "resource-group"
+		}
+		resource_attributes {
+			name   = "accountId"
+			value  = "12345"
+		}
+	}
+```
 
 ### Authorization policy between two specific services.
 

--- a/website/docs/r/iam_authorization_policy.html.markdown
+++ b/website/docs/r/iam_authorization_policy.html.markdown
@@ -224,20 +224,23 @@ specific to a service `internet-svcs` use above `resource_attributes` format.<br
 
 ## Argument reference
 Review the argument references that you can specify for your resource.
+**Note:**
+At least one of the following subject attributes is required: `source_service_name`, `source_resource_group_id`, or `subject_attributes`.
+Additionally, at least one of the following resource attributes is required: `target_service_name`, `target_resource_type`, `resource_attributes`.
 
 - `description`  (Optional, String) The description of the Authorization Policy.
 - `roles` - (Required, list) The comma separated list of roles. For more information, about supported service specific roles, see  [IAM roles and actions](https://cloud.ibm.com/docs/account?topic=account-iam-service-roles-actions)
 
-- `source_service_account` - (Optional, Forces new resource, string) The account GUID of source service.**Note** Conflicts with `subject_attributes`.
-- `source_service_name` - (Optional, Forces new resource, string) The source service name.**Note** Conflicts with `subject_attributes`.
-- `target_service_name` - (Optional, Forces new resource, string) The target service name.**Note** Conflicts with `resource_attributes`.
-- `source_resource_instance_id` - (Optional, Forces new resource, string) The source resource instance id.**Note** Conflicts with `subject_attributes`.
-- `target_resource_instance_id` - (Optional, Forces new resource, string) The target resource instance id.**Note** Conflicts with `resource_attributes`.
-- `source_resource_type` - (Optional, Forces new resource, string) The resource type of source service.**Note** Conflicts with `subject_attributes`.
-- `target_resource_type` - (Optional, Forces new resource, string) The resource type of target service.**Note** Conflicts with `resource_attributes`.
-- `source_resource_group_id` - (Optional, Forces new resource, string) The source resource group id.**Note** Conflicts with `subject_attributes`.
-- `target_resource_group_id` - (Optional, Forces new resource, string) The target resource group id.**Note** Conflicts with `resource_attributes`.
-- `resource_attributes` - (Optional, Forces new resource, list) A nested block describing the resource attributes of this policy.**Note** Conflicts with `target_service_name`, `target_resource_instance_id`, `target_resource_group_id` and `target_resource_type`.
+- `source_service_account` - (Optional, Forces new resource, string) The account GUID of source service. **Note** Conflicts with `subject_attributes`.
+- `source_service_name` - (Optional, Forces new resource, string) The source service name. **Note** Conflicts with `subject_attributes`.
+- `target_service_name` - (Optional, Forces new resource, string) The target service name. **Note** Conflicts with `resource_attributes`.
+- `source_resource_instance_id` - (Optional, Forces new resource, string) The source resource instance id. **Note** Conflicts with `subject_attributes`.
+- `target_resource_instance_id` - (Optional, Forces new resource, string) The target resource instance id. **Note** Conflicts with `resource_attributes`.
+- `source_resource_type` - (Optional, Forces new resource, string) The resource type of source service. **Note** Conflicts with `subject_attributes`.
+- `target_resource_type` - (Optional, Forces new resource, string) The resource type of target service. **Note** Conflicts with `resource_attributes`.
+- `source_resource_group_id` - (Optional, Forces new resource, string) The source resource group id. **Note** Conflicts with `subject_attributes`.
+- `target_resource_group_id` - (Optional, Forces new resource, string) The target resource group id. **Note** Conflicts with `resource_attributes`.
+- `resource_attributes` - (Optional, Forces new resource, list) A nested block describing the resource attributes of this policy. **Note** Conflicts with `target_service_name`, `target_resource_instance_id`, `target_resource_group_id` and `target_resource_type`.
 
   Nested scheme for `resource_attributes`:
   - `name` - (Required, String) The name of an attribute. Supported values are `serviceName` , `serviceInstance` ,`resourceType` , `resourceGroupId` `accountId` and other service specific resource attributes.

--- a/website/docs/r/iam_authorization_policy.html.markdown
+++ b/website/docs/r/iam_authorization_policy.html.markdown
@@ -237,14 +237,14 @@ Review the argument references that you can specify for your resource.
 - `target_resource_type` - (Optional, Forces new resource, string) The resource type of target service.**Note** Conflicts with `resource_attributes`.
 - `source_resource_group_id` - (Optional, Forces new resource, string) The source resource group id.**Note** Conflicts with `subject_attributes`.
 - `target_resource_group_id` - (Optional, Forces new resource, string) The target resource group id.**Note** Conflicts with `resource_attributes`.
-- `resource_attributes` - (Optional, Forces new resource, list) A nested block describing the resource attributes of this policy.**Note** Conflicts with `target_resource_instance_id`, `target_resource_group_id` and `target_resource_type`.
+- `resource_attributes` - (Optional, Forces new resource, list) A nested block describing the resource attributes of this policy.**Note** Conflicts with `target_service_name`, `target_resource_instance_id`, `target_resource_group_id` and `target_resource_type`.
 
   Nested scheme for `resource_attributes`:
   - `name` - (Required, String) The name of an attribute. Supported values are `serviceName` , `serviceInstance` ,`resourceType` , `resourceGroupId` `accountId` and other service specific resource attributes.
   - `value` - (Required, String) The value of an attribute.
   - `operator` - (Optional, String) Operator of an attribute. The default value is `stringEquals`.
 
-- `subject_attributes` - (Optional, Forces new resource, list) A nested block describing the subject attributes of this policy.**Note** Conflicts with `source_resource_instance_id`, `source_resource_group_id` `source_resource_type` and `source_service_account`.
+- `subject_attributes` - (Optional, Forces new resource, list) A nested block describing the subject attributes of this policy.**Note** Conflicts with `source_service_name`, `source_resource_instance_id`, `source_resource_group_id` `source_resource_type` and `source_service_account`.
   
   Nested scheme for `subject_attributes`:
   - `name` - (Required, String) The name of an attribute. Supported values are `serviceName` , `serviceInstance` , `region` , `resource` , `resourceType` , `resourceGroupId` `accountId`.

--- a/website/docs/r/iam_authorization_policy.html.markdown
+++ b/website/docs/r/iam_authorization_policy.html.markdown
@@ -95,6 +95,52 @@ resource "ibm_iam_authorization_policy" "policy" {
 ```
 
 
+### Authorization policy between resource group and a target service
+
+```terraform
+resource "ibm_resource_group" "source_resource_group" {
+  name     = "123123"
+}
+
+
+resource "ibm_iam_authorization_policy" "policy" {
+  source_resource_group_id    = ibm_resource_group.source_resource_group.id
+  target_service_name         = "cloud-object-storage"
+  roles                       = ["Reader"]
+}
+
+```
+
+### Authorization policy between resource group and a target service using resource attributes
+
+```terraform
+
+resource "ibm_iam_authorization_policy" "policy" {
+    roles                  = [
+        "Reader",
+    ]
+
+    resource_attributes {
+        name     = "accountId"
+        operator = "stringEquals"
+        value    = "12345"
+    }
+    resource_attributes {
+        name     = "serviceName"
+        operator = "stringEquals"
+        value    = "cloud-object-storage"
+    }
+
+    subject_attributes {
+        name  = "accountId"
+        value = "12345"
+    }
+    subject_attributes {
+        name  = "resourceGroupId"
+        value = "abcdef123456"
+    }
+}
+
 ### Authorization policy between two specific services.
 
 ```terraform
@@ -142,7 +188,7 @@ Review the argument references that you can specify for your resource.
 - `roles` - (Required, list) The comma separated list of roles. For more information, about supported service specific roles, see  [IAM roles and actions](https://cloud.ibm.com/docs/account?topic=account-iam-service-roles-actions)
 
 - `source_service_account` - (Optional, Forces new resource, string) The account GUID of source service.**Note** Conflicts with `subject_attributes`.
-- `source_service_name` - (Required, Forces new resource, string) The source service name.**Note** Conflicts with `subject_attributes`.
+- `source_service_name` - (Optional, Forces new resource, string) The source service name.**Note** Conflicts with `subject_attributes`.
 - `target_service_name` - (Required, Forces new resource, string) The target service name.**Note** Conflicts with `resource_attributes`.
 - `source_resource_instance_id` - (Optional, Forces new resource, string) The source resource instance id.**Note** Conflicts with `subject_attributes`.
 - `target_resource_instance_id` - (Optional, Forces new resource, string) The target resource instance id.**Note** Conflicts with `resource_attributes`.


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/IBM-Cloud/terraform-provider-ibm/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes [IAM/AM-issues/issues/1777](https://github.ibm.com/IAM/AM-issues/issues/1777)

Output from acceptance testing:

Tested against test service. Waiting on COS to update service definition in staging environment to test against global catalog available service.

Update: Tested against COS, and tests passed. Results below.


<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```bash
$ make testacc TESTARGS='-run=TestAccIBMIAMAuthorizationPolicy'
PASS
ok  	github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/iampolicy	98.144s
```

Updated tests with COS:
```bash
 make testacc TESTARGS='-run=TestAccIBMIAMAuthorizationPolicy'
ok  	github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/iampolicy	204.945s
```