### PR TITLE
feat: adding the fields region and instance_id in the service scc

### DIFF
--- a/examples/ibm-scc/control_library/main.tf
+++ b/examples/ibm-scc/control_library/main.tf
@@ -1,4 +1,5 @@
 resource "ibm_scc_control_library" "scc_demo_control_library" {
+  instance_id = "00000000-1111-2222-3333-444444444444"
   control_library_name = var.scc_control_library_name 
   control_library_description = var.scc_control_library_description
   control_library_type = "custom"

--- a/examples/ibm-scc/integration/main.tf
+++ b/examples/ibm-scc/integration/main.tf
@@ -1,4 +1,5 @@
 resource "ibm_scc_provider_type_instance" "scc_provider_type_instance_instance" {
+  instance_id = "00000000-1111-2222-3333-444444444444"
   provider_type_id = var.scc_provider_type_id
   name = var.scc_provider_type_instance_instance
   attributes = var.scc_provider_type_instance_attributes

--- a/examples/ibm-scc/profile/main.tf
+++ b/examples/ibm-scc/profile/main.tf
@@ -3,6 +3,7 @@ data "ibm_scc_control_library" "scc_control_library" {
 }
 
 resource "ibm_scc_profile" "scc_demo_profile" {
+	instance_id = "00000000-1111-2222-3333-444444444444"
 	profile_type = "custom"
 	profile_description = var.ibm_scc_profile_description
 	profile_name = var.ibm_scc_profile_name
@@ -15,6 +16,7 @@ resource "ibm_scc_profile" "scc_demo_profile" {
 }
 
 resource "ibm_scc_profile_attachment" "scc_demo_profile_attachment" {
+	instance_id = "00000000-1111-2222-3333-444444444444"
 	profile_id = resource.ibm_scc_profile.scc_demo_profile.id
 	name = var.ibm_scc_profile_attachment_name
 	description = var.ibm_scc_profile_attachment_description

--- a/examples/ibm-scc/report/main.tf
+++ b/examples/ibm-scc/report/main.tf
@@ -1,32 +1,40 @@
 data "ibm_scc_latest_reports" "scc_latest_reports_instance" {
+	instance_id = "00000000-1111-2222-3333-444444444444"
 	sort = "profile_name"
 }
 
 data "ibm_scc_report_rule" "scc_report_rule_instance" {
+	instance_id = "00000000-1111-2222-3333-444444444444"
 	report_id = var.scc_report_id
 	rule_id   = var.scc_rule_id
 }
 
 data "ibm_scc_report_tags" "scc_report_tags_instance" {
+	instance_id = "00000000-1111-2222-3333-444444444444"
 	report_id = var.scc_report_id
 }
 
 data "ibm_scc_report_evaluations" "scc_report_evaluations_instance" {
+	instance_id = "00000000-1111-2222-3333-444444444444"
 	report_id = var.scc_report_id
 }
 
 data "ibm_scc_report_controls" "scc_report_controls_instance" {
+	instance_id = "00000000-1111-2222-3333-444444444444"
 	report_id = var.scc_report_id
 }
 
 data "ibm_scc_report_summary" "scc_report_summary_instance" {
+	instance_id = "00000000-1111-2222-3333-444444444444"
 	report_id = var.scc_report_id
 }
 
 data "ibm_scc_report_violation_drift" "scc_report_violation_drift_instance" {
+	instance_id = "00000000-1111-2222-3333-444444444444"
 	report_id = var.scc_report_id
 }
 
 data "ibm_scc_report" "scc_report_instance" {
+	instance_id = "00000000-1111-2222-3333-444444444444"
 	report_id = var.scc_report_id
 }

--- a/examples/ibm-scc/rule/main.tf
+++ b/examples/ibm-scc/rule/main.tf
@@ -1,5 +1,6 @@
 // Provision scc_rule resource instance
 resource "ibm_scc_rule" "scc_rule_tf_demo" {
+	instance_id = "00000000-1111-2222-3333-444444444444"
     description = var.scc_description
     target {
         service_name = "cloud-object-storage"

--- a/go.mod
+++ b/go.mod
@@ -27,7 +27,7 @@ require (
 	github.com/IBM/platform-services-go-sdk v0.48.1
 	github.com/IBM/project-go-sdk v0.0.10
 	github.com/IBM/push-notifications-go-sdk v0.0.0-20210310100607-5790b96c47f5
-	github.com/IBM/scc-go-sdk/v5 v5.0.2
+	github.com/IBM/scc-go-sdk/v5 v5.1.0
 	github.com/IBM/schematics-go-sdk v0.2.1
 	github.com/IBM/secrets-manager-go-sdk/v2 v2.0.0
 	github.com/IBM/vpc-beta-go-sdk v0.6.0

--- a/go.mod
+++ b/go.mod
@@ -27,7 +27,7 @@ require (
 	github.com/IBM/platform-services-go-sdk v0.48.1
 	github.com/IBM/project-go-sdk v0.0.10
 	github.com/IBM/push-notifications-go-sdk v0.0.0-20210310100607-5790b96c47f5
-	github.com/IBM/scc-go-sdk/v5 v5.1.0
+	github.com/IBM/scc-go-sdk/v5 v5.1.1
 	github.com/IBM/schematics-go-sdk v0.2.1
 	github.com/IBM/secrets-manager-go-sdk/v2 v2.0.0
 	github.com/IBM/vpc-beta-go-sdk v0.6.0

--- a/go.mod
+++ b/go.mod
@@ -27,7 +27,7 @@ require (
 	github.com/IBM/platform-services-go-sdk v0.48.1
 	github.com/IBM/project-go-sdk v0.0.10
 	github.com/IBM/push-notifications-go-sdk v0.0.0-20210310100607-5790b96c47f5
-	github.com/IBM/scc-go-sdk/v5 v5.1.1
+	github.com/IBM/scc-go-sdk/v5 v5.1.2
 	github.com/IBM/schematics-go-sdk v0.2.1
 	github.com/IBM/secrets-manager-go-sdk/v2 v2.0.0
 	github.com/IBM/vpc-beta-go-sdk v0.6.0

--- a/go.sum
+++ b/go.sum
@@ -162,8 +162,8 @@ github.com/IBM/project-go-sdk v0.0.10 h1:vHSuemwZ4S4c6BEb22tzsEcPTs/5LnZ0yKpP3GG
 github.com/IBM/project-go-sdk v0.0.10/go.mod h1:lqe0M4cKvABI1iHR1b+KfasVcxQL6nl2VJ8eOyQs8Ig=
 github.com/IBM/push-notifications-go-sdk v0.0.0-20210310100607-5790b96c47f5 h1:NPUhkoOCRuv3OFWt19PmwjXGGTKlvmbuPg9fUrBUNe4=
 github.com/IBM/push-notifications-go-sdk v0.0.0-20210310100607-5790b96c47f5/go.mod h1:b07XHUVh0XYnQE9s2mqgjYST1h9buaQNqN4EcKhOsX0=
-github.com/IBM/scc-go-sdk/v5 v5.1.1 h1:tBkTJh1xk0NYvLSfX5/fPVwjcsJocytKU/7LlQ/Z0sk=
-github.com/IBM/scc-go-sdk/v5 v5.1.1/go.mod h1:YtAVlzq10bwR82QX4ZavhDIwa1s85RuVO9N/KmXVcuk=
+github.com/IBM/scc-go-sdk/v5 v5.1.2 h1:9axGtNlP3bHhoE9yJgCuc+g5/VdyhYqfhZ5oS3ovCFI=
+github.com/IBM/scc-go-sdk/v5 v5.1.2/go.mod h1:YtAVlzq10bwR82QX4ZavhDIwa1s85RuVO9N/KmXVcuk=
 github.com/IBM/schematics-go-sdk v0.2.1 h1:byATysGD+Z1k/wdtNqQmKALcAPjgSLuSyzcabh1jRAw=
 github.com/IBM/schematics-go-sdk v0.2.1/go.mod h1:Tw2OSAPdpC69AxcwoyqcYYaGTTW6YpERF9uNEU+BFRQ=
 github.com/IBM/secrets-manager-go-sdk/v2 v2.0.0 h1:Lx4Bvim/MfoHEYR+n312bty5DirAJypBGGS9YZo3zCw=

--- a/go.sum
+++ b/go.sum
@@ -123,8 +123,6 @@ github.com/IBM/code-engine-go-sdk v0.0.0-20230606173928-4863db061918 h1:RfHezAVs
 github.com/IBM/code-engine-go-sdk v0.0.0-20230606173928-4863db061918/go.mod h1:IP6U/1NxgxzPeYdyiEwMaZyzelTw82JGHWl7bY78eQM=
 github.com/IBM/container-registry-go-sdk v1.1.0 h1:sYyknIod8R4RJZQqAheiduP6wbSTphE9Ag8ho28yXjc=
 github.com/IBM/container-registry-go-sdk v1.1.0/go.mod h1:4TwsCnQtVfZ4Vkapy/KPvQBKFc3VOyUZYkwRU4FTPrs=
-github.com/IBM/continuous-delivery-go-sdk v1.1.2 h1:UHwwak2RVTSZGtIV+SjH0vALqSvA+Vwkd1PHAbGgGrc=
-github.com/IBM/continuous-delivery-go-sdk v1.1.2/go.mod h1:A9rI1HPbccBBFgwJxXB999yXXpj1l+MnlE+rsxKtxw0=
 github.com/IBM/continuous-delivery-go-sdk v1.2.0 h1:FcgB5EvVrZLUnyR4S/mBocHHo9gJ5IQkSlCa6nqmr2A=
 github.com/IBM/continuous-delivery-go-sdk v1.2.0/go.mod h1:oW51tS5/MDCcEM7lUvjK1H9GFC/oKsRbyYfmvGyMGmw=
 github.com/IBM/event-notifications-go-admin-sdk v0.2.4 h1:WWUxwrKQxvExEK+xaAQOs6gP54LvJDPi3KatDTMfwh0=
@@ -164,8 +162,8 @@ github.com/IBM/project-go-sdk v0.0.10 h1:vHSuemwZ4S4c6BEb22tzsEcPTs/5LnZ0yKpP3GG
 github.com/IBM/project-go-sdk v0.0.10/go.mod h1:lqe0M4cKvABI1iHR1b+KfasVcxQL6nl2VJ8eOyQs8Ig=
 github.com/IBM/push-notifications-go-sdk v0.0.0-20210310100607-5790b96c47f5 h1:NPUhkoOCRuv3OFWt19PmwjXGGTKlvmbuPg9fUrBUNe4=
 github.com/IBM/push-notifications-go-sdk v0.0.0-20210310100607-5790b96c47f5/go.mod h1:b07XHUVh0XYnQE9s2mqgjYST1h9buaQNqN4EcKhOsX0=
-github.com/IBM/scc-go-sdk/v5 v5.0.2 h1:OUqkzLfJqozp2aqylNurwaJd1SmY8o7KturFse6R2xM=
-github.com/IBM/scc-go-sdk/v5 v5.0.2/go.mod h1:YtAVlzq10bwR82QX4ZavhDIwa1s85RuVO9N/KmXVcuk=
+github.com/IBM/scc-go-sdk/v5 v5.1.0 h1:JBycHGp4BmGuAAPb4FnhtNdClOE69ErlasCVwcWQBmI=
+github.com/IBM/scc-go-sdk/v5 v5.1.0/go.mod h1:YtAVlzq10bwR82QX4ZavhDIwa1s85RuVO9N/KmXVcuk=
 github.com/IBM/schematics-go-sdk v0.2.1 h1:byATysGD+Z1k/wdtNqQmKALcAPjgSLuSyzcabh1jRAw=
 github.com/IBM/schematics-go-sdk v0.2.1/go.mod h1:Tw2OSAPdpC69AxcwoyqcYYaGTTW6YpERF9uNEU+BFRQ=
 github.com/IBM/secrets-manager-go-sdk/v2 v2.0.0 h1:Lx4Bvim/MfoHEYR+n312bty5DirAJypBGGS9YZo3zCw=

--- a/go.sum
+++ b/go.sum
@@ -162,8 +162,8 @@ github.com/IBM/project-go-sdk v0.0.10 h1:vHSuemwZ4S4c6BEb22tzsEcPTs/5LnZ0yKpP3GG
 github.com/IBM/project-go-sdk v0.0.10/go.mod h1:lqe0M4cKvABI1iHR1b+KfasVcxQL6nl2VJ8eOyQs8Ig=
 github.com/IBM/push-notifications-go-sdk v0.0.0-20210310100607-5790b96c47f5 h1:NPUhkoOCRuv3OFWt19PmwjXGGTKlvmbuPg9fUrBUNe4=
 github.com/IBM/push-notifications-go-sdk v0.0.0-20210310100607-5790b96c47f5/go.mod h1:b07XHUVh0XYnQE9s2mqgjYST1h9buaQNqN4EcKhOsX0=
-github.com/IBM/scc-go-sdk/v5 v5.1.0 h1:JBycHGp4BmGuAAPb4FnhtNdClOE69ErlasCVwcWQBmI=
-github.com/IBM/scc-go-sdk/v5 v5.1.0/go.mod h1:YtAVlzq10bwR82QX4ZavhDIwa1s85RuVO9N/KmXVcuk=
+github.com/IBM/scc-go-sdk/v5 v5.1.1 h1:tBkTJh1xk0NYvLSfX5/fPVwjcsJocytKU/7LlQ/Z0sk=
+github.com/IBM/scc-go-sdk/v5 v5.1.1/go.mod h1:YtAVlzq10bwR82QX4ZavhDIwa1s85RuVO9N/KmXVcuk=
 github.com/IBM/schematics-go-sdk v0.2.1 h1:byATysGD+Z1k/wdtNqQmKALcAPjgSLuSyzcabh1jRAw=
 github.com/IBM/schematics-go-sdk v0.2.1/go.mod h1:Tw2OSAPdpC69AxcwoyqcYYaGTTW6YpERF9uNEU+BFRQ=
 github.com/IBM/secrets-manager-go-sdk/v2 v2.0.0 h1:Lx4Bvim/MfoHEYR+n312bty5DirAJypBGGS9YZo3zCw=

--- a/ibm/acctest/acctest.go
+++ b/ibm/acctest/acctest.go
@@ -1619,6 +1619,7 @@ func TestAccPreCheckCodeEngine(t *testing.T) {
 }
 
 func TestAccPreCheckSccInstanceID(t *testing.T) {
+	TestAccPreCheck(t)
 	if v := os.Getenv("IBMCLOUD_SCC_INSTANCE_ID"); v == "" {
 		t.Fatal("IBMCLOUD_SCC_INSTANCE_ID must be set for acceptance tests")
 	}

--- a/ibm/acctest/acctest.go
+++ b/ibm/acctest/acctest.go
@@ -14,258 +14,287 @@ import (
 	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/provider"
 )
 
-var AppIDTenantID string
-var AppIDTestUserEmail string
-var BackupPolicyJobID string
-var BackupPolicyID string
-var CfOrganization string
-var CfSpace string
-var CisDomainStatic string
-var CisDomainTest string
-var CisInstance string
-var CisResourceGroup string
-var CloudShellAccountID string
-var CosCRN string
-var BucketCRN string
-var BucketName string
-var CosName string
-var Ibmid1 string
-var Ibmid2 string
-var IAMUser string
-var IAMAccountId string
-var IAMServiceId string
-var IAMTrustedProfileID string
-var Datacenter string
-var MachineType string
-var trustedMachineType string
-var PublicVlanID string
-var PrivateVlanID string
-var PrivateSubnetID string
-var PublicSubnetID string
-var SubnetID string
-var LbaasDatacenter string
-var LbaasSubnetId string
-var LbListerenerCertificateInstance string
-var IpsecDatacenter string
-var Customersubnetid string
-var Customerpeerip string
-var DedicatedHostName string
-var DedicatedHostID string
-var KubeVersion string
-var KubeUpdateVersion string
-var Zone string
-var ZonePrivateVlan string
-var ZonePublicVlan string
-var ZoneUpdatePrivateVlan string
-var ZoneUpdatePublicVlan string
-var WorkerPoolSecondaryStorage string
-var CsRegion string
-var ExtendedHardwareTesting bool
-var err error
-var placementGroupName string
-var CertCRN string
-var UpdatedCertCRN string
-var SecretCRN string
-var SecretCRN2 string
-var InstanceCRN string
-var SecretGroupID string
-var RegionName string
-var ISZoneName string
-var ISZoneName2 string
-var ISZoneName3 string
-var IsResourceGroupID string
-var ISCIDR string
-var ISCIDR2 string
-var ISPublicSSHKeyFilePath string
-var ISPrivateSSHKeyFilePath string
-var ISAddressPrefixCIDR string
-var InstanceName string
-var InstanceProfileName string
-var InstanceProfileNameUpdate string
-var IsBareMetalServerProfileName string
-var IsBareMetalServerImage string
-var DNSInstanceCRN string
-var DNSZoneID string
-var DNSInstanceCRN1 string
-var DNSZoneID1 string
-var DedicatedHostProfileName string
-var DedicatedHostGroupID string
-var InstanceDiskProfileName string
-var DedicatedHostGroupFamily string
-var DedicatedHostGroupClass string
-var ShareProfileName string
-var VNIId string
-var VolumeProfileName string
-var VSIUnattachedBootVolumeID string
-var VSIDataVolumeID string
-var ISRouteDestination string
-var ISRouteNextHop string
-var ISSnapshotCRN string
-var WorkspaceID string
-var TemplateID string
-var ActionID string
-var JobID string
-var RepoURL string
-var RepoBranch string
-var imageName string
-var functionNamespace string
-var HpcsInstanceID string
+var (
+	AppIDTenantID                   string
+	AppIDTestUserEmail              string
+	BackupPolicyJobID               string
+	BackupPolicyID                  string
+	CfOrganization                  string
+	CfSpace                         string
+	CisDomainStatic                 string
+	CisDomainTest                   string
+	CisInstance                     string
+	CisResourceGroup                string
+	CloudShellAccountID             string
+	CosCRN                          string
+	BucketCRN                       string
+	BucketName                      string
+	CosName                         string
+	Ibmid1                          string
+	Ibmid2                          string
+	IAMUser                         string
+	IAMAccountId                    string
+	IAMServiceId                    string
+	IAMTrustedProfileID             string
+	Datacenter                      string
+	MachineType                     string
+	trustedMachineType              string
+	PublicVlanID                    string
+	PrivateVlanID                   string
+	PrivateSubnetID                 string
+	PublicSubnetID                  string
+	SubnetID                        string
+	LbaasDatacenter                 string
+	LbaasSubnetId                   string
+	LbListerenerCertificateInstance string
+	IpsecDatacenter                 string
+	Customersubnetid                string
+	Customerpeerip                  string
+	DedicatedHostName               string
+	DedicatedHostID                 string
+	KubeVersion                     string
+	KubeUpdateVersion               string
+	Zone                            string
+	ZonePrivateVlan                 string
+	ZonePublicVlan                  string
+	ZoneUpdatePrivateVlan           string
+	ZoneUpdatePublicVlan            string
+	WorkerPoolSecondaryStorage      string
+	CsRegion                        string
+	ExtendedHardwareTesting         bool
+	err                             error
+	placementGroupName              string
+	CertCRN                         string
+	UpdatedCertCRN                  string
+	SecretCRN                       string
+	SecretCRN2                      string
+	InstanceCRN                     string
+	SecretGroupID                   string
+	RegionName                      string
+	ISZoneName                      string
+	ISZoneName2                     string
+	ISZoneName3                     string
+	IsResourceGroupID               string
+	ISCIDR                          string
+	ISCIDR2                         string
+	ISPublicSSHKeyFilePath          string
+	ISPrivateSSHKeyFilePath         string
+	ISAddressPrefixCIDR             string
+	InstanceName                    string
+	InstanceProfileName             string
+	InstanceProfileNameUpdate       string
+	IsBareMetalServerProfileName    string
+	IsBareMetalServerImage          string
+	DNSInstanceCRN                  string
+	DNSZoneID                       string
+	DNSInstanceCRN1                 string
+	DNSZoneID1                      string
+	DedicatedHostProfileName        string
+	DedicatedHostGroupID            string
+	InstanceDiskProfileName         string
+	DedicatedHostGroupFamily        string
+	DedicatedHostGroupClass         string
+	ShareProfileName                string
+	VNIId                           string
+	VolumeProfileName               string
+	VSIUnattachedBootVolumeID       string
+	VSIDataVolumeID                 string
+	ISRouteDestination              string
+	ISRouteNextHop                  string
+	ISSnapshotCRN                   string
+	WorkspaceID                     string
+	TemplateID                      string
+	ActionID                        string
+	JobID                           string
+	RepoURL                         string
+	RepoBranch                      string
+	imageName                       string
+	functionNamespace               string
+	HpcsInstanceID                  string
+)
 
 // Secrets Manager
-var SecretsManagerInstanceID string
-var SecretsManagerInstanceRegion string
-var SecretsManagerENInstanceCrn string
-var SecretsManagerIamCredentialsConfigurationApiKey string
-var SecretsManagerIamCredentialsSecretServiceId string
-var SecretsManagerIamCredentialsSecretServiceAccessGroup string
-var SecretsManagerPublicCertificateLetsEncryptEnvironment string
-var SecretsManagerPublicCertificateLetsEncryptPrivateKey string
-var SecretsManagerPublicCertificateCisCrn string
-var SecretsManagerPublicCertificateClassicInfrastructureUsername string
-var SecretsManagerPublicCertificateClassicInfrastructurePassword string
-var SecretsManagerPublicCertificateCommonName string
-var SecretsManagerValidateManualDnsCisZoneId string
-var SecretsManagerImportedCertificatePathToCertificate string
-var SecretsManagerSecretType string
-var SecretsManagerSecretID string
+var (
+	SecretsManagerInstanceID                                     string
+	SecretsManagerInstanceRegion                                 string
+	SecretsManagerENInstanceCrn                                  string
+	SecretsManagerIamCredentialsConfigurationApiKey              string
+	SecretsManagerIamCredentialsSecretServiceId                  string
+	SecretsManagerIamCredentialsSecretServiceAccessGroup         string
+	SecretsManagerPublicCertificateLetsEncryptEnvironment        string
+	SecretsManagerPublicCertificateLetsEncryptPrivateKey         string
+	SecretsManagerPublicCertificateCisCrn                        string
+	SecretsManagerPublicCertificateClassicInfrastructureUsername string
+	SecretsManagerPublicCertificateClassicInfrastructurePassword string
+	SecretsManagerPublicCertificateCommonName                    string
+	SecretsManagerValidateManualDnsCisZoneId                     string
+	SecretsManagerImportedCertificatePathToCertificate           string
+	SecretsManagerSecretType                                     string
+	SecretsManagerSecretID                                       string
+)
 
-var HpcsAdmin1 string
-var HpcsToken1 string
-var HpcsAdmin2 string
-var HpcsToken2 string
-var HpcsRootKeyCrn string
-var RealmName string
-var IksSa string
-var IksClusterID string
-var IksClusterVpcID string
-var IksClusterSubnetID string
-var IksClusterResourceGroupID string
-var IcdDbRegion string
-var IcdDbDeploymentId string
-var IcdDbBackupId string
-var IcdDbTaskId string
-var KmsInstanceID string
-var CrkID string
-var KmsAccountID string
-var BaasEncryptionkeyCRN string
+var (
+	HpcsAdmin1                string
+	HpcsToken1                string
+	HpcsAdmin2                string
+	HpcsToken2                string
+	HpcsRootKeyCrn            string
+	RealmName                 string
+	IksSa                     string
+	IksClusterID              string
+	IksClusterVpcID           string
+	IksClusterSubnetID        string
+	IksClusterResourceGroupID string
+	IcdDbRegion               string
+	IcdDbDeploymentId         string
+	IcdDbBackupId             string
+	IcdDbTaskId               string
+	KmsInstanceID             string
+	CrkID                     string
+	KmsAccountID              string
+	BaasEncryptionkeyCRN      string
+)
 
 // for snapshot encryption
-var IsKMSInstanceId string
-var IsKMSKeyName string
+var (
+	IsKMSInstanceId string
+	IsKMSKeyName    string
+)
 
 // For Power Colo
 
-var Pi_image string
-var Pi_sap_image string
-var Pi_image_bucket_name string
-var Pi_image_bucket_file_name string
-var Pi_image_bucket_access_key string
-var Pi_image_bucket_secret_key string
-var Pi_image_bucket_region string
-var Pi_key_name string
-var Pi_volume_name string
-var Pi_volume_id string
-var Pi_replication_volume_name string
-var Pi_volume_onboarding_source_crn string
-var Pi_auxiliary_volume_name string
-var Pi_volume_group_name string
-var Pi_volume_group_id string
-var Pi_volume_onboarding_id string
-var Pi_network_name string
-var Pi_cloud_instance_id string
-var Pi_instance_name string
-var Pi_dhcp_id string
-var PiCloudConnectionName string
-var PiSAPProfileID string
-var Pi_placement_group_name string
-var Pi_spp_placement_group_id string
-var PiStoragePool string
-var PiStorageType string
-var Pi_shared_processor_pool_id string
+var (
+	Pi_image                        string
+	Pi_sap_image                    string
+	Pi_image_bucket_name            string
+	Pi_image_bucket_file_name       string
+	Pi_image_bucket_access_key      string
+	Pi_image_bucket_secret_key      string
+	Pi_image_bucket_region          string
+	Pi_key_name                     string
+	Pi_volume_name                  string
+	Pi_volume_id                    string
+	Pi_replication_volume_name      string
+	Pi_volume_onboarding_source_crn string
+	Pi_auxiliary_volume_name        string
+	Pi_volume_group_name            string
+	Pi_volume_group_id              string
+	Pi_volume_onboarding_id         string
+	Pi_network_name                 string
+	Pi_cloud_instance_id            string
+	Pi_instance_name                string
+	Pi_dhcp_id                      string
+	PiCloudConnectionName           string
+	PiSAPProfileID                  string
+	Pi_placement_group_name         string
+	Pi_spp_placement_group_id       string
+	PiStoragePool                   string
+	PiStorageType                   string
+	Pi_shared_processor_pool_id     string
+)
 
-var Pi_capture_storage_image_path string
-var Pi_capture_cloud_storage_access_key string
-var Pi_capture_cloud_storage_secret_key string
+var (
+	Pi_capture_storage_image_path       string
+	Pi_capture_cloud_storage_access_key string
+	Pi_capture_cloud_storage_secret_key string
+)
 
 var ISDelegegatedVPC string
 
 // For Image
 
-var IsImageName string
-var IsImage string
-var IsImageEncryptedDataKey string
-var IsImageEncryptionKey string
-var IsWinImage string
-var IsCosBucketName string
-var IsCosBucketCRN string
-var Image_cos_url string
-var Image_cos_url_encrypted string
-var Image_operating_system string
+var (
+	IsImageName             string
+	IsImage                 string
+	IsImageEncryptedDataKey string
+	IsImageEncryptionKey    string
+	IsWinImage              string
+	IsCosBucketName         string
+	IsCosBucketCRN          string
+	Image_cos_url           string
+	Image_cos_url_encrypted string
+	Image_operating_system  string
+)
 
 // Transit Gateway Power Virtual Server
 var Tg_power_vs_network_id string
 
 // Transit Gateway cross account
-var Tg_cross_network_account_id string
-var Tg_cross_network_account_api_key string
-var Tg_cross_network_id string
+var (
+	Tg_cross_network_account_id      string
+	Tg_cross_network_account_api_key string
+	Tg_cross_network_id              string
+)
 
 // Enterprise Management
 var Account_to_be_imported string
 
 // Secuity and Complinace Center
-var SccApiEndpoint string
-var SccProviderTypeAttributes string
-var SccReportId string
+var (
+	SccApiEndpoint            string
+	SccProviderTypeAttributes string
+	SccReportID               string
+	SccInstanceID             string
+)
 
 // ROKS Cluster
 var ClusterName string
 
 // Satellite instance
-var Satellite_location_id string
-var Satellite_Resource_instance_id string
+var (
+	Satellite_location_id          string
+	Satellite_Resource_instance_id string
+)
 
 // Dedicated host
 var HostPoolID string
 
 // Continuous Delivery
-var CdResourceGroupName string
-var CdAppConfigInstanceName string
-var CdKeyProtectInstanceName string
-var CdSecretsManagerInstanceName string
-var CdSlackChannelName string
-var CdSlackTeamName string
-var CdSlackWebhook string
-var CdJiraProjectKey string
-var CdJiraApiUrl string
-var CdJiraUsername string
-var CdJiraApiToken string
-var CdSaucelabsAccessKey string
-var CdSaucelabsUsername string
-var CdBitbucketRepoUrl string
-var CdGithubConsolidatedRepoUrl string
-var CdGitlabRepoUrl string
-var CdHostedGitRepoUrl string
-var CdEventNotificationsInstanceName string
+var (
+	CdResourceGroupName              string
+	CdAppConfigInstanceName          string
+	CdKeyProtectInstanceName         string
+	CdSecretsManagerInstanceName     string
+	CdSlackChannelName               string
+	CdSlackTeamName                  string
+	CdSlackWebhook                   string
+	CdJiraProjectKey                 string
+	CdJiraApiUrl                     string
+	CdJiraUsername                   string
+	CdJiraApiToken                   string
+	CdSaucelabsAccessKey             string
+	CdSaucelabsUsername              string
+	CdBitbucketRepoUrl               string
+	CdGithubConsolidatedRepoUrl      string
+	CdGitlabRepoUrl                  string
+	CdHostedGitRepoUrl               string
+	CdEventNotificationsInstanceName string
+)
 
 // VPN Server
-var ISCertificateCrn string
-var ISClientCaCrn string
+var (
+	ISCertificateCrn string
+	ISClientCaCrn    string
+)
 
 // COS Replication Bucket
 var IBM_AccountID_REPL string
 
 // Atracker
-var IesApiKey string
-var IngestionKey string
-var COSApiKey string
+var (
+	IesApiKey    string
+	IngestionKey string
+	COSApiKey    string
+)
 
 // For Code Engine
 
-var CeResourceGroupID string
-var CeProjectId string
-var CeServiceInstanceID string
-var CeResourceKeyID string
+var (
+	CeResourceGroupID   string
+	CeProjectId         string
+	CeServiceInstanceID string
+	CeResourceKeyID     string
+)
 
 // for IAM Identity
 
@@ -627,14 +656,14 @@ func init() {
 
 	IsImage = os.Getenv("IS_IMAGE")
 	if IsImage == "" {
-		//IsImage = "fc538f61-7dd6-4408-978c-c6b85b69fe76" // for classic infrastructure
+		// IsImage = "fc538f61-7dd6-4408-978c-c6b85b69fe76" // for classic infrastructure
 		IsImage = "r006-907911a7-0ffe-467e-8821-3cc9a0d82a39" // for next gen infrastructure ibm-centos-7-9-minimal-amd64-10 image
 		fmt.Println("[INFO] Set the environment variable IS_IMAGE for testing ibm_is_instance, ibm_is_floating_ip else it is set to default value 'r006-907911a7-0ffe-467e-8821-3cc9a0d82a39'")
 	}
 
 	IsWinImage = os.Getenv("IS_WIN_IMAGE")
 	if IsWinImage == "" {
-		//IsWinImage = "a7a0626c-f97e-4180-afbe-0331ec62f32a" // classic windows machine: ibm-windows-server-2012-full-standard-amd64-1
+		// IsWinImage = "a7a0626c-f97e-4180-afbe-0331ec62f32a" // classic windows machine: ibm-windows-server-2012-full-standard-amd64-1
 		IsWinImage = "r006-d2e0d0e9-0a4f-4c45-afd7-cab787030776" // next gen windows machine: ibm-windows-server-2022-full-standard-amd64-8
 		fmt.Println("[INFO] Set the environment variable IS_WIN_IMAGE for testing ibm_is_instance data source else it is set to default value 'r006-d2e0d0e9-0a4f-4c45-afd7-cab787030776'")
 	}
@@ -675,7 +704,7 @@ func init() {
 
 	InstanceProfileName = os.Getenv("SL_INSTANCE_PROFILE")
 	if InstanceProfileName == "" {
-		//InstanceProfileName = "bc1-2x8" // for classic infrastructure
+		// InstanceProfileName = "bc1-2x8" // for classic infrastructure
 		InstanceProfileName = "cx2-2x4" // for next gen infrastructure
 		fmt.Println("[INFO] Set the environment variable SL_INSTANCE_PROFILE for testing ibm_is_instance resource else it is set to default value 'cx2-2x4'")
 	}
@@ -766,7 +795,7 @@ func init() {
 
 	InstanceDiskProfileName = os.Getenv("IS_INSTANCE_DISK_PROFILE")
 	if InstanceDiskProfileName == "" {
-		//InstanceProfileName = "bc1-2x8" // for classic infrastructure
+		// InstanceProfileName = "bc1-2x8" // for classic infrastructure
 		InstanceDiskProfileName = "bx2d-16x64" // for next gen infrastructure
 		fmt.Println("[INFO] Set the environment variable SL_INSTANCE_PROFILE for testing ibm_is_instance resource else it is set to default value 'bx2d-16x64'")
 	}
@@ -1063,7 +1092,7 @@ func init() {
 
 	IsImageName = os.Getenv("IS_IMAGE_NAME")
 	if IsImageName == "" {
-		//IsImageName = "ibm-ubuntu-18-04-2-minimal-amd64-1" // for classic infrastructure
+		// IsImageName = "ibm-ubuntu-18-04-2-minimal-amd64-1" // for classic infrastructure
 		IsImageName = "ibm-ubuntu-22-04-1-minimal-amd64-4" // for next gen infrastructure
 		fmt.Println("[INFO] Set the environment variable IS_IMAGE_NAME for testing data source ibm_is_image else it is set to default value `ibm-ubuntu-18-04-1-minimal-amd64-2`")
 	}
@@ -1230,8 +1259,13 @@ func init() {
 		fmt.Println("[WARN] Set the environment variable IBMCLOUD_SCC_PROVIDER_TYPE_ATTRIBUTES with a VALID ATTRIBUTE")
 	}
 
-	SccReportId = os.Getenv("IBMCLOUD_SCC_REPORT_ID")
-	if SccApiEndpoint == "" {
+	SccInstanceID = os.Getenv("IBMCLOUD_SCC_INSTANCE_ID")
+	if SccInstanceID == "" {
+		fmt.Println("[WARN] Set the environment variable IBMCLOUD_SCC_INSTANCE_ID with a VALID SCC INSTANCE ID")
+	}
+
+	SccReportID = os.Getenv("IBMCLOUD_SCC_REPORT_ID")
+	if SccReportID == "" {
 		fmt.Println("[WARN] Set the environment variable IBMCLOUD_SCC_REPORT_ID with a VALID REPORT_ID")
 	}
 
@@ -1435,11 +1469,12 @@ func init() {
 		CeResourceKeyID = ""
 		fmt.Println("[WARN] Set the environment variable IBM_CODE_ENGINE_RESOURCE_KEY_ID with the ID of a resource key to access a service instance")
 	}
-
 }
 
-var TestAccProviders map[string]*schema.Provider
-var TestAccProvider *schema.Provider
+var (
+	TestAccProviders map[string]*schema.Provider
+	TestAccProvider  *schema.Provider
+)
 
 func init() {
 	TestAccProvider = provider.Provider()
@@ -1489,8 +1524,8 @@ func TestAccPreCheckEnterpriseAccountImport(t *testing.T) {
 	if Account_to_be_imported == "" {
 		t.Fatal("ACCOUNT_TO_BE_IMPORTED must be set for acceptance tests")
 	}
-
 }
+
 func TestAccPreCheckCis(t *testing.T) {
 	TestAccPreCheck(t)
 	if CisInstance == "" {
@@ -1529,6 +1564,7 @@ func TestAccPreCheckHPCS(t *testing.T) {
 		t.Fatal("IBM_HPCS_TOKEN2 must be set for acceptance tests")
 	}
 }
+
 func TestAccPreCheckIAMTrustedProfile(t *testing.T) {
 	TestAccPreCheck(t)
 	if RealmName == "" {
@@ -1555,6 +1591,7 @@ func TestAccPreCheckImage(t *testing.T) {
 		t.Fatal("IMAGE_OPERATING_SYSTEM must be set for acceptance tests")
 	}
 }
+
 func TestAccPreCheckEncryptedImage(t *testing.T) {
 	TestAccPreCheck(t)
 	if Image_cos_url_encrypted == "" {
@@ -1578,5 +1615,11 @@ func TestAccPreCheckCodeEngine(t *testing.T) {
 	}
 	if CeProjectId == "" {
 		t.Fatal("IBM_CODE_ENGINE_PROJECT_INSTANCE_ID must be set for acceptance tests")
+	}
+}
+
+func TestAccPreCheckSccInstanceID(t *testing.T) {
+	if v := os.Getenv("IBMCLOUD_SCC_INSTANCE_ID"); v == "" {
+		t.Fatal("IBMCLOUD_SCC_INSTANCE_ID must be set for acceptance tests")
 	}
 }

--- a/ibm/acctest/acctest.go
+++ b/ibm/acctest/acctest.go
@@ -288,7 +288,6 @@ var (
 )
 
 // For Code Engine
-
 var (
 	CeResourceGroupID   string
 	CeProjectId         string
@@ -297,7 +296,6 @@ var (
 )
 
 // for IAM Identity
-
 var IamIdentityAssignmentTargetAccountId string
 
 func init() {
@@ -1249,26 +1247,6 @@ func init() {
 		fmt.Println("[WARN] Set the environment variable IBM_HPCS_ROOTKEY_CRN with a VALID CRN for a root key created in the HPCS instance")
 	}
 
-	SccApiEndpoint = os.Getenv("IBMCLOUD_SCC_API_ENDPOINT")
-	if SccApiEndpoint == "" {
-		fmt.Println("[WARN] Set the environment variable IBMCLOUD_SCC_API_ENDPOINT with a VALID endpoint")
-	}
-
-	SccProviderTypeAttributes = os.Getenv("IBMCLOUD_SCC_PROVIDER_TYPE_ATTRIBUTES")
-	if SccProviderTypeAttributes == "" {
-		fmt.Println("[WARN] Set the environment variable IBMCLOUD_SCC_PROVIDER_TYPE_ATTRIBUTES with a VALID ATTRIBUTE")
-	}
-
-	SccInstanceID = os.Getenv("IBMCLOUD_SCC_INSTANCE_ID")
-	if SccInstanceID == "" {
-		fmt.Println("[WARN] Set the environment variable IBMCLOUD_SCC_INSTANCE_ID with a VALID SCC INSTANCE ID")
-	}
-
-	SccReportID = os.Getenv("IBMCLOUD_SCC_REPORT_ID")
-	if SccReportID == "" {
-		fmt.Println("[WARN] Set the environment variable IBMCLOUD_SCC_REPORT_ID with a VALID REPORT_ID")
-	}
-
 	CloudShellAccountID = os.Getenv("IBM_CLOUD_SHELL_ACCOUNT_ID")
 	if CloudShellAccountID == "" {
 		fmt.Println("[INFO] Set the environment variable IBM_CLOUD_SHELL_ACCOUNT_ID for ibm-cloud-shell resource or datasource else tests will fail if this is not set correctly")
@@ -1302,6 +1280,26 @@ func init() {
 	Satellite_Resource_instance_id = os.Getenv("SATELLITE_RESOURCE_INSTANCE_ID")
 	if Satellite_Resource_instance_id == "" {
 		fmt.Println("[INFO] Set the environment variable SATELLITE_RESOURCE_INSTANCE_ID for ibm_cos_bucket satellite location resource or datasource else tests will fail if this is not set correctly")
+	}
+
+	SccInstanceID = os.Getenv("IBMCLOUD_SCC_INSTANCE_ID")
+	if SccInstanceID == "" {
+		fmt.Println("[WARN] Set the environment variable IBMCLOUD_SCC_INSTANCE_ID with a VALID SCC INSTANCE ID")
+	}
+
+	SccApiEndpoint = os.Getenv("IBMCLOUD_SCC_API_ENDPOINT")
+	if SccApiEndpoint == "" {
+		fmt.Println("[WARN] Set the environment variable IBMCLOUD_SCC_API_ENDPOINT with a VALID SCC API ENDPOINT")
+	}
+
+	SccReportID = os.Getenv("IBMCLOUD_SCC_REPORT_ID")
+	if SccReportID == "" {
+		fmt.Println("[WARN] Set the environment variable IBMCLOUD_SCC_REPORT_ID with a VALID SCC REPORT ID")
+	}
+
+	SccProviderTypeAttributes = os.Getenv("IBMCLOUD_SCC_PROVIDER_TYPE_ATTRIBUTES")
+	if SccProviderTypeAttributes == "" {
+		fmt.Println("[WARN] Set the environment variable IBMCLOUD_SCC_PROVIDER_TYPE_ATTRIBUTES with a VALID SCC PROVIDER TYPE ATTRIBUTE")
 	}
 
 	HostPoolID = os.Getenv("IBM_CONTAINER_DEDICATEDHOST_POOL_ID")
@@ -1618,9 +1616,21 @@ func TestAccPreCheckCodeEngine(t *testing.T) {
 	}
 }
 
-func TestAccPreCheckSccInstanceID(t *testing.T) {
+func TestAccPreCheckScc(t *testing.T) {
 	TestAccPreCheck(t)
-	if v := os.Getenv("IBMCLOUD_SCC_INSTANCE_ID"); v == "" {
-		t.Fatal("IBMCLOUD_SCC_INSTANCE_ID must be set for acceptance tests")
+	if SccApiEndpoint == "" {
+		t.Fatal("IBMCLOUD_SCC_API_ENDPOINT missing. Set the environment variable IBMCLOUD_SCC_API_ENDPOINT with a VALID endpoint")
+	}
+
+	if SccProviderTypeAttributes == "" {
+		t.Fatal("IBMCLOUD_SCC_PROVIDER_TYPE_ATTRIBUTES missing. Set the environment variable IBMCLOUD_SCC_PROVIDER_TYPE_ATTRIBUTES with a VALID ATTRIBUTE")
+	}
+
+	if SccInstanceID == "" {
+		t.Fatal("IBMCLOUD_SCC_INSTANCE_ID missing. Set the environment variable IBMCLOUD_SCC_INSTANCE_ID with a VALID SCC INSTANCE ID")
+	}
+
+	if SccReportID == "" {
+		t.Fatal("IBMCLOUD_SCC_REPORT_ID missing. Set the environment variable IBMCLOUD_SCC_REPORT_ID with a VALID REPORT_ID")
 	}
 }

--- a/ibm/conns/config.go
+++ b/ibm/conns/config.go
@@ -1705,10 +1705,12 @@ func (c *Config) ClientSession() (interface{}, error) {
 		session.metricsRouterClientErr = fmt.Errorf("Error occurred while configuring Metrics Router API Version 3 service: %q", err)
 	}
 
-	// SCC Service
+	// SCC (Security and Compliance Center) Service
 	sccApiClientURL := scc.DefaultServiceURL
 	// Construct the service options.
-
+	if regionURL, sccRegionErr := scc.GetServiceURLForRegion(c.Region); sccRegionErr == nil {
+		sccApiClientURL = regionURL
+	}
 	sccApiClientOptions := &scc.SecurityAndComplianceCenterApiV3Options{
 		Authenticator: authenticator,
 		URL:           EnvFallBack([]string{"IBMCLOUD_SCC_API_ENDPOINT"}, sccApiClientURL),
@@ -1724,7 +1726,7 @@ func (c *Config) ClientSession() (interface{}, error) {
 			"X-Original-User-Agent": {fmt.Sprintf("terraform-provider-ibm/%s", version.Version)},
 		})
 	} else {
-		session.securityAndComplianceCenterClientErr = fmt.Errorf("Error occurred while configuring Config Manager service: %q", err)
+		session.securityAndComplianceCenterClientErr = fmt.Errorf("Error occurred while configuring Security And Compliance Center service: %q", err)
 	}
 
 	// SCHEMATICS Service

--- a/ibm/service/scc/data_source_ibm_scc_control_library.go
+++ b/ibm/service/scc/data_source_ibm_scc_control_library.go
@@ -279,12 +279,6 @@ func dataSourceIbmSccControlLibraryRead(context context.Context, d *schema.Resou
 		return diag.FromErr(err)
 	}
 
-	// try to find the region if the field was set
-	region := getRegionData(*securityandcompliancecenterapiClient, d)
-	if val, err := securityandcompliancecenterapiv3.GetServiceURLForRegion(region); err == nil {
-		securityandcompliancecenterapiClient.SetServiceURL(val)
-	}
-
 	getControlLibraryOptions := &securityandcompliancecenterapiv3.GetControlLibraryOptions{}
 
 	getControlLibraryOptions.SetControlLibrariesID(d.Get("control_library_id").(string))
@@ -297,7 +291,6 @@ func dataSourceIbmSccControlLibraryRead(context context.Context, d *schema.Resou
 	}
 
 	d.SetId(fmt.Sprintf("%s", *getControlLibraryOptions.ControlLibrariesID))
-	setRegionData(d, region)
 
 	if err = d.Set("account_id", controlLibrary.AccountID); err != nil {
 		return diag.FromErr(fmt.Errorf("Error setting account_id: %s", err))

--- a/ibm/service/scc/data_source_ibm_scc_control_library.go
+++ b/ibm/service/scc/data_source_ibm_scc_control_library.go
@@ -17,117 +17,117 @@ import (
 )
 
 func DataSourceIbmSccControlLibrary() *schema.Resource {
-	return &schema.Resource{
+	return AddSchemaData(&schema.Resource{
 		ReadContext: dataSourceIbmSccControlLibraryRead,
 
 		Schema: map[string]*schema.Schema{
-			"control_library_id": &schema.Schema{
+			"control_library_id": {
 				Type:        schema.TypeString,
 				Required:    true,
 				Description: "The control library ID.",
 			},
-			"account_id": &schema.Schema{
+			"account_id": {
 				Type:        schema.TypeString,
 				Computed:    true,
 				Description: "The account ID.",
 			},
-			"control_library_name": &schema.Schema{
+			"control_library_name": {
 				Type:        schema.TypeString,
 				Computed:    true,
 				Description: "The control library name.",
 			},
-			"control_library_description": &schema.Schema{
+			"control_library_description": {
 				Type:        schema.TypeString,
 				Computed:    true,
 				Description: "The control library description.",
 			},
-			"control_library_type": &schema.Schema{
+			"control_library_type": {
 				Type:        schema.TypeString,
 				Computed:    true,
 				Description: "The control library type.",
 			},
-			"version_group_label": &schema.Schema{
+			"version_group_label": {
 				Type:        schema.TypeString,
 				Computed:    true,
 				Description: "The version group label.",
 			},
-			"control_library_version": &schema.Schema{
+			"control_library_version": {
 				Type:        schema.TypeString,
 				Computed:    true,
 				Description: "The control library version.",
 			},
-			"created_on": &schema.Schema{
+			"created_on": {
 				Type:        schema.TypeString,
 				Computed:    true,
 				Description: "The date when the control library was created.",
 			},
-			"created_by": &schema.Schema{
+			"created_by": {
 				Type:        schema.TypeString,
 				Computed:    true,
 				Description: "The user who created the control library.",
 			},
-			"updated_on": &schema.Schema{
+			"updated_on": {
 				Type:        schema.TypeString,
 				Computed:    true,
 				Description: "The date when the control library was updated.",
 			},
-			"updated_by": &schema.Schema{
+			"updated_by": {
 				Type:        schema.TypeString,
 				Computed:    true,
 				Description: "The user who updated the control library.",
 			},
-			"latest": &schema.Schema{
+			"latest": {
 				Type:        schema.TypeBool,
 				Computed:    true,
 				Description: "The latest version of the control library.",
 			},
-			"hierarchy_enabled": &schema.Schema{
+			"hierarchy_enabled": {
 				Type:        schema.TypeBool,
 				Computed:    true,
 				Description: "The indication of whether hierarchy is enabled for the control library.",
 			},
-			"controls_count": &schema.Schema{
+			"controls_count": {
 				Type:        schema.TypeInt,
 				Computed:    true,
 				Description: "The number of controls.",
 			},
-			"control_parents_count": &schema.Schema{
+			"control_parents_count": {
 				Type:        schema.TypeInt,
 				Computed:    true,
 				Description: "The number of parent controls in the control library.",
 			},
-			"controls": &schema.Schema{
+			"controls": {
 				Type:        schema.TypeList,
 				Computed:    true,
 				Description: "The list of controls in a control library.",
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
-						"control_name": &schema.Schema{
+						"control_name": {
 							Type:        schema.TypeString,
 							Computed:    true,
 							Description: "The ID of the control library that contains the profile.",
 						},
-						"control_id": &schema.Schema{
+						"control_id": {
 							Type:        schema.TypeString,
 							Computed:    true,
 							Description: "The control name.",
 						},
-						"control_description": &schema.Schema{
+						"control_description": {
 							Type:        schema.TypeString,
 							Computed:    true,
 							Description: "The control description.",
 						},
-						"control_category": &schema.Schema{
+						"control_category": {
 							Type:        schema.TypeString,
 							Computed:    true,
 							Description: "The control category.",
 						},
-						"control_parent": &schema.Schema{
+						"control_parent": {
 							Type:        schema.TypeString,
 							Computed:    true,
 							Description: "The parent control.",
 						},
-						"control_tags": &schema.Schema{
+						"control_tags": {
 							Type:        schema.TypeList,
 							Computed:    true,
 							Description: "The control tags.",
@@ -135,95 +135,95 @@ func DataSourceIbmSccControlLibrary() *schema.Resource {
 								Type: schema.TypeString,
 							},
 						},
-						"control_specifications": &schema.Schema{
+						"control_specifications": {
 							Type:        schema.TypeList,
 							Computed:    true,
 							Description: "The control specifications.",
 							Elem: &schema.Resource{
 								Schema: map[string]*schema.Schema{
-									"control_specification_id": &schema.Schema{
+									"control_specification_id": {
 										Type:        schema.TypeString,
 										Computed:    true,
 										Description: "The control specification ID.",
 									},
-									"responsibility": &schema.Schema{
+									"responsibility": {
 										Type:        schema.TypeString,
 										Computed:    true,
 										Description: "The responsibility for managing the control.",
 									},
-									"component_id": &schema.Schema{
+									"component_id": {
 										Type:        schema.TypeString,
 										Computed:    true,
 										Description: "The component ID.",
 									},
-									"component_name": &schema.Schema{
+									"component_name": {
 										Type:        schema.TypeString,
 										Computed:    true,
 										Description: "The component name.",
 									},
-									"environment": &schema.Schema{
+									"environment": {
 										Type:        schema.TypeString,
 										Computed:    true,
 										Description: "The control specifications environment.",
 									},
-									"control_specification_description": &schema.Schema{
+									"control_specification_description": {
 										Type:        schema.TypeString,
 										Computed:    true,
 										Description: "The control specifications description.",
 									},
-									"assessments_count": &schema.Schema{
+									"assessments_count": {
 										Type:        schema.TypeInt,
 										Computed:    true,
 										Description: "The number of assessments.",
 									},
-									"assessments": &schema.Schema{
+									"assessments": {
 										Type:        schema.TypeList,
 										Computed:    true,
 										Description: "The assessments.",
 										Elem: &schema.Resource{
 											Schema: map[string]*schema.Schema{
-												"assessment_id": &schema.Schema{
+												"assessment_id": {
 													Type:        schema.TypeString,
 													Computed:    true,
 													Description: "The assessment ID.",
 												},
-												"assessment_method": &schema.Schema{
+												"assessment_method": {
 													Type:        schema.TypeString,
 													Computed:    true,
 													Description: "The assessment method.",
 												},
-												"assessment_type": &schema.Schema{
+												"assessment_type": {
 													Type:        schema.TypeString,
 													Computed:    true,
 													Description: "The assessment type.",
 												},
-												"assessment_description": &schema.Schema{
+												"assessment_description": {
 													Type:        schema.TypeString,
 													Computed:    true,
 													Description: "The assessment description.",
 												},
-												"parameter_count": &schema.Schema{
+												"parameter_count": {
 													Type:        schema.TypeInt,
 													Computed:    true,
 													Description: "The parameter count.",
 												},
-												"parameters": &schema.Schema{
+												"parameters": {
 													Type:        schema.TypeList,
 													Computed:    true,
 													Description: "The parameters.",
 													Elem: &schema.Resource{
 														Schema: map[string]*schema.Schema{
-															"parameter_name": &schema.Schema{
+															"parameter_name": {
 																Type:        schema.TypeString,
 																Computed:    true,
 																Description: "The parameter name.",
 															},
-															"parameter_display_name": &schema.Schema{
+															"parameter_display_name": {
 																Type:        schema.TypeString,
 																Computed:    true,
 																Description: "The parameter display name.",
 															},
-															"parameter_type": &schema.Schema{
+															"parameter_type": {
 																Type:        schema.TypeString,
 																Computed:    true,
 																Description: "The parameter type.",
@@ -237,18 +237,18 @@ func DataSourceIbmSccControlLibrary() *schema.Resource {
 								},
 							},
 						},
-						"control_docs": &schema.Schema{
+						"control_docs": {
 							Type:        schema.TypeList,
 							Computed:    true,
 							Description: "The control documentation.",
 							Elem: &schema.Resource{
 								Schema: map[string]*schema.Schema{
-									"control_docs_id": &schema.Schema{
+									"control_docs_id": {
 										Type:        schema.TypeString,
 										Computed:    true,
 										Description: "The ID of the control documentation.",
 									},
-									"control_docs_type": &schema.Schema{
+									"control_docs_type": {
 										Type:        schema.TypeString,
 										Computed:    true,
 										Description: "The type of control documentation.",
@@ -256,12 +256,12 @@ func DataSourceIbmSccControlLibrary() *schema.Resource {
 								},
 							},
 						},
-						"control_requirement": &schema.Schema{
+						"control_requirement": {
 							Type:        schema.TypeBool,
 							Computed:    true,
 							Description: "Is this a control that can be automated or manually evaluated.",
 						},
-						"status": &schema.Schema{
+						"status": {
 							Type:        schema.TypeString,
 							Computed:    true,
 							Description: "The control status.",
@@ -270,7 +270,7 @@ func DataSourceIbmSccControlLibrary() *schema.Resource {
 				},
 			},
 		},
-	}
+	})
 }
 
 func dataSourceIbmSccControlLibraryRead(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
@@ -279,9 +279,16 @@ func dataSourceIbmSccControlLibraryRead(context context.Context, d *schema.Resou
 		return diag.FromErr(err)
 	}
 
+	// try to find the region if the field was set
+	region := getRegionData(*securityandcompliancecenterapiClient, d)
+	if val, err := securityandcompliancecenterapiv3.GetServiceURLForRegion(region); err == nil {
+		securityandcompliancecenterapiClient.SetServiceURL(val)
+	}
+
 	getControlLibraryOptions := &securityandcompliancecenterapiv3.GetControlLibraryOptions{}
 
 	getControlLibraryOptions.SetControlLibrariesID(d.Get("control_library_id").(string))
+	getControlLibraryOptions.SetInstanceID(d.Get("instance_id").(string))
 
 	controlLibrary, response, err := securityandcompliancecenterapiClient.GetControlLibraryWithContext(context, getControlLibraryOptions)
 	if err != nil {
@@ -290,6 +297,7 @@ func dataSourceIbmSccControlLibraryRead(context context.Context, d *schema.Resou
 	}
 
 	d.SetId(fmt.Sprintf("%s", *getControlLibraryOptions.ControlLibrariesID))
+	setRegionData(d, region)
 
 	if err = d.Set("account_id", controlLibrary.AccountID); err != nil {
 		return diag.FromErr(fmt.Errorf("Error setting account_id: %s", err))

--- a/ibm/service/scc/data_source_ibm_scc_control_library_test.go
+++ b/ibm/service/scc/data_source_ibm_scc_control_library_test.go
@@ -21,7 +21,6 @@ func TestAccIbmSccControlLibraryDataSourceBasic(t *testing.T) {
 	instanceID, ok := os.LookupEnv("IBMCLOUD_SCC_INSTANCE_ID")
 	if !ok {
 		t.Logf("Missing the env var IBMCLOUD_SCC_INSTANCE_ID.")
-		t.FailNow()
 	}
 
 	resource.Test(t, resource.TestCase{
@@ -50,7 +49,6 @@ func TestAccIbmSccControlLibraryDataSourceAllArgs(t *testing.T) {
 	instanceID, ok := os.LookupEnv("IBMCLOUD_SCC_INSTANCE_ID")
 	if !ok {
 		t.Logf("Missing the env var IBMCLOUD_SCC_INSTANCE_ID.")
-		t.FailNow()
 	}
 
 	resource.Test(t, resource.TestCase{

--- a/ibm/service/scc/data_source_ibm_scc_control_library_test.go
+++ b/ibm/service/scc/data_source_ibm_scc_control_library_test.go
@@ -5,6 +5,7 @@ package scc_test
 
 import (
 	"fmt"
+	"os"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
@@ -17,13 +18,18 @@ func TestAccIbmSccControlLibraryDataSourceBasic(t *testing.T) {
 	controlLibraryControlLibraryName := fmt.Sprintf("tf_control_library_name_%d", acctest.RandIntRange(10, 100))
 	controlLibraryControlLibraryDescription := fmt.Sprintf("tf_control_library_description_%d", acctest.RandIntRange(10, 100))
 	controlLibraryControlLibraryType := "custom"
+	instanceID, ok := os.LookupEnv("IBMCLOUD_SCC_INSTANCE_ID")
+	if !ok {
+		t.Logf("Missing the env var IBMCLOUD_SCC_INSTANCE_ID.")
+		t.FailNow()
+	}
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:  func() { acc.TestAccPreCheck(t) },
 		Providers: acc.TestAccProviders,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckIbmSccControlLibraryDataSourceConfigBasic(controlLibraryControlLibraryName, controlLibraryControlLibraryDescription, controlLibraryControlLibraryType),
+				Config: testAccCheckIbmSccControlLibraryDataSourceConfigBasic(instanceID, controlLibraryControlLibraryName, controlLibraryControlLibraryDescription, controlLibraryControlLibraryType),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrSet("data.ibm_scc_control_library.scc_control_library", "id"),
 					resource.TestCheckResourceAttrSet("data.ibm_scc_control_library.scc_control_library", "control_library_id"),
@@ -41,13 +47,18 @@ func TestAccIbmSccControlLibraryDataSourceAllArgs(t *testing.T) {
 
 	controlLibraryControlLibraryVersion := fmt.Sprintf("0.0.%d", acctest.RandIntRange(1, 100))
 	controlLibraryLatest := "true"
+	instanceID, ok := os.LookupEnv("IBMCLOUD_SCC_INSTANCE_ID")
+	if !ok {
+		t.Logf("Missing the env var IBMCLOUD_SCC_INSTANCE_ID.")
+		t.FailNow()
+	}
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:  func() { acc.TestAccPreCheck(t) },
 		Providers: acc.TestAccProviders,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckIbmSccControlLibraryDataSourceConfig(controlLibraryControlLibraryName, controlLibraryControlLibraryDescription, controlLibraryControlLibraryType, controlLibraryVersionGroupLabel, controlLibraryControlLibraryVersion, controlLibraryLatest),
+				Config: testAccCheckIbmSccControlLibraryDataSourceConfig(instanceID, controlLibraryControlLibraryName, controlLibraryControlLibraryDescription, controlLibraryControlLibraryType, controlLibraryVersionGroupLabel, controlLibraryControlLibraryVersion, controlLibraryLatest),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrSet("data.ibm_scc_control_library.scc_control_library", "id"),
 					resource.TestCheckResourceAttrSet("data.ibm_scc_control_library.scc_control_library", "account_id"),
@@ -77,9 +88,10 @@ func TestAccIbmSccControlLibraryDataSourceAllArgs(t *testing.T) {
 	})
 }
 
-func testAccCheckIbmSccControlLibraryDataSourceConfigBasic(controlLibraryControlLibraryName string, controlLibraryControlLibraryDescription string, controlLibraryControlLibraryType string) string {
+func testAccCheckIbmSccControlLibraryDataSourceConfigBasic(instanceID string, controlLibraryControlLibraryName string, controlLibraryControlLibraryDescription string, controlLibraryControlLibraryType string) string {
 	return fmt.Sprintf(`
 		resource "ibm_scc_control_library" "scc_control_library_instance" {
+			instance_id = "%s"
 			control_library_name = "%s"
 			control_library_description = "%s"
 			control_library_type = "%s"
@@ -120,15 +132,17 @@ func testAccCheckIbmSccControlLibraryDataSourceConfigBasic(controlLibraryControl
 		}
 
 		data "ibm_scc_control_library" "scc_control_library" {
-			control_library_id = ibm_scc_control_library.scc_control_library_instance.id
+			instance_id = ibm_scc_control_library.scc_control_library_instance.instance_id
+			control_library_id = ibm_scc_control_library.scc_control_library_instance.control_library_id
 		}
 
-	`, controlLibraryControlLibraryName, controlLibraryControlLibraryDescription, controlLibraryControlLibraryType)
+	`, instanceID, controlLibraryControlLibraryName, controlLibraryControlLibraryDescription, controlLibraryControlLibraryType)
 }
 
-func testAccCheckIbmSccControlLibraryDataSourceConfig(controlLibraryControlLibraryName string, controlLibraryControlLibraryDescription string, controlLibraryControlLibraryType string, controlLibraryVersionGroupLabel string, controlLibraryControlLibraryVersion string, controlLibraryLatest string) string {
+func testAccCheckIbmSccControlLibraryDataSourceConfig(instanceID string, controlLibraryControlLibraryName string, controlLibraryControlLibraryDescription string, controlLibraryControlLibraryType string, controlLibraryVersionGroupLabel string, controlLibraryControlLibraryVersion string, controlLibraryLatest string) string {
 	return fmt.Sprintf(`
 		resource "ibm_scc_control_library" "scc_control_library_instance" {
+			instance_id = "%s"
 			control_library_name = "%s"
 			control_library_description = "%s"
 			control_library_type = "%s"
@@ -170,8 +184,9 @@ func testAccCheckIbmSccControlLibraryDataSourceConfig(controlLibraryControlLibra
 		}
 
 		data "ibm_scc_control_library" "scc_control_library" {
-			control_library_id = ibm_scc_control_library.scc_control_library_instance.id
+			instance_id = ibm_scc_control_library.scc_control_library_instance.instance_id
+			control_library_id = ibm_scc_control_library.scc_control_library_instance.control_library_id
 		}
 
-	`, controlLibraryControlLibraryName, controlLibraryControlLibraryDescription, controlLibraryControlLibraryType, controlLibraryVersionGroupLabel, controlLibraryControlLibraryVersion, controlLibraryLatest)
+	`, instanceID, controlLibraryControlLibraryName, controlLibraryControlLibraryDescription, controlLibraryControlLibraryType, controlLibraryVersionGroupLabel, controlLibraryControlLibraryVersion, controlLibraryLatest)
 }

--- a/ibm/service/scc/data_source_ibm_scc_control_library_test.go
+++ b/ibm/service/scc/data_source_ibm_scc_control_library_test.go
@@ -5,7 +5,6 @@ package scc_test
 
 import (
 	"fmt"
-	"os"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
@@ -18,17 +17,13 @@ func TestAccIbmSccControlLibraryDataSourceBasic(t *testing.T) {
 	controlLibraryControlLibraryName := fmt.Sprintf("tf_control_library_name_%d", acctest.RandIntRange(10, 100))
 	controlLibraryControlLibraryDescription := fmt.Sprintf("tf_control_library_description_%d", acctest.RandIntRange(10, 100))
 	controlLibraryControlLibraryType := "custom"
-	instanceID, ok := os.LookupEnv("IBMCLOUD_SCC_INSTANCE_ID")
-	if !ok {
-		t.Logf("Missing the env var IBMCLOUD_SCC_INSTANCE_ID.")
-	}
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { acc.TestAccPreCheckSccInstanceID(t) },
+		PreCheck:  func() { acc.TestAccPreCheckScc(t) },
 		Providers: acc.TestAccProviders,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckIbmSccControlLibraryDataSourceConfigBasic(instanceID, controlLibraryControlLibraryName, controlLibraryControlLibraryDescription, controlLibraryControlLibraryType),
+				Config: testAccCheckIbmSccControlLibraryDataSourceConfigBasic(acc.SccInstanceID, controlLibraryControlLibraryName, controlLibraryControlLibraryDescription, controlLibraryControlLibraryType),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrSet("data.ibm_scc_control_library.scc_control_library", "id"),
 					resource.TestCheckResourceAttrSet("data.ibm_scc_control_library.scc_control_library", "control_library_id"),
@@ -43,20 +38,15 @@ func TestAccIbmSccControlLibraryDataSourceAllArgs(t *testing.T) {
 	controlLibraryControlLibraryDescription := fmt.Sprintf("tf_control_library_description_%d", acctest.RandIntRange(10, 100))
 	controlLibraryControlLibraryType := "custom"
 	controlLibraryVersionGroupLabel := fmt.Sprintf("d755830f-1d83-4fab-b5d5-1dfb2b0dad1%d", acctest.RandIntRange(1, 9))
-
 	controlLibraryControlLibraryVersion := fmt.Sprintf("0.0.%d", acctest.RandIntRange(1, 100))
 	controlLibraryLatest := "true"
-	instanceID, ok := os.LookupEnv("IBMCLOUD_SCC_INSTANCE_ID")
-	if !ok {
-		t.Logf("Missing the env var IBMCLOUD_SCC_INSTANCE_ID.")
-	}
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { acc.TestAccPreCheckSccInstanceID(t) },
+		PreCheck:  func() { acc.TestAccPreCheckScc(t) },
 		Providers: acc.TestAccProviders,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckIbmSccControlLibraryDataSourceConfig(instanceID, controlLibraryControlLibraryName, controlLibraryControlLibraryDescription, controlLibraryControlLibraryType, controlLibraryVersionGroupLabel, controlLibraryControlLibraryVersion, controlLibraryLatest),
+				Config: testAccCheckIbmSccControlLibraryDataSourceConfig(acc.SccInstanceID, controlLibraryControlLibraryName, controlLibraryControlLibraryDescription, controlLibraryControlLibraryType, controlLibraryVersionGroupLabel, controlLibraryControlLibraryVersion, controlLibraryLatest),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrSet("data.ibm_scc_control_library.scc_control_library", "id"),
 					resource.TestCheckResourceAttrSet("data.ibm_scc_control_library.scc_control_library", "account_id"),

--- a/ibm/service/scc/data_source_ibm_scc_control_library_test.go
+++ b/ibm/service/scc/data_source_ibm_scc_control_library_test.go
@@ -24,7 +24,7 @@ func TestAccIbmSccControlLibraryDataSourceBasic(t *testing.T) {
 	}
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { acc.TestAccPreCheck(t) },
+		PreCheck:  func() { acc.TestAccPreCheckSccInstanceID(t) },
 		Providers: acc.TestAccProviders,
 		Steps: []resource.TestStep{
 			{
@@ -52,7 +52,7 @@ func TestAccIbmSccControlLibraryDataSourceAllArgs(t *testing.T) {
 	}
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { acc.TestAccPreCheck(t) },
+		PreCheck:  func() { acc.TestAccPreCheckSccInstanceID(t) },
 		Providers: acc.TestAccProviders,
 		Steps: []resource.TestStep{
 			{

--- a/ibm/service/scc/data_source_ibm_scc_instance_settings.go
+++ b/ibm/service/scc/data_source_ibm_scc_instance_settings.go
@@ -90,6 +90,7 @@ func dataSourceIbmSccInstanceSettingsRead(context context.Context, d *schema.Res
 	}
 
 	getSettingsOptions := &securityandcompliancecenterapiv3.GetSettingsOptions{}
+	getSettingsOptions.SetInstanceID(d.Get("instance_id").(string))
 
 	settings, response, err := adminClient.GetSettingsWithContext(context, getSettingsOptions)
 

--- a/ibm/service/scc/data_source_ibm_scc_instance_settings.go
+++ b/ibm/service/scc/data_source_ibm_scc_instance_settings.go
@@ -17,7 +17,7 @@ import (
 )
 
 func DataSourceIbmSccInstanceSettings() *schema.Resource {
-	return &schema.Resource{
+	return AddSchemaData(&schema.Resource{
 		ReadContext: dataSourceIbmSccInstanceSettingsRead,
 
 		Schema: map[string]*schema.Schema{
@@ -80,7 +80,7 @@ func DataSourceIbmSccInstanceSettings() *schema.Resource {
 				},
 			},
 		},
-	}
+	})
 }
 
 func dataSourceIbmSccInstanceSettingsRead(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {

--- a/ibm/service/scc/data_source_ibm_scc_instance_settings_test.go
+++ b/ibm/service/scc/data_source_ibm_scc_instance_settings_test.go
@@ -5,6 +5,7 @@ package scc_test
 
 import (
 	"fmt"
+	"os"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
@@ -13,12 +14,17 @@ import (
 )
 
 func TestAccIbmSccInstanceSettingsDataSourceBasic(t *testing.T) {
+	instanceID, ok := os.LookupEnv("IBMCLOUD_SCC_INSTANCE_ID")
+	if !ok {
+		t.Logf("Missing the env var IBMCLOUD_SCC_INSTANCE_ID.")
+	}
+
 	resource.Test(t, resource.TestCase{
 		PreCheck:  func() { acc.TestAccPreCheck(t) },
 		Providers: acc.TestAccProviders,
 		Steps: []resource.TestStep{
 			resource.TestStep{
-				Config: testAccCheckIbmSccInstanceSettingsDataSourceConfigBasic(),
+				Config: testAccCheckIbmSccInstanceSettingsDataSourceConfigBasic(instanceID),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrSet("data.ibm_scc_instance_settings.scc_instance_settings_tf", "id"),
 					resource.TestCheckResourceAttrSet("data.ibm_scc_instance_settings.scc_instance_settings_tf", "event_notifications.#"),
@@ -29,9 +35,10 @@ func TestAccIbmSccInstanceSettingsDataSourceBasic(t *testing.T) {
 	})
 }
 
-func testAccCheckIbmSccInstanceSettingsDataSourceConfigBasic() string {
+func testAccCheckIbmSccInstanceSettingsDataSourceConfigBasic(instanceID string) string {
 	return fmt.Sprintf(`
 		data "ibm_scc_instance_settings" "scc_instance_settings_tf" {
+			instance_id = "%s"
 		}
-	`)
+	`, instanceID)
 }

--- a/ibm/service/scc/data_source_ibm_scc_instance_settings_test.go
+++ b/ibm/service/scc/data_source_ibm_scc_instance_settings_test.go
@@ -20,10 +20,10 @@ func TestAccIbmSccInstanceSettingsDataSourceBasic(t *testing.T) {
 	}
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { acc.TestAccPreCheck(t) },
+		PreCheck:  func() { acc.TestAccPreCheckSccInstanceID(t) },
 		Providers: acc.TestAccProviders,
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: testAccCheckIbmSccInstanceSettingsDataSourceConfigBasic(instanceID),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrSet("data.ibm_scc_instance_settings.scc_instance_settings_tf", "id"),

--- a/ibm/service/scc/data_source_ibm_scc_instance_settings_test.go
+++ b/ibm/service/scc/data_source_ibm_scc_instance_settings_test.go
@@ -5,7 +5,6 @@ package scc_test
 
 import (
 	"fmt"
-	"os"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
@@ -14,17 +13,12 @@ import (
 )
 
 func TestAccIbmSccInstanceSettingsDataSourceBasic(t *testing.T) {
-	instanceID, ok := os.LookupEnv("IBMCLOUD_SCC_INSTANCE_ID")
-	if !ok {
-		t.Logf("Missing the env var IBMCLOUD_SCC_INSTANCE_ID.")
-	}
-
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { acc.TestAccPreCheckSccInstanceID(t) },
+		PreCheck:  func() { acc.TestAccPreCheckScc(t) },
 		Providers: acc.TestAccProviders,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckIbmSccInstanceSettingsDataSourceConfigBasic(instanceID),
+				Config: testAccCheckIbmSccInstanceSettingsDataSourceConfigBasic(acc.SccInstanceID),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrSet("data.ibm_scc_instance_settings.scc_instance_settings_tf", "id"),
 					resource.TestCheckResourceAttrSet("data.ibm_scc_instance_settings.scc_instance_settings_tf", "event_notifications.#"),

--- a/ibm/service/scc/data_source_ibm_scc_latest_reports.go
+++ b/ibm/service/scc/data_source_ibm_scc_latest_reports.go
@@ -18,7 +18,7 @@ import (
 )
 
 func DataSourceIbmSccLatestReports() *schema.Resource {
-	return &schema.Resource{
+	return AddSchemaData(&schema.Resource{
 		ReadContext: dataSourceIbmSccLatestReportsRead,
 
 		Schema: map[string]*schema.Schema{
@@ -294,7 +294,7 @@ func DataSourceIbmSccLatestReports() *schema.Resource {
 				},
 			},
 		},
-	}
+	})
 }
 
 func dataSourceIbmSccLatestReportsRead(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {

--- a/ibm/service/scc/data_source_ibm_scc_latest_reports.go
+++ b/ibm/service/scc/data_source_ibm_scc_latest_reports.go
@@ -304,6 +304,7 @@ func dataSourceIbmSccLatestReportsRead(context context.Context, d *schema.Resour
 	}
 
 	getLatestReportsOptions := &securityandcompliancecenterapiv3.GetLatestReportsOptions{}
+	getLatestReportsOptions.SetInstanceID(d.Get("instance_id").(string))
 
 	if _, ok := d.GetOk("sort"); ok {
 		getLatestReportsOptions.SetSort(d.Get("sort").(string))

--- a/ibm/service/scc/data_source_ibm_scc_latest_reports_test.go
+++ b/ibm/service/scc/data_source_ibm_scc_latest_reports_test.go
@@ -5,7 +5,6 @@ package scc_test
 
 import (
 	"fmt"
-	"os"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
@@ -14,17 +13,12 @@ import (
 )
 
 func TestAccIbmSccLatestReportsDataSourceBasic(t *testing.T) {
-	instanceID, ok := os.LookupEnv("IBMCLOUD_SCC_INSTANCE_ID")
-	if !ok {
-		t.Logf("Missing the env var IBMCLOUD_SCC_INSTANCE_ID.")
-	}
-
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { acc.TestAccPreCheckSccInstanceID(t) },
+		PreCheck:  func() { acc.TestAccPreCheckScc(t) },
 		Providers: acc.TestAccProviders,
 		Steps: []resource.TestStep{
 			resource.TestStep{
-				Config: testAccCheckIbmSccLatestReportsDataSourceConfigBasic(instanceID),
+				Config: testAccCheckIbmSccLatestReportsDataSourceConfigBasic(acc.SccInstanceID),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrSet("data.ibm_scc_latest_reports.scc_latest_reports_instance", "id"),
 				),

--- a/ibm/service/scc/data_source_ibm_scc_latest_reports_test.go
+++ b/ibm/service/scc/data_source_ibm_scc_latest_reports_test.go
@@ -20,7 +20,7 @@ func TestAccIbmSccLatestReportsDataSourceBasic(t *testing.T) {
 	}
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { acc.TestAccPreCheck(t) },
+		PreCheck:  func() { acc.TestAccPreCheckSccInstanceID(t) },
 		Providers: acc.TestAccProviders,
 		Steps: []resource.TestStep{
 			resource.TestStep{

--- a/ibm/service/scc/data_source_ibm_scc_latest_reports_test.go
+++ b/ibm/service/scc/data_source_ibm_scc_latest_reports_test.go
@@ -5,6 +5,7 @@ package scc_test
 
 import (
 	"fmt"
+	"os"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
@@ -13,12 +14,17 @@ import (
 )
 
 func TestAccIbmSccLatestReportsDataSourceBasic(t *testing.T) {
+	instanceID, ok := os.LookupEnv("IBMCLOUD_SCC_INSTANCE_ID")
+	if !ok {
+		t.Logf("Missing the env var IBMCLOUD_SCC_INSTANCE_ID.")
+	}
+
 	resource.Test(t, resource.TestCase{
 		PreCheck:  func() { acc.TestAccPreCheck(t) },
 		Providers: acc.TestAccProviders,
 		Steps: []resource.TestStep{
 			resource.TestStep{
-				Config: testAccCheckIbmSccLatestReportsDataSourceConfigBasic(),
+				Config: testAccCheckIbmSccLatestReportsDataSourceConfigBasic(instanceID),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrSet("data.ibm_scc_latest_reports.scc_latest_reports_instance", "id"),
 				),
@@ -27,10 +33,11 @@ func TestAccIbmSccLatestReportsDataSourceBasic(t *testing.T) {
 	})
 }
 
-func testAccCheckIbmSccLatestReportsDataSourceConfigBasic() string {
+func testAccCheckIbmSccLatestReportsDataSourceConfigBasic(instanceID string) string {
 	return fmt.Sprintf(`
 		data "ibm_scc_latest_reports" "scc_latest_reports_instance" {
+			instance_id = "%s"
 			sort = "profile_name"
 		}
-	`)
+	`, instanceID)
 }

--- a/ibm/service/scc/data_source_ibm_scc_profile.go
+++ b/ibm/service/scc/data_source_ibm_scc_profile.go
@@ -17,7 +17,7 @@ import (
 )
 
 func DataSourceIbmSccProfile() *schema.Resource {
-	return &schema.Resource{
+	return AddSchemaData(&schema.Resource{
 		ReadContext: dataSourceIbmSccProfileRead,
 
 		Schema: map[string]*schema.Schema{
@@ -316,7 +316,7 @@ func DataSourceIbmSccProfile() *schema.Resource {
 				},
 			},
 		},
-	}
+	})
 }
 
 func dataSourceIbmSccProfileRead(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
@@ -328,6 +328,7 @@ func dataSourceIbmSccProfileRead(context context.Context, d *schema.ResourceData
 	getProfileOptions := &securityandcompliancecenterapiv3.GetProfileOptions{}
 
 	getProfileOptions.SetProfileID(d.Get("profile_id").(string))
+	getProfileOptions.SetInstanceID(d.Get("instance_id").(string))
 
 	profile, response, err := securityandcompliancecenterapiClient.GetProfileWithContext(context, getProfileOptions)
 	if err != nil {
@@ -355,10 +356,6 @@ func dataSourceIbmSccProfileRead(context context.Context, d *schema.ResourceData
 
 	if err = d.Set("version_group_label", profile.VersionGroupLabel); err != nil {
 		return diag.FromErr(fmt.Errorf("Error setting version_group_label: %s", err))
-	}
-
-	if err = d.Set("instance_id", profile.InstanceID); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting instance_id: %s", err))
 	}
 
 	if err = d.Set("latest", profile.Latest); err != nil {

--- a/ibm/service/scc/data_source_ibm_scc_profile_attachment.go
+++ b/ibm/service/scc/data_source_ibm_scc_profile_attachment.go
@@ -17,7 +17,7 @@ import (
 )
 
 func DataSourceIbmSccProfileAttachment() *schema.Resource {
-	return &schema.Resource{
+	return AddSchemaData(&schema.Resource{
 		ReadContext: dataSourceIbmSccProfileAttachmentRead,
 
 		Schema: map[string]*schema.Schema{
@@ -224,7 +224,7 @@ func DataSourceIbmSccProfileAttachment() *schema.Resource {
 				Description: "The description for the attachment.",
 			},
 		},
-	}
+	})
 }
 
 func dataSourceIbmSccProfileAttachmentRead(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
@@ -237,6 +237,7 @@ func dataSourceIbmSccProfileAttachmentRead(context context.Context, d *schema.Re
 
 	getProfileAttachmentOptions.SetAttachmentID(d.Get("attachment_id").(string))
 	getProfileAttachmentOptions.SetProfileID(d.Get("profile_id").(string))
+	getProfileAttachmentOptions.SetInstanceID(d.Get("instance_id").(string))
 
 	attachmentItem, response, err := securityandcompliancecenterapiClient.GetProfileAttachmentWithContext(context, getProfileAttachmentOptions)
 	if err != nil {

--- a/ibm/service/scc/data_source_ibm_scc_profile_attachment_test.go
+++ b/ibm/service/scc/data_source_ibm_scc_profile_attachment_test.go
@@ -17,7 +17,6 @@ func TestAccIbmSccProfileAttachmentDataSourceBasic(t *testing.T) {
 	instanceID, ok := os.LookupEnv("IBMCLOUD_SCC_INSTANCE_ID")
 	if !ok {
 		t.Logf("Missing the env var IBMCLOUD_SCC_INSTANCE_ID.")
-		t.FailNow()
 	}
 
 	resource.Test(t, resource.TestCase{
@@ -40,7 +39,6 @@ func TestAccIbmSccProfileAttachmentDataSourceAllArgs(t *testing.T) {
 	instanceID, ok := os.LookupEnv("IBMCLOUD_SCC_INSTANCE_ID")
 	if !ok {
 		t.Logf("Missing the env var IBMCLOUD_SCC_INSTANCE_ID.")
-		t.FailNow()
 	}
 
 	resource.Test(t, resource.TestCase{

--- a/ibm/service/scc/data_source_ibm_scc_profile_attachment_test.go
+++ b/ibm/service/scc/data_source_ibm_scc_profile_attachment_test.go
@@ -20,7 +20,7 @@ func TestAccIbmSccProfileAttachmentDataSourceBasic(t *testing.T) {
 	}
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { acc.TestAccPreCheck(t) },
+		PreCheck:  func() { acc.TestAccPreCheckSccInstanceID(t) },
 		Providers: acc.TestAccProviders,
 		Steps: []resource.TestStep{
 			{
@@ -42,7 +42,7 @@ func TestAccIbmSccProfileAttachmentDataSourceAllArgs(t *testing.T) {
 	}
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { acc.TestAccPreCheck(t) },
+		PreCheck:  func() { acc.TestAccPreCheckSccInstanceID(t) },
 		Providers: acc.TestAccProviders,
 		Steps: []resource.TestStep{
 			{

--- a/ibm/service/scc/data_source_ibm_scc_profile_attachment_test.go
+++ b/ibm/service/scc/data_source_ibm_scc_profile_attachment_test.go
@@ -5,7 +5,6 @@ package scc_test
 
 import (
 	"fmt"
-	"os"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
@@ -14,17 +13,12 @@ import (
 )
 
 func TestAccIbmSccProfileAttachmentDataSourceBasic(t *testing.T) {
-	instanceID, ok := os.LookupEnv("IBMCLOUD_SCC_INSTANCE_ID")
-	if !ok {
-		t.Logf("Missing the env var IBMCLOUD_SCC_INSTANCE_ID.")
-	}
-
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { acc.TestAccPreCheckSccInstanceID(t) },
+		PreCheck:  func() { acc.TestAccPreCheckScc(t) },
 		Providers: acc.TestAccProviders,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckIbmSccProfileAttachmentDataSourceConfigBasic(instanceID),
+				Config: testAccCheckIbmSccProfileAttachmentDataSourceConfigBasic(acc.SccInstanceID),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrSet("data.ibm_scc_profile_attachment.scc_profile_attachment_instance", "id"),
 					resource.TestCheckResourceAttrSet("data.ibm_scc_profile_attachment.scc_profile_attachment_instance", "attachment_id"),
@@ -36,17 +30,12 @@ func TestAccIbmSccProfileAttachmentDataSourceBasic(t *testing.T) {
 }
 
 func TestAccIbmSccProfileAttachmentDataSourceAllArgs(t *testing.T) {
-	instanceID, ok := os.LookupEnv("IBMCLOUD_SCC_INSTANCE_ID")
-	if !ok {
-		t.Logf("Missing the env var IBMCLOUD_SCC_INSTANCE_ID.")
-	}
-
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { acc.TestAccPreCheckSccInstanceID(t) },
+		PreCheck:  func() { acc.TestAccPreCheckScc(t) },
 		Providers: acc.TestAccProviders,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckIbmSccProfileAttachmentDataSourceConfig(instanceID),
+				Config: testAccCheckIbmSccProfileAttachmentDataSourceConfig(acc.SccInstanceID),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrSet("data.ibm_scc_profile_attachment.scc_profile_attachment_instance", "id"),
 					resource.TestCheckResourceAttrSet("data.ibm_scc_profile_attachment.scc_profile_attachment_instance", "attachment_id"),

--- a/ibm/service/scc/data_source_ibm_scc_profile_test.go
+++ b/ibm/service/scc/data_source_ibm_scc_profile_test.go
@@ -5,7 +5,6 @@ package scc_test
 
 import (
 	"fmt"
-	"os"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
@@ -18,17 +17,13 @@ func TestAccIbmSccProfileDataSourceBasic(t *testing.T) {
 	profileProfileName := fmt.Sprintf("tf_profile_name_%d", acctest.RandIntRange(10, 100))
 	profileProfileDescription := fmt.Sprintf("tf_profile_description_%d", acctest.RandIntRange(10, 100))
 	profileProfileType := "custom"
-	instanceID, ok := os.LookupEnv("IBMCLOUD_SCC_INSTANCE_ID")
-	if !ok {
-		t.Logf("Missing the env var IBMCLOUD_SCC_INSTANCE_ID.")
-	}
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { acc.TestAccPreCheckSccInstanceID(t) },
+		PreCheck:  func() { acc.TestAccPreCheckScc(t) },
 		Providers: acc.TestAccProviders,
 		Steps: []resource.TestStep{
 			resource.TestStep{
-				Config: testAccCheckIbmSccProfileDataSourceConfigBasic(instanceID, profileProfileName, profileProfileDescription, profileProfileType),
+				Config: testAccCheckIbmSccProfileDataSourceConfigBasic(acc.SccInstanceID, profileProfileName, profileProfileDescription, profileProfileType),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrSet("data.ibm_scc_profile.scc_profile_instance", "id"),
 					resource.TestCheckResourceAttrSet("data.ibm_scc_profile.scc_profile_instance", "profile_id"),
@@ -42,17 +37,13 @@ func TestAccIbmSccProfileDataSourceAllArgs(t *testing.T) {
 	profileProfileName := fmt.Sprintf("tf_profile_name_%d", acctest.RandIntRange(10, 100))
 	profileProfileDescription := fmt.Sprintf("tf_profile_description_%d", acctest.RandIntRange(10, 100))
 	profileProfileType := "custom"
-	instanceID, ok := os.LookupEnv("IBMCLOUD_SCC_INSTANCE_ID")
-	if !ok {
-		t.Logf("Missing the env var IBMCLOUD_SCC_INSTANCE_ID.")
-	}
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { acc.TestAccPreCheckSccInstanceID(t) },
+		PreCheck:  func() { acc.TestAccPreCheckScc(t) },
 		Providers: acc.TestAccProviders,
 		Steps: []resource.TestStep{
 			resource.TestStep{
-				Config: testAccCheckIbmSccProfileDataSourceConfig(instanceID, profileProfileName, profileProfileDescription, profileProfileType),
+				Config: testAccCheckIbmSccProfileDataSourceConfig(acc.SccInstanceID, profileProfileName, profileProfileDescription, profileProfileType),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrSet("data.ibm_scc_profile.scc_profile_instance", "id"),
 					resource.TestCheckResourceAttrSet("data.ibm_scc_profile.scc_profile_instance", "profile_name"),

--- a/ibm/service/scc/data_source_ibm_scc_profile_test.go
+++ b/ibm/service/scc/data_source_ibm_scc_profile_test.go
@@ -24,7 +24,7 @@ func TestAccIbmSccProfileDataSourceBasic(t *testing.T) {
 	}
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { acc.TestAccPreCheck(t) },
+		PreCheck:  func() { acc.TestAccPreCheckSccInstanceID(t) },
 		Providers: acc.TestAccProviders,
 		Steps: []resource.TestStep{
 			resource.TestStep{
@@ -48,7 +48,7 @@ func TestAccIbmSccProfileDataSourceAllArgs(t *testing.T) {
 	}
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { acc.TestAccPreCheck(t) },
+		PreCheck:  func() { acc.TestAccPreCheckSccInstanceID(t) },
 		Providers: acc.TestAccProviders,
 		Steps: []resource.TestStep{
 			resource.TestStep{

--- a/ibm/service/scc/data_source_ibm_scc_profile_test.go
+++ b/ibm/service/scc/data_source_ibm_scc_profile_test.go
@@ -21,7 +21,6 @@ func TestAccIbmSccProfileDataSourceBasic(t *testing.T) {
 	instanceID, ok := os.LookupEnv("IBMCLOUD_SCC_INSTANCE_ID")
 	if !ok {
 		t.Logf("Missing the env var IBMCLOUD_SCC_INSTANCE_ID.")
-		t.FailNow()
 	}
 
 	resource.Test(t, resource.TestCase{
@@ -46,7 +45,6 @@ func TestAccIbmSccProfileDataSourceAllArgs(t *testing.T) {
 	instanceID, ok := os.LookupEnv("IBMCLOUD_SCC_INSTANCE_ID")
 	if !ok {
 		t.Logf("Missing the env var IBMCLOUD_SCC_INSTANCE_ID.")
-		t.FailNow()
 	}
 
 	resource.Test(t, resource.TestCase{

--- a/ibm/service/scc/data_source_ibm_scc_provider_type.go
+++ b/ibm/service/scc/data_source_ibm_scc_provider_type.go
@@ -17,7 +17,7 @@ import (
 )
 
 func DataSourceIbmSccProviderType() *schema.Resource {
-	return AddSchemaData(&schema.Resource{
+	return &schema.Resource{
 		ReadContext: dataSourceIbmSccProviderTypeRead,
 
 		Schema: map[string]*schema.Schema{
@@ -109,7 +109,7 @@ func DataSourceIbmSccProviderType() *schema.Resource {
 				Description: "Time at which resource was updated.",
 			},
 		},
-	})
+	}
 }
 
 func dataSourceIbmSccProviderTypeRead(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {

--- a/ibm/service/scc/data_source_ibm_scc_provider_type.go
+++ b/ibm/service/scc/data_source_ibm_scc_provider_type.go
@@ -17,7 +17,7 @@ import (
 )
 
 func DataSourceIbmSccProviderType() *schema.Resource {
-	return &schema.Resource{
+	return AddSchemaData(&schema.Resource{
 		ReadContext: dataSourceIbmSccProviderTypeRead,
 
 		Schema: map[string]*schema.Schema{
@@ -109,7 +109,7 @@ func DataSourceIbmSccProviderType() *schema.Resource {
 				Description: "Time at which resource was updated.",
 			},
 		},
-	}
+	})
 }
 
 func dataSourceIbmSccProviderTypeRead(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {

--- a/ibm/service/scc/data_source_ibm_scc_provider_type_collection.go
+++ b/ibm/service/scc/data_source_ibm_scc_provider_type_collection.go
@@ -19,7 +19,7 @@ import (
 )
 
 func DataSourceIbmSccProviderTypeCollection() *schema.Resource {
-	return &schema.Resource{
+	return AddSchemaData(&schema.Resource{
 		ReadContext: dataSourceIbmSccProviderTypeCollectionRead,
 
 		Schema: map[string]*schema.Schema{
@@ -115,7 +115,7 @@ func DataSourceIbmSccProviderTypeCollection() *schema.Resource {
 				},
 			},
 		},
-	}
+	})
 }
 
 func dataSourceIbmSccProviderTypeCollectionRead(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {

--- a/ibm/service/scc/data_source_ibm_scc_provider_type_collection.go
+++ b/ibm/service/scc/data_source_ibm_scc_provider_type_collection.go
@@ -19,7 +19,7 @@ import (
 )
 
 func DataSourceIbmSccProviderTypeCollection() *schema.Resource {
-	return AddSchemaData(&schema.Resource{
+	return &schema.Resource{
 		ReadContext: dataSourceIbmSccProviderTypeCollectionRead,
 
 		Schema: map[string]*schema.Schema{
@@ -115,7 +115,7 @@ func DataSourceIbmSccProviderTypeCollection() *schema.Resource {
 				},
 			},
 		},
-	})
+	}
 }
 
 func dataSourceIbmSccProviderTypeCollectionRead(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {

--- a/ibm/service/scc/data_source_ibm_scc_provider_type_collection_test.go
+++ b/ibm/service/scc/data_source_ibm_scc_provider_type_collection_test.go
@@ -14,7 +14,7 @@ import (
 
 func TestAccIbmSccProviderTypeCollectionDataSourceBasic(t *testing.T) {
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { acc.TestAccPreCheck(t) },
+		PreCheck:  func() { acc.TestAccPreCheckSccInstanceID(t) },
 		Providers: acc.TestAccProviders,
 		Steps: []resource.TestStep{
 			resource.TestStep{

--- a/ibm/service/scc/data_source_ibm_scc_provider_type_collection_test.go
+++ b/ibm/service/scc/data_source_ibm_scc_provider_type_collection_test.go
@@ -14,7 +14,7 @@ import (
 
 func TestAccIbmSccProviderTypeCollectionDataSourceBasic(t *testing.T) {
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { acc.TestAccPreCheckSccInstanceID(t) },
+		PreCheck:  func() { acc.TestAccPreCheckScc(t) },
 		Providers: acc.TestAccProviders,
 		Steps: []resource.TestStep{
 			resource.TestStep{

--- a/ibm/service/scc/data_source_ibm_scc_provider_type_instance.go
+++ b/ibm/service/scc/data_source_ibm_scc_provider_type_instance.go
@@ -17,7 +17,7 @@ import (
 )
 
 func DataSourceIbmSccProviderTypeInstance() *schema.Resource {
-	return &schema.Resource{
+	return AddSchemaData(&schema.Resource{
 		ReadContext: dataSourceIbmSccProviderTypeInstanceRead,
 
 		Schema: map[string]*schema.Schema{
@@ -61,7 +61,7 @@ func DataSourceIbmSccProviderTypeInstance() *schema.Resource {
 				Description: "Time at which resource was updated.",
 			},
 		},
-	}
+	})
 }
 
 func dataSourceIbmSccProviderTypeInstanceRead(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {

--- a/ibm/service/scc/data_source_ibm_scc_provider_type_instance.go
+++ b/ibm/service/scc/data_source_ibm_scc_provider_type_instance.go
@@ -74,6 +74,7 @@ func dataSourceIbmSccProviderTypeInstanceRead(context context.Context, d *schema
 
 	getProviderTypeInstanceOptions.SetProviderTypeID(d.Get("provider_type_id").(string))
 	getProviderTypeInstanceOptions.SetProviderTypeInstanceID(d.Get("provider_type_instance_id").(string))
+	getProviderTypeInstanceOptions.SetInstanceID(d.Get("instance_id").(string))
 
 	providerTypeInstanceItem, response, err := securityAndComplianceCenterApIsClient.GetProviderTypeInstanceWithContext(context, getProviderTypeInstanceOptions)
 	if err != nil {

--- a/ibm/service/scc/data_source_ibm_scc_provider_type_instance_test.go
+++ b/ibm/service/scc/data_source_ibm_scc_provider_type_instance_test.go
@@ -5,7 +5,6 @@ package scc_test
 
 import (
 	"fmt"
-	"os"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
@@ -16,18 +15,12 @@ import (
 
 func TestAccIbmSccProviderTypeInstanceDataSourceBasic(t *testing.T) {
 	providerTypeInstanceName := fmt.Sprintf("tf_provider_type_instance_name_%d", acctest.RandIntRange(10, 100))
-	providerTypeInstanceAttributes := os.Getenv("IBMCLOUD_SCC_PROVIDER_TYPE_ATTRIBUTES")
-	instanceID, ok := os.LookupEnv("IBMCLOUD_SCC_INSTANCE_ID")
-	if !ok {
-		t.Logf("Missing the env var IBMCLOUD_SCC_INSTANCE_ID.")
-	}
-
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { acc.TestAccPreCheckSccInstanceID(t) },
+		PreCheck:  func() { acc.TestAccPreCheckScc(t) },
 		Providers: acc.TestAccProviders,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckIbmSccProviderTypeInstanceDataSourceConfigBasic(instanceID, providerTypeInstanceName, providerTypeInstanceAttributes),
+				Config: testAccCheckIbmSccProviderTypeInstanceDataSourceConfigBasic(acc.SccInstanceID, providerTypeInstanceName, acc.SccProviderTypeAttributes),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrSet("data.ibm_scc_provider_type_instance.scc_provider_type_instance_tf", "id"),
 					resource.TestCheckResourceAttrSet("data.ibm_scc_provider_type_instance.scc_provider_type_instance_tf", "provider_type_id"),
@@ -40,18 +33,13 @@ func TestAccIbmSccProviderTypeInstanceDataSourceBasic(t *testing.T) {
 
 func TestAccIbmSccProviderTypeInstanceDataSourceAllArgs(t *testing.T) {
 	providerTypeInstanceName := fmt.Sprintf("tf_provider_type_instance_name_%d", acctest.RandIntRange(10, 100))
-	providerTypeInstanceAttributes := os.Getenv("IBMCLOUD_SCC_PROVIDER_TYPE_ATTRIBUTES")
-	instanceID, ok := os.LookupEnv("IBMCLOUD_SCC_INSTANCE_ID")
-	if !ok {
-		t.Logf("Missing the env var IBMCLOUD_SCC_INSTANCE_ID.")
-	}
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { acc.TestAccPreCheckSccInstanceID(t) },
+		PreCheck:  func() { acc.TestAccPreCheckScc(t) },
 		Providers: acc.TestAccProviders,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckIbmSccProviderTypeInstanceDataSourceConfig(instanceID, providerTypeInstanceName, providerTypeInstanceAttributes),
+				Config: testAccCheckIbmSccProviderTypeInstanceDataSourceConfig(acc.SccInstanceID, providerTypeInstanceName, acc.SccProviderTypeAttributes),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrSet("data.ibm_scc_provider_type_instance.scc_provider_type_instance_tf", "id"),
 					resource.TestCheckResourceAttrSet("data.ibm_scc_provider_type_instance.scc_provider_type_instance_tf", "provider_type_id"),

--- a/ibm/service/scc/data_source_ibm_scc_provider_type_instance_test.go
+++ b/ibm/service/scc/data_source_ibm_scc_provider_type_instance_test.go
@@ -17,13 +17,17 @@ import (
 func TestAccIbmSccProviderTypeInstanceDataSourceBasic(t *testing.T) {
 	providerTypeInstanceName := fmt.Sprintf("tf_provider_type_instance_name_%d", acctest.RandIntRange(10, 100))
 	providerTypeInstanceAttributes := os.Getenv("IBMCLOUD_SCC_PROVIDER_TYPE_ATTRIBUTES")
+	instanceID, ok := os.LookupEnv("IBMCLOUD_SCC_INSTANCE_ID")
+	if !ok {
+		t.Logf("Missing the env var IBMCLOUD_SCC_INSTANCE_ID.")
+	}
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:  func() { acc.TestAccPreCheck(t) },
 		Providers: acc.TestAccProviders,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckIbmSccProviderTypeInstanceDataSourceConfigBasic(providerTypeInstanceName, providerTypeInstanceAttributes),
+				Config: testAccCheckIbmSccProviderTypeInstanceDataSourceConfigBasic(instanceID, providerTypeInstanceName, providerTypeInstanceAttributes),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrSet("data.ibm_scc_provider_type_instance.scc_provider_type_instance_tf", "id"),
 					resource.TestCheckResourceAttrSet("data.ibm_scc_provider_type_instance.scc_provider_type_instance_tf", "provider_type_id"),
@@ -37,13 +41,17 @@ func TestAccIbmSccProviderTypeInstanceDataSourceBasic(t *testing.T) {
 func TestAccIbmSccProviderTypeInstanceDataSourceAllArgs(t *testing.T) {
 	providerTypeInstanceName := fmt.Sprintf("tf_provider_type_instance_name_%d", acctest.RandIntRange(10, 100))
 	providerTypeInstanceAttributes := os.Getenv("IBMCLOUD_SCC_PROVIDER_TYPE_ATTRIBUTES")
+	instanceID, ok := os.LookupEnv("IBMCLOUD_SCC_INSTANCE_ID")
+	if !ok {
+		t.Logf("Missing the env var IBMCLOUD_SCC_INSTANCE_ID.")
+	}
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:  func() { acc.TestAccPreCheck(t) },
 		Providers: acc.TestAccProviders,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckIbmSccProviderTypeInstanceDataSourceConfig(providerTypeInstanceName, providerTypeInstanceAttributes),
+				Config: testAccCheckIbmSccProviderTypeInstanceDataSourceConfig(instanceID, providerTypeInstanceName, providerTypeInstanceAttributes),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrSet("data.ibm_scc_provider_type_instance.scc_provider_type_instance_tf", "id"),
 					resource.TestCheckResourceAttrSet("data.ibm_scc_provider_type_instance.scc_provider_type_instance_tf", "provider_type_id"),
@@ -59,32 +67,36 @@ func TestAccIbmSccProviderTypeInstanceDataSourceAllArgs(t *testing.T) {
 	})
 }
 
-func testAccCheckIbmSccProviderTypeInstanceDataSourceConfigBasic(providerTypeInstanceName string, providerTypeInstanceAttributes string) string {
+func testAccCheckIbmSccProviderTypeInstanceDataSourceConfigBasic(instanceID string, providerTypeInstanceName string, providerTypeInstanceAttributes string) string {
 	return fmt.Sprintf(`
 		resource "ibm_scc_provider_type_instance" "scc_provider_type_instance" {
+			instance_id = "%s"
 			provider_type_id = "afa2476ecfa5f09af248492fe991b4d1"
 			name = "%s"
 			attributes = %s
 		}
 
 		data "ibm_scc_provider_type_instance" "scc_provider_type_instance_tf" {
+			instance_id = resource.ibm_scc_provider_type_instance.scc_provider_type_instance.instance_id
 			provider_type_id = ibm_scc_provider_type_instance.scc_provider_type_instance.provider_type_id
 			provider_type_instance_id = ibm_scc_provider_type_instance.scc_provider_type_instance.provider_type_instance_id
 		}
-	`, providerTypeInstanceName, providerTypeInstanceAttributes)
+	`, instanceID, providerTypeInstanceName, providerTypeInstanceAttributes)
 }
 
-func testAccCheckIbmSccProviderTypeInstanceDataSourceConfig(providerTypeInstanceName string, providerTypeInstanceAttributes string) string {
+func testAccCheckIbmSccProviderTypeInstanceDataSourceConfig(instanceID string, providerTypeInstanceName string, providerTypeInstanceAttributes string) string {
 	return fmt.Sprintf(`
 		resource "ibm_scc_provider_type_instance" "scc_provider_type_instance" {
+			instance_id = "%s"
 			provider_type_id = "afa2476ecfa5f09af248492fe991b4d1"
 			name = "%s"
 			attributes = %s
 		}
 
 		data "ibm_scc_provider_type_instance" "scc_provider_type_instance_tf" {
+			instance_id = resource.ibm_scc_provider_type_instance.scc_provider_type_instance.instance_id
 			provider_type_id = ibm_scc_provider_type_instance.scc_provider_type_instance.provider_type_id
 			provider_type_instance_id = ibm_scc_provider_type_instance.scc_provider_type_instance.provider_type_instance_id
 		}
-	`, providerTypeInstanceName, providerTypeInstanceAttributes)
+	`, instanceID, providerTypeInstanceName, providerTypeInstanceAttributes)
 }

--- a/ibm/service/scc/data_source_ibm_scc_provider_type_instance_test.go
+++ b/ibm/service/scc/data_source_ibm_scc_provider_type_instance_test.go
@@ -23,7 +23,7 @@ func TestAccIbmSccProviderTypeInstanceDataSourceBasic(t *testing.T) {
 	}
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { acc.TestAccPreCheck(t) },
+		PreCheck:  func() { acc.TestAccPreCheckSccInstanceID(t) },
 		Providers: acc.TestAccProviders,
 		Steps: []resource.TestStep{
 			{
@@ -47,7 +47,7 @@ func TestAccIbmSccProviderTypeInstanceDataSourceAllArgs(t *testing.T) {
 	}
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { acc.TestAccPreCheck(t) },
+		PreCheck:  func() { acc.TestAccPreCheckSccInstanceID(t) },
 		Providers: acc.TestAccProviders,
 		Steps: []resource.TestStep{
 			{

--- a/ibm/service/scc/data_source_ibm_scc_provider_type_test.go
+++ b/ibm/service/scc/data_source_ibm_scc_provider_type_test.go
@@ -14,7 +14,7 @@ import (
 
 func TestAccIbmSccProviderTypeDataSourceBasic(t *testing.T) {
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { acc.TestAccPreCheck(t) },
+		PreCheck:  func() { acc.TestAccPreCheckSccInstanceID(t) },
 		Providers: acc.TestAccProviders,
 		Steps: []resource.TestStep{
 			resource.TestStep{

--- a/ibm/service/scc/data_source_ibm_scc_provider_type_test.go
+++ b/ibm/service/scc/data_source_ibm_scc_provider_type_test.go
@@ -14,7 +14,7 @@ import (
 
 func TestAccIbmSccProviderTypeDataSourceBasic(t *testing.T) {
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { acc.TestAccPreCheckSccInstanceID(t) },
+		PreCheck:  func() { acc.TestAccPreCheckScc(t) },
 		Providers: acc.TestAccProviders,
 		Steps: []resource.TestStep{
 			resource.TestStep{

--- a/ibm/service/scc/data_source_ibm_scc_report.go
+++ b/ibm/service/scc/data_source_ibm_scc_report.go
@@ -16,7 +16,7 @@ import (
 )
 
 func DataSourceIbmSccReport() *schema.Resource {
-	return &schema.Resource{
+	return AddSchemaData(&schema.Resource{
 		ReadContext: dataSourceIbmSccReportRead,
 
 		Schema: map[string]*schema.Schema{
@@ -176,7 +176,7 @@ func DataSourceIbmSccReport() *schema.Resource {
 				},
 			},
 		},
-	}
+	})
 }
 
 func dataSourceIbmSccReportRead(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {

--- a/ibm/service/scc/data_source_ibm_scc_report.go
+++ b/ibm/service/scc/data_source_ibm_scc_report.go
@@ -188,6 +188,7 @@ func dataSourceIbmSccReportRead(context context.Context, d *schema.ResourceData,
 	getReportOptions := &securityandcompliancecenterapiv3.GetReportOptions{}
 
 	getReportOptions.SetReportID(d.Get("report_id").(string))
+	getReportOptions.SetInstanceID(d.Get("instance_id").(string))
 
 	report, response, err := resultsClient.GetReportWithContext(context, getReportOptions)
 	if err != nil {

--- a/ibm/service/scc/data_source_ibm_scc_report_controls.go
+++ b/ibm/service/scc/data_source_ibm_scc_report_controls.go
@@ -301,6 +301,7 @@ func dataSourceIbmSccReportControlsRead(context context.Context, d *schema.Resou
 	getReportControlsOptions := &securityandcompliancecenterapiv3.GetReportControlsOptions{}
 
 	getReportControlsOptions.SetReportID(d.Get("report_id").(string))
+	getReportControlsOptions.SetInstanceID(d.Get("instance_id").(string))
 	if _, ok := d.GetOk("control_id"); ok {
 		getReportControlsOptions.SetControlID(d.Get("control_id").(string))
 	}

--- a/ibm/service/scc/data_source_ibm_scc_report_controls.go
+++ b/ibm/service/scc/data_source_ibm_scc_report_controls.go
@@ -18,7 +18,7 @@ import (
 )
 
 func DataSourceIbmSccReportControls() *schema.Resource {
-	return &schema.Resource{
+	return AddSchemaData(&schema.Resource{
 		ReadContext: dataSourceIbmSccReportControlsRead,
 
 		Schema: map[string]*schema.Schema{
@@ -289,7 +289,7 @@ func DataSourceIbmSccReportControls() *schema.Resource {
 				},
 			},
 		},
-	}
+	})
 }
 
 func dataSourceIbmSccReportControlsRead(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {

--- a/ibm/service/scc/data_source_ibm_scc_report_controls_test.go
+++ b/ibm/service/scc/data_source_ibm_scc_report_controls_test.go
@@ -24,7 +24,7 @@ func TestAccIbmSccReportControlsDataSourceBasic(t *testing.T) {
 		t.Logf("Missing the env var IBMCLOUD_SCC_REPORT_ID.")
 	}
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { acc.TestAccPreCheck(t) },
+		PreCheck:  func() { acc.TestAccPreCheckSccInstanceID(t) },
 		Providers: acc.TestAccProviders,
 		Steps: []resource.TestStep{
 			{

--- a/ibm/service/scc/data_source_ibm_scc_report_controls_test.go
+++ b/ibm/service/scc/data_source_ibm_scc_report_controls_test.go
@@ -5,7 +5,6 @@ package scc_test
 
 import (
 	"fmt"
-	"os"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
@@ -14,21 +13,13 @@ import (
 )
 
 func TestAccIbmSccReportControlsDataSourceBasic(t *testing.T) {
-	instanceID, ok := os.LookupEnv("IBMCLOUD_SCC_INSTANCE_ID")
-	if !ok {
-		t.Logf("Missing the env var IBMCLOUD_SCC_INSTANCE_ID.")
-	}
 
-	reportID, ok := os.LookupEnv("IBMCLOUD_SCC_REPORT_ID")
-	if !ok {
-		t.Logf("Missing the env var IBMCLOUD_SCC_REPORT_ID.")
-	}
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { acc.TestAccPreCheckSccInstanceID(t) },
+		PreCheck:  func() { acc.TestAccPreCheckScc(t) },
 		Providers: acc.TestAccProviders,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckIbmSccReportControlsDataSourceConfigBasic(instanceID, reportID),
+				Config: testAccCheckIbmSccReportControlsDataSourceConfigBasic(acc.SccInstanceID, acc.SccReportID),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrSet("data.ibm_scc_report_controls.scc_report_controls_instance", "id"),
 					resource.TestCheckResourceAttrSet("data.ibm_scc_report_controls.scc_report_controls_instance", "report_id"),

--- a/ibm/service/scc/data_source_ibm_scc_report_controls_test.go
+++ b/ibm/service/scc/data_source_ibm_scc_report_controls_test.go
@@ -14,12 +14,21 @@ import (
 )
 
 func TestAccIbmSccReportControlsDataSourceBasic(t *testing.T) {
+	instanceID, ok := os.LookupEnv("IBMCLOUD_SCC_INSTANCE_ID")
+	if !ok {
+		t.Logf("Missing the env var IBMCLOUD_SCC_INSTANCE_ID.")
+	}
+
+	reportID, ok := os.LookupEnv("IBMCLOUD_SCC_REPORT_ID")
+	if !ok {
+		t.Logf("Missing the env var IBMCLOUD_SCC_REPORT_ID.")
+	}
 	resource.Test(t, resource.TestCase{
 		PreCheck:  func() { acc.TestAccPreCheck(t) },
 		Providers: acc.TestAccProviders,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckIbmSccReportControlsDataSourceConfigBasic(),
+				Config: testAccCheckIbmSccReportControlsDataSourceConfigBasic(instanceID, reportID),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrSet("data.ibm_scc_report_controls.scc_report_controls_instance", "id"),
 					resource.TestCheckResourceAttrSet("data.ibm_scc_report_controls.scc_report_controls_instance", "report_id"),
@@ -29,11 +38,11 @@ func TestAccIbmSccReportControlsDataSourceBasic(t *testing.T) {
 	})
 }
 
-func testAccCheckIbmSccReportControlsDataSourceConfigBasic() string {
-	report_id := os.Getenv("IBMCLOUD_SCC_REPORT_ID")
+func testAccCheckIbmSccReportControlsDataSourceConfigBasic(instanceID, reportID string) string {
 	return fmt.Sprintf(`
 		data "ibm_scc_report_controls" "scc_report_controls_instance" {
+			instance_id = "%s"
 			report_id = "%s"
 		}
-	`, report_id)
+	`, instanceID, reportID)
 }

--- a/ibm/service/scc/data_source_ibm_scc_report_evaluations.go
+++ b/ibm/service/scc/data_source_ibm_scc_report_evaluations.go
@@ -268,6 +268,7 @@ func dataSourceIbmSccReportEvaluationsRead(context context.Context, d *schema.Re
 	listReportEvaluationsOptions := &securityandcompliancecenterapiv3.ListReportEvaluationsOptions{}
 
 	listReportEvaluationsOptions.SetReportID(d.Get("report_id").(string))
+	listReportEvaluationsOptions.SetInstanceID(d.Get("instance_id").(string))
 	if _, ok := d.GetOk("assessment_id"); ok {
 		listReportEvaluationsOptions.SetAssessmentID(d.Get("assessment_id").(string))
 	}

--- a/ibm/service/scc/data_source_ibm_scc_report_evaluations.go
+++ b/ibm/service/scc/data_source_ibm_scc_report_evaluations.go
@@ -18,7 +18,7 @@ import (
 )
 
 func DataSourceIbmSccReportEvaluations() *schema.Resource {
-	return &schema.Resource{
+	return AddSchemaData(&schema.Resource{
 		ReadContext: dataSourceIbmSccReportEvaluationsRead,
 
 		Schema: map[string]*schema.Schema{
@@ -256,7 +256,7 @@ func DataSourceIbmSccReportEvaluations() *schema.Resource {
 				},
 			},
 		},
-	}
+	})
 }
 
 func dataSourceIbmSccReportEvaluationsRead(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {

--- a/ibm/service/scc/data_source_ibm_scc_report_evaluations_test.go
+++ b/ibm/service/scc/data_source_ibm_scc_report_evaluations_test.go
@@ -5,7 +5,6 @@ package scc_test
 
 import (
 	"fmt"
-	"os"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
@@ -14,21 +13,12 @@ import (
 )
 
 func TestAccIbmSccReportEvaluationsDataSourceBasic(t *testing.T) {
-	instanceID, ok := os.LookupEnv("IBMCLOUD_SCC_INSTANCE_ID")
-	if !ok {
-		t.Logf("Missing the env var IBMCLOUD_SCC_INSTANCE_ID.")
-	}
-	reportID, ok := os.LookupEnv("IBMCLOUD_SCC_REPORT_ID")
-	if !ok {
-		t.Logf("Missing the env var IBMCLOUD_SCC_REPORT_ID.")
-	}
-
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { acc.TestAccPreCheckSccInstanceID(t) },
+		PreCheck:  func() { acc.TestAccPreCheckScc(t) },
 		Providers: acc.TestAccProviders,
 		Steps: []resource.TestStep{
 			resource.TestStep{
-				Config: testAccCheckIbmSccReportEvaluationsDataSourceConfigBasic(instanceID, reportID),
+				Config: testAccCheckIbmSccReportEvaluationsDataSourceConfigBasic(acc.SccInstanceID, acc.SccReportID),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrSet("data.ibm_scc_report_evaluations.scc_report_evaluations_instance", "id"),
 					resource.TestCheckResourceAttrSet("data.ibm_scc_report_evaluations.scc_report_evaluations_instance", "report_id"),

--- a/ibm/service/scc/data_source_ibm_scc_report_evaluations_test.go
+++ b/ibm/service/scc/data_source_ibm_scc_report_evaluations_test.go
@@ -14,12 +14,21 @@ import (
 )
 
 func TestAccIbmSccReportEvaluationsDataSourceBasic(t *testing.T) {
+	instanceID, ok := os.LookupEnv("IBMCLOUD_SCC_INSTANCE_ID")
+	if !ok {
+		t.Logf("Missing the env var IBMCLOUD_SCC_INSTANCE_ID.")
+	}
+	reportID, ok := os.LookupEnv("IBMCLOUD_SCC_REPORT_ID")
+	if !ok {
+		t.Logf("Missing the env var IBMCLOUD_SCC_REPORT_ID.")
+	}
+
 	resource.Test(t, resource.TestCase{
 		PreCheck:  func() { acc.TestAccPreCheck(t) },
 		Providers: acc.TestAccProviders,
 		Steps: []resource.TestStep{
 			resource.TestStep{
-				Config: testAccCheckIbmSccReportEvaluationsDataSourceConfigBasic(),
+				Config: testAccCheckIbmSccReportEvaluationsDataSourceConfigBasic(instanceID, reportID),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrSet("data.ibm_scc_report_evaluations.scc_report_evaluations_instance", "id"),
 					resource.TestCheckResourceAttrSet("data.ibm_scc_report_evaluations.scc_report_evaluations_instance", "report_id"),
@@ -30,11 +39,11 @@ func TestAccIbmSccReportEvaluationsDataSourceBasic(t *testing.T) {
 	})
 }
 
-func testAccCheckIbmSccReportEvaluationsDataSourceConfigBasic() string {
-	report_id := os.Getenv("IBMCLOUD_SCC_REPORT_ID")
+func testAccCheckIbmSccReportEvaluationsDataSourceConfigBasic(instanceID, reportID string) string {
 	return fmt.Sprintf(`
 		data "ibm_scc_report_evaluations" "scc_report_evaluations_instance" {
+			instance_id = "%s"
 			report_id = "%s"
 		}
-	`, report_id)
+	`, instanceID, reportID)
 }

--- a/ibm/service/scc/data_source_ibm_scc_report_evaluations_test.go
+++ b/ibm/service/scc/data_source_ibm_scc_report_evaluations_test.go
@@ -24,7 +24,7 @@ func TestAccIbmSccReportEvaluationsDataSourceBasic(t *testing.T) {
 	}
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { acc.TestAccPreCheck(t) },
+		PreCheck:  func() { acc.TestAccPreCheckSccInstanceID(t) },
 		Providers: acc.TestAccProviders,
 		Steps: []resource.TestStep{
 			resource.TestStep{

--- a/ibm/service/scc/data_source_ibm_scc_report_resources.go
+++ b/ibm/service/scc/data_source_ibm_scc_report_resources.go
@@ -177,6 +177,7 @@ func dataSourceIbmSccReportResourcesRead(context context.Context, d *schema.Reso
 	listReportResourcesOptions := &securityandcompliancecenterapiv3.ListReportResourcesOptions{}
 
 	listReportResourcesOptions.SetReportID(d.Get("report_id").(string))
+	listReportResourcesOptions.SetInstanceID(d.Get("instance_id").(string))
 	if _, ok := d.GetOk("id"); ok {
 		listReportResourcesOptions.SetID(d.Get("id").(string))
 	}

--- a/ibm/service/scc/data_source_ibm_scc_report_resources.go
+++ b/ibm/service/scc/data_source_ibm_scc_report_resources.go
@@ -18,7 +18,7 @@ import (
 )
 
 func DataSourceIbmSccReportResources() *schema.Resource {
-	return &schema.Resource{
+	return AddSchemaData(&schema.Resource{
 		ReadContext: dataSourceIbmSccReportResourcesRead,
 
 		Schema: map[string]*schema.Schema{
@@ -165,7 +165,7 @@ func DataSourceIbmSccReportResources() *schema.Resource {
 				},
 			},
 		},
-	}
+	})
 }
 
 func dataSourceIbmSccReportResourcesRead(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {

--- a/ibm/service/scc/data_source_ibm_scc_report_resources_test.go
+++ b/ibm/service/scc/data_source_ibm_scc_report_resources_test.go
@@ -5,7 +5,6 @@ package scc_test
 
 import (
 	"fmt"
-	"os"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
@@ -14,21 +13,12 @@ import (
 )
 
 func TestAccIbmSccReportResourcesDataSourceBasic(t *testing.T) {
-	instanceID, ok := os.LookupEnv("IBMCLOUD_SCC_INSTANCE_ID")
-	if !ok {
-		t.Logf("Missing the env var IBMCLOUD_SCC_INSTANCE_ID.")
-	}
-
-	reportID, ok := os.LookupEnv("IBMCLOUD_SCC_REPORT_ID")
-	if !ok {
-		t.Logf("Missing the env var IBMCLOUD_SCC_REPORT_ID.")
-	}
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { acc.TestAccPreCheckSccInstanceID(t) },
+		PreCheck:  func() { acc.TestAccPreCheckScc(t) },
 		Providers: acc.TestAccProviders,
 		Steps: []resource.TestStep{
 			resource.TestStep{
-				Config: testAccCheckIbmSccReportResourcesDataSourceConfigBasic(instanceID, reportID),
+				Config: testAccCheckIbmSccReportResourcesDataSourceConfigBasic(acc.SccInstanceID, acc.SccReportID),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrSet("data.ibm_scc_report_resources.scc_report_resources_instance", "id"),
 					resource.TestCheckResourceAttrSet("data.ibm_scc_report_resources.scc_report_resources_instance", "report_id"),

--- a/ibm/service/scc/data_source_ibm_scc_report_resources_test.go
+++ b/ibm/service/scc/data_source_ibm_scc_report_resources_test.go
@@ -14,12 +14,21 @@ import (
 )
 
 func TestAccIbmSccReportResourcesDataSourceBasic(t *testing.T) {
+	instanceID, ok := os.LookupEnv("IBMCLOUD_SCC_INSTANCE_ID")
+	if !ok {
+		t.Logf("Missing the env var IBMCLOUD_SCC_INSTANCE_ID.")
+	}
+
+	reportID, ok := os.LookupEnv("IBMCLOUD_SCC_REPORT_ID")
+	if !ok {
+		t.Logf("Missing the env var IBMCLOUD_SCC_REPORT_ID.")
+	}
 	resource.Test(t, resource.TestCase{
 		PreCheck:  func() { acc.TestAccPreCheck(t) },
 		Providers: acc.TestAccProviders,
 		Steps: []resource.TestStep{
 			resource.TestStep{
-				Config: testAccCheckIbmSccReportResourcesDataSourceConfigBasic(),
+				Config: testAccCheckIbmSccReportResourcesDataSourceConfigBasic(instanceID, reportID),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrSet("data.ibm_scc_report_resources.scc_report_resources_instance", "id"),
 					resource.TestCheckResourceAttrSet("data.ibm_scc_report_resources.scc_report_resources_instance", "report_id"),
@@ -30,11 +39,11 @@ func TestAccIbmSccReportResourcesDataSourceBasic(t *testing.T) {
 	})
 }
 
-func testAccCheckIbmSccReportResourcesDataSourceConfigBasic() string {
-	report_id := os.Getenv("IBMCLOUD_SCC_REPORT_ID")
+func testAccCheckIbmSccReportResourcesDataSourceConfigBasic(instanceID, reportID string) string {
 	return fmt.Sprintf(`
 		data "ibm_scc_report_resources" "scc_report_resources_instance" {
+			instance_id = "%s"
 			report_id = "%s"
 		}
-	`, report_id)
+	`, instanceID, reportID)
 }

--- a/ibm/service/scc/data_source_ibm_scc_report_resources_test.go
+++ b/ibm/service/scc/data_source_ibm_scc_report_resources_test.go
@@ -24,7 +24,7 @@ func TestAccIbmSccReportResourcesDataSourceBasic(t *testing.T) {
 		t.Logf("Missing the env var IBMCLOUD_SCC_REPORT_ID.")
 	}
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { acc.TestAccPreCheck(t) },
+		PreCheck:  func() { acc.TestAccPreCheckSccInstanceID(t) },
 		Providers: acc.TestAccProviders,
 		Steps: []resource.TestStep{
 			resource.TestStep{

--- a/ibm/service/scc/data_source_ibm_scc_report_rule.go
+++ b/ibm/service/scc/data_source_ibm_scc_report_rule.go
@@ -97,6 +97,7 @@ func dataSourceIbmSccReportRuleRead(context context.Context, d *schema.ResourceD
 
 	getReportRuleOptions.SetReportID(d.Get("report_id").(string))
 	getReportRuleOptions.SetRuleID(d.Get("rule_id").(string))
+	getReportRuleOptions.SetInstanceID(d.Get("instance_id").(string))
 
 	ruleInfo, response, err := resultsClient.GetReportRuleWithContext(context, getReportRuleOptions)
 	if err != nil {

--- a/ibm/service/scc/data_source_ibm_scc_report_rule.go
+++ b/ibm/service/scc/data_source_ibm_scc_report_rule.go
@@ -16,7 +16,7 @@ import (
 )
 
 func DataSourceIbmSccReportRule() *schema.Resource {
-	return &schema.Resource{
+	return AddSchemaData(&schema.Resource{
 		ReadContext: dataSourceIbmSccReportRuleRead,
 
 		Schema: map[string]*schema.Schema{
@@ -84,7 +84,7 @@ func DataSourceIbmSccReportRule() *schema.Resource {
 				},
 			},
 		},
-	}
+	})
 }
 
 func dataSourceIbmSccReportRuleRead(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {

--- a/ibm/service/scc/data_source_ibm_scc_report_rule_test.go
+++ b/ibm/service/scc/data_source_ibm_scc_report_rule_test.go
@@ -5,7 +5,6 @@ package scc_test
 
 import (
 	"fmt"
-	"os"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
@@ -14,22 +13,13 @@ import (
 )
 
 func TestAccIbmSccReportRuleDataSourceBasic(t *testing.T) {
-	instanceID, ok := os.LookupEnv("IBMCLOUD_SCC_INSTANCE_ID")
-	if !ok {
-		t.Logf("Missing the env var IBMCLOUD_SCC_INSTANCE_ID.")
-	}
-
-	reportID, ok := os.LookupEnv("IBMCLOUD_SCC_REPORT_ID")
-	if !ok {
-		t.Logf("Missing the env var IBMCLOUD_SCC_REPORT_ID.")
-	}
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { acc.TestAccPreCheckSccInstanceID(t) },
+		PreCheck:  func() { acc.TestAccPreCheckScc(t) },
 		Providers: acc.TestAccProviders,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckIbmSccReportRuleDataSourceConfigBasic(instanceID, reportID),
+				Config: testAccCheckIbmSccReportRuleDataSourceConfigBasic(acc.SccInstanceID, acc.SccReportID),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrSet("data.ibm_scc_report_rule.scc_report_rule_instance", "id"),
 					resource.TestCheckResourceAttrSet("data.ibm_scc_report_rule.scc_report_rule_instance", "report_id"),

--- a/ibm/service/scc/data_source_ibm_scc_report_rule_test.go
+++ b/ibm/service/scc/data_source_ibm_scc_report_rule_test.go
@@ -25,10 +25,10 @@ func TestAccIbmSccReportRuleDataSourceBasic(t *testing.T) {
 	}
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { acc.TestAccPreCheck(t) },
+		PreCheck:  func() { acc.TestAccPreCheckSccInstanceID(t) },
 		Providers: acc.TestAccProviders,
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: testAccCheckIbmSccReportRuleDataSourceConfigBasic(instanceID, reportID),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrSet("data.ibm_scc_report_rule.scc_report_rule_instance", "id"),

--- a/ibm/service/scc/data_source_ibm_scc_report_rule_test.go
+++ b/ibm/service/scc/data_source_ibm_scc_report_rule_test.go
@@ -14,12 +14,22 @@ import (
 )
 
 func TestAccIbmSccReportRuleDataSourceBasic(t *testing.T) {
+	instanceID, ok := os.LookupEnv("IBMCLOUD_SCC_INSTANCE_ID")
+	if !ok {
+		t.Logf("Missing the env var IBMCLOUD_SCC_INSTANCE_ID.")
+	}
+
+	reportID, ok := os.LookupEnv("IBMCLOUD_SCC_REPORT_ID")
+	if !ok {
+		t.Logf("Missing the env var IBMCLOUD_SCC_REPORT_ID.")
+	}
+
 	resource.Test(t, resource.TestCase{
 		PreCheck:  func() { acc.TestAccPreCheck(t) },
 		Providers: acc.TestAccProviders,
 		Steps: []resource.TestStep{
 			resource.TestStep{
-				Config: testAccCheckIbmSccReportRuleDataSourceConfigBasic(),
+				Config: testAccCheckIbmSccReportRuleDataSourceConfigBasic(instanceID, reportID),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrSet("data.ibm_scc_report_rule.scc_report_rule_instance", "id"),
 					resource.TestCheckResourceAttrSet("data.ibm_scc_report_rule.scc_report_rule_instance", "report_id"),
@@ -30,12 +40,12 @@ func TestAccIbmSccReportRuleDataSourceBasic(t *testing.T) {
 	})
 }
 
-func testAccCheckIbmSccReportRuleDataSourceConfigBasic() string {
-	report_id := os.Getenv("IBMCLOUD_SCC_REPORT_ID")
+func testAccCheckIbmSccReportRuleDataSourceConfigBasic(instanceID, reportID string) string {
 	return fmt.Sprintf(`
 		data "ibm_scc_report_rule" "scc_report_rule_instance" {
+			instance_id = "%s"
 			report_id = "%s"
 			rule_id = "rule-f8722625-1968-4d7a-93cb-4b0f8da726da"
 		}
-	`, report_id)
+	`, instanceID, reportID)
 }

--- a/ibm/service/scc/data_source_ibm_scc_report_summary.go
+++ b/ibm/service/scc/data_source_ibm_scc_report_summary.go
@@ -302,6 +302,7 @@ func dataSourceIbmSccReportSummaryRead(context context.Context, d *schema.Resour
 	getReportSummaryOptions := &securityandcompliancecenterapiv3.GetReportSummaryOptions{}
 
 	getReportSummaryOptions.SetReportID(d.Get("report_id").(string))
+	getReportSummaryOptions.SetInstanceID(d.Get("instance_id").(string))
 
 	reportSummary, response, err := resultsClient.GetReportSummaryWithContext(context, getReportSummaryOptions)
 	if err != nil {

--- a/ibm/service/scc/data_source_ibm_scc_report_summary.go
+++ b/ibm/service/scc/data_source_ibm_scc_report_summary.go
@@ -18,7 +18,7 @@ import (
 )
 
 func DataSourceIbmSccReportSummary() *schema.Resource {
-	return &schema.Resource{
+	return AddSchemaData(&schema.Resource{
 		ReadContext: dataSourceIbmSccReportSummaryRead,
 
 		Schema: map[string]*schema.Schema{
@@ -290,7 +290,7 @@ func DataSourceIbmSccReportSummary() *schema.Resource {
 				},
 			},
 		},
-	}
+	})
 }
 
 func dataSourceIbmSccReportSummaryRead(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {

--- a/ibm/service/scc/data_source_ibm_scc_report_summary_test.go
+++ b/ibm/service/scc/data_source_ibm_scc_report_summary_test.go
@@ -24,7 +24,7 @@ func TestAccIbmSccReportSummaryDataSourceBasic(t *testing.T) {
 		t.Logf("Missing the env var IBMCLOUD_SCC_REPORT_ID.")
 	}
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { acc.TestAccPreCheck(t) },
+		PreCheck:  func() { acc.TestAccPreCheckSccInstanceID(t) },
 		Providers: acc.TestAccProviders,
 		Steps: []resource.TestStep{
 			resource.TestStep{

--- a/ibm/service/scc/data_source_ibm_scc_report_summary_test.go
+++ b/ibm/service/scc/data_source_ibm_scc_report_summary_test.go
@@ -14,12 +14,21 @@ import (
 )
 
 func TestAccIbmSccReportSummaryDataSourceBasic(t *testing.T) {
+	instanceID, ok := os.LookupEnv("IBMCLOUD_SCC_INSTANCE_ID")
+	if !ok {
+		t.Logf("Missing the env var IBMCLOUD_SCC_INSTANCE_ID.")
+	}
+
+	reportID, ok := os.LookupEnv("IBMCLOUD_SCC_REPORT_ID")
+	if !ok {
+		t.Logf("Missing the env var IBMCLOUD_SCC_REPORT_ID.")
+	}
 	resource.Test(t, resource.TestCase{
 		PreCheck:  func() { acc.TestAccPreCheck(t) },
 		Providers: acc.TestAccProviders,
 		Steps: []resource.TestStep{
 			resource.TestStep{
-				Config: testAccCheckIbmSccReportSummaryDataSourceConfigBasic(),
+				Config: testAccCheckIbmSccReportSummaryDataSourceConfigBasic(instanceID, reportID),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrSet("data.ibm_scc_report_summary.scc_report_summary_instance", "id"),
 					resource.TestCheckResourceAttrSet("data.ibm_scc_report_summary.scc_report_summary_instance", "report_id"),
@@ -29,11 +38,11 @@ func TestAccIbmSccReportSummaryDataSourceBasic(t *testing.T) {
 	})
 }
 
-func testAccCheckIbmSccReportSummaryDataSourceConfigBasic() string {
-	report_id := os.Getenv("IBMCLOUD_SCC_REPORT_ID")
+func testAccCheckIbmSccReportSummaryDataSourceConfigBasic(instanceID, reportID string) string {
 	return fmt.Sprintf(`
 		data "ibm_scc_report_summary" "scc_report_summary_instance" {
+			instance_id = "%s"
 			report_id = "%s"
 		}
-	`, report_id)
+	`, instanceID, reportID)
 }

--- a/ibm/service/scc/data_source_ibm_scc_report_summary_test.go
+++ b/ibm/service/scc/data_source_ibm_scc_report_summary_test.go
@@ -5,7 +5,6 @@ package scc_test
 
 import (
 	"fmt"
-	"os"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
@@ -14,21 +13,12 @@ import (
 )
 
 func TestAccIbmSccReportSummaryDataSourceBasic(t *testing.T) {
-	instanceID, ok := os.LookupEnv("IBMCLOUD_SCC_INSTANCE_ID")
-	if !ok {
-		t.Logf("Missing the env var IBMCLOUD_SCC_INSTANCE_ID.")
-	}
-
-	reportID, ok := os.LookupEnv("IBMCLOUD_SCC_REPORT_ID")
-	if !ok {
-		t.Logf("Missing the env var IBMCLOUD_SCC_REPORT_ID.")
-	}
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { acc.TestAccPreCheckSccInstanceID(t) },
+		PreCheck:  func() { acc.TestAccPreCheckScc(t) },
 		Providers: acc.TestAccProviders,
 		Steps: []resource.TestStep{
 			resource.TestStep{
-				Config: testAccCheckIbmSccReportSummaryDataSourceConfigBasic(instanceID, reportID),
+				Config: testAccCheckIbmSccReportSummaryDataSourceConfigBasic(acc.SccInstanceID, acc.SccReportID),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrSet("data.ibm_scc_report_summary.scc_report_summary_instance", "id"),
 					resource.TestCheckResourceAttrSet("data.ibm_scc_report_summary.scc_report_summary_instance", "report_id"),

--- a/ibm/service/scc/data_source_ibm_scc_report_tags.go
+++ b/ibm/service/scc/data_source_ibm_scc_report_tags.go
@@ -17,7 +17,7 @@ import (
 )
 
 func DataSourceIbmSccReportTags() *schema.Resource {
-	return &schema.Resource{
+	return AddSchemaData(&schema.Resource{
 		ReadContext: dataSourceIbmSccReportTagsRead,
 
 		Schema: map[string]*schema.Schema{
@@ -60,7 +60,7 @@ func DataSourceIbmSccReportTags() *schema.Resource {
 				},
 			},
 		},
-	}
+	})
 }
 
 func dataSourceIbmSccReportTagsRead(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {

--- a/ibm/service/scc/data_source_ibm_scc_report_tags.go
+++ b/ibm/service/scc/data_source_ibm_scc_report_tags.go
@@ -72,6 +72,7 @@ func dataSourceIbmSccReportTagsRead(context context.Context, d *schema.ResourceD
 	getReportTagsOptions := &securityandcompliancecenterapiv3.GetReportTagsOptions{}
 
 	getReportTagsOptions.SetReportID(d.Get("report_id").(string))
+	getReportTagsOptions.SetInstanceID(d.Get("instance_id").(string))
 
 	reportTags, response, err := resultsClient.GetReportTagsWithContext(context, getReportTagsOptions)
 	if err != nil {

--- a/ibm/service/scc/data_source_ibm_scc_report_tags_test.go
+++ b/ibm/service/scc/data_source_ibm_scc_report_tags_test.go
@@ -14,12 +14,21 @@ import (
 )
 
 func TestAccIbmSccReportTagsDataSourceBasic(t *testing.T) {
+	instanceID, ok := os.LookupEnv("IBMCLOUD_SCC_INSTANCE_ID")
+	if !ok {
+		t.Logf("Missing the env var IBMCLOUD_SCC_INSTANCE_ID.")
+	}
+
+	reportID, ok := os.LookupEnv("IBMCLOUD_SCC_REPORT_ID")
+	if !ok {
+		t.Logf("Missing the env var IBMCLOUD_SCC_REPORT_ID.")
+	}
 	resource.Test(t, resource.TestCase{
 		PreCheck:  func() { acc.TestAccPreCheck(t) },
 		Providers: acc.TestAccProviders,
 		Steps: []resource.TestStep{
 			resource.TestStep{
-				Config: testAccCheckIbmSccReportTagsDataSourceConfigBasic(),
+				Config: testAccCheckIbmSccReportTagsDataSourceConfigBasic(instanceID, reportID),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrSet("data.ibm_scc_report_tags.scc_report_tags_instance", "id"),
 					resource.TestCheckResourceAttrSet("data.ibm_scc_report_tags.scc_report_tags_instance", "report_id"),
@@ -29,11 +38,11 @@ func TestAccIbmSccReportTagsDataSourceBasic(t *testing.T) {
 	})
 }
 
-func testAccCheckIbmSccReportTagsDataSourceConfigBasic() string {
-	report_id := os.Getenv("IBMCLOUD_SCC_REPORT_ID")
+func testAccCheckIbmSccReportTagsDataSourceConfigBasic(instanceID, reportID string) string {
 	return fmt.Sprintf(`
 		data "ibm_scc_report_tags" "scc_report_tags_instance" {
+			instance_id = "%s"
 			report_id = "%s"
 		}
-	`, report_id)
+	`, instanceID, reportID)
 }

--- a/ibm/service/scc/data_source_ibm_scc_report_tags_test.go
+++ b/ibm/service/scc/data_source_ibm_scc_report_tags_test.go
@@ -5,7 +5,6 @@ package scc_test
 
 import (
 	"fmt"
-	"os"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
@@ -14,21 +13,12 @@ import (
 )
 
 func TestAccIbmSccReportTagsDataSourceBasic(t *testing.T) {
-	instanceID, ok := os.LookupEnv("IBMCLOUD_SCC_INSTANCE_ID")
-	if !ok {
-		t.Logf("Missing the env var IBMCLOUD_SCC_INSTANCE_ID.")
-	}
-
-	reportID, ok := os.LookupEnv("IBMCLOUD_SCC_REPORT_ID")
-	if !ok {
-		t.Logf("Missing the env var IBMCLOUD_SCC_REPORT_ID.")
-	}
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { acc.TestAccPreCheck(t) },
+		PreCheck:  func() { acc.TestAccPreCheckScc(t) },
 		Providers: acc.TestAccProviders,
 		Steps: []resource.TestStep{
-			resource.TestStep{
-				Config: testAccCheckIbmSccReportTagsDataSourceConfigBasic(instanceID, reportID),
+			{
+				Config: testAccCheckIbmSccReportTagsDataSourceConfigBasic(acc.SccInstanceID, acc.SccReportID),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrSet("data.ibm_scc_report_tags.scc_report_tags_instance", "id"),
 					resource.TestCheckResourceAttrSet("data.ibm_scc_report_tags.scc_report_tags_instance", "report_id"),

--- a/ibm/service/scc/data_source_ibm_scc_report_test.go
+++ b/ibm/service/scc/data_source_ibm_scc_report_test.go
@@ -24,7 +24,7 @@ func TestAccIbmSccReportDataSourceBasic(t *testing.T) {
 		t.Logf("Missing the env var IBMCLOUD_SCC_REPORT_ID.")
 	}
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { acc.TestAccPreCheck(t) },
+		PreCheck:  func() { acc.TestAccPreCheckSccInstanceID(t) },
 		Providers: acc.TestAccProviders,
 		Steps: []resource.TestStep{
 			{

--- a/ibm/service/scc/data_source_ibm_scc_report_test.go
+++ b/ibm/service/scc/data_source_ibm_scc_report_test.go
@@ -14,12 +14,21 @@ import (
 )
 
 func TestAccIbmSccReportDataSourceBasic(t *testing.T) {
+	instanceID, ok := os.LookupEnv("IBMCLOUD_SCC_INSTANCE_ID")
+	if !ok {
+		t.Logf("Missing the env var IBMCLOUD_SCC_INSTANCE_ID.")
+	}
+
+	reportID, ok := os.LookupEnv("IBMCLOUD_SCC_REPORT_ID")
+	if !ok {
+		t.Logf("Missing the env var IBMCLOUD_SCC_REPORT_ID.")
+	}
 	resource.Test(t, resource.TestCase{
 		PreCheck:  func() { acc.TestAccPreCheck(t) },
 		Providers: acc.TestAccProviders,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckIbmSccReportDataSourceConfigBasic(),
+				Config: testAccCheckIbmSccReportDataSourceConfigBasic(instanceID, reportID),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrSet("data.ibm_scc_report.scc_report_instance", "id"),
 					resource.TestCheckResourceAttrSet("data.ibm_scc_report.scc_report_instance", "report_id"),
@@ -29,11 +38,11 @@ func TestAccIbmSccReportDataSourceBasic(t *testing.T) {
 	})
 }
 
-func testAccCheckIbmSccReportDataSourceConfigBasic() string {
-	report_id := os.Getenv("IBMCLOUD_SCC_REPORT_ID")
+func testAccCheckIbmSccReportDataSourceConfigBasic(instanceID, reportID string) string {
 	return fmt.Sprintf(`
 		data "ibm_scc_report" "scc_report_instance" {
+			instance_id = "%s"
 			report_id = "%s"
 		}
-	`, report_id)
+	`, instanceID, reportID)
 }

--- a/ibm/service/scc/data_source_ibm_scc_report_test.go
+++ b/ibm/service/scc/data_source_ibm_scc_report_test.go
@@ -5,7 +5,6 @@ package scc_test
 
 import (
 	"fmt"
-	"os"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
@@ -14,21 +13,12 @@ import (
 )
 
 func TestAccIbmSccReportDataSourceBasic(t *testing.T) {
-	instanceID, ok := os.LookupEnv("IBMCLOUD_SCC_INSTANCE_ID")
-	if !ok {
-		t.Logf("Missing the env var IBMCLOUD_SCC_INSTANCE_ID.")
-	}
-
-	reportID, ok := os.LookupEnv("IBMCLOUD_SCC_REPORT_ID")
-	if !ok {
-		t.Logf("Missing the env var IBMCLOUD_SCC_REPORT_ID.")
-	}
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { acc.TestAccPreCheckSccInstanceID(t) },
+		PreCheck:  func() { acc.TestAccPreCheckScc(t) },
 		Providers: acc.TestAccProviders,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckIbmSccReportDataSourceConfigBasic(instanceID, reportID),
+				Config: testAccCheckIbmSccReportDataSourceConfigBasic(acc.SccInstanceID, acc.SccReportID),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrSet("data.ibm_scc_report.scc_report_instance", "id"),
 					resource.TestCheckResourceAttrSet("data.ibm_scc_report.scc_report_instance", "report_id"),

--- a/ibm/service/scc/data_source_ibm_scc_report_violation_drift.go
+++ b/ibm/service/scc/data_source_ibm_scc_report_violation_drift.go
@@ -114,6 +114,7 @@ func dataSourceIbmSccReportViolationDriftRead(context context.Context, d *schema
 	getReportViolationsDriftOptions := &securityandcompliancecenterapiv3.GetReportViolationsDriftOptions{}
 
 	getReportViolationsDriftOptions.SetReportID(d.Get("report_id").(string))
+	getReportViolationsDriftOptions.SetInstanceID(d.Get("instance_id").(string))
 	if _, ok := d.GetOk("scan_time_duration"); ok {
 		getReportViolationsDriftOptions.SetScanTimeDuration(int64(d.Get("scan_time_duration").(int)))
 	}

--- a/ibm/service/scc/data_source_ibm_scc_report_violation_drift.go
+++ b/ibm/service/scc/data_source_ibm_scc_report_violation_drift.go
@@ -18,7 +18,7 @@ import (
 )
 
 func DataSourceIbmSccReportViolationDrift() *schema.Resource {
-	return &schema.Resource{
+	return AddSchemaData(&schema.Resource{
 		ReadContext: dataSourceIbmSccReportViolationDriftRead,
 
 		Schema: map[string]*schema.Schema{
@@ -102,7 +102,7 @@ func DataSourceIbmSccReportViolationDrift() *schema.Resource {
 				},
 			},
 		},
-	}
+	})
 }
 
 func dataSourceIbmSccReportViolationDriftRead(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {

--- a/ibm/service/scc/data_source_ibm_scc_report_violation_drift_test.go
+++ b/ibm/service/scc/data_source_ibm_scc_report_violation_drift_test.go
@@ -14,12 +14,21 @@ import (
 )
 
 func TestAccIbmSccReportViolationDriftDataSourceBasic(t *testing.T) {
+	instanceID, ok := os.LookupEnv("IBMCLOUD_SCC_INSTANCE_ID")
+	if !ok {
+		t.Logf("Missing the env var IBMCLOUD_SCC_INSTANCE_ID.")
+	}
+
+	reportID, ok := os.LookupEnv("IBMCLOUD_SCC_REPORT_ID")
+	if !ok {
+		t.Logf("Missing the env var IBMCLOUD_SCC_REPORT_ID.")
+	}
 	resource.Test(t, resource.TestCase{
 		PreCheck:  func() { acc.TestAccPreCheck(t) },
 		Providers: acc.TestAccProviders,
 		Steps: []resource.TestStep{
 			resource.TestStep{
-				Config: testAccCheckIbmSccReportViolationDriftDataSourceConfigBasic(),
+				Config: testAccCheckIbmSccReportViolationDriftDataSourceConfigBasic(instanceID, reportID),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrSet("data.ibm_scc_report_violation_drift.scc_report_violation_drift_instance", "id"),
 					resource.TestCheckResourceAttrSet("data.ibm_scc_report_violation_drift.scc_report_violation_drift_instance", "report_id"),
@@ -29,11 +38,11 @@ func TestAccIbmSccReportViolationDriftDataSourceBasic(t *testing.T) {
 	})
 }
 
-func testAccCheckIbmSccReportViolationDriftDataSourceConfigBasic() string {
-	report_id := os.Getenv("IBMCLOUD_SCC_REPORT_ID")
+func testAccCheckIbmSccReportViolationDriftDataSourceConfigBasic(instanceID, reportID string) string {
 	return fmt.Sprintf(`
 		data "ibm_scc_report_violation_drift" "scc_report_violation_drift_instance" {
+			instance_id = "%s"
 			report_id = "%s"
 		}
-	`, report_id)
+	`, instanceID, reportID)
 }

--- a/ibm/service/scc/data_source_ibm_scc_report_violation_drift_test.go
+++ b/ibm/service/scc/data_source_ibm_scc_report_violation_drift_test.go
@@ -24,7 +24,7 @@ func TestAccIbmSccReportViolationDriftDataSourceBasic(t *testing.T) {
 		t.Logf("Missing the env var IBMCLOUD_SCC_REPORT_ID.")
 	}
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { acc.TestAccPreCheck(t) },
+		PreCheck:  func() { acc.TestAccPreCheckSccInstanceID(t) },
 		Providers: acc.TestAccProviders,
 		Steps: []resource.TestStep{
 			resource.TestStep{

--- a/ibm/service/scc/data_source_ibm_scc_report_violation_drift_test.go
+++ b/ibm/service/scc/data_source_ibm_scc_report_violation_drift_test.go
@@ -5,7 +5,6 @@ package scc_test
 
 import (
 	"fmt"
-	"os"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
@@ -14,21 +13,12 @@ import (
 )
 
 func TestAccIbmSccReportViolationDriftDataSourceBasic(t *testing.T) {
-	instanceID, ok := os.LookupEnv("IBMCLOUD_SCC_INSTANCE_ID")
-	if !ok {
-		t.Logf("Missing the env var IBMCLOUD_SCC_INSTANCE_ID.")
-	}
-
-	reportID, ok := os.LookupEnv("IBMCLOUD_SCC_REPORT_ID")
-	if !ok {
-		t.Logf("Missing the env var IBMCLOUD_SCC_REPORT_ID.")
-	}
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { acc.TestAccPreCheckSccInstanceID(t) },
+		PreCheck:  func() { acc.TestAccPreCheckScc(t) },
 		Providers: acc.TestAccProviders,
 		Steps: []resource.TestStep{
 			resource.TestStep{
-				Config: testAccCheckIbmSccReportViolationDriftDataSourceConfigBasic(instanceID, reportID),
+				Config: testAccCheckIbmSccReportViolationDriftDataSourceConfigBasic(acc.SccInstanceID, acc.SccReportID),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrSet("data.ibm_scc_report_violation_drift.scc_report_violation_drift_instance", "id"),
 					resource.TestCheckResourceAttrSet("data.ibm_scc_report_violation_drift.scc_report_violation_drift_instance", "report_id"),

--- a/ibm/service/scc/data_source_ibm_scc_rule.go
+++ b/ibm/service/scc/data_source_ibm_scc_rule.go
@@ -18,7 +18,7 @@ import (
 )
 
 func DataSourceIbmSccRule() *schema.Resource {
-	return &schema.Resource{
+	return AddSchemaData(&schema.Resource{
 		ReadContext: dataSourceIbmSccRuleRead,
 		Timeouts: &schema.ResourceTimeout{
 			Read: schema.DefaultTimeout(40 * time.Minute),
@@ -373,7 +373,7 @@ func DataSourceIbmSccRule() *schema.Resource {
 				},
 			},
 		},
-	}
+	})
 }
 
 func dataSourceIbmSccRuleRead(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
@@ -385,6 +385,7 @@ func dataSourceIbmSccRuleRead(context context.Context, d *schema.ResourceData, m
 	getRuleOptions := &securityandcompliancecenterapiv3.GetRuleOptions{}
 
 	getRuleOptions.SetRuleID(d.Get("rule_id").(string))
+	getRuleOptions.SetInstanceID(d.Get("instance_id").(string))
 
 	rule, response, err := configManagerClient.GetRuleWithContext(context, getRuleOptions)
 	if err != nil {

--- a/ibm/service/scc/data_source_ibm_scc_rule_test.go
+++ b/ibm/service/scc/data_source_ibm_scc_rule_test.go
@@ -5,7 +5,6 @@ package scc_test
 
 import (
 	"fmt"
-	"os"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
@@ -16,17 +15,13 @@ import (
 
 func TestAccIbmSccRuleDataSourceBasic(t *testing.T) {
 	ruleDescription := fmt.Sprintf("tf_description_%d", acctest.RandIntRange(10, 100))
-	instanceID, ok := os.LookupEnv("IBMCLOUD_SCC_INSTANCE_ID")
-	if !ok {
-		t.Logf("Missing the env var IBMCLOUD_SCC_INSTANCE_ID.")
-	}
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { acc.TestAccPreCheckSccInstanceID(t) },
+		PreCheck:  func() { acc.TestAccPreCheckScc(t) },
 		Providers: acc.TestAccProviders,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckIbmSccRuleDataSourceConfigBasic(instanceID, ruleDescription),
+				Config: testAccCheckIbmSccRuleDataSourceConfigBasic(acc.SccInstanceID, ruleDescription),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrSet("data.ibm_scc_rule.scc_rule_instance", "id"),
 					resource.TestCheckResourceAttrSet("data.ibm_scc_rule.scc_rule_instance", "rule_id"),
@@ -51,17 +46,13 @@ func TestAccIbmSccRuleDataSourceBasic(t *testing.T) {
 func TestAccIbmSccRuleDataSourceAllArgs(t *testing.T) {
 	ruleDescription := fmt.Sprintf("tf_description_%d", acctest.RandIntRange(10, 100))
 	ruleVersion := "0.0.1"
-	instanceID, ok := os.LookupEnv("IBMCLOUD_SCC_INSTANCE_ID")
-	if !ok {
-		t.Logf("Missing the env var IBMCLOUD_SCC_INSTANCE_ID.")
-	}
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { acc.TestAccPreCheckSccInstanceID(t) },
+		PreCheck:  func() { acc.TestAccPreCheckScc(t) },
 		Providers: acc.TestAccProviders,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckIbmSccRuleDataSourceConfig(instanceID, ruleDescription, ruleVersion),
+				Config: testAccCheckIbmSccRuleDataSourceConfig(acc.SccInstanceID, ruleDescription, ruleVersion),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrSet("data.ibm_scc_rule.scc_rule_instance", "id"),
 					resource.TestCheckResourceAttrSet("data.ibm_scc_rule.scc_rule_instance", "rule_id"),

--- a/ibm/service/scc/data_source_ibm_scc_rule_test.go
+++ b/ibm/service/scc/data_source_ibm_scc_rule_test.go
@@ -19,7 +19,6 @@ func TestAccIbmSccRuleDataSourceBasic(t *testing.T) {
 	instanceID, ok := os.LookupEnv("IBMCLOUD_SCC_INSTANCE_ID")
 	if !ok {
 		t.Logf("Missing the env var IBMCLOUD_SCC_INSTANCE_ID.")
-		t.FailNow()
 	}
 
 	resource.Test(t, resource.TestCase{
@@ -55,7 +54,6 @@ func TestAccIbmSccRuleDataSourceAllArgs(t *testing.T) {
 	instanceID, ok := os.LookupEnv("IBMCLOUD_SCC_INSTANCE_ID")
 	if !ok {
 		t.Logf("Missing the env var IBMCLOUD_SCC_INSTANCE_ID.")
-		t.FailNow()
 	}
 
 	resource.Test(t, resource.TestCase{

--- a/ibm/service/scc/data_source_ibm_scc_rule_test.go
+++ b/ibm/service/scc/data_source_ibm_scc_rule_test.go
@@ -5,6 +5,7 @@ package scc_test
 
 import (
 	"fmt"
+	"os"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
@@ -15,13 +16,18 @@ import (
 
 func TestAccIbmSccRuleDataSourceBasic(t *testing.T) {
 	ruleDescription := fmt.Sprintf("tf_description_%d", acctest.RandIntRange(10, 100))
+	instanceID, ok := os.LookupEnv("IBMCLOUD_SCC_INSTANCE_ID")
+	if !ok {
+		t.Logf("Missing the env var IBMCLOUD_SCC_INSTANCE_ID.")
+		t.FailNow()
+	}
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:  func() { acc.TestAccPreCheck(t) },
 		Providers: acc.TestAccProviders,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckIbmSccRuleDataSourceConfigBasic(ruleDescription),
+				Config: testAccCheckIbmSccRuleDataSourceConfigBasic(instanceID, ruleDescription),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrSet("data.ibm_scc_rule.scc_rule_instance", "id"),
 					resource.TestCheckResourceAttrSet("data.ibm_scc_rule.scc_rule_instance", "rule_id"),
@@ -46,13 +52,18 @@ func TestAccIbmSccRuleDataSourceBasic(t *testing.T) {
 func TestAccIbmSccRuleDataSourceAllArgs(t *testing.T) {
 	ruleDescription := fmt.Sprintf("tf_description_%d", acctest.RandIntRange(10, 100))
 	ruleVersion := "0.0.1"
+	instanceID, ok := os.LookupEnv("IBMCLOUD_SCC_INSTANCE_ID")
+	if !ok {
+		t.Logf("Missing the env var IBMCLOUD_SCC_INSTANCE_ID.")
+		t.FailNow()
+	}
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:  func() { acc.TestAccPreCheck(t) },
 		Providers: acc.TestAccProviders,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckIbmSccRuleDataSourceConfig(ruleDescription, ruleVersion),
+				Config: testAccCheckIbmSccRuleDataSourceConfig(instanceID, ruleDescription, ruleVersion),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrSet("data.ibm_scc_rule.scc_rule_instance", "id"),
 					resource.TestCheckResourceAttrSet("data.ibm_scc_rule.scc_rule_instance", "rule_id"),
@@ -75,9 +86,10 @@ func TestAccIbmSccRuleDataSourceAllArgs(t *testing.T) {
 	})
 }
 
-func testAccCheckIbmSccRuleDataSourceConfigBasic(ruleDescription string) string {
+func testAccCheckIbmSccRuleDataSourceConfigBasic(instanceID string, ruleDescription string) string {
 	return fmt.Sprintf(`
 		resource "ibm_scc_rule" "scc_rule_instance" {
+			instance_id = "%s"
 			description = "%s"
 			target {
 				service_name = "cloud-object-storage"
@@ -97,14 +109,16 @@ func testAccCheckIbmSccRuleDataSourceConfigBasic(ruleDescription string) string 
 		}
 
 		data "ibm_scc_rule" "scc_rule_instance" {
-			rule_id = ibm_scc_rule.scc_rule_instance.id
+			instance_id = resource.ibm_scc_rule.scc_rule_instance.instance_id
+			rule_id = resource.ibm_scc_rule.scc_rule_instance.rule_id
 		}
-	`, ruleDescription)
+	`, instanceID, ruleDescription)
 }
 
-func testAccCheckIbmSccRuleDataSourceConfig(ruleDescription string, ruleVersion string) string {
+func testAccCheckIbmSccRuleDataSourceConfig(instanceID string, ruleDescription string, ruleVersion string) string {
 	return fmt.Sprintf(`
 		resource "ibm_scc_rule" "scc_rule_instance" {
+			instance_id = "%s"
 			description = "%s"
 			target {
 				service_name = "cloud-object-storage"
@@ -124,7 +138,8 @@ func testAccCheckIbmSccRuleDataSourceConfig(ruleDescription string, ruleVersion 
 		}
 
 		data "ibm_scc_rule" "scc_rule_instance" {
-			rule_id = ibm_scc_rule.scc_rule_instance.id
+			instance_id = resource.ibm_scc_rule.scc_rule_instance.instance_id
+			rule_id = resource.ibm_scc_rule.scc_rule_instance.rule_id
 		}
-	`, ruleDescription, ruleVersion)
+	`, instanceID, ruleDescription, ruleVersion)
 }

--- a/ibm/service/scc/data_source_ibm_scc_rule_test.go
+++ b/ibm/service/scc/data_source_ibm_scc_rule_test.go
@@ -22,7 +22,7 @@ func TestAccIbmSccRuleDataSourceBasic(t *testing.T) {
 	}
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { acc.TestAccPreCheck(t) },
+		PreCheck:  func() { acc.TestAccPreCheckSccInstanceID(t) },
 		Providers: acc.TestAccProviders,
 		Steps: []resource.TestStep{
 			{
@@ -57,7 +57,7 @@ func TestAccIbmSccRuleDataSourceAllArgs(t *testing.T) {
 	}
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { acc.TestAccPreCheck(t) },
+		PreCheck:  func() { acc.TestAccPreCheckSccInstanceID(t) },
 		Providers: acc.TestAccProviders,
 		Steps: []resource.TestStep{
 			{

--- a/ibm/service/scc/ibm_scc_utilities.go
+++ b/ibm/service/scc/ibm_scc_utilities.go
@@ -20,13 +20,6 @@ func AddSchemaData(resource *schema.Resource) *schema.Resource {
 		ForceNew:    true,
 		Description: "The ID of the Security and Compliance Center instance.",
 	}
-	resource.Schema["region"] = &schema.Schema{
-		Type:        schema.TypeString,
-		Optional:    true,
-		Computed:    true,
-		ForceNew:    true,
-		Description: "The region code of the instance",
-	}
 	return resource
 }
 

--- a/ibm/service/scc/ibm_scc_utilities.go
+++ b/ibm/service/scc/ibm_scc_utilities.go
@@ -1,0 +1,40 @@
+// Copyright IBM Corp. 2023 All Rights Reserved.
+// Licensed under the Mozilla Public License v2.0
+
+package scc
+
+import (
+	"strings"
+
+	"github.com/IBM/scc-go-sdk/v5/securityandcompliancecenterapiv3"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+// AddSchemaData will add the data instance_id and region to the resource 
+func AddSchemaData(resource *schema.Resource) *schema.Resource {
+	resource.Schema["instance_id"] = &schema.Schema{
+		Type:        schema.TypeString,
+		Required:    true,
+		ForceNew:    true,
+		Description: "The ID of the Security and Compliance Center instance.",
+	}
+	resource.Schema["region"] = &schema.Schema{
+		Type:        schema.TypeString,
+		Optional:    true,
+		Computed:    true,
+		ForceNew:    true,
+		Description: "The region code of the instance",
+	}
+	return resource
+}
+
+// getRegionData will check if the field region is defined
+func getRegionData(client securityandcompliancecenterapiv3.SecurityAndComplianceCenterApiV3, d *schema.ResourceData) string {
+	_, ok := d.GetOk("region")
+	if ok {
+		return d.Get("region").(string)
+	} else {
+		url := client.Service.GetServiceURL()
+		return strings.Split(url, ".")[1]
+	}
+}

--- a/ibm/service/scc/ibm_scc_utilities.go
+++ b/ibm/service/scc/ibm_scc_utilities.go
@@ -10,7 +10,9 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
-// AddSchemaData will add the data instance_id and region to the resource 
+const INSTANCE_ID = "instance_id"
+
+// AddSchemaData will add the Schemas 'instance_id' and 'region' to the resource
 func AddSchemaData(resource *schema.Resource) *schema.Resource {
 	resource.Schema["instance_id"] = &schema.Schema{
 		Type:        schema.TypeString,
@@ -30,11 +32,19 @@ func AddSchemaData(resource *schema.Resource) *schema.Resource {
 
 // getRegionData will check if the field region is defined
 func getRegionData(client securityandcompliancecenterapiv3.SecurityAndComplianceCenterApiV3, d *schema.ResourceData) string {
-	_, ok := d.GetOk("region")
+	val, ok := d.GetOk("region")
 	if ok {
-		return d.Get("region").(string)
+		return val.(string)
 	} else {
 		url := client.Service.GetServiceURL()
 		return strings.Split(url, ".")[1]
 	}
+}
+
+// setRegionData will set the field "region" field if the field was previously defined
+func setRegionData(d *schema.ResourceData, region string) error {
+	if val, ok := d.GetOk("region"); ok {
+		return d.Set("region", val.(string))
+	}
+	return nil
 }

--- a/ibm/service/scc/resource_ibm_scc_control_library.go
+++ b/ibm/service/scc/resource_ibm_scc_control_library.go
@@ -500,8 +500,7 @@ func resourceIbmSccControlLibraryUpdate(context context.Context, d *schema.Resou
 	if err != nil {
 		return diag.FromErr(err)
 	}
-	// TODO: use replaceCustomControlLibraryOptions.SetInstanceID to set the InstanceID
-	replaceCustomControlLibraryOptions.InstanceID = &parts[0]
+	replaceCustomControlLibraryOptions.SetInstanceID(parts[0])
 	replaceCustomControlLibraryOptions.SetControlLibrariesID(parts[1])
 
 	hasChange := false

--- a/ibm/service/scc/resource_ibm_scc_control_library.go
+++ b/ibm/service/scc/resource_ibm_scc_control_library.go
@@ -19,7 +19,7 @@ import (
 )
 
 func ResourceIbmSccControlLibrary() *schema.Resource {
-	return &schema.Resource{
+	return AddSchemaData(&schema.Resource{
 		CreateContext: resourceIbmSccControlLibraryCreate,
 		ReadContext:   resourceIbmSccControlLibraryRead,
 		UpdateContext: resourceIbmSccControlLibraryUpdate,
@@ -27,6 +27,11 @@ func ResourceIbmSccControlLibrary() *schema.Resource {
 		Importer:      &schema.ResourceImporter{},
 
 		Schema: map[string]*schema.Schema{
+			"control_library_id": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The control library ID.",
+			},
 			"control_library_name": {
 				Type:         schema.TypeString,
 				Required:     true,
@@ -276,7 +281,7 @@ func ResourceIbmSccControlLibrary() *schema.Resource {
 				Description: "The number of parent controls in the control library.",
 			},
 		},
-	}
+	})
 }
 
 func ResourceIbmSccControlLibraryValidator() *validate.ResourceValidator {
@@ -340,6 +345,8 @@ func resourceIbmSccControlLibraryCreate(context context.Context, d *schema.Resou
 	bodyModelMap := map[string]interface{}{}
 	createCustomControlLibraryOptions := &securityandcompliancecenterapiv3.CreateCustomControlLibraryOptions{}
 
+	instance_id := d.Get("instance_id").(string)
+	bodyModelMap["instance_id"] = instance_id
 	bodyModelMap["control_library_name"] = d.Get("control_library_name")
 	bodyModelMap["control_library_description"] = d.Get("control_library_description")
 	bodyModelMap["control_library_type"] = d.Get("control_library_type")
@@ -369,7 +376,7 @@ func resourceIbmSccControlLibraryCreate(context context.Context, d *schema.Resou
 		return diag.FromErr(fmt.Errorf("CreateCustomControlLibraryWithContext failed %s\n%s", err, response))
 	}
 
-	d.SetId(*controlLibrary.ID)
+	d.SetId(instance_id + "/" + *controlLibrary.ID)
 
 	return resourceIbmSccControlLibraryRead(context, d, meta)
 }
@@ -381,8 +388,12 @@ func resourceIbmSccControlLibraryRead(context context.Context, d *schema.Resourc
 	}
 
 	getControlLibraryOptions := &securityandcompliancecenterapiv3.GetControlLibraryOptions{}
-
-	getControlLibraryOptions.SetControlLibrariesID(d.Id())
+	parts, err := flex.SepIdParts(d.Id(), "/")
+	if err != nil {
+		return diag.FromErr(err)
+	}
+	getControlLibraryOptions.SetInstanceID(parts[0])
+	getControlLibraryOptions.SetControlLibrariesID(parts[1])
 
 	controlLibrary, response, err := securityandcompliancecenterapiClient.GetControlLibraryWithContext(context, getControlLibraryOptions)
 	if err != nil {
@@ -393,7 +404,12 @@ func resourceIbmSccControlLibraryRead(context context.Context, d *schema.Resourc
 		log.Printf("[DEBUG] GetControlLibraryWithContext failed %s\n%s", err, response)
 		return diag.FromErr(fmt.Errorf("GetControlLibraryWithContext failed %s\n%s", err, response))
 	}
-
+	if err = d.Set("instance_id", parts[0]); err != nil {
+		return diag.FromErr(fmt.Errorf("Error setting instance_id: %s", err))
+	}
+	if err = d.Set("control_library_id", controlLibrary.ID); err != nil {
+		return diag.FromErr(fmt.Errorf("Error setting control_library_id: %s", err))
+	}
 	if err = d.Set("control_library_name", controlLibrary.ControlLibraryName); err != nil {
 		return diag.FromErr(fmt.Errorf("Error setting control_library_name: %s", err))
 	}
@@ -480,8 +496,13 @@ func resourceIbmSccControlLibraryUpdate(context context.Context, d *schema.Resou
 	}
 
 	replaceCustomControlLibraryOptions := &securityandcompliancecenterapiv3.ReplaceCustomControlLibraryOptions{}
-
-	replaceCustomControlLibraryOptions.SetControlLibrariesID(d.Id())
+	parts, err := flex.SepIdParts(d.Id(), "/")
+	if err != nil {
+		return diag.FromErr(err)
+	}
+	// TODO: use replaceCustomControlLibraryOptions.SetInstanceID to set the InstanceID
+	replaceCustomControlLibraryOptions.InstanceID = &parts[0]
+	replaceCustomControlLibraryOptions.SetControlLibrariesID(parts[1])
 
 	hasChange := false
 
@@ -546,7 +567,12 @@ func resourceIbmSccControlLibraryDelete(context context.Context, d *schema.Resou
 
 	deleteCustomControlLibraryOptions := &securityandcompliancecenterapiv3.DeleteCustomControlLibraryOptions{}
 
-	deleteCustomControlLibraryOptions.SetControlLibrariesID(d.Id())
+	parts, err := flex.SepIdParts(d.Id(), "/")
+	if err != nil {
+		return diag.FromErr(err)
+	}
+	deleteCustomControlLibraryOptions.SetInstanceID(parts[0])
+	deleteCustomControlLibraryOptions.SetControlLibrariesID(parts[1])
 
 	_, response, err := securityandcompliancecenterapiClient.DeleteCustomControlLibraryWithContext(context, deleteCustomControlLibraryOptions)
 	if err != nil {
@@ -776,6 +802,7 @@ func resourceIbmSccControlLibraryMapToControlLibrary(modelMap map[string]interfa
 
 func resourceIbmSccControlLibraryMapToControlLibraryPrototype(modelMap map[string]interface{}) (*securityandcompliancecenterapiv3.CreateCustomControlLibraryOptions, error) {
 	model := &securityandcompliancecenterapiv3.CreateCustomControlLibraryOptions{}
+	model.InstanceID = core.StringPtr(modelMap["instance_id"].(string))
 	model.ControlLibraryName = core.StringPtr(modelMap["control_library_name"].(string))
 	model.ControlLibraryDescription = core.StringPtr(modelMap["control_library_description"].(string))
 	model.ControlLibraryType = core.StringPtr(modelMap["control_library_type"].(string))

--- a/ibm/service/scc/resource_ibm_scc_control_library_test.go
+++ b/ibm/service/scc/resource_ibm_scc_control_library_test.go
@@ -32,7 +32,7 @@ func TestAccIbmSccControlLibraryBasic(t *testing.T) {
 	}
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { acc.TestAccPreCheck(t) },
+		PreCheck:     func() { acc.TestAccPreCheckSccInstanceID(t) },
 		Providers:    acc.TestAccProviders,
 		CheckDestroy: testAccCheckIbmSccControlLibraryDestroy,
 		Steps: []resource.TestStep{
@@ -79,7 +79,7 @@ func TestAccIbmSccControlLibraryAllArgs(t *testing.T) {
 	}
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { acc.TestAccPreCheck(t) },
+		PreCheck:     func() { acc.TestAccPreCheckSccInstanceID(t) },
 		Providers:    acc.TestAccProviders,
 		CheckDestroy: testAccCheckIbmSccControlLibraryDestroy,
 		Steps: []resource.TestStep{

--- a/ibm/service/scc/resource_ibm_scc_control_library_test.go
+++ b/ibm/service/scc/resource_ibm_scc_control_library_test.go
@@ -5,7 +5,6 @@ package scc_test
 
 import (
 	"fmt"
-	"os"
 	"strings"
 	"testing"
 
@@ -26,18 +25,14 @@ func TestAccIbmSccControlLibraryBasic(t *testing.T) {
 	controlLibraryNameUpdate := controlLibraryName
 	controlLibraryDescriptionUpdate := controlLibraryDescription
 	controlLibraryTypeUpdate := controlLibraryType
-	instanceID, ok := os.LookupEnv("IBMCLOUD_SCC_INSTANCE_ID")
-	if !ok {
-		t.Logf("Missing the env var IBMCLOUD_SCC_INSTANCE_ID.")
-	}
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { acc.TestAccPreCheckSccInstanceID(t) },
+		PreCheck:     func() { acc.TestAccPreCheckScc(t) },
 		Providers:    acc.TestAccProviders,
 		CheckDestroy: testAccCheckIbmSccControlLibraryDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
-				Config: testAccCheckIbmSccControlLibraryConfigBasic(instanceID, controlLibraryName, controlLibraryDescription, controlLibraryType),
+				Config: testAccCheckIbmSccControlLibraryConfigBasic(acc.SccInstanceID, controlLibraryName, controlLibraryDescription, controlLibraryType),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckIbmSccControlLibraryExists("ibm_scc_control_library.scc_control_library_instance", conf),
 					resource.TestCheckResourceAttr("ibm_scc_control_library.scc_control_library_instance", "control_library_name", controlLibraryName),
@@ -46,7 +41,7 @@ func TestAccIbmSccControlLibraryBasic(t *testing.T) {
 				),
 			},
 			resource.TestStep{
-				Config: testAccCheckIbmSccControlLibraryConfigBasic(instanceID, controlLibraryNameUpdate, controlLibraryDescriptionUpdate, controlLibraryTypeUpdate),
+				Config: testAccCheckIbmSccControlLibraryConfigBasic(acc.SccInstanceID, controlLibraryNameUpdate, controlLibraryDescriptionUpdate, controlLibraryTypeUpdate),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr("ibm_scc_control_library.scc_control_library_instance", "control_library_name", controlLibraryNameUpdate),
 					resource.TestCheckResourceAttr("ibm_scc_control_library.scc_control_library_instance", "control_library_description", controlLibraryDescriptionUpdate),
@@ -73,18 +68,14 @@ func TestAccIbmSccControlLibraryAllArgs(t *testing.T) {
 	versionGroupLabelUpdate := versionGroupLabel
 	controlLibraryVersionUpdate := "0.0.2"
 	latestUpdate := "true"
-	instanceID, ok := os.LookupEnv("IBMCLOUD_SCC_INSTANCE_ID")
-	if !ok {
-		t.Logf("Missing the env var IBMCLOUD_SCC_INSTANCE_ID.")
-	}
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { acc.TestAccPreCheckSccInstanceID(t) },
+		PreCheck:     func() { acc.TestAccPreCheckScc(t) },
 		Providers:    acc.TestAccProviders,
 		CheckDestroy: testAccCheckIbmSccControlLibraryDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
-				Config: testAccCheckIbmSccControlLibraryConfig(instanceID, controlLibraryName, controlLibraryDescription, controlLibraryType, versionGroupLabel, controlLibraryVersion, latest),
+				Config: testAccCheckIbmSccControlLibraryConfig(acc.SccInstanceID, controlLibraryName, controlLibraryDescription, controlLibraryType, versionGroupLabel, controlLibraryVersion, latest),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckIbmSccControlLibraryExists("ibm_scc_control_library.scc_control_library_instance", conf),
 					resource.TestCheckResourceAttr("ibm_scc_control_library.scc_control_library_instance", "control_library_name", controlLibraryName),
@@ -97,7 +88,7 @@ func TestAccIbmSccControlLibraryAllArgs(t *testing.T) {
 				),
 			},
 			resource.TestStep{
-				Config: testAccCheckIbmSccControlLibraryConfig(instanceID, controlLibraryNameUpdate, controlLibraryDescriptionUpdate, controlLibraryTypeUpdate, versionGroupLabelUpdate, controlLibraryVersionUpdate, latestUpdate),
+				Config: testAccCheckIbmSccControlLibraryConfig(acc.SccInstanceID, controlLibraryNameUpdate, controlLibraryDescriptionUpdate, controlLibraryTypeUpdate, versionGroupLabelUpdate, controlLibraryVersionUpdate, latestUpdate),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr("ibm_scc_control_library.scc_control_library_instance", "control_library_name", controlLibraryNameUpdate),
 					resource.TestCheckResourceAttr("ibm_scc_control_library.scc_control_library_instance", "control_library_description", controlLibraryDescriptionUpdate),

--- a/ibm/service/scc/resource_ibm_scc_control_library_test.go
+++ b/ibm/service/scc/resource_ibm_scc_control_library_test.go
@@ -29,7 +29,6 @@ func TestAccIbmSccControlLibraryBasic(t *testing.T) {
 	instanceID, ok := os.LookupEnv("IBMCLOUD_SCC_INSTANCE_ID")
 	if !ok {
 		t.Logf("Missing the env var IBMCLOUD_SCC_INSTANCE_ID.")
-		t.FailNow()
 	}
 
 	resource.Test(t, resource.TestCase{
@@ -77,7 +76,6 @@ func TestAccIbmSccControlLibraryAllArgs(t *testing.T) {
 	instanceID, ok := os.LookupEnv("IBMCLOUD_SCC_INSTANCE_ID")
 	if !ok {
 		t.Logf("Missing the env var IBMCLOUD_SCC_INSTANCE_ID.")
-		t.FailNow()
 	}
 
 	resource.Test(t, resource.TestCase{

--- a/ibm/service/scc/resource_ibm_scc_control_library_test.go
+++ b/ibm/service/scc/resource_ibm_scc_control_library_test.go
@@ -5,6 +5,8 @@ package scc_test
 
 import (
 	"fmt"
+	"os"
+	"strings"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
@@ -24,6 +26,11 @@ func TestAccIbmSccControlLibraryBasic(t *testing.T) {
 	controlLibraryNameUpdate := controlLibraryName
 	controlLibraryDescriptionUpdate := controlLibraryDescription
 	controlLibraryTypeUpdate := controlLibraryType
+	instanceID, ok := os.LookupEnv("IBMCLOUD_SCC_INSTANCE_ID")
+	if !ok {
+		t.Logf("Missing the env var IBMCLOUD_SCC_INSTANCE_ID.")
+		t.FailNow()
+	}
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { acc.TestAccPreCheck(t) },
@@ -31,7 +38,7 @@ func TestAccIbmSccControlLibraryBasic(t *testing.T) {
 		CheckDestroy: testAccCheckIbmSccControlLibraryDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
-				Config: testAccCheckIbmSccControlLibraryConfigBasic(controlLibraryName, controlLibraryDescription, controlLibraryType),
+				Config: testAccCheckIbmSccControlLibraryConfigBasic(instanceID, controlLibraryName, controlLibraryDescription, controlLibraryType),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckIbmSccControlLibraryExists("ibm_scc_control_library.scc_control_library_instance", conf),
 					resource.TestCheckResourceAttr("ibm_scc_control_library.scc_control_library_instance", "control_library_name", controlLibraryName),
@@ -40,7 +47,7 @@ func TestAccIbmSccControlLibraryBasic(t *testing.T) {
 				),
 			},
 			resource.TestStep{
-				Config: testAccCheckIbmSccControlLibraryConfigBasic(controlLibraryNameUpdate, controlLibraryDescriptionUpdate, controlLibraryTypeUpdate),
+				Config: testAccCheckIbmSccControlLibraryConfigBasic(instanceID, controlLibraryNameUpdate, controlLibraryDescriptionUpdate, controlLibraryTypeUpdate),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr("ibm_scc_control_library.scc_control_library_instance", "control_library_name", controlLibraryNameUpdate),
 					resource.TestCheckResourceAttr("ibm_scc_control_library.scc_control_library_instance", "control_library_description", controlLibraryDescriptionUpdate),
@@ -67,6 +74,11 @@ func TestAccIbmSccControlLibraryAllArgs(t *testing.T) {
 	versionGroupLabelUpdate := versionGroupLabel
 	controlLibraryVersionUpdate := "0.0.2"
 	latestUpdate := "true"
+	instanceID, ok := os.LookupEnv("IBMCLOUD_SCC_INSTANCE_ID")
+	if !ok {
+		t.Logf("Missing the env var IBMCLOUD_SCC_INSTANCE_ID.")
+		t.FailNow()
+	}
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { acc.TestAccPreCheck(t) },
@@ -74,7 +86,7 @@ func TestAccIbmSccControlLibraryAllArgs(t *testing.T) {
 		CheckDestroy: testAccCheckIbmSccControlLibraryDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
-				Config: testAccCheckIbmSccControlLibraryConfig(controlLibraryName, controlLibraryDescription, controlLibraryType, versionGroupLabel, controlLibraryVersion, latest),
+				Config: testAccCheckIbmSccControlLibraryConfig(instanceID, controlLibraryName, controlLibraryDescription, controlLibraryType, versionGroupLabel, controlLibraryVersion, latest),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckIbmSccControlLibraryExists("ibm_scc_control_library.scc_control_library_instance", conf),
 					resource.TestCheckResourceAttr("ibm_scc_control_library.scc_control_library_instance", "control_library_name", controlLibraryName),
@@ -87,7 +99,7 @@ func TestAccIbmSccControlLibraryAllArgs(t *testing.T) {
 				),
 			},
 			resource.TestStep{
-				Config: testAccCheckIbmSccControlLibraryConfig(controlLibraryNameUpdate, controlLibraryDescriptionUpdate, controlLibraryTypeUpdate, versionGroupLabelUpdate, controlLibraryVersionUpdate, latestUpdate),
+				Config: testAccCheckIbmSccControlLibraryConfig(instanceID, controlLibraryNameUpdate, controlLibraryDescriptionUpdate, controlLibraryTypeUpdate, versionGroupLabelUpdate, controlLibraryVersionUpdate, latestUpdate),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr("ibm_scc_control_library.scc_control_library_instance", "control_library_name", controlLibraryNameUpdate),
 					resource.TestCheckResourceAttr("ibm_scc_control_library.scc_control_library_instance", "control_library_description", controlLibraryDescriptionUpdate),
@@ -107,9 +119,10 @@ func TestAccIbmSccControlLibraryAllArgs(t *testing.T) {
 	})
 }
 
-func testAccCheckIbmSccControlLibraryConfigBasic(controlLibraryName string, controlLibraryDescription string, controlLibraryType string) string {
+func testAccCheckIbmSccControlLibraryConfigBasic(instanceID string, controlLibraryName string, controlLibraryDescription string, controlLibraryType string) string {
 	return fmt.Sprintf(`
 		resource "ibm_scc_control_library" "scc_control_library_instance" {
+			instance_id = "%s"
 			control_library_name = "%s"
 			control_library_description = "%s"
 			control_library_type = "%s"
@@ -148,13 +161,14 @@ func testAccCheckIbmSccControlLibraryConfigBasic(controlLibraryName string, cont
 				status = "enabled"
 			}
 		}
-	`, controlLibraryName, controlLibraryDescription, controlLibraryType)
+	`, instanceID, controlLibraryName, controlLibraryDescription, controlLibraryType)
 }
 
-func testAccCheckIbmSccControlLibraryConfig(controlLibraryName string, controlLibraryDescription string, controlLibraryType string, versionGroupLabel string, controlLibraryVersion string, latest string) string {
+func testAccCheckIbmSccControlLibraryConfig(instanceID string, controlLibraryName string, controlLibraryDescription string, controlLibraryType string, versionGroupLabel string, controlLibraryVersion string, latest string) string {
 	return fmt.Sprintf(`
 
 		resource "ibm_scc_control_library" "scc_control_library_instance" {
+			instance_id = "%s"
 			control_library_name = "%s"
 			control_library_description = "%s"
 			control_library_type = "%s"
@@ -194,7 +208,7 @@ func testAccCheckIbmSccControlLibraryConfig(controlLibraryName string, controlLi
 				status = "enabled"
 			}
 		}
-	`, controlLibraryName, controlLibraryDescription, controlLibraryType, versionGroupLabel, controlLibraryVersion, latest)
+	`, instanceID, controlLibraryName, controlLibraryDescription, controlLibraryType, versionGroupLabel, controlLibraryVersion, latest)
 }
 
 func testAccCheckIbmSccControlLibraryExists(n string, obj securityandcompliancecenterapiv3.ControlLibrary) resource.TestCheckFunc {
@@ -212,7 +226,9 @@ func testAccCheckIbmSccControlLibraryExists(n string, obj securityandcompliancec
 
 		getControlLibraryOptions := &securityandcompliancecenterapiv3.GetControlLibraryOptions{}
 
-		getControlLibraryOptions.SetControlLibrariesID(rs.Primary.ID)
+		id := strings.Split(rs.Primary.ID, "/")
+		getControlLibraryOptions.SetInstanceID(id[0])
+		getControlLibraryOptions.SetControlLibrariesID(id[1])
 
 		controlLibrary, _, err := securityandcompliancecenterapiClient.GetControlLibrary(getControlLibraryOptions)
 		if err != nil {
@@ -236,7 +252,9 @@ func testAccCheckIbmSccControlLibraryDestroy(s *terraform.State) error {
 
 		getControlLibraryOptions := &securityandcompliancecenterapiv3.GetControlLibraryOptions{}
 
-		getControlLibraryOptions.SetControlLibrariesID(rs.Primary.ID)
+		id := strings.Split(rs.Primary.ID, "/")
+		getControlLibraryOptions.SetInstanceID(id[0])
+		getControlLibraryOptions.SetControlLibrariesID(id[1])
 
 		// Try to find the key
 		_, response, err := securityandcompliancecenterapiClient.GetControlLibrary(getControlLibraryOptions)

--- a/ibm/service/scc/resource_ibm_scc_profile.go
+++ b/ibm/service/scc/resource_ibm_scc_profile.go
@@ -19,7 +19,7 @@ import (
 )
 
 func ResourceIbmSccProfile() *schema.Resource {
-	return &schema.Resource{
+	return AddSchemaData(&schema.Resource{
 		CreateContext: resourceIbmSccProfileCreate,
 		ReadContext:   resourceIbmSccProfileRead,
 		UpdateContext: resourceIbmSccProfileUpdate,
@@ -27,6 +27,11 @@ func ResourceIbmSccProfile() *schema.Resource {
 		Importer:      &schema.ResourceImporter{},
 
 		Schema: map[string]*schema.Schema{
+			"profile_id": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The profile name.",
+			},
 			"profile_name": {
 				Type:         schema.TypeString,
 				Required:     true,
@@ -320,7 +325,7 @@ func ResourceIbmSccProfile() *schema.Resource {
 				Description: "The number of attachments related to this profile.",
 			},
 		},
-	}
+	})
 }
 
 func ResourceIbmSccProfileValidator() *validate.ResourceValidator {
@@ -360,6 +365,8 @@ func resourceIbmSccProfileCreate(context context.Context, d *schema.ResourceData
 	bodyModelMap := map[string]interface{}{}
 	createProfileOptions := &securityandcompliancecenterapiv3.CreateProfileOptions{}
 
+	instance_id := d.Get("instance_id").(string)
+	bodyModelMap["instance_id"] = instance_id
 	bodyModelMap["profile_name"] = d.Get("profile_name")
 	bodyModelMap["profile_description"] = d.Get("profile_description")
 	bodyModelMap["profile_type"] = "custom"
@@ -376,6 +383,7 @@ func resourceIbmSccProfileCreate(context context.Context, d *schema.ResourceData
 		return diag.FromErr(err)
 	}
 	createProfileOptions = convertedModel
+	createProfileOptions.SetInstanceID(instance_id)
 
 	profile, response, err := securityandcompliancecenterapiClient.CreateProfileWithContext(context, createProfileOptions)
 	if err != nil {
@@ -383,7 +391,7 @@ func resourceIbmSccProfileCreate(context context.Context, d *schema.ResourceData
 		return diag.FromErr(fmt.Errorf("CreateProfileWithContext failed %s\n%s", err, response))
 	}
 
-	d.SetId(*profile.ID)
+	d.SetId(instance_id + "/" + *profile.ID)
 
 	return resourceIbmSccProfileRead(context, d, meta)
 }
@@ -397,7 +405,12 @@ func resourceIbmSccProfileRead(context context.Context, d *schema.ResourceData, 
 
 	getProfileOptions := &securityandcompliancecenterapiv3.GetProfileOptions{}
 
-	getProfileOptions.SetProfileID(d.Id())
+	parts, err := flex.SepIdParts(d.Id(), "/")
+	if err != nil {
+		return diag.FromErr(err)
+	}
+	getProfileOptions.SetInstanceID(parts[0])
+	getProfileOptions.SetProfileID(parts[1])
 
 	profile, response, err := securityandcompliancecenterapiClient.GetProfileWithContext(context, getProfileOptions)
 	if err != nil {
@@ -409,6 +422,12 @@ func resourceIbmSccProfileRead(context context.Context, d *schema.ResourceData, 
 		return diag.FromErr(fmt.Errorf("GetProfileWithContext failed %s\n%s", err, response))
 	}
 
+	if err = d.Set("instance_id", parts[0]); err != nil {
+		return diag.FromErr(fmt.Errorf("Error setting instance_id: %s", err))
+	}
+	if err = d.Set("profile_id", parts[1]); err != nil {
+		return diag.FromErr(fmt.Errorf("Error setting profile_id: %s", err))
+	}
 	if err = d.Set("profile_name", profile.ProfileName); err != nil {
 		return diag.FromErr(fmt.Errorf("Error setting profile_name: %s", err))
 	}
@@ -513,6 +532,13 @@ func resourceIbmSccProfileUpdate(context context.Context, d *schema.ResourceData
 	}
 
 	replaceProfileOptions := &securityandcompliancecenterapiv3.ReplaceProfileOptions{}
+	parts, err := flex.SepIdParts(d.Id(), "/")
+	if err != nil {
+		return diag.FromErr(err)
+	}
+	// TODO: Implement replaceProfileOptions.SetInstanceID
+	replaceProfileOptions.InstanceID = &parts[0]
+	replaceProfileOptions.SetProfileID(parts[1])
 	hasChange := false
 	bodyModelMap := map[string]interface{}{}
 
@@ -568,7 +594,12 @@ func resourceIbmSccProfileDelete(context context.Context, d *schema.ResourceData
 
 	deleteCustomProfileOptions := &securityandcompliancecenterapiv3.DeleteCustomProfileOptions{}
 
-	deleteCustomProfileOptions.SetProfileID(d.Id())
+	parts, err := flex.SepIdParts(d.Id(), "/")
+	if err != nil {
+		return diag.FromErr(err)
+	}
+	deleteCustomProfileOptions.SetInstanceID(parts[0])
+	deleteCustomProfileOptions.SetProfileID(parts[1])
 
 	_, response, err := securityandcompliancecenterapiClient.DeleteCustomProfileWithContext(context, deleteCustomProfileOptions)
 	if err != nil {

--- a/ibm/service/scc/resource_ibm_scc_profile.go
+++ b/ibm/service/scc/resource_ibm_scc_profile.go
@@ -536,8 +536,7 @@ func resourceIbmSccProfileUpdate(context context.Context, d *schema.ResourceData
 	if err != nil {
 		return diag.FromErr(err)
 	}
-	// TODO: Implement replaceProfileOptions.SetInstanceID
-	replaceProfileOptions.InstanceID = &parts[0]
+	replaceProfileOptions.SetInstanceID(parts[0])
 	replaceProfileOptions.SetProfileID(parts[1])
 	hasChange := false
 	bodyModelMap := map[string]interface{}{}

--- a/ibm/service/scc/resource_ibm_scc_profile_attachment_test.go
+++ b/ibm/service/scc/resource_ibm_scc_profile_attachment_test.go
@@ -25,7 +25,7 @@ func TestAccIbmSccProfileAttachmentBasic(t *testing.T) {
 	}
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { acc.TestAccPreCheck(t) },
+		PreCheck:     func() { acc.TestAccPreCheckSccInstanceID(t) },
 		Providers:    acc.TestAccProviders,
 		CheckDestroy: testAccCheckIbmSccProfileAttachmentDestroy,
 		Steps: []resource.TestStep{
@@ -47,7 +47,7 @@ func TestAccIbmSccProfileAttachmentAllArgs(t *testing.T) {
 		t.Logf("Missing the env var IBMCLOUD_SCC_INSTANCE_ID.")
 	}
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { acc.TestAccPreCheck(t) },
+		PreCheck:     func() { acc.TestAccPreCheckSccInstanceID(t) },
 		Providers:    acc.TestAccProviders,
 		CheckDestroy: testAccCheckIbmSccProfileAttachmentDestroy,
 		Steps: []resource.TestStep{

--- a/ibm/service/scc/resource_ibm_scc_profile_attachment_test.go
+++ b/ibm/service/scc/resource_ibm_scc_profile_attachment_test.go
@@ -22,7 +22,6 @@ func TestAccIbmSccProfileAttachmentBasic(t *testing.T) {
 	instanceID, ok := os.LookupEnv("IBMCLOUD_SCC_INSTANCE_ID")
 	if !ok {
 		t.Logf("Missing the env var IBMCLOUD_SCC_INSTANCE_ID.")
-		t.FailNow()
 	}
 
 	resource.Test(t, resource.TestCase{
@@ -46,7 +45,6 @@ func TestAccIbmSccProfileAttachmentAllArgs(t *testing.T) {
 	instanceID, ok := os.LookupEnv("IBMCLOUD_SCC_INSTANCE_ID")
 	if !ok {
 		t.Logf("Missing the env var IBMCLOUD_SCC_INSTANCE_ID.")
-		t.FailNow()
 	}
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { acc.TestAccPreCheck(t) },

--- a/ibm/service/scc/resource_ibm_scc_profile_attachment_test.go
+++ b/ibm/service/scc/resource_ibm_scc_profile_attachment_test.go
@@ -5,7 +5,6 @@ package scc_test
 
 import (
 	"fmt"
-	"os"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
@@ -19,18 +18,14 @@ import (
 
 func TestAccIbmSccProfileAttachmentBasic(t *testing.T) {
 	var conf securityandcompliancecenterapiv3.AttachmentItem
-	instanceID, ok := os.LookupEnv("IBMCLOUD_SCC_INSTANCE_ID")
-	if !ok {
-		t.Logf("Missing the env var IBMCLOUD_SCC_INSTANCE_ID.")
-	}
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { acc.TestAccPreCheckSccInstanceID(t) },
+		PreCheck:     func() { acc.TestAccPreCheckScc(t) },
 		Providers:    acc.TestAccProviders,
 		CheckDestroy: testAccCheckIbmSccProfileAttachmentDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
-				Config: testAccCheckIbmSccProfileAttachmentConfigBasic(instanceID),
+				Config: testAccCheckIbmSccProfileAttachmentConfigBasic(acc.SccInstanceID),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckIbmSccProfileAttachmentExists("ibm_scc_profile_attachment.scc_profile_attachment_instance", conf),
 				),
@@ -42,23 +37,19 @@ func TestAccIbmSccProfileAttachmentBasic(t *testing.T) {
 func TestAccIbmSccProfileAttachmentAllArgs(t *testing.T) {
 	var conf securityandcompliancecenterapiv3.AttachmentItem
 
-	instanceID, ok := os.LookupEnv("IBMCLOUD_SCC_INSTANCE_ID")
-	if !ok {
-		t.Logf("Missing the env var IBMCLOUD_SCC_INSTANCE_ID.")
-	}
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { acc.TestAccPreCheckSccInstanceID(t) },
+		PreCheck:     func() { acc.TestAccPreCheckScc(t) },
 		Providers:    acc.TestAccProviders,
 		CheckDestroy: testAccCheckIbmSccProfileAttachmentDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
-				Config: testAccCheckIbmSccProfileAttachmentConfig(instanceID),
+				Config: testAccCheckIbmSccProfileAttachmentConfig(acc.SccInstanceID),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckIbmSccProfileAttachmentExists("ibm_scc_profile_attachment.scc_profile_attachment_instance", conf),
 				),
 			},
 			resource.TestStep{
-				Config: testAccCheckIbmSccProfileAttachmentConfig(instanceID),
+				Config: testAccCheckIbmSccProfileAttachmentConfig(acc.SccInstanceID),
 				Check:  resource.ComposeAggregateTestCheckFunc(),
 			},
 			resource.TestStep{

--- a/ibm/service/scc/resource_ibm_scc_profile_test.go
+++ b/ibm/service/scc/resource_ibm_scc_profile_test.go
@@ -32,7 +32,7 @@ func TestAccIbmSccProfileBasic(t *testing.T) {
 	}
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { acc.TestAccPreCheck(t) },
+		PreCheck:     func() { acc.TestAccPreCheckSccInstanceID(t) },
 		Providers:    acc.TestAccProviders,
 		CheckDestroy: testAccCheckIbmSccProfileDestroy,
 		Steps: []resource.TestStep{
@@ -71,7 +71,7 @@ func TestAccIbmSccProfileAllArgs(t *testing.T) {
 	}
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { acc.TestAccPreCheck(t) },
+		PreCheck:     func() { acc.TestAccPreCheckSccInstanceID(t) },
 		Providers:    acc.TestAccProviders,
 		CheckDestroy: testAccCheckIbmSccProfileDestroy,
 		Steps: []resource.TestStep{

--- a/ibm/service/scc/resource_ibm_scc_profile_test.go
+++ b/ibm/service/scc/resource_ibm_scc_profile_test.go
@@ -5,7 +5,6 @@ package scc_test
 
 import (
 	"fmt"
-	"os"
 	"strings"
 	"testing"
 
@@ -26,18 +25,14 @@ func TestAccIbmSccProfileBasic(t *testing.T) {
 	profileNameUpdate := profileName
 	profileDescriptionUpdate := profileDescription
 	profileTypeUpdate := profileType
-	instanceID, ok := os.LookupEnv("IBMCLOUD_SCC_INSTANCE_ID")
-	if !ok {
-		t.Logf("Missing the env var IBMCLOUD_SCC_INSTANCE_ID.")
-	}
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { acc.TestAccPreCheckSccInstanceID(t) },
+		PreCheck:     func() { acc.TestAccPreCheckScc(t) },
 		Providers:    acc.TestAccProviders,
 		CheckDestroy: testAccCheckIbmSccProfileDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
-				Config: testAccCheckIbmSccProfileConfigBasic(instanceID, profileName, profileDescription, profileType),
+				Config: testAccCheckIbmSccProfileConfigBasic(acc.SccInstanceID, profileName, profileDescription, profileType),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckIbmSccProfileExists("ibm_scc_profile.scc_profile_instance", conf),
 					resource.TestCheckResourceAttr("ibm_scc_profile.scc_profile_instance", "profile_name", profileName),
@@ -46,7 +41,7 @@ func TestAccIbmSccProfileBasic(t *testing.T) {
 				),
 			},
 			resource.TestStep{
-				Config: testAccCheckIbmSccProfileConfigBasic(instanceID, profileNameUpdate, profileDescriptionUpdate, profileTypeUpdate),
+				Config: testAccCheckIbmSccProfileConfigBasic(acc.SccInstanceID, profileNameUpdate, profileDescriptionUpdate, profileTypeUpdate),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr("ibm_scc_profile.scc_profile_instance", "profile_name", profileNameUpdate),
 					resource.TestCheckResourceAttr("ibm_scc_profile.scc_profile_instance", "profile_description", profileDescriptionUpdate),
@@ -65,18 +60,14 @@ func TestAccIbmSccProfileAllArgs(t *testing.T) {
 	profileNameUpdate := profileName
 	profileDescriptionUpdate := profileDescription
 	profileTypeUpdate := profileType
-	instanceID, ok := os.LookupEnv("IBMCLOUD_SCC_INSTANCE_ID")
-	if !ok {
-		t.Logf("Missing the env var IBMCLOUD_SCC_INSTANCE_ID.")
-	}
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { acc.TestAccPreCheckSccInstanceID(t) },
+		PreCheck:     func() { acc.TestAccPreCheckScc(t) },
 		Providers:    acc.TestAccProviders,
 		CheckDestroy: testAccCheckIbmSccProfileDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
-				Config: testAccCheckIbmSccProfileConfig(instanceID, profileName, profileDescription, profileType),
+				Config: testAccCheckIbmSccProfileConfig(acc.SccInstanceID, profileName, profileDescription, profileType),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckIbmSccProfileExists("ibm_scc_profile.scc_profile_instance", conf),
 					resource.TestCheckResourceAttr("ibm_scc_profile.scc_profile_instance", "profile_name", profileName),
@@ -85,7 +76,7 @@ func TestAccIbmSccProfileAllArgs(t *testing.T) {
 				),
 			},
 			resource.TestStep{
-				Config: testAccCheckIbmSccProfileConfig(instanceID, profileNameUpdate, profileDescriptionUpdate, profileTypeUpdate),
+				Config: testAccCheckIbmSccProfileConfig(acc.SccInstanceID, profileNameUpdate, profileDescriptionUpdate, profileTypeUpdate),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr("ibm_scc_profile.scc_profile_instance", "profile_name", profileNameUpdate),
 					resource.TestCheckResourceAttr("ibm_scc_profile.scc_profile_instance", "profile_description", profileDescriptionUpdate),

--- a/ibm/service/scc/resource_ibm_scc_profile_test.go
+++ b/ibm/service/scc/resource_ibm_scc_profile_test.go
@@ -29,7 +29,6 @@ func TestAccIbmSccProfileBasic(t *testing.T) {
 	instanceID, ok := os.LookupEnv("IBMCLOUD_SCC_INSTANCE_ID")
 	if !ok {
 		t.Logf("Missing the env var IBMCLOUD_SCC_INSTANCE_ID.")
-		t.FailNow()
 	}
 
 	resource.Test(t, resource.TestCase{
@@ -69,7 +68,6 @@ func TestAccIbmSccProfileAllArgs(t *testing.T) {
 	instanceID, ok := os.LookupEnv("IBMCLOUD_SCC_INSTANCE_ID")
 	if !ok {
 		t.Logf("Missing the env var IBMCLOUD_SCC_INSTANCE_ID.")
-		t.FailNow()
 	}
 
 	resource.Test(t, resource.TestCase{

--- a/ibm/service/scc/resource_ibm_scc_provider_type_instance.go
+++ b/ibm/service/scc/resource_ibm_scc_provider_type_instance.go
@@ -209,7 +209,7 @@ func resourceIbmSccProviderTypeInstanceUpdate(context context.Context, d *schema
 	}
 
 	// TODO: add updateProviderTypeInstanceOptions.SetInstanceID to scc-go-sdk
-	updateProviderTypeInstanceOptions.InstanceID = &parts[0]
+	updateProviderTypeInstanceOptions.SetInstanceID(parts[0])
 	updateProviderTypeInstanceOptions.SetProviderTypeID(parts[1])
 	updateProviderTypeInstanceOptions.SetProviderTypeInstanceID(parts[2])
 

--- a/ibm/service/scc/resource_ibm_scc_provider_type_instance.go
+++ b/ibm/service/scc/resource_ibm_scc_provider_type_instance.go
@@ -1,4 +1,4 @@
-//ng Copyright IBM Corp. 2023 All Rights Reserved.
+// ng Copyright IBM Corp. 2023 All Rights Reserved.
 // Licensed under the Mozilla Public License v2.0
 
 package scc
@@ -102,9 +102,11 @@ func resourceIbmSccProviderTypeInstanceCreate(context context.Context, d *schema
 	}
 
 	createProviderTypeInstanceOptions := &securityandcompliancecenterapiv3.CreateProviderTypeInstanceOptions{}
+	instanceID := d.Get("instance_id").(string)
 
 	createProviderTypeInstanceOptions.SetProviderTypeID(d.Get("provider_type_id").(string))
 	createProviderTypeInstanceOptions.SetName(d.Get("name").(string))
+	createProviderTypeInstanceOptions.SetInstanceID(instanceID)
 	attributesModel, err := resourceIbmSccProviderTypeInstanceMapToProviderTypeInstanceAttributes(d.Get("attributes").(map[string]interface{}))
 	if err != nil {
 		return diag.FromErr(err)
@@ -117,7 +119,7 @@ func resourceIbmSccProviderTypeInstanceCreate(context context.Context, d *schema
 		return diag.FromErr(fmt.Errorf("CreateProviderTypeInstanceWithContext failed %s\n%s", err, response))
 	}
 
-	d.SetId(fmt.Sprintf("%s/%s", *createProviderTypeInstanceOptions.ProviderTypeID, *providerTypeInstanceItem.ID))
+	d.SetId(fmt.Sprintf("%s/%s/%s", instanceID, *createProviderTypeInstanceOptions.ProviderTypeID, *providerTypeInstanceItem.ID))
 
 	return resourceIbmSccProviderTypeInstanceRead(context, d, meta)
 }
@@ -135,8 +137,9 @@ func resourceIbmSccProviderTypeInstanceRead(context context.Context, d *schema.R
 		return diag.FromErr(err)
 	}
 
-	getProviderTypeInstanceOptions.SetProviderTypeID(parts[0])
-	getProviderTypeInstanceOptions.SetProviderTypeInstanceID(parts[1])
+	getProviderTypeInstanceOptions.SetInstanceID(parts[0])
+	getProviderTypeInstanceOptions.SetProviderTypeID(parts[1])
+	getProviderTypeInstanceOptions.SetProviderTypeInstanceID(parts[2])
 
 	providerTypeInstanceItem, response, err := securityAndComplianceCenterApIsClient.GetProviderTypeInstanceWithContext(context, getProviderTypeInstanceOptions)
 	if err != nil {
@@ -146,6 +149,10 @@ func resourceIbmSccProviderTypeInstanceRead(context context.Context, d *schema.R
 		}
 		log.Printf("[DEBUG] GetProviderTypeInstanceWithContext failed %s\n%s", err, response)
 		return diag.FromErr(fmt.Errorf("GetProviderTypeInstanceWithContext failed %s\n%s", err, response))
+	}
+
+	if err = d.Set("instance_id", parts[0]); err != nil {
+		return diag.FromErr(fmt.Errorf("Error setting instance_id: %s", err))
 	}
 
 	if err = d.Set("name", providerTypeInstanceItem.Name); err != nil {
@@ -181,7 +188,7 @@ func resourceIbmSccProviderTypeInstanceRead(context context.Context, d *schema.R
 			return diag.FromErr(fmt.Errorf("Error setting provider_type_instance_id: %s", err))
 		}
 	}
-	if err = d.Set("provider_type_id", parts[0]); err != nil {
+	if err = d.Set("provider_type_id", parts[1]); err != nil {
 		return diag.FromErr(fmt.Errorf("Error setting provider_type_id: %s", err))
 	}
 
@@ -201,8 +208,9 @@ func resourceIbmSccProviderTypeInstanceUpdate(context context.Context, d *schema
 		return diag.FromErr(err)
 	}
 
-	updateProviderTypeInstanceOptions.SetProviderTypeID(parts[0])
-	updateProviderTypeInstanceOptions.SetProviderTypeInstanceID(parts[1])
+	updateProviderTypeInstanceOptions.InstanceID = &parts[0]
+	updateProviderTypeInstanceOptions.SetProviderTypeID(parts[1])
+	updateProviderTypeInstanceOptions.SetProviderTypeInstanceID(parts[2])
 
 	hasChange := false
 
@@ -243,8 +251,9 @@ func resourceIbmSccProviderTypeInstanceDelete(context context.Context, d *schema
 		return diag.FromErr(err)
 	}
 
-	deleteProviderTypeInstanceOptions.SetProviderTypeID(parts[0])
-	deleteProviderTypeInstanceOptions.SetProviderTypeInstanceID(parts[1])
+	deleteProviderTypeInstanceOptions.SetInstanceID(parts[0])
+	deleteProviderTypeInstanceOptions.SetProviderTypeID(parts[1])
+	deleteProviderTypeInstanceOptions.SetProviderTypeInstanceID(parts[2])
 
 	response, err := securityAndComplianceCenterApIsClient.DeleteProviderTypeInstanceWithContext(context, deleteProviderTypeInstanceOptions)
 	if err != nil {

--- a/ibm/service/scc/resource_ibm_scc_provider_type_instance.go
+++ b/ibm/service/scc/resource_ibm_scc_provider_type_instance.go
@@ -208,6 +208,7 @@ func resourceIbmSccProviderTypeInstanceUpdate(context context.Context, d *schema
 		return diag.FromErr(err)
 	}
 
+	// TODO: add updateProviderTypeInstanceOptions.SetInstanceID to scc-go-sdk
 	updateProviderTypeInstanceOptions.InstanceID = &parts[0]
 	updateProviderTypeInstanceOptions.SetProviderTypeID(parts[1])
 	updateProviderTypeInstanceOptions.SetProviderTypeInstanceID(parts[2])

--- a/ibm/service/scc/resource_ibm_scc_provider_type_instance.go
+++ b/ibm/service/scc/resource_ibm_scc_provider_type_instance.go
@@ -19,7 +19,7 @@ import (
 )
 
 func ResourceIbmSccProviderTypeInstance() *schema.Resource {
-	return &schema.Resource{
+	return AddSchemaData(&schema.Resource{
 		CreateContext: resourceIbmSccProviderTypeInstanceCreate,
 		ReadContext:   resourceIbmSccProviderTypeInstanceRead,
 		UpdateContext: resourceIbmSccProviderTypeInstanceUpdate,
@@ -65,7 +65,7 @@ func ResourceIbmSccProviderTypeInstance() *schema.Resource {
 				Description: "The unique identifier of the provider type instance.",
 			},
 		},
-	}
+	})
 }
 
 func ResourceIbmSccProviderTypeInstanceValidator() *validate.ResourceValidator {

--- a/ibm/service/scc/resource_ibm_scc_provider_type_instance_test.go
+++ b/ibm/service/scc/resource_ibm_scc_provider_type_instance_test.go
@@ -29,7 +29,7 @@ func TestAccIbmSccProviderTypeInstanceBasic(t *testing.T) {
 	}
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { acc.TestAccPreCheck(t) },
+		PreCheck:     func() { acc.TestAccPreCheckSccInstanceID(t) },
 		Providers:    acc.TestAccProviders,
 		CheckDestroy: testAccCheckIbmSccProviderTypeInstanceDestroy,
 		Steps: []resource.TestStep{
@@ -62,7 +62,7 @@ func TestAccIbmSccProviderTypeInstanceAllArgs(t *testing.T) {
 	}
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { acc.TestAccPreCheck(t) },
+		PreCheck:     func() { acc.TestAccPreCheckSccInstanceID(t) },
 		Providers:    acc.TestAccProviders,
 		CheckDestroy: testAccCheckIbmSccProviderTypeInstanceDestroy,
 		Steps: []resource.TestStep{

--- a/ibm/service/scc/resource_ibm_scc_provider_type_instance_test.go
+++ b/ibm/service/scc/resource_ibm_scc_provider_type_instance_test.go
@@ -23,6 +23,10 @@ func TestAccIbmSccProviderTypeInstanceBasic(t *testing.T) {
 	providerTypeAttributes := os.Getenv("IBMCLOUD_SCC_PROVIDER_TYPE_ATTRIBUTES")
 	name := fmt.Sprintf("tf_provider_type_instance_name_%d", acctest.RandIntRange(10, 100))
 	nameUpdate := fmt.Sprintf("tf_provider_type_instance_name_%d", acctest.RandIntRange(10, 100))
+	instanceID, ok := os.LookupEnv("IBMCLOUD_SCC_INSTANCE_ID")
+	if !ok {
+		t.Logf("Missing the env var IBMCLOUD_SCC_INSTANCE_ID.")
+	}
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { acc.TestAccPreCheck(t) },
@@ -30,14 +34,14 @@ func TestAccIbmSccProviderTypeInstanceBasic(t *testing.T) {
 		CheckDestroy: testAccCheckIbmSccProviderTypeInstanceDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckIbmSccProviderTypeInstanceConfigBasic(name, providerTypeAttributes),
+				Config: testAccCheckIbmSccProviderTypeInstanceConfigBasic(instanceID, name, providerTypeAttributes),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckIbmSccProviderTypeInstanceExists("ibm_scc_provider_type_instance.scc_provider_type_instance_wlp", conf),
 					resource.TestCheckResourceAttr("ibm_scc_provider_type_instance.scc_provider_type_instance_wlp", "name", name),
 				),
 			},
 			{
-				Config: testAccCheckIbmSccProviderTypeInstanceConfigBasic(nameUpdate, providerTypeAttributes),
+				Config: testAccCheckIbmSccProviderTypeInstanceConfigBasic(instanceID, nameUpdate, providerTypeAttributes),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr("ibm_scc_provider_type_instance.scc_provider_type_instance_wlp", "name", nameUpdate),
 				),
@@ -52,20 +56,25 @@ func TestAccIbmSccProviderTypeInstanceAllArgs(t *testing.T) {
 	name := fmt.Sprintf("tf_provider_type_instance_name_%d", acctest.RandIntRange(10, 100))
 	nameUpdate := fmt.Sprintf("tf_provider_type_instance_name_%d", acctest.RandIntRange(10, 100))
 
+	instanceID, ok := os.LookupEnv("IBMCLOUD_SCC_INSTANCE_ID")
+	if !ok {
+		t.Logf("Missing the env var IBMCLOUD_SCC_INSTANCE_ID.")
+	}
+
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { acc.TestAccPreCheck(t) },
 		Providers:    acc.TestAccProviders,
 		CheckDestroy: testAccCheckIbmSccProviderTypeInstanceDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckIbmSccProviderTypeInstanceConfig(name, providerTypeAttributes),
+				Config: testAccCheckIbmSccProviderTypeInstanceConfig(instanceID, name, providerTypeAttributes),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckIbmSccProviderTypeInstanceExists("ibm_scc_provider_type_instance.scc_provider_type_instance_wlp", conf),
 					resource.TestCheckResourceAttr("ibm_scc_provider_type_instance.scc_provider_type_instance_wlp", "name", name),
 				),
 			},
 			{
-				Config: testAccCheckIbmSccProviderTypeInstanceConfig(nameUpdate, providerTypeAttributes),
+				Config: testAccCheckIbmSccProviderTypeInstanceConfig(instanceID, nameUpdate, providerTypeAttributes),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr("ibm_scc_provider_type_instance.scc_provider_type_instance_wlp", "name", nameUpdate),
 				),
@@ -79,24 +88,26 @@ func TestAccIbmSccProviderTypeInstanceAllArgs(t *testing.T) {
 	})
 }
 
-func testAccCheckIbmSccProviderTypeInstanceConfigBasic(name string, attributes string) string {
+func testAccCheckIbmSccProviderTypeInstanceConfigBasic(instanceID string, name string, attributes string) string {
 	return fmt.Sprintf(`
 		resource "ibm_scc_provider_type_instance" "scc_provider_type_instance_wlp" {
+			instance_id = "%s"
 			provider_type_id = "afa2476ecfa5f09af248492fe991b4d1"
 			name = "%s"
 			attributes = %s
 		}
-	`, name, attributes)
+	`, instanceID, name, attributes)
 }
 
-func testAccCheckIbmSccProviderTypeInstanceConfig(name string, attributes string) string {
+func testAccCheckIbmSccProviderTypeInstanceConfig(instanceID string, name string, attributes string) string {
 	return fmt.Sprintf(`
 		resource "ibm_scc_provider_type_instance" "scc_provider_type_instance_wlp" {
+			instance_id = "%s"
 			provider_type_id = "afa2476ecfa5f09af248492fe991b4d1"
 			name = "%s"
 			attributes = %s
 		}
-	`, name, attributes)
+	`, instanceID, name, attributes)
 }
 
 func testAccCheckIbmSccProviderTypeInstanceExists(n string, obj securityandcompliancecenterapiv3.ProviderTypeInstanceItem) resource.TestCheckFunc {
@@ -118,8 +129,9 @@ func testAccCheckIbmSccProviderTypeInstanceExists(n string, obj securityandcompl
 			return err
 		}
 
-		getProviderTypeInstanceOptions.SetProviderTypeID(parts[0])
-		getProviderTypeInstanceOptions.SetProviderTypeInstanceID(parts[1])
+		getProviderTypeInstanceOptions.SetInstanceID(parts[0])
+		getProviderTypeInstanceOptions.SetProviderTypeID(parts[1])
+		getProviderTypeInstanceOptions.SetProviderTypeInstanceID(parts[2])
 
 		providerTypeInstanceItem, _, err := securityAndComplianceCenterApIsClient.GetProviderTypeInstance(getProviderTypeInstanceOptions)
 		if err != nil {
@@ -148,8 +160,9 @@ func testAccCheckIbmSccProviderTypeInstanceDestroy(s *terraform.State) error {
 			return err
 		}
 
-		getProviderTypeInstanceOptions.SetProviderTypeID(parts[0])
-		getProviderTypeInstanceOptions.SetProviderTypeInstanceID(parts[1])
+		getProviderTypeInstanceOptions.SetInstanceID(parts[0])
+		getProviderTypeInstanceOptions.SetProviderTypeID(parts[1])
+		getProviderTypeInstanceOptions.SetProviderTypeInstanceID(parts[2])
 
 		// Try to find the key
 		_, response, err := securityAndComplianceCenterApIsClient.GetProviderTypeInstance(getProviderTypeInstanceOptions)

--- a/ibm/service/scc/resource_ibm_scc_provider_type_instance_test.go
+++ b/ibm/service/scc/resource_ibm_scc_provider_type_instance_test.go
@@ -5,7 +5,6 @@ package scc_test
 
 import (
 	"fmt"
-	"os"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
@@ -20,28 +19,23 @@ import (
 
 func TestAccIbmSccProviderTypeInstanceBasic(t *testing.T) {
 	var conf securityandcompliancecenterapiv3.ProviderTypeInstanceItem
-	providerTypeAttributes := os.Getenv("IBMCLOUD_SCC_PROVIDER_TYPE_ATTRIBUTES")
 	name := fmt.Sprintf("tf_provider_type_instance_name_%d", acctest.RandIntRange(10, 100))
 	nameUpdate := fmt.Sprintf("tf_provider_type_instance_name_%d", acctest.RandIntRange(10, 100))
-	instanceID, ok := os.LookupEnv("IBMCLOUD_SCC_INSTANCE_ID")
-	if !ok {
-		t.Logf("Missing the env var IBMCLOUD_SCC_INSTANCE_ID.")
-	}
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { acc.TestAccPreCheckSccInstanceID(t) },
+		PreCheck:     func() { acc.TestAccPreCheckScc(t) },
 		Providers:    acc.TestAccProviders,
 		CheckDestroy: testAccCheckIbmSccProviderTypeInstanceDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckIbmSccProviderTypeInstanceConfigBasic(instanceID, name, providerTypeAttributes),
+				Config: testAccCheckIbmSccProviderTypeInstanceConfigBasic(acc.SccInstanceID, name, acc.SccProviderTypeAttributes),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckIbmSccProviderTypeInstanceExists("ibm_scc_provider_type_instance.scc_provider_type_instance_wlp", conf),
 					resource.TestCheckResourceAttr("ibm_scc_provider_type_instance.scc_provider_type_instance_wlp", "name", name),
 				),
 			},
 			{
-				Config: testAccCheckIbmSccProviderTypeInstanceConfigBasic(instanceID, nameUpdate, providerTypeAttributes),
+				Config: testAccCheckIbmSccProviderTypeInstanceConfigBasic(acc.SccInstanceID, nameUpdate, acc.SccProviderTypeAttributes),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr("ibm_scc_provider_type_instance.scc_provider_type_instance_wlp", "name", nameUpdate),
 				),
@@ -52,29 +46,23 @@ func TestAccIbmSccProviderTypeInstanceBasic(t *testing.T) {
 
 func TestAccIbmSccProviderTypeInstanceAllArgs(t *testing.T) {
 	var conf securityandcompliancecenterapiv3.ProviderTypeInstanceItem
-	providerTypeAttributes := os.Getenv("IBMCLOUD_SCC_PROVIDER_TYPE_ATTRIBUTES")
 	name := fmt.Sprintf("tf_provider_type_instance_name_%d", acctest.RandIntRange(10, 100))
 	nameUpdate := fmt.Sprintf("tf_provider_type_instance_name_%d", acctest.RandIntRange(10, 100))
 
-	instanceID, ok := os.LookupEnv("IBMCLOUD_SCC_INSTANCE_ID")
-	if !ok {
-		t.Logf("Missing the env var IBMCLOUD_SCC_INSTANCE_ID.")
-	}
-
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { acc.TestAccPreCheckSccInstanceID(t) },
+		PreCheck:     func() { acc.TestAccPreCheckScc(t) },
 		Providers:    acc.TestAccProviders,
 		CheckDestroy: testAccCheckIbmSccProviderTypeInstanceDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckIbmSccProviderTypeInstanceConfig(instanceID, name, providerTypeAttributes),
+				Config: testAccCheckIbmSccProviderTypeInstanceConfig(acc.SccInstanceID, name, acc.SccProviderTypeAttributes),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckIbmSccProviderTypeInstanceExists("ibm_scc_provider_type_instance.scc_provider_type_instance_wlp", conf),
 					resource.TestCheckResourceAttr("ibm_scc_provider_type_instance.scc_provider_type_instance_wlp", "name", name),
 				),
 			},
 			{
-				Config: testAccCheckIbmSccProviderTypeInstanceConfig(instanceID, nameUpdate, providerTypeAttributes),
+				Config: testAccCheckIbmSccProviderTypeInstanceConfig(acc.SccInstanceID, nameUpdate, acc.SccProviderTypeAttributes),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr("ibm_scc_provider_type_instance.scc_provider_type_instance_wlp", "name", nameUpdate),
 				),

--- a/ibm/service/scc/resource_ibm_scc_rule.go
+++ b/ibm/service/scc/resource_ibm_scc_rule.go
@@ -642,7 +642,7 @@ func resourceIbmSccRuleUpdate(context context.Context, d *schema.ResourceData, m
 	if err != nil {
 		return diag.FromErr(err)
 	}
-	replaceRuleOptions.InstanceID = &parts[0]
+	replaceRuleOptions.SetInstanceID(parts[0])
 	replaceRuleOptions.SetRuleID(parts[1])
 	replaceRuleOptions.SetIfMatch(d.Get("etag").(string))
 

--- a/ibm/service/scc/resource_ibm_scc_rule_test.go
+++ b/ibm/service/scc/resource_ibm_scc_rule_test.go
@@ -28,7 +28,7 @@ func TestAccIbmSccRuleBasic(t *testing.T) {
 	}
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { acc.TestAccPreCheck(t) },
+		PreCheck:     func() { acc.TestAccPreCheckSccInstanceID(t) },
 		Providers:    acc.TestAccProviders,
 		CheckDestroy: testAccCheckIbmSccRuleDestroy,
 		Steps: []resource.TestStep{
@@ -61,7 +61,7 @@ func TestAccIbmSccRuleAllArgs(t *testing.T) {
 	}
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { acc.TestAccPreCheck(t) },
+		PreCheck:     func() { acc.TestAccPreCheckSccInstanceID(t) },
 		Providers:    acc.TestAccProviders,
 		CheckDestroy: testAccCheckIbmSccRuleDestroy,
 		Steps: []resource.TestStep{

--- a/ibm/service/scc/resource_ibm_scc_rule_test.go
+++ b/ibm/service/scc/resource_ibm_scc_rule_test.go
@@ -25,7 +25,6 @@ func TestAccIbmSccRuleBasic(t *testing.T) {
 	instanceID, ok := os.LookupEnv("IBMCLOUD_SCC_INSTANCE_ID")
 	if !ok {
 		t.Logf("Missing the env var IBMCLOUD_SCC_INSTANCE_ID.")
-		t.FailNow()
 	}
 
 	resource.Test(t, resource.TestCase{
@@ -59,7 +58,6 @@ func TestAccIbmSccRuleAllArgs(t *testing.T) {
 	instanceID, ok := os.LookupEnv("IBMCLOUD_SCC_INSTANCE_ID")
 	if !ok {
 		t.Logf("Missing the env var IBMCLOUD_SCC_INSTANCE_ID.")
-		t.FailNow()
 	}
 
 	resource.Test(t, resource.TestCase{

--- a/ibm/service/scc/resource_ibm_scc_rule_test.go
+++ b/ibm/service/scc/resource_ibm_scc_rule_test.go
@@ -5,7 +5,6 @@ package scc_test
 
 import (
 	"fmt"
-	"os"
 	"strings"
 	"testing"
 
@@ -22,25 +21,20 @@ func TestAccIbmSccRuleBasic(t *testing.T) {
 	var conf securityandcompliancecenterapiv3.Rule
 	description := fmt.Sprintf("tf_description_%d", acctest.RandIntRange(10, 100))
 	descriptionUpdate := description
-	instanceID, ok := os.LookupEnv("IBMCLOUD_SCC_INSTANCE_ID")
-	if !ok {
-		t.Logf("Missing the env var IBMCLOUD_SCC_INSTANCE_ID.")
-	}
-
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { acc.TestAccPreCheckSccInstanceID(t) },
+		PreCheck:     func() { acc.TestAccPreCheckScc(t) },
 		Providers:    acc.TestAccProviders,
 		CheckDestroy: testAccCheckIbmSccRuleDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckIbmSccRuleConfigBasic(instanceID, description),
+				Config: testAccCheckIbmSccRuleConfigBasic(acc.SccInstanceID, description),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckIbmSccRuleExists("ibm_scc_rule.scc_rule_instance", conf),
 					resource.TestCheckResourceAttr("ibm_scc_rule.scc_rule_instance", "description", description),
 				),
 			},
 			{
-				Config: testAccCheckIbmSccRuleConfigBasic(instanceID, descriptionUpdate),
+				Config: testAccCheckIbmSccRuleConfigBasic(acc.SccInstanceID, descriptionUpdate),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr("ibm_scc_rule.scc_rule_instance", "description", descriptionUpdate),
 				),
@@ -55,18 +49,14 @@ func TestAccIbmSccRuleAllArgs(t *testing.T) {
 	version := fmt.Sprintf("0.0.%d", acctest.RandIntRange(10, 100))
 	descriptionUpdate := fmt.Sprintf("tf_description_%d", acctest.RandIntRange(10, 100))
 	versionUpdate := fmt.Sprintf("0.0.%d", acctest.RandIntRange(2, 100))
-	instanceID, ok := os.LookupEnv("IBMCLOUD_SCC_INSTANCE_ID")
-	if !ok {
-		t.Logf("Missing the env var IBMCLOUD_SCC_INSTANCE_ID.")
-	}
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { acc.TestAccPreCheckSccInstanceID(t) },
+		PreCheck:     func() { acc.TestAccPreCheckScc(t) },
 		Providers:    acc.TestAccProviders,
 		CheckDestroy: testAccCheckIbmSccRuleDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckIbmSccRuleConfig(instanceID, description, version),
+				Config: testAccCheckIbmSccRuleConfig(acc.SccInstanceID, description, version),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckIbmSccRuleExists("ibm_scc_rule.scc_rule_instance", conf),
 					resource.TestCheckResourceAttr("ibm_scc_rule.scc_rule_instance", "description", description),
@@ -74,7 +64,7 @@ func TestAccIbmSccRuleAllArgs(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccCheckIbmSccRuleConfig(instanceID, descriptionUpdate, versionUpdate),
+				Config: testAccCheckIbmSccRuleConfig(acc.SccInstanceID, descriptionUpdate, versionUpdate),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr("ibm_scc_rule.scc_rule_instance", "description", descriptionUpdate),
 					resource.TestCheckResourceAttr("ibm_scc_rule.scc_rule_instance", "version", versionUpdate),

--- a/website/docs/d/scc_control_library.html.markdown
+++ b/website/docs/d/scc_control_library.html.markdown
@@ -10,10 +10,13 @@ subcategory: "Security and Compliance Center"
 
 Retrieve information about a scc_control_library from a read-only data source. Then, you can reference the fields of the data source in other resources within the same configuration by using interpolation syntax.
 
+~> NOTE: if you specify the `region` in the provider, that region will become the default URL. Else, exporting the environmental variable IBMCLOUD_SCC_API_ENDPOINT will override any URL(ex. `export IBMCLOUD_SCC_API_ENDPOINT=https://us-south.compliance.ibm.com`).
+
 ## Example Usage
 
 ```hcl
 data "ibm_scc_control_library" "scc_control_library" {
+    instance_id = "00000000-1111-2222-3333-444444444444"
 	control_library_id = ibm_scc_control_library.scc_control_library_instance.controlLibrary_id
 }
 ```
@@ -24,6 +27,7 @@ You can specify the following arguments for this data source.
 
 * `control_library_id` - (Required, Forces new resource, String) The control library ID.
   * Constraints: The maximum length is `256` characters. The minimum length is `1` character. The value must match regular expression `/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/`.
+* `instance_id` - (Required, Forces new resource, String) The ID of the SCC instance in a particular region.
 
 ## Attribute Reference
 

--- a/website/docs/d/scc_control_library.html.markdown
+++ b/website/docs/d/scc_control_library.html.markdown
@@ -17,7 +17,7 @@ Retrieve information about a scc_control_library from a read-only data source. T
 ```hcl
 data "ibm_scc_control_library" "scc_control_library" {
     instance_id = "00000000-1111-2222-3333-444444444444"
-	control_library_id = ibm_scc_control_library.scc_control_library_instance.controlLibrary_id
+    control_library_id = "aaaaaaaa-1111-bbbb-2222-cccccccccccc"
 }
 ```
 

--- a/website/docs/d/scc_instance_settings.html.markdown
+++ b/website/docs/d/scc_instance_settings.html.markdown
@@ -15,8 +15,11 @@ Provides a read-only data source to retrieve information about scc_instance_sett
 
 ```hcl
 resource "ibm_scc_instance_settings" "scc_instance_settings_instance" {
+  instance_id = "00000000-1111-2222-3333-444444444444"
 }
 ```
+## Argument Reference
+
 
 ## Attribute Reference
 

--- a/website/docs/d/scc_latest_reports.html.markdown
+++ b/website/docs/d/scc_latest_reports.html.markdown
@@ -10,10 +10,13 @@ subcategory: "Security and Compliance Center"
 
 Retrieve information about the latest reports from a read-only data source. Then, you can reference the fields of the data source in other resources within the same configuration by using interpolation syntax.
 
+~> NOTE: if you specify the `region` in the provider, that region will become the default URL. Else, exporting the environmental variable IBMCLOUD_SCC_API_ENDPOINT will override any URL(ex. `export IBMCLOUD_SCC_API_ENDPOINT=https://us-south.compliance.ibm.com`).
+
 ## Example Usage
 
 ```hcl
 data "ibm_scc_latest_reports" "scc_latest_reports" {
+    instance_id = "00000000-1111-2222-3333-444444444444"
 	sort = "profile_name"
 }
 ```
@@ -24,6 +27,7 @@ You can specify the following arguments for this data source.
 
 * `sort` - (Optional, String) This field sorts results by using a valid sort field. To learn more, see [Sorting](https://cloud.ibm.com/docs/api-handbook?topic=api-handbook-sorting).
   * Constraints: The maximum length is `32` characters. The minimum length is `1` character. The value must match regular expression `/^[\\-]?[a-z0-9_]+$/`.
+* `instance_id` - (Required, Forces new resource, String) The ID of the SCC instance in a particular region.
 
 ## Attribute Reference
 

--- a/website/docs/d/scc_latest_reports.html.markdown
+++ b/website/docs/d/scc_latest_reports.html.markdown
@@ -17,7 +17,7 @@ Retrieve information about the latest reports from a read-only data source. Then
 ```hcl
 data "ibm_scc_latest_reports" "scc_latest_reports" {
     instance_id = "00000000-1111-2222-3333-444444444444"
-	sort = "profile_name"
+    sort = "profile_name"
 }
 ```
 

--- a/website/docs/d/scc_profile.html.markdown
+++ b/website/docs/d/scc_profile.html.markdown
@@ -16,8 +16,8 @@ Retrieve information about a profile from a read-only data source. Then, you can
 
 ```hcl
 data "ibm_scc_profile" "scc_profile" {
-	instance_id = "00000000-1111-2222-3333-444444444444"
-	profile_id = ibm_scc_profile.scc_profile_instance.profile_id
+    instance_id = "00000000-1111-2222-3333-444444444444"
+    profile_id = ibm_scc_profile.scc_profile_instance.profile_id
 }
 ```
 

--- a/website/docs/d/scc_profile.html.markdown
+++ b/website/docs/d/scc_profile.html.markdown
@@ -10,10 +10,13 @@ subcategory: "Security and Compliance Center"
 
 Retrieve information about a profile from a read-only data source. Then, you can reference the fields of the data source in other resources within the same configuration by using interpolation syntax.
 
+~> NOTE: if you specify the `region` in the provider, that region will become the default URL. Else, exporting the environmental variable IBMCLOUD_SCC_API_ENDPOINT will override any URL(ex. `export IBMCLOUD_SCC_API_ENDPOINT=https://us-south.compliance.ibm.com`).
+
 ## Example Usage
 
 ```hcl
 data "ibm_scc_profile" "scc_profile" {
+	instance_id = "00000000-1111-2222-3333-444444444444"
 	profile_id = ibm_scc_profile.scc_profile_instance.profile_id
 }
 ```
@@ -22,6 +25,7 @@ data "ibm_scc_profile" "scc_profile" {
 
 You can specify the following arguments for this data source.
 
+* `instance_id` - (Required, Forces new resource, String) The ID of the SCC instance in a particular region.
 * `profile_id` - (Required, Forces new resource, String) The profile ID.
   * Constraints: The maximum length is `36` characters. The minimum length is `36` characters. The value must match regular expression `/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/`.
 

--- a/website/docs/d/scc_profile_attachment.html.markdown
+++ b/website/docs/d/scc_profile_attachment.html.markdown
@@ -16,9 +16,9 @@ Retrieve information about a profile attachment from a read-only data source. Th
 
 ```hcl
 data "ibm_scc_profile_attachment" "scc_profile_attachment" {
-	instance_id = "00000000-1111-2222-3333-444444444444"
-	attachment_id = "attachment_id"
-	profile_id = ibm_scc_profile_attachment.scc_profile_attachment.profiles_id
+    instance_id = "00000000-1111-2222-3333-444444444444"
+    attachment_id = "attachment_id"
+    profile_id = ibm_scc_profile_attachment.scc_profile_attachment.profiles_id
 }
 ```
 

--- a/website/docs/d/scc_profile_attachment.html.markdown
+++ b/website/docs/d/scc_profile_attachment.html.markdown
@@ -10,10 +10,13 @@ subcategory: "Security and Compliance Center"
 
 Retrieve information about a profile attachment from a read-only data source. Then, you can reference the fields of the data source in other resources within the same configuration by using interpolation syntax.
 
+~> NOTE: if you specify the `region` in the provider, that region will become the default URL. Else, exporting the environmental variable IBMCLOUD_SCC_API_ENDPOINT will override any URL(ex. `export IBMCLOUD_SCC_API_ENDPOINT=https://us-south.compliance.ibm.com`).
+
 ## Example Usage
 
 ```hcl
 data "ibm_scc_profile_attachment" "scc_profile_attachment" {
+	instance_id = "00000000-1111-2222-3333-444444444444"
 	attachment_id = "attachment_id"
 	profile_id = ibm_scc_profile_attachment.scc_profile_attachment.profiles_id
 }
@@ -23,6 +26,7 @@ data "ibm_scc_profile_attachment" "scc_profile_attachment" {
 
 You can specify the following arguments for this data source.
 
+* `instance_id` - (Required, Forces new resource, String) The ID of the SCC instance in a particular region.
 * `attachment_id` - (Required, Forces new resource, String) The attachment ID.
   * Constraints: The maximum length is `36` characters. The minimum length is `36` characters. The value must match regular expression `/^[0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-4[0-9A-Fa-f]{3}-[89ABab][0-9A-Fa-f]{3}-[0-9A-Fa-f]{12}$|^$/`.
 * `profile_id` - (Required, Forces new resource, String) The profile ID.

--- a/website/docs/d/scc_provider_type.html.markdown
+++ b/website/docs/d/scc_provider_type.html.markdown
@@ -16,8 +16,7 @@ Retrieve information about a provider type from a read-only data source. Then, y
 
 ```hcl
 data "ibm_scc_provider_type" "scc_provider_type" {
-	instance_id = "00000000-1111-2222-3333-444444444444"
-	provider_type_id = "provider_type_id"
+    provider_type_id = "provider_type_id"
 }
 ```
 
@@ -25,7 +24,6 @@ data "ibm_scc_provider_type" "scc_provider_type" {
 
 You can specify the following arguments for this data source.
 
-* `instance_id` - (Required, Forces new resource, String) The ID of the SCC instance in a particular region.
 * `provider_type_id` - (Required, Forces new resource, String) The provider type ID.
   * Constraints: The maximum length is `36` characters. The minimum length is `32` characters. The value must match regular expression `/^[a-zA-Z0-9 ,\\-_]+$/`.
 

--- a/website/docs/d/scc_provider_type.html.markdown
+++ b/website/docs/d/scc_provider_type.html.markdown
@@ -10,10 +10,13 @@ subcategory: "Security and Compliance Center"
 
 Retrieve information about a provider type from a read-only data source. Then, you can reference the fields of the data source in other resources within the same configuration by using interpolation syntax.
 
+~> NOTE: if you specify the `region` in the provider, that region will become the default URL. Else, exporting the environmental variable IBMCLOUD_SCC_API_ENDPOINT will override any URL(ex. `export IBMCLOUD_SCC_API_ENDPOINT=https://us-south.compliance.ibm.com`).
+
 ## Example Usage
 
 ```hcl
 data "ibm_scc_provider_type" "scc_provider_type" {
+	instance_id = "00000000-1111-2222-3333-444444444444"
 	provider_type_id = "provider_type_id"
 }
 ```
@@ -22,6 +25,7 @@ data "ibm_scc_provider_type" "scc_provider_type" {
 
 You can specify the following arguments for this data source.
 
+* `instance_id` - (Required, Forces new resource, String) The ID of the SCC instance in a particular region.
 * `provider_type_id` - (Required, Forces new resource, String) The provider type ID.
   * Constraints: The maximum length is `36` characters. The minimum length is `32` characters. The value must match regular expression `/^[a-zA-Z0-9 ,\\-_]+$/`.
 

--- a/website/docs/d/scc_provider_type_collection.html.markdown
+++ b/website/docs/d/scc_provider_type_collection.html.markdown
@@ -10,12 +10,21 @@ subcategory: "Security and Compliance Center"
 
 Retrieve information about a provider type collection from a read-only data source. Then, you can reference the fields of the data source in other resources within the same configuration by using interpolation syntax.
 
+~> NOTE: if you specify the `region` in the provider, that region will become the default URL. Else, exporting the environmental variable IBMCLOUD_SCC_API_ENDPOINT will override any URL(ex. `export IBMCLOUD_SCC_API_ENDPOINT=https://us-south.compliance.ibm.com`).
+
 ## Example Usage
 
 ```hcl
 data "ibm_scc_provider_type_collection" "scc_provider_type_collection" {
+	instance_id = "00000000-1111-2222-3333-444444444444"
 }
 ```
+
+## Argument Reference
+
+You can specify the following arguments for this data source.
+
+* `instance_id` - (Required, Forces new resource, String) The ID of the SCC instance in a particular region.
 
 ## Attribute Reference
 

--- a/website/docs/d/scc_provider_type_collection.html.markdown
+++ b/website/docs/d/scc_provider_type_collection.html.markdown
@@ -16,15 +16,8 @@ Retrieve information about a provider type collection from a read-only data sour
 
 ```hcl
 data "ibm_scc_provider_type_collection" "scc_provider_type_collection" {
-	instance_id = "00000000-1111-2222-3333-444444444444"
 }
 ```
-
-## Argument Reference
-
-You can specify the following arguments for this data source.
-
-* `instance_id` - (Required, Forces new resource, String) The ID of the SCC instance in a particular region.
 
 ## Attribute Reference
 

--- a/website/docs/d/scc_provider_type_instance.html.markdown
+++ b/website/docs/d/scc_provider_type_instance.html.markdown
@@ -16,9 +16,9 @@ Retrieve information about a provider type instance from a read-only data source
 
 ```hcl
 data "ibm_scc_provider_type_instance" "scc_provider_type_instance" {
-  instance_id = "00000000-1111-2222-3333-444444444444"
-	provider_type_id = ibm_scc_provider_type_instance.scc_provider_type_instance.provider_type_id
-	provider_type_instance_id = ibm_scc_provider_type_instance.scc_provider_type_instance_instance.providerTypeInstanceItem_id
+    instance_id = "00000000-1111-2222-3333-444444444444"
+    provider_type_id = ibm_scc_provider_type_instance.scc_provider_type_instance.provider_type_id
+    provider_type_instance_id = ibm_scc_provider_type_instance.scc_provider_type_instance_instance.providerTypeInstanceItem_id
 }
 ```
 

--- a/website/docs/d/scc_provider_type_instance.html.markdown
+++ b/website/docs/d/scc_provider_type_instance.html.markdown
@@ -10,10 +10,13 @@ subcategory: "Security and Compliance Center"
 
 Retrieve information about a provider type instance from a read-only data source. Then, you can reference the fields of the data source in other resources within the same configuration by using interpolation syntax.
 
+~> NOTE: if you specify the `region` in the provider, that region will become the default URL. Else, exporting the environmental variable IBMCLOUD_SCC_API_ENDPOINT will override any URL(ex. `export IBMCLOUD_SCC_API_ENDPOINT=https://us-south.compliance.ibm.com`).
+
 ## Example Usage
 
 ```hcl
 data "ibm_scc_provider_type_instance" "scc_provider_type_instance" {
+  instance_id = "00000000-1111-2222-3333-444444444444"
 	provider_type_id = ibm_scc_provider_type_instance.scc_provider_type_instance.provider_type_id
 	provider_type_instance_id = ibm_scc_provider_type_instance.scc_provider_type_instance_instance.providerTypeInstanceItem_id
 }
@@ -23,6 +26,7 @@ data "ibm_scc_provider_type_instance" "scc_provider_type_instance" {
 
 You can specify the following arguments for this data source.
 
+* `instance_id` - (Required, Forces new resource, String) The ID of the SCC instance in a particular region.
 * `provider_type_id` - (Required, Forces new resource, String) The provider type ID.
   * Constraints: The maximum length is `36` characters. The minimum length is `32` characters. The value must match regular expression `/^[a-zA-Z0-9 ,\\-_]+$/`.
 * `provider_type_instance_id` - (Required, Forces new resource, String) The provider type instance ID.

--- a/website/docs/d/scc_provider_type_instance.html.markdown
+++ b/website/docs/d/scc_provider_type_instance.html.markdown
@@ -3,7 +3,7 @@ layout: "ibm"
 page_title: "IBM : ibm_scc_provider_type_instance"
 description: |-
   Get information about scc_provider_type_instance
-subcategory: "Security and Compliance Center APIs"
+subcategory: "Security and Compliance Center"
 ---
 
 # ibm_scc_provider_type_instance

--- a/website/docs/d/scc_report.html.markdown
+++ b/website/docs/d/scc_report.html.markdown
@@ -10,10 +10,13 @@ subcategory: "Security and Compliance Center"
 
 Retrieve information about a report from a read-only data source. Then, you can reference the fields of the data source in other resources within the same configuration by using interpolation syntax.
 
+~> NOTE: if you specify the `region` in the provider, that region will become the default URL. Else, exporting the environmental variable IBMCLOUD_SCC_API_ENDPOINT will override any URL(ex. `export IBMCLOUD_SCC_API_ENDPOINT=https://us-south.compliance.ibm.com`).
+
 ## Example Usage
 
 ```hcl
 data "ibm_scc_report" "scc_report" {
+	instance_id = "00000000-1111-2222-3333-444444444444"
 	report_id = "report_id"
 }
 ```
@@ -22,6 +25,7 @@ data "ibm_scc_report" "scc_report" {
 
 You can specify the following arguments for this data source.
 
+* `instance_id` - (Required, Forces new resource, String) The ID of the SCC instance in a particular region.
 * `report_id` - (Required, Forces new resource, String) The ID of the scan that is associated with a report.
   * Constraints: The maximum length is `128` characters. The minimum length is `1` character. The value must match regular expression `/^[a-zA-Z0-9\\-]+$/`.
 

--- a/website/docs/d/scc_report.html.markdown
+++ b/website/docs/d/scc_report.html.markdown
@@ -16,8 +16,8 @@ Retrieve information about a report from a read-only data source. Then, you can 
 
 ```hcl
 data "ibm_scc_report" "scc_report" {
-	instance_id = "00000000-1111-2222-3333-444444444444"
-	report_id = "report_id"
+    instance_id = "00000000-1111-2222-3333-444444444444"
+    report_id = "report_id"
 }
 ```
 

--- a/website/docs/d/scc_report_controls.html.markdown
+++ b/website/docs/d/scc_report_controls.html.markdown
@@ -10,10 +10,13 @@ subcategory: "Security and Compliance Center"
 
 Retrieve information about report controls from a read-only data source. Then, you can reference the fields of the data source in other resources within the same configuration by using interpolation syntax.
 
+~> NOTE: if you specify the `region` in the provider, that region will become the default URL. Else, exporting the environmental variable IBMCLOUD_SCC_API_ENDPOINT will override any URL(ex. `export IBMCLOUD_SCC_API_ENDPOINT=https://us-south.compliance.ibm.com`).
+
 ## Example Usage
 
 ```hcl
 data "ibm_scc_report_controls" "scc_report_controls" {
+	instance_id = "00000000-1111-2222-3333-444444444444"
 	report_id = "report_id"
 	status = "compliant"
 }
@@ -23,6 +26,7 @@ data "ibm_scc_report_controls" "scc_report_controls" {
 
 You can specify the following arguments for this data source.
 
+* `instance_id` - (Required, Forces new resource, String) The ID of the SCC instance in a particular region.
 * `control_category` - (Optional, String) A control category value.
   * Constraints: The maximum length is `1024` characters. The minimum length is `1` character. The value must match regular expression `/^[a-zA-Z0-9\\-]+$/`.
 * `control_description` - (Optional, String) The description of the control.

--- a/website/docs/d/scc_report_controls.html.markdown
+++ b/website/docs/d/scc_report_controls.html.markdown
@@ -16,9 +16,9 @@ Retrieve information about report controls from a read-only data source. Then, y
 
 ```hcl
 data "ibm_scc_report_controls" "scc_report_controls" {
-	instance_id = "00000000-1111-2222-3333-444444444444"
-	report_id = "report_id"
-	status = "compliant"
+    instance_id = "00000000-1111-2222-3333-444444444444"
+    report_id = "report_id"
+    status = "compliant"
 }
 ```
 

--- a/website/docs/d/scc_report_evaluations.html.markdown
+++ b/website/docs/d/scc_report_evaluations.html.markdown
@@ -16,9 +16,9 @@ Retrieve information about report evaluations from a read-only data source. Then
 
 ```hcl
 data "ibm_scc_report_evaluations" "scc_report_evaluations" {
-	instance_id = "00000000-1111-2222-3333-444444444444"
-	report_id = "report_id"
-	status = "failure"
+    instance_id = "00000000-1111-2222-3333-444444444444"
+    report_id = "report_id"
+    status = "failure"
 }
 ```
 

--- a/website/docs/d/scc_report_evaluations.html.markdown
+++ b/website/docs/d/scc_report_evaluations.html.markdown
@@ -10,10 +10,13 @@ subcategory: "Security and Compliance Center"
 
 Retrieve information about report evaluations from a read-only data source. Then, you can reference the fields of the data source in other resources within the same configuration by using interpolation syntax.
 
+~> NOTE: if you specify the `region` in the provider, that region will become the default URL. Else, exporting the environmental variable IBMCLOUD_SCC_API_ENDPOINT will override any URL(ex. `export IBMCLOUD_SCC_API_ENDPOINT=https://us-south.compliance.ibm.com`).
+
 ## Example Usage
 
 ```hcl
 data "ibm_scc_report_evaluations" "scc_report_evaluations" {
+	instance_id = "00000000-1111-2222-3333-444444444444"
 	report_id = "report_id"
 	status = "failure"
 }
@@ -23,6 +26,7 @@ data "ibm_scc_report_evaluations" "scc_report_evaluations" {
 
 You can specify the following arguments for this data source.
 
+* `instance_id` - (Required, Forces new resource, String) The ID of the SCC instance in a particular region.
 * `assessment_id` - (Optional, String) The ID of the assessment.
   * Constraints: The maximum length is `128` characters. The minimum length is `1` character. The value must match regular expression `/^[a-zA-Z0-9\\-]+$/`.
 * `component_id` - (Optional, String) The ID of component.

--- a/website/docs/d/scc_report_resources.html.markdown
+++ b/website/docs/d/scc_report_resources.html.markdown
@@ -10,10 +10,13 @@ subcategory: "Security and Compliance Center"
 
 Retrieve information about report resources from a read-only data source. Then, you can reference the fields of the data source in other resources within the same configuration by using interpolation syntax.
 
+~> NOTE: if you specify the `region` in the provider, that region will become the default URL. Else, exporting the environmental variable IBMCLOUD_SCC_API_ENDPOINT will override any URL(ex. `export IBMCLOUD_SCC_API_ENDPOINT=https://us-south.compliance.ibm.com`).
+
 ## Example Usage
 
 ```hcl
 data "ibm_scc_report_resources" "scc_report_resources" {
+	instance_id = "00000000-1111-2222-3333-444444444444"
 	report_id = "report_id"
 	status = "compliant"
 }
@@ -23,6 +26,7 @@ data "ibm_scc_report_resources" "scc_report_resources" {
 
 You can specify the following arguments for this data source.
 
+* `instance_id` - (Required, Forces new resource, String) The ID of the SCC instance in a particular region.
 * `account_id` - (Optional, String) The ID of the account owning a resource.
   * Constraints: The maximum length is `128` characters. The minimum length is `1` character. The value must match regular expression `/^[a-zA-Z0-9\\-]+$/`.
 * `component_id` - (Optional, String) The ID of component.

--- a/website/docs/d/scc_report_resources.html.markdown
+++ b/website/docs/d/scc_report_resources.html.markdown
@@ -16,9 +16,9 @@ Retrieve information about report resources from a read-only data source. Then, 
 
 ```hcl
 data "ibm_scc_report_resources" "scc_report_resources" {
-	instance_id = "00000000-1111-2222-3333-444444444444"
-	report_id = "report_id"
-	status = "compliant"
+    instance_id = "00000000-1111-2222-3333-444444444444"
+    report_id = "report_id"
+    status = "compliant"
 }
 ```
 

--- a/website/docs/d/scc_report_rule.html.markdown
+++ b/website/docs/d/scc_report_rule.html.markdown
@@ -16,9 +16,9 @@ Retrieve information about a report rule from a read-only data source. Then, you
 
 ```hcl
 data "ibm_scc_report_rule" "scc_report_rule" {
-  instance_id = "00000000-1111-2222-3333-444444444444"
-	report_id = "report_id"
-	rule_id = "rule-8d444f8c-fd1d-48de-bcaa-f43732568761"
+    instance_id = "00000000-1111-2222-3333-444444444444"
+    report_id = "report_id"
+    rule_id = "rule-8d444f8c-fd1d-48de-bcaa-f43732568761"
 }
 ```
 

--- a/website/docs/d/scc_report_rule.html.markdown
+++ b/website/docs/d/scc_report_rule.html.markdown
@@ -10,10 +10,13 @@ subcategory: "Security and Compliance Center"
 
 Retrieve information about a report rule from a read-only data source. Then, you can reference the fields of the data source in other resources within the same configuration by using interpolation syntax.
 
+~> NOTE: if you specify the `region` in the provider, that region will become the default URL. Else, exporting the environmental variable IBMCLOUD_SCC_API_ENDPOINT will override any URL(ex. `export IBMCLOUD_SCC_API_ENDPOINT=https://us-south.compliance.ibm.com`).
+
 ## Example Usage
 
 ```hcl
 data "ibm_scc_report_rule" "scc_report_rule" {
+  instance_id = "00000000-1111-2222-3333-444444444444"
 	report_id = "report_id"
 	rule_id = "rule-8d444f8c-fd1d-48de-bcaa-f43732568761"
 }
@@ -23,6 +26,7 @@ data "ibm_scc_report_rule" "scc_report_rule" {
 
 You can specify the following arguments for this data source.
 
+* `instance_id` - (Required, Forces new resource, String) The ID of the SCC instance in a particular region.
 * `report_id` - (Required, Forces new resource, String) The ID of the scan that is associated with a report.
   * Constraints: The maximum length is `128` characters. The minimum length is `1` character. The value must match regular expression `/^[a-zA-Z0-9\\-]+$/`.
 * `rule_id` - (Required, Forces new resource, String) The ID of a rule in a report.

--- a/website/docs/d/scc_report_summary.html.markdown
+++ b/website/docs/d/scc_report_summary.html.markdown
@@ -16,7 +16,7 @@ Retrieve information about a report summary from a read-only data source. Then, 
 
 ```hcl
 data "ibm_scc_report_summary" "scc_report_summary" {
-	instance_id = "00000000-1111-2222-3333-444444444444"
+    instance_id = "00000000-1111-2222-3333-444444444444"
 	report_id = "report_id"
 }
 ```

--- a/website/docs/d/scc_report_summary.html.markdown
+++ b/website/docs/d/scc_report_summary.html.markdown
@@ -10,10 +10,13 @@ subcategory: "Security and Compliance Center"
 
 Retrieve information about a report summary from a read-only data source. Then, you can reference the fields of the data source in other resources within the same configuration by using interpolation syntax.
 
+~> NOTE: if you specify the `region` in the provider, that region will become the default URL. Else, exporting the environmental variable IBMCLOUD_SCC_API_ENDPOINT will override any URL(ex. `export IBMCLOUD_SCC_API_ENDPOINT=https://us-south.compliance.ibm.com`).
+
 ## Example Usage
 
 ```hcl
 data "ibm_scc_report_summary" "scc_report_summary" {
+	instance_id = "00000000-1111-2222-3333-444444444444"
 	report_id = "report_id"
 }
 ```
@@ -22,6 +25,7 @@ data "ibm_scc_report_summary" "scc_report_summary" {
 
 You can specify the following arguments for this data source.
 
+* `instance_id` - (Required, Forces new resource, String) The ID of the SCC instance in a particular region.
 * `report_id` - (Required, Forces new resource, String) The ID of the scan that is associated with a report.
   * Constraints: The maximum length is `128` characters. The minimum length is `1` character. The value must match regular expression `/^[a-zA-Z0-9\\-]+$/`.
 

--- a/website/docs/d/scc_report_tags.html.markdown
+++ b/website/docs/d/scc_report_tags.html.markdown
@@ -10,10 +10,13 @@ subcategory: "Security and Compliance Center"
 
 Retrieve information about report tags from a read-only data source. Then, you can reference the fields of the data source in other resources within the same configuration by using interpolation syntax.
 
+~> NOTE: if you specify the `region` in the provider, that region will become the default URL. Else, exporting the environmental variable IBMCLOUD_SCC_API_ENDPOINT will override any URL(ex. `export IBMCLOUD_SCC_API_ENDPOINT=https://us-south.compliance.ibm.com`).
+
 ## Example Usage
 
 ```hcl
 data "ibm_scc_report_tags" "scc_report_tags" {
+	instance_id = "00000000-1111-2222-3333-444444444444"
 	report_id = "report_id"
 }
 ```
@@ -22,6 +25,7 @@ data "ibm_scc_report_tags" "scc_report_tags" {
 
 You can specify the following arguments for this data source.
 
+* `instance_id` - (Required, Forces new resource, String) The ID of the SCC instance in a particular region.
 * `report_id` - (Required, Forces new resource, String) The ID of the scan that is associated with a report.
   * Constraints: The maximum length is `128` characters. The minimum length is `1` character. The value must match regular expression `/^[a-zA-Z0-9\\-]+$/`.
 

--- a/website/docs/d/scc_report_tags.html.markdown
+++ b/website/docs/d/scc_report_tags.html.markdown
@@ -16,8 +16,8 @@ Retrieve information about report tags from a read-only data source. Then, you c
 
 ```hcl
 data "ibm_scc_report_tags" "scc_report_tags" {
-	instance_id = "00000000-1111-2222-3333-444444444444"
-	report_id = "report_id"
+    instance_id = "00000000-1111-2222-3333-444444444444"
+    report_id = "report_id"
 }
 ```
 

--- a/website/docs/d/scc_report_violation_drift.html.markdown
+++ b/website/docs/d/scc_report_violation_drift.html.markdown
@@ -10,10 +10,13 @@ subcategory: "Security and Compliance Center"
 
 Retrieve information about a report violation drift from a read-only data source. Then, yo can reference the fields of the data source in other resources within the same configuration by using interpolation syntax.
 
+~> NOTE: if you specify the `region` in the provider, that region will become the default URL. Else, exporting the environmental variable IBMCLOUD_SCC_API_ENDPOINT will override any URL(ex. `export IBMCLOUD_SCC_API_ENDPOINT=https://us-south.compliance.ibm.com`).
+
 ## Example Usage
 
 ```hcl
 data "ibm_scc_report_violation_drift" "scc_report_violation_drift" {
+	instance_id = "00000000-1111-2222-3333-444444444444"
 	report_id = "report_id"
 }
 ```
@@ -22,6 +25,7 @@ data "ibm_scc_report_violation_drift" "scc_report_violation_drift" {
 
 You can specify the following arguments for this data source.
 
+* `instance_id` - (Required, Forces new resource, String) The ID of the SCC instance in a particular region.
 * `report_id` - (Required, Forces new resource, String) The ID of the scan that is associated with a report.
   * Constraints: The maximum length is `128` characters. The minimum length is `1` character. The value must match regular expression `/^[a-zA-Z0-9\\-]+$/`.
 * `scan_time_duration` - (Optional, Integer) The duration of the `scan_time` timestamp in number of days.

--- a/website/docs/d/scc_report_violation_drift.html.markdown
+++ b/website/docs/d/scc_report_violation_drift.html.markdown
@@ -16,8 +16,8 @@ Retrieve information about a report violation drift from a read-only data source
 
 ```hcl
 data "ibm_scc_report_violation_drift" "scc_report_violation_drift" {
-	instance_id = "00000000-1111-2222-3333-444444444444"
-	report_id = "report_id"
+    instance_id = "00000000-1111-2222-3333-444444444444"
+    report_id = "report_id"
 }
 ```
 

--- a/website/docs/d/scc_rule.html.markdown
+++ b/website/docs/d/scc_rule.html.markdown
@@ -16,8 +16,8 @@ Retrieve information about a rule from a read-only data source. Then, you can re
 
 ```hcl
 data "ibm_scc_rule" "scc_rule" {
-	instance_id = "00000000-1111-2222-3333-444444444444"
-	rule_id = ibm_scc_rule.scc_rule_instance.rule_id
+    instance_id = "00000000-1111-2222-3333-444444444444"
+    rule_id = ibm_scc_rule.scc_rule_instance.rule_id
 }
 ```
 

--- a/website/docs/d/scc_rule.html.markdown
+++ b/website/docs/d/scc_rule.html.markdown
@@ -10,10 +10,13 @@ subcategory: "Security and Compliance Center"
 
 Retrieve information about a rule from a read-only data source. Then, you can reference the fields of the data source in other resources within the same configuration by using interpolation syntax.
 
+~> NOTE: if you specify the `region` in the provider, that region will become the default URL. Else, exporting the environmental variable IBMCLOUD_SCC_API_ENDPOINT will override any URL(ex. `export IBMCLOUD_SCC_API_ENDPOINT=https://us-south.compliance.ibm.com`).
+
 ## Example Usage
 
 ```hcl
 data "ibm_scc_rule" "scc_rule" {
+	instance_id = "00000000-1111-2222-3333-444444444444"
 	rule_id = ibm_scc_rule.scc_rule_instance.rule_id
 }
 ```
@@ -22,6 +25,7 @@ data "ibm_scc_rule" "scc_rule" {
 
 You can specify the following arguments for this data source.
 
+* `instance_id` - (Required, Forces new resource, String) The ID of the SCC instance in a particular region.
 * `rule_id` - (Required, Forces new resource, String) The ID of the corresponding rule.
   * Constraints: The maximum length is `41` characters. The minimum length is `41` characters. The value must match regular expression `/rule-[0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{12}/`.
 

--- a/website/docs/r/scc_control_library.html.markdown
+++ b/website/docs/r/scc_control_library.html.markdown
@@ -10,10 +10,13 @@ subcategory: "Security and Compliance Center"
 
 Create, update, and delete control libraries by using this resource.
 
+~> NOTE: if you specify the `region` in the provider, that region will become the default URL. Else, exporting the environmental variable IBMCLOUD_SCC_API_ENDPOINT will override any URL(ex. `export IBMCLOUD_SCC_API_ENDPOINT=https://us-south.compliance.ibm.com`).
+
 ## Example Usage
 
 ```hcl
 resource "ibm_scc_control_library" "scc_control_library_instance" {
+  instance_id = "00000000-1111-2222-3333-444444444444"
   control_library_description = "control_library_description"
   control_library_name = "control_library_name"
   control_library_type = "predefined"
@@ -60,6 +63,7 @@ resource "ibm_scc_control_library" "scc_control_library_instance" {
 
 You can specify the following arguments for this resource.
 
+* `instance_id` - (Required, Forces new resource, String) The ID of the SCC instance in a particular region.
 * `control_library_description` - (Required, String) The control library description.
   * Constraints: The maximum length is `256` characters. The minimum length is `2` characters. The value must match regular expression `/[A-Za-z0-9]+/`.
 * `control_library_name` - (Required, String) The control library name.
@@ -140,6 +144,7 @@ After your resource is created, you can read values from the listed arguments an
 
 * `controls_count` - (Optional, Integer) The number of controls.
 * `id` - The unique identifier of the scc_control_library.
+* `control_library_id` - (String) The ID that is associated with the created `control_library`
 * `account_id` - (String) The account ID.
   * Constraints: The maximum length is `32` characters. The minimum length is `0` characters. The value must match regular expression `/^[a-zA-Z0-9-]*$/`.
 * `control_parents_count` - (Integer) The number of parent controls in the control library.
@@ -154,14 +159,21 @@ After your resource is created, you can read values from the listed arguments an
 
 ## Import
 
-You can import the `ibm_scc_control_library` resource by using `id`. The control library ID.
+You can import the `ibm_scc_control_library` resource by using `id`.
+The `id` property can be formed from `instance_id` and `control_library_id` in the following format:
+
+```
+<instance_id>/<control_library_id>
+```
+* `instance_id`: A string. The instance ID.
+* `control_library_id`: A string. The control library ID.
 
 # Syntax
 ```
-$ terraform import ibm_scc_control_library.scc_control_library <id>
+$ terraform import ibm_scc_control_library.scc_control_library <instance_id>/<control_library_id>
 ```
 
 # Example
 ```
-$ terraform import ibm_scc_control_library.scc_control_library f3517159-889e-4781-819a-89d89b747c85
+$ terraform import ibm_scc_control_library.scc_control_library 00000000-1111-2222-3333-444444444444/f3517159-889e-4781-819a-89d89b747c85
 ```

--- a/website/docs/r/scc_profile.html.markdown
+++ b/website/docs/r/scc_profile.html.markdown
@@ -10,10 +10,13 @@ subcategory: "Security and Compliance Center"
 
 Create, update, and delete profiles with this resource.
 
+~> NOTE: if you specify the `region` in the provider, that region will become the default URL. Else, exporting the environmental variable IBMCLOUD_SCC_API_ENDPOINT will override any URL(ex. `export IBMCLOUD_SCC_API_ENDPOINT=https://us-south.compliance.ibm.com`).
+
 ## Example Usage
 
 ```hcl
 resource "ibm_scc_profile" "scc_profile_instance" {
+  instance_id = "00000000-1111-2222-3333-444444444444"
   controls {
 		control_library_id = "e98a56ff-dc24-41d4-9875-1e188e2da6cd"
 		control_id = "5C453578-E9A1-421E-AD0F-C6AFCDD67CCF"
@@ -68,6 +71,7 @@ resource "ibm_scc_profile" "scc_profile_instance" {
 
 You can specify the following arguments for this resource.
 
+* `instance_id` - (Required, Forces new resource, String) The ID of the SCC instance in a particular region.
 * `controls` - (Required, List) The array of controls that are used to create the profile.
   * Constraints: The maximum length is `600` items. The minimum length is `0` items.
 Nested schema for **controls**:
@@ -157,6 +161,7 @@ Nested schema for **default_parameters**:
 After your resource is created, you can read values from the listed arguments and the following attributes.
 
 * `id` - The unique identifier of the scc_profile.
+* `profile_id` - (String) The ID that is associated with the created `profile`
 * `attachments_count` - (Integer) The number of attachments related to this profile.
 * `control_parents_count` - (Integer) The number of parent controls for the profile.
 * `controls_count` - (Integer) The number of controls for the profile.
@@ -178,9 +183,16 @@ After your resource is created, you can read values from the listed arguments an
 
 ## Import
 
-You can import the `ibm_scc_profile` resource by using `id`. The unique ID of the profile.
+You can import the `ibm_scc_profile` resource by using `id`.
+The `id` property can be formed from `instance_id` and `profiles_id` in the following format:
+
+```
+<instance_id>/<profile_id>
+```
+* `instance_id`: A string. The instance ID.
+* `profile_id`: A string. The profile ID.
 
 # Syntax
 ```
-$ terraform import ibm_scc_profile.scc_profile <id>
+$ terraform import ibm_scc_profile.scc_profile <instance_id>/<profile_id>
 ```

--- a/website/docs/r/scc_profile_attachment.html.markdown
+++ b/website/docs/r/scc_profile_attachment.html.markdown
@@ -10,11 +10,36 @@ subcategory: "Security and Compliance Center"
 
 Create, update, and delete profile attachments with this resource.
 
+~> NOTE: if you specify the `region` in the provider, that region will become the default URL. Else, exporting the environmental variable IBMCLOUD_SCC_API_ENDPOINT will override any URL(ex. `export IBMCLOUD_SCC_API_ENDPOINT=https://us-south.compliance.ibm.com`).
+
 ## Example Usage
 
 ```hcl
 resource "ibm_scc_profile_attachment" "scc_profile_attachment_instance" {
-  profiles_id = ibm_scc_profile.scc_profile_instance.id
+  profile_id = "a0bd1ee2-1ed3-407e-a2f4-ce7a1a38f54d"
+  instance_id = "34324315-2edc-23dc-2389-34982389834d"
+  name = "profile_attachment_name"
+  description = "scc_profile_attachment_description"
+  scope {
+    environment = "ibm-cloud"	
+    properties {
+      name = "scope_id"
+      value = resource.ibm_scc_control_library.scc_control_library_instance.account_id
+    }
+    properties {
+      name = "scope_type"
+      value = "account"
+    }
+  }
+  schedule = "every_30_days"
+  status = "enabled"
+  notifications {
+    enabled = false
+    controls {
+      failed_control_ids = []
+      threshold_limit = 14
+    }
+  }
 }
 ```
 
@@ -22,6 +47,7 @@ resource "ibm_scc_profile_attachment" "scc_profile_attachment_instance" {
 
 You can specify the following arguments for this resource.
 
+* `instance_id` - (Required, Forces new resource, String) The ID of the SCC instance in a particular region.
 * `profile_id` - (Required, Forces new resource, String) The profile ID.
   * Constraints: The maximum length is `36` characters. The minimum length is `36` characters. The value must match regular expression `/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/`.
 * `scope` - (List) The scope payload for the multi cloud feature.
@@ -44,6 +70,13 @@ Nested schema for **notifications**:
 		  * Constraints: The list items must match regular expression `/^[0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-4[0-9A-Fa-f]{3}-[89ABab][0-9A-Fa-f]{3}-[0-9A-Fa-f]{12}$|^$/`. The maximum length is `512` items. The minimum length is `0` items.
 		* `threshold_limit` - (Integer) The threshold limit.
 	* `enabled` - (Boolean) enabled notifications.
+* `attachment_parameters` - (List) The request payload of the attachment parameters.
+Nested schema for **attachment_parameters**:
+    * `parameter_name` - (String) The name of the parameter to target.
+    * `parameter_display_name` - (String) The display name of the parameter shown in the UI.
+    * `parameter_type` - (String) The type of the parameter value.
+    * `parameter_value` - (String) The value of the parameter.
+    * `assessment_type` - (String) The type of assessment the parameter uses. 
 * `schedule` - (String) The schedule of an attachment evaluation.
   * Constraints: Allowable values are: `daily`, `every_7_days`, `every_30_days`.
 * `name` - (String) The name of the attachment.
@@ -54,6 +87,7 @@ Nested schema for **notifications**:
 After your resource is created, you can read values from the listed arguments and the following attributes.
 
 * `id` - The unique identifier of the scc_profile_attachment.
+* `profile_attachment_id` - (String) The ID that is associated with the created `profile_attachment`
 * `account_id` - (String) The account ID that is associated to the attachment.
   * Constraints: The maximum length is `32` characters. The minimum length is `32` characters. The value must match regular expression `/^[a-zA-Z0-9-]*$/`.
 * `attachment_id` - (String) The ID of the attachment.
@@ -98,15 +132,16 @@ Nested schema for **last_scan**:
 ## Import
 
 You can import the `ibm_scc_profile_attachment` resource by using `id`.
-The `id` property can be formed from `profiles_id`, and `attachment_id` in the following format:
+The `id` property can be formed from `instance_id`, `profiles_id`, and `attachment_id` in the following format:
 
 ```
-<profiles_id>/<attachment_id>
+<instance_id>/<profile_id>/<attachment_id>
 ```
-* `profiles_id`: A string. The profile ID.
+* `instance_id`: A string. The instance ID.
+* `profile_id`: A string. The profile ID.
 * `attachment_id`: A string. The attachment ID.
 
 # Syntax
 ```
-$ terraform import ibm_scc_profile_attachment.scc_profile_attachment <profiles_id>/<attachment_id>
+$ terraform import ibm_scc_profile_attachment.scc_profile_attachment <instance_id>/<profile_id>/<attachment_id>
 ```

--- a/website/docs/r/scc_provider_type_instance.html.markdown
+++ b/website/docs/r/scc_provider_type_instance.html.markdown
@@ -10,10 +10,13 @@ subcategory: "Security and Compliance Center"
 
 Create, update, and delete provider type instances with this resource.
 
+~> NOTE: if you specify the `region` in the provider, that region will become the default URL. Else, exporting the environmental variable IBMCLOUD_SCC_API_ENDPOINT will override any URL(ex. `export IBMCLOUD_SCC_API_ENDPOINT=https://us-south.compliance.ibm.com`).
+
 ## Example Usage
 
 ```hcl
 resource "ibm_scc_provider_type_instance" "scc_provider_type_instance_instance" {
+  instance_id = "00000000-1111-2222-3333-444444444444"
   attributes = {"wp_crn":"crn:v1:staging:public:sysdig-secure:eu-gb:a/14q5SEnVIbwxzvP4AWPCjr2dJg5BAvPb:d1461d1ae-df1eee12fa81812e0-12-aa259::"}
   name = "workload-protection-instance-1"
   provider_type_id = "provider_type_id"
@@ -24,6 +27,7 @@ resource "ibm_scc_provider_type_instance" "scc_provider_type_instance_instance" 
 
 You can specify the following arguments for this resource.
 
+* `instance_id` - (Required, Forces new resource, String) The ID of the SCC instance in a particular region.
 * `attributes` - (Required, Map) The attributes for connecting to the provider type instance.
 * `name` - (Required, String) The name for the provider_type instance
 * `provider_type_id` - (Required, String) The unique identifier of the provider type instance.
@@ -33,6 +37,7 @@ You can specify the following arguments for this resource.
 After your resource is created, you can read values from the listed arguments and the following attributes.
 
 * `id` - The unique identifier of the scc_provider_type_instance.
+* `provider_type_instance_id` - (String) The ID that is associated with the created `provider_type_instance`
 * `created_at` - (String) The time when resource was created.
 * `type` - (String) The type of the provider type.
 * `updated_at` - (String) The time when resource was updated.
@@ -41,15 +46,16 @@ After your resource is created, you can read values from the listed arguments an
 ## Import
 
 You can import the `ibm_scc_provider_type_instance` resource by using `id`.
-The `id` property can be formed from `provider_type_id`, and `provider_type_instance_id` in the following format:
+The `id` property can be formed from `instance_id`, `provider_type_id`, and `provider_type_instance_id` in the following format:
 
 ```
 <provider_type_id>/<provider_type_instance_id>
 ```
+* `instance_id`: A string. The instance ID.
 * `provider_type_id`: A string. The provider type ID.
 * `provider_type_instance_id`: A string. The provider type instance ID.
 
 # Syntax
 ```
-$ terraform import ibm_scc_provider_type_instance.scc_provider_type_instance <provider_type_id>/<provider_type_instance_id>
+$ terraform import ibm_scc_provider_type_instance.scc_provider_type_instance <instance_id>/<provider_type_id>/<provider_type_instance_id>
 ```

--- a/website/docs/r/scc_rule.html.markdown
+++ b/website/docs/r/scc_rule.html.markdown
@@ -10,10 +10,13 @@ subcategory: "Security and Compliance Center"
 
 Create, update, and delete rules with this resource.
 
+~> NOTE: if you specify the `region` in the provider, that region will become the default URL. Else, exporting the environmental variable IBMCLOUD_SCC_API_ENDPOINT will override any URL(ex. `export IBMCLOUD_SCC_API_ENDPOINT=https://us-south.compliance.ibm.com`).
+
 ## Example Usage
 
 ```hcl
 resource "ibm_scc_rule" "scc_rule_instance" {
+  instance_id = "00000000-1111-2222-3333-444444444444"
   description = "Example rule"
   import {
 		parameters {
@@ -60,6 +63,7 @@ scc_rule provides the following [Timeouts](https://www.terraform.io/docs/configu
 
 You can specify the following arguments for this resource.
 
+* `instance_id` - (Required, Forces new resource, String) The ID of the SCC instance in a particular region.
 * `description` - (Required, String) The details of a rule's response.
   * Constraints: The maximum length is `512` characters. The minimum length is `0` characters. The value must match regular expression `/[A-Za-z0-9]+/`.
 * `import` - (Optional, List) The collection of import parameters.
@@ -171,6 +175,7 @@ Nested schema for **target**:
 After your resource is created, you can read values from the listed arguments and the following attributes.
 
 * `id` - The unique identifier of the scc_rule.
+* `rule_id` - (String) The ID that is associated with the created `rule`
 * `account_id` - (String) The account ID.
   * Constraints: The maximum length is `32` characters. The minimum length is `3` characters. The value must match regular expression `/[A-Za-z0-9]+/`.
 * `created_by` - (String) The user who created the rule.
@@ -186,8 +191,15 @@ After your resource is created, you can read values from the listed arguments an
 ## Import
 
 You can import the `ibm_scc_rule` resource by using `id`. The rule ID.
+The `id` property can be formed from `instance_id` and `rule_id` in the following format:
+
+```
+<instance_id>/<rule_id>
+```
+* `instance_id`: A string. The instance ID.
+* `rule_id`: A string. The rule ID.
 
 # Syntax
 ```
-$ terraform import ibm_scc_rule.scc_rule <id>
+$ terraform import ibm_scc_rule.scc_rule <instance_id>/<rule_id>
 ```


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/IBM-Cloud/terraform-provider-ibm/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TEST=./ibm/service/scc
=== RUN   TestAccIbmSccControlLibraryDataSourceBasic
--- PASS: TestAccIbmSccControlLibraryDataSourceBasic (15.21s)
=== RUN   TestAccIbmSccControlLibraryDataSourceAllArgs
--- PASS: TestAccIbmSccControlLibraryDataSourceAllArgs (12.74s)
=== RUN   TestAccIbmSccInstanceSettingsDataSourceBasic
--- PASS: TestAccIbmSccInstanceSettingsDataSourceBasic (10.83s)
=== RUN   TestAccIbmSccLatestReportsDataSourceBasic
--- PASS: TestAccIbmSccLatestReportsDataSourceBasic (13.98s)
=== RUN   TestAccIbmSccProfileAttachmentDataSourceBasic
--- PASS: TestAccIbmSccProfileAttachmentDataSourceBasic (22.13s)
=== RUN   TestAccIbmSccProfileAttachmentDataSourceAllArgs
--- PASS: TestAccIbmSccProfileAttachmentDataSourceAllArgs (25.10s)
=== RUN   TestAccIbmSccProfileDataSourceBasic
--- PASS: TestAccIbmSccProfileDataSourceBasic (17.73s)
=== RUN   TestAccIbmSccProfileDataSourceAllArgs
--- PASS: TestAccIbmSccProfileDataSourceAllArgs (19.89s)
=== RUN   TestAccIbmSccProviderTypeCollectionDataSourceBasic
--- PASS: TestAccIbmSccProviderTypeCollectionDataSourceBasic (8.39s)
=== RUN   TestAccIbmSccProviderTypeInstanceDataSourceBasic
--- PASS: TestAccIbmSccProviderTypeInstanceDataSourceBasic (12.77s)
=== RUN   TestAccIbmSccProviderTypeInstanceDataSourceAllArgs
--- PASS: TestAccIbmSccProviderTypeInstanceDataSourceAllArgs (12.11s)
=== RUN   TestAccIbmSccProviderTypeDataSourceBasic
--- PASS: TestAccIbmSccProviderTypeDataSourceBasic (8.17s)
=== RUN   TestAccIbmSccReportControlsDataSourceBasic
--- PASS: TestAccIbmSccReportControlsDataSourceBasic (15.15s)
=== RUN   TestAccIbmSccReportEvaluationsDataSourceBasic
--- PASS: TestAccIbmSccReportEvaluationsDataSourceBasic (12.70s)
=== RUN   TestAccIbmSccReportResourcesDataSourceBasic
--- PASS: TestAccIbmSccReportResourcesDataSourceBasic (9.31s)
=== RUN   TestAccIbmSccReportRuleDataSourceBasic
--- PASS: TestAccIbmSccReportRuleDataSourceBasic (8.70s)
=== RUN   TestAccIbmSccReportSummaryDataSourceBasic
--- PASS: TestAccIbmSccReportSummaryDataSourceBasic (17.06s)
=== RUN   TestAccIbmSccReportTagsDataSourceBasic
--- PASS: TestAccIbmSccReportTagsDataSourceBasic (8.82s)
=== RUN   TestAccIbmSccReportDataSourceBasic
--- PASS: TestAccIbmSccReportDataSourceBasic (8.62s)
=== RUN   TestAccIbmSccReportViolationDriftDataSourceBasic
--- PASS: TestAccIbmSccReportViolationDriftDataSourceBasic (8.60s)
=== RUN   TestAccIbmSccRuleDataSourceBasic
--- PASS: TestAccIbmSccRuleDataSourceBasic (14.19s)
=== RUN   TestAccIbmSccRuleDataSourceAllArgs
--- PASS: TestAccIbmSccRuleDataSourceAllArgs (16.82s)
=== RUN   TestAccIbmSccControlLibraryBasic
--- PASS: TestAccIbmSccControlLibraryBasic (18.28s)
=== RUN   TestAccIbmSccControlLibraryAllArgs
--- PASS: TestAccIbmSccControlLibraryAllArgs (20.97s)
=== RUN   TestAccIbmSccProfileAttachmentBasic
--- PASS: TestAccIbmSccProfileAttachmentBasic (17.24s)
=== RUN   TestAccIbmSccProfileAttachmentAllArgs
--- PASS: TestAccIbmSccProfileAttachmentAllArgs (25.76s)
=== RUN   TestAccIbmSccProfileBasic
--- PASS: TestAccIbmSccProfileBasic (20.45s)
=== RUN   TestAccIbmSccProfileAllArgs
--- PASS: TestAccIbmSccProfileAllArgs (23.31s)
=== RUN   TestAccIbmSccProviderTypeInstanceBasic
--- PASS: TestAccIbmSccProviderTypeInstanceBasic (18.62s)
=== RUN   TestAccIbmSccProviderTypeInstanceAllArgs
--- PASS: TestAccIbmSccProviderTypeInstanceAllArgs (21.09s)
=== RUN   TestAccIbmSccRuleBasic
--- PASS: TestAccIbmSccRuleBasic (23.35s)
=== RUN   TestAccIbmSccRuleAllArgs
--- PASS: TestAccIbmSccRuleAllArgs (31.99s)
PASS
ok      github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/scc     520.609s
...
```
