### PR TITLE
Fix typo in example for sm_imported_certificate resource

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "go.mod|go.sum|.*.map|^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2023-09-19T16:31:40Z",
+  "generated_at": "2023-10-06T11:01:49Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -4758,7 +4758,7 @@
       }
     ]
   },
-  "version": "0.13.1+ibm.52.dss",
+  "version": "0.13.1+ibm.61.dss",
   "word_list": {
     "file": null,
     "hash": null

--- a/website/docs/r/sm_imported_certificate.html.markdown
+++ b/website/docs/r/sm_imported_certificate.html.markdown
@@ -21,7 +21,7 @@ resource "ibm_sm_imported_certificate" "sm_imported_certificate" {
   description = "Extended description for this secret."
   labels = ["my-label"]
   secret_group_id = ibm_sm_secret_group.sm_secret_group.secret_group_id
-  certificate: "-----BEGIN CERTIFICATE-----\nMIIE3jCCBGSgAwIBAgIUZfTbf3adn87l5J2Q2Aw+6Vk/qhowCgYIKoZIzj0EAwIw\n-----END CERTIFICATE-----"
+  certificate = "-----BEGIN CERTIFICATE-----\nMIIE3jCCBGSgAwIBAgIUZfTbf3adn87l5J2Q2Aw+6Vk/qhowCgYIKoZIzj0EAwIw\n-----END CERTIFICATE-----"
 }
 ```
 


### PR DESCRIPTION
Fix typo in the doc 

---
![Screenshot 2023-10-06 at 12 11 12](https://github.com/IBM-Cloud/terraform-provider-ibm/assets/32323373/2eaf9cac-1dfc-4e12-a764-9f563ef88f1b)

---

<!--- See what makes a good Pull Request at : https://github.com/IBM-Cloud/terraform-provider-ibm/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
n/a (minor fix in doc only)
