### PR TITLE
Fix handling of bundle_certs in Secrets Manager public cert

### DIFF
--- a/ibm/service/secretsmanager/resource_ibm_sm_public_certificate.go
+++ b/ibm/service/secretsmanager/resource_ibm_sm_public_certificate.go
@@ -781,8 +781,9 @@ func resourceIbmSmPublicCertificateMapToSecretPrototype(d *schema.ResourceData) 
 			model.Dns = core.StringPtr(d.Get("dns").(string))
 		}
 	}
-	if _, ok := d.GetOk("bundle_certs"); ok {
-		model.BundleCerts = core.BoolPtr(d.Get("bundle_certs").(bool))
+	bundleCerts, ok := d.GetOkExists("bundle_certs")
+	if ok {
+		model.BundleCerts = core.BoolPtr(bundleCerts.(bool))
 	}
 	if _, ok := d.GetOk("rotation"); ok {
 		RotationModel, err := resourceIbmSmPublicCertificateMapToPublicCertificateRotationPolicy(d.Get("rotation").([]interface{})[0].(map[string]interface{}))


### PR DESCRIPTION
Fix handling of bundle_certs in Secrets Manager public cert

<!--- See what makes a good Pull Request at : https://github.com/IBM-Cloud/terraform-provider-ibm/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #4803

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```
