### PR TITLE
Deprecated match_resource_types and Intoduced match_resource_type

### DIFF
--- a/ibm/service/vpc/resource_ibm_is_backup_policy_test.go
+++ b/ibm/service/vpc/resource_ibm_is_backup_policy_test.go
@@ -69,6 +69,59 @@ func TestAccIBMIsBackupPolicyBasic(t *testing.T) {
 	})
 }
 
+func TestAccIBMIsBackupPolicyMatchResourceType(t *testing.T) {
+	vpcname := fmt.Sprintf("tf-vpc-%d", acctest.RandIntRange(10, 100))
+	name := fmt.Sprintf("tf-instnace-%d", acctest.RandIntRange(10, 100))
+	subnetname := fmt.Sprintf("tf-subnet-%d", acctest.RandIntRange(10, 100))
+	sshname := fmt.Sprintf("tf-ssh-%d", acctest.RandIntRange(10, 100))
+	volname := fmt.Sprintf("tf-vol-%d", acctest.RandIntRange(10, 100))
+	backupPolicyName := fmt.Sprintf("tfbakuppolicyname%d", acctest.RandIntRange(10, 100))
+	backupPolicyNameUpdate := fmt.Sprintf("tfbakuppolicyname%d", acctest.RandIntRange(10, 100))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { acc.TestAccPreCheck(t) },
+		Providers:    acc.TestAccProviders,
+		CheckDestroy: testAccCheckIBMIsBackupPolicyDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccCheckIBMIsBackupPolicyConfigMatchResourceType(backupPolicyName, vpcname, subnetname, sshname, volname, name),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("ibm_is_backup_policy.is_backup_policy", "name", backupPolicyName),
+					resource.TestCheckResourceAttrSet("ibm_is_backup_policy.is_backup_policy", "match_resource_types.#"),
+					resource.TestCheckResourceAttrSet("ibm_is_backup_policy.is_backup_policy", "match_user_tags.#"),
+					resource.TestCheckResourceAttrSet("ibm_is_backup_policy.is_backup_policy", "resource_group"),
+					resource.TestCheckResourceAttrSet("ibm_is_backup_policy.is_backup_policy", "created_at"),
+					resource.TestCheckResourceAttrSet("ibm_is_backup_policy.is_backup_policy", "crn"),
+					resource.TestCheckResourceAttrSet("ibm_is_backup_policy.is_backup_policy", "href"),
+					resource.TestCheckResourceAttrSet("ibm_is_backup_policy.is_backup_policy", "lifecycle_state"),
+					resource.TestCheckResourceAttrSet("ibm_is_backup_policy.is_backup_policy", "resource_type"),
+					resource.TestCheckResourceAttrSet("ibm_is_backup_policy.is_backup_policy", "version"),
+				),
+			},
+			resource.TestStep{
+				Config: testAccCheckIBMIsBackupPolicyConfigMatchResourceType(backupPolicyNameUpdate, vpcname, subnetname, sshname, volname, name),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("ibm_is_backup_policy.is_backup_policy", "name", backupPolicyNameUpdate),
+					resource.TestCheckResourceAttrSet("ibm_is_backup_policy.is_backup_policy", "match_resource_types.#"),
+					resource.TestCheckResourceAttrSet("ibm_is_backup_policy.is_backup_policy", "match_user_tags.#"),
+					resource.TestCheckResourceAttrSet("ibm_is_backup_policy.is_backup_policy", "resource_group"),
+					resource.TestCheckResourceAttrSet("ibm_is_backup_policy.is_backup_policy", "created_at"),
+					resource.TestCheckResourceAttrSet("ibm_is_backup_policy.is_backup_policy", "crn"),
+					resource.TestCheckResourceAttrSet("ibm_is_backup_policy.is_backup_policy", "href"),
+					resource.TestCheckResourceAttrSet("ibm_is_backup_policy.is_backup_policy", "lifecycle_state"),
+					resource.TestCheckResourceAttrSet("ibm_is_backup_policy.is_backup_policy", "resource_type"),
+					resource.TestCheckResourceAttrSet("ibm_is_backup_policy.is_backup_policy", "version"),
+				),
+			},
+			{
+				ResourceName:      "ibm_is_backup_policy.is_backup_policy",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
 func testAccCheckIBMIsBackupPolicyConfigBasic(backupPolicyName string, vpcname, subnetname, sshname, volName, name string) string {
 	return fmt.Sprintf(`
 	resource "ibm_is_vpc" "testacc_vpc" {
@@ -112,6 +165,54 @@ func testAccCheckIBMIsBackupPolicyConfigBasic(backupPolicyName string, vpcname, 
 	  resource "ibm_is_backup_policy" "is_backup_policy" {
 		depends_on  = [ibm_is_instance.testacc_instance]
 		match_user_tags = ["tag-0"]
+		name            = "%s"
+	}`, vpcname, subnetname, acc.ISZoneName, acc.ISCIDR, sshname, volName, acc.ISZoneName, name, acc.IsImage, acc.InstanceProfileName, acc.ISZoneName, backupPolicyName)
+}
+
+func testAccCheckIBMIsBackupPolicyConfigMatchResourceType(backupPolicyName string, vpcname, subnetname, sshname, volName, name string) string {
+	return fmt.Sprintf(`
+	resource "ibm_is_vpc" "testacc_vpc" {
+		name = "%s"
+	  }
+
+	  resource "ibm_is_subnet" "testacc_subnet" {
+		name            = "%s"
+		vpc             = ibm_is_vpc.testacc_vpc.id
+		zone            = "%s"
+		ipv4_cidr_block = "%s"
+	  }
+
+	  resource "ibm_is_ssh_key" "testacc_sshkey" {
+		name       = "%s"
+		// public_key = file("../../test-fixtures/.ssh/id_rsa")
+		public_key = file("~/.ssh/id_rsa.pub")
+	  }
+
+	  resource "ibm_is_volume" "storage" {
+		name    = "%s"
+		profile = "10iops-tier"
+		zone    = "%s"
+		# capacity= 200
+		tags 	= ["tag-0"]
+	  }
+
+	  resource "ibm_is_instance" "testacc_instance" {
+		name    = "%s"
+		image   = "%s"
+		profile = "%s"
+		primary_network_interface {
+		  subnet = ibm_is_subnet.testacc_subnet.id
+		}
+		vpc     = ibm_is_vpc.testacc_vpc.id
+		zone    = "%s"
+		keys    = [ibm_is_ssh_key.testacc_sshkey.id]
+		volumes = [ibm_is_volume.storage.id]
+	  }
+
+	  resource "ibm_is_backup_policy" "is_backup_policy" {
+		depends_on  = [ibm_is_instance.testacc_instance]
+		match_user_tags = ["tag-0"]
+		match_resource_type = "volume"
 		name            = "%s"
 	}`, vpcname, subnetname, acc.ISZoneName, acc.ISCIDR, sshname, volName, acc.ISZoneName, name, acc.IsImage, acc.InstanceProfileName, acc.ISZoneName, backupPolicyName)
 }

--- a/website/docs/r/is_backup_policy.html.markdown
+++ b/website/docs/r/is_backup_policy.html.markdown
@@ -36,6 +36,10 @@ resource "ibm_is_backup_policy" "example" {
 Review the argument reference that you can specify for your resource.
 
 - `match_resource_types` - (Optional, List) A resource type this backup policy applies to. Resources that have both a matching type and a matching user tag will be subject to the backup policy. The default value is `["volume"]`.
+  
+~> **Note**
+  `match_resource_types` is deprecated. Please use `match_resource_type` instead.
+- `match_resource_type` - (Optional, String) The resource type this backup policy will apply to. Resources that have both a matching type and a matching user tag will be subject to the backup policy. The default value is `["volume"]`.
 - `match_user_tags` - (Required, List) The user tags this backup policy applies to. Resources that have both a matching user tag and a matching type will be subject to the backup policy.
 - `name` - (Required, String) The user-defined name for this backup policy. Names must be unique within the region this backup policy resides in. 
 - `resource_group` - (Optional, List) The resource group id, to use. If unspecified, the account's [default resource group](https://cloud.ibm.com/apidocs/resource-manager#introduction) is used.


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/IBM-Cloud/terraform-provider-ibm/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```


```
resource "ibm_is_backup_policy" "is_backup_policy" {
  match_user_tags = ["tag-0"]
  name            = "sunitha-terraform-baas"
}

resource "ibm_is_backup_policy" "is_backup_policy1" {
  match_user_tags = ["tag-0"] 
  match_resource_type = "volume"
  name            = "sunitha-terraform-baas1" 
} 
data "ibm_is_backup_policies" "is_backup_policies" {
}
```
<img width="1154" alt="Screenshot 2023-10-10 at 11 29 05 AM" src="https://github.com/IBM-Cloud/terraform-provider-ibm/assets/127872893/e9f033ec-ed44-404e-89ff-704480e79e60">

<img width="1187" alt="Screenshot 2023-10-10 at 11 29 22 AM" src="https://github.com/IBM-Cloud/terraform-provider-ibm/assets/127872893/0e9686d1-0398-444f-9f68-09aadc7b4381">

