### PR TITLE
added support for security groups for network load balancers

### DIFF
--- a/ibm/service/vpc/resource_ibm_is_lb.go
+++ b/ibm/service/vpc/resource_ibm_is_lb.go
@@ -189,13 +189,12 @@ func ResourceIBMISLB() *schema.Resource {
 			},
 
 			isLBSecurityGroups: {
-				Type:          schema.TypeSet,
-				Computed:      true,
-				Optional:      true,
-				Elem:          &schema.Schema{Type: schema.TypeString},
-				Set:           schema.HashString,
-				Description:   "Load Balancer securitygroups list",
-				ConflictsWith: []string{isLBProfile},
+				Type:        schema.TypeSet,
+				Computed:    true,
+				Optional:    true,
+				Elem:        &schema.Schema{Type: schema.TypeString},
+				Set:         schema.HashString,
+				Description: "Load Balancer securitygroups list",
 			},
 
 			isLBSecurityGroupsSupported: {

--- a/website/docs/d/is_flow_log.html.markdown
+++ b/website/docs/d/is_flow_log.html.markdown
@@ -33,8 +33,8 @@ data "ibm_is_flow_log" "example" {
 
 Review the argument reference that you can specify for your data source.
 
-- `identifier` - (Optional, String) The ID of the subnet, This is required when `name` is not specified.
-- `name` - (Optional, String) The name of the subnet,  This is required when `identifier` is not specified.
+- `identifier` - (Optional, String) The ID of the flow log collector, This is required when `name` is not specified.
+- `name` - (Optional, String) The name of the flow log collector,  This is required when `identifier` is not specified.
 
 ## Attribute reference
 

--- a/website/docs/r/is_lb.html.markdown
+++ b/website/docs/r/is_lb.html.markdown
@@ -90,7 +90,7 @@ Review the argument references that you can specify for your resource.
 - `route_mode` - (Optional, Forces new resource, Bool) Indicates whether route mode is enabled for this load balancer.
 
   ~> **NOTE:** Currently, `route_mode` enabled is supported only by private network load balancers.
-- `security_groups`  (Optional, List) A list of security groups to use for this load balancer. This option is supported only for application load balancers.
+- `security_groups`  (Optional, List) A list of security groups to use for this load balancer. This option is supported for both application and network load balancers.
 - `subnets` - (Required, List) List of the subnets IDs to connect to the load balancer.
 
   ~> **NOTE:** 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/IBM-Cloud/terraform-provider-ibm/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
=== RUN   TestAccIBMISLB_basic_network_security_group
--- PASS: TestAccIBMISLB_basic_network_security_group (1104.20s)
PASS
ok      github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/vpc     1107.007s
```

