### PR TITLE
Code engine add job run implementation

### DIFF
--- a/examples/ibm-code-engine/README.md
+++ b/examples/ibm-code-engine/README.md
@@ -9,6 +9,7 @@ The following types of resources are supported:
 * code_engine_build
 * code_engine_config_map
 * code_engine_job
+* code_engine_job_run
 * code_engine_project
 * code_engine_secret
 
@@ -91,6 +92,17 @@ resource "ibm_code_engine_job" "code_engine_job_instance" {
 
 ```
 
+code_engine_job_run resource:
+
+```hcl
+resource "ibm_code_engine_job_run" "code_engine_job_run_instance" {
+  project_id      = var.code_engine_project_id
+  job_name        = var.code_engine_job_name
+  name            = var.code_engine_job_run_name
+}
+
+```
+
 code_engine_secret resource:
 
 ```hcl
@@ -160,6 +172,16 @@ code_engine_job data source:
 data "ibm_code_engine_job" "code_engine_job_instance" {
   project_id = var.code_engine_project_id
   name       = var.code_engine_job_name
+}
+
+```
+
+code_engine_job_run data source:
+
+```hcl
+data "ibm_code_engine_job_run" "code_engine_job_run_instance" {
+  project_id = var.code_engine_project_id
+  name       = var.code_engine_job_run_name
 }
 
 ```

--- a/examples/ibm-code-engine/main.tf
+++ b/examples/ibm-code-engine/main.tf
@@ -64,6 +64,13 @@ resource "ibm_code_engine_job" "code_engine_job_instance" {
   name            = var.code_engine_job_name
 }
 
+// Provision code_engine_job_run resource instance
+resource "ibm_code_engine_job_run" "code_engine_job_run_instance" {
+  project_id = ibm_code_engine_project.code_engine_project_instance.project_id
+  name       = var.code_engine_job_run_name
+  job_name   = ibm_code_engine_job.code_engine_job_instance.name
+}
+
 // Provision code_engine_secret resource instance for format service_access
 
 resource "ibm_code_engine_secret" "code_engine_secret_service_access" {
@@ -132,6 +139,12 @@ data "ibm_code_engine_build" "code_engine_build_data" {
 data "ibm_code_engine_job" "code_engine_job_data" {
   project_id = data.ibm_code_engine_project.code_engine_project_data.project_id
   name       = var.code_engine_job_name
+}
+
+// Create code_engine_job_run data source
+data "ibm_code_engine_job_run" "code_engine_job_run_data" {
+  project_id = data.ibm_code_engine_project.code_engine_project_data.project_id
+  name       = var.code_engine_job_run_name
 }
 
 // Create code_engine_binding data source

--- a/examples/ibm-code-engine/outputs.tf
+++ b/examples/ibm-code-engine/outputs.tf
@@ -29,6 +29,12 @@ output "ibm_code_engine_job" {
   value       = ibm_code_engine_job.code_engine_job_instance
   description = "code_engine_job resource instance"
 }
+// This allows code_engine_job_run data to be referenced by other resources and the terraform CLI
+// Modify this if only certain data should be exposed
+output "ibm_code_engine_job_run" {
+  value       = ibm_code_engine_job_run.code_engine_job_run_instance
+  description = "code_engine_job resource instance"
+}
 // This allows code_engine_secret data to be referenced by other resources and the terraform CLI
 // Modify this if only certain data should be exposed
 output "ibm_code_engine_secret" {

--- a/examples/ibm-code-engine/variables.tf
+++ b/examples/ibm-code-engine/variables.tf
@@ -95,6 +95,12 @@ variable "code_engine_job_name" {
   default     = "my-job"
 }
 
+variable "code_engine_job_run_name" {
+  description = "The name of the job run. Use a name that is unique within the project."
+  type        = string
+  default     = "my-job-run"
+}
+
 // Resource arguments for code_engine_secret with format service_access
 variable "code_engine_secret_service_access_name" {
   description = "The name of the service access secret"

--- a/ibm/provider/provider.go
+++ b/ibm/provider/provider.go
@@ -853,6 +853,7 @@ func Provider() *schema.Provider {
 			"ibm_code_engine_build":      codeengine.DataSourceIbmCodeEngineBuild(),
 			"ibm_code_engine_config_map": codeengine.DataSourceIbmCodeEngineConfigMap(),
 			"ibm_code_engine_job":        codeengine.DataSourceIbmCodeEngineJob(),
+			"ibm_code_engine_job_run":    codeengine.DataSourceIbmCodeEngineJobRun(),
 			"ibm_code_engine_project":    codeengine.DataSourceIbmCodeEngineProject(),
 			"ibm_code_engine_secret":     codeengine.DataSourceIbmCodeEngineSecret(),
 
@@ -1365,6 +1366,7 @@ func Provider() *schema.Provider {
 			"ibm_code_engine_build":      codeengine.ResourceIbmCodeEngineBuild(),
 			"ibm_code_engine_config_map": codeengine.ResourceIbmCodeEngineConfigMap(),
 			"ibm_code_engine_job":        codeengine.ResourceIbmCodeEngineJob(),
+			"ibm_code_engine_job_run":    codeengine.ResourceIbmCodeEngineJobRun(),
 			"ibm_code_engine_project":    codeengine.ResourceIbmCodeEngineProject(),
 			"ibm_code_engine_secret":     codeengine.ResourceIbmCodeEngineSecret(),
 
@@ -1621,6 +1623,7 @@ func Validator() validate.ValidatorDict {
 				"ibm_code_engine_build":      codeengine.ResourceIbmCodeEngineBuildValidator(),
 				"ibm_code_engine_config_map": codeengine.ResourceIbmCodeEngineConfigMapValidator(),
 				"ibm_code_engine_job":        codeengine.ResourceIbmCodeEngineJobValidator(),
+				"ibm_code_engine_job_run":    codeengine.ResourceIbmCodeEngineJobRunValidator(),
 				"ibm_code_engine_project":    codeengine.ResourceIbmCodeEngineProjectValidator(),
 				"ibm_code_engine_secret":     codeengine.ResourceIbmCodeEngineSecretValidator(),
 

--- a/ibm/service/codeengine/data_source_ibm_code_engine_job_run.go
+++ b/ibm/service/codeengine/data_source_ibm_code_engine_job_run.go
@@ -1,0 +1,439 @@
+// Copyright IBM Corp. 2023 All Rights Reserved.
+// Licensed under the Mozilla Public License v2.0
+
+package codeengine
+
+import (
+	"context"
+	"fmt"
+	"log"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/conns"
+	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/flex"
+	"github.com/IBM/code-engine-go-sdk/codeenginev2"
+)
+
+func DataSourceIbmCodeEngineJobRun() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceIbmCodeEngineJobRunRead,
+
+		Schema: map[string]*schema.Schema{
+			"project_id": &schema.Schema{
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "The ID of the project.",
+			},
+			"name": &schema.Schema{
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "The name of the job run.",
+			},
+			"created_at": &schema.Schema{
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The timestamp when the resource was created.",
+			},
+			"href": &schema.Schema{
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "When you provision a new job run, a URL is created identifying the location of the instance.",
+			},
+			"job_run_id": &schema.Schema{
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The identifier of the resource.",
+			},
+			"job_name": &schema.Schema{
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "Optional name of the job reference of this job run. If specified, the job run will inherit the configuration of the referenced job.",
+			},
+			"image_reference": &schema.Schema{
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The name of the image that is used for this job. The format is `REGISTRY/NAMESPACE/REPOSITORY:TAG` where `REGISTRY` and `TAG` are optional. If `REGISTRY` is not specified, the default is `docker.io`. If `TAG` is not specified, the default is `latest`. If the image reference points to a registry that requires authentication, make sure to also specify the property `image_secret`.",
+			},
+			"image_secret": &schema.Schema{
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The name of the image registry access secret. The image registry access secret is used to authenticate with a private registry when you download the container image. If the image reference points to a registry that requires authentication, the job / job runs will be created but submitted job runs will fail, until this property is provided, too. This property must not be set on a job run, which references a job template.",
+			},
+			"resource_type": &schema.Schema{
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The type of the job run.",
+			},
+			"run_arguments": &schema.Schema{
+				Type:        schema.TypeList,
+				Computed:    true,
+				Description: "Set arguments for the job that are passed to start job run containers. If not specified an empty string array will be applied and the arguments specified by the container image, will be used to start the container.",
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
+			},
+			"run_as_user": &schema.Schema{
+				Type:        schema.TypeInt,
+				Computed:    true,
+				Description: "The user ID (UID) to run the job (e.g., 1001).",
+			},
+			"run_commands": &schema.Schema{
+				Type:        schema.TypeList,
+				Computed:    true,
+				Description: "Set commands for the job that are passed to start job run containers. If not specified an empty string array will be applied and the command specified by the container image, will be used to start the container.",
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
+			},
+			"run_env_variables": &schema.Schema{
+				Type:        schema.TypeList,
+				Computed:    true,
+				Description: "References to config maps, secrets or literal values, which are exposed as environment variables in the job run.",
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"key": &schema.Schema{
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "The key to reference as environment variable.",
+						},
+						"name": &schema.Schema{
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "The name of the environment variable.",
+						},
+						"prefix": &schema.Schema{
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "A prefix that can be added to all keys of a full secret or config map reference.",
+						},
+						"reference": &schema.Schema{
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "The name of the secret or config map.",
+						},
+						"type": &schema.Schema{
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "Specify the type of the environment variable.",
+						},
+						"value": &schema.Schema{
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "The literal value of the environment variable.",
+						},
+					},
+				},
+			},
+			"run_mode": &schema.Schema{
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The mode for runs of the job. Valid values are `task` and `daemon`. In `task` mode, the `max_execution_time` and `retry_limit` properties apply. In `daemon` mode, since there is no timeout and failed instances are restarted indefinitely, the `max_execution_time` and `retry_limit` properties are not allowed.",
+			},
+			"run_service_account": &schema.Schema{
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The name of the service account. For built-in service accounts, you can use the shortened names `manager`, `none`, `reader`, and `writer`. This property must not be set on a job run, which references a job template.",
+			},
+			"run_volume_mounts": &schema.Schema{
+				Type:        schema.TypeList,
+				Computed:    true,
+				Description: "Optional mounts of config maps or a secrets.",
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"mount_path": &schema.Schema{
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "The path that should be mounted.",
+						},
+						"name": &schema.Schema{
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "The name of the mount.",
+						},
+						"reference": &schema.Schema{
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "The name of the referenced secret or config map.",
+						},
+						"type": &schema.Schema{
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "Specify the type of the volume mount. Allowed types are: 'config_map', 'secret'.",
+						},
+					},
+				},
+			},
+			"scale_array_spec": &schema.Schema{
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "Define a custom set of array indices as comma-separated list containing single values and hyphen-separated ranges like `5,12-14,23,27`. Each instance can pick up its array index via environment variable `JOB_INDEX`. The number of unique array indices specified here determines the number of job instances to run.",
+			},
+			"scale_cpu_limit": &schema.Schema{
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "Optional amount of CPU set for the instance of the job. For valid values see [Supported memory and CPU combinations](https://cloud.ibm.com/docs/codeengine?topic=codeengine-mem-cpu-combo).",
+			},
+			"scale_ephemeral_storage_limit": &schema.Schema{
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "Optional amount of ephemeral storage to set for the instance of the job. The amount specified as ephemeral storage, must not exceed the amount of `scale_memory_limit`. The units for specifying ephemeral storage are Megabyte (M) or Gigabyte (G), whereas G and M are the shorthand expressions for GB and MB. For more information see [Units of measurement](https://cloud.ibm.com/docs/codeengine?topic=codeengine-mem-cpu-combo#unit-measurements).",
+			},
+			"scale_max_execution_time": &schema.Schema{
+				Type:        schema.TypeInt,
+				Computed:    true,
+				Description: "The maximum execution time in seconds for runs of the job. This property can only be specified if `run_mode` is `task`.",
+			},
+			"scale_memory_limit": &schema.Schema{
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "Optional amount of memory set for the instance of the job. For valid values see [Supported memory and CPU combinations](https://cloud.ibm.com/docs/codeengine?topic=codeengine-mem-cpu-combo). The units for specifying memory are Megabyte (M) or Gigabyte (G), whereas G and M are the shorthand expressions for GB and MB. For more information see [Units of measurement](https://cloud.ibm.com/docs/codeengine?topic=codeengine-mem-cpu-combo#unit-measurements).",
+			},
+			"scale_retry_limit": &schema.Schema{
+				Type:        schema.TypeInt,
+				Computed:    true,
+				Description: "The number of times to rerun an instance of the job before the job is marked as failed. This property can only be specified if `run_mode` is `task`.",
+			},
+			"status": &schema.Schema{
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The current status of the job run. Possible values: [failed, completed, running]",
+			},
+			"status_details": &schema.Schema{
+				Type:        schema.TypeList,
+				Computed:    true,
+				Description: "The detailed status of the job run.",
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"completion_time": &schema.Schema{
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "Time the job run completed.",
+						},
+						"failed": &schema.Schema{
+							Type:        schema.TypeInt,
+							Computed:    true,
+							Description: "Number of failed job run instances.",
+						},
+						"pending": &schema.Schema{
+							Type:        schema.TypeInt,
+							Computed:    true,
+							Description: "Number of pending job run instances.",
+						},
+						"requested": &schema.Schema{
+							Type:        schema.TypeInt,
+							Computed:    true,
+							Description: "Number of requested job run instances.",
+						},
+						"running": &schema.Schema{
+							Type:        schema.TypeInt,
+							Computed:    true,
+							Description: "Number of running job run instances.",
+						},
+						"start_time": &schema.Schema{
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "Time the job run started.",
+						},
+						"succeeded": &schema.Schema{
+							Type:        schema.TypeInt,
+							Computed:    true,
+							Description: "Number of succeeded job run instances.",
+						},
+						"unknown": &schema.Schema{
+							Type:        schema.TypeInt,
+							Computed:    true,
+							Description: "Number of job run instances with unknown state.",
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func dataSourceIbmCodeEngineJobRunRead(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	codeEngineClient, err := meta.(conns.ClientSession).CodeEngineV2()
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	getJobRunOptions := &codeenginev2.GetJobRunOptions{}
+
+	getJobRunOptions.SetProjectID(d.Get("project_id").(string))
+	getJobRunOptions.SetName(d.Get("name").(string))
+
+	jobRun, response, err := codeEngineClient.GetJobRunWithContext(context, getJobRunOptions)
+	if err != nil {
+		log.Printf("[DEBUG] GetJobRunWithContext failed %s\n%s", err, response)
+		return diag.FromErr(fmt.Errorf("GetJobRunWithContext failed %s\n%s", err, response))
+	}
+
+	d.SetId(fmt.Sprintf("%s/%s", *getJobRunOptions.ProjectID, *getJobRunOptions.Name))
+
+	if err = d.Set("created_at", jobRun.CreatedAt); err != nil {
+		return diag.FromErr(fmt.Errorf("Error setting created_at: %s", err))
+	}
+
+	if err = d.Set("href", jobRun.Href); err != nil {
+		return diag.FromErr(fmt.Errorf("Error setting href: %s", err))
+	}
+
+	if err = d.Set("job_run_id", jobRun.ID); err != nil {
+		return diag.FromErr(fmt.Errorf("Error setting job_run_id: %s", err))
+	}
+
+	if err = d.Set("job_name", jobRun.JobName); err != nil {
+		return diag.FromErr(fmt.Errorf("Error setting job_name: %s", err))
+	}
+
+	if err = d.Set("image_reference", jobRun.ImageReference); err != nil {
+		return diag.FromErr(fmt.Errorf("Error setting image_reference: %s", err))
+	}
+
+	if err = d.Set("image_secret", jobRun.ImageSecret); err != nil {
+		return diag.FromErr(fmt.Errorf("Error setting image_secret: %s", err))
+	}
+
+	if err = d.Set("resource_type", jobRun.ResourceType); err != nil {
+		return diag.FromErr(fmt.Errorf("Error setting resource_type: %s", err))
+	}
+
+	if err = d.Set("run_as_user", flex.IntValue(jobRun.RunAsUser)); err != nil {
+		return diag.FromErr(fmt.Errorf("Error setting run_as_user: %s", err))
+	}
+
+	runEnvVariables := []map[string]interface{}{}
+	if jobRun.RunEnvVariables != nil {
+		for _, modelItem := range jobRun.RunEnvVariables {
+			modelMap, err := dataSourceIbmCodeEngineJobRunEnvVarToMap(&modelItem)
+			if err != nil {
+				return diag.FromErr(err)
+			}
+			runEnvVariables = append(runEnvVariables, modelMap)
+		}
+	}
+	if err = d.Set("run_env_variables", runEnvVariables); err != nil {
+		return diag.FromErr(fmt.Errorf("Error setting run_env_variables %s", err))
+	}
+
+	if err = d.Set("run_mode", jobRun.RunMode); err != nil {
+		return diag.FromErr(fmt.Errorf("Error setting run_mode: %s", err))
+	}
+
+	if err = d.Set("run_service_account", jobRun.RunServiceAccount); err != nil {
+		return diag.FromErr(fmt.Errorf("Error setting run_service_account: %s", err))
+	}
+
+	runVolumeMounts := []map[string]interface{}{}
+	if jobRun.RunVolumeMounts != nil {
+		for _, modelItem := range jobRun.RunVolumeMounts {
+			modelMap, err := dataSourceIbmCodeEngineJobRunVolumeMountToMap(&modelItem)
+			if err != nil {
+				return diag.FromErr(err)
+			}
+			runVolumeMounts = append(runVolumeMounts, modelMap)
+		}
+	}
+	if err = d.Set("run_volume_mounts", runVolumeMounts); err != nil {
+		return diag.FromErr(fmt.Errorf("Error setting run_volume_mounts %s", err))
+	}
+
+	if err = d.Set("scale_array_spec", jobRun.ScaleArraySpec); err != nil {
+		return diag.FromErr(fmt.Errorf("Error setting scale_array_spec: %s", err))
+	}
+
+	if err = d.Set("scale_cpu_limit", jobRun.ScaleCpuLimit); err != nil {
+		return diag.FromErr(fmt.Errorf("Error setting scale_cpu_limit: %s", err))
+	}
+
+	if err = d.Set("scale_ephemeral_storage_limit", jobRun.ScaleEphemeralStorageLimit); err != nil {
+		return diag.FromErr(fmt.Errorf("Error setting scale_ephemeral_storage_limit: %s", err))
+	}
+
+	if err = d.Set("scale_max_execution_time", flex.IntValue(jobRun.ScaleMaxExecutionTime)); err != nil {
+		return diag.FromErr(fmt.Errorf("Error setting scale_max_execution_time: %s", err))
+	}
+
+	if err = d.Set("scale_memory_limit", jobRun.ScaleMemoryLimit); err != nil {
+		return diag.FromErr(fmt.Errorf("Error setting scale_memory_limit: %s", err))
+	}
+
+	if err = d.Set("scale_retry_limit", flex.IntValue(jobRun.ScaleRetryLimit)); err != nil {
+		return diag.FromErr(fmt.Errorf("Error setting scale_retry_limit: %s", err))
+	}
+
+	if err = d.Set("status", jobRun.Status); err != nil {
+		return diag.FromErr(fmt.Errorf("Error setting status: %s", err))
+	}
+
+	statusDetailsMap, err := dataSourceIbmCodeEngineJobRunDetailedStatusToMap(jobRun.StatusDetails)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+	if err = d.Set("status_details", []map[string]interface{}{statusDetailsMap}); err != nil {
+		return diag.FromErr(fmt.Errorf("Error setting status_details: %s", err))
+	}
+
+	return nil
+}
+
+func dataSourceIbmCodeEngineJobRunEnvVarToMap(model *codeenginev2.EnvVar) (map[string]interface{}, error) {
+	modelMap := make(map[string]interface{})
+	if model.Key != nil {
+		modelMap["key"] = model.Key
+	}
+	if model.Name != nil {
+		modelMap["name"] = model.Name
+	}
+	if model.Prefix != nil {
+		modelMap["prefix"] = model.Prefix
+	}
+	if model.Reference != nil {
+		modelMap["reference"] = model.Reference
+	}
+	modelMap["type"] = model.Type
+	if model.Value != nil {
+		modelMap["value"] = model.Value
+	}
+	return modelMap, nil
+}
+
+func dataSourceIbmCodeEngineJobRunVolumeMountToMap(model *codeenginev2.VolumeMount) (map[string]interface{}, error) {
+	modelMap := make(map[string]interface{})
+	modelMap["mount_path"] = model.MountPath
+	modelMap["name"] = model.Name
+	modelMap["reference"] = model.Reference
+	modelMap["type"] = model.Type
+	return modelMap, nil
+}
+
+func dataSourceIbmCodeEngineJobRunDetailedStatusToMap(model *codeenginev2.JobRunStatus) (map[string]interface{}, error) {
+	modelMap := make(map[string]interface{})
+	if model.CompletionTime != nil {
+		modelMap["completion_time"] = model.CompletionTime
+	}
+	if model.Failed != nil {
+		modelMap["failed"] = model.Failed
+	}
+	if model.Pending != nil {
+		modelMap["pending"] = model.Pending
+	}
+	if model.Requested != nil {
+		modelMap["requested"] = model.Requested
+	}
+	if model.Running != nil {
+		modelMap["running"] = model.Running
+	}
+	if model.StartTime != nil {
+		modelMap["start_time"] = model.StartTime
+	}
+	if model.Succeeded != nil {
+		modelMap["succeeded"] = model.Succeeded
+	}
+	if model.Unknown != nil {
+		modelMap["unknown"] = model.Unknown
+	}
+	return modelMap, nil
+}

--- a/ibm/service/codeengine/data_source_ibm_code_engine_job_run_test.go
+++ b/ibm/service/codeengine/data_source_ibm_code_engine_job_run_test.go
@@ -1,0 +1,66 @@
+// Copyright IBM Corp. 2023 All Rights Reserved.
+// Licensed under the Mozilla Public License v2.0
+
+package codeengine_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	acc "github.com/IBM-Cloud/terraform-provider-ibm/ibm/acctest"
+)
+
+func TestAccIbmCodeEngineJobRunDataSourceBasic(t *testing.T) {
+	jobName := fmt.Sprintf("tf-data-job-basic-%d", acctest.RandIntRange(10, 1000))
+	jobRunName := fmt.Sprintf("tf-data-job-run-basic-%d", acctest.RandIntRange(10, 1000))
+	jobImageReference := "icr.io/codeengine/helloworld"
+
+	projectID := acc.CeProjectId
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { acc.TestAccPreCheck(t) },
+		Providers: acc.TestAccProviders,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccCheckIbmCodeEngineJobRunDataSourceConfigBasic(projectID, jobImageReference, jobName, jobRunName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet("data.ibm_code_engine_job_run.code_engine_job_run_instance", "job_run_id"),
+					resource.TestCheckResourceAttr("data.ibm_code_engine_job_run.code_engine_job_run_instance", "project_id", projectID),
+					resource.TestCheckResourceAttr("data.ibm_code_engine_job_run.code_engine_job_run_instance", "name", jobRunName),
+					resource.TestCheckResourceAttr("data.ibm_code_engine_job_run.code_engine_job_run_instance", "jobName", jobName),
+					resource.TestCheckResourceAttr("data.ibm_code_engine_job_run.code_engine_job_run_instance", "resource_type", "job_run_v2"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckIbmCodeEngineJobRunDataSourceConfigBasic(projectID string, jobImageReference string, jobName string, jobRunName string) string {
+	return fmt.Sprintf(`
+		data "ibm_code_engine_project" "code_engine_project_instance" {
+			project_id = "%s"
+		}
+
+		resource "ibm_code_engine_job" "code_engine_job_instance" {
+			project_id = data.ibm_code_engine_project.code_engine_project_instance.project_id
+			image_reference = "%s"
+			name = "%s"
+		}
+
+		resource "ibm_code_engine_job_run" "code_engine_job_run_instance" {
+			project_id = ibm_code_engine_project.ce_project.project_id
+			name       = "%s"
+			job_name   = ibm_code_engine_job.code_engine_job_instance.name
+		}
+
+		data "ibm_code_engine_job_run" "code_engine_job_run_instance" {
+			project_id = ibm_code_engine_project.ce_project.project_id
+			name       = data.ibm_code_engine_job_run.code_engine_job_run_instance.name
+		}
+
+
+	`, projectID, jobImageReference, jobName, jobRunName)
+}

--- a/ibm/service/codeengine/data_source_ibm_code_engine_job_run_test.go
+++ b/ibm/service/codeengine/data_source_ibm_code_engine_job_run_test.go
@@ -30,7 +30,7 @@ func TestAccIbmCodeEngineJobRunDataSourceBasic(t *testing.T) {
 					resource.TestCheckResourceAttrSet("data.ibm_code_engine_job_run.code_engine_job_run_instance", "job_run_id"),
 					resource.TestCheckResourceAttr("data.ibm_code_engine_job_run.code_engine_job_run_instance", "project_id", projectID),
 					resource.TestCheckResourceAttr("data.ibm_code_engine_job_run.code_engine_job_run_instance", "name", jobRunName),
-					resource.TestCheckResourceAttr("data.ibm_code_engine_job_run.code_engine_job_run_instance", "jobName", jobName),
+					resource.TestCheckResourceAttr("data.ibm_code_engine_job_run.code_engine_job_run_instance", "job_name", jobName),
 					resource.TestCheckResourceAttr("data.ibm_code_engine_job_run.code_engine_job_run_instance", "resource_type", "job_run_v2"),
 				),
 			},
@@ -51,14 +51,14 @@ func testAccCheckIbmCodeEngineJobRunDataSourceConfigBasic(projectID string, jobI
 		}
 
 		resource "ibm_code_engine_job_run" "code_engine_job_run_instance" {
-			project_id = ibm_code_engine_project.ce_project.project_id
+			project_id = data.ibm_code_engine_project.code_engine_project_instance.project_id
 			name       = "%s"
 			job_name   = ibm_code_engine_job.code_engine_job_instance.name
 		}
 
 		data "ibm_code_engine_job_run" "code_engine_job_run_instance" {
-			project_id = ibm_code_engine_project.ce_project.project_id
-			name       = data.ibm_code_engine_job_run.code_engine_job_run_instance.name
+			project_id = data.ibm_code_engine_project.code_engine_project_instance.project_id
+			name       = ibm_code_engine_job_run.code_engine_job_run_instance.name
 		}
 
 

--- a/ibm/service/codeengine/resource_ibm_code_engine_job_run.go
+++ b/ibm/service/codeengine/resource_ibm_code_engine_job_run.go
@@ -1,0 +1,798 @@
+// Copyright IBM Corp. 2023 All Rights Reserved.
+// Licensed under the Mozilla Public License v2.0
+
+package codeengine
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"time"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/IBM-Cloud/bluemix-go/bmxerror"
+	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/conns"
+	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/flex"
+	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/validate"
+	"github.com/IBM/code-engine-go-sdk/codeenginev2"
+	"github.com/IBM/go-sdk-core/v5/core"
+)
+
+func ResourceIbmCodeEngineJobRun() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceIbmCodeEngineJobRunCreate,
+		ReadContext:   resourceIbmCodeEngineJobRunRead,
+		DeleteContext: resourceIbmCodeEngineJobRunDelete,
+		Importer:      &schema.ResourceImporter{},
+
+		Schema: map[string]*schema.Schema{
+			"project_id": &schema.Schema{
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: validate.InvokeValidator("ibm_code_engine_job_run", "project_id"),
+				Description:  "The ID of the project.",
+			},
+			"image_reference": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+				// ForceNew:     true,
+				Computed:     true,
+				ValidateFunc: validate.InvokeValidator("ibm_code_engine_job_run", "image_reference"),
+				Description:  "The name of the image that is used for this job. The format is `REGISTRY/NAMESPACE/REPOSITORY:TAG` where `REGISTRY` and `TAG` are optional. If `REGISTRY` is not specified, the default is `docker.io`. If `TAG` is not specified, the default is `latest`. If the image reference points to a registry that requires authentication, make sure to also specify the property `image_secret`.",
+			},
+			"image_secret": &schema.Schema{
+				Type:         schema.TypeString,
+				Optional:     true,
+				Computed:     true,
+				ValidateFunc: validate.InvokeValidator("ibm_code_engine_job_run", "image_secret"),
+				Description:  "The name of the image registry access secret. The image registry access secret is used to authenticate with a private registry when you download the container image. If the image reference points to a registry that requires authentication, the job / job runs will be created but submitted job runs will fail, until this property is provided, too. This property must not be set on a job run, which references a job template.",
+			},
+			"job_name": &schema.Schema{
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: validate.InvokeValidator("ibm_code_engine_job_run", "job_name"),
+				Description:  "Optional name of the job on which this job run is based on. If specified, the job run will inherit the configuration of the referenced job.",
+			},
+			"name": &schema.Schema{
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: validate.InvokeValidator("ibm_code_engine_job_run", "name"),
+				Description:  "The name of the job run. Use a name that is unique within the project.",
+			},
+			"run_arguments": &schema.Schema{
+				Type:        schema.TypeList,
+				Optional:    true,
+				Computed:    true,
+				MinItems:    0,
+				Description: "Set arguments for the job that are passed to start job run containers. If not specified an empty string array will be applied and the arguments specified by the container image, will be used to start the container.",
+				Elem:        &schema.Schema{Type: schema.TypeString},
+			},
+			"run_as_user": &schema.Schema{
+				Type:     schema.TypeInt,
+				Optional: true,
+				Computed: true,
+				// Default:     0,
+				Description: "The user ID (UID) to run the application (e.g., 1001).",
+			},
+			"run_commands": &schema.Schema{
+				Type:        schema.TypeList,
+				Optional:    true,
+				Computed:    true,
+				MinItems:    0,
+				Description: "Set commands for the job that are passed to start job run containers. If not specified an empty string array will be applied and the command specified by the container image, will be used to start the container.",
+				Elem:        &schema.Schema{Type: schema.TypeString},
+			},
+			"run_env_variables": &schema.Schema{
+				Type:        schema.TypeList,
+				Optional:    true,
+				Computed:    true,
+				MinItems:    0,
+				Description: "Optional references to config maps, secrets or a literal values.",
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"key": &schema.Schema{
+							Type:        schema.TypeString,
+							Optional:    true,
+							Description: "The key to reference as environment variable.",
+						},
+						"name": &schema.Schema{
+							Type:        schema.TypeString,
+							Optional:    true,
+							Description: "The name of the environment variable.",
+						},
+						"prefix": &schema.Schema{
+							Type:        schema.TypeString,
+							Optional:    true,
+							Description: "A prefix that can be added to all keys of a full secret or config map reference.",
+						},
+						"reference": &schema.Schema{
+							Type:        schema.TypeString,
+							Optional:    true,
+							Description: "The name of the secret or config map.",
+						},
+						"type": &schema.Schema{
+							Type:        schema.TypeString,
+							Optional:    true,
+							Default:     "literal",
+							Description: "Specify the type of the environment variable.",
+						},
+						"value": &schema.Schema{
+							Type:        schema.TypeString,
+							Optional:    true,
+							Description: "The literal value of the environment variable.",
+						},
+					},
+				},
+			},
+			"run_mode": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				// Default:      "task",
+				ValidateFunc: validate.InvokeValidator("ibm_code_engine_job_run", "run_mode"),
+				Description:  "The mode for runs of the job. Valid values are `task` and `daemon`. In `task` mode, the `max_execution_time` and `retry_limit` properties apply. In `daemon` mode, since there is no timeout and failed instances are restarted indefinitely, the `max_execution_time` and `retry_limit` properties are not allowed.",
+			},
+			"run_service_account": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				// Default:      "default",
+				ValidateFunc: validate.InvokeValidator("ibm_code_engine_job_run", "run_service_account"),
+				Description:  "The name of the service account. For built-in service accounts, you can use the shortened names `manager`, `none`, `reader`, and `writer`. This property must not be set on a job run, which references a job template.",
+			},
+			"run_volume_mounts": &schema.Schema{
+				Type:        schema.TypeList,
+				Optional:    true,
+				Computed:    true,
+				MinItems:    0,
+				Description: "Optional mounts of config maps or a secrets.",
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"mount_path": &schema.Schema{
+							Type:        schema.TypeString,
+							Required:    true,
+							Description: "The path that should be mounted.",
+						},
+						"name": &schema.Schema{
+							Type:        schema.TypeString,
+							Optional:    true,
+							Description: "Optional name of the mount. If not set, it will be generated based on the `ref` and a random ID. In case the `ref` is longer than 58 characters, it will be cut off.",
+						},
+						"reference": &schema.Schema{
+							Type:        schema.TypeString,
+							Required:    true,
+							Description: "The name of the referenced secret or config map.",
+						},
+						"type": &schema.Schema{
+							Type:        schema.TypeString,
+							Required:    true,
+							Description: "Specify the type of the volume mount. Allowed types are: 'config_map', 'secret'.",
+						},
+					},
+				},
+			},
+			"scale_array_spec": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				// Default:      "0",
+				ValidateFunc: validate.InvokeValidator("ibm_code_engine_job_run", "scale_array_spec"),
+				Description:  "Define a custom set of array indices as comma-separated list containing single values and hyphen-separated ranges like `5,12-14,23,27`. Each instance can pick up its array index via environment variable `JOB_INDEX`. The number of unique array indices specified here determines the number of job instances to run.",
+			},
+			"scale_cpu_limit": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				// Default:      "1",
+				ValidateFunc: validate.InvokeValidator("ibm_code_engine_job_run", "scale_cpu_limit"),
+				Description:  "Optional amount of CPU set for the instance of the job. For valid values see [Supported memory and CPU combinations](https://cloud.ibm.com/docs/codeengine?topic=codeengine-mem-cpu-combo).",
+			},
+			"scale_ephemeral_storage_limit": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				// Default:      "400M",
+				ValidateFunc: validate.InvokeValidator("ibm_code_engine_job_run", "scale_ephemeral_storage_limit"),
+				Description:  "Optional amount of ephemeral storage to set for the instance of the job. The amount specified as ephemeral storage, must not exceed the amount of `scale_memory_limit`. The units for specifying ephemeral storage are Megabyte (M) or Gigabyte (G), whereas G and M are the shorthand expressions for GB and MB. For more information see [Units of measurement](https://cloud.ibm.com/docs/codeengine?topic=codeengine-mem-cpu-combo#unit-measurements).",
+			},
+			"scale_max_execution_time": &schema.Schema{
+				Type:     schema.TypeInt,
+				Optional: true,
+				Computed: true,
+				// Default:     7200,
+				Description: "The maximum execution time in seconds for runs of the job. This property can only be specified if `run_mode` is `task`.",
+			},
+			"scale_memory_limit": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				// Default:      "4G",
+				ValidateFunc: validate.InvokeValidator("ibm_code_engine_job_run", "scale_memory_limit"),
+				Description:  "Optional amount of memory set for the instance of the job. For valid values see [Supported memory and CPU combinations](https://cloud.ibm.com/docs/codeengine?topic=codeengine-mem-cpu-combo). The units for specifying memory are Megabyte (M) or Gigabyte (G), whereas G and M are the shorthand expressions for GB and MB. For more information see [Units of measurement](https://cloud.ibm.com/docs/codeengine?topic=codeengine-mem-cpu-combo#unit-measurements).",
+			},
+			"scale_retry_limit": &schema.Schema{
+				Type:     schema.TypeInt,
+				Optional: true,
+				Computed: true,
+				// Default:     3,
+				Description: "The number of times to rerun an instance of the job before the job is marked as failed. This property can only be specified if `run_mode` is `task`.",
+			},
+			"created_at": &schema.Schema{
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The timestamp when the resource was created.",
+			},
+			"href": &schema.Schema{
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "When you provision a new job,  a URL is created identifying the location of the instance.",
+			},
+			"job_run_id": &schema.Schema{
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The identifier of the resource.",
+			},
+			"resource_type": &schema.Schema{
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The type of the job.",
+			},
+			"status": &schema.Schema{
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The current status of the job run. Possible values: [failed, completed, running]",
+			},
+			"status_details": &schema.Schema{
+				Type:        schema.TypeList,
+				Computed:    true,
+				Description: "The detailed status of the job run.",
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"completion_time": &schema.Schema{
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "Time the job run completed.",
+						},
+						"failed": &schema.Schema{
+							Type:        schema.TypeInt,
+							Computed:    true,
+							Description: "Number of failed job run instances.",
+						},
+						"pending": &schema.Schema{
+							Type:        schema.TypeInt,
+							Computed:    true,
+							Description: "Number of pending job run instances.",
+						},
+						"requested": &schema.Schema{
+							Type:        schema.TypeInt,
+							Computed:    true,
+							Description: "Number of requested job run instances.",
+						},
+						"running": &schema.Schema{
+							Type:        schema.TypeInt,
+							Computed:    true,
+							Description: "Number of running job run instances.",
+						},
+						"start_time": &schema.Schema{
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "Time the job run started.",
+						},
+						"succeeded": &schema.Schema{
+							Type:        schema.TypeInt,
+							Computed:    true,
+							Description: "Number of succeeded job run instances.",
+						},
+						"unknown": &schema.Schema{
+							Type:        schema.TypeInt,
+							Computed:    true,
+							Description: "Number of job run instances with unknown state.",
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func ResourceIbmCodeEngineJobRunValidator() *validate.ResourceValidator {
+	validateSchema := make([]validate.ValidateSchema, 0)
+	validateSchema = append(validateSchema,
+		validate.ValidateSchema{
+			Identifier:                 "project_id",
+			ValidateFunctionIdentifier: validate.ValidateRegexpLen,
+			Type:                       validate.TypeString,
+			Required:                   true,
+			Regexp:                     `^[0-9a-z]{8}-[0-9a-z]{4}-[0-9a-z]{4}-[0-9a-z]{4}-[0-9a-z]{12}$`,
+			MinValueLength:             36,
+			MaxValueLength:             36,
+		},
+		validate.ValidateSchema{
+			Identifier:                 "image_reference",
+			ValidateFunctionIdentifier: validate.ValidateRegexpLen,
+			Type:                       validate.TypeString,
+			Optional:                   true,
+			Regexp:                     `^([a-z0-9][a-z0-9\-_.]+[a-z0-9][\/])?([a-z0-9][a-z0-9\-_]+[a-z0-9][\/])?[a-z0-9][a-z0-9\-_.\/]+[a-z0-9](:[\w][\w.\-]{0,127})?(@sha256:[a-fA-F0-9]{64})?$`,
+			MinValueLength:             1,
+			MaxValueLength:             256,
+		},
+		validate.ValidateSchema{
+			Identifier:                 "image_secret",
+			ValidateFunctionIdentifier: validate.ValidateRegexpLen,
+			Type:                       validate.TypeString,
+			Optional:                   true,
+			Regexp:                     `^[a-z0-9]([\-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([\-a-z0-9]*[a-z0-9])?)*$`,
+			MinValueLength:             1,
+			MaxValueLength:             253,
+		},
+		validate.ValidateSchema{
+			Identifier:                 "job_name",
+			ValidateFunctionIdentifier: validate.ValidateRegexpLen,
+			Type:                       validate.TypeString,
+			Required:                   true,
+			Regexp:                     `^[a-z0-9]([\-a-z0-9]*[a-z0-9])?$`,
+			MinValueLength:             1,
+			MaxValueLength:             63,
+		},
+		validate.ValidateSchema{
+			Identifier:                 "name",
+			ValidateFunctionIdentifier: validate.ValidateRegexpLen,
+			Type:                       validate.TypeString,
+			Optional:                   true,
+			Regexp:                     `^[a-z0-9]([\-a-z0-9]*[a-z0-9])?$`,
+			MinValueLength:             1,
+			MaxValueLength:             63,
+		},
+		validate.ValidateSchema{
+			Identifier:                 "run_mode",
+			ValidateFunctionIdentifier: validate.ValidateAllowedStringValue,
+			Type:                       validate.TypeString,
+			Optional:                   true,
+			AllowedValues:              "daemon, task",
+			Regexp:                     `^(task|daemon)$`,
+			MinValueLength:             0,
+		},
+		validate.ValidateSchema{
+			Identifier:                 "run_service_account",
+			ValidateFunctionIdentifier: validate.ValidateAllowedStringValue,
+			Type:                       validate.TypeString,
+			Optional:                   true,
+			AllowedValues:              "default, manager, none, reader, writer",
+			Regexp:                     `^(manager|reader|writer|none|default)$`,
+			MinValueLength:             0,
+		},
+		validate.ValidateSchema{
+			Identifier:                 "scale_array_spec",
+			ValidateFunctionIdentifier: validate.ValidateRegexpLen,
+			Type:                       validate.TypeString,
+			Optional:                   true,
+			Regexp:                     `^(?:[1-9]\d\d\d\d\d\d|[1-9]\d\d\d\d\d|[1-9]\d\d\d\d|[1-9]\d\d\d|[1-9]\d\d|[1-9]?\d)(?:-(?:[1-9]\d\d\d\d\d\d|[1-9]\d\d\d\d\d|[1-9]\d\d\d\d|[1-9]\d\d\d|[1-9]\d\d|[1-9]?\d))?(?:,(?:[1-9]\d\d\d\d\d\d|[1-9]\d\d\d\d\d|[1-9]\d\d\d\d|[1-9]\d\d\d|[1-9]\d\d|[1-9]?\d)(?:-(?:[1-9]\d\d\d\d\d\d|[1-9]\d\d\d\d\d|[1-9]\d\d\d\d|[1-9]\d\d\d|[1-9]\d\d|[1-9]?\d))?)*$`,
+			MinValueLength:             1,
+			MaxValueLength:             253,
+		},
+		validate.ValidateSchema{
+			Identifier:                 "scale_cpu_limit",
+			ValidateFunctionIdentifier: validate.ValidateRegexpLen,
+			Type:                       validate.TypeString,
+			Optional:                   true,
+			Regexp:                     `^([0-9.]+)([eEinumkKMGTPB]*)$`,
+			MinValueLength:             0,
+			MaxValueLength:             10,
+		},
+		validate.ValidateSchema{
+			Identifier:                 "scale_ephemeral_storage_limit",
+			ValidateFunctionIdentifier: validate.ValidateRegexpLen,
+			Type:                       validate.TypeString,
+			Optional:                   true,
+			Regexp:                     `^([0-9.]+)([eEinumkKMGTPB]*)$`,
+			MinValueLength:             0,
+			MaxValueLength:             10,
+		},
+		validate.ValidateSchema{
+			Identifier:                 "scale_memory_limit",
+			ValidateFunctionIdentifier: validate.ValidateRegexpLen,
+			Type:                       validate.TypeString,
+			Optional:                   true,
+			Regexp:                     `^([0-9.]+)([eEinumkKMGTPB]*)$`,
+			MinValueLength:             0,
+			MaxValueLength:             10,
+		},
+	)
+
+	resourceValidator := validate.ResourceValidator{ResourceName: "ibm_code_engine_job_run", Schema: validateSchema}
+	return &resourceValidator
+}
+
+func resourceIbmCodeEngineJobRunCreate(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	codeEngineClient, err := meta.(conns.ClientSession).CodeEngineV2()
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	createJobRunOptions := &codeenginev2.CreateJobRunOptions{}
+
+	createJobRunOptions.SetProjectID(d.Get("project_id").(string))
+	createJobRunOptions.SetName(d.Get("name").(string))
+	createJobRunOptions.SetJobName(d.Get("job_name").(string))
+
+	if _, ok := d.GetOk("image_reference"); ok {
+		createJobRunOptions.SetImageReference(d.Get("image_reference").(string))
+	}
+	if _, ok := d.GetOk("image_secret"); ok {
+		createJobRunOptions.SetImageSecret(d.Get("image_secret").(string))
+	}
+	if _, ok := d.GetOk("run_arguments"); ok {
+		var runArguments []string
+		for _, v := range d.Get("run_arguments").([]interface{}) {
+			runArgumentsItem := v.(string)
+			runArguments = append(runArguments, runArgumentsItem)
+		}
+		createJobRunOptions.SetRunArguments(runArguments)
+	}
+	if _, ok := d.GetOk("run_as_user"); ok {
+		createJobRunOptions.SetRunAsUser(int64(d.Get("run_as_user").(int)))
+	}
+	if _, ok := d.GetOk("run_commands"); ok {
+		var runCommands []string
+		for _, v := range d.Get("run_commands").([]interface{}) {
+			runCommandsItem := v.(string)
+			runCommands = append(runCommands, runCommandsItem)
+		}
+		createJobRunOptions.SetRunCommands(runCommands)
+	}
+	if _, ok := d.GetOk("run_env_variables"); ok {
+		var runEnvVariables []codeenginev2.EnvVarPrototype
+		for _, v := range d.Get("run_env_variables").([]interface{}) {
+			value := v.(map[string]interface{})
+			runEnvVariablesItem, err := resourceIbmCodeEngineJobMapToEnvVarPrototype(value)
+			if err != nil {
+				return diag.FromErr(err)
+			}
+			runEnvVariables = append(runEnvVariables, *runEnvVariablesItem)
+		}
+		createJobRunOptions.SetRunEnvVariables(runEnvVariables)
+	}
+	if _, ok := d.GetOk("run_mode"); ok {
+		createJobRunOptions.SetRunMode(d.Get("run_mode").(string))
+	}
+	if _, ok := d.GetOk("run_service_account"); ok {
+		createJobRunOptions.SetRunServiceAccount(d.Get("run_service_account").(string))
+	}
+	if _, ok := d.GetOk("run_volume_mounts"); ok {
+		var runVolumeMounts []codeenginev2.VolumeMountPrototype
+		for _, v := range d.Get("run_volume_mounts").([]interface{}) {
+			value := v.(map[string]interface{})
+			runVolumeMountsItem, err := resourceIbmCodeEngineJobMapToVolumeMountPrototype(value)
+			if err != nil {
+				return diag.FromErr(err)
+			}
+			runVolumeMounts = append(runVolumeMounts, *runVolumeMountsItem)
+		}
+		createJobRunOptions.SetRunVolumeMounts(runVolumeMounts)
+	}
+	if _, ok := d.GetOk("scale_array_spec"); ok {
+		createJobRunOptions.SetScaleArraySpec(d.Get("scale_array_spec").(string))
+	}
+	if _, ok := d.GetOk("scale_cpu_limit"); ok {
+		createJobRunOptions.SetScaleCpuLimit(d.Get("scale_cpu_limit").(string))
+	}
+	if _, ok := d.GetOk("scale_ephemeral_storage_limit"); ok {
+		createJobRunOptions.SetScaleEphemeralStorageLimit(d.Get("scale_ephemeral_storage_limit").(string))
+	}
+	if _, ok := d.GetOk("scale_max_execution_time"); ok {
+		createJobRunOptions.SetScaleMaxExecutionTime(int64(d.Get("scale_max_execution_time").(int)))
+	}
+	if _, ok := d.GetOk("scale_memory_limit"); ok {
+		createJobRunOptions.SetScaleMemoryLimit(d.Get("scale_memory_limit").(string))
+	}
+	if _, ok := d.GetOk("scale_retry_limit"); ok {
+		createJobRunOptions.SetScaleRetryLimit(int64(d.Get("scale_retry_limit").(int)))
+	}
+
+	jobRun, response, err := codeEngineClient.CreateJobRunWithContext(context, createJobRunOptions)
+	if err != nil {
+		log.Printf("[DEBUG] CreateJobRunWithContext failed %s\n%s", err, response)
+		return diag.FromErr(fmt.Errorf("CreateJobRunWithContext failed %s\n%s", err, response))
+	}
+
+	d.SetId(fmt.Sprintf("%s/%s", *createJobRunOptions.ProjectID, *jobRun.Name))
+
+	_, err = waitForIbmCodeEngineJonRunCreate(context, d, meta)
+	if err != nil {
+		return diag.FromErr(fmt.Errorf(
+			"Error waiting for resource IbmCodeEngineJobRun (%s) to be created: %s", d.Id(), err))
+	}
+
+	return resourceIbmCodeEngineJobRunRead(context, d, meta)
+}
+
+func waitForIbmCodeEngineJonRunCreate(context context.Context, d *schema.ResourceData, meta interface{}) (interface{}, error) {
+	if d.Get("run_mode") == "daemon" {
+		return true, nil
+	}
+
+	codeEngineClient, err := meta.(conns.ClientSession).CodeEngineV2()
+	if err != nil {
+		return false, err
+	}
+
+	getJobRunOptions := &codeenginev2.GetJobRunOptions{}
+	parts, err := flex.SepIdParts(d.Id(), "/")
+	if err != nil {
+		return false, err
+	}
+
+	getJobRunOptions.SetProjectID(parts[0])
+	getJobRunOptions.SetName(parts[1])
+
+	stateConf := &resource.StateChangeConf{
+		Pending: []string{"running"},
+		Target:  []string{"failed", "completed"},
+		Refresh: func() (interface{}, string, error) {
+			stateObj, response, err := codeEngineClient.GetJobRun(getJobRunOptions)
+			if err != nil {
+				if apiErr, ok := err.(bmxerror.RequestFailure); ok && apiErr.StatusCode() == 404 {
+					return nil, "", fmt.Errorf("The instance %s does not exist anymore: %s\n%s", "getJobRunOptions", err, response)
+				}
+				return nil, "", err
+			}
+			failStates := map[string]bool{"failed": true}
+			if failStates[*stateObj.Status] {
+				return stateObj, *stateObj.Status, fmt.Errorf("The instance %s failed: %s\n%s", "getJobRunOptions", err, response)
+			}
+			return stateObj, *stateObj.Status, nil
+		},
+		Timeout:    d.Timeout(schema.TimeoutCreate),
+		Delay:      20 * time.Second,
+		MinTimeout: 20 * time.Second,
+	}
+
+	return stateConf.WaitForStateContext(context)
+}
+
+func resourceIbmCodeEngineJobRunRead(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	codeEngineClient, err := meta.(conns.ClientSession).CodeEngineV2()
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	getJobRunOptions := &codeenginev2.GetJobRunOptions{}
+
+	parts, err := flex.SepIdParts(d.Id(), "/")
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	getJobRunOptions.SetProjectID(parts[0])
+	getJobRunOptions.SetName(parts[1])
+
+	jobRun, response, err := codeEngineClient.GetJobRunWithContext(context, getJobRunOptions)
+	if err != nil {
+		if response != nil && response.StatusCode == 404 {
+			d.SetId("")
+			return nil
+		}
+		log.Printf("[DEBUG] GetJobRunWithContext failed %s\n%s", err, response)
+		return diag.FromErr(fmt.Errorf("GetJobRunWithContext failed %s\n%s", err, response))
+	}
+
+	if err = d.Set("project_id", jobRun.ProjectID); err != nil {
+		return diag.FromErr(fmt.Errorf("Error setting project_id: %s", err))
+	}
+	if err = d.Set("image_reference", jobRun.ImageReference); err != nil {
+		return diag.FromErr(fmt.Errorf("Error setting image_reference: %s", err))
+	}
+	if err = d.Set("name", jobRun.Name); err != nil {
+		return diag.FromErr(fmt.Errorf("Error setting name: %s", err))
+	}
+	if err = d.Set("job_name", jobRun.JobName); err != nil {
+		return diag.FromErr(fmt.Errorf("Error setting name: %s", err))
+	}
+	if !core.IsNil(jobRun.ImageSecret) {
+		if err = d.Set("image_secret", jobRun.ImageSecret); err != nil {
+			return diag.FromErr(fmt.Errorf("Error setting image_secret: %s", err))
+		}
+	}
+	if !core.IsNil(jobRun.RunArguments) {
+		if err = d.Set("run_arguments", jobRun.RunArguments); err != nil {
+			return diag.FromErr(fmt.Errorf("Error setting run_arguments: %s", err))
+		}
+	}
+	if !core.IsNil(jobRun.RunAsUser) {
+		if err = d.Set("run_as_user", flex.IntValue(jobRun.RunAsUser)); err != nil {
+			return diag.FromErr(fmt.Errorf("Error setting run_as_user: %s", err))
+		}
+	}
+	if !core.IsNil(jobRun.RunCommands) {
+		if err = d.Set("run_commands", jobRun.RunCommands); err != nil {
+			return diag.FromErr(fmt.Errorf("Error setting run_commands: %s", err))
+		}
+	}
+	if !core.IsNil(jobRun.RunEnvVariables) {
+		runEnvVariables := []map[string]interface{}{}
+		for _, runEnvVariablesItem := range jobRun.RunEnvVariables {
+			runEnvVariablesItemMap, err := resourceIbmCodeEngineJobEnvVarToMap(&runEnvVariablesItem)
+			if err != nil {
+				return diag.FromErr(err)
+			}
+			runEnvVariables = append(runEnvVariables, runEnvVariablesItemMap)
+		}
+		if err = d.Set("run_env_variables", runEnvVariables); err != nil {
+			return diag.FromErr(fmt.Errorf("Error setting run_env_variables: %s", err))
+		}
+	}
+	if !core.IsNil(jobRun.RunMode) {
+		if err = d.Set("run_mode", jobRun.RunMode); err != nil {
+			return diag.FromErr(fmt.Errorf("Error setting run_mode: %s", err))
+		}
+	}
+	if !core.IsNil(jobRun.RunServiceAccount) {
+		if err = d.Set("run_service_account", jobRun.RunServiceAccount); err != nil {
+			return diag.FromErr(fmt.Errorf("Error setting run_service_account: %s", err))
+		}
+	}
+	if !core.IsNil(jobRun.RunVolumeMounts) {
+		runVolumeMounts := []map[string]interface{}{}
+		for _, runVolumeMountsItem := range jobRun.RunVolumeMounts {
+			runVolumeMountsItemMap, err := resourceIbmCodeEngineJobVolumeMountToMap(&runVolumeMountsItem)
+			if err != nil {
+				return diag.FromErr(err)
+			}
+			runVolumeMounts = append(runVolumeMounts, runVolumeMountsItemMap)
+		}
+		if err = d.Set("run_volume_mounts", runVolumeMounts); err != nil {
+			return diag.FromErr(fmt.Errorf("Error setting run_volume_mounts: %s", err))
+		}
+	}
+	if !core.IsNil(jobRun.ScaleArraySpec) {
+		if err = d.Set("scale_array_spec", jobRun.ScaleArraySpec); err != nil {
+			return diag.FromErr(fmt.Errorf("Error setting scale_array_spec: %s", err))
+		}
+	}
+	if !core.IsNil(jobRun.ScaleCpuLimit) {
+		if err = d.Set("scale_cpu_limit", jobRun.ScaleCpuLimit); err != nil {
+			return diag.FromErr(fmt.Errorf("Error setting scale_cpu_limit: %s", err))
+		}
+	}
+	if !core.IsNil(jobRun.ScaleEphemeralStorageLimit) {
+		if err = d.Set("scale_ephemeral_storage_limit", jobRun.ScaleEphemeralStorageLimit); err != nil {
+			return diag.FromErr(fmt.Errorf("Error setting scale_ephemeral_storage_limit: %s", err))
+		}
+	}
+	if !core.IsNil(jobRun.ScaleMaxExecutionTime) {
+		if err = d.Set("scale_max_execution_time", flex.IntValue(jobRun.ScaleMaxExecutionTime)); err != nil {
+			return diag.FromErr(fmt.Errorf("Error setting scale_max_execution_time: %s", err))
+		}
+	}
+	if !core.IsNil(jobRun.ScaleMemoryLimit) {
+		if err = d.Set("scale_memory_limit", jobRun.ScaleMemoryLimit); err != nil {
+			return diag.FromErr(fmt.Errorf("Error setting scale_memory_limit: %s", err))
+		}
+	}
+	if !core.IsNil(jobRun.ScaleRetryLimit) {
+		if err = d.Set("scale_retry_limit", flex.IntValue(jobRun.ScaleRetryLimit)); err != nil {
+			return diag.FromErr(fmt.Errorf("Error setting scale_retry_limit: %s", err))
+		}
+	}
+	if !core.IsNil(jobRun.CreatedAt) {
+		if err = d.Set("created_at", jobRun.CreatedAt); err != nil {
+			return diag.FromErr(fmt.Errorf("Error setting created_at: %s", err))
+		}
+	}
+	if !core.IsNil(jobRun.Href) {
+		if err = d.Set("href", jobRun.Href); err != nil {
+			return diag.FromErr(fmt.Errorf("Error setting href: %s", err))
+		}
+	}
+	if !core.IsNil(jobRun.ID) {
+		if err = d.Set("job_run_id", jobRun.ID); err != nil {
+			return diag.FromErr(fmt.Errorf("Error setting job_run_id: %s", err))
+		}
+	}
+	if !core.IsNil(jobRun.ResourceType) {
+		if err = d.Set("resource_type", jobRun.ResourceType); err != nil {
+			return diag.FromErr(fmt.Errorf("Error setting resource_type: %s", err))
+		}
+	}
+	if !core.IsNil(jobRun.Status) {
+		if err = d.Set("status", jobRun.Status); err != nil {
+			return diag.FromErr(fmt.Errorf("Error setting status: %s", err))
+		}
+	}
+	if !core.IsNil(jobRun.StatusDetails) {
+		statusDetailsMap, err := resourceIbmCodeEngineJobRunDetailedStatusToMap(jobRun.StatusDetails)
+		if err != nil {
+			return diag.FromErr(err)
+		}
+		if err = d.Set("status_details", []map[string]interface{}{statusDetailsMap}); err != nil {
+			return diag.FromErr(fmt.Errorf("Error setting status_details: %s", err))
+		}
+	}
+
+	return nil
+}
+
+func resourceIbmCodeEngineJobRunDelete(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	codeEngineClient, err := meta.(conns.ClientSession).CodeEngineV2()
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	deleteJobRunOptions := &codeenginev2.DeleteJobRunOptions{}
+
+	parts, err := flex.SepIdParts(d.Id(), "/")
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	deleteJobRunOptions.SetProjectID(parts[0])
+	deleteJobRunOptions.SetName(parts[1])
+
+	response, err := codeEngineClient.DeleteJobRunWithContext(context, deleteJobRunOptions)
+	if err != nil {
+		log.Printf("[DEBUG] DeleteJobRunWithContext failed %s\n%s", err, response)
+		return diag.FromErr(fmt.Errorf("DeleteJobRunWithContext failed %s\n%s", err, response))
+	}
+
+	d.SetId("")
+
+	return nil
+}
+
+func resourceIbmCodeEngineJobRunMapToEnvVarPrototype(modelMap map[string]interface{}) (*codeenginev2.EnvVarPrototype, error) {
+	model := &codeenginev2.EnvVarPrototype{}
+	if modelMap["key"] != nil && modelMap["key"].(string) != "" {
+		model.Key = core.StringPtr(modelMap["key"].(string))
+	}
+	if modelMap["name"] != nil && modelMap["name"].(string) != "" {
+		model.Name = core.StringPtr(modelMap["name"].(string))
+	}
+	if modelMap["prefix"] != nil && modelMap["prefix"].(string) != "" {
+		model.Prefix = core.StringPtr(modelMap["prefix"].(string))
+	}
+	if modelMap["reference"] != nil && modelMap["reference"].(string) != "" {
+		model.Reference = core.StringPtr(modelMap["reference"].(string))
+	}
+	if modelMap["type"] != nil && modelMap["type"].(string) != "" {
+		model.Type = core.StringPtr(modelMap["type"].(string))
+	}
+	if modelMap["value"] != nil && modelMap["value"].(string) != "" {
+		model.Value = core.StringPtr(modelMap["value"].(string))
+	}
+	return model, nil
+}
+
+func resourceIbmCodeEngineJobRunDetailedStatusToMap(model *codeenginev2.JobRunStatus) (map[string]interface{}, error) {
+	modelMap := make(map[string]interface{})
+	if model.CompletionTime != nil {
+		modelMap["completion_time"] = model.CompletionTime
+	}
+	if model.Failed != nil {
+		modelMap["failed"] = model.Failed
+	}
+	if model.Pending != nil {
+		modelMap["pending"] = model.Pending
+	}
+	if model.Requested != nil {
+		modelMap["requested"] = model.Requested
+	}
+	if model.Running != nil {
+		modelMap["running"] = model.Running
+	}
+	if model.StartTime != nil {
+		modelMap["start_time"] = model.StartTime
+	}
+	if model.Succeeded != nil {
+		modelMap["succeeded"] = model.Succeeded
+	}
+	if model.Unknown != nil {
+		modelMap["unknown"] = model.Unknown
+	}
+	return modelMap, nil
+}

--- a/ibm/service/codeengine/resource_ibm_code_engine_job_run_test.go
+++ b/ibm/service/codeengine/resource_ibm_code_engine_job_run_test.go
@@ -34,11 +34,11 @@ func TestAccIbmCodeEngineJobRunBasic(t *testing.T) {
 				Config: testAccCheckIbmCodeEngineJobRunConfigBasic(projectID, jobImageReference, jobName, jobRunName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckIbmCodeEngineJobRunExists("ibm_code_engine_job_run.code_engine_job_run_instance", conf),
-					resource.TestCheckResourceAttrSet("data.ibm_code_engine_job_run.code_engine_job_run_instance", "job_run_id"),
-					resource.TestCheckResourceAttr("data.ibm_code_engine_job_run.code_engine_job_run_instance", "project_id", projectID),
-					resource.TestCheckResourceAttr("data.ibm_code_engine_job_run.code_engine_job_run_instance", "name", jobRunName),
-					resource.TestCheckResourceAttr("data.ibm_code_engine_job_run.code_engine_job_run_instance", "jobName", jobName),
-					resource.TestCheckResourceAttr("data.ibm_code_engine_job_run.code_engine_job_run_instance", "resource_type", "job_run_v2"),
+					resource.TestCheckResourceAttrSet("ibm_code_engine_job_run.code_engine_job_run_instance", "job_run_id"),
+					resource.TestCheckResourceAttr("ibm_code_engine_job_run.code_engine_job_run_instance", "project_id", projectID),
+					resource.TestCheckResourceAttr("ibm_code_engine_job_run.code_engine_job_run_instance", "name", jobRunName),
+					resource.TestCheckResourceAttr("ibm_code_engine_job_run.code_engine_job_run_instance", "job_name", jobName),
+					resource.TestCheckResourceAttr("ibm_code_engine_job_run.code_engine_job_run_instance", "resource_type", "job_run_v2"),
 				),
 			},
 		},
@@ -58,7 +58,7 @@ func testAccCheckIbmCodeEngineJobRunConfigBasic(projectID string, imageReference
 		}
 
 		resource "ibm_code_engine_job_run" "code_engine_job_run_instance" {
-			project_id = ibm_code_engine_project.ce_project.project_id
+			project_id = data.ibm_code_engine_project.code_engine_project_instance.project_id
 			name       = "%s"
 			job_name   = ibm_code_engine_job.code_engine_job_instance.name
 		}

--- a/ibm/service/codeengine/resource_ibm_code_engine_job_run_test.go
+++ b/ibm/service/codeengine/resource_ibm_code_engine_job_run_test.go
@@ -1,0 +1,132 @@
+// Copyright IBM Corp. 2023 All Rights Reserved.
+// Licensed under the Mozilla Public License v2.0
+
+package codeengine_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	acc "github.com/IBM-Cloud/terraform-provider-ibm/ibm/acctest"
+	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/conns"
+	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/flex"
+	"github.com/IBM/code-engine-go-sdk/codeenginev2"
+)
+
+func TestAccIbmCodeEngineJobRunBasic(t *testing.T) {
+	var conf codeenginev2.JobRun
+	jobName := fmt.Sprintf("tf-data-job-basic-%d", acctest.RandIntRange(10, 1000))
+	jobRunName := fmt.Sprintf("tf-data-job-run-basic-%d", acctest.RandIntRange(10, 1000))
+	jobImageReference := "icr.io/codeengine/helloworld"
+
+	projectID := acc.CeProjectId
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { acc.TestAccPreCheck(t) },
+		Providers:    acc.TestAccProviders,
+		CheckDestroy: testAccCheckIbmCodeEngineJobRunDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccCheckIbmCodeEngineJobRunConfigBasic(projectID, jobImageReference, jobName, jobRunName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckIbmCodeEngineJobRunExists("ibm_code_engine_job_run.code_engine_job_run_instance", conf),
+					resource.TestCheckResourceAttrSet("data.ibm_code_engine_job_run.code_engine_job_run_instance", "job_run_id"),
+					resource.TestCheckResourceAttr("data.ibm_code_engine_job_run.code_engine_job_run_instance", "project_id", projectID),
+					resource.TestCheckResourceAttr("data.ibm_code_engine_job_run.code_engine_job_run_instance", "name", jobRunName),
+					resource.TestCheckResourceAttr("data.ibm_code_engine_job_run.code_engine_job_run_instance", "jobName", jobName),
+					resource.TestCheckResourceAttr("data.ibm_code_engine_job_run.code_engine_job_run_instance", "resource_type", "job_run_v2"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckIbmCodeEngineJobRunConfigBasic(projectID string, imageReference string, jobName string, jobRunName string) string {
+	return fmt.Sprintf(`
+		data "ibm_code_engine_project" "code_engine_project_instance" {
+			project_id = "%s"
+		}
+
+		resource "ibm_code_engine_job" "code_engine_job_instance" {
+			project_id = data.ibm_code_engine_project.code_engine_project_instance.project_id
+			image_reference = "%s"
+			name = "%s"
+		}
+
+		resource "ibm_code_engine_job_run" "code_engine_job_run_instance" {
+			project_id = ibm_code_engine_project.ce_project.project_id
+			name       = "%s"
+			job_name   = ibm_code_engine_job.code_engine_job_instance.name
+		}
+	`, projectID, imageReference, jobName, jobRunName)
+}
+
+func testAccCheckIbmCodeEngineJobRunExists(n string, obj codeenginev2.JobRun) resource.TestCheckFunc {
+
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+
+		codeEngineClient, err := acc.TestAccProvider.Meta().(conns.ClientSession).CodeEngineV2()
+		if err != nil {
+			return err
+		}
+
+		getJobRunOptions := &codeenginev2.GetJobRunOptions{}
+
+		parts, err := flex.SepIdParts(rs.Primary.ID, "/")
+		if err != nil {
+			return err
+		}
+
+		getJobRunOptions.SetProjectID(parts[0])
+		getJobRunOptions.SetName(parts[1])
+
+		job, _, err := codeEngineClient.GetJobRun(getJobRunOptions)
+		if err != nil {
+			return err
+		}
+
+		obj = *job
+		return nil
+	}
+}
+
+func testAccCheckIbmCodeEngineJobRunDestroy(s *terraform.State) error {
+	codeEngineClient, err := acc.TestAccProvider.Meta().(conns.ClientSession).CodeEngineV2()
+	if err != nil {
+		return err
+	}
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "ibm_code_engine_job_run" {
+			continue
+		}
+
+		getJobRunOptions := &codeenginev2.GetJobRunOptions{}
+
+		parts, err := flex.SepIdParts(rs.Primary.ID, "/")
+		if err != nil {
+			return err
+		}
+
+		getJobRunOptions.SetProjectID(parts[0])
+		getJobRunOptions.SetName(parts[1])
+
+		// Try to find the key
+		_, response, err := codeEngineClient.GetJobRun(getJobRunOptions)
+
+		if err == nil {
+			return fmt.Errorf("code_engine_job_run still exists: %s", rs.Primary.ID)
+		} else if response.StatusCode != 404 {
+			return fmt.Errorf("Error checking for code_engine_job_run (%s) has been destroyed: %s", rs.Primary.ID, err)
+		}
+	}
+
+	return nil
+}

--- a/website/docs/d/code_engine_job_run.html.markdown
+++ b/website/docs/d/code_engine_job_run.html.markdown
@@ -1,0 +1,122 @@
+---
+layout: "ibm"
+page_title: "IBM : ibm_code_engine_job_run"
+description: |-
+  Get information about code_engine_job_run
+subcategory: "Code Engine"
+---
+
+# ibm_code_engine_job_run
+
+Provides a read-only data source for code_engine_job_run. You can then reference the fields of the data source in other resources within the same configuration using interpolation syntax.
+
+## Example Usage
+
+```hcl
+data "ibm_code_engine_job_run" "code_engine_job_run" {
+	project_id = data.ibm_code_engine_project.code_engine_project.project_id
+	name       = "my-job-run"
+}
+```
+
+## Argument Reference
+
+Review the argument reference that you can specify for your data source.
+
+* `name` - (Required, Forces new resource, String) The name of your job run.
+  * Constraints: The maximum length is `253` characters. The minimum length is `1` character. The value must match regular expression `/^[a-z0-9]([\\-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([\\-a-z0-9]*[a-z0-9])?)*$/`.
+* `project_id` - (Required, Forces new resource, String) The ID of the project.
+  * Constraints: The maximum length is `36` characters. The minimum length is `36` characters. The value must match regular expression `/^[0-9a-z]{8}-[0-9a-z]{4}-[0-9a-z]{4}-[0-9a-z]{4}-[0-9a-z]{12}$/`.
+
+## Attribute Reference
+
+In addition to all argument references listed, you can access the following attribute references after your data source is created.
+
+* `id` - The unique identifier of the code_engine_job_run.
+* `created_at` - (String) The timestamp when the resource was created.
+
+* `href` - (String) When you provision a new job,  a URL is created identifying the location of the instance.
+  * Constraints: The maximum length is `2048` characters. The minimum length is `0` characters. The value must match regular expression `/(([^:\/?#]+):)?(\/\/([^\/?#]*))?([^?#]*)(\\?([^#]*))?(#(.*))?$/`.
+
+* `image_reference` - (String) The name of the image that is used for this job. The format is `REGISTRY/NAMESPACE/REPOSITORY:TAG` where `REGISTRY` and `TAG` are optional. If `REGISTRY` is not specified, the default is `docker.io`. If `TAG` is not specified, the default is `latest`. If the image reference points to a registry that requires authentication, make sure to also specify the property `image_secret`.
+  * Constraints: The maximum length is `256` characters. The minimum length is `1` character. The value must match regular expression `/^([a-z0-9][a-z0-9\\-_.]+[a-z0-9][\/])?([a-z0-9][a-z0-9\\-_]+[a-z0-9][\/])?[a-z0-9][a-z0-9\\-_.\/]+[a-z0-9](:[\\w][\\w.\\-]{0,127})?(@sha256:[a-fA-F0-9]{64})?$/`.
+
+* `image_secret` - (String) The name of the image registry access secret. The image registry access secret is used to authenticate with a private registry when you download the container image. If the image reference points to a registry that requires authentication, the job / job runs will be created but submitted job runs will fail, until this property is provided, too. This property must not be set on a job run, which references a job template.
+  * Constraints: The maximum length is `253` characters. The minimum length is `1` character. The value must match regular expression `/^[a-z0-9]([\\-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([\\-a-z0-9]*[a-z0-9])?)*$/`.
+
+* `job_id` - (String) The identifier of the resource.
+  * Constraints: The maximum length is `36` characters. The minimum length is `36` characters. The value must match regular expression `/^[0-9a-z]{8}-[0-9a-z]{4}-[0-9a-z]{4}-[0-9a-z]{4}-[0-9a-z]{12}$/`.
+
+* `resource_type` - (String) The type of the job.
+  * Constraints: Allowable values are: `job_run_v2`.
+
+* `run_arguments` - (List) Set arguments for the job that are passed to start job run containers. If not specified an empty string array will be applied and the arguments specified by the container image, will be used to start the container.
+  * Constraints: The list items must match regular expression `/^.*$/`. The maximum length is `100` items. The minimum length is `0` items.
+
+* `run_as_user` - (Integer) The user ID (UID) to run the job (e.g., 1001).
+
+* `run_commands` - (List) Set commands for the job that are passed to start job run containers. If not specified an empty string array will be applied and the command specified by the container image, will be used to start the container.
+  * Constraints: The list items must match regular expression `/^.*$/`. The maximum length is `100` items. The minimum length is `0` items.
+
+* `run_env_variables` - (List) References to config maps, secrets or literal values, which are exposed as environment variables in the job run.
+  * Constraints: The maximum length is `100` items. The minimum length is `0` items.
+Nested scheme for **run_env_variables**:
+	* `key` - (String) The key to reference as environment variable.
+	  * Constraints: The maximum length is `253` characters. The minimum length is `1` character. The value must match regular expression `/^[\\-._a-zA-Z0-9]+$/`.
+	* `name` - (String) The name of the environment variable.
+	  * Constraints: The maximum length is `253` characters. The minimum length is `1` character. The value must match regular expression `/^[\\-._a-zA-Z0-9]+$/`.
+	* `prefix` - (String) A prefix that can be added to all keys of a full secret or config map reference.
+	  * Constraints: The maximum length is `253` characters. The minimum length is `0` characters. The value must match regular expression `/^[a-zA-Z_][a-zA-Z0-9_]*$/`.
+	* `reference` - (String) The name of the secret or config map.
+	  * Constraints: The maximum length is `253` characters. The minimum length is `1` character. The value must match regular expression `/^[a-z0-9]([\\-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([\\-a-z0-9]*[a-z0-9])?)*$/`.
+	* `type` - (String) Specify the type of the environment variable.
+	  * Constraints: The default value is `literal`. Allowable values are: `literal`, `config_map_full_reference`, `secret_full_reference`, `config_map_key_reference`, `secret_key_reference`. The value must match regular expression `/^(literal|config_map_full_reference|secret_full_reference|config_map_key_reference|secret_key_reference)$/`.
+	* `value` - (String) The literal value of the environment variable.
+	  * Constraints: The maximum length is `253` characters. The minimum length is `1` character. The value must match regular expression `/^[\\-._a-zA-Z0-9]+$/`.
+
+* `run_mode` - (String) The mode for runs of the job. Valid values are `task` and `daemon`. In `task` mode, the `max_execution_time` and `retry_limit` properties apply. In `daemon` mode, since there is no timeout and failed instances are restarted indefinitely, the `max_execution_time` and `retry_limit` properties are not allowed.
+  * Constraints: The default value is `task`. Allowable values are: `task`, `daemon`. The minimum length is `0` characters. The value must match regular expression `/^(task|daemon)$/`.
+
+* `run_service_account` - (String) The name of the service account. For built-in service accounts, you can use the shortened names `manager`, `none`, `reader`, and `writer`. This property must not be set on a job run, which references a job template.
+  * Constraints: The default value is `default`. Allowable values are: `default`, `manager`, `reader`, `writer`, `none`. The minimum length is `0` characters. The value must match regular expression `/^(manager|reader|writer|none|default)$/`.
+
+* `run_volume_mounts` - (List) Optional mounts of config maps or a secrets.
+  * Constraints: The maximum length is `100` items. The minimum length is `0` items.
+Nested scheme for **run_volume_mounts**:
+	* `mount_path` - (String) The path that should be mounted.
+	  * Constraints: The maximum length is `256` characters. The minimum length is `1` character. The value must match regular expression `/^\/([^\/\\0]+\/?)+$/`.
+	* `name` - (String) The name of the mount.
+	  * Constraints: The maximum length is `63` characters. The minimum length is `0` characters. The value must match regular expression `/^[a-z]([-a-z0-9]*[a-z0-9])?$/`.
+	* `reference` - (String) The name of the referenced secret or config map.
+	  * Constraints: The maximum length is `253` characters. The minimum length is `1` character. The value must match regular expression `/^[a-z0-9]([\\-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([\\-a-z0-9]*[a-z0-9])?)*$/`.
+	* `type` - (String) Specify the type of the volume mount. Allowed types are: 'config_map', 'secret'.
+	  * Constraints: The default value is `secret`. Allowable values are: `config_map`, `secret`. The value must match regular expression `/^(config_map|secret)$/`.
+
+* `scale_array_spec` - (String) Define a custom set of array indices as comma-separated list containing single values and hyphen-separated ranges like `5,12-14,23,27`. Each instance can pick up its array index via environment variable `JOB_INDEX`. The number of unique array indices specified here determines the number of job instances to run.
+  * Constraints: The maximum length is `253` characters. The minimum length is `1` character. The value must match regular expression `/^(?:[1-9]\\d\\d\\d\\d\\d\\d|[1-9]\\d\\d\\d\\d\\d|[1-9]\\d\\d\\d\\d|[1-9]\\d\\d\\d|[1-9]\\d\\d|[1-9]?\\d)(?:-(?:[1-9]\\d\\d\\d\\d\\d\\d|[1-9]\\d\\d\\d\\d\\d|[1-9]\\d\\d\\d\\d|[1-9]\\d\\d\\d|[1-9]\\d\\d|[1-9]?\\d))?(?:,(?:[1-9]\\d\\d\\d\\d\\d\\d|[1-9]\\d\\d\\d\\d\\d|[1-9]\\d\\d\\d\\d|[1-9]\\d\\d\\d|[1-9]\\d\\d|[1-9]?\\d)(?:-(?:[1-9]\\d\\d\\d\\d\\d\\d|[1-9]\\d\\d\\d\\d\\d|[1-9]\\d\\d\\d\\d|[1-9]\\d\\d\\d|[1-9]\\d\\d|[1-9]?\\d))?)*$/`.
+
+* `scale_cpu_limit` - (String) Optional amount of CPU set for the instance of the job. For valid values see [Supported memory and CPU combinations](https://cloud.ibm.com/docs/codeengine?topic=codeengine-mem-cpu-combo).
+  * Constraints: The default value is `1`. The maximum length is `10` characters. The minimum length is `0` characters. The value must match regular expression `/^([0-9.]+)([eEinumkKMGTPB]*)$/`.
+
+* `scale_ephemeral_storage_limit` - (String) Optional amount of ephemeral storage to set for the instance of the job. The amount specified as ephemeral storage, must not exceed the amount of `scale_memory_limit`. The units for specifying ephemeral storage are Megabyte (M) or Gigabyte (G), whereas G and M are the shorthand expressions for GB and MB. For more information see [Units of measurement](https://cloud.ibm.com/docs/codeengine?topic=codeengine-mem-cpu-combo#unit-measurements).
+  * Constraints: The default value is `400M`. The maximum length is `10` characters. The minimum length is `0` characters. The value must match regular expression `/^([0-9.]+)([eEinumkKMGTPB]*)$/`.
+
+* `scale_max_execution_time` - (Integer) The maximum execution time in seconds for runs of the job. This property can only be specified if `run_mode` is `task`.
+
+* `scale_memory_limit` - (String) Optional amount of memory set for the instance of the job. For valid values see [Supported memory and CPU combinations](https://cloud.ibm.com/docs/codeengine?topic=codeengine-mem-cpu-combo). The units for specifying memory are Megabyte (M) or Gigabyte (G), whereas G and M are the shorthand expressions for GB and MB. For more information see [Units of measurement](https://cloud.ibm.com/docs/codeengine?topic=codeengine-mem-cpu-combo#unit-measurements).
+  * Constraints: The default value is `4G`. The maximum length is `10` characters. The minimum length is `0` characters. The value must match regular expression `/^([0-9.]+)([eEinumkKMGTPB]*)$/`.
+
+* `scale_retry_limit` - (Integer) The number of times to rerun an instance of the job before the job is marked as failed. This property can only be specified if `run_mode` is `task`.
+
+* `status` - (String) The current status of the job run.
+  * Constraints: Allowable values are: `failed`, `completed`, `running`
+
+* `status_details` - (Map) The detailed status of the job run.
+  * `start_time` - (String) Time the job run started.
+  * `completion_time` - (String) Time the job run completed.
+  * `failed` - (Integer) Number of failed job run instances.
+  * `pending` - (Integer) Number of pending job run instances.
+  * `requested` - (Integer) Number of requested job run instances.
+  * `running` - (Integer) Number of running job run instances.
+  * `succeeded` - (Integer) Number of succeeded job run instances.
+  * `unknown` - (Integer) Number of job run instances with unknown state.

--- a/website/docs/r/code_engine_job_run.html.markdown
+++ b/website/docs/r/code_engine_job_run.html.markdown
@@ -1,0 +1,130 @@
+---
+layout: "ibm"
+page_title: "IBM : ibm_code_engine_job_run"
+description: |-
+  Manages code_engine_job_run.
+subcategory: "Code Engine"
+---
+
+# ibm_code_engine_job_run
+
+Provides a resource for code_engine_job_run. This allows code_engine_job_run to be created and deleted.
+
+## Example Usage
+
+```hcl
+resource "ibm_code_engine_job_run" "code_engine_job_run_instance" {
+  project_id      = ibm_code_engine_project.code_engine_project_instance.project_id
+  name            = "my-job"
+  job_name        = "my-job-run"
+}
+```
+
+## Argument Reference
+
+Review the argument reference that you can specify for your resource.
+
+* `image_reference` - (Optional, String) The name of the image that is used for this job. The format is `REGISTRY/NAMESPACE/REPOSITORY:TAG` where `REGISTRY` and `TAG` are optional. If `REGISTRY` is not specified, the default is `docker.io`. If `TAG` is not specified, the default is `latest`. If the image reference points to a registry that requires authentication, make sure to also specify the property `image_secret`.
+  * Constraints: The maximum length is `256` characters. The minimum length is `1` character. The value must match regular expression `/^([a-z0-9][a-z0-9\\-_.]+[a-z0-9][\/])?([a-z0-9][a-z0-9\\-_]+[a-z0-9][\/])?[a-z0-9][a-z0-9\\-_.\/]+[a-z0-9](:[\\w][\\w.\\-]{0,127})?(@sha256:[a-fA-F0-9]{64})?$/`.
+* `image_secret` - (Optional, String) The name of the image registry access secret. The image registry access secret is used to authenticate with a private registry when you download the container image. If the image reference points to a registry that requires authentication, the job / job runs will be created but submitted job runs will fail, until this property is provided, too. This property must not be set on a job run, which references a job template.
+  * Constraints: The maximum length is `253` characters. The minimum length is `1` character. The value must match regular expression `/^[a-z0-9]([\\-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([\\-a-z0-9]*[a-z0-9])?)*$/`.
+* `name` - (Required, String) The name of the job run. Use a name that is unique within the project.
+  * Constraints: The maximum length is `63` characters. The minimum length is `1` character. The value must match regular expression `/^[a-z0-9]([\\-a-z0-9]*[a-z0-9])?$/`.
+* `job_name` - (Required, String) The name of the job on which this job run is based on. If specified, the job run will inherit the configuration of the referenced job.
+  * Constraints: The maximum length is `63` characters. The minimum length is `1` character. The value must match regular expression `/^[a-z0-9]([\\-a-z0-9]*[a-z0-9])?$/`.
+* `project_id` - (Required, Forces new resource, String) The ID of the project.
+  * Constraints: The maximum length is `36` characters. The minimum length is `36` characters. The value must match regular expression `/^[0-9a-z]{8}-[0-9a-z]{4}-[0-9a-z]{4}-[0-9a-z]{4}-[0-9a-z]{12}$/`.
+* `run_arguments` - (Optional, List) Set arguments for the job that are passed to start job run containers. If not specified an empty string array will be applied and the arguments specified by the container image, will be used to start the container.
+  * Constraints: The list items must match regular expression `/^.*$/`. The maximum length is `100` items. The minimum length is `0` items.
+* `run_as_user` - (Optional, Integer) The user ID (UID) to run the application (e.g., 1001).
+* `run_commands` - (Optional, List) Set commands for the job that are passed to start job run containers. If not specified an empty string array will be applied and the command specified by the container image, will be used to start the container.
+  * Constraints: The list items must match regular expression `/^.*$/`. The maximum length is `100` items. The minimum length is `0` items.
+* `run_env_variables` - (Optional, List) Optional references to config maps, secrets or a literal values.
+  * Constraints: The maximum length is `100` items. The minimum length is `0` items.
+Nested scheme for **run_env_variables**:
+	* `key` - (Optional, String) The key to reference as environment variable.
+	  * Constraints: The maximum length is `253` characters. The minimum length is `1` character. The value must match regular expression `/^[\\-._a-zA-Z0-9]+$/`.
+	* `name` - (Optional, String) The name of the environment variable.
+	  * Constraints: The maximum length is `253` characters. The minimum length is `1` character. The value must match regular expression `/^[\\-._a-zA-Z0-9]+$/`.
+	* `prefix` - (Optional, String) A prefix that can be added to all keys of a full secret or config map reference.
+	  * Constraints: The maximum length is `253` characters. The minimum length is `0` characters. The value must match regular expression `/^[a-zA-Z_][a-zA-Z0-9_]*$/`.
+	* `reference` - (Optional, String) The name of the secret or config map.
+	  * Constraints: The maximum length is `253` characters. The minimum length is `1` character. The value must match regular expression `/^[a-z0-9]([\\-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([\\-a-z0-9]*[a-z0-9])?)*$/`.
+	* `type` - (Optional, String) Specify the type of the environment variable.
+	  * Constraints: The default value is `literal`. Allowable values are: `literal`, `config_map_full_reference`, `secret_full_reference`, `config_map_key_reference`, `secret_key_reference`. The value must match regular expression `/^(literal|config_map_full_reference|secret_full_reference|config_map_key_reference|secret_key_reference)$/`.
+	* `value` - (Optional, String) The literal value of the environment variable.
+	  * Constraints: The maximum length is `253` characters. The minimum length is `1` character. The value must match regular expression `/^[\\-._a-zA-Z0-9]+$/`.
+* `run_mode` - (Optional, String) The mode for runs of the job. Valid values are `task` and `daemon`. In `task` mode, the `max_execution_time` and `retry_limit` properties apply. In `daemon` mode, since there is no timeout and failed instances are restarted indefinitely, the `max_execution_time` and `retry_limit` properties are not allowed.
+  * Constraints: The default value is `task`. Allowable values are: `task`, `daemon`. The minimum length is `0` characters. The value must match regular expression `/^(task|daemon)$/`.
+* `run_service_account` - (Optional, String) The name of the service account. For built-in service accounts, you can use the shortened names `manager`, `none`, `reader`, and `writer`. This property must not be set on a job run, which references a job template.
+  * Constraints: The default value is `default`. Allowable values are: `default`, `manager`, `reader`, `writer`, `none`. The minimum length is `0` characters. The value must match regular expression `/^(manager|reader|writer|none|default)$/`.
+* `run_volume_mounts` - (Optional, List) Optional mounts of config maps or a secrets.
+  * Constraints: The maximum length is `100` items. The minimum length is `0` items.
+Nested scheme for **run_volume_mounts**:
+	* `mount_path` - (Required, String) The path that should be mounted.
+	  * Constraints: The maximum length is `256` characters. The minimum length is `1` character. The value must match regular expression `/^\/([^\/\\0]+\/?)+$/`.
+	* `name` - (Optional, String) Optional name of the mount. If not set, it will be generated based on the `ref` and a random ID. In case the `ref` is longer than 58 characters, it will be cut off.
+	  * Constraints: The maximum length is `63` characters. The minimum length is `0` characters. The value must match regular expression `/^[a-z]([-a-z0-9]*[a-z0-9])?$/`.
+	* `reference` - (Required, String) The name of the referenced secret or config map.
+	  * Constraints: The maximum length is `253` characters. The minimum length is `1` character. The value must match regular expression `/^[a-z0-9]([\\-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([\\-a-z0-9]*[a-z0-9])?)*$/`.
+	* `type` - (Required, String) Specify the type of the volume mount. Allowed types are: 'config_map', 'secret'.
+	  * Constraints: The default value is `secret`. Allowable values are: `config_map`, `secret`. The value must match regular expression `/^(config_map|secret)$/`.
+* `scale_array_spec` - (Optional, String) Define a custom set of array indices as comma-separated list containing single values and hyphen-separated ranges like `5,12-14,23,27`. Each instance can pick up its array index via environment variable `JOB_INDEX`. The number of unique array indices specified here determines the number of job instances to run.
+  * Constraints:  The default value is `0`. The maximum length is `253` characters. The minimum length is `1` character. The value must match regular expression `/^(?:[1-9]\\d\\d\\d\\d\\d\\d|[1-9]\\d\\d\\d\\d\\d|[1-9]\\d\\d\\d\\d|[1-9]\\d\\d\\d|[1-9]\\d\\d|[1-9]?\\d)(?:-(?:[1-9]\\d\\d\\d\\d\\d\\d|[1-9]\\d\\d\\d\\d\\d|[1-9]\\d\\d\\d\\d|[1-9]\\d\\d\\d|[1-9]\\d\\d|[1-9]?\\d))?(?:,(?:[1-9]\\d\\d\\d\\d\\d\\d|[1-9]\\d\\d\\d\\d\\d|[1-9]\\d\\d\\d\\d|[1-9]\\d\\d\\d|[1-9]\\d\\d|[1-9]?\\d)(?:-(?:[1-9]\\d\\d\\d\\d\\d\\d|[1-9]\\d\\d\\d\\d\\d|[1-9]\\d\\d\\d\\d|[1-9]\\d\\d\\d|[1-9]\\d\\d|[1-9]?\\d))?)*$/`.
+* `scale_cpu_limit` - (Optional, String) Optional amount of CPU set for the instance of the job. For valid values see [Supported memory and CPU combinations](https://cloud.ibm.com/docs/codeengine?topic=codeengine-mem-cpu-combo).
+  * Constraints: The default value is `1`. The maximum length is `10` characters. The minimum length is `0` characters. The value must match regular expression `/^([0-9.]+)([eEinumkKMGTPB]*)$/`.
+* `scale_ephemeral_storage_limit` - (Optional, String) Optional amount of ephemeral storage to set for the instance of the job. The amount specified as ephemeral storage, must not exceed the amount of `scale_memory_limit`. The units for specifying ephemeral storage are Megabyte (M) or Gigabyte (G), whereas G and M are the shorthand expressions for GB and MB. For more information see [Units of measurement](https://cloud.ibm.com/docs/codeengine?topic=codeengine-mem-cpu-combo#unit-measurements).
+  * Constraints: The default value is `400M`. The maximum length is `10` characters. The minimum length is `0` characters. The value must match regular expression `/^([0-9.]+)([eEinumkKMGTPB]*)$/`.
+* `scale_max_execution_time` - (Optional, Integer) The maximum execution time in seconds for runs of the job. This property can only be specified if `run_mode` is `task`.
+  * Constraints: The default value is `7200`.
+* `scale_memory_limit` - (Optional, String) Optional amount of memory set for the instance of the job. For valid values see [Supported memory and CPU combinations](https://cloud.ibm.com/docs/codeengine?topic=codeengine-mem-cpu-combo). The units for specifying memory are Megabyte (M) or Gigabyte (G), whereas G and M are the shorthand expressions for GB and MB. For more information see [Units of measurement](https://cloud.ibm.com/docs/codeengine?topic=codeengine-mem-cpu-combo#unit-measurements).
+  * Constraints: The default value is `4G`. The maximum length is `10` characters. The minimum length is `0` characters. The value must match regular expression `/^([0-9.]+)([eEinumkKMGTPB]*)$/`.
+* `scale_retry_limit` - (Optional, Integer) The number of times to rerun an instance of the job before the job is marked as failed. This property can only be specified if `run_mode` is `task`.
+  * Constraints: The default value is `3`.
+
+## Attribute Reference
+
+In addition to all argument references listed, you can access the following attribute references after your resource is created.
+
+* `id` - The unique identifier of the code_engine_job_run.
+* `job_id` - (String) The identifier of the resource.
+  * Constraints: The maximum length is `36` characters. The minimum length is `36` characters. The value must match regular expression `/^[0-9a-z]{8}-[0-9a-z]{4}-[0-9a-z]{4}-[0-9a-z]{4}-[0-9a-z]{12}$/`.
+* `created_at` - (String) The timestamp when the resource was created.
+* `entity_tag` - (String) The version of the job instance, which is used to achieve optimistic locking.
+  * Constraints: The maximum length is `63` characters. The minimum length is `1` character. The value must match regular expression `/^[\\*\\-a-z0-9]+$/`.
+* `href` - (String) When you provision a new job,  a URL is created identifying the location of the instance.
+  * Constraints: The maximum length is `2048` characters. The minimum length is `0` characters. The value must match regular expression `/(([^:\/?#]+):)?(\/\/([^\/?#]*))?([^?#]*)(\\?([^#]*))?(#(.*))?$/`.
+* `resource_type` - (String) The type of the job.
+  * Constraints: Allowable values are: `job_run_v2`.
+* `status` - (String) The current status of the job run.
+  * Constraints: Allowable values are: `failed`, `completed`, `running`
+* `status_details` - (Map) The detailed status of the job run.
+  * `start_time` - (String) Time the job run started.
+  * `completion_time` - (String) Time the job run completed.
+  * `failed` - (Integer) Number of failed job run instances.
+  * `pending` - (Integer) Number of pending job run instances.
+  * `requested` - (Integer) Number of requested job run instances.
+  * `running` - (Integer) Number of running job run instances.
+  * `succeeded` - (Integer) Number of succeeded job run instances.
+  * `unknown` - (Integer) Number of job run instances with unknown state.
+
+## Import
+
+You can import the `ibm_code_engine_job_run` resource by using `name`.
+The `name` property can be formed from `project_id`, and `name` in the following format:
+
+```
+<project_id>/<name>
+```
+* `project_id`: A string in the format `15314cc3-85b4-4338-903f-c28cdee6d005`. The ID of the project.
+* `name`: A string in the format `my-job-run`. The name of your job run.
+
+# Syntax
+```shell
+$ terraform import ibm_code_engine_job_run.code_engine_job_run <project_id>/<name>
+```
+
+# Example
+```shell
+$ terraform import ibm_code_engine_job_run.code_engine_job_run "15314cc3-85b4-4338-903f-c28cdee6d005/my-job"
+```


### PR DESCRIPTION
### Info
This PR adds an implementation for IBM Cloud Code Engine Job Run

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #4897

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccIbmCodeEngineJobRunBasic'
=> Checking that code complies with gofmt requirements...
TF_ACC=1 go test $(go list ./... |grep -v 'vendor') -v -run=TestAccIbmCodeEngineJobRunBasic -timeout 700m
?   	github.com/IBM-Cloud/terraform-provider-ibm	[no test files]
?   	github.com/IBM-Cloud/terraform-provider-ibm/ibm/acctest	[no test files]
?   	github.com/IBM-Cloud/terraform-provider-ibm/ibm/flex	[no test files]
?   	github.com/IBM-Cloud/terraform-provider-ibm/ibm/provider	[no test files]
testing: warning: no tests to run=
PASS
...
=== RUN   TestAccIbmCodeEngineJobRunBasic
--- PASS: TestAccIbmCodeEngineJobRunBasic (84.56s)
PASS
ok  	github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/codeengine	86.492s
```

```
$ make testacc TESTARGS='-run=TestAccIbmCodeEngineJobRunDataSourceBasic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test $(go list ./... |grep -v 'vendor') -v -run=TestAccIbmCodeEngineJobRunDataSourceBasic -timeout 700m
?   	github.com/IBM-Cloud/terraform-provider-ibm	[no test files]
?   	github.com/IBM-Cloud/terraform-provider-ibm/ibm/acctest	[no test files]
?   	github.com/IBM-Cloud/terraform-provider-ibm/ibm/flex	[no test files]
?   	github.com/IBM-Cloud/terraform-provider-ibm/ibm/provider	[no test files]
testing: warning: no tests to run
PASS
ok  	github.com/IBM-Cloud/terraform-provider-ibm/ibm/conns	1.217s [no tests to run]
...
=== RUN   TestAccIbmCodeEngineJobRunDataSourceBasic
--- PASS: TestAccIbmCodeEngineJobRunDataSourceBasic (105.95s)
PASS
ok  	github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/codeengine	108.032s
```
