### PR TITLE
Fix wrong syntax in doc for Ingress Secret Opaque for required argument "fields"

### DIFF
--- a/website/docs/r/container_ingress_secret_opaque.html.markdown
+++ b/website/docs/r/container_ingress_secret_opaque.html.markdown
@@ -17,10 +17,10 @@ resource "ibm_container_ingress_secret_opaque" "secret" {
   secret_name="mySecretName"
   secret_namespace="mySecretNamespace"
   persistence = true
-  fields = {
+  fields {
     crn = "cert:region:crn"
   }
-  fields = {
+  fields {
     field_name = "myFieldName"
     crn = "cert:region:crn"
   }


### PR DESCRIPTION
Fix required argument "fields" in Kubernetes Service `container_ingress_secret_opaque` resource documentation.

This is to prevent the following error:

```terraform
❯ terraform plan
╷
│ Error: Unsupported argument
│
│   on main.tf line 18, in resource "ibm_container_ingress_secret_opaque" "secret":
│   18:   fields = {
│
│ An argument named "fields" is not expected here. Did you mean to define a block of type
│ "fields"?
╵
```

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Output from acceptance testing:

n/a
