### PR TITLE
Fix for COS issue 4844 

### DIFF
--- a/ibm/service/cos/data_source_ibm_cos_bucket.go
+++ b/ibm/service/cos/data_source_ibm_cos_bucket.go
@@ -720,6 +720,9 @@ func dataSourceIBMCosBucketRead(d *schema.ResourceData, meta interface{}) error 
 	if endpointType == "private" {
 		sess.SetServiceURL("https://config.private.cloud-object-storage.cloud.ibm.com/v1")
 	}
+	if endpointType == "direct" {
+		sess.SetServiceURL("https://config.direct.cloud-object-storage.cloud.ibm.com/v1")
+	}
 
 	if bucketType == "sl" {
 		satconfig := fmt.Sprintf("https://config.%s.%s.cloud-object-storage.appdomain.cloud/v1", serviceID, satlc_id)

--- a/ibm/service/cos/resource_ibm_cos_bucket.go
+++ b/ibm/service/cos/resource_ibm_cos_bucket.go
@@ -924,6 +924,9 @@ func resourceIBMCOSBucketUpdate(d *schema.ResourceData, meta interface{}) error 
 	if endpointType == "private" {
 		sess.SetServiceURL("https://config.private.cloud-object-storage.cloud.ibm.com/v1")
 	}
+	if endpointType == "direct" {
+		sess.SetServiceURL("https://config.direct.cloud-object-storage.cloud.ibm.com/v1")
+	}
 
 	if apiType == "sl" {
 		satconfig := fmt.Sprintf("https://config.%s.%s.cloud-object-storage.appdomain.cloud/v1", serviceID, bLocation)
@@ -1152,6 +1155,9 @@ func resourceIBMCOSBucketRead(d *schema.ResourceData, meta interface{}) error {
 	}
 	if endpointType == "private" {
 		sess.SetServiceURL("https://config.private.cloud-object-storage.cloud.ibm.com/v1")
+	}
+	if endpointType == "direct" {
+		sess.SetServiceURL("https://config.direct.cloud-object-storage.cloud.ibm.com/v1")
 	}
 
 	if apiType == "sl" {

--- a/ibm/service/cos/resource_ibm_cos_bucket_website_configuration_test.go
+++ b/ibm/service/cos/resource_ibm_cos_bucket_website_configuration_test.go
@@ -12,7 +12,7 @@ import (
 
 func TestAccIBMCosBucket_Website_Configuration_Bucket_Basic(t *testing.T) {
 	serviceName := fmt.Sprintf("terraform_%d", acctest.RandIntRange(10, 100))
-	bucketName := fmt.Sprintf("terraformStaticWebHosting%d", acctest.RandIntRange(10, 100))
+	bucketName := fmt.Sprintf("terraform-static-web-hosting%d", acctest.RandIntRange(10, 100))
 	bucketRegion := "us"
 	bucketClass := "standard"
 	bucketRegionType := "cross_region_location"
@@ -41,7 +41,7 @@ func TestAccIBMCosBucket_Website_Configuration_Bucket_Basic(t *testing.T) {
 
 func TestAccIBMCosBucket_Website_Configuration_Bucket_Without_Public_Access(t *testing.T) {
 	serviceName := fmt.Sprintf("terraform_%d", acctest.RandIntRange(10, 100))
-	bucketName := fmt.Sprintf("terraformStaticWebHosting%d", acctest.RandIntRange(10, 100))
+	bucketName := fmt.Sprintf("terraform-static-web-hosting%d", acctest.RandIntRange(10, 100))
 	bucketRegion := "us"
 	bucketClass := "standard"
 	bucketRegionType := "cross_region_location"
@@ -69,7 +69,7 @@ func TestAccIBMCosBucket_Website_Configuration_Bucket_Without_Public_Access(t *t
 }
 func TestAccIBMCosBucket_Website_Configuration_Bucket_Index_Document_Only(t *testing.T) {
 	serviceName := fmt.Sprintf("terraform_%d", acctest.RandIntRange(10, 100))
-	bucketName := fmt.Sprintf("terraformStaticWebHosting%d", acctest.RandIntRange(10, 100))
+	bucketName := fmt.Sprintf("terraform-static-web-hosting%d", acctest.RandIntRange(10, 100))
 	bucketRegion := "us"
 	bucketClass := "standard"
 	bucketRegionType := "cross_region_location"
@@ -96,7 +96,7 @@ func TestAccIBMCosBucket_Website_Configuration_Bucket_Index_Document_Only(t *tes
 
 func TestAccIBMCosBucket_Website_Configuration_Bucket_With_Routing_Rule(t *testing.T) {
 	serviceName := fmt.Sprintf("terraform_%d", acctest.RandIntRange(10, 100))
-	bucketName := fmt.Sprintf("terraformStaticWebHosting%d", acctest.RandIntRange(10, 100))
+	bucketName := fmt.Sprintf("terraform-static-web-hosting%d", acctest.RandIntRange(10, 100))
 	bucketRegion := "us"
 	bucketClass := "standard"
 	bucketRegionType := "cross_region_location"
@@ -133,7 +133,7 @@ func TestAccIBMCosBucket_Website_Configuration_Bucket_With_Routing_Rule(t *testi
 
 func TestAccIBMCosBucket_Website_Configuration_Bucket_With_JSON_Routing_Rule(t *testing.T) {
 	serviceName := fmt.Sprintf("terraform_%d", acctest.RandIntRange(10, 100))
-	bucketName := fmt.Sprintf("terraformStaticWebHosting%d", acctest.RandIntRange(10, 100))
+	bucketName := fmt.Sprintf("terraform-static-web-hosting%d", acctest.RandIntRange(10, 100))
 	bucketRegion := "us"
 	bucketClass := "standard"
 	bucketRegionType := "cross_region_location"
@@ -163,7 +163,7 @@ func TestAccIBMCosBucket_Website_Configuration_Bucket_With_JSON_Routing_Rule(t *
 }
 func TestAccIBMCosBucket_Website_Configuration_Bucket_With_Routing_Rule_Condition_Only(t *testing.T) {
 	serviceName := fmt.Sprintf("terraform_%d", acctest.RandIntRange(10, 100))
-	bucketName := fmt.Sprintf("terraformStaticWebHosting%d", acctest.RandIntRange(10, 100))
+	bucketName := fmt.Sprintf("terraform-static-web-hosting%d", acctest.RandIntRange(10, 100))
 	bucketRegion := "us"
 	bucketClass := "standard"
 	bucketRegionType := "cross_region_location"
@@ -192,7 +192,7 @@ func TestAccIBMCosBucket_Website_Configuration_Bucket_With_Routing_Rule_Conditio
 
 func TestAccIBMCosBucket_Website_Configuration_Bucket_With_Routing_Rule_Redirect_Only(t *testing.T) {
 	serviceName := fmt.Sprintf("terraform_%d", acctest.RandIntRange(10, 100))
-	bucketName := fmt.Sprintf("terraformStaticWebHosting%d", acctest.RandIntRange(10, 100))
+	bucketName := fmt.Sprintf("terraform-static-web-hosting%d", acctest.RandIntRange(10, 100))
 	bucketRegion := "us"
 	bucketClass := "standard"
 	bucketRegionType := "cross_region_location"
@@ -227,7 +227,7 @@ func TestAccIBMCosBucket_Website_Configuration_Bucket_With_Routing_Rule_Redirect
 
 func TestAccIBMCosBucket_Website_Configuration_Bucket_With_Multiple_Routing_Rules(t *testing.T) {
 	serviceName := fmt.Sprintf("terraform_%d", acctest.RandIntRange(10, 100))
-	bucketName := fmt.Sprintf("terraformStaticWebHosting%d", acctest.RandIntRange(10, 100))
+	bucketName := fmt.Sprintf("terraform-static-web-hosting%d", acctest.RandIntRange(10, 100))
 	bucketRegion := "us"
 	bucketClass := "standard"
 	bucketRegionType := "cross_region_location"
@@ -263,7 +263,7 @@ func TestAccIBMCosBucket_Website_Configuration_Bucket_With_Multiple_Routing_Rule
 
 func TestAccIBMCosBucket_Website_Configuration_Bucket_Upload_Object_With_Redirect(t *testing.T) {
 	serviceName := fmt.Sprintf("terraform_%d", acctest.RandIntRange(10, 100))
-	bucketName := fmt.Sprintf("terraformStaticWebHosting%d", acctest.RandIntRange(10, 100))
+	bucketName := fmt.Sprintf("terraform-static-web-hosting%d", acctest.RandIntRange(10, 100))
 	bucketRegion := "us"
 	bucketClass := "standard"
 	bucketRegionType := "cross_region_location"
@@ -293,7 +293,7 @@ func TestAccIBMCosBucket_Website_Configuration_Bucket_Upload_Object_With_Redirec
 
 func TestAccIBMCosBucket_Website_Configuration_Bucket_Empty_Config(t *testing.T) {
 	serviceName := fmt.Sprintf("terraform_%d", acctest.RandIntRange(10, 100))
-	bucketName := fmt.Sprintf("terraformStaticWebHosting%d", acctest.RandIntRange(10, 100))
+	bucketName := fmt.Sprintf("terraform-static-web-hosting%d", acctest.RandIntRange(10, 100))
 	bucketRegion := "us"
 	bucketClass := "standard"
 	bucketRegionType := "cross_region_location"
@@ -312,7 +312,7 @@ func TestAccIBMCosBucket_Website_Configuration_Bucket_Empty_Config(t *testing.T)
 
 func TestAccIBMCosBucket_Website_Configuration_Bucket_Index_And_Redirect_Together(t *testing.T) {
 	serviceName := fmt.Sprintf("terraform_%d", acctest.RandIntRange(10, 100))
-	bucketName := fmt.Sprintf("terraformStaticWebHosting%d", acctest.RandIntRange(10, 100))
+	bucketName := fmt.Sprintf("terraform-static-web-hosting%d", acctest.RandIntRange(10, 100))
 	bucketRegion := "us"
 	bucketClass := "standard"
 	bucketRegionType := "cross_region_location"
@@ -333,7 +333,7 @@ func TestAccIBMCosBucket_Website_Configuration_Bucket_Index_And_Redirect_Togethe
 
 func TestAccIBMCosBucket_Website_Configuration_Bucket_No_Config(t *testing.T) {
 	serviceName := fmt.Sprintf("terraform_%d", acctest.RandIntRange(10, 100))
-	bucketName := fmt.Sprintf("terraformStaticWebHosting%d", acctest.RandIntRange(10, 100))
+	bucketName := fmt.Sprintf("terraform-static-web-hosting%d", acctest.RandIntRange(10, 100))
 	bucketRegion := "us"
 	bucketClass := "standard"
 	bucketRegionType := "cross_region_location"


### PR DESCRIPTION
--- PASS: TestAccIBMCOSBucketDataSource_basic (38.56s)
PASS
ok  	github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/cos	40.046s
--- PASS: TestAccIBMCOSBucketObjectDataSource_basic (45.83s)
PASS
ok 	[github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/cos](http://github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/cos)	47.900s
--- PASS: TestAccIBMCOSBucketObject_basic (65.82s)
PASS
ok 	[github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/cos](http://github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/cos)	67.577s
--- PASS: TestAccIBMCOSBucketObject_VersioningEnabled (31.05s)
PASS
ok 	[github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/cos](http://github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/cos)	32.666s
--- PASS: TestAccIBMCosBucket_Objectlock_Bucket_Enabled (68.92s)
PASS
ok 	[github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/cos](http://github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/cos)	70.524s
--- PASS: TestAccIBMCosBucket_Objectlock_Configuration_Without_Rule (81.83s)
PASS
ok 	[github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/cos](http://github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/cos)	83.254s
--- PASS: TestAccIBMCosBucket_Objectlock_Configuration_Valid_Mode_and_Days (70.73s)
PASS
ok 	[github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/cos](http://github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/cos)	72.157s
--- PASS: TestAccIBMCosBucket_Objectlock_Configuration_Valid_Mode_and_Years (77.37s)
PASS
ok 	[github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/cos](http://github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/cos)	78.803s
=== RUN  TestAccIBMCosBucket_Basic
--- PASS: TestAccIBMCosBucket_Basic (141.29s)
=== RUN  TestAccIBMCosBucket_Basic_Single_Site_Location
--- PASS: TestAccIBMCosBucket_Basic_Single_Site_Location (87.65s)
PASS
ok 	[github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/cos](http://github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/cos)	230.614s
--- PASS: TestAccIBMCosBucket_import (85.78s)
PASS
ok 	[github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/cos](http://github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/cos)	87.194s
--- PASS: TestAccIBMCOSKP (76.74s)
--- PASS: TestAccIBMCOSHPCS
--- PASS: TestAccIBMCosBucket_Website_Configuration_Bucket_Basic (80.83s)
PASS
ok 	[github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/cos](http://github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/cos)	82.267s