### PR TITLE
Add IC_REGION to readme and tip on env vars

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,11 +124,19 @@ Issuing `make testacc` will now run the testcase with names matching `TestAccIBM
 
 You will also need to export the following environment variables for running the Acceptance tests.
 * `IC_API_KEY`- The IBM Cloud API Key
+* `IC_REGION` - The IBM Cloud [region](https://cloud.ibm.com/docs/overview?topic=overview-locations) used by test resources - defaults to `us-south`
 * `IAAS_CLASSIC_API_KEY` - The IBM Cloud Classic Infrastructure API Key
 * `IAAS_CLASSIC_USERNAME` - The IBM Cloud Classic Infrastructure username associated with the Classic InfrastAPI Key.
 
 Additional environment variables may be required depending on the tests being run. Check console log for warning messages about required variables. 
 
+Alternatively, look for the name of the function by PreCheck under the specific test case and inspect [ibm/acctest/acctest.go](https://github.com/IBM-Cloud/terraform-provider-ibm/blob/master/ibm/acctest/acctest.go) to find the list of environment variables required for the test.
+
+```
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { acc.TestAccPreCheck(t) },
+		Providers:    acc.TestAccProviders,
+```
 
 # IBM Cloud Ansible Modules
 


### PR DESCRIPTION
Add IC_REGION because it is easy to miss out on when setting up the test environment.

Add a tip on how to locate the required environment variables that need to be set for each specific test

For example, if I am testing some code engine test cases on resources created in us-east resource group, my tests would fail with 403 forbidden because those IDs were not present in the default us-south region. The acctest.go precheck function did not mention IC_REGION for that particular test case and it took me some manual over the REST API to find out that the test code was hitting a different region than intended.

<!--- See what makes a good Pull Request at : https://github.com/IBM-Cloud/terraform-provider-ibm/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```

No tests since modification is only in README.md