### PR TITLE
fix: CIS - remove deafult value for min_tls_version

### DIFF
--- a/ibm/service/cis/resource_ibm_cis_domain_settings.go
+++ b/ibm/service/cis/resource_ibm_cis_domain_settings.go
@@ -127,7 +127,6 @@ func ResourceIBMCISSettings() *schema.Resource {
 				ValidateFunc: validate.InvokeValidator(
 					ibmCISDomainSettings,
 					cisDomainSettingsTLSVersionValidatorID),
-				Default: "1.1",
 			},
 			cisDomainSettingsCNAMEFlattening: {
 				Type:        schema.TypeString,

--- a/ibm/service/cis/resource_ibm_cis_tls_settings.go
+++ b/ibm/service/cis/resource_ibm_cis_tls_settings.go
@@ -56,7 +56,6 @@ func ResourceIBMCISTLSSettings() *schema.Resource {
 				Description:  "Minimum version of TLS required",
 				Optional:     true,
 				ValidateFunc: validate.InvokeValidator(ibmCISTLSSettings, cisTLSSettingsMinTLSVersion),
-				Default:      "1.1",
 			},
 		},
 		Create:   resourceCISTLSSettingsUpdate,


### PR DESCRIPTION
Issue - https://github.com/IBM-Cloud/terraform-provider-ibm/issues/4937

Test Cases - 

```
arpit-mac@Arpits-MacBook-Pro-6 terraform-provider-ibm % make testacc TEST=./ibm/service/cis TESTARGS='-run=TestAccIBMCisSettings_Basic'   

==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./ibm/service/cis -v -run=TestAccIBMCisSettings_Basic -timeout 700m
--- PASS: TestAccIBMCisSettings_Basic (675.20s)
PASS
ok 	github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/cis	676.840s
```



```
arpit-mac@Arpits-MacBook-Pro-6 terraform-provider-ibm % make testacc TEST=./ibm/service/cis TESTARGS='-run=TestAccIBMCisTLSSettings_Basic'

==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./ibm/service/cis -v -run=TestAccIBMCisTLSSettings_Basic -timeout 700m
--- PASS: TestAccIBMCisTLSSettings_Basic (350.01s)
PASS
ok  	github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/cis	351.567s
```