### PR TITLE
Add satellite features and add support to the user can direct which security groups are added to their workers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,4 @@ vendor/
 !command/test-fixtures/**/*.tfstate
 !command/test-fixtures/**/.terraform/
 
+*.sh

--- a/go.mod
+++ b/go.mod
@@ -3,8 +3,8 @@ module github.com/IBM-Cloud/terraform-provider-ibm
 go 1.19
 
 require (
-	github.com/IBM-Cloud/bluemix-go v0.0.0-20231204080125-462fa9e436bc
-	github.com/IBM-Cloud/container-services-go-sdk v0.0.0-20231116055201-2a84da7b9bd6
+	github.com/IBM-Cloud/bluemix-go v0.0.0-20240110132033-6ead1f81a985
+	github.com/IBM-Cloud/container-services-go-sdk v0.0.0-20231207111718-a3b74cc935fa
 	github.com/IBM-Cloud/power-go-client v1.5.8
 	github.com/IBM/apigateway-go-sdk v0.0.0-20210714141226-a5d5d49caaca
 	github.com/IBM/appconfiguration-go-admin-sdk v0.3.0
@@ -83,7 +83,7 @@ require (
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/cenkalti/backoff/v3 v3.2.2 // indirect
 	github.com/cespare/xxhash/v2 v2.2.0 // indirect
-	github.com/cloudflare/circl v1.3.3 // indirect
+	github.com/cloudflare/circl v1.3.7 // indirect
 	github.com/cloudfoundry/jibber_jabber v0.0.0-20151120183258-bcc4c8345a21 // indirect
 	github.com/coreos/go-systemd v0.0.0-20191104093116-d3cd4ed1dbcf // indirect
 	github.com/coreos/pkg v0.0.0-20220810130054-c7d1c02cb6cf // indirect

--- a/go.sum
+++ b/go.sum
@@ -101,10 +101,10 @@ github.com/DataDog/datadog-go v2.2.0+incompatible/go.mod h1:LButxg5PwREeZtORoXG3
 github.com/DataDog/datadog-go v3.2.0+incompatible h1:qSG2N4FghB1He/r2mFrWKCaL7dXCilEuNEeAn20fdD4=
 github.com/DataDog/datadog-go v3.2.0+incompatible/go.mod h1:LButxg5PwREeZtORoXG3tL4fMGNddJ+vMq1mwgfaqoQ=
 github.com/DataDog/zstd v1.4.4/go.mod h1:1jcaCB/ufaK+sKp1NBhlGmpz41jOoPQ35bpF36t7BBo=
-github.com/IBM-Cloud/bluemix-go v0.0.0-20231204080125-462fa9e436bc h1:AeooCa6UMWycgKJ9n0do9PEZaNlYZZHqspfwUzPvopc=
-github.com/IBM-Cloud/bluemix-go v0.0.0-20231204080125-462fa9e436bc/go.mod h1:jIGLnIfj+uBv2ALz3rVHzNbNwt0V/bEWNeJKECa8Q+k=
-github.com/IBM-Cloud/container-services-go-sdk v0.0.0-20231116055201-2a84da7b9bd6 h1:QXU1Atl/JSI3ZtYB9tHbWLhrFYE1E+5Iww1sjQ7mqdo=
-github.com/IBM-Cloud/container-services-go-sdk v0.0.0-20231116055201-2a84da7b9bd6/go.mod h1:xUQL9SGAjoZFd4GNjrjjtEpjpkgU7RFXRyHesbKTjiY=
+github.com/IBM-Cloud/bluemix-go v0.0.0-20240110132033-6ead1f81a985 h1:Rsi0y9dJZNkF9zIa0Yjf9rdYHb5UqMMGbZvOcsESq90=
+github.com/IBM-Cloud/bluemix-go v0.0.0-20240110132033-6ead1f81a985/go.mod h1:jIGLnIfj+uBv2ALz3rVHzNbNwt0V/bEWNeJKECa8Q+k=
+github.com/IBM-Cloud/container-services-go-sdk v0.0.0-20231207111718-a3b74cc935fa h1:tsgTFGt4j1V3PQmzZbA4wJAeT5rz24OgY4AvY2QGek0=
+github.com/IBM-Cloud/container-services-go-sdk v0.0.0-20231207111718-a3b74cc935fa/go.mod h1:xUQL9SGAjoZFd4GNjrjjtEpjpkgU7RFXRyHesbKTjiY=
 github.com/IBM-Cloud/ibm-cloud-cli-sdk v0.5.3/go.mod h1:RiUvKuHKTBmBApDMUQzBL14pQUGKcx/IioKQPIcRQjs=
 github.com/IBM-Cloud/power-go-client v1.5.8 h1:4l9PmnYRXV/KfVNBRuc9hya6kW5cQZhN4UMUMdpn1JU=
 github.com/IBM-Cloud/power-go-client v1.5.8/go.mod h1:y4WDw/l9+29CKX98ngCCvGoHdzX49LL00B1euoAbWzQ=
@@ -314,8 +314,9 @@ github.com/circonus-labs/circonus-gometrics v2.3.1+incompatible/go.mod h1:nmEj6D
 github.com/circonus-labs/circonusllhist v0.1.3 h1:TJH+oke8D16535+jHExHj4nQvzlZrj7ug5D7I/orNUA=
 github.com/circonus-labs/circonusllhist v0.1.3/go.mod h1:kMXHVDlOchFAehlya5ePtbp5jckzBHf4XRpQvBOLI+I=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
-github.com/cloudflare/circl v1.3.3 h1:fE/Qz0QdIGqeWfnwq0RE0R7MI51s0M2E4Ga9kq5AEMs=
 github.com/cloudflare/circl v1.3.3/go.mod h1:5XYMA4rFBvNIrhs50XuiBJ15vF2pZn4nnUKZrLbUZFA=
+github.com/cloudflare/circl v1.3.7 h1:qlCDlTPz2n9fu58M0Nh1J/JzcFpfgkFHHX3O35r5vcU=
+github.com/cloudflare/circl v1.3.7/go.mod h1:sRTcRWXGLrKw6yIGJ+l7amYJFfAXbZG0kBSc8r4zxgA=
 github.com/cloudfoundry-community/go-cfclient v0.0.0-20190201205600-f136f9222381/go.mod h1:e5+USP2j8Le2M0Jo3qKPFnNhuo1wueU4nWHCXBOfQ14=
 github.com/cloudfoundry/jibber_jabber v0.0.0-20151120183258-bcc4c8345a21 h1:tuijfIjZyjZaHq9xDUh0tNitwXshJpbLkqMOJv4H3do=
 github.com/cloudfoundry/jibber_jabber v0.0.0-20151120183258-bcc4c8345a21/go.mod h1:po7NpZ/QiTKzBKyrsEAxwnTamCoh8uDk/egRpQ7siIc=

--- a/ibm/flex/structures.go
+++ b/ibm/flex/structures.go
@@ -251,6 +251,15 @@ func FlattenUsersSet(userList *schema.Set) []string {
 	return users
 }
 
+func FlattenSet(set *schema.Set) []string {
+	setList := set.List()
+	elems := make([]string, 0, len(setList))
+	for _, elem := range setList {
+		elems = append(elems, elem.(string))
+	}
+	return elems
+}
+
 func ExpandMembers(configured []interface{}) []datatypes.Network_LBaaS_LoadBalancerServerInstanceInfo {
 	members := make([]datatypes.Network_LBaaS_LoadBalancerServerInstanceInfo, 0, len(configured))
 	for _, lRaw := range configured {
@@ -422,6 +431,19 @@ func FlattenZones(list []containerv1.WorkerPoolZoneResponse) []map[string]interf
 			"zone":         zone.WorkerPoolZone.ID,
 			"private_vlan": zone.WorkerPoolZone.WorkerPoolZoneNetwork.PrivateVLAN,
 			"public_vlan":  zone.WorkerPoolZone.WorkerPoolZoneNetwork.PublicVLAN,
+			"worker_count": zone.WorkerCount,
+		}
+		zones[i] = l
+	}
+	return zones
+}
+
+func FlattenZonesv2(list []containerv2.ZoneResp) []map[string]interface{} {
+	zones := make([]map[string]interface{}, len(list))
+	for i, zone := range list {
+		l := map[string]interface{}{
+			"zone":         zone.ID,
+			"subnets":      zone.Subnets,
 			"worker_count": zone.WorkerCount,
 		}
 		zones[i] = l
@@ -3242,13 +3264,13 @@ func FlattenOpaqueSecret(fields containerv2.Fields) []map[string]interface{} {
 	return flattenedOpaqueSecret
 }
 
-// flattenHostLabels ..
-func FlattenHostLabels(hostLabels []interface{}) map[string]string {
+// flatten the provided key-value pairs
+func FlattenKeyValues(keyValues []interface{}) map[string]string {
 	labels := make(map[string]string)
-	for _, v := range hostLabels {
+	for _, v := range keyValues {
 		parts := strings.Split(v.(string), ":")
 		if len(parts) != 2 {
-			log.Fatal("Entered label " + v.(string) + "is in incorrect format.")
+			log.Fatal("Entered key-value " + v.(string) + "is in incorrect format.")
 		}
 		labels[parts[0]] = parts[1]
 	}

--- a/ibm/service/kubernetes/resource_ibm_container_vpc_cluster.go
+++ b/ibm/service/kubernetes/resource_ibm_container_vpc_cluster.go
@@ -322,6 +322,15 @@ func ResourceIBMContainerVpcCluster() *schema.Resource {
 				RequiredWith:     []string{"kms_instance_id", "crk"},
 			},
 
+			"security_groups": {
+				Type:             schema.TypeSet,
+				Optional:         true,
+				Description:      "Allow user to set which security groups added to their workers",
+				Elem:             &schema.Schema{Type: schema.TypeString},
+				Set:              flex.ResourceIBMVPCHash,
+				DiffSuppressFunc: flex.ApplyOnce,
+			},
+
 			//Get Cluster info Request
 			"state": {
 				Type:     schema.TypeString,
@@ -585,6 +594,11 @@ func resourceIBMContainerVpcClusterCreate(d *schema.ResourceData, meta interface
 	// Update params with Cloud Object Store instance CRN id option if provided
 	if v, ok := d.GetOk("cos_instance_crn"); ok {
 		params.CosInstanceCRN = v.(string)
+	}
+
+	if v, ok := d.GetOk("security_groups"); ok {
+		securityGroups := flex.FlattenSet(v.(*schema.Set))
+		params.SecurityGroupIDs = securityGroups
 	}
 
 	targetEnv, err := getVpcClusterTargetHeader(d, meta)

--- a/ibm/service/kubernetes/resource_ibm_container_vpc_worker_pool.go
+++ b/ibm/service/kubernetes/resource_ibm_container_vpc_worker_pool.go
@@ -212,6 +212,15 @@ func ResourceIBMContainerVpcWorkerPool() *schema.Resource {
 				Computed:    true,
 				Description: "Autoscaling is enabled on the workerpool",
 			},
+
+			"security_groups": {
+				Type:             schema.TypeSet,
+				Optional:         true,
+				Description:      "Allow user to set which security groups added to their workers",
+				Elem:             &schema.Schema{Type: schema.TypeString},
+				Set:              flex.ResourceIBMVPCHash,
+				DiffSuppressFunc: flex.ApplyOnce,
+			},
 		},
 	}
 }
@@ -281,6 +290,11 @@ func resourceIBMContainerVpcWorkerPoolCreate(d *schema.ResourceData, meta interf
 			WorkerCount: d.Get("worker_count").(int),
 			Zones:       zone,
 		},
+	}
+
+	if v, ok := d.GetOk("security_groups"); ok {
+		securityGroups := flex.FlattenSet(v.(*schema.Set))
+		params.SecurityGroupIDs = securityGroups
 	}
 
 	if kmsid, ok := d.GetOk("kms_instance_id"); ok {

--- a/ibm/service/kubernetes/resource_ibm_container_vpc_worker_pool_test.go
+++ b/ibm/service/kubernetes/resource_ibm_container_vpc_worker_pool_test.go
@@ -85,6 +85,31 @@ func TestAccIBMContainerVpcClusterWorkerPoolDedicatedHost(t *testing.T) {
 	})
 }
 
+func TestAccIBMContainerVpcClusterWorkerPoolSecurityGroups(t *testing.T) {
+
+	name := fmt.Sprintf("tf-vpc-worker-pool-%d", acctest.RandIntRange(10, 100))
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { acc.TestAccPreCheck(t) },
+		Providers: acc.TestAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckIBMVpcContainerWorkerPoolSecurityGroups(name),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(
+						"ibm_container_vpc_worker_pool.test_pool", "flavor", "cx2.2x4"),
+					resource.TestCheckResourceAttr(
+						"ibm_container_vpc_worker_pool.test_pool", "zones.#", "1"),
+				),
+			},
+			{
+				ResourceName:      "ibm_container_vpc_worker_pool.test_pool",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
 func testAccCheckIBMVpcContainerWorkerPoolDestroy(s *terraform.State) error {
 
 	wpClient, err := acc.TestAccProvider.Meta().(conns.ClientSession).VpcContainerAPI()
@@ -169,6 +194,70 @@ func testAccCheckIBMVpcContainerWorkerPoolBasic(name string) string {
 		"test"  = "test-pool"
 		"test1" = "test-pool1"
 	  }
+	}
+		`, name)
+}
+
+func testAccCheckIBMVpcContainerWorkerPoolSecurityGroups(name string) string {
+	return fmt.Sprintf(`
+	data "ibm_resource_group" "resource_group" {
+		is_default=true
+	}
+	resource "ibm_is_vpc" "vpc" {
+		name = "%[1]s"
+	}
+	resource "ibm_is_security_group" "security_group1" {
+		name = "%[1]s-security-group-1"
+		vpc  = ibm_is_vpc.vpc.id
+	}
+	resource "ibm_is_security_group" "security_group2" {
+		name = "%[1]s-security-group-2"
+		vpc  = ibm_is_vpc.vpc.id
+	}
+	resource "ibm_is_subnet" "subnet1" {
+		name                     = "%[1]s-subnet-1"
+		vpc                      = ibm_is_vpc.vpc.id
+		zone                     = "us-south-1"
+		total_ipv4_address_count = 256
+	}
+	resource "ibm_is_subnet" "subnet2" {
+		name                     = "%[1]s-subnet-2"
+		vpc                      = ibm_is_vpc.vpc.id
+		zone                     = "us-south-2"
+		total_ipv4_address_count = 256
+	}
+	
+	resource "ibm_container_vpc_cluster" "cluster" {
+	  name              = "%[1]s"
+	  vpc_id            = ibm_is_vpc.vpc.id
+	  flavor            = "cx2.2x4"
+	  worker_count      = 1
+	  resource_group_id = data.ibm_resource_group.resource_group.id
+	  wait_till         = "MasterNodeReady"
+	  zones {
+		subnet_id = ibm_is_subnet.subnet1.id
+		name      = ibm_is_subnet.subnet1.zone
+	  }
+	  security_groups = [ 
+		ibm_is_security_group.security_group1.id,
+		"cluster",
+	  ]
+	}
+	resource "ibm_container_vpc_worker_pool" "test_pool" {
+	  cluster           = ibm_container_vpc_cluster.cluster.id
+	  worker_pool_name  = "%[1]s"
+	  flavor            = "cx2.2x4"
+	  vpc_id            = ibm_is_vpc.vpc.id
+	  worker_count      = 1
+	  resource_group_id = data.ibm_resource_group.resource_group.id
+	  zones {
+		subnet_id = ibm_is_subnet.subnet2.id
+		name      = ibm_is_subnet.subnet2.zone
+	  }
+	  security_groups = [ 
+		ibm_is_security_group.security_group2.id,
+	  ]
+
 	}
 		`, name)
 }

--- a/ibm/service/satellite/data_source_ibm_satellite_host_script.go
+++ b/ibm/service/satellite/data_source_ibm_satellite_host_script.go
@@ -125,7 +125,7 @@ func dataSourceIBMSatelliteAttachHostScriptRead(d *schema.ResourceData, meta int
 	labels := make(map[string]string)
 	if v, ok := d.GetOk("labels"); ok {
 		l := v.(*schema.Set)
-		labels = flex.FlattenHostLabels(l.List())
+		labels = flex.FlattenKeyValues(l.List())
 		d.Set("labels", l)
 	}
 

--- a/ibm/service/satellite/data_source_ibm_satellite_location.go
+++ b/ibm/service/satellite/data_source_ibm_satellite_location.go
@@ -138,6 +138,16 @@ func DataSourceIBMSatelliteLocation() *schema.Resource {
 					},
 				},
 			},
+			"service_subnet": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "Custom subnet CIDR to provide private IP addresses for services",
+			},
+			"pod_subnet": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "Custom subnet CIDR to provide private IP addresses for pods",
+			},
 		},
 	}
 }
@@ -214,6 +224,13 @@ func dataSourceIBMSatelliteLocationRead(d *schema.ResourceData, meta interface{}
 			"An error occured during reading of instance (%s) tags : %s", d.Id(), err)
 	}
 	d.Set("tags", tags)
+
+	if instance.PodSubnet != nil {
+		d.Set("pod_subnet", *instance.PodSubnet)
+	}
+	if instance.ServiceSubnet != nil {
+		d.Set("service_subnet", *instance.ServiceSubnet)
+	}
 
 	return nil
 }

--- a/ibm/service/satellite/resource_ibm_satellite_cluster.go
+++ b/ibm/service/satellite/resource_ibm_satellite_cluster.go
@@ -280,6 +280,13 @@ func ResourceIBMSatelliteCluster() *schema.Resource {
 				Sensitive:   true,
 				Description: "The IBM Cloud Identity and Access Management (IAM) service CRN token for the service that creates the cluster.",
 			},
+			"calico_ip_autodetection": {
+				Type:             schema.TypeMap,
+				Optional:         true,
+				Description:      "Set IP autodetection to use correct interface for Calico",
+				Elem:             &schema.Schema{Type: schema.TypeString},
+				DiffSuppressFunc: flex.ApplyOnce,
+			},
 		},
 	}
 }
@@ -392,13 +399,21 @@ func resourceIBMSatelliteClusterCreate(d *schema.ResourceData, meta interface{})
 	if v, ok := d.GetOk("host_labels"); ok {
 		hostLabels := make(map[string]string)
 		hl := v.(*schema.Set)
-		hostLabels = flex.FlattenHostLabels(hl.List())
+		hostLabels = flex.FlattenKeyValues(hl.List())
 		createClusterOptions.Labels = hostLabels
 	}
 
 	if v, ok := d.GetOk("entitlement"); ok {
 		entitlement := v.(string)
 		createClusterOptions.DefaultWorkerPoolEntitlement = &entitlement
+	}
+
+	if m, ok := d.GetOk("calico_ip_autodetection"); ok {
+		methods := make(map[string]string)
+		for k, v := range m.(map[string]interface{}) {
+			methods[k] = v.(string)
+		}
+		createClusterOptions.SetCalicoIPAutodetectionMethods(methods)
 	}
 
 	if v, ok := d.GetOk("crn_token"); ok {

--- a/ibm/service/satellite/resource_ibm_satellite_cluster_worker_pool.go
+++ b/ibm/service/satellite/resource_ibm_satellite_cluster_worker_pool.go
@@ -232,7 +232,7 @@ func resourceIBMSatelliteClusterWorkerPoolCreate(d *schema.ResourceData, meta in
 	hostLabels := make(map[string]string)
 	if v, ok := d.GetOk("host_labels"); ok {
 		hl := v.(*schema.Set)
-		hostLabels = flex.FlattenHostLabels(hl.List())
+		hostLabels = flex.FlattenKeyValues(hl.List())
 		createWorkerPoolOptions.HostLabels = hostLabels
 	} else {
 		createWorkerPoolOptions.HostLabels = hostLabels

--- a/ibm/service/satellite/resource_ibm_satellite_host.go
+++ b/ibm/service/satellite/resource_ibm_satellite_host.go
@@ -149,7 +149,7 @@ func resourceIBMSatelliteHostCreate(d *schema.ResourceData, meta interface{}) er
 	labels := make(map[string]string)
 	if _, ok := d.GetOk(hostLabels); ok {
 		l := d.Get(hostLabels).(*schema.Set)
-		labels = flex.FlattenHostLabels(l.List())
+		labels = flex.FlattenKeyValues(l.List())
 		hostAssignOptions.Labels = labels
 	} else {
 		hostAssignOptions.Labels = labels
@@ -268,7 +268,7 @@ func resourceIBMSatelliteHostUpdate(d *schema.ResourceData, meta interface{}) er
 		labels := make(map[string]string)
 		if _, ok := d.GetOk(hostLabels); ok {
 			l := d.Get(hostLabels).(*schema.Set)
-			labels = flex.FlattenHostLabels(l.List())
+			labels = flex.FlattenKeyValues(l.List())
 			updateHostOptions.Labels = labels
 		}
 		response, err := satClient.UpdateSatelliteHost(updateHostOptions)

--- a/ibm/service/satellite/resource_ibm_satellite_location.go
+++ b/ibm/service/satellite/resource_ibm_satellite_location.go
@@ -209,6 +209,18 @@ func ResourceIBMSatelliteLocation() *schema.Resource {
 				Computed:  true,
 				Sensitive: true,
 			},
+			"service_subnet": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				ForceNew:    true,
+				Description: "Custom subnet CIDR to provide private IP addresses for services",
+			},
+			"pod_subnet": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				ForceNew:    true,
+				Description: "Custom subnet CIDR to provide private IP addresses for pods",
+			},
 		},
 	}
 }
@@ -273,6 +285,16 @@ func resourceIBMSatelliteLocationCreate(d *schema.ResourceData, meta interface{}
 			"X-Auth-Resource-Group": v.(string),
 		}
 		createSatLocOptions.Headers = pathParamsMap
+	}
+
+	if v, ok := d.GetOk("pod_subnet"); ok {
+		podSubnet := v.(string)
+		createSatLocOptions.PodSubnet = &podSubnet
+	}
+
+	if v, ok := d.GetOk("service_subnet"); ok {
+		serviceSubnet := v.(string)
+		createSatLocOptions.ServiceSubnet = &serviceSubnet
 	}
 
 	instance, response, err := satClient.CreateSatelliteLocation(createSatLocOptions)
@@ -355,6 +377,14 @@ func resourceIBMSatelliteLocationRead(d *schema.ResourceData, meta interface{}) 
 	if instance.Ingress != nil {
 		d.Set("ingress_hostname", *instance.Ingress.Hostname)
 		d.Set("ingress_secret", *instance.Ingress.SecretName)
+	}
+
+	if instance.PodSubnet != nil {
+		d.Set("pod_subnet", *instance.PodSubnet)
+	}
+
+	if instance.ServiceSubnet != nil {
+		d.Set("service_subnet", *instance.ServiceSubnet)
 	}
 
 	return nil

--- a/website/docs/r/container_vpc_cluster.html.markdown
+++ b/website/docs/r/container_vpc_cluster.html.markdown
@@ -217,6 +217,7 @@ Review the argument references that you can specify for your resource.
 - `crk` - (Optional, String) Root Key ID for boot volume encryption.
 - `kms_instance_id` - (Optional, String) Instance ID for boot volume encryption.
 - `kms_account_id` - (Optional, String) Account ID for boot volume encryption, if other account is providing the kms.
+- `security_groups` - (Optional, List) Enables users to define specific security groups for their workers.
 
 **Note**
 

--- a/website/docs/r/container_vpc_worker_pool.html.markdown
+++ b/website/docs/r/container_vpc_worker_pool.html.markdown
@@ -104,6 +104,7 @@ Review the argument references that you can specify for your resource.
 - `crk` - Root Key ID for boot volume encryption.
 - `kms_instance_id` - Instance ID for boot volume encryption. 
 - `kms_account_id` - Account ID for boot volume encryption, if other account is providing the kms.
+- `security_groups` - (Optional, List) Enables users to define specific security groups for their workers.
 
 ## Attribute reference
 In addition to all argument reference list, you can access the following attribute reference after your resource is created.

--- a/website/docs/r/satellite_cluster.html.markdown
+++ b/website/docs/r/satellite_cluster.html.markdown
@@ -33,6 +33,54 @@ resource "ibm_satellite_cluster" "create_cluster" {
 
 ```
 
+### Create satellite cluster with calico ip autodetection
+
+```terraform
+data "ibm_resource_group" "rg_cluster" {
+  name = var.resource_group
+}
+
+resource "ibm_satellite_cluster" "create_cluster" {
+  count = var.create_cluster ? 1 : 0
+
+  name                   = var.cluster
+  location               = var.location
+  resource_group_id      = data.ibm_resource_group.rg_cluster.id
+  enable_config_admin    = true
+  kube_version           = var.kube_version
+  wait_for_worker_update = (var.wait_for_worker_update ? var.wait_for_worker_update : true)
+  worker_count           = (var.worker_count != null ? var.worker_count : null)
+  host_labels            = (var.host_labels != null ? var.host_labels : null)
+  operating_system       = var.operating_system
+
+  dynamic "zones" {
+    for_each = (var.zones != null ? var.zones : null)
+    content {
+      id = zones.value
+    }
+  }
+
+  default_worker_pool_labels = (var.default_worker_pool_labels != null ? var.default_worker_pool_labels : null)
+  tags                       = (var.tags != null ? var.tags : null)
+  calico_ip_autodetection = (var.calico_ip_autodetection != null ? var.calico_ip_autodetection : null)
+
+  timeouts {
+    create = (var.create_timeout != null ? var.create_timeout : null)
+    update = (var.update_timeout != null ? var.update_timeout : null)
+    delete = (var.delete_timeout != null ? var.delete_timeout : null)
+  }
+
+}
+```
+
+Example value for `calico_ip_autodetection`:
+
+```terraform
+calico_ip_autodetection = {
+  "can-reach" = "www.ibm.com",
+}
+```
+
 ## Timeouts
 
 The `ibm_satellite_cluster` provides the following [Timeouts](https://www.terraform.io/docs/language/resources/syntax.html) configuration options:
@@ -72,6 +120,7 @@ Review the argument references that you can specify for your resource.
 - `tags` - (Optional, Array of Strings) Tags associated with the container cluster instance.
 - `pod_subnet` - Specify a custom subnet CIDR to provide private IP addresses for pods. The subnet must be at least `/23` or larger. For more information, see [Configuring VPC subnets](https://cloud.ibm.com/docs/containers?topic=containers-vpc-subnets).
 - `service_subnet` -  Specify a custom subnet CIDR to provide private IP addresses for services. The subnet must be at least `/24` or larger. For more information, see [Configuring VPC subnets](https://cloud.ibm.com/docs/containers?topic=containers-vpc-subnets#vpc_basics).
+- `calico_ip_autodetection` - (Optional, Map) "Set IP autodetection to use correct interface for Calico, works only with RHCOS"
 
 
 ## Attributes reference

--- a/website/docs/r/satellite_location.html.markdown
+++ b/website/docs/r/satellite_location.html.markdown
@@ -44,6 +44,23 @@ resource "ibm_satellite_location" "create_location" {
 }
 ```
 
+### Sample to create location and specify pod- and service subnet
+
+```terraform
+data "ibm_resource_group" "group" {
+    name = "Default"
+}
+
+resource "ibm_satellite_location" "create_location" {
+  location          = var.location
+  zones             = var.location_zones
+  managed_from      = var.managed_from
+  resource_group_id = data.ibm_resource_group.group.id
+  pod_subnet        = var.pod_subnet // "10.42.0.0/16"
+  service_subnet    = var.service_subnet // "192.168.42.0/24"
+}
+```
+
 ## Timeouts
 
 The `ibm_satellite_location` provides the following [Timeouts](https://www.terraform.io/docs/language/resources/syntax.html) configuration options:
@@ -74,6 +91,8 @@ Review the argument references that you can specify for your resource.
 - `logging_account_id` - (Optional, String) The account ID for IBM Log Analysis with LogDNA log forwarding.
 - `managed_from` - (Required, String) The IBM Cloud regions that you can choose from to manage your Satellite location. To list available multizone regions, run `ibmcloud ks locations`. For more information, refer to [supported IBM Cloud locations](https://cloud.ibm.com/docs/satellite?topic=satellite-sat-regions).
 - `zones`- Array of Strings - Optional- The names for the host zones. For high availability, allocate your hosts across these three zones based on your infrastructure provider zones. For example, `us-east-1`, `us-east-2`, `us-east-3` .
+- `service_subnet` - (String) Custom subnet CIDR to provide private IP addresses for services
+- `pod_subnet` - (String) Custom subnet CIDR to provide private IP addresses for pods
 
 
 ## Attribute reference


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/IBM-Cloud/terraform-provider-ibm/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TEST=./ibm/service/satellite TESTARGS='-run=TestAccSatelliteLocation_PodAndServiceSubnet'

--- PASS: TestAccSatelliteLocation_PodAndServiceSubnet (1187.34s)
PASS
ok      command-line-arguments  1187.409s
```
