### PR TITLE
new host link endpoint commits

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.18
 
 require (
 	github.com/IBM-Cloud/bluemix-go v0.0.0-20231204080125-462fa9e436bc
-	github.com/IBM-Cloud/container-services-go-sdk v0.0.0-20231106114255-c50117860a3c
+	github.com/IBM-Cloud/container-services-go-sdk v0.0.0-20231116055201-2a84da7b9bd6
 	github.com/IBM-Cloud/power-go-client v1.5.4
 	github.com/IBM/apigateway-go-sdk v0.0.0-20210714141226-a5d5d49caaca
 	github.com/IBM/appconfiguration-go-admin-sdk v0.3.0

--- a/go.sum
+++ b/go.sum
@@ -106,6 +106,8 @@ github.com/IBM-Cloud/bluemix-go v0.0.0-20231204080125-462fa9e436bc h1:AeooCa6UMW
 github.com/IBM-Cloud/bluemix-go v0.0.0-20231204080125-462fa9e436bc/go.mod h1:jIGLnIfj+uBv2ALz3rVHzNbNwt0V/bEWNeJKECa8Q+k=
 github.com/IBM-Cloud/container-services-go-sdk v0.0.0-20231106114255-c50117860a3c h1:tRS4VuOG3lHNG+yrsh3vZZQDVNLuFJB0oZbTJp9YXds=
 github.com/IBM-Cloud/container-services-go-sdk v0.0.0-20231106114255-c50117860a3c/go.mod h1:xUQL9SGAjoZFd4GNjrjjtEpjpkgU7RFXRyHesbKTjiY=
+github.com/IBM-Cloud/container-services-go-sdk v0.0.0-20231116055201-2a84da7b9bd6 h1:QXU1Atl/JSI3ZtYB9tHbWLhrFYE1E+5Iww1sjQ7mqdo=
+github.com/IBM-Cloud/container-services-go-sdk v0.0.0-20231116055201-2a84da7b9bd6/go.mod h1:xUQL9SGAjoZFd4GNjrjjtEpjpkgU7RFXRyHesbKTjiY=
 github.com/IBM-Cloud/ibm-cloud-cli-sdk v0.5.3/go.mod h1:RiUvKuHKTBmBApDMUQzBL14pQUGKcx/IioKQPIcRQjs=
 github.com/IBM-Cloud/power-go-client v1.5.4 h1:fk+QgOdZvwq696UynehfGrMGMHXDYOJfRCE3Pec9o6c=
 github.com/IBM-Cloud/power-go-client v1.5.4/go.mod h1:ZsKqKC4d4MAWujkttW1w9tG7xjlIbkIpVENX476ghVY=

--- a/ibm/service/satellite/data_source_ibm_satellite_host_script.go
+++ b/ibm/service/satellite/data_source_ibm_satellite_host_script.go
@@ -74,6 +74,11 @@ func DataSourceIBMSatelliteAttachHostScript() *schema.Resource {
 				Optional:     true,
 				ExactlyOneOf: []string{"host_provider", "custom_script"},
 			},
+			"host_link_agent_endpoint": {
+				Description: "The satellite link agent endpoint, required for reduced firewall attach script",
+				Type:        schema.TypeString,
+				Optional:    true,
+			},
 		},
 	}
 }
@@ -153,6 +158,12 @@ func dataSourceIBMSatelliteAttachHostScriptRead(d *schema.ResourceData, meta int
 		host_os = "RHEL"
 		createRegOptions.OperatingSystem = &host_os
 		scriptPath = filepath.Join(scriptDir, "addHost.sh")
+	}
+
+	// If the user supplied link agent endpoint, use reduced firewall attach script
+	if hlae, ok := d.GetOk("host_link_agent_endpoint"); ok {
+		host_link_agent_endpoint := hlae.(string)
+		createRegOptions.HostLinkAgentEndpoint = &host_link_agent_endpoint
 	}
 
 	resp, err := satClient.AttachSatelliteHost(createRegOptions)

--- a/ibm/service/satellite/data_source_ibm_satellite_host_script_test.go
+++ b/ibm/service/satellite/data_source_ibm_satellite_host_script_test.go
@@ -55,6 +55,7 @@ func TestAccIBMSatelliteAttachHostScriptDataSourceBasicCoreos(t *testing.T) {
 				Config: testAccCheckIBMSatelliteAttachHostScriptDataSourceConfigCoreos(locationName),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("data.ibm_satellite_attach_host_script.script", "host_provider", "ibm"),
+					resource.TestCheckResourceAttr("data.ibm_satellite_attach_host_script.script", "host_link_agent_endpoint", "testendpoint"),
 				),
 			},
 		},
@@ -75,5 +76,6 @@ data "ibm_satellite_attach_host_script" "script" {
 	labels         = ["env:prod"]
 	coreos_host	   = true
 	host_provider  = "ibm"
+	host_link_agent_endpoint = "testendpoint"
 }`, locationName)
 }

--- a/website/docs/d/satellite_attach_host_script.html.markdown
+++ b/website/docs/d/satellite_attach_host_script.html.markdown
@@ -21,14 +21,15 @@ data "ibm_satellite_attach_host_script" "script" {
 }
 ```
 
-###  Sample to read satellite host script to attach AWS EC2 host to Satellite control plane
+###  Sample to read satellite host script to attach AWS EC2 host to Satellite control plane and uses reduced firewall requirements.
 
 ```terraform
 data "ibm_satellite_attach_host_script" "script" {
-  location          = var.location
-  labels            = var.labels
-  script_dir        = "/tmp"
-  host_provider     = "aws"
+  location                 = var.location
+  labels                   = var.labels
+  script_dir               = "/tmp"
+  host_provider            = "aws"
+  host_link_agent_endpoint = "c-01-ws.us-south.link.satellite.cloud.ibm.com"
 }
 ```
 ###  Sample to read satellite host script to attach IBM host to Satellite control plane
@@ -38,11 +39,11 @@ data "ibm_satellite_attach_host_script" "script" {
   location      = var.location
   custom_script = <<EOF
 subscription-manager refresh
-subscription-manager repos --enable rhel-server-rhscl-7-rpms
-subscription-manager repos --enable rhel-7-server-optional-rpms
-subscription-manager repos --enable rhel-7-server-rh-common-rpms
-subscription-manager repos --enable rhel-7-server-supplementary-rpms
-subscription-manager repos --enable rhel-7-server-extras-rpms
+subscription-manager release --set=8
+subscription-manager repos --enable rhel-8-for-x86_64-baseos-rpms 
+subscription-manager repos --enable rhel-8-for-x86_64-appstream-rpms
+subscription-manager repos --disable='*eus*'
+yum install container-selinux -y
 EOF
 }
 
@@ -57,6 +58,7 @@ Review the argument references that you can specify for your data source.
 - `host_provider` - (Optional, String) The name of host provider, such as `ibm`, `aws` or `azure`.
 - `labels` - (Optional, Set(Strings)) The set of key-value pairs to label the host, such as `["cpu:4"]` to describe the host capabilities.
 - `script_dir` - (Optional, String) The directory path to store the generated script.
+- `host_link_agent_endpoint` - (Optional, String) The endpoint that the link agent uses to connect to the link tunnel server. Required for reduced firewall support.
 
 ## Attributes reference
 In addition to the argument reference list, you can access the following attribute reference after your resource is created.


### PR DESCRIPTION
Added changes to see if the user supplied a host link endpoint variable. If they did, this will allow the host attach script resource to use the reduced firewall configuration with the IBM provider.

Updated the container service package to pick up the new SDK changes that allow this to happen

Added test cases to test functionality of user supplied sat link agent endpoint

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #4911 

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
╰$ make testacc TEST=./ibm/service/satellite TESTARGS='-run=TestAccIBMSatelliteAttachHostScriptDataSourceBasicCoreos'
...

=== RUN   TestAccIBMSatelliteAttachHostScriptDataSourceBasicCoreos
--- PASS: TestAccIBMSatelliteAttachHostScriptDataSourceBasicCoreos (1107.19s)
PASS
ok      github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/satellite       1108.433s
```
