### PR TITLE
Add note to Logs Router Service Indicating it's in Beta

### DIFF
--- a/website/docs/d/logs_router_tenant.html.markdown
+++ b/website/docs/d/logs_router_tenant.html.markdown
@@ -8,6 +8,8 @@ subcategory: "Logs Router"
 
 # ibm_logs_router_tenant
 
+~> **Beta:** This resource is in Beta, and is subject to change.
+
 Provides a read-only data source to retrieve information about a logs_router_tenant. You can then reference the fields of the data source in other resources within the same configuration by using interpolation syntax.
 
 ## Example Usage

--- a/website/docs/r/logs_router_tenant.html.markdown
+++ b/website/docs/r/logs_router_tenant.html.markdown
@@ -8,6 +8,8 @@ subcategory: "Logs Router"
 
 # ibm_logs_router_tenant
 
+~> **Beta:** This resource is in Beta, and is subject to change.
+
 Create, update, and delete logs_router_tenants with this resource.
 
 ## Example Usage


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/IBM-Cloud/terraform-provider-ibm/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccIbmLogsRouter'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test $(go list ./... |grep -v 'vendor') -v -run=TestAccIbmLogsRouter -timeout 700m
?   	github.com/IBM-Cloud/terraform-provider-ibm	[no test files]
?   	github.com/IBM-Cloud/terraform-provider-ibm/ibm/acctest	[no test files]
?   	github.com/IBM-Cloud/terraform-provider-ibm/ibm/flex	[no test files]
?   	github.com/IBM-Cloud/terraform-provider-ibm/ibm/provider	[no test files]
testing: warning: no tests to run
PASS
ok  	github.com/IBM-Cloud/terraform-provider-ibm/ibm/conns	(cached) [no tests to run]
[WARN] Set the environment variable IBM_PROJECTS_CONFIG_APIKEY for testing IBM Projects Config resources, the tests will fail if this is not set
... [Many warnings for unset variables for other services' acceptance tests]
[WARN] Set the environment variable IBM_SATELLITE_SSH_PUB_KEY with a ssh public key or ibm_satellite_* tests may fail
=== RUN   TestAccIbmLogsRouterTenantDataSourceBasic
--- PASS: TestAccIbmLogsRouterTenantDataSourceBasic (23.16s)
=== RUN   TestAccIbmLogsRouterTenantBasic
--- PASS: TestAccIbmLogsRouterTenantBasic (31.10s)
PASS
ok  	github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/logsrouter	56.739s
[WARN] Set the environment variable IBM_PROJECTS_CONFIG_APIKEY for testing IBM Projects Config resources, the tests will fail if this is not Set
... [Many warnings for unset variables for other services' acceptance tests]
[WARN] Set the environment variable IBM_SATELLITE_SSH_PUB_KEY with a ssh public key or ibm_satellite_* tests may fail
testing: warning: no tests to run
PASS
ok  	github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/vpc	(cached) [no tests to run]

```
