### PR TITLE
added enhancement to one step delegate resolver in is_vpc

### DIFF
--- a/ibm/service/vpc/resource_ibm_is_vpc_test.go
+++ b/ibm/service/vpc/resource_ibm_is_vpc_test.go
@@ -298,6 +298,53 @@ func TestAccIBMISVPC_dns_delegated(t *testing.T) {
 		},
 	})
 }
+func TestAccIBMISVPC_dns_delegated_first(t *testing.T) {
+	var vpc string
+	name1 := fmt.Sprintf("terraformvpcuat-%d", acctest.RandIntRange(10, 100))
+	name2 := fmt.Sprintf("terraformvpcuat-%d", acctest.RandIntRange(10, 100))
+	subnet1 := fmt.Sprintf("terraformsubnet-%d", acctest.RandIntRange(10, 100))
+	subnet2 := fmt.Sprintf("terraformsubnet-%d", acctest.RandIntRange(10, 100))
+	resourecinstance := fmt.Sprintf("terraformresource-%d", acctest.RandIntRange(10, 100))
+	resolver1 := fmt.Sprintf("terraformresolver-%d", acctest.RandIntRange(10, 100))
+	binding := fmt.Sprintf("terraformbinding-%d", acctest.RandIntRange(10, 100))
+	enableHubTrue := true
+	enableHubFalse := false
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { acc.TestAccPreCheck(t) },
+		Providers:    acc.TestAccProviders,
+		CheckDestroy: testAccCheckIBMISVPCDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckIBMISVPCDnsDelegatedFirstConfig(name1, name2, subnet1, subnet2, resourecinstance, resolver1, binding, enableHubTrue, enableHubFalse),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckIBMISVPCExists("ibm_is_vpc.hub_true", vpc),
+					resource.TestCheckResourceAttr(
+						"ibm_is_vpc.hub_true", "name", name1),
+					resource.TestCheckResourceAttr(
+						"ibm_is_vpc.hub_false_delegated", "name", name2),
+					resource.TestCheckResourceAttr(
+						"ibm_is_vpc.hub_true", "dns.0.enable_hub", fmt.Sprintf("%t", enableHubTrue)),
+					resource.TestCheckResourceAttr(
+						"ibm_is_vpc.hub_true", "dns.0.resolver.0.type", "system"),
+					resource.TestCheckResourceAttr(
+						"ibm_is_vpc.hub_false_delegated", "dns.0.enable_hub", fmt.Sprintf("%t", enableHubFalse)),
+					resource.TestCheckResourceAttr(
+						"ibm_is_vpc.hub_false_delegated", "dns.0.resolver.0.type", "delegated"),
+					resource.TestCheckResourceAttr(
+						"ibm_is_vpc.hub_false_delegated", "dns.0.resolution_binding_count", "1"),
+					resource.TestCheckResourceAttr(
+						"ibm_is_vpc.hub_false_delegated", "dns.0.resolver.0.dns_binding_name", binding),
+					resource.TestCheckResourceAttrSet(
+						"ibm_is_vpc.hub_false_delegated", "dns.0.resolver.0.dns_binding_id"),
+					resource.TestCheckResourceAttrSet(
+						"ibm_is_vpc.hub_false_delegated", "dns.0.resolver.0.vpc_id"),
+					resource.TestCheckResourceAttrSet(
+						"ibm_is_vpc.hub_false_delegated", "dns.0.resolver.0.vpc_name"),
+				),
+			},
+		},
+	})
+}
 
 func TestAccIBMISVPC_basic_apm(t *testing.T) {
 	var vpc string
@@ -596,6 +643,69 @@ func testAccCheckIBMISVPCDnsDelegatedConfig(vpcname, vpcname2, subnetname1, subn
 	}
 	
 	`, vpcname, enableHub, vpcname2, enablehubfalse, subnetname1, acc.ISZoneName, subnetname2, acc.ISZoneName, subnetname3, acc.ISZoneName, subnetname4, acc.ISZoneName, resourceinstance, resolver1, resolver2, bindingname)
+
+}
+func testAccCheckIBMISVPCDnsDelegatedFirstConfig(vpcname, vpcname2, subnetname1, subnetname2, resourceinstance, resolver1, bindingname string, enableHub, enablehubfalse bool) string {
+	return fmt.Sprintf(`
+	data "ibm_resource_group" "rg" {
+		is_default	   =  true
+	}
+	
+	resource ibm_is_vpc hub_true {
+		name = "%s"
+		dns {
+			enable_hub = %t
+		}
+	}
+	
+	resource ibm_is_vpc hub_false_delegated {
+		depends_on = [ ibm_dns_custom_resolver.test_hub_true ]
+		name = "%s"
+		dns {
+			enable_hub = %t
+			resolver {
+				type = "delegated"
+				vpc_id = ibm_is_vpc.hub_true.id
+				dns_binding_name = "%s"
+			}
+		}
+	}
+	
+	resource "ibm_is_subnet" "hub_true_sub1" {
+		name		   				=  "%s"
+		vpc      	   				=  ibm_is_vpc.hub_true.id
+		zone		   				=  "%s"
+		total_ipv4_address_count 	= 16
+	}
+	resource "ibm_is_subnet" "hub_true_sub2" {
+		name		   				=  "%s"
+		vpc      	   				=  ibm_is_vpc.hub_true.id
+		zone		   				=  "%s"
+		total_ipv4_address_count 	= 16
+	}
+	resource "ibm_resource_instance" "dns-cr-instance" {
+		name		   		=  "%s"
+		resource_group_id  	=  data.ibm_resource_group.rg.id
+		location           	=  "global"
+		service		   		=  "dns-svcs"
+		plan		   		=  "standard-dns"
+	}
+	resource "ibm_dns_custom_resolver" "test_hub_true" {
+		name		   		=  "%s"
+		instance_id 	   	=  ibm_resource_instance.dns-cr-instance.guid
+		description	   		=  "new test CR - TF"
+		high_availability  	=  true
+		enabled 	   		=  true
+		locations {
+				subnet_crn  = ibm_is_subnet.hub_true_sub1.crn
+				enabled	 = true
+		}
+		locations {
+				subnet_crn  = ibm_is_subnet.hub_true_sub2.crn
+				enabled	 = true
+		}
+	}
+	`, vpcname, enableHub, vpcname2, enablehubfalse, bindingname, subnetname1, acc.ISZoneName, subnetname2, acc.ISZoneName, resourceinstance, resolver1)
 
 }
 func testAccCheckIBMISVPCDnsDelegatedUpdate1Config(vpcname, vpcname2, subnetname1, subnetname2, subnetname3, subnetname4, resourceinstance, resolver1, resolver2, bindingname string, enableHub, enablehubfalse bool) string {

--- a/website/docs/r/is_vpc.html.markdown
+++ b/website/docs/r/is_vpc.html.markdown
@@ -83,6 +83,22 @@ resource "ibm_is_vpc" "example-system" {
 	}
 }
 
+// delegated type resolver
+
+resource "ibm_is_vpc" "example-delegated" {
+  // required : add a dependency on ibm dns custom resolver of the hub vpc
+	depends_on = [ ibm_dns_custom_resolver.example-hub ]
+	name = "example-hub-false-delegated"
+	dns {
+		enable_hub = false
+		resolver {
+			type = "delegated"
+			vpc_id = ibm_is_vpc.example.id
+			dns_binding_name = "example-vpc-binding"
+		}
+	}
+}
+
 ```
 
 ## Timeouts
@@ -116,6 +132,9 @@ Review the argument references that you can specify for your resource.
   - `resolver` - (Optional, List) The zone list this backup policy plan will create snapshot clones in.
     Nested scheme for `resolver`:
 
+      - `dns_binding_id` - (String) The VPC dns binding id whose DNS resolver provides the DNS server addresses for this VPC. (If any)
+      - `dns_binding_name` - (Optional, String) The VPC dns binding name whose DNS resolver provides the DNS server addresses for this VPC. Only applicable for `delegated`, providing value would create binding with this name.
+
         ~> **Note:** 
           `manual_servers` must be set if and only if `dns.resolver.type` is manual.
       - `manual_servers` - (Optional, List) The DNS servers to use for this VPC, replacing any existing servers. All the DNS servers must either: **have a unique zone_affinity**, or **not have a zone_affinity**.
@@ -139,7 +158,7 @@ Review the argument references that you can specify for your resource.
         ~> **Note:** 
               Updating from `manual` requires dns resolver `manual_servers` to be specified as null.<br/>
               Updating to `manual` requires dns resolver `manual_servers` to be specified and not empty.<br/>
-              Updating from `delegated` requires `dns.resolver.vpc` to be specified as null.
+              Updating from `delegated` requires `dns.resolver.vpc` to be specified as null. If type is `delegated` while creation then `vpc_id` is required
       - `vpc_id` - (Optional, List) (update only) The VPC ID to provide DNS server addresses for this VPC. The specified VPC must be configured with a DNS Services custom resolver and must be in one of this VPC's DNS resolution bindings. Mutually exclusive with `vpc_crn`
 
         ~> **Note:** 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/IBM-Cloud/terraform-provider-ibm/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
=== RUN   TestAccIBMISVPC_dns_delegated_first
--- PASS: TestAccIBMISVPC_dns_delegated_first (295.69s)
PASS
ok      github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/vpc     298.237s
```

