### PR TITLE
fix: add multipart support for mqcloud service

### DIFF
--- a/examples/ibm-mqcloud/README.md
+++ b/examples/ibm-mqcloud/README.md
@@ -1,14 +1,21 @@
-# Example for MqcloudV1
+# Examples for MQ on Cloud
 
-This example illustrates how to use the MqcloudV1
+These examples illustrate how to use the resources and data sources associated with MQ on Cloud.
 
-The following types of resources are supported:
+The following resources are supported:
+* ibm_mqcloud_queue_manager
+* ibm_mqcloud_application
+* ibm_mqcloud_user
+* ibm_mqcloud_keystore_certificate
+* ibm_mqcloud_truststore_certificate
 
-* mqcloud_queue_manager
-* mqcloud_application
-* mqcloud_user
-* mqcloud_keystore_certificate
-* mqcloud_truststore_certificate
+The following data sources are supported:
+* ibm_mqcloud_queue_manager
+* ibm_mqcloud_queue_manager_status
+* ibm_mqcloud_application
+* ibm_mqcloud_user
+* ibm_mqcloud_truststore_certificate
+* ibm_mqcloud_keystore_certificate
 
 ## Usage
 
@@ -22,13 +29,12 @@ $ terraform apply
 
 Run `terraform destroy` when you don't need these resources.
 
+## MQ on Cloud resources
 
-## MqcloudV1 resources
-
-mqcloud_queue_manager resource:
+### Resource: ibm_mqcloud_queue_manager
 
 ```hcl
-resource "mqcloud_queue_manager" "mqcloud_queue_manager_instance" {
+resource "ibm_mqcloud_queue_manager" "mqcloud_queue_manager_instance" {
   service_instance_guid = var.mqcloud_queue_manager_service_instance_guid
   name = var.mqcloud_queue_manager_name
   display_name = var.mqcloud_queue_manager_display_name
@@ -37,94 +43,300 @@ resource "mqcloud_queue_manager" "mqcloud_queue_manager_instance" {
   version = var.mqcloud_queue_manager_version
 }
 ```
-mqcloud_application resource:
+
+#### Inputs
+
+| Name | Description | Type | Required |
+|------|-------------|------|---------|
+| ibmcloud\_api\_key | IBM Cloud API key | `string` | true |
+| service_instance_guid | The GUID that uniquely identifies the MQ on Cloud service instance. | `string` | true |
+| name | A queue manager name conforming to MQ restrictions. | `string` | true |
+| display_name | A displayable name for the queue manager - limited only in length. | `string` | false |
+| location | The locations in which the queue manager could be deployed. | `string` | true |
+| size | The queue manager sizes of deployment available. Deployment of lite queue managers for aws_us_east_1 and aws_eu_west_1 locations is not available. | `string` | true |
+| version | The MQ version of the queue manager. | `string` | false |
+
+#### Outputs
+
+| Name | Description |
+|------|-------------|
+| status_uri | A reference uri to get deployment status of the queue manager. |
+| web_console_url | The url through which to access the web console for this queue manager. |
+| rest_api_endpoint_url | The url through which to access REST APIs for this queue manager. |
+| administrator_api_endpoint_url | The url through which to access the Admin REST APIs for this queue manager. |
+| connection_info_uri | The uri through which the CDDT for this queue manager can be obtained. |
+| date_created | RFC3339 formatted UTC date for when the queue manager was created. |
+| upgrade_available | Describes whether an upgrade is available for this queue manager. |
+| available_upgrade_versions_uri | The uri through which the available versions to upgrade to can be found for this queue manager. |
+| href | The URL for this queue manager. |
+| queue_manager_id | The ID of the queue manager which was allocated on creation, and can be used for delete calls. |
+
+### Resource: ibm_mqcloud_application
 
 ```hcl
-resource "mqcloud_application" "mqcloud_application_instance" {
+resource "ibm_mqcloud_application" "mqcloud_application_instance" {
   service_instance_guid = var.mqcloud_application_service_instance_guid
   name = var.mqcloud_application_name
 }
 ```
-mqcloud_user resource:
+
+#### Inputs
+
+| Name | Description | Type | Required |
+|------|-------------|------|---------|
+| ibmcloud\_api\_key | IBM Cloud API key | `string` | true |
+| service_instance_guid | The GUID that uniquely identifies the MQ on Cloud service instance. | `string` | true |
+| name | The name of the application - conforming to MQ rules. | `string` | true |
+
+#### Outputs
+
+| Name | Description |
+|------|-------------|
+| create_api_key_uri | The URI to create a new apikey for the application. |
+| href | The URL for this application. |
+| application_id | The ID of the application which was allocated on creation, and can be used for delete calls. |
+
+### Resource: ibm_mqcloud_user
 
 ```hcl
-resource "mqcloud_user" "mqcloud_user_instance" {
+resource "ibm_mqcloud_user" "mqcloud_user_instance" {
   service_instance_guid = var.mqcloud_user_service_instance_guid
   name = var.mqcloud_user_name
   email = var.mqcloud_user_email
 }
 ```
-mqcloud_keystore_certificate resource:
+
+#### Inputs
+
+| Name | Description | Type | Required |
+|------|-------------|------|---------|
+| ibmcloud\_api\_key | IBM Cloud API key | `string` | true |
+| service_instance_guid | The GUID that uniquely identifies the MQ on Cloud service instance. | `string` | true |
+| name | The shortname of the user that will be used as the IBM MQ administrator in interactions with a queue manager for this service instance. | `string` | true |
+| email | The email of the user. | `string` | true |
+
+#### Outputs
+
+| Name | Description |
+|------|-------------|
+| href | The URL for the user details. |
+| user_id | The ID of the user which was allocated on creation, and can be used for delete calls. |
+
+### Resource: ibm_mqcloud_keystore_certificate
 
 ```hcl
-resource "mqcloud_keystore_certificate" "mqcloud_keystore_certificate_instance" {
+resource "ibm_mqcloud_keystore_certificate" "mqcloud_keystore_certificate_instance" {
   service_instance_guid = var.mqcloud_keystore_certificate_service_instance_guid
   queue_manager_id = var.mqcloud_keystore_certificate_queue_manager_id
   label = var.mqcloud_keystore_certificate_label
+  certificate_file = var.mqcloud_keystore_certificate_certificate_file
 }
 ```
-mqcloud_truststore_certificate resource:
+
+#### Inputs
+
+| Name | Description | Type | Required |
+|------|-------------|------|---------|
+| ibmcloud\_api\_key | IBM Cloud API key | `string` | true |
+| service_instance_guid | The GUID that uniquely identifies the MQ on Cloud service instance. | `string` | true |
+| queue_manager_id | The id of the queue manager to retrieve its full details. | `string` | true |
+| label | The label to use for the certificate to be uploaded. | `string` | true |
+| certificate_file | The filename and path of the certificate to be uploaded. | `base64-encoded string` | true |
+
+#### Outputs
+
+| Name | Description |
+|------|-------------|
+| certificate_type | The type of certificate. |
+| fingerprint_sha256 | Fingerprint SHA256. |
+| subject_dn | Subject's Distinguished Name. |
+| subject_cn | Subject's Common Name. |
+| issuer_dn | Issuer's Distinguished Name. |
+| issuer_cn | Issuer's Common Name. |
+| issued | Date certificate was issued. |
+| expiry | Expiry date for the certificate. |
+| is_default | Indicates whether it is the queue manager's default certificate. |
+| dns_names_total_count | The total count of dns names. |
+| dns_names | The list of DNS names. |
+| href | The URL for this key store certificate. |
+| certificate_id | ID of the certificate. |
+
+### Resource: ibm_mqcloud_truststore_certificate
 
 ```hcl
-resource "mqcloud_truststore_certificate" "mqcloud_truststore_certificate_instance" {
+resource "ibm_mqcloud_truststore_certificate" "mqcloud_truststore_certificate_instance" {
   service_instance_guid = var.mqcloud_truststore_certificate_service_instance_guid
   queue_manager_id = var.mqcloud_truststore_certificate_queue_manager_id
   label = var.mqcloud_truststore_certificate_label
+  certificate_file = var.mqcloud_truststore_certificate_certificate_file
 }
 ```
 
-## MqcloudV1 data sources
+#### Inputs
 
-mqcloud_queue_manager data source:
+| Name | Description | Type | Required |
+|------|-------------|------|---------|
+| ibmcloud\_api\_key | IBM Cloud API key | `string` | true |
+| service_instance_guid | The GUID that uniquely identifies the MQ on Cloud service instance. | `string` | true |
+| queue_manager_id | The id of the queue manager to retrieve its full details. | `string` | true |
+| label | The label to use for the certificate to be uploaded. | `string` | true |
+| certificate_file | The filename and path of the certificate to be uploaded. | `base64-encoded string` | true |
+
+#### Outputs
+
+| Name | Description |
+|------|-------------|
+| certificate_type | The type of certificate. |
+| fingerprint_sha256 | Fingerprint SHA256. |
+| subject_dn | Subject's Distinguished Name. |
+| subject_cn | Subject's Common Name. |
+| issuer_dn | Issuer's Distinguished Name. |
+| issuer_cn | Issuer's Common Name. |
+| issued | The Date the certificate was issued. |
+| expiry | Expiry date for the certificate. |
+| trusted | Indicates whether a certificate is trusted. |
+| href | The URL for this trust store certificate. |
+| certificate_id | Id of the certificate. |
+
+## MQ on Cloud data sources
+
+### Data source: ibm_mqcloud_queue_manager
 
 ```hcl
-data "mqcloud_queue_manager" "mqcloud_queue_manager_instance" {
-  service_instance_guid = var.mqcloud_queue_manager_service_instance_guid
-  name = var.mqcloud_queue_manager_name
+data "ibm_mqcloud_queue_manager" "mqcloud_queue_manager_instance" {
+  service_instance_guid = var.data_mqcloud_queue_manager_service_instance_guid
+  name = var.data_mqcloud_queue_manager_name
 }
 ```
-mqcloud_queue_manager_status data source:
+
+#### Inputs
+
+| Name | Description | Type | Required |
+|------|-------------|------|---------|
+| service_instance_guid | The GUID that uniquely identifies the MQ on Cloud service instance. | `string` | true |
+| name | A queue manager name conforming to MQ restrictions. | `string` | false |
+
+#### Outputs
+
+| Name | Description |
+|------|-------------|
+| queue_managers | List of queue managers. |
+
+### Data source: ibm_mqcloud_queue_manager_status
 
 ```hcl
-data "mqcloud_queue_manager_status" "mqcloud_queue_manager_status_instance" {
+data "ibm_mqcloud_queue_manager_status" "mqcloud_queue_manager_status_instance" {
   service_instance_guid = var.mqcloud_queue_manager_status_service_instance_guid
   queue_manager_id = var.mqcloud_queue_manager_status_queue_manager_id
 }
 ```
-mqcloud_application data source:
+
+#### Inputs
+
+| Name | Description | Type | Required |
+|------|-------------|------|---------|
+| service_instance_guid | The GUID that uniquely identifies the MQ on Cloud service instance. | `string` | true |
+| queue_manager_id | The id of the queue manager to retrieve its full details. | `string` | true |
+
+#### Outputs
+
+| Name | Description |
+|------|-------------|
+| status | The deploying and failed states are not queue manager states, they are states which can occur when the request to deploy has been fired, or with that request has failed without producing a queue manager to have any state. The other states map to the queue manager states. State "ending" is either quiesing or ending immediately. State "ended" is either ended normally or endedimmediately. The others map one to one with queue manager states. |
+
+### Data source: ibm_mqcloud_application
 
 ```hcl
-data "mqcloud_application" "mqcloud_application_instance" {
-  service_instance_guid = var.mqcloud_application_service_instance_guid
-  name = var.mqcloud_application_name
+data "ibm_mqcloud_application" "mqcloud_application_instance" {
+  service_instance_guid = var.data_mqcloud_application_service_instance_guid
+  name = var.data_mqcloud_application_name
 }
 ```
-mqcloud_user data source:
+
+#### Inputs
+
+| Name | Description | Type | Required |
+|------|-------------|------|---------|
+| service_instance_guid | The GUID that uniquely identifies the MQ on Cloud service instance. | `string` | true |
+| name | The name of the application - conforming to MQ rules. | `string` | false |
+
+#### Outputs
+
+| Name | Description |
+|------|-------------|
+| applications | List of applications. |
+
+### Data source: ibm_mqcloud_user
 
 ```hcl
-data "mqcloud_user" "mqcloud_user_instance" {
-  service_instance_guid = var.mqcloud_user_service_instance_guid
-  name = var.mqcloud_user_name
+data "ibm_mqcloud_user" "mqcloud_user_instance" {
+  service_instance_guid = var.data_mqcloud_user_service_instance_guid
+  name = var.data_mqcloud_user_name
 }
 ```
-mqcloud_truststore_certificate data source:
+
+#### Inputs
+
+| Name | Description | Type | Required |
+|------|-------------|------|---------|
+| service_instance_guid | The GUID that uniquely identifies the MQ on Cloud service instance. | `string` | true |
+| name | The shortname of the user that will be used as the IBM MQ administrator in interactions with a queue manager for this service instance. | `string` | false |
+
+#### Outputs
+
+| Name | Description |
+|------|-------------|
+| users | List of users. |
+
+### Data source: ibm_mqcloud_truststore_certificate
 
 ```hcl
-data "mqcloud_truststore_certificate" "mqcloud_truststore_certificate_instance" {
-  service_instance_guid = var.mqcloud_truststore_certificate_service_instance_guid
-  queue_manager_id = var.mqcloud_truststore_certificate_queue_manager_id
-  label = var.mqcloud_truststore_certificate_label
+data "ibm_mqcloud_truststore_certificate" "mqcloud_truststore_certificate_instance" {
+  service_instance_guid = var.data_mqcloud_truststore_certificate_service_instance_guid
+  queue_manager_id = var.data_mqcloud_truststore_certificate_queue_manager_id
+  label = var.data_mqcloud_truststore_certificate_label
 }
 ```
-mqcloud_keystore_certificate data source:
+
+#### Inputs
+
+| Name | Description | Type | Required |
+|------|-------------|------|---------|
+| service_instance_guid | The GUID that uniquely identifies the MQ on Cloud service instance. | `string` | true |
+| queue_manager_id | The id of the queue manager to retrieve its full details. | `string` | true |
+| label | Certificate label in queue manager store. | `string` | false |
+
+#### Outputs
+
+| Name | Description |
+|------|-------------|
+| total_count | The total count of trust store certificates. |
+| trust_store | The list of trust store certificates. |
+
+### Data source: ibm_mqcloud_keystore_certificate
 
 ```hcl
-data "mqcloud_keystore_certificate" "mqcloud_keystore_certificate_instance" {
-  service_instance_guid = var.mqcloud_keystore_certificate_service_instance_guid
-  queue_manager_id = var.mqcloud_keystore_certificate_queue_manager_id
-  label = var.mqcloud_keystore_certificate_label
+data "ibm_mqcloud_keystore_certificate" "mqcloud_keystore_certificate_instance" {
+  service_instance_guid = var.data_mqcloud_keystore_certificate_service_instance_guid
+  queue_manager_id = var.data_mqcloud_keystore_certificate_queue_manager_id
+  label = var.data_mqcloud_keystore_certificate_label
 }
 ```
+
+#### Inputs
+
+| Name | Description | Type | Required |
+|------|-------------|------|---------|
+| service_instance_guid | The GUID that uniquely identifies the MQ on Cloud service instance. | `string` | true |
+| queue_manager_id | The id of the queue manager to retrieve its full details. | `string` | true |
+| label | Certificate label in queue manager store. | `string` | false |
+
+#### Outputs
+
+| Name | Description |
+|------|-------------|
+| total_count | The total count of key store certificates. |
+| key_store | The list of key store certificates. |
 
 ## Assumptions
 
@@ -145,31 +357,3 @@ data "mqcloud_keystore_certificate" "mqcloud_keystore_certificate_instance" {
 | Name | Version |
 |------|---------|
 | ibm | 1.13.1 |
-
-## Inputs
-
-| Name | Description | Type | Required |
-|------|-------------|------|---------|
-| ibmcloud\_api\_key | IBM Cloud API key | `string` | true |
-| service_instance_guid | The GUID that uniquely identifies the MQ on Cloud service instance. | `string` | true |
-| name | A queue manager name conforming to MQ restrictions. | `string` | true |
-| display_name | A displayable name for the queue manager - limited only in length. | `string` | false |
-| location | The locations in which the queue manager could be deployed. | `string` | true |
-| size | The queue manager sizes of deployment available. Deployment of lite queue managers for aws_us_east_1 and aws_eu_west_1 locations is not available. | `string` | true |
-| version | The MQ version of the queue manager. | `string` | false |
-| name | The name of the application - conforming to MQ rules. | `string` | true |
-| name | The shortname of the user that will be used as the IBM MQ administrator in interactions with a queue manager for this service instance. | `string` | true |
-| email | The email of the user. | `string` | true |
-| queue_manager_id | The id of the queue manager to retrieve its full details. | `string` | true |
-| label | Certificate label in queue manager store. | `string` | true |
-
-## Outputs
-
-| Name | Description |
-|------|-------------|
-| mqcloud_queue_manager | mqcloud_queue_manager object |
-| mqcloud_queue_manager_status | mqcloud_queue_manager_status object |
-| mqcloud_application | mqcloud_application object |
-| mqcloud_user | mqcloud_user object |
-| mqcloud_truststore_certificate | mqcloud_truststore_certificate object |
-| mqcloud_keystore_certificate | mqcloud_keystore_certificate object |

--- a/examples/ibm-mqcloud/main.tf
+++ b/examples/ibm-mqcloud/main.tf
@@ -30,6 +30,7 @@ resource "ibm_mqcloud_keystore_certificate" "mqcloud_keystore_certificate_instan
   service_instance_guid = var.mqcloud_keystore_certificate_service_instance_guid
   queue_manager_id = var.mqcloud_keystore_certificate_queue_manager_id
   label = var.mqcloud_keystore_certificate_label
+  certificate_file = var.mqcloud_keystore_certificate_certificate_file
 }
 
 // Provision mqcloud_truststore_certificate resource instance
@@ -37,6 +38,7 @@ resource "ibm_mqcloud_truststore_certificate" "mqcloud_truststore_certificate_in
   service_instance_guid = var.mqcloud_truststore_certificate_service_instance_guid
   queue_manager_id = var.mqcloud_truststore_certificate_queue_manager_id
   label = var.mqcloud_truststore_certificate_label
+  certificate_file = var.mqcloud_truststore_certificate_certificate_file
 }
 
 // Data source is not linked to a resource instance
@@ -44,9 +46,8 @@ resource "ibm_mqcloud_truststore_certificate" "mqcloud_truststore_certificate_in
 /*
 // Create mqcloud_queue_manager data source
 data "ibm_mqcloud_queue_manager" "mqcloud_queue_manager_instance" {
-  service_instance_guid = var.mqcloud_queue_manager_service_instance_guid
-  
-  name = var.mqcloud_queue_manager_name
+  service_instance_guid = var.data_mqcloud_queue_manager_service_instance_guid
+  name = var.data_mqcloud_queue_manager_name
 }
 */
 
@@ -65,8 +66,8 @@ data "ibm_mqcloud_queue_manager_status" "mqcloud_queue_manager_status_instance" 
 /*
 // Create mqcloud_application data source
 data "ibm_mqcloud_application" "mqcloud_application_instance" {
-  service_instance_guid = var.mqcloud_application_service_instance_guid
-  name = var.mqcloud_application_name
+  service_instance_guid = var.data_mqcloud_application_service_instance_guid
+  name = var.data_mqcloud_application_name
 }
 */
 
@@ -75,8 +76,8 @@ data "ibm_mqcloud_application" "mqcloud_application_instance" {
 /*
 // Create mqcloud_user data source
 data "ibm_mqcloud_user" "mqcloud_user_instance" {
-  service_instance_guid = var.mqcloud_user_service_instance_guid
-  name = var.mqcloud_user_name
+  service_instance_guid = var.data_mqcloud_user_service_instance_guid
+  name = var.data_mqcloud_user_name
 }
 */
 
@@ -85,9 +86,9 @@ data "ibm_mqcloud_user" "mqcloud_user_instance" {
 /*
 // Create mqcloud_truststore_certificate data source
 data "ibm_mqcloud_truststore_certificate" "mqcloud_truststore_certificate_instance" {
-  service_instance_guid = var.mqcloud_truststore_certificate_service_instance_guid
-  queue_manager_id = var.mqcloud_truststore_certificate_queue_manager_id
-  label = var.mqcloud_truststore_certificate_label
+  service_instance_guid = var.data_mqcloud_truststore_certificate_service_instance_guid
+  queue_manager_id = var.data_mqcloud_truststore_certificate_queue_manager_id
+  label = var.data_mqcloud_truststore_certificate_label
 }
 */
 
@@ -96,8 +97,8 @@ data "ibm_mqcloud_truststore_certificate" "mqcloud_truststore_certificate_instan
 /*
 // Create mqcloud_keystore_certificate data source
 data "ibm_mqcloud_keystore_certificate" "mqcloud_keystore_certificate_instance" {
-  service_instance_guid = var.mqcloud_keystore_certificate_service_instance_guid
-  queue_manager_id = var.mqcloud_keystore_certificate_queue_manager_id
-  label = var.mqcloud_keystore_certificate_label
+  service_instance_guid = var.data_mqcloud_keystore_certificate_service_instance_guid
+  queue_manager_id = var.data_mqcloud_keystore_certificate_queue_manager_id
+  label = var.data_mqcloud_keystore_certificate_label
 }
 */

--- a/examples/ibm-mqcloud/variables.tf
+++ b/examples/ibm-mqcloud/variables.tf
@@ -22,7 +22,7 @@ variable "mqcloud_queue_manager_display_name" {
 variable "mqcloud_queue_manager_location" {
   description = "The locations in which the queue manager could be deployed."
   type        = string
-  default     = "reserved-eu-fr-cluster-f884"
+  default     = "reserved-eu-de-cluster-f884"
 }
 variable "mqcloud_queue_manager_size" {
   description = "The queue manager sizes of deployment available. Deployment of lite queue managers for aws_us_east_1 and aws_eu_west_1 locations is not available."
@@ -53,24 +53,6 @@ variable "mqcloud_user_service_instance_guid" {
   type        = string
   default     = "Service Instance ID"
 }
-
-// Data source arguments for mqcloud_application
-variable "mqcloud_application_service_instance_guid" {
-  description = "The GUID that uniquely identifies the MQ on Cloud service instance."
-  type        = string
-  default     = "Service Instance ID"
-}
-variable "mqcloud_user_name" {
-  description = "The shortname of the user that will be used as the IBM MQ administrator in interactions with a queue manager for this service instance."
-  type        = string
-  default     = "name"
-}
-
-variable "mqcloud_application_name" {
-  description = "The name of the application - conforming to MQ rules."
-  type        = string
-  default     = "name"
-}
 variable "mqcloud_user_name" {
   description = "The shortname of the user that will be used as the IBM MQ administrator in interactions with a queue manager for this service instance."
   type        = string
@@ -94,9 +76,14 @@ variable "mqcloud_keystore_certificate_queue_manager_id" {
   default     = "Queue Manager ID"
 }
 variable "mqcloud_keystore_certificate_label" {
-  description = "Certificate label in queue manager store."
+  description = "The label to use for the certificate to be uploaded."
   type        = string
   default     = "label"
+}
+variable "mqcloud_keystore_certificate_certificate_file" {
+  description = "The filename and path of the certificate to be uploaded."
+  type        = string
+  default     = "SGVsbG8gd29ybGQ="
 }
 
 // Resource arguments for mqcloud_truststore_certificate
@@ -110,21 +97,24 @@ variable "mqcloud_truststore_certificate_queue_manager_id" {
   type        = string
   default     = "Queue Manager ID"
 }
-
 variable "mqcloud_truststore_certificate_label" {
-  description = "Certificate label in queue manager store."
+  description = "The label to use for the certificate to be uploaded."
   type        = string
   default     = "label"
 }
+variable "mqcloud_truststore_certificate_certificate_file" {
+  description = "The filename and path of the certificate to be uploaded."
+  type        = string
+  default     = "SGVsbG8gd29ybGQ="
+}
 
 // Data source arguments for mqcloud_queue_manager
-variable "mqcloud_queue_manager_service_instance_guid" {
+variable "data_mqcloud_queue_manager_service_instance_guid" {
   description = "The GUID that uniquely identifies the MQ on Cloud service instance."
   type        = string
   default     = "Service Instance ID"
 }
-
-variable "mqcloud_queue_manager_name" {
+variable "data_mqcloud_queue_manager_name" {
   description = "A queue manager name conforming to MQ restrictions."
   type        = string
   default     = "name"
@@ -143,60 +133,58 @@ variable "mqcloud_queue_manager_status_queue_manager_id" {
 }
 
 // Data source arguments for mqcloud_application
-variable "mqcloud_application_service_instance_guid" {
+variable "data_mqcloud_application_service_instance_guid" {
   description = "The GUID that uniquely identifies the MQ on Cloud service instance."
   type        = string
   default     = "Service Instance ID"
 }
-
-variable "mqcloud_application_name" {
+variable "data_mqcloud_application_name" {
   description = "The name of the application - conforming to MQ rules."
   type        = string
   default     = "name"
 }
 
 // Data source arguments for mqcloud_user
-variable "mqcloud_user_service_instance_guid" {
+variable "data_mqcloud_user_service_instance_guid" {
   description = "The GUID that uniquely identifies the MQ on Cloud service instance."
   type        = string
   default     = "Service Instance ID"
 }
-
-variable "mqcloud_user_name" {
+variable "data_mqcloud_user_name" {
   description = "The shortname of the user that will be used as the IBM MQ administrator in interactions with a queue manager for this service instance."
   type        = string
   default     = "name"
 }
 
 // Data source arguments for mqcloud_truststore_certificate
-variable "mqcloud_truststore_certificate_service_instance_guid" {
+variable "data_mqcloud_truststore_certificate_service_instance_guid" {
   description = "The GUID that uniquely identifies the MQ on Cloud service instance."
   type        = string
   default     = "Service Instance ID"
 }
-variable "mqcloud_truststore_certificate_queue_manager_id" {
+variable "data_mqcloud_truststore_certificate_queue_manager_id" {
   description = "The id of the queue manager to retrieve its full details."
   type        = string
   default     = "Queue Manager ID"
 }
-variable "mqcloud_truststore_certificate_label" {
+variable "data_mqcloud_truststore_certificate_label" {
   description = "Certificate label in queue manager store."
   type        = string
   default     = "label"
 }
 
 // Data source arguments for mqcloud_keystore_certificate
-variable "mqcloud_keystore_certificate_service_instance_guid" {
+variable "data_mqcloud_keystore_certificate_service_instance_guid" {
   description = "The GUID that uniquely identifies the MQ on Cloud service instance."
   type        = string
   default     = "Service Instance ID"
 }
-variable "mqcloud_keystore_certificate_queue_manager_id" {
+variable "data_mqcloud_keystore_certificate_queue_manager_id" {
   description = "The id of the queue manager to retrieve its full details."
   type        = string
   default     = "Queue Manager ID"
 }
-variable "mqcloud_keystore_certificate_label" {
+variable "data_mqcloud_keystore_certificate_label" {
   description = "Certificate label in queue manager store."
   type        = string
   default     = "label"

--- a/go.mod
+++ b/go.mod
@@ -62,7 +62,7 @@ require (
 )
 
 require (
-	github.com/IBM/mqcloud-go-sdk v0.0.0-20231207105140-14d858932788
+	github.com/IBM/mqcloud-go-sdk v0.0.4
 	github.com/IBM/sarama v1.41.2
 	k8s.io/utils v0.0.0-20230313181309-38a27ef9d749
 	sigs.k8s.io/controller-runtime v0.14.1

--- a/go.sum
+++ b/go.sum
@@ -154,8 +154,8 @@ github.com/IBM/ibm-hpcs-uko-sdk v0.0.20-beta/go.mod h1:MLVNHMYoKsvovJZ4v1gQCpIYt
 github.com/IBM/keyprotect-go-client v0.5.1/go.mod h1:5TwDM/4FRJq1ZOlwQL1xFahLWQ3TveR88VmL1u3njyI=
 github.com/IBM/keyprotect-go-client v0.12.2 h1:Cjxcqin9Pl0xz3MnxdiVd4v/eIa79xL3hQpSbwOr/DQ=
 github.com/IBM/keyprotect-go-client v0.12.2/go.mod h1:yr8h2noNgU8vcbs+vhqoXp3Lmv73PI0zAc6VMgFvWwM=
-github.com/IBM/mqcloud-go-sdk v0.0.0-20231207105140-14d858932788 h1:cIT0YSzqMGqxM3OJQx1gp4gtYYy9U35O0tVdcFHOgwc=
-github.com/IBM/mqcloud-go-sdk v0.0.0-20231207105140-14d858932788/go.mod h1:R4NBbDMygpHiFywUnOdV0UfBZap4HcHa3QXLlACr9TU=
+github.com/IBM/mqcloud-go-sdk v0.0.4 h1:gqMpoU5a0qJ0GETG4PQrkgeEEoaQLvbxRJnEe6ytvC4=
+github.com/IBM/mqcloud-go-sdk v0.0.4/go.mod h1:gQptHC6D+rxfg0muRFFGvTDmvl4YfiDE0uXkaRRewRk=
 github.com/IBM/networking-go-sdk v0.42.2 h1:caqjx4jyFHi10Vlf3skHvlL6K3YJRVstsmCBmvdyqkA=
 github.com/IBM/networking-go-sdk v0.42.2/go.mod h1:lTUZwtUkMANMnrLHFIgRhHrkBfwASY/Iho1fabaPHxo=
 github.com/IBM/platform-services-go-sdk v0.55.0 h1:W598xZanL61bwd8O2DQexr4qjIr+/tP0Y845zoms5yA=

--- a/ibm/acctest/acctest.go
+++ b/ibm/acctest/acctest.go
@@ -126,10 +126,14 @@ var (
 
 // MQ on Cloud
 var (
-	MqcloudInstanceID     string
-	MqcloudQueueManagerID string
-	MqcloudKSCertFilePath string
-	MqcloudTSCertFilePath string
+	MqcloudConfigEndpoint            string
+	MqcloudInstanceID                string
+	MqcloudQueueManagerID            string
+	MqcloudKSCertFilePath            string
+	MqcloudTSCertFilePath            string
+	MqCloudQueueManagerLocation      string
+	MqCloudQueueManagerVersion       string
+	MqCloudQueueManagerVersionUpdate string
 )
 
 // Secrets Manager
@@ -1591,11 +1595,15 @@ func init() {
 		fmt.Println("[WARN] Set the environment variable IBM_SATELLITE_SSH_PUB_KEY with a ssh public key or ibm_satellite_* tests may fail")
 	}
 
+	MqcloudConfigEndpoint = os.Getenv("IBMCLOUD_MQCLOUD_CONFIG_ENDPOINT")
+	if MqcloudConfigEndpoint == "" {
+		fmt.Println("[INFO] Set the environment variable IBMCLOUD_MQCLOUD_CONFIG_ENDPOINT for ibm_mqcloud service else tests will fail if this is not set correctly")
+	}
+
 	MqcloudInstanceID = os.Getenv("IBM_MQCLOUD_INSTANCE_ID")
 	if MqcloudInstanceID == "" {
 		fmt.Println("[INFO] Set the environment variable IBM_MQCLOUD_INSTANCE_ID for ibm_mqcloud_queue_manager resource or datasource else tests will fail if this is not set correctly")
 	}
-
 	MqcloudQueueManagerID = os.Getenv("IBM_MQCLOUD_QUEUEMANAGER_ID")
 	if MqcloudQueueManagerID == "" {
 		fmt.Println("[INFO] Set the environment variable IBM_MQCLOUD_QUEUEMANAGER_ID for ibm_mqcloud_queue_manager resource or datasource else tests will fail if this is not set correctly")
@@ -1607,6 +1615,18 @@ func init() {
 	MqcloudTSCertFilePath = os.Getenv("IBM_MQCLOUD_TS_CERT_PATH")
 	if MqcloudTSCertFilePath == "" {
 		fmt.Println("[INFO] Set the environment variable IBM_MQCLOUD_TS_CERT_PATH for ibm_mqcloud_truststore_certificate resource or datasource else tests will fail if this is not set correctly")
+	}
+	MqCloudQueueManagerLocation = os.Getenv(("IBM_MQCLOUD_QUEUEMANAGER_LOCATION"))
+	if MqCloudQueueManagerLocation == "" {
+		fmt.Println("[INFO] Set the environment variable IBM_MQCLOUD_QUEUEMANAGER_LOCATION for ibm_mqcloud_queue_manager resource or datasource else tests will fail if this is not set correctly")
+	}
+	MqCloudQueueManagerVersion = os.Getenv(("IBM_MQCLOUD_QUEUEMANAGER_VERSION"))
+	if MqCloudQueueManagerVersion == "" {
+		fmt.Println("[INFO] Set the environment variable IBM_MQCLOUD_QUEUEMANAGER_VERSION for ibm_mqcloud_queue_manager resource or datasource else tests will fail if this is not set correctly")
+	}
+	MqCloudQueueManagerVersionUpdate = os.Getenv(("IBM_MQCLOUD_QUEUEMANAGER_VERSIONUPDATE"))
+	if MqCloudQueueManagerVersionUpdate == "" {
+		fmt.Println("[INFO] Set the environment variable IBM_MQCLOUD_QUEUEMANAGER_VERSIONUPDATE for ibm_mqcloud_queue_manager resource or datasource else tests will fail if this is not set correctly")
 	}
 }
 
@@ -1821,6 +1841,9 @@ func TestAccPreCheckSatelliteSSH(t *testing.T) {
 
 func TestAccPreCheckMqcloud(t *testing.T) {
 	TestAccPreCheck(t)
+	if MqcloudConfigEndpoint == "" {
+		t.Fatal("IBMCLOUD_MQCLOUD_CONFIG_ENDPOINT must be set for acceptance tests")
+	}
 	if MqcloudInstanceID == "" {
 		t.Fatal("IBM_MQCLOUD_INSTANCE_ID must be set for acceptance tests")
 	}
@@ -1832,6 +1855,15 @@ func TestAccPreCheckMqcloud(t *testing.T) {
 	}
 	if MqcloudKSCertFilePath == "" {
 		t.Fatal("IBM_MQCLOUD_KS_CERT_PATH must be set for acceptance tests")
+	}
+	if MqCloudQueueManagerLocation == "" {
+		t.Fatal("IBM_MQCLOUD_QUEUEMANAGER_LOCATION must be set for acceptance tests")
+	}
+	if MqCloudQueueManagerVersion == "" {
+		t.Fatal("IBM_MQCLOUD_QUEUEMANAGER_VERSION must be set for acceptance tests")
+	}
+	if MqCloudQueueManagerVersionUpdate == "" {
+		t.Fatal("IBM_MQCLOUD_QUEUEMANAGER_VERSIONUPDATE must be set for acceptance tests")
 	}
 }
 

--- a/ibm/conns/config.go
+++ b/ibm/conns/config.go
@@ -1210,9 +1210,12 @@ func (session clientSession) ProjectV1() (*project.ProjectV1, error) {
 
 // MQ on Cloud
 func (session clientSession) MqcloudV1() (*mqcloudv1.MqcloudV1, error) {
-	sessionMqcloudClient := session.mqcloudClient
-	sessionMqcloudClient.EnableRetries(0, 0)
-	return session.mqcloudClient, session.mqcloudClientErr
+	if session.mqcloudClientErr != nil {
+		sessionMqcloudClient := session.mqcloudClient
+		sessionMqcloudClient.EnableRetries(0, 0)
+		return session.mqcloudClient, session.mqcloudClientErr
+	}
+	return session.mqcloudClient.Clone(), nil
 }
 
 // ClientSession configures and returns a fully initialized ClientSession
@@ -3266,23 +3269,24 @@ func (c *Config) ClientSession() (interface{}, error) {
 	if fileMap != nil && c.Visibility != "public-and-private" {
 		mqCloudURL = fileFallBack(fileMap, c.Visibility, "IBMCLOUD_MQCLOUD_CONFIG_ENDPOINT", c.Region, mqCloudURL)
 	}
-
+	accept_language := os.Getenv("IBMCLOUD_MQCLOUD_ACCEPT_LANGUAGE")
 	mqcloudClientOptions := &mqcloudv1.MqcloudV1Options{
-		Authenticator: authenticator,
-		URL:           EnvFallBack([]string{"IBMCLOUD_MQCLOUD_CONFIG_ENDPOINT"}, mqCloudURL),
+		Authenticator:  authenticator,
+		AcceptLanguage: core.StringPtr(accept_language),
+		URL:            EnvFallBack([]string{"IBMCLOUD_MQCLOUD_CONFIG_ENDPOINT"}, mqCloudURL),
 	}
 
 	// Construct the service client for MQ Cloud.
 	session.mqcloudClient, err = mqcloudv1.NewMqcloudV1(mqcloudClientOptions)
-	if err != nil {
-		session.mqcloudClientErr = fmt.Errorf("Error occurred while configuring MQ Cloud service: %q", err)
-	} else {
+	if err == nil {
 		// Enable retries for API calls
 		session.mqcloudClient.Service.EnableRetries(c.RetryCount, c.RetryDelay)
 		// Add custom header for analytics
 		session.mqcloudClient.SetDefaultHeaders(gohttp.Header{
 			"X-Original-User-Agent": {fmt.Sprintf("terraform-provider-ibm/%s", version.Version)},
 		})
+	} else {
+		session.mqcloudClientErr = fmt.Errorf("Error occurred while configuring MQ on Cloud service: %q", err)
 	}
 
 	// Construct the service options.

--- a/ibm/service/mqcloud/data_source_ibm_mqcloud_application.go
+++ b/ibm/service/mqcloud/data_source_ibm_mqcloud_application.go
@@ -9,11 +9,11 @@ import (
 
 	"time"
 
-	"github.com/IBM/mqcloud-go-sdk/mqcloudv1"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 
 	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/conns"
+	"github.com/IBM/mqcloud-go-sdk/mqcloudv1"
 )
 
 func DataSourceIbmMqcloudApplication() *schema.Resource {
@@ -128,7 +128,7 @@ func dataSourceIbmMqcloudApplicationRead(context context.Context, d *schema.Reso
 
 	if suppliedFilter {
 		if len(allItems) == 0 {
-			return diag.FromErr(fmt.Errorf("No Applications found with name %s", name))
+			return diag.FromErr(fmt.Errorf("No Application found with name: \"%s\"", name))
 		}
 		d.SetId(name)
 	} else {
@@ -146,7 +146,7 @@ func dataSourceIbmMqcloudApplicationRead(context context.Context, d *schema.Reso
 	}
 
 	if err = d.Set("applications", mapSlice); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting applications %s", err))
+		return diag.FromErr(fmt.Errorf("Error setting applications: %s", err))
 	}
 
 	return nil

--- a/ibm/service/mqcloud/data_source_ibm_mqcloud_application_test.go
+++ b/ibm/service/mqcloud/data_source_ibm_mqcloud_application_test.go
@@ -13,6 +13,7 @@ import (
 )
 
 func TestAccIbmMqcloudApplicationDataSourceBasic(t *testing.T) {
+	t.Parallel()
 	applicationDetailsServiceInstanceGuid := acc.MqcloudInstanceID
 	applicationDetailsName := "appdsbasic"
 
@@ -33,46 +34,7 @@ func TestAccIbmMqcloudApplicationDataSourceBasic(t *testing.T) {
 	})
 }
 
-func TestAccIbmMqcloudApplicationDataSourceAllArgs(t *testing.T) {
-	applicationDetailsServiceInstanceGuid := acc.MqcloudInstanceID
-	applicationDetailsName := "appdsargs"
-
-	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { acc.TestAccPreCheckMqcloud(t) },
-		Providers: acc.TestAccProviders,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccCheckIbmMqcloudApplicationDataSourceConfig(applicationDetailsServiceInstanceGuid, applicationDetailsName),
-				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttrSet("data.ibm_mqcloud_application.mqcloud_application_instance", "id"),
-					resource.TestCheckResourceAttrSet("data.ibm_mqcloud_application.mqcloud_application_instance", "service_instance_guid"),
-					resource.TestCheckResourceAttrSet("data.ibm_mqcloud_application.mqcloud_application_instance", "name"),
-					resource.TestCheckResourceAttrSet("data.ibm_mqcloud_application.mqcloud_application_instance", "applications.#"),
-					resource.TestCheckResourceAttrSet("data.ibm_mqcloud_application.mqcloud_application_instance", "applications.0.id"),
-					resource.TestCheckResourceAttr("data.ibm_mqcloud_application.mqcloud_application_instance", "applications.0.name", applicationDetailsName),
-					resource.TestCheckResourceAttrSet("data.ibm_mqcloud_application.mqcloud_application_instance", "applications.0.create_api_key_uri"),
-					resource.TestCheckResourceAttrSet("data.ibm_mqcloud_application.mqcloud_application_instance", "applications.0.href"),
-				),
-			},
-		},
-	})
-}
-
 func testAccCheckIbmMqcloudApplicationDataSourceConfigBasic(applicationDetailsServiceInstanceGuid string, applicationDetailsName string) string {
-	return fmt.Sprintf(`
-		resource "ibm_mqcloud_application" "mqcloud_application_instance" {
-			service_instance_guid = "%s"
-			name = "%s"
-		}
-
-		data "ibm_mqcloud_application" "mqcloud_application_instance" {
-			service_instance_guid = ibm_mqcloud_application.mqcloud_application_instance.service_instance_guid
-			name = ibm_mqcloud_application.mqcloud_application_instance.name
-		}
-	`, applicationDetailsServiceInstanceGuid, applicationDetailsName)
-}
-
-func testAccCheckIbmMqcloudApplicationDataSourceConfig(applicationDetailsServiceInstanceGuid string, applicationDetailsName string) string {
 	return fmt.Sprintf(`
 		resource "ibm_mqcloud_application" "mqcloud_application_instance" {
 			service_instance_guid = "%s"

--- a/ibm/service/mqcloud/data_source_ibm_mqcloud_keystore_certificate.go
+++ b/ibm/service/mqcloud/data_source_ibm_mqcloud_keystore_certificate.go
@@ -169,7 +169,7 @@ func dataSourceIbmMqcloudKeystoreCertificateRead(context context.Context, d *sch
 
 	if suppliedFilter {
 		if len(keyStoreCertificateDetailsCollection.KeyStore) == 0 {
-			return diag.FromErr(fmt.Errorf("no KeyStore found with label %s", label))
+			return diag.FromErr(fmt.Errorf("No Key Store Certificate found with label: \"%s\"", label))
 		}
 		d.SetId(label)
 	} else {
@@ -192,7 +192,7 @@ func dataSourceIbmMqcloudKeystoreCertificateRead(context context.Context, d *sch
 		}
 	}
 	if err = d.Set("key_store", keyStore); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting key_store %s", err))
+		return diag.FromErr(fmt.Errorf("Error setting key_store: %s", err))
 	}
 
 	return nil

--- a/ibm/service/mqcloud/data_source_ibm_mqcloud_keystore_certificate_test.go
+++ b/ibm/service/mqcloud/data_source_ibm_mqcloud_keystore_certificate_test.go
@@ -14,6 +14,7 @@ import (
 )
 
 func TestAccIbmMqcloudKeystoreCertificateDataSourceBasic(t *testing.T) {
+	t.Parallel()
 	keyStoreCertificateDetailsServiceInstanceGuid := acc.MqcloudInstanceID
 	keyStoreCertificateDetailsQueueManagerID := acc.MqcloudQueueManagerID
 	keyStoreCertificateDetailsLabel := fmt.Sprintf("tf_label_%d", acctest.RandIntRange(10, 100))
@@ -26,46 +27,9 @@ func TestAccIbmMqcloudKeystoreCertificateDataSourceBasic(t *testing.T) {
 			{
 				Config: testAccCheckIbmMqcloudKeystoreCertificateDataSourceConfigBasic(keyStoreCertificateDetailsServiceInstanceGuid, keyStoreCertificateDetailsQueueManagerID, keyStoreCertificateDetailsLabel, keyStoreCertificateDetailsCertificateFile),
 				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet("data.ibm_mqcloud_keystore_certificate.mqcloud_keystore_certificate_instance", "id"),
 					resource.TestCheckResourceAttrSet("data.ibm_mqcloud_keystore_certificate.mqcloud_keystore_certificate_instance", "service_instance_guid"),
 					resource.TestCheckResourceAttrSet("data.ibm_mqcloud_keystore_certificate.mqcloud_keystore_certificate_instance", "queue_manager_id"),
-					resource.TestCheckResourceAttrSet("data.ibm_mqcloud_keystore_certificate.mqcloud_keystore_certificate_instance", "key_store.#"),
-					resource.TestCheckResourceAttr("data.ibm_mqcloud_keystore_certificate.mqcloud_keystore_certificate_instance", "key_store.0.label", keyStoreCertificateDetailsLabel),
-				),
-			},
-		},
-	})
-}
-
-func TestAccIbmMqcloudKeystoreCertificateDataSourceAllArgs(t *testing.T) {
-	keyStoreCertificateDetailsServiceInstanceGuid := acc.MqcloudInstanceID
-	keyStoreCertificateDetailsQueueManagerID := acc.MqcloudQueueManagerID
-	keyStoreCertificateDetailsLabel := fmt.Sprintf("tf_label_%d", acctest.RandIntRange(10, 100))
-	keyStoreCertificateDetailsCertificateFile := acc.MqcloudKSCertFilePath
-
-	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { acc.TestAccPreCheckMqcloud(t) },
-		Providers: acc.TestAccProviders,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccCheckIbmMqcloudKeystoreCertificateDataSourceConfig(keyStoreCertificateDetailsServiceInstanceGuid, keyStoreCertificateDetailsQueueManagerID, keyStoreCertificateDetailsLabel, keyStoreCertificateDetailsCertificateFile),
-				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttrSet("data.ibm_mqcloud_keystore_certificate.mqcloud_keystore_certificate_instance", "service_instance_guid"),
-					resource.TestCheckResourceAttrSet("data.ibm_mqcloud_keystore_certificate.mqcloud_keystore_certificate_instance", "queue_manager_id"),
-					resource.TestCheckResourceAttrSet("data.ibm_mqcloud_keystore_certificate.mqcloud_keystore_certificate_instance", "label"),
-					resource.TestCheckResourceAttrSet("data.ibm_mqcloud_keystore_certificate.mqcloud_keystore_certificate_instance", "total_count"),
-					resource.TestCheckResourceAttrSet("data.ibm_mqcloud_keystore_certificate.mqcloud_keystore_certificate_instance", "key_store.#"),
-					resource.TestCheckResourceAttr("data.ibm_mqcloud_keystore_certificate.mqcloud_keystore_certificate_instance", "key_store.0.label", keyStoreCertificateDetailsLabel),
-					resource.TestCheckResourceAttrSet("data.ibm_mqcloud_keystore_certificate.mqcloud_keystore_certificate_instance", "key_store.0.certificate_type"),
-					resource.TestCheckResourceAttrSet("data.ibm_mqcloud_keystore_certificate.mqcloud_keystore_certificate_instance", "key_store.0.fingerprint_sha256"),
-					resource.TestCheckResourceAttrSet("data.ibm_mqcloud_keystore_certificate.mqcloud_keystore_certificate_instance", "key_store.0.subject_dn"),
-					resource.TestCheckResourceAttrSet("data.ibm_mqcloud_keystore_certificate.mqcloud_keystore_certificate_instance", "key_store.0.subject_cn"),
-					resource.TestCheckResourceAttrSet("data.ibm_mqcloud_keystore_certificate.mqcloud_keystore_certificate_instance", "key_store.0.issuer_dn"),
-					resource.TestCheckResourceAttrSet("data.ibm_mqcloud_keystore_certificate.mqcloud_keystore_certificate_instance", "key_store.0.issuer_cn"),
-					resource.TestCheckResourceAttrSet("data.ibm_mqcloud_keystore_certificate.mqcloud_keystore_certificate_instance", "key_store.0.issued"),
-					resource.TestCheckResourceAttrSet("data.ibm_mqcloud_keystore_certificate.mqcloud_keystore_certificate_instance", "key_store.0.expiry"),
-					resource.TestCheckResourceAttrSet("data.ibm_mqcloud_keystore_certificate.mqcloud_keystore_certificate_instance", "key_store.0.is_default"),
-					resource.TestCheckResourceAttrSet("data.ibm_mqcloud_keystore_certificate.mqcloud_keystore_certificate_instance", "key_store.0.dns_names_total_count"),
-					resource.TestCheckResourceAttrSet("data.ibm_mqcloud_keystore_certificate.mqcloud_keystore_certificate_instance", "key_store.0.href"),
 				),
 			},
 		},
@@ -78,24 +42,7 @@ func testAccCheckIbmMqcloudKeystoreCertificateDataSourceConfigBasic(keyStoreCert
 			service_instance_guid = "%s"
 			queue_manager_id = "%s"
 			label = "%s"
-			certificate_file = "%s"
-		}
-
-		data "ibm_mqcloud_keystore_certificate" "mqcloud_keystore_certificate_instance" {
-			service_instance_guid = ibm_mqcloud_keystore_certificate.mqcloud_keystore_certificate_instance.service_instance_guid
-			queue_manager_id = ibm_mqcloud_keystore_certificate.mqcloud_keystore_certificate_instance.queue_manager_id
-			label = ibm_mqcloud_keystore_certificate.mqcloud_keystore_certificate_instance.label
-		}
-	`, keyStoreCertificateDetailsServiceInstanceGuid, keyStoreCertificateDetailsQueueManagerID, keyStoreCertificateDetailsLabel, keyStoreCertificateDetailsCertificateFile)
-}
-
-func testAccCheckIbmMqcloudKeystoreCertificateDataSourceConfig(keyStoreCertificateDetailsServiceInstanceGuid string, keyStoreCertificateDetailsQueueManagerID string, keyStoreCertificateDetailsLabel string, keyStoreCertificateDetailsCertificateFile string) string {
-	return fmt.Sprintf(`
-		resource "ibm_mqcloud_keystore_certificate" "mqcloud_keystore_certificate_instance" {
-			service_instance_guid = "%s"
-			queue_manager_id = "%s"
-			label = "%s"
-			certificate_file = "%s"
+			certificate_file = filebase64("%s")
 		}
 
 		data "ibm_mqcloud_keystore_certificate" "mqcloud_keystore_certificate_instance" {

--- a/ibm/service/mqcloud/data_source_ibm_mqcloud_queue_manager.go
+++ b/ibm/service/mqcloud/data_source_ibm_mqcloud_queue_manager.go
@@ -182,7 +182,7 @@ func dataSourceIbmMqcloudQueueManagerRead(context context.Context, d *schema.Res
 
 	if suppliedFilter {
 		if len(allItems) == 0 {
-			return diag.FromErr(fmt.Errorf("No Queue Managers found with name %s", name))
+			return diag.FromErr(fmt.Errorf("No Queue Manager found with name: \"%s\"", name))
 		}
 		d.SetId(name)
 	} else {
@@ -200,7 +200,7 @@ func dataSourceIbmMqcloudQueueManagerRead(context context.Context, d *schema.Res
 	}
 
 	if err = d.Set("queue_managers", mapSlice); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting queue_managers %s", err))
+		return diag.FromErr(fmt.Errorf("Error setting queue_managers: %s", err))
 	}
 
 	return nil

--- a/ibm/service/mqcloud/data_source_ibm_mqcloud_queue_manager_test.go
+++ b/ibm/service/mqcloud/data_source_ibm_mqcloud_queue_manager_test.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 
 	acc "github.com/IBM-Cloud/terraform-provider-ibm/ibm/acctest"
@@ -15,8 +16,8 @@ import (
 func TestAccIbmMqcloudQueueManagerDataSourceBasic(t *testing.T) {
 	t.Parallel()
 	queueManagerDetailsServiceInstanceGuid := acc.MqcloudInstanceID
-	queueManagerDetailsName := "queue_manager_ds_basic"
-	queueManagerDetailsLocation := "ibmcloud_eu_de"
+	queueManagerDetailsName := fmt.Sprintf("tf_queue_manager_ds_basic%d", acctest.RandIntRange(10, 100))
+	queueManagerDetailsLocation := acc.MqCloudQueueManagerLocation
 	queueManagerDetailsSize := "small"
 
 	resource.Test(t, resource.TestCase{
@@ -41,11 +42,11 @@ func TestAccIbmMqcloudQueueManagerDataSourceBasic(t *testing.T) {
 func TestAccIbmMqcloudQueueManagerDataSourceAllArgs(t *testing.T) {
 	t.Parallel()
 	queueManagerDetailsServiceInstanceGuid := acc.MqcloudInstanceID
-	queueManagerDetailsName := "queue_manager_ds_allargs"
-	queueManagerDetailsDisplayName := "queue_manager_ds_allargs"
-	queueManagerDetailsLocation := "ibmcloud_eu_de"
+	queueManagerDetailsName := fmt.Sprintf("tf_queue_manager_ds_allargs%d", acctest.RandIntRange(10, 100))
+	queueManagerDetailsDisplayName := queueManagerDetailsName
+	queueManagerDetailsLocation := acc.MqCloudQueueManagerLocation
 	queueManagerDetailsSize := "small"
-	queueManagerDetailsVersion := "9.3.3_3"
+	queueManagerDetailsVersion := acc.MqCloudQueueManagerVersion
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:  func() { acc.TestAccPreCheckMqcloud(t) },

--- a/ibm/service/mqcloud/data_source_ibm_mqcloud_truststore_certificate.go
+++ b/ibm/service/mqcloud/data_source_ibm_mqcloud_truststore_certificate.go
@@ -156,7 +156,7 @@ func dataSourceIbmMqcloudTruststoreCertificateRead(context context.Context, d *s
 
 	if suppliedFilter {
 		if len(trustStoreCertificateDetailsCollection.TrustStore) == 0 {
-			return diag.FromErr(fmt.Errorf("no TrustStore found with label %s", label))
+			return diag.FromErr(fmt.Errorf("No Trust Store Certificate found with label: \"%s\"", label))
 		}
 		d.SetId(label)
 	} else {
@@ -179,7 +179,7 @@ func dataSourceIbmMqcloudTruststoreCertificateRead(context context.Context, d *s
 		}
 	}
 	if err = d.Set("trust_store", trustStore); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting trust_store %s", err))
+		return diag.FromErr(fmt.Errorf("Error setting trust_store: %s", err))
 	}
 
 	return nil

--- a/ibm/service/mqcloud/data_source_ibm_mqcloud_truststore_certificate_test.go
+++ b/ibm/service/mqcloud/data_source_ibm_mqcloud_truststore_certificate_test.go
@@ -14,6 +14,7 @@ import (
 )
 
 func TestAccIbmMqcloudTruststoreCertificateDataSourceBasic(t *testing.T) {
+	t.Parallel()
 	trustStoreCertificateDetailsServiceInstanceGuid := acc.MqcloudInstanceID
 	trustStoreCertificateDetailsQueueManagerID := acc.MqcloudQueueManagerID
 	trustStoreCertificateDetailsLabel := fmt.Sprintf("tf_label_%d", acctest.RandIntRange(10, 100))
@@ -26,45 +27,9 @@ func TestAccIbmMqcloudTruststoreCertificateDataSourceBasic(t *testing.T) {
 			{
 				Config: testAccCheckIbmMqcloudTruststoreCertificateDataSourceConfigBasic(trustStoreCertificateDetailsServiceInstanceGuid, trustStoreCertificateDetailsQueueManagerID, trustStoreCertificateDetailsLabel, trustStoreCertificateDetailsCertificateFile),
 				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet("data.ibm_mqcloud_truststore_certificate.mqcloud_truststore_certificate_instance", "id"),
 					resource.TestCheckResourceAttrSet("data.ibm_mqcloud_truststore_certificate.mqcloud_truststore_certificate_instance", "service_instance_guid"),
 					resource.TestCheckResourceAttrSet("data.ibm_mqcloud_truststore_certificate.mqcloud_truststore_certificate_instance", "queue_manager_id"),
-					resource.TestCheckResourceAttrSet("data.ibm_mqcloud_truststore_certificate.mqcloud_truststore_certificate_instance", "trust_store.#"),
-					resource.TestCheckResourceAttr("data.ibm_mqcloud_truststore_certificate.mqcloud_truststore_certificate_instance", "trust_store.0.label", trustStoreCertificateDetailsLabel),
-				),
-			},
-		},
-	})
-}
-
-func TestAccIbmMqcloudTruststoreCertificateDataSourceAllArgs(t *testing.T) {
-	trustStoreCertificateDetailsServiceInstanceGuid := acc.MqcloudInstanceID
-	trustStoreCertificateDetailsQueueManagerID := acc.MqcloudQueueManagerID
-	trustStoreCertificateDetailsLabel := fmt.Sprintf("tf_label_%d", acctest.RandIntRange(10, 100))
-	trustStoreCertificateDetailsCertificateFile := acc.MqcloudTSCertFilePath
-
-	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { acc.TestAccPreCheckMqcloud(t) },
-		Providers: acc.TestAccProviders,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccCheckIbmMqcloudTruststoreCertificateDataSourceConfig(trustStoreCertificateDetailsServiceInstanceGuid, trustStoreCertificateDetailsQueueManagerID, trustStoreCertificateDetailsLabel, trustStoreCertificateDetailsCertificateFile),
-				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttrSet("data.ibm_mqcloud_truststore_certificate.mqcloud_truststore_certificate_instance", "service_instance_guid"),
-					resource.TestCheckResourceAttrSet("data.ibm_mqcloud_truststore_certificate.mqcloud_truststore_certificate_instance", "queue_manager_id"),
-					resource.TestCheckResourceAttrSet("data.ibm_mqcloud_truststore_certificate.mqcloud_truststore_certificate_instance", "label"),
-					resource.TestCheckResourceAttrSet("data.ibm_mqcloud_truststore_certificate.mqcloud_truststore_certificate_instance", "total_count"),
-					resource.TestCheckResourceAttrSet("data.ibm_mqcloud_truststore_certificate.mqcloud_truststore_certificate_instance", "trust_store.#"),
-					resource.TestCheckResourceAttr("data.ibm_mqcloud_truststore_certificate.mqcloud_truststore_certificate_instance", "trust_store.0.label", trustStoreCertificateDetailsLabel),
-					resource.TestCheckResourceAttrSet("data.ibm_mqcloud_truststore_certificate.mqcloud_truststore_certificate_instance", "trust_store.0.certificate_type"),
-					resource.TestCheckResourceAttrSet("data.ibm_mqcloud_truststore_certificate.mqcloud_truststore_certificate_instance", "trust_store.0.fingerprint_sha256"),
-					resource.TestCheckResourceAttrSet("data.ibm_mqcloud_truststore_certificate.mqcloud_truststore_certificate_instance", "trust_store.0.subject_dn"),
-					resource.TestCheckResourceAttrSet("data.ibm_mqcloud_truststore_certificate.mqcloud_truststore_certificate_instance", "trust_store.0.subject_cn"),
-					resource.TestCheckResourceAttrSet("data.ibm_mqcloud_truststore_certificate.mqcloud_truststore_certificate_instance", "trust_store.0.issuer_dn"),
-					resource.TestCheckResourceAttrSet("data.ibm_mqcloud_truststore_certificate.mqcloud_truststore_certificate_instance", "trust_store.0.issuer_cn"),
-					resource.TestCheckResourceAttrSet("data.ibm_mqcloud_truststore_certificate.mqcloud_truststore_certificate_instance", "trust_store.0.issued"),
-					resource.TestCheckResourceAttrSet("data.ibm_mqcloud_truststore_certificate.mqcloud_truststore_certificate_instance", "trust_store.0.expiry"),
-					resource.TestCheckResourceAttrSet("data.ibm_mqcloud_truststore_certificate.mqcloud_truststore_certificate_instance", "trust_store.0.trusted"),
-					resource.TestCheckResourceAttrSet("data.ibm_mqcloud_truststore_certificate.mqcloud_truststore_certificate_instance", "trust_store.0.href"),
 				),
 			},
 		},
@@ -77,24 +42,7 @@ func testAccCheckIbmMqcloudTruststoreCertificateDataSourceConfigBasic(trustStore
 			service_instance_guid = "%s"
 			queue_manager_id = "%s"
 			label = "%s"
-			certificate_file = "%s"
-		}
-
-		data "ibm_mqcloud_truststore_certificate" "mqcloud_truststore_certificate_instance" {
-			service_instance_guid = ibm_mqcloud_truststore_certificate.mqcloud_truststore_certificate_instance.service_instance_guid
-			queue_manager_id = ibm_mqcloud_truststore_certificate.mqcloud_truststore_certificate_instance.queue_manager_id
-			label = ibm_mqcloud_truststore_certificate.mqcloud_truststore_certificate_instance.label
-		}
-	`, trustStoreCertificateDetailsServiceInstanceGuid, trustStoreCertificateDetailsQueueManagerID, trustStoreCertificateDetailsLabel, trustStoreCertificateDetailsCertificateFile)
-}
-
-func testAccCheckIbmMqcloudTruststoreCertificateDataSourceConfig(trustStoreCertificateDetailsServiceInstanceGuid string, trustStoreCertificateDetailsQueueManagerID string, trustStoreCertificateDetailsLabel string, trustStoreCertificateDetailsCertificateFile string) string {
-	return fmt.Sprintf(`
-		resource "ibm_mqcloud_truststore_certificate" "mqcloud_truststore_certificate_instance" {
-			service_instance_guid = "%s"
-			queue_manager_id = "%s"
-			label = "%s"
-			certificate_file = "%s"
+			certificate_file = filebase64("%s")
 		}
 
 		data "ibm_mqcloud_truststore_certificate" "mqcloud_truststore_certificate_instance" {

--- a/ibm/service/mqcloud/data_source_ibm_mqcloud_user.go
+++ b/ibm/service/mqcloud/data_source_ibm_mqcloud_user.go
@@ -127,7 +127,7 @@ func dataSourceIbmMqcloudUserRead(context context.Context, d *schema.ResourceDat
 
 	if suppliedFilter {
 		if len(allItems) == 0 {
-			return diag.FromErr(fmt.Errorf("No Users found with name %s", name))
+			return diag.FromErr(fmt.Errorf("No User found with name: \"%s\"", name))
 		}
 		d.SetId(name)
 	} else {
@@ -145,7 +145,7 @@ func dataSourceIbmMqcloudUserRead(context context.Context, d *schema.ResourceDat
 	}
 
 	if err = d.Set("users", mapSlice); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting users %s", err))
+		return diag.FromErr(fmt.Errorf("Error setting users: %s", err))
 	}
 
 	return nil

--- a/ibm/service/mqcloud/data_source_ibm_mqcloud_user_test.go
+++ b/ibm/service/mqcloud/data_source_ibm_mqcloud_user_test.go
@@ -14,6 +14,7 @@ import (
 )
 
 func TestAccIbmMqcloudUserDataSourceBasic(t *testing.T) {
+	t.Parallel()
 	userDetailsServiceInstanceGuid := acc.MqcloudInstanceID
 	userDetailsName := fmt.Sprintf("tfname%d", acctest.RandIntRange(10, 100))
 	userDetailsEmail := fmt.Sprintf("tfemail%d@ibm.com", acctest.RandIntRange(10, 100))
@@ -36,48 +37,7 @@ func TestAccIbmMqcloudUserDataSourceBasic(t *testing.T) {
 	})
 }
 
-func TestAccIbmMqcloudUserDataSourceAllArgs(t *testing.T) {
-	userDetailsServiceInstanceGuid := acc.MqcloudInstanceID
-	userDetailsName := fmt.Sprintf("tfname%d", acctest.RandIntRange(10, 100))
-	userDetailsEmail := fmt.Sprintf("tfemail%d@ibm.com", acctest.RandIntRange(10, 100))
-
-	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { acc.TestAccPreCheckMqcloud(t) },
-		Providers: acc.TestAccProviders,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccCheckIbmMqcloudUserDataSourceConfig(userDetailsServiceInstanceGuid, userDetailsName, userDetailsEmail),
-				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttrSet("data.ibm_mqcloud_user.mqcloud_user_instance", "id"),
-					resource.TestCheckResourceAttrSet("data.ibm_mqcloud_user.mqcloud_user_instance", "service_instance_guid"),
-					resource.TestCheckResourceAttrSet("data.ibm_mqcloud_user.mqcloud_user_instance", "name"),
-					resource.TestCheckResourceAttrSet("data.ibm_mqcloud_user.mqcloud_user_instance", "users.#"),
-					resource.TestCheckResourceAttrSet("data.ibm_mqcloud_user.mqcloud_user_instance", "users.0.id"),
-					resource.TestCheckResourceAttr("data.ibm_mqcloud_user.mqcloud_user_instance", "users.0.name", userDetailsName),
-					resource.TestCheckResourceAttr("data.ibm_mqcloud_user.mqcloud_user_instance", "users.0.email", userDetailsEmail),
-					resource.TestCheckResourceAttrSet("data.ibm_mqcloud_user.mqcloud_user_instance", "users.0.href"),
-				),
-			},
-		},
-	})
-}
-
 func testAccCheckIbmMqcloudUserDataSourceConfigBasic(userDetailsServiceInstanceGuid string, userDetailsName string, userDetailsEmail string) string {
-	return fmt.Sprintf(`
-		resource "ibm_mqcloud_user" "mqcloud_user_instance" {
-			service_instance_guid = "%s"
-			name = "%s"
-			email = "%s"
-		}
-
-		data "ibm_mqcloud_user" "mqcloud_user_instance" {
-			service_instance_guid = ibm_mqcloud_user.mqcloud_user_instance.service_instance_guid
-			name = ibm_mqcloud_user.mqcloud_user_instance.name
-		}
-	`, userDetailsServiceInstanceGuid, userDetailsName, userDetailsEmail)
-}
-
-func testAccCheckIbmMqcloudUserDataSourceConfig(userDetailsServiceInstanceGuid string, userDetailsName string, userDetailsEmail string) string {
 	return fmt.Sprintf(`
 		resource "ibm_mqcloud_user" "mqcloud_user_instance" {
 			service_instance_guid = "%s"

--- a/ibm/service/mqcloud/resource_ibm_mqcloud_application_test.go
+++ b/ibm/service/mqcloud/resource_ibm_mqcloud_application_test.go
@@ -17,6 +17,7 @@ import (
 )
 
 func TestAccIbmMqcloudApplicationBasic(t *testing.T) {
+	t.Parallel()
 	var conf mqcloudv1.ApplicationDetails
 	serviceInstanceGuid := acc.MqcloudInstanceID
 	name := "appbasic"
@@ -34,28 +35,6 @@ func TestAccIbmMqcloudApplicationBasic(t *testing.T) {
 					resource.TestCheckResourceAttr("ibm_mqcloud_application.mqcloud_application_instance", "name", name),
 				),
 			},
-		},
-	})
-}
-
-func TestAccIbmMqcloudApplicationAllArgs(t *testing.T) {
-	var conf mqcloudv1.ApplicationDetails
-	serviceInstanceGuid := acc.MqcloudInstanceID
-	name := "appallargs"
-
-	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { acc.TestAccPreCheckMqcloud(t) },
-		Providers:    acc.TestAccProviders,
-		CheckDestroy: testAccCheckIbmMqcloudApplicationDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccCheckIbmMqcloudApplicationConfig(serviceInstanceGuid, name),
-				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckIbmMqcloudApplicationExists("ibm_mqcloud_application.mqcloud_application_instance", conf),
-					resource.TestCheckResourceAttr("ibm_mqcloud_application.mqcloud_application_instance", "service_instance_guid", serviceInstanceGuid),
-					resource.TestCheckResourceAttr("ibm_mqcloud_application.mqcloud_application_instance", "name", name),
-				),
-			},
 			{
 				ResourceName:      "ibm_mqcloud_application.mqcloud_application_instance",
 				ImportState:       true,
@@ -67,16 +46,6 @@ func TestAccIbmMqcloudApplicationAllArgs(t *testing.T) {
 
 func testAccCheckIbmMqcloudApplicationConfigBasic(serviceInstanceGuid string, name string) string {
 	return fmt.Sprintf(`
-		resource "ibm_mqcloud_application" "mqcloud_application_instance" {
-			service_instance_guid = "%s"
-			name = "%s"
-		}
-	`, serviceInstanceGuid, name)
-}
-
-func testAccCheckIbmMqcloudApplicationConfig(serviceInstanceGuid string, name string) string {
-	return fmt.Sprintf(`
-
 		resource "ibm_mqcloud_application" "mqcloud_application_instance" {
 			service_instance_guid = "%s"
 			name = "%s"

--- a/ibm/service/mqcloud/resource_ibm_mqcloud_keystore_certificate_test.go
+++ b/ibm/service/mqcloud/resource_ibm_mqcloud_keystore_certificate_test.go
@@ -18,6 +18,7 @@ import (
 )
 
 func TestAccIbmMqcloudKeystoreCertificateBasic(t *testing.T) {
+	t.Parallel()
 	var conf mqcloudv1.KeyStoreCertificateDetails
 	serviceInstanceGuid := acc.MqcloudInstanceID
 	queueManagerID := acc.MqcloudQueueManagerID
@@ -38,35 +39,11 @@ func TestAccIbmMqcloudKeystoreCertificateBasic(t *testing.T) {
 					resource.TestCheckResourceAttr("ibm_mqcloud_keystore_certificate.mqcloud_keystore_certificate_instance", "label", label),
 				),
 			},
-		},
-	})
-}
-
-func TestAccIbmMqcloudKeystoreCertificateAllArgs(t *testing.T) {
-	var conf mqcloudv1.KeyStoreCertificateDetails
-	serviceInstanceGuid := acc.MqcloudInstanceID
-	queueManagerID := acc.MqcloudQueueManagerID
-	label := fmt.Sprintf("tf_label_%d", acctest.RandIntRange(10, 100))
-	certificateFile := acc.MqcloudKSCertFilePath
-
-	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { acc.TestAccPreCheckMqcloud(t) },
-		Providers:    acc.TestAccProviders,
-		CheckDestroy: testAccCheckIbmMqcloudKeystoreCertificateDestroy,
-		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckIbmMqcloudKeystoreCertificateConfig(serviceInstanceGuid, queueManagerID, label, certificateFile),
-				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckIbmMqcloudKeystoreCertificateExists("ibm_mqcloud_keystore_certificate.mqcloud_keystore_certificate_instance", conf),
-					resource.TestCheckResourceAttr("ibm_mqcloud_keystore_certificate.mqcloud_keystore_certificate_instance", "service_instance_guid", serviceInstanceGuid),
-					resource.TestCheckResourceAttr("ibm_mqcloud_keystore_certificate.mqcloud_keystore_certificate_instance", "queue_manager_id", queueManagerID),
-					resource.TestCheckResourceAttr("ibm_mqcloud_keystore_certificate.mqcloud_keystore_certificate_instance", "label", label),
-				),
-			},
-			{
-				ResourceName:      "ibm_mqcloud_keystore_certificate.mqcloud_keystore_certificate_instance",
-				ImportState:       true,
-				ImportStateVerify: true,
+				ResourceName:            "ibm_mqcloud_keystore_certificate.mqcloud_keystore_certificate_instance",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"certificate_file"},
 			},
 		},
 	})
@@ -78,19 +55,7 @@ func testAccCheckIbmMqcloudKeystoreCertificateConfigBasic(serviceInstanceGuid st
 			service_instance_guid = "%s"
 			queue_manager_id = "%s"
 			label = "%s"
-			certificate_file = "%s"
-		}
-	`, serviceInstanceGuid, queueManagerID, label, certificateFile)
-}
-
-func testAccCheckIbmMqcloudKeystoreCertificateConfig(serviceInstanceGuid string, queueManagerID string, label string, certificateFile string) string {
-	return fmt.Sprintf(`
-
-		resource "ibm_mqcloud_keystore_certificate" "mqcloud_keystore_certificate_instance" {
-			service_instance_guid = "%s"
-			queue_manager_id = "%s"
-			label = "%s"
-			certificate_file = "%s"
+			certificate_file = filebase64("%s")
 		}
 	`, serviceInstanceGuid, queueManagerID, label, certificateFile)
 }

--- a/ibm/service/mqcloud/resource_ibm_mqcloud_queue_manager.go
+++ b/ibm/service/mqcloud/resource_ibm_mqcloud_queue_manager.go
@@ -252,14 +252,15 @@ func resourceIbmMqcloudQueueManagerRead(context context.Context, d *schema.Resou
 	var queueManagerDetails *mqcloudv1.QueueManagerDetails
 	var response *core.DetailedResponse
 
-	err = resource.RetryContext(context, 10*time.Second, func() *resource.RetryError {
+	err = resource.RetryContext(context, 150*time.Second, func() *resource.RetryError {
 		queueManagerDetails, response, err = mqcloudClient.GetQueueManagerWithContext(context, getQueueManagerOptions)
-		if err != nil || response == nil {
-			if response.StatusCode == 404 {
-				return resource.RetryableError(err)
+		if err != nil || queueManagerDetails == nil {
+			if response != nil && response.StatusCode == 404 {
+				return resource.RetryableError(fmt.Errorf("Queue Manager not found, retrying"))
 			}
 			return resource.NonRetryableError(err)
 		}
+
 		return nil
 	})
 

--- a/ibm/service/mqcloud/resource_ibm_mqcloud_queue_manager_test.go
+++ b/ibm/service/mqcloud/resource_ibm_mqcloud_queue_manager_test.go
@@ -14,14 +14,15 @@ import (
 	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/conns"
 	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/flex"
 	"github.com/IBM/mqcloud-go-sdk/mqcloudv1"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 )
 
 func TestAccIbmMqcloudQueueManagerBasic(t *testing.T) {
 	t.Parallel()
 	var conf mqcloudv1.QueueManagerDetails
 	serviceInstanceGuid := acc.MqcloudInstanceID
-	name := "queue_manager_basic"
-	location := "ibmcloud_eu_de"
+	name := fmt.Sprintf("tf_queue_manager_basic%d", acctest.RandIntRange(10, 100))
+	location := acc.MqCloudQueueManagerLocation
 	size := "small"
 
 	resource.Test(t, resource.TestCase{
@@ -47,12 +48,12 @@ func TestAccIbmMqcloudQueueManagerAllArgs(t *testing.T) {
 	t.Parallel()
 	var conf mqcloudv1.QueueManagerDetails
 	serviceInstanceGuid := acc.MqcloudInstanceID
-	name := "queue_manager_allargs"
-	displayName := "queue_manager_allargs"
-	location := "ibmcloud_eu_de"
+	name := fmt.Sprintf("tf_queue_manager_allargs%d", acctest.RandIntRange(10, 100))
+	displayName := name
+	location := acc.MqCloudQueueManagerLocation
 	size := "small"
-	version := "9.3.3_3"
-	versionUpdate := "9.3.4_1"
+	version := acc.MqCloudQueueManagerVersion
+	versionUpdate := acc.MqCloudQueueManagerVersionUpdate
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { acc.TestAccPreCheckMqcloud(t) },

--- a/ibm/service/mqcloud/resource_ibm_mqcloud_truststore_certificate_test.go
+++ b/ibm/service/mqcloud/resource_ibm_mqcloud_truststore_certificate_test.go
@@ -18,6 +18,7 @@ import (
 )
 
 func TestAccIbmMqcloudTruststoreCertificateBasic(t *testing.T) {
+	t.Parallel()
 	var conf mqcloudv1.TrustStoreCertificateDetails
 	serviceInstanceGuid := acc.MqcloudInstanceID
 	queueManagerID := acc.MqcloudQueueManagerID
@@ -38,35 +39,11 @@ func TestAccIbmMqcloudTruststoreCertificateBasic(t *testing.T) {
 					resource.TestCheckResourceAttr("ibm_mqcloud_truststore_certificate.mqcloud_truststore_certificate_instance", "label", label),
 				),
 			},
-		},
-	})
-}
-
-func TestAccIbmMqcloudTruststoreCertificateAllArgs(t *testing.T) {
-	var conf mqcloudv1.TrustStoreCertificateDetails
-	serviceInstanceGuid := acc.MqcloudInstanceID
-	queueManagerID := acc.MqcloudQueueManagerID
-	label := fmt.Sprintf("tf_label_%d", acctest.RandIntRange(10, 100))
-	certificateFile := acc.MqcloudTSCertFilePath
-
-	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { acc.TestAccPreCheckMqcloud(t) },
-		Providers:    acc.TestAccProviders,
-		CheckDestroy: testAccCheckIbmMqcloudTruststoreCertificateDestroy,
-		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckIbmMqcloudTruststoreCertificateConfig(serviceInstanceGuid, queueManagerID, label, certificateFile),
-				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckIbmMqcloudTruststoreCertificateExists("ibm_mqcloud_truststore_certificate.mqcloud_truststore_certificate_instance", conf),
-					resource.TestCheckResourceAttr("ibm_mqcloud_truststore_certificate.mqcloud_truststore_certificate_instance", "service_instance_guid", serviceInstanceGuid),
-					resource.TestCheckResourceAttr("ibm_mqcloud_truststore_certificate.mqcloud_truststore_certificate_instance", "queue_manager_id", queueManagerID),
-					resource.TestCheckResourceAttr("ibm_mqcloud_truststore_certificate.mqcloud_truststore_certificate_instance", "label", label),
-				),
-			},
-			{
-				ResourceName:      "ibm_mqcloud_truststore_certificate.mqcloud_truststore_certificate_instance",
-				ImportState:       true,
-				ImportStateVerify: true,
+				ResourceName:            "ibm_mqcloud_truststore_certificate.mqcloud_truststore_certificate_instance",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"certificate_file"},
 			},
 		},
 	})
@@ -78,19 +55,7 @@ func testAccCheckIbmMqcloudTruststoreCertificateConfigBasic(serviceInstanceGuid 
 			service_instance_guid = "%s"
 			queue_manager_id = "%s"
 			label = "%s"
-			certificate_file = "%s"
-		}
-	`, serviceInstanceGuid, queueManagerID, label, certificateFile)
-}
-
-func testAccCheckIbmMqcloudTruststoreCertificateConfig(serviceInstanceGuid string, queueManagerID string, label string, certificateFile string) string {
-	return fmt.Sprintf(`
-
-		resource "ibm_mqcloud_truststore_certificate" "mqcloud_truststore_certificate_instance" {
-			service_instance_guid = "%s"
-			queue_manager_id = "%s"
-			label = "%s"
-			certificate_file = "%s"
+			certificate_file = filebase64("%s")
 		}
 	`, serviceInstanceGuid, queueManagerID, label, certificateFile)
 }

--- a/ibm/service/mqcloud/resource_ibm_mqcloud_user_test.go
+++ b/ibm/service/mqcloud/resource_ibm_mqcloud_user_test.go
@@ -18,6 +18,7 @@ import (
 )
 
 func TestAccIbmMqcloudUserBasic(t *testing.T) {
+	t.Parallel()
 	var conf mqcloudv1.UserDetails
 	serviceInstanceGuid := acc.MqcloudInstanceID
 	name := fmt.Sprintf("tfname%d", acctest.RandIntRange(10, 100))
@@ -37,30 +38,6 @@ func TestAccIbmMqcloudUserBasic(t *testing.T) {
 					resource.TestCheckResourceAttr("ibm_mqcloud_user.mqcloud_user_instance", "email", email),
 				),
 			},
-		},
-	})
-}
-
-func TestAccIbmMqcloudUserAllArgs(t *testing.T) {
-	var conf mqcloudv1.UserDetails
-	serviceInstanceGuid := acc.MqcloudInstanceID
-	name := fmt.Sprintf("tfname%d", acctest.RandIntRange(10, 100))
-	email := fmt.Sprintf("tfemail%d@ibm.com", acctest.RandIntRange(10, 100))
-
-	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { acc.TestAccPreCheckMqcloud(t) },
-		Providers:    acc.TestAccProviders,
-		CheckDestroy: testAccCheckIbmMqcloudUserDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccCheckIbmMqcloudUserConfig(serviceInstanceGuid, name, email),
-				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckIbmMqcloudUserExists("ibm_mqcloud_user.mqcloud_user_instance", conf),
-					resource.TestCheckResourceAttr("ibm_mqcloud_user.mqcloud_user_instance", "service_instance_guid", serviceInstanceGuid),
-					resource.TestCheckResourceAttr("ibm_mqcloud_user.mqcloud_user_instance", "name", name),
-					resource.TestCheckResourceAttr("ibm_mqcloud_user.mqcloud_user_instance", "email", email),
-				),
-			},
 			{
 				ResourceName:      "ibm_mqcloud_user.mqcloud_user_instance",
 				ImportState:       true,
@@ -72,17 +49,6 @@ func TestAccIbmMqcloudUserAllArgs(t *testing.T) {
 
 func testAccCheckIbmMqcloudUserConfigBasic(serviceInstanceGuid string, name string, email string) string {
 	return fmt.Sprintf(`
-		resource "ibm_mqcloud_user" "mqcloud_user_instance" {
-			service_instance_guid = "%s"
-			name = "%s"
-			email = "%s"
-		}
-	`, serviceInstanceGuid, name, email)
-}
-
-func testAccCheckIbmMqcloudUserConfig(serviceInstanceGuid string, name string, email string) string {
-	return fmt.Sprintf(`
-
 		resource "ibm_mqcloud_user" "mqcloud_user_instance" {
 			service_instance_guid = "%s"
 			name = "%s"

--- a/ibm/service/mqcloud/utils.go
+++ b/ibm/service/mqcloud/utils.go
@@ -31,9 +31,9 @@ const qmCreating = "initializing"
 const isQueueManagerDeleting = "true"
 const isQueueManagerDeleteDone = "true"
 const reservedDeploymentPlan = "reserved-deployment"
-const enforceReservedDeploymentPlan = true
+const enforceReservedDeploymentPlan = false
 
-// waitForQmStatusUpdate Waits for QM to be in running state
+// waitForQmStatusUpdate waits for Queue Manager to be in running state
 func waitForQmStatusUpdate(context context.Context, d *schema.ResourceData, meta interface{}) (interface{}, error) {
 	mqcloudClient, err := meta.(conns.ClientSession).MqcloudV1()
 	if err != nil {
@@ -58,7 +58,6 @@ func waitForQmStatusUpdate(context context.Context, d *schema.ResourceData, meta
 			if queueManagerStatus == nil || queueManagerStatus.Status == nil {
 				return nil, "", fmt.Errorf("queueManagerStatus or queueManagerStatus.Status is nil")
 			}
-			fmt.Println("The queue manager is currently in the " + *queueManagerStatus.Status + " state ....")
 
 			if *queueManagerStatus.Status == "running" {
 				return queueManagerStatus, qmStatus, nil
@@ -135,7 +134,7 @@ func checkSIPlan(d *schema.ResourceData, meta interface{}) error {
 	}
 	instance, response, err := rsConClient.GetResourceInstance(&rsInst)
 	if err != nil {
-		return fmt.Errorf("[ERROR] Failed to retrieve resource instance: %s, Response: %s", err, response)
+		return fmt.Errorf("[ERROR] Failed to retrieve Resource Instance: %s, Response: %s", err, response)
 	}
 
 	// Creating a Resource Catalog Client
@@ -148,7 +147,7 @@ func checkSIPlan(d *schema.ResourceData, meta interface{}) error {
 	// Checking the service plan
 	plan, err := rsCatRepo.GetServicePlanName(*instance.ResourcePlanID)
 	if err != nil {
-		return fmt.Errorf("[ERROR] Failed to retrieve service plan: %s", err)
+		return fmt.Errorf("[ERROR] Failed to retrieve Service Plan: %s", err)
 	}
 
 	// Update cache

--- a/ibm/service/mqcloud/utils.go
+++ b/ibm/service/mqcloud/utils.go
@@ -31,7 +31,7 @@ const qmCreating = "initializing"
 const isQueueManagerDeleting = "true"
 const isQueueManagerDeleteDone = "true"
 const reservedDeploymentPlan = "reserved-deployment"
-const enforceReservedDeploymentPlan = false
+const enforceReservedDeploymentPlan = true
 
 // waitForQmStatusUpdate waits for Queue Manager to be in running state
 func waitForQmStatusUpdate(context context.Context, d *schema.ResourceData, meta interface{}) (interface{}, error) {

--- a/website/docs/r/mqcloud_keystore_certificate.html.markdown
+++ b/website/docs/r/mqcloud_keystore_certificate.html.markdown
@@ -14,6 +14,7 @@ Create, update, and delete mqcloud_keystore_certificates with this resource.
 
 ```hcl
 resource "ibm_mqcloud_keystore_certificate" "mqcloud_keystore_certificate_instance" {
+  certificate_file = filebase64("certificate_file.data")
   label = "label"
   queue_manager_id = var.queue_manager_id
   service_instance_guid = var.service_instance_guid
@@ -24,7 +25,9 @@ resource "ibm_mqcloud_keystore_certificate" "mqcloud_keystore_certificate_instan
 
 You can specify the following arguments for this resource.
 
-* `label` - (Required, Forces new resource, String) Certificate label in queue manager store.
+* `certificate_file` - (Required, Forces new resource, String) The filename and path of the certificate to be uploaded.
+  * Constraints: The maximum length is `65537` characters. The minimum length is `1500` characters.
+* `label` - (Required, Forces new resource, String) The label to use for the certificate to be uploaded.
   * Constraints: The maximum length is `64` characters. The minimum length is `1` character. The value must match regular expression `/^[a-zA-Z0-9_.]*$/`.
 * `queue_manager_id` - (Required, Forces new resource, String) The id of the queue manager to retrieve its full details.
   * Constraints: The maximum length is `32` characters. The minimum length is `32` characters. The value must match regular expression `/^[0-9a-fA-F]{32}$/`.
@@ -66,6 +69,10 @@ The `id` property can be formed from `service_instance_guid`, `queue_manager_id`
 * `service_instance_guid`: A string in the format `a2b4d4bc-dadb-4637-bcec-9b7d1e723af8`. The GUID that uniquely identifies the MQ on Cloud service instance.
 * `queue_manager_id`: A string in the format `b8e1aeda078009cf3db74e90d5d42328`. The id of the queue manager to retrieve its full details.
 * `certificate_id`: A string. ID of the certificate.
+
+> ### Important Note
+> When configuring the `ibm_mqcloud_keystore_certificate` resource in the root module:
+> Ensure to set the `certificate_file` value to an empty string (`certificate_file=""`). This step is crucial as we are not downloading the certificate to the local system.
 
 # Syntax
 <pre>

--- a/website/docs/r/mqcloud_queue_manager.html.markdown
+++ b/website/docs/r/mqcloud_queue_manager.html.markdown
@@ -15,7 +15,7 @@ Create, update, and delete mqcloud_queue_managers with this resource.
 ```hcl
 resource "ibm_mqcloud_queue_manager" "mqcloud_queue_manager_instance" {
   display_name = "A test queue manager"
-  location = "reserved-eu-fr-cluster-f884"
+  location = "reserved-eu-de-cluster-f884"
   name = "testqm"
   service_instance_guid = var.service_instance_guid
   size = "lite"

--- a/website/docs/r/mqcloud_truststore_certificate.html.markdown
+++ b/website/docs/r/mqcloud_truststore_certificate.html.markdown
@@ -14,6 +14,7 @@ Create, update, and delete mqcloud_truststore_certificates with this resource.
 
 ```hcl
 resource "ibm_mqcloud_truststore_certificate" "mqcloud_truststore_certificate_instance" {
+  certificate_file = filebase64("certificate_file.data")
   label = "label"
   queue_manager_id = var.queue_manager_id
   service_instance_guid = var.service_instance_guid
@@ -24,7 +25,9 @@ resource "ibm_mqcloud_truststore_certificate" "mqcloud_truststore_certificate_in
 
 You can specify the following arguments for this resource.
 
-* `label` - (Required, Forces new resource, String) Certificate label in queue manager store.
+* `certificate_file` - (Required, Forces new resource, String) The filename and path of the certificate to be uploaded.
+  * Constraints: The maximum length is `65537` characters. The minimum length is `1500` characters.
+* `label` - (Required, Forces new resource, String) The label to use for the certificate to be uploaded.
   * Constraints: The maximum length is `64` characters. The minimum length is `1` character. The value must match regular expression `/^[a-zA-Z0-9_.]*$/`.
 * `queue_manager_id` - (Required, Forces new resource, String) The id of the queue manager to retrieve its full details.
   * Constraints: The maximum length is `32` characters. The minimum length is `32` characters. The value must match regular expression `/^[0-9a-fA-F]{32}$/`.
@@ -63,6 +66,10 @@ The `id` property can be formed from `service_instance_guid`, `queue_manager_id`
 * `service_instance_guid`: A string in the format `a2b4d4bc-dadb-4637-bcec-9b7d1e723af8`. The GUID that uniquely identifies the MQ on Cloud service instance.
 * `queue_manager_id`: A string in the format `b8e1aeda078009cf3db74e90d5d42328`. The id of the queue manager to retrieve its full details.
 * `certificate_id`: A string. Id of the certificate.
+
+> ### Important Note
+> When configuring the `ibm_mqcloud_keystore_certificate` resource in the root module:
+> Ensure to set the `certificate_file` value to an empty string (`certificate_file=""`). This step is crucial as we are not downloading the certificate to the local system.
 
 # Syntax
 <pre>


### PR DESCRIPTION
(cherry picked from commit e7253421db30943d3582ce07d9504a2117f30ce1)

<!--- See what makes a good Pull Request at : https://github.com/IBM-Cloud/terraform-provider-ibm/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->

Changes
- add fix for the multipart support from the new openapi-sdkgen version
- related readme and doc changes from the new openapi-sdkgen version
- related the test file changes from the new openapi-sdkgen version

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$  make testacc TEST=./ibm/service/mqcloud/...   
=== RUN   TestAccIbmMqcloudApplicationDataSourceBasic
=== PAUSE TestAccIbmMqcloudApplicationDataSourceBasic
=== RUN   TestAccIbmMqcloudKeystoreCertificateDataSourceBasic
=== PAUSE TestAccIbmMqcloudKeystoreCertificateDataSourceBasic
=== RUN   TestAccIbmMqcloudQueueManagerStatusDataSourceBasic
=== PAUSE TestAccIbmMqcloudQueueManagerStatusDataSourceBasic
=== RUN   TestAccIbmMqcloudQueueManagerDataSourceBasic
=== PAUSE TestAccIbmMqcloudQueueManagerDataSourceBasic
=== RUN   TestAccIbmMqcloudQueueManagerDataSourceAllArgs
=== PAUSE TestAccIbmMqcloudQueueManagerDataSourceAllArgs
=== RUN   TestAccIbmMqcloudTruststoreCertificateDataSourceBasic
=== PAUSE TestAccIbmMqcloudTruststoreCertificateDataSourceBasic
=== RUN   TestAccIbmMqcloudUserDataSourceBasic
=== PAUSE TestAccIbmMqcloudUserDataSourceBasic
=== RUN   TestAccIbmMqcloudApplicationBasic
=== PAUSE TestAccIbmMqcloudApplicationBasic
=== RUN   TestAccIbmMqcloudKeystoreCertificateBasic
=== PAUSE TestAccIbmMqcloudKeystoreCertificateBasic
=== RUN   TestAccIbmMqcloudQueueManagerBasic
=== PAUSE TestAccIbmMqcloudQueueManagerBasic
=== RUN   TestAccIbmMqcloudQueueManagerAllArgs
=== PAUSE TestAccIbmMqcloudQueueManagerAllArgs
=== RUN   TestAccIbmMqcloudTruststoreCertificateBasic
=== PAUSE TestAccIbmMqcloudTruststoreCertificateBasic
=== RUN   TestAccIbmMqcloudUserBasic
=== PAUSE TestAccIbmMqcloudUserBasic
=== CONT  TestAccIbmMqcloudApplicationDataSourceBasic
=== CONT  TestAccIbmMqcloudQueueManagerAllArgs
=== CONT  TestAccIbmMqcloudApplicationBasic
=== CONT  TestAccIbmMqcloudQueueManagerBasic
--- PASS: TestAccIbmMqcloudApplicationBasic (55.56s)
=== CONT  TestAccIbmMqcloudKeystoreCertificateBasic
--- PASS: TestAccIbmMqcloudApplicationDataSourceBasic (56.49s)
=== CONT  TestAccIbmMqcloudQueueManagerDataSourceAllArgs
--- PASS: TestAccIbmMqcloudKeystoreCertificateBasic (70.77s)
=== CONT  TestAccIbmMqcloudUserDataSourceBasic
--- PASS: TestAccIbmMqcloudUserDataSourceBasic (42.53s)
=== CONT  TestAccIbmMqcloudTruststoreCertificateDataSourceBasic
--- PASS: TestAccIbmMqcloudTruststoreCertificateDataSourceBasic (45.86s)
=== CONT  TestAccIbmMqcloudUserBasic
--- PASS: TestAccIbmMqcloudUserBasic (45.24s)
=== CONT  TestAccIbmMqcloudTruststoreCertificateBasic
--- PASS: TestAccIbmMqcloudTruststoreCertificateBasic (56.02s)
=== CONT  TestAccIbmMqcloudQueueManagerDataSourceBasic
--- PASS: TestAccIbmMqcloudQueueManagerBasic (363.16s)
=== CONT  TestAccIbmMqcloudKeystoreCertificateDataSourceBasic
--- PASS: TestAccIbmMqcloudQueueManagerDataSourceAllArgs (317.08s)
=== CONT  TestAccIbmMqcloudQueueManagerStatusDataSourceBasic
--- PASS: TestAccIbmMqcloudQueueManagerStatusDataSourceBasic (33.40s)
--- PASS: TestAccIbmMqcloudKeystoreCertificateDataSourceBasic (57.80s)
--- PASS: TestAccIbmMqcloudQueueManagerAllArgs (629.39s)
--- PASS: TestAccIbmMqcloudQueueManagerDataSourceBasic (323.60s)
PASS
ok      github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/mqcloud 640.916s
...
```
