### PR TITLE
fix(docs): Add ibm_resource_instance sample config in the mqcloud website docs

### DIFF
--- a/website/docs/r/mqcloud_queue_manager.html.markdown
+++ b/website/docs/r/mqcloud_queue_manager.html.markdown
@@ -13,11 +13,18 @@ Create, update, and delete mqcloud_queue_managers with this resource.
 ## Example Usage
 
 ```hcl
+resource "ibm_resource_instance" "mqcloud_instance" {
+    name     = "mqcloud-service-name"
+    service  = "mqcloud"
+    plan     = "default"
+    location = "eu-de"
+}
+
 resource "ibm_mqcloud_queue_manager" "mqcloud_queue_manager_instance" {
   display_name = "A test queue manager"
   location = "reserved-eu-de-cluster-f884"
   name = "testqm"
-  service_instance_guid = var.service_instance_guid
+  service_instance_guid = ibm_resource_instance.mqcloud_instance.guid
   size = "lite"
   version = "9.3.2_2"
 }


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/IBM-Cloud/terraform-provider-ibm/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

add `ibm_resource_instance` sample config code part in the website doc for improved reference.

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccXXX'
not required.
...
```
