### PR TITLE
support empty lists for CBR rule contexts and zone addresses

### DIFF
--- a/ibm/service/contextbasedrestrictions/resource_ibm_cbr_rule.go
+++ b/ibm/service/contextbasedrestrictions/resource_ibm_cbr_rule.go
@@ -35,7 +35,7 @@ func ResourceIBMCbrRule() *schema.Resource {
 			},
 			"contexts": &schema.Schema{
 				Type:        schema.TypeList,
-				Required:    true,
+				Optional:    true,
 				Description: "The contexts this rule applies to.",
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
@@ -122,6 +122,7 @@ func ResourceIBMCbrRule() *schema.Resource {
 				Type:        schema.TypeList,
 				MaxItems:    1,
 				Optional:    true,
+				Computed:    true,
 				Description: "The operations this rule applies to.",
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
@@ -144,7 +145,7 @@ func ResourceIBMCbrRule() *schema.Resource {
 			"enforcement_mode": &schema.Schema{
 				Type:         schema.TypeString,
 				Optional:     true,
-				Default:      "enabled",
+				Computed:     true,
 				ValidateFunc: validate.InvokeValidator("ibm_cbr_rule", "enforcement_mode"),
 				Description:  "The rule enforcement mode: * `enabled` - The restrictions are enforced and reported. This is the default. * `disabled` - The restrictions are disabled. Nothing is enforced or reported. * `report` - The restrictions are evaluated and reported, but not enforced.",
 			},
@@ -252,8 +253,8 @@ func resourceIBMCbrRuleCreate(context context.Context, d *schema.ResourceData, m
 	if _, ok := d.GetOk("description"); ok {
 		createRuleOptions.SetDescription(d.Get("description").(string))
 	}
+	contexts := []contextbasedrestrictionsv1.RuleContext{}
 	if _, ok := d.GetOk("contexts"); ok {
-		var contexts []contextbasedrestrictionsv1.RuleContext
 		for _, e := range d.Get("contexts").([]interface{}) {
 			value := e.(map[string]interface{})
 			contextsItem, err := resourceIBMCbrRuleMapToRuleContext(value)
@@ -262,8 +263,8 @@ func resourceIBMCbrRuleCreate(context context.Context, d *schema.ResourceData, m
 			}
 			contexts = append(contexts, *contextsItem)
 		}
-		createRuleOptions.SetContexts(contexts)
 	}
+	createRuleOptions.SetContexts(contexts)
 	if _, ok := d.GetOk("resources"); ok {
 		var resources []contextbasedrestrictionsv1.Resource
 		for _, e := range d.Get("resources").([]interface{}) {
@@ -408,8 +409,8 @@ func resourceIBMCbrRuleUpdate(context context.Context, d *schema.ResourceData, m
 	if _, ok := d.GetOk("description"); ok {
 		replaceRuleOptions.SetDescription(d.Get("description").(string))
 	}
+	contexts := []contextbasedrestrictionsv1.RuleContext{}
 	if _, ok := d.GetOk("contexts"); ok {
-		var contexts []contextbasedrestrictionsv1.RuleContext
 		for _, e := range d.Get("contexts").([]interface{}) {
 			value := e.(map[string]interface{})
 			contextsItem, err := resourceIBMCbrRuleMapToRuleContext(value)
@@ -418,8 +419,8 @@ func resourceIBMCbrRuleUpdate(context context.Context, d *schema.ResourceData, m
 			}
 			contexts = append(contexts, *contextsItem)
 		}
-		replaceRuleOptions.SetContexts(contexts)
 	}
+	replaceRuleOptions.SetContexts(contexts)
 	if _, ok := d.GetOk("resources"); ok {
 		var resources []contextbasedrestrictionsv1.Resource
 		for _, e := range d.Get("resources").([]interface{}) {

--- a/ibm/service/contextbasedrestrictions/resource_ibm_cbr_zone.go
+++ b/ibm/service/contextbasedrestrictions/resource_ibm_cbr_zone.go
@@ -47,7 +47,7 @@ func ResourceIBMCbrZone() *schema.Resource {
 			},
 			"addresses": &schema.Schema{
 				Type:        schema.TypeList,
-				Required:    true,
+				Optional:    true,
 				Description: "The list of addresses in the zone.",
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
@@ -249,8 +249,8 @@ func resourceIBMCbrZoneCreate(context context.Context, d *schema.ResourceData, m
 	if _, ok := d.GetOk("description"); ok {
 		createZoneOptions.SetDescription(d.Get("description").(string))
 	}
+	addresses := []contextbasedrestrictionsv1.AddressIntf{}
 	if _, ok := d.GetOk("addresses"); ok {
-		var addresses []contextbasedrestrictionsv1.AddressIntf
 		for _, e := range d.Get("addresses").([]interface{}) {
 			value := e.(map[string]interface{})
 			addressesItem, err := resourceIBMCbrZoneMapToAddress(value)
@@ -259,8 +259,8 @@ func resourceIBMCbrZoneCreate(context context.Context, d *schema.ResourceData, m
 			}
 			addresses = append(addresses, addressesItem)
 		}
-		createZoneOptions.SetAddresses(addresses)
 	}
+	createZoneOptions.SetAddresses(addresses)
 	if _, ok := d.GetOk("excluded"); ok {
 		var excluded []contextbasedrestrictionsv1.AddressIntf
 		for _, e := range d.Get("excluded").([]interface{}) {
@@ -401,8 +401,8 @@ func resourceIBMCbrZoneUpdate(context context.Context, d *schema.ResourceData, m
 	if _, ok := d.GetOk("description"); ok {
 		replaceZoneOptions.SetDescription(d.Get("description").(string))
 	}
+	addresses := []contextbasedrestrictionsv1.AddressIntf{}
 	if _, ok := d.GetOk("addresses"); ok {
-		var addresses []contextbasedrestrictionsv1.AddressIntf
 		for _, e := range d.Get("addresses").([]interface{}) {
 			value := e.(map[string]interface{})
 			addressesItem, err := resourceIBMCbrZoneMapToAddress(value)
@@ -411,8 +411,8 @@ func resourceIBMCbrZoneUpdate(context context.Context, d *schema.ResourceData, m
 			}
 			addresses = append(addresses, addressesItem)
 		}
-		replaceZoneOptions.SetAddresses(addresses)
 	}
+	replaceZoneOptions.SetAddresses(addresses)
 	if _, ok := d.GetOk("excluded"); ok {
 		var excluded []contextbasedrestrictionsv1.AddressIntf
 		for _, e := range d.Get("excluded").([]interface{}) {

--- a/website/docs/d/cbr_rule.html.markdown
+++ b/website/docs/d/cbr_rule.html.markdown
@@ -31,7 +31,7 @@ In addition to all argument references listed, you can access the following attr
 
 * `id` - The unique identifier of the cbr_rule.
 * `contexts` - (List) The contexts this rule applies to.
-  * Constraints: The maximum length is `1000` items. The minimum length is `1` item.
+  * Constraints: The maximum length is `1000` items. The minimum length is `0` items.
 Nested scheme for **contexts**:
 	* `attributes` - (List) The attributes.
 	  * Constraints: The minimum length is `1` item.

--- a/website/docs/d/cbr_zone.html.markdown
+++ b/website/docs/d/cbr_zone.html.markdown
@@ -36,7 +36,7 @@ In addition to all argument references listed, you can access the following attr
 * `address_count` - (Integer) The number of addresses in the zone.
 
 * `addresses` - (List) The list of addresses in the zone.
-  * Constraints: The maximum length is `1000` items. The minimum length is `1` item.
+  * Constraints: The maximum length is `1000` items. The minimum length is `0` items.
 Nested scheme for **addresses**:
 	* `ref` - (List) A service reference value.
 	Nested scheme for **ref**:

--- a/website/docs/r/cbr_rule.html.markdown
+++ b/website/docs/r/cbr_rule.html.markdown
@@ -101,7 +101,7 @@ resource "ibm_cbr_rule" "cbr_rule" {
 Review the argument reference that you can specify for your resource.
 
 * `contexts` - (Optional, List) The contexts this rule applies to.
-  * Constraints: The maximum length is `1000` items. The minimum length is `1` item.
+  * Constraints: The maximum length is `1000` items. The minimum length is `0` items.
 Nested scheme for **contexts**:
 	* `attributes` - (Required, List) The attributes.
 	  * Constraints: The minimum length is `1` item.

--- a/website/docs/r/cbr_zone.html.markdown
+++ b/website/docs/r/cbr_zone.html.markdown
@@ -47,7 +47,7 @@ Review the argument reference that you can specify for your resource.
 * `account_id` - (Optional, String) The id of the account owning this zone.
   * Constraints: The maximum length is `128` characters. The minimum length is `1` character. The value must match regular expression `/^[a-zA-Z0-9\-]+$/`.
 * `addresses` - (Optional, List) The list of addresses in the zone.
-  * Constraints: The maximum length is `1000` items. The minimum length is `1` item.
+  * Constraints: The maximum length is `1000` items. The minimum length is `0` items.
 Nested scheme for **addresses**:
 	* `ref` - (Optional, List) A service reference value.
 	Nested scheme for **ref**:


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/IBM-Cloud/terraform-provider-ibm/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccIBMCbr'

=== RUN   TestAccIBMCbrRuleDataSourceBasic
--- PASS: TestAccIBMCbrRuleDataSourceBasic (14.90s)
=== RUN   TestAccIBMCbrRuleDataSourceAllArgs
--- PASS: TestAccIBMCbrRuleDataSourceAllArgs (11.43s)
=== RUN   TestAccIBMCbrZoneDataSourceBasic
--- PASS: TestAccIBMCbrZoneDataSourceBasic (11.58s)
=== RUN   TestAccIBMCbrZoneDataSourceAllArgs
--- PASS: TestAccIBMCbrZoneDataSourceAllArgs (10.80s)
=== RUN   TestAccIBMCbrRuleBasic
--- PASS: TestAccIBMCbrRuleBasic (8.89s)
=== RUN   TestAccIBMCbrRuleAllArgs
--- PASS: TestAccIBMCbrRuleAllArgs (19.86s)
=== RUN   TestAccIBMCbrZoneBasic
--- PASS: TestAccIBMCbrZoneBasic (9.38s)
=== RUN   TestAccIBMCbrZoneAllArgs
--- PASS: TestAccIBMCbrZoneAllArgs (19.46s)
PASS
```
