### PR TITLE
encode test ids as constants for easy replacement

### DIFF
--- a/ibm/service/contextbasedrestrictions/data_source_ibm_cbr_rule_test.go
+++ b/ibm/service/contextbasedrestrictions/data_source_ibm_cbr_rule_test.go
@@ -13,6 +13,11 @@ import (
 	acc "github.com/IBM-Cloud/terraform-provider-ibm/ibm/acctest"
 )
 
+const (
+	testAccountID = "12ab34cd56ef78ab90cd12ef34ab56cd"
+	testZoneID    = "559052eb8f43302824e7ae490c0281eb"
+)
+
 func TestAccIBMCbrRuleDataSourceBasic(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:  func() { acc.TestAccPreCheck(t) },
@@ -77,13 +82,13 @@ func testAccCheckIBMCbrRuleDataSourceConfigBasic() string {
   			contexts {
     			attributes {
       				name = "networkZoneId"
-      				value = "559052eb8f43302824e7ae490c0281eb"
+      				value = "%s"
     			}
   			}
   			resources {
     			attributes {
       				name = "accountId"
-      				value = "12ab34cd56ef78ab90cd12ef34ab56cd"
+      				value = "%s"
     			}
     			attributes {
       				name = "serviceName"
@@ -94,7 +99,7 @@ func testAccCheckIBMCbrRuleDataSourceConfigBasic() string {
 		data "ibm_cbr_rule" "cbr_rule" {
 			rule_id = ibm_cbr_rule.cbr_rule.id
 		}
-	`)
+	`, testZoneID, testAccountID)
 }
 
 func testAccCheckIBMCbrRuleDataSourceConfig(ruleDescription string, ruleEnforcementMode string) string {
@@ -104,13 +109,13 @@ func testAccCheckIBMCbrRuleDataSourceConfig(ruleDescription string, ruleEnforcem
 			contexts {
     			attributes {
       				name = "networkZoneId"
-      				value = "559052eb8f43302824e7ae490c0281eb"
+      				value = "%s"
     			}
 			}
 			resources {
 				attributes {
       				name = "accountId"
-      				value = "12ab34cd56ef78ab90cd12ef34ab56cd"
+      				value = "%s"
     			}
     			attributes {
       				name = "serviceName"
@@ -133,5 +138,5 @@ func testAccCheckIBMCbrRuleDataSourceConfig(ruleDescription string, ruleEnforcem
 		data "ibm_cbr_rule" "cbr_rule" {
 			rule_id = ibm_cbr_rule.cbr_rule.id
 		}
-	`, ruleDescription, ruleEnforcementMode)
+	`, ruleDescription, testZoneID, testAccountID, ruleEnforcementMode)
 }

--- a/ibm/service/contextbasedrestrictions/data_source_ibm_cbr_zone_test.go
+++ b/ibm/service/contextbasedrestrictions/data_source_ibm_cbr_zone_test.go
@@ -45,7 +45,7 @@ func TestAccIBMCbrZoneDataSourceBasic(t *testing.T) {
 
 func TestAccIBMCbrZoneDataSourceAllArgs(t *testing.T) {
 	zoneName := fmt.Sprintf("tf_name_%d", acctest.RandIntRange(10, 100))
-	zoneAccountID := "12ab34cd56ef78ab90cd12ef34ab56cd"
+	zoneAccountID := testAccountID
 	zoneDescription := fmt.Sprintf("tf_description_%d", acctest.RandIntRange(10, 100))
 
 	resource.Test(t, resource.TestCase{
@@ -86,7 +86,7 @@ func testAccCheckIBMCbrZoneDataSourceConfigBasic() string {
 		resource "ibm_cbr_zone" "cbr_zone" {
 			name = "Test Zone Data Source Config Basic"
 			description = "Test Zone Data Source Config Basic"
-			account_id = "12ab34cd56ef78ab90cd12ef34ab56cd"
+			account_id = "%s"
 			addresses {
 				type = "ipRange"
 				value = "169.23.22.0-169.23.22.255"
@@ -96,7 +96,7 @@ func testAccCheckIBMCbrZoneDataSourceConfigBasic() string {
 		data "ibm_cbr_zone" "cbr_zone" {
 			zone_id = ibm_cbr_zone.cbr_zone.id
 		}
-	`)
+	`, testAccountID)
 }
 
 func testAccCheckIBMCbrZoneDataSourceConfig(zoneName string, zoneAccountID string, zoneDescription string) string {

--- a/ibm/service/contextbasedrestrictions/resource_ibm_cbr_rule_test.go
+++ b/ibm/service/contextbasedrestrictions/resource_ibm_cbr_rule_test.go
@@ -78,13 +78,13 @@ func testAccCheckIBMCbrRuleConfigBasic() string {
   			contexts {
     			attributes {
       				name = "networkZoneId"
-      				value = "559052eb8f43302824e7ae490c0281eb"
+      				value = "%s"
     			}
   			}
 			resources {
     			attributes {
       				name = "accountId"
-      				value = "12ab34cd56ef78ab90cd12ef34ab56cd"
+      				value = "%s"
     			}
     			attributes {
       				name = "serviceName"
@@ -97,7 +97,7 @@ func testAccCheckIBMCbrRuleConfigBasic() string {
   			}
 			enforcement_mode = "disabled"
 		}
-	`)
+	`, testZoneID, testAccountID)
 }
 
 func testAccCheckIBMCbrRuleConfig(description string, enforcementMode string) string {
@@ -108,13 +108,13 @@ func testAccCheckIBMCbrRuleConfig(description string, enforcementMode string) st
 			contexts {
     			attributes {
       				name = "networkZoneId"
-      				value = "559052eb8f43302824e7ae490c0281eb"
+      				value = "%s"
     			}
 			}
 			resources {
     			attributes {
       				name = "accountId"
-      				value = "12ab34cd56ef78ab90cd12ef34ab56cd"
+      				value = "%s"
     			}
     			attributes {
       				name = "serviceName"
@@ -133,7 +133,7 @@ func testAccCheckIBMCbrRuleConfig(description string, enforcementMode string) st
 			}
 			enforcement_mode = "%s"
 		}
-	`, description, enforcementMode)
+	`, description, testZoneID, testAccountID, enforcementMode)
 }
 
 func testAccCheckIBMCbrRuleExists(n string, obj contextbasedrestrictionsv1.Rule) resource.TestCheckFunc {

--- a/ibm/service/contextbasedrestrictions/resource_ibm_cbr_zone_test.go
+++ b/ibm/service/contextbasedrestrictions/resource_ibm_cbr_zone_test.go
@@ -37,10 +37,10 @@ func TestAccIBMCbrZoneBasic(t *testing.T) {
 func TestAccIBMCbrZoneAllArgs(t *testing.T) {
 	var conf contextbasedrestrictionsv1.Zone
 	name := fmt.Sprintf("tf_name_%d", acctest.RandIntRange(10, 100))
-	accountID := fmt.Sprintf("12ab34cd56ef78ab90cd12ef34ab56cd")
+	accountID := testAccountID
 	description := fmt.Sprintf("tf_description_%d", acctest.RandIntRange(10, 100))
 	nameUpdate := fmt.Sprintf("tf_name_%d", acctest.RandIntRange(10, 100))
-	accountIDUpdate := fmt.Sprintf("12ab34cd56ef78ab90cd12ef34ab56cd")
+	accountIDUpdate := testAccountID
 	descriptionUpdate := fmt.Sprintf("tf_description_%d", acctest.RandIntRange(10, 100))
 
 	resource.Test(t, resource.TestCase{
@@ -79,13 +79,13 @@ func testAccCheckIBMCbrZoneConfigBasic() string {
 		resource "ibm_cbr_zone" "cbr_zone" {
 			name = "Test Zone Resource Config Basic"
 			description = "Test Zone Resource Config Basic"
-			account_id = "12ab34cd56ef78ab90cd12ef34ab56cd"
+			account_id = "%s"
 			addresses {
 				type = "ipRange"
 				value = "169.23.22.0-169.23.22.255"
 			}
 		}
-	`)
+	`, testAccountID)
 }
 
 func testAccCheckIBMCbrZoneConfig(name string, accountID string, description string) string {


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/IBM-Cloud/terraform-provider-ibm/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccIBMCbr'

=== RUN   TestAccIBMCbrRuleDataSourceBasic
--- PASS: TestAccIBMCbrRuleDataSourceBasic (14.90s)
=== RUN   TestAccIBMCbrRuleDataSourceAllArgs
--- PASS: TestAccIBMCbrRuleDataSourceAllArgs (11.43s)
=== RUN   TestAccIBMCbrZoneDataSourceBasic
--- PASS: TestAccIBMCbrZoneDataSourceBasic (11.58s)
=== RUN   TestAccIBMCbrZoneDataSourceAllArgs
--- PASS: TestAccIBMCbrZoneDataSourceAllArgs (10.80s)
=== RUN   TestAccIBMCbrRuleBasic
--- PASS: TestAccIBMCbrRuleBasic (8.89s)
=== RUN   TestAccIBMCbrRuleAllArgs
--- PASS: TestAccIBMCbrRuleAllArgs (19.86s)
=== RUN   TestAccIBMCbrZoneBasic
--- PASS: TestAccIBMCbrZoneBasic (9.38s)
=== RUN   TestAccIBMCbrZoneAllArgs
--- PASS: TestAccIBMCbrZoneAllArgs (19.46s)
PASS
```
