### PR TITLE
added a nil check on data source of bm servers

### DIFF
--- a/ibm/service/vpc/data_source_ibm_is_bare_metal_server.go
+++ b/ibm/service/vpc/data_source_ibm_is_bare_metal_server.go
@@ -470,9 +470,11 @@ func dataSourceIBMISBareMetalServerRead(context context.Context, d *schema.Resou
 
 	d.SetId(*bms.ID)
 	d.Set(isBareMetalServerBandwidth, bms.Bandwidth)
-	bmsBootTargetIntf := bms.BootTarget.(*vpcv1.BareMetalServerBootTarget)
-	bmsBootTarget := bmsBootTargetIntf.ID
-	d.Set(isBareMetalServerBootTarget, bmsBootTarget)
+	if bms.BootTarget != nil {
+		bmsBootTargetIntf := bms.BootTarget.(*vpcv1.BareMetalServerBootTarget)
+		bmsBootTarget := bmsBootTargetIntf.ID
+		d.Set(isBareMetalServerBootTarget, bmsBootTarget)
+	}
 
 	// set keys and image using initialization
 

--- a/ibm/service/vpc/data_source_ibm_is_bare_metal_servers.go
+++ b/ibm/service/vpc/data_source_ibm_is_bare_metal_servers.go
@@ -521,9 +521,11 @@ func dataSourceIBMISBareMetalServersRead(context context.Context, d *schema.Reso
 		}
 		l["id"] = *bms.ID
 		l[isBareMetalServerBandwidth] = *bms.Bandwidth
-		bmsBootTargetIntf := bms.BootTarget.(*vpcv1.BareMetalServerBootTarget)
-		bmsBootTarget := bmsBootTargetIntf.ID
-		l[isBareMetalServerBootTarget] = bmsBootTarget
+		if bms.BootTarget != nil {
+			bmsBootTargetIntf := bms.BootTarget.(*vpcv1.BareMetalServerBootTarget)
+			bmsBootTarget := bmsBootTargetIntf.ID
+			l[isBareMetalServerBootTarget] = bmsBootTarget
+		}
 		cpuList := make([]map[string]interface{}, 0)
 		if bms.Cpu != nil {
 			currentCPU := map[string]interface{}{}


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/IBM-Cloud/terraform-provider-ibm/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```
