### PR TITLE
Adding the fix for cos deletion access denied issue

### DIFF
--- a/ibm/service/cos/resource_ibm_cos_bucket.go
+++ b/ibm/service/cos/resource_ibm_cos_bucket.go
@@ -20,6 +20,7 @@ import (
 	token "github.com/IBM/ibm-cos-sdk-go/aws/credentials/ibmiam/token"
 	"github.com/IBM/ibm-cos-sdk-go/aws/session"
 	"github.com/IBM/ibm-cos-sdk-go/service/s3"
+	rc "github.com/IBM/platform-services-go-sdk/resourcecontrollerv2"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
@@ -1550,7 +1551,26 @@ func resourceIBMCOSBucketExists(d *schema.ResourceData, meta interface{}) (bool,
 	if len(bucket_meta) < 2 || len(strings.Split(bucket_meta[1], ":")) < 2 {
 		return false, fmt.Errorf("[ERROR] Error parsing bucket ID. Bucket ID format must be: $CRN:meta:$buckettype:$bucketlocation")
 	}
-
+	resourceInstanceId := strings.Split(d.Id(), ":bucket:")[0]
+	resourceInstanceIdInput := resourceInstanceId + "::"
+	resourceInstanceGet := rc.GetResourceInstanceOptions{
+		ID: &resourceInstanceIdInput,
+	}
+	rsConClientV2, errConf := meta.(conns.ClientSession).ResourceControllerV2API()
+	if errConf != nil {
+		return false, errConf
+	}
+	instance, resp, err := rsConClientV2.GetResourceInstance(&resourceInstanceGet)
+	if err != nil {
+		if resp != nil && resp.StatusCode == 404 {
+			return false, nil
+		}
+		fmt.Println(fmt.Errorf("[WARN] Error getting resource instance from cos bucket: %s with resp code: %s", err, resp))
+	}
+	if instance != nil && (strings.Contains(*instance.State, "removed") || strings.Contains(*instance.State, "pending_reclamation")) {
+		log.Printf("[WARN] Removing instance from state because it's in removed or pending_reclamation state from the cos bucket resource")
+		return false, nil
+	}
 	bucketName := parseBucketId(d.Id(), "bucketName")
 	serviceID := parseBucketId(d.Id(), "serviceID")
 


### PR DESCRIPTION
Regression result :
=== RUN   TestAccIBMCosBucket_Objectlock_Bucket_Enabled
--- PASS: TestAccIBMCosBucket_Objectlock_Bucket_Enabled (75.90s)
=== RUN   TestAccIBMCosBucket_Objectlock_Configuration_Without_Rule
--- PASS: TestAccIBMCosBucket_Objectlock_Configuration_Without_Rule (71.78s)
--- PASS: TestAccIBMCosBucket_Objectlock_Configuration_Valid_Mode_and_Years  (75.59s)
=== RUN   TestAccIBMCosBucket_Objectlock_Configuration_Empty
--- PASS: TestAccIBMCosBucket_Objectlock_Configuration_Empty (0.39s)
=== RUN   TestAccIBMCosBucket_Objectlock_Configuration_Without_Mode
--- PASS: TestAccIBMCosBucket_Objectlock_Configuration_Without_Mode (0.37s)
=== RUN   TestAccIBMCosBucket_Objectlock_Configuration_With_Mode_Only
--- PASS: TestAccIBMCosBucket_Objectlock_Configuration_With_Mode_Only (49.26s)
=== RUN   TestAccIBMCosBucket_Objectlock_Configuration_With_Versioning_Not_Enabled
--- PASS: TestAccIBMCosBucket_Objectlock_Configuration_With_Versioning_Not_Enabled (0.40s)
=== RUN   TestAccIBMCosBucket_Objectlock_Configuration_Invalid_Mode
--- PASS: TestAccIBMCosBucket_Objectlock_Configuration_Invalid_Mode (50.87s)
=== RUN   TestAccIBMCosBucket_Objectlock_Configuration_Invalid_Days
--- PASS: TestAccIBMCosBucket_Objectlock_Configuration_Invalid_Days (50.63s)
=== RUN   TestAccIBMCosBucket_Basic
--- PASS: TestAccIBMCosBucket_Basic (95.45s)
=== RUN   TestAccIBMCosBucket_Basic_Single_Site_Location
--- PASS: TestAccIBMCosBucket_Basic_Single_Site_Location (64.88s)
=== RUN   TestAccIBMCosBucket_AllowedIP
--- PASS: TestAccIBMCosBucket_OneRate_With_Invalid_Storageclass (5.31s)
=== RUN   TestAccIBMCosBucket_COS_Plan_Storageclass_Mismatch_Type1
--- PASS: TestAccIBMCosBucket_COS_Plan_Storageclass_Mismatch_Type1 (79.37s)
=== RUN   TestAccIBMCosBucket_COS_Plan_Storageclass_Mismatch_Type2
--- PASS: TestAccIBMCosBucket_COS_Plan_Storageclass_Mismatch_Type2 (68.97s)
=== RUN   TestAccIBMCosBucket_Website_Configuration_Bucket_Basic
--- PASS: TestAccIBMCosBucket_Website_Configuration_Bucket_Basic (95.79s)
--- PASS: TestAccIBMCosBucket_Website_Configuration_Bucket_With_Multiple_Routing_Rules (76.57s)
=== RUN   TestAccIBMCosBucket_Website_Configuration_Bucket_Upload_Object_With_Redirect
--- PASS: TestAccIBMCosBucket_Website_Configuration_Bucket_Upload_Object_With_Redirect (77.09s)
=== RUN   TestAccIBMCosBucket_Website_Configuration_Bucket_Empty_Config
--- PASS: TestAccIBMCosBucket_Website_Configuration_Bucket_Empty_Config (54.25s)
=== RUN   TestAccIBMCosBucket_Website_Configuration_Bucket_Index_And_Redirect_Together
--- PASS: TestAccIBMCosBucket_Website_Configuration_Bucket_Index_And_Redirect_Together (0.41s)
=== RUN   TestAccIBMCosBucket_Website_Configuration_Bucket_No_Config
--- PASS: TestAccIBMCosBucket_Website_Configuration_Bucket_No_Config (0.45s)
=== RUN   TestAccIBMCOSBucketDataSource_basic
--- PASS: TestAccIBMCOSBucketDataSource_basic (35.65s)
PASS
ok  	github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/cos	38.744s