### PR TITLE
docs(is-vpn-gateways): Remove status attribute from docs for vpngateway resources and data sources

### DIFF
--- a/website/docs/d/is_vpn_gateway.html.markdown
+++ b/website/docs/d/is_vpn_gateway.html.markdown
@@ -65,7 +65,6 @@ In addition to all argument references listed, you can access the following attr
 	- `private_ip_address` - (String) The private IP address assigned to the VPN gateway member. This property will be present only when the VPN gateway status is `available`. This property may add support for IPv6 addresses in the future. When processing a value in this property, verify that the address is in an expected format. If it is not, log an error. Optionally halt processing and surface the error, or bypass the resource on which the unexpected IP address format was encountered. Same as `primary_ip.0.address`
 	- `public_ip_address` - (String) The public IP address assigned to the VPN gateway member. This property may add support for IPv6 addresses in the future. When processing a value in this property, verify that the address is in an expected format. If it is not, log an error. Optionally halt processing and surface the error, or bypass the resource on which the unexpected IP address format was encountered.
 	- `role` - (String) The high availability role assigned to the VPN gateway member.
-	- `status` - (String) The status of the VPN gateway member.
 
 - `mode` - (String) Route mode VPN gateway.
 
@@ -79,7 +78,6 @@ In addition to all argument references listed, you can access the following attr
 
 - `resource_type` - (String) The resource type.
 
-- `status` - (String) The status of the VPN gateway.
 - `health_reasons` - (List) The reasons for the current health_state (if any).
 
   Nested scheme for `health_reasons`:

--- a/website/docs/d/is_vpn_gateways.html.markdown
+++ b/website/docs/d/is_vpn_gateways.html.markdown
@@ -56,11 +56,9 @@ In addition to all argument reference list, you can access the following attribu
           Nested scheme for `private_ip`:
           - `address` - (String) The IP address. If the address has not yet been selected, the value will be 0.0.0.0. This property may add support for IPv6 addresses in the future. When processing a value in this property, verify that the address is in an expected format. If it is not, log an error. Optionally halt processing and surface the error, or bypass the resource on which the unexpected IP address format was encountered.
 	  - `private_address` - (String) The private IP address assigned to the VPN gateway member. Same as `private_ip.0.address`.</br>
-	  - `status` - (String) The status of the VPN gateway member.
   
 
   - `resource_type` - (String) The resource type, supported value is `vpn_gateway`.
-  - `status` - (String) The status of the VPN gateway, supported values are **available**, **deleting**, **failed**, **pending**.
   - `health_reasons` - (List) The reasons for the current health_state (if any).
 
       Nested scheme for `health_reasons`:

--- a/website/docs/r/is_vpn_gateway.html.markdown
+++ b/website/docs/r/is_vpn_gateway.html.markdown
@@ -74,12 +74,10 @@ In addition to all argument reference list, you can access the following attribu
   - `address` -  (String) The public IP address assigned to the VPN gateway member.
   - `private_address` -  (String) The private IP address assigned to the VPN gateway member.
   - `role` -  (String) The high availability role assigned to the VPN gateway member.
-  - `status` -  (String) The status of the VPN gateway member.
 - `public_ip_address` - (String) The IP address assigned to this VPN gateway.
 - `public_ip_address2` -  (String) The Second Public IP address assigned to this VPN gateway member.
 - `private_ip_address` -  (String) The Private IP address assigned to this VPN gateway member.
 - `private_ip_address2` -  (String) The Second Private IP address assigned to this VPN gateway.
-- `status` -  (String) The status of the VPN gateway. Supported values are **available**, **deleting**, **failed**, or **pending**.
 - `health_reasons` - (List) The reasons for the current health_state (if any).
 
   Nested scheme for `health_reasons`:


### PR DESCRIPTION


<!--- See what makes a good Pull Request at : https://github.com/IBM-Cloud/terraform-provider-ibm/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```
