### PR TITLE
fix(IAM Policy Management): Update check for authorization policy subject and add test coverage

### DIFF
--- a/ibm/service/iampolicy/resource_ibm_iam_authorization_policy.go
+++ b/ibm/service/iampolicy/resource_ibm_iam_authorization_policy.go
@@ -362,8 +362,10 @@ func resourceIBMIAMAuthorizationPolicyCreate(d *schema.ResourceData, meta interf
 				var resourceValue bool
 				if value == "true" {
 					resourceValue = true
-				} else {
+				} else if value == "false" {
 					resourceValue = false
+				} else {
+					return fmt.Errorf("[ERROR] When operator = stringExists, value should be either \"true\" or \"false\", instead of %s", value)
 				}
 				at := iampolicymanagementv1.V2PolicyResourceAttribute{
 					Key:      &name,

--- a/ibm/service/iampolicy/resource_ibm_iam_trusted_profile_policy_test.go
+++ b/ibm/service/iampolicy/resource_ibm_iam_trusted_profile_policy_test.go
@@ -271,6 +271,27 @@ func TestAccIBMIAMTrustedProfilePolicy_With_Resource_Attributes(t *testing.T) {
 	})
 }
 
+func TestAccIBMIAMTrustedProfilePolicy_With_Resource_Attributes_Without_Wildcard(t *testing.T) {
+	var conf iampolicymanagementv1.V2PolicyTemplateMetaData
+	name := fmt.Sprintf("terraform_%d", acctest.RandIntRange(10, 100))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { acc.TestAccPreCheck(t) },
+		Providers:    acc.TestAccProviders,
+		CheckDestroy: testAccCheckIBMIAMTrustedProfilePolicyDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckIBMIAMTrustedProfilePolicyResourceAttributesWithoutWildcard(name),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckIBMIAMTrustedProfilePolicyExists("ibm_iam_trusted_profile_policy.policy", conf),
+					resource.TestCheckResourceAttr("ibm_iam_trusted_profile.profileID", "name", name),
+					resource.TestCheckResourceAttr("ibm_iam_trusted_profile_policy.policy", "resource_attributes.#", "2"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccIBMIAMTrustedProfilePolicy_With_Resource_Tags(t *testing.T) {
 	var conf iampolicymanagementv1.V2PolicyTemplateMetaData
 	name := fmt.Sprintf("terraform_%d", acctest.RandIntRange(10, 100))
@@ -807,6 +828,29 @@ func testAccCheckIBMIAMTrustedProfilePolicyResourceAttributes(name string) strin
 	  }
 	`, name)
 }
+
+func testAccCheckIBMIAMTrustedProfilePolicyResourceAttributesWithoutWildcard(name string) string {
+	return fmt.Sprintf(`
+	resource "ibm_iam_trusted_profile" "profileID" {
+		name = "%s"
+	  }
+  
+	  resource "ibm_iam_trusted_profile_policy" "policy" {
+		profile_id     = ibm_iam_trusted_profile.profileID.id
+		roles              = ["Viewer"]
+		resource_attributes {
+			name     = "resource"
+			value    = "test"
+			operator = "stringMatch"
+		}
+		resource_attributes {
+			name     = "serviceName"
+			value    = "messagehub"
+		}
+	  }
+	`, name)
+}
+
 func testAccCheckIBMIAMTrustedProfilePolicyResourceAttributesUpdate(name string) string {
 	return fmt.Sprintf(`
 	resource "ibm_iam_trusted_profile" "profileID" {

--- a/ibm/service/iampolicy/resource_ibm_iam_user_policy_test.go
+++ b/ibm/service/iampolicy/resource_ibm_iam_user_policy_test.go
@@ -180,6 +180,7 @@ func TestAccIBMIAMUserPolicy_import(t *testing.T) {
 		},
 	})
 }
+
 func TestAccIBMIAMUserPolicy_With_Resource_Attributes(t *testing.T) {
 	var conf iampolicymanagementv1.V2PolicyTemplateMetaData
 
@@ -205,6 +206,26 @@ func TestAccIBMIAMUserPolicy_With_Resource_Attributes(t *testing.T) {
 		},
 	})
 }
+
+func TestAccIBMIAMUserPolicy_With_Resource_Attributes_Without_Wildcard(t *testing.T) {
+	var conf iampolicymanagementv1.V2PolicyTemplateMetaData
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { acc.TestAccPreCheck(t) },
+		Providers:    acc.TestAccProviders,
+		CheckDestroy: testAccCheckIBMIAMServicePolicyDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckIBMIAMUserPolicyResourceAttributesWithoutWildcard(),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckIBMIAMUserPolicyExists("ibm_iam_user_policy.policy", conf),
+					resource.TestCheckResourceAttr("ibm_iam_user_policy.policy", "resource_attributes.#", "2"),
+				),
+			},
+		},
+	})
+}
+
 
 func TestAccIBMIAMUserPolicy_account_management(t *testing.T) {
 	var conf iampolicymanagementv1.V2PolicyTemplateMetaData
@@ -806,6 +827,28 @@ func testAccCheckIBMIAMUserPolicyResourceAttributes() string {
 	  
 `, acc.IAMUser)
 }
+
+func testAccCheckIBMIAMUserPolicyResourceAttributesWithoutWildcard() string {
+	return fmt.Sprintf(`
+  
+	  resource "ibm_iam_user_policy" "policy" {
+		ibm_id = "%s"
+		roles  = ["Viewer"]
+		resource_attributes {
+			name     = "resource"
+			value    = "test*"
+			operator = "stringMatch"
+		}
+		resource_attributes {
+			name     = "serviceName"
+			value    = "messagehub"
+		}
+	  }
+	  
+`, acc.IAMUser)
+}
+
+
 func testAccCheckIBMIAMUserPolicyResourceAttributesUpdate() string {
 	return fmt.Sprintf(`
 	resource "ibm_iam_user_policy" "policy" {


### PR DESCRIPTION

<!--- See what makes a good Pull Request at : https://github.com/IBM-Cloud/terraform-provider-ibm/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes [#2212](https://github.ibm.com/IAM/AM-issues/issues/2212)

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
All of the authorization tests:

```sh
$ go test ./ibm/service/iampolicy/ -run=TestAccIBMIAMAuthorizationPolicy_ -timeout 700m -v
...
PASS
ok  	github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/iampolicy	357.904s ```
 Tests added for each policy type
Access group test:
```sh
$ go test ./ibm/service/iampolicy/ -run=TestAccIBMIAMAccessGroupPolicy_StringMatch_Without_Wildcard -timeout 700m -v
... === RUN   TestAccIBMIAMAccessGroupPolicy_StringMatch_Without_Wildcard
--- PASS: TestAccIBMIAMAccessGroupPolicy_StringMatch_Without_Wildcard (23.43s)
PASS
ok  	github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/iampolicy	26.051s
```

service policy test:
```sh
$ go test ./ibm/service/iampolicy/ -run=TestAccIBMIAMServicePolicy_With_Resource_Attributes_Without_Wildcard -timeout 700m -v === RUN   TestAccIBMIAMServicePolicy_With_Resource_Attributes_Without_Wildcard
--- PASS: TestAccIBMIAMServicePolicy_With_Resource_Attributes_Without_Wildcard (23.87s)
PASS
ok  	github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/iampolicy	25.931s
```

trusted profile test

```sh $ go test ./ibm/service/iampolicy/ -run=TestAccIBMIAMTrustedProfilePolicy_With_Resource_Attributes_Without_Wildcard -timeout 700m -v
=== RUN   TestAccIBMIAMTrustedProfilePolicy_With_Resource_Attributes_Without_Wildcard
--- PASS: TestAccIBMIAMTrustedProfilePolicy_With_Resource_Attributes_Without_Wildcard (28.18s)
PASS
ok  	github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/iampolicy	30.317s

```

user policy test
```sh $ go test ./ibm/service/iampolicy/ -run=TestAccIBMIAMUserPolicy_With_Resource_Attributes_Without_Wildcard -timeout 700m -v
--- PASS: TestAccIBMIAMUserPolicy_With_Resource_Attributes_Without_Wildcard (33.04s)
PASS
ok  	github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/iampolicy	35.134s
```
