### PR TITLE
feat(Catalog Management): update platform go sdk version, remove old …

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -24,7 +24,7 @@ require (
 	github.com/IBM/ibm-hpcs-uko-sdk v0.0.20-beta
 	github.com/IBM/keyprotect-go-client v0.12.2
 	github.com/IBM/networking-go-sdk v0.44.0
-	github.com/IBM/platform-services-go-sdk v0.56.3
+	github.com/IBM/platform-services-go-sdk v0.59.0
 	github.com/IBM/project-go-sdk v0.2.1
 	github.com/IBM/push-notifications-go-sdk v0.0.0-20210310100607-5790b96c47f5
 	github.com/IBM/scc-go-sdk/v5 v5.1.4

--- a/go.sum
+++ b/go.sum
@@ -158,8 +158,8 @@ github.com/IBM/mqcloud-go-sdk v0.0.4 h1:gqMpoU5a0qJ0GETG4PQrkgeEEoaQLvbxRJnEe6yt
 github.com/IBM/mqcloud-go-sdk v0.0.4/go.mod h1:gQptHC6D+rxfg0muRFFGvTDmvl4YfiDE0uXkaRRewRk=
 github.com/IBM/networking-go-sdk v0.44.0 h1:6acyMd6hwxcjK3bJ2suiUBTjzg8mRFAvYD76zbx0adk=
 github.com/IBM/networking-go-sdk v0.44.0/go.mod h1:XtqYRInR5NHmFUXhOL6RovpDdv6PnJfZ1lPFvssA8MA=
-github.com/IBM/platform-services-go-sdk v0.56.3 h1:DQ1VMQSknhPsdT7d+AybKiZT82esczAkHCIBkwYubzQ=
-github.com/IBM/platform-services-go-sdk v0.56.3/go.mod h1:+U6Kg7o5u/Bh4ZkLxjymSgfdpVsaWAtsMtzhwclUry0=
+github.com/IBM/platform-services-go-sdk v0.59.0 h1:FSRM3oKHxzShLCsIIb6Dl+JSaVOXpBWnfWFITJR6DDk=
+github.com/IBM/platform-services-go-sdk v0.59.0/go.mod h1:+U6Kg7o5u/Bh4ZkLxjymSgfdpVsaWAtsMtzhwclUry0=
 github.com/IBM/project-go-sdk v0.2.1 h1:Xo7ITrfyfVm0eCsaC2SADlhcEjqjx9rtU37fwnzGMCI=
 github.com/IBM/project-go-sdk v0.2.1/go.mod h1:lqe0M4cKvABI1iHR1b+KfasVcxQL6nl2VJ8eOyQs8Ig=
 github.com/IBM/push-notifications-go-sdk v0.0.0-20210310100607-5790b96c47f5 h1:NPUhkoOCRuv3OFWt19PmwjXGGTKlvmbuPg9fUrBUNe4=

--- a/ibm/service/catalogmanagement/data_source_ibm_cm_object.go
+++ b/ibm/service/catalogmanagement/data_source_ibm_cm_object.go
@@ -326,12 +326,6 @@ func dataSourceIBMCmObjectPublishObjectToMap(model *catalogmanagementv1.PublishO
 	if model.PublicApproved != nil {
 		modelMap["public_approved"] = *model.PublicApproved
 	}
-	if model.PortalApprovalRecord != nil {
-		modelMap["portal_approval_record"] = *model.PortalApprovalRecord
-	}
-	if model.PortalURL != nil {
-		modelMap["portal_url"] = *model.PortalURL
-	}
 	return modelMap, nil
 }
 

--- a/ibm/service/catalogmanagement/resource_ibm_cm_object.go
+++ b/ibm/service/catalogmanagement/resource_ibm_cm_object.go
@@ -545,12 +545,6 @@ func resourceIBMCmObjectMapToPublishObject(modelMap map[string]interface{}) (*ca
 	if modelMap["public_approved"] != nil {
 		model.PublicApproved = core.BoolPtr(modelMap["public_approved"].(bool))
 	}
-	if modelMap["portal_approval_record"] != nil && modelMap["portal_approval_record"].(string) != "" {
-		model.PortalApprovalRecord = core.StringPtr(modelMap["portal_approval_record"].(string))
-	}
-	if modelMap["portal_url"] != nil && modelMap["portal_url"].(string) != "" {
-		model.PortalURL = core.StringPtr(modelMap["portal_url"].(string))
-	}
 	return model, nil
 }
 
@@ -584,12 +578,6 @@ func resourceIBMCmObjectPublishObjectToMap(model *catalogmanagementv1.PublishObj
 	}
 	if model.PublicApproved != nil {
 		modelMap["public_approved"] = model.PublicApproved
-	}
-	if model.PortalApprovalRecord != nil {
-		modelMap["portal_approval_record"] = model.PortalApprovalRecord
-	}
-	if model.PortalURL != nil {
-		modelMap["portal_url"] = model.PortalURL
 	}
 	return modelMap, nil
 }


### PR DESCRIPTION
…catalog fields

<!--- See what makes a good Pull Request at : https://github.com/IBM-Cloud/terraform-provider-ibm/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Output from acceptance testing:
```
TF_ACC=1 go test $(go list ./... |grep -v 'vendor') -v -run TestAccIBMCmCatalogBasic -timeout 700m
=== RUN   TestAccIBMCmCatalogBasic
--- PASS: TestAccIBMCmCatalogBasic (23.90s)
TF_ACC=1 go test $(go list ./... |grep -v 'vendor') -v -run TestAccIBMCmCatalogSimpleArgs -timeout 700m
=== RUN   TestAccIBMCmCatalogSimpleArgs
--- PASS: TestAccIBMCmCatalogSimpleArgs (31.85s)
TF_ACC=1 go test $(go list ./... |grep -v 'vendor') -v -run TestAccIBMCmCatalogDataSourceBasic -timeout 700m
=== RUN   TestAccIBMCmCatalogDataSourceBasic
--- PASS: TestAccIBMCmCatalogDataSourceBasic (21.18s)
TF_ACC=1 go test $(go list ./... |grep -v 'vendor') -v -run TestAccIBMCmCatalogDataSourceSimpleArgs -timeout 700m
=== RUN   TestAccIBMCmCatalogDataSourceSimpleArgs
--- PASS: TestAccIBMCmCatalogDataSourceSimpleArgs (19.83s)
TF_ACC=1 go test $(go list ./... |grep -v 'vendor') -v -run TestAccIBMCmOfferingBasic -timeout 700m
=== RUN   TestAccIBMCmOfferingBasic
--- PASS: TestAccIBMCmOfferingBasic (23.49s)
TF_ACC=1 go test $(go list ./... |grep -v 'vendor') -v -run TestAccIBMCmOfferingSimpleArgs -timeout 700m
=== RUN   TestAccIBMCmOfferingSimpleArgs
--- PASS: TestAccIBMCmOfferingSimpleArgs (31.00s)
TF_ACC=1 go test $(go list ./... |grep -v 'vendor') -v -run TestAccIBMCmOfferingDataSourceBasic -timeout 700m
=== RUN   TestAccIBMCmOfferingDataSourceBasic
--- PASS: TestAccIBMCmOfferingDataSourceBasic (22.82s)
TF_ACC=1 go test $(go list ./... |grep -v 'vendor') -v -run TestAccIBMCmOfferingDataSourceSimpleArgs -timeout 700m
=== RUN   TestAccIBMCmOfferingDataSourceSimpleArgs
--- PASS: TestAccIBMCmOfferingDataSourceSimpleArgs (21.47s)
TF_ACC=1 go test $(go list ./... |grep -v 'vendor') -v -run TestAccIBMCmVersionBasic -timeout 700m
=== RUN   TestAccIBMCmVersionBasic
--- PASS: TestAccIBMCmVersionBasic (25.18s)
TF_ACC=1 go test $(go list ./... |grep -v 'vendor') -v -run TestAccIBMCmVersionSimpleArgs -timeout 700m
=== RUN   TestAccIBMCmVersionSimpleArgs
--- PASS: TestAccIBMCmVersionSimpleArgs (23.55s)
TF_ACC=1 go test $(go list ./... |grep -v 'vendor') -v -run TestAccIBMCmVersionDataSourceSimpleArgs -timeout 700m
=== RUN   TestAccIBMCmVersionDataSourceSimpleArgs
--- PASS: TestAccIBMCmVersionDataSourceSimpleArgs (23.71s)
```
