### PR TITLE
feat: remove CF auth to avoid delay of 60s for nothing

### DIFF
--- a/ibm/conns/config.go
+++ b/ibm/conns/config.go
@@ -1324,20 +1324,8 @@ func (c *Config) ClientSession() (interface{}, error) {
 				session.functionConfigErr = fmt.Errorf("[ERROR] Error occured while fetching auth key for function: %q", err)
 			}
 		}
-		err = authenticateCF(sess.BluemixSession)
-		if err != nil {
-			for count := c.RetryCount; count >= 0; count-- {
-				if err == nil || !isRetryable(err) {
-					break
-				}
-				time.Sleep(c.RetryDelay)
-				log.Printf("Retrying CF Authentication %d", count)
-				err = authenticateCF(sess.BluemixSession)
-			}
-			if err != nil {
-				session.functionConfigErr = fmt.Errorf("[ERROR] Error occured while fetching auth key for function: %q", err)
-			}
-		}
+
+		session.functionConfigErr = fmt.Errorf("[ERROR] Error occured while fetching auth key for function: %q", err)
 	}
 
 	if c.IAMTrustedProfileID == "" && sess.BluemixSession.Config.IAMAccessToken != "" && sess.BluemixSession.Config.BluemixAPIKey == "" {
@@ -3398,20 +3386,6 @@ func authenticateAPIKey(sess *bxsession.Session) error {
 		DefaultHeader: gohttp.Header{
 			"User-Agent":            []string{http.UserAgent()},
 			"X-Original-User-Agent": []string{config.UserAgent},
-		},
-	})
-	if err != nil {
-		return err
-	}
-	return tokenRefresher.AuthenticateAPIKey(config.BluemixAPIKey)
-}
-
-func authenticateCF(sess *bxsession.Session) error {
-	config := sess.Config
-	tokenRefresher, err := authentication.NewUAARepository(config, &rest.Client{
-		DefaultHeader: gohttp.Header{
-			"User-Agent":            []string{http.UserAgent()},
-			"X-Original-User-Agent": []string{http.UserAgent()},
 		},
 	})
 	if err != nil {


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/IBM-Cloud/terraform-provider-ibm/blob/master/.github/CONTRIBUTING.md --->
/fixes https://github.com/IBM-Cloud/terraform-provider-ibm/issues/5161

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```
