### PR TITLE
feat: use new standardized structures for errors

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,7 @@ require (
 	github.com/IBM/event-notifications-go-admin-sdk v0.4.0
 	github.com/IBM/eventstreams-go-sdk v1.4.0
 	github.com/IBM/go-sdk-core/v3 v3.2.4
-	github.com/IBM/go-sdk-core/v5 v5.15.3
+	github.com/IBM/go-sdk-core/v5 v5.16.1
 	github.com/IBM/ibm-cos-sdk-go v1.10.0
 	github.com/IBM/ibm-cos-sdk-go-config v1.2.0
 	github.com/IBM/ibm-hpcs-tke-sdk v0.0.0-20211109141421-a4b61b05f7d1

--- a/go.sum
+++ b/go.sum
@@ -140,8 +140,8 @@ github.com/IBM/go-sdk-core/v5 v5.7.0/go.mod h1:+YbdhrjCHC84ls4MeBp+Hj4NZCni+tDAc
 github.com/IBM/go-sdk-core/v5 v5.9.2/go.mod h1:YlOwV9LeuclmT/qi/LAK2AsobbAP42veV0j68/rlZsE=
 github.com/IBM/go-sdk-core/v5 v5.9.5/go.mod h1:YlOwV9LeuclmT/qi/LAK2AsobbAP42veV0j68/rlZsE=
 github.com/IBM/go-sdk-core/v5 v5.10.2/go.mod h1:WZPFasUzsKab/2mzt29xPcfruSk5js2ywAPwW4VJjdI=
-github.com/IBM/go-sdk-core/v5 v5.15.3 h1:yBSSYLuQSO9Ip+j3mONsTcymoYQyxarQ6rh3aU9cVt8=
-github.com/IBM/go-sdk-core/v5 v5.15.3/go.mod h1:ee+AZaB15yUwZigJdRCwZZ3u7HIvEQzxNUdxVpnJHY8=
+github.com/IBM/go-sdk-core/v5 v5.16.1 h1:vAgOxRvaXD5AmgwR7dlstjT1JFE4BA4lPcGsEFZOKGs=
+github.com/IBM/go-sdk-core/v5 v5.16.1/go.mod h1:aojBkkq4HXkOYdn7YZ6ve8cjPWHdcB3tt8v0b9Cbac8=
 github.com/IBM/ibm-cos-sdk-go v1.3.1/go.mod h1:YLBAYobEA8bD27P7xpMwSQeNQu6W3DNBtBComXrRzRY=
 github.com/IBM/ibm-cos-sdk-go v1.10.0 h1:/2VIev2/jBei39OqU2+nSZQnoWJ+KtkiSAIDkqsd7uU=
 github.com/IBM/ibm-cos-sdk-go v1.10.0/go.mod h1:C8KRTRaoD3CWPPBOa6FCOpdh0ZMlUjKAAA4i3F+Q/sc=

--- a/ibm/flex/structures.go
+++ b/ibm/flex/structures.go
@@ -3274,6 +3274,7 @@ type ServiceErrorResponse struct {
 	Message    string
 	StatusCode int
 	Result     interface{}
+	Error      error
 }
 
 func BeautifyError(err error, response *core.DetailedResponse) *ServiceErrorResponse {
@@ -3289,6 +3290,7 @@ func BeautifyError(err error, response *core.DetailedResponse) *ServiceErrorResp
 		Message:    err.Error(),
 		StatusCode: statusCode,
 		Result:     result,
+		Error:      err,
 	}
 }
 

--- a/ibm/flex/terraform_problem.go
+++ b/ibm/flex/terraform_problem.go
@@ -1,0 +1,109 @@
+package flex
+
+import (
+	"errors"
+	"fmt"
+	v "github.com/IBM-Cloud/terraform-provider-ibm/version"
+	"github.com/IBM/go-sdk-core/v5/core"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+)
+
+// TerraformProblem provides a type that holds standardized information
+// suitable to problems that occur in the Terraform Provider code.
+type TerraformProblem struct {
+	*core.IBMProblem
+
+	Resource  string
+	Operation string
+}
+
+// GetID returns a hash value computed from stable fields in the
+// TerraformProblem instance, including Resource and Operation.
+func (e *TerraformProblem) GetID() string {
+	return core.CreateIDHash("terraform", e.GetBaseSignature(), e.Resource, e.Operation)
+}
+
+// GetConsoleMessage returns the fields of the problem that
+// are relevant to a user, formatted as a YAML string.
+func (e *TerraformProblem) GetConsoleMessage() string {
+	return core.ComputeConsoleMessage(e)
+}
+
+// GetConsoleMessage returns the fields of the problem that
+// are relevant to a developer, formatted as a YAML string.
+func (e *TerraformProblem) GetDebugMessage() string {
+	return core.ComputeDebugMessage(e)
+}
+
+func (e *TerraformProblem) GetConsoleOrderedMaps() *core.OrderedMaps {
+	orderedMaps := core.NewOrderedMaps()
+
+	orderedMaps.Add("id", e.GetID())
+	orderedMaps.Add("summary", e.Summary)
+	orderedMaps.Add("severity", e.Severity)
+	orderedMaps.Add("resource", e.Resource)
+	orderedMaps.Add("operation", e.Operation)
+	orderedMaps.Add("component", e.Component)
+
+	return orderedMaps
+}
+
+func (e *TerraformProblem) GetDebugOrderedMaps() *core.OrderedMaps {
+	orderedMaps := e.GetConsoleOrderedMaps()
+
+	var orderableCausedBy core.OrderableProblem
+	if errors.As(e.GetCausedBy(), &orderableCausedBy) {
+		orderedMaps.Add("caused_by", orderableCausedBy.GetDebugOrderedMaps().GetMaps())
+	}
+
+	return orderedMaps
+}
+
+// GetDiag returns a new Diagnostics object using the console
+// message as the summary. It is used to create a Diagnostics
+// object from a TerraformProblem in the resource/data source code.
+func (e *TerraformProblem) GetDiag() diag.Diagnostics {
+	return diag.Errorf("%s", e.GetConsoleMessage())
+}
+
+// TerraformErrorf creates and returns a new instance
+// of `TerraformProblem` with "error" level severity.
+func TerraformErrorf(err error, summary, resource, operation string) *TerraformProblem {
+	return &TerraformProblem{
+		IBMProblem: core.IBMErrorf(err, getComponentInfo(), summary, ""),
+		Resource:   resource,
+		Operation:  operation,
+	}
+}
+
+func getComponentInfo() *core.ProblemComponent {
+	return core.NewProblemComponent("github.com/IBM-Cloud/terraform-provider-ibm", v.Version)
+}
+
+// FmtErrorf wraps `fmt.Errorf(format string, a ...interface{}) error`
+// and checks for the instance of a "Problem" type. If it finds one,
+// the Problem instance needs to be returned instead of wrapped by
+// `fmt.Errorf`.
+func FmtErrorf(format string, a ...interface{}) error {
+	for _, arg := range a {
+		// Look for an error instance among the arguments.
+		var err error
+
+		if errArg, ok := arg.(error); ok {
+			err = errArg
+		} else if ser, ok := arg.(*ServiceErrorResponse); ok {
+			// Deal with the "ServiceErrorResponse" type, which
+			// wraps errors in some of the handwritten code.
+			err = ser.Error
+		}
+
+		if err != nil {
+			var problem core.Problem
+			if errors.As(err, &problem) {
+				return problem
+			}
+		}
+	}
+
+	return fmt.Errorf(format, a...)
+}


### PR DESCRIPTION
feat: add new TerraformProblem type for identifiable errors

This adds baseline support for a new error structure, created specifically
for Terraform code.

cc @hkantare @astha-jain - this is part of the identifiable error work we have been discussing the last couple of months. It enables the new error formats for some of the VPC resources (the ones that use `Create` instead of `CreateContext`, etc.) by wrapping the provider and catching errors coming from the resources. This will need to remain a draft until the [Go SDK Core PR](https://github.com/IBM/go-sdk-core/pull/199) and [Go SDK Generator PR](https://github.ibm.com/CloudEngineering/openapi-sdkgen/pull/1612) are merged and released.

Edit: the core and generator PRs are merged and this first step is ready to go.

<!--- See what makes a good Pull Request at : https://github.com/IBM-Cloud/terraform-provider-ibm/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```
