### PR TITLE
Fix the spelling of IBM i in documentation and strings

### DIFF
--- a/examples/ansible/examples/simple-vm-power-vs/README.md
+++ b/examples/ansible/examples/simple-vm-power-vs/README.md
@@ -1,6 +1,6 @@
 # IBM Power Virtual Server in IBM Cloud
 
-This example creates a Power Systems Virtual Server running AIX or IBMi. The
+This example creates a Power Systems Virtual Server running AIX or IBM i. The
 server is configured to allow incoming SSH connections through a publicly
 accessible IP address and authenticated using the provided SSH key.
 

--- a/ibm/service/power/data_source_ibm_pi_instance.go
+++ b/ibm/service/power/data_source_ibm_pi_instance.go
@@ -165,22 +165,22 @@ func DataSourceIBMPIInstance() *schema.Resource {
 			Attr_IBMiCSS: {
 				Type:        schema.TypeBool,
 				Computed:    true,
-				Description: "IBMi Cloud Storage Solution",
+				Description: "IBM i Cloud Storage Solution",
 			},
 			Attr_IBMiPHA: {
 				Type:        schema.TypeBool,
 				Computed:    true,
-				Description: "IBMi Power High Availability",
+				Description: "IBM i Power High Availability",
 			},
 			Attr_IBMiRDS: {
 				Type:        schema.TypeBool,
 				Computed:    true,
-				Description: "IBMi Rational Dev Studio",
+				Description: "IBM i Rational Dev Studio",
 			},
 			Attr_IBMiRDSUsers: {
 				Type:        schema.TypeInt,
 				Computed:    true,
-				Description: "IBMi Rational Dev Studio Number of User Licenses",
+				Description: "IBM i Rational Dev Studio Number of User Licenses",
 			},
 		},
 	}

--- a/ibm/service/power/resource_ibm_pi_instance.go
+++ b/ibm/service/power/resource_ibm_pi_instance.go
@@ -356,24 +356,24 @@ func ResourceIBMPIInstance() *schema.Resource {
 			Arg_IBMiCSS: {
 				Type:        schema.TypeBool,
 				Optional:    true,
-				Description: "IBMi Cloud Storage Solution",
+				Description: "IBM i Cloud Storage Solution",
 			},
 			Arg_IBMiPHA: {
 				Type:        schema.TypeBool,
 				Optional:    true,
-				Description: "IBMi Power High Availability",
+				Description: "IBM i Power High Availability",
 			},
 			Attr_IBMiRDS: {
 				Type:        schema.TypeBool,
 				Optional:    false,
 				Required:    false,
 				Computed:    true,
-				Description: "IBMi Rational Dev Studio",
+				Description: "IBM i Rational Dev Studio",
 			},
 			Arg_IBMiRDSUsers: {
 				Type:        schema.TypeInt,
 				Optional:    true,
-				Description: "IBMi Rational Dev Studio Number of User Licenses",
+				Description: "IBM i Rational Dev Studio Number of User Licenses",
 			},
 		},
 	}
@@ -816,7 +816,7 @@ func resourceIBMPIInstanceUpdate(ctx context.Context, d *schema.ResourceData, me
 		sl.IbmiPHA = flex.PtrToBool(d.Get(Arg_IBMiPHA).(bool))
 		ibmrdsUsers := d.Get(Arg_IBMiRDSUsers).(int)
 		if ibmrdsUsers < 0 {
-			return diag.Errorf("request with IBMi Rational Dev Studio property requires IBMi Rational Dev Studio number of users")
+			return diag.Errorf("request with  IBM i Rational Dev Studio property requires IBM i Rational Dev Studio number of users")
 		}
 		sl.IbmiRDS = flex.PtrToBool(ibmrdsUsers > 0)
 		sl.IbmiRDSUsers = int64(ibmrdsUsers)
@@ -1481,7 +1481,7 @@ func createPVMInstance(d *schema.ResourceData, client *st.IBMPIInstanceClient, i
 		}
 		if ibmrdsUsers, ok := d.GetOk(Arg_IBMiRDSUsers); ok {
 			if ibmrdsUsers.(int) < 0 {
-				return nil, fmt.Errorf("request with IBMi Rational Dev Studio property requires IBMi Rational Dev Studio number of users")
+				return nil, fmt.Errorf("request with IBM i Rational Dev Studio property requires IBM i Rational Dev Studio number of users")
 			}
 			sl.IbmiRDS = flex.PtrToBool(ibmrdsUsers.(int) > 0)
 			sl.IbmiRDSUsers = int64(ibmrdsUsers.(int))

--- a/website/docs/d/pi_instance.html.markdown
+++ b/website/docs/d/pi_instance.html.markdown
@@ -47,11 +47,11 @@ In addition to all argument reference list, you can access the following attribu
 - `deployment_type` - (String) The custom deployment type.
 - `health_status` - (String) The health of the instance.
 
-**Notes** IBMi software licenses for IBMi virtual server instances -- only for IBMi instances
-- `ibmi_css` - (Boolean) IBMi Cloud Storage Solution.
-- `ibmi_pha` - (Boolean) IBMi Power High Availability.
-- `ibmi_rds` - (Boolean) IBMi Rational Dev Studio.
-- `ibmi_rds_users` - (Integer) IBMi Rational Dev Studio Number of User Licenses.
+**Notes** IBM i software licenses for IBM i virtual server instances -- only for IBM i instances
+- `ibmi_css` - (Boolean) IBM i Cloud Storage Solution.
+- `ibmi_pha` - (Boolean) IBM i Power High Availability.
+- `ibmi_rds` - (Boolean) IBM i Rational Dev Studio.
+- `ibmi_rds_users` - (Integer) IBM i Rational Dev Studio Number of User Licenses.
 - `id` - (String) The unique identifier of the instance.
 - `license_repository_capacity` - The VTL license repository capacity TB value. Only available with VTL instances.
 - `memory` - (Float) The amount of memory that is allocated to the instance.

--- a/website/docs/r/pi_instance.html.markdown
+++ b/website/docs/r/pi_instance.html.markdown
@@ -67,10 +67,10 @@ Review the argument references that you can specify for your resource.
 - `pi_deployment_type` - (Optional, String) Custom deployment type; Allowable value: `EPIC` or `VMNoStorage`.
 - `pi_health_status` - (Optional, String) Specifies if Terraform should poll for the health status to be `OK` or `WARNING`. The default value is `OK`.
 
-**Notes** Ibmi software licenses for IBMi virtual server instances -- only for IBMi instances. Default to `false` and `0` if no values provided
-- `pi_ibmi_css` - (Optional, Boolean) IBMi Cloud Storage Solution.
-- `pi_ibmi_pha` - (Optional, Boolean) IBMi Power High Availability.
-- `pi_ibmi_rds_users` - (Optional, Integer) IBMi Rational Dev Studio Number of User Licenses.
+**Notes** IBM i software licenses for IBM i virtual server instances -- only for IBM i instances. Default to `false` and `0` if no values provided
+- `pi_ibmi_css` - (Optional, Boolean) IBM i Cloud Storage Solution.
+- `pi_ibmi_pha` - (Optional, Boolean) IBM i Power High Availability.
+- `pi_ibmi_rds_users` - (Optional, Integer) IBM i Rational Dev Studio Number of User Licenses.
 - `pi_image_id` - (Required, String) The ID of the image that you want to use for your Power Systems Virtual Server instance. The image determines the operating system that is installed in your instance. To list available images, run the `ibmcloud pi images` command.
   - **Note**: only images belonging to your project can be used image for deploying a Power Systems Virtual Server instance. To import an images to your project, see [ibm_pi_image](https://registry.terraform.io/providers/IBM-Cloud/ibm/latest/docs/resources/pi_image).
 - `pi_instance_name` - (Required, String) The name of the Power Systems Virtual Server instance. 
@@ -112,7 +112,7 @@ Review the argument references that you can specify for your resource.
 In addition to all argument reference list, you can access the following attribute reference after your resource is created.
 
 - `health_status` - (String) The health status of the VM.
-- `ibmi_rds` - (Boolean) IBMi Rational Dev Studio.
+- `ibmi_rds` - (Boolean) IBM i Rational Dev Studio.
 - `id` - (String) The unique identifier of the instance. The ID is composed of `<power_instance_id>/<instance_id>`.
 - `instance_id` - (String) The unique identifier of the instance. 
 - `max_processors`- (Float) The maximum number of processors that can be allocated to the instance with shutting down or rebooting the `LPAR`.


### PR DESCRIPTION
The correct spelling of the IBM i operating system name is "IBM i" with a space between "IBM" and "i".