### PR TITLE
adds tags support for is_ssh_key(s) datasource

### DIFF
--- a/ibm/service/vpc/data_source_ibm_is_ssh_key.go
+++ b/ibm/service/vpc/data_source_ibm_is_ssh_key.go
@@ -23,6 +23,14 @@ func DataSourceIBMISSSHKey() *schema.Resource {
 				Description: "Resource group ID",
 			},
 
+			"tags": {
+				Type:        schema.TypeSet,
+				Computed:    true,
+				Elem:        &schema.Schema{Type: schema.TypeString},
+				Set:         flex.ResourceIBMVPCHash,
+				Description: "User Tags for the ssh",
+			},
+
 			isKeyName: {
 				Type:        schema.TypeString,
 				Required:    true,
@@ -150,6 +158,12 @@ func keyGetByName(d *schema.ResourceData, meta interface{}, name string) error {
 			if key.PublicKey != nil {
 				d.Set(isKeyPublicKey, *key.PublicKey)
 			}
+			tags, err := flex.GetGlobalTagsUsingCRN(meta, *key.CRN, "", isUserTagType)
+			if err != nil {
+				log.Printf(
+					"Error on get of resource vpc ssh key (%s) tags: %s", d.Id(), err)
+			}
+			d.Set("tags", tags)
 			accesstags, err := flex.GetGlobalTagsUsingCRN(meta, *key.CRN, "", isKeyAccessTagType)
 			if err != nil {
 				log.Printf(

--- a/ibm/service/vpc/data_source_ibm_is_ssh_key_test.go
+++ b/ibm/service/vpc/data_source_ibm_is_ssh_key_test.go
@@ -29,6 +29,22 @@ ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCKVmnMOlHKcZK8tpt3MP1lqOLAcqcJzhsvJcjscgVE
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(
 						"data.ibm_is_ssh_key.ds_key", "name", name1),
+					resource.TestCheckResourceAttrSet(
+						"data.ibm_is_ssh_key.ds_key", "crn"),
+					resource.TestCheckResourceAttrSet(
+						"data.ibm_is_ssh_key.ds_key", "fingerprint"),
+					resource.TestCheckResourceAttrSet(
+						"data.ibm_is_ssh_key.ds_key", "id"),
+					resource.TestCheckResourceAttrSet(
+						"data.ibm_is_ssh_key.ds_key", "length"),
+					resource.TestCheckResourceAttrSet(
+						"data.ibm_is_ssh_key.ds_key", "public_key"),
+					resource.TestCheckResourceAttrSet(
+						"data.ibm_is_ssh_key.ds_key", "type"),
+					resource.TestCheckResourceAttrSet(
+						"data.ibm_is_ssh_key.ds_key", "tags.#"),
+					resource.TestCheckResourceAttr(
+						"data.ibm_is_ssh_key.ds_key", "tags.#", "3"),
 				),
 			},
 		},
@@ -38,8 +54,9 @@ ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCKVmnMOlHKcZK8tpt3MP1lqOLAcqcJzhsvJcjscgVE
 func testDSCheckIBMISSSHKeyConfig(publicKey, name string) string {
 	return fmt.Sprintf(`
 		resource "ibm_is_ssh_key" "key" {
-			name = "%s"
-			public_key = "%s"
+			name 		= "%s"
+			public_key 	= "%s"
+			tags		= ["test:1", "test:2", "test:3"]
 		}
 		data "ibm_is_ssh_key" "ds_key" {
 		    name = "${ibm_is_ssh_key.key.name}"

--- a/ibm/service/vpc/data_source_ibm_is_ssh_keys.go
+++ b/ibm/service/vpc/data_source_ibm_is_ssh_keys.go
@@ -109,6 +109,13 @@ func DataSourceIBMIsSshKeys() *schema.Resource {
 							Computed:    true,
 							Description: "The crypto-system used by this key.",
 						},
+						"tags": {
+							Type:        schema.TypeSet,
+							Computed:    true,
+							Elem:        &schema.Schema{Type: schema.TypeString},
+							Set:         flex.ResourceIBMVPCHash,
+							Description: "User Tags for the ssh",
+						},
 						isKeyAccessTags: {
 							Type:        schema.TypeSet,
 							Computed:    true,
@@ -154,7 +161,6 @@ func dataSourceIBMIsSshKeysRead(context context.Context, d *schema.ResourceData,
 	}
 
 	d.SetId(dataSourceIBMIsSshKeysID(d))
-
 	err = d.Set(isKeys, dataSourceKeyCollectionFlattenKeys(allrecs, d, meta))
 	if err != nil {
 		return diag.FromErr(fmt.Errorf("Error setting keys %s", err))
@@ -212,6 +218,12 @@ func dataSourceKeyCollectionKeysToMap(keysItem vpcv1.Key, d *schema.ResourceData
 	if keysItem.Type != nil {
 		keysMap[isKeyType] = keysItem.Type
 	}
+	tags, err := flex.GetGlobalTagsUsingCRN(meta, *keysItem.CRN, "", isUserTagType)
+	if err != nil {
+		log.Printf(
+			"Error on get of resource vpc SSH Key (%s) user tags: %s", d.Id(), err)
+	}
+	keysMap["tags"] = tags
 	accesstags, err := flex.GetGlobalTagsUsingCRN(meta, *keysItem.CRN, "", isKeyAccessTagType)
 	if err != nil {
 		log.Printf(

--- a/website/docs/d/is_ssh_key.html.markdown
+++ b/website/docs/d/is_ssh_key.html.markdown
@@ -44,4 +44,5 @@ In addition to all argument reference list, you can access the following attribu
 - `fingerprint`-  (String) The SHA256 fingerprint of the public key.
 - `length` - (String) The length of the SSH key.
 - `public_key` - (String) The public SSH key value.
+- `tags` - (List) User tags associated for the ssh key.
 - `type` - (String) The crypto system that is used by this key.

--- a/website/docs/d/is_ssh_keys.html.markdown
+++ b/website/docs/d/is_ssh_keys.html.markdown
@@ -47,3 +47,4 @@ In addition to all argument references listed, you can access the following attr
 		- `name` - (String) The user-defined name for this resource group.
 		  - Constraints: The maximum length is `40` characters. The minimum length is `1` character. The value must match regular expression `/^[a-zA-Z0-9-_ ]+$/`.
 	- `type` - (String) The crypto-system used by this key.
+	- `tags` - (List) User tags associated for the ssh key.


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/IBM-Cloud/terraform-provider-ibm/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
=== RUN   TestAccIBMISSSHKeyDatasource_basic
--- PASS: TestAccIBMISSSHKeyDatasource_basic (53.61s)
PASS
ok      github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/vpc     55.217s
```
```
=== RUN   TestAccIBMIsSshKeysDataSourceTags
--- PASS: TestAccIBMIsSshKeysDataSourceTags (34.46s)
PASS
ok      github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/vpc     35.724s
```
