### PR TITLE
Fix iam policy linting issue

### DIFF
--- a/ibm/service/iampolicy/resource_ibm_iam_user_policy_test.go
+++ b/ibm/service/iampolicy/resource_ibm_iam_user_policy_test.go
@@ -226,7 +226,6 @@ func TestAccIBMIAMUserPolicy_With_Resource_Attributes_Without_Wildcard(t *testin
 	})
 }
 
-
 func TestAccIBMIAMUserPolicy_account_management(t *testing.T) {
 	var conf iampolicymanagementv1.V2PolicyTemplateMetaData
 	name := fmt.Sprintf("terraform_%d", acctest.RandIntRange(10, 100))
@@ -847,7 +846,6 @@ func testAccCheckIBMIAMUserPolicyResourceAttributesWithoutWildcard() string {
 	  
 `, acc.IAMUser)
 }
-
 
 func testAccCheckIBMIAMUserPolicyResourceAttributesUpdate() string {
 	return fmt.Sprintf(`


### PR DESCRIPTION
For whatever reason, one of the latest commits in the terraform plugin has some linting error.
