### PR TITLE
SCC: adding datasources for automated WP connection  and  Profile attachments

### DIFF
--- a/ibm/provider/provider.go
+++ b/ibm/provider/provider.go
@@ -764,6 +764,7 @@ func Provider() *schema.Provider {
 			"ibm_scc_instance_settings":        scc.DataSourceIbmSccInstanceSettings(),
 			"ibm_scc_control_library":          scc.DataSourceIbmSccControlLibrary(),
 			"ibm_scc_profile":                  scc.DataSourceIbmSccProfile(),
+			"ibm_scc_profiles":                 scc.DataSourceIbmSccProfiles(),
 			"ibm_scc_profile_attachment":       scc.DataSourceIbmSccProfileAttachment(),
 			"ibm_scc_provider_type":            scc.DataSourceIbmSccProviderType(),
 			"ibm_scc_provider_type_collection": scc.DataSourceIbmSccProviderTypeCollection(),

--- a/ibm/provider/provider.go
+++ b/ibm/provider/provider.go
@@ -767,6 +767,7 @@ func Provider() *schema.Provider {
 			"ibm_scc_profiles":                 scc.DataSourceIbmSccProfiles(),
 			"ibm_scc_profile_attachment":       scc.DataSourceIbmSccProfileAttachment(),
 			"ibm_scc_provider_type":            scc.DataSourceIbmSccProviderType(),
+			"ibm_scc_provider_types":           scc.DataSourceIbmSccProviderTypes(),
 			"ibm_scc_provider_type_collection": scc.DataSourceIbmSccProviderTypeCollection(),
 			"ibm_scc_provider_type_instance":   scc.DataSourceIbmSccProviderTypeInstance(),
 			"ibm_scc_latest_reports":           scc.DataSourceIbmSccLatestReports(),

--- a/ibm/provider/provider.go
+++ b/ibm/provider/provider.go
@@ -763,6 +763,7 @@ func Provider() *schema.Provider {
 			// Security and Compliance Center
 			"ibm_scc_instance_settings":        scc.DataSourceIbmSccInstanceSettings(),
 			"ibm_scc_control_library":          scc.DataSourceIbmSccControlLibrary(),
+			"ibm_scc_control_libraries":        scc.DataSourceIbmSccControlLibraries(),
 			"ibm_scc_profile":                  scc.DataSourceIbmSccProfile(),
 			"ibm_scc_profiles":                 scc.DataSourceIbmSccProfiles(),
 			"ibm_scc_profile_attachment":       scc.DataSourceIbmSccProfileAttachment(),

--- a/ibm/service/scc/data_source_ibm_scc_control_libraries.go
+++ b/ibm/service/scc/data_source_ibm_scc_control_libraries.go
@@ -1,0 +1,206 @@
+// Copyright IBM Corp. 2023 All Rights Reserved.
+// Licensed under the Mozilla Public License v2.0
+
+package scc
+
+import (
+	"context"
+	"fmt"
+	"log"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/conns"
+	"github.com/IBM/scc-go-sdk/v5/securityandcompliancecenterapiv3"
+)
+
+func DataSourceIbmSccControlLibraries() *schema.Resource {
+	return AddSchemaData(&schema.Resource{
+		ReadContext: dataSourceIbmSccControlLibrariesRead,
+
+		Schema: map[string]*schema.Schema{
+			"control_library_type": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"control_libraries": &schema.Schema{
+				Type:        schema.TypeList,
+				Computed:    true,
+				Description: "The list of control_libraries found.",
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"id": {
+							Type:        schema.TypeString,
+							Required:    true,
+							Description: "The ID of the control library.",
+						},
+						"account_id": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "The ID of associated with the control library.",
+						},
+						// "instance_id": {
+						// 	Type:        schema.TypeString,
+						// 	Computed:    true,
+						// 	Description: "The profile description.",
+						// },
+						"control_library_name": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "The name of the control library.",
+						},
+						"control_library_description": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "The description of the control library.",
+						},
+						"control_library_type": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "The type of the control library.",
+						},
+						"version_group_label": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "The version group label of the control library.",
+						},
+						"control_library_version": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "The version of the control library.",
+						},
+						// "hierarchy_enabled": {
+						// 	Type:        schema.TypeBool,
+						// 	Computed:    true,
+						// 	Description: "The indication of whether hierarchy is enabled for the control library.",
+						// },
+						"created_by": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "The user who created the control library.",
+						},
+						"created_on": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "The date when the control library was created.",
+						},
+						"updated_by": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "The user who updated the control library.",
+						},
+						"updated_on": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "The date when the control library was updated.",
+						},
+						"controls_count": {
+							Type:        schema.TypeInt,
+							Computed:    true,
+							Description: "The number of controls for the control library.",
+						},
+						// "control_parents_count": {
+						// 	Type:        schema.TypeInt,
+						// 	Computed:    true,
+						// 	Description: "The number of parent controls for the control library.",
+						// },
+					},
+				},
+			},
+		},
+	})
+}
+
+func dataSourceIbmSccControlLibrariesRead(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	securityandcompliancecenterapiClient, err := meta.(conns.ClientSession).SecurityAndComplianceCenterV3()
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	listControlLibrariesOptions := &securityandcompliancecenterapiv3.ListControlLibrariesOptions{}
+	listControlLibrariesOptions.SetInstanceID(d.Get("instance_id").(string))
+	if val, ok := d.GetOk("control_library_type"); ok && val != nil {
+		listControlLibrariesOptions.SetControlLibraryType(val.(string))
+	}
+
+	pager, err := securityandcompliancecenterapiClient.NewControlLibrariesPager(listControlLibrariesOptions)
+	if err != nil {
+		log.Printf("[DEBUG] ListcontrolLibrarysWithContext failed %s", err)
+		return diag.FromErr(fmt.Errorf("ListcontrolLibrarysWithContext failed %s", err))
+	}
+	controlLibraryList, err := pager.GetAll()
+	if err != nil {
+		log.Printf("[DEBUG] ListcontrolLibrarysWithContext failed %s", err)
+		return diag.FromErr(fmt.Errorf("ListcontrolLibrarysWithContext failed %s", err))
+	}
+	d.SetId(fmt.Sprintf("%s/control_libraries", d.Get("instance_id").(string)))
+	if err = d.Set("instance_id", d.Get("instance_id")); err != nil {
+		return diag.FromErr(fmt.Errorf("Error setting instance_id %s", err))
+	}
+	controlLibraries := []map[string]interface{}{}
+	for _, cl := range controlLibraryList {
+		modelMap, err := dataSourceIbmSccControlLibraryToMap(&cl)
+		if err != nil {
+			return diag.FromErr(fmt.Errorf("Error setting control library:%v\n%s", cl, err))
+		}
+		controlLibraries = append(controlLibraries, modelMap)
+	}
+	if err = d.Set("control_libraries", controlLibraries); err != nil {
+		return diag.FromErr(fmt.Errorf("Error setting control_libraries: %s", err))
+	}
+	return nil
+}
+
+func dataSourceIbmSccControlLibraryToMap(controlLibrary *securityandcompliancecenterapiv3.ControlLibraryItem) (map[string]interface{}, error) {
+	modelMap := make(map[string]interface{})
+	if controlLibrary.ID != nil {
+		modelMap["id"] = controlLibrary.ID
+	}
+	if controlLibrary.AccountID != nil {
+		modelMap["account_id"] = controlLibrary.AccountID
+	}
+	// if controlLibrary.InstanceID != nil {
+	// 	modelMap["instance_id"] = controlLibrary.InstanceID
+	// }
+	if controlLibrary.ControlLibraryName != nil {
+		modelMap["control_library_name"] = controlLibrary.ControlLibraryName
+	}
+	if controlLibrary.ControlLibraryDescription != nil {
+		modelMap["control_library_description"] = controlLibrary.ControlLibraryDescription
+	}
+	if controlLibrary.ControlLibraryType != nil {
+		modelMap["control_library_type"] = controlLibrary.ControlLibraryType
+	}
+	if controlLibrary.VersionGroupLabel != nil {
+		modelMap["version_group_label"] = controlLibrary.VersionGroupLabel
+	}
+	if controlLibrary.ControlLibraryVersion != nil {
+		modelMap["control_library_version"] = controlLibrary.ControlLibraryVersion
+	}
+	if controlLibrary.Latest != nil {
+		modelMap["latest"] = controlLibrary.Latest
+	}
+	// if controlLibrary.HierarchyEnabled != nil {
+	// 	modelMap["hierarchy_enabled"] = controlLibrary.HierarchyEnabled
+	// }
+	if controlLibrary.CreatedBy != nil {
+		modelMap["created_by"] = controlLibrary.CreatedBy
+	}
+	if controlLibrary.CreatedOn != nil {
+		modelMap["created_on"] = controlLibrary.CreatedOn.String()
+	}
+	if controlLibrary.UpdatedBy != nil {
+		modelMap["updated_by"] = controlLibrary.UpdatedBy
+	}
+	if controlLibrary.UpdatedOn != nil {
+		modelMap["updated_on"] = controlLibrary.UpdatedOn.String()
+	}
+	if controlLibrary.ControlsCount != nil {
+		modelMap["controls_count"] = controlLibrary.ControlsCount
+	}
+	// if controlLibrary.ControlParentCount != nil {
+	// 	modelMap["controls_parents_count"] = controlLibrary.ControlParentsCount
+	// }
+	return modelMap, nil
+}

--- a/ibm/service/scc/data_source_ibm_scc_control_libraries.go
+++ b/ibm/service/scc/data_source_ibm_scc_control_libraries.go
@@ -12,6 +12,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 
 	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/conns"
+	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/validate"
 	"github.com/IBM/scc-go-sdk/v5/securityandcompliancecenterapiv3"
 )
 
@@ -21,13 +22,15 @@ func DataSourceIbmSccControlLibraries() *schema.Resource {
 
 		Schema: map[string]*schema.Schema{
 			"control_library_type": {
-				Type:     schema.TypeString,
-				Optional: true,
+				Type:         schema.TypeString,
+				Description:  "The type of control library to be found.",
+				ValidateFunc: validate.InvokeValidator("ibm_scc_control_library", "control_library_type"),
+				Optional:     true,
 			},
 			"control_libraries": &schema.Schema{
 				Type:        schema.TypeList,
 				Computed:    true,
-				Description: "The list of control_libraries found.",
+				Description: "The list of control libraries found.",
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"id": {
@@ -69,6 +72,11 @@ func DataSourceIbmSccControlLibraries() *schema.Resource {
 							Type:        schema.TypeString,
 							Computed:    true,
 							Description: "The version of the control library.",
+						},
+						"latest": {
+							Type:        schema.TypeBool,
+							Computed:    true,
+							Description: "The latest version of the control library.",
 						},
 						// "hierarchy_enabled": {
 						// 	Type:        schema.TypeBool,
@@ -126,13 +134,13 @@ func dataSourceIbmSccControlLibrariesRead(context context.Context, d *schema.Res
 
 	pager, err := securityandcompliancecenterapiClient.NewControlLibrariesPager(listControlLibrariesOptions)
 	if err != nil {
-		log.Printf("[DEBUG] ListcontrolLibrarysWithContext failed %s", err)
-		return diag.FromErr(fmt.Errorf("ListcontrolLibrarysWithContext failed %s", err))
+		log.Printf("[DEBUG] ListControlLibrarysWithContext failed %s", err)
+		return diag.FromErr(fmt.Errorf("ListControlLibrarysWithContext failed %s", err))
 	}
 	controlLibraryList, err := pager.GetAll()
 	if err != nil {
-		log.Printf("[DEBUG] ListcontrolLibrarysWithContext failed %s", err)
-		return diag.FromErr(fmt.Errorf("ListcontrolLibrarysWithContext failed %s", err))
+		log.Printf("[DEBUG] ListControlLibrarysWithContext failed %s", err)
+		return diag.FromErr(fmt.Errorf("ListControlLibrarysWithContext failed %s", err))
 	}
 	d.SetId(fmt.Sprintf("%s/control_libraries", d.Get("instance_id").(string)))
 	if err = d.Set("instance_id", d.Get("instance_id")); err != nil {

--- a/ibm/service/scc/data_source_ibm_scc_control_libraries.go
+++ b/ibm/service/scc/data_source_ibm_scc_control_libraries.go
@@ -35,7 +35,7 @@ func DataSourceIbmSccControlLibraries() *schema.Resource {
 					Schema: map[string]*schema.Schema{
 						"id": {
 							Type:        schema.TypeString,
-							Required:    true,
+							Computed:    true,
 							Description: "The ID of the control library.",
 						},
 						"account_id": {

--- a/ibm/service/scc/data_source_ibm_scc_control_libraries_test.go
+++ b/ibm/service/scc/data_source_ibm_scc_control_libraries_test.go
@@ -1,0 +1,59 @@
+package scc_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	acc "github.com/IBM-Cloud/terraform-provider-ibm/ibm/acctest"
+)
+
+func TestAccIbmSccControlLibrariesDataSourceBasic(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { acc.TestAccPreCheckScc(t) },
+		Providers: acc.TestAccProviders,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccCheckIbmSccControlLibrariesDataSourceConfigBasic(acc.SccInstanceID),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet("data.ibm_scc_control_libraries.scc_control_libraries_instance", "instance_id"),
+					resource.TestCheckResourceAttrSet("data.ibm_scc_control_libraries.scc_control_libraries_instance", "control_libraries.#"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccIbmSccControlLibrariesDataSourceAllArgs(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { acc.TestAccPreCheckScc(t) },
+		Providers: acc.TestAccProviders,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccCheckIbmSccControlLibrariesDataSourceConfigAllArgs(acc.SccInstanceID),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet("data.ibm_scc_control_libraries.scc_control_libraries_instance", "instance_id"),
+					resource.TestCheckResourceAttrSet("data.ibm_scc_control_libraries.scc_control_libraries_instance", "control_libraries.#"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckIbmSccControlLibrariesDataSourceConfigBasic(instanceID string) string {
+	return fmt.Sprintf(`
+		data "ibm_scc_control_libraries" "scc_control_libraries_instance" {
+			instance_id = "%s"
+		}
+	`, instanceID)
+}
+
+func testAccCheckIbmSccControlLibrariesDataSourceConfigAllArgs(instanceID string) string {
+	return fmt.Sprintf(`
+		data "ibm_scc_control_libraries" "scc_control_libraries_instance" {
+      control_library_type = "predefined"
+			instance_id = "%s"
+		}
+	`, instanceID)
+}

--- a/ibm/service/scc/data_source_ibm_scc_profiles.go
+++ b/ibm/service/scc/data_source_ibm_scc_profiles.go
@@ -33,7 +33,7 @@ func DataSourceIbmSccProfiles() *schema.Resource {
 					Schema: map[string]*schema.Schema{
 						"id": {
 							Type:        schema.TypeString,
-							Required:    true,
+							Computed:    true,
 							Description: "The profile ID.",
 						},
 						"profile_name": {

--- a/ibm/service/scc/data_source_ibm_scc_profiles.go
+++ b/ibm/service/scc/data_source_ibm_scc_profiles.go
@@ -1,0 +1,197 @@
+// Copyright IBM Corp. 2023 All Rights Reserved.
+// Licensed under the Mozilla Public License v2.0
+
+package scc
+
+import (
+	"context"
+	"fmt"
+	"log"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/conns"
+	"github.com/IBM/scc-go-sdk/v5/securityandcompliancecenterapiv3"
+)
+
+func DataSourceIbmSccProfiles() *schema.Resource {
+	return AddSchemaData(&schema.Resource{
+		ReadContext: dataSourceIbmSccProfilesRead,
+
+		Schema: map[string]*schema.Schema{
+			"profile_type": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"profiles": &schema.Schema{
+				Type:        schema.TypeList,
+				Computed:    true,
+				Description: "The list of profiles found.",
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"id": {
+							Type:        schema.TypeString,
+							Required:    true,
+							Description: "The profile ID.",
+						},
+						"profile_name": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "The profile name.",
+						},
+						"profile_description": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "The profile description.",
+						},
+						"profile_type": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "The profile type, such as custom or predefined.",
+						},
+						"profile_version": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "The version status of the profile.",
+						},
+						"version_group_label": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "The version group label of the profile.",
+						},
+						"latest": {
+							Type:        schema.TypeBool,
+							Computed:    true,
+							Description: "The latest version of the profile.",
+						},
+						"hierarchy_enabled": {
+							Type:        schema.TypeBool,
+							Computed:    true,
+							Description: "The indication of whether hierarchy is enabled for the profile.",
+						},
+						"created_by": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "The user who created the profile.",
+						},
+						"created_on": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "The date when the profile was created.",
+						},
+						"updated_by": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "The user who updated the profile.",
+						},
+						"updated_on": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "The date when the profile was updated.",
+						},
+						"controls_count": {
+							Type:        schema.TypeInt,
+							Computed:    true,
+							Description: "The number of controls for the profile.",
+						},
+						"control_parents_count": {
+							Type:        schema.TypeInt,
+							Computed:    true,
+							Description: "The number of parent controls for the profile.",
+						},
+						"attachments_count": {
+							Type:        schema.TypeInt,
+							Computed:    true,
+							Description: "The number of attachments related to this profile.",
+						},
+					},
+				},
+			},
+		},
+	})
+}
+
+func dataSourceIbmSccProfilesRead(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	securityandcompliancecenterapiClient, err := meta.(conns.ClientSession).SecurityAndComplianceCenterV3()
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	listProfilesOptions := &securityandcompliancecenterapiv3.ListProfilesOptions{}
+	listProfilesOptions.SetInstanceID(d.Get("instance_id").(string))
+	if val, ok := d.GetOk("profile_type"); ok && val != nil {
+		listProfilesOptions.SetProfileType(d.Get("profile_type").(string))
+	}
+
+	pager, err := securityandcompliancecenterapiClient.NewProfilesPager(listProfilesOptions)
+	if err != nil {
+		log.Printf("[DEBUG] ListProfilesWithContext failed %s", err)
+		return diag.FromErr(fmt.Errorf("ListProfilesWithContext failed %s", err))
+	}
+	profileList, err := pager.GetAll()
+	if err != nil {
+		log.Printf("[DEBUG] ListProfilesWithContext failed %s", err)
+		return diag.FromErr(fmt.Errorf("ListProfilesWithContext failed %s", err))
+	}
+	d.SetId(fmt.Sprintf("%s/profiles", d.Get("instance_id").(string)))
+	if err = d.Set("instance_id", d.Get("instance_id")); err != nil {
+		return diag.FromErr(fmt.Errorf("Error setting instance_id %s", err))
+	}
+	profiles := []map[string]interface{}{}
+	for _, profile := range profileList {
+		modelMap, err := dataSourceIbmSccProfileToMap(&profile)
+		if err != nil {
+			return diag.FromErr(fmt.Errorf("Error setting profile:%v\n%s", profile, err))
+		}
+		profiles = append(profiles, modelMap)
+	}
+	if err = d.Set("profiles", profiles); err != nil {
+		return diag.FromErr(fmt.Errorf("Error setting profiles %s", err))
+	}
+	return nil
+}
+
+func dataSourceIbmSccProfileToMap(profile *securityandcompliancecenterapiv3.ProfileItem) (map[string]interface{}, error) {
+	modelMap := make(map[string]interface{})
+	if profile.ID != nil {
+		modelMap["id"] = profile.ID
+	}
+	if profile.ProfileName != nil {
+		modelMap["profile_name"] = profile.ProfileName
+	}
+	if profile.ProfileDescription != nil {
+		modelMap["profile_description"] = profile.ProfileDescription
+	}
+	if profile.ProfileType != nil {
+		modelMap["profile_type"] = profile.ProfileType
+	}
+	if profile.ProfileVersion != nil {
+		modelMap["profile_version"] = profile.ProfileVersion
+	}
+	if profile.VersionGroupLabel != nil {
+		modelMap["version_group_label"] = profile.VersionGroupLabel
+	}
+	if profile.Latest != nil {
+		modelMap["latest"] = profile.Latest
+	}
+	if profile.CreatedBy != nil {
+		modelMap["created_by"] = profile.CreatedBy
+	}
+	if profile.CreatedOn != nil {
+		modelMap["created_on"] = profile.CreatedOn.String()
+	}
+	if profile.UpdatedBy != nil {
+		modelMap["updated_by"] = profile.UpdatedBy
+	}
+	if profile.UpdatedOn != nil {
+		modelMap["updated_on"] = profile.UpdatedOn.String()
+	}
+	if profile.ControlsCount != nil {
+		modelMap["controls_count"] = profile.ControlsCount
+	}
+	if profile.AttachmentsCount != nil {
+		modelMap["attachments_count"] = profile.AttachmentsCount
+	}
+	return modelMap, nil
+}

--- a/ibm/service/scc/data_source_ibm_scc_profiles.go
+++ b/ibm/service/scc/data_source_ibm_scc_profiles.go
@@ -12,6 +12,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 
 	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/conns"
+	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/validate"
 	"github.com/IBM/scc-go-sdk/v5/securityandcompliancecenterapiv3"
 )
 
@@ -46,9 +47,10 @@ func DataSourceIbmSccProfiles() *schema.Resource {
 							Description: "The profile description.",
 						},
 						"profile_type": {
-							Type:        schema.TypeString,
-							Computed:    true,
-							Description: "The profile type, such as custom or predefined.",
+							Type:         schema.TypeString,
+							Computed:     true,
+							ValidateFunc: validate.InvokeValidator("ibm_scc_profile", "profile_type"),
+							Description:  "The profile type, such as custom or predefined.",
 						},
 						"profile_version": {
 							Type:        schema.TypeString,

--- a/ibm/service/scc/data_source_ibm_scc_profiles.go
+++ b/ibm/service/scc/data_source_ibm_scc_profiles.go
@@ -147,7 +147,7 @@ func dataSourceIbmSccProfilesRead(context context.Context, d *schema.ResourceDat
 		profiles = append(profiles, modelMap)
 	}
 	if err = d.Set("profiles", profiles); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting profiles %s", err))
+		return diag.FromErr(fmt.Errorf("Error setting profiles: %s", err))
 	}
 	return nil
 }

--- a/ibm/service/scc/data_source_ibm_scc_profiles_test.go
+++ b/ibm/service/scc/data_source_ibm_scc_profiles_test.go
@@ -1,0 +1,34 @@
+package scc_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	acc "github.com/IBM-Cloud/terraform-provider-ibm/ibm/acctest"
+)
+
+func TestAccIbmSccProfilesDataSourceBasic(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { acc.TestAccPreCheckScc(t) },
+		Providers: acc.TestAccProviders,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccCheckIbmSccProfilesDataSourceConfigBasic(acc.SccInstanceID),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet("data.ibm_scc_profiles.scc_profiles_instance", "instance_id"),
+					resource.TestCheckResourceAttrSet("data.ibm_scc_profiles.scc_profiles_instance", "profiles.#"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckIbmSccProfilesDataSourceConfigBasic(instanceID string) string {
+	return fmt.Sprintf(`
+		data "ibm_scc_profiles" "scc_profiles_instance" {
+			instance_id = "%s"
+		}
+	`, instanceID)
+}

--- a/ibm/service/scc/data_source_ibm_scc_profiles_test.go
+++ b/ibm/service/scc/data_source_ibm_scc_profiles_test.go
@@ -25,10 +25,35 @@ func TestAccIbmSccProfilesDataSourceBasic(t *testing.T) {
 	})
 }
 
+func TestAccIbmSccProfilesDataSourceAllArgs(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { acc.TestAccPreCheckScc(t) },
+		Providers: acc.TestAccProviders,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccCheckIbmSccProfilesDataSourceConfigAllArgs(acc.SccInstanceID),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet("data.ibm_scc_profiles.scc_profiles_instance", "instance_id"),
+					resource.TestCheckResourceAttrSet("data.ibm_scc_profiles.scc_profiles_instance", "profiles.#"),
+				),
+			},
+		},
+	})
+}
+
 func testAccCheckIbmSccProfilesDataSourceConfigBasic(instanceID string) string {
 	return fmt.Sprintf(`
 		data "ibm_scc_profiles" "scc_profiles_instance" {
 			instance_id = "%s"
+		}
+	`, instanceID)
+}
+
+func testAccCheckIbmSccProfilesDataSourceConfigAllArgs(instanceID string) string {
+	return fmt.Sprintf(`
+		data "ibm_scc_profiles" "scc_profiles_instance" {
+			instance_id = "%s"
+      profile_type = "predefined"
 		}
 	`, instanceID)
 }

--- a/ibm/service/scc/data_source_ibm_scc_profiles_test.go
+++ b/ibm/service/scc/data_source_ibm_scc_profiles_test.go
@@ -19,6 +19,8 @@ func TestAccIbmSccProfilesDataSourceBasic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrSet("data.ibm_scc_profiles.scc_profiles_instance", "instance_id"),
 					resource.TestCheckResourceAttrSet("data.ibm_scc_profiles.scc_profiles_instance", "profiles.#"),
+					resource.TestCheckResourceAttrSet("data.ibm_scc_profiles.scc_profiles_instance", "profiles.0.id"),
+					resource.TestCheckResourceAttrSet("data.ibm_scc_profiles.scc_profiles_instance", "profiles.0.profile_name"),
 				),
 			},
 		},
@@ -35,6 +37,8 @@ func TestAccIbmSccProfilesDataSourceAllArgs(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrSet("data.ibm_scc_profiles.scc_profiles_instance", "instance_id"),
 					resource.TestCheckResourceAttrSet("data.ibm_scc_profiles.scc_profiles_instance", "profiles.#"),
+					resource.TestCheckResourceAttrSet("data.ibm_scc_profiles.scc_profiles_instance", "profiles.0.id"),
+					resource.TestCheckResourceAttrSet("data.ibm_scc_profiles.scc_profiles_instance", "profiles.0.profile_name"),
 				),
 			},
 		},

--- a/ibm/service/scc/data_source_ibm_scc_provider_type.go
+++ b/ibm/service/scc/data_source_ibm_scc_provider_type.go
@@ -214,10 +214,3 @@ func dataSourceIbmSccProviderTypeLabelTypeToMap(model *securityandcompliancecent
 	}
 	return modelMap, nil
 }
-
-func dataSourceIbmSccProviderTypeAdditionalPropertyToMap(model *securityandcompliancecenterapiv3.AdditionalProperty) (map[string]interface{}, error) {
-	modelMap := make(map[string]interface{})
-	modelMap["type"] = model.Type
-	modelMap["display_name"] = model.DisplayName
-	return modelMap, nil
-}

--- a/ibm/service/scc/data_source_ibm_scc_provider_types.go
+++ b/ibm/service/scc/data_source_ibm_scc_provider_types.go
@@ -1,0 +1,208 @@
+// Copyright IBM Corp. 2023 All Rights Reserved.
+// Licensed under the Mozilla Public License v2.0
+
+package scc
+
+import (
+	"context"
+	"fmt"
+	"log"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/conns"
+	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/flex"
+	"github.com/IBM/scc-go-sdk/v5/securityandcompliancecenterapiv3"
+)
+
+func DataSourceIbmSccProviderTypes() *schema.Resource {
+	return AddSchemaData(&schema.Resource{
+		ReadContext: dataSourceIbmSccProviderTypesRead,
+
+		Schema: map[string]*schema.Schema{
+			"provider_types": &schema.Schema{
+				Type:        schema.TypeList,
+				Computed:    true,
+				Description: "The list of provider_types found.",
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"id": &schema.Schema{
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "The unique identifier of the provider type.",
+						},
+						"type": &schema.Schema{
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "The type of the provider type.",
+						},
+						"name": &schema.Schema{
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "The name of the provider type.",
+						},
+						"description": &schema.Schema{
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "The provider type description.",
+						},
+						"s2s_enabled": &schema.Schema{
+							Type:        schema.TypeBool,
+							Computed:    true,
+							Description: "A boolean that indicates whether the provider type is s2s-enabled.",
+						},
+						"instance_limit": &schema.Schema{
+							Type:        schema.TypeInt,
+							Computed:    true,
+							Description: "The maximum number of instances that can be created for the provider type.",
+						},
+						"mode": &schema.Schema{
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "The mode that is used to get results from provider (`PUSH` or `PULL`).",
+						},
+						"data_type": &schema.Schema{
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "The format of the results that a provider supports.",
+						},
+						"label": &schema.Schema{
+							Type:        schema.TypeList,
+							Computed:    true,
+							Description: "The label that is associated with the provider type.",
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"text": &schema.Schema{
+										Type:        schema.TypeString,
+										Computed:    true,
+										Description: "The text of the label.",
+									},
+									"tip": &schema.Schema{
+										Type:        schema.TypeString,
+										Computed:    true,
+										Description: "The text to be shown when user hover overs the label.",
+									},
+								},
+							},
+						},
+						"attributes": &schema.Schema{
+							Type:        schema.TypeMap,
+							Computed:    true,
+							Description: "The attributes that are required when you're creating an instance of a provider type. The attributes field can have multiple  keys in its value. Each of those keys has a value  object that includes the type, and display name as keys. For example, `{type:\"\", display_name:\"\"}`. **NOTE;** If the provider type is s2s-enabled, which means that if the `s2s_enabled` field is set to `true`, then a CRN field of type text is required in the attributes value object.",
+							Elem: &schema.Schema{
+								Type: schema.TypeString,
+							},
+						},
+						"created_at": &schema.Schema{
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "Time at which resource was created.",
+						},
+						"updated_at": &schema.Schema{
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "Time at which resource was updated.",
+						},
+					},
+				},
+			},
+		},
+	})
+}
+
+func dataSourceIbmSccProviderTypesRead(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	securityAndComplianceCenterApIsClient, err := meta.(conns.ClientSession).SecurityAndComplianceCenterV3()
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	listProviderTypesByIdOptions := &securityandcompliancecenterapiv3.ListProviderTypesOptions{}
+
+	listProviderTypesByIdOptions.SetInstanceID(d.Get("instance_id").(string))
+
+	providerTypeItems, response, err := securityAndComplianceCenterApIsClient.ListProviderTypesWithContext(context, listProviderTypesByIdOptions)
+	if err != nil {
+		log.Printf("[DEBUG] GetProviderTypeByIDWithContext failed %s\n%s", err, response)
+		return diag.FromErr(fmt.Errorf("GetProviderTypeByIDWithContext failed %s\n%s", err, response))
+	}
+
+	d.SetId(fmt.Sprintf("%s/provider_types", d.Get("instance_id").(string)))
+
+	providerTypes := []map[string]interface{}{}
+	for _, providerType := range providerTypeItems.ProviderTypes {
+		modelMap, err := dataSourceIbmSccProviderToMap(&providerType)
+		if err != nil {
+			return diag.FromErr(fmt.Errorf("Error setting provider_type: %v\n%s", providerType, err))
+		}
+		providerTypes = append(providerTypes, modelMap)
+	}
+	if err = d.Set("provider_types", providerTypes); err != nil {
+		return diag.FromErr(fmt.Errorf("Error setting provider_types: %s", err))
+	}
+
+	return nil
+}
+
+func dataSourceIbmSccProviderToMap(model *securityandcompliancecenterapiv3.ProviderTypeItem) (map[string]interface{}, error) {
+	modelMap := make(map[string]interface{})
+	if model.ID != nil {
+		modelMap["id"] = model.ID
+	}
+
+	if model.Type != nil {
+		modelMap["type"] = model.Type
+	}
+
+	if model.Name != nil {
+		modelMap["name"] = model.Name
+	}
+
+	if model.Description != nil {
+		modelMap["description"] = model.Description
+	}
+
+	if model.S2sEnabled != nil {
+		modelMap["s2s_enabled"] = model.S2sEnabled
+	}
+
+	if model.InstanceLimit != nil {
+		modelMap["instance_limit"] = model.InstanceLimit
+	}
+
+	if model.Mode != nil {
+		modelMap["mode"] = model.Mode
+	}
+
+	if model.DataType != nil {
+		modelMap["data_type"] = model.DataType
+	}
+
+	if model.Attributes != nil {
+		convertedMap := make(map[string]interface{}, len(model.Attributes))
+		for k, v := range model.Attributes {
+			convertedMap[k] = v
+		}
+		modelMap["attributes"] = flex.Flatten(convertedMap)
+	}
+
+	if model.Label != nil {
+		labelList := []map[string]interface{}{}
+		convertedMap, err := dataSourceIbmSccProviderTypeLabelTypeToMap(model.Label)
+		if err != nil {
+			return modelMap, err
+		}
+		labelList = append(labelList, convertedMap)
+		modelMap["label"] = labelList
+	}
+
+	if model.CreatedAt != nil {
+		modelMap["created_at"] = flex.DateTimeToString(model.CreatedAt)
+	}
+
+	if model.UpdatedAt != nil {
+		modelMap["updated_at"] = flex.DateTimeToString(model.UpdatedAt)
+	}
+
+	return modelMap, nil
+}

--- a/ibm/service/scc/data_source_ibm_scc_provider_types_test.go
+++ b/ibm/service/scc/data_source_ibm_scc_provider_types_test.go
@@ -19,6 +19,8 @@ func TestAccIbmSccProviderTypesDataSourceBasic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrSet("data.ibm_scc_provider_types.scc_provider_types_instance", "instance_id"),
 					resource.TestCheckResourceAttrSet("data.ibm_scc_provider_types.scc_provider_types_instance", "provider_types.#"),
+					resource.TestCheckResourceAttrSet("data.ibm_scc_provider_types.scc_provider_types_instance", "provider_types.0.name"),
+					resource.TestCheckResourceAttrSet("data.ibm_scc_provider_types.scc_provider_types_instance", "provider_types.0.id"),
 				),
 			},
 		},

--- a/ibm/service/scc/data_source_ibm_scc_provider_types_test.go
+++ b/ibm/service/scc/data_source_ibm_scc_provider_types_test.go
@@ -1,0 +1,34 @@
+package scc_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	acc "github.com/IBM-Cloud/terraform-provider-ibm/ibm/acctest"
+)
+
+func TestAccIbmSccProviderTypesDataSourceBasic(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { acc.TestAccPreCheckScc(t) },
+		Providers: acc.TestAccProviders,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccCheckIbmSccProviderTypesDataSourceConfigBasic(acc.SccInstanceID),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet("data.ibm_scc_provider_types.scc_provider_types_instance", "instance_id"),
+					resource.TestCheckResourceAttrSet("data.ibm_scc_provider_types.scc_provider_types_instance", "provider_types.#"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckIbmSccProviderTypesDataSourceConfigBasic(instanceID string) string {
+	return fmt.Sprintf(`
+		data "ibm_scc_provider_types" "scc_provider_types_instance" {
+			instance_id = "%s"
+		}
+	`, instanceID)
+}

--- a/ibm/service/scc/resource_ibm_scc_control_library.go
+++ b/ibm/service/scc/resource_ibm_scc_control_library.go
@@ -154,6 +154,7 @@ func ResourceIbmSccControlLibrary() *schema.Resource {
 										Computed:    true,
 										Description: "The number of assessments.",
 									},
+
 									"assessments": {
 										Type:        schema.TypeSet,
 										Optional:    true,
@@ -210,6 +211,13 @@ func ResourceIbmSccControlLibrary() *schema.Resource {
 													},
 												},
 											},
+										},
+									},
+									"assessments_map": {
+										Type:     schema.TypeMap,
+										Computed: true,
+										Elem: &schema.Schema{
+											Type: schema.TypeString,
 										},
 									},
 								},
@@ -924,8 +932,6 @@ func resourceIbmSccControlLibraryControlSpecificationsToMap(model *securityandco
 		}
 		assessmentsList := schema.NewSet(compareAssessmentSetFunc, assessments)
 		modelMap["assessments"] = assessmentsList
-
-		// modelMap["assessments"] = assessments
 	}
 	return modelMap, nil
 }

--- a/ibm/service/scc/resource_ibm_scc_control_library.go
+++ b/ibm/service/scc/resource_ibm_scc_control_library.go
@@ -889,12 +889,18 @@ func resourceIbmSccControlLibraryControlsInControlLibToMap(model *securityandcom
 
 // using the assessment_id for comparison
 func compareAssessmentSetFunc(v interface{}) int {
+	if v == nil {
+		return 0
+	}
 	m := v.(map[string]interface{})
 	id := (m["assessment_id"]).(*string)
 	assId := (*id)[5:18]
 	var i big.Int
 	i.SetString(strings.Replace(assId, "-", "", 4), 16)
-	val, _ := strconv.Atoi(i.String())
+	val, err := strconv.Atoi(i.String())
+	if err != nil {
+		log.Printf("[ERROR] Setting the Assessments for Control Library failed %s\n", err)
+	}
 	return val
 }
 

--- a/ibm/service/scc/resource_ibm_scc_control_library.go
+++ b/ibm/service/scc/resource_ibm_scc_control_library.go
@@ -163,7 +163,7 @@ func ResourceIbmSccControlLibrary() *schema.Resource {
 											Schema: map[string]*schema.Schema{
 												"assessment_id": {
 													Type:        schema.TypeString,
-													Optional:    true,
+													Required:    true,
 													Description: "The assessment ID.",
 												},
 												"assessment_method": {

--- a/ibm/service/scc/resource_ibm_scc_control_library_test.go
+++ b/ibm/service/scc/resource_ibm_scc_control_library_test.go
@@ -58,7 +58,7 @@ func TestAccIbmSccControlLibraryAllArgs(t *testing.T) {
 	controlLibraryDescription := fmt.Sprintf("tf_control_library_description_%d", acctest.RandIntRange(10, 100))
 	controlLibraryType := "custom"
 	versionGroupLabel := "11111111-2222-3333-4444-555555555555"
-	controlLibraryVersion := "0.0.1"
+	controlLibraryVersion := "0.0.0"
 	latest := "true"
 	controlsCount := "1"
 
@@ -66,7 +66,7 @@ func TestAccIbmSccControlLibraryAllArgs(t *testing.T) {
 	controlLibraryDescriptionUpdate := controlLibraryDescription
 	controlLibraryTypeUpdate := "custom"
 	versionGroupLabelUpdate := versionGroupLabel
-	controlLibraryVersionUpdate := "0.0.2"
+	controlLibraryVersionUpdate := "0.0.1"
 	latestUpdate := "true"
 
 	resource.Test(t, resource.TestCase{
@@ -75,7 +75,7 @@ func TestAccIbmSccControlLibraryAllArgs(t *testing.T) {
 		CheckDestroy: testAccCheckIbmSccControlLibraryDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
-				Config: testAccCheckIbmSccControlLibraryConfig(acc.SccInstanceID, controlLibraryName, controlLibraryDescription, controlLibraryType, versionGroupLabel, controlLibraryVersion, latest),
+				Config: testAccCheckIbmSccControlLibraryConfigBasic(acc.SccInstanceID, controlLibraryName, controlLibraryDescription, controlLibraryType),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckIbmSccControlLibraryExists("ibm_scc_control_library.scc_control_library_instance", conf),
 					resource.TestCheckResourceAttr("ibm_scc_control_library.scc_control_library_instance", "control_library_name", controlLibraryName),
@@ -115,7 +115,7 @@ func testAccCheckIbmSccControlLibraryConfigBasic(instanceID string, controlLibra
 			control_library_name = "%s"
 			control_library_description = "%s"
 			control_library_type = "%s"
-			version_group_label = "03354ab4-03be-41c0-a469-826fc0262e78"
+			version_group_label = "11111111-2222-3333-4444-555555555555"
 			latest = true
 			controls {
 				control_name = "control-name"
@@ -134,12 +134,18 @@ func testAccCheckIbmSccControlLibraryConfigBasic(instanceID string, controlLibra
 						assessment_id = "rule-a637949b-7e51-46c4-afd4-b96619001bf1"
 						assessment_method = "ibm-cloud-rule"
 						assessment_type = "automated"
-						assessment_description = "assessment_description"
+						assessment_description = "test 1"
 						parameters {
 							parameter_display_name = "Sign out due to inactivity in seconds"
-                            parameter_name         = "session_invalidation_in_seconds"
-							parameter_type = "numeric"
+              				parameter_name         = "session_invalidation_in_seconds"
+							parameter_type         = "numeric"
 						}
+					}
+					assessments {
+						assessment_id = "rule-f88e215f-bb33-4bd8-bd1c-d8a065e9aa70"
+						assessment_method = "ibm-cloud-rule"
+						assessment_type = "automated"
+						assessment_description = "test 2"
 					}
 				}
 				control_docs {
@@ -178,14 +184,20 @@ func testAccCheckIbmSccControlLibraryConfig(instanceID string, controlLibraryNam
 					environment = "environment"
 					control_specification_description = "control_specification_description"
 					assessments {
+						assessment_id = "rule-f88e215f-bb33-4bd8-bd1c-d8a065e9aa70"
+						assessment_method = "ibm-cloud-rule"
+						assessment_type = "automated"
+						assessment_description = "test 2"
+					}
+					assessments {
 						assessment_id = "rule-a637949b-7e51-46c4-afd4-b96619001bf1"
 						assessment_method = "ibm-cloud-rule"
 						assessment_type = "automated"
-						assessment_description = "assessment_description"
+						assessment_description = "test 1"
 						parameters {
-							parameter_display_name = "Sign out due to inactivity in seconds"
-                            parameter_name         = "session_invalidation_in_seconds"
-							parameter_type = "numeric"
+							parameter_display_name  = "Sign out due to inactivity in seconds"
+              				parameter_name          = "session_invalidation_in_seconds"
+							parameter_type          = "numeric"
 						}
 					}
 				}

--- a/ibm/service/scc/resource_ibm_scc_profile_attachment.go
+++ b/ibm/service/scc/resource_ibm_scc_profile_attachment.go
@@ -325,12 +325,18 @@ func resourceIbmSccProfileAttachmentCreate(context context.Context, d *schema.Re
 }
 
 func cmpAttachParamSetFunc(v interface{}) int {
+	if v == nil {
+		return 0
+	}
 	m := v.(map[string]interface{})
 	id := (m["assessment_id"]).(*string)
 	assId := (*id)[5:18]
 	var i big.Int
 	i.SetString(strings.Replace(assId, "-", "", 4), 16)
-	val, _ := strconv.Atoi(i.String())
+	val, err := strconv.Atoi(i.String())
+	if err != nil {
+		log.Printf("[ERROR] Setting the Parameters of the Profile Attachment failed %s\n", err)
+	}
 	return val
 }
 

--- a/ibm/service/scc/resource_ibm_scc_profile_attachment.go
+++ b/ibm/service/scc/resource_ibm_scc_profile_attachment.go
@@ -7,6 +7,9 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"math/big"
+	"strconv"
+	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -162,7 +165,7 @@ func ResourceIbmSccProfileAttachment() *schema.Resource {
 				},
 			},
 			"attachment_parameters": {
-				Type:        schema.TypeList,
+				Type:        schema.TypeSet,
 				Optional:    true,
 				Description: "The profile parameters for the attachment.",
 				Elem: &schema.Resource{
@@ -321,6 +324,16 @@ func resourceIbmSccProfileAttachmentCreate(context context.Context, d *schema.Re
 	return resourceIbmSccProfileAttachmentRead(context, d, meta)
 }
 
+func cmpAttachParamSetFunc(v interface{}) int {
+	m := v.(map[string]interface{})
+	id := (m["assessment_id"]).(*string)
+	assId := (*id)[5:18]
+	var i big.Int
+	i.SetString(strings.Replace(assId, "-", "", 4), 16)
+	val, _ := strconv.Atoi(i.String())
+	return val
+}
+
 func resourceIbmSccProfileAttachmentRead(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	securityandcompliancecenterapiClient, err := meta.(conns.ClientSession).SecurityAndComplianceCenterV3()
 	if err != nil {
@@ -419,14 +432,15 @@ func resourceIbmSccProfileAttachmentRead(context context.Context, d *schema.Reso
 		}
 	}
 	if !core.IsNil(attachmentItem.AttachmentParameters) {
-		attachmentParameters := []map[string]interface{}{}
+		attachmentParametersList := []interface{}{}
 		for _, attachmentParametersItem := range attachmentItem.AttachmentParameters {
 			attachmentParametersItemMap, err := resourceIbmSccProfileAttachmentAttachmentParameterPrototypeToMap(&attachmentParametersItem)
 			if err != nil {
 				return diag.FromErr(err)
 			}
-			attachmentParameters = append(attachmentParameters, attachmentParametersItemMap)
+			attachmentParametersList = append(attachmentParametersList, attachmentParametersItemMap)
 		}
+		attachmentParameters := schema.NewSet(cmpAttachParamSetFunc, attachmentParametersList)
 		if err = d.Set("attachment_parameters", attachmentParameters); err != nil {
 			return diag.FromErr(fmt.Errorf("Error setting attachment_parameters: %s", err))
 		}

--- a/ibm/service/scc/resource_ibm_scc_profile_attachment.go
+++ b/ibm/service/scc/resource_ibm_scc_profile_attachment.go
@@ -177,7 +177,7 @@ func ResourceIbmSccProfileAttachment() *schema.Resource {
 						},
 						"assessment_id": {
 							Type:        schema.TypeString,
-							Optional:    true,
+							Required:    true,
 							Description: "The implementation ID of the parameter.",
 						},
 						"parameter_name": {

--- a/ibm/service/scc/resource_ibm_scc_profile_attachment_test.go
+++ b/ibm/service/scc/resource_ibm_scc_profile_attachment_test.go
@@ -90,8 +90,8 @@ func testAccCheckIbmSccProfileAttachmentConfigBasic(instanceID string) string {
 						assessment_description = "assessment_description"
 						parameters {
 							parameter_display_name = "Sign out due to inactivity in seconds"
-                            parameter_name         = "session_invalidation_in_seconds"
-							parameter_type = "numeric"
+							parameter_name         = "session_invalidation_in_seconds"
+							parameter_type         = "numeric"
 						}
 					}
 				}

--- a/ibm/service/scc/resource_ibm_scc_profile_test.go
+++ b/ibm/service/scc/resource_ibm_scc_profile_test.go
@@ -207,11 +207,11 @@ func testAccCheckIbmSccProfileConfig(instanceID string, profileName string, prof
 			}
 			default_parameters {
 				assessment_type = "automated"
-				assessment_id = {for k,v in resource.ibm_scc_control_library.scc_control_library_instance.controls[0].control_specifications[0].assessments: k => v if v.assessment_id == "rule-a637949b-7e51-46c4-afd4-b96619001bf1"}[0].assessment_id
+				assessment_id = "rule-a637949b-7e51-46c4-afd4-b96619001bf1"
 				parameter_name = "session_invalidation_in_seconds"
 				parameter_type = "numeric"
 				parameter_default_value = "9"
-				parameter_display_name = {for k,v in resource.ibm_scc_control_library.scc_control_library_instance.controls[0].control_specifications[0].assessments: k => v if v.assessment_id == "rule-a637949b-7e51-46c4-afd4-b96619001bf1"}[0].parameters[0].parameter_display_name
+				parameter_display_name = "Sign out due to inactivity in seconds"
 			}
 		}
 

--- a/ibm/service/scc/resource_ibm_scc_profile_test.go
+++ b/ibm/service/scc/resource_ibm_scc_profile_test.go
@@ -194,7 +194,7 @@ func testAccCheckIbmSccProfileConfig(instanceID string, profileName string, prof
 				status = "enabled"
 			}
 		}
-
+		
 		resource "ibm_scc_profile" "scc_profile_instance" {
 			instance_id = resource.ibm_scc_control_library.scc_control_library_instance.instance_id
 			profile_name = "%s"
@@ -207,11 +207,11 @@ func testAccCheckIbmSccProfileConfig(instanceID string, profileName string, prof
 			}
 			default_parameters {
 				assessment_type = "automated"
-				assessment_id = resource.ibm_scc_control_library.scc_control_library_instance.controls[0].control_specifications[0].assessments[0].assessment_id
+				assessment_id = {for k,v in resource.ibm_scc_control_library.scc_control_library_instance.controls[0].control_specifications[0].assessments: k => v if v.assessment_id == "rule-a637949b-7e51-46c4-afd4-b96619001bf1"}[0].assessment_id
 				parameter_name = "session_invalidation_in_seconds"
 				parameter_type = "numeric"
 				parameter_default_value = "9"
-				parameter_display_name = resource.ibm_scc_control_library.scc_control_library_instance.controls[0].control_specifications[0].assessments[0].parameters[0].parameter_display_name
+				parameter_display_name = {for k,v in resource.ibm_scc_control_library.scc_control_library_instance.controls[0].control_specifications[0].assessments: k => v if v.assessment_id == "rule-a637949b-7e51-46c4-afd4-b96619001bf1"}[0].parameters[0].parameter_display_name
 			}
 		}
 

--- a/website/docs/d/scc_control_libraries.html.markdown
+++ b/website/docs/d/scc_control_libraries.html.markdown
@@ -1,0 +1,49 @@
+---
+layout: "ibm"
+page_title: "IBM : ibm_scc_control_libraries"
+description: |-
+  Get information about scc_control_libraries
+subcategory: "Security and Compliance Center"
+---
+
+# ibm_scc_control_library
+
+Retrieve information about a list of scc_control_libraries from a read-only data source. Then, you can reference the fields of the data source in other resources within the same configuration by using interpolation syntax.
+
+~> NOTE: if you specify the `region` in the provider, that region will become the default URL. Else, exporting the environmental variable IBMCLOUD_SCC_API_ENDPOINT will override any URL(ex. `export IBMCLOUD_SCC_API_ENDPOINT=https://us-south.compliance.cloud.ibm.com`).
+
+## Example Usage
+
+```hcl
+data "ibm_scc_control_libraries" "scc_control_libraries" {
+    instance_id = "00000000-1111-2222-3333-444444444444"
+}
+```
+
+## Argument Reference
+
+You can specify the following arguments for this data source.
+
+* `control_library_type` - (Optional, Forces new resource, String) The type of control library to query.
+  * Constraints: Allowable values are: `predefined`, `custom`.
+* `instance_id` - (Required, Forces new resource, String) The ID of the SCC instance in a particular region.
+
+## Attribute Reference
+
+After your data source is created, you can read values from the following attributes.
+
+* `control_libraries` - (List) The list of control libraries.
+
+    Nested schema for **control_libraries**:
+    * `id` - (String) The unique identifier of the scc_control_library.
+    * `account_id` - (String) The account ID.
+    * `control_library_description` - (String) The control library description.
+    * `control_library_name` - (String) The control library name.
+    * `control_library_type` - (String) The control library type.
+    * `control_library_version` - (String) The control library version.
+    * `control_count` - (Integer) The number of controls in the control library.
+    * `created_by` - (String) The user who created the control library.
+    * `created_on` - (String) The date when the control library was created.
+    * `updated_by` - (String) The user who updated the control library.
+    * `updated_on` - (String) The date when the control library was updated.
+    * `version_group_label` - (String) The version group label.

--- a/website/docs/d/scc_control_libraries.html.markdown
+++ b/website/docs/d/scc_control_libraries.html.markdown
@@ -36,14 +36,25 @@ After your data source is created, you can read values from the following attrib
 
     Nested schema for **control_libraries**:
     * `id` - (String) The unique identifier of the scc_control_library.
+
     * `account_id` - (String) The account ID.
+
     * `control_library_description` - (String) The control library description.
+
     * `control_library_name` - (String) The control library name.
+
     * `control_library_type` - (String) The control library type.
+
     * `control_library_version` - (String) The control library version.
+
     * `control_count` - (Integer) The number of controls in the control library.
+
     * `created_by` - (String) The user who created the control library.
+
     * `created_on` - (String) The date when the control library was created.
+
     * `updated_by` - (String) The user who updated the control library.
+
     * `updated_on` - (String) The date when the control library was updated.
+    
     * `version_group_label` - (String) The version group label.

--- a/website/docs/d/scc_instance_settings.html.markdown
+++ b/website/docs/d/scc_instance_settings.html.markdown
@@ -15,7 +15,7 @@ Provides a read-only data source to retrieve information about scc_instance_sett
 ## Example Usage
 
 ```hcl
-resource "ibm_scc_instance_settings" "scc_instance_settings_instance" {
+data "ibm_scc_instance_settings" "scc_instance_settings_instance" {
   instance_id = "00000000-1111-2222-3333-444444444444"
 }
 ```

--- a/website/docs/d/scc_profile.html.markdown
+++ b/website/docs/d/scc_profile.html.markdown
@@ -33,14 +33,14 @@ You can specify the following arguments for this data source.
 
 After your data source is created, you can read values from the following attributes.
 
-* `id` - The unique identifier of the scc_profile.
 * `attachments_count` - (Integer) The number of attachments related to this profile.
 
 * `control_parents_count` - (Integer) The number of parent controls for the profile.
 
 * `controls` - (List) The array of controls that are used to create the profile.
   * Constraints: The maximum length is `600` items. The minimum length is `0` items.
-Nested schema for **controls**:
+	
+	Nested schema for **controls**:
 	* `control_category` - (String) The control category.
 	  * Constraints: The maximum length is `512` characters. The minimum length is `2` characters. The value must match regular expression `/[A-Za-z0-9]+/`.
 	* `control_description` - (String) The control description.
@@ -64,7 +64,8 @@ Nested schema for **controls**:
 	* `control_requirement` - (Boolean) Is this a control that can be automated or manually evaluated.
 	* `control_specifications` - (List) The control specifications.
 	  * Constraints: The maximum length is `400` items. The minimum length is `0` items.
-	Nested schema for **control_specifications**:
+		
+		Nested schema for **control_specifications**:
 		* `assessments` - (List) The assessments.
 		  * Constraints: The maximum length is `10` items. The minimum length is `0` items.
 		Nested schema for **assessments**:
@@ -79,7 +80,8 @@ Nested schema for **controls**:
 			* `parameter_count` - (Integer) The parameter count.
 			* `parameters` - (List) The parameters.
 			  * Constraints: The maximum length is `512` items. The minimum length is `0` items.
-			Nested schema for **parameters**:
+			
+				Nested schema for **parameters**:
 				* `parameter_display_name` - (String) The parameter display name.
 				  * Constraints: The maximum length is `64` characters. The minimum length is `2` characters. The value must match regular expression `/^[a-zA-Z0-9_,'\\s\\-]*$/`.
 				* `parameter_name` - (String) The parameter name.
@@ -110,7 +112,8 @@ Nested schema for **controls**:
 
 * `default_parameters` - (List) The default parameters of the profile.
   * Constraints: The maximum length is `512` items. The minimum length is `0` items.
-Nested schema for **default_parameters**:
+
+	Nested schema for **default_parameters**:
 	* `assessment_id` - (String) The implementation ID of the parameter.
 	  * Constraints: The maximum length is `64` characters. The minimum length is `2` characters. The value must match regular expression `/[A-Za-z0-9]+/`.
 	* `assessment_type` - (String) The type of the implementation.

--- a/website/docs/d/scc_profiles.html.markdown
+++ b/website/docs/d/scc_profiles.html.markdown
@@ -1,0 +1,22 @@
+---
+layout: "ibm"
+page_title: "IBM : ibm_scc_profiles"
+description: |-
+  Get information about scc_profiles
+subcategory: "Security and Compliance Center"
+---
+
+# ibm_scc_profiles
+
+Retrieve information about a list of profiles from a read-only data source. Then, you can reference the fields of the data source in other resources within the same configuration by using interpolation syntax.
+
+~> NOTE: if you specify the `region` in the provider, that region will become the default URL. Else, exporting the environmental variable IBMCLOUD_SCC_API_ENDPOINT will override any URL(ex. `export IBMCLOUD_SCC_API_ENDPOINT=https://us-south.compliance.cloud.ibm.com`).
+
+## Example Usage
+
+```hcl
+data "ibm_scc_profiles" "scc_profiles" {
+    instance_id = "00000000-1111-2222-3333-444444444444"
+    profile_id = ibm_scc_profile.scc_profile_instance.profile_id
+}
+```

--- a/website/docs/d/scc_profiles.html.markdown
+++ b/website/docs/d/scc_profiles.html.markdown
@@ -15,8 +15,59 @@ Retrieve information about a list of profiles from a read-only data source. Then
 ## Example Usage
 
 ```hcl
-data "ibm_scc_profiles" "scc_profiles" {
+data "ibm_scc_profiles" "scc_profiles_instace" {
     instance_id = "00000000-1111-2222-3333-444444444444"
-    profile_id = ibm_scc_profile.scc_profile_instance.profile_id
+    profile_type = ibm_scc_profile.scc_profile_instance.profile_id
 }
 ```
+
+## Argument Reference
+
+You can specify the following arguments for this data source.
+
+* `profile_type` - (Optional, Forces new resource, String) The type of profiles to query.
+  * Constraints: Allowable values are: `predefined`, `custom`.
+* `instance_id` - (Required, Forces new resource, String) The ID of the SCC instance in a particular region.
+
+## Attribute Reference
+
+After your data source is created, you can read values from the following attributes.
+
+* `profiles` - (List) The list of profiles.
+
+    Nested schema for **profiles**:
+    * `id` - The unique identifier of the scc_profile.
+
+    * `attachments_count` - (Integer) The number of attachments related to this profile.
+
+    * `control_parents_count` - (Integer) The number of parent controls for the profile.    
+
+    * `instance_id` - (String) The instance ID.
+
+    * `latest` - (Boolean) The latest version of the profile.
+
+    * `profile_description` - (String) The profile description.
+      * Constraints: The maximum length is `256` characters. The minimum length is `2` characters. The value must match regular expression `/[A-Za-z0-9]+/`.
+
+    * `profile_name` - (String) The profile name.
+
+
+    * `profile_type` - (String) The profile type, such as custom or predefined.
+
+    * `profile_version` - (String) The version status of the profile.
+
+    * `version_group_label` - (String) The version group label of the profile.
+
+    * `latest` - (Boolean) The latest version of the profile.
+
+    * `hierarchy_enabled` - (Boolean) The indication of whether hierarchy is enabled for the profile.
+
+    * `created_by` - (String) The user who created the profile.
+
+    * `created_on` - (String) The date when the profile was created.
+
+    * `controls_count` - (Integer) The number of controls for the profile.
+
+    * `control_parents_count` - (Integer) The number of parent controls for the profile.
+
+    * `attachments_count` - (Integer) The number of attachments related to this profile.

--- a/website/docs/d/scc_provider_types.html.markdown
+++ b/website/docs/d/scc_provider_types.html.markdown
@@ -1,0 +1,66 @@
+---
+layout: "ibm"
+page_title: "IBM : ibm_scc_provider_types"
+description: |-
+  Get information about various scc_provider_types
+subcategory: "Security and Compliance Center"
+---
+
+# ibm_scc_provider_types
+
+Retrieve information about a provider type from a read-only data source. Then, you can reference the fields of the data source in other resources within the same configuration by using interpolation syntax.
+
+~> NOTE: if you specify the `region` in the provider, that region will become the default URL. Else, exporting the environmental variable IBMCLOUD_SCC_API_ENDPOINT will override any URL(ex. `export IBMCLOUD_SCC_API_ENDPOINT=https://us-south.compliance.cloud.ibm.com`).
+
+## Example Usage
+
+```hcl
+data "ibm_scc_provider_types" "scc_provider_types_instance" {
+    instance_id = "00000000-1111-2222-3333-444444444444"
+}
+```
+
+## Argument Reference
+
+You can specify the following arguments for this data source.
+
+* `instance_id` - (Required, Forces new resource, String) The ID of the SCC instance in a particular region.
+
+
+## Attribute Reference
+
+After your data source is created, you can read values from the following attributes.
+
+* `provider_types` - (List) The list of provider_types.
+
+* `id` - The unique identifier of the scc_provider_type.
+
+* `type` - (String) The type of the provider type.
+
+* `name` - (String) The name of the provider type.
+
+* `description` - (String) The provider type description.
+
+* `s2s_enabled` - (Boolean) A boolean that indicates whether the provider type is s2s-enabled.
+  
+  **NOTE;** If the provider type is s2s-enabled, which means that if the `s2s_enabled` field is set to `true`, then a CRN field of type text is required in the attributes value object when creating a `ibm_scc_provider_type_instance`
+
+* `attributes` - (Map) The attributes that are required when you're creating an instance of a provider type. The attributes field can have multiple  keys in its value. Each of those keys has a value  object that includes the type, and display name as keys. For example, `{type:"", display_name:""}`. 
+
+* `created_at` - (String) The time when the resource was created.
+
+* `data_type` - (String) The format of the results that a provider supports.
+
+* `icon` - (String) The icon of a provider in .svg format that is encoded as a base64 string.
+
+* `instance_limit` - (Integer) The maximum number of instances that can be created for the provider type.
+
+* `label` - (List) The label that is associated with the provider type.
+Nested schema for **label**:
+	* `text` - (String) The text of the label.
+	* `tip` - (String) The text to be shown when user hover overs the label.
+
+* `mode` - (String) The mode that is used to get results from provider (`PUSH` or `PULL`).
+
+* `updated_at` - (String) The time when the resource was updated.
+

--- a/website/docs/r/scc_control_library.html.markdown
+++ b/website/docs/r/scc_control_library.html.markdown
@@ -161,19 +161,18 @@ After your resource is created, you can read values from the listed arguments an
 
 You can import the `ibm_scc_control_library` resource by using `id`.
 The `id` property can be formed from `instance_id` and `control_library_id` in the following format:
-
-```
+```bash
 <instance_id>/<control_library_id>
 ```
 * `instance_id`: A string. The instance ID.
 * `control_library_id`: A string. The control library ID.
 
 # Syntax
-```
+```bash
 $ terraform import ibm_scc_control_library.scc_control_library <instance_id>/<control_library_id>
 ```
 
 # Example
-```
+```bash
 $ terraform import ibm_scc_control_library.scc_control_library 00000000-1111-2222-3333-444444444444/f3517159-889e-4781-819a-89d89b747c85
 ```

--- a/website/docs/r/scc_instance_settings.html.markdown
+++ b/website/docs/r/scc_instance_settings.html.markdown
@@ -60,6 +60,11 @@ After your resource is created, you can read values from the listed arguments an
 You can import the `ibm_scc_instance_settings` resource by using `instance_id`. The unique identifier of the scc_instance_settings.
 
 # Syntax
-```
+```bash
 $ terraform import ibm_scc_instance_settings.scc_instance_settings <instance_id>
+```
+
+# Example
+```bash
+$ terraform import ibm_scc_instance_settings.scc_instance_settings 00000000-1111-2222-3333-444444444444
 ```

--- a/website/docs/r/scc_profile.html.markdown
+++ b/website/docs/r/scc_profile.html.markdown
@@ -186,13 +186,20 @@ After your resource is created, you can read values from the listed arguments an
 You can import the `ibm_scc_profile` resource by using `id`.
 The `id` property can be formed from `instance_id` and `profiles_id` in the following format:
 
-```
+```bash
 <instance_id>/<profile_id>
 ```
+
 * `instance_id`: A string. The instance ID.
 * `profile_id`: A string. The profile ID.
 
 # Syntax
-```
+
+```bash
 $ terraform import ibm_scc_profile.scc_profile <instance_id>/<profile_id>
+```
+
+# Example
+```bash
+$ terraform import ibm_scc_profile.scc_profile 00000000-1111-2222-3333-444444444444/00000000-1111-2222-3333-444444444444
 ```

--- a/website/docs/r/scc_profile_attachment.html.markdown
+++ b/website/docs/r/scc_profile_attachment.html.markdown
@@ -96,7 +96,8 @@ After your resource is created, you can read values from the listed arguments an
   * Constraints: The maximum length is `32` characters. The minimum length is `32` characters. The value must match regular expression `/^[a-zA-Z0-9-]*$/`.
 * `attachment_parameters` - (List) The profile parameters for the attachment.
   * Constraints: The maximum length is `512` items. The minimum length is `0` items.
-Nested schema for **attachment_parameters**:
+
+  Nested schema for **attachment_parameters**:
 	* `assessment_id` - (String) The implementation ID of the parameter.
 	  * Constraints: The maximum length is `64` characters. The minimum length is `2` characters. The value must match regular expression `/[A-Za-z0-9]+/`.
 	* `assessment_type` - (String) The type of the implementation.
@@ -117,7 +118,8 @@ Nested schema for **attachment_parameters**:
 * `instance_id` - (String) The instance ID of the account that is associated to the attachment.
   * Constraints: The maximum length is `36` characters. The minimum length is `36` characters. The value must match regular expression `/^[0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-4[0-9A-Fa-f]{3}-[89ABab][0-9A-Fa-f]{3}-[0-9A-Fa-f]{12}$|^$/`.
 * `last_scan` - (List) The details of the last scan of an attachment.
-Nested schema for **last_scan**:
+
+  Nested schema for **last_scan**:
 	* `id` - (String) The ID of the last scan of an attachment.
 	  * Constraints: The maximum length is `36` characters. The minimum length is `36` characters. The value must match regular expression `/^[a-zA-Z0-9-]*$/`.
 	* `status` - (String) The status of the last scan of an attachment.

--- a/website/docs/r/scc_profile_attachment.html.markdown
+++ b/website/docs/r/scc_profile_attachment.html.markdown
@@ -136,7 +136,7 @@ Nested schema for **last_scan**:
 You can import the `ibm_scc_profile_attachment` resource by using `id`.
 The `id` property can be formed from `instance_id`, `profiles_id`, and `attachment_id` in the following format:
 
-```
+```bash
 <instance_id>/<profile_id>/<attachment_id>
 ```
 * `instance_id`: A string. The instance ID.
@@ -144,6 +144,11 @@ The `id` property can be formed from `instance_id`, `profiles_id`, and `attachme
 * `attachment_id`: A string. The attachment ID.
 
 # Syntax
-```
+```bash
 $ terraform import ibm_scc_profile_attachment.scc_profile_attachment <instance_id>/<profile_id>/<attachment_id>
+```
+
+# Example
+```bash
+$ terraform import ibm_scc_profile_attachment.scc_profile_attachment 00000000-1111-2222-3333-444444444444/00000000-1111-2222-3333-444444444444/f3517159-889e-4781-819a-89d89b747c85
 ```

--- a/website/docs/r/scc_provider_type_instance.html.markdown
+++ b/website/docs/r/scc_provider_type_instance.html.markdown
@@ -48,14 +48,20 @@ After your resource is created, you can read values from the listed arguments an
 You can import the `ibm_scc_provider_type_instance` resource by using `id`.
 The `id` property can be formed from `instance_id`, `provider_type_id`, and `provider_type_instance_id` in the following format:
 
-```
-<provider_type_id>/<provider_type_instance_id>
+```bash
+<instance_id>/<provider_type_id>/<provider_type_instance_id>
 ```
 * `instance_id`: A string. The instance ID.
 * `provider_type_id`: A string. The provider type ID.
 * `provider_type_instance_id`: A string. The provider type instance ID.
 
 # Syntax
-```
+
+```bash
 $ terraform import ibm_scc_provider_type_instance.scc_provider_type_instance <instance_id>/<provider_type_id>/<provider_type_instance_id>
+```
+
+# Example
+```bash
+$ terraform import ibm_scc_provider_type_instance.scc_provider_type_instance 00000000-1111-2222-3333-444444444444/00000000-1111-2222-3333-444444444444/f3517159-889e-4781-819a-89d89b747c85
 ```

--- a/website/docs/r/scc_rule.html.markdown
+++ b/website/docs/r/scc_rule.html.markdown
@@ -193,13 +193,19 @@ After your resource is created, you can read values from the listed arguments an
 You can import the `ibm_scc_rule` resource by using `id`. The rule ID.
 The `id` property can be formed from `instance_id` and `rule_id` in the following format:
 
-```
+```bash
 <instance_id>/<rule_id>
 ```
 * `instance_id`: A string. The instance ID.
 * `rule_id`: A string. The rule ID.
 
 # Syntax
-```
+
+```bash
 $ terraform import ibm_scc_rule.scc_rule <instance_id>/<rule_id>
+```
+
+# Example
+```bash
+$ terraform import ibm_scc_rule.scc_rule 00000000-1111-2222-3333-444444444444/00000000-1111-2222-3333-444444444444
 ```


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/IBM-Cloud/terraform-provider-ibm/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

Updates:
* expose a new datasource `ibm_scc_control_libraries` that returns a list of control_libraries available to an instance.
  * Users can now use the datasource to help create a profile resource given from the datasource. 
* expose a new datasource `ibm_scc_profiles` that returns a list of profiles available to an instance
  * Users can now use the datasource to help create a profile_attachment resource in relation to the data given from the datasource 
* expose a new datasource `ibm_scc_provider_types` that returns a list of provider available to an instance 
  * Users can use the datasource to find the ibm_scc_provider_type.id  needed to create a resource of  scc_provider_type_instance. 
* fixes the import of documentation of scc
### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #5186 
Closes #5185
Closes #5208

Output from acceptance testing:

```shell
$ make testacc TEST=./ibm/service/scc       
=== RUN   TestAccIbmSccControlLibrariesDataSourceBasic
--- PASS: TestAccIbmSccControlLibrariesDataSourceBasic (51.25s)
=== RUN   TestAccIbmSccControlLibrariesDataSourceAllArgs
--- PASS: TestAccIbmSccControlLibrariesDataSourceAllArgs (41.44s)
=== RUN   TestAccIbmSccControlLibraryDataSourceBasic
--- PASS: TestAccIbmSccControlLibraryDataSourceBasic (56.03s)
=== RUN   TestAccIbmSccControlLibraryDataSourceAllArgs
--- PASS: TestAccIbmSccControlLibraryDataSourceAllArgs (55.85s)
=== RUN   TestAccIbmSccInstanceSettingsDataSourceBasic
--- PASS: TestAccIbmSccInstanceSettingsDataSourceBasic (42.82s)
=== RUN   TestAccIbmSccLatestReportsDataSourceBasic
--- PASS: TestAccIbmSccLatestReportsDataSourceBasic (44.97s)
=== RUN   TestAccIbmSccProfileAttachmentDataSourceBasic
--- PASS: TestAccIbmSccProfileAttachmentDataSourceBasic (66.66s)
=== RUN   TestAccIbmSccProfileAttachmentDataSourceAllArgs
--- PASS: TestAccIbmSccProfileAttachmentDataSourceAllArgs (64.63s)
=== RUN   TestAccIbmSccProfileDataSourceBasic
--- PASS: TestAccIbmSccProfileDataSourceBasic (65.19s)
=== RUN   TestAccIbmSccProfileDataSourceAllArgs
--- PASS: TestAccIbmSccProfileDataSourceAllArgs (58.10s)
=== RUN   TestAccIbmSccProfilesDataSourceBasic
--- PASS: TestAccIbmSccProfilesDataSourceBasic (44.98s)
=== RUN   TestAccIbmSccProfilesDataSourceAllArgs
--- PASS: TestAccIbmSccProfilesDataSourceAllArgs (48.66s)
=== RUN   TestAccIbmSccProviderTypeCollectionDataSourceBasic
--- PASS: TestAccIbmSccProviderTypeCollectionDataSourceBasic (40.12s)
=== RUN   TestAccIbmSccProviderTypeInstanceDataSourceBasic
--- PASS: TestAccIbmSccProviderTypeInstanceDataSourceBasic (51.32s)
=== RUN   TestAccIbmSccProviderTypeInstanceDataSourceAllArgs
--- PASS: TestAccIbmSccProviderTypeInstanceDataSourceAllArgs (51.91s)
=== RUN   TestAccIbmSccProviderTypeDataSourceBasic
--- PASS: TestAccIbmSccProviderTypeDataSourceBasic (39.37s)
=== RUN   TestAccIbmSccProviderTypesDataSourceBasic
--- PASS: TestAccIbmSccProviderTypesDataSourceBasic (39.61s)
=== RUN   TestAccIbmSccReportControlsDataSourceBasic
--- PASS: TestAccIbmSccReportControlsDataSourceBasic (42.73s)
=== RUN   TestAccIbmSccReportEvaluationsDataSourceBasic
--- PASS: TestAccIbmSccReportEvaluationsDataSourceBasic (42.10s)
=== RUN   TestAccIbmSccReportResourcesDataSourceBasic
--- PASS: TestAccIbmSccReportResourcesDataSourceBasic (39.08s)
=== RUN   TestAccIbmSccReportRuleDataSourceBasic
--- PASS: TestAccIbmSccReportRuleDataSourceBasic (39.16s)
=== RUN   TestAccIbmSccReportSummaryDataSourceBasic
--- PASS: TestAccIbmSccReportSummaryDataSourceBasic (44.01s)
=== RUN   TestAccIbmSccReportTagsDataSourceBasic
--- PASS: TestAccIbmSccReportTagsDataSourceBasic (38.63s)
=== RUN   TestAccIbmSccReportDataSourceBasic
--- PASS: TestAccIbmSccReportDataSourceBasic (38.64s)
=== RUN   TestAccIbmSccReportViolationDriftDataSourceBasic
--- PASS: TestAccIbmSccReportViolationDriftDataSourceBasic (39.60s)
=== RUN   TestAccIbmSccRuleDataSourceBasic
--- PASS: TestAccIbmSccRuleDataSourceBasic (56.10s)
=== RUN   TestAccIbmSccRuleDataSourceAllArgs
--- PASS: TestAccIbmSccRuleDataSourceAllArgs (55.48s)
=== RUN   TestAccIbmSccControlLibraryBasic
--- PASS: TestAccIbmSccControlLibraryBasic (87.26s)
=== RUN   TestAccIbmSccControlLibraryAllArgs
--- PASS: TestAccIbmSccControlLibraryAllArgs (105.08s)
=== RUN   TestAccIbmSccInstanceSettingsBasic
--- PASS: TestAccIbmSccInstanceSettingsBasic (56.88s)
=== RUN   TestAccIbmSccInstanceSettingsAllArgs
--- PASS: TestAccIbmSccInstanceSettingsAllArgs (111.14s)
=== RUN   TestAccIbmSccProfileAttachmentBasic
--- PASS: TestAccIbmSccProfileAttachmentBasic (63.77s)
=== RUN   TestAccIbmSccProfileAttachmentAllArgs
--- PASS: TestAccIbmSccProfileAttachmentAllArgs (104.06s)
=== RUN   TestAccIbmSccProfileBasic
--- PASS: TestAccIbmSccProfileBasic (92.74s)
=== RUN   TestAccIbmSccProfileAllArgs
--- PASS: TestAccIbmSccProfileAllArgs (97.96s)
=== RUN   TestAccIbmSccProviderTypeInstanceBasic
--- PASS: TestAccIbmSccProviderTypeInstanceBasic (89.87s)
=== RUN   TestAccIbmSccProviderTypeInstanceAllArgs
--- PASS: TestAccIbmSccProviderTypeInstanceAllArgs (98.29s)
=== RUN   TestAccIbmSccRuleBasic
--- PASS: TestAccIbmSccRuleBasic (104.38s)
=== RUN   TestAccIbmSccRuleAllArgs
--- PASS: TestAccIbmSccRuleAllArgs (99.30s)
PASS
ok      github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/scc     2409.749s
```
