### PR TITLE
Add filter attributes in sm_secrets data source

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -29,7 +29,7 @@ require (
 	github.com/IBM/push-notifications-go-sdk v0.0.0-20210310100607-5790b96c47f5
 	github.com/IBM/scc-go-sdk/v5 v5.1.5
 	github.com/IBM/schematics-go-sdk v0.2.3
-	github.com/IBM/secrets-manager-go-sdk/v2 v2.0.3
+	github.com/IBM/secrets-manager-go-sdk/v2 v2.0.4
 	github.com/IBM/vpc-beta-go-sdk v0.6.0
 	github.com/IBM/vpc-go-sdk v0.48.0
 	github.com/ScaleFT/sshkeys v0.0.0-20200327173127-6142f742bca5

--- a/go.sum
+++ b/go.sum
@@ -170,8 +170,8 @@ github.com/IBM/scc-go-sdk/v5 v5.1.5 h1:c17/7CfUjjgHXQe1fIY3GVsahqij1vDu9/dKPak8T
 github.com/IBM/scc-go-sdk/v5 v5.1.5/go.mod h1:YtAVlzq10bwR82QX4ZavhDIwa1s85RuVO9N/KmXVcuk=
 github.com/IBM/schematics-go-sdk v0.2.3 h1:lgTt0Sbudii3cuSk1YSQgrtiZAXDbBABAoVj3eQuBrU=
 github.com/IBM/schematics-go-sdk v0.2.3/go.mod h1:Tw2OSAPdpC69AxcwoyqcYYaGTTW6YpERF9uNEU+BFRQ=
-github.com/IBM/secrets-manager-go-sdk/v2 v2.0.3 h1:28x9ksuRllUbDHmbwk15snNZgaEDc+BtY5Ey8oMqKn8=
-github.com/IBM/secrets-manager-go-sdk/v2 v2.0.3/go.mod h1:5gq8D8uWOIbqOm1uztay6lpOysgJaxxEsaVZLWGWb40=
+github.com/IBM/secrets-manager-go-sdk/v2 v2.0.4 h1:xa9e+POVqaXxXHXkSMCOVAbKdUNEu86jQmo5hcpd+L4=
+github.com/IBM/secrets-manager-go-sdk/v2 v2.0.4/go.mod h1:5gq8D8uWOIbqOm1uztay6lpOysgJaxxEsaVZLWGWb40=
 github.com/IBM/vpc-beta-go-sdk v0.6.0 h1:wfM3AcW3zOM3xsRtZ+EA6+sESlGUjQ6Yf4n5QQyz4uc=
 github.com/IBM/vpc-beta-go-sdk v0.6.0/go.mod h1:fzHDAQIqH/5yJmYsKodKHLcqxMDT+yfH6vZjdiw8CQA=
 github.com/IBM/vpc-go-sdk v0.48.0 h1:4yeSxVX9mizsIW2F0rsVI47rZoNKBrZ1QK9RwwRas9Q=
@@ -1522,8 +1522,10 @@ github.com/xanzy/ssh-agent v0.3.3 h1:+/15pJfg/RsTxqYcX6fHqOXZwwMP+2VyYWJeWM2qQFM
 github.com/xdg-go/pbkdf2 v1.0.0/go.mod h1:jrpuAogTd400dnrH08LKmI/xc1MbPOebTwRqcT5RDeI=
 github.com/xdg-go/scram v1.0.2/go.mod h1:1WAq6h33pAW+iRreB34OORO2Nf7qel3VV3fjBj+hCSs=
 github.com/xdg-go/scram v1.1.1/go.mod h1:RaEWvsqvNKKvBPvcKeFjrG2cJqOkHTiyTpzz23ni57g=
+github.com/xdg-go/scram v1.1.2/go.mod h1:RT/sEzTbU5y00aCK8UOx6R7YryM0iF1N2MOmC3kKLN4=
 github.com/xdg-go/stringprep v1.0.2/go.mod h1:8F9zXuvzgwmyT5DUm4GUfZGDdT3W+LCvS6+da4O5kxM=
 github.com/xdg-go/stringprep v1.0.3/go.mod h1:W3f5j4i+9rC0kuIEJL0ky1VpHXQU3ocBgklLGvcBnW8=
+github.com/xdg-go/stringprep v1.0.4/go.mod h1:mPGuuIYwz7CmR2bT9j4GbQqutWS1zV24gijq1dTyGkM=
 github.com/xdg/scram v0.0.0-20180814205039-7eeb5667e42c/go.mod h1:lB8K/P019DLNhemzwFU4jHLhdvlE6uDZjXFejJXr49I=
 github.com/xdg/stringprep v0.0.0-20180714160509-73f8eece6fdc/go.mod h1:Jhud4/sHMO4oL310DaZAKk9ZaJ08SJfe+sJh0HrGL1Y=
 github.com/xdg/stringprep v1.0.0/go.mod h1:Jhud4/sHMO4oL310DaZAKk9ZaJ08SJfe+sJh0HrGL1Y=

--- a/ibm/service/secretsmanager/data_source_ibm_sm_secrets.go
+++ b/ibm/service/secretsmanager/data_source_ibm_sm_secrets.go
@@ -36,6 +36,18 @@ func DataSourceIbmSmSecrets() *schema.Resource {
 				Optional:    true,
 				Description: "Filter secrets by groups. You can apply multiple filters by using a comma-separated list of secret group IDs. If you need to filter secrets that are in the default secret group, use the `default` keyword.",
 			},
+			"secret_types": &schema.Schema{
+				Type:        schema.TypeList,
+				Optional:    true,
+				Description: "Filter secrets by secret types.",
+				Elem:        &schema.Schema{Type: schema.TypeString},
+			},
+			"match_all_labels": &schema.Schema{
+				Type:        schema.TypeList,
+				Optional:    true,
+				Description: "Filter secrets by a label or a combination of labels.",
+				Elem:        &schema.Schema{Type: schema.TypeString},
+			},
 			"total_count": &schema.Schema{
 				Type:        schema.TypeInt,
 				Computed:    true,
@@ -534,6 +546,24 @@ func dataSourceIbmSmSecretsRead(context context.Context, d *schema.ResourceData,
 			groupsList := strings.Split(groupsStr, ",")
 			listSecretsOptions.SetGroups(groupsList)
 		}
+	}
+
+	if _, ok := d.GetOk("secret_types"); ok {
+		secretTypes := d.Get("secret_types").([]interface{})
+		parsedTypes := make([]string, len(secretTypes))
+		for i, v := range secretTypes {
+			parsedTypes[i] = fmt.Sprint(v)
+		}
+		listSecretsOptions.SetSecretTypes(parsedTypes)
+	}
+
+	if _, ok := d.GetOk("match_all_labels"); ok {
+		labels := d.Get("match_all_labels").([]interface{})
+		parsedLabels := make([]string, len(labels))
+		for i, v := range labels {
+			parsedLabels[i] = fmt.Sprint(v)
+		}
+		listSecretsOptions.SetMatchAllLabels(parsedLabels)
 	}
 
 	var pager *secretsmanagerv2.SecretsPager

--- a/website/docs/d/sm_secrets.html.markdown
+++ b/website/docs/d/sm_secrets.html.markdown
@@ -31,14 +31,16 @@ Review the argument reference that you can specify for your data source.
 	* Constraints: Allowable values are: `id`, `created_at`, `updated_at`, `expiration_date`, `secret_type`, `name`.
 * `search` - (Optional, String) - Obtain a collection of secrets that contain the specified string in one or more of the fields: `id`, `name`, `description`, `labels`, `secret_type`.
 * `groups` - (Optional, String) - Filter secrets by groups. You can apply multiple filters by using a comma-separated list of secret group IDs. If you need to filter secrets that are in the default secret group, use the `default` keyword.
+* `secret_types` - (Optional, String) - Filter secrets by secret types. You can apply multiple filters by using a comma-separated list of secret types.
+* `match_all_labels` - (Optional, String) - Filter secrets by a label or a combination of labels (comma-separated list).
 
 ## Attribute Reference
 
 In addition to all argument references listed, you can access the following attribute references after your data source is created.
 
 * `id` - The unique identifier of the sm_secrets.
-* `secrets` - (List) A collection of secret metadata.
-  * Constraints: The maximum length is `1000` items. The minimum length is `0` items.
+* `secrets` - (List) A collection of secret metadata. Note that the list of metadata attributes conatains attributes that are common to all types of secrets, as well as attributes that are specific to cetrain secret types. A type specific attribute is included in every secret but the value is empty for secrets of other types. The common attributes are: `name, id, description, secret_type, crn, created_by, created_at, updated_at, downloaded, secret_group_id, state, state_description, versions_total`.
+  * Constraints: The maximum length is `1000` items. The minimum length is `0` items. 
 Nested scheme for **secrets**:
 	* `access_groups` - (List) Access Groups that you can use for an `iam_credentials` secret.Up to 10 Access Groups can be used for each secret.
 	  * Constraints: The list items must match regular expression `/^AccessGroupId-[a-z0-9-]+[a-z0-9]$/`. The maximum length is `10` items. The minimum length is `1` item.


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/IBM-Cloud/terraform-provider-ibm/blob/master/.github/CONTRIBUTING.md --->

Add new filter attributes in sm_secrets data source.
<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Output from acceptance testing:

=== RUN   TestAccIbmSmArbitrarySecretMetadataDataSourceBasic
--- PASS: TestAccIbmSmArbitrarySecretMetadataDataSourceBasic (17.76s)
=== RUN   TestAccIbmSmArbitrarySecretDataSourceBasic
--- PASS: TestAccIbmSmArbitrarySecretDataSourceBasic (15.09s)
=== RUN   TestAccIbmSmConfigurationsDataSourceBasic
--- PASS: TestAccIbmSmConfigurationsDataSourceBasic (25.35s)
=== RUN   TestAccIbmSmEnRegistrationDataSourceBasic
--- PASS: TestAccIbmSmEnRegistrationDataSourceBasic (14.54s)
=== RUN   TestAccIbmSmIamCredentialsConfigurationDataSourceBasic
--- PASS: TestAccIbmSmIamCredentialsConfigurationDataSourceBasic (13.35s)
=== RUN   TestAccIbmSmIamCredentialsSecretMetadataDataSourceBasic
--- PASS: TestAccIbmSmIamCredentialsSecretMetadataDataSourceBasic (17.84s)
=== RUN   TestAccIbmSmIamCredentialsSecretDataSourceBasic
--- PASS: TestAccIbmSmIamCredentialsSecretDataSourceBasic (22.75s)
=== RUN   TestAccIbmSmImportedCertificateMetadataDataSourceBasic
--- PASS: TestAccIbmSmImportedCertificateMetadataDataSourceBasic (14.04s)
=== RUN   TestAccIbmSmImportedCertificateDataSourceBasic
--- PASS: TestAccIbmSmImportedCertificateDataSourceBasic (14.48s)
=== RUN   TestAccIbmSmKvSecretMetadataDataSourceBasic
--- PASS: TestAccIbmSmKvSecretMetadataDataSourceBasic (13.72s)
=== RUN   TestAccIbmSmKvSecretDataSourceBasic
--- PASS: TestAccIbmSmKvSecretDataSourceBasic (14.57s)
=== RUN   TestAccIbmSmPrivateCertificateConfigurationIntermediateCADataSourceBasic
--- PASS: TestAccIbmSmPrivateCertificateConfigurationIntermediateCADataSourceBasic (20.15s)
=== RUN   TestAccIbmSmPrivateCertificateConfigurationRootCADataSourceBasic
--- PASS: TestAccIbmSmPrivateCertificateConfigurationRootCADataSourceBasic (17.49s)
=== RUN   TestAccIbmSmPrivateCertificateConfigurationTemplateDataSourceBasic
--- PASS: TestAccIbmSmPrivateCertificateConfigurationTemplateDataSourceBasic (22.16s)
=== RUN   TestAccIbmSmPrivateCertificateMetadataDataSourceBasic
--- PASS: TestAccIbmSmPrivateCertificateMetadataDataSourceBasic (28.45s)
=== RUN   TestAccIbmSmPrivateCertificateDataSourceBasic
--- PASS: TestAccIbmSmPrivateCertificateDataSourceBasic (27.46s)
=== RUN   TestAccIbmSmPublicCertificateConfigurationCALetsEncryptDataSourceBasic
--- PASS: TestAccIbmSmPublicCertificateConfigurationCALetsEncryptDataSourceBasic (12.64s)
=== RUN   TestAccIbmSmPublicCertificateConfigurationDnsCisDataSourceBasic
--- PASS: TestAccIbmSmPublicCertificateConfigurationDnsCisDataSourceBasic (13.14s)
=== RUN   TestAccIbmSmPublicCertificateConfigurationDnsClassicInfrastructureDataSourceBasic
--- PASS: TestAccIbmSmPublicCertificateConfigurationDnsClassicInfrastructureDataSourceBasic (13.40s)
=== RUN   TestAccIbmSmPublicCertificateMetadataDataSourceBasic
--- PASS: TestAccIbmSmPublicCertificateMetadataDataSourceBasic (137.56s)
=== RUN   TestAccIbmSmPublicCertificateDataSourceBasic
--- PASS: TestAccIbmSmPublicCertificateDataSourceBasic (127.51s)
=== RUN   TestAccIbmSmSecretGroupDataSourceBasic
--- PASS: TestAccIbmSmSecretGroupDataSourceBasic (12.25s)
=== RUN   TestAccIbmSmSecretGroupDataSourceAllArgs
--- PASS: TestAccIbmSmSecretGroupDataSourceAllArgs (11.99s)
=== RUN   TestAccIbmSmSecretGroupsDataSourceBasic
--- PASS: TestAccIbmSmSecretGroupsDataSourceBasic (13.10s)
=== RUN   TestAccIbmSmSecretGroupsDataSourceAllArgs
--- PASS: TestAccIbmSmSecretGroupsDataSourceAllArgs (19.60s)
=== RUN   TestAccIbmSmSecretsDataSourceBasic
--- PASS: TestAccIbmSmSecretsDataSourceBasic (14.71s)
=== RUN   TestAccIbmSmServiceCredentialsSecretMetadataDataSourceBasic
--- PASS: TestAccIbmSmServiceCredentialsSecretMetadataDataSourceBasic (16.56s)
=== RUN   TestAccIbmSmServiceCredentialsSecretDataSourceBasic
--- PASS: TestAccIbmSmServiceCredentialsSecretDataSourceBasic (16.37s)
=== RUN   TestAccIbmSmUsernamePasswordSecretMetadataDataSourceBasic
--- PASS: TestAccIbmSmUsernamePasswordSecretMetadataDataSourceBasic (14.13s)
=== RUN   TestAccIbmSmUsernamePasswordSecretDataSourceBasic
--- PASS: TestAccIbmSmUsernamePasswordSecretDataSourceBasic (13.94s)
=== RUN   TestAccIbmSmArbitrarySecretBasic
--- PASS: TestAccIbmSmArbitrarySecretBasic (14.48s)
=== RUN   TestAccIbmSmArbitrarySecretAllArgs
--- PASS: TestAccIbmSmArbitrarySecretAllArgs (26.96s)
=== RUN   TestAccIbmSmEnRegistrationBasic
--- PASS: TestAccIbmSmEnRegistrationBasic (13.15s)
=== RUN   TestAccIbmSmIamCredentialsConfigurationBasic
--- PASS: TestAccIbmSmIamCredentialsConfigurationBasic (14.95s)
=== RUN   TestAccIbmSmIamCredentialsSecretBasic
--- PASS: TestAccIbmSmIamCredentialsSecretBasic (19.35s)
=== RUN   TestAccIbmSmIamCredentialsSecretAllArgs
--- PASS: TestAccIbmSmIamCredentialsSecretAllArgs (30.86s)
=== RUN   TestAccIbmSmImportedCertificateBasic
--- PASS: TestAccIbmSmImportedCertificateBasic (14.43s)
=== RUN   TestAccIbmSmImportedCertificateAllArgs
--- PASS: TestAccIbmSmImportedCertificateAllArgs (25.80s)
=== RUN   TestAccIbmSmKvSecretBasic
--- PASS: TestAccIbmSmKvSecretBasic (14.00s)
=== RUN   TestAccIbmSmKvSecretAllArgs
--- PASS: TestAccIbmSmKvSecretAllArgs (28.70s)
=== RUN   TestAccIbmSmPrivateCertificateConfigurationActionSetSignedBasic
--- PASS: TestAccIbmSmPrivateCertificateConfigurationActionSetSignedBasic (17.18s)
=== RUN   TestAccIbmSmPrivateCertificateConfigurationActionSignCsrBasic
--- PASS: TestAccIbmSmPrivateCertificateConfigurationActionSignCsrBasic (16.63s)
=== RUN   TestAccIbmSmPrivateCertificateConfigurationIntermediateCABasic
--- PASS: TestAccIbmSmPrivateCertificateConfigurationIntermediateCABasic (18.02s)
=== RUN   TestAccIbmSmPrivateCertificateConfigurationIntermediateCAllArgs
--- PASS: TestAccIbmSmPrivateCertificateConfigurationIntermediateCAllArgs (29.26s)
=== RUN   TestAccIbmSmPrivateCertificateConfigurationRootCABasic
--- PASS: TestAccIbmSmPrivateCertificateConfigurationRootCABasic (14.96s)
=== RUN   TestAccIbmSmPrivateCertificateConfigurationRootCAllArgs
--- PASS: TestAccIbmSmPrivateCertificateConfigurationRootCAllArgs (25.85s)
=== RUN   TestAccIbmSmPrivateCertificateConfigurationTemplateBasic
--- PASS: TestAccIbmSmPrivateCertificateConfigurationTemplateBasic (25.61s)
=== RUN   TestAccIbmSmPrivateCertificateConfigurationTemplateAllArgs
--- PASS: TestAccIbmSmPrivateCertificateConfigurationTemplateAllArgs (34.03s)
=== RUN   TestAccIbmSmPrivateCertificateBasic
--- PASS: TestAccIbmSmPrivateCertificateBasic (25.56s)
=== RUN   TestAccIbmSmPrivateCertificateAllArgs
--- PASS: TestAccIbmSmPrivateCertificateAllArgs (41.48s)
=== RUN   TestAccIbmSmPublicCertificateActionValidateManualDnsBasic
--- PASS: TestAccIbmSmPublicCertificateActionValidateManualDnsBasic (25.47s)
=== RUN   TestAccIbmSmPublicCertificateConfigurationCALetsEncryptBasic
--- PASS: TestAccIbmSmPublicCertificateConfigurationCALetsEncryptBasic (14.33s)
=== RUN   TestAccIbmSmConfigurationPublicCertificateDnsCisBasic
--- PASS: TestAccIbmSmConfigurationPublicCertificateDnsCisBasic (14.01s)
=== RUN   TestAccIbmSmPublicCertificateConfigurationDNSClassicInfrastructureBasic
--- PASS: TestAccIbmSmPublicCertificateConfigurationDNSClassicInfrastructureBasic (13.95s)
=== RUN   TestAccIbmSmPublicCertificateBasic
--- PASS: TestAccIbmSmPublicCertificateBasic (139.24s)
=== RUN   TestAccIbmSmPublicCertificateAllArgs
--- PASS: TestAccIbmSmPublicCertificateAllArgs (139.55s)
=== RUN   TestAccIbmSmSecretGroupBasic
--- PASS: TestAccIbmSmSecretGroupBasic (21.71s)
=== RUN   TestAccIbmSmSecretGroupAllArgs
--- PASS: TestAccIbmSmSecretGroupAllArgs (21.70s)
=== RUN   TestAccIbmSmServiceCredentialsSecretBasic
--- PASS: TestAccIbmSmServiceCredentialsSecretBasic (16.97s)
=== RUN   TestAccIbmSmServiceCredentialsSecretAllArgs
--- PASS: TestAccIbmSmServiceCredentialsSecretAllArgs (28.63s)
=== RUN   TestAccIbmSmServiceCredentialsSecretAllArgsWithExistingServiceId
--- PASS: TestAccIbmSmServiceCredentialsSecretAllArgsWithExistingServiceId (21.52s)
=== RUN   TestAccIbmSmUsernamePasswordSecretBasic
--- PASS: TestAccIbmSmUsernamePasswordSecretBasic (15.07s)
=== RUN   TestAccIbmSmUsernamePasswordSecretAllArgs
--- PASS: TestAccIbmSmUsernamePasswordSecretAllArgs (26.00s)
PASS
ok      github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/secretsmanager  1687.020s

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```
