### PR TITLE
Minimum validation for multitenant formations

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/IBM/apigateway-go-sdk v0.0.0-20210714141226-a5d5d49caaca
 	github.com/IBM/appconfiguration-go-admin-sdk v0.3.0
 	github.com/IBM/appid-management-go-sdk v0.0.0-20210908164609-dd0e0eaf732f
-	github.com/IBM/cloud-databases-go-sdk v0.5.0
+	github.com/IBM/cloud-databases-go-sdk v0.6.0
 	github.com/IBM/cloudant-go-sdk v0.0.43
 	github.com/IBM/code-engine-go-sdk v0.0.0-20231106200405-99e81b3ee752
 	github.com/IBM/container-registry-go-sdk v1.1.0

--- a/go.sum
+++ b/go.sum
@@ -118,6 +118,8 @@ github.com/IBM/appid-management-go-sdk v0.0.0-20210908164609-dd0e0eaf732f h1:4c1
 github.com/IBM/appid-management-go-sdk v0.0.0-20210908164609-dd0e0eaf732f/go.mod h1:d22kTYY7RYBWcQlZpqrSdshpB/lJ16viWS5Sbjtlc8s=
 github.com/IBM/cloud-databases-go-sdk v0.5.0 h1:Bie6MnT1jLchQmtKVA20HHETTPdlOR+i11P2kJ55viM=
 github.com/IBM/cloud-databases-go-sdk v0.5.0/go.mod h1:nCIVfeZnhBYIiwByT959dFP4VWUeNLxomDYy63tTC6M=
+github.com/IBM/cloud-databases-go-sdk v0.6.0 h1:QK3eif7+kusgeuMB54Zw5nco/kDwsDg2sD/84/foDxo=
+github.com/IBM/cloud-databases-go-sdk v0.6.0/go.mod h1:nCIVfeZnhBYIiwByT959dFP4VWUeNLxomDYy63tTC6M=
 github.com/IBM/cloudant-go-sdk v0.0.43 h1:YxTy4RpAEezX32YIWnds76hrBREmO4u6IkBz1WylNuQ=
 github.com/IBM/cloudant-go-sdk v0.0.43/go.mod h1:WeYrJPaHTw19943ndWnVfwMIlZ5z0XUM2uEXNBrwZ1M=
 github.com/IBM/code-engine-go-sdk v0.0.0-20231106200405-99e81b3ee752 h1:S5NT0aKKUqd9hnIrPN/qUijKx9cZjJi3kfFpog0ByDA=

--- a/ibm/service/database/resource_ibm_database.go
+++ b/ibm/service/database/resource_ibm_database.go
@@ -2876,6 +2876,7 @@ func validateGroupHostFlavor(groupId string, resourceName string, group *Group) 
 }
 
 func validateMultitenantMemoryCpu(groupId string, resourceName string, resourceDefaults *Group, group *Group) error {
+	// TODO: Replace this with resourceDefaults.Memory.CPUEnforcementRatioCeiling when it is fixed
 	cpuEnforcementRatioCeiling := 16384
 	// members := resourceDefaults.Members.Minimum
 

--- a/ibm/service/database/resource_ibm_database.go
+++ b/ibm/service/database/resource_ibm_database.go
@@ -1242,7 +1242,6 @@ func resourceIBMDatabaseInstanceCreate(context context.Context, d *schema.Resour
 	}
 
 	initialNodeCount, err := getInitialNodeCount(serviceName, plan, meta)
-	fmt.Printf("LALALA initialNodeCount %d", initialNodeCount)
 	if err != nil {
 		return diag.FromErr(err)
 	}

--- a/ibm/service/database/resource_ibm_database.go
+++ b/ibm/service/database/resource_ibm_database.go
@@ -2874,27 +2874,19 @@ func validateMultitenantMemoryCpu(resourceDefaults *Group, group *Group, cpuEnfo
 	// TODO: Replace this with  cpuEnforcementRatioCeiling when it is fixed
 	cpuEnforcementRatioCeilingTemp := 16384
 
-	if resourceDefaults.Members == nil {
-		return nil
-	}
-
-	if group.Memory.Allocation < resourceDefaults.Memory.Minimum/resourceDefaults.Members.Allocation {
-		return fmt.Errorf("We were unable to complete your request: group.memory requires a minimum of %d megabytes. Try again with valid values or contact support if the issue persists.", resourceDefaults.Memory.Minimum/resourceDefaults.Members.Allocation)
-	}
-
 	if group.CPU == nil {
 		return nil
 	}
 
-	if group.CPU != nil && group.CPU.Allocation > 2 {
+	if group.CPU.Allocation == 0 {
 		return nil
 	}
 
-	if group.CPU != nil && group.Memory.Allocation*resourceDefaults.Members.Allocation < cpuEnforcementRatioCeilingTemp*resourceDefaults.Members.Allocation && group.Memory.Allocation*resourceDefaults.Members.Allocation > group.CPU.Allocation*cpuEnforcementRatioMb {
-		return fmt.Errorf("We were unable to complete your request: group.memory %d with group.cpu %d is not valid. Try again with valid values or contact support if the issue persists.", group.Memory.Allocation, group.CPU.Allocation)
+	if group.CPU.Allocation >= cpuEnforcementRatioCeilingTemp/cpuEnforcementRatioMb {
+		return nil
+	} else {
+		return fmt.Errorf("The current cpu alloaction of %d is not valid for your current configuration.", group.CPU.Allocation)
 	}
-
-	return nil
 }
 
 func validateGroupsDiff(_ context.Context, diff *schema.ResourceDiff, meta interface{}) (err error) {

--- a/ibm/service/database/resource_ibm_database.go
+++ b/ibm/service/database/resource_ibm_database.go
@@ -2870,14 +2870,14 @@ func validateGroupHostFlavor(groupId string, resourceName string, group *Group) 
 	return nil
 }
 
-func validateMultitenantMemoryCpu(groupId string, resourceName string, resourceDefaults *Group, group *Group) error {
+func validateMultitenantMemoryCpu(groupId string, resourceDefaults *Group, group *Group) error {
 	// TODO: Replace this with resourceDefaults.Memory.CPUEnforcementRatioCeiling when it is fixed
 	cpuEnforcementRatioCeiling := 16384
-	cpuEnforcmentRationMb := resourceDefaults.Memory.CPUEnforcementRatioMb
+	cpuEnforcementRatioMb := resourceDefaults.Memory.CPUEnforcementRatioMb
 
-	// This means the CPUEnforcementRatioMb was not sent, which means we are dealing with a non-multitenant going to a multitenat
-	if cpuEnforcmentRationMb == 0 {
-		cpuEnforcmentRationMb = 8192
+	// This means the cpuEnforcementRatioMb was not sent, which means we are dealing with a non-multitenant going to a multitenat
+	if cpuEnforcementRatioMb == 0 {
+		cpuEnforcementRatioMb = 8192
 	}
 
 	if resourceDefaults.Members == nil {
@@ -2896,7 +2896,7 @@ func validateMultitenantMemoryCpu(groupId string, resourceName string, resourceD
 		return nil
 	}
 
-	if group.CPU != nil && group.Memory.Allocation*resourceDefaults.Members.Allocation < cpuEnforcementRatioCeiling*resourceDefaults.Members.Allocation && group.Memory.Allocation*resourceDefaults.Members.Allocation > group.CPU.Allocation*cpuEnforcmentRationMb {
+	if group.CPU != nil && group.Memory.Allocation*resourceDefaults.Members.Allocation < cpuEnforcementRatioCeiling*resourceDefaults.Members.Allocation && group.Memory.Allocation*resourceDefaults.Members.Allocation > group.CPU.Allocation*cpuEnforcementRatioMb {
 		return fmt.Errorf("We were unable to complete your request: group.memory %d with group.cpu %d is not valid. Try again with valid values or contact support if the issue persists.", group.Memory.Allocation, group.CPU.Allocation)
 	}
 
@@ -2971,7 +2971,7 @@ func validateGroupsDiff(_ context.Context, diff *schema.ResourceDiff, meta inter
 			nodeCount := groupDefaults.Members.Allocation
 
 			if group.Memory != nil && group.HostFlavor != nil && group.HostFlavor.ID != "" && group.HostFlavor.ID == "multitenant" && groupDefaults.Memory.CPUEnforcementRatioCeilingMb != 0 && groupDefaults.Memory.CPUEnforcementRatioMb != 0 {
-				err = validateMultitenantMemoryCpu(groupId, "memory", groupDefaults, group)
+				err = validateMultitenantMemoryCpu(groupId, groupDefaults, group)
 				if err != nil {
 					return err
 				}

--- a/ibm/service/database/resource_ibm_database_elasticsearch_test.go
+++ b/ibm/service/database/resource_ibm_database_elasticsearch_test.go
@@ -78,7 +78,7 @@ func TestAccIBMDatabaseInstance_Elasticsearch_Basic(t *testing.T) {
 					resource.TestCheckResourceAttr(name, "service", "databases-for-elasticsearch"),
 					resource.TestCheckResourceAttr(name, "plan", "standard"),
 					resource.TestCheckResourceAttr(name, "location", acc.Region()),
-					resource.TestCheckResourceAttr(name, "groups.0.memory.0.allocation_mb", "6144"),
+					resource.TestCheckResourceAttr(name, "groups.0.memory.0.allocation_mb", "12288"),
 					resource.TestCheckResourceAttr(name, "groups.0.disk.0.allocation_mb", "18432"),
 					resource.TestCheckResourceAttr(name, "users.#", "0"),
 					resource.TestCheckResourceAttr(name, "connectionstrings.#", "1"),
@@ -213,7 +213,7 @@ func TestAccIBMDatabaseInstance_Elasticsearch_Group(t *testing.T) {
 					resource.TestCheckResourceAttr(name, "plan", "standard"),
 					resource.TestCheckResourceAttr(name, "location", acc.Region()),
 					resource.TestCheckResourceAttr(name, "groups.0.count", "3"),
-					resource.TestCheckResourceAttr(name, "groups.0.memory.0.allocation_mb", "3072"),
+					resource.TestCheckResourceAttr(name, "groups.0.memory.0.allocation_mb", "12288"),
 					resource.TestCheckResourceAttr(name, "groups.0.disk.0.allocation_mb", "18432"),
 					resource.TestCheckResourceAttr(name, "groups.0.cpu.0.allocation_count", "9"),
 					resource.TestCheckResourceAttr(name, "allowlist.#", "2"),
@@ -231,7 +231,7 @@ func TestAccIBMDatabaseInstance_Elasticsearch_Group(t *testing.T) {
 					resource.TestCheckResourceAttr(name, "plan", "standard"),
 					resource.TestCheckResourceAttr(name, "location", acc.Region()),
 					resource.TestCheckResourceAttr(name, "groups.0.count", "3"),
-					resource.TestCheckResourceAttr(name, "groups.0.memory.0.allocation_mb", "3072"),
+					resource.TestCheckResourceAttr(name, "groups.0.memory.0.allocation_mb", "12288"),
 					resource.TestCheckResourceAttr(name, "groups.0.disk.0.allocation_mb", "18432"),
 					resource.TestCheckResourceAttr(name, "groups.0.cpu.0.allocation_count", "9"),
 					resource.TestCheckResourceAttr(name, "allowlist.#", "0"),
@@ -248,7 +248,7 @@ func TestAccIBMDatabaseInstance_Elasticsearch_Group(t *testing.T) {
 					resource.TestCheckResourceAttr(name, "plan", "standard"),
 					resource.TestCheckResourceAttr(name, "location", acc.Region()),
 					resource.TestCheckResourceAttr(name, "groups.0.count", "4"),
-					resource.TestCheckResourceAttr(name, "groups.0.memory.0.allocation_mb", "4096"),
+					resource.TestCheckResourceAttr(name, "groups.0.memory.0.allocation_mb", "15360"),
 					resource.TestCheckResourceAttr(name, "groups.0.disk.0.allocation_mb", "24576"),
 					resource.TestCheckResourceAttr(name, "groups.0.cpu.0.allocation_count", "12"),
 					resource.TestCheckResourceAttr(name, "allowlist.#", "0"),
@@ -329,7 +329,7 @@ func testAccCheckIBMDatabaseInstanceElasticsearchBasic(databaseResourceGroup str
 		group {
 			group_id = "member"
 			memory {
-				allocation_mb = 2048
+				allocation_mb = 4096
 			}
 			host_flavor {
 				id = "multitenant"
@@ -379,7 +379,7 @@ func testAccCheckIBMDatabaseInstanceElasticsearchFullyspecified(databaseResource
 		group {
 			group_id = "member"
 			memory {
-				allocation_mb = 2048
+				allocation_mb = 4096
 			}
 			host_flavor {
 				id = "multitenant"
@@ -414,7 +414,7 @@ func testAccCheckIBMDatabaseInstanceElasticsearchReduced(databaseResourceGroup s
 		group {
 			group_id = "member"
 			memory {
-				allocation_mb = 2048
+				allocation_mb = 4096
 			}
 			host_flavor {
 				id = "multitenant"
@@ -449,7 +449,7 @@ func testAccCheckIBMDatabaseInstanceElasticsearchGroupMigration(databaseResource
 		  group_id = "member"
 
 		  memory {
-		    allocation_mb = 2048
+		    allocation_mb = 4096
 		  }
 		  host_flavor {
 			  id = "multitenant"
@@ -489,7 +489,7 @@ func testAccCheckIBMDatabaseInstanceElasticsearchNodeBasic(databaseResourceGroup
 			  allocation_count = 3
 			}
 			memory {
-			  allocation_mb = 1024
+			  allocation_mb = 4096
 			}
 			disk {
 			  allocation_mb = 5120
@@ -539,7 +539,7 @@ func testAccCheckIBMDatabaseInstanceElasticsearchNodeFullyspecified(databaseReso
 			  allocation_count = 3
 			}
 			memory {
-			  allocation_mb = 1024
+			  allocation_mb = 5120
 			}
 			disk {
 			  allocation_mb = 6144
@@ -597,7 +597,7 @@ func testAccCheckIBMDatabaseInstanceElasticsearchNodeReduced(databaseResourceGro
 			  allocation_count = 3
 			}
 			memory {
-			  allocation_mb = 1024
+			  allocation_mb = 4096
 			}
 			disk {
 			  allocation_mb = 6144
@@ -639,7 +639,7 @@ func testAccCheckIBMDatabaseInstanceElasticsearchNodeScaleOut(databaseResourceGr
 			  allocation_count = 4
 			}
 			memory {
-			  allocation_mb = 1024
+			  allocation_mb = 4096
 			}
 			disk {
 			  allocation_mb = 6144
@@ -682,7 +682,7 @@ func testAccCheckIBMDatabaseInstanceElasticsearchGroupBasic(databaseResourceGrou
 				allocation_count = 3
 			}
 			memory {
-				allocation_mb = 1024
+				allocation_mb = 4096
 			}
 			disk {
 				allocation_mb = 5120
@@ -734,7 +734,7 @@ func testAccCheckIBMDatabaseInstanceElasticsearchGroupFullyspecified(databaseRes
 		    allocation_count = 3
 		  }
 		  memory {
-		    allocation_mb = 1024
+		    allocation_mb = 4096
 		  }
 		  disk {
 		    allocation_mb = 6144
@@ -794,7 +794,7 @@ func testAccCheckIBMDatabaseInstanceElasticsearchGroupReduced(databaseResourceGr
 		    allocation_count = 3
 		  }
 		  memory {
-		    allocation_mb = 1024
+		    allocation_mb = 4096
 		  }
 		  disk {
 		    allocation_mb = 6144
@@ -837,7 +837,7 @@ func testAccCheckIBMDatabaseInstanceElasticsearchGroupScaleOut(databaseResourceG
 		    allocation_count = 4
 		  }
 		  memory {
-		    allocation_mb = 1024
+		    allocation_mb = 4096
 		  }
 		  disk {
 		    allocation_mb = 6144

--- a/ibm/service/database/resource_ibm_database_etcd_test.go
+++ b/ibm/service/database/resource_ibm_database_etcd_test.go
@@ -36,7 +36,7 @@ func TestAccIBMDatabaseInstance_Etcd_Basic(t *testing.T) {
 					resource.TestCheckResourceAttr(name, "plan", "standard"),
 					resource.TestCheckResourceAttr(name, "location", acc.Region()),
 					resource.TestCheckResourceAttr(name, "adminuser", "root"),
-					resource.TestCheckResourceAttr(name, "groups.0.memory.0.allocation_mb", "9216"),
+					resource.TestCheckResourceAttr(name, "groups.0.memory.0.allocation_mb", "12288"),
 					resource.TestCheckResourceAttr(name, "groups.0.disk.0.allocation_mb", "184320"),
 					resource.TestCheckResourceAttr(name, "allowlist.#", "1"),
 					resource.TestCheckResourceAttr(name, "users.#", "1"),
@@ -69,7 +69,7 @@ func TestAccIBMDatabaseInstance_Etcd_Basic(t *testing.T) {
 					resource.TestCheckResourceAttr(name, "service", "databases-for-etcd"),
 					resource.TestCheckResourceAttr(name, "plan", "standard"),
 					resource.TestCheckResourceAttr(name, "location", acc.Region()),
-					resource.TestCheckResourceAttr(name, "groups.0.memory.0.allocation_mb", "9216"),
+					resource.TestCheckResourceAttr(name, "groups.0.memory.0.allocation_mb", "12288"),
 					resource.TestCheckResourceAttr(name, "groups.0.disk.0.allocation_mb", "193536"),
 					resource.TestCheckResourceAttr(name, "allowlist.#", "0"),
 					resource.TestCheckResourceAttr(name, "users.#", "0"),
@@ -135,7 +135,7 @@ func testAccCheckIBMDatabaseInstanceEtcdBasic(databaseResourceGroup string, name
 		group {
 			group_id = "member"
 			memory {
-			  allocation_mb = 3072
+			  allocation_mb = 4096
 			}
 			host_flavor {
 				id = "multitenant"
@@ -217,7 +217,7 @@ func testAccCheckIBMDatabaseInstanceEtcdReduced(databaseResourceGroup string, na
 		group {
 			group_id = "member"
 			memory {
-			  allocation_mb = 3072
+			  allocation_mb = 4096
 			}
 			host_flavor {
 				id = "multitenant"

--- a/ibm/service/database/resource_ibm_database_mongodb_test.go
+++ b/ibm/service/database/resource_ibm_database_mongodb_test.go
@@ -38,7 +38,7 @@ func TestAccIBMDatabaseInstanceMongodbBasic(t *testing.T) {
 					resource.TestCheckResourceAttr(name, "adminuser", "admin"),
 					resource.TestCheckResourceAttr(name, "allowlist.#", "1"),
 					resource.TestCheckResourceAttr(name, "users.#", "1"),
-					resource.TestCheckResourceAttr(name, "groups.0.memory.0.allocation_mb", "3072"),
+					resource.TestCheckResourceAttr(name, "groups.0.memory.0.allocation_mb", "12288"),
 					resource.TestCheckResourceAttr(name, "groups.0.disk.0.allocation_mb", "30720"),
 					resource.TestCheckResourceAttr(name, "connectionstrings.#", "2"),
 					resource.TestCheckResourceAttr(name, "connectionstrings.1.name", "admin"),
@@ -56,7 +56,7 @@ func TestAccIBMDatabaseInstanceMongodbBasic(t *testing.T) {
 					resource.TestCheckResourceAttr(name, "location", acc.Region()),
 					resource.TestCheckResourceAttr(name, "allowlist.#", "2"),
 					resource.TestCheckResourceAttr(name, "users.#", "2"),
-					resource.TestCheckResourceAttr(name, "groups.0.memory.0.allocation_mb", "6144"),
+					resource.TestCheckResourceAttr(name, "groups.0.memory.0.allocation_mb", "15360"),
 					resource.TestCheckResourceAttr(name, "groups.0.disk.0.allocation_mb", "30720"),
 					resource.TestCheckResourceAttr(name, "connectionstrings.#", "3"),
 					resource.TestCheckResourceAttr(name, "connectionstrings.2.name", "admin"),
@@ -71,7 +71,7 @@ func TestAccIBMDatabaseInstanceMongodbBasic(t *testing.T) {
 					resource.TestCheckResourceAttr(name, "service", "databases-for-mongodb"),
 					resource.TestCheckResourceAttr(name, "plan", "standard"),
 					resource.TestCheckResourceAttr(name, "location", acc.Region()),
-					resource.TestCheckResourceAttr(name, "groups.0.memory.0.allocation_mb", "3072"),
+					resource.TestCheckResourceAttr(name, "groups.0.memory.0.allocation_mb", "12288"),
 					resource.TestCheckResourceAttr(name, "groups.0.disk.0.allocation_mb", "30720"),
 					resource.TestCheckResourceAttr(name, "allowlist.#", "0"),
 					resource.TestCheckResourceAttr(name, "users.#", "0"),
@@ -139,7 +139,7 @@ func testAccCheckIBMDatabaseInstanceMongodbBasic(databaseResourceGroup string, n
 		group {
 			group_id = "member"
 			memory {
-				allocation_mb = 1024
+				allocation_mb = 4096
 			}
 			host_flavor {
 				id = "multitenant"
@@ -176,7 +176,7 @@ func testAccCheckIBMDatabaseInstanceMongodbFullyspecified(databaseResourceGroup 
 		group {
 			group_id = "member"
 			memory {
-				allocation_mb = 2048
+				allocation_mb = 5120
 			}
 			host_flavor {
 				id = "multitenant"
@@ -221,7 +221,7 @@ func testAccCheckIBMDatabaseInstanceMongodbReduced(databaseResourceGroup string,
 		group {
 			group_id = "member"
 			memory {
-				allocation_mb = 1024
+				allocation_mb = 4096
 			}
 			host_flavor {
 				id = "multitenant"

--- a/ibm/service/database/resource_ibm_database_mysql_test.go
+++ b/ibm/service/database/resource_ibm_database_mysql_test.go
@@ -35,7 +35,7 @@ func TestAccIBMMysqlDatabaseInstanceBasic(t *testing.T) {
 					resource.TestCheckResourceAttr(name, "plan", "standard"),
 					resource.TestCheckResourceAttr(name, "location", acc.Region()),
 					resource.TestCheckResourceAttr(name, "adminuser", "admin"),
-					resource.TestCheckResourceAttr(name, "groups.0.memory.0.allocation_mb", "3072"),
+					resource.TestCheckResourceAttr(name, "groups.0.memory.0.allocation_mb", "12288"),
 					resource.TestCheckResourceAttr(name, "groups.0.disk.0.allocation_mb", "61440"),
 					resource.TestCheckResourceAttr(name, "service_endpoints", "public"),
 					resource.TestCheckResourceAttr(name, "allowlist.#", "1"),
@@ -55,7 +55,7 @@ func TestAccIBMMysqlDatabaseInstanceBasic(t *testing.T) {
 					resource.TestCheckResourceAttr(name, "service", "databases-for-mysql"),
 					resource.TestCheckResourceAttr(name, "plan", "standard"),
 					resource.TestCheckResourceAttr(name, "location", acc.Region()),
-					resource.TestCheckResourceAttr(name, "groups.0.memory.0.allocation_mb", "6144"),
+					resource.TestCheckResourceAttr(name, "groups.0.memory.0.allocation_mb", "15360"),
 					resource.TestCheckResourceAttr(name, "groups.0.disk.0.allocation_mb", "92160"),
 					resource.TestCheckResourceAttr(name, "service_endpoints", "public-and-private"),
 					resource.TestCheckResourceAttr(name, "allowlist.#", "2"),
@@ -90,7 +90,7 @@ func testAccCheckIBMDatabaseInstanceMysqlBasic(databaseResourceGroup string, nam
 		group {
 			group_id = "member"
 			memory {
-				allocation_mb = 1024
+				allocation_mb = 4096
 			}
 			host_flavor {
 				id = "multitenant"
@@ -133,7 +133,7 @@ func testAccCheckIBMDatabaseInstanceMysqlFullyspecified(databaseResourceGroup st
 		group {
 			group_id = "member"
 			memory {
-				allocation_mb = 2048
+				allocation_mb = 5120
 			}
 			disk {
 				allocation_mb = 30720

--- a/ibm/service/database/resource_ibm_database_postgresql_test.go
+++ b/ibm/service/database/resource_ibm_database_postgresql_test.go
@@ -57,7 +57,7 @@ func TestAccIBMDatabaseInstancePostgresBasic(t *testing.T) {
 					resource.TestCheckResourceAttr(name, "plan", "standard"),
 					resource.TestCheckResourceAttr(name, "location", acc.Region()),
 					resource.TestCheckResourceAttr(name, "adminuser", "admin"),
-					resource.TestCheckResourceAttr(name, "groups.0.memory.0.allocation_mb", "4096"),
+					resource.TestCheckResourceAttr(name, "groups.0.memory.0.allocation_mb", "8192"),
 					resource.TestCheckResourceAttr(name, "groups.0.disk.0.allocation_mb", "20480"),
 					resource.TestCheckResourceAttr(name, "groups.0.cpu.0.allocation_count", "0"),
 					resource.TestCheckResourceAttr(name, "service_endpoints", "public"),
@@ -79,7 +79,7 @@ func TestAccIBMDatabaseInstancePostgresBasic(t *testing.T) {
 					resource.TestCheckResourceAttr(name, "service", "databases-for-postgresql"),
 					resource.TestCheckResourceAttr(name, "plan", "standard"),
 					resource.TestCheckResourceAttr(name, "location", acc.Region()),
-					resource.TestCheckResourceAttr(name, "groups.0.memory.0.allocation_mb", "8192"),
+					resource.TestCheckResourceAttr(name, "groups.0.memory.0.allocation_mb", "16384"),
 					resource.TestCheckResourceAttr(name, "groups.0.disk.0.allocation_mb", "28672"),
 					resource.TestCheckResourceAttr(name, "service_endpoints", "public-and-private"),
 					resource.TestCheckResourceAttr(name, "allowlist.#", "2"),
@@ -127,7 +127,7 @@ func TestAccIBMDatabaseInstancePostgresGroup(t *testing.T) {
 					resource.TestCheckResourceAttr(name, "location", acc.Region()),
 					resource.TestCheckResourceAttr(name, "adminuser", "admin"),
 					resource.TestCheckResourceAttr(name, "groups.0.count", "2"),
-					resource.TestCheckResourceAttr(name, "groups.0.memory.0.allocation_mb", "2048"),
+					resource.TestCheckResourceAttr(name, "groups.0.memory.0.allocation_mb", "8192"),
 					resource.TestCheckResourceAttr(name, "groups.0.disk.0.allocation_mb", "10240"),
 					resource.TestCheckResourceAttr(name, "groups.0.cpu.0.allocation_count", "6"),
 					resource.TestCheckResourceAttr(name, "service_endpoints", "public"),
@@ -149,7 +149,7 @@ func TestAccIBMDatabaseInstancePostgresGroup(t *testing.T) {
 					resource.TestCheckResourceAttr(name, "plan", "standard"),
 					resource.TestCheckResourceAttr(name, "location", acc.Region()),
 					resource.TestCheckResourceAttr(name, "groups.0.count", "2"),
-					resource.TestCheckResourceAttr(name, "groups.0.memory.0.allocation_mb", "2304"),
+					resource.TestCheckResourceAttr(name, "groups.0.memory.0.allocation_mb", "16384"),
 					resource.TestCheckResourceAttr(name, "groups.0.disk.0.allocation_mb", "14336"),
 					resource.TestCheckResourceAttr(name, "groups.0.cpu.0.allocation_count", "6"),
 					resource.TestCheckResourceAttr(name, "service_endpoints", "public-and-private"),
@@ -174,7 +174,7 @@ func TestAccIBMDatabaseInstancePostgresGroup(t *testing.T) {
 					resource.TestCheckResourceAttr(name, "plan", "standard"),
 					resource.TestCheckResourceAttr(name, "location", acc.Region()),
 					resource.TestCheckResourceAttr(name, "groups.0.count", "2"),
-					resource.TestCheckResourceAttr(name, "groups.0.memory.0.allocation_mb", "2048"),
+					resource.TestCheckResourceAttr(name, "groups.0.memory.0.allocation_mb", "8192"),
 					resource.TestCheckResourceAttr(name, "groups.0.disk.0.allocation_mb", "14336"),
 					resource.TestCheckResourceAttr(name, "groups.0.cpu.0.allocation_count", "6"),
 					resource.TestCheckResourceAttr(name, "allowlist.#", "0"),
@@ -192,7 +192,7 @@ func TestAccIBMDatabaseInstancePostgresGroup(t *testing.T) {
 					resource.TestCheckResourceAttr(name, "plan", "standard"),
 					resource.TestCheckResourceAttr(name, "location", acc.Region()),
 					resource.TestCheckResourceAttr(name, "groups.0.count", "3"),
-					resource.TestCheckResourceAttr(name, "groups.0.memory.0.allocation_mb", "3072"),
+					resource.TestCheckResourceAttr(name, "groups.0.memory.0.allocation_mb", "8192"),
 					resource.TestCheckResourceAttr(name, "groups.0.disk.0.allocation_mb", "21504"),
 					resource.TestCheckResourceAttr(name, "groups.0.cpu.0.allocation_count", "9"),
 					resource.TestCheckResourceAttr(name, "allowlist.#", "0"),
@@ -419,7 +419,7 @@ func testAccCheckIBMDatabaseInstancePostgresBasic(databaseResourceGroup string, 
 		group {
 			group_id = "member"
 			memory {
-			  allocation_mb = 2048
+			  allocation_mb = 4096
 			}
 			host_flavor {
 				id = "multitenant"
@@ -469,7 +469,7 @@ func testAccCheckIBMDatabaseInstancePostgresFullyspecified(databaseResourceGroup
 		group {
 			group_id = "member"
 			memory {
-			  allocation_mb = 4096
+			  allocation_mb = 8192
 			}
 			disk {
 			  allocation_mb = 14336
@@ -544,7 +544,7 @@ func testAccCheckIBMDatabaseInstancePostgresGroupBasic(databaseResourceGroup str
 				allocation_count = 2
 			}
 			memory {
-				allocation_mb = 1024
+				allocation_mb = 4096
 			}
 			disk {
 				allocation_mb = 5120
@@ -589,7 +589,7 @@ func testAccCheckIBMDatabaseInstancePostgresGroupFullyspecified(databaseResource
 				allocation_count = 2
 			}
 			memory {
-				allocation_mb = 1152
+				allocation_mb = 8192
 			}
 			disk {
 				allocation_mb = 7168
@@ -642,7 +642,7 @@ func testAccCheckIBMDatabaseInstancePostgresGroupReduced(databaseResourceGroup s
 				allocation_count = 2
 			}
 			memory {
-				allocation_mb = 1024
+				allocation_mb = 4096
 			}
 			disk {
 				allocation_mb = 7168
@@ -677,7 +677,7 @@ func testAccCheckIBMDatabaseInstancePostgresGroupScaleOut(databaseResourceGroup 
 				allocation_count = 3
 			}
 			memory {
-				allocation_mb = 1024
+				allocation_mb = 8192
 			}
 			disk {
 				allocation_mb = 7168

--- a/ibm/service/database/resource_ibm_database_rabbitmq_test.go
+++ b/ibm/service/database/resource_ibm_database_rabbitmq_test.go
@@ -35,7 +35,7 @@ func TestAccIBMDatabaseInstance_Rabbitmq_Basic(t *testing.T) {
 					resource.TestCheckResourceAttr(name, "plan", "standard"),
 					resource.TestCheckResourceAttr(name, "location", acc.Region()),
 					resource.TestCheckResourceAttr(name, "adminuser", "admin"),
-					resource.TestCheckResourceAttr(name, "groups.0.memory.0.allocation_mb", "3072"),
+					resource.TestCheckResourceAttr(name, "groups.0.memory.0.allocation_mb", "24576"),
 					resource.TestCheckResourceAttr(name, "groups.0.disk.0.allocation_mb", "3072"),
 					resource.TestCheckResourceAttr(name, "allowlist.#", "1"),
 					resource.TestCheckResourceAttr(name, "users.#", "1"),
@@ -53,7 +53,7 @@ func TestAccIBMDatabaseInstance_Rabbitmq_Basic(t *testing.T) {
 					resource.TestCheckResourceAttr(name, "service", "messages-for-rabbitmq"),
 					resource.TestCheckResourceAttr(name, "plan", "standard"),
 					resource.TestCheckResourceAttr(name, "location", acc.Region()),
-					resource.TestCheckResourceAttr(name, "groups.0.memory.0.allocation_mb", "6144"),
+					resource.TestCheckResourceAttr(name, "groups.0.memory.0.allocation_mb", "30720"),
 					resource.TestCheckResourceAttr(name, "groups.0.disk.0.allocation_mb", "6144"),
 					resource.TestCheckResourceAttr(name, "allowlist.#", "2"),
 					resource.TestCheckResourceAttr(name, "users.#", "2"),
@@ -69,7 +69,7 @@ func TestAccIBMDatabaseInstance_Rabbitmq_Basic(t *testing.T) {
 					resource.TestCheckResourceAttr(name, "service", "messages-for-rabbitmq"),
 					resource.TestCheckResourceAttr(name, "plan", "standard"),
 					resource.TestCheckResourceAttr(name, "location", acc.Region()),
-					resource.TestCheckResourceAttr(name, "groups.0.memory.0.allocation_mb", "3072"),
+					resource.TestCheckResourceAttr(name, "groups.0.memory.0.allocation_mb", "24576"),
 					resource.TestCheckResourceAttr(name, "groups.0.disk.0.allocation_mb", "6144"),
 					resource.TestCheckResourceAttr(name, "allowlist.#", "0"),
 					resource.TestCheckResourceAttr(name, "users.#", "0"),
@@ -140,7 +140,7 @@ func testAccCheckIBMDatabaseInstanceRabbitmqBasic(databaseResourceGroup string, 
 		group {
 			group_id = "member"
 			memory {
-				allocation_mb = 1024
+				allocation_mb = 8192
 			}
 			host_flavor {
 				id = "multitenant"
@@ -183,7 +183,7 @@ func testAccCheckIBMDatabaseInstanceRabbitmqFullyspecified(databaseResourceGroup
 		group {
 			group_id = "member"
 			memory {
-				allocation_mb = 2048
+				allocation_mb = 10240
 			}
 			host_flavor {
 				id = "multitenant"
@@ -230,7 +230,7 @@ func testAccCheckIBMDatabaseInstanceRabbitmqReduced(databaseResourceGroup string
 		group {
 			group_id = "member"
 			memory {
-				allocation_mb = 1024
+				allocation_mb = 8192
 			}
 			host_flavor {
 				id = "multitenant"

--- a/ibm/service/database/resource_ibm_database_redis_test.go
+++ b/ibm/service/database/resource_ibm_database_redis_test.go
@@ -36,7 +36,7 @@ func TestAccIBMDatabaseInstance_Redis_Basic(t *testing.T) {
 					resource.TestCheckResourceAttr(name, "plan", "standard"),
 					resource.TestCheckResourceAttr(name, "location", acc.Region()),
 					resource.TestCheckResourceAttr(name, "adminuser", "admin"),
-					resource.TestCheckResourceAttr(name, "groups.0.memory.0.allocation_mb", "2048"),
+					resource.TestCheckResourceAttr(name, "groups.0.memory.0.allocation_mb", "8192"),
 					resource.TestCheckResourceAttr(name, "groups.0.disk.0.allocation_mb", "2048"),
 					resource.TestCheckResourceAttr(name, "allowlist.#", "1"),
 					resource.TestCheckResourceAttr(name, "connectionstrings.#", "1"),
@@ -52,7 +52,7 @@ func TestAccIBMDatabaseInstance_Redis_Basic(t *testing.T) {
 					resource.TestCheckResourceAttr(name, "service", "databases-for-redis"),
 					resource.TestCheckResourceAttr(name, "plan", "standard"),
 					resource.TestCheckResourceAttr(name, "location", acc.Region()),
-					resource.TestCheckResourceAttr(name, "groups.0.memory.0.allocation_mb", "2304"),
+					resource.TestCheckResourceAttr(name, "groups.0.memory.0.allocation_mb", "10240"),
 					resource.TestCheckResourceAttr(name, "groups.0.disk.0.allocation_mb", "4096"),
 					resource.TestCheckResourceAttr(name, "allowlist.#", "2"),
 				),
@@ -65,7 +65,7 @@ func TestAccIBMDatabaseInstance_Redis_Basic(t *testing.T) {
 					resource.TestCheckResourceAttr(name, "plan", "standard"),
 					resource.TestCheckResourceAttr(name, "location", acc.Region()),
 					resource.TestCheckResourceAttr(name, "allowlist.#", "0"),
-					resource.TestCheckResourceAttr(name, "groups.0.memory.0.allocation_mb", "2048"),
+					resource.TestCheckResourceAttr(name, "groups.0.memory.0.allocation_mb", "8192"),
 					resource.TestCheckResourceAttr(name, "groups.0.disk.0.allocation_mb", "4096"),
 				),
 			},
@@ -173,7 +173,7 @@ func testAccCheckIBMDatabaseInstanceRedisBasic(databaseResourceGroup string, nam
 		group {
 			group_id = "member"
 			memory {
-				allocation_mb = 1024
+				allocation_mb = 4096
 			}
 			host_flavor {
 				id = "multitenant"
@@ -216,7 +216,7 @@ func testAccCheckIBMDatabaseInstanceRedisFullyspecified(databaseResourceGroup st
 		group {
 			group_id = "member"
 			memory {
-				allocation_mb = 1152
+				allocation_mb = 5120
 			}
 			host_flavor {
 				id = "multitenant"
@@ -254,7 +254,7 @@ func testAccCheckIBMDatabaseInstanceRedisReduced(databaseResourceGroup string, n
 		group {
 			group_id = "member"
 			memory {
-				allocation_mb = 1024
+				allocation_mb = 4096
 			}
 			host_flavor {
 				id = "multitenant"
@@ -285,7 +285,7 @@ func testAccCheckIBMDatabaseInstanceRedisUserRole(databaseResourceGroup string, 
 			group_id = "member"
 
 			memory {
-				allocation_mb = 1024
+				allocation_mb = 8192
 			}
 			host_flavor {
 				id = "multitenant"


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/IBM-Cloud/terraform-provider-ibm/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

# Testing Done

## Provisioning with Redis

#### Provisioning multitenant Redis with insufficient memory
```
data "ibm_resource_group" "group" {
  name = "default"
}

resource "ibm_database" "test_acc" {
  resource_group_id = data.ibm_resource_group.group.id
  name              = "min-compute-redis-03-13-two"
  service           = "databases-for-redis"
  plan              = "standard"
  location          = "us-south"
  adminpassword     = "password123456789"
  group {
    group_id = "member"
    memory {
      allocation_mb = 1024
    }
    host_flavor {
      id = "multitenant"
    }
  }
  tags              = ["one:two"]
  users {
    name     = "user123"
    password = "password123456789"
  }
}
```


```
terraform plan
╷
│ Warning: Provider development overrides are in effect
│ 
│ The following provider development overrides are set in the CLI configuration:
│  - ibm-cloud/ibm in /Users/omar/.go/bin
│ 
│ The behavior may therefore not match any released version of the provider and applying changes may cause the state to become incompatible with published releases.
╵
data.ibm_resource_group.group: Reading...
data.ibm_resource_group.group: Read complete after 1s [id=eb922ba0717f47589ca26d202c5cc915]

Planning failed. Terraform encountered an error while generating this plan.

╷
│ Error: 1 error occurred:
│ 	* We were unable to complete your request: group.memory requires a minimum of 4096 megabytes. Try again with valid values or contact support if the issue persists.
│ 
│ 
│ 
│   with ibm_database.test_acc,
│   on main.tf line 5, in resource "ibm_database" "test_acc":
│    5: resource "ibm_database" "test_acc" {
```

#### Provisioning multitenant Redis with below-ratio memory
```
data "ibm_resource_group" "group" {
  name = "default"
}

resource "ibm_database" "test_acc" {
  resource_group_id = data.ibm_resource_group.group.id
  name              = "min-compute-redis-03-13-two"
  service           = "databases-for-redis"
  plan              = "standard"
  location          = "us-south"
  adminpassword     = "password123456789"
  group {
    group_id = "member"
    memory {
      allocation_mb = 5120
    }
    host_flavor {
      id = "multitenant"
    }
    cpu {
      allocation_count = 2
    }
  }
  tags              = ["one:two"]
  users {
    name     = "user123"
    password = "password123456789"
  }
}
```

```
terraform plan
╷
│ Warning: Provider development overrides are in effect
│ 
│ The following provider development overrides are set in the CLI configuration:
│  - ibm-cloud/ibm in /Users/omar/.go/bin
│ 
│ The behavior may therefore not match any released version of the provider and applying changes may cause the state to become incompatible with published releases.
╵
data.ibm_resource_group.group: Reading...
data.ibm_resource_group.group: Read complete after 1s [id=eb922ba0717f47589ca26d202c5cc915]

Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  + create

Terraform will perform the following actions:

  # ibm_database.test_acc will be created
  + resource "ibm_database" "test_acc" {
      + adminpassword           = (sensitive value)
      + adminuser               = (known after apply)
      + configuration_schema    = (known after apply)
      + connectionstrings       = (known after apply)
      + groups                  = (known after apply)
      + guid                    = (known after apply)
      + id                      = (known after apply)
      + location                = "us-south"
      + name                    = "min-compute-redis-03-13-two"
      + plan                    = "standard"
      + resource_controller_url = (known after apply)
      + resource_crn            = (known after apply)
      + resource_group_id       = "eb922ba0717f47589ca26d202c5cc915"
      + resource_group_name     = (known after apply)
      + resource_name           = (known after apply)
      + resource_status         = (known after apply)
      + service                 = "databases-for-redis"
      + service_endpoints       = "public"
      + status                  = (known after apply)
      + tags                    = [
          + "one:two",
        ]
      + version                 = (known after apply)

      + group {
          + group_id = "member"

          + cpu {
              + allocation_count = 2
            }

          + host_flavor {
              + id = "multitenant"
            }

          + memory {
              + allocation_mb = 5120
            }
        }

      + users {
          # At least one attribute in this block is (or was) sensitive,
          # so its contents will not be displayed.
        }
    }

Plan: 1 to add, 0 to change, 0 to destroy.
```
#### Provisioning multitenant Redis with exact-ratio memory
```
data "ibm_resource_group" "group" {
  name = "default"
}

resource "ibm_database" "test_acc" {
  resource_group_id = data.ibm_resource_group.group.id
  name              = "min-compute-redis-03-13-two"
  service           = "databases-for-redis"
  plan              = "standard"
  location          = "us-south"
  adminpassword     = "password123456789"
  group {
    group_id = "member"
    memory {
      allocation_mb = 8192
    }
    host_flavor {
      id = "multitenant"
    }
    cpu {
      allocation_count = 2
    }
  }
  tags              = ["one:two"]
  users {
    name     = "user123"
    password = "password123456789"
  }
}
```

```
terraform plan
╷
│ Warning: Provider development overrides are in effect
│ 
│ The following provider development overrides are set in the CLI configuration:
│  - ibm-cloud/ibm in /Users/omar/.go/bin
│ 
│ The behavior may therefore not match any released version of the provider and applying changes may cause the state to become incompatible with published releases.
╵
data.ibm_resource_group.group: Reading...
data.ibm_resource_group.group: Read complete after 1s [id=eb922ba0717f47589ca26d202c5cc915]

Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  + create

Terraform will perform the following actions:

  # ibm_database.test_acc will be created
  + resource "ibm_database" "test_acc" {
      + adminpassword           = (sensitive value)
      + adminuser               = (known after apply)
      + configuration_schema    = (known after apply)
      + connectionstrings       = (known after apply)
      + groups                  = (known after apply)
      + guid                    = (known after apply)
      + id                      = (known after apply)
      + location                = "us-south"
      + name                    = "min-compute-redis-03-13-two"
      + plan                    = "standard"
      + resource_controller_url = (known after apply)
      + resource_crn            = (known after apply)
      + resource_group_id       = "eb922ba0717f47589ca26d202c5cc915"
      + resource_group_name     = (known after apply)
      + resource_name           = (known after apply)
      + resource_status         = (known after apply)
      + service                 = "databases-for-redis"
      + service_endpoints       = "public"
      + status                  = (known after apply)
      + tags                    = [
          + "one:two",
        ]
      + version                 = (known after apply)

      + group {
          + group_id = "member"

          + cpu {
              + allocation_count = 2
            }

          + host_flavor {
              + id = "multitenant"
            }

          + memory {
              + allocation_mb = 8192
            }
        }

      + users {
          # At least one attribute in this block is (or was) sensitive,
          # so its contents will not be displayed.
        }
    }

Plan: 1 to add, 0 to change, 0 to destroy.
```
#### Provisioning multitenant Redis with Invalid Ratio
```
data "ibm_resource_group" "group" {
  name = "default"
}

resource "ibm_database" "test_acc" {
  resource_group_id = data.ibm_resource_group.group.id
  name              = "min-compute-redis-03-13-two"
  service           = "databases-for-redis"
  plan              = "standard"
  location          = "us-south"
  adminpassword     = "password123456789"
  group {
    group_id = "member"
    memory {
      allocation_mb = 8704
    }
    host_flavor {
      id = "multitenant"
    }
    cpu {
      allocation_count = 1
    }
  }
  tags              = ["one:two"]
  users {
    name     = "user123"
    password = "password123456789"
  }
}
```

```
terraform plan
╷
│ Warning: Provider development overrides are in effect
│ 
│ The following provider development overrides are set in the CLI configuration:
│  - ibm-cloud/ibm in /Users/omar/.go/bin
│ 
│ The behavior may therefore not match any released version of the provider and applying changes may cause the state to become incompatible with published releases.
╵
data.ibm_resource_group.group: Reading...
data.ibm_resource_group.group: Read complete after 1s [id=eb922ba0717f47589ca26d202c5cc915]

Planning failed. Terraform encountered an error while generating this plan.

╷
│ Error: 1 error occurred:
│ 	* The current cpu alloaction of 1 is not valid for your current configuration.
│ 
│ 
│ 
│   with ibm_database.test_acc,
│   on main.tf line 5, in resource "ibm_database" "test_acc":
│    5: resource "ibm_database" "test_acc" {
│ 
```

## Provisioning with RabbitMQ

#### Provisioning multitenant RabbitMQ with insufficient memory
```
data "ibm_resource_group" "group" {
  name = "default"
}

resource "ibm_database" "test_acc" {
  resource_group_id = data.ibm_resource_group.group.id
  name              = "min-compute-rabbitmq-03-13-two"
  service           = "messages-for-rabbitmq"
  plan              = "standard"
  location          = "us-south"
  adminpassword     = "password123456789"
  group {
    group_id = "member"
    memory {
      allocation_mb = 1024
    }
    host_flavor {
      id = "multitenant"
    }
  }
  tags              = ["one:two"]
  users {
    name     = "user123"
    password = "password123456789"
  }
}
```


```
terraform plan
╷
│ Warning: Provider development overrides are in effect
│ 
│ The following provider development overrides are set in the CLI configuration:
│  - ibm-cloud/ibm in /Users/omar/.go/bin
│ 
│ The behavior may therefore not match any released version of the provider and applying changes may cause the state to become incompatible with published releases.
╵
data.ibm_resource_group.group: Reading...
data.ibm_resource_group.group: Read complete after 2s [id=eb922ba0717f47589ca26d202c5cc915]

Planning failed. Terraform encountered an error while generating this plan.

╷
│ Error: 1 error occurred:
│ 	* member group memory must be >= 8192 and <= 114688 in increments of 128
│ 
│ 
│ 
│   with ibm_database.test_acc,
│   on main.tf line 5, in resource "ibm_database" "test_acc":
│    5: resource "ibm_database" "test_acc" {
│ 
```

## Scaling

#### Scaling non-multitenant to multitenant
##### Initial Non-Multitenant Formation
```
data "ibm_resource_group" "group" {
  name = "default"
}

resource "ibm_database" "test_acc" {
  resource_group_id = data.ibm_resource_group.group.id
  name              = "min-compute-redis-03-22-four"
  service           = "databases-for-redis"
  plan              = "standard"
  location          = "us-south"
  adminpassword     = "password123456789"
  group {
    group_id = "member"
    memory {
      allocation_mb = 1024
    }
  }
  tags              = ["one:two"]
  users {
    name     = "user123"
    password = "password123456789"
  }
}
```

##### Convert to Multitenant Formation with Invalid CPU Ratio
```
data "ibm_resource_group" "group" {
  name = "default"
}

resource "ibm_database" "test_acc" {
  resource_group_id = data.ibm_resource_group.group.id
  name              = "min-compute-redis-03-22-four"
  service           = "databases-for-redis"
  plan              = "standard"
  location          = "us-south"
  adminpassword     = "password123456789"
  group {
    group_id = "member"
    memory {
      allocation_mb = 1024
    }
    host_flavor {
      id = "multitenant"
    }
    cpu {
      allocation_count = 1
    }
  }
  tags              = ["one:two"]
  users {
    name     = "user123"
    password = "password123456789"
  }
}
```

##### Result
```
Planning failed. Terraform encountered an error while generating this plan.

╷
│ Error: 1 error occurred:
│ 	* The current cpu alloaction of 1 is not valid for your current configuration.
│ 
│ 
│ 
│   with ibm_database.test_acc,
│   on main.tf line 5, in resource "ibm_database" "test_acc":
│    5: resource "ibm_database" "test_acc" {
│ 
```

##### Convert to Multitenant Formation
```
data "ibm_resource_group" "group" {
  name = "default"
}

resource "ibm_database" "test_acc" {
  resource_group_id = data.ibm_resource_group.group.id
  name              = "min-compute-redis-03-22-four"
  service           = "databases-for-redis"
  plan              = "standard"
  location          = "us-south"
  adminpassword     = "password123456789"
  group {
    group_id = "member"
    memory {
      allocation_mb = 1024
    }
    host_flavor {
      id = "multitenant"
    }
  }
  tags              = ["one:two"]
  users {
    name     = "user123"
    password = "password123456789"
  }
}
```

##### Result
```
data "ibm_resource_group" "group" {
  name = "default"
}

resource "ibm_database" "test_acc" {
  resource_group_id = data.ibm_resource_group.group.id
  name              = "min-compute-redis-03-22-four"
  service           = "databases-for-redis"
  plan              = "standard"
  location          = "us-south"
  adminpassword     = "password123456789"
  group {
    group_id = "member"
    memory {
      allocation_mb = 1024
    }
    host_flavor {
      id = "multitenant"
    }
  }
  tags              = ["one:two"]
  users {
    name     = "user123"
    password = "password123456789"
  }
}
```

##### Scale Multitenant Formation Below Acceptable Memory
```
data "ibm_resource_group" "group" {
  name = "default"
}

resource "ibm_database" "test_acc" {
  resource_group_id = data.ibm_resource_group.group.id
  name              = "min-compute-redis-03-22-four"
  service           = "databases-for-redis"
  plan              = "standard"
  location          = "us-south"
  adminpassword     = "password123456789"
  group {
    group_id = "member"
    memory {
      allocation_mb = 2048
    }
    host_flavor {
      id = "multitenant"
    }
  }
  tags              = ["one:two"]
  users {
    name     = "user123"
    password = "password123456789"
  }
}
```

##### Result
```
Planning failed. Terraform encountered an error while generating this plan.

╷
│ Error: 1 error occurred:
│ 	* member group memory must be >= 4096 and <= 114688 in increments of 128
│ 
│ 
│ 
│   with ibm_database.test_acc,
│   on main.tf line 5, in resource "ibm_database" "test_acc":
│    5: resource "ibm_database" "test_acc" {
```

##### Scale Multitenant Formation With Acceptable Memory
```
data "ibm_resource_group" "group" {
  name = "default"
}

resource "ibm_database" "test_acc" {
  resource_group_id = data.ibm_resource_group.group.id
  name              = "min-compute-redis-03-22-four"
  service           = "databases-for-redis"
  plan              = "standard"
  location          = "us-south"
  adminpassword     = "password123456789"
  group {
    group_id = "member"
    memory {
      allocation_mb = 4096
    }
    host_flavor {
      id = "multitenant"
    }
  }
  tags              = ["one:two"]
  users {
    name     = "user123"
    password = "password123456789"
  }
}
```

##### Result
```
Apply complete! Resources: 0 added, 1 changed, 0 destroyed.
```

## Acceptance Test
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TEST=./ibm/service/database TESTARGS='-run=TestAccIBMDatabaseInstance_Redis_Basic'
--- PASS: TestAccIBMDatabaseInstance_Redis_Basic (824.23s)
PASS
ok  	github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/database	825.700s
...
```

```
--- PASS: TestAccIBMDatabaseInstanceMongodbBasic (1304.27s)
PASS
ok  	github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/database	1305.719s
```

```
--- PASS: TestAccIBMDatabaseInstance_Rabbitmq_Basic (1522.74s)
PASS
ok  	github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/database	1524.222s
```

```
--- PASS: TestAccIBMDatabaseInstance_Elasticsearch_Basic (953.96s)
PASS
ok  	github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/database	956.385s
```

```
--- PASS: TestAccIBMDatabaseInstance_ElasticsearchPlatinum_Basic (1658.71s)
PASS
ok  	github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/database	1659.985s
```

```
--- PASS: TestAccIBMDatabaseInstance_Etcd_Basic (2848.54s)
PASS
ok  	github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/database	2849.976s
```

```
--- PASS: TestAccIBMMysqlDatabaseInstanceBasic (838.18s)
PASS
ok  	github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/database	839.679s
```

```
--- PASS: TestAccIBMCassandraDatabaseInstanceBasic (2222.69s)
PASS
ok  	github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/database	2223.982s
```

```
--- PASS: TestAccIBMMongoDBEnterpriseDatabaseInstanceBasic (6331.87s)
PASS
ok  	github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/database	6333.160s
```