### PR TITLE
feat: use new standardized structures for errors

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,7 @@ require (
 	github.com/IBM/event-notifications-go-admin-sdk v0.4.0
 	github.com/IBM/eventstreams-go-sdk v1.4.0
 	github.com/IBM/go-sdk-core/v3 v3.2.4
-	github.com/IBM/go-sdk-core/v5 v5.16.1
+	github.com/IBM/go-sdk-core/v5 v5.16.2
 	github.com/IBM/ibm-cos-sdk-go v1.10.0
 	github.com/IBM/ibm-cos-sdk-go-config v1.2.0
 	github.com/IBM/ibm-hpcs-tke-sdk v0.0.0-20211109141421-a4b61b05f7d1
@@ -64,6 +64,7 @@ require (
 require (
 	github.com/IBM/mqcloud-go-sdk v0.0.4
 	github.com/IBM/sarama v1.41.2
+	github.com/stretchr/testify v1.8.4
 	k8s.io/utils v0.0.0-20230313181309-38a27ef9d749
 	sigs.k8s.io/controller-runtime v0.14.1
 )
@@ -197,7 +198,6 @@ require (
 	github.com/softlayer/xmlrpc v0.0.0-20200409220501-5f089df7cb7e // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/stretchr/objx v0.5.0 // indirect
-	github.com/stretchr/testify v1.8.4 // indirect
 	github.com/vmihailenco/msgpack v4.0.4+incompatible // indirect
 	github.com/vmihailenco/msgpack/v5 v5.3.5 // indirect
 	github.com/vmihailenco/tagparser/v2 v2.0.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -140,8 +140,8 @@ github.com/IBM/go-sdk-core/v5 v5.7.0/go.mod h1:+YbdhrjCHC84ls4MeBp+Hj4NZCni+tDAc
 github.com/IBM/go-sdk-core/v5 v5.9.2/go.mod h1:YlOwV9LeuclmT/qi/LAK2AsobbAP42veV0j68/rlZsE=
 github.com/IBM/go-sdk-core/v5 v5.9.5/go.mod h1:YlOwV9LeuclmT/qi/LAK2AsobbAP42veV0j68/rlZsE=
 github.com/IBM/go-sdk-core/v5 v5.10.2/go.mod h1:WZPFasUzsKab/2mzt29xPcfruSk5js2ywAPwW4VJjdI=
-github.com/IBM/go-sdk-core/v5 v5.16.1 h1:vAgOxRvaXD5AmgwR7dlstjT1JFE4BA4lPcGsEFZOKGs=
-github.com/IBM/go-sdk-core/v5 v5.16.1/go.mod h1:aojBkkq4HXkOYdn7YZ6ve8cjPWHdcB3tt8v0b9Cbac8=
+github.com/IBM/go-sdk-core/v5 v5.16.2 h1:4psKDqjN6mPacgbaRjV/qcYtXlnAEISLJF/QQa7FQqo=
+github.com/IBM/go-sdk-core/v5 v5.16.2/go.mod h1:aojBkkq4HXkOYdn7YZ6ve8cjPWHdcB3tt8v0b9Cbac8=
 github.com/IBM/ibm-cos-sdk-go v1.3.1/go.mod h1:YLBAYobEA8bD27P7xpMwSQeNQu6W3DNBtBComXrRzRY=
 github.com/IBM/ibm-cos-sdk-go v1.10.0 h1:/2VIev2/jBei39OqU2+nSZQnoWJ+KtkiSAIDkqsd7uU=
 github.com/IBM/ibm-cos-sdk-go v1.10.0/go.mod h1:C8KRTRaoD3CWPPBOa6FCOpdh0ZMlUjKAAA4i3F+Q/sc=

--- a/ibm/flex/terraform_problem_test.go
+++ b/ibm/flex/terraform_problem_test.go
@@ -1,0 +1,213 @@
+package flex
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/IBM/go-sdk-core/v5/core"
+	"github.com/stretchr/testify/assert"
+)
+
+const (
+	MODULE_NAME  = "github.com/IBM-Cloud/terraform-provider-ibm"
+	MOCK_VERSION = "1.63.0"
+)
+
+func TestTerraformProblemEmbedsIBMProblem(t *testing.T) {
+	terraformProb := &TerraformProblem{}
+
+	// Check that the methods defined by IBMProblem are supported here.
+	assert.NotNil(t, terraformProb.Error)
+	assert.NotNil(t, terraformProb.GetBaseSignature)
+	assert.NotNil(t, terraformProb.GetCausedBy)
+	assert.NotNil(t, terraformProb.Unwrap)
+}
+
+func TestTerraformProblemGetConsoleMessage(t *testing.T) {
+	terraformProb := getPopulatedTerraformProblem()
+	message := terraformProb.GetConsoleMessage()
+	expected := `---
+id: terraform-98c0e1fd
+summary: Create failed.
+severity: error
+resource: ibm_some_resource
+operation: create
+component:
+  name: github.com/IBM-Cloud/terraform-provider-ibm
+  version: 1.63.0
+---
+`
+	assert.Equal(t, expected, message)
+}
+
+func TestTerraformProblemGetDebugMessage(t *testing.T) {
+	terraformProb := getPopulatedTerraformProblem()
+	message := terraformProb.GetDebugMessage()
+	expected := `---
+id: terraform-98c0e1fd
+summary: Create failed.
+severity: error
+resource: ibm_some_resource
+operation: create
+component:
+  name: github.com/IBM-Cloud/terraform-provider-ibm
+  version: 1.63.0
+---
+`
+	assert.Equal(t, expected, message)
+}
+
+func TestTerraformProblemGetID(t *testing.T) {
+	terraformProb := getPopulatedTerraformProblem()
+	assert.Equal(t, "terraform-98c0e1fd", terraformProb.GetID())
+}
+
+func TestTerraformProblemGetConsoleOrderedMaps(t *testing.T) {
+	terraformProb := getPopulatedTerraformProblem()
+	orderedMaps := terraformProb.GetConsoleOrderedMaps()
+	assert.NotNil(t, orderedMaps)
+
+	maps := orderedMaps.GetMaps()
+	assert.NotNil(t, maps)
+	assert.Len(t, maps, 6)
+
+	assert.Equal(t, "id", maps[0].Key)
+	assert.Equal(t, "terraform-98c0e1fd", maps[0].Value)
+
+	assert.Equal(t, "summary", maps[1].Key)
+	assert.Equal(t, "Create failed.", maps[1].Value)
+
+	assert.Equal(t, "severity", maps[2].Key)
+	assert.Equal(t, core.ErrorSeverity, maps[2].Value)
+
+	assert.Equal(t, "resource", maps[3].Key)
+	assert.Equal(t, "ibm_some_resource", maps[3].Value)
+
+	assert.Equal(t, "operation", maps[4].Key)
+	assert.Equal(t, "create", maps[4].Value)
+
+	assert.Equal(t, "component", maps[5].Key)
+	assert.Equal(t, MODULE_NAME, maps[5].Value.(*core.ProblemComponent).Name)
+	assert.Equal(t, MOCK_VERSION, maps[5].Value.(*core.ProblemComponent).Version)
+}
+
+func TestTerraformProblemGetDebugOrderedMaps(t *testing.T) {
+	terraformProb := getPopulatedTerraformProblem()
+	orderedMaps := terraformProb.GetDebugOrderedMaps()
+	assert.NotNil(t, orderedMaps)
+
+	maps := orderedMaps.GetMaps()
+	assert.NotNil(t, maps)
+	assert.Len(t, maps, 6)
+
+	assert.Equal(t, "id", maps[0].Key)
+	assert.Equal(t, "terraform-98c0e1fd", maps[0].Value)
+
+	assert.Equal(t, "summary", maps[1].Key)
+	assert.Equal(t, "Create failed.", maps[1].Value)
+
+	assert.Equal(t, "severity", maps[2].Key)
+	assert.Equal(t, core.ErrorSeverity, maps[2].Value)
+
+	assert.Equal(t, "resource", maps[3].Key)
+	assert.Equal(t, "ibm_some_resource", maps[3].Value)
+
+	assert.Equal(t, "operation", maps[4].Key)
+	assert.Equal(t, "create", maps[4].Value)
+
+	assert.Equal(t, "component", maps[5].Key)
+	assert.Equal(t, MODULE_NAME, maps[5].Value.(*core.ProblemComponent).Name)
+	assert.Equal(t, MOCK_VERSION, maps[5].Value.(*core.ProblemComponent).Version)
+}
+
+func TestTerraformProblemGetDiag(t *testing.T) {
+	terraformProb := getPopulatedTerraformProblem()
+	diagnostics := terraformProb.GetDiag()
+
+	assert.True(t, diagnostics.HasError())
+	assert.Len(t, diagnostics, 1)
+
+	diagnostic := diagnostics[0]
+	assert.Nil(t, diagnostic.Validate())
+	assert.Equal(t, terraformProb.GetConsoleMessage(), diagnostic.Summary)
+}
+
+func TestTerraformErrorf(t *testing.T) {
+	causedBy := &core.SDKProblem{}
+	summary := "Update failed."
+	resourceName := "ibm_some_resource"
+	operation := "update"
+
+	terraformProb := TerraformErrorf(causedBy, summary, resourceName, operation)
+	assert.NotNil(t, terraformProb)
+	assert.Equal(t, summary, terraformProb.Summary)
+	assert.Equal(t, getComponentInfo(), terraformProb.Component)
+	assert.Equal(t, core.ErrorSeverity, terraformProb.Severity)
+}
+
+func TestFmtErrorfWithProblem(t *testing.T) {
+	msg := "Request failed."
+	sdkProb := &core.SDKProblem{
+		IBMProblem: &core.IBMProblem{
+			Summary: msg,
+		},
+	}
+
+	err := FmtErrorf("Operation failed: %s", sdkProb)
+
+	var errAsProb *core.SDKProblem
+	assert.True(t, errors.As(err, &errAsProb))
+	assert.NotNil(t, errAsProb)
+	assert.Equal(t, msg, errAsProb.Summary)
+}
+
+func TestFmtErrorfWithNoError(t *testing.T) {
+	msg := "Bad input"
+	err := FmtErrorf("Operation failed: %s", msg)
+	assert.Equal(t, "Operation failed: Bad input", err.Error())
+	assert.Equal(t, fmt.Errorf("Operation failed: %s", msg).Error(), err.Error())
+
+	var errAsProb core.Problem
+	assert.False(t, errors.As(err, &errAsProb))
+	assert.Nil(t, errAsProb)
+}
+
+func TestFmtErrorfWithProblemInServiceErrorResponse(t *testing.T) {
+	msg := "Request failed."
+	sdkProb := &core.SDKProblem{
+		IBMProblem: &core.IBMProblem{
+			Summary: msg,
+		},
+	}
+
+	ser := &ServiceErrorResponse{
+		Error: sdkProb,
+	}
+
+	err := FmtErrorf("Operation failed: %s", ser)
+
+	var errAsProb *core.SDKProblem
+	assert.True(t, errors.As(err, &errAsProb))
+	assert.NotNil(t, errAsProb)
+	assert.Equal(t, msg, errAsProb.Summary)
+}
+
+func TestGetComponentInfo(t *testing.T) {
+	component := getComponentInfo()
+	assert.NotNil(t, component)
+	assert.Equal(t, MODULE_NAME, component.Name)
+	assert.Equal(t, "0.0.1", component.Version)
+}
+
+func getPopulatedTerraformProblem() *TerraformProblem {
+	return &TerraformProblem{
+		IBMProblem: &core.IBMProblem{
+			Summary:   "Create failed.",
+			Component: core.NewProblemComponent(MODULE_NAME, MOCK_VERSION),
+			Severity:  core.ErrorSeverity,
+		},
+		Resource:  "ibm_some_resource",
+		Operation: "create",
+	}
+}

--- a/ibm/provider/provider.go
+++ b/ibm/provider/provider.go
@@ -4,11 +4,16 @@
 package provider
 
 import (
+	"context"
+	"errors"
+	"fmt"
+	"log"
 	"os"
 	"sync"
 	"time"
 
 	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/conns"
+	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/flex"
 	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/apigateway"
 	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/appconfiguration"
 	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/appid"
@@ -55,12 +60,14 @@ import (
 	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/usagereports"
 	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/vpc"
 	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/validate"
+	"github.com/IBM/go-sdk-core/v5/core"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
 // Provider returns a *schema.Provider.
 func Provider() *schema.Provider {
-	return &schema.Provider{
+	provider := schema.Provider{
 		Schema: map[string]*schema.Schema{
 			"bluemix_api_key": {
 				Type:        schema.TypeString,
@@ -1438,6 +1445,148 @@ func Provider() *schema.Provider {
 
 		ConfigureFunc: providerConfigure,
 	}
+
+	wrappedProvider := wrapProvider(provider)
+	return &wrappedProvider
+}
+
+func wrapProvider(provider schema.Provider) schema.Provider {
+	wrappedResourcesMap := map[string]*schema.Resource{}
+	wrappedDataSourcesMap := map[string]*schema.Resource{}
+
+	for key, value := range provider.ResourcesMap {
+		wrappedResourcesMap[key] = wrapResource(key, value)
+	}
+
+	for key, value := range provider.DataSourcesMap {
+		wrappedDataSourcesMap[key] = wrapDataSource(key, value)
+	}
+
+	return schema.Provider{
+		Schema:         provider.Schema,
+		DataSourcesMap: wrappedDataSourcesMap,
+		ResourcesMap:   wrappedResourcesMap,
+		ConfigureFunc:  provider.ConfigureFunc,
+	}
+}
+
+func wrapResource(name string, resource *schema.Resource) *schema.Resource {
+	return &schema.Resource{
+		Schema:               resource.Schema,
+		SchemaVersion:        resource.SchemaVersion,
+		MigrateState:         resource.MigrateState,
+		StateUpgraders:       resource.StateUpgraders,
+		Exists:               resource.Exists,
+		CreateContext:        wrapFunction(name, "create", resource.CreateContext, resource.Create, false),
+		ReadContext:          wrapFunction(name, "read", resource.ReadContext, resource.Read, false),
+		UpdateContext:        wrapFunction(name, "update", resource.UpdateContext, resource.Update, false),
+		DeleteContext:        wrapFunction(name, "delete", resource.DeleteContext, resource.Delete, false),
+		CreateWithoutTimeout: wrapFunction(name, "create", resource.CreateWithoutTimeout, nil, false),
+		ReadWithoutTimeout:   wrapFunction(name, "read", resource.ReadWithoutTimeout, nil, false),
+		UpdateWithoutTimeout: wrapFunction(name, "update", resource.UpdateWithoutTimeout, nil, false),
+		DeleteWithoutTimeout: wrapFunction(name, "delete", resource.DeleteWithoutTimeout, nil, false),
+		CustomizeDiff:        wrapCustomizeDiff(name, resource.CustomizeDiff),
+		Importer:             resource.Importer,
+		DeprecationMessage:   resource.DeprecationMessage,
+		Timeouts:             resource.Timeouts,
+		Description:          resource.Description,
+		UseJSONNumber:        resource.UseJSONNumber,
+	}
+}
+
+func wrapDataSource(name string, resource *schema.Resource) *schema.Resource {
+	return &schema.Resource{
+		Schema:             resource.Schema,
+		SchemaVersion:      resource.SchemaVersion,
+		MigrateState:       resource.MigrateState,
+		StateUpgraders:     resource.StateUpgraders,
+		Exists:             resource.Exists,
+		ReadContext:        wrapFunction(name, "read", resource.ReadContext, resource.Read, true),
+		ReadWithoutTimeout: wrapFunction(name, "read", resource.ReadWithoutTimeout, nil, true),
+		Importer:           resource.Importer,
+		DeprecationMessage: resource.DeprecationMessage,
+		Timeouts:           resource.Timeouts,
+		Description:        resource.Description,
+		UseJSONNumber:      resource.UseJSONNumber,
+	}
+}
+
+func wrapFunction(
+	resourceName, operationName string,
+	function func(context.Context, *schema.ResourceData, interface{}) diag.Diagnostics,
+	fallback func(*schema.ResourceData, interface{}) error,
+	isDataSource bool,
+) func(context.Context, *schema.ResourceData, interface{}) diag.Diagnostics {
+	if function != nil {
+		return func(context context.Context, schema *schema.ResourceData, meta interface{}) diag.Diagnostics {
+			return function(context, schema, meta)
+		}
+	} else if fallback != nil {
+		return func(context context.Context, schema *schema.ResourceData, meta interface{}) diag.Diagnostics {
+			return wrapError(fallback(schema, meta), resourceName, operationName, isDataSource)
+		}
+	}
+
+	return nil
+}
+
+func wrapError(err error, resourceName, operationName string, isDataSource bool) diag.Diagnostics {
+	var diags diag.Diagnostics
+
+	if err != nil {
+		// Distinguish data sources from resources. Data sources technically are resources but
+		// they may have the same names and we need to tell them apart.
+		if isDataSource {
+			resourceName = fmt.Sprintf("(Data) %s", resourceName)
+		}
+		tfError := flex.TerraformErrorf(err, "", resourceName, operationName)
+		log.Printf("[DEBUG] %s", tfError.GetDebugMessage())
+		return append(
+			diags,
+			diag.Diagnostic{
+				Severity: diag.Error,
+				Summary:  tfError.Error(),
+				Detail:   tfError.GetConsoleMessage(),
+			},
+		)
+	}
+
+	return nil
+}
+
+func wrapCustomizeDiff(resourceName string, function schema.CustomizeDiffFunc) schema.CustomizeDiffFunc {
+	if function == nil {
+		return nil
+	}
+
+	return func(c context.Context, rd *schema.ResourceDiff, i interface{}) error {
+		return wrapDiffErrors(function(c, rd, i), resourceName)
+	}
+}
+
+func wrapDiffErrors(err error, resourceName string) error {
+	if err != nil {
+		// CustomizeDiff fields often use the customizediff.All() method, which concatenates the errors
+		// returned from multiple functions using errors.Join(). Individual errors are still embedded in the
+		// error and can be extracted by unwrapping the error or using errors.As() (which is more convenient).
+		var problem core.Problem
+		if errors.As(err, &problem) {
+			// By the time this error gets printed by the Terraform code, we've lost control of it and the
+			// message that gets printed comes from the Error() method (and we only see the Summary).
+			// Although it would be ideal to return the full TerraformError object, it is sufficient
+			// to package the console message into a new error so that the user gets the information.
+			tfError := flex.TerraformErrorf(problem, "", resourceName, "CustomizeDiff")
+			log.Printf("[DEBUG] %s", tfError.GetDebugMessage())
+			return errors.New(tfError.GetConsoleMessage())
+		}
+
+		tfError := flex.TerraformErrorf(nil, err.Error(), resourceName, "CustomizeDiff")
+		log.Printf("[DEBUG] %s", tfError.GetDebugMessage())
+		return errors.New(tfError.GetConsoleMessage())
+	}
+
+	// Return the nil error.
+	return err
 }
 
 var (

--- a/ibm/service/vpc/data_source_ibm_is_backup_policies.go
+++ b/ibm/service/vpc/data_source_ibm_is_backup_policies.go
@@ -5,7 +5,6 @@ package vpc
 
 import (
 	"context"
-	"fmt"
 	"log"
 	"time"
 
@@ -278,7 +277,7 @@ func dataSourceIBMIsBackupPoliciesRead(context context.Context, d *schema.Resour
 		backupPolicyCollection, response, err := sess.ListBackupPoliciesWithContext(context, listBackupPoliciesOptions)
 		if err != nil {
 			log.Printf("[DEBUG] ListBackupPoliciesWithContext failed %s\n%s", err, response)
-			return diag.FromErr(fmt.Errorf("[ERROR] ListBackupPoliciesWithContext failed %s\n%s", err, response))
+			return diag.FromErr(flex.FmtErrorf("[ERROR] ListBackupPoliciesWithContext failed %s\n%s", err, response))
 		}
 		if backupPolicyCollection != nil && *backupPolicyCollection.TotalCount == int64(0) {
 			break
@@ -299,7 +298,7 @@ func dataSourceIBMIsBackupPoliciesRead(context context.Context, d *schema.Resour
 	if matchBackupPolicies != nil {
 		err = d.Set("backup_policies", dataSourceBackupPolicyCollectionFlattenBackupPolicies(matchBackupPolicies))
 		if err != nil {
-			return diag.FromErr(fmt.Errorf("[ERROR] Error setting backup_policies %s", err))
+			return diag.FromErr(flex.FmtErrorf("[ERROR] Error setting backup_policies %s", err))
 		}
 	}
 

--- a/ibm/service/vpc/data_source_ibm_is_backup_policy.go
+++ b/ibm/service/vpc/data_source_ibm_is_backup_policy.go
@@ -5,7 +5,6 @@ package vpc
 
 import (
 	"context"
-	"fmt"
 	"log"
 
 	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/flex"
@@ -232,7 +231,7 @@ func dataSourceIBMIsBackupPolicyRead(context context.Context, d *schema.Resource
 		backupPolicyInfo, response, err := sess.GetBackupPolicyWithContext(context, getBackupPolicyOptions)
 		if err != nil {
 			log.Printf("[DEBUG] GetBackupPolicyWithContext failed %s\n%s", err, response)
-			return diag.FromErr(fmt.Errorf("[ERROR] GetBackupPolicyWithContext failed %s\n%s", err, response))
+			return diag.FromErr(flex.FmtErrorf("[ERROR] GetBackupPolicyWithContext failed %s\n%s", err, response))
 		}
 		backupPolicy = backupPolicyInfo.(*vpcv1.BackupPolicy)
 
@@ -249,7 +248,7 @@ func dataSourceIBMIsBackupPolicyRead(context context.Context, d *schema.Resource
 			backupPolicyCollection, response, err := sess.ListBackupPoliciesWithContext(context, listBackupPoliciesOptions)
 			if err != nil {
 				log.Printf("[DEBUG] ListBackupPoliciesWithContext failed %s\n%s", err, response)
-				return diag.FromErr(fmt.Errorf("[ERROR] ListBackupPoliciesWithContext failed %s\n%s", err, response))
+				return diag.FromErr(flex.FmtErrorf("[ERROR] ListBackupPoliciesWithContext failed %s\n%s", err, response))
 			}
 			if backupPolicyCollection != nil && *backupPolicyCollection.TotalCount == int64(0) {
 				break
@@ -270,37 +269,37 @@ func dataSourceIBMIsBackupPolicyRead(context context.Context, d *schema.Resource
 			}
 		}
 		if backupPolicy == nil {
-			return diag.FromErr(fmt.Errorf("[ERROR] No backup policy found with name (%s)", name))
+			return diag.FromErr(flex.FmtErrorf("[ERROR] No backup policy found with name (%s)", name))
 		}
 	}
 
 	d.SetId(*backupPolicy.ID)
 
 	if err = d.Set("created_at", backupPolicy.CreatedAt.String()); err != nil {
-		return diag.FromErr(fmt.Errorf("[ERROR] Error setting created_at: %s", err))
+		return diag.FromErr(flex.FmtErrorf("[ERROR] Error setting created_at: %s", err))
 	}
 	if err = d.Set("crn", backupPolicy.CRN); err != nil {
-		return diag.FromErr(fmt.Errorf("[ERROR] Error setting crn: %s", err))
+		return diag.FromErr(flex.FmtErrorf("[ERROR] Error setting crn: %s", err))
 	}
 	if err = d.Set("href", backupPolicy.Href); err != nil {
-		return diag.FromErr(fmt.Errorf("[ERROR] Error setting href: %s", err))
+		return diag.FromErr(flex.FmtErrorf("[ERROR] Error setting href: %s", err))
 	}
 	if backupPolicy.LastJobCompletedAt != nil {
 		if err = d.Set("last_job_completed_at", backupPolicy.LastJobCompletedAt.String()); err != nil {
-			return diag.FromErr(fmt.Errorf("[ERROR] Error setting last_job_completed_at: %s", err))
+			return diag.FromErr(flex.FmtErrorf("[ERROR] Error setting last_job_completed_at: %s", err))
 		}
 	}
 	if err = d.Set("lifecycle_state", backupPolicy.LifecycleState); err != nil {
-		return diag.FromErr(fmt.Errorf("[ERROR] Error setting lifecycle_state: %s", err))
+		return diag.FromErr(flex.FmtErrorf("[ERROR] Error setting lifecycle_state: %s", err))
 	}
 	if err = d.Set("name", backupPolicy.Name); err != nil {
-		return diag.FromErr(fmt.Errorf("[ERROR] Error setting name: %s", err))
+		return diag.FromErr(flex.FmtErrorf("[ERROR] Error setting name: %s", err))
 	}
 
 	if backupPolicy.Plans != nil {
 		err = d.Set("plans", dataSourceBackupPolicyFlattenPlans(backupPolicy.Plans))
 		if err != nil {
-			return diag.FromErr(fmt.Errorf("[ERROR] Error setting plans %s", err))
+			return diag.FromErr(flex.FmtErrorf("[ERROR] Error setting plans %s", err))
 		}
 	}
 
@@ -320,28 +319,28 @@ func dataSourceIBMIsBackupPolicyRead(context context.Context, d *schema.Resource
 		d.Set("health_reasons", healthReasonsList)
 	}
 	if err = d.Set("health_state", backupPolicy.HealthState); err != nil {
-		return diag.FromErr(fmt.Errorf("[ERROR] Error setting health_state: %s", err))
+		return diag.FromErr(flex.FmtErrorf("[ERROR] Error setting health_state: %s", err))
 	}
 
 	if backupPolicy.Scope != nil {
 		err = d.Set("scope", dataSourceBackupPolicyFlattenScope(*backupPolicy.Scope.(*vpcv1.BackupPolicyScope)))
 		if err != nil {
-			return diag.FromErr(fmt.Errorf("[ERROR] Error setting scope: %s", err))
+			return diag.FromErr(flex.FmtErrorf("[ERROR] Error setting scope: %s", err))
 		}
 	}
 
 	if backupPolicy.MatchResourceType != nil {
 		if err = d.Set("match_resource_types", []string{*backupPolicy.MatchResourceType}); err != nil {
-			return diag.FromErr(fmt.Errorf("[ERROR] Error setting match_resource_types: %s", err))
+			return diag.FromErr(flex.FmtErrorf("[ERROR] Error setting match_resource_types: %s", err))
 		}
 		if err = d.Set("match_resource_type", *backupPolicy.MatchResourceType); err != nil {
-			return diag.FromErr(fmt.Errorf("[ERROR] Error setting match_resource_type: %s", err))
+			return diag.FromErr(flex.FmtErrorf("[ERROR] Error setting match_resource_type: %s", err))
 		}
 	}
 
 	if backupPolicy.IncludedContent != nil {
 		if err = d.Set("included_content", backupPolicy.IncludedContent); err != nil {
-			return diag.FromErr(fmt.Errorf("[ERROR] Error setting included_content: %s", err))
+			return diag.FromErr(flex.FmtErrorf("[ERROR] Error setting included_content: %s", err))
 		}
 	}
 
@@ -356,11 +355,11 @@ func dataSourceIBMIsBackupPolicyRead(context context.Context, d *schema.Resource
 	if backupPolicy.ResourceGroup != nil {
 		err = d.Set("resource_group", dataSourceBackupPolicyFlattenResourceGroup(*backupPolicy.ResourceGroup))
 		if err != nil {
-			return diag.FromErr(fmt.Errorf("[ERROR] Error setting resource_group %s", err))
+			return diag.FromErr(flex.FmtErrorf("[ERROR] Error setting resource_group %s", err))
 		}
 	}
 	if err = d.Set("resource_type", backupPolicy.ResourceType); err != nil {
-		return diag.FromErr(fmt.Errorf("[ERROR] Error setting resource_type: %s", err))
+		return diag.FromErr(flex.FmtErrorf("[ERROR] Error setting resource_type: %s", err))
 	}
 
 	return nil

--- a/ibm/service/vpc/data_source_ibm_is_backup_policy_job.go
+++ b/ibm/service/vpc/data_source_ibm_is_backup_policy_job.go
@@ -5,7 +5,6 @@ package vpc
 
 import (
 	"context"
-	"fmt"
 	"log"
 	"reflect"
 
@@ -333,37 +332,37 @@ func dataSourceIBMIsBackupPolicyJobRead(context context.Context, d *schema.Resou
 	backupPolicyJob, response, err := vpcClient.GetBackupPolicyJobWithContext(context, getBackupPolicyJobOptions)
 	if err != nil {
 		log.Printf("[DEBUG] GetBackupPolicyJobWithContext failed %s\n%s", err, response)
-		return diag.FromErr(fmt.Errorf("GetBackupPolicyJobWithContext failed %s\n%s", err, response))
+		return diag.FromErr(flex.FmtErrorf("GetBackupPolicyJobWithContext failed %s\n%s", err, response))
 	}
 
 	d.SetId(*backupPolicyJob.ID)
 	if err = d.Set("auto_delete", backupPolicyJob.AutoDelete); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting auto_delete: %s", err))
+		return diag.FromErr(flex.FmtErrorf("Error setting auto_delete: %s", err))
 	}
 	if err = d.Set("auto_delete_after", flex.IntValue(backupPolicyJob.AutoDeleteAfter)); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting auto_delete_after: %s", err))
+		return diag.FromErr(flex.FmtErrorf("Error setting auto_delete_after: %s", err))
 	}
 
 	if backupPolicyJob.BackupPolicyPlan != nil {
 		err = d.Set("backup_policy_plan", dataSourceBackupPolicyJobFlattenBackupPolicyPlan(*backupPolicyJob.BackupPolicyPlan))
 		if err != nil {
-			return diag.FromErr(fmt.Errorf("Error setting backup_policy_plan %s", err))
+			return diag.FromErr(flex.FmtErrorf("Error setting backup_policy_plan %s", err))
 		}
 	}
 	if err = d.Set("completed_at", flex.DateTimeToString(backupPolicyJob.CompletedAt)); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting completed_at: %s", err))
+		return diag.FromErr(flex.FmtErrorf("Error setting completed_at: %s", err))
 	}
 	if err = d.Set("created_at", flex.DateTimeToString(backupPolicyJob.CreatedAt)); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting created_at: %s", err))
+		return diag.FromErr(flex.FmtErrorf("Error setting created_at: %s", err))
 	}
 	if err = d.Set("href", backupPolicyJob.Href); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting href: %s", err))
+		return diag.FromErr(flex.FmtErrorf("Error setting href: %s", err))
 	}
 	if err = d.Set("job_type", backupPolicyJob.JobType); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting job_type: %s", err))
+		return diag.FromErr(flex.FmtErrorf("Error setting job_type: %s", err))
 	}
 	if err = d.Set("resource_type", backupPolicyJob.ResourceType); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting resource_type: %s", err))
+		return diag.FromErr(flex.FmtErrorf("Error setting resource_type: %s", err))
 	}
 
 	if backupPolicyJob.Source != nil {
@@ -373,7 +372,7 @@ func dataSourceIBMIsBackupPolicyJobRead(context context.Context, d *schema.Resou
 				jobSource := backupPolicyJob.Source.(*vpcv1.BackupPolicyJobSourceVolumeReference)
 				err = d.Set("source_volume", dataSourceBackupPolicyJobFlattenSourceVolume(*jobSource))
 				if err != nil {
-					return diag.FromErr(fmt.Errorf("Error setting source_volume %s", err))
+					return diag.FromErr(flex.FmtErrorf("Error setting source_volume %s", err))
 				}
 			}
 		case "*vpcv1.BackupPolicyJobSourceInstanceReference":
@@ -381,27 +380,27 @@ func dataSourceIBMIsBackupPolicyJobRead(context context.Context, d *schema.Resou
 				jobSource := backupPolicyJob.Source.(*vpcv1.BackupPolicyJobSourceInstanceReference)
 				err = d.Set("source_instance", dataSourceBackupPolicyJobFlattenSourceInstance(*jobSource))
 				if err != nil {
-					return diag.FromErr(fmt.Errorf("Error setting source_instance %s", err))
+					return diag.FromErr(flex.FmtErrorf("Error setting source_instance %s", err))
 				}
 			}
 		}
 
 	}
 	if err = d.Set("status", backupPolicyJob.Status); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting status: %s", err))
+		return diag.FromErr(flex.FmtErrorf("Error setting status: %s", err))
 	}
 
 	if backupPolicyJob.StatusReasons != nil {
 		err = d.Set("status_reasons", dataSourceBackupPolicyJobFlattenStatusReasons(backupPolicyJob.StatusReasons))
 		if err != nil {
-			return diag.FromErr(fmt.Errorf("Error setting status_reasons %s", err))
+			return diag.FromErr(flex.FmtErrorf("Error setting status_reasons %s", err))
 		}
 	}
 
 	if backupPolicyJob.TargetSnapshots != nil {
 		err = d.Set("target_snapshot", dataSourceBackupPolicyJobFlattenTargetSnapshot(backupPolicyJob.TargetSnapshots))
 		if err != nil {
-			return diag.FromErr(fmt.Errorf("Error setting target_snapshot %s", err))
+			return diag.FromErr(flex.FmtErrorf("Error setting target_snapshot %s", err))
 		}
 	}
 

--- a/ibm/service/vpc/data_source_ibm_is_backup_policy_jobs.go
+++ b/ibm/service/vpc/data_source_ibm_is_backup_policy_jobs.go
@@ -5,7 +5,6 @@ package vpc
 
 import (
 	"context"
-	"fmt"
 	"log"
 	"reflect"
 	"strings"
@@ -420,7 +419,7 @@ func dataSourceIBMIsBackupPolicyJobsRead(context context.Context, d *schema.Reso
 		backupPolicyJobCollection, response, err := vpcClient.ListBackupPolicyJobsWithContext(context, listBackupPolicyJobsOptions)
 		if err != nil {
 			log.Printf("[DEBUG] ListBackupPolicyJobsWithContext failed %s\n%s", err, response)
-			return diag.FromErr(fmt.Errorf("ListBackupPolicyJobsWithContext failed %s\n%s", err, response))
+			return diag.FromErr(flex.FmtErrorf("ListBackupPolicyJobsWithContext failed %s\n%s", err, response))
 		}
 
 		if backupPolicyJobCollection != nil && *backupPolicyJobCollection.TotalCount == int64(0) {
@@ -438,7 +437,7 @@ func dataSourceIBMIsBackupPolicyJobsRead(context context.Context, d *schema.Reso
 	if allrecs != nil {
 		err = d.Set("jobs", dataSourceBackupPolicyJobCollectionFlattenJobs(allrecs))
 		if err != nil {
-			return diag.FromErr(fmt.Errorf("Error setting jobs %s", err))
+			return diag.FromErr(flex.FmtErrorf("Error setting jobs %s", err))
 		}
 	}
 

--- a/ibm/service/vpc/data_source_ibm_is_backup_policy_plan.go
+++ b/ibm/service/vpc/data_source_ibm_is_backup_policy_plan.go
@@ -5,7 +5,6 @@ package vpc
 
 import (
 	"context"
-	"fmt"
 	"log"
 
 	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/flex"
@@ -163,7 +162,7 @@ func dataSourceIBMIsBackupPolicyPlanRead(context context.Context, d *schema.Reso
 		backupPolicyPlanInfo, response, err := sess.GetBackupPolicyPlanWithContext(context, getBackupPolicyPlanOptions)
 		if err != nil {
 			log.Printf("[DEBUG] GetBackupPolicyPlanWithContext failed %s\n%s", err, response)
-			return diag.FromErr(fmt.Errorf("[ERROR] GetBackupPolicyPlanWithContext failed %s\n%s", err, response))
+			return diag.FromErr(flex.FmtErrorf("[ERROR] GetBackupPolicyPlanWithContext failed %s\n%s", err, response))
 		}
 		backupPolicyPlan = backupPolicyPlanInfo
 	} else if v, ok := d.GetOk("name"); ok {
@@ -176,7 +175,7 @@ func dataSourceIBMIsBackupPolicyPlanRead(context context.Context, d *schema.Reso
 		backupPolicyPlanCollection, response, err := sess.ListBackupPolicyPlansWithContext(context, listBackupPolicyPlansOptions)
 		if err != nil {
 			log.Printf("[DEBUG] ListBackupPolicyPlansWithContext failed %s\n%s", err, response)
-			return diag.FromErr(fmt.Errorf("[ERROR] ListBackupPolicyPlansWithContext failed %s\n%s", err, response))
+			return diag.FromErr(flex.FmtErrorf("[ERROR] ListBackupPolicyPlansWithContext failed %s\n%s", err, response))
 		}
 		for _, backupPolicyPlanInfo := range backupPolicyPlanCollection.Plans {
 			if *backupPolicyPlanInfo.Name == name {
@@ -185,32 +184,32 @@ func dataSourceIBMIsBackupPolicyPlanRead(context context.Context, d *schema.Reso
 			}
 		}
 		if backupPolicyPlan == nil {
-			return diag.FromErr(fmt.Errorf("[ERROR] No backup policy plan found with name (%s)", name))
+			return diag.FromErr(flex.FmtErrorf("[ERROR] No backup policy plan found with name (%s)", name))
 		}
 	}
 
 	d.SetId(*backupPolicyPlan.ID)
 
 	if err = d.Set("active", backupPolicyPlan.Active); err != nil {
-		return diag.FromErr(fmt.Errorf("[ERROR] Error setting active: %s", err))
+		return diag.FromErr(flex.FmtErrorf("[ERROR] Error setting active: %s", err))
 	}
 	if err = d.Set("attach_user_tags", backupPolicyPlan.AttachUserTags); err != nil {
-		return diag.FromErr(fmt.Errorf("[ERROR] Error setting attach_user_tags: %s", err))
+		return diag.FromErr(flex.FmtErrorf("[ERROR] Error setting attach_user_tags: %s", err))
 	}
 	if err = d.Set("copy_user_tags", backupPolicyPlan.CopyUserTags); err != nil {
-		return diag.FromErr(fmt.Errorf("[ERROR] Error setting copy_user_tags: %s", err))
+		return diag.FromErr(flex.FmtErrorf("[ERROR] Error setting copy_user_tags: %s", err))
 	}
 	if err = d.Set("created_at", flex.DateTimeToString(backupPolicyPlan.CreatedAt)); err != nil {
-		return diag.FromErr(fmt.Errorf("[ERROR] Error setting created_at: %s", err))
+		return diag.FromErr(flex.FmtErrorf("[ERROR] Error setting created_at: %s", err))
 	}
 	if err = d.Set("cron_spec", backupPolicyPlan.CronSpec); err != nil {
-		return diag.FromErr(fmt.Errorf("[ERROR] Error setting cron_spec: %s", err))
+		return diag.FromErr(flex.FmtErrorf("[ERROR] Error setting cron_spec: %s", err))
 	}
 
 	if backupPolicyPlan.DeletionTrigger != nil {
 		err = d.Set("deletion_trigger", dataSourceBackupPolicyPlanFlattenDeletionTrigger(*backupPolicyPlan.DeletionTrigger))
 		if err != nil {
-			return diag.FromErr(fmt.Errorf("[ERROR] Error setting deletion_trigger %s", err))
+			return diag.FromErr(flex.FmtErrorf("[ERROR] Error setting deletion_trigger %s", err))
 		}
 	}
 	if backupPolicyPlan.ClonePolicy != nil {
@@ -231,29 +230,29 @@ func dataSourceIBMIsBackupPolicyPlanRead(context context.Context, d *schema.Reso
 		d.Set("clone_policy", backupPolicyPlanClonePolicyMap)
 	}
 	if err = d.Set("href", backupPolicyPlan.Href); err != nil {
-		return diag.FromErr(fmt.Errorf("[ERROR] Error setting href: %s", err))
+		return diag.FromErr(flex.FmtErrorf("[ERROR] Error setting href: %s", err))
 	}
 	if err = d.Set("lifecycle_state", backupPolicyPlan.LifecycleState); err != nil {
-		return diag.FromErr(fmt.Errorf("[ERROR] Error setting lifecycle_state: %s", err))
+		return diag.FromErr(flex.FmtErrorf("[ERROR] Error setting lifecycle_state: %s", err))
 	}
 	if err = d.Set("name", backupPolicyPlan.Name); err != nil {
-		return diag.FromErr(fmt.Errorf("[ERROR] Error setting name: %s", err))
+		return diag.FromErr(flex.FmtErrorf("[ERROR] Error setting name: %s", err))
 	}
 	remoteRegionPolicies := []map[string]interface{}{}
 	if backupPolicyPlan.RemoteRegionPolicies != nil {
 		for _, remoteCopyPolicy := range backupPolicyPlan.RemoteRegionPolicies {
 			remoteRegionPoliciesMap, err := dataSourceIBMIsVPCBackupPolicyPlanRemoteCopyPolicyItemToMap(&remoteCopyPolicy)
 			if err != nil {
-				return diag.FromErr(fmt.Errorf("[ERROR] Error setting remote copy policies: %s", err))
+				return diag.FromErr(flex.FmtErrorf("[ERROR] Error setting remote copy policies: %s", err))
 			}
 			remoteRegionPolicies = append(remoteRegionPolicies, remoteRegionPoliciesMap)
 		}
 	}
 	if err = d.Set("remote_region_policy", remoteRegionPolicies); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting remote_region_policy %s", err))
+		return diag.FromErr(flex.FmtErrorf("Error setting remote_region_policy %s", err))
 	}
 	if err = d.Set("resource_type", backupPolicyPlan.ResourceType); err != nil {
-		return diag.FromErr(fmt.Errorf("[ERROR] Error setting resource_type: %s", err))
+		return diag.FromErr(flex.FmtErrorf("[ERROR] Error setting resource_type: %s", err))
 	}
 
 	return nil

--- a/ibm/service/vpc/data_source_ibm_is_backup_policy_plans.go
+++ b/ibm/service/vpc/data_source_ibm_is_backup_policy_plans.go
@@ -5,7 +5,6 @@ package vpc
 
 import (
 	"context"
-	"fmt"
 	"log"
 	"time"
 
@@ -171,7 +170,7 @@ func dataSourceIBMIsBackupPolicyPlansRead(context context.Context, d *schema.Res
 	backupPolicyPlanCollection, response, err := vpcClient.ListBackupPolicyPlansWithContext(context, listBackupPolicyPlansOptions)
 	if err != nil {
 		log.Printf("[DEBUG] ListBackupPolicyPlansWithContext failed %s\n%s", err, response)
-		return diag.FromErr(fmt.Errorf("[ERROR] ListBackupPolicyPlansWithContext failed %s\n%s", err, response))
+		return diag.FromErr(flex.FmtErrorf("[ERROR] ListBackupPolicyPlansWithContext failed %s\n%s", err, response))
 	}
 
 	// Use the provided filter argument and construct a new list with only the requested resource(s)
@@ -191,7 +190,7 @@ func dataSourceIBMIsBackupPolicyPlansRead(context context.Context, d *schema.Res
 	}
 	if suppliedFilter {
 		if len(backupPolicyPlanCollection.Plans) == 0 {
-			return diag.FromErr(fmt.Errorf("[ERROR] no plans found with name %s", name))
+			return diag.FromErr(flex.FmtErrorf("[ERROR] no plans found with name %s", name))
 		}
 		d.SetId(name)
 	} else {
@@ -201,7 +200,7 @@ func dataSourceIBMIsBackupPolicyPlansRead(context context.Context, d *schema.Res
 	if backupPolicyPlanCollection.Plans != nil {
 		err = d.Set("plans", dataSourceBackupPolicyPlanCollectionFlattenPlans(backupPolicyPlanCollection.Plans))
 		if err != nil {
-			return diag.FromErr(fmt.Errorf("[ERROR] Error setting plans %s", err))
+			return diag.FromErr(flex.FmtErrorf("[ERROR] Error setting plans %s", err))
 		}
 	}
 

--- a/ibm/service/vpc/data_source_ibm_is_bare_metal_server.go
+++ b/ibm/service/vpc/data_source_ibm_is_bare_metal_server.go
@@ -729,7 +729,7 @@ func dataSourceIBMISBareMetalServerRead(context context.Context, d *schema.Resou
 		server, response, err := sess.GetBareMetalServerWithContext(context, options)
 		if err != nil {
 			log.Printf("[DEBUG] GetBareMetalServerWithContext failed %s\n%s", err, response)
-			return diag.FromErr(fmt.Errorf("[ERROR] Error Getting Bare Metal Server (%s): %s\n%s", id, err, response))
+			return diag.FromErr(flex.FmtErrorf("[ERROR] Error Getting Bare Metal Server (%s): %s\n%s", id, err, response))
 		}
 		bms = server
 	} else if name != "" {
@@ -738,10 +738,10 @@ func dataSourceIBMISBareMetalServerRead(context context.Context, d *schema.Resou
 		bmservers, response, err := sess.ListBareMetalServersWithContext(context, options)
 		if err != nil {
 			log.Printf("[DEBUG] ListBareMetalServersWithContext failed %s\n%s", err, response)
-			return diag.FromErr(fmt.Errorf("[ERROR] Error Listing Bare Metal Server (%s): %s\n%s", name, err, response))
+			return diag.FromErr(flex.FmtErrorf("[ERROR] Error Listing Bare Metal Server (%s): %s\n%s", name, err, response))
 		}
 		if len(bmservers.BareMetalServers) == 0 {
-			return diag.FromErr(fmt.Errorf("[ERROR] No bare metal servers found with name %s", name))
+			return diag.FromErr(flex.FmtErrorf("[ERROR] No bare metal servers found with name %s", name))
 		}
 		bms = &bmservers.BareMetalServers[0]
 	}
@@ -762,7 +762,7 @@ func dataSourceIBMISBareMetalServerRead(context context.Context, d *schema.Resou
 
 	initialization, response, err := sess.GetBareMetalServerInitialization(optionsInitialization)
 	if err != nil || initialization == nil {
-		return diag.FromErr(fmt.Errorf("[Error] Error getting Bare Metal Server (%s) initialization : %s\n%s", *bms.ID, err, response))
+		return diag.FromErr(flex.FmtErrorf("[Error] Error getting Bare Metal Server (%s) initialization : %s\n%s", *bms.ID, err, response))
 	}
 
 	d.Set(isBareMetalServerImage, initialization.Image.ID)
@@ -784,10 +784,10 @@ func dataSourceIBMISBareMetalServerRead(context context.Context, d *schema.Resou
 	}
 	d.Set(isBareMetalServerCPU, cpuList)
 	if err = d.Set(isBareMetalServerCreatedAt, bms.CreatedAt.String()); err != nil {
-		return diag.FromErr(fmt.Errorf("[ERROR] Error setting created_at: %s", err))
+		return diag.FromErr(flex.FmtErrorf("[ERROR] Error setting created_at: %s", err))
 	}
 	if err = d.Set(isBareMetalServerCRN, bms.CRN); err != nil {
-		return diag.FromErr(fmt.Errorf("[ERROR] Error setting crn: %s", err))
+		return diag.FromErr(flex.FmtErrorf("[ERROR] Error setting crn: %s", err))
 	}
 
 	diskList := make([]map[string]interface{}, 0)
@@ -806,21 +806,21 @@ func dataSourceIBMISBareMetalServerRead(context context.Context, d *schema.Resou
 	}
 	d.Set(isBareMetalServerDisks, diskList)
 	if err = d.Set(isBareMetalServerHref, bms.Href); err != nil {
-		return diag.FromErr(fmt.Errorf("[ERROR] Error setting href: %s", err))
+		return diag.FromErr(flex.FmtErrorf("[ERROR] Error setting href: %s", err))
 	}
 	if err = d.Set(isBareMetalServerMemory, bms.Memory); err != nil {
-		return diag.FromErr(fmt.Errorf("[ERROR] Error setting memory: %s", err))
+		return diag.FromErr(flex.FmtErrorf("[ERROR] Error setting memory: %s", err))
 	}
 	if err = d.Set(isBareMetalServerName, *bms.Name); err != nil {
-		return diag.FromErr(fmt.Errorf("[ERROR] Error setting name: %s", err))
+		return diag.FromErr(flex.FmtErrorf("[ERROR] Error setting name: %s", err))
 	}
 	if err = d.Set("identifier", *bms.ID); err != nil {
-		return diag.FromErr(fmt.Errorf("[ERROR] Error setting identifier: %s", err))
+		return diag.FromErr(flex.FmtErrorf("[ERROR] Error setting identifier: %s", err))
 	}
 
 	//enable secure boot
 	if err = d.Set(isBareMetalServerEnableSecureBoot, bms.EnableSecureBoot); err != nil {
-		return diag.FromErr(fmt.Errorf("[ERROR] Error setting enable_secure_boot: %s", err))
+		return diag.FromErr(flex.FmtErrorf("[ERROR] Error setting enable_secure_boot: %s", err))
 	}
 
 	// tpm
@@ -830,7 +830,7 @@ func dataSourceIBMISBareMetalServerRead(context context.Context, d *schema.Resou
 			return diag.FromErr(err)
 		}
 		if err = d.Set(isBareMetalServerTrustedPlatformModule, []map[string]interface{}{trustedPlatformModuleMap}); err != nil {
-			return diag.FromErr(fmt.Errorf("[ERROR] Error setting trusted_platform_module: %s", err))
+			return diag.FromErr(flex.FmtErrorf("[ERROR] Error setting trusted_platform_module: %s", err))
 		}
 	}
 
@@ -871,7 +871,7 @@ func dataSourceIBMISBareMetalServerRead(context context.Context, d *schema.Resou
 		}
 		bmsnic, response, err := sess.GetBareMetalServerNetworkInterface(getnicoptions)
 		if err != nil {
-			return diag.FromErr(fmt.Errorf("[ERROR] Error getting network interfaces attached to the bare metal server %s\n%s", err, response))
+			return diag.FromErr(flex.FmtErrorf("[ERROR] Error getting network interfaces attached to the bare metal server %s\n%s", err, response))
 		}
 
 		switch reflect.TypeOf(bmsnic).String() {
@@ -969,7 +969,7 @@ func dataSourceIBMISBareMetalServerRead(context context.Context, d *schema.Resou
 			}
 			bmsnicintf, response, err := sess.GetBareMetalServerNetworkInterface(getnicoptions)
 			if err != nil {
-				return diag.FromErr(fmt.Errorf("[ERROR] Error getting network interfaces attached to the bare metal server %s\n%s", err, response))
+				return diag.FromErr(flex.FmtErrorf("[ERROR] Error getting network interfaces attached to the bare metal server %s\n%s", err, response))
 			}
 
 			switch reflect.TypeOf(bmsnicintf).String() {
@@ -1035,16 +1035,16 @@ func dataSourceIBMISBareMetalServerRead(context context.Context, d *schema.Resou
 	}
 
 	if err = d.Set(isBareMetalServerProfile, *bms.Profile.Name); err != nil {
-		return diag.FromErr(fmt.Errorf("[ERROR] Error setting profile: %s", err))
+		return diag.FromErr(flex.FmtErrorf("[ERROR] Error setting profile: %s", err))
 	}
 	if bms.ResourceGroup != nil {
 		d.Set(isBareMetalServerResourceGroup, *bms.ResourceGroup.ID)
 	}
 	if err = d.Set(isBareMetalServerResourceType, bms.ResourceType); err != nil {
-		return diag.FromErr(fmt.Errorf("[ERROR] Error setting resource_type: %s", err))
+		return diag.FromErr(flex.FmtErrorf("[ERROR] Error setting resource_type: %s", err))
 	}
 	if err = d.Set(isBareMetalServerStatus, *bms.Status); err != nil {
-		return diag.FromErr(fmt.Errorf("[ERROR] Error setting status: %s", err))
+		return diag.FromErr(flex.FmtErrorf("[ERROR] Error setting status: %s", err))
 	}
 	statusReasonsList := make([]map[string]interface{}, 0)
 	if bms.StatusReasons != nil {
@@ -1063,10 +1063,10 @@ func dataSourceIBMISBareMetalServerRead(context context.Context, d *schema.Resou
 	d.Set(isBareMetalServerStatusReasons, statusReasonsList)
 
 	if err = d.Set(isBareMetalServerVPC, *bms.VPC.ID); err != nil {
-		return diag.FromErr(fmt.Errorf("[ERROR] Error setting vpc: %s", err))
+		return diag.FromErr(flex.FmtErrorf("[ERROR] Error setting vpc: %s", err))
 	}
 	if err = d.Set(isBareMetalServerZone, *bms.Zone.Name); err != nil {
-		return diag.FromErr(fmt.Errorf("[ERROR] Error setting zone: %s", err))
+		return diag.FromErr(flex.FmtErrorf("[ERROR] Error setting zone: %s", err))
 	}
 
 	tags, err := flex.GetGlobalTagsUsingCRN(meta, *bms.CRN, "", isBareMetalServerAccessTagType)

--- a/ibm/service/vpc/data_source_ibm_is_bare_metal_server_disk.go
+++ b/ibm/service/vpc/data_source_ibm_is_bare_metal_server_disk.go
@@ -5,9 +5,9 @@ package vpc
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/conns"
+	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/flex"
 	"github.com/IBM/vpc-go-sdk/vpcv1"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -83,7 +83,7 @@ func dataSourceIBMISBareMetalServerDiskRead(context context.Context, d *schema.R
 
 	disk, response, err := sess.GetBareMetalServerDiskWithContext(context, options)
 	if err != nil || disk == nil {
-		return diag.FromErr(fmt.Errorf("[ERROR] Error getting Bare Metal Server (%s) disk (%s): %s\n%s", bareMetalServerID, bareMetalServerDiskID, err, response))
+		return diag.FromErr(flex.FmtErrorf("[ERROR] Error getting Bare Metal Server (%s) disk (%s): %s\n%s", bareMetalServerID, bareMetalServerDiskID, err, response))
 	}
 	d.SetId(*disk.ID)
 	d.Set(isBareMetalServerDiskHref, *disk.Href)

--- a/ibm/service/vpc/data_source_ibm_is_bare_metal_server_disks.go
+++ b/ibm/service/vpc/data_source_ibm_is_bare_metal_server_disks.go
@@ -5,10 +5,10 @@ package vpc
 
 import (
 	"context"
-	"fmt"
 	"time"
 
 	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/conns"
+	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/flex"
 	"github.com/IBM/vpc-go-sdk/vpcv1"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -89,7 +89,7 @@ func dataSourceIBMISBareMetalServerDisksRead(context context.Context, d *schema.
 	diskCollection, response, err := sess.ListBareMetalServerDisksWithContext(context, options)
 	disks := diskCollection.Disks
 	if err != nil || disks == nil {
-		return diag.FromErr(fmt.Errorf("[ERROR] Error getting Bare Metal Server (%s) disks: %s\n%s", bareMetalServerID, err, response))
+		return diag.FromErr(flex.FmtErrorf("[ERROR] Error getting Bare Metal Server (%s) disks: %s\n%s", bareMetalServerID, err, response))
 	}
 	disksInfo := make([]map[string]interface{}, 0)
 	for _, disk := range disks {

--- a/ibm/service/vpc/data_source_ibm_is_bare_metal_server_network_interface.go
+++ b/ibm/service/vpc/data_source_ibm_is_bare_metal_server_network_interface.go
@@ -5,7 +5,6 @@ package vpc
 
 import (
 	"context"
-	"fmt"
 	"reflect"
 
 	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/conns"
@@ -238,7 +237,7 @@ func dataSourceIBMISBareMetalServerNetworkInterfaceRead(context context.Context,
 
 	nicIntf, response, err := sess.GetBareMetalServerNetworkInterfaceWithContext(context, options)
 	if err != nil || nicIntf == nil {
-		return diag.FromErr(fmt.Errorf("[ERROR] Error getting Bare Metal Server (%s) network interface (%s): %s\n%s", bareMetalServerID, bareMetalServerNicID, err, response))
+		return diag.FromErr(flex.FmtErrorf("[ERROR] Error getting Bare Metal Server (%s) network interface (%s): %s\n%s", bareMetalServerID, bareMetalServerNicID, err, response))
 	}
 	switch reflect.TypeOf(nicIntf).String() {
 	case "*vpcv1.BareMetalServerNetworkInterfaceByPci":

--- a/ibm/service/vpc/data_source_ibm_is_bare_metal_server_network_interface_floating_ip.go
+++ b/ibm/service/vpc/data_source_ibm_is_bare_metal_server_network_interface_floating_ip.go
@@ -5,9 +5,9 @@ package vpc
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/conns"
+	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/flex"
 	"github.com/IBM/vpc-go-sdk/vpcv1"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -92,7 +92,7 @@ func dataSourceIBMISBareMetalServerNetworkInterfaceFloatingIPRead(context contex
 
 	ip, response, err := sess.GetBareMetalServerNetworkInterfaceFloatingIPWithContext(context, options)
 	if err != nil {
-		return diag.FromErr(fmt.Errorf("[ERROR] Error fetching floating IP for bare metal server %s\n%s", err, response))
+		return diag.FromErr(flex.FmtErrorf("[ERROR] Error fetching floating IP for bare metal server %s\n%s", err, response))
 	}
 	d.Set(floatingIPName, *ip.Name)
 	d.Set(floatingIPAddress, *ip.Address)

--- a/ibm/service/vpc/data_source_ibm_is_bare_metal_server_network_interface_floating_ips.go
+++ b/ibm/service/vpc/data_source_ibm_is_bare_metal_server_network_interface_floating_ips.go
@@ -5,10 +5,10 @@ package vpc
 
 import (
 	"context"
-	"fmt"
 	"time"
 
 	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/conns"
+	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/flex"
 	"github.com/IBM/vpc-go-sdk/vpcv1"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -104,7 +104,7 @@ func dataSourceIBMISBareMetalServerNetworkInterfaceFloatingIPsRead(context conte
 
 	fips, response, err := sess.ListBareMetalServerNetworkInterfaceFloatingIpsWithContext(context, options)
 	if err != nil {
-		return diag.FromErr(fmt.Errorf("[ERROR] Error fetching floating IPs for bare metal server %s\n%s", err, response))
+		return diag.FromErr(flex.FmtErrorf("[ERROR] Error fetching floating IPs for bare metal server %s\n%s", err, response))
 	}
 	allFloatingIPs = append(allFloatingIPs, fips.FloatingIps...)
 	fipInfo := make([]map[string]interface{}, 0)

--- a/ibm/service/vpc/data_source_ibm_is_bare_metal_server_network_interface_reserved_ip.go
+++ b/ibm/service/vpc/data_source_ibm_is_bare_metal_server_network_interface_reserved_ip.go
@@ -5,9 +5,9 @@ package vpc
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/conns"
+	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/flex"
 	"github.com/IBM/vpc-go-sdk/vpcv1"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -117,7 +117,7 @@ func dataSourceIBMISBareMetalServerNICReservedIPRead(context context.Context, d 
 	reserveIP, response, err := sess.GetBareMetalServerNetworkInterfaceIPWithContext(context, options)
 
 	if err != nil || response == nil || reserveIP == nil {
-		return diag.FromErr(fmt.Errorf("[ERROR] Error fetching the reserved IP %s\n%s", err, response))
+		return diag.FromErr(flex.FmtErrorf("[ERROR] Error fetching the reserved IP %s\n%s", err, response))
 	}
 
 	d.SetId(*reserveIP.ID)

--- a/ibm/service/vpc/data_source_ibm_is_bare_metal_server_network_interface_reserved_ips.go
+++ b/ibm/service/vpc/data_source_ibm_is_bare_metal_server_network_interface_reserved_ips.go
@@ -5,10 +5,10 @@ package vpc
 
 import (
 	"context"
-	"fmt"
 	"time"
 
 	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/conns"
+	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/flex"
 	"github.com/IBM/vpc-go-sdk/vpcv1"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -130,7 +130,7 @@ func dataSourceIBMISBareMetalServerNICReservedIPsRead(context context.Context, d
 
 	result, response, err := sess.ListBareMetalServerNetworkInterfaceIpsWithContext(context, options)
 	if err != nil || response == nil || result == nil {
-		return diag.FromErr(fmt.Errorf("[ERROR] Error fetching reserved ips %s\n%s", err, response))
+		return diag.FromErr(flex.FmtErrorf("[ERROR] Error fetching reserved ips %s\n%s", err, response))
 	}
 	allrecs = append(allrecs, result.Ips...)
 

--- a/ibm/service/vpc/data_source_ibm_is_bare_metal_server_network_interfaces.go
+++ b/ibm/service/vpc/data_source_ibm_is_bare_metal_server_network_interfaces.go
@@ -5,7 +5,6 @@ package vpc
 
 import (
 	"context"
-	"fmt"
 	"reflect"
 	"time"
 
@@ -221,7 +220,7 @@ func dataSourceIBMISBareMetalServerNetworkInterfacesRead(context context.Context
 	nics := []vpcv1.BareMetalServerNetworkInterfaceIntf{}
 	bmsNics, response, err := sess.ListBareMetalServerNetworkInterfacesWithContext(context, options)
 	if err != nil || bmsNics == nil {
-		return diag.FromErr(fmt.Errorf("[ERROR] Error listing Bare Metal Server (%s) network interfaces : %s\n%s", bareMetalServerID, err, response))
+		return diag.FromErr(flex.FmtErrorf("[ERROR] Error listing Bare Metal Server (%s) network interfaces : %s\n%s", bareMetalServerID, err, response))
 	}
 	nics = append(nics, bmsNics.NetworkInterfaces...)
 	nicsInfo := make([]map[string]interface{}, 0)

--- a/ibm/service/vpc/data_source_ibm_is_bare_metal_server_profile.go
+++ b/ibm/service/vpc/data_source_ibm_is_bare_metal_server_profile.go
@@ -423,7 +423,7 @@ func dataSourceIBMISBMSProfileRead(context context.Context, d *schema.ResourceDa
 	}
 	bmsProfile, response, err := sess.GetBareMetalServerProfileWithContext(context, options)
 	if err != nil || bmsProfile == nil {
-		return diag.FromErr(fmt.Errorf("[ERROR] Error Getting Bare Metal Server Profile (%s): %s\n%s", name, err, response))
+		return diag.FromErr(flex.FmtErrorf("[ERROR] Error Getting Bare Metal Server Profile (%s): %s\n%s", name, err, response))
 	}
 	d.SetId(*bmsProfile.Name)
 	d.Set(isBareMetalServerProfileName, *bmsProfile.Name)
@@ -466,7 +466,7 @@ func dataSourceIBMISBMSProfileRead(context context.Context, d *schema.ResourceDa
 		consoleTypes = append(consoleTypes, modelMap)
 	}
 	if err = d.Set("console_types", consoleTypes); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting console_types %s", err))
+		return diag.FromErr(flex.FmtErrorf("Error setting console_types %s", err))
 	}
 
 	networkInterfaceCount := []map[string]interface{}{}
@@ -478,7 +478,7 @@ func dataSourceIBMISBMSProfileRead(context context.Context, d *schema.ResourceDa
 		networkInterfaceCount = append(networkInterfaceCount, modelMap)
 	}
 	if err = d.Set("network_interface_count", networkInterfaceCount); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting network_interface_count %s", err))
+		return diag.FromErr(flex.FmtErrorf("Error setting network_interface_count %s", err))
 	}
 
 	if bmsProfile.CpuArchitecture != nil {
@@ -641,7 +641,7 @@ func dataSourceIBMIsBareMetalServerProfileBareMetalServerProfileNetworkInterface
 		}
 		return modelMap, nil
 	} else {
-		return nil, fmt.Errorf("Unrecognized vpcv1.BareMetalServerProfileNetworkInterfaceCountIntf subtype encountered")
+		return nil, flex.FmtErrorf("Unrecognized vpcv1.BareMetalServerProfileNetworkInterfaceCountIntf subtype encountered")
 	}
 }
 

--- a/ibm/service/vpc/data_source_ibm_is_bare_metal_server_profiles.go
+++ b/ibm/service/vpc/data_source_ibm_is_bare_metal_server_profiles.go
@@ -5,7 +5,6 @@ package vpc
 
 import (
 	"context"
-	"fmt"
 	"time"
 
 	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/conns"
@@ -424,7 +423,7 @@ func dataSourceIBMIsBareMetalServerProfilesRead(context context.Context, d *sche
 		}
 		availableProfiles, response, err := sess.ListBareMetalServerProfilesWithContext(context, listBMSProfilesOptions)
 		if err != nil {
-			return diag.FromErr(fmt.Errorf("[ERROR] Error fetching Bare Metal Server Profiles %s\n%s", err, response))
+			return diag.FromErr(flex.FmtErrorf("[ERROR] Error fetching Bare Metal Server Profiles %s\n%s", err, response))
 		}
 		start = flex.GetNext(availableProfiles.Next)
 		allrecs = append(allrecs, availableProfiles.Profiles...)

--- a/ibm/service/vpc/data_source_ibm_is_bare_metal_servers.go
+++ b/ibm/service/vpc/data_source_ibm_is_bare_metal_servers.go
@@ -5,7 +5,6 @@ package vpc
 
 import (
 	"context"
-	"fmt"
 	"log"
 	"reflect"
 	"time"
@@ -782,7 +781,7 @@ func dataSourceIBMISBareMetalServersRead(context context.Context, d *schema.Reso
 		}
 		availableServers, response, err := sess.ListBareMetalServersWithContext(context, listBareMetalServersOptions)
 		if err != nil {
-			return diag.FromErr(fmt.Errorf("[ERROR] Error fetching Bare Metal Servers %s\n%s", err, response))
+			return diag.FromErr(flex.FmtErrorf("[ERROR] Error fetching Bare Metal Servers %s\n%s", err, response))
 		}
 		start = flex.GetNext(availableServers.Next)
 		allrecs = append(allrecs, availableServers.BareMetalServers...)
@@ -888,7 +887,7 @@ func dataSourceIBMISBareMetalServersRead(context context.Context, d *schema.Reso
 			}
 			bmsnic, response, err := sess.GetBareMetalServerNetworkInterface(getnicoptions)
 			if err != nil {
-				return diag.FromErr(fmt.Errorf("[ERROR] Error getting network interfaces attached to the bare metal server %s\n%s", err, response))
+				return diag.FromErr(flex.FmtErrorf("[ERROR] Error getting network interfaces attached to the bare metal server %s\n%s", err, response))
 			}
 
 			switch reflect.TypeOf(bmsnic).String() {
@@ -982,7 +981,7 @@ func dataSourceIBMISBareMetalServersRead(context context.Context, d *schema.Reso
 				}
 				bmsnicintf, response, err := sess.GetBareMetalServerNetworkInterface(getnicoptions)
 				if err != nil {
-					return diag.FromErr(fmt.Errorf("[ERROR] Error getting network interfaces attached to the bare metal server %s\n%s", err, response))
+					return diag.FromErr(flex.FmtErrorf("[ERROR] Error getting network interfaces attached to the bare metal server %s\n%s", err, response))
 				}
 
 				switch reflect.TypeOf(bmsnicintf).String() {

--- a/ibm/service/vpc/data_source_ibm_is_dedicated_host.go
+++ b/ibm/service/vpc/data_source_ibm_is_dedicated_host.go
@@ -5,7 +5,6 @@ package vpc
 
 import (
 	"context"
-	"fmt"
 	"log"
 	"time"
 
@@ -408,20 +407,20 @@ func dataSourceIbmIsDedicatedHostRead(context context.Context, d *schema.Resourc
 		d.SetId(*dedicatedHost.ID)
 
 		if err = d.Set("available_memory", dedicatedHost.AvailableMemory); err != nil {
-			return diag.FromErr(fmt.Errorf("[ERROR] Error setting available_memory: %s", err))
+			return diag.FromErr(flex.FmtErrorf("[ERROR] Error setting available_memory: %s", err))
 		}
 
 		if dedicatedHost.AvailableVcpu != nil {
 			err = d.Set("available_vcpu", dataSourceDedicatedHostFlattenAvailableVcpu(*dedicatedHost.AvailableVcpu))
 			if err != nil {
-				return diag.FromErr(fmt.Errorf("[ERROR] Error setting available_vcpu %s", err))
+				return diag.FromErr(flex.FmtErrorf("[ERROR] Error setting available_vcpu %s", err))
 			}
 		}
 		if err = d.Set("created_at", dedicatedHost.CreatedAt.String()); err != nil {
-			return diag.FromErr(fmt.Errorf("[ERROR] Error setting created_at: %s", err))
+			return diag.FromErr(flex.FmtErrorf("[ERROR] Error setting created_at: %s", err))
 		}
 		if err = d.Set("crn", dedicatedHost.CRN); err != nil {
-			return diag.FromErr(fmt.Errorf("[ERROR] Error setting crn: %s", err))
+			return diag.FromErr(flex.FmtErrorf("[ERROR] Error setting crn: %s", err))
 		}
 		accesstags, err := flex.GetGlobalTagsUsingCRN(meta, *dedicatedHost.CRN, "", isDedicatedHostAccessTagType)
 		if err != nil {
@@ -432,93 +431,93 @@ func dataSourceIbmIsDedicatedHostRead(context context.Context, d *schema.Resourc
 		if dedicatedHost.Disks != nil {
 			err = d.Set("disks", dataSourceDedicatedHostFlattenDisks(dedicatedHost.Disks))
 			if err != nil {
-				return diag.FromErr(fmt.Errorf("[ERROR] Error setting disks %s", err))
+				return diag.FromErr(flex.FmtErrorf("[ERROR] Error setting disks %s", err))
 			}
 		}
 		if dedicatedHost.Group != nil {
 			err = d.Set("host_group", *dedicatedHost.Group.ID)
 			if err != nil {
-				return diag.FromErr(fmt.Errorf("[ERROR] Error setting group %s", err))
+				return diag.FromErr(flex.FmtErrorf("[ERROR] Error setting group %s", err))
 			}
 		}
 		if err = d.Set("href", dedicatedHost.Href); err != nil {
-			return diag.FromErr(fmt.Errorf("[ERROR] Error setting href: %s", err))
+			return diag.FromErr(flex.FmtErrorf("[ERROR] Error setting href: %s", err))
 		}
 		if err = d.Set("instance_placement_enabled", dedicatedHost.InstancePlacementEnabled); err != nil {
-			return diag.FromErr(fmt.Errorf("[ERROR] Error setting instance_placement_enabled: %s", err))
+			return diag.FromErr(flex.FmtErrorf("[ERROR] Error setting instance_placement_enabled: %s", err))
 		}
 
 		if dedicatedHost.Instances != nil {
 			err = d.Set("instances", dataSourceDedicatedHostFlattenInstances(dedicatedHost.Instances))
 			if err != nil {
-				return diag.FromErr(fmt.Errorf("[ERROR] Error setting instances %s", err))
+				return diag.FromErr(flex.FmtErrorf("[ERROR] Error setting instances %s", err))
 			}
 		}
 		if err = d.Set("lifecycle_state", dedicatedHost.LifecycleState); err != nil {
-			return diag.FromErr(fmt.Errorf("[ERROR] Error setting lifecycle_state: %s", err))
+			return diag.FromErr(flex.FmtErrorf("[ERROR] Error setting lifecycle_state: %s", err))
 		}
 		if err = d.Set("memory", dedicatedHost.Memory); err != nil {
-			return diag.FromErr(fmt.Errorf("[ERROR] Error setting memory: %s", err))
+			return diag.FromErr(flex.FmtErrorf("[ERROR] Error setting memory: %s", err))
 		}
 		if err = d.Set("name", dedicatedHost.Name); err != nil {
-			return diag.FromErr(fmt.Errorf("[ERROR] Error setting name: %s", err))
+			return diag.FromErr(flex.FmtErrorf("[ERROR] Error setting name: %s", err))
 		}
 		if dedicatedHost.Numa != nil {
 			if err = d.Set("numa", dataSourceDedicatedHostFlattenNumaNodes(*dedicatedHost.Numa)); err != nil {
-				return diag.FromErr(fmt.Errorf("[ERROR] Error setting numa nodes: %s", err))
+				return diag.FromErr(flex.FmtErrorf("[ERROR] Error setting numa nodes: %s", err))
 			}
 		}
 		if dedicatedHost.Profile != nil {
 			err = d.Set("profile", dataSourceDedicatedHostFlattenProfile(*dedicatedHost.Profile))
 			if err != nil {
-				return diag.FromErr(fmt.Errorf("[ERROR] Error setting profile %s", err))
+				return diag.FromErr(flex.FmtErrorf("[ERROR] Error setting profile %s", err))
 			}
 		}
 		if err = d.Set("provisionable", dedicatedHost.Provisionable); err != nil {
-			return diag.FromErr(fmt.Errorf("[ERROR] Error setting provisionable: %s", err))
+			return diag.FromErr(flex.FmtErrorf("[ERROR] Error setting provisionable: %s", err))
 		}
 
 		if dedicatedHost.ResourceGroup != nil {
 			err = d.Set("resource_group", *dedicatedHost.ResourceGroup.ID)
 			if err != nil {
-				return diag.FromErr(fmt.Errorf("[ERROR] Error setting resource_group %s", err))
+				return diag.FromErr(flex.FmtErrorf("[ERROR] Error setting resource_group %s", err))
 			}
 		}
 		if err = d.Set("resource_type", dedicatedHost.ResourceType); err != nil {
-			return diag.FromErr(fmt.Errorf("[ERROR] Error setting resource_type: %s", err))
+			return diag.FromErr(flex.FmtErrorf("[ERROR] Error setting resource_type: %s", err))
 		}
 		if err = d.Set("socket_count", dedicatedHost.SocketCount); err != nil {
-			return diag.FromErr(fmt.Errorf("[ERROR] Error setting socket_count: %s", err))
+			return diag.FromErr(flex.FmtErrorf("[ERROR] Error setting socket_count: %s", err))
 		}
 		if err = d.Set("state", dedicatedHost.State); err != nil {
-			return diag.FromErr(fmt.Errorf("[ERROR] Error setting state: %s", err))
+			return diag.FromErr(flex.FmtErrorf("[ERROR] Error setting state: %s", err))
 		}
 
 		if dedicatedHost.SupportedInstanceProfiles != nil {
 			err = d.Set("supported_instance_profiles", dataSourceDedicatedHostFlattenSupportedInstanceProfiles(dedicatedHost.SupportedInstanceProfiles))
 			if err != nil {
-				return diag.FromErr(fmt.Errorf("[ERROR] Error setting supported_instance_profiles %s", err))
+				return diag.FromErr(flex.FmtErrorf("[ERROR] Error setting supported_instance_profiles %s", err))
 			}
 		}
 
 		if dedicatedHost.Vcpu != nil {
 			err = d.Set("vcpu", dataSourceDedicatedHostFlattenVcpu(*dedicatedHost.Vcpu))
 			if err != nil {
-				return diag.FromErr(fmt.Errorf("[ERROR] Error setting vcpu %s", err))
+				return diag.FromErr(flex.FmtErrorf("[ERROR] Error setting vcpu %s", err))
 			}
 		}
 
 		if dedicatedHost.Zone != nil {
 			err = d.Set("zone", *dedicatedHost.Zone.Name)
 			if err != nil {
-				return diag.FromErr(fmt.Errorf("[ERROR] Error setting zone %s", err))
+				return diag.FromErr(flex.FmtErrorf("[ERROR] Error setting zone %s", err))
 			}
 		}
 
 		return nil
 
 	}
-	return diag.FromErr(fmt.Errorf("[ERROR] No Dedicated Host found with name %s", name))
+	return diag.FromErr(flex.FmtErrorf("[ERROR] No Dedicated Host found with name %s", name))
 }
 
 // dataSourceIbmIsDedicatedHostID returns a reasonable ID for the list.

--- a/ibm/service/vpc/data_source_ibm_is_dedicated_host_disk.go
+++ b/ibm/service/vpc/data_source_ibm_is_dedicated_host_disk.go
@@ -5,10 +5,10 @@ package vpc
 
 import (
 	"context"
-	"fmt"
 	"log"
 
 	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/conns"
+	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/flex"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 
@@ -149,43 +149,43 @@ func dataSourceIbmIsDedicatedHostDiskRead(context context.Context, d *schema.Res
 
 	d.SetId(*dedicatedHostDisk.ID)
 	if err = d.Set("available", dedicatedHostDisk.Available); err != nil {
-		return diag.FromErr(fmt.Errorf("[ERROR] Error setting available: %s", err))
+		return diag.FromErr(flex.FmtErrorf("[ERROR] Error setting available: %s", err))
 	}
 	if err = d.Set("created_at", dedicatedHostDisk.CreatedAt.String()); err != nil {
-		return diag.FromErr(fmt.Errorf("[ERROR] Error setting created_at: %s", err))
+		return diag.FromErr(flex.FmtErrorf("[ERROR] Error setting created_at: %s", err))
 	}
 	if err = d.Set("href", dedicatedHostDisk.Href); err != nil {
-		return diag.FromErr(fmt.Errorf("[ERROR] Error setting href: %s", err))
+		return diag.FromErr(flex.FmtErrorf("[ERROR] Error setting href: %s", err))
 	}
 
 	if dedicatedHostDisk.InstanceDisks != nil {
 		err = d.Set("instance_disks", dataSourceDedicatedHostDiskFlattenInstanceDisks(dedicatedHostDisk.InstanceDisks))
 		if err != nil {
-			return diag.FromErr(fmt.Errorf("[ERROR] Error setting instance_disks %s", err))
+			return diag.FromErr(flex.FmtErrorf("[ERROR] Error setting instance_disks %s", err))
 		}
 	}
 	if err = d.Set("interface_type", dedicatedHostDisk.InterfaceType); err != nil {
-		return diag.FromErr(fmt.Errorf("[ERROR] Error setting interface_type: %s", err))
+		return diag.FromErr(flex.FmtErrorf("[ERROR] Error setting interface_type: %s", err))
 	}
 	if dedicatedHostDisk.LifecycleState != nil {
 		if err = d.Set("lifecycle_state", dedicatedHostDisk.LifecycleState); err != nil {
-			return diag.FromErr(fmt.Errorf("[ERROR] Error setting lifecycle_state: %s", err))
+			return diag.FromErr(flex.FmtErrorf("[ERROR] Error setting lifecycle_state: %s", err))
 		}
 	}
 	if err = d.Set("name", dedicatedHostDisk.Name); err != nil {
-		return diag.FromErr(fmt.Errorf("[ERROR] Error setting name: %s", err))
+		return diag.FromErr(flex.FmtErrorf("[ERROR] Error setting name: %s", err))
 	}
 	if err = d.Set("provisionable", dedicatedHostDisk.Provisionable); err != nil {
-		return diag.FromErr(fmt.Errorf("[ERROR] Error setting provisionable: %s", err))
+		return diag.FromErr(flex.FmtErrorf("[ERROR] Error setting provisionable: %s", err))
 	}
 	if err = d.Set("resource_type", dedicatedHostDisk.ResourceType); err != nil {
-		return diag.FromErr(fmt.Errorf("[ERROR] Error setting resource_type: %s", err))
+		return diag.FromErr(flex.FmtErrorf("[ERROR] Error setting resource_type: %s", err))
 	}
 	if err = d.Set("size", dedicatedHostDisk.Size); err != nil {
-		return diag.FromErr(fmt.Errorf("[ERROR] Error setting size: %s", err))
+		return diag.FromErr(flex.FmtErrorf("[ERROR] Error setting size: %s", err))
 	}
 	if err = d.Set("supported_instance_interface_types", dedicatedHostDisk.SupportedInstanceInterfaceTypes); err != nil {
-		return diag.FromErr(fmt.Errorf("[ERROR] Error setting supported_instance_interface_types: %s", err))
+		return diag.FromErr(flex.FmtErrorf("[ERROR] Error setting supported_instance_interface_types: %s", err))
 	}
 
 	return nil

--- a/ibm/service/vpc/data_source_ibm_is_dedicated_host_disks.go
+++ b/ibm/service/vpc/data_source_ibm_is_dedicated_host_disks.go
@@ -5,11 +5,11 @@ package vpc
 
 import (
 	"context"
-	"fmt"
 	"log"
 	"time"
 
 	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/conns"
+	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/flex"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 
@@ -161,7 +161,7 @@ func dataSourceIbmIsDedicatedHostDisksRead(context context.Context, d *schema.Re
 	if dedicatedHostDiskCollection.Disks != nil {
 		err = d.Set("disks", dataSourceDedicatedHostDiskCollectionFlattenDisks(dedicatedHostDiskCollection.Disks))
 		if err != nil {
-			return diag.FromErr(fmt.Errorf("[ERROR] Error setting disks %s", err))
+			return diag.FromErr(flex.FmtErrorf("[ERROR] Error setting disks %s", err))
 		}
 	}
 

--- a/ibm/service/vpc/data_source_ibm_is_dedicated_host_group.go
+++ b/ibm/service/vpc/data_source_ibm_is_dedicated_host_group.go
@@ -5,10 +5,10 @@ package vpc
 
 import (
 	"context"
-	"fmt"
 	"log"
 
 	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/conns"
+	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/flex"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 
@@ -157,58 +157,58 @@ func dataSourceIbmIsDedicatedHostGroupRead(context context.Context, d *schema.Re
 
 		d.SetId(*dedicatedHostGroup.ID)
 		if err = d.Set("class", dedicatedHostGroup.Class); err != nil {
-			return diag.FromErr(fmt.Errorf("[ERROR] Error setting class: %s", err))
+			return diag.FromErr(flex.FmtErrorf("[ERROR] Error setting class: %s", err))
 		}
 		if dedicatedHostGroup.CreatedAt != nil {
 			if err = d.Set("created_at", dedicatedHostGroup.CreatedAt.String()); err != nil {
-				return diag.FromErr(fmt.Errorf("[ERROR] Error setting created_at: %s", err))
+				return diag.FromErr(flex.FmtErrorf("[ERROR] Error setting created_at: %s", err))
 			}
 		}
 
 		if err = d.Set("crn", dedicatedHostGroup.CRN); err != nil {
-			return diag.FromErr(fmt.Errorf("[ERROR] Error setting crn: %s", err))
+			return diag.FromErr(flex.FmtErrorf("[ERROR] Error setting crn: %s", err))
 		}
 
 		if dedicatedHostGroup.DedicatedHosts != nil {
 			err = d.Set("dedicated_hosts", dataSourceDedicatedHostGroupFlattenDedicatedHosts(dedicatedHostGroup.DedicatedHosts))
 			if err != nil {
-				return diag.FromErr(fmt.Errorf("[ERROR] Error setting dedicated_hosts %s", err))
+				return diag.FromErr(flex.FmtErrorf("[ERROR] Error setting dedicated_hosts %s", err))
 			}
 		}
 		if err = d.Set("family", dedicatedHostGroup.Family); err != nil {
-			return diag.FromErr(fmt.Errorf("[ERROR] Error setting family: %s", err))
+			return diag.FromErr(flex.FmtErrorf("[ERROR] Error setting family: %s", err))
 		}
 		if err = d.Set("href", dedicatedHostGroup.Href); err != nil {
-			return diag.FromErr(fmt.Errorf("[ERROR] Error setting href: %s", err))
+			return diag.FromErr(flex.FmtErrorf("[ERROR] Error setting href: %s", err))
 		}
 
 		if dedicatedHostGroup.ResourceGroup != nil {
 			err = d.Set("resource_group", *dedicatedHostGroup.ResourceGroup.ID)
 			if err != nil {
-				return diag.FromErr(fmt.Errorf("[ERROR] Error setting resource_group %s", err))
+				return diag.FromErr(flex.FmtErrorf("[ERROR] Error setting resource_group %s", err))
 			}
 		}
 		if err = d.Set("resource_type", dedicatedHostGroup.ResourceType); err != nil {
-			return diag.FromErr(fmt.Errorf("[ERROR] Error setting resource_type: %s", err))
+			return diag.FromErr(flex.FmtErrorf("[ERROR] Error setting resource_type: %s", err))
 		}
 
 		if dedicatedHostGroup.SupportedInstanceProfiles != nil {
 			err = d.Set("supported_instance_profiles", dataSourceDedicatedHostGroupFlattenSupportedInstanceProfiles(dedicatedHostGroup.SupportedInstanceProfiles))
 			if err != nil {
-				return diag.FromErr(fmt.Errorf("[ERROR] Error setting supported_instance_profiles %s", err))
+				return diag.FromErr(flex.FmtErrorf("[ERROR] Error setting supported_instance_profiles %s", err))
 			}
 		}
 
 		if dedicatedHostGroup.Zone != nil {
 			err = d.Set("zone", *dedicatedHostGroup.Zone.Name)
 			if err != nil {
-				return diag.FromErr(fmt.Errorf("[ERROR] Error setting zone %s", err))
+				return diag.FromErr(flex.FmtErrorf("[ERROR] Error setting zone %s", err))
 			}
 		}
 		return nil
 
 	}
-	return diag.FromErr(fmt.Errorf("[ERROR] No Dedicated Host Group found with name %s", name))
+	return diag.FromErr(flex.FmtErrorf("[ERROR] No Dedicated Host Group found with name %s", name))
 }
 
 func dataSourceDedicatedHostGroupFlattenDedicatedHosts(result []vpcv1.DedicatedHostReference) (dedicatedHosts []map[string]interface{}) {

--- a/ibm/service/vpc/data_source_ibm_is_dedicated_host_groups.go
+++ b/ibm/service/vpc/data_source_ibm_is_dedicated_host_groups.go
@@ -5,7 +5,6 @@ package vpc
 
 import (
 	"context"
-	"fmt"
 	"log"
 	"time"
 
@@ -215,11 +214,11 @@ func dataSourceIbmIsDedicatedHostGroupsRead(context context.Context, d *schema.R
 		d.SetId(dataSourceIbmIsDedicatedHostGroupsID(d))
 		err = d.Set("host_groups", dataSourceDedicatedHostGroupCollectionFlattenGroups(allrecs))
 		if err != nil {
-			return diag.FromErr(fmt.Errorf("[ERROR] Error setting groups %s", err))
+			return diag.FromErr(flex.FmtErrorf("[ERROR] Error setting groups %s", err))
 		}
 
 		if err = d.Set("total_count", len(allrecs)); err != nil {
-			return diag.FromErr(fmt.Errorf("[ERROR] Error setting total_count: %s", err))
+			return diag.FromErr(flex.FmtErrorf("[ERROR] Error setting total_count: %s", err))
 		}
 
 	}

--- a/ibm/service/vpc/data_source_ibm_is_dedicated_host_profile.go
+++ b/ibm/service/vpc/data_source_ibm_is_dedicated_host_profile.go
@@ -5,11 +5,11 @@ package vpc
 
 import (
 	"context"
-	"fmt"
 	"log"
 	"time"
 
 	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/conns"
+	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/flex"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 
@@ -345,62 +345,62 @@ func dataSourceIbmIsDedicatedHostProfileRead(context context.Context, d *schema.
 		return diag.FromErr(err)
 	}
 	if dedicatedHostProfile == nil {
-		return diag.FromErr(fmt.Errorf("[ERROR] No Dedicated Host Profile found with name %s", name))
+		return diag.FromErr(flex.FmtErrorf("[ERROR] No Dedicated Host Profile found with name %s", name))
 	}
 	d.SetId(dataSourceIbmIsDedicatedHostProfileID(d))
 
 	if err = d.Set("class", dedicatedHostProfile.Class); err != nil {
-		return diag.FromErr(fmt.Errorf("[ERROR] Error setting class: %s", err))
+		return diag.FromErr(flex.FmtErrorf("[ERROR] Error setting class: %s", err))
 	}
 
 	if dedicatedHostProfile.Disks != nil {
 		err = d.Set("disks", dataSourceDedicatedHostProfileFlattenDisks(dedicatedHostProfile.Disks))
 		if err != nil {
-			return diag.FromErr(fmt.Errorf("[ERROR] Error setting disks %s", err))
+			return diag.FromErr(flex.FmtErrorf("[ERROR] Error setting disks %s", err))
 		}
 	}
 	if dedicatedHostProfile.Status != nil {
 		d.Set("status", dedicatedHostProfile.Status)
 	}
 	if err = d.Set("family", dedicatedHostProfile.Family); err != nil {
-		return diag.FromErr(fmt.Errorf("[ERROR] Error setting family: %s", err))
+		return diag.FromErr(flex.FmtErrorf("[ERROR] Error setting family: %s", err))
 	}
 	if err = d.Set("href", dedicatedHostProfile.Href); err != nil {
-		return diag.FromErr(fmt.Errorf("[ERROR] Error setting href: %s", err))
+		return diag.FromErr(flex.FmtErrorf("[ERROR] Error setting href: %s", err))
 	}
 
 	if dedicatedHostProfile.Memory != nil {
 		err = d.Set("memory", dataSourceDedicatedHostProfileFlattenMemory(*dedicatedHostProfile.Memory.(*vpcv1.DedicatedHostProfileMemory)))
 		if err != nil {
-			return diag.FromErr(fmt.Errorf("[ERROR] Error setting memory %s", err))
+			return diag.FromErr(flex.FmtErrorf("[ERROR] Error setting memory %s", err))
 		}
 	}
 
 	if dedicatedHostProfile.SocketCount != nil {
 		err = d.Set("socket_count", dataSourceDedicatedHostProfileFlattenSocketCount(*dedicatedHostProfile.SocketCount.(*vpcv1.DedicatedHostProfileSocket)))
 		if err != nil {
-			return diag.FromErr(fmt.Errorf("[ERROR] Error setting socket_count %s", err))
+			return diag.FromErr(flex.FmtErrorf("[ERROR] Error setting socket_count %s", err))
 		}
 	}
 
 	if dedicatedHostProfile.SupportedInstanceProfiles != nil {
 		err = d.Set("supported_instance_profiles", dataSourceDedicatedHostProfileFlattenSupportedInstanceProfiles(dedicatedHostProfile.SupportedInstanceProfiles))
 		if err != nil {
-			return diag.FromErr(fmt.Errorf("[ERROR] Error setting supported_instance_profiles %s", err))
+			return diag.FromErr(flex.FmtErrorf("[ERROR] Error setting supported_instance_profiles %s", err))
 		}
 	}
 
 	if dedicatedHostProfile.VcpuArchitecture != nil {
 		err = d.Set("vcpu_architecture", dataSourceDedicatedHostProfileFlattenVcpuArchitecture(*dedicatedHostProfile.VcpuArchitecture))
 		if err != nil {
-			return diag.FromErr(fmt.Errorf("[ERROR] Error setting vcpu_architecture %s", err))
+			return diag.FromErr(flex.FmtErrorf("[ERROR] Error setting vcpu_architecture %s", err))
 		}
 	}
 
 	if dedicatedHostProfile.VcpuCount != nil {
 		err = d.Set("vcpu_count", dataSourceDedicatedHostProfileFlattenVcpuCount(*dedicatedHostProfile.VcpuCount.(*vpcv1.DedicatedHostProfileVcpu)))
 		if err != nil {
-			return diag.FromErr(fmt.Errorf("[ERROR] Error setting vcpu_count %s", err))
+			return diag.FromErr(flex.FmtErrorf("[ERROR] Error setting vcpu_count %s", err))
 		}
 	}
 
@@ -408,7 +408,7 @@ func dataSourceIbmIsDedicatedHostProfileRead(context context.Context, d *schema.
 	if dedicatedHostProfile.VcpuManufacturer != nil {
 		err = d.Set("vcpu_manufacturer", dataSourceDedicatedHostProfileFlattenVcpuManufacturer(*dedicatedHostProfile.VcpuManufacturer))
 		if err != nil {
-			return diag.FromErr(fmt.Errorf("Error setting vcpu_architecture %s", err))
+			return diag.FromErr(flex.FmtErrorf("Error setting vcpu_architecture %s", err))
 		}
 	}
 

--- a/ibm/service/vpc/data_source_ibm_is_dedicated_host_profiles.go
+++ b/ibm/service/vpc/data_source_ibm_is_dedicated_host_profiles.go
@@ -5,7 +5,6 @@ package vpc
 
 import (
 	"context"
-	"fmt"
 	"log"
 	"time"
 
@@ -379,11 +378,11 @@ func dataSourceIbmIsDedicatedHostProfilesRead(context context.Context, d *schema
 
 		err = d.Set("profiles", dataSourceDedicatedHostProfileCollectionFlattenProfiles(allrecs))
 		if err != nil {
-			return diag.FromErr(fmt.Errorf("[ERROR] Error setting profiles %s", err))
+			return diag.FromErr(flex.FmtErrorf("[ERROR] Error setting profiles %s", err))
 		}
 
 		if err = d.Set("total_count", len(allrecs)); err != nil {
-			return diag.FromErr(fmt.Errorf("[ERROR] Error setting total_count: %s", err))
+			return diag.FromErr(flex.FmtErrorf("[ERROR] Error setting total_count: %s", err))
 		}
 	}
 	return nil

--- a/ibm/service/vpc/data_source_ibm_is_dedicated_hosts.go
+++ b/ibm/service/vpc/data_source_ibm_is_dedicated_hosts.go
@@ -5,7 +5,6 @@ package vpc
 
 import (
 	"context"
-	"fmt"
 	"log"
 	"time"
 
@@ -466,11 +465,11 @@ func dataSourceIbmIsDedicatedHostsRead(context context.Context, d *schema.Resour
 
 		err = d.Set("dedicated_hosts", dataSourceDedicatedHostCollectionFlattenDedicatedHosts(allrecs, meta))
 		if err != nil {
-			return diag.FromErr(fmt.Errorf("[ERROR] Error setting dedicated_hosts %s", err))
+			return diag.FromErr(flex.FmtErrorf("[ERROR] Error setting dedicated_hosts %s", err))
 		}
 
 		if err = d.Set("total_count", len(allrecs)); err != nil {
-			return diag.FromErr(fmt.Errorf("[ERROR] Error setting total_count: %s", err))
+			return diag.FromErr(flex.FmtErrorf("[ERROR] Error setting total_count: %s", err))
 		}
 	}
 	return nil

--- a/ibm/service/vpc/data_source_ibm_is_floating_ip.go
+++ b/ibm/service/vpc/data_source_ibm_is_floating_ip.go
@@ -205,7 +205,7 @@ func floatingIPGet(d *schema.ResourceData, meta interface{}, name string) error 
 		}
 		floatingIPs, response, err := sess.ListFloatingIps(floatingIPOptions)
 		if err != nil {
-			return fmt.Errorf("[ERROR] Error Fetching floating IPs %s\n%s", err, response)
+			return flex.FmtErrorf("[ERROR] Error Fetching floating IPs %s\n%s", err, response)
 		}
 		start = flex.GetNext(floatingIPs.Next)
 		allFloatingIPs = append(allFloatingIPs, floatingIPs.FloatingIps...)
@@ -249,7 +249,7 @@ func floatingIPGet(d *schema.ResourceData, meta interface{}, name string) error 
 		}
 	}
 
-	return fmt.Errorf("[ERROR] No floatingIP found with name  %s", name)
+	return flex.FmtErrorf("[ERROR] No floatingIP found with name  %s", name)
 
 }
 

--- a/ibm/service/vpc/data_source_ibm_is_floating_ips.go
+++ b/ibm/service/vpc/data_source_ibm_is_floating_ips.go
@@ -5,7 +5,6 @@ package vpc
 
 import (
 	"context"
-	"fmt"
 	"log"
 	"reflect"
 	"time"
@@ -237,7 +236,7 @@ func dataSourceIBMIsFloatingIpsRead(context context.Context, d *schema.ResourceD
 		floatingIPs, response, err := sess.ListFloatingIps(floatingIPOptions)
 		if err != nil {
 			log.Printf("[DEBUG] Error Fetching floating IPs  %s\n%s", err, response)
-			return diag.FromErr(fmt.Errorf("[ERROR] Error Fetching floating IPs %s\n%s", err, response))
+			return diag.FromErr(flex.FmtErrorf("[ERROR] Error Fetching floating IPs %s\n%s", err, response))
 		}
 		start = flex.GetNext(floatingIPs.Next)
 		allFloatingIPs = append(allFloatingIPs, floatingIPs.FloatingIps...)
@@ -262,7 +261,7 @@ func dataSourceIBMIsFloatingIpsRead(context context.Context, d *schema.ResourceD
 	}
 	if suppliedFilter {
 		if len(matchFloatingIps) == 0 {
-			return diag.FromErr(fmt.Errorf("no FloatingIps found with name %s", name))
+			return diag.FromErr(flex.FmtErrorf("no FloatingIps found with name %s", name))
 		}
 		d.SetId(name)
 	} else {
@@ -272,7 +271,7 @@ func dataSourceIBMIsFloatingIpsRead(context context.Context, d *schema.ResourceD
 	if matchFloatingIps != nil {
 		err = d.Set("floating_ips", dataSourceFloatingIPCollectionFlattenFloatingIps(matchFloatingIps, d, meta))
 		if err != nil {
-			return diag.FromErr(fmt.Errorf("[ERROR] Error setting floating_ips %s", err))
+			return diag.FromErr(flex.FmtErrorf("[ERROR] Error setting floating_ips %s", err))
 		}
 	}
 	return nil

--- a/ibm/service/vpc/data_source_ibm_is_flow_log.go
+++ b/ibm/service/vpc/data_source_ibm_is_flow_log.go
@@ -5,7 +5,6 @@ package vpc
 
 import (
 	"context"
-	"fmt"
 	"log"
 
 	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/flex"
@@ -221,13 +220,13 @@ func dataSourceIBMIsFlowLogRead(context context.Context, d *schema.ResourceData,
 
 		flowlogCollectors, response, err := sess.ListFlowLogCollectors(listOptions)
 		if err != nil {
-			return diag.FromErr(fmt.Errorf("Error Fetching Flow Logs for VPC %s\n%s", err, response))
+			return diag.FromErr(flex.FmtErrorf("Error Fetching Flow Logs for VPC %s\n%s", err, response))
 		}
 
 		allrecs := flowlogCollectors.FlowLogCollectors
 
 		if len(allrecs) == 0 {
-			return diag.FromErr(fmt.Errorf("[ERROR] No flow log collector found with name (%s)", name))
+			return diag.FromErr(flex.FmtErrorf("[ERROR] No flow log collector found with name (%s)", name))
 		}
 		flc := allrecs[0]
 		flowLogCollector = &flc
@@ -240,48 +239,48 @@ func dataSourceIBMIsFlowLogRead(context context.Context, d *schema.ResourceData,
 		flowlogCollector, response, err := sess.GetFlowLogCollectorWithContext(context, getFlowLogCollectorOptions)
 		if err != nil {
 			log.Printf("[DEBUG] GetFlowLogCollectorWithContext failed %s\n%s", err, response)
-			return diag.FromErr(fmt.Errorf("GetFlowLogCollectorWithContext failed %s\n%s", err, response))
+			return diag.FromErr(flex.FmtErrorf("GetFlowLogCollectorWithContext failed %s\n%s", err, response))
 		}
 		flowLogCollector = flowlogCollector
 	}
 
 	d.SetId(*flowLogCollector.ID)
 	if err = d.Set("active", flowLogCollector.Active); err != nil {
-		return diag.FromErr(fmt.Errorf("[ERROR] Error setting active: %s", err))
+		return diag.FromErr(flex.FmtErrorf("[ERROR] Error setting active: %s", err))
 	}
 	if err = d.Set("auto_delete", flowLogCollector.AutoDelete); err != nil {
-		return diag.FromErr(fmt.Errorf("[ERROR] Error setting auto_delete: %s", err))
+		return diag.FromErr(flex.FmtErrorf("[ERROR] Error setting auto_delete: %s", err))
 	}
 	if err = d.Set("created_at", flex.DateTimeToString(flowLogCollector.CreatedAt)); err != nil {
-		return diag.FromErr(fmt.Errorf("[ERROR] Error setting created_at: %s", err))
+		return diag.FromErr(flex.FmtErrorf("[ERROR] Error setting created_at: %s", err))
 	}
 	if err = d.Set("crn", flowLogCollector.CRN); err != nil {
-		return diag.FromErr(fmt.Errorf("[ERROR] Error setting crn: %s", err))
+		return diag.FromErr(flex.FmtErrorf("[ERROR] Error setting crn: %s", err))
 	}
 	if err = d.Set("href", flowLogCollector.Href); err != nil {
-		return diag.FromErr(fmt.Errorf("[ERROR] Error setting href: %s", err))
+		return diag.FromErr(flex.FmtErrorf("[ERROR] Error setting href: %s", err))
 	}
 	if err = d.Set("lifecycle_state", flowLogCollector.LifecycleState); err != nil {
-		return diag.FromErr(fmt.Errorf("[ERROR] Error setting lifecycle_state: %s", err))
+		return diag.FromErr(flex.FmtErrorf("[ERROR] Error setting lifecycle_state: %s", err))
 	}
 	if err = d.Set("name", flowLogCollector.Name); err != nil {
-		return diag.FromErr(fmt.Errorf("[ERROR] Error setting name: %s", err))
+		return diag.FromErr(flex.FmtErrorf("[ERROR] Error setting name: %s", err))
 	}
 	if err = d.Set("identifier", *flowLogCollector.ID); err != nil {
-		return diag.FromErr(fmt.Errorf("[ERROR] Error setting identifier: %s", err))
+		return diag.FromErr(flex.FmtErrorf("[ERROR] Error setting identifier: %s", err))
 	}
 
 	if flowLogCollector.ResourceGroup != nil {
 		err = d.Set("resource_group", dataSourceFlowLogCollectorFlattenResourceGroup(*flowLogCollector.ResourceGroup))
 		if err != nil {
-			return diag.FromErr(fmt.Errorf("[ERROR] Error setting resource_group %s", err))
+			return diag.FromErr(flex.FmtErrorf("[ERROR] Error setting resource_group %s", err))
 		}
 	}
 
 	if flowLogCollector.StorageBucket != nil {
 		err = d.Set("storage_bucket", dataSourceFlowLogCollectorFlattenStorageBucket(*flowLogCollector.StorageBucket))
 		if err != nil {
-			return diag.FromErr(fmt.Errorf("[ERROR] Error setting storage_bucket %s", err))
+			return diag.FromErr(flex.FmtErrorf("[ERROR] Error setting storage_bucket %s", err))
 		}
 	}
 
@@ -290,14 +289,14 @@ func dataSourceIBMIsFlowLogRead(context context.Context, d *schema.ResourceData,
 		target := targetIntf.(*vpcv1.FlowLogCollectorTarget)
 		err = d.Set("target", dataSourceFlowLogCollectorFlattenTarget(*target))
 		if err != nil {
-			return diag.FromErr(fmt.Errorf("[ERROR] Error setting target %s", err))
+			return diag.FromErr(flex.FmtErrorf("[ERROR] Error setting target %s", err))
 		}
 	}
 
 	if flowLogCollector.VPC != nil {
 		err = d.Set("vpc", dataSourceFlowLogCollectorFlattenVPC(*flowLogCollector.VPC))
 		if err != nil {
-			return diag.FromErr(fmt.Errorf("[ERROR] Error setting vpc %s", err))
+			return diag.FromErr(flex.FmtErrorf("[ERROR] Error setting vpc %s", err))
 		}
 	}
 
@@ -309,7 +308,7 @@ func dataSourceIBMIsFlowLogRead(context context.Context, d *schema.ResourceData,
 
 	err = d.Set(isFlowLogAccessTags, accesstags)
 	if err != nil {
-		return diag.FromErr(fmt.Errorf("[ERROR] Error setting access tags %s", err))
+		return diag.FromErr(flex.FmtErrorf("[ERROR] Error setting access tags %s", err))
 	}
 	return nil
 }

--- a/ibm/service/vpc/data_source_ibm_is_flow_logs.go
+++ b/ibm/service/vpc/data_source_ibm_is_flow_logs.go
@@ -4,7 +4,6 @@
 package vpc
 
 import (
-	"fmt"
 	"log"
 	"time"
 
@@ -184,7 +183,7 @@ func dataSourceIBMISFlowLogsRead(d *schema.ResourceData, meta interface{}) error
 		}
 		flowlogCollectors, response, err := sess.ListFlowLogCollectors(listOptions)
 		if err != nil {
-			return fmt.Errorf("[ERROR] Error Fetching Flow Logs for VPC %s\n%s", err, response)
+			return flex.FmtErrorf("[ERROR] Error Fetching Flow Logs for VPC %s\n%s", err, response)
 		}
 		start = flex.GetNext(flowlogCollectors.Next)
 		allrecs = append(allrecs, flowlogCollectors.FlowLogCollectors...)

--- a/ibm/service/vpc/data_source_ibm_is_ike_policies.go
+++ b/ibm/service/vpc/data_source_ibm_is_ike_policies.go
@@ -5,7 +5,6 @@ package vpc
 
 import (
 	"context"
-	"fmt"
 	"log"
 	"time"
 
@@ -173,7 +172,7 @@ func dataSourceIBMIsIkePoliciesRead(context context.Context, d *schema.ResourceD
 		ikePolicyCollection, response, err := vpcClient.ListIkePoliciesWithContext(context, listIkePoliciesOptions)
 		if err != nil || ikePolicyCollection == nil {
 			log.Printf("[DEBUG] ListIkePoliciesWithContext failed %s\n%s", err, response)
-			return diag.FromErr(fmt.Errorf("ListIkePoliciesWithContext failed %s\n%s", err, response))
+			return diag.FromErr(flex.FmtErrorf("ListIkePoliciesWithContext failed %s\n%s", err, response))
 		}
 		start = flex.GetNext(ikePolicyCollection.Next)
 		allrecs = append(allrecs, ikePolicyCollection.IkePolicies...)
@@ -186,7 +185,7 @@ func dataSourceIBMIsIkePoliciesRead(context context.Context, d *schema.ResourceD
 
 	err = d.Set("ike_policies", dataSourceIkePolicyCollectionFlattenIkePolicies(allrecs))
 	if err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting ike_policies %s", err))
+		return diag.FromErr(flex.FmtErrorf("Error setting ike_policies %s", err))
 	}
 
 	return nil

--- a/ibm/service/vpc/data_source_ibm_is_ike_policy.go
+++ b/ibm/service/vpc/data_source_ibm_is_ike_policy.go
@@ -5,7 +5,6 @@ package vpc
 
 import (
 	"context"
-	"fmt"
 	"log"
 
 	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/conns"
@@ -168,7 +167,7 @@ func dataSourceIBMIsIkePolicyRead(context context.Context, d *schema.ResourceDat
 			}
 			ikePolicies, response, err := vpcClient.ListIkePolicies(listIkePoliciesyOptions)
 			if err != nil {
-				return diag.FromErr(fmt.Errorf("Error Fetching IKE Policies %s\n%s", err, response))
+				return diag.FromErr(flex.FmtErrorf("Error Fetching IKE Policies %s\n%s", err, response))
 			}
 			start = flex.GetNext(ikePolicies.Next)
 			allrecs = append(allrecs, ikePolicies.IkePolicies...)
@@ -186,7 +185,7 @@ func dataSourceIBMIsIkePolicyRead(context context.Context, d *schema.ResourceDat
 		}
 		if !ike_policy_found {
 			log.Printf("[DEBUG] No ike policy found with given name %s", name)
-			return diag.FromErr(fmt.Errorf("No ike policy found with given name %s", name))
+			return diag.FromErr(flex.FmtErrorf("No ike policy found with given name %s", name))
 		}
 
 	} else {
@@ -197,55 +196,55 @@ func dataSourceIBMIsIkePolicyRead(context context.Context, d *schema.ResourceDat
 		ikePolicy1, response, err := vpcClient.GetIkePolicyWithContext(context, getIkePolicyOptions)
 		if err != nil {
 			log.Printf("[DEBUG] GetIkePolicyWithContext failed %s\n%s", err, response)
-			return diag.FromErr(fmt.Errorf("GetIkePolicyWithContext failed %s\n%s", err, response))
+			return diag.FromErr(flex.FmtErrorf("GetIkePolicyWithContext failed %s\n%s", err, response))
 		}
 		ikePolicy = ikePolicy1
 	}
 
 	d.SetId(*ikePolicy.ID)
 	if err = d.Set("authentication_algorithm", ikePolicy.AuthenticationAlgorithm); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting authentication_algorithm: %s", err))
+		return diag.FromErr(flex.FmtErrorf("Error setting authentication_algorithm: %s", err))
 	}
 
 	if ikePolicy.Connections != nil {
 		err = d.Set("connections", dataSourceIkePolicyFlattenConnections(ikePolicy.Connections))
 		if err != nil {
-			return diag.FromErr(fmt.Errorf("Error setting connections %s", err))
+			return diag.FromErr(flex.FmtErrorf("Error setting connections %s", err))
 		}
 	}
 	if err = d.Set("created_at", flex.DateTimeToString(ikePolicy.CreatedAt)); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting created_at: %s", err))
+		return diag.FromErr(flex.FmtErrorf("Error setting created_at: %s", err))
 	}
 	if err = d.Set("dh_group", flex.IntValue(ikePolicy.DhGroup)); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting dh_group: %s", err))
+		return diag.FromErr(flex.FmtErrorf("Error setting dh_group: %s", err))
 	}
 	if err = d.Set("encryption_algorithm", ikePolicy.EncryptionAlgorithm); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting encryption_algorithm: %s", err))
+		return diag.FromErr(flex.FmtErrorf("Error setting encryption_algorithm: %s", err))
 	}
 	if err = d.Set("href", ikePolicy.Href); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting href: %s", err))
+		return diag.FromErr(flex.FmtErrorf("Error setting href: %s", err))
 	}
 	if err = d.Set("ike_version", flex.IntValue(ikePolicy.IkeVersion)); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting ike_version: %s", err))
+		return diag.FromErr(flex.FmtErrorf("Error setting ike_version: %s", err))
 	}
 	if err = d.Set("key_lifetime", flex.IntValue(ikePolicy.KeyLifetime)); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting key_lifetime: %s", err))
+		return diag.FromErr(flex.FmtErrorf("Error setting key_lifetime: %s", err))
 	}
 	if err = d.Set("name", ikePolicy.Name); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting name: %s", err))
+		return diag.FromErr(flex.FmtErrorf("Error setting name: %s", err))
 	}
 	if err = d.Set("negotiation_mode", ikePolicy.NegotiationMode); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting negotiation_mode: %s", err))
+		return diag.FromErr(flex.FmtErrorf("Error setting negotiation_mode: %s", err))
 	}
 
 	if ikePolicy.ResourceGroup != nil {
 		err = d.Set("resource_group", dataSourceIkePolicyFlattenResourceGroup(*ikePolicy.ResourceGroup))
 		if err != nil {
-			return diag.FromErr(fmt.Errorf("Error setting resource_group %s", err))
+			return diag.FromErr(flex.FmtErrorf("Error setting resource_group %s", err))
 		}
 	}
 	if err = d.Set("resource_type", ikePolicy.ResourceType); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting resource_type: %s", err))
+		return diag.FromErr(flex.FmtErrorf("Error setting resource_type: %s", err))
 	}
 
 	return nil

--- a/ibm/service/vpc/data_source_ibm_is_image.go
+++ b/ibm/service/vpc/data_source_ibm_is_image.go
@@ -288,12 +288,12 @@ func imageGetByName(d *schema.ResourceData, meta interface{}, name, visibility s
 	}
 	availableImages, response, err := sess.ListImages(listImagesOptions)
 	if err != nil {
-		return fmt.Errorf("[ERROR] Error Fetching Images %s\n%s", err, response)
+		return flex.FmtErrorf("[ERROR] Error Fetching Images %s\n%s", err, response)
 	}
 	allrecs := availableImages.Images
 
 	if len(allrecs) == 0 {
-		return fmt.Errorf("[ERROR] No image found with name  %s", name)
+		return flex.FmtErrorf("[ERROR] No image found with name  %s", name)
 	}
 	image := allrecs[0]
 	d.SetId(*image.ID)
@@ -371,9 +371,9 @@ func imageGetById(d *schema.ResourceData, meta interface{}, identifier string) e
 	image, response, err := sess.GetImage(getImageOptions)
 	if err != nil {
 		if response.StatusCode == 404 {
-			return fmt.Errorf("[ERROR] No image found with id  %s", identifier)
+			return flex.FmtErrorf("[ERROR] No image found with id  %s", identifier)
 		}
-		return fmt.Errorf("[ERROR] Error Fetching Images %s\n%s", err, response)
+		return flex.FmtErrorf("[ERROR] Error Fetching Images %s\n%s", err, response)
 	}
 
 	d.SetId(*image.ID)

--- a/ibm/service/vpc/data_source_ibm_is_image_export_job.go
+++ b/ibm/service/vpc/data_source_ibm_is_image_export_job.go
@@ -156,45 +156,45 @@ func DataSourceIBMIsImageExportRead(context context.Context, d *schema.ResourceD
 	imageExportJob, response, err := vpcClient.GetImageExportJobWithContext(context, getImageExportJobOptions)
 	if err != nil {
 		log.Printf("[DEBUG] GetImageExportJobWithContext failed %s\n%s", err, response)
-		return diag.FromErr(fmt.Errorf("GetImageExportJobWithContext failed %s\n%s", err, response))
+		return diag.FromErr(flex.FmtErrorf("GetImageExportJobWithContext failed %s\n%s", err, response))
 	}
 
 	d.SetId(fmt.Sprintf("%s/%s", *getImageExportJobOptions.ImageID, *getImageExportJobOptions.ID))
 
 	if err = d.Set("completed_at", flex.DateTimeToString(imageExportJob.CompletedAt)); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting completed_at: %s", err))
+		return diag.FromErr(flex.FmtErrorf("Error setting completed_at: %s", err))
 	}
 
 	if err = d.Set("created_at", flex.DateTimeToString(imageExportJob.CreatedAt)); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting created_at: %s", err))
+		return diag.FromErr(flex.FmtErrorf("Error setting created_at: %s", err))
 	}
 
 	if err = d.Set("encrypted_data_key", imageExportJob.EncryptedDataKey); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting encrypted_data_key: %s", err))
+		return diag.FromErr(flex.FmtErrorf("Error setting encrypted_data_key: %s", err))
 	}
 
 	if err = d.Set("format", imageExportJob.Format); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting format: %s", err))
+		return diag.FromErr(flex.FmtErrorf("Error setting format: %s", err))
 	}
 
 	if err = d.Set("href", imageExportJob.Href); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting href: %s", err))
+		return diag.FromErr(flex.FmtErrorf("Error setting href: %s", err))
 	}
 
 	if err = d.Set("name", imageExportJob.Name); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting name: %s", err))
+		return diag.FromErr(flex.FmtErrorf("Error setting name: %s", err))
 	}
 
 	if err = d.Set("resource_type", imageExportJob.ResourceType); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting resource_type: %s", err))
+		return diag.FromErr(flex.FmtErrorf("Error setting resource_type: %s", err))
 	}
 
 	if err = d.Set("started_at", flex.DateTimeToString(imageExportJob.StartedAt)); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting started_at: %s", err))
+		return diag.FromErr(flex.FmtErrorf("Error setting started_at: %s", err))
 	}
 
 	if err = d.Set("status", imageExportJob.Status); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting status: %s", err))
+		return diag.FromErr(flex.FmtErrorf("Error setting status: %s", err))
 	}
 
 	statusReasons := []map[string]interface{}{}
@@ -208,7 +208,7 @@ func DataSourceIBMIsImageExportRead(context context.Context, d *schema.ResourceD
 		}
 	}
 	if err = d.Set("status_reasons", statusReasons); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting status_reasons %s", err))
+		return diag.FromErr(flex.FmtErrorf("Error setting status_reasons %s", err))
 	}
 
 	storageBucket := []map[string]interface{}{}
@@ -220,11 +220,11 @@ func DataSourceIBMIsImageExportRead(context context.Context, d *schema.ResourceD
 		storageBucket = append(storageBucket, modelMap)
 	}
 	if err = d.Set("storage_bucket", storageBucket); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting storage_bucket %s", err))
+		return diag.FromErr(flex.FmtErrorf("Error setting storage_bucket %s", err))
 	}
 
 	if err = d.Set("storage_href", imageExportJob.StorageHref); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting storage_href: %s", err))
+		return diag.FromErr(flex.FmtErrorf("Error setting storage_href: %s", err))
 	}
 
 	storageObject := []map[string]interface{}{}
@@ -236,7 +236,7 @@ func DataSourceIBMIsImageExportRead(context context.Context, d *schema.ResourceD
 		storageObject = append(storageObject, modelMap)
 	}
 	if err = d.Set("storage_object", storageObject); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting storage_object %s", err))
+		return diag.FromErr(flex.FmtErrorf("Error setting storage_object %s", err))
 	}
 
 	return nil

--- a/ibm/service/vpc/data_source_ibm_is_image_export_jobs.go
+++ b/ibm/service/vpc/data_source_ibm_is_image_export_jobs.go
@@ -5,10 +5,10 @@ package vpc
 
 import (
 	"context"
-	"fmt"
 	"log"
 	"time"
 
+	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/flex"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 
@@ -164,7 +164,7 @@ func DataSourceIBMIsImageExportsRead(context context.Context, d *schema.Resource
 	imageExportJobUnpaginatedCollection, response, err := vpcClient.ListImageExportJobsWithContext(context, listImageExportJobsOptions)
 	if err != nil {
 		log.Printf("[DEBUG] ListImageExportJobsWithContext failed %s\n%s", err, response)
-		return diag.FromErr(fmt.Errorf("ListImageExportJobsWithContext failed %s\n%s", err, response))
+		return diag.FromErr(flex.FmtErrorf("ListImageExportJobsWithContext failed %s\n%s", err, response))
 	}
 
 	d.SetId(DataSourceIBMIsImageExportsID(d))
@@ -180,7 +180,7 @@ func DataSourceIBMIsImageExportsRead(context context.Context, d *schema.Resource
 		}
 	}
 	if err = d.Set("export_jobs", exportJobs); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting export_jobs %s", err))
+		return diag.FromErr(flex.FmtErrorf("Error setting export_jobs %s", err))
 	}
 
 	return nil

--- a/ibm/service/vpc/data_source_ibm_is_images.go
+++ b/ibm/service/vpc/data_source_ibm_is_images.go
@@ -4,7 +4,6 @@
 package vpc
 
 import (
-	"fmt"
 	"log"
 	"time"
 
@@ -338,7 +337,7 @@ func imageList(d *schema.ResourceData, meta interface{}) error {
 		}
 		availableImages, response, err := sess.ListImages(listImagesOptions)
 		if err != nil {
-			return fmt.Errorf("[ERROR] Error Fetching Images %s\n%s", err, response)
+			return flex.FmtErrorf("[ERROR] Error Fetching Images %s\n%s", err, response)
 		}
 		start = flex.GetNext(availableImages.Next)
 		allrecs = append(allrecs, availableImages.Images...)

--- a/ibm/service/vpc/data_source_ibm_is_instance.go
+++ b/ibm/service/vpc/data_source_ibm_is_instance.go
@@ -1119,12 +1119,12 @@ func instanceGetByName(d *schema.ResourceData, meta interface{}, name string) er
 
 	instances, response, err := sess.ListInstances(listInstancesOptions)
 	if err != nil {
-		return fmt.Errorf("[ERROR] Error Fetching Instances %s\n%s", err, response)
+		return flex.FmtErrorf("[ERROR] Error Fetching Instances %s\n%s", err, response)
 	}
 	allrecs := instances.Instances
 
 	if len(allrecs) == 0 {
-		return fmt.Errorf("[ERROR] No Instance found with name %s", name)
+		return flex.FmtErrorf("[ERROR] No Instance found with name %s", name)
 	}
 	instance := allrecs[0]
 	d.SetId(*instance.ID)
@@ -1245,7 +1245,7 @@ func instanceGetByName(d *schema.ResourceData, meta interface{}, name string) er
 		}
 		insnic, response, err := sess.GetInstanceNetworkInterface(getnicoptions)
 		if err != nil {
-			return fmt.Errorf("[ERROR] Error getting network interfaces attached to the instance %s\n%s", err, response)
+			return flex.FmtErrorf("[ERROR] Error getting network interfaces attached to the instance %s\n%s", err, response)
 		}
 		if insnic.PortSpeed != nil {
 			currentPrimNic[isInstanceNicPortSpeed] = *insnic.PortSpeed
@@ -1310,7 +1310,7 @@ func instanceGetByName(d *schema.ResourceData, meta interface{}, name string) er
 				}
 				insnic, response, err := sess.GetInstanceNetworkInterface(getnicoptions)
 				if err != nil {
-					return fmt.Errorf("[ERROR] Error getting network interfaces attached to the instance %s\n%s", err, response)
+					return flex.FmtErrorf("[ERROR] Error getting network interfaces attached to the instance %s\n%s", err, response)
 				}
 				currentNic[isInstanceNicSubnet] = *insnic.Subnet.ID
 				if len(insnic.SecurityGroups) != 0 {
@@ -1354,14 +1354,14 @@ func instanceGetByName(d *schema.ResourceData, meta interface{}, name string) er
 				if keyFlag != "" {
 					block, err := pem.Decode(keybytes)
 					if block == nil {
-						return fmt.Errorf("[ERROR] Failed to load the private key from the given key contents. Instead of the key file path, please make sure the private key is pem format (%v)", err)
+						return flex.FmtErrorf("[ERROR] Failed to load the private key from the given key contents. Instead of the key file path, please make sure the private key is pem format (%v)", err)
 					}
 					isEncrypted := false
 					if block.Type == "OPENSSH PRIVATE KEY" {
 						var err error
 						isEncrypted, err = isOpenSSHPrivKeyEncrypted(block.Bytes)
 						if err != nil {
-							return fmt.Errorf("[ERROR] Failed to check if the provided open ssh key is encrypted or not %s", err)
+							return flex.FmtErrorf("[ERROR] Failed to check if the provided open ssh key is encrypted or not %s", err)
 						}
 					} else {
 						isEncrypted = x509.IsEncryptedPEMBlock(block)
@@ -1372,24 +1372,24 @@ func instanceGetByName(d *schema.ResourceData, meta interface{}, name string) er
 						if pass, ok := d.GetOk(isInstancePassphrase); ok {
 							passphrase = pass.(string)
 						} else {
-							return fmt.Errorf("[ERROR] Mandatory field 'passphrase' not provided")
+							return flex.FmtErrorf("[ERROR] Mandatory field 'passphrase' not provided")
 						}
 						var err error
 						privateKey, err = sshkeys.ParseEncryptedRawPrivateKey(keybytes, []byte(passphrase))
 						if err != nil {
-							return fmt.Errorf("[ERROR] Fail to decrypting the private key: %s", err)
+							return flex.FmtErrorf("[ERROR] Fail to decrypting the private key: %s", err)
 						}
 					} else {
 						var err error
 						privateKey, err = sshkeys.ParseEncryptedRawPrivateKey(keybytes, nil)
 						if err != nil {
-							return fmt.Errorf("[ERROR] Fail to decrypting the private key: %s", err)
+							return flex.FmtErrorf("[ERROR] Fail to decrypting the private key: %s", err)
 						}
 					}
 					var ok bool
 					rsaKey, ok = privateKey.(*rsa.PrivateKey)
 					if !ok {
-						return fmt.Errorf("[ERROR] Failed to convert to RSA private key")
+						return flex.FmtErrorf("[ERROR] Failed to convert to RSA private key")
 					}
 				}
 			}
@@ -1401,7 +1401,7 @@ func instanceGetByName(d *schema.ResourceData, meta interface{}, name string) er
 	}
 	initParms, response, err := sess.GetInstanceInitialization(getInstanceInitializationOptions)
 	if err != nil {
-		return fmt.Errorf("[ERROR] Error Getting instance Initialization: %s\n%s", err, response)
+		return flex.FmtErrorf("[ERROR] Error Getting instance Initialization: %s\n%s", err, response)
 	}
 	if initParms.Keys != nil {
 		initKeyList := make([]map[string]interface{}, 0)
@@ -1438,7 +1438,7 @@ func instanceGetByName(d *schema.ResourceData, meta interface{}, name string) er
 			rng := rand.Reader
 			clearPassword, err := rsa.DecryptPKCS1v15(rng, rsaKey, ciphertext)
 			if err != nil {
-				return fmt.Errorf("[ERROR] Can not decrypt the password with the given key, %s", err)
+				return flex.FmtErrorf("[ERROR] Can not decrypt the password with the given key, %s", err)
 			}
 			password = string(clearPassword)
 		}

--- a/ibm/service/vpc/data_source_ibm_is_instance_disk.go
+++ b/ibm/service/vpc/data_source_ibm_is_instance_disk.go
@@ -5,10 +5,10 @@ package vpc
 
 import (
 	"context"
-	"fmt"
 	"log"
 
 	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/conns"
+	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/flex"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 
@@ -83,22 +83,22 @@ func dataSourceIbmIsInstanceDiskRead(context context.Context, d *schema.Resource
 
 	d.SetId(*instanceDisk.ID)
 	if err = d.Set("created_at", instanceDisk.CreatedAt.String()); err != nil {
-		return diag.FromErr(fmt.Errorf("[ERROR] Error setting created_at: %s", err))
+		return diag.FromErr(flex.FmtErrorf("[ERROR] Error setting created_at: %s", err))
 	}
 	if err = d.Set("href", instanceDisk.Href); err != nil {
-		return diag.FromErr(fmt.Errorf("[ERROR] Error setting href: %s", err))
+		return diag.FromErr(flex.FmtErrorf("[ERROR] Error setting href: %s", err))
 	}
 	if err = d.Set("interface_type", instanceDisk.InterfaceType); err != nil {
-		return diag.FromErr(fmt.Errorf("[ERROR] Error setting interface_type: %s", err))
+		return diag.FromErr(flex.FmtErrorf("[ERROR] Error setting interface_type: %s", err))
 	}
 	if err = d.Set("name", instanceDisk.Name); err != nil {
-		return diag.FromErr(fmt.Errorf("[ERROR] Error setting name: %s", err))
+		return diag.FromErr(flex.FmtErrorf("[ERROR] Error setting name: %s", err))
 	}
 	if err = d.Set("resource_type", instanceDisk.ResourceType); err != nil {
-		return diag.FromErr(fmt.Errorf("[ERROR] Error setting resource_type: %s", err))
+		return diag.FromErr(flex.FmtErrorf("[ERROR] Error setting resource_type: %s", err))
 	}
 	if err = d.Set("size", instanceDisk.Size); err != nil {
-		return diag.FromErr(fmt.Errorf("[ERROR] Error setting size: %s", err))
+		return diag.FromErr(flex.FmtErrorf("[ERROR] Error setting size: %s", err))
 	}
 
 	return nil

--- a/ibm/service/vpc/data_source_ibm_is_instance_disks.go
+++ b/ibm/service/vpc/data_source_ibm_is_instance_disks.go
@@ -5,11 +5,11 @@ package vpc
 
 import (
 	"context"
-	"fmt"
 	"log"
 	"time"
 
 	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/conns"
+	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/flex"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 
@@ -94,7 +94,7 @@ func dataSourceIbmIsInstanceDisksRead(context context.Context, d *schema.Resourc
 	if instanceDiskCollection.Disks != nil {
 		err = d.Set(isInstanceDisks, dataSourceInstanceDiskCollectionFlattenDisks(instanceDiskCollection.Disks))
 		if err != nil {
-			return diag.FromErr(fmt.Errorf("[ERROR] Error setting disks %s", err))
+			return diag.FromErr(flex.FmtErrorf("[ERROR] Error setting disks %s", err))
 		}
 	}
 

--- a/ibm/service/vpc/data_source_ibm_is_instance_group.go
+++ b/ibm/service/vpc/data_source_ibm_is_instance_group.go
@@ -4,7 +4,6 @@
 package vpc
 
 import (
-	"fmt"
 	"log"
 
 	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/flex"
@@ -115,7 +114,7 @@ func dataSourceIBMISInstanceGroupRead(d *schema.ResourceData, meta interface{}) 
 		}
 		instanceGroupsCollection, response, err := sess.ListInstanceGroups(&listInstanceGroupOptions)
 		if err != nil {
-			return fmt.Errorf("[ERROR] Error Fetching InstanceGroups %s\n%s", err, response)
+			return flex.FmtErrorf("[ERROR] Error Fetching InstanceGroups %s\n%s", err, response)
 		}
 		start = flex.GetNext(instanceGroupsCollection.Next)
 		allrecs = append(allrecs, instanceGroupsCollection.InstanceGroups...)
@@ -161,5 +160,5 @@ func dataSourceIBMISInstanceGroupRead(d *schema.ResourceData, meta interface{}) 
 			return nil
 		}
 	}
-	return fmt.Errorf("Instance group %s not found", name)
+	return flex.FmtErrorf("Instance group %s not found", name)
 }

--- a/ibm/service/vpc/data_source_ibm_is_instance_group_manager.go
+++ b/ibm/service/vpc/data_source_ibm_is_instance_group_manager.go
@@ -117,7 +117,7 @@ func dataSourceIBMISInstanceGroupManagerRead(d *schema.ResourceData, meta interf
 		}
 		instanceGroupManagerCollections, response, err := sess.ListInstanceGroupManagers(&listInstanceGroupManagerOptions)
 		if err != nil {
-			return fmt.Errorf("[ERROR] Error Getting InstanceGroup Managers %s\n%s", err, response)
+			return flex.FmtErrorf("[ERROR] Error Getting InstanceGroup Managers %s\n%s", err, response)
 		}
 		start = flex.GetNext(instanceGroupManagerCollections.Next)
 		allrecs = append(allrecs, instanceGroupManagerCollections.Managers...)
@@ -168,5 +168,5 @@ func dataSourceIBMISInstanceGroupManagerRead(d *schema.ResourceData, meta interf
 			return nil
 		}
 	}
-	return fmt.Errorf("Instance group manager %s not found", instanceGroupManagerName)
+	return flex.FmtErrorf("Instance group manager %s not found", instanceGroupManagerName)
 }

--- a/ibm/service/vpc/data_source_ibm_is_instance_group_manager_action.go
+++ b/ibm/service/vpc/data_source_ibm_is_instance_group_manager_action.go
@@ -155,7 +155,7 @@ func dataSourceIBMISInstanceGroupManagerActionRead(d *schema.ResourceData, meta 
 		}
 		instanceGroupManagerActionsCollection, response, err := sess.ListInstanceGroupManagerActions(&listInstanceGroupManagerActionsOptions)
 		if err != nil {
-			return fmt.Errorf("[ERROR] Error Getting InstanceGroup Manager Actions %s\n%s", err, response)
+			return flex.FmtErrorf("[ERROR] Error Getting InstanceGroup Manager Actions %s\n%s", err, response)
 		}
 		if instanceGroupManagerActionsCollection != nil && *instanceGroupManagerActionsCollection.TotalCount == int64(0) {
 			break
@@ -173,47 +173,47 @@ func dataSourceIBMISInstanceGroupManagerActionRead(d *schema.ResourceData, meta 
 			d.SetId(fmt.Sprintf("%s/%s/%s", instanceGroupID, instanceGroupManagerID, *instanceGroupManagerAction.ID))
 
 			if err = d.Set("auto_delete", *instanceGroupManagerAction.AutoDelete); err != nil {
-				return fmt.Errorf("[ERROR] Error setting auto_delete: %s", err)
+				return flex.FmtErrorf("[ERROR] Error setting auto_delete: %s", err)
 			}
 
 			if err = d.Set("auto_delete_timeout", flex.IntValue(instanceGroupManagerAction.AutoDeleteTimeout)); err != nil {
-				return fmt.Errorf("[ERROR] Error setting auto_delete_timeout: %s", err)
+				return flex.FmtErrorf("[ERROR] Error setting auto_delete_timeout: %s", err)
 			}
 			if err = d.Set("created_at", instanceGroupManagerAction.CreatedAt.String()); err != nil {
-				return fmt.Errorf("[ERROR] Error setting created_at: %s", err)
+				return flex.FmtErrorf("[ERROR] Error setting created_at: %s", err)
 			}
 
 			if err = d.Set("action_id", *instanceGroupManagerAction.ID); err != nil {
-				return fmt.Errorf("[ERROR] Error setting instance_group_manager_action : %s", err)
+				return flex.FmtErrorf("[ERROR] Error setting instance_group_manager_action : %s", err)
 			}
 
 			if err = d.Set("resource_type", *instanceGroupManagerAction.ResourceType); err != nil {
-				return fmt.Errorf("[ERROR] Error setting resource_type: %s", err)
+				return flex.FmtErrorf("[ERROR] Error setting resource_type: %s", err)
 			}
 			if err = d.Set("status", *instanceGroupManagerAction.Status); err != nil {
-				return fmt.Errorf("[ERROR] Error setting status: %s", err)
+				return flex.FmtErrorf("[ERROR] Error setting status: %s", err)
 			}
 			if err = d.Set("updated_at", instanceGroupManagerAction.UpdatedAt.String()); err != nil {
-				return fmt.Errorf("[ERROR] Error setting updated_at: %s", err)
+				return flex.FmtErrorf("[ERROR] Error setting updated_at: %s", err)
 			}
 			if err = d.Set("action_type", *instanceGroupManagerAction.ActionType); err != nil {
-				return fmt.Errorf("[ERROR] Error setting action_type: %s", err)
+				return flex.FmtErrorf("[ERROR] Error setting action_type: %s", err)
 			}
 
 			if instanceGroupManagerAction.CronSpec != nil {
 				if err = d.Set("cron_spec", *instanceGroupManagerAction.CronSpec); err != nil {
-					return fmt.Errorf("[ERROR] Error setting cron_spec: %s", err)
+					return flex.FmtErrorf("[ERROR] Error setting cron_spec: %s", err)
 				}
 			}
 
 			if instanceGroupManagerAction.LastAppliedAt != nil {
 				if err = d.Set("last_applied_at", instanceGroupManagerAction.LastAppliedAt.String()); err != nil {
-					return fmt.Errorf("[ERROR] Error setting last_applied_at: %s", err)
+					return flex.FmtErrorf("[ERROR] Error setting last_applied_at: %s", err)
 				}
 			}
 			if instanceGroupManagerAction.NextRunAt != nil {
 				if err = d.Set("next_run_at", instanceGroupManagerAction.NextRunAt.String()); err != nil {
-					return fmt.Errorf("[ERROR] Error setting next_run_at: %s", err)
+					return flex.FmtErrorf("[ERROR] Error setting next_run_at: %s", err)
 				}
 			}
 
@@ -237,5 +237,5 @@ func dataSourceIBMISInstanceGroupManagerActionRead(d *schema.ResourceData, meta 
 			return nil
 		}
 	}
-	return fmt.Errorf("instance group manager action %s not found", actionName)
+	return flex.FmtErrorf("instance group manager action %s not found", actionName)
 }

--- a/ibm/service/vpc/data_source_ibm_is_instance_group_manager_actions.go
+++ b/ibm/service/vpc/data_source_ibm_is_instance_group_manager_actions.go
@@ -4,7 +4,6 @@
 package vpc
 
 import (
-	"fmt"
 	"time"
 
 	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/flex"
@@ -171,7 +170,7 @@ func dataSourceIBMISInstanceGroupManagerActionsRead(d *schema.ResourceData, meta
 		}
 		instanceGroupManagerActionsCollection, response, err := sess.ListInstanceGroupManagerActions(&listInstanceGroupManagerActionsOptions)
 		if err != nil {
-			return fmt.Errorf("[ERROR] Error Getting InstanceGroup Manager Actions %s\n%s", err, response)
+			return flex.FmtErrorf("[ERROR] Error Getting InstanceGroup Manager Actions %s\n%s", err, response)
 		}
 		if instanceGroupManagerActionsCollection != nil && *instanceGroupManagerActionsCollection.TotalCount == int64(0) {
 			break

--- a/ibm/service/vpc/data_source_ibm_is_instance_group_manager_policies.go
+++ b/ibm/service/vpc/data_source_ibm_is_instance_group_manager_policies.go
@@ -101,7 +101,7 @@ func dataSourceIBMISInstanceGroupManagerPoliciesRead(d *schema.ResourceData, met
 		}
 		instanceGroupManagerPolicyCollection, response, err := sess.ListInstanceGroupManagerPolicies(&listInstanceGroupManagerPoliciesOptions)
 		if err != nil {
-			return fmt.Errorf("[ERROR] Error Getting InstanceGroup Manager Policies %s\n%s", err, response)
+			return flex.FmtErrorf("[ERROR] Error Getting InstanceGroup Manager Policies %s\n%s", err, response)
 		}
 		start = flex.GetNext(instanceGroupManagerPolicyCollection.Next)
 		allrecs = append(allrecs, instanceGroupManagerPolicyCollection.Policies...)

--- a/ibm/service/vpc/data_source_ibm_is_instance_group_manager_policy.go
+++ b/ibm/service/vpc/data_source_ibm_is_instance_group_manager_policy.go
@@ -85,7 +85,7 @@ func dataSourceIBMISInstanceGroupManagerPolicyRead(d *schema.ResourceData, meta 
 		}
 		instanceGroupManagerPolicyCollection, response, err := sess.ListInstanceGroupManagerPolicies(&listInstanceGroupManagerPoliciesOptions)
 		if err != nil {
-			return fmt.Errorf("[ERROR] Error Getting InstanceGroup Manager Policies %s\n%s", err, response)
+			return flex.FmtErrorf("[ERROR] Error Getting InstanceGroup Manager Policies %s\n%s", err, response)
 		}
 		start = flex.GetNext(instanceGroupManagerPolicyCollection.Next)
 		allrecs = append(allrecs, instanceGroupManagerPolicyCollection.Policies...)
@@ -105,5 +105,5 @@ func dataSourceIBMISInstanceGroupManagerPolicyRead(d *schema.ResourceData, meta 
 			return nil
 		}
 	}
-	return fmt.Errorf("Instance group manager policy %s not found", policyName)
+	return flex.FmtErrorf("Instance group manager policy %s not found", policyName)
 }

--- a/ibm/service/vpc/data_source_ibm_is_instance_group_managers.go
+++ b/ibm/service/vpc/data_source_ibm_is_instance_group_managers.go
@@ -134,7 +134,7 @@ func dataSourceIBMISInstanceGroupManagersRead(d *schema.ResourceData, meta inter
 		}
 		instanceGroupManagerCollections, response, err := sess.ListInstanceGroupManagers(&listInstanceGroupManagerOptions)
 		if err != nil {
-			return fmt.Errorf("[ERROR] Error Getting InstanceGroup Managers %s\n%s", err, response)
+			return flex.FmtErrorf("[ERROR] Error Getting InstanceGroup Managers %s\n%s", err, response)
 		}
 
 		start = flex.GetNext(instanceGroupManagerCollections.Next)

--- a/ibm/service/vpc/data_source_ibm_is_instance_group_membership.go
+++ b/ibm/service/vpc/data_source_ibm_is_instance_group_membership.go
@@ -116,7 +116,7 @@ func dataSourceIBMISInstanceGroupMembershipRead(d *schema.ResourceData, meta int
 		}
 		instanceGroupMembershipCollection, response, err := sess.ListInstanceGroupMemberships(&listInstanceGroupMembershipsOptions)
 		if err != nil || instanceGroupMembershipCollection == nil {
-			return fmt.Errorf("[ERROR] Error Getting InstanceGroup Membership Collection %s\n%s", err, response)
+			return flex.FmtErrorf("[ERROR] Error Getting InstanceGroup Membership Collection %s\n%s", err, response)
 		}
 
 		start = flex.GetNext(instanceGroupMembershipCollection.Next)
@@ -164,5 +164,5 @@ func dataSourceIBMISInstanceGroupMembershipRead(d *schema.ResourceData, meta int
 			return nil
 		}
 	}
-	return fmt.Errorf("Instance group membership %s not found", instanceGroupMembershipName)
+	return flex.FmtErrorf("Instance group membership %s not found", instanceGroupMembershipName)
 }

--- a/ibm/service/vpc/data_source_ibm_is_instance_group_memberships.go
+++ b/ibm/service/vpc/data_source_ibm_is_instance_group_memberships.go
@@ -4,7 +4,6 @@
 package vpc
 
 import (
-	"fmt"
 	"time"
 
 	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/flex"
@@ -131,7 +130,7 @@ func dataSourceIBMISInstanceGroupMembershipsRead(d *schema.ResourceData, meta in
 		}
 		instanceGroupMembershipCollection, response, err := sess.ListInstanceGroupMemberships(&listInstanceGroupMembershipsOptions)
 		if err != nil {
-			return fmt.Errorf("[ERROR] Error Getting InstanceGroup Membership Collection %s\n%s", err, response)
+			return flex.FmtErrorf("[ERROR] Error Getting InstanceGroup Membership Collection %s\n%s", err, response)
 		}
 
 		start = flex.GetNext(instanceGroupMembershipCollection.Next)

--- a/ibm/service/vpc/data_source_ibm_is_instance_groups.go
+++ b/ibm/service/vpc/data_source_ibm_is_instance_groups.go
@@ -5,7 +5,6 @@ package vpc
 
 import (
 	"context"
-	"fmt"
 	"log"
 	"time"
 
@@ -343,7 +342,7 @@ func DataSourceIBMIsInstanceGroupsRead(context context.Context, d *schema.Resour
 		instanceGroupCollection, response, err := vpcClient.ListInstanceGroupsWithContext(context, listInstanceGroupsOptions)
 		if err != nil {
 			log.Printf("[DEBUG] ListInstanceGroupsWithContext failed %s\n%s", err, response)
-			return diag.FromErr(fmt.Errorf("ListInstanceGroupsWithContext failed %s\n%s", err, response))
+			return diag.FromErr(flex.FmtErrorf("ListInstanceGroupsWithContext failed %s\n%s", err, response))
 		}
 		start = flex.GetNext(instanceGroupCollection.Next)
 		allrecs = append(allrecs, instanceGroupCollection.InstanceGroups...)
@@ -365,7 +364,7 @@ func DataSourceIBMIsInstanceGroupsRead(context context.Context, d *schema.Resour
 	}
 
 	if err = d.Set("instance_groups", instanceGroups); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting instance_groups %s", err))
+		return diag.FromErr(flex.FmtErrorf("Error setting instance_groups %s", err))
 	}
 
 	return nil

--- a/ibm/service/vpc/data_source_ibm_is_instance_network_interface.go
+++ b/ibm/service/vpc/data_source_ibm_is_instance_network_interface.go
@@ -267,7 +267,7 @@ func dataSourceIBMIsInstanceNetworkInterfaceRead(context context.Context, d *sch
 
 		instances, response, err := vpcClient.ListInstancesWithContext(context, listInstancesOptions)
 		if err != nil {
-			return diag.FromErr(fmt.Errorf("[ERROR] Error Fetching Instances %s\n%s", err, response))
+			return diag.FromErr(flex.FmtErrorf("[ERROR] Error Fetching Instances %s\n%s", err, response))
 		}
 		start = flex.GetNext(instances.Next)
 		allrecs = append(allrecs, instances.Instances...)
@@ -287,36 +287,36 @@ func dataSourceIBMIsInstanceNetworkInterfaceRead(context context.Context, d *sch
 
 			if err != nil {
 				log.Printf("[DEBUG] ListSecurityGroupNetworkInterfacesWithContext failed %s\n%s", err, response)
-				return diag.FromErr(fmt.Errorf("ListSecurityGroupNetworkInterfacesWithContext failed %s\n%s", err, response))
+				return diag.FromErr(flex.FmtErrorf("ListSecurityGroupNetworkInterfacesWithContext failed %s\n%s", err, response))
 			}
 			network_interface_name := d.Get("network_interface_name").(string)
 			for _, networkInterface := range networkInterfaceCollection.NetworkInterfaces {
 				if *networkInterface.Name == network_interface_name {
 					d.SetId(fmt.Sprintf("%s/%s", ins_id, *networkInterface.ID))
 					if err = d.Set("allow_ip_spoofing", networkInterface.AllowIPSpoofing); err != nil {
-						return diag.FromErr(fmt.Errorf("[ERROR] Error setting allow_ip_spoofing: %s", err))
+						return diag.FromErr(flex.FmtErrorf("[ERROR] Error setting allow_ip_spoofing: %s", err))
 					}
 					if err = d.Set("created_at", flex.DateTimeToString(networkInterface.CreatedAt)); err != nil {
-						return diag.FromErr(fmt.Errorf("[ERROR] Error setting created_at: %s", err))
+						return diag.FromErr(flex.FmtErrorf("[ERROR] Error setting created_at: %s", err))
 					}
 
 					if networkInterface.FloatingIps != nil {
 						err = d.Set("floating_ips", dataSourceNetworkInterfaceFlattenFloatingIps(networkInterface.FloatingIps))
 						if err != nil {
-							return diag.FromErr(fmt.Errorf("[ERROR] Error setting floating_ips %s", err))
+							return diag.FromErr(flex.FmtErrorf("[ERROR] Error setting floating_ips %s", err))
 						}
 					}
 					if err = d.Set("href", networkInterface.Href); err != nil {
-						return diag.FromErr(fmt.Errorf("[ERROR] Error setting href: %s", err))
+						return diag.FromErr(flex.FmtErrorf("[ERROR] Error setting href: %s", err))
 					}
 					if err = d.Set("name", networkInterface.Name); err != nil {
-						return diag.FromErr(fmt.Errorf("[ERROR] Error setting name: %s", err))
+						return diag.FromErr(flex.FmtErrorf("[ERROR] Error setting name: %s", err))
 					}
 					if err = d.Set("port_speed", flex.IntValue(networkInterface.PortSpeed)); err != nil {
-						return diag.FromErr(fmt.Errorf("[ERROR] Error setting port_speed: %s", err))
+						return diag.FromErr(flex.FmtErrorf("[ERROR] Error setting port_speed: %s", err))
 					}
 					if err = d.Set("primary_ipv4_address", networkInterface.PrimaryIP.Address); err != nil {
-						return diag.FromErr(fmt.Errorf("[ERROR] Error setting primary_ipv4_address: %s", err))
+						return diag.FromErr(flex.FmtErrorf("[ERROR] Error setting primary_ipv4_address: %s", err))
 					}
 					if networkInterface.PrimaryIP != nil {
 						// reserved ip changes
@@ -341,36 +341,36 @@ func dataSourceIBMIsInstanceNetworkInterfaceRead(context context.Context, d *sch
 						d.Set(isInstanceNicPrimaryIP, primaryIpList)
 					}
 					if err = d.Set("resource_type", networkInterface.ResourceType); err != nil {
-						return diag.FromErr(fmt.Errorf("[ERROR] Error setting resource_type: %s", err))
+						return diag.FromErr(flex.FmtErrorf("[ERROR] Error setting resource_type: %s", err))
 					}
 
 					if networkInterface.SecurityGroups != nil {
 						err = d.Set("security_groups", dataSourceNetworkInterfaceFlattenSecurityGroups(networkInterface.SecurityGroups))
 						if err != nil {
-							return diag.FromErr(fmt.Errorf("[ERROR] Error setting security_groups %s", err))
+							return diag.FromErr(flex.FmtErrorf("[ERROR] Error setting security_groups %s", err))
 						}
 					}
 					if err = d.Set("status", networkInterface.Status); err != nil {
-						return diag.FromErr(fmt.Errorf("[ERROR] Error setting status: %s", err))
+						return diag.FromErr(flex.FmtErrorf("[ERROR] Error setting status: %s", err))
 					}
 
 					if networkInterface.Subnet != nil {
 						err = d.Set("subnet", dataSourceNetworkInterfaceFlattenSubnet(*networkInterface.Subnet))
 						if err != nil {
-							return diag.FromErr(fmt.Errorf("[ERROR] Error setting subnet %s", err))
+							return diag.FromErr(flex.FmtErrorf("[ERROR] Error setting subnet %s", err))
 						}
 					}
 					if err = d.Set("type", networkInterface.Type); err != nil {
-						return diag.FromErr(fmt.Errorf("[ERROR] Error setting type: %s", err))
+						return diag.FromErr(flex.FmtErrorf("[ERROR] Error setting type: %s", err))
 					}
 					return nil
 				}
 			}
-			return diag.FromErr(fmt.Errorf("Network interface %s not found.", network_interface_name))
+			return diag.FromErr(flex.FmtErrorf("Network interface %s not found.", network_interface_name))
 		}
 	}
 
-	return diag.FromErr(fmt.Errorf("Instance %s not found. %s", instance_name, err))
+	return diag.FromErr(flex.FmtErrorf("Instance %s not found. %s", instance_name, err))
 }
 
 func dataSourceNetworkInterfaceFlattenFloatingIps(result []vpcv1.FloatingIPReference) (floatingIps []map[string]interface{}) {

--- a/ibm/service/vpc/data_source_ibm_is_instance_network_interface_reserved_ip.go
+++ b/ibm/service/vpc/data_source_ibm_is_instance_network_interface_reserved_ip.go
@@ -5,9 +5,9 @@ package vpc
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/conns"
+	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/flex"
 	"github.com/IBM/vpc-go-sdk/vpcv1"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -122,7 +122,7 @@ func dataSourceIBMISInstanceNICReservedIPRead(context context.Context, d *schema
 	reserveIP, response, err := sess.GetInstanceNetworkInterfaceIPWithContext(context, options)
 
 	if err != nil || response == nil || reserveIP == nil {
-		return diag.FromErr(fmt.Errorf("[ERROR] Error fetching the reserved IP %s\n%s", err, response))
+		return diag.FromErr(flex.FmtErrorf("[ERROR] Error fetching the reserved IP %s\n%s", err, response))
 	}
 
 	d.SetId(*reserveIP.ID)

--- a/ibm/service/vpc/data_source_ibm_is_instance_network_interface_reserved_ips.go
+++ b/ibm/service/vpc/data_source_ibm_is_instance_network_interface_reserved_ips.go
@@ -5,7 +5,6 @@ package vpc
 
 import (
 	"context"
-	"fmt"
 	"time"
 
 	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/conns"
@@ -136,7 +135,7 @@ func dataSourceIBMISInstanceNICReservedIPsRead(context context.Context, d *schem
 
 		result, response, err := sess.ListInstanceNetworkInterfaceIpsWithContext(context, options)
 		if err != nil || response == nil || result == nil {
-			return diag.FromErr(fmt.Errorf("[ERROR] Error fetching reserved ips %s\n%s", err, response))
+			return diag.FromErr(flex.FmtErrorf("[ERROR] Error fetching reserved ips %s\n%s", err, response))
 		}
 		start = flex.GetNext(result.Next)
 		allrecs = append(allrecs, result.Ips...)

--- a/ibm/service/vpc/data_source_ibm_is_instance_network_interfaces.go
+++ b/ibm/service/vpc/data_source_ibm_is_instance_network_interfaces.go
@@ -5,7 +5,6 @@ package vpc
 
 import (
 	"context"
-	"fmt"
 	"log"
 	"time"
 
@@ -282,7 +281,7 @@ func dataSourceIBMIsInstanceNetworkInterfacesRead(context context.Context, d *sc
 
 		instances, response, err := vpcClient.ListInstances(listInstancesOptions)
 		if err != nil {
-			return diag.FromErr(fmt.Errorf("[ERROR] Error Fetching Instances %s\n%s", err, response))
+			return diag.FromErr(flex.FmtErrorf("[ERROR] Error Fetching Instances %s\n%s", err, response))
 		}
 		start = flex.GetNext(instances.Next)
 		allrecs = append(allrecs, instances.Instances...)
@@ -302,7 +301,7 @@ func dataSourceIBMIsInstanceNetworkInterfacesRead(context context.Context, d *sc
 
 			if err != nil {
 				log.Printf("[DEBUG] ListSecurityGroupNetworkInterfacesWithContext failed %s\n%s", err, response)
-				return diag.FromErr(fmt.Errorf("ListSecurityGroupNetworkInterfacesWithContext failed %s\n%s", err, response))
+				return diag.FromErr(flex.FmtErrorf("ListSecurityGroupNetworkInterfacesWithContext failed %s\n%s", err, response))
 			}
 
 			d.SetId(ins_id)
@@ -310,14 +309,14 @@ func dataSourceIBMIsInstanceNetworkInterfacesRead(context context.Context, d *sc
 			if networkInterfaceCollection.NetworkInterfaces != nil {
 				err = d.Set("network_interfaces", dataSourceNetworkInterfaceCollectionFlattenNetworkInterfaces(networkInterfaceCollection.NetworkInterfaces))
 				if err != nil {
-					return diag.FromErr(fmt.Errorf("[ERROR] Error setting network_interfaces %s", err))
+					return diag.FromErr(flex.FmtErrorf("[ERROR] Error setting network_interfaces %s", err))
 				}
 			}
 			return nil
 		}
 	}
 
-	return diag.FromErr(fmt.Errorf("Instance %s not found. %s", instance_name, err))
+	return diag.FromErr(flex.FmtErrorf("Instance %s not found. %s", instance_name, err))
 }
 
 // dataSourceIBMIsInstanceNetworkInterfacesID returns a reasonable ID for the list.

--- a/ibm/service/vpc/data_source_ibm_is_instance_profiles.go
+++ b/ibm/service/vpc/data_source_ibm_is_instance_profiles.go
@@ -4,9 +4,9 @@
 package vpc
 
 import (
-	"fmt"
 	"time"
 
+	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/flex"
 	"github.com/IBM/vpc-go-sdk/vpcv1"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
@@ -688,7 +688,7 @@ func instanceProfilesList(d *schema.ResourceData, meta interface{}) error {
 	listInstanceProfilesOptions := &vpcv1.ListInstanceProfilesOptions{}
 	availableProfiles, response, err := sess.ListInstanceProfiles(listInstanceProfilesOptions)
 	if err != nil {
-		return fmt.Errorf("[ERROR] Error Fetching Instance Profiles %s\n%s", err, response)
+		return flex.FmtErrorf("[ERROR] Error Fetching Instance Profiles %s\n%s", err, response)
 	}
 	profilesInfo := make([]map[string]interface{}, 0)
 	for _, profile := range availableProfiles.Profiles {
@@ -806,7 +806,7 @@ func instanceProfilesList(d *schema.ResourceData, meta interface{}) error {
 		if profile.Disks != nil {
 			l[isInstanceDisks] = dataSourceInstanceProfileFlattenDisks(profile.Disks)
 			if err != nil {
-				return fmt.Errorf("[ERROR] Error setting disks %s", err)
+				return flex.FmtErrorf("[ERROR] Error setting disks %s", err)
 			}
 		}
 		profilesInfo = append(profilesInfo, l)

--- a/ibm/service/vpc/data_source_ibm_is_instance_template.go
+++ b/ibm/service/vpc/data_source_ibm_is_instance_template.go
@@ -1459,7 +1459,7 @@ func dataSourceIBMISInstanceTemplateRead(context context.Context, d *schema.Reso
 			}
 		}
 		if !flag {
-			return diag.FromErr(fmt.Errorf("[ERROR] No Instance Template found with name %s", name))
+			return diag.FromErr(flex.FmtErrorf("[ERROR] No Instance Template found with name %s", name))
 		}
 	}
 	return nil

--- a/ibm/service/vpc/data_source_ibm_is_instance_volume_attachment.go
+++ b/ibm/service/vpc/data_source_ibm_is_instance_volume_attachment.go
@@ -4,8 +4,7 @@
 package vpc
 
 import (
-	"fmt"
-
+	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/flex"
 	"github.com/IBM/vpc-go-sdk/vpcv1"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
@@ -135,7 +134,7 @@ func instanceVolumeAttachmentGetByName(d *schema.ResourceData, meta interface{},
 	}
 	volumeAtts, response, err := sess.ListInstanceVolumeAttachments(listInstanceVolumeAttOptions)
 	if err != nil {
-		return fmt.Errorf("[ERROR] Error fetching Instance volume attachments %s\n%s", err, response)
+		return flex.FmtErrorf("[ERROR] Error fetching Instance volume attachments %s\n%s", err, response)
 	}
 	allrecs = append(allrecs, volumeAtts.VolumeAttachments...)
 	for _, volumeAtt := range allrecs {
@@ -164,5 +163,5 @@ func instanceVolumeAttachmentGetByName(d *schema.ResourceData, meta interface{},
 			return nil
 		}
 	}
-	return fmt.Errorf("[ERROR] No Instance volume attachment found with name %s on instance %s", name, instanceId)
+	return flex.FmtErrorf("[ERROR] No Instance volume attachment found with name %s on instance %s", name, instanceId)
 }

--- a/ibm/service/vpc/data_source_ibm_is_instance_volume_attachments.go
+++ b/ibm/service/vpc/data_source_ibm_is_instance_volume_attachments.go
@@ -4,9 +4,9 @@
 package vpc
 
 import (
-	"fmt"
 	"time"
 
+	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/flex"
 	"github.com/IBM/vpc-go-sdk/vpcv1"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
@@ -130,7 +130,7 @@ func instanceGetVolumeAttachments(d *schema.ResourceData, meta interface{}, inst
 	}
 	volumeAtts, response, err := sess.ListInstanceVolumeAttachments(listInstanceVolumeAttOptions)
 	if err != nil {
-		return fmt.Errorf("[ERROR] Error Fetching Instance volume attachments %s\n%s", err, response)
+		return flex.FmtErrorf("[ERROR] Error Fetching Instance volume attachments %s\n%s", err, response)
 	}
 	allrecs = append(allrecs, volumeAtts.VolumeAttachments...)
 	volAttList := make([]map[string]interface{}, 0)

--- a/ibm/service/vpc/data_source_ibm_is_instances.go
+++ b/ibm/service/vpc/data_source_ibm_is_instances.go
@@ -4,7 +4,6 @@
 package vpc
 
 import (
-	"fmt"
 	"log"
 	"time"
 
@@ -1114,7 +1113,7 @@ func instancesList(d *schema.ResourceData, meta interface{}) error {
 			}
 			instanceGroupsCollection, response, err := sess.ListInstanceGroups(&listInstanceGroupOptions)
 			if err != nil {
-				return fmt.Errorf("[ERROR] Error Fetching InstanceGroups %s\n%s", err, response)
+				return flex.FmtErrorf("[ERROR] Error Fetching InstanceGroups %s\n%s", err, response)
 			}
 			start = flex.GetNext(instanceGroupsCollection.Next)
 			allrecs = append(allrecs, instanceGroupsCollection.InstanceGroups...)
@@ -1174,7 +1173,7 @@ func instancesList(d *schema.ResourceData, meta interface{}) error {
 
 		instances, response, err := sess.ListInstances(listInstancesOptions)
 		if err != nil {
-			return fmt.Errorf("[ERROR] Error Fetching Instances %s\n%s", err, response)
+			return flex.FmtErrorf("[ERROR] Error Fetching Instances %s\n%s", err, response)
 		}
 		start = flex.GetNext(instances.Next)
 		allrecs = append(allrecs, instances.Instances...)
@@ -1195,7 +1194,7 @@ func instancesList(d *schema.ResourceData, meta interface{}) error {
 			}
 			instanceGroupMembershipCollection, response, err := sess.ListInstanceGroupMemberships(&listInstanceGroupMembershipsOptions)
 			if err != nil {
-				return fmt.Errorf("[ERROR] Error Getting InstanceGroup Membership Collection %s\n%s", err, response)
+				return flex.FmtErrorf("[ERROR] Error Getting InstanceGroup Membership Collection %s\n%s", err, response)
 			}
 
 			start = flex.GetNext(instanceGroupMembershipCollection.Next)
@@ -1376,7 +1375,7 @@ func instancesList(d *schema.ResourceData, meta interface{}) error {
 			}
 			insnic, response, err := sess.GetInstanceNetworkInterface(getnicoptions)
 			if err != nil {
-				return fmt.Errorf("[ERROR] Error getting network interfaces attached to the instance %s\n%s", err, response)
+				return flex.FmtErrorf("[ERROR] Error getting network interfaces attached to the instance %s\n%s", err, response)
 			}
 			currentPrimNic[isInstanceNicSubnet] = *insnic.Subnet.ID
 			if len(insnic.SecurityGroups) != 0 {
@@ -1437,7 +1436,7 @@ func instancesList(d *schema.ResourceData, meta interface{}) error {
 					}
 					insnic, response, err := sess.GetInstanceNetworkInterface(getnicoptions)
 					if err != nil {
-						return fmt.Errorf("[ERROR] Error getting network interfaces attached to the instance %s\n%s", err, response)
+						return flex.FmtErrorf("[ERROR] Error getting network interfaces attached to the instance %s\n%s", err, response)
 					}
 					currentNic[isInstanceNicSubnet] = *insnic.Subnet.ID
 					if len(insnic.SecurityGroups) != 0 {

--- a/ibm/service/vpc/data_source_ibm_is_ipsec_policies.go
+++ b/ibm/service/vpc/data_source_ibm_is_ipsec_policies.go
@@ -5,7 +5,6 @@ package vpc
 
 import (
 	"context"
-	"fmt"
 	"log"
 	"time"
 
@@ -173,7 +172,7 @@ func dataSourceIBMIsIpsecPoliciesRead(context context.Context, d *schema.Resourc
 		iPsecPolicyCollection, response, err := vpcClient.ListIpsecPoliciesWithContext(context, listIpsecPoliciesOptions)
 		if err != nil || iPsecPolicyCollection == nil {
 			log.Printf("[DEBUG] ListIpsecPoliciesWithContext failed %s\n%s", err, response)
-			return diag.FromErr(fmt.Errorf("ListIpsecPoliciesWithContext failed %s\n%s", err, response))
+			return diag.FromErr(flex.FmtErrorf("ListIpsecPoliciesWithContext failed %s\n%s", err, response))
 		}
 		start = flex.GetNext(iPsecPolicyCollection.Next)
 		allrecs = append(allrecs, iPsecPolicyCollection.IpsecPolicies...)
@@ -186,7 +185,7 @@ func dataSourceIBMIsIpsecPoliciesRead(context context.Context, d *schema.Resourc
 
 	err = d.Set("ipsec_policies", dataSourceIPsecPolicyCollectionFlattenIpsecPolicies(allrecs))
 	if err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting ipsec_policies %s", err))
+		return diag.FromErr(flex.FmtErrorf("Error setting ipsec_policies %s", err))
 	}
 
 	return nil

--- a/ibm/service/vpc/data_source_ibm_is_ipsec_policy.go
+++ b/ibm/service/vpc/data_source_ibm_is_ipsec_policy.go
@@ -5,7 +5,6 @@ package vpc
 
 import (
 	"context"
-	"fmt"
 	"log"
 
 	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/conns"
@@ -169,7 +168,7 @@ func dataSourceIBMIsIpsecPolicyRead(context context.Context, d *schema.ResourceD
 			}
 			ipSecPolicy, response, err := vpcClient.ListIpsecPolicies(listIPSecPoliciesyOptions)
 			if err != nil {
-				return diag.FromErr(fmt.Errorf("Error Fetching IPSec Policies %s\n%s", err, response))
+				return diag.FromErr(flex.FmtErrorf("Error Fetching IPSec Policies %s\n%s", err, response))
 			}
 			start = flex.GetNext(ipSecPolicy.Next)
 			allrecs = append(allrecs, ipSecPolicy.IpsecPolicies...)
@@ -188,7 +187,7 @@ func dataSourceIBMIsIpsecPolicyRead(context context.Context, d *schema.ResourceD
 
 		if !ipsec_policy_found {
 			log.Printf("[DEBUG] No ipsec policy found with given name %s", name)
-			return diag.FromErr(fmt.Errorf("No ipsec policy found with given name %s", name))
+			return diag.FromErr(flex.FmtErrorf("No ipsec policy found with given name %s", name))
 		}
 
 	} else {
@@ -199,55 +198,55 @@ func dataSourceIBMIsIpsecPolicyRead(context context.Context, d *schema.ResourceD
 		ipsecPolicy1, response, err := vpcClient.GetIpsecPolicyWithContext(context, getIPSecPolicyOptions)
 		if err != nil {
 			log.Printf("[DEBUG] GetIpsecPolicyWithContext failed %s\n%s", err, response)
-			return diag.FromErr(fmt.Errorf("GetIpsecPolicyWithContext failed %s\n%s", err, response))
+			return diag.FromErr(flex.FmtErrorf("GetIpsecPolicyWithContext failed %s\n%s", err, response))
 		}
 		IPSecPolicy = ipsecPolicy1
 	}
 
 	d.SetId(*IPSecPolicy.ID)
 	if err = d.Set("authentication_algorithm", IPSecPolicy.AuthenticationAlgorithm); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting authentication_algorithm: %s", err))
+		return diag.FromErr(flex.FmtErrorf("Error setting authentication_algorithm: %s", err))
 	}
 
 	if IPSecPolicy.Connections != nil {
 		err = d.Set("connections", dataSourceIPsecPolicyFlattenConnections(IPSecPolicy.Connections))
 		if err != nil {
-			return diag.FromErr(fmt.Errorf("Error setting connections %s", err))
+			return diag.FromErr(flex.FmtErrorf("Error setting connections %s", err))
 		}
 	}
 	if err = d.Set("created_at", flex.DateTimeToString(IPSecPolicy.CreatedAt)); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting created_at: %s", err))
+		return diag.FromErr(flex.FmtErrorf("Error setting created_at: %s", err))
 	}
 	if err = d.Set("encapsulation_mode", IPSecPolicy.EncapsulationMode); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting encapsulation_mode: %s", err))
+		return diag.FromErr(flex.FmtErrorf("Error setting encapsulation_mode: %s", err))
 	}
 	if err = d.Set("encryption_algorithm", IPSecPolicy.EncryptionAlgorithm); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting encryption_algorithm: %s", err))
+		return diag.FromErr(flex.FmtErrorf("Error setting encryption_algorithm: %s", err))
 	}
 	if err = d.Set("href", IPSecPolicy.Href); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting href: %s", err))
+		return diag.FromErr(flex.FmtErrorf("Error setting href: %s", err))
 	}
 	if err = d.Set("key_lifetime", flex.IntValue(IPSecPolicy.KeyLifetime)); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting key_lifetime: %s", err))
+		return diag.FromErr(flex.FmtErrorf("Error setting key_lifetime: %s", err))
 	}
 	if err = d.Set("name", IPSecPolicy.Name); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting name: %s", err))
+		return diag.FromErr(flex.FmtErrorf("Error setting name: %s", err))
 	}
 	if err = d.Set("pfs", IPSecPolicy.Pfs); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting pfs: %s", err))
+		return diag.FromErr(flex.FmtErrorf("Error setting pfs: %s", err))
 	}
 
 	if IPSecPolicy.ResourceGroup != nil {
 		err = d.Set("resource_group", dataSourceIPsecPolicyFlattenResourceGroup(*IPSecPolicy.ResourceGroup))
 		if err != nil {
-			return diag.FromErr(fmt.Errorf("Error setting resource_group %s", err))
+			return diag.FromErr(flex.FmtErrorf("Error setting resource_group %s", err))
 		}
 	}
 	if err = d.Set("resource_type", IPSecPolicy.ResourceType); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting resource_type: %s", err))
+		return diag.FromErr(flex.FmtErrorf("Error setting resource_type: %s", err))
 	}
 	if err = d.Set("transform_protocol", IPSecPolicy.TransformProtocol); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting transform_protocol: %s", err))
+		return diag.FromErr(flex.FmtErrorf("Error setting transform_protocol: %s", err))
 	}
 
 	return nil

--- a/ibm/service/vpc/data_source_ibm_is_lb.go
+++ b/ibm/service/vpc/data_source_ibm_is_lb.go
@@ -4,7 +4,6 @@
 package vpc
 
 import (
-	"fmt"
 	"log"
 	"strconv"
 
@@ -342,7 +341,7 @@ func lbGetByName(d *schema.ResourceData, meta interface{}, name string) error {
 		}
 		lbs, response, err := sess.ListLoadBalancers(listLoadBalancersOptions)
 		if err != nil {
-			return fmt.Errorf("[ERROR] Error Fetching Load Balancers %s\n%s", err, response)
+			return flex.FmtErrorf("[ERROR] Error Fetching Load Balancers %s\n%s", err, response)
 		}
 		start = flex.GetNext(lbs.Next)
 		allrecs = append(allrecs, lbs.LoadBalancers...)
@@ -541,5 +540,5 @@ func lbGetByName(d *schema.ResourceData, meta interface{}, name string) error {
 			return nil
 		}
 	}
-	return fmt.Errorf("[ERROR] No Load balancer found with name %s", name)
+	return flex.FmtErrorf("[ERROR] No Load balancer found with name %s", name)
 }

--- a/ibm/service/vpc/data_source_ibm_is_lb_listener.go
+++ b/ibm/service/vpc/data_source_ibm_is_lb_listener.go
@@ -5,7 +5,6 @@ package vpc
 
 import (
 	"context"
-	"fmt"
 	"log"
 
 	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/flex"
@@ -234,71 +233,71 @@ func dataSourceIBMIsLbListenerRead(context context.Context, d *schema.ResourceDa
 	loadBalancerListener, response, err := vpcClient.GetLoadBalancerListenerWithContext(context, getLoadBalancerListenerOptions)
 	if err != nil {
 		log.Printf("[DEBUG] GetLoadBalancerListenerWithContext failed %s\n%s", err, response)
-		return diag.FromErr(fmt.Errorf("GetLoadBalancerListenerWithContext failed %s\n%s", err, response))
+		return diag.FromErr(flex.FmtErrorf("GetLoadBalancerListenerWithContext failed %s\n%s", err, response))
 	}
 
 	d.SetId(*loadBalancerListener.ID)
 	if err = d.Set("accept_proxy_protocol", loadBalancerListener.AcceptProxyProtocol); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting accept_proxy_protocol: %s", err))
+		return diag.FromErr(flex.FmtErrorf("Error setting accept_proxy_protocol: %s", err))
 	}
 
 	if loadBalancerListener.CertificateInstance != nil {
 		err = d.Set("certificate_instance", dataSourceLoadBalancerListenerFlattenCertificateInstance(*loadBalancerListener.CertificateInstance))
 		if err != nil {
-			return diag.FromErr(fmt.Errorf("Error setting certificate_instance %s", err))
+			return diag.FromErr(flex.FmtErrorf("Error setting certificate_instance %s", err))
 		}
 	}
 	if loadBalancerListener.ConnectionLimit != nil {
 		if err = d.Set("connection_limit", flex.IntValue(loadBalancerListener.ConnectionLimit)); err != nil {
-			return diag.FromErr(fmt.Errorf("Error setting connection_limit: %s", err))
+			return diag.FromErr(flex.FmtErrorf("Error setting connection_limit: %s", err))
 		}
 	}
 	if loadBalancerListener.IdleConnectionTimeout != nil {
 		if err = d.Set(isLBListenerIdleConnectionTimeout, flex.IntValue(loadBalancerListener.IdleConnectionTimeout)); err != nil {
-			return diag.FromErr(fmt.Errorf("Error setting idle_connection_timeout: %s", err))
+			return diag.FromErr(flex.FmtErrorf("Error setting idle_connection_timeout: %s", err))
 		}
 	}
 	if err = d.Set("created_at", loadBalancerListener.CreatedAt.String()); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting created_at: %s", err))
+		return diag.FromErr(flex.FmtErrorf("Error setting created_at: %s", err))
 	}
 
 	if loadBalancerListener.DefaultPool != nil {
 		err = d.Set("default_pool", dataSourceLoadBalancerListenerFlattenDefaultPool(*loadBalancerListener.DefaultPool))
 		if err != nil {
-			return diag.FromErr(fmt.Errorf("Error setting default_pool %s", err))
+			return diag.FromErr(flex.FmtErrorf("Error setting default_pool %s", err))
 		}
 	}
 	if err = d.Set("href", loadBalancerListener.Href); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting href: %s", err))
+		return diag.FromErr(flex.FmtErrorf("Error setting href: %s", err))
 	}
 
 	if loadBalancerListener.HTTPSRedirect != nil {
 		err = d.Set("https_redirect", dataSourceLoadBalancerListenerFlattenHTTPSRedirect(*loadBalancerListener.HTTPSRedirect))
 		if err != nil {
-			return diag.FromErr(fmt.Errorf("Error setting https_redirect %s", err))
+			return diag.FromErr(flex.FmtErrorf("Error setting https_redirect %s", err))
 		}
 	}
 
 	if loadBalancerListener.Policies != nil {
 		err = d.Set("policies", dataSourceLoadBalancerListenerFlattenPolicies(loadBalancerListener.Policies))
 		if err != nil {
-			return diag.FromErr(fmt.Errorf("Error setting policies %s", err))
+			return diag.FromErr(flex.FmtErrorf("Error setting policies %s", err))
 		}
 	}
 	if err = d.Set("port", flex.IntValue(loadBalancerListener.Port)); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting port: %s", err))
+		return diag.FromErr(flex.FmtErrorf("Error setting port: %s", err))
 	}
 	if err = d.Set("port_max", flex.IntValue(loadBalancerListener.PortMax)); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting port_max: %s", err))
+		return diag.FromErr(flex.FmtErrorf("Error setting port_max: %s", err))
 	}
 	if err = d.Set("port_min", flex.IntValue(loadBalancerListener.PortMin)); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting port_min: %s", err))
+		return diag.FromErr(flex.FmtErrorf("Error setting port_min: %s", err))
 	}
 	if err = d.Set("protocol", loadBalancerListener.Protocol); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting protocol: %s", err))
+		return diag.FromErr(flex.FmtErrorf("Error setting protocol: %s", err))
 	}
 	if err = d.Set("provisioning_status", loadBalancerListener.ProvisioningStatus); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting provisioning_status: %s", err))
+		return diag.FromErr(flex.FmtErrorf("Error setting provisioning_status: %s", err))
 	}
 
 	return nil

--- a/ibm/service/vpc/data_source_ibm_is_lb_listener_policies.go
+++ b/ibm/service/vpc/data_source_ibm_is_lb_listener_policies.go
@@ -5,10 +5,10 @@ package vpc
 
 import (
 	"context"
-	"fmt"
 	"log"
 	"time"
 
+	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/flex"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 
@@ -210,7 +210,7 @@ func dataSourceIBMIsLbListenerPoliciesRead(context context.Context, d *schema.Re
 	loadBalancerListenerPolicyCollection, response, err := vpcClient.ListLoadBalancerListenerPoliciesWithContext(context, listLoadBalancerListenerPoliciesOptions)
 	if err != nil {
 		log.Printf("[DEBUG] ListLoadBalancerListenerPoliciesWithContext failed %s\n%s", err, response)
-		return diag.FromErr(fmt.Errorf("ListLoadBalancerListenerPoliciesWithContext failed %s\n%s", err, response))
+		return diag.FromErr(flex.FmtErrorf("ListLoadBalancerListenerPoliciesWithContext failed %s\n%s", err, response))
 	}
 
 	d.SetId(dataSourceIBMIsLbListenerPoliciesID(d))
@@ -218,7 +218,7 @@ func dataSourceIBMIsLbListenerPoliciesRead(context context.Context, d *schema.Re
 	if loadBalancerListenerPolicyCollection.Policies != nil {
 		err = d.Set("policies", dataSourceLoadBalancerListenerPolicyCollectionFlattenPolicies(loadBalancerListenerPolicyCollection.Policies))
 		if err != nil {
-			return diag.FromErr(fmt.Errorf("Error setting policies %s", err))
+			return diag.FromErr(flex.FmtErrorf("Error setting policies %s", err))
 		}
 	}
 

--- a/ibm/service/vpc/data_source_ibm_is_lb_listener_policy.go
+++ b/ibm/service/vpc/data_source_ibm_is_lb_listener_policy.go
@@ -5,7 +5,6 @@ package vpc
 
 import (
 	"context"
-	"fmt"
 	"log"
 
 	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/flex"
@@ -202,33 +201,33 @@ func dataSourceIBMIsLbListenerPolicyRead(context context.Context, d *schema.Reso
 	loadBalancerListenerPolicy, response, err := vpcClient.GetLoadBalancerListenerPolicyWithContext(context, getLoadBalancerListenerPolicyOptions)
 	if err != nil {
 		log.Printf("[DEBUG] GetLoadBalancerListenerPolicyWithContext failed %s\n%s", err, response)
-		return diag.FromErr(fmt.Errorf("GetLoadBalancerListenerPolicyWithContext failed %s\n%s", err, response))
+		return diag.FromErr(flex.FmtErrorf("GetLoadBalancerListenerPolicyWithContext failed %s\n%s", err, response))
 	}
 	d.SetId(*loadBalancerListenerPolicy.ID)
 	if err = d.Set("action", loadBalancerListenerPolicy.Action); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting action: %s", err))
+		return diag.FromErr(flex.FmtErrorf("Error setting action: %s", err))
 	}
 
 	if err = d.Set("created_at", loadBalancerListenerPolicy.CreatedAt.String()); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting created_at: %s", err))
+		return diag.FromErr(flex.FmtErrorf("Error setting created_at: %s", err))
 	}
 	if err = d.Set("href", loadBalancerListenerPolicy.Href); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting href: %s", err))
+		return diag.FromErr(flex.FmtErrorf("Error setting href: %s", err))
 	}
 	if err = d.Set("name", loadBalancerListenerPolicy.Name); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting name: %s", err))
+		return diag.FromErr(flex.FmtErrorf("Error setting name: %s", err))
 	}
 	if err = d.Set("priority", flex.IntValue(loadBalancerListenerPolicy.Priority)); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting priority: %s", err))
+		return diag.FromErr(flex.FmtErrorf("Error setting priority: %s", err))
 	}
 	if err = d.Set("provisioning_status", loadBalancerListenerPolicy.ProvisioningStatus); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting provisioning_status: %s", err))
+		return diag.FromErr(flex.FmtErrorf("Error setting provisioning_status: %s", err))
 	}
 
 	if loadBalancerListenerPolicy.Rules != nil {
 		err = d.Set("rules", dataSourceLoadBalancerListenerPolicyFlattenRules(loadBalancerListenerPolicy.Rules))
 		if err != nil {
-			return diag.FromErr(fmt.Errorf("Error setting rules %s", err))
+			return diag.FromErr(flex.FmtErrorf("Error setting rules %s", err))
 		}
 	}
 
@@ -236,7 +235,7 @@ func dataSourceIBMIsLbListenerPolicyRead(context context.Context, d *schema.Reso
 		target := loadBalancerListenerPolicy.Target.(*vpcv1.LoadBalancerListenerPolicyTarget)
 		err = d.Set("target", dataSourceLoadBalancerListenerPolicyFlattenTarget(*target))
 		if err != nil {
-			return diag.FromErr(fmt.Errorf("Error setting target %s", err))
+			return diag.FromErr(flex.FmtErrorf("Error setting target %s", err))
 		}
 	}
 

--- a/ibm/service/vpc/data_source_ibm_is_lb_listener_policy_rule.go
+++ b/ibm/service/vpc/data_source_ibm_is_lb_listener_policy_rule.go
@@ -5,7 +5,6 @@ package vpc
 
 import (
 	"context"
-	"fmt"
 	"log"
 
 	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/flex"
@@ -95,30 +94,30 @@ func dataSourceIBMIsLbListenerPolicyRuleRead(context context.Context, d *schema.
 	loadBalancerListenerPolicyRule, response, err := vpcClient.GetLoadBalancerListenerPolicyRuleWithContext(context, getLoadBalancerListenerPolicyRuleOptions)
 	if err != nil {
 		log.Printf("[DEBUG] GetLoadBalancerListenerPolicyRuleWithContext failed %s\n%s", err, response)
-		return diag.FromErr(fmt.Errorf("GetLoadBalancerListenerPolicyRuleWithContext failed %s\n%s", err, response))
+		return diag.FromErr(flex.FmtErrorf("GetLoadBalancerListenerPolicyRuleWithContext failed %s\n%s", err, response))
 	}
 
 	d.SetId(*loadBalancerListenerPolicyRule.ID)
 	if err = d.Set("condition", loadBalancerListenerPolicyRule.Condition); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting condition: %s", err))
+		return diag.FromErr(flex.FmtErrorf("Error setting condition: %s", err))
 	}
 	if err = d.Set("created_at", flex.DateTimeToString(loadBalancerListenerPolicyRule.CreatedAt)); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting created_at: %s", err))
+		return diag.FromErr(flex.FmtErrorf("Error setting created_at: %s", err))
 	}
 	if err = d.Set("field", loadBalancerListenerPolicyRule.Field); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting field: %s", err))
+		return diag.FromErr(flex.FmtErrorf("Error setting field: %s", err))
 	}
 	if err = d.Set("href", loadBalancerListenerPolicyRule.Href); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting href: %s", err))
+		return diag.FromErr(flex.FmtErrorf("Error setting href: %s", err))
 	}
 	if err = d.Set("provisioning_status", loadBalancerListenerPolicyRule.ProvisioningStatus); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting provisioning_status: %s", err))
+		return diag.FromErr(flex.FmtErrorf("Error setting provisioning_status: %s", err))
 	}
 	if err = d.Set("type", loadBalancerListenerPolicyRule.Type); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting type: %s", err))
+		return diag.FromErr(flex.FmtErrorf("Error setting type: %s", err))
 	}
 	if err = d.Set("value", loadBalancerListenerPolicyRule.Value); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting value: %s", err))
+		return diag.FromErr(flex.FmtErrorf("Error setting value: %s", err))
 	}
 
 	return nil

--- a/ibm/service/vpc/data_source_ibm_is_lb_listener_policy_rules.go
+++ b/ibm/service/vpc/data_source_ibm_is_lb_listener_policy_rules.go
@@ -5,10 +5,10 @@ package vpc
 
 import (
 	"context"
-	"fmt"
 	"log"
 	"time"
 
+	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/flex"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 
@@ -102,7 +102,7 @@ func dataSourceIBMIsLbListenerPolicyRulesRead(context context.Context, d *schema
 	loadBalancerListenerPolicyRuleCollection, response, err := vpcClient.ListLoadBalancerListenerPolicyRulesWithContext(context, listLoadBalancerListenerPolicyRulesOptions)
 	if err != nil {
 		log.Printf("[DEBUG] ListLoadBalancerListenerPolicyRulesWithContext failed %s\n%s", err, response)
-		return diag.FromErr(fmt.Errorf("ListLoadBalancerListenerPolicyRulesWithContext failed %s\n%s", err, response))
+		return diag.FromErr(flex.FmtErrorf("ListLoadBalancerListenerPolicyRulesWithContext failed %s\n%s", err, response))
 	}
 
 	d.SetId(dataSourceIBMIsLbListenerPolicyRulesID(d))
@@ -110,7 +110,7 @@ func dataSourceIBMIsLbListenerPolicyRulesRead(context context.Context, d *schema
 	if loadBalancerListenerPolicyRuleCollection.Rules != nil {
 		err = d.Set("rules", dataSourceLoadBalancerListenerPolicyRuleCollectionFlattenRules(loadBalancerListenerPolicyRuleCollection.Rules))
 		if err != nil {
-			return diag.FromErr(fmt.Errorf("Error setting rules %s", err))
+			return diag.FromErr(flex.FmtErrorf("Error setting rules %s", err))
 		}
 	}
 

--- a/ibm/service/vpc/data_source_ibm_is_lb_listeners.go
+++ b/ibm/service/vpc/data_source_ibm_is_lb_listeners.go
@@ -5,10 +5,10 @@ package vpc
 
 import (
 	"context"
-	"fmt"
 	"log"
 	"time"
 
+	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/flex"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 
@@ -243,7 +243,7 @@ func dataSourceIBMIsLbListenersRead(context context.Context, d *schema.ResourceD
 	loadBalancerListenerCollection, response, err := vpcClient.ListLoadBalancerListenersWithContext(context, listLoadBalancerListenersOptions)
 	if err != nil {
 		log.Printf("[DEBUG] ListLoadBalancerListenersWithContext failed %s\n%s", err, response)
-		return diag.FromErr(fmt.Errorf("ListLoadBalancerListenersWithContext failed %s\n%s", err, response))
+		return diag.FromErr(flex.FmtErrorf("ListLoadBalancerListenersWithContext failed %s\n%s", err, response))
 	}
 
 	d.SetId(dataSourceIBMIsLbListenersID(d))
@@ -251,7 +251,7 @@ func dataSourceIBMIsLbListenersRead(context context.Context, d *schema.ResourceD
 	if loadBalancerListenerCollection.Listeners != nil {
 		err = d.Set("listeners", dataSourceLoadBalancerListenerCollectionFlattenListeners(loadBalancerListenerCollection.Listeners))
 		if err != nil {
-			return diag.FromErr(fmt.Errorf("Error setting listeners %s", err))
+			return diag.FromErr(flex.FmtErrorf("Error setting listeners %s", err))
 		}
 	}
 

--- a/ibm/service/vpc/data_source_ibm_is_lb_pool.go
+++ b/ibm/service/vpc/data_source_ibm_is_lb_pool.go
@@ -5,7 +5,6 @@ package vpc
 
 import (
 	"context"
-	"fmt"
 	"log"
 
 	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/flex"
@@ -223,7 +222,7 @@ func dataSourceIBMIsLbPoolRead(context context.Context, d *schema.ResourceData, 
 		loadBalancerPoolInfo, response, err := sess.GetLoadBalancerPoolWithContext(context, getLoadBalancerPoolOptions)
 		if err != nil {
 			log.Printf("[DEBUG] GetLoadBalancerPoolWithContext failed %s\n%s", err, response)
-			return diag.FromErr(fmt.Errorf("GetLoadBalancerPoolWithContext failed %s\n%s", err, response))
+			return diag.FromErr(flex.FmtErrorf("GetLoadBalancerPoolWithContext failed %s\n%s", err, response))
 		}
 		loadBalancerPool = loadBalancerPoolInfo
 
@@ -235,7 +234,7 @@ func dataSourceIBMIsLbPoolRead(context context.Context, d *schema.ResourceData, 
 		loadBalancerPoolCollection, response, err := sess.ListLoadBalancerPoolsWithContext(context, listLoadBalancerPoolsOptions)
 		if err != nil {
 			log.Printf("[DEBUG] ListLoadBalancerPoolsWithContext failed %s\n%s", err, response)
-			return diag.FromErr(fmt.Errorf("ListLoadBalancerPoolsWithContext failed %s\n%s", err, response))
+			return diag.FromErr(flex.FmtErrorf("ListLoadBalancerPoolsWithContext failed %s\n%s", err, response))
 		}
 
 		name := v.(string)
@@ -247,64 +246,64 @@ func dataSourceIBMIsLbPoolRead(context context.Context, d *schema.ResourceData, 
 		}
 		if loadBalancerPool == nil {
 			log.Printf("[DEBUG] No LoadBalancerPool found with name (%s)", name)
-			return diag.FromErr(fmt.Errorf("No LoadBalancerPool found with name (%s)", name))
+			return diag.FromErr(flex.FmtErrorf("No LoadBalancerPool found with name (%s)", name))
 		}
 
 	}
 
 	d.SetId(*loadBalancerPool.ID)
 	if err = d.Set("algorithm", loadBalancerPool.Algorithm); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting algorithm: %s", err))
+		return diag.FromErr(flex.FmtErrorf("Error setting algorithm: %s", err))
 	}
 	if err = d.Set("created_at", flex.DateTimeToString(loadBalancerPool.CreatedAt)); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting created_at: %s", err))
+		return diag.FromErr(flex.FmtErrorf("Error setting created_at: %s", err))
 	}
 
 	if loadBalancerPool.HealthMonitor != nil {
 		err = d.Set("health_monitor", dataSourceLoadBalancerPoolFlattenHealthMonitor(*loadBalancerPool.HealthMonitor))
 		if err != nil {
-			return diag.FromErr(fmt.Errorf("Error setting health_monitor %s", err))
+			return diag.FromErr(flex.FmtErrorf("Error setting health_monitor %s", err))
 		}
 	}
 	if err = d.Set("href", loadBalancerPool.Href); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting href: %s", err))
+		return diag.FromErr(flex.FmtErrorf("Error setting href: %s", err))
 	}
 
 	if loadBalancerPool.InstanceGroup != nil {
 		err = d.Set("instance_group", dataSourceLoadBalancerPoolFlattenInstanceGroup(*loadBalancerPool.InstanceGroup))
 		if err != nil {
-			return diag.FromErr(fmt.Errorf("Error setting instance_group %s", err))
+			return diag.FromErr(flex.FmtErrorf("Error setting instance_group %s", err))
 		}
 	}
 
 	if loadBalancerPool.Members != nil {
 		err = d.Set("members", dataSourceLoadBalancerPoolFlattenMembers(loadBalancerPool.Members))
 		if err != nil {
-			return diag.FromErr(fmt.Errorf("Error setting members %s", err))
+			return diag.FromErr(flex.FmtErrorf("Error setting members %s", err))
 		}
 	}
 
 	if err = d.Set("identifier", loadBalancerPool.ID); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting identifier: %s", err))
+		return diag.FromErr(flex.FmtErrorf("Error setting identifier: %s", err))
 	}
 
 	if err = d.Set("name", loadBalancerPool.Name); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting name: %s", err))
+		return diag.FromErr(flex.FmtErrorf("Error setting name: %s", err))
 	}
 	if err = d.Set("protocol", loadBalancerPool.Protocol); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting protocol: %s", err))
+		return diag.FromErr(flex.FmtErrorf("Error setting protocol: %s", err))
 	}
 	if err = d.Set("provisioning_status", loadBalancerPool.ProvisioningStatus); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting provisioning_status: %s", err))
+		return diag.FromErr(flex.FmtErrorf("Error setting provisioning_status: %s", err))
 	}
 	if err = d.Set("proxy_protocol", loadBalancerPool.ProxyProtocol); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting proxy_protocol: %s", err))
+		return diag.FromErr(flex.FmtErrorf("Error setting proxy_protocol: %s", err))
 	}
 
 	if loadBalancerPool.SessionPersistence != nil {
 		err = d.Set("session_persistence", dataSourceLoadBalancerPoolFlattenSessionPersistence(*loadBalancerPool.SessionPersistence))
 		if err != nil {
-			return diag.FromErr(fmt.Errorf("Error setting session_persistence %s", err))
+			return diag.FromErr(flex.FmtErrorf("Error setting session_persistence %s", err))
 		}
 	}
 

--- a/ibm/service/vpc/data_source_ibm_is_lb_pool_member.go
+++ b/ibm/service/vpc/data_source_ibm_is_lb_pool_member.go
@@ -5,7 +5,6 @@ package vpc
 
 import (
 	"context"
-	"fmt"
 	"log"
 
 	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/flex"
@@ -132,35 +131,35 @@ func dataSourceIBMIsLbPoolMemberRead(context context.Context, d *schema.Resource
 	loadBalancerPoolMember, response, err := sess.GetLoadBalancerPoolMemberWithContext(context, getLoadBalancerPoolMemberOptions)
 	if err != nil {
 		log.Printf("[DEBUG] GetLoadBalancerPoolMemberWithContext failed %s\n%s", err, response)
-		return diag.FromErr(fmt.Errorf("GetLoadBalancerPoolMemberWithContext failed %s\n%s", err, response))
+		return diag.FromErr(flex.FmtErrorf("GetLoadBalancerPoolMemberWithContext failed %s\n%s", err, response))
 	}
 
 	d.SetId(*loadBalancerPoolMember.ID)
 	if err = d.Set("created_at", flex.DateTimeToString(loadBalancerPoolMember.CreatedAt)); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting created_at: %s", err))
+		return diag.FromErr(flex.FmtErrorf("Error setting created_at: %s", err))
 	}
 	if err = d.Set("health", loadBalancerPoolMember.Health); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting health: %s", err))
+		return diag.FromErr(flex.FmtErrorf("Error setting health: %s", err))
 	}
 	if err = d.Set("href", loadBalancerPoolMember.Href); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting href: %s", err))
+		return diag.FromErr(flex.FmtErrorf("Error setting href: %s", err))
 	}
 	if err = d.Set("port", flex.IntValue(loadBalancerPoolMember.Port)); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting port: %s", err))
+		return diag.FromErr(flex.FmtErrorf("Error setting port: %s", err))
 	}
 	if err = d.Set("provisioning_status", loadBalancerPoolMember.ProvisioningStatus); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting provisioning_status: %s", err))
+		return diag.FromErr(flex.FmtErrorf("Error setting provisioning_status: %s", err))
 	}
 
 	if loadBalancerPoolMember.Target != nil {
 		target := loadBalancerPoolMember.Target.(*vpcv1.LoadBalancerPoolMemberTarget)
 		err = d.Set("target", dataSourceLoadBalancerPoolMemberFlattenTarget(*target))
 		if err != nil {
-			return diag.FromErr(fmt.Errorf("Error setting target %s", err))
+			return diag.FromErr(flex.FmtErrorf("Error setting target %s", err))
 		}
 	}
 	if err = d.Set("weight", flex.IntValue(loadBalancerPoolMember.Weight)); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting weight: %s", err))
+		return diag.FromErr(flex.FmtErrorf("Error setting weight: %s", err))
 	}
 
 	return nil

--- a/ibm/service/vpc/data_source_ibm_is_lb_pool_members.go
+++ b/ibm/service/vpc/data_source_ibm_is_lb_pool_members.go
@@ -5,10 +5,10 @@ package vpc
 
 import (
 	"context"
-	"fmt"
 	"log"
 	"time"
 
+	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/flex"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 
@@ -140,7 +140,7 @@ func dataSourceIBMIsLbPoolMembersRead(context context.Context, d *schema.Resourc
 	loadBalancerPoolMemberCollection, response, err := sess.ListLoadBalancerPoolMembersWithContext(context, listLoadBalancerPoolMembersOptions)
 	if err != nil {
 		log.Printf("[DEBUG] ListLoadBalancerPoolMembersWithContext failed %s\n%s", err, response)
-		return diag.FromErr(fmt.Errorf("ListLoadBalancerPoolMembersWithContext failed %s\n%s", err, response))
+		return diag.FromErr(flex.FmtErrorf("ListLoadBalancerPoolMembersWithContext failed %s\n%s", err, response))
 	}
 
 	d.SetId(dataSourceIBMIsLbPoolMembersID(d))
@@ -148,7 +148,7 @@ func dataSourceIBMIsLbPoolMembersRead(context context.Context, d *schema.Resourc
 	if loadBalancerPoolMemberCollection.Members != nil {
 		err = d.Set("members", dataSourceLoadBalancerPoolMemberCollectionFlattenMembers(loadBalancerPoolMemberCollection.Members))
 		if err != nil {
-			return diag.FromErr(fmt.Errorf("Error setting members %s", err))
+			return diag.FromErr(flex.FmtErrorf("Error setting members %s", err))
 		}
 	}
 

--- a/ibm/service/vpc/data_source_ibm_is_lb_pools.go
+++ b/ibm/service/vpc/data_source_ibm_is_lb_pools.go
@@ -5,10 +5,10 @@ package vpc
 
 import (
 	"context"
-	"fmt"
 	"log"
 	"time"
 
+	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/flex"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 
@@ -225,10 +225,10 @@ func dataSourceIBMIsLbPoolsRead(context context.Context, d *schema.ResourceData,
 	loadBalancerPoolCollection, response, err := sess.ListLoadBalancerPoolsWithContext(context, listLoadBalancerPoolsOptions)
 	if err != nil {
 		log.Printf("[DEBUG] ListLoadBalancerPoolsWithContext failed %s\n%s", err, response)
-		return diag.FromErr(fmt.Errorf("ListLoadBalancerPoolsWithContext failed %s\n%s", err, response))
+		return diag.FromErr(flex.FmtErrorf("ListLoadBalancerPoolsWithContext failed %s\n%s", err, response))
 	}
 	if err = d.Set("lb", d.Get("lb").(string)); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting lb: %s", err))
+		return diag.FromErr(flex.FmtErrorf("Error setting lb: %s", err))
 	}
 
 	d.SetId(dataSourceIBMIsLbPoolsID(d))
@@ -236,7 +236,7 @@ func dataSourceIBMIsLbPoolsRead(context context.Context, d *schema.ResourceData,
 	if loadBalancerPoolCollection.Pools != nil {
 		err = d.Set("pools", dataSourceLoadBalancerPoolCollectionFlattenPools(loadBalancerPoolCollection.Pools))
 		if err != nil {
-			return diag.FromErr(fmt.Errorf("Error setting pools %s", err))
+			return diag.FromErr(flex.FmtErrorf("Error setting pools %s", err))
 		}
 	}
 

--- a/ibm/service/vpc/data_source_ibm_is_lb_profile.go
+++ b/ibm/service/vpc/data_source_ibm_is_lb_profile.go
@@ -5,10 +5,10 @@ package vpc
 
 import (
 	"context"
-	"fmt"
 	"log"
 	"reflect"
 
+	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/flex"
 	"github.com/IBM/vpc-go-sdk/vpcv1"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -70,7 +70,7 @@ func dataSourceIBMISLbProfileRead(context context.Context, d *schema.ResourceDat
 	}
 	lbProfile, response, err := sess.GetLoadBalancerProfileWithContext(context, getLoadBalancerProfileOptions)
 	if err != nil {
-		return diag.FromErr(fmt.Errorf("[ERROR] Error Fetching Load Balancer Profile(%s) for VPC %s\n%s", lbprofilename, err, response))
+		return diag.FromErr(flex.FmtErrorf("[ERROR] Error Fetching Load Balancer Profile(%s) for VPC %s\n%s", lbprofilename, err, response))
 	}
 
 	d.Set("name", *lbProfile.Name)

--- a/ibm/service/vpc/data_source_ibm_is_lb_profiles.go
+++ b/ibm/service/vpc/data_source_ibm_is_lb_profiles.go
@@ -4,7 +4,6 @@
 package vpc
 
 import (
-	"fmt"
 	"reflect"
 	"time"
 
@@ -91,7 +90,7 @@ func dataSourceIBMISLbProfilesRead(d *schema.ResourceData, meta interface{}) err
 		}
 		lbProfile, response, err := sess.GetLoadBalancerProfile(getLoadBalancerProfileOptions)
 		if err != nil {
-			return fmt.Errorf("[ERROR] Error Fetching Load Balancer Profile(%s) for VPC %s\n%s", lbprofilename, err, response)
+			return flex.FmtErrorf("[ERROR] Error Fetching Load Balancer Profile(%s) for VPC %s\n%s", lbprofilename, err, response)
 		}
 		allrecs = append(allrecs, *lbProfile)
 	} else {
@@ -102,7 +101,7 @@ func dataSourceIBMISLbProfilesRead(d *schema.ResourceData, meta interface{}) err
 			}
 			profileCollectors, response, err := sess.ListLoadBalancerProfiles(listOptions)
 			if err != nil {
-				return fmt.Errorf("[ERROR] Error Fetching Load Balancer Profiles for VPC %s\n%s", err, response)
+				return flex.FmtErrorf("[ERROR] Error Fetching Load Balancer Profiles for VPC %s\n%s", err, response)
 			}
 			start = flex.GetNext(profileCollectors.Next)
 			allrecs = append(allrecs, profileCollectors.Profiles...)

--- a/ibm/service/vpc/data_source_ibm_is_lbs.go
+++ b/ibm/service/vpc/data_source_ibm_is_lbs.go
@@ -4,7 +4,6 @@
 package vpc
 
 import (
-	"fmt"
 	"log"
 	"time"
 
@@ -306,7 +305,7 @@ func getLbs(d *schema.ResourceData, meta interface{}) error {
 		}
 		lbs, response, err := sess.ListLoadBalancers(listLoadBalancersOptions)
 		if err != nil {
-			return fmt.Errorf("[ERROR] Error Fetching Load Balancers %s\n%s", err, response)
+			return flex.FmtErrorf("[ERROR] Error Fetching Load Balancers %s\n%s", err, response)
 		}
 		start = flex.GetNext(lbs.Next)
 		allrecs = append(allrecs, lbs.LoadBalancers...)

--- a/ibm/service/vpc/data_source_ibm_is_network_acl.go
+++ b/ibm/service/vpc/data_source_ibm_is_network_acl.go
@@ -5,7 +5,6 @@ package vpc
 
 import (
 	"context"
-	"fmt"
 	"log"
 	"reflect"
 
@@ -378,7 +377,7 @@ func dataSourceIBMIsNetworkACLRead(context context.Context, d *schema.ResourceDa
 			networkACLCollection, response, err := vpcClient.ListNetworkAclsWithContext(context, listNetworkAclsOptions)
 			if err != nil || networkACLCollection == nil {
 				log.Printf("[DEBUG] ListNetworkAclsWithContext failed %s\n%s", err, response)
-				return diag.FromErr(fmt.Errorf("ListNetworkAclsWithContext failed %s\n%s", err, response))
+				return diag.FromErr(flex.FmtErrorf("ListNetworkAclsWithContext failed %s\n%s", err, response))
 			}
 			start = flex.GetNext(networkACLCollection.Next)
 			allrecs = append(allrecs, networkACLCollection.NetworkAcls...)
@@ -397,7 +396,7 @@ func dataSourceIBMIsNetworkACLRead(context context.Context, d *schema.ResourceDa
 
 		if !acl_found {
 			log.Printf("[DEBUG] No networkACL found with given VPC %s and ACL name %s", vpc_name_str, network_acl_name)
-			return diag.FromErr(fmt.Errorf("[ERROR] No networkACL found with given VPC %s and ACL name %s", vpc_name_str, network_acl_name))
+			return diag.FromErr(flex.FmtErrorf("[ERROR] No networkACL found with given VPC %s and ACL name %s", vpc_name_str, network_acl_name))
 		}
 	} else {
 
@@ -408,49 +407,49 @@ func dataSourceIBMIsNetworkACLRead(context context.Context, d *schema.ResourceDa
 		networkACLInst, response, err := vpcClient.GetNetworkACLWithContext(context, getNetworkACLOptions)
 		if err != nil || networkACLInst == nil {
 			log.Printf("[DEBUG] GetNetworkACLWithContext failed %s\n%s", err, response)
-			return diag.FromErr(fmt.Errorf("GetNetworkACLWithContext failed %s\n%s", err, response))
+			return diag.FromErr(flex.FmtErrorf("GetNetworkACLWithContext failed %s\n%s", err, response))
 		}
 		networkACL = networkACLInst
 	}
 	d.SetId(*networkACL.ID)
 	if err = d.Set("created_at", flex.DateTimeToString(networkACL.CreatedAt)); err != nil {
-		return diag.FromErr(fmt.Errorf("[ERROR] Error setting created_at: %s", err))
+		return diag.FromErr(flex.FmtErrorf("[ERROR] Error setting created_at: %s", err))
 	}
 	if err = d.Set("crn", networkACL.CRN); err != nil {
-		return diag.FromErr(fmt.Errorf("[ERROR] Error setting crn: %s", err))
+		return diag.FromErr(flex.FmtErrorf("[ERROR] Error setting crn: %s", err))
 	}
 	if err = d.Set("href", networkACL.Href); err != nil {
-		return diag.FromErr(fmt.Errorf("[ERROR] Error setting href: %s", err))
+		return diag.FromErr(flex.FmtErrorf("[ERROR] Error setting href: %s", err))
 	}
 	if err = d.Set("name", networkACL.Name); err != nil {
-		return diag.FromErr(fmt.Errorf("[ERROR] Error setting name: %s", err))
+		return diag.FromErr(flex.FmtErrorf("[ERROR] Error setting name: %s", err))
 	}
 
 	if networkACL.ResourceGroup != nil {
 		err = d.Set(isNetworkACLResourceGroup, dataSourceNetworkACLFlattenResourceGroup(*networkACL.ResourceGroup))
 		if err != nil {
-			return diag.FromErr(fmt.Errorf("[ERROR] Error setting resource_group %s", err))
+			return diag.FromErr(flex.FmtErrorf("[ERROR] Error setting resource_group %s", err))
 		}
 	}
 
 	if networkACL.Rules != nil {
 		err = d.Set(isNetworkACLRules, dataSourceNetworkACLFlattenRules(networkACL.Rules))
 		if err != nil {
-			return diag.FromErr(fmt.Errorf("[ERROR] Error setting rules %s", err))
+			return diag.FromErr(flex.FmtErrorf("[ERROR] Error setting rules %s", err))
 		}
 	}
 
 	if networkACL.Subnets != nil {
 		err = d.Set("subnets", dataSourceNetworkACLFlattenSubnets(networkACL.Subnets))
 		if err != nil {
-			return diag.FromErr(fmt.Errorf("[ERROR] Error setting subnets %s", err))
+			return diag.FromErr(flex.FmtErrorf("[ERROR] Error setting subnets %s", err))
 		}
 	}
 
 	if networkACL.VPC != nil {
 		err = d.Set("vpc", dataSourceNetworkACLFlattenVPC(*networkACL.VPC))
 		if err != nil {
-			return diag.FromErr(fmt.Errorf("[ERROR] Error setting vpc %s", err))
+			return diag.FromErr(flex.FmtErrorf("[ERROR] Error setting vpc %s", err))
 		}
 	}
 

--- a/ibm/service/vpc/data_source_ibm_is_network_acl_rule.go
+++ b/ibm/service/vpc/data_source_ibm_is_network_acl_rule.go
@@ -4,7 +4,6 @@
 package vpc
 
 import (
-	"fmt"
 	"reflect"
 
 	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/flex"
@@ -189,7 +188,7 @@ func nawaclRuleDataGet(d *schema.ResourceData, meta interface{}, name, nwACLID s
 
 		ruleList, response, err := sess.ListNetworkACLRules(listNetworkACLRulesOptions)
 		if err != nil {
-			return fmt.Errorf("[ERROR] Error Fetching network acl ruless %s\n%s", err, response)
+			return flex.FmtErrorf("[ERROR] Error Fetching network acl ruless %s\n%s", err, response)
 		}
 		start = flex.GetNext(ruleList.Next)
 

--- a/ibm/service/vpc/data_source_ibm_is_network_acl_rules.go
+++ b/ibm/service/vpc/data_source_ibm_is_network_acl_rules.go
@@ -4,7 +4,6 @@
 package vpc
 
 import (
-	"fmt"
 	"reflect"
 	"time"
 
@@ -205,7 +204,7 @@ func networkACLRulesList(d *schema.ResourceData, meta interface{}, nwACLID strin
 
 		ruleList, response, err := sess.ListNetworkACLRules(listNetworkACLRulesOptions)
 		if err != nil {
-			return fmt.Errorf("[ERROR] Error Fetching network acl ruless %s\n%s", err, response)
+			return flex.FmtErrorf("[ERROR] Error Fetching network acl ruless %s\n%s", err, response)
 		}
 		start = flex.GetNext(ruleList.Next)
 

--- a/ibm/service/vpc/data_source_ibm_is_network_acls.go
+++ b/ibm/service/vpc/data_source_ibm_is_network_acls.go
@@ -5,7 +5,6 @@ package vpc
 
 import (
 	"context"
-	"fmt"
 	"log"
 	"time"
 
@@ -377,7 +376,7 @@ func dataSourceIBMIsNetworkAclsRead(context context.Context, d *schema.ResourceD
 		networkACLCollection, response, err := vpcClient.ListNetworkAclsWithContext(context, listNetworkAclsOptions)
 		if err != nil || networkACLCollection == nil {
 			log.Printf("[DEBUG] ListNetworkAclsWithContext failed %s\n%s", err, response)
-			return diag.FromErr(fmt.Errorf("ListNetworkAclsWithContext failed %s\n%s", err, response))
+			return diag.FromErr(flex.FmtErrorf("ListNetworkAclsWithContext failed %s\n%s", err, response))
 		}
 		start = flex.GetNext(networkACLCollection.Next)
 		allrecs = append(allrecs, networkACLCollection.NetworkAcls...)
@@ -390,7 +389,7 @@ func dataSourceIBMIsNetworkAclsRead(context context.Context, d *schema.ResourceD
 
 	err = d.Set("network_acls", dataSourceNetworkACLCollectionFlattenNetworkAcls(allrecs, d, meta))
 	if err != nil {
-		return diag.FromErr(fmt.Errorf("[ERROR] Error setting network_acls %s", err))
+		return diag.FromErr(flex.FmtErrorf("[ERROR] Error setting network_acls %s", err))
 	}
 
 	return nil

--- a/ibm/service/vpc/data_source_ibm_is_operating_system.go
+++ b/ibm/service/vpc/data_source_ibm_is_operating_system.go
@@ -4,8 +4,7 @@
 package vpc
 
 import (
-	"fmt"
-
+	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/flex"
 	"github.com/IBM/vpc-go-sdk/vpcv1"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
@@ -93,7 +92,7 @@ func osGet(d *schema.ResourceData, meta interface{}, name string) error {
 	}
 	os, response, err := sess.GetOperatingSystem(getOperatingSystemOptions)
 	if err != nil || os == nil {
-		return fmt.Errorf("[ERROR] Error Getting Operating System Details %s , %s", err, response)
+		return flex.FmtErrorf("[ERROR] Error Getting Operating System Details %s , %s", err, response)
 	}
 	d.Set(isOperatingSystemName, *os.Name)
 	d.SetId(*os.Name)

--- a/ibm/service/vpc/data_source_ibm_is_operating_systems.go
+++ b/ibm/service/vpc/data_source_ibm_is_operating_systems.go
@@ -4,7 +4,6 @@
 package vpc
 
 import (
-	"fmt"
 	"time"
 
 	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/flex"
@@ -100,7 +99,7 @@ func osList(d *schema.ResourceData, meta interface{}) error {
 
 		osList, response, err := sess.ListOperatingSystems(listOperatingSystemsOptions)
 		if err != nil {
-			return fmt.Errorf("[ERROR] Error Fetching operating systems %s\n%s", err, response)
+			return flex.FmtErrorf("[ERROR] Error Fetching operating systems %s\n%s", err, response)
 		}
 		start = flex.GetNext(osList.Next)
 		allrecs = append(allrecs, osList.OperatingSystems...)

--- a/ibm/service/vpc/data_source_ibm_is_placement_group.go
+++ b/ibm/service/vpc/data_source_ibm_is_placement_group.go
@@ -5,7 +5,6 @@ package vpc
 
 import (
 	"context"
-	"fmt"
 	"log"
 
 	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/conns"
@@ -127,32 +126,32 @@ func dataSourceIbmIsPlacementGroupRead(context context.Context, d *schema.Resour
 
 			d.SetId(*placementGroup.ID)
 			if err = d.Set("created_at", placementGroup.CreatedAt.String()); err != nil {
-				return diag.FromErr(fmt.Errorf("[ERROR] Error setting created_at: %s", err))
+				return diag.FromErr(flex.FmtErrorf("[ERROR] Error setting created_at: %s", err))
 			}
 			if err = d.Set("crn", placementGroup.CRN); err != nil {
-				return diag.FromErr(fmt.Errorf("[ERROR] Error setting crn: %s", err))
+				return diag.FromErr(flex.FmtErrorf("[ERROR] Error setting crn: %s", err))
 			}
 			if err = d.Set("href", placementGroup.Href); err != nil {
-				return diag.FromErr(fmt.Errorf("[ERROR] Error setting href: %s", err))
+				return diag.FromErr(flex.FmtErrorf("[ERROR] Error setting href: %s", err))
 			}
 			if err = d.Set("lifecycle_state", placementGroup.LifecycleState); err != nil {
-				return diag.FromErr(fmt.Errorf("[ERROR] Error setting lifecycle_state: %s", err))
+				return diag.FromErr(flex.FmtErrorf("[ERROR] Error setting lifecycle_state: %s", err))
 			}
 			if err = d.Set("name", placementGroup.Name); err != nil {
-				return diag.FromErr(fmt.Errorf("[ERROR] Error setting name: %s", err))
+				return diag.FromErr(flex.FmtErrorf("[ERROR] Error setting name: %s", err))
 			}
 
 			if placementGroup.ResourceGroup != nil {
 				err = d.Set("resource_group", dataSourcePlacementGroupFlattenResourceGroup(*placementGroup.ResourceGroup))
 				if err != nil {
-					return diag.FromErr(fmt.Errorf("[ERROR] Error setting resource_group %s", err))
+					return diag.FromErr(flex.FmtErrorf("[ERROR] Error setting resource_group %s", err))
 				}
 			}
 			if err = d.Set("resource_type", placementGroup.ResourceType); err != nil {
-				return diag.FromErr(fmt.Errorf("[ERROR] Error setting resource_type: %s", err))
+				return diag.FromErr(flex.FmtErrorf("[ERROR] Error setting resource_type: %s", err))
 			}
 			if err = d.Set("strategy", placementGroup.Strategy); err != nil {
-				return diag.FromErr(fmt.Errorf("[ERROR] Error setting strategy: %s", err))
+				return diag.FromErr(flex.FmtErrorf("[ERROR] Error setting strategy: %s", err))
 			}
 			tags, err := flex.GetGlobalTagsUsingCRN(meta, *placementGroup.CRN, "", isUserTagType)
 			if err != nil {
@@ -171,7 +170,7 @@ func dataSourceIbmIsPlacementGroupRead(context context.Context, d *schema.Resour
 			return nil
 		}
 	}
-	return diag.FromErr(fmt.Errorf("[ERROR] No placement group found with name %s", pgname))
+	return diag.FromErr(flex.FmtErrorf("[ERROR] No placement group found with name %s", pgname))
 }
 
 func dataSourcePlacementGroupFlattenResourceGroup(result vpcv1.ResourceGroupReference) (finalList []map[string]interface{}) {

--- a/ibm/service/vpc/data_source_ibm_is_placement_groups.go
+++ b/ibm/service/vpc/data_source_ibm_is_placement_groups.go
@@ -5,7 +5,6 @@ package vpc
 
 import (
 	"context"
-	"fmt"
 	"log"
 	"time"
 
@@ -146,10 +145,10 @@ func dataSourceIbmIsPlacementGroupsRead(context context.Context, d *schema.Resou
 	d.SetId(dataSourceIbmIsPlacementGroupsID(d))
 	err = d.Set("placement_groups", dataSourcePlacementGroupCollectionFlattenPlacementGroups(meta, allrecs))
 	if err != nil {
-		return diag.FromErr(fmt.Errorf("[ERROR] Error setting placement_groups %s", err))
+		return diag.FromErr(flex.FmtErrorf("[ERROR] Error setting placement_groups %s", err))
 	}
 	if err = d.Set("total_count", len(allrecs)); err != nil {
-		return diag.FromErr(fmt.Errorf("[ERROR] Error setting total_count: %s", err))
+		return diag.FromErr(flex.FmtErrorf("[ERROR] Error setting total_count: %s", err))
 	}
 	return nil
 }

--- a/ibm/service/vpc/data_source_ibm_is_public_gateway.go
+++ b/ibm/service/vpc/data_source_ibm_is_public_gateway.go
@@ -4,7 +4,6 @@
 package vpc
 
 import (
-	"fmt"
 	"log"
 
 	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/flex"
@@ -131,7 +130,7 @@ func dataSourceIBMISPublicGatewayRead(d *schema.ResourceData, meta interface{}) 
 		}
 		publicgws, response, err := sess.ListPublicGateways(listPublicGatewaysOptions)
 		if err != nil {
-			return fmt.Errorf("[ERROR] Error Fetching public gateways %s\n%s", err, response)
+			return flex.FmtErrorf("[ERROR] Error Fetching public gateways %s\n%s", err, response)
 		}
 		start = flex.GetNext(publicgws.Next)
 		allrecs = append(allrecs, publicgws.PublicGateways...)
@@ -185,5 +184,5 @@ func dataSourceIBMISPublicGatewayRead(d *schema.ResourceData, meta interface{}) 
 			return nil
 		}
 	}
-	return fmt.Errorf("[ERROR] No Public gateway found with name %s", name)
+	return flex.FmtErrorf("[ERROR] No Public gateway found with name %s", name)
 }

--- a/ibm/service/vpc/data_source_ibm_is_public_gateways.go
+++ b/ibm/service/vpc/data_source_ibm_is_public_gateways.go
@@ -4,7 +4,6 @@
 package vpc
 
 import (
-	"fmt"
 	"log"
 	"time"
 
@@ -161,7 +160,7 @@ func publicGatewaysGet(d *schema.ResourceData, meta interface{}, name string) er
 		}
 		publicgws, response, err := sess.ListPublicGateways(listPublicGatewaysOptions)
 		if err != nil {
-			return fmt.Errorf("[ERROR] Error Fetching public gateways %s\n%s", err, response)
+			return flex.FmtErrorf("[ERROR] Error Fetching public gateways %s\n%s", err, response)
 		}
 		start = flex.GetNext(publicgws.Next)
 		allrecs = append(allrecs, publicgws.PublicGateways...)

--- a/ibm/service/vpc/data_source_ibm_is_reservation.go
+++ b/ibm/service/vpc/data_source_ibm_is_reservation.go
@@ -5,7 +5,6 @@ package vpc
 
 import (
 	"context"
-	"fmt"
 	"log"
 
 	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/flex"
@@ -232,7 +231,7 @@ func dataSourceIBMIsReservationRead(context context.Context, d *schema.ResourceD
 		reservationInfo, response, err := sess.GetReservationWithContext(context, getReservationOptions)
 		if err != nil {
 			log.Printf("[DEBUG] GetReservationWithContext failed %s\n%s", err, response)
-			return diag.FromErr(fmt.Errorf("[ERROR] GetReservationWithContext failed %s\n%s", err, response))
+			return diag.FromErr(flex.FmtErrorf("[ERROR] GetReservationWithContext failed %s\n%s", err, response))
 		}
 		reservation = reservationInfo
 
@@ -250,7 +249,7 @@ func dataSourceIBMIsReservationRead(context context.Context, d *schema.ResourceD
 			reservationCollection, response, err := sess.ListReservationsWithContext(context, listReservationsOptions)
 			if err != nil {
 				log.Printf("[DEBUG] ListReservationsWithContext failed %s\n%s", err, response)
-				return diag.FromErr(fmt.Errorf("[ERROR] ListReservationsWithContext failed %s\n%s", err, response))
+				return diag.FromErr(flex.FmtErrorf("[ERROR] ListReservationsWithContext failed %s\n%s", err, response))
 			}
 			if reservationCollection != nil && *reservationCollection.TotalCount == int64(0) {
 				break
@@ -268,20 +267,20 @@ func dataSourceIBMIsReservationRead(context context.Context, d *schema.ResourceD
 			}
 		}
 		if reservation == nil {
-			return diag.FromErr(fmt.Errorf("[ERROR] No reservation found with name (%s)", name))
+			return diag.FromErr(flex.FmtErrorf("[ERROR] No reservation found with name (%s)", name))
 		}
 	}
 
 	d.SetId(*reservation.ID)
 	if err = d.Set("affinity_policy", reservation.AffinityPolicy); err != nil {
-		return diag.FromErr(fmt.Errorf("[ERROR] Error setting affinity_policy: %s", err))
+		return diag.FromErr(flex.FmtErrorf("[ERROR] Error setting affinity_policy: %s", err))
 	}
 	if reservation.Capacity != nil {
 		capacityList := []map[string]interface{}{}
 		capacityMap := dataSourceReservationCapacityToMap(*reservation.Capacity)
 		capacityList = append(capacityList, capacityMap)
 		if err = d.Set("capacity", capacityList); err != nil {
-			return diag.FromErr(fmt.Errorf("[ERROR] Error setting capacity: %s", err))
+			return diag.FromErr(flex.FmtErrorf("[ERROR] Error setting capacity: %s", err))
 		}
 	}
 	if reservation.CommittedUse != nil {
@@ -289,23 +288,23 @@ func dataSourceIBMIsReservationRead(context context.Context, d *schema.ResourceD
 		committedUseMap := dataSourceReservationCommittedUseToMap(*reservation.CommittedUse)
 		committedUseList = append(committedUseList, committedUseMap)
 		if err = d.Set("committed_use", committedUseList); err != nil {
-			return diag.FromErr(fmt.Errorf("[ERROR] Error setting committed_use: %s", err))
+			return diag.FromErr(flex.FmtErrorf("[ERROR] Error setting committed_use: %s", err))
 		}
 	}
 	if err = d.Set("created_at", reservation.CreatedAt.String()); err != nil {
-		return diag.FromErr(fmt.Errorf("[ERROR] Error setting created_at: %s", err))
+		return diag.FromErr(flex.FmtErrorf("[ERROR] Error setting created_at: %s", err))
 	}
 	if err = d.Set("crn", reservation.CRN); err != nil {
-		return diag.FromErr(fmt.Errorf("[ERROR] Error setting crn: %s", err))
+		return diag.FromErr(flex.FmtErrorf("[ERROR] Error setting crn: %s", err))
 	}
 	if err = d.Set("href", reservation.Href); err != nil {
-		return diag.FromErr(fmt.Errorf("[ERROR] Error setting href: %s", err))
+		return diag.FromErr(flex.FmtErrorf("[ERROR] Error setting href: %s", err))
 	}
 	if err = d.Set("lifecycle_state", reservation.LifecycleState); err != nil {
-		return diag.FromErr(fmt.Errorf("[ERROR] Error setting lifecycle_state: %s", err))
+		return diag.FromErr(flex.FmtErrorf("[ERROR] Error setting lifecycle_state: %s", err))
 	}
 	if err = d.Set("name", reservation.Name); err != nil {
-		return diag.FromErr(fmt.Errorf("[ERROR] Error setting name: %s", err))
+		return diag.FromErr(flex.FmtErrorf("[ERROR] Error setting name: %s", err))
 	}
 	if reservation.Profile != nil {
 		profileList := []map[string]interface{}{}
@@ -313,7 +312,7 @@ func dataSourceIBMIsReservationRead(context context.Context, d *schema.ResourceD
 		profileMap := dataSourceReservationProfileToMap(*profile)
 		profileList = append(profileList, profileMap)
 		if err = d.Set("profile", profileList); err != nil {
-			return diag.FromErr(fmt.Errorf("[ERROR] Error setting profile: %s", err))
+			return diag.FromErr(flex.FmtErrorf("[ERROR] Error setting profile: %s", err))
 		}
 	}
 	if reservation.ResourceGroup != nil {
@@ -321,14 +320,14 @@ func dataSourceIBMIsReservationRead(context context.Context, d *schema.ResourceD
 		resourceGroupMap := dataSourceReservationResourceGroupToMap(*reservation.ResourceGroup)
 		resourceGroupList = append(resourceGroupList, resourceGroupMap)
 		if err = d.Set("resource_group", resourceGroupList); err != nil {
-			return diag.FromErr(fmt.Errorf("[ERROR] Error setting resource_group: %s", err))
+			return diag.FromErr(flex.FmtErrorf("[ERROR] Error setting resource_group: %s", err))
 		}
 	}
 	if err = d.Set("resource_type", reservation.ResourceType); err != nil {
-		return diag.FromErr(fmt.Errorf("[ERROR] Error setting resource_type: %s", err))
+		return diag.FromErr(flex.FmtErrorf("[ERROR] Error setting resource_type: %s", err))
 	}
 	if err = d.Set("status", reservation.Status); err != nil {
-		return diag.FromErr(fmt.Errorf("[ERROR] Error setting status: %s", err))
+		return diag.FromErr(flex.FmtErrorf("[ERROR] Error setting status: %s", err))
 	}
 	if reservation.StatusReasons != nil {
 		statusReasonsList := []map[string]interface{}{}
@@ -336,7 +335,7 @@ func dataSourceIBMIsReservationRead(context context.Context, d *schema.ResourceD
 			statusReasonsList = append(statusReasonsList, dataSourceReservationStatusReasonsToMap(statusReasonsItem))
 		}
 		if err = d.Set("status_reasons", statusReasonsList); err != nil {
-			return diag.FromErr(fmt.Errorf("[ERROR] Error setting status_reasons: %s", err))
+			return diag.FromErr(flex.FmtErrorf("[ERROR] Error setting status_reasons: %s", err))
 		}
 	}
 	zone := ""
@@ -344,7 +343,7 @@ func dataSourceIBMIsReservationRead(context context.Context, d *schema.ResourceD
 		zone = *reservation.Zone.Name
 	}
 	if err = d.Set("zone", zone); err != nil {
-		return diag.FromErr(fmt.Errorf("[ERROR] Error setting zone: %s", err))
+		return diag.FromErr(flex.FmtErrorf("[ERROR] Error setting zone: %s", err))
 	}
 	return nil
 }

--- a/ibm/service/vpc/data_source_ibm_is_reservations.go
+++ b/ibm/service/vpc/data_source_ibm_is_reservations.go
@@ -5,7 +5,6 @@ package vpc
 
 import (
 	"context"
-	"fmt"
 	"log"
 	"time"
 
@@ -266,7 +265,7 @@ func dataSourceIBMIsReservationsRead(context context.Context, d *schema.Resource
 		reservationCollection, response, err := sess.ListReservationsWithContext(context, listReservationsOptions)
 		if err != nil {
 			log.Printf("[DEBUG] ListReservationsWithContext failed %s\n%s", err, response)
-			return diag.FromErr(fmt.Errorf("[ERROR] ListReservationsWithContext failed %s\n%s", err, response))
+			return diag.FromErr(flex.FmtErrorf("[ERROR] ListReservationsWithContext failed %s\n%s", err, response))
 		}
 		if reservationCollection != nil && *reservationCollection.TotalCount == int64(0) {
 			break
@@ -283,7 +282,7 @@ func dataSourceIBMIsReservationsRead(context context.Context, d *schema.Resource
 	if reservations != nil {
 		err = d.Set("reservations", dataSourceReservationCollectionFlattenReservations(reservations))
 		if err != nil {
-			return diag.FromErr(fmt.Errorf("[ERROR] Error setting reservations %s", err))
+			return diag.FromErr(flex.FmtErrorf("[ERROR] Error setting reservations %s", err))
 		}
 	}
 

--- a/ibm/service/vpc/data_source_ibm_is_security_group.go
+++ b/ibm/service/vpc/data_source_ibm_is_security_group.go
@@ -4,7 +4,6 @@
 package vpc
 
 import (
-	"fmt"
 	"log"
 	"reflect"
 
@@ -185,7 +184,7 @@ func securityGroupGet(d *schema.ResourceData, meta interface{}, name string) err
 		}
 		sgs, response, err := sess.ListSecurityGroups(listSgOptions)
 		if err != nil || sgs == nil {
-			return fmt.Errorf("[ERROR] Error Getting Security Groups %s\n%s", err, response)
+			return flex.FmtErrorf("[ERROR] Error Getting Security Groups %s\n%s", err, response)
 		}
 		if *sgs.TotalCount == int64(0) {
 			break
@@ -332,6 +331,6 @@ func securityGroupGet(d *schema.ResourceData, meta interface{}, name string) err
 			return nil
 		}
 	}
-	return fmt.Errorf("[ERROR] No Security Group found with name %s", name)
+	return flex.FmtErrorf("[ERROR] No Security Group found with name %s", name)
 
 }

--- a/ibm/service/vpc/data_source_ibm_is_security_group_rule.go
+++ b/ibm/service/vpc/data_source_ibm_is_security_group_rule.go
@@ -5,7 +5,6 @@ package vpc
 
 import (
 	"context"
-	"fmt"
 	"log"
 	"reflect"
 
@@ -142,7 +141,7 @@ func dataSourceIBMIsSecurityGroupRuleRead(context context.Context, d *schema.Res
 	securityGroupRuleIntf, response, err := vpcClient.GetSecurityGroupRuleWithContext(context, getSecurityGroupRuleOptions)
 	if err != nil || securityGroupRuleIntf == nil {
 		log.Printf("[DEBUG] GetSecurityGroupRuleWithContext failed %s\n%s", err, response)
-		return diag.FromErr(fmt.Errorf("GetSecurityGroupRuleWithContext failed %s\n%s", err, response))
+		return diag.FromErr(flex.FmtErrorf("GetSecurityGroupRuleWithContext failed %s\n%s", err, response))
 	}
 
 	switch reflect.TypeOf(securityGroupRuleIntf).String() {
@@ -152,25 +151,25 @@ func dataSourceIBMIsSecurityGroupRuleRead(context context.Context, d *schema.Res
 
 			d.SetId(*securityGroupRule.ID)
 			if err = d.Set("direction", securityGroupRule.Direction); err != nil {
-				return diag.FromErr(fmt.Errorf("Error setting direction: %s", err))
+				return diag.FromErr(flex.FmtErrorf("Error setting direction: %s", err))
 			}
 			if err = d.Set("href", securityGroupRule.Href); err != nil {
-				return diag.FromErr(fmt.Errorf("Error setting href: %s", err))
+				return diag.FromErr(flex.FmtErrorf("Error setting href: %s", err))
 			}
 			if err = d.Set("ip_version", securityGroupRule.IPVersion); err != nil {
-				return diag.FromErr(fmt.Errorf("Error setting ip_version: %s", err))
+				return diag.FromErr(flex.FmtErrorf("Error setting ip_version: %s", err))
 			}
 			if err = d.Set("protocol", securityGroupRule.Protocol); err != nil {
-				return diag.FromErr(fmt.Errorf("Error setting protocol: %s", err))
+				return diag.FromErr(flex.FmtErrorf("Error setting protocol: %s", err))
 			}
 			if securityGroupRule.Remote != nil {
 				securityGroupRuleRemote, err := dataSourceSecurityGroupRuleFlattenRemote(securityGroupRule.Remote)
 				if err != nil {
-					return diag.FromErr(fmt.Errorf("Error flattening securityGroupRule.Remote %s", err))
+					return diag.FromErr(flex.FmtErrorf("Error flattening securityGroupRule.Remote %s", err))
 				}
 				err = d.Set("remote", securityGroupRuleRemote)
 				if err != nil {
-					return diag.FromErr(fmt.Errorf("Error setting remote %s", err))
+					return diag.FromErr(flex.FmtErrorf("Error setting remote %s", err))
 				}
 			}
 
@@ -181,33 +180,33 @@ func dataSourceIBMIsSecurityGroupRuleRead(context context.Context, d *schema.Res
 
 			d.SetId(*securityGroupRule.ID)
 			if err = d.Set("direction", securityGroupRule.Direction); err != nil {
-				return diag.FromErr(fmt.Errorf("Error setting direction: %s", err))
+				return diag.FromErr(flex.FmtErrorf("Error setting direction: %s", err))
 			}
 			if err = d.Set("href", securityGroupRule.Href); err != nil {
-				return diag.FromErr(fmt.Errorf("Error setting href: %s", err))
+				return diag.FromErr(flex.FmtErrorf("Error setting href: %s", err))
 			}
 			if err = d.Set("ip_version", securityGroupRule.IPVersion); err != nil {
-				return diag.FromErr(fmt.Errorf("Error setting ip_version: %s", err))
+				return diag.FromErr(flex.FmtErrorf("Error setting ip_version: %s", err))
 			}
 			if err = d.Set("protocol", securityGroupRule.Protocol); err != nil {
-				return diag.FromErr(fmt.Errorf("Error setting protocol: %s", err))
+				return diag.FromErr(flex.FmtErrorf("Error setting protocol: %s", err))
 			}
 			if securityGroupRule.Remote != nil {
 				securityGroupRuleRemote, err := dataSourceSecurityGroupRuleFlattenRemote(securityGroupRule.Remote)
 				if err != nil {
-					return diag.FromErr(fmt.Errorf("Error flattening securityGroupRule.Remote %s", err))
+					return diag.FromErr(flex.FmtErrorf("Error flattening securityGroupRule.Remote %s", err))
 				}
 				err = d.Set("remote", securityGroupRuleRemote)
 				if err != nil {
-					return diag.FromErr(fmt.Errorf("Error setting remote %s", err))
+					return diag.FromErr(flex.FmtErrorf("Error setting remote %s", err))
 				}
 			}
 
 			if err = d.Set("code", flex.IntValue(securityGroupRule.Code)); err != nil {
-				return diag.FromErr(fmt.Errorf("Error setting code: %s", err))
+				return diag.FromErr(flex.FmtErrorf("Error setting code: %s", err))
 			}
 			if err = d.Set("type", flex.IntValue(securityGroupRule.Type)); err != nil {
-				return diag.FromErr(fmt.Errorf("Error setting type: %s", err))
+				return diag.FromErr(flex.FmtErrorf("Error setting type: %s", err))
 			}
 		}
 	case "*vpcv1.SecurityGroupRuleSecurityGroupRuleProtocolTcpudp":
@@ -216,32 +215,32 @@ func dataSourceIBMIsSecurityGroupRuleRead(context context.Context, d *schema.Res
 
 			d.SetId(*securityGroupRule.ID)
 			if err = d.Set("direction", securityGroupRule.Direction); err != nil {
-				return diag.FromErr(fmt.Errorf("Error setting direction: %s", err))
+				return diag.FromErr(flex.FmtErrorf("Error setting direction: %s", err))
 			}
 			if err = d.Set("href", securityGroupRule.Href); err != nil {
-				return diag.FromErr(fmt.Errorf("Error setting href: %s", err))
+				return diag.FromErr(flex.FmtErrorf("Error setting href: %s", err))
 			}
 			if err = d.Set("ip_version", securityGroupRule.IPVersion); err != nil {
-				return diag.FromErr(fmt.Errorf("Error setting ip_version: %s", err))
+				return diag.FromErr(flex.FmtErrorf("Error setting ip_version: %s", err))
 			}
 			if err = d.Set("protocol", securityGroupRule.Protocol); err != nil {
-				return diag.FromErr(fmt.Errorf("Error setting protocol: %s", err))
+				return diag.FromErr(flex.FmtErrorf("Error setting protocol: %s", err))
 			}
 			if securityGroupRule.Remote != nil {
 				securityGroupRuleRemote, err := dataSourceSecurityGroupRuleFlattenRemote(securityGroupRule.Remote)
 				if err != nil {
-					return diag.FromErr(fmt.Errorf("Error flattening securityGroupRule.Remote %s", err))
+					return diag.FromErr(flex.FmtErrorf("Error flattening securityGroupRule.Remote %s", err))
 				}
 				err = d.Set("remote", securityGroupRuleRemote)
 				if err != nil {
-					return diag.FromErr(fmt.Errorf("Error setting remote %s", err))
+					return diag.FromErr(flex.FmtErrorf("Error setting remote %s", err))
 				}
 			}
 			if err = d.Set("port_max", flex.IntValue(securityGroupRule.PortMax)); err != nil {
-				return diag.FromErr(fmt.Errorf("Error setting port_max: %s", err))
+				return diag.FromErr(flex.FmtErrorf("Error setting port_max: %s", err))
 			}
 			if err = d.Set("port_min", flex.IntValue(securityGroupRule.PortMin)); err != nil {
-				return diag.FromErr(fmt.Errorf("Error setting port_min: %s", err))
+				return diag.FromErr(flex.FmtErrorf("Error setting port_min: %s", err))
 			}
 		}
 	}

--- a/ibm/service/vpc/data_source_ibm_is_security_group_rules.go
+++ b/ibm/service/vpc/data_source_ibm_is_security_group_rules.go
@@ -4,10 +4,10 @@
 package vpc
 
 import (
-	"fmt"
 	"reflect"
 	"time"
 
+	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/flex"
 	"github.com/IBM/vpc-go-sdk/vpcv1"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
@@ -146,7 +146,7 @@ func dataSourceIBMIsSecurityGroupRulesRead(d *schema.ResourceData, meta interfac
 
 	ruleList, response, err := sess.ListSecurityGroupRules(&listSecurityGroupRuleOptions)
 	if err != nil {
-		return fmt.Errorf("Error fetching security group rules %s\n%s", err, response)
+		return flex.FmtErrorf("Error fetching security group rules %s\n%s", err, response)
 	}
 
 	rulesInfo := make([]map[string]interface{}, 0)

--- a/ibm/service/vpc/data_source_ibm_is_security_group_target.go
+++ b/ibm/service/vpc/data_source_ibm_is_security_group_target.go
@@ -78,7 +78,7 @@ func dataSourceIBMISSecurityGroupTargetRead(d *schema.ResourceData, meta interfa
 		}
 		groups, response, err := sess.ListSecurityGroupTargets(listSecurityGroupTargetsOptions)
 		if err != nil {
-			return fmt.Errorf("[ERROR] Error Getting InstanceGroup Managers %s\n%s", err, response)
+			return flex.FmtErrorf("[ERROR] Error Getting InstanceGroup Managers %s\n%s", err, response)
 		}
 		if *groups.TotalCount == int64(0) {
 			break
@@ -109,5 +109,5 @@ func dataSourceIBMISSecurityGroupTargetRead(d *schema.ResourceData, meta interfa
 			return nil
 		}
 	}
-	return fmt.Errorf("Security Group Target %s not found", name)
+	return flex.FmtErrorf("Security Group Target %s not found", name)
 }

--- a/ibm/service/vpc/data_source_ibm_is_security_group_targets.go
+++ b/ibm/service/vpc/data_source_ibm_is_security_group_targets.go
@@ -4,8 +4,6 @@
 package vpc
 
 import (
-	"fmt"
-
 	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/flex"
 	"github.com/IBM/vpc-go-sdk/vpcv1"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -87,7 +85,7 @@ func dataSourceIBMISSecurityGroupTargetsRead(d *schema.ResourceData, meta interf
 		}
 		groups, response, err := sess.ListSecurityGroupTargets(listSecurityGroupTargetsOptions)
 		if err != nil || groups == nil {
-			return fmt.Errorf("[ERROR] Error Getting InstanceGroup Managers %s\n%s", err, response)
+			return flex.FmtErrorf("[ERROR] Error Getting InstanceGroup Managers %s\n%s", err, response)
 		}
 		if *groups.TotalCount == int64(0) {
 			break

--- a/ibm/service/vpc/data_source_ibm_is_security_groups.go
+++ b/ibm/service/vpc/data_source_ibm_is_security_groups.go
@@ -5,7 +5,6 @@ package vpc
 
 import (
 	"context"
-	"fmt"
 	"log"
 	"reflect"
 	"time"
@@ -344,7 +343,7 @@ func dataSourceIBMIsSecurityGroupsRead(context context.Context, d *schema.Resour
 		securityGroupCollection, response, err := vpcClient.ListSecurityGroupsWithContext(context, listSecurityGroupsOptions)
 		if err != nil {
 			log.Printf("[DEBUG] ListSecurityGroupsWithContext failed %s\n%s", err, response)
-			return diag.FromErr(fmt.Errorf("ListSecurityGroupsWithContext failed %s\n%s", err, response))
+			return diag.FromErr(flex.FmtErrorf("ListSecurityGroupsWithContext failed %s\n%s", err, response))
 		}
 
 		start = flex.GetNext(securityGroupCollection.Next)
@@ -358,7 +357,7 @@ func dataSourceIBMIsSecurityGroupsRead(context context.Context, d *schema.Resour
 	d.SetId(dataSourceIBMIsSecurityGroupsID(d))
 	err = d.Set("security_groups", dataSourceSecurityGroupCollectionFlattenSecurityGroups(allrecs, d, meta))
 	if err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting security_groups %s", err))
+		return diag.FromErr(flex.FmtErrorf("Error setting security_groups %s", err))
 	}
 	return nil
 }

--- a/ibm/service/vpc/data_source_ibm_is_share.go
+++ b/ibm/service/vpc/data_source_ibm_is_share.go
@@ -5,7 +5,6 @@ package vpc
 
 import (
 	"context"
-	"fmt"
 	"log"
 
 	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/conns"
@@ -407,32 +406,32 @@ func dataSourceIbmIsShareRead(context context.Context, d *schema.ResourceData, m
 			}
 		}
 		if share == nil {
-			return diag.FromErr(fmt.Errorf("[ERROR] Share with provided name %s not found", shareName))
+			return diag.FromErr(flex.FmtErrorf("[ERROR] Share with provided name %s not found", shareName))
 		}
 	}
 
 	d.SetId(*share.ID)
 	if err = d.Set("created_at", share.CreatedAt.String()); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting created_at: %s", err))
+		return diag.FromErr(flex.FmtErrorf("Error setting created_at: %s", err))
 	}
 	if err = d.Set("crn", share.CRN); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting crn: %s", err))
+		return diag.FromErr(flex.FmtErrorf("Error setting crn: %s", err))
 	}
 	if err = d.Set("encryption", share.Encryption); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting encryption: %s", err))
+		return diag.FromErr(flex.FmtErrorf("Error setting encryption: %s", err))
 	}
 
 	if share.EncryptionKey != nil {
 		err = d.Set("encryption_key", *share.EncryptionKey.CRN)
 		if err != nil {
-			return diag.FromErr(fmt.Errorf("Error setting encryption_key %s", err))
+			return diag.FromErr(flex.FmtErrorf("Error setting encryption_key %s", err))
 		}
 	}
 	if err = d.Set("href", share.Href); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting href: %s", err))
+		return diag.FromErr(flex.FmtErrorf("Error setting href: %s", err))
 	}
 	if err = d.Set("iops", share.Iops); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting iops: %s", err))
+		return diag.FromErr(flex.FmtErrorf("Error setting iops: %s", err))
 	}
 	latest_syncs := []map[string]interface{}{}
 	if share.LatestSync != nil {
@@ -448,15 +447,15 @@ func dataSourceIbmIsShareRead(context context.Context, d *schema.ResourceData, m
 	if share.LatestJob != nil {
 		err = d.Set("latest_job", dataSourceShareFlattenLatestJob(*share.LatestJob))
 		if err != nil {
-			return diag.FromErr(fmt.Errorf("Error setting latest_job %s", err))
+			return diag.FromErr(flex.FmtErrorf("Error setting latest_job %s", err))
 		}
 	}
 
 	if err = d.Set("lifecycle_state", share.LifecycleState); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting lifecycle_state: %s", err))
+		return diag.FromErr(flex.FmtErrorf("Error setting lifecycle_state: %s", err))
 	}
 	if err = d.Set("name", share.Name); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting name: %s", err))
+		return diag.FromErr(flex.FmtErrorf("Error setting name: %s", err))
 	}
 	if share.AccessControlMode != nil {
 		d.Set("access_control_mode", *share.AccessControlMode)
@@ -464,62 +463,62 @@ func dataSourceIbmIsShareRead(context context.Context, d *schema.ResourceData, m
 	if share.Profile != nil {
 		err = d.Set("profile", *share.Profile.Name)
 		if err != nil {
-			return diag.FromErr(fmt.Errorf("Error setting profile %s", err))
+			return diag.FromErr(flex.FmtErrorf("Error setting profile %s", err))
 		}
 	}
 
 	if share.ReplicaShare != nil {
 		err = d.Set("replica_share", dataSourceShareFlattenReplicaShare(*share.ReplicaShare))
 		if err != nil {
-			return diag.FromErr(fmt.Errorf("Error setting replica_share %s", err))
+			return diag.FromErr(flex.FmtErrorf("Error setting replica_share %s", err))
 		}
 	}
 	if err = d.Set("replication_cron_spec", share.ReplicationCronSpec); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting replication_cron_spec: %s", err))
+		return diag.FromErr(flex.FmtErrorf("Error setting replication_cron_spec: %s", err))
 	}
 	if err = d.Set("replication_role", share.ReplicationRole); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting replication_role: %s", err))
+		return diag.FromErr(flex.FmtErrorf("Error setting replication_role: %s", err))
 	}
 	if err = d.Set("replication_status", share.ReplicationStatus); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting replication_status: %s", err))
+		return diag.FromErr(flex.FmtErrorf("Error setting replication_status: %s", err))
 	}
 
 	if share.ReplicationStatusReasons != nil {
 		err = d.Set("replication_status_reasons", dataSourceShareFlattenReplicationStatusReasons(share.ReplicationStatusReasons))
 		if err != nil {
-			return diag.FromErr(fmt.Errorf("Error setting replication_status_reasons %s", err))
+			return diag.FromErr(flex.FmtErrorf("Error setting replication_status_reasons %s", err))
 		}
 	}
 
 	if share.ResourceGroup != nil {
 		err = d.Set("resource_group", *share.ResourceGroup.ID)
 		if err != nil {
-			return diag.FromErr(fmt.Errorf("Error setting resource_group %s", err))
+			return diag.FromErr(flex.FmtErrorf("Error setting resource_group %s", err))
 		}
 	}
 	if err = d.Set("resource_type", share.ResourceType); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting resource_type: %s", err))
+		return diag.FromErr(flex.FmtErrorf("Error setting resource_type: %s", err))
 	}
 	if err = d.Set("size", share.Size); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting size: %s", err))
+		return diag.FromErr(flex.FmtErrorf("Error setting size: %s", err))
 	}
 	if share.SourceShare != nil {
 		err = d.Set("source_share", dataSourceShareFlattenSourceShare(*share.SourceShare))
 		if err != nil {
-			return diag.FromErr(fmt.Errorf("Error setting source_share %s", err))
+			return diag.FromErr(flex.FmtErrorf("Error setting source_share %s", err))
 		}
 	}
 	if share.MountTargets != nil {
 		err = d.Set("share_targets", dataSourceShareFlattenTargets(share.MountTargets))
 		if err != nil {
-			return diag.FromErr(fmt.Errorf("Error setting targets %s", err))
+			return diag.FromErr(flex.FmtErrorf("Error setting targets %s", err))
 		}
 	}
 
 	if share.Zone != nil {
 		err = d.Set("zone", *share.Zone.Name)
 		if err != nil {
-			return diag.FromErr(fmt.Errorf("Error setting zone %s", err))
+			return diag.FromErr(flex.FmtErrorf("Error setting zone %s", err))
 		}
 	}
 

--- a/ibm/service/vpc/data_source_ibm_is_share_mount_target.go
+++ b/ibm/service/vpc/data_source_ibm_is_share_mount_target.go
@@ -9,6 +9,7 @@ import (
 	"log"
 
 	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/conns"
+	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/flex"
 	"github.com/IBM/vpc-go-sdk/vpcv1"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -336,26 +337,26 @@ func dataSourceIBMIsShareTargetRead(context context.Context, d *schema.ResourceD
 		d.Set("access_control_mode", *shareTarget.AccessControlMode)
 	}
 	if err = d.Set("created_at", shareTarget.CreatedAt.String()); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting created_at: %s", err))
+		return diag.FromErr(flex.FmtErrorf("Error setting created_at: %s", err))
 	}
 	if err = d.Set("href", shareTarget.Href); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting href: %s", err))
+		return diag.FromErr(flex.FmtErrorf("Error setting href: %s", err))
 	}
 	if err = d.Set("lifecycle_state", shareTarget.LifecycleState); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting lifecycle_state: %s", err))
+		return diag.FromErr(flex.FmtErrorf("Error setting lifecycle_state: %s", err))
 	}
 	if err = d.Set("mount_path", shareTarget.MountPath); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting mount_path: %s", err))
+		return diag.FromErr(flex.FmtErrorf("Error setting mount_path: %s", err))
 	}
 	if err = d.Set("name", shareTarget.Name); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting name: %s", err))
+		return diag.FromErr(flex.FmtErrorf("Error setting name: %s", err))
 	}
 	if err = d.Set("resource_type", shareTarget.ResourceType); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting resource_type: %s", err))
+		return diag.FromErr(flex.FmtErrorf("Error setting resource_type: %s", err))
 	}
 	if shareTarget.TransitEncryption != nil {
 		if err = d.Set("transit_encryption", *shareTarget.TransitEncryption); err != nil {
-			return diag.FromErr(fmt.Errorf("Error setting transit_encryption: %s", err))
+			return diag.FromErr(flex.FmtErrorf("Error setting transit_encryption: %s", err))
 		}
 	}
 
@@ -369,21 +370,21 @@ func dataSourceIBMIsShareTargetRead(context context.Context, d *schema.ResourceD
 	if shareTarget.VPC != nil {
 		err = d.Set("vpc", dataSourceShareMountTargetFlattenVpc(*shareTarget.VPC))
 		if err != nil {
-			return diag.FromErr(fmt.Errorf("Error setting vpc %s", err))
+			return diag.FromErr(flex.FmtErrorf("Error setting vpc %s", err))
 		}
 	}
 
 	if shareTarget.VirtualNetworkInterface != nil {
 		err = d.Set("virtual_network_interface", dataSourceShareMountTargetFlattenVNI(*shareTarget.VirtualNetworkInterface))
 		if err != nil {
-			return diag.FromErr(fmt.Errorf("Error setting vpc %s", err))
+			return diag.FromErr(flex.FmtErrorf("Error setting vpc %s", err))
 		}
 	}
 
 	if shareTarget.Subnet != nil {
 		err = d.Set("subnet", dataSourceShareMountTargetFlattenSubnet(*shareTarget.Subnet))
 		if err != nil {
-			return diag.FromErr(fmt.Errorf("Error setting subnet %s", err))
+			return diag.FromErr(flex.FmtErrorf("Error setting subnet %s", err))
 		}
 	}
 

--- a/ibm/service/vpc/data_source_ibm_is_share_mount_targets.go
+++ b/ibm/service/vpc/data_source_ibm_is_share_mount_targets.go
@@ -5,7 +5,6 @@ package vpc
 
 import (
 	"context"
-	"fmt"
 	"log"
 	"time"
 
@@ -316,7 +315,7 @@ func dataSourceIBMIsShareTargetsRead(context context.Context, d *schema.Resource
 	if len(allrecs) > 0 {
 		err = d.Set("mount_targets", dataSourceShareMountTargetCollectionFlattenTargets(allrecs))
 		if err != nil {
-			return diag.FromErr(fmt.Errorf("Error setting targets %s", err))
+			return diag.FromErr(flex.FmtErrorf("Error setting targets %s", err))
 		}
 	}
 

--- a/ibm/service/vpc/data_source_ibm_is_share_profile.go
+++ b/ibm/service/vpc/data_source_ibm_is_share_profile.go
@@ -5,11 +5,11 @@ package vpc
 
 import (
 	"context"
-	"fmt"
 	"log"
 	"time"
 
 	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/conns"
+	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/flex"
 	"github.com/IBM/vpc-go-sdk/vpcv1"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -155,7 +155,7 @@ func dataSourceIbmIsShareProfileRead(context context.Context, d *schema.Resource
 		capacityMap := dataSourceShareProfileCapacityToMap(*capacity)
 		capacityList = append(capacityList, capacityMap)
 		if err = d.Set("capacity", capacityList); err != nil {
-			return diag.FromErr(fmt.Errorf("Error setting capacity: %s", err))
+			return diag.FromErr(flex.FmtErrorf("Error setting capacity: %s", err))
 		}
 	}
 	if shareProfile.Iops != nil {
@@ -164,18 +164,18 @@ func dataSourceIbmIsShareProfileRead(context context.Context, d *schema.Resource
 		iopsMap := dataSourceShareProfileIopsToMap(*iops)
 		iopsList = append(iopsList, iopsMap)
 		if err = d.Set("iops", iopsList); err != nil {
-			return diag.FromErr(fmt.Errorf("Error setting iops: %s", err))
+			return diag.FromErr(flex.FmtErrorf("Error setting iops: %s", err))
 		}
 	}
 	d.SetId(*shareProfile.Name)
 	if err = d.Set("family", shareProfile.Family); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting family: %s", err))
+		return diag.FromErr(flex.FmtErrorf("Error setting family: %s", err))
 	}
 	if err = d.Set("href", shareProfile.Href); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting href: %s", err))
+		return diag.FromErr(flex.FmtErrorf("Error setting href: %s", err))
 	}
 	if err = d.Set("resource_type", shareProfile.ResourceType); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting resource_type: %s", err))
+		return diag.FromErr(flex.FmtErrorf("Error setting resource_type: %s", err))
 	}
 
 	return nil

--- a/ibm/service/vpc/data_source_ibm_is_share_profiles.go
+++ b/ibm/service/vpc/data_source_ibm_is_share_profiles.go
@@ -5,11 +5,11 @@ package vpc
 
 import (
 	"context"
-	"fmt"
 	"log"
 	"time"
 
 	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/conns"
+	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/flex"
 	"github.com/IBM/vpc-go-sdk/vpcv1"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -167,11 +167,11 @@ func dataSourceIbmIsShareProfilesRead(context context.Context, d *schema.Resourc
 	if shareProfileCollection.Profiles != nil {
 		err = d.Set("profiles", dataSourceShareProfileCollectionFlattenProfiles(shareProfileCollection.Profiles))
 		if err != nil {
-			return diag.FromErr(fmt.Errorf("Error setting profiles %s", err))
+			return diag.FromErr(flex.FmtErrorf("Error setting profiles %s", err))
 		}
 	}
 	if err = d.Set("total_count", shareProfileCollection.TotalCount); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting total_count: %s", err))
+		return diag.FromErr(flex.FmtErrorf("Error setting total_count: %s", err))
 	}
 
 	return nil

--- a/ibm/service/vpc/data_source_ibm_is_shares.go
+++ b/ibm/service/vpc/data_source_ibm_is_shares.go
@@ -5,7 +5,6 @@ package vpc
 
 import (
 	"context"
-	"fmt"
 	"log"
 	"time"
 
@@ -432,11 +431,11 @@ func dataSourceIbmIsSharesRead(context context.Context, d *schema.ResourceData, 
 	if allrecs != nil {
 		err = d.Set("shares", dataSourceShareCollectionFlattenShares(meta, allrecs))
 		if err != nil {
-			return diag.FromErr(fmt.Errorf("Error setting shares %s", err))
+			return diag.FromErr(flex.FmtErrorf("Error setting shares %s", err))
 		}
 	}
 	if err = d.Set("total_count", totalCount); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting total_count: %s", err))
+		return diag.FromErr(flex.FmtErrorf("Error setting total_count: %s", err))
 	}
 
 	return nil

--- a/ibm/service/vpc/data_source_ibm_is_snapshot.go
+++ b/ibm/service/vpc/data_source_ibm_is_snapshot.go
@@ -4,7 +4,6 @@
 package vpc
 
 import (
-	"fmt"
 	"log"
 
 	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/flex"
@@ -411,7 +410,7 @@ func snapshotGetByNameOrID(d *schema.ResourceData, meta interface{}, name, id st
 			}
 			snapshots, response, err := sess.ListSnapshots(listSnapshotOptions)
 			if err != nil {
-				return fmt.Errorf("[ERROR] Error Fetching snapshots %s\n%s", err, response)
+				return flex.FmtErrorf("[ERROR] Error Fetching snapshots %s\n%s", err, response)
 			}
 			start = flex.GetNext(snapshots.Next)
 			allrecs = append(allrecs, snapshots.Snapshots...)
@@ -478,7 +477,7 @@ func snapshotGetByNameOrID(d *schema.ResourceData, meta interface{}, name, id st
 					for _, copiesItem := range snapshot.Copies {
 						copiesMap, err := dataSourceIBMIsSnapshotsSnapshotCopiesItemToMap(&copiesItem)
 						if err != nil {
-							return fmt.Errorf("[ERROR] Error fetching snapshot copies: %s", err)
+							return flex.FmtErrorf("[ERROR] Error fetching snapshot copies: %s", err)
 						}
 						snapshotCopies = append(snapshotCopies, copiesMap)
 					}
@@ -487,7 +486,7 @@ func snapshotGetByNameOrID(d *schema.ResourceData, meta interface{}, name, id st
 
 				if snapshot.UserTags != nil {
 					if err = d.Set(isSnapshotUserTags, snapshot.UserTags); err != nil {
-						return fmt.Errorf("[ERROR] Error setting user tags: %s", err)
+						return flex.FmtErrorf("[ERROR] Error setting user tags: %s", err)
 					}
 				}
 				if snapshot.ResourceGroup != nil && snapshot.ResourceGroup.ID != nil {
@@ -538,17 +537,17 @@ func snapshotGetByNameOrID(d *schema.ResourceData, meta interface{}, name, id st
 				return nil
 			}
 		}
-		return fmt.Errorf("[ERROR] No snapshot found with name %s", name)
+		return flex.FmtErrorf("[ERROR] No snapshot found with name %s", name)
 	} else {
 		getSnapshotOptions := &vpcv1.GetSnapshotOptions{
 			ID: &id,
 		}
 		snapshot, response, err := sess.GetSnapshot(getSnapshotOptions)
 		if err != nil {
-			return fmt.Errorf("[ERROR] Error fetching snapshot %s\n%s", err, response)
+			return flex.FmtErrorf("[ERROR] Error fetching snapshot %s\n%s", err, response)
 		}
 		if (response != nil && response.StatusCode == 404) || snapshot == nil {
-			return fmt.Errorf("[ERROR] No snapshot found with id %s", id)
+			return flex.FmtErrorf("[ERROR] No snapshot found with id %s", id)
 		}
 		d.SetId(*snapshot.ID)
 		d.Set(isSnapshotName, *snapshot.Name)
@@ -586,7 +585,7 @@ func snapshotGetByNameOrID(d *schema.ResourceData, meta interface{}, name, id st
 			for _, copiesItem := range snapshot.Copies {
 				copiesMap, err := dataSourceIBMIsSnapshotsSnapshotCopiesItemToMap(&copiesItem)
 				if err != nil {
-					return fmt.Errorf("[ERROR] Error fetching snapshot copies: %s", err)
+					return flex.FmtErrorf("[ERROR] Error fetching snapshot copies: %s", err)
 				}
 				snapshotCopies = append(snapshotCopies, copiesMap)
 			}
@@ -598,7 +597,7 @@ func snapshotGetByNameOrID(d *schema.ResourceData, meta interface{}, name, id st
 		}
 		if snapshot.UserTags != nil {
 			if err = d.Set(isSnapshotUserTags, snapshot.UserTags); err != nil {
-				return fmt.Errorf("[ERROR] Error setting user tags: %s", err)
+				return flex.FmtErrorf("[ERROR] Error setting user tags: %s", err)
 			}
 		}
 		if snapshot.ResourceGroup != nil && snapshot.ResourceGroup.ID != nil {

--- a/ibm/service/vpc/data_source_ibm_is_snapshot_clone.go
+++ b/ibm/service/vpc/data_source_ibm_is_snapshot_clone.go
@@ -5,7 +5,6 @@ package vpc
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/conns"
 	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/flex"
@@ -68,7 +67,7 @@ func getSnapshotClone(context context.Context, d *schema.ResourceData, meta inte
 
 	clone, response, err := sess.GetSnapshotCloneWithContext(context, getSnapshotCloneOptions)
 	if err != nil {
-		return fmt.Errorf("[ERROR] Error fetching snapshot(%s) clone(%s) %s\n%s", id, zone, err, response)
+		return flex.FmtErrorf("[ERROR] Error fetching snapshot(%s) clone(%s) %s\n%s", id, zone, err, response)
 	}
 
 	if clone != nil && clone.Zone != nil {
@@ -79,7 +78,7 @@ func getSnapshotClone(context context.Context, d *schema.ResourceData, meta inte
 			d.Set(isSnapshotCloneCreatedAt, flex.DateTimeToString(clone.CreatedAt))
 		}
 	} else {
-		return fmt.Errorf("[ERROR] No snapshot(%s) clone(%s) found", id, zone)
+		return flex.FmtErrorf("[ERROR] No snapshot(%s) clone(%s) found", id, zone)
 	}
 	return nil
 }

--- a/ibm/service/vpc/data_source_ibm_is_snapshot_clones.go
+++ b/ibm/service/vpc/data_source_ibm_is_snapshot_clones.go
@@ -5,7 +5,6 @@ package vpc
 
 import (
 	"context"
-	"fmt"
 	"time"
 
 	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/conns"
@@ -84,7 +83,7 @@ func getSnapshotClones(context context.Context, d *schema.ResourceData, meta int
 
 	clonesCollection, response, err := sess.ListSnapshotClonesWithContext(context, listSnapshotClonesOptions)
 	if err != nil {
-		return fmt.Errorf("[ERROR] Error fetching snapshot(%s) clones %s\n%s", id, err, response)
+		return flex.FmtErrorf("[ERROR] Error fetching snapshot(%s) clones %s\n%s", id, err, response)
 	}
 	clones := clonesCollection.Clones
 

--- a/ibm/service/vpc/data_source_ibm_is_snapshot_consistency_group.go
+++ b/ibm/service/vpc/data_source_ibm_is_snapshot_consistency_group.go
@@ -296,7 +296,7 @@ func dataSourceIBMIsSnapshotConsistencyGroupRead(context context.Context, d *sch
 
 			snapshotConsistencyGroup, response, err := vpcClient.ListSnapshotConsistencyGroups(listSnapshotConsistencyGroupsOptions)
 			if err != nil {
-				return diag.FromErr(fmt.Errorf("[ERROR] Error fetching snapshots %s\n%s", err, response))
+				return diag.FromErr(flex.FmtErrorf("[ERROR] Error fetching snapshots %s\n%s", err, response))
 			}
 			start = flex.GetNext(snapshotConsistencyGroup.Next)
 			allrecs = append(allrecs, snapshotConsistencyGroup.SnapshotConsistencyGroups...)
@@ -318,31 +318,31 @@ func dataSourceIBMIsSnapshotConsistencyGroupRead(context context.Context, d *sch
 					backupPolicyPlan = append(backupPolicyPlan, modelMap)
 				}
 				if err = d.Set("backup_policy_plan", backupPolicyPlan); err != nil {
-					return diag.FromErr(fmt.Errorf("Error setting backup_policy_plan %s", err))
+					return diag.FromErr(flex.FmtErrorf("Error setting backup_policy_plan %s", err))
 				}
 
 				if err = d.Set("created_at", flex.DateTimeToString(snapshotConsistencyGroup.CreatedAt)); err != nil {
-					return diag.FromErr(fmt.Errorf("Error setting created_at: %s", err))
+					return diag.FromErr(flex.FmtErrorf("Error setting created_at: %s", err))
 				}
 
 				if err = d.Set("crn", snapshotConsistencyGroup.CRN); err != nil {
-					return diag.FromErr(fmt.Errorf("Error setting crn: %s", err))
+					return diag.FromErr(flex.FmtErrorf("Error setting crn: %s", err))
 				}
 
 				if err = d.Set("delete_snapshots_on_delete", snapshotConsistencyGroup.DeleteSnapshotsOnDelete); err != nil {
-					return diag.FromErr(fmt.Errorf("Error setting delete_snapshots_on_delete: %s", err))
+					return diag.FromErr(flex.FmtErrorf("Error setting delete_snapshots_on_delete: %s", err))
 				}
 
 				if err = d.Set("href", snapshotConsistencyGroup.Href); err != nil {
-					return diag.FromErr(fmt.Errorf("Error setting href: %s", err))
+					return diag.FromErr(flex.FmtErrorf("Error setting href: %s", err))
 				}
 
 				if err = d.Set("lifecycle_state", snapshotConsistencyGroup.LifecycleState); err != nil {
-					return diag.FromErr(fmt.Errorf("Error setting lifecycle_state: %s", err))
+					return diag.FromErr(flex.FmtErrorf("Error setting lifecycle_state: %s", err))
 				}
 
 				if err = d.Set("name", snapshotConsistencyGroup.Name); err != nil {
-					return diag.FromErr(fmt.Errorf("Error setting name: %s", err))
+					return diag.FromErr(flex.FmtErrorf("Error setting name: %s", err))
 				}
 
 				resourceGroup := []map[string]interface{}{}
@@ -354,11 +354,11 @@ func dataSourceIBMIsSnapshotConsistencyGroupRead(context context.Context, d *sch
 					resourceGroup = append(resourceGroup, modelMap)
 				}
 				if err = d.Set("resource_group", resourceGroup); err != nil {
-					return diag.FromErr(fmt.Errorf("Error setting resource_group %s", err))
+					return diag.FromErr(flex.FmtErrorf("Error setting resource_group %s", err))
 				}
 
 				if err = d.Set("resource_type", snapshotConsistencyGroup.ResourceType); err != nil {
-					return diag.FromErr(fmt.Errorf("Error setting resource_type: %s", err))
+					return diag.FromErr(flex.FmtErrorf("Error setting resource_type: %s", err))
 				}
 
 				snapshots := []map[string]interface{}{}
@@ -372,7 +372,7 @@ func dataSourceIBMIsSnapshotConsistencyGroupRead(context context.Context, d *sch
 					}
 				}
 				if err = d.Set("snapshots", snapshots); err != nil {
-					return diag.FromErr(fmt.Errorf("Error setting snapshots %s", err))
+					return diag.FromErr(flex.FmtErrorf("Error setting snapshots %s", err))
 				}
 				tags, err := flex.GetGlobalTagsUsingCRN(meta, *snapshotConsistencyGroup.CRN, "", isUserTagType)
 				if err != nil {
@@ -390,7 +390,7 @@ func dataSourceIBMIsSnapshotConsistencyGroupRead(context context.Context, d *sch
 				return nil
 			}
 		}
-		return diag.FromErr(fmt.Errorf("[ERROR] No snapshot consistency group found with name %s", name))
+		return diag.FromErr(flex.FmtErrorf("[ERROR] No snapshot consistency group found with name %s", name))
 	} else {
 		getSnapshotConsistencyGroupOptions := &vpcv1.GetSnapshotConsistencyGroupOptions{}
 
@@ -399,7 +399,7 @@ func dataSourceIBMIsSnapshotConsistencyGroupRead(context context.Context, d *sch
 		snapshotConsistencyGroup, response, err := vpcClient.GetSnapshotConsistencyGroupWithContext(context, getSnapshotConsistencyGroupOptions)
 		if err != nil {
 			log.Printf("[DEBUG] GetSnapshotConsistencyGroupWithContext failed %s\n%s", err, response)
-			return diag.FromErr(fmt.Errorf("GetSnapshotConsistencyGroupWithContext failed %s\n%s", err, response))
+			return diag.FromErr(flex.FmtErrorf("GetSnapshotConsistencyGroupWithContext failed %s\n%s", err, response))
 		}
 
 		d.SetId(fmt.Sprintf("%s", *getSnapshotConsistencyGroupOptions.ID))
@@ -413,31 +413,31 @@ func dataSourceIBMIsSnapshotConsistencyGroupRead(context context.Context, d *sch
 			backupPolicyPlan = append(backupPolicyPlan, modelMap)
 		}
 		if err = d.Set("backup_policy_plan", backupPolicyPlan); err != nil {
-			return diag.FromErr(fmt.Errorf("Error setting backup_policy_plan %s", err))
+			return diag.FromErr(flex.FmtErrorf("Error setting backup_policy_plan %s", err))
 		}
 
 		if err = d.Set("created_at", flex.DateTimeToString(snapshotConsistencyGroup.CreatedAt)); err != nil {
-			return diag.FromErr(fmt.Errorf("Error setting created_at: %s", err))
+			return diag.FromErr(flex.FmtErrorf("Error setting created_at: %s", err))
 		}
 
 		if err = d.Set("crn", snapshotConsistencyGroup.CRN); err != nil {
-			return diag.FromErr(fmt.Errorf("Error setting crn: %s", err))
+			return diag.FromErr(flex.FmtErrorf("Error setting crn: %s", err))
 		}
 
 		if err = d.Set("delete_snapshots_on_delete", snapshotConsistencyGroup.DeleteSnapshotsOnDelete); err != nil {
-			return diag.FromErr(fmt.Errorf("Error setting delete_snapshots_on_delete: %s", err))
+			return diag.FromErr(flex.FmtErrorf("Error setting delete_snapshots_on_delete: %s", err))
 		}
 
 		if err = d.Set("href", snapshotConsistencyGroup.Href); err != nil {
-			return diag.FromErr(fmt.Errorf("Error setting href: %s", err))
+			return diag.FromErr(flex.FmtErrorf("Error setting href: %s", err))
 		}
 
 		if err = d.Set("lifecycle_state", snapshotConsistencyGroup.LifecycleState); err != nil {
-			return diag.FromErr(fmt.Errorf("Error setting lifecycle_state: %s", err))
+			return diag.FromErr(flex.FmtErrorf("Error setting lifecycle_state: %s", err))
 		}
 
 		if err = d.Set("name", snapshotConsistencyGroup.Name); err != nil {
-			return diag.FromErr(fmt.Errorf("Error setting name: %s", err))
+			return diag.FromErr(flex.FmtErrorf("Error setting name: %s", err))
 		}
 
 		resourceGroup := []map[string]interface{}{}
@@ -449,11 +449,11 @@ func dataSourceIBMIsSnapshotConsistencyGroupRead(context context.Context, d *sch
 			resourceGroup = append(resourceGroup, modelMap)
 		}
 		if err = d.Set("resource_group", resourceGroup); err != nil {
-			return diag.FromErr(fmt.Errorf("Error setting resource_group %s", err))
+			return diag.FromErr(flex.FmtErrorf("Error setting resource_group %s", err))
 		}
 
 		if err = d.Set("resource_type", snapshotConsistencyGroup.ResourceType); err != nil {
-			return diag.FromErr(fmt.Errorf("Error setting resource_type: %s", err))
+			return diag.FromErr(flex.FmtErrorf("Error setting resource_type: %s", err))
 		}
 
 		snapshots := []map[string]interface{}{}
@@ -467,7 +467,7 @@ func dataSourceIBMIsSnapshotConsistencyGroupRead(context context.Context, d *sch
 			}
 		}
 		if err = d.Set("snapshots", snapshots); err != nil {
-			return diag.FromErr(fmt.Errorf("Error setting snapshots %s", err))
+			return diag.FromErr(flex.FmtErrorf("Error setting snapshots %s", err))
 		}
 		tags, err := flex.GetGlobalTagsUsingCRN(meta, *snapshotConsistencyGroup.CRN, "", isUserTagType)
 		if err != nil {

--- a/ibm/service/vpc/data_source_ibm_is_snapshot_consistency_groups.go
+++ b/ibm/service/vpc/data_source_ibm_is_snapshot_consistency_groups.go
@@ -5,7 +5,6 @@ package vpc
 
 import (
 	"context"
-	"fmt"
 	"log"
 	"time"
 
@@ -277,7 +276,7 @@ func dataSourceIBMIsSnapshotConsistencyGroupsRead(context context.Context, d *sc
 
 		snapshotConsistencyGroup, response, err := vpcClient.ListSnapshotConsistencyGroups(listSnapshotConsistencyGroupsOptions)
 		if err != nil {
-			return diag.FromErr(fmt.Errorf("[ERROR] Error fetching snapshots %s\n%s", err, response))
+			return diag.FromErr(flex.FmtErrorf("[ERROR] Error fetching snapshots %s\n%s", err, response))
 		}
 		start = flex.GetNext(snapshotConsistencyGroup.Next)
 		allrecs = append(allrecs, snapshotConsistencyGroup.SnapshotConsistencyGroups...)
@@ -358,7 +357,7 @@ func dataSourceIBMIsSnapshotConsistencyGroupsRead(context context.Context, d *sc
 
 	d.SetId(dataSourceIBMIsSnapshotConsistencyGroupsID(d))
 	if err = d.Set("snapshot_consistency_groups", snapshotConsistencyGroupsInfo); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting snapshot_consistency_groups %s", err))
+		return diag.FromErr(flex.FmtErrorf("Error setting snapshot_consistency_groups %s", err))
 	}
 	return nil
 }

--- a/ibm/service/vpc/data_source_ibm_is_snapshots.go
+++ b/ibm/service/vpc/data_source_ibm_is_snapshots.go
@@ -4,7 +4,6 @@
 package vpc
 
 import (
-	"fmt"
 	"log"
 	"time"
 
@@ -563,7 +562,7 @@ func getSnapshots(d *schema.ResourceData, meta interface{}) error {
 		}
 		snapshots, response, err := sess.ListSnapshots(listSnapshotOptions)
 		if err != nil {
-			return fmt.Errorf("[ERROR] Error fetching snapshots %s\n%s", err, response)
+			return flex.FmtErrorf("[ERROR] Error fetching snapshots %s\n%s", err, response)
 		}
 		start = flex.GetNext(snapshots.Next)
 		allrecs = append(allrecs, snapshots.Snapshots...)
@@ -619,7 +618,7 @@ func getSnapshots(d *schema.ResourceData, meta interface{}) error {
 			for _, copiesItem := range snapshot.Copies {
 				copiesMap, err := dataSourceIBMIsSnapshotsSnapshotCopiesItemToMap(&copiesItem)
 				if err != nil {
-					return fmt.Errorf("[ERROR] Error fetching snapshot copies: %s", err)
+					return flex.FmtErrorf("[ERROR] Error fetching snapshot copies: %s", err)
 				}
 				snapshotCopies = append(snapshotCopies, copiesMap)
 			}

--- a/ibm/service/vpc/data_source_ibm_is_source_share.go
+++ b/ibm/service/vpc/data_source_ibm_is_source_share.go
@@ -5,10 +5,10 @@ package vpc
 
 import (
 	"context"
-	"fmt"
 	"log"
 
 	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/conns"
+	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/flex"
 	"github.com/IBM/vpc-go-sdk/vpcv1"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -70,25 +70,25 @@ func dataSourceIbmIsSourceShareRead(context context.Context, d *schema.ResourceD
 			return nil
 		}
 		log.Printf("[DEBUG] GetShareWithContext failed %s\n", err)
-		return diag.FromErr(fmt.Errorf("[DEBUG] GetShareWithContext failed %s\n", err))
+		return diag.FromErr(flex.FmtErrorf("[DEBUG] GetShareWithContext failed %s\n", err))
 	}
 
 	d.SetId(*share.ID)
 
 	if err = d.Set("crn", share.CRN); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting crn: %s", err))
+		return diag.FromErr(flex.FmtErrorf("Error setting crn: %s", err))
 	}
 
 	if err = d.Set("href", share.Href); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting href: %s", err))
+		return diag.FromErr(flex.FmtErrorf("Error setting href: %s", err))
 	}
 
 	if err = d.Set("name", share.Name); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting name: %s", err))
+		return diag.FromErr(flex.FmtErrorf("Error setting name: %s", err))
 	}
 
 	if err = d.Set("resource_type", share.ResourceType); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting resource_type: %s", err))
+		return diag.FromErr(flex.FmtErrorf("Error setting resource_type: %s", err))
 	}
 
 	return nil

--- a/ibm/service/vpc/data_source_ibm_is_ssh_key.go
+++ b/ibm/service/vpc/data_source_ibm_is_ssh_key.go
@@ -4,7 +4,6 @@
 package vpc
 
 import (
-	"fmt"
 	"log"
 
 	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/flex"
@@ -128,7 +127,7 @@ func keyGetByName(d *schema.ResourceData, meta interface{}, name string) error {
 
 		keys, response, err := sess.ListKeys(listKeysOptions)
 		if err != nil {
-			return fmt.Errorf("[ERROR] Error fetching Keys %s\n%s", err, response)
+			return flex.FmtErrorf("[ERROR] Error fetching Keys %s\n%s", err, response)
 		}
 		start = flex.GetNext(keys.Next)
 		allrecs = append(allrecs, keys.Keys...)
@@ -173,5 +172,5 @@ func keyGetByName(d *schema.ResourceData, meta interface{}, name string) error {
 			return nil
 		}
 	}
-	return fmt.Errorf("[ERROR] No SSH Key found with name %s", name)
+	return flex.FmtErrorf("[ERROR] No SSH Key found with name %s", name)
 }

--- a/ibm/service/vpc/data_source_ibm_is_ssh_keys.go
+++ b/ibm/service/vpc/data_source_ibm_is_ssh_keys.go
@@ -5,7 +5,6 @@ package vpc
 
 import (
 	"context"
-	"fmt"
 	"log"
 	"time"
 
@@ -148,7 +147,7 @@ func dataSourceIBMIsSshKeysRead(context context.Context, d *schema.ResourceData,
 		keyCollection, response, err := vpcClient.ListKeysWithContext(context, listKeysOptions)
 		if err != nil || keyCollection == nil {
 			log.Printf("[DEBUG] ListKeysWithContext failed %s\n%s", err, response)
-			return diag.FromErr(fmt.Errorf("ListKeysWithContext failed %s\n%s", err, response))
+			return diag.FromErr(flex.FmtErrorf("ListKeysWithContext failed %s\n%s", err, response))
 		}
 
 		start = flex.GetNext(keyCollection.Next)
@@ -163,7 +162,7 @@ func dataSourceIBMIsSshKeysRead(context context.Context, d *schema.ResourceData,
 	d.SetId(dataSourceIBMIsSshKeysID(d))
 	err = d.Set(isKeys, dataSourceKeyCollectionFlattenKeys(allrecs, d, meta))
 	if err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting keys %s", err))
+		return diag.FromErr(flex.FmtErrorf("Error setting keys %s", err))
 	}
 
 	return nil

--- a/ibm/service/vpc/data_source_ibm_is_subnet.go
+++ b/ibm/service/vpc/data_source_ibm_is_subnet.go
@@ -4,7 +4,6 @@
 package vpc
 
 import (
-	"fmt"
 	"log"
 
 	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/flex"
@@ -224,7 +223,7 @@ func subnetGetByNameOrID(d *schema.ResourceData, meta interface{}) error {
 		}
 		subnetinfo, response, err := sess.GetSubnet(getSubnetOptions)
 		if err != nil {
-			return fmt.Errorf("[ERROR] Error Getting Subnet (%s): %s\n%s", id, err, response)
+			return flex.FmtErrorf("[ERROR] Error Getting Subnet (%s): %s\n%s", id, err, response)
 		}
 		subnet = subnetinfo
 	} else if v, ok := d.GetOk(isSubnetName); ok {
@@ -242,7 +241,7 @@ func subnetGetByNameOrID(d *schema.ResourceData, meta interface{}) error {
 			}
 			subnetsCollection, response, err := sess.ListSubnets(getSubnetsListOptions)
 			if err != nil {
-				return fmt.Errorf("[ERROR] Error Fetching subnets List %s\n%s", err, response)
+				return flex.FmtErrorf("[ERROR] Error Fetching subnets List %s\n%s", err, response)
 			}
 			start = flex.GetNext(subnetsCollection.Next)
 			allrecs = append(allrecs, subnetsCollection.Subnets...)
@@ -258,7 +257,7 @@ func subnetGetByNameOrID(d *schema.ResourceData, meta interface{}) error {
 			}
 		}
 		if subnet == nil {
-			return fmt.Errorf("[ERROR] No subnet found with name (%s)", name)
+			return flex.FmtErrorf("[ERROR] No subnet found with name (%s)", name)
 		}
 	}
 
@@ -267,7 +266,7 @@ func subnetGetByNameOrID(d *schema.ResourceData, meta interface{}) error {
 	if subnet.RoutingTable != nil {
 		err = d.Set("routing_table", dataSourceSubnetFlattenroutingTable(*subnet.RoutingTable))
 		if err != nil {
-			return fmt.Errorf("Error setting routing_table %s", err)
+			return flex.FmtErrorf("Error setting routing_table %s", err)
 		}
 	}
 	d.Set(isSubnetName, *subnet.Name)

--- a/ibm/service/vpc/data_source_ibm_is_subnet_reserved_ip.go
+++ b/ibm/service/vpc/data_source_ibm_is_subnet_reserved_ip.go
@@ -4,8 +4,7 @@
 package vpc
 
 import (
-	"fmt"
-
+	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/flex"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
@@ -169,7 +168,7 @@ func dataSdataSourceIBMISReservedIPRead(d *schema.ResourceData, meta interface{}
 	reserveIP, response, err := sess.GetSubnetReservedIP(options)
 
 	if err != nil || response == nil || reserveIP == nil {
-		return fmt.Errorf("[ERROR] Error fetching the reserved IP %s\n%s", err, response)
+		return flex.FmtErrorf("[ERROR] Error fetching the reserved IP %s\n%s", err, response)
 	}
 
 	d.SetId(*reserveIP.ID)

--- a/ibm/service/vpc/data_source_ibm_is_subnet_reserved_ips.go
+++ b/ibm/service/vpc/data_source_ibm_is_subnet_reserved_ips.go
@@ -4,7 +4,6 @@
 package vpc
 
 import (
-	"fmt"
 	"time"
 
 	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/flex"
@@ -183,7 +182,7 @@ func dataSdataSourceIBMISReservedIPsRead(d *schema.ResourceData, meta interface{
 
 		result, response, err := sess.ListSubnetReservedIps(options)
 		if err != nil || response == nil || result == nil {
-			return fmt.Errorf("[ERROR] Error fetching reserved ips %s\n%s", err, response)
+			return flex.FmtErrorf("[ERROR] Error fetching reserved ips %s\n%s", err, response)
 		}
 		start = flex.GetNext(result.Next)
 		allrecs = append(allrecs, result.ReservedIps...)
@@ -273,7 +272,7 @@ func dataSourceIBMIsReservedIPReservedIPTargetToMap(model vpcv1.ReservedIPTarget
 		}
 		return modelMap, nil
 	} else {
-		return nil, fmt.Errorf("Unrecognized vpcv1.ReservedIPTargetIntf subtype encountered")
+		return nil, flex.FmtErrorf("Unrecognized vpcv1.ReservedIPTargetIntf subtype encountered")
 	}
 }
 

--- a/ibm/service/vpc/data_source_ibm_is_subnets.go
+++ b/ibm/service/vpc/data_source_ibm_is_subnets.go
@@ -4,7 +4,6 @@
 package vpc
 
 import (
-	"fmt"
 	"strconv"
 	"time"
 
@@ -249,7 +248,7 @@ func subnetList(d *schema.ResourceData, meta interface{}) error {
 		}
 		subnets, response, err := sess.ListSubnets(options)
 		if err != nil {
-			return fmt.Errorf("[ERROR] Error Fetching subnets %s\n%s", err, response)
+			return flex.FmtErrorf("[ERROR] Error Fetching subnets %s\n%s", err, response)
 		}
 		start = flex.GetNext(subnets.Next)
 		allrecs = append(allrecs, subnets.Subnets...)

--- a/ibm/service/vpc/data_source_ibm_is_virtual_endpoint_gateway.go
+++ b/ibm/service/vpc/data_source_ibm_is_virtual_endpoint_gateway.go
@@ -4,7 +4,6 @@
 package vpc
 
 import (
-	"fmt"
 	"log"
 
 	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/flex"
@@ -158,12 +157,12 @@ func dataSourceIBMISEndpointGatewayRead(
 
 	results, response, err := sess.ListEndpointGateways(options)
 	if err != nil {
-		return fmt.Errorf("[ERROR] Error fetching endpoint gateways %s\n%s", err, response)
+		return flex.FmtErrorf("[ERROR] Error fetching endpoint gateways %s\n%s", err, response)
 	}
 	allrecs := results.EndpointGateways
 
 	if len(allrecs) == 0 {
-		return fmt.Errorf("[ERROR] No Virtual Endpoints Gateway found with given name %s", name)
+		return flex.FmtErrorf("[ERROR] No Virtual Endpoints Gateway found with given name %s", name)
 	}
 	result := allrecs[0]
 	d.SetId(*result.ID)

--- a/ibm/service/vpc/data_source_ibm_is_virtual_endpoint_gateway_ips.go
+++ b/ibm/service/vpc/data_source_ibm_is_virtual_endpoint_gateway_ips.go
@@ -4,7 +4,6 @@
 package vpc
 
 import (
-	"fmt"
 	"time"
 
 	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/flex"
@@ -103,7 +102,7 @@ func dataSourceIBMISEndpointGatewayIPsRead(d *schema.ResourceData, meta interfac
 		}
 		result, response, err := sess.ListEndpointGatewayIps(options)
 		if err != nil {
-			return fmt.Errorf("[ERROR] Error fetching endpoint gateway ips %s\n%s", err, response)
+			return flex.FmtErrorf("[ERROR] Error fetching endpoint gateway ips %s\n%s", err, response)
 		}
 		start = flex.GetNext(result.Next)
 		allrecs = append(allrecs, result.Ips...)

--- a/ibm/service/vpc/data_source_ibm_is_virtual_endpoint_gateways.go
+++ b/ibm/service/vpc/data_source_ibm_is_virtual_endpoint_gateways.go
@@ -4,7 +4,6 @@
 package vpc
 
 import (
-	"fmt"
 	"log"
 	"time"
 
@@ -196,7 +195,7 @@ func dataSourceIBMISEndpointGatewaysRead(d *schema.ResourceData, meta interface{
 		}
 		result, response, err := sess.ListEndpointGateways(options)
 		if err != nil {
-			return fmt.Errorf("[ERROR] Error fetching endpoint gateways %s\n%s", err, response)
+			return flex.FmtErrorf("[ERROR] Error fetching endpoint gateways %s\n%s", err, response)
 		}
 		start = flex.GetNext(result.Next)
 		allrecs = append(allrecs, result.EndpointGateways...)

--- a/ibm/service/vpc/data_source_ibm_is_virtual_network_interface.go
+++ b/ibm/service/vpc/data_source_ibm_is_virtual_network_interface.go
@@ -431,33 +431,33 @@ func dataSourceIBMIsVirtualNetworkInterfaceRead(context context.Context, d *sche
 	virtualNetworkInterface, response, err := vpcClient.GetVirtualNetworkInterfaceWithContext(context, getVirtualNetworkInterfaceOptions)
 	if err != nil {
 		log.Printf("[DEBUG] GetVirtualNetworkInterfaceWithContext failed %s\n%s", err, response)
-		return diag.FromErr(fmt.Errorf("GetVirtualNetworkInterfaceWithContext failed %s\n%s", err, response))
+		return diag.FromErr(flex.FmtErrorf("GetVirtualNetworkInterfaceWithContext failed %s\n%s", err, response))
 	}
 
 	d.SetId(*virtualNetworkInterface.ID)
 
 	if err = d.Set("auto_delete", virtualNetworkInterface.AutoDelete); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting auto_delete: %s", err))
+		return diag.FromErr(flex.FmtErrorf("Error setting auto_delete: %s", err))
 	}
 
 	if err = d.Set("created_at", flex.DateTimeToString(virtualNetworkInterface.CreatedAt)); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting created_at: %s", err))
+		return diag.FromErr(flex.FmtErrorf("Error setting created_at: %s", err))
 	}
 
 	if err = d.Set("crn", virtualNetworkInterface.CRN); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting crn: %s", err))
+		return diag.FromErr(flex.FmtErrorf("Error setting crn: %s", err))
 	}
 
 	if err = d.Set("href", virtualNetworkInterface.Href); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting href: %s", err))
+		return diag.FromErr(flex.FmtErrorf("Error setting href: %s", err))
 	}
 
 	if err = d.Set("lifecycle_state", virtualNetworkInterface.LifecycleState); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting lifecycle_state: %s", err))
+		return diag.FromErr(flex.FmtErrorf("Error setting lifecycle_state: %s", err))
 	}
 
 	if err = d.Set("name", virtualNetworkInterface.Name); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting name: %s", err))
+		return diag.FromErr(flex.FmtErrorf("Error setting name: %s", err))
 	}
 
 	primaryIP := []map[string]interface{}{}
@@ -469,7 +469,7 @@ func dataSourceIBMIsVirtualNetworkInterfaceRead(context context.Context, d *sche
 		primaryIP = append(primaryIP, modelMap)
 	}
 	if err = d.Set("primary_ip", primaryIP); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting primary_ip %s", err))
+		return diag.FromErr(flex.FmtErrorf("Error setting primary_ip %s", err))
 	}
 
 	resourceGroup := []map[string]interface{}{}
@@ -481,11 +481,11 @@ func dataSourceIBMIsVirtualNetworkInterfaceRead(context context.Context, d *sche
 		resourceGroup = append(resourceGroup, modelMap)
 	}
 	if err = d.Set("resource_group", resourceGroup); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting resource_group %s", err))
+		return diag.FromErr(flex.FmtErrorf("Error setting resource_group %s", err))
 	}
 
 	if err = d.Set("resource_type", virtualNetworkInterface.ResourceType); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting resource_type: %s", err))
+		return diag.FromErr(flex.FmtErrorf("Error setting resource_type: %s", err))
 	}
 
 	securityGroups := []map[string]interface{}{}
@@ -499,7 +499,7 @@ func dataSourceIBMIsVirtualNetworkInterfaceRead(context context.Context, d *sche
 		}
 	}
 	if err = d.Set("security_groups", securityGroups); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting security_groups %s", err))
+		return diag.FromErr(flex.FmtErrorf("Error setting security_groups %s", err))
 	}
 
 	subnet := []map[string]interface{}{}
@@ -511,7 +511,7 @@ func dataSourceIBMIsVirtualNetworkInterfaceRead(context context.Context, d *sche
 		subnet = append(subnet, modelMap)
 	}
 	if err = d.Set("subnet", subnet); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting subnet %s", err))
+		return diag.FromErr(flex.FmtErrorf("Error setting subnet %s", err))
 	}
 
 	target := []map[string]interface{}{}
@@ -523,7 +523,7 @@ func dataSourceIBMIsVirtualNetworkInterfaceRead(context context.Context, d *sche
 		target = append(target, modelMap)
 	}
 	if err = d.Set("target", target); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting target %s", err))
+		return diag.FromErr(flex.FmtErrorf("Error setting target %s", err))
 	}
 
 	vpc := []map[string]interface{}{}
@@ -535,7 +535,7 @@ func dataSourceIBMIsVirtualNetworkInterfaceRead(context context.Context, d *sche
 		vpc = append(vpc, modelMap)
 	}
 	if err = d.Set("vpc", vpc); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting vpc %s", err))
+		return diag.FromErr(flex.FmtErrorf("Error setting vpc %s", err))
 	}
 
 	zone := []map[string]interface{}{}
@@ -547,7 +547,7 @@ func dataSourceIBMIsVirtualNetworkInterfaceRead(context context.Context, d *sche
 		zone = append(zone, modelMap)
 	}
 	if err = d.Set("zone", zone); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting zone %s", err))
+		return diag.FromErr(flex.FmtErrorf("Error setting zone %s", err))
 	}
 
 	// vni p2 changes
@@ -739,7 +739,7 @@ func dataSourceIBMIsVirtualNetworkInterfaceVirtualNetworkInterfaceTargetToMap(mo
 		}
 		return modelMap, nil
 	} else {
-		return nil, fmt.Errorf("Unrecognized vpcv1.VirtualNetworkInterfaceTargetIntf subtype encountered")
+		return nil, flex.FmtErrorf("Unrecognized vpcv1.VirtualNetworkInterfaceTargetIntf subtype encountered")
 	}
 }
 

--- a/ibm/service/vpc/data_source_ibm_is_virtual_network_interfaces.go
+++ b/ibm/service/vpc/data_source_ibm_is_virtual_network_interfaces.go
@@ -5,7 +5,6 @@ package vpc
 
 import (
 	"context"
-	"fmt"
 	"log"
 	"time"
 
@@ -454,7 +453,7 @@ func dataSourceIBMIsVirtualNetworkInterfacesRead(context context.Context, d *sch
 	allItems, err := pager.GetAll()
 	if err != nil {
 		log.Printf("[DEBUG] VirtualNetworkInterfacesPager.GetAll() failed %s", err)
-		return diag.FromErr(fmt.Errorf("VirtualNetworkInterfacesPager.GetAll() failed %s", err))
+		return diag.FromErr(flex.FmtErrorf("VirtualNetworkInterfacesPager.GetAll() failed %s", err))
 	}
 
 	d.SetId(dataSourceIBMIsVirtualNetworkInterfacesID(d))
@@ -484,7 +483,7 @@ func dataSourceIBMIsVirtualNetworkInterfacesRead(context context.Context, d *sch
 	}
 
 	if err = d.Set("virtual_network_interfaces", mapSlice); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting virtual_network_interfaces %s", err))
+		return diag.FromErr(flex.FmtErrorf("Error setting virtual_network_interfaces %s", err))
 	}
 
 	return nil

--- a/ibm/service/vpc/data_source_ibm_is_volume.go
+++ b/ibm/service/vpc/data_source_ibm_is_volume.go
@@ -4,7 +4,6 @@
 package vpc
 
 import (
-	"fmt"
 	"log"
 
 	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/flex"
@@ -307,12 +306,12 @@ func volumeGet(d *schema.ResourceData, meta interface{}, name string) error {
 	listVolumesOptions.Name = &name
 	vols, response, err := sess.ListVolumes(listVolumesOptions)
 	if err != nil {
-		return fmt.Errorf("[ERROR] Error Fetching volumes %s\n%s", err, response)
+		return flex.FmtErrorf("[ERROR] Error Fetching volumes %s\n%s", err, response)
 	}
 	allrecs := vols.Volumes
 
 	if len(allrecs) == 0 {
-		return fmt.Errorf("[ERROR] No Volume found with name %s", name)
+		return flex.FmtErrorf("[ERROR] No Volume found with name %s", name)
 	}
 	vol := allrecs[0]
 	d.SetId(*vol.ID)

--- a/ibm/service/vpc/data_source_ibm_is_volume_profiles.go
+++ b/ibm/service/vpc/data_source_ibm_is_volume_profiles.go
@@ -4,7 +4,6 @@
 package vpc
 
 import (
-	"fmt"
 	"time"
 
 	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/flex"
@@ -67,7 +66,7 @@ func volumeProfilesList(d *schema.ResourceData, meta interface{}) error {
 		}
 		availableProfiles, response, err := sess.ListVolumeProfiles(listVolumeProfilesOptions)
 		if err != nil {
-			return fmt.Errorf("[ERROR] Error Fetching Volume Profiles %s\n%s", err, response)
+			return flex.FmtErrorf("[ERROR] Error Fetching Volume Profiles %s\n%s", err, response)
 		}
 		start = flex.GetNext(availableProfiles.Next)
 		allrecs = append(allrecs, availableProfiles.Profiles...)
@@ -79,7 +78,7 @@ func volumeProfilesList(d *schema.ResourceData, meta interface{}) error {
 	// listVolumeProfilesOptions := &vpcv1.ListVolumeProfilesOptions{}
 	// availableProfiles, response, err := sess.ListVolumeProfiles(listVolumeProfilesOptions)
 	// if err != nil {
-	// 	return fmt.Errorf("[ERROR] Error Fetching Volume Profiles %s\n%s", err, response)
+	// 	return flex.FmtErrorf("[ERROR] Error Fetching Volume Profiles %s\n%s", err, response)
 	// }
 	profilesInfo := make([]map[string]interface{}, 0)
 	for _, profile := range allrecs {

--- a/ibm/service/vpc/data_source_ibm_is_volumes.go
+++ b/ibm/service/vpc/data_source_ibm_is_volumes.go
@@ -5,7 +5,6 @@ package vpc
 
 import (
 	"context"
-	"fmt"
 	"log"
 	"time"
 
@@ -644,7 +643,7 @@ func dataSourceIBMIsVolumesRead(context context.Context, d *schema.ResourceData,
 		volumeCollection, response, err := vpcClient.ListVolumesWithContext(context, listVolumesOptions)
 		if err != nil {
 			log.Printf("[DEBUG] ListVolumesWithContext failed %s\n%s", err, response)
-			return diag.FromErr(fmt.Errorf("ListVolumesWithContext failed %s\n%s", err, response))
+			return diag.FromErr(flex.FmtErrorf("ListVolumesWithContext failed %s\n%s", err, response))
 		}
 
 		start = flex.GetNext(volumeCollection.Next)
@@ -660,7 +659,7 @@ func dataSourceIBMIsVolumesRead(context context.Context, d *schema.ResourceData,
 
 	err = d.Set(isVolumes, dataSourceVolumeCollectionFlattenVolumes(allrecs, meta))
 	if err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting volumes %s", err))
+		return diag.FromErr(flex.FmtErrorf("Error setting volumes %s", err))
 	}
 
 	return nil

--- a/ibm/service/vpc/data_source_ibm_is_vpc.go
+++ b/ibm/service/vpc/data_source_ibm_is_vpc.go
@@ -4,7 +4,6 @@
 package vpc
 
 import (
-	"fmt"
 	"log"
 	"reflect"
 
@@ -518,7 +517,7 @@ func vpcGetByNameOrId(d *schema.ResourceData, meta interface{}, name, id string)
 		}
 		vpcGet, response, err := sess.GetVPC(getVpcsOptions)
 		if err != nil {
-			return fmt.Errorf("[ERROR] Error Fetching vpc %s\n%s", err, response)
+			return flex.FmtErrorf("[ERROR] Error Fetching vpc %s\n%s", err, response)
 		}
 		flag = true
 		setVpcDetails(d, vpcGet, meta, sess)
@@ -532,7 +531,7 @@ func vpcGetByNameOrId(d *schema.ResourceData, meta interface{}, name, id string)
 			}
 			vpcs, response, err := sess.ListVpcs(listVpcsOptions)
 			if err != nil {
-				return fmt.Errorf("[ERROR] Error Fetching vpcs %s\n%s", err, response)
+				return flex.FmtErrorf("[ERROR] Error Fetching vpcs %s\n%s", err, response)
 			}
 			start = flex.GetNext(vpcs.Next)
 			allrecs = append(allrecs, vpcs.Vpcs...)
@@ -548,7 +547,7 @@ func vpcGetByNameOrId(d *schema.ResourceData, meta interface{}, name, id string)
 		}
 	}
 	if !flag {
-		return fmt.Errorf("[ERROR] No VPC found with name %s", name)
+		return flex.FmtErrorf("[ERROR] No VPC found with name %s", name)
 	}
 	return nil
 }
@@ -606,11 +605,11 @@ func setVpcDetails(d *schema.ResourceData, vpc *vpcv1.VPC, meta interface{}, ses
 			}
 		}
 		if err = d.Set("health_reasons", healthReasons); err != nil {
-			return fmt.Errorf("[ERROR] Error setting health_reasons %s", err)
+			return flex.FmtErrorf("[ERROR] Error setting health_reasons %s", err)
 		}
 
 		if err = d.Set("health_state", vpc.HealthState); err != nil {
-			return fmt.Errorf("[ERROR] Error setting health_state: %s", err)
+			return flex.FmtErrorf("[ERROR] Error setting health_state: %s", err)
 		}
 
 		controller, err := flex.GetBaseController(meta)
@@ -650,7 +649,7 @@ func setVpcDetails(d *schema.ResourceData, vpc *vpcv1.VPC, meta interface{}, ses
 			}
 			s, response, err := sess.ListSubnets(options)
 			if err != nil {
-				return fmt.Errorf("[ERROR] Error fetching subnets %s\n%s", err, response)
+				return flex.FmtErrorf("[ERROR] Error fetching subnets %s\n%s", err, response)
 			}
 			startSub = flex.GetNext(s.Next)
 			allrecsSub = append(allrecsSub, s.Subnets...)
@@ -691,7 +690,7 @@ func setVpcDetails(d *schema.ResourceData, vpc *vpcv1.VPC, meta interface{}, ses
 			}
 			sgs, response, err := sess.ListSecurityGroups(listSgOptions)
 			if err != nil || sgs == nil {
-				return fmt.Errorf("[ERROR] Error fetching Security Groups %s\n%s", err, response)
+				return flex.FmtErrorf("[ERROR] Error fetching Security Groups %s\n%s", err, response)
 			}
 			if *sgs.TotalCount == int64(0) {
 				break
@@ -815,7 +814,7 @@ func setVpcDetails(d *schema.ResourceData, vpc *vpcv1.VPC, meta interface{}, ses
 				return err
 			}
 			if err = d.Set(isVPCDns, []map[string]interface{}{dnsMap}); err != nil {
-				return fmt.Errorf("[ERROR] Error setting dns: %s", err)
+				return flex.FmtErrorf("[ERROR] Error setting dns: %s", err)
 			}
 		}
 		return nil
@@ -879,7 +878,7 @@ func dataSourceIBMIsVPCVpcdnsResolverToMap(model vpcv1.VpcdnsResolverIntf) (map[
 		}
 		return modelMap, nil
 	} else {
-		return nil, fmt.Errorf("Unrecognized vpcv1.VpcdnsResolverIntf subtype encountered")
+		return nil, flex.FmtErrorf("Unrecognized vpcv1.VpcdnsResolverIntf subtype encountered")
 	}
 }
 

--- a/ibm/service/vpc/data_source_ibm_is_vpc_address_prefix.go
+++ b/ibm/service/vpc/data_source_ibm_is_vpc_address_prefix.go
@@ -5,7 +5,6 @@ package vpc
 
 import (
 	"context"
-	"fmt"
 	"log"
 
 	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/conns"
@@ -119,7 +118,7 @@ func dataSourceIBMIsVPCAddressPrefixRead(context context.Context, d *schema.Reso
 			}
 			vpcs, response, err := vpcClient.ListVpcs(listVpcsOptions)
 			if err != nil {
-				return diag.FromErr(fmt.Errorf("Error Fetching vpcs %s\n%s", err, response))
+				return diag.FromErr(flex.FmtErrorf("Error Fetching vpcs %s\n%s", err, response))
 			}
 			start = flex.GetNext(vpcs.Next)
 			allrecs = append(allrecs, vpcs.Vpcs...)
@@ -137,7 +136,7 @@ func dataSourceIBMIsVPCAddressPrefixRead(context context.Context, d *schema.Reso
 		}
 		if !vpc_found {
 			log.Printf("[DEBUG] VPC with given name not found %s\n", vpc_name)
-			return diag.FromErr(fmt.Errorf("VPC with given name not found %s\n", vpc_name))
+			return diag.FromErr(flex.FmtErrorf("VPC with given name not found %s\n", vpc_name))
 		}
 	}
 	if address_prefix_id != "" {
@@ -149,7 +148,7 @@ func dataSourceIBMIsVPCAddressPrefixRead(context context.Context, d *schema.Reso
 		addressPrefix1, response, err := vpcClient.GetVPCAddressPrefixWithContext(context, getVPCAddressPrefixOptions)
 		if err != nil {
 			log.Printf("[DEBUG] GetVPCAddressPrefixWithContext failed %s\n%s", err, response)
-			return diag.FromErr(fmt.Errorf("GetVPCAddressPrefixWithContext failed %s\n%s", err, response))
+			return diag.FromErr(flex.FmtErrorf("GetVPCAddressPrefixWithContext failed %s\n%s", err, response))
 		}
 		addressPrefix = addressPrefix1
 
@@ -166,7 +165,7 @@ func dataSourceIBMIsVPCAddressPrefixRead(context context.Context, d *schema.Reso
 			addressPrefixCollection, response, err := vpcClient.ListVPCAddressPrefixesWithContext(context, listVpcAddressPrefixesOptions)
 			if err != nil {
 				log.Printf("[DEBUG] ListVpcAddressPrefixesWithContext failed %s\n%s", err, response)
-				return diag.FromErr(fmt.Errorf("ListVpcAddressPrefixesWithContext failed %s\n%s", err, response))
+				return diag.FromErr(flex.FmtErrorf("ListVpcAddressPrefixesWithContext failed %s\n%s", err, response))
 			}
 			start = flex.GetNext(addressPrefixCollection.Next)
 			allrecs = append(allrecs, addressPrefixCollection.AddressPrefixes...)
@@ -184,32 +183,32 @@ func dataSourceIBMIsVPCAddressPrefixRead(context context.Context, d *schema.Reso
 		}
 		if !address_prefix_found {
 			log.Printf("[DEBUG] Address Prefix with given name not found %s\n", address_prefix_name)
-			return diag.FromErr(fmt.Errorf("Address Prefix with given name not found %s\n", address_prefix_name))
+			return diag.FromErr(flex.FmtErrorf("Address Prefix with given name not found %s\n", address_prefix_name))
 		}
 	}
 	d.SetId(*addressPrefix.ID)
 	if err = d.Set("cidr", addressPrefix.CIDR); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting cidr: %s", err))
+		return diag.FromErr(flex.FmtErrorf("Error setting cidr: %s", err))
 	}
 
 	if err = d.Set("created_at", flex.DateTimeToString(addressPrefix.CreatedAt)); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting created_at: %s", err))
+		return diag.FromErr(flex.FmtErrorf("Error setting created_at: %s", err))
 	}
 
 	if err = d.Set("has_subnets", addressPrefix.HasSubnets); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting has_subnets: %s", err))
+		return diag.FromErr(flex.FmtErrorf("Error setting has_subnets: %s", err))
 	}
 
 	if err = d.Set("href", addressPrefix.Href); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting href: %s", err))
+		return diag.FromErr(flex.FmtErrorf("Error setting href: %s", err))
 	}
 
 	if err = d.Set("is_default", addressPrefix.IsDefault); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting is_default: %s", err))
+		return diag.FromErr(flex.FmtErrorf("Error setting is_default: %s", err))
 	}
 
 	if err = d.Set("name", addressPrefix.Name); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting name: %s", err))
+		return diag.FromErr(flex.FmtErrorf("Error setting name: %s", err))
 	}
 
 	zone := []map[string]interface{}{}
@@ -221,7 +220,7 @@ func dataSourceIBMIsVPCAddressPrefixRead(context context.Context, d *schema.Reso
 		zone = append(zone, modelMap)
 	}
 	if err = d.Set("zone", zone); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting zone %s", err))
+		return diag.FromErr(flex.FmtErrorf("Error setting zone %s", err))
 	}
 
 	return nil

--- a/ibm/service/vpc/data_source_ibm_is_vpc_address_prefixes.go
+++ b/ibm/service/vpc/data_source_ibm_is_vpc_address_prefixes.go
@@ -5,7 +5,6 @@ package vpc
 
 import (
 	"context"
-	"fmt"
 	"log"
 	"time"
 
@@ -119,7 +118,7 @@ func dataSourceIbmIsVpcAddressPrefixRead(context context.Context, d *schema.Reso
 		addressPrefixCollection, response, err := vpcClient.ListVPCAddressPrefixesWithContext(context, listVpcAddressPrefixesOptions)
 		if err != nil {
 			log.Printf("[DEBUG] ListVpcAddressPrefixesWithContext failed %s\n%s", err, response)
-			return diag.FromErr(fmt.Errorf("ListVpcAddressPrefixesWithContext failed %s\n%s", err, response))
+			return diag.FromErr(flex.FmtErrorf("ListVpcAddressPrefixesWithContext failed %s\n%s", err, response))
 		}
 		start = flex.GetNext(addressPrefixCollection.Next)
 		allrecs = append(allrecs, addressPrefixCollection.AddressPrefixes...)
@@ -147,7 +146,7 @@ func dataSourceIbmIsVpcAddressPrefixRead(context context.Context, d *schema.Reso
 
 	if suppliedFilter {
 		if len(matchAddressPrefixes) == 0 {
-			return diag.FromErr(fmt.Errorf("no AddressPrefixes found with name %s", name))
+			return diag.FromErr(flex.FmtErrorf("no AddressPrefixes found with name %s", name))
 		}
 		d.SetId(name)
 	} else {
@@ -157,7 +156,7 @@ func dataSourceIbmIsVpcAddressPrefixRead(context context.Context, d *schema.Reso
 	if matchAddressPrefixes != nil {
 		err = d.Set("address_prefixes", dataSourceAddressPrefixCollectionFlattenAddressPrefixes(matchAddressPrefixes))
 		if err != nil {
-			return diag.FromErr(fmt.Errorf("[ERROR] Error setting address_prefixes %s", err))
+			return diag.FromErr(flex.FmtErrorf("[ERROR] Error setting address_prefixes %s", err))
 		}
 	}
 

--- a/ibm/service/vpc/data_source_ibm_is_vpc_dns_resolution_binding.go
+++ b/ibm/service/vpc/data_source_ibm_is_vpc_dns_resolution_binding.go
@@ -5,7 +5,6 @@ package vpc
 
 import (
 	"context"
-	"fmt"
 	"log"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
@@ -235,13 +234,13 @@ func dataSourceIBMIsVPCDnsResolutionBindingRead(context context.Context, d *sche
 	vpcdnsResolutionBinding, response, err := sess.GetVPCDnsResolutionBindingWithContext(context, getVPCDnsResolutionBindingOptions)
 	if err != nil {
 		log.Printf("[DEBUG] GetVPCDnsResolutionBindingWithContext failed %s\n%s", err, response)
-		return diag.FromErr(fmt.Errorf("GetVPCDnsResolutionBindingWithContext failed %s\n%s", err, response))
+		return diag.FromErr(flex.FmtErrorf("GetVPCDnsResolutionBindingWithContext failed %s\n%s", err, response))
 	}
 
 	d.SetId(*vpcdnsResolutionBinding.ID)
 
 	if err = d.Set("created_at", flex.DateTimeToString(vpcdnsResolutionBinding.CreatedAt)); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting created_at: %s", err))
+		return diag.FromErr(flex.FmtErrorf("Error setting created_at: %s", err))
 	}
 
 	endpointGateways := []map[string]interface{}{}
@@ -255,23 +254,23 @@ func dataSourceIBMIsVPCDnsResolutionBindingRead(context context.Context, d *sche
 		}
 	}
 	if err = d.Set("endpoint_gateways", endpointGateways); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting endpoint_gateways %s", err))
+		return diag.FromErr(flex.FmtErrorf("Error setting endpoint_gateways %s", err))
 	}
 
 	if err = d.Set("href", vpcdnsResolutionBinding.Href); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting href: %s", err))
+		return diag.FromErr(flex.FmtErrorf("Error setting href: %s", err))
 	}
 
 	if err = d.Set("lifecycle_state", vpcdnsResolutionBinding.LifecycleState); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting lifecycle_state: %s", err))
+		return diag.FromErr(flex.FmtErrorf("Error setting lifecycle_state: %s", err))
 	}
 
 	if err = d.Set("name", vpcdnsResolutionBinding.Name); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting name: %s", err))
+		return diag.FromErr(flex.FmtErrorf("Error setting name: %s", err))
 	}
 
 	if err = d.Set("resource_type", vpcdnsResolutionBinding.ResourceType); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting resource_type: %s", err))
+		return diag.FromErr(flex.FmtErrorf("Error setting resource_type: %s", err))
 	}
 
 	vpc := []map[string]interface{}{}
@@ -283,7 +282,7 @@ func dataSourceIBMIsVPCDnsResolutionBindingRead(context context.Context, d *sche
 		vpc = append(vpc, modelMap)
 	}
 	if err = d.Set("vpc", vpc); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting vpc %s", err))
+		return diag.FromErr(flex.FmtErrorf("Error setting vpc %s", err))
 	}
 
 	return nil

--- a/ibm/service/vpc/data_source_ibm_is_vpc_dns_resolution_bindings.go
+++ b/ibm/service/vpc/data_source_ibm_is_vpc_dns_resolution_bindings.go
@@ -5,7 +5,6 @@ package vpc
 
 import (
 	"context"
-	"fmt"
 	"log"
 	"time"
 
@@ -264,7 +263,7 @@ func dataSourceIBMIsVPCDnsResolutionBindingsRead(context context.Context, d *sch
 		vpcdnsResolutionBindingCollection, response, err := sess.ListVPCDnsResolutionBindingsWithContext(context, listVPCDnsResolutionBindingOptions)
 		if err != nil {
 			log.Printf("[DEBUG] ListVPCDnsResolutionBindingsWithContext failed %s\n%s", err, response)
-			return diag.FromErr(fmt.Errorf("ListVPCDnsResolutionBindingsWithContext failed %s\n%s", err, response))
+			return diag.FromErr(flex.FmtErrorf("ListVPCDnsResolutionBindingsWithContext failed %s\n%s", err, response))
 		}
 		start = flex.GetNext(vpcdnsResolutionBindingCollection.Next)
 		allrecs = append(allrecs, vpcdnsResolutionBindingCollection.DnsResolutionBindings...)

--- a/ibm/service/vpc/data_source_ibm_is_vpc_routing_table.go
+++ b/ibm/service/vpc/data_source_ibm_is_vpc_routing_table.go
@@ -216,7 +216,7 @@ func dataSourceIBMIBMIsVPCRoutingTableRead(context context.Context, d *schema.Re
 		rt, response, err := vpcClient.GetVPCRoutingTableWithContext(context, getVPCRoutingTableOptions)
 		if err != nil {
 			log.Printf("[DEBUG] GetVPCRoutingTableWithContext failed %s\n%s", err, response)
-			return diag.FromErr(fmt.Errorf("[ERROR] GetVPCRoutingTableWithContext failed %s\n%s", err, response))
+			return diag.FromErr(flex.FmtErrorf("[ERROR] GetVPCRoutingTableWithContext failed %s\n%s", err, response))
 		}
 		routingTable = rt
 	} else {
@@ -232,7 +232,7 @@ func dataSourceIBMIBMIsVPCRoutingTableRead(context context.Context, d *schema.Re
 			result, detail, err := vpcClient.ListVPCRoutingTables(listOptions)
 			if err != nil {
 				log.Printf("[ERROR] Error reading list of VPC Routing Tables:%s\n%s", err, detail)
-				return diag.FromErr(fmt.Errorf("[ERROR] ListVPCRoutingTables failed %s\n%s", err, detail))
+				return diag.FromErr(flex.FmtErrorf("[ERROR] ListVPCRoutingTables failed %s\n%s", err, detail))
 			}
 			start = flex.GetNext(result.Next)
 			allrecs = append(allrecs, result.RoutingTables...)
@@ -253,7 +253,7 @@ func dataSourceIBMIBMIsVPCRoutingTableRead(context context.Context, d *schema.Re
 	d.SetId(*routingTable.ID)
 
 	if err = d.Set(rtCreateAt, flex.DateTimeToString(routingTable.CreatedAt)); err != nil {
-		return diag.FromErr(fmt.Errorf("[ERROR] Error setting created_at: %s", err))
+		return diag.FromErr(flex.FmtErrorf("[ERROR] Error setting created_at: %s", err))
 	}
 	acceptRoutesFromInfo := make([]map[string]interface{}, 0)
 	if routingTable.AcceptRoutesFrom != nil {
@@ -266,50 +266,50 @@ func dataSourceIBMIBMIsVPCRoutingTableRead(context context.Context, d *schema.Re
 		}
 	}
 	if err = d.Set(isRoutingTableAcceptRoutesFrom, acceptRoutesFromInfo); err != nil {
-		return diag.FromErr(fmt.Errorf("[ERROR] Error setting accept_routes_from %s", err))
+		return diag.FromErr(flex.FmtErrorf("[ERROR] Error setting accept_routes_from %s", err))
 	}
 
 	if err = d.Set(isRoutingTableID, routingTable.ID); err != nil {
-		return diag.FromErr(fmt.Errorf("[ERROR] Error setting routing_table: %s", err))
+		return diag.FromErr(flex.FmtErrorf("[ERROR] Error setting routing_table: %s", err))
 	}
 
 	if err = d.Set(rtHref, routingTable.Href); err != nil {
-		return diag.FromErr(fmt.Errorf("[ERROR] Error setting href: %s", err))
+		return diag.FromErr(flex.FmtErrorf("[ERROR] Error setting href: %s", err))
 	}
 
 	if err = d.Set(rtIsDefault, routingTable.IsDefault); err != nil {
-		return diag.FromErr(fmt.Errorf("[ERROR] Error setting is_default: %s", err))
+		return diag.FromErr(flex.FmtErrorf("[ERROR] Error setting is_default: %s", err))
 	}
 
 	if err = d.Set(rtLifecycleState, routingTable.LifecycleState); err != nil {
-		return diag.FromErr(fmt.Errorf("[ERROR] Error setting lifecycle_state: %s", err))
+		return diag.FromErr(flex.FmtErrorf("[ERROR] Error setting lifecycle_state: %s", err))
 	}
 
 	if err = d.Set(rName, routingTable.Name); err != nil {
-		return diag.FromErr(fmt.Errorf("[ERROR] Error setting name: %s", err))
+		return diag.FromErr(flex.FmtErrorf("[ERROR] Error setting name: %s", err))
 	}
 
 	if err = d.Set(rtResourceType, routingTable.ResourceType); err != nil {
-		return diag.FromErr(fmt.Errorf("[ERROR] Error setting resource_type: %s", err))
+		return diag.FromErr(flex.FmtErrorf("[ERROR] Error setting resource_type: %s", err))
 	}
 
 	if err = d.Set(rtRouteDirectLinkIngress, routingTable.RouteDirectLinkIngress); err != nil {
-		return diag.FromErr(fmt.Errorf("[ERROR] Error setting route_direct_link_ingress: %s", err))
+		return diag.FromErr(flex.FmtErrorf("[ERROR] Error setting route_direct_link_ingress: %s", err))
 	}
 
 	if err = d.Set(rtRouteInternetIngress, routingTable.RouteInternetIngress); err != nil {
-		return diag.FromErr(fmt.Errorf("[ERROR] Error setting route_internet_ingress: %s", err))
+		return diag.FromErr(flex.FmtErrorf("[ERROR] Error setting route_internet_ingress: %s", err))
 	}
 	if err = d.Set(rtRouteTransitGatewayIngress, routingTable.RouteTransitGatewayIngress); err != nil {
-		return diag.FromErr(fmt.Errorf("[ERROR] Error setting route_transit_gateway_ingress: %s", err))
+		return diag.FromErr(flex.FmtErrorf("[ERROR] Error setting route_transit_gateway_ingress: %s", err))
 	}
 
 	if err = d.Set(rtRouteVPCZoneIngress, routingTable.RouteVPCZoneIngress); err != nil {
-		return diag.FromErr(fmt.Errorf("[ERROR] Error setting route_vpc_zone_ingress: %s", err))
+		return diag.FromErr(flex.FmtErrorf("[ERROR] Error setting route_vpc_zone_ingress: %s", err))
 	}
 
 	if err = d.Set("advertise_routes_to", routingTable.AdvertiseRoutesTo); err != nil {
-		return diag.FromErr(fmt.Errorf("[ERROR] Error setting value of advertise_routes_to: %s", err))
+		return diag.FromErr(flex.FmtErrorf("[ERROR] Error setting value of advertise_routes_to: %s", err))
 	}
 	routes := []map[string]interface{}{}
 	if routingTable.Routes != nil {
@@ -322,7 +322,7 @@ func dataSourceIBMIBMIsVPCRoutingTableRead(context context.Context, d *schema.Re
 		}
 	}
 	if err = d.Set(rtRoutes, routes); err != nil {
-		return diag.FromErr(fmt.Errorf("[ERROR] Error setting routes %s", err))
+		return diag.FromErr(flex.FmtErrorf("[ERROR] Error setting routes %s", err))
 	}
 
 	subnets := []map[string]interface{}{}
@@ -336,7 +336,7 @@ func dataSourceIBMIBMIsVPCRoutingTableRead(context context.Context, d *schema.Re
 		}
 	}
 	if err = d.Set(rtSubnets, subnets); err != nil {
-		return diag.FromErr(fmt.Errorf("[ERROR] Error setting subnets %s", err))
+		return diag.FromErr(flex.FmtErrorf("[ERROR] Error setting subnets %s", err))
 	}
 
 	return nil

--- a/ibm/service/vpc/data_source_ibm_is_vpc_routing_table_route.go
+++ b/ibm/service/vpc/data_source_ibm_is_vpc_routing_table_route.go
@@ -5,7 +5,6 @@ package vpc
 
 import (
 	"context"
-	"fmt"
 	"log"
 
 	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/conns"
@@ -232,7 +231,7 @@ func dataSourceIBMIBMIsVPCRoutingTableRouteRead(context context.Context, d *sche
 		r, response, err := vpcClient.GetVPCRoutingTableRouteWithContext(context, getVPCRoutingTableRouteOptions)
 		if err != nil {
 			log.Printf("[DEBUG] GetVPCRoutingTableRouteWithContext failed %s\n%s", err, response)
-			return diag.FromErr(fmt.Errorf("[ERROR] GetVPCRoutingTableRouteWithContext failed %s\n%s", err, response))
+			return diag.FromErr(flex.FmtErrorf("[ERROR] GetVPCRoutingTableRouteWithContext failed %s\n%s", err, response))
 		}
 		route = r
 	} else {
@@ -250,7 +249,7 @@ func dataSourceIBMIBMIsVPCRoutingTableRouteRead(context context.Context, d *sche
 			result, detail, err := vpcClient.ListVPCRoutingTableRoutes(listVpcRoutingTablesRoutesOptions)
 			if err != nil {
 				log.Printf("Error reading list of VPC Routing Table Routes:%s\n%s", err, detail)
-				return diag.FromErr(fmt.Errorf("[ERROR] GetVPCRoutingTableRouteWithContext failed %s\n%s", err, detail))
+				return diag.FromErr(flex.FmtErrorf("[ERROR] GetVPCRoutingTableRouteWithContext failed %s\n%s", err, detail))
 			}
 			start = flex.GetNext(result.Next)
 			allrecs = append(allrecs, result.Routes...)
@@ -266,22 +265,22 @@ func dataSourceIBMIBMIsVPCRoutingTableRouteRead(context context.Context, d *sche
 			}
 		}
 		if route == nil {
-			return diag.FromErr(fmt.Errorf("[ERROR] Route not found with name: %s", routeName))
+			return diag.FromErr(flex.FmtErrorf("[ERROR] Route not found with name: %s", routeName))
 		}
 	}
 
 	d.SetId(*route.ID)
 
 	if err = d.Set(rAction, route.Action); err != nil {
-		return diag.FromErr(fmt.Errorf("[ERROR] Error setting action: %s", err))
+		return diag.FromErr(flex.FmtErrorf("[ERROR] Error setting action: %s", err))
 	}
 
 	if err = d.Set("advertise", route.Advertise); err != nil {
-		return diag.FromErr(fmt.Errorf("[ERROR] Error setting advertise: %s", err))
+		return diag.FromErr(flex.FmtErrorf("[ERROR] Error setting advertise: %s", err))
 	}
 
 	if err = d.Set(rtCreateAt, flex.DateTimeToString(route.CreatedAt)); err != nil {
-		return diag.FromErr(fmt.Errorf("[ERROR] Error setting created_at: %s", err))
+		return diag.FromErr(flex.FmtErrorf("[ERROR] Error setting created_at: %s", err))
 	}
 
 	// creator changes
@@ -290,33 +289,33 @@ func dataSourceIBMIBMIsVPCRoutingTableRouteRead(context context.Context, d *sche
 		mm, err := dataSourceIBMIsRouteCreatorToMap(route.Creator)
 		if err != nil {
 			log.Printf("Error reading list of VPC Routing Table Routes' creator:%s", err)
-			return diag.FromErr(fmt.Errorf("[ERROR] Error fetching creator: %s", err))
+			return diag.FromErr(flex.FmtErrorf("[ERROR] Error fetching creator: %s", err))
 		}
 		creator = append(creator, mm)
 
 	}
 	if err = d.Set("creator", creator); err != nil {
-		return diag.FromErr(fmt.Errorf("[ERROR] Error setting creator: %s", err))
+		return diag.FromErr(flex.FmtErrorf("[ERROR] Error setting creator: %s", err))
 	}
 
 	if err = d.Set(isRoutingTableRouteID, route.ID); err != nil {
-		return diag.FromErr(fmt.Errorf("[ERROR] Error setting route_id: %s", err))
+		return diag.FromErr(flex.FmtErrorf("[ERROR] Error setting route_id: %s", err))
 	}
 
 	if err = d.Set(rDestination, route.Destination); err != nil {
-		return diag.FromErr(fmt.Errorf("[ERROR] Error setting destination: %s", err))
+		return diag.FromErr(flex.FmtErrorf("[ERROR] Error setting destination: %s", err))
 	}
 
 	if err = d.Set(rtHref, route.Href); err != nil {
-		return diag.FromErr(fmt.Errorf("[ERROR] Error setting href: %s", err))
+		return diag.FromErr(flex.FmtErrorf("[ERROR] Error setting href: %s", err))
 	}
 
 	if err = d.Set(rtLifecycleState, route.LifecycleState); err != nil {
-		return diag.FromErr(fmt.Errorf("[ERROR] Error setting lifecycle_state: %s", err))
+		return diag.FromErr(flex.FmtErrorf("[ERROR] Error setting lifecycle_state: %s", err))
 	}
 
 	if err = d.Set(rName, route.Name); err != nil {
-		return diag.FromErr(fmt.Errorf("[ERROR] Error setting name: %s", err))
+		return diag.FromErr(flex.FmtErrorf("[ERROR] Error setting name: %s", err))
 	}
 
 	nextHop := []map[string]interface{}{}
@@ -328,16 +327,16 @@ func dataSourceIBMIBMIsVPCRoutingTableRouteRead(context context.Context, d *sche
 		nextHop = append(nextHop, modelMap)
 	}
 	if err = d.Set(rNextHop, nextHop); err != nil {
-		return diag.FromErr(fmt.Errorf("[ERROR] Error setting next_hop %s", err))
+		return diag.FromErr(flex.FmtErrorf("[ERROR] Error setting next_hop %s", err))
 	}
 
 	//orgin
 	if err = d.Set("origin", route.Origin); err != nil {
-		return diag.FromErr(fmt.Errorf("[ERROR] Error setting origin %s", err))
+		return diag.FromErr(flex.FmtErrorf("[ERROR] Error setting origin %s", err))
 	}
 	// priority
 	if err = d.Set("priority", route.Priority); err != nil {
-		return diag.FromErr(fmt.Errorf("[ERROR] Error setting priority, :%s", err))
+		return diag.FromErr(flex.FmtErrorf("[ERROR] Error setting priority, :%s", err))
 	}
 	zone := []map[string]interface{}{}
 	if route.Zone != nil {
@@ -348,7 +347,7 @@ func dataSourceIBMIBMIsVPCRoutingTableRouteRead(context context.Context, d *sche
 		zone = append(zone, modelMap)
 	}
 	if err = d.Set(rZone, zone); err != nil {
-		return diag.FromErr(fmt.Errorf("[ERROR] Error setting zone %s", err))
+		return diag.FromErr(flex.FmtErrorf("[ERROR] Error setting zone %s", err))
 	}
 
 	return nil
@@ -386,7 +385,7 @@ func dataSourceIBMIBMIsVPCRoutingTableRouteRouteNextHopToMap(model vpcv1.RouteNe
 		}
 		return modelMap, nil
 	} else {
-		return nil, fmt.Errorf("[ERROR] Unrecognized vpcv1.RouteNextHopIntf subtype encountered")
+		return nil, flex.FmtErrorf("[ERROR] Unrecognized vpcv1.RouteNextHopIntf subtype encountered")
 	}
 }
 

--- a/ibm/service/vpc/data_source_ibm_is_vpc_routing_table_routes.go
+++ b/ibm/service/vpc/data_source_ibm_is_vpc_routing_table_routes.go
@@ -4,7 +4,6 @@
 package vpc
 
 import (
-	"fmt"
 	"log"
 	"time"
 
@@ -296,7 +295,7 @@ func dataSourceIBMIsRouteCreatorToMap(model vpcv1.RouteCreatorIntf) (map[string]
 		}
 		return modelMap, nil
 	} else {
-		return nil, fmt.Errorf("[Error] unrecognized vpcv1.RouteCreatorIntf subtype encountered")
+		return nil, flex.FmtErrorf("[Error] unrecognized vpcv1.RouteCreatorIntf subtype encountered")
 	}
 }
 

--- a/ibm/service/vpc/data_source_ibm_is_vpcs.go
+++ b/ibm/service/vpc/data_source_ibm_is_vpcs.go
@@ -7,7 +7,6 @@ import (
 	//"encoding/json"
 
 	"context"
-	"fmt"
 	"log"
 	"reflect"
 	"time"
@@ -618,7 +617,7 @@ func dataSourceIBMISVPCListRead(context context.Context, d *schema.ResourceData,
 			}
 			s, response, err := sess.ListSubnetsWithContext(context, options)
 			if err != nil {
-				return diag.FromErr(fmt.Errorf("[ERROR] Error fetching subnets %s\n%s", err, response))
+				return diag.FromErr(flex.FmtErrorf("[ERROR] Error fetching subnets %s\n%s", err, response))
 			}
 			startSub = flex.GetNext(s.Next)
 			allrecsSub = append(allrecsSub, s.Subnets...)
@@ -659,7 +658,7 @@ func dataSourceIBMISVPCListRead(context context.Context, d *schema.ResourceData,
 			}
 			sgs, response, err := sess.ListSecurityGroupsWithContext(context, listSgOptions)
 			if err != nil {
-				return diag.FromErr(fmt.Errorf("[ERROR] Error fetching Security Groups %s\n%s", err, response))
+				return diag.FromErr(flex.FmtErrorf("[ERROR] Error fetching Security Groups %s\n%s", err, response))
 			}
 			if *sgs.TotalCount == int64(0) {
 				break

--- a/ibm/service/vpc/data_source_ibm_is_vpn_gateway.go
+++ b/ibm/service/vpc/data_source_ibm_is_vpn_gateway.go
@@ -5,7 +5,6 @@ package vpc
 
 import (
 	"context"
-	"fmt"
 	"log"
 
 	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/conns"
@@ -345,7 +344,7 @@ func dataSourceIBMIsVPNGatewayRead(context context.Context, d *schema.ResourceDa
 		vpnGatewayIntf, response, err := vpcClient.GetVPNGatewayWithContext(context, getVPNGatewayOptions)
 		if err != nil || vpnGatewayIntf.(*vpcv1.VPNGateway) == nil {
 			log.Printf("[DEBUG] GetVPNGatewayWithContext failed %s\n%s", err, response)
-			return diag.FromErr(fmt.Errorf("GetVPNGatewayWithContext failed %s\n%s", err, response))
+			return diag.FromErr(flex.FmtErrorf("GetVPNGatewayWithContext failed %s\n%s", err, response))
 		}
 		vpnGateway = vpnGatewayIntf.(*vpcv1.VPNGateway)
 	} else {
@@ -359,7 +358,7 @@ func dataSourceIBMIsVPNGatewayRead(context context.Context, d *schema.ResourceDa
 			}
 			availableVPNGateways, detail, err := vpcClient.ListVPNGatewaysWithContext(context, listvpnGWOptions)
 			if err != nil || availableVPNGateways == nil {
-				return diag.FromErr(fmt.Errorf("Error reading list of VPN Gateways:%s\n%s", err, detail))
+				return diag.FromErr(flex.FmtErrorf("Error reading list of VPN Gateways:%s\n%s", err, detail))
 			}
 			start = flex.GetNext(availableVPNGateways.Next)
 			allrecs = append(allrecs, availableVPNGateways.VPNGateways...)
@@ -377,7 +376,7 @@ func dataSourceIBMIsVPNGatewayRead(context context.Context, d *schema.ResourceDa
 		}
 		if !vpn_gateway_found {
 			log.Printf("[DEBUG] No vpn gateway found with given name %s", vpn_gateway_name)
-			return diag.FromErr(fmt.Errorf("No vpn gateway found with given name %s", vpn_gateway_name))
+			return diag.FromErr(flex.FmtErrorf("No vpn gateway found with given name %s", vpn_gateway_name))
 		}
 	}
 	d.SetId(*vpnGateway.ID)
@@ -385,63 +384,63 @@ func dataSourceIBMIsVPNGatewayRead(context context.Context, d *schema.ResourceDa
 	if vpnGateway.Connections != nil {
 		err = d.Set("connections", dataSourceVPNGatewayFlattenConnections(vpnGateway.Connections))
 		if err != nil {
-			return diag.FromErr(fmt.Errorf("Error setting connections %s", err))
+			return diag.FromErr(flex.FmtErrorf("Error setting connections %s", err))
 		}
 	}
 	if err = d.Set("created_at", flex.DateTimeToString(vpnGateway.CreatedAt)); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting created_at: %s", err))
+		return diag.FromErr(flex.FmtErrorf("Error setting created_at: %s", err))
 	}
 	if err = d.Set("crn", vpnGateway.CRN); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting crn: %s", err))
+		return diag.FromErr(flex.FmtErrorf("Error setting crn: %s", err))
 	}
 	if err = d.Set("href", vpnGateway.Href); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting href: %s", err))
+		return diag.FromErr(flex.FmtErrorf("Error setting href: %s", err))
 	}
 
 	if vpnGateway.Members != nil {
 		err = d.Set("members", dataSourceVPNGatewayFlattenMembers(vpnGateway.Members))
 		if err != nil {
-			return diag.FromErr(fmt.Errorf("Error setting members %s", err))
+			return diag.FromErr(flex.FmtErrorf("Error setting members %s", err))
 		}
 	}
 	if err = d.Set("name", vpnGateway.Name); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting name: %s", err))
+		return diag.FromErr(flex.FmtErrorf("Error setting name: %s", err))
 	}
 
 	if vpnGateway.ResourceGroup != nil {
 		err = d.Set("resource_group", dataSourceVPNGatewayFlattenResourceGroup(*vpnGateway.ResourceGroup))
 		if err != nil {
-			return diag.FromErr(fmt.Errorf("Error setting resource_group %s", err))
+			return diag.FromErr(flex.FmtErrorf("Error setting resource_group %s", err))
 		}
 	}
 	if err = d.Set("resource_type", vpnGateway.ResourceType); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting resource_type: %s", err))
+		return diag.FromErr(flex.FmtErrorf("Error setting resource_type: %s", err))
 	}
 	if err = d.Set("health_state", vpnGateway.HealthState); err != nil {
-		return diag.FromErr(fmt.Errorf("[ERROR] Error setting health_state: %s", err))
+		return diag.FromErr(flex.FmtErrorf("[ERROR] Error setting health_state: %s", err))
 	}
 	if err := d.Set("health_reasons", resourceVPNGatewayRouteFlattenHealthReasons(vpnGateway.HealthReasons)); err != nil {
-		return diag.FromErr(fmt.Errorf("[ERROR] Error setting health_reasons: %s", err))
+		return diag.FromErr(flex.FmtErrorf("[ERROR] Error setting health_reasons: %s", err))
 	}
 	if err = d.Set("lifecycle_state", vpnGateway.LifecycleState); err != nil {
-		return diag.FromErr(fmt.Errorf("[ERROR] Error setting lifecycle_state: %s", err))
+		return diag.FromErr(flex.FmtErrorf("[ERROR] Error setting lifecycle_state: %s", err))
 	}
 	if err := d.Set("lifecycle_reasons", resourceVPNGatewayFlattenLifecycleReasons(vpnGateway.LifecycleReasons)); err != nil {
-		return diag.FromErr(fmt.Errorf("[ERROR] Error setting lifecycle_reasons: %s", err))
+		return diag.FromErr(flex.FmtErrorf("[ERROR] Error setting lifecycle_reasons: %s", err))
 	}
 	if vpnGateway.Subnet != nil {
 		err = d.Set("subnet", dataSourceVPNGatewayFlattenSubnet(*vpnGateway.Subnet))
 		if err != nil {
-			return diag.FromErr(fmt.Errorf("Error setting subnet %s", err))
+			return diag.FromErr(flex.FmtErrorf("Error setting subnet %s", err))
 		}
 	}
 	if err = d.Set("mode", vpnGateway.Mode); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting mode: %s", err))
+		return diag.FromErr(flex.FmtErrorf("Error setting mode: %s", err))
 	}
 	if vpnGateway.VPC != nil {
 		err = d.Set("vpc", dataSourceVPNGatewayFlattenVPC(vpnGateway.VPC))
 		if err != nil {
-			return diag.FromErr(fmt.Errorf("Error setting vpc: %s", err))
+			return diag.FromErr(flex.FmtErrorf("Error setting vpc: %s", err))
 		}
 	}
 	tags, err := flex.GetGlobalTagsUsingCRN(meta, *vpnGateway.CRN, "", isUserTagType)

--- a/ibm/service/vpc/data_source_ibm_is_vpn_gateway_connection.go
+++ b/ibm/service/vpc/data_source_ibm_is_vpn_gateway_connection.go
@@ -296,7 +296,7 @@ func dataSourceIBMIsVPNGatewayConnectionRead(context context.Context, d *schema.
 			}
 			availableVPNGateways, detail, err := vpcClient.ListVPNGatewaysWithContext(context, listvpnGWOptions)
 			if err != nil || availableVPNGateways == nil {
-				return diag.FromErr(fmt.Errorf("Error reading list of VPN Gateways:%s\n%s", err, detail))
+				return diag.FromErr(flex.FmtErrorf("Error reading list of VPN Gateways:%s\n%s", err, detail))
 			}
 			start = flex.GetNext(availableVPNGateways.Next)
 			allrecs = append(allrecs, availableVPNGateways.VPNGateways...)
@@ -315,7 +315,7 @@ func dataSourceIBMIsVPNGatewayConnectionRead(context context.Context, d *schema.
 		}
 		if !vpn_gateway_found {
 			log.Printf("[DEBUG] No vpn gateway and connection found with given name %s", vpn_gateway_name)
-			return diag.FromErr(fmt.Errorf("No vpn gateway and connection found with given name %s", vpn_gateway_name))
+			return diag.FromErr(flex.FmtErrorf("No vpn gateway and connection found with given name %s", vpn_gateway_name))
 		}
 	}
 
@@ -324,7 +324,7 @@ func dataSourceIBMIsVPNGatewayConnectionRead(context context.Context, d *schema.
 
 		availableVPNGatewayConnections, detail, err := vpcClient.ListVPNGatewayConnections(listvpnGWConnectionOptions)
 		if err != nil || availableVPNGatewayConnections == nil {
-			return diag.FromErr(fmt.Errorf("Error reading list of VPN Gateway Connections:%s\n%s", err, detail))
+			return diag.FromErr(flex.FmtErrorf("Error reading list of VPN Gateway Connections:%s\n%s", err, detail))
 		}
 
 		vpn_gateway_conn_found := false
@@ -337,7 +337,7 @@ func dataSourceIBMIsVPNGatewayConnectionRead(context context.Context, d *schema.
 			}
 		}
 		if !vpn_gateway_conn_found {
-			return diag.FromErr(fmt.Errorf("VPN gateway connection %s not found", vpn_gateway_connection_name))
+			return diag.FromErr(flex.FmtErrorf("VPN gateway connection %s not found", vpn_gateway_connection_name))
 		}
 	} else if vpn_gateway_connection != "" {
 		getVPNGatewayConnectionOptions := &vpcv1.GetVPNGatewayConnectionOptions{}
@@ -348,7 +348,7 @@ func dataSourceIBMIsVPNGatewayConnectionRead(context context.Context, d *schema.
 		vpnGatewayConnectionIntf, response, err := vpcClient.GetVPNGatewayConnectionWithContext(context, getVPNGatewayConnectionOptions)
 		if err != nil || vpnGatewayConnectionIntf.(*vpcv1.VPNGatewayConnection) == nil {
 			log.Printf("[DEBUG] GetVPNGatewayConnectionWithContext failed %s\n%s", err, response)
-			return diag.FromErr(fmt.Errorf("GetVPNGatewayConnectionWithContext failed %s\n%s", err, response))
+			return diag.FromErr(flex.FmtErrorf("GetVPNGatewayConnectionWithContext failed %s\n%s", err, response))
 		}
 		vpnGatewayConnection = vpnGatewayConnectionIntf.(*vpcv1.VPNGatewayConnection)
 	}
@@ -356,81 +356,81 @@ func dataSourceIBMIsVPNGatewayConnectionRead(context context.Context, d *schema.
 	d.SetId(fmt.Sprintf("%s/%s", vpn_gateway_id, *vpnGatewayConnection.ID))
 
 	if err = d.Set("admin_state_up", vpnGatewayConnection.AdminStateUp); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting admin_state_up: %s", err))
+		return diag.FromErr(flex.FmtErrorf("Error setting admin_state_up: %s", err))
 	}
 	if err = d.Set("authentication_mode", vpnGatewayConnection.AuthenticationMode); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting authentication_mode: %s", err))
+		return diag.FromErr(flex.FmtErrorf("Error setting authentication_mode: %s", err))
 	}
 	if err = d.Set("created_at", flex.DateTimeToString(vpnGatewayConnection.CreatedAt)); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting created_at: %s", err))
+		return diag.FromErr(flex.FmtErrorf("Error setting created_at: %s", err))
 	}
 
 	if vpnGatewayConnection.DeadPeerDetection != nil {
 		err = d.Set("dead_peer_detection", dataSourceVPNGatewayConnectionFlattenDeadPeerDetection(*vpnGatewayConnection.DeadPeerDetection))
 		if err != nil {
-			return diag.FromErr(fmt.Errorf("Error setting dead_peer_detection %s", err))
+			return diag.FromErr(flex.FmtErrorf("Error setting dead_peer_detection %s", err))
 		}
 	}
 	if err = d.Set("href", vpnGatewayConnection.Href); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting href: %s", err))
+		return diag.FromErr(flex.FmtErrorf("Error setting href: %s", err))
 	}
 
 	if vpnGatewayConnection.IkePolicy != nil {
 		err = d.Set("ike_policy", dataSourceVPNGatewayConnectionFlattenIkePolicy(*vpnGatewayConnection.IkePolicy))
 		if err != nil {
-			return diag.FromErr(fmt.Errorf("Error setting ike_policy %s", err))
+			return diag.FromErr(flex.FmtErrorf("Error setting ike_policy %s", err))
 		}
 	}
 
 	if vpnGatewayConnection.IpsecPolicy != nil {
 		err = d.Set("ipsec_policy", dataSourceVPNGatewayConnectionFlattenIpsecPolicy(*vpnGatewayConnection.IpsecPolicy))
 		if err != nil {
-			return diag.FromErr(fmt.Errorf("Error setting ipsec_policy %s", err))
+			return diag.FromErr(flex.FmtErrorf("Error setting ipsec_policy %s", err))
 		}
 	}
 	if err = d.Set("mode", vpnGatewayConnection.Mode); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting mode: %s", err))
+		return diag.FromErr(flex.FmtErrorf("Error setting mode: %s", err))
 	}
 	if err = d.Set("name", vpnGatewayConnection.Name); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting name: %s", err))
+		return diag.FromErr(flex.FmtErrorf("Error setting name: %s", err))
 	}
 	if err = d.Set("peer_address", vpnGatewayConnection.PeerAddress); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting peer_address: %s", err))
+		return diag.FromErr(flex.FmtErrorf("Error setting peer_address: %s", err))
 	}
 	if err = d.Set("psk", vpnGatewayConnection.Psk); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting psk: %s", err))
+		return diag.FromErr(flex.FmtErrorf("Error setting psk: %s", err))
 	}
 	if err = d.Set("resource_type", vpnGatewayConnection.ResourceType); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting resource_type: %s", err))
+		return diag.FromErr(flex.FmtErrorf("Error setting resource_type: %s", err))
 	}
 	if err = d.Set("status", vpnGatewayConnection.Status); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting status: %s", err))
+		return diag.FromErr(flex.FmtErrorf("Error setting status: %s", err))
 	}
 	if err := d.Set("status_reasons", resourceVPNGatewayConnectionFlattenLifecycleReasons(vpnGatewayConnection.StatusReasons)); err != nil {
-		return diag.FromErr(fmt.Errorf("[ERROR] Error setting status_reasons: %s", err))
+		return diag.FromErr(flex.FmtErrorf("[ERROR] Error setting status_reasons: %s", err))
 	}
 	if err = d.Set("routing_protocol", vpnGatewayConnection.RoutingProtocol); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting routing_protocol: %s", err))
+		return diag.FromErr(flex.FmtErrorf("Error setting routing_protocol: %s", err))
 	}
 
 	if vpnGatewayConnection.Tunnels != nil {
 		err = d.Set("tunnels", dataSourceVPNGatewayConnectionFlattenTunnels(vpnGatewayConnection.Tunnels))
 		if err != nil {
-			return diag.FromErr(fmt.Errorf("Error setting tunnels %s", err))
+			return diag.FromErr(flex.FmtErrorf("Error setting tunnels %s", err))
 		}
 	}
 
 	if len(vpnGatewayConnection.LocalCIDRs) > 0 {
 		err = d.Set("local_cidrs", vpnGatewayConnection.LocalCIDRs)
 		if err != nil {
-			return diag.FromErr(fmt.Errorf("Error setting local CIDRs %s", err))
+			return diag.FromErr(flex.FmtErrorf("Error setting local CIDRs %s", err))
 		}
 	}
 
 	if len(vpnGatewayConnection.PeerCIDRs) > 0 {
 		err = d.Set("peer_cidrs", vpnGatewayConnection.PeerCIDRs)
 		if err != nil {
-			return diag.FromErr(fmt.Errorf("Error setting Peer CIDRs %s", err))
+			return diag.FromErr(flex.FmtErrorf("Error setting Peer CIDRs %s", err))
 		}
 	}
 	return nil

--- a/ibm/service/vpc/data_source_ibm_is_vpn_gateway_connections.go
+++ b/ibm/service/vpc/data_source_ibm_is_vpn_gateway_connections.go
@@ -4,7 +4,6 @@
 package vpc
 
 import (
-	"fmt"
 	"time"
 
 	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/flex"
@@ -194,7 +193,7 @@ func dataSourceIBMVPNGatewayConnectionsRead(d *schema.ResourceData, meta interfa
 	}
 	availableVPNGatewayConnections, detail, err := sess.ListVPNGatewayConnections(listvpnGWConnectionOptions)
 	if err != nil {
-		return fmt.Errorf("[ERROR] Error reading list of VPN Gateway Connections:%s\n%s", err, detail)
+		return flex.FmtErrorf("[ERROR] Error reading list of VPN Gateway Connections:%s\n%s", err, detail)
 	}
 	vpngatewayconnections := make([]map[string]interface{}, 0)
 	for _, instance := range availableVPNGatewayConnections.Connections {

--- a/ibm/service/vpc/data_source_ibm_is_vpn_gateways.go
+++ b/ibm/service/vpc/data_source_ibm_is_vpn_gateways.go
@@ -4,7 +4,6 @@
 package vpc
 
 import (
-	"fmt"
 	"log"
 	"time"
 
@@ -262,7 +261,7 @@ func dataSourceIBMVPNGatewaysRead(d *schema.ResourceData, meta interface{}) erro
 		}
 		availableVPNGateways, detail, err := sess.ListVPNGateways(listvpnGWOptions)
 		if err != nil {
-			return fmt.Errorf("[ERROR] Error reading list of VPN Gateways:%s\n%s", err, detail)
+			return flex.FmtErrorf("[ERROR] Error reading list of VPN Gateways:%s\n%s", err, detail)
 		}
 		start = flex.GetNext(availableVPNGateways.Next)
 		allrecs = append(allrecs, availableVPNGateways.VPNGateways...)

--- a/ibm/service/vpc/data_source_ibm_is_vpn_server.go
+++ b/ibm/service/vpc/data_source_ibm_is_vpn_server.go
@@ -441,7 +441,7 @@ func dataSourceIBMIsVPNServerRead(context context.Context, d *schema.ResourceDat
 		vpnServerInfo, response, err := sess.GetVPNServerWithContext(context, getVPNServerOptions)
 		if err != nil {
 			log.Printf("[DEBUG] GetVPNServerWithContext failed %s\n%s", err, response)
-			return diag.FromErr(fmt.Errorf("[ERROR] GetVPNServerWithContext failed %s\n%s", err, response))
+			return diag.FromErr(flex.FmtErrorf("[ERROR] GetVPNServerWithContext failed %s\n%s", err, response))
 		}
 		vpnServer = vpnServerInfo
 	} else if v, ok := d.GetOk("name"); ok {
@@ -458,7 +458,7 @@ func dataSourceIBMIsVPNServerRead(context context.Context, d *schema.ResourceDat
 			vpnServerCollection, response, err := sess.ListVPNServersWithContext(context, listVPNServersOptions)
 			if err != nil {
 				log.Printf("[DEBUG] ListVPNServersWithContext failed %s\n%s", err, response)
-				return diag.FromErr(fmt.Errorf("[ERROR] ListVPNServersWithContext failed %s\n%s", err, response))
+				return diag.FromErr(flex.FmtErrorf("[ERROR] ListVPNServersWithContext failed %s\n%s", err, response))
 			}
 			start = flex.GetNext(vpnServerCollection.Next)
 			allrecs = append(allrecs, vpnServerCollection.VPNServers...)
@@ -475,20 +475,20 @@ func dataSourceIBMIsVPNServerRead(context context.Context, d *schema.ResourceDat
 		}
 		if vpnServer == nil {
 			log.Printf("[DEBUG] No vpnServer found with name %s", name)
-			return diag.FromErr(fmt.Errorf("[ERROR] No vpn server found with name %s", name))
+			return diag.FromErr(flex.FmtErrorf("[ERROR] No vpn server found with name %s", name))
 		}
 	}
 
 	d.SetId(fmt.Sprintf("%s", *vpnServer.ID))
 	err = d.Set("identifier", vpnServer.ID)
 	if err != nil {
-		return diag.FromErr(fmt.Errorf("[ERROR] Error setting identifier %s", err))
+		return diag.FromErr(flex.FmtErrorf("[ERROR] Error setting identifier %s", err))
 	}
 
 	if vpnServer.Certificate != nil {
 		err = d.Set("certificate", dataSourceVPNServerFlattenCertificate(*vpnServer.Certificate))
 		if err != nil {
-			return diag.FromErr(fmt.Errorf("[ERROR] Error setting certificate %s", err))
+			return diag.FromErr(flex.FmtErrorf("[ERROR] Error setting certificate %s", err))
 		}
 	}
 
@@ -514,104 +514,104 @@ func dataSourceIBMIsVPNServerRead(context context.Context, d *schema.ResourceDat
 	}
 	err = d.Set("client_authentication", vpnServerAuthenticationPrototypeArray)
 	if err != nil {
-		return diag.FromErr(fmt.Errorf("[ERROR] Error setting client_authentication %s", err))
+		return diag.FromErr(flex.FmtErrorf("[ERROR] Error setting client_authentication %s", err))
 	}
 
 	if err = d.Set("client_auto_delete", vpnServer.ClientAutoDelete); err != nil {
-		return diag.FromErr(fmt.Errorf("[ERROR] Error setting client_auto_delete: %s", err))
+		return diag.FromErr(flex.FmtErrorf("[ERROR] Error setting client_auto_delete: %s", err))
 	}
 	if err = d.Set("client_auto_delete_timeout", flex.IntValue(vpnServer.ClientAutoDeleteTimeout)); err != nil {
-		return diag.FromErr(fmt.Errorf("[ERROR] Error setting client_auto_delete_timeout: %s", err))
+		return diag.FromErr(flex.FmtErrorf("[ERROR] Error setting client_auto_delete_timeout: %s", err))
 	}
 
 	if vpnServer.ClientDnsServerIps != nil {
 		err = d.Set("client_dns_server_ips", dataSourceVPNServerFlattenClientDnsServerIps(vpnServer.ClientDnsServerIps))
 		if err != nil {
-			return diag.FromErr(fmt.Errorf("[ERROR] Error setting client_dns_server_ips %s", err))
+			return diag.FromErr(flex.FmtErrorf("[ERROR] Error setting client_dns_server_ips %s", err))
 		}
 	}
 	if err = d.Set("client_idle_timeout", flex.IntValue(vpnServer.ClientIdleTimeout)); err != nil {
-		return diag.FromErr(fmt.Errorf("[ERROR] Error setting client_idle_timeout: %s", err))
+		return diag.FromErr(flex.FmtErrorf("[ERROR] Error setting client_idle_timeout: %s", err))
 	}
 	if err = d.Set("client_ip_pool", vpnServer.ClientIPPool); err != nil {
-		return diag.FromErr(fmt.Errorf("[ERROR] Error setting client_ip_pool: %s", err))
+		return diag.FromErr(flex.FmtErrorf("[ERROR] Error setting client_ip_pool: %s", err))
 	}
 	if err = d.Set("created_at", flex.DateTimeToString(vpnServer.CreatedAt)); err != nil {
-		return diag.FromErr(fmt.Errorf("[ERROR] Error setting created_at: %s", err))
+		return diag.FromErr(flex.FmtErrorf("[ERROR] Error setting created_at: %s", err))
 	}
 	if err = d.Set("crn", vpnServer.CRN); err != nil {
-		return diag.FromErr(fmt.Errorf("[ERROR] Error setting crn: %s", err))
+		return diag.FromErr(flex.FmtErrorf("[ERROR] Error setting crn: %s", err))
 	}
 	if err = d.Set("enable_split_tunneling", vpnServer.EnableSplitTunneling); err != nil {
-		return diag.FromErr(fmt.Errorf("[ERROR] Error setting enable_split_tunneling: %s", err))
+		return diag.FromErr(flex.FmtErrorf("[ERROR] Error setting enable_split_tunneling: %s", err))
 	}
 	if err = d.Set("health_state", vpnServer.HealthState); err != nil {
-		return diag.FromErr(fmt.Errorf("[ERROR] Error setting health_state: %s", err))
+		return diag.FromErr(flex.FmtErrorf("[ERROR] Error setting health_state: %s", err))
 	}
 	if vpnServer.HealthReasons != nil {
 		if err := d.Set("health_reasons", resourceVPNServerFlattenHealthReasons(vpnServer.HealthReasons)); err != nil {
-			return diag.FromErr(fmt.Errorf("[ERROR] Error setting health_reasons: %s", err))
+			return diag.FromErr(flex.FmtErrorf("[ERROR] Error setting health_reasons: %s", err))
 		}
 	}
 	if err = d.Set("hostname", vpnServer.Hostname); err != nil {
-		return diag.FromErr(fmt.Errorf("[ERROR] Error setting hostname: %s", err))
+		return diag.FromErr(flex.FmtErrorf("[ERROR] Error setting hostname: %s", err))
 	}
 	if err = d.Set("href", vpnServer.Href); err != nil {
-		return diag.FromErr(fmt.Errorf("[ERROR] Error setting href: %s", err))
+		return diag.FromErr(flex.FmtErrorf("[ERROR] Error setting href: %s", err))
 	}
 	if err = d.Set("lifecycle_state", vpnServer.LifecycleState); err != nil {
-		return diag.FromErr(fmt.Errorf("[ERROR] Error setting lifecycle_state: %s", err))
+		return diag.FromErr(flex.FmtErrorf("[ERROR] Error setting lifecycle_state: %s", err))
 	}
 	if vpnServer.LifecycleReasons != nil {
 		if err := d.Set("lifecycle_reasons", resourceVPNServerFlattenLifecycleReasons(vpnServer.LifecycleReasons)); err != nil {
-			return diag.FromErr(fmt.Errorf("[ERROR] Error setting lifecycle_reasons: %s", err))
+			return diag.FromErr(flex.FmtErrorf("[ERROR] Error setting lifecycle_reasons: %s", err))
 		}
 	}
 	if err = d.Set("name", vpnServer.Name); err != nil {
-		return diag.FromErr(fmt.Errorf("[ERROR] Error setting name: %s", err))
+		return diag.FromErr(flex.FmtErrorf("[ERROR] Error setting name: %s", err))
 	}
 	if err = d.Set("port", flex.IntValue(vpnServer.Port)); err != nil {
-		return diag.FromErr(fmt.Errorf("[ERROR] Error setting port: %s", err))
+		return diag.FromErr(flex.FmtErrorf("[ERROR] Error setting port: %s", err))
 	}
 
 	if vpnServer.PrivateIps != nil {
 		err = d.Set("private_ips", dataSourceVPNServerFlattenPrivateIps(vpnServer.PrivateIps))
 		if err != nil {
-			return diag.FromErr(fmt.Errorf("[ERROR] Error setting private_ips %s", err))
+			return diag.FromErr(flex.FmtErrorf("[ERROR] Error setting private_ips %s", err))
 		}
 	}
 	if err = d.Set("protocol", vpnServer.Protocol); err != nil {
-		return diag.FromErr(fmt.Errorf("[ERROR] Error setting protocol: %s", err))
+		return diag.FromErr(flex.FmtErrorf("[ERROR] Error setting protocol: %s", err))
 	}
 
 	if vpnServer.ResourceGroup != nil {
 		err = d.Set("resource_group", dataSourceVPNServerFlattenResourceGroup(*vpnServer.ResourceGroup))
 		if err != nil {
-			return diag.FromErr(fmt.Errorf("[ERROR] Error setting resource_group %s", err))
+			return diag.FromErr(flex.FmtErrorf("[ERROR] Error setting resource_group %s", err))
 		}
 	}
 	if err = d.Set("resource_type", vpnServer.ResourceType); err != nil {
-		return diag.FromErr(fmt.Errorf("[ERROR] Error setting resource_type: %s", err))
+		return diag.FromErr(flex.FmtErrorf("[ERROR] Error setting resource_type: %s", err))
 	}
 
 	if vpnServer.SecurityGroups != nil {
 		err = d.Set("security_groups", dataSourceVPNServerFlattenSecurityGroups(vpnServer.SecurityGroups))
 		if err != nil {
-			return diag.FromErr(fmt.Errorf("[ERROR] Error setting security_groups %s", err))
+			return diag.FromErr(flex.FmtErrorf("[ERROR] Error setting security_groups %s", err))
 		}
 	}
 
 	if vpnServer.Subnets != nil {
 		err = d.Set("subnets", dataSourceVPNServerFlattenSubnets(vpnServer.Subnets))
 		if err != nil {
-			return diag.FromErr(fmt.Errorf("[ERROR] Error setting subnets %s", err))
+			return diag.FromErr(flex.FmtErrorf("[ERROR] Error setting subnets %s", err))
 		}
 	}
 
 	if vpnServer.VPC != nil {
 		err = d.Set("vpc", dataSourceVPNServerFlattenVpcReference(vpnServer.VPC))
 		if err != nil {
-			return diag.FromErr(fmt.Errorf("[ERROR] Error setting the vpc: %s", err))
+			return diag.FromErr(flex.FmtErrorf("[ERROR] Error setting the vpc: %s", err))
 		}
 	}
 

--- a/ibm/service/vpc/data_source_ibm_is_vpn_server_client.go
+++ b/ibm/service/vpc/data_source_ibm_is_vpn_server_client.go
@@ -5,7 +5,6 @@ package vpc
 
 import (
 	"context"
-	"fmt"
 	"log"
 
 	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/flex"
@@ -116,7 +115,7 @@ func dataSourceIBMIsVPNServerClientRead(context context.Context, d *schema.Resou
 	vpnServerClient, response, err := sess.GetVPNServerClientWithContext(context, getVPNServerClientOptions)
 	if err != nil {
 		log.Printf("[DEBUG] GetVPNServerClientWithContext failed %s\n%s", err, response)
-		return diag.FromErr(fmt.Errorf("[ERROR] GetVPNServerClientWithContext failed %s\n%s", err, response))
+		return diag.FromErr(flex.FmtErrorf("[ERROR] GetVPNServerClientWithContext failed %s\n%s", err, response))
 	}
 
 	d.SetId(*vpnServerClient.ID)
@@ -124,39 +123,39 @@ func dataSourceIBMIsVPNServerClientRead(context context.Context, d *schema.Resou
 	if vpnServerClient.ClientIP != nil {
 		err = d.Set("client_ip", dataSourceVPNServerClientFlattenClientIP(*vpnServerClient.ClientIP))
 		if err != nil {
-			return diag.FromErr(fmt.Errorf("[ERROR] Error setting client_ip %s", err))
+			return diag.FromErr(flex.FmtErrorf("[ERROR] Error setting client_ip %s", err))
 		}
 	}
 	if err = d.Set("common_name", vpnServerClient.CommonName); err != nil {
-		return diag.FromErr(fmt.Errorf("[ERROR] Error setting common_name: %s", err))
+		return diag.FromErr(flex.FmtErrorf("[ERROR] Error setting common_name: %s", err))
 	}
 	if err = d.Set("created_at", flex.DateTimeToString(vpnServerClient.CreatedAt)); err != nil {
-		return diag.FromErr(fmt.Errorf("[ERROR] Error setting created_at: %s", err))
+		return diag.FromErr(flex.FmtErrorf("[ERROR] Error setting created_at: %s", err))
 	}
 	if err = d.Set("disconnected_at", flex.DateTimeToString(vpnServerClient.DisconnectedAt)); err != nil {
-		return diag.FromErr(fmt.Errorf("[ERROR] Error setting disconnected_at: %s", err))
+		return diag.FromErr(flex.FmtErrorf("[ERROR] Error setting disconnected_at: %s", err))
 	}
 	if err = d.Set("href", vpnServerClient.Href); err != nil {
-		return diag.FromErr(fmt.Errorf("[ERROR] Error setting href: %s", err))
+		return diag.FromErr(flex.FmtErrorf("[ERROR] Error setting href: %s", err))
 	}
 
 	if vpnServerClient.RemoteIP != nil {
 		err = d.Set("remote_ip", dataSourceVPNServerClientFlattenRemoteIP(*vpnServerClient.RemoteIP))
 		if err != nil {
-			return diag.FromErr(fmt.Errorf("[ERROR] Error setting remote_ip %s", err))
+			return diag.FromErr(flex.FmtErrorf("[ERROR] Error setting remote_ip %s", err))
 		}
 	}
 	if err = d.Set("remote_port", flex.IntValue(vpnServerClient.RemotePort)); err != nil {
-		return diag.FromErr(fmt.Errorf("[ERROR] Error setting remote_port: %s", err))
+		return diag.FromErr(flex.FmtErrorf("[ERROR] Error setting remote_port: %s", err))
 	}
 	if err = d.Set("resource_type", vpnServerClient.ResourceType); err != nil {
-		return diag.FromErr(fmt.Errorf("[ERROR] Error setting resource_type: %s", err))
+		return diag.FromErr(flex.FmtErrorf("[ERROR] Error setting resource_type: %s", err))
 	}
 	if err = d.Set("status", vpnServerClient.Status); err != nil {
-		return diag.FromErr(fmt.Errorf("[ERROR] Error setting status: %s", err))
+		return diag.FromErr(flex.FmtErrorf("[ERROR] Error setting status: %s", err))
 	}
 	if err = d.Set("username", vpnServerClient.Username); err != nil {
-		return diag.FromErr(fmt.Errorf("[ERROR] Error setting username: %s", err))
+		return diag.FromErr(flex.FmtErrorf("[ERROR] Error setting username: %s", err))
 	}
 
 	return nil

--- a/ibm/service/vpc/data_source_ibm_is_vpn_server_client_config.go
+++ b/ibm/service/vpc/data_source_ibm_is_vpn_server_client_config.go
@@ -5,11 +5,11 @@ package vpc
 
 import (
 	"context"
-	"fmt"
 	"log"
 	"os"
 	"strings"
 
+	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/flex"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 
@@ -54,7 +54,7 @@ func dataSourceIBMIsVPNServerClientConfigurationRead(context context.Context, d 
 	result, response, err := sess.GetVPNServerClientConfigurationWithContext(context, getVPNServerClientConfigurationOptions)
 	if err != nil {
 		log.Printf("[DEBUG] GetVPNServerClientWithContext failed %s\n%s", err, response)
-		return diag.FromErr(fmt.Errorf("[ERROR] GetVPNServerClientWithContext failed %s\n%s", err, response))
+		return diag.FromErr(flex.FmtErrorf("[ERROR] GetVPNServerClientWithContext failed %s\n%s", err, response))
 	}
 
 	d.SetId(d.Get("vpn_server").(string))
@@ -70,14 +70,14 @@ func dataSourceIBMIsVPNServerClientConfigurationRead(context context.Context, d 
 			_, err = f.WriteString(configStr)
 		}
 		if err != nil {
-			return diag.FromErr(fmt.Errorf("[ERROR] Error Saving VPNServerClientConfiguration Result: %s", err))
+			return diag.FromErr(flex.FmtErrorf("[ERROR] Error Saving VPNServerClientConfiguration Result: %s", err))
 
 		}
 		log.Printf("OpenVPN client configuration was saved to {{.%s}}", fileName)
 	}
 
 	if err = d.Set("vpn_server_client_configuration", *result); err != nil {
-		return diag.FromErr(fmt.Errorf("[ERROR] Error setting VPNServerClientConfiguration Result: %s", err))
+		return diag.FromErr(flex.FmtErrorf("[ERROR] Error setting VPNServerClientConfiguration Result: %s", err))
 	}
 	return nil
 }

--- a/ibm/service/vpc/data_source_ibm_is_vpn_server_clients.go
+++ b/ibm/service/vpc/data_source_ibm_is_vpn_server_clients.go
@@ -5,7 +5,6 @@ package vpc
 
 import (
 	"context"
-	"fmt"
 	"log"
 	"time"
 
@@ -130,7 +129,7 @@ func dataSourceIBMIsVPNServerClientsRead(context context.Context, d *schema.Reso
 		vpnServerClientCollection, response, err := sess.ListVPNServerClientsWithContext(context, listVPNServerClientsOptions)
 		if err != nil {
 			log.Printf("[DEBUG] ListVPNServerClientsWithContext failed %s\n%s", err, response)
-			return diag.FromErr(fmt.Errorf("[ERROR] ListVPNServerClientsWithContext failed %s\n%s", err, response))
+			return diag.FromErr(flex.FmtErrorf("[ERROR] ListVPNServerClientsWithContext failed %s\n%s", err, response))
 		}
 		start = flex.GetNext(vpnServerClientCollection.Next)
 		allrecs = append(allrecs, vpnServerClientCollection.Clients...)
@@ -144,7 +143,7 @@ func dataSourceIBMIsVPNServerClientsRead(context context.Context, d *schema.Reso
 	if allrecs != nil {
 		err = d.Set("clients", dataSourceVPNServerClientCollectionFlattenClients(allrecs))
 		if err != nil {
-			return diag.FromErr(fmt.Errorf("[ERROR] Error setting clients %s", err))
+			return diag.FromErr(flex.FmtErrorf("[ERROR] Error setting clients %s", err))
 		}
 	}
 	return nil

--- a/ibm/service/vpc/data_source_ibm_is_vpn_server_route.go
+++ b/ibm/service/vpc/data_source_ibm_is_vpn_server_route.go
@@ -149,7 +149,7 @@ func dataSourceIBMIsVPNServerRouteRead(context context.Context, d *schema.Resour
 		vpnServerRouteInfo, response, err := sess.GetVPNServerRouteWithContext(context, getVPNServerRouteOptions)
 		if err != nil {
 			log.Printf("[DEBUG] GetVPNServerRouteWithContext failed %s\n%s", err, response)
-			return diag.FromErr(fmt.Errorf("[ERROR] GetVPNServerRouteWithContext failed %s\n%s", err, response))
+			return diag.FromErr(flex.FmtErrorf("[ERROR] GetVPNServerRouteWithContext failed %s\n%s", err, response))
 		}
 		vpnServerRoute = vpnServerRouteInfo
 	} else if v, ok := d.GetOk("name"); ok {
@@ -168,7 +168,7 @@ func dataSourceIBMIsVPNServerRouteRead(context context.Context, d *schema.Resour
 			vpnServerRouteCollection, response, err := sess.ListVPNServerRoutesWithContext(context, listVPNServerRoutesOptions)
 			if err != nil {
 				log.Printf("[DEBUG] ListVPNServerRoutesWithContext failed %s\n%s", err, response)
-				return diag.FromErr(fmt.Errorf("[ERROR] ListVPNServerRoutesWithContext failed %s\n%s", err, response))
+				return diag.FromErr(flex.FmtErrorf("[ERROR] ListVPNServerRoutesWithContext failed %s\n%s", err, response))
 			}
 			start = flex.GetNext(vpnServerRouteCollection.Next)
 			allrecs = append(allrecs, vpnServerRouteCollection.Routes...)
@@ -185,52 +185,52 @@ func dataSourceIBMIsVPNServerRouteRead(context context.Context, d *schema.Resour
 		}
 		if vpnServerRoute == nil {
 			log.Printf("[DEBUG] No vpnServer route found with name %s", name)
-			return diag.FromErr(fmt.Errorf("[ERROR] No vpn server route found with name %s", name))
+			return diag.FromErr(flex.FmtErrorf("[ERROR] No vpn server route found with name %s", name))
 		}
 	}
 
 	d.SetId(fmt.Sprintf("%s/%s", d.Get("vpn_server").(string), *vpnServerRoute.ID))
 
 	if err = d.Set("vpn_server", d.Get("vpn_server").(string)); err != nil {
-		return diag.FromErr(fmt.Errorf("[ERROR] Error setting vpn_server: %s", err))
+		return diag.FromErr(flex.FmtErrorf("[ERROR] Error setting vpn_server: %s", err))
 	}
 
 	if err = d.Set("identifier", *vpnServerRoute.ID); err != nil {
-		return diag.FromErr(fmt.Errorf("[ERROR] Error setting identifier: %s", err))
+		return diag.FromErr(flex.FmtErrorf("[ERROR] Error setting identifier: %s", err))
 	}
 	if err = d.Set("action", vpnServerRoute.Action); err != nil {
-		return diag.FromErr(fmt.Errorf("[ERROR] Error setting action: %s", err))
+		return diag.FromErr(flex.FmtErrorf("[ERROR] Error setting action: %s", err))
 	}
 	if err = d.Set("created_at", flex.DateTimeToString(vpnServerRoute.CreatedAt)); err != nil {
-		return diag.FromErr(fmt.Errorf("[ERROR] Error setting created_at: %s", err))
+		return diag.FromErr(flex.FmtErrorf("[ERROR] Error setting created_at: %s", err))
 	}
 	if err = d.Set("destination", vpnServerRoute.Destination); err != nil {
-		return diag.FromErr(fmt.Errorf("[ERROR] Error setting destination: %s", err))
+		return diag.FromErr(flex.FmtErrorf("[ERROR] Error setting destination: %s", err))
 	}
 	if err = d.Set("href", vpnServerRoute.Href); err != nil {
-		return diag.FromErr(fmt.Errorf("[ERROR] Error setting href: %s", err))
+		return diag.FromErr(flex.FmtErrorf("[ERROR] Error setting href: %s", err))
 	}
 	if err = d.Set("health_state", vpnServerRoute.HealthState); err != nil {
-		return diag.FromErr(fmt.Errorf("[ERROR] Error setting health_state: %s", err))
+		return diag.FromErr(flex.FmtErrorf("[ERROR] Error setting health_state: %s", err))
 	}
 	if vpnServerRoute.HealthReasons != nil {
 		if err := d.Set("health_reasons", resourceVPNServerRouteFlattenHealthReasons(vpnServerRoute.HealthReasons)); err != nil {
-			return diag.FromErr(fmt.Errorf("[ERROR] Error setting health_reasons: %s", err))
+			return diag.FromErr(flex.FmtErrorf("[ERROR] Error setting health_reasons: %s", err))
 		}
 	}
 	if err = d.Set("lifecycle_state", vpnServerRoute.LifecycleState); err != nil {
-		return diag.FromErr(fmt.Errorf("[ERROR] Error setting lifecycle_state: %s", err))
+		return diag.FromErr(flex.FmtErrorf("[ERROR] Error setting lifecycle_state: %s", err))
 	}
 	if vpnServerRoute.LifecycleReasons != nil {
 		if err := d.Set("lifecycle_reasons", resourceVPNServerRouteFlattenLifecycleReasons(vpnServerRoute.LifecycleReasons)); err != nil {
-			return diag.FromErr(fmt.Errorf("[ERROR] Error setting lifecycle_reasons: %s", err))
+			return diag.FromErr(flex.FmtErrorf("[ERROR] Error setting lifecycle_reasons: %s", err))
 		}
 	}
 	if err = d.Set("name", vpnServerRoute.Name); err != nil {
-		return diag.FromErr(fmt.Errorf("[ERROR] Error setting name: %s", err))
+		return diag.FromErr(flex.FmtErrorf("[ERROR] Error setting name: %s", err))
 	}
 	if err = d.Set("resource_type", vpnServerRoute.ResourceType); err != nil {
-		return diag.FromErr(fmt.Errorf("[ERROR] Error setting resource_type: %s", err))
+		return diag.FromErr(flex.FmtErrorf("[ERROR] Error setting resource_type: %s", err))
 	}
 
 	return nil

--- a/ibm/service/vpc/data_source_ibm_is_vpn_server_routes.go
+++ b/ibm/service/vpc/data_source_ibm_is_vpn_server_routes.go
@@ -5,7 +5,6 @@ package vpc
 
 import (
 	"context"
-	"fmt"
 	"log"
 	"time"
 
@@ -154,7 +153,7 @@ func dataSourceIBMIsVPNServerRoutesRead(context context.Context, d *schema.Resou
 		vpnServerRouteCollection, response, err := sess.ListVPNServerRoutesWithContext(context, listVPNServerRoutesOptions)
 		if err != nil {
 			log.Printf("[DEBUG] ListVPNServerRoutesWithContext failed %s\n%s", err, response)
-			return diag.FromErr(fmt.Errorf("[ERROR] ListVPNServerRoutesWithContext failed %s\n%s", err, response))
+			return diag.FromErr(flex.FmtErrorf("[ERROR] ListVPNServerRoutesWithContext failed %s\n%s", err, response))
 		}
 		start = flex.GetNext(vpnServerRouteCollection.Next)
 		allrecs = append(allrecs, vpnServerRouteCollection.Routes...)
@@ -168,7 +167,7 @@ func dataSourceIBMIsVPNServerRoutesRead(context context.Context, d *schema.Resou
 	if allrecs != nil {
 		err = d.Set("routes", dataSourceVPNServerRouteCollectionFlattenRoutes(allrecs))
 		if err != nil {
-			return diag.FromErr(fmt.Errorf("[ERROR] Error setting routes %s", err))
+			return diag.FromErr(flex.FmtErrorf("[ERROR] Error setting routes %s", err))
 		}
 	}
 

--- a/ibm/service/vpc/data_source_ibm_is_vpn_servers.go
+++ b/ibm/service/vpc/data_source_ibm_is_vpn_servers.go
@@ -5,7 +5,6 @@ package vpc
 
 import (
 	"context"
-	"fmt"
 	"log"
 	"time"
 
@@ -459,7 +458,7 @@ func dataSourceIBMIsVPNServersRead(context context.Context, d *schema.ResourceDa
 		vpnServerCollection, response, err := sess.ListVPNServersWithContext(context, listVPNServersOptions)
 		if err != nil {
 			log.Printf("[DEBUG] ListVPNServersWithContext failed %s\n%s", err, response)
-			return diag.FromErr(fmt.Errorf("[ERROR] ListVPNServersWithContext failed %s\n%s", err, response))
+			return diag.FromErr(flex.FmtErrorf("[ERROR] ListVPNServersWithContext failed %s\n%s", err, response))
 		}
 		start = flex.GetNext(vpnServerCollection.Next)
 		allrecs = append(allrecs, vpnServerCollection.VPNServers...)
@@ -473,7 +472,7 @@ func dataSourceIBMIsVPNServersRead(context context.Context, d *schema.ResourceDa
 	if allrecs != nil {
 		err = d.Set("vpn_servers", dataSourceVPNServerCollectionFlattenVPNServers(allrecs, meta))
 		if err != nil {
-			return diag.FromErr(fmt.Errorf("[ERROR] Error setting vpn_servers %s", err))
+			return diag.FromErr(flex.FmtErrorf("[ERROR] Error setting vpn_servers %s", err))
 		}
 	}
 

--- a/ibm/service/vpc/resource_ibm_is_backup_policy.go
+++ b/ibm/service/vpc/resource_ibm_is_backup_policy.go
@@ -5,7 +5,6 @@ package vpc
 
 import (
 	"context"
-	"fmt"
 	"log"
 
 	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/flex"
@@ -259,7 +258,7 @@ func resourceIBMIsBackupPolicyCreate(context context.Context, d *schema.Resource
 	backupPolicyIntf, response, err := vpcClient.CreateBackupPolicyWithContext(context, createBackupPolicyOptions)
 	if err != nil {
 		log.Printf("[DEBUG] CreateBackupPolicyWithContext failed %s\n%s", err, response)
-		return diag.FromErr(fmt.Errorf("[ERROR] CreateBackupPolicyWithContext failed %s\n%s", err, response))
+		return diag.FromErr(flex.FmtErrorf("[ERROR] CreateBackupPolicyWithContext failed %s\n%s", err, response))
 	}
 
 	backupPolicy := backupPolicyIntf.(*vpcv1.BackupPolicy)
@@ -285,7 +284,7 @@ func resourceIBMIsBackupPolicyRead(context context.Context, d *schema.ResourceDa
 			return nil
 		}
 		log.Printf("[DEBUG] GetBackupPolicyWithContext failed %s\n%s", err, response)
-		return diag.FromErr(fmt.Errorf("[ERROR] GetBackupPolicyWithContext failed %s\n%s", err, response))
+		return diag.FromErr(flex.FmtErrorf("[ERROR] GetBackupPolicyWithContext failed %s\n%s", err, response))
 	}
 	backupPolicy := backupPolicyIntf.(*vpcv1.BackupPolicy)
 
@@ -293,67 +292,67 @@ func resourceIBMIsBackupPolicyRead(context context.Context, d *schema.ResourceDa
 		matchResourceTypes := *backupPolicy.MatchResourceType
 		matchResourceTypesList := []string{matchResourceTypes}
 		if err = d.Set("match_resource_types", matchResourceTypesList); err != nil {
-			return diag.FromErr(fmt.Errorf("[ERROR] Error setting match_resource_types: %s", err))
+			return diag.FromErr(flex.FmtErrorf("[ERROR] Error setting match_resource_types: %s", err))
 		}
 		if err = d.Set("match_resource_type", backupPolicy.MatchResourceType); err != nil {
-			return diag.FromErr(fmt.Errorf("[ERROR] Error setting match_resource_type: %s", err))
+			return diag.FromErr(flex.FmtErrorf("[ERROR] Error setting match_resource_type: %s", err))
 		}
 	}
 	if backupPolicy.IncludedContent != nil {
 		if err = d.Set("included_content", backupPolicy.IncludedContent); err != nil {
-			return diag.FromErr(fmt.Errorf("[ERROR] Error setting included_content: %s", err))
+			return diag.FromErr(flex.FmtErrorf("[ERROR] Error setting included_content: %s", err))
 		}
 	}
 
 	if backupPolicy.MatchUserTags != nil {
 		if err = d.Set("match_user_tags", backupPolicy.MatchUserTags); err != nil {
-			return diag.FromErr(fmt.Errorf("[ERROR] Error setting match_user_tags: %s", err))
+			return diag.FromErr(flex.FmtErrorf("[ERROR] Error setting match_user_tags: %s", err))
 		}
 	}
 	if backupPolicy.Name != nil {
 		if err = d.Set("name", backupPolicy.Name); err != nil {
-			return diag.FromErr(fmt.Errorf("[ERROR] Error setting name: %s", err))
+			return diag.FromErr(flex.FmtErrorf("[ERROR] Error setting name: %s", err))
 		}
 	}
 	if backupPolicy.ResourceGroup != nil {
 		resourceGroupID := *backupPolicy.ResourceGroup.ID
 		if err = d.Set("resource_group", resourceGroupID); err != nil {
-			return diag.FromErr(fmt.Errorf("[ERROR] Error setting resource_group: %s", err))
+			return diag.FromErr(flex.FmtErrorf("[ERROR] Error setting resource_group: %s", err))
 		}
 	}
 	if backupPolicy.CreatedAt != nil {
 		if err = d.Set("created_at", flex.DateTimeToString(backupPolicy.CreatedAt)); err != nil {
-			return diag.FromErr(fmt.Errorf("[ERROR] Error setting created_at: %s", err))
+			return diag.FromErr(flex.FmtErrorf("[ERROR] Error setting created_at: %s", err))
 		}
 	}
 
 	if backupPolicy.CRN != nil {
 		if err = d.Set("crn", backupPolicy.CRN); err != nil {
-			return diag.FromErr(fmt.Errorf("[ERROR] Error setting crn: %s", err))
+			return diag.FromErr(flex.FmtErrorf("[ERROR] Error setting crn: %s", err))
 		}
 	}
 
 	if backupPolicy.Href != nil {
 		if err = d.Set("href", backupPolicy.Href); err != nil {
-			return diag.FromErr(fmt.Errorf("[ERROR] Error setting href: %s", err))
+			return diag.FromErr(flex.FmtErrorf("[ERROR] Error setting href: %s", err))
 		}
 	}
 
 	if backupPolicy.LastJobCompletedAt != nil {
 		if err = d.Set("last_job_completed_at", flex.DateTimeToString(backupPolicy.LastJobCompletedAt)); err != nil {
-			return diag.FromErr(fmt.Errorf("[ERROR] Error setting last_job_completed_at: %s", err))
+			return diag.FromErr(flex.FmtErrorf("[ERROR] Error setting last_job_completed_at: %s", err))
 		}
 	}
 
 	if backupPolicy.LifecycleState != nil {
 		if err = d.Set("lifecycle_state", backupPolicy.LifecycleState); err != nil {
-			return diag.FromErr(fmt.Errorf("[ERROR] Error setting lifecycle_state: %s", err))
+			return diag.FromErr(flex.FmtErrorf("[ERROR] Error setting lifecycle_state: %s", err))
 		}
 	}
 
 	if backupPolicy.ResourceType != nil {
 		if err = d.Set("resource_type", backupPolicy.ResourceType); err != nil {
-			return diag.FromErr(fmt.Errorf("[ERROR] Error setting resource_type: %s", err))
+			return diag.FromErr(flex.FmtErrorf("[ERROR] Error setting resource_type: %s", err))
 		}
 	}
 
@@ -373,7 +372,7 @@ func resourceIBMIsBackupPolicyRead(context context.Context, d *schema.ResourceDa
 		d.Set("health_reasons", healthReasonsList)
 	}
 	if err = d.Set("health_state", backupPolicy.HealthState); err != nil {
-		return diag.FromErr(fmt.Errorf("[ERROR] Error setting health_state: %s", err))
+		return diag.FromErr(flex.FmtErrorf("[ERROR] Error setting health_state: %s", err))
 	}
 
 	if backupPolicy.Scope != nil {
@@ -382,12 +381,12 @@ func resourceIBMIsBackupPolicyRead(context context.Context, d *schema.ResourceDa
 		scope = append(scope, scopeMap)
 
 		if err = d.Set("scope", scope); err != nil {
-			return diag.FromErr(fmt.Errorf("[ERROR] Error setting scope: %s", err))
+			return diag.FromErr(flex.FmtErrorf("[ERROR] Error setting scope: %s", err))
 		}
 	}
 
 	if err = d.Set("version", response.Headers.Get("Etag")); err != nil {
-		return diag.FromErr(fmt.Errorf("[ERROR] Error setting version: %s", err))
+		return diag.FromErr(flex.FmtErrorf("[ERROR] Error setting version: %s", err))
 	}
 
 	return nil
@@ -430,7 +429,7 @@ func resourceIBMIsBackupPolicyUpdate(context context.Context, d *schema.Resource
 		_, response, err := vpcClient.UpdateBackupPolicyWithContext(context, updateBackupPolicyOptions)
 		if err != nil {
 			log.Printf("[DEBUG] UpdateBackupPolicyWithContext failed %s\n%s", err, response)
-			return diag.FromErr(fmt.Errorf("[ERROR] UpdateBackupPolicyWithContext failed %s\n%s", err, response))
+			return diag.FromErr(flex.FmtErrorf("[ERROR] UpdateBackupPolicyWithContext failed %s\n%s", err, response))
 		}
 	}
 
@@ -448,7 +447,7 @@ func resourceIBMIsBackupPolicyDelete(context context.Context, d *schema.Resource
 	_, response, err := vpcClient.DeleteBackupPolicyWithContext(context, deleteBackupPolicyOptions)
 	if err != nil {
 		log.Printf("[DEBUG] DeleteBackupPolicyWithContext failed %s\n%s", err, response)
-		return diag.FromErr(fmt.Errorf("[ERROR] DeleteBackupPolicyWithContext failed %s\n%s", err, response))
+		return diag.FromErr(flex.FmtErrorf("[ERROR] DeleteBackupPolicyWithContext failed %s\n%s", err, response))
 	}
 	d.SetId("")
 	return nil

--- a/ibm/service/vpc/resource_ibm_is_backup_policy_plan.go
+++ b/ibm/service/vpc/resource_ibm_is_backup_policy_plan.go
@@ -258,13 +258,13 @@ func resourceIBMIsBackupPolicyPlanCreate(context context.Context, d *schema.Reso
 			if deleteOverCountString != "" && deleteOverCountString != "null" {
 				deleteOverCount, err := strconv.ParseInt(backupPolicyPlanDeletionTriggerPrototypeMap["delete_over_count"].(string), 10, 64)
 				if err != nil {
-					return diag.FromErr(fmt.Errorf("[ERROR] Error setting delete_over_count: %s", err))
+					return diag.FromErr(flex.FmtErrorf("[ERROR] Error setting delete_over_count: %s", err))
 				}
 				deleteOverCountint := int64(deleteOverCount)
 				if deleteOverCountint >= int64(0) {
 					backupPolicyPlanDeletionTriggerPrototype.DeleteOverCount = core.Int64Ptr(deleteOverCountint)
 				} else {
-					return diag.FromErr(fmt.Errorf("[ERROR] Error setting delete_over_count: Retention count and days cannot be both zero"))
+					return diag.FromErr(flex.FmtErrorf("[ERROR] Error setting delete_over_count: Retention count and days cannot be both zero"))
 				}
 			}
 		}
@@ -289,7 +289,7 @@ func resourceIBMIsBackupPolicyPlanCreate(context context.Context, d *schema.Reso
 	backupPolicyPlan, response, err := vpcClient.CreateBackupPolicyPlanWithContext(context, createBackupPolicyPlanOptions)
 	if err != nil {
 		log.Printf("[DEBUG] CreateBackupPolicyPlanWithContext failed %s\n%s", err, response)
-		return diag.FromErr(fmt.Errorf("[ERROR] CreateBackupPolicyPlanWithContext failed %s\n%s", err, response))
+		return diag.FromErr(flex.FmtErrorf("[ERROR] CreateBackupPolicyPlanWithContext failed %s\n%s", err, response))
 	}
 
 	d.SetId(fmt.Sprintf("%s/%s", *createBackupPolicyPlanOptions.BackupPolicyID, *backupPolicyPlan.ID))
@@ -320,30 +320,30 @@ func resourceIBMIsBackupPolicyPlanRead(context context.Context, d *schema.Resour
 			return nil
 		}
 		log.Printf("[DEBUG] GetBackupPolicyPlanWithContext failed %s\n%s", err, response)
-		return diag.FromErr(fmt.Errorf("[ERROR] GetBackupPolicyPlanWithContext failed %s\n%s", err, response))
+		return diag.FromErr(flex.FmtErrorf("[ERROR] GetBackupPolicyPlanWithContext failed %s\n%s", err, response))
 	}
 
 	if getBackupPolicyPlanOptions.BackupPolicyID != nil {
 		if err = d.Set("backup_policy_id", getBackupPolicyPlanOptions.BackupPolicyID); err != nil {
-			return diag.FromErr(fmt.Errorf("[ERROR] Error setting backup_policy_id: %s", err))
+			return diag.FromErr(flex.FmtErrorf("[ERROR] Error setting backup_policy_id: %s", err))
 		}
 	}
 
 	if getBackupPolicyPlanOptions.ID != nil {
 		if err = d.Set("backup_policy_plan_id", getBackupPolicyPlanOptions.ID); err != nil {
-			return diag.FromErr(fmt.Errorf("[ERROR] Error setting backup_policy_plan_id: %s", err))
+			return diag.FromErr(flex.FmtErrorf("[ERROR] Error setting backup_policy_plan_id: %s", err))
 		}
 	}
 
 	if backupPolicyPlan.CronSpec != nil {
 		if err = d.Set("cron_spec", backupPolicyPlan.CronSpec); err != nil {
-			return diag.FromErr(fmt.Errorf("[ERROR] Error setting cron_spec: %s", err))
+			return diag.FromErr(flex.FmtErrorf("[ERROR] Error setting cron_spec: %s", err))
 		}
 	}
 
 	if backupPolicyPlan.Active != nil {
 		if err = d.Set("active", backupPolicyPlan.Active); err != nil {
-			return diag.FromErr(fmt.Errorf("[ERROR] Error setting active: %s", err))
+			return diag.FromErr(flex.FmtErrorf("[ERROR] Error setting active: %s", err))
 		}
 	}
 
@@ -367,20 +367,20 @@ func resourceIBMIsBackupPolicyPlanRead(context context.Context, d *schema.Resour
 
 	if backupPolicyPlan.AttachUserTags != nil {
 		if err = d.Set("attach_user_tags", backupPolicyPlan.AttachUserTags); err != nil {
-			return diag.FromErr(fmt.Errorf("[ERROR] Error setting attach_user_tags: %s", err))
+			return diag.FromErr(flex.FmtErrorf("[ERROR] Error setting attach_user_tags: %s", err))
 		}
 	}
 
 	if backupPolicyPlan.CopyUserTags != nil {
 		if err = d.Set("copy_user_tags", backupPolicyPlan.CopyUserTags); err != nil {
-			return diag.FromErr(fmt.Errorf("[ERROR] Error setting copy_user_tags: %s", err))
+			return diag.FromErr(flex.FmtErrorf("[ERROR] Error setting copy_user_tags: %s", err))
 		}
 	}
 
 	if backupPolicyPlan.DeletionTrigger != nil {
 		deletionTriggerMap := resourceIBMIsBackupPolicyPlanBackupPolicyPlanDeletionTriggerPrototypeToMap(*backupPolicyPlan.DeletionTrigger)
 		if err = d.Set("deletion_trigger", []map[string]interface{}{deletionTriggerMap}); err != nil {
-			return diag.FromErr(fmt.Errorf("[ERROR] Error setting deletion_trigger: %s", err))
+			return diag.FromErr(flex.FmtErrorf("[ERROR] Error setting deletion_trigger: %s", err))
 		}
 	}
 	if backupPolicyPlan.RemoteRegionPolicies != nil {
@@ -393,32 +393,32 @@ func resourceIBMIsBackupPolicyPlanRead(context context.Context, d *schema.Resour
 			remoteCopyPolicies = append(remoteCopyPolicies, remoteCopyPoliciesItemMap)
 		}
 		if err = d.Set("remote_region_policy", remoteCopyPolicies); err != nil {
-			return diag.FromErr(fmt.Errorf("[ERROR] Error setting remote_region_policy %s", err))
+			return diag.FromErr(flex.FmtErrorf("[ERROR] Error setting remote_region_policy %s", err))
 		}
 	}
 	if backupPolicyPlan.Name != nil {
 		if err = d.Set("name", backupPolicyPlan.Name); err != nil {
-			return diag.FromErr(fmt.Errorf("[ERROR] Error setting name: %s", err))
+			return diag.FromErr(flex.FmtErrorf("[ERROR] Error setting name: %s", err))
 		}
 	}
 
 	if backupPolicyPlan.CreatedAt != nil {
 		if err = d.Set("created_at", flex.DateTimeToString(backupPolicyPlan.CreatedAt)); err != nil {
-			return diag.FromErr(fmt.Errorf("[ERROR] Error setting created_at: %s", err))
+			return diag.FromErr(flex.FmtErrorf("[ERROR] Error setting created_at: %s", err))
 		}
 	}
 
 	if err = d.Set("href", backupPolicyPlan.Href); err != nil {
-		return diag.FromErr(fmt.Errorf("[ERROR] Error setting href: %s", err))
+		return diag.FromErr(flex.FmtErrorf("[ERROR] Error setting href: %s", err))
 	}
 	if err = d.Set("lifecycle_state", backupPolicyPlan.LifecycleState); err != nil {
-		return diag.FromErr(fmt.Errorf("[ERROR] Error setting lifecycle_state: %s", err))
+		return diag.FromErr(flex.FmtErrorf("[ERROR] Error setting lifecycle_state: %s", err))
 	}
 	if err = d.Set("resource_type", backupPolicyPlan.ResourceType); err != nil {
-		return diag.FromErr(fmt.Errorf("[ERROR] Error setting resource_type: %s", err))
+		return diag.FromErr(flex.FmtErrorf("[ERROR] Error setting resource_type: %s", err))
 	}
 	if err = d.Set("version", response.Headers.Get("Etag")); err != nil {
-		return diag.FromErr(fmt.Errorf("[ERROR] Error setting version: %s", err))
+		return diag.FromErr(flex.FmtErrorf("[ERROR] Error setting version: %s", err))
 	}
 
 	return nil
@@ -487,7 +487,7 @@ func resourceIBMIsBackupPolicyPlanUpdate(context context.Context, d *schema.Reso
 			if deleteOverCountString != "" && deleteOverCountString != "null" {
 				deleteOverCount, err := strconv.ParseInt(backupPolicyPlanDeletionTriggerPrototypeMap["delete_over_count"].(string), 10, 64)
 				if err != nil {
-					return diag.FromErr(fmt.Errorf("[ERROR] Error setting delete_over_count: %s", err))
+					return diag.FromErr(flex.FmtErrorf("[ERROR] Error setting delete_over_count: %s", err))
 				}
 				deleteOverCountint := int64(deleteOverCount)
 				if deleteOverCountint >= int64(0) {
@@ -548,7 +548,7 @@ func resourceIBMIsBackupPolicyPlanUpdate(context context.Context, d *schema.Reso
 	if hasChange {
 		backupPolicyPlanPatch, err := patchVals.AsPatch()
 		if err != nil {
-			return diag.FromErr(fmt.Errorf("[ERROR] [ERROR] Error calling asPatch for BackupPolicyPlanPatch: %s", err))
+			return diag.FromErr(flex.FmtErrorf("[ERROR] [ERROR] Error calling asPatch for BackupPolicyPlanPatch: %s", err))
 		}
 
 		if deleteOverCountBool {
@@ -562,7 +562,7 @@ func resourceIBMIsBackupPolicyPlanUpdate(context context.Context, d *schema.Reso
 		_, response, err := vpcClient.UpdateBackupPolicyPlanWithContext(context, updateBackupPolicyPlanOptions)
 		if err != nil {
 			log.Printf("[DEBUG] UpdateBackupPolicyPlanWithContext failed %s\n%s", err, response)
-			return diag.FromErr(fmt.Errorf("[ERROR] UpdateBackupPolicyPlanWithContext failed %s\n%s", err, response))
+			return diag.FromErr(flex.FmtErrorf("[ERROR] UpdateBackupPolicyPlanWithContext failed %s\n%s", err, response))
 		}
 	}
 
@@ -590,7 +590,7 @@ func resourceIBMIsBackupPolicyPlanDelete(context context.Context, d *schema.Reso
 	_, response, err := vpcClient.DeleteBackupPolicyPlanWithContext(context, deleteBackupPolicyPlanOptions)
 	if err != nil {
 		log.Printf("[DEBUG] DeleteBackupPolicyPlanWithContext failed %s\n%s", err, response)
-		return diag.FromErr(fmt.Errorf("[ERROR] DeleteBackupPolicyPlanWithContext failed %s\n%s", err, response))
+		return diag.FromErr(flex.FmtErrorf("[ERROR] DeleteBackupPolicyPlanWithContext failed %s\n%s", err, response))
 	}
 
 	d.SetId("")

--- a/ibm/service/vpc/resource_ibm_is_bare_metal_server.go
+++ b/ibm/service/vpc/resource_ibm_is_bare_metal_server.go
@@ -1856,7 +1856,7 @@ func resourceIBMISBareMetalServerCreate(context context.Context, d *schema.Resou
 	createbmsoptions.BareMetalServerPrototype = options
 	bms, response, err := sess.CreateBareMetalServerWithContext(context, createbmsoptions)
 	if err != nil {
-		return diag.FromErr(fmt.Errorf("[DEBUG] Create bare metal server err %s\n%s", err, response))
+		return diag.FromErr(flex.FmtErrorf("[DEBUG] Create bare metal server err %s\n%s", err, response))
 	}
 	d.SetId(*bms.ID)
 	log.Printf("[INFO] Bare Metal Server : %s", *bms.ID)
@@ -1909,7 +1909,7 @@ func bareMetalServerGet(context context.Context, d *schema.ResourceData, meta in
 			d.SetId("")
 			return nil
 		}
-		return fmt.Errorf("[ERROR] Error getting Bare Metal Server (%s): %s\n%s", id, err, response)
+		return flex.FmtErrorf("[ERROR] Error getting Bare Metal Server (%s): %s\n%s", id, err, response)
 	}
 	d.SetId(*bms.ID)
 	d.Set(isBareMetalServerBandwidth, bms.Bandwidth)
@@ -1932,7 +1932,7 @@ func bareMetalServerGet(context context.Context, d *schema.ResourceData, meta in
 
 	//enable secure boot
 	if err = d.Set(isBareMetalServerEnableSecureBoot, bms.EnableSecureBoot); err != nil {
-		return fmt.Errorf("[ERROR] Error setting enable_secure_boot: %s", err)
+		return flex.FmtErrorf("[ERROR] Error setting enable_secure_boot: %s", err)
 	}
 
 	// tpm
@@ -1942,7 +1942,7 @@ func bareMetalServerGet(context context.Context, d *schema.ResourceData, meta in
 			return (err)
 		}
 		if err = d.Set(isBareMetalServerTrustedPlatformModule, []map[string]interface{}{trustedPlatformModuleMap}); err != nil {
-			return fmt.Errorf("[ERROR] Error setting trusted_platform_module: %s", err)
+			return flex.FmtErrorf("[ERROR] Error setting trusted_platform_module: %s", err)
 		}
 	}
 
@@ -1975,7 +1975,7 @@ func bareMetalServerGet(context context.Context, d *schema.ResourceData, meta in
 			d.SetId("")
 			return nil
 		}
-		return fmt.Errorf("[ERROR] Error getting Bare Metal Server (%s) initialization: %s\n%s", id, err, response)
+		return flex.FmtErrorf("[ERROR] Error getting Bare Metal Server (%s) initialization: %s\n%s", id, err, response)
 	}
 	if bmsinitialization != nil && bmsinitialization.Image.ID != nil {
 		d.Set(isBareMetalServerImage, *bmsinitialization.Image.ID)
@@ -2006,7 +2006,7 @@ func bareMetalServerGet(context context.Context, d *schema.ResourceData, meta in
 		bmsnic, response, err := sess.GetBareMetalServerNetworkInterfaceWithContext(context, getnicoptions)
 
 		if err != nil {
-			return fmt.Errorf("[ERROR] Error getting primary network interface attached to the bare metal server %s\n%s", err, response)
+			return flex.FmtErrorf("[ERROR] Error getting primary network interface attached to the bare metal server %s\n%s", err, response)
 		}
 
 		if bms.PrimaryNetworkInterface.PrimaryIP != nil {
@@ -2037,7 +2037,7 @@ func bareMetalServerGet(context context.Context, d *schema.ResourceData, meta in
 			}
 			bmsRip, response, err := sess.GetSubnetReservedIP(getripoptions)
 			if err != nil {
-				return fmt.Errorf("[ERROR] Error getting network interface reserved ip(%s) attached to the bare metal server primary network interface(%s): %s\n%s", *bms.PrimaryNetworkInterface.PrimaryIP.ID, *bms.PrimaryNetworkInterface.ID, err, response)
+				return flex.FmtErrorf("[ERROR] Error getting network interface reserved ip(%s) attached to the bare metal server primary network interface(%s): %s\n%s", *bms.PrimaryNetworkInterface.PrimaryIP.ID, *bms.PrimaryNetworkInterface.ID, err, response)
 			}
 			currentIP[isBareMetalServerNicIpAutoDelete] = bmsRip.AutoDelete
 		}
@@ -2143,7 +2143,7 @@ func bareMetalServerGet(context context.Context, d *schema.ResourceData, meta in
 				}
 				bmsnicintf, response, err := sess.GetBareMetalServerNetworkInterfaceWithContext(context, getnicoptions)
 				if err != nil {
-					return fmt.Errorf("[ERROR] Error getting network interface(%s) attached to the bare metal server(%s) %s\n%s", nicId, id, err, response)
+					return flex.FmtErrorf("[ERROR] Error getting network interface(%s) attached to the bare metal server(%s) %s\n%s", nicId, id, err, response)
 				}
 				if intfc.PrimaryIP != nil {
 					primaryIpList := make([]map[string]interface{}, 0)
@@ -2166,7 +2166,7 @@ func bareMetalServerGet(context context.Context, d *schema.ResourceData, meta in
 						}
 						bmsRip, response, err := sess.GetSubnetReservedIP(getripoptions)
 						if err != nil {
-							return fmt.Errorf("[ERROR] Error getting network interface reserved ip(%s) attached to the bare metal server network interface(%s): %s\n%s", ripId, nicId, err, response)
+							return flex.FmtErrorf("[ERROR] Error getting network interface reserved ip(%s) attached to the bare metal server network interface(%s): %s\n%s", ripId, nicId, err, response)
 						}
 						if bmsRip.AutoDelete != nil {
 							currentIP[isBareMetalServerNicIpAutoDelete] = *bmsRip.AutoDelete
@@ -2838,7 +2838,7 @@ func bareMetalServerUpdate(context context.Context, d *schema.ResourceData, meta
 					d.SetId("")
 					return nil
 				}
-				return fmt.Errorf("[ERROR] Error getting Bare Metal Server (%s): %s\n%s", id, err, response)
+				return flex.FmtErrorf("[ERROR] Error getting Bare Metal Server (%s): %s\n%s", id, err, response)
 			}
 			bmscrn = *bms.CRN
 		}
@@ -2915,12 +2915,12 @@ func bareMetalServerUpdate(context context.Context, d *schema.ResourceData, meta
 						}
 						networkInterfacePatch, err := bmsPatchModel.AsPatch()
 						if err != nil {
-							return fmt.Errorf("[ERROR] Error calling asPatch for BareMetalServerNetworkInterfacePatch: %s", err)
+							return flex.FmtErrorf("[ERROR] Error calling asPatch for BareMetalServerNetworkInterfacePatch: %s", err)
 						}
 						updatepnicfoptions.BareMetalServerNetworkInterfacePatch = networkInterfacePatch
 						_, response, err := sess.UpdateBareMetalServerNetworkInterface(updatepnicfoptions)
 						if err != nil {
-							return fmt.Errorf("[ERROR] Error while updating network interface(%s) of bar emetal server(%s) \n%s: %q", networkId, d.Id(), err, response)
+							return flex.FmtErrorf("[ERROR] Error while updating network interface(%s) of bar emetal server(%s) \n%s: %q", networkId, d.Id(), err, response)
 						}
 						ns.Remove(nA)
 						os.Remove(oA)
@@ -3355,12 +3355,12 @@ func bareMetalServerUpdate(context context.Context, d *schema.ResourceData, meta
 		// 		}
 		// 		reservedIpPathAsPatch, err := reservedIpPath.AsPatch()
 		// 		if err != nil {
-		// 			return fmt.Errorf("[ERROR] Error calling reserved ip as patch \n%s", err)
+		// 			return flex.FmtErrorf("[ERROR] Error calling reserved ip as patch \n%s", err)
 		// 		}
 		// 		updateripoptions.ReservedIPPatch = reservedIpPathAsPatch
 		// 		_, response, err := sess.UpdateSubnetReservedIP(updateripoptions)
 		// 		if err != nil {
-		// 			return fmt.Errorf("[ERROR] Error updating bare metal server network interface reserved ip(%s): %s\n%s", ripId, err, response)
+		// 			return flex.FmtErrorf("[ERROR] Error updating bare metal server network interface reserved ip(%s): %s\n%s", ripId, err, response)
 		// 		}
 		// 	}
 
@@ -3380,7 +3380,7 @@ func bareMetalServerUpdate(context context.Context, d *schema.ResourceData, meta
 		// 				}
 		// 				_, response, err := sess.CreateSecurityGroupTargetBinding(createsgnicoptions)
 		// 				if err != nil {
-		// 					return fmt.Errorf("[ERROR] Error while creating security group %q for network interface of bare metal server %s\n%s: %q", add[i], d.Id(), err, response)
+		// 					return flex.FmtErrorf("[ERROR] Error while creating security group %q for network interface of bare metal server %s\n%s: %q", add[i], d.Id(), err, response)
 		// 				}
 		// 			}
 
@@ -3395,7 +3395,7 @@ func bareMetalServerUpdate(context context.Context, d *schema.ResourceData, meta
 		// 				}
 		// 				response, err := sess.DeleteSecurityGroupTargetBinding(deletesgnicoptions)
 		// 				if err != nil {
-		// 					return fmt.Errorf("[ERROR] Error while removing security group %q for network interface of instance %s\n%s: %q", remove[i], d.Id(), err, response)
+		// 					return flex.FmtErrorf("[ERROR] Error while removing security group %q for network interface of instance %s\n%s: %q", remove[i], d.Id(), err, response)
 		// 				}
 		// 			}
 		// 		}
@@ -3453,12 +3453,12 @@ func bareMetalServerUpdate(context context.Context, d *schema.ResourceData, meta
 			}
 			reservedIpPathAsPatch, err := reservedIpPath.AsPatch()
 			if err != nil {
-				return fmt.Errorf("[ERROR] Error calling reserved ip as patch \n%s", err)
+				return flex.FmtErrorf("[ERROR] Error calling reserved ip as patch \n%s", err)
 			}
 			updateripoptions.ReservedIPPatch = reservedIpPathAsPatch
 			_, response, err := sess.UpdateSubnetReservedIP(updateripoptions)
 			if err != nil {
-				return fmt.Errorf("[ERROR] Error updating bare metal server primary network interface reserved ip(%s): %s\n%s", ripId, err, response)
+				return flex.FmtErrorf("[ERROR] Error updating bare metal server primary network interface reserved ip(%s): %s\n%s", ripId, err, response)
 			}
 		}
 		bmsNicUpdateOptions := &vpcv1.UpdateBareMetalServerNetworkInterfaceOptions{
@@ -3509,7 +3509,7 @@ func bareMetalServerUpdate(context context.Context, d *schema.ResourceData, meta
 					}
 					_, response, err := sess.CreateSecurityGroupTargetBinding(createsgnicoptions)
 					if err != nil {
-						return fmt.Errorf("[ERROR] Error while creating security group %q for primary network interface of bare metal server %s\n%s: %q", add[i], d.Id(), err, response)
+						return flex.FmtErrorf("[ERROR] Error while creating security group %q for primary network interface of bare metal server %s\n%s: %q", add[i], d.Id(), err, response)
 					}
 					_, err = isWaitForBareMetalServerAvailable(sess, id, d.Timeout(schema.TimeoutUpdate), d)
 					if err != nil {
@@ -3527,7 +3527,7 @@ func bareMetalServerUpdate(context context.Context, d *schema.ResourceData, meta
 					}
 					response, err := sess.DeleteSecurityGroupTargetBinding(deletesgnicoptions)
 					if err != nil {
-						return fmt.Errorf("[ERROR] Error while removing security group %q for primary network interface of bare metal server %s\n%s: %q", remove[i], d.Id(), err, response)
+						return flex.FmtErrorf("[ERROR] Error while removing security group %q for primary network interface of bare metal server %s\n%s: %q", remove[i], d.Id(), err, response)
 					}
 					_, err = isWaitForBareMetalServerAvailable(sess, id, d.Timeout(schema.TimeoutUpdate), d)
 					if err != nil {
@@ -3570,12 +3570,12 @@ func bareMetalServerUpdate(context context.Context, d *schema.ResourceData, meta
 	if flag {
 		bmsPatch, err := bmsPatchModel.AsPatch()
 		if err != nil {
-			return fmt.Errorf("[ERROR] Error calling asPatch for BareMetalServerPatch: %s", err)
+			return flex.FmtErrorf("[ERROR] Error calling asPatch for BareMetalServerPatch: %s", err)
 		}
 		options.BareMetalServerPatch = bmsPatch
 		_, response, err := sess.UpdateBareMetalServerWithContext(context, options)
 		if err != nil {
-			return fmt.Errorf("[ERROR] Error updating Bare Metal Server: %s\n%s", err, response)
+			return flex.FmtErrorf("[ERROR] Error updating Bare Metal Server: %s\n%s", err, response)
 		}
 	}
 
@@ -3631,7 +3631,7 @@ func bareMetalServerDelete(context context.Context, d *schema.ResourceData, meta
 		if response != nil && response.StatusCode == 404 {
 			return nil
 		}
-		return fmt.Errorf("[ERROR] Error Getting Bare Metal Server (%s): %s\n%s", id, err, response)
+		return flex.FmtErrorf("[ERROR] Error Getting Bare Metal Server (%s): %s\n%s", id, err, response)
 	}
 	if *bms.Status == "running" {
 
@@ -3642,7 +3642,7 @@ func bareMetalServerDelete(context context.Context, d *schema.ResourceData, meta
 
 		response, err := sess.StopBareMetalServerWithContext(context, options)
 		if err != nil && response != nil && response.StatusCode != 204 {
-			return fmt.Errorf("[ERROR] Error stopping Bare Metal Server (%s): %s\n%s", id, err, response)
+			return flex.FmtErrorf("[ERROR] Error stopping Bare Metal Server (%s): %s\n%s", id, err, response)
 		}
 		isWaitForBareMetalServerActionStop(sess, d.Timeout(schema.TimeoutDelete), id, d)
 
@@ -3652,7 +3652,7 @@ func bareMetalServerDelete(context context.Context, d *schema.ResourceData, meta
 	}
 	response, err = sess.DeleteBareMetalServerWithContext(context, options)
 	if err != nil {
-		return fmt.Errorf("[ERROR] Error Deleting Bare Metal Server : %s\n%s", err, response)
+		return flex.FmtErrorf("[ERROR] Error Deleting Bare Metal Server : %s\n%s", err, response)
 	}
 	_, err = isWaitForBareMetalServerDeleted(sess, id, d.Timeout(schema.TimeoutDelete))
 	if err != nil {
@@ -3687,10 +3687,10 @@ func isBareMetalServerDeleteRefreshFunc(bmsC *vpcv1.VpcV1, id string) resource.S
 			if response != nil && response.StatusCode == 404 {
 				return bms, isBareMetalServerActionDeleted, nil
 			}
-			return bms, "", fmt.Errorf("[ERROR] Error Getting Bare Metal Server: %s\n%s", err, response)
+			return bms, "", flex.FmtErrorf("[ERROR] Error Getting Bare Metal Server: %s\n%s", err, response)
 		}
 		if *bms.Status == isBareMetalServerStatusFailed {
-			return bms, *bms.Status, fmt.Errorf("[ERROR] The Bare Metal Server (%s) failed to delete: %v", *bms.ID, err)
+			return bms, *bms.Status, flex.FmtErrorf("[ERROR] The Bare Metal Server (%s) failed to delete: %v", *bms.ID, err)
 		}
 		return bms, isBareMetalServerActionDeleting, err
 	}
@@ -3717,7 +3717,7 @@ func isBareMetalServerRefreshFunc(client *vpcv1.VpcV1, id string, d *schema.Reso
 		}
 		bms, response, err := client.GetBareMetalServer(bmsgetoptions)
 		if err != nil {
-			return nil, "", fmt.Errorf("[ERROR] Error getting Bare Metal Server: %s\n%s", err, response)
+			return nil, "", flex.FmtErrorf("[ERROR] Error getting Bare Metal Server: %s\n%s", err, response)
 		}
 		d.Set(isBareMetalServerStatus, *bms.Status)
 
@@ -3753,9 +3753,9 @@ func isBareMetalServerRefreshFunc(client *vpcv1.VpcV1, id string, d *schema.Reso
 
 				out, err := json.MarshalIndent(bmsStatusReason, "", "    ")
 				if err != nil {
-					return bms, *bms.Status, fmt.Errorf("[ERROR] The Bare Metal Server (%s) went into failed state during the operation \n [WARNING] Running terraform apply again will remove the tainted bare metal server and attempt to create the bare metal server again replacing the previous configuration", *bms.ID)
+					return bms, *bms.Status, flex.FmtErrorf("[ERROR] The Bare Metal Server (%s) went into failed state during the operation \n [WARNING] Running terraform apply again will remove the tainted bare metal server and attempt to create the bare metal server again replacing the previous configuration", *bms.ID)
 				}
-				return bms, *bms.Status, fmt.Errorf("[ERROR] Bare Metal Server (%s) went into failed state during the operation \n (%+v) \n [WARNING] Running terraform apply again will remove the tainted Bare Metal Server and attempt to create the Bare Metal Server again replacing the previous configuration", *bms.ID, string(out))
+				return bms, *bms.Status, flex.FmtErrorf("[ERROR] Bare Metal Server (%s) went into failed state during the operation \n (%+v) \n [WARNING] Running terraform apply again will remove the tainted Bare Metal Server and attempt to create the Bare Metal Server again replacing the previous configuration", *bms.ID, string(out))
 			}
 			return bms, *bms.Status, nil
 
@@ -3775,7 +3775,7 @@ func isWaitForBareMetalServerActionStop(bmsC *vpcv1.VpcV1, timeout time.Duration
 			}
 			bms, response, err := bmsC.GetBareMetalServer(getbmsoptions)
 			if err != nil {
-				return nil, "", fmt.Errorf("[ERROR] Error Getting Bare Metal Server: %s\n%s", err, response)
+				return nil, "", flex.FmtErrorf("[ERROR] Error Getting Bare Metal Server: %s\n%s", err, response)
 			}
 			select {
 			case data := <-communicator:
@@ -3786,7 +3786,7 @@ func isWaitForBareMetalServerActionStop(bmsC *vpcv1.VpcV1, timeout time.Duration
 			if *bms.Status == isBareMetalServerStatusFailed {
 				// let know the isRestartStopAction() to stop
 				close(communicator)
-				return bms, *bms.Status, fmt.Errorf("[ERROR] The  Bare Metal Server %s failed to stop: %v", id, err)
+				return bms, *bms.Status, flex.FmtErrorf("[ERROR] The  Bare Metal Server %s failed to stop: %v", id, err)
 			}
 			return bms, *bms.Status, nil
 		},
@@ -3812,7 +3812,7 @@ func isBareMetalServerRestartStopAction(bmsC *vpcv1.VpcV1, id string, d *schema.
 			}
 			response, err := bmsC.StopBareMetalServer(createbmssactoptions)
 			if err != nil {
-				communicator <- fmt.Errorf("[ERROR] Error retrying Bare Metal Server action stop: %s\n%s", err, response)
+				communicator <- flex.FmtErrorf("[ERROR] Error retrying Bare Metal Server action stop: %s\n%s", err, response)
 				return
 			}
 		case <-communicator:
@@ -3833,7 +3833,7 @@ func isBareMetalServerStart(bmsC *vpcv1.VpcV1, id string, d *schema.ResourceData
 		if response != nil && response.StatusCode == 404 {
 			return nil, nil
 		}
-		return nil, fmt.Errorf("[ERROR] Error creating Bare Metal Server action start : %s\n%s", err, response)
+		return nil, flex.FmtErrorf("[ERROR] Error creating Bare Metal Server action start : %s\n%s", err, response)
 	}
 	_, err = isWaitForBareMetalServerAvailable(bmsC, d.Id(), d.Timeout(schema.TimeoutUpdate), d)
 	if err != nil {
@@ -3852,7 +3852,7 @@ func isBareMetalServerStop(bmsC *vpcv1.VpcV1, id string, d *schema.ResourceData,
 		if response != nil && response.StatusCode == 404 {
 			return nil, nil
 		}
-		return nil, fmt.Errorf("[ERROR] Error creating Bare Metal Server Action stop: %s\n%s", err, response)
+		return nil, flex.FmtErrorf("[ERROR] Error creating Bare Metal Server Action stop: %s\n%s", err, response)
 	}
 	_, err = isWaitForBareMetalServerActionStop(bmsC, d.Timeout(schema.TimeoutUpdate), d.Id(), d)
 	if err != nil {
@@ -3869,7 +3869,7 @@ func isBareMetalServerRestart(bmsC *vpcv1.VpcV1, id string, d *schema.ResourceDa
 		if response != nil && response.StatusCode == 404 {
 			return nil, nil
 		}
-		return nil, fmt.Errorf("[ERROR] Error creating Bare Metal Server action restart: %s\n%s", err, response)
+		return nil, flex.FmtErrorf("[ERROR] Error creating Bare Metal Server action restart: %s\n%s", err, response)
 	}
 	_, err = isWaitForBareMetalServerAvailable(bmsC, d.Id(), d.Timeout(schema.TimeoutUpdate), d)
 	if err != nil {
@@ -3897,7 +3897,7 @@ func resourceStopServerIfRunning(id, stoppingType string, d *schema.ResourceData
 		if response != nil && response.StatusCode == 404 {
 			return isServerStopped, nil
 		}
-		return isServerStopped, fmt.Errorf("[ERROR] Error Getting Bare Metal Server (%s): %s\n%s", id, err, response)
+		return isServerStopped, flex.FmtErrorf("[ERROR] Error Getting Bare Metal Server (%s): %s\n%s", id, err, response)
 	}
 	if *bms.Status == "running" {
 
@@ -3908,7 +3908,7 @@ func resourceStopServerIfRunning(id, stoppingType string, d *schema.ResourceData
 
 		response, err := sess.StopBareMetalServerWithContext(context, options)
 		if err != nil && response != nil && response.StatusCode != 204 {
-			return isServerStopped, fmt.Errorf("[ERROR] Error stopping Bare Metal Server (%s): %s\n%s", id, err, response)
+			return isServerStopped, flex.FmtErrorf("[ERROR] Error stopping Bare Metal Server (%s): %s\n%s", id, err, response)
 		}
 		isServerStopped = true
 		isWaitForBareMetalServerActionStop(sess, d.Timeout(schema.TimeoutDelete), id, d)
@@ -3925,7 +3925,7 @@ func resourceStartServerIfStopped(id, stoppingType string, d *schema.ResourceDat
 		if response != nil && response.StatusCode == 404 {
 			return isServerStopped, nil
 		}
-		return isServerStopped, fmt.Errorf("[ERROR] Error Getting Bare Metal Server (%s): %s\n%s", id, err, response)
+		return isServerStopped, flex.FmtErrorf("[ERROR] Error Getting Bare Metal Server (%s): %s\n%s", id, err, response)
 	}
 	if *bms.Status == "stopped" {
 
@@ -3937,7 +3937,7 @@ func resourceStartServerIfStopped(id, stoppingType string, d *schema.ResourceDat
 			if response != nil && response.StatusCode == 404 {
 				return isServerStopped, nil
 			}
-			return isServerStopped, fmt.Errorf("[ERROR] Error creating Bare Metal Server action start : %s\n%s", err, response)
+			return isServerStopped, flex.FmtErrorf("[ERROR] Error creating Bare Metal Server action start : %s\n%s", err, response)
 		}
 		isServerStopped = true
 		_, err = isWaitForBareMetalServerAvailable(sess, d.Id(), d.Timeout(schema.TimeoutUpdate), d)

--- a/ibm/service/vpc/resource_ibm_is_bare_metal_server_action.go
+++ b/ibm/service/vpc/resource_ibm_is_bare_metal_server_action.go
@@ -9,6 +9,7 @@ import (
 	"log"
 	"time"
 
+	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/flex"
 	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/validate"
 	"github.com/IBM/vpc-go-sdk/vpcv1"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
@@ -208,7 +209,7 @@ func bareMetalServerActionGet(context context.Context, sess *vpcv1.VpcV1, id str
 			d.SetId("")
 			return nil
 		}
-		return fmt.Errorf("[ERROR] Error getting Bare Metal Server (%s): %s\n%s", id, err, response)
+		return flex.FmtErrorf("[ERROR] Error getting Bare Metal Server (%s): %s\n%s", id, err, response)
 	}
 	d.SetId(*bms.ID)
 	d.Set(isBareMetalServerStatus, *bms.Status)
@@ -324,7 +325,7 @@ func isBareMetalServerActionRefreshFunc(client *vpcv1.VpcV1, id string, d *schem
 		}
 		bms, response, err := client.GetBareMetalServer(bmsgetoptions)
 		if err != nil {
-			return nil, "", fmt.Errorf("[ERROR] Error getting Bare Metal Server: %s\n%s", err, response)
+			return nil, "", flex.FmtErrorf("[ERROR] Error getting Bare Metal Server: %s\n%s", err, response)
 		}
 		d.Set(isBareMetalServerStatus, *bms.Status)
 
@@ -344,7 +345,7 @@ func isBareMetalServerActionRefreshFunc(client *vpcv1.VpcV1, id string, d *schem
 		if *bms.Status == "failed" {
 			// let know the isRestartStartAction() to stop
 			close(communicator)
-			return bms, *bms.Status, fmt.Errorf("[ERROR] Error Bare Metal Server is in failed state")
+			return bms, *bms.Status, flex.FmtErrorf("[ERROR] Error Bare Metal Server is in failed state")
 
 		}
 		return bms, isBareMetalServerStatusPending, nil

--- a/ibm/service/vpc/resource_ibm_is_bare_metal_server_disk.go
+++ b/ibm/service/vpc/resource_ibm_is_bare_metal_server_disk.go
@@ -5,9 +5,9 @@ package vpc
 
 import (
 	"context"
-	"fmt"
 	"time"
 
+	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/flex"
 	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/validate"
 	"github.com/IBM/vpc-go-sdk/vpcv1"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
@@ -95,12 +95,12 @@ func resourceIBMISBareMetalServerDiskCreate(context context.Context, d *schema.R
 	}
 	diskPatch, err := diskPatchModel.AsPatch()
 	if err != nil {
-		return diag.FromErr(fmt.Errorf("[ERROR] Error calling asPatch for BareMetalServerDiskPatch %s", err))
+		return diag.FromErr(flex.FmtErrorf("[ERROR] Error calling asPatch for BareMetalServerDiskPatch %s", err))
 	}
 	options.BareMetalServerDiskPatch = diskPatch
 	disk, response, err := sess.UpdateBareMetalServerDiskWithContext(context, options)
 	if err != nil || disk == nil {
-		return diag.FromErr(fmt.Errorf("[ERROR] Error updating bare metal server (%s)  disk (%s) err %s\n%s", bareMetalServerId, diskId, err, response))
+		return diag.FromErr(flex.FmtErrorf("[ERROR] Error updating bare metal server (%s)  disk (%s) err %s\n%s", bareMetalServerId, diskId, err, response))
 	}
 	d.SetId(*disk.ID)
 	err = bareMetalServerDiskGet(context, d, sess, bareMetalServerId, diskId)
@@ -122,7 +122,7 @@ func bareMetalServerDiskGet(context context.Context, d *schema.ResourceData, ses
 			d.SetId("")
 			return nil
 		}
-		return fmt.Errorf("[ERROR] Error fetching bare metal server (%s)  disk (%s) err %s\n%s", bareMetalServerId, diskId, err, response)
+		return flex.FmtErrorf("[ERROR] Error fetching bare metal server (%s)  disk (%s) err %s\n%s", bareMetalServerId, diskId, err, response)
 	}
 
 	d.Set(isBareMetalServerID, bareMetalServerId)
@@ -178,12 +178,12 @@ func resourceIBMISBareMetalServerDiskUpdate(context context.Context, d *schema.R
 		}
 		diskPatch, err := diskPatchModel.AsPatch()
 		if err != nil {
-			return diag.FromErr(fmt.Errorf("[ERROR] Error calling asPatch for BareMetalServerDiskPatch %s", err))
+			return diag.FromErr(flex.FmtErrorf("[ERROR] Error calling asPatch for BareMetalServerDiskPatch %s", err))
 		}
 		options.BareMetalServerDiskPatch = diskPatch
 		disk, response, err := sess.UpdateBareMetalServerDiskWithContext(context, options)
 		if err != nil || disk == nil {
-			return diag.FromErr(fmt.Errorf("[ERROR] Error updating bare metal server (%s)  disk (%s) err %s\n%s", bareMetalServerId, diskId, err, response))
+			return diag.FromErr(flex.FmtErrorf("[ERROR] Error updating bare metal server (%s)  disk (%s) err %s\n%s", bareMetalServerId, diskId, err, response))
 		}
 		err = bareMetalServerDiskGet(context, d, sess, bareMetalServerId, diskId)
 		if err != nil {

--- a/ibm/service/vpc/resource_ibm_is_dedicated_host.go
+++ b/ibm/service/vpc/resource_ibm_is_dedicated_host.go
@@ -5,7 +5,6 @@ package vpc
 
 import (
 	"context"
-	"fmt"
 	"log"
 	"time"
 
@@ -517,17 +516,17 @@ func resourceIbmIsDedicatedHostRead(context context.Context, d *schema.ResourceD
 	}
 
 	if err = d.Set("available_memory", flex.IntValue(dedicatedHost.AvailableMemory)); err != nil {
-		return diag.FromErr(fmt.Errorf("[ERROR] Error setting available_memory: %s", err))
+		return diag.FromErr(flex.FmtErrorf("[ERROR] Error setting available_memory: %s", err))
 	}
 	availableVcpuMap := resourceIbmIsDedicatedHostVCPUToMap(*dedicatedHost.AvailableVcpu)
 	if err = d.Set("available_vcpu", []map[string]interface{}{availableVcpuMap}); err != nil {
-		return diag.FromErr(fmt.Errorf("[ERROR] Error setting available_vcpu: %s", err))
+		return diag.FromErr(flex.FmtErrorf("[ERROR] Error setting available_vcpu: %s", err))
 	}
 	if err = d.Set("created_at", dedicatedHost.CreatedAt.String()); err != nil {
-		return diag.FromErr(fmt.Errorf("[ERROR] Error setting created_at: %s", err))
+		return diag.FromErr(flex.FmtErrorf("[ERROR] Error setting created_at: %s", err))
 	}
 	if err = d.Set("crn", dedicatedHost.CRN); err != nil {
-		return diag.FromErr(fmt.Errorf("[ERROR] Error setting crn: %s", err))
+		return diag.FromErr(flex.FmtErrorf("[ERROR] Error setting crn: %s", err))
 	}
 	disks := []map[string]interface{}{}
 	for _, disksItem := range dedicatedHost.Disks {
@@ -535,15 +534,15 @@ func resourceIbmIsDedicatedHostRead(context context.Context, d *schema.ResourceD
 		disks = append(disks, disksItemMap)
 	}
 	if err = d.Set("disks", disks); err != nil {
-		return diag.FromErr(fmt.Errorf("[ERROR] Error setting disks: %s", err))
+		return diag.FromErr(flex.FmtErrorf("[ERROR] Error setting disks: %s", err))
 	}
 	d.Set("host_group", *dedicatedHost.Group.ID)
 
 	if err = d.Set("href", dedicatedHost.Href); err != nil {
-		return diag.FromErr(fmt.Errorf("[ERROR] Error setting href: %s", err))
+		return diag.FromErr(flex.FmtErrorf("[ERROR] Error setting href: %s", err))
 	}
 	if err = d.Set("instance_placement_enabled", dedicatedHost.InstancePlacementEnabled); err != nil {
-		return diag.FromErr(fmt.Errorf("[ERROR] Error setting instance_placement_enabled: %s", err))
+		return diag.FromErr(flex.FmtErrorf("[ERROR] Error setting instance_placement_enabled: %s", err))
 	}
 	instances := []map[string]interface{}{}
 	for _, instancesItem := range dedicatedHost.Instances {
@@ -551,40 +550,40 @@ func resourceIbmIsDedicatedHostRead(context context.Context, d *schema.ResourceD
 		instances = append(instances, instancesItemMap)
 	}
 	if err = d.Set("instances", instances); err != nil {
-		return diag.FromErr(fmt.Errorf("[ERROR] Error setting instances: %s", err))
+		return diag.FromErr(flex.FmtErrorf("[ERROR] Error setting instances: %s", err))
 	}
 	if err = d.Set("lifecycle_state", dedicatedHost.LifecycleState); err != nil {
-		return diag.FromErr(fmt.Errorf("[ERROR] Error setting lifecycle_state: %s", err))
+		return diag.FromErr(flex.FmtErrorf("[ERROR] Error setting lifecycle_state: %s", err))
 	}
 	if err = d.Set("memory", flex.IntValue(dedicatedHost.Memory)); err != nil {
-		return diag.FromErr(fmt.Errorf("[ERROR] Error setting memory: %s", err))
+		return diag.FromErr(flex.FmtErrorf("[ERROR] Error setting memory: %s", err))
 	}
 	if err = d.Set("name", dedicatedHost.Name); err != nil {
-		return diag.FromErr(fmt.Errorf("[ERROR] Error setting name: %s", err))
+		return diag.FromErr(flex.FmtErrorf("[ERROR] Error setting name: %s", err))
 	}
 	if dedicatedHost.Numa != nil {
 		if err = d.Set("numa", dataSourceDedicatedHostFlattenNumaNodes(*dedicatedHost.Numa)); err != nil {
-			return diag.FromErr(fmt.Errorf("[ERROR] Error setting numa: %s", err))
+			return diag.FromErr(flex.FmtErrorf("[ERROR] Error setting numa: %s", err))
 		}
 	}
 
 	if err = d.Set("profile", *dedicatedHost.Profile.Name); err != nil {
-		return diag.FromErr(fmt.Errorf("[ERROR] Error setting profile: %s", err))
+		return diag.FromErr(flex.FmtErrorf("[ERROR] Error setting profile: %s", err))
 	}
 	if err = d.Set("provisionable", dedicatedHost.Provisionable); err != nil {
-		return diag.FromErr(fmt.Errorf("[ERROR] Error setting provisionable: %s", err))
+		return diag.FromErr(flex.FmtErrorf("[ERROR] Error setting provisionable: %s", err))
 	}
 	if err = d.Set("resource_group", *dedicatedHost.ResourceGroup.ID); err != nil {
-		return diag.FromErr(fmt.Errorf("[ERROR] Error setting resource_group: %s", err))
+		return diag.FromErr(flex.FmtErrorf("[ERROR] Error setting resource_group: %s", err))
 	}
 	if err = d.Set("resource_type", dedicatedHost.ResourceType); err != nil {
-		return diag.FromErr(fmt.Errorf("[ERROR] Error setting resource_type: %s", err))
+		return diag.FromErr(flex.FmtErrorf("[ERROR] Error setting resource_type: %s", err))
 	}
 	if err = d.Set("socket_count", flex.IntValue(dedicatedHost.SocketCount)); err != nil {
-		return diag.FromErr(fmt.Errorf("[ERROR] Error setting socket_count: %s", err))
+		return diag.FromErr(flex.FmtErrorf("[ERROR] Error setting socket_count: %s", err))
 	}
 	if err = d.Set("state", dedicatedHost.State); err != nil {
-		return diag.FromErr(fmt.Errorf("[ERROR] Error setting state: %s", err))
+		return diag.FromErr(flex.FmtErrorf("[ERROR] Error setting state: %s", err))
 	}
 	supportedInstanceProfiles := []map[string]interface{}{}
 	for _, supportedInstanceProfilesItem := range dedicatedHost.SupportedInstanceProfiles {
@@ -592,15 +591,15 @@ func resourceIbmIsDedicatedHostRead(context context.Context, d *schema.ResourceD
 		supportedInstanceProfiles = append(supportedInstanceProfiles, supportedInstanceProfilesItemMap)
 	}
 	if err = d.Set("supported_instance_profiles", supportedInstanceProfiles); err != nil {
-		return diag.FromErr(fmt.Errorf("[ERROR] Error setting supported_instance_profiles: %s", err))
+		return diag.FromErr(flex.FmtErrorf("[ERROR] Error setting supported_instance_profiles: %s", err))
 	}
 	vcpuMap := resourceIbmIsDedicatedHostVCPUToMap(*dedicatedHost.Vcpu)
 	if err = d.Set("vcpu", []map[string]interface{}{vcpuMap}); err != nil {
-		return diag.FromErr(fmt.Errorf("[ERROR] Error setting vcpu: %s", err))
+		return diag.FromErr(flex.FmtErrorf("[ERROR] Error setting vcpu: %s", err))
 	}
 
 	if err = d.Set("zone", *dedicatedHost.Zone.Name); err != nil {
-		return diag.FromErr(fmt.Errorf("[ERROR] Error setting zone: %s", err))
+		return diag.FromErr(flex.FmtErrorf("[ERROR] Error setting zone: %s", err))
 	}
 	accesstags, err := flex.GetGlobalTagsUsingCRN(meta, *dedicatedHost.CRN, "", isDedicatedHostAccessTagType)
 	if err != nil {
@@ -773,10 +772,10 @@ func isWaitForDedicatedHostDelete(instanceC *vpcv1.VpcV1, d *schema.ResourceData
 				if response != nil && response.StatusCode == 404 {
 					return dedicatedhost, isDedicatedHostDeleteDone, nil
 				}
-				return nil, "", fmt.Errorf("[ERROR] Error getting dedicated Host: %s\n%s", err, response)
+				return nil, "", flex.FmtErrorf("[ERROR] Error getting dedicated Host: %s\n%s", err, response)
 			}
 			if *dedicatedhost.State == isDedicatedHostFailed {
-				return dedicatedhost, *dedicatedhost.State, fmt.Errorf("[ERROR] The  Dedicated host %s failed to delete: %v", d.Id(), err)
+				return dedicatedhost, *dedicatedhost.State, flex.FmtErrorf("[ERROR] The  Dedicated host %s failed to delete: %v", d.Id(), err)
 			}
 			return dedicatedhost, isDedicatedHostDeleting, nil
 		},
@@ -810,14 +809,14 @@ func isDedicatedHostRefreshFunc(instanceC *vpcv1.VpcV1, id string, d *schema.Res
 		}
 		dhost, response, err := instanceC.GetDedicatedHost(getinsOptions)
 		if dhost == nil || err != nil {
-			return nil, "", fmt.Errorf("[ERROR] Error getting dedicated host : %s\n%s", err, response)
+			return nil, "", flex.FmtErrorf("[ERROR] Error getting dedicated host : %s\n%s", err, response)
 		}
 		d.Set("state", *dhost.State)
 		d.Set("lifecycle_state", *dhost.LifecycleState)
 
 		if *dhost.LifecycleState == isDedicatedHostSuspended || *dhost.LifecycleState == isDedicatedHostFailed {
 
-			return dhost, *dhost.LifecycleState, fmt.Errorf("status of dedicated host is %s : \n%s", *dhost.LifecycleState, response)
+			return dhost, *dhost.LifecycleState, flex.FmtErrorf("status of dedicated host is %s : \n%s", *dhost.LifecycleState, response)
 
 		}
 		return dhost, *dhost.LifecycleState, nil

--- a/ibm/service/vpc/resource_ibm_is_dedicated_host_disk_management.go
+++ b/ibm/service/vpc/resource_ibm_is_dedicated_host_disk_management.go
@@ -4,8 +4,7 @@
 package vpc
 
 import (
-	"fmt"
-
+	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/flex"
 	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/validate"
 	"github.com/IBM/vpc-go-sdk/vpcv1"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -92,13 +91,13 @@ func resourceIBMisDedicatedHostDiskManagementCreate(d *schema.ResourceData, meta
 
 		dedicatedHostDiskPatch, err := dedicatedHostDiskPatchModel.AsPatch()
 		if err != nil {
-			return fmt.Errorf("[ERROR] Error calling asPatch for DedicatedHostDiskPatch: %s", err)
+			return flex.FmtErrorf("[ERROR] Error calling asPatch for DedicatedHostDiskPatch: %s", err)
 		}
 		updateDedicatedHostDiskOptions.SetDedicatedHostDiskPatch(dedicatedHostDiskPatch)
 
 		_, _, err = sess.UpdateDedicatedHostDisk(updateDedicatedHostDiskOptions)
 		if err != nil {
-			return fmt.Errorf("[ERROR] Error calling UpdateDedicatedHostDisk: %s", err)
+			return flex.FmtErrorf("[ERROR] Error calling UpdateDedicatedHostDisk: %s", err)
 		}
 
 	}
@@ -129,13 +128,13 @@ func resourceIBMisDedicatedHostDiskManagementUpdate(d *schema.ResourceData, meta
 
 			dedicatedHostDiskPatch, err := dedicatedHostDiskPatchModel.AsPatch()
 			if err != nil {
-				return fmt.Errorf("[ERROR] Error calling asPatch for DedicatedHostDiskPatch: %s", err)
+				return flex.FmtErrorf("[ERROR] Error calling asPatch for DedicatedHostDiskPatch: %s", err)
 			}
 			updateDedicatedHostDiskOptions.SetDedicatedHostDiskPatch(dedicatedHostDiskPatch)
 
 			_, response, err := sess.UpdateDedicatedHostDisk(updateDedicatedHostDiskOptions)
 			if err != nil {
-				return fmt.Errorf("[ERROR] Error updating dedicated host disk: %s %s", err, response)
+				return flex.FmtErrorf("[ERROR] Error updating dedicated host disk: %s %s", err, response)
 			}
 
 		}

--- a/ibm/service/vpc/resource_ibm_is_dedicated_host_group.go
+++ b/ibm/service/vpc/resource_ibm_is_dedicated_host_group.go
@@ -5,10 +5,10 @@ package vpc
 
 import (
 	"context"
-	"fmt"
 	"log"
 
 	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/conns"
+	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/flex"
 	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/validate"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -257,31 +257,31 @@ func resourceIbmIsDedicatedHostGroupRead(context context.Context, d *schema.Reso
 	}
 
 	if err = d.Set("class", dedicatedHostGroup.Class); err != nil {
-		return diag.FromErr(fmt.Errorf("[ERROR] Error setting class: %s", err))
+		return diag.FromErr(flex.FmtErrorf("[ERROR] Error setting class: %s", err))
 	}
 	if err = d.Set("family", dedicatedHostGroup.Family); err != nil {
-		return diag.FromErr(fmt.Errorf("[ERROR] Error setting family: %s", err))
+		return diag.FromErr(flex.FmtErrorf("[ERROR] Error setting family: %s", err))
 	}
 	if err = d.Set("name", dedicatedHostGroup.Name); err != nil {
-		return diag.FromErr(fmt.Errorf("[ERROR] Error setting name: %s", err))
+		return diag.FromErr(flex.FmtErrorf("[ERROR] Error setting name: %s", err))
 	}
 	if dedicatedHostGroup.ResourceGroup != nil {
 		resourceGroupID := *dedicatedHostGroup.ResourceGroup.ID
 		if err = d.Set("resource_group", resourceGroupID); err != nil {
-			return diag.FromErr(fmt.Errorf("[ERROR] Error setting resource_group: %s", err))
+			return diag.FromErr(flex.FmtErrorf("[ERROR] Error setting resource_group: %s", err))
 		}
 	}
 	if dedicatedHostGroup.Zone != nil {
 		zoneName := *dedicatedHostGroup.Zone.Name
 		if err = d.Set("zone", zoneName); err != nil {
-			return diag.FromErr(fmt.Errorf("[ERROR] Error setting zone: %s", err))
+			return diag.FromErr(flex.FmtErrorf("[ERROR] Error setting zone: %s", err))
 		}
 	}
 	if err = d.Set("created_at", dedicatedHostGroup.CreatedAt.String()); err != nil {
-		return diag.FromErr(fmt.Errorf("[ERROR] Error setting created_at: %s", err))
+		return diag.FromErr(flex.FmtErrorf("[ERROR] Error setting created_at: %s", err))
 	}
 	if err = d.Set("crn", dedicatedHostGroup.CRN); err != nil {
-		return diag.FromErr(fmt.Errorf("[ERROR] Error setting crn: %s", err))
+		return diag.FromErr(flex.FmtErrorf("[ERROR] Error setting crn: %s", err))
 	}
 	dedicatedHosts := []map[string]interface{}{}
 	for _, dedicatedHostsItem := range dedicatedHostGroup.DedicatedHosts {
@@ -289,13 +289,13 @@ func resourceIbmIsDedicatedHostGroupRead(context context.Context, d *schema.Reso
 		dedicatedHosts = append(dedicatedHosts, dedicatedHostsItemMap)
 	}
 	if err = d.Set("dedicated_hosts", dedicatedHosts); err != nil {
-		return diag.FromErr(fmt.Errorf("[ERROR] Error setting dedicated_hosts: %s", err))
+		return diag.FromErr(flex.FmtErrorf("[ERROR] Error setting dedicated_hosts: %s", err))
 	}
 	if err = d.Set("href", dedicatedHostGroup.Href); err != nil {
-		return diag.FromErr(fmt.Errorf("[ERROR] Error setting href: %s", err))
+		return diag.FromErr(flex.FmtErrorf("[ERROR] Error setting href: %s", err))
 	}
 	if err = d.Set("resource_type", dedicatedHostGroup.ResourceType); err != nil {
-		return diag.FromErr(fmt.Errorf("[ERROR] Error setting resource_type: %s", err))
+		return diag.FromErr(flex.FmtErrorf("[ERROR] Error setting resource_type: %s", err))
 	}
 	supportedInstanceProfiles := []map[string]interface{}{}
 	for _, supportedInstanceProfilesItem := range dedicatedHostGroup.SupportedInstanceProfiles {
@@ -303,7 +303,7 @@ func resourceIbmIsDedicatedHostGroupRead(context context.Context, d *schema.Reso
 		supportedInstanceProfiles = append(supportedInstanceProfiles, supportedInstanceProfilesItemMap)
 	}
 	if err = d.Set("supported_instance_profiles", supportedInstanceProfiles); err != nil {
-		return diag.FromErr(fmt.Errorf("[ERROR] Error setting supported_instance_profiles: %s", err))
+		return diag.FromErr(flex.FmtErrorf("[ERROR] Error setting supported_instance_profiles: %s", err))
 	}
 
 	return nil

--- a/ibm/service/vpc/resource_ibm_is_flow_log.go
+++ b/ibm/service/vpc/resource_ibm_is_flow_log.go
@@ -5,7 +5,6 @@ package vpc
 
 import (
 	"context"
-	"fmt"
 	"log"
 	"os"
 	"time"
@@ -256,7 +255,7 @@ func resourceIBMISFlowLogCreate(d *schema.ResourceData, meta interface{}) error 
 
 	flowlogCollector, response, err := sess.CreateFlowLogCollector(createFlowLogCollectorOptionsModel)
 	if err != nil {
-		return fmt.Errorf("Create Flow Log Collector err %s\n%s", err, response)
+		return flex.FmtErrorf("Create Flow Log Collector err %s\n%s", err, response)
 	}
 	d.SetId(*flowlogCollector.ID)
 
@@ -296,7 +295,7 @@ func resourceIBMISFlowLogRead(d *schema.ResourceData, meta interface{}) error {
 	}
 	flowlogCollector, response, err := sess.GetFlowLogCollector(getOptions)
 	if err != nil {
-		return fmt.Errorf("[ERROR] Error Getting Flow Log Collector: %s\n%s", err, response)
+		return flex.FmtErrorf("[ERROR] Error Getting Flow Log Collector: %s\n%s", err, response)
 	}
 
 	if flowlogCollector.Name != nil {
@@ -383,7 +382,7 @@ func resourceIBMISFlowLogUpdate(d *schema.ResourceData, meta interface{}) error 
 	}
 	flowlogCollector, response, err := sess.GetFlowLogCollector(getOptions)
 	if err != nil {
-		return fmt.Errorf("[ERROR] Error Getting Flow Log Collector: %s\n%s", err, response)
+		return flex.FmtErrorf("[ERROR] Error Getting Flow Log Collector: %s\n%s", err, response)
 	}
 
 	if d.HasChange(isFlowLogTags) {
@@ -416,12 +415,12 @@ func resourceIBMISFlowLogUpdate(d *schema.ResourceData, meta interface{}) error 
 		}
 		flowLogCollectorPatch, err := flowLogCollectorPatchModel.AsPatch()
 		if err != nil {
-			return fmt.Errorf("[ERROR] Error calling asPatch for FlowLogCollectorPatch: %s", err)
+			return flex.FmtErrorf("[ERROR] Error calling asPatch for FlowLogCollectorPatch: %s", err)
 		}
 		updoptions.FlowLogCollectorPatch = flowLogCollectorPatch
 		_, response, err = sess.UpdateFlowLogCollector(updoptions)
 		if err != nil {
-			return fmt.Errorf("[ERROR] Error updating flow log collector:%s\n%s", err, response)
+			return flex.FmtErrorf("[ERROR] Error updating flow log collector:%s\n%s", err, response)
 		}
 	}
 
@@ -441,7 +440,7 @@ func resourceIBMISFlowLogDelete(d *schema.ResourceData, meta interface{}) error 
 	response, err := sess.DeleteFlowLogCollector(delOptions)
 
 	if err != nil && response.StatusCode != 404 {
-		return fmt.Errorf("[ERROR] Error deleting flow log collector:%s\n%s", err, response)
+		return flex.FmtErrorf("[ERROR] Error deleting flow log collector:%s\n%s", err, response)
 	}
 
 	d.SetId("")
@@ -461,7 +460,7 @@ func resourceIBMISFlowLogExists(d *schema.ResourceData, meta interface{}) (bool,
 	}
 	_, response, err := sess.GetFlowLogCollector(getOptions)
 	if err != nil && response.StatusCode != 404 {
-		return false, fmt.Errorf("[ERROR] Error Getting Flow Log Collector : %s\n%s", err, response)
+		return false, flex.FmtErrorf("[ERROR] Error Getting Flow Log Collector : %s\n%s", err, response)
 	}
 	if response.StatusCode == 404 {
 		d.SetId("")

--- a/ibm/service/vpc/resource_ibm_is_ike_policy.go
+++ b/ibm/service/vpc/resource_ibm_is_ike_policy.go
@@ -4,7 +4,6 @@
 package vpc
 
 import (
-	"fmt"
 	"log"
 
 	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/flex"
@@ -239,7 +238,7 @@ func ikepCreate(d *schema.ResourceData, meta interface{}, authenticationAlg, enc
 	}
 	ike, response, err := sess.CreateIkePolicy(options)
 	if err != nil {
-		return fmt.Errorf("[DEBUG] ike policy err %s\n%s", err, response)
+		return flex.FmtErrorf("[DEBUG] ike policy err %s\n%s", err, response)
 	}
 	d.SetId(*ike.ID)
 	log.Printf("[INFO] ike policy : %s", *ike.ID)
@@ -266,7 +265,7 @@ func ikepGet(d *schema.ResourceData, meta interface{}, id string) error {
 			d.SetId("")
 			return nil
 		}
-		return fmt.Errorf("[ERROR] Error getting IKE Policy(%s): %s\n%s", id, err, response)
+		return flex.FmtErrorf("[ERROR] Error getting IKE Policy(%s): %s\n%s", id, err, response)
 	}
 
 	d.Set(isIKEName, *ike.Name)
@@ -340,13 +339,13 @@ func ikepUpdate(d *schema.ResourceData, meta interface{}, id string) error {
 		ikePolicyPatchModel.IkeVersion = &ikeVersion
 		ikePolicyPatch, err := ikePolicyPatchModel.AsPatch()
 		if err != nil {
-			return fmt.Errorf("[ERROR] Error calling asPatch for IkePolicyPatch: %s", err)
+			return flex.FmtErrorf("[ERROR] Error calling asPatch for IkePolicyPatch: %s", err)
 		}
 		options.IkePolicyPatch = ikePolicyPatch
 
 		_, response, err := sess.UpdateIkePolicy(options)
 		if err != nil {
-			return fmt.Errorf("[ERROR] Error on update of IKE Policy(%s): %s\n%s", id, err, response)
+			return flex.FmtErrorf("[ERROR] Error on update of IKE Policy(%s): %s\n%s", id, err, response)
 		}
 	}
 	return nil
@@ -372,7 +371,7 @@ func ikepDelete(d *schema.ResourceData, meta interface{}, id string) error {
 			d.SetId("")
 			return nil
 		}
-		return fmt.Errorf("[ERROR] Error getting IKE Policy(%s): %s\n%s", id, err, response)
+		return flex.FmtErrorf("[ERROR] Error getting IKE Policy(%s): %s\n%s", id, err, response)
 	}
 
 	deleteIkePolicyOptions := &vpcv1.DeleteIkePolicyOptions{
@@ -380,7 +379,7 @@ func ikepDelete(d *schema.ResourceData, meta interface{}, id string) error {
 	}
 	response, err = sess.DeleteIkePolicy(deleteIkePolicyOptions)
 	if err != nil {
-		return fmt.Errorf("[ERROR] Error Deleting IKE Policy(%s): %s\n%s", id, err, response)
+		return flex.FmtErrorf("[ERROR] Error Deleting IKE Policy(%s): %s\n%s", id, err, response)
 	}
 	d.SetId("")
 	return nil
@@ -405,7 +404,7 @@ func ikepExists(d *schema.ResourceData, meta interface{}, id string) (bool, erro
 		if response != nil && response.StatusCode == 404 {
 			return false, nil
 		}
-		return false, fmt.Errorf("[ERROR] Error getting IKE Policy(%s): %s\n%s", id, err, response)
+		return false, flex.FmtErrorf("[ERROR] Error getting IKE Policy(%s): %s\n%s", id, err, response)
 	}
 
 	return true, nil

--- a/ibm/service/vpc/resource_ibm_is_image_deprecate.go
+++ b/ibm/service/vpc/resource_ibm_is_image_deprecate.go
@@ -5,7 +5,6 @@ package vpc
 
 import (
 	"context"
-	"fmt"
 	"log"
 	"time"
 
@@ -202,7 +201,7 @@ func imgDeprecateCreate(context context.Context, d *schema.ResourceData, meta in
 	}
 	response, err := sess.DeprecateImageWithContext(context, imageDeprecatePrototype)
 	if err != nil {
-		return fmt.Errorf("[ERROR] Image deprecate err %s\n%s", err, response)
+		return flex.FmtErrorf("[ERROR] Image deprecate err %s\n%s", err, response)
 	}
 	d.SetId(id)
 	log.Printf("[INFO] Image ID : %s", id)
@@ -236,14 +235,14 @@ func isImageDeprecateRefreshFunc(imageC *vpcv1.VpcV1, id string) resource.StateR
 		}
 		image, response, err := imageC.GetImage(getimgoptions)
 		if err != nil {
-			return nil, "", fmt.Errorf("[ERROR] Error Getting Image: %s\n%s", err, response)
+			return nil, "", flex.FmtErrorf("[ERROR] Error Getting Image: %s\n%s", err, response)
 		}
 
 		if *image.Status == "deprecated" {
 			return image, isImageProvisioningDone, nil
 		}
 		if *image.Status == "failed" {
-			return image, "", fmt.Errorf("[ERROR] Error Image(%s) went to failed state while deprecating ", *image.ID)
+			return image, "", flex.FmtErrorf("[ERROR] Error Image(%s) went to failed state while deprecating ", *image.ID)
 		}
 
 		return image, isImageProvisioning, nil
@@ -274,7 +273,7 @@ func imgDeprecateGet(d *schema.ResourceData, meta interface{}, id string) error 
 			d.SetId("")
 			return nil
 		}
-		return fmt.Errorf("[ERROR] Error Getting Image (%s): %s\n%s", id, err, response)
+		return flex.FmtErrorf("[ERROR] Error Getting Image (%s): %s\n%s", id, err, response)
 	}
 	if image.MinimumProvisionedSize != nil {
 		d.Set(isImageMinimumProvisionedSize, *image.MinimumProvisionedSize)

--- a/ibm/service/vpc/resource_ibm_is_image_export_job.go
+++ b/ibm/service/vpc/resource_ibm_is_image_export_job.go
@@ -219,7 +219,7 @@ func ResourceIBMIsImageExportCreate(context context.Context, d *schema.ResourceD
 	imageExportJob, response, err := vpcClient.CreateImageExportJobWithContext(context, createImageExportJobOptions)
 	if err != nil {
 		log.Printf("[DEBUG] CreateImageExportJobWithContext failed %s\n%s", err, response)
-		return diag.FromErr(fmt.Errorf("CreateImageExportJobWithContext failed %s\n%s", err, response))
+		return diag.FromErr(flex.FmtErrorf("CreateImageExportJobWithContext failed %s\n%s", err, response))
 	}
 
 	d.SetId(fmt.Sprintf("%s/%s", *createImageExportJobOptions.ImageID, *imageExportJob.ID))
@@ -250,36 +250,36 @@ func ResourceIBMIsImageExportRead(context context.Context, d *schema.ResourceDat
 			return nil
 		}
 		log.Printf("[DEBUG] GetImageExportJobWithContext failed %s\n%s", err, response)
-		return diag.FromErr(fmt.Errorf("GetImageExportJobWithContext failed %s\n%s", err, response))
+		return diag.FromErr(flex.FmtErrorf("GetImageExportJobWithContext failed %s\n%s", err, response))
 	}
 
 	if err = d.Set("format", imageExportJob.Format); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting format: %s", err))
+		return diag.FromErr(flex.FmtErrorf("Error setting format: %s", err))
 	}
 	if err = d.Set("name", imageExportJob.Name); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting name: %s", err))
+		return diag.FromErr(flex.FmtErrorf("Error setting name: %s", err))
 	}
 	if err = d.Set("completed_at", flex.DateTimeToString(imageExportJob.CompletedAt)); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting completed_at: %s", err))
+		return diag.FromErr(flex.FmtErrorf("Error setting completed_at: %s", err))
 	}
 	if err = d.Set("created_at", flex.DateTimeToString(imageExportJob.CreatedAt)); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting created_at: %s", err))
+		return diag.FromErr(flex.FmtErrorf("Error setting created_at: %s", err))
 	}
 	if err = d.Set("encrypted_data_key", imageExportJob.EncryptedDataKey); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting encrypted_data_key: %s", err))
+		return diag.FromErr(flex.FmtErrorf("Error setting encrypted_data_key: %s", err))
 	}
 	if err = d.Set("href", imageExportJob.Href); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting href: %s", err))
+		return diag.FromErr(flex.FmtErrorf("Error setting href: %s", err))
 	}
 
 	if err = d.Set("resource_type", imageExportJob.ResourceType); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting resource_type: %s", err))
+		return diag.FromErr(flex.FmtErrorf("Error setting resource_type: %s", err))
 	}
 	if err = d.Set("started_at", flex.DateTimeToString(imageExportJob.StartedAt)); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting started_at: %s", err))
+		return diag.FromErr(flex.FmtErrorf("Error setting started_at: %s", err))
 	}
 	if err = d.Set("status", imageExportJob.Status); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting status: %s", err))
+		return diag.FromErr(flex.FmtErrorf("Error setting status: %s", err))
 	}
 
 	if imageExportJob.StorageBucket != nil {
@@ -302,20 +302,20 @@ func ResourceIBMIsImageExportRead(context context.Context, d *schema.ResourceDat
 		statusReasons = append(statusReasons, statusReasonsItemMap)
 	}
 	if err = d.Set("status_reasons", statusReasons); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting status_reasons: %s", err))
+		return diag.FromErr(flex.FmtErrorf("Error setting status_reasons: %s", err))
 	}
 	if err = d.Set("storage_href", imageExportJob.StorageHref); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting storage_href: %s", err))
+		return diag.FromErr(flex.FmtErrorf("Error setting storage_href: %s", err))
 	}
 	storageObjectMap, err := ResourceIBMIsImageExportCloudObjectStorageObjectReferenceToMap(imageExportJob.StorageObject)
 	if err != nil {
 		return diag.FromErr(err)
 	}
 	if err = d.Set("storage_object", []map[string]interface{}{storageObjectMap}); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting storage_object: %s", err))
+		return diag.FromErr(flex.FmtErrorf("Error setting storage_object: %s", err))
 	}
 	if err = d.Set("image_export_job", imageExportJob.ID); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting image_export_job: %s", err))
+		return diag.FromErr(flex.FmtErrorf("Error setting image_export_job: %s", err))
 	}
 
 	return nil
@@ -351,7 +351,7 @@ func ResourceIBMIsImageExportUpdate(context context.Context, d *schema.ResourceD
 		_, response, err := vpcClient.UpdateImageExportJobWithContext(context, updateImageExportJobOptions)
 		if err != nil {
 			log.Printf("[DEBUG] UpdateImageExportJobWithContext failed %s\n%s", err, response)
-			return diag.FromErr(fmt.Errorf("UpdateImageExportJobWithContext failed %s\n%s", err, response))
+			return diag.FromErr(flex.FmtErrorf("UpdateImageExportJobWithContext failed %s\n%s", err, response))
 		}
 	}
 
@@ -377,7 +377,7 @@ func ResourceIBMIsImageExportDelete(context context.Context, d *schema.ResourceD
 	response, err := vpcClient.DeleteImageExportJobWithContext(context, deleteImageExportJobOptions)
 	if err != nil {
 		log.Printf("[DEBUG] DeleteImageExportJobWithContext failed %s\n%s", err, response)
-		return diag.FromErr(fmt.Errorf("DeleteImageExportJobWithContext failed %s\n%s", err, response))
+		return diag.FromErr(flex.FmtErrorf("DeleteImageExportJobWithContext failed %s\n%s", err, response))
 	}
 	_, err = isWaitForImageExportJobDeleted(context, d, meta, vpcClient, d.Id(), d.Timeout(schema.TimeoutDelete))
 	if err != nil {
@@ -427,7 +427,7 @@ func ResourceIBMIsImageExportCloudObjectStorageBucketIdentityToMap(model vpcv1.C
 		}
 		return modelMap, nil
 	} else {
-		return nil, fmt.Errorf("Unrecognized vpcv1.CloudObjectStorageBucketIdentityIntf subtype encountered")
+		return nil, flex.FmtErrorf("Unrecognized vpcv1.CloudObjectStorageBucketIdentityIntf subtype encountered")
 	}
 }
 
@@ -491,7 +491,7 @@ func isImageExportJobDeleteRefreshFunc(context context.Context, d *schema.Resour
 			if response != nil && response.StatusCode == 404 {
 				return imageExportJob, "done", nil
 			}
-			return imageExportJob, "", fmt.Errorf("[ERROR] Error Getting Image export job: %s\n%s", err, response)
+			return imageExportJob, "", flex.FmtErrorf("[ERROR] Error Getting Image export job: %s\n%s", err, response)
 		}
 		return imageExportJob, *imageExportJob.Status, err
 	}

--- a/ibm/service/vpc/resource_ibm_is_image_obsolete.go
+++ b/ibm/service/vpc/resource_ibm_is_image_obsolete.go
@@ -5,7 +5,6 @@ package vpc
 
 import (
 	"context"
-	"fmt"
 	"log"
 	"time"
 
@@ -196,7 +195,7 @@ func imgObsoleteCreate(context context.Context, d *schema.ResourceData, meta int
 
 	response, err := sess.ObsoleteImageWithContext(context, imageObsoletePrototype)
 	if err != nil {
-		return fmt.Errorf("[ERROR] Image obsolete err %s\n%s", err, response)
+		return flex.FmtErrorf("[ERROR] Image obsolete err %s\n%s", err, response)
 	}
 	d.SetId(id)
 	log.Printf("[INFO] Image ID : %s", id)
@@ -229,14 +228,14 @@ func isImageObsoleteRefreshFunc(imageC *vpcv1.VpcV1, id string) resource.StateRe
 		}
 		image, response, err := imageC.GetImage(getimgoptions)
 		if err != nil {
-			return nil, "", fmt.Errorf("[ERROR] Error Getting Image: %s\n%s", err, response)
+			return nil, "", flex.FmtErrorf("[ERROR] Error Getting Image: %s\n%s", err, response)
 		}
 
 		if *image.Status == "obsolete" {
 			return image, isImageProvisioningDone, nil
 		}
 		if *image.Status == "failed" {
-			return image, "", fmt.Errorf("[ERROR] Error Image(%s) went to failed state while obsoleting ", *image.ID)
+			return image, "", flex.FmtErrorf("[ERROR] Error Image(%s) went to failed state while obsoleting ", *image.ID)
 		}
 
 		return image, isImageProvisioning, nil
@@ -267,7 +266,7 @@ func imgObsoleteGet(d *schema.ResourceData, meta interface{}, id string) error {
 			d.SetId("")
 			return nil
 		}
-		return fmt.Errorf("[ERROR] Error Getting Image (%s): %s\n%s", id, err, response)
+		return flex.FmtErrorf("[ERROR] Error Getting Image (%s): %s\n%s", id, err, response)
 	}
 	if image.MinimumProvisionedSize != nil {
 		d.Set(isImageMinimumProvisionedSize, *image.MinimumProvisionedSize)

--- a/ibm/service/vpc/resource_ibm_is_instance.go
+++ b/ibm/service/vpc/resource_ibm_is_instance.go
@@ -152,7 +152,7 @@ func ResourceIBMISInstance() *schema.Resource {
 						d.SetId("")
 						return nil, nil
 					}
-					return nil, fmt.Errorf("[ERROR] Error Getting Instance: %s\n%s", err, response)
+					return nil, flex.FmtErrorf("[ERROR] Error Getting Instance: %s\n%s", err, response)
 				}
 				var volumes []string
 				volumes = make([]string, 0)
@@ -1903,10 +1903,10 @@ func instanceCreateByImage(d *schema.ResourceData, meta interface{}, profile, na
 			autodelete = reservedipautodeleteok.(bool)
 		}
 		if ipv4str != "" && reservedipv4 != "" && ipv4str != reservedipv4 {
-			return fmt.Errorf("[ERROR] Error creating instance, primary_network_interface error, use either primary_ipv4_address(%s) or primary_ip.0.address(%s)", ipv4str, reservedipv4)
+			return flex.FmtErrorf("[ERROR] Error creating instance, primary_network_interface error, use either primary_ipv4_address(%s) or primary_ip.0.address(%s)", ipv4str, reservedipv4)
 		}
 		if reservedIp != "" && (ipv4str != "" || reservedipv4 != "" || reservedipname != "") {
-			return fmt.Errorf("[ERROR] Error creating instance, primary_network_interface error, reserved_ip(%s) is mutually exclusive with other primary_ip attributes", reservedIp)
+			return flex.FmtErrorf("[ERROR] Error creating instance, primary_network_interface error, reserved_ip(%s) is mutually exclusive with other primary_ip attributes", reservedIp)
 		}
 		if reservedIp != "" {
 			primnicobj.PrimaryIP = &vpcv1.NetworkInterfaceIPPrototypeReservedIPIdentity{
@@ -1994,10 +1994,10 @@ func instanceCreateByImage(d *schema.ResourceData, meta interface{}, profile, na
 				autodelete = reservedipautodeleteok.(bool)
 			}
 			if ipv4str != "" && reservedipv4 != "" && ipv4str != reservedipv4 {
-				return fmt.Errorf("[ERROR] Error creating instance, network_interfaces error, use either primary_ipv4_address(%s) or primary_ip.0.address(%s)", ipv4str, reservedipv4)
+				return flex.FmtErrorf("[ERROR] Error creating instance, network_interfaces error, use either primary_ipv4_address(%s) or primary_ip.0.address(%s)", ipv4str, reservedipv4)
 			}
 			if reservedIp != "" && (ipv4str != "" || reservedipv4 != "" || reservedipname != "") {
-				return fmt.Errorf("[ERROR] Error creating instance, network_interfaces error, reserved_ip(%s) is mutually exclusive with other primary_ip attributes", reservedIp)
+				return flex.FmtErrorf("[ERROR] Error creating instance, network_interfaces error, reserved_ip(%s) is mutually exclusive with other primary_ip attributes", reservedIp)
 			}
 			if reservedIp != "" {
 				nwInterface.PrimaryIP = &vpcv1.NetworkInterfaceIPPrototypeReservedIPIdentity{
@@ -2330,10 +2330,10 @@ func instanceCreateByCatalogOffering(d *schema.ResourceData, meta interface{}, p
 			autodelete = reservedipautodeleteok.(bool)
 		}
 		if ipv4str != "" && reservedipv4 != "" && ipv4str != reservedipv4 {
-			return fmt.Errorf("[ERROR] Error creating instance, primary_network_interface error, use either primary_ipv4_address(%s) or primary_ip.0.address(%s)", ipv4str, reservedipv4)
+			return flex.FmtErrorf("[ERROR] Error creating instance, primary_network_interface error, use either primary_ipv4_address(%s) or primary_ip.0.address(%s)", ipv4str, reservedipv4)
 		}
 		if reservedIp != "" && (ipv4str != "" || reservedipv4 != "" || reservedipname != "") {
-			return fmt.Errorf("[ERROR] Error creating instance, primary_network_interface error, reserved_ip(%s) is mutually exclusive with other primary_ip attributes", reservedIp)
+			return flex.FmtErrorf("[ERROR] Error creating instance, primary_network_interface error, reserved_ip(%s) is mutually exclusive with other primary_ip attributes", reservedIp)
 		}
 		if reservedIp != "" {
 			primnicobj.PrimaryIP = &vpcv1.NetworkInterfaceIPPrototypeReservedIPIdentity{
@@ -2421,10 +2421,10 @@ func instanceCreateByCatalogOffering(d *schema.ResourceData, meta interface{}, p
 				autodelete = reservedipautodeleteok.(bool)
 			}
 			if ipv4str != "" && reservedipv4 != "" && ipv4str != reservedipv4 {
-				return fmt.Errorf("[ERROR] Error creating instance, network_interfaces error, use either primary_ipv4_address(%s) or primary_ip.0.address(%s)", ipv4str, reservedipv4)
+				return flex.FmtErrorf("[ERROR] Error creating instance, network_interfaces error, use either primary_ipv4_address(%s) or primary_ip.0.address(%s)", ipv4str, reservedipv4)
 			}
 			if reservedIp != "" && (ipv4str != "" || reservedipv4 != "" || reservedipname != "") {
-				return fmt.Errorf("[ERROR] Error creating instance, network_interfaces error, reserved_ip(%s) is mutually exclusive with other primary_ip attributes", reservedIp)
+				return flex.FmtErrorf("[ERROR] Error creating instance, network_interfaces error, reserved_ip(%s) is mutually exclusive with other primary_ip attributes", reservedIp)
 			}
 			if reservedIp != "" {
 				nwInterface.PrimaryIP = &vpcv1.NetworkInterfaceIPPrototypeReservedIPIdentity{
@@ -2752,10 +2752,10 @@ func instanceCreateByTemplate(d *schema.ResourceData, meta interface{}, profile,
 			autodelete = reservedipautodeleteok.(bool)
 		}
 		if ipv4str != "" && reservedipv4 != "" && ipv4str != reservedipv4 {
-			return fmt.Errorf("[ERROR] Error creating instance, primary_network_interface error, use either primary_ipv4_address(%s) or primary_ip.0.address(%s)", ipv4str, reservedipv4)
+			return flex.FmtErrorf("[ERROR] Error creating instance, primary_network_interface error, use either primary_ipv4_address(%s) or primary_ip.0.address(%s)", ipv4str, reservedipv4)
 		}
 		if reservedIp != "" && (ipv4str != "" || reservedipv4 != "" || reservedipname != "") {
-			return fmt.Errorf("[ERROR] Error creating instance, primary_network_interface error, reserved_ip(%s) is mutually exclusive with other primary_ip attributes", reservedIp)
+			return flex.FmtErrorf("[ERROR] Error creating instance, primary_network_interface error, reserved_ip(%s) is mutually exclusive with other primary_ip attributes", reservedIp)
 		}
 		if reservedIp != "" {
 			primnicobj.PrimaryIP = &vpcv1.NetworkInterfaceIPPrototypeReservedIPIdentity{
@@ -2842,10 +2842,10 @@ func instanceCreateByTemplate(d *schema.ResourceData, meta interface{}, profile,
 				autodelete = reservedipautodeleteok.(bool)
 			}
 			if ipv4str != "" && reservedipv4 != "" && ipv4str != reservedipv4 {
-				return fmt.Errorf("[ERROR] Error creating instance, network_interfaces error, use either primary_ipv4_address(%s) or primary_ip.0.address(%s)", ipv4str, reservedipv4)
+				return flex.FmtErrorf("[ERROR] Error creating instance, network_interfaces error, use either primary_ipv4_address(%s) or primary_ip.0.address(%s)", ipv4str, reservedipv4)
 			}
 			if reservedIp != "" && (ipv4str != "" || reservedipv4 != "" || reservedipname != "") {
-				return fmt.Errorf("[ERROR] Error creating instance, network_interfaces error, reserved_ip(%s) is mutually exclusive with other primary_ip attributes", reservedIp)
+				return flex.FmtErrorf("[ERROR] Error creating instance, network_interfaces error, reserved_ip(%s) is mutually exclusive with other primary_ip attributes", reservedIp)
 			}
 			if reservedIp != "" {
 				nwInterface.PrimaryIP = &vpcv1.NetworkInterfaceIPPrototypeReservedIPIdentity{
@@ -3173,10 +3173,10 @@ func instanceCreateBySnapshot(d *schema.ResourceData, meta interface{}, profile,
 			autodelete = reservedipautodeleteok.(bool)
 		}
 		if ipv4str != "" && reservedipv4 != "" && ipv4str != reservedipv4 {
-			return fmt.Errorf("[ERROR] Error creating instance, primary_network_interface error, use either primary_ipv4_address(%s) or primary_ip.0.address(%s)", ipv4str, reservedipv4)
+			return flex.FmtErrorf("[ERROR] Error creating instance, primary_network_interface error, use either primary_ipv4_address(%s) or primary_ip.0.address(%s)", ipv4str, reservedipv4)
 		}
 		if reservedIp != "" && (ipv4str != "" || reservedipv4 != "" || reservedipname != "") {
-			return fmt.Errorf("[ERROR] Error creating instance, primary_network_interface error, reserved_ip(%s) is mutually exclusive with other primary_ip attributes", reservedIp)
+			return flex.FmtErrorf("[ERROR] Error creating instance, primary_network_interface error, reserved_ip(%s) is mutually exclusive with other primary_ip attributes", reservedIp)
 		}
 		if reservedIp != "" {
 			primnicobj.PrimaryIP = &vpcv1.NetworkInterfaceIPPrototypeReservedIPIdentity{
@@ -3263,10 +3263,10 @@ func instanceCreateBySnapshot(d *schema.ResourceData, meta interface{}, profile,
 				autodelete = reservedipautodeleteok.(bool)
 			}
 			if ipv4str != "" && reservedipv4 != "" && ipv4str != reservedipv4 {
-				return fmt.Errorf("[ERROR] Error creating instance, network_interfaces error, use either primary_ipv4_address(%s) or primary_ip.0.address(%s)", ipv4str, reservedipv4)
+				return flex.FmtErrorf("[ERROR] Error creating instance, network_interfaces error, use either primary_ipv4_address(%s) or primary_ip.0.address(%s)", ipv4str, reservedipv4)
 			}
 			if reservedIp != "" && (ipv4str != "" || reservedipv4 != "" || reservedipname != "") {
-				return fmt.Errorf("[ERROR] Error creating instance, network_interfaces error, reserved_ip(%s) is mutually exclusive with other primary_ip attributes", reservedIp)
+				return flex.FmtErrorf("[ERROR] Error creating instance, network_interfaces error, reserved_ip(%s) is mutually exclusive with other primary_ip attributes", reservedIp)
 			}
 			if reservedIp != "" {
 				nwInterface.PrimaryIP = &vpcv1.NetworkInterfaceIPPrototypeReservedIPIdentity{
@@ -3567,10 +3567,10 @@ func instanceCreateByVolume(d *schema.ResourceData, meta interface{}, profile, n
 			autodelete = reservedipautodeleteok.(bool)
 		}
 		if ipv4str != "" && reservedipv4 != "" && ipv4str != reservedipv4 {
-			return fmt.Errorf("[ERROR] Error creating instance, primary_network_interface error, use either primary_ipv4_address(%s) or primary_ip.0.address(%s)", ipv4str, reservedipv4)
+			return flex.FmtErrorf("[ERROR] Error creating instance, primary_network_interface error, use either primary_ipv4_address(%s) or primary_ip.0.address(%s)", ipv4str, reservedipv4)
 		}
 		if reservedIp != "" && (ipv4str != "" || reservedipv4 != "" || reservedipname != "") {
-			return fmt.Errorf("[ERROR] Error creating instance, primary_network_interface error, reserved_ip(%s) is mutually exclusive with other primary_ip attributes", reservedIp)
+			return flex.FmtErrorf("[ERROR] Error creating instance, primary_network_interface error, reserved_ip(%s) is mutually exclusive with other primary_ip attributes", reservedIp)
 		}
 		if reservedIp != "" {
 			primnicobj.PrimaryIP = &vpcv1.NetworkInterfaceIPPrototypeReservedIPIdentity{
@@ -3657,10 +3657,10 @@ func instanceCreateByVolume(d *schema.ResourceData, meta interface{}, profile, n
 				autodelete = reservedipautodeleteok.(bool)
 			}
 			if ipv4str != "" && reservedipv4 != "" && ipv4str != reservedipv4 {
-				return fmt.Errorf("[ERROR] Error creating instance, network_interfaces error, use either primary_ipv4_address(%s) or primary_ip.0.address(%s)", ipv4str, reservedipv4)
+				return flex.FmtErrorf("[ERROR] Error creating instance, network_interfaces error, use either primary_ipv4_address(%s) or primary_ip.0.address(%s)", ipv4str, reservedipv4)
 			}
 			if reservedIp != "" && (ipv4str != "" || reservedipv4 != "" || reservedipname != "") {
-				return fmt.Errorf("[ERROR] Error creating instance, network_interfaces error, reserved_ip(%s) is mutually exclusive with other primary_ip attributes", reservedIp)
+				return flex.FmtErrorf("[ERROR] Error creating instance, network_interfaces error, reserved_ip(%s) is mutually exclusive with other primary_ip attributes", reservedIp)
 			}
 			if reservedIp != "" {
 				nwInterface.PrimaryIP = &vpcv1.NetworkInterfaceIPPrototypeReservedIPIdentity{
@@ -3860,7 +3860,7 @@ func isInstanceRefreshFunc(instanceC *vpcv1.VpcV1, id string, d *schema.Resource
 		}
 		instance, response, err := instanceC.GetInstance(getinsOptions)
 		if err != nil {
-			return nil, "", fmt.Errorf("[ERROR] Error Getting Instance: %s\n%s", err, response)
+			return nil, "", flex.FmtErrorf("[ERROR] Error Getting Instance: %s\n%s", err, response)
 		}
 		d.Set(isInstanceStatus, *instance.Status)
 
@@ -3897,9 +3897,9 @@ func isInstanceRefreshFunc(instanceC *vpcv1.VpcV1, id string, d *schema.Resource
 
 				out, err := json.MarshalIndent(instanceStatusReason, "", "    ")
 				if err != nil {
-					return instance, *instance.Status, fmt.Errorf("[ERROR] Instance (%s) went into failed state during the operation \n [WARNING] Running terraform apply again will remove the tainted instance and attempt to create the instance again replacing the previous configuration", *instance.ID)
+					return instance, *instance.Status, flex.FmtErrorf("[ERROR] Instance (%s) went into failed state during the operation \n [WARNING] Running terraform apply again will remove the tainted instance and attempt to create the instance again replacing the previous configuration", *instance.ID)
 				}
-				return instance, *instance.Status, fmt.Errorf("[ERROR] Instance (%s) went into failed state during the operation \n (%+v) \n [WARNING] Running terraform apply again will remove the tainted instance and attempt to create the instance again replacing the previous configuration", *instance.ID, string(out))
+				return instance, *instance.Status, flex.FmtErrorf("[ERROR] Instance (%s) went into failed state during the operation \n (%+v) \n [WARNING] Running terraform apply again will remove the tainted instance and attempt to create the instance again replacing the previous configuration", *instance.ID, string(out))
 			}
 			return instance, *instance.Status, nil
 
@@ -3923,7 +3923,7 @@ func isRestartStartAction(instanceC *vpcv1.VpcV1, id string, d *schema.ResourceD
 			}
 			_, response, err := instanceC.CreateInstanceAction(createinsactoptions)
 			if err != nil {
-				communicator <- fmt.Errorf("[ERROR] Error retrying instance action start: %s\n%s", err, response)
+				communicator <- flex.FmtErrorf("[ERROR] Error retrying instance action start: %s\n%s", err, response)
 				return
 			}
 			waitTimeout := time.Duration(1) * time.Minute
@@ -3935,7 +3935,7 @@ func isRestartStartAction(instanceC *vpcv1.VpcV1, id string, d *schema.ResourceD
 			}
 			_, response, err = instanceC.CreateInstanceAction(createinsactoptions)
 			if err != nil {
-				communicator <- fmt.Errorf("[ERROR] Error retrying instance action start: %s\n%s", err, response)
+				communicator <- flex.FmtErrorf("[ERROR] Error retrying instance action start: %s\n%s", err, response)
 				return
 			}
 		case <-communicator:
@@ -3974,11 +3974,11 @@ func instanceGet(d *schema.ResourceData, meta interface{}, id string) error {
 			d.SetId("")
 			return nil
 		}
-		return fmt.Errorf("[ERROR] Error getting Instance: %s\n%s", err, response)
+		return flex.FmtErrorf("[ERROR] Error getting Instance: %s\n%s", err, response)
 	}
 	instanceInitialization, response, err := instanceC.GetInstanceInitialization(getinsIniOptions)
 	if err != nil {
-		return fmt.Errorf("[ERROR] Error getting Instance initialization details: %s\n%s", err, response)
+		return flex.FmtErrorf("[ERROR] Error getting Instance initialization details: %s\n%s", err, response)
 	}
 	if instanceInitialization.DefaultTrustedProfile != nil && instanceInitialization.DefaultTrustedProfile.AutoLink != nil {
 		d.Set(isInstanceDefaultTrustedProfileAutoLink, *instanceInitialization.DefaultTrustedProfile.AutoLink)
@@ -4069,7 +4069,7 @@ func instanceGet(d *schema.ResourceData, meta interface{}, id string) error {
 		}
 		insRip, response, err := instanceC.GetSubnetReservedIP(getripoptions)
 		if err != nil {
-			return fmt.Errorf("[ERROR] Error getting network interface reserved ip(%s) attached to the instance network interface(%s): %s\n%s", *instance.PrimaryNetworkInterface.PrimaryIP.ID, *instance.PrimaryNetworkInterface.ID, err, response)
+			return flex.FmtErrorf("[ERROR] Error getting network interface reserved ip(%s) attached to the instance network interface(%s): %s\n%s", *instance.PrimaryNetworkInterface.PrimaryIP.ID, *instance.PrimaryNetworkInterface.ID, err, response)
 		}
 		currentPrimIp[isInstanceNicReservedIpAutoDelete] = insRip.AutoDelete
 
@@ -4082,7 +4082,7 @@ func instanceGet(d *schema.ResourceData, meta interface{}, id string) error {
 		}
 		insnic, response, err := instanceC.GetInstanceNetworkInterface(getnicoptions)
 		if err != nil {
-			return fmt.Errorf("[ERROR] Error getting network interfaces attached to the instance %s\n%s", err, response)
+			return flex.FmtErrorf("[ERROR] Error getting network interfaces attached to the instance %s\n%s", err, response)
 		}
 		currentPrimNic[isInstanceNicAllowIPSpoofing] = *insnic.AllowIPSpoofing
 		if insnic.PortSpeed != nil {
@@ -4160,14 +4160,14 @@ func instanceGet(d *schema.ResourceData, meta interface{}, id string) error {
 		}
 		pna, response, err := instanceC.GetInstanceNetworkAttachment(getInstanceNetworkAttachment)
 		if err != nil {
-			return fmt.Errorf("[ERROR] Error on GetInstanceNetworkAttachment in instance : %s\n%s", err, response)
+			return flex.FmtErrorf("[ERROR] Error on GetInstanceNetworkAttachment in instance : %s\n%s", err, response)
 		}
 		primaryNetworkAttachmentMap, err := resourceIBMIsInstanceInstanceNetworkAttachmentReferenceToMap(instance.PrimaryNetworkAttachment, pna, instanceC, autoDelete)
 		if err != nil {
 			return err
 		}
 		if err = d.Set("primary_network_attachment", []map[string]interface{}{primaryNetworkAttachmentMap}); err != nil {
-			return fmt.Errorf("[ERROR] Error setting primary_network_attachment: %s", err)
+			return flex.FmtErrorf("[ERROR] Error setting primary_network_attachment: %s", err)
 		}
 	}
 
@@ -4206,7 +4206,7 @@ func instanceGet(d *schema.ResourceData, meta interface{}, id string) error {
 				}
 				insRip, response, err := instanceC.GetSubnetReservedIP(getripoptions)
 				if err != nil {
-					return fmt.Errorf("[ERROR] Error getting network interface reserved ip(%s) attached to the instance network interface(%s): %s\n%s", *intfc.PrimaryIP.ID, *intfc.ID, err, response)
+					return flex.FmtErrorf("[ERROR] Error getting network interface reserved ip(%s) attached to the instance network interface(%s): %s\n%s", *intfc.PrimaryIP.ID, *intfc.ID, err, response)
 				}
 				currentPrimIp[isInstanceNicReservedIpAutoDelete] = insRip.AutoDelete
 
@@ -4219,7 +4219,7 @@ func instanceGet(d *schema.ResourceData, meta interface{}, id string) error {
 				}
 				insnic, response, err := instanceC.GetInstanceNetworkInterface(getnicoptions)
 				if err != nil {
-					return fmt.Errorf("[ERROR] Error getting network interfaces attached to the instance %s\n%s", err, response)
+					return flex.FmtErrorf("[ERROR] Error getting network interfaces attached to the instance %s\n%s", err, response)
 				}
 				currentNic[isInstanceNicAllowIPSpoofing] = *insnic.AllowIPSpoofing
 				currentNic[isInstanceNicSubnet] = *insnic.Subnet.ID
@@ -4253,7 +4253,7 @@ func instanceGet(d *schema.ResourceData, meta interface{}, id string) error {
 				}
 				na, response, err := instanceC.GetInstanceNetworkAttachment(getInstanceNetworkAttachment)
 				if err != nil {
-					return fmt.Errorf("[ERROR] Error on GetInstanceNetworkAttachment in instance : %s\n%s", err, response)
+					return flex.FmtErrorf("[ERROR] Error on GetInstanceNetworkAttachment in instance : %s\n%s", err, response)
 				}
 				networkAttachmentsItemMap, err := resourceIBMIsInstanceInstanceNetworkAttachmentReferenceToMap(&networkAttachmentsItem, na, instanceC, autoDelete)
 				if err != nil {
@@ -4263,7 +4263,7 @@ func instanceGet(d *schema.ResourceData, meta interface{}, id string) error {
 			}
 		}
 		if err = d.Set("network_attachments", networkAttachments); err != nil {
-			return fmt.Errorf("[ERROR] Error setting network_attachments: %s", err)
+			return flex.FmtErrorf("[ERROR] Error setting network_attachments: %s", err)
 		}
 	}
 	if instance.Image != nil {
@@ -4333,7 +4333,7 @@ func instanceGet(d *schema.ResourceData, meta interface{}, id string) error {
 			}
 			bootVolumeAtt, response, err := instanceC.GetInstanceVolumeAttachment(getinsVolAttOptions)
 			if err != nil {
-				return fmt.Errorf("[ERROR] Error getting Instance boot volume attachment : %s\n%s", err, response)
+				return flex.FmtErrorf("[ERROR] Error getting Instance boot volume attachment : %s\n%s", err, response)
 			}
 
 			bootVol[isInstanceVolAttVolAutoDelete] = *bootVolumeAtt.DeleteVolumeOnInstanceDelete
@@ -4410,7 +4410,7 @@ func instanceGet(d *schema.ResourceData, meta interface{}, id string) error {
 			disks = append(disks, disksItemMap)
 		}
 		if err = d.Set(isInstanceDisks, disks); err != nil {
-			return fmt.Errorf("[ERROR] Error setting disks: %s", err)
+			return flex.FmtErrorf("[ERROR] Error setting disks: %s", err)
 		}
 	}
 
@@ -4420,7 +4420,7 @@ func instanceGet(d *schema.ResourceData, meta interface{}, id string) error {
 		placementTarget = append(placementTarget, placementTargetMap)
 	}
 	if err = d.Set(isInstancePlacementTarget, placementTarget); err != nil {
-		return fmt.Errorf("[ERROR] Error setting placement_target: %s", err)
+		return flex.FmtErrorf("[ERROR] Error setting placement_target: %s", err)
 	}
 	return nil
 }
@@ -4463,7 +4463,7 @@ func instanceUpdate(d *schema.ResourceData, meta interface{}) error {
 						}
 						res, err := instanceC.DeleteInstanceNetworkAttachment(deleteInstanceNetworkAttachmentOptions)
 						if err != nil {
-							return fmt.Errorf("[ERROR] Error while deleting network attachment(%s) of instance(%s) \n%s: %q", nacIdStr, d.Id(), err, res)
+							return flex.FmtErrorf("[ERROR] Error while deleting network attachment(%s) of instance(%s) \n%s: %q", nacIdStr, d.Id(), err, res)
 						}
 					}
 				}
@@ -4494,7 +4494,7 @@ func instanceUpdate(d *schema.ResourceData, meta interface{}) error {
 				}
 				_, res, err := instanceC.CreateInstanceNetworkAttachment(createInstanceNetworkAttachmentOptions)
 				if err != nil {
-					return fmt.Errorf("[ERROR] Error while creating network attachment(%s) of instance(%s) \n%s: %q", nacNameStr, d.Id(), err, res)
+					return flex.FmtErrorf("[ERROR] Error while creating network attachment(%s) of instance(%s) \n%s: %q", nacNameStr, d.Id(), err, res)
 				}
 			} else {
 				log.Printf("[DEBUG] nacId is not empty")
@@ -4513,12 +4513,12 @@ func instanceUpdate(d *schema.ResourceData, meta interface{}) error {
 					}
 					instanceNetworkAttachmentPatchAsPatch, err := instanceNetworkAttachmentPatch.AsPatch()
 					if err != nil {
-						return (fmt.Errorf("[ERROR] Error encountered while apply as patch for instanceNetworkAttachmentPatchAsPatch of network attachment(%s) of instance(%s) %s", nacId, id, err))
+						return (flex.FmtErrorf("[ERROR] Error encountered while apply as patch for instanceNetworkAttachmentPatchAsPatch of network attachment(%s) of instance(%s) %s", nacId, id, err))
 					}
 					updateInstanceNetworkAttachmentOptions.InstanceNetworkAttachmentPatch = instanceNetworkAttachmentPatchAsPatch
 					_, res, err := instanceC.UpdateInstanceNetworkAttachment(updateInstanceNetworkAttachmentOptions)
 					if err != nil {
-						return (fmt.Errorf("[ERROR] Error encountered while updating network attachment(%s) name of instance(%s) %s/n%s", nacId, id, err, res))
+						return (flex.FmtErrorf("[ERROR] Error encountered while updating network attachment(%s) name of instance(%s) %s/n%s", nacId, id, err, res))
 					}
 					// output, err := json.MarshalIndent(updateInstanceNetworkAttachmentOptions, "", "    ")
 					// if err == nil {
@@ -4556,13 +4556,13 @@ func instanceUpdate(d *schema.ResourceData, meta interface{}) error {
 					}
 					virtualNetworkInterfacePatchAsPatch, err := virtualNetworkInterfacePatch.AsPatch()
 					if err != nil {
-						return fmt.Errorf("[ERROR] Error encountered while apply as patch for virtualNetworkInterfacePatch of instance(%s) vni (%s) %s", d.Id(), vniId, err)
+						return flex.FmtErrorf("[ERROR] Error encountered while apply as patch for virtualNetworkInterfacePatch of instance(%s) vni (%s) %s", d.Id(), vniId, err)
 					}
 					updateVirtualNetworkInterfaceOptions.VirtualNetworkInterfacePatch = virtualNetworkInterfacePatchAsPatch
 					_, response, err := instanceC.UpdateVirtualNetworkInterface(updateVirtualNetworkInterfaceOptions)
 					if err != nil {
 						log.Printf("[DEBUG] UpdateVirtualNetworkInterfaceWithContext failed %s\n%s", err, response)
-						return fmt.Errorf("UpdateVirtualNetworkInterfaceWithContext failed during instance(%s) network attachment patch %s\n%s", d.Id(), err, response)
+						return flex.FmtErrorf("UpdateVirtualNetworkInterfaceWithContext failed during instance(%s) network attachment patch %s\n%s", d.Id(), err, response)
 					}
 
 					if d.HasChange(ipsName) {
@@ -4597,7 +4597,7 @@ func instanceUpdate(d *schema.ResourceData, meta interface{}) error {
 									_, response, err := instanceC.AddVirtualNetworkInterfaceIP(addVirtualNetworkInterfaceIPOptions)
 									if err != nil {
 										log.Printf("[DEBUG] AddVirtualNetworkInterfaceIPWithContext failed in VirtualNetworkInterface patch during instance nac patch %s\n%s", err, response)
-										return fmt.Errorf("AddVirtualNetworkInterfaceIPWithContext failed in VirtualNetworkInterface patch during instance nac patch %s\n%s", err, response)
+										return flex.FmtErrorf("AddVirtualNetworkInterfaceIPWithContext failed in VirtualNetworkInterface patch during instance nac patch %s\n%s", err, response)
 									}
 								}
 							}
@@ -4611,7 +4611,7 @@ func instanceUpdate(d *schema.ResourceData, meta interface{}) error {
 									response, err := instanceC.RemoveVirtualNetworkInterfaceIP(removeVirtualNetworkInterfaceIPOptions)
 									if err != nil {
 										log.Printf("[DEBUG] RemoveVirtualNetworkInterfaceIPWithContext failed in VirtualNetworkInterface patch during instance nac patch %s\n%s", err, response)
-										return fmt.Errorf("RemoveVirtualNetworkInterfaceIPWithContext failed in VirtualNetworkInterface patch during instance nac patch %s\n%s", err, response)
+										return flex.FmtErrorf("RemoveVirtualNetworkInterfaceIPWithContext failed in VirtualNetworkInterface patch during instance nac patch %s\n%s", err, response)
 									}
 								}
 							}
@@ -4640,12 +4640,12 @@ func instanceUpdate(d *schema.ResourceData, meta interface{}) error {
 						}
 						reservedIpPathAsPatch, err := reservedIpPath.AsPatch()
 						if err != nil {
-							return fmt.Errorf("[ERROR] Error calling reserved ip as patch on vni patch \n%s", err)
+							return flex.FmtErrorf("[ERROR] Error calling reserved ip as patch on vni patch \n%s", err)
 						}
 						updateripoptions.ReservedIPPatch = reservedIpPathAsPatch
 						_, response, err := instanceC.UpdateSubnetReservedIP(updateripoptions)
 						if err != nil {
-							return fmt.Errorf("[ERROR] Error updating vni reserved ip(%s): %s\n%s", ripId, err, response)
+							return flex.FmtErrorf("[ERROR] Error updating vni reserved ip(%s): %s\n%s", ripId, err, response)
 						}
 					}
 					if d.HasChange(sgName) {
@@ -4662,7 +4662,7 @@ func instanceUpdate(d *schema.ResourceData, meta interface{}) error {
 								}
 								_, response, err := instanceC.CreateSecurityGroupTargetBinding(createsgnicoptions)
 								if err != nil {
-									return fmt.Errorf("[ERROR] Error while creating security group %q for virtual network interface %s\n%s: %q", add[i], vniId, err, response)
+									return flex.FmtErrorf("[ERROR] Error while creating security group %q for virtual network interface %s\n%s: %q", add[i], vniId, err, response)
 								}
 								_, err = isWaitForVirtualNetworkInterfaceAvailable(instanceC, vniId, d.Timeout(schema.TimeoutUpdate))
 								if err != nil {
@@ -4679,7 +4679,7 @@ func instanceUpdate(d *schema.ResourceData, meta interface{}) error {
 								}
 								response, err := instanceC.DeleteSecurityGroupTargetBinding(deletesgnicoptions)
 								if err != nil {
-									return fmt.Errorf("[ERROR] Error while removing security group %q for virtual network interface %s\n%s: %q", remove[i], d.Id(), err, response)
+									return flex.FmtErrorf("[ERROR] Error while removing security group %q for virtual network interface %s\n%s: %q", remove[i], d.Id(), err, response)
 								}
 								_, err = isWaitForVirtualNetworkInterfaceAvailable(instanceC, vniId, d.Timeout(schema.TimeoutUpdate))
 								if err != nil {
@@ -4713,12 +4713,12 @@ func instanceUpdate(d *schema.ResourceData, meta interface{}) error {
 			}
 			instanceNetworkAttachmentPatchAsPatch, err := instanceNetworkAttachmentPatch.AsPatch()
 			if err != nil {
-				return (fmt.Errorf("[ERROR] Error encountered while apply as patch for instanceNetworkAttachmentPatchAsPatch of pna of instance(%s) %s", id, err))
+				return (flex.FmtErrorf("[ERROR] Error encountered while apply as patch for instanceNetworkAttachmentPatchAsPatch of pna of instance(%s) %s", id, err))
 			}
 			updateInstanceNetworkAttachmentOptions.InstanceNetworkAttachmentPatch = instanceNetworkAttachmentPatchAsPatch
 			_, res, err := instanceC.UpdateInstanceNetworkAttachment(updateInstanceNetworkAttachmentOptions)
 			if err != nil {
-				return (fmt.Errorf("[ERROR] Error encountered while updating pna name of instance(%s) %s/n%s", id, err, res))
+				return (flex.FmtErrorf("[ERROR] Error encountered while updating pna name of instance(%s) %s/n%s", id, err, res))
 			}
 		}
 		if d.HasChange(nacVniName) {
@@ -4752,13 +4752,13 @@ func instanceUpdate(d *schema.ResourceData, meta interface{}) error {
 			}
 			virtualNetworkInterfacePatchAsPatch, err := virtualNetworkInterfacePatch.AsPatch()
 			if err != nil {
-				return fmt.Errorf("[ERROR] Error encountered while apply as patch for virtualNetworkInterfacePatch of instance(%s) vni (%s) %s", d.Id(), vniId, err)
+				return flex.FmtErrorf("[ERROR] Error encountered while apply as patch for virtualNetworkInterfacePatch of instance(%s) vni (%s) %s", d.Id(), vniId, err)
 			}
 			updateVirtualNetworkInterfaceOptions.VirtualNetworkInterfacePatch = virtualNetworkInterfacePatchAsPatch
 			_, response, err := instanceC.UpdateVirtualNetworkInterface(updateVirtualNetworkInterfaceOptions)
 			if err != nil {
 				log.Printf("[DEBUG] UpdateVirtualNetworkInterfaceWithContext failed %s\n%s", err, response)
-				return fmt.Errorf("UpdateVirtualNetworkInterfaceWithContext failed during instance(%s) network attachment patch %s\n%s", d.Id(), err, response)
+				return flex.FmtErrorf("UpdateVirtualNetworkInterfaceWithContext failed during instance(%s) network attachment patch %s\n%s", d.Id(), err, response)
 			}
 
 			if d.HasChange(ipsName) {
@@ -4793,7 +4793,7 @@ func instanceUpdate(d *schema.ResourceData, meta interface{}) error {
 							_, response, err := instanceC.AddVirtualNetworkInterfaceIP(addVirtualNetworkInterfaceIPOptions)
 							if err != nil {
 								log.Printf("[DEBUG] AddVirtualNetworkInterfaceIPWithContext failed in VirtualNetworkInterface patch during instance nac patch %s\n%s", err, response)
-								return fmt.Errorf("AddVirtualNetworkInterfaceIPWithContext failed in VirtualNetworkInterface patch during instance nac patch %s\n%s", err, response)
+								return flex.FmtErrorf("AddVirtualNetworkInterfaceIPWithContext failed in VirtualNetworkInterface patch during instance nac patch %s\n%s", err, response)
 							}
 						}
 					}
@@ -4807,7 +4807,7 @@ func instanceUpdate(d *schema.ResourceData, meta interface{}) error {
 							response, err := instanceC.RemoveVirtualNetworkInterfaceIP(removeVirtualNetworkInterfaceIPOptions)
 							if err != nil {
 								log.Printf("[DEBUG] RemoveVirtualNetworkInterfaceIPWithContext failed in VirtualNetworkInterface patch during instance nac patch %s\n%s", err, response)
-								return fmt.Errorf("RemoveVirtualNetworkInterfaceIPWithContext failed in VirtualNetworkInterface patch during instance nac patch %s\n%s", err, response)
+								return flex.FmtErrorf("RemoveVirtualNetworkInterfaceIPWithContext failed in VirtualNetworkInterface patch during instance nac patch %s\n%s", err, response)
 							}
 						}
 					}
@@ -4836,12 +4836,12 @@ func instanceUpdate(d *schema.ResourceData, meta interface{}) error {
 				}
 				reservedIpPathAsPatch, err := reservedIpPath.AsPatch()
 				if err != nil {
-					return fmt.Errorf("[ERROR] Error calling reserved ip as patch on vni patch \n%s", err)
+					return flex.FmtErrorf("[ERROR] Error calling reserved ip as patch on vni patch \n%s", err)
 				}
 				updateripoptions.ReservedIPPatch = reservedIpPathAsPatch
 				_, response, err := instanceC.UpdateSubnetReservedIP(updateripoptions)
 				if err != nil {
-					return fmt.Errorf("[ERROR] Error updating vni reserved ip(%s): %s\n%s", ripId, err, response)
+					return flex.FmtErrorf("[ERROR] Error updating vni reserved ip(%s): %s\n%s", ripId, err, response)
 				}
 			}
 			if d.HasChange(sgName) {
@@ -4858,7 +4858,7 @@ func instanceUpdate(d *schema.ResourceData, meta interface{}) error {
 						}
 						_, response, err := instanceC.CreateSecurityGroupTargetBinding(createsgnicoptions)
 						if err != nil {
-							return fmt.Errorf("[ERROR] Error while creating security group %q for virtual network interface %s\n%s: %q", add[i], vniId, err, response)
+							return flex.FmtErrorf("[ERROR] Error while creating security group %q for virtual network interface %s\n%s: %q", add[i], vniId, err, response)
 						}
 						_, err = isWaitForVirtualNetworkInterfaceAvailable(instanceC, vniId, d.Timeout(schema.TimeoutUpdate))
 						if err != nil {
@@ -4875,7 +4875,7 @@ func instanceUpdate(d *schema.ResourceData, meta interface{}) error {
 						}
 						response, err := instanceC.DeleteSecurityGroupTargetBinding(deletesgnicoptions)
 						if err != nil {
-							return fmt.Errorf("[ERROR] Error while removing security group %q for virtual network interface %s\n%s: %q", remove[i], d.Id(), err, response)
+							return flex.FmtErrorf("[ERROR] Error while removing security group %q for virtual network interface %s\n%s: %q", remove[i], d.Id(), err, response)
 						}
 						_, err = isWaitForVirtualNetworkInterfaceAvailable(instanceC, vniId, d.Timeout(schema.TimeoutUpdate))
 						if err != nil {
@@ -4899,7 +4899,7 @@ func instanceUpdate(d *schema.ResourceData, meta interface{}) error {
 			}
 			_, response, err := instanceC.GetInstance(getinsOptions)
 			if err != nil {
-				return fmt.Errorf("[ERROR] Error getting instance (%s): %s\n%s", id, err, response)
+				return flex.FmtErrorf("[ERROR] Error getting instance (%s): %s\n%s", id, err, response)
 			}
 			eTag := response.Headers.Get("ETag")
 
@@ -4935,7 +4935,7 @@ func instanceUpdate(d *schema.ResourceData, meta interface{}) error {
 			}
 			mpatch, err := instancePatchModel.AsPatch()
 			if err != nil {
-				return fmt.Errorf("[ERROR] Error calling asPatch with reservation affinity: %s", err)
+				return flex.FmtErrorf("[ERROR] Error calling asPatch with reservation affinity: %s", err)
 			}
 			//Detaching the reservation from the reserved instance
 			if policyStr == "disabled" && idStr == "" {
@@ -4959,7 +4959,7 @@ func instanceUpdate(d *schema.ResourceData, meta interface{}) error {
 	if d.HasChange(bootVolSize) && !d.IsNewResource() {
 		old, new := d.GetChange(bootVolSize)
 		if new.(int) < old.(int) {
-			return fmt.Errorf("[ERROR] Error while updating boot volume size of the instance, only expansion is possible")
+			return flex.FmtErrorf("[ERROR] Error while updating boot volume size of the instance, only expansion is possible")
 		}
 		bootVol := int64(new.(int))
 		volId := d.Get("boot_volume.0.volume_id").(string)
@@ -4972,7 +4972,7 @@ func instanceUpdate(d *schema.ResourceData, meta interface{}) error {
 		volPatchModelAsPatch, err := volPatchModel.AsPatch()
 
 		if err != nil {
-			return (fmt.Errorf("[ERROR] Error encountered while apply as patch for boot volume of instance %s", err))
+			return (flex.FmtErrorf("[ERROR] Error encountered while apply as patch for boot volume of instance %s", err))
 		}
 
 		updateVolumeOptions.VolumePatch = volPatchModelAsPatch
@@ -4980,7 +4980,7 @@ func instanceUpdate(d *schema.ResourceData, meta interface{}) error {
 		vol, res, err := instanceC.UpdateVolume(updateVolumeOptions)
 
 		if vol == nil || err != nil {
-			return (fmt.Errorf("[ERROR] Error encountered while expanding boot volume of instance %s/n%s", err, res))
+			return (flex.FmtErrorf("[ERROR] Error encountered while expanding boot volume of instance %s/n%s", err, res))
 		}
 
 		_, err = isWaitForVolumeAvailable(instanceC, volId, d.Timeout(schema.TimeoutUpdate))
@@ -5007,21 +5007,21 @@ func instanceUpdate(d *schema.ResourceData, meta interface{}) error {
 				volumePatchModel.UserTags = userTagsArray
 				volumePatch, err := volumePatchModel.AsPatch()
 				if err != nil {
-					return fmt.Errorf("[ERROR] Error encountered while apply as patch for boot volume of instance %s", err)
+					return flex.FmtErrorf("[ERROR] Error encountered while apply as patch for boot volume of instance %s", err)
 				}
 				optionsget := &vpcv1.GetVolumeOptions{
 					ID: &volId,
 				}
 				_, response, err := instanceC.GetVolume(optionsget)
 				if err != nil {
-					return fmt.Errorf("[ERROR] Error getting Boot Volume (%s): %s\n%s", id, err, response)
+					return flex.FmtErrorf("[ERROR] Error getting Boot Volume (%s): %s\n%s", id, err, response)
 				}
 				eTag := response.Headers.Get("ETag")
 				updateVolumeOptions.IfMatch = &eTag
 				updateVolumeOptions.VolumePatch = volumePatch
 				vol, res, err := instanceC.UpdateVolume(updateVolumeOptions)
 				if vol == nil || err != nil {
-					return (fmt.Errorf("[ERROR] Error encountered while applying tags for boot volume of instance %s/n%s", err, res))
+					return (flex.FmtErrorf("[ERROR] Error encountered while applying tags for boot volume of instance %s/n%s", err, res))
 				}
 				_, err = isWaitForVolumeAvailable(instanceC, volId, d.Timeout(schema.TimeoutCreate))
 				if err != nil {
@@ -5043,7 +5043,7 @@ func instanceUpdate(d *schema.ResourceData, meta interface{}) error {
 		volPatchModelAsPatch, err := volPatchModel.AsPatch()
 
 		if err != nil {
-			return (fmt.Errorf("[ERROR] Error encountered while apply as patch for boot volume name update of instance %s", err))
+			return (flex.FmtErrorf("[ERROR] Error encountered while apply as patch for boot volume name update of instance %s", err))
 		}
 
 		updateVolumeOptions.VolumePatch = volPatchModelAsPatch
@@ -5051,7 +5051,7 @@ func instanceUpdate(d *schema.ResourceData, meta interface{}) error {
 		vol, res, err := instanceC.UpdateVolume(updateVolumeOptions)
 
 		if vol == nil || err != nil {
-			return (fmt.Errorf("[ERROR] Error encountered while updating name of boot volume of instance %s/n%s", err, res))
+			return (flex.FmtErrorf("[ERROR] Error encountered while updating name of boot volume of instance %s/n%s", err, res))
 		}
 	}
 	bootVolAutoDel := "boot_volume.0.auto_delete_volume"
@@ -5077,7 +5077,7 @@ func instanceUpdate(d *schema.ResourceData, meta interface{}) error {
 				}
 				volAttNamePatchModelAsPatch, err := volAttNamePatchModel.AsPatch()
 				if err != nil || volAttNamePatchModelAsPatch == nil {
-					return fmt.Errorf("[ERROR] Error Instance volume attachment (%s) as patch : %s", id, err)
+					return flex.FmtErrorf("[ERROR] Error Instance volume attachment (%s) as patch : %s", id, err)
 				}
 				updateInstanceVolAttOptions.VolumeAttachmentPatch = volAttNamePatchModelAsPatch
 
@@ -5095,7 +5095,7 @@ func instanceUpdate(d *schema.ResourceData, meta interface{}) error {
 		actiontype := "stop"
 
 		if dedicatedHost == "" && dedicatedHostGroup == "" {
-			return fmt.Errorf("[ERROR] Error: Instances cannot be moved from private to public hosts")
+			return flex.FmtErrorf("[ERROR] Error: Instances cannot be moved from private to public hosts")
 		}
 
 		createinsactoptions := &vpcv1.CreateInstanceActionOptions{
@@ -5107,7 +5107,7 @@ func instanceUpdate(d *schema.ResourceData, meta interface{}) error {
 			if response != nil && response.StatusCode == 404 {
 				return nil
 			}
-			return fmt.Errorf("[ERROR] Error Creating Instance Action: %s\n%s", err, response)
+			return flex.FmtErrorf("[ERROR] Error Creating Instance Action: %s\n%s", err, response)
 		}
 		_, err = isWaitForInstanceActionStop(instanceC, d.Timeout(schema.TimeoutUpdate), id, d)
 		if err != nil {
@@ -5134,7 +5134,7 @@ func instanceUpdate(d *schema.ResourceData, meta interface{}) error {
 
 		instancePatch, err := instancePatchModel.AsPatch()
 		if err != nil {
-			return fmt.Errorf("[ERROR] Error calling asPatch with total volume bandwidth for InstancePatch: %s", err)
+			return flex.FmtErrorf("[ERROR] Error calling asPatch with total volume bandwidth for InstancePatch: %s", err)
 		}
 
 		updateOptions.InstancePatch = instancePatch
@@ -5154,7 +5154,7 @@ func instanceUpdate(d *schema.ResourceData, meta interface{}) error {
 			if response != nil && response.StatusCode == 404 {
 				return nil
 			}
-			return fmt.Errorf("[ERROR] Error Creating Instance Action: %s\n%s", err, response)
+			return flex.FmtErrorf("[ERROR] Error Creating Instance Action: %s\n%s", err, response)
 		}
 		_, err = isWaitForInstanceActionStart(instanceC, d.Timeout(schema.TimeoutUpdate), id, d)
 		if err != nil {
@@ -5171,14 +5171,14 @@ func instanceUpdate(d *schema.ResourceData, meta interface{}) error {
 			}
 			instance, response, err := instanceC.GetInstance(getinsOptions)
 			if err != nil {
-				return fmt.Errorf("[ERROR] Error Getting Instance (%s): %s\n%s", id, err, response)
+				return flex.FmtErrorf("[ERROR] Error Getting Instance (%s): %s\n%s", id, err, response)
 			}
 			if (actiontype == "stop" || actiontype == "reboot") && *instance.Status != isInstanceStatusRunning {
 				d.Set(isInstanceAction, nil)
-				return fmt.Errorf("[ERROR] Error with stop/reboot action: Cannot invoke stop/reboot action while instance is not in running state")
+				return flex.FmtErrorf("[ERROR] Error with stop/reboot action: Cannot invoke stop/reboot action while instance is not in running state")
 			} else if actiontype == "start" && *instance.Status != isInstanceActionStatusStopped {
 				d.Set(isInstanceAction, nil)
-				return fmt.Errorf("[ERROR] Error with start action: Cannot invoke start action while instance is not in stopped state")
+				return flex.FmtErrorf("[ERROR] Error with start action: Cannot invoke start action while instance is not in stopped state")
 			}
 			createinsactoptions := &vpcv1.CreateInstanceActionOptions{
 				InstanceID: &id,
@@ -5190,7 +5190,7 @@ func instanceUpdate(d *schema.ResourceData, meta interface{}) error {
 			}
 			_, response, err = instanceC.CreateInstanceAction(createinsactoptions)
 			if err != nil {
-				return fmt.Errorf("[ERROR] Error Creating Instance Action: %s\n%s", err, response)
+				return flex.FmtErrorf("[ERROR] Error Creating Instance Action: %s\n%s", err, response)
 			}
 			if actiontype == "stop" {
 				_, err = isWaitForInstanceActionStop(instanceC, d.Timeout(schema.TimeoutUpdate), id, d)
@@ -5237,7 +5237,7 @@ func instanceUpdate(d *schema.ResourceData, meta interface{}) error {
 				}
 				vol, _, err := instanceC.CreateInstanceVolumeAttachment(createvolattoptions)
 				if err != nil {
-					return fmt.Errorf("[ERROR] Error while attaching volume %q for instance %s: %q", add[i], d.Id(), err)
+					return flex.FmtErrorf("[ERROR] Error while attaching volume %q for instance %s: %q", add[i], d.Id(), err)
 				}
 				_, err = isWaitForInstanceVolumeAttached(instanceC, d, id, *vol.ID)
 				if err != nil {
@@ -5263,7 +5263,7 @@ func instanceUpdate(d *schema.ResourceData, meta interface{}) error {
 						}
 						_, err := instanceC.DeleteInstanceVolumeAttachment(delvolattoptions)
 						if err != nil {
-							return fmt.Errorf("[ERROR] Error while removing volume %q for instance %s: %q", remove[i], d.Id(), err)
+							return flex.FmtErrorf("[ERROR] Error while removing volume %q for instance %s: %q", remove[i], d.Id(), err)
 						}
 						_, err = isWaitForInstanceVolumeDetached(instanceC, d, d.Id(), *vol.ID)
 						if err != nil {
@@ -5291,7 +5291,7 @@ func instanceUpdate(d *schema.ResourceData, meta interface{}) error {
 				}
 				_, response, err := instanceC.CreateSecurityGroupTargetBinding(createsgnicoptions)
 				if err != nil {
-					return fmt.Errorf("[ERROR] Error while creating security group %q for primary network interface of instance %s\n%s: %q", add[i], d.Id(), err, response)
+					return flex.FmtErrorf("[ERROR] Error while creating security group %q for primary network interface of instance %s\n%s: %q", add[i], d.Id(), err, response)
 				}
 				_, err = isWaitForInstanceAvailable(instanceC, d.Id(), d.Timeout(schema.TimeoutUpdate), d)
 				if err != nil {
@@ -5309,7 +5309,7 @@ func instanceUpdate(d *schema.ResourceData, meta interface{}) error {
 				}
 				response, err := instanceC.DeleteSecurityGroupTargetBinding(deletesgnicoptions)
 				if err != nil {
-					return fmt.Errorf("[ERROR] Error while removing security group %q for primary network interface of instance %s\n%s: %q", remove[i], d.Id(), err, response)
+					return flex.FmtErrorf("[ERROR] Error while removing security group %q for primary network interface of instance %s\n%s: %q", remove[i], d.Id(), err, response)
 				}
 				_, err = isWaitForInstanceAvailable(instanceC, d.Id(), d.Timeout(schema.TimeoutUpdate), d)
 				if err != nil {
@@ -5337,12 +5337,12 @@ func instanceUpdate(d *schema.ResourceData, meta interface{}) error {
 		}
 		reservedIpPathAsPatch, err := reservedIpPath.AsPatch()
 		if err != nil {
-			return fmt.Errorf("[ERROR] Error calling reserved ip as patch \n%s", err)
+			return flex.FmtErrorf("[ERROR] Error calling reserved ip as patch \n%s", err)
 		}
 		updateripoptions.ReservedIPPatch = reservedIpPathAsPatch
 		_, response, err := instanceC.UpdateSubnetReservedIP(updateripoptions)
 		if err != nil {
-			return fmt.Errorf("[ERROR] Error updating instance network interface reserved ip(%s): %s\n%s", ripId, err, response)
+			return flex.FmtErrorf("[ERROR] Error updating instance network interface reserved ip(%s): %s\n%s", ripId, err, response)
 		}
 	}
 
@@ -5361,13 +5361,13 @@ func instanceUpdate(d *schema.ResourceData, meta interface{}) error {
 		}
 		networkInterfacePatch, err := networkInterfacePatchModel.AsPatch()
 		if err != nil {
-			return fmt.Errorf("[ERROR] Error calling asPatch for NetworkInterfacePatch: %s", err)
+			return flex.FmtErrorf("[ERROR] Error calling asPatch for NetworkInterfacePatch: %s", err)
 		}
 		updatepnicfoptions.NetworkInterfacePatch = networkInterfacePatch
 
 		_, response, err := instanceC.UpdateInstanceNetworkInterface(updatepnicfoptions)
 		if err != nil {
-			return fmt.Errorf("[ERROR] Error while updating name %s for primary network interface of instance %s\n%s: %q", newName, d.Id(), err, response)
+			return flex.FmtErrorf("[ERROR] Error while updating name %s for primary network interface of instance %s\n%s: %q", newName, d.Id(), err, response)
 		}
 		_, err = isWaitForInstanceAvailable(instanceC, d.Id(), d.Timeout(schema.TimeoutUpdate), d)
 		if err != nil {
@@ -5403,12 +5403,12 @@ func instanceUpdate(d *schema.ResourceData, meta interface{}) error {
 				}
 				reservedIpPathAsPatch, err := reservedIpPath.AsPatch()
 				if err != nil {
-					return fmt.Errorf("[ERROR] Error calling reserved ip as patch \n%s", err)
+					return flex.FmtErrorf("[ERROR] Error calling reserved ip as patch \n%s", err)
 				}
 				updateripoptions.ReservedIPPatch = reservedIpPathAsPatch
 				_, response, err := instanceC.UpdateSubnetReservedIP(updateripoptions)
 				if err != nil {
-					return fmt.Errorf("[ERROR] Error updating instance network interface reserved ip(%s): %s\n%s", ripId, err, response)
+					return flex.FmtErrorf("[ERROR] Error updating instance network interface reserved ip(%s): %s\n%s", ripId, err, response)
 				}
 			}
 
@@ -5428,7 +5428,7 @@ func instanceUpdate(d *schema.ResourceData, meta interface{}) error {
 						}
 						_, response, err := instanceC.CreateSecurityGroupTargetBinding(createsgnicoptions)
 						if err != nil {
-							return fmt.Errorf("[ERROR] Error while creating security group %q for network interface of instance %s\n%s: %q", add[i], d.Id(), err, response)
+							return flex.FmtErrorf("[ERROR] Error while creating security group %q for network interface of instance %s\n%s: %q", add[i], d.Id(), err, response)
 						}
 						_, err = isWaitForInstanceAvailable(instanceC, d.Id(), d.Timeout(schema.TimeoutUpdate), d)
 						if err != nil {
@@ -5447,7 +5447,7 @@ func instanceUpdate(d *schema.ResourceData, meta interface{}) error {
 						}
 						response, err := instanceC.DeleteSecurityGroupTargetBinding(deletesgnicoptions)
 						if err != nil {
-							return fmt.Errorf("[ERROR] Error while removing security group %q for network interface of instance %s\n%s: %q", remove[i], d.Id(), err, response)
+							return flex.FmtErrorf("[ERROR] Error while removing security group %q for network interface of instance %s\n%s: %q", remove[i], d.Id(), err, response)
 						}
 						_, err = isWaitForInstanceAvailable(instanceC, d.Id(), d.Timeout(schema.TimeoutUpdate), d)
 						if err != nil {
@@ -5474,13 +5474,13 @@ func instanceUpdate(d *schema.ResourceData, meta interface{}) error {
 				}
 				networkInterfacePatch, err := instancePatchModel.AsPatch()
 				if err != nil {
-					return fmt.Errorf("[ERROR] Error calling asPatch for NetworkInterfacePatch: %s", err)
+					return flex.FmtErrorf("[ERROR] Error calling asPatch for NetworkInterfacePatch: %s", err)
 				}
 				updatepnicfoptions.NetworkInterfacePatch = networkInterfacePatch
 
 				_, response, err := instanceC.UpdateInstanceNetworkInterface(updatepnicfoptions)
 				if err != nil {
-					return fmt.Errorf("[ERROR] Error while updating name %s for network interface of instance %s\n%s: %q", newName, d.Id(), err, response)
+					return flex.FmtErrorf("[ERROR] Error while updating name %s for network interface of instance %s\n%s: %q", newName, d.Id(), err, response)
 				}
 				if err != nil {
 					return err
@@ -5501,7 +5501,7 @@ func instanceUpdate(d *schema.ResourceData, meta interface{}) error {
 		}
 		instancePatch, err := instancePatchModel.AsPatch()
 		if err != nil {
-			return fmt.Errorf("[ERROR] Error calling asPatch with total volume bandwidth for InstancePatch: %s", err)
+			return flex.FmtErrorf("[ERROR] Error calling asPatch with total volume bandwidth for InstancePatch: %s", err)
 		}
 		updnetoptions.InstancePatch = instancePatch
 
@@ -5522,7 +5522,7 @@ func instanceUpdate(d *schema.ResourceData, meta interface{}) error {
 		}
 		instancePatch, err := instancePatchModel.AsPatch()
 		if err != nil {
-			return fmt.Errorf("[ERROR] Error calling asPatch for InstancePatch: %s", err)
+			return flex.FmtErrorf("[ERROR] Error calling asPatch for InstancePatch: %s", err)
 		}
 		updnetoptions.InstancePatch = instancePatch
 
@@ -5544,7 +5544,7 @@ func instanceUpdate(d *schema.ResourceData, meta interface{}) error {
 		}
 		instancePatch, err := instancePatchModel.AsPatch()
 		if err != nil {
-			return fmt.Errorf("[ERROR] Error calling asPatch for InstancePatch: %s", err)
+			return flex.FmtErrorf("[ERROR] Error calling asPatch for InstancePatch: %s", err)
 		}
 		updatedoptions.InstancePatch = instancePatch
 
@@ -5587,7 +5587,7 @@ func instanceUpdate(d *schema.ResourceData, meta interface{}) error {
 
 		instancePatch, err := instancePatchModel.AsPatch()
 		if err != nil {
-			return fmt.Errorf("[ERROR] Error calling asPatch for InstancePatch: %s", err)
+			return flex.FmtErrorf("[ERROR] Error calling asPatch for InstancePatch: %s", err)
 		}
 		updatedoptions.InstancePatch = instancePatch
 
@@ -5610,7 +5610,7 @@ func instanceUpdate(d *schema.ResourceData, meta interface{}) error {
 		}
 		instancePatch, err := instancePatchModel.AsPatch()
 		if err != nil {
-			return fmt.Errorf("[ERROR] Error calling asPatch for InstancePatch: %s", err)
+			return flex.FmtErrorf("[ERROR] Error calling asPatch for InstancePatch: %s", err)
 		}
 		updatedoptions.InstancePatch = instancePatch
 
@@ -5631,7 +5631,7 @@ func instanceUpdate(d *schema.ResourceData, meta interface{}) error {
 				d.SetId("")
 				return nil
 			}
-			return fmt.Errorf("[ERROR] Error Getting Instance (%s): %s\n%s", id, err, response)
+			return flex.FmtErrorf("[ERROR] Error Getting Instance (%s): %s\n%s", id, err, response)
 		}
 
 		if instance != nil && *instance.Status == "running" {
@@ -5645,7 +5645,7 @@ func instanceUpdate(d *schema.ResourceData, meta interface{}) error {
 				if response != nil && response.StatusCode == 404 {
 					return nil
 				}
-				return fmt.Errorf("[ERROR] Error Creating Instance Action: %s\n%s", err, response)
+				return flex.FmtErrorf("[ERROR] Error Creating Instance Action: %s\n%s", err, response)
 			}
 			_, err = isWaitForInstanceActionStop(instanceC, d.Timeout(schema.TimeoutUpdate), id, d)
 			if err != nil {
@@ -5666,13 +5666,13 @@ func instanceUpdate(d *schema.ResourceData, meta interface{}) error {
 		}
 		instancePatch, err := instancePatchModel.AsPatch()
 		if err != nil {
-			return fmt.Errorf("[ERROR] Error calling asPatch for InstancePatch: %s", err)
+			return flex.FmtErrorf("[ERROR] Error calling asPatch for InstancePatch: %s", err)
 		}
 		updnetoptions.InstancePatch = instancePatch
 
 		_, response, err = instanceC.UpdateInstance(updnetoptions)
 		if err != nil {
-			return fmt.Errorf("[ERROR] Error in UpdateInstancePatch: %s\n%s", err, response)
+			return flex.FmtErrorf("[ERROR] Error in UpdateInstancePatch: %s\n%s", err, response)
 		}
 
 		actiontype := "start"
@@ -5685,7 +5685,7 @@ func instanceUpdate(d *schema.ResourceData, meta interface{}) error {
 			if response != nil && response.StatusCode == 404 {
 				return nil
 			}
-			return fmt.Errorf("[ERROR] Error Creating Instance Action: %s\n%s", err, response)
+			return flex.FmtErrorf("[ERROR] Error Creating Instance Action: %s\n%s", err, response)
 		}
 		_, err = isWaitForInstanceAvailable(instanceC, d.Id(), d.Timeout(schema.TimeoutUpdate), d)
 		if err != nil {
@@ -5699,7 +5699,7 @@ func instanceUpdate(d *schema.ResourceData, meta interface{}) error {
 	}
 	instance, response, err := instanceC.GetInstance(getinsOptions)
 	if err != nil {
-		return fmt.Errorf("[ERROR] Error Getting Instance: %s\n%s", err, response)
+		return flex.FmtErrorf("[ERROR] Error Getting Instance: %s\n%s", err, response)
 	}
 	if d.HasChange(isInstanceTags) {
 		oldList, newList := d.GetChange(isInstanceTags)
@@ -5746,7 +5746,7 @@ func instanceDelete(d *schema.ResourceData, meta interface{}, id string) error {
 			d.SetId("")
 			return nil
 		}
-		return fmt.Errorf("[ERROR] Error Getting Instance (%s): %s\n%s", id, err, response)
+		return flex.FmtErrorf("[ERROR] Error Getting Instance (%s): %s\n%s", id, err, response)
 	}
 
 	bootvolid := ""
@@ -5762,7 +5762,7 @@ func instanceDelete(d *schema.ResourceData, meta interface{}, id string) error {
 			if response != nil && response.StatusCode == 404 {
 				return nil
 			}
-			return fmt.Errorf("[ERROR] Error Creating Instance Action: %s\n%s", err, response)
+			return flex.FmtErrorf("[ERROR] Error Creating Instance Action: %s\n%s", err, response)
 		}
 		_, err = isWaitForInstanceActionStop(instanceC, d.Timeout(schema.TimeoutDelete), id, d)
 		if err != nil {
@@ -5773,7 +5773,7 @@ func instanceDelete(d *schema.ResourceData, meta interface{}, id string) error {
 		}
 		vols, response, err := instanceC.ListInstanceVolumeAttachments(listvolattoptions)
 		if err != nil {
-			return fmt.Errorf("[ERROR] Error Listing volume attachments to the instance: %s\n%s", err, response)
+			return flex.FmtErrorf("[ERROR] Error Listing volume attachments to the instance: %s\n%s", err, response)
 		}
 		for _, vol := range vols.VolumeAttachments {
 			if *vol.Type == "data" {
@@ -5783,7 +5783,7 @@ func instanceDelete(d *schema.ResourceData, meta interface{}, id string) error {
 				}
 				_, err := instanceC.DeleteInstanceVolumeAttachment(delvolattoptions)
 				if err != nil {
-					return fmt.Errorf("[ERROR] Error while removing volume Attachment %q for instance %s: %q", *vol.ID, d.Id(), err)
+					return flex.FmtErrorf("[ERROR] Error while removing volume Attachment %q for instance %s: %q", *vol.ID, d.Id(), err)
 				}
 				_, err = isWaitForInstanceVolumeDetached(instanceC, d, d.Id(), *vol.ID)
 				if err != nil {
@@ -5845,7 +5845,7 @@ func instanceExists(d *schema.ResourceData, meta interface{}, id string) (bool, 
 		if response != nil && response.StatusCode == 404 {
 			return false, nil
 		}
-		return false, fmt.Errorf("[ERROR] Error Getting Instance: %s\n%s", err, response)
+		return false, flex.FmtErrorf("[ERROR] Error Getting Instance: %s\n%s", err, response)
 	}
 	return true, nil
 }
@@ -5873,10 +5873,10 @@ func isWaitForInstanceDelete(instanceC *vpcv1.VpcV1, d *schema.ResourceData, id 
 				if response != nil && response.StatusCode == 404 {
 					return instance, isInstanceDeleteDone, nil
 				}
-				return nil, "", fmt.Errorf("[ERROR] Error Getting Instance: %s\n%s", err, response)
+				return nil, "", flex.FmtErrorf("[ERROR] Error Getting Instance: %s\n%s", err, response)
 			}
 			if *instance.Status == isInstanceFailed {
-				return instance, *instance.Status, fmt.Errorf("[ERROR] The  instance %s failed to delete: %v", d.Id(), err)
+				return instance, *instance.Status, flex.FmtErrorf("[ERROR] The  instance %s failed to delete: %v", d.Id(), err)
 			}
 			return instance, isInstanceDeleting, nil
 		},
@@ -5899,7 +5899,7 @@ func isWaitForInstanceActionStop(instanceC *vpcv1.VpcV1, timeout time.Duration, 
 			}
 			instance, response, err := instanceC.GetInstance(getinsoptions)
 			if err != nil {
-				return nil, "", fmt.Errorf("[ERROR] Error Getting Instance: %s\n%s", err, response)
+				return nil, "", flex.FmtErrorf("[ERROR] Error Getting Instance: %s\n%s", err, response)
 			}
 			select {
 			case data := <-communicator:
@@ -5910,7 +5910,7 @@ func isWaitForInstanceActionStop(instanceC *vpcv1.VpcV1, timeout time.Duration, 
 			if *instance.Status == isInstanceStatusFailed {
 				// let know the isRestartStopAction() to stop
 				close(communicator)
-				return instance, *instance.Status, fmt.Errorf("[ERROR] The  instance %s failed to stop: %v", id, err)
+				return instance, *instance.Status, flex.FmtErrorf("[ERROR] The  instance %s failed to stop: %v", id, err)
 			}
 			return instance, *instance.Status, nil
 		},
@@ -5938,7 +5938,7 @@ func isWaitForInstanceActionStart(instanceC *vpcv1.VpcV1, timeout time.Duration,
 			}
 			instance, response, err := instanceC.GetInstance(getinsoptions)
 			if err != nil {
-				return nil, "", fmt.Errorf("[ERROR] Error Getting Instance: %s\n%s", err, response)
+				return nil, "", flex.FmtErrorf("[ERROR] Error Getting Instance: %s\n%s", err, response)
 			}
 			select {
 			case data := <-communicator:
@@ -5949,7 +5949,7 @@ func isWaitForInstanceActionStart(instanceC *vpcv1.VpcV1, timeout time.Duration,
 			if *instance.Status == isInstanceStatusFailed {
 				// let know the isRestartStopAction() to stop
 				close(communicator)
-				return instance, *instance.Status, fmt.Errorf("[ERROR] The  instance %s failed to start: %v", id, err)
+				return instance, *instance.Status, flex.FmtErrorf("[ERROR] The  instance %s failed to start: %v", id, err)
 			}
 			return instance, *instance.Status, nil
 		},
@@ -5981,7 +5981,7 @@ func isRestartStopAction(instanceC *vpcv1.VpcV1, id string, d *schema.ResourceDa
 			}
 			_, response, err := instanceC.CreateInstanceAction(createinsactoptions)
 			if err != nil {
-				communicator <- fmt.Errorf("[ERROR] Error retrying instance action stop: %s\n%s", err, response)
+				communicator <- flex.FmtErrorf("[ERROR] Error retrying instance action stop: %s\n%s", err, response)
 				return
 			}
 		case <-communicator:
@@ -6016,7 +6016,7 @@ func isInstanceVolumeRefreshFunc(instanceC *vpcv1.VpcV1, id, volID string) resou
 		}
 		vol, response, err := instanceC.GetInstanceVolumeAttachment(getvolattoptions)
 		if err != nil {
-			return nil, "", fmt.Errorf("[ERROR] Error Attaching volume: %s\n%s", err, response)
+			return nil, "", flex.FmtErrorf("[ERROR] Error Attaching volume: %s\n%s", err, response)
 		}
 
 		if *vol.Status == isInstanceVolumeAttached {
@@ -6042,10 +6042,10 @@ func isWaitForInstanceVolumeDetached(instanceC *vpcv1.VpcV1, d *schema.ResourceD
 				if response != nil && response.StatusCode == 404 {
 					return vol, isInstanceDeleteDone, nil
 				}
-				return nil, "", fmt.Errorf("[ERROR] Error Detaching: %s\n%s", err, response)
+				return nil, "", flex.FmtErrorf("[ERROR] Error Detaching: %s\n%s", err, response)
 			}
 			if *vol.Status == isInstanceFailed {
-				return vol, *vol.Status, fmt.Errorf("[ERROR] The instance %s failed to detach volume %s: %v", d.Id(), volID, err)
+				return vol, *vol.Status, flex.FmtErrorf("[ERROR] The instance %s failed to detach volume %s: %v", d.Id(), volID, err)
 			}
 			return vol, isInstanceVolumeDetaching, nil
 		},
@@ -6167,7 +6167,7 @@ func resourceIBMIsInstanceInstanceNetworkAttachmentReferenceToMap(model *vpcv1.I
 	}
 	vniDetails, response, err := instanceC.GetVirtualNetworkInterface(getVirtualNetworkInterfaceOptions)
 	if err != nil {
-		return nil, fmt.Errorf("[ERROR] Error on GetInstanceNetworkAttachment in instance : %s\n%s", err, response)
+		return nil, flex.FmtErrorf("[ERROR] Error on GetInstanceNetworkAttachment in instance : %s\n%s", err, response)
 	}
 	vniMap["allow_ip_spoofing"] = vniDetails.AllowIPSpoofing
 	vniMap["auto_delete"] = vniDetails.AutoDelete

--- a/ibm/service/vpc/resource_ibm_is_instance_action.go
+++ b/ibm/service/vpc/resource_ibm_is_instance_action.go
@@ -5,9 +5,9 @@ package vpc
 
 import (
 	"context"
-	"fmt"
 	"time"
 
+	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/flex"
 	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/validate"
 	"github.com/IBM/vpc-go-sdk/vpcv1"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
@@ -126,14 +126,14 @@ func resourceIBMISInstanceActionCreate(context context.Context, d *schema.Resour
 	}
 	instance, response, err := sess.GetInstance(getinsOptions)
 	if err != nil {
-		return diag.FromErr(fmt.Errorf("[ERROR] Error Getting Instance (%s): %s\n%s", instanceId, err, response))
+		return diag.FromErr(flex.FmtErrorf("[ERROR] Error Getting Instance (%s): %s\n%s", instanceId, err, response))
 	}
 	if (actiontype == "stop" || actiontype == "reboot") && *instance.Status != isInstanceStatusRunning {
 		d.Set(isInstanceAction, nil)
-		return diag.FromErr(fmt.Errorf("[ERROR] Error with stop/reboot action: Cannot invoke stop/reboot action while instance is not in running state"))
+		return diag.FromErr(flex.FmtErrorf("[ERROR] Error with stop/reboot action: Cannot invoke stop/reboot action while instance is not in running state"))
 	} else if actiontype == "start" && *instance.Status != isInstanceActionStatusStopped {
 		d.Set(isInstanceAction, nil)
-		return diag.FromErr(fmt.Errorf("[ERROR] Error with start action: Cannot invoke start action while instance is not in stopped state"))
+		return diag.FromErr(flex.FmtErrorf("[ERROR] Error with start action: Cannot invoke start action while instance is not in stopped state"))
 	}
 	createinsactoptions := &vpcv1.CreateInstanceActionOptions{
 		InstanceID: &instanceId,
@@ -148,7 +148,7 @@ func resourceIBMISInstanceActionCreate(context context.Context, d *schema.Resour
 		if response != nil && response.StatusCode == 404 {
 			return nil
 		}
-		return diag.FromErr(fmt.Errorf("[ERROR] Error Creating Instance Action: %s\n%s", err, response))
+		return diag.FromErr(flex.FmtErrorf("[ERROR] Error Creating Instance Action: %s\n%s", err, response))
 	}
 	if actiontype == "stop" {
 		_, err = isWaitForInstanceActionStop(sess, d.Timeout(schema.TimeoutUpdate), instanceId, d)
@@ -182,7 +182,7 @@ func resourceIBMISInstanceActionRead(context context.Context, d *schema.Resource
 			d.SetId("")
 			return nil
 		}
-		return diag.FromErr(fmt.Errorf("[ERROR] Error getting instance (%s): %s\n%s", id, err, response))
+		return diag.FromErr(flex.FmtErrorf("[ERROR] Error getting instance (%s): %s\n%s", id, err, response))
 	}
 
 	d.Set(isInstanceStatus, *instance.Status)
@@ -218,14 +218,14 @@ func resourceIBMISInstanceActionUpdate(context context.Context, d *schema.Resour
 	}
 	instance, response, err := sess.GetInstance(getinsOptions)
 	if err != nil {
-		return diag.FromErr(fmt.Errorf("[ERROR] Error Getting Instance (%s): %s\n%s", id, err, response))
+		return diag.FromErr(flex.FmtErrorf("[ERROR] Error Getting Instance (%s): %s\n%s", id, err, response))
 	}
 	if (actiontype == "stop" || actiontype == "reboot") && *instance.Status != isInstanceStatusRunning {
 		d.Set(isInstanceAction, nil)
-		return diag.FromErr(fmt.Errorf("[ERROR] Error with stop/reboot action: Cannot invoke stop/reboot action while instance is not in running state"))
+		return diag.FromErr(flex.FmtErrorf("[ERROR] Error with stop/reboot action: Cannot invoke stop/reboot action while instance is not in running state"))
 	} else if actiontype == "start" && *instance.Status != isInstanceActionStatusStopped {
 		d.Set(isInstanceAction, nil)
-		return diag.FromErr(fmt.Errorf("[ERROR] Error with start action: Cannot invoke start action while instance is not in stopped state"))
+		return diag.FromErr(flex.FmtErrorf("[ERROR] Error with start action: Cannot invoke start action while instance is not in stopped state"))
 	}
 	createinsactoptions := &vpcv1.CreateInstanceActionOptions{
 		InstanceID: &id,
@@ -236,7 +236,7 @@ func resourceIBMISInstanceActionUpdate(context context.Context, d *schema.Resour
 		if response != nil && response.StatusCode == 404 {
 			return nil
 		}
-		return diag.FromErr(fmt.Errorf("[ERROR] Error Creating Instance Action: %s\n%s", err, response))
+		return diag.FromErr(flex.FmtErrorf("[ERROR] Error Creating Instance Action: %s\n%s", err, response))
 	}
 	if actiontype == "stop" {
 		_, err = isWaitForInstanceActionStop(sess, d.Timeout(schema.TimeoutUpdate), id, d)
@@ -272,7 +272,7 @@ func resourceIBMISInstanceActionExists(d *schema.ResourceData, meta interface{})
 		if response != nil && response.StatusCode == 404 {
 			return false, nil
 		}
-		return false, fmt.Errorf("[ERROR] Error getting instance : %s\n%s", err, response)
+		return false, flex.FmtErrorf("[ERROR] Error getting instance : %s\n%s", err, response)
 	}
 	return true, err
 }

--- a/ibm/service/vpc/resource_ibm_is_instance_disk_management.go
+++ b/ibm/service/vpc/resource_ibm_is_instance_disk_management.go
@@ -4,8 +4,7 @@
 package vpc
 
 import (
-	"fmt"
-
+	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/flex"
 	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/validate"
 	"github.com/IBM/vpc-go-sdk/vpcv1"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -93,13 +92,13 @@ func resourceIBMisInstanceDiskManagementCreate(d *schema.ResourceData, meta inte
 
 		instanceDiskPatch, err := instanceDiskPatchModel.AsPatch()
 		if err != nil {
-			return fmt.Errorf("[ERROR] Error calling asPatch for InstanceDiskPatch: %s", err)
+			return flex.FmtErrorf("[ERROR] Error calling asPatch for InstanceDiskPatch: %s", err)
 		}
 		updateInstanceDiskOptions.SetInstanceDiskPatch(instanceDiskPatch)
 
 		_, response, err := sess.UpdateInstanceDisk(updateInstanceDiskOptions)
 		if err != nil {
-			return fmt.Errorf("[ERROR] Error calling UpdateInstanceDisk: %s %s", err, response)
+			return flex.FmtErrorf("[ERROR] Error calling UpdateInstanceDisk: %s %s", err, response)
 		}
 
 	}
@@ -131,13 +130,13 @@ func resourceIBMisInstanceDiskManagementUpdate(d *schema.ResourceData, meta inte
 
 			instanceDiskPatch, err := instanceDiskPatchModel.AsPatch()
 			if err != nil {
-				return fmt.Errorf("[ERROR] Error calling asPatch for InstanceDiskPatch: %s", err)
+				return flex.FmtErrorf("[ERROR] Error calling asPatch for InstanceDiskPatch: %s", err)
 			}
 			updateInstanceDiskOptions.SetInstanceDiskPatch(instanceDiskPatch)
 
 			_, _, err = sess.UpdateInstanceDisk(updateInstanceDiskOptions)
 			if err != nil {
-				return fmt.Errorf("[ERROR] Error updating instance disk: %s", err)
+				return flex.FmtErrorf("[ERROR] Error updating instance disk: %s", err)
 			}
 
 		}

--- a/ibm/service/vpc/resource_ibm_is_instance_group_manager.go
+++ b/ibm/service/vpc/resource_ibm_is_instance_group_manager.go
@@ -209,7 +209,7 @@ func resourceIBMISInstanceGroupManagerCreate(d *schema.ResourceData, meta interf
 		}
 		instanceGroupManagerIntf, response, err := sess.CreateInstanceGroupManager(&createInstanceGroupManagerOptions)
 		if err != nil || instanceGroupManagerIntf == nil {
-			return fmt.Errorf("[ERROR] Error creating InstanceGroup manager: %s\n%s", err, response)
+			return flex.FmtErrorf("[ERROR] Error creating InstanceGroup manager: %s\n%s", err, response)
 		}
 		instanceGroupManager := instanceGroupManagerIntf.(*vpcv1.InstanceGroupManager)
 		d.SetId(fmt.Sprintf("%s/%s", instanceGroupID, *instanceGroupManager.ID))
@@ -261,7 +261,7 @@ func resourceIBMISInstanceGroupManagerCreate(d *schema.ResourceData, meta interf
 
 		instanceGroupManagerIntf, response, err := sess.CreateInstanceGroupManager(&createInstanceGroupManagerOptions)
 		if err != nil || instanceGroupManagerIntf == nil {
-			return fmt.Errorf("[ERROR] Error creating InstanceGroup manager: %s\n%s", err, response)
+			return flex.FmtErrorf("[ERROR] Error creating InstanceGroup manager: %s\n%s", err, response)
 		}
 		instanceGroupManager := instanceGroupManagerIntf.(*vpcv1.InstanceGroupManager)
 
@@ -333,7 +333,7 @@ func resourceIBMISInstanceGroupManagerUpdate(d *schema.ResourceData, meta interf
 		updateInstanceGroupManagerOptions.InstanceGroupID = &instanceGroupID
 		instanceGroupManagerPatch, err := instanceGroupManagerPatchModel.AsPatch()
 		if err != nil {
-			return fmt.Errorf("[ERROR] Error calling asPatch for InstanceGroupManagerPatch: %s", err)
+			return flex.FmtErrorf("[ERROR] Error calling asPatch for InstanceGroupManagerPatch: %s", err)
 		}
 		updateInstanceGroupManagerOptions.InstanceGroupManagerPatch = instanceGroupManagerPatch
 
@@ -344,7 +344,7 @@ func resourceIBMISInstanceGroupManagerUpdate(d *schema.ResourceData, meta interf
 
 		_, response, err := sess.UpdateInstanceGroupManager(&updateInstanceGroupManagerOptions)
 		if err != nil {
-			return fmt.Errorf("[ERROR] Error updating InstanceGroup manager: %s\n%s", err, response)
+			return flex.FmtErrorf("[ERROR] Error updating InstanceGroup manager: %s\n%s", err, response)
 		}
 	}
 	return resourceIBMISInstanceGroupManagerRead(d, meta)
@@ -373,7 +373,7 @@ func resourceIBMISInstanceGroupManagerRead(d *schema.ResourceData, meta interfac
 			d.SetId("")
 			return nil
 		}
-		return fmt.Errorf("[ERROR] Error Getting InstanceGroup Manager: %s\n%s", err, response)
+		return flex.FmtErrorf("[ERROR] Error Getting InstanceGroup Manager: %s\n%s", err, response)
 	}
 	instanceGroupManager := instanceGroupManagerIntf.(*vpcv1.InstanceGroupManager)
 
@@ -451,7 +451,7 @@ func resourceIBMISInstanceGroupManagerDelete(d *schema.ResourceData, meta interf
 			d.SetId("")
 			return nil
 		}
-		return fmt.Errorf("[ERROR] Error Deleting the InstanceGroup Manager: %s\n%s", err, response)
+		return flex.FmtErrorf("[ERROR] Error Deleting the InstanceGroup Manager: %s\n%s", err, response)
 	}
 	return nil
 }

--- a/ibm/service/vpc/resource_ibm_is_instance_group_manager_action.go
+++ b/ibm/service/vpc/resource_ibm_is_instance_group_manager_action.go
@@ -232,7 +232,7 @@ func resourceIBMISInstanceGroupManagerActionCreate(d *schema.ResourceData, meta 
 		runat := v.(string)
 		datetime, err := strfmt.ParseDateTime(runat)
 		if err != nil {
-			return fmt.Errorf("[ERROR] Error in converting run_at to datetime format %s", err)
+			return flex.FmtErrorf("[ERROR] Error in converting run_at to datetime format %s", err)
 		}
 		instanceGroupManagerActionPrototype.RunAt = &datetime
 	}
@@ -275,7 +275,7 @@ func resourceIBMISInstanceGroupManagerActionCreate(d *schema.ResourceData, meta 
 
 	instanceGroupManagerActionIntf, response, err := sess.CreateInstanceGroupManagerAction(&instanceGroupManagerActionOptions)
 	if err != nil || instanceGroupManagerActionIntf == nil {
-		return fmt.Errorf("[ERROR] Error creating InstanceGroup manager Action: %s\n%s", err, response)
+		return flex.FmtErrorf("[ERROR] Error creating InstanceGroup manager Action: %s\n%s", err, response)
 	}
 	instanceGroupManagerAction := instanceGroupManagerActionIntf.(*vpcv1.InstanceGroupManagerAction)
 	d.SetId(fmt.Sprintf("%s/%s/%s", instanceGroupID, instancegroupmanagerscheduledID, *instanceGroupManagerAction.ID))
@@ -310,7 +310,7 @@ func resourceIBMISInstanceGroupManagerActionUpdate(d *schema.ResourceData, meta 
 		runat := d.Get("run_at").(string)
 		datetime, err := strfmt.ParseDateTime(runat)
 		if err != nil {
-			return fmt.Errorf("[ERROR] Error in converting run_at to datetime format %s", err)
+			return flex.FmtErrorf("[ERROR] Error in converting run_at to datetime format %s", err)
 		}
 		instanceGroupManagerActionPatchModel.RunAt = &datetime
 		changed = true
@@ -357,7 +357,7 @@ func resourceIBMISInstanceGroupManagerActionUpdate(d *schema.ResourceData, meta 
 
 		instanceGroupManagerActionPatch, err := instanceGroupManagerActionPatchModel.AsPatch()
 		if err != nil {
-			return fmt.Errorf("[ERROR] Error calling asPatch for instanceGroupManagerActionPatch: %s", err)
+			return flex.FmtErrorf("[ERROR] Error calling asPatch for instanceGroupManagerActionPatch: %s", err)
 		}
 		updateInstanceGroupManagerActionOptions.InstanceGroupManagerActionPatch = instanceGroupManagerActionPatch
 
@@ -367,7 +367,7 @@ func resourceIBMISInstanceGroupManagerActionUpdate(d *schema.ResourceData, meta 
 		}
 		_, response, err := sess.UpdateInstanceGroupManagerAction(updateInstanceGroupManagerActionOptions)
 		if err != nil {
-			return fmt.Errorf("[ERROR] Error updating InstanceGroup manager action: %s\n%s", err, response)
+			return flex.FmtErrorf("[ERROR] Error updating InstanceGroup manager action: %s\n%s", err, response)
 		}
 	}
 	return resourceIBMISInstanceGroupManagerRead(d, meta)
@@ -399,55 +399,55 @@ func resourceIBMISInstanceGroupManagerActionRead(d *schema.ResourceData, meta in
 			d.SetId("")
 			return nil
 		}
-		return fmt.Errorf("[ERROR] Error Getting InstanceGroup Manager Action: %s\n%s", err, response)
+		return flex.FmtErrorf("[ERROR] Error Getting InstanceGroup Manager Action: %s\n%s", err, response)
 	}
 	instanceGroupManagerAction := instanceGroupManagerActionIntf.(*vpcv1.InstanceGroupManagerAction)
 	if err = d.Set("auto_delete", *instanceGroupManagerAction.AutoDelete); err != nil {
-		return fmt.Errorf("[ERROR] Error setting auto_delete: %s", err)
+		return flex.FmtErrorf("[ERROR] Error setting auto_delete: %s", err)
 	}
 
 	if err = d.Set("auto_delete_timeout", flex.IntValue(instanceGroupManagerAction.AutoDeleteTimeout)); err != nil {
-		return fmt.Errorf("[ERROR] Error setting auto_delete_timeout: %s", err)
+		return flex.FmtErrorf("[ERROR] Error setting auto_delete_timeout: %s", err)
 	}
 	if err = d.Set("created_at", instanceGroupManagerAction.CreatedAt.String()); err != nil {
-		return fmt.Errorf("[ERROR] Error setting created_at: %s", err)
+		return flex.FmtErrorf("[ERROR] Error setting created_at: %s", err)
 	}
 
 	if err = d.Set("action_id", *instanceGroupManagerAction.ID); err != nil {
-		return fmt.Errorf("[ERROR] Error setting instance_group_manager_action : %s", err)
+		return flex.FmtErrorf("[ERROR] Error setting instance_group_manager_action : %s", err)
 	}
 
 	if err = d.Set("name", *instanceGroupManagerAction.Name); err != nil {
-		return fmt.Errorf("[ERROR] Error setting name: %s", err)
+		return flex.FmtErrorf("[ERROR] Error setting name: %s", err)
 	}
 	if err = d.Set("resource_type", *instanceGroupManagerAction.ResourceType); err != nil {
-		return fmt.Errorf("[ERROR] Error setting resource_type: %s", err)
+		return flex.FmtErrorf("[ERROR] Error setting resource_type: %s", err)
 	}
 	if err = d.Set("status", *instanceGroupManagerAction.Status); err != nil {
-		return fmt.Errorf("[ERROR] Error setting status: %s", err)
+		return flex.FmtErrorf("[ERROR] Error setting status: %s", err)
 	}
 	if err = d.Set("updated_at", instanceGroupManagerAction.UpdatedAt.String()); err != nil {
-		return fmt.Errorf("[ERROR] Error setting updated_at: %s", err)
+		return flex.FmtErrorf("[ERROR] Error setting updated_at: %s", err)
 	}
 	if err = d.Set("action_type", *instanceGroupManagerAction.ActionType); err != nil {
-		return fmt.Errorf("[ERROR] Error setting action_type: %s", err)
+		return flex.FmtErrorf("[ERROR] Error setting action_type: %s", err)
 	}
 
 	if instanceGroupManagerAction.CronSpec != nil {
 		if err = d.Set("cron_spec", *instanceGroupManagerAction.CronSpec); err != nil {
-			return fmt.Errorf("[ERROR] Error setting cron_spec: %s", err)
+			return flex.FmtErrorf("[ERROR] Error setting cron_spec: %s", err)
 		}
 	}
 
 	if instanceGroupManagerAction.LastAppliedAt != nil {
 		if err = d.Set("last_applied_at", instanceGroupManagerAction.LastAppliedAt.String()); err != nil {
-			return fmt.Errorf("[ERROR] Error setting last_applied_at: %s", err)
+			return flex.FmtErrorf("[ERROR] Error setting last_applied_at: %s", err)
 		}
 	}
 
 	if instanceGroupManagerAction.NextRunAt != nil {
 		if err = d.Set("next_run_at", instanceGroupManagerAction.NextRunAt.String()); err != nil {
-			return fmt.Errorf("[ERROR] Error setting next_run_at: %s", err)
+			return flex.FmtErrorf("[ERROR] Error setting next_run_at: %s", err)
 		}
 	}
 
@@ -502,7 +502,7 @@ func resourceIBMISInstanceGroupManagerActionDelete(d *schema.ResourceData, meta 
 			d.SetId("")
 			return nil
 		}
-		return fmt.Errorf("[ERROR] Error Deleting the InstanceGroup Manager Action: %s\n%s", err, response)
+		return flex.FmtErrorf("[ERROR] Error Deleting the InstanceGroup Manager Action: %s\n%s", err, response)
 	}
 	return nil
 }
@@ -533,7 +533,7 @@ func resourceIBMISInstanceGroupManagerActionExists(d *schema.ResourceData, meta 
 		if response != nil && response.StatusCode == 404 {
 			return false, nil
 		}
-		return false, fmt.Errorf("[ERROR] Error Getting InstanceGroup Manager Action: %s\n%s", err, response)
+		return false, flex.FmtErrorf("[ERROR] Error Getting InstanceGroup Manager Action: %s\n%s", err, response)
 	}
 
 	return true, nil

--- a/ibm/service/vpc/resource_ibm_is_instance_group_manager_policy.go
+++ b/ibm/service/vpc/resource_ibm_is_instance_group_manager_policy.go
@@ -143,7 +143,7 @@ func resourceIBMISInstanceGroupManagerPolicyCreate(d *schema.ResourceData, meta 
 
 	data, response, err := sess.CreateInstanceGroupManagerPolicy(&createInstanceGroupManagerPolicyOptions)
 	if err != nil || data == nil {
-		return fmt.Errorf("[ERROR] Error Creating InstanceGroup Manager Policy: %s\n%s", err, response)
+		return flex.FmtErrorf("[ERROR] Error Creating InstanceGroup Manager Policy: %s\n%s", err, response)
 	}
 	instanceGroupManagerPolicy := data.(*vpcv1.InstanceGroupManagerPolicy)
 
@@ -195,7 +195,7 @@ func resourceIBMISInstanceGroupManagerPolicyUpdate(d *schema.ResourceData, meta 
 
 		instanceGroupManagerPolicyAsPatch, asPatchErr := instanceGroupManagerPolicyPatchModel.AsPatch()
 		if asPatchErr != nil {
-			return fmt.Errorf("[ERROR] Error calling asPatch for InstanceGroupManagerPolicyPatchModel: %s", asPatchErr)
+			return flex.FmtErrorf("[ERROR] Error calling asPatch for InstanceGroupManagerPolicyPatchModel: %s", asPatchErr)
 		}
 		updateInstanceGroupManagerPolicyOptions.InstanceGroupManagerPolicyPatch = instanceGroupManagerPolicyAsPatch
 
@@ -210,7 +210,7 @@ func resourceIBMISInstanceGroupManagerPolicyUpdate(d *schema.ResourceData, meta 
 
 		_, response, err := sess.UpdateInstanceGroupManagerPolicy(&updateInstanceGroupManagerPolicyOptions)
 		if err != nil {
-			return fmt.Errorf("[ERROR] Error Updating InstanceGroup Manager Policy: %s\n%s", err, response)
+			return flex.FmtErrorf("[ERROR] Error Updating InstanceGroup Manager Policy: %s\n%s", err, response)
 		}
 	}
 	return resourceIBMISInstanceGroupManagerPolicyRead(d, meta)
@@ -241,7 +241,7 @@ func resourceIBMISInstanceGroupManagerPolicyRead(d *schema.ResourceData, meta in
 			d.SetId("")
 			return nil
 		}
-		return fmt.Errorf("[ERROR] Error Getting InstanceGroup Manager Policy: %s\n%s", err, response)
+		return flex.FmtErrorf("[ERROR] Error Getting InstanceGroup Manager Policy: %s\n%s", err, response)
 	}
 	instanceGroupManagerPolicy := data.(*vpcv1.InstanceGroupManagerPolicy)
 	d.Set("name", *instanceGroupManagerPolicy.Name)
@@ -289,7 +289,7 @@ func resourceIBMISInstanceGroupManagerPolicyDelete(d *schema.ResourceData, meta 
 			d.SetId("")
 			return nil
 		}
-		return fmt.Errorf("[ERROR] Error Deleting the InstanceGroup Manager Policy: %s\n%s", err, response)
+		return flex.FmtErrorf("[ERROR] Error Deleting the InstanceGroup Manager Policy: %s\n%s", err, response)
 	}
 	return nil
 }
@@ -306,7 +306,7 @@ func resourceIBMISInstanceGroupManagerPolicyExists(d *schema.ResourceData, meta 
 	}
 
 	if len(parts) != 3 {
-		return false, fmt.Errorf("[ERROR] Incorrect ID %s: ID should be a combination of instanceGroupID/instanceGroupManagerID/instanceGroupManagerPolicyID", d.Id())
+		return false, flex.FmtErrorf("[ERROR] Incorrect ID %s: ID should be a combination of instanceGroupID/instanceGroupManagerID/instanceGroupManagerPolicyID", d.Id())
 	}
 	instanceGroupID := parts[0]
 	instanceGroupManagerID := parts[1]
@@ -323,7 +323,7 @@ func resourceIBMISInstanceGroupManagerPolicyExists(d *schema.ResourceData, meta 
 		if response != nil && response.StatusCode == 404 {
 			return false, nil
 		}
-		return false, fmt.Errorf("[ERROR] Error Getting InstanceGroup Manager Policy: %s\n%s", err, response)
+		return false, flex.FmtErrorf("[ERROR] Error Getting InstanceGroup Manager Policy: %s\n%s", err, response)
 	}
 	return true, nil
 }

--- a/ibm/service/vpc/resource_ibm_is_instance_group_membership.go
+++ b/ibm/service/vpc/resource_ibm_is_instance_group_membership.go
@@ -178,7 +178,7 @@ func resourceIBMISInstanceGroupMembershipUpdate(d *schema.ResourceData, meta int
 
 	instanceGroupMembership, response, err := sess.GetInstanceGroupMembership(&getInstanceGroupMembershipOptions)
 	if err != nil || instanceGroupMembership == nil {
-		return fmt.Errorf("[ERROR] Error Getting InstanceGroup Membership: %s\n%s", err, response)
+		return flex.FmtErrorf("[ERROR] Error Getting InstanceGroup Membership: %s\n%s", err, response)
 	}
 	d.SetId(fmt.Sprintf("%s/%s", instanceGroupID, instanceGroupMembershipID))
 
@@ -201,12 +201,12 @@ func resourceIBMISInstanceGroupMembershipUpdate(d *schema.ResourceData, meta int
 			updateInstanceGroupMembershipOptions.InstanceGroupID = &instanceGroupID
 			instanceGroupMembershipPatch, err := instanceGroupMembershipPatchModel.AsPatch()
 			if err != nil {
-				return fmt.Errorf("[ERROR] Error calling asPatch for InstanceGroupMembershipPatch: %s", err)
+				return flex.FmtErrorf("[ERROR] Error calling asPatch for InstanceGroupMembershipPatch: %s", err)
 			}
 			updateInstanceGroupMembershipOptions.InstanceGroupMembershipPatch = instanceGroupMembershipPatch
 			_, response, err := sess.UpdateInstanceGroupMembership(&updateInstanceGroupMembershipOptions)
 			if err != nil {
-				return fmt.Errorf("[ERROR] Error updating InstanceGroup Membership: %s\n%s", err, response)
+				return flex.FmtErrorf("[ERROR] Error updating InstanceGroup Membership: %s\n%s", err, response)
 			}
 		}
 	}
@@ -236,7 +236,7 @@ func resourceIBMISInstanceGroupMembershipRead(d *schema.ResourceData, meta inter
 			d.SetId("")
 			return nil
 		}
-		return fmt.Errorf("[ERROR] Error Getting InstanceGroup Membership: %s\n%s", err, response)
+		return flex.FmtErrorf("[ERROR] Error Getting InstanceGroup Membership: %s\n%s", err, response)
 	}
 	d.Set(isInstanceGroupMemershipDeleteInstanceOnMembershipDelete, *instanceGroupMembership.DeleteInstanceOnMembershipDelete)
 	d.Set(isInstanceGroupMembership, *instanceGroupMembership.ID)
@@ -293,7 +293,7 @@ func resourceIBMISInstanceGroupMembershipDelete(d *schema.ResourceData, meta int
 			d.SetId("")
 			return nil
 		}
-		return fmt.Errorf("[ERROR] Error Deleting the InstanceGroup Membership: %s\n%s", err, response)
+		return flex.FmtErrorf("[ERROR] Error Deleting the InstanceGroup Membership: %s\n%s", err, response)
 	}
 	return nil
 }

--- a/ibm/service/vpc/resource_ibm_is_instance_network_interface_floating_ip.go
+++ b/ibm/service/vpc/resource_ibm_is_instance_network_interface_floating_ip.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/flex"
 	"github.com/IBM/vpc-go-sdk/vpcv1"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
@@ -127,7 +128,7 @@ func resourceIBMISInstanceNetworkInterfaceFloatingIpCreate(context context.Conte
 
 	fip, response, err := sess.AddInstanceNetworkInterfaceFloatingIPWithContext(context, options)
 	if err != nil || fip == nil {
-		return diag.FromErr(fmt.Errorf("[DEBUG] Create Instance (%s) network interface (%s) floating ip (%s) err %s\n%s", instanceId, instanceNicId, instanceNicFipId, err, response))
+		return diag.FromErr(flex.FmtErrorf("[DEBUG] Create Instance (%s) network interface (%s) floating ip (%s) err %s\n%s", instanceId, instanceNicId, instanceNicFipId, err, response))
 	}
 	d.SetId(MakeTerraformNICFipID(instanceId, instanceNicId, *fip.ID))
 	err = instanceNICFipGet(d, fip, instanceId, instanceNicId)
@@ -160,7 +161,7 @@ func resourceIBMISInstanceNetworkInterfaceFloatingIpRead(context context.Context
 			d.SetId("")
 			return nil
 		}
-		return diag.FromErr(fmt.Errorf("[ERROR] Error getting Instance (%s) network interface (%s): %s\n%s", instanceId, nicID, err, response))
+		return diag.FromErr(flex.FmtErrorf("[ERROR] Error getting Instance (%s) network interface (%s): %s\n%s", instanceId, nicID, err, response))
 	}
 	err = instanceNICFipGet(d, fip, instanceId, nicID)
 	if err != nil {
@@ -211,7 +212,7 @@ func resourceIBMISInstanceNetworkInterfaceFloatingIpUpdate(context context.Conte
 
 		fip, response, err := sess.AddInstanceNetworkInterfaceFloatingIPWithContext(context, options)
 		if err != nil {
-			return diag.FromErr(fmt.Errorf("[ERROR] Error updating Instance: %s\n%s", err, response))
+			return diag.FromErr(flex.FmtErrorf("[ERROR] Error updating Instance: %s\n%s", err, response))
 		}
 		d.SetId(MakeTerraformNICFipID(instanceId, nicId, *fip.ID))
 		return diag.FromErr(instanceNICFipGet(d, fip, instanceId, nicId))
@@ -249,7 +250,7 @@ func instanceNetworkInterfaceFipDelete(context context.Context, d *schema.Resour
 		if response != nil && response.StatusCode == 404 {
 			return nil
 		}
-		return fmt.Errorf("[ERROR] Error getting Instance (%s) network interface(%s) Floating Ip(%s) : %s\n%s", instanceId, nicId, fipId, err, response)
+		return flex.FmtErrorf("[ERROR] Error getting Instance (%s) network interface(%s) Floating Ip(%s) : %s\n%s", instanceId, nicId, fipId, err, response)
 	}
 
 	options := &vpcv1.RemoveInstanceNetworkInterfaceFloatingIPOptions{
@@ -259,7 +260,7 @@ func instanceNetworkInterfaceFipDelete(context context.Context, d *schema.Resour
 	}
 	response, err = sess.RemoveInstanceNetworkInterfaceFloatingIPWithContext(context, options)
 	if err != nil {
-		return fmt.Errorf("[ERROR] Error Deleting Instance (%s) network interface (%s) Floating Ip(%s) : %s\n%s", instanceId, nicId, fipId, err, response)
+		return flex.FmtErrorf("[ERROR] Error Deleting Instance (%s) network interface (%s) Floating Ip(%s) : %s\n%s", instanceId, nicId, fipId, err, response)
 	}
 	_, err = isWaitForInstanceNetworkInterfaceFloatingIpDeleted(sess, instanceId, nicId, fipId, d.Timeout(schema.TimeoutDelete))
 	if err != nil {
@@ -297,7 +298,7 @@ func isInstanceNetworkInterfaceFloatingIpDeleteRefreshFunc(instanceC *vpcv1.VpcV
 			if response != nil && response.StatusCode == 404 {
 				return fip, isInstanceNetworkInterfaceFloatingIpDeleted, nil
 			}
-			return fip, isInstanceNetworkInterfaceFloatingIpFailed, fmt.Errorf("[ERROR] Error getting Instance(%s) Network Interface (%s) FloatingIp(%s) : %s\n%s", instanceId, nicId, fipId, err, response)
+			return fip, isInstanceNetworkInterfaceFloatingIpFailed, flex.FmtErrorf("[ERROR] Error getting Instance(%s) Network Interface (%s) FloatingIp(%s) : %s\n%s", instanceId, nicId, fipId, err, response)
 		}
 		return fip, isInstanceNetworkInterfaceFloatingIpDeleting, err
 	}
@@ -326,7 +327,7 @@ func isInstanceNetworkInterfaceFloatingIpRefreshFunc(client *vpcv1.VpcV1, instan
 		}
 		fip, response, err := client.GetInstanceNetworkInterfaceFloatingIP(getBmsNicFloatingIpOptions)
 		if err != nil {
-			return nil, "", fmt.Errorf("[ERROR] Error getting Instance (%s) Network Interface (%s) FloatingIp(%s) : %s\n%s", instanceId, nicId, fipId, err, response)
+			return nil, "", flex.FmtErrorf("[ERROR] Error getting Instance (%s) Network Interface (%s) FloatingIp(%s) : %s\n%s", instanceId, nicId, fipId, err, response)
 		}
 		status := ""
 

--- a/ibm/service/vpc/resource_ibm_is_instance_template.go
+++ b/ibm/service/vpc/resource_ibm_is_instance_template.go
@@ -1498,7 +1498,7 @@ func instanceTemplateCreateByCatalogOffering(d *schema.ResourceData, meta interf
 			}
 		}
 		if PrimaryIpv4Address != "" && reservedIpAddress != "" && PrimaryIpv4Address != reservedIpAddress {
-			return fmt.Errorf("[ERROR] Error creating instance template, primary_network_interface error, use either primary_ipv4_address(%s) or primary_ip.0.address(%s)", PrimaryIpv4Address, reservedIpAddress)
+			return flex.FmtErrorf("[ERROR] Error creating instance template, primary_network_interface error, use either primary_ipv4_address(%s) or primary_ip.0.address(%s)", PrimaryIpv4Address, reservedIpAddress)
 		}
 		if reservedIp != "" {
 			primnicobj.PrimaryIP = &vpcv1.NetworkInterfaceIPPrototypeReservedIPIdentity{
@@ -1591,10 +1591,10 @@ func instanceTemplateCreateByCatalogOffering(d *schema.ResourceData, meta interf
 				// }
 			}
 			if PrimaryIpv4Address != "" && reservedIpAddress != "" && PrimaryIpv4Address != reservedIpAddress {
-				return fmt.Errorf("[ERROR] Error creating instance template, network_interfaces error, use either primary_ipv4_address(%s) or primary_ip.0.address(%s)", PrimaryIpv4Address, reservedIpAddress)
+				return flex.FmtErrorf("[ERROR] Error creating instance template, network_interfaces error, use either primary_ipv4_address(%s) or primary_ip.0.address(%s)", PrimaryIpv4Address, reservedIpAddress)
 			}
 			if reservedIp != "" && (PrimaryIpv4Address != "" || reservedIpAddress != "" || reservedIpName != "" || okAuto) {
-				return fmt.Errorf("[ERROR] Error creating instance template, network_interfaces error, reserved_ip(%s) is mutually exclusive with other primary_ip attributes", reservedIp)
+				return flex.FmtErrorf("[ERROR] Error creating instance template, network_interfaces error, reserved_ip(%s) is mutually exclusive with other primary_ip attributes", reservedIp)
 			}
 			if reservedIp != "" {
 				nwInterface.PrimaryIP = &vpcv1.NetworkInterfaceIPPrototypeReservedIPIdentity{
@@ -1657,7 +1657,7 @@ func instanceTemplateCreateByCatalogOffering(d *schema.ResourceData, meta interf
 
 	instanceIntf, response, err := sess.CreateInstanceTemplate(options)
 	if err != nil {
-		return fmt.Errorf("[ERROR] Error creating InstanceTemplate: %s\n%s", err, response)
+		return flex.FmtErrorf("[ERROR] Error creating InstanceTemplate: %s\n%s", err, response)
 	}
 	instance := instanceIntf.(*vpcv1.InstanceTemplate)
 	d.SetId(*instance.ID)
@@ -1974,7 +1974,7 @@ func instanceTemplateCreate(d *schema.ResourceData, meta interface{}, profile, n
 			}
 		}
 		if PrimaryIpv4Address != "" && reservedIpAddress != "" && PrimaryIpv4Address != reservedIpAddress {
-			return fmt.Errorf("[ERROR] Error creating instance template, primary_network_interface error, use either primary_ipv4_address(%s) or primary_ip.0.address(%s)", PrimaryIpv4Address, reservedIpAddress)
+			return flex.FmtErrorf("[ERROR] Error creating instance template, primary_network_interface error, use either primary_ipv4_address(%s) or primary_ip.0.address(%s)", PrimaryIpv4Address, reservedIpAddress)
 		}
 		if reservedIp != "" {
 			primnicobj.PrimaryIP = &vpcv1.NetworkInterfaceIPPrototypeReservedIPIdentity{
@@ -2067,10 +2067,10 @@ func instanceTemplateCreate(d *schema.ResourceData, meta interface{}, profile, n
 				// }
 			}
 			if PrimaryIpv4Address != "" && reservedIpAddress != "" && PrimaryIpv4Address != reservedIpAddress {
-				return fmt.Errorf("[ERROR] Error creating instance template, network_interfaces error, use either primary_ipv4_address(%s) or primary_ip.0.address(%s)", PrimaryIpv4Address, reservedIpAddress)
+				return flex.FmtErrorf("[ERROR] Error creating instance template, network_interfaces error, use either primary_ipv4_address(%s) or primary_ip.0.address(%s)", PrimaryIpv4Address, reservedIpAddress)
 			}
 			if reservedIp != "" && (PrimaryIpv4Address != "" || reservedIpAddress != "" || reservedIpName != "" || okAuto) {
-				return fmt.Errorf("[ERROR] Error creating instance template, network_interfaces error, reserved_ip(%s) is mutually exclusive with other primary_ip attributes", reservedIp)
+				return flex.FmtErrorf("[ERROR] Error creating instance template, network_interfaces error, reserved_ip(%s) is mutually exclusive with other primary_ip attributes", reservedIp)
 			}
 			if reservedIp != "" {
 				nwInterface.PrimaryIP = &vpcv1.NetworkInterfaceIPPrototypeReservedIPIdentity{
@@ -2133,7 +2133,7 @@ func instanceTemplateCreate(d *schema.ResourceData, meta interface{}, profile, n
 
 	instanceIntf, response, err := sess.CreateInstanceTemplate(options)
 	if err != nil {
-		return fmt.Errorf("[ERROR] Error creating InstanceTemplate: %s\n%s", err, response)
+		return flex.FmtErrorf("[ERROR] Error creating InstanceTemplate: %s\n%s", err, response)
 	}
 	instance := instanceIntf.(*vpcv1.InstanceTemplate)
 	d.SetId(*instance.ID)
@@ -2150,7 +2150,7 @@ func instanceTemplateGet(d *schema.ResourceData, meta interface{}, ID string) er
 	}
 	instanceIntf, response, err := instanceC.GetInstanceTemplate(getinsOptions)
 	if err != nil {
-		return fmt.Errorf("[ERROR] Error Getting Instance template: %s\n%s", err, response)
+		return flex.FmtErrorf("[ERROR] Error Getting Instance template: %s\n%s", err, response)
 	}
 	instance := instanceIntf.(*vpcv1.InstanceTemplate)
 	d.Set(isInstanceTemplateName, *instance.Name)
@@ -2276,7 +2276,7 @@ func instanceTemplateGet(d *schema.ResourceData, meta interface{}, ID string) er
 		placementTargetMap = resourceIbmIsInstanceTemplateInstancePlacementTargetPrototypeToMap(*instance.PlacementTarget.(*vpcv1.InstancePlacementTargetPrototype))
 	}
 	if err = d.Set(isInstanceTemplatePlacementTarget, []map[string]interface{}{placementTargetMap}); err != nil {
-		return fmt.Errorf("[ERROR] Error setting placement_target: %s", err)
+		return flex.FmtErrorf("[ERROR] Error setting placement_target: %s", err)
 	}
 
 	if instance.PrimaryNetworkInterface != nil {
@@ -2504,7 +2504,7 @@ func instanceTemplateUpdate(d *schema.ResourceData, meta interface{}) error {
 		}
 		instanceTemplatePatch, err := instanceTemplatePatchModel.AsPatch()
 		if err != nil {
-			return fmt.Errorf("[ERROR] Error calling asPatch for InstanceTemplatePatch: %s", err)
+			return flex.FmtErrorf("[ERROR] Error calling asPatch for InstanceTemplatePatch: %s", err)
 		}
 		updnetoptions.InstanceTemplatePatch = instanceTemplatePatch
 
@@ -2545,7 +2545,7 @@ func instanceTemplateExists(d *schema.ResourceData, meta interface{}, ID string)
 		if response != nil && response.StatusCode == 404 {
 			return false, nil
 		}
-		return false, fmt.Errorf("[ERROR] Error Getting InstanceTemplate: %s\n%s", err, response)
+		return false, flex.FmtErrorf("[ERROR] Error Getting InstanceTemplate: %s\n%s", err, response)
 	}
 	return true, nil
 }

--- a/ibm/service/vpc/resource_ibm_is_ipsec_policy.go
+++ b/ibm/service/vpc/resource_ibm_is_ipsec_policy.go
@@ -5,7 +5,6 @@ package vpc
 
 import (
 	"context"
-	"fmt"
 	"log"
 
 	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/flex"
@@ -234,7 +233,7 @@ func ipsecpCreate(d *schema.ResourceData, meta interface{}, authenticationAlg, e
 	}
 	ipSec, response, err := sess.CreateIpsecPolicy(options)
 	if err != nil {
-		return fmt.Errorf("[DEBUG] ipSec policy err %s\n%s", err, response)
+		return flex.FmtErrorf("[DEBUG] ipSec policy err %s\n%s", err, response)
 	}
 	d.SetId(*ipSec.ID)
 	log.Printf("[INFO] ipSec policy : %s", *ipSec.ID)
@@ -261,7 +260,7 @@ func ipsecpGet(d *schema.ResourceData, meta interface{}, id string) error {
 			d.SetId("")
 			return nil
 		}
-		return fmt.Errorf("[ERROR] Error getting IPSEC Policy(%s): %s\n%s", id, err, response)
+		return flex.FmtErrorf("[ERROR] Error getting IPSEC Policy(%s): %s\n%s", id, err, response)
 	}
 	d.Set(isIpSecName, *ipSec.Name)
 	d.Set(isIpSecAuthenticationAlg, *ipSec.AuthenticationAlgorithm)
@@ -336,13 +335,13 @@ func ipsecpUpdate(d *schema.ResourceData, meta interface{}, id string) error {
 		}
 		ipsecPolicyPatch, err := ipsecPolicyPatchModel.AsPatch()
 		if err != nil {
-			return fmt.Errorf("[ERROR] Error calling asPatch for IPsecPolicyPatch: %s", err)
+			return flex.FmtErrorf("[ERROR] Error calling asPatch for IPsecPolicyPatch: %s", err)
 		}
 		options.IPsecPolicyPatch = ipsecPolicyPatch
 
 		_, response, err := sess.UpdateIpsecPolicy(options)
 		if err != nil {
-			return fmt.Errorf("[ERROR] Error on update of IPSEC Policy(%s): %s\n%s", id, err, response)
+			return flex.FmtErrorf("[ERROR] Error on update of IPSEC Policy(%s): %s\n%s", id, err, response)
 		}
 	}
 	return nil
@@ -368,14 +367,14 @@ func ipsecpDelete(d *schema.ResourceData, meta interface{}, id string) error {
 			d.SetId("")
 			return nil
 		}
-		return fmt.Errorf("[ERROR] Error getting IPSEC Policy(%s): %s\n%s", id, err, response)
+		return flex.FmtErrorf("[ERROR] Error getting IPSEC Policy(%s): %s\n%s", id, err, response)
 	}
 	deleteIpsecPolicyOptions := &vpcv1.DeleteIpsecPolicyOptions{
 		ID: &id,
 	}
 	response, err = sess.DeleteIpsecPolicy(deleteIpsecPolicyOptions)
 	if err != nil {
-		return fmt.Errorf("[ERROR] Error Deleting IPSEC Policy(%s): %s\n%s", id, err, response)
+		return flex.FmtErrorf("[ERROR] Error Deleting IPSEC Policy(%s): %s\n%s", id, err, response)
 	}
 	d.SetId("")
 	return nil
@@ -400,7 +399,7 @@ func ipsecpExists(d *schema.ResourceData, meta interface{}, id string) (bool, er
 		if response != nil && response.StatusCode == 404 {
 			return false, nil
 		}
-		return false, fmt.Errorf("[ERROR] Error getting IPSEC Policy(%s): %s\n%s", id, err, response)
+		return false, flex.FmtErrorf("[ERROR] Error getting IPSEC Policy(%s): %s\n%s", id, err, response)
 	}
 	return true, nil
 }

--- a/ibm/service/vpc/resource_ibm_is_lb.go
+++ b/ibm/service/vpc/resource_ibm_is_lb.go
@@ -5,7 +5,6 @@ package vpc
 
 import (
 	"context"
-	"fmt"
 	"log"
 	"os"
 	"time"
@@ -459,7 +458,7 @@ func lbCreate(d *schema.ResourceData, meta interface{}, name, lbType, rg string,
 
 	lb, response, err := sess.CreateLoadBalancer(options)
 	if err != nil {
-		return fmt.Errorf("[ERROR] Error while creating Load Balancer err %s\n%s", err, response)
+		return flex.FmtErrorf("[ERROR] Error while creating Load Balancer err %s\n%s", err, response)
 	}
 	d.SetId(*lb.ID)
 	log.Printf("[INFO] Load Balancer : %s", *lb.ID)
@@ -513,7 +512,7 @@ func lbGet(d *schema.ResourceData, meta interface{}, id string) error {
 			d.SetId("")
 			return nil
 		}
-		return fmt.Errorf("[ERROR] Error getting Load Balancer : %s\n%s", err, response)
+		return flex.FmtErrorf("[ERROR] Error getting Load Balancer : %s\n%s", err, response)
 	}
 	dnsList := make([]map[string]interface{}, 0)
 	if lb.Dns != nil {
@@ -639,7 +638,7 @@ func lbGet(d *schema.ResourceData, meta interface{}, id string) error {
 		d.Set(flex.ResourceGroupName, lb.ResourceGroup.Name)
 	}
 	if err = d.Set("version", response.Headers.Get("Etag")); err != nil {
-		return fmt.Errorf("[ERROR] Error setting version: %s", err)
+		return flex.FmtErrorf("[ERROR] Error setting version: %s", err)
 	}
 	return nil
 }
@@ -690,7 +689,7 @@ func lbUpdate(d *schema.ResourceData, meta interface{}, id, name string, hasChan
 		}
 		lb, response, err := sess.GetLoadBalancer(getLoadBalancerOptions)
 		if err != nil {
-			return fmt.Errorf("[ERROR] Error getting Load Balancer : %s\n%s", err, response)
+			return flex.FmtErrorf("[ERROR] Error getting Load Balancer : %s\n%s", err, response)
 		}
 		if d.HasChange(isLBTags) {
 			oldList, newList := d.GetChange(isLBTags)
@@ -737,7 +736,7 @@ func lbUpdate(d *schema.ResourceData, meta interface{}, id, name string, hasChan
 		}
 		loadBalancerPatch, err := loadBalancerPatchModel.AsPatch()
 		if err != nil {
-			return fmt.Errorf("[ERROR] Error calling asPatch for LoadBalancerPatch: %s", err)
+			return flex.FmtErrorf("[ERROR] Error calling asPatch for LoadBalancerPatch: %s", err)
 		}
 		if dnsRemoved {
 			loadBalancerPatch["dns"] = nil
@@ -746,7 +745,7 @@ func lbUpdate(d *schema.ResourceData, meta interface{}, id, name string, hasChan
 
 		_, response, err := sess.UpdateLoadBalancer(updateLoadBalancerOptions)
 		if err != nil {
-			return fmt.Errorf("[ERROR] Error Updating subents in vpc Load Balancer : %s\n%s", err, response)
+			return flex.FmtErrorf("[ERROR] Error Updating subents in vpc Load Balancer : %s\n%s", err, response)
 		}
 		_, err = isWaitForLBAvailable(sess, d.Id(), d.Timeout(schema.TimeoutUpdate))
 		if err != nil {
@@ -773,13 +772,13 @@ func lbUpdate(d *schema.ResourceData, meta interface{}, id, name string, hasChan
 		}
 		loadBalancerPatch, err := loadBalancerPatchModel.AsPatch()
 		if err != nil {
-			return fmt.Errorf("[ERROR] Error calling asPatch for LoadBalancerPatch: %s", err)
+			return flex.FmtErrorf("[ERROR] Error calling asPatch for LoadBalancerPatch: %s", err)
 		}
 		updateLoadBalancerOptions.LoadBalancerPatch = loadBalancerPatch
 
 		_, response, err := sess.UpdateLoadBalancer(updateLoadBalancerOptions)
 		if err != nil {
-			return fmt.Errorf("[ERROR] Error Updating subents in vpc Load Balancer : %s\n%s", err, response)
+			return flex.FmtErrorf("[ERROR] Error Updating subents in vpc Load Balancer : %s\n%s", err, response)
 		}
 		_, err = isWaitForLBAvailable(sess, d.Id(), d.Timeout(schema.TimeoutUpdate))
 		if err != nil {
@@ -796,13 +795,13 @@ func lbUpdate(d *schema.ResourceData, meta interface{}, id, name string, hasChan
 		}
 		loadBalancerPatch, err := loadBalancerPatchModel.AsPatch()
 		if err != nil {
-			return fmt.Errorf("[ERROR] Error calling asPatch for LoadBalancerPatch: %s", err)
+			return flex.FmtErrorf("[ERROR] Error calling asPatch for LoadBalancerPatch: %s", err)
 		}
 		updateLoadBalancerOptions.LoadBalancerPatch = loadBalancerPatch
 
 		_, response, err := sess.UpdateLoadBalancer(updateLoadBalancerOptions)
 		if err != nil {
-			return fmt.Errorf("[ERROR] Error Updating vpc Load Balancer : %s\n%s", err, response)
+			return flex.FmtErrorf("[ERROR] Error Updating vpc Load Balancer : %s\n%s", err, response)
 		}
 	}
 	if hasChangedLog {
@@ -820,13 +819,13 @@ func lbUpdate(d *schema.ResourceData, meta interface{}, id, name string, hasChan
 		}
 		loadBalancerPatch, err := loadBalancerPatchModel.AsPatch()
 		if err != nil {
-			return fmt.Errorf("[ERROR] Error calling asPatch for LoadBalancerPatch: %s", err)
+			return flex.FmtErrorf("[ERROR] Error calling asPatch for LoadBalancerPatch: %s", err)
 		}
 		updateLoadBalancerOptions.LoadBalancerPatch = loadBalancerPatch
 
 		_, response, err := sess.UpdateLoadBalancer(updateLoadBalancerOptions)
 		if err != nil {
-			return fmt.Errorf("[ERROR] Error Updating vpc Load Balancer : %s\n%s", err, response)
+			return flex.FmtErrorf("[ERROR] Error Updating vpc Load Balancer : %s\n%s", err, response)
 		}
 	}
 
@@ -839,7 +838,7 @@ func lbUpdate(d *schema.ResourceData, meta interface{}, id, name string, hasChan
 				createSecurityGroupTargetBindingOptions.ID = &id
 				_, response, err := sess.CreateSecurityGroupTargetBinding(createSecurityGroupTargetBindingOptions)
 				if err != nil {
-					return fmt.Errorf("[ERROR] Error while creating Security Group Target Binding %s\n%s", err, response)
+					return flex.FmtErrorf("[ERROR] Error while creating Security Group Target Binding %s\n%s", err, response)
 				}
 				_, err = isWaitForLBAvailable(sess, d.Id(), d.Timeout(schema.TimeoutUpdate))
 				if err != nil {
@@ -859,12 +858,12 @@ func lbUpdate(d *schema.ResourceData, meta interface{}, id, name string, hasChan
 					if response != nil && response.StatusCode == 404 {
 						continue
 					}
-					return fmt.Errorf("[ERROR] Error Getting Security Group Target for this load balancer (%s): %s\n%s", securityGroupID, err, response)
+					return flex.FmtErrorf("[ERROR] Error Getting Security Group Target for this load balancer (%s): %s\n%s", securityGroupID, err, response)
 				}
 				deleteSecurityGroupTargetBindingOptions := sess.NewDeleteSecurityGroupTargetBindingOptions(securityGroupID, id)
 				response, err = sess.DeleteSecurityGroupTargetBinding(deleteSecurityGroupTargetBindingOptions)
 				if err != nil {
-					return fmt.Errorf("[ERROR] Error Deleting Security Group Target for this load balancer : %s\n%s", err, response)
+					return flex.FmtErrorf("[ERROR] Error Deleting Security Group Target for this load balancer : %s\n%s", err, response)
 				}
 				_, err = isWaitForLBAvailable(sess, d.Id(), d.Timeout(schema.TimeoutUpdate))
 				if err != nil {
@@ -903,7 +902,7 @@ func lbDelete(d *schema.ResourceData, meta interface{}, id string) error {
 			d.SetId("")
 			return nil
 		}
-		return fmt.Errorf("[ERROR] Error Getting vpc load balancer(%s): %s\n%s", id, err, response)
+		return flex.FmtErrorf("[ERROR] Error Getting vpc load balancer(%s): %s\n%s", id, err, response)
 	}
 
 	deleteLoadBalancerOptions := &vpcv1.DeleteLoadBalancerOptions{
@@ -911,7 +910,7 @@ func lbDelete(d *schema.ResourceData, meta interface{}, id string) error {
 	}
 	response, err = sess.DeleteLoadBalancer(deleteLoadBalancerOptions)
 	if err != nil {
-		return fmt.Errorf("[ERROR] Error Deleting vpc load balancer : %s\n%s", err, response)
+		return flex.FmtErrorf("[ERROR] Error Deleting vpc load balancer : %s\n%s", err, response)
 	}
 	_, err = isWaitForLBDeleted(sess, id, d.Timeout(schema.TimeoutDelete))
 	if err != nil {
@@ -947,7 +946,7 @@ func isLBDeleteRefreshFunc(lbc *vpcv1.VpcV1, id string) resource.StateRefreshFun
 			if response != nil && response.StatusCode == 404 {
 				return lb, isLBDeleted, nil
 			}
-			return nil, "failed", fmt.Errorf("[ERROR] The vpc load balancer %s failed to delete: %s\n%s", id, err, response)
+			return nil, "failed", flex.FmtErrorf("[ERROR] The vpc load balancer %s failed to delete: %s\n%s", id, err, response)
 		}
 		return lb, isLBDeleting, nil
 	}
@@ -974,7 +973,7 @@ func lbExists(d *schema.ResourceData, meta interface{}, id string) (bool, error)
 		if response != nil && response.StatusCode == 404 {
 			return false, nil
 		}
-		return false, fmt.Errorf("[ERROR] Error getting vpc load balancer: %s\n%s", err, response)
+		return false, flex.FmtErrorf("[ERROR] Error getting vpc load balancer: %s\n%s", err, response)
 	}
 	return true, nil
 }
@@ -1002,7 +1001,7 @@ func isLBRefreshFunc(sess *vpcv1.VpcV1, lbId string) resource.StateRefreshFunc {
 		}
 		lb, response, err := sess.GetLoadBalancer(getlboptions)
 		if err != nil {
-			return nil, "", fmt.Errorf("[ERROR] Error Getting Load Balancer : %s\n%s", err, response)
+			return nil, "", flex.FmtErrorf("[ERROR] Error Getting Load Balancer : %s\n%s", err, response)
 		}
 
 		if *lb.ProvisioningStatus == "active" || *lb.ProvisioningStatus == "failed" {

--- a/ibm/service/vpc/resource_ibm_is_lb_listener.go
+++ b/ibm/service/vpc/resource_ibm_is_lb_listener.go
@@ -470,7 +470,7 @@ func isLBListenerRefreshFunc(sess *vpcv1.VpcV1, lbID, lbListenerID string) resou
 		}
 		lblis, response, err := sess.GetLoadBalancerListener(getLoadBalancerListenerOptions)
 		if err != nil {
-			return nil, "", fmt.Errorf("[ERROR] Error Getting Load Balancer Listener: %s\n%s", err, response)
+			return nil, "", flex.FmtErrorf("[ERROR] Error Getting Load Balancer Listener: %s\n%s", err, response)
 		}
 
 		if *lblis.ProvisioningStatus == "active" || *lblis.ProvisioningStatus == "failed" {
@@ -847,7 +847,7 @@ func isLBListenerDeleteRefreshFunc(lbc *vpcv1.VpcV1, lbID, lbListenerID string) 
 			if response != nil && response.StatusCode == 404 {
 				return lbLis, isLBListenerDeleted, nil
 			}
-			return nil, "", fmt.Errorf("[ERROR] The vpc load balancer listener %s failed to delete: %s\n%s", lbListenerID, err, response)
+			return nil, "", flex.FmtErrorf("[ERROR] The vpc load balancer listener %s failed to delete: %s\n%s", lbListenerID, err, response)
 		}
 		return lbLis, isLBListenerDeleting, nil
 	}
@@ -860,7 +860,7 @@ func resourceIBMISLBListenerExists(d *schema.ResourceData, meta interface{}) (bo
 		return false, err
 	}
 	if len(parts) != 2 {
-		return false, fmt.Errorf("[ERROR] Incorrect ID %s: ID should be a combination of lbID/lbListenerID", d.Id())
+		return false, flex.FmtErrorf("[ERROR] Incorrect ID %s: ID should be a combination of lbID/lbListenerID", d.Id())
 	}
 	lbID := parts[0]
 	lbListenerID := parts[1]
@@ -885,7 +885,7 @@ func lbListenerExists(d *schema.ResourceData, meta interface{}, lbID, lbListener
 		if response != nil && response.StatusCode == 404 {
 			return false, nil
 		}
-		return false, fmt.Errorf("[ERROR] Error getting Load balancer Listener: %s\n%s", err, response)
+		return false, flex.FmtErrorf("[ERROR] Error getting Load balancer Listener: %s\n%s", err, response)
 	}
 	return true, nil
 }

--- a/ibm/service/vpc/resource_ibm_is_lb_listener_policy.go
+++ b/ibm/service/vpc/resource_ibm_is_lb_listener_policy.go
@@ -715,7 +715,7 @@ func lbListenerPolicyExists(d *schema.ResourceData, meta interface{}, ID string)
 		return false, err
 	}
 	if len(parts) != 3 {
-		return false, fmt.Errorf("[ERROR] Incorrect ID %s: ID should be a combination of lbID/listenerID/policyID", d.Id())
+		return false, flex.FmtErrorf("[ERROR] Incorrect ID %s: ID should be a combination of lbID/listenerID/policyID", d.Id())
 	}
 
 	lbID := parts[0]
@@ -735,7 +735,7 @@ func lbListenerPolicyExists(d *schema.ResourceData, meta interface{}, ID string)
 		if response != nil && response.StatusCode == 404 {
 			return false, nil
 		}
-		return false, fmt.Errorf("[ERROR] Error getting Load balancer policy: %s\n%s", err, response)
+		return false, flex.FmtErrorf("[ERROR] Error getting Load balancer policy: %s\n%s", err, response)
 	}
 	return true, nil
 }
@@ -962,13 +962,13 @@ func lbListenerPolicyDelete(d *schema.ResourceData, meta interface{}, lbID, list
 
 	_, err = isWaitForLbAvailable(sess, lbID, d.Timeout(schema.TimeoutCreate))
 	if err != nil {
-		return fmt.Errorf(
+		return flex.FmtErrorf(
 			"LB-LP Error checking for load balancer (%s) is active: %s", lbID, err)
 	}
 
 	response, err = sess.DeleteLoadBalancerListenerPolicy(deleteLbListenerPolicyOptions)
 	if err != nil {
-		return fmt.Errorf("[ERROR] Error in lbListenerPolicyDelete: %s\n%s", err, response)
+		return flex.FmtErrorf("[ERROR] Error in lbListenerPolicyDelete: %s\n%s", err, response)
 	}
 	_, err = isWaitForLbListnerPolicyDeleted(sess, d.Id(), d.Timeout(schema.TimeoutDelete))
 	if err != nil {

--- a/ibm/service/vpc/resource_ibm_is_lb_listener_policy_rule.go
+++ b/ibm/service/vpc/resource_ibm_is_lb_listener_policy_rule.go
@@ -267,13 +267,13 @@ func lbListenerPolicyRuleCreate(d *schema.ResourceData, meta interface{}, lbID, 
 
 	_, err = isWaitForLoadbalancerAvailable(sess, lbID, d.Timeout(schema.TimeoutCreate))
 	if err != nil {
-		return fmt.Errorf(
+		return flex.FmtErrorf(
 			"LB-LP Error checking for load balancer (%s) is active: %s", lbID, err)
 	}
 
 	rule, response, err := sess.CreateLoadBalancerListenerPolicyRule(options)
 	if err != nil {
-		return fmt.Errorf("[ERROR] Error while creating lb listener policy for LB %s: Error %v Response %v", lbID, err, *response)
+		return flex.FmtErrorf("[ERROR] Error while creating lb listener policy for LB %s: Error %v Response %v", lbID, err, *response)
 	}
 
 	d.SetId(fmt.Sprintf("%s/%s/%s/%s", lbID, listenerID, policyID, *(rule.ID)))
@@ -408,7 +408,7 @@ func lbListenerPolicyRuleExists(d *schema.ResourceData, meta interface{}, ID str
 		return false, err
 	}
 	if len(parts) != 4 {
-		return false, fmt.Errorf("[ERROR] Incorrect ID %s: ID should be a combination of lbID/listenerID/policyID/ruleID", d.Id())
+		return false, flex.FmtErrorf("[ERROR] Incorrect ID %s: ID should be a combination of lbID/listenerID/policyID/ruleID", d.Id())
 	}
 	lbID := parts[0]
 	listenerID := parts[1]
@@ -429,7 +429,7 @@ func lbListenerPolicyRuleExists(d *schema.ResourceData, meta interface{}, ID str
 		if response != nil && response.StatusCode == 404 {
 			return false, nil
 		}
-		return false, fmt.Errorf("[ERROR] Error getting policy: %s\n%s", err, response)
+		return false, flex.FmtErrorf("[ERROR] Error getting policy: %s\n%s", err, response)
 	}
 	return true, nil
 }
@@ -494,7 +494,7 @@ func lbListenerPolicyRuleUpdate(d *schema.ResourceData, meta interface{}, lbID, 
 	if hasChanged {
 		loadBalancerListenerPolicyRulePatch, err := loadBalancerListenerPolicyRulePatchModel.AsPatch()
 		if err != nil {
-			return fmt.Errorf("[ERROR] Error calling asPatch for LoadBalancerListenerPolicyRulePatch: %s", err)
+			return flex.FmtErrorf("[ERROR] Error calling asPatch for LoadBalancerListenerPolicyRulePatch: %s", err)
 		}
 		updatePolicyRuleOptions.LoadBalancerListenerPolicyRulePatch = loadBalancerListenerPolicyRulePatch
 
@@ -504,13 +504,13 @@ func lbListenerPolicyRuleUpdate(d *schema.ResourceData, meta interface{}, lbID, 
 
 		_, err = isWaitForLoadbalancerAvailable(sess, lbID, d.Timeout(schema.TimeoutCreate))
 		if err != nil {
-			return fmt.Errorf(
+			return flex.FmtErrorf(
 				"LB-LP Error checking for load balancer (%s) is active: %s", lbID, err)
 		}
 
 		_, response, err := sess.UpdateLoadBalancerListenerPolicyRule(&updatePolicyRuleOptions)
 		if err != nil {
-			return fmt.Errorf("[ERROR] Error Updating in policy : %s\n%s", err, response)
+			return flex.FmtErrorf("[ERROR] Error Updating in policy : %s\n%s", err, response)
 		}
 
 		_, err = isWaitForLbListenerPolicyRuleAvailable(sess, d.Id(), d.Timeout(schema.TimeoutCreate))
@@ -570,7 +570,7 @@ func lbListenerPolicyRuleDelete(d *schema.ResourceData, meta interface{}, lbID, 
 			d.SetId("")
 			return nil
 		}
-		return fmt.Errorf("[ERROR] Error in LbListenerPolicyGet : %s\n%s", err, response)
+		return flex.FmtErrorf("[ERROR] Error in LbListenerPolicyGet : %s\n%s", err, response)
 	}
 
 	deleteLbListenerPolicyRuleOptions := &vpcv1.DeleteLoadBalancerListenerPolicyRuleOptions{
@@ -581,7 +581,7 @@ func lbListenerPolicyRuleDelete(d *schema.ResourceData, meta interface{}, lbID, 
 	}
 	response, err = sess.DeleteLoadBalancerListenerPolicyRule(deleteLbListenerPolicyRuleOptions)
 	if err != nil {
-		return fmt.Errorf("[ERROR] Error in lbListenerPolicyRuleDelete: %s\n%s", err, response)
+		return flex.FmtErrorf("[ERROR] Error in lbListenerPolicyRuleDelete: %s\n%s", err, response)
 	}
 	_, err = isWaitForLbListnerPolicyRuleDeleted(sess, d.Id(), d.Timeout(schema.TimeoutDelete))
 	if err != nil {
@@ -677,7 +677,7 @@ func lbListenerPolicyRuleGet(d *schema.ResourceData, meta interface{}, lbID, lis
 	}
 	lb, response, err := sess.GetLoadBalancer(getLoadBalancerOptions)
 	if err != nil {
-		return fmt.Errorf("[ERROR] Error Getting Load Balancer : %s\n%s", err, response)
+		return flex.FmtErrorf("[ERROR] Error Getting Load Balancer : %s\n%s", err, response)
 	}
 	d.Set(flex.RelatedCRN, *lb.CRN)
 

--- a/ibm/service/vpc/resource_ibm_is_lb_pool.go
+++ b/ibm/service/vpc/resource_ibm_is_lb_pool.go
@@ -299,7 +299,7 @@ func lbPoolCreate(d *schema.ResourceData, meta interface{}, name, lbID, algorith
 
 	_, err = isWaitForLBAvailable(sess, lbID, d.Timeout(schema.TimeoutCreate))
 	if err != nil {
-		return fmt.Errorf("[ERROR] Error checking for load balancer (%s) is active: %s", lbID, err)
+		return flex.FmtErrorf("[ERROR] Error checking for load balancer (%s) is active: %s", lbID, err)
 	}
 
 	options := &vpcv1.CreateLoadBalancerPoolOptions{
@@ -333,7 +333,7 @@ func lbPoolCreate(d *schema.ResourceData, meta interface{}, name, lbID, algorith
 	}
 	lbPool, response, err := sess.CreateLoadBalancerPool(options)
 	if err != nil {
-		return fmt.Errorf("[DEBUG] lbpool create err: %s\n%s", err, response)
+		return flex.FmtErrorf("[DEBUG] lbpool create err: %s\n%s", err, response)
 	}
 
 	d.SetId(fmt.Sprintf("%s/%s", lbID, *lbPool.ID))
@@ -341,12 +341,12 @@ func lbPoolCreate(d *schema.ResourceData, meta interface{}, name, lbID, algorith
 
 	_, err = isWaitForLBPoolActive(sess, lbID, *lbPool.ID, d.Timeout(schema.TimeoutCreate))
 	if err != nil {
-		return fmt.Errorf("[ERROR] Error checking for load balancer pool (%s) is active: %s", *lbPool.ID, err)
+		return flex.FmtErrorf("[ERROR] Error checking for load balancer pool (%s) is active: %s", *lbPool.ID, err)
 	}
 
 	_, err = isWaitForLBAvailable(sess, lbID, d.Timeout(schema.TimeoutCreate))
 	if err != nil {
-		return fmt.Errorf("[ERROR] Error checking for load balancer (%s) is active: %s", lbID, err)
+		return flex.FmtErrorf("[ERROR] Error checking for load balancer (%s) is active: %s", lbID, err)
 	}
 
 	return nil
@@ -386,7 +386,7 @@ func lbPoolGet(d *schema.ResourceData, meta interface{}, lbID, lbPoolID string) 
 			d.SetId("")
 			return nil
 		}
-		return fmt.Errorf("[ERROR] Error Getting Load Balancer Pool : %s\n%s", err, response)
+		return flex.FmtErrorf("[ERROR] Error Getting Load Balancer Pool : %s\n%s", err, response)
 	}
 	d.Set(isLBPoolName, *lbPool.Name)
 	d.Set(isLBPool, lbPoolID)
@@ -429,7 +429,7 @@ func lbPoolGet(d *schema.ResourceData, meta interface{}, lbID, lbPoolID string) 
 	}
 	lb, response, err := sess.GetLoadBalancer(getLoadBalancerOptions)
 	if err != nil {
-		return fmt.Errorf("[ERROR] Error Getting Load Balancer : %s\n%s", err, response)
+		return flex.FmtErrorf("[ERROR] Error Getting Load Balancer : %s\n%s", err, response)
 	}
 	d.Set(flex.RelatedCRN, *lb.CRN)
 	return nil
@@ -533,19 +533,19 @@ func lbPoolUpdate(d *schema.ResourceData, meta interface{}, lbID, lbPoolID strin
 		defer conns.IbmMutexKV.Unlock(isLBKey)
 		_, err := isWaitForLBAvailable(sess, lbID, d.Timeout(schema.TimeoutUpdate))
 		if err != nil {
-			return fmt.Errorf(
+			return flex.FmtErrorf(
 				"Error checking for load balancer (%s) is active: %s", lbID, err)
 		}
 
 		_, err = isWaitForLBPoolActive(sess, lbID, lbPoolID, d.Timeout(schema.TimeoutUpdate))
 		if err != nil {
-			return fmt.Errorf(
+			return flex.FmtErrorf(
 				"Error checking for load balancer pool (%s) is active: %s", lbPoolID, err)
 		}
 
 		LoadBalancerPoolPatch, err := loadBalancerPoolPatchModel.AsPatch()
 		if err != nil {
-			return fmt.Errorf("[ERROR] Error calling asPatch for LoadBalancerPoolPatch: %s", err)
+			return flex.FmtErrorf("[ERROR] Error calling asPatch for LoadBalancerPoolPatch: %s", err)
 		}
 		if sessionPersistenceRemoved {
 			LoadBalancerPoolPatch["session_persistence"] = nil
@@ -558,18 +558,18 @@ func lbPoolUpdate(d *schema.ResourceData, meta interface{}, lbID, lbPoolID strin
 
 		_, response, err := sess.UpdateLoadBalancerPool(updateLoadBalancerPoolOptions)
 		if err != nil {
-			return fmt.Errorf("[ERROR] Error Updating Load Balancer Pool : %s\n%s", err, response)
+			return flex.FmtErrorf("[ERROR] Error Updating Load Balancer Pool : %s\n%s", err, response)
 		}
 
 		_, err = isWaitForLBPoolActive(sess, lbID, lbPoolID, d.Timeout(schema.TimeoutUpdate))
 		if err != nil {
-			return fmt.Errorf(
+			return flex.FmtErrorf(
 				"Error checking for load balancer pool (%s) is active: %s", lbPoolID, err)
 		}
 
 		_, err = isWaitForLBAvailable(sess, lbID, d.Timeout(schema.TimeoutUpdate))
 		if err != nil {
-			return fmt.Errorf(
+			return flex.FmtErrorf(
 				"Error checking for load balancer (%s) is active: %s", lbID, err)
 		}
 	}
@@ -613,16 +613,16 @@ func lbPoolDelete(d *schema.ResourceData, meta interface{}, lbID, lbPoolID strin
 			d.SetId("")
 			return nil
 		}
-		return fmt.Errorf("[ERROR] Error Getting vpc load balancer pool(%s): %s\n%s", lbPoolID, err, response)
+		return flex.FmtErrorf("[ERROR] Error Getting vpc load balancer pool(%s): %s\n%s", lbPoolID, err, response)
 	}
 	_, err = isWaitForLBAvailable(sess, lbID, d.Timeout(schema.TimeoutDelete))
 	if err != nil {
-		return fmt.Errorf("[ERROR] Error checking for load balancer (%s) is active: %s", lbID, err)
+		return flex.FmtErrorf("[ERROR] Error checking for load balancer (%s) is active: %s", lbID, err)
 	}
 
 	_, err = isWaitForLBPoolActive(sess, lbID, lbPoolID, d.Timeout(schema.TimeoutDelete))
 	if err != nil {
-		return fmt.Errorf("[ERROR] Error checking for load balancer pool (%s) is active: %s", lbPoolID, err)
+		return flex.FmtErrorf("[ERROR] Error checking for load balancer pool (%s) is active: %s", lbPoolID, err)
 	}
 
 	deleteLoadBalancerPoolOptions := &vpcv1.DeleteLoadBalancerPoolOptions{
@@ -631,16 +631,16 @@ func lbPoolDelete(d *schema.ResourceData, meta interface{}, lbID, lbPoolID strin
 	}
 	response, err = sess.DeleteLoadBalancerPool(deleteLoadBalancerPoolOptions)
 	if err != nil {
-		return fmt.Errorf("[ERROR] Error Deleting Load Balancer Pool : %s\n%s", err, response)
+		return flex.FmtErrorf("[ERROR] Error Deleting Load Balancer Pool : %s\n%s", err, response)
 	}
 	_, err = isWaitForLBPoolDeleted(sess, lbID, lbPoolID, d.Timeout(schema.TimeoutDelete))
 	if err != nil {
-		return fmt.Errorf("[ERROR] Error checking for load balancer pool (%s) is deleted: %s", lbPoolID, err)
+		return flex.FmtErrorf("[ERROR] Error checking for load balancer pool (%s) is deleted: %s", lbPoolID, err)
 	}
 
 	_, err = isWaitForLBAvailable(sess, lbID, d.Timeout(schema.TimeoutDelete))
 	if err != nil {
-		return fmt.Errorf("[ERROR] Error checking for load balancer (%s) is active: %s", lbID, err)
+		return flex.FmtErrorf("[ERROR] Error checking for load balancer (%s) is active: %s", lbID, err)
 	}
 	d.SetId("")
 	return nil
@@ -653,7 +653,7 @@ func resourceIBMISLBPoolExists(d *schema.ResourceData, meta interface{}) (bool, 
 		return false, err
 	}
 	if len(parts) != 2 {
-		return false, fmt.Errorf("[ERROR] Incorrect ID %s: ID should be a combination of lbID/lbPoolID", d.Id())
+		return false, flex.FmtErrorf("[ERROR] Incorrect ID %s: ID should be a combination of lbID/lbPoolID", d.Id())
 	}
 
 	lbID := parts[0]
@@ -679,7 +679,7 @@ func lbPoolExists(d *schema.ResourceData, meta interface{}, lbID, lbPoolID strin
 		if response != nil && response.StatusCode == 404 {
 			return false, nil
 		}
-		return false, fmt.Errorf("[ERROR] Error getting Load balancer pool: %s\n%s", err, response)
+		return false, flex.FmtErrorf("[ERROR] Error getting Load balancer pool: %s\n%s", err, response)
 	}
 	return true, nil
 }
@@ -708,7 +708,7 @@ func isLBPoolRefreshFunc(sess *vpcv1.VpcV1, lbId, lbPoolId string) resource.Stat
 		}
 		lbPool, response, err := sess.GetLoadBalancerPool(getlbpOptions)
 		if err != nil {
-			return nil, "", fmt.Errorf("[ERROR] Error Getting Load Balancer Pool: %s\n%s", err, response)
+			return nil, "", flex.FmtErrorf("[ERROR] Error Getting Load Balancer Pool: %s\n%s", err, response)
 		}
 
 		if *lbPool.ProvisioningStatus == isLBPoolActive || *lbPool.ProvisioningStatus == isLBPoolFailed {
@@ -746,7 +746,7 @@ func isLBPoolDeleteRefreshFunc(lbc *vpcv1.VpcV1, lbId, lbPoolId string) resource
 			if response != nil && response.StatusCode == 404 {
 				return lbPool, isLBPoolDeleteDone, nil
 			}
-			return nil, "", fmt.Errorf("[ERROR] The vpc load balancer pool %s failed to delete: %s\n%s", lbPoolId, err, response)
+			return nil, "", flex.FmtErrorf("[ERROR] The vpc load balancer pool %s failed to delete: %s\n%s", lbPoolId, err, response)
 		}
 		return lbPool, isLBPoolDeletePending, nil
 	}

--- a/ibm/service/vpc/resource_ibm_is_lb_pool_member.go
+++ b/ibm/service/vpc/resource_ibm_is_lb_pool_member.go
@@ -186,12 +186,12 @@ func lbpMemberCreate(d *schema.ResourceData, meta interface{}, lbID, lbPoolID st
 	}
 	_, err = isWaitForLBPoolActive(sess, lbID, lbPoolID, d.Timeout(schema.TimeoutCreate))
 	if err != nil {
-		return fmt.Errorf("[ERROR] Error checking for load balancer pool (%s) is active: %s", lbPoolID, err)
+		return flex.FmtErrorf("[ERROR] Error checking for load balancer pool (%s) is active: %s", lbPoolID, err)
 	}
 
 	_, err = isWaitForLBAvailable(sess, lbID, d.Timeout(schema.TimeoutCreate))
 	if err != nil {
-		return fmt.Errorf("[ERROR] Error checking for load balancer (%s) is active: %s", lbID, err)
+		return flex.FmtErrorf("[ERROR] Error checking for load balancer (%s) is active: %s", lbID, err)
 	}
 
 	options := &vpcv1.CreateLoadBalancerPoolMemberOptions{
@@ -220,7 +220,7 @@ func lbpMemberCreate(d *schema.ResourceData, meta interface{}, lbID, lbPoolID st
 
 	lbPoolMember, response, err := sess.CreateLoadBalancerPoolMember(options)
 	if err != nil {
-		return fmt.Errorf("[DEBUG] lbpool member create err: %s\n%s", err, response)
+		return flex.FmtErrorf("[DEBUG] lbpool member create err: %s\n%s", err, response)
 	}
 
 	d.SetId(fmt.Sprintf("%s/%s/%s", lbID, lbPoolID, *lbPoolMember.ID))
@@ -233,12 +233,12 @@ func lbpMemberCreate(d *schema.ResourceData, meta interface{}, lbID, lbPoolID st
 
 	_, err = isWaitForLBPoolActive(sess, lbID, lbPoolID, d.Timeout(schema.TimeoutCreate))
 	if err != nil {
-		return fmt.Errorf("[ERROR] Error checking for load balancer pool (%s) is active: %s", lbPoolID, err)
+		return flex.FmtErrorf("[ERROR] Error checking for load balancer pool (%s) is active: %s", lbPoolID, err)
 	}
 
 	_, err = isWaitForLBAvailable(sess, lbID, d.Timeout(schema.TimeoutCreate))
 	if err != nil {
-		return fmt.Errorf("[ERROR] Error checking for load balancer (%s) is active: %s", lbID, err)
+		return flex.FmtErrorf("[ERROR] Error checking for load balancer (%s) is active: %s", lbID, err)
 	}
 
 	return nil
@@ -269,7 +269,7 @@ func isLBPoolMemberRefreshFunc(lbc *vpcv1.VpcV1, lbID, lbPoolID, lbPoolMemID str
 		}
 		lbPoolMem, response, err := lbc.GetLoadBalancerPoolMember(getlbpmoptions)
 		if err != nil {
-			return nil, "", fmt.Errorf("[ERROR] Error Getting Load Balancer Pool Member: %s\n%s", err, response)
+			return nil, "", flex.FmtErrorf("[ERROR] Error Getting Load Balancer Pool Member: %s\n%s", err, response)
 		}
 
 		if *lbPoolMem.ProvisioningStatus == isLBPoolMemberActive {
@@ -288,7 +288,7 @@ func resourceIBMISLBPoolMemberRead(d *schema.ResourceData, meta interface{}) err
 	}
 
 	if len(parts) < 3 {
-		return fmt.Errorf(
+		return flex.FmtErrorf(
 			"The id should contain loadbalancer Id, loadbalancer pool Id and loadbalancer poolmemebr Id")
 	}
 
@@ -320,7 +320,7 @@ func lbpmemberGet(d *schema.ResourceData, meta interface{}, lbID, lbPoolID, lbPo
 			d.SetId("")
 			return nil
 		}
-		return fmt.Errorf("[ERROR] Error Getting Load Balancer Pool Member: %s\n%s", err, response)
+		return flex.FmtErrorf("[ERROR] Error Getting Load Balancer Pool Member: %s\n%s", err, response)
 	}
 	d.Set(isLBPoolID, lbPoolID)
 	d.Set(isLBID, lbID)
@@ -342,7 +342,7 @@ func lbpmemberGet(d *schema.ResourceData, meta interface{}, lbID, lbPoolID, lbPo
 	}
 	lb, response, err := sess.GetLoadBalancer(getLoadBalancerOptions)
 	if err != nil {
-		return fmt.Errorf("[ERROR] Error Getting Load Balancer : %s\n%s", err, response)
+		return flex.FmtErrorf("[ERROR] Error Getting Load Balancer : %s\n%s", err, response)
 	}
 	d.Set(flex.RelatedCRN, *lb.CRN)
 	return nil
@@ -384,7 +384,7 @@ func lbpmemberUpdate(d *schema.ResourceData, meta interface{}, lbID, lbPoolID, l
 
 		_, err = isWaitForLBPoolActive(sess, lbID, lbPoolID, d.Timeout(schema.TimeoutUpdate))
 		if err != nil {
-			return fmt.Errorf(
+			return flex.FmtErrorf(
 				"Error checking for load balancer pool (%s) is active: %s", lbPoolID, err)
 		}
 
@@ -395,7 +395,7 @@ func lbpmemberUpdate(d *schema.ResourceData, meta interface{}, lbID, lbPoolID, l
 
 		_, err = isWaitForLBAvailable(sess, lbID, d.Timeout(schema.TimeoutUpdate))
 		if err != nil {
-			return fmt.Errorf(
+			return flex.FmtErrorf(
 				"Error checking for load balancer (%s) is active: %s", lbID, err)
 		}
 
@@ -426,13 +426,13 @@ func lbpmemberUpdate(d *schema.ResourceData, meta interface{}, lbID, lbPoolID, l
 
 		loadBalancerPoolMemberPatch, err := loadBalancerPoolMemberPatchModel.AsPatch()
 		if err != nil {
-			return fmt.Errorf("[ERROR] Error calling asPatch for LoadBalancerPoolMemberPatch: %s", err)
+			return flex.FmtErrorf("[ERROR] Error calling asPatch for LoadBalancerPoolMemberPatch: %s", err)
 		}
 		updatelbpmoptions.LoadBalancerPoolMemberPatch = loadBalancerPoolMemberPatch
 
 		_, response, err := sess.UpdateLoadBalancerPoolMember(updatelbpmoptions)
 		if err != nil {
-			return fmt.Errorf("[ERROR] Error Updating Load Balancer Pool Member: %s\n%s", err, response)
+			return flex.FmtErrorf("[ERROR] Error Updating Load Balancer Pool Member: %s\n%s", err, response)
 		}
 		_, err = isWaitForLBPoolMemberAvailable(sess, lbID, lbPoolID, lbPoolMemID, d.Timeout(schema.TimeoutCreate))
 		if err != nil {
@@ -441,13 +441,13 @@ func lbpmemberUpdate(d *schema.ResourceData, meta interface{}, lbID, lbPoolID, l
 
 		_, err = isWaitForLBPoolActive(sess, lbID, lbPoolID, d.Timeout(schema.TimeoutUpdate))
 		if err != nil {
-			return fmt.Errorf(
+			return flex.FmtErrorf(
 				"Error checking for load balancer pool (%s) is active: %s", lbPoolID, err)
 		}
 
 		_, err = isWaitForLBAvailable(sess, lbID, d.Timeout(schema.TimeoutUpdate))
 		if err != nil {
-			return fmt.Errorf(
+			return flex.FmtErrorf(
 				"Error checking for load balancer (%s) is active: %s", lbID, err)
 		}
 	}
@@ -494,7 +494,7 @@ func lbpmemberDelete(d *schema.ResourceData, meta interface{}, lbID, lbPoolID, l
 			d.SetId("")
 			return nil
 		}
-		return fmt.Errorf("[ERROR] Error Getting Load Balancer Pool Member: %s\n%s", err, response)
+		return flex.FmtErrorf("[ERROR] Error Getting Load Balancer Pool Member: %s\n%s", err, response)
 	}
 	_, err = isWaitForLBPoolMemberAvailable(sess, lbID, lbPoolID, lbPoolMemID, d.Timeout(schema.TimeoutDelete))
 	if err != nil {
@@ -503,12 +503,12 @@ func lbpmemberDelete(d *schema.ResourceData, meta interface{}, lbID, lbPoolID, l
 
 	_, err = isWaitForLBPoolActive(sess, lbID, lbPoolID, d.Timeout(schema.TimeoutDelete))
 	if err != nil {
-		return fmt.Errorf("[ERROR] Error checking for load balancer pool (%s) is active: %s", lbPoolID, err)
+		return flex.FmtErrorf("[ERROR] Error checking for load balancer pool (%s) is active: %s", lbPoolID, err)
 	}
 
 	_, err = isWaitForLBAvailable(sess, lbID, d.Timeout(schema.TimeoutDelete))
 	if err != nil {
-		return fmt.Errorf("[ERROR] Error checking for load balancer (%s) is active: %s", lbID, err)
+		return flex.FmtErrorf("[ERROR] Error checking for load balancer (%s) is active: %s", lbID, err)
 	}
 
 	dellbpmoptions := &vpcv1.DeleteLoadBalancerPoolMemberOptions{
@@ -518,7 +518,7 @@ func lbpmemberDelete(d *schema.ResourceData, meta interface{}, lbID, lbPoolID, l
 	}
 	response, err = sess.DeleteLoadBalancerPoolMember(dellbpmoptions)
 	if err != nil {
-		return fmt.Errorf("[ERROR] Error Deleting Load Balancer Pool Member: %s\n%s", err, response)
+		return flex.FmtErrorf("[ERROR] Error Deleting Load Balancer Pool Member: %s\n%s", err, response)
 	}
 
 	_, err = isWaitForLBPoolMemberDeleted(sess, lbID, lbPoolID, lbPoolMemID, d.Timeout(schema.TimeoutDelete))
@@ -528,12 +528,12 @@ func lbpmemberDelete(d *schema.ResourceData, meta interface{}, lbID, lbPoolID, l
 
 	_, err = isWaitForLBPoolActive(sess, lbID, lbPoolID, d.Timeout(schema.TimeoutDelete))
 	if err != nil {
-		return fmt.Errorf("[ERROR] Error checking for load balancer pool (%s) is active: %s", lbPoolID, err)
+		return flex.FmtErrorf("[ERROR] Error checking for load balancer pool (%s) is active: %s", lbPoolID, err)
 	}
 
 	_, err = isWaitForLBAvailable(sess, lbID, d.Timeout(schema.TimeoutDelete))
 	if err != nil {
-		return fmt.Errorf("[ERROR] Error checking for load balancer (%s) is active: %s", lbID, err)
+		return flex.FmtErrorf("[ERROR] Error checking for load balancer (%s) is active: %s", lbID, err)
 	}
 
 	d.SetId("")
@@ -568,7 +568,7 @@ func isDeleteLBPoolMemberRefreshFunc(lbc *vpcv1.VpcV1, lbID, lbPoolID, lbPoolMem
 			if response != nil && response.StatusCode == 404 {
 				return lbPoolMem, isLBPoolMemberDeleted, nil
 			}
-			return nil, "", fmt.Errorf("[ERROR] Error Deleting Load balancer pool member: %s\n%s", err, response)
+			return nil, "", flex.FmtErrorf("[ERROR] Error Deleting Load balancer pool member: %s\n%s", err, response)
 		}
 		return lbPoolMem, isLBPoolMemberDeletePending, nil
 	}
@@ -580,7 +580,7 @@ func resourceIBMISLBPoolMemberExists(d *schema.ResourceData, meta interface{}) (
 		return false, err
 	}
 	if len(parts) != 3 {
-		return false, fmt.Errorf(
+		return false, flex.FmtErrorf(
 			"The id should contain loadbalancer Id, loadbalancer pool Id and loadbalancer poolmemebr Id")
 	}
 
@@ -609,7 +609,7 @@ func lbpmemberExists(d *schema.ResourceData, meta interface{}, lbID, lbPoolID, l
 		if response != nil && response.StatusCode == 404 {
 			return false, nil
 		}
-		return false, fmt.Errorf("[ERROR] Error getting Load balancer pool member: %s\n%s", err, response)
+		return false, flex.FmtErrorf("[ERROR] Error getting Load balancer pool member: %s\n%s", err, response)
 	}
 	return true, nil
 }

--- a/ibm/service/vpc/resource_ibm_is_network_acl_rule.go
+++ b/ibm/service/vpc/resource_ibm_is_network_acl_rule.go
@@ -443,7 +443,7 @@ func nwaclRuleCreate(d *schema.ResourceData, meta interface{}, nwACLID string) e
 	}
 	nwaclRule, response, err := sess.CreateNetworkACLRule(createNetworkAclRuleOptions)
 	if err != nil || nwaclRule == nil {
-		return fmt.Errorf("[ERROR] Error Creating network ACL rule : %s\n%s", err, response)
+		return flex.FmtErrorf("[ERROR] Error Creating network ACL rule : %s\n%s", err, response)
 	}
 	err = nwaclRuleGet(d, meta, nwACLID, nwaclRule)
 	if err != nil {
@@ -471,7 +471,7 @@ func resourceIBMISNetworkACLRuleRead(d *schema.ResourceData, meta interface{}) e
 			d.SetId("")
 			return nil
 		}
-		return fmt.Errorf("[ERROR] Error getting Network ACL Rule (%s) : %s\n%s", ruleId, err, response)
+		return flex.FmtErrorf("[ERROR] Error getting Network ACL Rule (%s) : %s\n%s", ruleId, err, response)
 	}
 	err = nwaclRuleGet(d, meta, nwACLID, nwaclRule)
 	if err != nil {
@@ -744,7 +744,7 @@ func nwaclRuleUpdate(d *schema.ResourceData, meta interface{}, id, nwACLId strin
 	if hasChanged {
 		updateNetworkACLOptionsPatch, err := updateNetworkACLOptionsPatchModel.AsPatch()
 		if err != nil {
-			return fmt.Errorf("[ERROR] Error calling asPatch for NetworkACLOptionsPatch : %s", err)
+			return flex.FmtErrorf("[ERROR] Error calling asPatch for NetworkACLOptionsPatch : %s", err)
 		}
 		if aclRuleBeforeNull {
 			updateNetworkACLOptionsPatch["before"] = nil
@@ -752,7 +752,7 @@ func nwaclRuleUpdate(d *schema.ResourceData, meta interface{}, id, nwACLId strin
 		updateNetworkACLRuleOptions.NetworkACLRulePatch = updateNetworkACLOptionsPatch
 		_, response, err := sess.UpdateNetworkACLRule(updateNetworkACLRuleOptions)
 		if err != nil {
-			return fmt.Errorf("[ERROR] Error Updating Network ACL Rule : %s\n%s", err, response)
+			return flex.FmtErrorf("[ERROR] Error Updating Network ACL Rule : %s\n%s", err, response)
 		}
 	}
 	return nil
@@ -789,7 +789,7 @@ func nwaclRuleDelete(d *schema.ResourceData, meta interface{}, id, nwACLId strin
 			d.SetId("")
 			return nil
 		}
-		return fmt.Errorf("[ERROR] Error Getting Network ACL Rule  (%s): %s\n%s", id, err, response)
+		return flex.FmtErrorf("[ERROR] Error Getting Network ACL Rule  (%s): %s\n%s", id, err, response)
 	}
 
 	deleteNetworkAclRuleOptions := &vpcv1.DeleteNetworkACLRuleOptions{
@@ -798,7 +798,7 @@ func nwaclRuleDelete(d *schema.ResourceData, meta interface{}, id, nwACLId strin
 	}
 	response, err = sess.DeleteNetworkACLRule(deleteNetworkAclRuleOptions)
 	if err != nil {
-		return fmt.Errorf("[ERROR] Error Deleting Network ACL Rule : %s\n%s", err, response)
+		return flex.FmtErrorf("[ERROR] Error Deleting Network ACL Rule : %s\n%s", err, response)
 	}
 	d.SetId("")
 	return nil
@@ -818,7 +818,7 @@ func nwaclRuleExists(d *schema.ResourceData, meta interface{}, id, nwACLId strin
 		if response != nil && response.StatusCode == 404 {
 			return false, nil
 		}
-		return false, fmt.Errorf("[ERROR] Error getting Network ACL Rule: %s\n%s", err, response)
+		return false, flex.FmtErrorf("[ERROR] Error getting Network ACL Rule: %s\n%s", err, response)
 	}
 	return true, nil
 }
@@ -832,10 +832,10 @@ func makeTerraformACLRuleID(id1, id2 string) string {
 func parseNwACLTerraformID(s string) (string, string, error) {
 	segments := strings.Split(s, "/")
 	if len(segments) != 2 {
-		return "", "", fmt.Errorf("invalid terraform Id %s (incorrect number of segments)", s)
+		return "", "", flex.FmtErrorf("invalid terraform Id %s (incorrect number of segments)", s)
 	}
 	if segments[0] == "" || segments[1] == "" {
-		return "", "", fmt.Errorf("invalid terraform Id %s (one or more empty segments)", s)
+		return "", "", flex.FmtErrorf("invalid terraform Id %s (one or more empty segments)", s)
 	}
 	return segments[0], segments[1], nil
 }

--- a/ibm/service/vpc/resource_ibm_is_reservation.go
+++ b/ibm/service/vpc/resource_ibm_is_reservation.go
@@ -4,7 +4,6 @@
 package vpc
 
 import (
-	"fmt"
 	"log"
 
 	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/flex"
@@ -390,7 +389,7 @@ func resourceIBMISReservationCreate(d *schema.ResourceData, meta interface{}) er
 	reservation, response, err := sess.CreateReservation(createReservationOptions)
 	if err != nil {
 		log.Printf("[DEBUG] Reservation creation err %s\n%s", err, response)
-		return fmt.Errorf("[ERROR] Error while creating Reservation %s\n%v", err, response)
+		return flex.FmtErrorf("[ERROR] Error while creating Reservation %s\n%v", err, response)
 	}
 	d.SetId(*reservation.ID)
 	log.Printf("[INFO] Reservation : %s", *reservation.ID)
@@ -415,13 +414,13 @@ func resourceIBMISReservationRead(d *schema.ResourceData, meta interface{}) erro
 			d.SetId("")
 			return nil
 		}
-		return fmt.Errorf("[ERROR] Error Getting Reservation (%s): %s\n%s", id, err, response)
+		return flex.FmtErrorf("[ERROR] Error Getting Reservation (%s): %s\n%s", id, err, response)
 	}
 
 	if reservation.AffinityPolicy != nil {
 		if err = d.Set(isReservationAffinityPolicy, reservation.AffinityPolicy); err != nil {
 			log.Printf("[ERROR] Error setting %s: %s", isReservationAffinityPolicy, err)
-			return fmt.Errorf("[ERROR] Error setting %s: %s", isReservationAffinityPolicy, err)
+			return flex.FmtErrorf("[ERROR] Error setting %s: %s", isReservationAffinityPolicy, err)
 		}
 	}
 
@@ -468,35 +467,35 @@ func resourceIBMISReservationRead(d *schema.ResourceData, meta interface{}) erro
 	if reservation.CreatedAt != nil {
 		if err = d.Set(isReservationCreatedAt, flex.DateTimeToString(reservation.CreatedAt)); err != nil {
 			log.Printf("[ERROR] Error setting %s: %s", isReservationCreatedAt, err)
-			return fmt.Errorf("[ERROR] Error setting %s: %s", isReservationCreatedAt, err)
+			return flex.FmtErrorf("[ERROR] Error setting %s: %s", isReservationCreatedAt, err)
 		}
 	}
 
 	if reservation.CRN != nil {
 		if err = d.Set(isReservationCrn, reservation.CRN); err != nil {
 			log.Printf("[ERROR] Error setting %s: %s", isReservationCrn, err)
-			return fmt.Errorf("[ERROR] Error setting %s: %s", isReservationCrn, err)
+			return flex.FmtErrorf("[ERROR] Error setting %s: %s", isReservationCrn, err)
 		}
 	}
 
 	if reservation.Href != nil {
 		if err = d.Set(isReservationHref, reservation.Href); err != nil {
 			log.Printf("[ERROR] Error setting %s: %s", isReservationHref, err)
-			return fmt.Errorf("[ERROR] Error setting %s: %s", isReservationHref, err)
+			return flex.FmtErrorf("[ERROR] Error setting %s: %s", isReservationHref, err)
 		}
 	}
 
 	if reservation.LifecycleState != nil {
 		if err = d.Set(isReservationLifecycleState, reservation.LifecycleState); err != nil {
 			log.Printf("[ERROR] Error setting %s: %s", isReservationLifecycleState, err)
-			return fmt.Errorf("[ERROR] Error setting %s: %s", isReservationLifecycleState, err)
+			return flex.FmtErrorf("[ERROR] Error setting %s: %s", isReservationLifecycleState, err)
 		}
 	}
 
 	if reservation.Name != nil {
 		if err = d.Set(isReservationName, reservation.Name); err != nil {
 			log.Printf("[ERROR] Error setting %s: %s", isReservationName, err)
-			return fmt.Errorf("[ERROR] Error setting %s: %s", isReservationName, err)
+			return flex.FmtErrorf("[ERROR] Error setting %s: %s", isReservationName, err)
 		}
 	}
 
@@ -539,14 +538,14 @@ func resourceIBMISReservationRead(d *schema.ResourceData, meta interface{}) erro
 	if reservation.ResourceType != nil {
 		if err = d.Set(isReservationResourceType, reservation.ResourceType); err != nil {
 			log.Printf("[ERROR] Error setting %s: %s", isReservationResourceType, err)
-			return fmt.Errorf("[ERROR] Error setting %s: %s", isReservationResourceType, err)
+			return flex.FmtErrorf("[ERROR] Error setting %s: %s", isReservationResourceType, err)
 		}
 	}
 
 	if reservation.Status != nil {
 		if err = d.Set(isReservationStatus, reservation.Status); err != nil {
 			log.Printf("[ERROR] Error setting %s: %s", isReservationStatus, err)
-			return fmt.Errorf("[ERROR] Error setting %s: %s", isReservationStatus, err)
+			return flex.FmtErrorf("[ERROR] Error setting %s: %s", isReservationStatus, err)
 		}
 	}
 
@@ -563,7 +562,7 @@ func resourceIBMISReservationRead(d *schema.ResourceData, meta interface{}) erro
 	if reservation.Zone != nil && reservation.Zone.Name != nil {
 		if err = d.Set(isReservationZone, reservation.Zone.Name); err != nil {
 			log.Printf("[ERROR] Error setting %s: %s", isReservationZone, err)
-			return fmt.Errorf("[ERROR] Error setting %s: %s", isReservationZone, err)
+			return flex.FmtErrorf("[ERROR] Error setting %s: %s", isReservationZone, err)
 		}
 	}
 	return nil
@@ -637,14 +636,14 @@ func resourceIBMISReservationUpdate(d *schema.ResourceData, meta interface{}) er
 	if hasChanged {
 		reservationPatch, err := reservationPatchModel.AsPatch()
 		if err != nil {
-			return fmt.Errorf("[ERROR] Error calling asPatch for ReservationPatch: %s", err)
+			return flex.FmtErrorf("[ERROR] Error calling asPatch for ReservationPatch: %s", err)
 		}
 		updateReservationOptions := &vpcv1.UpdateReservationOptions{}
 		updateReservationOptions.ReservationPatch = reservationPatch
 		updateReservationOptions.ID = core.StringPtr(d.Id())
 		_, response, err := sess.UpdateReservation(updateReservationOptions)
 		if err != nil {
-			return fmt.Errorf("[ERROR] Error Updating Reservation : %s\n%s", err, response)
+			return flex.FmtErrorf("[ERROR] Error Updating Reservation : %s\n%s", err, response)
 		}
 	}
 	return resourceIBMISReservationRead(d, meta)
@@ -662,7 +661,7 @@ func resourceIBMISReservationDelete(d *schema.ResourceData, meta interface{}) er
 	}
 	_, _, err = sess.DeleteReservation(deleteReservationOptions)
 	if err != nil {
-		return fmt.Errorf("[ERROR] Error Deleting Reservation : %s", err)
+		return flex.FmtErrorf("[ERROR] Error Deleting Reservation : %s", err)
 	}
 	d.SetId("")
 	return nil

--- a/ibm/service/vpc/resource_ibm_is_reservation_activate.go
+++ b/ibm/service/vpc/resource_ibm_is_reservation_activate.go
@@ -4,7 +4,6 @@
 package vpc
 
 import (
-	"fmt"
 	"log"
 	"runtime/debug"
 
@@ -231,7 +230,7 @@ func resourceIBMISReservationActivateCreate(d *schema.ResourceData, meta interfa
 	response, err := sess.ActivateReservation(activateReservationOptions)
 	if err != nil {
 		log.Printf("[DEBUG] Reservation activation err %s\n%s", err, response)
-		return fmt.Errorf("[ERROR] Error while activating Reservation %s\n%v", err, response)
+		return flex.FmtErrorf("[ERROR] Error while activating Reservation %s\n%v", err, response)
 	}
 	log.Printf("[INFO] Reservation activated: %s", id)
 	d.SetId(id)
@@ -261,13 +260,13 @@ func resourceIBMISReservationActivateRead(d *schema.ResourceData, meta interface
 			d.SetId("")
 			return nil
 		}
-		return fmt.Errorf("[ERROR] Error Getting Reservation (%s): %s\n%s", id, err, response)
+		return flex.FmtErrorf("[ERROR] Error Getting Reservation (%s): %s\n%s", id, err, response)
 	}
 
 	if reservation.AffinityPolicy != nil {
 		if err = d.Set(isReservationAffinityPolicy, reservation.AffinityPolicy); err != nil {
 			log.Printf("[ERROR] Error setting %s: %s", isReservationAffinityPolicy, err)
-			return fmt.Errorf("[ERROR] Error setting %s: %s", isReservationAffinityPolicy, err)
+			return flex.FmtErrorf("[ERROR] Error setting %s: %s", isReservationAffinityPolicy, err)
 		}
 	}
 
@@ -314,35 +313,35 @@ func resourceIBMISReservationActivateRead(d *schema.ResourceData, meta interface
 	if reservation.CreatedAt != nil {
 		if err = d.Set(isReservationCreatedAt, flex.DateTimeToString(reservation.CreatedAt)); err != nil {
 			log.Printf("[ERROR] Error setting %s: %s", isReservationCreatedAt, err)
-			return fmt.Errorf("[ERROR] Error setting %s: %s", isReservationCreatedAt, err)
+			return flex.FmtErrorf("[ERROR] Error setting %s: %s", isReservationCreatedAt, err)
 		}
 	}
 
 	if reservation.CRN != nil {
 		if err = d.Set(isReservationCrn, reservation.CRN); err != nil {
 			log.Printf("[ERROR] Error setting %s: %s", isReservationCrn, err)
-			return fmt.Errorf("[ERROR] Error setting %s: %s", isReservationCrn, err)
+			return flex.FmtErrorf("[ERROR] Error setting %s: %s", isReservationCrn, err)
 		}
 	}
 
 	if reservation.Href != nil {
 		if err = d.Set(isReservationHref, reservation.Href); err != nil {
 			log.Printf("[ERROR] Error setting %s: %s", isReservationHref, err)
-			return fmt.Errorf("[ERROR] Error setting %s: %s", isReservationHref, err)
+			return flex.FmtErrorf("[ERROR] Error setting %s: %s", isReservationHref, err)
 		}
 	}
 
 	if reservation.LifecycleState != nil {
 		if err = d.Set(isReservationLifecycleState, reservation.LifecycleState); err != nil {
 			log.Printf("[ERROR] Error setting %s: %s", isReservationLifecycleState, err)
-			return fmt.Errorf("[ERROR] Error setting %s: %s", isReservationLifecycleState, err)
+			return flex.FmtErrorf("[ERROR] Error setting %s: %s", isReservationLifecycleState, err)
 		}
 	}
 
 	if reservation.Name != nil {
 		if err = d.Set(isReservationName, reservation.Name); err != nil {
 			log.Printf("[ERROR] Error setting %s: %s", isReservationName, err)
-			return fmt.Errorf("[ERROR] Error setting %s: %s", isReservationName, err)
+			return flex.FmtErrorf("[ERROR] Error setting %s: %s", isReservationName, err)
 		}
 	}
 
@@ -385,14 +384,14 @@ func resourceIBMISReservationActivateRead(d *schema.ResourceData, meta interface
 	if reservation.ResourceType != nil {
 		if err = d.Set(isReservationResourceType, reservation.ResourceType); err != nil {
 			log.Printf("[ERROR] Error setting %s: %s", isReservationResourceType, err)
-			return fmt.Errorf("[ERROR] Error setting %s: %s", isReservationResourceType, err)
+			return flex.FmtErrorf("[ERROR] Error setting %s: %s", isReservationResourceType, err)
 		}
 	}
 
 	if reservation.Status != nil {
 		if err = d.Set(isReservationStatus, reservation.Status); err != nil {
 			log.Printf("[ERROR] Error setting %s: %s", isReservationStatus, err)
-			return fmt.Errorf("[ERROR] Error setting %s: %s", isReservationStatus, err)
+			return flex.FmtErrorf("[ERROR] Error setting %s: %s", isReservationStatus, err)
 		}
 	}
 
@@ -409,7 +408,7 @@ func resourceIBMISReservationActivateRead(d *schema.ResourceData, meta interface
 	if reservation.Zone != nil && reservation.Zone.Name != nil {
 		if err = d.Set(isReservationZone, reservation.Zone.Name); err != nil {
 			log.Printf("[ERROR] Error setting %s: %s", isReservationZone, err)
-			return fmt.Errorf("[ERROR] Error setting %s: %s", isReservationZone, err)
+			return flex.FmtErrorf("[ERROR] Error setting %s: %s", isReservationZone, err)
 		}
 	}
 	return nil

--- a/ibm/service/vpc/resource_ibm_is_security_group.go
+++ b/ibm/service/vpc/resource_ibm_is_security_group.go
@@ -5,7 +5,6 @@ package vpc
 
 import (
 	"context"
-	"fmt"
 	"log"
 	"os"
 	"reflect"
@@ -202,7 +201,7 @@ func resourceIBMISSecurityGroupCreate(d *schema.ResourceData, meta interface{}) 
 	}
 	sg, response, err := sess.CreateSecurityGroup(createSecurityGroupOptions)
 	if err != nil {
-		return fmt.Errorf("[ERROR] Error while creating Security Group %s\n%s", err, response)
+		return flex.FmtErrorf("[ERROR] Error while creating Security Group %s\n%s", err, response)
 	}
 	d.SetId(*sg.ID)
 	v := os.Getenv("IC_ENV_TAGS")
@@ -241,7 +240,7 @@ func resourceIBMISSecurityGroupRead(d *schema.ResourceData, meta interface{}) er
 			d.SetId("")
 			return nil
 		}
-		return fmt.Errorf("[ERROR] Error getting Security Group : %s\n%s", err, response)
+		return flex.FmtErrorf("[ERROR] Error getting Security Group : %s\n%s", err, response)
 	}
 	tags, err := flex.GetGlobalTagsUsingCRN(meta, *group.CRN, "", isUserTagType)
 	if err != nil {
@@ -403,12 +402,12 @@ func resourceIBMISSecurityGroupUpdate(d *schema.ResourceData, meta interface{}) 
 		}
 		securityGroupPatch, err := securityGroupPatchModel.AsPatch()
 		if err != nil {
-			return fmt.Errorf("[ERROR] Error calling asPatch for SecurityGroupPatch: %s", err)
+			return flex.FmtErrorf("[ERROR] Error calling asPatch for SecurityGroupPatch: %s", err)
 		}
 		updateSecurityGroupOptions.SecurityGroupPatch = securityGroupPatch
 		_, response, err := sess.UpdateSecurityGroup(updateSecurityGroupOptions)
 		if err != nil {
-			return fmt.Errorf("[ERROR] Error Updating Security Group : %s\n%s", err, response)
+			return flex.FmtErrorf("[ERROR] Error Updating Security Group : %s\n%s", err, response)
 		}
 	}
 	return resourceIBMISSecurityGroupRead(d, meta)
@@ -430,7 +429,7 @@ func resourceIBMISSecurityGroupDelete(d *schema.ResourceData, meta interface{}) 
 			d.SetId("")
 			return nil
 		}
-		return fmt.Errorf("[ERROR] Error Getting Security Group (%s): %s\n%s", id, err, response)
+		return flex.FmtErrorf("[ERROR] Error Getting Security Group (%s): %s\n%s", id, err, response)
 	}
 
 	start := ""
@@ -441,7 +440,7 @@ func resourceIBMISSecurityGroupDelete(d *schema.ResourceData, meta interface{}) 
 
 		groups, response, err := sess.ListSecurityGroupTargets(listSecurityGroupTargetsOptions)
 		if err != nil || groups == nil {
-			return fmt.Errorf("[ERROR] Error Getting Security Group Targets %s\n%s", err, response)
+			return flex.FmtErrorf("[ERROR] Error Getting Security Group Targets %s\n%s", err, response)
 		}
 		if *groups.TotalCount == int64(0) {
 			break
@@ -475,7 +474,7 @@ func resourceIBMISSecurityGroupDelete(d *schema.ResourceData, meta interface{}) 
 							}
 						}
 					} else {
-						return fmt.Errorf("[ERROR] Error deleting security group target binding while deleting security group : %s\n%s", err, response)
+						return flex.FmtErrorf("[ERROR] Error deleting security group target binding while deleting security group : %s\n%s", err, response)
 					}
 				}
 
@@ -500,7 +499,7 @@ func resourceIBMISSecurityGroupDelete(d *schema.ResourceData, meta interface{}) 
 				}
 			}
 		} else {
-			return fmt.Errorf("[ERROR] Error Deleting Security Group : %s\n%s", err, response)
+			return flex.FmtErrorf("[ERROR] Error Deleting Security Group : %s\n%s", err, response)
 		}
 	}
 	d.SetId("")
@@ -522,7 +521,7 @@ func resourceIBMISSecurityGroupExists(d *schema.ResourceData, meta interface{}) 
 		if response != nil && response.StatusCode == 404 {
 			return false, nil
 		}
-		return false, fmt.Errorf("[ERROR] Error getting Security Group: %s\n%s", err, response)
+		return false, flex.FmtErrorf("[ERROR] Error getting Security Group: %s\n%s", err, response)
 	}
 	return true, nil
 }
@@ -598,7 +597,7 @@ func isTargetRefreshFunc(client *vpcv1.VpcV1, sgId, targetId string, target vpcv
 		}
 		sgTarget, response, err := client.GetSecurityGroupTarget(targetgetoptions)
 		if err != nil {
-			return target, "", fmt.Errorf("[ERROR] Error getting target(%s): %s\n%s", targetId, err, response)
+			return target, "", flex.FmtErrorf("[ERROR] Error getting target(%s): %s\n%s", targetId, err, response)
 		}
 		if response != nil && response.StatusCode == 404 {
 			return target, "done", nil
@@ -630,7 +629,7 @@ func isSgRefreshFunc(client *vpcv1.VpcV1, sgId string, groups []vpcv1.SecurityGr
 
 			sggroups, response, err := client.ListSecurityGroupTargets(listSecurityGroupTargetsOptions)
 			if err != nil || sggroups == nil {
-				return groups, "", fmt.Errorf("[ERROR] Error Getting Security Group Targets %s\n%s", err, response)
+				return groups, "", flex.FmtErrorf("[ERROR] Error Getting Security Group Targets %s\n%s", err, response)
 			}
 			if *sggroups.TotalCount == int64(0) {
 				return groups, "done", nil

--- a/ibm/service/vpc/resource_ibm_is_security_group_rule.go
+++ b/ibm/service/vpc/resource_ibm_is_security_group_rule.go
@@ -4,7 +4,6 @@
 package vpc
 
 import (
-	"fmt"
 	"reflect"
 	"strings"
 
@@ -248,7 +247,7 @@ func resourceIBMISSecurityGroupRuleCreate(d *schema.ResourceData, meta interface
 
 	rule, response, err := sess.CreateSecurityGroupRule(options)
 	if err != nil {
-		return fmt.Errorf("[ERROR] Error while creating Security Group Rule %s\n%s", err, response)
+		return flex.FmtErrorf("[ERROR] Error while creating Security Group Rule %s\n%s", err, response)
 	}
 	switch reflect.TypeOf(rule).String() {
 	case "*vpcv1.SecurityGroupRuleSecurityGroupRuleProtocolIcmp":
@@ -296,7 +295,7 @@ func resourceIBMISSecurityGroupRuleRead(d *schema.ResourceData, meta interface{}
 			d.SetId("")
 			return nil
 		}
-		return fmt.Errorf("[ERROR] Error Getting Security Group Rule (%s): %s\n%s", ruleID, err, response)
+		return flex.FmtErrorf("[ERROR] Error Getting Security Group Rule (%s): %s\n%s", ruleID, err, response)
 	}
 	d.Set(isSecurityGroupID, secgrpID)
 	getSecurityGroupOptions := &vpcv1.GetSecurityGroupOptions{
@@ -304,7 +303,7 @@ func resourceIBMISSecurityGroupRuleRead(d *schema.ResourceData, meta interface{}
 	}
 	sg, response, err := sess.GetSecurityGroup(getSecurityGroupOptions)
 	if err != nil {
-		return fmt.Errorf("[ERROR] Error Getting Security Group : %s\n%s", err, response)
+		return flex.FmtErrorf("[ERROR] Error Getting Security Group : %s\n%s", err, response)
 	}
 	d.Set(flex.RelatedCRN, *sg.CRN)
 	switch reflect.TypeOf(sgrule).String() {
@@ -421,7 +420,7 @@ func resourceIBMISSecurityGroupRuleUpdate(d *schema.ResourceData, meta interface
 	updateSecurityGroupRuleOptions := sgTemplate
 	_, response, err := sess.UpdateSecurityGroupRule(updateSecurityGroupRuleOptions)
 	if err != nil {
-		return fmt.Errorf("[ERROR] Error Updating Security Group Rule : %s\n%s", err, response)
+		return flex.FmtErrorf("[ERROR] Error Updating Security Group Rule : %s\n%s", err, response)
 	}
 	return resourceIBMISSecurityGroupRuleRead(d, meta)
 }
@@ -451,7 +450,7 @@ func resourceIBMISSecurityGroupRuleDelete(d *schema.ResourceData, meta interface
 			d.SetId("")
 			return nil
 		}
-		return fmt.Errorf("[ERROR] Error Getting Security Group Rule (%s): %s\n%s", ruleID, err, response)
+		return flex.FmtErrorf("[ERROR] Error Getting Security Group Rule (%s): %s\n%s", ruleID, err, response)
 	}
 
 	deleteSecurityGroupRuleOptions := &vpcv1.DeleteSecurityGroupRuleOptions{
@@ -460,7 +459,7 @@ func resourceIBMISSecurityGroupRuleDelete(d *schema.ResourceData, meta interface
 	}
 	response, err = sess.DeleteSecurityGroupRule(deleteSecurityGroupRuleOptions)
 	if err != nil && response.StatusCode != 404 {
-		return fmt.Errorf("[ERROR] Error Deleting Security Group Rule : %s\n%s", err, response)
+		return flex.FmtErrorf("[ERROR] Error Deleting Security Group Rule : %s\n%s", err, response)
 	}
 	d.SetId("")
 	return nil
@@ -485,7 +484,7 @@ func resourceIBMISSecurityGroupRuleExists(d *schema.ResourceData, meta interface
 		if response != nil && response.StatusCode == 404 {
 			return false, nil
 		}
-		return false, fmt.Errorf("[ERROR] Error getting Security Group Rule (%s): %s\n%s", ruleID, err, response)
+		return false, flex.FmtErrorf("[ERROR] Error getting Security Group Rule (%s): %s\n%s", ruleID, err, response)
 	}
 	return true, nil
 }
@@ -493,10 +492,10 @@ func resourceIBMISSecurityGroupRuleExists(d *schema.ResourceData, meta interface
 func parseISTerraformID(s string) (string, string, error) {
 	segments := strings.Split(s, ".")
 	if len(segments) != 2 {
-		return "", "", fmt.Errorf("invalid terraform Id %s (incorrect number of segments)", s)
+		return "", "", flex.FmtErrorf("invalid terraform Id %s (incorrect number of segments)", s)
 	}
 	if segments[0] == "" || segments[1] == "" {
-		return "", "", fmt.Errorf("invalid terraform Id %s (one or more empty segments)", s)
+		return "", "", flex.FmtErrorf("invalid terraform Id %s (one or more empty segments)", s)
 	}
 	return segments[0], segments[1], nil
 }
@@ -599,7 +598,7 @@ func parseIBMISSecurityGroupRuleDictionary(d *schema.ResourceData, tag string, s
 				if res != nil && res.StatusCode == 404 {
 					return nil, nil, nil, err
 				}
-				return nil, nil, nil, fmt.Errorf("Error getting Security Group in remote (%s): %s\n%s", parsed.remoteSecGrpID, err, res)
+				return nil, nil, nil, flex.FmtErrorf("Error getting Security Group in remote (%s): %s\n%s", parsed.remoteSecGrpID, err, res)
 			}
 		}
 		sgTemplate.Remote = remoteTemplate
@@ -621,7 +620,7 @@ func parseIBMISSecurityGroupRuleDictionary(d *schema.ResourceData, tag string, s
 			}
 			if value, ok := d.GetOk("icmp.0.code"); ok {
 				if !haveType {
-					return nil, nil, nil, fmt.Errorf("icmp code requires icmp type")
+					return nil, nil, nil, flex.FmtErrorf("icmp code requires icmp type")
 				}
 				parsed.icmpCode = int64(value.(int))
 				sgTemplate.Code = &parsed.icmpCode
@@ -671,7 +670,7 @@ func parseIBMISSecurityGroupRuleDictionary(d *schema.ResourceData, tag string, s
 	}
 	securityGroupRulePatch, err := securityGroupRulePatchModel.AsPatch()
 	if err != nil {
-		return nil, nil, nil, fmt.Errorf("[ERROR] Error calling asPatch for SecurityGroupRulePatch: %s", err)
+		return nil, nil, nil, flex.FmtErrorf("[ERROR] Error calling asPatch for SecurityGroupRulePatch: %s", err)
 	}
 	if _, ok := d.GetOk("icmp"); ok {
 

--- a/ibm/service/vpc/resource_ibm_is_security_group_target.go
+++ b/ibm/service/vpc/resource_ibm_is_security_group_target.go
@@ -114,7 +114,7 @@ func resourceIBMISSecurityGroupTargetCreate(d *schema.ResourceData, meta interfa
 
 	sg, response, err := sess.CreateSecurityGroupTargetBinding(createSecurityGroupTargetBindingOptions)
 	if err != nil || sg == nil {
-		return fmt.Errorf("[ERROR] Error while creating Security Group Target Binding %s\n%s", err, response)
+		return flex.FmtErrorf("[ERROR] Error while creating Security Group Target Binding %s\n%s", err, response)
 	}
 	sgtarget := sg.(*vpcv1.SecurityGroupTargetReference)
 	d.SetId(fmt.Sprintf("%s/%s", securityGroupID, *sgtarget.ID))
@@ -168,7 +168,7 @@ func resourceIBMISSecurityGroupTargetRead(d *schema.ResourceData, meta interface
 			d.SetId("")
 			return nil
 		}
-		return fmt.Errorf("[ERROR] Error getting Security Group Target : %s\n%s", err, response)
+		return flex.FmtErrorf("[ERROR] Error getting Security Group Target : %s\n%s", err, response)
 	}
 
 	target := data.(*vpcv1.SecurityGroupTargetReference)
@@ -204,13 +204,13 @@ func resourceIBMISSecurityGroupTargetDelete(d *schema.ResourceData, meta interfa
 			d.SetId("")
 			return nil
 		}
-		return fmt.Errorf("[ERROR] Error Getting Security Group Targets (%s): %s\n%s", securityGroupID, err, response)
+		return flex.FmtErrorf("[ERROR] Error Getting Security Group Targets (%s): %s\n%s", securityGroupID, err, response)
 	}
 
 	deleteSecurityGroupTargetBindingOptions := sess.NewDeleteSecurityGroupTargetBindingOptions(securityGroupID, securityGroupTargetID)
 	response, err = sess.DeleteSecurityGroupTargetBinding(deleteSecurityGroupTargetBindingOptions)
 	if err != nil {
-		return fmt.Errorf("[ERROR] Error Deleting Security Group Targets : %s\n%s", err, response)
+		return flex.FmtErrorf("[ERROR] Error Deleting Security Group Targets : %s\n%s", err, response)
 	}
 	securityGroupTargetReference := sgt.(*vpcv1.SecurityGroupTargetReference)
 	crn := securityGroupTargetReference.CRN
@@ -250,7 +250,7 @@ func resourceIBMISSecurityGroupTargetExists(d *schema.ResourceData, meta interfa
 			d.SetId("")
 			return false, nil
 		}
-		return false, fmt.Errorf("[ERROR] Error getting Security Group Target : %s\n%s", err, response)
+		return false, flex.FmtErrorf("[ERROR] Error getting Security Group Target : %s\n%s", err, response)
 	}
 	return true, nil
 
@@ -288,7 +288,7 @@ func isLBRemoveRefreshFunc(sess *vpcv1.VpcV1, sgt vpcv1.SecurityGroupTargetRefer
 				}
 				lb, response, err := sess.GetLoadBalancer(getlboptions)
 				if err != nil {
-					return nil, "", fmt.Errorf("[ERROR] Error Getting Load Balancer : %s\n%s", err, response)
+					return nil, "", flex.FmtErrorf("[ERROR] Error Getting Load Balancer : %s\n%s", err, response)
 				}
 
 				if *lb.ProvisioningStatus == "active" || *lb.ProvisioningStatus == "failed" {
@@ -297,7 +297,7 @@ func isLBRemoveRefreshFunc(sess *vpcv1.VpcV1, sgt vpcv1.SecurityGroupTargetRefer
 					return sgt, isLBProvisioning, nil
 				}
 			}
-			return nil, isLBProvisioningDone, fmt.Errorf("[ERROR] Error getting Security Group Target : %s\n%s", err, response)
+			return nil, isLBProvisioningDone, flex.FmtErrorf("[ERROR] Error getting Security Group Target : %s\n%s", err, response)
 		}
 		return sgt, isLBProvisioning, nil
 	}
@@ -326,7 +326,7 @@ func isLBSgTargetRefreshFunc(sess *vpcv1.VpcV1, lbId string) resource.StateRefre
 		}
 		lb, response, err := sess.GetLoadBalancer(getlboptions)
 		if err != nil {
-			return nil, "", fmt.Errorf("[ERROR] Error Getting Load Balancer : %s\n%s", err, response)
+			return nil, "", flex.FmtErrorf("[ERROR] Error Getting Load Balancer : %s\n%s", err, response)
 		}
 
 		if *lb.ProvisioningStatus == "active" || *lb.ProvisioningStatus == "failed" {
@@ -360,11 +360,11 @@ func isVNISgTargetRefreshFunc(vpcClient *vpcv1.VpcV1, vniId string) resource.Sta
 		}
 		vni, response, err := vpcClient.GetVirtualNetworkInterface(getVNIOptions)
 		if err != nil {
-			return nil, "", fmt.Errorf("[ERROR] Error Getting Load Balancer : %s\n%s", err, response)
+			return nil, "", flex.FmtErrorf("[ERROR] Error Getting Load Balancer : %s\n%s", err, response)
 		}
 
 		if *vni.LifecycleState == "failed" {
-			return vni, *vni.LifecycleState, fmt.Errorf("Network Interface creationg failed with status %s ", *vni.LifecycleState)
+			return vni, *vni.LifecycleState, flex.FmtErrorf("Network Interface creationg failed with status %s ", *vni.LifecycleState)
 		}
 		return vni, *vni.LifecycleState, nil
 	}

--- a/ibm/service/vpc/resource_ibm_is_share.go
+++ b/ibm/service/vpc/resource_ibm_is_share.go
@@ -1059,32 +1059,32 @@ func resourceIbmIsShareRead(context context.Context, d *schema.ResourceData, met
 
 	if share.EncryptionKey != nil {
 		if err = d.Set("encryption_key", *share.EncryptionKey.CRN); err != nil {
-			return diag.FromErr(fmt.Errorf("Error setting encryption_key: %s", err))
+			return diag.FromErr(flex.FmtErrorf("Error setting encryption_key: %s", err))
 		}
 	}
 	if share.AccessControlMode != nil {
 		if err = d.Set("access_control_mode", *share.AccessControlMode); err != nil {
-			return diag.FromErr(fmt.Errorf("Error setting access_control_mode: %s", err))
+			return diag.FromErr(flex.FmtErrorf("Error setting access_control_mode: %s", err))
 		}
 	}
 	if err = d.Set("iops", flex.IntValue(share.Iops)); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting iops: %s", err))
+		return diag.FromErr(flex.FmtErrorf("Error setting iops: %s", err))
 	}
 	if err = d.Set("name", share.Name); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting name: %s", err))
+		return diag.FromErr(flex.FmtErrorf("Error setting name: %s", err))
 	}
 	if share.Profile != nil {
 		if err = d.Set("profile", *share.Profile.Name); err != nil {
-			return diag.FromErr(fmt.Errorf("Error setting profile: %s", err))
+			return diag.FromErr(flex.FmtErrorf("Error setting profile: %s", err))
 		}
 	}
 	if share.ResourceGroup != nil {
 		if err = d.Set("resource_group", *share.ResourceGroup.ID); err != nil {
-			return diag.FromErr(fmt.Errorf("Error setting resource_group: %s", err))
+			return diag.FromErr(flex.FmtErrorf("Error setting resource_group: %s", err))
 		}
 	}
 	if err = d.Set("size", flex.IntValue(share.Size)); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting size: %s", err))
+		return diag.FromErr(flex.FmtErrorf("Error setting size: %s", err))
 	}
 	targets := make([]map[string]interface{}, 0)
 	if share.MountTargets != nil {
@@ -1111,7 +1111,7 @@ func resourceIbmIsShareRead(context context.Context, d *schema.ResourceData, met
 		}
 	}
 	if err = d.Set("mount_targets", targets); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting mount_targets: %s", err))
+		return diag.FromErr(flex.FmtErrorf("Error setting mount_targets: %s", err))
 	}
 
 	replicaShare := []map[string]interface{}{}
@@ -1141,26 +1141,26 @@ func resourceIbmIsShareRead(context context.Context, d *schema.ResourceData, met
 
 	if share.Zone != nil {
 		if err = d.Set("zone", *share.Zone.Name); err != nil {
-			return diag.FromErr(fmt.Errorf("Error setting zone: %s", err))
+			return diag.FromErr(flex.FmtErrorf("Error setting zone: %s", err))
 		}
 	}
 	if err = d.Set("created_at", share.CreatedAt.String()); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting created_at: %s", err))
+		return diag.FromErr(flex.FmtErrorf("Error setting created_at: %s", err))
 	}
 	if err = d.Set("crn", share.CRN); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting crn: %s", err))
+		return diag.FromErr(flex.FmtErrorf("Error setting crn: %s", err))
 	}
 	if err = d.Set("encryption", share.Encryption); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting encryption: %s", err))
+		return diag.FromErr(flex.FmtErrorf("Error setting encryption: %s", err))
 	}
 	if err = d.Set("href", share.Href); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting href: %s", err))
+		return diag.FromErr(flex.FmtErrorf("Error setting href: %s", err))
 	}
 	if err = d.Set("lifecycle_state", share.LifecycleState); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting lifecycle_state: %s", err))
+		return diag.FromErr(flex.FmtErrorf("Error setting lifecycle_state: %s", err))
 	}
 	if err = d.Set("resource_type", share.ResourceType); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting resource_type: %s", err))
+		return diag.FromErr(flex.FmtErrorf("Error setting resource_type: %s", err))
 	}
 
 	latest_syncs := []map[string]interface{}{}
@@ -1441,7 +1441,7 @@ func isShareRefreshFunc(context context.Context, vpcClient *vpcv1.VpcV1, shareid
 
 		share, response, err := vpcClient.GetShareWithContext(context, shareOptions)
 		if err != nil {
-			return nil, "", fmt.Errorf("Error Getting share: %s\n%s", err, response)
+			return nil, "", flex.FmtErrorf("Error Getting share: %s\n%s", err, response)
 		}
 		d.Set("lifecycle_state", *share.LifecycleState)
 		if *share.LifecycleState == "stable" || *share.LifecycleState == "failed" {
@@ -1468,10 +1468,10 @@ func isWaitForShareDelete(context context.Context, vpcClient *vpcv1.VpcV1, d *sc
 				if response != nil && response.StatusCode == 404 {
 					return share, "done", nil
 				}
-				return nil, "", fmt.Errorf("Error Getting Target: %s\n%s", err, response)
+				return nil, "", flex.FmtErrorf("Error Getting Target: %s\n%s", err, response)
 			}
 			if *share.LifecycleState == isInstanceFailed {
-				return share, *share.LifecycleState, fmt.Errorf("The  target %s failed to delete: %v", shareid, err)
+				return share, *share.LifecycleState, flex.FmtErrorf("The  target %s failed to delete: %v", shareid, err)
 			}
 			return share, "deleting", nil
 		},
@@ -1803,7 +1803,7 @@ func shareUpdate(vpcClient *vpcv1.VpcV1, context context.Context, d *schema.Reso
 						}
 						_, response, err := vpcClient.CreateSecurityGroupTargetBinding(createsgnicoptions)
 						if err != nil {
-							return fmt.Errorf("[ERROR] Error while creating security group %q for virtual network interface of share mount target %s\n%s: %q", add[i], d.Id(), err, response)
+							return flex.FmtErrorf("[ERROR] Error while creating security group %q for virtual network interface of share mount target %s\n%s: %q", add[i], d.Id(), err, response)
 						}
 						_, err = WaitForVNIAvailable(vpcClient, networkID, d, d.Timeout(schema.TimeoutUpdate))
 						if err != nil {
@@ -1825,7 +1825,7 @@ func shareUpdate(vpcClient *vpcv1.VpcV1, context context.Context, d *schema.Reso
 						}
 						response, err := vpcClient.DeleteSecurityGroupTargetBinding(deletesgnicoptions)
 						if err != nil {
-							return fmt.Errorf("[ERROR] Error while removing security group %q for virtual network interface of share mount target %s\n%s: %q", remove[i], d.Id(), err, response)
+							return flex.FmtErrorf("[ERROR] Error while removing security group %q for virtual network interface of share mount target %s\n%s: %q", remove[i], d.Id(), err, response)
 						}
 						_, err = WaitForVNIAvailable(vpcClient, networkID, d, d.Timeout(schema.TimeoutUpdate))
 						if err != nil {
@@ -1862,16 +1862,16 @@ func shareUpdate(vpcClient *vpcv1.VpcV1, context context.Context, d *schema.Reso
 				}
 				reservedIpPathAsPatch, err := reservedIpPath.AsPatch()
 				if err != nil {
-					return fmt.Errorf("[ERROR] Error calling reserved ip as patch \n%s", err)
+					return flex.FmtErrorf("[ERROR] Error calling reserved ip as patch \n%s", err)
 				}
 				updateripoptions.ReservedIPPatch = reservedIpPathAsPatch
 				_, response, err := vpcClient.UpdateSubnetReservedIP(updateripoptions)
 				if err != nil {
-					return fmt.Errorf("[ERROR] Error updating instance network interface reserved ip(%s): %s\n%s", ripId, err, response)
+					return flex.FmtErrorf("[ERROR] Error updating instance network interface reserved ip(%s): %s\n%s", ripId, err, response)
 				}
 				_, err = isWaitForReservedIpAvailable(sess, subnetId, ripId, d.Timeout(schema.TimeoutUpdate), d)
 				if err != nil {
-					return fmt.Errorf("[ERROR] Error waiting for the reserved IP to be available: %s", err)
+					return flex.FmtErrorf("[ERROR] Error waiting for the reserved IP to be available: %s", err)
 				}
 			}
 		}

--- a/ibm/service/vpc/resource_ibm_is_share_replica_operations.go
+++ b/ibm/service/vpc/resource_ibm_is_share_replica_operations.go
@@ -5,11 +5,11 @@ package vpc
 
 import (
 	"context"
-	"fmt"
 	"log"
 	"time"
 
 	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/conns"
+	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/flex"
 	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/validate"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
@@ -97,7 +97,6 @@ func resourceIbmIsShareReplicaOperationsCreate(context context.Context, d *schem
 	share_id := d.Get("share_replica").(string)
 
 	splitShare := d.Get("split_share").(bool)
-
 	if !splitShare {
 		fallback_policy := d.Get("fallback_policy").(string)
 		timeout := d.Get("timeout").(int)
@@ -111,7 +110,7 @@ func resourceIbmIsShareReplicaOperationsCreate(context context.Context, d *schem
 		response, err := vpcClient.FailoverShareWithContext(context, failOverShareOptions)
 		if err != nil {
 			log.Printf("[DEBUG] FailoverShareWithContext failed %s\n%s", err, response)
-			return diag.FromErr(fmt.Errorf("[ERROR] FailoverShareWithContext failed %s\n%s", err, response))
+			return diag.FromErr(flex.FmtErrorf("[ERROR] FailoverShareWithContext failed %s\n%s", err, response))
 		}
 	} else {
 		deleteShareSourceOptions := &vpcv1.DeleteShareSourceOptions{
@@ -120,7 +119,7 @@ func resourceIbmIsShareReplicaOperationsCreate(context context.Context, d *schem
 		response, err := vpcClient.DeleteShareSourceWithContext(context, deleteShareSourceOptions)
 		if err != nil {
 			log.Printf("[DEBUG] DeleteShareSourceWithContext failed %s\n%s", err, response)
-			return diag.FromErr(fmt.Errorf("[ERROR] DeleteShareSourceWithContext failed %s\n%s", err, response))
+			return diag.FromErr(flex.FmtErrorf("[ERROR] DeleteShareSourceWithContext failed %s\n%s", err, response))
 		}
 	}
 	_, err = isWaitForShareReplicationJobDone(context, vpcClient, share_id, d, d.Timeout(schema.TimeoutCreate))
@@ -154,7 +153,7 @@ func isShareReplicationJobRefreshFunc(context context.Context, vpcClient *vpcv1.
 
 		share, response, err := vpcClient.GetShareWithContext(context, shareOptions)
 		if err != nil {
-			return nil, "", fmt.Errorf("Error Getting share: %s\n%s", err, response)
+			return nil, "", flex.FmtErrorf("Error Getting share: %s\n%s", err, response)
 		}
 		if *share.ReplicationStatus == "active" || *share.ReplicationStatus == "none" {
 
@@ -202,7 +201,7 @@ func isShareSplitRefreshFunc(context context.Context, vpcClient *vpcv1.VpcV1, sh
 
 		share, response, err := vpcClient.GetShareWithContext(context, shareOptions)
 		if err != nil {
-			return nil, "", fmt.Errorf("Error Getting share: %s\n%s", err, response)
+			return nil, "", flex.FmtErrorf("Error Getting share: %s\n%s", err, response)
 		}
 		d.Set("replication_status", *share.LifecycleState)
 		if *share.LifecycleState == "none" {

--- a/ibm/service/vpc/resource_ibm_is_ssh_key.go
+++ b/ibm/service/vpc/resource_ibm_is_ssh_key.go
@@ -7,7 +7,6 @@ import (
 	"context"
 	"encoding/base64"
 	"errors"
-	"fmt"
 	"log"
 	"os"
 	"strings"
@@ -224,7 +223,7 @@ func keyCreate(d *schema.ResourceData, meta interface{}, name, publickey string)
 
 	key, response, err := sess.CreateKey(options)
 	if err != nil {
-		return fmt.Errorf("[DEBUG] Create SSH Key %s\n%s", err, response)
+		return flex.FmtErrorf("[DEBUG] Create SSH Key %s\n%s", err, response)
 	}
 	d.SetId(*key.ID)
 	log.Printf("[INFO] Key : %s", *key.ID)
@@ -275,7 +274,7 @@ func keyGet(d *schema.ResourceData, meta interface{}, id string) error {
 			d.SetId("")
 			return nil
 		}
-		return fmt.Errorf("[ERROR] Error getting SSH Key (%s): %s\n%s", id, err, response)
+		return flex.FmtErrorf("[ERROR] Error getting SSH Key (%s): %s\n%s", id, err, response)
 	}
 	d.Set(isKeyName, *key.Name)
 	d.Set(isKeyPublicKey, *key.PublicKey)
@@ -338,7 +337,7 @@ func keyUpdate(d *schema.ResourceData, meta interface{}, id, name string, hasCha
 		}
 		key, response, err := sess.GetKey(options)
 		if err != nil {
-			return fmt.Errorf("[ERROR] Error getting SSH Key : %s\n%s", err, response)
+			return flex.FmtErrorf("[ERROR] Error getting SSH Key : %s\n%s", err, response)
 		}
 		oldList, newList := d.GetChange(isKeyTags)
 		err = flex.UpdateGlobalTagsUsingCRN(oldList, newList, meta, *key.CRN, "", isKeyUserTagType)
@@ -353,7 +352,7 @@ func keyUpdate(d *schema.ResourceData, meta interface{}, id, name string, hasCha
 		}
 		key, response, err := sess.GetKey(options)
 		if err != nil {
-			return fmt.Errorf("Error getting SSH Key : %s\n%s", err, response)
+			return flex.FmtErrorf("Error getting SSH Key : %s\n%s", err, response)
 		}
 		oldList, newList := d.GetChange(isKeyAccessTags)
 		err = flex.UpdateGlobalTagsUsingCRN(oldList, newList, meta, *key.CRN, "", isKeyAccessTagType)
@@ -371,12 +370,12 @@ func keyUpdate(d *schema.ResourceData, meta interface{}, id, name string, hasCha
 		}
 		keyPatch, err := keyPatchModel.AsPatch()
 		if err != nil {
-			return fmt.Errorf("[ERROR] Error calling asPatch for KeyPatch: %s", err)
+			return flex.FmtErrorf("[ERROR] Error calling asPatch for KeyPatch: %s", err)
 		}
 		options.KeyPatch = keyPatch
 		_, response, err := sess.UpdateKey(options)
 		if err != nil {
-			return fmt.Errorf("[ERROR] Error updating vpc SSH Key: %s\n%s", err, response)
+			return flex.FmtErrorf("[ERROR] Error updating vpc SSH Key: %s\n%s", err, response)
 		}
 	}
 	return nil
@@ -406,7 +405,7 @@ func keyDelete(d *schema.ResourceData, meta interface{}, id string) error {
 		if response != nil && response.StatusCode == 404 {
 			return nil
 		}
-		return fmt.Errorf("[ERROR] Error getting SSH Key (%s): %s\n%s", id, err, response)
+		return flex.FmtErrorf("[ERROR] Error getting SSH Key (%s): %s\n%s", id, err, response)
 	}
 
 	options := &vpcv1.DeleteKeyOptions{
@@ -414,7 +413,7 @@ func keyDelete(d *schema.ResourceData, meta interface{}, id string) error {
 	}
 	response, err = sess.DeleteKey(options)
 	if err != nil {
-		return fmt.Errorf("[ERROR] Error deleting SSH Key : %s\n%s", err, response)
+		return flex.FmtErrorf("[ERROR] Error deleting SSH Key : %s\n%s", err, response)
 	}
 	d.SetId("")
 	return nil
@@ -440,7 +439,7 @@ func keyExists(d *schema.ResourceData, meta interface{}, id string) (bool, error
 		if response != nil && response.StatusCode == 404 {
 			return false, nil
 		}
-		return false, fmt.Errorf("[ERROR] Error getting SSH Key: %s\n%s", err, response)
+		return false, flex.FmtErrorf("[ERROR] Error getting SSH Key: %s\n%s", err, response)
 	}
 	return true, nil
 }

--- a/ibm/service/vpc/resource_ibm_is_subnet_network_acl_attachment.go
+++ b/ibm/service/vpc/resource_ibm_is_subnet_network_acl_attachment.go
@@ -4,11 +4,11 @@
 package vpc
 
 import (
-	"fmt"
 	"log"
 	"reflect"
 	"time"
 
+	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/flex"
 	"github.com/IBM/vpc-go-sdk/vpcv1"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
@@ -215,7 +215,7 @@ func resourceIBMISSubnetNetworkACLAttachmentCreate(d *schema.ResourceData, meta 
 
 	if err != nil {
 		log.Printf("[DEBUG] Error while attaching a network ACL to a subnet %s\n%s", err, response)
-		return fmt.Errorf("[ERROR] Error while attaching a network ACL to a subnet %s\n%s", err, response)
+		return flex.FmtErrorf("[ERROR] Error while attaching a network ACL to a subnet %s\n%s", err, response)
 	}
 	d.SetId(subnet)
 	log.Printf("[INFO] Network ACL : %s", *resultACL.ID)
@@ -241,7 +241,7 @@ func resourceIBMISSubnetNetworkACLAttachmentRead(d *schema.ResourceData, meta in
 			d.SetId("")
 			return nil
 		}
-		return fmt.Errorf("[ERROR] Error getting subnet's (%s) attached network ACL: %s\n%s", id, err, response)
+		return flex.FmtErrorf("[ERROR] Error getting subnet's (%s) attached network ACL: %s\n%s", id, err, response)
 	}
 	d.Set(isNetworkACLName, *nwacl.Name)
 	d.Set(isNetworkACLCRN, *nwacl.CRN)
@@ -356,7 +356,7 @@ func resourceIBMISSubnetNetworkACLAttachmentUpdate(d *schema.ResourceData, meta 
 
 		if err != nil {
 			log.Printf("[DEBUG] Error while attaching a network ACL to a subnet %s\n%s", err, response)
-			return fmt.Errorf("[ERROR] Error while attaching a network ACL to a subnet %s\n%s", err, response)
+			return flex.FmtErrorf("[ERROR] Error while attaching a network ACL to a subnet %s\n%s", err, response)
 		}
 		log.Printf("[INFO] Updated subnet %s with Network ACL : %s", subnet, *resultACL.ID)
 
@@ -383,7 +383,7 @@ func resourceIBMISSubnetNetworkACLAttachmentDelete(d *schema.ResourceData, meta 
 			d.SetId("")
 			return nil
 		}
-		return fmt.Errorf("[ERROR] Error Getting Subnet (%s): %s\n%s", id, err, response)
+		return flex.FmtErrorf("[ERROR] Error Getting Subnet (%s): %s\n%s", id, err, response)
 	}
 	// Fetch VPC
 	vpcID := *subnet.VPC.ID
@@ -397,7 +397,7 @@ func resourceIBMISSubnetNetworkACLAttachmentDelete(d *schema.ResourceData, meta 
 			d.SetId("")
 			return nil
 		}
-		return fmt.Errorf("[ERROR] Error getting VPC : %s\n%s", err, response)
+		return flex.FmtErrorf("[ERROR] Error getting VPC : %s\n%s", err, response)
 	}
 
 	// Fetch default network ACL
@@ -415,7 +415,7 @@ func resourceIBMISSubnetNetworkACLAttachmentDelete(d *schema.ResourceData, meta 
 
 		if err != nil {
 			log.Printf("[DEBUG] Error while attaching a network ACL to a subnet %s\n%s", err, response)
-			return fmt.Errorf("[ERROR] Error while attaching a network ACL to a subnet %s\n%s", err, response)
+			return flex.FmtErrorf("[ERROR] Error while attaching a network ACL to a subnet %s\n%s", err, response)
 		}
 		log.Printf("[INFO] Updated subnet %s with VPC default Network ACL : %s", id, *resultACL.ID)
 	} else {
@@ -440,7 +440,7 @@ func resourceIBMISSubnetNetworkACLAttachmentExists(d *schema.ResourceData, meta 
 		if response != nil && response.StatusCode == 404 {
 			return false, nil
 		}
-		return false, fmt.Errorf("[ERROR] Error getting subnet's attached network ACL: %s\n%s", err, response)
+		return false, flex.FmtErrorf("[ERROR] Error getting subnet's attached network ACL: %s\n%s", err, response)
 	}
 	return true, nil
 }

--- a/ibm/service/vpc/resource_ibm_is_subnet_public_gateway_attachment.go
+++ b/ibm/service/vpc/resource_ibm_is_subnet_public_gateway_attachment.go
@@ -5,7 +5,6 @@ package vpc
 
 import (
 	"context"
-	"fmt"
 	"log"
 	"time"
 
@@ -132,7 +131,7 @@ func resourceIBMISSubnetPublicGatewayAttachmentCreate(context context.Context, d
 
 	if err != nil {
 		log.Printf("[DEBUG] Error while attaching public gateway(%s) to subnet(%s) %s\n%s", publicGateway, subnet, err, response)
-		return diag.FromErr(fmt.Errorf("[ERROR] Error while attaching public gateway(%s) to subnet(%s) %s\n%s", publicGateway, subnet, err, response))
+		return diag.FromErr(flex.FmtErrorf("[ERROR] Error while attaching public gateway(%s) to subnet(%s) %s\n%s", publicGateway, subnet, err, response))
 	}
 	d.SetId(subnet)
 	_, err = isWaitForSubnetPublicGatewayAvailable(sess, d.Id(), d.Timeout(schema.TimeoutCreate))
@@ -162,7 +161,7 @@ func resourceIBMISSubnetPublicGatewayAttachmentRead(context context.Context, d *
 			d.SetId("")
 			return nil
 		}
-		return diag.FromErr(fmt.Errorf("[ERROR] Error getting subnet's (%s) attached public gateway: %s\n%s", id, err, response))
+		return diag.FromErr(flex.FmtErrorf("[ERROR] Error getting subnet's (%s) attached public gateway: %s\n%s", id, err, response))
 	}
 	d.Set(isPublicGatewayName, pg.Name)
 	d.Set(isSubnetID, id)
@@ -211,7 +210,7 @@ func resourceIBMISSubnetPublicGatewayAttachmentUpdate(context context.Context, d
 
 		if err != nil || pg == nil {
 			log.Printf("[DEBUG] Error while attaching public gateway(%s) to subnet(%s) %s\n%s", publicGateway, subnet, err, response)
-			return diag.FromErr(fmt.Errorf("[ERROR] Error while attaching public gateway(%s) to subnet(%s) %s\n%s", publicGateway, subnet, err, response))
+			return diag.FromErr(flex.FmtErrorf("[ERROR] Error while attaching public gateway(%s) to subnet(%s) %s\n%s", publicGateway, subnet, err, response))
 		}
 		log.Printf("[INFO] Updated subnet %s with public gateway(%s)", subnet, publicGateway)
 
@@ -238,7 +237,7 @@ func resourceIBMISSubnetPublicGatewayAttachmentDelete(context context.Context, d
 			d.SetId("")
 			return nil
 		}
-		return diag.FromErr(fmt.Errorf("[ERROR] Error Getting Subnet (%s): %s\n%s", id, err, response))
+		return diag.FromErr(flex.FmtErrorf("[ERROR] Error Getting Subnet (%s): %s\n%s", id, err, response))
 	}
 
 	// Construct an instance of the UnsetSubnetPublicGatewayOptions model
@@ -249,7 +248,7 @@ func resourceIBMISSubnetPublicGatewayAttachmentDelete(context context.Context, d
 
 	if err != nil {
 		log.Printf("[DEBUG] Error while detaching public gateway to subnet %s\n%s", err, res)
-		return diag.FromErr(fmt.Errorf("[ERROR] Error while detaching public gateway to subnet %s\n%s", err, res))
+		return diag.FromErr(flex.FmtErrorf("[ERROR] Error while detaching public gateway to subnet %s\n%s", err, res))
 	}
 	_, err = isWaitForSubnetPublicGatewayDelete(sess, d.Id(), d.Timeout(schema.TimeoutCreate))
 	if err != nil {
@@ -283,13 +282,13 @@ func isSubnetPublicGatewayRefreshFunc(subnetC *vpcv1.VpcV1, id string) resource.
 
 		if err != nil {
 			if response != nil && response.StatusCode == 404 {
-				return pg, "", fmt.Errorf("[ERROR] Error getting subnet's (%s) attached public gateway: %s\n%s", id, err, response)
+				return pg, "", flex.FmtErrorf("[ERROR] Error getting subnet's (%s) attached public gateway: %s\n%s", id, err, response)
 			}
-			return pg, "", fmt.Errorf("[ERROR] Error getting subnet's (%s) attached public gateway: %s\n%s", id, err, response)
+			return pg, "", flex.FmtErrorf("[ERROR] Error getting subnet's (%s) attached public gateway: %s\n%s", id, err, response)
 		}
 
 		if *pg.Status == "failed" {
-			return pg, IsPublicGatewayAttachmentFailed, fmt.Errorf("[ERROR] Error subnet (%s) public gateway attachment failed: %s\n%s", id, err, response)
+			return pg, IsPublicGatewayAttachmentFailed, flex.FmtErrorf("[ERROR] Error subnet (%s) public gateway attachment failed: %s\n%s", id, err, response)
 		}
 
 		return pg, *pg.Status, nil
@@ -322,11 +321,11 @@ func isSubnetPublicGatewayDeleteRefreshFunc(subnetC *vpcv1.VpcV1, id string) res
 			if response != nil && response.StatusCode == 404 {
 				return pg, "", nil
 			}
-			return pg, "", fmt.Errorf("[ERROR] Error getting subnet's (%s) attached public gateway: %s\n%s", id, err, response)
+			return pg, "", flex.FmtErrorf("[ERROR] Error getting subnet's (%s) attached public gateway: %s\n%s", id, err, response)
 		}
 
 		if *pg.Status == "failed" {
-			return pg, IsPublicGatewayAttachmentFailed, fmt.Errorf("[ERROR] Error subnet (%s) public gateway attachment failed: %s\n%s", id, err, response)
+			return pg, IsPublicGatewayAttachmentFailed, flex.FmtErrorf("[ERROR] Error subnet (%s) public gateway attachment failed: %s\n%s", id, err, response)
 		}
 
 		return pg, *pg.Status, nil

--- a/ibm/service/vpc/resource_ibm_is_subnet_reserved_ip.go
+++ b/ibm/service/vpc/resource_ibm_is_subnet_reserved_ip.go
@@ -175,14 +175,14 @@ func resourceIBMISReservedIPCreate(d *schema.ResourceData, meta interface{}) err
 	}
 	rip, response, err := sess.CreateSubnetReservedIP(options)
 	if err != nil || response == nil || rip == nil {
-		return fmt.Errorf("[ERROR] Error creating the reserved IP: %s\n%s", err, response)
+		return flex.FmtErrorf("[ERROR] Error creating the reserved IP: %s\n%s", err, response)
 	}
 
 	// Set id for the reserved IP as combination of subnet ID and reserved IP ID
 	d.SetId(fmt.Sprintf("%s/%s", subnetID, *rip.ID))
 	_, err = isWaitForReservedIpAvailable(sess, subnetID, *rip.ID, d.Timeout(schema.TimeoutCreate), d)
 	if err != nil {
-		return fmt.Errorf("[ERROR] Error waiting for the reserved IP to be available: %s", err)
+		return flex.FmtErrorf("[ERROR] Error waiting for the reserved IP to be available: %s", err)
 	}
 
 	return resourceIBMISReservedIPRead(d, meta)
@@ -196,7 +196,7 @@ func resourceIBMISReservedIPRead(d *schema.ResourceData, meta interface{}) error
 
 	allIDs, err := flex.IdParts(d.Id())
 	if err != nil {
-		return fmt.Errorf("[ERROR] The ID can not be split into subnet ID and reserved IP ID. %s", err)
+		return flex.FmtErrorf("[ERROR] The ID can not be split into subnet ID and reserved IP ID. %s", err)
 	}
 	subnetID := allIDs[0]
 
@@ -294,19 +294,19 @@ func resourceIBMISReservedIPUpdate(d *schema.ResourceData, meta interface{}) err
 
 		reservedIPPatch, err := patch.AsPatch()
 		if err != nil {
-			return fmt.Errorf("[ERROR] Error updating the reserved IP %s", err)
+			return flex.FmtErrorf("[ERROR] Error updating the reserved IP %s", err)
 		}
 
 		options.ReservedIPPatch = reservedIPPatch
 
 		_, response, err := sess.UpdateSubnetReservedIP(options)
 		if err != nil {
-			return fmt.Errorf("[ERROR] Error updating the reserved IP %s\n%s", err, response)
+			return flex.FmtErrorf("[ERROR] Error updating the reserved IP %s\n%s", err, response)
 		}
 
 		_, err = isWaitForReservedIpAvailable(sess, subnetID, reservedIPID, d.Timeout(schema.TimeoutCreate), d)
 		if err != nil {
-			return fmt.Errorf("[ERROR] Error waiting for the reserved IP to be available: %s", err)
+			return flex.FmtErrorf("[ERROR] Error waiting for the reserved IP to be available: %s", err)
 		}
 	}
 	return resourceIBMISReservedIPRead(d, meta)
@@ -336,7 +336,7 @@ func resourceIBMISReservedIPDelete(d *schema.ResourceData, meta interface{}) err
 	deleteOptions := sess.NewDeleteSubnetReservedIPOptions(subnetID, reservedIPID)
 	response, err := sess.DeleteSubnetReservedIP(deleteOptions)
 	if err != nil || response == nil {
-		return fmt.Errorf("[ERROR] Error deleting the reserverd ip %s in subnet %s, %s\n%s", reservedIPID, subnetID, err, response)
+		return flex.FmtErrorf("[ERROR] Error deleting the reserverd ip %s in subnet %s, %s\n%s", reservedIPID, subnetID, err, response)
 	}
 	d.SetId("")
 	return nil
@@ -369,7 +369,7 @@ func get(d *schema.ResourceData, meta interface{}) (*vpcv1.ReservedIP, error) {
 			d.SetId("")
 			return nil, nil
 		}
-		return nil, fmt.Errorf("[ERROR] Error Getting Reserved IP : %s\n%s", err, response)
+		return nil, flex.FmtErrorf("[ERROR] Error Getting Reserved IP : %s\n%s", err, response)
 	}
 	return rip, nil
 }
@@ -395,7 +395,7 @@ func isReserveIpRefreshFunc(sess *vpcv1.VpcV1, subnetid, id string, d *schema.Re
 		}
 		rsip, response, err := sess.GetSubnetReservedIP(getreservedipOptions)
 		if err != nil {
-			return nil, "", fmt.Errorf("[ERROR] Error Getting reserved ip(%s/%s) : %s\n%s", subnetid, id, err, response)
+			return nil, "", flex.FmtErrorf("[ERROR] Error Getting reserved ip(%s/%s) : %s\n%s", subnetid, id, err, response)
 		}
 		if rsip.LifecycleState != nil {
 			d.Set(isReservedIPLifecycleState, *rsip.LifecycleState)
@@ -403,7 +403,7 @@ func isReserveIpRefreshFunc(sess *vpcv1.VpcV1, subnetid, id string, d *schema.Re
 		d.Set(isReservedIPAddress, *rsip.Address)
 
 		if rsip.LifecycleState != nil && *rsip.LifecycleState == "failed" {
-			return rsip, "failed", fmt.Errorf("[ERROR] Error Reserved ip(%s/%s) creation failed : %s\n%s", subnetid, id, err, response)
+			return rsip, "failed", flex.FmtErrorf("[ERROR] Error Reserved ip(%s/%s) creation failed : %s\n%s", subnetid, id, err, response)
 		}
 		if rsip.LifecycleState != nil && *rsip.LifecycleState == "stable" {
 			return rsip, "done", nil

--- a/ibm/service/vpc/resource_ibm_is_subnet_routing_table_attachment.go
+++ b/ibm/service/vpc/resource_ibm_is_subnet_routing_table_attachment.go
@@ -5,10 +5,10 @@ package vpc
 
 import (
 	"context"
-	"fmt"
 	"log"
 	"time"
 
+	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/flex"
 	"github.com/IBM/vpc-go-sdk/vpcv1"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -144,7 +144,7 @@ func resourceIBMISSubnetRoutingTableAttachmentCreate(context context.Context, d 
 
 	if err != nil {
 		log.Printf("[DEBUG] Error while attaching a routing table to a subnet %s\n%s", err, response)
-		return diag.FromErr(fmt.Errorf("[ERROR] Error while attaching a routing table to a subnet %s\n%s", err, response))
+		return diag.FromErr(flex.FmtErrorf("[ERROR] Error while attaching a routing table to a subnet %s\n%s", err, response))
 	}
 	d.SetId(subnet)
 	log.Printf("[INFO] Routing Table : %s", *resultRT.ID)
@@ -170,7 +170,7 @@ func resourceIBMISSubnetRoutingTableAttachmentRead(context context.Context, d *s
 			d.SetId("")
 			return nil
 		}
-		return diag.FromErr(fmt.Errorf("[ERROR] Error getting subnet's (%s) attached routing table: %s\n%s", id, err, response))
+		return diag.FromErr(flex.FmtErrorf("[ERROR] Error getting subnet's (%s) attached routing table: %s\n%s", id, err, response))
 	}
 	d.Set(isRoutingTableName, *subRT.Name)
 	d.Set(isSubnetID, id)
@@ -225,7 +225,7 @@ func resourceIBMISSubnetRoutingTableAttachmentUpdate(context context.Context, d 
 
 		if err != nil {
 			log.Printf("[DEBUG] Error while attaching a routing table to a subnet %s\n%s", err, response)
-			return diag.FromErr(fmt.Errorf("[ERROR] Error while attaching a routing table to a subnet %s\n%s", err, response))
+			return diag.FromErr(flex.FmtErrorf("[ERROR] Error while attaching a routing table to a subnet %s\n%s", err, response))
 		}
 		log.Printf("[INFO] Updated subnet %s with Routing Table : %s", subnet, *resultRT.ID)
 
@@ -252,7 +252,7 @@ func resourceIBMISSubnetRoutingTableAttachmentDelete(context context.Context, d 
 			d.SetId("")
 			return nil
 		}
-		return diag.FromErr(fmt.Errorf("[ERROR] Error Getting Subnet (%s): %s\n%s", id, err, response))
+		return diag.FromErr(flex.FmtErrorf("[ERROR] Error Getting Subnet (%s): %s\n%s", id, err, response))
 	}
 	// Fetch VPC
 	vpcID := *subnet.VPC.ID
@@ -266,7 +266,7 @@ func resourceIBMISSubnetRoutingTableAttachmentDelete(context context.Context, d 
 			d.SetId("")
 			return nil
 		}
-		return diag.FromErr(fmt.Errorf("[ERROR] Error getting VPC : %s\n%s", err, response))
+		return diag.FromErr(flex.FmtErrorf("[ERROR] Error getting VPC : %s\n%s", err, response))
 	}
 
 	// Fetch default routing table
@@ -284,7 +284,7 @@ func resourceIBMISSubnetRoutingTableAttachmentDelete(context context.Context, d 
 
 		if err != nil {
 			log.Printf("[DEBUG] Error while attaching a routing table to a subnet %s\n%s", err, response)
-			return diag.FromErr(fmt.Errorf("[ERROR] Error while attaching a routing table to a subnet %s\n%s", err, response))
+			return diag.FromErr(flex.FmtErrorf("[ERROR] Error while attaching a routing table to a subnet %s\n%s", err, response))
 		}
 		log.Printf("[INFO] Updated subnet %s with VPC default Routing Table : %s", id, *resultRT.ID)
 	} else {

--- a/ibm/service/vpc/resource_ibm_is_virtual_endpoint_gateway.go
+++ b/ibm/service/vpc/resource_ibm_is_virtual_endpoint_gateway.go
@@ -349,7 +349,7 @@ func resourceIBMisVirtualEndpointGatewayCreate(d *schema.ResourceData, meta inte
 	endpointGateway, response, err := sess.CreateEndpointGateway(opt)
 	if err != nil {
 		log.Printf("Create Endpoint Gateway failed: %v", response)
-		return fmt.Errorf("[ERROR] Create Endpoint Gateway failed %s\n%s", err, response)
+		return flex.FmtErrorf("[ERROR] Create Endpoint Gateway failed %s\n%s", err, response)
 	}
 
 	d.SetId(*endpointGateway.ID)
@@ -400,7 +400,7 @@ func resourceIBMisVirtualEndpointGatewayUpdate(d *schema.ResourceData, meta inte
 	_, response, err := sess.UpdateEndpointGateway(opt)
 	if err != nil {
 		log.Printf("Update Endpoint Gateway failed: %v", response)
-		return fmt.Errorf("Update Endpoint Gateway failed : %s\n%s", err, response)
+		return flex.FmtErrorf("Update Endpoint Gateway failed : %s\n%s", err, response)
 	}
 	id := d.Id()
 	var remove, add []string
@@ -417,7 +417,7 @@ func resourceIBMisVirtualEndpointGatewayUpdate(d *schema.ResourceData, meta inte
 				createSecurityGroupTargetBindingOptions.ID = &id
 				_, response, err := sess.CreateSecurityGroupTargetBinding(createSecurityGroupTargetBindingOptions)
 				if err != nil {
-					return fmt.Errorf("Error while creating Security Group Target Binding %s\n%s", err, response)
+					return flex.FmtErrorf("Error while creating Security Group Target Binding %s\n%s", err, response)
 				}
 				_, err = isWaitForVirtualEndpointGatewayAvailable(sess, d.Id(), d.Timeout(schema.TimeoutUpdate))
 				if err != nil {
@@ -436,12 +436,12 @@ func resourceIBMisVirtualEndpointGatewayUpdate(d *schema.ResourceData, meta inte
 					if response != nil && response.StatusCode == 404 {
 						continue
 					}
-					return fmt.Errorf("Error Getting Security Group Target for this endpoint gateway (%s): %s\n%s", sgId, err, response)
+					return flex.FmtErrorf("Error Getting Security Group Target for this endpoint gateway (%s): %s\n%s", sgId, err, response)
 				}
 				deleteSecurityGroupTargetBindingOptions := sess.NewDeleteSecurityGroupTargetBindingOptions(sgId, id)
 				response, err = sess.DeleteSecurityGroupTargetBinding(deleteSecurityGroupTargetBindingOptions)
 				if err != nil {
-					return fmt.Errorf("Error Deleting Security Group Target for this endpoint gateway : %s\n%s", err, response)
+					return flex.FmtErrorf("Error Deleting Security Group Target for this endpoint gateway : %s\n%s", err, response)
 				}
 				_, err = isWaitForVirtualEndpointGatewayAvailable(sess, d.Id(), d.Timeout(schema.TimeoutUpdate))
 				if err != nil {
@@ -455,7 +455,7 @@ func resourceIBMisVirtualEndpointGatewayUpdate(d *schema.ResourceData, meta inte
 		opt := sess.NewGetEndpointGatewayOptions(d.Id())
 		endpointGateway, response, err := sess.GetEndpointGateway(opt)
 		if err != nil {
-			return fmt.Errorf("[ERROR] Error getting VPE: %s\n%s", err, response)
+			return flex.FmtErrorf("[ERROR] Error getting VPE: %s\n%s", err, response)
 		}
 		if d.HasChange(isVirtualEndpointGatewayTags) {
 			oldList, newList := d.GetChange(isVirtualEndpointGatewayTags)
@@ -492,7 +492,7 @@ func resourceIBMisVirtualEndpointGatewayRead(d *schema.ResourceData, meta interf
 			return nil
 		}
 		log.Printf("Get Endpoint Gateway failed: %v", response)
-		return fmt.Errorf("[ERROR] Get Endpoint Gateway failed %s\n%s", err, response)
+		return flex.FmtErrorf("[ERROR] Get Endpoint Gateway failed %s\n%s", err, response)
 	}
 	d.Set(isVirtualEndpointGatewayName, endpointGateway.Name)
 	d.Set(isVirtualEndpointGatewayHealthState, endpointGateway.HealthState)
@@ -562,7 +562,7 @@ func isVirtualEndpointGatewayRefreshFunc(sess *vpcv1.VpcV1, endPointGatewayId st
 		result, response, err := sess.GetEndpointGateway(opt)
 		if err != nil {
 			if response != nil && response.StatusCode == 404 {
-				return nil, "", fmt.Errorf("Error Getting Virtual Endpoint Gateway : %s\n%s", err, response)
+				return nil, "", flex.FmtErrorf("Error Getting Virtual Endpoint Gateway : %s\n%s", err, response)
 			}
 		}
 		if *result.LifecycleState == "stable" || *result.LifecycleState == "failed" {
@@ -582,7 +582,7 @@ func resourceIBMisVirtualEndpointGatewayDelete(d *schema.ResourceData, meta inte
 	response, err := sess.DeleteEndpointGateway(opt)
 	if err != nil {
 		log.Printf("Delete Endpoint Gateway failed: %v", response)
-		return fmt.Errorf("Delete Endpoint Gateway failed : %s\n%s", err, response)
+		return flex.FmtErrorf("Delete Endpoint Gateway failed : %s\n%s", err, response)
 	}
 	return nil
 }

--- a/ibm/service/vpc/resource_ibm_is_virtual_endpoint_gateway_ip.go
+++ b/ibm/service/vpc/resource_ibm_is_virtual_endpoint_gateway_ip.go
@@ -184,7 +184,7 @@ func resourceIBMisVirtualEndpointGatewayIPExists(d *schema.ResourceData, meta in
 		return false, err
 	}
 	if len(parts) != 2 {
-		return false, fmt.Errorf("[ERROR] Incorrect ID %s: ID should be a combination of gatewayID/ipID", d.Id())
+		return false, flex.FmtErrorf("[ERROR] Incorrect ID %s: ID should be a combination of gatewayID/ipID", d.Id())
 	}
 	gatewayID := parts[0]
 	ipID := parts[1]

--- a/ibm/service/vpc/resource_ibm_is_vpc_address_prefix.go
+++ b/ibm/service/vpc/resource_ibm_is_vpc_address_prefix.go
@@ -151,7 +151,7 @@ func vpcAddressPrefixCreate(d *schema.ResourceData, meta interface{}, name, zone
 	}
 	addrPrefix, response, err := sess.CreateVPCAddressPrefix(options)
 	if err != nil {
-		return fmt.Errorf("[ERROR] Error while creating VPC Address Prefix %s\n%s", err, response)
+		return flex.FmtErrorf("[ERROR] Error while creating VPC Address Prefix %s\n%s", err, response)
 	}
 
 	addrPrefixID := *addrPrefix.ID
@@ -191,7 +191,7 @@ func vpcAddressPrefixGet(d *schema.ResourceData, meta interface{}, vpcID, addrPr
 			d.SetId("")
 			return nil
 		}
-		return fmt.Errorf("[ERROR] Error Getting VPC Address Prefix (%s): %s\n%s", addrPrefixID, err, response)
+		return flex.FmtErrorf("[ERROR] Error Getting VPC Address Prefix (%s): %s\n%s", addrPrefixID, err, response)
 	}
 	d.Set(isVPCAddressPrefixVPCID, vpcID)
 	d.Set(isVPCAddressPrefixDefault, *addrPrefix.IsDefault)
@@ -207,7 +207,7 @@ func vpcAddressPrefixGet(d *schema.ResourceData, meta interface{}, vpcID, addrPr
 	}
 	vpc, response, err := sess.GetVPC(getVPCOptions)
 	if err != nil {
-		return fmt.Errorf("[ERROR] Error Getting VPC : %s\n%s", err, response)
+		return flex.FmtErrorf("[ERROR] Error Getting VPC : %s\n%s", err, response)
 	}
 	d.Set(flex.RelatedCRN, *vpc.CRN)
 
@@ -268,12 +268,12 @@ func vpcAddressPrefixUpdate(d *schema.ResourceData, meta interface{}, vpcID, add
 		}
 		addressPrefixPatch, err := addressPrefixPatchModel.AsPatch()
 		if err != nil {
-			return fmt.Errorf("[ERROR] Error calling asPatch for AddressPrefixPatch: %s", err)
+			return flex.FmtErrorf("[ERROR] Error calling asPatch for AddressPrefixPatch: %s", err)
 		}
 		updatevpcAddressPrefixoptions.AddressPrefixPatch = addressPrefixPatch
 		_, response, err := sess.UpdateVPCAddressPrefix(updatevpcAddressPrefixoptions)
 		if err != nil {
-			return fmt.Errorf("[ERROR] Error Updating VPC Address Prefix: %s\n%s", err, response)
+			return flex.FmtErrorf("[ERROR] Error Updating VPC Address Prefix: %s\n%s", err, response)
 		}
 	}
 	return nil
@@ -316,7 +316,7 @@ func vpcAddressPrefixDelete(d *schema.ResourceData, meta interface{}, vpcID, add
 		if response != nil && response.StatusCode == 404 {
 			return nil
 		}
-		return fmt.Errorf("[ERROR] Error Getting VPC Address Prefix (%s): %s\n%s", addrPrefixID, err, response)
+		return flex.FmtErrorf("[ERROR] Error Getting VPC Address Prefix (%s): %s\n%s", addrPrefixID, err, response)
 	}
 
 	deletevpcAddressPrefixOptions := &vpcv1.DeleteVPCAddressPrefixOptions{
@@ -328,7 +328,7 @@ func vpcAddressPrefixDelete(d *schema.ResourceData, meta interface{}, vpcID, add
 		if response != nil && response.StatusCode == 404 {
 			return nil
 		}
-		return fmt.Errorf("[ERROR] Error Deleting VPC Address Prefix (%s): %s\n%s", addrPrefixID, err, response)
+		return flex.FmtErrorf("[ERROR] Error Deleting VPC Address Prefix (%s): %s\n%s", addrPrefixID, err, response)
 	}
 	d.SetId("")
 	return nil
@@ -338,7 +338,7 @@ func resourceIBMISVpcAddressPrefixExists(d *schema.ResourceData, meta interface{
 
 	parts, err := flex.IdParts(d.Id())
 	if len(parts) != 2 {
-		return false, fmt.Errorf("[ERROR] Incorrect ID %s: ID should be a combination of vpcID/addrPrefixID", d.Id())
+		return false, flex.FmtErrorf("[ERROR] Incorrect ID %s: ID should be a combination of vpcID/addrPrefixID", d.Id())
 	}
 	if err != nil {
 		return false, err
@@ -364,7 +364,7 @@ func vpcAddressPrefixExists(d *schema.ResourceData, meta interface{}, vpcID, add
 		if response != nil && response.StatusCode == 404 {
 			return false, nil
 		}
-		return false, fmt.Errorf("[ERROR] Error getting VPC Address Prefix: %s\n%s", err, response)
+		return false, flex.FmtErrorf("[ERROR] Error getting VPC Address Prefix: %s\n%s", err, response)
 	}
 	return true, nil
 }

--- a/ibm/service/vpc/resource_ibm_is_vpc_dns_resolution_binding.go
+++ b/ibm/service/vpc/resource_ibm_is_vpc_dns_resolution_binding.go
@@ -265,7 +265,7 @@ func resourceIBMIsVPCDnsResolutionBindingCreate(context context.Context, d *sche
 	vpcdnsResolutionBinding, response, err := sess.CreateVPCDnsResolutionBindingWithContext(context, createVPCDnsResolutionBindingOptions)
 	if err != nil {
 		log.Printf("[DEBUG] CreateVPCDnsResolutionBindingWithContext failed %s\n%s", err, response)
-		return diag.FromErr(fmt.Errorf("CreateVPCDnsResolutionBindingWithContext failed %s\n%s", err, response))
+		return diag.FromErr(flex.FmtErrorf("CreateVPCDnsResolutionBindingWithContext failed %s\n%s", err, response))
 	}
 	d.SetId(MakeTerraformVPCDNSID(spokeVPCID, *vpcdnsResolutionBinding.ID))
 
@@ -293,7 +293,7 @@ func resourceIBMIsVPCDnsResolutionBindingRead(context context.Context, d *schema
 	if err != nil {
 		log.Printf("[DEBUG] GetVPCDnsResolutionBindingWithContext failed %s\n%s", err, response)
 		if response.StatusCode != 404 {
-			return diag.FromErr(fmt.Errorf("GetVPCDnsResolutionBindingWithContext failed %s\n%s", err, response))
+			return diag.FromErr(flex.FmtErrorf("GetVPCDnsResolutionBindingWithContext failed %s\n%s", err, response))
 		} else {
 			d.SetId("")
 			return nil
@@ -307,7 +307,7 @@ func resourceIBMIsVPCDnsResolutionBindingRead(context context.Context, d *schema
 }
 func resourceIBMIsVPCDnsResolutionBindingGet(vpcdnsResolutionBinding *vpcv1.VpcdnsResolutionBinding, d *schema.ResourceData) error {
 	if err := d.Set("created_at", flex.DateTimeToString(vpcdnsResolutionBinding.CreatedAt)); err != nil {
-		return fmt.Errorf("[ERROR] Error setting created_at: %s", err)
+		return flex.FmtErrorf("[ERROR] Error setting created_at: %s", err)
 	}
 
 	endpointGateways := []map[string]interface{}{}
@@ -321,23 +321,23 @@ func resourceIBMIsVPCDnsResolutionBindingGet(vpcdnsResolutionBinding *vpcv1.Vpcd
 		}
 	}
 	if err := d.Set("endpoint_gateways", endpointGateways); err != nil {
-		return fmt.Errorf("[ERROR] Error setting endpoint_gateways %s", err)
+		return flex.FmtErrorf("[ERROR] Error setting endpoint_gateways %s", err)
 	}
 
 	if err := d.Set("href", vpcdnsResolutionBinding.Href); err != nil {
-		return fmt.Errorf("[ERROR] Error setting href: %s", err)
+		return flex.FmtErrorf("[ERROR] Error setting href: %s", err)
 	}
 
 	if err := d.Set("lifecycle_state", vpcdnsResolutionBinding.LifecycleState); err != nil {
-		return fmt.Errorf("[ERROR] Error setting lifecycle_state: %s", err)
+		return flex.FmtErrorf("[ERROR] Error setting lifecycle_state: %s", err)
 	}
 
 	if err := d.Set("name", vpcdnsResolutionBinding.Name); err != nil {
-		return fmt.Errorf("[ERROR] Error setting name: %s", err)
+		return flex.FmtErrorf("[ERROR] Error setting name: %s", err)
 	}
 
 	if err := d.Set("resource_type", vpcdnsResolutionBinding.ResourceType); err != nil {
-		return fmt.Errorf("[ERROR] Error setting resource_type: %s", err)
+		return flex.FmtErrorf("[ERROR] Error setting resource_type: %s", err)
 	}
 
 	vpc := []map[string]interface{}{}
@@ -349,7 +349,7 @@ func resourceIBMIsVPCDnsResolutionBindingGet(vpcdnsResolutionBinding *vpcv1.Vpcd
 		vpc = append(vpc, modelMap)
 	}
 	if err := d.Set("vpc", vpc); err != nil {
-		return fmt.Errorf("[ERROR] Error setting vpc %s", err)
+		return flex.FmtErrorf("[ERROR] Error setting vpc %s", err)
 	}
 	return nil
 }
@@ -380,7 +380,7 @@ func resourceIBMIsVPCDnsResolutionBindingUpdate(context context.Context, d *sche
 		vpcdnsResolutionBinding, response, err := sess.UpdateVPCDnsResolutionBindingWithContext(context, updateVPCDnsResolutionBindingOptions)
 		if err != nil {
 			log.Printf("[DEBUG] UpdateVPCDnsResolutionBindingWithContext failed %s\n%s", err, response)
-			return diag.FromErr(fmt.Errorf("UpdateVPCDnsResolutionBindingWithContext failed %s\n%s", err, response))
+			return diag.FromErr(flex.FmtErrorf("UpdateVPCDnsResolutionBindingWithContext failed %s\n%s", err, response))
 		}
 		err = resourceIBMIsVPCDnsResolutionBindingGet(vpcdnsResolutionBinding, d)
 		if err != nil {
@@ -408,7 +408,7 @@ func resourceIBMIsVPCDnsResolutionBindingDelete(context context.Context, d *sche
 	if err != nil {
 		log.Printf("[DEBUG] DeleteVPCDnsResolutionBindingWithContext failed %s\n%s", err, response)
 		if response.StatusCode != 404 {
-			return diag.FromErr(fmt.Errorf("DeleteVPCDnsResolutionBindingWithContext failed %s\n%s", err, response))
+			return diag.FromErr(flex.FmtErrorf("DeleteVPCDnsResolutionBindingWithContext failed %s\n%s", err, response))
 		}
 	}
 	d.SetId("")
@@ -423,10 +423,10 @@ func MakeTerraformVPCDNSID(id1, id2 string) string {
 func ParseVPCDNSTerraformID(s string) (string, string, error) {
 	segments := strings.Split(s, "/")
 	if len(segments) != 2 {
-		return "", "", fmt.Errorf("invalid terraform Id %s (incorrect number of segments)", s)
+		return "", "", flex.FmtErrorf("invalid terraform Id %s (incorrect number of segments)", s)
 	}
 	if segments[0] == "" || segments[1] == "" {
-		return "", "", fmt.Errorf("invalid terraform Id %s (one or more empty segments)", s)
+		return "", "", flex.FmtErrorf("invalid terraform Id %s (one or more empty segments)", s)
 	}
 	return segments[0], segments[1], nil
 }

--- a/ibm/service/vpc/resource_ibm_is_vpc_routing_table.go
+++ b/ibm/service/vpc/resource_ibm_is_vpc_routing_table.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/flex"
 	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/validate"
 	"github.com/IBM/go-sdk-core/v5/core"
 	"github.com/IBM/vpc-go-sdk/vpcv1"
@@ -264,7 +265,7 @@ func resourceIBMISVPCRoutingTableRead(d *schema.ResourceData, meta interface{}) 
 			d.SetId("")
 			return nil
 		}
-		return fmt.Errorf("[ERROR] Error Getting VPC Routing table: %s\n%s", err, response)
+		return flex.FmtErrorf("[ERROR] Error Getting VPC Routing table: %s\n%s", err, response)
 	}
 
 	d.Set(rtVpcID, idSet[0])
@@ -285,7 +286,7 @@ func resourceIBMISVPCRoutingTableRead(d *schema.ResourceData, meta interface{}) 
 		acceptRoutesFromArray = append(acceptRoutesFromArray, string(*(routeTable.AcceptRoutesFrom[i].ResourceType)))
 	}
 	if err = d.Set("accept_routes_from_resource_type", acceptRoutesFromArray); err != nil {
-		return fmt.Errorf("[ERROR] Error setting accept_routes_from_resource_type: %s", err)
+		return flex.FmtErrorf("[ERROR] Error setting accept_routes_from_resource_type: %s", err)
 	}
 
 	for i := 0; i < len(routeTable.AdvertiseRoutesTo); i++ {
@@ -293,7 +294,7 @@ func resourceIBMISVPCRoutingTableRead(d *schema.ResourceData, meta interface{}) 
 	}
 
 	if err = d.Set("advertise_routes_to", advertiseRoutesToArray); err != nil {
-		return fmt.Errorf("[ERROR] Error setting advertise_routes_to: %s", err)
+		return flex.FmtErrorf("[ERROR] Error setting advertise_routes_to: %s", err)
 	}
 
 	subnets := make([]map[string]interface{}, 0)
@@ -393,7 +394,7 @@ func resourceIBMISVPCRoutingTableUpdate(d *schema.ResourceData, meta interface{}
 
 	routingTablePatchModelAsPatch, asPatchErr := routingTablePatchModel.AsPatch()
 	if asPatchErr != nil {
-		return fmt.Errorf("[ERROR] Error calling asPatch for RoutingTablePatchModel: %s", asPatchErr)
+		return flex.FmtErrorf("[ERROR] Error calling asPatch for RoutingTablePatchModel: %s", asPatchErr)
 	}
 
 	if removeAdvertiseRoutesTo {
@@ -438,7 +439,7 @@ func resourceIBMISVPCRoutingTableExists(d *schema.ResourceData, meta interface{}
 
 	idSet := strings.Split(d.Id(), "/")
 	if len(idSet) != 2 {
-		return false, fmt.Errorf("[ERROR] Incorrect ID %s: ID should be a combination of vpcID/routingTableID", d.Id())
+		return false, flex.FmtErrorf("[ERROR] Incorrect ID %s: ID should be a combination of vpcID/routingTableID", d.Id())
 	}
 	getVpcRoutingTableOptions := sess.NewGetVPCRoutingTableOptions(idSet[0], idSet[1])
 	_, response, err := sess.GetVPCRoutingTable(getVpcRoutingTableOptions)
@@ -447,7 +448,7 @@ func resourceIBMISVPCRoutingTableExists(d *schema.ResourceData, meta interface{}
 			d.SetId("")
 			return false, nil
 		}
-		return false, fmt.Errorf("[ERROR] Error Getting VPC Routing table : %s\n%s", err, response)
+		return false, flex.FmtErrorf("[ERROR] Error Getting VPC Routing table : %s\n%s", err, response)
 	}
 	return true, nil
 }

--- a/ibm/service/vpc/resource_ibm_is_vpc_routing_table_route.go
+++ b/ibm/service/vpc/resource_ibm_is_vpc_routing_table_route.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/flex"
 	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/validate"
 	"github.com/IBM/go-sdk-core/v5/core"
 	"github.com/IBM/vpc-go-sdk/vpcv1"
@@ -289,7 +290,7 @@ func resourceIBMISVPCRoutingTableRouteRead(d *schema.ResourceData, meta interfac
 			d.SetId("")
 			return nil
 		}
-		return fmt.Errorf("[ERROR] Error Getting VPC Routing table route: %s\n%s", err, response)
+		return flex.FmtErrorf("[ERROR] Error Getting VPC Routing table route: %s\n%s", err, response)
 	}
 
 	d.Set(rID, *route.ID)
@@ -308,7 +309,7 @@ func resourceIBMISVPCRoutingTableRouteRead(d *schema.ResourceData, meta interfac
 		}
 	}
 	if err = d.Set("origin", route.Origin); err != nil {
-		return fmt.Errorf("[ERROR] Error setting origin %s", err)
+		return flex.FmtErrorf("[ERROR] Error setting origin %s", err)
 	}
 	if route.Zone != nil {
 		d.Set(rZone, *route.Zone.Name)
@@ -380,7 +381,7 @@ func resourceIBMISVPCRoutingTableRouteUpdate(d *schema.ResourceData, meta interf
 	if hasChange {
 		routePatchModelAsPatch, patchErr := routePatchModel.AsPatch()
 		if patchErr != nil {
-			return fmt.Errorf("[ERROR] Error calling asPatch for VPC Routing Table Route Patch: %s", patchErr)
+			return flex.FmtErrorf("[ERROR] Error calling asPatch for VPC Routing Table Route Patch: %s", patchErr)
 		}
 		updateVpcRoutingTableRouteOptions.RoutePatch = routePatchModelAsPatch
 		_, response, err := sess.UpdateVPCRoutingTableRoute(updateVpcRoutingTableRouteOptions)
@@ -418,7 +419,7 @@ func resourceIBMISVPCRoutingTableRouteExists(d *schema.ResourceData, meta interf
 
 	idSet := strings.Split(d.Id(), "/")
 	if len(idSet) != 3 {
-		return false, fmt.Errorf("[ERROR] Incorrect ID %s: ID should be a combination of vpcID/routingTableID/routeID", d.Id())
+		return false, flex.FmtErrorf("[ERROR] Incorrect ID %s: ID should be a combination of vpcID/routingTableID/routeID", d.Id())
 	}
 	getVpcRoutingTableRouteOptions := sess.NewGetVPCRoutingTableRouteOptions(idSet[0], idSet[1], idSet[2])
 	_, response, err := sess.GetVPCRoutingTableRoute(getVpcRoutingTableRouteOptions)
@@ -427,7 +428,7 @@ func resourceIBMISVPCRoutingTableRouteExists(d *schema.ResourceData, meta interf
 			d.SetId("")
 			return false, nil
 		}
-		return false, fmt.Errorf("[ERROR] Error Getting VPC Routing table route : %s\n%s", err, response)
+		return false, flex.FmtErrorf("[ERROR] Error Getting VPC Routing table route : %s\n%s", err, response)
 	}
 	return true, nil
 }

--- a/ibm/service/vpc/resource_ibm_is_vpn_gateway.go
+++ b/ibm/service/vpc/resource_ibm_is_vpn_gateway.go
@@ -5,7 +5,6 @@ package vpc
 
 import (
 	"context"
-	"fmt"
 	"log"
 	"os"
 	"time"
@@ -416,7 +415,7 @@ func vpngwCreate(d *schema.ResourceData, meta interface{}, name, subnetID, mode 
 
 	vpnGatewayIntf, response, err := sess.CreateVPNGateway(options)
 	if err != nil {
-		return fmt.Errorf("[DEBUG] Create vpc VPN Gateway %s\n%s", err, response)
+		return flex.FmtErrorf("[DEBUG] Create vpc VPN Gateway %s\n%s", err, response)
 	}
 	vpnGateway := vpnGatewayIntf.(*vpcv1.VPNGateway)
 
@@ -472,7 +471,7 @@ func isVpnGatewayRefreshFunc(vpnGateway *vpcv1.VpcV1, id string) resource.StateR
 		}
 		vpnGatewayIntf, response, err := vpnGateway.GetVPNGateway(getVpnGatewayOptions)
 		if err != nil {
-			return nil, "", fmt.Errorf("[ERROR] Error Getting Vpn Gateway: %s\n%s", err, response)
+			return nil, "", flex.FmtErrorf("[ERROR] Error Getting Vpn Gateway: %s\n%s", err, response)
 		}
 		vpnGateway := vpnGatewayIntf.(*vpcv1.VPNGateway)
 
@@ -508,23 +507,23 @@ func vpngwGet(d *schema.ResourceData, meta interface{}, id string) error {
 			d.SetId("")
 			return nil
 		}
-		return fmt.Errorf("[ERROR] Error Getting Vpn Gateway (%s): %s\n%s", id, err, response)
+		return flex.FmtErrorf("[ERROR] Error Getting Vpn Gateway (%s): %s\n%s", id, err, response)
 	}
 	vpnGateway := vpnGatewayIntf.(*vpcv1.VPNGateway)
 
 	d.Set(isVPNGatewayName, *vpnGateway.Name)
 	d.Set(isVPNGatewaySubnet, *vpnGateway.Subnet.ID)
 	if err = d.Set(isVPNGatewayHealthState, vpnGateway.HealthState); err != nil {
-		return fmt.Errorf("[ERROR] Error setting health_state: %s", err)
+		return flex.FmtErrorf("[ERROR] Error setting health_state: %s", err)
 	}
 	if err := d.Set(isVPNGatewayHealthReasons, resourceVPNGatewayRouteFlattenHealthReasons(vpnGateway.HealthReasons)); err != nil {
-		return fmt.Errorf("[ERROR] Error setting health_reasons: %s", err)
+		return flex.FmtErrorf("[ERROR] Error setting health_reasons: %s", err)
 	}
 	if err = d.Set(isVPNGatewayLifecycleState, vpnGateway.LifecycleState); err != nil {
-		return fmt.Errorf("[ERROR] Error setting lifecycle_state: %s", err)
+		return flex.FmtErrorf("[ERROR] Error setting lifecycle_state: %s", err)
 	}
 	if err := d.Set(isVPNGatewayLifecycleReasons, resourceVPNGatewayFlattenLifecycleReasons(vpnGateway.LifecycleReasons)); err != nil {
-		return fmt.Errorf("[ERROR] Error setting lifecycle_reasons: %s", err)
+		return flex.FmtErrorf("[ERROR] Error setting lifecycle_reasons: %s", err)
 	}
 	members := []vpcv1.VPNGatewayMember{}
 	for _, member := range vpnGateway.Members {
@@ -593,7 +592,7 @@ func vpngwGet(d *schema.ResourceData, meta interface{}, id string) error {
 		vpcList = append(vpcList, dataSourceVPNServerCollectionVPNGatewayVpcReferenceToMap(vpnGateway.VPC))
 		err = d.Set("vpc", vpcList)
 		if err != nil {
-			return fmt.Errorf("Error setting the vpc: %s", err)
+			return flex.FmtErrorf("Error setting the vpc: %s", err)
 		}
 	}
 	return nil
@@ -627,7 +626,7 @@ func vpngwUpdate(d *schema.ResourceData, meta interface{}, id, name string, hasC
 		}
 		vpnGatewayIntf, response, err := sess.GetVPNGateway(getVpnGatewayOptions)
 		if err != nil {
-			return fmt.Errorf("[ERROR] Error getting Volume : %s\n%s", err, response)
+			return flex.FmtErrorf("[ERROR] Error getting Volume : %s\n%s", err, response)
 		}
 		vpnGateway := vpnGatewayIntf.(*vpcv1.VPNGateway)
 
@@ -644,7 +643,7 @@ func vpngwUpdate(d *schema.ResourceData, meta interface{}, id, name string, hasC
 		}
 		vpnGatewayIntf, response, err := sess.GetVPNGateway(getVpnGatewayOptions)
 		if err != nil {
-			return fmt.Errorf("[ERROR] Error getting Volume : %s\n%s", err, response)
+			return flex.FmtErrorf("[ERROR] Error getting Volume : %s\n%s", err, response)
 		}
 		vpnGateway := vpnGatewayIntf.(*vpcv1.VPNGateway)
 
@@ -664,12 +663,12 @@ func vpngwUpdate(d *schema.ResourceData, meta interface{}, id, name string, hasC
 		}
 		vpnGatewayPatch, err := vpnGatewayPatchModel.AsPatch()
 		if err != nil {
-			return fmt.Errorf("[ERROR] Error calling asPatch for VPNGatewayPatch: %s", err)
+			return flex.FmtErrorf("[ERROR] Error calling asPatch for VPNGatewayPatch: %s", err)
 		}
 		options.VPNGatewayPatch = vpnGatewayPatch
 		_, response, err := sess.UpdateVPNGateway(options)
 		if err != nil {
-			return fmt.Errorf("[ERROR] Error updating vpc Vpn Gateway: %s\n%s", err, response)
+			return flex.FmtErrorf("[ERROR] Error updating vpc Vpn Gateway: %s\n%s", err, response)
 		}
 	}
 	return nil
@@ -700,7 +699,7 @@ func vpngwDelete(d *schema.ResourceData, meta interface{}, id string) error {
 		if response != nil && response.StatusCode == 404 {
 			return nil
 		}
-		return fmt.Errorf("[ERROR] Error Getting Vpn Gateway (%s): %s\n%s", id, err, response)
+		return flex.FmtErrorf("[ERROR] Error Getting Vpn Gateway (%s): %s\n%s", id, err, response)
 	}
 
 	options := &vpcv1.DeleteVPNGatewayOptions{
@@ -708,7 +707,7 @@ func vpngwDelete(d *schema.ResourceData, meta interface{}, id string) error {
 	}
 	response, err = sess.DeleteVPNGateway(options)
 	if err != nil {
-		return fmt.Errorf("[ERROR] Error Deleting Vpn Gateway : %s\n%s", err, response)
+		return flex.FmtErrorf("[ERROR] Error Deleting Vpn Gateway : %s\n%s", err, response)
 	}
 	_, err = isWaitForVpnGatewayDeleted(sess, id, d.Timeout(schema.TimeoutDelete))
 	if err != nil {
@@ -743,7 +742,7 @@ func isVpnGatewayDeleteRefreshFunc(vpnGateway *vpcv1.VpcV1, id string) resource.
 			if response != nil && response.StatusCode == 404 {
 				return "", isVPNGatewayDeleted, nil
 			}
-			return "", "", fmt.Errorf("[ERROR] Error Getting Vpn Gateway: %s\n%s", err, response)
+			return "", "", flex.FmtErrorf("[ERROR] Error Getting Vpn Gateway: %s\n%s", err, response)
 		}
 		return vpngw, isVPNGatewayDeleting, err
 	}
@@ -769,7 +768,7 @@ func vpngwExists(d *schema.ResourceData, meta interface{}, id string) (bool, err
 		if response != nil && response.StatusCode == 404 {
 			return false, nil
 		}
-		return false, fmt.Errorf("[ERROR] Error getting Vpn Gatewa: %s\n%s", err, response)
+		return false, flex.FmtErrorf("[ERROR] Error getting Vpn Gatewa: %s\n%s", err, response)
 	}
 	return true, nil
 }

--- a/ibm/service/vpc/resource_ibm_is_vpn_gateway_connections.go
+++ b/ibm/service/vpc/resource_ibm_is_vpn_gateway_connections.go
@@ -361,7 +361,7 @@ func vpngwconCreate(d *schema.ResourceData, meta interface{}, name, gatewayID, p
 
 	vpnGatewayConnectionIntf, response, err := sess.CreateVPNGatewayConnection(options)
 	if err != nil {
-		return fmt.Errorf("[DEBUG] Create VPN Gateway Connection err %s\n%s", err, response)
+		return flex.FmtErrorf("[DEBUG] Create VPN Gateway Connection err %s\n%s", err, response)
 	}
 	vpnGatewayConnection := vpnGatewayConnectionIntf.(*vpcv1.VPNGatewayConnection)
 	d.SetId(fmt.Sprintf("%s/%s", gatewayID, *vpnGatewayConnection.ID))
@@ -401,7 +401,7 @@ func vpngwconGet(d *schema.ResourceData, meta interface{}, gID, gConnID string) 
 			d.SetId("")
 			return nil
 		}
-		return fmt.Errorf("[ERROR] Error Getting Vpn Gateway Connection (%s): %s\n%s", gConnID, err, response)
+		return flex.FmtErrorf("[ERROR] Error Getting Vpn Gateway Connection (%s): %s\n%s", gConnID, err, response)
 	}
 	d.Set(isVPNGatewayConnection, gConnID)
 	vpnGatewayConnection := vpnGatewayConnectionIntf.(*vpcv1.VPNGatewayConnection)
@@ -430,7 +430,7 @@ func vpngwconGet(d *schema.ResourceData, meta interface{}, gID, gConnID string) 
 		d.Set(isVPNGatewayConnectionStatus, *vpnGatewayConnection.Status)
 	}
 	if err := d.Set(isVPNGatewayConnectionStatusreasons, resourceVPNGatewayConnectionFlattenLifecycleReasons(vpnGatewayConnection.StatusReasons)); err != nil {
-		return fmt.Errorf("[ERROR] Error setting status_reasons: %s", err)
+		return flex.FmtErrorf("[ERROR] Error setting status_reasons: %s", err)
 	}
 	if vpnGatewayConnection.ResourceType != nil {
 		d.Set(isVPNGatewayConnectionResourcetype, *vpnGatewayConnection.ResourceType)
@@ -466,7 +466,7 @@ func vpngwconGet(d *schema.ResourceData, meta interface{}, gID, gConnID string) 
 	}
 	vpngatewayIntf, response, err := sess.GetVPNGateway(getVPNGatewayOptions)
 	if err != nil {
-		return fmt.Errorf("[ERROR] Error Getting VPN Gateway : %s\n%s", err, response)
+		return flex.FmtErrorf("[ERROR] Error Getting VPN Gateway : %s\n%s", err, response)
 	}
 	vpngateway := vpngatewayIntf.(*vpcv1.VPNGateway)
 	d.Set(flex.RelatedCRN, *vpngateway.CRN)
@@ -572,12 +572,12 @@ func vpngwconUpdate(d *schema.ResourceData, meta interface{}, gID, gConnID strin
 	if hasChanged {
 		vpnGatewayConnectionPatch, err := vpnGatewayConnectionPatchModel.AsPatch()
 		if err != nil {
-			return fmt.Errorf("[ERROR] Error calling asPatch for VPNGatewayConnectionPatch: %s", err)
+			return flex.FmtErrorf("[ERROR] Error calling asPatch for VPNGatewayConnectionPatch: %s", err)
 		}
 		updateVpnGatewayConnectionOptions.VPNGatewayConnectionPatch = vpnGatewayConnectionPatch
 		_, response, err := sess.UpdateVPNGatewayConnection(updateVpnGatewayConnectionOptions)
 		if err != nil {
-			return fmt.Errorf("[ERROR] Error updating Vpn Gateway Connection: %s\n%s", err, response)
+			return flex.FmtErrorf("[ERROR] Error updating Vpn Gateway Connection: %s\n%s", err, response)
 		}
 	}
 	return nil
@@ -616,7 +616,7 @@ func vpngwconDelete(d *schema.ResourceData, meta interface{}, gID, gConnID strin
 			d.SetId("")
 			return nil
 		}
-		return fmt.Errorf("[ERROR] Error Getting Vpn Gateway Connection(%s): %s\n%s", gConnID, err, response)
+		return flex.FmtErrorf("[ERROR] Error Getting Vpn Gateway Connection(%s): %s\n%s", gConnID, err, response)
 	}
 
 	deleteVpnGatewayConnectionOptions := &vpcv1.DeleteVPNGatewayConnectionOptions{
@@ -625,12 +625,12 @@ func vpngwconDelete(d *schema.ResourceData, meta interface{}, gID, gConnID strin
 	}
 	response, err = sess.DeleteVPNGatewayConnection(deleteVpnGatewayConnectionOptions)
 	if err != nil {
-		return fmt.Errorf("[ERROR] Error Deleting Vpn Gateway Connection : %s\n%s", err, response)
+		return flex.FmtErrorf("[ERROR] Error Deleting Vpn Gateway Connection : %s\n%s", err, response)
 	}
 
 	_, err = isWaitForVPNGatewayConnectionDeleted(sess, gID, gConnID, d.Timeout(schema.TimeoutDelete))
 	if err != nil {
-		return fmt.Errorf("[ERROR] Error checking for Vpn Gateway Connection (%s) is deleted: %s", gConnID, err)
+		return flex.FmtErrorf("[ERROR] Error checking for Vpn Gateway Connection (%s) is deleted: %s", gConnID, err)
 	}
 
 	d.SetId("")
@@ -663,7 +663,7 @@ func isVPNGatewayConnectionDeleteRefreshFunc(vpnGatewayConnection *vpcv1.VpcV1, 
 			if response != nil && response.StatusCode == 404 {
 				return "", isVPNGatewayConnectionDeleted, nil
 			}
-			return "", "", fmt.Errorf("[ERROR] The Vpn Gateway Connection %s failed to delete: %s\n%s", gConnID, err, response)
+			return "", "", flex.FmtErrorf("[ERROR] The Vpn Gateway Connection %s failed to delete: %s\n%s", gConnID, err, response)
 		}
 		return vpngwcon, isVPNGatewayConnectionDeleting, nil
 	}
@@ -676,7 +676,7 @@ func resourceIBMISVPNGatewayConnectionExists(d *schema.ResourceData, meta interf
 		return false, err
 	}
 	if len(parts) != 2 {
-		return false, fmt.Errorf("[ERROR] Incorrect ID %s: ID should be a combination of gID/gConnID", d.Id())
+		return false, flex.FmtErrorf("[ERROR] Incorrect ID %s: ID should be a combination of gID/gConnID", d.Id())
 	}
 
 	gID := parts[0]
@@ -700,7 +700,7 @@ func vpngwconExists(d *schema.ResourceData, meta interface{}, gID, gConnID strin
 		if response != nil && response.StatusCode == 404 {
 			return false, nil
 		}
-		return false, fmt.Errorf("[ERROR] Error getting Vpn Gateway Connection: %s\n%s", err, response)
+		return false, flex.FmtErrorf("[ERROR] Error getting Vpn Gateway Connection: %s\n%s", err, response)
 	}
 	return true, nil
 }

--- a/ibm/service/vpc/resource_ibm_is_vpn_server_client.go
+++ b/ibm/service/vpc/resource_ibm_is_vpn_server_client.go
@@ -74,7 +74,7 @@ func resourceIBMIsVPNServerClientDisconnect(context context.Context, d *schema.R
 			return nil
 		}
 		log.Printf("[DEBUG] GetVPNServerClientWithContext failed %s\n%s", err, response)
-		return diag.FromErr(fmt.Errorf("[ERROR] GetVPNServerClientWithContext failed %s\n%s", err, response))
+		return diag.FromErr(flex.FmtErrorf("[ERROR] GetVPNServerClientWithContext failed %s\n%s", err, response))
 	}
 
 	var flag bool
@@ -91,15 +91,15 @@ func resourceIBMIsVPNServerClientDisconnect(context context.Context, d *schema.R
 		response, err := sess.DisconnectVPNClientWithContext(context, disconnectVPNServerRouteOptions)
 		if err != nil {
 			log.Printf("[DEBUG] DisconnectVPNClientWithContext failed %s\n%s", err, response)
-			return diag.FromErr(fmt.Errorf("[ERROR] DisconnectVPNClientWithContext failed %s\n%s", err, response))
+			return diag.FromErr(flex.FmtErrorf("[ERROR] DisconnectVPNClientWithContext failed %s\n%s", err, response))
 		}
 
 		if err = d.Set("status_code", response.StatusCode); err != nil {
-			return diag.FromErr(fmt.Errorf("[ERROR] Error setting status_code: %s", err))
+			return diag.FromErr(flex.FmtErrorf("[ERROR] Error setting status_code: %s", err))
 		}
 
 		if err = d.Set("description", "The VPN client disconnection request was accepted."); err != nil {
-			return diag.FromErr(fmt.Errorf("[ERROR] Error setting description: %s", err))
+			return diag.FromErr(flex.FmtErrorf("[ERROR] Error setting description: %s", err))
 		}
 
 		d.SetId(fmt.Sprintf("%s/%s/%v", d.Get("vpn_server").(string), d.Get("vpn_client").(string), response.StatusCode))
@@ -113,22 +113,22 @@ func resourceIBMIsVPNServerClientDisconnect(context context.Context, d *schema.R
 		response, err := sess.DeleteVPNServerClientWithContext(context, deleteVPNServerClientOptions)
 		if err != nil {
 			log.Printf("[DEBUG] DeleteVPNServerClientWithContext failed %s\n%s", err, response)
-			return diag.FromErr(fmt.Errorf("[ERROR] DeleteVPNServerClientWithContext failed %s\n%s", err, response))
+			return diag.FromErr(flex.FmtErrorf("[ERROR] DeleteVPNServerClientWithContext failed %s\n%s", err, response))
 		}
 
 		if err = d.Set("status_code", response.StatusCode); err != nil {
-			return diag.FromErr(fmt.Errorf("[ERROR] Error setting status_code: %s", err))
+			return diag.FromErr(flex.FmtErrorf("[ERROR] Error setting status_code: %s", err))
 		}
 
 		if err = d.Set("description", "The VPN client disconnection request was accepted."); err != nil {
-			return diag.FromErr(fmt.Errorf("[ERROR] Error setting status_code: %s", err))
+			return diag.FromErr(flex.FmtErrorf("[ERROR] Error setting status_code: %s", err))
 		}
 
 		d.SetId(fmt.Sprintf("%s/%s", d.Get("vpn_server").(string), d.Get("vpn_client").(string)))
 	}
 
 	if err = d.Set("delete", d.Get("delete")); err != nil {
-		return diag.FromErr(fmt.Errorf("[ERROR] Error setting delete: %s", err))
+		return diag.FromErr(flex.FmtErrorf("[ERROR] Error setting delete: %s", err))
 	}
 	return nil
 }
@@ -141,10 +141,10 @@ func resourceIBMIsVPNServerClientDelete(context context.Context, d *schema.Resou
 
 	parts, err := flex.IdParts(d.Id())
 	if err != nil {
-		return diag.FromErr(fmt.Errorf("[ERROR]  Failed %s\n%s", "false", err))
+		return diag.FromErr(flex.FmtErrorf("[ERROR]  Failed %s\n%s", "false", err))
 	}
 	if len(parts) != 2 {
-		return diag.FromErr(fmt.Errorf("[ERROR] Incorrect ID %s: ID should be a combination of vpnServer/vpnClient", d.Id()))
+		return diag.FromErr(flex.FmtErrorf("[ERROR] Incorrect ID %s: ID should be a combination of vpnServer/vpnClient", d.Id()))
 	}
 	vpnServer := parts[0]
 	vpnClient := parts[1]
@@ -161,7 +161,7 @@ func resourceIBMIsVPNServerClientDelete(context context.Context, d *schema.Resou
 			return nil
 		}
 		log.Printf("[DEBUG] GetVPNServerClientWithContext failed %s\n%s", err, response)
-		return diag.FromErr(fmt.Errorf("[ERROR] GetVPNServerClientWithContext failed %s\n%s", err, response))
+		return diag.FromErr(flex.FmtErrorf("[ERROR] GetVPNServerClientWithContext failed %s\n%s", err, response))
 	}
 
 	deleteVPNServerClientOptions := &vpcv1.DeleteVPNServerClientOptions{}
@@ -171,7 +171,7 @@ func resourceIBMIsVPNServerClientDelete(context context.Context, d *schema.Resou
 	response, err = sess.DeleteVPNServerClientWithContext(context, deleteVPNServerClientOptions)
 	if err != nil {
 		log.Printf("[DEBUG] DeleteVPNServerClientWithContext failed %s\n%s", err, response)
-		return diag.FromErr(fmt.Errorf("[ERROR] DeleteVPNServerClientWithContext failed %s\n%s", err, response))
+		return diag.FromErr(flex.FmtErrorf("[ERROR] DeleteVPNServerClientWithContext failed %s\n%s", err, response))
 	}
 
 	d.SetId("")

--- a/ibm/service/vpc/resource_ibm_is_vpn_server_route.go
+++ b/ibm/service/vpc/resource_ibm_is_vpn_server_route.go
@@ -209,14 +209,14 @@ func resourceIBMIsVPNServerRouteCreate(context context.Context, d *schema.Resour
 	vpnServerRoute, response, err := sess.CreateVPNServerRouteWithContext(context, createVPNServerRouteOptions)
 	if err != nil {
 		log.Printf("[DEBUG] CreateVPNServerRouteWithContext failed %s\n%s", err, response)
-		return diag.FromErr(fmt.Errorf("[ERROR] CreateVPNServerRouteWithContext failed %s\n%s", err, response))
+		return diag.FromErr(flex.FmtErrorf("[ERROR] CreateVPNServerRouteWithContext failed %s\n%s", err, response))
 	}
 
 	d.SetId(fmt.Sprintf("%s/%s", *createVPNServerRouteOptions.VPNServerID, *vpnServerRoute.ID))
 
 	_, err = isWaitForVPNServerRouteStable(context, sess, d, d.Timeout(schema.TimeoutCreate))
 	if err != nil {
-		return diag.FromErr(fmt.Errorf("[ERROR] VPNServer Route failed %s\n", err))
+		return diag.FromErr(flex.FmtErrorf("[ERROR] VPNServer Route failed %s\n", err))
 	}
 	return resourceIBMIsVPNServerRouteRead(context, d, meta)
 }
@@ -233,7 +233,7 @@ func isWaitForVPNServerRouteStable(context context.Context, sess *vpcv1.VpcV1, d
 			parts, err := flex.SepIdParts(d.Id(), "/")
 			if err != nil {
 				log.Printf("[DEBUG] Getting ID failed %s", err)
-				return nil, "", fmt.Errorf("Error Getting VPC Server: %s", err)
+				return nil, "", flex.FmtErrorf("Error Getting VPC Server: %s", err)
 			}
 
 			getVPNServerRouteOptions.SetVPNServerID(parts[0])
@@ -242,7 +242,7 @@ func isWaitForVPNServerRouteStable(context context.Context, sess *vpcv1.VpcV1, d
 			vpnServerRoute, response, err := sess.GetVPNServerRouteWithContext(context, getVPNServerRouteOptions)
 			if err != nil {
 				log.Printf("[DEBUG] GetVPNServerRouteWithContext failed %s\n%s", err, response)
-				return vpnServerRoute, "", fmt.Errorf("Error Getting VPC Server Route: %s\n%s", err, response)
+				return vpnServerRoute, "", flex.FmtErrorf("Error Getting VPC Server Route: %s\n%s", err, response)
 			}
 
 			if *vpnServerRoute.LifecycleState == "stable" || *vpnServerRoute.LifecycleState == "failed" {
@@ -280,49 +280,49 @@ func resourceIBMIsVPNServerRouteRead(context context.Context, d *schema.Resource
 			return nil
 		}
 		log.Printf("[DEBUG] GetVPNServerRouteWithContext failed %s\n%s", err, response)
-		return diag.FromErr(fmt.Errorf("[ERROR] GetVPNServerRouteWithContext failed %s\n%s", err, response))
+		return diag.FromErr(flex.FmtErrorf("[ERROR] GetVPNServerRouteWithContext failed %s\n%s", err, response))
 	}
 
 	if err = d.Set("vpn_server", getVPNServerRouteOptions.VPNServerID); err != nil {
-		return diag.FromErr(fmt.Errorf("[ERROR] Error setting vpn_server: %s", err))
+		return diag.FromErr(flex.FmtErrorf("[ERROR] Error setting vpn_server: %s", err))
 	}
 	if err = d.Set("vpn_route", getVPNServerRouteOptions.ID); err != nil {
-		return diag.FromErr(fmt.Errorf("[ERROR] Error setting vpn_route: %s", err))
+		return diag.FromErr(flex.FmtErrorf("[ERROR] Error setting vpn_route: %s", err))
 	}
 
 	if err = d.Set("destination", vpnServerRoute.Destination); err != nil {
-		return diag.FromErr(fmt.Errorf("[ERROR] Error setting destination: %s", err))
+		return diag.FromErr(flex.FmtErrorf("[ERROR] Error setting destination: %s", err))
 	}
 	if err = d.Set("action", vpnServerRoute.Action); err != nil {
-		return diag.FromErr(fmt.Errorf("[ERROR] Error setting action: %s", err))
+		return diag.FromErr(flex.FmtErrorf("[ERROR] Error setting action: %s", err))
 	}
 	if err = d.Set("name", vpnServerRoute.Name); err != nil {
-		return diag.FromErr(fmt.Errorf("[ERROR] Error setting name: %s", err))
+		return diag.FromErr(flex.FmtErrorf("[ERROR] Error setting name: %s", err))
 	}
 	if err = d.Set("created_at", flex.DateTimeToString(vpnServerRoute.CreatedAt)); err != nil {
-		return diag.FromErr(fmt.Errorf("[ERROR] Error setting created_at: %s", err))
+		return diag.FromErr(flex.FmtErrorf("[ERROR] Error setting created_at: %s", err))
 	}
 	if err = d.Set("health_state", vpnServerRoute.HealthState); err != nil {
-		return diag.FromErr(fmt.Errorf("[ERROR] Error setting health_state: %s", err))
+		return diag.FromErr(flex.FmtErrorf("[ERROR] Error setting health_state: %s", err))
 	}
 	if vpnServerRoute.HealthReasons != nil {
 		if err := d.Set("health_reasons", resourceVPNServerRouteFlattenHealthReasons(vpnServerRoute.HealthReasons)); err != nil {
-			return diag.FromErr(fmt.Errorf("[ERROR] Error setting health_reasons: %s", err))
+			return diag.FromErr(flex.FmtErrorf("[ERROR] Error setting health_reasons: %s", err))
 		}
 	}
 	if err = d.Set("href", vpnServerRoute.Href); err != nil {
-		return diag.FromErr(fmt.Errorf("[ERROR] Error setting href: %s", err))
+		return diag.FromErr(flex.FmtErrorf("[ERROR] Error setting href: %s", err))
 	}
 	if err = d.Set("lifecycle_state", vpnServerRoute.LifecycleState); err != nil {
-		return diag.FromErr(fmt.Errorf("[ERROR] Error setting lifecycle_state: %s", err))
+		return diag.FromErr(flex.FmtErrorf("[ERROR] Error setting lifecycle_state: %s", err))
 	}
 	if vpnServerRoute.LifecycleReasons != nil {
 		if err := d.Set("lifecycle_reasons", resourceVPNServerRouteFlattenLifecycleReasons(vpnServerRoute.LifecycleReasons)); err != nil {
-			return diag.FromErr(fmt.Errorf("[ERROR] Error setting lifecycle_reasons: %s", err))
+			return diag.FromErr(flex.FmtErrorf("[ERROR] Error setting lifecycle_reasons: %s", err))
 		}
 	}
 	if err = d.Set("resource_type", vpnServerRoute.ResourceType); err != nil {
-		return diag.FromErr(fmt.Errorf("[ERROR] Error setting resource_type: %s", err))
+		return diag.FromErr(flex.FmtErrorf("[ERROR] Error setting resource_type: %s", err))
 	}
 
 	return nil
@@ -358,11 +358,11 @@ func resourceIBMIsVPNServerRouteUpdate(context context.Context, d *schema.Resour
 		_, response, err := sess.UpdateVPNServerRouteWithContext(context, updateVPNServerRouteOptions)
 		if err != nil {
 			log.Printf("[DEBUG] UpdateVPNServerRouteWithContext failed %s\n%s", err, response)
-			return diag.FromErr(fmt.Errorf("[ERROR] UpdateVPNServerRouteWithContext failed %s\n%s", err, response))
+			return diag.FromErr(flex.FmtErrorf("[ERROR] UpdateVPNServerRouteWithContext failed %s\n%s", err, response))
 		}
 		_, err = isWaitForVPNServerRouteStable(context, sess, d, d.Timeout(schema.TimeoutUpdate))
 		if err != nil {
-			return diag.FromErr(fmt.Errorf("[ERROR] VPNServer Route failed %s\n", err))
+			return diag.FromErr(flex.FmtErrorf("[ERROR] VPNServer Route failed %s\n", err))
 		}
 	}
 
@@ -388,11 +388,11 @@ func resourceIBMIsVPNServerRouteDelete(context context.Context, d *schema.Resour
 	response, err := sess.DeleteVPNServerRouteWithContext(context, deleteVPNServerRouteOptions)
 	if err != nil {
 		log.Printf("[DEBUG] DeleteVPNServerRouteWithContext failed %s\n%s", err, response)
-		return diag.FromErr(fmt.Errorf("[ERROR] DeleteVPNServerRouteWithContext failed %s\n%s", err, response))
+		return diag.FromErr(flex.FmtErrorf("[ERROR] DeleteVPNServerRouteWithContext failed %s\n%s", err, response))
 	}
 	_, err = isWaitForVPNServerRouteDeleted(context, sess, d)
 	if err != nil {
-		return diag.FromErr(fmt.Errorf("[ERROR] VPNServer Route failed %s\n", err))
+		return diag.FromErr(flex.FmtErrorf("[ERROR] VPNServer Route failed %s\n", err))
 	}
 	d.SetId("")
 
@@ -411,7 +411,7 @@ func isWaitForVPNServerRouteDeleted(context context.Context, sess *vpcv1.VpcV1, 
 			parts, err := flex.SepIdParts(d.Id(), "/")
 			if err != nil {
 				log.Printf("[DEBUG] Getting ID failed %s", err)
-				return nil, "", fmt.Errorf("Error Getting VPC Server: %s", err)
+				return nil, "", flex.FmtErrorf("Error Getting VPC Server: %s", err)
 			}
 
 			getVPNServerRouteOptions.SetVPNServerID(parts[0])
@@ -422,7 +422,7 @@ func isWaitForVPNServerRouteDeleted(context context.Context, sess *vpcv1.VpcV1, 
 				if response != nil && response.StatusCode == 404 {
 					return vpnServerRoute, isVPNServerRouteStatusDeleted, nil
 				}
-				return vpnServerRoute, *vpnServerRoute.LifecycleState, fmt.Errorf("The VPC route %s failed to delete: %s\n%s", d.Id(), err, response)
+				return vpnServerRoute, *vpnServerRoute.LifecycleState, flex.FmtErrorf("The VPC route %s failed to delete: %s\n%s", d.Id(), err, response)
 			}
 			return vpnServerRoute, *vpnServerRoute.LifecycleState, nil
 


### PR DESCRIPTION
This adds support for the new error formats designed for IBM Cloud services and tools. The support is only added in select VPC resources/ data sources for now. The support comes from wrapping the provider to catch errors and re-format them with the new system, so that the change to the actual resource/data source code has as small of a surface area as possible.

The primary change to resource code comes in the from of updating calls to `fmt.Errorf` to be calls to a new wrapper function, `flex.FmtErrorf`. It accepts the same arguments but instead of wrapping errors coming from the underlying Go SDK so that we retain only the message, it detects those errors and returns them so that we preserve all of the information needed for the new error formats.

With this change, error messages will now include more information about the problem and will include an identifying hash that allows the user to lookup more information about the specific error scenario that occurred.

<!--- See what makes a good Pull Request at : https://github.com/IBM-Cloud/terraform-provider-ibm/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```
