### PR TITLE
migrated vpc-go-sdk to 0.49.1 version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -31,7 +31,7 @@ require (
 	github.com/IBM/schematics-go-sdk v0.2.3
 	github.com/IBM/secrets-manager-go-sdk/v2 v2.0.4
 	github.com/IBM/vpc-beta-go-sdk v0.6.0
-	github.com/IBM/vpc-go-sdk v0.48.0
+	github.com/IBM/vpc-go-sdk v0.49.1
 	github.com/ScaleFT/sshkeys v0.0.0-20200327173127-6142f742bca5
 	github.com/akamai/AkamaiOPEN-edgegrid-golang v1.2.2
 	github.com/akamai/AkamaiOPEN-edgegrid-golang/v5 v5.0.0

--- a/go.sum
+++ b/go.sum
@@ -174,8 +174,8 @@ github.com/IBM/secrets-manager-go-sdk/v2 v2.0.4 h1:xa9e+POVqaXxXHXkSMCOVAbKdUNEu
 github.com/IBM/secrets-manager-go-sdk/v2 v2.0.4/go.mod h1:5gq8D8uWOIbqOm1uztay6lpOysgJaxxEsaVZLWGWb40=
 github.com/IBM/vpc-beta-go-sdk v0.6.0 h1:wfM3AcW3zOM3xsRtZ+EA6+sESlGUjQ6Yf4n5QQyz4uc=
 github.com/IBM/vpc-beta-go-sdk v0.6.0/go.mod h1:fzHDAQIqH/5yJmYsKodKHLcqxMDT+yfH6vZjdiw8CQA=
-github.com/IBM/vpc-go-sdk v0.48.0 h1:4yeSxVX9mizsIW2F0rsVI47rZoNKBrZ1QK9RwwRas9Q=
-github.com/IBM/vpc-go-sdk v0.48.0/go.mod h1:FDJpiokOmaYG2hNYDfqKVxUPe8mm/dPi3mdz8Zt4o/Q=
+github.com/IBM/vpc-go-sdk v0.49.1 h1:VIkZ8iJMBHqBulUXcPtN0ifxsa0xwlBtaLslU2V9HsY=
+github.com/IBM/vpc-go-sdk v0.49.1/go.mod h1:iBg9UJY1y/XpkweyP6YH7G6guzKPV8BYDoBMTdPupH4=
 github.com/Jeffail/gabs v1.1.1 h1:V0uzR08Hj22EX8+8QMhyI9sX2hwRu+/RJhJUmnwda/E=
 github.com/Jeffail/gabs v1.1.1/go.mod h1:6xMvQMK4k33lb7GUUpaAPh6nKMmemQeg5d4gn7/bOXc=
 github.com/Logicalis/asn1 v0.0.0-20190312173541-d60463189a56 h1:vuquMR410psHNax14XKNWa0Ae/kYgWJcXi0IFuX60N0=

--- a/ibm/service/vpc/data_source_ibm_is_snapshot_consistency_group.go
+++ b/ibm/service/vpc/data_source_ibm_is_snapshot_consistency_group.go
@@ -543,7 +543,7 @@ func dataSourceIBMIsSnapshotConsistencyGroupResourceGroupReferenceToMap(model *v
 	return modelMap, nil
 }
 
-func dataSourceIBMIsSnapshotConsistencyGroupSnapshotConsistencyGroupSnapshotsItemToMap(model *vpcv1.SnapshotConsistencyGroupSnapshotsItem) (map[string]interface{}, error) {
+func dataSourceIBMIsSnapshotConsistencyGroupSnapshotConsistencyGroupSnapshotsItemToMap(model *vpcv1.SnapshotReference) (map[string]interface{}, error) {
 	modelMap := make(map[string]interface{})
 	modelMap["crn"] = model.CRN
 	if model.Deleted != nil {

--- a/ibm/service/vpc/data_source_ibm_is_vpn_gateway_connection.go
+++ b/ibm/service/vpc/data_source_ibm_is_vpn_gateway_connection.go
@@ -283,7 +283,7 @@ func dataSourceIBMIsVPNGatewayConnectionRead(context context.Context, d *schema.
 	vpn_gateway_connection := d.Get("vpn_gateway_connection").(string)
 	vpn_gateway_connection_name := d.Get("vpn_gateway_connection_name").(string)
 
-	vpnGatewayConnection := &vpcv1.VPNGatewayConnection{}
+	var vpnGatewayConnectionInterface *vpcv1.VPNGatewayConnectionIntf
 
 	if vpn_gateway_name != "" {
 		listvpnGWOptions := vpcClient.NewListVPNGatewaysOptions()
@@ -328,12 +328,37 @@ func dataSourceIBMIsVPNGatewayConnectionRead(context context.Context, d *schema.
 		}
 
 		vpn_gateway_conn_found := false
-		for _, connectionItem := range availableVPNGatewayConnections.Connections {
-			connection := connectionItem.(*vpcv1.VPNGatewayConnection)
-			if *connection.Name == vpn_gateway_connection_name {
-				vpnGatewayConnection = connection
-				vpn_gateway_conn_found = true
-				break
+		for _, vpnGatewayConnectionIntf := range availableVPNGatewayConnections.Connections {
+			if _, ok := vpnGatewayConnectionIntf.(*vpcv1.VPNGatewayConnectionPolicyMode); ok {
+				vpnGatewayConnection := vpnGatewayConnectionIntf.(*vpcv1.VPNGatewayConnectionPolicyMode)
+				if *vpnGatewayConnection.Name == vpn_gateway_connection_name {
+					vpnGatewayConnectionInterface = &vpnGatewayConnectionIntf
+					vpn_gateway_conn_found = true
+					break
+				}
+			} else if _, ok := vpnGatewayConnectionIntf.(*vpcv1.VPNGatewayConnectionRouteMode); ok {
+				vpnGatewayConnection := vpnGatewayConnectionIntf.(*vpcv1.VPNGatewayConnectionRouteMode)
+				if *vpnGatewayConnection.Name == vpn_gateway_connection_name {
+					vpnGatewayConnectionInterface = &vpnGatewayConnectionIntf
+					vpn_gateway_conn_found = true
+					break
+				}
+			} else if _, ok := vpnGatewayConnectionIntf.(*vpcv1.VPNGatewayConnectionRouteModeVPNGatewayConnectionStaticRouteMode); ok {
+				vpnGatewayConnection := vpnGatewayConnectionIntf.(*vpcv1.VPNGatewayConnectionRouteModeVPNGatewayConnectionStaticRouteMode)
+				if *vpnGatewayConnection.Name == vpn_gateway_connection_name {
+					vpnGatewayConnectionInterface = &vpnGatewayConnectionIntf
+					vpn_gateway_conn_found = true
+					break
+				}
+			} else if _, ok := vpnGatewayConnectionIntf.(*vpcv1.VPNGatewayConnection); ok {
+				vpnGatewayConnection := vpnGatewayConnectionIntf.(*vpcv1.VPNGatewayConnection)
+				if *vpnGatewayConnection.Name == vpn_gateway_connection_name {
+					vpnGatewayConnectionInterface = &vpnGatewayConnectionIntf
+					vpn_gateway_conn_found = true
+					break
+				}
+			} else {
+				return diag.FromErr(fmt.Errorf("[ERROR] Unrecognized vpcv1.vpnGatewayConnectionIntf subtype encountered"))
 			}
 		}
 		if !vpn_gateway_conn_found {
@@ -346,93 +371,306 @@ func dataSourceIBMIsVPNGatewayConnectionRead(context context.Context, d *schema.
 		getVPNGatewayConnectionOptions.SetID(vpn_gateway_connection)
 
 		vpnGatewayConnectionIntf, response, err := vpcClient.GetVPNGatewayConnectionWithContext(context, getVPNGatewayConnectionOptions)
-		if err != nil || vpnGatewayConnectionIntf.(*vpcv1.VPNGatewayConnection) == nil {
+		vpnGatewayConnectionInterface = &vpnGatewayConnectionIntf
+		if err != nil {
 			log.Printf("[DEBUG] GetVPNGatewayConnectionWithContext failed %s\n%s", err, response)
 			return diag.FromErr(fmt.Errorf("GetVPNGatewayConnectionWithContext failed %s\n%s", err, response))
 		}
-		vpnGatewayConnection = vpnGatewayConnectionIntf.(*vpcv1.VPNGatewayConnection)
 	}
 
-	d.SetId(fmt.Sprintf("%s/%s", vpn_gateway_id, *vpnGatewayConnection.ID))
+	if _, ok := (*vpnGatewayConnectionInterface).(*vpcv1.VPNGatewayConnectionPolicyMode); ok {
+		vpnGatewayConnection := (*vpnGatewayConnectionInterface).(*vpcv1.VPNGatewayConnectionPolicyMode)
+		d.SetId(fmt.Sprintf("%s/%s", vpn_gateway_id, *vpnGatewayConnection.ID))
 
-	if err = d.Set("admin_state_up", vpnGatewayConnection.AdminStateUp); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting admin_state_up: %s", err))
-	}
-	if err = d.Set("authentication_mode", vpnGatewayConnection.AuthenticationMode); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting authentication_mode: %s", err))
-	}
-	if err = d.Set("created_at", flex.DateTimeToString(vpnGatewayConnection.CreatedAt)); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting created_at: %s", err))
-	}
-
-	if vpnGatewayConnection.DeadPeerDetection != nil {
-		err = d.Set("dead_peer_detection", dataSourceVPNGatewayConnectionFlattenDeadPeerDetection(*vpnGatewayConnection.DeadPeerDetection))
-		if err != nil {
-			return diag.FromErr(fmt.Errorf("Error setting dead_peer_detection %s", err))
+		if err = d.Set("admin_state_up", vpnGatewayConnection.AdminStateUp); err != nil {
+			return diag.FromErr(fmt.Errorf("Error setting admin_state_up: %s", err))
 		}
-	}
-	if err = d.Set("href", vpnGatewayConnection.Href); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting href: %s", err))
+		if err = d.Set("authentication_mode", vpnGatewayConnection.AuthenticationMode); err != nil {
+			return diag.FromErr(fmt.Errorf("Error setting authentication_mode: %s", err))
+		}
+		if err = d.Set("created_at", flex.DateTimeToString(vpnGatewayConnection.CreatedAt)); err != nil {
+			return diag.FromErr(fmt.Errorf("Error setting created_at: %s", err))
+		}
+
+		if vpnGatewayConnection.DeadPeerDetection != nil {
+			err = d.Set("dead_peer_detection", dataSourceVPNGatewayConnectionFlattenDeadPeerDetection(*vpnGatewayConnection.DeadPeerDetection))
+			if err != nil {
+				return diag.FromErr(fmt.Errorf("Error setting dead_peer_detection %s", err))
+			}
+		}
+		if err = d.Set("href", vpnGatewayConnection.Href); err != nil {
+			return diag.FromErr(fmt.Errorf("Error setting href: %s", err))
+		}
+
+		if vpnGatewayConnection.IkePolicy != nil {
+			err = d.Set("ike_policy", dataSourceVPNGatewayConnectionFlattenIkePolicy(*vpnGatewayConnection.IkePolicy))
+			if err != nil {
+				return diag.FromErr(fmt.Errorf("Error setting ike_policy %s", err))
+			}
+		}
+
+		if vpnGatewayConnection.IpsecPolicy != nil {
+			err = d.Set("ipsec_policy", dataSourceVPNGatewayConnectionFlattenIpsecPolicy(*vpnGatewayConnection.IpsecPolicy))
+			if err != nil {
+				return diag.FromErr(fmt.Errorf("Error setting ipsec_policy %s", err))
+			}
+		}
+		if err = d.Set("mode", vpnGatewayConnection.Mode); err != nil {
+			return diag.FromErr(fmt.Errorf("Error setting mode: %s", err))
+		}
+		if err = d.Set("name", vpnGatewayConnection.Name); err != nil {
+			return diag.FromErr(fmt.Errorf("Error setting name: %s", err))
+		}
+		if err = d.Set("peer_address", vpnGatewayConnection.PeerAddress); err != nil {
+			return diag.FromErr(fmt.Errorf("Error setting peer_address: %s", err))
+		}
+		if err = d.Set("psk", vpnGatewayConnection.Psk); err != nil {
+			return diag.FromErr(fmt.Errorf("Error setting psk: %s", err))
+		}
+		if err = d.Set("resource_type", vpnGatewayConnection.ResourceType); err != nil {
+			return diag.FromErr(fmt.Errorf("Error setting resource_type: %s", err))
+		}
+		if err = d.Set("status", vpnGatewayConnection.Status); err != nil {
+			return diag.FromErr(fmt.Errorf("Error setting status: %s", err))
+		}
+		if err := d.Set("status_reasons", resourceVPNGatewayConnectionFlattenLifecycleReasons(vpnGatewayConnection.StatusReasons)); err != nil {
+			return diag.FromErr(fmt.Errorf("[ERROR] Error setting status_reasons: %s", err))
+		}
+		if len(vpnGatewayConnection.LocalCIDRs) > 0 {
+			err = d.Set("local_cidrs", vpnGatewayConnection.LocalCIDRs)
+			if err != nil {
+				return diag.FromErr(fmt.Errorf("Error setting local CIDRs %s", err))
+			}
+		}
+
+		if len(vpnGatewayConnection.PeerCIDRs) > 0 {
+			err = d.Set("peer_cidrs", vpnGatewayConnection.PeerCIDRs)
+			if err != nil {
+				return diag.FromErr(fmt.Errorf("Error setting Peer CIDRs %s", err))
+			}
+		}
+	} else if _, ok := (*vpnGatewayConnectionInterface).(*vpcv1.VPNGatewayConnectionRouteMode); ok {
+		vpnGatewayConnection := (*vpnGatewayConnectionInterface).(*vpcv1.VPNGatewayConnectionRouteMode)
+		d.SetId(fmt.Sprintf("%s/%s", vpn_gateway_id, *vpnGatewayConnection.ID))
+
+		if err = d.Set("admin_state_up", vpnGatewayConnection.AdminStateUp); err != nil {
+			return diag.FromErr(fmt.Errorf("Error setting admin_state_up: %s", err))
+		}
+		if err = d.Set("authentication_mode", vpnGatewayConnection.AuthenticationMode); err != nil {
+			return diag.FromErr(fmt.Errorf("Error setting authentication_mode: %s", err))
+		}
+		if err = d.Set("created_at", flex.DateTimeToString(vpnGatewayConnection.CreatedAt)); err != nil {
+			return diag.FromErr(fmt.Errorf("Error setting created_at: %s", err))
+		}
+
+		if vpnGatewayConnection.DeadPeerDetection != nil {
+			err = d.Set("dead_peer_detection", dataSourceVPNGatewayConnectionFlattenDeadPeerDetection(*vpnGatewayConnection.DeadPeerDetection))
+			if err != nil {
+				return diag.FromErr(fmt.Errorf("Error setting dead_peer_detection %s", err))
+			}
+		}
+		if err = d.Set("href", vpnGatewayConnection.Href); err != nil {
+			return diag.FromErr(fmt.Errorf("Error setting href: %s", err))
+		}
+
+		if vpnGatewayConnection.IkePolicy != nil {
+			err = d.Set("ike_policy", dataSourceVPNGatewayConnectionFlattenIkePolicy(*vpnGatewayConnection.IkePolicy))
+			if err != nil {
+				return diag.FromErr(fmt.Errorf("Error setting ike_policy %s", err))
+			}
+		}
+
+		if vpnGatewayConnection.IpsecPolicy != nil {
+			err = d.Set("ipsec_policy", dataSourceVPNGatewayConnectionFlattenIpsecPolicy(*vpnGatewayConnection.IpsecPolicy))
+			if err != nil {
+				return diag.FromErr(fmt.Errorf("Error setting ipsec_policy %s", err))
+			}
+		}
+		if err = d.Set("mode", vpnGatewayConnection.Mode); err != nil {
+			return diag.FromErr(fmt.Errorf("Error setting mode: %s", err))
+		}
+		if err = d.Set("name", vpnGatewayConnection.Name); err != nil {
+			return diag.FromErr(fmt.Errorf("Error setting name: %s", err))
+		}
+		if err = d.Set("peer_address", vpnGatewayConnection.PeerAddress); err != nil {
+			return diag.FromErr(fmt.Errorf("Error setting peer_address: %s", err))
+		}
+		if err = d.Set("psk", vpnGatewayConnection.Psk); err != nil {
+			return diag.FromErr(fmt.Errorf("Error setting psk: %s", err))
+		}
+		if err = d.Set("resource_type", vpnGatewayConnection.ResourceType); err != nil {
+			return diag.FromErr(fmt.Errorf("Error setting resource_type: %s", err))
+		}
+		if err = d.Set("status", vpnGatewayConnection.Status); err != nil {
+			return diag.FromErr(fmt.Errorf("Error setting status: %s", err))
+		}
+		if err := d.Set("status_reasons", resourceVPNGatewayConnectionFlattenLifecycleReasons(vpnGatewayConnection.StatusReasons)); err != nil {
+			return diag.FromErr(fmt.Errorf("[ERROR] Error setting status_reasons: %s", err))
+		}
+		if err = d.Set("routing_protocol", vpnGatewayConnection.RoutingProtocol); err != nil {
+			return diag.FromErr(fmt.Errorf("Error setting routing_protocol: %s", err))
+		}
+
+		if vpnGatewayConnection.Tunnels != nil {
+			err = d.Set("tunnels", dataSourceVPNGatewayConnectionFlattenTunnels(vpnGatewayConnection.Tunnels))
+			if err != nil {
+				return diag.FromErr(fmt.Errorf("Error setting tunnels %s", err))
+			}
+		}
+	} else if _, ok := (*vpnGatewayConnectionInterface).(*vpcv1.VPNGatewayConnectionRouteModeVPNGatewayConnectionStaticRouteMode); ok {
+		vpnGatewayConnection := (*vpnGatewayConnectionInterface).(*vpcv1.VPNGatewayConnectionRouteModeVPNGatewayConnectionStaticRouteMode)
+		d.SetId(fmt.Sprintf("%s/%s", vpn_gateway_id, *vpnGatewayConnection.ID))
+
+		if err = d.Set("admin_state_up", vpnGatewayConnection.AdminStateUp); err != nil {
+			return diag.FromErr(fmt.Errorf("Error setting admin_state_up: %s", err))
+		}
+		if err = d.Set("authentication_mode", vpnGatewayConnection.AuthenticationMode); err != nil {
+			return diag.FromErr(fmt.Errorf("Error setting authentication_mode: %s", err))
+		}
+		if err = d.Set("created_at", flex.DateTimeToString(vpnGatewayConnection.CreatedAt)); err != nil {
+			return diag.FromErr(fmt.Errorf("Error setting created_at: %s", err))
+		}
+
+		if vpnGatewayConnection.DeadPeerDetection != nil {
+			err = d.Set("dead_peer_detection", dataSourceVPNGatewayConnectionFlattenDeadPeerDetection(*vpnGatewayConnection.DeadPeerDetection))
+			if err != nil {
+				return diag.FromErr(fmt.Errorf("Error setting dead_peer_detection %s", err))
+			}
+		}
+		if err = d.Set("href", vpnGatewayConnection.Href); err != nil {
+			return diag.FromErr(fmt.Errorf("Error setting href: %s", err))
+		}
+
+		if vpnGatewayConnection.IkePolicy != nil {
+			err = d.Set("ike_policy", dataSourceVPNGatewayConnectionFlattenIkePolicy(*vpnGatewayConnection.IkePolicy))
+			if err != nil {
+				return diag.FromErr(fmt.Errorf("Error setting ike_policy %s", err))
+			}
+		}
+
+		if vpnGatewayConnection.IpsecPolicy != nil {
+			err = d.Set("ipsec_policy", dataSourceVPNGatewayConnectionFlattenIpsecPolicy(*vpnGatewayConnection.IpsecPolicy))
+			if err != nil {
+				return diag.FromErr(fmt.Errorf("Error setting ipsec_policy %s", err))
+			}
+		}
+		if err = d.Set("mode", vpnGatewayConnection.Mode); err != nil {
+			return diag.FromErr(fmt.Errorf("Error setting mode: %s", err))
+		}
+		if err = d.Set("name", vpnGatewayConnection.Name); err != nil {
+			return diag.FromErr(fmt.Errorf("Error setting name: %s", err))
+		}
+		if err = d.Set("peer_address", vpnGatewayConnection.PeerAddress); err != nil {
+			return diag.FromErr(fmt.Errorf("Error setting peer_address: %s", err))
+		}
+		if err = d.Set("psk", vpnGatewayConnection.Psk); err != nil {
+			return diag.FromErr(fmt.Errorf("Error setting psk: %s", err))
+		}
+		if err = d.Set("resource_type", vpnGatewayConnection.ResourceType); err != nil {
+			return diag.FromErr(fmt.Errorf("Error setting resource_type: %s", err))
+		}
+		if err = d.Set("status", vpnGatewayConnection.Status); err != nil {
+			return diag.FromErr(fmt.Errorf("Error setting status: %s", err))
+		}
+		if err := d.Set("status_reasons", resourceVPNGatewayConnectionFlattenLifecycleReasons(vpnGatewayConnection.StatusReasons)); err != nil {
+			return diag.FromErr(fmt.Errorf("[ERROR] Error setting status_reasons: %s", err))
+		}
+		if err = d.Set("routing_protocol", vpnGatewayConnection.RoutingProtocol); err != nil {
+			return diag.FromErr(fmt.Errorf("Error setting routing_protocol: %s", err))
+		}
+
+		if vpnGatewayConnection.Tunnels != nil {
+			err = d.Set("tunnels", dataSourceVPNGatewayConnectionFlattenTunnels(vpnGatewayConnection.Tunnels))
+			if err != nil {
+				return diag.FromErr(fmt.Errorf("Error setting tunnels %s", err))
+			}
+		}
+	} else if _, ok := (*vpnGatewayConnectionInterface).(*vpcv1.VPNGatewayConnection); ok {
+		vpnGatewayConnection := (*vpnGatewayConnectionInterface).(*vpcv1.VPNGatewayConnection)
+		d.SetId(fmt.Sprintf("%s/%s", vpn_gateway_id, *vpnGatewayConnection.ID))
+
+		if err = d.Set("admin_state_up", vpnGatewayConnection.AdminStateUp); err != nil {
+			return diag.FromErr(fmt.Errorf("Error setting admin_state_up: %s", err))
+		}
+		if err = d.Set("authentication_mode", vpnGatewayConnection.AuthenticationMode); err != nil {
+			return diag.FromErr(fmt.Errorf("Error setting authentication_mode: %s", err))
+		}
+		if err = d.Set("created_at", flex.DateTimeToString(vpnGatewayConnection.CreatedAt)); err != nil {
+			return diag.FromErr(fmt.Errorf("Error setting created_at: %s", err))
+		}
+
+		if vpnGatewayConnection.DeadPeerDetection != nil {
+			err = d.Set("dead_peer_detection", dataSourceVPNGatewayConnectionFlattenDeadPeerDetection(*vpnGatewayConnection.DeadPeerDetection))
+			if err != nil {
+				return diag.FromErr(fmt.Errorf("Error setting dead_peer_detection %s", err))
+			}
+		}
+		if err = d.Set("href", vpnGatewayConnection.Href); err != nil {
+			return diag.FromErr(fmt.Errorf("Error setting href: %s", err))
+		}
+
+		if vpnGatewayConnection.IkePolicy != nil {
+			err = d.Set("ike_policy", dataSourceVPNGatewayConnectionFlattenIkePolicy(*vpnGatewayConnection.IkePolicy))
+			if err != nil {
+				return diag.FromErr(fmt.Errorf("Error setting ike_policy %s", err))
+			}
+		}
+
+		if vpnGatewayConnection.IpsecPolicy != nil {
+			err = d.Set("ipsec_policy", dataSourceVPNGatewayConnectionFlattenIpsecPolicy(*vpnGatewayConnection.IpsecPolicy))
+			if err != nil {
+				return diag.FromErr(fmt.Errorf("Error setting ipsec_policy %s", err))
+			}
+		}
+		if err = d.Set("mode", vpnGatewayConnection.Mode); err != nil {
+			return diag.FromErr(fmt.Errorf("Error setting mode: %s", err))
+		}
+		if err = d.Set("name", vpnGatewayConnection.Name); err != nil {
+			return diag.FromErr(fmt.Errorf("Error setting name: %s", err))
+		}
+		if err = d.Set("peer_address", vpnGatewayConnection.PeerAddress); err != nil {
+			return diag.FromErr(fmt.Errorf("Error setting peer_address: %s", err))
+		}
+		if err = d.Set("psk", vpnGatewayConnection.Psk); err != nil {
+			return diag.FromErr(fmt.Errorf("Error setting psk: %s", err))
+		}
+		if err = d.Set("resource_type", vpnGatewayConnection.ResourceType); err != nil {
+			return diag.FromErr(fmt.Errorf("Error setting resource_type: %s", err))
+		}
+		if err = d.Set("status", vpnGatewayConnection.Status); err != nil {
+			return diag.FromErr(fmt.Errorf("Error setting status: %s", err))
+		}
+		if err := d.Set("status_reasons", resourceVPNGatewayConnectionFlattenLifecycleReasons(vpnGatewayConnection.StatusReasons)); err != nil {
+			return diag.FromErr(fmt.Errorf("[ERROR] Error setting status_reasons: %s", err))
+		}
+		if err = d.Set("routing_protocol", vpnGatewayConnection.RoutingProtocol); err != nil {
+			return diag.FromErr(fmt.Errorf("Error setting routing_protocol: %s", err))
+		}
+
+		if vpnGatewayConnection.Tunnels != nil {
+			err = d.Set("tunnels", dataSourceVPNGatewayConnectionFlattenTunnels(vpnGatewayConnection.Tunnels))
+			if err != nil {
+				return diag.FromErr(fmt.Errorf("Error setting tunnels %s", err))
+			}
+		}
+
+		if len(vpnGatewayConnection.LocalCIDRs) > 0 {
+			err = d.Set("local_cidrs", vpnGatewayConnection.LocalCIDRs)
+			if err != nil {
+				return diag.FromErr(fmt.Errorf("Error setting local CIDRs %s", err))
+			}
+		}
+
+		if len(vpnGatewayConnection.PeerCIDRs) > 0 {
+			err = d.Set("peer_cidrs", vpnGatewayConnection.PeerCIDRs)
+			if err != nil {
+				return diag.FromErr(fmt.Errorf("Error setting Peer CIDRs %s", err))
+			}
+		}
+	} else {
+		return diag.FromErr(fmt.Errorf("[ERROR] Unrecognized vpcv1.vpnGatewayConnectionIntf subtype encountered"))
 	}
 
-	if vpnGatewayConnection.IkePolicy != nil {
-		err = d.Set("ike_policy", dataSourceVPNGatewayConnectionFlattenIkePolicy(*vpnGatewayConnection.IkePolicy))
-		if err != nil {
-			return diag.FromErr(fmt.Errorf("Error setting ike_policy %s", err))
-		}
-	}
-
-	if vpnGatewayConnection.IpsecPolicy != nil {
-		err = d.Set("ipsec_policy", dataSourceVPNGatewayConnectionFlattenIpsecPolicy(*vpnGatewayConnection.IpsecPolicy))
-		if err != nil {
-			return diag.FromErr(fmt.Errorf("Error setting ipsec_policy %s", err))
-		}
-	}
-	if err = d.Set("mode", vpnGatewayConnection.Mode); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting mode: %s", err))
-	}
-	if err = d.Set("name", vpnGatewayConnection.Name); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting name: %s", err))
-	}
-	if err = d.Set("peer_address", vpnGatewayConnection.PeerAddress); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting peer_address: %s", err))
-	}
-	if err = d.Set("psk", vpnGatewayConnection.Psk); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting psk: %s", err))
-	}
-	if err = d.Set("resource_type", vpnGatewayConnection.ResourceType); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting resource_type: %s", err))
-	}
-	if err = d.Set("status", vpnGatewayConnection.Status); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting status: %s", err))
-	}
-	if err := d.Set("status_reasons", resourceVPNGatewayConnectionFlattenLifecycleReasons(vpnGatewayConnection.StatusReasons)); err != nil {
-		return diag.FromErr(fmt.Errorf("[ERROR] Error setting status_reasons: %s", err))
-	}
-	if err = d.Set("routing_protocol", vpnGatewayConnection.RoutingProtocol); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting routing_protocol: %s", err))
-	}
-
-	if vpnGatewayConnection.Tunnels != nil {
-		err = d.Set("tunnels", dataSourceVPNGatewayConnectionFlattenTunnels(vpnGatewayConnection.Tunnels))
-		if err != nil {
-			return diag.FromErr(fmt.Errorf("Error setting tunnels %s", err))
-		}
-	}
-
-	if len(vpnGatewayConnection.LocalCIDRs) > 0 {
-		err = d.Set("local_cidrs", vpnGatewayConnection.LocalCIDRs)
-		if err != nil {
-			return diag.FromErr(fmt.Errorf("Error setting local CIDRs %s", err))
-		}
-	}
-
-	if len(vpnGatewayConnection.PeerCIDRs) > 0 {
-		err = d.Set("peer_cidrs", vpnGatewayConnection.PeerCIDRs)
-		if err != nil {
-			return diag.FromErr(fmt.Errorf("Error setting Peer CIDRs %s", err))
-		}
-	}
 	return nil
 }
 

--- a/ibm/service/vpc/data_source_ibm_is_vpn_gateway_connection_test.go
+++ b/ibm/service/vpc/data_source_ibm_is_vpn_gateway_connection_test.go
@@ -31,8 +31,6 @@ func TestAccIBMIsVPNGatewayConnectionDataSourceBasic(t *testing.T) {
 					resource.TestCheckResourceAttrSet("data.ibm_is_vpn_gateway_connection.example", "dead_peer_detection.0.action"),
 					resource.TestCheckResourceAttrSet("data.ibm_is_vpn_gateway_connection.example", "dead_peer_detection.0.interval"),
 					resource.TestCheckResourceAttrSet("data.ibm_is_vpn_gateway_connection.example", "dead_peer_detection.0.timeout"),
-					resource.TestCheckResourceAttrSet("data.ibm_is_vpn_gateway_connection.example", "tunnels.0.public_ip_address"),
-					resource.TestCheckResourceAttrSet("data.ibm_is_vpn_gateway_connection.example", "tunnels.0.status"),
 					resource.TestCheckResourceAttrSet("data.ibm_is_vpn_gateway_connection.example", "href"),
 					resource.TestCheckResourceAttrSet("data.ibm_is_vpn_gateway_connection.example", "mode"),
 					resource.TestCheckResourceAttrSet("data.ibm_is_vpn_gateway_connection.example", "name"),
@@ -51,8 +49,6 @@ func TestAccIBMIsVPNGatewayConnectionDataSourceBasic(t *testing.T) {
 					resource.TestCheckResourceAttrSet("data.ibm_is_vpn_gateway_connection.example", "dead_peer_detection.0.action"),
 					resource.TestCheckResourceAttrSet("data.ibm_is_vpn_gateway_connection.example", "dead_peer_detection.0.interval"),
 					resource.TestCheckResourceAttrSet("data.ibm_is_vpn_gateway_connection.example", "dead_peer_detection.0.timeout"),
-					resource.TestCheckResourceAttrSet("data.ibm_is_vpn_gateway_connection.example", "tunnels.0.public_ip_address"),
-					resource.TestCheckResourceAttrSet("data.ibm_is_vpn_gateway_connection.example", "tunnels.0.status"),
 					resource.TestCheckResourceAttrSet("data.ibm_is_vpn_gateway_connection.example1", "href"),
 					resource.TestCheckResourceAttrSet("data.ibm_is_vpn_gateway_connection.example1", "mode"),
 					resource.TestCheckResourceAttrSet("data.ibm_is_vpn_gateway_connection.example1", "name"),
@@ -71,8 +67,6 @@ func TestAccIBMIsVPNGatewayConnectionDataSourceBasic(t *testing.T) {
 					resource.TestCheckResourceAttrSet("data.ibm_is_vpn_gateway_connection.example", "dead_peer_detection.0.action"),
 					resource.TestCheckResourceAttrSet("data.ibm_is_vpn_gateway_connection.example", "dead_peer_detection.0.interval"),
 					resource.TestCheckResourceAttrSet("data.ibm_is_vpn_gateway_connection.example", "dead_peer_detection.0.timeout"),
-					resource.TestCheckResourceAttrSet("data.ibm_is_vpn_gateway_connection.example", "tunnels.0.public_ip_address"),
-					resource.TestCheckResourceAttrSet("data.ibm_is_vpn_gateway_connection.example", "tunnels.0.status"),
 					resource.TestCheckResourceAttrSet("data.ibm_is_vpn_gateway_connection.example2", "href"),
 					resource.TestCheckResourceAttrSet("data.ibm_is_vpn_gateway_connection.example2", "mode"),
 					resource.TestCheckResourceAttrSet("data.ibm_is_vpn_gateway_connection.example2", "name"),
@@ -91,8 +85,6 @@ func TestAccIBMIsVPNGatewayConnectionDataSourceBasic(t *testing.T) {
 					resource.TestCheckResourceAttrSet("data.ibm_is_vpn_gateway_connection.example", "dead_peer_detection.0.action"),
 					resource.TestCheckResourceAttrSet("data.ibm_is_vpn_gateway_connection.example", "dead_peer_detection.0.interval"),
 					resource.TestCheckResourceAttrSet("data.ibm_is_vpn_gateway_connection.example", "dead_peer_detection.0.timeout"),
-					resource.TestCheckResourceAttrSet("data.ibm_is_vpn_gateway_connection.example", "tunnels.0.public_ip_address"),
-					resource.TestCheckResourceAttrSet("data.ibm_is_vpn_gateway_connection.example", "tunnels.0.status"),
 					resource.TestCheckResourceAttrSet("data.ibm_is_vpn_gateway_connection.example3", "href"),
 					resource.TestCheckResourceAttrSet("data.ibm_is_vpn_gateway_connection.example3", "mode"),
 					resource.TestCheckResourceAttrSet("data.ibm_is_vpn_gateway_connection.example3", "name"),
@@ -108,45 +100,46 @@ func TestAccIBMIsVPNGatewayConnectionDataSourceBasic(t *testing.T) {
 
 func testAccCheckIBMIsVPNGatewayConnectionDataSourceConfigBasic(vpc, subnet, vpngwname, name string) string {
 	return fmt.Sprintf(`
-    	resource "ibm_is_vpc" "example" {
-    		name = "%s"
-    		
-    	}
-    	resource "ibm_is_subnet" "example" {
-    		name = "%s"
-    		vpc = "${ibm_is_vpc.example.id}"
-    		zone = "%s"
-    		ipv4_cidr_block = "%s"
-    		
-    	}
-    	resource "ibm_is_vpn_gateway" "example" {
-			name = "%s"
-			subnet = "${ibm_is_subnet.example.id}"
-			
-    	
-    	}
-    	resource "ibm_is_vpn_gateway_connection" "example" {
-    		name = "%s"
-    		vpn_gateway = "${ibm_is_vpn_gateway.example.id}"
-    		peer_address = "1.2.3.4"
-			local_cidrs   = [ibm_is_subnet.example.ipv4_cidr_block]
-    		preshared_key = "VPNDemoPassword"
-    	}
-		data "ibm_is_vpn_gateway_connection" "example" {
-    		vpn_gateway = ibm_is_vpn_gateway.example.id
-    		vpn_gateway_connection = ibm_is_vpn_gateway_connection.example.gateway_connection
-    	}
-    	data "ibm_is_vpn_gateway_connection" "example1" {
-    		vpn_gateway = ibm_is_vpn_gateway.example.id
-    		vpn_gateway_connection_name = ibm_is_vpn_gateway_connection.example.name
-    	}
-    	data "ibm_is_vpn_gateway_connection" "example2" {
-    		vpn_gateway_name = ibm_is_vpn_gateway.example.name
-    		vpn_gateway_connection = ibm_is_vpn_gateway_connection.example.gateway_connection
-    	}
-    	data "ibm_is_vpn_gateway_connection" "example3" {
-    		vpn_gateway_name = ibm_is_vpn_gateway.example.name
-    		vpn_gateway_connection_name = ibm_is_vpn_gateway_connection.example.name
-    	}
+	resource "ibm_is_vpc" "example" {
+		name = "%s"
+	  
+	  }
+	  resource "ibm_is_subnet" "example" {
+		name            = "%s"
+		vpc             = ibm_is_vpc.example.id
+		zone            = "%s"
+		ipv4_cidr_block = "%s"
+	  
+	  }
+	  resource "ibm_is_vpn_gateway" "example" {
+		name   = "%s"
+		subnet = ibm_is_subnet.example.id
+		mode   = "policy"
+	  
+	  }
+	  resource "ibm_is_vpn_gateway_connection" "example" {
+		name          = "%s"
+		vpn_gateway   = ibm_is_vpn_gateway.example.id
+		peer_address  = "1.2.3.4"
+		peer_cidrs    = [ibm_is_subnet.example.ipv4_cidr_block]
+		local_cidrs   = [ibm_is_subnet.example.ipv4_cidr_block]
+		preshared_key = "VPNDemoPassword"
+	  }
+	  data "ibm_is_vpn_gateway_connection" "example" {
+		vpn_gateway            = ibm_is_vpn_gateway.example.id
+		vpn_gateway_connection = ibm_is_vpn_gateway_connection.example.gateway_connection
+	  }
+	  data "ibm_is_vpn_gateway_connection" "example1" {
+		vpn_gateway                 = ibm_is_vpn_gateway.example.id
+		vpn_gateway_connection_name = ibm_is_vpn_gateway_connection.example.name
+	  }
+	  data "ibm_is_vpn_gateway_connection" "example2" {
+		vpn_gateway_name       = ibm_is_vpn_gateway.example.name
+		vpn_gateway_connection = ibm_is_vpn_gateway_connection.example.gateway_connection
+	  }
+	  data "ibm_is_vpn_gateway_connection" "example3" {
+		vpn_gateway_name            = ibm_is_vpn_gateway.example.name
+		vpn_gateway_connection_name = ibm_is_vpn_gateway_connection.example.name
+	  }
 	`, vpc, subnet, acc.ISZoneName, acc.ISCIDR, vpngwname, name)
 }

--- a/ibm/service/vpc/data_source_ibm_is_vpn_gateway_connections.go
+++ b/ibm/service/vpc/data_source_ibm_is_vpn_gateway_connections.go
@@ -197,51 +197,161 @@ func dataSourceIBMVPNGatewayConnectionsRead(d *schema.ResourceData, meta interfa
 		return fmt.Errorf("[ERROR] Error reading list of VPN Gateway Connections:%s\n%s", err, detail)
 	}
 	vpngatewayconnections := make([]map[string]interface{}, 0)
-	for _, instance := range availableVPNGatewayConnections.Connections {
+	for _, vpnGatewayConnectionIntf := range availableVPNGatewayConnections.Connections {
 		gatewayconnection := map[string]interface{}{}
-		data := instance.(*vpcv1.VPNGatewayConnection)
-		gatewayconnection[isVPNGatewayConnectionAdminAuthenticationmode] = *data.AuthenticationMode
-		gatewayconnection[isVPNGatewayConnectionCreatedat] = data.CreatedAt.String()
-		gatewayconnection[isVPNGatewayConnectionAdminStateup] = *data.AdminStateUp
-		gatewayconnection[isVPNGatewayConnectionDeadPeerDetectionAction] = *data.DeadPeerDetection.Action
-		gatewayconnection[isVPNGatewayConnectionDeadPeerDetectionInterval] = *data.DeadPeerDetection.Interval
-		gatewayconnection[isVPNGatewayConnectionDeadPeerDetectionTimeout] = *data.DeadPeerDetection.Timeout
-		gatewayconnection[isVPNGatewayConnectionID] = *data.ID
+		if _, ok := vpnGatewayConnectionIntf.(*vpcv1.VPNGatewayConnectionPolicyMode); ok {
+			data := vpnGatewayConnectionIntf.(*vpcv1.VPNGatewayConnectionPolicyMode)
+			gatewayconnection[isVPNGatewayConnectionAdminAuthenticationmode] = *data.AuthenticationMode
+			gatewayconnection[isVPNGatewayConnectionCreatedat] = data.CreatedAt.String()
+			gatewayconnection[isVPNGatewayConnectionAdminStateup] = *data.AdminStateUp
+			gatewayconnection[isVPNGatewayConnectionDeadPeerDetectionAction] = *data.DeadPeerDetection.Action
+			gatewayconnection[isVPNGatewayConnectionDeadPeerDetectionInterval] = *data.DeadPeerDetection.Interval
+			gatewayconnection[isVPNGatewayConnectionDeadPeerDetectionTimeout] = *data.DeadPeerDetection.Timeout
+			gatewayconnection[isVPNGatewayConnectionID] = *data.ID
 
-		if data.IkePolicy != nil {
-			gatewayconnection[isVPNGatewayConnectionIKEPolicy] = *data.IkePolicy.ID
-		}
-		if data.IpsecPolicy != nil {
-			gatewayconnection[isVPNGatewayConnectionIPSECPolicy] = *data.IpsecPolicy.ID
-		}
-		if data.LocalCIDRs != nil {
-			gatewayconnection[isVPNGatewayConnectionLocalCIDRS] = flex.FlattenStringList(data.LocalCIDRs)
-		}
-		if data.PeerCIDRs != nil {
-			gatewayconnection[isVPNGatewayConnectionPeerCIDRS] = flex.FlattenStringList(data.PeerCIDRs)
-		}
-		gatewayconnection[isVPNGatewayConnectionMode] = *data.Mode
-		gatewayconnection[isVPNGatewayConnectionName] = *data.Name
-		gatewayconnection[isVPNGatewayConnectionPeerAddress] = *data.PeerAddress
-		gatewayconnection[isVPNGatewayConnectionResourcetype] = *data.ResourceType
-		gatewayconnection[isVPNGatewayConnectionStatus] = *data.Status
-		gatewayconnection[isVPNGatewayConnectionStatusreasons] = resourceVPNGatewayConnectionFlattenLifecycleReasons(data.StatusReasons)
-		//if data.Tunnels != nil {
-		if len(data.Tunnels) > 0 {
-			vpcTunnelsList := make([]map[string]interface{}, 0)
-			for _, vpcTunnel := range data.Tunnels {
-				currentTunnel := map[string]interface{}{}
-				if vpcTunnel.PublicIP != nil {
-					if vpcTunnel.PublicIP != nil {
-						currentTunnel["address"] = *vpcTunnel.PublicIP.Address
-					}
-					if vpcTunnel.Status != nil {
-						currentTunnel["status"] = *vpcTunnel.Status
-					}
-					vpcTunnelsList = append(vpcTunnelsList, currentTunnel)
-				}
+			if data.IkePolicy != nil {
+				gatewayconnection[isVPNGatewayConnectionIKEPolicy] = *data.IkePolicy.ID
 			}
-			gatewayconnection[isVPNGatewayConnectionTunnels] = vpcTunnelsList
+			if data.IpsecPolicy != nil {
+				gatewayconnection[isVPNGatewayConnectionIPSECPolicy] = *data.IpsecPolicy.ID
+			}
+			if data.LocalCIDRs != nil {
+				gatewayconnection[isVPNGatewayConnectionLocalCIDRS] = flex.FlattenStringList(data.LocalCIDRs)
+			}
+			if data.PeerCIDRs != nil {
+				gatewayconnection[isVPNGatewayConnectionPeerCIDRS] = flex.FlattenStringList(data.PeerCIDRs)
+			}
+			gatewayconnection[isVPNGatewayConnectionMode] = *data.Mode
+			gatewayconnection[isVPNGatewayConnectionName] = *data.Name
+			gatewayconnection[isVPNGatewayConnectionPeerAddress] = *data.PeerAddress
+			gatewayconnection[isVPNGatewayConnectionResourcetype] = *data.ResourceType
+			gatewayconnection[isVPNGatewayConnectionStatus] = *data.Status
+			gatewayconnection[isVPNGatewayConnectionStatusreasons] = resourceVPNGatewayConnectionFlattenLifecycleReasons(data.StatusReasons)
+		} else if _, ok := vpnGatewayConnectionIntf.(*vpcv1.VPNGatewayConnectionRouteMode); ok {
+			data := vpnGatewayConnectionIntf.(*vpcv1.VPNGatewayConnectionRouteMode)
+			gatewayconnection[isVPNGatewayConnectionAdminAuthenticationmode] = *data.AuthenticationMode
+			gatewayconnection[isVPNGatewayConnectionCreatedat] = data.CreatedAt.String()
+			gatewayconnection[isVPNGatewayConnectionAdminStateup] = *data.AdminStateUp
+			gatewayconnection[isVPNGatewayConnectionDeadPeerDetectionAction] = *data.DeadPeerDetection.Action
+			gatewayconnection[isVPNGatewayConnectionDeadPeerDetectionInterval] = *data.DeadPeerDetection.Interval
+			gatewayconnection[isVPNGatewayConnectionDeadPeerDetectionTimeout] = *data.DeadPeerDetection.Timeout
+			gatewayconnection[isVPNGatewayConnectionID] = *data.ID
+
+			if data.IkePolicy != nil {
+				gatewayconnection[isVPNGatewayConnectionIKEPolicy] = *data.IkePolicy.ID
+			}
+			if data.IpsecPolicy != nil {
+				gatewayconnection[isVPNGatewayConnectionIPSECPolicy] = *data.IpsecPolicy.ID
+			}
+			gatewayconnection[isVPNGatewayConnectionMode] = *data.Mode
+			gatewayconnection[isVPNGatewayConnectionName] = *data.Name
+			gatewayconnection[isVPNGatewayConnectionPeerAddress] = *data.PeerAddress
+			gatewayconnection[isVPNGatewayConnectionResourcetype] = *data.ResourceType
+			gatewayconnection[isVPNGatewayConnectionStatus] = *data.Status
+			gatewayconnection[isVPNGatewayConnectionStatusreasons] = resourceVPNGatewayConnectionFlattenLifecycleReasons(data.StatusReasons)
+			//if data.Tunnels != nil {
+			if len(data.Tunnels) > 0 {
+				vpcTunnelsList := make([]map[string]interface{}, 0)
+				for _, vpcTunnel := range data.Tunnels {
+					currentTunnel := map[string]interface{}{}
+					if vpcTunnel.PublicIP != nil {
+						if vpcTunnel.PublicIP != nil {
+							currentTunnel["address"] = *vpcTunnel.PublicIP.Address
+						}
+						if vpcTunnel.Status != nil {
+							currentTunnel["status"] = *vpcTunnel.Status
+						}
+						vpcTunnelsList = append(vpcTunnelsList, currentTunnel)
+					}
+				}
+				gatewayconnection[isVPNGatewayConnectionTunnels] = vpcTunnelsList
+			}
+		} else if _, ok := vpnGatewayConnectionIntf.(*vpcv1.VPNGatewayConnectionRouteModeVPNGatewayConnectionStaticRouteMode); ok {
+			data := vpnGatewayConnectionIntf.(*vpcv1.VPNGatewayConnectionRouteModeVPNGatewayConnectionStaticRouteMode)
+			gatewayconnection[isVPNGatewayConnectionAdminAuthenticationmode] = *data.AuthenticationMode
+			gatewayconnection[isVPNGatewayConnectionCreatedat] = data.CreatedAt.String()
+			gatewayconnection[isVPNGatewayConnectionAdminStateup] = *data.AdminStateUp
+			gatewayconnection[isVPNGatewayConnectionDeadPeerDetectionAction] = *data.DeadPeerDetection.Action
+			gatewayconnection[isVPNGatewayConnectionDeadPeerDetectionInterval] = *data.DeadPeerDetection.Interval
+			gatewayconnection[isVPNGatewayConnectionDeadPeerDetectionTimeout] = *data.DeadPeerDetection.Timeout
+			gatewayconnection[isVPNGatewayConnectionID] = *data.ID
+
+			if data.IkePolicy != nil {
+				gatewayconnection[isVPNGatewayConnectionIKEPolicy] = *data.IkePolicy.ID
+			}
+			if data.IpsecPolicy != nil {
+				gatewayconnection[isVPNGatewayConnectionIPSECPolicy] = *data.IpsecPolicy.ID
+			}
+			gatewayconnection[isVPNGatewayConnectionMode] = *data.Mode
+			gatewayconnection[isVPNGatewayConnectionName] = *data.Name
+			gatewayconnection[isVPNGatewayConnectionPeerAddress] = *data.PeerAddress
+			gatewayconnection[isVPNGatewayConnectionResourcetype] = *data.ResourceType
+			gatewayconnection[isVPNGatewayConnectionStatus] = *data.Status
+			gatewayconnection[isVPNGatewayConnectionStatusreasons] = resourceVPNGatewayConnectionFlattenLifecycleReasons(data.StatusReasons)
+			//if data.Tunnels != nil {
+			if len(data.Tunnels) > 0 {
+				vpcTunnelsList := make([]map[string]interface{}, 0)
+				for _, vpcTunnel := range data.Tunnels {
+					currentTunnel := map[string]interface{}{}
+					if vpcTunnel.PublicIP != nil {
+						if vpcTunnel.PublicIP != nil {
+							currentTunnel["address"] = *vpcTunnel.PublicIP.Address
+						}
+						if vpcTunnel.Status != nil {
+							currentTunnel["status"] = *vpcTunnel.Status
+						}
+						vpcTunnelsList = append(vpcTunnelsList, currentTunnel)
+					}
+				}
+				gatewayconnection[isVPNGatewayConnectionTunnels] = vpcTunnelsList
+			}
+		} else if _, ok := vpnGatewayConnectionIntf.(*vpcv1.VPNGatewayConnection); ok {
+			data := vpnGatewayConnectionIntf.(*vpcv1.VPNGatewayConnection)
+			gatewayconnection[isVPNGatewayConnectionAdminAuthenticationmode] = *data.AuthenticationMode
+			gatewayconnection[isVPNGatewayConnectionCreatedat] = data.CreatedAt.String()
+			gatewayconnection[isVPNGatewayConnectionAdminStateup] = *data.AdminStateUp
+			gatewayconnection[isVPNGatewayConnectionDeadPeerDetectionAction] = *data.DeadPeerDetection.Action
+			gatewayconnection[isVPNGatewayConnectionDeadPeerDetectionInterval] = *data.DeadPeerDetection.Interval
+			gatewayconnection[isVPNGatewayConnectionDeadPeerDetectionTimeout] = *data.DeadPeerDetection.Timeout
+			gatewayconnection[isVPNGatewayConnectionID] = *data.ID
+
+			if data.IkePolicy != nil {
+				gatewayconnection[isVPNGatewayConnectionIKEPolicy] = *data.IkePolicy.ID
+			}
+			if data.IpsecPolicy != nil {
+				gatewayconnection[isVPNGatewayConnectionIPSECPolicy] = *data.IpsecPolicy.ID
+			}
+			if data.LocalCIDRs != nil {
+				gatewayconnection[isVPNGatewayConnectionLocalCIDRS] = flex.FlattenStringList(data.LocalCIDRs)
+			}
+			if data.PeerCIDRs != nil {
+				gatewayconnection[isVPNGatewayConnectionPeerCIDRS] = flex.FlattenStringList(data.PeerCIDRs)
+			}
+			gatewayconnection[isVPNGatewayConnectionMode] = *data.Mode
+			gatewayconnection[isVPNGatewayConnectionName] = *data.Name
+			gatewayconnection[isVPNGatewayConnectionPeerAddress] = *data.PeerAddress
+			gatewayconnection[isVPNGatewayConnectionResourcetype] = *data.ResourceType
+			gatewayconnection[isVPNGatewayConnectionStatus] = *data.Status
+			gatewayconnection[isVPNGatewayConnectionStatusreasons] = resourceVPNGatewayConnectionFlattenLifecycleReasons(data.StatusReasons)
+			//if data.Tunnels != nil {
+			if len(data.Tunnels) > 0 {
+				vpcTunnelsList := make([]map[string]interface{}, 0)
+				for _, vpcTunnel := range data.Tunnels {
+					currentTunnel := map[string]interface{}{}
+					if vpcTunnel.PublicIP != nil {
+						if vpcTunnel.PublicIP != nil {
+							currentTunnel["address"] = *vpcTunnel.PublicIP.Address
+						}
+						if vpcTunnel.Status != nil {
+							currentTunnel["status"] = *vpcTunnel.Status
+						}
+						vpcTunnelsList = append(vpcTunnelsList, currentTunnel)
+					}
+				}
+				gatewayconnection[isVPNGatewayConnectionTunnels] = vpcTunnelsList
+			}
+		} else {
+			return fmt.Errorf("[ERROR] Unrecognized vpcv1.vpnGatewayConnectionIntf subtype encountered")
 		}
 
 		vpngatewayconnections = append(vpngatewayconnections, gatewayconnection)

--- a/ibm/service/vpc/data_source_ibm_is_vpn_gateway_connections_test.go
+++ b/ibm/service/vpc/data_source_ibm_is_vpn_gateway_connections_test.go
@@ -41,7 +41,7 @@ func testAccCheckIBMISVpnGatewayconnectionsDataSourceConfig(vpc, subnet, vpngwna
 	return fmt.Sprintf(`
 	
 	data "ibm_resource_group" "rg" {
-		name = "Proof of Concepts"
+		is_default = true
 	}
 	resource "ibm_is_vpc" "testacc_vpc" {
 		name = "%s"

--- a/ibm/service/vpc/resource_ibm_is_snapshot_consistency_group.go
+++ b/ibm/service/vpc/resource_ibm_is_snapshot_consistency_group.go
@@ -316,11 +316,11 @@ func resourceIBMIsSnapshotConsistencyGroupCreate(context context.Context, d *sch
 			ID: &rg,
 		}
 	}
-	var snapshotConsistencyGroupPrototypeSnapshotsItemArray []vpcv1.SnapshotConsistencyGroupPrototypeSnapshotsItem
+	var snapshotConsistencyGroupPrototypeSnapshotsItemArray []vpcv1.SnapshotPrototypeSnapshotConsistencyGroupContext
 	snapshotsArray := d.Get("snapshots").([]interface{})
 	for _, snapshot := range snapshotsArray {
 		snapshotVal := snapshot.(map[string]interface{})
-		snapshotConsistencyGroupPrototypeSnapshotsItem := &vpcv1.SnapshotConsistencyGroupPrototypeSnapshotsItem{}
+		snapshotConsistencyGroupPrototypeSnapshotsItem := &vpcv1.SnapshotPrototypeSnapshotConsistencyGroupContext{}
 
 		volume := snapshotVal["source_volume"].(string)
 		snapshotConsistencyGroupPrototypeSnapshotsItem.SourceVolume = &vpcv1.VolumeIdentity{
@@ -714,7 +714,7 @@ func resourceIBMIsSnapshotConsistencyGroupResourceGroupReferenceToMap(model *vpc
 	return modelMap, nil
 }
 
-func resourceIBMIsSnapshotConsistencyGroupSnapshotConsistencyGroupSnapshotsItemToMap(model *vpcv1.SnapshotConsistencyGroupSnapshotsItem) (map[string]interface{}, error) {
+func resourceIBMIsSnapshotConsistencyGroupSnapshotConsistencyGroupSnapshotsItemToMap(model *vpcv1.SnapshotReference) (map[string]interface{}, error) {
 	modelMap := make(map[string]interface{})
 	modelMap["crn"] = model.CRN
 	if model.Deleted != nil {

--- a/ibm/service/vpc/resource_ibm_is_snapshot_consistency_group_test.go
+++ b/ibm/service/vpc/resource_ibm_is_snapshot_consistency_group_test.go
@@ -108,7 +108,7 @@ func testAccCheckIBMIsSnapshotConsistencyGroupConfig(vpcname, subnetname, sshnam
 		}
 		name = "%s"
 	  }
-	`, vpcname, subnetname, acc.ISZoneName, sshname, publicKey, name, "r134-f47cc24c-e020-4db5-ad96-1e5be8b5853b", acc.InstanceProfileName, acc.ISZoneName, deleteSnapshotsOnDelete, scgname, snapname)
+	`, vpcname, subnetname, acc.ISZoneName, sshname, publicKey, name, acc.IsImage, acc.InstanceProfileName, acc.ISZoneName, deleteSnapshotsOnDelete, scgname, snapname)
 }
 
 func testAccCheckIBMIsSnapshotConsistencyGroupExists(n string, obj vpcv1.SnapshotConsistencyGroup) resource.TestCheckFunc {

--- a/ibm/service/vpc/resource_ibm_is_vpn_gateway_connections.go
+++ b/ibm/service/vpc/resource_ibm_is_vpn_gateway_connections.go
@@ -363,9 +363,26 @@ func vpngwconCreate(d *schema.ResourceData, meta interface{}, name, gatewayID, p
 	if err != nil {
 		return fmt.Errorf("[DEBUG] Create VPN Gateway Connection err %s\n%s", err, response)
 	}
-	vpnGatewayConnection := vpnGatewayConnectionIntf.(*vpcv1.VPNGatewayConnection)
-	d.SetId(fmt.Sprintf("%s/%s", gatewayID, *vpnGatewayConnection.ID))
-	log.Printf("[INFO] VPNGatewayConnection : %s/%s", gatewayID, *vpnGatewayConnection.ID)
+
+	if _, ok := vpnGatewayConnectionIntf.(*vpcv1.VPNGatewayConnectionPolicyMode); ok {
+		vpnGatewayConnection := vpnGatewayConnectionIntf.(*vpcv1.VPNGatewayConnectionPolicyMode)
+		log.Printf("[INFO] VPNGatewayConnection : %s/%s", gatewayID, *vpnGatewayConnection.ID)
+		d.SetId(fmt.Sprintf("%s/%s", gatewayID, *vpnGatewayConnection.ID))
+	} else if _, ok := vpnGatewayConnectionIntf.(*vpcv1.VPNGatewayConnectionRouteMode); ok {
+		vpnGatewayConnection := vpnGatewayConnectionIntf.(*vpcv1.VPNGatewayConnectionRouteMode)
+		log.Printf("[INFO] VPNGatewayConnection : %s/%s", gatewayID, *vpnGatewayConnection.ID)
+		d.SetId(fmt.Sprintf("%s/%s", gatewayID, *vpnGatewayConnection.ID))
+	} else if _, ok := vpnGatewayConnectionIntf.(*vpcv1.VPNGatewayConnectionRouteModeVPNGatewayConnectionStaticRouteMode); ok {
+		vpnGatewayConnection := vpnGatewayConnectionIntf.(*vpcv1.VPNGatewayConnectionRouteModeVPNGatewayConnectionStaticRouteMode)
+		log.Printf("[INFO] VPNGatewayConnection : %s/%s", gatewayID, *vpnGatewayConnection.ID)
+		d.SetId(fmt.Sprintf("%s/%s", gatewayID, *vpnGatewayConnection.ID))
+	} else if _, ok := vpnGatewayConnectionIntf.(*vpcv1.VPNGatewayConnection); ok {
+		vpnGatewayConnection := vpnGatewayConnectionIntf.(*vpcv1.VPNGatewayConnection)
+		log.Printf("[INFO] VPNGatewayConnection : %s/%s", gatewayID, *vpnGatewayConnection.ID)
+		d.SetId(fmt.Sprintf("%s/%s", gatewayID, *vpnGatewayConnection.ID))
+	} else {
+		return fmt.Errorf("[ERROR] Unrecognized vpcv1.vpnGatewayConnectionIntf subtype encountered")
+	}
 	return nil
 }
 
@@ -404,63 +421,216 @@ func vpngwconGet(d *schema.ResourceData, meta interface{}, gID, gConnID string) 
 		return fmt.Errorf("[ERROR] Error Getting Vpn Gateway Connection (%s): %s\n%s", gConnID, err, response)
 	}
 	d.Set(isVPNGatewayConnection, gConnID)
-	vpnGatewayConnection := vpnGatewayConnectionIntf.(*vpcv1.VPNGatewayConnection)
-	d.Set(isVPNGatewayConnectionName, *vpnGatewayConnection.Name)
 	d.Set(isVPNGatewayConnectionVPNGateway, gID)
-	d.Set(isVPNGatewayConnectionAdminStateup, *vpnGatewayConnection.AdminStateUp)
-	d.Set(isVPNGatewayConnectionPeerAddress, *vpnGatewayConnection.PeerAddress)
-	d.Set(isVPNGatewayConnectionPreSharedKey, *vpnGatewayConnection.Psk)
 
-	if vpnGatewayConnection.LocalCIDRs != nil {
-		d.Set(isVPNGatewayConnectionLocalCIDRS, flex.FlattenStringList(vpnGatewayConnection.LocalCIDRs))
-	}
-	if vpnGatewayConnection.PeerCIDRs != nil {
-		d.Set(isVPNGatewayConnectionPeerCIDRS, flex.FlattenStringList(vpnGatewayConnection.PeerCIDRs))
-	}
-	if vpnGatewayConnection.IkePolicy != nil {
-		d.Set(isVPNGatewayConnectionIKEPolicy, *vpnGatewayConnection.IkePolicy.ID)
-	}
-	if vpnGatewayConnection.IpsecPolicy != nil {
-		d.Set(isVPNGatewayConnectionIPSECPolicy, *vpnGatewayConnection.IpsecPolicy.ID)
-	}
-	if vpnGatewayConnection.AuthenticationMode != nil {
-		d.Set(isVPNGatewayConnectionAdminAuthenticationmode, *vpnGatewayConnection.AuthenticationMode)
-	}
-	if vpnGatewayConnection.Status != nil {
-		d.Set(isVPNGatewayConnectionStatus, *vpnGatewayConnection.Status)
-	}
-	if err := d.Set(isVPNGatewayConnectionStatusreasons, resourceVPNGatewayConnectionFlattenLifecycleReasons(vpnGatewayConnection.StatusReasons)); err != nil {
-		return fmt.Errorf("[ERROR] Error setting status_reasons: %s", err)
-	}
-	if vpnGatewayConnection.ResourceType != nil {
-		d.Set(isVPNGatewayConnectionResourcetype, *vpnGatewayConnection.ResourceType)
-	}
-	if vpnGatewayConnection.CreatedAt != nil {
-		d.Set(isVPNGatewayConnectionCreatedat, vpnGatewayConnection.CreatedAt.String())
-	}
+	if _, ok := vpnGatewayConnectionIntf.(*vpcv1.VPNGatewayConnectionPolicyMode); ok {
+		vpnGatewayConnection := vpnGatewayConnectionIntf.(*vpcv1.VPNGatewayConnectionPolicyMode)
 
-	if vpnGatewayConnection.Mode != nil {
-		d.Set(isVPNGatewayConnectionMode, *vpnGatewayConnection.Mode)
-	}
-	vpcTunnelsList := make([]map[string]interface{}, 0)
-	if vpnGatewayConnection.Tunnels != nil {
-		for _, vpcTunnel := range vpnGatewayConnection.Tunnels {
-			currentTunnel := map[string]interface{}{}
-			if vpcTunnel.PublicIP != nil {
-				publicIP := *vpcTunnel.PublicIP
-				currentTunnel["address"] = *publicIP.Address
-			}
-			if vpcTunnel.Status != nil {
-				currentTunnel["status"] = *vpcTunnel.Status
-			}
-			vpcTunnelsList = append(vpcTunnelsList, currentTunnel)
+		d.Set(isVPNGatewayConnectionName, *vpnGatewayConnection.Name)
+		d.Set(isVPNGatewayConnectionAdminStateup, *vpnGatewayConnection.AdminStateUp)
+		d.Set(isVPNGatewayConnectionPeerAddress, *vpnGatewayConnection.PeerAddress)
+		d.Set(isVPNGatewayConnectionPreSharedKey, *vpnGatewayConnection.Psk)
+		if vpnGatewayConnection.LocalCIDRs != nil {
+			d.Set(isVPNGatewayConnectionLocalCIDRS, flex.FlattenStringList(vpnGatewayConnection.LocalCIDRs))
 		}
-	}
-	d.Set(isVPNGatewayConnectionTunnels, vpcTunnelsList)
+		if vpnGatewayConnection.PeerCIDRs != nil {
+			d.Set(isVPNGatewayConnectionPeerCIDRS, flex.FlattenStringList(vpnGatewayConnection.PeerCIDRs))
+		}
+		if vpnGatewayConnection.IkePolicy != nil {
+			d.Set(isVPNGatewayConnectionIKEPolicy, *vpnGatewayConnection.IkePolicy.ID)
+		}
+		if vpnGatewayConnection.IpsecPolicy != nil {
+			d.Set(isVPNGatewayConnectionIPSECPolicy, *vpnGatewayConnection.IpsecPolicy.ID)
+		}
+		if vpnGatewayConnection.AuthenticationMode != nil {
+			d.Set(isVPNGatewayConnectionAdminAuthenticationmode, *vpnGatewayConnection.AuthenticationMode)
+		}
+		if vpnGatewayConnection.Status != nil {
+			d.Set(isVPNGatewayConnectionStatus, *vpnGatewayConnection.Status)
+		}
+		if err := d.Set(isVPNGatewayConnectionStatusreasons, resourceVPNGatewayConnectionFlattenLifecycleReasons(vpnGatewayConnection.StatusReasons)); err != nil {
+			return fmt.Errorf("[ERROR] Error setting status_reasons: %s", err)
+		}
 
-	d.Set(isVPNGatewayConnectionDeadPeerDetectionAction, *vpnGatewayConnection.DeadPeerDetection.Action)
-	d.Set(isVPNGatewayConnectionDeadPeerDetectionInterval, *vpnGatewayConnection.DeadPeerDetection.Interval)
-	d.Set(isVPNGatewayConnectionDeadPeerDetectionTimeout, *vpnGatewayConnection.DeadPeerDetection.Timeout)
+		if vpnGatewayConnection.ResourceType != nil {
+			d.Set(isVPNGatewayConnectionResourcetype, *vpnGatewayConnection.ResourceType)
+		}
+		if vpnGatewayConnection.CreatedAt != nil {
+			d.Set(isVPNGatewayConnectionCreatedat, vpnGatewayConnection.CreatedAt.String())
+		}
+
+		if vpnGatewayConnection.Mode != nil {
+			d.Set(isVPNGatewayConnectionMode, *vpnGatewayConnection.Mode)
+		}
+		vpcTunnelsList := make([]map[string]interface{}, 0)
+		d.Set(isVPNGatewayConnectionTunnels, vpcTunnelsList)
+		d.Set(isVPNGatewayConnectionDeadPeerDetectionAction, *vpnGatewayConnection.DeadPeerDetection.Action)
+		d.Set(isVPNGatewayConnectionDeadPeerDetectionInterval, *vpnGatewayConnection.DeadPeerDetection.Interval)
+		d.Set(isVPNGatewayConnectionDeadPeerDetectionTimeout, *vpnGatewayConnection.DeadPeerDetection.Timeout)
+
+	} else if _, ok := vpnGatewayConnectionIntf.(*vpcv1.VPNGatewayConnectionRouteMode); ok {
+		vpnGatewayConnection := vpnGatewayConnectionIntf.(*vpcv1.VPNGatewayConnectionRouteMode)
+		d.Set(isVPNGatewayConnectionName, *vpnGatewayConnection.Name)
+		d.Set(isVPNGatewayConnectionAdminStateup, *vpnGatewayConnection.AdminStateUp)
+		d.Set(isVPNGatewayConnectionPeerAddress, *vpnGatewayConnection.PeerAddress)
+		d.Set(isVPNGatewayConnectionPreSharedKey, *vpnGatewayConnection.Psk)
+		if vpnGatewayConnection.IkePolicy != nil {
+			d.Set(isVPNGatewayConnectionIKEPolicy, *vpnGatewayConnection.IkePolicy.ID)
+		}
+		if vpnGatewayConnection.IpsecPolicy != nil {
+			d.Set(isVPNGatewayConnectionIPSECPolicy, *vpnGatewayConnection.IpsecPolicy.ID)
+		}
+		if vpnGatewayConnection.AuthenticationMode != nil {
+			d.Set(isVPNGatewayConnectionAdminAuthenticationmode, *vpnGatewayConnection.AuthenticationMode)
+		}
+		if vpnGatewayConnection.Status != nil {
+			d.Set(isVPNGatewayConnectionStatus, *vpnGatewayConnection.Status)
+		}
+		if err := d.Set(isVPNGatewayConnectionStatusreasons, resourceVPNGatewayConnectionFlattenLifecycleReasons(vpnGatewayConnection.StatusReasons)); err != nil {
+			return fmt.Errorf("[ERROR] Error setting status_reasons: %s", err)
+		}
+
+		if vpnGatewayConnection.ResourceType != nil {
+			d.Set(isVPNGatewayConnectionResourcetype, *vpnGatewayConnection.ResourceType)
+		}
+		if vpnGatewayConnection.CreatedAt != nil {
+			d.Set(isVPNGatewayConnectionCreatedat, vpnGatewayConnection.CreatedAt.String())
+		}
+
+		if vpnGatewayConnection.Mode != nil {
+			d.Set(isVPNGatewayConnectionMode, *vpnGatewayConnection.Mode)
+		}
+		vpcTunnelsList := make([]map[string]interface{}, 0)
+		if vpnGatewayConnection.Tunnels != nil {
+			for _, vpcTunnel := range vpnGatewayConnection.Tunnels {
+				currentTunnel := map[string]interface{}{}
+				if vpcTunnel.PublicIP != nil {
+					publicIP := *vpcTunnel.PublicIP
+					currentTunnel["address"] = *publicIP.Address
+				}
+				if vpcTunnel.Status != nil {
+					currentTunnel["status"] = *vpcTunnel.Status
+				}
+				vpcTunnelsList = append(vpcTunnelsList, currentTunnel)
+			}
+		}
+		d.Set(isVPNGatewayConnectionTunnels, vpcTunnelsList)
+		d.Set(isVPNGatewayConnectionDeadPeerDetectionAction, *vpnGatewayConnection.DeadPeerDetection.Action)
+		d.Set(isVPNGatewayConnectionDeadPeerDetectionInterval, *vpnGatewayConnection.DeadPeerDetection.Interval)
+		d.Set(isVPNGatewayConnectionDeadPeerDetectionTimeout, *vpnGatewayConnection.DeadPeerDetection.Timeout)
+
+	} else if _, ok := vpnGatewayConnectionIntf.(*vpcv1.VPNGatewayConnectionRouteModeVPNGatewayConnectionStaticRouteMode); ok {
+		vpnGatewayConnection := vpnGatewayConnectionIntf.(*vpcv1.VPNGatewayConnectionRouteModeVPNGatewayConnectionStaticRouteMode)
+		d.Set(isVPNGatewayConnectionName, *vpnGatewayConnection.Name)
+		d.Set(isVPNGatewayConnectionAdminStateup, *vpnGatewayConnection.AdminStateUp)
+		d.Set(isVPNGatewayConnectionPeerAddress, *vpnGatewayConnection.PeerAddress)
+		d.Set(isVPNGatewayConnectionPreSharedKey, *vpnGatewayConnection.Psk)
+		if vpnGatewayConnection.IkePolicy != nil {
+			d.Set(isVPNGatewayConnectionIKEPolicy, *vpnGatewayConnection.IkePolicy.ID)
+		}
+		if vpnGatewayConnection.IpsecPolicy != nil {
+			d.Set(isVPNGatewayConnectionIPSECPolicy, *vpnGatewayConnection.IpsecPolicy.ID)
+		}
+		if vpnGatewayConnection.AuthenticationMode != nil {
+			d.Set(isVPNGatewayConnectionAdminAuthenticationmode, *vpnGatewayConnection.AuthenticationMode)
+		}
+		if vpnGatewayConnection.Status != nil {
+			d.Set(isVPNGatewayConnectionStatus, *vpnGatewayConnection.Status)
+		}
+		if err := d.Set(isVPNGatewayConnectionStatusreasons, resourceVPNGatewayConnectionFlattenLifecycleReasons(vpnGatewayConnection.StatusReasons)); err != nil {
+			return fmt.Errorf("[ERROR] Error setting status_reasons: %s", err)
+		}
+
+		if vpnGatewayConnection.ResourceType != nil {
+			d.Set(isVPNGatewayConnectionResourcetype, *vpnGatewayConnection.ResourceType)
+		}
+		if vpnGatewayConnection.CreatedAt != nil {
+			d.Set(isVPNGatewayConnectionCreatedat, vpnGatewayConnection.CreatedAt.String())
+		}
+
+		if vpnGatewayConnection.Mode != nil {
+			d.Set(isVPNGatewayConnectionMode, *vpnGatewayConnection.Mode)
+		}
+		vpcTunnelsList := make([]map[string]interface{}, 0)
+		if vpnGatewayConnection.Tunnels != nil {
+			for _, vpcTunnel := range vpnGatewayConnection.Tunnels {
+				currentTunnel := map[string]interface{}{}
+				if vpcTunnel.PublicIP != nil {
+					publicIP := *vpcTunnel.PublicIP
+					currentTunnel["address"] = *publicIP.Address
+				}
+				if vpcTunnel.Status != nil {
+					currentTunnel["status"] = *vpcTunnel.Status
+				}
+				vpcTunnelsList = append(vpcTunnelsList, currentTunnel)
+			}
+		}
+		d.Set(isVPNGatewayConnectionTunnels, vpcTunnelsList)
+		d.Set(isVPNGatewayConnectionDeadPeerDetectionAction, *vpnGatewayConnection.DeadPeerDetection.Action)
+		d.Set(isVPNGatewayConnectionDeadPeerDetectionInterval, *vpnGatewayConnection.DeadPeerDetection.Interval)
+		d.Set(isVPNGatewayConnectionDeadPeerDetectionTimeout, *vpnGatewayConnection.DeadPeerDetection.Timeout)
+
+	} else if _, ok := vpnGatewayConnectionIntf.(*vpcv1.VPNGatewayConnection); ok {
+		vpnGatewayConnection := vpnGatewayConnectionIntf.(*vpcv1.VPNGatewayConnection)
+		d.Set(isVPNGatewayConnectionName, *vpnGatewayConnection.Name)
+		d.Set(isVPNGatewayConnectionAdminStateup, *vpnGatewayConnection.AdminStateUp)
+		d.Set(isVPNGatewayConnectionPeerAddress, *vpnGatewayConnection.PeerAddress)
+		d.Set(isVPNGatewayConnectionPreSharedKey, *vpnGatewayConnection.Psk)
+		if vpnGatewayConnection.LocalCIDRs != nil {
+			d.Set(isVPNGatewayConnectionLocalCIDRS, flex.FlattenStringList(vpnGatewayConnection.LocalCIDRs))
+		}
+		if vpnGatewayConnection.PeerCIDRs != nil {
+			d.Set(isVPNGatewayConnectionPeerCIDRS, flex.FlattenStringList(vpnGatewayConnection.PeerCIDRs))
+		}
+		if vpnGatewayConnection.IkePolicy != nil {
+			d.Set(isVPNGatewayConnectionIKEPolicy, *vpnGatewayConnection.IkePolicy.ID)
+		}
+		if vpnGatewayConnection.IpsecPolicy != nil {
+			d.Set(isVPNGatewayConnectionIPSECPolicy, *vpnGatewayConnection.IpsecPolicy.ID)
+		}
+		if vpnGatewayConnection.AuthenticationMode != nil {
+			d.Set(isVPNGatewayConnectionAdminAuthenticationmode, *vpnGatewayConnection.AuthenticationMode)
+		}
+		if vpnGatewayConnection.Status != nil {
+			d.Set(isVPNGatewayConnectionStatus, *vpnGatewayConnection.Status)
+		}
+		if err := d.Set(isVPNGatewayConnectionStatusreasons, resourceVPNGatewayConnectionFlattenLifecycleReasons(vpnGatewayConnection.StatusReasons)); err != nil {
+			return fmt.Errorf("[ERROR] Error setting status_reasons: %s", err)
+		}
+
+		if vpnGatewayConnection.ResourceType != nil {
+			d.Set(isVPNGatewayConnectionResourcetype, *vpnGatewayConnection.ResourceType)
+		}
+		if vpnGatewayConnection.CreatedAt != nil {
+			d.Set(isVPNGatewayConnectionCreatedat, vpnGatewayConnection.CreatedAt.String())
+		}
+
+		if vpnGatewayConnection.Mode != nil {
+			d.Set(isVPNGatewayConnectionMode, *vpnGatewayConnection.Mode)
+		}
+		vpcTunnelsList := make([]map[string]interface{}, 0)
+		if vpnGatewayConnection.Tunnels != nil {
+			for _, vpcTunnel := range vpnGatewayConnection.Tunnels {
+				currentTunnel := map[string]interface{}{}
+				if vpcTunnel.PublicIP != nil {
+					publicIP := *vpcTunnel.PublicIP
+					currentTunnel["address"] = *publicIP.Address
+				}
+				if vpcTunnel.Status != nil {
+					currentTunnel["status"] = *vpcTunnel.Status
+				}
+				vpcTunnelsList = append(vpcTunnelsList, currentTunnel)
+			}
+		}
+		d.Set(isVPNGatewayConnectionTunnels, vpcTunnelsList)
+		d.Set(isVPNGatewayConnectionDeadPeerDetectionAction, *vpnGatewayConnection.DeadPeerDetection.Action)
+		d.Set(isVPNGatewayConnectionDeadPeerDetectionInterval, *vpnGatewayConnection.DeadPeerDetection.Interval)
+		d.Set(isVPNGatewayConnectionDeadPeerDetectionTimeout, *vpnGatewayConnection.DeadPeerDetection.Timeout)
+
+	} else {
+		return fmt.Errorf("[ERROR] Unrecognized vpcv1.vpnGatewayConnectionIntf subtype encountered")
+	}
+
 	getVPNGatewayOptions := &vpcv1.GetVPNGatewayOptions{
 		ID: &gID,
 	}


### PR DESCRIPTION

### Community Note


Breaking changes from sdk:

- ibm/service/vpc/data_source_ibm_is_snapshot_consistency_group.go name changed in vpc-go-sdk
- ibm/service/vpc/resource_ibm_is_snapshot_consistency_group.go same as above
- ibm/service/vpc/resource_ibm_is_snapshot_consistency_group_test.go test file changes
- ibm/service/vpc/resource_ibm_is_vpn_gateway_connections.go, ibm/service/vpc/resource_ibm_is_vpn_gateway_connection_test.go added logic and test cases for converting based on the type 

```
vpnGatewayConnection := vpnGatewayConnectionIntf.(*vpcv1.VPNGatewayConnection)
```
- ibm/service/vpc/data_source_ibm_is_vpn_gateway_connections.go added logic for converting based on the type 

```
vpnGatewayConnection := vpnGatewayConnectionIntf.(*vpcv1.VPNGatewayConnection)
```


- ibm/service/vpc/data_source_ibm_is_vpn_gateway_connection.goadded logic for converting based on the type 

```
vpnGatewayConnection := vpnGatewayConnectionIntf.(*vpcv1.VPNGatewayConnection)
```



```
$ make testacc TEST=./ibm/service/vpc TESTARGS='-run=TestAccIBMISVPNGatewayConnection_multiple'
=== RUN   TestAccIBMISVPNGatewayConnection_multiple
--- PASS: TestAccIBMISVPNGatewayConnection_multiple (488.40s)
PASS
ok      github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/vpc     490.947s
```
```
$ make testacc TEST=./ibm/service/vpc TESTARGS='-run=TestAccIBMIsVPNGatewayConnectionDataSourceBasic
=== RUN   TestAccIBMIsVPNGatewayConnectionDataSourceBasic
--- PASS: TestAccIBMIsVPNGatewayConnectionDataSourceBasic (690.06s)
PASS
ok      github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/vpc     692.420s
```
```
$ make testacc TEST=./ibm/service/vpc TESTARGS='-run=TestAccIBMISVpnGatewayConnectionsDataSource_basic'
=== RUN   TestAccIBMISVpnGatewayConnectionsDataSource_basic
--- PASS: TestAccIBMISVpnGatewayConnectionsDataSource_basic (619.97s)
PASS
ok      github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/vpc     622.261s
```
```
$ make testacc TEST=./ibm/service/vpc TESTARGS='-run=TestAccIBMIsSnapshotConsistencyGroupBasic'
=== RUN   TestAccIBMIsSnapshotConsistencyGroupBasic
--- PASS: TestAccIBMIsSnapshotConsistencyGroupBasic (335.21s)
PASS
ok      github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/vpc     337.432s
```
```
$ make testacc TEST=./ibm/service/vpc TESTARGS='-run=TestAccIBMIsSnapshotConsistencyGroupDataSourceBasic'
=== RUN   TestAccIBMIsSnapshotConsistencyGroupDataSourceBasic
--- PASS: TestAccIBMIsSnapshotConsistencyGroupDataSourceBasic (232.78s)
PASS
ok      github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/vpc     234.408s
```
```
$ make testacc TEST=./ibm/service/vpc TESTARGS='-run=TestAccIBMIsSnapshotConsistencyGroupsDataSourceBasic'
=== RUN   TestAccIBMIsSnapshotConsistencyGroupsDataSourceBasic
--- PASS: TestAccIBMIsSnapshotConsistencyGroupsDataSourceBasic (267.60s)
PASS
ok      github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/vpc     269.245s
```