### PR TITLE
fix(flex): add Stringify function and tests

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -65,6 +65,7 @@ require (
 	github.com/IBM/go-sdk-core v1.1.0
 	github.com/IBM/mqcloud-go-sdk v0.0.4
 	github.com/IBM/sarama v1.41.2
+	github.com/stretchr/testify v1.9.0
 	k8s.io/utils v0.0.0-20230313181309-38a27ef9d749
 	sigs.k8s.io/controller-runtime v0.14.1
 )
@@ -198,7 +199,6 @@ require (
 	github.com/softlayer/xmlrpc v0.0.0-20200409220501-5f089df7cb7e // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/stretchr/objx v0.5.2 // indirect
-	github.com/stretchr/testify v1.9.0 // indirect
 	github.com/vmihailenco/msgpack v4.0.4+incompatible // indirect
 	github.com/vmihailenco/msgpack/v5 v5.3.5 // indirect
 	github.com/vmihailenco/tagparser/v2 v2.0.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -116,8 +116,6 @@ github.com/IBM/appconfiguration-go-admin-sdk v0.3.0 h1:OqFxnDxro0JiRwHBKytCcseY2
 github.com/IBM/appconfiguration-go-admin-sdk v0.3.0/go.mod h1:xPxAYhr/uywUIDEo/JqWbkUdTryPdzRdYBfUpA5IjoE=
 github.com/IBM/appid-management-go-sdk v0.0.0-20210908164609-dd0e0eaf732f h1:4c1kqY4GqmkQ+tO03rneDb74Tv7BhTj8jDiDB1p8mdM=
 github.com/IBM/appid-management-go-sdk v0.0.0-20210908164609-dd0e0eaf732f/go.mod h1:d22kTYY7RYBWcQlZpqrSdshpB/lJ16viWS5Sbjtlc8s=
-github.com/IBM/cloud-databases-go-sdk v0.5.0 h1:Bie6MnT1jLchQmtKVA20HHETTPdlOR+i11P2kJ55viM=
-github.com/IBM/cloud-databases-go-sdk v0.5.0/go.mod h1:nCIVfeZnhBYIiwByT959dFP4VWUeNLxomDYy63tTC6M=
 github.com/IBM/cloud-databases-go-sdk v0.6.0 h1:QK3eif7+kusgeuMB54Zw5nco/kDwsDg2sD/84/foDxo=
 github.com/IBM/cloud-databases-go-sdk v0.6.0/go.mod h1:nCIVfeZnhBYIiwByT959dFP4VWUeNLxomDYy63tTC6M=
 github.com/IBM/cloudant-go-sdk v0.0.43 h1:YxTy4RpAEezX32YIWnds76hrBREmO4u6IkBz1WylNuQ=
@@ -1489,6 +1487,7 @@ github.com/stretchr/testify v1.7.2/go.mod h1:R6va5+xMeoiuVRoj+gSkQ7d3FALtqAAGI1F
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
 github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
 github.com/stretchr/testify v1.8.2/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
+github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
 github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsTg=
 github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 github.com/subosito/gotenv v1.2.0/go.mod h1:N0PQaV/YGNqwC0u51sEeR/aUtSLEXKX9iv69rRypqCw=

--- a/ibm/flex/structures.go
+++ b/ibm/flex/structures.go
@@ -4327,3 +4327,27 @@ func Listdifference(a, b []string) []string {
 	}
 	return ab
 }
+
+// Stringify returns the stringified form of value "v".
+// If "v" is a string-based type (string, strfmt.Date, strfmt.DateTime, strfmt.UUID, etc.),
+// then it is returned unchanged (e.g. `this is a string`, `foo`, `2025-06-03`).
+// Otherwise, json.Marshal() is used to serialze "v" and the resulting string is returned
+// (e.g. `32`, `true`, `[true, false, true]`, `{"foo": "bar"}`).
+// Note: the backticks in the comments above are not part of the returned strings.
+func Stringify(v interface{}) string {
+	if !core.IsNil(v) {
+		if s, ok := v.(string); ok {
+			return s
+		} else if s, ok := v.(interface{ String() string }); ok {
+			return s.String()
+		} else {
+			bytes, err := json.Marshal(v)
+			if err != nil {
+				log.Printf("[ERROR] Error marshaling 'any type' value as string: %s", err.Error())
+				return ""
+			}
+			return string(bytes)
+		}
+	}
+	return ""
+}

--- a/ibm/flex/structures_test.go
+++ b/ibm/flex/structures_test.go
@@ -1,0 +1,86 @@
+package flex
+
+import (
+	"testing"
+
+	"github.com/IBM/go-sdk-core/v5/core"
+	"github.com/go-openapi/strfmt"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestStringifyString(t *testing.T) {
+	var foo interface{}
+	foo = nil
+	assert.Equal(t, "", Stringify(foo))
+
+	foo = "a string"
+	assert.Equal(t, foo, Stringify(foo))
+
+	foo = ""
+	assert.Equal(t, foo, Stringify(foo))
+}
+
+func TestStringifyDate(t *testing.T) {
+	var foo interface{}
+	foo = nil
+	assert.Equal(t, "", Stringify(foo))
+
+	d := "2025-06-03"
+	foo, err := core.ParseDate(d)
+	assert.Nil(t, err)
+	assert.Equal(t, d, Stringify(foo))
+}
+
+func TestStringifyDateTime(t *testing.T) {
+	var foo interface{}
+	foo = nil
+	assert.Equal(t, "", Stringify(foo))
+
+	dt := "2025-06-03T11:59:59.999Z"
+	foo, err := core.ParseDateTime(dt)
+	assert.Nil(t, err)
+	assert.Equal(t, dt, Stringify(foo))
+}
+
+func TestStringifyUUID(t *testing.T) {
+	var foo interface{}
+	foo = nil
+	assert.Equal(t, "", Stringify(foo))
+
+	u := uuid.New().String()
+	foo = strfmt.UUID(u)
+	assert.NotNil(t, foo)
+	assert.Equal(t, u, Stringify(foo))
+}
+func TestStringifyBoolean(t *testing.T) {
+	var foo interface{}
+	foo = true
+	assert.Equal(t, "true", Stringify(foo))
+
+	foo = false
+	assert.Equal(t, "false", Stringify(foo))
+}
+
+func TestStringifyNumber(t *testing.T) {
+	var foo interface{}
+	foo = 38
+	assert.Equal(t, "38", Stringify(foo))
+
+	foo = 38.12345
+	assert.Equal(t, "38.12345", Stringify(foo))
+}
+
+func TestStringifyList(t *testing.T) {
+	var foo interface{}
+	foo = []string{"foo", "bar"}
+	assert.Equal(t, `["foo","bar"]`, Stringify(foo))
+
+	foo = []bool{true, false, true}
+	assert.Equal(t, `[true,false,true]`, Stringify(foo))
+}
+
+func TestStringifyMap(t *testing.T) {
+	var foo interface{} = map[string]interface{}{"foo": "bar"}
+	assert.Equal(t, `{"foo":"bar"}`, Stringify(foo))
+}


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/IBM-Cloud/terraform-provider-ibm/blob/master/.github/CONTRIBUTING.md --->

This PR adds the Stringify() function and its unit tests to the `flex` module.  This new function will be used by Terraform code emitted by the SDK generator.

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->


Output from acceptance testing:
```
$ cd ibm/flex && go test -v -run TestStringify
=== RUN   TestStringifyString
--- PASS: TestStringifyString (0.00s)
=== RUN   TestStringifyBoolean
--- PASS: TestStringifyBoolean (0.00s)
=== RUN   TestStringifyNumber
--- PASS: TestStringifyNumber (0.00s)
=== RUN   TestStringifySlice
--- PASS: TestStringifySlice (0.00s)
=== RUN   TestStringifyMap
--- PASS: TestStringifyMap (0.00s)
PASS
ok  	github.com/IBM-Cloud/terraform-provider-ibm/ibm/flex	0.012s
...
```
