### PR TITLE
Change network type from list to set in resource instance

### DIFF
--- a/ibm/service/power/resource_ibm_pi_instance.go
+++ b/ibm/service/power/resource_ibm_pi_instance.go
@@ -147,7 +147,7 @@ func ResourceIBMPIInstance() *schema.Resource {
 				Description: "Indicates if all volumes attached to the server must reside in the same storage pool",
 			},
 			PIInstanceNetwork: {
-				Type:        schema.TypeList,
+				Type:        schema.TypeSet,
 				ForceNew:    true,
 				Required:    true,
 				Description: "List of one or more networks to attach to the instance",
@@ -1202,7 +1202,7 @@ func createSAPInstance(d *schema.ResourceData, sapClient *st.IBMPISAPInstanceCli
 	profileID := d.Get(PISAPInstanceProfileID).(string)
 	imageid := d.Get(helpers.PIInstanceImageId).(string)
 
-	pvmNetworks := expandPVMNetworks(d.Get(PIInstanceNetwork).([]interface{}))
+	pvmNetworks := expandPVMNetworks(d.Get(PIInstanceNetwork).(*schema.Set).List())
 
 	var replicants int64
 	if r, ok := d.GetOk(helpers.PIInstanceReplicants); ok {
@@ -1336,7 +1336,7 @@ func createPVMInstance(d *schema.ResourceData, client *st.IBMPIInstanceClient, i
 		return nil, fmt.Errorf("%s is required for creating pvm instances", helpers.PIInstanceProcType)
 	}
 
-	pvmNetworks := expandPVMNetworks(d.Get(PIInstanceNetwork).([]interface{}))
+	pvmNetworks := expandPVMNetworks(d.Get(PIInstanceNetwork).(*schema.Set).List())
 
 	var volids []string
 	if v, ok := d.GetOk(helpers.PIInstanceVolumeIds); ok {


### PR DESCRIPTION
There's an issue where doing terraform apply after an instance has been created will cause it to show that there were changes in the configuration even though there weren't. 

This PR is fixes: https://github.com/IBM-Cloud/terraform-provider-ibm/issues/5224