### PR TITLE
Revert type change in the instance list

### DIFF
--- a/ibm/service/power/resource_ibm_pi_instance.go
+++ b/ibm/service/power/resource_ibm_pi_instance.go
@@ -147,7 +147,7 @@ func ResourceIBMPIInstance() *schema.Resource {
 				Description: "Indicates if all volumes attached to the server must reside in the same storage pool",
 			},
 			PIInstanceNetwork: {
-				Type:             schema.TypeSet,
+				Type:             schema.TypeList,
 				DiffSuppressFunc: flex.ApplyOnce,
 				Required:         true,
 				Description:      "List of one or more networks to attach to the instance",
@@ -1201,7 +1201,7 @@ func createSAPInstance(d *schema.ResourceData, sapClient *st.IBMPISAPInstanceCli
 	profileID := d.Get(PISAPInstanceProfileID).(string)
 	imageid := d.Get(helpers.PIInstanceImageId).(string)
 
-	pvmNetworks := expandPVMNetworks(d.Get(PIInstanceNetwork).(*schema.Set).List())
+	pvmNetworks := expandPVMNetworks(d.Get(PIInstanceNetwork).([]interface{}))
 
 	var replicants int64
 	if r, ok := d.GetOk(helpers.PIInstanceReplicants); ok {
@@ -1335,7 +1335,7 @@ func createPVMInstance(d *schema.ResourceData, client *st.IBMPIInstanceClient, i
 		return nil, fmt.Errorf("%s is required for creating pvm instances", helpers.PIInstanceProcType)
 	}
 
-	pvmNetworks := expandPVMNetworks(d.Get(PIInstanceNetwork).(*schema.Set).List())
+	pvmNetworks := expandPVMNetworks(d.Get(PIInstanceNetwork).([]interface{}))
 
 	var volids []string
 	if v, ok := d.GetOk(helpers.PIInstanceVolumeIds); ok {


### PR DESCRIPTION
This PR undoes a type change from set to list due to compatibility reasons.

Reran changes to make sure it resolved the original problem:
```
No changes. Your infrastructure matches the configuration.

Terraform has compared your real infrastructure against your configuration and found no differences, so no changes are needed.
2024-04-03T14:47:30.363-0500 [INFO]  backend/local: apply calling Apply
2024-04-03T14:47:30.363-0500 [DEBUG] Building and walking apply graph for NormalMode plan
2024-04-03T14:47:30.363-0500 [DEBUG] ProviderTransformer: "ibm_pi_instance.instance (expand)" (*terraform.nodeExpandApplyableResource) needs provider["terraform.local/local/ibm"]
2024-04-03T14:47:30.363-0500 [DEBUG] ReferenceTransformer: "ibm_pi_instance.instance (expand)" references: [var.pi_network]
2024-04-03T14:47:30.363-0500 [DEBUG] ReferenceTransformer: "var.pi_network" references: []
2024-04-03T14:47:30.363-0500 [DEBUG] ReferenceTransformer: "provider[\"terraform.local/local/ibm\"]" references: []
2024-04-03T14:47:30.363-0500 [DEBUG] pruneUnusedNodes: ibm_pi_instance.instance (expand) is no longer needed, removing
2024-04-03T14:47:30.363-0500 [DEBUG] pruneUnusedNodes: provider["terraform.local/local/ibm"] is no longer needed, removing
2024-04-03T14:47:30.363-0500 [DEBUG] Starting graph walk: walkApply

Apply complete! Resources: 0 added, 0 changed, 0 destroyed.
```