### PR TITLE
Deprecate vtl attributes in data source/resource

### DIFF
--- a/ibm/service/power/data_source_ibm_pi_catalog_images.go
+++ b/ibm/service/power/data_source_ibm_pi_catalog_images.go
@@ -32,6 +32,7 @@ func DataSourceIBMPICatalogImages() *schema.Resource {
 				Type:        schema.TypeBool,
 			},
 			Arg_VTL: {
+				Deprecated:  "This field is deprecated.",
 				Description: "Set true to include VTL images. The default value is false.",
 				Optional:    true,
 				Type:        schema.TypeBool,

--- a/ibm/service/power/data_source_ibm_pi_instance.go
+++ b/ibm/service/power/data_source_ibm_pi_instance.go
@@ -64,6 +64,7 @@ func DataSourceIBMPIInstance() *schema.Resource {
 			},
 			Attr_LicenseRepositoryCapacity: {
 				Computed:    true,
+				Deprecated:  "This field is deprecated.",
 				Description: "The VTL license repository capacity TB value.",
 				Type:        schema.TypeInt,
 			},

--- a/ibm/service/power/data_source_ibm_pi_instances.go
+++ b/ibm/service/power/data_source_ibm_pi_instances.go
@@ -40,6 +40,7 @@ func DataSourceIBMPIInstances() *schema.Resource {
 						},
 						Attr_LicenseRepositoryCapacity: {
 							Computed:    true,
+							Deprecated:  "This field is deprecated.",
 							Description: "The VTL license repository capacity TB value.",
 							Type:        schema.TypeInt,
 						},

--- a/ibm/service/power/resource_ibm_pi_instance.go
+++ b/ibm/service/power/resource_ibm_pi_instance.go
@@ -49,6 +49,7 @@ func ResourceIBMPIInstance() *schema.Resource {
 				Type:        schema.TypeInt,
 				Optional:    true,
 				Computed:    true,
+				Deprecated:  "This field is deprecated.",
 				Description: "The VTL license repository capacity TB value",
 			},
 			"status": {

--- a/website/docs/d/pi_catalog_images.html.markdown
+++ b/website/docs/d/pi_catalog_images.html.markdown
@@ -37,7 +37,7 @@ Review the argument reference that you can specify for your data source.
 
 - `pi_cloud_instance_id` - (Required, String) The GUID of the service instance associated with an account.
 - `sap` - (Optional, Bool) Set `true` to include SAP images. The default value is `false`.
-- `vtl` - (Optional, Bool) Set `true` to include VTL images. The default value is `false`.
+- `vtl` - (Deprecated, Optional, Bool) Set `true` to include VTL images. The default value is `false`.
 
 ## Attribute reference
 In addition to the argument reference list, you can access the following attribute references after your data source is created.

--- a/website/docs/d/pi_instance.html.markdown
+++ b/website/docs/d/pi_instance.html.markdown
@@ -49,7 +49,7 @@ In addition to all argument reference list, you can access the following attribu
 - `ibmi_rds` - (Boolean) IBM i Rational Dev Studio.
 - `ibmi_rds_users` - (Integer) IBM i Rational Dev Studio Number of User Licenses.
 - `id` - (String) The unique identifier of the instance.
-- `license_repository_capacity` - (Integer) The VTL license repository capacity TB value. Only available with VTL instances.
+- `license_repository_capacity` - (Deprecated, Integer) The VTL license repository capacity TB value. Only available with VTL instances.
 - `maxmem`- (Float) The maximum amount of memory that can be allocated to the instance without shutting down or rebooting the `LPAR`.
 - `maxproc`- (Float) The maximum number of processors that can be allocated to the instance without shutting down or rebooting the `LPAR`.
 - `max_virtual_cores` - (Integer) The maximum number of virtual cores that can be assigned without rebooting the instance.

--- a/website/docs/d/pi_instances.html.markdown
+++ b/website/docs/d/pi_instances.html.markdown
@@ -42,7 +42,7 @@ In addition to all argument reference list, you can access the following attribu
 
   Nested scheme for `pvm_instances`:
   - `health_status` - (String) The health of the instance.
-  - `license_repository_capacity` - The VTL license repository capacity TB value. Only available with VTL instances.
+  - `license_repository_capacity` - (Deprecated, Integer) The VTL license repository capacity TB value. Only available with VTL instances.
   - `memory` - (Float) The amount of memory that is allocated to the instance.
   - `minproc`- (Float) The minimum number of processors that must be allocated to the instance. 
   - `maxproc`- (Float) The maximum number of processors that can be allocated to the instance without shutting down or rebooting the `LPAR`.

--- a/website/docs/r/pi_instance.html.markdown
+++ b/website/docs/r/pi_instance.html.markdown
@@ -75,7 +75,7 @@ Review the argument references that you can specify for your resource.
   - **Note**: only images belonging to your project can be used image for deploying a Power Systems Virtual Server instance. To import an images to your project, see [ibm_pi_image](https://registry.terraform.io/providers/IBM-Cloud/ibm/latest/docs/resources/pi_image).
 - `pi_instance_name` - (Required, String) The name of the Power Systems Virtual Server instance. 
 - `pi_key_pair_name` - (Optional, String) The name of the SSH key that you want to use to access your Power Systems Virtual Server instance. The SSH key must be uploaded to IBM Cloud.
-- `pi_license_repository_capacity` - (Optional, Integer) The VTL license repository capacity TB value. Only use with VTL instances. `pi_memory >= 16 + (2 * pi_license_repository_capacity)`.
+- `pi_license_repository_capacity` - (Deprecated, Optional, Integer) The VTL license repository capacity TB value. Only use with VTL instances. `pi_memory >= 16 + (2 * pi_license_repository_capacity)`.
   - **Note**: Provisioning VTL instances is temporarily disabled.
 - `pi_memory` - (Optional, Float) The amount of memory that you want to assign to your instance in gigabytes.
   - Required when not creating SAP instances. Conflicts with `pi_sap_profile_id`.


### PR DESCRIPTION
After speaking with @michaelkad and John Nguyen from my team, we've decided to deprecate vtl related properties for terraform to match the CLI.

PowerVS no longer wishes to manage vtl.

The components affected are:
data source ibm_pi_catalog_images
data source ibm_pi_instance
data source ibm_pi_instances
resource ibm_pi_instance
