### PR TITLE
fix: prevent panic on SCC Profile Attachment

### DIFF
--- a/ibm/service/scc/resource_ibm_scc_profile_attachment.go
+++ b/ibm/service/scc/resource_ibm_scc_profile_attachment.go
@@ -437,7 +437,7 @@ func resourceIbmSccProfileAttachmentRead(context context.Context, d *schema.Reso
 		}
 	}
 	if !core.IsNil(attachmentItem.AttachmentParameters) {
-		attachmentParameters := d.Get("attachment_parameters").(*schema.Set)
+		attachmentParameters := &schema.Set{F: hashAttachmentParameters}
 		for _, attachmentParametersItem := range attachmentItem.AttachmentParameters {
 			attachmentParametersItemMap, err := resourceIbmSccProfileAttachmentAttachmentParameterPrototypeToMap(&attachmentParametersItem)
 			if err != nil {

--- a/ibm/service/scc/resource_ibm_scc_profile_attachment.go
+++ b/ibm/service/scc/resource_ibm_scc_profile_attachment.go
@@ -7,9 +7,6 @@ import (
 	"context"
 	"fmt"
 	"log"
-	"math/big"
-	"strconv"
-	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -168,40 +165,8 @@ func ResourceIbmSccProfileAttachment() *schema.Resource {
 				Type:        schema.TypeSet,
 				Optional:    true,
 				Description: "The profile parameters for the attachment.",
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"assessment_type": {
-							Type:        schema.TypeString,
-							Optional:    true,
-							Description: "The type of the implementation.",
-						},
-						"assessment_id": {
-							Type:        schema.TypeString,
-							Required:    true,
-							Description: "The implementation ID of the parameter.",
-						},
-						"parameter_name": {
-							Type:        schema.TypeString,
-							Optional:    true,
-							Description: "The parameter name.",
-						},
-						"parameter_value": {
-							Type:        schema.TypeString,
-							Optional:    true,
-							Description: "The value of the parameter.",
-						},
-						"parameter_display_name": {
-							Type:        schema.TypeString,
-							Optional:    true,
-							Description: "The parameter display name.",
-						},
-						"parameter_type": {
-							Type:        schema.TypeString,
-							Optional:    true,
-							Description: "The parameter type.",
-						},
-					},
-				},
+				Elem:        schemaAttachmentParameters(),
+				Set:         hashAttachmentParameters,
 			},
 			"last_scan": {
 				Type:        schema.TypeList,
@@ -269,6 +234,56 @@ func ResourceIbmSccProfileAttachmentValidator() *validate.ResourceValidator {
 	return &resourceValidator
 }
 
+// hashAttachmentParameters will determine how to hash the AttachmentParameters schema.Resource
+// It uses the 'assessment_id' in order to determine the difference.
+func hashAttachmentParameters(v interface{}) int {
+	if v == nil {
+		return 0
+	}
+	m := v.(map[string]interface{})
+	id := (m["assessment_id"]).(string)
+	return schema.HashString(id)
+}
+
+// schemaAttachmentParameters returns a *schema.Resource for AttachmentParameters
+func schemaAttachmentParameters() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"assessment_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "The implementation ID of the parameter.",
+			},
+			"assessment_type": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Default:     "automated",
+				Description: "The type of the implementation.",
+			},
+			"parameter_name": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "The parameter name.",
+			},
+			"parameter_display_name": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "The parameter display name.",
+			},
+			"parameter_type": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "The parameter type.",
+			},
+			"parameter_value": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "The value of the parameter.",
+			},
+		},
+	}
+}
+
 func resourceIbmSccProfileAttachmentCreate(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	securityandcompliancecenterapiClient, err := meta.(conns.ClientSession).SecurityAndComplianceCenterV3()
 	if err != nil {
@@ -279,6 +294,7 @@ func resourceIbmSccProfileAttachmentCreate(context context.Context, d *schema.Re
 	createAttachmentOptions := &securityandcompliancecenterapiv3.CreateAttachmentOptions{}
 	instance_id := d.Get("instance_id").(string)
 	bodyModelMap["instance_id"] = instance_id
+
 	if _, ok := d.GetOk("profile_id"); ok {
 		bodyModelMap["profile_id"] = d.Get("profile_id")
 	}
@@ -288,11 +304,10 @@ func resourceIbmSccProfileAttachmentCreate(context context.Context, d *schema.Re
 	if _, ok := d.GetOk("scope"); ok {
 		bodyModelMap["scope"] = d.Get("scope")
 	}
-	// manual chang
+
+	// manual change
 	if _, ok := d.GetOk("attachment_parameters"); ok {
 		bodyModelMap["attachment_parameters"] = d.Get("attachment_parameters")
-	} else {
-		bodyModelMap["attachment_parameters"] = []interface{}{}
 	}
 	if _, ok := d.GetOk("notifications"); ok {
 		bodyModelMap["notifications"] = d.Get("notifications")
@@ -322,22 +337,6 @@ func resourceIbmSccProfileAttachmentCreate(context context.Context, d *schema.Re
 	d.SetId(fmt.Sprintf("%s/%s/%s", instance_id, *createAttachmentOptions.ProfileID, *attachmentPrototype.Attachments[0].ID))
 
 	return resourceIbmSccProfileAttachmentRead(context, d, meta)
-}
-
-func cmpAttachParamSetFunc(v interface{}) int {
-	if v == nil {
-		return 0
-	}
-	m := v.(map[string]interface{})
-	id := (m["assessment_id"]).(*string)
-	assId := (*id)[5:18]
-	var i big.Int
-	i.SetString(strings.Replace(assId, "-", "", 4), 16)
-	val, err := strconv.Atoi(i.String())
-	if err != nil {
-		log.Printf("[ERROR] Setting the Parameters of the Profile Attachment failed %s\n", err)
-	}
-	return val
 }
 
 func resourceIbmSccProfileAttachmentRead(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
@@ -438,15 +437,14 @@ func resourceIbmSccProfileAttachmentRead(context context.Context, d *schema.Reso
 		}
 	}
 	if !core.IsNil(attachmentItem.AttachmentParameters) {
-		attachmentParametersList := []interface{}{}
+		attachmentParameters := d.Get("attachment_parameters").(*schema.Set)
 		for _, attachmentParametersItem := range attachmentItem.AttachmentParameters {
 			attachmentParametersItemMap, err := resourceIbmSccProfileAttachmentAttachmentParameterPrototypeToMap(&attachmentParametersItem)
 			if err != nil {
 				return diag.FromErr(err)
 			}
-			attachmentParametersList = append(attachmentParametersList, attachmentParametersItemMap)
+			attachmentParameters.Add(attachmentParametersItemMap)
 		}
-		attachmentParameters := schema.NewSet(cmpAttachParamSetFunc, attachmentParametersList)
 		if err = d.Set("attachment_parameters", attachmentParameters); err != nil {
 			return diag.FromErr(fmt.Errorf("Error setting attachment_parameters: %s", err))
 		}
@@ -523,12 +521,17 @@ func resourceIbmSccProfileAttachmentUpdate(context context.Context, d *schema.Re
 		hasChange = true
 	}
 
-	if d.HasChange("attachment_item") {
-		attachmentItem, err := resourceIbmSccProfileAttachmentMapToAttachmentItem(d.Get("attachment_item.0").(map[string]interface{}))
-		if err != nil {
-			return diag.FromErr(err)
+	if d.HasChange("attachment_parameters") {
+		attachmentItems := d.Get("attachment_parameters")
+		attachmentParameters := []securityandcompliancecenterapiv3.AttachmentParameterPrototype{}
+		for _, attachmentParametersItem := range attachmentItems.(*schema.Set).List() {
+			attachmentParametersItemModel, err := resourceIbmSccProfileAttachmentMapToAttachmentParameterPrototype(attachmentParametersItem.(map[string]interface{}))
+			if err != nil {
+				return diag.FromErr(err)
+			}
+			attachmentParameters = append(attachmentParameters, *attachmentParametersItemModel)
 		}
-		replaceProfileAttachmentOptions.SetAttachmentID(*attachmentItem.ID)
+		replaceProfileAttachmentOptions.SetAttachmentParameters(attachmentParameters)
 		hasChange = true
 	}
 
@@ -634,13 +637,15 @@ func resourceIbmSccProfileAttachmentMapToAttachmentsPrototype(modelMap map[strin
 		model.Notifications = NotificationsModel
 	}
 	attachmentParameters := []securityandcompliancecenterapiv3.AttachmentParameterPrototype{}
-	for _, attachmentParametersItem := range modelMap["attachment_parameters"].([]interface{}) {
-		if attachmentParametersItem != nil {
-			attachmentParametersItemModel, err := resourceIbmSccProfileAttachmentMapToAttachmentParameterPrototype(attachmentParametersItem.(map[string]interface{}))
-			if err != nil {
-				return model, err
+	if modelMap["attachment_parameters"] != nil {
+		for _, attachmentParametersItem := range modelMap["attachment_parameters"].(*schema.Set).List() {
+			if attachmentParametersItem != nil {
+				attachmentParametersItemModel, err := resourceIbmSccProfileAttachmentMapToAttachmentParameterPrototype(attachmentParametersItem.(map[string]interface{}))
+				if err != nil {
+					return model, err
+				}
+				attachmentParameters = append(attachmentParameters, *attachmentParametersItemModel)
 			}
-			attachmentParameters = append(attachmentParameters, *attachmentParametersItemModel)
 		}
 	}
 	model.AttachmentParameters = attachmentParameters
@@ -834,6 +839,7 @@ func resourceIbmSccProfileAttachmentMapToLastScan(modelMap map[string]interface{
 
 func resourceIbmSccProfileAttachmentMapToAttachmentPrototype(modelMap map[string]interface{}) (*securityandcompliancecenterapiv3.CreateAttachmentOptions, error) {
 	model := &securityandcompliancecenterapiv3.CreateAttachmentOptions{}
+	model.SetInstanceID(modelMap["instance_id"].(string))
 	if modelMap["profile_id"] != nil && modelMap["profile_id"].(string) != "" {
 		model.ProfileID = core.StringPtr(modelMap["profile_id"].(string))
 	}
@@ -844,7 +850,6 @@ func resourceIbmSccProfileAttachmentMapToAttachmentPrototype(modelMap map[string
 	}
 	attachments = append(attachments, *attachmentsItemModel)
 	model.Attachments = attachments
-	model.SetInstanceID(modelMap["instance_id"].(string))
 	return model, nil
 }
 
@@ -899,22 +904,22 @@ func resourceIbmSccProfileAttachmentFailedControlsToMap(model *securityandcompli
 func resourceIbmSccProfileAttachmentAttachmentParameterPrototypeToMap(model *securityandcompliancecenterapiv3.AttachmentParameterPrototype) (map[string]interface{}, error) {
 	modelMap := make(map[string]interface{})
 	if model.AssessmentType != nil {
-		modelMap["assessment_type"] = model.AssessmentType
+		modelMap["assessment_type"] = flex.StringValue(model.AssessmentType)
 	}
 	if model.AssessmentID != nil {
-		modelMap["assessment_id"] = model.AssessmentID
+		modelMap["assessment_id"] = flex.StringValue(model.AssessmentID)
 	}
 	if model.ParameterName != nil {
-		modelMap["parameter_name"] = model.ParameterName
+		modelMap["parameter_name"] = flex.StringValue(model.ParameterName)
 	}
 	if model.ParameterValue != nil {
-		modelMap["parameter_value"] = model.ParameterValue
+		modelMap["parameter_value"] = flex.StringValue(model.ParameterValue)
 	}
 	if model.ParameterDisplayName != nil {
-		modelMap["parameter_display_name"] = model.ParameterDisplayName
+		modelMap["parameter_display_name"] = flex.StringValue(model.ParameterDisplayName)
 	}
 	if model.ParameterType != nil {
-		modelMap["parameter_type"] = model.ParameterType
+		modelMap["parameter_type"] = flex.StringValue(model.ParameterType)
 	}
 	return modelMap, nil
 }

--- a/ibm/service/scc/resource_ibm_scc_profile_attachment_test.go
+++ b/ibm/service/scc/resource_ibm_scc_profile_attachment_test.go
@@ -53,6 +53,10 @@ func TestAccIbmSccProfileAttachmentAllArgs(t *testing.T) {
 				Check:  resource.ComposeAggregateTestCheckFunc(),
 			},
 			resource.TestStep{
+				Config: testAccCheckIbmSccProfileAttachmentConfigChange(acc.SccInstanceID),
+				Check:  resource.ComposeAggregateTestCheckFunc(),
+			},
+			resource.TestStep{
 				ResourceName:      "ibm_scc_profile_attachment.scc_profile_attachment_instance",
 				ImportState:       true,
 				ImportStateVerify: true,
@@ -148,70 +152,30 @@ func testAccCheckIbmSccProfileAttachmentConfigBasic(instanceID string) string {
 
 func testAccCheckIbmSccProfileAttachmentConfig(instanceID string) string {
 	return fmt.Sprintf(`
-		resource "ibm_scc_control_library" "scc_control_library_instance" {
-			instance_id = "%s"
-			control_library_name = "control_library_name"
-			control_library_description = "control_library_description"
-			control_library_type = "custom"
-			version_group_label = "03354ab4-03be-41c0-a469-826fc0262e78"
-			latest = true
-			controls {
-				control_name = "control-name"
-				control_id = "1fa45e17-9322-4e6c-bbd6-1c51db08e790"
-				control_description = "control_description"
-				control_category = "control_category"
-				control_tags = [ "control_tags" ]
-				control_specifications {
-					control_specification_id = "f3517159-889e-4781-819a-89d89b747c85"
-					responsibility = "user"
-					component_id = "f3517159-889e-4781-819a-89d89b747c85"
-					component_name = "f3517159-889e-4781-819a-89d89b747c85"
-					environment = "environment"
-					control_specification_description = "control_specification_description"
-					assessments {
-						assessment_id = "rule-a637949b-7e51-46c4-afd4-b96619001bf1"
-						assessment_method = "ibm-cloud-rule"
-						assessment_type = "automated"
-						assessment_description = "assessment_description"
-						parameters {
-							parameter_display_name = "Sign out due to inactivity in seconds"
-                            parameter_name         = "session_invalidation_in_seconds"
-							parameter_type = "numeric"
-						}
-					}
-				}
-				control_docs {
-					control_docs_id = "control_docs_id"
-					control_docs_type = "control_docs_type"
-				}
-				control_requirement = true
-				status = "enabled"
-			}
-		}
+	locals {
+		scc_profiles_map = tomap(merge([
+			for i , cl in data.ibm_scc_profiles.scc_profiles.profiles :
+			{(cl.profile_name) = "${cl.id}"}  if cl.latest == true && cl.profile_type == "predefined"
+		]...))
+	}
 
-		resource "ibm_scc_profile" "scc_profile_instance" {
-			instance_id = resource.ibm_scc_control_library.scc_control_library_instance.instance_id
-			profile_name = "profile_name"
-			profile_description = "profile_description"
-			profile_type = "custom"
-			controls {
-				control_library_id = resource.ibm_scc_control_library.scc_control_library_instance.control_library_id
-				control_id = resource.ibm_scc_control_library.scc_control_library_instance.controls[0].control_id
-			}
-			default_parameters {
-			}
-		}
+	data "ibm_scc_profiles" "scc_profiles" {
+		instance_id = "%s"
+	}
 
-		resource "ibm_scc_profile_attachment" "scc_profile_attachment_instance" {
-			instance_id = resource.ibm_scc_control_library.scc_control_library_instance.instance_id
-			profile_id = ibm_scc_profile.scc_profile_instance.profile_id
-			name = "profile_attachment_name"
-			description = "scc_profile_attachment_description"
+    data "ibm_iam_account_settings" "iam_account_settings" {
+    }
+
+    resource "ibm_scc_profile_attachment" "scc_profile_attachment_instance" {
+		instance_id = "%s"
+		profile_id = local.scc_profiles_map["CIS IBM Cloud Foundations Benchmark"]
+		name = "profile_attachment_name"
+		description = "scc_profile_attachment_description"
 			scope {
 				environment = "ibm-cloud"	
 				properties {
 					name = "scope_id"
-					value = resource.ibm_scc_control_library.scc_control_library_instance.account_id
+					value = data.ibm_iam_account_settings.iam_account_settings.account_id
 				}
 				properties {
 					name = "scope_type"
@@ -219,7 +183,7 @@ func testAccCheckIbmSccProfileAttachmentConfig(instanceID string) string {
 				}
 			}
 			schedule = "every_30_days"
-			status = "enabled"
+			status = "disabled"
 			notifications {
 				enabled = false
 				controls {
@@ -227,8 +191,133 @@ func testAccCheckIbmSccProfileAttachmentConfig(instanceID string) string {
 					threshold_limit = 14
 				}
 			}
+		attachment_parameters {
+			parameter_value = "['1.2', '1.3']"
+			assessment_id = "rule-e16fcfea-fe21-4d30-a721-423611481fea"
+        	assessment_type = "automated"
+			parameter_display_name = "IBM Cloud Internet Services TLS version"
+			parameter_name = "tls_version"
+			parameter_type = "string_list"
 		}
-	`, instanceID)
+		attachment_parameters {
+			parameter_value = "22"
+			assessment_id = "rule-f9137be8-2490-4afb-8cd5-a201cb167eb2"
+			assessment_type = "automated"
+			parameter_display_name = "Network ACL rule for allowed IPs to SSH port"
+			parameter_name = "ssh_port"
+			parameter_type = "numeric"
+		}
+		attachment_parameters {
+			parameter_value = "3389"
+			assessment_id = "rule-9653d2c7-6290-4128-a5a3-65487ba40370"
+			assessment_type = "automated"
+			parameter_display_name = "Security group rule RDP allow port number"
+			parameter_name = "rdp_port"
+			parameter_type = "numeric"
+		}
+		attachment_parameters {
+			parameter_value = "22"
+			assessment_id = "rule-7c5f6385-67e4-4edf-bec8-c722558b2dec"
+			assessment_type = "automated"
+			parameter_display_name = "Security group rule SSH allow port number"
+			parameter_name = "ssh_port"
+			parameter_type = "numeric"
+		}
+		attachment_parameters {
+			parameter_value = "3389"
+			assessment_id = "rule-f1e80ee7-88d5-4bf2-b42f-c863bb24601c"
+			assessment_type = "automated"
+			parameter_display_name = "Disallowed IPs for ingress to RDP port"
+			parameter_name = "rdp_port"
+			parameter_type = "numeric"
+		}
+	}
+	`, instanceID, instanceID)
+}
+
+func testAccCheckIbmSccProfileAttachmentConfigChange(instanceID string) string {
+	return fmt.Sprintf(`
+	locals {
+		scc_profiles_map = tomap(merge([
+			for i , cl in data.ibm_scc_profiles.scc_profiles.profiles :
+			{(cl.profile_name) = "${cl.id}"}  if cl.latest == true && cl.profile_type == "predefined"
+		]...))
+	}
+
+	data "ibm_scc_profiles" "scc_profiles" {
+		instance_id = "%s"
+	}
+
+    data "ibm_iam_account_settings" "iam_account_settings" {
+    }
+
+    resource "ibm_scc_profile_attachment" "scc_profile_attachment_instance" {
+		instance_id = "%s"
+		profile_id = local.scc_profiles_map["CIS IBM Cloud Foundations Benchmark"]
+		name = "profile_attachment_name"
+		description = "scc_profile_attachment_description"
+			scope {
+				environment = "ibm-cloud"	
+				properties {
+					name = "scope_id"
+					value = data.ibm_iam_account_settings.iam_account_settings.account_id
+				}
+				properties {
+					name = "scope_type"
+					value = "account"
+				}
+			}
+			schedule = "every_30_days"
+			status = "disabled"
+			notifications {
+				enabled = false
+				controls {
+					failed_control_ids = []
+					threshold_limit = 14
+				}
+			}
+		attachment_parameters {
+			parameter_value = "['1.2', '1.3']"
+			assessment_id = "rule-e16fcfea-fe21-4d30-a721-423611481fea"
+        	assessment_type = "automated"
+			parameter_display_name = "IBM Cloud Internet Services TLS version"
+			parameter_name = "tls_version"
+			parameter_type = "string_list"
+		}
+		attachment_parameters {
+			parameter_value = "22"
+			assessment_id = "rule-f9137be8-2490-4afb-8cd5-a201cb167eb2"
+			assessment_type = "automated"
+			parameter_display_name = "Network ACL rule for allowed IPs to SSH port"
+			parameter_name = "ssh_port"
+			parameter_type = "numeric"
+		}
+		attachment_parameters {
+			parameter_value = "22"
+			assessment_id = "rule-7c5f6385-67e4-4edf-bec8-c722558b2dec"
+			assessment_type = "automated"
+			parameter_display_name = "Security group rule SSH allow port number"
+			parameter_name = "ssh_port"
+			parameter_type = "numeric"
+		}
+		attachment_parameters {
+			parameter_value = "3389"
+			assessment_id = "rule-9653d2c7-6290-4128-a5a3-65487ba40370"
+			assessment_type = "automated"
+			parameter_display_name = "Security group rule RDP allow port number"
+			parameter_name = "rdp_port"
+			parameter_type = "numeric"
+		}
+		attachment_parameters {
+			parameter_value = "3389"
+			assessment_id = "rule-f1e80ee7-88d5-4bf2-b42f-c863bb24601c"
+			assessment_type = "automated"
+			parameter_display_name = "Disallowed IPs for ingress to RDP port"
+			parameter_name = "rdp_port"
+			parameter_type = "numeric"
+		}
+	}
+	`, instanceID, instanceID)
 }
 
 func testAccCheckIbmSccProfileAttachmentExists(n string, obj securityandcompliancecenterapiv3.AttachmentItem) resource.TestCheckFunc {

--- a/website/docs/r/scc_profile_attachment.html.markdown
+++ b/website/docs/r/scc_profile_attachment.html.markdown
@@ -40,6 +40,13 @@ resource "ibm_scc_profile_attachment" "scc_profile_attachment_instance" {
       threshold_limit = 14
     }
   }
+  attachment_parameters {
+    parameter_value = "22"
+    assessment_id = "rule-this-is-a-fake-ruleid"
+    parameter_display_name = "Network ACL rule for allowed IPs to SSH port"
+    parameter_name = "ssh_port"
+    parameter_type = "numeric"
+	}
 }
 ```
 

--- a/website/docs/r/scc_profile_attachment.html.markdown
+++ b/website/docs/r/scc_profile_attachment.html.markdown
@@ -74,10 +74,10 @@ Nested schema for **notifications**:
 	* `enabled` - (Boolean) enabled notifications.
 * `attachment_parameters` - (List) The request payload of the attachment parameters.
 Nested schema for **attachment_parameters**:
-    * `parameter_name` - (String) The name of the parameter to target.
-    * `parameter_display_name` - (String) The display name of the parameter shown in the UI.
-    * `parameter_type` - (String) The type of the parameter value.
-    * `parameter_value` - (String) The value of the parameter.
+    * `parameter_name` - (Required, String) The name of the parameter to target.
+    * `parameter_display_name` - (Required, String) The display name of the parameter shown in the UI.
+    * `parameter_type` - (Required, String) The type of the parameter value.
+    * `parameter_value` - (Required, String) The value of the parameter.
     * `assessment_type` - (String) The type of assessment the parameter uses. 
 * `schedule` - (String) The schedule of an attachment evaluation.
   * Constraints: Allowable values are: `daily`, `every_7_days`, `every_30_days`.


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/IBM-Cloud/terraform-provider-ibm/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->
Changes the logic for Profile Attachment. It now uses the `*schema.Set` correctly. 
- Made a sub Resource for AttachmentParameters
- renamed the SchemaSetFunc
- took out the usage of `NewSet`(giving too many problems in diff)
- Added an reordering for ProfileAttachment

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #5259 

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```shell 
$ make testacc TEST=./ibm/service/scc
=== RUN   TestAccIbmSccControlLibrariesDataSourceBasic
--- PASS: TestAccIbmSccControlLibrariesDataSourceBasic (14.86s)
=== RUN   TestAccIbmSccControlLibrariesDataSourceAllArgs
--- PASS: TestAccIbmSccControlLibrariesDataSourceAllArgs (12.44s)
=== RUN   TestAccIbmSccControlLibraryDataSourceBasic
--- PASS: TestAccIbmSccControlLibraryDataSourceBasic (16.88s)
=== RUN   TestAccIbmSccControlLibraryDataSourceAllArgs
--- PASS: TestAccIbmSccControlLibraryDataSourceAllArgs (17.71s)
=== RUN   TestAccIbmSccInstanceSettingsDataSourceBasic
--- PASS: TestAccIbmSccInstanceSettingsDataSourceBasic (12.97s)
=== RUN   TestAccIbmSccLatestReportsDataSourceBasic
--- PASS: TestAccIbmSccLatestReportsDataSourceBasic (14.08s)
=== RUN   TestAccIbmSccProfileAttachmentDataSourceBasic
--- PASS: TestAccIbmSccProfileAttachmentDataSourceBasic (22.13s)
=== RUN   TestAccIbmSccProfileAttachmentDataSourceAllArgs
--- PASS: TestAccIbmSccProfileAttachmentDataSourceAllArgs (24.12s)
=== RUN   TestAccIbmSccProfileDataSourceBasic
--- PASS: TestAccIbmSccProfileDataSourceBasic (20.44s)
=== RUN   TestAccIbmSccProfileDataSourceAllArgs
--- PASS: TestAccIbmSccProfileDataSourceAllArgs (21.49s)
=== RUN   TestAccIbmSccProfilesDataSourceBasic
--- PASS: TestAccIbmSccProfilesDataSourceBasic (22.28s)
=== RUN   TestAccIbmSccProfilesDataSourceAllArgs
--- PASS: TestAccIbmSccProfilesDataSourceAllArgs (18.09s)
=== RUN   TestAccIbmSccProviderTypeCollectionDataSourceBasic
--- PASS: TestAccIbmSccProviderTypeCollectionDataSourceBasic (12.00s)
=== RUN   TestAccIbmSccProviderTypeInstanceDataSourceBasic
--- PASS: TestAccIbmSccProviderTypeInstanceDataSourceBasic (16.93s)
=== RUN   TestAccIbmSccProviderTypeInstanceDataSourceAllArgs
--- PASS: TestAccIbmSccProviderTypeInstanceDataSourceAllArgs (14.62s)
=== RUN   TestAccIbmSccProviderTypeDataSourceBasic
--- PASS: TestAccIbmSccProviderTypeDataSourceBasic (11.51s)
=== RUN   TestAccIbmSccProviderTypesDataSourceBasic
--- PASS: TestAccIbmSccProviderTypesDataSourceBasic (12.31s)
=== RUN   TestAccIbmSccReportControlsDataSourceBasic
--- PASS: TestAccIbmSccReportControlsDataSourceBasic (16.59s)
=== RUN   TestAccIbmSccReportEvaluationsDataSourceBasic
--- PASS: TestAccIbmSccReportEvaluationsDataSourceBasic (14.03s)
=== RUN   TestAccIbmSccReportResourcesDataSourceBasic
--- PASS: TestAccIbmSccReportResourcesDataSourceBasic (10.27s)
=== RUN   TestAccIbmSccReportRuleDataSourceBasic
--- PASS: TestAccIbmSccReportRuleDataSourceBasic (10.85s)
=== RUN   TestAccIbmSccReportSummaryDataSourceBasic
--- PASS: TestAccIbmSccReportSummaryDataSourceBasic (12.81s)
=== RUN   TestAccIbmSccReportTagsDataSourceBasic
--- PASS: TestAccIbmSccReportTagsDataSourceBasic (10.59s)
=== RUN   TestAccIbmSccReportDataSourceBasic
--- PASS: TestAccIbmSccReportDataSourceBasic (9.93s)
=== RUN   TestAccIbmSccReportViolationDriftDataSourceBasic
--- PASS: TestAccIbmSccReportViolationDriftDataSourceBasic (10.44s)
=== RUN   TestAccIbmSccRuleDataSourceBasic
--- PASS: TestAccIbmSccRuleDataSourceBasic (23.77s)
=== RUN   TestAccIbmSccRuleDataSourceAllArgs
--- PASS: TestAccIbmSccRuleDataSourceAllArgs (15.11s)
=== RUN   TestAccIbmSccControlLibraryBasic
--- PASS: TestAccIbmSccControlLibraryBasic (23.59s)
=== RUN   TestAccIbmSccControlLibraryAllArgs
--- PASS: TestAccIbmSccControlLibraryAllArgs (29.73s)
=== RUN   TestAccIbmSccInstanceSettingsBasic
--- PASS: TestAccIbmSccInstanceSettingsBasic (14.58s)
=== RUN   TestAccIbmSccInstanceSettingsAllArgs
--- PASS: TestAccIbmSccInstanceSettingsAllArgs (30.26s)
=== RUN   TestAccIbmSccProfileAttachmentBasic
--- PASS: TestAccIbmSccProfileAttachmentBasic (27.48s)
=== RUN   TestAccIbmSccProfileAttachmentAllArgs
--- PASS: TestAccIbmSccProfileAttachmentAllArgs (58.35s)
=== RUN   TestAccIbmSccProfileBasic
--- PASS: TestAccIbmSccProfileBasic (26.77s)
=== RUN   TestAccIbmSccProfileAllArgs
--- PASS: TestAccIbmSccProfileAllArgs (29.12s)
=== RUN   TestAccIbmSccProviderTypeInstanceBasic
--- PASS: TestAccIbmSccProviderTypeInstanceBasic (24.24s)
=== RUN   TestAccIbmSccProviderTypeInstanceAllArgs
--- PASS: TestAccIbmSccProviderTypeInstanceAllArgs (24.62s)
=== RUN   TestAccIbmSccRuleBasic
--- PASS: TestAccIbmSccRuleBasic (21.68s)
=== RUN   TestAccIbmSccRuleAllArgs
--- PASS: TestAccIbmSccRuleAllArgs (26.83s)
PASS
ok      github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/scc     757.004s
...
```
