### PR TITLE
fix(ibm_database resource): Fix cpuEnforcement multitenant bug

### DIFF
--- a/ibm/service/database/resource_ibm_database.go
+++ b/ibm/service/database/resource_ibm_database.go
@@ -1054,8 +1054,11 @@ func getDefaultScalingGroups(_service string, _plan string, _hostFlavor string, 
 		getDefaultScalingGroupsOptions.SetHostFlavor(_hostFlavor)
 	}
 
-	getDefaultScalingGroupsResponse, _, err := cloudDatabasesClient.GetDefaultScalingGroups(getDefaultScalingGroupsOptions)
+	getDefaultScalingGroupsResponse, response, err := cloudDatabasesClient.GetDefaultScalingGroups(getDefaultScalingGroupsOptions)
 	if err != nil {
+		if response.StatusCode == 422 {
+			return groups, fmt.Errorf("%s is not available on multitenant", service)
+		}
 		return groups, err
 	}
 

--- a/ibm/service/database/resource_ibm_database.go
+++ b/ibm/service/database/resource_ibm_database.go
@@ -2926,10 +2926,14 @@ func validateGroupsDiff(_ context.Context, diff *schema.ResourceDiff, meta inter
 
 		tfGroups := expandGroups(group.(*schema.Set).List())
 
-		err, cpuEnforcementRatioCeiling, cpuEnforcementRatioMb := getCpuEnforcementRatios(service, plan, meta, group)
+		cpuEnforcementRatioCeiling, cpuEnforcementRatioMb := 0, 0
 
-		if err != nil {
-			return err
+		if memberGroup.HostFlavor != nil && memberGroup.HostFlavor.ID == "multitenant" {
+			err, cpuEnforcementRatioCeiling, cpuEnforcementRatioMb = getCpuEnforcementRatios(service, plan, memberGroup.HostFlavor.ID, meta, group)
+
+			if err != nil {
+				return err
+			}
 		}
 
 		// validate group_ids are unique
@@ -3010,9 +3014,9 @@ func validateGroupsDiff(_ context.Context, diff *schema.ResourceDiff, meta inter
 	return nil
 }
 
-func getCpuEnforcementRatios(service string, plan string, meta interface{}, group interface{}) (err error, cpuEnforcementRatioCeiling int, cpuEnforcementRatioMb int) {
+func getCpuEnforcementRatios(service string, plan string, hostFlavor string, meta interface{}, group interface{}) (err error, cpuEnforcementRatioCeiling int, cpuEnforcementRatioMb int) {
 	var currentGroups []Group
-	defaultList, err := getDefaultScalingGroups(service, plan, "multitenant", meta)
+	defaultList, err := getDefaultScalingGroups(service, plan, hostFlavor, meta)
 
 	if err != nil {
 		return err, 0, 0

--- a/ibm/service/database/resource_ibm_database.go
+++ b/ibm/service/database/resource_ibm_database.go
@@ -544,6 +544,14 @@ func ResourceIBMDatabaseInstance() *schema.Resource {
 									"id": {
 										Type:     schema.TypeString,
 										Required: true,
+										ValidateFunc: validation.StringInSlice([]string{
+											"multitenant",
+											"b3c.4x16.encrypted",
+											"b3c.8x32.encrypted",
+											"m3c.8x64.encrypted",
+											"b3c.16x64.encrypted",
+											"b3c.32x128.encrypted",
+											"m3c.30x240.encrypted"}, false),
 									},
 								},
 							},

--- a/ibm/service/database/resource_ibm_database_mongodb_enterprise_test.go
+++ b/ibm/service/database/resource_ibm_database_mongodb_enterprise_test.go
@@ -208,6 +208,7 @@ func testAccCheckIBMDatabaseInstanceMongoDBEnterpriseBasic(databaseResourceGroup
 		location                     = "%[3]s"
 		adminpassword                = "password12345678"
 		tags                         = ["one:two"]
+		service_endpoints            = "public"
 		group {
 			group_id = "member"
 			host_flavor {

--- a/ibm/service/database/resource_ibm_database_postgresql_test.go
+++ b/ibm/service/database/resource_ibm_database_postgresql_test.go
@@ -416,6 +416,7 @@ func testAccCheckIBMDatabaseInstancePostgresBasic(databaseResourceGroup string, 
 		plan                         = "standard"
 		location                     = "%[3]s"
 		adminpassword                = "password12345678"
+		service_endpoints            = "public"
 		group {
 			group_id = "member"
 			memory {


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/IBM-Cloud/terraform-provider-ibm/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

**Description**

We were making calls to get the multitenant cpu_enforcement_ratios for databases that do not support multitenant. The API would reply with an error. This fix makes sure that we don't try to get the cpu_enforcement_ratios in the event that a databases is NOT multitenant.

It also enhances the way we report errors for databases that do not support multitenant.

Displays error messages if an invalid host_flavor is passed.

**Examples of Fix Working**

**Mongodb Enterprise**
```
data "ibm_resource_group" "group" {
  name = "default"
}

resource "ibm_database" "test_acc" {
  name              = "coolguy-mongodb-two"
  plan              = "enterprise"
  location          = "eu-gb"
  service           = "databases-for-mongodb"
  resource_group_id = data.ibm_resource_group.group.id
   group {
    group_id = "member"
  } 
}
```

`Apply complete! Resources: 1 added, 0 changed, 0 destroyed.`

**EnterpriseDB**

```
data "ibm_resource_group" "group" {
  name = "default"
}

resource "ibm_database" "test_acc" {
  name              = "coolguy-edb-two"
  plan              = "standard"
  location          = "eu-gb"
  service           = "databases-for-enterprisedb"
  resource_group_id = data.ibm_resource_group.group.id
   group {
    group_id = "member"
  } 
}
```

**New Error Messaging**
```
resource "ibm_database" "mongdb" {
  name              = "coolguy-mongo"
  plan              = "enterprise"
  location          = "us-south"
  service           = "databases-for-mongodb"
  resource_group_id = data.ibm_resource_group.group.id

  group {
    group_id = "member"

    host_flavor {
      id = "multitenant"      
    }
  }
}
```

```
Planning failed. Terraform encountered an error while generating this plan.

╷
│ Error: 1 error occurred:
│ 	* mongodbee is not available on multitenant

```

**Host Flavor Validation**

```
resource "ibm_database" "test_acc" {
  name              = "coolguy-mongodb-two"
  plan              = "enterprise"
  location          = "eu-gb"
  service           = "databases-for-mongodb"
  resource_group_id = data.ibm_resource_group.group.id
   group {
    group_id = "member"
    host_flavor {
      id = "notValid"      
    }
  } 
}
```

```
│ Error: expected group.0.host_flavor.0.id to be one of ["multitenant" "b3c.4x16.encrypted" "b3c.8x32.encrypted" "m3c.8x64.encrypted" "b3c.16x64.encrypted" "b3c.32x128.encrypted" "m3c.30x240.encrypted"], got notValid
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TEST=./ibm/service/database TESTARGS='-run=TestAccIBMDatabaseInstance_Redis_Basic'
--- PASS: TestAccIBMDatabaseInstance_Redis_Basic (1427.93s)
PASS
ok  	github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/database	1429.586s
```

```
make testacc TEST=./ibm/service/database TESTARGS='-run=TestAccIBMMongoDBEnterpriseDatabaseInstanceBasic'
--- PASS: TestAccIBMMongoDBEnterpriseDatabaseInstanceBasic (8161.14s)
PASS
ok  	github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/database	8162.930s
```
