### PR TITLE
feat: wrap provider to create new error structures

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/IBM/event-notifications-go-admin-sdk v0.4.0
 	github.com/IBM/eventstreams-go-sdk v1.4.0
 	github.com/IBM/go-sdk-core/v3 v3.2.4
-	github.com/IBM/go-sdk-core/v5 v5.16.5
+	github.com/IBM/go-sdk-core/v5 v5.17.0
 	github.com/IBM/ibm-cos-sdk-go v1.10.1
 	github.com/IBM/ibm-cos-sdk-go-config/v2 v2.0.4
 	github.com/IBM/ibm-hpcs-tke-sdk v0.0.0-20211109141421-a4b61b05f7d1

--- a/go.sum
+++ b/go.sum
@@ -141,8 +141,8 @@ github.com/IBM/go-sdk-core/v5 v5.7.0/go.mod h1:+YbdhrjCHC84ls4MeBp+Hj4NZCni+tDAc
 github.com/IBM/go-sdk-core/v5 v5.9.2/go.mod h1:YlOwV9LeuclmT/qi/LAK2AsobbAP42veV0j68/rlZsE=
 github.com/IBM/go-sdk-core/v5 v5.9.5/go.mod h1:YlOwV9LeuclmT/qi/LAK2AsobbAP42veV0j68/rlZsE=
 github.com/IBM/go-sdk-core/v5 v5.10.2/go.mod h1:WZPFasUzsKab/2mzt29xPcfruSk5js2ywAPwW4VJjdI=
-github.com/IBM/go-sdk-core/v5 v5.16.5 h1:5ZltNcryRI8kVcuvNJGR2EXKqb7HtM4atA0Nm5QwAFE=
-github.com/IBM/go-sdk-core/v5 v5.16.5/go.mod h1:GatGZpxlo1KaxiRN6E10/rNgWtUtx1hN/GoHSCaSPKA=
+github.com/IBM/go-sdk-core/v5 v5.17.0 h1:J/8by7r70JmCYqXL/NHFcgpneFAqv16oKMtif+syA14=
+github.com/IBM/go-sdk-core/v5 v5.17.0/go.mod h1:GatGZpxlo1KaxiRN6E10/rNgWtUtx1hN/GoHSCaSPKA=
 github.com/IBM/ibm-cos-sdk-go v1.10.1 h1:vQCsu61OHRVF2lL6ah+m3AmUlhnYGkI1qogukCEFULs=
 github.com/IBM/ibm-cos-sdk-go v1.10.1/go.mod h1:zhcgfL2YG5DVaI5R2F6oYO2DYnvwW14vpcpFq+ybhXU=
 github.com/IBM/ibm-cos-sdk-go-config/v2 v2.0.4 h1:fvy/cMKn/3BngdxaL5dXaSlUuzTANY42VuVQuW0NEYE=

--- a/ibm/flex/terraform_problem_test.go
+++ b/ibm/flex/terraform_problem_test.go
@@ -1,0 +1,216 @@
+package flex
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	v "github.com/IBM-Cloud/terraform-provider-ibm/version"
+	"github.com/IBM/go-sdk-core/v5/core"
+	"github.com/stretchr/testify/assert"
+)
+
+const (
+	MODULE_NAME  = "github.com/IBM-Cloud/terraform-provider-ibm"
+	MOCK_VERSION = "1.63.0"
+)
+
+func TestTerraformProblemEmbedsIBMProblem(t *testing.T) {
+	terraformProb := &TerraformProblem{}
+
+	// Check that the methods defined by IBMProblem are supported here.
+	assert.NotNil(t, terraformProb.Error)
+	assert.NotNil(t, terraformProb.GetBaseSignature)
+	assert.NotNil(t, terraformProb.GetCausedBy)
+	assert.NotNil(t, terraformProb.Unwrap)
+}
+
+func TestTerraformProblemGetConsoleMessage(t *testing.T) {
+	terraformProb := getPopulatedTerraformProblem()
+	message := terraformProb.GetConsoleMessage()
+	expected := `---
+id: terraform-98c0e1fd
+summary: Create failed.
+severity: error
+resource: ibm_some_resource
+operation: create
+component:
+  name: github.com/IBM-Cloud/terraform-provider-ibm
+  version: 1.63.0
+---
+`
+	assert.Equal(t, expected, message)
+}
+
+func TestTerraformProblemGetDebugMessage(t *testing.T) {
+	terraformProb := getPopulatedTerraformProblem()
+	message := terraformProb.GetDebugMessage()
+	expected := `---
+id: terraform-98c0e1fd
+summary: Create failed.
+severity: error
+resource: ibm_some_resource
+operation: create
+component:
+  name: github.com/IBM-Cloud/terraform-provider-ibm
+  version: 1.63.0
+---
+`
+	assert.Equal(t, expected, message)
+}
+
+func TestTerraformProblemGetID(t *testing.T) {
+	terraformProb := getPopulatedTerraformProblem()
+	assert.Equal(t, "terraform-98c0e1fd", terraformProb.GetID())
+}
+
+func TestTerraformProblemGetConsoleOrderedMaps(t *testing.T) {
+	terraformProb := getPopulatedTerraformProblem()
+	orderedMaps := terraformProb.GetConsoleOrderedMaps()
+	assert.NotNil(t, orderedMaps)
+
+	maps := orderedMaps.GetMaps()
+	assert.NotNil(t, maps)
+	assert.Len(t, maps, 6)
+
+	assert.Equal(t, "id", maps[0].Key)
+	assert.Equal(t, "terraform-98c0e1fd", maps[0].Value)
+
+	assert.Equal(t, "summary", maps[1].Key)
+	assert.Equal(t, "Create failed.", maps[1].Value)
+
+	assert.Equal(t, "severity", maps[2].Key)
+	assert.Equal(t, core.ErrorSeverity, maps[2].Value)
+
+	assert.Equal(t, "resource", maps[3].Key)
+	assert.Equal(t, "ibm_some_resource", maps[3].Value)
+
+	assert.Equal(t, "operation", maps[4].Key)
+	assert.Equal(t, "create", maps[4].Value)
+
+	assert.Equal(t, "component", maps[5].Key)
+	assert.Equal(t, MODULE_NAME, maps[5].Value.(*core.ProblemComponent).Name)
+	assert.Equal(t, MOCK_VERSION, maps[5].Value.(*core.ProblemComponent).Version)
+}
+
+func TestTerraformProblemGetDebugOrderedMaps(t *testing.T) {
+	terraformProb := getPopulatedTerraformProblem()
+	orderedMaps := terraformProb.GetDebugOrderedMaps()
+	assert.NotNil(t, orderedMaps)
+
+	maps := orderedMaps.GetMaps()
+	assert.NotNil(t, maps)
+	assert.Len(t, maps, 6)
+
+	assert.Equal(t, "id", maps[0].Key)
+	assert.Equal(t, "terraform-98c0e1fd", maps[0].Value)
+
+	assert.Equal(t, "summary", maps[1].Key)
+	assert.Equal(t, "Create failed.", maps[1].Value)
+
+	assert.Equal(t, "severity", maps[2].Key)
+	assert.Equal(t, core.ErrorSeverity, maps[2].Value)
+
+	assert.Equal(t, "resource", maps[3].Key)
+	assert.Equal(t, "ibm_some_resource", maps[3].Value)
+
+	assert.Equal(t, "operation", maps[4].Key)
+	assert.Equal(t, "create", maps[4].Value)
+
+	assert.Equal(t, "component", maps[5].Key)
+	assert.Equal(t, MODULE_NAME, maps[5].Value.(*core.ProblemComponent).Name)
+	assert.Equal(t, MOCK_VERSION, maps[5].Value.(*core.ProblemComponent).Version)
+}
+
+func TestTerraformProblemGetDiag(t *testing.T) {
+	terraformProb := getPopulatedTerraformProblem()
+	diagnostics := terraformProb.GetDiag()
+
+	assert.True(t, diagnostics.HasError())
+	assert.Len(t, diagnostics, 1)
+
+	diagnostic := diagnostics[0]
+	assert.Nil(t, diagnostic.Validate())
+	assert.Equal(t, terraformProb.GetConsoleMessage(), diagnostic.Summary)
+}
+
+func TestTerraformErrorf(t *testing.T) {
+	causedBy := &core.SDKProblem{}
+	summary := "Update failed."
+	resourceName := "ibm_some_resource"
+	operation := "update"
+
+	terraformProb := TerraformErrorf(causedBy, summary, resourceName, operation)
+	assert.NotNil(t, terraformProb)
+	assert.Equal(t, summary, terraformProb.Summary)
+	assert.Equal(t, getComponentInfo(), terraformProb.Component)
+	assert.Equal(t, core.ErrorSeverity, terraformProb.Severity)
+}
+
+func TestFmtErrorfWithProblem(t *testing.T) {
+	msg := "Request failed."
+	sdkProb := &core.SDKProblem{
+		IBMProblem: &core.IBMProblem{
+			Summary: msg,
+		},
+	}
+
+	err := FmtErrorf("Operation failed: %s", sdkProb)
+
+	var tfErr *TerraformProblem
+	assert.ErrorAs(t, err, &tfErr)
+	assert.NotNil(t, tfErr)
+	assert.Equal(t, "Operation failed: Request failed.", tfErr.Summary)
+	assert.ErrorIs(t, tfErr.GetCausedBy(), sdkProb)
+}
+
+func TestFmtErrorfWithNoError(t *testing.T) {
+	msg := "Bad input"
+	err := FmtErrorf("Operation failed: %s", msg)
+	assert.Equal(t, "Operation failed: Bad input", err.Error())
+	assert.Equal(t, fmt.Errorf("Operation failed: %s", msg).Error(), err.Error())
+
+	var errAsProb core.Problem
+	assert.False(t, errors.As(err, &errAsProb))
+	assert.Nil(t, errAsProb)
+}
+
+func TestFmtErrorfWithProblemInServiceErrorResponse(t *testing.T) {
+	msg := "Request failed."
+	sdkProb := &core.SDKProblem{
+		IBMProblem: &core.IBMProblem{
+			Summary: msg,
+		},
+	}
+
+	ser := &ServiceErrorResponse{
+		Error: sdkProb,
+	}
+
+	err := FmtErrorf("Operation failed: %s", ser)
+
+	var tfErr *TerraformProblem
+	assert.ErrorAs(t, err, &tfErr)
+	assert.NotNil(t, tfErr)
+	assert.Equal(t, fmt.Sprintf("Operation failed: %s", ser), tfErr.Summary)
+	assert.ErrorIs(t, tfErr.GetCausedBy(), sdkProb)
+}
+
+func TestGetComponentInfo(t *testing.T) {
+	component := getComponentInfo()
+	assert.NotNil(t, component)
+	assert.Equal(t, MODULE_NAME, component.Name)
+	assert.Equal(t, v.Version, component.Version)
+}
+
+func getPopulatedTerraformProblem() *TerraformProblem {
+	return &TerraformProblem{
+		IBMProblem: &core.IBMProblem{
+			Summary:   "Create failed.",
+			Component: core.NewProblemComponent(MODULE_NAME, MOCK_VERSION),
+			Severity:  core.ErrorSeverity,
+		},
+		Resource:  "ibm_some_resource",
+		Operation: "create",
+	}
+}

--- a/ibm/provider/provider.go
+++ b/ibm/provider/provider.go
@@ -4,11 +4,16 @@
 package provider
 
 import (
+	"context"
+	"errors"
+	"fmt"
+	"log"
 	"os"
 	"sync"
 	"time"
 
 	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/conns"
+	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/flex"
 	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/apigateway"
 	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/appconfiguration"
 	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/appid"
@@ -56,12 +61,13 @@ import (
 	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/vmware"
 	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/vpc"
 	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/validate"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
 // Provider returns a *schema.Provider.
 func Provider() *schema.Provider {
-	return &schema.Provider{
+	provider := schema.Provider{
 		Schema: map[string]*schema.Schema{
 			"bluemix_api_key": {
 				Type:        schema.TypeString,
@@ -1450,6 +1456,150 @@ func Provider() *schema.Provider {
 
 		ConfigureFunc: providerConfigure,
 	}
+
+	wrappedProvider := wrapProvider(provider)
+	return &wrappedProvider
+}
+
+func wrapProvider(provider schema.Provider) schema.Provider {
+	wrappedResourcesMap := map[string]*schema.Resource{}
+	wrappedDataSourcesMap := map[string]*schema.Resource{}
+
+	for key, value := range provider.ResourcesMap {
+		wrappedResourcesMap[key] = wrapResource(key, value)
+	}
+
+	for key, value := range provider.DataSourcesMap {
+		wrappedDataSourcesMap[key] = wrapDataSource(key, value)
+	}
+
+	return schema.Provider{
+		Schema:         provider.Schema,
+		DataSourcesMap: wrappedDataSourcesMap,
+		ResourcesMap:   wrappedResourcesMap,
+		ConfigureFunc:  provider.ConfigureFunc,
+	}
+}
+
+func wrapResource(name string, resource *schema.Resource) *schema.Resource {
+	return &schema.Resource{
+		Schema:               resource.Schema,
+		SchemaVersion:        resource.SchemaVersion,
+		MigrateState:         resource.MigrateState,
+		StateUpgraders:       resource.StateUpgraders,
+		Exists:               resource.Exists,
+		CreateContext:        wrapFunction(name, "create", resource.CreateContext, resource.Create, false),
+		ReadContext:          wrapFunction(name, "read", resource.ReadContext, resource.Read, false),
+		UpdateContext:        wrapFunction(name, "update", resource.UpdateContext, resource.Update, false),
+		DeleteContext:        wrapFunction(name, "delete", resource.DeleteContext, resource.Delete, false),
+		CreateWithoutTimeout: wrapFunction(name, "create", resource.CreateWithoutTimeout, nil, false),
+		ReadWithoutTimeout:   wrapFunction(name, "read", resource.ReadWithoutTimeout, nil, false),
+		UpdateWithoutTimeout: wrapFunction(name, "update", resource.UpdateWithoutTimeout, nil, false),
+		DeleteWithoutTimeout: wrapFunction(name, "delete", resource.DeleteWithoutTimeout, nil, false),
+		CustomizeDiff:        wrapCustomizeDiff(name, resource.CustomizeDiff),
+		Importer:             resource.Importer,
+		DeprecationMessage:   resource.DeprecationMessage,
+		Timeouts:             resource.Timeouts,
+		Description:          resource.Description,
+		UseJSONNumber:        resource.UseJSONNumber,
+	}
+}
+
+func wrapDataSource(name string, resource *schema.Resource) *schema.Resource {
+	return &schema.Resource{
+		Schema:             resource.Schema,
+		SchemaVersion:      resource.SchemaVersion,
+		MigrateState:       resource.MigrateState,
+		StateUpgraders:     resource.StateUpgraders,
+		Exists:             resource.Exists,
+		ReadContext:        wrapFunction(name, "read", resource.ReadContext, resource.Read, true),
+		ReadWithoutTimeout: wrapFunction(name, "read", resource.ReadWithoutTimeout, nil, true),
+		Importer:           resource.Importer,
+		DeprecationMessage: resource.DeprecationMessage,
+		Timeouts:           resource.Timeouts,
+		Description:        resource.Description,
+		UseJSONNumber:      resource.UseJSONNumber,
+	}
+}
+
+func wrapFunction(
+	resourceName, operationName string,
+	function func(context.Context, *schema.ResourceData, interface{}) diag.Diagnostics,
+	fallback func(*schema.ResourceData, interface{}) error,
+	isDataSource bool,
+) func(context.Context, *schema.ResourceData, interface{}) diag.Diagnostics {
+	if function != nil {
+		return func(context context.Context, schema *schema.ResourceData, meta interface{}) diag.Diagnostics {
+			return function(context, schema, meta)
+		}
+	} else if fallback != nil {
+		return func(context context.Context, schema *schema.ResourceData, meta interface{}) diag.Diagnostics {
+			return wrapError(fallback(schema, meta), resourceName, operationName, isDataSource)
+		}
+	}
+
+	return nil
+}
+
+func wrapError(err error, resourceName, operationName string, isDataSource bool) diag.Diagnostics {
+	if err == nil {
+		return nil
+	}
+
+	var diags diag.Diagnostics
+
+	// Distinguish data sources from resources. Data sources technically are resources but
+	// they may have the same names and we need to tell them apart.
+	if isDataSource {
+		resourceName = fmt.Sprintf("(Data) %s", resourceName)
+	}
+
+	var tfError *flex.TerraformProblem
+	if errors.As(err, &tfError) {
+		tfError.Resource = resourceName
+		tfError.Operation = operationName
+	} else {
+		tfError = flex.TerraformErrorf(err, "", resourceName, operationName)
+	}
+
+	log.Printf("[DEBUG] %s", tfError.GetDebugMessage())
+	return append(
+		diags,
+		diag.Diagnostic{
+			Severity: diag.Error,
+			Summary:  tfError.Error(),
+			Detail:   tfError.GetConsoleMessage(),
+		},
+	)
+}
+
+func wrapCustomizeDiff(resourceName string, function schema.CustomizeDiffFunc) schema.CustomizeDiffFunc {
+	if function == nil {
+		return nil
+	}
+
+	return func(c context.Context, rd *schema.ResourceDiff, i interface{}) error {
+		return wrapDiffErrors(function(c, rd, i), resourceName)
+	}
+}
+
+func wrapDiffErrors(err error, resourceName string) error {
+	if err != nil {
+		// CustomizeDiff fields often use the customizediff.All() method, which concatenates the errors
+		// returned from multiple functions using errors.Join(). Individual errors are still embedded in the
+		// error and will be extracted when the error is unwrapped by the Go core.
+		tfError := flex.TerraformErrorf(err, err.Error(), resourceName, "CustomizeDiff")
+
+		// By the time this error gets printed by the Terraform code, we've lost control of it and the
+		// message that gets printed comes from the Error() method (and we only see the Summary).
+		// Although it would be ideal to return the full TerraformError object, it is sufficient
+		// to package the console message into a new error so that the user gets the information.
+		log.Printf("[DEBUG] %s", tfError.GetDebugMessage())
+		return errors.New(tfError.GetConsoleMessage())
+	}
+
+	// Return the nil error.
+	return err
 }
 
 var (


### PR DESCRIPTION
This commit adds code that wraps the provider in order to catch errors and re-format them with the new system, to minimize the surface area of the changes required for non-generated resource/data source code.

The primary change to resource code comes in the from of updating calls to `fmt.Errorf` to be calls to a new wrapper function, `flex.FmtErrorf`. It accepts the same arguments but instead of wrapping errors coming from the underlying Go SDK so that we retain only the message, it creates instances of the new TerraformProblem type to be propagated to the wrapped provider code. This way, we preserve all of the information needed for the new error formats, including the information from previous errors.

Note: This PR just creates the baseline support. Resource code that returns an `error` (rather than a `diag.Diagnostics` will start to get support for new errors right away, but they will not have all information needed from previous errors in the SDK. For that, individual service teams will need to update their code to use `flex.FmtErrorf` instead of `fmt.Errorf`.

@hkantare 

<!--- See what makes a good Pull Request at : https://github.com/IBM-Cloud/terraform-provider-ibm/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->
