### PR TITLE
Import vmware dependency, and format vmware provider files

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -65,6 +65,7 @@ require (
 	github.com/IBM/go-sdk-core v1.1.0
 	github.com/IBM/mqcloud-go-sdk v0.0.4
 	github.com/IBM/sarama v1.41.2
+	github.com/IBM/vmware-go-sdk v0.1.2
 	github.com/stretchr/testify v1.9.0
 	k8s.io/utils v0.0.0-20230313181309-38a27ef9d749
 	sigs.k8s.io/controller-runtime v0.14.1

--- a/go.sum
+++ b/go.sum
@@ -172,6 +172,8 @@ github.com/IBM/schematics-go-sdk v0.2.3 h1:lgTt0Sbudii3cuSk1YSQgrtiZAXDbBABAoVj3
 github.com/IBM/schematics-go-sdk v0.2.3/go.mod h1:Tw2OSAPdpC69AxcwoyqcYYaGTTW6YpERF9uNEU+BFRQ=
 github.com/IBM/secrets-manager-go-sdk/v2 v2.0.4 h1:xa9e+POVqaXxXHXkSMCOVAbKdUNEu86jQmo5hcpd+L4=
 github.com/IBM/secrets-manager-go-sdk/v2 v2.0.4/go.mod h1:5gq8D8uWOIbqOm1uztay6lpOysgJaxxEsaVZLWGWb40=
+github.com/IBM/vmware-go-sdk v0.1.2 h1:5lKWFyInWz9e2hwGsoFTEoLa1jYkD30SReN0fQ10w9M=
+github.com/IBM/vmware-go-sdk v0.1.2/go.mod h1:2UGPBJju3jiv5VKKBBm9a5L6bzF/aJdKOKAzJ7HaOjA=
 github.com/IBM/vpc-beta-go-sdk v0.6.0 h1:wfM3AcW3zOM3xsRtZ+EA6+sESlGUjQ6Yf4n5QQyz4uc=
 github.com/IBM/vpc-beta-go-sdk v0.6.0/go.mod h1:fzHDAQIqH/5yJmYsKodKHLcqxMDT+yfH6vZjdiw8CQA=
 github.com/IBM/vpc-go-sdk v0.50.0 h1:+vnXYK0FXFXYqaS/5/X1XEqH0bbRotkzkerRk21ZEjE=

--- a/ibm/conns/config.go
+++ b/ibm/conns/config.go
@@ -82,10 +82,10 @@ import (
 	project "github.com/IBM/project-go-sdk/projectv1"
 	"github.com/IBM/push-notifications-go-sdk/pushservicev1"
 	schematicsv1 "github.com/IBM/schematics-go-sdk/schematicsv1"
+	"github.com/IBM/vmware-go-sdk/vmwarev1"
 	vpcbeta "github.com/IBM/vpc-beta-go-sdk/vpcbetav1"
 	"github.com/IBM/vpc-go-sdk/common"
 	vpc "github.com/IBM/vpc-go-sdk/vpcv1"
-	"github.com/IBM/vmware-go-sdk/vmwarev1"
 	"github.com/apache/openwhisk-client-go/whisk"
 	jwt "github.com/golang-jwt/jwt"
 	slsession "github.com/softlayer/softlayer-go/session"
@@ -630,8 +630,8 @@ type clientSession struct {
 	mqcloudClientErr error
 
 	// VMware as a Service
-	vmwareClient     *vmwarev1.VmwareV1
-	vmwareClientErr  error
+	vmwareClient    *vmwarev1.VmwareV1
+	vmwareClientErr error
 }
 
 // Usage Reports
@@ -3270,7 +3270,7 @@ func (c *Config) ClientSession() (interface{}, error) {
 	vmwareURL := ContructEndpoint(fmt.Sprintf("api.%s.vmware", c.Region), cloudEndpoint+"/v1")
 	vmwareClientOptions := &vmwarev1.VmwareV1Options{
 		Authenticator: authenticator,
-		URL:    EnvFallBack([]string{"VMWARE_URL"}, vmwareURL),
+		URL:           EnvFallBack([]string{"VMWARE_URL"}, vmwareURL),
 	}
 
 	// Construct the service client.
@@ -3280,7 +3280,7 @@ func (c *Config) ClientSession() (interface{}, error) {
 		session.vmwareClient.Service.EnableRetries(c.RetryCount, c.RetryDelay)
 		// Add custom header for analytics
 		session.vmwareClient.SetDefaultHeaders(gohttp.Header{
-			"X-Original-User-Agent": { fmt.Sprintf("terraform-provider-ibm/%s", version.Version) },
+			"X-Original-User-Agent": {fmt.Sprintf("terraform-provider-ibm/%s", version.Version)},
 		})
 	} else {
 		session.vmwareClientErr = fmt.Errorf("Error occurred while configuring VMware as a Service API service: %q", err)

--- a/ibm/provider/provider.go
+++ b/ibm/provider/provider.go
@@ -53,8 +53,8 @@ import (
 	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/secretsmanager"
 	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/transitgateway"
 	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/usagereports"
-	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/vpc"
 	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/vmware"
+	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/vpc"
 	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/validate"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
@@ -898,7 +898,7 @@ func Provider() *schema.Provider {
 			"ibm_project":             project.DataSourceIbmProject(),
 			"ibm_project_config":      project.DataSourceIbmProjectConfig(),
 			"ibm_project_environment": project.DataSourceIbmProjectEnvironment(),
-		
+
 			// Added for VMware as a Service
 			"ibm_vmaas_vdc": vmware.DataSourceIbmVmaasVdc(),
 		},

--- a/ibm/service/vmware/data_source_ibm_vmaas_vdc.go
+++ b/ibm/service/vmware/data_source_ibm_vmaas_vdc.go
@@ -366,7 +366,7 @@ func dataSourceIbmVmaasVdcRead(context context.Context, d *schema.ResourceData, 
 
 	edges := []map[string]interface{}{}
 	if vDC.Edges != nil {
-		for _, modelItem := range vDC.Edges { 
+		for _, modelItem := range vDC.Edges {
 			modelMap, err := dataSourceIbmVmaasVdcEdgeToMap(&modelItem)
 			if err != nil {
 				return diag.FromErr(err)
@@ -380,7 +380,7 @@ func dataSourceIbmVmaasVdcRead(context context.Context, d *schema.ResourceData, 
 
 	statusReasons := []map[string]interface{}{}
 	if vDC.StatusReasons != nil {
-		for _, modelItem := range vDC.StatusReasons { 
+		for _, modelItem := range vDC.StatusReasons {
 			modelMap, err := dataSourceIbmVmaasVdcStatusReasonToMap(&modelItem)
 			if err != nil {
 				return diag.FromErr(err)

--- a/ibm/service/vmware/data_source_ibm_vmaas_vdc_test.go
+++ b/ibm/service/vmware/data_source_ibm_vmaas_vdc_test.go
@@ -75,17 +75,17 @@ func TestAccIbmVmaasVdcDataSourceAllArgs(t *testing.T) {
 					resource.TestCheckResourceAttrSet("data.ibm_vmaas_vdc.vmaas_vdc_instance", "director_site.#"),
 					resource.TestCheckResourceAttrSet("data.ibm_vmaas_vdc.vmaas_vdc_instance", "edges.#"),
 					/*
-					resource.TestCheckResourceAttrSet("data.ibm_vmaas_vdc.vmaas_vdc_instance", "edges.0.id"),
-					resource.TestCheckResourceAttrSet("data.ibm_vmaas_vdc.vmaas_vdc_instance", "edges.0.size"),
-					resource.TestCheckResourceAttrSet("data.ibm_vmaas_vdc.vmaas_vdc_instance", "edges.0.status"),
-					resource.TestCheckResourceAttrSet("data.ibm_vmaas_vdc.vmaas_vdc_instance", "edges.0.type"),
-					resource.TestCheckResourceAttrSet("data.ibm_vmaas_vdc.vmaas_vdc_instance", "edges.0.version"),
+						resource.TestCheckResourceAttrSet("data.ibm_vmaas_vdc.vmaas_vdc_instance", "edges.0.id"),
+						resource.TestCheckResourceAttrSet("data.ibm_vmaas_vdc.vmaas_vdc_instance", "edges.0.size"),
+						resource.TestCheckResourceAttrSet("data.ibm_vmaas_vdc.vmaas_vdc_instance", "edges.0.status"),
+						resource.TestCheckResourceAttrSet("data.ibm_vmaas_vdc.vmaas_vdc_instance", "edges.0.type"),
+						resource.TestCheckResourceAttrSet("data.ibm_vmaas_vdc.vmaas_vdc_instance", "edges.0.version"),
 					*/
 					resource.TestCheckResourceAttrSet("data.ibm_vmaas_vdc.vmaas_vdc_instance", "status_reasons.#"),
 					/*
-					resource.TestCheckResourceAttrSet("data.ibm_vmaas_vdc.vmaas_vdc_instance", "status_reasons.0.code"),
-					resource.TestCheckResourceAttrSet("data.ibm_vmaas_vdc.vmaas_vdc_instance", "status_reasons.0.message"),
-					resource.TestCheckResourceAttrSet("data.ibm_vmaas_vdc.vmaas_vdc_instance", "status_reasons.0.more_info"),
+						resource.TestCheckResourceAttrSet("data.ibm_vmaas_vdc.vmaas_vdc_instance", "status_reasons.0.code"),
+						resource.TestCheckResourceAttrSet("data.ibm_vmaas_vdc.vmaas_vdc_instance", "status_reasons.0.message"),
+						resource.TestCheckResourceAttrSet("data.ibm_vmaas_vdc.vmaas_vdc_instance", "status_reasons.0.more_info"),
 					*/
 					resource.TestCheckResourceAttrSet("data.ibm_vmaas_vdc.vmaas_vdc_instance", "name"),
 					resource.TestCheckResourceAttrSet("data.ibm_vmaas_vdc.vmaas_vdc_instance", "ordered_at"),
@@ -120,7 +120,7 @@ func testAccCheckIbmVmaasVdcDataSourceConfigBasic(ds_id string, ds_pvdc_id strin
 		data "ibm_vmaas_vdc" "vmaas_vdc_instance" {
 			vmaas_vdc_id = ibm_vmaas_vdc.vmaas_vdc_instance.id
 		}
-	`,ds_id, ds_pvdc_id, vDCName)
+	`, ds_id, ds_pvdc_id, vDCName)
 }
 
 func testAccCheckIbmVmaasVdcDataSourceConfig(vDCCpu string, ds_id string, ds_pvdc_id string, vDCName string, vDCRam string, vDCFastProvisioningEnabled string, vDCRhelByol string, vDCWindowsByol string) string {

--- a/ibm/service/vmware/resource_ibm_vmaas_vdc.go
+++ b/ibm/service/vmware/resource_ibm_vmaas_vdc.go
@@ -20,24 +20,24 @@ import (
 
 func ResourceIbmVmaasVdc() *schema.Resource {
 	return &schema.Resource{
-		CreateContext:   resourceIbmVmaasVdcCreate,
-		ReadContext:     resourceIbmVmaasVdcRead,
-		UpdateContext:   resourceIbmVmaasVdcUpdate,
-		DeleteContext:   resourceIbmVmaasVdcDelete,
-		Importer: &schema.ResourceImporter{},
+		CreateContext: resourceIbmVmaasVdcCreate,
+		ReadContext:   resourceIbmVmaasVdcRead,
+		UpdateContext: resourceIbmVmaasVdcUpdate,
+		DeleteContext: resourceIbmVmaasVdcDelete,
+		Importer:      &schema.ResourceImporter{},
 
 		Schema: map[string]*schema.Schema{
 			"accept_language": &schema.Schema{
-				Type:        schema.TypeString,
-				Optional:    true,
+				Type:         schema.TypeString,
+				Optional:     true,
 				ValidateFunc: validate.InvokeValidator("ibm_vmaas_vdc", "accept_language"),
-				Description: "Language.",
+				Description:  "Language.",
 			},
 			"cpu": &schema.Schema{
-				Type:        schema.TypeInt,
-				Optional:    true,
+				Type:         schema.TypeInt,
+				Optional:     true,
 				ValidateFunc: validate.InvokeValidator("ibm_vmaas_vdc", "cpu"),
-				Description: "The vCPU usage limit on the virtual data center (VDC). Supported for VDCs deployed on a multitenant Cloud Director site. This property is applicable when the resource pool type is reserved.",
+				Description:  "The vCPU usage limit on the virtual data center (VDC). Supported for VDCs deployed on a multitenant Cloud Director site. This property is applicable when the resource pool type is reserved.",
 			},
 			"director_site": &schema.Schema{
 				Type:        schema.TypeList,
@@ -92,16 +92,16 @@ func ResourceIbmVmaasVdc() *schema.Resource {
 				},
 			},
 			"name": &schema.Schema{
-				Type:        schema.TypeString,
-				Required:    true,
+				Type:         schema.TypeString,
+				Required:     true,
 				ValidateFunc: validate.InvokeValidator("ibm_vmaas_vdc", "name"),
-				Description: "A human readable ID for the virtual data center (VDC).",
+				Description:  "A human readable ID for the virtual data center (VDC).",
 			},
 			"ram": &schema.Schema{
-				Type:        schema.TypeInt,
-				Optional:    true,
+				Type:         schema.TypeInt,
+				Optional:     true,
 				ValidateFunc: validate.InvokeValidator("ibm_vmaas_vdc", "ram"),
-				Description: "The RAM usage limit on the virtual data center (VDC) in GB (1024^3 bytes). Supported for VDCs deployed on a multitenant Cloud Director site. This property is applicable when the resource pool type is reserved.",
+				Description:  "The RAM usage limit on the virtual data center (VDC) in GB (1024^3 bytes). Supported for VDCs deployed on a multitenant Cloud Director site. This property is applicable when the resource pool type is reserved.",
 			},
 			"fast_provisioning_enabled": &schema.Schema{
 				Type:        schema.TypeBool,

--- a/ibm/service/vmware/resource_ibm_vmaas_vdc_test.go
+++ b/ibm/service/vmware/resource_ibm_vmaas_vdc_test.go
@@ -11,9 +11,9 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 
+	acc "github.com/IBM-Cloud/terraform-provider-ibm/ibm/acctest"
 	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/conns"
 	"github.com/IBM/vmware-go-sdk/vmwarev1"
-	acc "github.com/IBM-Cloud/terraform-provider-ibm/ibm/acctest"
 )
 
 func TestAccIbmVmaasVdcBasic(t *testing.T) {

--- a/ibm/service/vmware/utils.go
+++ b/ibm/service/vmware/utils.go
@@ -43,7 +43,7 @@ func waitForVdcStatusUpdate(context context.Context, d *schema.ResourceData, met
 			getVdcOptions := &vmwarev1.GetVdcOptions{}
 
 			getVdcOptions.SetID(d.Id())
-		
+
 			vdc, response, err := vmwareClient.GetVdcWithContext(context, getVdcOptions)
 			if err != nil {
 				if response != nil && response.StatusCode == 404 {
@@ -60,7 +60,7 @@ func waitForVdcStatusUpdate(context context.Context, d *schema.ResourceData, met
 
 			if *vdc.Status == "ready_to_use" {
 				return vdc, VdcFinalState, nil
-			} else if *vdc.Status == "failed"  {
+			} else if *vdc.Status == "failed" {
 				return vdc, VdcFinalState, fmt.Errorf("%s", err)
 			}
 			return vdc, VdcCreatingState, nil
@@ -85,9 +85,9 @@ func waitForVdcToDelete(context context.Context, d *schema.ResourceData, meta in
 			getVdcOptions := &vmwarev1.GetVdcOptions{}
 
 			getVdcOptions.SetID(d.Id())
-		
+
 			vdc, response, err := vmwareClient.GetVdcWithContext(context, getVdcOptions)
-			
+
 			if err != nil {
 				if response != nil && response.StatusCode == 404 {
 					fmt.Println("The vdc is deleted.")


### PR DESCRIPTION
There are currently formatting issues and missing dependencies preventing the ibmcloud provider from building.

```
$ make build
==> Checking that code complies with gofmt requirements...
gofmt needs running on the following files:
./ibm/conns/config.go
./ibm/provider/provider.go
./ibm/service/vmware/resource_ibm_vmaas_vdc.go
./ibm/service/vmware/resource_ibm_vmaas_vdc_test.go
./ibm/service/vmware/utils.go
./ibm/service/vmware/data_source_ibm_vmaas_vdc_test.go
./ibm/service/vmware/data_source_ibm_vmaas_vdc.go
You can use the command: `make fmt` to reformat code.
make: *** [fmtcheck] Error 1
```

This PR resolves those, but there should be some git action preventing unformatted commits from merging.