### PR TITLE
Produce error when selecting invalid region in toolchain service

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -74,6 +74,7 @@ require (
 require (
 	cloud.google.com/go/kms v1.10.1 // indirect
 	cloud.google.com/go/monitoring v1.13.0 // indirect
+	github.com/IBM/vmware-go-sdk v0.1.2 // indirect
 	github.com/Logicalis/asn1 v0.0.0-20190312173541-d60463189a56 // indirect
 	github.com/PromonLogicalis/asn1 v0.0.0-20190312173541-d60463189a56 // indirect
 	github.com/ProtonMail/go-crypto v0.0.0-20230828082145-3c4c8a2d2371 // indirect

--- a/ibm/conns/config.go
+++ b/ibm/conns/config.go
@@ -3181,7 +3181,7 @@ func (c *Config) ClientSession() (interface{}, error) {
 		cdToolchainClientURL, err = cdtoolchainv2.GetServiceURLForRegion(c.Region)
 	}
 	if err != nil {
-		cdToolchainClientURL = cdtoolchainv2.DefaultServiceURL
+		session.cdToolchainClientErr = fmt.Errorf("Error occurred while configuring Toolchain service: %q", err)
 	}
 	if fileMap != nil && c.Visibility != "public-and-private" {
 		cdToolchainClientURL = fileFallBack(fileMap, c.Visibility, "IBMCLOUD_TOOLCHAIN_ENDPOINT", c.Region, cdToolchainClientURL)


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/IBM-Cloud/terraform-provider-ibm/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes [#5275 ](https://github.com/IBM-Cloud/terraform-provider-ibm/issues/5275)

**NOTE**: Any modifications not directly related to toolchain service was made by the formatter, or while installing modules needed for running acceptance tests.

Used the following env vars to run acceptance tests:
```
export IC_API_KEY="<IAM API Key>"
export IC_REGION="us-south"
export IAAS_CLASSIC_API_KEY="empty"
export IAAS_CLASSIC_USERNAME="empty"
export TESTARGS="-run TestAccIBMCdToolchainBasic" 
export IBM_CD_RESOURCE_GROUP_NAME="Default"
```

Output from acceptance testing (removed spam from WARN and INFO messages):

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test $(go list ./... |grep -v 'vendor') -v -run TestAccIBMCdToolchainBasic -timeout 700m
?   	github.com/IBM-Cloud/terraform-provider-ibm	[no test files]
?   	github.com/IBM-Cloud/terraform-provider-ibm/ibm/acctest	[no test files]
?   	github.com/IBM-Cloud/terraform-provider-ibm/ibm/provider	[no test files]
testing: warning: no tests to run
PASS
ok  	github.com/IBM-Cloud/terraform-provider-ibm/ibm/conns	(cached) [no tests to run]
testing: warning: no tests to run
PASS
ok  	github.com/IBM-Cloud/terraform-provider-ibm/ibm/flex	(cached) [no tests to run]
testing: warning: no tests to run
PASS
ok  	github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/apigateway	2.808s [no tests to run]
testing: warning: no tests to run
PASS
ok  	github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/appconfiguration	7.068s [no tests to run]
testing: warning: no tests to run
PASS
ok  	github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/appid	4.982s [no tests to run]
testing: warning: no tests to run
PASS
ok  	github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/atracker	9.266s [no tests to run]
testing: warning: no tests to run
PASS
ok  	github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/catalogmanagement	11.476s [no tests to run]
testing: warning: no tests to run
PASS
ok  	github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/cdtektonpipeline	13.725s [no tests to run]
?   	github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/kubernetes/utils/softwaredefinedstorage	[no test files]
=== RUN   TestAccIBMCdToolchainBasic
--- PASS: TestAccIBMCdToolchainBasic (48.96s)
PASS
ok  	github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/cdtoolchain	65.204s
testing: warning: no tests to run
PASS
ok  	github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/cis	20.163s [no tests to run]
testing: warning: no tests to run
PASS
ok  	github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/classicinfrastructure	18.739s [no tests to run]
testing: warning: no tests to run
PASS
ok  	github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/cloudant	21.474s [no tests to run]
testing: warning: no tests to run
PASS
ok  	github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/cloudfoundry	23.705s [no tests to run]
testing: warning: no tests to run
PASS
ok  	github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/cloudshell	25.755s [no tests to run]
testing: warning: no tests to run
PASS
ok  	github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/codeengine	22.983s [no tests to run]
testing: warning: no tests to run
PASS
ok  	github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/contextbasedrestrictions	22.730s [no tests to run]
testing: warning: no tests to run
PASS
ok  	github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/cos	22.828s [no tests to run]
testing: warning: no tests to run
PASS
ok  	github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/database	22.752s [no tests to run]
testing: warning: no tests to run
PASS
ok  	github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/directlink	22.822s [no tests to run]
testing: warning: no tests to run
PASS
ok  	github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/dnsservices	22.940s [no tests to run]
testing: warning: no tests to run
PASS
ok  	github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/enterprise	20.481s [no tests to run]
testing: warning: no tests to run
PASS
ok  	github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/eventnotification	21.000s [no tests to run]
testing: warning: no tests to run
PASS
ok  	github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/eventstreams	20.975s [no tests to run]
testing: warning: no tests to run
PASS
ok  	github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/functions	21.004s [no tests to run]
testing: warning: no tests to run
PASS
ok  	github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/globaltagging	20.859s [no tests to run]
testing: warning: no tests to run
PASS
ok  	github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/hpcs	21.096s [no tests to run]
testing: warning: no tests to run
PASS
ok  	github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/iamaccessgroup	21.087s [no tests to run]
testing: warning: no tests to run
PASS
ok  	github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/iamidentity	21.034s [no tests to run]
testing: warning: no tests to run
PASS
ok  	github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/iampolicy	20.929s [no tests to run]
testing: warning: no tests to run
PASS
ok  	github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/kms	20.589s [no tests to run]
testing: warning: no tests to run
PASS
ok  	github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/kubernetes	21.110s [no tests to run]
testing: warning: no tests to run
PASS
ok  	github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/metricsrouter	20.744s [no tests to run]
testing: warning: no tests to run
PASS
ok  	github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/mqcloud	21.931s [no tests to run]
testing: warning: no tests to run
PASS
ok  	github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/pag	22.998s [no tests to run]
testing: warning: no tests to run
PASS
ok  	github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/power	23.407s [no tests to run]
testing: warning: no tests to run
PASS
ok  	github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/project	23.066s [no tests to run]
?   	github.com/IBM-Cloud/terraform-provider-ibm/ibm/unittest	[no test files]
?   	github.com/IBM-Cloud/terraform-provider-ibm/ibm/validate	[no test files]
?   	github.com/IBM-Cloud/terraform-provider-ibm/version	[no test files]
testing: warning: no tests to run
PASS
ok  	github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/pushnotification	23.078s [no tests to run]
testing: warning: no tests to run
PASS
ok  	github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/registry	22.858s [no tests to run]
testing: warning: no tests to run
PASS
ok  	github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/resourcecontroller	22.581s [no tests to run]
testing: warning: no tests to run
PASS
ok  	github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/resourcemanager	22.166s [no tests to run]
testing: warning: no tests to run
PASS
ok  	github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/satellite	22.029s [no tests to run]
testing: warning: no tests to run
PASS
ok  	github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/scc	21.619s [no tests to run]
testing: warning: no tests to run
PASS
ok  	github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/schematics	21.057s [no tests to run]
testing: warning: no tests to run
PASS
ok  	github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/secretsmanager	22.576s [no tests to run]
testing: warning: no tests to run
PASS
ok  	github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/transitgateway	22.787s [no tests to run]
testing: warning: no tests to run
PASS
ok  	github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/usagereports	22.625s [no tests to run]
testing: warning: no tests to run
PASS
ok  	github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/vmware	22.466s [no tests to run]
testing: warning: no tests to run
PASS
ok  	github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/vpc	21.775s [no tests to run]
```
