### PR TITLE
Added IAM fields in enterprise create child account response

### DIFF
--- a/ibm/service/enterprise/resource_ibm_enterprise_account.go
+++ b/ibm/service/enterprise/resource_ibm_enterprise_account.go
@@ -163,6 +163,21 @@ func ResourceIBMEnterpriseAccount() *schema.Resource {
 				Computed:    true,
 				Description: "The IAM ID of the user or service that updated the account.",
 			},
+			"iam_service_id": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The IAM Service ID of the account will be used to create IAM_API_KEY with owner IAM policies.",
+			},
+			"iam_apikey_id": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The ID of IAM APIKEY which has owner IAM policies",
+			},
+			"iam_apikey": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The IAM API KEY of the account with owner IAM policies.",
+			},
 		},
 	}
 }
@@ -224,6 +239,15 @@ func resourceIbmEnterpriseAccountCreate(context context.Context, d *schema.Resou
 			return diag.FromErr(err)
 		}
 		d.SetId(*createAccountResponse.AccountID)
+		if (createAccountResponse.IamServiceID != nil) && (*createAccountResponse.IamServiceID != "") {
+			d.Set("iam_service_id", *createAccountResponse.IamServiceID)
+		}
+		if (createAccountResponse.IamApikeyID != nil) && (*createAccountResponse.IamApikeyID != "") {
+			d.Set("iam_apikey_id", *createAccountResponse.IamApikeyID)
+		}
+		if (createAccountResponse.IamApikey != nil) && (*createAccountResponse.IamApikey != "") {
+			d.Set("iam_apikey", *createAccountResponse.IamApikey)
+		}
 	} else {
 
 		err := errors.New("[ERROR] Required Parameters are missing." +

--- a/ibm/service/enterprise/resource_ibm_enterprise_account.go
+++ b/ibm/service/enterprise/resource_ibm_enterprise_account.go
@@ -176,6 +176,7 @@ func ResourceIBMEnterpriseAccount() *schema.Resource {
 			"iam_apikey": {
 				Type:        schema.TypeString,
 				Computed:    true,
+				Sensitive:   true,
 				Description: "The IAM API KEY of the account with owner IAM policies.",
 			},
 		},

--- a/website/docs/d/enterprise_accounts.html.markdown
+++ b/website/docs/d/enterprise_accounts.html.markdown
@@ -48,4 +48,7 @@ In addition to all argument reference list, you can access the following attribu
   - `updated_at` - (Timestamp) The time stamp at which an account was last updated.
   - `updated_by` - (String) The IAM ID of the user or service that updated an account.
   - `url` - (String) The URL of an account.
+  - `iam_apikey` - (String) The IAM API KEY of the account with owner IAM policies, will be used to create resources in enterprise child account.
+  - `iam_apikey_id` - (String) The ID of IAM_API_KEY which has owner IAM policies.
+  - `iam_service_id` - (String) The IAM Service ID of the account will be used to create IAM_API_KEY with owner IAM policies.
 - `id` - (String) The unique identifier of an accounts.


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/IBM-Cloud/terraform-provider-ibm/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
make testacc TESTARGS='-run=TestAccIbmEnterpriseAccountBasic' TEST=./ibm/service/enterprise

```
<img width="860" alt="image" src="https://github.com/IBM-Cloud/terraform-provider-ibm/assets/19454465/29428472-3406-400e-8dce-33cd82ed969b">
