### PR TITLE
fix(instance): made keys as forcenew true for instance and template

### DIFF
--- a/ibm/service/vpc/resource_ibm_is_instance.go
+++ b/ibm/service/vpc/resource_ibm_is_instance.go
@@ -293,12 +293,12 @@ func ResourceIBMISInstance() *schema.Resource {
 			},
 
 			isInstanceKeys: {
-				Type:             schema.TypeSet,
-				Optional:         true,
-				Elem:             &schema.Schema{Type: schema.TypeString},
-				Set:              schema.HashString,
-				DiffSuppressFunc: flex.ApplyOnce,
-				Description:      "SSH key Ids for the instance",
+				Type:        schema.TypeSet,
+				Optional:    true,
+				Elem:        &schema.Schema{Type: schema.TypeString},
+				Set:         schema.HashString,
+				ForceNew:    true,
+				Description: "SSH key Ids for the instance",
 			},
 
 			isInstanceTags: {

--- a/ibm/service/vpc/resource_ibm_is_instance_template.go
+++ b/ibm/service/vpc/resource_ibm_is_instance_template.go
@@ -200,12 +200,12 @@ func ResourceIBMISInstanceTemplate() *schema.Resource {
 			},
 
 			isInstanceTemplateKeys: {
-				Type:             schema.TypeSet,
-				Required:         true,
-				Elem:             &schema.Schema{Type: schema.TypeString},
-				Set:              schema.HashString,
-				DiffSuppressFunc: flex.ApplyOnce,
-				Description:      "SSH key Ids for the instance template",
+				Type:        schema.TypeSet,
+				Required:    true,
+				Elem:        &schema.Schema{Type: schema.TypeString},
+				Set:         schema.HashString,
+				ForceNew:    true,
+				Description: "SSH key Ids for the instance template",
 			},
 
 			isPlacementTargetDedicatedHost: {

--- a/ibm/service/vpc/resource_ibm_is_instance_template_test.go
+++ b/ibm/service/vpc/resource_ibm_is_instance_template_test.go
@@ -44,6 +44,49 @@ func TestAccIBMISInstanceTemplate_basic(t *testing.T) {
 		},
 	})
 }
+func TestAccIBMISInstanceTemplate_keys_update(t *testing.T) {
+	randInt := acctest.RandIntRange(10, 100)
+
+	publicKey := strings.TrimSpace(`
+	ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDVtuCfWKVGKaRmaRG6JQZY8YdxnDgGzVOK93IrV9R5Hl0JP1oiLLWlZQS2reAKb8lBqyDVEREpaoRUDjqDqXG8J/kR42FKN51su914pjSBc86wJ02VtT1Wm1zRbSg67kT+g8/T1jCgB5XBODqbcICHVP8Z1lXkgbiHLwlUrbz6OZkGJHo/M/kD1Eme8lctceIYNz/Ilm7ewMXZA4fsidpto9AjyarrJLufrOBl4MRVcZTDSJ7rLP982aHpu9pi5eJAjOZc7Og7n4ns3NFppiCwgVMCVUQbN5GBlWhZ1OsT84ZiTf+Zy8ew+Yg5T7Il8HuC7loWnz+esQPf0s3xhC/kTsGgZreIDoh/rxJfD67wKXetNSh5RH/n5BqjaOuXPFeNXmMhKlhj9nJ8scayx/wsvOGuocEIkbyJSLj3sLUU403OafgatEdnJOwbqg6rUNNF5RIjpJpL7eEWlKIi1j9LyhmPJ+fEO7TmOES82VpCMHpLbe4gf/MhhJ/Xy8DKh9s= root@ffd8363b1226
+	`)
+	publicKey2 := strings.TrimSpace(`ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIHEE9sLlndKFR/hVbF7SUNhKBFrxscJDHrVN/OD1Z+8V abc.edf@ibm.com`)
+	sshKey := "ed25519"
+	vpcName := fmt.Sprintf("tf-testvpc%d", randInt)
+	subnetName := fmt.Sprintf("tf-testsubnet%d", randInt)
+	templateName := fmt.Sprintf("tf-testtemplate%d", randInt)
+	sshKeyName := fmt.Sprintf("tf-testsshkey%d", randInt)
+	sshKeyName2 := fmt.Sprintf("tf-testsshkey%d", randInt)
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { acc.TestAccPreCheck(t) },
+		Providers:    acc.TestAccProviders,
+		CheckDestroy: testAccCheckIBMISInstanceTemplateDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckIBMISInstanceTemplateConfig(vpcName, subnetName, sshKeyName, publicKey, templateName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(
+						"ibm_is_instance_template.instancetemplate1", "name", templateName),
+					resource.TestCheckResourceAttr(
+						"ibm_is_instance_template.instancetemplate1", "keys.#", "1"),
+					resource.TestCheckResourceAttrSet(
+						"ibm_is_instance_template.instancetemplate1", "profile"),
+				),
+			},
+			{
+				Config: testAccCheckIBMISInstanceTemplateConfigKeyUpdate(vpcName, subnetName, sshKeyName, publicKey, sshKeyName2, sshKey, publicKey2, templateName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(
+						"ibm_is_instance_template.instancetemplate1", "name", templateName),
+					resource.TestCheckResourceAttr(
+						"ibm_is_instance_template.instancetemplate1", "keys.#", "2"),
+					resource.TestCheckResourceAttrSet(
+						"ibm_is_instance_template.instancetemplate1", "profile"),
+				),
+			},
+		},
+	})
+}
 func TestAccIBMISInstanceTemplate_vni(t *testing.T) {
 	randInt := acctest.RandIntRange(10, 100)
 
@@ -354,6 +397,50 @@ func testAccCheckIBMISInstanceTemplateConfig(vpcName, subnetName, sshKeyName, pu
 		
 	
 	`, vpcName, subnetName, sshKeyName, publicKey, templateName)
+
+}
+func testAccCheckIBMISInstanceTemplateConfigKeyUpdate(vpcName, subnetName, sshKeyName, publicKey, sshKeyName2, sshKey, publicKey2, templateName string) string {
+	return fmt.Sprintf(`	
+	resource "ibm_is_vpc" "vpc2" {
+	  name = "%s"
+	}
+	
+	resource "ibm_is_subnet" "subnet2" {
+	  name            = "%s"
+	  vpc             = ibm_is_vpc.vpc2.id
+	  zone            = "us-south-2"
+	  ipv4_cidr_block = "10.240.64.0/28"
+	}
+	
+	resource "ibm_is_ssh_key" "sshkey" {
+	  name       = "%s"
+	  public_key = "%s"
+	}
+	resource "ibm_is_ssh_key" "sshkey2" {
+	  name       	= "%s"
+	  public_key 	= "%s"
+	  type 			= "%s"
+	}
+
+	data "ibm_is_images" "is_images" {
+	}
+
+	resource "ibm_is_instance_template" "instancetemplate1" {
+	   name    = "%s"
+	   image   = data.ibm_is_images.is_images.images.0.id
+	   profile = "bx2-8x32"
+	
+	   primary_network_interface {
+		 subnet = ibm_is_subnet.subnet2.id
+	   }
+	
+	   vpc       = ibm_is_vpc.vpc2.id
+	   zone      = "us-south-2"
+	   keys      = [ibm_is_ssh_key.sshkey.id, ibm_is_ssh_key.sshkey2.id]
+	 }
+		
+	
+	`, vpcName, subnetName, sshKeyName, publicKey, sshKeyName2, publicKey2, sshKey, templateName)
 
 }
 func testAccCheckIBMISInstanceTemplateVniConfig(vpcName, subnetName, sshKeyName, publicKey, templateName string) string {


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/IBM-Cloud/terraform-provider-ibm/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes  #5284

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```
