### PR TITLE
fix: add helper for discriminating terraform problems

### DIFF
--- a/ibm/flex/terraform_problem.go
+++ b/ibm/flex/terraform_problem.go
@@ -66,11 +66,22 @@ func (e *TerraformProblem) GetDiag() diag.Diagnostics {
 	return diag.Errorf("%s", e.GetConsoleMessage())
 }
 
-// TerraformErrorf creates and returns a new instance
-// of `TerraformProblem` with "error" level severity.
+// TerraformErrorf creates and returns a new instance of `TerraformProblem`
+// with "error" level severity and a blank discriminator - the "caused by"
+// error is used to ensure uniqueness. This is a convenience function to
+// use when creating a new TerraformProblem instance from an error that
+// came from the SDK.
 func TerraformErrorf(err error, summary, resource, operation string) *TerraformProblem {
+	return DiscriminatedTerraformErrorf(err, summary, resource, operation, "")
+}
+
+// DiscriminatedTerraformErrorf creates and returns a new instance
+// of `TerraformProblem` with "error" level severity that contains
+// a discriminator used to make the instance unique relative to
+// other problem scenarios in the same resource/operation.
+func DiscriminatedTerraformErrorf(err error, summary, resource, operation, discriminator string) *TerraformProblem {
 	return &TerraformProblem{
-		IBMProblem: core.IBMErrorf(err, getComponentInfo(), summary, ""),
+		IBMProblem: core.IBMErrorf(err, getComponentInfo(), summary, discriminator),
 		Resource:   resource,
 		Operation:  operation,
 	}

--- a/ibm/flex/terraform_problem_test.go
+++ b/ibm/flex/terraform_problem_test.go
@@ -196,6 +196,24 @@ func TestFmtErrorfWithProblemInServiceErrorResponse(t *testing.T) {
 	assert.ErrorIs(t, tfErr.GetCausedBy(), sdkProb)
 }
 
+func TestDiscriminatedTerraformErrorf(t *testing.T) {
+	summary := "Update failed."
+	resourceName := "ibm_some_resource"
+	operation := "update"
+	discriminator := "failed-to-read-input"
+
+	terraformProb := DiscriminatedTerraformErrorf(nil, summary, resourceName, operation, discriminator)
+	assert.NotNil(t, terraformProb)
+	assert.Equal(t, summary, terraformProb.Summary)
+	assert.Equal(t, getComponentInfo(), terraformProb.Component)
+	assert.Equal(t, core.ErrorSeverity, terraformProb.Severity)
+
+	// The discriminator field is private, so it can't be checked, so make
+	// sure the hash is unique - that is the purpose of the discriminator.
+	terraformProbNoDisc := TerraformErrorf(nil, summary, resourceName, operation)
+	assert.NotEqual(t, terraformProbNoDisc.GetID(), terraformProb.GetID())
+}
+
 func TestGetComponentInfo(t *testing.T) {
 	component := getComponentInfo()
 	assert.NotNil(t, component)


### PR DESCRIPTION
If multiple errors may occur for the same operation in the same resource, and they are not caused by other tools like the SDK, we need a way to make the IDs for each error scenario unique. The way we support to do this is with a "discriminator" value but the `TerraformErrorf` function doesn't expose a way to set the discriminator. This commit adds an additional helper for use in scenarios where we need to create a discriminated error.