### PR TITLE
fix(docs): Remove beta tag from host_flavor id for cloud-databases

### DIFF
--- a/website/docs/r/database.html.markdown
+++ b/website/docs/r/database.html.markdown
@@ -716,7 +716,7 @@ Review the argument reference that you can specify for your resource.
 
     - `host_flavor` (Set, Optional)
       - Nested scheme for `host_flavor`:
-        - `id` - (Optional, String) **Beta feature:** The hosting infrastructure identifier. Selecting `multitenant` places your database on a logically separated, multi-tenant machine. With this identifier, minimum resource configurations apply. Alternatively, setting the identifier to any of the following host sizes places your database on the specified host size with no other tenants.
+        - `id` - (Optional, String) The hosting infrastructure identifier. Selecting `multitenant` places your database on a logically separated, multi-tenant machine. With this identifier, minimum resource configurations apply. Alternatively, setting the identifier to any of the following host sizes places your database on the specified host size with no other tenants.
           - `b3c.4x16.encrypted`
           - `b3c.8x32.encrypted`
           - `m3c.8x64.encrypted`


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/IBM-Cloud/terraform-provider-ibm/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

`host_flavor id` is not longer a Beta feature. The [beta feature tag](https://registry.terraform.io/providers/IBM-Cloud/ibm/latest/docs/resources/database#id) should be removed.
