### PR TITLE
Added support for snapshot service tags

### DIFF
--- a/ibm/service/vpc/data_source_ibm_is_snapshot.go
+++ b/ibm/service/vpc/data_source_ibm_is_snapshot.go
@@ -102,6 +102,13 @@ func DataSourceSnapshot() *schema.Resource {
 				Description:  "Snapshot name",
 			},
 
+			"service_tags": &schema.Schema{
+				Type:        schema.TypeList,
+				Computed:    true,
+				Description: "The [service tags](https://cloud.ibm.com/apidocs/tagging#types-of-tags) prefixed with `is.snapshot:` associated with this snapshot.",
+				Elem:        &schema.Schema{Type: schema.TypeString},
+			},
+
 			isSnapshotResourceGroup: {
 				Type:        schema.TypeString,
 				Computed:    true,
@@ -513,7 +520,9 @@ func snapshotGetByNameOrID(d *schema.ResourceData, meta interface{}, name, id st
 					}
 				}
 				d.Set(isSnapshotClones, flex.NewStringSet(schema.HashString, clones))
-
+				if err = d.Set("service_tags", snapshot.ServiceTags); err != nil {
+					return fmt.Errorf("[ERROR] Error setting service_tags: %s", err)
+				}
 				backupPolicyPlanList := []map[string]interface{}{}
 				if snapshot.BackupPolicyPlan != nil {
 					backupPolicyPlan := map[string]interface{}{}
@@ -563,6 +572,9 @@ func snapshotGetByNameOrID(d *schema.ResourceData, meta interface{}, name, id st
 
 		if snapshot.EncryptionKey != nil && snapshot.EncryptionKey.CRN != nil {
 			d.Set(isSnapshotEncryptionKey, *snapshot.EncryptionKey.CRN)
+		}
+		if err = d.Set("service_tags", snapshot.ServiceTags); err != nil {
+			return fmt.Errorf("Error setting service_tags: %s", err)
 		}
 		// source snapshot
 		sourceSnapshotList := []map[string]interface{}{}

--- a/ibm/service/vpc/data_source_ibm_is_snapshot_test.go
+++ b/ibm/service/vpc/data_source_ibm_is_snapshot_test.go
@@ -47,6 +47,40 @@ ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCKVmnMOlHKcZK8tpt3MP1lqOLAcqcJzhsvJcjscgVE
 		},
 	})
 }
+func TestAccIBMISSnapshotDatasource_serviceTags(t *testing.T) {
+	var snapshot string
+	snpName := "data.ibm_is_snapshot.ds_snapshot"
+	vpcname := fmt.Sprintf("tf-vpc-%d", acctest.RandIntRange(10, 100))
+	name := fmt.Sprintf("tf-instnace-%d", acctest.RandIntRange(10, 100))
+	subnetname := fmt.Sprintf("tf-subnet-%d", acctest.RandIntRange(10, 100))
+	publicKey := strings.TrimSpace(`
+ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCKVmnMOlHKcZK8tpt3MP1lqOLAcqcJzhsvJcjscgVERRN7/9484SOBJ3HSKxxNG5JN8owAjy5f9yYwcUg+JaUVuytn5Pv3aeYROHGGg+5G346xaq3DAwX6Y5ykr2fvjObgncQBnuU5KHWCECO/4h8uWuwh/kfniXPVjFToc+gnkqA+3RKpAecZhFXwfalQ9mMuYGFxn+fwn8cYEApsJbsEmb0iJwPiZ5hjFC8wREuiTlhPHDgkBLOiycd20op2nXzDbHfCHInquEe/gYxEitALONxm0swBOwJZwlTDOB7C6y2dzlrtxr1L59m7pCkWI4EtTRLvleehBoj3u7jB4usR
+`)
+	sshname := fmt.Sprintf("tf-ssh-%d", acctest.RandIntRange(10, 100))
+	volname := fmt.Sprintf("tf-vol-%d", acctest.RandIntRange(10, 100))
+	name1 := fmt.Sprintf("tfsnapshotuat-%d", acctest.RandIntRange(10, 100))
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { acc.TestAccPreCheck(t) },
+		Providers:    acc.TestAccProviders,
+		CheckDestroy: testAccCheckIBMISSnapshotDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testDSCheckIBMISSnapshotConfig(vpcname, subnetname, sshname, publicKey, volname, name, name1),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckIBMISSnapshotExists("ibm_is_snapshot.testacc_snapshot", snapshot),
+					resource.TestCheckResourceAttr(
+						"ibm_is_snapshot.testacc_snapshot", "name", name1),
+					resource.TestCheckResourceAttrSet(snpName, "href"),
+					resource.TestCheckResourceAttrSet(snpName, "crn"),
+					resource.TestCheckResourceAttrSet(snpName, "lifecycle_state"),
+					resource.TestCheckResourceAttrSet(snpName, "encryption"),
+					resource.TestCheckResourceAttrSet(snpName, "service_tags.#"),
+					// resource.TestCheckResourceAttrSet(snpName, "captured_at"), // Commented as the attribute is optional.
+				),
+			},
+		},
+	})
+}
 func TestAccIBMISSnapshotDatasource_clonesbasic(t *testing.T) {
 	var snapshot string
 	snpName := "data.ibm_is_snapshot.ds_snapshot"

--- a/ibm/service/vpc/data_source_ibm_is_snapshots.go
+++ b/ibm/service/vpc/data_source_ibm_is_snapshots.go
@@ -135,6 +135,13 @@ func DataSourceSnapshots() *schema.Resource {
 							Computed: true,
 						},
 
+						"service_tags": &schema.Schema{
+							Type:        schema.TypeList,
+							Computed:    true,
+							Description: "The [service tags](https://cloud.ibm.com/apidocs/tagging#types-of-tags) prefixed with `is.snapshot:` associated with this snapshot.",
+							Elem:        &schema.Schema{Type: schema.TypeString},
+						},
+
 						isSnapshotCopies: {
 							Type:        schema.TypeList,
 							Computed:    true,
@@ -588,6 +595,9 @@ func getSnapshots(d *schema.ResourceData, meta interface{}) error {
 		}
 		if snapshot.EncryptionKey != nil {
 			l[isSnapshotEncryptionKey] = snapshot.EncryptionKey.CRN
+		}
+		if snapshot.ServiceTags != nil && len(snapshot.ServiceTags) > 0 {
+			l["service_tags"] = snapshot.ServiceTags
 		}
 		if snapshot.EncryptionKey != nil && snapshot.EncryptionKey.CRN != nil {
 			l[isSnapshotEncryptionKey] = *snapshot.EncryptionKey.CRN

--- a/ibm/service/vpc/data_source_ibm_is_snapshots_test.go
+++ b/ibm/service/vpc/data_source_ibm_is_snapshots_test.go
@@ -54,6 +54,47 @@ ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCKVmnMOlHKcZK8tpt3MP1lqOLAcqcJzhsvJcjscgVE
 		},
 	})
 }
+func TestAccIBMISSnapshotsDatasource_serviceTags(t *testing.T) {
+	var snapshot string
+	snpName := "data.ibm_is_snapshots.ds_snapshot"
+	vpcname := fmt.Sprintf("tf-vpc-%d", acctest.RandIntRange(10, 100))
+	name := fmt.Sprintf("tf-instnace-%d", acctest.RandIntRange(10, 100))
+	subnetname := fmt.Sprintf("tf-subnet-%d", acctest.RandIntRange(10, 100))
+	publicKey := strings.TrimSpace(`
+ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCKVmnMOlHKcZK8tpt3MP1lqOLAcqcJzhsvJcjscgVERRN7/9484SOBJ3HSKxxNG5JN8owAjy5f9yYwcUg+JaUVuytn5Pv3aeYROHGGg+5G346xaq3DAwX6Y5ykr2fvjObgncQBnuU5KHWCECO/4h8uWuwh/kfniXPVjFToc+gnkqA+3RKpAecZhFXwfalQ9mMuYGFxn+fwn8cYEApsJbsEmb0iJwPiZ5hjFC8wREuiTlhPHDgkBLOiycd20op2nXzDbHfCHInquEe/gYxEitALONxm0swBOwJZwlTDOB7C6y2dzlrtxr1L59m7pCkWI4EtTRLvleehBoj3u7jB4usR
+`)
+	sshname := fmt.Sprintf("tf-ssh-%d", acctest.RandIntRange(10, 100))
+	volname := fmt.Sprintf("tf-vol-%d", acctest.RandIntRange(10, 100))
+	name1 := fmt.Sprintf("tfsnapshotuat-%d", acctest.RandIntRange(10, 100))
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { acc.TestAccPreCheck(t) },
+		Providers:    acc.TestAccProviders,
+		CheckDestroy: testAccCheckIBMISSnapshotDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckIBMISSnapshotConfig(vpcname, subnetname, sshname, publicKey, volname, name, name1),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckIBMISSnapshotExists("ibm_is_snapshot.testacc_snapshot", snapshot),
+					resource.TestCheckResourceAttr(
+						"ibm_is_snapshot.testacc_snapshot", "name", name1),
+				),
+			},
+			{
+				Config: testDSCheckIBMISSnapshotsConfig(name1),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(
+						snpName, "snapshots.0.name", name1),
+					resource.TestCheckResourceAttrSet(snpName, "snapshots.0.href"),
+					resource.TestCheckResourceAttrSet(snpName, "snapshots.0.crn"),
+					resource.TestCheckResourceAttrSet(snpName, "snapshots.0.lifecycle_state"),
+					resource.TestCheckResourceAttrSet(snpName, "snapshots.0.encryption"),
+					resource.TestCheckResourceAttrSet(snpName, "snapshots.0.captured_at"),
+					resource.TestCheckResourceAttrSet(snpName, "snapshots.0.service_tags.#"),
+				),
+			},
+		},
+	})
+}
 func TestAccIBMISSnapshotsDatasource_clonesbasic(t *testing.T) {
 	var snapshot string
 	snpName := "data.ibm_is_snapshots.ds_snapshot"

--- a/ibm/service/vpc/resource_ibm_is_snapshot.go
+++ b/ibm/service/vpc/resource_ibm_is_snapshot.go
@@ -86,6 +86,13 @@ func ResourceIBMSnapshot() *schema.Resource {
 				Description:  "Snapshot name",
 			},
 
+			"service_tags": &schema.Schema{
+				Type:        schema.TypeList,
+				Computed:    true,
+				Description: "The [service tags](https://cloud.ibm.com/apidocs/tagging#types-of-tags) prefixed with `is.snapshot:` associated with this snapshot.",
+				Elem:        &schema.Schema{Type: schema.TypeString},
+			},
+
 			isSnapshotSourceSnapshotCRN: {
 				Type:         schema.TypeString,
 				ForceNew:     true,
@@ -667,6 +674,9 @@ func snapshotGet(d *schema.ResourceData, meta interface{}, id string) error {
 	d.Set(isSnapshotEncryption, *snapshot.Encryption)
 	if snapshot.EncryptionKey != nil && snapshot.EncryptionKey.CRN != nil {
 		d.Set(isSnapshotEncryptionKey, *snapshot.EncryptionKey.CRN)
+	}
+	if err = d.Set("service_tags", snapshot.ServiceTags); err != nil {
+		return fmt.Errorf("[ERROR]Error setting service_tags: %s", err)
 	}
 	d.Set(isSnapshotLCState, *snapshot.LifecycleState)
 	d.Set(isSnapshotResourceType, *snapshot.ResourceType)

--- a/ibm/service/vpc/resource_ibm_is_snapshot_test.go
+++ b/ibm/service/vpc/resource_ibm_is_snapshot_test.go
@@ -55,6 +55,36 @@ ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCKVmnMOlHKcZK8tpt3MP1lqOLAcqcJzhsvJcjscgVE
 		},
 	})
 }
+func TestAccIBMISSnapshot_serviceTags(t *testing.T) {
+	var snapshot string
+	vpcname := fmt.Sprintf("tf-vpc-%d", acctest.RandIntRange(10, 100))
+	name := fmt.Sprintf("tf-instnace-%d", acctest.RandIntRange(10, 100))
+	subnetname := fmt.Sprintf("tf-subnet-%d", acctest.RandIntRange(10, 100))
+	publicKey := strings.TrimSpace(`
+ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCKVmnMOlHKcZK8tpt3MP1lqOLAcqcJzhsvJcjscgVERRN7/9484SOBJ3HSKxxNG5JN8owAjy5f9yYwcUg+JaUVuytn5Pv3aeYROHGGg+5G346xaq3DAwX6Y5ykr2fvjObgncQBnuU5KHWCECO/4h8uWuwh/kfniXPVjFToc+gnkqA+3RKpAecZhFXwfalQ9mMuYGFxn+fwn8cYEApsJbsEmb0iJwPiZ5hjFC8wREuiTlhPHDgkBLOiycd20op2nXzDbHfCHInquEe/gYxEitALONxm0swBOwJZwlTDOB7C6y2dzlrtxr1L59m7pCkWI4EtTRLvleehBoj3u7jB4usR
+`)
+	sshname := fmt.Sprintf("tf-ssh-%d", acctest.RandIntRange(10, 100))
+	volname := fmt.Sprintf("tf-vol-%d", acctest.RandIntRange(10, 100))
+	name1 := fmt.Sprintf("tfsnapshotuat-%d", acctest.RandIntRange(10, 100))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { acc.TestAccPreCheck(t) },
+		Providers:    acc.TestAccProviders,
+		CheckDestroy: testAccCheckIBMISSnapshotDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckIBMISSnapshotConfig(vpcname, subnetname, sshname, publicKey, volname, name, name1),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckIBMISSnapshotExists("ibm_is_snapshot.testacc_snapshot", snapshot),
+					resource.TestCheckResourceAttr(
+						"ibm_is_snapshot.testacc_snapshot", "name", name1),
+					resource.TestCheckResourceAttrSet(
+						"ibm_is_snapshot.testacc_snapshot", "service_tags.#"),
+				),
+			},
+		},
+	})
+}
 func TestAccIBMISSnapshot_encrypted(t *testing.T) {
 	var snapshot string
 	vpcname := fmt.Sprintf("tf-vpc-%d", acctest.RandIntRange(10, 100))

--- a/website/docs/d/is_snapshot.html.markdown
+++ b/website/docs/d/is_snapshot.html.markdown
@@ -128,6 +128,7 @@ In addition to all argument reference list, you can access the following attribu
 - `minimum_capacity` - (Integer) The minimum capacity of a volume created from this snapshot. When a snapshot is created, this sets to the capacity of the source_volume.
 - `operating_system` - (String) The globally unique name for the operating system included in this image.
 - `resource_type` - (String) The resource type.
+- `service_tags` - (List) The [service tags](https://cloud.ibm.com/apidocs/tagging#types-of-tags) prefixed with `is.snapshot:` associated with this snapshot.
 - `size` - (Integer) The size of this snapshot rounded up to the next gigabyte.
 - `snapshot_consistency_group` - (List) The snapshot consistency group which created this snapshot.
 

--- a/website/docs/d/is_snapshots.html.markdown
+++ b/website/docs/d/is_snapshots.html.markdown
@@ -95,6 +95,7 @@ In addition to all argument reference list, you can access the following attribu
   - `minimum_capacity` - (Integer) The minimum capacity of a volume created from this snapshot. When a snapshot is created, this will be set to the capacity of the source_volume.
   - `operating_system` - (String) The globally unique name for the operating system included in this image.  
   - `resource_type` - (String) The resource type.
+  - `service_tags` - (List) The [service tags](https://cloud.ibm.com/apidocs/tagging#types-of-tags) prefixed with `is.snapshot:` associated with this snapshot.
   - `size` - (Integer) The size of this snapshot rounded up to the next gigabyte.
   - `snapshot_consistency_group` - (List) The snapshot consistency group which created this snapshot.
 

--- a/website/docs/r/is_snapshot.html.markdown
+++ b/website/docs/r/is_snapshot.html.markdown
@@ -158,6 +158,7 @@ In addition to all argument reference list, you can access the following attribu
 - `minimum_capacity` - (Integer) The minimum capacity of a volume created from this snapshot. When a snapshot is created, this will be set to the capacity of the source_volume.
 - `operating_system` - (String) The globally unique name for an Operating System included in this image.
 - `resource_type` - (String) The resource type.
+- `service_tags` - (List) The [service tags](https://cloud.ibm.com/apidocs/tagging#types-of-tags) prefixed with `is.snapshot:` associated with this snapshot.
 - `size` - (Integer) The size of this snapshot rounded up to the next gigabyte.
 - `snapshot_consistency_group` - (List) The snapshot consistency group which created this snapshot.
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/IBM-Cloud/terraform-provider-ibm/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
% make testacc TEST=./ibm/service/vpc TESTARGS='-run=TestAccIBMISSnapshot_serviceTags'
=== RUN   TestAccIBMISSnapshot_serviceTags
--- PASS: TestAccIBMISSnapshot_serviceTags (262.35s)
PASS
ok      github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/vpc     264.318s
```
```
% make testacc TEST=./ibm/service/vpc TESTARGS='-run=TestAccIBMISSnapshotsDatasource_serviceTags'
=== RUN   TestAccIBMISSnapshotsDatasource_serviceTags
--- PASS: TestAccIBMISSnapshotsDatasource_serviceTags (245.55s)
PASS
ok      github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/vpc     247.170s
```
```
% make testacc TEST=./ibm/service/vpc TESTARGS='-run=TestAccIBMISSnapshotDatasource_serviceTags'
=== RUN   TestAccIBMISSnapshotDatasource_serviceTags
--- PASS: TestAccIBMISSnapshotDatasource_serviceTags (193.30s)
PASS
ok      github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/vpc     194.908s
```
