### PR TITLE
Add check on property required_config.value (not empty)

### DIFF
--- a/ibm/service/scc/resource_ibm_scc_rule.go
+++ b/ibm/service/scc/resource_ibm_scc_rule.go
@@ -799,7 +799,7 @@ func resourceIbmSccRuleMapToRequiredConfig(modelMap map[string]interface{}) (sec
 		model.Operator = core.StringPtr(modelMap["operator"].(string))
 	}
 	// Manual Intervention
-	if modelMap["value"] != nil {
+	if modelMap["value"] != nil && len(modelMap["value"].(string)) > 0 {
 		// model.Value = modelMap["value"].(string)
 		sLit := strings.Trim(modelMap["value"].(string), "[]")
 		sList := strings.Split(sLit, ",")
@@ -869,7 +869,7 @@ func resourceIbmSccRuleMapToRequiredConfigBase(modelMap map[string]interface{}) 
 	}
 	model.Property = core.StringPtr(modelMap["property"].(string))
 	model.Operator = core.StringPtr(modelMap["operator"].(string))
-	if modelMap["value"] != nil {
+	if modelMap["value"] != nil && len(modelMap["value"].(string)) > 0 {
 		sLit := strings.Trim(modelMap["value"].(string), "[]")
 		sList := strings.Split(sLit, ",")
 		if len(sList) == 1 {


### PR DESCRIPTION
Add check on property `required_config.value` (not empty) on func `resourceIbmSccRuleMapToRequiredConfig` and `resourceIbmSccRuleMapToRequiredConfigBase` like it is already done in func `resourceIbmSccRuleMapToRequiredConfigItems` to fix issue https://github.com/IBM-Cloud/terraform-provider-ibm/issues/5327

<!--- See what makes a good Pull Request at : https://github.com/IBM-Cloud/terraform-provider-ibm/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes [#5327](https://github.com/IBM-Cloud/terraform-provider-ibm/issues/5327)

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TEST=./ibm/service/scc

...
```
