### PR TITLE
scc fix: ability to add profile_version during create

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -26,7 +26,7 @@ require (
 	github.com/IBM/platform-services-go-sdk v0.62.10
 	github.com/IBM/project-go-sdk v0.2.8-1
 	github.com/IBM/push-notifications-go-sdk v0.0.0-20210310100607-5790b96c47f5
-	github.com/IBM/scc-go-sdk/v5 v5.1.5
+	github.com/IBM/scc-go-sdk/v5 v5.1.6
 	github.com/IBM/schematics-go-sdk v0.2.3
 	github.com/IBM/secrets-manager-go-sdk/v2 v2.0.4
 	github.com/IBM/vpc-beta-go-sdk v0.6.0

--- a/go.sum
+++ b/go.sum
@@ -166,8 +166,8 @@ github.com/IBM/push-notifications-go-sdk v0.0.0-20210310100607-5790b96c47f5 h1:N
 github.com/IBM/push-notifications-go-sdk v0.0.0-20210310100607-5790b96c47f5/go.mod h1:b07XHUVh0XYnQE9s2mqgjYST1h9buaQNqN4EcKhOsX0=
 github.com/IBM/sarama v1.41.2 h1:ZDBZfGPHAD4uuAtSv4U22fRZBgst0eEwGFzLj0fb85c=
 github.com/IBM/sarama v1.41.2/go.mod h1:xdpu7sd6OE1uxNdjYTSKUfY8FaKkJES9/+EyjSgiGQk=
-github.com/IBM/scc-go-sdk/v5 v5.1.5 h1:c17/7CfUjjgHXQe1fIY3GVsahqij1vDu9/dKPak8Tes=
-github.com/IBM/scc-go-sdk/v5 v5.1.5/go.mod h1:YtAVlzq10bwR82QX4ZavhDIwa1s85RuVO9N/KmXVcuk=
+github.com/IBM/scc-go-sdk/v5 v5.1.6 h1:vpcrADzaY6K967pcOVvp+rjAmoOyyxFgR9woQ20Q/l8=
+github.com/IBM/scc-go-sdk/v5 v5.1.6/go.mod h1:YtAVlzq10bwR82QX4ZavhDIwa1s85RuVO9N/KmXVcuk=
 github.com/IBM/schematics-go-sdk v0.2.3 h1:lgTt0Sbudii3cuSk1YSQgrtiZAXDbBABAoVj3eQuBrU=
 github.com/IBM/schematics-go-sdk v0.2.3/go.mod h1:Tw2OSAPdpC69AxcwoyqcYYaGTTW6YpERF9uNEU+BFRQ=
 github.com/IBM/secrets-manager-go-sdk/v2 v2.0.4 h1:xa9e+POVqaXxXHXkSMCOVAbKdUNEu86jQmo5hcpd+L4=

--- a/ibm/service/scc/resource_ibm_scc_profile.go
+++ b/ibm/service/scc/resource_ibm_scc_profile.go
@@ -266,8 +266,8 @@ func ResourceIbmSccProfile() *schema.Resource {
 			},
 			"profile_version": {
 				Type:        schema.TypeString,
-				Computed:    true,
 				Optional:    true,
+				Default:     "0.0.0",
 				Description: "The version status of the profile.",
 			},
 			"version_group_label": {
@@ -366,6 +366,8 @@ func resourceIbmSccProfileCreate(context context.Context, d *schema.ResourceData
 	bodyModelMap["profile_name"] = d.Get("profile_name")
 	bodyModelMap["profile_description"] = d.Get("profile_description")
 	bodyModelMap["profile_type"] = "custom"
+	// manual change for profile_version
+	bodyModelMap["profile_version"] = d.Get("profile_version")
 	if _, ok := d.GetOk("controls"); ok {
 		bodyModelMap["controls"] = d.Get("controls")
 	} else {
@@ -652,6 +654,7 @@ func resourceIbmSccProfileMapToProfilePrototype(modelMap map[string]interface{})
 	model.ProfileName = core.StringPtr(modelMap["profile_name"].(string))
 	model.ProfileDescription = core.StringPtr(modelMap["profile_description"].(string))
 	model.ProfileType = core.StringPtr(modelMap["profile_type"].(string))
+	model.ProfileVersion = core.StringPtr(modelMap["profile_version"].(string))
 	controls := []securityandcompliancecenterapiv3.ProfileControlsPrototype{}
 	for _, controlsItem := range modelMap["controls"].([]interface{}) {
 		controlsItemModel, err := resourceIbmSccProfileMapToProfileControlsPrototype(controlsItem.(map[string]interface{}))

--- a/ibm/service/scc/resource_ibm_scc_profile_test.go
+++ b/ibm/service/scc/resource_ibm_scc_profile_test.go
@@ -59,7 +59,7 @@ func TestAccIbmSccProfileAllArgs(t *testing.T) {
 	profileType := "custom"
 	profileNameUpdate := profileName
 	profileDescriptionUpdate := profileDescription
-	profileVersion := "0.0.0"
+	profileVersion := "0.0.1"
 	profileTypeUpdate := profileType
 
 	resource.Test(t, resource.TestCase{
@@ -68,7 +68,7 @@ func TestAccIbmSccProfileAllArgs(t *testing.T) {
 		CheckDestroy: testAccCheckIbmSccProfileDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
-				Config: testAccCheckIbmSccProfileConfig(acc.SccInstanceID, profileName, profileDescription, profileType),
+				Config: testAccCheckIbmSccProfileConfig(acc.SccInstanceID, profileName, profileDescription, profileType, profileVersion),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckIbmSccProfileExists("ibm_scc_profile.scc_profile_instance", conf),
 					resource.TestCheckResourceAttr("ibm_scc_profile.scc_profile_instance", "profile_name", profileName),
@@ -78,7 +78,7 @@ func TestAccIbmSccProfileAllArgs(t *testing.T) {
 				),
 			},
 			resource.TestStep{
-				Config: testAccCheckIbmSccProfileConfig(acc.SccInstanceID, profileNameUpdate, profileDescriptionUpdate, profileTypeUpdate),
+				Config: testAccCheckIbmSccProfileConfig(acc.SccInstanceID, profileNameUpdate, profileDescriptionUpdate, profileTypeUpdate, profileVersion),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr("ibm_scc_profile.scc_profile_instance", "profile_name", profileNameUpdate),
 					resource.TestCheckResourceAttr("ibm_scc_profile.scc_profile_instance", "profile_description", profileDescriptionUpdate),
@@ -152,7 +152,7 @@ func testAccCheckIbmSccProfileConfigBasic(instanceID string, profileName string,
 	`, instanceID, profileName, profileDescription, profileType)
 }
 
-func testAccCheckIbmSccProfileConfig(instanceID string, profileName string, profileDescription string, profileType string) string {
+func testAccCheckIbmSccProfileConfig(instanceID string, profileName string, profileDescription string, profileType string, profileVersion string) string {
 	return fmt.Sprintf(`
 		resource "ibm_scc_control_library" "scc_control_library_instance" {
 			instance_id = "%s"
@@ -200,7 +200,7 @@ func testAccCheckIbmSccProfileConfig(instanceID string, profileName string, prof
 			profile_name = "%s"
 			profile_description = "%s"
 			profile_type = "%s"
-			profile_version = "0.0.0"
+			profile_version = "%s"
 			controls {
 				control_library_id = resource.ibm_scc_control_library.scc_control_library_instance.control_library_id
 				control_id = resource.ibm_scc_control_library.scc_control_library_instance.controls[0].control_id
@@ -215,7 +215,7 @@ func testAccCheckIbmSccProfileConfig(instanceID string, profileName string, prof
 			}
 		}
 
-	`, instanceID, profileName, profileDescription, profileType)
+	`, instanceID, profileName, profileDescription, profileType, profileVersion)
 }
 
 func testAccCheckIbmSccProfileExists(n string, obj securityandcompliancecenterapiv3.Profile) resource.TestCheckFunc {


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/IBM-Cloud/terraform-provider-ibm/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #5292 

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```shell
$ make testacc TEST=./ibm/service/scc  TESTARGS="-run TestAccIbmSccProfiles*" 
...
=== RUN   TestAccIbmSccProfileAttachmentDataSourceBasic
--- PASS: TestAccIbmSccProfileAttachmentDataSourceBasic (23.46s)
=== RUN   TestAccIbmSccProfileAttachmentDataSourceAllArgs
--- PASS: TestAccIbmSccProfileAttachmentDataSourceAllArgs (21.13s)
=== RUN   TestAccIbmSccProfileDataSourceBasic
--- PASS: TestAccIbmSccProfileDataSourceBasic (17.85s)
=== RUN   TestAccIbmSccProfileDataSourceAllArgs
--- PASS: TestAccIbmSccProfileDataSourceAllArgs (18.08s)
=== RUN   TestAccIbmSccProfilesDataSourceBasic
--- PASS: TestAccIbmSccProfilesDataSourceBasic (14.62s)
=== RUN   TestAccIbmSccProfilesDataSourceAllArgs
--- PASS: TestAccIbmSccProfilesDataSourceAllArgs (13.69s)
=== RUN   TestAccIbmSccProfileAttachmentBasic
--- PASS: TestAccIbmSccProfileAttachmentBasic (18.72s)
=== RUN   TestAccIbmSccProfileAttachmentAllArgs
--- PASS: TestAccIbmSccProfileAttachmentAllArgs (52.87s)
=== RUN   TestAccIbmSccProfileBasic
--- PASS: TestAccIbmSccProfileBasic (24.92s)
=== RUN   TestAccIbmSccProfileAllArgs
--- PASS: TestAccIbmSccProfileAllArgs (27.07s)
PASS
ok      github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/scc     233.017s
...
```
