### PR TITLE
fix: update CreateMockByteArray() to decode input string

### DIFF
--- a/ibm/unittest/utils.go
+++ b/ibm/unittest/utils.go
@@ -4,6 +4,8 @@
 package unittest
 
 import (
+	"encoding/base64"
+
 	"github.com/IBM/go-sdk-core/v5/core"
 	"github.com/go-openapi/strfmt"
 )
@@ -17,8 +19,11 @@ func CreateMockUUID(mockData string) *strfmt.UUID {
 	return &uuid
 }
 
-func CreateMockByteArray(mockData string) *[]byte {
-	ba := []byte(mockData)
+func CreateMockByteArray(encodedString string) *[]byte {
+	ba, err := base64.StdEncoding.DecodeString(encodedString)
+	if err != nil {
+		panic(err)
+	}
 	return &ba
 }
 


### PR DESCRIPTION
This PR updates the CreateMockByteArray() function used in unit tests that are generated by the SDK generator.  Specifically, it syncs the definition of the function with the version used in Go SDKs.  The change is to add code to do a base64-decode of the input string which is assumed to be a base64-encoded string (the original un-encoded data would be simply a `[]byte` value - binary data).