### PR TITLE
Fix volume_ids into volume_id

### DIFF
--- a/ibm/service/power/ibm_pi_constants.go
+++ b/ibm/service/power/ibm_pi_constants.go
@@ -297,6 +297,7 @@ const (
 	Attr_VLanID                                      = "vlan_id"
 	Attr_VolumeGroupName                             = "volume_group_name"
 	Attr_VolumeGroups                                = "volume_groups"
+	Attr_VolumeID                                    = "volume_id"
 	Attr_VolumeIDs                                   = "volume_ids"
 	Attr_VolumePool                                  = "volume_pool"
 	Attr_Volumes                                     = "volumes"

--- a/ibm/service/power/resource_ibm_pi_volume.go
+++ b/ibm/service/power/resource_ibm_pi_volume.go
@@ -176,7 +176,7 @@ func ResourceIBMPIVolume() *schema.Resource {
 				Description: "The replication type of the volume 'metro' or 'global'.",
 				Type:        schema.TypeString,
 			},
-			Attr_VolumeIDs: {
+			Attr_VolumeID: {
 				Computed:    true,
 				Description: "The unique identifier of the volume.",
 				Type:        schema.TypeString,
@@ -302,7 +302,7 @@ func resourceIBMPIVolumeRead(ctx context.Context, d *schema.ResourceData, meta i
 	}
 	d.Set(Arg_CloudInstanceID, cloudInstanceID)
 	if vol.VolumeID != nil {
-		d.Set(Attr_VolumeIDs, vol.VolumeID)
+		d.Set(Attr_VolumeID, vol.VolumeID)
 	}
 	d.Set(Arg_VolumeName, vol.Name)
 	d.Set(Arg_VolumePool, vol.VolumePool)


### PR DESCRIPTION
The attribute volume_id has accidentally been changed into volume_ids in the volume refactor PR (https://github.com/IBM-Cloud/terraform-provider-ibm/pull/5329). This needs to be changed back for compatibility reasons. This bug was found while refactoring another resource.

