### PR TITLE
Code Engine Provider and Documentation Update

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/IBM/appid-management-go-sdk v0.0.0-20210908164609-dd0e0eaf732f
 	github.com/IBM/cloud-databases-go-sdk v0.7.0
 	github.com/IBM/cloudant-go-sdk v0.0.43
-	github.com/IBM/code-engine-go-sdk v0.0.0-20231106200405-99e81b3ee752
+	github.com/IBM/code-engine-go-sdk v0.0.0-20240126185534-a6e054aa01ed
 	github.com/IBM/container-registry-go-sdk v1.1.0
 	github.com/IBM/continuous-delivery-go-sdk v1.5.0
 	github.com/IBM/event-notifications-go-admin-sdk v0.6.0

--- a/go.sum
+++ b/go.sum
@@ -122,6 +122,8 @@ github.com/IBM/cloudant-go-sdk v0.0.43 h1:YxTy4RpAEezX32YIWnds76hrBREmO4u6IkBz1W
 github.com/IBM/cloudant-go-sdk v0.0.43/go.mod h1:WeYrJPaHTw19943ndWnVfwMIlZ5z0XUM2uEXNBrwZ1M=
 github.com/IBM/code-engine-go-sdk v0.0.0-20231106200405-99e81b3ee752 h1:S5NT0aKKUqd9hnIrPN/qUijKx9cZjJi3kfFpog0ByDA=
 github.com/IBM/code-engine-go-sdk v0.0.0-20231106200405-99e81b3ee752/go.mod h1:noWxHQUgW9msjOrDpV17gnwWbTbUlSmWMGq7/Vi/n9I=
+github.com/IBM/code-engine-go-sdk v0.0.0-20240126185534-a6e054aa01ed h1:X0VrZW5ulbqxbOmy5JoZcH0A+tw80k0/ZmRZz1NqogM=
+github.com/IBM/code-engine-go-sdk v0.0.0-20240126185534-a6e054aa01ed/go.mod h1:m4pD/58c6NVzlAFkN3XCYXpmDFmUyTG31ivLy/loyHQ=
 github.com/IBM/container-registry-go-sdk v1.1.0 h1:sYyknIod8R4RJZQqAheiduP6wbSTphE9Ag8ho28yXjc=
 github.com/IBM/container-registry-go-sdk v1.1.0/go.mod h1:4TwsCnQtVfZ4Vkapy/KPvQBKFc3VOyUZYkwRU4FTPrs=
 github.com/IBM/continuous-delivery-go-sdk v1.5.0 h1:FHSRruNt9WK7SavpIVuV6N+xll90UgZsuQjZvQ+slB4=

--- a/ibm/service/codeengine/README.md
+++ b/ibm/service/codeengine/README.md
@@ -8,4 +8,4 @@ This area is primarily for IBM provider contributors and maintainers. For inform
 * IBM Provider Docs: [Home](https://registry.terraform.io/providers/IBM-Cloud/ibm/latest/docs)
 * IBM Provider Docs: [One of the  resources](https://registry.terraform.io/providers/IBM-Cloud/ibm/latest/docs/resources/code_engine_app)
 * IBM API Docs: [IBM API Docs for ]()
-* IBM  SDK: [IBM SDK for ](https://github.com/IBM/code-engine-go-sdk/tree/main/codeenginev2)
+* IBM  SDK: [IBM SDK for ](https://github.com/IBM/appconfiguration-go-admin-sdk/tree/master/codeenginev2)

--- a/ibm/service/codeengine/data_source_ibm_code_engine_app.go
+++ b/ibm/service/codeengine/data_source_ibm_code_engine_app.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2023 All Rights Reserved.
+// Copyright IBM Corp. 2024 All Rights Reserved.
 // Licensed under the Mozilla Public License v2.0
 
 package codeengine
@@ -21,72 +21,175 @@ func DataSourceIbmCodeEngineApp() *schema.Resource {
 		ReadContext: dataSourceIbmCodeEngineAppRead,
 
 		Schema: map[string]*schema.Schema{
-			"project_id": &schema.Schema{
+			"project_id": {
 				Type:        schema.TypeString,
 				Required:    true,
 				Description: "The ID of the project.",
 			},
-			"name": &schema.Schema{
+			"name": {
 				Type:        schema.TypeString,
 				Required:    true,
 				Description: "The name of your application.",
 			},
-			"created_at": &schema.Schema{
+			"build": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "Reference to a build that is associated with the application.",
+			},
+			"build_run": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "Reference to a build run that is associated with the application.",
+			},
+			"created_at": {
 				Type:        schema.TypeString,
 				Computed:    true,
 				Description: "The timestamp when the resource was created.",
 			},
-			"endpoint": &schema.Schema{
+			"endpoint": {
 				Type:        schema.TypeString,
 				Computed:    true,
-				Description: "Optional URL to invoke app. Depending on visibility this is accessible publicly or in the private network only. Empty in case 'managed_domain_mappings' is set to 'local'.",
+				Description: "Optional URL to invoke the app. Depending on visibility,  this is accessible publicly or in the private network only. Empty in case 'managed_domain_mappings' is set to 'local'.",
 			},
-			"endpoint_internal": &schema.Schema{
+			"endpoint_internal": {
 				Type:        schema.TypeString,
 				Computed:    true,
-				Description: "URL to app that is only visible within the project.",
+				Description: "The URL to the app that is only visible within the project.",
 			},
-			"entity_tag": &schema.Schema{
+			"entity_tag": {
 				Type:        schema.TypeString,
 				Computed:    true,
 				Description: "The version of the app instance, which is used to achieve optimistic locking.",
 			},
-			"href": &schema.Schema{
+			"href": {
 				Type:        schema.TypeString,
 				Computed:    true,
 				Description: "When you provision a new app,  a URL is created identifying the location of the instance.",
 			},
-			"app_id": &schema.Schema{
+			"app_id": {
 				Type:        schema.TypeString,
 				Computed:    true,
 				Description: "The identifier of the resource.",
 			},
-			"image_port": &schema.Schema{
+			"image_port": {
 				Type:        schema.TypeInt,
 				Computed:    true,
 				Description: "Optional port the app listens on. While the app will always be exposed via port `443` for end users, this port is used to connect to the port that is exposed by the container image.",
 			},
-			"image_reference": &schema.Schema{
+			"image_reference": {
 				Type:        schema.TypeString,
 				Computed:    true,
 				Description: "The name of the image that is used for this app. The format is `REGISTRY/NAMESPACE/REPOSITORY:TAG` where `REGISTRY` and `TAG` are optional. If `REGISTRY` is not specified, the default is `docker.io`. If `TAG` is not specified, the default is `latest`. If the image reference points to a registry that requires authentication, make sure to also specify the property `image_secret`.",
 			},
-			"image_secret": &schema.Schema{
+			"image_secret": {
 				Type:        schema.TypeString,
 				Computed:    true,
 				Description: "Optional name of the image registry access secret. The image registry access secret is used to authenticate with a private registry when you download the container image. If the image reference points to a registry that requires authentication, the app will be created but cannot reach the ready status, until this property is provided, too.",
 			},
-			"managed_domain_mappings": &schema.Schema{
+			"managed_domain_mappings": {
 				Type:        schema.TypeString,
 				Computed:    true,
 				Description: "Optional value controlling which of the system managed domain mappings will be setup for the application. Valid values are 'local_public', 'local_private' and 'local'. Visibility can only be 'local_private' if the project supports application private visibility.",
 			},
-			"resource_type": &schema.Schema{
+			"probe_liveness": {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Description: "Response model for probes.",
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"failure_threshold": {
+							Type:        schema.TypeInt,
+							Computed:    true,
+							Description: "The number of consecutive, unsuccessful checks for the probe to be considered failed.",
+						},
+						"initial_delay": {
+							Type:        schema.TypeInt,
+							Computed:    true,
+							Description: "The amount of time in seconds to wait before the first probe check is performed.",
+						},
+						"interval": {
+							Type:        schema.TypeInt,
+							Computed:    true,
+							Description: "The amount of time in seconds between probe checks.",
+						},
+						"path": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "The path of the HTTP request to the resource. A path is only supported for a probe with a `type` of `http`.",
+						},
+						"port": {
+							Type:        schema.TypeInt,
+							Computed:    true,
+							Description: "The port on which to probe the resource.",
+						},
+						"timeout": {
+							Type:        schema.TypeInt,
+							Computed:    true,
+							Description: "The amount of time in seconds that the probe waits for a response from the application before it times out and fails.",
+						},
+						"type": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "Specifies whether to use HTTP or TCP for the probe checks. The default is TCP.",
+						},
+					},
+				},
+			},
+			"probe_readiness": {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Description: "Response model for probes.",
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"failure_threshold": {
+							Type:        schema.TypeInt,
+							Computed:    true,
+							Description: "The number of consecutive, unsuccessful checks for the probe to be considered failed.",
+						},
+						"initial_delay": {
+							Type:        schema.TypeInt,
+							Computed:    true,
+							Description: "The amount of time in seconds to wait before the first probe check is performed.",
+						},
+						"interval": {
+							Type:        schema.TypeInt,
+							Computed:    true,
+							Description: "The amount of time in seconds between probe checks.",
+						},
+						"path": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "The path of the HTTP request to the resource. A path is only supported for a probe with a `type` of `http`.",
+						},
+						"port": {
+							Type:        schema.TypeInt,
+							Computed:    true,
+							Description: "The port on which to probe the resource.",
+						},
+						"timeout": {
+							Type:        schema.TypeInt,
+							Computed:    true,
+							Description: "The amount of time in seconds that the probe waits for a response from the application before it times out and fails.",
+						},
+						"type": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "Specifies whether to use HTTP or TCP for the probe checks. The default is TCP.",
+						},
+					},
+				},
+			},
+			"region": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The region of the project the resource is located in. Possible values: 'au-syd', 'br-sao', 'ca-tor', 'eu-de', 'eu-gb', 'jp-osa', 'jp-tok', 'us-east', 'us-south'.",
+			},
+			"resource_type": {
 				Type:        schema.TypeString,
 				Computed:    true,
 				Description: "The type of the app.",
 			},
-			"run_arguments": &schema.Schema{
+			"run_arguments": {
 				Type:        schema.TypeList,
 				Computed:    true,
 				Description: "Optional arguments for the app that are passed to start the container. If not specified an empty string array will be applied and the arguments specified by the container image, will be used to start the container.",
@@ -94,12 +197,12 @@ func DataSourceIbmCodeEngineApp() *schema.Resource {
 					Type: schema.TypeString,
 				},
 			},
-			"run_as_user": &schema.Schema{
+			"run_as_user": {
 				Type:        schema.TypeInt,
 				Computed:    true,
-				Description: "Optional user ID (UID) to run the app (e.g., `1001`).",
+				Description: "Optional user ID (UID) to run the app.",
 			},
-			"run_commands": &schema.Schema{
+			"run_commands": {
 				Type:        schema.TypeList,
 				Computed:    true,
 				Description: "Optional commands for the app that are passed to start the container. If not specified an empty string array will be applied and the command specified by the container image, will be used to start the container.",
@@ -107,38 +210,38 @@ func DataSourceIbmCodeEngineApp() *schema.Resource {
 					Type: schema.TypeString,
 				},
 			},
-			"run_env_variables": &schema.Schema{
+			"run_env_variables": {
 				Type:        schema.TypeList,
 				Computed:    true,
 				Description: "References to config maps, secrets or literal values, which are exposed as environment variables in the application.",
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
-						"key": &schema.Schema{
+						"key": {
 							Type:        schema.TypeString,
 							Computed:    true,
 							Description: "The key to reference as environment variable.",
 						},
-						"name": &schema.Schema{
+						"name": {
 							Type:        schema.TypeString,
 							Computed:    true,
 							Description: "The name of the environment variable.",
 						},
-						"prefix": &schema.Schema{
+						"prefix": {
 							Type:        schema.TypeString,
 							Computed:    true,
 							Description: "A prefix that can be added to all keys of a full secret or config map reference.",
 						},
-						"reference": &schema.Schema{
+						"reference": {
 							Type:        schema.TypeString,
 							Computed:    true,
 							Description: "The name of the secret or config map.",
 						},
-						"type": &schema.Schema{
+						"type": {
 							Type:        schema.TypeString,
 							Computed:    true,
 							Description: "Specify the type of the environment variable.",
 						},
-						"value": &schema.Schema{
+						"value": {
 							Type:        schema.TypeString,
 							Computed:    true,
 							Description: "The literal value of the environment variable.",
@@ -146,33 +249,33 @@ func DataSourceIbmCodeEngineApp() *schema.Resource {
 					},
 				},
 			},
-			"run_service_account": &schema.Schema{
+			"run_service_account": {
 				Type:        schema.TypeString,
 				Computed:    true,
 				Description: "Optional name of the service account. For built-in service accounts, you can use the shortened names `manager` , `none`, `reader`, and `writer`.",
 			},
-			"run_volume_mounts": &schema.Schema{
+			"run_volume_mounts": {
 				Type:        schema.TypeList,
 				Computed:    true,
 				Description: "Mounts of config maps or secrets.",
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
-						"mount_path": &schema.Schema{
+						"mount_path": {
 							Type:        schema.TypeString,
 							Computed:    true,
 							Description: "The path that should be mounted.",
 						},
-						"name": &schema.Schema{
+						"name": {
 							Type:        schema.TypeString,
 							Computed:    true,
 							Description: "The name of the mount.",
 						},
-						"reference": &schema.Schema{
+						"reference": {
 							Type:        schema.TypeString,
 							Computed:    true,
 							Description: "The name of the referenced secret or config map.",
 						},
-						"type": &schema.Schema{
+						"type": {
 							Type:        schema.TypeString,
 							Computed:    true,
 							Description: "Specify the type of the volume mount. Allowed types are: 'config_map', 'secret'.",
@@ -180,73 +283,78 @@ func DataSourceIbmCodeEngineApp() *schema.Resource {
 					},
 				},
 			},
-			"scale_concurrency": &schema.Schema{
+			"scale_concurrency": {
 				Type:        schema.TypeInt,
 				Computed:    true,
 				Description: "Optional maximum number of requests that can be processed concurrently per instance.",
 			},
-			"scale_concurrency_target": &schema.Schema{
+			"scale_concurrency_target": {
 				Type:        schema.TypeInt,
 				Computed:    true,
 				Description: "Optional threshold of concurrent requests per instance at which one or more additional instances are created. Use this value to scale up instances based on concurrent number of requests. This option defaults to the value of the `scale_concurrency` option, if not specified.",
 			},
-			"scale_cpu_limit": &schema.Schema{
+			"scale_cpu_limit": {
 				Type:        schema.TypeString,
 				Computed:    true,
 				Description: "Optional number of CPU set for the instance of the app. For valid values see [Supported memory and CPU combinations](https://cloud.ibm.com/docs/codeengine?topic=codeengine-mem-cpu-combo).",
 			},
-			"scale_ephemeral_storage_limit": &schema.Schema{
+			"scale_down_delay": {
+				Type:        schema.TypeInt,
+				Computed:    true,
+				Description: "Optional amount of time in seconds that delays the scale-down behavior for an app instance.",
+			},
+			"scale_ephemeral_storage_limit": {
 				Type:        schema.TypeString,
 				Computed:    true,
 				Description: "Optional amount of ephemeral storage to set for the instance of the app. The amount specified as ephemeral storage, must not exceed the amount of `scale_memory_limit`. The units for specifying ephemeral storage are Megabyte (M) or Gigabyte (G), whereas G and M are the shorthand expressions for GB and MB. For more information see [Units of measurement](https://cloud.ibm.com/docs/codeengine?topic=codeengine-mem-cpu-combo#unit-measurements).",
 			},
-			"scale_initial_instances": &schema.Schema{
+			"scale_initial_instances": {
 				Type:        schema.TypeInt,
 				Computed:    true,
 				Description: "Optional initial number of instances that are created upon app creation or app update.",
 			},
-			"scale_max_instances": &schema.Schema{
+			"scale_max_instances": {
 				Type:        schema.TypeInt,
 				Computed:    true,
 				Description: "Optional maximum number of instances for this app. If you set this value to `0`, this property does not set a upper scaling limit. However, the app scaling is still limited by the project quota for instances. See [Limits and quotas for Code Engine](https://cloud.ibm.com/docs/codeengine?topic=codeengine-limits).",
 			},
-			"scale_memory_limit": &schema.Schema{
+			"scale_memory_limit": {
 				Type:        schema.TypeString,
 				Computed:    true,
 				Description: "Optional amount of memory set for the instance of the app. For valid values see [Supported memory and CPU combinations](https://cloud.ibm.com/docs/codeengine?topic=codeengine-mem-cpu-combo). The units for specifying memory are Megabyte (M) or Gigabyte (G), whereas G and M are the shorthand expressions for GB and MB. For more information see [Units of measurement](https://cloud.ibm.com/docs/codeengine?topic=codeengine-mem-cpu-combo#unit-measurements).",
 			},
-			"scale_min_instances": &schema.Schema{
+			"scale_min_instances": {
 				Type:        schema.TypeInt,
 				Computed:    true,
 				Description: "Optional minimum number of instances for this app. If you set this value to `0`, the app will scale down to zero, if not hit by any request for some time.",
 			},
-			"scale_request_timeout": &schema.Schema{
+			"scale_request_timeout": {
 				Type:        schema.TypeInt,
 				Computed:    true,
 				Description: "Optional amount of time in seconds that is allowed for a running app to respond to a request.",
 			},
-			"status": &schema.Schema{
+			"status": {
 				Type:        schema.TypeString,
 				Computed:    true,
 				Description: "The current status of the app.",
 			},
-			"status_details": &schema.Schema{
+			"status_details": {
 				Type:        schema.TypeList,
 				Computed:    true,
 				Description: "The detailed status of the application.",
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
-						"latest_created_revision": &schema.Schema{
+						"latest_created_revision": {
 							Type:        schema.TypeString,
 							Computed:    true,
 							Description: "Latest app revision that has been created.",
 						},
-						"latest_ready_revision": &schema.Schema{
+						"latest_ready_revision": {
 							Type:        schema.TypeString,
 							Computed:    true,
 							Description: "Latest app revision that reached a ready state.",
 						},
-						"reason": &schema.Schema{
+						"reason": {
 							Type:        schema.TypeString,
 							Computed:    true,
 							Description: "Optional information to provide more context in case of a 'failed' or 'warning' status.",
@@ -261,7 +369,9 @@ func DataSourceIbmCodeEngineApp() *schema.Resource {
 func dataSourceIbmCodeEngineAppRead(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	codeEngineClient, err := meta.(conns.ClientSession).CodeEngineV2()
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.TerraformErrorf(err, err.Error(), "(Data) ibm_code_engine_app", "read")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	getAppOptions := &codeenginev2.GetAppOptions{}
@@ -269,147 +379,251 @@ func dataSourceIbmCodeEngineAppRead(context context.Context, d *schema.ResourceD
 	getAppOptions.SetProjectID(d.Get("project_id").(string))
 	getAppOptions.SetName(d.Get("name").(string))
 
-	app, response, err := codeEngineClient.GetAppWithContext(context, getAppOptions)
+	app, _, err := codeEngineClient.GetAppWithContext(context, getAppOptions)
 	if err != nil {
-		log.Printf("[DEBUG] GetAppWithContext failed %s\n%s", err, response)
-		return diag.FromErr(fmt.Errorf("GetAppWithContext failed %s\n%s", err, response))
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("GetAppWithContext failed: %s", err.Error()), "(Data) ibm_code_engine_app", "read")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	d.SetId(fmt.Sprintf("%s/%s", *getAppOptions.ProjectID, *getAppOptions.Name))
 
+	if err = d.Set("build", app.Build); err != nil {
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("Error setting build: %s", err), "(Data) ibm_code_engine_app", "read")
+		return tfErr.GetDiag()
+	}
+
+	if err = d.Set("build_run", app.BuildRun); err != nil {
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("Error setting build_run: %s", err), "(Data) ibm_code_engine_app", "read")
+		return tfErr.GetDiag()
+	}
+
 	if err = d.Set("created_at", app.CreatedAt); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting created_at: %s", err))
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("Error setting created_at: %s", err), "(Data) ibm_code_engine_app", "read")
+		return tfErr.GetDiag()
 	}
 
 	if err = d.Set("endpoint", app.Endpoint); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting endpoint: %s", err))
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("Error setting endpoint: %s", err), "(Data) ibm_code_engine_app", "read")
+		return tfErr.GetDiag()
 	}
 
 	if err = d.Set("endpoint_internal", app.EndpointInternal); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting endpoint_internal: %s", err))
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("Error setting endpoint_internal: %s", err), "(Data) ibm_code_engine_app", "read")
+		return tfErr.GetDiag()
 	}
 
 	if err = d.Set("entity_tag", app.EntityTag); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting entity_tag: %s", err))
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("Error setting entity_tag: %s", err), "(Data) ibm_code_engine_app", "read")
+		return tfErr.GetDiag()
 	}
 
 	if err = d.Set("href", app.Href); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting href: %s", err))
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("Error setting href: %s", err), "(Data) ibm_code_engine_app", "read")
+		return tfErr.GetDiag()
 	}
 
 	if err = d.Set("app_id", app.ID); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting app_id: %s", err))
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("Error setting app_id: %s", err), "(Data) ibm_code_engine_app", "read")
+		return tfErr.GetDiag()
 	}
 
 	if err = d.Set("image_port", flex.IntValue(app.ImagePort)); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting image_port: %s", err))
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("Error setting image_port: %s", err), "(Data) ibm_code_engine_app", "read")
+		return tfErr.GetDiag()
 	}
 
 	if err = d.Set("image_reference", app.ImageReference); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting image_reference: %s", err))
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("Error setting image_reference: %s", err), "(Data) ibm_code_engine_app", "read")
+		return tfErr.GetDiag()
 	}
 
 	if err = d.Set("image_secret", app.ImageSecret); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting image_secret: %s", err))
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("Error setting image_secret: %s", err), "(Data) ibm_code_engine_app", "read")
+		return tfErr.GetDiag()
 	}
 
 	if err = d.Set("managed_domain_mappings", app.ManagedDomainMappings); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting managed_domain_mappings: %s", err))
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("Error setting managed_domain_mappings: %s", err), "(Data) ibm_code_engine_app", "read")
+		return tfErr.GetDiag()
+	}
+
+	probeLiveness := []map[string]interface{}{}
+	if app.ProbeLiveness != nil {
+		modelMap, err := dataSourceIbmCodeEngineAppProbeToMap(app.ProbeLiveness)
+		if err != nil {
+			tfErr := flex.TerraformErrorf(err, err.Error(), "(Data) ibm_code_engine_app", "read")
+			return tfErr.GetDiag()
+		}
+		probeLiveness = append(probeLiveness, modelMap)
+	}
+	if err = d.Set("probe_liveness", probeLiveness); err != nil {
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("Error setting probe_liveness: %s", err), "(Data) ibm_code_engine_app", "read")
+		return tfErr.GetDiag()
+	}
+
+	probeReadiness := []map[string]interface{}{}
+	if app.ProbeReadiness != nil {
+		modelMap, err := dataSourceIbmCodeEngineAppProbeToMap(app.ProbeReadiness)
+		if err != nil {
+			tfErr := flex.TerraformErrorf(err, err.Error(), "(Data) ibm_code_engine_app", "read")
+			return tfErr.GetDiag()
+		}
+		probeReadiness = append(probeReadiness, modelMap)
+	}
+	if err = d.Set("probe_readiness", probeReadiness); err != nil {
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("Error setting probe_readiness: %s", err), "(Data) ibm_code_engine_app", "read")
+		return tfErr.GetDiag()
+	}
+
+	if err = d.Set("region", app.Region); err != nil {
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("Error setting region: %s", err), "(Data) ibm_code_engine_app", "read")
+		return tfErr.GetDiag()
 	}
 
 	if err = d.Set("resource_type", app.ResourceType); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting resource_type: %s", err))
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("Error setting resource_type: %s", err), "(Data) ibm_code_engine_app", "read")
+		return tfErr.GetDiag()
 	}
 
 	if err = d.Set("run_as_user", flex.IntValue(app.RunAsUser)); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting run_as_user: %s", err))
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("Error setting run_as_user: %s", err), "(Data) ibm_code_engine_app", "read")
+		return tfErr.GetDiag()
 	}
 
 	runEnvVariables := []map[string]interface{}{}
 	if app.RunEnvVariables != nil {
 		for _, modelItem := range app.RunEnvVariables {
-			modelMap, err := dataSourceIbmCodeEngineAppEnvVarToMap(&modelItem)
+			modelMap, err := dataSourceIbmCodeEngineAppEnvVarToMap(&modelItem) /* #nosec G601 */
 			if err != nil {
-				return diag.FromErr(err)
+				tfErr := flex.TerraformErrorf(err, err.Error(), "(Data) ibm_code_engine_app", "read")
+				return tfErr.GetDiag()
 			}
 			runEnvVariables = append(runEnvVariables, modelMap)
 		}
 	}
 	if err = d.Set("run_env_variables", runEnvVariables); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting run_env_variables %s", err))
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("Error setting run_env_variables: %s", err), "(Data) ibm_code_engine_app", "read")
+		return tfErr.GetDiag()
 	}
 
 	if err = d.Set("run_service_account", app.RunServiceAccount); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting run_service_account: %s", err))
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("Error setting run_service_account: %s", err), "(Data) ibm_code_engine_app", "read")
+		return tfErr.GetDiag()
 	}
 
 	runVolumeMounts := []map[string]interface{}{}
 	if app.RunVolumeMounts != nil {
 		for _, modelItem := range app.RunVolumeMounts {
-			modelMap, err := dataSourceIbmCodeEngineAppVolumeMountToMap(&modelItem)
+			modelMap, err := dataSourceIbmCodeEngineAppVolumeMountToMap(&modelItem) /* #nosec G601 */
 			if err != nil {
-				return diag.FromErr(err)
+				tfErr := flex.TerraformErrorf(err, err.Error(), "(Data) ibm_code_engine_app", "read")
+				return tfErr.GetDiag()
 			}
 			runVolumeMounts = append(runVolumeMounts, modelMap)
 		}
 	}
 	if err = d.Set("run_volume_mounts", runVolumeMounts); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting run_volume_mounts %s", err))
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("Error setting run_volume_mounts: %s", err), "(Data) ibm_code_engine_app", "read")
+		return tfErr.GetDiag()
 	}
 
 	if err = d.Set("scale_concurrency", flex.IntValue(app.ScaleConcurrency)); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting scale_concurrency: %s", err))
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("Error setting scale_concurrency: %s", err), "(Data) ibm_code_engine_app", "read")
+		return tfErr.GetDiag()
 	}
 
 	if err = d.Set("scale_concurrency_target", flex.IntValue(app.ScaleConcurrencyTarget)); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting scale_concurrency_target: %s", err))
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("Error setting scale_concurrency_target: %s", err), "(Data) ibm_code_engine_app", "read")
+		return tfErr.GetDiag()
 	}
 
 	if err = d.Set("scale_cpu_limit", app.ScaleCpuLimit); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting scale_cpu_limit: %s", err))
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("Error setting scale_cpu_limit: %s", err), "(Data) ibm_code_engine_app", "read")
+		return tfErr.GetDiag()
+	}
+
+	if err = d.Set("scale_down_delay", flex.IntValue(app.ScaleDownDelay)); err != nil {
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("Error setting scale_down_delay: %s", err), "(Data) ibm_code_engine_app", "read")
+		return tfErr.GetDiag()
 	}
 
 	if err = d.Set("scale_ephemeral_storage_limit", app.ScaleEphemeralStorageLimit); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting scale_ephemeral_storage_limit: %s", err))
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("Error setting scale_ephemeral_storage_limit: %s", err), "(Data) ibm_code_engine_app", "read")
+		return tfErr.GetDiag()
 	}
 
 	if err = d.Set("scale_initial_instances", flex.IntValue(app.ScaleInitialInstances)); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting scale_initial_instances: %s", err))
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("Error setting scale_initial_instances: %s", err), "(Data) ibm_code_engine_app", "read")
+		return tfErr.GetDiag()
 	}
 
 	if err = d.Set("scale_max_instances", flex.IntValue(app.ScaleMaxInstances)); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting scale_max_instances: %s", err))
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("Error setting scale_max_instances: %s", err), "(Data) ibm_code_engine_app", "read")
+		return tfErr.GetDiag()
 	}
 
 	if err = d.Set("scale_memory_limit", app.ScaleMemoryLimit); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting scale_memory_limit: %s", err))
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("Error setting scale_memory_limit: %s", err), "(Data) ibm_code_engine_app", "read")
+		return tfErr.GetDiag()
 	}
 
 	if err = d.Set("scale_min_instances", flex.IntValue(app.ScaleMinInstances)); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting scale_min_instances: %s", err))
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("Error setting scale_min_instances: %s", err), "(Data) ibm_code_engine_app", "read")
+		return tfErr.GetDiag()
 	}
 
 	if err = d.Set("scale_request_timeout", flex.IntValue(app.ScaleRequestTimeout)); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting scale_request_timeout: %s", err))
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("Error setting scale_request_timeout: %s", err), "(Data) ibm_code_engine_app", "read")
+		return tfErr.GetDiag()
 	}
 
 	if err = d.Set("status", app.Status); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting status: %s", err))
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("Error setting status: %s", err), "(Data) ibm_code_engine_app", "read")
+		return tfErr.GetDiag()
 	}
 
 	statusDetails := []map[string]interface{}{}
 	if app.StatusDetails != nil {
 		modelMap, err := dataSourceIbmCodeEngineAppAppStatusToMap(app.StatusDetails)
 		if err != nil {
-			return diag.FromErr(err)
+			tfErr := flex.TerraformErrorf(err, err.Error(), "(Data) ibm_code_engine_app", "read")
+			return tfErr.GetDiag()
 		}
 		statusDetails = append(statusDetails, modelMap)
 	}
 	if err = d.Set("status_details", statusDetails); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting status_details %s", err))
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("Error setting status_details: %s", err), "(Data) ibm_code_engine_app", "read")
+		return tfErr.GetDiag()
 	}
 
 	return nil
+}
+
+func dataSourceIbmCodeEngineAppProbeToMap(model *codeenginev2.Probe) (map[string]interface{}, error) {
+	modelMap := make(map[string]interface{})
+	if model.FailureThreshold != nil {
+		modelMap["failure_threshold"] = flex.IntValue(model.FailureThreshold)
+	}
+	if model.InitialDelay != nil {
+		modelMap["initial_delay"] = flex.IntValue(model.InitialDelay)
+	}
+	if model.Interval != nil {
+		modelMap["interval"] = flex.IntValue(model.Interval)
+	}
+	if model.Path != nil {
+		modelMap["path"] = model.Path
+	}
+	if model.Port != nil {
+		modelMap["port"] = flex.IntValue(model.Port)
+	}
+	if model.Timeout != nil {
+		modelMap["timeout"] = flex.IntValue(model.Timeout)
+	}
+	if model.Type != nil {
+		modelMap["type"] = model.Type
+	}
+	return modelMap, nil
 }
 
 func dataSourceIbmCodeEngineAppEnvVarToMap(model *codeenginev2.EnvVar) (map[string]interface{}, error) {

--- a/ibm/service/codeengine/data_source_ibm_code_engine_app_test.go
+++ b/ibm/service/codeengine/data_source_ibm_code_engine_app_test.go
@@ -109,7 +109,9 @@ func testAccCheckIbmCodeEngineAppDataSourceConfigBasic(projectID string, appImag
 
 			lifecycle {
 				ignore_changes = [
-					run_env_variables
+					run_env_variables,
+					probe_liveness,
+					probe_readiness
 				]
 			}
 		}
@@ -153,7 +155,9 @@ func testAccCheckIbmCodeEngineAppDataSourceConfig(projectID string, appImageRefe
 
 			lifecycle {
 				ignore_changes = [
-					run_env_variables
+					run_env_variables,
+					probe_liveness,
+					probe_readiness
 				]
 			}
 		}

--- a/ibm/service/codeengine/data_source_ibm_code_engine_binding_test.go
+++ b/ibm/service/codeengine/data_source_ibm_code_engine_binding_test.go
@@ -57,7 +57,9 @@ func testAccCheckIbmCodeEngineBindingDataSourceConfigBasic(projectID string, app
 
 			lifecycle {
 				ignore_changes = [
-					run_env_variables
+					run_env_variables,
+					probe_liveness,
+					probe_readiness
 				]
 			}
 		}

--- a/ibm/service/codeengine/data_source_ibm_code_engine_build.go
+++ b/ibm/service/codeengine/data_source_ibm_code_engine_build.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2023 All Rights Reserved.
+// Copyright IBM Corp. 2024 All Rights Reserved.
 // Licensed under the Mozilla Public License v2.0
 
 package codeengine
@@ -21,88 +21,93 @@ func DataSourceIbmCodeEngineBuild() *schema.Resource {
 		ReadContext: dataSourceIbmCodeEngineBuildRead,
 
 		Schema: map[string]*schema.Schema{
-			"project_id": &schema.Schema{
+			"project_id": {
 				Type:        schema.TypeString,
 				Required:    true,
 				Description: "The ID of the project.",
 			},
-			"name": &schema.Schema{
+			"name": {
 				Type:        schema.TypeString,
 				Required:    true,
 				Description: "The name of your build.",
 			},
-			"created_at": &schema.Schema{
+			"created_at": {
 				Type:        schema.TypeString,
 				Computed:    true,
 				Description: "The timestamp when the resource was created.",
 			},
-			"entity_tag": &schema.Schema{
+			"entity_tag": {
 				Type:        schema.TypeString,
 				Computed:    true,
 				Description: "The version of the build instance, which is used to achieve optimistic locking.",
 			},
-			"href": &schema.Schema{
+			"href": {
 				Type:        schema.TypeString,
 				Computed:    true,
 				Description: "When you provision a new build,  a URL is created identifying the location of the instance.",
 			},
-			"build_id": &schema.Schema{
+			"build_id": {
 				Type:        schema.TypeString,
 				Computed:    true,
 				Description: "The identifier of the resource.",
 			},
-			"output_image": &schema.Schema{
+			"output_image": {
 				Type:        schema.TypeString,
 				Computed:    true,
 				Description: "The name of the image.",
 			},
-			"output_secret": &schema.Schema{
+			"output_secret": {
 				Type:        schema.TypeString,
 				Computed:    true,
 				Description: "The secret that is required to access the image registry. Make sure that the secret is granted with push permissions towards the specified container registry namespace.",
 			},
-			"resource_type": &schema.Schema{
+			"region": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The region of the project the resource is located in. Possible values: 'au-syd', 'br-sao', 'ca-tor', 'eu-de', 'eu-gb', 'jp-osa', 'jp-tok', 'us-east', 'us-south'.",
+			},
+			"resource_type": {
 				Type:        schema.TypeString,
 				Computed:    true,
 				Description: "The type of the build.",
 			},
-			"source_context_dir": &schema.Schema{
+			"source_context_dir": {
 				Type:        schema.TypeString,
 				Computed:    true,
-				Description: "Option directory in the repository that contains the buildpacks file or the Dockerfile.",
+				Description: "Optional directory in the repository that contains the buildpacks file or the Dockerfile.",
 			},
-			"source_revision": &schema.Schema{
+			"source_revision": {
 				Type:        schema.TypeString,
 				Computed:    true,
 				Description: "Commit, tag, or branch in the source repository to pull. This field is optional if the `source_type` is `git` and uses the HEAD of default branch if not specified. If the `source_type` value is `local`, this field must be omitted.",
 			},
-			"source_secret": &schema.Schema{
+			"source_secret": {
 				Type:        schema.TypeString,
 				Computed:    true,
 				Description: "Name of the secret that is used access the repository source. This field is optional if the `source_type` is `git`. Additionally, if the `source_url` points to a repository that requires authentication, the build will be created but cannot access any source code, until this property is provided, too. If the `source_type` value is `local`, this field must be omitted.",
 			},
-			"source_type": &schema.Schema{
+			"source_type": {
 				Type:        schema.TypeString,
 				Computed:    true,
 				Description: "Specifies the type of source to determine if your build source is in a repository or based on local source code.* local - For builds from local source code.* git - For builds from git version controlled source code.",
 			},
-			"source_url": &schema.Schema{
+			"source_url": {
 				Type:        schema.TypeString,
 				Computed:    true,
 				Description: "The URL of the code repository. This field is required if the `source_type` is `git`. If the `source_type` value is `local`, this field must be omitted. If the repository is publicly available you can provide a 'https' URL like `https://github.com/IBM/CodeEngine`. If the repository requires authentication, you need to provide a 'ssh' URL like `git@github.com:IBM/CodeEngine.git` along with a `source_secret` that points to a secret of format `ssh_auth`.",
 			},
-			"status": &schema.Schema{
+			"status": {
 				Type:        schema.TypeString,
 				Computed:    true,
 				Description: "The current status of the build.",
 			},
-			"status_details": &schema.Schema{
+			"status_details": {
 				Type:        schema.TypeList,
 				Computed:    true,
 				Description: "The detailed status of the build.",
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
-						"reason": &schema.Schema{
+						"reason": {
 							Type:        schema.TypeString,
 							Computed:    true,
 							Description: "Optional information to provide more context in case of a 'failed' or 'warning' status.",
@@ -110,22 +115,22 @@ func DataSourceIbmCodeEngineBuild() *schema.Resource {
 					},
 				},
 			},
-			"strategy_size": &schema.Schema{
+			"strategy_size": {
 				Type:        schema.TypeString,
 				Computed:    true,
-				Description: "Optional size for the build, which determines the amount of resources used. Build sizes are `small`, `medium`, `large`, `xlarge`.",
+				Description: "Optional size for the build, which determines the amount of resources used. Build sizes are `small`, `medium`, `large`, `xlarge`, `xxlarge`.",
 			},
-			"strategy_spec_file": &schema.Schema{
+			"strategy_spec_file": {
 				Type:        schema.TypeString,
 				Computed:    true,
 				Description: "Optional path to the specification file that is used for build strategies for building an image.",
 			},
-			"strategy_type": &schema.Schema{
+			"strategy_type": {
 				Type:        schema.TypeString,
 				Computed:    true,
 				Description: "The strategy to use for building the image.",
 			},
-			"timeout": &schema.Schema{
+			"timeout": {
 				Type:        schema.TypeInt,
 				Computed:    true,
 				Description: "The maximum amount of time, in seconds, that can pass before the build must succeed or fail.",
@@ -137,7 +142,9 @@ func DataSourceIbmCodeEngineBuild() *schema.Resource {
 func dataSourceIbmCodeEngineBuildRead(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	codeEngineClient, err := meta.(conns.ClientSession).CodeEngineV2()
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.TerraformErrorf(err, err.Error(), "(Data) ibm_code_engine_build", "read")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	getBuildOptions := &codeenginev2.GetBuildOptions{}
@@ -145,92 +152,117 @@ func dataSourceIbmCodeEngineBuildRead(context context.Context, d *schema.Resourc
 	getBuildOptions.SetProjectID(d.Get("project_id").(string))
 	getBuildOptions.SetName(d.Get("name").(string))
 
-	build, response, err := codeEngineClient.GetBuildWithContext(context, getBuildOptions)
+	build, _, err := codeEngineClient.GetBuildWithContext(context, getBuildOptions)
 	if err != nil {
-		log.Printf("[DEBUG] GetBuildWithContext failed %s\n%s", err, response)
-		return diag.FromErr(fmt.Errorf("GetBuildWithContext failed %s\n%s", err, response))
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("GetBuildWithContext failed: %s", err.Error()), "(Data) ibm_code_engine_build", "read")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	d.SetId(fmt.Sprintf("%s/%s", *getBuildOptions.ProjectID, *getBuildOptions.Name))
 
 	if err = d.Set("created_at", build.CreatedAt); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting created_at: %s", err))
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("Error setting created_at: %s", err), "(Data) ibm_code_engine_build", "read")
+		return tfErr.GetDiag()
 	}
 
 	if err = d.Set("entity_tag", build.EntityTag); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting entity_tag: %s", err))
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("Error setting entity_tag: %s", err), "(Data) ibm_code_engine_build", "read")
+		return tfErr.GetDiag()
 	}
 
 	if err = d.Set("href", build.Href); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting href: %s", err))
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("Error setting href: %s", err), "(Data) ibm_code_engine_build", "read")
+		return tfErr.GetDiag()
 	}
 
 	if err = d.Set("build_id", build.ID); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting build_id: %s", err))
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("Error setting build_id: %s", err), "(Data) ibm_code_engine_build", "read")
+		return tfErr.GetDiag()
 	}
 
 	if err = d.Set("output_image", build.OutputImage); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting output_image: %s", err))
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("Error setting output_image: %s", err), "(Data) ibm_code_engine_build", "read")
+		return tfErr.GetDiag()
 	}
 
 	if err = d.Set("output_secret", build.OutputSecret); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting output_secret: %s", err))
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("Error setting output_secret: %s", err), "(Data) ibm_code_engine_build", "read")
+		return tfErr.GetDiag()
+	}
+
+	if err = d.Set("region", build.Region); err != nil {
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("Error setting region: %s", err), "(Data) ibm_code_engine_build", "read")
+		return tfErr.GetDiag()
 	}
 
 	if err = d.Set("resource_type", build.ResourceType); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting resource_type: %s", err))
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("Error setting resource_type: %s", err), "(Data) ibm_code_engine_build", "read")
+		return tfErr.GetDiag()
 	}
 
 	if err = d.Set("source_context_dir", build.SourceContextDir); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting source_context_dir: %s", err))
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("Error setting source_context_dir: %s", err), "(Data) ibm_code_engine_build", "read")
+		return tfErr.GetDiag()
 	}
 
 	if err = d.Set("source_revision", build.SourceRevision); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting source_revision: %s", err))
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("Error setting source_revision: %s", err), "(Data) ibm_code_engine_build", "read")
+		return tfErr.GetDiag()
 	}
 
 	if err = d.Set("source_secret", build.SourceSecret); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting source_secret: %s", err))
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("Error setting source_secret: %s", err), "(Data) ibm_code_engine_build", "read")
+		return tfErr.GetDiag()
 	}
 
 	if err = d.Set("source_type", build.SourceType); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting source_type: %s", err))
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("Error setting source_type: %s", err), "(Data) ibm_code_engine_build", "read")
+		return tfErr.GetDiag()
 	}
 
 	if err = d.Set("source_url", build.SourceURL); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting source_url: %s", err))
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("Error setting source_url: %s", err), "(Data) ibm_code_engine_build", "read")
+		return tfErr.GetDiag()
 	}
 
 	if err = d.Set("status", build.Status); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting status: %s", err))
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("Error setting status: %s", err), "(Data) ibm_code_engine_build", "read")
+		return tfErr.GetDiag()
 	}
 
 	statusDetails := []map[string]interface{}{}
 	if build.StatusDetails != nil {
 		modelMap, err := dataSourceIbmCodeEngineBuildBuildStatusToMap(build.StatusDetails)
 		if err != nil {
-			return diag.FromErr(err)
+			tfErr := flex.TerraformErrorf(err, err.Error(), "(Data) ibm_code_engine_build", "read")
+			return tfErr.GetDiag()
 		}
 		statusDetails = append(statusDetails, modelMap)
 	}
 	if err = d.Set("status_details", statusDetails); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting status_details %s", err))
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("Error setting status_details: %s", err), "(Data) ibm_code_engine_build", "read")
+		return tfErr.GetDiag()
 	}
 
 	if err = d.Set("strategy_size", build.StrategySize); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting strategy_size: %s", err))
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("Error setting strategy_size: %s", err), "(Data) ibm_code_engine_build", "read")
+		return tfErr.GetDiag()
 	}
 
 	if err = d.Set("strategy_spec_file", build.StrategySpecFile); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting strategy_spec_file: %s", err))
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("Error setting strategy_spec_file: %s", err), "(Data) ibm_code_engine_build", "read")
+		return tfErr.GetDiag()
 	}
 
 	if err = d.Set("strategy_type", build.StrategyType); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting strategy_type: %s", err))
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("Error setting strategy_type: %s", err), "(Data) ibm_code_engine_build", "read")
+		return tfErr.GetDiag()
 	}
 
 	if err = d.Set("timeout", flex.IntValue(build.Timeout)); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting timeout: %s", err))
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("Error setting timeout: %s", err), "(Data) ibm_code_engine_build", "read")
+		return tfErr.GetDiag()
 	}
 
 	return nil

--- a/ibm/service/codeengine/data_source_ibm_code_engine_config_map.go
+++ b/ibm/service/codeengine/data_source_ibm_code_engine_config_map.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2023 All Rights Reserved.
+// Copyright IBM Corp. 2024 All Rights Reserved.
 // Licensed under the Mozilla Public License v2.0
 
 package codeengine
@@ -12,6 +12,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 
 	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/conns"
+	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/flex"
 	"github.com/IBM/code-engine-go-sdk/codeenginev2"
 )
 
@@ -20,22 +21,22 @@ func DataSourceIbmCodeEngineConfigMap() *schema.Resource {
 		ReadContext: dataSourceIbmCodeEngineConfigMapRead,
 
 		Schema: map[string]*schema.Schema{
-			"project_id": &schema.Schema{
+			"project_id": {
 				Type:        schema.TypeString,
 				Required:    true,
 				Description: "The ID of the project.",
 			},
-			"name": &schema.Schema{
+			"name": {
 				Type:        schema.TypeString,
 				Required:    true,
 				Description: "The name of your configmap.",
 			},
-			"created_at": &schema.Schema{
+			"created_at": {
 				Type:        schema.TypeString,
 				Computed:    true,
 				Description: "The timestamp when the resource was created.",
 			},
-			"data": &schema.Schema{
+			"data": {
 				Type:        schema.TypeMap,
 				Computed:    true,
 				Description: "The key-value pair for the config map. Values must be specified in `KEY=VALUE` format.",
@@ -43,22 +44,27 @@ func DataSourceIbmCodeEngineConfigMap() *schema.Resource {
 					Type: schema.TypeString,
 				},
 			},
-			"entity_tag": &schema.Schema{
+			"entity_tag": {
 				Type:        schema.TypeString,
 				Computed:    true,
 				Description: "The version of the config map instance, which is used to achieve optimistic locking.",
 			},
-			"href": &schema.Schema{
+			"href": {
 				Type:        schema.TypeString,
 				Computed:    true,
 				Description: "When you provision a new config map,  a URL is created identifying the location of the instance.",
 			},
-			"config_map_id": &schema.Schema{
+			"config_map_id": {
 				Type:        schema.TypeString,
 				Computed:    true,
 				Description: "The identifier of the resource.",
 			},
-			"resource_type": &schema.Schema{
+			"region": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The region of the project the resource is located in. Possible values: 'au-syd', 'br-sao', 'ca-tor', 'eu-de', 'eu-gb', 'jp-osa', 'jp-tok', 'us-east', 'us-south'.",
+			},
+			"resource_type": {
 				Type:        schema.TypeString,
 				Computed:    true,
 				Description: "The type of the config map.",
@@ -70,7 +76,9 @@ func DataSourceIbmCodeEngineConfigMap() *schema.Resource {
 func dataSourceIbmCodeEngineConfigMapRead(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	codeEngineClient, err := meta.(conns.ClientSession).CodeEngineV2()
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.TerraformErrorf(err, err.Error(), "(Data) ibm_code_engine_config_map", "read")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	getConfigMapOptions := &codeenginev2.GetConfigMapOptions{}
@@ -78,41 +86,54 @@ func dataSourceIbmCodeEngineConfigMapRead(context context.Context, d *schema.Res
 	getConfigMapOptions.SetProjectID(d.Get("project_id").(string))
 	getConfigMapOptions.SetName(d.Get("name").(string))
 
-	configMap, response, err := codeEngineClient.GetConfigMapWithContext(context, getConfigMapOptions)
+	configMap, _, err := codeEngineClient.GetConfigMapWithContext(context, getConfigMapOptions)
 	if err != nil {
-		log.Printf("[DEBUG] GetConfigMapWithContext failed %s\n%s", err, response)
-		return diag.FromErr(fmt.Errorf("GetConfigMapWithContext failed %s\n%s", err, response))
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("GetConfigMapWithContext failed: %s", err.Error()), "(Data) ibm_code_engine_config_map", "read")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	d.SetId(fmt.Sprintf("%s/%s", *getConfigMapOptions.ProjectID, *getConfigMapOptions.Name))
 
 	if err = d.Set("created_at", configMap.CreatedAt); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting created_at: %s", err))
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("error setting created_at: %s", err), "(Data) ibm_code_engine_config_map", "read")
+		return tfErr.GetDiag()
 	}
 
 	if configMap.Data != nil {
 		if err = d.Set("data", configMap.Data); err != nil {
-			return diag.FromErr(fmt.Errorf("Error setting data: %s", err))
+			tfErr := flex.TerraformErrorf(err, fmt.Sprintf("error setting data: %s", err), "(Data) ibm_code_engine_config_map", "read")
+			return tfErr.GetDiag()
 		}
 		if err != nil {
-			return diag.FromErr(fmt.Errorf("Error setting data %s", err))
+			tfErr := flex.TerraformErrorf(err, fmt.Sprintf("error setting data: %s", err), "(Data) ibm_code_engine_config_map", "read")
+			return tfErr.GetDiag()
 		}
 	}
 
 	if err = d.Set("entity_tag", configMap.EntityTag); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting entity_tag: %s", err))
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("error setting entity_tag: %s", err), "(Data) ibm_code_engine_config_map", "read")
+		return tfErr.GetDiag()
 	}
 
 	if err = d.Set("href", configMap.Href); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting href: %s", err))
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("error setting href: %s", err), "(Data) ibm_code_engine_config_map", "read")
+		return tfErr.GetDiag()
+	}
+
+	if err = d.Set("region", configMap.Region); err != nil {
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("error setting region: %s", err), "(Data) ibm_code_engine_config_map", "read")
+		return tfErr.GetDiag()
 	}
 
 	if err = d.Set("config_map_id", configMap.ID); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting config_map_id: %s", err))
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("error setting config_map_id: %s", err), "(Data) ibm_code_engine_config_map", "read")
+		return tfErr.GetDiag()
 	}
 
 	if err = d.Set("resource_type", configMap.ResourceType); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting resource_type: %s", err))
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("error setting resource_type: %s", err), "(Data) ibm_code_engine_config_map", "read")
+		return tfErr.GetDiag()
 	}
 
 	return nil

--- a/ibm/service/codeengine/data_source_ibm_code_engine_domain_mapping.go
+++ b/ibm/service/codeengine/data_source_ibm_code_engine_domain_mapping.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2023 All Rights Reserved.
+// Copyright IBM Corp. 2024 All Rights Reserved.
 // Licensed under the Mozilla Public License v2.0
 
 package codeengine
@@ -12,6 +12,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 
 	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/conns"
+	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/flex"
 	"github.com/IBM/code-engine-go-sdk/codeenginev2"
 )
 
@@ -20,33 +21,33 @@ func DataSourceIbmCodeEngineDomainMapping() *schema.Resource {
 		ReadContext: dataSourceIbmCodeEngineDomainMappingRead,
 
 		Schema: map[string]*schema.Schema{
-			"project_id": &schema.Schema{
+			"project_id": {
 				Type:        schema.TypeString,
 				Required:    true,
 				Description: "The ID of the project.",
 			},
-			"name": &schema.Schema{
+			"name": {
 				Type:        schema.TypeString,
 				Required:    true,
 				Description: "The name of your domain mapping.",
 			},
-			"cname_target": &schema.Schema{
+			"cname_target": {
 				Type:        schema.TypeString,
 				Computed:    true,
-				Description: "Exposes the value of the CNAME record that needs to be configured in the DNS settings of the domain, to route traffic properly to the target Code Engine region.",
+				Description: "The value of the CNAME record that must be configured in the DNS settings of the domain, to route traffic properly to the target Code Engine region.",
 			},
-			"component": &schema.Schema{
+			"component": {
 				Type:        schema.TypeList,
 				Computed:    true,
 				Description: "A reference to another component.",
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
-						"name": &schema.Schema{
+						"name": {
 							Type:        schema.TypeString,
 							Computed:    true,
 							Description: "The name of the referenced component.",
 						},
-						"resource_type": &schema.Schema{
+						"resource_type": {
 							Type:        schema.TypeString,
 							Computed:    true,
 							Description: "The type of the referenced resource.",
@@ -54,43 +55,48 @@ func DataSourceIbmCodeEngineDomainMapping() *schema.Resource {
 					},
 				},
 			},
-			"created_at": &schema.Schema{
+			"created_at": {
 				Type:        schema.TypeString,
 				Computed:    true,
 				Description: "The timestamp when the resource was created.",
 			},
-			"domain_mapping_id": &schema.Schema{
+			"domain_mapping_id": {
 				Type:        schema.TypeString,
 				Computed:    true,
 				Description: "The identifier of the resource.",
 			},
-			"entity_tag": &schema.Schema{
+			"entity_tag": {
 				Type:        schema.TypeString,
 				Computed:    true,
 				Description: "The version of the domain mapping instance, which is used to achieve optimistic locking.",
 			},
-			"href": &schema.Schema{
+			"href": {
 				Type:        schema.TypeString,
 				Computed:    true,
 				Description: "When you provision a new domain mapping, a URL is created identifying the location of the instance.",
 			},
-			"resource_type": &schema.Schema{
+			"region": {
 				Type:        schema.TypeString,
 				Computed:    true,
-				Description: "The type of the CE Resource.",
+				Description: "The region of the project the resource is located in. Possible values: 'au-syd', 'br-sao', 'ca-tor', 'eu-de', 'eu-gb', 'jp-osa', 'jp-tok', 'us-east', 'us-south'.",
 			},
-			"status": &schema.Schema{
+			"resource_type": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The type of the Code Engine resource.",
+			},
+			"status": {
 				Type:        schema.TypeString,
 				Computed:    true,
 				Description: "The current status of the domain mapping.",
 			},
-			"status_details": &schema.Schema{
+			"status_details": {
 				Type:        schema.TypeList,
 				Computed:    true,
 				Description: "The detailed status of the domain mapping.",
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
-						"reason": &schema.Schema{
+						"reason": {
 							Type:        schema.TypeString,
 							Computed:    true,
 							Description: "Optional information to provide more context in case of a 'failed' or 'warning' status.",
@@ -98,20 +104,20 @@ func DataSourceIbmCodeEngineDomainMapping() *schema.Resource {
 					},
 				},
 			},
-			"tls_secret": &schema.Schema{
+			"tls_secret": {
 				Type:        schema.TypeString,
 				Computed:    true,
-				Description: "The name of the TLS secret that holds the certificate and private key of this domain mapping.",
+				Description: "The name of the TLS secret that includes the certificate and private key of this domain mapping.",
 			},
-			"user_managed": &schema.Schema{
+			"user_managed": {
 				Type:        schema.TypeBool,
 				Computed:    true,
-				Description: "Exposes whether the domain mapping is managed by the user or by Code Engine.",
+				Description: "Specifies whether the domain mapping is managed by the user or by Code Engine.",
 			},
-			"visibility": &schema.Schema{
+			"visibility": {
 				Type:        schema.TypeString,
 				Computed:    true,
-				Description: "Exposes whether the domain mapping is reachable through the public internet, or private IBM network, or only through other components within the same Code Engine project.",
+				Description: "Specifies whether the domain mapping is reachable through the public internet, or private IBM network, or only through other components within the same Code Engine project.",
 			},
 		},
 	}
@@ -120,7 +126,9 @@ func DataSourceIbmCodeEngineDomainMapping() *schema.Resource {
 func dataSourceIbmCodeEngineDomainMappingRead(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	codeEngineClient, err := meta.(conns.ClientSession).CodeEngineV2()
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.TerraformErrorf(err, err.Error(), "(Data) ibm_code_engine_domain_mapping", "read")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	getDomainMappingOptions := &codeenginev2.GetDomainMappingOptions{}
@@ -128,76 +136,96 @@ func dataSourceIbmCodeEngineDomainMappingRead(context context.Context, d *schema
 	getDomainMappingOptions.SetProjectID(d.Get("project_id").(string))
 	getDomainMappingOptions.SetName(d.Get("name").(string))
 
-	domainMapping, response, err := codeEngineClient.GetDomainMappingWithContext(context, getDomainMappingOptions)
+	domainMapping, _, err := codeEngineClient.GetDomainMappingWithContext(context, getDomainMappingOptions)
 	if err != nil {
-		log.Printf("[DEBUG] GetDomainMappingWithContext failed %s\n%s", err, response)
-		return diag.FromErr(fmt.Errorf("GetDomainMappingWithContext failed %s\n%s", err, response))
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("GetDomainMappingWithContext failed: %s", err.Error()), "(Data) ibm_code_engine_domain_mapping", "read")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	d.SetId(fmt.Sprintf("%s/%s", *getDomainMappingOptions.ProjectID, *getDomainMappingOptions.Name))
 
 	if err = d.Set("cname_target", domainMapping.CnameTarget); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting cname_target: %s", err))
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("Error setting cname_target: %s", err), "(Data) ibm_code_engine_domain_mapping", "read")
+		return tfErr.GetDiag()
 	}
 
 	component := []map[string]interface{}{}
 	if domainMapping.Component != nil {
 		modelMap, err := dataSourceIbmCodeEngineDomainMappingComponentRefToMap(domainMapping.Component)
 		if err != nil {
-			return diag.FromErr(err)
+			tfErr := flex.TerraformErrorf(err, err.Error(), "(Data) ibm_code_engine_domain_mapping", "read")
+			return tfErr.GetDiag()
 		}
 		component = append(component, modelMap)
 	}
 	if err = d.Set("component", component); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting component %s", err))
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("Error setting component: %s", err), "(Data) ibm_code_engine_domain_mapping", "read")
+		return tfErr.GetDiag()
 	}
 
 	if err = d.Set("created_at", domainMapping.CreatedAt); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting created_at: %s", err))
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("Error setting created_at: %s", err), "(Data) ibm_code_engine_domain_mapping", "read")
+		return tfErr.GetDiag()
 	}
 
 	if err = d.Set("entity_tag", domainMapping.EntityTag); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting entity_tag: %s", err))
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("Error setting entity_tag: %s", err), "(Data) ibm_code_engine_domain_mapping", "read")
+		return tfErr.GetDiag()
 	}
 
 	if err = d.Set("href", domainMapping.Href); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting href: %s", err))
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("Error setting href: %s", err), "(Data) ibm_code_engine_domain_mapping", "read")
+		return tfErr.GetDiag()
 	}
 
 	if err = d.Set("domain_mapping_id", domainMapping.ID); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting domain_mapping_id: %s", err))
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("Error setting domain_mapping_id: %s", err), "(Data) ibm_code_engine_domain_mapping", "read")
+		return tfErr.GetDiag()
+	}
+
+	if err = d.Set("region", domainMapping.Region); err != nil {
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("Error setting region: %s", err), "(Data) ibm_code_engine_domain_mapping", "read")
+		return tfErr.GetDiag()
 	}
 
 	if err = d.Set("resource_type", domainMapping.ResourceType); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting resource_type: %s", err))
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("Error setting resource_type: %s", err), "(Data) ibm_code_engine_domain_mapping", "read")
+		return tfErr.GetDiag()
 	}
 
 	if err = d.Set("status", domainMapping.Status); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting status: %s", err))
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("Error setting status: %s", err), "(Data) ibm_code_engine_domain_mapping", "read")
+		return tfErr.GetDiag()
 	}
 
 	statusDetails := []map[string]interface{}{}
 	if domainMapping.StatusDetails != nil {
 		modelMap, err := dataSourceIbmCodeEngineDomainMappingDomainMappingStatusToMap(domainMapping.StatusDetails)
 		if err != nil {
-			return diag.FromErr(err)
+			tfErr := flex.TerraformErrorf(err, err.Error(), "(Data) ibm_code_engine_domain_mapping", "read")
+			return tfErr.GetDiag()
 		}
 		statusDetails = append(statusDetails, modelMap)
 	}
 	if err = d.Set("status_details", statusDetails); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting status_details %s", err))
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("Error setting status_details: %s", err), "(Data) ibm_code_engine_domain_mapping", "read")
+		return tfErr.GetDiag()
 	}
 
 	if err = d.Set("tls_secret", domainMapping.TlsSecret); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting tls_secret: %s", err))
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("Error setting tls_secret: %s", err), "(Data) ibm_code_engine_domain_mapping", "read")
+		return tfErr.GetDiag()
 	}
 
 	if err = d.Set("user_managed", domainMapping.UserManaged); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting user_managed: %s", err))
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("Error setting user_managed: %s", err), "(Data) ibm_code_engine_domain_mapping", "read")
+		return tfErr.GetDiag()
 	}
 
 	if err = d.Set("visibility", domainMapping.Visibility); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting visibility: %s", err))
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("Error setting visibility: %s", err), "(Data) ibm_code_engine_domain_mapping", "read")
+		return tfErr.GetDiag()
 	}
 
 	return nil

--- a/ibm/service/codeengine/data_source_ibm_code_engine_job.go
+++ b/ibm/service/codeengine/data_source_ibm_code_engine_job.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2023 All Rights Reserved.
+// Copyright IBM Corp. 2024 All Rights Reserved.
 // Licensed under the Mozilla Public License v2.0
 
 package codeengine
@@ -21,52 +21,67 @@ func DataSourceIbmCodeEngineJob() *schema.Resource {
 		ReadContext: dataSourceIbmCodeEngineJobRead,
 
 		Schema: map[string]*schema.Schema{
-			"project_id": &schema.Schema{
+			"project_id": {
 				Type:        schema.TypeString,
 				Required:    true,
 				Description: "The ID of the project.",
 			},
-			"name": &schema.Schema{
+			"name": {
 				Type:        schema.TypeString,
 				Required:    true,
 				Description: "The name of your job.",
 			},
-			"created_at": &schema.Schema{
+			"build": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "Reference to a build that is associated with the job.",
+			},
+			"build_run": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "Reference to a build run that is associated with the job.",
+			},
+			"created_at": {
 				Type:        schema.TypeString,
 				Computed:    true,
 				Description: "The timestamp when the resource was created.",
 			},
-			"entity_tag": &schema.Schema{
+			"entity_tag": {
 				Type:        schema.TypeString,
 				Computed:    true,
 				Description: "The version of the job instance, which is used to achieve optimistic locking.",
 			},
-			"href": &schema.Schema{
+			"href": {
 				Type:        schema.TypeString,
 				Computed:    true,
 				Description: "When you provision a new job,  a URL is created identifying the location of the instance.",
 			},
-			"job_id": &schema.Schema{
+			"job_id": {
 				Type:        schema.TypeString,
 				Computed:    true,
 				Description: "The identifier of the resource.",
 			},
-			"image_reference": &schema.Schema{
+			"image_reference": {
 				Type:        schema.TypeString,
 				Computed:    true,
 				Description: "The name of the image that is used for this job. The format is `REGISTRY/NAMESPACE/REPOSITORY:TAG` where `REGISTRY` and `TAG` are optional. If `REGISTRY` is not specified, the default is `docker.io`. If `TAG` is not specified, the default is `latest`. If the image reference points to a registry that requires authentication, make sure to also specify the property `image_secret`.",
 			},
-			"image_secret": &schema.Schema{
+			"image_secret": {
 				Type:        schema.TypeString,
 				Computed:    true,
 				Description: "The name of the image registry access secret. The image registry access secret is used to authenticate with a private registry when you download the container image. If the image reference points to a registry that requires authentication, the job / job runs will be created but submitted job runs will fail, until this property is provided, too. This property must not be set on a job run, which references a job template.",
 			},
-			"resource_type": &schema.Schema{
+			"region": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The region of the project the resource is located in. Possible values: 'au-syd', 'br-sao', 'ca-tor', 'eu-de', 'eu-gb', 'jp-osa', 'jp-tok', 'us-east', 'us-south'.",
+			},
+			"resource_type": {
 				Type:        schema.TypeString,
 				Computed:    true,
 				Description: "The type of the job.",
 			},
-			"run_arguments": &schema.Schema{
+			"run_arguments": {
 				Type:        schema.TypeList,
 				Computed:    true,
 				Description: "Set arguments for the job that are passed to start job run containers. If not specified an empty string array will be applied and the arguments specified by the container image, will be used to start the container.",
@@ -74,12 +89,12 @@ func DataSourceIbmCodeEngineJob() *schema.Resource {
 					Type: schema.TypeString,
 				},
 			},
-			"run_as_user": &schema.Schema{
+			"run_as_user": {
 				Type:        schema.TypeInt,
 				Computed:    true,
-				Description: "The user ID (UID) to run the job (e.g., 1001).",
+				Description: "The user ID (UID) to run the job.",
 			},
-			"run_commands": &schema.Schema{
+			"run_commands": {
 				Type:        schema.TypeList,
 				Computed:    true,
 				Description: "Set commands for the job that are passed to start job run containers. If not specified an empty string array will be applied and the command specified by the container image, will be used to start the container.",
@@ -87,38 +102,38 @@ func DataSourceIbmCodeEngineJob() *schema.Resource {
 					Type: schema.TypeString,
 				},
 			},
-			"run_env_variables": &schema.Schema{
+			"run_env_variables": {
 				Type:        schema.TypeList,
 				Computed:    true,
 				Description: "References to config maps, secrets or literal values, which are exposed as environment variables in the job run.",
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
-						"key": &schema.Schema{
+						"key": {
 							Type:        schema.TypeString,
 							Computed:    true,
 							Description: "The key to reference as environment variable.",
 						},
-						"name": &schema.Schema{
+						"name": {
 							Type:        schema.TypeString,
 							Computed:    true,
 							Description: "The name of the environment variable.",
 						},
-						"prefix": &schema.Schema{
+						"prefix": {
 							Type:        schema.TypeString,
 							Computed:    true,
 							Description: "A prefix that can be added to all keys of a full secret or config map reference.",
 						},
-						"reference": &schema.Schema{
+						"reference": {
 							Type:        schema.TypeString,
 							Computed:    true,
 							Description: "The name of the secret or config map.",
 						},
-						"type": &schema.Schema{
+						"type": {
 							Type:        schema.TypeString,
 							Computed:    true,
 							Description: "Specify the type of the environment variable.",
 						},
-						"value": &schema.Schema{
+						"value": {
 							Type:        schema.TypeString,
 							Computed:    true,
 							Description: "The literal value of the environment variable.",
@@ -126,38 +141,38 @@ func DataSourceIbmCodeEngineJob() *schema.Resource {
 					},
 				},
 			},
-			"run_mode": &schema.Schema{
+			"run_mode": {
 				Type:        schema.TypeString,
 				Computed:    true,
-				Description: "The mode for runs of the job. Valid values are `task` and `daemon`. In `task` mode, the `scale_max_execution_time` and `scale_retry_limit` properties apply. In `daemon` mode, since there is no timeout and failed instances are restarted indefinitely, the `scale_max_execution_time` and `scale_retry_limit` properties are not allowed.",
+				Description: "The mode for runs of the job. Valid values are `task` and `daemon`. In `task` mode, the `max_execution_time` and `retry_limit` properties apply. In `daemon` mode, since there is no timeout and failed instances are restarted indefinitely, the `max_execution_time` and `retry_limit` properties are not allowed.",
 			},
-			"run_service_account": &schema.Schema{
+			"run_service_account": {
 				Type:        schema.TypeString,
 				Computed:    true,
 				Description: "The name of the service account. For built-in service accounts, you can use the shortened names `manager`, `none`, `reader`, and `writer`. This property must not be set on a job run, which references a job template.",
 			},
-			"run_volume_mounts": &schema.Schema{
+			"run_volume_mounts": {
 				Type:        schema.TypeList,
 				Computed:    true,
-				Description: "Optional mounts of config maps or a secrets.",
+				Description: "Optional mounts of config maps or secrets.",
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
-						"mount_path": &schema.Schema{
+						"mount_path": {
 							Type:        schema.TypeString,
 							Computed:    true,
 							Description: "The path that should be mounted.",
 						},
-						"name": &schema.Schema{
+						"name": {
 							Type:        schema.TypeString,
 							Computed:    true,
 							Description: "The name of the mount.",
 						},
-						"reference": &schema.Schema{
+						"reference": {
 							Type:        schema.TypeString,
 							Computed:    true,
 							Description: "The name of the referenced secret or config map.",
 						},
-						"type": &schema.Schema{
+						"type": {
 							Type:        schema.TypeString,
 							Computed:    true,
 							Description: "Specify the type of the volume mount. Allowed types are: 'config_map', 'secret'.",
@@ -165,32 +180,32 @@ func DataSourceIbmCodeEngineJob() *schema.Resource {
 					},
 				},
 			},
-			"scale_array_spec": &schema.Schema{
+			"scale_array_spec": {
 				Type:        schema.TypeString,
 				Computed:    true,
-				Description: "Define a custom set of array indices as comma-separated list containing single values and hyphen-separated ranges like `5,12-14,23,27`. Each instance can pick up its array index via environment variable `JOB_INDEX`. The number of unique array indices specified here determines the number of job instances to run.",
+				Description: "Define a custom set of array indices as a comma-separated list containing single values and hyphen-separated ranges, such as  5,12-14,23,27. Each instance gets its array index value from the environment variable JOB_INDEX. The number of unique array indices that you specify with this parameter determines the number of job instances to run.",
 			},
-			"scale_cpu_limit": &schema.Schema{
+			"scale_cpu_limit": {
 				Type:        schema.TypeString,
 				Computed:    true,
 				Description: "Optional amount of CPU set for the instance of the job. For valid values see [Supported memory and CPU combinations](https://cloud.ibm.com/docs/codeengine?topic=codeengine-mem-cpu-combo).",
 			},
-			"scale_ephemeral_storage_limit": &schema.Schema{
+			"scale_ephemeral_storage_limit": {
 				Type:        schema.TypeString,
 				Computed:    true,
 				Description: "Optional amount of ephemeral storage to set for the instance of the job. The amount specified as ephemeral storage, must not exceed the amount of `scale_memory_limit`. The units for specifying ephemeral storage are Megabyte (M) or Gigabyte (G), whereas G and M are the shorthand expressions for GB and MB. For more information see [Units of measurement](https://cloud.ibm.com/docs/codeengine?topic=codeengine-mem-cpu-combo#unit-measurements).",
 			},
-			"scale_max_execution_time": &schema.Schema{
+			"scale_max_execution_time": {
 				Type:        schema.TypeInt,
 				Computed:    true,
 				Description: "The maximum execution time in seconds for runs of the job. This property can only be specified if `run_mode` is `task`.",
 			},
-			"scale_memory_limit": &schema.Schema{
+			"scale_memory_limit": {
 				Type:        schema.TypeString,
 				Computed:    true,
 				Description: "Optional amount of memory set for the instance of the job. For valid values see [Supported memory and CPU combinations](https://cloud.ibm.com/docs/codeengine?topic=codeengine-mem-cpu-combo). The units for specifying memory are Megabyte (M) or Gigabyte (G), whereas G and M are the shorthand expressions for GB and MB. For more information see [Units of measurement](https://cloud.ibm.com/docs/codeengine?topic=codeengine-mem-cpu-combo#unit-measurements).",
 			},
-			"scale_retry_limit": &schema.Schema{
+			"scale_retry_limit": {
 				Type:        schema.TypeInt,
 				Computed:    true,
 				Description: "The number of times to rerun an instance of the job before the job is marked as failed. This property can only be specified if `run_mode` is `task`.",
@@ -202,7 +217,9 @@ func DataSourceIbmCodeEngineJob() *schema.Resource {
 func dataSourceIbmCodeEngineJobRead(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	codeEngineClient, err := meta.(conns.ClientSession).CodeEngineV2()
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.TerraformErrorf(err, err.Error(), "(Data) ibm_code_engine_job", "read")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	getJobOptions := &codeenginev2.GetJobOptions{}
@@ -210,104 +227,140 @@ func dataSourceIbmCodeEngineJobRead(context context.Context, d *schema.ResourceD
 	getJobOptions.SetProjectID(d.Get("project_id").(string))
 	getJobOptions.SetName(d.Get("name").(string))
 
-	job, response, err := codeEngineClient.GetJobWithContext(context, getJobOptions)
+	job, _, err := codeEngineClient.GetJobWithContext(context, getJobOptions)
 	if err != nil {
-		log.Printf("[DEBUG] GetJobWithContext failed %s\n%s", err, response)
-		return diag.FromErr(fmt.Errorf("GetJobWithContext failed %s\n%s", err, response))
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("GetJobWithContext failed: %s", err.Error()), "(Data) ibm_code_engine_job", "read")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	d.SetId(fmt.Sprintf("%s/%s", *getJobOptions.ProjectID, *getJobOptions.Name))
 
+	if err = d.Set("build", job.Build); err != nil {
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("Error setting build: %s", err), "(Data) ibm_code_engine_job", "read")
+		return tfErr.GetDiag()
+	}
+
+	if err = d.Set("build_run", job.BuildRun); err != nil {
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("Error setting build_run: %s", err), "(Data) ibm_code_engine_job", "read")
+		return tfErr.GetDiag()
+	}
+
 	if err = d.Set("created_at", job.CreatedAt); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting created_at: %s", err))
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("Error setting created_at: %s", err), "(Data) ibm_code_engine_job", "read")
+		return tfErr.GetDiag()
 	}
 
 	if err = d.Set("entity_tag", job.EntityTag); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting entity_tag: %s", err))
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("Error setting entity_tag: %s", err), "(Data) ibm_code_engine_job", "read")
+		return tfErr.GetDiag()
 	}
 
 	if err = d.Set("href", job.Href); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting href: %s", err))
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("Error setting href: %s", err), "(Data) ibm_code_engine_job", "read")
+		return tfErr.GetDiag()
 	}
 
 	if err = d.Set("job_id", job.ID); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting job_id: %s", err))
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("Error setting job_id: %s", err), "(Data) ibm_code_engine_job", "read")
+		return tfErr.GetDiag()
 	}
 
 	if err = d.Set("image_reference", job.ImageReference); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting image_reference: %s", err))
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("Error setting image_reference: %s", err), "(Data) ibm_code_engine_job", "read")
+		return tfErr.GetDiag()
 	}
 
 	if err = d.Set("image_secret", job.ImageSecret); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting image_secret: %s", err))
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("Error setting image_secret: %s", err), "(Data) ibm_code_engine_job", "read")
+		return tfErr.GetDiag()
+	}
+
+	if err = d.Set("region", job.Region); err != nil {
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("Error setting region: %s", err), "(Data) ibm_code_engine_job", "read")
+		return tfErr.GetDiag()
 	}
 
 	if err = d.Set("resource_type", job.ResourceType); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting resource_type: %s", err))
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("Error setting resource_type: %s", err), "(Data) ibm_code_engine_job", "read")
+		return tfErr.GetDiag()
 	}
 
 	if err = d.Set("run_as_user", flex.IntValue(job.RunAsUser)); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting run_as_user: %s", err))
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("Error setting run_as_user: %s", err), "(Data) ibm_code_engine_job", "read")
+		return tfErr.GetDiag()
 	}
 
 	runEnvVariables := []map[string]interface{}{}
 	if job.RunEnvVariables != nil {
 		for _, modelItem := range job.RunEnvVariables {
-			modelMap, err := dataSourceIbmCodeEngineJobEnvVarToMap(&modelItem)
+			modelMap, err := dataSourceIbmCodeEngineJobEnvVarToMap(&modelItem) /* #nosec G601 */
 			if err != nil {
-				return diag.FromErr(err)
+				tfErr := flex.TerraformErrorf(err, err.Error(), "(Data) ibm_code_engine_job", "read")
+				return tfErr.GetDiag()
 			}
 			runEnvVariables = append(runEnvVariables, modelMap)
 		}
 	}
 	if err = d.Set("run_env_variables", runEnvVariables); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting run_env_variables %s", err))
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("Error setting run_env_variables: %s", err), "(Data) ibm_code_engine_job", "read")
+		return tfErr.GetDiag()
 	}
 
 	if err = d.Set("run_mode", job.RunMode); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting run_mode: %s", err))
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("Error setting run_mode: %s", err), "(Data) ibm_code_engine_job", "read")
+		return tfErr.GetDiag()
 	}
 
 	if err = d.Set("run_service_account", job.RunServiceAccount); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting run_service_account: %s", err))
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("Error setting run_service_account: %s", err), "(Data) ibm_code_engine_job", "read")
+		return tfErr.GetDiag()
 	}
 
 	runVolumeMounts := []map[string]interface{}{}
 	if job.RunVolumeMounts != nil {
 		for _, modelItem := range job.RunVolumeMounts {
-			modelMap, err := dataSourceIbmCodeEngineJobVolumeMountToMap(&modelItem)
+			modelMap, err := dataSourceIbmCodeEngineJobVolumeMountToMap(&modelItem) /* #nosec G601 */
 			if err != nil {
-				return diag.FromErr(err)
+				tfErr := flex.TerraformErrorf(err, err.Error(), "(Data) ibm_code_engine_job", "read")
+				return tfErr.GetDiag()
 			}
 			runVolumeMounts = append(runVolumeMounts, modelMap)
 		}
 	}
 	if err = d.Set("run_volume_mounts", runVolumeMounts); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting run_volume_mounts %s", err))
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("Error setting run_volume_mounts: %s", err), "(Data) ibm_code_engine_job", "read")
+		return tfErr.GetDiag()
 	}
 
 	if err = d.Set("scale_array_spec", job.ScaleArraySpec); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting scale_array_spec: %s", err))
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("Error setting scale_array_spec: %s", err), "(Data) ibm_code_engine_job", "read")
+		return tfErr.GetDiag()
 	}
 
 	if err = d.Set("scale_cpu_limit", job.ScaleCpuLimit); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting scale_cpu_limit: %s", err))
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("Error setting scale_cpu_limit: %s", err), "(Data) ibm_code_engine_job", "read")
+		return tfErr.GetDiag()
 	}
 
 	if err = d.Set("scale_ephemeral_storage_limit", job.ScaleEphemeralStorageLimit); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting scale_ephemeral_storage_limit: %s", err))
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("Error setting scale_ephemeral_storage_limit: %s", err), "(Data) ibm_code_engine_job", "read")
+		return tfErr.GetDiag()
 	}
 
 	if err = d.Set("scale_max_execution_time", flex.IntValue(job.ScaleMaxExecutionTime)); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting scale_max_execution_time: %s", err))
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("Error setting scale_max_execution_time: %s", err), "(Data) ibm_code_engine_job", "read")
+		return tfErr.GetDiag()
 	}
 
 	if err = d.Set("scale_memory_limit", job.ScaleMemoryLimit); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting scale_memory_limit: %s", err))
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("Error setting scale_memory_limit: %s", err), "(Data) ibm_code_engine_job", "read")
+		return tfErr.GetDiag()
 	}
 
 	if err = d.Set("scale_retry_limit", flex.IntValue(job.ScaleRetryLimit)); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting scale_retry_limit: %s", err))
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("Error setting scale_retry_limit: %s", err), "(Data) ibm_code_engine_job", "read")
+		return tfErr.GetDiag()
 	}
 
 	return nil

--- a/ibm/service/codeengine/data_source_ibm_code_engine_job_test.go
+++ b/ibm/service/codeengine/data_source_ibm_code_engine_job_test.go
@@ -90,6 +90,13 @@ func testAccCheckIbmCodeEngineJobDataSourceConfigBasic(projectID string, jobImag
 			project_id = data.ibm_code_engine_project.code_engine_project_instance.project_id
 			image_reference = "%s"
 			name = "%s"
+
+			lifecycle {
+				ignore_changes = [
+					run_env_variables,
+					scale_array_spec
+				]
+			}
 		}
 
 		data "ibm_code_engine_job" "code_engine_job_instance" {
@@ -116,6 +123,13 @@ func testAccCheckIbmCodeEngineJobDataSourceConfig(projectID string, jobImageRefe
 			scale_max_execution_time = %s
 			scale_memory_limit = "%s"
 			scale_retry_limit = %s
+
+			lifecycle {
+				ignore_changes = [
+					run_env_variables,
+					scale_array_spec
+				]
+			}
 		}
 
 		data "ibm_code_engine_job" "code_engine_job_instance" {

--- a/ibm/service/codeengine/data_source_ibm_code_engine_project.go
+++ b/ibm/service/codeengine/data_source_ibm_code_engine_project.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2023 All Rights Reserved.
+// Copyright IBM Corp. 2024 All Rights Reserved.
 // Licensed under the Mozilla Public License v2.0
 
 package codeengine
@@ -12,6 +12,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 
 	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/conns"
+	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/flex"
 	"github.com/IBM/code-engine-go-sdk/codeenginev2"
 )
 
@@ -20,55 +21,55 @@ func DataSourceIbmCodeEngineProject() *schema.Resource {
 		ReadContext: dataSourceIbmCodeEngineProjectRead,
 
 		Schema: map[string]*schema.Schema{
-			"project_id": &schema.Schema{
+			"project_id": {
 				Type:        schema.TypeString,
 				Required:    true,
 				Description: "The ID of the project.",
 			},
-			"account_id": &schema.Schema{
+			"account_id": {
 				Type:        schema.TypeString,
 				Computed:    true,
 				Description: "An alphanumeric value identifying the account ID.",
 			},
-			"created_at": &schema.Schema{
+			"created_at": {
 				Type:        schema.TypeString,
 				Computed:    true,
 				Description: "The timestamp when the project was created.",
 			},
-			"crn": &schema.Schema{
+			"crn": {
 				Type:        schema.TypeString,
 				Computed:    true,
 				Description: "The CRN of the project.",
 			},
-			"href": &schema.Schema{
+			"href": {
 				Type:        schema.TypeString,
 				Computed:    true,
 				Description: "When you provision a new resource, a URL is created identifying the location of the instance.",
 			},
-			"name": &schema.Schema{
+			"name": {
 				Type:        schema.TypeString,
 				Computed:    true,
 				Description: "The name of the project.",
 			},
-			"region": &schema.Schema{
+			"region": {
 				Type:        schema.TypeString,
 				Computed:    true,
 				Description: "The region for your project deployment. Possible values: 'au-syd', 'br-sao', 'ca-tor', 'eu-de', 'eu-gb', 'jp-osa', 'jp-tok', 'us-east', 'us-south'.",
 			},
-			"resource_group_id": &schema.Schema{
+			"resource_group_id": {
 				Type:        schema.TypeString,
 				Computed:    true,
 				Description: "The ID of the resource group.",
 			},
-			"resource_type": &schema.Schema{
+			"resource_type": {
 				Type:        schema.TypeString,
 				Computed:    true,
 				Description: "The type of the project.",
 			},
-			"status": &schema.Schema{
+			"status": {
 				Type:        schema.TypeString,
 				Computed:    true,
-				Description: "The current state of the project. For example, if the project is created and ready to get used, it will return active.",
+				Description: "The current state of the project. For example, when the project is created and is ready for use, the status of the project is active.",
 			},
 		},
 	}
@@ -77,55 +78,69 @@ func DataSourceIbmCodeEngineProject() *schema.Resource {
 func dataSourceIbmCodeEngineProjectRead(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	codeEngineClient, err := meta.(conns.ClientSession).CodeEngineV2()
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.TerraformErrorf(err, err.Error(), "(Data) ibm_code_engine_project", "read")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	getProjectOptions := &codeenginev2.GetProjectOptions{}
 
 	getProjectOptions.SetID(d.Get("project_id").(string))
+	log.Printf("[DEBUG]\n%+v", getProjectOptions)
 
-	project, response, err := codeEngineClient.GetProjectWithContext(context, getProjectOptions)
+	project, _, err := codeEngineClient.GetProjectWithContext(context, getProjectOptions)
 	if err != nil {
-		log.Printf("[DEBUG] GetProjectWithContext failed %s\n%s", err, response)
-		return diag.FromErr(fmt.Errorf("GetProjectWithContext failed %s\n%s", err, response))
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("GetProjectWithContext failed: %s", err.Error()), "(Data) ibm_code_engine_project", "read")
+
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
-	d.SetId(fmt.Sprintf("%s", *getProjectOptions.ID))
+	d.SetId(*getProjectOptions.ID)
 
 	if err = d.Set("account_id", project.AccountID); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting account_id: %s", err))
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("Error setting account_id: %s", err), "(Data) ibm_code_engine_project", "read")
+		return tfErr.GetDiag()
 	}
 
 	if err = d.Set("created_at", project.CreatedAt); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting created_at: %s", err))
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("Error setting created_at: %s", err), "(Data) ibm_code_engine_project", "read")
+		return tfErr.GetDiag()
 	}
 
 	if err = d.Set("crn", project.Crn); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting crn: %s", err))
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("Error setting crn: %s", err), "(Data) ibm_code_engine_project", "read")
+		return tfErr.GetDiag()
 	}
 
 	if err = d.Set("href", project.Href); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting href: %s", err))
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("Error setting href: %s", err), "(Data) ibm_code_engine_project", "read")
+		return tfErr.GetDiag()
 	}
 
 	if err = d.Set("name", project.Name); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting name: %s", err))
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("Error setting name: %s", err), "(Data) ibm_code_engine_project", "read")
+		return tfErr.GetDiag()
 	}
 
 	if err = d.Set("region", project.Region); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting region: %s", err))
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("Error setting region: %s", err), "(Data) ibm_code_engine_project", "read")
+		return tfErr.GetDiag()
 	}
 
 	if err = d.Set("resource_group_id", project.ResourceGroupID); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting resource_group_id: %s", err))
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("Error setting resource_group_id: %s", err), "(Data) ibm_code_engine_project", "read")
+		return tfErr.GetDiag()
 	}
 
 	if err = d.Set("resource_type", project.ResourceType); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting resource_type: %s", err))
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("Error setting resource_type: %s", err), "(Data) ibm_code_engine_project", "read")
+		return tfErr.GetDiag()
 	}
 
 	if err = d.Set("status", project.Status); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting status: %s", err))
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("Error setting status: %s", err), "(Data) ibm_code_engine_project", "read")
+		return tfErr.GetDiag()
 	}
 
 	return nil

--- a/ibm/service/codeengine/data_source_ibm_code_engine_secret.go
+++ b/ibm/service/codeengine/data_source_ibm_code_engine_secret.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2023 All Rights Reserved.
+// Copyright IBM Corp. 2024 All Rights Reserved.
 // Licensed under the Mozilla Public License v2.0
 
 package codeengine
@@ -12,6 +12,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 
 	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/conns"
+	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/flex"
 	"github.com/IBM/code-engine-go-sdk/codeenginev2"
 )
 
@@ -20,72 +21,77 @@ func DataSourceIbmCodeEngineSecret() *schema.Resource {
 		ReadContext: dataSourceIbmCodeEngineSecretRead,
 
 		Schema: map[string]*schema.Schema{
-			"project_id": &schema.Schema{
+			"project_id": {
 				Type:        schema.TypeString,
 				Required:    true,
 				Description: "The ID of the project.",
 			},
-			"name": &schema.Schema{
+			"name": {
 				Type:        schema.TypeString,
 				Required:    true,
 				Description: "The name of your secret.",
 			},
-			"created_at": &schema.Schema{
+			"created_at": {
 				Type:        schema.TypeString,
 				Computed:    true,
 				Description: "The timestamp when the resource was created.",
 			},
-			"data": &schema.Schema{
+			"data": {
 				Type:        schema.TypeMap,
 				Computed:    true,
-				Description: "Data container that allows to specify config parameters and their values as a key-value map. Each key field must consist of alphanumeric characters, `-`, `_` or `.` and must not be exceed a max length of 253 characters. Each value field can consists of any character and must not be exceed a max length of 1048576 characters.",
+				Description: "Data container that allows to specify config parameters and their values as a key-value map. Each key field must consist of alphanumeric characters, `-`, `_` or `.` and must not exceed a max length of 253 characters. Each value field can consists of any character and must not exceed a max length of 1048576 characters.",
 				Elem: &schema.Schema{
 					Type: schema.TypeString,
 				},
 			},
-			"entity_tag": &schema.Schema{
+			"entity_tag": {
 				Type:        schema.TypeString,
 				Computed:    true,
 				Description: "The version of the secret instance, which is used to achieve optimistic locking.",
 			},
-			"format": &schema.Schema{
+			"format": {
 				Type:        schema.TypeString,
 				Computed:    true,
 				Description: "Specify the format of the secret.",
 			},
-			"href": &schema.Schema{
+			"href": {
 				Type:        schema.TypeString,
 				Computed:    true,
 				Description: "When you provision a new secret,  a URL is created identifying the location of the instance.",
 			},
-			"secret_id": &schema.Schema{
+			"secret_id": {
 				Type:        schema.TypeString,
 				Computed:    true,
 				Description: "The identifier of the resource.",
 			},
-			"resource_type": &schema.Schema{
+			"region": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The region of the project the resource is located in. Possible values: 'au-syd', 'br-sao', 'ca-tor', 'eu-de', 'eu-gb', 'jp-osa', 'jp-tok', 'us-east', 'us-south'.",
+			},
+			"resource_type": {
 				Type:        schema.TypeString,
 				Computed:    true,
 				Description: "The type of the secret.",
 			},
-			"service_access": &schema.Schema{
+			"service_access": {
 				Type:        schema.TypeList,
 				Computed:    true,
 				Description: "Properties for Service Access Secrets.",
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
-						"resource_key": &schema.Schema{
+						"resource_key": {
 							Type:        schema.TypeList,
 							Computed:    true,
 							Description: "The service credential associated with the secret.",
 							Elem: &schema.Resource{
 								Schema: map[string]*schema.Schema{
-									"id": &schema.Schema{
+									"id": {
 										Type:        schema.TypeString,
 										Computed:    true,
 										Description: "ID of the service credential associated with the secret.",
 									},
-									"name": &schema.Schema{
+									"name": {
 										Type:        schema.TypeString,
 										Computed:    true,
 										Description: "Name of the service credential associated with the secret.",
@@ -93,18 +99,18 @@ func DataSourceIbmCodeEngineSecret() *schema.Resource {
 								},
 							},
 						},
-						"role": &schema.Schema{
+						"role": {
 							Type:        schema.TypeList,
 							Computed:    true,
 							Description: "A reference to the Role and Role CRN for service binding.",
 							Elem: &schema.Resource{
 								Schema: map[string]*schema.Schema{
-									"crn": &schema.Schema{
+									"crn": {
 										Type:        schema.TypeString,
 										Computed:    true,
-										Description: "CRN of the IAM Role for thise service access secret.",
+										Description: "CRN of the IAM Role for this service access secret.",
 									},
-									"name": &schema.Schema{
+									"name": {
 										Type:        schema.TypeString,
 										Computed:    true,
 										Description: "Role of the service credential.",
@@ -112,24 +118,89 @@ func DataSourceIbmCodeEngineSecret() *schema.Resource {
 								},
 							},
 						},
-						"service_instance": &schema.Schema{
+						"service_instance": {
 							Type:        schema.TypeList,
 							Computed:    true,
 							Description: "The IBM Cloud service instance associated with the secret.",
 							Elem: &schema.Resource{
 								Schema: map[string]*schema.Schema{
-									"id": &schema.Schema{
+									"id": {
 										Type:        schema.TypeString,
 										Computed:    true,
 										Description: "ID of the IBM Cloud service instance associated with the secret.",
 									},
-									"type": &schema.Schema{
+									"type": {
 										Type:        schema.TypeString,
 										Computed:    true,
 										Description: "Type of IBM Cloud service associated with the secret.",
 									},
 								},
 							},
+						},
+						"serviceid": {
+							Type:        schema.TypeList,
+							Computed:    true,
+							Description: "A reference to a Service ID.",
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"crn": {
+										Type:        schema.TypeString,
+										Computed:    true,
+										Description: "CRN value of a Service ID.",
+									},
+									"id": {
+										Type:        schema.TypeString,
+										Computed:    true,
+										Description: "The ID of the Service ID.",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			"service_operator": {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Description: "Properties for the IBM Cloud Operator Secret.",
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"apikey_id": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "The ID of the apikey associated with the operator secret.",
+						},
+						"resource_group_ids": {
+							Type:        schema.TypeList,
+							Computed:    true,
+							Description: "The list of resource groups (by ID) that the operator secret can bind services in.",
+							Elem: &schema.Schema{
+								Type: schema.TypeString,
+							},
+						},
+						"serviceid": {
+							Type:        schema.TypeList,
+							Computed:    true,
+							Description: "A reference to a Service ID.",
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"crn": {
+										Type:        schema.TypeString,
+										Computed:    true,
+										Description: "CRN value of a Service ID.",
+									},
+									"id": {
+										Type:        schema.TypeString,
+										Computed:    true,
+										Description: "The ID of the Service ID.",
+									},
+								},
+							},
+						},
+						"user_managed": {
+							Type:        schema.TypeBool,
+							Computed:    true,
+							Description: "Specifies whether the operator secret is user managed.",
 						},
 					},
 				},
@@ -141,7 +212,9 @@ func DataSourceIbmCodeEngineSecret() *schema.Resource {
 func dataSourceIbmCodeEngineSecretRead(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	codeEngineClient, err := meta.(conns.ClientSession).CodeEngineV2()
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.TerraformErrorf(err, err.Error(), "(Data) ibm_code_engine_secret", "read")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	getSecretOptions := &codeenginev2.GetSecretOptions{}
@@ -149,57 +222,87 @@ func dataSourceIbmCodeEngineSecretRead(context context.Context, d *schema.Resour
 	getSecretOptions.SetProjectID(d.Get("project_id").(string))
 	getSecretOptions.SetName(d.Get("name").(string))
 
-	secret, response, err := codeEngineClient.GetSecretWithContext(context, getSecretOptions)
+	secret, _, err := codeEngineClient.GetSecretWithContext(context, getSecretOptions)
 	if err != nil {
-		log.Printf("[DEBUG] GetSecretWithContext failed %s\n%s", err, response)
-		return diag.FromErr(fmt.Errorf("GetSecretWithContext failed %s\n%s", err, response))
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("GetSecretWithContext failed: %s", err.Error()), "(Data) ibm_code_engine_secret", "read")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	d.SetId(fmt.Sprintf("%s/%s", *getSecretOptions.ProjectID, *getSecretOptions.Name))
 
 	if err = d.Set("created_at", secret.CreatedAt); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting created_at: %s", err))
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("Error setting created_at: %s", err), "(Data) ibm_code_engine_secret", "read")
+		return tfErr.GetDiag()
 	}
 
 	if secret.Data != nil {
 		if err = d.Set("data", secret.Data); err != nil {
-			return diag.FromErr(fmt.Errorf("Error setting data: %s", err))
+			tfErr := flex.TerraformErrorf(err, fmt.Sprintf("Error setting data: %s", err), "(Data) ibm_code_engine_secret", "read")
+			return tfErr.GetDiag()
 		}
 		if err != nil {
-			return diag.FromErr(fmt.Errorf("Error setting data %s", err))
+			tfErr := flex.TerraformErrorf(err, fmt.Sprintf("Error setting data: %s", err), "(Data) ibm_code_engine_secret", "read")
+			return tfErr.GetDiag()
 		}
 	}
 
 	if err = d.Set("entity_tag", secret.EntityTag); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting entity_tag: %s", err))
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("Error setting entity_tag: %s", err), "(Data) ibm_code_engine_secret", "read")
+		return tfErr.GetDiag()
 	}
 
 	if err = d.Set("format", secret.Format); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting format: %s", err))
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("Error setting format: %s", err), "(Data) ibm_code_engine_secret", "read")
+		return tfErr.GetDiag()
 	}
 
 	if err = d.Set("href", secret.Href); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting href: %s", err))
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("Error setting href: %s", err), "(Data) ibm_code_engine_secret", "read")
+		return tfErr.GetDiag()
 	}
 
 	if err = d.Set("secret_id", secret.ID); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting secret_id: %s", err))
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("Error setting secret_id: %s", err), "(Data) ibm_code_engine_secret", "read")
+		return tfErr.GetDiag()
+	}
+
+	if err = d.Set("region", secret.Region); err != nil {
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("Error setting region: %s", err), "(Data) ibm_code_engine_secret", "read")
+		return tfErr.GetDiag()
 	}
 
 	if err = d.Set("resource_type", secret.ResourceType); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting resource_type: %s", err))
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("Error setting resource_type: %s", err), "(Data) ibm_code_engine_secret", "read")
+		return tfErr.GetDiag()
 	}
 
 	serviceAccess := []map[string]interface{}{}
 	if secret.ServiceAccess != nil {
 		modelMap, err := dataSourceIbmCodeEngineSecretServiceAccessSecretPropsToMap(secret.ServiceAccess)
 		if err != nil {
-			return diag.FromErr(err)
+			tfErr := flex.TerraformErrorf(err, err.Error(), "(Data) ibm_code_engine_secret", "read")
+			return tfErr.GetDiag()
 		}
 		serviceAccess = append(serviceAccess, modelMap)
 	}
 	if err = d.Set("service_access", serviceAccess); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting service_access %s", err))
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("Error setting service_access: %s", err), "(Data) ibm_code_engine_secret", "read")
+		return tfErr.GetDiag()
+	}
+
+	serviceOperator := []map[string]interface{}{}
+	if secret.ServiceOperator != nil {
+		modelMap, err := dataSourceIbmCodeEngineSecretOperatorSecretPropsToMap(secret.ServiceOperator)
+		if err != nil {
+			tfErr := flex.TerraformErrorf(err, err.Error(), "(Data) ibm_code_engine_secret", "read")
+			return tfErr.GetDiag()
+		}
+		serviceOperator = append(serviceOperator, modelMap)
+	}
+	if err = d.Set("service_operator", serviceOperator); err != nil {
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("Error setting service_operator: %s", err), "(Data) ibm_code_engine_secret", "read")
+		return tfErr.GetDiag()
 	}
 
 	return nil
@@ -224,6 +327,13 @@ func dataSourceIbmCodeEngineSecretServiceAccessSecretPropsToMap(model *codeengin
 		return modelMap, err
 	}
 	modelMap["service_instance"] = []map[string]interface{}{serviceInstanceMap}
+	if model.Serviceid != nil {
+		serviceidMap, err := dataSourceIbmCodeEngineSecretServiceIDRefToMap(model.Serviceid)
+		if err != nil {
+			return modelMap, err
+		}
+		modelMap["serviceid"] = []map[string]interface{}{serviceidMap}
+	}
 	return modelMap, nil
 }
 
@@ -257,5 +367,29 @@ func dataSourceIbmCodeEngineSecretServiceInstanceRefToMap(model *codeenginev2.Se
 	if model.Type != nil {
 		modelMap["type"] = model.Type
 	}
+	return modelMap, nil
+}
+
+func dataSourceIbmCodeEngineSecretServiceIDRefToMap(model *codeenginev2.ServiceIDRef) (map[string]interface{}, error) {
+	modelMap := make(map[string]interface{})
+	if model.Crn != nil {
+		modelMap["crn"] = model.Crn
+	}
+	if model.ID != nil {
+		modelMap["id"] = model.ID
+	}
+	return modelMap, nil
+}
+
+func dataSourceIbmCodeEngineSecretOperatorSecretPropsToMap(model *codeenginev2.OperatorSecretProps) (map[string]interface{}, error) {
+	modelMap := make(map[string]interface{})
+	modelMap["apikey_id"] = model.ApikeyID
+	modelMap["resource_group_ids"] = model.ResourceGroupIds
+	serviceidMap, err := dataSourceIbmCodeEngineSecretServiceIDRefToMap(model.Serviceid)
+	if err != nil {
+		return modelMap, err
+	}
+	modelMap["serviceid"] = []map[string]interface{}{serviceidMap}
+	modelMap["user_managed"] = model.UserManaged
 	return modelMap, nil
 }

--- a/ibm/service/codeengine/data_source_ibm_code_engine_secret_test.go
+++ b/ibm/service/codeengine/data_source_ibm_code_engine_secret_test.go
@@ -5,6 +5,7 @@ package codeengine_test
 
 import (
 	"fmt"
+	"os"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
@@ -132,8 +133,8 @@ func TestAccIbmCodeEngineSecretDataSourceSSHAuth(t *testing.T) {
 func TestAccIbmCodeEngineSecretDataSourceTls(t *testing.T) {
 	secretFormat := "tls"
 	secretName := fmt.Sprintf("tf-data-secret-tls-%d", acctest.RandIntRange(10, 1000))
-	tlsKey := decodeBase64EnvVar(acc.CeTLSKey, CeTlsKey)
-	tlsCert := decodeBase64EnvVar(acc.CeTLSCert, CeTlsCert)
+	tlsKey, _ := os.ReadFile(acc.CeTLSKeyFilePath)
+	tlsCert, _ := os.ReadFile(acc.CeTLSCertFilePath)
 
 	projectID := acc.CeProjectId
 
@@ -142,7 +143,7 @@ func TestAccIbmCodeEngineSecretDataSourceTls(t *testing.T) {
 		Providers: acc.TestAccProviders,
 		Steps: []resource.TestStep{
 			resource.TestStep{
-				Config: testAccCheckIbmCodeEngineSecretDataSourceTLSConfigBasic(projectID, tlsKey, tlsCert, secretFormat, secretName),
+				Config: testAccCheckIbmCodeEngineSecretDataSourceTLSConfigBasic(projectID, string(tlsKey), string(tlsCert), secretFormat, secretName),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("data.ibm_code_engine_secret.code_engine_secret_instance", "project_id", projectID),
 					resource.TestCheckResourceAttr("data.ibm_code_engine_secret.code_engine_secret_instance", "format", secretFormat),

--- a/ibm/service/codeengine/resource_ibm_code_engine_app.go
+++ b/ibm/service/codeengine/resource_ibm_code_engine_app.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2023 All Rights Reserved.
+// Copyright IBM Corp. 2024 All Rights Reserved.
 // Licensed under the Mozilla Public License v2.0
 
 package codeengine
@@ -13,7 +13,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 
-	"github.com/IBM-Cloud/bluemix-go/bmxerror"
 	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/conns"
 	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/flex"
 	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/validate"
@@ -34,98 +33,192 @@ func ResourceIbmCodeEngineApp() *schema.Resource {
 		},
 
 		Schema: map[string]*schema.Schema{
-			"project_id": &schema.Schema{
+			"project_id": {
 				Type:         schema.TypeString,
 				Required:     true,
 				ForceNew:     true,
 				ValidateFunc: validate.InvokeValidator("ibm_code_engine_app", "project_id"),
 				Description:  "The ID of the project.",
 			},
-			"image_reference": &schema.Schema{
-				Type:         schema.TypeString,
-				Required:     true,
-				ValidateFunc: validate.InvokeValidator("ibm_code_engine_app", "image_reference"),
-				Description:  "The name of the image that is used for this app. The format is `REGISTRY/NAMESPACE/REPOSITORY:TAG` where `REGISTRY` and `TAG` are optional. If `REGISTRY` is not specified, the default is `docker.io`. If `TAG` is not specified, the default is `latest`. If the image reference points to a registry that requires authentication, make sure to also specify the property `image_secret`.",
-			},
-			"name": &schema.Schema{
-				Type:         schema.TypeString,
-				Required:     true,
-				ForceNew:     true,
-				ValidateFunc: validate.InvokeValidator("ibm_code_engine_app", "name"),
-				Description:  "The name of the app. Use a name that is unique within the project.",
-			},
-			"image_port": &schema.Schema{
+			"image_port": {
 				Type:        schema.TypeInt,
 				Optional:    true,
 				Default:     8080,
 				Description: "Optional port the app listens on. While the app will always be exposed via port `443` for end users, this port is used to connect to the port that is exposed by the container image.",
 			},
-			"image_secret": &schema.Schema{
+			"image_reference": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ValidateFunc: validate.InvokeValidator("ibm_code_engine_app", "image_reference"),
+				Description:  "The name of the image that is used for this app. The format is `REGISTRY/NAMESPACE/REPOSITORY:TAG` where `REGISTRY` and `TAG` are optional. If `REGISTRY` is not specified, the default is `docker.io`. If `TAG` is not specified, the default is `latest`. If the image reference points to a registry that requires authentication, make sure to also specify the property `image_secret`.",
+			},
+			"image_secret": {
 				Type:         schema.TypeString,
 				Optional:     true,
 				ValidateFunc: validate.InvokeValidator("ibm_code_engine_app", "image_secret"),
 				Description:  "Optional name of the image registry access secret. The image registry access secret is used to authenticate with a private registry when you download the container image. If the image reference points to a registry that requires authentication, the app will be created but cannot reach the ready status, until this property is provided, too.",
 			},
-			"managed_domain_mappings": &schema.Schema{
+			"managed_domain_mappings": {
 				Type:         schema.TypeString,
 				Optional:     true,
 				Default:      "local_public",
 				ValidateFunc: validate.InvokeValidator("ibm_code_engine_app", "managed_domain_mappings"),
 				Description:  "Optional value controlling which of the system managed domain mappings will be setup for the application. Valid values are 'local_public', 'local_private' and 'local'. Visibility can only be 'local_private' if the project supports application private visibility.",
 			},
-			"run_arguments": &schema.Schema{
+			"name": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: validate.InvokeValidator("ibm_code_engine_app", "name"),
+				Description:  "The name of the app.",
+			},
+			"probe_liveness": {
+				Type:        schema.TypeList,
+				MaxItems:    1,
+				Optional:    true,
+				Description: "Response model for probes.",
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"failure_threshold": {
+							Type:        schema.TypeInt,
+							Optional:    true,
+							Default:     1,
+							Description: "The number of consecutive, unsuccessful checks for the probe to be considered failed.",
+						},
+						"initial_delay": {
+							Type:        schema.TypeInt,
+							Optional:    true,
+							Description: "The amount of time in seconds to wait before the first probe check is performed.",
+						},
+						"interval": {
+							Type:        schema.TypeInt,
+							Optional:    true,
+							Default:     10,
+							Description: "The amount of time in seconds between probe checks.",
+						},
+						"path": {
+							Type:        schema.TypeString,
+							Optional:    true,
+							Description: "The path of the HTTP request to the resource. A path is only supported for a probe with a `type` of `http`.",
+						},
+						"port": {
+							Type:        schema.TypeInt,
+							Optional:    true,
+							Description: "The port on which to probe the resource.",
+						},
+						"timeout": {
+							Type:        schema.TypeInt,
+							Optional:    true,
+							Default:     1,
+							Description: "The amount of time in seconds that the probe waits for a response from the application before it times out and fails.",
+						},
+						"type": {
+							Type:        schema.TypeString,
+							Optional:    true,
+							Description: "Specifies whether to use HTTP or TCP for the probe checks. The default is TCP.",
+						},
+					},
+				},
+			},
+			"probe_readiness": {
+				Type:        schema.TypeList,
+				MaxItems:    1,
+				Optional:    true,
+				Description: "Response model for probes.",
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"failure_threshold": {
+							Type:        schema.TypeInt,
+							Optional:    true,
+							Default:     1,
+							Description: "The number of consecutive, unsuccessful checks for the probe to be considered failed.",
+						},
+						"initial_delay": {
+							Type:        schema.TypeInt,
+							Optional:    true,
+							Description: "The amount of time in seconds to wait before the first probe check is performed.",
+						},
+						"interval": {
+							Type:        schema.TypeInt,
+							Optional:    true,
+							Default:     10,
+							Description: "The amount of time in seconds between probe checks.",
+						},
+						"path": {
+							Type:        schema.TypeString,
+							Optional:    true,
+							Description: "The path of the HTTP request to the resource. A path is only supported for a probe with a `type` of `http`.",
+						},
+						"port": {
+							Type:        schema.TypeInt,
+							Optional:    true,
+							Description: "The port on which to probe the resource.",
+						},
+						"timeout": {
+							Type:        schema.TypeInt,
+							Optional:    true,
+							Default:     1,
+							Description: "The amount of time in seconds that the probe waits for a response from the application before it times out and fails.",
+						},
+						"type": {
+							Type:        schema.TypeString,
+							Optional:    true,
+							Description: "Specifies whether to use HTTP or TCP for the probe checks. The default is TCP.",
+						},
+					},
+				},
+			},
+			"run_arguments": {
 				Type:        schema.TypeList,
 				Optional:    true,
-				MinItems:    0,
 				Description: "Optional arguments for the app that are passed to start the container. If not specified an empty string array will be applied and the arguments specified by the container image, will be used to start the container.",
 				Elem:        &schema.Schema{Type: schema.TypeString},
 			},
-			"run_as_user": &schema.Schema{
+			"run_as_user": {
 				Type:        schema.TypeInt,
 				Optional:    true,
-				Description: "Optional user ID (UID) to run the app (e.g., `1001`).",
+				Default:     0,
+				Description: "Optional user ID (UID) to run the app.",
 			},
-			"run_commands": &schema.Schema{
+			"run_commands": {
 				Type:        schema.TypeList,
 				Optional:    true,
-				MinItems:    0,
 				Description: "Optional commands for the app that are passed to start the container. If not specified an empty string array will be applied and the command specified by the container image, will be used to start the container.",
 				Elem:        &schema.Schema{Type: schema.TypeString},
 			},
-			"run_env_variables": &schema.Schema{
+			"run_env_variables": {
 				Type:        schema.TypeList,
 				Optional:    true,
-				Description: "Optional references to config maps, secrets or literal values that are exposed as environment variables within the running application.",
-				MinItems:    0,
+				Description: "References to config maps, secrets or literal values, which are exposed as environment variables in the application.",
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
-						"key": &schema.Schema{
+						"key": {
 							Type:        schema.TypeString,
 							Optional:    true,
 							Description: "The key to reference as environment variable.",
 						},
-						"name": &schema.Schema{
+						"name": {
 							Type:        schema.TypeString,
 							Optional:    true,
 							Description: "The name of the environment variable.",
 						},
-						"prefix": &schema.Schema{
+						"prefix": {
 							Type:        schema.TypeString,
 							Optional:    true,
 							Description: "A prefix that can be added to all keys of a full secret or config map reference.",
 						},
-						"reference": &schema.Schema{
+						"reference": {
 							Type:        schema.TypeString,
 							Optional:    true,
 							Description: "The name of the secret or config map.",
 						},
-						"type": &schema.Schema{
+						"type": {
 							Type:        schema.TypeString,
 							Optional:    true,
 							Default:     "literal",
 							Description: "Specify the type of the environment variable.",
 						},
-						"value": &schema.Schema{
+						"value": {
 							Type:        schema.TypeString,
 							Optional:    true,
 							Description: "The literal value of the environment variable.",
@@ -133,36 +226,35 @@ func ResourceIbmCodeEngineApp() *schema.Resource {
 					},
 				},
 			},
-			"run_service_account": &schema.Schema{
+			"run_service_account": {
 				Type:         schema.TypeString,
 				Optional:     true,
 				Default:      "default",
 				ValidateFunc: validate.InvokeValidator("ibm_code_engine_app", "run_service_account"),
 				Description:  "Optional name of the service account. For built-in service accounts, you can use the shortened names `manager` , `none`, `reader`, and `writer`.",
 			},
-			"run_volume_mounts": &schema.Schema{
+			"run_volume_mounts": {
 				Type:        schema.TypeList,
 				Optional:    true,
-				MinItems:    0,
-				Description: "Optional mounts of config maps or a secrets.",
+				Description: "Mounts of config maps or secrets.",
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
-						"mount_path": &schema.Schema{
+						"mount_path": {
 							Type:        schema.TypeString,
 							Required:    true,
 							Description: "The path that should be mounted.",
 						},
-						"name": &schema.Schema{
+						"name": {
 							Type:        schema.TypeString,
-							Optional:    true,
-							Description: "Optional name of the mount. If not set, it will be generated based on the `ref` and a random ID. In case the `ref` is longer than 58 characters, it will be cut off.",
+							Required:    true,
+							Description: "The name of the mount.",
 						},
-						"reference": &schema.Schema{
+						"reference": {
 							Type:        schema.TypeString,
 							Required:    true,
 							Description: "The name of the referenced secret or config map.",
 						},
-						"type": &schema.Schema{
+						"type": {
 							Type:        schema.TypeString,
 							Required:    true,
 							Description: "Specify the type of the volume mount. Allowed types are: 'config_map', 'secret'.",
@@ -170,119 +262,141 @@ func ResourceIbmCodeEngineApp() *schema.Resource {
 					},
 				},
 			},
-			"scale_concurrency": &schema.Schema{
+			"scale_concurrency": {
 				Type:        schema.TypeInt,
 				Optional:    true,
 				Default:     100,
 				Description: "Optional maximum number of requests that can be processed concurrently per instance.",
 			},
-			"scale_concurrency_target": &schema.Schema{
+			"scale_concurrency_target": {
 				Type:        schema.TypeInt,
 				Optional:    true,
 				Description: "Optional threshold of concurrent requests per instance at which one or more additional instances are created. Use this value to scale up instances based on concurrent number of requests. This option defaults to the value of the `scale_concurrency` option, if not specified.",
 			},
-			"scale_cpu_limit": &schema.Schema{
+			"scale_cpu_limit": {
 				Type:         schema.TypeString,
 				Optional:     true,
 				Default:      "1",
 				ValidateFunc: validate.InvokeValidator("ibm_code_engine_app", "scale_cpu_limit"),
 				Description:  "Optional number of CPU set for the instance of the app. For valid values see [Supported memory and CPU combinations](https://cloud.ibm.com/docs/codeengine?topic=codeengine-mem-cpu-combo).",
 			},
-			"scale_ephemeral_storage_limit": &schema.Schema{
+			"scale_down_delay": {
+				Type:         schema.TypeInt,
+				Optional:     true,
+				Default:      0,
+				ValidateFunc: validate.InvokeValidator("ibm_code_engine_app", "scale_down_delay"),
+				Description:  "Optional amount of time in seconds that delays the scale-down behavior for an app instance.",
+			},
+			"scale_ephemeral_storage_limit": {
 				Type:         schema.TypeString,
 				Optional:     true,
 				Default:      "400M",
 				ValidateFunc: validate.InvokeValidator("ibm_code_engine_app", "scale_ephemeral_storage_limit"),
 				Description:  "Optional amount of ephemeral storage to set for the instance of the app. The amount specified as ephemeral storage, must not exceed the amount of `scale_memory_limit`. The units for specifying ephemeral storage are Megabyte (M) or Gigabyte (G), whereas G and M are the shorthand expressions for GB and MB. For more information see [Units of measurement](https://cloud.ibm.com/docs/codeengine?topic=codeengine-mem-cpu-combo#unit-measurements).",
 			},
-			"scale_initial_instances": &schema.Schema{
+			"scale_initial_instances": {
 				Type:        schema.TypeInt,
 				Optional:    true,
 				Default:     1,
 				Description: "Optional initial number of instances that are created upon app creation or app update.",
 			},
-			"scale_max_instances": &schema.Schema{
+			"scale_max_instances": {
 				Type:        schema.TypeInt,
 				Optional:    true,
 				Default:     10,
 				Description: "Optional maximum number of instances for this app. If you set this value to `0`, this property does not set a upper scaling limit. However, the app scaling is still limited by the project quota for instances. See [Limits and quotas for Code Engine](https://cloud.ibm.com/docs/codeengine?topic=codeengine-limits).",
 			},
-			"scale_memory_limit": &schema.Schema{
+			"scale_memory_limit": {
 				Type:         schema.TypeString,
 				Optional:     true,
 				Default:      "4G",
 				ValidateFunc: validate.InvokeValidator("ibm_code_engine_app", "scale_memory_limit"),
 				Description:  "Optional amount of memory set for the instance of the app. For valid values see [Supported memory and CPU combinations](https://cloud.ibm.com/docs/codeengine?topic=codeengine-mem-cpu-combo). The units for specifying memory are Megabyte (M) or Gigabyte (G), whereas G and M are the shorthand expressions for GB and MB. For more information see [Units of measurement](https://cloud.ibm.com/docs/codeengine?topic=codeengine-mem-cpu-combo#unit-measurements).",
 			},
-			"scale_min_instances": &schema.Schema{
+			"scale_min_instances": {
 				Type:        schema.TypeInt,
 				Optional:    true,
 				Default:     0,
 				Description: "Optional minimum number of instances for this app. If you set this value to `0`, the app will scale down to zero, if not hit by any request for some time.",
 			},
-			"scale_request_timeout": &schema.Schema{
+			"scale_request_timeout": {
 				Type:        schema.TypeInt,
 				Optional:    true,
 				Default:     300,
 				Description: "Optional amount of time in seconds that is allowed for a running app to respond to a request.",
 			},
-			"created_at": &schema.Schema{
+			"build": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "Reference to a build that is associated with the application.",
+			},
+			"build_run": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "Reference to a build run that is associated with the application.",
+			},
+			"created_at": {
 				Type:        schema.TypeString,
 				Computed:    true,
 				Description: "The timestamp when the resource was created.",
 			},
-			"endpoint": &schema.Schema{
+			"endpoint": {
 				Type:        schema.TypeString,
 				Computed:    true,
-				Description: "Optional URL to invoke app. Depending on visibility this is accessible publicly or in the private network only. Empty in case 'managed_domain_mappings' is set to 'local'.",
+				Description: "Optional URL to invoke the app. Depending on visibility,  this is accessible publicly or in the private network only. Empty in case 'managed_domain_mappings' is set to 'local'.",
 			},
-			"endpoint_internal": &schema.Schema{
+			"endpoint_internal": {
 				Type:        schema.TypeString,
 				Computed:    true,
-				Description: "URL to app that is only visible within the project.",
+				Description: "The URL to the app that is only visible within the project.",
 			},
-			"entity_tag": &schema.Schema{
+			"entity_tag": {
 				Type:        schema.TypeString,
 				Computed:    true,
 				Description: "The version of the app instance, which is used to achieve optimistic locking.",
 			},
-			"href": &schema.Schema{
+			"href": {
 				Type:        schema.TypeString,
 				Computed:    true,
 				Description: "When you provision a new app,  a URL is created identifying the location of the instance.",
 			},
-			"app_id": &schema.Schema{
+			"app_id": {
 				Type:        schema.TypeString,
 				Computed:    true,
 				Description: "The identifier of the resource.",
 			},
-			"resource_type": &schema.Schema{
+			"region": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The region of the project the resource is located in. Possible values: 'au-syd', 'br-sao', 'ca-tor', 'eu-de', 'eu-gb', 'jp-osa', 'jp-tok', 'us-east', 'us-south'.",
+			},
+			"resource_type": {
 				Type:        schema.TypeString,
 				Computed:    true,
 				Description: "The type of the app.",
 			},
-			"status": &schema.Schema{
+			"status": {
 				Type:        schema.TypeString,
 				Computed:    true,
 				Description: "The current status of the app.",
 			},
-			"status_details": &schema.Schema{
+			"status_details": {
 				Type:        schema.TypeList,
 				Computed:    true,
 				Description: "The detailed status of the application.",
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
-						"latest_created_revision": &schema.Schema{
+						"latest_created_revision": {
 							Type:        schema.TypeString,
 							Computed:    true,
 							Description: "Latest app revision that has been created.",
 						},
-						"latest_ready_revision": &schema.Schema{
+						"latest_ready_revision": {
 							Type:        schema.TypeString,
 							Computed:    true,
 							Description: "Latest app revision that reached a ready state.",
 						},
-						"reason": &schema.Schema{
+						"reason": {
 							Type:        schema.TypeString,
 							Computed:    true,
 							Description: "Optional information to provide more context in case of a 'failed' or 'warning' status.",
@@ -290,7 +404,7 @@ func ResourceIbmCodeEngineApp() *schema.Resource {
 					},
 				},
 			},
-			"etag": &schema.Schema{
+			"etag": {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
@@ -320,15 +434,6 @@ func ResourceIbmCodeEngineAppValidator() *validate.ResourceValidator {
 			MaxValueLength:             256,
 		},
 		validate.ValidateSchema{
-			Identifier:                 "name",
-			ValidateFunctionIdentifier: validate.ValidateRegexpLen,
-			Type:                       validate.TypeString,
-			Required:                   true,
-			Regexp:                     `^[a-z]([-a-z0-9]*[a-z0-9])?$`,
-			MinValueLength:             1,
-			MaxValueLength:             63,
-		},
-		validate.ValidateSchema{
 			Identifier:                 "image_secret",
 			ValidateFunctionIdentifier: validate.ValidateRegexpLen,
 			Type:                       validate.TypeString,
@@ -343,6 +448,15 @@ func ResourceIbmCodeEngineAppValidator() *validate.ResourceValidator {
 			Type:                       validate.TypeString,
 			Optional:                   true,
 			AllowedValues:              "local, local_private, local_public",
+		},
+		validate.ValidateSchema{
+			Identifier:                 "name",
+			ValidateFunctionIdentifier: validate.ValidateRegexpLen,
+			Type:                       validate.TypeString,
+			Required:                   true,
+			Regexp:                     `^[a-z]([-a-z0-9]*[a-z0-9])?$`,
+			MinValueLength:             1,
+			MaxValueLength:             63,
 		},
 		validate.ValidateSchema{
 			Identifier:                 "run_service_account",
@@ -361,6 +475,14 @@ func ResourceIbmCodeEngineAppValidator() *validate.ResourceValidator {
 			Regexp:                     `^([0-9.]+)([eEinumkKMGTPB]*)$`,
 			MinValueLength:             0,
 			MaxValueLength:             10,
+		},
+		validate.ValidateSchema{
+			Identifier:                 "scale_down_delay",
+			ValidateFunctionIdentifier: validate.IntBetween,
+			Type:                       validate.TypeInt,
+			Optional:                   true,
+			MinValue:                   "0",
+			MaxValue:                   "3600",
 		},
 		validate.ValidateSchema{
 			Identifier:                 "scale_ephemeral_storage_limit",
@@ -389,7 +511,9 @@ func ResourceIbmCodeEngineAppValidator() *validate.ResourceValidator {
 func resourceIbmCodeEngineAppCreate(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	codeEngineClient, err := meta.(conns.ClientSession).CodeEngineV2()
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.TerraformErrorf(err, err.Error(), "ibm_code_engine_app", "create")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	createAppOptions := &codeenginev2.CreateAppOptions{}
@@ -405,6 +529,20 @@ func resourceIbmCodeEngineAppCreate(context context.Context, d *schema.ResourceD
 	}
 	if _, ok := d.GetOk("managed_domain_mappings"); ok {
 		createAppOptions.SetManagedDomainMappings(d.Get("managed_domain_mappings").(string))
+	}
+	if _, ok := d.GetOk("probe_liveness"); ok {
+		probeLivenessModel, err := resourceIbmCodeEngineAppMapToProbePrototype(d.Get("probe_liveness.0").(map[string]interface{}))
+		if err != nil {
+			return diag.FromErr(err)
+		}
+		createAppOptions.SetProbeLiveness(probeLivenessModel)
+	}
+	if _, ok := d.GetOk("probe_readiness"); ok {
+		probeReadinessModel, err := resourceIbmCodeEngineAppMapToProbePrototype(d.Get("probe_readiness.0").(map[string]interface{}))
+		if err != nil {
+			return diag.FromErr(err)
+		}
+		createAppOptions.SetProbeReadiness(probeReadinessModel)
 	}
 	if _, ok := d.GetOk("run_arguments"); ok {
 		var runArguments []string
@@ -461,6 +599,9 @@ func resourceIbmCodeEngineAppCreate(context context.Context, d *schema.ResourceD
 	if _, ok := d.GetOk("scale_cpu_limit"); ok {
 		createAppOptions.SetScaleCpuLimit(d.Get("scale_cpu_limit").(string))
 	}
+	if _, ok := d.GetOk("scale_down_delay"); ok {
+		createAppOptions.SetScaleDownDelay(int64(d.Get("scale_down_delay").(int)))
+	}
 	if _, ok := d.GetOk("scale_ephemeral_storage_limit"); ok {
 		createAppOptions.SetScaleEphemeralStorageLimit(d.Get("scale_ephemeral_storage_limit").(string))
 	}
@@ -480,18 +621,20 @@ func resourceIbmCodeEngineAppCreate(context context.Context, d *schema.ResourceD
 		createAppOptions.SetScaleRequestTimeout(int64(d.Get("scale_request_timeout").(int)))
 	}
 
-	app, response, err := codeEngineClient.CreateAppWithContext(context, createAppOptions)
+	app, _, err := codeEngineClient.CreateAppWithContext(context, createAppOptions)
 	if err != nil {
-		log.Printf("[DEBUG] CreateAppWithContext failed %s\n%s", err, response)
-		return diag.FromErr(fmt.Errorf("CreateAppWithContext failed %s\n%s", err, response))
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("CreateAppWithContext failed: %s", err.Error()), "ibm_code_engine_app", "create")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	d.SetId(fmt.Sprintf("%s/%s", *createAppOptions.ProjectID, *app.Name))
 
 	_, err = waitForIbmCodeEngineAppCreate(d, meta)
 	if err != nil {
-		return diag.FromErr(fmt.Errorf(
-			"Error waiting for resource IbmCodeEngineApp (%s) to be created: %s", d.Id(), err))
+		errMsg := fmt.Sprintf("Error waiting for resource IbmCodeEngineApp (%s) to be created: %s", d.Id(), err)
+		tfErr := flex.TerraformErrorf(err, errMsg, "ibm_code_engine_app", "create")
+		return tfErr.GetDiag()
 	}
 
 	return resourceIbmCodeEngineAppRead(context, d, meta)
@@ -518,14 +661,15 @@ func waitForIbmCodeEngineAppCreate(d *schema.ResourceData, meta interface{}) (in
 		Refresh: func() (interface{}, string, error) {
 			stateObj, response, err := codeEngineClient.GetApp(getAppOptions)
 			if err != nil {
-				if apiErr, ok := err.(bmxerror.RequestFailure); ok && apiErr.StatusCode() == 404 {
-					return nil, "", fmt.Errorf("The instance %s does not exist anymore: %s\n%s", "getAppOptions", err, response)
+				if sdkErr, ok := err.(*core.SDKProblem); ok && response.GetStatusCode() == 404 {
+					sdkErr.Summary = fmt.Sprintf("The instance %s does not exist anymore: %s", "getAppOptions", err)
+					return nil, "", sdkErr
 				}
 				return nil, "", err
 			}
 			failStates := map[string]bool{"failure": true, "failed": true}
 			if failStates[*stateObj.Status] {
-				return stateObj, *stateObj.Status, fmt.Errorf("The instance %s failed: %s\n%s", "getAppOptions", err, response)
+				return stateObj, *stateObj.Status, fmt.Errorf("the instance %s failed: %s", "getAppOptions", err)
 			}
 			return stateObj, *stateObj.Status, nil
 		},
@@ -540,14 +684,17 @@ func waitForIbmCodeEngineAppCreate(d *schema.ResourceData, meta interface{}) (in
 func resourceIbmCodeEngineAppRead(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	codeEngineClient, err := meta.(conns.ClientSession).CodeEngineV2()
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.TerraformErrorf(err, err.Error(), "ibm_code_engine_app", "read")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	getAppOptions := &codeenginev2.GetAppOptions{}
 
 	parts, err := flex.SepIdParts(d.Id(), "/")
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.TerraformErrorf(err, err.Error(), "ibm_code_engine_app", "read")
+		return tfErr.GetDiag()
 	}
 
 	getAppOptions.SetProjectID(parts[0])
@@ -559,161 +706,200 @@ func resourceIbmCodeEngineAppRead(context context.Context, d *schema.ResourceDat
 			d.SetId("")
 			return nil
 		}
-		log.Printf("[DEBUG] GetAppWithContext failed %s\n%s", err, response)
-		return diag.FromErr(fmt.Errorf("GetAppWithContext failed %s\n%s", err, response))
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("GetAppWithContext failed: %s", err.Error()), "ibm_code_engine_app", "read")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	if err = d.Set("project_id", app.ProjectID); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting project_id: %s", err))
-	}
-	if err = d.Set("image_reference", app.ImageReference); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting image_reference: %s", err))
-	}
-	if err = d.Set("name", app.Name); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting name: %s", err))
+		return diag.FromErr(fmt.Errorf("error setting project_id: %s", err))
 	}
 	if !core.IsNil(app.ImagePort) {
 		if err = d.Set("image_port", flex.IntValue(app.ImagePort)); err != nil {
-			return diag.FromErr(fmt.Errorf("Error setting image_port: %s", err))
+			return diag.FromErr(fmt.Errorf("error setting image_port: %s", err))
 		}
+	}
+	if err = d.Set("image_reference", app.ImageReference); err != nil {
+		return diag.FromErr(fmt.Errorf("error setting image_reference: %s", err))
 	}
 	if !core.IsNil(app.ImageSecret) {
 		if err = d.Set("image_secret", app.ImageSecret); err != nil {
-			return diag.FromErr(fmt.Errorf("Error setting image_secret: %s", err))
+			return diag.FromErr(fmt.Errorf("error setting image_secret: %s", err))
 		}
 	}
 	if !core.IsNil(app.ManagedDomainMappings) {
 		if err = d.Set("managed_domain_mappings", app.ManagedDomainMappings); err != nil {
-			return diag.FromErr(fmt.Errorf("Error setting managed_domain_mappings: %s", err))
+			return diag.FromErr(fmt.Errorf("error setting managed_domain_mappings: %s", err))
+		}
+	}
+	if err = d.Set("name", app.Name); err != nil {
+		return diag.FromErr(fmt.Errorf("error setting name: %s", err))
+	}
+	if !core.IsNil(app.ProbeLiveness) {
+		probeLivenessMap, err := resourceIbmCodeEngineAppProbeToMap(app.ProbeLiveness)
+		if err != nil {
+			return diag.FromErr(err)
+		}
+		if err = d.Set("probe_liveness", []map[string]interface{}{probeLivenessMap}); err != nil {
+			return diag.FromErr(fmt.Errorf("error setting probe_liveness: %s", err))
+		}
+	}
+	if !core.IsNil(app.ProbeReadiness) {
+		probeReadinessMap, err := resourceIbmCodeEngineAppProbeToMap(app.ProbeReadiness)
+		if err != nil {
+			return diag.FromErr(err)
+		}
+		if err = d.Set("probe_readiness", []map[string]interface{}{probeReadinessMap}); err != nil {
+			return diag.FromErr(fmt.Errorf("error setting probe_readiness: %s", err))
 		}
 	}
 	if !core.IsNil(app.RunArguments) {
 		if err = d.Set("run_arguments", app.RunArguments); err != nil {
-			return diag.FromErr(fmt.Errorf("Error setting run_arguments: %s", err))
+			return diag.FromErr(fmt.Errorf("error setting run_arguments: %s", err))
 		}
 	}
 	if !core.IsNil(app.RunAsUser) {
 		if err = d.Set("run_as_user", flex.IntValue(app.RunAsUser)); err != nil {
-			return diag.FromErr(fmt.Errorf("Error setting run_as_user: %s", err))
+			return diag.FromErr(fmt.Errorf("error setting run_as_user: %s", err))
 		}
 	}
 	if !core.IsNil(app.RunCommands) {
 		if err = d.Set("run_commands", app.RunCommands); err != nil {
-			return diag.FromErr(fmt.Errorf("Error setting run_commands: %s", err))
+			return diag.FromErr(fmt.Errorf("error setting run_commands: %s", err))
 		}
 	}
 	if !core.IsNil(app.RunEnvVariables) {
 		runEnvVariables := []map[string]interface{}{}
 		for _, runEnvVariablesItem := range app.RunEnvVariables {
-			runEnvVariablesItemMap, err := resourceIbmCodeEngineAppEnvVarToMap(&runEnvVariablesItem)
+			runEnvVariablesItemMap, err := resourceIbmCodeEngineAppEnvVarToMap(&runEnvVariablesItem) /* #nosec G601 */
 			if err != nil {
 				return diag.FromErr(err)
 			}
 			runEnvVariables = append(runEnvVariables, runEnvVariablesItemMap)
 		}
 		if err = d.Set("run_env_variables", runEnvVariables); err != nil {
-			return diag.FromErr(fmt.Errorf("Error setting run_env_variables: %s", err))
+			return diag.FromErr(fmt.Errorf("error setting run_env_variables: %s", err))
 		}
 	}
 	if !core.IsNil(app.RunServiceAccount) {
 		if err = d.Set("run_service_account", app.RunServiceAccount); err != nil {
-			return diag.FromErr(fmt.Errorf("Error setting run_service_account: %s", err))
+			return diag.FromErr(fmt.Errorf("error setting run_service_account: %s", err))
 		}
 	}
 	if !core.IsNil(app.RunVolumeMounts) {
 		runVolumeMounts := []map[string]interface{}{}
 		for _, runVolumeMountsItem := range app.RunVolumeMounts {
-			runVolumeMountsItemMap, err := resourceIbmCodeEngineAppVolumeMountToMap(&runVolumeMountsItem)
+			runVolumeMountsItemMap, err := resourceIbmCodeEngineAppVolumeMountToMap(&runVolumeMountsItem) /* #nosec G601 */
 			if err != nil {
 				return diag.FromErr(err)
 			}
 			runVolumeMounts = append(runVolumeMounts, runVolumeMountsItemMap)
 		}
 		if err = d.Set("run_volume_mounts", runVolumeMounts); err != nil {
-			return diag.FromErr(fmt.Errorf("Error setting run_volume_mounts: %s", err))
+			return diag.FromErr(fmt.Errorf("error setting run_volume_mounts: %s", err))
 		}
 	}
 	if !core.IsNil(app.ScaleConcurrency) {
 		if err = d.Set("scale_concurrency", flex.IntValue(app.ScaleConcurrency)); err != nil {
-			return diag.FromErr(fmt.Errorf("Error setting scale_concurrency: %s", err))
+			return diag.FromErr(fmt.Errorf("error setting scale_concurrency: %s", err))
 		}
 	}
 	if !core.IsNil(app.ScaleConcurrencyTarget) {
 		if err = d.Set("scale_concurrency_target", flex.IntValue(app.ScaleConcurrencyTarget)); err != nil {
-			return diag.FromErr(fmt.Errorf("Error setting scale_concurrency_target: %s", err))
+			return diag.FromErr(fmt.Errorf("error setting scale_concurrency_target: %s", err))
 		}
 	}
 	if !core.IsNil(app.ScaleCpuLimit) {
 		if err = d.Set("scale_cpu_limit", app.ScaleCpuLimit); err != nil {
-			return diag.FromErr(fmt.Errorf("Error setting scale_cpu_limit: %s", err))
+			return diag.FromErr(fmt.Errorf("error setting scale_cpu_limit: %s", err))
+		}
+	}
+	if !core.IsNil(app.ScaleDownDelay) {
+		if err = d.Set("scale_down_delay", flex.IntValue(app.ScaleDownDelay)); err != nil {
+			return diag.FromErr(fmt.Errorf("error setting scale_down_delay: %s", err))
 		}
 	}
 	if !core.IsNil(app.ScaleEphemeralStorageLimit) {
 		if err = d.Set("scale_ephemeral_storage_limit", app.ScaleEphemeralStorageLimit); err != nil {
-			return diag.FromErr(fmt.Errorf("Error setting scale_ephemeral_storage_limit: %s", err))
+			return diag.FromErr(fmt.Errorf("error setting scale_ephemeral_storage_limit: %s", err))
 		}
 	}
 	if !core.IsNil(app.ScaleInitialInstances) {
 		if err = d.Set("scale_initial_instances", flex.IntValue(app.ScaleInitialInstances)); err != nil {
-			return diag.FromErr(fmt.Errorf("Error setting scale_initial_instances: %s", err))
+			return diag.FromErr(fmt.Errorf("error setting scale_initial_instances: %s", err))
 		}
 	}
 	if !core.IsNil(app.ScaleMaxInstances) {
 		if err = d.Set("scale_max_instances", flex.IntValue(app.ScaleMaxInstances)); err != nil {
-			return diag.FromErr(fmt.Errorf("Error setting scale_max_instances: %s", err))
+			return diag.FromErr(fmt.Errorf("error setting scale_max_instances: %s", err))
 		}
 	}
 	if !core.IsNil(app.ScaleMemoryLimit) {
 		if err = d.Set("scale_memory_limit", app.ScaleMemoryLimit); err != nil {
-			return diag.FromErr(fmt.Errorf("Error setting scale_memory_limit: %s", err))
+			return diag.FromErr(fmt.Errorf("error setting scale_memory_limit: %s", err))
 		}
 	}
 	if !core.IsNil(app.ScaleMinInstances) {
 		if err = d.Set("scale_min_instances", flex.IntValue(app.ScaleMinInstances)); err != nil {
-			return diag.FromErr(fmt.Errorf("Error setting scale_min_instances: %s", err))
+			return diag.FromErr(fmt.Errorf("error setting scale_min_instances: %s", err))
 		}
 	}
 	if !core.IsNil(app.ScaleRequestTimeout) {
 		if err = d.Set("scale_request_timeout", flex.IntValue(app.ScaleRequestTimeout)); err != nil {
-			return diag.FromErr(fmt.Errorf("Error setting scale_request_timeout: %s", err))
+			return diag.FromErr(fmt.Errorf("error setting scale_request_timeout: %s", err))
+		}
+	}
+	if !core.IsNil(app.Build) {
+		if err = d.Set("build", app.Build); err != nil {
+			return diag.FromErr(fmt.Errorf("error setting build: %s", err))
+		}
+	}
+	if !core.IsNil(app.BuildRun) {
+		if err = d.Set("build_run", app.BuildRun); err != nil {
+			return diag.FromErr(fmt.Errorf("error setting build_run: %s", err))
 		}
 	}
 	if !core.IsNil(app.CreatedAt) {
 		if err = d.Set("created_at", app.CreatedAt); err != nil {
-			return diag.FromErr(fmt.Errorf("Error setting created_at: %s", err))
+			return diag.FromErr(fmt.Errorf("error setting created_at: %s", err))
 		}
 	}
 	if !core.IsNil(app.Endpoint) {
 		if err = d.Set("endpoint", app.Endpoint); err != nil {
-			return diag.FromErr(fmt.Errorf("Error setting endpoint: %s", err))
+			return diag.FromErr(fmt.Errorf("error setting endpoint: %s", err))
 		}
 	}
 	if !core.IsNil(app.EndpointInternal) {
 		if err = d.Set("endpoint_internal", app.EndpointInternal); err != nil {
-			return diag.FromErr(fmt.Errorf("Error setting endpoint_internal: %s", err))
+			return diag.FromErr(fmt.Errorf("error setting endpoint_internal: %s", err))
 		}
 	}
 	if err = d.Set("entity_tag", app.EntityTag); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting entity_tag: %s", err))
+		return diag.FromErr(fmt.Errorf("error setting entity_tag: %s", err))
 	}
 	if !core.IsNil(app.Href) {
 		if err = d.Set("href", app.Href); err != nil {
-			return diag.FromErr(fmt.Errorf("Error setting href: %s", err))
+			return diag.FromErr(fmt.Errorf("error setting href: %s", err))
 		}
 	}
 	if !core.IsNil(app.ID) {
 		if err = d.Set("app_id", app.ID); err != nil {
-			return diag.FromErr(fmt.Errorf("Error setting app_id: %s", err))
+			return diag.FromErr(fmt.Errorf("error setting app_id: %s", err))
+		}
+	}
+	if !core.IsNil(app.Region) {
+		if err = d.Set("region", app.Region); err != nil {
+			return diag.FromErr(fmt.Errorf("error setting region: %s", err))
 		}
 	}
 	if !core.IsNil(app.ResourceType) {
 		if err = d.Set("resource_type", app.ResourceType); err != nil {
-			return diag.FromErr(fmt.Errorf("Error setting resource_type: %s", err))
+			return diag.FromErr(fmt.Errorf("error setting resource_type: %s", err))
 		}
 	}
 	if !core.IsNil(app.Status) {
 		if err = d.Set("status", app.Status); err != nil {
-			return diag.FromErr(fmt.Errorf("Error setting status: %s", err))
+			return diag.FromErr(fmt.Errorf("error setting status: %s", err))
 		}
 	}
 	if !core.IsNil(app.StatusDetails) {
@@ -722,11 +908,12 @@ func resourceIbmCodeEngineAppRead(context context.Context, d *schema.ResourceDat
 			return diag.FromErr(err)
 		}
 		if err = d.Set("status_details", []map[string]interface{}{statusDetailsMap}); err != nil {
-			return diag.FromErr(fmt.Errorf("Error setting status_details: %s", err))
+			return diag.FromErr(fmt.Errorf("error setting status_details: %s", err))
 		}
 	}
 	if err = d.Set("etag", response.Headers.Get("Etag")); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting etag: %s", err))
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("Error setting etag: %s", err), "ibm_code_engine_app", "read")
+		return tfErr.GetDiag()
 	}
 
 	return nil
@@ -735,14 +922,17 @@ func resourceIbmCodeEngineAppRead(context context.Context, d *schema.ResourceDat
 func resourceIbmCodeEngineAppUpdate(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	codeEngineClient, err := meta.(conns.ClientSession).CodeEngineV2()
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.TerraformErrorf(err, err.Error(), "ibm_code_engine_app", "update")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	updateAppOptions := &codeenginev2.UpdateAppOptions{}
 
 	parts, err := flex.SepIdParts(d.Id(), "/")
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.TerraformErrorf(err, err.Error(), "ibm_code_engine_app", "update")
+		return tfErr.GetDiag()
 	}
 
 	updateAppOptions.SetProjectID(parts[0])
@@ -751,15 +941,20 @@ func resourceIbmCodeEngineAppUpdate(context context.Context, d *schema.ResourceD
 	hasChange := false
 
 	patchVals := &codeenginev2.AppPatch{}
-	if d.HasChange("image_reference") || d.HasChange("name") {
-		newImageReference := d.Get("image_reference").(string)
-		patchVals.ImageReference = &newImageReference
-		updateAppOptions.SetName(d.Get("name").(string))
-		hasChange = true
+	if d.HasChange("project_id") {
+		errMsg := fmt.Sprintf("Cannot update resource property \"%s\" with the ForceNew annotation."+
+			" The resource must be re-created to update this property.", "project_id")
+		tfErr := flex.TerraformErrorf(err, errMsg, "ibm_code_engine_app", "update")
+		return tfErr.GetDiag()
 	}
 	if d.HasChange("image_port") {
 		newImagePort := int64(d.Get("image_port").(int))
 		patchVals.ImagePort = &newImagePort
+		hasChange = true
+	}
+	if d.HasChange("image_reference") {
+		newImageReference := d.Get("image_reference").(string)
+		patchVals.ImageReference = &newImageReference
 		hasChange = true
 	}
 	if d.HasChange("image_secret") {
@@ -770,6 +965,22 @@ func resourceIbmCodeEngineAppUpdate(context context.Context, d *schema.ResourceD
 	if d.HasChange("managed_domain_mappings") {
 		newManagedDomainMappings := d.Get("managed_domain_mappings").(string)
 		patchVals.ManagedDomainMappings = &newManagedDomainMappings
+		hasChange = true
+	}
+	if d.HasChange("probe_liveness") {
+		probeLiveness, err := resourceIbmCodeEngineAppMapToProbePrototype(d.Get("probe_liveness.0").(map[string]interface{}))
+		if err != nil {
+			return diag.FromErr(err)
+		}
+		patchVals.ProbeLiveness = probeLiveness
+		hasChange = true
+	}
+	if d.HasChange("probe_readiness") {
+		probeReadiness, err := resourceIbmCodeEngineAppMapToProbePrototype(d.Get("probe_readiness.0").(map[string]interface{}))
+		if err != nil {
+			return diag.FromErr(err)
+		}
+		patchVals.ProbeReadiness = probeReadiness
 		hasChange = true
 	}
 	if d.HasChange("run_arguments") {
@@ -841,6 +1052,11 @@ func resourceIbmCodeEngineAppUpdate(context context.Context, d *schema.ResourceD
 		patchVals.ScaleCpuLimit = &newScaleCpuLimit
 		hasChange = true
 	}
+	if d.HasChange("scale_down_delay") {
+		newScaleDownDelay := int64(d.Get("scale_down_delay").(int))
+		patchVals.ScaleDownDelay = &newScaleDownDelay
+		hasChange = true
+	}
 	if d.HasChange("scale_ephemeral_storage_limit") {
 		newScaleEphemeralStorageLimit := d.Get("scale_ephemeral_storage_limit").(string)
 		patchVals.ScaleEphemeralStorageLimit = &newScaleEphemeralStorageLimit
@@ -875,87 +1091,72 @@ func resourceIbmCodeEngineAppUpdate(context context.Context, d *schema.ResourceD
 
 	if hasChange {
 		updateAppOptions.App, _ = patchVals.AsPatch()
-		_, response, err := codeEngineClient.UpdateAppWithContext(context, updateAppOptions)
+		_, _, err = codeEngineClient.UpdateAppWithContext(context, updateAppOptions)
 		if err != nil {
-			log.Printf("[DEBUG] UpdateAppWithContext failed %s\n%s", err, response)
-			return diag.FromErr(fmt.Errorf("UpdateAppWithContext failed %s\n%s", err, response))
+			tfErr := flex.TerraformErrorf(err, fmt.Sprintf("UpdateAppWithContext failed: %s", err.Error()), "ibm_code_engine_app", "update")
+			log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+			return tfErr.GetDiag()
 		}
-	}
-
-	_, err = waitForIbmCodeEngineAppUpdate(d, meta)
-	if err != nil {
-		return diag.FromErr(fmt.Errorf(
-			"Error waiting for resource IbmCodeEngineApp (%s) to be updated: %s", d.Id(), err))
 	}
 
 	return resourceIbmCodeEngineAppRead(context, d, meta)
 }
 
-func waitForIbmCodeEngineAppUpdate(d *schema.ResourceData, meta interface{}) (interface{}, error) {
-	codeEngineClient, err := meta.(conns.ClientSession).CodeEngineV2()
-	if err != nil {
-		return false, err
-	}
-	getAppOptions := &codeenginev2.GetAppOptions{}
-
-	parts, err := flex.SepIdParts(d.Id(), "/")
-	if err != nil {
-		return false, err
-	}
-
-	getAppOptions.SetProjectID(parts[0])
-	getAppOptions.SetName(parts[1])
-
-	stateConf := &resource.StateChangeConf{
-		Pending: []string{"deploying"},
-		Target:  []string{"ready"},
-		Refresh: func() (interface{}, string, error) {
-			stateObj, response, err := codeEngineClient.GetApp(getAppOptions)
-			if err != nil {
-				if apiErr, ok := err.(bmxerror.RequestFailure); ok && apiErr.StatusCode() == 404 {
-					return nil, "", fmt.Errorf("The instance %s does not exist anymore: %s\n%s", "getAppOptions", err, response)
-				}
-				return nil, "", err
-			}
-			failStates := map[string]bool{"failed": true, "warning": true}
-			if failStates[*stateObj.Status] {
-				return stateObj, *stateObj.Status, fmt.Errorf("The instance %s failed: %s\n%s", "getAppOptions", err, response)
-			}
-			return stateObj, *stateObj.Status, nil
-		},
-		Timeout:    d.Timeout(schema.TimeoutCreate),
-		Delay:      20 * time.Second,
-		MinTimeout: 20 * time.Second,
-	}
-
-	return stateConf.WaitForState()
-}
-
 func resourceIbmCodeEngineAppDelete(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	codeEngineClient, err := meta.(conns.ClientSession).CodeEngineV2()
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.TerraformErrorf(err, err.Error(), "ibm_code_engine_app", "delete")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	deleteAppOptions := &codeenginev2.DeleteAppOptions{}
 
 	parts, err := flex.SepIdParts(d.Id(), "/")
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.TerraformErrorf(err, err.Error(), "ibm_code_engine_app", "delete")
+		return tfErr.GetDiag()
 	}
 
 	deleteAppOptions.SetProjectID(parts[0])
 	deleteAppOptions.SetName(parts[1])
 
-	response, err := codeEngineClient.DeleteAppWithContext(context, deleteAppOptions)
+	_, err = codeEngineClient.DeleteAppWithContext(context, deleteAppOptions)
 	if err != nil {
-		log.Printf("[DEBUG] DeleteAppWithContext failed %s\n%s", err, response)
-		return diag.FromErr(fmt.Errorf("DeleteAppWithContext failed %s\n%s", err, response))
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("DeleteAppWithContext failed: %s", err.Error()), "ibm_code_engine_app", "delete")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	d.SetId("")
 
 	return nil
+}
+
+func resourceIbmCodeEngineAppMapToProbePrototype(modelMap map[string]interface{}) (*codeenginev2.ProbePrototype, error) {
+	model := &codeenginev2.ProbePrototype{}
+	if modelMap["failure_threshold"] != nil {
+		model.FailureThreshold = core.Int64Ptr(int64(modelMap["failure_threshold"].(int)))
+	}
+	if modelMap["initial_delay"] != nil {
+		model.InitialDelay = core.Int64Ptr(int64(modelMap["initial_delay"].(int)))
+	}
+	if modelMap["interval"] != nil {
+		model.Interval = core.Int64Ptr(int64(modelMap["interval"].(int)))
+	}
+	if modelMap["path"] != nil && modelMap["path"].(string) != "" {
+		model.Path = core.StringPtr(modelMap["path"].(string))
+	}
+	if modelMap["port"] != nil {
+		model.Port = core.Int64Ptr(int64(modelMap["port"].(int)))
+	}
+	if modelMap["timeout"] != nil {
+		model.Timeout = core.Int64Ptr(int64(modelMap["timeout"].(int)))
+	}
+	if modelMap["type"] != nil && modelMap["type"].(string) != "" {
+		model.Type = core.StringPtr(modelMap["type"].(string))
+	}
+	return model, nil
 }
 
 func resourceIbmCodeEngineAppMapToEnvVarPrototype(modelMap map[string]interface{}) (*codeenginev2.EnvVarPrototype, error) {
@@ -992,6 +1193,32 @@ func resourceIbmCodeEngineAppMapToVolumeMountPrototype(modelMap map[string]inter
 	return model, nil
 }
 
+func resourceIbmCodeEngineAppProbeToMap(model *codeenginev2.Probe) (map[string]interface{}, error) {
+	modelMap := make(map[string]interface{})
+	if model.FailureThreshold != nil {
+		modelMap["failure_threshold"] = flex.IntValue(model.FailureThreshold)
+	}
+	if model.InitialDelay != nil {
+		modelMap["initial_delay"] = flex.IntValue(model.InitialDelay)
+	}
+	if model.Interval != nil {
+		modelMap["interval"] = flex.IntValue(model.Interval)
+	}
+	if model.Path != nil {
+		modelMap["path"] = model.Path
+	}
+	if model.Port != nil {
+		modelMap["port"] = flex.IntValue(model.Port)
+	}
+	if model.Timeout != nil {
+		modelMap["timeout"] = flex.IntValue(model.Timeout)
+	}
+	if model.Type != nil {
+		modelMap["type"] = model.Type
+	}
+	return modelMap, nil
+}
+
 func resourceIbmCodeEngineAppEnvVarToMap(model *codeenginev2.EnvVar) (map[string]interface{}, error) {
 	modelMap := make(map[string]interface{})
 	if model.Key != nil {
@@ -1006,9 +1233,7 @@ func resourceIbmCodeEngineAppEnvVarToMap(model *codeenginev2.EnvVar) (map[string
 	if model.Reference != nil {
 		modelMap["reference"] = model.Reference
 	}
-	if model.Type != nil {
-		modelMap["type"] = model.Type
-	}
+	modelMap["type"] = model.Type
 	if model.Value != nil {
 		modelMap["value"] = model.Value
 	}
@@ -1018,9 +1243,7 @@ func resourceIbmCodeEngineAppEnvVarToMap(model *codeenginev2.EnvVar) (map[string
 func resourceIbmCodeEngineAppVolumeMountToMap(model *codeenginev2.VolumeMount) (map[string]interface{}, error) {
 	modelMap := make(map[string]interface{})
 	modelMap["mount_path"] = model.MountPath
-	if model.Name != nil {
-		modelMap["name"] = model.Name
-	}
+	modelMap["name"] = model.Name
 	modelMap["reference"] = model.Reference
 	modelMap["type"] = model.Type
 	return modelMap, nil

--- a/ibm/service/codeengine/resource_ibm_code_engine_app_test.go
+++ b/ibm/service/codeengine/resource_ibm_code_engine_app_test.go
@@ -43,7 +43,6 @@ func TestAccIbmCodeEngineAppBasic(t *testing.T) {
 					resource.TestCheckResourceAttr("ibm_code_engine_app.code_engine_app_instance", "name", name),
 					resource.TestCheckResourceAttr("ibm_code_engine_app.code_engine_app_instance", "image_port", "8080"),
 					resource.TestCheckResourceAttr("ibm_code_engine_app.code_engine_app_instance", "managed_domain_mappings", "local_public"),
-					resource.TestCheckResourceAttr("ibm_code_engine_app.code_engine_app_instance", "run_as_user", "0"),
 					resource.TestCheckResourceAttr("ibm_code_engine_app.code_engine_app_instance", "run_service_account", "default"),
 					resource.TestCheckResourceAttr("ibm_code_engine_app.code_engine_app_instance", "scale_concurrency", "100"),
 					resource.TestCheckResourceAttr("ibm_code_engine_app.code_engine_app_instance", "scale_cpu_limit", "1"),
@@ -65,7 +64,6 @@ func TestAccIbmCodeEngineAppBasic(t *testing.T) {
 					resource.TestCheckResourceAttr("ibm_code_engine_app.code_engine_app_instance", "name", nameUpdate),
 					resource.TestCheckResourceAttr("ibm_code_engine_app.code_engine_app_instance", "image_port", "8080"),
 					resource.TestCheckResourceAttr("ibm_code_engine_app.code_engine_app_instance", "managed_domain_mappings", "local_public"),
-					resource.TestCheckResourceAttr("ibm_code_engine_app.code_engine_app_instance", "run_as_user", "0"),
 					resource.TestCheckResourceAttr("ibm_code_engine_app.code_engine_app_instance", "run_service_account", "default"),
 					resource.TestCheckResourceAttr("ibm_code_engine_app.code_engine_app_instance", "scale_concurrency", "100"),
 					resource.TestCheckResourceAttr("ibm_code_engine_app.code_engine_app_instance", "scale_cpu_limit", "1"),
@@ -189,7 +187,9 @@ func testAccCheckIbmCodeEngineAppConfigBasic(projectID string, imageReference st
 
 			lifecycle {
 				ignore_changes = [
-					run_env_variables
+					run_env_variables,
+					probe_liveness,
+					probe_readiness
 				]
 			}
 		}
@@ -239,7 +239,9 @@ func testAccCheckIbmCodeEngineAppConfig(projectID string, configMapName string, 
 
 			lifecycle {
 				ignore_changes = [
-					run_env_variables
+					run_env_variables,
+					probe_liveness,
+					probe_readiness
 				]
 			}
 		}

--- a/ibm/service/codeengine/resource_ibm_code_engine_binding.go
+++ b/ibm/service/codeengine/resource_ibm_code_engine_binding.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2023 All Rights Reserved.
+// Copyright IBM Corp. 2024 All Rights Reserved.
 // Licensed under the Mozilla Public License v2.0
 
 package codeengine
@@ -31,14 +31,14 @@ func ResourceIbmCodeEngineBinding() *schema.Resource {
 		},
 
 		Schema: map[string]*schema.Schema{
-			"project_id": &schema.Schema{
+			"project_id": {
 				Type:         schema.TypeString,
 				Required:     true,
 				ForceNew:     true,
 				ValidateFunc: validate.InvokeValidator("ibm_code_engine_binding", "project_id"),
 				Description:  "The ID of the project.",
 			},
-			"component": &schema.Schema{
+			"component": {
 				Type:        schema.TypeList,
 				MinItems:    1,
 				MaxItems:    1,
@@ -47,12 +47,12 @@ func ResourceIbmCodeEngineBinding() *schema.Resource {
 				Description: "A reference to another component.",
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
-						"name": &schema.Schema{
+						"name": {
 							Type:        schema.TypeString,
 							Required:    true,
 							Description: "The name of the referenced component.",
 						},
-						"resource_type": &schema.Schema{
+						"resource_type": {
 							Type:        schema.TypeString,
 							Required:    true,
 							Description: "The type of the referenced resource.",
@@ -60,36 +60,36 @@ func ResourceIbmCodeEngineBinding() *schema.Resource {
 					},
 				},
 			},
-			"prefix": &schema.Schema{
+			"prefix": {
 				Type:         schema.TypeString,
 				Required:     true,
 				ForceNew:     true,
 				ValidateFunc: validate.InvokeValidator("ibm_code_engine_binding", "prefix"),
-				Description:  "Optional value that is set as prefix in the component that is bound. Will be generated if not provided.",
+				Description:  "The value that is set as a prefix in the component that is bound.",
 			},
-			"secret_name": &schema.Schema{
+			"secret_name": {
 				Type:         schema.TypeString,
 				Required:     true,
 				ForceNew:     true,
 				ValidateFunc: validate.InvokeValidator("ibm_code_engine_binding", "secret_name"),
-				Description:  "The service access secret that is binding to a component.",
+				Description:  "The service access secret that is bound to a component.",
 			},
-			"href": &schema.Schema{
+			"href": {
 				Type:        schema.TypeString,
 				Computed:    true,
 				Description: "When you provision a new binding,  a URL is created identifying the location of the instance.",
 			},
-			"resource_type": &schema.Schema{
+			"resource_type": {
 				Type:        schema.TypeString,
 				Computed:    true,
 				Description: "The type of the binding.",
 			},
-			"status": &schema.Schema{
+			"status": {
 				Type:        schema.TypeString,
 				Computed:    true,
 				Description: "The current status of the binding.",
 			},
-			"binding_id": &schema.Schema{
+			"binding_id": {
 				Type:        schema.TypeString,
 				Computed:    true,
 				Description: "The ID of the binding.",
@@ -137,7 +137,9 @@ func ResourceIbmCodeEngineBindingValidator() *validate.ResourceValidator {
 func resourceIbmCodeEngineBindingCreate(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	codeEngineClient, err := meta.(conns.ClientSession).CodeEngineV2()
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.TerraformErrorf(err, err.Error(), "ibm_code_engine_binding", "create")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	createBindingOptions := &codeenginev2.CreateBindingOptions{}
@@ -151,10 +153,11 @@ func resourceIbmCodeEngineBindingCreate(context context.Context, d *schema.Resou
 	createBindingOptions.SetPrefix(d.Get("prefix").(string))
 	createBindingOptions.SetSecretName(d.Get("secret_name").(string))
 
-	binding, response, err := codeEngineClient.CreateBindingWithContext(context, createBindingOptions)
+	binding, _, err := codeEngineClient.CreateBindingWithContext(context, createBindingOptions)
 	if err != nil {
-		log.Printf("[DEBUG] CreateBindingWithContext failed %s\n%s", err, response)
-		return diag.FromErr(fmt.Errorf("CreateBindingWithContext failed %s\n%s", err, response))
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("CreateBindingWithContext failed: %s", err.Error()), "ibm_code_engine_binding", "create")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	d.SetId(fmt.Sprintf("%s/%s", *createBindingOptions.ProjectID, *binding.ID))
@@ -165,14 +168,17 @@ func resourceIbmCodeEngineBindingCreate(context context.Context, d *schema.Resou
 func resourceIbmCodeEngineBindingRead(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	codeEngineClient, err := meta.(conns.ClientSession).CodeEngineV2()
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.TerraformErrorf(err, err.Error(), "ibm_code_engine_binding", "read")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	getBindingOptions := &codeenginev2.GetBindingOptions{}
 
 	parts, err := flex.SepIdParts(d.Id(), "/")
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.TerraformErrorf(err, err.Error(), "ibm_code_engine_binding", "read")
+		return tfErr.GetDiag()
 	}
 
 	getBindingOptions.SetProjectID(parts[0])
@@ -184,44 +190,45 @@ func resourceIbmCodeEngineBindingRead(context context.Context, d *schema.Resourc
 			d.SetId("")
 			return nil
 		}
-		log.Printf("[DEBUG] GetBindingWithContext failed %s\n%s", err, response)
-		return diag.FromErr(fmt.Errorf("GetBindingWithContext failed %s\n%s", err, response))
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("GetBindingWithContext failed: %s", err.Error()), "ibm_code_engine_binding", "read")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	if err = d.Set("project_id", binding.ProjectID); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting project_id: %s", err))
+		return diag.FromErr(fmt.Errorf("error setting project_id: %s", err))
 	}
 	componentMap, err := resourceIbmCodeEngineBindingComponentRefToMap(binding.Component)
 	if err != nil {
 		return diag.FromErr(err)
 	}
 	if err = d.Set("component", []map[string]interface{}{componentMap}); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting component: %s", err))
+		return diag.FromErr(fmt.Errorf("error setting component: %s", err))
 	}
 	if err = d.Set("prefix", binding.Prefix); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting prefix: %s", err))
+		return diag.FromErr(fmt.Errorf("error setting prefix: %s", err))
 	}
 	if err = d.Set("secret_name", binding.SecretName); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting secret_name: %s", err))
+		return diag.FromErr(fmt.Errorf("error setting secret_name: %s", err))
 	}
 	if !core.IsNil(binding.Href) {
 		if err = d.Set("href", binding.Href); err != nil {
-			return diag.FromErr(fmt.Errorf("Error setting href: %s", err))
+			return diag.FromErr(fmt.Errorf("error setting href: %s", err))
 		}
 	}
 	if !core.IsNil(binding.ResourceType) {
 		if err = d.Set("resource_type", binding.ResourceType); err != nil {
-			return diag.FromErr(fmt.Errorf("Error setting resource_type: %s", err))
+			return diag.FromErr(fmt.Errorf("error setting resource_type: %s", err))
 		}
 	}
 	if !core.IsNil(binding.Status) {
 		if err = d.Set("status", binding.Status); err != nil {
-			return diag.FromErr(fmt.Errorf("Error setting status: %s", err))
+			return diag.FromErr(fmt.Errorf("error setting status: %s", err))
 		}
 	}
 	if !core.IsNil(binding.ID) {
 		if err = d.Set("binding_id", binding.ID); err != nil {
-			return diag.FromErr(fmt.Errorf("Error setting binding_id: %s", err))
+			return diag.FromErr(fmt.Errorf("error setting binding_id: %s", err))
 		}
 	}
 
@@ -231,23 +238,27 @@ func resourceIbmCodeEngineBindingRead(context context.Context, d *schema.Resourc
 func resourceIbmCodeEngineBindingDelete(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	codeEngineClient, err := meta.(conns.ClientSession).CodeEngineV2()
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.TerraformErrorf(err, err.Error(), "ibm_code_engine_binding", "delete")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	deleteBindingOptions := &codeenginev2.DeleteBindingOptions{}
 
 	parts, err := flex.SepIdParts(d.Id(), "/")
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.TerraformErrorf(err, err.Error(), "ibm_code_engine_binding", "delete")
+		return tfErr.GetDiag()
 	}
 
 	deleteBindingOptions.SetProjectID(parts[0])
 	deleteBindingOptions.SetID(parts[1])
 
-	response, err := codeEngineClient.DeleteBindingWithContext(context, deleteBindingOptions)
+	_, err = codeEngineClient.DeleteBindingWithContext(context, deleteBindingOptions)
 	if err != nil {
-		log.Printf("[DEBUG] DeleteBindingWithContext failed %s\n%s", err, response)
-		return diag.FromErr(fmt.Errorf("DeleteBindingWithContext failed %s\n%s", err, response))
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("DeleteBindingWithContext failed: %s", err.Error()), "ibm_code_engine_binding", "delete")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	d.SetId("")

--- a/ibm/service/codeengine/resource_ibm_code_engine_binding_test.go
+++ b/ibm/service/codeengine/resource_ibm_code_engine_binding_test.go
@@ -69,7 +69,9 @@ func testAccCheckIbmCodeEngineBindingConfigBasic(projectID string, appName strin
 
 			lifecycle {
 				ignore_changes = [
-					run_env_variables
+					run_env_variables,
+					probe_liveness,
+					probe_readiness
 				]
 			}
 		}

--- a/ibm/service/codeengine/resource_ibm_code_engine_build.go
+++ b/ibm/service/codeengine/resource_ibm_code_engine_build.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2023 All Rights Reserved.
+// Copyright IBM Corp. 2024 All Rights Reserved.
 // Licensed under the Mozilla Public License v2.0
 
 package codeengine
@@ -27,127 +27,132 @@ func ResourceIbmCodeEngineBuild() *schema.Resource {
 		Importer:      &schema.ResourceImporter{},
 
 		Schema: map[string]*schema.Schema{
-			"project_id": &schema.Schema{
+			"project_id": {
 				Type:         schema.TypeString,
 				Required:     true,
 				ForceNew:     true,
 				ValidateFunc: validate.InvokeValidator("ibm_code_engine_build", "project_id"),
 				Description:  "The ID of the project.",
 			},
-			"name": &schema.Schema{
+			"name": {
 				Type:         schema.TypeString,
 				Required:     true,
 				ForceNew:     true,
 				ValidateFunc: validate.InvokeValidator("ibm_code_engine_build", "name"),
-				Description:  "The name of the build. Use a name that is unique within the project.",
+				Description:  "The name of the build.",
 			},
-			"output_image": &schema.Schema{
+			"output_image": {
 				Type:         schema.TypeString,
 				Required:     true,
 				ValidateFunc: validate.InvokeValidator("ibm_code_engine_build", "output_image"),
 				Description:  "The name of the image.",
 			},
-			"output_secret": &schema.Schema{
+			"output_secret": {
 				Type:         schema.TypeString,
 				Required:     true,
 				ValidateFunc: validate.InvokeValidator("ibm_code_engine_build", "output_secret"),
 				Description:  "The secret that is required to access the image registry. Make sure that the secret is granted with push permissions towards the specified container registry namespace.",
 			},
-			"strategy_type": &schema.Schema{
-				Type:         schema.TypeString,
-				Required:     true,
-				ValidateFunc: validate.InvokeValidator("ibm_code_engine_build", "strategy_type"),
-				Description:  "The strategy to use for building the image.",
-			},
-			"source_context_dir": &schema.Schema{
+			"source_context_dir": {
 				Type:         schema.TypeString,
 				Optional:     true,
 				ValidateFunc: validate.InvokeValidator("ibm_code_engine_build", "source_context_dir"),
-				Description:  "Option directory in the repository that contains the buildpacks file or the Dockerfile.",
+				Description:  "Optional directory in the repository that contains the buildpacks file or the Dockerfile.",
 			},
-			"source_revision": &schema.Schema{
+			"source_revision": {
 				Type:         schema.TypeString,
 				Optional:     true,
 				ValidateFunc: validate.InvokeValidator("ibm_code_engine_build", "source_revision"),
 				Description:  "Commit, tag, or branch in the source repository to pull. This field is optional if the `source_type` is `git` and uses the HEAD of default branch if not specified. If the `source_type` value is `local`, this field must be omitted.",
 			},
-			"source_secret": &schema.Schema{
+			"source_secret": {
 				Type:         schema.TypeString,
 				Optional:     true,
 				ValidateFunc: validate.InvokeValidator("ibm_code_engine_build", "source_secret"),
 				Description:  "Name of the secret that is used access the repository source. This field is optional if the `source_type` is `git`. Additionally, if the `source_url` points to a repository that requires authentication, the build will be created but cannot access any source code, until this property is provided, too. If the `source_type` value is `local`, this field must be omitted.",
 			},
-			"source_type": &schema.Schema{
+			"source_type": {
 				Type:         schema.TypeString,
 				Optional:     true,
 				Default:      "git",
 				ValidateFunc: validate.InvokeValidator("ibm_code_engine_build", "source_type"),
 				Description:  "Specifies the type of source to determine if your build source is in a repository or based on local source code.* local - For builds from local source code.* git - For builds from git version controlled source code.",
 			},
-			"source_url": &schema.Schema{
+			"source_url": {
 				Type:         schema.TypeString,
 				Optional:     true,
 				ValidateFunc: validate.InvokeValidator("ibm_code_engine_build", "source_url"),
 				Description:  "The URL of the code repository. This field is required if the `source_type` is `git`. If the `source_type` value is `local`, this field must be omitted. If the repository is publicly available you can provide a 'https' URL like `https://github.com/IBM/CodeEngine`. If the repository requires authentication, you need to provide a 'ssh' URL like `git@github.com:IBM/CodeEngine.git` along with a `source_secret` that points to a secret of format `ssh_auth`.",
 			},
-			"strategy_size": &schema.Schema{
+			"strategy_size": {
 				Type:         schema.TypeString,
 				Optional:     true,
 				Default:      "medium",
 				ValidateFunc: validate.InvokeValidator("ibm_code_engine_build", "strategy_size"),
-				Description:  "Optional size for the build, which determines the amount of resources used. Build sizes are `small`, `medium`, `large`, `xlarge`.",
+				Description:  "Optional size for the build, which determines the amount of resources used. Build sizes are `small`, `medium`, `large`, `xlarge`, `xxlarge`.",
 			},
-			"strategy_spec_file": &schema.Schema{
+			"strategy_spec_file": {
 				Type:         schema.TypeString,
 				Optional:     true,
 				Default:      "Dockerfile",
 				ValidateFunc: validate.InvokeValidator("ibm_code_engine_build", "strategy_spec_file"),
 				Description:  "Optional path to the specification file that is used for build strategies for building an image.",
 			},
-			"timeout": &schema.Schema{
+			"strategy_type": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ValidateFunc: validate.InvokeValidator("ibm_code_engine_build", "strategy_type"),
+				Description:  "The strategy to use for building the image.",
+			},
+			"timeout": {
 				Type:         schema.TypeInt,
 				Optional:     true,
 				Default:      600,
 				ValidateFunc: validate.InvokeValidator("ibm_code_engine_build", "timeout"),
 				Description:  "The maximum amount of time, in seconds, that can pass before the build must succeed or fail.",
 			},
-			"created_at": &schema.Schema{
+			"created_at": {
 				Type:        schema.TypeString,
 				Computed:    true,
 				Description: "The timestamp when the resource was created.",
 			},
-			"entity_tag": &schema.Schema{
+			"entity_tag": {
 				Type:        schema.TypeString,
 				Computed:    true,
 				Description: "The version of the build instance, which is used to achieve optimistic locking.",
 			},
-			"href": &schema.Schema{
+			"href": {
 				Type:        schema.TypeString,
 				Computed:    true,
 				Description: "When you provision a new build,  a URL is created identifying the location of the instance.",
 			},
-			"build_id": &schema.Schema{
+			"build_id": {
 				Type:        schema.TypeString,
 				Computed:    true,
 				Description: "The identifier of the resource.",
 			},
-			"resource_type": &schema.Schema{
+			"region": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The region of the project the resource is located in. Possible values: 'au-syd', 'br-sao', 'ca-tor', 'eu-de', 'eu-gb', 'jp-osa', 'jp-tok', 'us-east', 'us-south'.",
+			},
+			"resource_type": {
 				Type:        schema.TypeString,
 				Computed:    true,
 				Description: "The type of the build.",
 			},
-			"status": &schema.Schema{
+			"status": {
 				Type:        schema.TypeString,
 				Computed:    true,
 				Description: "The current status of the build.",
 			},
-			"status_details": &schema.Schema{
+			"status_details": {
 				Type:        schema.TypeList,
 				Computed:    true,
 				Description: "The detailed status of the build.",
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
-						"reason": &schema.Schema{
+						"reason": {
 							Type:        schema.TypeString,
 							Computed:    true,
 							Description: "Optional information to provide more context in case of a 'failed' or 'warning' status.",
@@ -155,7 +160,7 @@ func ResourceIbmCodeEngineBuild() *schema.Resource {
 					},
 				},
 			},
-			"etag": &schema.Schema{
+			"etag": {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
@@ -199,15 +204,6 @@ func ResourceIbmCodeEngineBuildValidator() *validate.ResourceValidator {
 			Type:                       validate.TypeString,
 			Required:                   true,
 			Regexp:                     `^[a-z0-9]([\-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([\-a-z0-9]*[a-z0-9])?)*$`,
-			MinValueLength:             1,
-			MaxValueLength:             253,
-		},
-		validate.ValidateSchema{
-			Identifier:                 "strategy_type",
-			ValidateFunctionIdentifier: validate.ValidateRegexpLen,
-			Type:                       validate.TypeString,
-			Required:                   true,
-			Regexp:                     `[\S]*`,
 			MinValueLength:             1,
 			MaxValueLength:             253,
 		},
@@ -273,6 +269,15 @@ func ResourceIbmCodeEngineBuildValidator() *validate.ResourceValidator {
 			MaxValueLength:             253,
 		},
 		validate.ValidateSchema{
+			Identifier:                 "strategy_type",
+			ValidateFunctionIdentifier: validate.ValidateRegexpLen,
+			Type:                       validate.TypeString,
+			Required:                   true,
+			Regexp:                     `[\S]*`,
+			MinValueLength:             1,
+			MaxValueLength:             253,
+		},
+		validate.ValidateSchema{
 			Identifier:                 "timeout",
 			ValidateFunctionIdentifier: validate.IntBetween,
 			Type:                       validate.TypeInt,
@@ -289,7 +294,9 @@ func ResourceIbmCodeEngineBuildValidator() *validate.ResourceValidator {
 func resourceIbmCodeEngineBuildCreate(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	codeEngineClient, err := meta.(conns.ClientSession).CodeEngineV2()
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.TerraformErrorf(err, err.Error(), "ibm_code_engine_build", "create")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	createBuildOptions := &codeenginev2.CreateBuildOptions{}
@@ -324,10 +331,11 @@ func resourceIbmCodeEngineBuildCreate(context context.Context, d *schema.Resourc
 		createBuildOptions.SetTimeout(int64(d.Get("timeout").(int)))
 	}
 
-	build, response, err := codeEngineClient.CreateBuildWithContext(context, createBuildOptions)
+	build, _, err := codeEngineClient.CreateBuildWithContext(context, createBuildOptions)
 	if err != nil {
-		log.Printf("[DEBUG] CreateBuildWithContext failed %s\n%s", err, response)
-		return diag.FromErr(fmt.Errorf("CreateBuildWithContext failed %s\n%s", err, response))
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("CreateBuildWithContext failed: %s", err.Error()), "ibm_code_engine_build", "create")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	d.SetId(fmt.Sprintf("%s/%s", *createBuildOptions.ProjectID, *build.Name))
@@ -338,14 +346,17 @@ func resourceIbmCodeEngineBuildCreate(context context.Context, d *schema.Resourc
 func resourceIbmCodeEngineBuildRead(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	codeEngineClient, err := meta.(conns.ClientSession).CodeEngineV2()
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.TerraformErrorf(err, err.Error(), "ibm_code_engine_build", "read")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	getBuildOptions := &codeenginev2.GetBuildOptions{}
 
 	parts, err := flex.SepIdParts(d.Id(), "/")
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.TerraformErrorf(err, err.Error(), "ibm_code_engine_build", "read")
+		return tfErr.GetDiag()
 	}
 
 	getBuildOptions.SetProjectID(parts[0])
@@ -357,91 +368,97 @@ func resourceIbmCodeEngineBuildRead(context context.Context, d *schema.ResourceD
 			d.SetId("")
 			return nil
 		}
-		log.Printf("[DEBUG] GetBuildWithContext failed %s\n%s", err, response)
-		return diag.FromErr(fmt.Errorf("GetBuildWithContext failed %s\n%s", err, response))
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("GetBuildWithContext failed: %s", err.Error()), "ibm_code_engine_build", "read")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	if err = d.Set("project_id", build.ProjectID); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting project_id: %s", err))
+		return diag.FromErr(fmt.Errorf("error setting project_id: %s", err))
 	}
 	if err = d.Set("name", build.Name); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting name: %s", err))
+		return diag.FromErr(fmt.Errorf("error setting name: %s", err))
 	}
 	if err = d.Set("output_image", build.OutputImage); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting output_image: %s", err))
+		return diag.FromErr(fmt.Errorf("error setting output_image: %s", err))
 	}
 	if err = d.Set("output_secret", build.OutputSecret); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting output_secret: %s", err))
-	}
-	if err = d.Set("strategy_type", build.StrategyType); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting strategy_type: %s", err))
+		return diag.FromErr(fmt.Errorf("error setting output_secret: %s", err))
 	}
 	if !core.IsNil(build.SourceContextDir) {
 		if err = d.Set("source_context_dir", build.SourceContextDir); err != nil {
-			return diag.FromErr(fmt.Errorf("Error setting source_context_dir: %s", err))
+			return diag.FromErr(fmt.Errorf("error setting source_context_dir: %s", err))
 		}
 	}
 	if !core.IsNil(build.SourceRevision) {
 		if err = d.Set("source_revision", build.SourceRevision); err != nil {
-			return diag.FromErr(fmt.Errorf("Error setting source_revision: %s", err))
+			return diag.FromErr(fmt.Errorf("error setting source_revision: %s", err))
 		}
 	}
 	if !core.IsNil(build.SourceSecret) {
 		if err = d.Set("source_secret", build.SourceSecret); err != nil {
-			return diag.FromErr(fmt.Errorf("Error setting source_secret: %s", err))
+			return diag.FromErr(fmt.Errorf("error setting source_secret: %s", err))
 		}
 	}
 	if !core.IsNil(build.SourceType) {
 		if err = d.Set("source_type", build.SourceType); err != nil {
-			return diag.FromErr(fmt.Errorf("Error setting source_type: %s", err))
+			return diag.FromErr(fmt.Errorf("error setting source_type: %s", err))
 		}
 	}
 	if !core.IsNil(build.SourceURL) {
 		if err = d.Set("source_url", build.SourceURL); err != nil {
-			return diag.FromErr(fmt.Errorf("Error setting source_url: %s", err))
+			return diag.FromErr(fmt.Errorf("error setting source_url: %s", err))
 		}
 	}
 	if !core.IsNil(build.StrategySize) {
 		if err = d.Set("strategy_size", build.StrategySize); err != nil {
-			return diag.FromErr(fmt.Errorf("Error setting strategy_size: %s", err))
+			return diag.FromErr(fmt.Errorf("error setting strategy_size: %s", err))
 		}
 	}
 	if !core.IsNil(build.StrategySpecFile) {
 		if err = d.Set("strategy_spec_file", build.StrategySpecFile); err != nil {
-			return diag.FromErr(fmt.Errorf("Error setting strategy_spec_file: %s", err))
+			return diag.FromErr(fmt.Errorf("error setting strategy_spec_file: %s", err))
 		}
+	}
+	if err = d.Set("strategy_type", build.StrategyType); err != nil {
+		return diag.FromErr(fmt.Errorf("error setting strategy_type: %s", err))
 	}
 	if !core.IsNil(build.Timeout) {
 		if err = d.Set("timeout", flex.IntValue(build.Timeout)); err != nil {
-			return diag.FromErr(fmt.Errorf("Error setting timeout: %s", err))
+			return diag.FromErr(fmt.Errorf("error setting timeout: %s", err))
 		}
 	}
 	if !core.IsNil(build.CreatedAt) {
 		if err = d.Set("created_at", build.CreatedAt); err != nil {
-			return diag.FromErr(fmt.Errorf("Error setting created_at: %s", err))
+			return diag.FromErr(fmt.Errorf("error setting created_at: %s", err))
 		}
 	}
 	if err = d.Set("entity_tag", build.EntityTag); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting entity_tag: %s", err))
+		return diag.FromErr(fmt.Errorf("error setting entity_tag: %s", err))
 	}
 	if !core.IsNil(build.Href) {
 		if err = d.Set("href", build.Href); err != nil {
-			return diag.FromErr(fmt.Errorf("Error setting href: %s", err))
+			return diag.FromErr(fmt.Errorf("error setting href: %s", err))
 		}
 	}
 	if !core.IsNil(build.ID) {
 		if err = d.Set("build_id", build.ID); err != nil {
-			return diag.FromErr(fmt.Errorf("Error setting build_id: %s", err))
+			return diag.FromErr(fmt.Errorf("error setting build_id: %s", err))
+		}
+	}
+	if !core.IsNil(build.Region) {
+		if err = d.Set("region", build.Region); err != nil {
+			return diag.FromErr(fmt.Errorf("error setting region: %s", err))
 		}
 	}
 	if !core.IsNil(build.ResourceType) {
 		if err = d.Set("resource_type", build.ResourceType); err != nil {
-			return diag.FromErr(fmt.Errorf("Error setting resource_type: %s", err))
+			return diag.FromErr(fmt.Errorf("error setting resource_type: %s", err))
 		}
 	}
 	if !core.IsNil(build.Status) {
 		if err = d.Set("status", build.Status); err != nil {
-			return diag.FromErr(fmt.Errorf("Error setting status: %s", err))
+			return diag.FromErr(fmt.Errorf("error setting status: %s", err))
 		}
 	}
 	if !core.IsNil(build.StatusDetails) {
@@ -450,11 +467,12 @@ func resourceIbmCodeEngineBuildRead(context context.Context, d *schema.ResourceD
 			return diag.FromErr(err)
 		}
 		if err = d.Set("status_details", []map[string]interface{}{statusDetailsMap}); err != nil {
-			return diag.FromErr(fmt.Errorf("Error setting status_details: %s", err))
+			return diag.FromErr(fmt.Errorf("error setting status_details: %s", err))
 		}
 	}
 	if err = d.Set("etag", response.Headers.Get("Etag")); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting etag: %s", err))
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("Error setting etag: %s", err), "ibm_code_engine_build", "read")
+		return tfErr.GetDiag()
 	}
 
 	return nil
@@ -463,14 +481,17 @@ func resourceIbmCodeEngineBuildRead(context context.Context, d *schema.ResourceD
 func resourceIbmCodeEngineBuildUpdate(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	codeEngineClient, err := meta.(conns.ClientSession).CodeEngineV2()
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.TerraformErrorf(err, err.Error(), "ibm_code_engine_build", "update")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	updateBuildOptions := &codeenginev2.UpdateBuildOptions{}
 
 	parts, err := flex.SepIdParts(d.Id(), "/")
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.TerraformErrorf(err, err.Error(), "ibm_code_engine_build", "update")
+		return tfErr.GetDiag()
 	}
 
 	updateBuildOptions.SetProjectID(parts[0])
@@ -480,20 +501,19 @@ func resourceIbmCodeEngineBuildUpdate(context context.Context, d *schema.Resourc
 
 	patchVals := &codeenginev2.BuildPatch{}
 	if d.HasChange("project_id") {
-		return diag.FromErr(fmt.Errorf("Cannot update resource property \"%s\" with the ForceNew annotation."+
-			" The resource must be re-created to update this property.", "project_id"))
+		errMsg := fmt.Sprintf("Cannot update resource property \"%s\" with the ForceNew annotation."+
+			" The resource must be re-created to update this property.", "project_id")
+		tfErr := flex.TerraformErrorf(err, errMsg, "ibm_code_engine_build", "update")
+		return tfErr.GetDiag()
 	}
-	if d.HasChange("name") {
-		return diag.FromErr(fmt.Errorf("Cannot update resource property \"%s\" with the ForceNew annotation."+
-			" The resource must be re-created to update this property.", "name"))
-	}
-	if d.HasChange("output_image") || d.HasChange("output_secret") || d.HasChange("strategy_type") {
+	if d.HasChange("output_image") {
 		newOutputImage := d.Get("output_image").(string)
 		patchVals.OutputImage = &newOutputImage
+		hasChange = true
+	}
+	if d.HasChange("output_secret") {
 		newOutputSecret := d.Get("output_secret").(string)
 		patchVals.OutputSecret = &newOutputSecret
-		newStrategyType := d.Get("strategy_type").(string)
-		patchVals.StrategyType = &newStrategyType
 		hasChange = true
 	}
 	if d.HasChange("source_context_dir") {
@@ -531,6 +551,11 @@ func resourceIbmCodeEngineBuildUpdate(context context.Context, d *schema.Resourc
 		patchVals.StrategySpecFile = &newStrategySpecFile
 		hasChange = true
 	}
+	if d.HasChange("strategy_type") {
+		newStrategyType := d.Get("strategy_type").(string)
+		patchVals.StrategyType = &newStrategyType
+		hasChange = true
+	}
 	if d.HasChange("timeout") {
 		newTimeout := int64(d.Get("timeout").(int))
 		patchVals.Timeout = &newTimeout
@@ -540,10 +565,11 @@ func resourceIbmCodeEngineBuildUpdate(context context.Context, d *schema.Resourc
 
 	if hasChange {
 		updateBuildOptions.Build, _ = patchVals.AsPatch()
-		_, response, err := codeEngineClient.UpdateBuildWithContext(context, updateBuildOptions)
+		_, _, err = codeEngineClient.UpdateBuildWithContext(context, updateBuildOptions)
 		if err != nil {
-			log.Printf("[DEBUG] UpdateBuildWithContext failed %s\n%s", err, response)
-			return diag.FromErr(fmt.Errorf("UpdateBuildWithContext failed %s\n%s", err, response))
+			tfErr := flex.TerraformErrorf(err, fmt.Sprintf("UpdateBuildWithContext failed: %s", err.Error()), "ibm_code_engine_build", "update")
+			log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+			return tfErr.GetDiag()
 		}
 	}
 
@@ -553,23 +579,27 @@ func resourceIbmCodeEngineBuildUpdate(context context.Context, d *schema.Resourc
 func resourceIbmCodeEngineBuildDelete(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	codeEngineClient, err := meta.(conns.ClientSession).CodeEngineV2()
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.TerraformErrorf(err, err.Error(), "ibm_code_engine_build", "delete")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	deleteBuildOptions := &codeenginev2.DeleteBuildOptions{}
 
 	parts, err := flex.SepIdParts(d.Id(), "/")
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.TerraformErrorf(err, err.Error(), "ibm_code_engine_build", "delete")
+		return tfErr.GetDiag()
 	}
 
 	deleteBuildOptions.SetProjectID(parts[0])
 	deleteBuildOptions.SetName(parts[1])
 
-	response, err := codeEngineClient.DeleteBuildWithContext(context, deleteBuildOptions)
+	_, err = codeEngineClient.DeleteBuildWithContext(context, deleteBuildOptions)
 	if err != nil {
-		log.Printf("[DEBUG] DeleteBuildWithContext failed %s\n%s", err, response)
-		return diag.FromErr(fmt.Errorf("DeleteBuildWithContext failed %s\n%s", err, response))
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("DeleteBuildWithContext failed: %s", err.Error()), "ibm_code_engine_build", "delete")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	d.SetId("")

--- a/ibm/service/codeengine/resource_ibm_code_engine_domain_mapping.go
+++ b/ibm/service/codeengine/resource_ibm_code_engine_domain_mapping.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2023 All Rights Reserved.
+// Copyright IBM Corp. 2024 All Rights Reserved.
 // Licensed under the Mozilla Public License v2.0
 
 package codeengine
@@ -13,7 +13,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 
-	"github.com/IBM-Cloud/bluemix-go/bmxerror"
 	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/conns"
 	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/flex"
 	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/validate"
@@ -34,14 +33,14 @@ func ResourceIbmCodeEngineDomainMapping() *schema.Resource {
 		},
 
 		Schema: map[string]*schema.Schema{
-			"project_id": &schema.Schema{
+			"project_id": {
 				Type:         schema.TypeString,
 				Required:     true,
 				ForceNew:     true,
 				ValidateFunc: validate.InvokeValidator("ibm_code_engine_domain_mapping", "project_id"),
 				Description:  "The ID of the project.",
 			},
-			"component": &schema.Schema{
+			"component": {
 				Type:        schema.TypeList,
 				MinItems:    1,
 				MaxItems:    1,
@@ -49,12 +48,12 @@ func ResourceIbmCodeEngineDomainMapping() *schema.Resource {
 				Description: "A reference to another component.",
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
-						"name": &schema.Schema{
+						"name": {
 							Type:        schema.TypeString,
 							Required:    true,
 							Description: "The name of the referenced component.",
 						},
-						"resource_type": &schema.Schema{
+						"resource_type": {
 							Type:        schema.TypeString,
 							Required:    true,
 							Description: "The type of the referenced resource.",
@@ -62,61 +61,66 @@ func ResourceIbmCodeEngineDomainMapping() *schema.Resource {
 					},
 				},
 			},
-			"name": &schema.Schema{
+			"name": {
 				Type:         schema.TypeString,
 				Required:     true,
 				ForceNew:     true,
 				ValidateFunc: validate.InvokeValidator("ibm_code_engine_domain_mapping", "name"),
 				Description:  "The name of the domain mapping.",
 			},
-			"tls_secret": &schema.Schema{
+			"tls_secret": {
 				Type:         schema.TypeString,
 				Required:     true,
 				ValidateFunc: validate.InvokeValidator("ibm_code_engine_domain_mapping", "tls_secret"),
-				Description:  "The name of the TLS secret that holds the certificate and private key of this domain mapping.",
+				Description:  "The name of the TLS secret that includes the certificate and private key of this domain mapping.",
 			},
-			"cname_target": &schema.Schema{
+			"cname_target": {
 				Type:        schema.TypeString,
 				Computed:    true,
-				Description: "Exposes the value of the CNAME record that needs to be configured in the DNS settings of the domain, to route traffic properly to the target Code Engine region.",
+				Description: "The value of the CNAME record that must be configured in the DNS settings of the domain, to route traffic properly to the target Code Engine region.",
 			},
-			"created_at": &schema.Schema{
+			"created_at": {
 				Type:        schema.TypeString,
 				Computed:    true,
 				Description: "The timestamp when the resource was created.",
 			},
-			"domain_mapping_id": &schema.Schema{
-				Type:        schema.TypeString,
-				Computed:    true,
-				Description: "The identifier of the resource.",
-			},
-			"entity_tag": &schema.Schema{
+			"entity_tag": {
 				Type:        schema.TypeString,
 				Computed:    true,
 				Description: "The version of the domain mapping instance, which is used to achieve optimistic locking.",
 			},
-			"href": &schema.Schema{
+			"href": {
 				Type:        schema.TypeString,
 				Computed:    true,
 				Description: "When you provision a new domain mapping, a URL is created identifying the location of the instance.",
 			},
-			"resource_type": &schema.Schema{
+			"domain_mapping_id": {
 				Type:        schema.TypeString,
 				Computed:    true,
-				Description: "The type of the CE Resource.",
+				Description: "The identifier of the resource.",
 			},
-			"status": &schema.Schema{
+			"region": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The region of the project the resource is located in. Possible values: 'au-syd', 'br-sao', 'ca-tor', 'eu-de', 'eu-gb', 'jp-osa', 'jp-tok', 'us-east', 'us-south'.",
+			},
+			"resource_type": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The type of the Code Engine resource.",
+			},
+			"status": {
 				Type:        schema.TypeString,
 				Computed:    true,
 				Description: "The current status of the domain mapping.",
 			},
-			"status_details": &schema.Schema{
+			"status_details": {
 				Type:        schema.TypeList,
 				Computed:    true,
 				Description: "The detailed status of the domain mapping.",
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
-						"reason": &schema.Schema{
+						"reason": {
 							Type:        schema.TypeString,
 							Computed:    true,
 							Description: "Optional information to provide more context in case of a 'failed' or 'warning' status.",
@@ -124,17 +128,17 @@ func ResourceIbmCodeEngineDomainMapping() *schema.Resource {
 					},
 				},
 			},
-			"user_managed": &schema.Schema{
+			"user_managed": {
 				Type:        schema.TypeBool,
 				Computed:    true,
-				Description: "Exposes whether the domain mapping is managed by the user or by Code Engine.",
+				Description: "Specifies whether the domain mapping is managed by the user or by Code Engine.",
 			},
-			"visibility": &schema.Schema{
+			"visibility": {
 				Type:        schema.TypeString,
 				Computed:    true,
-				Description: "Exposes whether the domain mapping is reachable through the public internet, or private IBM network, or only through other components within the same Code Engine project.",
+				Description: "Specifies whether the domain mapping is reachable through the public internet, or private IBM network, or only through other components within the same Code Engine project.",
 			},
-			"etag": &schema.Schema{
+			"etag": {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
@@ -181,7 +185,9 @@ func ResourceIbmCodeEngineDomainMappingValidator() *validate.ResourceValidator {
 func resourceIbmCodeEngineDomainMappingCreate(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	codeEngineClient, err := meta.(conns.ClientSession).CodeEngineV2()
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.TerraformErrorf(err, err.Error(), "ibm_code_engine_domain_mapping", "create")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	createDomainMappingOptions := &codeenginev2.CreateDomainMappingOptions{}
@@ -195,18 +201,20 @@ func resourceIbmCodeEngineDomainMappingCreate(context context.Context, d *schema
 	createDomainMappingOptions.SetName(d.Get("name").(string))
 	createDomainMappingOptions.SetTlsSecret(d.Get("tls_secret").(string))
 
-	domainMapping, response, err := codeEngineClient.CreateDomainMappingWithContext(context, createDomainMappingOptions)
+	domainMapping, _, err := codeEngineClient.CreateDomainMappingWithContext(context, createDomainMappingOptions)
 	if err != nil {
-		log.Printf("[DEBUG] CreateDomainMappingWithContext failed %s\n%s", err, response)
-		return diag.FromErr(fmt.Errorf("CreateDomainMappingWithContext failed %s\n%s", err, response))
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("CreateDomainMappingWithContext failed: %s", err.Error()), "ibm_code_engine_domain_mapping", "create")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	d.SetId(fmt.Sprintf("%s/%s", *createDomainMappingOptions.ProjectID, *domainMapping.Name))
 
 	_, err = waitForIbmCodeEngineDomainMappingCreate(d, meta)
 	if err != nil {
-		return diag.FromErr(fmt.Errorf(
-			"Error waiting for resource IbmCodeEngineDomainMapping (%s) to be created: %s", d.Id(), err))
+		errMsg := fmt.Sprintf("Error waiting for resource IbmCodeEngineDomainMapping (%s) to be created: %s", d.Id(), err)
+		tfErr := flex.TerraformErrorf(err, errMsg, "ibm_code_engine_domain_mapping", "create")
+		return tfErr.GetDiag()
 	}
 
 	return resourceIbmCodeEngineDomainMappingRead(context, d, meta)
@@ -233,14 +241,15 @@ func waitForIbmCodeEngineDomainMappingCreate(d *schema.ResourceData, meta interf
 		Refresh: func() (interface{}, string, error) {
 			stateObj, response, err := codeEngineClient.GetDomainMapping(getDomainMappingOptions)
 			if err != nil {
-				if apiErr, ok := err.(bmxerror.RequestFailure); ok && apiErr.StatusCode() == 404 {
-					return nil, "", fmt.Errorf("The instance %s does not exist anymore: %s\n%s", "getDomainMappingOptions", err, response)
+				if sdkErr, ok := err.(*core.SDKProblem); ok && response.GetStatusCode() == 404 {
+					sdkErr.Summary = fmt.Sprintf("The instance %s does not exist anymore: %s", "getDomainMappingOptions", err)
+					return nil, "", sdkErr
 				}
 				return nil, "", err
 			}
 			failStates := map[string]bool{"failure": true, "failed": true}
 			if failStates[*stateObj.Status] {
-				return stateObj, *stateObj.Status, fmt.Errorf("The instance %s failed: %s\n%s", "getDomainMappingOptions", err, response)
+				return stateObj, *stateObj.Status, fmt.Errorf("the instance %s failed: %s", "getDomainMappingOptions", err)
 			}
 			return stateObj, *stateObj.Status, nil
 		},
@@ -255,14 +264,17 @@ func waitForIbmCodeEngineDomainMappingCreate(d *schema.ResourceData, meta interf
 func resourceIbmCodeEngineDomainMappingRead(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	codeEngineClient, err := meta.(conns.ClientSession).CodeEngineV2()
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.TerraformErrorf(err, err.Error(), "ibm_code_engine_domain_mapping", "read")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	getDomainMappingOptions := &codeenginev2.GetDomainMappingOptions{}
 
 	parts, err := flex.SepIdParts(d.Id(), "/")
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.TerraformErrorf(err, err.Error(), "ibm_code_engine_domain_mapping", "read")
+		return tfErr.GetDiag()
 	}
 
 	getDomainMappingOptions.SetProjectID(parts[0])
@@ -274,57 +286,63 @@ func resourceIbmCodeEngineDomainMappingRead(context context.Context, d *schema.R
 			d.SetId("")
 			return nil
 		}
-		log.Printf("[DEBUG] GetDomainMappingWithContext failed %s\n%s", err, response)
-		return diag.FromErr(fmt.Errorf("GetDomainMappingWithContext failed %s\n%s", err, response))
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("GetDomainMappingWithContext failed: %s", err.Error()), "ibm_code_engine_domain_mapping", "read")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	if err = d.Set("project_id", domainMapping.ProjectID); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting project_id: %s", err))
+		return diag.FromErr(fmt.Errorf("error setting project_id: %s", err))
 	}
 	componentMap, err := resourceIbmCodeEngineDomainMappingComponentRefToMap(domainMapping.Component)
 	if err != nil {
 		return diag.FromErr(err)
 	}
 	if err = d.Set("component", []map[string]interface{}{componentMap}); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting component: %s", err))
+		return diag.FromErr(fmt.Errorf("error setting component: %s", err))
 	}
 	if err = d.Set("name", domainMapping.Name); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting name: %s", err))
+		return diag.FromErr(fmt.Errorf("error setting name: %s", err))
 	}
 	if err = d.Set("tls_secret", domainMapping.TlsSecret); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting tls_secret: %s", err))
+		return diag.FromErr(fmt.Errorf("error setting tls_secret: %s", err))
 	}
 	if !core.IsNil(domainMapping.CnameTarget) {
 		if err = d.Set("cname_target", domainMapping.CnameTarget); err != nil {
-			return diag.FromErr(fmt.Errorf("Error setting cname_target: %s", err))
+			return diag.FromErr(fmt.Errorf("error setting cname_target: %s", err))
 		}
 	}
 	if !core.IsNil(domainMapping.CreatedAt) {
 		if err = d.Set("created_at", domainMapping.CreatedAt); err != nil {
-			return diag.FromErr(fmt.Errorf("Error setting created_at: %s", err))
+			return diag.FromErr(fmt.Errorf("error setting created_at: %s", err))
 		}
 	}
 	if err = d.Set("entity_tag", domainMapping.EntityTag); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting entity_tag: %s", err))
+		return diag.FromErr(fmt.Errorf("error setting entity_tag: %s", err))
 	}
 	if !core.IsNil(domainMapping.Href) {
 		if err = d.Set("href", domainMapping.Href); err != nil {
-			return diag.FromErr(fmt.Errorf("Error setting href: %s", err))
+			return diag.FromErr(fmt.Errorf("error setting href: %s", err))
 		}
 	}
 	if !core.IsNil(domainMapping.ID) {
 		if err = d.Set("domain_mapping_id", domainMapping.ID); err != nil {
-			return diag.FromErr(fmt.Errorf("Error setting domain_mapping_id: %s", err))
+			return diag.FromErr(fmt.Errorf("error setting domain_mapping_id: %s", err))
+		}
+	}
+	if !core.IsNil(domainMapping.Region) {
+		if err = d.Set("region", domainMapping.Region); err != nil {
+			return diag.FromErr(fmt.Errorf("error setting region: %s", err))
 		}
 	}
 	if !core.IsNil(domainMapping.ResourceType) {
 		if err = d.Set("resource_type", domainMapping.ResourceType); err != nil {
-			return diag.FromErr(fmt.Errorf("Error setting resource_type: %s", err))
+			return diag.FromErr(fmt.Errorf("error setting resource_type: %s", err))
 		}
 	}
 	if !core.IsNil(domainMapping.Status) {
 		if err = d.Set("status", domainMapping.Status); err != nil {
-			return diag.FromErr(fmt.Errorf("Error setting status: %s", err))
+			return diag.FromErr(fmt.Errorf("error setting status: %s", err))
 		}
 	}
 	if !core.IsNil(domainMapping.StatusDetails) {
@@ -333,21 +351,22 @@ func resourceIbmCodeEngineDomainMappingRead(context context.Context, d *schema.R
 			return diag.FromErr(err)
 		}
 		if err = d.Set("status_details", []map[string]interface{}{statusDetailsMap}); err != nil {
-			return diag.FromErr(fmt.Errorf("Error setting status_details: %s", err))
+			return diag.FromErr(fmt.Errorf("error setting status_details: %s", err))
 		}
 	}
 	if !core.IsNil(domainMapping.UserManaged) {
 		if err = d.Set("user_managed", domainMapping.UserManaged); err != nil {
-			return diag.FromErr(fmt.Errorf("Error setting user_managed: %s", err))
+			return diag.FromErr(fmt.Errorf("error setting user_managed: %s", err))
 		}
 	}
 	if !core.IsNil(domainMapping.Visibility) {
 		if err = d.Set("visibility", domainMapping.Visibility); err != nil {
-			return diag.FromErr(fmt.Errorf("Error setting visibility: %s", err))
+			return diag.FromErr(fmt.Errorf("error setting visibility: %s", err))
 		}
 	}
 	if err = d.Set("etag", response.Headers.Get("Etag")); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting etag: %s", err))
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("Error setting etag: %s", err), "ibm_code_engine_domain_mapping", "read")
+		return tfErr.GetDiag()
 	}
 
 	return nil
@@ -356,14 +375,17 @@ func resourceIbmCodeEngineDomainMappingRead(context context.Context, d *schema.R
 func resourceIbmCodeEngineDomainMappingUpdate(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	codeEngineClient, err := meta.(conns.ClientSession).CodeEngineV2()
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.TerraformErrorf(err, err.Error(), "ibm_code_engine_domain_mapping", "update")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	updateDomainMappingOptions := &codeenginev2.UpdateDomainMappingOptions{}
 
 	parts, err := flex.SepIdParts(d.Id(), "/")
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.TerraformErrorf(err, err.Error(), "ibm_code_engine_domain_mapping", "update")
+		return tfErr.GetDiag()
 	}
 
 	updateDomainMappingOptions.SetProjectID(parts[0])
@@ -373,12 +395,10 @@ func resourceIbmCodeEngineDomainMappingUpdate(context context.Context, d *schema
 
 	patchVals := &codeenginev2.DomainMappingPatch{}
 	if d.HasChange("project_id") {
-		return diag.FromErr(fmt.Errorf("Cannot update resource property \"%s\" with the ForceNew annotation."+
-			" The resource must be re-created to update this property.", "project_id"))
-	}
-	if d.HasChange("name") {
-		return diag.FromErr(fmt.Errorf("Cannot update resource property \"%s\" with the ForceNew annotation."+
-			" The resource must be re-created to update this property.", "name"))
+		errMsg := fmt.Sprintf("Cannot update resource property \"%s\" with the ForceNew annotation."+
+			" The resource must be re-created to update this property.", "project_id")
+		tfErr := flex.TerraformErrorf(err, errMsg, "ibm_code_engine_domain_mapping", "update")
+		return tfErr.GetDiag()
 	}
 	if d.HasChange("component") {
 		component, err := resourceIbmCodeEngineDomainMappingMapToComponentRef(d.Get("component.0").(map[string]interface{}))
@@ -397,10 +417,11 @@ func resourceIbmCodeEngineDomainMappingUpdate(context context.Context, d *schema
 
 	if hasChange {
 		updateDomainMappingOptions.DomainMapping, _ = patchVals.AsPatch()
-		_, response, err := codeEngineClient.UpdateDomainMappingWithContext(context, updateDomainMappingOptions)
+		_, _, err = codeEngineClient.UpdateDomainMappingWithContext(context, updateDomainMappingOptions)
 		if err != nil {
-			log.Printf("[DEBUG] UpdateDomainMappingWithContext failed %s\n%s", err, response)
-			return diag.FromErr(fmt.Errorf("UpdateDomainMappingWithContext failed %s\n%s", err, response))
+			tfErr := flex.TerraformErrorf(err, fmt.Sprintf("UpdateDomainMappingWithContext failed: %s", err.Error()), "ibm_code_engine_domain_mapping", "update")
+			log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+			return tfErr.GetDiag()
 		}
 	}
 
@@ -410,23 +431,27 @@ func resourceIbmCodeEngineDomainMappingUpdate(context context.Context, d *schema
 func resourceIbmCodeEngineDomainMappingDelete(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	codeEngineClient, err := meta.(conns.ClientSession).CodeEngineV2()
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.TerraformErrorf(err, err.Error(), "ibm_code_engine_domain_mapping", "delete")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	deleteDomainMappingOptions := &codeenginev2.DeleteDomainMappingOptions{}
 
 	parts, err := flex.SepIdParts(d.Id(), "/")
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.TerraformErrorf(err, err.Error(), "ibm_code_engine_domain_mapping", "delete")
+		return tfErr.GetDiag()
 	}
 
 	deleteDomainMappingOptions.SetProjectID(parts[0])
 	deleteDomainMappingOptions.SetName(parts[1])
 
-	response, err := codeEngineClient.DeleteDomainMappingWithContext(context, deleteDomainMappingOptions)
+	_, err = codeEngineClient.DeleteDomainMappingWithContext(context, deleteDomainMappingOptions)
 	if err != nil {
-		log.Printf("[DEBUG] DeleteDomainMappingWithContext failed %s\n%s", err, response)
-		return diag.FromErr(fmt.Errorf("DeleteDomainMappingWithContext failed %s\n%s", err, response))
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("DeleteDomainMappingWithContext failed: %s", err.Error()), "ibm_code_engine_domain_mapping", "delete")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	d.SetId("")

--- a/ibm/service/codeengine/resource_ibm_code_engine_domain_mapping_test.go
+++ b/ibm/service/codeengine/resource_ibm_code_engine_domain_mapping_test.go
@@ -4,12 +4,11 @@
 package codeengine_test
 
 import (
-	"encoding/base64"
 	"fmt"
+	"os"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
-
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 
@@ -17,11 +16,6 @@ import (
 	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/conns"
 	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/flex"
 	"github.com/IBM/code-engine-go-sdk/codeenginev2"
-)
-
-const (
-	CeTlsCert = "IBM_CODE_ENGINE_TLS_CERT"
-	CeTlsKey  = "IBM_CODE_ENGINE_TLS_KEY"
 )
 
 func TestAccIbmCodeEngineDomainMappingBasic(t *testing.T) {
@@ -33,8 +27,8 @@ func TestAccIbmCodeEngineDomainMappingBasic(t *testing.T) {
 
 	projectID := acc.CeProjectId
 	domainMappingName := acc.CeDomainMappingName
-	domainMappingTLSKey := decodeBase64EnvVar(acc.CeTLSKey, CeTlsKey)
-	domainMappingTLSCert := decodeBase64EnvVar(acc.CeTLSCert, CeTlsCert)
+	domainMappingTLSKey, _ := os.ReadFile(acc.CeTLSKeyFilePath)
+	domainMappingTLSCert, _ := os.ReadFile(acc.CeTLSCertFilePath)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { acc.TestAccPreCheckCodeEngine(t) },
@@ -42,7 +36,7 @@ func TestAccIbmCodeEngineDomainMappingBasic(t *testing.T) {
 		CheckDestroy: testAccCheckIbmCodeEngineDomainMappingDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckIbmCodeEngineDomainMappingConfigBasic(projectID, app1Name, app2Name, domainMappingTLSKey, domainMappingTLSCert, secretName, app1Name, domainMappingName, "app1_instance"),
+				Config: testAccCheckIbmCodeEngineDomainMappingConfigBasic(projectID, app1Name, app2Name, string(domainMappingTLSKey), string(domainMappingTLSCert), secretName, app1Name, domainMappingName, "app1_instance"),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckIbmCodeEngineDomainMappingExists("ibm_code_engine_domain_mapping.code_engine_domain_mapping_instance", conf),
 					resource.TestCheckResourceAttrSet("ibm_code_engine_domain_mapping.code_engine_domain_mapping_instance", "id"),
@@ -60,7 +54,7 @@ func TestAccIbmCodeEngineDomainMappingBasic(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccCheckIbmCodeEngineDomainMappingConfigBasic(projectID, app1Name, app2Name, domainMappingTLSKey, domainMappingTLSCert, secretName, app2Name, domainMappingName, "app2_instance"),
+				Config: testAccCheckIbmCodeEngineDomainMappingConfigBasic(projectID, app1Name, app2Name, string(domainMappingTLSKey), string(domainMappingTLSCert), secretName, app2Name, domainMappingName, "app2_instance"),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttrSet("ibm_code_engine_domain_mapping.code_engine_domain_mapping_instance", "id"),
 					resource.TestCheckResourceAttrSet("ibm_code_engine_domain_mapping.code_engine_domain_mapping_instance", "href"),
@@ -80,7 +74,7 @@ func TestAccIbmCodeEngineDomainMappingBasic(t *testing.T) {
 	})
 }
 
-func testAccCheckIbmCodeEngineDomainMappingConfigBasic(projectID string, app1Name string, app2Name string, tlsKey string, tslCert string, secretName string, componentRefName string, domainMappingName string, dependsOn string) string {
+func testAccCheckIbmCodeEngineDomainMappingConfigBasic(projectID string, app1Name string, app2Name string, tlsKey string, tlsCert string, secretName string, componentRefName string, domainMappingName string, dependsOn string) string {
 	return fmt.Sprintf(`
 		data "ibm_code_engine_project" "code_engine_project_instance" {
 			project_id = "%s"
@@ -93,7 +87,9 @@ func testAccCheckIbmCodeEngineDomainMappingConfigBasic(projectID string, app1Nam
 
 			lifecycle {
 				ignore_changes = [
-					run_env_variables
+					run_env_variables,
+					probe_liveness,
+					probe_readiness
 				]
 			}
 		}
@@ -105,7 +101,9 @@ func testAccCheckIbmCodeEngineDomainMappingConfigBasic(projectID string, app1Nam
 
 			lifecycle {
 				ignore_changes = [
-					run_env_variables
+					run_env_variables,
+					probe_liveness,
+					probe_readiness
 				]
 			}
 		}
@@ -142,7 +140,7 @@ EOT
     			ibm_code_engine_app.code_engine_%s
   			]
 		}
-	`, projectID, app1Name, app2Name, tlsKey, tslCert, secretName, componentRefName, domainMappingName, dependsOn)
+	`, projectID, app1Name, app2Name, tlsKey, tlsCert, secretName, componentRefName, domainMappingName, dependsOn)
 }
 
 func testAccCheckIbmCodeEngineDomainMappingExists(n string, obj codeenginev2.DomainMapping) resource.TestCheckFunc {
@@ -209,13 +207,4 @@ func testAccCheckIbmCodeEngineDomainMappingDestroy(s *terraform.State) error {
 	}
 
 	return nil
-}
-
-func decodeBase64EnvVar(base64Text string, envVar string) string {
-	decodedText, err := base64.StdEncoding.DecodeString(base64Text)
-	if err != nil {
-		// fmt.Errorf("Error decoding environment variable %s: %s", envVar, err)
-		return ""
-	}
-	return string(decodedText)
 }

--- a/ibm/service/codeengine/resource_ibm_code_engine_job.go
+++ b/ibm/service/codeengine/resource_ibm_code_engine_job.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2023 All Rights Reserved.
+// Copyright IBM Corp. 2024 All Rights Reserved.
 // Licensed under the Mozilla Public License v2.0
 
 package codeengine
@@ -27,86 +27,83 @@ func ResourceIbmCodeEngineJob() *schema.Resource {
 		Importer:      &schema.ResourceImporter{},
 
 		Schema: map[string]*schema.Schema{
-			"project_id": &schema.Schema{
+			"project_id": {
 				Type:         schema.TypeString,
 				Required:     true,
 				ForceNew:     true,
 				ValidateFunc: validate.InvokeValidator("ibm_code_engine_job", "project_id"),
 				Description:  "The ID of the project.",
 			},
-			"image_reference": &schema.Schema{
+			"image_reference": {
 				Type:         schema.TypeString,
 				Required:     true,
 				ValidateFunc: validate.InvokeValidator("ibm_code_engine_job", "image_reference"),
 				Description:  "The name of the image that is used for this job. The format is `REGISTRY/NAMESPACE/REPOSITORY:TAG` where `REGISTRY` and `TAG` are optional. If `REGISTRY` is not specified, the default is `docker.io`. If `TAG` is not specified, the default is `latest`. If the image reference points to a registry that requires authentication, make sure to also specify the property `image_secret`.",
 			},
-			"name": &schema.Schema{
-				Type:         schema.TypeString,
-				Required:     true,
-				ForceNew:     true,
-				ValidateFunc: validate.InvokeValidator("ibm_code_engine_job", "name"),
-				Description:  "The name of the job. Use a name that is unique within the project.",
-			},
-			"image_secret": &schema.Schema{
+			"image_secret": {
 				Type:         schema.TypeString,
 				Optional:     true,
 				ValidateFunc: validate.InvokeValidator("ibm_code_engine_job", "image_secret"),
 				Description:  "The name of the image registry access secret. The image registry access secret is used to authenticate with a private registry when you download the container image. If the image reference points to a registry that requires authentication, the job / job runs will be created but submitted job runs will fail, until this property is provided, too. This property must not be set on a job run, which references a job template.",
 			},
-			"run_arguments": &schema.Schema{
+			"name": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: validate.InvokeValidator("ibm_code_engine_job", "name"),
+				Description:  "The name of the job.",
+			},
+			"run_arguments": {
 				Type:        schema.TypeList,
 				Optional:    true,
-				MinItems:    0,
 				Description: "Set arguments for the job that are passed to start job run containers. If not specified an empty string array will be applied and the arguments specified by the container image, will be used to start the container.",
 				Elem:        &schema.Schema{Type: schema.TypeString},
 			},
-			"run_as_user": &schema.Schema{
+			"run_as_user": {
 				Type:        schema.TypeInt,
 				Optional:    true,
 				Default:     0,
-				Description: "The user ID (UID) to run the application (e.g., 1001).",
+				Description: "The user ID (UID) to run the job.",
 			},
-			"run_commands": &schema.Schema{
+			"run_commands": {
 				Type:        schema.TypeList,
 				Optional:    true,
-				MinItems:    0,
 				Description: "Set commands for the job that are passed to start job run containers. If not specified an empty string array will be applied and the command specified by the container image, will be used to start the container.",
 				Elem:        &schema.Schema{Type: schema.TypeString},
 			},
-			"run_env_variables": &schema.Schema{
+			"run_env_variables": {
 				Type:        schema.TypeList,
 				Optional:    true,
-				MinItems:    0,
-				Description: "Optional references to config maps, secrets or a literal values.",
+				Description: "References to config maps, secrets or literal values, which are exposed as environment variables in the job run.",
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
-						"key": &schema.Schema{
+						"key": {
 							Type:        schema.TypeString,
 							Optional:    true,
 							Description: "The key to reference as environment variable.",
 						},
-						"name": &schema.Schema{
+						"name": {
 							Type:        schema.TypeString,
 							Optional:    true,
 							Description: "The name of the environment variable.",
 						},
-						"prefix": &schema.Schema{
+						"prefix": {
 							Type:        schema.TypeString,
 							Optional:    true,
 							Description: "A prefix that can be added to all keys of a full secret or config map reference.",
 						},
-						"reference": &schema.Schema{
+						"reference": {
 							Type:        schema.TypeString,
 							Optional:    true,
 							Description: "The name of the secret or config map.",
 						},
-						"type": &schema.Schema{
+						"type": {
 							Type:        schema.TypeString,
 							Optional:    true,
 							Default:     "literal",
 							Description: "Specify the type of the environment variable.",
 						},
-						"value": &schema.Schema{
+						"value": {
 							Type:        schema.TypeString,
 							Optional:    true,
 							Description: "The literal value of the environment variable.",
@@ -114,43 +111,42 @@ func ResourceIbmCodeEngineJob() *schema.Resource {
 					},
 				},
 			},
-			"run_mode": &schema.Schema{
+			"run_mode": {
 				Type:         schema.TypeString,
 				Optional:     true,
 				Default:      "task",
 				ValidateFunc: validate.InvokeValidator("ibm_code_engine_job", "run_mode"),
-				Description:  "The mode for runs of the job. Valid values are `task` and `daemon`. In `task` mode, the `scale_max_execution_time` and `scale_retry_limit` properties apply. In `daemon` mode, since there is no timeout and failed instances are restarted indefinitely, the `scale_max_execution_time` and `scale_retry_limit` properties are not allowed.",
+				Description:  "The mode for runs of the job. Valid values are `task` and `daemon`. In `task` mode, the `max_execution_time` and `retry_limit` properties apply. In `daemon` mode, since there is no timeout and failed instances are restarted indefinitely, the `max_execution_time` and `retry_limit` properties are not allowed.",
 			},
-			"run_service_account": &schema.Schema{
+			"run_service_account": {
 				Type:         schema.TypeString,
 				Optional:     true,
 				Default:      "default",
 				ValidateFunc: validate.InvokeValidator("ibm_code_engine_job", "run_service_account"),
 				Description:  "The name of the service account. For built-in service accounts, you can use the shortened names `manager`, `none`, `reader`, and `writer`. This property must not be set on a job run, which references a job template.",
 			},
-			"run_volume_mounts": &schema.Schema{
+			"run_volume_mounts": {
 				Type:        schema.TypeList,
 				Optional:    true,
-				MinItems:    0,
-				Description: "Optional mounts of config maps or a secrets.",
+				Description: "Optional mounts of config maps or secrets.",
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
-						"mount_path": &schema.Schema{
+						"mount_path": {
 							Type:        schema.TypeString,
 							Required:    true,
 							Description: "The path that should be mounted.",
 						},
-						"name": &schema.Schema{
+						"name": {
 							Type:        schema.TypeString,
-							Optional:    true,
-							Description: "Optional name of the mount. If not set, it will be generated based on the `ref` and a random ID. In case the `ref` is longer than 58 characters, it will be cut off.",
+							Required:    true,
+							Description: "The name of the mount.",
 						},
-						"reference": &schema.Schema{
+						"reference": {
 							Type:        schema.TypeString,
 							Required:    true,
 							Description: "The name of the referenced secret or config map.",
 						},
-						"type": &schema.Schema{
+						"type": {
 							Type:        schema.TypeString,
 							Required:    true,
 							Description: "Specify the type of the volume mount. Allowed types are: 'config_map', 'secret'.",
@@ -158,72 +154,86 @@ func ResourceIbmCodeEngineJob() *schema.Resource {
 					},
 				},
 			},
-			"scale_array_spec": &schema.Schema{
+			"scale_array_spec": {
 				Type:         schema.TypeString,
 				Optional:     true,
-				Default:      "0",
 				ValidateFunc: validate.InvokeValidator("ibm_code_engine_job", "scale_array_spec"),
-				Description:  "Define a custom set of array indices as comma-separated list containing single values and hyphen-separated ranges like `5,12-14,23,27`. Each instance can pick up its array index via environment variable `JOB_INDEX`. The number of unique array indices specified here determines the number of job instances to run.",
+				Description:  "Define a custom set of array indices as a comma-separated list containing single values and hyphen-separated ranges, such as  5,12-14,23,27. Each instance gets its array index value from the environment variable JOB_INDEX. The number of unique array indices that you specify with this parameter determines the number of job instances to run.",
 			},
-			"scale_cpu_limit": &schema.Schema{
+			"scale_cpu_limit": {
 				Type:         schema.TypeString,
 				Optional:     true,
 				Default:      "1",
 				ValidateFunc: validate.InvokeValidator("ibm_code_engine_job", "scale_cpu_limit"),
 				Description:  "Optional amount of CPU set for the instance of the job. For valid values see [Supported memory and CPU combinations](https://cloud.ibm.com/docs/codeengine?topic=codeengine-mem-cpu-combo).",
 			},
-			"scale_ephemeral_storage_limit": &schema.Schema{
+			"scale_ephemeral_storage_limit": {
 				Type:         schema.TypeString,
 				Optional:     true,
 				Default:      "400M",
 				ValidateFunc: validate.InvokeValidator("ibm_code_engine_job", "scale_ephemeral_storage_limit"),
 				Description:  "Optional amount of ephemeral storage to set for the instance of the job. The amount specified as ephemeral storage, must not exceed the amount of `scale_memory_limit`. The units for specifying ephemeral storage are Megabyte (M) or Gigabyte (G), whereas G and M are the shorthand expressions for GB and MB. For more information see [Units of measurement](https://cloud.ibm.com/docs/codeengine?topic=codeengine-mem-cpu-combo#unit-measurements).",
 			},
-			"scale_max_execution_time": &schema.Schema{
+			"scale_max_execution_time": {
 				Type:        schema.TypeInt,
 				Optional:    true,
 				Default:     7200,
 				Description: "The maximum execution time in seconds for runs of the job. This property can only be specified if `run_mode` is `task`.",
 			},
-			"scale_memory_limit": &schema.Schema{
+			"scale_memory_limit": {
 				Type:         schema.TypeString,
 				Optional:     true,
 				Default:      "4G",
 				ValidateFunc: validate.InvokeValidator("ibm_code_engine_job", "scale_memory_limit"),
 				Description:  "Optional amount of memory set for the instance of the job. For valid values see [Supported memory and CPU combinations](https://cloud.ibm.com/docs/codeengine?topic=codeengine-mem-cpu-combo). The units for specifying memory are Megabyte (M) or Gigabyte (G), whereas G and M are the shorthand expressions for GB and MB. For more information see [Units of measurement](https://cloud.ibm.com/docs/codeengine?topic=codeengine-mem-cpu-combo#unit-measurements).",
 			},
-			"scale_retry_limit": &schema.Schema{
+			"scale_retry_limit": {
 				Type:        schema.TypeInt,
 				Optional:    true,
 				Default:     3,
 				Description: "The number of times to rerun an instance of the job before the job is marked as failed. This property can only be specified if `run_mode` is `task`.",
 			},
-			"created_at": &schema.Schema{
+			"build": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "Reference to a build that is associated with the job.",
+			},
+			"build_run": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "Reference to a build run that is associated with the job.",
+			},
+			"created_at": {
 				Type:        schema.TypeString,
 				Computed:    true,
 				Description: "The timestamp when the resource was created.",
 			},
-			"entity_tag": &schema.Schema{
+			"entity_tag": {
 				Type:        schema.TypeString,
 				Computed:    true,
 				Description: "The version of the job instance, which is used to achieve optimistic locking.",
 			},
-			"href": &schema.Schema{
+			"href": {
 				Type:        schema.TypeString,
 				Computed:    true,
 				Description: "When you provision a new job,  a URL is created identifying the location of the instance.",
 			},
-			"job_id": &schema.Schema{
+			"job_id": {
 				Type:        schema.TypeString,
 				Computed:    true,
 				Description: "The identifier of the resource.",
 			},
-			"resource_type": &schema.Schema{
+			"region": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The region of the project the resource is located in. Possible values: 'au-syd', 'br-sao', 'ca-tor', 'eu-de', 'eu-gb', 'jp-osa', 'jp-tok', 'us-east', 'us-south'.",
+			},
+			"resource_type": {
 				Type:        schema.TypeString,
 				Computed:    true,
 				Description: "The type of the job.",
 			},
-			"etag": &schema.Schema{
+			"etag": {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
@@ -253,15 +263,6 @@ func ResourceIbmCodeEngineJobValidator() *validate.ResourceValidator {
 			MaxValueLength:             256,
 		},
 		validate.ValidateSchema{
-			Identifier:                 "name",
-			ValidateFunctionIdentifier: validate.ValidateRegexpLen,
-			Type:                       validate.TypeString,
-			Required:                   true,
-			Regexp:                     `^[a-z0-9]([\-a-z0-9]*[a-z0-9])?$`,
-			MinValueLength:             1,
-			MaxValueLength:             63,
-		},
-		validate.ValidateSchema{
 			Identifier:                 "image_secret",
 			ValidateFunctionIdentifier: validate.ValidateRegexpLen,
 			Type:                       validate.TypeString,
@@ -269,6 +270,15 @@ func ResourceIbmCodeEngineJobValidator() *validate.ResourceValidator {
 			Regexp:                     `^[a-z0-9]([\-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([\-a-z0-9]*[a-z0-9])?)*$`,
 			MinValueLength:             1,
 			MaxValueLength:             253,
+		},
+		validate.ValidateSchema{
+			Identifier:                 "name",
+			ValidateFunctionIdentifier: validate.ValidateRegexpLen,
+			Type:                       validate.TypeString,
+			Required:                   true,
+			Regexp:                     `^[a-z0-9]([\-a-z0-9]*[a-z0-9])?$`,
+			MinValueLength:             1,
+			MaxValueLength:             63,
 		},
 		validate.ValidateSchema{
 			Identifier:                 "run_mode",
@@ -333,7 +343,9 @@ func ResourceIbmCodeEngineJobValidator() *validate.ResourceValidator {
 func resourceIbmCodeEngineJobCreate(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	codeEngineClient, err := meta.(conns.ClientSession).CodeEngineV2()
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.TerraformErrorf(err, err.Error(), "ibm_code_engine_job", "create")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	createJobOptions := &codeenginev2.CreateJobOptions{}
@@ -412,10 +424,11 @@ func resourceIbmCodeEngineJobCreate(context context.Context, d *schema.ResourceD
 		createJobOptions.SetScaleRetryLimit(int64(d.Get("scale_retry_limit").(int)))
 	}
 
-	job, response, err := codeEngineClient.CreateJobWithContext(context, createJobOptions)
+	job, _, err := codeEngineClient.CreateJobWithContext(context, createJobOptions)
 	if err != nil {
-		log.Printf("[DEBUG] CreateJobWithContext failed %s\n%s", err, response)
-		return diag.FromErr(fmt.Errorf("CreateJobWithContext failed %s\n%s", err, response))
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("CreateJobWithContext failed: %s", err.Error()), "ibm_code_engine_job", "create")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	d.SetId(fmt.Sprintf("%s/%s", *createJobOptions.ProjectID, *job.Name))
@@ -426,14 +439,17 @@ func resourceIbmCodeEngineJobCreate(context context.Context, d *schema.ResourceD
 func resourceIbmCodeEngineJobRead(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	codeEngineClient, err := meta.(conns.ClientSession).CodeEngineV2()
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.TerraformErrorf(err, err.Error(), "ibm_code_engine_job", "read")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	getJobOptions := &codeenginev2.GetJobOptions{}
 
 	parts, err := flex.SepIdParts(d.Id(), "/")
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.TerraformErrorf(err, err.Error(), "ibm_code_engine_job", "read")
+		return tfErr.GetDiag()
 	}
 
 	getJobOptions.SetProjectID(parts[0])
@@ -445,130 +461,147 @@ func resourceIbmCodeEngineJobRead(context context.Context, d *schema.ResourceDat
 			d.SetId("")
 			return nil
 		}
-		log.Printf("[DEBUG] GetJobWithContext failed %s\n%s", err, response)
-		return diag.FromErr(fmt.Errorf("GetJobWithContext failed %s\n%s", err, response))
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("GetJobWithContext failed: %s", err.Error()), "ibm_code_engine_job", "read")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	if err = d.Set("project_id", job.ProjectID); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting project_id: %s", err))
+		return diag.FromErr(fmt.Errorf("error setting project_id: %s", err))
 	}
 	if err = d.Set("image_reference", job.ImageReference); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting image_reference: %s", err))
-	}
-	if err = d.Set("name", job.Name); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting name: %s", err))
+		return diag.FromErr(fmt.Errorf("error setting image_reference: %s", err))
 	}
 	if !core.IsNil(job.ImageSecret) {
 		if err = d.Set("image_secret", job.ImageSecret); err != nil {
-			return diag.FromErr(fmt.Errorf("Error setting image_secret: %s", err))
+			return diag.FromErr(fmt.Errorf("error setting image_secret: %s", err))
 		}
+	}
+	if err = d.Set("name", job.Name); err != nil {
+		return diag.FromErr(fmt.Errorf("error setting name: %s", err))
 	}
 	if !core.IsNil(job.RunArguments) {
 		if err = d.Set("run_arguments", job.RunArguments); err != nil {
-			return diag.FromErr(fmt.Errorf("Error setting run_arguments: %s", err))
+			return diag.FromErr(fmt.Errorf("error setting run_arguments: %s", err))
 		}
 	}
 	if !core.IsNil(job.RunAsUser) {
 		if err = d.Set("run_as_user", flex.IntValue(job.RunAsUser)); err != nil {
-			return diag.FromErr(fmt.Errorf("Error setting run_as_user: %s", err))
+			return diag.FromErr(fmt.Errorf("error setting run_as_user: %s", err))
 		}
 	}
 	if !core.IsNil(job.RunCommands) {
 		if err = d.Set("run_commands", job.RunCommands); err != nil {
-			return diag.FromErr(fmt.Errorf("Error setting run_commands: %s", err))
+			return diag.FromErr(fmt.Errorf("error setting run_commands: %s", err))
 		}
 	}
 	if !core.IsNil(job.RunEnvVariables) {
 		runEnvVariables := []map[string]interface{}{}
 		for _, runEnvVariablesItem := range job.RunEnvVariables {
-			runEnvVariablesItemMap, err := resourceIbmCodeEngineJobEnvVarToMap(&runEnvVariablesItem)
+			runEnvVariablesItemMap, err := resourceIbmCodeEngineJobEnvVarToMap(&runEnvVariablesItem) /* #nosec G601 */
 			if err != nil {
 				return diag.FromErr(err)
 			}
 			runEnvVariables = append(runEnvVariables, runEnvVariablesItemMap)
 		}
 		if err = d.Set("run_env_variables", runEnvVariables); err != nil {
-			return diag.FromErr(fmt.Errorf("Error setting run_env_variables: %s", err))
+			return diag.FromErr(fmt.Errorf("error setting run_env_variables: %s", err))
 		}
 	}
 	if !core.IsNil(job.RunMode) {
 		if err = d.Set("run_mode", job.RunMode); err != nil {
-			return diag.FromErr(fmt.Errorf("Error setting run_mode: %s", err))
+			return diag.FromErr(fmt.Errorf("error setting run_mode: %s", err))
 		}
 	}
 	if !core.IsNil(job.RunServiceAccount) {
 		if err = d.Set("run_service_account", job.RunServiceAccount); err != nil {
-			return diag.FromErr(fmt.Errorf("Error setting run_service_account: %s", err))
+			return diag.FromErr(fmt.Errorf("error setting run_service_account: %s", err))
 		}
 	}
 	if !core.IsNil(job.RunVolumeMounts) {
 		runVolumeMounts := []map[string]interface{}{}
 		for _, runVolumeMountsItem := range job.RunVolumeMounts {
-			runVolumeMountsItemMap, err := resourceIbmCodeEngineJobVolumeMountToMap(&runVolumeMountsItem)
+			runVolumeMountsItemMap, err := resourceIbmCodeEngineJobVolumeMountToMap(&runVolumeMountsItem) /* #nosec G601 */
 			if err != nil {
 				return diag.FromErr(err)
 			}
 			runVolumeMounts = append(runVolumeMounts, runVolumeMountsItemMap)
 		}
 		if err = d.Set("run_volume_mounts", runVolumeMounts); err != nil {
-			return diag.FromErr(fmt.Errorf("Error setting run_volume_mounts: %s", err))
+			return diag.FromErr(fmt.Errorf("error setting run_volume_mounts: %s", err))
 		}
 	}
 	if !core.IsNil(job.ScaleArraySpec) {
 		if err = d.Set("scale_array_spec", job.ScaleArraySpec); err != nil {
-			return diag.FromErr(fmt.Errorf("Error setting scale_array_spec: %s", err))
+			return diag.FromErr(fmt.Errorf("error setting scale_array_spec: %s", err))
 		}
 	}
 	if !core.IsNil(job.ScaleCpuLimit) {
 		if err = d.Set("scale_cpu_limit", job.ScaleCpuLimit); err != nil {
-			return diag.FromErr(fmt.Errorf("Error setting scale_cpu_limit: %s", err))
+			return diag.FromErr(fmt.Errorf("error setting scale_cpu_limit: %s", err))
 		}
 	}
 	if !core.IsNil(job.ScaleEphemeralStorageLimit) {
 		if err = d.Set("scale_ephemeral_storage_limit", job.ScaleEphemeralStorageLimit); err != nil {
-			return diag.FromErr(fmt.Errorf("Error setting scale_ephemeral_storage_limit: %s", err))
+			return diag.FromErr(fmt.Errorf("error setting scale_ephemeral_storage_limit: %s", err))
 		}
 	}
 	if !core.IsNil(job.ScaleMaxExecutionTime) {
 		if err = d.Set("scale_max_execution_time", flex.IntValue(job.ScaleMaxExecutionTime)); err != nil {
-			return diag.FromErr(fmt.Errorf("Error setting scale_max_execution_time: %s", err))
+			return diag.FromErr(fmt.Errorf("error setting scale_max_execution_time: %s", err))
 		}
 	}
 	if !core.IsNil(job.ScaleMemoryLimit) {
 		if err = d.Set("scale_memory_limit", job.ScaleMemoryLimit); err != nil {
-			return diag.FromErr(fmt.Errorf("Error setting scale_memory_limit: %s", err))
+			return diag.FromErr(fmt.Errorf("error setting scale_memory_limit: %s", err))
 		}
 	}
 	if !core.IsNil(job.ScaleRetryLimit) {
 		if err = d.Set("scale_retry_limit", flex.IntValue(job.ScaleRetryLimit)); err != nil {
-			return diag.FromErr(fmt.Errorf("Error setting scale_retry_limit: %s", err))
+			return diag.FromErr(fmt.Errorf("error setting scale_retry_limit: %s", err))
+		}
+	}
+	if !core.IsNil(job.Build) {
+		if err = d.Set("build", job.Build); err != nil {
+			return diag.FromErr(fmt.Errorf("error setting build: %s", err))
+		}
+	}
+	if !core.IsNil(job.BuildRun) {
+		if err = d.Set("build_run", job.BuildRun); err != nil {
+			return diag.FromErr(fmt.Errorf("error setting build_run: %s", err))
 		}
 	}
 	if !core.IsNil(job.CreatedAt) {
 		if err = d.Set("created_at", job.CreatedAt); err != nil {
-			return diag.FromErr(fmt.Errorf("Error setting created_at: %s", err))
+			return diag.FromErr(fmt.Errorf("error setting created_at: %s", err))
 		}
 	}
 	if err = d.Set("entity_tag", job.EntityTag); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting entity_tag: %s", err))
+		return diag.FromErr(fmt.Errorf("error setting entity_tag: %s", err))
 	}
 	if !core.IsNil(job.Href) {
 		if err = d.Set("href", job.Href); err != nil {
-			return diag.FromErr(fmt.Errorf("Error setting href: %s", err))
+			return diag.FromErr(fmt.Errorf("error setting href: %s", err))
 		}
 	}
 	if !core.IsNil(job.ID) {
 		if err = d.Set("job_id", job.ID); err != nil {
-			return diag.FromErr(fmt.Errorf("Error setting job_id: %s", err))
+			return diag.FromErr(fmt.Errorf("error setting job_id: %s", err))
+		}
+	}
+	if !core.IsNil(job.Region) {
+		if err = d.Set("region", job.Region); err != nil {
+			return diag.FromErr(fmt.Errorf("error setting region: %s", err))
 		}
 	}
 	if !core.IsNil(job.ResourceType) {
 		if err = d.Set("resource_type", job.ResourceType); err != nil {
-			return diag.FromErr(fmt.Errorf("Error setting resource_type: %s", err))
+			return diag.FromErr(fmt.Errorf("error setting resource_type: %s", err))
 		}
 	}
 	if err = d.Set("etag", response.Headers.Get("Etag")); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting etag: %s", err))
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("Error setting etag: %s", err), "ibm_code_engine_job", "read")
+		return tfErr.GetDiag()
 	}
 
 	return nil
@@ -577,14 +610,17 @@ func resourceIbmCodeEngineJobRead(context context.Context, d *schema.ResourceDat
 func resourceIbmCodeEngineJobUpdate(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	codeEngineClient, err := meta.(conns.ClientSession).CodeEngineV2()
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.TerraformErrorf(err, err.Error(), "ibm_code_engine_job", "update")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	updateJobOptions := &codeenginev2.UpdateJobOptions{}
 
 	parts, err := flex.SepIdParts(d.Id(), "/")
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.TerraformErrorf(err, err.Error(), "ibm_code_engine_job", "update")
+		return tfErr.GetDiag()
 	}
 
 	updateJobOptions.SetProjectID(parts[0])
@@ -593,10 +629,15 @@ func resourceIbmCodeEngineJobUpdate(context context.Context, d *schema.ResourceD
 	hasChange := false
 
 	patchVals := &codeenginev2.JobPatch{}
-	if d.HasChange("image_reference") || d.HasChange("name") {
+	if d.HasChange("project_id") {
+		errMsg := fmt.Sprintf("Cannot update resource property \"%s\" with the ForceNew annotation."+
+			" The resource must be re-created to update this property.", "project_id")
+		tfErr := flex.TerraformErrorf(err, errMsg, "ibm_code_engine_job", "update")
+		return tfErr.GetDiag()
+	}
+	if d.HasChange("image_reference") {
 		newImageReference := d.Get("image_reference").(string)
 		patchVals.ImageReference = &newImageReference
-		updateJobOptions.SetName(d.Get("name").(string))
 		hasChange = true
 	}
 	if d.HasChange("image_secret") {
@@ -697,10 +738,11 @@ func resourceIbmCodeEngineJobUpdate(context context.Context, d *schema.ResourceD
 
 	if hasChange {
 		updateJobOptions.Job, _ = patchVals.AsPatch()
-		_, response, err := codeEngineClient.UpdateJobWithContext(context, updateJobOptions)
+		_, _, err = codeEngineClient.UpdateJobWithContext(context, updateJobOptions)
 		if err != nil {
-			log.Printf("[DEBUG] UpdateJobWithContext failed %s\n%s", err, response)
-			return diag.FromErr(fmt.Errorf("UpdateJobWithContext failed %s\n%s", err, response))
+			tfErr := flex.TerraformErrorf(err, fmt.Sprintf("UpdateJobWithContext failed: %s", err.Error()), "ibm_code_engine_job", "update")
+			log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+			return tfErr.GetDiag()
 		}
 	}
 
@@ -710,23 +752,27 @@ func resourceIbmCodeEngineJobUpdate(context context.Context, d *schema.ResourceD
 func resourceIbmCodeEngineJobDelete(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	codeEngineClient, err := meta.(conns.ClientSession).CodeEngineV2()
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.TerraformErrorf(err, err.Error(), "ibm_code_engine_job", "delete")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	deleteJobOptions := &codeenginev2.DeleteJobOptions{}
 
 	parts, err := flex.SepIdParts(d.Id(), "/")
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.TerraformErrorf(err, err.Error(), "ibm_code_engine_job", "delete")
+		return tfErr.GetDiag()
 	}
 
 	deleteJobOptions.SetProjectID(parts[0])
 	deleteJobOptions.SetName(parts[1])
 
-	response, err := codeEngineClient.DeleteJobWithContext(context, deleteJobOptions)
+	_, err = codeEngineClient.DeleteJobWithContext(context, deleteJobOptions)
 	if err != nil {
-		log.Printf("[DEBUG] DeleteJobWithContext failed %s\n%s", err, response)
-		return diag.FromErr(fmt.Errorf("DeleteJobWithContext failed %s\n%s", err, response))
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("DeleteJobWithContext failed: %s", err.Error()), "ibm_code_engine_job", "delete")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	d.SetId("")
@@ -782,9 +828,7 @@ func resourceIbmCodeEngineJobEnvVarToMap(model *codeenginev2.EnvVar) (map[string
 	if model.Reference != nil {
 		modelMap["reference"] = model.Reference
 	}
-	if model.Type != nil {
-		modelMap["type"] = model.Type
-	}
+	modelMap["type"] = model.Type
 	if model.Value != nil {
 		modelMap["value"] = model.Value
 	}
@@ -794,9 +838,7 @@ func resourceIbmCodeEngineJobEnvVarToMap(model *codeenginev2.EnvVar) (map[string
 func resourceIbmCodeEngineJobVolumeMountToMap(model *codeenginev2.VolumeMount) (map[string]interface{}, error) {
 	modelMap := make(map[string]interface{})
 	modelMap["mount_path"] = model.MountPath
-	if model.Name != nil {
-		modelMap["name"] = model.Name
-	}
+	modelMap["name"] = model.Name
 	modelMap["reference"] = model.Reference
 	modelMap["type"] = model.Type
 	return modelMap, nil

--- a/ibm/service/codeengine/resource_ibm_code_engine_job_test.go
+++ b/ibm/service/codeengine/resource_ibm_code_engine_job_test.go
@@ -155,6 +155,13 @@ func testAccCheckIbmCodeEngineJobConfigBasic(projectID string, name string, imag
 			project_id = data.ibm_code_engine_project.code_engine_project_instance.project_id
 			name = "%s"
 			image_reference = "%s"
+
+			lifecycle {
+				ignore_changes = [
+					run_env_variables,
+					scale_array_spec
+				]
+			}
 		}
 	`, projectID, name, imageReference)
 }
@@ -177,7 +184,15 @@ func testAccCheckIbmCodeEngineJobConfig(projectID string, name string, imageRefe
 			scale_max_execution_time = %s
 			scale_memory_limit = "%s"
 			scale_retry_limit = %s
+
+			lifecycle {
+				ignore_changes = [
+					run_env_variables,
+					scale_array_spec
+				]
+			}
 		}
+	
 	`, projectID, name, imageReference, runAsUser, runMode, runServiceAccount, scaleCpuLimit, scaleEphemeralStorageLimit, scaleMaxExecutionTime, scaleMemoryLimit, scaleRetryLimit)
 }
 

--- a/ibm/service/codeengine/resource_ibm_code_engine_project.go
+++ b/ibm/service/codeengine/resource_ibm_code_engine_project.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2023 All Rights Reserved.
+// Copyright IBM Corp. 2024 All Rights Reserved.
 // Licensed under the Mozilla Public License v2.0
 
 package codeengine
@@ -13,8 +13,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 
-	"github.com/IBM-Cloud/bluemix-go/bmxerror"
 	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/conns"
+	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/flex"
 	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/validate"
 	"github.com/IBM/code-engine-go-sdk/codeenginev2"
 	"github.com/IBM/go-sdk-core/v5/core"
@@ -26,65 +26,64 @@ func ResourceIbmCodeEngineProject() *schema.Resource {
 		ReadContext:   resourceIbmCodeEngineProjectRead,
 		DeleteContext: resourceIbmCodeEngineProjectDelete,
 		Importer:      &schema.ResourceImporter{},
-
 		Timeouts: &schema.ResourceTimeout{
 			Create: schema.DefaultTimeout(10 * time.Minute),
 		},
 
 		Schema: map[string]*schema.Schema{
-			"name": &schema.Schema{
+			"name": {
 				Type:         schema.TypeString,
 				Required:     true,
 				ForceNew:     true,
 				ValidateFunc: validate.InvokeValidator("ibm_code_engine_project", "name"),
 				Description:  "The name of the project.",
 			},
-			"project_id": &schema.Schema{
+			"project_id": {
 				Type:        schema.TypeString,
 				Computed:    true,
 				Description: "The ID of the project.",
 			},
-			"resource_group_id": &schema.Schema{
+			"resource_group_id": {
 				Type:         schema.TypeString,
 				Optional:     true,
 				ForceNew:     true,
 				ValidateFunc: validate.InvokeValidator("ibm_code_engine_project", "resource_group_id"),
-				Description:  "Optional ID of the resource group for your project deployment. If this field is not defined, the default resource group of the account will be used.",
+				Description:  "The ID of the resource group.",
 			},
-			"account_id": &schema.Schema{
+			"account_id": {
 				Type:        schema.TypeString,
 				Computed:    true,
 				Description: "An alphanumeric value identifying the account ID.",
 			},
-			"created_at": &schema.Schema{
+			"created_at": {
 				Type:        schema.TypeString,
 				Computed:    true,
 				Description: "The timestamp when the project was created.",
 			},
-			"crn": &schema.Schema{
+			"crn": {
 				Type:        schema.TypeString,
 				Computed:    true,
 				Description: "The CRN of the project.",
 			},
-			"href": &schema.Schema{
+			"href": {
 				Type:        schema.TypeString,
 				Computed:    true,
 				Description: "When you provision a new resource, a URL is created identifying the location of the instance.",
 			},
-			"region": &schema.Schema{
+			"region": {
 				Type:        schema.TypeString,
 				Computed:    true,
 				Description: "The region for your project deployment. Possible values: 'au-syd', 'br-sao', 'ca-tor', 'eu-de', 'eu-gb', 'jp-osa', 'jp-tok', 'us-east', 'us-south'.",
 			},
-			"resource_type": &schema.Schema{
+			"resource_type": {
 				Type:        schema.TypeString,
 				Computed:    true,
 				Description: "The type of the project.",
 			},
-			"status": &schema.Schema{
+			"status": {
 				Type:        schema.TypeString,
 				Computed:    true,
-				Description: "The current state of the project. For example, if the project is created and ready to get used, it will return active.",
+				Description: "The current state of the project. For example, when the project is created and is ready for use, the status of the project is active.",
 			},
 		},
 	}
@@ -120,7 +119,9 @@ func ResourceIbmCodeEngineProjectValidator() *validate.ResourceValidator {
 func resourceIbmCodeEngineProjectCreate(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	codeEngineClient, err := meta.(conns.ClientSession).CodeEngineV2()
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.TerraformErrorf(err, err.Error(), "ibm_code_engine_project", "create")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	createProjectOptions := &codeenginev2.CreateProjectOptions{}
@@ -129,19 +130,29 @@ func resourceIbmCodeEngineProjectCreate(context context.Context, d *schema.Resou
 	if _, ok := d.GetOk("resource_group_id"); ok {
 		createProjectOptions.SetResourceGroupID(d.Get("resource_group_id").(string))
 	}
+	if _, ok := d.GetOk("tags"); ok {
+		var tags []string
+		for _, v := range d.Get("tags").([]interface{}) {
+			tagsItem := v.(string)
+			tags = append(tags, tagsItem)
+		}
+		createProjectOptions.SetTags(tags)
+	}
 
-	project, response, err := codeEngineClient.CreateProjectWithContext(context, createProjectOptions)
+	project, _, err := codeEngineClient.CreateProjectWithContext(context, createProjectOptions)
 	if err != nil {
-		log.Printf("[DEBUG] CreateProjectWithContext failed %s\n%s", err, response)
-		return diag.FromErr(fmt.Errorf("CreateProjectWithContext failed %s\n%s", err, response))
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("CreateProjectWithContext failed: %s", err.Error()), "ibm_code_engine_project", "create")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	d.SetId(*project.ID)
 
 	_, err = waitForIbmCodeEngineProjectCreate(d, meta)
 	if err != nil {
-		return diag.FromErr(fmt.Errorf(
-			"Error waiting for resource IbmCodeEngineProject (%s) to be created: %s", d.Id(), err))
+		errMsg := fmt.Sprintf("Error waiting for resource IbmCodeEngineProject (%s) to be created: %s", d.Id(), err)
+		tfErr := flex.TerraformErrorf(err, errMsg, "ibm_code_engine_project", "create")
+		return tfErr.GetDiag()
 	}
 
 	return resourceIbmCodeEngineProjectRead(context, d, meta)
@@ -162,14 +173,15 @@ func waitForIbmCodeEngineProjectCreate(d *schema.ResourceData, meta interface{})
 		Refresh: func() (interface{}, string, error) {
 			stateObj, response, err := codeEngineClient.GetProject(getProjectOptions)
 			if err != nil {
-				if apiErr, ok := err.(bmxerror.RequestFailure); ok && apiErr.StatusCode() == 404 {
-					return nil, "", fmt.Errorf("The instance %s does not exist anymore: %s\n%s", "getProjectOptions", err, response)
+				if sdkErr, ok := err.(*core.SDKProblem); ok && response.GetStatusCode() == 404 {
+					sdkErr.Summary = fmt.Sprintf("The instance %s does not exist anymore: %s", "getProjectOptions", err)
+					return nil, "", sdkErr
 				}
 				return nil, "", err
 			}
 			failStates := map[string]bool{"creation_failed": true}
 			if failStates[*stateObj.Status] {
-				return stateObj, *stateObj.Status, fmt.Errorf("The instance %s failed: %s\n%s", "getProjectOptions", err, response)
+				return stateObj, *stateObj.Status, fmt.Errorf("the instance %s failed: %s", "getProjectOptions", err)
 			}
 			return stateObj, *stateObj.Status, nil
 		},
@@ -184,7 +196,9 @@ func waitForIbmCodeEngineProjectCreate(d *schema.ResourceData, meta interface{})
 func resourceIbmCodeEngineProjectRead(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	codeEngineClient, err := meta.(conns.ClientSession).CodeEngineV2()
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.TerraformErrorf(err, err.Error(), "ibm_code_engine_project", "read")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	getProjectOptions := &codeenginev2.GetProjectOptions{}
@@ -197,54 +211,55 @@ func resourceIbmCodeEngineProjectRead(context context.Context, d *schema.Resourc
 			d.SetId("")
 			return nil
 		}
-		log.Printf("[DEBUG] GetProjectWithContext failed %s\n%s", err, response)
-		return diag.FromErr(fmt.Errorf("GetProjectWithContext failed %s\n%s", err, response))
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("GetProjectWithContext failed: %s", err.Error()), "ibm_code_engine_project", "read")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	if err = d.Set("name", project.Name); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting name: %s", err))
+		return diag.FromErr(fmt.Errorf("error setting name: %s", err))
 	}
 	if err = d.Set("project_id", project.ID); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting project_id: %s", err))
+		return diag.FromErr(fmt.Errorf("error setting project_id: %s", err))
 	}
 	if !core.IsNil(project.ResourceGroupID) {
 		if err = d.Set("resource_group_id", project.ResourceGroupID); err != nil {
-			return diag.FromErr(fmt.Errorf("Error setting resource_group_id: %s", err))
+			return diag.FromErr(fmt.Errorf("error setting resource_group_id: %s", err))
 		}
 	}
 	if !core.IsNil(project.AccountID) {
 		if err = d.Set("account_id", project.AccountID); err != nil {
-			return diag.FromErr(fmt.Errorf("Error setting account_id: %s", err))
+			return diag.FromErr(fmt.Errorf("error setting account_id: %s", err))
 		}
 	}
 	if !core.IsNil(project.CreatedAt) {
 		if err = d.Set("created_at", project.CreatedAt); err != nil {
-			return diag.FromErr(fmt.Errorf("Error setting created_at: %s", err))
+			return diag.FromErr(fmt.Errorf("error setting created_at: %s", err))
 		}
 	}
 	if !core.IsNil(project.Crn) {
 		if err = d.Set("crn", project.Crn); err != nil {
-			return diag.FromErr(fmt.Errorf("Error setting crn: %s", err))
+			return diag.FromErr(fmt.Errorf("error setting crn: %s", err))
 		}
 	}
 	if !core.IsNil(project.Href) {
 		if err = d.Set("href", project.Href); err != nil {
-			return diag.FromErr(fmt.Errorf("Error setting href: %s", err))
+			return diag.FromErr(fmt.Errorf("error setting href: %s", err))
 		}
 	}
 	if !core.IsNil(project.Region) {
 		if err = d.Set("region", project.Region); err != nil {
-			return diag.FromErr(fmt.Errorf("Error setting region: %s", err))
+			return diag.FromErr(fmt.Errorf("error setting region: %s", err))
 		}
 	}
 	if !core.IsNil(project.ResourceType) {
 		if err = d.Set("resource_type", project.ResourceType); err != nil {
-			return diag.FromErr(fmt.Errorf("Error setting resource_type: %s", err))
+			return diag.FromErr(fmt.Errorf("error setting resource_type: %s", err))
 		}
 	}
 	if !core.IsNil(project.Status) {
 		if err = d.Set("status", project.Status); err != nil {
-			return diag.FromErr(fmt.Errorf("Error setting status: %s", err))
+			return diag.FromErr(fmt.Errorf("error setting status: %s", err))
 		}
 	}
 
@@ -254,17 +269,20 @@ func resourceIbmCodeEngineProjectRead(context context.Context, d *schema.Resourc
 func resourceIbmCodeEngineProjectDelete(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	codeEngineClient, err := meta.(conns.ClientSession).CodeEngineV2()
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.TerraformErrorf(err, err.Error(), "ibm_code_engine_project", "delete")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	deleteProjectOptions := &codeenginev2.DeleteProjectOptions{}
 
 	deleteProjectOptions.SetID(d.Id())
 
-	response, err := codeEngineClient.DeleteProjectWithContext(context, deleteProjectOptions)
+	_, err = codeEngineClient.DeleteProjectWithContext(context, deleteProjectOptions)
 	if err != nil {
-		log.Printf("[DEBUG] DeleteProjectWithContext failed %s\n%s", err, response)
-		return diag.FromErr(fmt.Errorf("DeleteProjectWithContext failed %s\n%s", err, response))
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("DeleteProjectWithContext failed: %s", err.Error()), "ibm_code_engine_project", "delete")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	d.SetId("")

--- a/ibm/service/codeengine/resource_ibm_code_engine_secret.go
+++ b/ibm/service/codeengine/resource_ibm_code_engine_secret.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2023 All Rights Reserved.
+// Copyright IBM Corp. 2024 All Rights Reserved.
 // Licensed under the Mozilla Public License v2.0
 
 package codeengine
@@ -34,6 +34,12 @@ func ResourceIbmCodeEngineSecret() *schema.Resource {
 				ValidateFunc: validate.InvokeValidator("ibm_code_engine_secret", "project_id"),
 				Description:  "The ID of the project.",
 			},
+			"data": {
+				Type:        schema.TypeMap,
+				Optional:    true,
+				Description: "Data container that allows to specify config parameters and their values as a key-value map. Each key field must consist of alphanumeric characters, `-`, `_` or `.` and must not exceed a max length of 253 characters. Each value field can consists of any character and must not exceed a max length of 1048576 characters.",
+				Elem:        &schema.Schema{Type: schema.TypeString},
+			},
 			"format": {
 				Type:         schema.TypeString,
 				Required:     true,
@@ -47,13 +53,6 @@ func ResourceIbmCodeEngineSecret() *schema.Resource {
 				ForceNew:     true,
 				ValidateFunc: validate.InvokeValidator("ibm_code_engine_secret", "name"),
 				Description:  "The name of the secret.",
-			},
-			"data": {
-				Type:        schema.TypeMap,
-				Optional:    true,
-				Sensitive:   true,
-				Description: "Data container that allows to specify config parameters and their values as a key-value map. Each key field must consist of alphanumeric characters, `-`, `_` or `.` and must not be exceed a max length of 253 characters. Each value field can consists of any character and must not be exceed a max length of 1048576 characters.",
-				Elem:        &schema.Schema{Type: schema.TypeString},
 			},
 			"service_access": {
 				Type:        schema.TypeList,
@@ -94,7 +93,7 @@ func ResourceIbmCodeEngineSecret() *schema.Resource {
 									"crn": {
 										Type:        schema.TypeString,
 										Optional:    true,
-										Description: "CRN of the IAM Role for thise service access secret.",
+										Description: "CRN of the IAM Role for this service access secret.",
 									},
 									"name": {
 										Type:        schema.TypeString,
@@ -125,6 +124,73 @@ func ResourceIbmCodeEngineSecret() *schema.Resource {
 								},
 							},
 						},
+						"serviceid": {
+							Type:        schema.TypeList,
+							MaxItems:    1,
+							Optional:    true,
+							Description: "A reference to a Service ID.",
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"crn": {
+										Type:        schema.TypeString,
+										Computed:    true,
+										Description: "CRN value of a Service ID.",
+									},
+									"id": {
+										Type:        schema.TypeString,
+										Optional:    true,
+										Description: "The ID of the Service ID.",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			"service_operator": {
+				Type:        schema.TypeList,
+				MaxItems:    1,
+				Optional:    true,
+				Description: "Properties for the IBM Cloud Operator Secret.",
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"apikey_id": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "The ID of the apikey associated with the operator secret.",
+						},
+						"resource_group_ids": {
+							Type:        schema.TypeList,
+							Required:    true,
+							Description: "The list of resource groups (by ID) that the operator secret can bind services in.",
+							Elem:        &schema.Schema{Type: schema.TypeString},
+						},
+						"serviceid": {
+							Type:        schema.TypeList,
+							MinItems:    1,
+							MaxItems:    1,
+							Required:    true,
+							Description: "A reference to a Service ID.",
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"crn": {
+										Type:        schema.TypeString,
+										Computed:    true,
+										Description: "CRN value of a Service ID.",
+									},
+									"id": {
+										Type:        schema.TypeString,
+										Optional:    true,
+										Description: "The ID of the Service ID.",
+									},
+								},
+							},
+						},
+						"user_managed": {
+							Type:        schema.TypeBool,
+							Computed:    true,
+							Description: "Specifies whether the operator secret is user managed.",
+						},
 					},
 				},
 			},
@@ -143,10 +209,10 @@ func ResourceIbmCodeEngineSecret() *schema.Resource {
 				Computed:    true,
 				Description: "When you provision a new secret,  a URL is created identifying the location of the instance.",
 			},
-			"id": {
+			"region": {
 				Type:        schema.TypeString,
 				Computed:    true,
-				Description: "The identifier of the resource.",
+				Description: "The region of the project the resource is located in. Possible values: 'au-syd', 'br-sao', 'ca-tor', 'eu-de', 'eu-gb', 'jp-osa', 'jp-tok', 'us-east', 'us-south'.",
 			},
 			"resource_type": {
 				Type:        schema.TypeString,
@@ -183,8 +249,8 @@ func ResourceIbmCodeEngineSecretValidator() *validate.ResourceValidator {
 			ValidateFunctionIdentifier: validate.ValidateAllowedStringValue,
 			Type:                       validate.TypeString,
 			Required:                   true,
-			AllowedValues:              "basic_auth, generic, registry, service_access, ssh_auth, tls",
-			Regexp:                     `^(generic|ssh_auth|basic_auth|tls|service_access|registry)$`,
+			AllowedValues:              "basic_auth, generic, other, registry, service_access, service_operator, ssh_auth, tls",
+			Regexp:                     `^(generic|ssh_auth|basic_auth|tls|service_access|registry|service_operator|other)$`,
 		},
 		validate.ValidateSchema{
 			Identifier:                 "name",
@@ -204,7 +270,9 @@ func ResourceIbmCodeEngineSecretValidator() *validate.ResourceValidator {
 func resourceIbmCodeEngineSecretCreate(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	codeEngineClient, err := meta.(conns.ClientSession).CodeEngineV2()
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.TerraformErrorf(err, err.Error(), "ibm_code_engine_secret", "create")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	createSecretOptions := &codeenginev2.CreateSecretOptions{}
@@ -226,11 +294,19 @@ func resourceIbmCodeEngineSecretCreate(context context.Context, d *schema.Resour
 		}
 		createSecretOptions.SetServiceAccess(serviceAccessModel)
 	}
+	if _, ok := d.GetOk("service_operator"); ok {
+		serviceOperatorModel, err := resourceIbmCodeEngineSecretMapToOperatorSecretPrototypeProps(d.Get("service_operator.0").(map[string]interface{}))
+		if err != nil {
+			return diag.FromErr(err)
+		}
+		createSecretOptions.SetServiceOperator(serviceOperatorModel)
+	}
 
-	secret, response, err := codeEngineClient.CreateSecretWithContext(context, createSecretOptions)
+	secret, _, err := codeEngineClient.CreateSecretWithContext(context, createSecretOptions)
 	if err != nil {
-		log.Printf("[DEBUG] CreateSecretWithContext failed %s\n%s", err, response)
-		return diag.FromErr(fmt.Errorf("CreateSecretWithContext failed %s\n%s", err, response))
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("CreateSecretWithContext failed: %s", err.Error()), "ibm_code_engine_secret", "create")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	d.SetId(fmt.Sprintf("%s/%s", *createSecretOptions.ProjectID, *secret.Name))
@@ -241,14 +317,17 @@ func resourceIbmCodeEngineSecretCreate(context context.Context, d *schema.Resour
 func resourceIbmCodeEngineSecretRead(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	codeEngineClient, err := meta.(conns.ClientSession).CodeEngineV2()
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.TerraformErrorf(err, err.Error(), "ibm_code_engine_secret", "read")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	getSecretOptions := &codeenginev2.GetSecretOptions{}
 
 	parts, err := flex.SepIdParts(d.Id(), "/")
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.TerraformErrorf(err, err.Error(), "ibm_code_engine_secret", "read")
+		return tfErr.GetDiag()
 	}
 
 	getSecretOptions.SetProjectID(parts[0])
@@ -260,12 +339,22 @@ func resourceIbmCodeEngineSecretRead(context context.Context, d *schema.Resource
 			d.SetId("")
 			return nil
 		}
-		log.Printf("[DEBUG] GetSecretWithContext failed %s\n%s", err, response)
-		return diag.FromErr(fmt.Errorf("GetSecretWithContext failed %s\n%s", err, response))
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("GetSecretWithContext failed: %s", err.Error()), "ibm_code_engine_secret", "read")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	if err = d.Set("project_id", secret.ProjectID); err != nil {
 		return diag.FromErr(fmt.Errorf("error setting project_id: %s", err))
+	}
+	if !core.IsNil(secret.Data) {
+		data := make(map[string]string)
+		for k, v := range secret.Data {
+			data[k] = string(v)
+		}
+		if err = d.Set("data", data); err != nil {
+			return diag.FromErr(fmt.Errorf("error setting data: %s", err))
+		}
 	}
 	if err = d.Set("format", secret.Format); err != nil {
 		return diag.FromErr(fmt.Errorf("error setting format: %s", err))
@@ -273,55 +362,55 @@ func resourceIbmCodeEngineSecretRead(context context.Context, d *schema.Resource
 	if err = d.Set("name", secret.Name); err != nil {
 		return diag.FromErr(fmt.Errorf("error setting name: %s", err))
 	}
-
-	if !core.IsNil(secret.Data) {
-		data := make(map[string]string)
-		for k, v := range secret.Data {
-			data[k] = string(v)
-		}
-		if err = d.Set("data", data); err != nil {
-			return diag.FromErr(fmt.Errorf("Error setting data: %s", err))
-		}
-	}
 	if !core.IsNil(secret.ServiceAccess) {
 		serviceAccessMap, err := resourceIbmCodeEngineSecretServiceAccessSecretPropsToMap(secret.ServiceAccess)
 		if err != nil {
 			return diag.FromErr(err)
 		}
 		if err = d.Set("service_access", []map[string]interface{}{serviceAccessMap}); err != nil {
-			return diag.FromErr(fmt.Errorf("Error setting service_access: %s", err))
+			return diag.FromErr(fmt.Errorf("error setting service_access: %s", err))
+		}
+	}
+	if !core.IsNil(secret.ServiceOperator) {
+		serviceOperatorMap, err := resourceIbmCodeEngineSecretOperatorSecretPropsToMap(secret.ServiceOperator)
+		if err != nil {
+			return diag.FromErr(err)
+		}
+		if err = d.Set("service_operator", []map[string]interface{}{serviceOperatorMap}); err != nil {
+			return diag.FromErr(fmt.Errorf("error setting service_operator: %s", err))
 		}
 	}
 	if !core.IsNil(secret.CreatedAt) {
 		if err = d.Set("created_at", secret.CreatedAt); err != nil {
-			return diag.FromErr(fmt.Errorf("Error setting created_at: %s", err))
+			return diag.FromErr(fmt.Errorf("error setting created_at: %s", err))
 		}
 	}
 	if err = d.Set("entity_tag", secret.EntityTag); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting entity_tag: %s", err))
+		return diag.FromErr(fmt.Errorf("error setting entity_tag: %s", err))
 	}
 	if !core.IsNil(secret.Href) {
 		if err = d.Set("href", secret.Href); err != nil {
-			return diag.FromErr(fmt.Errorf("Error setting href: %s", err))
-		}
-	}
-	if !core.IsNil(secret.ID) {
-		if err = d.Set("id", secret.ID); err != nil {
-			return diag.FromErr(fmt.Errorf("Error setting id: %s", err))
-		}
-	}
-	if !core.IsNil(secret.ResourceType) {
-		if err = d.Set("resource_type", secret.ResourceType); err != nil {
-			return diag.FromErr(fmt.Errorf("Error setting resource_type: %s", err))
+			return diag.FromErr(fmt.Errorf("error setting href: %s", err))
 		}
 	}
 	if !core.IsNil(secret.ID) {
 		if err = d.Set("secret_id", secret.ID); err != nil {
-			return diag.FromErr(fmt.Errorf("Error setting secret_id: %s", err))
+			return diag.FromErr(fmt.Errorf("error setting id: %s", err))
+		}
+	}
+	if !core.IsNil(secret.Region) {
+		if err = d.Set("region", secret.Region); err != nil {
+			return diag.FromErr(fmt.Errorf("error setting region: %s", err))
+		}
+	}
+	if !core.IsNil(secret.ResourceType) {
+		if err = d.Set("resource_type", secret.ResourceType); err != nil {
+			return diag.FromErr(fmt.Errorf("error setting resource_type: %s", err))
 		}
 	}
 	if err = d.Set("etag", response.Headers.Get("Etag")); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting etag: %s", err))
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("Error setting etag: %s", err), "ibm_code_engine_secret", "read")
+		return tfErr.GetDiag()
 	}
 
 	return nil
@@ -330,40 +419,38 @@ func resourceIbmCodeEngineSecretRead(context context.Context, d *schema.Resource
 func resourceIbmCodeEngineSecretUpdate(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	codeEngineClient, err := meta.(conns.ClientSession).CodeEngineV2()
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.TerraformErrorf(err, err.Error(), "ibm_code_engine_secret", "update")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	replaceSecretOptions := &codeenginev2.ReplaceSecretOptions{}
 
 	parts, err := flex.SepIdParts(d.Id(), "/")
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.TerraformErrorf(err, err.Error(), "ibm_code_engine_secret", "update")
+		return tfErr.GetDiag()
 	}
 
 	replaceSecretOptions.SetProjectID(parts[0])
 	replaceSecretOptions.SetName(parts[1])
-	replaceSecretOptions.SetFormat(d.Get("format").(string))
 
 	hasChange := false
 
-	if d.HasChange("format") {
-		return diag.FromErr(fmt.Errorf("Cannot update resource property \"%s\" with the ForceNew annotation."+
-			" The resource must be re-created to update this property.", "format"))
-	}
 	if d.HasChange("project_id") {
-		return diag.FromErr(fmt.Errorf("Cannot update resource property \"%s\" with the ForceNew annotation."+
-			" The resource must be re-created to update this property.", "project_id"))
+		errMsg := fmt.Sprintf("Cannot update resource property \"%s\" with the ForceNew annotation."+
+			" The resource must be re-created to update this property.", "project_id")
+		tfErr := flex.TerraformErrorf(err, errMsg, "ibm_code_engine_secret", "update")
+		return tfErr.GetDiag()
 	}
-	if d.HasChange("name") {
-		return diag.FromErr(fmt.Errorf("Cannot update resource property \"%s\" with the ForceNew annotation."+
-			" The resource must be re-created to update this property.", "name"))
-	}
-	if d.HasChange("if_match") {
-		replaceSecretOptions.SetIfMatch(d.Get("if_match").(string))
-		hasChange = true
+	if d.HasChange("format") {
+		errMsg := fmt.Sprintf("Cannot update resource property \"%s\" with the ForceNew annotation."+
+			" The resource must be re-created to update this property.", "format")
+		tfErr := flex.TerraformErrorf(err, errMsg, "ibm_code_engine_secret", "update")
+		return tfErr.GetDiag()
 	}
 	if d.HasChange("data") {
-		data, err := resourceIbmCodeEngineSecretMapToSecretData(d.Get("data").(map[string]interface{}))
+		data, err := resourceIbmCodeEngineSecretMapToSecretData(d.Get("data.0").(map[string]interface{}))
 		if err != nil {
 			return diag.FromErr(err)
 		}
@@ -373,10 +460,11 @@ func resourceIbmCodeEngineSecretUpdate(context context.Context, d *schema.Resour
 	replaceSecretOptions.SetIfMatch(d.Get("etag").(string))
 
 	if hasChange {
-		_, response, err := codeEngineClient.ReplaceSecretWithContext(context, replaceSecretOptions)
+		_, _, err = codeEngineClient.ReplaceSecretWithContext(context, replaceSecretOptions)
 		if err != nil {
-			log.Printf("[DEBUG] ReplaceSecretWithContext failed %s\n%s", err, response)
-			return diag.FromErr(fmt.Errorf("ReplaceSecretWithContext failed %s\n%s", err, response))
+			tfErr := flex.TerraformErrorf(err, fmt.Sprintf("ReplaceSecretWithContext failed: %s", err.Error()), "ibm_code_engine_secret", "update")
+			log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+			return tfErr.GetDiag()
 		}
 	}
 
@@ -386,23 +474,27 @@ func resourceIbmCodeEngineSecretUpdate(context context.Context, d *schema.Resour
 func resourceIbmCodeEngineSecretDelete(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	codeEngineClient, err := meta.(conns.ClientSession).CodeEngineV2()
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.TerraformErrorf(err, err.Error(), "ibm_code_engine_secret", "delete")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	deleteSecretOptions := &codeenginev2.DeleteSecretOptions{}
 
 	parts, err := flex.SepIdParts(d.Id(), "/")
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.TerraformErrorf(err, err.Error(), "ibm_code_engine_secret", "delete")
+		return tfErr.GetDiag()
 	}
 
 	deleteSecretOptions.SetProjectID(parts[0])
 	deleteSecretOptions.SetName(parts[1])
 
-	response, err := codeEngineClient.DeleteSecretWithContext(context, deleteSecretOptions)
+	_, err = codeEngineClient.DeleteSecretWithContext(context, deleteSecretOptions)
 	if err != nil {
-		log.Printf("[DEBUG] DeleteSecretWithContext failed %s\n%s", err, response)
-		return diag.FromErr(fmt.Errorf("DeleteSecretWithContext failed %s\n%s", err, response))
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("DeleteSecretWithContext failed: %s", err.Error()), "ibm_code_engine_secret", "delete")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	d.SetId("")
@@ -441,6 +533,13 @@ func resourceIbmCodeEngineSecretMapToServiceAccessSecretPrototypeProps(modelMap 
 		return model, err
 	}
 	model.ServiceInstance = ServiceInstanceModel
+	if modelMap["serviceid"] != nil && len(modelMap["serviceid"].([]interface{})) > 0 {
+		ServiceidModel, err := resourceIbmCodeEngineSecretMapToServiceIDRef(modelMap["serviceid"].([]interface{})[0].(map[string]interface{}))
+		if err != nil {
+			return model, err
+		}
+		model.Serviceid = ServiceidModel
+	}
 	return model, nil
 }
 
@@ -468,6 +567,44 @@ func resourceIbmCodeEngineSecretMapToServiceInstanceRefPrototype(modelMap map[st
 	return model, nil
 }
 
+func resourceIbmCodeEngineSecretMapToServiceIDRef(modelMap map[string]interface{}) (*codeenginev2.ServiceIDRef, error) {
+	model := &codeenginev2.ServiceIDRef{}
+	if modelMap["crn"] != nil && modelMap["crn"].(string) != "" {
+		model.Crn = core.StringPtr(modelMap["crn"].(string))
+	}
+	if modelMap["id"] != nil && modelMap["id"].(string) != "" {
+		model.ID = core.StringPtr(modelMap["id"].(string))
+	}
+	return model, nil
+}
+
+func resourceIbmCodeEngineSecretMapToOperatorSecretPrototypeProps(modelMap map[string]interface{}) (*codeenginev2.OperatorSecretPrototypeProps, error) {
+	model := &codeenginev2.OperatorSecretPrototypeProps{}
+	if modelMap["resource_group_ids"] != nil {
+		resourceGroupIds := []string{}
+		for _, resourceGroupIdsItem := range modelMap["resource_group_ids"].([]interface{}) {
+			resourceGroupIds = append(resourceGroupIds, resourceGroupIdsItem.(string))
+		}
+		model.ResourceGroupIds = resourceGroupIds
+	}
+	if modelMap["serviceid"] != nil && len(modelMap["serviceid"].([]interface{})) > 0 {
+		ServiceidModel, err := resourceIbmCodeEngineSecretMapToServiceIDRefPrototype(modelMap["serviceid"].([]interface{})[0].(map[string]interface{}))
+		if err != nil {
+			return model, err
+		}
+		model.Serviceid = ServiceidModel
+	}
+	return model, nil
+}
+
+func resourceIbmCodeEngineSecretMapToServiceIDRefPrototype(modelMap map[string]interface{}) (*codeenginev2.ServiceIDRefPrototype, error) {
+	model := &codeenginev2.ServiceIDRefPrototype{}
+	if modelMap["id"] != nil && modelMap["id"].(string) != "" {
+		model.ID = core.StringPtr(modelMap["id"].(string))
+	}
+	return model, nil
+}
+
 func resourceIbmCodeEngineSecretServiceAccessSecretPropsToMap(model *codeenginev2.ServiceAccessSecretProps) (map[string]interface{}, error) {
 	modelMap := make(map[string]interface{})
 	resourceKeyMap, err := resourceIbmCodeEngineSecretResourceKeyRefToMap(model.ResourceKey)
@@ -487,6 +624,13 @@ func resourceIbmCodeEngineSecretServiceAccessSecretPropsToMap(model *codeenginev
 		return modelMap, err
 	}
 	modelMap["service_instance"] = []map[string]interface{}{serviceInstanceMap}
+	if model.Serviceid != nil {
+		serviceidMap, err := resourceIbmCodeEngineSecretServiceIDRefToMap(model.Serviceid)
+		if err != nil {
+			return modelMap, err
+		}
+		modelMap["serviceid"] = []map[string]interface{}{serviceidMap}
+	}
 	return modelMap, nil
 }
 
@@ -520,5 +664,29 @@ func resourceIbmCodeEngineSecretServiceInstanceRefToMap(model *codeenginev2.Serv
 	if model.Type != nil {
 		modelMap["type"] = model.Type
 	}
+	return modelMap, nil
+}
+
+func resourceIbmCodeEngineSecretServiceIDRefToMap(model *codeenginev2.ServiceIDRef) (map[string]interface{}, error) {
+	modelMap := make(map[string]interface{})
+	if model.Crn != nil {
+		modelMap["crn"] = model.Crn
+	}
+	if model.ID != nil {
+		modelMap["id"] = model.ID
+	}
+	return modelMap, nil
+}
+
+func resourceIbmCodeEngineSecretOperatorSecretPropsToMap(model *codeenginev2.OperatorSecretProps) (map[string]interface{}, error) {
+	modelMap := make(map[string]interface{})
+	modelMap["apikey_id"] = model.ApikeyID
+	modelMap["resource_group_ids"] = model.ResourceGroupIds
+	serviceidMap, err := resourceIbmCodeEngineSecretServiceIDRefToMap(model.Serviceid)
+	if err != nil {
+		return modelMap, err
+	}
+	modelMap["serviceid"] = []map[string]interface{}{serviceidMap}
+	modelMap["user_managed"] = model.UserManaged
 	return modelMap, nil
 }

--- a/ibm/service/codeengine/resource_ibm_code_engine_secret_test.go
+++ b/ibm/service/codeengine/resource_ibm_code_engine_secret_test.go
@@ -5,6 +5,7 @@ package codeengine_test
 
 import (
 	"fmt"
+	"os"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
@@ -238,8 +239,8 @@ func TestAccIbmCodeEngineSecretTls(t *testing.T) {
 	format := "tls"
 	name := fmt.Sprintf("tf-secret-tls-%d", acctest.RandIntRange(10, 1000))
 	nameUpdate := fmt.Sprintf("tf-secret-tls-update-%d", acctest.RandIntRange(10, 1000))
-	tlsKey := decodeBase64EnvVar(acc.CeTLSKey, CeTlsKey)
-	tlsCert := decodeBase64EnvVar(acc.CeTLSCert, CeTlsCert)
+	tlsKey, _ := os.ReadFile(acc.CeTLSKeyFilePath)
+	tlsCert, _ := os.ReadFile(acc.CeTLSCertFilePath)
 
 	projectID := acc.CeProjectId
 
@@ -249,7 +250,7 @@ func TestAccIbmCodeEngineSecretTls(t *testing.T) {
 		CheckDestroy: testAccCheckIbmCodeEngineSecretDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
-				Config: testAccCheckIbmCodeEngineSecretTLSConfig(projectID, tlsKey, tlsCert, format, name),
+				Config: testAccCheckIbmCodeEngineSecretTLSConfig(projectID, string(tlsKey), string(tlsCert), format, name),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckIbmCodeEngineSecretExists("ibm_code_engine_secret.code_engine_secret_instance", conf),
 					resource.TestCheckResourceAttr("ibm_code_engine_secret.code_engine_secret_instance", "project_id", projectID),
@@ -261,7 +262,7 @@ func TestAccIbmCodeEngineSecretTls(t *testing.T) {
 				),
 			},
 			resource.TestStep{
-				Config: testAccCheckIbmCodeEngineSecretTLSConfig(projectID, tlsKey, tlsCert, format, nameUpdate),
+				Config: testAccCheckIbmCodeEngineSecretTLSConfig(projectID, string(tlsKey), string(tlsCert), format, nameUpdate),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr("ibm_code_engine_secret.code_engine_secret_instance", "project_id", projectID),
 					resource.TestCheckResourceAttr("ibm_code_engine_secret.code_engine_secret_instance", "format", format),

--- a/website/docs/d/code_engine_app.html.markdown
+++ b/website/docs/d/code_engine_app.html.markdown
@@ -8,39 +8,44 @@ subcategory: "Code Engine"
 
 # ibm_code_engine_app
 
-Provides a read-only data source for code_engine_app. You can then reference the fields of the data source in other resources within the same configuration using interpolation syntax.
+Provides a read-only data source to retrieve information about a code_engine_app. You can then reference the fields of the data source in other resources within the same configuration by using interpolation syntax.
 
 ## Example Usage
 
 ```hcl
 data "ibm_code_engine_app" "code_engine_app" {
-	project_id = data.ibm_code_engine_project.code_engine_project.project_id
-	name       = "my-app"
+	name = ibm_code_engine_app.code_engine_app_instance.name
+	project_id = ibm_code_engine_app.code_engine_app_instance.project_id
 }
 ```
 
 ## Argument Reference
 
-Review the argument reference that you can specify for your data source.
+You can specify the following arguments for this data source.
 
 * `name` - (Required, Forces new resource, String) The name of your application.
-  * Constraints: The maximum length is `253` characters. The minimum length is `1` character. The value must match regular expression `/^[a-z0-9]([\\-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([\\-a-z0-9]*[a-z0-9])?)*$/`.
+  * Constraints: The maximum length is `63` characters. The minimum length is `1` character. The value must match regular expression `/^[a-z]([-a-z0-9]*[a-z0-9])?$/`.
 * `project_id` - (Required, Forces new resource, String) The ID of the project.
   * Constraints: The maximum length is `36` characters. The minimum length is `36` characters. The value must match regular expression `/^[0-9a-z]{8}-[0-9a-z]{4}-[0-9a-z]{4}-[0-9a-z]{4}-[0-9a-z]{12}$/`.
 
 ## Attribute Reference
 
-In addition to all argument references listed, you can access the following attribute references after your data source is created.
+After your data source is created, you can read values from the following attributes.
 
 * `id` - The unique identifier of the code_engine_app.
+
 * `app_id` - (String) The identifier of the resource.
   * Constraints: The maximum length is `36` characters. The minimum length is `36` characters. The value must match regular expression `/^[0-9a-z]{8}-[0-9a-z]{4}-[0-9a-z]{4}-[0-9a-z]{4}-[0-9a-z]{12}$/`.
 
+* `build` - (String) Reference to a build that is associated with the application.
+
+* `build_run` - (String) Reference to a build run that is associated with the application.
+
 * `created_at` - (String) The timestamp when the resource was created.
 
-* `endpoint` - (String) Optional URL to invoke app. Depending on visibility this is accessible publicly or in the private network only. Empty in case 'managed_domain_mappings' is set to 'local'.
+* `endpoint` - (String) Optional URL to invoke the app. Depending on visibility,  this is accessible publicly or in the private network only. Empty in case 'managed_domain_mappings' is set to 'local'.
 
-* `endpoint_internal` - (String) URL to app that is only visible within the project.
+* `endpoint_internal` - (String) The URL to the app that is only visible within the project.
 
 * `entity_tag` - (String) The version of the app instance, which is used to achieve optimistic locking.
   * Constraints: The maximum length is `63` characters. The minimum length is `1` character. The value must match regular expression `/^[\\*\\-a-z0-9]+$/`.
@@ -49,6 +54,7 @@ In addition to all argument references listed, you can access the following attr
   * Constraints: The maximum length is `2048` characters. The minimum length is `0` characters. The value must match regular expression `/(([^:\/?#]+):)?(\/\/([^\/?#]*))?([^?#]*)(\\?([^#]*))?(#(.*))?$/`.
 
 * `image_port` - (Integer) Optional port the app listens on. While the app will always be exposed via port `443` for end users, this port is used to connect to the port that is exposed by the container image.
+  * Constraints: The default value is `8080`.
 
 * `image_reference` - (String) The name of the image that is used for this app. The format is `REGISTRY/NAMESPACE/REPOSITORY:TAG` where `REGISTRY` and `TAG` are optional. If `REGISTRY` is not specified, the default is `docker.io`. If `TAG` is not specified, the default is `latest`. If the image reference points to a registry that requires authentication, make sure to also specify the property `image_secret`.
   * Constraints: The maximum length is `256` characters. The minimum length is `1` character. The value must match regular expression `/^([a-z0-9][a-z0-9\\-_.]+[a-z0-9][\/])?([a-z0-9][a-z0-9\\-_]+[a-z0-9][\/])?[a-z0-9][a-z0-9\\-_.\/]+[a-z0-9](:[\\w][\\w.\\-]{0,127})?(@sha256:[a-fA-F0-9]{64})?$/`.
@@ -59,20 +65,57 @@ In addition to all argument references listed, you can access the following attr
 * `managed_domain_mappings` - (String) Optional value controlling which of the system managed domain mappings will be setup for the application. Valid values are 'local_public', 'local_private' and 'local'. Visibility can only be 'local_private' if the project supports application private visibility.
   * Constraints: The default value is `local_public`. Allowable values are: `local`, `local_private`, `local_public`.
 
+* `probe_liveness` - (List) Response model for probes.
+Nested schema for **probe_liveness**:
+	* `failure_threshold` - (Integer) The number of consecutive, unsuccessful checks for the probe to be considered failed.
+	  * Constraints: The default value is `1`. The maximum value is `10`. The minimum value is `1`.
+	* `initial_delay` - (Integer) The amount of time in seconds to wait before the first probe check is performed.
+	  * Constraints: The maximum value is `10`. The minimum value is `1`.
+	* `interval` - (Integer) The amount of time in seconds between probe checks.
+	  * Constraints: The default value is `10`. The maximum value is `60`. The minimum value is `1`.
+	* `path` - (String) The path of the HTTP request to the resource. A path is only supported for a probe with a `type` of `http`.
+	  * Constraints: The maximum length is `2048` characters. The minimum length is `0` characters. The value must match regular expression `/^\/(([a-zA-Z0-9-._~!$&'()*+,;=:@]|%[a-fA-F0-9]{2})+(\/([a-zA-Z0-9-._~!$&'()*+,;=:@]|%[a-fA-F0-9]{2})*)*)?(\\?([a-zA-Z0-9-._~!$&'()*+,;=:@\/?]|%[a-fA-F0-9]{2})*)?$/`.
+	* `port` - (Integer) The port on which to probe the resource.
+	  * Constraints: The maximum value is `65535`. The minimum value is `1`.
+	* `timeout` - (Integer) The amount of time in seconds that the probe waits for a response from the application before it times out and fails.
+	  * Constraints: The default value is `1`. The maximum value is `3600`. The minimum value is `1`.
+	* `type` - (String) Specifies whether to use HTTP or TCP for the probe checks. The default is TCP.
+	  * Constraints: Allowable values are: `tcp`, `http`.
+
+* `probe_readiness` - (List) Response model for probes.
+Nested schema for **probe_readiness**:
+	* `failure_threshold` - (Integer) The number of consecutive, unsuccessful checks for the probe to be considered failed.
+	  * Constraints: The default value is `1`. The maximum value is `10`. The minimum value is `1`.
+	* `initial_delay` - (Integer) The amount of time in seconds to wait before the first probe check is performed.
+	  * Constraints: The maximum value is `10`. The minimum value is `1`.
+	* `interval` - (Integer) The amount of time in seconds between probe checks.
+	  * Constraints: The default value is `10`. The maximum value is `60`. The minimum value is `1`.
+	* `path` - (String) The path of the HTTP request to the resource. A path is only supported for a probe with a `type` of `http`.
+	  * Constraints: The maximum length is `2048` characters. The minimum length is `0` characters. The value must match regular expression `/^\/(([a-zA-Z0-9-._~!$&'()*+,;=:@]|%[a-fA-F0-9]{2})+(\/([a-zA-Z0-9-._~!$&'()*+,;=:@]|%[a-fA-F0-9]{2})*)*)?(\\?([a-zA-Z0-9-._~!$&'()*+,;=:@\/?]|%[a-fA-F0-9]{2})*)?$/`.
+	* `port` - (Integer) The port on which to probe the resource.
+	  * Constraints: The maximum value is `65535`. The minimum value is `1`.
+	* `timeout` - (Integer) The amount of time in seconds that the probe waits for a response from the application before it times out and fails.
+	  * Constraints: The default value is `1`. The maximum value is `3600`. The minimum value is `1`.
+	* `type` - (String) Specifies whether to use HTTP or TCP for the probe checks. The default is TCP.
+	  * Constraints: Allowable values are: `tcp`, `http`.
+
+* `region` - (String) The region of the project the resource is located in. Possible values: 'au-syd', 'br-sao', 'ca-tor', 'eu-de', 'eu-gb', 'jp-osa', 'jp-tok', 'us-east', 'us-south'.
+
 * `resource_type` - (String) The type of the app.
   * Constraints: Allowable values are: `app_v2`.
 
 * `run_arguments` - (List) Optional arguments for the app that are passed to start the container. If not specified an empty string array will be applied and the arguments specified by the container image, will be used to start the container.
   * Constraints: The list items must match regular expression `/^.*$/`. The maximum length is `100` items. The minimum length is `0` items.
 
-* `run_as_user` - (Integer) Optional user ID (UID) to run the app (e.g., `1001`).
+* `run_as_user` - (Integer) Optional user ID (UID) to run the app.
+  * Constraints: The default value is `0`.
 
 * `run_commands` - (List) Optional commands for the app that are passed to start the container. If not specified an empty string array will be applied and the command specified by the container image, will be used to start the container.
   * Constraints: The list items must match regular expression `/^.*$/`. The maximum length is `100` items. The minimum length is `0` items.
 
 * `run_env_variables` - (List) References to config maps, secrets or literal values, which are exposed as environment variables in the application.
   * Constraints: The maximum length is `100` items. The minimum length is `0` items.
-Nested scheme for **run_env_variables**:
+Nested schema for **run_env_variables**:
 	* `key` - (String) The key to reference as environment variable.
 	  * Constraints: The maximum length is `253` characters. The minimum length is `1` character. The value must match regular expression `/^[\\-._a-zA-Z0-9]+$/`.
 	* `name` - (String) The name of the environment variable.
@@ -91,7 +134,7 @@ Nested scheme for **run_env_variables**:
 
 * `run_volume_mounts` - (List) Mounts of config maps or secrets.
   * Constraints: The maximum length is `100` items. The minimum length is `0` items.
-Nested scheme for **run_volume_mounts**:
+Nested schema for **run_volume_mounts**:
 	* `mount_path` - (String) The path that should be mounted.
 	  * Constraints: The maximum length is `256` characters. The minimum length is `1` character. The value must match regular expression `/^\/([^\/\\0]+\/?)+$/`.
 	* `name` - (String) The name of the mount.
@@ -102,34 +145,39 @@ Nested scheme for **run_volume_mounts**:
 	  * Constraints: The default value is `secret`. Allowable values are: `config_map`, `secret`. The value must match regular expression `/^(config_map|secret)$/`.
 
 * `scale_concurrency` - (Integer) Optional maximum number of requests that can be processed concurrently per instance.
+  * Constraints: The default value is `100`.
 
 * `scale_concurrency_target` - (Integer) Optional threshold of concurrent requests per instance at which one or more additional instances are created. Use this value to scale up instances based on concurrent number of requests. This option defaults to the value of the `scale_concurrency` option, if not specified.
 
 * `scale_cpu_limit` - (String) Optional number of CPU set for the instance of the app. For valid values see [Supported memory and CPU combinations](https://cloud.ibm.com/docs/codeengine?topic=codeengine-mem-cpu-combo).
   * Constraints: The default value is `1`. The maximum length is `10` characters. The minimum length is `0` characters. The value must match regular expression `/^([0-9.]+)([eEinumkKMGTPB]*)$/`.
 
-* `scale_down_delay` - (Integer) Optional amount of time in seconds that delays the scale down behavior for an app instance.
-  * Constraints: The maximum value is `3600`. The minimum value is `0`.
+* `scale_down_delay` - (Integer) Optional amount of time in seconds that delays the scale-down behavior for an app instance.
+  * Constraints: The default value is `0`. The maximum value is `3600`. The minimum value is `0`.
 
 * `scale_ephemeral_storage_limit` - (String) Optional amount of ephemeral storage to set for the instance of the app. The amount specified as ephemeral storage, must not exceed the amount of `scale_memory_limit`. The units for specifying ephemeral storage are Megabyte (M) or Gigabyte (G), whereas G and M are the shorthand expressions for GB and MB. For more information see [Units of measurement](https://cloud.ibm.com/docs/codeengine?topic=codeengine-mem-cpu-combo#unit-measurements).
   * Constraints: The default value is `400M`. The maximum length is `10` characters. The minimum length is `0` characters. The value must match regular expression `/^([0-9.]+)([eEinumkKMGTPB]*)$/`.
 
 * `scale_initial_instances` - (Integer) Optional initial number of instances that are created upon app creation or app update.
+  * Constraints: The default value is `1`.
 
 * `scale_max_instances` - (Integer) Optional maximum number of instances for this app. If you set this value to `0`, this property does not set a upper scaling limit. However, the app scaling is still limited by the project quota for instances. See [Limits and quotas for Code Engine](https://cloud.ibm.com/docs/codeengine?topic=codeengine-limits).
+  * Constraints: The default value is `10`.
 
 * `scale_memory_limit` - (String) Optional amount of memory set for the instance of the app. For valid values see [Supported memory and CPU combinations](https://cloud.ibm.com/docs/codeengine?topic=codeengine-mem-cpu-combo). The units for specifying memory are Megabyte (M) or Gigabyte (G), whereas G and M are the shorthand expressions for GB and MB. For more information see [Units of measurement](https://cloud.ibm.com/docs/codeengine?topic=codeengine-mem-cpu-combo#unit-measurements).
   * Constraints: The default value is `4G`. The maximum length is `10` characters. The minimum length is `0` characters. The value must match regular expression `/^([0-9.]+)([eEinumkKMGTPB]*)$/`.
 
 * `scale_min_instances` - (Integer) Optional minimum number of instances for this app. If you set this value to `0`, the app will scale down to zero, if not hit by any request for some time.
+  * Constraints: The default value is `0`.
 
 * `scale_request_timeout` - (Integer) Optional amount of time in seconds that is allowed for a running app to respond to a request.
+  * Constraints: The default value is `300`.
 
 * `status` - (String) The current status of the app.
   * Constraints: Allowable values are: `ready`, `deploying`, `failed`, `warning`.
 
 * `status_details` - (List) The detailed status of the application.
-Nested scheme for **status_details**:
+Nested schema for **status_details**:
 	* `latest_created_revision` - (String) Latest app revision that has been created.
 	* `latest_ready_revision` - (String) Latest app revision that reached a ready state.
 	* `reason` - (String) Optional information to provide more context in case of a 'failed' or 'warning' status.

--- a/website/docs/d/code_engine_binding.html.markdown
+++ b/website/docs/d/code_engine_binding.html.markdown
@@ -14,8 +14,8 @@ Provides a read-only data source to retrieve information about a code_engine_bin
 
 ```hcl
 data "ibm_code_engine_binding" "code_engine_binding" {
-	id = "a172ced-b5f21bc-71ba50c-1638604"
-	project_id = ibm_code_engine_binding.code_engine_binding.project_id
+	binding_id = "a172ced-b5f21bc-71ba50c-1638604"
+	project_id = ibm_code_engine_binding.code_engine_binding_instance.project_id
 }
 ```
 
@@ -23,7 +23,7 @@ data "ibm_code_engine_binding" "code_engine_binding" {
 
 You can specify the following arguments for this data source.
 
-* `binding_id` - (Required, Forces new resource, String) The ID of the binding.
+* `binding_id` - (Required, Forces new resource, String) The id of your binding.
   * Constraints: The maximum length is `253` characters. The minimum length is `1` character. The value must match regular expression `/.+/`.
 * `project_id` - (Required, Forces new resource, String) The ID of the project.
   * Constraints: The maximum length is `36` characters. The minimum length is `36` characters. The value must match regular expression `/^[0-9a-z]{8}-[0-9a-z]{4}-[0-9a-z]{4}-[0-9a-z]{4}-[0-9a-z]{12}$/`.
@@ -35,7 +35,7 @@ After your data source is created, you can read values from the following attrib
 * `id` - The unique identifier of the code_engine_binding.
 
 * `component` - (List) A reference to another component.
-Nested scheme for **component**:
+Nested schema for **component**:
 	* `name` - (String) The name of the referenced component.
 	  * Constraints: The maximum length is `63` characters. The minimum length is `1` character. The value must match regular expression `/^[a-z0-9]([\\-a-z0-9]*[a-z0-9])?$/`.
 	* `resource_type` - (String) The type of the referenced resource.
@@ -44,7 +44,7 @@ Nested scheme for **component**:
 * `href` - (String) When you provision a new binding,  a URL is created identifying the location of the instance.
   * Constraints: The maximum length is `2048` characters. The minimum length is `0` characters. The value must match regular expression `/(([^:\/?#]+):)?(\/\/([^\/?#]*))?([^?#]*)(\\?([^#]*))?(#(.*))?$/`.
 
-* `prefix` - (String) The value that is set as prefix in the component that is bound.
+* `prefix` - (String) The value that is set as a prefix in the component that is bound.
   * Constraints: The maximum length is `31` characters. The minimum length is `0` characters. The value must match regular expression `/^[A-Z]([_A-Z0-9]*[A-Z0-9])*$/`.
 
 * `resource_type` - (String) The type of the binding.

--- a/website/docs/d/code_engine_build.html.markdown
+++ b/website/docs/d/code_engine_build.html.markdown
@@ -8,7 +8,7 @@ subcategory: "Code Engine"
 
 # ibm_code_engine_build
 
-Provides a read-only data source for code_engine_build. You can then reference the fields of the data source in other resources within the same configuration using interpolation syntax.
+Provides a read-only data source to retrieve information about a code_engine_build. You can then reference the fields of the data source in other resources within the same configuration by using interpolation syntax.
 
 ## Example Usage
 
@@ -21,18 +21,19 @@ data "ibm_code_engine_build" "code_engine_build" {
 
 ## Argument Reference
 
-Review the argument reference that you can specify for your data source.
+You can specify the following arguments for this data source.
 
 * `name` - (Required, Forces new resource, String) The name of your build.
-  * Constraints: The maximum length is `253` characters. The minimum length is `1` character. The value must match regular expression `/^[a-z0-9]([\\-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([\\-a-z0-9]*[a-z0-9])?)*$/`.
+  * Constraints: The maximum length is `63` characters. The minimum length is `1` character. The value must match regular expression `/^[a-z0-9]([\\-a-z0-9]*[a-z0-9])?$/`.
 * `project_id` - (Required, Forces new resource, String) The ID of the project.
   * Constraints: The maximum length is `36` characters. The minimum length is `36` characters. The value must match regular expression `/^[0-9a-z]{8}-[0-9a-z]{4}-[0-9a-z]{4}-[0-9a-z]{4}-[0-9a-z]{12}$/`.
 
 ## Attribute Reference
 
-In addition to all argument references listed, you can access the following attribute references after your data source is created.
+After your data source is created, you can read values from the following attributes.
 
 * `id` - The unique identifier of the code_engine_build.
+
 * `build_id` - (String) The identifier of the resource.
   * Constraints: The maximum length is `36` characters. The minimum length is `36` characters. The value must match regular expression `/^[0-9a-z]{8}-[0-9a-z]{4}-[0-9a-z]{4}-[0-9a-z]{4}-[0-9a-z]{12}$/`.
 
@@ -50,10 +51,12 @@ In addition to all argument references listed, you can access the following attr
 * `output_secret` - (String) The secret that is required to access the image registry. Make sure that the secret is granted with push permissions towards the specified container registry namespace.
   * Constraints: The maximum length is `253` characters. The minimum length is `1` character. The value must match regular expression `/^[a-z0-9]([\\-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([\\-a-z0-9]*[a-z0-9])?)*$/`.
 
+* `region` - (String) The region of the project the resource is located in. Possible values: 'au-syd', 'br-sao', 'ca-tor', 'eu-de', 'eu-gb', 'jp-osa', 'jp-tok', 'us-east', 'us-south'.
+
 * `resource_type` - (String) The type of the build.
   * Constraints: Allowable values are: `build_v2`.
 
-* `source_context_dir` - (String) Option directory in the repository that contains the buildpacks file or the Dockerfile.
+* `source_context_dir` - (String) Optional directory in the repository that contains the buildpacks file or the Dockerfile.
   * Constraints: The maximum length is `253` characters. The minimum length is `0` characters. The value must match regular expression `/^(.*)+$/`.
 
 * `source_revision` - (String) Commit, tag, or branch in the source repository to pull. This field is optional if the `source_type` is `git` and uses the HEAD of default branch if not specified. If the `source_type` value is `local`, this field must be omitted.
@@ -72,11 +75,11 @@ In addition to all argument references listed, you can access the following attr
   * Constraints: Allowable values are: `ready`, `failed`.
 
 * `status_details` - (List) The detailed status of the build.
-Nested scheme for **status_details**:
+Nested schema for **status_details**:
 	* `reason` - (String) Optional information to provide more context in case of a 'failed' or 'warning' status.
 	  * Constraints: Allowable values are: `registered`, `strategy_not_found`, `cluster_build_strategy_not_found`, `set_owner_reference_failed`, `spec_source_secret_not_found`, `spec_output_secret_ref_not_found`, `spec_runtime_secret_ref_not_found`, `multiple_secret_ref_not_found`, `runtime_paths_can_not_be_empty`, `remote_repository_unreachable`, `failed`.
 
-* `strategy_size` - (String) Optional size for the build, which determines the amount of resources used. Build sizes are `small`, `medium`, `large`, `xlarge`.
+* `strategy_size` - (String) Optional size for the build, which determines the amount of resources used. Build sizes are `small`, `medium`, `large`, `xlarge`, `xxlarge`.
   * Constraints: The default value is `medium`. The maximum length is `253` characters. The minimum length is `1` character. The value must match regular expression `/[\\S]*/`.
 
 * `strategy_spec_file` - (String) Optional path to the specification file that is used for build strategies for building an image.
@@ -86,5 +89,5 @@ Nested scheme for **status_details**:
   * Constraints: The default value is `dockerfile`. The maximum length is `253` characters. The minimum length is `1` character. The value must match regular expression `/[\\S]*/`.
 
 * `timeout` - (Integer) The maximum amount of time, in seconds, that can pass before the build must succeed or fail.
-  * Constraints: The maximum value is `3600`. The minimum value is `1`.
+  * Constraints: The default value is `600`. The maximum value is `3600`. The minimum value is `1`.
 

--- a/website/docs/d/code_engine_config_map.html.markdown
+++ b/website/docs/d/code_engine_config_map.html.markdown
@@ -8,7 +8,7 @@ subcategory: "Code Engine"
 
 # ibm_code_engine_config_map
 
-Provides a read-only data source for code_engine_config_map. You can then reference the fields of the data source in other resources within the same configuration using interpolation syntax.
+Provides a read-only data source to retrieve information about a code_engine_config_map. You can then reference the fields of the data source in other resources within the same configuration by using interpolation syntax.
 
 ## Example Usage
 
@@ -21,7 +21,7 @@ data "ibm_code_engine_config_map" "code_engine_config_map" {
 
 ## Argument Reference
 
-Review the argument reference that you can specify for your data source.
+You can specify the following arguments for this data source.
 
 * `name` - (Required, Forces new resource, String) The name of your configmap.
   * Constraints: The maximum length is `253` characters. The minimum length is `1` character. The value must match regular expression `/^[a-z0-9]([\\-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([\\-a-z0-9]*[a-z0-9])?)*$/`.
@@ -30,9 +30,10 @@ Review the argument reference that you can specify for your data source.
 
 ## Attribute Reference
 
-In addition to all argument references listed, you can access the following attribute references after your data source is created.
+After your data source is created, you can read values from the following attributes.
 
 * `id` - The unique identifier of the code_engine_config_map.
+
 * `config_map_id` - (String) The identifier of the resource.
   * Constraints: The maximum length is `36` characters. The minimum length is `36` characters. The value must match regular expression `/^[0-9a-z]{8}-[0-9a-z]{4}-[0-9a-z]{4}-[0-9a-z]{4}-[0-9a-z]{12}$/`.
 
@@ -44,6 +45,8 @@ In addition to all argument references listed, you can access the following attr
 
 * `href` - (String) When you provision a new config map,  a URL is created identifying the location of the instance.
   * Constraints: The maximum length is `2048` characters. The minimum length is `0` characters. The value must match regular expression `/(([^:\/?#]+):)?(\/\/([^\/?#]*))?([^?#]*)(\\?([^#]*))?(#(.*))?$/`.
+
+* `region` - (String) The region of the project the resource is located in. Possible values: 'au-syd', 'br-sao', 'ca-tor', 'eu-de', 'eu-gb', 'jp-osa', 'jp-tok', 'us-east', 'us-south'.
 
 * `resource_type` - (String) The type of the config map.
   * Constraints: Allowable values are: `config_map_v2`.

--- a/website/docs/d/code_engine_domain_mapping.html.markdown
+++ b/website/docs/d/code_engine_domain_mapping.html.markdown
@@ -33,14 +33,15 @@ You can specify the following arguments for this data source.
 After your data source is created, you can read values from the following attributes.
 
 * `id` - The unique identifier of the code_engine_domain_mapping.
+
 * `domain_mapping_id` - (String) The identifier of the resource.
   * Constraints: The maximum length is `36` characters. The minimum length is `36` characters. The value must match regular expression `/^[0-9a-z]{8}-[0-9a-z]{4}-[0-9a-z]{4}-[0-9a-z]{4}-[0-9a-z]{12}$/`.
 
-* `cname_target` - (String) Exposes the value of the CNAME record that needs to be configured in the DNS settings of the domain, to route traffic properly to the target Code Engine region.
+* `cname_target` - (String) The value of the CNAME record that must be configured in the DNS settings of the domain, to route traffic properly to the target Code Engine region.
   * Constraints: The maximum length is `2048` characters. The minimum length is `0` characters. The value must match regular expression `/(([^:\/?#]+):)?(\/\/([^\/?#]*))?([^?#]*)(\\?([^#]*))?(#(.*))?$/`.
 
 * `component` - (List) A reference to another component.
-Nested scheme for **component**:
+Nested schema for **component**:
 	* `name` - (String) The name of the referenced component.
 	  * Constraints: The maximum length is `63` characters. The minimum length is `1` character. The value must match regular expression `/^[a-z0-9]([\\-a-z0-9]*[a-z0-9])?$/`.
 	* `resource_type` - (String) The type of the referenced resource.
@@ -54,22 +55,24 @@ Nested scheme for **component**:
 * `href` - (String) When you provision a new domain mapping, a URL is created identifying the location of the instance.
   * Constraints: The maximum length is `2048` characters. The minimum length is `0` characters. The value must match regular expression `/(([^:\/?#]+):)?(\/\/([^\/?#]*))?([^?#]*)(\\?([^#]*))?(#(.*))?$/`.
 
-* `resource_type` - (String) The type of the CE Resource.
+* `region` - (String) The region of the project the resource is located in. Possible values: 'au-syd', 'br-sao', 'ca-tor', 'eu-de', 'eu-gb', 'jp-osa', 'jp-tok', 'us-east', 'us-south'.
+
+* `resource_type` - (String) The type of the Code Engine resource.
   * Constraints: Allowable values are: `domain_mapping_v2`.
 
 * `status` - (String) The current status of the domain mapping.
-  * Constraints: Possible values are: `ready`, `failed`, `deploying`.
+  * Constraints: Allowable values are: `ready`, `failed`, `deploying`.
 
 * `status_details` - (List) The detailed status of the domain mapping.
-Nested scheme for **status_details**:
+Nested schema for **status_details**:
 	* `reason` - (String) Optional information to provide more context in case of a 'failed' or 'warning' status.
-	  * Constraints: Possible values are: `ready`, `domain_already_claimed`, `app_ref_failed`, `failed_reconcile_ingress`, `deploying`, `failed`.
+	  * Constraints: Allowable values are: `ready`, `domain_already_claimed`, `app_ref_failed`, `failed_reconcile_ingress`, `deploying`, `failed`.
 
-* `tls_secret` - (String) The name of the TLS secret that holds the certificate and private key of this domain mapping.
+* `tls_secret` - (String) The name of the TLS secret that includes the certificate and private key of this domain mapping.
   * Constraints: The maximum length is `253` characters. The minimum length is `1` character. The value must match regular expression `/^[a-z0-9]([\\-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([\\-a-z0-9]*[a-z0-9])?)*$/`.
 
-* `user_managed` - (Boolean) Exposes whether the domain mapping is managed by the user or by Code Engine.
+* `user_managed` - (Boolean) Specifies whether the domain mapping is managed by the user or by Code Engine.
 
-* `visibility` - (String) Exposes whether the domain mapping is reachable through the public internet, or private IBM network, or only through other components within the same Code Engine project.
-  * Constraints: Possible values are: `custom`, `private`, `project`, `public`.
+* `visibility` - (String) Specifies whether the domain mapping is reachable through the public internet, or private IBM network, or only through other components within the same Code Engine project.
+  * Constraints: Allowable values are: `custom`, `private`, `project`, `public`.
 

--- a/website/docs/d/code_engine_job.html.markdown
+++ b/website/docs/d/code_engine_job.html.markdown
@@ -8,7 +8,7 @@ subcategory: "Code Engine"
 
 # ibm_code_engine_job
 
-Provides a read-only data source for code_engine_job. You can then reference the fields of the data source in other resources within the same configuration using interpolation syntax.
+Provides a read-only data source to retrieve information about a code_engine_job. You can then reference the fields of the data source in other resources within the same configuration by using interpolation syntax.
 
 ## Example Usage
 
@@ -21,18 +21,26 @@ data "ibm_code_engine_job" "code_engine_job" {
 
 ## Argument Reference
 
-Review the argument reference that you can specify for your data source.
+You can specify the following arguments for this data source.
 
 * `name` - (Required, Forces new resource, String) The name of your job.
-  * Constraints: The maximum length is `253` characters. The minimum length is `1` character. The value must match regular expression `/^[a-z0-9]([\\-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([\\-a-z0-9]*[a-z0-9])?)*$/`.
+  * Constraints: The maximum length is `63` characters. The minimum length is `1` character. The value must match regular expression `/^[a-z0-9]([\\-a-z0-9]*[a-z0-9])?$/`.
 * `project_id` - (Required, Forces new resource, String) The ID of the project.
   * Constraints: The maximum length is `36` characters. The minimum length is `36` characters. The value must match regular expression `/^[0-9a-z]{8}-[0-9a-z]{4}-[0-9a-z]{4}-[0-9a-z]{4}-[0-9a-z]{12}$/`.
 
 ## Attribute Reference
 
-In addition to all argument references listed, you can access the following attribute references after your data source is created.
+After your data source is created, you can read values from the following attributes.
 
 * `id` - The unique identifier of the code_engine_job.
+
+* `job_id` - (String) The identifier of the resource.
+  * Constraints: The maximum length is `36` characters. The minimum length is `36` characters. The value must match regular expression `/^[0-9a-z]{8}-[0-9a-z]{4}-[0-9a-z]{4}-[0-9a-z]{4}-[0-9a-z]{12}$/`.
+
+* `build` - (String) Reference to a build that is associated with the job.
+
+* `build_run` - (String) Reference to a build run that is associated with the job.
+
 * `created_at` - (String) The timestamp when the resource was created.
 
 * `entity_tag` - (String) The version of the job instance, which is used to achieve optimistic locking.
@@ -47,8 +55,7 @@ In addition to all argument references listed, you can access the following attr
 * `image_secret` - (String) The name of the image registry access secret. The image registry access secret is used to authenticate with a private registry when you download the container image. If the image reference points to a registry that requires authentication, the job / job runs will be created but submitted job runs will fail, until this property is provided, too. This property must not be set on a job run, which references a job template.
   * Constraints: The maximum length is `253` characters. The minimum length is `1` character. The value must match regular expression `/^[a-z0-9]([\\-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([\\-a-z0-9]*[a-z0-9])?)*$/`.
 
-* `job_id` - (String) The identifier of the resource.
-  * Constraints: The maximum length is `36` characters. The minimum length is `36` characters. The value must match regular expression `/^[0-9a-z]{8}-[0-9a-z]{4}-[0-9a-z]{4}-[0-9a-z]{4}-[0-9a-z]{12}$/`.
+* `region` - (String) The region of the project the resource is located in. Possible values: 'au-syd', 'br-sao', 'ca-tor', 'eu-de', 'eu-gb', 'jp-osa', 'jp-tok', 'us-east', 'us-south'.
 
 * `resource_type` - (String) The type of the job.
   * Constraints: Allowable values are: `job_v2`.
@@ -56,14 +63,15 @@ In addition to all argument references listed, you can access the following attr
 * `run_arguments` - (List) Set arguments for the job that are passed to start job run containers. If not specified an empty string array will be applied and the arguments specified by the container image, will be used to start the container.
   * Constraints: The list items must match regular expression `/^.*$/`. The maximum length is `100` items. The minimum length is `0` items.
 
-* `run_as_user` - (Integer) The user ID (UID) to run the job (e.g., 1001).
+* `run_as_user` - (Integer) The user ID (UID) to run the job.
+  * Constraints: The default value is `0`.
 
 * `run_commands` - (List) Set commands for the job that are passed to start job run containers. If not specified an empty string array will be applied and the command specified by the container image, will be used to start the container.
   * Constraints: The list items must match regular expression `/^.*$/`. The maximum length is `100` items. The minimum length is `0` items.
 
 * `run_env_variables` - (List) References to config maps, secrets or literal values, which are exposed as environment variables in the job run.
   * Constraints: The maximum length is `100` items. The minimum length is `0` items.
-Nested scheme for **run_env_variables**:
+Nested schema for **run_env_variables**:
 	* `key` - (String) The key to reference as environment variable.
 	  * Constraints: The maximum length is `253` characters. The minimum length is `1` character. The value must match regular expression `/^[\\-._a-zA-Z0-9]+$/`.
 	* `name` - (String) The name of the environment variable.
@@ -77,15 +85,15 @@ Nested scheme for **run_env_variables**:
 	* `value` - (String) The literal value of the environment variable.
 	  * Constraints: The maximum length is `253` characters. The minimum length is `1` character. The value must match regular expression `/^[\\-._a-zA-Z0-9]+$/`.
 
-* `run_mode` - (String) The mode for runs of the job. Valid values are `task` and `daemon`. In `task` mode, the `scale_max_execution_time` and `scale_retry_limit` properties apply. In `daemon` mode, since there is no timeout and failed instances are restarted indefinitely, the `scale_max_execution_time` and `scale_retry_limit` properties are not allowed.
+* `run_mode` - (String) The mode for runs of the job. Valid values are `task` and `daemon`. In `task` mode, the `max_execution_time` and `retry_limit` properties apply. In `daemon` mode, since there is no timeout and failed instances are restarted indefinitely, the `max_execution_time` and `retry_limit` properties are not allowed.
   * Constraints: The default value is `task`. Allowable values are: `task`, `daemon`. The minimum length is `0` characters. The value must match regular expression `/^(task|daemon)$/`.
 
 * `run_service_account` - (String) The name of the service account. For built-in service accounts, you can use the shortened names `manager`, `none`, `reader`, and `writer`. This property must not be set on a job run, which references a job template.
   * Constraints: The default value is `default`. Allowable values are: `default`, `manager`, `reader`, `writer`, `none`. The minimum length is `0` characters. The value must match regular expression `/^(manager|reader|writer|none|default)$/`.
 
-* `run_volume_mounts` - (List) Optional mounts of config maps or a secrets.
+* `run_volume_mounts` - (List) Optional mounts of config maps or secrets.
   * Constraints: The maximum length is `100` items. The minimum length is `0` items.
-Nested scheme for **run_volume_mounts**:
+Nested schema for **run_volume_mounts**:
 	* `mount_path` - (String) The path that should be mounted.
 	  * Constraints: The maximum length is `256` characters. The minimum length is `1` character. The value must match regular expression `/^\/([^\/\\0]+\/?)+$/`.
 	* `name` - (String) The name of the mount.
@@ -95,7 +103,7 @@ Nested scheme for **run_volume_mounts**:
 	* `type` - (String) Specify the type of the volume mount. Allowed types are: 'config_map', 'secret'.
 	  * Constraints: The default value is `secret`. Allowable values are: `config_map`, `secret`. The value must match regular expression `/^(config_map|secret)$/`.
 
-* `scale_array_spec` - (String) Define a custom set of array indices as comma-separated list containing single values and hyphen-separated ranges like `5,12-14,23,27`. Each instance can pick up its array index via environment variable `JOB_INDEX`. The number of unique array indices specified here determines the number of job instances to run.
+* `scale_array_spec` - (String) Define a custom set of array indices as a comma-separated list containing single values and hyphen-separated ranges, such as  5,12-14,23,27. Each instance gets its array index value from the environment variable JOB_INDEX. The number of unique array indices that you specify with this parameter determines the number of job instances to run.
   * Constraints: The maximum length is `253` characters. The minimum length is `1` character. The value must match regular expression `/^(?:[1-9]\\d\\d\\d\\d\\d\\d|[1-9]\\d\\d\\d\\d\\d|[1-9]\\d\\d\\d\\d|[1-9]\\d\\d\\d|[1-9]\\d\\d|[1-9]?\\d)(?:-(?:[1-9]\\d\\d\\d\\d\\d\\d|[1-9]\\d\\d\\d\\d\\d|[1-9]\\d\\d\\d\\d|[1-9]\\d\\d\\d|[1-9]\\d\\d|[1-9]?\\d))?(?:,(?:[1-9]\\d\\d\\d\\d\\d\\d|[1-9]\\d\\d\\d\\d\\d|[1-9]\\d\\d\\d\\d|[1-9]\\d\\d\\d|[1-9]\\d\\d|[1-9]?\\d)(?:-(?:[1-9]\\d\\d\\d\\d\\d\\d|[1-9]\\d\\d\\d\\d\\d|[1-9]\\d\\d\\d\\d|[1-9]\\d\\d\\d|[1-9]\\d\\d|[1-9]?\\d))?)*$/`.
 
 * `scale_cpu_limit` - (String) Optional amount of CPU set for the instance of the job. For valid values see [Supported memory and CPU combinations](https://cloud.ibm.com/docs/codeengine?topic=codeengine-mem-cpu-combo).
@@ -105,9 +113,11 @@ Nested scheme for **run_volume_mounts**:
   * Constraints: The default value is `400M`. The maximum length is `10` characters. The minimum length is `0` characters. The value must match regular expression `/^([0-9.]+)([eEinumkKMGTPB]*)$/`.
 
 * `scale_max_execution_time` - (Integer) The maximum execution time in seconds for runs of the job. This property can only be specified if `run_mode` is `task`.
+  * Constraints: The default value is `7200`.
 
 * `scale_memory_limit` - (String) Optional amount of memory set for the instance of the job. For valid values see [Supported memory and CPU combinations](https://cloud.ibm.com/docs/codeengine?topic=codeengine-mem-cpu-combo). The units for specifying memory are Megabyte (M) or Gigabyte (G), whereas G and M are the shorthand expressions for GB and MB. For more information see [Units of measurement](https://cloud.ibm.com/docs/codeengine?topic=codeengine-mem-cpu-combo#unit-measurements).
   * Constraints: The default value is `4G`. The maximum length is `10` characters. The minimum length is `0` characters. The value must match regular expression `/^([0-9.]+)([eEinumkKMGTPB]*)$/`.
 
 * `scale_retry_limit` - (Integer) The number of times to rerun an instance of the job before the job is marked as failed. This property can only be specified if `run_mode` is `task`.
+  * Constraints: The default value is `3`.
 

--- a/website/docs/d/code_engine_project.html.markdown
+++ b/website/docs/d/code_engine_project.html.markdown
@@ -8,7 +8,7 @@ subcategory: "Code Engine"
 
 # ibm_code_engine_project
 
-Provides a read-only data source for code_engine_project. You can then reference the fields of the data source in other resources within the same configuration using interpolation syntax.
+Provides a read-only data source to retrieve information about a code_engine_project. You can then reference the fields of the data source in other resources within the same configuration by using interpolation syntax.
 
 ## Example Usage
 
@@ -20,16 +20,17 @@ data "ibm_code_engine_project" "code_engine_project" {
 
 ## Argument Reference
 
-Review the argument reference that you can specify for your data source.
+You can specify the following arguments for this data source.
 
 * `project_id` - (Required, Forces new resource, String) The ID of the project.
   * Constraints: The maximum length is `36` characters. The minimum length is `36` characters. The value must match regular expression `/^[0-9a-z]{8}-[0-9a-z]{4}-[0-9a-z]{4}-[0-9a-z]{4}-[0-9a-z]{12}$/`.
 
 ## Attribute Reference
 
-In addition to all argument references listed, you can access the following attribute references after your data source is created.
+After your data source is created, you can read values from the following attributes.
 
 * `id` - The unique identifier of the code_engine_project.
+
 * `account_id` - (String) An alphanumeric value identifying the account ID.
 
 * `created_at` - (String) The timestamp when the project was created.
@@ -39,11 +40,10 @@ In addition to all argument references listed, you can access the following attr
 * `href` - (String) When you provision a new resource, a URL is created identifying the location of the instance.
   * Constraints: The maximum length is `2048` characters. The minimum length is `0` characters. The value must match regular expression `/(([^:\/?#]+):)?(\/\/([^\/?#]*))?([^?#]*)(\\?([^#]*))?(#(.*))?$/`.
 
-* `name` - (String) The name of the project.
+* `name` - (Forces new resource, String) The name of the project.
   * Constraints: The maximum length is `128` characters. The minimum length is `1` character. The value must match regular expression `/^([^\\x00-\\x7F]|[a-zA-Z0-9\\-._: ])+$/`.
 
-* `region` - (String) The region for your project deployment.
-  * Constraints: Possible values are: `au-syd`, `br-sao`, `ca-tor`, `eu-de`, `eu-gb`, `jp-osa`, `jp-tok`, `us-east`, `us-south`.
+* `region` - (String) The region for your project deployment. Possible values: `au-syd`, `br-sao`, `ca-tor`, `eu-de`, `eu-es`, `eu-gb`, `jp-osa`, `jp-tok`, `us-east`, `us-south`.
 
 * `resource_group_id` - (String) The ID of the resource group.
   * Constraints: The maximum length is `32` characters. The minimum length is `32` characters. The value must match regular expression `/^[a-z0-9]*$/`.
@@ -51,6 +51,6 @@ In addition to all argument references listed, you can access the following attr
 * `resource_type` - (String) The type of the project.
   * Constraints: Allowable values are: `project_v2`.
 
-* `status` - (String) The current state of the project. For example, if the project is created and ready to get used, it will return `active`. After deleting a project it will remain in `status` `soft_deleted` for a seven day period, during which it will still be retrievable.
-  * Constraints: Possible values are: `active`, `inactive`, `pending_removal`, `hard_deleting`, `hard_deletion_failed`, `hard_deleted`, `deleting`, `deletion_failed`, `soft_deleted`, `preparing`, `creating`, `creation_failed`.
+* `status` - (String) The current state of the project. For example, when the project is created and is ready for use, the status of the project is active. After deleting a project it will remain in `status` `soft_deleted` for a seven day period, during which it will still be retrievable.
+  * Constraints: Allowable values are: `active`, `inactive`, `pending_removal`, `hard_deleting`, `hard_deletion_failed`, `hard_deleted`, `deleting`, `deletion_failed`, `soft_deleted`, `preparing`, `creating`, `creation_failed`.
 

--- a/website/docs/d/code_engine_secret.html.markdown
+++ b/website/docs/d/code_engine_secret.html.markdown
@@ -33,41 +33,64 @@ You can specify the following arguments for this data source.
 After your data source is created, you can read values from the following attributes.
 
 * `id` - The unique identifier of the code_engine_secret.
+
+* `secret_id` - (String) The identifier of the resource.
+  * Constraints: The maximum length is `36` characters. The minimum length is `36` characters. The value must match regular expression `/^[0-9a-z]{8}-[0-9a-z]{4}-[0-9a-z]{4}-[0-9a-z]{4}-[0-9a-z]{12}$/`.
+
 * `created_at` - (String) The timestamp when the resource was created.
 
-* `data` - (Map) Data container that allows to specify config parameters and their values as a key-value map. Each key field must consist of alphanumeric characters, `-`, `_` or `.` and must not be exceed a max length of 253 characters. Each value field can consists of any character and must not be exceed a max length of 1048576 characters.
+* `data` - (Map) Data container that allows to specify config parameters and their values as a key-value map. Each key field must consist of alphanumeric characters, `-`, `_` or `.` and must not exceed a max length of 253 characters. Each value field can consists of any character and must not exceed a max length of 1048576 characters.
 
 * `entity_tag` - (String) The version of the secret instance, which is used to achieve optimistic locking.
   * Constraints: The maximum length is `63` characters. The minimum length is `1` character. The value must match regular expression `/^[\\*\\-a-z0-9]+$/`.
 
 * `format` - (Forces new resource, String) Specify the format of the secret.
-  * Constraints: Allowable values are: `generic`, `ssh_auth`, `basic_auth`, `tls`, `service_access`, `registry`. The value must match regular expression `/^(generic|ssh_auth|basic_auth|tls|service_access|registry)$/`.
+  * Constraints: Allowable values are: `generic`, `ssh_auth`, `basic_auth`, `tls`, `service_access`, `registry`, `service_operator`, `other`. The value must match regular expression `/^(generic|ssh_auth|basic_auth|tls|service_access|registry|service_operator|other)$/`.
 
 * `href` - (String) When you provision a new secret,  a URL is created identifying the location of the instance.
   * Constraints: The maximum length is `2048` characters. The minimum length is `0` characters. The value must match regular expression `/(([^:\/?#]+):)?(\/\/([^\/?#]*))?([^?#]*)(\\?([^#]*))?(#(.*))?$/`.
 
+* `region` - (String) The region of the project the resource is located in. Possible values: 'au-syd', 'br-sao', 'ca-tor', 'eu-de', 'eu-gb', 'jp-osa', 'jp-tok', 'us-east', 'us-south'.
+
 * `resource_type` - (String) The type of the secret.
 
-* `secret_id` - (String) The identifier of the resource.
-  * Constraints: The maximum length is `36` characters. The minimum length is `36` characters. The value must match regular expression `/^[0-9a-z]{8}-[0-9a-z]{4}-[0-9a-z]{4}-[0-9a-z]{4}-[0-9a-z]{12}$/`.
-
 * `service_access` - (Forces new resource, List) Properties for Service Access Secrets.
-Nested scheme for **service_access**:
+Nested schema for **service_access**:
 	* `resource_key` - (List) The service credential associated with the secret.
-	Nested scheme for **resource_key**:
+	Nested schema for **resource_key**:
 		* `id` - (String) ID of the service credential associated with the secret.
 		  * Constraints: The maximum length is `36` characters. The minimum length is `0` characters. The value must match regular expression `/^[a-z0-9][\\-a-z0-9]*[a-z0-9]$/`.
 		* `name` - (String) Name of the service credential associated with the secret.
 	* `role` - (List) A reference to the Role and Role CRN for service binding.
-	Nested scheme for **role**:
-		* `crn` - (String) CRN of the IAM Role for thise service access secret.
+	Nested schema for **role**:
+		* `crn` - (String) CRN of the IAM Role for this service access secret.
 		  * Constraints: The maximum length is `253` characters. The minimum length is `0` characters. The value must match regular expression `/^[A-Z][a-zA-Z() ]*[a-z)]$|^crn\\:v1\\:[a-zA-Z0-9]*\\:(public|dedicated|local)\\:[\\-a-z0-9]*\\:([a-z][\\-a-z0-9_]*[a-z0-9])?\\:((a|o|s)\/[\\-a-z0-9]+)?\\:[\\-a-z0-9\/]*\\:[\\-a-zA-Z0-9]*(\\:[\\-a-zA-Z0-9\/.]*)?$/`.
 		* `name` - (String) Role of the service credential.
 		  * Constraints: The default value is `Writer`.
 	* `service_instance` - (List) The IBM Cloud service instance associated with the secret.
-	Nested scheme for **service_instance**:
+	Nested schema for **service_instance**:
 		* `id` - (String) ID of the IBM Cloud service instance associated with the secret.
 		  * Constraints: The maximum length is `36` characters. The minimum length is `36` characters. The value must match regular expression `/^[a-z0-9][\\-a-z0-9]*[a-z0-9]$/`.
 		* `type` - (String) Type of IBM Cloud service associated with the secret.
 		  * Constraints: The maximum length is `253` characters. The minimum length is `1` character. The value must match regular expression `/^.*$/`.
+	* `serviceid` - (List) A reference to a Service ID.
+	Nested schema for **serviceid**:
+		* `crn` - (String) CRN value of a Service ID.
+		  * Constraints: The maximum length is `253` characters. The minimum length is `0` characters. The value must match regular expression `/^crn\\:v1\\:[a-zA-Z0-9]*\\:(public|dedicated|local)\\:[\\-a-z0-9]*\\:([a-z][\\-a-z0-9_]*[a-z0-9])?\\:((a|o|s)\/[\\-a-z0-9]+)?\\:[\\-a-z0-9\/]*\\:[\\-a-zA-Z0-9]*(\\:[\\-a-zA-Z0-9\/.]*)?$/`.
+		* `id` - (String) The ID of the Service ID.
+		  * Constraints: The maximum length is `46` characters. The minimum length is `46` characters. The value must match regular expression `/^ServiceId-[0-9a-z]{8}-[0-9a-z]{4}-[0-9a-z]{4}-[0-9a-z]{4}-[0-9a-z]{12}$/`.
+
+* `service_operator` - (List) Properties for the IBM Cloud Operator Secret.
+Nested schema for **service_operator**:
+	* `apikey_id` - (String) The ID of the apikey associated with the operator secret.
+	  * Constraints: The maximum length is `43` characters. The minimum length is `43` characters. The value must match regular expression `/^ApiKey-[0-9a-z]{8}-[0-9a-z]{4}-[0-9a-z]{4}-[0-9a-z]{4}-[0-9a-z]{12}$/`.
+	* `resource_group_ids` - (List) The list of resource groups (by ID) that the operator secret can bind services in.
+	  * Constraints: The list items must match regular expression `/^[a-z0-9]*$/`. The maximum length is `100` items. The minimum length is `0` items.
+	* `serviceid` - (List) A reference to a Service ID.
+	Nested schema for **serviceid**:
+		* `crn` - (String) CRN value of a Service ID.
+		  * Constraints: The maximum length is `253` characters. The minimum length is `0` characters. The value must match regular expression `/^crn\\:v1\\:[a-zA-Z0-9]*\\:(public|dedicated|local)\\:[\\-a-z0-9]*\\:([a-z][\\-a-z0-9_]*[a-z0-9])?\\:((a|o|s)\/[\\-a-z0-9]+)?\\:[\\-a-z0-9\/]*\\:[\\-a-zA-Z0-9]*(\\:[\\-a-zA-Z0-9\/.]*)?$/`.
+		* `id` - (String) The ID of the Service ID.
+		  * Constraints: The maximum length is `46` characters. The minimum length is `46` characters. The value must match regular expression `/^ServiceId-[0-9a-z]{8}-[0-9a-z]{4}-[0-9a-z]{4}-[0-9a-z]{4}-[0-9a-z]{12}$/`.
+	* `user_managed` - (Boolean) Specifies whether the operator secret is user managed.
 

--- a/website/docs/r/code_engine_app.html.markdown
+++ b/website/docs/r/code_engine_app.html.markdown
@@ -51,19 +51,51 @@ You can specify the following arguments for this resource.
   * Constraints: The maximum length is `253` characters. The minimum length is `1` character. The value must match regular expression `/^[a-z0-9]([\\-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([\\-a-z0-9]*[a-z0-9])?)*$/`.
 * `managed_domain_mappings` - (Optional, String) Optional value controlling which of the system managed domain mappings will be setup for the application. Valid values are 'local_public', 'local_private' and 'local'. Visibility can only be 'local_private' if the project supports application private visibility.
   * Constraints: The default value is `local_public`. Allowable values are: `local`, `local_private`, `local_public`.
-* `name` - (Required, Forces new resource, String) The name of the app. Use a name that is unique within the project.
+* `name` - (Required, Forces new resource, String) The name of the app.
   * Constraints: The maximum length is `63` characters. The minimum length is `1` character. The value must match regular expression `/^[a-z]([-a-z0-9]*[a-z0-9])?$/`.
+* `probe_liveness` - (Optional, List) Response model for probes.
+Nested schema for **probe_liveness**:
+	* `failure_threshold` - (Optional, Integer) The number of consecutive, unsuccessful checks for the probe to be considered failed.
+	  * Constraints: The default value is `1`. The maximum value is `10`. The minimum value is `1`.
+	* `initial_delay` - (Optional, Integer) The amount of time in seconds to wait before the first probe check is performed.
+	  * Constraints: The maximum value is `10`. The minimum value is `1`.
+	* `interval` - (Optional, Integer) The amount of time in seconds between probe checks.
+	  * Constraints: The default value is `10`. The maximum value is `60`. The minimum value is `1`.
+	* `path` - (Optional, String) The path of the HTTP request to the resource. A path is only supported for a probe with a `type` of `http`.
+	  * Constraints: The maximum length is `2048` characters. The minimum length is `0` characters. The value must match regular expression `/^\/(([a-zA-Z0-9-._~!$&'()*+,;=:@]|%[a-fA-F0-9]{2})+(\/([a-zA-Z0-9-._~!$&'()*+,;=:@]|%[a-fA-F0-9]{2})*)*)?(\\?([a-zA-Z0-9-._~!$&'()*+,;=:@\/?]|%[a-fA-F0-9]{2})*)?$/`.
+	* `port` - (Optional, Integer) The port on which to probe the resource.
+	  * Constraints: The maximum value is `65535`. The minimum value is `1`.
+	* `timeout` - (Optional, Integer) The amount of time in seconds that the probe waits for a response from the application before it times out and fails.
+	  * Constraints: The default value is `1`. The maximum value is `3600`. The minimum value is `1`.
+	* `type` - (Optional, String) Specifies whether to use HTTP or TCP for the probe checks. The default is TCP.
+	  * Constraints: Allowable values are: `tcp`, `http`.
+* `probe_readiness` - (Optional, List) Response model for probes.
+Nested schema for **probe_readiness**:
+	* `failure_threshold` - (Optional, Integer) The number of consecutive, unsuccessful checks for the probe to be considered failed.
+	  * Constraints: The default value is `1`. The maximum value is `10`. The minimum value is `1`.
+	* `initial_delay` - (Optional, Integer) The amount of time in seconds to wait before the first probe check is performed.
+	  * Constraints: The maximum value is `10`. The minimum value is `1`.
+	* `interval` - (Optional, Integer) The amount of time in seconds between probe checks.
+	  * Constraints: The default value is `10`. The maximum value is `60`. The minimum value is `1`.
+	* `path` - (Optional, String) The path of the HTTP request to the resource. A path is only supported for a probe with a `type` of `http`.
+	  * Constraints: The maximum length is `2048` characters. The minimum length is `0` characters. The value must match regular expression `/^\/(([a-zA-Z0-9-._~!$&'()*+,;=:@]|%[a-fA-F0-9]{2})+(\/([a-zA-Z0-9-._~!$&'()*+,;=:@]|%[a-fA-F0-9]{2})*)*)?(\\?([a-zA-Z0-9-._~!$&'()*+,;=:@\/?]|%[a-fA-F0-9]{2})*)?$/`.
+	* `port` - (Optional, Integer) The port on which to probe the resource.
+	  * Constraints: The maximum value is `65535`. The minimum value is `1`.
+	* `timeout` - (Optional, Integer) The amount of time in seconds that the probe waits for a response from the application before it times out and fails.
+	  * Constraints: The default value is `1`. The maximum value is `3600`. The minimum value is `1`.
+	* `type` - (Optional, String) Specifies whether to use HTTP or TCP for the probe checks. The default is TCP.
+	  * Constraints: Allowable values are: `tcp`, `http`.
 * `project_id` - (Required, Forces new resource, String) The ID of the project.
   * Constraints: The maximum length is `36` characters. The minimum length is `36` characters. The value must match regular expression `/^[0-9a-z]{8}-[0-9a-z]{4}-[0-9a-z]{4}-[0-9a-z]{4}-[0-9a-z]{12}$/`.
 * `run_arguments` - (Optional, List) Optional arguments for the app that are passed to start the container. If not specified an empty string array will be applied and the arguments specified by the container image, will be used to start the container.
   * Constraints: The list items must match regular expression `/^.*$/`. The maximum length is `100` items. The minimum length is `0` items.
-* `run_as_user` - (Optional, Integer) Optional user ID (UID) to run the app (e.g., `1001`).
+* `run_as_user` - (Optional, Integer) Optional user ID (UID) to run the app.
   * Constraints: The default value is `0`.
 * `run_commands` - (Optional, List) Optional commands for the app that are passed to start the container. If not specified an empty string array will be applied and the command specified by the container image, will be used to start the container.
   * Constraints: The list items must match regular expression `/^.*$/`. The maximum length is `100` items. The minimum length is `0` items.
-* `run_env_variables` - (Optional, List) Optional references to config maps, secrets or literal values that are exposed as environment variables within the running application.
+* `run_env_variables` - (Optional, List) References to config maps, secrets or literal values, which are exposed as environment variables in the application.
   * Constraints: The maximum length is `100` items. The minimum length is `0` items.
-Nested scheme for **run_env_variables**:
+Nested schema for **run_env_variables**:
 	* `key` - (Optional, String) The key to reference as environment variable.
 	  * Constraints: The maximum length is `253` characters. The minimum length is `1` character. The value must match regular expression `/^[\\-._a-zA-Z0-9]+$/`.
 	* `name` - (Optional, String) The name of the environment variable.
@@ -78,12 +110,12 @@ Nested scheme for **run_env_variables**:
 	  * Constraints: The maximum length is `253` characters. The minimum length is `1` character. The value must match regular expression `/^[\\-._a-zA-Z0-9]+$/`.
 * `run_service_account` - (Optional, String) Optional name of the service account. For built-in service accounts, you can use the shortened names `manager` , `none`, `reader`, and `writer`.
   * Constraints: The default value is `default`. Allowable values are: `default`, `manager`, `reader`, `writer`, `none`. The minimum length is `0` characters. The value must match regular expression `/^(manager|reader|writer|none|default)$/`.
-* `run_volume_mounts` - (Optional, List) Optional mounts of config maps or a secrets.
+* `run_volume_mounts` - (Optional, List) Mounts of config maps or secrets.
   * Constraints: The maximum length is `100` items. The minimum length is `0` items.
-Nested scheme for **run_volume_mounts**:
+Nested schema for **run_volume_mounts**:
 	* `mount_path` - (Required, String) The path that should be mounted.
 	  * Constraints: The maximum length is `256` characters. The minimum length is `1` character. The value must match regular expression `/^\/([^\/\\0]+\/?)+$/`.
-	* `name` - (Optional, String) Optional name of the mount. If not set, it will be generated based on the `ref` and a random ID. In case the `ref` is longer than 58 characters, it will be cut off.
+	* `name` - (Required, String) The name of the mount.
 	  * Constraints: The maximum length is `63` characters. The minimum length is `0` characters. The value must match regular expression `/^[a-z]([-a-z0-9]*[a-z0-9])?$/`.
 	* `reference` - (Required, String) The name of the referenced secret or config map.
 	  * Constraints: The maximum length is `253` characters. The minimum length is `1` character. The value must match regular expression `/^[a-z0-9]([\\-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([\\-a-z0-9]*[a-z0-9])?)*$/`.
@@ -94,7 +126,7 @@ Nested scheme for **run_volume_mounts**:
 * `scale_concurrency_target` - (Optional, Integer) Optional threshold of concurrent requests per instance at which one or more additional instances are created. Use this value to scale up instances based on concurrent number of requests. This option defaults to the value of the `scale_concurrency` option, if not specified.
 * `scale_cpu_limit` - (Optional, String) Optional number of CPU set for the instance of the app. For valid values see [Supported memory and CPU combinations](https://cloud.ibm.com/docs/codeengine?topic=codeengine-mem-cpu-combo).
   * Constraints: The default value is `1`. The maximum length is `10` characters. The minimum length is `0` characters. The value must match regular expression `/^([0-9.]+)([eEinumkKMGTPB]*)$/`.
-* `scale_down_delay` - (Optional, Integer) Optional amount of time in seconds that delays the scale down behavior for an app instance.
+* `scale_down_delay` - (Optional, Integer) Optional amount of time in seconds that delays the scale-down behavior for an app instance.
   * Constraints: The default value is `0`. The maximum value is `3600`. The minimum value is `0`.
 * `scale_ephemeral_storage_limit` - (Optional, String) Optional amount of ephemeral storage to set for the instance of the app. The amount specified as ephemeral storage, must not exceed the amount of `scale_memory_limit`. The units for specifying ephemeral storage are Megabyte (M) or Gigabyte (G), whereas G and M are the shorthand expressions for GB and MB. For more information see [Units of measurement](https://cloud.ibm.com/docs/codeengine?topic=codeengine-mem-cpu-combo#unit-measurements).
   * Constraints: The default value is `400M`. The maximum length is `10` characters. The minimum length is `0` characters. The value must match regular expression `/^([0-9.]+)([eEinumkKMGTPB]*)$/`.
@@ -116,19 +148,22 @@ After your resource is created, you can read values from the listed arguments an
 * `id` - The unique identifier of the code_engine_app.
 * `app_id` - (String) The identifier of the resource.
   * Constraints: The maximum length is `36` characters. The minimum length is `36` characters. The value must match regular expression `/^[0-9a-z]{8}-[0-9a-z]{4}-[0-9a-z]{4}-[0-9a-z]{4}-[0-9a-z]{12}$/`.
+* `build` - (String) Reference to a build that is associated with the application.
+* `build_run` - (String) Reference to a build run that is associated with the application.
 * `created_at` - (String) The timestamp when the resource was created.
-* `endpoint` - (String) Optional URL to invoke app. Depending on visibility this is accessible publicly or in the private network only. Empty in case 'managed_domain_mappings' is set to 'local'.
-* `endpoint_internal` - (String) URL to app that is only visible within the project.
+* `endpoint` - (String) Optional URL to invoke the app. Depending on visibility,  this is accessible publicly or in the private network only. Empty in case 'managed_domain_mappings' is set to 'local'.
+* `endpoint_internal` - (String) The URL to the app that is only visible within the project.
 * `entity_tag` - (String) The version of the app instance, which is used to achieve optimistic locking.
   * Constraints: The maximum length is `63` characters. The minimum length is `1` character. The value must match regular expression `/^[\\*\\-a-z0-9]+$/`.
 * `href` - (String) When you provision a new app,  a URL is created identifying the location of the instance.
   * Constraints: The maximum length is `2048` characters. The minimum length is `0` characters. The value must match regular expression `/(([^:\/?#]+):)?(\/\/([^\/?#]*))?([^?#]*)(\\?([^#]*))?(#(.*))?$/`.
+* `region` - (String) The region of the project the resource is located in. Possible values: 'au-syd', 'br-sao', 'ca-tor', 'eu-de', 'eu-gb', 'jp-osa', 'jp-tok', 'us-east', 'us-south'.
 * `resource_type` - (String) The type of the app.
   * Constraints: Allowable values are: `app_v2`.
 * `status` - (String) The current status of the app.
   * Constraints: Allowable values are: `ready`, `deploying`, `failed`, `warning`.
 * `status_details` - (List) The detailed status of the application.
-Nested scheme for **status_details**:
+Nested schema for **status_details**:
 	* `latest_created_revision` - (String) Latest app revision that has been created.
 	* `latest_ready_revision` - (String) Latest app revision that reached a ready state.
 	* `reason` - (String) Optional information to provide more context in case of a 'failed' or 'warning' status.
@@ -140,13 +175,13 @@ Nested scheme for **status_details**:
 You can import the `ibm_code_engine_app` resource by using `name`.
 The `name` property can be formed from `project_id`, and `name` in the following format:
 
-```
-<project_id>/<name>
-```
+<pre>
+&lt;project_id&gt;/&lt;name&gt;
+</pre>
 * `project_id`: A string in the format `15314cc3-85b4-4338-903f-c28cdee6d005`. The ID of the project.
-* `name`: A string in the format `my-app`. The name of your application.
+* `name`: A string in the format `my-app`. The name of the app.
 
 # Syntax
-```
-$ terraform import ibm_code_engine_app.code_engine_app <project_id>/<name>
-```
+<pre>
+$ terraform import ibm_code_engine_app.code_engine_app &lt;project_id&gt;/&lt;name&gt;
+</pre>

--- a/website/docs/r/code_engine_binding.html.markdown
+++ b/website/docs/r/code_engine_binding.html.markdown
@@ -36,16 +36,16 @@ code_engine_binding provides the following [Timeouts](https://www.terraform.io/d
 You can specify the following arguments for this resource.
 
 * `component` - (Required, Forces new resource, List) A reference to another component.
-Nested scheme for **component**:
+Nested schema for **component**:
 	* `name` - (Required, String) The name of the referenced component.
 	  * Constraints: The maximum length is `63` characters. The minimum length is `1` character. The value must match regular expression `/^[a-z0-9]([\\-a-z0-9]*[a-z0-9])?$/`.
 	* `resource_type` - (Required, String) The type of the referenced resource.
 	  * Constraints: The maximum length is `63` characters. The minimum length is `1` character. The value must match regular expression `/.+/`.
-* `prefix` - (Required, Forces new resource, String) Optional value that is set as prefix in the component that is bound. Will be generated if not provided.
+* `prefix` - (Required, Forces new resource, String) The value that is set as a prefix in the component that is bound.
   * Constraints: The maximum length is `31` characters. The minimum length is `0` characters. The value must match regular expression `/^[A-Z]([_A-Z0-9]*[A-Z0-9])*$/`.
 * `project_id` - (Required, Forces new resource, String) The ID of the project.
   * Constraints: The maximum length is `36` characters. The minimum length is `36` characters. The value must match regular expression `/^[0-9a-z]{8}-[0-9a-z]{4}-[0-9a-z]{4}-[0-9a-z]{4}-[0-9a-z]{12}$/`.
-* `secret_name` - (Required, Forces new resource, String) The service access secret that is binding to a component.
+* `secret_name` - (Required, Forces new resource, String) The service access secret that is bound to a component.
   * Constraints: The maximum length is `253` characters. The minimum length is `1` character. The value must match regular expression `/^[a-z0-9]([\\-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([\\-a-z0-9]*[a-z0-9])?)*$/`.
 
 ## Attribute Reference
@@ -53,7 +53,7 @@ Nested scheme for **component**:
 After your resource is created, you can read values from the listed arguments and the following attributes.
 
 * `id` - The unique identifier of the code_engine_binding.
-* `binding_id` - (String) The ID of the binding.
+* `code_engine_binding_id` - (String) The ID of the binding.
   * Constraints: The maximum length is `253` characters. The minimum length is `1` character. The value must match regular expression `/.+/`.
 * `href` - (String) When you provision a new binding,  a URL is created identifying the location of the instance.
   * Constraints: The maximum length is `2048` characters. The minimum length is `0` characters. The value must match regular expression `/(([^:\/?#]+):)?(\/\/([^\/?#]*))?([^?#]*)(\\?([^#]*))?(#(.*))?$/`.
@@ -64,16 +64,16 @@ After your resource is created, you can read values from the listed arguments an
 
 ## Import
 
-You can import the `ibm_code_engine_binding` resource by using `binding_id`.
-The `id` property can be formed from `project_id`, and `binding_id` in the following format:
+You can import the `ibm_code_engine_binding` resource by using `id`.
+The `id` property can be formed from `project_id`, and `code_engine_binding_id` in the following format:
 
-```
-<project_id>/<id>
-```
+<pre>
+&lt;project_id&gt;/&lt;code_engine_binding_id&gt;
+</pre>
 * `project_id`: A string in the format `15314cc3-85b4-4338-903f-c28cdee6d005`. The ID of the project.
-* `binding_id`: A string in the format `a172ced-b5f21bc-71ba50c-1638604`. The ID of your binding.
+* `code_engine_binding_id`: A string in the format `a172ced-b5f21bc-71ba50c-1638604`. The ID of the binding.
 
 # Syntax
-```
-$ terraform import ibm_code_engine_binding.code_engine_binding <project_id>/<binding_id>
-```
+<pre>
+$ terraform import ibm_code_engine_binding.code_engine_binding &lt;project_id&gt;/&lt;code_engine_binding_id&gt;
+</pre>

--- a/website/docs/r/code_engine_build.html.markdown
+++ b/website/docs/r/code_engine_build.html.markdown
@@ -8,7 +8,7 @@ subcategory: "Code Engine"
 
 # ibm_code_engine_build
 
-Provides a resource for code_engine_build. This allows code_engine_build to be created, updated and deleted.
+Create, update, and delete code_engine_builds with this resource.
 
 ## Example Usage
 
@@ -25,9 +25,9 @@ resource "ibm_code_engine_build" "code_engine_build_instance" {
 
 ## Argument Reference
 
-Review the argument reference that you can specify for your resource.
+You can specify the following arguments for this resource.
 
-* `name` - (Required, String) The name of the build. Use a name that is unique within the project.
+* `name` - (Required, Forces new resource, String) The name of the build.
   * Constraints: The maximum length is `63` characters. The minimum length is `1` character. The value must match regular expression `/^[a-z0-9]([\\-a-z0-9]*[a-z0-9])?$/`.
 * `output_image` - (Required, String) The name of the image.
   * Constraints: The maximum length is `256` characters. The minimum length is `1` character. The value must match regular expression `/^([a-z0-9][a-z0-9\\-_.]+[a-z0-9][\/])?([a-z0-9][a-z0-9\\-_]+[a-z0-9][\/])?[a-z0-9][a-z0-9\\-_.\/]+[a-z0-9](:[\\w][\\w.\\-]{0,127})?(@sha256:[a-fA-F0-9]{64})?$/`.
@@ -35,7 +35,7 @@ Review the argument reference that you can specify for your resource.
   * Constraints: The maximum length is `253` characters. The minimum length is `1` character. The value must match regular expression `/^[a-z0-9]([\\-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([\\-a-z0-9]*[a-z0-9])?)*$/`.
 * `project_id` - (Required, Forces new resource, String) The ID of the project.
   * Constraints: The maximum length is `36` characters. The minimum length is `36` characters. The value must match regular expression `/^[0-9a-z]{8}-[0-9a-z]{4}-[0-9a-z]{4}-[0-9a-z]{4}-[0-9a-z]{12}$/`.
-* `source_context_dir` - (Optional, String) Option directory in the repository that contains the buildpacks file or the Dockerfile.
+* `source_context_dir` - (Optional, String) Optional directory in the repository that contains the buildpacks file or the Dockerfile.
   * Constraints: The maximum length is `253` characters. The minimum length is `0` characters. The value must match regular expression `/^(.*)+$/`.
 * `source_revision` - (Optional, String) Commit, tag, or branch in the source repository to pull. This field is optional if the `source_type` is `git` and uses the HEAD of default branch if not specified. If the `source_type` value is `local`, this field must be omitted.
   * Constraints: The maximum length is `253` characters. The minimum length is `0` characters. The value must match regular expression `/^[\\S]*$/`.
@@ -43,9 +43,9 @@ Review the argument reference that you can specify for your resource.
   * Constraints: The maximum length is `253` characters. The minimum length is `1` character. The value must match regular expression `/^[a-z0-9]([\\-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([\\-a-z0-9]*[a-z0-9])?)*$/`.
 * `source_type` - (Optional, String) Specifies the type of source to determine if your build source is in a repository or based on local source code.* local - For builds from local source code.* git - For builds from git version controlled source code.
   * Constraints: The default value is `git`. Allowable values are: `local`, `git`.
-* `source_url` - (Required, String) The URL of the code repository. This field is required if the `source_type` is `git`. If the `source_type` value is `local`, this field must be omitted. If the repository is publicly available you can provide a 'https' URL like `https://github.com/IBM/CodeEngine`. If the repository requires authentication, you need to provide a 'ssh' URL like `git@github.com:IBM/CodeEngine.git` along with a `source_secret` that points to a secret of format `ssh_auth`.
+* `source_url` - (Optional, String) The URL of the code repository. This field is required if the `source_type` is `git`. If the `source_type` value is `local`, this field must be omitted. If the repository is publicly available you can provide a 'https' URL like `https://github.com/IBM/CodeEngine`. If the repository requires authentication, you need to provide a 'ssh' URL like `git@github.com:IBM/CodeEngine.git` along with a `source_secret` that points to a secret of format `ssh_auth`.
   * Constraints: The maximum length is `253` characters. The minimum length is `1` character. The value must match regular expression `/^((https:\/\/[a-z0-9]([\\-.]?[a-z0-9])+(:\\d{1,5})?)|((ssh:\/\/)?git@[a-z0-9]([\\-.]{0,1}[a-z0-9])+(:[a-zA-Z0-9\/][\\w\\-.]*)?))(\/([\\w\\-.]|%20)+)*$/`.
-* `strategy_size` - (Optional, String) Optional size for the build, which determines the amount of resources used. Build sizes are `small`, `medium`, `large`, `xlarge`.
+* `strategy_size` - (Optional, String) Optional size for the build, which determines the amount of resources used. Build sizes are `small`, `medium`, `large`, `xlarge`, `xxlarge`.
   * Constraints: The default value is `medium`. The maximum length is `253` characters. The minimum length is `1` character. The value must match regular expression `/[\\S]*/`.
 * `strategy_spec_file` - (Optional, String) Optional path to the specification file that is used for build strategies for building an image.
   * Constraints: The default value is `Dockerfile`. The maximum length is `253` characters. The minimum length is `1` character. The value must match regular expression `/^[\\S]*$/`.
@@ -56,7 +56,7 @@ Review the argument reference that you can specify for your resource.
 
 ## Attribute Reference
 
-In addition to all argument references listed, you can access the following attribute references after your resource is created.
+After your resource is created, you can read values from the listed arguments and the following attributes.
 
 * `id` - The unique identifier of the code_engine_build.
 * `build_id` - (String) The identifier of the resource.
@@ -66,14 +66,16 @@ In addition to all argument references listed, you can access the following attr
   * Constraints: The maximum length is `63` characters. The minimum length is `1` character. The value must match regular expression `/^[\\*\\-a-z0-9]+$/`.
 * `href` - (String) When you provision a new build,  a URL is created identifying the location of the instance.
   * Constraints: The maximum length is `2048` characters. The minimum length is `0` characters. The value must match regular expression `/(([^:\/?#]+):)?(\/\/([^\/?#]*))?([^?#]*)(\\?([^#]*))?(#(.*))?$/`.
+* `region` - (String) The region of the project the resource is located in. Possible values: 'au-syd', 'br-sao', 'ca-tor', 'eu-de', 'eu-gb', 'jp-osa', 'jp-tok', 'us-east', 'us-south'.
 * `resource_type` - (String) The type of the build.
   * Constraints: Allowable values are: `build_v2`.
 * `status` - (String) The current status of the build.
-  * Constraints: Possible values are: `ready`, `failed`.
+  * Constraints: Allowable values are: `ready`, `failed`.
 * `status_details` - (List) The detailed status of the build.
-Nested scheme for **status_details**:
+Nested schema for **status_details**:
 	* `reason` - (String) Optional information to provide more context in case of a 'failed' or 'warning' status.
 	  * Constraints: Allowable values are: `registered`, `strategy_not_found`, `cluster_build_strategy_not_found`, `set_owner_reference_failed`, `spec_source_secret_not_found`, `spec_output_secret_ref_not_found`, `spec_runtime_secret_ref_not_found`, `multiple_secret_ref_not_found`, `runtime_paths_can_not_be_empty`, `remote_repository_unreachable`, `failed`.
+
 * `etag` - ETag identifier for code_engine_build.
 
 ## Import
@@ -81,18 +83,13 @@ Nested scheme for **status_details**:
 You can import the `ibm_code_engine_build` resource by using `name`.
 The `name` property can be formed from `project_id`, and `name` in the following format:
 
-```
-<project_id>/<name>
-```
+<pre>
+&lt;project_id&gt;/&lt;name&gt;
+</pre>
 * `project_id`: A string in the format `15314cc3-85b4-4338-903f-c28cdee6d005`. The ID of the project.
-* `name`: A string in the format `my-build`. The name of your build.
+* `name`: A string in the format `my-build`. The name of the build.
 
 # Syntax
-```
-$ terraform import ibm_code_engine_build.code_engine_build <project_id>/<name>
-```
-
-# Example
-```
-$ terraform import ibm_code_engine_build.code_engine_build "15314cc3-85b4-4338-903f-c28cdee6d005/my-build"
-```
+<pre>
+$ terraform import ibm_code_engine_build.code_engine_build &lt;project_id&gt;/&lt;name&gt;
+</pre>

--- a/website/docs/r/code_engine_config_map.html.markdown
+++ b/website/docs/r/code_engine_config_map.html.markdown
@@ -8,7 +8,7 @@ subcategory: "Code Engine"
 
 # ibm_code_engine_config_map
 
-Provides a resource for code_engine_config_map. This allows code_engine_config_map to be created, updated and deleted.
+Create, update, and delete code_engine_config_maps with this resource.
 
 ## Example Usage
 
@@ -21,17 +21,17 @@ resource "ibm_code_engine_config_map" "code_engine_config_map_instance" {
 
 ## Argument Reference
 
-Review the argument reference that you can specify for your resource.
+You can specify the following arguments for this resource.
 
 * `data` - (Optional, Map) The key-value pair for the config map. Values must be specified in `KEY=VALUE` format. Each `KEY` field must consist of alphanumeric characters, `-`, `_` or `.` and must not be exceed a max length of 253 characters. Each `VALUE` field can consists of any character and must not be exceed a max length of 1048576 characters.
-* `name` - (Required, String) The name of the config map. Use a name that is unique within the project.
+* `name` - (Required, Forces new resource, String) The name of the config map.
   * Constraints: The maximum length is `253` characters. The minimum length is `1` character. The value must match regular expression `/^[a-z0-9]([\\-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([\\-a-z0-9]*[a-z0-9])?)*$/`.
 * `project_id` - (Required, Forces new resource, String) The ID of the project.
   * Constraints: The maximum length is `36` characters. The minimum length is `36` characters. The value must match regular expression `/^[0-9a-z]{8}-[0-9a-z]{4}-[0-9a-z]{4}-[0-9a-z]{4}-[0-9a-z]{12}$/`.
 
 ## Attribute Reference
 
-In addition to all argument references listed, you can access the following attribute references after your resource is created.
+After your resource is created, you can read values from the listed arguments and the following attributes.
 
 * `id` - The unique identifier of the code_engine_config_map.
 * `config_map_id` - (String) The identifier of the resource.
@@ -40,6 +40,7 @@ In addition to all argument references listed, you can access the following attr
 * `entity_tag` - (String) The version of the config map instance, which is used to achieve optimistic locking.
 * `href` - (String) When you provision a new config map,  a URL is created identifying the location of the instance.
   * Constraints: The maximum length is `2048` characters. The minimum length is `0` characters. The value must match regular expression `/(([^:\/?#]+):)?(\/\/([^\/?#]*))?([^?#]*)(\\?([^#]*))?(#(.*))?$/`.
+* `region` - (String) The region of the project the resource is located in. Possible values: 'au-syd', 'br-sao', 'ca-tor', 'eu-de', 'eu-gb', 'jp-osa', 'jp-tok', 'us-east', 'us-south'.
 * `resource_type` - (String) The type of the config map.
   * Constraints: Allowable values are: `config_map_v2`.
 * `etag` - ETag identifier for code_engine_config_map.
@@ -49,18 +50,13 @@ In addition to all argument references listed, you can access the following attr
 You can import the `ibm_code_engine_config_map` resource by using `name`.
 The `name` property can be formed from `project_id`, and `name` in the following format:
 
-```
-<project_id>/<name>
-```
+<pre>
+&lt;project_id&gt;/&lt;name&gt;
+</pre>
 * `project_id`: A string in the format `15314cc3-85b4-4338-903f-c28cdee6d005`. The ID of the project.
-* `name`: A string in the format `my-config-map`. The name of your configmap.
+* `name`: A string in the format `my-config-map`. The name of the config map.
 
 # Syntax
-```
-$ terraform import ibm_code_engine_config_map.code_engine_config_map <project_id>/<name>
-```
-
-# Example
-```
-$ terraform import ibm_code_engine_config_map.code_engine_config_map "15314cc3-85b4-4338-903f-c28cdee6d005/my-config-map"
-```
+<pre>
+$ terraform import ibm_code_engine_config_map.code_engine_config_map &lt;project_id&gt;/&lt;name&gt;
+</pre>

--- a/website/docs/r/code_engine_domain_mapping.html.markdown
+++ b/website/docs/r/code_engine_domain_mapping.html.markdown
@@ -14,13 +14,13 @@ Create, update, and delete code_engine_domain_mappings with this resource.
 
 ```hcl
 resource "ibm_code_engine_domain_mapping" "code_engine_domain_mapping_instance" {
+  project_id = ibm_code_engine_project.code_engine_project_instance.project_id
+  name      = "www.example.com"
+  tls_secret = "my-tls-secret"
   component {
-		name = "my-app-1"
+		name          = "my-app-1"
 		resource_type = "app_v2"
   }
-  name = "www.example.com"
-  project_id = ibm_code_engine_project.code_engine_project_instance.project_id
-  tls_secret = "my-tls-secret"
 }
 ```
 
@@ -36,7 +36,7 @@ code_engine_domain_mapping provides the following [Timeouts](https://www.terrafo
 You can specify the following arguments for this resource.
 
 * `component` - (Required, List) A reference to another component.
-Nested scheme for **component**:
+Nested schema for **component**:
 	* `name` - (Required, String) The name of the referenced component.
 	  * Constraints: The maximum length is `63` characters. The minimum length is `1` character. The value must match regular expression `/^[a-z0-9]([\\-a-z0-9]*[a-z0-9])?$/`.
 	* `resource_type` - (Required, String) The type of the referenced resource.
@@ -45,7 +45,7 @@ Nested scheme for **component**:
   * Constraints: The maximum length is `253` characters. The minimum length is `1` character. The value must match regular expression `/^[a-z0-9]([\\-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([\\-a-z0-9]*[a-z0-9])?)+$/`.
 * `project_id` - (Required, Forces new resource, String) The ID of the project.
   * Constraints: The maximum length is `36` characters. The minimum length is `36` characters. The value must match regular expression `/^[0-9a-z]{8}-[0-9a-z]{4}-[0-9a-z]{4}-[0-9a-z]{4}-[0-9a-z]{12}$/`.
-* `tls_secret` - (Required, String) The name of the TLS secret that holds the certificate and private key of this domain mapping.
+* `tls_secret` - (Required, String) The name of the TLS secret that includes the certificate and private key of this domain mapping.
   * Constraints: The maximum length is `253` characters. The minimum length is `1` character. The value must match regular expression `/^[a-z0-9]([\\-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([\\-a-z0-9]*[a-z0-9])?)*$/`.
 
 ## Attribute Reference
@@ -55,24 +55,26 @@ After your resource is created, you can read values from the listed arguments an
 * `id` - The unique identifier of the code_engine_domain_mapping.
 * `domain_mapping_id` - (String) The identifier of the resource.
     * Constraints: The maximum length is `36` characters. The minimum length is `36` characters. The value must match regular expression `/^[0-9a-z]{8}-[0-9a-z]{4}-[0-9a-z]{4}-[0-9a-z]{4}-[0-9a-z]{12}$/`.
-* `cname_target` - (String) Exposes the value of the CNAME record that needs to be configured in the DNS settings of the domain, to route traffic properly to the target Code Engine region.
+* `cname_target` - (String) The value of the CNAME record that must be configured in the DNS settings of the domain, to route traffic properly to the target Code Engine region.
   * Constraints: The maximum length is `2048` characters. The minimum length is `0` characters. The value must match regular expression `/(([^:\/?#]+):)?(\/\/([^\/?#]*))?([^?#]*)(\\?([^#]*))?(#(.*))?$/`.
 * `created_at` - (String) The timestamp when the resource was created.
 * `entity_tag` - (String) The version of the domain mapping instance, which is used to achieve optimistic locking.
   * Constraints: The maximum length is `63` characters. The minimum length is `1` character. The value must match regular expression `/^[\\*\\-a-z0-9]+$/`.
 * `href` - (String) When you provision a new domain mapping, a URL is created identifying the location of the instance.
   * Constraints: The maximum length is `2048` characters. The minimum length is `0` characters. The value must match regular expression `/(([^:\/?#]+):)?(\/\/([^\/?#]*))?([^?#]*)(\\?([^#]*))?(#(.*))?$/`.
-* `resource_type` - (String) The type of the CE Resource.
+* `region` - (String) The region of the project the resource is located in. Possible values: 'au-syd', 'br-sao', 'ca-tor', 'eu-de', 'eu-gb', 'jp-osa', 'jp-tok', 'us-east', 'us-south'.
+* `resource_type` - (String) The type of the Code Engine resource.
   * Constraints: Allowable values are: `domain_mapping_v2`.
 * `status` - (String) The current status of the domain mapping.
-  * Constraints: Possible values are: `ready`, `failed`, `deploying`.
+  * Constraints: Allowable values are: `ready`, `failed`, `deploying`.
 * `status_details` - (List) The detailed status of the domain mapping.
-Nested scheme for **status_details**:
+Nested schema for **status_details**:
 	* `reason` - (String) Optional information to provide more context in case of a 'failed' or 'warning' status.
-	  * Constraints: Possible values are: `ready`, `domain_already_claimed`, `app_ref_failed`, `failed_reconcile_ingress`, `deploying`, `failed`.
-* `user_managed` - (Boolean) Exposes whether the domain mapping is managed by the user or by Code Engine.
-* `visibility` - (String) Exposes whether the domain mapping is reachable through the public internet, or private IBM network, or only through other components within the same Code Engine project.
-  * Constraints: Possible values are: `custom`, `private`, `project`, `public`.
+	  * Constraints: Allowable values are: `ready`, `domain_already_claimed`, `app_ref_failed`, `failed_reconcile_ingress`, `deploying`, `failed`.
+* `user_managed` - (Boolean) Specifies whether the domain mapping is managed by the user or by Code Engine.
+* `visibility` - (String) Specifies whether the domain mapping is reachable through the public internet, or private IBM network, or only through other components within the same Code Engine project.
+  * Constraints: Allowable values are: `custom`, `private`, `project`, `public`.
+
 * `etag` - ETag identifier for code_engine_domain_mapping.
 
 ## Import
@@ -80,13 +82,13 @@ Nested scheme for **status_details**:
 You can import the `ibm_code_engine_domain_mapping` resource by using `name`.
 The `name` property can be formed from `project_id`, and `name` in the following format:
 
-```
-<project_id>/<name>
-```
+<pre>
+&lt;project_id&gt;/&lt;name&gt;
+</pre>
 * `project_id`: A string in the format `15314cc3-85b4-4338-903f-c28cdee6d005`. The ID of the project.
 * `name`: A string in the format `www.example.com`. The name of the domain mapping.
 
 # Syntax
-```
-$ terraform import ibm_code_engine_domain_mapping.code_engine_domain_mapping <project_id>/<name>
-```
+<pre>
+$ terraform import ibm_code_engine_domain_mapping.code_engine_domain_mapping &lt;project_id&gt;/&lt;name&gt;
+</pre>

--- a/website/docs/r/code_engine_job.html.markdown
+++ b/website/docs/r/code_engine_job.html.markdown
@@ -40,7 +40,7 @@ You can specify the following arguments for this resource.
   * Constraints: The maximum length is `256` characters. The minimum length is `1` character. The value must match regular expression `/^([a-z0-9][a-z0-9\\-_.]+[a-z0-9][\/])?([a-z0-9][a-z0-9\\-_]+[a-z0-9][\/])?[a-z0-9][a-z0-9\\-_.\/]+[a-z0-9](:[\\w][\\w.\\-]{0,127})?(@sha256:[a-fA-F0-9]{64})?$/`.
 * `image_secret` - (Optional, String) The name of the image registry access secret. The image registry access secret is used to authenticate with a private registry when you download the container image. If the image reference points to a registry that requires authentication, the job / job runs will be created but submitted job runs will fail, until this property is provided, too. This property must not be set on a job run, which references a job template.
   * Constraints: The maximum length is `253` characters. The minimum length is `1` character. The value must match regular expression `/^[a-z0-9]([\\-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([\\-a-z0-9]*[a-z0-9])?)*$/`.
-* `name` - (Required, Forces new resource, String) The name of the job. Use a name that is unique within the project.
+* `name` - (Required, Forces new resource, String) The name of the job.
   * Constraints: The maximum length is `63` characters. The minimum length is `1` character. The value must match regular expression `/^[a-z0-9]([\\-a-z0-9]*[a-z0-9])?$/`.
 * `project_id` - (Required, Forces new resource, String) The ID of the project.
   * Constraints: The maximum length is `36` characters. The minimum length is `36` characters. The value must match regular expression `/^[0-9a-z]{8}-[0-9a-z]{4}-[0-9a-z]{4}-[0-9a-z]{4}-[0-9a-z]{12}$/`.
@@ -50,9 +50,9 @@ You can specify the following arguments for this resource.
   * Constraints: The default value is `0`.
 * `run_commands` - (Optional, List) Set commands for the job that are passed to start job run containers. If not specified an empty string array will be applied and the command specified by the container image, will be used to start the container.
   * Constraints: The list items must match regular expression `/^.*$/`. The maximum length is `100` items. The minimum length is `0` items.
-* `run_env_variables` - (Optional, List) Optional references to config maps, secrets or literal values.
+* `run_env_variables` - (Optional, List) References to config maps, secrets or literal values, which are exposed as environment variables in the job run.
   * Constraints: The maximum length is `100` items. The minimum length is `0` items.
-Nested scheme for **run_env_variables**:
+Nested schema for **run_env_variables**:
 	* `key` - (Optional, String) The key to reference as environment variable.
 	  * Constraints: The maximum length is `253` characters. The minimum length is `1` character. The value must match regular expression `/^[\\-._a-zA-Z0-9]+$/`.
 	* `name` - (Optional, String) The name of the environment variable.
@@ -69,19 +69,19 @@ Nested scheme for **run_env_variables**:
   * Constraints: The default value is `task`. Allowable values are: `task`, `daemon`. The minimum length is `0` characters. The value must match regular expression `/^(task|daemon)$/`.
 * `run_service_account` - (Optional, String) The name of the service account. For built-in service accounts, you can use the shortened names `manager`, `none`, `reader`, and `writer`. This property must not be set on a job run, which references a job template.
   * Constraints: The default value is `default`. Allowable values are: `default`, `manager`, `reader`, `writer`, `none`. The minimum length is `0` characters. The value must match regular expression `/^(manager|reader|writer|none|default)$/`.
-* `run_volume_mounts` - (Optional, List) Optional mounts of config maps or a secrets.
+* `run_volume_mounts` - (Optional, List) Optional mounts of config maps or secrets.
   * Constraints: The maximum length is `100` items. The minimum length is `0` items.
-Nested scheme for **run_volume_mounts**:
+Nested schema for **run_volume_mounts**:
 	* `mount_path` - (Required, String) The path that should be mounted.
 	  * Constraints: The maximum length is `256` characters. The minimum length is `1` character. The value must match regular expression `/^\/([^\/\\0]+\/?)+$/`.
-	* `name` - (Optional, String) Optional name of the mount. If not set, it will be generated based on the `ref` and a random ID. In case the `ref` is longer than 58 characters, it will be cut off.
+	* `name` - (Required, String) The name of the mount.
 	  * Constraints: The maximum length is `63` characters. The minimum length is `0` characters. The value must match regular expression `/^[a-z]([-a-z0-9]*[a-z0-9])?$/`.
 	* `reference` - (Required, String) The name of the referenced secret or config map.
 	  * Constraints: The maximum length is `253` characters. The minimum length is `1` character. The value must match regular expression `/^[a-z0-9]([\\-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([\\-a-z0-9]*[a-z0-9])?)*$/`.
 	* `type` - (Required, String) Specify the type of the volume mount. Allowed types are: 'config_map', 'secret'.
 	  * Constraints: The default value is `secret`. Allowable values are: `config_map`, `secret`. The value must match regular expression `/^(config_map|secret)$/`.
-* `scale_array_spec` - (Optional, String) Define a custom set of array indices as comma-separated list containing single values and hyphen-separated ranges like `5,12-14,23,27`. Each instance can pick up its array index via environment variable `JOB_INDEX`. The number of unique array indices specified here determines the number of job instances to run.
-  * Constraints:  The default value is `0`. The maximum length is `253` characters. The minimum length is `1` character. The value must match regular expression `/^(?:[1-9]\\d\\d\\d\\d\\d\\d|[1-9]\\d\\d\\d\\d\\d|[1-9]\\d\\d\\d\\d|[1-9]\\d\\d\\d|[1-9]\\d\\d|[1-9]?\\d)(?:-(?:[1-9]\\d\\d\\d\\d\\d\\d|[1-9]\\d\\d\\d\\d\\d|[1-9]\\d\\d\\d\\d|[1-9]\\d\\d\\d|[1-9]\\d\\d|[1-9]?\\d))?(?:,(?:[1-9]\\d\\d\\d\\d\\d\\d|[1-9]\\d\\d\\d\\d\\d|[1-9]\\d\\d\\d\\d|[1-9]\\d\\d\\d|[1-9]\\d\\d|[1-9]?\\d)(?:-(?:[1-9]\\d\\d\\d\\d\\d\\d|[1-9]\\d\\d\\d\\d\\d|[1-9]\\d\\d\\d\\d|[1-9]\\d\\d\\d|[1-9]\\d\\d|[1-9]?\\d))?)*$/`.
+* `scale_array_spec` - (Optional, String) Define a custom set of array indices as a comma-separated list containing single values and hyphen-separated ranges, such as  5,12-14,23,27. Each instance gets its array index value from the environment variable JOB_INDEX. The number of unique array indices that you specify with this parameter determines the number of job instances to run.
+  * Constraints: The maximum length is `253` characters. The minimum length is `1` character. The value must match regular expression `/^(?:[1-9]\\d\\d\\d\\d\\d\\d|[1-9]\\d\\d\\d\\d\\d|[1-9]\\d\\d\\d\\d|[1-9]\\d\\d\\d|[1-9]\\d\\d|[1-9]?\\d)(?:-(?:[1-9]\\d\\d\\d\\d\\d\\d|[1-9]\\d\\d\\d\\d\\d|[1-9]\\d\\d\\d\\d|[1-9]\\d\\d\\d|[1-9]\\d\\d|[1-9]?\\d))?(?:,(?:[1-9]\\d\\d\\d\\d\\d\\d|[1-9]\\d\\d\\d\\d\\d|[1-9]\\d\\d\\d\\d|[1-9]\\d\\d\\d|[1-9]\\d\\d|[1-9]?\\d)(?:-(?:[1-9]\\d\\d\\d\\d\\d\\d|[1-9]\\d\\d\\d\\d\\d|[1-9]\\d\\d\\d\\d|[1-9]\\d\\d\\d|[1-9]\\d\\d|[1-9]?\\d))?)*$/`.
 * `scale_cpu_limit` - (Optional, String) Optional amount of CPU set for the instance of the job. For valid values see [Supported memory and CPU combinations](https://cloud.ibm.com/docs/codeengine?topic=codeengine-mem-cpu-combo).
   * Constraints: The default value is `1`. The maximum length is `10` characters. The minimum length is `0` characters. The value must match regular expression `/^([0-9.]+)([eEinumkKMGTPB]*)$/`.
 * `scale_ephemeral_storage_limit` - (Optional, String) Optional amount of ephemeral storage to set for the instance of the job. The amount specified as ephemeral storage, must not exceed the amount of `scale_memory_limit`. The units for specifying ephemeral storage are Megabyte (M) or Gigabyte (G), whereas G and M are the shorthand expressions for GB and MB. For more information see [Units of measurement](https://cloud.ibm.com/docs/codeengine?topic=codeengine-mem-cpu-combo#unit-measurements).
@@ -100,13 +100,17 @@ After your resource is created, you can read values from the listed arguments an
 * `id` - The unique identifier of the code_engine_job.
 * `job_id` - (String) The identifier of the resource.
   * Constraints: The maximum length is `36` characters. The minimum length is `36` characters. The value must match regular expression `/^[0-9a-z]{8}-[0-9a-z]{4}-[0-9a-z]{4}-[0-9a-z]{4}-[0-9a-z]{12}$/`.
+* `build` - (String) Reference to a build that is associated with the job.
+* `build_run` - (String) Reference to a build run that is associated with the job.
 * `created_at` - (String) The timestamp when the resource was created.
 * `entity_tag` - (String) The version of the job instance, which is used to achieve optimistic locking.
   * Constraints: The maximum length is `63` characters. The minimum length is `1` character. The value must match regular expression `/^[\\*\\-a-z0-9]+$/`.
 * `href` - (String) When you provision a new job,  a URL is created identifying the location of the instance.
   * Constraints: The maximum length is `2048` characters. The minimum length is `0` characters. The value must match regular expression `/(([^:\/?#]+):)?(\/\/([^\/?#]*))?([^?#]*)(\\?([^#]*))?(#(.*))?$/`.
+* `region` - (String) The region of the project the resource is located in. Possible values: 'au-syd', 'br-sao', 'ca-tor', 'eu-de', 'eu-gb', 'jp-osa', 'jp-tok', 'us-east', 'us-south'.
 * `resource_type` - (String) The type of the job.
   * Constraints: Allowable values are: `job_v2`.
+
 * `etag` - ETag identifier for code_engine_job.
 
 ## Import
@@ -114,13 +118,13 @@ After your resource is created, you can read values from the listed arguments an
 You can import the `ibm_code_engine_job` resource by using `name`.
 The `name` property can be formed from `project_id`, and `name` in the following format:
 
-```
-<project_id>/<name>
-```
+<pre>
+&lt;project_id&gt;/&lt;name&gt;
+</pre>
 * `project_id`: A string in the format `15314cc3-85b4-4338-903f-c28cdee6d005`. The ID of the project.
-* `name`: A string in the format `my-job`. The name of your job.
+* `name`: A string in the format `my-job`. The name of the job.
 
 # Syntax
-```
-$ terraform import ibm_code_engine_job.code_engine_job <project_id>/<name>
-```
+<pre>
+$ terraform import ibm_code_engine_job.code_engine_job &lt;project_id&gt;/&lt;name&gt;
+</pre>

--- a/website/docs/r/code_engine_project.html.markdown
+++ b/website/docs/r/code_engine_project.html.markdown
@@ -8,7 +8,7 @@ subcategory: "Code Engine"
 
 # ibm_code_engine_project
 
-Provides a resource for ibm_code_engine_project. This allows ibm_code_engine_project to be created and deleted.
+Create and delete code_engine_projects with this resource.
 
 ## Example Usage
 
@@ -25,21 +25,23 @@ resource "ibm_code_engine_project" "code_engine_project_instance" {
 
 ## Timeouts
 
-* `Create` The creation of an instance is considered failed when no response is received for 2 minutes.
-* `Delete` The deletion of an instance is considered failed when no response is received for 2 minutes.
+code_engine_project provides the following [Timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) configuration options:
+
+* `create` - (Default 10 minutes) Used for creating a code_engine_project.
+* `delete` - (Default Projects(/projects/{id}) minutes) Used for deleting a code_engine_project.
 
 ## Argument Reference
 
-Review the argument reference that you can specify for your resource.
+You can specify the following arguments for this resource.
 
 * `name` - (Required, Forces new resource, String) The name of the project.
   * Constraints: The maximum length is `128` characters. The minimum length is `1` character. The value must match regular expression `/^([^\\x00-\\x7F]|[a-zA-Z0-9\\-._: ])+$/`.
-* `resource_group_id` - (Optional, Forces new resource, String) Optional ID of the resource group for your project deployment. If this field is not defined, the default resource group of the account will be used.
+* `resource_group_id` - (Optional, Forces new resource, String) The ID of the resource group. If this field is not defined, the default resource group of the account will be used.
   * Constraints: The maximum length is `32` characters. The minimum length is `32` characters. The value must match regular expression `/^[a-z0-9]*$/`.
 
 ## Attribute Reference
 
-In addition to all argument references listed, you can access the following attribute references after your resource is created.
+After your resource is created, you can read values from the listed arguments and the following attributes.
 
 * `id` - The unique identifier of the code_engine_project.
 * `project_id` - (String) The ID of the project.
@@ -49,21 +51,20 @@ In addition to all argument references listed, you can access the following attr
 * `crn` - (String) The CRN of the project.
 * `href` - (String) When you provision a new resource, a URL is created identifying the location of the instance.
   * Constraints: The maximum length is `2048` characters. The minimum length is `0` characters. The value must match regular expression `/(([^:\/?#]+):)?(\/\/([^\/?#]*))?([^?#]*)(\\?([^#]*))?(#(.*))?$/`.
-* `region` - (String) The region for your project deployment. Possible values: `au-syd`, `br-sao`, `ca-tor`, `eu-de`, `eu-gb`, `jp-osa`, `jp-tok`, `us-east`, `us-south`.
-  * Constraints: The maximum length is `48` characters. The minimum length is `0` characters. The value must match regular expression `/^[a-z0-9-]+$/`.
+* `region` - (String) The region for your project deployment. Possible values: `au-syd`, `br-sao`, `ca-tor`, `eu-de`, `eu-es`, `eu-gb`, `jp-osa`, `jp-tok`, `us-east`, `us-south`.
 * `resource_type` - (String) The type of the project.
   * Constraints: Allowable values are: `project_v2`.
-* `status` - (String) The current state of the project. For example, if the project is created and ready to get used, it will return active.
+* `status` - (String) The current state of the project. For example, when the project is created and is ready for use, the status of the project is active.
   * Constraints: Allowable values are: `active`, `inactive`, `pending_removal`, `hard_deleting`, `hard_deletion_failed`, `hard_deleted`, `deleting`, `deletion_failed`, `soft_deleted`, `preparing`, `creating`, `creation_failed`.
 
 ## Import
 
-You can import the `ibm_code_engine_project` resource by using `project_id`. The ID of the project.
+You can import the `ibm_code_engine_project` resource by using `id`. The ID of the project.
 
 # Syntax
-```
-$ terraform import ibm_code_engine_project.code_engine_project <project_id>
-```
+<pre>
+$ terraform import ibm_code_engine_project.code_engine_project &lt;id&gt;
+</pre>
 
 # Example
 ```

--- a/website/docs/r/code_engine_secret.html.markdown
+++ b/website/docs/r/code_engine_secret.html.markdown
@@ -29,32 +29,51 @@ resource "ibm_code_engine_secret" "code_engine_secret_instance" {
 
 You can specify the following arguments for this resource.
 
-* `data` - (Optional, Map) Data container that allows to specify config parameters and their values as a key-value map. Each key field must consist of alphanumeric characters, `-`, `_` or `.` and must not be exceed a max length of 253 characters. Each value field can consists of any character and must not be exceed a max length of 1048576 characters.
+* `data` - (Optional, Map) Data container that allows to specify config parameters and their values as a key-value map. Each key field must consist of alphanumeric characters, `-`, `_` or `.` and must not exceed a max length of 253 characters. Each value field can consists of any character and must not exceed a max length of 1048576 characters.
 * `format` - (Required, Forces new resource, String) Specify the format of the secret.
-  * Constraints: Allowable values are: `generic`, `ssh_auth`, `basic_auth`, `tls`, `service_access`, `registry`. The value must match regular expression `/^(generic|ssh_auth|basic_auth|tls|service_access|registry)$/`.
+  * Constraints: Allowable values are: `generic`, `ssh_auth`, `basic_auth`, `tls`, `service_access`, `registry`, `service_operator`, `other`. The value must match regular expression `/^(generic|ssh_auth|basic_auth|tls|service_access|registry|service_operator|other)$/`.
 * `name` - (Required, Forces new resource, String) The name of the secret.
   * Constraints: The maximum length is `253` characters. The minimum length is `1` character. The value must match regular expression `/^[a-z0-9]([\\-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([\\-a-z0-9]*[a-z0-9])?)*$/`.
 * `project_id` - (Required, Forces new resource, String) The ID of the project.
   * Constraints: The maximum length is `36` characters. The minimum length is `36` characters. The value must match regular expression `/^[0-9a-z]{8}-[0-9a-z]{4}-[0-9a-z]{4}-[0-9a-z]{4}-[0-9a-z]{12}$/`.
 * `service_access` - (Optional, Forces new resource, List) Properties for Service Access Secrets.
-Nested scheme for **service_access**:
+Nested schema for **service_access**:
 	* `resource_key` - (Required, List) The service credential associated with the secret.
-	Nested scheme for **resource_key**:
+	Nested schema for **resource_key**:
 		* `id` - (Optional, String) ID of the service credential associated with the secret.
 		  * Constraints: The maximum length is `36` characters. The minimum length is `0` characters. The value must match regular expression `/^[a-z0-9][\\-a-z0-9]*[a-z0-9]$/`.
 		* `name` - (Computed, String) Name of the service credential associated with the secret.
 	* `role` - (Optional, List) A reference to the Role and Role CRN for service binding.
-	Nested scheme for **role**:
-		* `crn` - (Optional, String) CRN of the IAM Role for thise service access secret.
+	Nested schema for **role**:
+		* `crn` - (Optional, String) CRN of the IAM Role for this service access secret.
 		  * Constraints: The maximum length is `253` characters. The minimum length is `0` characters. The value must match regular expression `/^[A-Z][a-zA-Z() ]*[a-z)]$|^crn\\:v1\\:[a-zA-Z0-9]*\\:(public|dedicated|local)\\:[\\-a-z0-9]*\\:([a-z][\\-a-z0-9_]*[a-z0-9])?\\:((a|o|s)\/[\\-a-z0-9]+)?\\:[\\-a-z0-9\/]*\\:[\\-a-zA-Z0-9]*(\\:[\\-a-zA-Z0-9\/.]*)?$/`.
 		* `name` - (Computed, String) Role of the service credential.
 		  * Constraints: The default value is `Writer`.
 	* `service_instance` - (Required, List) The IBM Cloud service instance associated with the secret.
-	Nested scheme for **service_instance**:
+	Nested schema for **service_instance**:
 		* `id` - (Optional, String) ID of the IBM Cloud service instance associated with the secret.
 		  * Constraints: The maximum length is `36` characters. The minimum length is `36` characters. The value must match regular expression `/^[a-z0-9][\\-a-z0-9]*[a-z0-9]$/`.
 		* `type` - (Computed, String) Type of IBM Cloud service associated with the secret.
 		  * Constraints: The maximum length is `253` characters. The minimum length is `1` character. The value must match regular expression `/^.*$/`.
+	* `serviceid` - (Optional, List) A reference to a Service ID.
+	Nested schema for **serviceid**:
+		* `crn` - (Computed, String) CRN value of a Service ID.
+		  * Constraints: The maximum length is `253` characters. The minimum length is `0` characters. The value must match regular expression `/^crn\\:v1\\:[a-zA-Z0-9]*\\:(public|dedicated|local)\\:[\\-a-z0-9]*\\:([a-z][\\-a-z0-9_]*[a-z0-9])?\\:((a|o|s)\/[\\-a-z0-9]+)?\\:[\\-a-z0-9\/]*\\:[\\-a-zA-Z0-9]*(\\:[\\-a-zA-Z0-9\/.]*)?$/`.
+		* `id` - (Optional, String) The ID of the Service ID.
+		  * Constraints: The maximum length is `46` characters. The minimum length is `46` characters. The value must match regular expression `/^ServiceId-[0-9a-z]{8}-[0-9a-z]{4}-[0-9a-z]{4}-[0-9a-z]{4}-[0-9a-z]{12}$/`.
+* `service_operator` - (Optional, List) Properties for the IBM Cloud Operator Secret.
+Nested schema for **service_operator**:
+	* `apikey_id` - (Computed, String) The ID of the apikey associated with the operator secret.
+	  * Constraints: The maximum length is `43` characters. The minimum length is `43` characters. The value must match regular expression `/^ApiKey-[0-9a-z]{8}-[0-9a-z]{4}-[0-9a-z]{4}-[0-9a-z]{4}-[0-9a-z]{12}$/`.
+	* `resource_group_ids` - (Required, List) The list of resource groups (by ID) that the operator secret can bind services in.
+	  * Constraints: The list items must match regular expression `/^[a-z0-9]*$/`. The maximum length is `100` items. The minimum length is `0` items.
+	* `serviceid` - (Required, List) A reference to a Service ID.
+	Nested schema for **serviceid**:
+		* `crn` - (Computed, String) CRN value of a Service ID.
+		  * Constraints: The maximum length is `253` characters. The minimum length is `0` characters. The value must match regular expression `/^crn\\:v1\\:[a-zA-Z0-9]*\\:(public|dedicated|local)\\:[\\-a-z0-9]*\\:([a-z][\\-a-z0-9_]*[a-z0-9])?\\:((a|o|s)\/[\\-a-z0-9]+)?\\:[\\-a-z0-9\/]*\\:[\\-a-zA-Z0-9]*(\\:[\\-a-zA-Z0-9\/.]*)?$/`.
+		* `id` - (Optional, String) The ID of the Service ID.
+		  * Constraints: The maximum length is `46` characters. The minimum length is `46` characters. The value must match regular expression `/^ServiceId-[0-9a-z]{8}-[0-9a-z]{4}-[0-9a-z]{4}-[0-9a-z]{4}-[0-9a-z]{12}$/`.
+	* `user_managed` - (Computed, Boolean) Specifies whether the operator secret is user managed.
 
 ## Attribute Reference
 
@@ -68,6 +87,7 @@ After your resource is created, you can read values from the listed arguments an
   * Constraints: The maximum length is `63` characters. The minimum length is `1` character. The value must match regular expression `/^[\\*\\-a-z0-9]+$/`.
 * `href` - (String) When you provision a new secret,  a URL is created identifying the location of the instance.
   * Constraints: The maximum length is `2048` characters. The minimum length is `0` characters. The value must match regular expression `/(([^:\/?#]+):)?(\/\/([^\/?#]*))?([^?#]*)(\\?([^#]*))?(#(.*))?$/`.
+* `region` - (String) The region of the project the resource is located in. Possible values: 'au-syd', 'br-sao', 'ca-tor', 'eu-de', 'eu-gb', 'jp-osa', 'jp-tok', 'us-east', 'us-south'.
 * `resource_type` - (String) The type of the secret.
 * `etag` - ETag identifier for code_engine_secret.
 
@@ -76,18 +96,13 @@ After your resource is created, you can read values from the listed arguments an
 You can import the `ibm_code_engine_secret` resource by using `name`.
 The `name` property can be formed from `project_id`, and `name` in the following format:
 
-```
-<project_id>/<name>
-```
+<pre>
+&lt;project_id&gt;/&lt;name&gt;
+</pre>
 * `project_id`: A string in the format `15314cc3-85b4-4338-903f-c28cdee6d005`. The ID of the project.
-* `name`: A string in the format `my-secret`. The name of your secret.
+* `name`: A string in the format `my-secret`. The name of the secret.
 
 # Syntax
-```
-$ terraform import ibm_code_engine_secret.code_engine_secret <project_id>/<name>
-```
-
-# Example
-```
-$ terraform import ibm_code_engine_secret.code_engine_secret "15314cc3-85b4-4338-903f-c28cdee6d005/my-secret"
-```
+<pre>
+$ terraform import ibm_code_engine_secret.code_engine_secret &lt;project_id&gt;/&lt;name&gt;
+</pre>


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/IBM-Cloud/terraform-provider-ibm/blob/master/.github/CONTRIBUTING.md --->

Updated the provider and documentation using the latest version of the generator.

Includes:

* App liveness and readiness probe
* Support for Operator Secrets
* Job builds and Build Runas

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
TF_ACC=1 go test -timeout 1800s -v $(go list ./... |grep -v 'vendor') 
?   	github.com/IBM-Cloud/terraform-provider-ibm	[no test files]
?   	github.com/IBM-Cloud/terraform-provider-ibm/ibm/acctest	[no test files]
?   	github.com/IBM-Cloud/terraform-provider-ibm/ibm/provider	[no test files]
=== RUN   TestString
--- PASS: TestString (0.00s)
=== RUN   TestString_positiveIndex
--- PASS: TestString_positiveIndex (0.00s)
PASS
ok  	github.com/IBM-Cloud/terraform-provider-ibm/ibm/conns	(cached)
=== RUN   TestTerraformProblemEmbedsIBMProblem
--- PASS: TestTerraformProblemEmbedsIBMProblem (0.00s)
=== RUN   TestTerraformProblemGetConsoleMessage
--- PASS: TestTerraformProblemGetConsoleMessage (0.00s)
=== RUN   TestTerraformProblemGetDebugMessage
--- PASS: TestTerraformProblemGetDebugMessage (0.00s)
=== RUN   TestTerraformProblemGetID
--- PASS: TestTerraformProblemGetID (0.00s)
=== RUN   TestTerraformProblemGetConsoleOrderedMaps
--- PASS: TestTerraformProblemGetConsoleOrderedMaps (0.00s)
=== RUN   TestTerraformProblemGetDebugOrderedMaps
--- PASS: TestTerraformProblemGetDebugOrderedMaps (0.00s)
=== RUN   TestTerraformProblemGetDiag
--- PASS: TestTerraformProblemGetDiag (0.00s)
=== RUN   TestTerraformErrorf
--- PASS: TestTerraformErrorf (0.00s)
=== RUN   TestFmtErrorfWithProblem
--- PASS: TestFmtErrorfWithProblem (0.00s)
=== RUN   TestFmtErrorfWithNoError
--- PASS: TestFmtErrorfWithNoError (0.00s)
=== RUN   TestFmtErrorfWithProblemInServiceErrorResponse
--- PASS: TestFmtErrorfWithProblemInServiceErrorResponse (0.00s)
=== RUN   TestGetComponentInfo
--- PASS: TestGetComponentInfo (0.00s)
PASS
ok  	github.com/IBM-Cloud/terraform-provider-ibm/ibm/flex	(cached)
?   	github.com/IBM-Cloud/terraform-provider-ibm/ibm/validate	[no test files]
?   	github.com/IBM-Cloud/terraform-provider-ibm/version	[no test files]
=== RUN   TestAccIbmCodeEngineAppDataSourceBasic
--- PASS: TestAccIbmCodeEngineAppDataSourceBasic (75.94s)
=== RUN   TestAccIbmCodeEngineAppDataSourceExtended
--- PASS: TestAccIbmCodeEngineAppDataSourceExtended (72.52s)
=== RUN   TestAccIbmCodeEngineBindingDataSourceBasic
--- PASS: TestAccIbmCodeEngineBindingDataSourceBasic (76.50s)
=== RUN   TestAccIbmCodeEngineBuildDataSourceBasic
--- PASS: TestAccIbmCodeEngineBuildDataSourceBasic (11.12s)
=== RUN   TestAccIbmCodeEngineConfigMapDataSourceBasic
--- PASS: TestAccIbmCodeEngineConfigMapDataSourceBasic (10.52s)
=== RUN   TestAccIbmCodeEngineDomainMappingDataSourceBasic
--- PASS: TestAccIbmCodeEngineDomainMappingDataSourceBasic (195.74s)
=== RUN   TestAccIbmCodeEngineJobDataSourceBasic
--- PASS: TestAccIbmCodeEngineJobDataSourceBasic (11.92s)
=== RUN   TestAccIbmCodeEngineJobDataSourceExtended
--- PASS: TestAccIbmCodeEngineJobDataSourceExtended (10.40s)
=== RUN   TestAccIbmCodeEngineProjectDataSourceBasic
--- PASS: TestAccIbmCodeEngineProjectDataSourceBasic (9.30s)
=== RUN   TestAccIbmCodeEngineSecretDataSourceGeneric
--- PASS: TestAccIbmCodeEngineSecretDataSourceGeneric (9.62s)
=== RUN   TestAccIbmCodeEngineSecretDataSourceBasicAuth
--- PASS: TestAccIbmCodeEngineSecretDataSourceBasicAuth (10.12s)
=== RUN   TestAccIbmCodeEngineSecretDataSourceRegistry
--- PASS: TestAccIbmCodeEngineSecretDataSourceRegistry (11.04s)
=== RUN   TestAccIbmCodeEngineSecretDataSourceSSHAuth
--- PASS: TestAccIbmCodeEngineSecretDataSourceSSHAuth (9.84s)
=== RUN   TestAccIbmCodeEngineSecretDataSourceTls
--- PASS: TestAccIbmCodeEngineSecretDataSourceTls (10.47s)
=== RUN   TestAccIbmCodeEngineSecretDataSourceServiceAccess
--- PASS: TestAccIbmCodeEngineSecretDataSourceServiceAccess (13.60s)
=== RUN   TestAccIbmCodeEngineAppBasic
--- PASS: TestAccIbmCodeEngineAppBasic (201.83s)
=== RUN   TestAccIbmCodeEngineAppExtended
--- PASS: TestAccIbmCodeEngineAppExtended (143.60s)
=== RUN   TestAccIbmCodeEngineBindingBasic
--- PASS: TestAccIbmCodeEngineBindingBasic (75.93s)
=== RUN   TestAccIbmCodeEngineBuildBasic
--- PASS: TestAccIbmCodeEngineBuildBasic (10.44s)
=== RUN   TestAccIbmCodeEngineConfigMapBasic
--- PASS: TestAccIbmCodeEngineConfigMapBasic (21.03s)
=== RUN   TestAccIbmCodeEngineDomainMappingBasic
--- PASS: TestAccIbmCodeEngineDomainMappingBasic (140.52s)
=== RUN   TestAccIbmCodeEngineJobBasic
--- PASS: TestAccIbmCodeEngineJobBasic (18.58s)
=== RUN   TestAccIbmCodeEngineJobExtended
--- PASS: TestAccIbmCodeEngineJobExtended (25.29s)
=== RUN   TestAccIbmCodeEngineProjectBasic
--- PASS: TestAccIbmCodeEngineProjectBasic (82.87s)
=== RUN   TestAccIbmCodeEngineSecretGeneric
--- PASS: TestAccIbmCodeEngineSecretGeneric (24.89s)
=== RUN   TestAccIbmCodeEngineSecretBasicAuth
--- PASS: TestAccIbmCodeEngineSecretBasicAuth (23.68s)
=== RUN   TestAccIbmCodeEngineSecretRegistry
--- PASS: TestAccIbmCodeEngineSecretRegistry (21.11s)
=== RUN   TestAccIbmCodeEngineSecretSSHAuth
--- PASS: TestAccIbmCodeEngineSecretSSHAuth (22.02s)
=== RUN   TestAccIbmCodeEngineSecretTls
--- PASS: TestAccIbmCodeEngineSecretTls (19.12s)
=== RUN   TestAccIbmCodeEngineSecretServiceAccess
--- PASS: TestAccIbmCodeEngineSecretServiceAccess (14.09s)
PASS
ok  	github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/codeengine	1384.230s
```
