### PR TITLE
fix(bm-profiles): resolved nil pointer on resource type

### DIFF
--- a/ibm/service/vpc/data_source_ibm_is_bare_metal_server_profile.go
+++ b/ibm/service/vpc/data_source_ibm_is_bare_metal_server_profile.go
@@ -522,7 +522,7 @@ func dataSourceIBMISBMSProfileRead(context context.Context, d *schema.ResourceDa
 		memList = append(memList, m)
 		d.Set(isBareMetalServerProfileMemory, memList)
 	}
-	d.Set(isBareMetalServerProfileRT, *bmsProfile.ResourceType)
+	d.Set(isBareMetalServerProfileRT, bmsProfile.ResourceType)
 	if bmsProfile.SupportedTrustedPlatformModuleModes != nil {
 		list := make([]map[string]interface{}, 0)
 		var stpmmlist []string

--- a/ibm/service/vpc/data_source_ibm_is_bare_metal_server_profile_test.go
+++ b/ibm/service/vpc/data_source_ibm_is_bare_metal_server_profile_test.go
@@ -47,6 +47,40 @@ func TestAccIBMISBMSProfileDataSource_basic(t *testing.T) {
 		},
 	})
 }
+func TestAccIBMISBMSProfileDataSource_EmptyResourceType(t *testing.T) {
+	resName := "data.ibm_is_bare_metal_server_profile.test1"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { acc.TestAccPreCheck(t) },
+		Providers: acc.TestAccProviders,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccCheckIBMISBMSProfileDataSourceResourceTypeConfig(),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet(resName, "name"),
+					resource.TestCheckResourceAttrSet(resName, "bandwidth.#"),
+					resource.TestCheckResourceAttrSet(resName, "console_types.#"),
+					resource.TestCheckResourceAttrSet(resName, "console_types.0.type"),
+					resource.TestCheckResourceAttrSet(resName, "console_types.0.values.#"),
+					resource.TestCheckResourceAttrSet(resName, "cpu_architecture.#"),
+					resource.TestCheckResourceAttrSet(resName, "cpu_core_count.#"),
+					resource.TestCheckResourceAttrSet(resName, "cpu_socket_count.#"),
+					resource.TestCheckResourceAttrSet(resName, "disks.#"),
+					resource.TestCheckResourceAttrSet(resName, "family"),
+					resource.TestCheckResourceAttrSet(resName, "href"),
+					resource.TestCheckResourceAttrSet(resName, "id"),
+					resource.TestCheckResourceAttrSet(resName, "memory.#"),
+					resource.TestCheckResourceAttrSet(resName, "network_interface_count.#"),
+					resource.TestCheckResourceAttrSet(resName, "network_interface_count.0.max"),
+					resource.TestCheckResourceAttrSet(resName, "network_interface_count.0.min"),
+					resource.TestCheckResourceAttrSet(resName, "network_interface_count.0.type"),
+					resource.TestCheckResourceAttrSet(resName, "os_architecture.#"),
+					resource.TestCheckResourceAttrSet(resName, "supported_trusted_platform_module_modes.#"),
+				),
+			},
+		},
+	})
+}
 func TestAccIBMISBMSProfileDataSource_vni(t *testing.T) {
 	resName := "data.ibm_is_bare_metal_server_profile.test1"
 
@@ -100,5 +134,12 @@ func testAccCheckIBMISBMSProfileDataSourceConfig() string {
 
 		data "ibm_is_bare_metal_server_profile" "test1" {
 			name = data.ibm_is_bare_metal_server_profiles.testbmsps.profiles.0.name
+		}`)
+}
+func testAccCheckIBMISBMSProfileDataSourceResourceTypeConfig() string {
+	// status filter defaults to empty
+	return fmt.Sprintf(`
+		data "ibm_is_bare_metal_server_profile" "test1" {
+			name = "cx2d-metal-96x192"
 		}`)
 }

--- a/ibm/service/vpc/data_source_ibm_is_bare_metal_server_profiles.go
+++ b/ibm/service/vpc/data_source_ibm_is_bare_metal_server_profiles.go
@@ -551,7 +551,7 @@ func dataSourceIBMIsBareMetalServerProfilesRead(context context.Context, d *sche
 			memList = append(memList, m)
 			l[isBareMetalServerProfileMemory] = memList
 		}
-		l[isBareMetalServerProfileRT] = *profile.ResourceType
+		l[isBareMetalServerProfileRT] = profile.ResourceType
 		if profile.SupportedTrustedPlatformModuleModes != nil {
 			list := make([]map[string]interface{}, 0)
 			var stpmmlist []string

--- a/ibm/service/vpc/data_source_ibm_is_bare_metal_server_profiles_test.go
+++ b/ibm/service/vpc/data_source_ibm_is_bare_metal_server_profiles_test.go
@@ -47,6 +47,40 @@ func TestAccIBMISBMSProfilesDataSource_basic(t *testing.T) {
 		},
 	})
 }
+func TestAccIBMISBMSProfilesDataSource_ResourceTypeNull(t *testing.T) {
+	resName := "data.ibm_is_bare_metal_server_profiles.test1"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { acc.TestAccPreCheck(t) },
+		Providers: acc.TestAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckIBMISBMSProfilesDataSourceConfig(),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet(resName, "profiles.0.name"),
+					resource.TestCheckResourceAttrSet(resName, "profiles.0.id"),
+					resource.TestCheckResourceAttrSet(resName, "profiles.0.family"),
+					resource.TestCheckResourceAttrSet(resName, "profiles.0.bandwidth.#"),
+					resource.TestCheckResourceAttrSet(resName, "profiles.0.console_types.#"),
+					resource.TestCheckResourceAttrSet(resName, "profiles.0.console_types.0.type"),
+					resource.TestCheckResourceAttrSet(resName, "profiles.0.console_types.0.values.#"),
+					resource.TestCheckResourceAttrSet(resName, "profiles.0.cpu_architecture.#"),
+					resource.TestCheckResourceAttrSet(resName, "profiles.0.cpu_core_count.#"),
+					resource.TestCheckResourceAttrSet(resName, "profiles.0.cpu_socket_count.#"),
+					resource.TestCheckResourceAttrSet(resName, "profiles.0.disks.#"),
+					resource.TestCheckResourceAttrSet(resName, "profiles.0.href"),
+					resource.TestCheckResourceAttrSet(resName, "profiles.0.memory.#"),
+					resource.TestCheckResourceAttrSet(resName, "profiles.0.network_interface_count.#"),
+					resource.TestCheckResourceAttrSet(resName, "profiles.0.network_interface_count.0.max"),
+					resource.TestCheckResourceAttrSet(resName, "profiles.0.network_interface_count.0.min"),
+					resource.TestCheckResourceAttrSet(resName, "profiles.0.network_interface_count.0.type"),
+					resource.TestCheckResourceAttrSet(resName, "profiles.0.os_architecture.#"),
+					resource.TestCheckResourceAttrSet(resName, "profiles.0.supported_trusted_platform_module_modes.#"),
+				),
+			},
+		},
+	})
+}
 func TestAccIBMISBMSProfilesDataSource_vni(t *testing.T) {
 	resName := "data.ibm_is_bare_metal_server_profiles.test1"
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/IBM-Cloud/terraform-provider-ibm/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
% make testacc TEST=./ibm/service/vpc TESTARGS='-run=TestAccIBMISBMSProfileDataSource_EmptyResourceType'
=== RUN   TestAccIBMISBMSProfileDataSource_EmptyResourceType
--- PASS: TestAccIBMISBMSProfileDataSource_EmptyResourceType (27.26s)
PASS
ok      github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/vpc     29.249s
```

```
% make testacc TEST=./ibm/service/vpc TESTARGS='-run=TestAccIBMISBMSProfilesDataSource_ResourceTypeNull'
=== RUN   TestAccIBMISBMSProfilesDataSource_ResourceTypeNull
--- PASS: TestAccIBMISBMSProfilesDataSource_ResourceTypeNull (21.64s)
PASS
ok      github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/vpc     23.692s
```
