### PR TITLE
Fix to handle crash for cloudshell

### DIFF
--- a/ibm/service/cloudshell/resource_ibm_cloud_shell_account_settings.go
+++ b/ibm/service/cloudshell/resource_ibm_cloud_shell_account_settings.go
@@ -164,7 +164,7 @@ func resourceIBMCloudShellAccountSettingsCreate(context context.Context, d *sche
 	}
 
 	accountSettings, response, err := ibmCloudShellClient.UpdateAccountSettingsWithContext(context, updateAccountSettingsOptions)
-	if err != nil {
+	if err != nil || accountSettings == nil {
 		log.Printf("[DEBUG] UpdateAccountSettingsWithContext failed %s\n%s", err, response)
 		return diag.FromErr(fmt.Errorf("UpdateAccountSettingsWithContext failed %s\n%s", err, response))
 	}
@@ -211,7 +211,7 @@ func resourceIBMCloudShellAccountSettingsRead(context context.Context, d *schema
 	getAccountSettingsOptions.SetAccountID(strings.TrimPrefix(d.Id(), "ac-"))
 
 	accountSettings, response, err := ibmCloudShellClient.GetAccountSettingsWithContext(context, getAccountSettingsOptions)
-	if err != nil {
+	if err != nil || accountSettings == nil {
 		if response != nil && response.StatusCode == 404 {
 			d.SetId("")
 			return nil
@@ -345,8 +345,8 @@ func resourceIBMCloudShellAccountSettingsUpdate(context context.Context, d *sche
 	}
 
 	if hasChange {
-		_, response, err := ibmCloudShellClient.UpdateAccountSettingsWithContext(context, updateAccountSettingsOptions)
-		if err != nil {
+		accountSettings, response, err := ibmCloudShellClient.UpdateAccountSettingsWithContext(context, updateAccountSettingsOptions)
+		if err != nil || accountSettings == nil {
 			log.Printf("[DEBUG] UpdateAccountSettingsWithContext failed %s\n%s", err, response)
 			return diag.FromErr(fmt.Errorf("UpdateAccountSettingsWithContext failed %s\n%s", err, response))
 		}


### PR DESCRIPTION
```
harinireddy@Harinis-MBP default % unset TF_LOG
harinireddy@Harinis-MBP default % terraform1.5 apply  
var.ibmcloud_api_key
  The IBM Cloud API token this account authenticates to

  Enter a value: 

module.iam_account_settings.data.ibm_iam_account_settings.iam_account_settings: Reading...
module.iam_account_settings.data.ibm_iam_account_settings.iam_account_settings: Read complete after 1s [id=883079c85357a1f3f85d968780e56518]
module.iam_account_settings.data.ibm_cloud_shell_account_settings.cloud_shell_account_settings[0]: Reading...
module.iam_account_settings.data.ibm_cloud_shell_account_settings.cloud_shell_account_settings[0]: Read complete after 2s [id=883079c85357a1f3f85d968780e56518]

Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  + create

Terraform will perform the following actions:

  # module.iam_account_settings.ibm_cloud_shell_account_settings.cloud_shell_account_settings[0] will be created
  + resource "ibm_cloud_shell_account_settings" "cloud_shell_account_settings" {
      + account_id = "883079c85357a1f3f85d968780e56518"
      + created_at = (known after apply)
      + created_by = (known after apply)
      + enabled    = false
      + id         = (known after apply)
      + rev        = "28-4858fbf15bf0008b86a37a15b2248323"
      + type       = (known after apply)
      + updated_at = (known after apply)
      + updated_by = (known after apply)
    }

  # module.iam_account_settings.ibm_iam_access_group_account_settings.iam_access_group_account_settings will be created
  + resource "ibm_iam_access_group_account_settings" "iam_access_group_account_settings" {
      + account_id            = (known after apply)
      + id                    = (known after apply)
      + public_access_enabled = false
    }

  # module.iam_account_settings.ibm_iam_account_settings.iam_account_settings will be created
  + resource "ibm_iam_account_settings" "iam_account_settings" {
      + allowed_ip_addresses                       = "0.0.0.0/0"
      + entity_tag                                 = (known after apply)
      + history                                    = (known after apply)
      + id                                         = (known after apply)
      + if_match                                   = "*"
      + include_history                            = false
      + max_sessions_per_identity                  = "NOT_SET"
      + mfa                                        = "TOTP4ALL"
      + restrict_create_platform_apikey            = "RESTRICTED"
      + restrict_create_service_id                 = "RESTRICTED"
      + session_expiration_in_seconds              = "86400"
      + session_invalidation_in_seconds            = "7200"
      + system_access_token_expiration_in_seconds  = "3600"
      + system_refresh_token_expiration_in_seconds = "259200"
    }

Plan: 3 to add, 0 to change, 0 to destroy.

Changes to Outputs:
  + account_allowed_ip_addresses              = "0.0.0.0/0"
  + account_allowed_ip_addresses_control_mode = "RESTRICT"
  + account_allowed_ip_addresses_enforced     = true
  + account_iam_access_token_expiration       = "3600"
  + account_iam_active_session_timeout        = "86400"
  + account_iam_apikey_creation               = "RESTRICTED"
  + account_iam_inactive_session_timeout      = "7200"
  + account_iam_mfa                           = "TOTP4ALL"
  + account_iam_refresh_token_expiration      = "259200"
  + account_iam_serviceid_creation            = "RESTRICTED"
  + account_iam_user_mfa_list                 = []
  + account_public_access                     = false
  + account_shell_settings_status             = false

Do you want to perform these actions?
  Terraform will perform the actions described above.
  Only 'yes' will be accepted to approve.

  Enter a value: yes

module.iam_account_settings.ibm_iam_access_group_account_settings.iam_access_group_account_settings: Creating...
module.iam_account_settings.ibm_iam_account_settings.iam_account_settings: Creating...
module.iam_account_settings.ibm_cloud_shell_account_settings.cloud_shell_account_settings[0]: Creating...
module.iam_account_settings.ibm_iam_account_settings.iam_account_settings: Creation complete after 1s [id=883079c85357a1f3f85d968780e56518]
module.iam_account_settings.ibm_iam_access_group_account_settings.iam_access_group_account_settings: Creation complete after 2s [id=883079c85357a1f3f85d968780e56518]
module.iam_account_settings.ibm_cloud_shell_account_settings.cloud_shell_account_settings[0]: Creation complete after 4s [id=ac-883079c85357a1f3f85d968780e56518]

Apply complete! Resources: 3 added, 0 changed, 0 destroyed.

Outputs:

account_allowed_ip_addresses = "0.0.0.0/0"
account_allowed_ip_addresses_control_mode = "RESTRICT"
account_allowed_ip_addresses_enforced = true
account_iam_access_token_expiration = "3600"
account_iam_active_session_timeout = "86400"
account_iam_apikey_creation = "RESTRICTED"
account_iam_inactive_session_timeout = "7200"
account_iam_mfa = "TOTP4ALL"
account_iam_refresh_token_expiration = "259200"
account_iam_serviceid_creation = "RESTRICTED"
account_iam_user_mfa_list = tolist([])
account_public_access = false
account_shell_settings_status = false
harinireddy@Harinis-MBP default % 
```