### PR TITLE
Update Usage Reports terraform code to support new error handling

### DIFF
--- a/examples/ibm-usage-reports/README.md
+++ b/examples/ibm-usage-reports/README.md
@@ -1,10 +1,12 @@
-# Example for UsageReportsV4
+# Examples for Usage Reports
 
-This example illustrates how to use the UsageReportsV4
+These examples illustrate how to use the resources and data sources associated with Usage Reports.
 
-The following types of resources are supported:
+The following resources are supported:
+* ibm_billing_report_snapshot
 
-* billing_report_snapshot
+The following data sources are supported:
+* ibm_billing_snapshot_list
 
 ## Usage
 
@@ -18,14 +20,12 @@ $ terraform apply
 
 Run `terraform destroy` when you don't need these resources.
 
+## Usage Reports resources
 
-## UsageReportsV4 resources
-
-billing_report_snapshot resource:
+### Resource: ibm_billing_report_snapshot
 
 ```hcl
-resource "billing_report_snapshot" "billing_report_snapshot_instance" {
-  account_id = var.billing_report_snapshot_account_id
+resource "ibm_billing_report_snapshot" "billing_report_snapshot_instance" {
   interval = var.billing_report_snapshot_interval
   versioning = var.billing_report_snapshot_versioning
   report_types = var.billing_report_snapshot_report_types
@@ -35,18 +35,59 @@ resource "billing_report_snapshot" "billing_report_snapshot_instance" {
 }
 ```
 
-## UsageReportsV4 data sources
+#### Inputs
 
-billing_snapshot_list data source:
+| Name | Description | Type | Required |
+|------|-------------|------|---------|
+| ibmcloud\_api\_key | IBM Cloud API key | `string` | true |
+| interval | Frequency of taking the snapshot of the billing reports. | `string` | true |
+| versioning | A new version of report is created or the existing report version is overwritten with every update. | `string` | false |
+| report_types | The type of billing reports to take snapshot of. Possible values are [account_summary, enterprise_summary, account_resource_instance_usage]. | `list(string)` | false |
+| cos_reports_folder | The billing reports root folder to store the billing reports snapshots. Defaults to "IBMCloud-Billing-Reports". | `string` | false |
+| cos_bucket | The name of the COS bucket to store the snapshot of the billing reports. | `string` | true |
+| cos_location | Region of the COS instance. | `string` | true |
+
+#### Outputs
+
+| Name | Description |
+|------|-------------|
+| state | Status of the billing snapshot configuration. Possible values are [enabled, disabled]. |
+| account_type | Type of account. Possible values are [enterprise, account]. |
+| compression | Compression format of the snapshot report. |
+| content_type | Type of content stored in snapshot report. |
+| cos_endpoint | The endpoint of the COS instance. |
+| created_at | Timestamp in milliseconds when the snapshot configuration was created. |
+| last_updated_at | Timestamp in milliseconds when the snapshot configuration was last updated. |
+| history | List of previous versions of the snapshot configurations. |
+
+## Usage Reports data sources
+
+### Data source: ibm_billing_snapshot_list
 
 ```hcl
-data "billing_snapshot_list" "billing_snapshot_list_instance" {
-  account_id = var.billing_snapshot_list_account_id
+data "ibm_billing_snapshot_list" "billing_snapshot_list_instance" {
   month = var.billing_snapshot_list_month
   date_from = var.billing_snapshot_list_date_from
   date_to = var.billing_snapshot_list_date_to
+  limit = var.billing_snapshot_list_limit
 }
 ```
+
+#### Inputs
+
+| Name | Description | Type | Required |
+|------|-------------|------|---------|
+| month | The month for which billing report snapshot is requested.  Format is yyyy-mm. | `string` | true |
+| date_from | Timestamp in milliseconds for which billing report snapshot is requested. | `number` | false |
+| date_to | Timestamp in milliseconds for which billing report snapshot is requested. | `number` | false |
+| limit | Number of usage records returned. The default value is 30. Maximum value is 200. | `number` | false |
+
+#### Outputs
+
+| Name | Description |
+|------|-------------|
+| count | Number of total snapshots. |
+| snapshots |  |
 
 ## Assumptions
 
@@ -67,27 +108,3 @@ data "billing_snapshot_list" "billing_snapshot_list_instance" {
 | Name | Version |
 |------|---------|
 | ibm | 1.13.1 |
-
-## Inputs
-
-| Name | Description | Type | Required |
-|------|-------------|------|---------|
-| ibmcloud\_api\_key | IBM Cloud API key | `string` | true |
-| account_id | Account ID for which billing report snapshot is configured. | `string` | true |
-| interval | Frequency of taking the snapshot of the billing reports. | `string` | true |
-| versioning | A new version of report is created or the existing report version is overwritten with every update. | `string` | false |
-| report_types | The type of billing reports to take snapshot of. Possible values are [account_summary, enterprise_summary, account_resource_instance_usage]. | `list(string)` | false |
-| cos_reports_folder | The billing reports root folder to store the billing reports snapshots. Defaults to "IBMCloud-Billing-Reports". | `string` | false |
-| cos_bucket | The name of the COS bucket to store the snapshot of the billing reports. | `string` | true |
-| cos_location | Region of the COS instance. | `string` | true |
-| account_id | Account ID for which the billing report snapshot is requested. | `string` | true |
-| month | The month for which billing report snapshot is requested.  Format is yyyy-mm. | `string` | true |
-| date_from | Timestamp in milliseconds for which billing report snapshot is requested. | `number` | false |
-| date_to | Timestamp in milliseconds for which billing report snapshot is requested. | `number` | false |
-
-## Outputs
-
-| Name | Description |
-|------|-------------|
-| billing_report_snapshot | billing_report_snapshot object |
-| billing_snapshot_list | billing_snapshot_list object |

--- a/examples/ibm-usage-reports/variables.tf
+++ b/examples/ibm-usage-reports/variables.tf
@@ -56,3 +56,8 @@ variable "billing_snapshot_list_date_to" {
   type        = number
   default     = 1675987200000
 }
+variable "billing_snapshot_list_limit" {
+  description = "Number of usage records returned. The default value is 30. Maximum value is 200."
+  type        = number
+  default     = 0
+}

--- a/go.mod
+++ b/go.mod
@@ -75,6 +75,7 @@ require (
 require (
 	cloud.google.com/go/kms v1.10.1 // indirect
 	cloud.google.com/go/monitoring v1.13.0 // indirect
+	github.com/Bowery/prompt v0.0.0-20190916142128-fa8279994f75 // indirect
 	github.com/Logicalis/asn1 v0.0.0-20190312173541-d60463189a56 // indirect
 	github.com/PromonLogicalis/asn1 v0.0.0-20190312173541-d60463189a56 // indirect
 	github.com/ProtonMail/go-crypto v0.0.0-20230828082145-3c4c8a2d2371 // indirect
@@ -93,6 +94,7 @@ require (
 	github.com/coreos/pkg v0.0.0-20220810130054-c7d1c02cb6cf // indirect
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
 	github.com/dchest/bcrypt_pbkdf v0.0.0-20150205184540-83f37f9c154a // indirect
+	github.com/dchest/safefile v0.0.0-20151022103144-855e8d98f185 // indirect
 	github.com/dgrijalva/jwt-go v3.2.0+incompatible // indirect
 	github.com/eapache/go-resiliency v1.4.0 // indirect
 	github.com/eapache/go-xerial-snappy v0.0.0-20230731223053-c322873962e3 // indirect
@@ -125,6 +127,7 @@ require (
 	github.com/google/gnostic v0.6.9 // indirect
 	github.com/google/go-querystring v1.1.0 // indirect
 	github.com/google/gofuzz v1.2.0 // indirect
+	github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510 // indirect
 	github.com/hashicorp/errwrap v1.1.0 // indirect
 	github.com/hashicorp/go-checkpoint v0.5.0 // indirect
 	github.com/hashicorp/go-cleanhttp v0.5.2 // indirect
@@ -165,6 +168,7 @@ require (
 	github.com/jmespath/go-jmespath v0.4.0 // indirect
 	github.com/josharian/intern v1.0.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
+	github.com/kardianos/govendor v1.0.9 // indirect
 	github.com/klauspost/compress v1.16.7 // indirect
 	github.com/kube-object-storage/lib-bucket-provisioner v0.0.0-20221122204822-d1a8c34382f1 // indirect
 	github.com/leodido/go-urn v1.4.0 // indirect
@@ -176,6 +180,8 @@ require (
 	github.com/mitchellh/copystructure v1.2.0 // indirect
 	github.com/mitchellh/go-testing-interface v1.14.1 // indirect
 	github.com/mitchellh/go-wordwrap v1.0.0 // indirect
+	github.com/mitchellh/gox v1.0.1 // indirect
+	github.com/mitchellh/iochan v1.0.0 // indirect
 	github.com/mitchellh/mapstructure v1.5.0 // indirect
 	github.com/mitchellh/reflectwalk v1.0.2 // indirect
 	github.com/moby/spdystream v0.2.0 // indirect
@@ -216,6 +222,9 @@ require (
 	golang.org/x/term v0.19.0 // indirect
 	golang.org/x/text v0.14.0 // indirect
 	golang.org/x/time v0.3.0 // indirect
+	golang.org/x/tools v0.16.1 // indirect
+	golang.org/x/tools/cmd/cover v0.1.0-deprecated // indirect
+	golang.org/x/tools/go/vcs v0.1.0-deprecated // indirect
 	gomodules.xyz/jsonpatch/v2 v2.2.0 // indirect
 	google.golang.org/appengine v1.6.7 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20230525234030-28d5490b6b19 // indirect

--- a/go.sum
+++ b/go.sum
@@ -105,6 +105,8 @@ github.com/Azure/go-autorest/logger v0.2.1/go.mod h1:T9E3cAhj2VqvPOtCYAvby9aBXkZ
 github.com/Azure/go-autorest/tracing v0.5.0/go.mod h1:r/s2XiOKccPW3HrqB+W0TQzfbtp2fGCgRFtBroKn4Dk=
 github.com/Azure/go-autorest/tracing v0.6.0 h1:TYi4+3m5t6K48TGI9AUdb+IzbnSxvnvUMfuitfgcfuo=
 github.com/Azure/go-autorest/tracing v0.6.0/go.mod h1:+vhtPC754Xsa23ID7GlGsrdKBpUA79WCAKPPZVC2DeU=
+github.com/Bowery/prompt v0.0.0-20190916142128-fa8279994f75 h1:xGHheKK44eC6K0u5X+DZW/fRaR1LnDdqPHMZMWx5fv8=
+github.com/Bowery/prompt v0.0.0-20190916142128-fa8279994f75/go.mod h1:4/6eNcqZ09BZ9wLK3tZOjBA1nDj+B0728nlX5YRlSmQ=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/BurntSushi/toml v1.2.0 h1:Rt8g24XnyGTyglgET/PRUNlrUeu9F5L+7FilkXfZgs0=
 github.com/BurntSushi/toml v1.2.0/go.mod h1:CxXYINrC8qIiEnFrOxCa7Jy5BFHlXnUU2pbicEuybxQ=
@@ -391,6 +393,8 @@ github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/dchest/bcrypt_pbkdf v0.0.0-20150205184540-83f37f9c154a h1:saTgr5tMLFnmy/yg3qDTft4rE5DY2uJ/cCxCe3q0XTU=
 github.com/dchest/bcrypt_pbkdf v0.0.0-20150205184540-83f37f9c154a/go.mod h1:Bw9BbhOJVNR+t0jCqx2GC6zv0TGBsShs56Y3gfSCvl0=
+github.com/dchest/safefile v0.0.0-20151022103144-855e8d98f185 h1:3T8ZyTDp5QxTx3NU48JVb2u+75xc040fofcBaN+6jPA=
+github.com/dchest/safefile v0.0.0-20151022103144-855e8d98f185/go.mod h1:cFRxtTwTOJkz2x3rQUNCYKWC93yP1VKjR8NUhqFxZNU=
 github.com/denisenkom/go-mssqldb v0.0.0-20190412130859-3b1d194e553a/go.mod h1:zAg7JM8CkOJ43xKXIj7eRO9kmWm/TW578qo+oDO6tuM=
 github.com/denverdino/aliyungo v0.0.0-20190125010748-a747050bb1ba h1:p6poVbjHDkKa+wtC8frBMwQtT3BmqGYBjzMwJ63tuR4=
 github.com/denverdino/aliyungo v0.0.0-20190125010748-a747050bb1ba/go.mod h1:dV8lFg6daOBZbT6/BDGIz6Y3WFGn8juu6G+CQ6LHtl0=
@@ -776,6 +780,8 @@ github.com/google/pprof v0.0.0-20210407192527-94a9f03dee38/go.mod h1:kpwsk12EmLe
 github.com/google/pprof v0.0.0-20230510103437-eeec1cb781c3 h1:2XF1Vzq06X+inNqgJ9tRnGuw+ZVCB3FazXODD6JE1R8=
 github.com/google/pprof v0.0.0-20230510103437-eeec1cb781c3/go.mod h1:79YE0hCXdHag9sBkw2o+N/YnZtTkXi0UT9Nnixa5eYk=
 github.com/google/renameio v0.1.0/go.mod h1:KWCgfxg9yswjAJkECMjeO8J8rahYeXnNhOm40UhjYkI=
+github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510 h1:El6M4kTTCOh6aBiKaUGG7oYTSPP8MxqL4YI3kZKwcP4=
+github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510/go.mod h1:pupxD2MaaD3pAXIBCelhxNneeOaAeabZDe5s4K6zSpQ=
 github.com/google/uuid v1.0.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/google/uuid v1.1.1/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/google/uuid v1.1.2/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
@@ -946,6 +952,7 @@ github.com/hashicorp/go-uuid v1.0.2-0.20191001231223-f32f5fe8d6a8/go.mod h1:6SBZ
 github.com/hashicorp/go-uuid v1.0.2/go.mod h1:6SBZvOh/SIDV7/2o3Jml5SYk/TvGqwFJ/bN7x4byOro=
 github.com/hashicorp/go-uuid v1.0.3 h1:2gKiV6YVmrJ1i2CKKa9obLvRieoRGviZFL26PcT/Co8=
 github.com/hashicorp/go-uuid v1.0.3/go.mod h1:6SBZvOh/SIDV7/2o3Jml5SYk/TvGqwFJ/bN7x4byOro=
+github.com/hashicorp/go-version v1.0.0/go.mod h1:fltr4n8CU8Ke44wwGCBoEymUuxUHl09ZGVZPK5anwXA=
 github.com/hashicorp/go-version v1.1.0/go.mod h1:fltr4n8CU8Ke44wwGCBoEymUuxUHl09ZGVZPK5anwXA=
 github.com/hashicorp/go-version v1.2.0/go.mod h1:fltr4n8CU8Ke44wwGCBoEymUuxUHl09ZGVZPK5anwXA=
 github.com/hashicorp/go-version v1.6.0 h1:feTTfFNnjP967rlCxM/I9g701jU+RN74YKx2mOkIeek=
@@ -1137,6 +1144,8 @@ github.com/jtolds/gls v4.2.1+incompatible/go.mod h1:QJZ7F/aHp+rZTRtaJ1ow/lLfFfVY
 github.com/jtolds/gls v4.20.0+incompatible/go.mod h1:QJZ7F/aHp+rZTRtaJ1ow/lLfFfVYBRgL+9YlvaHOwJU=
 github.com/julienschmidt/httprouter v1.2.0/go.mod h1:SYymIcj16QtmaHHD7aYtjjsJG7VTCxuUUipMqKk8s4w=
 github.com/julienschmidt/httprouter v1.3.0/go.mod h1:JR6WtHb+2LUe8TCKY3cZOxFyyO8IZAc4RVcycCCAKdM=
+github.com/kardianos/govendor v1.0.9 h1:WOH3FcVI9eOgnIZYg96iwUwrL4eOVx+aQ66oyX2R8Yc=
+github.com/kardianos/govendor v1.0.9/go.mod h1:yvmR6q9ZZ7nSF5Wvh40v0wfP+3TwwL8zYQp+itoZSVM=
 github.com/karrick/godirwalk v1.8.0/go.mod h1:H5KPZjojv4lE+QYImBI8xVtrBRgYrIVsaRPx4tDPEn4=
 github.com/karrick/godirwalk v1.10.3/go.mod h1:RoGL9dQei4vP9ilrpETWE8CLOZ1kiN0LhBygSwrAsHA=
 github.com/kelseyhightower/envconfig v1.3.0/go.mod h1:cccZRl6mQpaq41TPp5QxidR+Sa3axMbJDNb//FQX6Gg=
@@ -1255,7 +1264,10 @@ github.com/mitchellh/go-testing-interface v1.14.1/go.mod h1:gfgS7OtZj6MA4U1UrDRp
 github.com/mitchellh/go-wordwrap v1.0.0 h1:6GlHJ/LTGMrIJbwgdqdl2eEH8o+Exx/0m8ir9Gns0u4=
 github.com/mitchellh/go-wordwrap v1.0.0/go.mod h1:ZXFpozHsX6DPmq2I0TCekCxypsnAUbP2oI0UX1GXzOo=
 github.com/mitchellh/gox v0.4.0/go.mod h1:Sd9lOJ0+aimLBi73mGofS1ycjY8lL3uZM3JPS42BGNg=
+github.com/mitchellh/gox v1.0.1 h1:x0jD3dcHk9a9xPSDN6YEL4xL6Qz0dvNYm8yZqui5chI=
+github.com/mitchellh/gox v1.0.1/go.mod h1:ED6BioOGXMswlXa2zxfh/xdd5QhwYliBFn9V18Ap4z4=
 github.com/mitchellh/hashstructure v1.0.0/go.mod h1:QjSHrPWS+BGUVBYkbTZWEnOh3G1DutKwClXU/ABz6AQ=
+github.com/mitchellh/iochan v1.0.0 h1:C+X3KsSTLFVBr/tK1eYN/vs4rJcvsiLU338UhYPJWeY=
 github.com/mitchellh/iochan v1.0.0/go.mod h1:JwYml1nuB7xOzsp52dPpHFffvOCDupsG0QubkSMEySY=
 github.com/mitchellh/mapstructure v0.0.0-20160808181253-ca63d7c062ee/go.mod h1:FVVH3fgwuzCH5S8UJGiWEs2h04kUh9fWfEaFds41c1Y=
 github.com/mitchellh/mapstructure v1.1.2/go.mod h1:FVVH3fgwuzCH5S8UJGiWEs2h04kUh9fWfEaFds41c1Y=
@@ -2171,6 +2183,10 @@ golang.org/x/tools v0.12.0/go.mod h1:Sc0INKfu04TlqNoRA1hgpFZbhYXHPr4V5DzpSBTPqQM
 golang.org/x/tools v0.13.0/go.mod h1:HvlwmtVNQAhOuCjW7xxvovg8wbNq7LwfXh/k7wXUl58=
 golang.org/x/tools v0.16.1 h1:TLyB3WofjdOEepBHAU20JdNC1Zbg87elYofWYAY5oZA=
 golang.org/x/tools v0.16.1/go.mod h1:kYVVN6I1mBNoB1OX+noeBjbRk4IUEPa7JJ+TJMEooJ0=
+golang.org/x/tools/cmd/cover v0.1.0-deprecated h1:Rwy+mWYz6loAF+LnG1jHG/JWMHRMMC2/1XX3Ejkx9lA=
+golang.org/x/tools/cmd/cover v0.1.0-deprecated/go.mod h1:hMDiIvlpN1NoVgmjLjUJE9tMHyxHjFX7RuQ+rW12mSA=
+golang.org/x/tools/go/vcs v0.1.0-deprecated h1:cOIJqWBl99H1dH5LWizPa+0ImeeJq3t3cJjaeOWUAL4=
+golang.org/x/tools/go/vcs v0.1.0-deprecated/go.mod h1:zUrvATBAvEI9535oC0yWYsLsHIV4Z7g63sNPVMtuBy8=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=

--- a/ibm/conns/config.go
+++ b/ibm/conns/config.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2017, 2021 All Rights Reserved.
+// Copyright IBM Corp. 2024 All Rights Reserved.
 // Licensed under the Mozilla Public License v2.0
 
 package conns
@@ -3561,7 +3561,11 @@ func RefreshToken(sess *bxsession.Session) error {
 func EnvFallBack(envs []string, defaultValue string) string {
 	for _, k := range envs {
 		if v := os.Getenv(k); v != "" {
-			return v
+			if strings.Contains(v, "https://") {
+				return v
+			} else {
+				return fmt.Sprintf("https://%s/v1", v)
+			}
 		}
 	}
 	return defaultValue

--- a/ibm/conns/config.go
+++ b/ibm/conns/config.go
@@ -3561,11 +3561,7 @@ func RefreshToken(sess *bxsession.Session) error {
 func EnvFallBack(envs []string, defaultValue string) string {
 	for _, k := range envs {
 		if v := os.Getenv(k); v != "" {
-			if strings.Contains(v, "https://") {
-				return v
-			} else {
-				return fmt.Sprintf("https://%s/v1", v)
-			}
+			return v
 		}
 	}
 	return defaultValue

--- a/ibm/provider/provider.go
+++ b/ibm/provider/provider.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2017, 2021 All Rights Reserved.
+// Copyright IBM Corp. 2024 All Rights Reserved.
 // Licensed under the Mozilla Public License v2.0
 
 package provider

--- a/ibm/service/usagereports/data_source_ibm_billing_snapshot_list.go
+++ b/ibm/service/usagereports/data_source_ibm_billing_snapshot_list.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2023 All Rights Reserved.
+// Copyright IBM Corp. 2024 All Rights Reserved.
 // Licensed under the Mozilla Public License v2.0
 
 package usagereports
@@ -22,68 +22,74 @@ func DataSourceIBMBillingSnapshotList() *schema.Resource {
 		ReadContext: dataSourceIBMBillingSnapshotListRead,
 
 		Schema: map[string]*schema.Schema{
-			"month": {
+			"month": &schema.Schema{
 				Type:        schema.TypeString,
 				Required:    true,
 				Description: "The month for which billing report snapshot is requested.  Format is yyyy-mm.",
 			},
-			"date_from": {
+			"date_from": &schema.Schema{
 				Type:        schema.TypeInt,
 				Optional:    true,
 				Description: "Timestamp in milliseconds for which billing report snapshot is requested.",
 			},
-			"date_to": {
+			"date_to": &schema.Schema{
 				Type:        schema.TypeInt,
 				Optional:    true,
 				Description: "Timestamp in milliseconds for which billing report snapshot is requested.",
 			},
-			"snapshotcount": {
+			"limit": &schema.Schema{
+				Type:        schema.TypeInt,
+				Optional:    true,
+				Default:     30,
+				Description: "Number of usage records returned. The default value is 30. Maximum value is 200.",
+			},
+			"snapshotcount": &schema.Schema{
 				Type:        schema.TypeInt,
 				Computed:    true,
 				Description: "Number of total snapshots.",
 			},
-			"snapshots": {
+			"snapshots": &schema.Schema{
 				Type:     schema.TypeList,
 				Computed: true,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
-						"account_id": {
+						"account_id": &schema.Schema{
 							Type:        schema.TypeString,
 							Computed:    true,
 							Description: "Account ID for which billing report snapshot is configured.",
 						},
-						"month": {
+						"month": &schema.Schema{
 							Type:        schema.TypeString,
 							Computed:    true,
 							Description: "Month of captured snapshot.",
 						},
-						"account_type": {
+						"account_type": &schema.Schema{
 							Type:        schema.TypeString,
 							Computed:    true,
 							Description: "Type of account. Possible values are [enterprise, account].",
 						},
-						"expected_processed_at": {
+						"expected_processed_at": &schema.Schema{
 							Type:        schema.TypeInt,
 							Computed:    true,
 							Description: "Timestamp of snapshot processed.",
 						},
-						"state": {
+						"state": &schema.Schema{
 							Type:        schema.TypeString,
 							Computed:    true,
 							Description: "Status of the billing snapshot configuration. Possible values are [enabled, disabled].",
 						},
-						"billing_period": {
+						"billing_period": &schema.Schema{
 							Type:        schema.TypeList,
 							Computed:    true,
 							Description: "Period of billing in snapshot.",
 							Elem: &schema.Resource{
 								Schema: map[string]*schema.Schema{
-									"start": {
+									"start": &schema.Schema{
 										Type:        schema.TypeString,
 										Computed:    true,
 										Description: "Date and time of start of billing in the respective snapshot.",
 									},
-									"end": {
+									"end": &schema.Schema{
 										Type:        schema.TypeString,
 										Computed:    true,
 										Description: "Date and time of end of billing in the respective snapshot.",
@@ -91,53 +97,53 @@ func DataSourceIBMBillingSnapshotList() *schema.Resource {
 								},
 							},
 						},
-						"snapshot_id": {
+						"snapshot_id": &schema.Schema{
 							Type:        schema.TypeString,
 							Computed:    true,
 							Description: "Id of the snapshot captured.",
 						},
-						"charset": {
+						"charset": &schema.Schema{
 							Type:        schema.TypeString,
 							Computed:    true,
 							Description: "Character encoding used.",
 						},
-						"compression": {
+						"compression": &schema.Schema{
 							Type:        schema.TypeString,
 							Computed:    true,
 							Description: "Compression format of the snapshot report.",
 						},
-						"content_type": {
+						"content_type": &schema.Schema{
 							Type:        schema.TypeString,
 							Computed:    true,
 							Description: "Type of content stored in snapshot report.",
 						},
-						"bucket": {
+						"bucket": &schema.Schema{
 							Type:        schema.TypeString,
 							Computed:    true,
 							Description: "The name of the COS bucket to store the snapshot of the billing reports.",
 						},
-						"version": {
+						"version": &schema.Schema{
 							Type:        schema.TypeString,
 							Computed:    true,
 							Description: "Version of the snapshot.",
 						},
-						"created_on": {
+						"created_on": &schema.Schema{
 							Type:        schema.TypeString,
 							Computed:    true,
 							Description: "Date and time of creation of snapshot.",
 						},
-						"report_types": {
+						"report_types": &schema.Schema{
 							Type:        schema.TypeList,
 							Computed:    true,
 							Description: "List of report types configured for the snapshot.",
 							Elem: &schema.Resource{
 								Schema: map[string]*schema.Schema{
-									"type": {
+									"type": &schema.Schema{
 										Type:        schema.TypeString,
 										Computed:    true,
 										Description: "The type of billing report of the snapshot. Possible values are [account_summary, enterprise_summary, account_resource_instance_usage].",
 									},
-									"version": {
+									"version": &schema.Schema{
 										Type:        schema.TypeString,
 										Computed:    true,
 										Description: "Version of the snapshot.",
@@ -145,23 +151,23 @@ func DataSourceIBMBillingSnapshotList() *schema.Resource {
 								},
 							},
 						},
-						"files": {
+						"files": &schema.Schema{
 							Type:        schema.TypeList,
 							Computed:    true,
 							Description: "List of location of reports.",
 							Elem: &schema.Resource{
 								Schema: map[string]*schema.Schema{
-									"report_types": {
+									"report_types": &schema.Schema{
 										Type:        schema.TypeString,
 										Computed:    true,
 										Description: "The type of billing report stored. Possible values are [account_summary, enterprise_summary, account_resource_instance_usage].",
 									},
-									"location": {
+									"location": &schema.Schema{
 										Type:        schema.TypeString,
 										Computed:    true,
 										Description: "Absolute path of the billing report in the COS instance.",
 									},
-									"account_id": {
+									"account_id": &schema.Schema{
 										Type:        schema.TypeString,
 										Computed:    true,
 										Description: "Account ID for which billing report is captured.",
@@ -169,7 +175,7 @@ func DataSourceIBMBillingSnapshotList() *schema.Resource {
 								},
 							},
 						},
-						"processed_at": {
+						"processed_at": &schema.Schema{
 							Type:        schema.TypeInt,
 							Computed:    true,
 							Description: "Timestamp at which snapshot is captured.",
@@ -184,67 +190,61 @@ func DataSourceIBMBillingSnapshotList() *schema.Resource {
 func dataSourceIBMBillingSnapshotListRead(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	usageReportsClient, err := meta.(conns.ClientSession).UsageReportsV4()
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.TerraformErrorf(err, err.Error(), "(Data) ibm_billing_snapshot_list", "read")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
-
-	var next_ref string
-	var snapshotList []usagereportsv4.SnapshotListSnapshotsItem
 	userDetails, err := meta.(conns.ClientSession).BluemixUserDetails()
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.TerraformErrorf(err, err.Error(), "(Data) ibm_billing_snapshot_list", "read")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
-	for {
-		getReportsSnapshotOptions := &usagereportsv4.GetReportsSnapshotOptions{}
-		if next_ref != "" {
-			getReportsSnapshotOptions.SetStart(next_ref)
-		}
 
-		getReportsSnapshotOptions.SetAccountID(userDetails.UserAccount)
-		getReportsSnapshotOptions.SetMonth(d.Get("month").(string))
-		if _, ok := d.GetOk("date_from"); ok {
-			getReportsSnapshotOptions.SetDateFrom(int64(d.Get("date_from").(int)))
-		}
-		if _, ok := d.GetOk("date_to"); ok {
-			getReportsSnapshotOptions.SetDateTo(int64(d.Get("date_to").(int)))
-		}
+	getReportsSnapshotOptions := &usagereportsv4.GetReportsSnapshotOptions{}
 
-		snapshotListResponse, response, err := usageReportsClient.GetReportsSnapshotWithContext(context, getReportsSnapshotOptions)
-		if err != nil {
-			log.Printf("[DEBUG] GetReportsSnapshotWithContext failed %s\n%s", err, response)
-			return diag.FromErr(fmt.Errorf("GetReportsSnapshotWithContext failed %s\n%s", err, response))
-		}
-		if snapshotListResponse.Snapshots != nil && len(snapshotListResponse.Snapshots) > 0 {
-			snapshotList = append(snapshotList, snapshotListResponse.Snapshots...)
-		}
-		if snapshotListResponse.Next == nil || snapshotListResponse.Next.Offset == nil {
-			break
-		}
-		next_ref = *snapshotListResponse.Next.Offset
-		if err != nil {
-			log.Printf("[DEBUG] ListAccountGroupsWithContext failed. Error occurred while parsing NextURL: %s", err)
-			return diag.FromErr(err)
-		}
-		if next_ref == "" {
-			break
-		}
+	getReportsSnapshotOptions.SetAccountID(userDetails.UserAccount)
+	getReportsSnapshotOptions.SetMonth(d.Get("month").(string))
+	if _, ok := d.GetOk("date_from"); ok {
+		getReportsSnapshotOptions.SetDateFrom(int64(d.Get("date_from").(int)))
+	}
+	if _, ok := d.GetOk("date_to"); ok {
+		getReportsSnapshotOptions.SetDateTo(int64(d.Get("date_to").(int)))
+	}
+	if _, ok := d.GetOk("limit"); ok {
+		getReportsSnapshotOptions.SetLimit(int64(d.Get("limit").(int)))
+	}
+
+	var pager *usagereportsv4.GetReportsSnapshotPager
+	pager, err = usageReportsClient.NewGetReportsSnapshotPager(getReportsSnapshotOptions)
+	if err != nil {
+		tfErr := flex.TerraformErrorf(err, err.Error(), "(Data) ibm_billing_snapshot_list", "read")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
+	}
+
+	snapshotList, err := pager.GetAll()
+	if err != nil {
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("GetReportsSnapshotPager.GetAll() failed %s", err), "(Data) ibm_billing_snapshot_list", "read")
+		log.Printf("[DEBUG] %s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	d.SetId(dataSourceIBMBillingSnapshotListID(d))
-
-	if len(snapshotList) == 0 {
-		return diag.FromErr(fmt.Errorf("no snapshots found for account: %s", userDetails.UserAccount))
-	}
 
 	snapshots := []map[string]interface{}{}
 	for _, modelItem := range snapshotList {
 		modelMap, err := dataSourceIBMBillingSnapshotListSnapshotListSnapshotsItemToMap(&modelItem)
 		if err != nil {
-			return diag.FromErr(err)
+			tfErr := flex.TerraformErrorf(err, err.Error(), "(Data) ibm_billing_snapshot_list", "read")
+			return tfErr.GetDiag()
 		}
 		snapshots = append(snapshots, modelMap)
 	}
+
 	if err = d.Set("snapshots", snapshots); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting snapshots %s", err))
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("Error setting snapshots %s", err), "(Data) ibm_billing_snapshot_list", "read")
+		return tfErr.GetDiag()
 	}
 
 	return nil

--- a/ibm/service/usagereports/data_source_ibm_billing_snapshot_list_test.go
+++ b/ibm/service/usagereports/data_source_ibm_billing_snapshot_list_test.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2023 All Rights Reserved.
+// Copyright IBM Corp. 2024 All Rights Reserved.
 // Licensed under the Mozilla Public License v2.0
 
 package usagereports_test
@@ -18,10 +18,10 @@ func TestAccIBMBillingSnapshotListDataSourceBasic(t *testing.T) {
 	date_from := acc.Snapshot_date_from
 	date_to := acc.Snapshot_date_to
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { acc.TestAccPreCheckUsage(t) },
+		PreCheck:  func() { acc.TestAccPreCheck(t) },
 		Providers: acc.TestAccProviders,
 		Steps: []resource.TestStep{
-			{
+			resource.TestStep{
 				Config: testAccCheckIBMBillingSnapshotListDataSourceConfigBasic(month, date_from, date_to),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrSet("data.ibm_billing_snapshot_list.billing_snapshot_list_instance", "id"),

--- a/ibm/service/usagereports/data_source_ibm_billing_snapshot_list_test.go
+++ b/ibm/service/usagereports/data_source_ibm_billing_snapshot_list_test.go
@@ -18,7 +18,7 @@ func TestAccIBMBillingSnapshotListDataSourceBasic(t *testing.T) {
 	date_from := acc.Snapshot_date_from
 	date_to := acc.Snapshot_date_to
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { acc.TestAccPreCheck(t) },
+		PreCheck:  func() { acc.TestAccPreCheckUsage(t) },
 		Providers: acc.TestAccProviders,
 		Steps: []resource.TestStep{
 			resource.TestStep{

--- a/ibm/service/usagereports/resource_ibm_billing_report_snapshot.go
+++ b/ibm/service/usagereports/resource_ibm_billing_report_snapshot.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2023 All Rights Reserved.
+// Copyright IBM Corp. 2024 All Rights Reserved.
 // Licensed under the Mozilla Public License v2.0
 
 package usagereports
@@ -22,159 +22,164 @@ func ResourceIBMBillingReportSnapshot() *schema.Resource {
 	return &schema.Resource{
 		CreateContext: resourceIBMBillingReportSnapshotCreate,
 		ReadContext:   resourceIBMBillingReportSnapshotRead,
-		UpdateContext: resourceIBMBillingReportSnapshotUpdate,
 		DeleteContext: resourceIBMBillingReportSnapshotDelete,
 		Importer:      &schema.ResourceImporter{},
 
 		Schema: map[string]*schema.Schema{
-			"interval": {
+			"interval": &schema.Schema{
 				Type:         schema.TypeString,
 				Required:     true,
+				ForceNew:     true,
 				ValidateFunc: validate.InvokeValidator("ibm_billing_report_snapshot", "interval"),
 				Description:  "Frequency of taking the snapshot of the billing reports.",
 			},
-			"versioning": {
+			"versioning": &schema.Schema{
 				Type:         schema.TypeString,
 				Optional:     true,
 				Default:      "new",
+				ForceNew:     true,
 				ValidateFunc: validate.InvokeValidator("ibm_billing_report_snapshot", "versioning"),
 				Description:  "A new version of report is created or the existing report version is overwritten with every update.",
 			},
-			"report_types": {
+			"report_types": &schema.Schema{
 				Type:        schema.TypeList,
 				Optional:    true,
+				ForceNew:    true,
 				Description: "The type of billing reports to take snapshot of. Possible values are [account_summary, enterprise_summary, account_resource_instance_usage].",
 				Elem:        &schema.Schema{Type: schema.TypeString},
 			},
-			"cos_reports_folder": {
+			"cos_reports_folder": &schema.Schema{
 				Type:        schema.TypeString,
 				Optional:    true,
 				Default:     "IBMCloud-Billing-Reports",
+				ForceNew:    true,
 				Description: "The billing reports root folder to store the billing reports snapshots. Defaults to \"IBMCloud-Billing-Reports\".",
 			},
-			"cos_bucket": {
+			"cos_bucket": &schema.Schema{
 				Type:        schema.TypeString,
 				Required:    true,
+				ForceNew:    true,
 				Description: "The name of the COS bucket to store the snapshot of the billing reports.",
 			},
-			"cos_location": {
+			"cos_location": &schema.Schema{
 				Type:        schema.TypeString,
 				Required:    true,
+				ForceNew:    true,
 				Description: "Region of the COS instance.",
 			},
-			"state": {
+			"state": &schema.Schema{
 				Type:        schema.TypeString,
 				Computed:    true,
 				Description: "Status of the billing snapshot configuration. Possible values are [enabled, disabled].",
 			},
-			"account_type": {
+			"account_type": &schema.Schema{
 				Type:        schema.TypeString,
 				Computed:    true,
 				Description: "Type of account. Possible values are [enterprise, account].",
 			},
-			"compression": {
+			"compression": &schema.Schema{
 				Type:        schema.TypeString,
 				Computed:    true,
 				Description: "Compression format of the snapshot report.",
 			},
-			"content_type": {
+			"content_type": &schema.Schema{
 				Type:        schema.TypeString,
 				Computed:    true,
 				Description: "Type of content stored in snapshot report.",
 			},
-			"cos_endpoint": {
+			"cos_endpoint": &schema.Schema{
 				Type:        schema.TypeString,
 				Computed:    true,
 				Description: "The endpoint of the COS instance.",
 			},
-			"created_at": {
+			"created_at": &schema.Schema{
 				Type:        schema.TypeInt,
 				Computed:    true,
 				Description: "Timestamp in milliseconds when the snapshot configuration was created.",
 			},
-			"last_updated_at": {
+			"last_updated_at": &schema.Schema{
 				Type:        schema.TypeInt,
 				Computed:    true,
 				Description: "Timestamp in milliseconds when the snapshot configuration was last updated.",
 			},
-			"history": {
+			"history": &schema.Schema{
 				Type:        schema.TypeList,
 				Computed:    true,
 				Description: "List of previous versions of the snapshot configurations.",
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
-						"start_time": {
+						"start_time": &schema.Schema{
 							Type:        schema.TypeInt,
 							Computed:    true,
 							Description: "Timestamp in milliseconds when the snapshot configuration was created.",
 						},
-						"end_time": {
+						"end_time": &schema.Schema{
 							Type:        schema.TypeInt,
 							Computed:    true,
 							Description: "Timestamp in milliseconds when the snapshot configuration ends.",
 						},
-						"updated_by": {
+						"updated_by": &schema.Schema{
 							Type:        schema.TypeString,
 							Computed:    true,
 							Description: "Account that updated the billing snapshot configuration.",
 						},
-						"account_id": {
+						"account_id": &schema.Schema{
 							Type:        schema.TypeString,
 							Computed:    true,
 							Description: "Account ID for which billing report snapshot is configured.",
 						},
-						"state": {
+						"state": &schema.Schema{
 							Type:        schema.TypeString,
 							Computed:    true,
 							Description: "Status of the billing snapshot configuration. Possible values are [enabled, disabled].",
 						},
-						"account_type": {
+						"account_type": &schema.Schema{
 							Type:        schema.TypeString,
 							Computed:    true,
 							Description: "Type of account. Possible values [enterprise, account].",
 						},
-						"interval": {
+						"interval": &schema.Schema{
 							Type:        schema.TypeString,
 							Computed:    true,
 							Description: "Frequency of taking the snapshot of the billing reports.",
 						},
-						"versioning": {
+						"versioning": &schema.Schema{
 							Type:        schema.TypeString,
 							Computed:    true,
 							Description: "A new version of report is created or the existing report version is overwritten with every update.",
 						},
-						"report_types": {
+						"report_types": &schema.Schema{
 							Type:        schema.TypeList,
 							Computed:    true,
 							Description: "The type of billing reports to take snapshot of. Possible values are [account_summary, enterprise_summary, account_resource_instance_usage].",
 							Elem:        &schema.Schema{Type: schema.TypeString},
 						},
-						"compression": {
+						"compression": &schema.Schema{
 							Type:        schema.TypeString,
 							Computed:    true,
 							Description: "Compression format of the snapshot report.",
 						},
-						"content_type": {
+						"content_type": &schema.Schema{
 							Type:        schema.TypeString,
 							Computed:    true,
 							Description: "Type of content stored in snapshot report.",
 						},
-						"cos_reports_folder": {
+						"cos_reports_folder": &schema.Schema{
 							Type:        schema.TypeString,
 							Computed:    true,
 							Description: "The billing reports root folder to store the billing reports snapshots. Defaults to \"IBMCloud-Billing-Reports\".",
 						},
-						"cos_bucket": {
+						"cos_bucket": &schema.Schema{
 							Type:        schema.TypeString,
 							Computed:    true,
 							Description: "The name of the COS bucket to store the snapshot of the billing reports.",
 						},
-						"cos_location": {
+						"cos_location": &schema.Schema{
 							Type:        schema.TypeString,
 							Computed:    true,
 							Description: "Region of the COS instance.",
 						},
-						"cos_endpoint": {
+						"cos_endpoint": &schema.Schema{
 							Type:        schema.TypeString,
 							Computed:    true,
 							Description: "The endpoint of the COS instance.",
@@ -212,14 +217,18 @@ func ResourceIBMBillingReportSnapshotValidator() *validate.ResourceValidator {
 func resourceIBMBillingReportSnapshotCreate(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	usageReportsClient, err := meta.(conns.ClientSession).UsageReportsV4()
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.TerraformErrorf(err, err.Error(), "ibm_billing_report_snapshot", "create")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	createReportsSnapshotConfigOptions := &usagereportsv4.CreateReportsSnapshotConfigOptions{}
 
 	userDetails, err := meta.(conns.ClientSession).BluemixUserDetails()
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.TerraformErrorf(err, err.Error(), "ibm_billing_report_snapshot", "create")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	createReportsSnapshotConfigOptions.SetAccountID(userDetails.UserAccount)
@@ -241,10 +250,11 @@ func resourceIBMBillingReportSnapshotCreate(context context.Context, d *schema.R
 		createReportsSnapshotConfigOptions.SetVersioning(d.Get("versioning").(string))
 	}
 
-	snapshotConfig, response, err := usageReportsClient.CreateReportsSnapshotConfigWithContext(context, createReportsSnapshotConfigOptions)
+	snapshotConfig, _, err := usageReportsClient.CreateReportsSnapshotConfigWithContext(context, createReportsSnapshotConfigOptions)
 	if err != nil {
-		log.Printf("[DEBUG] CreateReportsSnapshotConfigWithContext failed %s\n%s", err, response)
-		return diag.FromErr(fmt.Errorf("CreateReportsSnapshotConfigWithContext failed %s\n%s", err, response))
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("CreateReportsSnapshotConfigWithContext failed: %s", err.Error()), "ibm_billing_report_snapshot", "create")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	d.SetId(*snapshotConfig.AccountID)
@@ -255,7 +265,9 @@ func resourceIBMBillingReportSnapshotCreate(context context.Context, d *schema.R
 func resourceIBMBillingReportSnapshotRead(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	usageReportsClient, err := meta.(conns.ClientSession).UsageReportsV4()
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.TerraformErrorf(err, err.Error(), "ibm_billing_report_snapshot", "read")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	getReportsSnapshotConfigOptions := &usagereportsv4.GetReportsSnapshotConfigOptions{}
@@ -268,8 +280,9 @@ func resourceIBMBillingReportSnapshotRead(context context.Context, d *schema.Res
 			d.SetId("")
 			return nil
 		}
-		log.Printf("[DEBUG] GetReportsSnapshotConfigWithContext failed %s\n%s", err, response)
-		return diag.FromErr(fmt.Errorf("GetReportsSnapshotConfigWithContext failed %s\n%s", err, response))
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("GetReportsSnapshotConfigWithContext failed: %s", err.Error()), "ibm_billing_report_snapshot", "read")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	if err = d.Set("interval", snapshotConfig.Interval); err != nil {
@@ -348,73 +361,23 @@ func resourceIBMBillingReportSnapshotRead(context context.Context, d *schema.Res
 	return nil
 }
 
-func resourceIBMBillingReportSnapshotUpdate(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	usageReportsClient, err := meta.(conns.ClientSession).UsageReportsV4()
-	if err != nil {
-		return diag.FromErr(err)
-	}
-
-	updateReportsSnapshotConfigOptions := &usagereportsv4.UpdateReportsSnapshotConfigOptions{}
-
-	updateReportsSnapshotConfigOptions.SetAccountID(d.Id())
-
-	hasChange := false
-
-	if d.HasChange("interval") {
-		updateReportsSnapshotConfigOptions.SetInterval(d.Get("interval").(string))
-		hasChange = true
-	}
-	if d.HasChange("cos_bucket") {
-		updateReportsSnapshotConfigOptions.SetCosBucket(d.Get("cos_bucket").(string))
-		hasChange = true
-	}
-	if d.HasChange("cos_location") {
-		updateReportsSnapshotConfigOptions.SetCosLocation(d.Get("cos_location").(string))
-		hasChange = true
-	}
-	if d.HasChange("cos_reports_folder") {
-		updateReportsSnapshotConfigOptions.SetCosReportsFolder(d.Get("cos_reports_folder").(string))
-		hasChange = true
-	}
-	if d.HasChange("report_types") {
-		var reportTypes []string
-		for _, v := range d.Get("report_types").([]interface{}) {
-			reportTypesItem := v.(string)
-			reportTypes = append(reportTypes, reportTypesItem)
-		}
-		updateReportsSnapshotConfigOptions.SetReportTypes(reportTypes)
-		hasChange = true
-	}
-	if d.HasChange("versioning") {
-		updateReportsSnapshotConfigOptions.SetVersioning(d.Get("versioning").(string))
-		hasChange = true
-	}
-
-	if hasChange {
-		_, response, err := usageReportsClient.UpdateReportsSnapshotConfigWithContext(context, updateReportsSnapshotConfigOptions)
-		if err != nil {
-			log.Printf("[DEBUG] UpdateReportsSnapshotConfigWithContext failed %s\n%s", err, response)
-			return diag.FromErr(fmt.Errorf("UpdateReportsSnapshotConfigWithContext failed %s\n%s", err, response))
-		}
-	}
-
-	return resourceIBMBillingReportSnapshotRead(context, d, meta)
-}
-
 func resourceIBMBillingReportSnapshotDelete(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	usageReportsClient, err := meta.(conns.ClientSession).UsageReportsV4()
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.TerraformErrorf(err, err.Error(), "ibm_billing_report_snapshot", "delete")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	deleteReportsSnapshotConfigOptions := &usagereportsv4.DeleteReportsSnapshotConfigOptions{}
 
 	deleteReportsSnapshotConfigOptions.SetAccountID(d.Id())
 
-	response, err := usageReportsClient.DeleteReportsSnapshotConfigWithContext(context, deleteReportsSnapshotConfigOptions)
+	_, err = usageReportsClient.DeleteReportsSnapshotConfigWithContext(context, deleteReportsSnapshotConfigOptions)
 	if err != nil {
-		log.Printf("[DEBUG] DeleteReportsSnapshotConfigWithContext failed %s\n%s", err, response)
-		return diag.FromErr(fmt.Errorf("DeleteReportsSnapshotConfigWithContext failed %s\n%s", err, response))
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("DeleteReportsSnapshotConfigWithContext failed: %s", err.Error()), "ibm_billing_report_snapshot", "delete")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	d.SetId("")

--- a/ibm/service/usagereports/resource_ibm_billing_report_snapshot_test.go
+++ b/ibm/service/usagereports/resource_ibm_billing_report_snapshot_test.go
@@ -26,25 +26,25 @@ func TestAccIBMBillingReportSnapshotBasic(t *testing.T) {
 	cosLocationUpdate := acc.Cos_location_update
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { acc.TestAccPreCheck(t) },
+		PreCheck:     func() { acc.TestAccPreCheckUsage(t) },
 		Providers:    acc.TestAccProviders,
 		CheckDestroy: testAccCheckIBMBillingReportSnapshotDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
 				Config: testAccCheckIBMBillingReportSnapshotConfigBasic(interval, cosBucket, cosLocation),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckIBMBillingReportSnapshotExists("ibm_billing_report_snapshot.billing_report_snapshot_instance_1", conf),
-					resource.TestCheckResourceAttr("ibm_billing_report_snapshot.billing_report_snapshot_instance_1", "interval", interval),
-					resource.TestCheckResourceAttr("ibm_billing_report_snapshot.billing_report_snapshot_instance_1", "cos_bucket", cosBucket),
-					resource.TestCheckResourceAttr("ibm_billing_report_snapshot.billing_report_snapshot_instance_1", "cos_location", cosLocation),
+					testAccCheckIBMBillingReportSnapshotExists("ibm_billing_report_snapshot.billing_report_snapshot_instance", conf),
+					resource.TestCheckResourceAttr("ibm_billing_report_snapshot.billing_report_snapshot_instance", "interval", interval),
+					resource.TestCheckResourceAttr("ibm_billing_report_snapshot.billing_report_snapshot_instance", "cos_bucket", cosBucket),
+					resource.TestCheckResourceAttr("ibm_billing_report_snapshot.billing_report_snapshot_instance", "cos_location", cosLocation),
 				),
 			},
 			{
 				Config: testAccCheckIBMBillingReportSnapshotConfigBasic(intervalUpdate, cosBucketUpdate, cosLocationUpdate),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr("ibm_billing_report_snapshot.billing_report_snapshot_instance_1", "interval", intervalUpdate),
-					resource.TestCheckResourceAttr("ibm_billing_report_snapshot.billing_report_snapshot_instance_1", "cos_bucket", cosBucketUpdate),
-					resource.TestCheckResourceAttr("ibm_billing_report_snapshot.billing_report_snapshot_instance_1", "cos_location", cosLocationUpdate),
+					resource.TestCheckResourceAttr("ibm_billing_report_snapshot.billing_report_snapshot_instance", "interval", intervalUpdate),
+					resource.TestCheckResourceAttr("ibm_billing_report_snapshot.billing_report_snapshot_instance", "cos_bucket", cosBucketUpdate),
+					resource.TestCheckResourceAttr("ibm_billing_report_snapshot.billing_report_snapshot_instance", "cos_location", cosLocationUpdate),
 				),
 			},
 		},
@@ -60,7 +60,7 @@ func TestAccIBMBillingReportSnapshotAllArgs(t *testing.T) {
 	cosLocation := acc.Cos_location
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { acc.TestAccPreCheck(t) },
+		PreCheck:     func() { acc.TestAccPreCheckUsage(t) },
 		Providers:    acc.TestAccProviders,
 		CheckDestroy: testAccCheckIBMBillingReportSnapshotDestroy,
 		Steps: []resource.TestStep{
@@ -74,11 +74,6 @@ func TestAccIBMBillingReportSnapshotAllArgs(t *testing.T) {
 					resource.TestCheckResourceAttr("ibm_billing_report_snapshot.billing_report_snapshot_instance", "cos_bucket", cosBucket),
 					resource.TestCheckResourceAttr("ibm_billing_report_snapshot.billing_report_snapshot_instance", "cos_location", cosLocation),
 				),
-			},
-			resource.TestStep{
-				ResourceName:      "ibm_billing_report_snapshot.billing_report_snapshot",
-				ImportState:       true,
-				ImportStateVerify: true,
 			},
 		},
 	})

--- a/website/docs/d/billing_snapshot_list.html.markdown
+++ b/website/docs/d/billing_snapshot_list.html.markdown
@@ -26,6 +26,8 @@ You can specify the following arguments for this data source.
 
 * `date_from` - (Optional, Integer) Timestamp in milliseconds for which billing report snapshot is requested.
 * `date_to` - (Optional, Integer) Timestamp in milliseconds for which billing report snapshot is requested.
+* `limit` - (Optional, Integer) Number of usage records returned. The default value is 30. Maximum value is 200.
+  * Constraints: The default value is `30`. The maximum value is `200`. The minimum value is `1`.
 * `month` - (Required, String) The month for which billing report snapshot is requested.  Format is yyyy-mm.
 
 ## Attribute Reference
@@ -34,6 +36,7 @@ After your data source is created, you can read values from the following attrib
 
 * `id` - The unique identifier of the billing_snapshot_list.
 * `count` - (Integer) Number of total snapshots.
+
 * `snapshots` - (List) 
 Nested schema for **snapshots**:
 	* `account_id` - (String) Account ID for which billing report snapshot is configured.

--- a/website/docs/r/billing_report_snapshot.html.markdown
+++ b/website/docs/r/billing_report_snapshot.html.markdown
@@ -48,15 +48,15 @@ If service-to-service authorization already exists in the specific COS bucket, t
 
 You can specify the following arguments for this resource.
 
-* `cos_bucket` - (Required, String) The name of the COS bucket to store the snapshot of the billing reports.
-* `cos_location` - (Required, String) Region of the COS instance.
-* `cos_reports_folder` - (Optional, String) The billing reports root folder to store the billing reports snapshots. Defaults to "IBMCloud-Billing-Reports".
+* `cos_bucket` - (Required, Forces new resource, String) The name of the COS bucket to store the snapshot of the billing reports.
+* `cos_location` - (Required, Forces new resource, String) Region of the COS instance.
+* `cos_reports_folder` - (Optional, Forces new resource, String) The billing reports root folder to store the billing reports snapshots. Defaults to "IBMCloud-Billing-Reports".
   * Constraints: The default value is `IBMCloud-Billing-Reports`.
-* `interval` - (Required, String) Frequency of taking the snapshot of the billing reports.
+* `interval` - (Required, Forces new resource, String) Frequency of taking the snapshot of the billing reports.
   * Constraints: Allowable values are: `daily`.
-* `report_types` - (Optional, List) The type of billing reports to take snapshot of. Possible values are [account_summary, enterprise_summary, account_resource_instance_usage].
+* `report_types` - (Optional, Forces new resource, List) The type of billing reports to take snapshot of. Possible values are [account_summary, enterprise_summary, account_resource_instance_usage].
   * Constraints: Allowable list items are: `account_summary`, `enterprise_summary`, `account_resource_instance_usage`.
-* `versioning` - (Optional, String) A new version of report is created or the existing report version is overwritten with every update.
+* `versioning` - (Optional, Forces new resource, String) A new version of report is created or the existing report version is overwritten with every update.
   * Constraints: The default value is `new`. Allowable values are: `new`, `overwrite`.
 
 ## Attribute Reference
@@ -103,9 +103,9 @@ Nested schema for **history**:
 You can import the `ibm_billing_report_snapshot` resource by using `account_id`. Account ID for which billing report snapshot is configured.
 
 # Syntax
-```
-$ terraform import ibm_billing_report_snapshot.billing_report_snapshot <account_id>
-```
+<pre>
+$ terraform import ibm_billing_report_snapshot.billing_report_snapshot &lt;account_id&gt;
+</pre>
 
 # Example
 ```


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/IBM-Cloud/terraform-provider-ibm/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates https://github.ibm.com/BSS/metering-deliverables/issues/2243

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccIBMBillingReportSnapshot'

=== RUN   TestAccIBMBillingReportSnapshotBasic
--- PASS: TestAccIBMBillingReportSnapshotBasic (29.62s)
PASS
ok      github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/usagereports    35.628s

=== RUN   TestAccIBMBillingReportSnapshotAllArgs
--- PASS: TestAccIBMBillingReportSnapshotAllArgs (19.33s)
PASS
ok      github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/usagereports    25.633s

$make testacc TESTARGS="-run=TestAccIBMBillingSnapshotListDataSourceBasic"

=== RUN   TestAccIBMBillingSnapshotListDataSourceBasic
--- PASS: TestAccIBMBillingSnapshotListDataSourceBasic (12.57s)
PASS
ok      github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/usagereports    24.533s
...
```
