### PR TITLE
wait for kms apply

### DIFF
--- a/ibm/service/kubernetes/resource_ibm_container_cluster.go
+++ b/ibm/service/kubernetes/resource_ibm_container_cluster.go
@@ -53,6 +53,8 @@ const (
 	defaultWorkerPool = "default"
 	computeWorkerPool = "compute"
 	gatewayWorkerpool = "gateway"
+
+	masterDeployed = "deployed"
 )
 
 const PUBLIC_SUBNET_TYPE = "public"

--- a/ibm/service/kubernetes/resource_ibm_container_vpc_cluster_test.go
+++ b/ibm/service/kubernetes/resource_ibm_container_vpc_cluster_test.go
@@ -812,6 +812,7 @@ func testAccCheckIBMContainerVpcClusterBaseEnvvar(name string) string {
 			instance_id = "%[1]s"
 			crk_id = "%[2]s"
 			account_id = "%[3]s"
+			wait_for_apply = "true"
 		}
 	`, acc.KmsInstanceID, acc.CrkID, acc.KmsAccountID)
 	}
@@ -826,7 +827,7 @@ func testAccCheckIBMContainerVpcClusterBaseEnvvar(name string) string {
 			subnet_id = "%[4]s"
 			name      = "us-south-1"
 		}
-		wait_till = "normal"
+		wait_till = "IngressReady"
 		%[5]s
 	}
 	`, name, acc.IksClusterVpcID, acc.IksClusterResourceGroupID, acc.IksClusterSubnetID, kmsConfig)

--- a/website/docs/r/container_vpc_cluster.html.markdown
+++ b/website/docs/r/container_vpc_cluster.html.markdown
@@ -185,6 +185,7 @@ Review the argument references that you can specify for your resource.
   - `instance_id` - (Optional, String) The GUID of the Key Protect instance.
   - `private_endpoint` - (Optional, Bool) Set **true** to configure the KMS private service endpoint. Default value is **false**.
   - `account_id` - (Optional, String) Account ID of KMS instance holder - if not provided, defaults to the account in use.
+  - `wait_for_apply` - (Optional, Bool) Set **true** to make terraform wait until KMS is applied to master and it is ready and deployed. Default value is **false**.
 - `host_pool_id` - (Optional, String) If provided, the cluster will be associated with a dedicated host pool identified by this ID.
 - `kube_version` - (Optional, String)  Specify the Kubernetes version, including the major.minor version. If you do not include this flag, the default version is used. To see available versions, run `ibmcloud ks versions`.
 - `operating_system` - (Optional, String) The operating system of the workers in the default worker pool. For supported options, see [Red Hat OpenShift on IBM Cloud version information](https://cloud.ibm.com/docs/openshift?topic=openshift-openshift_versions) or [IBM Cloud Kubernetes Service version information](https://cloud.ibm.com/docs/containers?topic=containers-cs_versions). This field only affects cluster creation, to manage the default worker pool, create a dedicated worker pool resource.


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/IBM-Cloud/terraform-provider-ibm/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
[…]

[DEBUG] Wait for KMS to apply to master
[DEBUG] Waiting for state to become: [Ready]
[DEBUG] Waiting for KMS to apply to master
[DEBUG] REQUEST: [2024-05-22T15:53:06+02:00] GET /global/v2/getCluster?cluster=<redacted>&v1-compatible HTTP/1.1
[…]
[DEBUG] RESPONSE: [2024-05-22T15:53:07+02:00] Elapsed: 1199ms HTTP/1.1 200 OK
[…]
[DEBUG] KeyProtectEnabled still false
[DEBUG] Waiting for KMS to apply to master
[DEBUG] REQUEST: [2024-05-22T15:53:12+02:00] GET /global/v2/getCluster?cluster=<redacted>&v1-compatible HTTP/1.1
[…]
[DEBUG] RESPONSE: [2024-05-22T15:53:14+02:00] Elapsed: 1120ms HTTP/1.1 200 OK

[…]

[DEBUG] KeyProtectEnabled still false
[DEBUG] Waiting for KMS to apply to master
[DEBUG] REQUEST: [2024-05-22T16:08:58+02:00] GET /global/v2/getCluster?cluster=<redacted>&v1-compatible HTTP/1.1
[…]
[DEBUG] RESPONSE: [2024-05-22T16:08:59+02:00] Elapsed: 1014ms HTTP/1.1 200 OK
[…]
[DEBUG] KMS applied to master

[…]

2024-05-22T16:17:15.975+0200 [DEBUG] sdk.helper_resource: Finished TestCase: test_name=TestAccIBMContainerVpcClusterBaseEnvvar
--- PASS: TestAccIBMContainerVpcClusterBaseEnvvar (1931.50s)
PASS
ok      github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/kubernetes      1934.223s


...
```
