### PR TITLE
Refactor PI Instance

### DIFF
--- a/ibm/service/power/data_source_ibm_pi_instance.go
+++ b/ibm/service/power/data_source_ibm_pi_instance.go
@@ -128,6 +128,12 @@ func DataSourceIBMPIInstance() *schema.Resource {
 							Description: "The MAC address of the instance.",
 							Type:        schema.TypeString,
 						},
+						Attr_Macaddress: {
+							Computed:    true,
+							Deprecated:  "Deprecated, use mac_address instead",
+							Description: "The MAC address of the instance.",
+							Type:        schema.TypeString,
+						},
 						Attr_NetworkID: {
 							Computed:    true,
 							Description: "The network ID of the instance.",

--- a/ibm/service/power/data_source_ibm_pi_instance_ip.go
+++ b/ibm/service/power/data_source_ibm_pi_instance_ip.go
@@ -56,7 +56,7 @@ func DataSourceIBMPIInstanceIP() *schema.Resource {
 				Description: "The IP octet of the network that is attached to this instance.",
 				Type:        schema.TypeString,
 			},
-			Attr_MacAddress: {
+			Attr_Macaddress: {
 				Computed:    true,
 				Description: "The MAC address of the network that is attached to this instance.",
 				Type:        schema.TypeString,
@@ -96,7 +96,7 @@ func dataSourceIBMPIInstancesIPRead(ctx context.Context, d *schema.ResourceData,
 			d.SetId(network.NetworkID)
 			d.Set(Attr_ExternalIP, network.ExternalIP)
 			d.Set(Attr_IP, network.IPAddress)
-			d.Set(Attr_MacAddress, network.MacAddress)
+			d.Set(Attr_Macaddress, network.MacAddress)
 			d.Set(Attr_NetworkID, network.NetworkID)
 			d.Set(Attr_Type, network.Type)
 

--- a/ibm/service/power/data_source_ibm_pi_instances.go
+++ b/ibm/service/power/data_source_ibm_pi_instances.go
@@ -104,6 +104,12 @@ func DataSourceIBMPIInstances() *schema.Resource {
 										Description: "The MAC address of the instance.",
 										Type:        schema.TypeString,
 									},
+									Attr_Macaddress: {
+										Computed:    true,
+										Deprecated:  "Deprecated, use mac_address instead",
+										Description: "The MAC address of the instance.",
+										Type:        schema.TypeString,
+									},
 									Attr_NetworkID: {
 										Computed:    true,
 										Description: "The network ID of the instance.",

--- a/ibm/service/power/data_source_ibm_pi_network_port.go
+++ b/ibm/service/power/data_source_ibm_pi_network_port.go
@@ -51,12 +51,12 @@ func DataSourceIBMPINetworkPort() *schema.Resource {
 							Description: "Network port href.",
 							Type:        schema.TypeString,
 						},
-						Attr_IPAddress: {
+						Attr_IPaddress: {
 							Computed:    true,
 							Description: "The IP address of the port.",
 							Type:        schema.TypeString,
 						},
-						Attr_MacAddress: {
+						Attr_Macaddress: {
 							Computed:    true,
 							Description: "The MAC address of the port.",
 							Type:        schema.TypeString,
@@ -111,8 +111,8 @@ func flattenNetworkPorts(networkPorts []*models.NetworkPort) interface{} {
 		l := map[string]interface{}{
 			Attr_Description: i.Description,
 			Attr_Href:        i.Href,
-			Attr_IPAddress:   *i.IPAddress,
-			Attr_MacAddress:  *i.MacAddress,
+			Attr_IPaddress:   *i.IPAddress,
+			Attr_Macaddress:  *i.MacAddress,
 			Attr_PortID:      *i.PortID,
 			Attr_PublicIP:    i.ExternalIP,
 			Attr_Status:      *i.Status,

--- a/ibm/service/power/ibm_pi_constants.go
+++ b/ibm/service/power/ibm_pi_constants.go
@@ -45,7 +45,6 @@ const (
 	Arg_Name                                = "pi_name"
 	Arg_Network                             = "pi_network"
 	Arg_NetworkName                         = "pi_network_name"
-	Arg_PIInstanceSharedProcessorPool       = "pi_shared_processor_pool"
 	Arg_PinPolicy                           = "pi_pin_policy"
 	Arg_PlacementGroupID                    = "pi_placement_group_id"
 	Arg_PlacementGroupName                  = "pi_placement_group_name"
@@ -99,6 +98,10 @@ const (
 	Arg_VolumeSize                          = "pi_volume_size"
 	Arg_VolumeType                          = "pi_volume_type"
 	Arg_VTL                                 = "vtl"
+
+	// Duplicate Arguments, will be removed as refactoring take course.
+	PIVolumeGroupID      = "pi_volume_group_id"
+	PIVolumeOnboardingID = "pi_volume_onboarding_id"
 
 	// Attributes
 	Attr_Access                                      = "access"
@@ -198,6 +201,7 @@ const (
 	Attr_Images                                      = "images"
 	Attr_ImageType                                   = "image_type"
 	Attr_InputVolumes                                = "input_volumes"
+	Attr_InstanceID                                  = "instance_id"
 	Attr_InstanceIP                                  = "instance_ip"
 	Attr_InstanceMac                                 = "instance_mac"
 	Attr_Instances                                   = "instances"
@@ -205,7 +209,8 @@ const (
 	Attr_InstanceVolumes                             = "instance_volumes"
 	Attr_IOThrottleRate                              = "io_throttle_rate"
 	Attr_IP                                          = "ip"
-	Attr_IPAddress                                   = "ipaddress"
+	Attr_IPAddress                                   = "ip_address"
+	Attr_IPaddress                                   = "ipaddress"
 	Attr_IPOctet                                     = "ipoctet"
 	Attr_IsActive                                    = "is_active"
 	Attr_Jumbo                                       = "jumbo"
@@ -220,7 +225,8 @@ const (
 	Attr_LicenseRepositoryCapacity                   = "license_repository_capacity"
 	Attr_LicenseType                                 = "license_type"
 	Attr_Location                                    = "location"
-	Attr_MacAddress                                  = "macaddress"
+	Attr_MacAddress                                  = "mac_address"
+	Attr_Macaddress                                  = "macaddress"
 	Attr_MasterChangedVolumeName                     = "master_changed_volume_name"
 	Attr_MasterVolumeName                            = "master_volume_name"
 	Attr_Max                                         = "max"
@@ -255,9 +261,8 @@ const (
 	Attr_NumberOfVolumes                             = "number_of_volumes"
 	Attr_Onboardings                                 = "onboardings"
 	Attr_OperatingSystem                             = "operating_system"
+	Attr_OSType                                      = "os_type"
 	Attr_PercentComplete                             = "percent_complete"
-	Attr_PIInstanceSharedProcessorPool               = "shared_processor_pool"
-	Attr_PIInstanceSharedProcessorPoolID             = "shared_processor_pool_id"
 	Attr_PinPolicy                                   = "pin_policy"
 	Attr_PlacementGroupID                            = "placement_group_id"
 	Attr_PlacementGroups                             = "placement_groups"
@@ -309,14 +314,12 @@ const (
 	Attr_SharedProcessorPoolInstanceMemory           = "memory"
 	Attr_SharedProcessorPoolInstanceName             = "name"
 	Attr_SharedProcessorPoolInstances                = "instances"
-	Attr_SharedProcessorPoolInstanceStatus           = "status"
 	Attr_SharedProcessorPoolInstanceUncapped         = "uncapped"
 	Attr_SharedProcessorPoolInstanceVcpus            = "vcpus"
 	Attr_SharedProcessorPoolName                     = "name"
 	Attr_SharedProcessorPoolPlacementGroups          = "spp_placement_groups"
 	Attr_SharedProcessorPoolReservedCores            = "reserved_cores"
 	Attr_SharedProcessorPools                        = "shared_processor_pools"
-	Attr_SharedProcessorPoolStatus                   = "status"
 	Attr_SharedProcessorPoolStatusDetail             = "status_detail"
 	Attr_Size                                        = "size"
 	Attr_SnapshotID                                  = "snapshot_id"
@@ -392,6 +395,18 @@ const (
 	Attr_WorkspaceType                               = "pi_workspace_type"
 	Attr_WWN                                         = "wwn"
 
+	// Duplicate Attributes, will be removed as refactoring take course.
+	PICloudConnectionClassicGreSource      = "gre_source_address"
+	PICloudConnectionConnectionMode        = "connection_mode"
+	PICloudConnectionIBMIPAddress          = "ibm_ip_address"
+	PICloudConnectionId                    = "cloud_connection_id"
+	PICloudConnectionPort                  = "port"
+	PICloudConnectionUserIPAddress         = "user_ip_address"
+	PIDRLocation                           = "location"
+	PIPlacementGroupID                     = "placement_group_id"
+	PIPlacementGroupMembers                = "members"
+	PIVPNConnectionDeadPeerDetectionAction = "action"
+
 	// OS Type
 	OS_IBMI  = "ibmi"
 	StockVTL = "stock-vtl"
@@ -442,13 +457,12 @@ const (
 	State_Added              = "added"
 	State_Adding             = "adding"
 	State_Available          = "available"
-	State_BUILD              = "BUILD"
+	State_Build              = "build"
 	State_Building           = "building"
 	State_Completed          = "completed"
 	State_Creating           = "creating"
 	State_Deleted            = "deleted"
 	State_Deleting           = "deleting"
-	State_DELETING           = "DELETING"
 	State_Down               = "down"
 	State_Error              = "error"
 	State_ERROR              = "ERROR"
@@ -457,68 +471,35 @@ const (
 	State_Inactive           = "inactive"
 	State_InProgress         = "in progress"
 	State_InUse              = "in-use"
-	State_NotFound           = "Not Found"
+	State_NotFound           = "not found"
 	State_Pending            = "pending"
 	State_PENDING            = "PENDING"
 	State_PendingReclamation = "pending_reclamation"
 	State_Provisioning       = "provisioning"
 	State_Removed            = "removed"
+	State_Resize             = "resize"
 	State_RESIZE             = "RESIZE"
 	State_Retry              = "retry"
 	State_Shutoff            = "shutoff"
+	State_Stopping           = "stopping"
 	State_SHUTOFF            = "SHUTOFF"
 	State_Up                 = "up"
+	State_VerifyResize       = "verify_resize"
+	Status_Active            = "ACTIVE"
+	Status_Deleting          = "deleting"
 	Status_Error             = "ERROR"
 	Status_Pending           = "PENDING"
 	Status_Shutoff           = "SHUTOFF"
 
+	// Timeout values
+	Timeout_Active  = 2 * time.Minute
+	Timeout_Delay   = 60 * time.Second
+	Timeout_Warning = 60 * time.Second
+
 	// TODO: Second Half Cleanup, remove extra variables
 
-	// SAP Profile
-	PISAPProfiles         = "profiles"
-	PISAPProfileCertified = "certified"
-	PISAPProfileCores     = "cores"
-	PISAPProfileMemory    = "memory"
-	PISAPProfileID        = "profile_id"
-	PISAPProfileType      = "type"
-
-	//Added timeout values for warning  and active status
-	warningTimeOut = 60 * time.Second
-	activeTimeOut  = 2 * time.Minute
-
-	PIConsoleLanguageCode             = "pi_language_code"
-	PICloudConnectionId               = "cloud_connection_id"
-	PICloudConnectionStatus           = "status"
-	PICloudConnectionIBMIPAddress     = "ibm_ip_address"
-	PICloudConnectionUserIPAddress    = "user_ip_address"
-	PICloudConnectionPort             = "port"
-	PICloudConnectionClassicGreSource = "gre_source_address"
-	PICloudConnectionConnectionMode   = "connection_mode"
-	PIInstanceDeploymentType          = "pi_deployment_type"
-	PIInstanceMigratable              = "pi_migratable"
-	PIInstanceNetwork                 = "pi_network"
-	PIInstanceStoragePool             = "pi_storage_pool"
-	PIInstanceStorageType             = "pi_storage_type"
-	PISAPInstanceProfileID            = "pi_sap_profile_id"
-	PISAPInstanceDeploymentType       = "pi_sap_deployment_type"
-	PIInstanceSharedProcessorPool     = "pi_shared_processor_pool"
-	PIInstanceStorageConnection       = "pi_storage_connection"
-	PIInstanceStoragePoolAffinity     = "pi_storage_pool_affinity"
-
-	PIInstanceUserData  = "pi_user_data"
-	PIInstanceVolumeIds = "pi_volume_ids"
-
-	// Placement Group
-	PIPlacementGroupID      = "placement_group_id"
-	PIPlacementGroupMembers = "members"
-
-	// Volume
-	PIVolumeIds             = "pi_volume_ids"
-	PIAffinityPolicy        = "pi_affinity_policy"
-	PIAffinityVolume        = "pi_affinity_volume"
-	PIAffinityInstance      = "pi_affinity_instance"
-	PIAntiAffinityInstances = "pi_anti_affinity_instances"
-	PIAntiAffinityVolumes   = "pi_anti_affinity_volumes"
+	PIConsoleLanguageCode = "pi_language_code"
+	PIInstanceMigratable  = "pi_migratable"
 
 	// Volume Clone
 	PIVolumeCloneName   = "pi_volume_clone_name"
@@ -528,18 +509,12 @@ const (
 	// IBM PI Volume Group
 	PIVolumeGroupName                 = "pi_volume_group_name"
 	PIVolumeGroupConsistencyGroupName = "pi_consistency_group_name"
-	PIVolumeGroupID                   = "pi_volume_group_id"
 	PIVolumeGroupAction               = "pi_volume_group_action"
-	PIVolumeOnboardingID              = "pi_volume_onboarding_id"
-
-	// Disaster Recovery Location
-	PIDRLocation = "location"
 
 	// VPN
 	PIVPNConnectionId                         = "connection_id"
 	PIVPNConnectionStatus                     = "connection_status"
 	PIVPNConnectionDeadPeerDetection          = "dead_peer_detections"
-	PIVPNConnectionDeadPeerDetectionAction    = "action"
 	PIVPNConnectionDeadPeerDetectionInterval  = "interval"
 	PIVPNConnectionDeadPeerDetectionThreshold = "threshold"
 	PIVPNConnectionLocalGatewayAddress        = "local_gateway_address"
@@ -553,5 +528,4 @@ const (
 	PIWorkspaceDatacenter    = "pi_datacenter"
 	PIWorkspaceResourceGroup = "pi_resource_group_id"
 	PIWorkspacePlan          = "pi_plan"
-	PIVirtualOpticalDevice   = "pi_virtual_optical_device"
 )

--- a/ibm/service/power/resource_ibm_pi_cloud_connection.go
+++ b/ibm/service/power/resource_ibm_pi_cloud_connection.go
@@ -130,7 +130,7 @@ func ResourceIBMPICloudConnection() *schema.Resource {
 				Computed:    true,
 				Description: "Cloud connection ID",
 			},
-			PICloudConnectionStatus: {
+			Attr_Status: {
 				Type:        schema.TypeString,
 				Computed:    true,
 				Description: "Link status",
@@ -443,7 +443,7 @@ func resourceIBMPICloudConnectionRead(ctx context.Context, d *schema.ResourceDat
 	d.Set(helpers.PICloudConnectionMetered, cloudConnection.Metered)
 	d.Set(PICloudConnectionIBMIPAddress, cloudConnection.IbmIPAddress)
 	d.Set(PICloudConnectionUserIPAddress, cloudConnection.UserIPAddress)
-	d.Set(PICloudConnectionStatus, cloudConnection.LinkStatus)
+	d.Set(Attr_Status, cloudConnection.LinkStatus)
 	d.Set(PICloudConnectionPort, cloudConnection.Port)
 	d.Set(helpers.PICloudConnectionSpeed, cloudConnection.Speed)
 	d.Set(helpers.PICloudInstanceId, cloudInstanceID)

--- a/ibm/service/power/resource_ibm_pi_dhcp.go
+++ b/ibm/service/power/resource_ibm_pi_dhcp.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"strings"
 	"time"
 
 	"github.com/IBM-Cloud/power-go-client/clients/instance"
@@ -272,7 +273,7 @@ func waitForIBMPIDhcpStatus(ctx context.Context, client *instance.IBMPIDhcpClien
 				log.Printf("[DEBUG] get DHCP failed %v", err)
 				return nil, "", err
 			}
-			if *dhcpServer.Status != State_Active {
+			if strings.ToLower(*dhcpServer.Status) != State_Active {
 				return dhcpServer, State_Building, nil
 			}
 			return dhcpServer, State_Active, nil

--- a/ibm/service/power/resource_ibm_pi_image.go
+++ b/ibm/service/power/resource_ibm_pi_image.go
@@ -123,41 +123,41 @@ func ResourceIBMPIImage() *schema.Resource {
 				Description: "Storage pool where the image will be loaded, if provided then pi_affinity_policy will be ignored",
 				ForceNew:    true,
 			},
-			PIAffinityPolicy: {
+			Arg_AffinityPolicy: {
 				Type:         schema.TypeString,
 				Optional:     true,
 				Description:  "Affinity policy for image; ignored if pi_image_storage_pool provided; for policy affinity requires one of pi_affinity_instance or pi_affinity_volume to be specified; for policy anti-affinity requires one of pi_anti_affinity_instances or pi_anti_affinity_volumes to be specified",
 				ValidateFunc: validate.ValidateAllowedStringValues([]string{"affinity", "anti-affinity"}),
 				ForceNew:     true,
 			},
-			PIAffinityVolume: {
+			Arg_AffinityVolume: {
 				Type:          schema.TypeString,
 				Optional:      true,
 				Description:   "Volume (ID or Name) to base storage affinity policy against; required if requesting affinity and pi_affinity_instance is not provided",
-				ConflictsWith: []string{PIAffinityInstance},
+				ConflictsWith: []string{Arg_AffinityInstance},
 				ForceNew:      true,
 			},
-			PIAffinityInstance: {
+			Arg_AffinityInstance: {
 				Type:          schema.TypeString,
 				Optional:      true,
 				Description:   "PVM Instance (ID or Name) to base storage affinity policy against; required if requesting storage affinity and pi_affinity_volume is not provided",
-				ConflictsWith: []string{PIAffinityVolume},
+				ConflictsWith: []string{Arg_AffinityVolume},
 				ForceNew:      true,
 			},
-			PIAntiAffinityVolumes: {
+			Arg_AntiAffinityVolumes: {
 				Type:          schema.TypeList,
 				Optional:      true,
 				Elem:          &schema.Schema{Type: schema.TypeString},
 				Description:   "List of volumes to base storage anti-affinity policy against; required if requesting anti-affinity and pi_anti_affinity_instances is not provided",
-				ConflictsWith: []string{PIAntiAffinityInstances},
+				ConflictsWith: []string{Arg_AntiAffinityInstances},
 				ForceNew:      true,
 			},
-			PIAntiAffinityInstances: {
+			Arg_AntiAffinityInstances: {
 				Type:          schema.TypeList,
 				Optional:      true,
 				Elem:          &schema.Schema{Type: schema.TypeString},
 				Description:   "List of pvmInstances to base storage anti-affinity policy against; required if requesting anti-affinity and pi_anti_affinity_volumes is not provided",
-				ConflictsWith: []string{PIAntiAffinityVolumes},
+				ConflictsWith: []string{Arg_AntiAffinityVolumes},
 				ForceNew:      true,
 			},
 			Arg_ImageImportDetails: {
@@ -261,27 +261,27 @@ func resourceIBMPIImageCreate(ctx context.Context, d *schema.ResourceData, meta 
 		if v, ok := d.GetOk(helpers.PIImageStoragePool); ok {
 			body.StoragePool = v.(string)
 		}
-		if ap, ok := d.GetOk(PIAffinityPolicy); ok {
+		if ap, ok := d.GetOk(Arg_AffinityPolicy); ok {
 			policy := ap.(string)
 			affinity := &models.StorageAffinity{
 				AffinityPolicy: &policy,
 			}
 
 			if policy == "affinity" {
-				if av, ok := d.GetOk(PIAffinityVolume); ok {
+				if av, ok := d.GetOk(Arg_AffinityVolume); ok {
 					afvol := av.(string)
 					affinity.AffinityVolume = &afvol
 				}
-				if ai, ok := d.GetOk(PIAffinityInstance); ok {
+				if ai, ok := d.GetOk(Arg_AffinityInstance); ok {
 					afins := ai.(string)
 					affinity.AffinityPVMInstance = &afins
 				}
 			} else {
-				if avs, ok := d.GetOk(PIAntiAffinityVolumes); ok {
+				if avs, ok := d.GetOk(Arg_AntiAffinityVolumes); ok {
 					afvols := flex.ExpandStringList(avs.([]interface{}))
 					affinity.AntiAffinityVolumes = afvols
 				}
-				if ais, ok := d.GetOk(PIAntiAffinityInstances); ok {
+				if ais, ok := d.GetOk(Arg_AntiAffinityInstances); ok {
 					afinss := flex.ExpandStringList(ais.([]interface{}))
 					affinity.AntiAffinityPVMInstances = afinss
 				}

--- a/ibm/service/power/resource_ibm_pi_image_test.go
+++ b/ibm/service/power/resource_ibm_pi_image_test.go
@@ -96,11 +96,11 @@ func testAccCheckIBMPIImageExists(n string) resource.TestCheckFunc {
 func testAccCheckIBMPIImageConfig(name string) string {
 	return fmt.Sprintf(`
 	resource "ibm_pi_image" "power_image" {
-		pi_image_name       = "%s"
-		pi_image_id         = "IBMi-74-01-001"
-		pi_cloud_instance_id = "%s"
+		pi_cloud_instance_id = "%[2]s"
+		pi_image_id         = "%[3]s"
+		pi_image_name       = "%[1]s"
 	  }
-	`, name, acc.Pi_cloud_instance_id)
+	`, name, acc.Pi_cloud_instance_id, acc.Pi_image)
 }
 
 func TestAccIBMPIImageCOSPublicImport(t *testing.T) {
@@ -130,7 +130,7 @@ func testAccCheckIBMPIImageCOSPublicConfig(name string) string {
 		pi_cloud_instance_id = "%[2]s"
 		pi_image_bucket_name = "%[3]s"
 		pi_image_bucket_access = "public"
-		pi_image_bucket_region = "us-south"
+		pi_image_bucket_region = "us-east"
 		pi_image_bucket_file_name = "%[4]s"
 		pi_image_storage_type = "tier1"
 	}

--- a/ibm/service/power/resource_ibm_pi_instance.go
+++ b/ibm/service/power/resource_ibm_pi_instance.go
@@ -16,8 +16,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 
-	st "github.com/IBM-Cloud/power-go-client/clients/instance"
-	"github.com/IBM-Cloud/power-go-client/helpers"
+	"github.com/IBM-Cloud/power-go-client/clients/instance"
 	"github.com/IBM-Cloud/power-go-client/power/models"
 	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/conns"
 	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/flex"
@@ -39,114 +38,44 @@ func ResourceIBMPIInstance() *schema.Resource {
 		},
 
 		Schema: map[string]*schema.Schema{
-
-			helpers.PICloudInstanceId: {
-				Type:        schema.TypeString,
+			// Arguments
+			Arg_AffinityInstance: {
+				ConflictsWith: []string{Arg_AffinityVolume},
+				Description:   "PVM Instance (ID or Name) to base storage affinity policy against; required if requesting storage affinity and pi_affinity_volume is not provided",
+				Optional:      true,
+				Type:          schema.TypeString,
+			},
+			Arg_AffinityPolicy: {
+				Description:  "Affinity policy for pvm instance being created; ignored if pi_storage_pool provided; for policy affinity requires one of pi_affinity_instance or pi_affinity_volume to be specified; for policy anti-affinity requires one of pi_anti_affinity_instances or pi_anti_affinity_volumes to be specified",
+				Optional:     true,
+				Type:         schema.TypeString,
+				ValidateFunc: validate.ValidateAllowedStringValues([]string{Affinity, AntiAffinity}),
+			},
+			Arg_AffinityVolume: {
+				ConflictsWith: []string{Arg_AffinityInstance},
+				Description:   "Volume (ID or Name) to base storage affinity policy against; required if requesting affinity and pi_affinity_instance is not provided",
+				Optional:      true,
+				Type:          schema.TypeString,
+			},
+			Arg_AntiAffinityInstances: {
+				ConflictsWith: []string{Arg_AntiAffinityVolumes},
+				Description:   "List of pvmInstances to base storage anti-affinity policy against; required if requesting anti-affinity and pi_anti_affinity_volumes is not provided",
+				Elem:          &schema.Schema{Type: schema.TypeString},
+				Optional:      true,
+				Type:          schema.TypeList,
+			},
+			Arg_AntiAffinityVolumes: {
+				ConflictsWith: []string{Arg_AntiAffinityInstances},
+				Description:   "List of volumes to base storage anti-affinity policy against; required if requesting anti-affinity and pi_anti_affinity_instances is not provided",
+				Elem:          &schema.Schema{Type: schema.TypeString},
+				Optional:      true,
+				Type:          schema.TypeList,
+			},
+			Arg_CloudInstanceID: {
+				Description: "This is the Power Instance id that is assigned to the account",
 				ForceNew:    true,
 				Required:    true,
-				Description: "This is the Power Instance id that is assigned to the account",
-			},
-			helpers.PIInstanceLicenseRepositoryCapacity: {
-				Type:        schema.TypeInt,
-				Optional:    true,
-				Computed:    true,
-				Deprecated:  "This field is deprecated.",
-				Description: "The VTL license repository capacity TB value",
-			},
-			"status": {
 				Type:        schema.TypeString,
-				Computed:    true,
-				Description: "PI instance status",
-			},
-			"min_processors": {
-				Type:        schema.TypeFloat,
-				Computed:    true,
-				Description: "Minimum number of the CPUs",
-			},
-			"min_memory": {
-				Type:        schema.TypeFloat,
-				Computed:    true,
-				Description: "Minimum memory",
-			},
-			"max_processors": {
-				Type:        schema.TypeFloat,
-				Computed:    true,
-				Description: "Maximum number of processors",
-			},
-			"max_memory": {
-				Type:        schema.TypeFloat,
-				Computed:    true,
-				Description: "Maximum memory size",
-			},
-			helpers.PIInstanceVolumeIds: {
-				Type:             schema.TypeSet,
-				Optional:         true,
-				Elem:             &schema.Schema{Type: schema.TypeString},
-				Set:              schema.HashString,
-				DiffSuppressFunc: flex.ApplyOnce,
-				Description:      "List of PI volumes",
-			},
-			helpers.PIInstanceUserData: {
-				Type:        schema.TypeString,
-				ForceNew:    true,
-				Optional:    true,
-				Description: "Base64 encoded data to be passed in for invoking a cloud init script",
-			},
-			helpers.PIInstanceStorageType: {
-				Type:        schema.TypeString,
-				Optional:    true,
-				Computed:    true,
-				Description: "Storage type for server deployment; if pi_storage_type is not provided the storage type will default to tier3",
-			},
-			PIInstanceStoragePool: {
-				Type:        schema.TypeString,
-				Optional:    true,
-				Computed:    true,
-				Description: "Storage Pool for server deployment; if provided then pi_storage_pool_affinity will be ignored; Only valid when you deploy one of the IBM supplied stock images. Storage pool for a custom image (an imported image or an image that is created from a VM capture) defaults to the storage pool the image was created in",
-			},
-			PIAffinityPolicy: {
-				Type:         schema.TypeString,
-				Optional:     true,
-				Description:  "Affinity policy for pvm instance being created; ignored if pi_storage_pool provided; for policy affinity requires one of pi_affinity_instance or pi_affinity_volume to be specified; for policy anti-affinity requires one of pi_anti_affinity_instances or pi_anti_affinity_volumes to be specified",
-				ValidateFunc: validate.ValidateAllowedStringValues([]string{"affinity", "anti-affinity"}),
-			},
-			PIAffinityVolume: {
-				Type:          schema.TypeString,
-				Optional:      true,
-				Description:   "Volume (ID or Name) to base storage affinity policy against; required if requesting affinity and pi_affinity_instance is not provided",
-				ConflictsWith: []string{PIAffinityInstance},
-			},
-			PIAffinityInstance: {
-				Type:          schema.TypeString,
-				Optional:      true,
-				Description:   "PVM Instance (ID or Name) to base storage affinity policy against; required if requesting storage affinity and pi_affinity_volume is not provided",
-				ConflictsWith: []string{PIAffinityVolume},
-			},
-			PIAntiAffinityVolumes: {
-				Type:          schema.TypeList,
-				Optional:      true,
-				Elem:          &schema.Schema{Type: schema.TypeString},
-				Description:   "List of volumes to base storage anti-affinity policy against; required if requesting anti-affinity and pi_anti_affinity_instances is not provided",
-				ConflictsWith: []string{PIAntiAffinityInstances},
-			},
-			PIAntiAffinityInstances: {
-				Type:          schema.TypeList,
-				Optional:      true,
-				Elem:          &schema.Schema{Type: schema.TypeString},
-				Description:   "List of pvmInstances to base storage anti-affinity policy against; required if requesting anti-affinity and pi_anti_affinity_volumes is not provided",
-				ConflictsWith: []string{PIAntiAffinityVolumes},
-			},
-			helpers.PIInstanceStorageConnection: {
-				Type:         schema.TypeString,
-				Optional:     true,
-				ValidateFunc: validate.ValidateAllowedStringValues([]string{"vSCSI"}),
-				Description:  "Storage Connectivity Group for server deployment",
-			},
-			PIInstanceStoragePoolAffinity: {
-				Type:        schema.TypeBool,
-				Optional:    true,
-				Default:     true,
-				Description: "Indicates if all volumes attached to the server must reside in the same storage pool",
 			},
 			Arg_DeploymentTarget: {
 				Description: "The deployment of a dedicated host.",
@@ -169,233 +98,306 @@ func ResourceIBMPIInstance() *schema.Resource {
 				MaxItems: 1,
 				Type:     schema.TypeSet,
 			},
-			PIInstanceNetwork: {
-				Type:             schema.TypeList,
+			Arg_DeploymentType: {
+				Description:  "Custom Deployment Type Information",
+				ForceNew:     true,
+				Optional:     true,
+				Type:         schema.TypeString,
+				ValidateFunc: validate.ValidateAllowedStringValues([]string{DeploymentTypeEpic, DeploymentTypeVMNoStorage}),
+			},
+			Arg_HealthStatus: {
+				Default:      OK,
+				Description:  "Allow the user to set the status of the lpar so that they can connect to it faster",
+				Optional:     true,
+				Type:         schema.TypeString,
+				ValidateFunc: validate.ValidateAllowedStringValues([]string{OK, Warning}),
+			},
+			Arg_IBMiCSS: {
+				Description: "IBM i Cloud Storage Solution",
+				Optional:    true,
+				Type:        schema.TypeBool,
+			},
+			Arg_IBMiPHA: {
+				Description: "IBM i Power High Availability",
+				Optional:    true,
+				Type:        schema.TypeBool,
+			},
+			Arg_IBMiRDSUsers: {
+				Description: "IBM i Rational Dev Studio Number of User Licenses",
+				Optional:    true,
+				Type:        schema.TypeInt,
+			},
+			Arg_ImageID: {
+				Description:      "PI instance image id",
 				DiffSuppressFunc: flex.ApplyOnce,
 				Required:         true,
+				Type:             schema.TypeString,
+			},
+			Arg_InstanceName: {
+				Description: "PI Instance name",
+				Required:    true,
+				Type:        schema.TypeString,
+			},
+			Arg_KeyPairName: {
+				Description: "SSH key name",
+				ForceNew:    true,
+				Optional:    true,
+				Type:        schema.TypeString,
+			},
+			Arg_LicenseRepositoryCapacity: {
+				Computed:    true,
+				Deprecated:  "This field is deprecated.",
+				Description: "The VTL license repository capacity TB value",
+				Optional:    true,
+				Type:        schema.TypeInt,
+			},
+			Arg_Memory: {
+				Computed:      true,
+				ConflictsWith: []string{Arg_SAPProfileID},
+				Description:   "Memory size",
+				Optional:      true,
+				Type:          schema.TypeFloat,
+			},
+			Arg_Network: {
 				Description:      "List of one or more networks to attach to the instance",
+				DiffSuppressFunc: flex.ApplyOnce,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
-						"ip_address": {
+						Attr_IPAddress: {
 							Type:     schema.TypeString,
 							Optional: true,
 							Computed: true,
 						},
-						"mac_address": {
+						Attr_MacAddress: {
 							Type:     schema.TypeString,
 							Computed: true,
 						},
-						"network_id": {
+						Attr_NetworkID: {
 							Type:     schema.TypeString,
 							Required: true,
 						},
-						"network_name": {
+						Attr_NetworkName: {
 							Type:     schema.TypeString,
 							Computed: true,
 						},
-						"type": {
+						Attr_Type: {
 							Type:     schema.TypeString,
 							Computed: true,
 						},
-						"external_ip": {
+						Attr_ExternalIP: {
 							Type:     schema.TypeString,
 							Computed: true,
 						},
 					},
 				},
+				Required: true,
+				Type:     schema.TypeList,
 			},
-			helpers.PIPlacementGroupID: {
-				Type:        schema.TypeString,
-				Optional:    true,
+			Arg_PinPolicy: {
+				Default:      None,
+				Description:  "Pin Policy of the instance",
+				Optional:     true,
+				Type:         schema.TypeString,
+				ValidateFunc: validate.ValidateAllowedStringValues([]string{None, Soft, Hard}),
+			},
+			Arg_PlacementGroupID: {
 				Description: "Placement group ID",
-			},
-			Arg_PIInstanceSharedProcessorPool: {
-				Type:          schema.TypeString,
-				ForceNew:      true,
-				Optional:      true,
-				ConflictsWith: []string{PISAPInstanceProfileID},
-				Description:   "Shared Processor Pool the instance is deployed on",
-			},
-			Attr_PIInstanceSharedProcessorPoolID: {
-				Type:        schema.TypeString,
 				Computed:    true,
-				Description: "Shared Processor Pool ID the instance is deployed on",
-			},
-			"health_status": {
+				Optional:    true,
 				Type:        schema.TypeString,
-				Computed:    true,
-				Description: "PI Instance health status",
 			},
-			"instance_id": {
-				Type:        schema.TypeString,
-				Computed:    true,
-				Description: "Instance ID",
-			},
-			"pin_policy": {
-				Type:        schema.TypeString,
-				Computed:    true,
-				Description: "PIN Policy of the Instance",
-			},
-			helpers.PIInstanceImageId: {
-				Type:             schema.TypeString,
-				Required:         true,
-				Description:      "PI instance image id",
-				DiffSuppressFunc: flex.ApplyOnce,
-			},
-			helpers.PIInstanceProcessors: {
-				Type:          schema.TypeFloat,
-				Optional:      true,
+			Arg_ProcType: {
 				Computed:      true,
-				ConflictsWith: []string{PISAPInstanceProfileID},
-				Description:   "Processors count",
-			},
-			helpers.PIInstanceName: {
-				Type:        schema.TypeString,
-				Required:    true,
-				Description: "PI Instance name",
-			},
-			helpers.PIInstanceProcType: {
-				Type:          schema.TypeString,
-				Optional:      true,
-				Computed:      true,
-				ValidateFunc:  validate.ValidateAllowedStringValues([]string{"dedicated", "shared", "capped"}),
-				ConflictsWith: []string{PISAPInstanceProfileID},
+				ConflictsWith: []string{Arg_SAPProfileID},
 				Description:   "Instance processor type",
-			},
-			helpers.PIInstanceSSHKeyName: {
-				Type:        schema.TypeString,
-				ForceNew:    true,
-				Optional:    true,
-				Description: "SSH key name",
-			},
-			helpers.PIInstanceMemory: {
-				Type:          schema.TypeFloat,
 				Optional:      true,
-				Computed:      true,
-				ConflictsWith: []string{PISAPInstanceProfileID},
-				Description:   "Memory size",
-			},
-			PIInstanceDeploymentType: {
-				Type:         schema.TypeString,
-				ForceNew:     true,
-				Optional:     true,
-				ValidateFunc: validate.ValidateAllowedStringValues([]string{"EPIC", "VMNoStorage"}),
-				Description:  "Custom Deployment Type Information",
-			},
-			PISAPInstanceProfileID: {
 				Type:          schema.TypeString,
+				ValidateFunc:  validate.ValidateAllowedStringValues([]string{Dedicated, Shared, Capped}),
+			},
+			Arg_Processors: {
+				Computed:      true,
+				ConflictsWith: []string{Arg_SAPProfileID},
+				Description:   "Processors count",
 				Optional:      true,
-				ConflictsWith: []string{helpers.PIInstanceProcessors, helpers.PIInstanceMemory, helpers.PIInstanceProcType},
-				Description:   "SAP Profile ID for the amount of cores and memory",
+				Type:          schema.TypeFloat,
 			},
-			PISAPInstanceDeploymentType: {
-				Type:        schema.TypeString,
-				ForceNew:    true,
-				Optional:    true,
-				Description: "Custom SAP Deployment Type Information",
-			},
-			PIVirtualOpticalDevice: {
-				Type:         schema.TypeString,
-				Optional:     true,
-				ValidateFunc: validate.ValidateAllowedStringValues([]string{"attach"}),
-				Description:  "Virtual Machine's Cloud Initialization Virtual Optical Device",
-			},
-			helpers.PIInstanceSystemType: {
-				Type:        schema.TypeString,
-				ForceNew:    true,
-				Optional:    true,
-				Computed:    true,
-				Description: "PI Instance system type",
-			},
-			helpers.PIInstanceReplicants: {
-				Type:        schema.TypeInt,
-				ForceNew:    true,
-				Optional:    true,
+			Arg_Replicants: {
 				Default:     1,
 				Description: "PI Instance replicas count",
-			},
-			helpers.PIInstanceReplicationPolicy: {
-				Type:         schema.TypeString,
-				ForceNew:     true,
-				Optional:     true,
-				ValidateFunc: validate.ValidateAllowedStringValues([]string{"affinity", "anti-affinity", "none"}),
-				Default:      "none",
-				Description:  "Replication policy for the PI Instance",
-			},
-			helpers.PIInstanceReplicationScheme: {
-				Type:         schema.TypeString,
-				ForceNew:     true,
-				Optional:     true,
-				ValidateFunc: validate.ValidateAllowedStringValues([]string{"prefix", "suffix"}),
-				Default:      "suffix",
-				Description:  "Replication scheme",
-			},
-			helpers.PIInstanceProgress: {
-				Type:        schema.TypeFloat,
-				Computed:    true,
-				Description: "Progress of the operation",
-			},
-			helpers.PIInstancePinPolicy: {
-				Type:         schema.TypeString,
-				Optional:     true,
-				Description:  "Pin Policy of the instance",
-				Default:      "none",
-				ValidateFunc: validate.ValidateAllowedStringValues([]string{"none", "soft", "hard"}),
-			},
-			"operating_system": {
-				Type:        schema.TypeString,
-				Computed:    true,
-				Description: "Operating System",
-			},
-			"os_type": {
-				Type:        schema.TypeString,
-				Computed:    true,
-				Description: "OS Type",
-			},
-			helpers.PIInstanceHealthStatus: {
-				Type:         schema.TypeString,
-				Optional:     true,
-				ValidateFunc: validate.ValidateAllowedStringValues([]string{helpers.PIInstanceHealthOk, helpers.PIInstanceHealthWarning}),
-				Default:      "OK",
-				Description:  "Allow the user to set the status of the lpar so that they can connect to it faster",
-			},
-			helpers.PIVirtualCoresAssigned: {
-				Type:        schema.TypeInt,
+				ForceNew:    true,
 				Optional:    true,
+				Type:        schema.TypeInt,
+			},
+			Arg_ReplicationPolicy: {
+				Default:      None,
+				Description:  "Replication policy for the PI Instance",
+				ForceNew:     true,
+				Optional:     true,
+				Type:         schema.TypeString,
+				ValidateFunc: validate.ValidateAllowedStringValues([]string{Affinity, AntiAffinity, None}),
+			},
+			Arg_ReplicationScheme: {
+				Default:      Suffix,
+				Description:  "Replication scheme",
+				ForceNew:     true,
+				Optional:     true,
+				Type:         schema.TypeString,
+				ValidateFunc: validate.ValidateAllowedStringValues([]string{Prefix, Suffix}),
+			},
+			Arg_SAPProfileID: {
+				ConflictsWith: []string{Arg_Processors, Arg_Memory, Arg_ProcType},
+				Description:   "SAP Profile ID for the amount of cores and memory",
+				Optional:      true,
+				Type:          schema.TypeString,
+			},
+			Arg_SAPDeploymentType: {
+				Description: "Custom SAP Deployment Type Information",
+				ForceNew:    true,
+				Optional:    true,
+				Type:        schema.TypeString,
+			},
+			Arg_SharedProcessorPool: {
+				ConflictsWith: []string{Arg_SAPProfileID},
+				Description:   "Shared Processor Pool the instance is deployed on",
+				ForceNew:      true,
+				Optional:      true,
+				Type:          schema.TypeString,
+			},
+			Arg_StoragePool: {
+				Computed:    true,
+				Description: "Storage Pool for server deployment; if provided then pi_storage_pool_affinity will be ignored; Only valid when you deploy one of the IBM supplied stock images. Storage pool for a custom image (an imported image or an image that is created from a VM capture) defaults to the storage pool the image was created in",
+				Optional:    true,
+				Type:        schema.TypeString,
+			},
+			Arg_StoragePoolAffinity: {
+				Default:     true,
+				Description: "Indicates if all volumes attached to the server must reside in the same storage pool",
+				Optional:    true,
+				Type:        schema.TypeBool,
+			},
+			Arg_StorageType: {
+				Computed:    true,
+				Description: "Storage type for server deployment; if pi_storage_type is not provided the storage type will default to tier3",
+				Optional:    true,
+				Type:        schema.TypeString,
+			},
+			Arg_StorageConnection: {
+				Description:  "Storage Connectivity Group for server deployment",
+				Optional:     true,
+				Type:         schema.TypeString,
+				ValidateFunc: validate.ValidateAllowedStringValues([]string{vSCSI}),
+			},
+			Arg_SysType: {
+				Computed:    true,
+				Description: "PI Instance system type",
+				ForceNew:    true,
+				Optional:    true,
+				Type:        schema.TypeString,
+			},
+			Arg_UserData: {
+				Description: "Base64 encoded data to be passed in for invoking a cloud init script",
+				ForceNew:    true,
+				Optional:    true,
+				Type:        schema.TypeString,
+			},
+			Arg_VirtualCoresAssigned: {
 				Computed:    true,
 				Description: "Virtual Cores Assigned to the PVMInstance",
-			},
-			"max_virtual_cores": {
-				Type:        schema.TypeInt,
-				Computed:    true,
-				Description: "Maximum Virtual Cores Assigned to the PVMInstance",
-			},
-			"min_virtual_cores": {
-				Type:        schema.TypeInt,
-				Computed:    true,
-				Description: "Minimum Virtual Cores Assigned to the PVMInstance",
-			},
-			Arg_IBMiCSS: {
-				Type:        schema.TypeBool,
 				Optional:    true,
-				Description: "IBM i Cloud Storage Solution",
+				Type:        schema.TypeInt,
 			},
-			Arg_IBMiPHA: {
-				Type:        schema.TypeBool,
-				Optional:    true,
-				Description: "IBM i Power High Availability",
+			Arg_VirtualOpticalDevice: {
+				Description:  "Virtual Machine's Cloud Initialization Virtual Optical Device",
+				Optional:     true,
+				Type:         schema.TypeString,
+				ValidateFunc: validate.ValidateAllowedStringValues([]string{Attach}),
+			},
+			Arg_VolumeIDs: {
+				Description:      "List of PI volumes",
+				DiffSuppressFunc: flex.ApplyOnce,
+				Elem:             &schema.Schema{Type: schema.TypeString},
+				Optional:         true,
+				Set:              schema.HashString,
+				Type:             schema.TypeSet,
+			},
+
+			// Attributes
+			Attr_HealthStatus: {
+				Computed:    true,
+				Description: "PI Instance health status",
+				Type:        schema.TypeString,
 			},
 			Attr_IBMiRDS: {
-				Type:        schema.TypeBool,
-				Optional:    false,
-				Required:    false,
 				Computed:    true,
 				Description: "IBM i Rational Dev Studio",
+				Optional:    false,
+				Required:    false,
+				Type:        schema.TypeBool,
 			},
-			Arg_IBMiRDSUsers: {
+			Attr_InstanceID: {
+				Computed:    true,
+				Description: "Instance ID",
+				Type:        schema.TypeString,
+			},
+			Attr_MaxMemory: {
+				Computed:    true,
+				Description: "Maximum memory size",
+				Type:        schema.TypeFloat,
+			},
+			Attr_MaxProcessors: {
+				Computed:    true,
+				Description: "Maximum number of processors",
+				Type:        schema.TypeFloat,
+			},
+			Attr_MaxVirtualCores: {
+				Computed:    true,
+				Description: "Maximum Virtual Cores Assigned to the PVMInstance",
 				Type:        schema.TypeInt,
-				Optional:    true,
-				Description: "IBM i Rational Dev Studio Number of User Licenses",
+			},
+			Attr_MinMemory: {
+				Computed:    true,
+				Description: "Minimum memory",
+				Type:        schema.TypeFloat,
+			},
+			Attr_MinProcessors: {
+				Computed:    true,
+				Description: "Minimum number of the CPUs",
+				Type:        schema.TypeFloat,
+			},
+			Attr_MinVirtualCores: {
+				Computed:    true,
+				Description: "Minimum Virtual Cores Assigned to the PVMInstance",
+				Type:        schema.TypeInt,
+			},
+			Attr_OperatingSystem: {
+				Computed:    true,
+				Description: "Operating System",
+				Type:        schema.TypeString,
+			},
+			Attr_OSType: {
+				Computed:    true,
+				Description: "OS Type",
+				Type:        schema.TypeString,
+			},
+			Attr_PinPolicy: {
+				Computed:    true,
+				Description: "PIN Policy of the Instance",
+				Type:        schema.TypeString,
+			},
+			Attr_Progress: {
+				Computed:    true,
+				Description: "Progress of the operation",
+				Type:        schema.TypeFloat,
+			},
+			Attr_SharedProcessorPoolID: {
+				Computed:    true,
+				Description: "Shared Processor Pool ID the instance is deployed on",
+				Type:        schema.TypeString,
+			},
+			Attr_Status: {
+				Computed:    true,
+				Description: "PI instance status",
+				Type:        schema.TypeString,
 			},
 			Attr_Fault: {
 				Computed:    true,
@@ -412,13 +414,13 @@ func resourceIBMPIInstanceCreate(ctx context.Context, d *schema.ResourceData, me
 	if err != nil {
 		return diag.FromErr(err)
 	}
-	cloudInstanceID := d.Get(helpers.PICloudInstanceId).(string)
-	client := st.NewIBMPIInstanceClient(ctx, sess, cloudInstanceID)
-	sapClient := st.NewIBMPISAPInstanceClient(ctx, sess, cloudInstanceID)
-	imageClient := st.NewIBMPIImageClient(ctx, sess, cloudInstanceID)
+	cloudInstanceID := d.Get(Arg_CloudInstanceID).(string)
+	client := instance.NewIBMPIInstanceClient(ctx, sess, cloudInstanceID)
+	sapClient := instance.NewIBMPISAPInstanceClient(ctx, sess, cloudInstanceID)
+	imageClient := instance.NewIBMPIImageClient(ctx, sess, cloudInstanceID)
 
 	var pvmList *models.PVMInstanceList
-	if _, ok := d.GetOk(PISAPInstanceProfileID); ok {
+	if _, ok := d.GetOk(Arg_SAPProfileID); ok {
 		pvmList, err = createSAPInstance(d, sapClient)
 	} else {
 		pvmList, err = createPVMInstance(d, client, imageClient)
@@ -428,7 +430,7 @@ func resourceIBMPIInstanceCreate(ctx context.Context, d *schema.ResourceData, me
 	}
 
 	var instanceReadyStatus string
-	if r, ok := d.GetOk(helpers.PIInstanceHealthStatus); ok {
+	if r, ok := d.GetOk(Arg_HealthStatus); ok {
 		instanceReadyStatus = r.(string)
 	}
 
@@ -441,13 +443,13 @@ func resourceIBMPIInstanceCreate(ctx context.Context, d *schema.ResourceData, me
 	d.SetId(id)
 
 	for _, s := range *pvmList {
-		if dt, ok := d.GetOk(PIInstanceDeploymentType); ok && dt.(string) == "VMNoStorage" {
-			_, err = isWaitForPIInstanceShutoff(ctx, client, *s.PvmInstanceID, instanceReadyStatus)
+		if dt, ok := d.GetOk(Arg_DeploymentType); ok && dt.(string) == DeploymentTypeVMNoStorage {
+			_, err = isWaitForPIInstanceShutoff(ctx, client, *s.PvmInstanceID, instanceReadyStatus, d.Timeout(schema.TimeoutCreate))
 			if err != nil {
 				return diag.FromErr(err)
 			}
 		} else {
-			_, err = isWaitForPIInstanceAvailable(ctx, client, *s.PvmInstanceID, instanceReadyStatus)
+			_, err = isWaitForPIInstanceAvailable(ctx, client, *s.PvmInstanceID, instanceReadyStatus, d.Timeout(schema.TimeoutCreate))
 			if err != nil {
 				return diag.FromErr(err)
 			}
@@ -457,7 +459,7 @@ func resourceIBMPIInstanceCreate(ctx context.Context, d *schema.ResourceData, me
 	// If Storage Pool Affinity is given as false we need to update the vm instance.
 	// Default value is true which indicates that all volumes attached to the server
 	// must reside in the same storage pool.
-	storagePoolAffinity := d.Get(PIInstanceStoragePoolAffinity).(bool)
+	storagePoolAffinity := d.Get(Arg_StoragePoolAffinity).(bool)
 	if !storagePoolAffinity {
 		for _, s := range *pvmList {
 			body := &models.PVMInstanceUpdate{
@@ -471,7 +473,7 @@ func resourceIBMPIInstanceCreate(ctx context.Context, d *schema.ResourceData, me
 		}
 	}
 	// If virtual optical device provided then update cloud initialization
-	if vod, ok := d.GetOk(PIVirtualOpticalDevice); ok {
+	if vod, ok := d.GetOk(Arg_VirtualOpticalDevice); ok {
 		for _, s := range *pvmList {
 			body := &models.PVMInstanceUpdate{
 				CloudInitialization: &models.CloudInitialization{
@@ -502,74 +504,74 @@ func resourceIBMPIInstanceRead(ctx context.Context, d *schema.ResourceData, meta
 	cloudInstanceID := idArr[0]
 	instanceID := idArr[1]
 
-	client := st.NewIBMPIInstanceClient(ctx, sess, cloudInstanceID)
+	client := instance.NewIBMPIInstanceClient(ctx, sess, cloudInstanceID)
 	powervmdata, err := client.Get(instanceID)
 	if err != nil {
 		return diag.FromErr(err)
 	}
 
-	d.Set(helpers.PIInstanceMemory, powervmdata.Memory)
-	d.Set(helpers.PIInstanceProcessors, powervmdata.Processors)
+	d.Set(Arg_Memory, powervmdata.Memory)
+	d.Set(Arg_Processors, powervmdata.Processors)
 	if powervmdata.Status != nil {
-		d.Set("status", powervmdata.Status)
+		d.Set(Attr_Status, powervmdata.Status)
 	}
-	d.Set(helpers.PIInstanceProcType, powervmdata.ProcType)
-	d.Set("min_processors", powervmdata.Minproc)
-	d.Set(helpers.PIInstanceProgress, powervmdata.Progress)
+	d.Set(Arg_ProcType, powervmdata.ProcType)
+	d.Set(Attr_MinProcessors, powervmdata.Minproc)
+	d.Set(Attr_Progress, powervmdata.Progress)
 	if powervmdata.StorageType != nil && *powervmdata.StorageType != "" {
-		d.Set(helpers.PIInstanceStorageType, powervmdata.StorageType)
+		d.Set(Arg_StorageType, powervmdata.StorageType)
 	}
-	d.Set(PIInstanceStoragePool, powervmdata.StoragePool)
-	d.Set(PIInstanceStoragePoolAffinity, powervmdata.StoragePoolAffinity)
-	d.Set(helpers.PICloudInstanceId, cloudInstanceID)
-	d.Set("instance_id", powervmdata.PvmInstanceID)
-	d.Set(helpers.PIInstanceName, powervmdata.ServerName)
-	d.Set(helpers.PIInstanceImageId, powervmdata.ImageID)
-	if *powervmdata.PlacementGroup != "none" {
-		d.Set(helpers.PIPlacementGroupID, powervmdata.PlacementGroup)
+	d.Set(Arg_StoragePool, powervmdata.StoragePool)
+	d.Set(Arg_StoragePoolAffinity, powervmdata.StoragePoolAffinity)
+	d.Set(Arg_CloudInstanceID, cloudInstanceID)
+	d.Set(Attr_InstanceID, powervmdata.PvmInstanceID)
+	d.Set(Arg_InstanceName, powervmdata.ServerName)
+	d.Set(Arg_ImageID, powervmdata.ImageID)
+	if *powervmdata.PlacementGroup != None {
+		d.Set(Arg_PlacementGroupID, powervmdata.PlacementGroup)
 	}
-	d.Set(Arg_PIInstanceSharedProcessorPool, powervmdata.SharedProcessorPool)
-	d.Set(Attr_PIInstanceSharedProcessorPoolID, powervmdata.SharedProcessorPoolID)
+	d.Set(Arg_SharedProcessorPool, powervmdata.SharedProcessorPool)
+	d.Set(Attr_SharedProcessorPoolID, powervmdata.SharedProcessorPoolID)
 
 	networksMap := []map[string]interface{}{}
 	if powervmdata.Networks != nil {
 		for _, n := range powervmdata.Networks {
 			if n != nil {
 				v := map[string]interface{}{
-					"ip_address":   n.IPAddress,
-					"mac_address":  n.MacAddress,
-					"network_id":   n.NetworkID,
-					"network_name": n.NetworkName,
-					"type":         n.Type,
-					"external_ip":  n.ExternalIP,
+					Attr_IPAddress:   n.IPAddress,
+					Attr_MacAddress:  n.MacAddress,
+					Attr_NetworkID:   n.NetworkID,
+					Attr_NetworkName: n.NetworkName,
+					Attr_Type:        n.Type,
+					Attr_ExternalIP:  n.ExternalIP,
 				}
 				networksMap = append(networksMap, v)
 			}
 		}
 	}
-	d.Set(PIInstanceNetwork, networksMap)
+	d.Set(Arg_Network, networksMap)
 
 	if powervmdata.SapProfile != nil && powervmdata.SapProfile.ProfileID != nil {
-		d.Set(PISAPInstanceProfileID, powervmdata.SapProfile.ProfileID)
+		d.Set(Arg_SAPProfileID, powervmdata.SapProfile.ProfileID)
 	}
-	d.Set(helpers.PIInstanceSystemType, powervmdata.SysType)
-	d.Set("min_memory", powervmdata.Minmem)
-	d.Set("max_processors", powervmdata.Maxproc)
-	d.Set("max_memory", powervmdata.Maxmem)
-	d.Set("pin_policy", powervmdata.PinPolicy)
-	d.Set("operating_system", powervmdata.OperatingSystem)
-	d.Set("os_type", powervmdata.OsType)
+	d.Set(Arg_SysType, powervmdata.SysType)
+	d.Set(Attr_MinMemory, powervmdata.Minmem)
+	d.Set(Attr_MaxProcessors, powervmdata.Maxproc)
+	d.Set(Attr_MaxMemory, powervmdata.Maxmem)
+	d.Set(Attr_PinPolicy, powervmdata.PinPolicy)
+	d.Set(Attr_OperatingSystem, powervmdata.OperatingSystem)
+	d.Set(Attr_OSType, powervmdata.OsType)
 
 	if powervmdata.Health != nil {
-		d.Set("health_status", powervmdata.Health.Status)
+		d.Set(Attr_HealthStatus, powervmdata.Health.Status)
 	}
 	if powervmdata.VirtualCores != nil {
-		d.Set(helpers.PIVirtualCoresAssigned, powervmdata.VirtualCores.Assigned)
-		d.Set("max_virtual_cores", powervmdata.VirtualCores.Max)
-		d.Set("min_virtual_cores", powervmdata.VirtualCores.Min)
+		d.Set(Arg_VirtualCoresAssigned, powervmdata.VirtualCores.Assigned)
+		d.Set(Attr_MaxVirtualCores, powervmdata.VirtualCores.Max)
+		d.Set(Attr_MinVirtualCores, powervmdata.VirtualCores.Min)
 	}
-	d.Set(helpers.PIInstanceLicenseRepositoryCapacity, powervmdata.LicenseRepositoryCapacity)
-	d.Set(PIInstanceDeploymentType, powervmdata.DeploymentType)
+	d.Set(Arg_LicenseRepositoryCapacity, powervmdata.LicenseRepositoryCapacity)
+	d.Set(Arg_DeploymentType, powervmdata.DeploymentType)
 	if powervmdata.SoftwareLicenses != nil {
 		d.Set(Arg_IBMiCSS, powervmdata.SoftwareLicenses.IbmiCSS)
 		d.Set(Arg_IBMiPHA, powervmdata.SoftwareLicenses.IbmiPHA)
@@ -590,13 +592,13 @@ func resourceIBMPIInstanceRead(ctx context.Context, d *schema.ResourceData, meta
 
 func resourceIBMPIInstanceUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 
-	name := d.Get(helpers.PIInstanceName).(string)
-	mem := d.Get(helpers.PIInstanceMemory).(float64)
-	procs := d.Get(helpers.PIInstanceProcessors).(float64)
-	processortype := d.Get(helpers.PIInstanceProcType).(string)
-	assignedVirtualCores := int64(d.Get(helpers.PIVirtualCoresAssigned).(int))
+	name := d.Get(Arg_InstanceName).(string)
+	mem := d.Get(Arg_Memory).(float64)
+	procs := d.Get(Arg_Processors).(float64)
+	processortype := d.Get(Arg_ProcType).(string)
+	assignedVirtualCores := int64(d.Get(Arg_VirtualCoresAssigned).(int))
 
-	if d.Get("health_status") == "WARNING" {
+	if d.Get(Attr_HealthStatus) == Warning {
 		return diag.Errorf("the operation cannot be performed when the lpar health in the WARNING State")
 	}
 
@@ -610,40 +612,41 @@ func resourceIBMPIInstanceUpdate(ctx context.Context, d *schema.ResourceData, me
 		return diag.FromErr(err)
 	}
 
-	client := st.NewIBMPIInstanceClient(ctx, sess, cloudInstanceID)
+	client := instance.NewIBMPIInstanceClient(ctx, sess, cloudInstanceID)
 
 	// Check if cloud instance is capable of changing virtual cores
-	cloudInstanceClient := st.NewIBMPICloudInstanceClient(ctx, sess, cloudInstanceID)
+	cloudInstanceClient := instance.NewIBMPICloudInstanceClient(ctx, sess, cloudInstanceID)
 	cloudInstance, err := cloudInstanceClient.Get(cloudInstanceID)
 	if err != nil {
 		return diag.FromErr(err)
 	}
 	cores_enabled := checkCloudInstanceCapability(cloudInstance, CUSTOM_VIRTUAL_CORES)
 
-	if d.HasChanges(helpers.PIInstanceName, PIVirtualOpticalDevice) {
+	if d.HasChanges(Arg_InstanceName, Arg_VirtualOpticalDevice) {
 		body := &models.PVMInstanceUpdate{}
-		if d.HasChange(helpers.PIInstanceName) {
+		if d.HasChange(Arg_InstanceName) {
 			body.ServerName = name
 		}
-		if d.HasChange(PIVirtualOpticalDevice) {
-			body.CloudInitialization.VirtualOpticalDevice = d.Get(PIVirtualOpticalDevice).(string)
+		if d.HasChange(Arg_VirtualOpticalDevice) {
+			body.CloudInitialization.VirtualOpticalDevice = d.Get(Arg_VirtualOpticalDevice).(string)
 		}
 		_, err = client.Update(instanceID, body)
 		if err != nil {
 			return diag.Errorf("failed to update the lpar: %v", err)
 		}
-		_, err = isWaitForPIInstanceAvailable(ctx, client, instanceID, "OK")
+		_, err = isWaitForPIInstanceAvailable(ctx, client, instanceID, OK, d.Timeout(schema.TimeoutUpdate))
 		if err != nil {
 			return diag.FromErr(err)
 		}
 	}
 
-	if d.HasChange(helpers.PIInstanceProcType) {
+	if d.HasChange(Arg_ProcType) {
 		// Stop the lpar
-		if d.Get("status") == "SHUTOFF" {
+		status := d.Get(Attr_Status).(string)
+		if strings.ToLower(status) == State_Shutoff {
 			log.Printf("the lpar is in the shutoff state. Nothing to do . Moving on ")
 		} else {
-			err := stopLparForResourceChange(ctx, client, instanceID)
+			err := stopLparForResourceChange(ctx, client, instanceID, d)
 			if err != nil {
 				return diag.FromErr(err)
 			}
@@ -662,20 +665,20 @@ func resourceIBMPIInstanceUpdate(ctx context.Context, d *schema.ResourceData, me
 		if err != nil {
 			return diag.FromErr(err)
 		}
-		_, err = isWaitForPIInstanceStopped(ctx, client, instanceID)
+		_, err = isWaitForPIInstanceStopped(ctx, client, instanceID, d.Timeout(schema.TimeoutUpdate))
 		if err != nil {
 			return diag.FromErr(err)
 		}
 
 		// Start the lpar
-		err := startLparAfterResourceChange(ctx, client, instanceID)
+		err := startLparAfterResourceChange(ctx, client, instanceID, d)
 		if err != nil {
 			return diag.FromErr(err)
 		}
 	}
 
 	// Virtual core will be updated only if service instance capability is enabled
-	if d.HasChange(helpers.PIVirtualCoresAssigned) {
+	if d.HasChange(Arg_VirtualCoresAssigned) {
 		body := &models.PVMInstanceUpdate{
 			VirtualCores: &models.VirtualCores{Assigned: &assignedVirtualCores},
 		}
@@ -683,18 +686,17 @@ func resourceIBMPIInstanceUpdate(ctx context.Context, d *schema.ResourceData, me
 		if err != nil {
 			return diag.Errorf("failed to update the lpar with the change for virtual cores: %v", err)
 		}
-		_, err = isWaitForPIInstanceAvailable(ctx, client, instanceID, "OK")
+		_, err = isWaitForPIInstanceAvailable(ctx, client, instanceID, OK, d.Timeout(schema.TimeoutUpdate))
 		if err != nil {
 			return diag.FromErr(err)
 		}
 	}
 
 	// Start of the change for Memory and Processors
-	if d.HasChange(helpers.PIInstanceMemory) || d.HasChange(helpers.PIInstanceProcessors) {
+	if d.HasChange(Arg_Memory) || d.HasChange(Arg_Processors) {
 
-		maxMemLpar := d.Get("max_memory").(float64)
-		maxCPULpar := d.Get("max_processors").(float64)
-		//log.Printf("the required memory is set to [%d] and current max memory is set to  [%d] ", int(mem), int(maxMemLpar))
+		maxMemLpar := d.Get(Attr_MaxMemory).(float64)
+		maxCPULpar := d.Get(Attr_MaxProcessors).(float64)
 
 		if mem > maxMemLpar || procs > maxCPULpar {
 			log.Printf("Will require a shutdown to perform the change")
@@ -703,13 +705,11 @@ func resourceIBMPIInstanceUpdate(ctx context.Context, d *schema.ResourceData, me
 			log.Printf("maxCPULpar is set to %f", maxCPULpar)
 		}
 
-		//if d.GetOkExists("reboot_for_resource_change")
-
-		instanceState := d.Get("status")
+		instanceState := d.Get(Attr_Status).(string)
 		log.Printf("the instance state is %s", instanceState)
 
-		if (mem > maxMemLpar || procs > maxCPULpar) && instanceState != "SHUTOFF" {
-			err = performChangeAndReboot(ctx, client, instanceID, cloudInstanceID, mem, procs)
+		if (mem > maxMemLpar || procs > maxCPULpar) && strings.ToLower(instanceState) != State_Shutoff {
+			err = performChangeAndReboot(ctx, client, d, instanceID, mem, procs)
 			if err != nil {
 				return diag.FromErr(err)
 			}
@@ -730,13 +730,13 @@ func resourceIBMPIInstanceUpdate(ctx context.Context, d *schema.ResourceData, me
 			if err != nil {
 				return diag.Errorf("failed to update the lpar with the change %v", err)
 			}
-			if instanceState == "SHUTOFF" {
-				_, err = isWaitforPIInstanceUpdate(ctx, client, instanceID)
+			if strings.ToLower(instanceState) == State_Shutoff {
+				_, err = isWaitforPIInstanceUpdate(ctx, client, instanceID, d.Timeout(schema.TimeoutUpdate))
 				if err != nil {
 					return diag.FromErr(err)
 				}
 			} else {
-				_, err = isWaitForPIInstanceAvailable(ctx, client, instanceID, "OK")
+				_, err = isWaitForPIInstanceAvailable(ctx, client, instanceID, Arg_HealthStatus, d.Timeout(schema.TimeoutUpdate))
 				if err != nil {
 					return diag.FromErr(err)
 				}
@@ -746,8 +746,8 @@ func resourceIBMPIInstanceUpdate(ctx context.Context, d *schema.ResourceData, me
 
 	// License repository capacity will be updated only if service instance is a vtl instance
 	// might need to check if lrc was set
-	if d.HasChange(helpers.PIInstanceLicenseRepositoryCapacity) {
-		lrc := d.Get(helpers.PIInstanceLicenseRepositoryCapacity).(int64)
+	if d.HasChange(Arg_LicenseRepositoryCapacity) {
+		lrc := d.Get(Arg_LicenseRepositoryCapacity).(int64)
 		body := &models.PVMInstanceUpdate{
 			LicenseRepositoryCapacity: lrc,
 		}
@@ -755,25 +755,26 @@ func resourceIBMPIInstanceUpdate(ctx context.Context, d *schema.ResourceData, me
 		if err != nil {
 			return diag.Errorf("failed to update the lpar with the change for license repository capacity %s", err)
 		}
-		_, err = isWaitForPIInstanceAvailable(ctx, client, instanceID, "OK")
+		_, err = isWaitForPIInstanceAvailable(ctx, client, instanceID, OK, d.Timeout(schema.TimeoutUpdate))
 		if err != nil {
 			diag.FromErr(err)
 		}
 	}
 
-	if d.HasChange(PISAPInstanceProfileID) {
+	if d.HasChange(Arg_SAPProfileID) {
 		// Stop the lpar
-		if d.Get("status") == "SHUTOFF" {
+		status := d.Get(Attr_Status).(string)
+		if strings.ToLower(status) == State_Shutoff {
 			log.Printf("the lpar is in the shutoff state. Nothing to do... Moving on ")
 		} else {
-			err := stopLparForResourceChange(ctx, client, instanceID)
+			err := stopLparForResourceChange(ctx, client, instanceID, d)
 			if err != nil {
 				return diag.FromErr(err)
 			}
 		}
 
 		// Update the profile id
-		profileID := d.Get(PISAPInstanceProfileID).(string)
+		profileID := d.Get(Arg_SAPProfileID).(string)
 		body := &models.PVMInstanceUpdate{
 			SapProfileID: profileID,
 		}
@@ -783,19 +784,19 @@ func resourceIBMPIInstanceUpdate(ctx context.Context, d *schema.ResourceData, me
 		}
 
 		// Wait for the resize to complete and status to reset
-		_, err = isWaitForPIInstanceStopped(ctx, client, instanceID)
+		_, err = isWaitForPIInstanceStopped(ctx, client, instanceID, d.Timeout(schema.TimeoutUpdate))
 		if err != nil {
 			return diag.FromErr(err)
 		}
 
 		// Start the lpar
-		err := startLparAfterResourceChange(ctx, client, instanceID)
+		err := startLparAfterResourceChange(ctx, client, instanceID, d)
 		if err != nil {
 			return diag.FromErr(err)
 		}
 	}
-	if d.HasChange(PIInstanceStoragePoolAffinity) {
-		storagePoolAffinity := d.Get(PIInstanceStoragePoolAffinity).(bool)
+	if d.HasChange(Arg_StoragePoolAffinity) {
+		storagePoolAffinity := d.Get(Arg_StoragePoolAffinity).(bool)
 		body := &models.PVMInstanceUpdate{
 			StoragePoolAffinity: &storagePoolAffinity,
 		}
@@ -806,10 +807,10 @@ func resourceIBMPIInstanceUpdate(ctx context.Context, d *schema.ResourceData, me
 		}
 	}
 
-	if d.HasChange(helpers.PIPlacementGroupID) {
-		pgClient := st.NewIBMPIPlacementGroupClient(ctx, sess, cloudInstanceID)
+	if d.HasChange(Arg_PlacementGroupID) {
+		pgClient := instance.NewIBMPIPlacementGroupClient(ctx, sess, cloudInstanceID)
 
-		oldRaw, newRaw := d.GetChange(helpers.PIPlacementGroupID)
+		oldRaw, newRaw := d.GetChange(Arg_PlacementGroupID)
 		old := oldRaw.(string)
 		new := newRaw.(string)
 
@@ -826,7 +827,7 @@ func resourceIBMPIInstanceUpdate(ctx context.Context, d *schema.ResourceData, me
 					return diag.FromErr(err)
 				}
 			} else {
-				_, err = isWaitForPIInstancePlacementGroupDelete(ctx, pgClient, *pgID.ID, instanceID)
+				_, err = isWaitForPIInstancePlacementGroupDelete(ctx, pgClient, *pgID.ID, instanceID, d.Timeout(schema.TimeoutUpdate))
 				if err != nil {
 					return diag.FromErr(err)
 				}
@@ -843,7 +844,7 @@ func resourceIBMPIInstanceUpdate(ctx context.Context, d *schema.ResourceData, me
 			if err != nil {
 				return diag.FromErr(err)
 			} else {
-				_, err = isWaitForPIInstancePlacementGroupAdd(ctx, pgClient, *pgID.ID, instanceID)
+				_, err = isWaitForPIInstancePlacementGroupAdd(ctx, pgClient, *pgID.ID, instanceID, d.Timeout(schema.TimeoutUpdate))
 				if err != nil {
 					return diag.FromErr(err)
 				}
@@ -851,10 +852,11 @@ func resourceIBMPIInstanceUpdate(ctx context.Context, d *schema.ResourceData, me
 		}
 	}
 	if d.HasChanges(Arg_IBMiCSS, Arg_IBMiPHA, Arg_IBMiRDSUsers) {
-		if d.Get("status") == "ACTIVE" {
+		status := d.Get(Attr_Status).(string)
+		if strings.ToLower(status) == State_Active {
 			log.Printf("the lpar is in the Active state, continuing with update")
 		} else {
-			_, err = isWaitForPIInstanceAvailable(ctx, client, instanceID, "OK")
+			_, err = isWaitForPIInstanceAvailable(ctx, client, instanceID, OK, d.Timeout(schema.TimeoutUpdate))
 			if err != nil {
 				return diag.FromErr(err)
 			}
@@ -875,7 +877,7 @@ func resourceIBMPIInstanceUpdate(ctx context.Context, d *schema.ResourceData, me
 		if err != nil {
 			return diag.FromErr(err)
 		}
-		_, err = isWaitForPIInstanceSoftwareLicenses(ctx, client, instanceID, sl)
+		_, err = isWaitForPIInstanceSoftwareLicenses(ctx, client, instanceID, sl, d.Timeout(schema.TimeoutUpdate))
 		if err != nil {
 			return diag.FromErr(err)
 		}
@@ -895,7 +897,7 @@ func resourceIBMPIInstanceDelete(ctx context.Context, d *schema.ResourceData, me
 	}
 
 	cloudInstanceID := idArr[0]
-	client := st.NewIBMPIInstanceClient(ctx, sess, cloudInstanceID)
+	client := instance.NewIBMPIInstanceClient(ctx, sess, cloudInstanceID)
 	for _, instanceID := range idArr[1:] {
 		err = client.Delete(instanceID)
 		if err != nil {
@@ -904,7 +906,7 @@ func resourceIBMPIInstanceDelete(ctx context.Context, d *schema.ResourceData, me
 	}
 
 	for _, instanceID := range idArr[1:] {
-		_, err = isWaitForPIInstanceDeleted(ctx, client, instanceID)
+		_, err = isWaitForPIInstanceDeleted(ctx, client, instanceID, d.Timeout(schema.TimeoutUpdate))
 		if err != nil {
 			return diag.FromErr(err)
 		}
@@ -914,54 +916,54 @@ func resourceIBMPIInstanceDelete(ctx context.Context, d *schema.ResourceData, me
 	return nil
 }
 
-func isWaitForPIInstanceDeleted(ctx context.Context, client *st.IBMPIInstanceClient, id string) (interface{}, error) {
+func isWaitForPIInstanceDeleted(ctx context.Context, client *instance.IBMPIInstanceClient, id string, timeout time.Duration) (interface{}, error) {
 
 	log.Printf("Waiting for  (%s) to be deleted.", id)
 
 	stateConf := &retry.StateChangeConf{
-		Pending:    []string{"retry", helpers.PIInstanceDeleting},
-		Target:     []string{helpers.PIInstanceNotFound},
+		Pending:    []string{State_Retry, State_Deleting},
+		Target:     []string{State_NotFound},
 		Refresh:    isPIInstanceDeleteRefreshFunc(client, id),
-		Delay:      10 * time.Second,
-		MinTimeout: 10 * time.Second,
-		Timeout:    10 * time.Minute,
+		Delay:      Timeout_Delay,
+		MinTimeout: Timeout_Active,
+		Timeout:    timeout,
 	}
 
 	return stateConf.WaitForStateContext(ctx)
 }
 
-func isPIInstanceDeleteRefreshFunc(client *st.IBMPIInstanceClient, id string) retry.StateRefreshFunc {
+func isPIInstanceDeleteRefreshFunc(client *instance.IBMPIInstanceClient, id string) retry.StateRefreshFunc {
 	return func() (interface{}, string, error) {
 		pvm, err := client.Get(id)
 		if err != nil {
 			log.Printf("The power vm does not exist")
-			return pvm, helpers.PIInstanceNotFound, nil
+			return pvm, State_NotFound, nil
 		}
-		return pvm, helpers.PIInstanceDeleting, nil
+		return pvm, State_Deleting, nil
 	}
 }
 
-func isWaitForPIInstanceAvailable(ctx context.Context, client *st.IBMPIInstanceClient, id string, instanceReadyStatus string) (interface{}, error) {
+func isWaitForPIInstanceAvailable(ctx context.Context, client *instance.IBMPIInstanceClient, id string, instanceReadyStatus string, timeout time.Duration) (interface{}, error) {
 	log.Printf("Waiting for PIInstance (%s) to be available and active ", id)
 
-	queryTimeOut := activeTimeOut
-	if instanceReadyStatus == helpers.PIInstanceHealthWarning {
-		queryTimeOut = warningTimeOut
+	queryTimeOut := Timeout_Active
+	if instanceReadyStatus == Warning {
+		queryTimeOut = Timeout_Warning
 	}
 
 	stateConf := &retry.StateChangeConf{
-		Pending:    []string{"PENDING", helpers.PIInstanceBuilding, helpers.PIInstanceHealthWarning},
-		Target:     []string{helpers.PIInstanceAvailable, helpers.PIInstanceHealthOk, "ERROR", "", "SHUTOFF"},
+		Pending:    []string{State_Pending, State_Build, Warning},
+		Target:     []string{State_Active, OK, State_Error, "", State_Shutoff},
 		Refresh:    isPIInstanceRefreshFunc(client, id, instanceReadyStatus),
-		Delay:      30 * time.Second,
+		Delay:      Timeout_Delay,
 		MinTimeout: queryTimeOut,
-		Timeout:    120 * time.Minute,
+		Timeout:    timeout,
 	}
 
 	return stateConf.WaitForStateContext(ctx)
 }
 
-func isPIInstanceRefreshFunc(client *st.IBMPIInstanceClient, id, instanceReadyStatus string) retry.StateRefreshFunc {
+func isPIInstanceRefreshFunc(client *instance.IBMPIInstanceClient, id, instanceReadyStatus string) retry.StateRefreshFunc {
 	return func() (interface{}, string, error) {
 
 		pvm, err := client.Get(id)
@@ -969,10 +971,10 @@ func isPIInstanceRefreshFunc(client *st.IBMPIInstanceClient, id, instanceReadySt
 			return nil, "", err
 		}
 		// Check for `instanceReadyStatus` health status and also the final health status "OK"
-		if *pvm.Status == helpers.PIInstanceAvailable && (pvm.Health.Status == instanceReadyStatus || pvm.Health.Status == helpers.PIInstanceHealthOk) {
-			return pvm, helpers.PIInstanceAvailable, nil
+		if strings.ToLower(*pvm.Status) == State_Active && (pvm.Health.Status == instanceReadyStatus || pvm.Health.Status == OK) {
+			return pvm, State_Active, nil
 		}
-		if *pvm.Status == "ERROR" {
+		if strings.ToLower(*pvm.Status) == State_Error {
 			if pvm.Fault != nil {
 				err = fmt.Errorf("failed to create the lpar: %s", pvm.Fault.Message)
 			} else {
@@ -981,28 +983,26 @@ func isPIInstanceRefreshFunc(client *st.IBMPIInstanceClient, id, instanceReadySt
 			return pvm, *pvm.Status, err
 		}
 
-		return pvm, helpers.PIInstanceBuilding, nil
+		return pvm, State_Build, nil
 	}
 }
 
-func isWaitForPIInstancePlacementGroupAdd(ctx context.Context, client *st.IBMPIPlacementGroupClient, pgID string, id string) (interface{}, error) {
+func isWaitForPIInstancePlacementGroupAdd(ctx context.Context, client *instance.IBMPIPlacementGroupClient, pgID string, id string, timeout time.Duration) (interface{}, error) {
 	log.Printf("Waiting for PIInstance Placement Group (%s) to be updated ", id)
-
-	queryTimeOut := activeTimeOut
 
 	stateConf := &retry.StateChangeConf{
 		Pending:    []string{State_Adding},
 		Target:     []string{State_Added},
 		Refresh:    isPIInstancePlacementGroupAddRefreshFunc(client, pgID, id),
-		Delay:      30 * time.Second,
-		MinTimeout: queryTimeOut,
-		Timeout:    10 * time.Minute,
+		Delay:      Timeout_Delay,
+		MinTimeout: Timeout_Active,
+		Timeout:    timeout,
 	}
 
 	return stateConf.WaitForStateContext(ctx)
 }
 
-func isPIInstancePlacementGroupAddRefreshFunc(client *st.IBMPIPlacementGroupClient, pgID string, id string) retry.StateRefreshFunc {
+func isPIInstancePlacementGroupAddRefreshFunc(client *instance.IBMPIPlacementGroupClient, pgID string, id string) retry.StateRefreshFunc {
 	return func() (interface{}, string, error) {
 		pg, err := client.Get(pgID)
 		if err != nil {
@@ -1017,24 +1017,24 @@ func isPIInstancePlacementGroupAddRefreshFunc(client *st.IBMPIPlacementGroupClie
 	}
 }
 
-func isWaitForPIInstancePlacementGroupDelete(ctx context.Context, client *st.IBMPIPlacementGroupClient, pgID string, id string) (interface{}, error) {
+func isWaitForPIInstancePlacementGroupDelete(ctx context.Context, client *instance.IBMPIPlacementGroupClient, pgID string, id string, timeout time.Duration) (interface{}, error) {
 	log.Printf("Waiting for PIInstance Placement Group (%s) to be updated ", id)
 
-	queryTimeOut := activeTimeOut
+	queryTimeOut := Timeout_Active
 
 	stateConf := &retry.StateChangeConf{
 		Pending:    []string{State_Deleting},
 		Target:     []string{State_Deleted},
 		Refresh:    isPIInstancePlacementGroupDeleteRefreshFunc(client, pgID, id),
-		Delay:      30 * time.Second,
+		Delay:      Timeout_Delay,
 		MinTimeout: queryTimeOut,
-		Timeout:    10 * time.Minute,
+		Timeout:    timeout,
 	}
 
 	return stateConf.WaitForStateContext(ctx)
 }
 
-func isPIInstancePlacementGroupDeleteRefreshFunc(client *st.IBMPIPlacementGroupClient, pgID string, id string) retry.StateRefreshFunc {
+func isPIInstancePlacementGroupDeleteRefreshFunc(client *instance.IBMPIPlacementGroupClient, pgID string, id string) retry.StateRefreshFunc {
 	return func() (interface{}, string, error) {
 		pg, err := client.Get(pgID)
 		if err != nil {
@@ -1049,24 +1049,24 @@ func isPIInstancePlacementGroupDeleteRefreshFunc(client *st.IBMPIPlacementGroupC
 	}
 }
 
-func isWaitForPIInstanceSoftwareLicenses(ctx context.Context, client *st.IBMPIInstanceClient, id string, softwareLicenses *models.SoftwareLicenses) (interface{}, error) {
+func isWaitForPIInstanceSoftwareLicenses(ctx context.Context, client *instance.IBMPIInstanceClient, id string, softwareLicenses *models.SoftwareLicenses, timeout time.Duration) (interface{}, error) {
 	log.Printf("Waiting for PIInstance Software Licenses (%s) to be updated ", id)
 
-	queryTimeOut := activeTimeOut
+	queryTimeOut := Timeout_Active
 
 	stateConf := &retry.StateChangeConf{
-		Pending:    []string{"notdone"},
-		Target:     []string{"done"},
+		Pending:    []string{State_InProgress},
+		Target:     []string{State_Available},
 		Refresh:    isPIInstanceSoftwareLicensesRefreshFunc(client, id, softwareLicenses),
-		Delay:      90 * time.Second,
+		Delay:      Timeout_Delay,
 		MinTimeout: queryTimeOut,
-		Timeout:    120 * time.Minute,
+		Timeout:    timeout,
 	}
 
 	return stateConf.WaitForStateContext(ctx)
 }
 
-func isPIInstanceSoftwareLicensesRefreshFunc(client *st.IBMPIInstanceClient, id string, softwareLicenses *models.SoftwareLicenses) retry.StateRefreshFunc {
+func isPIInstanceSoftwareLicensesRefreshFunc(client *instance.IBMPIInstanceClient, id string, softwareLicenses *models.SoftwareLicenses) retry.StateRefreshFunc {
 	return func() (interface{}, string, error) {
 
 		pvm, err := client.Get(id)
@@ -1077,13 +1077,13 @@ func isPIInstanceSoftwareLicensesRefreshFunc(client *st.IBMPIInstanceClient, id 
 		// Check that each software license we modified has been updated
 		if softwareLicenses.IbmiCSS != nil {
 			if *softwareLicenses.IbmiCSS != *pvm.SoftwareLicenses.IbmiCSS {
-				return pvm, "notdone", nil
+				return pvm, State_InProgress, nil
 			}
 		}
 
 		if softwareLicenses.IbmiPHA != nil {
 			if *softwareLicenses.IbmiPHA != *pvm.SoftwareLicenses.IbmiPHA {
-				return pvm, "notdone", nil
+				return pvm, State_InProgress, nil
 			}
 		}
 
@@ -1091,48 +1091,48 @@ func isPIInstanceSoftwareLicensesRefreshFunc(client *st.IBMPIInstanceClient, id 
 			// If the update set IBMiRDS to false, don't check IBMiRDSUsers as it will be updated on the terraform side on the read
 			if !*softwareLicenses.IbmiRDS {
 				if *softwareLicenses.IbmiRDS != *pvm.SoftwareLicenses.IbmiRDS {
-					return pvm, "notdone", nil
+					return pvm, State_InProgress, nil
 				}
 			} else if (*softwareLicenses.IbmiRDS != *pvm.SoftwareLicenses.IbmiRDS) || (softwareLicenses.IbmiRDSUsers != pvm.SoftwareLicenses.IbmiRDSUsers) {
-				return pvm, "notdone", nil
+				return pvm, State_InProgress, nil
 			}
 		}
 
-		return pvm, "done", nil
+		return pvm, State_Available, nil
 	}
 }
 
-func isWaitForPIInstanceShutoff(ctx context.Context, client *st.IBMPIInstanceClient, id string, instanceReadyStatus string) (interface{}, error) {
+func isWaitForPIInstanceShutoff(ctx context.Context, client *instance.IBMPIInstanceClient, id string, instanceReadyStatus string, timeout time.Duration) (interface{}, error) {
 	log.Printf("Waiting for PIInstance (%s) to be shutoff and health active ", id)
 
-	queryTimeOut := activeTimeOut
-	if instanceReadyStatus == helpers.PIInstanceHealthWarning {
-		queryTimeOut = warningTimeOut
+	queryTimeOut := Timeout_Active
+	if instanceReadyStatus == Warning {
+		queryTimeOut = Timeout_Warning
 	}
 
 	stateConf := &retry.StateChangeConf{
-		Pending:    []string{Status_Pending, helpers.PIInstanceBuilding, helpers.PIInstanceHealthWarning},
-		Target:     []string{helpers.PIInstanceHealthOk, Status_Error, "", Status_Shutoff},
+		Pending:    []string{State_Pending, State_Build, Warning},
+		Target:     []string{OK, State_Error, "", State_Shutoff},
 		Refresh:    isPIInstanceShutoffRefreshFunc(client, id, instanceReadyStatus),
-		Delay:      30 * time.Second,
+		Delay:      Timeout_Delay,
 		MinTimeout: queryTimeOut,
-		Timeout:    120 * time.Minute,
+		Timeout:    timeout,
 	}
 
 	return stateConf.WaitForStateContext(ctx)
 }
 
-func isPIInstanceShutoffRefreshFunc(client *st.IBMPIInstanceClient, id, instanceReadyStatus string) retry.StateRefreshFunc {
+func isPIInstanceShutoffRefreshFunc(client *instance.IBMPIInstanceClient, id, instanceReadyStatus string) retry.StateRefreshFunc {
 	return func() (interface{}, string, error) {
 
 		pvm, err := client.Get(id)
 		if err != nil {
 			return nil, "", err
 		}
-		if *pvm.Status == Status_Shutoff && (pvm.Health.Status == instanceReadyStatus || pvm.Health.Status == helpers.PIInstanceHealthOk) {
-			return pvm, Status_Shutoff, nil
+		if strings.ToLower(*pvm.Status) == State_Shutoff && (pvm.Health.Status == instanceReadyStatus || pvm.Health.Status == OK) {
+			return pvm, State_Shutoff, nil
 		}
-		if *pvm.Status == Status_Error {
+		if strings.ToLower(*pvm.Status) == State_Error {
 			if pvm.Fault != nil {
 				err = fmt.Errorf("failed to create the lpar: %s", pvm.Fault.Message)
 			} else {
@@ -1141,7 +1141,7 @@ func isPIInstanceShutoffRefreshFunc(client *st.IBMPIInstanceClient, id, instance
 			return pvm, *pvm.Status, err
 		}
 
-		return pvm, helpers.PIInstanceBuilding, nil
+		return pvm, State_Build, nil
 	}
 }
 
@@ -1154,22 +1154,22 @@ func encodeBase64(userData string) string {
 	return userData
 }
 
-func isWaitForPIInstanceStopped(ctx context.Context, client *st.IBMPIInstanceClient, id string) (interface{}, error) {
+func isWaitForPIInstanceStopped(ctx context.Context, client *instance.IBMPIInstanceClient, id string, timeout time.Duration) (interface{}, error) {
 	log.Printf("Waiting for PIInstance (%s) to be stopped and powered off ", id)
 
 	stateConf := &retry.StateChangeConf{
-		Pending:    []string{"STOPPING", "RESIZE", "VERIFY_RESIZE", helpers.PIInstanceHealthWarning},
-		Target:     []string{"OK", "SHUTOFF"},
+		Pending:    []string{State_Stopping, State_Resize, State_VerifyResize, Warning},
+		Target:     []string{OK, State_Shutoff},
 		Refresh:    isPIInstanceRefreshFuncOff(client, id),
-		Delay:      10 * time.Second,
-		MinTimeout: 2 * time.Minute, // This is the time that the client will execute to check the status of the request
-		Timeout:    30 * time.Minute,
+		Delay:      Timeout_Delay,
+		MinTimeout: Timeout_Active, // This is the time that the client will execute to check the status of the request
+		Timeout:    timeout,
 	}
 
 	return stateConf.WaitForStateContext(ctx)
 }
 
-func isPIInstanceRefreshFuncOff(client *st.IBMPIInstanceClient, id string) retry.StateRefreshFunc {
+func isPIInstanceRefreshFuncOff(client *instance.IBMPIInstanceClient, id string) retry.StateRefreshFunc {
 	return func() (interface{}, string, error) {
 
 		log.Printf("Calling the check Refresh status of the pvm instance %s", id)
@@ -1177,45 +1177,45 @@ func isPIInstanceRefreshFuncOff(client *st.IBMPIInstanceClient, id string) retry
 		if err != nil {
 			return nil, "", err
 		}
-		if *pvm.Status == "SHUTOFF" && pvm.Health.Status == helpers.PIInstanceHealthOk {
-			return pvm, "SHUTOFF", nil
+		if strings.ToLower(*pvm.Status) == State_Shutoff && pvm.Health.Status == OK {
+			return pvm, State_Shutoff, nil
 		}
-		return pvm, "STOPPING", nil
+		return pvm, State_Stopping, nil
 	}
 }
 
-func stopLparForResourceChange(ctx context.Context, client *st.IBMPIInstanceClient, id string) error {
+func stopLparForResourceChange(ctx context.Context, client *instance.IBMPIInstanceClient, id string, d *schema.ResourceData) error {
 	body := &models.PVMInstanceAction{
 		//Action: flex.PtrToString("stop"),
-		Action: flex.PtrToString("immediate-shutdown"),
+		Action: flex.PtrToString(Action_ImmediateShutdown),
 	}
 	err := client.Action(id, body)
 	if err != nil {
 		return fmt.Errorf("failed to perform the stop action on the pvm instance %v", err)
 	}
 
-	_, err = isWaitForPIInstanceStopped(ctx, client, id)
+	_, err = isWaitForPIInstanceStopped(ctx, client, id, d.Timeout(schema.TimeoutUpdate))
 
 	return err
 }
 
 // Start the lpar
-func startLparAfterResourceChange(ctx context.Context, client *st.IBMPIInstanceClient, id string) error {
+func startLparAfterResourceChange(ctx context.Context, client *instance.IBMPIInstanceClient, id string, d *schema.ResourceData) error {
 	body := &models.PVMInstanceAction{
-		Action: flex.PtrToString("start"),
+		Action: flex.PtrToString(Action_Start),
 	}
 	err := client.Action(id, body)
 	if err != nil {
 		return fmt.Errorf("failed to perform the start action on the pvm instance %v", err)
 	}
 
-	_, err = isWaitForPIInstanceAvailable(ctx, client, id, "OK")
+	_, err = isWaitForPIInstanceAvailable(ctx, client, id, OK, d.Timeout(schema.TimeoutUpdate))
 
 	return err
 }
 
 // Stop / Modify / Start only when the lpar is off limits
-func performChangeAndReboot(ctx context.Context, client *st.IBMPIInstanceClient, id, cloudInstanceID string, mem, procs float64) error {
+func performChangeAndReboot(ctx context.Context, client *instance.IBMPIInstanceClient, d *schema.ResourceData, id string, mem, procs float64) error {
 	/*
 		These are the steps
 		1. Stop the lpar - Check if the lpar is SHUTOFF
@@ -1226,7 +1226,7 @@ func performChangeAndReboot(ctx context.Context, client *st.IBMPIInstanceClient,
 	//Execute the stop
 
 	log.Printf("Calling the stop lpar for Resource Change code ..")
-	err := stopLparForResourceChange(ctx, client, id)
+	err := stopLparForResourceChange(ctx, client, id, d)
 	if err != nil {
 		return err
 	}
@@ -1241,14 +1241,14 @@ func performChangeAndReboot(ctx context.Context, client *st.IBMPIInstanceClient,
 		return fmt.Errorf("failed to update the lpar with the change, %s", updateErr)
 	}
 
-	_, err = isWaitforPIInstanceUpdate(ctx, client, id)
+	_, err = isWaitforPIInstanceUpdate(ctx, client, id, d.Timeout(schema.TimeoutUpdate))
 	if err != nil {
 		return fmt.Errorf("failed to get an update from the Service after the resource change, %s", err)
 	}
 
 	// Now we can start the lpar
 	log.Printf("Calling the start lpar After the  Resource Change code ..")
-	err = startLparAfterResourceChange(ctx, client, id)
+	err = startLparAfterResourceChange(ctx, client, id, d)
 	if err != nil {
 		return err
 	}
@@ -1257,22 +1257,22 @@ func performChangeAndReboot(ctx context.Context, client *st.IBMPIInstanceClient,
 
 }
 
-func isWaitforPIInstanceUpdate(ctx context.Context, client *st.IBMPIInstanceClient, id string) (interface{}, error) {
+func isWaitforPIInstanceUpdate(ctx context.Context, client *instance.IBMPIInstanceClient, id string, timeout time.Duration) (interface{}, error) {
 	log.Printf("Waiting for PIInstance (%s) to be ACTIVE or SHUTOFF AFTER THE RESIZE Due to DLPAR Operation ", id)
 
 	stateConf := &retry.StateChangeConf{
-		Pending:    []string{"RESIZE", "VERIFY_RESIZE"},
-		Target:     []string{"ACTIVE", "SHUTOFF", helpers.PIInstanceHealthOk},
+		Pending:    []string{State_Resize, State_VerifyResize},
+		Target:     []string{State_Active, State_Shutoff, OK},
 		Refresh:    isPIInstanceShutAfterResourceChange(client, id),
-		Delay:      10 * time.Second,
+		Delay:      Timeout_Delay,
 		MinTimeout: 5 * time.Minute,
-		Timeout:    60 * time.Minute,
+		Timeout:    timeout,
 	}
 
 	return stateConf.WaitForStateContext(ctx)
 }
 
-func isPIInstanceShutAfterResourceChange(client *st.IBMPIInstanceClient, id string) retry.StateRefreshFunc {
+func isPIInstanceShutAfterResourceChange(client *instance.IBMPIInstanceClient, id string) retry.StateRefreshFunc {
 	return func() (interface{}, string, error) {
 
 		pvm, err := client.Get(id)
@@ -1280,12 +1280,12 @@ func isPIInstanceShutAfterResourceChange(client *st.IBMPIInstanceClient, id stri
 			return nil, "", err
 		}
 
-		if *pvm.Status == "SHUTOFF" && pvm.Health.Status == helpers.PIInstanceHealthOk {
+		if strings.ToLower(*pvm.Status) == State_Shutoff && pvm.Health.Status == OK {
 			log.Printf("The lpar is now off after the resource change...")
-			return pvm, "SHUTOFF", nil
+			return pvm, State_Shutoff, nil
 		}
 
-		return pvm, "RESIZE", nil
+		return pvm, State_Resize, nil
 	}
 }
 
@@ -1294,8 +1294,8 @@ func expandPVMNetworks(networks []interface{}) []*models.PVMInstanceAddNetwork {
 	for _, v := range networks {
 		network := v.(map[string]interface{})
 		pvmInstanceNetwork := &models.PVMInstanceAddNetwork{
-			IPAddress: network["ip_address"].(string),
-			NetworkID: flex.PtrToString(network["network_id"].(string)),
+			IPAddress: network[Attr_IPAddress].(string),
+			NetworkID: flex.PtrToString(network[Attr_NetworkID].(string)),
 		}
 		pvmNetworks = append(pvmNetworks, pvmInstanceNetwork)
 	}
@@ -1313,24 +1313,24 @@ func checkCloudInstanceCapability(cloudInstance *models.CloudInstance, custom_ca
 	return false
 }
 
-func createSAPInstance(d *schema.ResourceData, sapClient *st.IBMPISAPInstanceClient) (*models.PVMInstanceList, error) {
+func createSAPInstance(d *schema.ResourceData, sapClient *instance.IBMPISAPInstanceClient) (*models.PVMInstanceList, error) {
 
-	name := d.Get(helpers.PIInstanceName).(string)
-	profileID := d.Get(PISAPInstanceProfileID).(string)
-	imageid := d.Get(helpers.PIInstanceImageId).(string)
+	name := d.Get(Arg_InstanceName).(string)
+	profileID := d.Get(Arg_SAPProfileID).(string)
+	imageid := d.Get(Arg_ImageID).(string)
 
-	pvmNetworks := expandPVMNetworks(d.Get(PIInstanceNetwork).([]interface{}))
+	pvmNetworks := expandPVMNetworks(d.Get(Arg_Network).([]interface{}))
 
 	var replicants int64
-	if r, ok := d.GetOk(helpers.PIInstanceReplicants); ok {
+	if r, ok := d.GetOk(Arg_Replicants); ok {
 		replicants = int64(r.(int))
 	}
 	var replicationpolicy string
-	if r, ok := d.GetOk(helpers.PIInstanceReplicationPolicy); ok {
+	if r, ok := d.GetOk(Arg_ReplicationPolicy); ok {
 		replicationpolicy = r.(string)
 	}
 	var replicationNamingScheme string
-	if r, ok := d.GetOk(helpers.PIInstanceReplicationScheme); ok {
+	if r, ok := d.GetOk(Arg_ReplicationScheme); ok {
 		replicationNamingScheme = r.(string)
 	}
 	instances := &models.PVMInstanceMultiCreate{
@@ -1347,62 +1347,62 @@ func createSAPInstance(d *schema.ResourceData, sapClient *st.IBMPISAPInstanceCli
 		ProfileID: &profileID,
 	}
 
-	if v, ok := d.GetOk(PISAPInstanceDeploymentType); ok {
+	if v, ok := d.GetOk(Arg_SAPDeploymentType); ok {
 		body.DeploymentType = v.(string)
 	}
-	if v, ok := d.GetOk(helpers.PIInstanceVolumeIds); ok {
+	if v, ok := d.GetOk(Arg_VolumeIDs); ok {
 		volids := flex.ExpandStringList((v.(*schema.Set)).List())
 		if len(volids) > 0 {
 			body.VolumeIDs = volids
 		}
 	}
-	if p, ok := d.GetOk(helpers.PIInstancePinPolicy); ok {
+	if p, ok := d.GetOk(Arg_PinPolicy); ok {
 		pinpolicy := p.(string)
-		if d.Get(helpers.PIInstancePinPolicy) == "soft" || d.Get(helpers.PIInstancePinPolicy) == "hard" {
+		if d.Get(Arg_PinPolicy) == Soft || d.Get(Arg_PinPolicy) == Hard {
 			body.PinPolicy = models.PinPolicy(pinpolicy)
 		}
 	}
 
-	if v, ok := d.GetOk(helpers.PIInstanceSSHKeyName); ok {
+	if v, ok := d.GetOk(Arg_KeyPairName); ok {
 		sshkey := v.(string)
 		body.SSHKeyName = sshkey
 	}
-	if u, ok := d.GetOk(helpers.PIInstanceUserData); ok {
+	if u, ok := d.GetOk(Arg_UserData); ok {
 		userData := u.(string)
 		body.UserData = encodeBase64(userData)
 	}
-	if sys, ok := d.GetOk(helpers.PIInstanceSystemType); ok {
+	if sys, ok := d.GetOk(Arg_SysType); ok {
 		body.SysType = sys.(string)
 	}
 
-	if st, ok := d.GetOk(helpers.PIInstanceStorageType); ok {
+	if st, ok := d.GetOk(Arg_StorageType); ok {
 		body.StorageType = st.(string)
 	}
-	if sp, ok := d.GetOk(PIInstanceStoragePool); ok {
+	if sp, ok := d.GetOk(Arg_StoragePool); ok {
 		body.StoragePool = sp.(string)
 	}
 
-	if ap, ok := d.GetOk(PIAffinityPolicy); ok {
+	if ap, ok := d.GetOk(Arg_AffinityPolicy); ok {
 		policy := ap.(string)
 		affinity := &models.StorageAffinity{
 			AffinityPolicy: &policy,
 		}
 
-		if policy == "affinity" {
-			if av, ok := d.GetOk(PIAffinityVolume); ok {
+		if policy == Affinity {
+			if av, ok := d.GetOk(Arg_AffinityVolume); ok {
 				afvol := av.(string)
 				affinity.AffinityVolume = &afvol
 			}
-			if ai, ok := d.GetOk(PIAffinityInstance); ok {
+			if ai, ok := d.GetOk(Arg_AffinityInstance); ok {
 				afins := ai.(string)
 				affinity.AffinityPVMInstance = &afins
 			}
 		} else {
-			if avs, ok := d.GetOk(PIAntiAffinityVolumes); ok {
+			if avs, ok := d.GetOk(Arg_AntiAffinityVolumes); ok {
 				afvols := flex.ExpandStringList(avs.([]interface{}))
 				affinity.AntiAffinityVolumes = afvols
 			}
-			if ais, ok := d.GetOk(PIAntiAffinityInstances); ok {
+			if ais, ok := d.GetOk(Arg_AntiAffinityInstances); ok {
 				afinss := flex.ExpandStringList(ais.([]interface{}))
 				affinity.AntiAffinityPVMInstances = afinss
 			}
@@ -1410,7 +1410,7 @@ func createSAPInstance(d *schema.ResourceData, sapClient *st.IBMPISAPInstanceCli
 		body.StorageAffinity = affinity
 	}
 
-	if pg, ok := d.GetOk(helpers.PIPlacementGroupID); ok {
+	if pg, ok := d.GetOk(Arg_PlacementGroupID); ok {
 		body.PlacementGroup = pg.(string)
 	}
 	if deploymentTarget, ok := d.GetOk(Arg_DeploymentTarget); ok {
@@ -1427,62 +1427,62 @@ func createSAPInstance(d *schema.ResourceData, sapClient *st.IBMPISAPInstanceCli
 	return pvmList, nil
 }
 
-func createPVMInstance(d *schema.ResourceData, client *st.IBMPIInstanceClient, imageClient *st.IBMPIImageClient) (*models.PVMInstanceList, error) {
+func createPVMInstance(d *schema.ResourceData, client *instance.IBMPIInstanceClient, imageClient *instance.IBMPIImageClient) (*models.PVMInstanceList, error) {
 
-	name := d.Get(helpers.PIInstanceName).(string)
-	imageid := d.Get(helpers.PIInstanceImageId).(string)
+	name := d.Get(Arg_InstanceName).(string)
+	imageid := d.Get(Arg_ImageID).(string)
 
 	var mem, procs float64
 	var systype, processortype string
-	if v, ok := d.GetOk(helpers.PIInstanceMemory); ok {
+	if v, ok := d.GetOk(Arg_Memory); ok {
 		mem = v.(float64)
 	} else {
-		return nil, fmt.Errorf("%s is required for creating pvm instances", helpers.PIInstanceMemory)
+		return nil, fmt.Errorf("%s is required for creating pvm instances", Arg_Memory)
 	}
-	if v, ok := d.GetOk(helpers.PIInstanceProcessors); ok {
+	if v, ok := d.GetOk(Arg_Processors); ok {
 		procs = v.(float64)
 	} else {
-		return nil, fmt.Errorf("%s is required for creating pvm instances", helpers.PIInstanceProcessors)
+		return nil, fmt.Errorf("%s is required for creating pvm instances", Arg_Processors)
 	}
-	if v, ok := d.GetOk(helpers.PIInstanceSystemType); ok {
+	if v, ok := d.GetOk(Arg_SysType); ok {
 		systype = v.(string)
 	} else {
-		return nil, fmt.Errorf("%s is required for creating pvm instances", helpers.PIInstanceSystemType)
+		return nil, fmt.Errorf("%s is required for creating pvm instances", Arg_SysType)
 	}
-	if v, ok := d.GetOk(helpers.PIInstanceProcType); ok {
+	if v, ok := d.GetOk(Arg_ProcType); ok {
 		processortype = v.(string)
 	} else {
-		return nil, fmt.Errorf("%s is required for creating pvm instances", helpers.PIInstanceProcType)
+		return nil, fmt.Errorf("%s is required for creating pvm instances", Arg_ProcType)
 	}
 
-	pvmNetworks := expandPVMNetworks(d.Get(PIInstanceNetwork).([]interface{}))
+	pvmNetworks := expandPVMNetworks(d.Get(Arg_Network).([]interface{}))
 
 	var volids []string
-	if v, ok := d.GetOk(helpers.PIInstanceVolumeIds); ok {
+	if v, ok := d.GetOk(Arg_VolumeIDs); ok {
 		volids = flex.ExpandStringList((v.(*schema.Set)).List())
 	}
 	var replicants float64
-	if r, ok := d.GetOk(helpers.PIInstanceReplicants); ok {
+	if r, ok := d.GetOk(Arg_Replicants); ok {
 		replicants = float64(r.(int))
 	}
 	var replicationpolicy string
-	if r, ok := d.GetOk(helpers.PIInstanceReplicationPolicy); ok {
+	if r, ok := d.GetOk(Arg_ReplicationPolicy); ok {
 		replicationpolicy = r.(string)
 	}
 	var replicationNamingScheme string
-	if r, ok := d.GetOk(helpers.PIInstanceReplicationScheme); ok {
+	if r, ok := d.GetOk(Arg_ReplicationScheme); ok {
 		replicationNamingScheme = r.(string)
 	}
 	var pinpolicy string
-	if p, ok := d.GetOk(helpers.PIInstancePinPolicy); ok {
+	if p, ok := d.GetOk(Arg_PinPolicy); ok {
 		pinpolicy = p.(string)
 		if pinpolicy == "" {
-			pinpolicy = "none"
+			pinpolicy = None
 		}
 	}
 
 	var userData string
-	if u, ok := d.GetOk(helpers.PIInstanceUserData); ok {
+	if u, ok := d.GetOk(Arg_UserData); ok {
 		userData = u.(string)
 	}
 
@@ -1499,55 +1499,55 @@ func createPVMInstance(d *schema.ResourceData, client *st.IBMPIInstanceClient, i
 		ReplicantAffinityPolicy: flex.PtrToString(replicationpolicy),
 		Networks:                pvmNetworks,
 	}
-	if s, ok := d.GetOk(helpers.PIInstanceSSHKeyName); ok {
+	if s, ok := d.GetOk(Arg_KeyPairName); ok {
 		sshkey := s.(string)
 		body.KeyPairName = sshkey
 	}
 	if len(volids) > 0 {
 		body.VolumeIDs = volids
 	}
-	if d.Get(helpers.PIInstancePinPolicy) == "soft" || d.Get(helpers.PIInstancePinPolicy) == "hard" {
+	if d.Get(Arg_PinPolicy) == Soft || d.Get(Arg_PinPolicy) == Hard {
 		body.PinPolicy = models.PinPolicy(pinpolicy)
 	}
 
 	var assignedVirtualCores int64
-	if a, ok := d.GetOk(helpers.PIVirtualCoresAssigned); ok {
+	if a, ok := d.GetOk(Arg_VirtualCoresAssigned); ok {
 		assignedVirtualCores = int64(a.(int))
 		body.VirtualCores = &models.VirtualCores{Assigned: &assignedVirtualCores}
 	}
 
-	if st, ok := d.GetOk(helpers.PIInstanceStorageType); ok {
+	if st, ok := d.GetOk(Arg_StorageType); ok {
 		body.StorageType = st.(string)
 	}
-	if sp, ok := d.GetOk(PIInstanceStoragePool); ok {
+	if sp, ok := d.GetOk(Arg_StoragePool); ok {
 		body.StoragePool = sp.(string)
 	}
 
-	if dt, ok := d.GetOk(PIInstanceDeploymentType); ok {
+	if dt, ok := d.GetOk(Arg_DeploymentType); ok {
 		body.DeploymentType = dt.(string)
 	}
 
-	if ap, ok := d.GetOk(PIAffinityPolicy); ok {
+	if ap, ok := d.GetOk(Arg_AffinityPolicy); ok {
 		policy := ap.(string)
 		affinity := &models.StorageAffinity{
 			AffinityPolicy: &policy,
 		}
 
-		if policy == "affinity" {
-			if av, ok := d.GetOk(PIAffinityVolume); ok {
+		if policy == Affinity {
+			if av, ok := d.GetOk(Arg_AffinityVolume); ok {
 				afvol := av.(string)
 				affinity.AffinityVolume = &afvol
 			}
-			if ai, ok := d.GetOk(PIAffinityInstance); ok {
+			if ai, ok := d.GetOk(Arg_AffinityInstance); ok {
 				afins := ai.(string)
 				affinity.AffinityPVMInstance = &afins
 			}
 		} else {
-			if avs, ok := d.GetOk(PIAntiAffinityVolumes); ok {
+			if avs, ok := d.GetOk(Arg_AntiAffinityVolumes); ok {
 				afvols := flex.ExpandStringList(avs.([]interface{}))
 				affinity.AntiAffinityVolumes = afvols
 			}
-			if ais, ok := d.GetOk(PIAntiAffinityInstances); ok {
+			if ais, ok := d.GetOk(Arg_AntiAffinityInstances); ok {
 				afinss := flex.ExpandStringList(ais.([]interface{}))
 				affinity.AntiAffinityPVMInstances = afinss
 			}
@@ -1555,15 +1555,15 @@ func createPVMInstance(d *schema.ResourceData, client *st.IBMPIInstanceClient, i
 		body.StorageAffinity = affinity
 	}
 
-	if sc, ok := d.GetOk(helpers.PIInstanceStorageConnection); ok {
+	if sc, ok := d.GetOk(Arg_StorageConnection); ok {
 		body.StorageConnection = sc.(string)
 	}
 
-	if pg, ok := d.GetOk(helpers.PIPlacementGroupID); ok {
+	if pg, ok := d.GetOk(Arg_PlacementGroupID); ok {
 		body.PlacementGroup = pg.(string)
 	}
 
-	if spp, ok := d.GetOk(Arg_PIInstanceSharedProcessorPool); ok {
+	if spp, ok := d.GetOk(Arg_SharedProcessorPool); ok {
 		body.SharedProcessorPool = spp.(string)
 	}
 	imageData, err := imageClient.GetStockImage(imageid)
@@ -1574,9 +1574,9 @@ func createPVMInstance(d *schema.ResourceData, client *st.IBMPIInstanceClient, i
 			return nil, fmt.Errorf("image doesn't exist. %e", err)
 		}
 	}
-	if lrc, ok := d.GetOk(helpers.PIInstanceLicenseRepositoryCapacity); ok {
+	if lrc, ok := d.GetOk(Arg_LicenseRepositoryCapacity); ok {
 
-		if imageData.Specifications.ImageType == "stock-vtl" {
+		if imageData.Specifications.ImageType == StockVTL {
 			body.LicenseRepositoryCapacity = int64(lrc.(int))
 		} else {
 			return nil, fmt.Errorf("pi_license_repository_capacity should only be used when creating VTL instances. %e", err)

--- a/ibm/service/power/resource_ibm_pi_instance_test.go
+++ b/ibm/service/power/resource_ibm_pi_instance_test.go
@@ -7,19 +7,20 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
 	"testing"
 	"time"
 
 	acc "github.com/IBM-Cloud/terraform-provider-ibm/ibm/acctest"
 	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/conns"
 	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/flex"
+	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/power"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 
 	st "github.com/IBM-Cloud/power-go-client/clients/instance"
-	"github.com/IBM-Cloud/power-go-client/helpers"
 )
 
 func testAccCheckIBMPIInstanceConfig(name, instanceHealthStatus string) string {
@@ -30,33 +31,33 @@ func testAccCheckIBMPIInstanceConfig(name, instanceHealthStatus string) string {
 		pi_ssh_key           = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCKVmnMOlHKcZK8tpt3MP1lqOLAcqcJzhsvJcjscgVERRN7/9484SOBJ3HSKxxNG5JN8owAjy5f9yYwcUg+JaUVuytn5Pv3aeYROHGGg+5G346xaq3DAwX6Y5ykr2fvjObgncQBnuU5KHWCECO/4h8uWuwh/kfniXPVjFToc+gnkqA+3RKpAecZhFXwfalQ9mMuYGFxn+fwn8cYEApsJbsEmb0iJwPiZ5hjFC8wREuiTlhPHDgkBLOiycd20op2nXzDbHfCHInquEe/gYxEitALONxm0swBOwJZwlTDOB7C6y2dzlrtxr1L59m7pCkWI4EtTRLvleehBoj3u7jB4usR"
 	  }
 	  data "ibm_pi_image" "power_image" {
-		pi_image_name        = "%[3]s"
 		pi_cloud_instance_id = "%[1]s"
+		pi_image_name        = "%[3]s"
 	  }
 	  data "ibm_pi_network" "power_networks" {
 		pi_cloud_instance_id = "%[1]s"
 		pi_network_name      = "%[4]s"
 	  }
 	  resource "ibm_pi_volume" "power_volume" {
-		pi_volume_size       = 20
-		pi_volume_name       = "%[2]s"
-		pi_volume_shareable  = true
-		pi_volume_pool       = data.ibm_pi_image.power_image.storage_pool
-		pi_volume_type       = "%[6]s"
 		pi_cloud_instance_id = "%[1]s"
+		pi_volume_name       = "%[2]s"
+		pi_volume_pool       = data.ibm_pi_image.power_image.storage_pool
+		pi_volume_shareable  = true
+		pi_volume_size       = 20
+		pi_volume_type       = "%[6]s"
 	  }
 	  resource "ibm_pi_instance" "power_instance" {
-		pi_memory             = "2"
-		pi_processors         = "0.25"
-		pi_instance_name      = "%[2]s"
-		pi_proc_type          = "shared"
-		pi_image_id           = data.ibm_pi_image.power_image.id
-		pi_key_pair_name      = ibm_pi_key.key.name
-		pi_sys_type           = "s922"
 		pi_cloud_instance_id  = "%[1]s"
+		pi_health_status      = "%[5]s"
+		pi_image_id           = data.ibm_pi_image.power_image.id
+		pi_instance_name      = "%[2]s"
+		pi_key_pair_name      = ibm_pi_key.key.name
+		pi_memory             = "2"
+		pi_proc_type          = "shared"
+		pi_processors         = "0.25"
 		pi_storage_pool       = data.ibm_pi_image.power_image.storage_pool
 		pi_storage_type       = "%[6]s"
-		pi_health_status      = "%[5]s"
+		pi_sys_type           = "s922"
 		pi_volume_ids         = [ibm_pi_volume.power_volume.volume_id]
 		pi_network {
 			network_id = data.ibm_pi_network.power_networks.id
@@ -73,28 +74,29 @@ func testAccCheckIBMPIInstanceDeploymentTypeConfig(name, instanceHealthStatus, e
 		pi_ssh_key           = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCKVmnMOlHKcZK8tpt3MP1lqOLAcqcJzhsvJcjscgVERRN7/9484SOBJ3HSKxxNG5JN8owAjy5f9yYwcUg+JaUVuytn5Pv3aeYROHGGg+5G346xaq3DAwX6Y5ykr2fvjObgncQBnuU5KHWCECO/4h8uWuwh/kfniXPVjFToc+gnkqA+3RKpAecZhFXwfalQ9mMuYGFxn+fwn8cYEApsJbsEmb0iJwPiZ5hjFC8wREuiTlhPHDgkBLOiycd20op2nXzDbHfCHInquEe/gYxEitALONxm0swBOwJZwlTDOB7C6y2dzlrtxr1L59m7pCkWI4EtTRLvleehBoj3u7jB4usR"
 	  }
 	  data "ibm_pi_image" "power_image" {
-		pi_image_name        = "%[3]s"
 		pi_cloud_instance_id = "%[1]s"
+		pi_image_name        = "%[3]s"
 	  }
 	  data "ibm_pi_network" "power_networks" {
 		pi_cloud_instance_id = "%[1]s"
 		pi_network_name      = "%[4]s"
 	  }
 	  resource "ibm_pi_instance" "power_instance" {
-		pi_memory             = "2"
-		pi_processors         = "1"
-		pi_instance_name      = "%[2]s"
-		pi_proc_type          = "dedicated"
-		pi_image_id           = data.ibm_pi_image.power_image.id
-		pi_key_pair_name      = ibm_pi_key.key.name
-		pi_sys_type           = "%[7]s"
 		pi_cloud_instance_id  = "%[1]s"
-		pi_storage_type 	  = "%[8]s"
+		pi_deployment_type          = "%[6]s"
 		pi_health_status      = "%[5]s"
+		pi_image_id           = data.ibm_pi_image.power_image.id
+		pi_instance_name      = "%[2]s"
+		pi_key_pair_name      = ibm_pi_key.key.name
+		pi_memory             = "2"
+		pi_proc_type          = "dedicated"
+		pi_processors         = "1"
+		pi_storage_type 	  = "%[8]s"
+		pi_sys_type           = "%[7]s"
 		pi_network {
 			network_id = data.ibm_pi_network.power_networks.id
 		}
-		pi_deployment_type          = "%[6]s"
+		
 	  }
 	`, acc.Pi_cloud_instance_id, name, acc.Pi_image, acc.Pi_network_name, instanceHealthStatus, epic, systype, acc.PiStorageType)
 }
@@ -111,26 +113,27 @@ func testAccCheckIBMPIInstanceIBMiLicense(name, instanceHealthStatus string, IBM
 		  }
 		  resource "ibm_pi_volume" "power_volume" {
 			pi_cloud_instance_id = "%[1]s"
-			pi_volume_size       = 1
 			pi_volume_name       = "%[2]s"
+			pi_volume_size       = 1
 			pi_volume_type        = "tier3"
 		  }
 		  resource "ibm_pi_instance" "power_instance" {
-			pi_memory             = "2"
-			pi_processors         = "0.25"
-			pi_instance_name      = "%[2]s"
-			pi_proc_type          = "shared"
-			pi_image_id           = data.ibm_pi_image.power_image.id
-			pi_sys_type           = "s922"
 			pi_cloud_instance_id  = "%[1]s"
-			pi_storage_pool       = data.ibm_pi_image.power_image.storage_pool
 			pi_health_status      = "%[5]s"
+			pi_ibmi_css 		  = %[6]t
+			pi_ibmi_rds_users 	  = %[7]d
+			pi_image_id           = data.ibm_pi_image.power_image.id
+			pi_instance_name      = "%[2]s"
+			pi_memory             = "2"
+			pi_proc_type          = "shared"
+			pi_processors         = "0.25"
+			pi_storage_pool       = data.ibm_pi_image.power_image.storage_pool
+			pi_sys_type           = "s922"
 			pi_volume_ids         = [ibm_pi_volume.power_volume.volume_id]
 			pi_network {
 				network_id = data.ibm_pi_network.power_networks.id
 			}
-			pi_ibmi_css 		  = %[6]t
-			pi_ibmi_rds_users 	  = %[7]d
+			
 		  }`, acc.Pi_cloud_instance_id, name, acc.Pi_image, acc.Pi_network_name, instanceHealthStatus, IBMiCSS, IBMiRDSUsers)
 }
 
@@ -142,27 +145,27 @@ func testAccIBMPIInstanceNetworkConfig(name, privateNetIP string) string {
 		pi_ssh_key           = "ssh-rsa AAAAB3NzaC1yc2EAAAABJQAAAQEArb2aK0mekAdbYdY9rwcmeNSxqVCwez3WZTYEq+1Nwju0x5/vQFPSD2Kp9LpKBbxx3OVLN4VffgGUJznz9DAr7veLkWaf3iwEil6U4rdrhBo32TuDtoBwiczkZ9gn1uJzfIaCJAJdnO80Kv9k0smbQFq5CSb9H+F5VGyFue/iVd5/b30MLYFAz6Jg1GGWgw8yzA4Gq+nO7HtyuA2FnvXdNA3yK/NmrTiPCdJAtEPZkGu9LcelkQ8y90ArlKfjtfzGzYDE4WhOufFxyWxciUePh425J2eZvElnXSdGha+FCfYjQcvqpCVoBAG70U4fJBGjB+HL/GpCXLyiYXPrSnzC9w=="
 	}
 	resource "ibm_pi_network" "power_networks" {
+		pi_cidr              = "192.168.17.0/24"
 		pi_cloud_instance_id = "%[1]s"
-		pi_network_name      = "%[2]s"
-		pi_network_type      = "vlan"
 		pi_dns               = ["127.0.0.1"]
 		pi_gateway           = "192.168.17.2"
-		pi_cidr              = "192.168.17.0/24"
+		pi_network_name      = "%[2]s"
+		pi_network_type      = "vlan"
 		pi_ipaddress_range {
 			pi_ending_ip_address = "192.168.17.254"
 			pi_starting_ip_address = "192.168.17.3"
 		}
 	}
 	resource "ibm_pi_instance" "power_instance" {
-		pi_memory             = "2"
-		pi_processors         = "0.25"
-		pi_instance_name      = "%[2]s"
-		pi_proc_type          = "shared"
-		pi_image_id           = "%[4]s"
-		pi_key_pair_name      = ibm_pi_key.key.name
-		pi_sys_type           = "e980"
-		pi_storage_type 	  = "tier3"
 		pi_cloud_instance_id  = "%[1]s"
+		pi_image_id           = "%[4]s"
+		pi_instance_name      = "%[2]s"
+		pi_key_pair_name      = ibm_pi_key.key.name
+		pi_memory             = "2"
+		pi_proc_type          = "shared"
+		pi_processors         = "0.25"
+		pi_storage_type 	  = "tier3"
+		pi_sys_type           = "s922"
 		pi_network {
 			network_id = resource.ibm_pi_network.power_networks.network_id
 			ip_address = "%[3]s"
@@ -186,16 +189,16 @@ func testAccIBMPIInstanceVTLConfig(name string) string {
 	}
 
 	resource "ibm_pi_instance" "vtl_instance" {
-		pi_memory             = "22"
-		pi_processors         = "2"
-		pi_instance_name      = "%[2]s"
-		pi_license_repository_capacity = "3"
-		pi_proc_type          = "shared"
-		pi_image_id           = "%[3]s"
-		pi_key_pair_name      = ibm_pi_key.vtl_key.name
-		pi_sys_type           = "s922"
 		pi_cloud_instance_id  = "%[1]s"
+		pi_image_id           = "%[3]s"
+		pi_instance_name      = "%[2]s"
+		pi_key_pair_name      = ibm_pi_key.vtl_key.name
+		pi_license_repository_capacity = "3"
+		pi_memory             = "22"
+		pi_proc_type          = "shared"
+		pi_processors         = "2"
 		pi_storage_type 	  = "tier1"
+		pi_sys_type           = "s922"
 		pi_network {
 			network_id = ibm_pi_network.vtl_network.network_id
 		}
@@ -206,23 +209,30 @@ func testAccIBMPIInstanceVTLConfig(name string) string {
 
 func testAccCheckIBMPIInstanceReplicantConfig(name string) string {
 	return fmt.Sprintf(`
+	resource "ibm_pi_volume" "power_volume" {
+		pi_cloud_instance_id = "%[1]s"
+		pi_volume_name       = "%[2]s"
+		pi_volume_shareable  = true
+		pi_volume_size       = 1
+		pi_volume_type        = "tier3"
+	  }
 	resource "ibm_pi_instance" "power_instance" {
 		pi_cloud_instance_id = "%[1]s"
-		pi_memory            = "2"
-		pi_processors        = "1"
-		pi_instance_name     = "%[2]s"
-		pi_proc_type         = "shared"
 		pi_image_id          = "%[3]s"
-		pi_sys_type          = "s922"
-		pi_volume_ids        = ["%[5]s"]
-		pi_network {
-		  network_id = "%[4]s"
-		}
+		pi_instance_name     = "%[2]s"
+		pi_memory            = "2"
+		pi_proc_type         = "shared"
+		pi_processors        = "1"
 		pi_replicants         = 3
 		pi_replication_policy = "affinity"
 		pi_replication_scheme = "suffix"
+		pi_sys_type          = "s922"
+		pi_volume_ids        = [resource.ibm_pi_volume.power_volume.volume_id]
+		pi_network {
+			network_id = "%[4]s"
+		  }
 	  }
-	`, acc.Pi_cloud_instance_id, name, acc.Pi_image, acc.Pi_network_name, acc.Pi_volume_name)
+	`, acc.Pi_cloud_instance_id, name, acc.Pi_image, acc.Pi_network_name)
 }
 
 func testAccCheckIBMPIInstanceDeplomentTargetConfig(name string) string {
@@ -317,7 +327,7 @@ func TestAccIBMPIInstanceBasic(t *testing.T) {
 		CheckDestroy: testAccCheckIBMPIInstanceDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckIBMPIInstanceConfig(name, helpers.PIInstanceHealthWarning),
+				Config: testAccCheckIBMPIInstanceConfig(name, power.Warning),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckIBMPIInstanceExists(instanceRes),
 					resource.TestCheckResourceAttr(instanceRes, "pi_instance_name", name),
@@ -353,7 +363,7 @@ func TestAccIBMPIInstanceDeploymentType(t *testing.T) {
 		CheckDestroy: testAccCheckIBMPIInstanceDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckIBMPIInstanceDeploymentTypeConfig(name, helpers.PIInstanceHealthOk, "EPIC", "e980"),
+				Config: testAccCheckIBMPIInstanceDeploymentTypeConfig(name, power.OK, "EPIC", "e980"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckIBMPIInstanceExists(instanceRes),
 					resource.TestCheckResourceAttr(instanceRes, "pi_instance_name", name),
@@ -372,24 +382,24 @@ func TestAccIBMPIInstanceIBMiLicense(t *testing.T) {
 		CheckDestroy: testAccCheckIBMPIInstanceDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckIBMPIInstanceIBMiLicense(name, helpers.PIInstanceHealthOk, true, 2),
+				Config: testAccCheckIBMPIInstanceIBMiLicense(name, power.OK, true, 2),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckIBMPIInstanceExists(instanceRes),
 					resource.TestCheckResourceAttr(instanceRes, "pi_instance_name", name),
-					resource.TestCheckResourceAttr(instanceRes, "status", "ACTIVE"),
+					resource.TestCheckResourceAttr(instanceRes, "status", strings.ToUpper(power.State_Active)),
 					resource.TestCheckResourceAttr(instanceRes, "pi_ibmi_css", "true"),
-					resource.TestCheckResourceAttr(instanceRes, "pi_ibmi_rds", "true"),
+					resource.TestCheckResourceAttr(instanceRes, "ibmi_rds", "true"),
 					resource.TestCheckResourceAttr(instanceRes, "pi_ibmi_rds_users", "2"),
 				),
 			},
 			{
-				Config: testAccCheckIBMPIInstanceIBMiLicense(name, helpers.PIInstanceHealthOk, false, 0),
+				Config: testAccCheckIBMPIInstanceIBMiLicense(name, power.OK, false, 0),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckIBMPIInstanceExists(instanceRes),
-					testAccCheckIBMPIInstanceStatus(instanceRes, "ACTIVE"),
+					testAccCheckIBMPIInstanceStatus(instanceRes, strings.ToUpper(power.State_Active)),
 					resource.TestCheckResourceAttr(instanceRes, "pi_instance_name", name),
 					resource.TestCheckResourceAttr(instanceRes, "pi_ibmi_css", "false"),
-					resource.TestCheckResourceAttr(instanceRes, "pi_ibmi_rds", "false"),
+					resource.TestCheckResourceAttr(instanceRes, "ibmi_rds", "false"),
 					resource.TestCheckResourceAttr(instanceRes, "pi_ibmi_rds_users", "0"),
 				),
 			},
@@ -410,7 +420,7 @@ func TestAccIBMPIInstanceReplicant(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckIBMPIInstanceExists(instanceRes),
 					resource.TestCheckResourceAttr(instanceRes, "pi_replicants", "3"),
-					resource.TestCheckResourceAttr(instanceRes, "pi_replication_policy", "affinity"),
+					resource.TestCheckResourceAttr(instanceRes, "pi_replication_policy", power.Affinity),
 					resource.TestCheckResourceAttr(instanceRes, "pi_replication_scheme", "suffix"),
 				),
 				ExpectNonEmptyPlan: true,
@@ -491,23 +501,32 @@ func TestAccIBMPISAPInstance(t *testing.T) {
 		},
 	})
 }
+
 func testAccIBMPISAPInstanceConfig(name, sapProfile string) string {
 	return fmt.Sprintf(`
+
 	resource "ibm_pi_network" "power_network" {
-		pi_cloud_instance_id	= "%[1]s"
-		pi_network_name			= "%[2]s"
-		pi_network_type			= "pub-vlan"
+		pi_cidr              = "192.168.17.0/24"
+		pi_cloud_instance_id = "%[1]s"
+		pi_dns               = ["127.0.0.1"]
+		pi_gateway           = "192.168.17.2"
+		pi_network_name      = "%[2]s"
+		pi_network_type      = "vlan"
+		pi_ipaddress_range {
+			pi_ending_ip_address = "192.168.17.254"
+			pi_starting_ip_address = "192.168.17.3"
+		}
 	}
 	resource "ibm_pi_instance" "sap" {
 		pi_cloud_instance_id  	= "%[1]s"
+		pi_health_status		= "OK"
+		pi_image_id           	= "%[4]s"
 		pi_instance_name      	= "%[2]s"
 		pi_sap_profile_id       = "%[3]s"
-		pi_image_id           	= "%[4]s"
 		pi_storage_type			= "tier1"
 		pi_network {
-			network_id = ibm_pi_network.power_network.network_id
-		}
-		pi_health_status		= "OK"
+			network_id = resource.ibm_pi_network.power_network.network_id
+		}	
 	}
 	`, acc.Pi_cloud_instance_id, name, sapProfile, acc.Pi_sap_image)
 }
@@ -521,7 +540,7 @@ func TestAccIBMPIInstanceMixedStorage(t *testing.T) {
 		CheckDestroy: testAccCheckIBMPIInstanceDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccIBMPIInstanceMixedStorage(name),
+				Config: testAccIBMPIInstanceMixedStorage(name, power.Warning),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckIBMPIInstanceExists(instanceRes),
 					resource.TestCheckResourceAttr(instanceRes, "pi_instance_name", name),
@@ -532,7 +551,7 @@ func TestAccIBMPIInstanceMixedStorage(t *testing.T) {
 	})
 }
 
-func testAccIBMPIInstanceMixedStorage(name string) string {
+func testAccIBMPIInstanceMixedStorage(name, healthStatus string) string {
 	return fmt.Sprintf(`
 	resource "ibm_pi_key" "key" {
 		pi_cloud_instance_id = "%[1]s"
@@ -542,36 +561,37 @@ func testAccIBMPIInstanceMixedStorage(name string) string {
 	resource "ibm_pi_network" "power_network" {
 		pi_cloud_instance_id = "%[1]s"
 		pi_network_name      = "%[2]s"
-		pi_network_type      = "pub-vlan"
+		pi_network_type      = "vlan"
+		pi_cidr              = "192.168.17.0/24"
 	}
 	resource "ibm_pi_volume" "power_volume" {
 		pi_cloud_instance_id = "%[1]s"
-		pi_volume_size       = 20
 		pi_volume_name       = "%[2]s"
 		pi_volume_shareable  = true
+		pi_volume_size       = 20
 		pi_volume_type       = "tier3"
 	}
 	resource "ibm_pi_instance" "instance" {
 		pi_cloud_instance_id     = "%[1]s"
-		pi_memory                = "2"
-		pi_processors            = "0.25"
+		pi_image_id              = "%[3]s"
 		pi_instance_name         = "%[2]s"
-		pi_proc_type             = "shared"
-		pi_image_id              = "ca4ea55f-b329-4cf5-bdce-d2f38cfc6da3"
 		pi_key_pair_name         = ibm_pi_key.key.name
-		pi_sys_type              = "s922"
-		pi_storage_type          = "tier1"
+		pi_memory                = "2"
+		pi_proc_type             = "shared"
+		pi_processors            = "0.25"
 		pi_storage_pool_affinity = false
+		pi_storage_type          = "tier1"
+		pi_sys_type              = "s922"
 		pi_network {
 			network_id = ibm_pi_network.power_network.network_id
 		}
 	}
 	resource "ibm_pi_volume_attach" "power_attach_volume"{
 		pi_cloud_instance_id = "%[1]s"
-		pi_volume_id         = ibm_pi_volume.power_volume.volume_id
 		pi_instance_id       = ibm_pi_instance.instance.instance_id
+		pi_volume_id         = ibm_pi_volume.power_volume.volume_id
 	}
-	`, acc.Pi_cloud_instance_id, name)
+	`, acc.Pi_cloud_instance_id, name, acc.Pi_image)
 }
 
 func TestAccIBMPIInstanceUpdateActiveState(t *testing.T) {
@@ -583,17 +603,17 @@ func TestAccIBMPIInstanceUpdateActiveState(t *testing.T) {
 		CheckDestroy: testAccCheckIBMPIInstanceDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckIBMPIActiveInstanceConfigUpdate(name, helpers.PIInstanceHealthOk, "0.25", "2"),
+				Config: testAccCheckIBMPIActiveInstanceConfigUpdate(name, power.OK, "0.25", "2"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckIBMPIInstanceExists(instanceRes),
 					resource.TestCheckResourceAttr(instanceRes, "pi_instance_name", name),
-					resource.TestCheckResourceAttr(instanceRes, "status", "ACTIVE"),
+					resource.TestCheckResourceAttr(instanceRes, "status", strings.ToUpper(power.State_Active)),
 				),
 			},
 			{
-				Config: testAccCheckIBMPIActiveInstanceConfigUpdate(name, helpers.PIInstanceHealthOk, "0.5", "4"),
+				Config: testAccCheckIBMPIActiveInstanceConfigUpdate(name, power.OK, "0.5", "4"),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckIBMPIInstanceStatus(instanceRes, "ACTIVE"),
+					testAccCheckIBMPIInstanceStatus(instanceRes, strings.ToUpper(power.State_Active)),
 					testAccCheckIBMPIInstanceExists(instanceRes),
 					resource.TestCheckResourceAttr(instanceRes, "pi_instance_name", name),
 				),
@@ -612,16 +632,16 @@ func TestAccIBMPIInstanceUpdateStoppedState(t *testing.T) {
 		CheckDestroy: testAccCheckIBMPIInstanceDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckIBMPIStoppedInstanceConfigUpdate(name, helpers.PIInstanceHealthOk, "0.25", "2", "stop"),
+				Config: testAccCheckIBMPIStoppedInstanceConfigUpdate(name, power.OK, "0.25", "2", "stop"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckIBMPIInstanceExists(instanceRes),
 					resource.TestCheckResourceAttr(instanceRes, "pi_instance_name", name),
 				),
 			},
 			{
-				Config: testAccCheckIBMPIStoppedInstanceConfigUpdate(name, helpers.PIInstanceHealthOk, "0.5", "4", "stop"),
+				Config: testAccCheckIBMPIStoppedInstanceConfigUpdate(name, power.OK, "0.5", "4", "stop"),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckIBMPIInstanceStatus(instanceRes, "SHUTOFF"),
+					testAccCheckIBMPIInstanceStatus(instanceRes, strings.ToUpper(power.State_Shutoff)),
 					testAccCheckIBMPIInstanceExists(instanceRes),
 					resource.TestCheckResourceAttr(instanceRes, "pi_instance_name", name),
 				),
@@ -634,31 +654,31 @@ func TestAccIBMPIInstanceUpdateStoppedState(t *testing.T) {
 func testAccCheckIBMPIActiveInstanceConfigUpdate(name, instanceHealthStatus, proc, memory string) string {
 	return fmt.Sprintf(`
 	data "ibm_pi_image" "power_image" {
-		pi_image_name        = "%[3]s"
 		pi_cloud_instance_id = "%[1]s"
+		pi_image_name        = "%[3]s"
 	}
 	data "ibm_pi_network" "power_networks" {
 		pi_cloud_instance_id = "%[1]s"
 		pi_network_name      = "%[4]s"
 	}
 	resource "ibm_pi_volume" "power_volume" {
-		pi_volume_size       = 20
-		pi_volume_name       = "%[2]s"
-		pi_volume_shareable  = true
-		pi_volume_pool       = data.ibm_pi_image.power_image.storage_pool
 		pi_cloud_instance_id = "%[1]s"
+		pi_volume_name       = "%[2]s"
+		pi_volume_pool       = data.ibm_pi_image.power_image.storage_pool
+		pi_volume_shareable  = true
+		pi_volume_size       = 20
 	}
 	resource "ibm_pi_instance" "power_instance" {
-		pi_memory            = "%[7]s"
-		pi_processors        = "%[6]s"
-		pi_instance_name     = "%[2]s"
-		pi_proc_type         = "shared"
-		pi_image_id          = data.ibm_pi_image.power_image.id
-		pi_sys_type          = "s922"
 		pi_cloud_instance_id = "%[1]s"
-		pi_storage_pool      = data.ibm_pi_image.power_image.storage_pool
-		pi_pin_policy        = "none"
 		pi_health_status     = "%[5]s"
+		pi_image_id          = data.ibm_pi_image.power_image.id
+		pi_instance_name     = "%[2]s"
+		pi_memory            = "%[7]s"
+		pi_pin_policy        = "none"
+		pi_proc_type         = "shared"
+		pi_processors        = "%[6]s"
+		pi_storage_pool      = data.ibm_pi_image.power_image.storage_pool
+		pi_sys_type          = "s922"
 		pi_volume_ids        = [ibm_pi_volume.power_volume.volume_id]
 		pi_network {
 			network_id = data.ibm_pi_network.power_networks.id
@@ -670,41 +690,41 @@ func testAccCheckIBMPIActiveInstanceConfigUpdate(name, instanceHealthStatus, pro
 func testAccCheckIBMPIStoppedInstanceConfigUpdate(name, instanceHealthStatus, proc, memory, action string) string {
 	return fmt.Sprintf(`
 	data "ibm_pi_image" "power_image" {
-		pi_image_name        = "%[3]s"
 		pi_cloud_instance_id = "%[1]s"
+		pi_image_name        = "%[3]s"
 	}
 	data "ibm_pi_network" "power_networks" {
 		pi_cloud_instance_id = "%[1]s"
 		pi_network_name      = "%[4]s"
 	}
 	resource "ibm_pi_volume" "power_volume" {
-		pi_volume_size       = 20
-		pi_volume_name       = "%[2]s"
-		pi_volume_shareable  = true
-		pi_volume_pool       = data.ibm_pi_image.power_image.storage_pool
 		pi_cloud_instance_id = "%[1]s"
+		pi_volume_name       = "%[2]s"
+		pi_volume_pool       = data.ibm_pi_image.power_image.storage_pool
+		pi_volume_shareable  = true
+		pi_volume_size       = 20
 	}	  
 	resource "ibm_pi_instance" "power_instance" {
-		pi_memory             = "%[7]s"
-		pi_processors         = "%[6]s"
-		pi_instance_name      = "%[2]s"
-		pi_proc_type          = "shared"
-		pi_image_id           = data.ibm_pi_image.power_image.id
-		pi_sys_type           = "s922"
 		pi_cloud_instance_id  = "%[1]s"
-		pi_storage_pool       = data.ibm_pi_image.power_image.storage_pool		
-		pi_pin_policy         = "none"
 		pi_health_status      = "%[5]s"
+		pi_image_id           = data.ibm_pi_image.power_image.id
+		pi_instance_name      = "%[2]s"
+		pi_memory             = "%[7]s"
+		pi_pin_policy         = "none"
+		pi_proc_type          = "shared"
+		pi_processors         = "%[6]s"
+		pi_storage_pool       = data.ibm_pi_image.power_image.storage_pool		
+		pi_sys_type           = "s922"
 		pi_volume_ids         = [ibm_pi_volume.power_volume.volume_id]
 		pi_network {
 			network_id = data.ibm_pi_network.power_networks.id
 		}
 	}
 	resource "ibm_pi_instance_action" "power_instance_action" {
-  		pi_cloud_instance_id = "%[1]s"
-  		pi_instance_id       = ibm_pi_instance.power_instance.instance_id
   		pi_action            = "%[8]s"
+  		pi_cloud_instance_id = "%[1]s"
   		pi_health_status     = "%[5]s"
+  		pi_instance_id       = ibm_pi_instance.power_instance.instance_id
 	}
 	`, acc.Pi_cloud_instance_id, name, acc.Pi_image, acc.Pi_network_name, instanceHealthStatus, proc, memory, action)
 }
@@ -756,7 +776,7 @@ func TestAccIBMPIInstanceDeploymentTypeNoStorage(t *testing.T) {
 		CheckDestroy: testAccCheckIBMPIInstanceDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckIBMPIInstanceDeploymentTypeConfig(name, helpers.PIInstanceHealthOk, "VMNoStorage", "s922"),
+				Config: testAccCheckIBMPIInstanceDeploymentTypeConfig(name, power.OK, "VMNoStorage", "s922"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckIBMPIInstanceExists(instanceRes),
 					resource.TestCheckResourceAttr(instanceRes, "pi_instance_name", name),

--- a/ibm/service/power/resource_ibm_pi_shared_processor_pool.go
+++ b/ibm/service/power/resource_ibm_pi_shared_processor_pool.go
@@ -98,13 +98,13 @@ func ResourceIBMPISharedProcessorPool() *schema.Resource {
 				Description: "The host ID where the shared processor pool resides",
 			},
 
-			Attr_SharedProcessorPoolStatus: {
+			Attr_Status: {
 				Type:        schema.TypeString,
 				Computed:    true,
 				Description: "The status of the shared processor pool",
 			},
 
-			Attr_SharedProcessorPoolStatusDetail: {
+			Attr_StatusDetail: {
 				Type:        schema.TypeString,
 				Computed:    true,
 				Description: "The status details of the shared processor pool",
@@ -153,7 +153,7 @@ func ResourceIBMPISharedProcessorPool() *schema.Resource {
 							Computed:    true,
 							Description: "The server instance name",
 						},
-						Attr_SharedProcessorPoolInstanceStatus: {
+						Attr_Status: {
 							Type:        schema.TypeString,
 							Computed:    true,
 							Description: "Status of the server",
@@ -218,7 +218,7 @@ func isWaitForPISharedProcessorPoolAvailable(ctx context.Context, d *schema.Reso
 		Target:     []string{"active", "failed", ""},
 		Refresh:    isPISharedProcessorPoolRefreshFunc(client, id, sharedProcessorPoolReadyStatus),
 		Delay:      20 * time.Second,
-		MinTimeout: activeTimeOut,
+		MinTimeout: Timeout_Active,
 		Timeout:    d.Timeout(schema.TimeoutCreate),
 	}
 
@@ -293,7 +293,7 @@ func resourceIBMPISharedProcessorPoolRead(ctx context.Context, d *schema.Resourc
 		d.Set(Attr_SharedProcessorPoolPlacementGroups, pgIDs)
 	}
 	d.Set(Attr_SharedProcessorPoolHostID, response.SharedProcessorPool.HostID)
-	d.Set(Attr_SharedProcessorPoolStatus, response.SharedProcessorPool.Status)
+	d.Set(Attr_Status, response.SharedProcessorPool.Status)
 	d.Set(Attr_SharedProcessorPoolStatusDetail, response.SharedProcessorPool.StatusDetail)
 
 	serversMap := []map[string]interface{}{}
@@ -307,7 +307,7 @@ func resourceIBMPISharedProcessorPoolRead(ctx context.Context, d *schema.Resourc
 					Attr_SharedProcessorPoolInstanceId:               s.ID,
 					Attr_SharedProcessorPoolInstanceMemory:           s.Memory,
 					Attr_SharedProcessorPoolInstanceName:             s.Name,
-					Attr_SharedProcessorPoolInstanceStatus:           s.Status,
+					Attr_Status:                                      s.Status,
 					Attr_SharedProcessorPoolInstanceVcpus:            s.Vcpus,
 				}
 				serversMap = append(serversMap, v)

--- a/ibm/service/power/resource_ibm_pi_snapshot.go
+++ b/ibm/service/power/resource_ibm_pi_snapshot.go
@@ -239,8 +239,8 @@ func resourceIBMPISnapshotDelete(ctx context.Context, d *schema.ResourceData, me
 func isWaitForPIInstanceSnapshotAvailable(ctx context.Context, client *instance.IBMPISnapshotClient, id string, timeout time.Duration) (interface{}, error) {
 	log.Printf("Waiting for PIInstance Snapshot (%s) to be available and active ", id)
 	stateConf := &retry.StateChangeConf{
-		Pending:    []string{State_InProgress, State_BUILD},
-		Target:     []string{State_Available, State_ACTIVE},
+		Pending:    []string{State_InProgress, State_Build},
+		Target:     []string{State_Available, State_Active},
 		Refresh:    isPIInstanceSnapshotRefreshFunc(client, id),
 		Delay:      30 * time.Second,
 		MinTimeout: 2 * time.Minute,
@@ -270,7 +270,7 @@ func isWaitForPIInstanceSnapshotDeleted(ctx context.Context, client *instance.IB
 	log.Printf("Waiting for (%s) to be deleted.", id)
 
 	stateConf := &retry.StateChangeConf{
-		Pending:    []string{State_Retry, State_DELETING},
+		Pending:    []string{State_Retry, State_Deleting},
 		Target:     []string{State_NotFound},
 		Refresh:    isPIInstanceSnapshotDeleteRefreshFunc(client, id),
 		Delay:      10 * time.Second,

--- a/ibm/service/power/resource_ibm_pi_volume_group.go
+++ b/ibm/service/power/resource_ibm_pi_volume_group.go
@@ -52,7 +52,7 @@ func ResourceIBMPIVolumeGroup() *schema.Resource {
 				Description:   "The name of consistency group at storage controller level",
 				ConflictsWith: []string{PIVolumeGroupName},
 			},
-			PIVolumeIds: {
+			Arg_VolumeIDs: {
 				Type:        schema.TypeSet,
 				Required:    true,
 				Elem:        &schema.Schema{Type: schema.TypeString},
@@ -97,7 +97,7 @@ func resourceIBMPIVolumeGroupCreate(ctx context.Context, d *schema.ResourceData,
 		Name: vgName,
 	}
 
-	volids := flex.ExpandStringList((d.Get(PIVolumeIds).(*schema.Set)).List())
+	volids := flex.ExpandStringList((d.Get(Arg_VolumeIDs).(*schema.Set)).List())
 	body.VolumeIDs = volids
 
 	if v, ok := d.GetOk(PIVolumeGroupConsistencyGroupName); ok {
@@ -143,7 +143,7 @@ func resourceIBMPIVolumeGroupRead(ctx context.Context, d *schema.ResourceData, m
 	d.Set("consistency_group_name", vg.ConsistencyGroupName)
 	d.Set("replication_status", vg.ReplicationStatus)
 	d.Set(PIVolumeGroupName, vg.Name)
-	d.Set(PIVolumeIds, vg.VolumeIDs)
+	d.Set(Arg_VolumeIDs, vg.VolumeIDs)
 	d.Set("status_description_errors", flattenVolumeGroupStatusDescription(vg.StatusDescription.Errors))
 
 	return nil
@@ -162,8 +162,8 @@ func resourceIBMPIVolumeGroupUpdate(ctx context.Context, d *schema.ResourceData,
 	}
 
 	client := st.NewIBMPIVolumeGroupClient(ctx, sess, cloudInstanceID)
-	if d.HasChanges(PIVolumeIds) {
-		old, new := d.GetChange(PIVolumeIds)
+	if d.HasChanges(Arg_VolumeIDs) {
+		old, new := d.GetChange(Arg_VolumeIDs)
 		oldList := old.(*schema.Set)
 		newList := new.(*schema.Set)
 		body := &models.VolumeGroupUpdate{
@@ -195,7 +195,7 @@ func resourceIBMPIVolumeGroupDelete(ctx context.Context, d *schema.ResourceData,
 
 	client := st.NewIBMPIVolumeGroupClient(ctx, sess, cloudInstanceID)
 
-	volids := flex.ExpandStringList((d.Get(PIVolumeIds).(*schema.Set)).List())
+	volids := flex.ExpandStringList((d.Get(Arg_VolumeIDs).(*schema.Set)).List())
 	if len(volids) > 0 {
 		body := &models.VolumeGroupUpdate{
 			RemoveVolumes: volids,

--- a/website/docs/d/pi_instance.html.markdown
+++ b/website/docs/d/pi_instance.html.markdown
@@ -77,7 +77,8 @@ In addition to all argument reference list, you can access the following attribu
   Nested scheme for `networks`:
   - `external_ip` - (String) The external IP address of the instance.
   - `ip` - (String) The IP address of the instance.
-  - `macaddress` - (String) The MAC address of the instance.
+  - `macaddress` - (String) The MAC address of the instance. Deprecated please use `mac_address` instead.
+  - `mac_address` - (String) The MAC address of the instance.
   - `network_id` - (String) The network ID of the instance.
   - `network_name` - (String) The network name of the instance.
   - `type` - (String) The type of the network.

--- a/website/docs/d/pi_instances.html.markdown
+++ b/website/docs/d/pi_instances.html.markdown
@@ -69,7 +69,8 @@ In addition to all argument reference list, you can access the following attribu
       Nested scheme for `networks`:
         - `external_ip` - (String) The external IP address of the instance.
         - `ip` - (String) The IP address of the instance.
-        - `macaddress` - (String) The MAC address of the instance.
+        - `macaddress` - (String) The MAC address of the instance. Deprecated please use `mac_address` instead.
+        - `mac_address` - (String) The MAC address of the instance.
         - `network_id` - (String) The network ID of the instance.
         - `network_name` - (String) The network name of the instance.
         - `type` - (String) The type of the network.

--- a/website/docs/r/pi_instance.html.markdown
+++ b/website/docs/r/pi_instance.html.markdown
@@ -7,10 +7,12 @@ description: |-
 ---
 
 # ibm_pi_instance
+
 Create, delete or update a [Power Systems Virtual Server instance](https://cloud.ibm.com/docs/power-iaas?topic=power-iaas-creating-power-virtual-server).
 
 ## Example usage
-The following example creates a Power Systems Virtual Server instance. 
+
+The following example creates a Power Systems Virtual Server instance.
 
 ```terraform
 resource "ibm_pi_instance" "test-instance" {
@@ -32,13 +34,15 @@ resource "ibm_pi_instance" "test-instance" {
 
 ~> **WARNING:** Updating a ibm_pi_instance resource with `pi_replicants` set does not update replicant vms!
 
-**Note**
+### Notes
+
 * Please find [supported Regions](https://cloud.ibm.com/apidocs/power-cloud#endpoint) for endpoints.
 * If a Power cloud instance is provisioned at `lon04`, The provider level attributes should be as follows:
   * `region` - `lon`
   * `zone` - `lon04`
   
 Example usage:  
+
   ```terraform
     provider "ibm" {
       region    =   "lon"
@@ -50,76 +54,78 @@ Example usage:
 
 The `ibm_pi_instance` provides the following [timeouts](https://www.terraform.io/docs/language/resources/syntax.html) configuration options:
 
-- **create** - The creation of the instance is considered failed if no response is received for 120 minutes.
-- **Update** The updation of the instance is considered failed if no response is received for 60 minutes.
-- **delete** - The deletion of the instance is considered failed if no response is received for 60 minutes.
-
+* **create** - (Default 120 minutes) Used for creating an instance.
+* **update** - (Default 60 minutes) Used for updating an instance.
+* **delete** - (Default 60 minutes) Used for deleting an instance.
 
 ## Argument reference
-Review the argument references that you can specify for your resource. 
 
-- `pi_affinity_instance` - (Optional, String) PVM Instance (ID or Name) to base storage affinity policy against; required if requesting `affinity` and `pi_affinity_volume` is not provided.
-- `pi_affinity_policy` - (Optional, String) Affinity policy for pvm instance being created; ignored if `pi_storage_pool` provided; for policy affinity requires one of `pi_affinity_instance` or `pi_affinity_volume` to be specified; for policy anti-affinity requires one of `pi_anti_affinity_instances` or `pi_anti_affinity_volumes` to be specified; Allowable values: `affinity`, `anti-affinity`
-- `pi_affinity_volume`- (Optional, String) Volume (ID or Name) to base storage affinity policy against; required if requesting `affinity` and `pi_affinity_instance` is not provided.
-- `pi_anti_affinity_instances` - (Optional, String) List of pvmInstances to base storage anti-affinity policy against; required if requesting `anti-affinity` and `pi_anti_affinity_volumes` is not provided.
-- `pi_anti_affinity_volumes`- (Optional, String) List of volumes to base storage anti-affinity policy against; required if requesting `anti-affinity` and `pi_anti_affinity_instances` is not provided.
-- `pi_cloud_instance_id` - (Required, String) The GUID of the service instance associated with an account.
-- `pi_deployment_target` - (Optional, List) The deployment of a dedicated host. Max items: 1.
+Review the argument references that you can specify for your resource.
+
+* `pi_affinity_instance` - (Optional, String) PVM Instance (ID or Name) to base storage affinity policy against; required if requesting `affinity` and `pi_affinity_volume` is not provided.
+* `pi_affinity_policy` - (Optional, String) Affinity policy for pvm instance being created; ignored if `pi_storage_pool` provided; for policy affinity requires one of `pi_affinity_instance` or `pi_affinity_volume` to be specified; for policy anti-affinity requires one of `pi_anti_affinity_instances` or `pi_anti_affinity_volumes` to be specified; Allowable values: `affinity`, `anti-affinity`
+* `pi_affinity_volume`- (Optional, String) Volume (ID or Name) to base storage affinity policy against; required if requesting `affinity` and `pi_affinity_instance` is not provided.
+* `pi_anti_affinity_instances` - (Optional, String) List of pvmInstances to base storage anti-affinity policy against; required if requesting `anti-affinity` and `pi_anti_affinity_volumes` is not provided.
+* `pi_anti_affinity_volumes`- (Optional, String) List of volumes to base storage anti-affinity policy against; required if requesting `anti-affinity` and `pi_anti_affinity_instances` is not provided.
+* `pi_cloud_instance_id` - (Required, String) The GUID of the service instance associated with an account.
+* `pi_deployment_target` - (Optional, List) The deployment of a dedicated host. Max items: 1.
   
   Nested scheme for `pi_deployment_target` :
   * `id` - (Required, String) The uuid of the host group or host.
   * `type` - (Required, String) The deployment target type. Supported values are `host` and `hostGroup`.
 
 - `pi_deployment_type` - (Optional, String) Custom deployment type; Allowable value: `EPIC` or `VMNoStorage`.
-- `pi_health_status` - (Optional, String) Specifies if Terraform should poll for the health status to be `OK` or `WARNING`. The default value is `OK`.
+* `pi_health_status` - (Optional, String) Specifies if Terraform should poll for the health status to be `OK` or `WARNING`. The default value is `OK`.
 
 **Notes** IBM i software licenses for IBM i virtual server instances -- only for IBM i instances. Default to `false` and `0` if no values provided
-- `pi_ibmi_css` - (Optional, Boolean) IBM i Cloud Storage Solution.
-- `pi_ibmi_pha` - (Optional, Boolean) IBM i Power High Availability.
-- `pi_ibmi_rds_users` - (Optional, Integer) IBM i Rational Dev Studio Number of User Licenses.
-- `pi_image_id` - (Required, String) The ID of the image that you want to use for your Power Systems Virtual Server instance. The image determines the operating system that is installed in your instance. To list available images, run the `ibmcloud pi images` command.
-  - **Notes**:
+
+* `pi_ibmi_css` - (Optional, Boolean) IBM i Cloud Storage Solution.
+* `pi_ibmi_pha` - (Optional, Boolean) IBM i Power High Availability.
+* `pi_ibmi_rds_users` - (Optional, Integer) IBM i Rational Dev Studio Number of User Licenses.
+* `pi_image_id` - (Required, String) The ID of the image that you want to use for your Power Systems Virtual Server instance. The image determines the operating system that is installed in your instance. To list available images, run the `ibmcloud pi images` command.
+  * **Notes**:
         - Only images belonging to your project can be used image for deploying a Power Systems Virtual Server instance. To import an images to your project, see [ibm_pi_image](https://registry.terraform.io/providers/IBM-Cloud/ibm/latest/docs/resources/pi_image).
         - If using `pi_deployment_type = VMNoStorage` then use the following images for the respective OS you intend to create the instance: `AIX-EMPTY`, `IBMI-EMPTY`, `SLES-EMPTY`, `RHEL-EMPTY`.
-- `pi_instance_name` - (Required, String) The name of the Power Systems Virtual Server instance. 
-- `pi_key_pair_name` - (Optional, String) The name of the SSH key that you want to use to access your Power Systems Virtual Server instance. The SSH key must be uploaded to IBM Cloud.
-- `pi_license_repository_capacity` - (Deprecated, Optional, Integer) The VTL license repository capacity TB value. Only use with VTL instances. `pi_memory >= 16 + (2 * pi_license_repository_capacity)`.
-  - **Note**: Provisioning VTL instances is temporarily disabled.
-- `pi_memory` - (Optional, Float) The amount of memory that you want to assign to your instance in GB.
-  - Required when not creating SAP instances. Conflicts with `pi_sap_profile_id`.
-- `pi_network` - (Required, List of Map) List of one or more networks to attach to the instance.
+* `pi_instance_name` - (Required, String) The name of the Power Systems Virtual Server instance.
+* `pi_key_pair_name` - (Optional, String) The name of the SSH key that you want to use to access your Power Systems Virtual Server instance. The SSH key must be uploaded to IBM Cloud.
+* `pi_license_repository_capacity` - (Deprecated, Optional, Integer) The VTL license repository capacity TB value. Only use with VTL instances. `pi_memory >= 16 + (2 * pi_license_repository_capacity)`.
+  * **Note**: Provisioning VTL instances is temporarily disabled.
+* `pi_memory` - (Optional, Float) The amount of memory that you want to assign to your instance in GB.
+  * Required when not creating SAP instances. Conflicts with `pi_sap_profile_id`.
+* `pi_network` - (Required, List of Map) List of one or more networks to attach to the instance.
 
   The `pi_network` block supports:
-  - `network_id` - (String) The network ID to assign to the instance.
-  - `ip_address` - (String) The ip address to be used of this network.
-- `pi_pin_policy` - (Optional, String) Select the pinning policy for your Power Systems Virtual Server instance. Supported values are `soft`, `hard`, and `none`.    **Note** You can choose to soft pin (`soft`) or hard pin (`hard`) a virtual server to the physical host where it runs. When you soft pin an instance for high availability, the instance automatically migrates back to the original host once the host is back to its operating state. If the instance has a licensing restriction with the host, the hard pin option restricts the movement of the instance during remote restart, automated remote restart, DRO, and live partition migration. The default pinning policy is `none`. 
-- `pi_placement_group_id` - (Optional, String) The ID of the placement group that the instance is in or empty quotes `""` to indicate it is not in a placement group. The meta-argument `count` and a `pi_replicants` cannot be used when specifying a placement group ID. Instances provisioning in the same placement group must be provisioned one at a time; however, to provision multiple instances on the same host or different hosts then use `pi_replicants` and `pi_replication_policy` instead of `pi_placement_group_id`.
-- `pi_processors` - (Optional, Float) The number of vCPUs to assign to the VM as visible within the guest Operating System.
-  - Required when not creating SAP instances. Conflicts with `pi_sap_profile_id`.
-- `pi_proc_type` - (Optional, String) The type of processor mode in which the VM will run with `shared`, `capped` or `dedicated`.
-  - Required when not creating SAP instances. Conflicts with `pi_sap_profile_id`.
-- `pi_replicants` - (Optional, Integer) The number of instances that you want to provision with the same configuration. If this parameter is not set,  `1` is used by default.
-- `pi_replication_policy` - (Optional, String) The replication policy that you want to use, either `affinity`, `anti-affinity` or `none`. If this parameter is not set, `none` is used by default. 
-- `pi_replication_scheme` - (Optional, String) The replication scheme that you want to set, either `prefix` or `suffix`.
-- `pi_sap_profile_id` - (Optional, String) SAP Profile ID for the amount of cores and memory.
-  - Required only when creating SAP instances.
-- `pi_sap_deployment_type` - (Optional, String) Custom SAP deployment type information (For Internal Use Only).
-- `pi_shared_processor_pool` - (Optional, String) The shared processor pool for instance deployment. Conflicts with `pi_sap_profile_id`.
-- `pi_storage_pool` - (Optional, String) Storage Pool for server deployment; if provided then `pi_affinity_policy` will be ignored; Only valid when you deploy one of the IBM supplied stock images. Storage pool for a custom image (an imported image or an image that is created from a VM capture) defaults to the storage pool the image was created in.
-- `pi_storage_pool_affinity` - (Optional, Boolean) Indicates if all volumes attached to the server must reside in the same storage pool. The default value is `true`. To attach data volumes from a different storage pool (mixed storage) set to `false` and use `pi_volume_attach` resource. Once set to `false`, cannot be set back to `true` unless all volumes attached reside in the same storage type and pool.
-- `pi_storage_type` - (Optional, String) - Storage type for server deployment; If storage type is not provided the storage type will default to `tier3`.
-- `pi_storage_connection` - (Optional, String) - Storage Connectivity Group (SCG) for server deployment. Only supported value is `vSCSI`.
-- `pi_sys_type` - (Optional, String) The type of system on which to create the VM (e880/e980/e1080/s922/s1022).
-  - Supported SAP system types are (e880/e980/e1080).
-- `pi_user_data` - (Optional, String) The user data `cloud-init` to pass to the instance during creation. It can be a base64 encoded or an unencoded string. If it is an unencoded string, the provider will encode it before it passing it down.
-- `pi_virtual_cores_assigned`  - (Optional, Integer) Specify the number of virtual cores to be assigned.
-- `pi_virtual_optical_device` - (Optional, String) Virtual Machine's Cloud Initialization Virtual Optical Device.
-- `pi_volume_ids` - (Optional, List of String) The list of volume IDs that you want to attach to the instance during creation.
+  * `network_id` - (String) The network ID to assign to the instance.
+  * `ip_address` - (String) The ip address to be used of this network.
+* `pi_pin_policy` - (Optional, String) Select the pinning policy for your Power Systems Virtual Server instance. Supported values are `soft`, `hard`, and `none`.    **Note** You can choose to soft pin (`soft`) or hard pin (`hard`) a virtual server to the physical host where it runs. When you soft pin an instance for high availability, the instance automatically migrates back to the original host once the host is back to its operating state. If the instance has a licensing restriction with the host, the hard pin option restricts the movement of the instance during remote restart, automated remote restart, DRO, and live partition migration. The default pinning policy is `none`.
+* `pi_placement_group_id` - (Optional, String) The ID of the placement group that the instance is in or empty quotes `""` to indicate it is not in a placement group. The meta-argument `count` and a `pi_replicants` cannot be used when specifying a placement group ID. Instances provisioning in the same placement group must be provisioned one at a time; however, to provision multiple instances on the same host or different hosts then use `pi_replicants` and `pi_replication_policy` instead of `pi_placement_group_id`.
+* `pi_processors` - (Optional, Float) The number of vCPUs to assign to the VM as visible within the guest Operating System.
+  * Required when not creating SAP instances. Conflicts with `pi_sap_profile_id`.
+* `pi_proc_type` - (Optional, String) The type of processor mode in which the VM will run with `shared`, `capped` or `dedicated`.
+  * Required when not creating SAP instances. Conflicts with `pi_sap_profile_id`.
+* `pi_replicants` - (Optional, Integer) The number of instances that you want to provision with the same configuration. If this parameter is not set,  `1` is used by default.
+* `pi_replication_policy` - (Optional, String) The replication policy that you want to use, either `affinity`, `anti-affinity` or `none`. If this parameter is not set, `none` is used by default.
+* `pi_replication_scheme` - (Optional, String) The replication scheme that you want to set, either `prefix` or `suffix`.
+* `pi_sap_profile_id` - (Optional, String) SAP Profile ID for the amount of cores and memory.
+  * Required only when creating SAP instances.
+* `pi_sap_deployment_type` - (Optional, String) Custom SAP deployment type information (For Internal Use Only).
+* `pi_shared_processor_pool` - (Optional, String) The shared processor pool for instance deployment. Conflicts with `pi_sap_profile_id`.
+* `pi_storage_pool` - (Optional, String) Storage Pool for server deployment; if provided then `pi_affinity_policy` will be ignored; Only valid when you deploy one of the IBM supplied stock images. Storage pool for a custom image (an imported image or an image that is created from a VM capture) defaults to the storage pool the image was created in.
+* `pi_storage_pool_affinity` - (Optional, Boolean) Indicates if all volumes attached to the server must reside in the same storage pool. The default value is `true`. To attach data volumes from a different storage pool (mixed storage) set to `false` and use `pi_volume_attach` resource. Once set to `false`, cannot be set back to `true` unless all volumes attached reside in the same storage type and pool.
+* `pi_storage_type` - (Optional, String) - Storage type for server deployment; If storage type is not provided the storage type will default to `tier3`.
+* `pi_storage_connection` - (Optional, String) - Storage Connectivity Group (SCG) for server deployment. Only supported value is `vSCSI`.
+* `pi_sys_type` - (Optional, String) The type of system on which to create the VM (e880/e980/e1080/s922/s1022).
+  * Supported SAP system types are (e880/e980/e1080).
+* `pi_user_data` - (Optional, String) The user data `cloud-init` to pass to the instance during creation. It can be a base64 encoded or an unencoded string. If it is an unencoded string, the provider will encode it before it passing it down.
+* `pi_virtual_cores_assigned`  - (Optional, Integer) Specify the number of virtual cores to be assigned.
+* `pi_virtual_optical_device` - (Optional, String) Virtual Machine's Cloud Initialization Virtual Optical Device.
+* `pi_volume_ids` - (Optional, List of String) The list of volume IDs that you want to attach to the instance during creation.
 
 ## Attribute reference
+
 In addition to all argument reference list, you can access the following attribute reference after your resource is created.
 
-- `fault` - (Map) Fault information, if any.
+* `fault` - (Map) Fault information, if any.
   
    Nested scheme for `fault`:
       - `code` - (String) The fault status of the server.
@@ -127,34 +133,35 @@ In addition to all argument reference list, you can access the following attribu
       - `details` - (String) The fault details of the server.
       - `message` -  (String) The fault message of the server.
 
-- `health_status` - (String) The health status of the VM.
-- `ibmi_rds` - (Boolean) IBM i Rational Dev Studio.
-- `id` - (String) The unique identifier of the instance. The ID is composed of `<cloud_instance_id>/<instance_id_1>/.../<instance_id_n>`.
-- `instance_id` - (String) The unique identifier of the instance. 
-- `max_processors`- (Float) The maximum number of processors that can be allocated to the instance with shutting down or rebooting the `LPAR`.
-- `max_virtual_cores` - (Integer) The maximum number of virtual cores.
-- `min_processors` - (Float) The minimum number of processors that the instance can have. 
-- `min_memory` - (Float) The minimum memory that was allocated to the instance.
-- `max_memory`- (Float) The maximum amount of memory that can be allocated to the instance without shut down or reboot the `LPAR`.
-- `min_virtual_cores` - (Integer) The minimum number of virtual cores.
-- `pin_policy`  - (String) The pinning policy of the instance.
-- `pi_network` - (List of Map) - A list of networks that are assigned to the instance.
+* `health_status` - (String) The health status of the VM.
+* `ibmi_rds` - (Boolean) IBM i Rational Dev Studio.
+* `id` - (String) The unique identifier of the instance. The ID is composed of `<pi_cloud_instance_id>/<instance_id_1>/.../<instance_id_n>`.
+* `instance_id` - (String) The unique identifier of the instance.
+* `max_processors`- (Float) The maximum number of processors that can be allocated to the instance with shutting down or rebooting the `LPAR`.
+* `max_virtual_cores` - (Integer) The maximum number of virtual cores.
+* `min_processors` - (Float) The minimum number of processors that the instance can have.
+* `min_memory` - (Float) The minimum memory that was allocated to the instance.
+* `max_memory`- (Float) The maximum amount of memory that can be allocated to the instance without shut down or reboot the `LPAR`.
+* `min_virtual_cores` - (Integer) The minimum number of virtual cores.
+* `pin_policy`  - (String) The pinning policy of the instance.
+* `pi_network` - (List of Map) - A list of networks that are assigned to the instance.
   Nested scheme for `pi_network`:
-  - `ip_address` - (String) The IP address of the network.
-  - `mac_address` - (String) The MAC address of the network.
-  - `network_id` - (String) The ID of the network.
-  - `network_name` - (String) The name of the network.
-  - `type` - (String) The type of network.
-  - `external_ip` - (String) The external IP address of the network.
-- `progress` - (Float) - Specifies the overall progress of the instance deployment process in percentage.
-- `shared_processor_pool_id` - (String)  The ID of the shared processor pool for the instance.
-- `status` - (String) The status of the instance.
+  * `ip_address` - (String) The IP address of the network.
+  * `mac_address` - (String) The MAC address of the network.
+  * `network_id` - (String) The ID of the network.
+  * `network_name` - (String) The name of the network.
+  * `type` - (String) The type of network.
+  * `external_ip` - (String) The external IP address of the network.
+* `progress` - (Float) - Specifies the overall progress of the instance deployment process in percentage.
+* `shared_processor_pool_id` - (String)  The ID of the shared processor pool for the instance.
+* `status` - (String) The status of the instance.
+
 ## Import
 
-The `ibm_pi_instance` can be imported using `cloud_instance_id` and `instance_id`.
+The `ibm_pi_instance` can be imported using `pi_cloud_instance_id` and `instance_id`.
 
-**Example**
+### Example
 
-```
-$ terraform import ibm_pi_instance.example d7bec597-4726-451f-8a63-e62e6f19c32c/cea6651a-bc0a-4438-9f8a-a0770b112ebb
+```bash
+terraform import ibm_pi_instance.example d7bec597-4726-451f-8a63-e62e6f19c32c/cea6651a-bc0a-4438-9f8a-a0770b112ebb
 ```


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/IBM-Cloud/terraform-provider-ibm/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
=== RUN   TestAccIBMPIInstanceBasic
--- PASS: TestAccIBMPIInstanceBasic (516.53s)
PASS

=== RUN   TestAccIBMPIInstanceIBMiLicense
--- PASS: TestAccIBMPIInstanceIBMiLicense (618.72s)
PASS

=== RUN   TestAccIBMPIInstanceReplicant
--- PASS: TestAccIBMPIInstanceReplicant (1239.04s)
PASS

=== RUN   TestAccIBMPIInstanceNetwork
--- PASS: TestAccIBMPIInstanceNetwork (1107.70s)
PASS

=== RUN   TestAccIBMPIInstanceMixedStorage
--- PASS: TestAccIBMPIInstanceMixedStorage (1141.47s)
PASS

=== RUN   TestAccIBMPIInstanceUpdateStoppedState
--- PASS: TestAccIBMPIInstanceUpdateStoppedState (1019.82s)
PASS

=== RUN   TestAccIBMPIInstanceUpdateActiveState
--- PASS: TestAccIBMPIInstanceUpdateActiveState (1088.30s)
PASS

=== RUN   TestAccIBMPIInstanceDeploymentTypeNoStorage
--- PASS: TestAccIBMPIInstanceDeploymentTypeNoStorage (643.53s)
PASS

=== RUN   TestAccIBMPIInstanceIPDataSource_basic
--- PASS: TestAccIBMPIInstanceIPDataSource_basic (21.11s)
PASS

=== RUN   TestAccIBMPIInstanceDataSource_basic
--- PASS: TestAccIBMPIInstanceDataSource_basic (23.45s)
PASS

=== RUN   TestAccIBMPIInstancesDataSource_basic
--- PASS: TestAccIBMPIInstancesDataSource_basic (16.69s)
PASS

=== RUN   TestAccIBMPINetworkPortDataSource_basic
--- PASS: TestAccIBMPINetworkPortDataSource_basic (11.58s)
PASS

=== RUN   TestAccIBMPICloudConnectionbasic
--- PASS: TestAccIBMPICloudConnectionbasic (306.86s)

=== RUN   TestAccIBMPICloudConnectionNetworks
--- PASS: TestAccIBMPICloudConnectionNetworks (398.98s)

=== RUN   TestAccIBMPICloudConnectionClassic
--- PASS: TestAccIBMPICloudConnectionClassic (412.91s)

=== RUN   TestAccIBMPICloudConnectionVPC
--- PASS: TestAccIBMPICloudConnectionVPC (386.58s)

=== RUN   TestAccIBMPICloudConnectionTransitGateway
--- PASS: TestAccIBMPICloudConnectionTransitGateway (321.78s)
PASS

=== RUN   TestAccIBMPIDhcpbasic
--- PASS: TestAccIBMPIDhcpbasic (547.17s)

=== RUN   TestAccIBMPIDhcpWithCidrName
--- PASS: TestAccIBMPIDhcpWithCidrName (492.56s)

=== RUN   TestAccIBMPIDhcpSNAT
--- PASS: TestAccIBMPIDhcpSNAT (387.59s)
PASS

=== RUN   TestAccIBMPIImagebasic
--- PASS: TestAccIBMPIImagebasic (42.63s)
PASS
```
