### PR TITLE
ContinuousTargetOccurence updates

### DIFF
--- a/ibm/service/kubernetes/resource_ibm_container_cluster.go
+++ b/ibm/service/kubernetes/resource_ibm_container_cluster.go
@@ -1567,7 +1567,7 @@ func WaitForClusterVersionUpdate(d *schema.ResourceData, meta interface{}, targe
 		Timeout:                   d.Timeout(schema.TimeoutUpdate),
 		Delay:                     20 * time.Second,
 		MinTimeout:                10 * time.Second,
-		ContinuousTargetOccurence: 5,
+		ContinuousTargetOccurence: 3,
 	}
 
 	return stateConf.WaitForState()

--- a/ibm/service/kubernetes/resource_ibm_container_storage_attachment.go
+++ b/ibm/service/kubernetes/resource_ibm_container_storage_attachment.go
@@ -299,7 +299,7 @@ func waitforVolumetoAttach(d *schema.ResourceData, meta interface{}) (interface{
 		Timeout:                   d.Timeout(schema.TimeoutCreate),
 		Delay:                     10 * time.Second,
 		MinTimeout:                5 * time.Second,
-		ContinuousTargetOccurence: 5,
+		ContinuousTargetOccurence: 3,
 	}
 	return createStateConf.WaitForState()
 }

--- a/ibm/service/kubernetes/resource_ibm_container_vpc_cluster.go
+++ b/ibm/service/kubernetes/resource_ibm_container_vpc_cluster.go
@@ -1196,7 +1196,7 @@ func waitForVpcClusterOneWorkerAvailable(d *schema.ResourceData, meta interface{
 		Timeout:                   d.Timeout(schema.TimeoutCreate),
 		Delay:                     10 * time.Second,
 		MinTimeout:                5 * time.Second,
-		ContinuousTargetOccurence: 5,
+		ContinuousTargetOccurence: 3,
 	}
 	return createStateConf.WaitForState()
 }
@@ -1232,7 +1232,7 @@ func waitForVpcClusterState(d *schema.ResourceData, meta interface{}, waitForSta
 		Timeout:                   d.Timeout(schema.TimeoutCreate),
 		Delay:                     10 * time.Second,
 		MinTimeout:                5 * time.Second,
-		ContinuousTargetOccurence: 5,
+		ContinuousTargetOccurence: 3,
 	}
 	return createStateConf.WaitForState()
 }
@@ -1266,7 +1266,7 @@ func waitForVpcClusterMasterAvailable(d *schema.ResourceData, meta interface{}) 
 		Timeout:                   d.Timeout(schema.TimeoutCreate),
 		Delay:                     10 * time.Second,
 		MinTimeout:                5 * time.Second,
-		ContinuousTargetOccurence: 5,
+		ContinuousTargetOccurence: 3,
 	}
 	return createStateConf.WaitForState()
 }
@@ -1342,7 +1342,7 @@ func waitForVpcClusterIngressAvailable(d *schema.ResourceData, meta interface{})
 		Timeout:                   d.Timeout(schema.TimeoutCreate),
 		Delay:                     10 * time.Second,
 		MinTimeout:                5 * time.Second,
-		ContinuousTargetOccurence: 5,
+		ContinuousTargetOccurence: 3,
 	}
 	return createStateConf.WaitForState()
 }
@@ -1397,7 +1397,7 @@ func WaitForVpcClusterVersionUpdate(d *schema.ResourceData, meta interface{}, ta
 		Timeout:                   d.Timeout(schema.TimeoutUpdate),
 		Delay:                     10 * time.Second,
 		MinTimeout:                10 * time.Second,
-		ContinuousTargetOccurence: 5,
+		ContinuousTargetOccurence: 3,
 	}
 
 	return stateConf.WaitForState()
@@ -1435,7 +1435,7 @@ func WaitForVpcClusterWokersVersionUpdate(d *schema.ResourceData, meta interface
 		Timeout:                   d.Timeout(schema.TimeoutUpdate),
 		Delay:                     10 * time.Second,
 		MinTimeout:                10 * time.Second,
-		ContinuousTargetOccurence: 5,
+		ContinuousTargetOccurence: 3,
 	}
 
 	return stateConf.WaitForState()

--- a/ibm/service/kubernetes/resource_ibm_container_vpc_worker.go
+++ b/ibm/service/kubernetes/resource_ibm_container_vpc_worker.go
@@ -688,7 +688,7 @@ func WaitForVpcClusterVpcWokersVersionUpdate(d *schema.ResourceData, meta interf
 		Timeout:                   d.Timeout(schema.TimeoutUpdate),
 		Delay:                     10 * time.Second,
 		MinTimeout:                10 * time.Second,
-		ContinuousTargetOccurence: 5,
+		ContinuousTargetOccurence: 3,
 	}
 
 	return stateConf.WaitForState()

--- a/ibm/service/satellite/resource_ibm_satellite_cluster.go
+++ b/ibm/service/satellite/resource_ibm_satellite_cluster.go
@@ -984,7 +984,7 @@ func WaitForSatelliteClusterVersionUpdate(d *schema.ResourceData, meta interface
 		Timeout:                   d.Timeout(schema.TimeoutUpdate),
 		Delay:                     20 * time.Second,
 		MinTimeout:                10 * time.Second,
-		ContinuousTargetOccurence: 5,
+		ContinuousTargetOccurence: 3,
 	}
 
 	return stateConf.WaitForState()


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/IBM-Cloud/terraform-provider-ibm/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
2024-05-27T14:35:36.064+0200 [DEBUG] sdk.helper_resource: Finished TestCase: test_name=TestAccIBMContainerVpcClusterBaseEnvvar
--- PASS: TestAccIBMContainerVpcClusterBaseEnvvar (4234.28s)
PASS
ok      github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/kubernetes      4237.086

...
```

lowered the ContinuousTargetOccurence numbers across the board.
