### PR TITLE
fix(CatalogManagement): remove deprecated arguments not supported in latest sdk

### DIFF
--- a/ibm/service/catalogmanagement/data_source_ibm_cm_offering.go
+++ b/ibm/service/catalogmanagement/data_source_ibm_cm_offering.go
@@ -1975,24 +1975,6 @@ func DataSourceIBMCmOffering() *schema.Resource {
 				Description: "A list of account IDs to add to this offering's access list.",
 				Elem:        &schema.Schema{Type: schema.TypeString},
 			},
-			"permit_request_ibm_public_publish": &schema.Schema{
-				Type:        schema.TypeBool,
-				Computed:    true,
-				Deprecated:  "This argument is deprecated",
-				Description: "Is it permitted to request publishing to IBM or Public.",
-			},
-			"ibm_publish_approved": &schema.Schema{
-				Type:        schema.TypeBool,
-				Computed:    true,
-				Deprecated:  "This argument is deprecated",
-				Description: "Indicates if this offering has been approved for use by all IBMers.",
-			},
-			"public_publish_approved": &schema.Schema{
-				Type:        schema.TypeBool,
-				Computed:    true,
-				Deprecated:  "This argument is deprecated",
-				Description: "Indicates if this offering has been approved for use by all IBM Cloud users.",
-			},
 			"public_original_crn": &schema.Schema{
 				Type:        schema.TypeString,
 				Computed:    true,
@@ -2633,18 +2615,6 @@ func dataSourceIBMCmOfferingRead(context context.Context, d *schema.ResourceData
 
 	if err = d.Set("share_enabled", offering.ShareEnabled); err != nil {
 		return diag.FromErr(fmt.Errorf("Error setting share_enabled: %s", err))
-	}
-
-	if err = d.Set("permit_request_ibm_public_publish", offering.PermitRequestIBMPublicPublish); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting permit_request_ibm_public_publish: %s", err))
-	}
-
-	if err = d.Set("ibm_publish_approved", offering.IBMPublishApproved); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting ibm_publish_approved: %s", err))
-	}
-
-	if err = d.Set("public_publish_approved", offering.PublicPublishApproved); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting public_publish_approved: %s", err))
 	}
 
 	if err = d.Set("public_original_crn", offering.PublicOriginalCRN); err != nil {

--- a/ibm/service/catalogmanagement/resource_ibm_cm_offering.go
+++ b/ibm/service/catalogmanagement/resource_ibm_cm_offering.go
@@ -2051,27 +2051,6 @@ func ResourceIBMCmOffering() *schema.Resource {
 				Description: "A list of account IDs to add to this offering's access list.",
 				Elem:        &schema.Schema{Type: schema.TypeString},
 			},
-			"permit_request_ibm_public_publish": &schema.Schema{
-				Type:        schema.TypeBool,
-				Optional:    true,
-				Computed:    true,
-				Deprecated:  "This argument is deprecated",
-				Description: "Is it permitted to request publishing to IBM or Public.",
-			},
-			"ibm_publish_approved": &schema.Schema{
-				Type:        schema.TypeBool,
-				Optional:    true,
-				Computed:    true,
-				Deprecated:  "This argument is deprecated",
-				Description: "Indicates if this offering has been approved for use by all IBMers.",
-			},
-			"public_publish_approved": &schema.Schema{
-				Type:        schema.TypeBool,
-				Optional:    true,
-				Computed:    true,
-				Deprecated:  "This argument is deprecated",
-				Description: "Indicates if this offering has been approved for use by all IBM Cloud users.",
-			},
 			"public_original_crn": &schema.Schema{
 				Type:        schema.TypeString,
 				Optional:    true,
@@ -2694,15 +2673,6 @@ func resourceIBMCmOfferingCreate(context context.Context, d *schema.ResourceData
 	if _, ok := d.GetOk("share_enabled"); ok {
 		createOfferingOptions.SetShareEnabled(d.Get("share_enabled").(bool))
 	}
-	if _, ok := d.GetOk("permit_request_ibm_public_publish"); ok {
-		createOfferingOptions.SetPermitRequestIBMPublicPublish(d.Get("permit_request_ibm_public_publish").(bool))
-	}
-	if _, ok := d.GetOk("ibm_publish_approved"); ok {
-		createOfferingOptions.SetIBMPublishApproved(d.Get("ibm_publish_approved").(bool))
-	}
-	if _, ok := d.GetOk("public_publish_approved"); ok {
-		createOfferingOptions.SetPublicPublishApproved(d.Get("public_publish_approved").(bool))
-	}
 	if _, ok := d.GetOk("public_original_crn"); ok {
 		createOfferingOptions.SetPublicOriginalCRN(d.Get("public_original_crn").(string))
 	}
@@ -2944,15 +2914,6 @@ func resourceIBMCmOfferingRead(context context.Context, d *schema.ResourceData, 
 	}
 	if err = d.Set("share_enabled", offering.ShareEnabled); err != nil {
 		return diag.FromErr(fmt.Errorf("Error setting share_enabled: %s", err))
-	}
-	if err = d.Set("permit_request_ibm_public_publish", offering.PermitRequestIBMPublicPublish); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting permit_request_ibm_public_publish: %s", err))
-	}
-	if err = d.Set("ibm_publish_approved", offering.IBMPublishApproved); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting ibm_publish_approved: %s", err))
-	}
-	if err = d.Set("public_publish_approved", offering.PublicPublishApproved); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting public_publish_approved: %s", err))
 	}
 	if err = d.Set("public_original_crn", offering.PublicOriginalCRN); err != nil {
 		return diag.FromErr(fmt.Errorf("Error setting public_original_crn: %s", err))

--- a/ibm/service/catalogmanagement/resource_ibm_cm_version.go
+++ b/ibm/service/catalogmanagement/resource_ibm_cm_version.go
@@ -827,6 +827,7 @@ func ResourceIBMCmVersion() *schema.Resource {
 			},
 			"required_resources": &schema.Schema{
 				Type:        schema.TypeList,
+				Optional:    true,
 				Computed:    true,
 				Description: "Resource requirments for installation.",
 				Elem: &schema.Resource{
@@ -1912,6 +1913,22 @@ func resourceIBMCmVersionCreate(context context.Context, d *schema.ResourceData,
 		updateOfferingOptions.Updates = append(updateOfferingOptions.Updates, update)
 		hasChange = true
 	}
+	if _, ok := d.GetOk("required_resources"); ok {
+		var method string
+		if activeVersion.RequiredResources == nil {
+			method = "add"
+		} else {
+			method = "replace"
+		}
+		path := fmt.Sprintf("%s/required_resources", pathToVersion)
+		update := catalogmanagementv1.JSONPatchOperation{
+			Op:    &method,
+			Path:  &path,
+			Value: d.Get("required_resources"),
+		}
+		updateOfferingOptions.Updates = append(updateOfferingOptions.Updates, update)
+		hasChange = true
+	}
 	if _, ok := d.GetOk("install"); ok {
 		var method string
 		if activeVersion.Install == nil {
@@ -2416,6 +2433,22 @@ func resourceIBMCmVersionUpdate(context context.Context, d *schema.ResourceData,
 			Op:    &method,
 			Path:  &path,
 			Value: d.Get("iam_permissions"),
+		}
+		updateOfferingOptions.Updates = append(updateOfferingOptions.Updates, update)
+		hasChange = true
+	}
+	if d.HasChange("required_resources") {
+		var method string
+		if activeVersion.RequiredResources == nil {
+			method = "add"
+		} else {
+			method = "replace"
+		}
+		path := fmt.Sprintf("%s/required_resources", pathToVersion)
+		update := catalogmanagementv1.JSONPatchOperation{
+			Op:    &method,
+			Path:  &path,
+			Value: d.Get("required_resources"),
 		}
 		updateOfferingOptions.Updates = append(updateOfferingOptions.Updates, update)
 		hasChange = true

--- a/ibm/service/catalogmanagement/resource_ibm_cm_version_test.go
+++ b/ibm/service/catalogmanagement/resource_ibm_cm_version_test.go
@@ -240,6 +240,10 @@ func testAccCheckIBMCmVersionComplexConfig(zipurl string, targetVersion string, 
 					}
 				}
 			}
+			required_resources {
+				type = "terraformVersion"
+				value = "1.5"
+			}
 		}
 	`, zipurl, targetVersion, usageText, installInstructions, iamPermissionServiceNameOne, iamPermissionsRoleCRNsOne, iamPermissionServiceNameTwo, iamPermissionsRoleCRNsTwo, featureTitleOne, featureDescriptionOne, featureTitleTwo, featureDescriptionTwo, archDiagDesc, archDiagCaption, archDiagType, archDiagURL)
 }

--- a/website/docs/r/cm_version.html.markdown
+++ b/website/docs/r/cm_version.html.markdown
@@ -163,6 +163,10 @@ Nested scheme for **pre_install**:
 	* `script` - (Optional, String) Optional script that needs to be run post any pre-condition script.
 	* `script_permission` - (Optional, String) Optional iam permissions that are required on the target cluster to run this script.
 * `product_kind` - (Optional, Forces new resource, String) Optional product kind for the software being onboarded.  Valid values are software, module, or solution.  Default value is software.
+* `required_resources` - (Optional, List) Resource requirments for installation.
+Nested scheme for **required_resources**:
+	* `type` - (Optional, String) Type of requirement.
+	* `value` - (Optional, String) mem, disk, cores, and nodes can be parsed as an int.  targetVersion will be a semver range value..
 * `sha` - (Optional, Forces new resource, String) SHA256 fingerprint of the image file. Required for virtual server image for VPC.
 * `solution_info` - (Optional, List) Version Solution Information.  Only supported for Product kind Solution.
 Nested scheme for **solution_info**:


### PR DESCRIPTION
PR to remove deprecated catalog management offering fields.  Newest SDK doesn't support these values anymore so they need to be removed.
<!--- See what makes a good Pull Request at : https://github.com/IBM-Cloud/terraform-provider-ibm/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->

Output from acceptance testing:

```
make testacc TESTARGS='-run=TestAccIBMCmOfferingSimpleArgs'
TF_ACC=1 go test $(go list ./... |grep -v 'vendor') -v -run=TestAccIBMCmOfferingSimpleArgs -timeout 700m
=== RUN   TestAccIBMCmOfferingSimpleArgs
--- PASS: TestAccIBMCmOfferingSimpleArgs (33.84s)

make testacc TESTARGS='-run=TestAccIBMCmOfferingDataSourceSimpleArgs'
TF_ACC=1 go test $(go list ./... |grep -v 'vendor') -v -run=TestAccIBMCmOfferingDataSourceSimpleArgs -timeout 700m
=== RUN   TestAccIBMCmOfferingDataSourceSimpleArgs
--- PASS: TestAccIBMCmOfferingDataSourceSimpleArgs (24.91s)
```
