### PR TITLE
chore: Adding  default prefixfiletr for TGW connection resource  depe…

### DIFF
--- a/ibm/service/transitgateway/data_source_ibm_tg_gateway.go
+++ b/ibm/service/transitgateway/data_source_ibm_tg_gateway.go
@@ -139,6 +139,13 @@ func DataSourceIBMTransitGateway() *schema.Resource {
 							Type:     schema.TypeString,
 							Computed: true,
 						},
+						tgDefaultPrefixFilter: {
+							Type:         schema.TypeString,
+							Optional:     true,
+							Computed:     true,
+							ValidateFunc: validate.InvokeValidator("ibm_tg_connection_prefix_filter", tgAction),
+							Description:  "Whether to permit or deny the prefix filter",
+						},
 					},
 				},
 			},
@@ -283,6 +290,9 @@ func dataSourceIBMTransitGatewayConnectionsRead(d *schema.ResourceData, meta int
 			}
 			if instance.Status != nil {
 				tgConn[tgConnectionStatus] = *instance.Status
+			}
+			if instance.PrefixFiltersDefault != nil {
+				tgConn[tgDefaultPrefixFilter] = *instance.PrefixFiltersDefault
 			}
 
 			connections = append(connections, tgConn)

--- a/website/docs/d/tg_gateway.html.markdown
+++ b/website/docs/d/tg_gateway.html.markdown
@@ -20,13 +20,11 @@ resource "ibm_tg_gateway" "new_tg_gw" {
   global         = true
   resource_group = "30951d2dff914dafb26455a88c0c0092"
 }
-
 data "ibm_tg_gateway" "ds_tggateway" {
   name = ibm_tg_gateway.new_tg_gw.name
 }
 ```
 ---
-
 ## Argument reference
 Review the argument references that you can specify for your data source. 
 

--- a/website/docs/d/tg_gateway.html.markdown
+++ b/website/docs/d/tg_gateway.html.markdown
@@ -1,4 +1,3 @@
----
 
 subcategory: "Transit Gateway"
 layout: "ibm"
@@ -13,6 +12,7 @@ Retrieve information of an existing IBM Cloud infrastructure transit gateway as 
 
 ## Example usage
 
+---
 ```terraform
 resource "ibm_tg_gateway" "new_tg_gw" {
   name           = "transit-gateway-1"
@@ -25,6 +25,7 @@ data "ibm_tg_gateway" "ds_tggateway" {
   name = ibm_tg_gateway.new_tg_gw.name
 }
 ```
+---
 
 ## Argument reference
 Review the argument references that you can specify for your data source. 
@@ -63,3 +64,4 @@ In addition to the argument reference list, you can access the following attribu
   - `zone` - (String) The location of the GRE tunnel. This field only applies to network type `gre_tunnel` and `unbound_gre_tunnel` connections.
 - `status` - (String) The gateway status.
 - `updated_at` - (Timestamp) The date and time resource is last updated.
+- `default_prefix_filter` - (String) Whether to permit or deny the prefix filter, Default value for action for prefix filters

--- a/website/docs/r/tg_connection.html.markdown
+++ b/website/docs/r/tg_connection.html.markdown
@@ -1,4 +1,4 @@
----
+
 subcategory: "Transit Gateway"
 layout: "ibm"
 page_title: "IBM : tg_connection"
@@ -11,6 +11,7 @@ Create, update and delete for the transit gateway's connection resource. For mor
 
 ## Example usage
 
+---
 ```terraform
 resource "ibm_tg_connection" "test_ibm_tg_connection" {
   gateway      = ibm_tg_gateway.test_tg_gateway.id
@@ -20,6 +21,7 @@ resource "ibm_tg_connection" "test_ibm_tg_connection" {
 }
   
 ```
+---
 
 ## Argument reference
 Review the argument references that you can specify for your resource. 
@@ -37,6 +39,7 @@ Review the argument references that you can specify for your resource.
 - `remote_gateway_ip` - (Optional, Forces new resource, String) - The remote gateway IP address. This field only applies to network type `gre_tunnel` and `unbound_gre_tunnel` connections.
 - `remote_tunnel_ip` - (Optional, Forces new resource, String) - The remote tunnel IP address. This field only applies to network type `gre_tunnel` and `unbound_gre_tunnel` connections.
 - `zone` - (Optional, Forces new resource, String) - The location of the GRE tunnel. This field only applies to network type `gre_tunnel` and `unbound_gre_tunnel` connections.
+- `default_prefix_filter` - (Optinal, String) Whether to permit or deny the prefix filter
 
 ## Attribute reference
 
@@ -60,7 +63,9 @@ The `ibm_tg_connection` resource can be imported by using transit gateway ID and
 
 **Example**
 
+---
 ```
 $ terraform import ibm_tg_connection.example 5ffda12064634723b079acdb018ef308/cea6651a-bd0a-4438-9f8a-a0770bbf3ebb
 
 ```
+---


### PR DESCRIPTION
…ndency:none

<!--- See what makes a good Pull Request at : https://github.com/IBM-Cloud/terraform-provider-ibm/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
=== RUN   TestAccIBMTransitGatewayConnection_basic
2024-06-10 14:24:09.574989 I | Inside testAccCheckIBMTransitGatewayConnectionExists :  


--- PASS: TestAccIBMTransitGatewayConnection_basic (264.31s)
PASS
ok  	github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/transitgateway	267.490s

=== RUN   TestAccIBMTransitGatewayDataSource_basic
--- PASS: TestAccIBMTransitGatewayDataSource_basic (340.93s)
PASS
ok  	github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/transitgateway	343.992s
sushmitham@sushmithas-MacBook-Pro terraform-provider-ibm % 
...
```
