### PR TITLE
Respect store_value argument when creating apikey for ServiceId #4615

### DIFF
--- a/ibm/service/iamidentity/resource_ibm_iam_service_api_key.go
+++ b/ibm/service/iamidentity/resource_ibm_iam_service_api_key.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2017, 2021 All Rights Reserved.
+// Copyright IBM Corp. 2017, 2024 All Rights Reserved.
 // Licensed under the Mozilla Public License v2.0
 
 package iamidentity
@@ -75,6 +75,7 @@ func ResourceIBMIAMServiceAPIKey() *schema.Resource {
 			"store_value": {
 				Type:             schema.TypeBool,
 				Optional:         true,
+				Default:          true,
 				DiffSuppressFunc: flex.ApplyOnce,
 				Description:      "Boolean value deciding whether API key value is retrievable in the future",
 			},
@@ -171,7 +172,7 @@ func resourceIBMIAMServiceAPIkeyCreate(d *schema.ResourceData, meta interface{})
 		createAPIKeyOptions.Apikey = &apikeyString
 	}
 
-	if strvalue, ok := d.GetOk("store_value"); ok {
+	if strvalue := d.Get("store_value"); strvalue != nil {
 		value := strvalue.(bool)
 		createAPIKeyOptions.StoreValue = &value
 	}


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/IBM-Cloud/terraform-provider-ibm/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #4615 

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TEST=./ibm/service/iamidentity/resource_ibm_iam_service_api_key_test.go
=== RUN   TestAccIBMIAMServiceAPIKey_Basic
--- PASS: TestAccIBMIAMServiceAPIKey_Basic (109.01s)
=== RUN   TestAccIBMIAMServiceAPIKey_doNotStoreApikeyValue
--- PASS: TestAccIBMIAMServiceAPIKey_doNotStoreApikeyValue (44.86s)
=== RUN   TestAccIBMIAMServiceAPIKey_import
--- PASS: TestAccIBMIAMServiceAPIKey_import (46.24s)
PASS
ok  	command-line-arguments	201.598s
```
