### PR TITLE
feat: add build-local target for easing local development

### DIFF
--- a/scripts/post-build.sh
+++ b/scripts/post-build.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+
+# Read the VERSION argument
+VERSION=$1
+
+# Colors and formatting
+BOLD="\033[1m"
+CYAN="\033[0;36m"
+GREEN="\033[0;32m"
+RESET="\033[0m"
+
+# Determine the correct home directory and terraform plugin path based on the OS
+if [[ "$OSTYPE" == "linux-gnu"* || "$OSTYPE" == "darwin"* ]]; then
+  # Linux or macOS
+  TERRAFORM_HOME="$HOME/.terraform.d/plugins"
+  TERRAFORM_RC="$HOME/.terraformrc"
+elif [[ "$OSTYPE" == "cygwin" || "$OSTYPE" == "msys" || "$OSTYPE" == "win32" ]]; then
+  # Windows
+  TERRAFORM_HOME="$APPDATA/terraform.d/plugins"
+  TERRAFORM_RC="$APPDATA/terraform.rc"
+else
+  echo -e "${RED}Unsupported OS type: $OSTYPE${RESET}"
+  exit 1
+fi
+
+# Update the terraform.rc or .terraformrc file using echo
+echo -e "\n${GREEN}==> Updating $TERRAFORM_RC file...${RESET}"
+cat <<EOL > "$TERRAFORM_RC"
+provider_installation {
+    filesystem_mirror {
+        path    = "$TERRAFORM_HOME"
+        include = ["ibm-cloud/ibm"]
+    }
+    direct {
+        include = ["*/*"]
+    }
+}
+EOL
+
+# Print the instructions for updating the Terraform example
+echo -e "\n${CYAN}${BOLD}⬇ Add the following to your Terraform configuration:${RESET}\n"
+echo -e "terraform {"
+echo -e "  required_providers {"
+echo -e "    ibm = {"
+echo -e "      source  = \"${CYAN}IBM-Cloud/ibm${RESET}\""
+echo -e "      version = \"${CYAN}$VERSION${RESET}\""
+echo -e "    }"
+echo -e "  }"
+echo -e "}\n"


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/IBM-Cloud/terraform-provider-ibm/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

- Add new target build-local to the Makefile for building the provider locally.
- Invoke post-build.sh script after the local build process to handle post-build tasks.
- Ensure cross-platform compatibility by setting appropriate paths for:
    - Linux and macOS: $HOME/.terraform.d/plugins and $HOME/.terraformrc.
    - Windows: %APPDATA%/terraform.d/plugins and %APPDATA%/terraform.rc.
- Update the Terraform configuration file based on the operating system.
- Provide clear instructions for updating the Terraform configuration.

Output from make build-local:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make build-local

==> Checking that code complies with gofmt requirements...
go vet .
go install
mkdir -p /Users/shuaib/.terraform.d/plugins/registry.terraform.io/ibm-cloud/ibm/0.0.1/darwin_arm64
mv /Users/shuaib/go/bin/terraform-provider-ibm /Users/shuaib/.terraform.d/plugins/registry.terraform.io/ibm-cloud/ibm/0.0.1/darwin_arm64/terraform-provider-ibm_v0.0.1
./scripts/post-build.sh 0.0.1

==> Updating /Users/shuaib/.terraformrc file...

⬇ Add the following to your Terraform configuration:

terraform {
  required_providers {
    ibm = {
      source  = "IBM-Cloud/ibm"
      version = "0.0.1"
    }
  }
}
...
```
