### PR TITLE
Fix policy references bug in AG templates

### DIFF
--- a/ibm/service/iamaccessgroup/resource_ibm_iam_access_group_template.go
+++ b/ibm/service/iamaccessgroup/resource_ibm_iam_access_group_template.go
@@ -238,7 +238,7 @@ func ResourceIBMIAMAccessGroupTemplate() *schema.Resource {
 				},
 			},
 			"policy_template_references": {
-				Type:        schema.TypeList,
+				Type:        schema.TypeSet,
 				Optional:    true,
 				ForceNew:    true,
 				Description: "References to policy templates assigned to the access group template.",
@@ -367,7 +367,7 @@ func resourceIBMIAMAccessGroupTemplateCreate(context context.Context, d *schema.
 	}
 	if _, ok := d.GetOk("policy_template_references"); ok {
 		var policyTemplateReferences []iamaccessgroupsv2.PolicyTemplates
-		for _, v := range d.Get("policy_template_references").([]interface{}) {
+		for _, v := range d.Get("policy_template_references").(*schema.Set).List() {
 			value := v.(map[string]interface{})
 			policyTemplateReferencesItem, err := resourceIBMIAMAccessGroupTemplateMapToPolicyTemplates(value)
 			if err != nil {

--- a/ibm/service/iamaccessgroup/resource_ibm_iam_access_group_template_version.go
+++ b/ibm/service/iamaccessgroup/resource_ibm_iam_access_group_template_version.go
@@ -238,7 +238,7 @@ func ResourceIBMIAMAccessGroupTemplateVersion() *schema.Resource {
 				},
 			},
 			"policy_template_references": {
-				Type:        schema.TypeList,
+				Type:        schema.TypeSet,
 				Optional:    true,
 				Description: "References to policy templates assigned to the access group template.",
 				Elem: &schema.Resource{
@@ -370,7 +370,7 @@ func resourceIBMIAMAccessGroupTemplateVersionCreate(context context.Context, d *
 	}
 	if _, ok := d.GetOk("policy_template_references"); ok {
 		var policyTemplateReferences []iamaccessgroupsv2.PolicyTemplates
-		for _, v := range d.Get("policy_template_references").([]interface{}) {
+		for _, v := range d.Get("policy_template_references").(*schema.Set).List() {
 			value := v.(map[string]interface{})
 			policyTemplateReferencesItem, err := resourceIBMIAMAccessGroupTemplateVersionMapToPolicyTemplates(value)
 			if err != nil {
@@ -544,7 +544,7 @@ func resourceIBMIAMAccessGroupTemplateVersionUpdate(context context.Context, d *
 
 	if _, ok := d.GetOk("policy_template_references"); ok {
 		var policyTemplateReferences []iamaccessgroupsv2.PolicyTemplates
-		for _, v := range d.Get("policy_template_references").([]interface{}) {
+		for _, v := range d.Get("policy_template_references").(*schema.Set).List() {
 			value := v.(map[string]interface{})
 			policyTemplateReferencesItem, err := resourceIBMIAMAccessGroupTemplateVersionMapToPolicyTemplates(value)
 			if err != nil {


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/IBM-Cloud/terraform-provider-ibm/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccXXX'
```
```
=== RUN   TestAccIBMIAMAccessGroupTemplateAssignmentDataSourceBasic
--- PASS: TestAccIBMIAMAccessGroupTemplateAssignmentDataSourceBasic (19.70s)
=== RUN   TestAccIBMIAMAccessGroupTemplateVersionsDataSourceBasic
--- PASS: TestAccIBMIAMAccessGroupTemplateVersionsDataSourceBasic (18.17s)
=== RUN   TestAccIBMIAMAccessGroupTemplateAssignmentBasic
--- PASS: TestAccIBMIAMAccessGroupTemplateAssignmentBasic (216.48s)
=== RUN   TestAccIBMIAMAccessGroupTemplateBasic
--- PASS: TestAccIBMIAMAccessGroupTemplateBasic (26.00s)
=== RUN   TestAccIBMIAMAccessGroupTemplateBasicWithCommit
--- PASS: TestAccIBMIAMAccessGroupTemplateBasicWithCommit (40.32s)
=== RUN   TestAccIBMIAMAccessGroupTemplateBasicWithAssertionAndActionControl
--- PASS: TestAccIBMIAMAccessGroupTemplateBasicWithAssertionAndActionControl (26.43s)
=== RUN   TestAccIBMIAMAccessGroupTemplateVersion
--- PASS: TestAccIBMIAMAccessGroupTemplateVersion (26.12s)
=== RUN   TestAccIBMIAMAccessGroupTemplateVersionUpdateWithCommit
--- PASS: TestAccIBMIAMAccessGroupTemplateVersionUpdateWithCommit (48.47s)
PASS
ok  	github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/iamaccessgroup	423.519s
```
Terraform Example:
```
resource "ibm_iam_access_group_template" "iam_access_group_template_instance" {
    account_id          = "dfc6bf8c040145f8b4dd20973c0bdbfd"
    committed           = false
    created_at          = "2024-06-17T17:37:41.000Z"
    created_by_id       = "IBMid-668000IN8T"
    description         = "This access group template allows admin access to all IAM platform services in the account."
    href                = "https://iam.cloud.ibm.com/v1/group_templates/AccessGroupTemplateId-24db1c41-8f58-4bd3-af5c-1803ebdda969/versions/1"
    id                  = "AccessGroupTemplateId-24db1c41-8f58-4bd3-af5c-1803ebdda969/1"
    last_modified_at    = "2024-06-17T17:37:41.000Z"
    last_modified_by_id = "IBMid-668000IN8T"
    name                = "IAM Admin Group template Terraform"
    template_id         = "AccessGroupTemplateId-24db1c41-8f58-4bd3-af5c-1803ebdda969"
    version             = "1"

    group {
        description = "description"
        name        = "TestingTerraformAG1"

        action_controls {
            access {
                add = false
            }
        }

        assertions {
            action_controls {
                add    = false
                remove = false
            }
        }

        members {
            services = []
            users    = []

            action_controls {
                add    = false
                remove = false
            }
        }
    }

    policy_template_references {
        id      = "policyTemplate-0ad333cb-2a58-4ec4-a9a0-9366d91368b1"
        version = "1"
    }
    policy_template_references {
        id      = "policyTemplate-c60424a0-6935-4515-a6a3-fa585003796d"
        version = "1"
    }
    policy_template_references {
        id      = "policyTemplate-d4cf633c-c1fb-494a-ba1f-9cbe0917362e"
        version = "1"
    }
}

# ibm_iam_access_group_template_version.iam_access_group_template_version_instance:
resource "ibm_iam_access_group_template_version" "iam_access_group_template_version_instance" {
    account_id          = "dfc6bf8c040145f8b4dd20973c0bdbfd"
    committed           = false
    created_at          = "2024-06-17T17:37:41.000Z"
       created_by_id       = "IBMid-668000IN8T"
    description         = "This access group template allows admin access to all IAM platform services in the account."
    href                = "https://iam.cloud.ibm.com/v1/group_templates/AccessGroupTemplateId-24db1c41-8f58-4bd3-af5c-1803ebdda969/versions/2"
    id                  = "AccessGroupTemplateId-24db1c41-8f58-4bd3-af5c-1803ebdda969/2"
    last_modified_at    = "2024-06-17T17:47:13.000Z"
    last_modified_by_id = "IBMid-668000IN8T"
    name                = "IAM Admin Group template Terraform"
    template_id         = "AccessGroupTemplateId-24db1c41-8f58-4bd3-af5c-1803ebdda969"
    version             = "2"

    group {
        description = "description2"
        name        = "TestingTerraformAG3"

        action_controls {
            access {
                add = false
            }
        }

        assertions {
            action_controls {
                add    = false
                remove = false
            }
        }

        members {
            services = []
            users    = []

            action_controls {
                add    = false
                remove = false
            }
        }
    }

    policy_template_references {
        id      = "policyTemplate-0ad333cb-2a58-4ec4-a9a0-9366d91368b1"
        version = "1"
    }
    policy_template_references {
        id      = "policyTemplate-c60424a0-6935-4515-a6a3-fa585003796d"
        version = "1"
    }
    policy_template_references {
        id      = "policyTemplate-d4cf633c-c1fb-494a-ba1f-9cbe0917362e"
        version = "1"
    }
}

# ibm_iam_policy_template.cr_admin:
resource "ibm_iam_policy_template" "cr_admin" {
    account_id  = "dfc6bf8c040145f8b4dd20973c0bdbfd"
    committed   = true
    id          = "policyTemplate-d4cf633c-c1fb-494a-ba1f-9cbe0917362e/1"
    name        = "Container Registry Admin"
    template_id = "policyTemplate-d4cf633c-c1fb-494a-ba1f-9cbe0917362e"
    version     = "1"
    
    policy {
        description = "Enterprise Managed Policies for container registry admin"
        roles       = [
            "Administrator",
        ]
        type        = "access"

        resource {
            attributes {
                key      = "serviceName"
                operator = "stringEquals"
                value    = "container-registry"
            }
        }
    }
}

# ibm_iam_policy_template.resource_group_admin:
resource "ibm_iam_policy_template" "resource_group_admin" {
    account_id  = "dfc6bf8c040145f8b4dd20973c0bdbfd"
    committed   = true
    id          = "policyTemplate-c60424a0-6935-4515-a6a3-fa585003796d/1"
    name        = "Resource Group Admin"
    template_id = "policyTemplate-c60424a0-6935-4515-a6a3-fa585003796d"
    version     = "1"

    policy {
        description = "Enterprise Managed Policies for resource group admin"
        roles       = [
            "Administrator",
        ]
        type        = "access"

        resource {
            attributes {
                key      = "resourceType"
                operator = "stringEquals"
                value    = "resource-group"
            }
        }
    }
}

# ibm_iam_policy_template.secrets_manager_admin:
resource "ibm_iam_policy_template" "secrets_manager_admin" {
    account_id  = "dfc6bf8c040145f8b4dd20973c0bdbfd"
    committed   = true
    id          = "policyTemplate-0ad333cb-2a58-4ec4-a9a0-9366d91368b1/1"
    name        = "Secrets Manager Admin"
    template_id = "policyTemplate-0ad333cb-2a58-4ec4-a9a0-9366d91368b1"
    version     = "1"

    policy {
        description = "Enterprise Managed Policies for secrets manager admin"
        roles       = [
            "Administrator",
        ]
        type        = "access"
        
        resource {
            attributes {
                key      = "serviceName"
                operator = "stringEquals"
                value    = "secrets-manager"
            }
        }
    }
}
```
OUTPUT:
```
terraform apply    
ibm_iam_policy_template.secrets_manager_admin: Refreshing state... [id=policyTemplate-0ad333cb-2a58-4ec4-a9a0-9366d91368b1/1]
ibm_iam_policy_template.resource_group_admin: Refreshing state... [id=policyTemplate-c60424a0-6935-4515-a6a3-fa585003796d/1]
ibm_iam_policy_template.cr_admin: Refreshing state... [id=policyTemplate-d4cf633c-c1fb-494a-ba1f-9cbe0917362e/1]
ibm_iam_access_group_template.iam_access_group_template_instance: Refreshing state... [id=AccessGroupTemplateId-24db1c41-8f58-4bd3-af5c-1803ebdda969/1]
ibm_iam_access_group_template_version.iam_access_group_template_version_instance: Refreshing state... [id=AccessGroupTemplateId-24db1c41-8f58-4bd3-af5c-1803ebdda969/2]

No changes. Your infrastructure matches the configuration.

Terraform has compared your real infrastructure against your configuration and found no differences, so no changes are needed.
```