### PR TITLE
fix(MQ on Cloud): queue_manager_options data source to include whole data

### DIFF
--- a/ibm/service/mqcloud/data_source_ibm_mqcloud_queue_manager_options.go
+++ b/ibm/service/mqcloud/data_source_ibm_mqcloud_queue_manager_options.go
@@ -97,6 +97,17 @@ func dataSourceIbmMqcloudQueueManagerOptionsRead(context context.Context, d *sch
 		return flex.DiscriminatedTerraformErrorf(err, fmt.Sprintf("Error setting latest_version: %s", err), "(Data) ibm_mqcloud_queue_manager_options", "read", "set-latest_version").GetDiag()
 	}
 
+	if err = d.Set("locations", configurationOptions.Locations); err != nil {
+		return flex.DiscriminatedTerraformErrorf(err, fmt.Sprintf("Error setting locations: %s", err), "(Data) ibm_mqcloud_queue_manager_options", "read", "set-locations").GetDiag()
+	}
+
+	if err = d.Set("versions", configurationOptions.Versions); err != nil {
+		return flex.DiscriminatedTerraformErrorf(err, fmt.Sprintf("Error setting versions: %s", err), "(Data) ibm_mqcloud_queue_manager_options", "read", "set-versions").GetDiag()
+	}
+
+	if err = d.Set("sizes", configurationOptions.Sizes); err != nil {
+		return flex.DiscriminatedTerraformErrorf(err, fmt.Sprintf("Error setting sizes: %s", err), "(Data) ibm_mqcloud_queue_manager_options", "read", "set-sizes").GetDiag()
+	}
 	return nil
 }
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/IBM-Cloud/terraform-provider-ibm/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

- fix for queuemanager options data source to include latest version, versions, locations and sizes data.

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TEST=./ibm/service/mqcloud/... 
 
=== RUN   TestLoadWaitForQmStatusEnvVar
=== RUN   TestLoadWaitForQmStatusEnvVar/EnvVar_Set_To_True
=== RUN   TestLoadWaitForQmStatusEnvVar/EnvVar_Set_To_False
=== RUN   TestLoadWaitForQmStatusEnvVar/EnvVar_Not_Set
=== RUN   TestLoadWaitForQmStatusEnvVar/EnvVar_Set_To_Random_String
--- PASS: TestLoadWaitForQmStatusEnvVar (0.00s)
    --- PASS: TestLoadWaitForQmStatusEnvVar/EnvVar_Set_To_True (0.00s)
    --- PASS: TestLoadWaitForQmStatusEnvVar/EnvVar_Set_To_False (0.00s)
    --- PASS: TestLoadWaitForQmStatusEnvVar/EnvVar_Not_Set (0.00s)
    --- PASS: TestLoadWaitForQmStatusEnvVar/EnvVar_Set_To_Random_String (0.00s)
=== RUN   TestIsVersionDowngrade
=== RUN   TestIsVersionDowngrade/1.2.3_to_1.2.2
=== RUN   TestIsVersionDowngrade/1.2.3_to_1.2.4
=== RUN   TestIsVersionDowngrade/1.2.3_to_1.3.0
=== RUN   TestIsVersionDowngrade/1.2.3_to_1.2.3
=== RUN   TestIsVersionDowngrade/_to_1.0.0
=== RUN   TestIsVersionDowngrade/1.0.0_to_
=== RUN   TestIsVersionDowngrade/abc.def.ghi_to_1.2.3
--- PASS: TestIsVersionDowngrade (0.00s)
    --- PASS: TestIsVersionDowngrade/1.2.3_to_1.2.2 (0.00s)
    --- PASS: TestIsVersionDowngrade/1.2.3_to_1.2.4 (0.00s)
    --- PASS: TestIsVersionDowngrade/1.2.3_to_1.3.0 (0.00s)
    --- PASS: TestIsVersionDowngrade/1.2.3_to_1.2.3 (0.00s)
    --- PASS: TestIsVersionDowngrade/_to_1.0.0 (0.00s)
    --- PASS: TestIsVersionDowngrade/1.0.0_to_ (0.00s)
    --- PASS: TestIsVersionDowngrade/abc.def.ghi_to_1.2.3 (0.00s)
=== RUN   TestHandlePlanCheck
=== RUN   TestHandlePlanCheck/reserved-deployment
=== RUN   TestHandlePlanCheck/Basic_Plan
--- PASS: TestHandlePlanCheck (0.00s)
    --- PASS: TestHandlePlanCheck/reserved-deployment (0.00s)
    --- PASS: TestHandlePlanCheck/Basic_Plan (0.00s)
=== RUN   Test_checkSIPlan
=== RUN   Test_checkSIPlan/Cache_Hit:_Reserved_Deployment_Plan
=== RUN   Test_checkSIPlan/Cache_Hit:_Default_Plan
=== RUN   Test_checkSIPlan/Reserved_Deployment_Plan_Wildcard
=== RUN   Test_checkSIPlan/Reserved_Deployment_Plan
=== RUN   Test_checkSIPlan/Default_Plan
=== RUN   Test_checkSIPlan/fetchServicePlanFunc_Error:_Invalid_id
--- PASS: Test_checkSIPlan (0.00s)
    --- PASS: Test_checkSIPlan/Cache_Hit:_Reserved_Deployment_Plan (0.00s)
    --- PASS: Test_checkSIPlan/Cache_Hit:_Default_Plan (0.00s)
    --- PASS: Test_checkSIPlan/Reserved_Deployment_Plan_Wildcard (0.00s)
    --- PASS: Test_checkSIPlan/Reserved_Deployment_Plan (0.00s)
    --- PASS: Test_checkSIPlan/Default_Plan (0.00s)
    --- PASS: Test_checkSIPlan/fetchServicePlanFunc_Error:_Invalid_id (0.00s)
=== RUN   TestAccIbmMqcloudApplicationDataSourceBasic
=== PAUSE TestAccIbmMqcloudApplicationDataSourceBasic
=== RUN   TestDataSourceIbmMqcloudApplicationApplicationDetailsToMap
--- PASS: TestDataSourceIbmMqcloudApplicationApplicationDetailsToMap (0.00s)
=== RUN   TestAccIbmMqcloudKeystoreCertificateDataSourceBasic
=== PAUSE TestAccIbmMqcloudKeystoreCertificateDataSourceBasic
=== RUN   TestDataSourceIbmMqcloudKeystoreCertificateKeyStoreCertificateDetailsToMap
--- PASS: TestDataSourceIbmMqcloudKeystoreCertificateKeyStoreCertificateDetailsToMap (0.00s)
=== RUN   TestDataSourceIbmMqcloudKeystoreCertificateCertificateConfigurationToMap
--- PASS: TestDataSourceIbmMqcloudKeystoreCertificateCertificateConfigurationToMap (0.00s)
=== RUN   TestDataSourceIbmMqcloudKeystoreCertificateChannelsDetailsToMap
--- PASS: TestDataSourceIbmMqcloudKeystoreCertificateChannelsDetailsToMap (0.00s)
=== RUN   TestDataSourceIbmMqcloudKeystoreCertificateChannelDetailsToMap
--- PASS: TestDataSourceIbmMqcloudKeystoreCertificateChannelDetailsToMap (0.00s)
=== RUN   TestAccIbmMqcloudQueueManagerOptionsDataSourceBasic
=== PAUSE TestAccIbmMqcloudQueueManagerOptionsDataSourceBasic
=== RUN   TestAccIbmMqcloudQueueManagerStatusDataSourceBasic
=== PAUSE TestAccIbmMqcloudQueueManagerStatusDataSourceBasic
=== RUN   TestAccIbmMqcloudQueueManagerDataSourceBasic
=== PAUSE TestAccIbmMqcloudQueueManagerDataSourceBasic
=== RUN   TestAccIbmMqcloudQueueManagerDataSourceAllArgs
=== PAUSE TestAccIbmMqcloudQueueManagerDataSourceAllArgs
=== RUN   TestDataSourceIbmMqcloudQueueManagerQueueManagerDetailsToMap
--- PASS: TestDataSourceIbmMqcloudQueueManagerQueueManagerDetailsToMap (0.00s)
=== RUN   TestAccIbmMqcloudTruststoreCertificateDataSourceBasic
=== PAUSE TestAccIbmMqcloudTruststoreCertificateDataSourceBasic
=== RUN   TestDataSourceIbmMqcloudTruststoreCertificateTrustStoreCertificateDetailsToMap
--- PASS: TestDataSourceIbmMqcloudTruststoreCertificateTrustStoreCertificateDetailsToMap (0.00s)
=== RUN   TestAccIbmMqcloudUserDataSourceBasic
=== PAUSE TestAccIbmMqcloudUserDataSourceBasic
=== RUN   TestDataSourceIbmMqcloudUserUserDetailsToMap
--- PASS: TestDataSourceIbmMqcloudUserUserDetailsToMap (0.00s)
=== RUN   TestAccIbmMqcloudApplicationBasic
=== PAUSE TestAccIbmMqcloudApplicationBasic
=== RUN   TestAccIbmMqcloudKeystoreCertificateBasic
=== PAUSE TestAccIbmMqcloudKeystoreCertificateBasic
=== RUN   TestResourceIbmMqcloudKeystoreCertificateCertificateConfigurationToMap
--- PASS: TestResourceIbmMqcloudKeystoreCertificateCertificateConfigurationToMap (0.00s)
=== RUN   TestResourceIbmMqcloudKeystoreCertificateChannelsDetailsToMap
--- PASS: TestResourceIbmMqcloudKeystoreCertificateChannelsDetailsToMap (0.00s)
=== RUN   TestResourceIbmMqcloudKeystoreCertificateChannelDetailsToMap
--- PASS: TestResourceIbmMqcloudKeystoreCertificateChannelDetailsToMap (0.00s)
=== RUN   TestAccIbmMqcloudQueueManagerBasic
=== PAUSE TestAccIbmMqcloudQueueManagerBasic
=== RUN   TestAccIbmMqcloudQueueManagerAllArgs
=== PAUSE TestAccIbmMqcloudQueueManagerAllArgs
=== RUN   TestAccIbmMqcloudTruststoreCertificateBasic
=== PAUSE TestAccIbmMqcloudTruststoreCertificateBasic
=== RUN   TestAccIbmMqcloudUserBasic
=== PAUSE TestAccIbmMqcloudUserBasic
=== CONT  TestAccIbmMqcloudApplicationDataSourceBasic
=== CONT  TestAccIbmMqcloudUserDataSourceBasic
=== CONT  TestAccIbmMqcloudQueueManagerDataSourceBasic
=== CONT  TestAccIbmMqcloudTruststoreCertificateDataSourceBasic
--- PASS: TestAccIbmMqcloudUserDataSourceBasic (38.82s)
=== CONT  TestAccIbmMqcloudQueueManagerDataSourceAllArgs
--- PASS: TestAccIbmMqcloudTruststoreCertificateDataSourceBasic (43.62s)
=== CONT  TestAccIbmMqcloudQueueManagerOptionsDataSourceBasic
--- PASS: TestAccIbmMqcloudApplicationDataSourceBasic (46.03s)
=== CONT  TestAccIbmMqcloudQueueManagerStatusDataSourceBasic
--- PASS: TestAccIbmMqcloudQueueManagerStatusDataSourceBasic (30.96s)
=== CONT  TestAccIbmMqcloudQueueManagerAllArgs
--- PASS: TestAccIbmMqcloudQueueManagerOptionsDataSourceBasic (39.52s)
=== CONT  TestAccIbmMqcloudUserBasic
--- PASS: TestAccIbmMqcloudUserBasic (42.76s)
=== CONT  TestAccIbmMqcloudTruststoreCertificateBasic
--- PASS: TestAccIbmMqcloudTruststoreCertificateBasic (36.58s)
=== CONT  TestAccIbmMqcloudKeystoreCertificateBasic
--- PASS: TestAccIbmMqcloudKeystoreCertificateBasic (51.55s)
=== CONT  TestAccIbmMqcloudQueueManagerBasic
--- PASS: TestAccIbmMqcloudQueueManagerDataSourceBasic (421.14s)
=== CONT  TestAccIbmMqcloudApplicationBasic
--- PASS: TestAccIbmMqcloudApplicationBasic (33.95s)
=== CONT  TestAccIbmMqcloudKeystoreCertificateDataSourceBasic
--- PASS: TestAccIbmMqcloudQueueManagerDataSourceAllArgs (417.95s)
--- PASS: TestAccIbmMqcloudKeystoreCertificateDataSourceBasic (55.94s)
--- PASS: TestAccIbmMqcloudQueueManagerBasic (400.65s)
--- PASS: TestAccIbmMqcloudQueueManagerAllArgs (749.67s)
PASS
ok      github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/mqcloud  828.172s
...
```
