### PR TITLE
feat(Catalog Management): can create catalog data source with id or label

### DIFF
--- a/ibm/service/catalogmanagement/data_source_ibm_cm_catalog_test.go
+++ b/ibm/service/catalogmanagement/data_source_ibm_cm_catalog_test.go
@@ -40,7 +40,7 @@ func TestAccIBMCmCatalogDataSourceSimpleArgs(t *testing.T) {
 			resource.TestStep{
 				Config: testAccCheckIBMCmCatalogDataSourceConfig(catalogLabel, catalogShortDescription),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttrSet("data.ibm_cm_catalog.cm_catalog", "catalog_identifier"),
+					resource.TestCheckResourceAttrSet("data.ibm_cm_catalog.cm_catalog", "id"),
 					resource.TestCheckResourceAttrSet("data.ibm_cm_catalog.cm_catalog", "label"),
 					resource.TestCheckResourceAttrSet("data.ibm_cm_catalog.cm_catalog", "short_description"),
 				),
@@ -71,7 +71,7 @@ func testAccCheckIBMCmCatalogDataSourceConfig(catalogLabel string, catalogShortD
 		}
 
 		data "ibm_cm_catalog" "cm_catalog" {
-			catalog_identifier = ibm_cm_catalog.cm_catalog.id
+			label = ibm_cm_catalog.cm_catalog.label
 		}
 	`, catalogLabel, catalogShortDescription)
 }

--- a/website/docs/d/cm_catalog.html.markdown
+++ b/website/docs/d/cm_catalog.html.markdown
@@ -22,7 +22,8 @@ data "ibm_cm_catalog" "cm_catalog" {
 
 Review the argument reference that you can specify for your data source.
 
-* `catalog_identifier` - (Required, Forces new resource, String) Catalog identifier.
+* `catalog_identifier` - (Optional, String) Catalog identifier.
+* `label` - (Optional, String) Catalog label.
 
 ## Attribute Reference
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/IBM-Cloud/terraform-provider-ibm/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #5434

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
TF_ACC=1 go test $(go list ./... |grep -v 'vendor') -v -run TestAccIBMCmCatalogDataSourceSimpleArgs -timeout 700m
=== RUN   TestAccIBMCmCatalogDataSourceSimpleArgs
--- PASS: TestAccIBMCmCatalogDataSourceSimpleArgs (21.18s)
```
