### PR TITLE
Added new service Logs Routing to IBM Terraform Provider

### DIFF
--- a/examples/ibm-logs-routing/README.md
+++ b/examples/ibm-logs-routing/README.md
@@ -49,9 +49,9 @@ resource "ibm_logs_router_tenant" "logs_router_tenant_instance" {
 | targets | List of targets. | `list()` | true |
 | targets.log_sink_crn | CRN of the Mezmo or Cloud Logs instance to sends logs to | `string` | true |
 | targets.name | The name for this target. The name is regionally unique for this tenant. | `string` | true |
-| targets.parameters.host | Host name of the log-sin | `string` | true |
+| targets.parameters.host | Host name of the log-sink | `string` | true |
 | targets.parameters.port | Network port of the log-sink | `integer` | true |
-| targets.parameters.access_credential | Secret to connect to the Mezmo log sink. This is not required for log sink of type Cloud Logs | `string` | false |
+| targets.parameters.access_credential | Secret to connect to the Mezmo log-sink. This is not required for log-sink of type Cloud Logs | `string` | false |
 
 #### Outputs
 
@@ -106,14 +106,6 @@ data "ibm_logs_router_targets" "logs_router_targets_instance" {
 | Name | Description |
 |------|-------------|
 | targets | List of targets of a tenant. |
-
-## Assumptions
-
-1. TODO
-
-## Notes
-
-1. TODO
 
 ## Requirements
 

--- a/examples/ibm-logs-routing/README.md
+++ b/examples/ibm-logs-routing/README.md
@@ -1,0 +1,128 @@
+# Examples for IBM Cloud Logs Routing
+
+These examples illustrate how to use the resources and data sources associated with IBM Cloud Logs Routing.
+
+The following resources are supported:
+* ibm_logs_router_tenant
+
+The following data sources are supported:
+* ibm_logs_router_tenants
+* ibm_logs_router_targets
+
+## Usage
+
+To run this example, execute the following commands:
+
+```bash
+$ terraform init
+$ terraform plan
+$ terraform apply
+```
+
+Run `terraform destroy` when you don't need these resources.
+
+## IBM Cloud Logs Routing resources
+
+### Resource: ibm_logs_router_tenant
+
+```hcl
+resource "ibm_logs_router_tenant" "logs_router_tenant_instance" {
+  name = var.logs_router_tenant_name
+  targets {
+    log_sink_crn = "crn:v1:bluemix:public:logdna:eu-de:a/7246b8fa0a174a71899f5affa4f18d78:3517d2ed-9429-af34-ad52-34278391cbc8::"
+    name = "my-log-sink"
+    parameters {
+      host = "www.example.com"
+      port = 1
+      access_credential = "new-credential"
+    }
+  }
+}
+```
+
+#### Inputs
+
+| Name | Description | Type | Required |
+|------|-------------|------|---------|
+| ibmcloud\_api\_key | IBM Cloud API key | `string` | true |
+| name | The name for this tenant. The name is regionally unique across all tenants in the account. | `string` | true |
+| targets | List of targets. | `list()` | true |
+| targets.log_sink_crn | CRN of the Mezmo or Cloud Logs instance to sends logs to | `string` | true |
+| targets.name | The name for this target. The name is regionally unique for this tenant. | `string` | true |
+| targets.parameters.host | Host name of the log-sin | `string` | true |
+| targets.parameters.port | Network port of the log-sink | `integer` | true |
+| targets.parameters.access_credential | Secret to connect to the Mezmo log sink. This is not required for log sink of type Cloud Logs | `string` | false |
+
+#### Outputs
+
+| Name | Description |
+|------|-------------|
+| created_at | Time stamp the tenant was originally created. |
+| updated_at | Time stamp the tenant was last updated. |
+| crn | Cloud resource name of the tenant. |
+| etag | Resource version identifier. |
+| targets | List of targets. |
+
+## IBM Cloud Logs Routing data sources
+
+### Data source: ibm_logs_router_tenants
+
+```hcl
+data "ibm_logs_router_tenants" "logs_router_tenants_instance" {
+  name = var.logs_router_tenants_name
+}
+```
+
+#### Inputs
+
+| Name | Description | Type | Required |
+|------|-------------|------|---------|
+| name | Optional: The name of a tenant. | `string` | true |
+
+#### Outputs
+
+| Name | Description |
+|------|-------------|
+| tenants | List of tenants in the account. |
+
+### Data source: ibm_logs_router_targets
+
+```hcl
+data "ibm_logs_router_targets" "logs_router_targets_instance" {
+  tenant_id = var.logs_router_targets_tenant_id
+  name = var.logs_router_targets_name
+}
+```
+
+#### Inputs
+
+| Name | Description | Type | Required |
+|------|-------------|------|---------|
+| tenant_id | The instance ID of the tenant. | `` | true |
+| name | Optional: Name of the tenant target. | `string` | false |
+
+#### Outputs
+
+| Name | Description |
+|------|-------------|
+| targets | List of targets of a tenant. |
+
+## Assumptions
+
+1. TODO
+
+## Notes
+
+1. TODO
+
+## Requirements
+
+| Name | Version |
+|------|---------|
+| terraform | ~> 0.12 |
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| ibm | 1.13.1 |

--- a/examples/ibm-logs-routing/main.tf
+++ b/examples/ibm-logs-routing/main.tf
@@ -1,0 +1,36 @@
+provider "ibm" {
+  ibmcloud_api_key = var.ibmcloud_api_key
+  region = "us-south"
+}
+
+// Provision logs_router_tenant resource instance
+resource "ibm_logs_router_tenant" "logs_router_tenant_instance" {
+  name = var.logs_router_tenant_name
+  targets {
+    log_sink_crn = "crn:v1:bluemix:public:logdna:eu-de:a/7246b8fa0a174a71899f5affa4f18d78:3517d2ed-9429-af34-ad52-34278391cbc8::"
+    name = "my-logdna-target"
+    parameters {
+      host = "www.example-1.com"
+      port = 80
+      access_credential = "new-cred"
+    }
+  }
+    targets {
+    log_sink_crn = "crn:v1:bluemix:public:logs:eu-de:a/7246b8fa0a174a71899f5affa4f18d78:3517d2ed-9429-af34-ad52-34278391cbc8::"
+    name = "my-cloud-logs-target"
+    parameters {
+      host = "www.example-2.com"
+      port = 80
+    }
+  }
+}
+
+// Create logs_router_tenants data source
+data "ibm_logs_router_tenants" "logs_router_tenants_instance" {
+  name = ibm_logs_router_tenant.logs_router_tenant_instance_both.name
+}
+
+// Create logs_router_targets data source
+data "ibm_logs_router_targets" "logs_router_targets_instance" {
+  tenant_id = ibm_logs_router_tenant.logs_router_tenant_instance_both.id
+}

--- a/examples/ibm-logs-routing/outputs.tf
+++ b/examples/ibm-logs-routing/outputs.tf
@@ -1,0 +1,12 @@
+// This output allows logs_router_tenant data to be referenced by other resources and the terraform CLI
+// Modify this output if only certain data should be exposed
+output "ibm_logs_router_tenant" {
+  value       = ibm_logs_router_tenant.logs_router_tenant_instance
+  description = "logs_router_tenant resource instance"
+}
+
+output "ibm_logs_router_tenants" {
+  value       = data.ibm_logs_router_tenants.logs_router_tenants_instance
+  description = "logs_router_tenants"
+}
+

--- a/examples/ibm-logs-routing/variables.tf
+++ b/examples/ibm-logs-routing/variables.tf
@@ -1,0 +1,11 @@
+variable "ibmcloud_api_key" {
+  description = "IBM Cloud API key"
+  type        = string
+}
+
+// Resource arguments for logs_router_tenant
+variable "logs_router_tenant_name" {
+  description = "The name for this tenant. The name is regionally unique across all tenants in the account."
+  type        = string
+  default     = "my-logging-tenant"
+}

--- a/examples/ibm-logs-routing/versions.tf
+++ b/examples/ibm-logs-routing/versions.tf
@@ -1,0 +1,9 @@
+terraform {
+  required_version = ">= 1.0"
+  required_providers {
+    ibm = {
+      source = "IBM-Cloud/ibm"
+      version = "1.52.0-beta0"
+    }
+  }
+}

--- a/go.mod
+++ b/go.mod
@@ -25,6 +25,7 @@ require (
 	github.com/IBM/ibm-hpcs-uko-sdk v0.0.20-beta
 	github.com/IBM/keyprotect-go-client v0.14.0
 	github.com/IBM/logs-go-sdk v0.3.0
+	github.com/IBM/logs-router-go-sdk v1.0.3
 	github.com/IBM/networking-go-sdk v0.48.0
 	github.com/IBM/platform-services-go-sdk v0.64.4
 	github.com/IBM/project-go-sdk v0.3.5

--- a/go.sum
+++ b/go.sum
@@ -136,6 +136,8 @@ github.com/IBM/keyprotect-go-client v0.14.0 h1:GqgK3BdczA/w7+B1RxEPLya0w9S/ZXi5Y
 github.com/IBM/keyprotect-go-client v0.14.0/go.mod h1:cAt714Vnwnd03mmkBHHSJlDNRVthdRmJB6RePd4/B8Q=
 github.com/IBM/logs-go-sdk v0.3.0 h1:FHzTCCMyp9DvQGXgkppzcOPywC4ggt7x8xu0MR5h8xI=
 github.com/IBM/logs-go-sdk v0.3.0/go.mod h1:yv/GCXC4/p+MZEeXl4xjZAOMvDAVRwu61WyHZFKFXQM=
+github.com/IBM/logs-router-go-sdk v1.0.3 h1:VO64OpANNouxS/0kvUeBpENKWxYx3TYnoNzW8OycMb0=
+github.com/IBM/logs-router-go-sdk v1.0.3/go.mod h1:tCN2vFgu5xG0ob9iJcxi5M4bJ6mWmu3nhmRPnvlwev0=
 github.com/IBM/mqcloud-go-sdk v0.1.0 h1:fWt4uisg5GbbsfNmAxx5/6c5gQIPM+VrEsTtnimELeA=
 github.com/IBM/mqcloud-go-sdk v0.1.0/go.mod h1:LesMQlKHXvdks4jqQLZH7HfATY5lvTzHuwQU5+y7b2g=
 github.com/IBM/networking-go-sdk v0.48.0 h1:CyClGO1FhugemuCRiJvXo03Nup6JbReu7MK4vH6ITZw=

--- a/ibm/provider/provider.go
+++ b/ibm/provider/provider.go
@@ -47,6 +47,7 @@ import (
 	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/kms"
 	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/kubernetes"
 	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/logs"
+	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/logsrouting"
 	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/metricsrouter"
 	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/mqcloud"
 	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/pag"
@@ -959,6 +960,10 @@ func Provider() *schema.Provider {
 			"ibm_logs_data_usage_metrics": logs.AddLogsInstanceFields(logs.DataSourceIbmLogsDataUsageMetrics()),
 			"ibm_logs_enrichments":        logs.AddLogsInstanceFields(logs.DataSourceIbmLogsEnrichments()),
 			"ibm_logs_data_access_rules":  logs.AddLogsInstanceFields(logs.DataSourceIbmLogsDataAccessRules()),
+
+			// Logs Router Service
+			"ibm_logs_router_tenants": logsrouting.DataSourceIBMLogsRouterTenants(),
+			"ibm_logs_router_targets": logsrouting.DataSourceIBMLogsRouterTargets(),
 		},
 
 		ResourcesMap: map[string]*schema.Resource{
@@ -1536,6 +1541,9 @@ func Provider() *schema.Provider {
 			"ibm_logs_data_usage_metrics": logs.AddLogsInstanceFields(logs.ResourceIbmLogsDataUsageMetrics()),
 			"ibm_logs_enrichment":         logs.AddLogsInstanceFields(logs.ResourceIbmLogsEnrichment()),
 			"ibm_logs_data_access_rule":   logs.AddLogsInstanceFields(logs.ResourceIbmLogsDataAccessRule()),
+
+			// Logs Router Service
+			"ibm_logs_router_tenant": logsrouting.ResourceIBMLogsRouterTenant(),
 		},
 
 		ConfigureFunc: providerConfigure,
@@ -1982,6 +1990,9 @@ func Validator() validate.ValidatorDict {
 				"ibm_logs_dashboard_folder": logs.ResourceIbmLogsDashboardFolderValidator(),
 				"ibm_logs_enrichment":       logs.ResourceIbmLogsEnrichmentValidator(),
 				"ibm_logs_data_access_rule": logs.ResourceIbmLogsDataAccessRuleValidator(),
+
+				// Added for Logs Router Service
+				"ibm_logs_router_tenant": logsrouting.ResourceIBMLogsRouterTenantValidator(),
 			},
 			DataSourceValidatorDictionary: map[string]*validate.ResourceValidator{
 				"ibm_is_subnet":                     vpc.DataSourceIBMISSubnetValidator(),

--- a/ibm/service/logsrouting/README.md
+++ b/ibm/service/logsrouting/README.md
@@ -1,0 +1,11 @@
+# Logs Routing Terraform IBM Provider 
+<!-- markdownlint-disable MD026 -->
+This area is primarily for IBM provider contributors and maintainers. For information on _using_ Terraform and the IBM provider, see the links below.
+
+
+## Handy Links
+* [Find out about contributing](../../../CONTRIBUTING.md) to the IBM provider!
+* IBM Provider Docs: [Home](https://registry.terraform.io/providers/IBM-Cloud/ibm/latest/docs)
+* IBM Provider Docs: [One of the  resources](https://registry.terraform.io/providers/IBM-Cloud/ibm/latest/docs/resources/ibm_logs_router_tenant)
+* IBM API Docs: [IBM API Docs for IBM Cloud Logs Router](https://cloud.ibm.com/apidocs/logs-router-service-api/logs-router-v1)
+* IBM  SDK: [IBM SDK for IBM Cloud Logs Router](https://github.com/IBM/logs-router-go-sdk)

--- a/ibm/service/logsrouting/data_source_ibm_logs-router_targets.go
+++ b/ibm/service/logsrouting/data_source_ibm_logs-router_targets.go
@@ -1,0 +1,247 @@
+// Copyright IBM Corp. 2024 All Rights Reserved.
+// Licensed under the Mozilla Public License v2.0
+
+/*
+ * IBM OpenAPI Terraform Generator Version: 3.90.1-64fd3296-20240515-180710
+ */
+
+package logsrouting
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"time"
+
+	"github.com/go-openapi/strfmt"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/conns"
+	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/flex"
+	"github.com/IBM/go-sdk-core/v5/core"
+	"github.com/IBM/logs-router-go-sdk/ibmcloudlogsroutingv0"
+)
+
+func DataSourceIBMLogsRouterTargets() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceIBMLogsRouterTargetsRead,
+
+		Schema: map[string]*schema.Schema{
+			"tenant_id": &schema.Schema{
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "The instance ID of the tenant.",
+			},
+			"name": &schema.Schema{
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "Optional: Name of the tenant target.",
+			},
+			"targets": &schema.Schema{
+				Type:        schema.TypeList,
+				Computed:    true,
+				Description: "List of target of a tenant.",
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"id": &schema.Schema{
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "Unique ID of the target.",
+						},
+						"log_sink_crn": &schema.Schema{
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "Cloud resource name of the log-sink target instance.",
+						},
+						"name": &schema.Schema{
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "The name for this tenant target. The name is unique across all targets for this tenant.",
+						},
+						"etag": &schema.Schema{
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "Resource version identifier.",
+						},
+						"type": &schema.Schema{
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "Type of log-sink. Identical to the <code>service-name</code> segment of <code>log_sink_crn</code>.",
+						},
+						"created_at": &schema.Schema{
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "Time stamp the target was originally created.",
+						},
+						"updated_at": &schema.Schema{
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "Time stamp the target was last updated.",
+						},
+						"parameters": &schema.Schema{
+							Type:        schema.TypeList,
+							Computed:    true,
+							Description: "List of properties returned from a successful list operation for a log-sink of type IBM Log Analysis (logdna).",
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"host": &schema.Schema{
+										Type:        schema.TypeString,
+										Computed:    true,
+										Description: "Host name of the log-sink.",
+									},
+									"port": &schema.Schema{
+										Type:        schema.TypeInt,
+										Computed:    true,
+										Description: "Network port of the log-sink.",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func dataSourceIBMLogsRouterTargetsRead(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	ibmCloudLogsRoutingClient, err := meta.(conns.ClientSession).IBMCloudLogsRoutingV0()
+	if err != nil {
+		// Error is coming from SDK client, so it doesn't need to be discriminated.
+		tfErr := flex.TerraformErrorf(err, err.Error(), "(Data) ibm_logs_router_targets", "read")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
+	}
+
+	listTenantTargetsOptions := &ibmcloudlogsroutingv0.ListTenantTargetsOptions{}
+
+	listTenantTargetsOptions.SetTenantID(core.UUIDPtr(strfmt.UUID(d.Get("tenant_id").(string))))
+	if _, ok := d.GetOk("name"); ok {
+		listTenantTargetsOptions.SetName(d.Get("name").(string))
+	}
+
+	targetTypeCollection, _, err := ibmCloudLogsRoutingClient.ListTenantTargetsWithContext(context, listTenantTargetsOptions)
+	if err != nil {
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("ListTenantTargetsWithContext failed: %s", err.Error()), "(Data) ibm_logs_router_targets", "read")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
+	}
+
+	d.SetId(dataSourceIBMLogsRouterTargetsID(d))
+
+	targets := []map[string]interface{}{}
+	if targetTypeCollection.Targets != nil {
+		for _, modelItem := range targetTypeCollection.Targets {
+			modelMap, err := DataSourceIBMLogsRouterTargetsTargetTypeToMap(modelItem)
+			if err != nil {
+				return flex.DiscriminatedTerraformErrorf(err, err.Error(), "(Data) ibm_logs_router_targets", "read", "targets-to-map").GetDiag()
+			}
+			targets = append(targets, modelMap)
+		}
+	}
+	if err = d.Set("targets", targets); err != nil {
+		return flex.DiscriminatedTerraformErrorf(err, fmt.Sprintf("Error setting targets: %s", err), "(Data) ibm_logs_router_targets", "read", "set-targets").GetDiag()
+	}
+
+	return nil
+}
+
+// dataSourceIBMLogsRouterTargetsID returns a reasonable ID for the list.
+func dataSourceIBMLogsRouterTargetsID(d *schema.ResourceData) string {
+	return time.Now().UTC().String()
+}
+
+func DataSourceIBMLogsRouterTargetsTargetTypeToMap(model ibmcloudlogsroutingv0.TargetTypeIntf) (map[string]interface{}, error) {
+	if _, ok := model.(*ibmcloudlogsroutingv0.TargetTypeLogDna); ok {
+		return DataSourceIBMLogsRouterTargetsTargetTypeLogDnaToMap(model.(*ibmcloudlogsroutingv0.TargetTypeLogDna))
+	} else if _, ok := model.(*ibmcloudlogsroutingv0.TargetTypeLogs); ok {
+		return DataSourceIBMLogsRouterTargetsTargetTypeLogsToMap(model.(*ibmcloudlogsroutingv0.TargetTypeLogs))
+	} else if _, ok := model.(*ibmcloudlogsroutingv0.TargetType); ok {
+		modelMap := make(map[string]interface{})
+		model := model.(*ibmcloudlogsroutingv0.TargetType)
+		if model.ID != nil {
+			modelMap["id"] = model.ID.String()
+		}
+		if model.LogSinkCRN != nil {
+			modelMap["log_sink_crn"] = *model.LogSinkCRN
+		}
+		if model.Name != nil {
+			modelMap["name"] = *model.Name
+		}
+		if model.Etag != nil {
+			modelMap["etag"] = *model.Etag
+		}
+		if model.Type != nil {
+			modelMap["type"] = *model.Type
+		}
+		if model.CreatedAt != nil {
+			modelMap["created_at"] = *model.CreatedAt
+		}
+		if model.UpdatedAt != nil {
+			modelMap["updated_at"] = *model.UpdatedAt
+		}
+		if model.Parameters != nil {
+			parametersMap, err := DataSourceIBMLogsRouterTargetsTargetParametersTypeLogDnaToMap(model.Parameters)
+			if err != nil {
+				return modelMap, err
+			}
+			modelMap["parameters"] = []map[string]interface{}{parametersMap}
+		}
+		return modelMap, nil
+	} else {
+		return nil, fmt.Errorf("Unrecognized ibmcloudlogsroutingv0.TargetTypeIntf subtype encountered")
+	}
+}
+
+func DataSourceIBMLogsRouterTargetsTargetParametersTypeLogDnaToMap(model *ibmcloudlogsroutingv0.TargetParametersTypeLogDna) (map[string]interface{}, error) {
+	modelMap := make(map[string]interface{})
+	modelMap["host"] = *model.Host
+	modelMap["port"] = flex.IntValue(model.Port)
+	return modelMap, nil
+}
+
+func DataSourceIBMLogsRouterTargetsTargetTypeLogDnaToMap(model *ibmcloudlogsroutingv0.TargetTypeLogDna) (map[string]interface{}, error) {
+	modelMap := make(map[string]interface{})
+	modelMap["id"] = model.ID.String()
+	modelMap["log_sink_crn"] = *model.LogSinkCRN
+	modelMap["name"] = *model.Name
+	modelMap["etag"] = *model.Etag
+	modelMap["type"] = *model.Type
+	modelMap["created_at"] = *model.CreatedAt
+	modelMap["updated_at"] = *model.UpdatedAt
+	if model.Parameters != nil {
+		parametersMap, err := DataSourceIBMLogsRouterTargetsTargetParametersTypeLogDnaToMap(model.Parameters)
+		if err != nil {
+			return modelMap, err
+		}
+		modelMap["parameters"] = []map[string]interface{}{parametersMap}
+	}
+	return modelMap, nil
+}
+
+func DataSourceIBMLogsRouterTargetsTargetTypeLogsToMap(model *ibmcloudlogsroutingv0.TargetTypeLogs) (map[string]interface{}, error) {
+	modelMap := make(map[string]interface{})
+	modelMap["id"] = model.ID.String()
+	modelMap["log_sink_crn"] = *model.LogSinkCRN
+	modelMap["name"] = *model.Name
+	modelMap["etag"] = *model.Etag
+	modelMap["type"] = *model.Type
+	modelMap["created_at"] = *model.CreatedAt
+	modelMap["updated_at"] = *model.UpdatedAt
+	if model.Parameters != nil {
+		parametersMap, err := DataSourceIBMLogsRouterTargetsTargetParametersTypeLogsToMap(model.Parameters)
+		if err != nil {
+			return modelMap, err
+		}
+		modelMap["parameters"] = []map[string]interface{}{parametersMap}
+	}
+	return modelMap, nil
+}
+
+func DataSourceIBMLogsRouterTargetsTargetParametersTypeLogsToMap(model *ibmcloudlogsroutingv0.TargetParametersTypeLogs) (map[string]interface{}, error) {
+	modelMap := make(map[string]interface{})
+	modelMap["host"] = *model.Host
+	modelMap["port"] = flex.IntValue(model.Port)
+	return modelMap, nil
+}

--- a/ibm/service/logsrouting/data_source_ibm_logs-router_targets_test.go
+++ b/ibm/service/logsrouting/data_source_ibm_logs-router_targets_test.go
@@ -1,0 +1,213 @@
+// Copyright IBM Corp. 2024 All Rights Reserved.
+// Licensed under the Mozilla Public License v2.0
+
+/*
+ * IBM OpenAPI Terraform Generator Version: 3.90.1-64fd3296-20240515-180710
+ */
+
+package logsrouting_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	acc "github.com/IBM-Cloud/terraform-provider-ibm/ibm/acctest"
+	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/logsrouting"
+	. "github.com/IBM-Cloud/terraform-provider-ibm/ibm/unittest"
+	"github.com/IBM/go-sdk-core/v5/core"
+	"github.com/IBM/logs-router-go-sdk/ibmcloudlogsroutingv0"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestAccIBMLogsRouterTargetsDataSourceBasic(t *testing.T) {
+	tenantName := fmt.Sprintf("tf-name-%d", acctest.RandIntRange(10, 100))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { acc.TestAccPreCheck(t) },
+		Providers: acc.TestAccProviders,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccCheckIBMLogsRouterTargetsDataSourceConfigBasic(tenantName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet("data.ibm_logs_router_targets.logs_router_targets_instance", "id"),
+					resource.TestCheckResourceAttrSet("data.ibm_logs_router_targets.logs_router_targets_instance", "tenant_id"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckIBMLogsRouterTargetsDataSourceConfigBasic(tenantName string) string {
+	return fmt.Sprintf(`
+		 resource "ibm_logs_router_tenant" "logs_router_tenant_instance" {
+			 name = "%s"
+			 targets {
+				 log_sink_crn = "crn:v1:bluemix:public:logdna:eu-de:a/3516b8fa0a174a71899f5affa4f18d78:3517d2ed-9429-af34-ad52-34278391cbc8::"
+				 name = "my-log-sink"
+				 type = "logdna"
+				 parameters {
+					 host = "www.example.com"
+					 port = 1
+					 access_credential = "%s"
+				 }
+			 }
+		 }	
+ 
+		 data "ibm_logs_router_targets" "logs_router_targets_instance" {
+			 tenant_id = ibm_logs_router_tenant.logs_router_tenant_instance.id
+		 }
+	 `, tenantName, acc.IngestionKey)
+}
+
+func TestDataSourceIBMLogsRouterTargetsTargetTypeToMap(t *testing.T) {
+	checkResult := func(result map[string]interface{}) {
+		targetParametersTypeLogDnaModel := make(map[string]interface{})
+		targetParametersTypeLogDnaModel["host"] = "www.example.com"
+		targetParametersTypeLogDnaModel["port"] = int(1)
+
+		model := make(map[string]interface{})
+		model["id"] = "8717db99-2cfb-4ba6-a033-89c994c2e9f0"
+		model["log_sink_crn"] = "crn:v1:bluemix:public:logdna:eu-de:a/3516b8fa0a174a71899f5affa4f18d78:3517d2ed-9429-af34-ad52-34278391cbc8::"
+		model["name"] = "my-log-sink"
+		model["etag"] = "c3a43545a7f2675970671ac3a57b8db067a1866b2222e1b950ee8da612e347c6"
+		model["type"] = "logdna"
+		model["created_at"] = "2024-06-20T18:30:00.143156Z"
+		model["updated_at"] = "2024-06-20T18:30:00.143156Z"
+		model["parameters"] = []map[string]interface{}{targetParametersTypeLogDnaModel}
+
+		assert.Equal(t, result, model)
+	}
+
+	targetParametersTypeLogDnaModel := new(ibmcloudlogsroutingv0.TargetParametersTypeLogDna)
+	targetParametersTypeLogDnaModel.Host = core.StringPtr("www.example.com")
+	targetParametersTypeLogDnaModel.Port = core.Int64Ptr(int64(1))
+
+	model := new(ibmcloudlogsroutingv0.TargetType)
+	model.ID = CreateMockUUID("8717db99-2cfb-4ba6-a033-89c994c2e9f0")
+	model.LogSinkCRN = core.StringPtr("crn:v1:bluemix:public:logdna:eu-de:a/3516b8fa0a174a71899f5affa4f18d78:3517d2ed-9429-af34-ad52-34278391cbc8::")
+	model.Name = core.StringPtr("my-log-sink")
+	model.Etag = core.StringPtr("c3a43545a7f2675970671ac3a57b8db067a1866b2222e1b950ee8da612e347c6")
+	model.Type = core.StringPtr("logdna")
+	model.CreatedAt = core.StringPtr("2024-06-20T18:30:00.143156Z")
+	model.UpdatedAt = core.StringPtr("2024-06-20T18:30:00.143156Z")
+	model.Parameters = targetParametersTypeLogDnaModel
+
+	result, err := logsrouting.DataSourceIBMLogsRouterTargetsTargetTypeToMap(model)
+	assert.Nil(t, err)
+	checkResult(result)
+}
+
+func TestDataSourceIBMLogsRouterTargetsTargetParametersTypeLogDnaToMap(t *testing.T) {
+	checkResult := func(result map[string]interface{}) {
+		model := make(map[string]interface{})
+		model["host"] = "www.example.com"
+		model["port"] = int(1)
+
+		assert.Equal(t, result, model)
+	}
+
+	model := new(ibmcloudlogsroutingv0.TargetParametersTypeLogDna)
+	model.Host = core.StringPtr("www.example.com")
+	model.Port = core.Int64Ptr(int64(1))
+
+	result, err := logsrouting.DataSourceIBMLogsRouterTargetsTargetParametersTypeLogDnaToMap(model)
+	assert.Nil(t, err)
+	checkResult(result)
+}
+
+func TestDataSourceIBMLogsRouterTargetsTargetTypeLogDnaToMap(t *testing.T) {
+	checkResult := func(result map[string]interface{}) {
+		targetParametersTypeLogDnaModel := make(map[string]interface{})
+		targetParametersTypeLogDnaModel["host"] = "www.example.com"
+		targetParametersTypeLogDnaModel["port"] = int(8080)
+
+		model := make(map[string]interface{})
+		model["id"] = "8717db99-2cfb-4ba6-a033-89c994c2e9f0"
+		model["log_sink_crn"] = "crn:v1:bluemix:public:logdna:eu-de:a/3516b8fa0a174a71899f5affa4f18d78:3517d2ed-9429-af34-ad52-34278391cbc8::"
+		model["name"] = "my-log-sink"
+		model["etag"] = "c3a43545a7f2675970671ac3a57b8db067a1866b2222e1b950ee8da612e347c6"
+		model["type"] = "logdna"
+		model["created_at"] = "2024-06-20T18:30:00.143156Z"
+		model["updated_at"] = "2024-06-20T18:30:00.143156Z"
+		model["parameters"] = []map[string]interface{}{targetParametersTypeLogDnaModel}
+
+		assert.Equal(t, result, model)
+	}
+
+	targetParametersTypeLogDnaModel := new(ibmcloudlogsroutingv0.TargetParametersTypeLogDna)
+	targetParametersTypeLogDnaModel.Host = core.StringPtr("www.example.com")
+	targetParametersTypeLogDnaModel.Port = core.Int64Ptr(int64(8080))
+
+	model := new(ibmcloudlogsroutingv0.TargetTypeLogDna)
+	model.ID = CreateMockUUID("8717db99-2cfb-4ba6-a033-89c994c2e9f0")
+	model.LogSinkCRN = core.StringPtr("crn:v1:bluemix:public:logdna:eu-de:a/3516b8fa0a174a71899f5affa4f18d78:3517d2ed-9429-af34-ad52-34278391cbc8::")
+	model.Name = core.StringPtr("my-log-sink")
+	model.Etag = core.StringPtr("c3a43545a7f2675970671ac3a57b8db067a1866b2222e1b950ee8da612e347c6")
+	model.Type = core.StringPtr("logdna")
+	model.CreatedAt = core.StringPtr("2024-06-20T18:30:00.143156Z")
+	model.UpdatedAt = core.StringPtr("2024-06-20T18:30:00.143156Z")
+	model.Parameters = targetParametersTypeLogDnaModel
+
+	result, err := logsrouting.DataSourceIBMLogsRouterTargetsTargetTypeLogDnaToMap(model)
+	assert.Nil(t, err)
+	checkResult(result)
+}
+
+func TestDataSourceIBMLogsRouterTargetsTargetTypeLogsToMap(t *testing.T) {
+	checkResult := func(result map[string]interface{}) {
+		targetParametersTypeLogsModel := make(map[string]interface{})
+		targetParametersTypeLogsModel["host"] = "www.example.com"
+		targetParametersTypeLogsModel["port"] = int(8080)
+
+		model := make(map[string]interface{})
+		model["id"] = "8717db99-2cfb-4ba6-a033-89c994c2e9f0"
+		model["log_sink_crn"] = "crn:v1:bluemix:public:logs:eu-de:a/4516b8fa0a174a71899f5affa4f18d78:3517d2ed-9429-af34-ad52-34278391cbc8::"
+		model["name"] = "my-log-sink"
+		model["etag"] = "c3a43545a7f2675970671ac3a57b8db067a1866b2222e1b950ee8da612e347c6"
+		model["type"] = "logs"
+		model["created_at"] = "2024-06-20T18:30:00.143156Z"
+		model["updated_at"] = "2024-06-20T18:30:00.143156Z"
+		model["parameters"] = []map[string]interface{}{targetParametersTypeLogsModel}
+
+		assert.Equal(t, result, model)
+	}
+
+	targetParametersTypeLogsModel := new(ibmcloudlogsroutingv0.TargetParametersTypeLogs)
+	targetParametersTypeLogsModel.Host = core.StringPtr("www.example.com")
+	targetParametersTypeLogsModel.Port = core.Int64Ptr(int64(8080))
+
+	model := new(ibmcloudlogsroutingv0.TargetTypeLogs)
+	model.ID = CreateMockUUID("8717db99-2cfb-4ba6-a033-89c994c2e9f0")
+	model.LogSinkCRN = core.StringPtr("crn:v1:bluemix:public:logs:eu-de:a/4516b8fa0a174a71899f5affa4f18d78:3517d2ed-9429-af34-ad52-34278391cbc8::")
+	model.Name = core.StringPtr("my-log-sink")
+	model.Etag = core.StringPtr("c3a43545a7f2675970671ac3a57b8db067a1866b2222e1b950ee8da612e347c6")
+	model.Type = core.StringPtr("logs")
+	model.CreatedAt = core.StringPtr("2024-06-20T18:30:00.143156Z")
+	model.UpdatedAt = core.StringPtr("2024-06-20T18:30:00.143156Z")
+	model.Parameters = targetParametersTypeLogsModel
+
+	result, err := logsrouting.DataSourceIBMLogsRouterTargetsTargetTypeLogsToMap(model)
+	assert.Nil(t, err)
+	checkResult(result)
+}
+
+func TestDataSourceIBMLogsRouterTargetsTargetParametersTypeLogsToMap(t *testing.T) {
+	checkResult := func(result map[string]interface{}) {
+		model := make(map[string]interface{})
+		model["host"] = "www.example.com"
+		model["port"] = int(1)
+
+		assert.Equal(t, result, model)
+	}
+
+	model := new(ibmcloudlogsroutingv0.TargetParametersTypeLogs)
+	model.Host = core.StringPtr("www.example.com")
+	model.Port = core.Int64Ptr(int64(1))
+
+	result, err := logsrouting.DataSourceIBMLogsRouterTargetsTargetParametersTypeLogsToMap(model)
+	assert.Nil(t, err)
+	checkResult(result)
+}

--- a/ibm/service/logsrouting/data_source_ibm_logs-router_tenants.go
+++ b/ibm/service/logsrouting/data_source_ibm_logs-router_tenants.go
@@ -1,0 +1,298 @@
+// Copyright IBM Corp. 2024 All Rights Reserved.
+// Licensed under the Mozilla Public License v2.0
+
+/*
+ * IBM OpenAPI Terraform Generator Version: 3.90.1-64fd3296-20240515-180710
+ */
+
+package logsrouting
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"time"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/conns"
+	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/flex"
+	"github.com/IBM/logs-router-go-sdk/ibmcloudlogsroutingv0"
+)
+
+func DataSourceIBMLogsRouterTenants() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceIBMLogsRouterTenantsRead,
+
+		Schema: map[string]*schema.Schema{
+			"name": &schema.Schema{
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "Optional: The name of a tenant.",
+			},
+			"tenants": &schema.Schema{
+				Type:        schema.TypeList,
+				Computed:    true,
+				Description: "List of tenants in the account.",
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"id": &schema.Schema{
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "Unique ID of the tenant.",
+						},
+						"created_at": &schema.Schema{
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "Time stamp the tenant was originally created.",
+						},
+						"updated_at": &schema.Schema{
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "Time stamp the tenant was last updated.",
+						},
+						"crn": &schema.Schema{
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "Cloud resource name of the tenant.",
+						},
+						"name": &schema.Schema{
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "The name for this tenant. The name is regionally unique across all tenants in the account.",
+						},
+						"etag": &schema.Schema{
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "Resource version identifier.",
+						},
+						"targets": &schema.Schema{
+							Type:        schema.TypeList,
+							Computed:    true,
+							Description: "List of targets.",
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"id": &schema.Schema{
+										Type:        schema.TypeString,
+										Computed:    true,
+										Description: "Unique ID of the target.",
+									},
+									"log_sink_crn": &schema.Schema{
+										Type:        schema.TypeString,
+										Computed:    true,
+										Description: "Cloud resource name of the log-sink target instance.",
+									},
+									"name": &schema.Schema{
+										Type:        schema.TypeString,
+										Computed:    true,
+										Description: "The name for this tenant target. The name is unique across all targets for this tenant.",
+									},
+									"etag": &schema.Schema{
+										Type:        schema.TypeString,
+										Computed:    true,
+										Description: "Resource version identifier.",
+									},
+									"type": &schema.Schema{
+										Type:        schema.TypeString,
+										Computed:    true,
+										Description: "Type of log-sink. Identical to the <code>service-name</code> segment of <code>log_sink_crn</code>.",
+									},
+									"created_at": &schema.Schema{
+										Type:        schema.TypeString,
+										Computed:    true,
+										Description: "Time stamp the target was originally created.",
+									},
+									"updated_at": &schema.Schema{
+										Type:        schema.TypeString,
+										Computed:    true,
+										Description: "Time stamp the target was last updated.",
+									},
+									"parameters": &schema.Schema{
+										Type:        schema.TypeList,
+										Computed:    true,
+										Description: "List of properties returned from a successful list operation for a log-sink of type IBM Log Analysis (logdna).",
+										Elem: &schema.Resource{
+											Schema: map[string]*schema.Schema{
+												"host": &schema.Schema{
+													Type:        schema.TypeString,
+													Computed:    true,
+													Description: "Host name of the log-sink.",
+												},
+												"port": &schema.Schema{
+													Type:        schema.TypeInt,
+													Computed:    true,
+													Description: "Network port of the log-sink.",
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func dataSourceIBMLogsRouterTenantsRead(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	ibmCloudLogsRoutingClient, err := meta.(conns.ClientSession).IBMCloudLogsRoutingV0()
+	if err != nil {
+		// Error is coming from SDK client, so it doesn't need to be discriminated.
+		tfErr := flex.TerraformErrorf(err, err.Error(), "(Data) ibm_logs_router_tenants", "read")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
+	}
+
+	listTenantsOptions := &ibmcloudlogsroutingv0.ListTenantsOptions{}
+
+	if _, ok := d.GetOk("name"); ok {
+		listTenantsOptions.SetName(d.Get("name").(string))
+	}
+
+	tenantCollection, _, err := ibmCloudLogsRoutingClient.ListTenantsWithContext(context, listTenantsOptions)
+	if err != nil {
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("ListTenantsWithContext failed: %s", err.Error()), "(Data) ibm_logs_router_tenants", "read")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
+	}
+
+	d.SetId(dataSourceIBMLogsRouterTenantsID(d))
+
+	tenants := []map[string]interface{}{}
+	if tenantCollection.Tenants != nil {
+		for _, modelItem := range tenantCollection.Tenants {
+			modelMap, err := DataSourceIBMLogsRouterTenantsTenantToMap(&modelItem)
+			if err != nil {
+				return flex.DiscriminatedTerraformErrorf(err, err.Error(), "(Data) ibm_logs_router_tenants", "read", "tenants-to-map").GetDiag()
+			}
+			tenants = append(tenants, modelMap)
+		}
+	}
+	if err = d.Set("tenants", tenants); err != nil {
+		return flex.DiscriminatedTerraformErrorf(err, fmt.Sprintf("Error setting tenants: %s", err), "(Data) ibm_logs_router_tenants", "read", "set-tenants").GetDiag()
+	}
+
+	return nil
+}
+
+// dataSourceIBMLogsRouterTenantsID returns a reasonable ID for the list.
+func dataSourceIBMLogsRouterTenantsID(d *schema.ResourceData) string {
+	return time.Now().UTC().String()
+}
+
+func DataSourceIBMLogsRouterTenantsTenantToMap(model *ibmcloudlogsroutingv0.Tenant) (map[string]interface{}, error) {
+	modelMap := make(map[string]interface{})
+	modelMap["id"] = model.ID.String()
+	modelMap["created_at"] = *model.CreatedAt
+	modelMap["updated_at"] = *model.UpdatedAt
+	modelMap["crn"] = *model.CRN
+	modelMap["name"] = *model.Name
+	modelMap["etag"] = *model.Etag
+	targets := []map[string]interface{}{}
+	for _, targetsItem := range model.Targets {
+		targetsItemMap, err := DataSourceIBMLogsRouterTenantsTargetTypeToMap(targetsItem)
+		if err != nil {
+			return modelMap, err
+		}
+		targets = append(targets, targetsItemMap)
+	}
+	modelMap["targets"] = targets
+	return modelMap, nil
+}
+
+func DataSourceIBMLogsRouterTenantsTargetTypeToMap(model ibmcloudlogsroutingv0.TargetTypeIntf) (map[string]interface{}, error) {
+	if _, ok := model.(*ibmcloudlogsroutingv0.TargetTypeLogDna); ok {
+		return DataSourceIBMLogsRouterTenantsTargetTypeLogDnaToMap(model.(*ibmcloudlogsroutingv0.TargetTypeLogDna))
+	} else if _, ok := model.(*ibmcloudlogsroutingv0.TargetTypeLogs); ok {
+		return DataSourceIBMLogsRouterTenantsTargetTypeLogsToMap(model.(*ibmcloudlogsroutingv0.TargetTypeLogs))
+	} else if _, ok := model.(*ibmcloudlogsroutingv0.TargetType); ok {
+		modelMap := make(map[string]interface{})
+		model := model.(*ibmcloudlogsroutingv0.TargetType)
+		if model.ID != nil {
+			modelMap["id"] = model.ID.String()
+		}
+		if model.LogSinkCRN != nil {
+			modelMap["log_sink_crn"] = *model.LogSinkCRN
+		}
+		if model.Name != nil {
+			modelMap["name"] = *model.Name
+		}
+		if model.Etag != nil {
+			modelMap["etag"] = *model.Etag
+		}
+		if model.Type != nil {
+			modelMap["type"] = *model.Type
+		}
+		if model.CreatedAt != nil {
+			modelMap["created_at"] = *model.CreatedAt
+		}
+		if model.UpdatedAt != nil {
+			modelMap["updated_at"] = *model.UpdatedAt
+		}
+		if model.Parameters != nil {
+			parametersMap, err := DataSourceIBMLogsRouterTenantsTargetParametersTypeLogDnaToMap(model.Parameters)
+			if err != nil {
+				return modelMap, err
+			}
+			modelMap["parameters"] = []map[string]interface{}{parametersMap}
+		}
+		return modelMap, nil
+	} else {
+		return nil, fmt.Errorf("Unrecognized ibmcloudlogsroutingv0.TargetTypeIntf subtype encountered")
+	}
+}
+
+func DataSourceIBMLogsRouterTenantsTargetParametersTypeLogDnaToMap(model *ibmcloudlogsroutingv0.TargetParametersTypeLogDna) (map[string]interface{}, error) {
+	modelMap := make(map[string]interface{})
+	modelMap["host"] = *model.Host
+	modelMap["port"] = flex.IntValue(model.Port)
+	return modelMap, nil
+}
+
+func DataSourceIBMLogsRouterTenantsTargetTypeLogDnaToMap(model *ibmcloudlogsroutingv0.TargetTypeLogDna) (map[string]interface{}, error) {
+	modelMap := make(map[string]interface{})
+	modelMap["id"] = model.ID.String()
+	modelMap["log_sink_crn"] = *model.LogSinkCRN
+	modelMap["name"] = *model.Name
+	modelMap["etag"] = *model.Etag
+	modelMap["type"] = *model.Type
+	modelMap["created_at"] = *model.CreatedAt
+	modelMap["updated_at"] = *model.UpdatedAt
+	if model.Parameters != nil {
+		parametersMap, err := DataSourceIBMLogsRouterTenantsTargetParametersTypeLogDnaToMap(model.Parameters)
+		if err != nil {
+			return modelMap, err
+		}
+		modelMap["parameters"] = []map[string]interface{}{parametersMap}
+	}
+	return modelMap, nil
+}
+
+func DataSourceIBMLogsRouterTenantsTargetTypeLogsToMap(model *ibmcloudlogsroutingv0.TargetTypeLogs) (map[string]interface{}, error) {
+	modelMap := make(map[string]interface{})
+	modelMap["id"] = model.ID.String()
+	modelMap["log_sink_crn"] = *model.LogSinkCRN
+	modelMap["name"] = *model.Name
+	modelMap["etag"] = *model.Etag
+	modelMap["type"] = *model.Type
+	modelMap["created_at"] = *model.CreatedAt
+	modelMap["updated_at"] = *model.UpdatedAt
+	if model.Parameters != nil {
+		parametersMap, err := DataSourceIBMLogsRouterTenantsTargetParametersTypeLogsToMap(model.Parameters)
+		if err != nil {
+			return modelMap, err
+		}
+		modelMap["parameters"] = []map[string]interface{}{parametersMap}
+	}
+	return modelMap, nil
+}
+
+func DataSourceIBMLogsRouterTenantsTargetParametersTypeLogsToMap(model *ibmcloudlogsroutingv0.TargetParametersTypeLogs) (map[string]interface{}, error) {
+	modelMap := make(map[string]interface{})
+	modelMap["host"] = *model.Host
+	modelMap["port"] = flex.IntValue(model.Port)
+	return modelMap, nil
+}

--- a/ibm/service/logsrouting/data_source_ibm_logs-router_tenants_test.go
+++ b/ibm/service/logsrouting/data_source_ibm_logs-router_tenants_test.go
@@ -1,0 +1,268 @@
+// Copyright IBM Corp. 2024 All Rights Reserved.
+// Licensed under the Mozilla Public License v2.0
+
+/*
+ * IBM OpenAPI Terraform Generator Version: 3.90.1-64fd3296-20240515-180710
+ */
+
+package logsrouting_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	acc "github.com/IBM-Cloud/terraform-provider-ibm/ibm/acctest"
+	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/logsrouting"
+	. "github.com/IBM-Cloud/terraform-provider-ibm/ibm/unittest"
+	"github.com/IBM/go-sdk-core/v5/core"
+	"github.com/IBM/logs-router-go-sdk/ibmcloudlogsroutingv0"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestAccIBMLogsRouterTenantsDataSourceBasic(t *testing.T) {
+	tenantName := fmt.Sprintf("tf-name-%d", acctest.RandIntRange(10, 100))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { acc.TestAccPreCheck(t) },
+		Providers: acc.TestAccProviders,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccCheckIBMLogsRouterTenantsDataSourceConfigBasic(tenantName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet("data.ibm_logs_router_tenants.logs_router_tenants_instance", "id"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckIBMLogsRouterTenantsDataSourceConfigBasic(tenantName string) string {
+	return fmt.Sprintf(`
+		 resource "ibm_logs_router_tenant" "logs_router_tenant_instance" {
+			 name = "%s"
+			 targets {
+				 log_sink_crn = "crn:v1:bluemix:public:logdna:eu-de:a/3516b8fa0a174a71899f5affa4f18d78:3517d2ed-9429-af34-ad52-34278391cbc8::"
+				 name = "my-log-sink"
+				 type = "logdna"
+				 parameters {
+					 host = "www.example.com"
+					 port = 1
+					 access_credential = "%s"
+				 }
+			 }
+		 }
+ 
+		 data "ibm_logs_router_tenants" "logs_router_tenants_instance" {
+			 name = ibm_logs_router_tenant.logs_router_tenant_instance.name
+		 }
+	 `, tenantName, acc.IngestionKey)
+}
+
+func TestDataSourceIBMLogsRouterTenantsTenantToMap(t *testing.T) {
+	checkResult := func(result map[string]interface{}) {
+		targetParametersTypeLogDnaModel := make(map[string]interface{})
+		targetParametersTypeLogDnaModel["host"] = "www.example.com"
+		targetParametersTypeLogDnaModel["port"] = int(8080)
+
+		targetTypeModel := make(map[string]interface{})
+		targetTypeModel["id"] = "C1C1C838-A4AC-4BD7-8BC6-3173B272429D"
+		targetTypeModel["log_sink_crn"] = "crn:v1:bluemix:public:logdna:eu-de:a/3516b8fa0a174a71899f5affa4f18d78:3517d2ed-9429-af34-ad52-34278391cbc8::"
+		targetTypeModel["name"] = "my-logdna-log-sink"
+		targetTypeModel["etag"] = "c3a43545a7f2675970671ac3a57b8db067a1866b2222e1b950ee8da612e347c6"
+		targetTypeModel["type"] = "logdna"
+		targetTypeModel["created_at"] = "2024-06-20T18:30:00.143156Z"
+		targetTypeModel["updated_at"] = "2024-06-20T18:30:00.143156Z"
+		targetTypeModel["parameters"] = []map[string]interface{}{targetParametersTypeLogDnaModel}
+
+		model := make(map[string]interface{})
+		model["id"] = "8717db99-2cfb-4ba6-a033-89c994c2e9f0"
+		model["created_at"] = "2024-06-20T18:30:00.143156Z"
+		model["updated_at"] = "2024-06-20T18:30:00.143156Z"
+		model["crn"] = "crn:v1:bluemix:public:logs-router:eu-de:a/3516b8fa0a174a71899f5affa4f18d78:3517d2ed-9429-af34-ad52-34278391cbc8::"
+		model["name"] = "my-logging-tenant"
+		model["etag"] = "822b4b5423e225206c1d75666595714a11925cd0f82b229839864443d6c3c049"
+		model["targets"] = []map[string]interface{}{targetTypeModel}
+
+		assert.Equal(t, result, model)
+	}
+
+	targetParametersTypeLogDnaModel := new(ibmcloudlogsroutingv0.TargetParametersTypeLogDna)
+	targetParametersTypeLogDnaModel.Host = core.StringPtr("www.example.com")
+	targetParametersTypeLogDnaModel.Port = core.Int64Ptr(int64(8080))
+
+	targetTypeModel := new(ibmcloudlogsroutingv0.TargetTypeLogDna)
+	targetTypeModel.ID = CreateMockUUID("C1C1C838-A4AC-4BD7-8BC6-3173B272429D")
+	targetTypeModel.LogSinkCRN = core.StringPtr("crn:v1:bluemix:public:logdna:eu-de:a/3516b8fa0a174a71899f5affa4f18d78:3517d2ed-9429-af34-ad52-34278391cbc8::")
+	targetTypeModel.Name = core.StringPtr("my-logdna-log-sink")
+	targetTypeModel.Etag = core.StringPtr("c3a43545a7f2675970671ac3a57b8db067a1866b2222e1b950ee8da612e347c6")
+	targetTypeModel.Type = core.StringPtr("logdna")
+	targetTypeModel.CreatedAt = core.StringPtr("2024-06-20T18:30:00.143156Z")
+	targetTypeModel.UpdatedAt = core.StringPtr("2024-06-20T18:30:00.143156Z")
+	targetTypeModel.Parameters = targetParametersTypeLogDnaModel
+
+	model := new(ibmcloudlogsroutingv0.Tenant)
+	model.ID = CreateMockUUID("8717db99-2cfb-4ba6-a033-89c994c2e9f0")
+	model.CreatedAt = core.StringPtr("2024-06-20T18:30:00.143156Z")
+	model.UpdatedAt = core.StringPtr("2024-06-20T18:30:00.143156Z")
+	model.CRN = core.StringPtr("crn:v1:bluemix:public:logs-router:eu-de:a/3516b8fa0a174a71899f5affa4f18d78:3517d2ed-9429-af34-ad52-34278391cbc8::")
+	model.Name = core.StringPtr("my-logging-tenant")
+	model.Etag = core.StringPtr("822b4b5423e225206c1d75666595714a11925cd0f82b229839864443d6c3c049")
+	model.Targets = []ibmcloudlogsroutingv0.TargetTypeIntf{targetTypeModel}
+
+	result, err := logsrouting.DataSourceIBMLogsRouterTenantsTenantToMap(model)
+	assert.Nil(t, err)
+	checkResult(result)
+}
+
+func TestDataSourceIBMLogsRouterTenantsTargetTypeToMap(t *testing.T) {
+	checkResult := func(result map[string]interface{}) {
+		targetParametersTypeLogDnaModel := make(map[string]interface{})
+		targetParametersTypeLogDnaModel["host"] = "www.example.com"
+		targetParametersTypeLogDnaModel["port"] = int(1)
+
+		model := make(map[string]interface{})
+		model["id"] = "8717db99-2cfb-4ba6-a033-89c994c2e9f0"
+		model["log_sink_crn"] = "crn:v1:bluemix:public:logdna:eu-de:a/3516b8fa0a174a71899f5affa4f18d78:3517d2ed-9429-af34-ad52-34278391cbc8::"
+		model["name"] = "my-log-sink"
+		model["etag"] = "c3a43545a7f2675970671ac3a57b8db067a1866b2222e1b950ee8da612e347c6"
+		model["type"] = "logdna"
+		model["created_at"] = "2024-06-20T18:30:00.143156Z"
+		model["updated_at"] = "2024-06-20T18:30:00.143156Z"
+		model["parameters"] = []map[string]interface{}{targetParametersTypeLogDnaModel}
+
+		assert.Equal(t, result, model)
+	}
+
+	targetParametersTypeLogDnaModel := new(ibmcloudlogsroutingv0.TargetParametersTypeLogDna)
+	targetParametersTypeLogDnaModel.Host = core.StringPtr("www.example.com")
+	targetParametersTypeLogDnaModel.Port = core.Int64Ptr(int64(1))
+
+	model := new(ibmcloudlogsroutingv0.TargetType)
+	model.ID = CreateMockUUID("8717db99-2cfb-4ba6-a033-89c994c2e9f0")
+	model.LogSinkCRN = core.StringPtr("crn:v1:bluemix:public:logdna:eu-de:a/3516b8fa0a174a71899f5affa4f18d78:3517d2ed-9429-af34-ad52-34278391cbc8::")
+	model.Name = core.StringPtr("my-log-sink")
+	model.Etag = core.StringPtr("c3a43545a7f2675970671ac3a57b8db067a1866b2222e1b950ee8da612e347c6")
+	model.Type = core.StringPtr("logdna")
+	model.CreatedAt = core.StringPtr("2024-06-20T18:30:00.143156Z")
+	model.UpdatedAt = core.StringPtr("2024-06-20T18:30:00.143156Z")
+	model.Parameters = targetParametersTypeLogDnaModel
+
+	result, err := logsrouting.DataSourceIBMLogsRouterTenantsTargetTypeToMap(model)
+	assert.Nil(t, err)
+	checkResult(result)
+}
+
+func TestDataSourceIBMLogsRouterTenantsTargetParametersTypeLogDnaToMap(t *testing.T) {
+	checkResult := func(result map[string]interface{}) {
+		model := make(map[string]interface{})
+		model["host"] = "www.example.com"
+		model["port"] = int(1)
+
+		assert.Equal(t, result, model)
+	}
+
+	model := new(ibmcloudlogsroutingv0.TargetParametersTypeLogDna)
+	model.Host = core.StringPtr("www.example.com")
+	model.Port = core.Int64Ptr(int64(1))
+
+	result, err := logsrouting.DataSourceIBMLogsRouterTenantsTargetParametersTypeLogDnaToMap(model)
+	assert.Nil(t, err)
+	checkResult(result)
+}
+
+func TestDataSourceIBMLogsRouterTenantsTargetTypeLogDnaToMap(t *testing.T) {
+	checkResult := func(result map[string]interface{}) {
+		targetParametersTypeLogDnaModel := make(map[string]interface{})
+		targetParametersTypeLogDnaModel["host"] = "www.example.com"
+		targetParametersTypeLogDnaModel["port"] = int(8080)
+
+		model := make(map[string]interface{})
+		model["id"] = "8717db99-2cfb-4ba6-a033-89c994c2e9f0"
+		model["log_sink_crn"] = "crn:v1:bluemix:public:logdna:eu-de:a/3516b8fa0a174a71899f5affa4f18d78:3517d2ed-9429-af34-ad52-34278391cbc8::"
+		model["name"] = "my-log-sink"
+		model["etag"] = "c3a43545a7f2675970671ac3a57b8db067a1866b2222e1b950ee8da612e347c6"
+		model["type"] = "logdna"
+		model["created_at"] = "2024-06-20T18:30:00.143156Z"
+		model["updated_at"] = "2024-06-20T18:30:00.143156Z"
+		model["parameters"] = []map[string]interface{}{targetParametersTypeLogDnaModel}
+
+		assert.Equal(t, result, model)
+	}
+
+	targetParametersTypeLogDnaModel := new(ibmcloudlogsroutingv0.TargetParametersTypeLogDna)
+	targetParametersTypeLogDnaModel.Host = core.StringPtr("www.example.com")
+	targetParametersTypeLogDnaModel.Port = core.Int64Ptr(int64(8080))
+
+	model := new(ibmcloudlogsroutingv0.TargetTypeLogDna)
+	model.ID = CreateMockUUID("8717db99-2cfb-4ba6-a033-89c994c2e9f0")
+	model.LogSinkCRN = core.StringPtr("crn:v1:bluemix:public:logdna:eu-de:a/3516b8fa0a174a71899f5affa4f18d78:3517d2ed-9429-af34-ad52-34278391cbc8::")
+	model.Name = core.StringPtr("my-log-sink")
+	model.Etag = core.StringPtr("c3a43545a7f2675970671ac3a57b8db067a1866b2222e1b950ee8da612e347c6")
+	model.Type = core.StringPtr("logdna")
+	model.CreatedAt = core.StringPtr("2024-06-20T18:30:00.143156Z")
+	model.UpdatedAt = core.StringPtr("2024-06-20T18:30:00.143156Z")
+	model.Parameters = targetParametersTypeLogDnaModel
+
+	result, err := logsrouting.DataSourceIBMLogsRouterTenantsTargetTypeLogDnaToMap(model)
+	assert.Nil(t, err)
+	checkResult(result)
+}
+
+func TestDataSourceIBMLogsRouterTenantsTargetTypeLogsToMap(t *testing.T) {
+	checkResult := func(result map[string]interface{}) {
+		targetParametersTypeLogsModel := make(map[string]interface{})
+		targetParametersTypeLogsModel["host"] = "www.example.com"
+		targetParametersTypeLogsModel["port"] = int(8080)
+
+		model := make(map[string]interface{})
+		model["id"] = "8717db99-2cfb-4ba6-a033-89c994c2e9f0"
+		model["log_sink_crn"] = "crn:v1:bluemix:public:logs:eu-de:a/4516b8fa0a174a71899f5affa4f18d78:3517d2ed-9429-af34-ad52-34278391cbc8::"
+		model["name"] = "my-log-sink"
+		model["etag"] = "c3a43545a7f2675970671ac3a57b8db067a1866b2222e1b950ee8da612e347c6"
+		model["type"] = "logs"
+		model["created_at"] = "2024-06-20T18:30:00.143156Z"
+		model["updated_at"] = "2024-06-20T18:30:00.143156Z"
+		model["parameters"] = []map[string]interface{}{targetParametersTypeLogsModel}
+
+		assert.Equal(t, result, model)
+	}
+
+	targetParametersTypeLogsModel := new(ibmcloudlogsroutingv0.TargetParametersTypeLogs)
+	targetParametersTypeLogsModel.Host = core.StringPtr("www.example.com")
+	targetParametersTypeLogsModel.Port = core.Int64Ptr(int64(8080))
+
+	model := new(ibmcloudlogsroutingv0.TargetTypeLogs)
+	model.ID = CreateMockUUID("8717db99-2cfb-4ba6-a033-89c994c2e9f0")
+	model.LogSinkCRN = core.StringPtr("crn:v1:bluemix:public:logs:eu-de:a/4516b8fa0a174a71899f5affa4f18d78:3517d2ed-9429-af34-ad52-34278391cbc8::")
+	model.Name = core.StringPtr("my-log-sink")
+	model.Etag = core.StringPtr("c3a43545a7f2675970671ac3a57b8db067a1866b2222e1b950ee8da612e347c6")
+	model.Type = core.StringPtr("logs")
+	model.CreatedAt = core.StringPtr("2024-06-20T18:30:00.143156Z")
+	model.UpdatedAt = core.StringPtr("2024-06-20T18:30:00.143156Z")
+	model.Parameters = targetParametersTypeLogsModel
+
+	result, err := logsrouting.DataSourceIBMLogsRouterTenantsTargetTypeLogsToMap(model)
+	assert.Nil(t, err)
+	checkResult(result)
+}
+
+func TestDataSourceIBMLogsRouterTenantsTargetParametersTypeLogsToMap(t *testing.T) {
+	checkResult := func(result map[string]interface{}) {
+		model := make(map[string]interface{})
+		model["host"] = "www.example.com"
+		model["port"] = int(1)
+
+		assert.Equal(t, result, model)
+	}
+
+	model := new(ibmcloudlogsroutingv0.TargetParametersTypeLogs)
+	model.Host = core.StringPtr("www.example.com")
+	model.Port = core.Int64Ptr(int64(1))
+
+	result, err := logsrouting.DataSourceIBMLogsRouterTenantsTargetParametersTypeLogsToMap(model)
+	assert.Nil(t, err)
+	checkResult(result)
+}

--- a/ibm/service/logsrouting/resource_ibm_logs-router_tenant.go
+++ b/ibm/service/logsrouting/resource_ibm_logs-router_tenant.go
@@ -1,0 +1,766 @@
+// Copyright IBM Corp. 2024 All Rights Reserved.
+// Licensed under the Mozilla Public License v2.0
+
+/*
+ * IBM OpenAPI Terraform Generator Version: 3.90.1-64fd3296-20240515-180710
+ */
+
+package logsrouting
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"strings"
+
+	"github.com/go-openapi/strfmt"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/conns"
+	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/flex"
+	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/validate"
+	"github.com/IBM/go-sdk-core/v5/core"
+	"github.com/IBM/logs-router-go-sdk/ibmcloudlogsroutingv0"
+)
+
+func ResourceIBMLogsRouterTenant() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceIBMLogsRouterTenantCreate,
+		ReadContext:   resourceIBMLogsRouterTenantRead,
+		UpdateContext: resourceIBMLogsRouterTenantUpdate,
+		DeleteContext: resourceIBMLogsRouterTenantDelete,
+		Importer:      &schema.ResourceImporter{},
+
+		Schema: map[string]*schema.Schema{
+			"name": &schema.Schema{
+				Type:         schema.TypeString,
+				Required:     true,
+				ValidateFunc: validate.InvokeValidator("ibm_logs_router_tenant", "name"),
+				Description:  "The name for this tenant. The name is regionally unique across all tenants in the account.",
+			},
+			"targets": &schema.Schema{
+				Type:        schema.TypeList,
+				Optional:    true,
+				MinItems:    1,
+				Description: "List of targets",
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"id": &schema.Schema{
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "Unique ID of the target.",
+						},
+						"log_sink_crn": &schema.Schema{
+							Type:        schema.TypeString,
+							ForceNew:    true,
+							Optional:    true,
+							Description: "Cloud resource name of the log-sink target instance.",
+						},
+						"name": &schema.Schema{
+							Type:        schema.TypeString,
+							Optional:    true,
+							Description: "The name for this tenant target. The name is unique across all targets for this tenant.",
+						},
+						"etag": &schema.Schema{
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "Resource version identifier.",
+						},
+						"type": &schema.Schema{
+							Type:        schema.TypeString,
+							Optional:    true,
+							Computed:    true,
+							Description: "Type of log-sink. Identical to the <code>service-name</code> segment of <code>log_sink_crn</code>.",
+						},
+						"created_at": &schema.Schema{
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "Time stamp the target was originally created.",
+						},
+						"updated_at": &schema.Schema{
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "Time stamp the target was last updated.",
+						},
+						"parameters": &schema.Schema{
+							Type:        schema.TypeList,
+							MaxItems:    1,
+							Optional:    true,
+							Description: "List of properties returned from a successful list operation for a log-sink of type IBM Log Analysis (logdna).",
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"host": &schema.Schema{
+										Type:        schema.TypeString,
+										Required:    true,
+										Description: "Host name of the log-sink.",
+									},
+									"port": &schema.Schema{
+										Type:        schema.TypeInt,
+										Required:    true,
+										Description: "Network port of the log-sink.",
+									},
+									"access_credential": &schema.Schema{
+										Type:        schema.TypeString,
+										Optional:    true,
+										Sensitive:   true,
+										Description: "Secret to connect to the log-sink",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			"created_at": &schema.Schema{
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "Time stamp the tenant was originally created.",
+			},
+			"updated_at": &schema.Schema{
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "Time stamp the tenant was last updated.",
+			},
+			"crn": &schema.Schema{
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "Cloud resource name of the tenant.",
+			},
+			"etag": &schema.Schema{
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "Resource version identifier.",
+			},
+		},
+	}
+}
+
+func ResourceIBMLogsRouterTenantValidator() *validate.ResourceValidator {
+	validateSchema := make([]validate.ValidateSchema, 0)
+	validateSchema = append(validateSchema,
+		validate.ValidateSchema{
+			Identifier:                 "name",
+			ValidateFunctionIdentifier: validate.ValidateRegexpLen,
+			Type:                       validate.TypeString,
+			Required:                   true,
+			Regexp:                     `[a-z,A-Z,0-9,-,.]`,
+			MinValueLength:             1,
+			MaxValueLength:             35,
+		},
+	)
+
+	resourceValidator := validate.ResourceValidator{ResourceName: "ibm_logs_router_tenant", Schema: validateSchema}
+	return &resourceValidator
+}
+
+func resourceIBMLogsRouterTenantCreate(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	ibmCloudLogsRoutingClient, err := meta.(conns.ClientSession).IBMCloudLogsRoutingV0()
+	if err != nil {
+		// Error is coming from SDK client, so it doesn't need to be discriminated.
+		tfErr := flex.TerraformErrorf(err, err.Error(), "ibm_logs_router_tenant", "create")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
+	}
+
+	createTenantOptions := &ibmcloudlogsroutingv0.CreateTenantOptions{}
+
+	createTenantOptions.SetName(d.Get("name").(string))
+	var targets []ibmcloudlogsroutingv0.TargetTypePrototypeIntf
+	for _, v := range d.Get("targets").([]interface{}) {
+		value := v.(map[string]interface{})
+		targetsItem, err := ResourceIBMLogsRouterTenantMapToTargetTypePrototype(value)
+		if err != nil {
+			return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_logs_router_tenant", "create", "parse-targets").GetDiag()
+		}
+		targets = append(targets, targetsItem)
+	}
+	createTenantOptions.SetTargets(targets)
+
+	tenant, _, err := ibmCloudLogsRoutingClient.CreateTenantWithContext(context, createTenantOptions)
+	if err != nil {
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("CreateTenantWithContext failed: %s", err.Error()), "ibm_logs_router_tenant", "create")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
+	}
+
+	d.SetId(tenant.ID.String())
+
+	return resourceIBMLogsRouterTenantRead(context, d, meta)
+}
+
+func resourceIBMLogsRouterTenantRead(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	ibmCloudLogsRoutingClient, err := meta.(conns.ClientSession).IBMCloudLogsRoutingV0()
+	if err != nil {
+		tfErr := flex.TerraformErrorf(err, err.Error(), "ibm_logs_router_tenant", "read")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
+	}
+
+	getTenantDetailOptions := &ibmcloudlogsroutingv0.GetTenantDetailOptions{}
+
+	tenantId := strfmt.UUID(d.Id())
+	getTenantDetailOptions.SetTenantID(&tenantId)
+
+	tenant, response, err := ibmCloudLogsRoutingClient.GetTenantDetailWithContext(context, getTenantDetailOptions)
+	if err != nil {
+		if response != nil && response.StatusCode == 404 {
+			d.SetId("")
+			return nil
+		}
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("GetTenantDetailWithContext failed: %s", err.Error()), "ibm_logs_router_tenant", "read")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
+	}
+	if err = d.Set("name", tenant.Name); err != nil {
+		err = fmt.Errorf("Error setting name: %s", err)
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_logs_router_tenant", "read", "set-name").GetDiag()
+	}
+	targets := []map[string]interface{}{}
+	for _, targetsItem := range tenant.Targets {
+		targetsItemMap, err := ResourceIBMLogsRouterTenantTargetTypeToMap(targetsItem)
+		if err != nil {
+			return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_logs_router_tenant", "read", "targets-to-map").GetDiag()
+		}
+		targets = append(targets, targetsItemMap)
+	}
+
+	saveCredsTarget0 := d.Get("targets.0.parameters.0.access_credential").(string)
+	saveCredsTarget1 := d.Get("targets.1.parameters.0.access_credential").(string)
+	if len(targets) == 2 {
+		if d.Get("targets.1.type").(string) == "logdna" {
+			targets[0], targets[1] = targets[1], targets[0]
+		}
+	}
+
+	if err = d.Set("targets", targets); err != nil {
+		err = fmt.Errorf("Error setting targets: %s", err)
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_logs_router_tenant", "read", "set-targets").GetDiag()
+	}
+	if err = d.Set("created_at", tenant.CreatedAt); err != nil {
+		err = fmt.Errorf("Error setting created_at: %s", err)
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_logs_router_tenant", "read", "set-created_at").GetDiag()
+	}
+	if err = d.Set("updated_at", tenant.UpdatedAt); err != nil {
+		err = fmt.Errorf("Error setting updated_at: %s", err)
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_logs_router_tenant", "read", "set-updated_at").GetDiag()
+	}
+	if err = d.Set("crn", tenant.CRN); err != nil {
+		err = fmt.Errorf("Error setting crn: %s", err)
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_logs_router_tenant", "read", "set-crn").GetDiag()
+	}
+	if err = d.Set("etag", tenant.Etag); err != nil {
+		err = fmt.Errorf("Error setting etag: %s", err)
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_logs_router_tenant", "read", "set-etag").GetDiag()
+	}
+
+	rewriteAccessCredential := false
+	newCRNTarget0, check := d.GetOk("targets.0.log_sink_crn")
+	if check {
+		if crn, ok := newCRNTarget0.(string); ok && crn != "" {
+			if strings.Contains(crn, ":logdna:") {
+				model := &ibmcloudlogsroutingv0.TargetParametersTypeLogDnaPrototype{}
+				hostTarget0 := d.Get("targets.0.parameters.0.host").(string)
+				portTarget0 := int64(d.Get("targets.0.parameters.0.port").(int))
+				model.Host = &hostTarget0
+				model.Port = &portTarget0
+				model.AccessCredential = &saveCredsTarget0
+				parameters0Map, err := ResourceIBMLogsRouterTenantTargetParametersTypeLogDnaToMapAccessCredential(model)
+				if err != nil {
+					return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_logs_router_tenant", "read", "set-access_credential").GetDiag()
+				}
+				targets[0]["parameters"] = []map[string]interface{}{parameters0Map}
+				rewriteAccessCredential = true
+			}
+		}
+	}
+
+	newCRNTarget1, check := d.GetOk("targets.1.log_sink_crn")
+	if check {
+		if crn, ok := newCRNTarget1.(string); ok && crn != "" {
+			if strings.Contains(crn, ":logdna:") {
+				model := &ibmcloudlogsroutingv0.TargetParametersTypeLogDnaPrototype{}
+				hostTarget1 := d.Get("targets.1.parameters.0.host").(string)
+				portTarget1 := int64(d.Get("targets.1.parameters.0.port").(int))
+				model.Host = &hostTarget1
+				model.Port = &portTarget1
+				model.AccessCredential = &saveCredsTarget1
+				parameters1Map, err := ResourceIBMLogsRouterTenantTargetParametersTypeLogDnaToMapAccessCredential(model)
+				if err != nil {
+					return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_logs_router_tenant", "read", "set-access_credential").GetDiag()
+				}
+				targets[1]["parameters"] = []map[string]interface{}{parameters1Map}
+				rewriteAccessCredential = true
+			}
+		}
+	}
+
+	if rewriteAccessCredential {
+		if err = d.Set("targets", targets); err != nil {
+			err = fmt.Errorf("Error setting targets: %s", err)
+			return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_logs_router_tenant", "read", "set-targets").GetDiag()
+		}
+	}
+
+	return nil
+}
+
+func resourceIBMLogsRouterTenantUpdate(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	ibmCloudLogsRoutingClient, err := meta.(conns.ClientSession).IBMCloudLogsRoutingV0()
+	if err != nil {
+		tfErr := flex.TerraformErrorf(err, err.Error(), "ibm_logs_router_tenant", "update")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
+	}
+
+	updateTenantOptions := &ibmcloudlogsroutingv0.UpdateTenantOptions{}
+
+	tenantId := strfmt.UUID(d.Id())
+	updateTenantOptions.SetTenantID(&tenantId)
+
+	hasChange := false
+	hasChangeTarget0 := false
+	hasChangeTarget1 := false
+
+	patchVals := &ibmcloudlogsroutingv0.TenantPatch{}
+
+	if d.HasChange("name") {
+		newName := d.Get("name").(string)
+		patchVals.Name = &newName
+		hasChange = true
+	}
+
+	updateTenantOptions.SetIfMatch(d.Get("etag").(string))
+
+	updateTarget0Options := &ibmcloudlogsroutingv0.UpdateTargetOptions{}
+	target0ID := strfmt.UUID(d.Get("targets.0.id").(string))
+	updateTarget0Options.SetTenantID(&tenantId)
+	updateTarget0Options.SetTargetID(&target0ID)
+
+	patchValsTarget0 := &ibmcloudlogsroutingv0.TargetTypePatch{}
+	if d.HasChange("targets.0.tenant_id") {
+		errMsg := fmt.Sprintf("Cannot update resource property \"%s\" with the ForceNew annotation."+
+			" The resource must be re-created to update this property.", "tenant_id")
+		return flex.DiscriminatedTerraformErrorf(nil, errMsg, "ibm_logs_router_tenant", "update", "tenant_id-forces-new").GetDiag()
+	}
+	if d.HasChange("targets.0.log_sink_crn") {
+		newLogSinkCRN := d.Get("targets.0.log_sink_crn").(string)
+		patchValsTarget0.LogSinkCRN = &newLogSinkCRN
+		hasChangeTarget0 = true
+	}
+	if d.HasChange("targets.0.name") {
+		newName := d.Get("targets.0.name").(string)
+		patchValsTarget0.Name = &newName
+		hasChangeTarget0 = true
+	}
+	if d.HasChange("targets.0.parameters") {
+		parameters, err := ResourceIBMLogsRouterTargetMapToTargetParametersTypeLogDNAPrototype(d.Get("targets.0.parameters.0").(map[string]interface{}))
+		if err != nil {
+			return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_logs_router_tenant", "update", "parse-parameters").GetDiag()
+		}
+		patchValsTarget0.Parameters = parameters
+		hasChangeTarget0 = true
+	}
+	updateTarget0Options.SetIfMatch(d.Get("targets.0.etag").(string))
+
+	updateTarget1Options := &ibmcloudlogsroutingv0.UpdateTargetOptions{}
+	target1ID := strfmt.UUID(d.Get("targets.1.id").(string))
+	updateTarget1Options.SetTenantID(&tenantId)
+	updateTarget1Options.SetTargetID(&target1ID)
+
+	bodyModelMap := map[string]interface{}{}
+	createTarget1Options := &ibmcloudlogsroutingv0.CreateTargetOptions{}
+	target1Create := false
+	if d.Get("targets.1.id").(string) == "" && d.Get("targets.1.log_sink_crn").(string) != "" {
+		target1Create = true
+		if _, ok := d.GetOk("targets.1.log_sink_crn"); ok {
+			bodyModelMap["log_sink_crn"] = d.Get("targets.1.log_sink_crn")
+		}
+		if _, ok := d.GetOk("targets.1.name"); ok {
+			bodyModelMap["name"] = d.Get("targets.1.name")
+		}
+		if _, ok := d.GetOk("targets.1.parameters"); ok {
+			bodyModelMap["parameters"] = d.Get("targets.1.parameters")
+		}
+		createTarget1Options.SetTenantID(&tenantId)
+		convertedModel, err := ResourceIBMLogsRouterTargetMapToTargetTypePrototypeTargetTypeLogDNAPrototype(bodyModelMap)
+		if err != nil {
+			return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_logs_router_target", "create", "parse-request-body").GetDiag()
+		}
+		createTarget1Options.TargetTypePrototype = convertedModel
+	}
+
+	patchValsTarget1 := &ibmcloudlogsroutingv0.TargetTypePatch{}
+	if d.HasChange("targets.1.tenant_id") {
+		errMsg := fmt.Sprintf("Cannot update resource property \"%s\" with the ForceNew annotation."+
+			" The resource must be re-created to update this property.", "tenant_id")
+		return flex.DiscriminatedTerraformErrorf(nil, errMsg, "ibm_logs_router_tenant", "update", "tenant_id-forces-new").GetDiag()
+	}
+	if d.HasChange("targets.1.log_sink_crn") {
+		newLogSinkCRN := d.Get("targets.1.log_sink_crn").(string)
+		patchValsTarget1.LogSinkCRN = &newLogSinkCRN
+		hasChangeTarget1 = true
+	}
+	if d.HasChange("targets.1.name") {
+		newName := d.Get("targets.1.name").(string)
+		patchValsTarget1.Name = &newName
+		hasChangeTarget1 = true
+	}
+	if d.HasChange("targets.1.parameters") {
+		parameters, err := ResourceIBMLogsRouterTargetMapToTargetParametersTypeLogDNAPrototype(d.Get("targets.1.parameters.0").(map[string]interface{}))
+		if err != nil {
+			return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_logs_router_tenant", "update", "parse-parameters").GetDiag()
+		}
+		patchValsTarget1.Parameters = parameters
+		hasChangeTarget1 = true
+	}
+	updateTarget1Options.SetIfMatch(d.Get("targets.1.etag").(string))
+
+	if hasChange {
+		updateTenantOptions.TenantPatch, _ = patchVals.AsPatch()
+
+		// Fields with `nil` values are omitted from the generic map,
+		// so we need to re-add them to support removing arguments.
+		if _, exists := d.GetOk("name"); d.HasChange("name") && !exists {
+			updateTenantOptions.TenantPatch["name"] = nil
+		}
+
+		_, _, err = ibmCloudLogsRoutingClient.UpdateTenantWithContext(context, updateTenantOptions)
+		if err != nil {
+			tfErr := flex.TerraformErrorf(err, fmt.Sprintf("UpdateTenantWithContext failed: %s", err.Error()), "ibm_logs_router_tenant", "update")
+			log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+			return tfErr.GetDiag()
+		}
+	}
+
+	target0Patched := false
+
+	// second target will be created either logDNA or logs, but first target must be changed first
+	// if there is a change to the existing target1, we have to apply that first either delete or udpate, then update target 0
+	if target1Create && hasChangeTarget0 {
+		updateTarget0Options.TargetTypePatch, _ = patchValsTarget0.AsPatch()
+
+		// Fields with `nil` values are omitted from the generic map,
+		// so we need to re-add them to support removing arguments.
+		if _, exists := d.GetOk("targets.0.log_sink_crn"); d.HasChange("targets.0.log_sink_crn") && !exists {
+			updateTarget0Options.TargetTypePatch["log_sink_crn"] = nil
+		}
+		if _, exists := d.GetOk("targets.0.name"); d.HasChange("targets.0.name") && !exists {
+			updateTarget0Options.TargetTypePatch["name"] = nil
+		}
+		if _, exists := d.GetOk("targets.0.parameters"); d.HasChange("targets.0.parameters") && !exists {
+			updateTarget0Options.TargetTypePatch["parameters"] = nil
+		}
+		target0Patched = true
+
+		_, newCRN := d.GetChange("targets.0.log_sink_crn")
+		if crn, ok := newCRN.(string); ok {
+			if strings.Contains(crn, ":logs:") {
+				_, _, err = ibmCloudLogsRoutingClient.UpdateLogsTargetWithContext(context, updateTarget0Options)
+			} else {
+				_, _, err = ibmCloudLogsRoutingClient.UpdateTargetWithContext(context, updateTarget0Options)
+			}
+		}
+
+		if err != nil {
+			tfErr := flex.TerraformErrorf(err, fmt.Sprintf("UpdateTargetWithContext failed: %s", err.Error()), "ibm_logs_router_target", "update")
+			log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+			return tfErr.GetDiag()
+		}
+	}
+
+	if target1Create {
+		_, _, err := ibmCloudLogsRoutingClient.CreateTargetWithContext(context, createTarget1Options)
+		if err != nil {
+			tfErr := flex.TerraformErrorf(err, fmt.Sprintf("CreateTargetWithContext failed: %s", err.Error()), "ibm_logs_router_target", "create")
+			log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+			return tfErr.GetDiag()
+		}
+
+	} else if hasChangeTarget1 {
+		target1Delete := false
+		updateTarget1Options.TargetTypePatch, _ = patchValsTarget1.AsPatch()
+
+		// Fields with `nil` values are omitted from the generic map,
+		// so we need to re-add them to support removing arguments.
+		if _, exists := d.GetOk("targets.1.log_sink_crn"); d.HasChange("targets.1.log_sink_crn") && !exists {
+			updateTarget1Options.TargetTypePatch["log_sink_crn"] = nil
+		}
+		if _, exists := d.GetOk("targets.1.name"); d.HasChange("targets.1.name") && !exists {
+			updateTarget1Options.TargetTypePatch["name"] = nil
+		}
+		if _, exists := d.GetOk("targets.1.parameters"); d.HasChange("targets.1.parameters") && !exists {
+			updateTarget1Options.TargetTypePatch["parameters"] = nil
+			target1Delete = true
+		}
+		if target1Delete {
+			deleteTargetOptions := &ibmcloudlogsroutingv0.DeleteTargetOptions{}
+			deleteTargetOptions.SetTenantID(&tenantId)
+			deleteTargetOptions.SetTargetID(&target1ID)
+			_, err = ibmCloudLogsRoutingClient.DeleteTargetWithContext(context, deleteTargetOptions)
+			if err != nil {
+				tfErr := flex.TerraformErrorf(err, fmt.Sprintf("DeleteTargetWithContext failed: %s", err.Error()), "ibm_logs_router_target", "delete")
+				log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+				return tfErr.GetDiag()
+			}
+
+		} else {
+			_, newCRN := d.GetChange("targets.1.log_sink_crn")
+			if crn, ok := newCRN.(string); ok {
+				if strings.Contains(crn, ":logs:") {
+					_, _, err = ibmCloudLogsRoutingClient.UpdateLogsTargetWithContext(context, updateTarget1Options)
+				} else {
+					_, _, err = ibmCloudLogsRoutingClient.UpdateTargetWithContext(context, updateTarget1Options)
+				}
+			}
+			if err != nil {
+				tfErr := flex.TerraformErrorf(err, fmt.Sprintf("UpdateTargetWithContext failed: %s", err.Error()), "ibm_logs_router_target", "update")
+				log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+				return tfErr.GetDiag()
+			}
+		}
+	}
+
+	if hasChangeTarget0 && !target0Patched {
+		updateTarget0Options.TargetTypePatch, _ = patchValsTarget0.AsPatch()
+
+		// Fields with `nil` values are omitted from the generic map,
+		// so we need to re-add them to support removing arguments.
+		if _, exists := d.GetOk("targets.0.log_sink_crn"); d.HasChange("targets.0.log_sink_crn") && !exists {
+			updateTarget0Options.TargetTypePatch["log_sink_crn"] = nil
+		}
+		if _, exists := d.GetOk("targets.0.name"); d.HasChange("targets.0.name") && !exists {
+			updateTarget0Options.TargetTypePatch["name"] = nil
+		}
+		if _, exists := d.GetOk("targets.0.parameters"); d.HasChange("targets.0.parameters") && !exists {
+			updateTarget0Options.TargetTypePatch["parameters"] = nil
+		}
+		target0Patched = true
+		// update logs RM access credential
+		_, newCRN := d.GetChange("targets.0.log_sink_crn")
+		if crn, ok := newCRN.(string); ok {
+			if strings.Contains(crn, ":logs:") {
+				_, _, err = ibmCloudLogsRoutingClient.UpdateLogsTargetWithContext(context, updateTarget0Options)
+			} else {
+				_, _, err = ibmCloudLogsRoutingClient.UpdateTargetWithContext(context, updateTarget0Options)
+			}
+		}
+		if err != nil {
+			tfErr := flex.TerraformErrorf(err, fmt.Sprintf("UpdateTargetWithContext failed: %s", err.Error()), "ibm_logs_router_target", "update")
+			log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+			return tfErr.GetDiag()
+		}
+	}
+
+	return resourceIBMLogsRouterTenantRead(context, d, meta)
+}
+
+func resourceIBMLogsRouterTenantDelete(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	ibmCloudLogsRoutingClient, err := meta.(conns.ClientSession).IBMCloudLogsRoutingV0()
+	if err != nil {
+		tfErr := flex.TerraformErrorf(err, err.Error(), "ibm_logs_router_tenant", "delete")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
+	}
+
+	deleteTenantOptions := &ibmcloudlogsroutingv0.DeleteTenantOptions{}
+
+	tenantId := strfmt.UUID(d.Id())
+	deleteTenantOptions.SetTenantID(&tenantId)
+
+	_, err = ibmCloudLogsRoutingClient.DeleteTenantWithContext(context, deleteTenantOptions)
+	if err != nil {
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("DeleteTenantWithContext failed: %s", err.Error()), "ibm_logs_router_tenant", "delete")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
+	}
+
+	d.SetId("")
+
+	return nil
+}
+
+func ResourceIBMLogsRouterTenantMapToTargetTypePrototype(modelMap map[string]interface{}) (ibmcloudlogsroutingv0.TargetTypePrototypeIntf, error) {
+	model := &ibmcloudlogsroutingv0.TargetTypePrototype{}
+	if modelMap["log_sink_crn"] != nil && modelMap["log_sink_crn"].(string) != "" {
+		model.LogSinkCRN = core.StringPtr(modelMap["log_sink_crn"].(string))
+	}
+	if modelMap["name"] != nil && modelMap["name"].(string) != "" {
+		model.Name = core.StringPtr(modelMap["name"].(string))
+	}
+	if modelMap["parameters"] != nil && len(modelMap["parameters"].([]interface{})) > 0 {
+		ParametersModel, err := ResourceIBMLogsRouterTenantMapToTargetParametersTypeLogDnaPrototype(modelMap["parameters"].([]interface{})[0].(map[string]interface{}))
+		if err != nil {
+			return model, err
+		}
+		model.Parameters = ParametersModel
+	}
+	return model, nil
+}
+
+func ResourceIBMLogsRouterTenantMapToTargetParametersTypeLogDnaPrototype(modelMap map[string]interface{}) (*ibmcloudlogsroutingv0.TargetParametersTypeLogDnaPrototype, error) {
+	model := &ibmcloudlogsroutingv0.TargetParametersTypeLogDnaPrototype{}
+	model.Host = core.StringPtr(modelMap["host"].(string))
+	model.Port = core.Int64Ptr(int64(modelMap["port"].(int)))
+	model.AccessCredential = core.StringPtr(modelMap["access_credential"].(string))
+	return model, nil
+}
+
+func ResourceIBMLogsRouterTenantMapToTargetTypePrototypeTargetTypeLogDnaPrototype(modelMap map[string]interface{}) (*ibmcloudlogsroutingv0.TargetTypePrototypeTargetTypeLogDnaPrototype, error) {
+	model := &ibmcloudlogsroutingv0.TargetTypePrototypeTargetTypeLogDnaPrototype{}
+	model.LogSinkCRN = core.StringPtr(modelMap["log_sink_crn"].(string))
+	model.Name = core.StringPtr(modelMap["name"].(string))
+	if modelMap["parameters"] != nil && len(modelMap["parameters"].([]interface{})) > 0 {
+		ParametersModel, err := ResourceIBMLogsRouterTenantMapToTargetParametersTypeLogDnaPrototype(modelMap["parameters"].([]interface{})[0].(map[string]interface{}))
+		if err != nil {
+			return model, err
+		}
+		model.Parameters = ParametersModel
+	}
+	return model, nil
+}
+
+func ResourceIBMLogsRouterTenantMapToTargetTypePrototypeTargetTypeLogsPrototype(modelMap map[string]interface{}) (*ibmcloudlogsroutingv0.TargetTypePrototypeTargetTypeLogsPrototype, error) {
+	model := &ibmcloudlogsroutingv0.TargetTypePrototypeTargetTypeLogsPrototype{}
+	model.LogSinkCRN = core.StringPtr(modelMap["log_sink_crn"].(string))
+	model.Name = core.StringPtr(modelMap["name"].(string))
+	if modelMap["parameters"] != nil && len(modelMap["parameters"].([]interface{})) > 0 {
+		ParametersModel, err := ResourceIBMLogsRouterTenantMapToTargetParametersTypeLogsPrototype(modelMap["parameters"].([]interface{})[0].(map[string]interface{}))
+		if err != nil {
+			return model, err
+		}
+		model.Parameters = ParametersModel
+	}
+	return model, nil
+}
+
+func ResourceIBMLogsRouterTenantMapToTargetParametersTypeLogsPrototype(modelMap map[string]interface{}) (*ibmcloudlogsroutingv0.TargetParametersTypeLogsPrototype, error) {
+	model := &ibmcloudlogsroutingv0.TargetParametersTypeLogsPrototype{}
+	model.Host = core.StringPtr(modelMap["host"].(string))
+	model.Port = core.Int64Ptr(int64(modelMap["port"].(int)))
+	return model, nil
+}
+
+func ResourceIBMLogsRouterTenantTargetTypeToMap(model ibmcloudlogsroutingv0.TargetTypeIntf) (map[string]interface{}, error) {
+	if _, ok := model.(*ibmcloudlogsroutingv0.TargetTypeLogDna); ok {
+		return ResourceIBMLogsRouterTenantTargetTypeLogDnaToMap(model.(*ibmcloudlogsroutingv0.TargetTypeLogDna))
+	} else if _, ok := model.(*ibmcloudlogsroutingv0.TargetTypeLogs); ok {
+		return ResourceIBMLogsRouterTenantTargetTypeLogsToMap(model.(*ibmcloudlogsroutingv0.TargetTypeLogs))
+	} else if _, ok := model.(*ibmcloudlogsroutingv0.TargetType); ok {
+		modelMap := make(map[string]interface{})
+		model := model.(*ibmcloudlogsroutingv0.TargetType)
+		if model.ID != nil {
+			modelMap["id"] = model.ID.String()
+		}
+		if model.LogSinkCRN != nil {
+			modelMap["log_sink_crn"] = *model.LogSinkCRN
+		}
+		if model.Name != nil {
+			modelMap["name"] = *model.Name
+		}
+		if model.Etag != nil {
+			modelMap["etag"] = *model.Etag
+		}
+		if model.Type != nil {
+			modelMap["type"] = *model.Type
+		}
+		if model.CreatedAt != nil {
+			modelMap["created_at"] = *model.CreatedAt
+		}
+		if model.UpdatedAt != nil {
+			modelMap["updated_at"] = *model.UpdatedAt
+		}
+		if model.Parameters != nil {
+			parametersMap, err := ResourceIBMLogsRouterTenantTargetParametersTypeLogDnaToMap(model.Parameters)
+			if err != nil {
+				return modelMap, err
+			}
+			modelMap["parameters"] = []map[string]interface{}{parametersMap}
+		}
+		return modelMap, nil
+	} else {
+		return nil, fmt.Errorf("Unrecognized ibmcloudlogsroutingv0.TargetTypeIntf subtype encountered")
+	}
+}
+
+func ResourceIBMLogsRouterTenantTargetParametersTypeLogDnaToMap(model *ibmcloudlogsroutingv0.TargetParametersTypeLogDna) (map[string]interface{}, error) {
+	modelMap := make(map[string]interface{})
+	modelMap["host"] = *model.Host
+	modelMap["port"] = flex.IntValue(model.Port)
+	return modelMap, nil
+}
+
+func ResourceIBMLogsRouterTenantTargetParametersTypeLogDnaToMapAccessCredential(model *ibmcloudlogsroutingv0.TargetParametersTypeLogDnaPrototype) (map[string]interface{}, error) {
+	modelMap := make(map[string]interface{})
+	modelMap["host"] = *model.Host
+	modelMap["port"] = flex.IntValue(model.Port)
+	modelMap["access_credential"] = *model.AccessCredential // pragma: whitelist secret
+	return modelMap, nil
+}
+
+func ResourceIBMLogsRouterTenantTargetTypeLogDnaToMap(model *ibmcloudlogsroutingv0.TargetTypeLogDna) (map[string]interface{}, error) {
+	modelMap := make(map[string]interface{})
+	modelMap["id"] = model.ID.String()
+	modelMap["log_sink_crn"] = *model.LogSinkCRN
+	modelMap["name"] = *model.Name
+	modelMap["etag"] = *model.Etag
+	modelMap["type"] = *model.Type
+	modelMap["created_at"] = *model.CreatedAt
+	modelMap["updated_at"] = *model.UpdatedAt
+	if model.Parameters != nil {
+		parametersMap, err := ResourceIBMLogsRouterTenantTargetParametersTypeLogDnaToMap(model.Parameters)
+		if err != nil {
+			return modelMap, err
+		}
+		modelMap["parameters"] = []map[string]interface{}{parametersMap}
+	}
+	return modelMap, nil
+}
+
+func ResourceIBMLogsRouterTenantTargetTypeLogsToMap(model *ibmcloudlogsroutingv0.TargetTypeLogs) (map[string]interface{}, error) {
+	modelMap := make(map[string]interface{})
+	modelMap["id"] = model.ID.String()
+	modelMap["log_sink_crn"] = *model.LogSinkCRN
+	modelMap["name"] = *model.Name
+	modelMap["etag"] = *model.Etag
+	modelMap["type"] = *model.Type
+	modelMap["created_at"] = *model.CreatedAt
+	modelMap["updated_at"] = *model.UpdatedAt
+	if model.Parameters != nil {
+		parametersMap, err := ResourceIBMLogsRouterTenantTargetParametersTypeLogsToMap(model.Parameters)
+		if err != nil {
+			return modelMap, err
+		}
+		modelMap["parameters"] = []map[string]interface{}{parametersMap}
+	}
+	return modelMap, nil
+}
+
+func ResourceIBMLogsRouterTenantTargetParametersTypeLogsToMap(model *ibmcloudlogsroutingv0.TargetParametersTypeLogs) (map[string]interface{}, error) {
+	modelMap := make(map[string]interface{})
+	modelMap["host"] = *model.Host
+	modelMap["port"] = flex.IntValue(model.Port)
+	return modelMap, nil
+}
+
+func ResourceIBMLogsRouterTargetMapToTargetParametersTypeLogDNAPrototype(modelMap map[string]interface{}) (*ibmcloudlogsroutingv0.TargetParametersTypeLogDnaPrototype, error) {
+	model := &ibmcloudlogsroutingv0.TargetParametersTypeLogDnaPrototype{}
+	model.Host = core.StringPtr(modelMap["host"].(string))
+	model.Port = core.Int64Ptr(int64(modelMap["port"].(int)))
+	model.AccessCredential = core.StringPtr(modelMap["access_credential"].(string))
+	return model, nil
+}
+
+func ResourceIBMLogsRouterTargetMapToTargetTypePrototypeTargetTypeLogDNAPrototype(modelMap map[string]interface{}) (*ibmcloudlogsroutingv0.TargetTypePrototypeTargetTypeLogDnaPrototype, error) {
+	model := &ibmcloudlogsroutingv0.TargetTypePrototypeTargetTypeLogDnaPrototype{}
+	model.LogSinkCRN = core.StringPtr(modelMap["log_sink_crn"].(string))
+	model.Name = core.StringPtr(modelMap["name"].(string))
+	if modelMap["parameters"] != nil && len(modelMap["parameters"].([]interface{})) > 0 {
+		ParametersModel, err := ResourceIBMLogsRouterTargetMapToTargetParametersTypeLogDNAPrototype(modelMap["parameters"].([]interface{})[0].(map[string]interface{}))
+		if err != nil {
+			return model, err
+		}
+		model.Parameters = ParametersModel
+	}
+	return model, nil
+}

--- a/ibm/service/logsrouting/resource_ibm_logs-router_tenant_test.go
+++ b/ibm/service/logsrouting/resource_ibm_logs-router_tenant_test.go
@@ -1,0 +1,467 @@
+// Copyright IBM Corp. 2024 All Rights Reserved.
+// Licensed under the Mozilla Public License v2.0
+
+package logsrouting_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/go-openapi/strfmt"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	acc "github.com/IBM-Cloud/terraform-provider-ibm/ibm/acctest"
+	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/conns"
+	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/logsrouting"
+	. "github.com/IBM-Cloud/terraform-provider-ibm/ibm/unittest"
+	"github.com/IBM/go-sdk-core/v5/core"
+	"github.com/IBM/logs-router-go-sdk/ibmcloudlogsroutingv0"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestAccIBMLogsRouterTenantBasic(t *testing.T) {
+	var conf ibmcloudlogsroutingv0.Tenant
+	name := fmt.Sprintf("tf-name-%d", acctest.RandIntRange(10, 100))
+	host := fmt.Sprintf("www.example.%d.com", acctest.RandIntRange(10, 100))
+	crn := "crn:v1:bluemix:public:logdna:eu-de:a/3516b8fa0a174a71899f5affa4f18d78:3517d2ed-9429-af34-ad52-34278391cbc8::"
+	nameUpdate := fmt.Sprintf("tf-name-%d", acctest.RandIntRange(10, 100))
+	hostUpdate := fmt.Sprintf("www.example.%d.com", acctest.RandIntRange(10, 100))
+	crnUpdate := "crn:v1:bluemix:public:logdna:eu-de:a/3516b8fa0a174a71899f5affa4f18d78:3517d2ed-9429-af34-ad52-34278391cbc8::"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { acc.TestAccPreCheck(t) },
+		Providers:    acc.TestAccProviders,
+		CheckDestroy: testAccCheckIBMLogsRouterTenantDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccCheckIBMLogsRouterTenantConfigBasic(name, crn, host),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckIBMLogsRouterTenantExists("ibm_logs_router_tenant.logs_router_tenant_instance", conf),
+					resource.TestCheckResourceAttr("ibm_logs_router_tenant.logs_router_tenant_instance", "name", name),
+				),
+			},
+			resource.TestStep{
+				Config: testAccCheckIBMLogsRouterTenantConfigBasic(nameUpdate, crnUpdate, hostUpdate),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("ibm_logs_router_tenant.logs_router_tenant_instance", "name", nameUpdate),
+				),
+			},
+			resource.TestStep{
+				ResourceName:            "ibm_logs_router_tenant.logs_router_tenant_instance",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"targets.0.parameters.0.access_credential", "targets.1.parameters.0.access_credential"},
+			},
+		},
+	})
+}
+
+func TestAccIBMLogsRouterTenantAllArgs(t *testing.T) {
+	var conf ibmcloudlogsroutingv0.Tenant
+
+	name := fmt.Sprintf("tenant-name-%d", acctest.RandIntRange(10, 100))
+	host0 := fmt.Sprintf("www.example.%d.com", acctest.RandIntRange(10, 100))
+	port0 := acctest.RandIntRange(1, 9999)
+	target0Name := fmt.Sprintf("target-%s", acctest.RandString(4))
+	accessCredential := fmt.Sprintf("access-%s", acctest.RandString(4))
+
+	nameUpdate := fmt.Sprintf("tenant-name-%d", acctest.RandIntRange(10, 100))
+	host0Update := fmt.Sprintf("www.example.%d.com", acctest.RandIntRange(10, 100))
+	port0Update := acctest.RandIntRange(1, 9999)
+	target0NameUpdate := fmt.Sprintf("target-%s", acctest.RandString(4))
+	accessCredentialUpdate := fmt.Sprintf("access-%s", acctest.RandString(4))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { acc.TestAccPreCheck(t) },
+		Providers:    acc.TestAccProviders,
+		CheckDestroy: testAccCheckIBMLogsRouterTenantDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccCheckIBMLogsRouterTenantConfigAllArgs(name, target0Name, host0, port0, accessCredential),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckIBMLogsRouterTenantExists("ibm_logs_router_tenant.logs_router_tenant_instance", conf),
+					resource.TestCheckResourceAttr("ibm_logs_router_tenant.logs_router_tenant_instance", "name", name),
+				),
+			},
+			resource.TestStep{
+				Config: testAccCheckIBMLogsRouterTenantConfigAllArgs(nameUpdate, target0NameUpdate, host0Update, port0Update, accessCredentialUpdate),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("ibm_logs_router_tenant.logs_router_tenant_instance", "name", nameUpdate),
+				),
+			},
+			resource.TestStep{
+				ResourceName:            "ibm_logs_router_tenant.logs_router_tenant_instance",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"targets.0.parameters.0.access_credential", "targets.1.parameters.0.access_credential"},
+			},
+		},
+	})
+}
+
+func testAccCheckIBMLogsRouterTenantConfigBasic(name string, crn string, host string) string {
+	return fmt.Sprintf(`
+		resource "ibm_logs_router_tenant" "logs_router_tenant_instance" {
+			name = "%s"
+			targets {
+				log_sink_crn = "%s"
+				name = "my-log-sink"
+				parameters {
+					host = "%s"
+					port = 1
+					access_credential = "%s"
+				}
+			}
+		}
+		`, name, crn, host, acc.IngestionKey)
+}
+
+func testAccCheckIBMLogsRouterTenantConfigAllArgs(name string, target0Name string, host0 string, port0 int, accessCredential string) string {
+	return fmt.Sprintf(`
+		resource "ibm_logs_router_tenant" "logs_router_tenant_instance" {
+			name = "%s"
+			targets {
+				log_sink_crn = "crn:v1:bluemix:public:logdna:eu-de:a/3516b8fa0a174a71899f5affa4f18d78:3517d2ed-9429-af34-ad52-34278391cbc8::"
+				name = "%s"
+				parameters {
+					host = "%s"
+					port = %d
+					access_credential = "%s"
+				}
+			}
+		}
+		`, name, target0Name, host0, port0, accessCredential)
+}
+
+func testAccCheckIBMLogsRouterTenantExists(n string, obj ibmcloudlogsroutingv0.Tenant) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+
+		ibmCloudLogsRoutingClient, err := acc.TestAccProvider.Meta().(conns.ClientSession).IBMCloudLogsRoutingV0()
+		if err != nil {
+			return err
+		}
+
+		getTenantDetailOptions := &ibmcloudlogsroutingv0.GetTenantDetailOptions{}
+
+		tenantId := strfmt.UUID(rs.Primary.ID)
+		getTenantDetailOptions.SetTenantID(&tenantId)
+
+		tenant, _, err := ibmCloudLogsRoutingClient.GetTenantDetail(getTenantDetailOptions)
+		if err != nil {
+			return err
+		}
+
+		obj = *tenant
+		return nil
+	}
+}
+
+func testAccCheckIBMLogsRouterTenantDestroy(s *terraform.State) error {
+	ibmCloudLogsRoutingClient, err := acc.TestAccProvider.Meta().(conns.ClientSession).IBMCloudLogsRoutingV0()
+	if err != nil {
+		return err
+	}
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "ibm_logs_router_tenant" {
+			continue
+		}
+
+		getTenantDetailOptions := &ibmcloudlogsroutingv0.GetTenantDetailOptions{}
+
+		tenantId := strfmt.UUID(rs.Primary.ID)
+		getTenantDetailOptions.SetTenantID(&tenantId)
+
+		// Try to find the key
+		_, response, err := ibmCloudLogsRoutingClient.GetTenantDetail(getTenantDetailOptions)
+
+		if err == nil {
+			return fmt.Errorf("logs_router_tenant still exists: %s", rs.Primary.ID)
+		} else if response.StatusCode != 404 {
+			return fmt.Errorf("Error checking for logs_router_tenant (%s) has been destroyed: %s", rs.Primary.ID, err)
+		}
+	}
+
+	return nil
+}
+
+func TestResourceIBMLogsRouterTenantTargetTypeToMap(t *testing.T) {
+	checkResult := func(result map[string]interface{}) {
+		targetParametersTypeLogDnaModel := make(map[string]interface{})
+		targetParametersTypeLogDnaModel["host"] = "www.example.com"
+		targetParametersTypeLogDnaModel["port"] = int(1)
+
+		model := make(map[string]interface{})
+		model["id"] = "8717db99-2cfb-4ba6-a033-89c994c2e9f0"
+		model["log_sink_crn"] = "crn:v1:bluemix:public:logdna:eu-de:a/3516b8fa0a174a71899f5affa4f18d78:3517d2ed-9429-af34-ad52-34278391cbc8::"
+		model["name"] = "my-log-sink"
+		model["etag"] = "c3a43545a7f2675970671ac3a57b8db067a1866b2222e1b950ee8da612e347c6"
+		model["type"] = "logdna"
+		model["created_at"] = "2024-06-20T18:30:00.143156Z"
+		model["updated_at"] = "2024-06-20T18:30:00.143156Z"
+		model["parameters"] = []map[string]interface{}{targetParametersTypeLogDnaModel}
+
+		assert.Equal(t, result, model)
+	}
+
+	targetParametersTypeLogDnaModel := new(ibmcloudlogsroutingv0.TargetParametersTypeLogDna)
+	targetParametersTypeLogDnaModel.Host = core.StringPtr("www.example.com")
+	targetParametersTypeLogDnaModel.Port = core.Int64Ptr(int64(1))
+
+	model := new(ibmcloudlogsroutingv0.TargetType)
+	model.ID = CreateMockUUID("8717db99-2cfb-4ba6-a033-89c994c2e9f0")
+	model.LogSinkCRN = core.StringPtr("crn:v1:bluemix:public:logdna:eu-de:a/3516b8fa0a174a71899f5affa4f18d78:3517d2ed-9429-af34-ad52-34278391cbc8::")
+	model.Name = core.StringPtr("my-log-sink")
+	model.Etag = core.StringPtr("c3a43545a7f2675970671ac3a57b8db067a1866b2222e1b950ee8da612e347c6")
+	model.Type = core.StringPtr("logdna")
+	model.CreatedAt = core.StringPtr("2024-06-20T18:30:00.143156Z")
+	model.UpdatedAt = core.StringPtr("2024-06-20T18:30:00.143156Z")
+	model.Parameters = targetParametersTypeLogDnaModel
+
+	result, err := logsrouting.ResourceIBMLogsRouterTenantTargetTypeToMap(model)
+	assert.Nil(t, err)
+	checkResult(result)
+}
+
+func TestResourceIBMLogsRouterTenantTargetParametersTypeLogDnaToMap(t *testing.T) {
+	checkResult := func(result map[string]interface{}) {
+		model := make(map[string]interface{})
+		model["host"] = "www.example.com"
+		model["port"] = int(1)
+
+		assert.Equal(t, result, model)
+	}
+
+	model := new(ibmcloudlogsroutingv0.TargetParametersTypeLogDna)
+	model.Host = core.StringPtr("www.example.com")
+	model.Port = core.Int64Ptr(int64(1))
+
+	result, err := logsrouting.ResourceIBMLogsRouterTenantTargetParametersTypeLogDnaToMap(model)
+	assert.Nil(t, err)
+	checkResult(result)
+}
+
+func TestResourceIBMLogsRouterTenantTargetTypeLogDnaToMap(t *testing.T) {
+	checkResult := func(result map[string]interface{}) {
+		targetParametersTypeLogDnaModel := make(map[string]interface{})
+		targetParametersTypeLogDnaModel["host"] = "www.example.com"
+		targetParametersTypeLogDnaModel["port"] = int(8080)
+
+		model := make(map[string]interface{})
+		model["id"] = "8717db99-2cfb-4ba6-a033-89c994c2e9f0"
+		model["log_sink_crn"] = "crn:v1:bluemix:public:logdna:eu-de:a/3516b8fa0a174a71899f5affa4f18d78:3517d2ed-9429-af34-ad52-34278391cbc8::"
+		model["name"] = "my-log-sink"
+		model["etag"] = "c3a43545a7f2675970671ac3a57b8db067a1866b2222e1b950ee8da612e347c6"
+		model["type"] = "logdna"
+		model["created_at"] = "2024-06-20T18:30:00.143156Z"
+		model["updated_at"] = "2024-06-20T18:30:00.143156Z"
+		model["parameters"] = []map[string]interface{}{targetParametersTypeLogDnaModel}
+
+		assert.Equal(t, result, model)
+	}
+
+	targetParametersTypeLogDnaModel := new(ibmcloudlogsroutingv0.TargetParametersTypeLogDna)
+	targetParametersTypeLogDnaModel.Host = core.StringPtr("www.example.com")
+	targetParametersTypeLogDnaModel.Port = core.Int64Ptr(int64(8080))
+
+	model := new(ibmcloudlogsroutingv0.TargetTypeLogDna)
+	model.ID = CreateMockUUID("8717db99-2cfb-4ba6-a033-89c994c2e9f0")
+	model.LogSinkCRN = core.StringPtr("crn:v1:bluemix:public:logdna:eu-de:a/3516b8fa0a174a71899f5affa4f18d78:3517d2ed-9429-af34-ad52-34278391cbc8::")
+	model.Name = core.StringPtr("my-log-sink")
+	model.Etag = core.StringPtr("c3a43545a7f2675970671ac3a57b8db067a1866b2222e1b950ee8da612e347c6")
+	model.Type = core.StringPtr("logdna")
+	model.CreatedAt = core.StringPtr("2024-06-20T18:30:00.143156Z")
+	model.UpdatedAt = core.StringPtr("2024-06-20T18:30:00.143156Z")
+	model.Parameters = targetParametersTypeLogDnaModel
+
+	result, err := logsrouting.ResourceIBMLogsRouterTenantTargetTypeLogDnaToMap(model)
+	assert.Nil(t, err)
+	checkResult(result)
+}
+
+func TestResourceIBMLogsRouterTenantTargetTypeLogsToMap(t *testing.T) {
+	checkResult := func(result map[string]interface{}) {
+		targetParametersTypeLogsModel := make(map[string]interface{})
+		targetParametersTypeLogsModel["host"] = "www.example.com"
+		targetParametersTypeLogsModel["port"] = int(8080)
+
+		model := make(map[string]interface{})
+		model["id"] = "8717db99-2cfb-4ba6-a033-89c994c2e9f0"
+		model["log_sink_crn"] = "crn:v1:bluemix:public:logs:eu-de:a/4516b8fa0a174a71899f5affa4f18d78:3517d2ed-9429-af34-ad52-34278391cbc8::"
+		model["name"] = "my-log-sink"
+		model["etag"] = "c3a43545a7f2675970671ac3a57b8db067a1866b2222e1b950ee8da612e347c6"
+		model["type"] = "logs"
+		model["created_at"] = "2024-06-20T18:30:00.143156Z"
+		model["updated_at"] = "2024-06-20T18:30:00.143156Z"
+		model["parameters"] = []map[string]interface{}{targetParametersTypeLogsModel}
+
+		assert.Equal(t, result, model)
+	}
+
+	targetParametersTypeLogsModel := new(ibmcloudlogsroutingv0.TargetParametersTypeLogs)
+	targetParametersTypeLogsModel.Host = core.StringPtr("www.example.com")
+	targetParametersTypeLogsModel.Port = core.Int64Ptr(int64(8080))
+
+	model := new(ibmcloudlogsroutingv0.TargetTypeLogs)
+	model.ID = CreateMockUUID("8717db99-2cfb-4ba6-a033-89c994c2e9f0")
+	model.LogSinkCRN = core.StringPtr("crn:v1:bluemix:public:logs:eu-de:a/4516b8fa0a174a71899f5affa4f18d78:3517d2ed-9429-af34-ad52-34278391cbc8::")
+	model.Name = core.StringPtr("my-log-sink")
+	model.Etag = core.StringPtr("c3a43545a7f2675970671ac3a57b8db067a1866b2222e1b950ee8da612e347c6")
+	model.Type = core.StringPtr("logs")
+	model.CreatedAt = core.StringPtr("2024-06-20T18:30:00.143156Z")
+	model.UpdatedAt = core.StringPtr("2024-06-20T18:30:00.143156Z")
+	model.Parameters = targetParametersTypeLogsModel
+
+	result, err := logsrouting.ResourceIBMLogsRouterTenantTargetTypeLogsToMap(model)
+	assert.Nil(t, err)
+	checkResult(result)
+}
+
+func TestResourceIBMLogsRouterTenantTargetParametersTypeLogsToMap(t *testing.T) {
+	checkResult := func(result map[string]interface{}) {
+		model := make(map[string]interface{})
+		model["host"] = "www.example.com"
+		model["port"] = int(1)
+
+		assert.Equal(t, result, model)
+	}
+
+	model := new(ibmcloudlogsroutingv0.TargetParametersTypeLogs)
+	model.Host = core.StringPtr("www.example.com")
+	model.Port = core.Int64Ptr(int64(1))
+
+	result, err := logsrouting.ResourceIBMLogsRouterTenantTargetParametersTypeLogsToMap(model)
+	assert.Nil(t, err)
+	checkResult(result)
+}
+
+func TestResourceIBMLogsRouterTenantMapToTargetTypePrototype(t *testing.T) {
+	checkResult := func(result ibmcloudlogsroutingv0.TargetTypePrototypeIntf) {
+		targetParametersTypeLogDnaPrototypeModel := new(ibmcloudlogsroutingv0.TargetParametersTypeLogDnaPrototype)
+		targetParametersTypeLogDnaPrototypeModel.Host = core.StringPtr("www.example.com")
+		targetParametersTypeLogDnaPrototypeModel.Port = core.Int64Ptr(int64(1))
+		targetParametersTypeLogDnaPrototypeModel.AccessCredential = core.StringPtr("ingestion-secret")
+
+		model := new(ibmcloudlogsroutingv0.TargetTypePrototype)
+		model.LogSinkCRN = core.StringPtr("crn:v1:bluemix:public:logdna:eu-de:a/3516b8fa0a174a71899f5affa4f18d78:3517d2ed-9429-af34-ad52-34278391cbc8::")
+		model.Name = core.StringPtr("my-log-sink")
+		model.Parameters = targetParametersTypeLogDnaPrototypeModel
+
+		assert.Equal(t, result, model)
+	}
+
+	targetParametersTypeLogDnaPrototypeModel := make(map[string]interface{})
+	targetParametersTypeLogDnaPrototypeModel["host"] = "www.example.com"
+	targetParametersTypeLogDnaPrototypeModel["port"] = int(1)
+	targetParametersTypeLogDnaPrototypeModel["access_credential"] = "ingestion-secret"
+
+	model := make(map[string]interface{})
+	model["log_sink_crn"] = "crn:v1:bluemix:public:logdna:eu-de:a/3516b8fa0a174a71899f5affa4f18d78:3517d2ed-9429-af34-ad52-34278391cbc8::"
+	model["name"] = "my-log-sink"
+	model["parameters"] = []interface{}{targetParametersTypeLogDnaPrototypeModel}
+
+	result, err := logsrouting.ResourceIBMLogsRouterTenantMapToTargetTypePrototype(model)
+	assert.Nil(t, err)
+	checkResult(result)
+}
+
+func TestResourceIBMLogsRouterTenantMapToTargetParametersTypeLogDnaPrototype(t *testing.T) {
+	checkResult := func(result *ibmcloudlogsroutingv0.TargetParametersTypeLogDnaPrototype) {
+		model := new(ibmcloudlogsroutingv0.TargetParametersTypeLogDnaPrototype)
+		model.Host = core.StringPtr("www.example.com")
+		model.Port = core.Int64Ptr(int64(1))
+		model.AccessCredential = core.StringPtr("ingestion-secret")
+
+		assert.Equal(t, result, model)
+	}
+
+	model := make(map[string]interface{})
+	model["host"] = "www.example.com"
+	model["port"] = int(1)
+	model["access_credential"] = "ingestion-secret"
+
+	result, err := logsrouting.ResourceIBMLogsRouterTenantMapToTargetParametersTypeLogDnaPrototype(model)
+	assert.Nil(t, err)
+	checkResult(result)
+}
+
+func TestResourceIBMLogsRouterTenantMapToTargetTypePrototypeTargetTypeLogDnaPrototype(t *testing.T) {
+	checkResult := func(result *ibmcloudlogsroutingv0.TargetTypePrototypeTargetTypeLogDnaPrototype) {
+		targetParametersTypeLogDnaPrototypeModel := new(ibmcloudlogsroutingv0.TargetParametersTypeLogDnaPrototype)
+		targetParametersTypeLogDnaPrototypeModel.Host = core.StringPtr("www.example.com")
+		targetParametersTypeLogDnaPrototypeModel.Port = core.Int64Ptr(int64(8080))
+		targetParametersTypeLogDnaPrototypeModel.AccessCredential = core.StringPtr("an-ingestion-secret")
+
+		model := new(ibmcloudlogsroutingv0.TargetTypePrototypeTargetTypeLogDnaPrototype)
+		model.LogSinkCRN = core.StringPtr("crn:v1:bluemix:public:logdna:eu-de:a/3516b8fa0a174a71899f5affa4f18d78:3517d2ed-9429-af34-ad52-34278391cbc8::")
+		model.Name = core.StringPtr("my-log-sink")
+		model.Parameters = targetParametersTypeLogDnaPrototypeModel
+
+		assert.Equal(t, result, model)
+	}
+
+	targetParametersTypeLogDnaPrototypeModel := make(map[string]interface{})
+	targetParametersTypeLogDnaPrototypeModel["host"] = "www.example.com"
+	targetParametersTypeLogDnaPrototypeModel["port"] = int(8080)
+	targetParametersTypeLogDnaPrototypeModel["access_credential"] = "an-ingestion-secret"
+
+	model := make(map[string]interface{})
+	model["log_sink_crn"] = "crn:v1:bluemix:public:logdna:eu-de:a/3516b8fa0a174a71899f5affa4f18d78:3517d2ed-9429-af34-ad52-34278391cbc8::"
+	model["name"] = "my-log-sink"
+	model["parameters"] = []interface{}{targetParametersTypeLogDnaPrototypeModel}
+
+	result, err := logsrouting.ResourceIBMLogsRouterTenantMapToTargetTypePrototypeTargetTypeLogDnaPrototype(model)
+	assert.Nil(t, err)
+	checkResult(result)
+}
+
+func TestResourceIBMLogsRouterTenantMapToTargetTypePrototypeTargetTypeLogsPrototype(t *testing.T) {
+	checkResult := func(result *ibmcloudlogsroutingv0.TargetTypePrototypeTargetTypeLogsPrototype) {
+		targetParametersTypeLogsPrototypeModel := new(ibmcloudlogsroutingv0.TargetParametersTypeLogsPrototype)
+		targetParametersTypeLogsPrototypeModel.Host = core.StringPtr("www.example.com")
+		targetParametersTypeLogsPrototypeModel.Port = core.Int64Ptr(int64(8080))
+
+		model := new(ibmcloudlogsroutingv0.TargetTypePrototypeTargetTypeLogsPrototype)
+		model.LogSinkCRN = core.StringPtr("crn:v1:bluemix:public:logs:eu-de:a/4516b8fa0a174a71899f5affa4f18d78:3517d2ed-9429-af34-ad52-34278391cbc8::")
+		model.Name = core.StringPtr("my-log-sink")
+		model.Parameters = targetParametersTypeLogsPrototypeModel
+
+		assert.Equal(t, result, model)
+	}
+
+	targetParametersTypeLogsPrototypeModel := make(map[string]interface{})
+	targetParametersTypeLogsPrototypeModel["host"] = "www.example.com"
+	targetParametersTypeLogsPrototypeModel["port"] = int(8080)
+
+	model := make(map[string]interface{})
+	model["log_sink_crn"] = "crn:v1:bluemix:public:logs:eu-de:a/4516b8fa0a174a71899f5affa4f18d78:3517d2ed-9429-af34-ad52-34278391cbc8::"
+	model["name"] = "my-log-sink"
+	model["parameters"] = []interface{}{targetParametersTypeLogsPrototypeModel}
+
+	result, err := logsrouting.ResourceIBMLogsRouterTenantMapToTargetTypePrototypeTargetTypeLogsPrototype(model)
+	assert.Nil(t, err)
+	checkResult(result)
+}
+
+func TestResourceIBMLogsRouterTenantMapToTargetParametersTypeLogsPrototype(t *testing.T) {
+	checkResult := func(result *ibmcloudlogsroutingv0.TargetParametersTypeLogsPrototype) {
+		model := new(ibmcloudlogsroutingv0.TargetParametersTypeLogsPrototype)
+		model.Host = core.StringPtr("www.example.com")
+		model.Port = core.Int64Ptr(int64(1))
+
+		assert.Equal(t, result, model)
+	}
+
+	model := make(map[string]interface{})
+	model["host"] = "www.example.com"
+	model["port"] = int(1)
+
+	result, err := logsrouting.ResourceIBMLogsRouterTenantMapToTargetParametersTypeLogsPrototype(model)
+	assert.Nil(t, err)
+	checkResult(result)
+}

--- a/website/allowed-subcategories.txt
+++ b/website/allowed-subcategories.txt
@@ -25,6 +25,7 @@ Identity & Access Management (IAM)
 Internet services
 Key Management Service
 Kubernetes Service
+Logs Routing
 Metrics Router
 MQ on Cloud
 Object Storage

--- a/website/docs/d/logs-router_targets.html.markdown
+++ b/website/docs/d/logs-router_targets.html.markdown
@@ -1,0 +1,58 @@
+---
+layout: "ibm"
+page_title: "IBM : ibm_logs_router_targets"
+description: |-
+  Get information about logs_router_targets
+subcategory: "IBM Cloud Logs Routing"
+---
+
+# ibm_logs_router_targets
+
+Provides a read-only data source to retrieve information about logs_router_targets. You can then reference the fields of the data source in other resources within the same configuration by using interpolation syntax.
+
+## Example Usage
+
+```hcl
+data "ibm_logs_router_targets" "logs_router_targets" {
+	tenant_id = "9fab83da-98cb-4f18-a7ba-b6f0435c9673"
+	name = "my-target"
+}
+```
+
+## Argument Reference
+
+You can specify the following arguments for this data source.
+
+* `name` - (Optional, String) Optional: Name of the tenant target.
+  * Constraints: The maximum length is `35` characters. The minimum length is `1` character. The value must match regular expression `/[A-F,0-9,-]/`.
+* `tenant_id` - (Required, Forces new resource, String) The instance ID of the tenant.
+  * Constraints: The maximum length is `36` characters. The minimum length is `36` characters. The value must match regular expression `/[A-F,0-9,-]/`.
+
+## Attribute Reference
+
+After your data source is created, you can read values from the following attributes.
+
+* `id` - The unique identifier of the logs_router_targets.
+* `targets` - (List) List of target of a tenant.
+  * Constraints: The maximum length is `2` items. The minimum length is `1` item.
+Nested schema for **targets**:
+	* `created_at` - (String) Time stamp the target was originally created.
+	  * Constraints: The maximum length is `36` characters. The minimum length is `1` character. The value must match regular expression `/[0-9,:,.,-,T,Z]/`.
+	* `etag` - (String) Resource version identifier.
+	  * Constraints: The maximum length is `66` characters. The minimum length is `66` characters. The value must match regular expression `/(?:W\/)?"(?:[ !#-\\x7E\\x80-\\xFF]*|  [  ]|\\.)*"/`.
+	* `id` - (String) Unique ID of the target.
+	* `log_sink_crn` - (String) Cloud resource name of the log-sink target instance.
+	  * Constraints: The maximum length is `256` characters. The minimum length is `1` character. The value must match regular expression `/[a-z,A-Z,0-9,:,-]/`.
+	* `name` - (String) The name for this tenant target. The name is unique across all targets for this tenant.
+	  * Constraints: The maximum length is `35` characters. The minimum length is `1` character. The value must match regular expression `/[a-z,A-Z,0-9,-,.]/`.
+	* `parameters` - (List) List of properties returned from a successful list operation for a log-sink of type IBM Log Analysis (logdna).
+	Nested schema for **parameters**:
+		* `host` - (String) Host name of the log-sink.
+		  * Constraints: The maximum length is `256` characters. The minimum length is `1` character. The value must match regular expression `/[a-z,A-Z,0-9,-,.]/`.
+		* `port` - (Integer) Network port of the log-sink.
+		  * Constraints: The maximum value is `65535`. The minimum value is `1`.
+	* `type` - (String) Type of log-sink. Identical to the <code>service-name</code> segment of <code>log_sink_crn</code>.
+	  * Constraints: Allowable values are: `logdna`.
+	* `updated_at` - (String) Time stamp the target was last updated.
+	  * Constraints: The maximum length is `36` characters. The minimum length is `1` character. The value must match regular expression `/[0-9,:,.,-,T,Z]/`.
+

--- a/website/docs/d/logs-router_tenants.html.markdown
+++ b/website/docs/d/logs-router_tenants.html.markdown
@@ -1,0 +1,69 @@
+---
+layout: "ibm"
+page_title: "IBM : ibm_logs_router_tenants"
+description: |-
+  Get information about logs_router_tenants
+subcategory: "IBM Cloud Logs Routing"
+---
+
+# ibm_logs_router_tenants
+
+Provides a read-only data source to retrieve information about logs_router_tenants. You can then reference the fields of the data source in other resources within the same configuration by using interpolation syntax.
+
+## Example Usage
+
+```hcl
+data "ibm_logs_router_tenants" "logs_router_tenants" {
+	name = ibm_logs_router_tenant.logs_router_tenant_instance.name
+}
+```
+
+## Argument Reference
+
+You can specify the following arguments for this data source.
+
+* `name` - (Required, String) Optional: The name of a tenant.
+  * Constraints: The maximum length is `35` characters. The minimum length is `1` character. The value must match regular expression `/[A-F,0-9,-]/`.
+
+## Attribute Reference
+
+After your data source is created, you can read values from the following attributes.
+
+* `id` - The unique identifier of the logs_router_tenants.
+* `tenants` - (List) List of tenants in the account.
+  * Constraints: The maximum length is `1` item. The minimum length is `0` items.
+Nested schema for **tenants**:
+	* `created_at` - (String) Time stamp the tenant was originally created.
+	  * Constraints: The maximum length is `36` characters. The minimum length is `1` character. The value must match regular expression `/[0-9,:,.,-,T,Z]/`.
+	* `crn` - (String) Cloud resource name of the tenant.
+	  * Constraints: The maximum length is `256` characters. The minimum length is `1` character. The value must match regular expression `/[a-z,A-Z,0-9,:,-]/`.
+	* `etag` - (String) Resource version identifier.
+	  * Constraints: The maximum length is `66` characters. The minimum length is `66` characters. The value must match regular expression `/(?:W\/)?"(?:[ !#-\\x7E\\x80-\\xFF]*|  [  ]|\\.)*"/`.
+	* `id` - (String) Unique ID of the tenant.
+	* `name` - (String) The name for this tenant. The name is regionally unique across all tenants in the account.
+	  * Constraints: The maximum length is `35` characters. The minimum length is `1` character. The value must match regular expression `/[a-z,A-Z,0-9,-,.]/`.
+	* `targets` - (List) List of targets.
+	  * Constraints: The maximum length is `2` items. The minimum length is `1` item.
+	Nested schema for **targets**:
+		* `created_at` - (String) Time stamp the target was originally created.
+		  * Constraints: The maximum length is `36` characters. The minimum length is `1` character. The value must match regular expression `/[0-9,:,.,-,T,Z]/`.
+		* `etag` - (String) Resource version identifier.
+		  * Constraints: The maximum length is `66` characters. The minimum length is `66` characters. The value must match regular expression `/(?:W\/)?"(?:[ !#-\\x7E\\x80-\\xFF]*|  [  ]|\\.)*"/`.
+		* `id` - (String) Unique ID of the target.
+		* `log_sink_crn` - (String) Cloud resource name of the log-sink target instance.
+		  * Constraints: The maximum length is `256` characters. The minimum length is `1` character. The value must match regular expression `/[a-z,A-Z,0-9,:,-]/`.
+		* `name` - (String) The name for this tenant target. The name is unique across all targets for this tenant.
+		  * Constraints: The maximum length is `35` characters. The minimum length is `1` character. The value must match regular expression `/[a-z,A-Z,0-9,-,.]/`.
+		* `parameters` - (List) List of properties returned from a successful list operation for a log-sink of type IBM Log Analysis (logdna).
+		Nested schema for **parameters**:
+			* `host` - (String) Host name of the log-sink.
+			  * Constraints: The maximum length is `256` characters. The minimum length is `1` character. The value must match regular expression `/[a-z,A-Z,0-9,-,.]/`.
+			* `port` - (Integer) Network port of the log-sink.
+			  * Constraints: The maximum value is `65535`. The minimum value is `1`.
+		* `type` - (String) Type of log-sink. Identical to the <code>service-name</code> segment of <code>log_sink_crn</code>.
+		  * Constraints: Allowable values are: `logdna`.
+		* `updated_at` - (String) Time stamp the target was last updated.
+		  * Constraints: The maximum length is `36` characters. The minimum length is `1` character. The value must match regular expression `/[0-9,:,.,-,T,Z]/`.
+	* `updated_at` - (String) Time stamp the tenant was last updated.
+	  * Constraints: The maximum length is `36` characters. The minimum length is `1` character. The value must match regular expression `/[0-9,:,.,-,T,Z]/`.
+

--- a/website/docs/r/logs-router_tenant.html.markdown
+++ b/website/docs/r/logs-router_tenant.html.markdown
@@ -1,0 +1,85 @@
+---
+layout: "ibm"
+page_title: "IBM : ibm_logs_router_tenant"
+description: |-
+  Manages logs_router_tenant.
+subcategory: "IBM Cloud Logs Routing"
+---
+
+# ibm_logs_router_tenant
+
+Create, update, and delete logs_router_tenants with this resource.
+
+## Example Usage
+
+```hcl
+resource "ibm_logs_router_tenant" "logs_router_tenant_instance" {
+  name = "my-logging-tenant"
+  targets {
+		log_sink_crn = "crn:v1:bluemix:public:logdna:eu-de:a/3516b8fa0a174a71899f5affa4f18d78:3517d2ed-9429-af34-ad52-34278391cbc8::"
+		name = "my-log-sink"
+		parameters {
+			host = "www.example.com"
+			port = 1
+			access_credential = "credential"
+		}
+  }
+}
+```
+
+## Argument Reference
+
+You can specify the following arguments for this resource.
+
+* `name` - (Required, String) The name for this tenant. The name is regionally unique across all tenants in the account.
+  * Constraints: The maximum length is `35` characters. The minimum length is `1` character. The value must match regular expression `/[a-z,A-Z,0-9,-,.]/`.
+* `targets` - (Required, List) List of targets.
+  * Constraints: The maximum length is `2` items. The minimum length is `1` item.
+Nested schema for **targets**:
+	* `log_sink_crn` - (Optional, String) Cloud resource name of the log-sink target instance.
+	  * Constraints: The maximum length is `256` characters. The minimum length is `1` character. The value must match regular expression `/[a-z,A-Z,0-9,:,-]/`.
+	* `name` - (Optional, String) The name for this tenant target. The name is unique across all targets for this tenant.
+	  * Constraints: The maximum length is `35` characters. The minimum length is `1` character. The value must match regular expression `/[a-z,A-Z,0-9,-,.]/`.
+	* `parameters` - (Optional, List) List of properties returned from a successful list operation for a log-sink of type IBM Log Analysis (logdna).
+	Nested schema for **parameters**:
+		* `host` - (Required, String) Host name of the log-sink.
+		  * Constraints: The maximum length is `256` characters. The minimum length is `1` character. The value must match regular expression `/[a-z,A-Z,0-9,-,.]/`.
+		* `port` - (Required, Integer) Network port of the log-sink.
+		  * Constraints: The maximum value is `65535`. The minimum value is `1`.
+		* `access_credential` - (Optional, String) Secret to connect to the Mezmo log sink. This is not required for log sink of type Cloud Logs.
+
+
+## Attribute Reference
+
+After your resource is created, you can read values from the listed arguments and the following attributes.
+
+* `id` - The unique identifier of the logs_router_tenant.
+* `created_at` - (String) Time stamp the tenant was originally created.
+  * Constraints: The maximum length is `36` characters. The minimum length is `1` character. The value must match regular expression `/[0-9,:,.,-,T,Z]/`.
+* `crn` - (String) Cloud resource name of the tenant.
+  * Constraints: The maximum length is `256` characters. The minimum length is `1` character. The value must match regular expression `/[a-z,A-Z,0-9,:,-]/`.
+* `etag` - (String) Resource version identifier.
+  * Constraints: The maximum length is `66` characters. The minimum length is `66` characters. The value must match regular expression `/(?:W\/)?"(?:[ !#-\\x7E\\x80-\\xFF]*|  [  ]|\\.)*"/`.
+* `updated_at` - (String) Time stamp the tenant was last updated.
+  * Constraints: The maximum length is `36` characters. The minimum length is `1` character. The value must match regular expression `/[0-9,:,.,-,T,Z]/`.
+
+* `etag` - ETag identifier for logs_router_tenant.
+
+* `target.0.etag` - ETag identifier for logs_router_tenant target.
+
+* `target.0.id` -  The unique identifier of the logs_router_tenant target
+
+## Import
+
+You can import the `ibm_logs_router_tenant` resource by using `id`. Unique ID of the tenant.
+For more information, see [the documentation](http://cloud.ibm.com)
+
+# Syntax
+<pre>
+$ terraform import ibm_logs_router_tenant.logs_router_tenant &lt;id&gt;
+</pre>
+
+# Example
+```
+$ terraform import ibm_logs_router_tenant.logs_router_tenant 8717db99-2cfb-4ba6-a033-89c994c2e9f0
+```

--- a/website/docs/r/logs-router_tenant.html.markdown
+++ b/website/docs/r/logs-router_tenant.html.markdown
@@ -46,7 +46,7 @@ Nested schema for **targets**:
 		  * Constraints: The maximum length is `256` characters. The minimum length is `1` character. The value must match regular expression `/[a-z,A-Z,0-9,-,.]/`.
 		* `port` - (Required, Integer) Network port of the log-sink.
 		  * Constraints: The maximum value is `65535`. The minimum value is `1`.
-		* `access_credential` - (Optional, String) Secret to connect to the Mezmo log sink. This is not required for log sink of type Cloud Logs.
+		* `access_credential` - (Optional, String) Secret to connect to the Mezmo log-sink. This is not required for log-sink of type Cloud Logs.
 
 
 ## Attribute Reference


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/IBM-Cloud/terraform-provider-ibm/blob/master/.github/CONTRIBUTING.md --->

- Add IBM Cloud Logs Routing service to IBM Terraform Provider

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccIbmLogsRouter'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test $(go list ./... |grep -v 'vendor') -v -run=TestAccIbmLogsRouter -timeout 700m
...
ok  	github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/logs	34.286s [no tests to run]
?   	github.com/IBM-Cloud/terraform-provider-ibm/ibm/unittest	[no test files]
?   	github.com/IBM-Cloud/terraform-provider-ibm/ibm/validate	[no test files]
?   	github.com/IBM-Cloud/terraform-provider-ibm/version	[no test files]
=== RUN   TestAccIBMLogsRouterTargetsDataSourceBasic
--- PASS: TestAccIBMLogsRouterTargetsDataSourceBasic (65.23s)
=== RUN   TestAccIBMLogsRouterTenantsDataSourceBasic
--- PASS: TestAccIBMLogsRouterTenantsDataSourceBasic (54.36s)
=== RUN   TestAccIBMLogsRouterTenantBasic
--- PASS: TestAccIBMLogsRouterTenantBasic (38.19s)
=== RUN   TestAccIBMLogsRouterTenantAllArgs
--- PASS: TestAccIBMLogsRouterTenantAllArgs (59.19s)
PASS
ok  	github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/logsrouting	245.787s
testing: warning: no tests to run
...
```
