### PR TITLE
Allow resizing kubernetes service worker-pools to 0

### DIFF
--- a/ibm/validate/validators.go
+++ b/ibm/validate/validators.go
@@ -16,7 +16,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
-	homedir "github.com/mitchellh/go-homedir"
+	"github.com/mitchellh/go-homedir"
 
 	"github.com/IBM-Cloud/bluemix-go/helpers"
 	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/flex"
@@ -304,9 +304,9 @@ func ValidateWeight(v interface{}, k string) (ws []string, errors []error) {
 
 func ValidateSizePerZone(v interface{}, k string) (ws []string, errors []error) {
 	sizePerZone := v.(int)
-	if sizePerZone <= 0 {
+	if sizePerZone < 0 {
 		errors = append(errors, fmt.Errorf(
-			"%q must be greater than 0",
+			"%q must be non-negative",
 			k))
 	}
 	return


### PR DESCRIPTION
IKS introduced the ability to resize an existing worker-pool to 0, so we have to allow that in the terraform provider as well. 

<!--- See what makes a good Pull Request at : https://github.com/IBM-Cloud/terraform-provider-ibm/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
% export TESTARGS='-run "(TestAccIBMContainerWorkerPoolBasic|TestAccIBMContainerWorkerPoolZeroSize|TestAccIBMContainerWorkerPoolInvalidSizePerZone)"'
% make testacc
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test $(go list ./... |grep -v 'vendor') -v -run "(TestAccIBMContainerWorkerPoolBasic|TestAccIBMContainerWorkerPoolZeroSize|TestAccIBMContainerWorkerPoolInvalidSizePerZone)" -timeout 700m
?   	github.com/IBM-Cloud/terraform-provider-ibm	[no test files]
?   	github.com/IBM-Cloud/terraform-provider-ibm/ibm/acctest	[no test files]
?   	github.com/IBM-Cloud/terraform-provider-ibm/ibm/provider	[no test files]

[...]

=== RUN   TestAccIBMContainerWorkerPoolBasic
--- PASS: TestAccIBMContainerWorkerPoolBasic (1244.19s)
=== RUN   TestAccIBMContainerWorkerPoolZeroSize
--- PASS: TestAccIBMContainerWorkerPoolZeroSize (1483.26s)
=== RUN   TestAccIBMContainerWorkerPoolInvalidSizePerZone
--- PASS: TestAccIBMContainerWorkerPoolInvalidSizePerZone (0.32s)
PASS
ok  	github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/kubernetes	2732.484s

[...]
```
