### PR TITLE
Added an empty check on protocol_state_filtering_mode

### DIFF
--- a/ibm/service/vpc/resource_ibm_is_bare_metal_server.go
+++ b/ibm/service/vpc/resource_ibm_is_bare_metal_server.go
@@ -4219,10 +4219,12 @@ func resourceIBMIsBareMetalServerMapToVirtualNetworkInterfacePrototypeAttachment
 	if _, ok := d.GetOkExists(enablenat); ok && modelMap["enable_infrastructure_nat"] != nil {
 		model.EnableInfrastructureNat = core.BoolPtr(modelMap["enable_infrastructure_nat"].(bool))
 	}
-	if pStateFilteringInt, ok := modelMap["protocol_state_filtering_mode"]; ok {
-		protocolStateFilteringMode := pStateFilteringInt.(string)
-		if protocolStateFilteringMode != "" {
-			model.ProtocolStateFilteringMode = core.StringPtr(protocolStateFilteringMode)
+	if modelMap["protocol_state_filtering_mode"] != nil {
+		if pStateFilteringInt, ok := modelMap["protocol_state_filtering_mode"]; ok {
+			protocolStateFilteringMode := pStateFilteringInt.(string)
+			if protocolStateFilteringMode != "" {
+				model.ProtocolStateFilteringMode = core.StringPtr(protocolStateFilteringMode)
+			}
 		}
 	}
 	if modelMap["ips"] != nil && modelMap["ips"].(*schema.Set).Len() > 0 {

--- a/ibm/service/vpc/resource_ibm_is_bare_metal_server.go
+++ b/ibm/service/vpc/resource_ibm_is_bare_metal_server.go
@@ -4220,7 +4220,10 @@ func resourceIBMIsBareMetalServerMapToVirtualNetworkInterfacePrototypeAttachment
 		model.EnableInfrastructureNat = core.BoolPtr(modelMap["enable_infrastructure_nat"].(bool))
 	}
 	if pStateFilteringInt, ok := modelMap["protocol_state_filtering_mode"]; ok {
-		model.ProtocolStateFilteringMode = core.StringPtr(pStateFilteringInt.(string))
+		protocolStateFilteringMode := pStateFilteringInt.(string)
+		if protocolStateFilteringMode != "" {
+			model.ProtocolStateFilteringMode = core.StringPtr(protocolStateFilteringMode)
+		}
 	}
 	if modelMap["ips"] != nil && modelMap["ips"].(*schema.Set).Len() > 0 {
 		ips := []vpcv1.VirtualNetworkInterfaceIPPrototypeIntf{}

--- a/ibm/service/vpc/resource_ibm_is_bare_metal_server_network_attachment.go
+++ b/ibm/service/vpc/resource_ibm_is_bare_metal_server_network_attachment.go
@@ -1092,8 +1092,8 @@ func resourceIBMIsBareMetalServerNetworkAttachmentMapToBareMetalServerNetworkAtt
 	if modelMap["name"] != nil && modelMap["name"].(string) != "" {
 		model.Name = core.StringPtr(modelMap["name"].(string))
 	}
-	if pStateFilteringInt, ok := modelMap["protocol_state_filtering_mode"]; ok && modelMap["protocol_state_filtering_mode"] != nil {
-		if pStateFilteringInt.(string) != "" {
+	if modelMap["protocol_state_filtering_mode"] != nil {
+		if pStateFilteringInt, ok := modelMap["protocol_state_filtering_mode"]; ok && pStateFilteringInt.(string) != "" {
 			model.ProtocolStateFilteringMode = core.StringPtr(pStateFilteringInt.(string))
 		}
 	}

--- a/ibm/service/vpc/resource_ibm_is_bare_metal_server_network_attachment.go
+++ b/ibm/service/vpc/resource_ibm_is_bare_metal_server_network_attachment.go
@@ -1092,8 +1092,10 @@ func resourceIBMIsBareMetalServerNetworkAttachmentMapToBareMetalServerNetworkAtt
 	if modelMap["name"] != nil && modelMap["name"].(string) != "" {
 		model.Name = core.StringPtr(modelMap["name"].(string))
 	}
-	if pStateFilteringInt, ok := modelMap["protocol_state_filtering_mode"]; ok {
-		model.ProtocolStateFilteringMode = core.StringPtr(pStateFilteringInt.(string))
+	if pStateFilteringInt, ok := modelMap["protocol_state_filtering_mode"]; ok && modelMap["protocol_state_filtering_mode"] != nil {
+		if pStateFilteringInt.(string) != "" {
+			model.ProtocolStateFilteringMode = core.StringPtr(pStateFilteringInt.(string))
+		}
 	}
 	if modelMap["primary_ip"] != nil && len(modelMap["primary_ip"].([]interface{})) > 0 {
 		PrimaryIPModel, err := resourceIBMIsBareMetalServerNetworkAttachmentMapToVirtualNetworkInterfacePrimaryIPPrototype(modelMap["primary_ip"].([]interface{})[0].(map[string]interface{}))

--- a/ibm/service/vpc/resource_ibm_is_instance.go
+++ b/ibm/service/vpc/resource_ibm_is_instance.go
@@ -6493,8 +6493,10 @@ func resourceIBMIsInstanceMapToVirtualNetworkInterfacePrototypeAttachmentContext
 	if modelMap["name"] != nil && modelMap["name"].(string) != "" {
 		model.Name = core.StringPtr(modelMap["name"].(string))
 	}
-	if pStateFilteringInt, ok := modelMap["protocol_state_filtering_mode"]; ok {
-		model.ProtocolStateFilteringMode = core.StringPtr(pStateFilteringInt.(string))
+	if pStateFilteringInt, ok := modelMap["protocol_state_filtering_mode"]; ok && modelMap["protocol_state_filtering_mode"] != nil {
+		if pStateFilteringInt.(string) != "" {
+			model.ProtocolStateFilteringMode = core.StringPtr(pStateFilteringInt.(string))
+		}
 	}
 	if modelMap["primary_ip"] != nil && len(modelMap["primary_ip"].([]interface{})) > 0 {
 		PrimaryIPModel, err := resourceIBMIsInstanceMapToVirtualNetworkInterfacePrimaryIPReservedIPPrototype(modelMap["primary_ip"].([]interface{})[0].(map[string]interface{}))

--- a/ibm/service/vpc/resource_ibm_is_instance.go
+++ b/ibm/service/vpc/resource_ibm_is_instance.go
@@ -6493,8 +6493,8 @@ func resourceIBMIsInstanceMapToVirtualNetworkInterfacePrototypeAttachmentContext
 	if modelMap["name"] != nil && modelMap["name"].(string) != "" {
 		model.Name = core.StringPtr(modelMap["name"].(string))
 	}
-	if pStateFilteringInt, ok := modelMap["protocol_state_filtering_mode"]; ok && modelMap["protocol_state_filtering_mode"] != nil {
-		if pStateFilteringInt.(string) != "" {
+	if modelMap["protocol_state_filtering_mode"] != nil {
+		if pStateFilteringInt, ok := modelMap["protocol_state_filtering_mode"]; ok && pStateFilteringInt.(string) != "" {
 			model.ProtocolStateFilteringMode = core.StringPtr(pStateFilteringInt.(string))
 		}
 	}

--- a/ibm/service/vpc/resource_ibm_is_instance_network_attachment.go
+++ b/ibm/service/vpc/resource_ibm_is_instance_network_attachment.go
@@ -732,8 +732,10 @@ func resourceIBMIsInstanceNetworkAttachmentMapToInstanceNetworkAttachmentPrototy
 	if modelMap["name"] != nil && modelMap["name"].(string) != "" {
 		model.Name = core.StringPtr(modelMap["name"].(string))
 	}
-	if pStateFilteringInt, ok := modelMap["protocol_state_filtering_mode"]; ok {
-		model.ProtocolStateFilteringMode = core.StringPtr(pStateFilteringInt.(string))
+	if pStateFilteringInt, ok := modelMap["protocol_state_filtering_mode"]; ok && modelMap["protocol_state_filtering_mode"] != nil {
+		if pStateFilteringInt.(string) != "" {
+			model.ProtocolStateFilteringMode = core.StringPtr(pStateFilteringInt.(string))
+		}
 	}
 	if modelMap["primary_ip"] != nil && len(modelMap["primary_ip"].([]interface{})) > 0 {
 		PrimaryIPModel, err := resourceIBMIsInstanceNetworkAttachmentMapToVirtualNetworkInterfacePrimaryIPPrototype(modelMap["primary_ip"].([]interface{})[0].(map[string]interface{}))

--- a/ibm/service/vpc/resource_ibm_is_instance_network_attachment.go
+++ b/ibm/service/vpc/resource_ibm_is_instance_network_attachment.go
@@ -732,8 +732,8 @@ func resourceIBMIsInstanceNetworkAttachmentMapToInstanceNetworkAttachmentPrototy
 	if modelMap["name"] != nil && modelMap["name"].(string) != "" {
 		model.Name = core.StringPtr(modelMap["name"].(string))
 	}
-	if pStateFilteringInt, ok := modelMap["protocol_state_filtering_mode"]; ok && modelMap["protocol_state_filtering_mode"] != nil {
-		if pStateFilteringInt.(string) != "" {
+	if modelMap["protocol_state_filtering_mode"] != nil {
+		if pStateFilteringInt, ok := modelMap["protocol_state_filtering_mode"]; ok && pStateFilteringInt.(string) != "" {
 			model.ProtocolStateFilteringMode = core.StringPtr(pStateFilteringInt.(string))
 		}
 	}

--- a/ibm/service/vpc/resource_ibm_is_instance_template.go
+++ b/ibm/service/vpc/resource_ibm_is_instance_template.go
@@ -2813,8 +2813,8 @@ func resourceIBMIsInstanceTemplateMapToVirtualNetworkInterfacePrototypeAttachmen
 		}
 		model.PrimaryIP = PrimaryIPModel
 	}
-	if pStateFilteringInt, ok := modelMap["protocol_state_filtering_mode"]; ok && modelMap["protocol_state_filtering_mode"] != nil {
-		if pStateFilteringInt.(string) != "" {
+	if modelMap["protocol_state_filtering_mode"] != nil {
+		if pStateFilteringInt, ok := modelMap["protocol_state_filtering_mode"]; ok && pStateFilteringInt.(string) != "" {
 			model.ProtocolStateFilteringMode = core.StringPtr(pStateFilteringInt.(string))
 		}
 	}

--- a/ibm/service/vpc/resource_ibm_is_instance_template.go
+++ b/ibm/service/vpc/resource_ibm_is_instance_template.go
@@ -2813,8 +2813,10 @@ func resourceIBMIsInstanceTemplateMapToVirtualNetworkInterfacePrototypeAttachmen
 		}
 		model.PrimaryIP = PrimaryIPModel
 	}
-	if pStateFilteringInt, ok := modelMap["protocol_state_filtering_mode"]; ok {
-		model.ProtocolStateFilteringMode = core.StringPtr(pStateFilteringInt.(string))
+	if pStateFilteringInt, ok := modelMap["protocol_state_filtering_mode"]; ok && modelMap["protocol_state_filtering_mode"] != nil {
+		if pStateFilteringInt.(string) != "" {
+			model.ProtocolStateFilteringMode = core.StringPtr(pStateFilteringInt.(string))
+		}
 	}
 	if modelMap["resource_group"] != nil && modelMap["resource_group"].(string) != "" {
 		resourcegroupid := modelMap["resource_group"].(string)

--- a/ibm/service/vpc/resource_ibm_is_instance_template_test.go
+++ b/ibm/service/vpc/resource_ibm_is_instance_template_test.go
@@ -133,7 +133,7 @@ func TestAccIBMISInstanceTemplate_vni(t *testing.T) {
 					resource.TestCheckResourceAttrSet(
 						"ibm_is_instance_template.instancetemplate1", "primary_network_attachment"),
 					resource.TestCheckResourceAttrSet(
-						"ibm_is_instance_template.instancetemplate1", "primary_network_attachment.0.virtual_network_interface"),
+						"ibm_is_instance_template.instancetemplate1", "primary_network_attachment.0.virtual_network_interface.#"),
 				),
 			},
 		},
@@ -151,8 +151,8 @@ func TestAccIBMISInstanceTemplate_vniPSFM(t *testing.T) {
 	sshKeyName := fmt.Sprintf("tf-testsshkey%d", randInt)
 	protocolStateFilteringMode := "auto"
 
-	pNacName := fmt.Sprintf("tf-testvpc-pNac%d", randInt)
-	sNacName := fmt.Sprintf("tf-testvpc-sNac%d", randInt)
+	pNacName := fmt.Sprintf("tf-testvpc-pnac%d", randInt)
+	sNacName := fmt.Sprintf("tf-testvpc-snac%d", randInt)
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { acc.TestAccPreCheck(t) },
 		Providers:    acc.TestAccProviders,
@@ -166,9 +166,15 @@ func TestAccIBMISInstanceTemplate_vniPSFM(t *testing.T) {
 					resource.TestCheckResourceAttrSet(
 						"ibm_is_instance_template.instancetemplate1", "profile"),
 					resource.TestCheckResourceAttrSet(
-						"ibm_is_instance_template.instancetemplate1", "primary_network_attachment"),
+						"ibm_is_instance_template.instancetemplate1", "primary_network_attachment.#"),
 					resource.TestCheckResourceAttrSet(
-						"ibm_is_instance_template.instancetemplate1", "primary_network_attachment.0.virtual_network_interface"),
+						"ibm_is_instance_template.instancetemplate1", "primary_network_attachment.0.virtual_network_interface.#"),
+					resource.TestCheckResourceAttrSet(
+						"ibm_is_instance_template.instancetemplate1", "primary_network_attachment.0.virtual_network_interface.0.protocol_state_filtering_mode"),
+					resource.TestCheckResourceAttrSet(
+						"ibm_is_instance_template.instancetemplate1", "network_attachments.#"),
+					resource.TestCheckResourceAttrSet(
+						"ibm_is_instance_template.instancetemplate1", "network_attachments.0.virtual_network_interface.0.protocol_state_filtering_mode"),
 				),
 			},
 		},

--- a/ibm/service/vpc/resource_ibm_is_share_mount_target.go
+++ b/ibm/service/vpc/resource_ibm_is_share_mount_target.go
@@ -811,8 +811,8 @@ func ShareMountTargetMapToShareMountTargetPrototype(d *schema.ResourceData, vniM
 	if name != "" {
 		vniPrototype.Name = &name
 	}
-	if pStateFilteringInt, ok := vniMap["protocol_state_filtering_mode"]; ok && vniMap["protocol_state_filtering_mode"] != nil {
-		if pStateFilteringInt.(string) != "" {
+	if vniMap["protocol_state_filtering_mode"] != nil {
+		if pStateFilteringInt, ok := vniMap["protocol_state_filtering_mode"]; ok && pStateFilteringInt.(string) != "" {
 			vniPrototype.ProtocolStateFilteringMode = core.StringPtr(pStateFilteringInt.(string))
 		}
 	}

--- a/ibm/service/vpc/resource_ibm_is_share_mount_target.go
+++ b/ibm/service/vpc/resource_ibm_is_share_mount_target.go
@@ -811,8 +811,10 @@ func ShareMountTargetMapToShareMountTargetPrototype(d *schema.ResourceData, vniM
 	if name != "" {
 		vniPrototype.Name = &name
 	}
-	if pStateFilteringInt, ok := vniMap["protocol_state_filtering_mode"]; ok {
-		vniPrototype.ProtocolStateFilteringMode = core.StringPtr(pStateFilteringInt.(string))
+	if pStateFilteringInt, ok := vniMap["protocol_state_filtering_mode"]; ok && vniMap["protocol_state_filtering_mode"] != nil {
+		if pStateFilteringInt.(string) != "" {
+			vniPrototype.ProtocolStateFilteringMode = core.StringPtr(pStateFilteringInt.(string))
+		}
 	}
 	primaryIp, ok := vniMap["primary_ip"]
 	if ok && len(primaryIp.([]interface{})) > 0 {


### PR DESCRIPTION
…ervers

<!--- See what makes a good Pull Request at : https://github.com/IBM-Cloud/terraform-provider-ibm/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```
