### PR TITLE
Support Cloud Logs data access rules

### DIFF
--- a/ibm/provider/provider.go
+++ b/ibm/provider/provider.go
@@ -954,6 +954,7 @@ func Provider() *schema.Provider {
 			"ibm_logs_dashboard_folders":  logs.AddLogsInstanceFields(logs.DataSourceIbmLogsDashboardFolders()),
 			"ibm_logs_data_usage_metrics": logs.AddLogsInstanceFields(logs.DataSourceIbmLogsDataUsageMetrics()),
 			"ibm_logs_enrichments":        logs.AddLogsInstanceFields(logs.DataSourceIbmLogsEnrichments()),
+			"ibm_logs_data_access_rules":  logs.AddLogsInstanceFields(logs.DataSourceIbmLogsDataAccessRules()),
 		},
 
 		ResourcesMap: map[string]*schema.Resource{
@@ -1525,6 +1526,7 @@ func Provider() *schema.Provider {
 			"ibm_logs_dashboard_folder":   logs.AddLogsInstanceFields(logs.ResourceIbmLogsDashboardFolder()),
 			"ibm_logs_data_usage_metrics": logs.AddLogsInstanceFields(logs.ResourceIbmLogsDataUsageMetrics()),
 			"ibm_logs_enrichment":         logs.AddLogsInstanceFields(logs.ResourceIbmLogsEnrichment()),
+			"ibm_logs_data_access_rule":   logs.AddLogsInstanceFields(logs.ResourceIbmLogsDataAccessRule()),
 		},
 
 		ConfigureFunc: providerConfigure,
@@ -1965,6 +1967,7 @@ func Validator() validate.ValidatorDict {
 				"ibm_logs_view_folder":      logs.ResourceIbmLogsViewFolderValidator(),
 				"ibm_logs_dashboard_folder": logs.ResourceIbmLogsDashboardFolderValidator(),
 				"ibm_logs_enrichment":       logs.ResourceIbmLogsEnrichmentValidator(),
+				"ibm_logs_data_access_rule": logs.ResourceIbmLogsDataAccessRuleValidator(),
 			},
 			DataSourceValidatorDictionary: map[string]*validate.ResourceValidator{
 				"ibm_is_subnet":                     vpc.DataSourceIBMISSubnetValidator(),

--- a/ibm/service/logs/data_source_ibm_logs_data_access_rules.go
+++ b/ibm/service/logs/data_source_ibm_logs_data_access_rules.go
@@ -1,0 +1,172 @@
+// Copyright IBM Corp. 2024 All Rights Reserved.
+// Licensed under the Mozilla Public License v2.0
+
+/*
+ * IBM OpenAPI Terraform Generator Version: 3.91.0-d9755c53-20240605-153412
+ */
+
+package logs
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"time"
+
+	"github.com/go-openapi/strfmt"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/conns"
+	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/flex"
+	"github.com/IBM/logs-go-sdk/logsv0"
+)
+
+func DataSourceIbmLogsDataAccessRules() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceIbmLogsDataAccessRulesRead,
+
+		Schema: map[string]*schema.Schema{
+			"logs_data_access_rules_id": &schema.Schema{
+				Type:        schema.TypeList,
+				Optional:    true,
+				Description: "Array of data access rule IDs.",
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
+			},
+			"data_access_rules": &schema.Schema{
+				Type:        schema.TypeList,
+				Computed:    true,
+				Description: "Data Access Rule details.",
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"id": &schema.Schema{
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "Data Access Rule ID.",
+						},
+						"display_name": &schema.Schema{
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "Data Access Rule Display Name.",
+						},
+						"description": &schema.Schema{
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "Optional Data Access Rule Description.",
+						},
+						"filters": &schema.Schema{
+							Type:        schema.TypeList,
+							Computed:    true,
+							Description: "List of filters that the Data Access Rule is composed of.",
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"entity_type": &schema.Schema{
+										Type:        schema.TypeString,
+										Computed:    true,
+										Description: "Filter's Entity Type.",
+									},
+									"expression": &schema.Schema{
+										Type:        schema.TypeString,
+										Computed:    true,
+										Description: "Filter's Expression.",
+									},
+								},
+							},
+						},
+						"default_expression": &schema.Schema{
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "Default expression to use when no filter matches the query.",
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func dataSourceIbmLogsDataAccessRulesRead(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	logsClient, err := meta.(conns.ClientSession).LogsV0()
+	if err != nil {
+		// Error is coming from SDK client, so it doesn't need to be discriminated.
+		tfErr := flex.TerraformErrorf(err, err.Error(), "(Data) ibm_logs_data_access_rules", "read")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
+	}
+
+	region := getLogsInstanceRegion(logsClient, d)
+	instanceId := d.Get("instance_id").(string)
+	logsClient = getClientWithLogsInstanceEndpoint(logsClient, instanceId, region, getLogsInstanceEndpointType(logsClient, d))
+
+	listDataAccessRulesOptions := &logsv0.ListDataAccessRulesOptions{}
+
+	if _, ok := d.GetOk("logs_data_access_rules_id"); ok {
+		var id []strfmt.UUID
+		for _, v := range d.Get("logs_data_access_rules_id").([]interface{}) {
+			idItem := strfmt.UUID(v.(string))
+			id = append(id, idItem)
+		}
+		listDataAccessRulesOptions.SetID(id)
+	}
+
+	dataAccessRuleCollection, _, err := logsClient.ListDataAccessRulesWithContext(context, listDataAccessRulesOptions)
+	if err != nil {
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("ListDataAccessRulesWithContext failed: %s", err.Error()), "(Data) ibm_logs_data_access_rules", "read")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
+	}
+
+	d.SetId(dataSourceIbmLogsDataAccessRulesID(d))
+
+	dataAccessRules := []map[string]interface{}{}
+	if dataAccessRuleCollection.DataAccessRules != nil {
+		for _, modelItem := range dataAccessRuleCollection.DataAccessRules {
+			modelMap, err := DataSourceIbmLogsDataAccessRulesDataAccessRuleToMap(&modelItem)
+			if err != nil {
+				return flex.DiscriminatedTerraformErrorf(err, err.Error(), "(Data) ibm_logs_data_access_rules", "read", "data_access_rules-to-map").GetDiag()
+			}
+			dataAccessRules = append(dataAccessRules, modelMap)
+		}
+	}
+	if err = d.Set("data_access_rules", dataAccessRules); err != nil {
+		return flex.DiscriminatedTerraformErrorf(err, fmt.Sprintf("Error setting data_access_rules: %s", err), "(Data) ibm_logs_data_access_rules", "read", "set-data_access_rules").GetDiag()
+	}
+
+	return nil
+}
+
+// dataSourceIbmLogsDataAccessRulesID returns a reasonable ID for the list.
+func dataSourceIbmLogsDataAccessRulesID(d *schema.ResourceData) string {
+	return time.Now().UTC().String()
+}
+
+func DataSourceIbmLogsDataAccessRulesDataAccessRuleToMap(model *logsv0.DataAccessRule) (map[string]interface{}, error) {
+	modelMap := make(map[string]interface{})
+	modelMap["id"] = model.ID.String()
+	modelMap["display_name"] = *model.DisplayName
+	if model.Description != nil {
+		modelMap["description"] = *model.Description
+	}
+	if model.Filters != nil {
+		filters := []map[string]interface{}{}
+		for _, filtersItem := range model.Filters {
+			filtersItemMap, err := DataSourceIbmLogsDataAccessRulesDataAccessRuleFilterToMap(&filtersItem)
+			if err != nil {
+				return modelMap, err
+			}
+			filters = append(filters, filtersItemMap)
+		}
+		modelMap["filters"] = filters
+	}
+	modelMap["default_expression"] = *model.DefaultExpression
+	return modelMap, nil
+}
+
+func DataSourceIbmLogsDataAccessRulesDataAccessRuleFilterToMap(model *logsv0.DataAccessRuleFilter) (map[string]interface{}, error) {
+	modelMap := make(map[string]interface{})
+	modelMap["entity_type"] = *model.EntityType
+	modelMap["expression"] = *model.Expression
+	return modelMap, nil
+}

--- a/ibm/service/logs/data_source_ibm_logs_data_access_rules_test.go
+++ b/ibm/service/logs/data_source_ibm_logs_data_access_rules_test.go
@@ -1,0 +1,104 @@
+// Copyright IBM Corp. 2024 All Rights Reserved.
+// Licensed under the Mozilla Public License v2.0
+
+/*
+ * IBM OpenAPI Terraform Generator Version: 3.91.0-d9755c53-20240605-153412
+ */
+
+package logs_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	acc "github.com/IBM-Cloud/terraform-provider-ibm/ibm/acctest"
+)
+
+func TestAccIbmLogsDataAccessRulesDataSourceBasic(t *testing.T) {
+	dataAccessRuleDisplayName := fmt.Sprintf("tf_display_name_%d", acctest.RandIntRange(10, 100))
+	dataAccessRuleDefaultExpression := "<v1>true"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { acc.TestAccPreCheckCloudLogs(t) },
+		Providers: acc.TestAccProviders,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccCheckIbmLogsDataAccessRulesDataSourceConfigBasic(dataAccessRuleDisplayName, dataAccessRuleDefaultExpression),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet("data.ibm_logs_data_access_rules.logs_data_access_rules_instance", "id"),
+					resource.TestCheckResourceAttrSet("data.ibm_logs_data_access_rules.logs_data_access_rules_instance", "data_access_rules.#"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccIbmLogsDataAccessRulesDataSourceAllArgs(t *testing.T) {
+	dataAccessRuleDisplayName := fmt.Sprintf("tf_display_name_%d", acctest.RandIntRange(10, 100))
+	dataAccessRuleDescription := fmt.Sprintf("tf_description_%d", acctest.RandIntRange(10, 100))
+	dataAccessRuleDefaultExpression := "<v1>true"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { acc.TestAccPreCheckCloudLogs(t) },
+		Providers: acc.TestAccProviders,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccCheckIbmLogsDataAccessRulesDataSourceConfig(dataAccessRuleDisplayName, dataAccessRuleDescription, dataAccessRuleDefaultExpression),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet("data.ibm_logs_data_access_rules.logs_data_access_rules_instance", "id"),
+					resource.TestCheckResourceAttrSet("data.ibm_logs_data_access_rules.logs_data_access_rules_instance", "logs_data_access_rules_id.#"),
+					resource.TestCheckResourceAttrSet("data.ibm_logs_data_access_rules.logs_data_access_rules_instance", "data_access_rules.#"),
+					resource.TestCheckResourceAttrSet("data.ibm_logs_data_access_rules.logs_data_access_rules_instance", "data_access_rules.0.id"),
+					resource.TestCheckResourceAttr("data.ibm_logs_data_access_rules.logs_data_access_rules_instance", "data_access_rules.0.display_name", dataAccessRuleDisplayName),
+					resource.TestCheckResourceAttr("data.ibm_logs_data_access_rules.logs_data_access_rules_instance", "data_access_rules.0.description", dataAccessRuleDescription),
+					resource.TestCheckResourceAttr("data.ibm_logs_data_access_rules.logs_data_access_rules_instance", "data_access_rules.0.default_expression", dataAccessRuleDefaultExpression),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckIbmLogsDataAccessRulesDataSourceConfigBasic(dataAccessRuleDisplayName string, dataAccessRuleDefaultExpression string) string {
+	return fmt.Sprintf(`
+		 resource "ibm_logs_data_access_rule" "logs_data_access_rule_instance" {
+			 instance_id  = "%s"
+			 region       = "%s"
+			 display_name = "%s"
+			 filters {
+				 entity_type = "logs"
+				 expression  = "<v1> foo == 'bar'"
+			 }
+			 default_expression = "%s"
+		 }
+ 
+		 data "ibm_logs_data_access_rules" "logs_data_access_rules_instance" {
+			 instance_id 			  = ibm_logs_data_access_rule.logs_data_access_rule_instance.instance_id
+			 region      			  = ibm_logs_data_access_rule.logs_data_access_rule_instance.region
+		 }
+	 `, acc.LogsInstanceId, acc.LogsInstanceRegion, dataAccessRuleDisplayName, dataAccessRuleDefaultExpression)
+}
+
+func testAccCheckIbmLogsDataAccessRulesDataSourceConfig(dataAccessRuleDisplayName string, dataAccessRuleDescription string, dataAccessRuleDefaultExpression string) string {
+	return fmt.Sprintf(`
+		 resource "ibm_logs_data_access_rule" "logs_data_access_rule_instance" {
+			 instance_id  = "%s"
+			 region       = "%s"
+			 display_name = "%s"
+			 description  = "%s"
+			 filters {
+				 entity_type = "logs"
+				 expression  = "<v1> foo == 'bar'"
+			 }
+			 default_expression = "%s"
+		 }
+ 
+		 data "ibm_logs_data_access_rules" "logs_data_access_rules_instance" {
+			 instance_id 			  = ibm_logs_data_access_rule.logs_data_access_rule_instance.instance_id
+			 region      			  = ibm_logs_data_access_rule.logs_data_access_rule_instance.region
+			 logs_data_access_rules_id = [ibm_logs_data_access_rule.logs_data_access_rule_instance.access_rule_id]
+		 }
+	 `, acc.LogsInstanceId, acc.LogsInstanceRegion, dataAccessRuleDisplayName, dataAccessRuleDescription, dataAccessRuleDefaultExpression)
+}

--- a/ibm/service/logs/resource_ibm_logs_dashboard_folder.go
+++ b/ibm/service/logs/resource_ibm_logs_dashboard_folder.go
@@ -97,6 +97,7 @@ func resourceIbmLogsDashboardFolderCreate(context context.Context, d *schema.Res
 	return resourceIbmLogsDashboardFolderRead(context, d, meta)
 }
 
+// niranjan
 func resourceIbmLogsDashboardFolderRead(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	logsClient, err := meta.(conns.ClientSession).LogsV0()
 	if err != nil {

--- a/ibm/service/logs/resource_ibm_logs_dashboard_folder.go
+++ b/ibm/service/logs/resource_ibm_logs_dashboard_folder.go
@@ -97,7 +97,6 @@ func resourceIbmLogsDashboardFolderCreate(context context.Context, d *schema.Res
 	return resourceIbmLogsDashboardFolderRead(context, d, meta)
 }
 
-// niranjan
 func resourceIbmLogsDashboardFolderRead(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	logsClient, err := meta.(conns.ClientSession).LogsV0()
 	if err != nil {

--- a/ibm/service/logs/resource_ibm_logs_data_access_rule.go
+++ b/ibm/service/logs/resource_ibm_logs_data_access_rule.go
@@ -1,0 +1,328 @@
+// Copyright IBM Corp. 2024 All Rights Reserved.
+// Licensed under the Mozilla Public License v2.0
+
+/*
+ * IBM OpenAPI Terraform Generator Version: 3.91.0-d9755c53-20240605-153412
+ */
+
+package logs
+
+import (
+	"context"
+	"fmt"
+	"log"
+
+	"github.com/go-openapi/strfmt"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/conns"
+	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/flex"
+	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/validate"
+	"github.com/IBM/go-sdk-core/v5/core"
+	"github.com/IBM/logs-go-sdk/logsv0"
+)
+
+func ResourceIbmLogsDataAccessRule() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceIbmLogsDataAccessRuleCreate,
+		ReadContext:   resourceIbmLogsDataAccessRuleRead,
+		UpdateContext: resourceIbmLogsDataAccessRuleUpdate,
+		DeleteContext: resourceIbmLogsDataAccessRuleDelete,
+		Importer:      &schema.ResourceImporter{},
+
+		Schema: map[string]*schema.Schema{
+			"display_name": &schema.Schema{
+				Type:         schema.TypeString,
+				Required:     true,
+				ValidateFunc: validate.InvokeValidator("ibm_logs_data_access_rule", "display_name"),
+				Description:  "Data Access Rule Display Name.",
+			},
+			"description": &schema.Schema{
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validate.InvokeValidator("ibm_logs_data_access_rule", "description"),
+				Description:  "Optional Data Access Rule Description.",
+			},
+			"filters": &schema.Schema{
+				Type:        schema.TypeList,
+				Required:    true,
+				Description: "List of filters that the Data Access Rule is composed of.",
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"entity_type": &schema.Schema{
+							Type:        schema.TypeString,
+							Required:    true,
+							Description: "Filter's Entity Type.",
+						},
+						"expression": &schema.Schema{
+							Type:        schema.TypeString,
+							Required:    true,
+							Description: "Filter's Expression.",
+						},
+					},
+				},
+			},
+			"default_expression": &schema.Schema{
+				Type:         schema.TypeString,
+				Required:     true,
+				ValidateFunc: validate.InvokeValidator("ibm_logs_data_access_rule", "default_expression"),
+				Description:  "Default expression to use when no filter matches the query.",
+			},
+			"access_rule_id": &schema.Schema{
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "Data access rule ID.",
+			},
+		},
+	}
+}
+
+func ResourceIbmLogsDataAccessRuleValidator() *validate.ResourceValidator {
+	validateSchema := make([]validate.ValidateSchema, 0)
+	validateSchema = append(validateSchema,
+		validate.ValidateSchema{
+			Identifier:                 "display_name",
+			ValidateFunctionIdentifier: validate.ValidateRegexpLen,
+			Type:                       validate.TypeString,
+			Required:                   true,
+			Regexp:                     `^[A-Za-z0-9_\.,\-"{}()\[\]=!:#\/$|' ]+$`,
+			MinValueLength:             1,
+			MaxValueLength:             4096,
+		},
+		validate.ValidateSchema{
+			Identifier:                 "description",
+			ValidateFunctionIdentifier: validate.ValidateRegexpLen,
+			Type:                       validate.TypeString,
+			Optional:                   true,
+			Regexp:                     `^[A-Za-z0-9_\-\s]+$`,
+			MinValueLength:             1,
+			MaxValueLength:             4096,
+		},
+		validate.ValidateSchema{
+			Identifier:                 "default_expression",
+			ValidateFunctionIdentifier: validate.ValidateRegexpLen,
+			Type:                       validate.TypeString,
+			Required:                   true,
+			Regexp:                     `^[A-Za-z0-9_\.,\-"{}()\[\]=!:#\/$|'<> ]+$`,
+			MinValueLength:             1,
+			MaxValueLength:             4096,
+		},
+	)
+
+	resourceValidator := validate.ResourceValidator{ResourceName: "ibm_logs_data_access_rule", Schema: validateSchema}
+	return &resourceValidator
+}
+
+func resourceIbmLogsDataAccessRuleCreate(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	logsClient, err := meta.(conns.ClientSession).LogsV0()
+	if err != nil {
+		// Error is coming from SDK client, so it doesn't need to be discriminated.
+		tfErr := flex.TerraformErrorf(err, err.Error(), "ibm_logs_data_access_rule", "create")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
+	}
+
+	region := getLogsInstanceRegion(logsClient, d)
+	instanceId := d.Get("instance_id").(string)
+	logsClient = getClientWithLogsInstanceEndpoint(logsClient, instanceId, region, getLogsInstanceEndpointType(logsClient, d))
+
+	createDataAccessRuleOptions := &logsv0.CreateDataAccessRuleOptions{}
+
+	createDataAccessRuleOptions.SetDisplayName(d.Get("display_name").(string))
+	var filters []logsv0.DataAccessRuleFilter
+	for _, v := range d.Get("filters").([]interface{}) {
+		value := v.(map[string]interface{})
+		filtersItem, err := ResourceIbmLogsDataAccessRuleMapToDataAccessRuleFilter(value)
+		if err != nil {
+			return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_logs_data_access_rule", "create", "parse-filters").GetDiag()
+		}
+		filters = append(filters, *filtersItem)
+	}
+	createDataAccessRuleOptions.SetFilters(filters)
+	createDataAccessRuleOptions.SetDefaultExpression(d.Get("default_expression").(string))
+	if _, ok := d.GetOk("description"); ok {
+		createDataAccessRuleOptions.SetDescription(d.Get("description").(string))
+	}
+
+	dataAccessRule, _, err := logsClient.CreateDataAccessRuleWithContext(context, createDataAccessRuleOptions)
+	if err != nil {
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("CreateDataAccessRuleWithContext failed: %s", err.Error()), "ibm_logs_data_access_rule", "create")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
+	}
+	dataAccessRuleId := fmt.Sprintf("%s/%s/%s", region, instanceId, *dataAccessRule.ID)
+	d.SetId(dataAccessRuleId)
+
+	return resourceIbmLogsDataAccessRuleRead(context, d, meta)
+}
+
+func resourceIbmLogsDataAccessRuleRead(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	logsClient, err := meta.(conns.ClientSession).LogsV0()
+	if err != nil {
+		tfErr := flex.TerraformErrorf(err, err.Error(), "ibm_logs_data_access_rule", "read")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
+	}
+
+	logsClient, region, instanceId, accessRuleId, err := updateClientURLWithInstanceEndpoint(d.Id(), logsClient, d)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	listDataAccessRulesOptions := &logsv0.ListDataAccessRulesOptions{}
+
+	ruleID := core.UUIDPtr(strfmt.UUID(accessRuleId))
+	listDataAccessRulesOptions.ID = []strfmt.UUID{*ruleID}
+
+	dataAccessRuleCollection, response, err := logsClient.ListDataAccessRulesWithContext(context, listDataAccessRulesOptions)
+	if err != nil {
+		if response != nil && response.StatusCode == 404 {
+			d.SetId("")
+			return nil
+		}
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("ListDataAccessRulesWithContext failed: %s", err.Error()), "ibm_logs_data_access_rule", "read")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
+	}
+
+	if err = d.Set("access_rule_id", accessRuleId); err != nil {
+		return diag.FromErr(fmt.Errorf("Error setting access_rule_id: %s", err))
+	}
+	if err = d.Set("instance_id", instanceId); err != nil {
+		return diag.FromErr(fmt.Errorf("Error setting instance_id: %s", err))
+	}
+	if err = d.Set("region", region); err != nil {
+		return diag.FromErr(fmt.Errorf("Error setting region: %s", err))
+	}
+
+	if dataAccessRuleCollection != nil && len(dataAccessRuleCollection.DataAccessRules) > 0 && &dataAccessRuleCollection.DataAccessRules[0] != nil {
+
+		dataAccessRule := dataAccessRuleCollection.DataAccessRules[0]
+
+		if err = d.Set("display_name", dataAccessRule.DisplayName); err != nil {
+			err = fmt.Errorf("Error setting display_name: %s", err)
+			return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_logs_data_access_rule", "read", "set-display_name").GetDiag()
+		}
+		if !core.IsNil(dataAccessRule.Description) {
+			if err = d.Set("description", dataAccessRule.Description); err != nil {
+				err = fmt.Errorf("Error setting description: %s", err)
+				return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_logs_data_access_rule", "read", "set-description").GetDiag()
+			}
+		}
+		filters := []map[string]interface{}{}
+		for _, filtersItem := range dataAccessRule.Filters {
+			filtersItemMap, err := ResourceIbmLogsDataAccessRuleDataAccessRuleFilterToMap(&filtersItem)
+			if err != nil {
+				return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_logs_data_access_rule", "read", "filters-to-map").GetDiag()
+			}
+			filters = append(filters, filtersItemMap)
+		}
+		if err = d.Set("filters", filters); err != nil {
+			err = fmt.Errorf("Error setting filters: %s", err)
+			return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_logs_data_access_rule", "read", "set-filters").GetDiag()
+		}
+		if err = d.Set("default_expression", dataAccessRule.DefaultExpression); err != nil {
+			err = fmt.Errorf("Error setting default_expression: %s", err)
+			return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_logs_data_access_rule", "read", "set-default_expression").GetDiag()
+		}
+	}
+
+	return nil
+}
+
+func resourceIbmLogsDataAccessRuleUpdate(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	logsClient, err := meta.(conns.ClientSession).LogsV0()
+	if err != nil {
+		tfErr := flex.TerraformErrorf(err, err.Error(), "ibm_logs_data_access_rule", "update")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
+	}
+
+	logsClient, _, _, accessRuleId, err := updateClientURLWithInstanceEndpoint(d.Id(), logsClient, d)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	updateDataAccessRuleOptions := &logsv0.UpdateDataAccessRuleOptions{}
+
+	updateDataAccessRuleOptions.SetID(core.UUIDPtr(strfmt.UUID(accessRuleId)))
+
+	hasChange := false
+
+	if d.HasChange("display_name") ||
+		d.HasChange("filters") ||
+		d.HasChange("default_expression") ||
+		d.HasChange("description") {
+
+		updateDataAccessRuleOptions.SetDisplayName(d.Get("display_name").(string))
+		var filters []logsv0.DataAccessRuleFilter
+		for _, v := range d.Get("filters").([]interface{}) {
+			value := v.(map[string]interface{})
+			filtersItem, err := ResourceIbmLogsDataAccessRuleMapToDataAccessRuleFilter(value)
+			if err != nil {
+				return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_logs_data_access_rule", "update", "parse-filters").GetDiag()
+			}
+			filters = append(filters, *filtersItem)
+		}
+		updateDataAccessRuleOptions.SetFilters(filters)
+		updateDataAccessRuleOptions.SetDefaultExpression(d.Get("default_expression").(string))
+
+		updateDataAccessRuleOptions.SetDescription(d.Get("description").(string))
+		hasChange = true
+	}
+
+	if hasChange {
+		_, _, err = logsClient.UpdateDataAccessRuleWithContext(context, updateDataAccessRuleOptions)
+		if err != nil {
+			tfErr := flex.TerraformErrorf(err, fmt.Sprintf("UpdateDataAccessRuleWithContext failed: %s", err.Error()), "ibm_logs_data_access_rule", "update")
+			log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+			return tfErr.GetDiag()
+		}
+	}
+
+	return resourceIbmLogsDataAccessRuleRead(context, d, meta)
+}
+
+func resourceIbmLogsDataAccessRuleDelete(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	logsClient, err := meta.(conns.ClientSession).LogsV0()
+	if err != nil {
+		tfErr := flex.TerraformErrorf(err, err.Error(), "ibm_logs_data_access_rule", "delete")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
+	}
+
+	logsClient, _, _, accessRuleId, err := updateClientURLWithInstanceEndpoint(d.Id(), logsClient, d)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	deleteDataAccessRuleOptions := &logsv0.DeleteDataAccessRuleOptions{}
+	deleteDataAccessRuleOptions.SetID(core.UUIDPtr(strfmt.UUID(accessRuleId)))
+
+	_, err = logsClient.DeleteDataAccessRuleWithContext(context, deleteDataAccessRuleOptions)
+	if err != nil {
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("DeleteDataAccessRuleWithContext failed: %s", err.Error()), "ibm_logs_data_access_rule", "delete")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
+	}
+
+	d.SetId("")
+
+	return nil
+}
+
+func ResourceIbmLogsDataAccessRuleMapToDataAccessRuleFilter(modelMap map[string]interface{}) (*logsv0.DataAccessRuleFilter, error) {
+	model := &logsv0.DataAccessRuleFilter{}
+	model.EntityType = core.StringPtr(modelMap["entity_type"].(string))
+	model.Expression = core.StringPtr(modelMap["expression"].(string))
+	return model, nil
+}
+
+func ResourceIbmLogsDataAccessRuleDataAccessRuleFilterToMap(model *logsv0.DataAccessRuleFilter) (map[string]interface{}, error) {
+	modelMap := make(map[string]interface{})
+	modelMap["entity_type"] = *model.EntityType
+	modelMap["expression"] = *model.Expression
+	return modelMap, nil
+}

--- a/ibm/service/logs/resource_ibm_logs_data_access_rule_test.go
+++ b/ibm/service/logs/resource_ibm_logs_data_access_rule_test.go
@@ -1,0 +1,190 @@
+// Copyright IBM Corp. 2024 All Rights Reserved.
+// Licensed under the Mozilla Public License v2.0
+
+package logs_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/go-openapi/strfmt"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	acc "github.com/IBM-Cloud/terraform-provider-ibm/ibm/acctest"
+	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/conns"
+	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/flex"
+	"github.com/IBM/go-sdk-core/v5/core"
+	"github.com/IBM/logs-go-sdk/logsv0"
+)
+
+func TestAccIbmLogsDataAccessRuleBasic(t *testing.T) {
+	var conf logsv0.DataAccessRule
+	displayName := fmt.Sprintf("tf_display_name_%d", acctest.RandIntRange(10, 100))
+	defaultExpression := "<v1>true"
+	displayNameUpdate := fmt.Sprintf("tf_display_name_%d", acctest.RandIntRange(10, 100))
+	defaultExpressionUpdate := "<v1>false"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { acc.TestAccPreCheckCloudLogs(t) },
+		Providers:    acc.TestAccProviders,
+		CheckDestroy: testAccCheckIbmLogsDataAccessRuleDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccCheckIbmLogsDataAccessRuleConfigBasic(displayName, defaultExpression),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckIbmLogsDataAccessRuleExists("ibm_logs_data_access_rule.logs_data_access_rule_instance", conf),
+					resource.TestCheckResourceAttr("ibm_logs_data_access_rule.logs_data_access_rule_instance", "display_name", displayName),
+					resource.TestCheckResourceAttr("ibm_logs_data_access_rule.logs_data_access_rule_instance", "default_expression", defaultExpression),
+				),
+			},
+			resource.TestStep{
+				Config: testAccCheckIbmLogsDataAccessRuleConfigBasic(displayNameUpdate, defaultExpressionUpdate),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("ibm_logs_data_access_rule.logs_data_access_rule_instance", "display_name", displayNameUpdate),
+					resource.TestCheckResourceAttr("ibm_logs_data_access_rule.logs_data_access_rule_instance", "default_expression", defaultExpressionUpdate),
+				),
+			},
+		},
+	})
+}
+
+func TestAccIbmLogsDataAccessRuleAllArgs(t *testing.T) {
+	var conf logsv0.DataAccessRule
+	displayName := fmt.Sprintf("tf_display_name_%d", acctest.RandIntRange(10, 100))
+	description := fmt.Sprintf("tf_description_%d", acctest.RandIntRange(10, 100))
+	defaultExpression := "<v1>true"
+	displayNameUpdate := fmt.Sprintf("tf_display_name_%d", acctest.RandIntRange(10, 100))
+	descriptionUpdate := fmt.Sprintf("tf_description_%d", acctest.RandIntRange(10, 100))
+	defaultExpressionUpdate := "<v1>false"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { acc.TestAccPreCheckCloudLogs(t) },
+		Providers:    acc.TestAccProviders,
+		CheckDestroy: testAccCheckIbmLogsDataAccessRuleDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccCheckIbmLogsDataAccessRuleConfig(displayName, description, defaultExpression),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckIbmLogsDataAccessRuleExists("ibm_logs_data_access_rule.logs_data_access_rule_instance", conf),
+					resource.TestCheckResourceAttr("ibm_logs_data_access_rule.logs_data_access_rule_instance", "display_name", displayName),
+					resource.TestCheckResourceAttr("ibm_logs_data_access_rule.logs_data_access_rule_instance", "description", description),
+					resource.TestCheckResourceAttr("ibm_logs_data_access_rule.logs_data_access_rule_instance", "default_expression", defaultExpression),
+				),
+			},
+			resource.TestStep{
+				Config: testAccCheckIbmLogsDataAccessRuleConfig(displayNameUpdate, descriptionUpdate, defaultExpressionUpdate),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("ibm_logs_data_access_rule.logs_data_access_rule_instance", "display_name", displayNameUpdate),
+					resource.TestCheckResourceAttr("ibm_logs_data_access_rule.logs_data_access_rule_instance", "description", descriptionUpdate),
+					resource.TestCheckResourceAttr("ibm_logs_data_access_rule.logs_data_access_rule_instance", "default_expression", defaultExpressionUpdate),
+				),
+			},
+			resource.TestStep{
+				ResourceName:      "ibm_logs_data_access_rule.logs_data_access_rule_instance",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testAccCheckIbmLogsDataAccessRuleConfigBasic(displayName string, defaultExpression string) string {
+	return fmt.Sprintf(`
+		resource "ibm_logs_data_access_rule" "logs_data_access_rule_instance" {
+			instance_id  = "%s"
+			region       = "%s"
+			display_name = "%s"
+			filters {
+				entity_type = "logs"
+				expression  = "<v1> foo == 'bar'"
+			}
+			default_expression = "%s"
+		}
+	`, acc.LogsInstanceId, acc.LogsInstanceRegion, displayName, defaultExpression)
+}
+
+func testAccCheckIbmLogsDataAccessRuleConfig(displayName string, description string, defaultExpression string) string {
+	return fmt.Sprintf(`
+
+		resource "ibm_logs_data_access_rule" "logs_data_access_rule_instance" {
+			instance_id  = "%s"
+			region       = "%s"
+			display_name = "%s"
+			description  = "%s"
+			filters {
+				entity_type = "logs"
+				expression  = "<v1> foo == 'bar'"
+			}
+			default_expression = "%s"
+		}
+	`, acc.LogsInstanceId, acc.LogsInstanceRegion, displayName, description, defaultExpression)
+}
+
+func testAccCheckIbmLogsDataAccessRuleExists(n string, obj logsv0.DataAccessRule) resource.TestCheckFunc {
+
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+		resourceID, err := flex.IdParts(rs.Primary.ID)
+		if err != nil {
+			return err
+		}
+
+		logsClient, err := acc.TestAccProvider.Meta().(conns.ClientSession).LogsV0()
+		if err != nil {
+			return err
+		}
+		logsClient = getTestClientWithLogsInstanceEndpoint(logsClient)
+
+		listDataAccessRulesOptions := &logsv0.ListDataAccessRulesOptions{}
+		accessRuleID := core.UUIDPtr(strfmt.UUID(resourceID[2]))
+
+		listDataAccessRulesOptions.ID = []strfmt.UUID{*accessRuleID}
+		dataAccessRuleCollection, _, err := logsClient.ListDataAccessRules(listDataAccessRulesOptions)
+		if err != nil {
+			return err
+		}
+		if dataAccessRuleCollection != nil && len(dataAccessRuleCollection.DataAccessRules) > 0 && &dataAccessRuleCollection.DataAccessRules[0] != nil && dataAccessRuleCollection.DataAccessRules[0].ID == accessRuleID {
+			dataAccessRule := dataAccessRuleCollection.DataAccessRules[0]
+			obj = dataAccessRule
+			return nil
+		}
+
+		return nil
+	}
+}
+
+func testAccCheckIbmLogsDataAccessRuleDestroy(s *terraform.State) error {
+	logsClient, err := acc.TestAccProvider.Meta().(conns.ClientSession).LogsV0()
+	if err != nil {
+		return err
+	}
+	logsClient = getTestClientWithLogsInstanceEndpoint(logsClient)
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "ibm_logs_data_access_rule" {
+			continue
+		}
+		resourceID, err := flex.IdParts(rs.Primary.ID)
+		if err != nil {
+			return err
+		}
+
+		listDataAccessRulesOptions := &logsv0.ListDataAccessRulesOptions{}
+		accessRuleID := core.UUIDPtr(strfmt.UUID(resourceID[2]))
+
+		listDataAccessRulesOptions.ID = []strfmt.UUID{*accessRuleID}
+
+		dataAccessRuleCollection, _, err := logsClient.ListDataAccessRules(listDataAccessRulesOptions)
+
+		if dataAccessRuleCollection != nil && len(dataAccessRuleCollection.DataAccessRules) > 0 && &dataAccessRuleCollection.DataAccessRules[0] != nil && dataAccessRuleCollection.DataAccessRules[0].ID == accessRuleID {
+			return fmt.Errorf("logs_data_access_rule still exists: %s", rs.Primary.ID)
+		}
+	}
+
+	return nil
+}

--- a/website/docs/d/logs_data_access_rules.html.markdown
+++ b/website/docs/d/logs_data_access_rules.html.markdown
@@ -1,0 +1,56 @@
+---
+layout: "ibm"
+page_title: "IBM : ibm_logs_data_access_rules"
+description: |-
+  Get information about logs_data_access_rules
+subcategory: "Cloud Logs"
+---
+
+# ibm_logs_data_access_rules
+
+Provides a read-only data source to retrieve information about logs_data_access_rules. You can then reference the fields of the data source in other resources within the same configuration by using interpolation syntax.
+
+## Example Usage
+
+```hcl
+data "ibm_logs_data_access_rules" "logs_data_access_rules_instance" {
+  instance_id               = "9d392fb2-b01b-40d5-9aec-fe21d02ab6ed"
+  region                    = "eu-de"
+  logs_data_access_rules_id = [ibm_logs_data_access_rule.logs_data_access_rule_instance.access_rule_id]
+}
+
+```
+
+## Argument Reference
+
+You can specify the following arguments for this data source.
+
+* `instance_id` - (Required, String)  Cloud Logs Instance GUID.
+* `region` - (Optional, String) Cloud Logs Instance Region.
+* `logs_data_access_rules_id` - (Optional, List) Array of data access rule IDs.
+  * Constraints: The list items must match regular expression `/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/`. The maximum length is `4096` items. The minimum length is `0` items.
+
+## Attribute Reference
+
+After your data source is created, you can read values from the following attributes.
+
+* `id` - The unique identifier of the logs_data_access_rules.
+* `data_access_rules` - (List) Data Access Rule details.
+  * Constraints: The maximum length is `4096` items. The minimum length is `0` items.
+Nested schema for **data_access_rules**:
+	* `default_expression` - (String) Default expression to use when no filter matches the query.
+	  * Constraints: The maximum length is `4096` characters. The minimum length is `1` character. The value must match regular expression `/^[A-Za-z0-9_\\.,\\-"{}()\\[\\]=!:#\/$|'<> ]+$/`.
+	* `description` - (String) Optional Data Access Rule Description.
+	  * Constraints: The maximum length is `4096` characters. The minimum length is `1` character. The value must match regular expression `/^[A-Za-z0-9_\\-\\s]+$/`.
+	* `display_name` - (String) Data Access Rule Display Name.
+	  * Constraints: The maximum length is `4096` characters. The minimum length is `1` character. The value must match regular expression `/^[A-Za-z0-9_\\.,\\-"{}()\\[\\]=!:#\/$|' ]+$/`.
+	* `filters` - (List) List of filters that the Data Access Rule is composed of.
+	  * Constraints: The maximum length is `4096` items. The minimum length is `0` items.
+	Nested schema for **filters**:
+		* `entity_type` - (String) Filter's Entity Type.
+		  * Constraints: Allowable values are: `unspecified`, `logs`.
+		* `expression` - (String) Filter's Expression.
+		  * Constraints: The maximum length is `4096` characters. The minimum length is `1` character. The value must match regular expression `/^[A-Za-z0-9_\\.,\\-"{}()\\[\\]=!:#\/$|'<> ]+$/`.
+	* `id` - (String) Data Access Rule ID.
+	  * Constraints: The maximum length is `36` characters. The minimum length is `36` characters. The value must match regular expression `/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/`.
+

--- a/website/docs/r/logs_data_access_rule.html.markdown
+++ b/website/docs/r/logs_data_access_rule.html.markdown
@@ -1,0 +1,69 @@
+---
+layout: "ibm"
+page_title: "IBM : ibm_logs_data_access_rule"
+description: |-
+  Manages logs_data_access_rule.
+subcategory: "Cloud Logs"
+---
+
+# ibm_logs_data_access_rule
+
+Create, update, and delete logs_data_access_rules with this resource.
+
+## Example Usage
+
+```hcl
+resource "ibm_logs_data_access_rule" "logs_data_access_rule_instance" {
+  instance_id  = "9d392fb2-b01b-40d5-9aec-fe21d02ab6ed"
+  region       = "eu-de"
+  display_name = "Test Data Access Rule"
+  description  = "Data Access Rule intended for testing"
+  filters {
+    entity_type = "logs"
+    expression  = "<v1> foo == 'bar'"
+  }
+  default_expression = "<v1>true"
+}
+```
+
+## Argument Reference
+
+You can specify the following arguments for this resource.
+
+* `instance_id` - (Required, Forces new resource, String) Cloud Logs Instance GUID.
+* `region` - (Optional, Forces new resource, String) Cloud Logs Instance Region.
+* `endpoint_type` - (Optional, String) Cloud Logs Instance Endpoint type. Allowed values `public` and `private`.
+* `default_expression` - (Required, String) Default expression to use when no filter matches the query.
+  * Constraints: The maximum length is `4096` characters. The minimum length is `1` character. The value must match regular expression `/^[A-Za-z0-9_\\.,\\-"{}()\\[\\]=!:#\/$|'<> ]+$/`.
+* `description` - (Optional, String) Optional Data Access Rule Description.
+  * Constraints: The maximum length is `4096` characters. The minimum length is `1` character. The value must match regular expression `/^[A-Za-z0-9_\\-\\s]+$/`.
+* `display_name` - (Required, String) Data Access Rule Display Name.
+  * Constraints: The maximum length is `4096` characters. The minimum length is `1` character. The value must match regular expression `/^[A-Za-z0-9_\\.,\\-"{}()\\[\\]=!:#\/$|' ]+$/`.
+* `filters` - (Required, List) List of filters that the Data Access Rule is composed of.
+  * Constraints: The maximum length is `4096` items. The minimum length is `0` items.
+Nested schema for **filters**:
+	* `entity_type` - (Required, String) Filter's Entity Type.
+	  * Constraints: Allowable values are: `unspecified`, `logs`.
+	* `expression` - (Required, String) Filter's Expression.
+	  * Constraints: The maximum length is `4096` characters. The minimum length is `1` character. The value must match regular expression `/^[A-Za-z0-9_\\.,\\-"{}()\\[\\]=!:#\/$|'<> ]+$/`.
+
+## Attribute Reference
+
+After your resource is created, you can read values from the listed arguments and the following attributes.
+
+* `id` - The unique identifier of the logs_data_access_rule.
+* `access_rule_id` - The unique identifier of the logs data access rule.
+
+## Import
+
+You can import the `ibm_logs_data_access_rule` resource by using `id`. `id` combination of `region`, `instance_id` and `access_rule_id`.
+
+# Syntax
+<pre>
+$ terraform import ibm_logs_dashboard_folder.logs_dashboard_folder < region >/< instance_id >/< access_rule_id >;
+</pre>
+
+# Example
+```
+$ terraform import ibm_logs_data_access_rule.logs_data_access_rule eu-gb/3dc02998-0b50-4ea8-b68a-4779d716fa1f/d6a3658e-78d2-47d0-9b81-b2c551f01b09
+```


### PR DESCRIPTION
```
 make testacc TEST=./ibm/service/logs TESTARGS='-run=TestAccIbmLogsDataAccessRule'
...
=== RUN   TestAccIbmLogsDataAccessRulesDataSourceBasic
--- PASS: TestAccIbmLogsDataAccessRulesDataSourceBasic (28.43s)
=== RUN   TestAccIbmLogsDataAccessRulesDataSourceAllArgs
--- PASS: TestAccIbmLogsDataAccessRulesDataSourceAllArgs (24.25s)
=== RUN   TestAccIbmLogsDataAccessRuleBasic
--- PASS: TestAccIbmLogsDataAccessRuleBasic (38.70s)
=== RUN   TestAccIbmLogsDataAccessRuleAllArgs
--- PASS: TestAccIbmLogsDataAccessRuleAllArgs (39.24s)
PASS
ok  	github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/logs	133.959s
```