### PR TITLE
feat(ResourceController): Added onetime_credentials to ResourceInstan…

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -26,7 +26,7 @@ require (
 	github.com/IBM/keyprotect-go-client v0.14.0
 	github.com/IBM/logs-go-sdk v0.3.0
 	github.com/IBM/networking-go-sdk v0.48.0
-	github.com/IBM/platform-services-go-sdk v0.64.4
+	github.com/IBM/platform-services-go-sdk v0.65.0
 	github.com/IBM/project-go-sdk v0.3.5
 	github.com/IBM/push-notifications-go-sdk v0.0.0-20210310100607-5790b96c47f5
 	github.com/IBM/scc-go-sdk/v5 v5.1.6
@@ -64,7 +64,7 @@ require (
 )
 
 require (
-	github.com/IBM-Cloud/bluemix-go v0.0.0-20240423071914-9e96525baef4
+	github.com/IBM-Cloud/bluemix-go v0.0.0-20240719075425-078fcb3a55be
 	github.com/IBM/go-sdk-core v1.1.0
 	github.com/IBM/mqcloud-go-sdk v0.1.0
 	github.com/IBM/sarama v1.41.2

--- a/ibm/service/resourcecontroller/data_source_ibm_resource_instance.go
+++ b/ibm/service/resourcecontroller/data_source_ibm_resource_instance.go
@@ -94,6 +94,13 @@ func DataSourceIBMResourceInstance() *schema.Resource {
 				Description: "Guid of resource instance",
 			},
 
+			// ### Modification addded onetime_credentials to Resource scehama
+			"onetime_credentials": {
+				Type:        schema.TypeBool,
+				Computed:    true,
+				Description: "onetime_credentials of resource instance",
+			},
+
 			"parameters_json": {
 				Description: "Parameters asociated with instance in json string",
 				Type:        schema.TypeString,
@@ -270,6 +277,8 @@ func DataSourceIBMResourceInstanceRead(d *schema.ResourceData, meta interface{})
 	d.Set(flex.ResourceName, instance.Name)
 	d.Set(flex.ResourceCRN, instance.CRN)
 	d.Set(flex.ResourceStatus, instance.State)
+	// ### Modifiction : Setting the onetime credientials
+	d.Set("onetime_credentials", instance.OnetimeCredentials)
 	if instance.Parameters != nil {
 		params, err := json.Marshal(instance.Parameters)
 		if err != nil {

--- a/ibm/service/resourcecontroller/data_source_ibm_resource_key.go
+++ b/ibm/service/resourcecontroller/data_source_ibm_resource_key.go
@@ -58,6 +58,13 @@ func DataSourceIBMResourceKey() *schema.Resource {
 				Description: "Status of resource key",
 			},
 
+			// ### Modification addded onetime_credentials to Resource scehama
+			"onetime_credentials": {
+				Type:        schema.TypeBool,
+				Computed:    true,
+				Description: "onetime_credentials of resource key",
+			},
+
 			"credentials": {
 				Description: "Credentials asociated with the key",
 				Sensitive:   true,
@@ -162,6 +169,8 @@ func dataSourceIBMResourceKeyRead(d *schema.ResourceData, meta interface{}) erro
 		d.Set("role", roleCrn[strings.LastIndex(roleCrn, ":")+1:])
 	}
 
+	// ### Modification for onetime_credientails
+	d.Set("onetime_credentials", key.OnetimeCredentials)
 	d.Set("credentials", flex.Flatten(key.Credentials))
 	creds, err := json.Marshal(key.Credentials)
 	if err != nil {

--- a/ibm/service/resourcecontroller/resource_ibm_resource_instance.go
+++ b/ibm/service/resourcecontroller/resource_ibm_resource_instance.go
@@ -94,6 +94,13 @@ func ResourceIBMResourceInstance() *schema.Resource {
 					"resource_group_id"),
 			},
 
+			// ### Modification : Adding onetime_credientails into the response scehama
+			"onetime_credentials": {
+				Description: "A boolean that dictates if the onetime_credentials is true or false.",
+				Type:        schema.TypeBool,
+				Computed:    true,
+			},
+
 			"parameters": {
 				Type:          schema.TypeMap,
 				Optional:      true,
@@ -595,6 +602,8 @@ func ResourceIBMResourceInstanceRead(d *schema.ResourceData, meta interface{}) e
 	}
 	d.Set("plan", servicePlan)
 	d.Set("guid", instance.GUID)
+	// ### Modificataion : Setting  "onetime_credentials"
+	d.Set("onetime_credentials", instance.OnetimeCredentials)
 	if instance.Parameters != nil {
 		if endpoint, ok := instance.Parameters["service-endpoints"]; ok {
 			d.Set("service_endpoints", endpoint)

--- a/ibm/service/resourcecontroller/resource_ibm_resource_instance_test.go
+++ b/ibm/service/resourcecontroller/resource_ibm_resource_instance_test.go
@@ -423,3 +423,46 @@ func testAccCheckIBMResourceInstanceServiceendpoints(serviceName string) string 
 			
 	`, serviceName)
 }
+
+// /#### Adding new test case for onetime_credentials
+func TestAccIBMResourceInstanceWithOnetimeCredentials(t *testing.T) {
+	serviceName := fmt.Sprintf("tf-Pgress-%d", acctest.RandIntRange(10, 100))
+	resourceName := "ibm_resource_instance.instance"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { acc.TestAccPreCheck(t) },
+		Providers:    acc.TestAccProviders,
+		CheckDestroy: testAccCheckIBMResourceInstanceDestroy,
+		Steps: []resource.TestStep{
+
+			{
+				Config: testAccCheckIBMResourceInstanceOnetimeCredentals(serviceName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckIBMResourceInstanceExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "name", serviceName),
+					resource.TestCheckResourceAttr(resourceName, "service", "cloud-object-storage"),
+					resource.TestCheckResourceAttr(resourceName, "plan", "lite"),
+					resource.TestCheckResourceAttr(resourceName, "location", "global"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckIBMResourceInstanceOnetimeCredentals(serviceName string) string {
+	return fmt.Sprintf(`
+    
+    resource "ibm_resource_instance" "instance" {
+        name     = "%s"
+        location = "global"
+        service  = "cloud-object-storage"
+        plan     = "lite"
+        parameters = {
+          onetime_credentials = true,
+        }
+      
+        
+    }
+            
+    `, serviceName)
+}

--- a/ibm/service/resourcecontroller/resource_ibm_resource_key.go
+++ b/ibm/service/resourcecontroller/resource_ibm_resource_key.go
@@ -75,7 +75,12 @@ func ResourceIBMResourceKey() *schema.Resource {
 				DiffSuppressFunc: flex.ApplyOnce,
 				Description:      "Arbitrary parameters to pass. Must be a JSON object",
 			},
-
+			// ### Modification addded onetime_credentials to Resource scehama
+			"onetime_credentials": {
+				Type:        schema.TypeBool,
+				Computed:    true,
+				Description: "onetime_credentials of resource key",
+			},
 			"credentials": {
 				Description: "Credentials asociated with the key",
 				Type:        schema.TypeMap,
@@ -366,6 +371,8 @@ func resourceIBMResourceKeyRead(d *schema.ResourceData, meta interface{}) error 
 	d.Set("resource_group_id", *resourceKey.ResourceGroupID)
 	d.Set("source_crn", *resourceKey.SourceCRN)
 	d.Set("state", *resourceKey.State)
+	// ### Modificataion : Setting  "onetime_credentials"
+	d.Set("onetime_credentials", *resourceKey.OnetimeCredentials)
 	d.Set("iam_compatible", *resourceKey.IamCompatible)
 	d.Set("resource_instance_url", *resourceKey.ResourceInstanceURL)
 	if resourceKey.CreatedAt != nil {

--- a/website/docs/d/resource_instance.html.markdown
+++ b/website/docs/d/resource_instance.html.markdown
@@ -48,3 +48,4 @@ In addition to all argument reference list, you can access the following attribu
 - `parameters_json` - (String) The parameters associated with the instance in json format.
 - `plan` - (String) The plan for the service offering used by this resource instance.
 - `status` - (String) The status of resource instance.
+- `onetime_credentials` - (Bool) A boolean that dictates if the onetime_credentials is true or false.

--- a/website/docs/d/resource_key.html.markdown
+++ b/website/docs/d/resource_key.html.markdown
@@ -68,6 +68,7 @@ In addition to all argument reference list, you can access the following attribu
 - `id` - (String) The unique identifier of the resource key.
 - `role` - (String) The user role.
 - `status` - (String) The status of the resource key.  
+- `onetime_credentials` - (Bool) A boolean that dictates if the onetime_credentials is true or false.
 
 ## Note
 Credentials will be seen as redacted, if the user does not have access equal to or greater than the access of the service credentials. Please refer to the documentation to access credentials - https://cloud.ibm.com/docs/account?topic=account-service_credentials&interface=ui#viewing-credentials-ui.

--- a/website/docs/r/resource_instance.html.markdown
+++ b/website/docs/r/resource_instance.html.markdown
@@ -213,3 +213,4 @@ In addition to all argument reference list, you can access the following attribu
 - `type` - (String) The type of the instance. For example, `service_instance`.
 - `update_at` - (Timestamp) The date when the instance last updated.
 - `update_by` - (String) The subject who updated the instance.
+- `onetime_credentials` - (Bool) A boolean that dictates if the onetime_credentials is true or false.

--- a/website/docs/r/resource_key.html.markdown
+++ b/website/docs/r/resource_key.html.markdown
@@ -165,6 +165,7 @@ In addition to all argument reference list, you can access the following attribu
 - `updated_at` - (Timestamp) The date when the key was last updated.
 - `updated_by` - (String) The subject who updated the key.
 - `url` - (String) When you created a new key, a relative URL path is created identifying the location of the key.
+- `onetime_credentials` - (Bool) A boolean that dictates if the onetime_credentials is true or false.
 
 ## Note
 Credentials will be seen as redacted, if the user does not have access equal to or greater than the access of the service credentials. Please refer to the documentation to access credentials - https://cloud.ibm.com/docs/account?topic=account-service_credentials&interface=ui#viewing-credentials-ui.


### PR DESCRIPTION

[output_acceptancetest.txt](https://github.com/user-attachments/files/16385561/output_acceptancetest.txt)
…ce and ResourceKey read schemas

<!--- See what makes a good Pull Request at : https://github.com/IBM-Cloud/terraform-provider-ibm/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```
