### PR TITLE
deprecate force_delete arg from key ring resource

### DIFF
--- a/ibm/service/kms/resource_ibm_kms_key_rings.go
+++ b/ibm/service/kms/resource_ibm_kms_key_rings.go
@@ -39,7 +39,7 @@ func ResourceIBMKmskeyRings() *schema.Resource {
 			"force_delete": {
 				Type:        schema.TypeBool,
 				Optional:    true,
-				Description: "set to true to force delete this key ring. This allows key ring deletion as long as all keys inside have key state equals to 5 (destroyed). Keys are moved to the default key ring.",
+				Description: "(Deprecated) set to true to force delete this key ring. This allows key ring deletion as long as all keys inside have key state equals to 5 (destroyed). Keys are moved to the default key ring.",
 				ForceNew:    false,
 				Default:     false,
 			},
@@ -148,14 +148,11 @@ func resourceIBMKmsKeyRingDelete(d *schema.ResourceData, meta interface{}) error
 	if err != nil {
 		return err
 	}
-	force_delete := d.Get("force_delete").(bool)
 
-	err = kpAPI.DeleteKeyRing(context.Background(), id[0], kp.WithForce(force_delete))
+	err = kpAPI.DeleteKeyRing(context.Background(), id[0], kp.WithForce(true))
 	if err != nil {
 		kpError := err.(*kp.Error)
-		// Key ring deletion used to occur by silencing the 409 failed deletion and allowing instance deletion to clean it up
-		// Will be deprecated in the future in favor of force_delete flag
-		if kpError.StatusCode == 404 || kpError.StatusCode == 409 {
+		if kpError.StatusCode == 404 {
 			return nil
 		} else {
 			return fmt.Errorf(" failed to Destroy key ring with error: %s", err)

--- a/ibm/service/kms/resource_ibm_kms_key_rings_test.go
+++ b/ibm/service/kms/resource_ibm_kms_key_rings_test.go
@@ -70,49 +70,7 @@ func TestAccIBMKMSResource_Key_Ring_Not_Exist(t *testing.T) {
 	})
 }
 
-// Developer note: Test is disabled as a bug exists where this is not properly testable
-// func TestAccIBMKMSResource_Key_Ring_ForceDeleteFalse(t *testing.T) {
-// 	instanceName := fmt.Sprintf("tf_kms_%d", acctest.RandIntRange(10, 100))
-// 	keyName := fmt.Sprintf("key_%d", acctest.RandIntRange(10, 100))
-// 	keyRing := fmt.Sprintf("keyRing%d", acctest.RandIntRange(10, 100))
-
-// 	resource.Test(t, resource.TestCase{
-// 		PreCheck:  func() { acc.TestAccPreCheck(t) },
-// 		Providers: acc.TestAccProviders,
-// 		Steps: []resource.TestStep{
-// 			// Create a Key Ring and check force_delete is false
-// 			{
-// 				Config: buildResourceSet(WithResourceKMSInstance(instanceName), WithResourceKMSKeyRing(keyRing, false), WithResourceKMSKey(keyName, "ibm_kms_key_rings.test.key_ring_id")),
-// 				Check: resource.ComposeTestCheckFunc(
-// 					resource.TestCheckResourceAttr("ibm_kms_key.test", "key_name", keyName),
-// 					resource.TestCheckResourceAttr("ibm_kms_key.test", "key_ring_id", keyRing),
-// 					resource.TestCheckResourceAttr("ibm_kms_key_rings.test", "force_delete", "false"),
-// 				),
-// 			},
-// 			// Developer note: We cannot move key rings to default key ring as we have not implemented that PATCH endpoint in terraform. Therefore we must depend on the force_delete flag to clean up test cases
-// 			// Attempt to delete the key ring and key
-// 			{
-// 				Config:      buildResourceSet(WithResourceKMSInstance(instanceName)),
-// 				ExpectError: regexp.MustCompile("KEY_RING_NOT_EMPTY_ERR:"),
-// 			},
-// 			// Update key ring to force_delete for cleanup
-// 			{
-// 				Config: buildResourceSet(WithResourceKMSInstance(instanceName), WithResourceKMSKeyRing(keyRing, true)),
-// 				Check: resource.ComposeTestCheckFunc(
-// 					resource.TestCheckResourceAttr("ibm_kms_key_rings.test", "force_delete", "true"),
-// 				),
-// 			},
-// 			// Delete Key Ring
-// 			{
-// 				Config:      buildResourceSet(WithResourceKMSInstance(instanceName), WithDataKMSKeys()),
-// 				ExpectError: regexp.MustCompile(`\[ERROR\] No keys in instance`),
-// 			},
-// 			// Developer note: There is no support for listing keys under a certain key state so we cannot verify deleted key is now in default key ring
-// 		},
-// 	})
-// }
-
-func TestAccIBMKMSResource_Key_Ring_ForceDeleteTrue(t *testing.T) {
+func TestAccIBMKMSResource_Key_Ring_AlwaysForceDeleteTrue(t *testing.T) {
 	instanceName := fmt.Sprintf("tf_kms_%d", acctest.RandIntRange(10, 100))
 	keyName := fmt.Sprintf("key_%d", acctest.RandIntRange(10, 100))
 	keyRing := fmt.Sprintf("keyRing%d", acctest.RandIntRange(10, 100))
@@ -121,74 +79,23 @@ func TestAccIBMKMSResource_Key_Ring_ForceDeleteTrue(t *testing.T) {
 		PreCheck:  func() { acc.TestAccPreCheck(t) },
 		Providers: acc.TestAccProviders,
 		Steps: []resource.TestStep{
-			// Create a Key Ring and check force_delete is true
+			// Create a Key Ring and check force_delete is false
 			{
-				Config: buildResourceSet(WithResourceKMSInstance(instanceName), WithResourceKMSKeyRing(keyRing, true), WithResourceKMSKey(keyName, "ibm_kms_key_rings.test.key_ring_id")),
+				Config: buildResourceSet(WithResourceKMSInstance(instanceName), WithResourceKMSKeyRing(keyRing, false), WithResourceKMSKey(keyName, "ibm_kms_key_rings.test.key_ring_id")),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("ibm_kms_key.test", "key_name", keyName),
 					resource.TestCheckResourceAttr("ibm_kms_key.test", "key_ring_id", keyRing),
-					resource.TestCheckResourceAttr("ibm_kms_key_rings.test", "force_delete", "true"),
+					resource.TestCheckResourceAttr("ibm_kms_key_rings.test", "force_delete", "false"),
 				),
 			},
 			// Attempt to delete the key ring and key
 			{
-				Config: buildResourceSet(WithResourceKMSInstance(instanceName)),
-				Check:  resource.ComposeTestCheckFunc(),
-			},
-			{
 				Config:      buildResourceSet(WithResourceKMSInstance(instanceName), WithDataKMSKeys()),
 				ExpectError: regexp.MustCompile(`\[ERROR\] No keys in instance`),
-			},
-			{
-				Config: buildResourceSet(WithResourceKMSInstance(instanceName), WithDataKMSKeyRings()),
-				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr("data.ibm_kms_key_rings.test_key_rings", "key_rings.0.id", "default"),
-				),
 			},
 		},
 	})
 }
-
-// Developer note: Test is disabled as a bug exists where this is not properly testable
-// func TestAccIBMKMSResource_Key_Ring_ForceDeleteTrueContainsActiveKeys(t *testing.T) {
-// 	instanceName := fmt.Sprintf("tf_kms_%d", acctest.RandIntRange(10, 100))
-// 	keyName := fmt.Sprintf("key_%d", acctest.RandIntRange(10, 100))
-// 	keyRing := fmt.Sprintf("keyRing%d", acctest.RandIntRange(10, 100))
-
-// 	resource.Test(t, resource.TestCase{
-// 		PreCheck:  func() { acc.TestAccPreCheck(t) },
-// 		Providers: acc.TestAccProviders,
-// 		Steps: []resource.TestStep{
-// 			// Create a Key Ring and check force_delete is true
-// 			{
-// 				Config: buildResourceSet(WithResourceKMSInstance(instanceName), WithResourceKMSKeyRing(keyRing, true), WithResourceKMSKey(keyName, "ibm_kms_key_rings.test.key_ring_id")),
-// 				Check: resource.ComposeTestCheckFunc(
-// 					resource.TestCheckResourceAttr("ibm_kms_key.test", "key_name", keyName),
-// 					resource.TestCheckResourceAttr("ibm_kms_key.test", "key_ring_id", keyRing),
-// 					resource.TestCheckResourceAttr("ibm_kms_key_rings.test", "force_delete", "true"),
-// 				),
-// 			},
-// 			// Attempt to delete the key ring while active key exists
-// 			// We must specify key ring ID and not reference here as the resource is removed
-// 			{
-// 				Config:      buildResourceSet(WithResourceKMSInstance(instanceName), WithResourceKMSKey(keyName, keyRing)),
-// 				ExpectError: regexp.MustCompile("KEY_RING_KEYS_NOT_DELETED_ERR:"),
-// 			},
-// 			// Attempt to delete keys
-// 			{
-// 				Config: buildResourceSet(WithResourceKMSInstance(instanceName), WithResourceKMSKeyRing(keyRing, true)),
-// 			},
-// 			// Attempt to delete key ring and check no more keys
-// 			{
-// 				Config:      buildResourceSet(WithResourceKMSInstance(instanceName), WithDataKMSKeys()),
-// 				ExpectError: regexp.MustCompile(`\[ERROR\] No keys in instance`),
-// 				Check: resource.ComposeTestCheckFunc(
-// 					resource.TestCheckResourceAttr("data.ibm_kms_key_rings.test_key_rings", "key_rings.0.id", "default"),
-// 				),
-// 			},
-// 		},
-// 	})
-// }
 
 type CreateResourceOption func(resourceText *string)
 

--- a/website/docs/r/kms_key_rings.html.markdown
+++ b/website/docs/r/kms_key_rings.html.markdown
@@ -23,7 +23,6 @@ resource "ibm_resource_instance" "kms_instance" {
 resource "ibm_kms_key_rings" "key_ring" {
   instance_id = ibm_resource_instance.kms_instance.guid
   key_ring_id = "key-ring-id"
-  force_delete = true
 }
 resource "ibm_kms_key" "key" {
   instance_id = ibm_resource_instance.kp_instance.guid
@@ -34,15 +33,8 @@ resource "ibm_kms_key" "key" {
 }
 ```
 
-Sample example of deleting a key ring where all keys inside have key state equals to 5 (destroyed). Keys are moved to the default key ring.
-
-```terraform
-resource "ibm_kms_key_rings" "key_ring" {
-  instance_id = ibm_resource_instance.kms_instance.guid
-  key_ring_id = "key-ring-id"
-  force_delete = true
-}
-```
+~>**Deprecated:**
+`force_delete` argument will no longer be supported. Users are advised to remove references to `force_delete` from all `ibm_kms_key_rings` configurations by `July 30th 2025`. New default behavior of deleting a key ring is to move keys with state equals to 5 (destroyed) to the default key ring.
 
 ## Argument reference
 Review the argument references that you can specify for your resource. 
@@ -50,7 +42,7 @@ Review the argument references that you can specify for your resource.
 - `endpoint_type` - (Optional, Forces new resource, String) The type of the public endpoint, or private endpoint to be used for creating keys.
 - `instance_id` - (Required, Forces new resource, String) The hs-crypto or key protect instance GUID.
 - `key_ring_id` - (Required, Forces new resource, String) The ID that identifies the key ring. Each ID is unique within the given instance and is not reserved across the key protect service. **Constraints** `2 ≤ length ≤ 100`. Value must match regular expression of `^[a-zA-Z0-9-]*$`.
-- `force_delete` - (Optional, Bool) If set to **true**, allows force deletion of a key ring. Terraform users are recommended to have this set to **true**. All keys in the key ring are required to be deleted (in state **5**) before this action can be performed. If the key ring to be deleted contains keys, they will be moved to the **default** key ring which requires the **kms.secrets.patch** IAM action.
+- `force_delete` - (**Deprecated**)(Optional, Bool) If set to **true**, allows force deletion of a key ring. Terraform users are recommended to have this set to **true**. All keys in the key ring are required to be deleted (in state **5**) before this action can be performed. If the key ring to be deleted contains keys, they will be moved to the **default** key ring which requires the **kms.secrets.patch** IAM action.
 
 ## Attribute reference
 In addition to all argument reference list, you can access the following attribute reference after your resource is created.


### PR DESCRIPTION
- updated force delete tests
- changed key ring delete code to not read force_delete
- unsilenced 409 for delete
- update docs for resource with Deprecation Notice and date 1 year from now

<!--- See what makes a good Pull Request at : https://github.com/IBM-Cloud/terraform-provider-ibm/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

1)Testing 409 block:
2)Forwards Compatible Test:
3)Testing normal create+destroy:

<details>



- Using instance built using existing provider to tf apply
- Added key manually through the UI 
- Now destroy using updated code is blocked by KEY_RING_KEYS_NOT_DELETED_ERR

1)Testing 409 block:

```
(base) wsiew@Williams-MacBook-Pro ibm-key-protect % terraform destroy --target ibm_kms_key_rings.key_ring

ibm_resource_instance.kp_instance: Refreshing state... [id=crn:v1:bluemix:public:kms:us-south:a/eba0f7b1166e441ab74ac94e564c72ec:15cbb1d0-f8b6-4c0d-9dec-0d005b3881d5::]
ibm_kms_key_rings.key_ring: Refreshing state... [id=key-ring-id:keyRing:crn:v1:bluemix:public:kms:us-south:a/eba0f7b1166e441ab74ac94e564c72ec:15cbb1d0-f8b6-4c0d-9dec-0d005b3881d5::]

Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  - destroy

Terraform will perform the following actions:

  # ibm_kms_key.key_not_part_of_key_ring will be destroyed
  - resource "ibm_kms_key" "key_not_part_of_key_ring" {
      - crn                     = "crn:v1:bluemix:public:kms:us-south:a/eba0f7b1166e441ab74ac94e564c72ec:15cbb1d0-f8b6-4c0d-9dec-0d005b3881d5:key:c70fe16d-a3d0-468f-b2fd-4c98c539f0e1" -> null
      - description             = "I am description of keyring" -> null
      - endpoint_type           = "public" -> null
      - expiration_date         = "2024-12-01T23:20:50Z" -> null
      - force_delete            = false -> null
      - id                      = "crn:v1:bluemix:public:kms:us-south:a/eba0f7b1166e441ab74ac94e564c72ec:15cbb1d0-f8b6-4c0d-9dec-0d005b3881d5:key:c70fe16d-a3d0-468f-b2fd-4c98c539f0e1" -> null
      - instance_crn            = "crn:v1:bluemix:public:kms:us-south:a/eba0f7b1166e441ab74ac94e564c72ec:15cbb1d0-f8b6-4c0d-9dec-0d005b3881d5::" -> null
      - instance_id             = "15cbb1d0-f8b6-4c0d-9dec-0d005b3881d5" -> null
      - key_id                  = "c70fe16d-a3d0-468f-b2fd-4c98c539f0e1" -> null
      - key_name                = "key_not_part_of_key_ring" -> null
      - key_ring_id             = "key-ring-id" -> null
      - payload                 = (sensitive value) -> null
      - registrations           = [] -> null
      - resource_controller_url = "https://cloud.ibm.com/services/kms/crn%3Av1%3Abluemix%3Apublic%3Akms%3Aus-south%3Aa%2Feba0f7b1166e441ab74ac94e564c72ec%3A15cbb1d0-f8b6-4c0d-9dec-0d005b3881d5%3A%3A" -> null
      - resource_crn            = "crn:v1:bluemix:public:kms:us-south:a/eba0f7b1166e441ab74ac94e564c72ec:15cbb1d0-f8b6-4c0d-9dec-0d005b3881d5:key:c70fe16d-a3d0-468f-b2fd-4c98c539f0e1" -> null
      - resource_name           = "key_not_part_of_key_ring" -> null
      - resource_status         = "1" -> null
      - standard_key            = true -> null
      - type                    = "kms" -> null
    }

  # ibm_kms_key.key_part_of_key_ring will be destroyed
  - resource "ibm_kms_key" "key_part_of_key_ring" {
      - crn                     = "crn:v1:bluemix:public:kms:us-south:a/eba0f7b1166e441ab74ac94e564c72ec:15cbb1d0-f8b6-4c0d-9dec-0d005b3881d5:key:f4542b34-59a2-4103-9cf0-584db7933de7" -> null
      - description             = "I am description of keyring1" -> null
      - endpoint_type           = "public" -> null
      - expiration_date         = "2024-12-01T23:20:50Z" -> null
      - force_delete            = false -> null
      - id                      = "crn:v1:bluemix:public:kms:us-south:a/eba0f7b1166e441ab74ac94e564c72ec:15cbb1d0-f8b6-4c0d-9dec-0d005b3881d5:key:f4542b34-59a2-4103-9cf0-584db7933de7" -> null
      - instance_crn            = "crn:v1:bluemix:public:kms:us-south:a/eba0f7b1166e441ab74ac94e564c72ec:15cbb1d0-f8b6-4c0d-9dec-0d005b3881d5::" -> null
      - instance_id             = "15cbb1d0-f8b6-4c0d-9dec-0d005b3881d5" -> null
      - key_id                  = "f4542b34-59a2-4103-9cf0-584db7933de7" -> null
      - key_name                = "key_part_of_key_ring" -> null
      - key_ring_id             = "key-ring-id" -> null
      - payload                 = (sensitive value) -> null
      - registrations           = [] -> null
      - resource_controller_url = "https://cloud.ibm.com/services/kms/crn%3Av1%3Abluemix%3Apublic%3Akms%3Aus-south%3Aa%2Feba0f7b1166e441ab74ac94e564c72ec%3A15cbb1d0-f8b6-4c0d-9dec-0d005b3881d5%3A%3A" -> null
      - resource_crn            = "crn:v1:bluemix:public:kms:us-south:a/eba0f7b1166e441ab74ac94e564c72ec:15cbb1d0-f8b6-4c0d-9dec-0d005b3881d5:key:f4542b34-59a2-4103-9cf0-584db7933de7" -> null
      - resource_name           = "key_part_of_key_ring" -> null
      - resource_status         = "1" -> null
      - standard_key            = false -> null
      - type                    = "kms" -> null
    }

  # ibm_kms_key_rings.key_ring will be destroyed
  - resource "ibm_kms_key_rings" "key_ring" {
      - endpoint_type = "public" -> null
      - force_delete  = false -> null
      - id            = "key-ring-id:keyRing:crn:v1:bluemix:public:kms:us-south:a/eba0f7b1166e441ab74ac94e564c72ec:15cbb1d0-f8b6-4c0d-9dec-0d005b3881d5::" -> null
      - instance_id   = "15cbb1d0-f8b6-4c0d-9dec-0d005b3881d5" -> null
      - key_ring_id   = "key-ring-id" -> null
    }

Plan: 0 to add, 0 to change, 3 to destroy.
╷
│ Warning: Resource targeting is in effect
│ 
│ You are creating a plan with the -target option, which means that the result of this plan may not represent all of the changes requested by the current configuration.
│ 
│ The -target option is not for routine use, and is provided only for exceptional situations such as recovering from errors or mistakes, or when Terraform specifically suggests to use it as part of an
│ error message.
╵

Do you really want to destroy all resources?
  Terraform will destroy all your managed infrastructure, as shown above.
  There is no undo. Only 'yes' will be accepted to confirm.

  Enter a value: yes

ibm_kms_key.key_part_of_key_ring: Destroying... [id=crn:v1:bluemix:public:kms:us-south:a/eba0f7b1166e441ab74ac94e564c72ec:15cbb1d0-f8b6-4c0d-9dec-0d005b3881d5:key:f4542b34-59a2-4103-9cf0-584db7933de7]
ibm_kms_key.key_not_part_of_key_ring: Destroying... [id=crn:v1:bluemix:public:kms:us-south:a/eba0f7b1166e441ab74ac94e564c72ec:15cbb1d0-f8b6-4c0d-9dec-0d005b3881d5:key:c70fe16d-a3d0-468f-b2fd-4c98c539f0e1]
ibm_kms_key.key_part_of_key_ring: Destruction complete after 1s
ibm_kms_key.key_not_part_of_key_ring: Destruction complete after 1s
ibm_kms_key_rings.key_ring: Destroying... [id=key-ring-id:keyRing:crn:v1:bluemix:public:kms:us-south:a/eba0f7b1166e441ab74ac94e564c72ec:15cbb1d0-f8b6-4c0d-9dec-0d005b3881d5::]
╷
│ Warning: Applied changes may be incomplete
│ 
│ The plan was created with the -target option in effect, so some changes requested in the configuration may have been ignored and the output values may not be fully updated. Run the following command
│ to verify that no other changes are pending:
│     terraform plan
│ 
│ Note that the -target option is not suitable for routine use, and is provided only for exceptional situations such as recovering from errors or mistakes, or when Terraform specifically suggests to
│ use it as part of an error message.
╵
╷
│ Error:  failed to Destroy key ring with error: kp.Error: correlation_id='04a03964-0847-49a9-b18b-92904a52768b', msg='Conflict: Key ring could not be deleted: Please see `reasons` for more details (KEY_RING_KEYS_NOT_DELETED_ERR)', reasons='[KEY_RING_KEYS_NOT_DELETED_ERR: The specified key ring contains at least one non-deleted key - FOR_MORE_INFO_REFER: https://cloud.ibm.com/apidocs/key-protect]'
│ 
│ ---
│ id: terraform-580b6205
│ summary: ' failed to Destroy key ring with error: kp.Error: correlation_id=''04a03964-0847-49a9-b18b-92904a52768b'',
│   msg=''Conflict: Key ring could not be deleted: Please see `reasons` for more details
│   (KEY_RING_KEYS_NOT_DELETED_ERR)'', reasons=''[KEY_RING_KEYS_NOT_DELETED_ERR: The
│   specified key ring contains at least one non-deleted key - FOR_MORE_INFO_REFER:
│   https://cloud.ibm.com/apidocs/key-protect]'''
│ severity: error
│ resource: ibm_kms_key_rings
│ operation: delete
│ component:
│   name: github.com/IBM-Cloud/terraform-provider-ibm
│   version: 1.65.0
│ ---
│ 
╵
(base) wsiew@Williams-MacBook-Pro ibm-key-protect % 
```

After removing key
2)Forwards Compatible Test: successful deletion
```
(base) wsiew@Williams-MacBook-Pro ibm-key-protect % terraform destroy --target ibm_kms_key_rings.key_ring

ibm_resource_instance.kp_instance: Refreshing state... [id=crn:v1:bluemix:public:kms:us-south:a/eba0f7b1166e441ab74ac94e564c72ec:15cbb1d0-f8b6-4c0d-9dec-0d005b3881d5::]
ibm_kms_key_rings.key_ring: Refreshing state... [id=key-ring-id:keyRing:crn:v1:bluemix:public:kms:us-south:a/eba0f7b1166e441ab74ac94e564c72ec:15cbb1d0-f8b6-4c0d-9dec-0d005b3881d5::]

Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  - destroy

Terraform will perform the following actions:

  # ibm_kms_key_rings.key_ring will be destroyed
  - resource "ibm_kms_key_rings" "key_ring" {
      - endpoint_type = "public" -> null
      - force_delete  = false -> null
      - id            = "key-ring-id:keyRing:crn:v1:bluemix:public:kms:us-south:a/eba0f7b1166e441ab74ac94e564c72ec:15cbb1d0-f8b6-4c0d-9dec-0d005b3881d5::" -> null
      - instance_id   = "15cbb1d0-f8b6-4c0d-9dec-0d005b3881d5" -> null
      - key_ring_id   = "key-ring-id" -> null
    }

Plan: 0 to add, 0 to change, 1 to destroy.
╷
│ Warning: Resource targeting is in effect
│ 
│ You are creating a plan with the -target option, which means that the result of this plan may not represent all of the changes requested by the current configuration.
│ 
│ The -target option is not for routine use, and is provided only for exceptional situations such as recovering from errors or mistakes, or when Terraform specifically suggests to use it as part of an
│ error message.
╵

Do you really want to destroy all resources?
  Terraform will destroy all your managed infrastructure, as shown above.
  There is no undo. Only 'yes' will be accepted to confirm.

  Enter a value: yes

ibm_kms_key_rings.key_ring: Destroying... [id=key-ring-id:keyRing:crn:v1:bluemix:public:kms:us-south:a/eba0f7b1166e441ab74ac94e564c72ec:15cbb1d0-f8b6-4c0d-9dec-0d005b3881d5::]
ibm_kms_key_rings.key_ring: Destruction complete after 2s
╷
│ Warning: Applied changes may be incomplete
│ 
│ The plan was created with the -target option in effect, so some changes requested in the configuration may have been ignored and the output values may not be fully updated. Run the following command
│ to verify that no other changes are pending:
│     terraform plan
│ 
│ Note that the -target option is not suitable for routine use, and is provided only for exceptional situations such as recovering from errors or mistakes, or when Terraform specifically suggests to
│ use it as part of an error message.
╵

Destroy complete! Resources: 1 destroyed.
(base) wsiew@Williams-MacBook-Pro ibm-key-protect % 
```
3)Testing normal create+destroy:
Lets create it again using the new provider

Terraform apply 
```
(base) wsiew@Williams-MacBook-Pro ibm-key-protect % terraform apply                                      
ibm_resource_instance.kp_instance: Refreshing state... [id=crn:v1:bluemix:public:kms:us-south:a/eba0f7b1166e441ab74ac94e564c72ec:15cbb1d0-f8b6-4c0d-9dec-0d005b3881d5::]

Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  + create

Terraform will perform the following actions:

  # ibm_kms_key.key_not_part_of_key_ring will be created
  + resource "ibm_kms_key" "key_not_part_of_key_ring" {
      + crn                     = (known after apply)
      + description             = "I am description of keyring"
      + endpoint_type           = (known after apply)
      + expiration_date         = "2024-12-01T23:20:50Z"
      + force_delete            = false
      + id                      = (known after apply)
      + instance_crn            = (known after apply)
      + instance_id             = "15cbb1d0-f8b6-4c0d-9dec-0d005b3881d5"
      + key_id                  = (known after apply)
      + key_name                = "key_not_part_of_key_ring"
      + key_ring_id             = "key-ring-id"
      + payload                 = (sensitive value)
      + registrations           = (known after apply)
      + resource_controller_url = (known after apply)
      + resource_crn            = (known after apply)
      + resource_group_name     = (known after apply)
      + resource_name           = (known after apply)
      + resource_status         = (known after apply)
      + standard_key            = true
      + type                    = (known after apply)
    }

  # ibm_kms_key.key_part_of_key_ring will be created
  + resource "ibm_kms_key" "key_part_of_key_ring" {
      + crn                     = (known after apply)
      + description             = "I am description of keyring1"
      + endpoint_type           = (known after apply)
      + expiration_date         = "2024-12-01T23:20:50Z"
      + force_delete            = false
      + id                      = (known after apply)
      + instance_crn            = (known after apply)
      + instance_id             = "15cbb1d0-f8b6-4c0d-9dec-0d005b3881d5"
      + key_id                  = (known after apply)
      + key_name                = "key_part_of_key_ring"
      + key_ring_id             = "key-ring-id"
      + payload                 = (sensitive value)
      + registrations           = (known after apply)
      + resource_controller_url = (known after apply)
      + resource_crn            = (known after apply)
      + resource_group_name     = (known after apply)
      + resource_name           = (known after apply)
      + resource_status         = (known after apply)
      + standard_key            = false
      + type                    = (known after apply)
    }

  # ibm_kms_key_rings.key_ring will be created
  + resource "ibm_kms_key_rings" "key_ring" {
      + endpoint_type = (known after apply)
      + force_delete  = false
      + id            = (known after apply)
      + instance_id   = "15cbb1d0-f8b6-4c0d-9dec-0d005b3881d5"
      + key_ring_id   = "key-ring-id"
    }

Plan: 3 to add, 0 to change, 0 to destroy.

Do you want to perform these actions?
  Terraform will perform the actions described above.
  Only 'yes' will be accepted to approve.

  Enter a value: yes

ibm_kms_key_rings.key_ring: Creating...
ibm_kms_key_rings.key_ring: Creation complete after 3s [id=key-ring-id:keyRing:crn:v1:bluemix:public:kms:us-south:a/eba0f7b1166e441ab74ac94e564c72ec:15cbb1d0-f8b6-4c0d-9dec-0d005b3881d5::]
ibm_kms_key.key_not_part_of_key_ring: Creating...
ibm_kms_key.key_part_of_key_ring: Creating...
ibm_kms_key.key_part_of_key_ring: Creation complete after 3s [id=crn:v1:bluemix:public:kms:us-south:a/eba0f7b1166e441ab74ac94e564c72ec:15cbb1d0-f8b6-4c0d-9dec-0d005b3881d5:key:22caa822-c855-4539-827a-2add3a90dd88]
ibm_kms_key.key_not_part_of_key_ring: Creation complete after 3s [id=crn:v1:bluemix:public:kms:us-south:a/eba0f7b1166e441ab74ac94e564c72ec:15cbb1d0-f8b6-4c0d-9dec-0d005b3881d5:key:f9d2ad9a-c854-4078-a93d-a43fe3b0f45f]

Apply complete! Resources: 3 added, 0 changed, 0 destroyed.
(base) wsiew@Williams-MacBook-Pro ibm-key-protect % terraform destroy
ibm_resource_instance.kp_instance: Refreshing state... [id=crn:v1:bluemix:public:kms:us-south:a/eba0f7b1166e441ab74ac94e564c72ec:15cbb1d0-f8b6-4c0d-9dec-0d005b3881d5::]
ibm_kms_key_rings.key_ring: Refreshing state... [id=key-ring-id:keyRing:crn:v1:bluemix:public:kms:us-south:a/eba0f7b1166e441ab74ac94e564c72ec:15cbb1d0-f8b6-4c0d-9dec-0d005b3881d5::]
ibm_kms_key.key_not_part_of_key_ring: Refreshing state... [id=crn:v1:bluemix:public:kms:us-south:a/eba0f7b1166e441ab74ac94e564c72ec:15cbb1d0-f8b6-4c0d-9dec-0d005b3881d5:key:f9d2ad9a-c854-4078-a93d-a43fe3b0f45f]
ibm_kms_key.key_part_of_key_ring: Refreshing state... [id=crn:v1:bluemix:public:kms:us-south:a/eba0f7b1166e441ab74ac94e564c72ec:15cbb1d0-f8b6-4c0d-9dec-0d005b3881d5:key:22caa822-c855-4539-827a-2add3a90dd88]

Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  - destroy

Terraform will perform the following actions:

  # ibm_kms_key.key_not_part_of_key_ring will be destroyed
  - resource "ibm_kms_key" "key_not_part_of_key_ring" {
      - crn                     = "crn:v1:bluemix:public:kms:us-south:a/eba0f7b1166e441ab74ac94e564c72ec:15cbb1d0-f8b6-4c0d-9dec-0d005b3881d5:key:f9d2ad9a-c854-4078-a93d-a43fe3b0f45f" -> null
      - description             = "I am description of keyring" -> null
      - endpoint_type           = "public" -> null
      - expiration_date         = "2024-12-01T23:20:50Z" -> null
      - force_delete            = false -> null
      - id                      = "crn:v1:bluemix:public:kms:us-south:a/eba0f7b1166e441ab74ac94e564c72ec:15cbb1d0-f8b6-4c0d-9dec-0d005b3881d5:key:f9d2ad9a-c854-4078-a93d-a43fe3b0f45f" -> null
      - instance_crn            = "crn:v1:bluemix:public:kms:us-south:a/eba0f7b1166e441ab74ac94e564c72ec:15cbb1d0-f8b6-4c0d-9dec-0d005b3881d5::" -> null
      - instance_id             = "15cbb1d0-f8b6-4c0d-9dec-0d005b3881d5" -> null
      - key_id                  = "f9d2ad9a-c854-4078-a93d-a43fe3b0f45f" -> null
      - key_name                = "key_not_part_of_key_ring" -> null
      - key_ring_id             = "key-ring-id" -> null
      - payload                 = (sensitive value) -> null
      - registrations           = [] -> null
      - resource_controller_url = "https://cloud.ibm.com/services/kms/crn%3Av1%3Abluemix%3Apublic%3Akms%3Aus-south%3Aa%2Feba0f7b1166e441ab74ac94e564c72ec%3A15cbb1d0-f8b6-4c0d-9dec-0d005b3881d5%3A%3A" -> null
      - resource_crn            = "crn:v1:bluemix:public:kms:us-south:a/eba0f7b1166e441ab74ac94e564c72ec:15cbb1d0-f8b6-4c0d-9dec-0d005b3881d5:key:f9d2ad9a-c854-4078-a93d-a43fe3b0f45f" -> null
      - resource_name           = "key_not_part_of_key_ring" -> null
      - resource_status         = "1" -> null
      - standard_key            = true -> null
      - type                    = "kms" -> null
    }

  # ibm_kms_key.key_part_of_key_ring will be destroyed
  - resource "ibm_kms_key" "key_part_of_key_ring" {
      - crn                     = "crn:v1:bluemix:public:kms:us-south:a/eba0f7b1166e441ab74ac94e564c72ec:15cbb1d0-f8b6-4c0d-9dec-0d005b3881d5:key:22caa822-c855-4539-827a-2add3a90dd88" -> null
      - description             = "I am description of keyring1" -> null
      - endpoint_type           = "public" -> null
      - expiration_date         = "2024-12-01T23:20:50Z" -> null
      - force_delete            = false -> null
      - id                      = "crn:v1:bluemix:public:kms:us-south:a/eba0f7b1166e441ab74ac94e564c72ec:15cbb1d0-f8b6-4c0d-9dec-0d005b3881d5:key:22caa822-c855-4539-827a-2add3a90dd88" -> null
      - instance_crn            = "crn:v1:bluemix:public:kms:us-south:a/eba0f7b1166e441ab74ac94e564c72ec:15cbb1d0-f8b6-4c0d-9dec-0d005b3881d5::" -> null
      - instance_id             = "15cbb1d0-f8b6-4c0d-9dec-0d005b3881d5" -> null
      - key_id                  = "22caa822-c855-4539-827a-2add3a90dd88" -> null
      - key_name                = "key_part_of_key_ring" -> null
      - key_ring_id             = "key-ring-id" -> null
      - payload                 = (sensitive value) -> null
      - registrations           = [] -> null
      - resource_controller_url = "https://cloud.ibm.com/services/kms/crn%3Av1%3Abluemix%3Apublic%3Akms%3Aus-south%3Aa%2Feba0f7b1166e441ab74ac94e564c72ec%3A15cbb1d0-f8b6-4c0d-9dec-0d005b3881d5%3A%3A" -> null
      - resource_crn            = "crn:v1:bluemix:public:kms:us-south:a/eba0f7b1166e441ab74ac94e564c72ec:15cbb1d0-f8b6-4c0d-9dec-0d005b3881d5:key:22caa822-c855-4539-827a-2add3a90dd88" -> null
      - resource_name           = "key_part_of_key_ring" -> null
      - resource_status         = "1" -> null
      - standard_key            = false -> null
      - type                    = "kms" -> null
    }

  # ibm_kms_key_rings.key_ring will be destroyed
  - resource "ibm_kms_key_rings" "key_ring" {
      - endpoint_type = "public" -> null
      - force_delete  = false -> null
      - id            = "key-ring-id:keyRing:crn:v1:bluemix:public:kms:us-south:a/eba0f7b1166e441ab74ac94e564c72ec:15cbb1d0-f8b6-4c0d-9dec-0d005b3881d5::" -> null
      - instance_id   = "15cbb1d0-f8b6-4c0d-9dec-0d005b3881d5" -> null
      - key_ring_id   = "key-ring-id" -> null
    }

  # ibm_resource_instance.kp_instance will be destroyed
  - resource "ibm_resource_instance" "kp_instance" {
      - account_id              = "eba0f7b1166e441ab74ac94e564c72ec" -> null
      - allow_cleanup           = false -> null
      - created_at              = "2024-07-29T18:49:39.450Z" -> null
      - created_by              = "IBMid-6620028GBG" -> null
      - crn                     = "crn:v1:bluemix:public:kms:us-south:a/eba0f7b1166e441ab74ac94e564c72ec:15cbb1d0-f8b6-4c0d-9dec-0d005b3881d5::" -> null
      - dashboard_url           = "/keyprotect/crn%3Av1%3Abluemix%3Apublic%3Akms%3Aus-south%3Aa%2Feba0f7b1166e441ab74ac94e564c72ec%3A15cbb1d0-f8b6-4c0d-9dec-0d005b3881d5%3A%3A" -> null
      - extensions              = {
          - "endpoints.private" = "https://private.us-south.kms.cloud.ibm.com"
          - "endpoints.public"  = "https://us-south.kms.cloud.ibm.com"
        } -> null
      - guid                    = "15cbb1d0-f8b6-4c0d-9dec-0d005b3881d5" -> null
      - id                      = "crn:v1:bluemix:public:kms:us-south:a/eba0f7b1166e441ab74ac94e564c72ec:15cbb1d0-f8b6-4c0d-9dec-0d005b3881d5::" -> null
      - last_operation          = {
          - "async"       = "false"
          - "cancelable"  = "false"
          - "description" = "Completed create instance operation"
          - "poll"        = "false"
          - "state"       = "succeeded"
          - "type"        = "create"
        } -> null
      - location                = "us-south" -> null
      - locked                  = false -> null
      - name                    = "wsiew-2024-july-keyringtest" -> null
      - plan                    = "tiered-pricing" -> null
      - plan_history            = [
          - {
              - resource_plan_id = "eedd3585-90c6-4c8f-be3d-062069e99fc3"
              - start_date       = "2024-07-29T18:49:39.450Z"
            },
        ] -> null
      - resource_aliases_url    = "/v2/resource_instances/15cbb1d0-f8b6-4c0d-9dec-0d005b3881d5/resource_aliases" -> null
      - resource_bindings_url   = "/v2/resource_instances/15cbb1d0-f8b6-4c0d-9dec-0d005b3881d5/resource_bindings" -> null
      - resource_controller_url = "https://cloud.ibm.com/services/" -> null
      - resource_crn            = "crn:v1:bluemix:public:kms:us-south:a/eba0f7b1166e441ab74ac94e564c72ec:15cbb1d0-f8b6-4c0d-9dec-0d005b3881d5::" -> null
      - resource_group_crn      = "crn:v1:bluemix:public:resource-controller::a/eba0f7b1166e441ab74ac94e564c72ec::resource-group:f956c41a82d1436fbbf68f418f831c05" -> null
      - resource_group_id       = "f956c41a82d1436fbbf68f418f831c05" -> null
      - resource_group_name     = "crn:v1:bluemix:public:resource-controller::a/eba0f7b1166e441ab74ac94e564c72ec::resource-group:f956c41a82d1436fbbf68f418f831c05" -> null
      - resource_id             = "ee41347f-b18e-4ca6-bf80-b5467c63f9a6" -> null
      - resource_keys_url       = "/v2/resource_instances/15cbb1d0-f8b6-4c0d-9dec-0d005b3881d5/resource_keys" -> null
      - resource_name           = "wsiew-2024-july-keyringtest" -> null
      - resource_plan_id        = "eedd3585-90c6-4c8f-be3d-062069e99fc3" -> null
      - resource_status         = "active" -> null
      - service                 = "kms" -> null
      - state                   = "active" -> null
      - status                  = "active" -> null
      - sub_type                = "kms" -> null
      - tags                    = [] -> null
      - target_crn              = "crn:v1:bluemix:public:globalcatalog::::deployment:eedd3585-90c6-4c8f-be3d-062069e99fc3%3Aus-south" -> null
      - type                    = "service_instance" -> null
      - update_at               = "2024-07-29T18:49:39.712Z" -> null
    }

Plan: 0 to add, 0 to change, 4 to destroy.

Do you really want to destroy all resources?
  Terraform will destroy all your managed infrastructure, as shown above.
  There is no undo. Only 'yes' will be accepted to confirm.

  Enter a value: yes

ibm_kms_key.key_not_part_of_key_ring: Destroying... [id=crn:v1:bluemix:public:kms:us-south:a/eba0f7b1166e441ab74ac94e564c72ec:15cbb1d0-f8b6-4c0d-9dec-0d005b3881d5:key:f9d2ad9a-c854-4078-a93d-a43fe3b0f45f]
ibm_kms_key.key_part_of_key_ring: Destroying... [id=crn:v1:bluemix:public:kms:us-south:a/eba0f7b1166e441ab74ac94e564c72ec:15cbb1d0-f8b6-4c0d-9dec-0d005b3881d5:key:22caa822-c855-4539-827a-2add3a90dd88]
ibm_kms_key.key_part_of_key_ring: Destruction complete after 2s
ibm_kms_key.key_not_part_of_key_ring: Destruction complete after 2s
ibm_kms_key_rings.key_ring: Destroying... [id=key-ring-id:keyRing:crn:v1:bluemix:public:kms:us-south:a/eba0f7b1166e441ab74ac94e564c72ec:15cbb1d0-f8b6-4c0d-9dec-0d005b3881d5::]
ibm_kms_key_rings.key_ring: Destruction complete after 1s
ibm_resource_instance.kp_instance: Destroying... [id=crn:v1:bluemix:public:kms:us-south:a/eba0f7b1166e441ab74ac94e564c72ec:15cbb1d0-f8b6-4c0d-9dec-0d005b3881d5::]
ibm_resource_instance.kp_instance: Still destroying... [id=crn:v1:bluemix:public:kms:us-south:a/eb...15cbb1d0-f8b6-4c0d-9dec-0d005b3881d5::, 10s elapsed]
ibm_resource_instance.kp_instance: Destruction complete after 11s

Destroy complete! Resources: 4 destroyed.
(base) wsiew@Williams-MacBook-Pro ibm-key-protect % 
```


</details>
Output from acceptance testing:

```
(base) wsiew@Williams-MacBook-Pro terraform-provider-ibm % make testacc TEST=./ibm/service/kms TESTARGS='-run=TestAccIBMKMS'              ==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./ibm/service/kms -v -run=TestAccIBMKMS -timeout 700m
[WARN] Set the environment variable IBM_PROJECTS_CONFIG_APIKEY for testing IBM Projects Config resources, the tests will fail if this is not set
[WARN] Set the environment variable IBM_APPID_TENANT_ID for testing AppID resources, AppID tests will fail if this is not set
[WARN] Set the environment variable IBM_APPID_TEST_USER_EMAIL for testing AppID user resources, the tests will fail if this is not set
[WARN] Set the environment variable IBM_ORG for testing ibm_org  resource Some tests for that resource will fail if this is not set correctly
[WARN] Set the environment variable IBM_SPACE for testing ibm_space  resource Some tests for that resource will fail if this is not set correctly
[WARN] Set the environment variable IBM_ID1 for testing ibm_space resource Some tests for that resource will fail if this is not set correctly
[WARN] Set the environment variable IBM_ID2 for testing ibm_space resource Some tests for that resource will fail if this is not set correctly
[WARN] Set the environment variable IBM_IAMUSER for testing ibm_iam_user_policy resource Some tests for that resource will fail if this is not set correctly
[WARN] Set the environment variable IBM_IAMACCOUNTID for testing ibm_iam_trusted_profile resource Some tests for that resource will fail if this is not set correctly
[WARN] Set the environment variable IBM_IAM_SERVICE_ID for testing ibm_iam_trusted_profile_identity resource Some tests for that resource will fail if this is not set correctly
[WARN] Set the environment variable IBM_IAM_TRUSTED_PROFILE_ID for testing ibm_iam_trusted_profile_identity resource Some tests for that resource will fail if this is not set correctly
[WARN] Set the environment variable IBM_DATACENTER for testing ibm_container_cluster resource else it is set to default value 'par01'
[WARN] Set the environment variable IBM_MACHINE_TYPE for testing ibm_container_cluster resource else it is set to default value 'b3c.4x16'
[WARN] Set the environment variable IBM_CERT_CRN for testing ibm_container_alb_cert or ibm_container_ingress_secret_tls resource else it is set to default value
[WARN] Set the environment variable IBM_UPDATE_CERT_CRN for testing ibm_container_alb_cert or ibm_container_ingress_secret_tls resource else it is set to default value
[WARN] Set the environment variable IBM_SECRET_CRN for testing ibm_container_ingress_secret_opaque resource else it is set to default value
[WARN] Set the environment variable IBM_SECRET_CRN_2 for testing ibm_container_ingress_secret_opaque resource else it is set to default value
[WARN] Set the environment variable IBM_INGRESS_INSTANCE_CRN for testing ibm_container_ingress_instance resource. Some tests for that resource will fail if this is not set correctly
[WARN] Set the environment variable IBM_INGRESS_INSTANCE_SECRET_GROUP_ID for testing ibm_container_ingress_instance resource. Some tests for that resource will fail if this is not set correctly
[WARN] Set the environment variable IBM_CONTAINER_REGION for testing ibm_container resources else it is set to default value 'eu-de'
[WARN] Set the environment variable IBM_CIS_INSTANCE with a VALID CIS Instance NAME for testing ibm_cis resources on staging/test
[WARN] Set the environment variable IBM_CIS_DOMAIN_STATIC with the Domain name registered with the CIS instance on test/staging. Domain must be predefined in CIS to avoid CIS billing costs due to domain delete/create
[WARN] Set the environment variable IBM_CIS_DOMAIN_TEST with a VALID Domain name for testing the one time create and delete of a domain in CIS. Note each create/delete will trigger a monthly billing instance. Only to be run in staging/test
[WARN] Set the environment variable IBM_CIS_RESOURCE_GROUP with the resource group for the CIS Instance 
[WARN] Set the environment variable IBM_COS_CRN with a VALID COS instance CRN for testing ibm_cos_* resources
[WARN] Set the environment variable IBM_COS_Bucket_CRN with a VALID BUCKET CRN for testing ibm_cos_bucket* resources
[WARN] Set the environment variable IBM_COS_BUCKET_NAME with a VALID BUCKET Name for testing ibm_cos_bucket* resources
[WARN] Set the environment variable IBM_COS_NAME with a VALID COS instance name for testing resources with cos deps
[WARN] Set the environment variable IBM_TRUSTED_MACHINE_TYPE for testing ibm_container_cluster resource else it is set to default value 'mb1c.16x64'
[WARN] Set the environment variable IBM_BM_EXTENDED_HW_TESTING to true/false for testing ibm_compute_bare_metal resource else it is set to default value 'false'
[WARN] Set the environment variable IBM_PUBLIC_VLAN_ID for testing ibm_container_cluster resource else it is set to default value '2393319'
[WARN] Set the environment variable IBM_PRIVATE_VLAN_ID for testing ibm_container_cluster resource else it is set to default value '2393321'
[WARN] Set the environment variable IBM_KUBE_VERSION for testing ibm_container_cluster resource else it is set to default value '1.18.14'
[WARN] Set the environment variable IBM_KUBE_UPDATE_VERSION for testing ibm_container_cluster resource else it is set to default value '1.19.6'
[WARN] Set the environment variable IBM_PRIVATE_SUBNET_ID for testing ibm_container_cluster resource else it is set to default value '1636107'
[WARN] Set the environment variable IBM_PUBLIC_SUBNET_ID for testing ibm_container_cluster resource else it is set to default value '1165645'
[WARN] Set the environment variable IBM_SUBNET_ID for testing ibm_container_cluster resource else it is set to default value '1165645'
[INFO] Set the environment variable IBM_IPSEC_DATACENTER for testing ibm_ipsec_vpn resource else it is set to default value 'tok02'
[INFO] Set the environment variable IBM_IPSEC_CUSTOMER_SUBNET_ID for testing ibm_ipsec_vpn resource else it is set to default value '123456'
[INFO] Set the environment variable IBM_IPSEC_CUSTOMER_PEER_IP for testing ibm_ipsec_vpn resource else it is set to default value '192.168.0.1'
[WARN] Set the environment variable IBM_LBAAS_DATACENTER for testing ibm_lbaas resource else it is set to default value 'dal13'
[WARN] Set the environment variable IBM_LBAAS_SUBNETID for testing ibm_lbaas resource else it is set to default value '2144241'
[WARN] Set the environment variable IBM_LB_LISTENER_CERTIFICATE_INSTANCE for testing ibm_is_lb_listener resource for https redirect else it is set to default value 'crn:v1:staging:public:cloudcerts:us-south:a/2d1bace7b46e4815a81e52c6ffeba5cf:af925157-b125-4db2-b642-adacb8b9c7f5:certificate:c81627a1bf6f766379cc4b98fd2a44ed'
[WARN] Set the environment variable IBM_DEDICATED_HOSTNAME for testing ibm_compute_vm_instance resource else it is set to default value 'terraform-dedicatedhost'
[WARN] Set the environment variable IBM_DEDICATED_HOST_ID for testing ibm_compute_vm_instance resource else it is set to default value '30301'
[WARN] Set the environment variable IBM_WORKER_POOL_ZONE for testing ibm_container_worker_pool_zone_attachment resource else it is set to default value 'ams03'
[WARN] Set the environment variable IBM_WORKER_POOL_ZONE_PRIVATE_VLAN for testing ibm_container_worker_pool_zone_attachment resource else it is set to default value '2538975'
[WARN] Set the environment variable IBM_WORKER_POOL_ZONE_PUBLIC_VLAN for testing ibm_container_worker_pool_zone_attachment resource else it is set to default value '2538967'
[WARN] Set the environment variable IBM_WORKER_POOL_ZONE_UPDATE_PRIVATE_VLAN for testing ibm_container_worker_pool_zone_attachment resource else it is set to default value '2388377'
[WARN] Set the environment variable IBM_WORKER_POOL_ZONE_UPDATE_PUBLIC_VLAN for testing ibm_container_worker_pool_zone_attachment resource else it is set to default value '2388375'
[WARN] Set the environment variable IBM_WORKER_POOL_SECONDARY_STORAGE for testing secondary_storage attachment to IKS workerpools
[WARN] Set the environment variable IBM_PLACEMENT_GROUP_NAME for testing ibm_compute_vm_instance resource else it is set to default value 'terraform-group'
[INFO] Set the environment variable SL_REGION for testing ibm_is_region datasource else it is set to default value 'us-south'
[INFO] Set the environment variable SL_ZONE for testing ibm_is_zone datasource else it is set to default value 'us-south-1'
[INFO] Set the environment variable SL_ZONE_2 for testing ibm_is_zone datasource else it is set to default value 'us-south-2'
[INFO] Set the environment variable SL_ZONE_3 for testing ibm_is_zone datasource else it is set to default value 'us-south-3'
[INFO] Set the environment variable SL_CIDR for testing ibm_is_subnet else it is set to default value '10.240.0.0/24'
[INFO] Set the environment variable SL_CIDR_2 for testing ibm_is_subnet else it is set to default value '10.240.64.0/24'
[INFO] Set the environment variable SL_CIDR_2 for testing ibm_is_subnet else it is set to default value '10.240.64.0/24'
[INFO] Set the environment variable SL_CIDR_2 for testing ibm_is_instance datasource else it is set to default value './test-fixtures/.ssh/pkcs8_rsa.pub'
[INFO] Set the environment variable IS_PRIVATE_SSH_KEY_PATH for testing ibm_is_instance datasource else it is set to default value './test-fixtures/.ssh/pkcs8_rsa'
[INFO] Set the environment variable SL_RESOURCE_GROUP_ID for testing with different resource group id else it is set to default value 'c01d34dff4364763476834c990398zz8'
[INFO] Set the environment variable IS_RESOURCE_CRN for testing with created resource instance
[INFO] Set the environment variable IS_IMAGE for testing ibm_is_instance, ibm_is_floating_ip else it is set to default value 'r006-907911a7-0ffe-467e-8821-3cc9a0d82a39'
[INFO] Set the environment variable IS_IMAGE2 for testing ibm_is_instance, ibm_is_floating_ip else it is set to default value 'r134-f47cc24c-e020-4db5-ad96-1e5be8b5853b'
[INFO] Set the environment variable IS_WIN_IMAGE for testing ibm_is_instance data source else it is set to default value 'r006-d2e0d0e9-0a4f-4c45-afd7-cab787030776'
[INFO] Set the environment variable IS_COS_BUCKET_NAME for testing ibm_is_image_export_job else it is set to default value 'bucket-27200-lwx4cfvcue'
[INFO] Set the environment variable IS_COS_BUCKET_CRN for testing ibm_is_image_export_job else it is set to default value 'bucket-27200-lwx4cfvcue'
[INFO] Set the environment variable IS_INSTANCE_NAME for testing ibm_is_instance resource else it is set to default value 'instance-01'
[INFO] Set the environment variable IS_BACKUP_POLICY_JOB_ID for testing ibm_is_backup_policy_job datasource
[INFO] Set the environment variable IS_BACKUP_POLICY_ID for testing ibm_is_backup_policy_jobs datasource
[INFO] Set the environment variable IS_REMOTE_CP_BAAS_ENCRYPTION_KEY_CRN for testing remote_copies_policy with Baas plans, else it is set to default value, 'crn:v1:bluemix:public:kms:us-south:a/dffc98a0f1f0f95f6613b3b752286b87:e4a29d1a-2ef0-42a6-8fd2-350deb1c647e:key:5437653b-c4b1-447f-9646-b2a2a4cd6179'
[INFO] Set the environment variable SL_INSTANCE_PROFILE for testing ibm_is_instance resource else it is set to default value 'cx2-2x4'
[INFO] Set the environment variable SL_KMS_INSTANCE_ID for testing ibm_kms_key resource else it is set to default value '30222bb5-1c6d-3834-8d78-ae6348cf8z61'
[INFO] Set the environment variable SL_KMS_KEY_NAME for testing ibm_kms_key resource else it is set to default value 'tfp-test-key'
[INFO] Set the environment variable SL_INSTANCE_PROFILE_UPDATE for testing ibm_is_instance resource else it is set to default value 'cx2-4x8'
[INFO] Set the environment variable IS_BARE_METAL_SERVER_PROFILE for testing ibm_is_bare_metal_server resource else it is set to default value 'bx2-metal-96x384'
[INFO] Set the environment variable IsBareMetalServerImage for testing ibm_is_bare_metal_server resource else it is set to default value 'r006-2d1f36b0-df65-4570-82eb-df7ae5f778b1'
[INFO] Set the environment variable IS_DNS_INSTANCE_CRN for testing ibm_is_lb resource else it is set to default value 'crn:v1:staging:public:dns-svcs:global:a/efe5afc483594adaa8325e2b4d1290df:82df2e3c-53a5-43c6-89ce-dcf78be18668::'
[INFO] Set the environment variable IS_DNS_INSTANCE_CRN1 for testing ibm_is_lb resource else it is set to default value 'crn:v1:staging:public:dns-svcs:global:a/efe5afc483594adaa8325e2b4d1290df:599ae4aa-c554-4a88-8bb2-b199b9a3c046::'
[INFO] Set the environment variable IS_DNS_ZONE_ID for testing ibm_is_lb resource else it is set to default value 'dd501d1d-490b-4bb4-a05d-a31954a1c59e'
[INFO] Set the environment variable IS_DNS_ZONE_ID_1 for testing ibm_is_lb resource else it is set to default value 'b1def78d-51b3-4ea5-a746-1b64c992fcab'
[INFO] Set the environment variable IS_DEDICATED_HOST_NAME for testing ibm_is_instance resource else it is set to default value 'tf-dhost-01'
[INFO] Set the environment variable IS_DEDICATED_HOST_GROUP_ID for testing ibm_is_instance resource else it is set to default value '0717-9104e7b5-77ad-44ad-9eaa-091e6b6efce1'
[INFO] Set the environment variable IS_DEDICATED_HOST_PROFILE for testing ibm_is_instance resource else it is set to default value 'bx2d-host-152x608'
[INFO] Set the environment variable IS_DEDICATED_HOST_GROUP_CLASS for testing ibm_is_instance resource else it is set to default value 'bx2d'
[INFO] Set the environment variable IS_DEDICATED_HOST_GROUP_FAMILY for testing ibm_is_instance resource else it is set to default value 'balanced'
[INFO] Set the environment variable SL_INSTANCE_PROFILE for testing ibm_is_instance resource else it is set to default value 'bx2d-16x64'
[INFO] Set the environment variable IS_SHARE_PROFILE for testing ibm_is_instance resource else it is set to default value 'tier-3iops'
[INFO] Set the environment variable IS_SHARE_PROFILE for testing ibm_is_instance resource else it is set to default value
[INFO] Set the environment variable IS_SHARE_PROFILE for testing ibm_is_instance resource else it is set to default value
[INFO] Set the environment variable IS_VOLUME_PROFILE for testing ibm_is_volume_profile else it is set to default value 'general-purpose'
[INFO] Set the environment variable IS_VIRTUAL_NETWORK_INTERFACE for testing ibm_is_virtual_network_interface else it is set to default value 'c93dc4c6-e85a-4da2-9ea6-f24576256122'
[INFO] Set the environment variable IS_UNATTACHED_BOOT_VOLUME_NAME for testing ibm_is_image else it is set to default value 'r006-1cbe9f0a-7101-4d25-ae72-2a2d725e530e'
[INFO] Set the environment variable IS_VSI_DATA_VOLUME_ID for testing ibm_is_image else it is set to default value 'r006-1cbe9f0a-7101-4d25-ae72-2a2d725e530e'
[INFO] Set the environment variable SL_ROUTE_NEXTHOP else it is set to default value '10.0.0.4'
[INFO] Set the environment variable ISSnapshotCRN for ibm_is_snapshot resource else it is set to default value 'crn:v1:bluemix:public:is:ca-tor:a/xxxxxxxx::snapshot:xxxx-xxxxc-xxx-xxxx-xxxx-xxxxxxxxxx'
[INFO] Set the environment variable ICD_DB_DEPLOYMENT_ID for testing ibm_cloud_databases else it is set to default value 'crn:v1:bluemix:public:databases-for-redis:au-syd:a/40ddc34a953a8c02f10987b59085b60e:5042afe1-72c2-4231-89cc-c949e5d56251::'
[INFO] Set the environment variable ICD_DB_BACKUP_ID for testing ibm_cloud_databases else it is set to default value 'crn:v1:bluemix:public:databases-for-redis:au-syd:a/40ddc34a953a8c02f10987b59085b60e:5042afe1-72c2-4231-89cc-c949e5d56251:backup:0d862fdb-4faa-42e5-aecb-5057f4d399c3'
[INFO] Set the environment variable ICD_DB_TASK_ID for testing ibm_cloud_databases else it is set to default value 'crn:v1:bluemix:public:databases-for-redis:au-syd:a/40ddc34a953a8c02f10987b59085b60e:367b0a22-05bb-41e3-a1ed-ded1ff0889e5:task:882013a6-2751-4df7-a77a-98d258638704'
[INFO] Set the environment variable PI_IMAGE for testing ibm_pi_image resource else it is set to default value '7200-03-03'
[INFO] Set the environment variable PI_SAP_IMAGE for testing ibm_pi_image resource else it is set to default value 'Linux-RHEL-SAP-8-2'
[INFO] Set the environment variable PI_IMAGE_BUCKET_NAME for testing ibm_pi_image resource else it is set to default value 'images-public-bucket'
[INFO] Set the environment variable PI_IMAGE_BUCKET_FILE_NAME for testing ibm_pi_image resource else it is set to default value 'rhel.ova.gz'
[INFO] Set the environment variable PI_IMAGE_BUCKET_ACCESS_KEY for testing ibm_pi_image_export resource else it is set to default value 'images-bucket-access-key'
[INFO] Set the environment variable PI_IMAGE_BUCKET_SECRET_KEY for testing ibm_pi_image_export resource else it is set to default value 'PI_IMAGE_BUCKET_SECRET_KEY'
[INFO] Set the environment variable PI_IMAGE_BUCKET_REGION for testing ibm_pi_image_export resource else it is set to default value 'us-east'
[INFO] Set the environment variable PI_KEY_NAME for testing ibm_pi_key_name resource else it is set to default value 'terraform-test-power'
[INFO] Set the environment variable PI_NETWORK_NAME for testing ibm_pi_network_name resource else it is set to default value 'terraform-test-power'
[INFO] Set the environment variable PI_VOLUME_NAME for testing ibm_pi_network_name resource else it is set to default value 'terraform-test-power'
[INFO] Set the environment variable PI_VOLUME_ID for testing ibm_pi_volume_flash_copy_mappings resource else it is set to default value 'terraform-test-power'
[INFO] Set the environment variable PI_REPLICATION_VOLUME_NAME for testing ibm_pi_volume resource else it is set to default value 'terraform-test-power'
[INFO] Set the environment variable PI_VOLUME_ONBARDING_SOURCE_CRN for testing ibm_pi_volume_onboarding resource else it is set to default value 'terraform-test-power'
[INFO] Set the environment variable PI_AUXILIARY_VOLUME_NAME for testing ibm_pi_volume_onboarding resource else it is set to default value 'terraform-test-power'
[INFO] Set the environment variable PI_VOLUME_GROUP_NAME for testing ibm_pi_volume_group resource else it is set to default value 'terraform-test-power'
[INFO] Set the environment variable PI_VOLUME_GROUP_ID for testing ibm_pi_volume_group_storage_details data source else it is set to default value 'terraform-test-power'
[INFO] Set the environment variable PI_VOLUME_ONBOARDING_ID for testing ibm_pi_volume_onboarding resource else it is set to default value 'terraform-test-power'
[INFO] Set the environment variable PI_CLOUDINSTANCE_ID for testing ibm_pi_image resource else it is set to default value 'd16705bd-7f1a-48c9-9e0e-1c17b71e7331'
[INFO] Set the environment variable PI_SNAPSHOT_ID for testing ibm_pi_instance_snapshot data source else it is set to default value '1ea33118-4c43-4356-bfce-904d0658de82'
[INFO] Set the environment variable PI_PVM_INSTANCE_ID for testing Pi_instance_name resource else it is set to default value 'terraform-test-power'
[INFO] Set the environment variable PI_DHCP_ID for testing ibm_pi_dhcp resource else it is set to default value 'terraform-test-power'
[INFO] Set the environment variable PI_CLOUD_CONNECTION_NAME for testing ibm_pi_cloud_connection resource else it is set to default value 'terraform-test-power'
[INFO] Set the environment variable PI_SAP_PROFILE_ID for testing ibm_pi_sap_profile resource else it is set to default value 'terraform-test-power'
[WARN] Set the environment variable PI_PLACEMENT_GROUP_NAME for testing ibm_pi_placement_group resource else it is set to default value 'tf-pi-placement-group'
[WARN] Set the environment variable PI_SPP_PLACEMENT_GROUP_ID for testing ibm_pi_spp_placement_group resource else it is set to default value 'tf-pi-spp-placement-group'
[INFO] Set the environment variable PI_STORAGE_POOL for testing ibm_pi_storage_pool_capacity else it is set to default value 'terraform-test-power'
[INFO] Set the environment variable PI_STORAGE_TYPE for testing ibm_pi_storage_type_capacity else it is set to default value 'terraform-test-power'
[INFO] Set the environment variable PI_CAPTURE_STORAGE_IMAGE_PATH for testing Pi_capture_storage_image_path resource else it is set to default value 'terraform-test-power'
[INFO] Set the environment variable PI_CAPTURE_CLOUD_STORAGE_ACCESS_KEY for testing Pi_capture_cloud_storage_access_key resource else it is set to default value 'terraform-test-power'
[INFO] Set the environment variable PI_CAPTURE_CLOUD_STORAGE_SECRET_KEY for testing Pi_capture_cloud_storage_secret_key resource else it is set to default value 'terraform-test-power'
[WARN] Set the environment variable PI_SHARED_PROCESSOR_POOL_ID for testing ibm_pi_shared_processor_pool resource else it is set to default value 'tf-pi-shared-processor-pool'
[INFO] Set the environment variable PI_TARGET_STORAGE_TIER for testing Pi_target_storage_tier resource else it is set to default value 'terraform-test-tier'
[INFO] Set the environment variable PI_VOLUME_CLONE_TASK_ID for testing Pi_volume_clone_task_id resource else it is set to default value 'terraform-test-volume-clone-task-id'
[WARN] Set the environment variable PI_RESOURCE_GROUP_ID for testing ibm_pi_workspace resource else it is set to default value ''
[INFO] Set the environment variable SCHEMATICS_WORKSPACE_ID for testing schematics resources else it is set to default value
[INFO] Set the environment variable SCHEMATICS_TEMPLATE_ID for testing schematics resources else it is set to default value
[INFO] Set the environment variable SCHEMATICS_ACTION_ID for testing schematics resources else it is set to default value
[INFO] Set the environment variable SCHEMATICS_JOB_ID for testing schematics resources else it is set to default value
[INFO] Set the environment variable SCHEMATICS_REPO_URL for testing schematics resources else tests will fail if this is not set correctly
[INFO] Set the environment variable SCHEMATICS_REPO_BRANCH for testing schematics resources else tests will fail if this is not set correctly
[WARN] Set the environment variable IMAGE_COS_URL with a VALID COS Image SQL URL for testing ibm_is_image resources on staging/test
[WARN] Set the environment variable IS_DELEGATED_VPC with a VALID created vpc name for testing ibm_is_vpc data source on staging/test
[WARN] Set the environment variable IMAGE_COS_URL_ENCRYPTED with a VALID COS Image SQL URL for testing ibm_is_image resources on staging/test
[WARN] Set the environment variable IMAGE_OPERATING_SYSTEM with a VALID Operating system for testing ibm_is_image resources on staging/test
[INFO] Set the environment variable IS_IMAGE_NAME for testing data source ibm_is_image else it is set to default value `ibm-ubuntu-18-04-1-minimal-amd64-2`
[INFO] Set the environment variable IS_IMAGE_ENCRYPTED_DATA_KEY for testing resource ibm_is_image else it is set to default value
[INFO] Set the environment variable IS_IMAGE_ENCRYPTION_KEY for testing resource ibm_is_image else it is set to default value
[INFO] Set the environment variable IBM_FUNCTION_NAMESPACE for testing ibm_function_package, ibm_function_action, ibm_function_rule, ibm_function_trigger resource else  tests will fail if this is not set correctly
[INFO] Set the environment variable HPCS_INSTANCE_ID for testing data_source_ibm_kms_key_test else it is set to default value
[INFO] Set the environment variable SECRETS_MANAGER_INSTANCE_ID for testing Secrets Manager's tests else tests will fail if this is not set correctly
[INFO] Set the environment variable SECRETS_MANAGER_INSTANCE_REGION for testing Secrets Manager's tests else tests will fail if this is not set correctly
[INFO] Set the environment variable SECRETS_MANAGER_EN_INSTANCE_CRN for testing Event Notifications for Secrets Manager tests else tests will fail if this is not set correctly
[INFO] Set the environment variable SECRETS_MANAGER_EN_INSTANCE_CRN for testing IAM Credentials secret's tests else tests will assume that IAM Credentials engine is already configured and fail if not set correctly
[INFO] Set the environment variable SECRETS_MANAGER_IAM_CREDENTIALS_SECRET_SERVICE_ID or SECRETS_MANAGER_IAM_CREDENTIALS_SECRET_ACCESS_GROUP for testing IAM Credentials secret's tests, else tests fail if not set correctly
[INFO] Set the environment variable SECRETS_MANAGER_PUBLIC_CERTIFICATE_LETS_ENCRYPT_ENVIRONMENT for testing public certificate's tests, else it is set to default value ('production'). For public certificate's tests, tests will fail if this is not set correctly
[INFO] Set the environment variable SECRETS_MANAGER_PUBLIC_CERTIFICATE_LETS_ENCRYPT_PRIVATE_KEY for testing public certificate's tests, else tests fail if not set correctly
[INFO] Set the environment variable SECRETS_MANAGER_PUBLIC_CERTIFICATE_COMMON_NAME for testing public certificate's tests, else tests fail if not set correctly
[INFO] Set the environment variable SECRETS_MANAGER_VALIDATE_MANUAL_DNS_CIS_ZONE_ID for testing validate manual dns' test, else tests fail if not set correctly
[INFO] Set the environment variable SECRETS_MANAGER_PUBLIC_CERTIFICATE_CIS_CRN for testing public certificate's tests, else tests fail if not set correctly
[INFO] Set the environment variable SECRETS_MANAGER_PUBLIC_CLASSIC_INFRASTRUCTURE_USERNAME for testing public certificate's tests, else tests fail if not set correctly
[INFO] Set the environment variable SECRETS_MANAGER_PUBLIC_CLASSIC_INFRASTRUCTURE_PASSWORD for testing public certificate's tests, else tests fail if not set correctly
[INFO] Set the environment variable SECRETS_MANAGER_IMPORTED_CERTIFICATE_PATH_TO_CERTIFICATE for testing imported certificate's tests, else tests fail if not set correctly
[INFO] Set the environment variable SECRETS_MANAGER_SERVICE_CREDENTIALS_COS_CRN for testing service credentials' tests, else tests fail if not set correctly
[INFO] Set the environment variable IBM_TG_CROSS_ACCOUNT_API_KEY for testing ibm_tg_connection resource else  tests will fail if this is not set correctly
[INFO] Set the environment variable IBM_TG_CROSS_ACCOUNT_ID for testing ibm_tg_connection resource else  tests will fail if this is not set correctly
[INFO] Set the environment variable IBM_TG_CROSS_NETWORK_ID for testing ibm_tg_connection resource else  tests will fail if this is not set correctly
[INFO] Set the environment variable IBM_TG_POWER_VS_NETWORK_ID for testing ibm_tg_connection resource else tests will fail if this is not set correctly
[INFO] Set the environment variable ACCOUNT_TO_BE_IMPORTED for testing import enterprise account resource else  tests will fail if this is not set correctly
[INFO] Set the environment variable COS_BUCKET for testing CRUD operations on billing snapshot configuration APIs
[INFO] Set the environment variable COS_LOCATION for testing CRUD operations on billing snapshot configuration APIs
[INFO] Set the environment variable COS_BUCKET_UPDATE for testing update operation on billing snapshot configuration API
[INFO] Set the environment variable COS_LOCATION_UPDATE for testing update operation on billing snapshot configuration API
[INFO] Set the environment variable COS_REPORTS_FOLDER for testing CRUD operations on billing snapshot configuration APIs
[INFO] Set the environment variable SNAPSHOT_DATE_FROM for testing CRUD operations on billing snapshot configuration APIs
[INFO] Set the environment variable SNAPSHOT_DATE_TO for testing CRUD operations on billing snapshot configuration APIs
[INFO] Set the environment variable SNAPSHOT_MONTH for testing CRUD operations on billing snapshot configuration APIs
[WARN] Set the environment variable IBM_HPCS_ADMIN1 with a VALID HPCS Admin Key1 Path
[WARN] Set the environment variable IBM_HPCS_TOKEN1 with a VALID token for HPCS Admin Key1
[WARN] Set the environment variable IBM_HPCS_ADMIN2 with a VALID HPCS Admin Key2 Path
[WARN] Set the environment variable IBM_IAM_REALM_NAME with a VALID realm name for iam trusted profile claim rule
[WARN] Set the environment variable IBM_IAM_IKS_SA with a VALID realm name for iam trusted profile link
[WARN] Set the environment variable IBM_HPCS_TOKEN2 with a VALID token for HPCS Admin Key2
[WARN] Set the environment variable IBM_HPCS_ROOTKEY_CRN with a VALID CRN for a root key created in the HPCS instance
[INFO] Set the environment variable IBM_CLOUD_SHELL_ACCOUNT_ID for ibm-cloud-shell resource or datasource else tests will fail if this is not set correctly
[WARN] Set the environment variable IBM_CLUSTER_VPC_ID for testing ibm_container_vpc_alb_create resources, ibm_container_vpc_alb_create tests will fail if this is not set
[WARN] Set the environment variable IBM_CLUSTER_VPC_SUBNET_ID for testing ibm_container_vpc_alb_create resources, ibm_container_vpc_alb_creates tests will fail if this is not set
[WARN] Set the environment variable IBM_CLUSTER_VPC_RESOURCE_GROUP_ID for testing ibm_container_vpc_alb_create resources, ibm_container_vpc_alb_creates tests will fail if this is not set
[INFO] Set the environment variable IBM_CONTAINER_CLUSTER_NAME for ibm_container_nlb_dns resource or datasource else tests will fail if this is not set correctly
[INFO] Set the environment variable SATELLITE_LOCATION_ID for ibm_cos_bucket satellite location resource or datasource else tests will fail if this is not set correctly
[INFO] Set the environment variable SATELLITE_RESOURCE_INSTANCE_ID for ibm_cos_bucket satellite location resource or datasource else tests will fail if this is not set correctly
[WARN] Set the environment variable IBMCLOUD_SCC_INSTANCE_ID with a VALID SCC INSTANCE ID
[WARN] Set the environment variable IBMCLOUD_SCC_API_ENDPOINT with a VALID SCC API ENDPOINT
[WARN] Set the environment variable IBMCLOUD_SCC_REPORT_ID with a VALID SCC REPORT ID
[WARN] Set the environment variable IBMCLOUD_SCC_PROVIDER_TYPE_ATTRIBUTES with a VALID SCC PROVIDER TYPE ATTRIBUTE
[WARN] Set the environment variable IBMCLOUD_SCC_PROVIDER_TYPE_ID with a VALID SCC PROVIDER TYPE ID
[WARN] Set the environment variable IBMCLOUD_SCC_EVENT_NOTIFICATION_CRN
[WARN] Set the environment variable IBMCLOUD_SCC_OBJECT_STORAGE_CRN with a valid cloud object storage crn
[WARN] Set the environment variable IBMCLOUD_SCC_OBJECT_STORAGE_BUCKET with a valid cloud object storage bucket
[INFO] Set the environment variable IBM_CONTAINER_DEDICATEDHOST_POOL_ID for ibm_container_vpc_cluster resource to test dedicated host functionality
[INFO] Set the environment variable IBM_KMS_INSTANCE_ID for ibm_container_vpc_cluster resource or datasource else tests will fail if this is not set correctly
[INFO] Set the environment variable IBM_CRK_ID for ibm_container_vpc_cluster resource or datasource else tests will fail if this is not set correctly
[INFO] Set the environment variable IBM_KMS_ACCOUNT_ID for ibm_container_vpc_cluster resource or datasource else tests will fail if this is not set correctly
[INFO] Set the environment variable IBM_CLUSTER_ID for ibm_container_vpc_worker_pool resource or datasource else tests will fail if this is not set correctly
[WARN] Set the environment variable IBM_CD_RESOURCE_GROUP_NAME for testing CD resources, CD tests will fail if this is not set
[WARN] Set the environment variable IBM_CD_APPCONFIG_INSTANCE_NAME for testing CD resources, CD tests will fail if this is not set
[WARN] Set the environment variable IBM_CD_KEYPROTECT_INSTANCE_NAME for testing CD resources, CD tests will fail if this is not set
[WARN] Set the environment variable IBM_CD_SECRETSMANAGER_INSTANCE_NAME for testing CD resources, CD tests will fail if this is not set
[WARN] Set the environment variable IBM_CD_SLACK_CHANNEL_NAME for testing CD resources, CD tests will fail if this is not set
[WARN] Set the environment variable IBM_CD_SLACK_TEAM_NAME for testing CD resources, CD tests will fail if this is not set
[WARN] Set the environment variable IBM_CD_SLACK_WEBHOOK for testing CD resources, CD tests will fail if this is not set
[WARN] Set the environment variable IBM_CD_JIRA_PROJECT_KEY for testing CD resources, CD tests will fail if this is not set
[WARN] Set the environment variable IBM_CD_JIRA_API_URL for testing CD resources, CD tests will fail if this is not set
[WARN] Set the environment variable IBM_CD_JIRA_USERNAME for testing CD resources, CD tests will fail if this is not set
[WARN] Set the environment variable IBM_CD_JIRA_API_TOKEN for testing CD resources, CD tests will fail if this is not set
[WARN] Set the environment variable IBM_CD_SAUCELABS_ACCESS_KEY for testing CD resources, CD tests will fail if this is not set
[WARN] Set the environment variable IBM_CD_SAUCELABS_USERNAME for testing CD resources, CD tests will fail if this is not set
[WARN] Set the environment variable IBM_CD_BITBUCKET_REPO_URL for testing CD resources, CD tests will fail if this is not set
[WARN] Set the environment variable IBM_CD_GITHUB_CONSOLIDATED_REPO_URL for testing CD resources, CD tests will fail if this is not set
[WARN] Set the environment variable IBM_CD_GITLAB_REPO_URL for testing CD resources, CD tests will fail if this is not set
[WARN] Set the environment variable IBM_CD_HOSTED_GIT_REPO_URL for testing CD resources, CD tests will fail if this is not set
[WARN] Set the environment variable IBM_CD_EVENTNOTIFICATIONS_INSTANCE_NAME for testing CD resources, CD tests will fail if this is not set
[INFO] Set the environment variable IS_CERTIFICATE_CRN for testing ibm_is_vpn_server resource
[INFO] Set the environment variable IS_CLIENT_CA_CRN for testing ibm_is_vpn_server resource
[INFO] Set the environment variable IBM_AccountID_REPL for setting up authorization policy to enable replication feature resource or datasource else tests will fail if this is not set correctly
[WARN] Set the environment variable COS_API_KEY for testing COS targets, the tests will fail if this is not set
[WARN] Set the environment variable INGESTION_KEY for testing Logdna targets, the tests will fail if this is not set
[WARN] Set the environment variable IES_API_KEY for testing Event streams targets, the tests will fail if this is not set
[WARN] Set the environment variable ENTERPRISE_CRN for testing enterprise backup policy, the tests will fail if this is not set
[WARN] Set the environment variable IBM_CODE_ENGINE_RESOURCE_GROUP_ID with the resource group for Code Engine
[WARN] Set the environment variable IBM_CODE_ENGINE_PROJECT_INSTANCE_ID with the ID of a Code Engine project instance
[WARN] Set the environment variable IBM_CODE_ENGINE_SERVICE_INSTANCE_ID with the ID of a IBM Cloud service instance, e.g. for COS
[WARN] Set the environment variable IBM_CODE_ENGINE_RESOURCE_KEY_ID with the ID of a resource key to access a service instance
[WARN] Set the environment variable IBM_CODE_ENGINE_DOMAIN_MAPPING_NAME with the name of a domain mapping
[WARN] Set the environment variable IBM_CODE_ENGINE_TLS_CERT with the TLS certificate in base64 format
[WARN] Set the environment variable IBM_CODE_ENGINE_TLS_KEY with a TLS key in base64 format
[WARN] Set the environment variable IBM_SATELLITE_SSH_PUB_KEY with a ssh public key or ibm_satellite_* tests may fail
[INFO] Set the environment variable IBMCLOUD_MQCLOUD_CONFIG_ENDPOINT for ibm_mqcloud service else tests will fail if this is not set correctly
[INFO] Set the environment variable IBM_MQCLOUD_INSTANCE_ID for ibm_mqcloud_queue_manager resource or datasource else tests will fail if this is not set correctly
[INFO] Set the environment variable IBM_MQCLOUD_QUEUEMANAGER_ID for ibm_mqcloud_queue_manager resource or datasource else tests will fail if this is not set correctly
[INFO] Set the environment variable IBM_MQCLOUD_KS_CERT_PATH for ibm_mqcloud_keystore_certificate resource or datasource else tests will fail if this is not set correctly
[INFO] Set the environment variable IBM_MQCLOUD_TS_CERT_PATH for ibm_mqcloud_truststore_certificate resource or datasource else tests will fail if this is not set correctly
[INFO] Set the environment variable IBM_MQCLOUD_QUEUEMANAGER_LOCATION for ibm_mqcloud_queue_manager resource or datasource else tests will fail if this is not set correctly
[INFO] Set the environment variable IBM_MQCLOUD_QUEUEMANAGER_VERSION for ibm_mqcloud_queue_manager resource or datasource else tests will fail if this is not set correctly
[INFO] Set the environment variable IBM_MQCLOUD_QUEUEMANAGER_VERSIONUPDATE for ibm_mqcloud_queue_manager resource or datasource else tests will fail if this is not set correctly
[INFO] Set the environment variable IBMCLOUD_LOGS_SERVICE_INSTANCE_ID for testing cloud logs related operations
[INFO] Set the environment variable IBMCLOUD_LOGS_SERVICE_INSTANCE_REGION for testing cloud logs related operations
[INFO] Set the environment variable IBMCLOUD_LOGS_SERVICE_EVENT_NOTIFICATIONS_INSTANCE_ID for testing cloud logs related operations
[INFO] Set the environment variable IBMCLOUD_LOGS_SERVICE_EVENT_NOTIFICATIONS_INSTANCE_REGION for testing cloud logs related operations
[WARN] Set the environment variable IBM_PAG_COS_INSTANCE_NAME for testing IBM PAG resource, the tests will fail if this is not set
[WARN] Set the environment variable IBM_PAG_COS_BUCKET_NAME for testing IBM PAG resource, the tests will fail if this is not set
[WARN] Set the environment variable IBM_PAG_COS_BUCKET_REGION for testing IBM PAG resource, the tests will fail if this is not set
[WARN] Set the environment variable IBM_PAG_VPC_NAME for testing IBM PAG resource, the tests will fail if this is not set
[WARN] Set the environment variable IBM_PAG_SERVICE_PLAN for testing IBM PAG resource, the tests will fail if this is not set
[WARN] Set the environment variable IBM_PAG_VPC_SUBNET_INS_1 for testing IBM PAG resource, the tests will fail if this is not set
[WARN] Set the environment variable IBM_PAG_VPC_SUBNET_INS_2 for testing IBM PAG resource, the tests will fail if this is not set
[WARN] Set the environment variable IBM_PAG_VPC_SUBNET_INS_2 for testing IBM PAG resource, the tests will fail if this is not set
[WARN] Set the environment variable IBM_PAG_VPC_SUBNET_INS_2 for testing IBM PAG resource, the tests will fail if this is not set
[WARN] Set the environment variable IBM_VMAAS_DS_ID for testing ibm_vmaas_vdc resource else tests will fail if this is not set correctly
[WARN] Set the environment variable IBM_VMAAS_DS_PVDC_ID for testing ibm_vmaas_vdc resource else tests will fail if this is not set correctly
=== RUN   TestAccIBMKMSDataSourceKeyPolicy_basicNew
--- PASS: TestAccIBMKMSDataSourceKeyPolicy_basicNew (48.90s)
=== RUN   TestAccIBMKMSKeyRingDataSource_basic
--- PASS: TestAccIBMKMSKeyRingDataSource_basic (41.14s)
=== RUN   TestAccIBMKMSKeyDataSource_basic
--- PASS: TestAccIBMKMSKeyDataSource_basic (43.50s)
=== RUN   TestAccIBMKMSKeyDataSource_description
--- PASS: TestAccIBMKMSKeyDataSource_description (44.40s)
=== RUN   TestAccIBMKMSKeyDataSource_Key
--- PASS: TestAccIBMKMSKeyDataSource_Key (48.78s)
=== RUN   TestAccIBMKMSKeyDataSourceHPCS_basic
    data_source_ibm_kms_key_test.go:77: 
--- SKIP: TestAccIBMKMSKeyDataSourceHPCS_basic (0.00s)
=== RUN   TestAccIBMKMSDataSource_basic
--- PASS: TestAccIBMKMSDataSource_basic (42.06s)
=== RUN   TestAccIBMKMSHPCSDataSource_basic
    data_source_ibm_kms_keys_test.go:36: 
--- SKIP: TestAccIBMKMSHPCSDataSource_basic (0.00s)
=== RUN   TestAccIBMKMSKeyDataSource_Keys
--- PASS: TestAccIBMKMSKeyDataSource_Keys (49.58s)
=== RUN   TestAccIBMKMSInstancePolicy_basic_check
--- PASS: TestAccIBMKMSInstancePolicy_basic_check (49.88s)
=== RUN   TestAccIBMKMSInstancePolicy_rotation_check
--- PASS: TestAccIBMKMSInstancePolicy_rotation_check (37.31s)
=== RUN   TestAccIBMKMSInstancePolicy_dualAuth_check
--- PASS: TestAccIBMKMSInstancePolicy_dualAuth_check (35.83s)
=== RUN   TestAccIBMKMSInstancePolicy_metrics_check
--- PASS: TestAccIBMKMSInstancePolicy_metrics_check (36.72s)
=== RUN   TestAccIBMKMSInstancePolicy_kcia_check
--- PASS: TestAccIBMKMSInstancePolicy_kcia_check (37.10s)
=== RUN   TestAccIBMKMSInstancePolicy_kcia_attributes_check
--- PASS: TestAccIBMKMSInstancePolicy_kcia_attributes_check (38.51s)
=== RUN   TestAccIBMKMSInstancePolicyWithKey
--- PASS: TestAccIBMKMSInstancePolicyWithKey (44.56s)
=== RUN   TestAccIBMKMSInstancePolicy_invalid_interval_check
--- PASS: TestAccIBMKMSInstancePolicy_invalid_interval_check (0.43s)
=== RUN   TestAccIBMKMSResource_Key_Alias_Name
--- PASS: TestAccIBMKMSResource_Key_Alias_Name (46.49s)
=== RUN   TestAccIBMKMSResource_Key_Alias_Duplicate
--- PASS: TestAccIBMKMSResource_Key_Alias_Duplicate (34.80s)
=== RUN   TestAccIBMKMSResource_Key_Alias_Key_Check
--- PASS: TestAccIBMKMSResource_Key_Alias_Key_Check (83.43s)
=== RUN   TestAccIBMKMSResource_Key_Alias_Key_Limit
--- PASS: TestAccIBMKMSResource_Key_Alias_Key_Limit (35.69s)
=== RUN   TestAccIBMKMSKeyPolicy_basic_check
--- PASS: TestAccIBMKMSKeyPolicy_basic_check (58.42s)
=== RUN   TestAccIBMKMSKeyPolicy_basic_check_enable
--- PASS: TestAccIBMKMSKeyPolicy_basic_check_enable (84.96s)
=== RUN   TestAccIBMKMSKeyPolicy_rotation_check
--- PASS: TestAccIBMKMSKeyPolicy_rotation_check (46.59s)
=== RUN   TestAccIBMKMSKeyPolicy_dualAuth_check
--- PASS: TestAccIBMKMSKeyPolicy_dualAuth_check (47.12s)
=== RUN   TestAccIBMKMSKeyPolicy_dualAuth_check_with_Alias
--- PASS: TestAccIBMKMSKeyPolicy_dualAuth_check_with_Alias (46.45s)
=== RUN   TestAccIBMKMSResource_Key_Ring_Name
--- PASS: TestAccIBMKMSResource_Key_Ring_Name (37.76s)
=== RUN   TestAccIBMKMSResource_Key_Ring_Key
--- PASS: TestAccIBMKMSResource_Key_Ring_Key (61.19s)
=== RUN   TestAccIBMKMSResource_Key_Ring_Not_Exist
--- PASS: TestAccIBMKMSResource_Key_Ring_Not_Exist (30.50s)
=== RUN   TestAccIBMKMSResource_Key_Ring_AlwaysForceDeleteTrue
--- PASS: TestAccIBMKMSResource_Key_Ring_AlwaysForceDeleteTrue (53.31s)
=== RUN   TestAccIBMKMSResource_basic
--- PASS: TestAccIBMKMSResource_basic (149.01s)
=== RUN   TestAccIBMKMSHPCSResource_basic
    resource_ibm_kms_key_test.go:78: 
--- SKIP: TestAccIBMKMSHPCSResource_basic (0.00s)
=== RUN   TestAccIBMKMSResource_ValidExpDate
--- PASS: TestAccIBMKMSResource_ValidExpDate (58.06s)
=== RUN   TestAccIBMKMSResource_InvalidExpDate
--- PASS: TestAccIBMKMSResource_InvalidExpDate (34.65s)
=== RUN   TestAccIBMKMSKeyWithPolicyOverridesResource_InvalidExpDate
--- PASS: TestAccIBMKMSKeyWithPolicyOverridesResource_InvalidExpDate (36.06s)
PASS
ok      github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/kms     1546.301s
(base) wsiew@Williams-MacBook-Pro terraform-provider-ibm % 
```

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```

...
```
