### PR TITLE
move wait_till logic into function, integrate it into cluster datasource

### DIFF
--- a/ibm/service/kubernetes/data_source_ibm_container_cluster.go
+++ b/ibm/service/kubernetes/data_source_ibm_container_cluster.go
@@ -7,11 +7,13 @@ import (
 	"fmt"
 	"log"
 	"strings"
+	"time"
 
 	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/conns"
 	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/flex"
 	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/validate"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 )
 
 func DataSourceIBMContainerCluster() *schema.Resource {
@@ -34,6 +36,23 @@ func DataSourceIBMContainerCluster() *schema.Resource {
 				ValidateFunc: validate.InvokeDataSourceValidator(
 					"ibm_container_cluster",
 					"name"),
+			},
+			"wait_till": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringInSlice([]string{oneWorkerNodeReady, clusterNormal}, true),
+				Description:  "wait_till can be configured for Master Ready, One worker Ready, Ingress Ready or Normal",
+			},
+			"wait_till_timeout": {
+				Type:         schema.TypeInt,
+				Optional:     true,
+				Default:      "20",
+				Description:  "timeout for wait_till in minutes",
+				RequiredWith: []string{"wait_till"},
+			},
+			"state": {
+				Type:     schema.TypeString,
+				Computed: true,
 			},
 			"worker_count": {
 				Description: "Number of workers",
@@ -390,6 +409,16 @@ func dataSourceIBMContainerClusterRead(d *schema.ResourceData, meta interface{})
 	if v, ok := d.GetOk("name"); ok {
 		name = v.(string)
 	}
+
+	// timeoutStage will define the timeout stage
+	var timeoutStage string
+	var timeout time.Duration = 20 * time.Minute
+	if v, ok := d.GetOk("wait_till"); ok {
+		timeoutStage = strings.ToLower(v.(string))
+		timeoutInt := d.Get("wait_till_timeout").(int)
+		timeout = time.Duration(timeoutInt) * time.Minute
+	}
+
 	clusterFields, err := csAPI.Find(name, targetEnv)
 	if err != nil {
 		return fmt.Errorf("[ERROR] Error retrieving cluster: %s", err)
@@ -434,6 +463,19 @@ func dataSourceIBMContainerClusterRead(d *schema.ResourceData, meta interface{})
 	filteredAlbs := flex.FlattenAlbs(albs, filterType)
 
 	d.SetId(clusterFields.ID)
+
+	err = waitForCluster(d, timeoutStage, timeout, meta)
+	if err != nil {
+		return err
+	}
+	if timeoutStage != "" {
+		clusterFields, err = csAPI.Find(name, targetEnv)
+		if err != nil {
+			return fmt.Errorf("[ERROR] Error retrieving cluster after waitForCluster: %s", err)
+		}
+	}
+
+	d.Set("state", clusterFields.State)
 	d.Set("worker_count", clusterFields.WorkerCount)
 	d.Set("workers", workers)
 	d.Set("region", clusterFields.Region)

--- a/ibm/service/kubernetes/data_source_ibm_container_cluster.go
+++ b/ibm/service/kubernetes/data_source_ibm_container_cluster.go
@@ -464,11 +464,12 @@ func dataSourceIBMContainerClusterRead(d *schema.ResourceData, meta interface{})
 
 	d.SetId(clusterFields.ID)
 
-	err = waitForCluster(d, timeoutStage, timeout, meta)
-	if err != nil {
-		return err
-	}
 	if timeoutStage != "" {
+		err = waitForCluster(d, timeoutStage, timeout, meta)
+		if err != nil {
+			return err
+		}
+
 		clusterFields, err = csAPI.Find(name, targetEnv)
 		if err != nil {
 			return fmt.Errorf("[ERROR] Error retrieving cluster after waitForCluster: %s", err)

--- a/ibm/service/kubernetes/resource_ibm_container_cluster.go
+++ b/ibm/service/kubernetes/resource_ibm_container_cluster.go
@@ -700,27 +700,10 @@ func resourceIBMContainerClusterCreate(d *schema.ResourceData, meta interface{})
 			return err
 		}
 	}
-
-	_, err = waitForClusterMasterAvailable(d, meta)
+	timeoutStage := strings.ToLower(d.Get("wait_till").(string))
+	err = waitForCluster(d, timeoutStage, d.Timeout(schema.TimeoutCreate), meta)
 	if err != nil {
 		return err
-	}
-	waitForState := strings.ToLower(d.Get("wait_till").(string))
-
-	switch waitForState {
-	case strings.ToLower(oneWorkerNodeReady):
-		_, err = waitForClusterOneWorkerAvailable(d, meta)
-		if err != nil {
-			return err
-		}
-
-	case strings.ToLower(clusterNormal):
-		pendingStates := []string{clusterDeploying, clusterRequested, clusterPending, clusterDeployed, clusterCritical, clusterWarning}
-		_, err = waitForClusterState(d, meta, waitForState, pendingStates)
-		if err != nil {
-			return err
-		}
-
 	}
 
 	d.Set("force_delete_storage", d.Get("force_delete_storage").(bool))
@@ -757,6 +740,31 @@ func resourceIBMContainerClusterCreate(d *schema.ResourceData, meta interface{})
 	}
 
 	return resourceIBMContainerClusterUpdate(d, meta)
+}
+
+func waitForCluster(d *schema.ResourceData, timeoutStage string, timeout time.Duration, meta interface{}) error {
+	switch timeoutStage {
+	case strings.ToLower(masterNodeReady):
+		_, err := waitForClusterMasterAvailable(d, meta, timeout)
+		if err != nil {
+			return err
+		}
+
+	case strings.ToLower(oneWorkerNodeReady):
+		_, err := waitForClusterOneWorkerAvailable(d, meta, timeout)
+		if err != nil {
+			return err
+		}
+
+	case clusterNormal:
+		pendingStates := []string{clusterDeploying, clusterRequested, clusterPending, clusterDeployed, clusterCritical, clusterWarning}
+		_, err := waitForClusterState(d, meta, clusterNormal, pendingStates, timeout)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
 }
 
 func resourceIBMContainerClusterRead(d *schema.ResourceData, meta interface{}) error {
@@ -1275,46 +1283,8 @@ func waitForClusterDelete(d *schema.ResourceData, meta interface{}) (interface{}
 	return stateConf.WaitForState()
 }
 
-// WaitForClusterAvailable Waits for cluster creation
-func WaitForClusterAvailable(d *schema.ResourceData, meta interface{}, target v1.ClusterTargetHeader) (interface{}, error) {
-	csClient, err := meta.(conns.ClientSession).ContainerAPI()
-	if err != nil {
-		return nil, err
-	}
-	log.Printf("Waiting for cluster (%s) to be available.", d.Id())
-	id := d.Id()
-
-	stateConf := &resource.StateChangeConf{
-		Pending:    []string{"retry", clusterProvisioning},
-		Target:     []string{clusterNormal},
-		Refresh:    clusterStateRefreshFunc(csClient.Clusters(), id, target),
-		Timeout:    d.Timeout(schema.TimeoutCreate),
-		Delay:      10 * time.Second,
-		MinTimeout: 10 * time.Second,
-	}
-
-	return stateConf.WaitForState()
-}
-
-func clusterStateRefreshFunc(client v1.Clusters, instanceID string, target v1.ClusterTargetHeader) resource.StateRefreshFunc {
-	return func() (interface{}, string, error) {
-		clusterFields, err := client.FindWithOutShowResourcesCompatible(instanceID, target)
-		if err != nil {
-			return nil, "", fmt.Errorf("[ERROR] clusterStateRefreshFunc Error retrieving cluster: %s", err)
-		}
-		// Check active transactions
-		log.Println("Checking cluster")
-		//Check for cluster state to be normal
-		log.Println("Checking cluster state", strings.Compare(clusterFields.State, clusterNormal))
-		if strings.Compare(clusterFields.State, clusterNormal) != 0 {
-			return clusterFields, clusterProvisioning, nil
-		}
-		return clusterFields, clusterNormal, nil
-	}
-}
-
 // waitForClusterMasterAvailable Waits for cluster creation
-func waitForClusterMasterAvailable(d *schema.ResourceData, meta interface{}) (interface{}, error) {
+func waitForClusterMasterAvailable(d *schema.ResourceData, meta interface{}, timeout time.Duration) (interface{}, error) {
 	targetEnv, err := getClusterTargetHeader(d, meta)
 	if err != nil {
 		return nil, err
@@ -1339,7 +1309,7 @@ func waitForClusterMasterAvailable(d *schema.ResourceData, meta interface{}) (in
 			}
 			return clusterFields, deployInProgress, nil
 		},
-		Timeout:    d.Timeout(schema.TimeoutCreate),
+		Timeout:    timeout,
 		Delay:      10 * time.Second,
 		MinTimeout: 10 * time.Second,
 	}
@@ -1347,7 +1317,7 @@ func waitForClusterMasterAvailable(d *schema.ResourceData, meta interface{}) (in
 	return stateConf.WaitForState()
 }
 
-func waitForClusterState(d *schema.ResourceData, meta interface{}, waitForState string, pendingState []string) (interface{}, error) {
+func waitForClusterState(d *schema.ResourceData, meta interface{}, waitForState string, pendingState []string, timeout time.Duration) (interface{}, error) {
 	targetEnv, err := getClusterTargetHeader(d, meta)
 	if err != nil {
 		return nil, err
@@ -1376,7 +1346,7 @@ func waitForClusterState(d *schema.ResourceData, meta interface{}, waitForState 
 
 			return cls, cls.State, nil
 		},
-		Timeout:    d.Timeout(schema.TimeoutCreate),
+		Timeout:    timeout,
 		Delay:      10 * time.Second,
 		MinTimeout: 10 * time.Second,
 	}
@@ -1385,7 +1355,7 @@ func waitForClusterState(d *schema.ResourceData, meta interface{}, waitForState 
 }
 
 // waitForClusterOneWorkerAvailable Waits for cluster creation
-func waitForClusterOneWorkerAvailable(d *schema.ResourceData, meta interface{}) (interface{}, error) {
+func waitForClusterOneWorkerAvailable(d *schema.ResourceData, meta interface{}, timeout time.Duration) (interface{}, error) {
 	targetEnv, err := getClusterTargetHeader(d, meta)
 	if err != nil {
 		return nil, err
@@ -1435,7 +1405,7 @@ func waitForClusterOneWorkerAvailable(d *schema.ResourceData, meta interface{}) 
 			}
 			return nil, normal, nil
 		},
-		Timeout:    d.Timeout(schema.TimeoutCreate),
+		Timeout:    timeout,
 		Delay:      10 * time.Second,
 		MinTimeout: 10 * time.Second,
 	}
@@ -1481,41 +1451,6 @@ func workerStateRefreshFunc(client v1.Workers, instanceID string, target v1.Clus
 		}
 		return workerFields, workerNormal, nil
 	}
-}
-
-func WaitForClusterCreation(d *schema.ResourceData, meta interface{}, target v1.ClusterTargetHeader) (interface{}, error) {
-	csClient, err := meta.(conns.ClientSession).ContainerAPI()
-	if err != nil {
-		return nil, err
-	}
-	log.Printf("Waiting for cluster (%s) to be available.", d.Id())
-	ClusterID := d.Id()
-
-	stateConf := &resource.StateChangeConf{
-		Pending: []string{"retry", clusterProvisioning},
-		Target:  []string{clusterNormal},
-		Refresh: func() (interface{}, string, error) {
-			workerFields, err := csClient.Workers().List(ClusterID, target)
-			log.Println("Total workers: ", len(workerFields))
-			if err != nil {
-				return nil, "", fmt.Errorf("[ERROR] Error retrieving workers for cluster: %s", err)
-			}
-			log.Println("Checking workers...")
-			//verifying for atleast sing node to be in normal state
-			for _, e := range workerFields {
-				log.Println("Worker node status: ", e.State)
-				if e.State == workerNormal {
-					return workerFields, workerNormal, nil
-				}
-			}
-			return workerFields, workerProvisioning, nil
-		},
-		Timeout:    d.Timeout(schema.TimeoutCreate),
-		Delay:      10 * time.Second,
-		MinTimeout: 10 * time.Second,
-	}
-
-	return stateConf.WaitForState()
 }
 
 func WaitForSubnetAvailable(d *schema.ResourceData, meta interface{}, target v1.ClusterTargetHeader) (interface{}, error) {

--- a/ibm/service/kubernetes/resource_ibm_container_cluster.go
+++ b/ibm/service/kubernetes/resource_ibm_container_cluster.go
@@ -700,6 +700,12 @@ func resourceIBMContainerClusterCreate(d *schema.ResourceData, meta interface{})
 			return err
 		}
 	}
+
+	_, err = waitForClusterMasterAvailable(d, meta, d.Timeout(schema.TimeoutCreate))
+	if err != nil {
+		return err
+	}
+
 	timeoutStage := strings.ToLower(d.Get("wait_till").(string))
 	err = waitForCluster(d, timeoutStage, d.Timeout(schema.TimeoutCreate), meta)
 	if err != nil {

--- a/website/docs/d/container_cluster.html.markdown
+++ b/website/docs/d/container_cluster.html.markdown
@@ -33,6 +33,8 @@ Review the argument references that you can specify for your data source.
 - `name` - (Optional, String) The name or ID of the cluster.
 - `list_bounded_services`- (Optional, Bool) If set to **false** services which are bound to the cluster are not going to be listed. The default value is **true**.
 - `resource_group_id` - (Optional, String) The ID of the resource group where your cluster is provisioned into. To list resource groups, run `ibmcloud resource groups` or use the `ibm_resource_group` data source.
+- `wait_till` - (Optional, String) The cluster creation happens in multi-stages. To avoid the longer wait times for resource execution. This argument in the resource will wait for the specified stage and complete the execution. The supported stages are  `MasterNodeReady` Resource waits till the master node is ready.  `OneWorkerNodeReady` Resource waits till one worker node is in to ready state. `Normal` Terraform marks the creation of your cluster complete when the cluster is in a [Normal](https://cloud.ibm.com/docs/containers?topic=containers-cluster-states-reference#cluster-state-normal) state. At the moment wait_till `Normal` also ignores the critical and warning states the are temporary happen during cluster creation, but cannot distinguish it from actual critical or warning states. If you do not specify this option, the provider will not wait.
+- `wait_till_timeout` - ( Optional, Int ) This parameter can be used to set the `wait_till` timeout in minutes. The `wait_till_timeout` can only be used with `wait_till`. The default value is 20 minutes.
 
 **Deprecated reference**
 

--- a/website/docs/d/container_cluster.html.markdown
+++ b/website/docs/d/container_cluster.html.markdown
@@ -74,6 +74,7 @@ In addition to all argument reference list, you can access the following attribu
 - `public_service_endpoint_url` - (String) The URL of the public service endpoint for your cluster.
 - `private_service_endpoint` -  (Bool) Indicates if the private service endpoint is enabled (**true**) or disabled (**false**) for a cluster. 
 - `private_service_endpoint_url` - (String) The URL of the private service endpoint for your cluster.
+- `state` - (String) The state of the cluster.
 - `vlans`- (List of objects) A list of VLANs that are attached to the cluster. 
 
   Nested scheme for `vlans`:


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/IBM-Cloud/terraform-provider-ibm/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
=== RUN   TestAccIBMContainerCluster_basic
--- PASS: TestAccIBMContainerCluster_basic (1077.40s)
PASS
ok      github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/kubernetes      1080.663s



=== RUN   TestAccIBMContainerClusterDataSource_basic
--- PASS: TestAccIBMContainerClusterDataSource_basic (1220.10s)
PASS
ok      github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/kubernetes      1223.629s



// Modified the timeout to 1 minute, to test that out too
=== RUN   TestAccIBMContainerClusterDataSource_basic
    data_source_ibm_container_cluster_test.go:20: Step 2/2 error: Error running pre-apply refresh: exit status 1
        
        Error: timeout while waiting for state to become 'normal' (last state: 'deploying', timeout: 1m0s)
        
          with data.ibm_container_cluster.testacc_ds_cluster,
          on terraform_plugin_test.tf line 30, in data "ibm_container_cluster" "testacc_ds_cluster":
          30:   data "ibm_container_cluster" "testacc_ds_cluster" {
        
        ---
        id: terraform-9ef4459f
        summary: 'timeout while waiting for state to become ''normal'' (last state:
        ''deploying'',
          timeout: 1m0s)'
        severity: error
        resource: (Data) ibm_container_cluster
        operation: read
        component:
          name: github.com/IBM-Cloud/terraform-provider-ibm
          version: 1.67.1
        ---
        
--- FAIL: TestAccIBMContainerClusterDataSource_basic (1121.72s)
FAIL
FAIL    github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/kubernetes      1125.158s
FAIL
make: *** [testacc] Error 1
...
```
