### PR TITLE
fix: read endpoint type from schema

### DIFF
--- a/ibm/service/cos/data_source_ibm_cos_bucket.go
+++ b/ibm/service/cos/data_source_ibm_cos_bucket.go
@@ -729,7 +729,9 @@ func dataSourceIBMCosBucketRead(d *schema.ResourceData, meta interface{}) error 
 		// User is expected to define both private and direct url type under "private" in endpoints file since visibility type "direct" is not supported.
 		cosConfigURL := conns.FileFallBack(rsConClient.Config.EndpointsFile, "private", "IBMCLOUD_COS_CONFIG_ENDPOINT", bucketRegion, cosConfigUrls[endpointType])
 		cosConfigURL = conns.EnvFallBack([]string{"IBMCLOUD_COS_CONFIG_ENDPOINT"}, cosConfigURL)
-		sess.SetServiceURL(cosConfigURL)
+		if cosConfigURL != "" {
+			sess.SetServiceURL(cosConfigURL)
+		}
 	}
 
 	if bucketType == "sl" {

--- a/ibm/service/cos/resource_ibm_cos_bucket.go
+++ b/ibm/service/cos/resource_ibm_cos_bucket.go
@@ -742,7 +742,10 @@ func resourceIBMCOSBucketUpdate(d *schema.ResourceData, meta interface{}) error 
 	}
 	bucketName := parseBucketId(d.Id(), "bucketName")
 	serviceID := parseBucketId(d.Id(), "serviceID")
-	endpointType := d.Get("endpoint_type").(string)
+	endpointType := parseBucketId(d.Id(), "endpointType")
+	if endpointType == "" {
+		endpointType = d.Get("endpoint_type").(string)
+	}
 	bLocation := parseBucketId(d.Id(), "bLocation")
 	apiType := parseBucketId(d.Id(), "apiType")
 	if apiType == "sl" {
@@ -1088,7 +1091,10 @@ func resourceIBMCOSBucketRead(d *schema.ResourceData, meta interface{}) error {
 	}
 	bucketName := parseBucketId(d.Id(), "bucketName")
 	serviceID := parseBucketId(d.Id(), "serviceID")
-	endpointType := d.Get("endpoint_type").(string)
+	endpointType := parseBucketId(d.Id(), "endpointType")
+	if endpointType == "" {
+		endpointType = d.Get("endpoint_type").(string)
+	}
 	apiType := parseBucketId(d.Id(), "apiType")
 	bLocation := parseBucketId(d.Id(), "bLocation")
 
@@ -1516,8 +1522,10 @@ func resourceIBMCOSBucketDelete(d *schema.ResourceData, meta interface{}) error 
 		apiType = "sl"
 	}
 
-	endpointType := d.Get("endpoint_type").(string)
-
+	endpointType := parseBucketId(d.Id(), "endpointType")
+	if endpointType == "" {
+		endpointType = d.Get("endpoint_type").(string)
+	}
 	var apiEndpoint, apiEndpointPrivate, directApiEndpoint, visibility string
 
 	if apiType == "sl" {
@@ -1642,8 +1650,11 @@ func resourceIBMCOSBucketExists(d *schema.ResourceData, meta interface{}) (bool,
 
 	apiType := parseBucketId(d.Id(), "apiType")
 	bLocation := parseBucketId(d.Id(), "bLocation")
-	endpointType := d.Get("endpoint_type").(string)
 
+	endpointType := parseBucketId(d.Id(), "endpointType")
+	if endpointType == "" {
+		endpointType = d.Get("endpoint_type").(string)
+	}
 	if apiType == "sl" {
 		satloc_guid := strings.Split(serviceID, ":")
 		bucketsatcrn := satloc_guid[0]

--- a/ibm/service/cos/resource_ibm_cos_bucket.go
+++ b/ibm/service/cos/resource_ibm_cos_bucket.go
@@ -939,7 +939,9 @@ func resourceIBMCOSBucketUpdate(d *schema.ResourceData, meta interface{}) error 
 		// User is expected to define both private and direct url type under "private" in endpoints file since visibility type "direct" is not supported.
 		cosConfigURL := conns.FileFallBack(rsConClient.Config.EndpointsFile, "private", "IBMCLOUD_COS_CONFIG_ENDPOINT", bLocation, cosConfigUrls[endpointType])
 		cosConfigURL = conns.EnvFallBack([]string{"IBMCLOUD_COS_CONFIG_ENDPOINT"}, cosConfigURL)
-		sess.SetServiceURL(cosConfigURL)
+		if cosConfigURL != "" {
+			sess.SetServiceURL(cosConfigURL)
+		}
 	}
 
 	if apiType == "sl" {
@@ -1208,7 +1210,9 @@ func resourceIBMCOSBucketRead(d *schema.ResourceData, meta interface{}) error {
 		// User is expected to define both private and direct url type under "private" in endpoints file since visibility type "direct" is not supported.
 		cosConfigURL := conns.FileFallBack(rsConClient.Config.EndpointsFile, "private", "IBMCLOUD_COS_CONFIG_ENDPOINT", bLocation, cosConfigUrls[endpointType])
 		cosConfigURL = conns.EnvFallBack([]string{"IBMCLOUD_COS_CONFIG_ENDPOINT"}, cosConfigURL)
-		sess.SetServiceURL(cosConfigURL)
+		if cosConfigURL != "" {
+			sess.SetServiceURL(cosConfigURL)
+		}
 	}
 
 	if apiType == "sl" {

--- a/ibm/service/cos/resource_ibm_cos_bucket.go
+++ b/ibm/service/cos/resource_ibm_cos_bucket.go
@@ -742,7 +742,7 @@ func resourceIBMCOSBucketUpdate(d *schema.ResourceData, meta interface{}) error 
 	}
 	bucketName := parseBucketId(d.Id(), "bucketName")
 	serviceID := parseBucketId(d.Id(), "serviceID")
-	endpointType := parseBucketId(d.Id(), "endpointType")
+	endpointType := d.Get("endpoint_type").(string)
 	bLocation := parseBucketId(d.Id(), "bLocation")
 	apiType := parseBucketId(d.Id(), "apiType")
 	if apiType == "sl" {
@@ -1086,7 +1086,7 @@ func resourceIBMCOSBucketRead(d *schema.ResourceData, meta interface{}) error {
 	}
 	bucketName := parseBucketId(d.Id(), "bucketName")
 	serviceID := parseBucketId(d.Id(), "serviceID")
-	endpointType := parseBucketId(d.Id(), "endpointType")
+	endpointType := d.Get("endpoint_type").(string)
 	apiType := parseBucketId(d.Id(), "apiType")
 	bLocation := parseBucketId(d.Id(), "bLocation")
 
@@ -1512,7 +1512,7 @@ func resourceIBMCOSBucketDelete(d *schema.ResourceData, meta interface{}) error 
 		apiType = "sl"
 	}
 
-	endpointType := parseBucketId(d.Id(), "endpointType")
+	endpointType := d.Get("endpoint_type").(string)
 
 	var apiEndpoint, apiEndpointPrivate, directApiEndpoint, visibility string
 
@@ -1638,7 +1638,7 @@ func resourceIBMCOSBucketExists(d *schema.ResourceData, meta interface{}) (bool,
 
 	apiType := parseBucketId(d.Id(), "apiType")
 	bLocation := parseBucketId(d.Id(), "bLocation")
-	endpointType := parseBucketId(d.Id(), "endpointType")
+	endpointType := d.Get("endpoint_type").(string)
 
 	if apiType == "sl" {
 		satloc_guid := strings.Split(serviceID, ":")


### PR DESCRIPTION
Fix: Read endpoint from schema instead of fake generated bucketid.

<!--- See what makes a good Pull Request at : https://github.com/IBM-Cloud/terraform-provider-ibm/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```
