### PR TITLE
remove the return value from waitForVpcCluster

### DIFF
--- a/ibm/service/kubernetes/data_source_ibm_container_vpc_cluster.go
+++ b/ibm/service/kubernetes/data_source_ibm_container_vpc_cluster.go
@@ -405,13 +405,16 @@ func dataSourceIBMContainerClusterVPCRead(d *schema.ResourceData, meta interface
 
 	d.SetId(cls.ID)
 
-	returnedClusterInfo, err := waitForVpcCluster(d, meta, timeoutStage, timeout)
-	if err != nil {
-		return err
-	}
+	if timeoutStage != "" {
+		err = waitForVpcCluster(d, meta, timeoutStage, timeout)
+		if err != nil {
+			return err
+		}
 
-	if returnedClusterInfo != nil {
-		cls = returnedClusterInfo
+		cls, err = csClient.Clusters().GetCluster(clusterNameOrID, targetEnv)
+		if err != nil {
+			return fmt.Errorf("[ERROR] Error retrieving container vpc cluster: %s", err)
+		}
 	}
 
 	d.Set("crn", cls.CRN)

--- a/ibm/service/kubernetes/resource_ibm_container_vpc_cluster.go
+++ b/ibm/service/kubernetes/resource_ibm_container_vpc_cluster.go
@@ -5,7 +5,6 @@ package kubernetes
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"log"
 	"os"
@@ -655,7 +654,7 @@ func resourceIBMContainerVpcClusterCreate(d *schema.ResourceData, meta interface
 		}
 	}
 
-	_, err = waitForVpcCluster(d, meta, timeoutStage, d.Timeout(schema.TimeoutCreate))
+	err = waitForVpcCluster(d, meta, timeoutStage, d.Timeout(schema.TimeoutCreate))
 	if err != nil {
 		return err
 	}
@@ -1094,45 +1093,37 @@ func isLBDeleteRefreshFunc(lbc *vpcv1.VpcV1, id string) resource.StateRefreshFun
 	}
 }
 
-func waitForVpcCluster(d *schema.ResourceData, meta interface{}, timeoutStage string, timeout time.Duration) (*v2.ClusterInfo, error) {
-	var clusterinfo interface{}
+func waitForVpcCluster(d *schema.ResourceData, meta interface{}, timeoutStage string, timeout time.Duration) error {
 	var err error
 	switch timeoutStage {
 
 	case strings.ToLower(clusterNormal):
 		pendingStates := []string{clusterDeploying, clusterRequested, clusterPending, clusterDeployed, clusterCritical, clusterWarning}
-		clusterinfo, err = waitForVpcClusterState(d, meta, clusterNormal, pendingStates, timeout)
+		_, err = waitForVpcClusterState(d, meta, clusterNormal, pendingStates, timeout)
 		if err != nil {
-			return nil, err
+			return err
 		}
 
 	case strings.ToLower(masterNodeReady):
-		clusterinfo, err = waitForVpcClusterMasterAvailable(d, meta, timeout)
+		_, err = waitForVpcClusterMasterAvailable(d, meta, timeout)
 		if err != nil {
-			return nil, err
+			return err
 		}
 
 	case strings.ToLower(oneWorkerNodeReady):
-		clusterinfo, err = waitForVpcClusterOneWorkerAvailable(d, meta, timeout)
+		_, err = waitForVpcClusterOneWorkerAvailable(d, meta, timeout)
 		if err != nil {
-			return nil, err
+			return err
 		}
 
 	case strings.ToLower(ingressReady):
-		clusterinfo, err = waitForVpcClusterIngressAvailable(d, meta, timeout)
+		_, err = waitForVpcClusterIngressAvailable(d, meta, timeout)
 		if err != nil {
-			return nil, err
+			return err
 		}
-	default:
-		// silent fallback
-		return nil, nil
 	}
 
-	ci, ok := clusterinfo.(*v2.ClusterInfo)
-	if !ok {
-		return nil, errors.New("[ERROR] cannot convert returned value to ClusterInfo")
-	}
-	return ci, nil
+	return nil
 }
 
 func waitForVpcClusterDelete(d *schema.ResourceData, meta interface{}) (interface{}, error) {


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/IBM-Cloud/terraform-provider-ibm/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #5548

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
=== RUN   TestAccIBMContainerVpcClusterBasic
--- PASS: TestAccIBMContainerVpcClusterBasic (3422.43s)
PASS
ok      github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/kubernetes      3426.144s



=== RUN   TestAccIBMContainerVPCClusterDataSource_basic
--- PASS: TestAccIBMContainerVPCClusterDataSource_basic (2975.79s)
PASS
ok      github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/kubernetes      2979.195s

...
```
