### PR TITLE
Update(Cloud-Databases): Added hints for region and location mismatches

### DIFF
--- a/ibm/service/database/data_source_ibm_database.go
+++ b/ibm/service/database/data_source_ibm_database.go
@@ -685,7 +685,7 @@ func dataSourceIBMDatabaseInstanceRead(d *schema.ResourceData, meta interface{})
 
 	autoscalingGroup, _, err := cloudDatabasesClient.GetAutoscalingConditions(getAutoscalingConditionsOptions)
 	if err != nil {
-		return fmt.Errorf("[ERROR] Error getting database autoscaling groups: %s", err)
+		return fmt.Errorf("[ERROR] Error getting database autoscaling groups: %s\n Hint: Check if there is a mismatch between your database location and IBMCLOUD_REGION", err)
 	}
 	d.Set("auto_scaling", flattenAutoScalingGroup(*autoscalingGroup))
 

--- a/ibm/service/database/resource_ibm_database.go
+++ b/ibm/service/database/resource_ibm_database.go
@@ -1754,7 +1754,7 @@ func resourceIBMDatabaseInstanceRead(context context.Context, d *schema.Resource
 
 	autoscalingGroup, _, err := cloudDatabasesClient.GetAutoscalingConditions(getAutoscalingConditionsOptions)
 	if err != nil {
-		return diag.FromErr(fmt.Errorf("[ERROR] Error getting database autoscaling groups: %s", err))
+		return diag.FromErr(fmt.Errorf("[ERROR] Error getting database autoscaling groups: %s\n Hint: Check if there is a mismatch between your database location and IBMCLOUD_REGION", err))
 	}
 	d.Set("auto_scaling", flattenAutoScalingGroup(*autoscalingGroup))
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/IBM-Cloud/terraform-provider-ibm/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

```
╷
│ Error: [ERROR] Error getting database autoscaling groups: Not Found
│  Hint: Check if there is a mismatch between your database location and IBMCLOUD_REGION
│ 
│   with ibm_database.elasticsearch,
│   on main.tf line 105, in resource "ibm_database" "elasticsearch":
│  105: resource "ibm_database" "elasticsearch" {
│ 
╵
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```
