### PR TITLE
[KMS] Force delete subresources during kmip_adapter destroy, avoid casting panics

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -23,7 +23,7 @@ require (
 	github.com/IBM/ibm-cos-sdk-go-config/v2 v2.1.0
 	github.com/IBM/ibm-hpcs-tke-sdk v0.0.0-20211109141421-a4b61b05f7d1
 	github.com/IBM/ibm-hpcs-uko-sdk v0.0.20-beta
-	github.com/IBM/keyprotect-go-client v0.14.0
+	github.com/IBM/keyprotect-go-client v0.15.1
 	github.com/IBM/logs-go-sdk v0.3.0
 	github.com/IBM/logs-router-go-sdk v1.0.3
 	github.com/IBM/networking-go-sdk v0.48.0

--- a/go.sum
+++ b/go.sum
@@ -164,8 +164,8 @@ github.com/IBM/ibm-hpcs-tke-sdk v0.0.0-20211109141421-a4b61b05f7d1/go.mod h1:M2J
 github.com/IBM/ibm-hpcs-uko-sdk v0.0.20-beta h1:P1fdIfKsD9xvJQ5MHIEztPS9yfNf9x+VDTamaYcmqcs=
 github.com/IBM/ibm-hpcs-uko-sdk v0.0.20-beta/go.mod h1:MLVNHMYoKsvovJZ4v1gQCpIYtRDHTtoIHK6XztDZGsU=
 github.com/IBM/keyprotect-go-client v0.5.1/go.mod h1:5TwDM/4FRJq1ZOlwQL1xFahLWQ3TveR88VmL1u3njyI=
-github.com/IBM/keyprotect-go-client v0.14.0 h1:GqgK3BdczA/w7+B1RxEPLya0w9S/ZXi5YWKAxdW8vHQ=
-github.com/IBM/keyprotect-go-client v0.14.0/go.mod h1:cAt714Vnwnd03mmkBHHSJlDNRVthdRmJB6RePd4/B8Q=
+github.com/IBM/keyprotect-go-client v0.15.1 h1:m4qzqF5zOumRxKZ8s7vtK7A/UV/D278L8xpRG+WgT0s=
+github.com/IBM/keyprotect-go-client v0.15.1/go.mod h1:asXtHwL/4uCHA221Vd/7SkXEi2pcRHDzPyyksc1DthE=
 github.com/IBM/logs-go-sdk v0.3.0 h1:FHzTCCMyp9DvQGXgkppzcOPywC4ggt7x8xu0MR5h8xI=
 github.com/IBM/logs-go-sdk v0.3.0/go.mod h1:yv/GCXC4/p+MZEeXl4xjZAOMvDAVRwu61WyHZFKFXQM=
 github.com/IBM/logs-router-go-sdk v1.0.3 h1:VO64OpANNouxS/0kvUeBpENKWxYx3TYnoNzW8OycMb0=
@@ -1604,6 +1604,7 @@ github.com/stretchr/testify v1.7.2/go.mod h1:R6va5+xMeoiuVRoj+gSkQ7d3FALtqAAGI1F
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
 github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
 github.com/stretchr/testify v1.8.2/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
+github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
 github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsTg=
 github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 github.com/subosito/gotenv v1.2.0/go.mod h1:N0PQaV/YGNqwC0u51sEeR/aUtSLEXKX9iv69rRypqCw=
@@ -2035,6 +2036,7 @@ golang.org/x/sys v0.10.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.11.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.12.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.13.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.14.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
 golang.org/x/sys v0.15.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
 golang.org/x/sys v0.17.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
 golang.org/x/sys v0.20.0 h1:Od9JTbYCk261bKm4M/mw7AklTlFYIa0bIp9BgSm1S8Y=

--- a/ibm/service/kms/data_source_ibm_kms_kmip_object.go
+++ b/ibm/service/kms/data_source_ibm_kms_kmip_object.go
@@ -92,7 +92,7 @@ func DataSourceIBMKMSKMIPObject() *schema.Resource {
 		Type:         schema.TypeString,
 		Optional:     true,
 		Computed:     true,
-		Description:  "The id of the KMIP adapter that contains the cert",
+		Description:  "The id of the KMIP adapter that contains the kmip object",
 		ForceNew:     true,
 		ExactlyOneOf: []string{"adapter_id", "adapter_name"},
 	}
@@ -100,7 +100,7 @@ func DataSourceIBMKMSKMIPObject() *schema.Resource {
 		Type:         schema.TypeString,
 		Optional:     true,
 		Computed:     true,
-		Description:  "The name of the KMIP adapter that contains the cert",
+		Description:  "The name of the KMIP adapter that contains the kmip object",
 		ForceNew:     true,
 		ExactlyOneOf: []string{"adapter_id", "adapter_name"},
 	}

--- a/ibm/service/kms/resource_ibm_kms_key.go
+++ b/ibm/service/kms/resource_ibm_kms_key.go
@@ -281,9 +281,10 @@ func resourceIBMKmsKeyExists(d *schema.ResourceData, meta interface{}) (bool, er
 
 	_, err = kpAPI.GetKey(context.Background(), keyid)
 	if err != nil {
-		kpError := err.(*kp.Error)
-		if kpError.StatusCode == 404 {
-			return false, nil
+		if kpError, ok := err.(*kp.Error); ok {
+			if kpError.StatusCode == 404 {
+				return false, nil
+			}
 		}
 		return false, err
 	}
@@ -455,10 +456,11 @@ func populateSchemaData(d *schema.ResourceData, meta interface{}) (*kp.Client, e
 	ctx := context.Background()
 	key, err := kpAPI.GetKey(ctx, keyid)
 	if err != nil {
-		kpError := err.(*kp.Error)
-		if kpError.StatusCode == 404 || kpError.StatusCode == 409 {
-			d.SetId("")
-			return nil, nil
+		if kpError, ok := err.(*kp.Error); ok {
+			if kpError.StatusCode == 404 || kpError.StatusCode == 409 {
+				d.SetId("")
+				return nil, nil
+			}
 		}
 		return nil, fmt.Errorf("[ERROR] Get Key failed with error while reading Key: %s", err)
 	} else if key.State == 5 { //Refers to Deleted state of the Key

--- a/ibm/service/kms/resource_ibm_kms_key_alias.go
+++ b/ibm/service/kms/resource_ibm_kms_key_alias.go
@@ -98,10 +98,11 @@ func resourceIBMKmsKeyAliasRead(d *schema.ResourceData, meta interface{}) error 
 	}
 	key, err := kpAPI.GetKey(context.Background(), keyid)
 	if err != nil {
-		kpError := err.(*kp.Error)
-		if kpError.StatusCode == 404 || kpError.StatusCode == 409 {
-			d.SetId("")
-			return nil
+		if kpError, ok := err.(*kp.Error); ok {
+			if kpError.StatusCode == 404 || kpError.StatusCode == 409 {
+				d.SetId("")
+				return nil
+			}
 		}
 		return fmt.Errorf("[ERROR] Get Key failed with error while reading policies: %s", err)
 	} else if key.State == 5 { //Refers to Deleted state of the Key
@@ -129,12 +130,12 @@ func resourceIBMKmsKeyAliasDelete(d *schema.ResourceData, meta interface{}) erro
 	}
 	err1 := kpAPI.DeleteKeyAlias(context.Background(), id[0], keyid)
 	if err1 != nil {
-		kpError := err1.(*kp.Error)
-		if kpError.StatusCode == 404 {
-			return nil
-		} else {
-			return fmt.Errorf(" failed to Destroy alias with error: %s", err1)
+		if kpError, ok := err1.(*kp.Error); ok {
+			if kpError.StatusCode == 404 {
+				return nil
+			}
 		}
+		return fmt.Errorf(" failed to Destroy alias with error: %s", err1)
 	}
 	return nil
 }

--- a/ibm/service/kms/resource_ibm_kms_key_policies.go
+++ b/ibm/service/kms/resource_ibm_kms_key_policies.go
@@ -213,10 +213,11 @@ func resourceIBMKmsKeyPolicyRead(context context.Context, d *schema.ResourceData
 	}
 	key, err := kpAPI.GetKey(context, keyid)
 	if err != nil {
-		kpError := err.(*kp.Error)
-		if kpError.StatusCode == 404 || kpError.StatusCode == 409 {
-			d.SetId("")
-			return nil
+		if kpError, ok := err.(*kp.Error); ok {
+			if kpError.StatusCode == 404 || kpError.StatusCode == 409 {
+				d.SetId("")
+				return nil
+			}
 		}
 		return diag.Errorf("Get Key failed with error while reading policies: %s", err)
 	} else if key.State == 5 { //Refers to Deleted state of the Key

--- a/ibm/service/kms/resource_ibm_kms_key_rings.go
+++ b/ibm/service/kms/resource_ibm_kms_key_rings.go
@@ -123,10 +123,11 @@ func resourceIBMKmsKeyRingRead(d *schema.ResourceData, meta interface{}) error {
 	}
 	_, err = kpAPI.GetKeyRings(context.Background())
 	if err != nil {
-		kpError := err.(*kp.Error)
-		if kpError.StatusCode == 404 || kpError.StatusCode == 409 {
-			d.SetId("")
-			return nil
+		if kpError, ok := err.(*kp.Error); ok {
+			if kpError.StatusCode == 404 || kpError.StatusCode == 409 {
+				d.SetId("")
+				return nil
+			}
 		}
 		return fmt.Errorf("[ERROR] Get Key Rings failed with error: %s", err)
 	}
@@ -151,11 +152,10 @@ func resourceIBMKmsKeyRingDelete(d *schema.ResourceData, meta interface{}) error
 
 	err = kpAPI.DeleteKeyRing(context.Background(), id[0], kp.WithForce(true))
 	if err != nil {
-		kpError := err.(*kp.Error)
-		if kpError.StatusCode == 404 {
-			return nil
-		} else {
-			return fmt.Errorf(" failed to Destroy key ring with error: %s", err)
+		if kpError, ok := err.(*kp.Error); ok {
+			if kpError.StatusCode == 404 {
+				return nil
+			}
 		}
 	}
 	return nil

--- a/ibm/service/kms/resource_ibm_kms_kmip_client_cert.go
+++ b/ibm/service/kms/resource_ibm_kms_kmip_client_cert.go
@@ -158,9 +158,10 @@ func resourceIBMKmsKMIPClientCertExists(d *schema.ResourceData, meta interface{}
 	ctx := context.Background()
 	_, err = kpAPI.GetKMIPClientCertificate(ctx, adapterID, certID)
 	if err != nil {
-		kpError := err.(*kp.Error)
-		if kpError.StatusCode == 404 {
-			return false, nil
+		if kpError, ok := err.(*kp.Error); ok {
+			if kpError.StatusCode == 404 {
+				return false, nil
+			}
 		}
 		return false, wrapError(err, "Error checking KMIP Client Certificate existence")
 	}

--- a/ibm/service/kms/resource_ibm_kp_key.go
+++ b/ibm/service/kms/resource_ibm_kp_key.go
@@ -267,9 +267,10 @@ func resourceIBMKeyExists(d *schema.ResourceData, meta interface{}) (bool, error
 	// keyid := d.Id()
 	_, err = api.GetKey(context.Background(), keyid)
 	if err != nil {
-		kpError := err.(*kp.Error)
-		if kpError.StatusCode == 404 {
-			return false, nil
+		if kpError, ok := err.(*kp.Error); ok {
+			if kpError.StatusCode == 404 {
+				return false, nil
+			}
 		}
 		return false, err
 	}


### PR DESCRIPTION

Update kmip_adapter destroy behavior to force delete kmip_objects under the kmip_adapter to be destroyed. This will minimize scenarios where kmip_adapter parent resources cannot be destroyed to cleaned up due to failure to destroy kmip_adapter under parent resource.
Also updated areas of casting vars without validation (prevents potential panics)

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccXXX'
// See below
...
```
