### PR TITLE
Deprecated ibm_resource_access_tag and replaced it with ibm_iam_access_tag. Fixed 5566 too.

### DIFF
--- a/ibm/provider/provider.go
+++ b/ibm/provider/provider.go
@@ -1395,6 +1395,9 @@ func Provider() *schema.Provider {
 			"ibm_resource_tag":        globaltagging.ResourceIBMResourceTag(),
 			"ibm_resource_access_tag": globaltagging.ResourceIBMResourceAccessTag(),
 
+			// Added for Iam Access Tag
+			"ibm_iam_access_tag": globaltagging.ResourceIBMIamAccessTag(),
+
 			// Atracker
 			"ibm_atracker_target":   atracker.ResourceIBMAtrackerTarget(),
 			"ibm_atracker_route":    atracker.ResourceIBMAtrackerRoute(),
@@ -1863,6 +1866,7 @@ func Validator() validate.ValidatorDict {
 				"ibm_is_virtual_endpoint_gateway":         vpc.ResourceIBMISEndpointGatewayValidator(),
 				"ibm_resource_tag":                        globaltagging.ResourceIBMResourceTagValidator(),
 				"ibm_resource_access_tag":                 globaltagging.ResourceIBMResourceAccessTagValidator(),
+				"ibm_iam_access_tag":                      globaltagging.ResourceIBMIamAccessTagValidator(),
 				"ibm_satellite_location":                  satellite.ResourceIBMSatelliteLocationValidator(),
 				"ibm_satellite_cluster":                   satellite.ResourceIBMSatelliteClusterValidator(),
 				"ibm_pi_volume":                           power.ResourceIBMPIVolumeValidator(),

--- a/ibm/service/globaltagging/resource_ibm_iam_access_tag.go
+++ b/ibm/service/globaltagging/resource_ibm_iam_access_tag.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2017, 2021 All Rights Reserved.
+// Copyright IBM Corp. 2017, 2024 All Rights Reserved.
 // Licensed under the Mozilla Public License v2.0
 
 package globaltagging
@@ -15,11 +15,11 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
-func ResourceIBMResourceAccessTag() *schema.Resource {
+func ResourceIBMIamAccessTag() *schema.Resource {
 	return &schema.Resource{
-		Create:   resourceIBMResourceAccessTagCreate,
-		Read:     resourceIBMResourceAccessTagRead,
-		Delete:   resourceIBMResourceAccessTagDelete,
+		Create:   resourceIBMIamAccessTagCreate,
+		Read:     resourceIBMIamAccessTagRead,
+		Delete:   resourceIBMIamAccessTagDelete,
 		Importer: &schema.ResourceImporter{},
 
 		Schema: map[string]*schema.Schema{
@@ -28,7 +28,7 @@ func ResourceIBMResourceAccessTag() *schema.Resource {
 				Type:         schema.TypeString,
 				Required:     true,
 				ForceNew:     true,
-				ValidateFunc: validate.InvokeValidator("ibm_resource_access_tag", "name"),
+				ValidateFunc: validate.InvokeValidator("ibm_iam_access_tag", "name"),
 				Set:          flex.ResourceIBMVPCHash,
 				Description:  "Name of the access tag",
 			},
@@ -38,11 +38,10 @@ func ResourceIBMResourceAccessTag() *schema.Resource {
 				Description: "Type of the tag(access)",
 			},
 		},
-		DeprecationMessage: "ibm_resource_access_tag has been deprecated. Use ibm_iam_access_tag instead.",
 	}
 }
 
-func ResourceIBMResourceAccessTagValidator() *validate.ResourceValidator {
+func ResourceIBMIamAccessTagValidator() *validate.ResourceValidator {
 
 	validateSchema := make([]validate.ValidateSchema, 0)
 
@@ -56,11 +55,11 @@ func ResourceIBMResourceAccessTagValidator() *validate.ResourceValidator {
 			MinValueLength:             1,
 			MaxValueLength:             128})
 
-	ibmResourceAccessTagValidator := validate.ResourceValidator{ResourceName: "ibm_resource_access_tag", Schema: validateSchema}
-	return &ibmResourceAccessTagValidator
+	ibmIamAccessTagValidator := validate.ResourceValidator{ResourceName: "ibm_iam_access_tag", Schema: validateSchema}
+	return &ibmIamAccessTagValidator
 }
 
-func resourceIBMResourceAccessTagCreate(d *schema.ResourceData, meta interface{}) error {
+func resourceIBMIamAccessTagCreate(d *schema.ResourceData, meta interface{}) error {
 
 	gtClient, err := meta.(conns.ClientSession).GlobalTaggingAPIv1()
 	if err != nil {
@@ -99,7 +98,7 @@ func resourceIBMResourceAccessTagCreate(d *schema.ResourceData, meta interface{}
 	return nil
 }
 
-func resourceIBMResourceAccessTagRead(d *schema.ResourceData, meta interface{}) error {
+func resourceIBMIamAccessTagRead(d *schema.ResourceData, meta interface{}) error {
 	tagName := d.Id()
 	gtClient, err := meta.(conns.ClientSession).GlobalTaggingAPIv1()
 	if err != nil {
@@ -128,7 +127,7 @@ func resourceIBMResourceAccessTagRead(d *schema.ResourceData, meta interface{}) 
 	return nil
 }
 
-func resourceIBMResourceAccessTagDelete(d *schema.ResourceData, meta interface{}) error {
+func resourceIBMIamAccessTagDelete(d *schema.ResourceData, meta interface{}) error {
 
 	gtClient, err := meta.(conns.ClientSession).GlobalTaggingAPIv1()
 	if err != nil {

--- a/ibm/service/globaltagging/resource_ibm_iam_access_tag_test.go
+++ b/ibm/service/globaltagging/resource_ibm_iam_access_tag_test.go
@@ -124,14 +124,14 @@ func testAccCheckIamAccessTagExists(n string) resource.TestCheckFunc {
 
 func testAccCheckIamAccessTagCreate(name string) string {
 	return fmt.Sprintf(`
-	resource ibm_iam_access_tag tag {
+	resource "ibm_iam_access_tag" "tag" {
 		name = "%s"
 	  }
 `, name)
 }
 func testAccCheckIamAccessTagUsage(name, sshkeyname, publicKey string) string {
 	return fmt.Sprintf(`
-	resource ibm_iam_access_tag tag {
+	resource "ibm_iam_access_tag" "tag" {
 		name = "%s"
 	}
 	resource "ibm_is_ssh_key" "key" {

--- a/ibm/service/globaltagging/resource_ibm_iam_access_tag_test.go
+++ b/ibm/service/globaltagging/resource_ibm_iam_access_tag_test.go
@@ -69,9 +69,10 @@ ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCKVmnMOlHKcZK8tpt3MP1lqOLAcqcJzhsvJcjscgVE
 					resource.TestCheckResourceAttr("ibm_iam_access_tag.tag", "id", name),
 					resource.TestCheckResourceAttr("ibm_iam_access_tag.tag", "name", name),
 					resource.TestCheckResourceAttr("ibm_iam_access_tag.tag", "tag_type", "access"),
-					resource.TestCheckResourceAttr("ibm_is_ssh_key.key", "name", sshkeyname),
-					resource.TestCheckResourceAttrSet("ibm_is_ssh_key.key", "access_tags.#"),
-					resource.TestCheckResourceAttr("ibm_is_ssh_key.key", "access_tags.0", name),
+					testAccCheckResourceTagExists("ibm_resource_tag.tag"),
+					resource.TestCheckResourceAttr("ibm_resource_tag.tag", "tags.#", "1"),
+					resource.TestCheckResourceAttr("ibm_resource_tag.tag", "tags.0", name),
+					resource.TestCheckResourceAttr("ibm_resource_tag.tag", "tag_type", "access"),
 				),
 			},
 		},
@@ -136,7 +137,11 @@ func testAccCheckIamAccessTagUsage(name, sshkeyname, publicKey string) string {
 	resource "ibm_is_ssh_key" "key" {
 		name = "%s"
 		public_key = "%s"
-		access_tags = [ibm_iam_access_tag.tag.name]
+	}
+	resource "ibm_resource_tag" "tag" {
+		resource_id = ibm_is_ssh_key.key.crn
+		tags        = [ibm_iam_access_tag.tag.name]
+		tag_type	= "access"
 	}
 `, name, sshkeyname, publicKey)
 }

--- a/ibm/service/globaltagging/resource_ibm_iam_access_tag_test.go
+++ b/ibm/service/globaltagging/resource_ibm_iam_access_tag_test.go
@@ -1,0 +1,142 @@
+// Copyright IBM Corp. 2017, 2024 All Rights Reserved.
+// Licensed under the Mozilla Public License v2.0
+
+package globaltagging_test
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+	"testing"
+
+	acc "github.com/IBM-Cloud/terraform-provider-ibm/ibm/acctest"
+	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/conns"
+	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/flex"
+	"github.com/IBM/platform-services-go-sdk/globaltaggingv1"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+)
+
+const (
+	iamAccessTagRegex = "^([A-Za-z0-9_.-]|[A-Za-z0-9_.-][A-Za-z0-9_ .-]*[A-Za-z0-9_.-]):([A-Za-z0-9_.-]|[A-Za-z0-9_.-][A-Za-z0-9_ .-]*[A-Za-z0-9_.-])$"
+)
+
+func TestAccIamAccessTag_Basic(t *testing.T) {
+	name := fmt.Sprintf("tf%d:iam-access%d", acctest.RandIntRange(10, 100), acctest.RandIntRange(10, 100))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { acc.TestAccPreCheck(t) },
+		Providers: acc.TestAccProviders,
+		Steps: []resource.TestStep{
+
+			resource.TestStep{
+				Config: testAccCheckIamAccessTagCreate(name),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckIamAccessTagExists("ibm_iam_access_tag.tag"),
+					resource.TestCheckResourceAttr("ibm_iam_access_tag.tag", "id", name),
+					resource.TestCheckResourceAttr("ibm_iam_access_tag.tag", "name", name),
+					resource.TestCheckResourceAttr("ibm_iam_access_tag.tag", "tag_type", "access"),
+				),
+			},
+		},
+	})
+}
+func TestAccIamAccessTag_Usage(t *testing.T) {
+	name := fmt.Sprintf("tf%d:iam-access%d", acctest.RandIntRange(10, 100), acctest.RandIntRange(10, 100))
+	publicKey := strings.TrimSpace(`
+ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCKVmnMOlHKcZK8tpt3MP1lqOLAcqcJzhsvJcjscgVERRN7/9484SOBJ3HSKxxNG5JN8owAjy5f9yYwcUg+JaUVuytn5Pv3aeYROHGGg+5G346xaq3DAwX6Y5ykr2fvjObgncQBnuU5KHWCECO/4h8uWuwh/kfniXPVjFToc+gnkqA+3RKpAecZhFXwfalQ9mMuYGFxn+fwn8cYEApsJbsEmb0iJwPiZ5hjFC8wREuiTlhPHDgkBLOiycd20op2nXzDbHfCHInquEe/gYxEitALONxm0swBOwJZwlTDOB7C6y2dzlrtxr1L59m7pCkWI4EtTRLvleehBoj3u7jB4usR
+`)
+	sshkeyname := fmt.Sprintf("tfssh-createname-%d", acctest.RandIntRange(10, 100))
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { acc.TestAccPreCheck(t) },
+		Providers: acc.TestAccProviders,
+		Steps: []resource.TestStep{
+
+			resource.TestStep{
+				Config: testAccCheckIamAccessTagCreate(name),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckIamAccessTagExists("ibm_iam_access_tag.tag"),
+					resource.TestCheckResourceAttr("ibm_iam_access_tag.tag", "id", name),
+					resource.TestCheckResourceAttr("ibm_iam_access_tag.tag", "name", name),
+					resource.TestCheckResourceAttr("ibm_iam_access_tag.tag", "tag_type", "access"),
+				),
+			},
+			resource.TestStep{
+				Config: testAccCheckIamAccessTagUsage(name, sshkeyname, publicKey),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckIamAccessTagExists("ibm_iam_access_tag.tag"),
+					resource.TestCheckResourceAttr("ibm_iam_access_tag.tag", "id", name),
+					resource.TestCheckResourceAttr("ibm_iam_access_tag.tag", "name", name),
+					resource.TestCheckResourceAttr("ibm_iam_access_tag.tag", "tag_type", "access"),
+					resource.TestCheckResourceAttr("ibm_is_ssh_key.key", "name", sshkeyname),
+					resource.TestCheckResourceAttrSet("ibm_is_ssh_key.key", "access_tags.#"),
+					resource.TestCheckResourceAttr("ibm_is_ssh_key.key", "access_tags.0", name),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckIamAccessTagExists(n string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		var tagName string
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+
+		iamAccessTagRegex, err := regexp.Compile(iamAccessTagRegex)
+		if err != nil {
+			return err
+		}
+
+		if iamAccessTagRegex.MatchString(rs.Primary.ID) {
+			tagName = rs.Primary.ID
+		}
+
+		gtClient, err := acc.TestAccProvider.Meta().(conns.ClientSession).GlobalTaggingAPIv1()
+		if err != nil {
+			return fmt.Errorf("Error getting global tagging client settings: %s", err)
+		}
+		accessTagType := "access"
+		listTagsOptions := &globaltaggingv1.ListTagsOptions{
+			TagType: &accessTagType,
+		}
+		taggingResult, _, err := gtClient.ListTags(listTagsOptions)
+		if err != nil {
+			return err
+		}
+
+		var taglist []string
+		for _, item := range taggingResult.Items {
+			taglist = append(taglist, *item.Name)
+		}
+		existingAccessTags := flex.NewStringSet(flex.ResourceIBMVPCHash, taglist)
+		if !existingAccessTags.Contains(tagName) {
+			return fmt.Errorf(
+				"Error on get of resource tags (%s) : %s", tagName, err)
+		}
+		return nil
+	}
+}
+
+func testAccCheckIamAccessTagCreate(name string) string {
+	return fmt.Sprintf(`
+	resource ibm_iam_access_tag tag {
+		name = "%s"
+	  }
+`, name)
+}
+func testAccCheckIamAccessTagUsage(name, sshkeyname, publicKey string) string {
+	return fmt.Sprintf(`
+	resource ibm_iam_access_tag tag {
+		name = "%s"
+	}
+	resource "ibm_is_ssh_key" "key" {
+		name = "%s"
+		public_key = "%s"
+		access_tags = [ibm_iam_access_tag.tag.name]
+	}
+`, name, sshkeyname, publicKey)
+}

--- a/ibm/service/globaltagging/resource_ibm_resource_tag.go
+++ b/ibm/service/globaltagging/resource_ibm_resource_tag.go
@@ -304,6 +304,12 @@ func resourceIBMResourceTagDelete(d *schema.ResourceData, meta interface{}) erro
 	for i, v := range removeTags.List() {
 		remove[i] = fmt.Sprint(v)
 	}
+	var tType string
+	if v, ok := d.GetOk(tagType); ok && v != nil {
+		tType = v.(string)
+	} else {
+		tType = "user"
+	}
 
 	if len(remove) > 0 {
 		resources := []globaltaggingv1.Resource{}
@@ -313,6 +319,7 @@ func resourceIBMResourceTagDelete(d *schema.ResourceData, meta interface{}) erro
 		detachTagOptions := &globaltaggingv1.DetachTagOptions{
 			Resources: resources,
 			TagNames:  remove,
+			TagType:   &tType,
 		}
 
 		_, resp, err := gtClient.DetachTag(detachTagOptions)

--- a/website/docs/r/iam_access_tag.html.markdown
+++ b/website/docs/r/iam_access_tag.html.markdown
@@ -1,0 +1,66 @@
+---
+subcategory: "Global Tagging"
+layout: "ibm"
+page_title: "IBM : iam_access_tag"
+description: |-
+  Manages iam access tags.
+---
+
+# ibm_iam_access_tag
+
+Create or delete IBM Cloud access management tags. For more information, about access tags, see [IBM Cloud access management tags](https://cloud.ibm.com/apidocs/tagging#create-tag).
+
+
+## Example usage
+The following example enables you to create access management tags
+
+```terraform
+resource "ibm_iam_access_tag" "example" {
+	name        = "example:tag"
+}
+
+```
+
+## Argument reference
+Review the argument references that you can specify for your resource.
+
+- `name` - (Required, String) The name of the access management tag.
+
+
+## Attributes reference
+In addition to all argument reference list, you can access the following attribute reference after your resource is created.
+
+- `id` - (String) The unique identifier of the access tag. Same as `name`.
+- `tag_type` - (String) Type of the tag(`access`)
+
+
+## Import
+
+The `ibm_iam_access_tag` resource can be imported by using the resource CRN.
+
+**Syntax**
+
+```
+$ terraform import ibm_iam_access_tag.tag tag_name
+```
+
+**Example**
+
+```
+$ terraform import ibm_iam_access_tag.tag crn:v1:bluemix:public:satellite:us-east:a/ab3ed67929c2a81285fbb5f9eb22800a:c1ga7h9w0angomd44654::
+
+```
+
+Example for importing access tags.
+
+**Syntax**
+
+```
+$ terraform import ibm_iam_access_tag.tag tag_name
+```
+
+**Example**
+
+```
+$ terraform import ibm_iam_access_tag.tag example:test
+```

--- a/website/docs/r/resource_access_tag.html.markdown
+++ b/website/docs/r/resource_access_tag.html.markdown
@@ -8,6 +8,9 @@ description: |-
 
 # ibm_resource_access_tag
 
+  ~>**Deprecated:**
+  The ability to use the ibm_resource_access_tag resource to create or delete IBM Cloud access management tags in Terraform has been removed in favor of a dedicated ibm_iam_access_tag resource. For more information, check out [here](https://registry.terraform.io/providers/IBM-Cloud/ibm/latest/docs/resources/iam_access_tag)
+
 Create, update, or delete IBM Cloud access management tags. For more information, about tagging, see [IBM Cloud access management tags](https://cloud.ibm.com/apidocs/tagging#create-tag).
 
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/IBM-Cloud/terraform-provider-ibm/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #5566
Relates OR Closes #5522

This PR addresses https://github.com/IBM-Cloud/terraform-provider-ibm/issues/5522 and https://github.com/IBM-Cloud/terraform-provider-ibm/issues/5566

The `ibm_resource_access_tag` terraform resource has been deprecated and replaced with the `ibm_iam_access_tag` terraform resource. We just renamed it with the new name following the decision here: https://github.com/IBM-Cloud/terraform-provider-ibm/issues/5522#issuecomment-2286819650

With this PR we fixed the https://github.com/IBM-Cloud/terraform-provider-ibm/issues/5566 too.
Reworked the tests in order to use a resource that requires less time to be provisioned.

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

Test about the fix in the `ibm_resource_tag` terraform resource about https://github.com/IBM-Cloud/terraform-provider-ibm/issues/5566
```
make testacc TEST=./ibm/service/globaltagging TESTARGS='-run=TestAccResourceTag_Basic -count=1'
=== RUN   TestAccResourceTag_Basic
--- PASS: TestAccResourceTag_Basic (76.64s)
PASS
ok      github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/globaltagging   78.420s

make testacc TEST=./ibm/service/globaltagging TESTARGS='-run=TestAccResourceTag_Wait -count=1'
=== RUN   TestAccResourceTag_Wait
--- PASS: TestAccResourceTag_Wait (70.54s)
PASS
ok      github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/globaltagging   72.340s

make testacc TEST=./ibm/service/globaltagging TESTARGS='-run=TestAccResourceTag_replace_Basic -count=1'
=== RUN   TestAccResourceTag_replace_Basic
--- PASS: TestAccResourceTag_replace_Basic (76.12s)
PASS
ok      github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/globaltagging   77.636s
...
```

Test about the `ibm_iam_access_tag` terraform resource:
```
make testacc TEST=./ibm/service/globaltagging TESTARGS='-run=TestAccIamAccessTag_Basic -count=1''
=== RUN   TestAccIamAccessTag_Basic
--- PASS: TestAccIamAccessTag_Basic (30.05s)
PASS
ok      github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/globaltagging   31.540s

make testacc TEST=./ibm/service/globaltagging  TESTARGS='-run=TestAccIamAccessTag_Usage -count=1'
=== RUN   TestAccIamAccessTag_Usage
--- PASS: TestAccIamAccessTag_Usage (101.26s)
PASS
ok      github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/globaltagging   102.753s
```

We used the `-count=1` flag to avoid the usage of the case.

