### PR TITLE
fix code engine secret update data mapping #5582

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "go.mod|go.sum|.*.map|^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2024-08-22T12:30:44Z",
+  "generated_at": "2024-08-27T13:07:20Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -4988,7 +4988,7 @@
       }
     ]
   },
-  "version": "0.13.1+ibm.62.dss",
+  "version": "0.13.1+ibm.61.dss",
   "word_list": {
     "file": null,
     "hash": null

--- a/ibm/service/codeengine/resource_ibm_code_engine_secret.go
+++ b/ibm/service/codeengine/resource_ibm_code_engine_secret.go
@@ -434,6 +434,7 @@ func resourceIbmCodeEngineSecretUpdate(context context.Context, d *schema.Resour
 
 	replaceSecretOptions.SetProjectID(parts[0])
 	replaceSecretOptions.SetName(parts[1])
+	replaceSecretOptions.SetFormat(d.Get("format").(string))
 
 	hasChange := false
 
@@ -450,7 +451,7 @@ func resourceIbmCodeEngineSecretUpdate(context context.Context, d *schema.Resour
 		return tfErr.GetDiag()
 	}
 	if d.HasChange("data") {
-		data, err := resourceIbmCodeEngineSecretMapToSecretData(d.Get("data.0").(map[string]interface{}))
+		data, err := resourceIbmCodeEngineSecretMapToSecretData(d.Get("data").(map[string]interface{}))
 		if err != nil {
 			return diag.FromErr(err)
 		}


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/IBM-Cloud/terraform-provider-ibm/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #5582

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccIbmCodeEngineSecretGeneric'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test $(go list ./... |grep -v 'vendor') -v -run=TestAccIbmCodeEngineSecretGeneric -timeout 700m
=== RUN   -run=TestAccIbmCodeEngineSecretGeneric
--- PASS: -run=TestAccIbmCodeEngineSecretGeneric (23.76s)
PASS
ok      github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/codeengine      33.461s
```

```
$ make testacc TESTARGS='-run=TestAccIbmCodeEngineSecretGeneric'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test $(go list ./... |grep -v 'vendor') -v -run=TestAccIbmCodeEngineSecretGeneric -timeout 700m
=== RUN   -run=TestAccIbmCodeEngineSecretGeneric
--- PASS: -run=TestAccIbmCodeEngineSecretGeneric (27.73s)
PASS
ok      github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/codeengine      37.345s
```

```
$ make testacc TESTARGS='-run=TestAccIbmCodeEngineSecretRegistry'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test $(go list ./... |grep -v 'vendor') -v -run=TestAccIbmCodeEngineSecretRegistry -timeout 700m
=== RUN   -run=TestAccIbmCodeEngineSecretRegistry
--- PASS: -run=TestAccIbmCodeEngineSecretRegistry (21.35s)
PASS
ok      github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/codeengine      30.852s
```

```
$ make testacc TESTARGS='-run=TestAccIbmCodeEngineSecretSSHAuth'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test $(go list ./... |grep -v 'vendor') -v -run=TestAccIbmCodeEngineSecretSSHAuth -timeout 700m
=== RUN   -run=TestAccIbmCodeEngineSecretSSHAuth
--- PASS: -run=TestAccIbmCodeEngineSecretSSHAuth (27.91s)
PASS
ok      github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/codeengine      37.517s
```

```
$ make testacc TESTARGS='-run=TestAccIbmCodeEngineSecretDataSourceGeneric'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test $(go list ./... |grep -v 'vendor') -v -run=TestAccIbmCodeEngineSecretDataSourceGeneric -timeout 700m
=== RUN   TestAccIbmCodeEngineSecretDataSourceGeneric
--- PASS: TestAccIbmCodeEngineSecretDataSourceGeneric (11.57s)
PASS
ok      github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/codeengine      (cached)
```

```
$ make testacc TESTARGS='-run=TestAccIbmCodeEngineSecretDataSourceRegistry'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test $(go list ./... |grep -v 'vendor') -v -run=TestAccIbmCodeEngineSecretDataSourceRegistry -timeout 700m
=== RUN   -run=TestAccIbmCodeEngineSecretDataSourceRegistry
--- PASS: -run=TestAccIbmCodeEngineSecretDataSourceRegistry (11.03s)
PASS
ok      github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/codeengine      21.741s
```

```
$ make testacc TESTARGS='-run=TestAccIbmCodeEngineSecretDataSourceSSHAuth'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test $(go list ./... |grep -v 'vendor') -v -run=TestAccIbmCodeEngineSecretDataSourceSSHAuth -timeout 700m
=== RUN   -run=TestAccIbmCodeEngineSecretDataSourceSSHAuth
--- PASS: -run=TestAccIbmCodeEngineSecretDataSourceSSHAuth (13.70s)
PASS
ok      github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/codeengine      23.342s
```

```
$ make testacc TESTARGS='-run=TestAccIbmCodeEngineSecretDataSourceBasicAuth'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test $(go list ./... |grep -v 'vendor') -v -run=TestAccIbmCodeEngineSecretDataSourceBasicAuth -timeout 700m
=== RUN   TestAccIbmCodeEngineSecretDataSourceBasicAuth
--- PASS: TestAccIbmCodeEngineSecretDataSourceBasicAuth (12.06s)
PASS
ok      github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/codeengine      21.382s
```

