### PR TITLE
add service_to_service_enabled field to atracker event streams endpoint

### DIFF
--- a/examples/ibm-atracker/main.tf
+++ b/examples/ibm-atracker/main.tf
@@ -33,6 +33,7 @@ resource "ibm_atracker_target" atracker_target_eventstreams_instance {
     brokers = [ "kafka-x:9094" ]
     topic = "my-topic"
     api_key = "xxxxxxxxxxxxxx"
+    service_to_service_enabled = false
   }
   region = var.atracker_target_region
 }

--- a/go.mod
+++ b/go.mod
@@ -30,7 +30,7 @@ require (
 	github.com/IBM/logs-router-go-sdk v1.0.3
 	github.com/IBM/mqcloud-go-sdk v0.1.0
 	github.com/IBM/networking-go-sdk v0.49.0
-	github.com/IBM/platform-services-go-sdk v0.67.0
+	github.com/IBM/platform-services-go-sdk v0.68.1
 	github.com/IBM/project-go-sdk v0.3.5
 	github.com/IBM/push-notifications-go-sdk v0.0.0-20210310100607-5790b96c47f5
 	github.com/IBM/sarama v1.41.2

--- a/go.sum
+++ b/go.sum
@@ -173,8 +173,8 @@ github.com/IBM/mqcloud-go-sdk v0.1.0 h1:fWt4uisg5GbbsfNmAxx5/6c5gQIPM+VrEsTtnimE
 github.com/IBM/mqcloud-go-sdk v0.1.0/go.mod h1:LesMQlKHXvdks4jqQLZH7HfATY5lvTzHuwQU5+y7b2g=
 github.com/IBM/networking-go-sdk v0.49.0 h1:lPS34u3C0JVrbxH+Ulua76Nwl6Frv8BEfq6LRkyvOv0=
 github.com/IBM/networking-go-sdk v0.49.0/go.mod h1:G9CKbmPE8gSLjN+ABh4hIZ1bMx076enl5Eekvj6zQnA=
-github.com/IBM/platform-services-go-sdk v0.67.0 h1:AGu3NiCUyvyFUqbgtmsFRh74kyXrmNbSu1yG/qwGLIM=
-github.com/IBM/platform-services-go-sdk v0.67.0/go.mod h1:6rYd3stLSnotYmZlxclw45EJPaQuLmh5f7c+Mg7rOg4=
+github.com/IBM/platform-services-go-sdk v0.68.1 h1:RXGzEmdllzSj5OzCJO7AoTeQ+cgTTNa20CrrpLQe5KQ=
+github.com/IBM/platform-services-go-sdk v0.68.1/go.mod h1:6rYd3stLSnotYmZlxclw45EJPaQuLmh5f7c+Mg7rOg4=
 github.com/IBM/project-go-sdk v0.3.5 h1:L+YClFUa14foS0B/hOOY9n7sIdsT5/XQicnXOyJSpyM=
 github.com/IBM/project-go-sdk v0.3.5/go.mod h1:FOJM9ihQV3EEAY6YigcWiTNfVCThtdY8bLC/nhQHFvo=
 github.com/IBM/push-notifications-go-sdk v0.0.0-20210310100607-5790b96c47f5 h1:NPUhkoOCRuv3OFWt19PmwjXGGTKlvmbuPg9fUrBUNe4=

--- a/ibm/service/atracker/data_source_ibm_atracker_targets.go
+++ b/ibm/service/atracker/data_source_ibm_atracker_targets.go
@@ -98,7 +98,7 @@ func DataSourceIBMAtrackerTargets() *schema.Resource {
 									"service_to_service_enabled": {
 										Type:        schema.TypeBool,
 										Computed:    true,
-										Description: "ATracker service is enabled to support service to service authentication. If service to service is enabled then set this flag is true and do not supply apikey.",
+										Description: "Determines if IBM Cloud Activity Tracker Event Routing has service to service authentication enabled. Set this flag to true if service to service is enabled and do not supply an apikey.",
 									},
 								},
 							},
@@ -151,7 +151,12 @@ func DataSourceIBMAtrackerTargets() *schema.Resource {
 										Type:        schema.TypeString,
 										Computed:    true,
 										Sensitive:   true,
-										Description: "The user password (api key) for the message hub topic in the Event Streams instance.",
+										Description: "The user password (api key) for the message hub topic in the Event Streams instance. This is required if service_to_service is not enabled.",
+									},
+									"service_to_service_enabled": &schema.Schema{
+										Type:        schema.TypeBool,
+										Computed:    true,
+										Description: "Determines if IBM Cloud Activity Tracker Event Routing has service to service authentication enabled. Set this flag to true if service to service is enabled and do not supply an apikey.",
 									},
 								},
 							},
@@ -420,6 +425,9 @@ func DataSourceIBMAtrackerTargetsEventstreamsEndpointToMap(model *atrackerv2.Eve
 	}
 	if model.APIKey != nil {
 		modelMap["api_key"] = *model.APIKey // pragma: allowlist secret
+	}
+	if model.ServiceToServiceEnabled != nil {
+		modelMap["service_to_service_enabled"] = *model.ServiceToServiceEnabled
 	}
 	return modelMap, nil
 }

--- a/ibm/service/atracker/data_source_ibm_atracker_targets_test.go
+++ b/ibm/service/atracker/data_source_ibm_atracker_targets_test.go
@@ -106,6 +106,7 @@ func testAccCheckIBMAtrackerTargetsDataSourceConfig(targetName string, targetTar
 				brokers = [ "kafka-x:9094" ]
 				topic = "my-topic"
 				api_key = "%s" // pragma: allowlist secret
+				service_to_service_enabled = false
 			}
 			cloudlogs_endpoint {
 				target_crn = "crn:v1:bluemix:public:logs:eu-es:a/11111111111111111111111111111111:22222222-2222-2222-2222-222222222222::"

--- a/website/docs/d/atracker_targets.html.markdown
+++ b/website/docs/d/atracker_targets.html.markdown
@@ -46,7 +46,7 @@ Nested scheme for **targets**:
 		  * Constraints: The maximum length is `1000` characters. The minimum length is `3` characters. The value must match regular expression `/^[a-zA-Z0-9 -._:\/]+$/`.
 		* `endpoint` - (String) The host name of the Cloud Object Storage endpoint.
 		  * Constraints: The maximum length is `1000` characters. The minimum length is `3` characters. The value must match regular expression `/^[a-zA-Z0-9 -._:]+$/`.
-		* `service_to_service_enabled` - (Boolean) ATracker service is enabled to support service to service authentication. If service to service is enabled then set this flag is true and do not supply apikey.
+		* `service_to_service_enabled` - (Boolean) Determines if IBM Cloud Activity Tracker Event Routing has service to service authentication enabled. Set this flag to true if service to service is enabled and do not supply an apikey.
 		* `target_crn` - (String) The CRN of the Cloud Object Storage instance.
 		  * Constraints: The maximum length is `1000` characters. The minimum length is `3` characters. The value must match regular expression `/^[a-zA-Z0-9 -._:\/]+$/`.
 	* `logdna_endpoint` - (List) Property values for a LogDNA Endpoint.
@@ -57,12 +57,13 @@ Nested scheme for **targets**:
 		  * Constraints: The maximum length is `1000` characters. The minimum length is `3` characters. The value must match regular expression `/^[a-zA-Z0-9 -._:\/]+$/`.
 	* `eventstreams_endpoint` - (List) Property values for Event streams Endpoint.
 	Nested scheme for **eventstreams_endpoint**:
-		* `api_key` - (String) The IAM API key that has access to the Event streams instance.
+		* `api_key` - (String) The user password (api key) for the message hub topic in the Event Streams instance. This is required if service_to_service is not enabled..
 			* Constraints: The maximum length is `1000` characters. The minimum length is `3` characters. The value must match regular expression `/^[a-zA-Z0-9 -._:]+$/`.
 		* `topic` - (String) The topic name defined under the Event streams instance.
 			* Constraints: The maximum length is `1000` characters. The minimum length is `3` characters. The value must match regular expression `/^[a-zA-Z0-9 -._:\/]+$/`.
 		* `brokers` - (List) The list of brokers defined under the Event streams instance and used in the event streams endpoint.
 			* Constraints: The list items must match regular expression `/^[a-zA-Z0-9 -._:]+$/`.
+		* `service_to_service_enabled` - (Boolean) Determines if IBM Cloud Activity Tracker Event Routing has service to service authentication enabled. Set this flag to true if service to service is enabled and do not supply an apikey.
 		* `target_crn` - (String) The CRN of the Event streams instance.
 			* Constraints: The maximum length is `1000` characters. The minimum length is `3` characters. The value must match regular expression `/^[a-zA-Z0-9 -._:\/]+$/`.
 	* `cloudlogs_endpoint` - (List) Property values for an IBM Cloud Logs endpoint.

--- a/website/docs/r/atracker_target.html.markdown
+++ b/website/docs/r/atracker_target.html.markdown
@@ -70,7 +70,7 @@ Nested scheme for **cos_endpoint**:
 	  * Constraints: The maximum length is `1000` characters. The minimum length is `3` characters. The value must match regular expression `/^[a-zA-Z0-9 -._:\/]+$/`.
 	* `endpoint` - (Required, String) The host name of the Cloud Object Storage endpoint.
 	  * Constraints: The maximum length is `1000` characters. The minimum length is `3` characters. The value must match regular expression `/^[a-zA-Z0-9 -._:]+$/`.
-	* `service_to_service_enabled` - (Optional, Boolean) ATracker service is enabled to support service to service authentication. If service to service is enabled then set this flag is true and do not supply apikey.
+	* `service_to_service_enabled` - (Optional, Boolean) Determines if IBM Cloud Activity Tracker Event Routing has service to service authentication enabled. Set this flag to true if service to service is enabled and do not supply an apikey.
 	* `target_crn` - (Required, String) The CRN of the Cloud Object Storage instance.
 	  * Constraints: The maximum length is `1000` characters. The minimum length is `3` characters. The value must match regular expression `/^[a-zA-Z0-9 -._:\/]+$/`.
 * `logdna_endpoint` - (Optional, List) Property values for a LogDNA Endpoint.
@@ -81,12 +81,13 @@ Nested scheme for **logdna_endpoint**:
 	  * Constraints: The maximum length is `1000` characters. The minimum length is `3` characters. The value must match regular expression `/^[a-zA-Z0-9 -._:\/]+$/`.
 * `eventstreams_endpoint` - (List) Property values for Event streams Endpoint.
 Nested scheme for **eventstreams_endpoint**:
-  * `api_key` - (String) The IAM API key that has access to the Event streams instance.
+  * `api_key` - (String) The user password (api key) for the message hub topic in the Event Streams instance. This is required if service_to_service is not enabled. .
     * Constraints: The maximum length is `1000` characters. The minimum length is `3` characters. The value must match regular expression `/^[a-zA-Z0-9 -._:]+$/`.
   * `topic` - (String) The topic name defined under the Event streams instance.
     * Constraints: The maximum length is `1000` characters. The minimum length is `3` characters. The value must match regular expression `/^[a-zA-Z0-9 -._:\/]+$/`.
   * `brokers` - (List) The list of brokers defined under the Event streams instance and used in the event streams endpoint.
     * Constraints: The list items must match regular expression `/^[a-zA-Z0-9 -._:]+$/`.
+	* `service_to_service_enabled` - (Optional, Boolean) Determines if IBM Cloud Activity Tracker Event Routing has service to service authentication enabled. Set this flag to true if service to service is enabled and do not supply an apikey.
   * `target_crn` - (String) The CRN of the Event streams instance.
     * Constraints: The maximum length is `1000` characters. The minimum length is `3` characters. The value must match regular expression `/^[a-zA-Z0-9 -._:\/]+$/`.
 * `cloudlogs_endpoint` - (Optional, List) Property Values for IBM Cloud Logs Endpoint.


### PR DESCRIPTION
### What has been done?
Add service to service authentication for atracker to message hub through the new boolean field service_to_service_enabled in atracker event streams endpoint.

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccXXX'
Helens-IBM:terraform-provider-ibm.helenxu1221 helenxu$ make fmt && make testacc TEST=./ibm/service/atracker TESTARGS='-run=TestAccIBMAtracker.*' gofmt -w $(find .  -path ./.direnv -prune -false -o -name '*.go' |grep -v vendor)
gofmt -w $(find .  -path ./.direnv -prune -false -o -name '*.go' |grep -v vendor)
make: Entering directory `/Users/helenxu/go/src/github.com/IBM-Cloud/terraform-provider-ibm.helenxu1221'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./ibm/service/atracker -v -run=TestAccIBMAtracker.* -timeout 700m
[WARN] Set the environment variable IBM_PROJECTS_CONFIG_APIKEY for testing IBM Projects Config resources, the tests will fail if this is not set
[WARN] Set the environment variable IBM_APPID_TENANT_ID for testing AppID resources, AppID tests will fail if this is not set
[WARN] Set the environment variable IBM_APPID_TEST_USER_EMAIL for testing AppID user resources, the tests will fail if this is not set
...
=== RUN   TestAccIBMAtrackerRoutesDataSourceBasic
--- PASS: TestAccIBMAtrackerRoutesDataSourceBasic (19.10s)
=== RUN   TestAccIBMAtrackerTargetsDataSourceBasic
--- PASS: TestAccIBMAtrackerTargetsDataSourceBasic (15.46s)
=== RUN   TestAccIBMAtrackerTargetsDataSourceAllArgs
--- PASS: TestAccIBMAtrackerTargetsDataSourceAllArgs (16.70s)
=== RUN   TestAccIBMAtrackerRouteBasic
--- PASS: TestAccIBMAtrackerRouteBasic (28.16s)
=== RUN   TestAccIBMAtrackerRouteBasicMultipleRules
--- PASS: TestAccIBMAtrackerRouteBasicMultipleRules (28.08s)
=== RUN   TestAccIBMAtrackerSettingsBasic
--- PASS: TestAccIBMAtrackerSettingsBasic (16.07s)
=== RUN   TestAccIBMAtrackerTargetBasic
--- PASS: TestAccIBMAtrackerTargetBasic (29.82s)
PASS
ok  	github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/atracker	155.104s
make: *** No rule to make target `gofmt'.  Stop.
make: Leaving directory `/Users/helenxu/go/src/github.com/IBM-Cloud/terraform-provider-ibm.helenxu1221'
```
