### PR TITLE
fix: unexpected topic state change and acceptance test

### DIFF
--- a/ibm/service/eventstreams/resource_ibm_event_streams_topic.go
+++ b/ibm/service/eventstreams/resource_ibm_event_streams_topic.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"log"
 	"os"
+	"slices"
 	"strings"
 	"time"
 
@@ -288,6 +289,7 @@ func createSaramaAdminClient(d *schema.ResourceData, meta interface{}) (sarama.C
 	d.Set("kafka_http_url", adminURL)
 	log.Printf("[INFO] createSaramaAdminClient kafka_http_url is set to %s", adminURL)
 	brokerAddress := flex.ExpandStringList(instance.Extensions["kafka_brokers_sasl"].([]interface{}))
+	slices.Sort(brokerAddress)
 	d.Set("kafka_brokers_sasl", brokerAddress)
 	log.Printf("[INFO] createSaramaAdminClient kafka_brokers_sasl is set to %s", brokerAddress)
 	tenantID := strings.TrimPrefix(strings.Split(adminURL, ".")[0], "https://")

--- a/ibm/service/eventstreams/resource_ibm_event_streams_topic_test.go
+++ b/ibm/service/eventstreams/resource_ibm_event_streams_topic_test.go
@@ -302,7 +302,7 @@ func createEventStreamsTopicResourceWithConfig(createInstance bool, topicName st
 }
 
 func testAccCheckIBMEventStreamsInstanceDestroy(s *terraform.State) error {
-	rsContClient, err := acc.TestAccProvider.Meta().(conns.ClientSession).ResourceControllerAPI()
+	rsContClient, err := acc.TestAccProvider.Meta().(conns.ClientSession).ResourceControllerAPIV2()
 	if err != nil {
 		return err
 	}
@@ -311,16 +311,17 @@ func testAccCheckIBMEventStreamsInstanceDestroy(s *terraform.State) error {
 			continue
 		}
 		instanceID := rs.Primary.ID
-		instance, err := rsContClient.ResourceServiceInstance().GetInstance(instanceID)
+		instance, err := rsContClient.ResourceServiceInstanceV2().GetInstance(instanceID)
+		if err != nil {
+			if strings.Contains(err.Error(), "404") {
+				return nil
+			}
+			return fmt.Errorf("[ERROR] Error checking if instance (%s) has been destroyed: %s", rs.Primary.ID, err)
+		}
 
-		if err == nil {
-			if !reflect.DeepEqual(instance, models.ServiceInstance{}) && instance.State == "active" {
-				return fmt.Errorf("Instance still exists: %s", rs.Primary.ID)
-			}
-		} else {
-			if !strings.Contains(err.Error(), "404") {
-				return fmt.Errorf("[ERROR] Error checking if instance (%s) has been destroyed: %s", rs.Primary.ID, err)
-			}
+		if !reflect.DeepEqual(instance, models.ServiceInstanceV2{}) &&
+			instance.State != "removed" && instance.State != "pending_reclamation" {
+			return fmt.Errorf("[ERROR] Instance (%s) is not removed", rs.Primary.ID)
 		}
 	}
 	return nil


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/IBM-Cloud/terraform-provider-ibm/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->

this PR fixes 2 issues:
-  https://github.com/IBM-Cloud/terraform-provider-ibm/issues/3199, it returns sorted broker addresses, so topic state will not change.
- Acceptance test: deprecated RC V1 api returns unexpected results and causes checkInstanceDestroy fails, replace it with RC V2 API and check state to be removed or pending_reclamation.

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ TF_ACC=1 go test . -v '-run=TestAccIBMEventStreamsTopicResourceBasic'
=== RUN   TestAccIBMEventStreamsTopicResourceBasic
--- PASS: TestAccIBMEventStreamsTopicResourceBasic (87.77s)
PASS
ok      github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/eventstreams    89.458s
...
```
