### PR TITLE
fix: nil check for instance.LastOperation.Async

### DIFF
--- a/ibm/service/resourcecontroller/resource_ibm_resource_instance.go
+++ b/ibm/service/resourcecontroller/resource_ibm_resource_instance.go
@@ -901,7 +901,7 @@ func waitForResourceInstanceUpdate(d *schema.ResourceData, meta interface{}) (in
 				}
 				return nil, "", fmt.Errorf("[ERROR] Get the resource instance %s failed with resp code: %s, err: %v", d.Id(), resp, err)
 			}
-			if instance.LastOperation.Async != nil && *instance.LastOperation.Async {
+			if instance.LastOperation != nil && instance.LastOperation.Async != nil && *instance.LastOperation.Async {
 				if *instance.LastOperation.State == RsInstanceFailStatus {
 					return instance, *instance.LastOperation.State, fmt.Errorf("[ERROR] The resource instance '%s' update failed: %v", d.Id(), err)
 				}

--- a/ibm/service/resourcecontroller/resource_ibm_resource_instance.go
+++ b/ibm/service/resourcecontroller/resource_ibm_resource_instance.go
@@ -901,7 +901,7 @@ func waitForResourceInstanceUpdate(d *schema.ResourceData, meta interface{}) (in
 				}
 				return nil, "", fmt.Errorf("[ERROR] Get the resource instance %s failed with resp code: %s, err: %v", d.Id(), resp, err)
 			}
-			if *instance.LastOperation.Async {
+			if instance.LastOperation.Async != nil && *instance.LastOperation.Async {
 				if *instance.LastOperation.State == RsInstanceFailStatus {
 					return instance, *instance.LastOperation.State, fmt.Errorf("[ERROR] The resource instance '%s' update failed: %v", d.Id(), err)
 				}


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/IBM-Cloud/terraform-provider-ibm/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes [#5618](https://github.com/IBM-Cloud/terraform-provider-ibm/issues/5618)

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```
