### PR TITLE
fix(is_share): added empty check and moved source_share_crn outside

### DIFF
--- a/ibm/service/vpc/resource_ibm_is_share.go
+++ b/ibm/service/vpc/resource_ibm_is_share.go
@@ -1096,23 +1096,24 @@ func resourceIbmIsShareCreate(context context.Context, d *schema.ResourceData, m
 			sharePrototype.SourceShare = &vpcv1.ShareIdentity{
 				ID: &sourceShare,
 			}
-		} else {
-			sourceShareCRN := d.Get("source_share_crn").(string)
-			if sourceShareCRN != "" {
-				sharePrototype.SourceShare = &vpcv1.ShareIdentity{
-					CRN: &sourceShareCRN,
-				}
+		}
+		replicationCronSpec := d.Get("replication_cron_spec").(string)
+		sharePrototype.ReplicationCronSpec = &replicationCronSpec
+	} else if sourceShareCrnIntf, sShareCrnok := d.GetOk("source_share_crn"); sShareCrnok {
+		sourceShareCRN := sourceShareCrnIntf.(string)
+		if sourceShareCRN != "" {
+			sharePrototype.SourceShare = &vpcv1.ShareIdentity{
+				CRN: &sourceShareCRN,
 			}
 		}
-
 		replicationCronSpec := d.Get("replication_cron_spec").(string)
 		sharePrototype.ReplicationCronSpec = &replicationCronSpec
 	} else {
 		originShare := d.Get("origin_share")
-		OriginShareModel := ResourceIBMIsShareMapToShareIdentity(originShare.([]interface{})[0].(map[string]interface{}))
-
-		sharePrototype.OriginShare = OriginShareModel
-
+		if len(originShare.([]interface{})) > 0 {
+			OriginShareModel := ResourceIBMIsShareMapToShareIdentity(originShare.([]interface{})[0].(map[string]interface{}))
+			sharePrototype.OriginShare = OriginShareModel
+		}
 	}
 
 	if iopsIntf, ok := d.GetOk("iops"); ok {

--- a/ibm/service/vpc/resource_ibm_is_share_test.go
+++ b/ibm/service/vpc/resource_ibm_is_share_test.go
@@ -137,6 +137,32 @@ func TestAccIbmIsShareAllArgs(t *testing.T) {
 		},
 	})
 }
+func TestAccIbmIsShareAllArgs_EmptyCheck(t *testing.T) {
+	var conf vpcv1.Share
+
+	name := fmt.Sprintf("tf-fs-name-%d", acctest.RandIntRange(10, 100))
+	name2 := fmt.Sprintf("tf-fs-name2-%d", acctest.RandIntRange(10, 100))
+	name3 := fmt.Sprintf("tf-fs-name3-%d", acctest.RandIntRange(10, 100))
+	name4 := fmt.Sprintf("tf-fs-name4-%d", acctest.RandIntRange(10, 100))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { acc.TestAccPreCheck(t) },
+		Providers:    acc.TestAccProviders,
+		CheckDestroy: testAccCheckIbmIsShareDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckIbmIsShareAllConfigEmptyCheckConfig(name, name2, name3, name4),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckIbmIsShareExists("ibm_is_share.test-share", conf),
+					resource.TestCheckResourceAttr("ibm_is_share.test-share", "name", name),
+					resource.TestCheckResourceAttr("ibm_is_share.test-share2", "name", name2),
+					resource.TestCheckResourceAttr("ibm_is_share.test-share-replica", "name", name3),
+					resource.TestCheckResourceAttr("ibm_is_share.test-share2-replica-crn", "name", name4),
+				),
+			},
+		},
+	})
+}
 
 func TestAccIbmIsShareReplicaMain(t *testing.T) {
 	var conf vpcv1.Share
@@ -431,6 +457,37 @@ func testAccCheckIbmIsShareConfig(vpcName, name string, size int, shareTergetNam
 		tags = ["sr01", "sr02"]
 	}
 	`, vpcName, name, acc.ShareProfileName, size, shareTergetName)
+}
+func testAccCheckIbmIsShareAllConfigEmptyCheckConfig(sharename1, sharename2, sharename3, sharename4 string) string {
+	return fmt.Sprintf(`
+
+	resource "ibm_is_share" "test-share" {
+		name    = "%s"
+		size    = 200
+		profile = "%s"
+		zone    = "%s"
+	}
+	resource "ibm_is_share" "test-share2" {
+		name    = "%s"
+		size    = 200
+		profile = "%s"
+		zone    = "%s"
+	}
+	resource "ibm_is_share" "test-share-replica" {
+		name                  = "%s"
+		profile               = "%s"
+		zone                  = "%s"
+		source_share          = ibm_is_share.test-share.id
+		replication_cron_spec = "0 */6 * * *"
+	}
+	resource "ibm_is_share" "test-share2-replica-crn" {
+		name                  = "%s"
+		profile               = "%s"
+		zone                  = "%s"
+		source_share_crn      = ibm_is_share.test-share2.crn
+		replication_cron_spec = "0 */5 * * *"
+	}
+	`, sharename1, acc.ShareProfileName, acc.ISZoneName, sharename2, acc.ShareProfileName, acc.ISZoneName, sharename3, acc.ShareProfileName, acc.ISZoneName2, sharename4, acc.ShareProfileName, acc.ISZoneName3)
 }
 
 func testAccCheckIbmIsShareConfigReplica(vpcName, vpcName1, name string, size int, shareTergetName, shareTergetName1, replicaName string) string {


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/IBM-Cloud/terraform-provider-ibm/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
% make testacc TEST=./ibm/service/vpc TESTARGS='-run=TestAccIbmIsShareAllArgs_EmptyCheck'
=== RUN   TestAccIbmIsShareAllArgs_EmptyCheck
--- PASS: TestAccIbmIsShareAllArgs_EmptyCheck (121.08s)
PASS
ok      github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/vpc     123.164s
```