### PR TITLE
Add region parameter to logs-routing resources and data sources

### DIFF
--- a/examples/ibm-logs-routing/README.md
+++ b/examples/ibm-logs-routing/README.md
@@ -28,6 +28,7 @@ Run `terraform destroy` when you don't need these resources.
 ```hcl
 resource "ibm_logs_router_tenant" "logs_router_tenant_instance" {
   name = var.logs_router_tenant_name
+  region = "us-east"
   targets {
     log_sink_crn = "crn:v1:bluemix:public:logdna:eu-de:a/7246b8fa0a174a71899f5affa4f18d78:3517d2ed-9429-af34-ad52-34278391cbc8::"
     name = "my-log-sink"
@@ -46,6 +47,7 @@ resource "ibm_logs_router_tenant" "logs_router_tenant_instance" {
 |------|-------------|------|---------|
 | ibmcloud\_api\_key | IBM Cloud API key | `string` | true |
 | name | The name for this tenant. The name is regionally unique across all tenants in the account. | `string` | true |
+| region | The region to onboard this tenant. | `string` | true |
 | targets | List of targets. | `list()` | true |
 | targets.log_sink_crn | CRN of the Mezmo or Cloud Logs instance to sends logs to | `string` | true |
 | targets.name | The name for this target. The name is regionally unique for this tenant. | `string` | true |
@@ -70,6 +72,7 @@ resource "ibm_logs_router_tenant" "logs_router_tenant_instance" {
 ```hcl
 data "ibm_logs_router_tenants" "logs_router_tenants_instance" {
   name = var.logs_router_tenants_name
+  region = "us-east"
 }
 ```
 
@@ -77,7 +80,8 @@ data "ibm_logs_router_tenants" "logs_router_tenants_instance" {
 
 | Name | Description | Type | Required |
 |------|-------------|------|---------|
-| name | Optional: The name of a tenant. | `string` | true |
+| name | The name of a tenant. | `string` | true |
+| region | The region to query the tenant. | `string` | true |
 
 #### Outputs
 
@@ -90,7 +94,7 @@ data "ibm_logs_router_tenants" "logs_router_tenants_instance" {
 ```hcl
 data "ibm_logs_router_targets" "logs_router_targets_instance" {
   tenant_id = var.logs_router_targets_tenant_id
-  name = var.logs_router_targets_name
+  region = "us-east"
 }
 ```
 
@@ -99,6 +103,7 @@ data "ibm_logs_router_targets" "logs_router_targets_instance" {
 | Name | Description | Type | Required |
 |------|-------------|------|---------|
 | tenant_id | The instance ID of the tenant. | `` | true |
+| region | The region where the tenant for this target exists, | `string` | true |
 | name | Optional: Name of the tenant target. | `string` | false |
 
 #### Outputs

--- a/examples/ibm-logs-routing/README.md
+++ b/examples/ibm-logs-routing/README.md
@@ -34,7 +34,7 @@ resource "ibm_logs_router_tenant" "logs_router_tenant_instance" {
     name = "my-log-sink"
     parameters {
       host = "www.example.com"
-      port = 1
+      port = 443
       access_credential = "new-credential"
     }
   }

--- a/examples/ibm-logs-routing/main.tf
+++ b/examples/ibm-logs-routing/main.tf
@@ -12,7 +12,7 @@ resource "ibm_logs_router_tenant" "logs_router_tenant_instance" {
     name = "my-logdna-target"
     parameters {
       host = "www.example-1.com"
-      port = 80
+      port = 443
       access_credential = "new-cred"
     }
   }
@@ -21,7 +21,7 @@ resource "ibm_logs_router_tenant" "logs_router_tenant_instance" {
     name = "my-cloud-logs-target"
     parameters {
       host = "www.example-2.com"
-      port = 80
+      port = 443
     }
   }
 }
@@ -34,7 +34,7 @@ resource "ibm_logs_router_tenant" "logs_router_tenant_instance_eu_de" {
     name = "my-logdna-target"
     parameters {
       host = "www.example-1.com"
-      port = 80
+      port = 443
       access_credential = "new-cred"
     }
   }
@@ -42,10 +42,12 @@ resource "ibm_logs_router_tenant" "logs_router_tenant_instance_eu_de" {
 
 // Create logs_router_tenants data source
 data "ibm_logs_router_tenants" "logs_router_tenants_instance" {
-  name = ibm_logs_router_tenant.logs_router_tenant_instance_both.name
+  name = ibm_logs_router_tenant.logs_router_tenant_instance.name
+  region = ibm_logs_router_tenant.logs_router_tenant_instance.region
 }
 
 // Create logs_router_targets data source
 data "ibm_logs_router_targets" "logs_router_targets_instance" {
-  tenant_id = ibm_logs_router_tenant.logs_router_tenant_instance_both.id
+  tenant_id = ibm_logs_router_tenant.logs_router_tenant_instance.id
+  region = ibm_logs_router_tenant.logs_router_tenant_instance.region
 }

--- a/examples/ibm-logs-routing/main.tf
+++ b/examples/ibm-logs-routing/main.tf
@@ -6,8 +6,9 @@ provider "ibm" {
 // Provision logs_router_tenant resource instance
 resource "ibm_logs_router_tenant" "logs_router_tenant_instance" {
   name = var.logs_router_tenant_name
+  region = "us-east"
   targets {
-    log_sink_crn = "crn:v1:bluemix:public:logdna:eu-de:a/7246b8fa0a174a71899f5affa4f18d78:3517d2ed-9429-af34-ad52-34278391cbc8::"
+    log_sink_crn = "crn:v1:bluemix:public:logdna:us-east:a/7246b8fa0a174a71899f5affa4f18d78:3517d2ed-9429-af34-ad52-34278391cbc8::"
     name = "my-logdna-target"
     parameters {
       host = "www.example-1.com"
@@ -16,11 +17,25 @@ resource "ibm_logs_router_tenant" "logs_router_tenant_instance" {
     }
   }
     targets {
-    log_sink_crn = "crn:v1:bluemix:public:logs:eu-de:a/7246b8fa0a174a71899f5affa4f18d78:3517d2ed-9429-af34-ad52-34278391cbc8::"
+    log_sink_crn = "crn:v1:bluemix:public:logs:us-east:a/7246b8fa0a174a71899f5affa4f18d78:3517d2ed-9429-af34-ad52-34278391cbc8::"
     name = "my-cloud-logs-target"
     parameters {
       host = "www.example-2.com"
       port = 80
+    }
+  }
+}
+
+resource "ibm_logs_router_tenant" "logs_router_tenant_instance_eu_de" {
+  name = "eu-de-tenant"
+  region = "eu-de"
+  targets {
+    log_sink_crn = "crn:v1:bluemix:public:logdna:eu-de:a/7246b8fa0a174a71899f5affa4f18d78:3517d2ed-9429-af34-ad52-34278391cbc8::"
+    name = "my-logdna-target"
+    parameters {
+      host = "www.example-1.com"
+      port = 80
+      access_credential = "new-cred"
     }
   }
 }

--- a/go.mod
+++ b/go.mod
@@ -27,7 +27,7 @@ require (
 	github.com/IBM/ibm-hpcs-uko-sdk v0.0.20-beta
 	github.com/IBM/keyprotect-go-client v0.15.1
 	github.com/IBM/logs-go-sdk v0.3.0
-	github.com/IBM/logs-router-go-sdk v1.0.3
+	github.com/IBM/logs-router-go-sdk v1.0.5
 	github.com/IBM/mqcloud-go-sdk v0.1.0
 	github.com/IBM/networking-go-sdk v0.49.0
 	github.com/IBM/platform-services-go-sdk v0.67.0

--- a/go.sum
+++ b/go.sum
@@ -167,8 +167,8 @@ github.com/IBM/keyprotect-go-client v0.15.1 h1:m4qzqF5zOumRxKZ8s7vtK7A/UV/D278L8
 github.com/IBM/keyprotect-go-client v0.15.1/go.mod h1:asXtHwL/4uCHA221Vd/7SkXEi2pcRHDzPyyksc1DthE=
 github.com/IBM/logs-go-sdk v0.3.0 h1:FHzTCCMyp9DvQGXgkppzcOPywC4ggt7x8xu0MR5h8xI=
 github.com/IBM/logs-go-sdk v0.3.0/go.mod h1:yv/GCXC4/p+MZEeXl4xjZAOMvDAVRwu61WyHZFKFXQM=
-github.com/IBM/logs-router-go-sdk v1.0.3 h1:VO64OpANNouxS/0kvUeBpENKWxYx3TYnoNzW8OycMb0=
-github.com/IBM/logs-router-go-sdk v1.0.3/go.mod h1:tCN2vFgu5xG0ob9iJcxi5M4bJ6mWmu3nhmRPnvlwev0=
+github.com/IBM/logs-router-go-sdk v1.0.5 h1:r0kC1+HfmSeQCD6zQTUp4PDI/zp4Ueo1Zo19ipHuNlw=
+github.com/IBM/logs-router-go-sdk v1.0.5/go.mod h1:tCN2vFgu5xG0ob9iJcxi5M4bJ6mWmu3nhmRPnvlwev0=
 github.com/IBM/mqcloud-go-sdk v0.1.0 h1:fWt4uisg5GbbsfNmAxx5/6c5gQIPM+VrEsTtnimELeA=
 github.com/IBM/mqcloud-go-sdk v0.1.0/go.mod h1:LesMQlKHXvdks4jqQLZH7HfATY5lvTzHuwQU5+y7b2g=
 github.com/IBM/networking-go-sdk v0.49.0 h1:lPS34u3C0JVrbxH+Ulua76Nwl6Frv8BEfq6LRkyvOv0=

--- a/ibm/service/logsrouting/data_source_ibm_logs-router_targets.go
+++ b/ibm/service/logsrouting/data_source_ibm_logs-router_targets.go
@@ -38,6 +38,12 @@ func DataSourceIBMLogsRouterTargets() *schema.Resource {
 				Optional:    true,
 				Description: "Optional: Name of the tenant target.",
 			},
+			"region": {
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: "The region where the tenant for these targets exist.",
+			},
 			"targets": &schema.Schema{
 				Type:        schema.TypeList,
 				Computed:    true,
@@ -119,6 +125,10 @@ func dataSourceIBMLogsRouterTargetsRead(context context.Context, d *schema.Resou
 	listTenantTargetsOptions.SetTenantID(core.UUIDPtr(strfmt.UUID(d.Get("tenant_id").(string))))
 	if _, ok := d.GetOk("name"); ok {
 		listTenantTargetsOptions.SetName(d.Get("name").(string))
+	}
+
+	if _, ok := d.GetOk("region"); ok {
+		listTenantTargetsOptions.SetRegion(d.Get("region").(string))
 	}
 
 	targetTypeCollection, _, err := ibmCloudLogsRoutingClient.ListTenantTargetsWithContext(context, listTenantTargetsOptions)

--- a/ibm/service/logsrouting/data_source_ibm_logs-router_targets_test.go
+++ b/ibm/service/logsrouting/data_source_ibm_logs-router_targets_test.go
@@ -44,6 +44,7 @@ func testAccCheckIBMLogsRouterTargetsDataSourceConfigBasic(tenantName string) st
 	return fmt.Sprintf(`
 		 resource "ibm_logs_router_tenant" "logs_router_tenant_instance" {
 			 name = "%s"
+			 region = "br-sao"
 			 targets {
 				 log_sink_crn = "crn:v1:bluemix:public:logdna:eu-de:a/3516b8fa0a174a71899f5affa4f18d78:3517d2ed-9429-af34-ad52-34278391cbc8::"
 				 name = "my-log-sink"
@@ -58,6 +59,7 @@ func testAccCheckIBMLogsRouterTargetsDataSourceConfigBasic(tenantName string) st
  
 		 data "ibm_logs_router_targets" "logs_router_targets_instance" {
 			 tenant_id = ibm_logs_router_tenant.logs_router_tenant_instance.id
+			 region = ibm_logs_router_tenant.logs_router_tenant_instance.region
 		 }
 	 `, tenantName, acc.IngestionKey)
 }

--- a/ibm/service/logsrouting/data_source_ibm_logs-router_tenants.go
+++ b/ibm/service/logsrouting/data_source_ibm_logs-router_tenants.go
@@ -31,6 +31,12 @@ func DataSourceIBMLogsRouterTenants() *schema.Resource {
 				Required:    true,
 				Description: "Optional: The name of a tenant.",
 			},
+			"region": {
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: "The region where the tenants exist.",
+			},
 			"tenants": &schema.Schema{
 				Type:        schema.TypeList,
 				Computed:    true,
@@ -150,6 +156,10 @@ func dataSourceIBMLogsRouterTenantsRead(context context.Context, d *schema.Resou
 
 	if _, ok := d.GetOk("name"); ok {
 		listTenantsOptions.SetName(d.Get("name").(string))
+	}
+
+	if _, ok := d.GetOk("region"); ok {
+		listTenantsOptions.SetRegion(d.Get("region").(string))
 	}
 
 	tenantCollection, _, err := ibmCloudLogsRoutingClient.ListTenantsWithContext(context, listTenantsOptions)

--- a/ibm/service/logsrouting/data_source_ibm_logs-router_tenants_test.go
+++ b/ibm/service/logsrouting/data_source_ibm_logs-router_tenants_test.go
@@ -43,6 +43,7 @@ func testAccCheckIBMLogsRouterTenantsDataSourceConfigBasic(tenantName string) st
 	return fmt.Sprintf(`
 		 resource "ibm_logs_router_tenant" "logs_router_tenant_instance" {
 			 name = "%s"
+			 region = "br-sao"
 			 targets {
 				 log_sink_crn = "crn:v1:bluemix:public:logdna:eu-de:a/3516b8fa0a174a71899f5affa4f18d78:3517d2ed-9429-af34-ad52-34278391cbc8::"
 				 name = "my-log-sink"
@@ -57,6 +58,7 @@ func testAccCheckIBMLogsRouterTenantsDataSourceConfigBasic(tenantName string) st
  
 		 data "ibm_logs_router_tenants" "logs_router_tenants_instance" {
 			 name = ibm_logs_router_tenant.logs_router_tenant_instance.name
+			 region = ibm_logs_router_tenant.logs_router_tenant_instance.region
 		 }
 	 `, tenantName, acc.IngestionKey)
 }

--- a/ibm/service/logsrouting/resource_ibm_logs-router_tenant_test.go
+++ b/ibm/service/logsrouting/resource_ibm_logs-router_tenant_test.go
@@ -49,9 +49,16 @@ func TestAccIBMLogsRouterTenantBasic(t *testing.T) {
 				),
 			},
 			resource.TestStep{
-				ResourceName:            "ibm_logs_router_tenant.logs_router_tenant_instance",
-				ImportState:             true,
-				ImportStateVerify:       true,
+				ResourceName:      "ibm_logs_router_tenant.logs_router_tenant_instance",
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: func(s *terraform.State) (string, error) {
+					rs, ok := s.RootModule().Resources["ibm_logs_router_tenant.logs_router_tenant_instance"]
+					if !ok {
+						return "", fmt.Errorf("Not found: %s", "ibm_logs_router_tenant.logs_router_tenant_instance")
+					}
+					return fmt.Sprintf("%s/%s", rs.Primary.ID, rs.Primary.Attributes["region"]), nil
+				},
 				ImportStateVerifyIgnore: []string{"targets.0.parameters.0.access_credential", "targets.1.parameters.0.access_credential"},
 			},
 		},
@@ -92,9 +99,16 @@ func TestAccIBMLogsRouterTenantAllArgs(t *testing.T) {
 				),
 			},
 			resource.TestStep{
-				ResourceName:            "ibm_logs_router_tenant.logs_router_tenant_instance",
-				ImportState:             true,
-				ImportStateVerify:       true,
+				ResourceName:      "ibm_logs_router_tenant.logs_router_tenant_instance",
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: func(s *terraform.State) (string, error) {
+					rs, ok := s.RootModule().Resources["ibm_logs_router_tenant.logs_router_tenant_instance"]
+					if !ok {
+						return "", fmt.Errorf("Not found: %s", "ibm_logs_router_tenant.logs_router_tenant_instance")
+					}
+					return fmt.Sprintf("%s/%s", rs.Primary.ID, rs.Primary.Attributes["region"]), nil
+				},
 				ImportStateVerifyIgnore: []string{"targets.0.parameters.0.access_credential", "targets.1.parameters.0.access_credential"},
 			},
 		},
@@ -105,6 +119,7 @@ func testAccCheckIBMLogsRouterTenantConfigBasic(name string, crn string, host st
 	return fmt.Sprintf(`
 		resource "ibm_logs_router_tenant" "logs_router_tenant_instance" {
 			name = "%s"
+			region = "br-sao"
 			targets {
 				log_sink_crn = "%s"
 				name = "my-log-sink"
@@ -122,6 +137,7 @@ func testAccCheckIBMLogsRouterTenantConfigAllArgs(name string, target0Name strin
 	return fmt.Sprintf(`
 		resource "ibm_logs_router_tenant" "logs_router_tenant_instance" {
 			name = "%s"
+			region = "br-sao"
 			targets {
 				log_sink_crn = "crn:v1:bluemix:public:logdna:eu-de:a/3516b8fa0a174a71899f5affa4f18d78:3517d2ed-9429-af34-ad52-34278391cbc8::"
 				name = "%s"
@@ -151,6 +167,7 @@ func testAccCheckIBMLogsRouterTenantExists(n string, obj ibmcloudlogsroutingv0.T
 
 		tenantId := strfmt.UUID(rs.Primary.ID)
 		getTenantDetailOptions.SetTenantID(&tenantId)
+		getTenantDetailOptions.SetRegion(rs.Primary.Attributes["region"])
 
 		tenant, _, err := ibmCloudLogsRoutingClient.GetTenantDetail(getTenantDetailOptions)
 		if err != nil {
@@ -176,6 +193,7 @@ func testAccCheckIBMLogsRouterTenantDestroy(s *terraform.State) error {
 
 		tenantId := strfmt.UUID(rs.Primary.ID)
 		getTenantDetailOptions.SetTenantID(&tenantId)
+		getTenantDetailOptions.SetRegion(rs.Primary.Attributes["region"])
 
 		// Try to find the key
 		_, response, err := ibmCloudLogsRoutingClient.GetTenantDetail(getTenantDetailOptions)

--- a/website/docs/d/logs-router_targets.html.markdown
+++ b/website/docs/d/logs-router_targets.html.markdown
@@ -15,7 +15,7 @@ Provides a read-only data source to retrieve information about logs_router_targe
 ```hcl
 data "ibm_logs_router_targets" "logs_router_targets" {
 	tenant_id = "9fab83da-98cb-4f18-a7ba-b6f0435c9673"
-	name = "my-target"
+	region = "us-east"
 }
 ```
 
@@ -25,6 +25,8 @@ You can specify the following arguments for this data source.
 
 * `name` - (Optional, String) Optional: Name of the tenant target.
   * Constraints: The maximum length is `35` characters. The minimum length is `1` character. The value must match regular expression `/[A-F,0-9,-]/`.
+* `region` - (Required, Forces new resource, String) The region where the tenant for this target exists.
+  * Constraints: The value must match one of the available regions. For a list of regions, see the available [IBM Cloud Logs Router Endpoints](https://cloud.ibm.com/docs/logs-router?topic=logs-router-locations).
 * `tenant_id` - (Required, Forces new resource, String) The instance ID of the tenant.
   * Constraints: The maximum length is `36` characters. The minimum length is `36` characters. The value must match regular expression `/[A-F,0-9,-]/`.
 

--- a/website/docs/d/logs-router_tenants.html.markdown
+++ b/website/docs/d/logs-router_tenants.html.markdown
@@ -15,6 +15,7 @@ Provides a read-only data source to retrieve information about logs_router_tenan
 ```hcl
 data "ibm_logs_router_tenants" "logs_router_tenants" {
 	name = ibm_logs_router_tenant.logs_router_tenant_instance.name
+	region = ibm_logs_router_tenant.logs_router_tenant_instance.region
 }
 ```
 
@@ -24,6 +25,8 @@ You can specify the following arguments for this data source.
 
 * `name` - (Required, String) Optional: The name of a tenant.
   * Constraints: The maximum length is `35` characters. The minimum length is `1` character. The value must match regular expression `/[A-F,0-9,-]/`.
+* `region` - (Required, Forces new resource, String) The region where the tenant for this target exists.
+  * Constraints: The value must match one of the available regions. For a list of regions, see the available [IBM Cloud Logs Router Endpoints](https://cloud.ibm.com/docs/logs-router?topic=logs-router-locations).
 
 ## Attribute Reference
 

--- a/website/docs/r/logs-router_tenant.html.markdown
+++ b/website/docs/r/logs-router_tenant.html.markdown
@@ -13,15 +13,29 @@ Create, update, and delete logs_router_tenants with this resource.
 ## Example Usage
 
 ```hcl
+resource "ibm_resource_instance" "logs_instance" {
+  name     = "logs-instance"
+  service  = "logs"
+  plan     = "standard"
+  location = "eu-de"
+  parameters = {
+    retention_period        = "14"
+    logs_bucket_crn         = "crn:v1:bluemix:public:cloud-object-storage:global:a/4448261269a14562b839e0a3019ed980:f8b3176e-af8e-4e14-a2f9-7f82634e7f0b:bucket:logs-bucket"
+    logs_bucket_endpoint    = "s3.direct.eu-de.cloud-object-storage.appdomain.cloud"
+    metrics_bucket_crn      = "crn:v1:bluemix:public:cloud-object-storage:global:a/4448261269a14562b839e0a3019ed980:f8b3176e-af8e-4e14-a2f9-7f82634e7f0b:bucket:metrics-bucket"
+    metrics_bucket_endpoint = "s3.direct.eu-de.cloud-object-storage.appdomain.cloud"
+  }
+}
+
 resource "ibm_logs_router_tenant" "logs_router_tenant_instance" {
-  name = "my-logging-tenant"
+  name = "cloud-logs-router-tenant"
+  region = "eu-de"
   targets {
-		log_sink_crn = "crn:v1:bluemix:public:logdna:eu-de:a/3516b8fa0a174a71899f5affa4f18d78:3517d2ed-9429-af34-ad52-34278391cbc8::"
-		name = "my-log-sink"
+		log_sink_crn = ibm_resource_instance.logs_instance.target_crn
+		name = "my-cloud-logs-target"
 		parameters {
-			host = "www.example.com"
-			port = 1
-			access_credential = "credential"
+			host = ibm_resource_instance.logs_instance.extensions.external_ingress_private
+			port = 443
 		}
   }
 }
@@ -33,14 +47,16 @@ You can specify the following arguments for this resource.
 
 * `name` - (Required, String) The name for this tenant. The name is regionally unique across all tenants in the account.
   * Constraints: The maximum length is `35` characters. The minimum length is `1` character. The value must match regular expression `/[a-z,A-Z,0-9,-,.]/`.
+* `region` - (Required, Forces new resource, String) The region to create the tenant.
+  * Constraints: The value must match one of the available regions. For a list of regions, see the available [IBM Cloud Logs Router Endpoints](https://cloud.ibm.com/docs/logs-router?topic=logs-router-locations).
 * `targets` - (Required, List) List of targets.
   * Constraints: The maximum length is `2` items. The minimum length is `1` item.
 Nested schema for **targets**:
-	* `log_sink_crn` - (Optional, String) Cloud resource name of the log-sink target instance.
+	* `log_sink_crn` - (Required, String) Cloud resource name of the log-sink target instance.
 	  * Constraints: The maximum length is `256` characters. The minimum length is `1` character. The value must match regular expression `/[a-z,A-Z,0-9,:,-]/`.
 	* `name` - (Optional, String) The name for this tenant target. The name is unique across all targets for this tenant.
 	  * Constraints: The maximum length is `35` characters. The minimum length is `1` character. The value must match regular expression `/[a-z,A-Z,0-9,-,.]/`.
-	* `parameters` - (Optional, List) List of properties returned from a successful list operation for a log-sink of type IBM Log Analysis (logdna).
+	* `parameters` - (Required, List) List of properties returned from a successful list operation for a log-sink of type IBM Log Analysis (logdna).
 	Nested schema for **parameters**:
 		* `host` - (Required, String) Host name of the log-sink.
 		  * Constraints: The maximum length is `256` characters. The minimum length is `1` character. The value must match regular expression `/[a-z,A-Z,0-9,-,.]/`.
@@ -71,15 +87,14 @@ After your resource is created, you can read values from the listed arguments an
 
 ## Import
 
-You can import the `ibm_logs_router_tenant` resource by using `id`. Unique ID of the tenant.
-For more information, see [the documentation](http://cloud.ibm.com)
+You can import the `ibm_logs_router_tenant` resource by using `id`, the unique `id` of the tenant, and `region` where the tenant exists in the format `id/region`.
 
 # Syntax
 <pre>
-$ terraform import ibm_logs_router_tenant.logs_router_tenant &lt;id&gt;
+$ terraform import ibm_logs_router_tenant.logs_router_tenant &lt;id/region&gt;
 </pre>
 
 # Example
 ```
-$ terraform import ibm_logs_router_tenant.logs_router_tenant 8717db99-2cfb-4ba6-a033-89c994c2e9f0
+$ terraform import ibm_logs_router_tenant.logs_router_tenant 8717db99-2cfb-4ba6-a033-89c994c2e9f0/us-east
 ```


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/IBM-Cloud/terraform-provider-ibm/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->
### Changes to logs-router resources and data-sources
- Adding a `region` parameter to allow for managing IBM Cloud Logs Routing tenants in multiple regions. 


### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #5616

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccIbmLogsRouter'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test $(go list ./... |grep -v 'vendor') -v -run=TestAccIbmLogsRouter -timeout 700m
...
=== RUN   TestAccIBMLogsRouterTargetsDataSourceBasic
--- PASS: TestAccIBMLogsRouterTargetsDataSourceBasic (84.45s)
=== RUN   TestDataSourceIBMLogsRouterTargetsTargetTypeToMap
--- PASS: TestDataSourceIBMLogsRouterTargetsTargetTypeToMap (0.00s)
=== RUN   TestDataSourceIBMLogsRouterTargetsTargetParametersTypeLogDnaToMap
--- PASS: TestDataSourceIBMLogsRouterTargetsTargetParametersTypeLogDnaToMap (0.00s)
=== RUN   TestDataSourceIBMLogsRouterTargetsTargetTypeLogDnaToMap
--- PASS: TestDataSourceIBMLogsRouterTargetsTargetTypeLogDnaToMap (0.00s)
=== RUN   TestDataSourceIBMLogsRouterTargetsTargetTypeLogsToMap
--- PASS: TestDataSourceIBMLogsRouterTargetsTargetTypeLogsToMap (0.00s)
=== RUN   TestDataSourceIBMLogsRouterTargetsTargetParametersTypeLogsToMap
--- PASS: TestDataSourceIBMLogsRouterTargetsTargetParametersTypeLogsToMap (0.00s)
=== RUN   TestAccIBMLogsRouterTenantsDataSourceBasic
--- PASS: TestAccIBMLogsRouterTenantsDataSourceBasic (78.46s)
=== RUN   TestDataSourceIBMLogsRouterTenantsTenantToMap
--- PASS: TestDataSourceIBMLogsRouterTenantsTenantToMap (0.00s)
=== RUN   TestDataSourceIBMLogsRouterTenantsTargetTypeToMap
--- PASS: TestDataSourceIBMLogsRouterTenantsTargetTypeToMap (0.00s)
=== RUN   TestDataSourceIBMLogsRouterTenantsTargetParametersTypeLogDnaToMap
--- PASS: TestDataSourceIBMLogsRouterTenantsTargetParametersTypeLogDnaToMap (0.00s)
=== RUN   TestDataSourceIBMLogsRouterTenantsTargetTypeLogDnaToMap
--- PASS: TestDataSourceIBMLogsRouterTenantsTargetTypeLogDnaToMap (0.00s)
=== RUN   TestDataSourceIBMLogsRouterTenantsTargetTypeLogsToMap
--- PASS: TestDataSourceIBMLogsRouterTenantsTargetTypeLogsToMap (0.00s)
=== RUN   TestDataSourceIBMLogsRouterTenantsTargetParametersTypeLogsToMap
--- PASS: TestDataSourceIBMLogsRouterTenantsTargetParametersTypeLogsToMap (0.00s)
=== RUN   TestAccIBMLogsRouterTenantBasic
--- PASS: TestAccIBMLogsRouterTenantBasic (73.71s)
=== RUN   TestAccIBMLogsRouterTenantAllArgs
--- PASS: TestAccIBMLogsRouterTenantAllArgs (74.16s)
=== RUN   TestResourceIBMLogsRouterTenantTargetTypeToMap
--- PASS: TestResourceIBMLogsRouterTenantTargetTypeToMap (0.00s)
=== RUN   TestResourceIBMLogsRouterTenantTargetParametersTypeLogDnaToMap
--- PASS: TestResourceIBMLogsRouterTenantTargetParametersTypeLogDnaToMap (0.00s)
=== RUN   TestResourceIBMLogsRouterTenantTargetTypeLogDnaToMap
--- PASS: TestResourceIBMLogsRouterTenantTargetTypeLogDnaToMap (0.00s)
=== RUN   TestResourceIBMLogsRouterTenantTargetTypeLogsToMap
--- PASS: TestResourceIBMLogsRouterTenantTargetTypeLogsToMap (0.00s)
=== RUN   TestResourceIBMLogsRouterTenantTargetParametersTypeLogsToMap
--- PASS: TestResourceIBMLogsRouterTenantTargetParametersTypeLogsToMap (0.00s)
=== RUN   TestResourceIBMLogsRouterTenantMapToTargetTypePrototype
--- PASS: TestResourceIBMLogsRouterTenantMapToTargetTypePrototype (0.00s)
=== RUN   TestResourceIBMLogsRouterTenantMapToTargetParametersTypeLogDnaPrototype
--- PASS: TestResourceIBMLogsRouterTenantMapToTargetParametersTypeLogDnaPrototype (0.00s)
=== RUN   TestResourceIBMLogsRouterTenantMapToTargetTypePrototypeTargetTypeLogDnaPrototype
--- PASS: TestResourceIBMLogsRouterTenantMapToTargetTypePrototypeTargetTypeLogDnaPrototype (0.00s)
=== RUN   TestResourceIBMLogsRouterTenantMapToTargetTypePrototypeTargetTypeLogsPrototype
--- PASS: TestResourceIBMLogsRouterTenantMapToTargetTypePrototypeTargetTypeLogsPrototype (0.00s)
=== RUN   TestResourceIBMLogsRouterTenantMapToTargetParametersTypeLogsPrototype
--- PASS: TestResourceIBMLogsRouterTenantMapToTargetParametersTypeLogsPrototype (0.00s)
PASS
ok  	github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/logsrouting	315.100s
...
```
