### PR TITLE
fix for context and history parameter of template assignment

### DIFF
--- a/ibm/service/iamidentity/resource_ibm_iam_trusted_profile_template_assignment.go
+++ b/ibm/service/iamidentity/resource_ibm_iam_trusted_profile_template_assignment.go
@@ -6,9 +6,10 @@ package iamidentity
 import (
 	"context"
 	"fmt"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"log"
 	"time"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -434,14 +435,16 @@ func resourceIBMTrustedProfileTemplateAssignmentRead(context context.Context, d 
 	if err = d.Set("target", templateAssignmentResponse.Target); err != nil {
 		return diag.FromErr(fmt.Errorf("error setting target: %s", err))
 	}
+	ctx := []map[string]interface{}{}
 	if !core.IsNil(templateAssignmentResponse.Context) {
 		contextMap, err := resourceIBMTrustedProfileTemplateAssignmentResponseContextToMap(templateAssignmentResponse.Context)
 		if err != nil {
 			return diag.FromErr(err)
 		}
-		if err = d.Set("context", []map[string]interface{}{contextMap}); err != nil {
-			return diag.FromErr(fmt.Errorf("error setting context: %s", err))
-		}
+		ctx = append(ctx, contextMap)
+	}
+	if err = d.Set("context", ctx); err != nil {
+		return diag.FromErr(fmt.Errorf("[ERROR] Error setting context: %s", err))
 	}
 	if err = d.Set("account_id", templateAssignmentResponse.AccountID); err != nil {
 		return diag.FromErr(fmt.Errorf("error setting account_id: %s", err))
@@ -462,8 +465,8 @@ func resourceIBMTrustedProfileTemplateAssignmentRead(context context.Context, d 
 			return diag.FromErr(fmt.Errorf("error setting resources: %s", err))
 		}
 	}
+	history := []map[string]interface{}{}
 	if !core.IsNil(templateAssignmentResponse.History) {
-		history := []map[string]interface{}{}
 		for _, historyItem := range templateAssignmentResponse.History {
 			historyItemMap, err := resourceIBMTrustedProfileTemplateAssignmentEnityHistoryRecordToMap(&historyItem)
 			if err != nil {
@@ -471,9 +474,9 @@ func resourceIBMTrustedProfileTemplateAssignmentRead(context context.Context, d 
 			}
 			history = append(history, historyItemMap)
 		}
-		if err = d.Set("history", history); err != nil {
-			return diag.FromErr(fmt.Errorf("error setting history: %s", err))
-		}
+	}
+	if err = d.Set("history", history); err != nil {
+		return diag.FromErr(fmt.Errorf("[ERROR] Error setting history: %s", err))
 	}
 	if !core.IsNil(templateAssignmentResponse.Href) {
 		if err = d.Set("href", templateAssignmentResponse.Href); err != nil {

--- a/ibm/service/iamidentity/resource_ibm_iam_trusted_profile_template_assignment_test.go
+++ b/ibm/service/iamidentity/resource_ibm_iam_trusted_profile_template_assignment_test.go
@@ -30,8 +30,8 @@ func TestAccIBMTrustedProfileTemplateAssignmentBasic(t *testing.T) {
 		CheckDestroy: testAccCheckIBMTrustedProfileTemplateAssignmentResourceDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config:             testAccCheckIBMTrustedProfileTemplateAssignmentConfigBasic(name, 1),
-				ExpectNonEmptyPlan: true,
+
+				Config: testAccCheckIBMTrustedProfileTemplateAssignmentConfigBasic(name, 1),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckIBMTrustedProfileTemplateAssignmentExists("ibm_iam_trusted_profile_template_assignment.trusted_profile_template_assignment_instance", conf),
 					resource.TestCheckResourceAttrSet("ibm_iam_trusted_profile_template_assignment.trusted_profile_template_assignment_instance", "id"),
@@ -54,8 +54,7 @@ func TestAccIBMTrustedProfileTemplateAssignmentBasic(t *testing.T) {
 				Config:      testAccCheckIBMTrustedProfileTemplateAssignmentConfigBasic(name, 3),
 			},
 			{
-				ExpectNonEmptyPlan: true,
-				Config:             testAccCheckIBMTrustedProfileTemplateAssignmentConfigBasic(name, 2),
+				Config: testAccCheckIBMTrustedProfileTemplateAssignmentConfigBasic(name, 2),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr("ibm_iam_trusted_profile_template_assignment.trusted_profile_template_assignment_instance", "template_version", "2"),
 				),


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/IBM-Cloud/terraform-provider-ibm/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccIBMTrustedProfileTemplateAssignmentBasic'

=== RUN   TestAccIBMTrustedProfileTemplateAssignmentBasic
--- PASS: TestAccIBMTrustedProfileTemplateAssignmentBasic (535.03s)
PASS
ok   

...
```
