### PR TITLE
Fix: cbr-provider-produced-inconsistent-result

### DIFF
--- a/ibm/service/contextbasedrestrictions/resource_ibm_cbr_rule.go
+++ b/ibm/service/contextbasedrestrictions/resource_ibm_cbr_rule.go
@@ -10,7 +10,6 @@ import (
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 
 	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/conns"
@@ -18,12 +17,6 @@ import (
 	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/validate"
 	"github.com/IBM/go-sdk-core/v5/core"
 	"github.com/IBM/platform-services-go-sdk/contextbasedrestrictionsv1"
-)
-
-const (
-	cbrRuleReadPending  = "pending"
-	cbrRuleReadComplete = "finished"
-	cbrRuleReadError    = "error"
 )
 
 func ResourceIBMCbrRule() *schema.Resource {
@@ -256,53 +249,6 @@ func ResourceIBMCbrRuleValidator() *validate.ResourceValidator {
 	return &resourceValidator
 }
 
-// waitForCbrRuleRead will leverage use retry.StateChangeConf due to the service's eventual consistency
-func waitForCbrRuleRead(cbrClient *contextbasedrestrictionsv1.ContextBasedRestrictionsV1, context context.Context, id string) (interface{}, error) {
-	stateConf := &retry.StateChangeConf{
-		Pending: []string{cbrRuleReadPending},
-		Target:  []string{cbrRuleReadError, cbrRuleReadComplete, ""},
-		Refresh: func() (interface{}, string, error) {
-			log.Printf("[DEBUG] Read cbr rule (%s) read", id)
-			getRuleOptions := &contextbasedrestrictionsv1.GetRuleOptions{}
-			getRuleOptions.SetRuleID(id)
-			_, response, err := cbrClient.GetRuleWithContext(context, getRuleOptions)
-			if err != nil && response.StatusCode == 404 {
-				return response, cbrRuleReadPending, nil
-			} else if err != nil {
-				return response, cbrRuleReadError, err
-			} else {
-				return response, cbrRuleReadComplete, nil
-			}
-		},
-
-		Timeout:    120 * time.Second,
-		Delay:      20 * time.Second,
-		MinTimeout: 10 * time.Second,
-	}
-	return stateConf.WaitForStateContext(context)
-}
-
-func readNewCbrRule(cbrClient *contextbasedrestrictionsv1.ContextBasedRestrictionsV1, context context.Context, d *schema.ResourceData) diag.Diagnostics {
-	getRuleOptions := &contextbasedrestrictionsv1.GetRuleOptions{}
-	getRuleOptions.SetRuleID(d.Id())
-
-	_, response, err := cbrClient.GetRuleWithContext(context, getRuleOptions)
-	if err != nil {
-		//  Leverage retry for the read due to eventual consistency of the service.
-		if response != nil && response.StatusCode == 404 {
-			log.Printf("[INFO] Read cbr rule response status code: 404, provider will try again. %s", err)
-			_, err := waitForCbrRuleRead(cbrClient, context, d.Id())
-			if err != nil {
-				log.Printf("[DEBUG] GetRuleWithContext failed %s\n%s", err, response)
-				d.SetId("")
-				return diag.FromErr(fmt.Errorf("GetRuleWithContext failed %s\n%s", err, response))
-			}
-		}
-	}
-
-	return nil
-}
-
 func resourceIBMCbrRuleCreate(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	contextBasedRestrictionsClient, err := meta.(conns.ClientSession).ContextBasedRestrictionsV1()
 	if err != nil {
@@ -362,10 +308,7 @@ func resourceIBMCbrRuleCreate(context context.Context, d *schema.ResourceData, m
 
 	d.SetId(*rule.ID)
 
-	// handle Eventual consistency case
-	readNewCbrRule(contextBasedRestrictionsClient, context, d)
-
-	return resourceIBMCbrRuleRead(context, d, meta)
+	return nil
 }
 
 func resourceIBMCbrRuleRead(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
@@ -520,7 +463,7 @@ func resourceIBMCbrRuleUpdate(context context.Context, d *schema.ResourceData, m
 		return diag.FromErr(fmt.Errorf("ReplaceRuleWithContext failed %s\n%s", err, response))
 	}
 
-	return resourceIBMCbrRuleRead(context, d, meta)
+	return nil
 }
 
 func resourceIBMCbrRuleDelete(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {

--- a/ibm/service/contextbasedrestrictions/resource_ibm_cbr_rule.go
+++ b/ibm/service/contextbasedrestrictions/resource_ibm_cbr_rule.go
@@ -308,81 +308,81 @@ func resourceIBMCbrRuleCreate(context context.Context, d *schema.ResourceData, m
 
 	d.SetId(*rule.ID)
 
-	if fromErr := resourceIBMCbrRuleSetData(response, rule, d); fromErr != nil {
-		return diag.FromErr(fmt.Errorf("Error setting rule's resource data: %s", fromErr))
+	if err := resourceIBMCbrRuleSetData(response, rule, d); err != nil {
+		return diag.FromErr(fmt.Errorf("Error setting rule's resource data: %s", err))
 	}
 
 	return nil
 }
 
-func resourceIBMCbrRuleSetData(response *core.DetailedResponse, rule *contextbasedrestrictionsv1.Rule, d *schema.ResourceData) diag.Diagnostics {
+func resourceIBMCbrRuleSetData(response *core.DetailedResponse, rule *contextbasedrestrictionsv1.Rule, d *schema.ResourceData) error {
 	if err := d.Set("x_correlation_id", response.Headers.Get("x_correlation_id")); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting x_correlation_id: %s", err))
+		return fmt.Errorf("Error setting x_correlation_id: %s", err)
 	}
 	if err := d.Set("transaction_id", response.Headers.Get("transaction_id")); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting transaction_id: %s", err))
+		return fmt.Errorf("Error setting transaction_id: %s", err)
 	}
 	if err := d.Set("description", rule.Description); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting description: %s", err))
+		return fmt.Errorf("Error setting description: %s", err)
 	}
 	contexts := []map[string]interface{}{}
 	if rule.Contexts != nil {
 		for _, contextsItem := range rule.Contexts {
 			contextsItemMap, err := resourceIBMCbrRuleRuleContextToMap(&contextsItem)
 			if err != nil {
-				return diag.FromErr(err)
+				return err
 			}
 			contexts = append(contexts, contextsItemMap)
 		}
 	}
 	if err := d.Set("contexts", contexts); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting contexts: %s", err))
+		return fmt.Errorf("Error setting contexts: %s", err)
 	}
 	resources := []map[string]interface{}{}
 	if rule.Resources != nil {
 		for _, resourcesItem := range rule.Resources {
 			resourcesItemMap, err := resourceIBMCbrRuleResourceToMap(&resourcesItem)
 			if err != nil {
-				return diag.FromErr(err)
+				return err
 			}
 			resources = append(resources, resourcesItemMap)
 		}
 	}
 	if err := d.Set("resources", resources); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting resources: %s", err))
+		return fmt.Errorf("Error setting resources: %s", err)
 	}
 	if rule.Operations != nil {
 		operationsMap, err := resourceIBMCbrRuleNewRuleOperationsToMap(rule.Operations)
 		if err != nil {
-			return diag.FromErr(err)
+			return err
 		}
 		if err = d.Set("operations", []map[string]interface{}{operationsMap}); err != nil {
-			return diag.FromErr(fmt.Errorf("Error setting operations: %s", err))
+			return fmt.Errorf("Error setting operations: %s", err)
 		}
 	}
 	if err := d.Set("enforcement_mode", rule.EnforcementMode); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting enforcement_mode: %s", err))
+		return fmt.Errorf("Error setting enforcement_mode: %s", err)
 	}
 	if err := d.Set("crn", rule.CRN); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting crn: %s", err))
+		return fmt.Errorf("Error setting crn: %s", err)
 	}
 	if err := d.Set("href", rule.Href); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting href: %s", err))
+		return fmt.Errorf("Error setting href: %s", err)
 	}
 	if err := d.Set("created_at", flex.DateTimeToString(rule.CreatedAt)); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting created_at: %s", err))
+		return fmt.Errorf("Error setting created_at: %s", err)
 	}
 	if err := d.Set("created_by_id", rule.CreatedByID); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting created_by_id: %s", err))
+		return fmt.Errorf("Error setting created_by_id: %s", err)
 	}
 	if err := d.Set("last_modified_at", flex.DateTimeToString(rule.LastModifiedAt)); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting last_modified_at: %s", err))
+		return fmt.Errorf("Error setting last_modified_at: %s", err)
 	}
 	if err := d.Set("last_modified_by_id", rule.LastModifiedByID); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting last_modified_by_id: %s", err))
+		return fmt.Errorf("Error setting last_modified_by_id: %s", err)
 	}
 	if err := d.Set("version", response.Headers.Get("Etag")); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting version: %s", err))
+		return fmt.Errorf("Error setting version: %s", err)
 	}
 
 	return nil
@@ -475,8 +475,8 @@ func resourceIBMCbrRuleUpdate(context context.Context, d *schema.ResourceData, m
 		return diag.FromErr(fmt.Errorf("ReplaceRuleWithContext failed %s\n%s", err, response))
 	}
 
-	if fromErr := resourceIBMCbrRuleSetData(response, rule, d); fromErr != nil {
-		return diag.FromErr(fmt.Errorf("Error setting rule's resource data: %s", fromErr))
+	if err := resourceIBMCbrRuleSetData(response, rule, d); err != nil {
+		return diag.FromErr(fmt.Errorf("Error setting rule's resource data: %s", err))
 	}
 
 	return nil

--- a/ibm/service/contextbasedrestrictions/resource_ibm_cbr_rule.go
+++ b/ibm/service/contextbasedrestrictions/resource_ibm_cbr_rule.go
@@ -308,14 +308,14 @@ func resourceIBMCbrRuleCreate(context context.Context, d *schema.ResourceData, m
 
 	d.SetId(*rule.ID)
 
-	if err := resourceIBMCbrRuleSetData(response, rule, d); err != nil {
+	if err := resourceIBMCbrRuleSetData(rule, response, d); err != nil {
 		return diag.FromErr(fmt.Errorf("Error setting rule's resource data: %s", err))
 	}
 
 	return nil
 }
 
-func resourceIBMCbrRuleSetData(response *core.DetailedResponse, rule *contextbasedrestrictionsv1.Rule, d *schema.ResourceData) error {
+func resourceIBMCbrRuleSetData(rule *contextbasedrestrictionsv1.Rule, response *core.DetailedResponse, d *schema.ResourceData) error {
 	if err := d.Set("description", rule.Description); err != nil {
 		return fmt.Errorf("Error setting description: %s", err)
 	}
@@ -409,8 +409,8 @@ func resourceIBMCbrRuleRead(context context.Context, d *schema.ResourceData, met
 		return diag.FromErr(fmt.Errorf("Error setting transaction_id: %s", err))
 	}
 
-	if fromErr := resourceIBMCbrRuleSetData(response, rule, d); fromErr != nil {
-		return diag.FromErr(fmt.Errorf("Error setting rule's resource data: %s", fromErr))
+	if err = resourceIBMCbrRuleSetData(rule, response, d); err != nil {
+		return diag.FromErr(fmt.Errorf("Error setting rule's resource data: %s", err))
 	}
 
 	return nil
@@ -476,7 +476,7 @@ func resourceIBMCbrRuleUpdate(context context.Context, d *schema.ResourceData, m
 		return diag.FromErr(fmt.Errorf("ReplaceRuleWithContext failed %s\n%s", err, response))
 	}
 
-	if err := resourceIBMCbrRuleSetData(response, rule, d); err != nil {
+	if err := resourceIBMCbrRuleSetData(rule, response, d); err != nil {
 		return diag.FromErr(fmt.Errorf("Error setting rule's resource data: %s", err))
 	}
 

--- a/ibm/service/contextbasedrestrictions/resource_ibm_cbr_rule.go
+++ b/ibm/service/contextbasedrestrictions/resource_ibm_cbr_rule.go
@@ -316,12 +316,6 @@ func resourceIBMCbrRuleCreate(context context.Context, d *schema.ResourceData, m
 }
 
 func resourceIBMCbrRuleSetData(response *core.DetailedResponse, rule *contextbasedrestrictionsv1.Rule, d *schema.ResourceData) error {
-	if err := d.Set("x_correlation_id", response.Headers.Get("x_correlation_id")); err != nil {
-		return fmt.Errorf("Error setting x_correlation_id: %s", err)
-	}
-	if err := d.Set("transaction_id", response.Headers.Get("transaction_id")); err != nil {
-		return fmt.Errorf("Error setting transaction_id: %s", err)
-	}
 	if err := d.Set("description", rule.Description); err != nil {
 		return fmt.Errorf("Error setting description: %s", err)
 	}
@@ -406,6 +400,13 @@ func resourceIBMCbrRuleRead(context context.Context, d *schema.ResourceData, met
 		}
 		log.Printf("[DEBUG] GetRuleWithContext failed %s\n%s", err, response)
 		return diag.FromErr(fmt.Errorf("GetRuleWithContext failed %s\n%s", err, response))
+	}
+
+	if err = d.Set("x_correlation_id", getRuleOptions.XCorrelationID); err != nil {
+		return diag.FromErr(fmt.Errorf("Error setting x_correlation_id: %s", err))
+	}
+	if err = d.Set("transaction_id", getRuleOptions.TransactionID); err != nil {
+		return diag.FromErr(fmt.Errorf("Error setting transaction_id: %s", err))
 	}
 
 	if fromErr := resourceIBMCbrRuleSetData(response, rule, d); fromErr != nil {

--- a/ibm/service/contextbasedrestrictions/resource_ibm_cbr_rule.go
+++ b/ibm/service/contextbasedrestrictions/resource_ibm_cbr_rule.go
@@ -308,6 +308,83 @@ func resourceIBMCbrRuleCreate(context context.Context, d *schema.ResourceData, m
 
 	d.SetId(*rule.ID)
 
+	if fromErr := resourceIBMCbrRuleSetData(response, rule, d); fromErr != nil {
+		return diag.FromErr(fmt.Errorf("Error setting rule's resource data: %s", fromErr))
+	}
+
+	return nil
+}
+
+func resourceIBMCbrRuleSetData(response *core.DetailedResponse, rule *contextbasedrestrictionsv1.Rule, d *schema.ResourceData) diag.Diagnostics {
+	if err := d.Set("x_correlation_id", response.Headers.Get("x_correlation_id")); err != nil {
+		return diag.FromErr(fmt.Errorf("Error setting x_correlation_id: %s", err))
+	}
+	if err := d.Set("transaction_id", response.Headers.Get("transaction_id")); err != nil {
+		return diag.FromErr(fmt.Errorf("Error setting transaction_id: %s", err))
+	}
+	if err := d.Set("description", rule.Description); err != nil {
+		return diag.FromErr(fmt.Errorf("Error setting description: %s", err))
+	}
+	contexts := []map[string]interface{}{}
+	if rule.Contexts != nil {
+		for _, contextsItem := range rule.Contexts {
+			contextsItemMap, err := resourceIBMCbrRuleRuleContextToMap(&contextsItem)
+			if err != nil {
+				return diag.FromErr(err)
+			}
+			contexts = append(contexts, contextsItemMap)
+		}
+	}
+	if err := d.Set("contexts", contexts); err != nil {
+		return diag.FromErr(fmt.Errorf("Error setting contexts: %s", err))
+	}
+	resources := []map[string]interface{}{}
+	if rule.Resources != nil {
+		for _, resourcesItem := range rule.Resources {
+			resourcesItemMap, err := resourceIBMCbrRuleResourceToMap(&resourcesItem)
+			if err != nil {
+				return diag.FromErr(err)
+			}
+			resources = append(resources, resourcesItemMap)
+		}
+	}
+	if err := d.Set("resources", resources); err != nil {
+		return diag.FromErr(fmt.Errorf("Error setting resources: %s", err))
+	}
+	if rule.Operations != nil {
+		operationsMap, err := resourceIBMCbrRuleNewRuleOperationsToMap(rule.Operations)
+		if err != nil {
+			return diag.FromErr(err)
+		}
+		if err = d.Set("operations", []map[string]interface{}{operationsMap}); err != nil {
+			return diag.FromErr(fmt.Errorf("Error setting operations: %s", err))
+		}
+	}
+	if err := d.Set("enforcement_mode", rule.EnforcementMode); err != nil {
+		return diag.FromErr(fmt.Errorf("Error setting enforcement_mode: %s", err))
+	}
+	if err := d.Set("crn", rule.CRN); err != nil {
+		return diag.FromErr(fmt.Errorf("Error setting crn: %s", err))
+	}
+	if err := d.Set("href", rule.Href); err != nil {
+		return diag.FromErr(fmt.Errorf("Error setting href: %s", err))
+	}
+	if err := d.Set("created_at", flex.DateTimeToString(rule.CreatedAt)); err != nil {
+		return diag.FromErr(fmt.Errorf("Error setting created_at: %s", err))
+	}
+	if err := d.Set("created_by_id", rule.CreatedByID); err != nil {
+		return diag.FromErr(fmt.Errorf("Error setting created_by_id: %s", err))
+	}
+	if err := d.Set("last_modified_at", flex.DateTimeToString(rule.LastModifiedAt)); err != nil {
+		return diag.FromErr(fmt.Errorf("Error setting last_modified_at: %s", err))
+	}
+	if err := d.Set("last_modified_by_id", rule.LastModifiedByID); err != nil {
+		return diag.FromErr(fmt.Errorf("Error setting last_modified_by_id: %s", err))
+	}
+	if err := d.Set("version", response.Headers.Get("Etag")); err != nil {
+		return diag.FromErr(fmt.Errorf("Error setting version: %s", err))
+	}
+
 	return nil
 }
 

--- a/ibm/service/contextbasedrestrictions/resource_ibm_cbr_rule.go
+++ b/ibm/service/contextbasedrestrictions/resource_ibm_cbr_rule.go
@@ -408,73 +408,8 @@ func resourceIBMCbrRuleRead(context context.Context, d *schema.ResourceData, met
 		return diag.FromErr(fmt.Errorf("GetRuleWithContext failed %s\n%s", err, response))
 	}
 
-	if err = d.Set("x_correlation_id", getRuleOptions.XCorrelationID); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting x_correlation_id: %s", err))
-	}
-	if err = d.Set("transaction_id", getRuleOptions.TransactionID); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting transaction_id: %s", err))
-	}
-	if err = d.Set("description", rule.Description); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting description: %s", err))
-	}
-	contexts := []map[string]interface{}{}
-	if rule.Contexts != nil {
-		for _, contextsItem := range rule.Contexts {
-			contextsItemMap, err := resourceIBMCbrRuleRuleContextToMap(&contextsItem)
-			if err != nil {
-				return diag.FromErr(err)
-			}
-			contexts = append(contexts, contextsItemMap)
-		}
-	}
-	if err = d.Set("contexts", contexts); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting contexts: %s", err))
-	}
-	resources := []map[string]interface{}{}
-	if rule.Resources != nil {
-		for _, resourcesItem := range rule.Resources {
-			resourcesItemMap, err := resourceIBMCbrRuleResourceToMap(&resourcesItem)
-			if err != nil {
-				return diag.FromErr(err)
-			}
-			resources = append(resources, resourcesItemMap)
-		}
-	}
-	if err = d.Set("resources", resources); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting resources: %s", err))
-	}
-	if rule.Operations != nil {
-		operationsMap, err := resourceIBMCbrRuleNewRuleOperationsToMap(rule.Operations)
-		if err != nil {
-			return diag.FromErr(err)
-		}
-		if err = d.Set("operations", []map[string]interface{}{operationsMap}); err != nil {
-			return diag.FromErr(fmt.Errorf("Error setting operations: %s", err))
-		}
-	}
-	if err = d.Set("enforcement_mode", rule.EnforcementMode); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting enforcement_mode: %s", err))
-	}
-	if err = d.Set("crn", rule.CRN); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting crn: %s", err))
-	}
-	if err = d.Set("href", rule.Href); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting href: %s", err))
-	}
-	if err = d.Set("created_at", flex.DateTimeToString(rule.CreatedAt)); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting created_at: %s", err))
-	}
-	if err = d.Set("created_by_id", rule.CreatedByID); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting created_by_id: %s", err))
-	}
-	if err = d.Set("last_modified_at", flex.DateTimeToString(rule.LastModifiedAt)); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting last_modified_at: %s", err))
-	}
-	if err = d.Set("last_modified_by_id", rule.LastModifiedByID); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting last_modified_by_id: %s", err))
-	}
-	if err = d.Set("version", response.Headers.Get("Etag")); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting version: %s", err))
+	if fromErr := resourceIBMCbrRuleSetData(response, rule, d); fromErr != nil {
+		return diag.FromErr(fmt.Errorf("Error setting rule's resource data: %s", fromErr))
 	}
 
 	return nil
@@ -534,10 +469,14 @@ func resourceIBMCbrRuleUpdate(context context.Context, d *schema.ResourceData, m
 	}
 	replaceRuleOptions.SetIfMatch(d.Get("version").(string))
 
-	_, response, err := contextBasedRestrictionsClient.ReplaceRuleWithContext(context, replaceRuleOptions)
+	rule, response, err := contextBasedRestrictionsClient.ReplaceRuleWithContext(context, replaceRuleOptions)
 	if err != nil {
 		log.Printf("[DEBUG] ReplaceRuleWithContext failed %s\n%s", err, response)
 		return diag.FromErr(fmt.Errorf("ReplaceRuleWithContext failed %s\n%s", err, response))
+	}
+
+	if fromErr := resourceIBMCbrRuleSetData(response, rule, d); fromErr != nil {
+		return diag.FromErr(fmt.Errorf("Error setting rule's resource data: %s", fromErr))
 	}
 
 	return nil

--- a/ibm/service/contextbasedrestrictions/resource_ibm_cbr_zone.go
+++ b/ibm/service/contextbasedrestrictions/resource_ibm_cbr_zone.go
@@ -309,13 +309,13 @@ func resourceIBMCbrZoneCreate(context context.Context, d *schema.ResourceData, m
 
 	d.SetId(*zone.ID)
 
-	if err := ResourceIBMCbrZoneSetData(response, zone, d); err != nil {
+	if err := ResourceIBMCbrZoneSetData(zone, response, d); err != nil {
 		return diag.FromErr(fmt.Errorf("Error setting zone's resource data: %s", err))
 	}
 	return nil
 }
 
-func ResourceIBMCbrZoneSetData(response *core.DetailedResponse, zone *contextbasedrestrictionsv1.Zone, d *schema.ResourceData) error {
+func ResourceIBMCbrZoneSetData(zone *contextbasedrestrictionsv1.Zone, response *core.DetailedResponse, d *schema.ResourceData) error {
 	if err := d.Set("name", zone.Name); err != nil {
 		return fmt.Errorf("Error setting name: %s", err)
 	}
@@ -390,8 +390,8 @@ func resourceIBMCbrZoneRead(context context.Context, d *schema.ResourceData, met
 		return nil
 	}
 
-	if fromErr := ResourceIBMCbrZoneSetData(response, zone, d); fromErr != nil {
-		return diag.FromErr(fmt.Errorf("Error setting zone's resource data: %s", fromErr))
+	if err = ResourceIBMCbrZoneSetData(zone, response, d); err != nil {
+		return diag.FromErr(fmt.Errorf("Error setting zone's resource data: %s", err))
 	}
 
 	return nil
@@ -419,8 +419,7 @@ func resourceIBMCbrZoneUpdate(context context.Context, d *schema.ResourceData, m
 		return nil
 	}
 
-	version := response.Headers.Get("Etag")
-	replaceZoneOptions := contextBasedRestrictionsClient.NewReplaceZoneOptions(zoneId, version)
+	replaceZoneOptions := contextBasedRestrictionsClient.NewReplaceZoneOptions(zoneId, response.Headers.Get("Etag"))
 
 	if _, ok := d.GetOk("name"); ok {
 		replaceZoneOptions.SetName(d.Get("name").(string))
@@ -465,8 +464,8 @@ func resourceIBMCbrZoneUpdate(context context.Context, d *schema.ResourceData, m
 		log.Printf("[DEBUG] ReplaceZoneWithContext failed %s\n%s", err, response)
 		return diag.FromErr(fmt.Errorf("ReplaceZoneWithContext failed %s\n%s", err, response))
 	}
-	
-	if err := ResourceIBMCbrZoneSetData(response, zone, d); err != nil {
+
+	if err := ResourceIBMCbrZoneSetData(zone, response, d); err != nil {
 		return diag.FromErr(fmt.Errorf("Error setting zone's resource data: %s", err))
 	}
 

--- a/ibm/service/contextbasedrestrictions/resource_ibm_cbr_zone.go
+++ b/ibm/service/contextbasedrestrictions/resource_ibm_cbr_zone.go
@@ -311,6 +311,69 @@ func resourceIBMCbrZoneCreate(context context.Context, d *schema.ResourceData, m
 
 	d.SetId(*zone.ID)
 
+	if fromErr := ResourceIBMCbrZoneSetData(response, zone, d); fromErr != nil {
+		return diag.FromErr(fmt.Errorf("Error setting zone's resource data: %s", fromErr))
+	}
+	return nil
+}
+
+func ResourceIBMCbrZoneSetData(response *core.DetailedResponse, zone *contextbasedrestrictionsv1.Zone, d *schema.ResourceData) diag.Diagnostics {
+	if err := d.Set("name", zone.Name); err != nil {
+		return diag.FromErr(fmt.Errorf("Error setting name: %s", err))
+	}
+	if err := d.Set("account_id", zone.AccountID); err != nil {
+		return diag.FromErr(fmt.Errorf("Error setting account_id: %s", err))
+	}
+	if err := d.Set("description", zone.Description); err != nil {
+		return diag.FromErr(fmt.Errorf("Error setting description: %s", err))
+	}
+
+	var addresses []map[string]interface{}
+	addresses, err := resourceDecodeAddressList(zone.Addresses, cbrZoneAddressIdDefault)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+	if err = d.Set("addresses", addresses); err != nil {
+		return diag.FromErr(fmt.Errorf("Error setting addresses: %s", err))
+	}
+
+	var excluded []map[string]interface{}
+	excluded, err = resourceDecodeAddressList(zone.Excluded, cbrZoneAddressIdDefault)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+	if err = d.Set("excluded", excluded); err != nil {
+		return diag.FromErr(fmt.Errorf("Error setting excluded: %s", err))
+	}
+
+	if err = d.Set("crn", zone.CRN); err != nil {
+		return diag.FromErr(fmt.Errorf("Error setting crn: %s", err))
+	}
+	if err = d.Set("address_count", flex.IntValue(zone.AddressCount)); err != nil {
+		return diag.FromErr(fmt.Errorf("Error setting address_count: %s", err))
+	}
+	if err = d.Set("excluded_count", flex.IntValue(zone.ExcludedCount)); err != nil {
+		return diag.FromErr(fmt.Errorf("Error setting excluded_count: %s", err))
+	}
+	if err = d.Set("href", zone.Href); err != nil {
+		return diag.FromErr(fmt.Errorf("Error setting href: %s", err))
+	}
+	if err = d.Set("created_at", flex.DateTimeToString(zone.CreatedAt)); err != nil {
+		return diag.FromErr(fmt.Errorf("Error setting created_at: %s", err))
+	}
+	if err = d.Set("created_by_id", zone.CreatedByID); err != nil {
+		return diag.FromErr(fmt.Errorf("Error setting created_by_id: %s", err))
+	}
+	if err = d.Set("last_modified_at", flex.DateTimeToString(zone.LastModifiedAt)); err != nil {
+		return diag.FromErr(fmt.Errorf("Error setting last_modified_at: %s", err))
+	}
+	if err = d.Set("last_modified_by_id", zone.LastModifiedByID); err != nil {
+		return diag.FromErr(fmt.Errorf("Error setting last_modified_by_id: %s", err))
+	}
+	if err = d.Set("version", response.Headers.Get("Etag")); err != nil {
+		return diag.FromErr(fmt.Errorf("Error setting version: %s", err))
+	}
+
 	return nil
 }
 

--- a/ibm/service/contextbasedrestrictions/resource_ibm_cbr_zone.go
+++ b/ibm/service/contextbasedrestrictions/resource_ibm_cbr_zone.go
@@ -312,67 +312,67 @@ func resourceIBMCbrZoneCreate(context context.Context, d *schema.ResourceData, m
 	d.SetId(*zone.ID)
 
 	version := response.Headers.Get("Etag")
-	if fromErr := ResourceIBMCbrZoneSetData(zone, version, d); fromErr != nil {
-		return diag.FromErr(fmt.Errorf("Error setting zone's resource data: %s", fromErr))
+	if err := ResourceIBMCbrZoneSetData(zone, version, d); err != nil {
+		return diag.FromErr(fmt.Errorf("Error setting zone's resource data: %s", err))
 	}
 	return nil
 }
 
-func ResourceIBMCbrZoneSetData(zone *contextbasedrestrictionsv1.Zone, version string, d *schema.ResourceData) diag.Diagnostics {
+func ResourceIBMCbrZoneSetData(zone *contextbasedrestrictionsv1.Zone, version string, d *schema.ResourceData) error {
 	if err := d.Set("name", zone.Name); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting name: %s", err))
+		return fmt.Errorf("Error setting name: %s", err)
 	}
 	if err := d.Set("account_id", zone.AccountID); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting account_id: %s", err))
+		return fmt.Errorf("Error setting account_id: %s", err)
 	}
 	if err := d.Set("description", zone.Description); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting description: %s", err))
+		return fmt.Errorf("Error setting description: %s", err)
 	}
 
 	var addresses []map[string]interface{}
 	addresses, err := resourceDecodeAddressList(zone.Addresses, cbrZoneAddressIdDefault)
 	if err != nil {
-		return diag.FromErr(err)
+		return err
 	}
 	if err = d.Set("addresses", addresses); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting addresses: %s", err))
+		return fmt.Errorf("Error setting addresses: %s", err)
 	}
 
 	var excluded []map[string]interface{}
 	excluded, err = resourceDecodeAddressList(zone.Excluded, cbrZoneAddressIdDefault)
 	if err != nil {
-		return diag.FromErr(err)
+		return err
 	}
 	if err = d.Set("excluded", excluded); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting excluded: %s", err))
+		return fmt.Errorf("Error setting excluded: %s", err)
 	}
 
 	if err = d.Set("crn", zone.CRN); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting crn: %s", err))
+		return fmt.Errorf("Error setting crn: %s", err)
 	}
 	if err = d.Set("address_count", flex.IntValue(zone.AddressCount)); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting address_count: %s", err))
+		return fmt.Errorf("Error setting address_count: %s", err)
 	}
 	if err = d.Set("excluded_count", flex.IntValue(zone.ExcludedCount)); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting excluded_count: %s", err))
+		return fmt.Errorf("Error setting excluded_count: %s", err)
 	}
 	if err = d.Set("href", zone.Href); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting href: %s", err))
+		return fmt.Errorf("Error setting href: %s", err)
 	}
 	if err = d.Set("created_at", flex.DateTimeToString(zone.CreatedAt)); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting created_at: %s", err))
+		return fmt.Errorf("Error setting created_at: %s", err)
 	}
 	if err = d.Set("created_by_id", zone.CreatedByID); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting created_by_id: %s", err))
+		return fmt.Errorf("Error setting created_by_id: %s", err)
 	}
 	if err = d.Set("last_modified_at", flex.DateTimeToString(zone.LastModifiedAt)); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting last_modified_at: %s", err))
+		return fmt.Errorf("Error setting last_modified_at: %s", err)
 	}
 	if err = d.Set("last_modified_by_id", zone.LastModifiedByID); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting last_modified_by_id: %s", err))
+		return fmt.Errorf("Error setting last_modified_by_id: %s", err)
 	}
 	if err = d.Set("version", version); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting version: %s", err))
+		return fmt.Errorf("Error setting version: %s", err)
 	}
 
 	return nil
@@ -475,8 +475,8 @@ func resourceIBMCbrZoneUpdate(context context.Context, d *schema.ResourceData, m
 	}
 
 	version = response.Headers.Get("Etag")
-	if fromErr := ResourceIBMCbrZoneSetData(zone, version, d); fromErr != nil {
-		return diag.FromErr(fmt.Errorf("Error setting zone's resource data: %s", fromErr))
+	if err := ResourceIBMCbrZoneSetData(zone, version, d); err != nil {
+		return diag.FromErr(fmt.Errorf("Error setting zone's resource data: %s", err))
 	}
 
 	return nil

--- a/ibm/service/contextbasedrestrictions/resource_ibm_cbr_zone_addresses.go
+++ b/ibm/service/contextbasedrestrictions/resource_ibm_cbr_zone_addresses.go
@@ -246,9 +246,7 @@ func resourceReplaceZoneAddresses(context context.Context, d *schema.ResourceDat
 		return nil
 	}
 
-	version := response.Headers.Get("Etag")
-
-	replaceZoneOptions := contextBasedRestrictionsClient.NewReplaceZoneOptions(zoneId, version)
+	replaceZoneOptions := contextBasedRestrictionsClient.NewReplaceZoneOptions(zoneId, response.Headers.Get("Etag"))
 	replaceZoneOptions.SetName(*currentZone.Name)
 	replaceZoneOptions.SetAccountID(*currentZone.AccountID)
 	if currentZone.Description != nil {

--- a/ibm/service/contextbasedrestrictions/resource_ibm_cbr_zone_addresses.go
+++ b/ibm/service/contextbasedrestrictions/resource_ibm_cbr_zone_addresses.go
@@ -234,10 +234,7 @@ func resourceReplaceZoneAddresses(context context.Context, d *schema.ResourceDat
 	mutex.Lock()
 	defer mutex.Unlock()
 
-	var currentZone *contextbasedrestrictionsv1.Zone
-	var version string
-	var found bool
-	currentZone, version, found, err = getZone(contextBasedRestrictionsClient, context, zoneId)
+	currentZone, response, found, err := getZone(contextBasedRestrictionsClient, context, zoneId)
 	if err != nil {
 		return err
 	}
@@ -248,6 +245,8 @@ func resourceReplaceZoneAddresses(context context.Context, d *schema.ResourceDat
 		}
 		return nil
 	}
+
+	version := response.Headers.Get("Etag")
 
 	replaceZoneOptions := contextBasedRestrictionsClient.NewReplaceZoneOptions(zoneId, version)
 	replaceZoneOptions.SetName(*currentZone.Name)
@@ -275,7 +274,7 @@ func resourceReplaceZoneAddresses(context context.Context, d *schema.ResourceDat
 	}
 	replaceZoneOptions.SetAddresses(addresses)
 
-	_, response, err := contextBasedRestrictionsClient.ReplaceZoneWithContext(context, replaceZoneOptions)
+	_, response, err = contextBasedRestrictionsClient.ReplaceZoneWithContext(context, replaceZoneOptions)
 	if err != nil {
 		log.Printf("[DEBUG] ReplaceZoneWithContext failed %s\n%s", err, response)
 		return fmt.Errorf("ReplaceZoneWithContext failed %s\n%s", err, response)


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/IBM-Cloud/terraform-provider-ibm/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
 make testacc TEST=./ibm/service/contextbasedrestrictions TESTARGS='-run=TestAccIBMCbrRuleBasic'
=== RUN   TestAccIBMCbrRuleBasic
--- PASS: TestAccIBMCbrRuleBasic (12.78s)
PASS
ok      github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/contextbasedrestrictions        14.466s


make testacc TEST=./ibm/service/contextbasedrestrictions TESTARGS='-run=TestAccIBMCbrRuleAllArgs'
=== RUN   TestAccIBMCbrRuleAllArgs
--- PASS: TestAccIBMCbrRuleAllArgs (24.86s)
PASS
ok      github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/contextbasedrestrictions        26.549s

make testacc TEST=./ibm/service/contextbasedrestrictions TESTARGS='-run=TestAccIBMCbrZoneBasic'
=== RUN   TestAccIBMCbrZoneBasic
--- PASS: TestAccIBMCbrZoneBasic (14.36s)
PASS
ok      github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/contextbasedrestrictions        15.920s

make testacc TEST=./ibm/service/contextbasedrestrictions TESTARGS='-run=TestAccIBMCbrZoneAllArgs'
=== RUN   TestAccIBMCbrZoneAllArgs
--- PASS: TestAccIBMCbrZoneAllArgs (22.99s)
PASS
ok      github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/contextbasedrestrictions        24.587s


make testacc TEST=./ibm/service/contextbasedrestrictions TESTARGS='-run=TestAccIBMCbrZoneAddressesBasic'
=== RUN   TestAccIBMCbrZoneAddressesBasic
--- PASS: TestAccIBMCbrZoneAddressesBasic (31.54s)
PASS
ok      github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/contextbasedrestrictions        33.140s

make testacc TEST=./ibm/service/contextbasedrestrictions TESTARGS='-run=TestAccIBMCbrZoneAddressesUpdate'
=== RUN   TestAccIBMCbrZoneAddressesUpdate
--- PASS: TestAccIBMCbrZoneAddressesUpdate (47.46s)
PASS
ok      github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/contextbasedrestrictions        49.076s


...
```
