### PR TITLE
Granular CRN for image datasources and resources

### DIFF
--- a/ibm/acctest/acctest.go
+++ b/ibm/acctest/acctest.go
@@ -214,6 +214,7 @@ var (
 	Pi_image_bucket_name            string
 	Pi_image_bucket_region          string
 	Pi_image_bucket_secret_key      string
+	Pi_image_id                     string
 	Pi_instance_name                string
 	Pi_key_name                     string
 	Pi_network_name                 string
@@ -1047,7 +1048,13 @@ func init() {
 	Pi_image_bucket_region = os.Getenv("PI_IMAGE_BUCKET_REGION")
 	if Pi_image_bucket_region == "" {
 		Pi_image_bucket_region = "us-east"
-		fmt.Println("[INFO] Set the environment variable PI_IMAGE_BUCKET_REGION for testing ibm_pi_image_export resource else it is set to default value 'us-east'")
+		fmt.Println("[INFO] Set the environment variable PI_IMAGE_BUCKET_REGION for testing ibm_pi_image resource else it is set to default value 'us-east'")
+	}
+
+	Pi_image_id = os.Getenv("PI_IMAGE_ID")
+	if Pi_image_id == "" {
+		Pi_image_id = "IBMi-72-09-2924-11"
+		fmt.Println("[INFO] Set the environment variable PI_IMAGE_ID for testing ibm_pi_image resource else it is set to default value 'IBMi-72-09-2924-11'")
 	}
 
 	Pi_key_name = os.Getenv("PI_KEY_NAME")

--- a/ibm/service/power/data_source_ibm_pi_catalog_images.go
+++ b/ibm/service/power/data_source_ibm_pi_catalog_images.go
@@ -59,6 +59,11 @@ func DataSourceIBMPICatalogImages() *schema.Resource {
 							Description: "Date of image creation",
 							Type:        schema.TypeString,
 						},
+						Attr_CRN: {
+							Computed:    true,
+							Description: "CRN of this resource.",
+							Type:        schema.TypeString,
+						},
 						Attr_Description: {
 							Computed:    true,
 							Description: "The description of an image.",
@@ -158,6 +163,9 @@ func dataSourceIBMPICatalogImagesRead(ctx context.Context, d *schema.ResourceDat
 		}
 		if i.CreationDate != nil {
 			image[Attr_CreationDate] = i.CreationDate.String()
+		}
+		if i.Crn != "" {
+			image[Attr_CRN] = i.Crn
 		}
 		if i.Href != nil {
 			image[Attr_Href] = *i.Href

--- a/ibm/service/power/data_source_ibm_pi_image.go
+++ b/ibm/service/power/data_source_ibm_pi_image.go
@@ -5,9 +5,11 @@ package power
 
 import (
 	"context"
+	"log"
 
 	"github.com/IBM-Cloud/power-go-client/clients/instance"
 	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/conns"
+	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/flex"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
@@ -35,6 +37,11 @@ func DataSourceIBMPIImage() *schema.Resource {
 			Attr_Architecture: {
 				Computed:    true,
 				Description: "The CPU architecture that the image is designed for. ",
+				Type:        schema.TypeString,
+			},
+			Attr_CRN: {
+				Computed:    true,
+				Description: "The CRN of this resource.",
 				Type:        schema.TypeString,
 			},
 			Attr_Hypervisor: {
@@ -73,6 +80,13 @@ func DataSourceIBMPIImage() *schema.Resource {
 				Description: "The storage type for this image.",
 				Type:        schema.TypeString,
 			},
+			Attr_UserTags: {
+				Computed:    true,
+				Description: "List of user tags attached to the resource.",
+				Elem:        &schema.Schema{Type: schema.TypeString},
+				Set:         schema.HashString,
+				Type:        schema.TypeSet,
+			},
 		},
 	}
 }
@@ -93,6 +107,14 @@ func dataSourceIBMPIImagesRead(ctx context.Context, d *schema.ResourceData, meta
 
 	d.SetId(*imagedata.ImageID)
 	d.Set(Attr_Architecture, imagedata.Specifications.Architecture)
+	if imagedata.Crn != "" {
+		d.Set(Attr_CRN, imagedata.Crn)
+		tags, err := flex.GetTagsUsingCRN(meta, string(imagedata.Crn))
+		if err != nil {
+			log.Printf("Error on get of pi image (%s) user_tags: %s", *imagedata.ImageID, err)
+		}
+		d.Set(Attr_UserTags, tags)
+	}
 	d.Set(Attr_Hypervisor, imagedata.Specifications.HypervisorType)
 	d.Set(Attr_ImageType, imagedata.Specifications.ImageType)
 	d.Set(Attr_OperatingSystem, imagedata.Specifications.OperatingSystem)

--- a/ibm/service/power/data_source_ibm_pi_images.go
+++ b/ibm/service/power/data_source_ibm_pi_images.go
@@ -5,10 +5,12 @@ package power
 
 import (
 	"context"
+	"log"
 
 	"github.com/IBM-Cloud/power-go-client/clients/instance"
 	"github.com/IBM-Cloud/power-go-client/power/models"
 	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/conns"
+	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/flex"
 	"github.com/hashicorp/go-uuid"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -34,6 +36,11 @@ func DataSourceIBMPIImages() *schema.Resource {
 				Description: "List of all supported images.",
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
+						Attr_CRN: {
+							Computed:    true,
+							Description: "The CRN of this resource.",
+							Type:        schema.TypeString,
+						},
 						Attr_Href: {
 							Computed:    true,
 							Description: "The hyper link of an image.",
@@ -69,6 +76,13 @@ func DataSourceIBMPIImages() *schema.Resource {
 							Description: "The storage type of an image.",
 							Type:        schema.TypeString,
 						},
+						Attr_UserTags: {
+							Computed:    true,
+							Description: "List of user tags attached to the resource.",
+							Elem:        &schema.Schema{Type: schema.TypeString},
+							Set:         schema.HashString,
+							Type:        schema.TypeSet,
+						},
 					},
 				},
 				Type: schema.TypeList,
@@ -93,12 +107,12 @@ func dataSourceIBMPIImagesAllRead(ctx context.Context, d *schema.ResourceData, m
 
 	var clientgenU, _ = uuid.GenerateUUID()
 	d.SetId(clientgenU)
-	d.Set(Attr_ImageInfo, flattenStockImages(imagedata.Images))
+	d.Set(Attr_ImageInfo, flattenStockImages(imagedata.Images, meta))
 
 	return nil
 }
 
-func flattenStockImages(list []*models.ImageReference) []map[string]interface{} {
+func flattenStockImages(list []*models.ImageReference, meta interface{}) []map[string]interface{} {
 	result := make([]map[string]interface{}, 0, len(list))
 	for _, i := range list {
 		l := map[string]interface{}{
@@ -109,6 +123,15 @@ func flattenStockImages(list []*models.ImageReference) []map[string]interface{} 
 			Attr_State:       *i.State,
 			Attr_StoragePool: *i.StoragePool,
 			Attr_StorageType: *i.StorageType,
+		}
+		if i.Crn != "" {
+			l[Attr_CRN] = i.Crn
+			tags, err := flex.GetTagsUsingCRN(meta, string(i.Crn))
+			if err != nil {
+				log.Printf(
+					"Error on get of image (%s) user_tags: %s", *i.ImageID, err)
+			}
+			l[Attr_UserTags] = tags
 		}
 		result = append(result, l)
 	}

--- a/ibm/service/power/resource_ibm_pi_image_test.go
+++ b/ibm/service/power/resource_ibm_pi_image_test.go
@@ -20,7 +20,7 @@ import (
 )
 
 func TestAccIBMPIImagebasic(t *testing.T) {
-
+	imageRes := "ibm_pi_image.power_image"
 	name := fmt.Sprintf("tf-pi-image-%d", acctest.RandIntRange(10, 100))
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { acc.TestAccPreCheck(t) },
@@ -30,9 +30,8 @@ func TestAccIBMPIImagebasic(t *testing.T) {
 			{
 				Config: testAccCheckIBMPIImageConfig(name),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckIBMPIImageExists("ibm_pi_image.power_image"),
-					resource.TestCheckResourceAttr(
-						"ibm_pi_image.power_image", "pi_image_name", name),
+					testAccCheckIBMPIImageExists(imageRes),
+					resource.TestCheckResourceAttr(imageRes, "pi_image_name", name),
 				),
 			},
 		},
@@ -137,6 +136,54 @@ func testAccCheckIBMPIImageCOSPublicConfig(name string) string {
 	`, name, acc.Pi_cloud_instance_id, acc.Pi_image_bucket_name, acc.Pi_image_bucket_file_name)
 }
 
+func TestAccIBMPIImageUserTags(t *testing.T) {
+	imageRes := "ibm_pi_image.power_image"
+	name := fmt.Sprintf("tf-pi-image-%d", acctest.RandIntRange(10, 100))
+	userTagsString := `["env:dev","test_tag"]`
+	userTagsStringUpdated := `["env:dev","test_tag","ibm"]`
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { acc.TestAccPreCheck(t) },
+		Providers:    acc.TestAccProviders,
+		CheckDestroy: testAccCheckIBMPIImageDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckIBMPIImageUserTagsConfig(name, userTagsString),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckIBMPIImageExists(imageRes),
+					resource.TestCheckResourceAttr(imageRes, "pi_image_name", name),
+					resource.TestCheckResourceAttrSet(imageRes, "image_id"),
+					resource.TestCheckResourceAttr(imageRes, "pi_user_tags.#", "2"),
+					resource.TestCheckTypeSetElemAttr(imageRes, "pi_user_tags.*", "env:dev"),
+					resource.TestCheckTypeSetElemAttr(imageRes, "pi_user_tags.*", "test_tag"),
+				),
+			},
+			{
+				Config: testAccCheckIBMPIImageUserTagsConfig(name, userTagsStringUpdated),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckIBMPIImageExists(imageRes),
+					resource.TestCheckResourceAttr(imageRes, "pi_image_name", name),
+					resource.TestCheckResourceAttrSet(imageRes, "image_id"),
+					resource.TestCheckResourceAttr(imageRes, "pi_user_tags.#", "3"),
+					resource.TestCheckTypeSetElemAttr(imageRes, "pi_user_tags.*", "env:dev"),
+					resource.TestCheckTypeSetElemAttr(imageRes, "pi_user_tags.*", "test_tag"),
+					resource.TestCheckTypeSetElemAttr(imageRes, "pi_user_tags.*", "ibm"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckIBMPIImageUserTagsConfig(name string, userTagsString string) string {
+	return fmt.Sprintf(`
+	resource "ibm_pi_image" "power_image" {
+		pi_cloud_instance_id = "%[2]s"
+		pi_image_id         = "%[3]s"
+		pi_image_name       = "%[1]s"
+		pi_user_tags        = %[4]s
+	  }
+	`, name, acc.Pi_cloud_instance_id, acc.Pi_image, userTagsString)
+}
+
 func TestAccIBMPIImageBYOLImport(t *testing.T) {
 	imageRes := "ibm_pi_image.cos_image"
 	name := fmt.Sprintf("tf-pi-image-byoi-%d", acctest.RandIntRange(10, 100))
@@ -164,7 +211,7 @@ func testAccCheckIBMPIImageBYOLConfig(name string) string {
 		pi_image_bucket_access = "private"
 		pi_image_bucket_file_name = "%[4]s" 
 		pi_image_bucket_name = "%[3]s" 
-		pi_image_bucket_region = "us-east"
+		pi_image_bucket_region = "%[7]s"
 		pi_image_name       = "%[1]s"
 		pi_image_secret_key = "%[6]s"
 		pi_image_storage_type = "tier3"
@@ -174,5 +221,5 @@ func testAccCheckIBMPIImageBYOLConfig(name string) string {
 			vendor = "SAP"
 		}
 	}
-	`, name, acc.Pi_cloud_instance_id, acc.Pi_image_bucket_name, acc.Pi_image_bucket_file_name, acc.Pi_image_bucket_access_key, acc.Pi_image_bucket_secret_key)
+	`, name, acc.Pi_cloud_instance_id, acc.Pi_image_bucket_name, acc.Pi_image_bucket_file_name, acc.Pi_image_bucket_access_key, acc.Pi_image_bucket_secret_key, acc.Pi_image_bucket_region)
 }

--- a/website/docs/d/pi_catalog_images.html.markdown
+++ b/website/docs/d/pi_catalog_images.html.markdown
@@ -48,6 +48,7 @@ In addition to the argument reference list, you can access the following attribu
 	- `architecture` - (String) The CPU architecture that the image is designed for.
 	- `container_format` - (String) The container format.
 	- `creation_date` - (String) Date of image creation.
+	- `crn` - (String) The CRN of this resource.
 	- `description` - (String) The description of an image.
 	- `disk_format` - (String) The disk format.
 	- `endianness` - (String) The `Endianness` order.

--- a/website/docs/d/pi_image.html.markdown
+++ b/website/docs/d/pi_image.html.markdown
@@ -42,6 +42,7 @@ Review the argument references that you can specify for your data source.
 In addition to all argument reference list, you can access the following attribute references after your data source is created. 
 
 - `architecture` - (String) The CPU architecture that the image is designed for. 
+- `crn` - (String) The CRN of this resource.
 - `hypervisor` - (String) Hypervisor type.
 - `id` - (String) The unique identifier of the image.
 - `image_type` - (String) The identifier of this image type.
@@ -50,3 +51,5 @@ In addition to all argument reference list, you can access the following attribu
 - `state` - (String) The state for this image. 
 - `storage_type` - (String) The storage type for this image.
 - `storage_pool` - (String) Storage pool where image resides.
+- `user_tags` - (List) List of user tags attached to the resource.
+

--- a/website/docs/d/pi_images.html.markdown
+++ b/website/docs/d/pi_images.html.markdown
@@ -43,6 +43,7 @@ In addition to all argument reference list, you can access the following attribu
 - `image_info` - (List) List of all supported images. 
 
   Nested scheme for `image_info`:
+  - `crn` - (String) The CRN of this resource.
   - `href` - (String) The hyper link of an image. 
   - `id` - (String) The unique identifier of an image.
   - `image_type` - (String) The identifier of this image type.
@@ -50,3 +51,4 @@ In addition to all argument reference list, you can access the following attribu
   - `state` - (String) The state of an image.
   - `storage_pool` - (String) Storage pool where image resides.
   - `storage_type` - (String) The storage type of an image.
+  - `user_tags` - (List) List of user tags attached to the resource.

--- a/website/docs/r/pi_image.html.markdown
+++ b/website/docs/r/pi_image.html.markdown
@@ -95,11 +95,13 @@ Review the argument references that you can specify for your resource.
   - `license_type` - (Required, String) Origin of the license of the product. Allowable value is: `byol`.
   - `product` - (Required, String) Product within the image.Allowable values are: `Hana`, `Netweaver`.
   - `vendor` - (Required, String) Vendor supporting the product. Allowable value is: `SAP`.
+- `pi_user_tags` - (Optional, List) The user tags attached to this resource.
 
 ## Attribute reference
 
 In addition to all argument reference list, you can access the following attribute reference after your resource is created.
 
+- `crn` - (String) The CRN of this resource.
 - `id` - (String) The unique identifier of an image. The ID is composed of `<pi_cloud_instance_id>/<image_id>`.
 - `image_id` - (String) The unique identifier of an image.
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/IBM-Cloud/terraform-provider-ibm/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Output from acceptance testing:

pi_catalog_images (d):

```
=== RUN   TestAccIBMPICatalogImagesDataSourceBasic
--- PASS: TestAccIBMPICatalogImagesDataSourceBasic (52.36s)
PASS
```

```
=== RUN   TestAccIBMPICatalogImagesDataSourceVTL
--- PASS: TestAccIBMPICatalogImagesDataSourceVTL (51.41s)
PASS
```

```
=== RUN   TestAccIBMPICatalogImagesDataSourceSAP
--- PASS: TestAccIBMPICatalogImagesDataSourceSAP (74.17s)
PASS
```

```
=== RUN   TestAccIBMPICatalogImagesDataSourceSAPAndVTL
--- PASS: TestAccIBMPICatalogImagesDataSourceSAPAndVTL (61.02s)
PASS
```

pi_image (d):

```
=== RUN   TestAccIBMPIImageDataSource_basic
--- PASS: TestAccIBMPIImageDataSource_basic (17.08s)
PASS
```

pi_images (d):

```
=== RUN   TestAccIBMPIImagesDataSource_basic
--- PASS: TestAccIBMPIImagesDataSource_basic (28.87s)
PASS
```

pi_image (r):

```
=== RUN   TestAccIBMPIImagebasic
--- PASS: TestAccIBMPIImagebasic (40.15s)
PASS
```

(Used private bucket)
```
=== RUN   TestAccIBMPIImageCOSPublicImport
--- PASS: TestAccIBMPIImageCOSPublicImport (1227.62s)
PASS
```

```
=== RUN   TestAccIBMPIImageBYOLImport
--- PASS: TestAccIBMPIImageBYOLImport (1817.78s)
PASS
```

```=== RUN   TestAccIBMPIImageUserTags
--- PASS: TestAccIBMPIImageUserTags (38.51s)
PASS
```