### PR TITLE
Granular CRN for instance datasources and resources

### DIFF
--- a/ibm/service/power/data_source_ibm_pi_instance_test.go
+++ b/ibm/service/power/data_source_ibm_pi_instance_test.go
@@ -13,6 +13,7 @@ import (
 )
 
 func TestAccIBMPIInstanceDataSource_basic(t *testing.T) {
+	instanceResData := "data.ibm_pi_instance.testacc_ds_instance"
 	resource.Test(t, resource.TestCase{
 		PreCheck:  func() { acc.TestAccPreCheck(t) },
 		Providers: acc.TestAccProviders,
@@ -20,7 +21,7 @@ func TestAccIBMPIInstanceDataSource_basic(t *testing.T) {
 			{
 				Config: testAccCheckIBMPIInstanceDataSourceConfig(),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttrSet("data.ibm_pi_instance.testacc_ds_instance", "id"),
+					resource.TestCheckResourceAttrSet(instanceResData, "id"),
 				),
 			},
 		},

--- a/ibm/service/power/data_source_ibm_pi_instances_test.go
+++ b/ibm/service/power/data_source_ibm_pi_instances_test.go
@@ -13,6 +13,7 @@ import (
 )
 
 func TestAccIBMPIInstancesDataSource_basic(t *testing.T) {
+	instancesResData := "data.ibm_pi_instances.testacc_ds_instance"
 	resource.Test(t, resource.TestCase{
 		PreCheck:  func() { acc.TestAccPreCheck(t) },
 		Providers: acc.TestAccProviders,
@@ -20,7 +21,7 @@ func TestAccIBMPIInstancesDataSource_basic(t *testing.T) {
 			{
 				Config: testAccCheckIBMPIInstancesDataSourceConfig(),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttrSet("data.ibm_pi_instances.testacc_ds_instance", "id"),
+					resource.TestCheckResourceAttrSet(instancesResData, "id"),
 				),
 			},
 		},

--- a/ibm/service/power/resource_ibm_pi_instance_test.go
+++ b/ibm/service/power/resource_ibm_pi_instance_test.go
@@ -256,6 +256,50 @@ func testAccCheckIBMPIInstanceDeplomentTargetConfig(name string) string {
 	`, acc.Pi_cloud_instance_id, name, acc.Pi_image, acc.Pi_network_name)
 }
 
+func testAccCheckIBMPIInstanceUserTagsConfig(name, instanceHealthStatus string, userTagsString string) string {
+	return fmt.Sprintf(`
+	resource "ibm_pi_key" "key" {
+		pi_cloud_instance_id = "%[1]s"
+		pi_key_name          = "%[2]s"
+		pi_ssh_key           = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCKVmnMOlHKcZK8tpt3MP1lqOLAcqcJzhsvJcjscgVERRN7/9484SOBJ3HSKxxNG5JN8owAjy5f9yYwcUg+JaUVuytn5Pv3aeYROHGGg+5G346xaq3DAwX6Y5ykr2fvjObgncQBnuU5KHWCECO/4h8uWuwh/kfniXPVjFToc+gnkqA+3RKpAecZhFXwfalQ9mMuYGFxn+fwn8cYEApsJbsEmb0iJwPiZ5hjFC8wREuiTlhPHDgkBLOiycd20op2nXzDbHfCHInquEe/gYxEitALONxm0swBOwJZwlTDOB7C6y2dzlrtxr1L59m7pCkWI4EtTRLvleehBoj3u7jB4usR"
+	  }
+	  data "ibm_pi_image" "power_image" {
+		pi_cloud_instance_id = "%[1]s"
+		pi_image_name        = "%[3]s"
+	  }
+	  data "ibm_pi_network" "power_networks" {
+		pi_cloud_instance_id = "%[1]s"
+		pi_network_name      = "%[4]s"
+	  }
+	  resource "ibm_pi_volume" "power_volume" {
+		pi_cloud_instance_id = "%[1]s"
+		pi_volume_name       = "%[2]s"
+		pi_volume_pool       = data.ibm_pi_image.power_image.storage_pool
+		pi_volume_shareable  = true
+		pi_volume_size       = 20
+		pi_volume_type       = "%[6]s"
+	  }
+	  resource "ibm_pi_instance" "power_instance" {
+		pi_cloud_instance_id  = "%[1]s"
+		pi_health_status      = "%[5]s"
+		pi_image_id           = data.ibm_pi_image.power_image.id
+		pi_instance_name      = "%[2]s"
+		pi_key_pair_name      = ibm_pi_key.key.name
+		pi_memory             = "2"
+		pi_proc_type          = "shared"
+		pi_processors         = "0.25"
+		pi_storage_pool       = data.ibm_pi_image.power_image.storage_pool
+		pi_storage_type       = "%[6]s"
+		pi_sys_type           = "s922"
+		pi_volume_ids         = [ibm_pi_volume.power_volume.volume_id]
+		pi_network {
+			network_id = data.ibm_pi_network.power_networks.id
+		}
+		pi_user_tags          = %[7]s
+	  }
+	`, acc.Pi_cloud_instance_id, name, acc.Pi_image, acc.Pi_network_name, instanceHealthStatus, acc.PiStorageType, userTagsString)
+}
+
 func testAccCheckIBMPIInstanceDestroy(s *terraform.State) error {
 	sess, err := acc.TestAccProvider.Meta().(conns.ClientSession).IBMPISession()
 	if err != nil {
@@ -780,6 +824,41 @@ func TestAccIBMPIInstanceDeploymentTypeNoStorage(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckIBMPIInstanceExists(instanceRes),
 					resource.TestCheckResourceAttr(instanceRes, "pi_instance_name", name),
+				),
+			},
+		},
+	})
+}
+
+func TestAccIBMPIInstanceUserTags(t *testing.T) {
+	instanceRes := "ibm_pi_instance.power_instance"
+	name := fmt.Sprintf("tf-pi-instance-%d", acctest.RandIntRange(10, 100))
+	userTagsString := `["env:dev", "test_tag"]`
+	userTagsStringUpdated := `["env:dev", "test_tag", "test_tag2"]`
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { acc.TestAccPreCheck(t) },
+		Providers:    acc.TestAccProviders,
+		CheckDestroy: testAccCheckIBMPIInstanceDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckIBMPIInstanceUserTagsConfig(name, power.OK, userTagsString),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckIBMPIInstanceExists(instanceRes),
+					resource.TestCheckResourceAttr(instanceRes, "pi_instance_name", name),
+					resource.TestCheckResourceAttr(instanceRes, "pi_user_tags.#", "2"),
+					resource.TestCheckTypeSetElemAttr(instanceRes, "pi_user_tags.*", "env:dev"),
+					resource.TestCheckTypeSetElemAttr(instanceRes, "pi_user_tags.*", "test_tag"),
+				),
+			},
+			{
+				Config: testAccCheckIBMPIInstanceUserTagsConfig(name, power.OK, userTagsStringUpdated),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckIBMPIInstanceExists(instanceRes),
+					resource.TestCheckResourceAttr(instanceRes, "pi_instance_name", name),
+					resource.TestCheckResourceAttr(instanceRes, "pi_user_tags.#", "3"),
+					resource.TestCheckTypeSetElemAttr(instanceRes, "pi_user_tags.*", "env:dev"),
+					resource.TestCheckTypeSetElemAttr(instanceRes, "pi_user_tags.*", "test_tag"),
+					resource.TestCheckTypeSetElemAttr(instanceRes, "pi_user_tags.*", "test_tag2"),
 				),
 			},
 		},

--- a/website/docs/d/pi_cloud_instance.html.markdown
+++ b/website/docs/d/pi_cloud_instance.html.markdown
@@ -45,11 +45,13 @@ In addition to the argument reference list, you can access the following attribu
 
   Nested scheme for `pvm_instances`:
   - `creation_date` - (String) Date of PVM instance creation.
+  - `crn` - (String) The CRN of this resource.
   - `href` - (String) Link to Cloud Instance resource.
   - `id` - (String) PVM Instance ID.
   - `name` - (String) Name of the server.
   - `status` - (String) The status of the instance.
   - `systype` - (string) System type used to host the instance.
+  - `user_tags` - (List) List of user tags attached to the resource.
 - `region` - (String) The region the cloud instance lives.
 - `tenant_id` - (String) The tenant ID that owns this cloud instance.
 - `total_instances` - (String) The count of lpars that belong to this specific cloud instance.

--- a/website/docs/d/pi_instance.html.markdown
+++ b/website/docs/d/pi_instance.html.markdown
@@ -46,6 +46,7 @@ Review the argument references that you can specify for your data source.
 
 In addition to all argument reference list, you can access the following attribute references after your data source is created.
 
+- `crn` - (String) The CRN of this resource.
 - `deployment_type` - (String) The custom deployment type.
 - `fault` - (Map) Fault information, if any.
   
@@ -94,5 +95,6 @@ In addition to all argument reference list, you can access the following attribu
 - `storage_pool` - (String) The storage Pool where server is deployed.
 - `storage_pool_affinity` - (Boolean) Indicates if all volumes attached to the server must reside in the same storage pool.
 - `storage_type` - (String) The storage type where server is deployed.
+- `user_tags` - (List) List of user tags attached to the resource.
 - `virtual_cores_assigned` - (Integer) The virtual cores that are assigned to the instance.
 - `volumes` - (List) List of volume IDs that are attached to the instance.

--- a/website/docs/d/pi_instances.html.markdown
+++ b/website/docs/d/pi_instances.html.markdown
@@ -47,6 +47,7 @@ In addition to all argument reference list, you can access the following attribu
 - `pvm_instances` - (List) List of power virtual server instances for the respective cloud instance.
 
   Nested scheme for `pvm_instances`:
+  - `crn` - (String) The CRN of this resource.
   - `fault` - (Map) Fault information, if any.
 
       Nested scheme for `fault`:
@@ -87,4 +88,5 @@ In addition to all argument reference list, you can access the following attribu
   - `storage_pool` - (String) The storage Pool where server is deployed.
   - `storage_pool_affinity` - (Boolean) Indicates if all volumes attached to the server must reside in the same storage pool.
   - `storage_type` - (String) The storage type where server is deployed.
+  - `user_tags` - (List) List of user tags attached to the resource.
   - `virtual_cores_assigned` - (Integer) The virtual cores that are assigned to the instance.

--- a/website/docs/r/pi_capture.html.markdown
+++ b/website/docs/r/pi_capture.html.markdown
@@ -71,11 +71,12 @@ Review the argument references that you can specify for your resource.
 - `pi_capture_cloud_storage_access_key`- (Optional,String) Cloud Storage Access key
 - `pi_capture_cloud_storage_secret_key`- (Optional,String) Cloud Storage Secret key
 - `pi_capture_storage_image_path` - (Optional,String) Cloud Storage Image Path (bucket-name [/folder/../..])
-
+- `pi_user_tags` - (Optional, List) List of user tags attached to the resource.
 
 ## Attribute reference
 In addition to all argument reference list, you can access the following attribute reference after your resource is created.
 
+- `crn` - (String) The CRN of the resource.
 - `id` - (String) The image id of the capture instance. The ID is composed of `<pi_cloud_instance_id>/<pi_capture_name>/<pi_capture_destination>`.
 - `image_id` - (String) The image id of the capture instance.
 

--- a/website/docs/r/pi_instance.html.markdown
+++ b/website/docs/r/pi_instance.html.markdown
@@ -117,6 +117,7 @@ Review the argument references that you can specify for your resource.
 - `pi_sys_type` - (Optional, String) The type of system on which to create the VM (e880/e980/e1080/s922/s1022).
   - Supported SAP system types are (e880/e980/e1080).
 - `pi_user_data` - (Optional, String) The user data `cloud-init` to pass to the instance during creation. It can be a base64 encoded or an unencoded string. If it is an unencoded string, the provider will encode it before it passing it down.
+- `pi_user_tags` - (Optional, List) The user tags attached to this resource.
 - `pi_virtual_cores_assigned`  - (Optional, Integer) Specify the number of virtual cores to be assigned.
 - `pi_virtual_optical_device` - (Optional, String) Virtual Machine's Cloud Initialization Virtual Optical Device.
 - `pi_volume_ids` - (Optional, List of String) The list of volume IDs that you want to attach to the instance during creation.
@@ -125,6 +126,7 @@ Review the argument references that you can specify for your resource.
 
 In addition to all argument reference list, you can access the following attribute reference after your resource is created.
 
+- `crn` - (String) The CRN of this resource.
 - `fault` - (Map) Fault information, if any.
   
    Nested scheme for `fault`:


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/IBM-Cloud/terraform-provider-ibm/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Output from acceptance testing:

pi_instance (r):

```
=== RUN   TestAccIBMPIInstanceBasic
--- PASS: TestAccIBMPIInstanceBasic (341.98s)
PASS
```

```
=== RUN   TestAccIBMPIInstanceDeploymentType
--- PASS: TestAccIBMPIInstanceDeploymentType (982.16s)
PASS
```

```
=== RUN   TestAccIBMPIInstanceReplicant
--- PASS: TestAccIBMPIInstanceReplicant (1408.88s)
PASS
```

```
=== RUN   TestAccIBMPIInstanceNetwork
--- PASS: TestAccIBMPIInstanceNetwork (1156.62s)
PASS
```

```
=== RUN   TestAccIBMPIInstanceDeploymentTypeNoStorage
--- PASS: TestAccIBMPIInstanceDeploymentTypeNoStorage (288.31s)
PASS
```

```
=== RUN   TestAccIBMPIInstanceUpdateActiveState
--- PASS: TestAccIBMPIInstanceUpdateActiveState (1257.55s)
PASS
```

```
=== RUN   TestAccIBMPIInstanceUpdateStoppedState
--- PASS: TestAccIBMPIInstanceUpdateStoppedState (1248.31s)
PASS
```

```
=== RUN   TestAccIBMPISAPInstance
--- PASS: TestAccIBMPISAPInstance (1284.73s)
PASS
```

```
=== RUN   TestAccIBMPIInstanceUserTags
--- PASS: TestAccIBMPIInstanceUserTags (1690.37s)
PASS
```

pi_cloud_instance (d):

```
=== RUN   TestAccIBMPICloudInstanceDataSource_basic
--- PASS: TestAccIBMPICloudInstanceDataSource_basic (10.04s)
PASS
```

pi_instance (d):

```
=== RUN   TestAccIBMPIInstanceDataSource_basic
--- PASS: TestAccIBMPIInstanceDataSource_basic (24.94s)
PASS
```

pi_instances (d):

```
=== RUN   TestAccIBMPIInstancesDataSource_basic
--- PASS: TestAccIBMPIInstancesDataSource_basic (29.16s)
PASS
```

pi_capture (r):

```
=== RUN   TestAccIBMPICaptureBasic
--- PASS: TestAccIBMPICaptureBasic (51.88s)
PASS
```

```
=== RUN   TestAccIBMPICaptureWithVolume
--- PASS: TestAccIBMPICaptureWithVolume (1263.53s)
PASS
```

```
=== RUN   TestAccIBMPICaptureCloudStorage
--- PASS: TestAccIBMPICaptureCloudStorage (4162.42s)
PASS
```

```
=== RUN   TestAccIBMPICaptureBoth
--- PASS: TestAccIBMPICaptureBoth (1835.85s)
PASS
```

```
=== RUN   TestAccIBMPICaptureUserTags
--- PASS: TestAccIBMPICaptureUserTags (118.50s)
PASS
```
