### PR TITLE
Add GRS Attributes/Arguments to pi_volume resource

### DIFF
--- a/ibm/service/power/ibm_pi_constants.go
+++ b/ibm/service/power/ibm_pi_constants.go
@@ -63,6 +63,7 @@ const (
 	Arg_Remove                              = "pi_remove"
 	Arg_Replicants                          = "pi_replicants"
 	Arg_ReplicationEnabled                  = "pi_replication_enabled"
+	Arg_ReplicationSites                    = "pi_replication_sites"
 	Arg_ReplicationPolicy                   = "pi_replication_policy"
 	Arg_ReplicationScheme                   = "pi_replication_scheme"
 	Arg_ResourceGroupID                     = "pi_resource_group_id"

--- a/website/docs/r/pi_volume.html.markdown
+++ b/website/docs/r/pi_volume.html.markdown
@@ -59,6 +59,10 @@ Review the argument references that you can specify for your resource.
 - `pi_anti_affinity_volumes`- (Optional, String) List of volumes to base volume anti-affinity policy against; required if requesting `anti-affinity` and `pi_anti_affinity_instances` is not provided.
 - `pi_cloud_instance_id` - (Required, String) The GUID of the service instance associated with an account.
 - `pi_replication_enabled` - (Optional, Boolean) Indicates if the volume should be replication enabled or not.
+
+  **Note:** `replication_sites` will be populated automatically with default sites if set to true and sites are not specified.
+
+- `pi_replication_sites` - (Optional, List) List of replication sites for volume replication. Must set `pi_replication_enabled` to true to use.
 - `pi_user_tags` - (Optional, List) The user tags attached to this resource.
 - `pi_volume_name` - (Required, String) The name of the volume.
 - `pi_volume_pool` - (Optional, String) Volume pool where the volume will be created; if provided then `pi_affinity_policy` values will be ignored.
@@ -82,6 +86,7 @@ In addition to all argument reference list, you can access the following attribu
 - `mirroring_state` - (String) Mirroring state for replication enabled volume.
 - `primary_role` - (String) Indicates whether `master`/`auxiliary` volume is playing the primary role.
 - `replication_status` - (String) The replication status of the volume.
+- `replication_sites` - (List) List of replication sites for volume replication.
 - `replication_type` - (String) The replication type of the volume `metro` or `global`.
 - `volume_id` - (String) The unique identifier of the volume.
 - `volume_status` - (String) The status of the volume.


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/IBM-Cloud/terraform-provider-ibm/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Output from acceptance testing:

```
=== RUN   TestAccIBMPIVolumebasic
--- PASS: TestAccIBMPIVolumebasic (85.61s)
PASS
```

```
=== RUN   TestAccIBMPIVolumePool
--- PASS: TestAccIBMPIVolumePool (45.81s)
PASS
```

```
=== RUN   TestAccIBMPIVolumeGRS
--- PASS: TestAccIBMPIVolumeGRS (75.89s)
PASS
```

```
=== RUN   TestAccIBMPIVolumeUpdate
--- PASS: TestAccIBMPIVolumeUpdate (47.67s)
PASS
```

Description:
Added pi_replication_sites argument and replication_sites attribute to pi_volume resource.
