### PR TITLE
Add GRS attributes to pi_volume (d) and pi_instance_volumes (d)

### DIFF
--- a/ibm/service/power/data_source_ibm_pi_instance_volumes.go
+++ b/ibm/service/power/data_source_ibm_pi_instance_volumes.go
@@ -51,9 +51,19 @@ func DataSourceIBMPIInstanceVolumes() *schema.Resource {
 							Description: "Indicates if the volume is boot capable.",
 							Type:        schema.TypeBool,
 						},
+						Attr_CreationDate: {
+							Computed:    true,
+							Description: "Date volume was created.",
+							Type:        schema.TypeString,
+						},
 						Attr_CRN: {
 							Computed:    true,
 							Description: "The CRN of this resource.",
+							Type:        schema.TypeString,
+						},
+						Attr_FreezeTime: {
+							Computed:    true,
+							Description: "The freeze time of remote copy.",
 							Type:        schema.TypeString,
 						},
 						Attr_Href: {
@@ -66,6 +76,11 @@ func DataSourceIBMPIInstanceVolumes() *schema.Resource {
 							Description: "The unique identifier of the volume.",
 							Type:        schema.TypeString,
 						},
+						Attr_LastUpdateDate: {
+							Computed:    true,
+							Description: "The last updated date of the volume.",
+							Type:        schema.TypeString,
+						},
 						Attr_Name: {
 							Computed:    true,
 							Description: "The name of the volume.",
@@ -75,6 +90,17 @@ func DataSourceIBMPIInstanceVolumes() *schema.Resource {
 							Computed:    true,
 							Description: "Volume pool, name of storage pool where the volume is located.",
 							Type:        schema.TypeString,
+						},
+						Attr_ReplicationEnabled: {
+							Computed:    true,
+							Description: "Indicates if the volume should be replication enabled or not.",
+							Type:        schema.TypeBool,
+						},
+						Attr_ReplicationSites: {
+							Computed:    true,
+							Description: "List of replication sites for volume replication.",
+							Elem:        &schema.Schema{Type: schema.TypeString},
+							Type:        schema.TypeList,
 						},
 						Attr_Shareable: {
 							Computed:    true,
@@ -136,16 +162,20 @@ func dataSourceIBMPIInstanceVolumesRead(ctx context.Context, d *schema.ResourceD
 func flattenVolumesInstances(list []*models.VolumeReference, meta interface{}) []map[string]interface{} {
 	result := make([]map[string]interface{}, 0, len(list))
 	for _, i := range list {
+
 		l := map[string]interface{}{
-			Attr_Bootable:  *i.Bootable,
-			Attr_Href:      *i.Href,
-			Attr_ID:        *i.VolumeID,
-			Attr_Name:      *i.Name,
-			Attr_Pool:      i.VolumePool,
-			Attr_Shareable: *i.Shareable,
-			Attr_Size:      *i.Size,
-			Attr_State:     *i.State,
-			Attr_Type:      *i.DiskType,
+			Attr_Bootable:           *i.Bootable,
+			Attr_CreationDate:       i.CreationDate.String(),
+			Attr_Href:               *i.Href,
+			Attr_ID:                 *i.VolumeID,
+			Attr_LastUpdateDate:     i.LastUpdateDate.String(),
+			Attr_Name:               *i.Name,
+			Attr_Pool:               i.VolumePool,
+			Attr_ReplicationEnabled: i.ReplicationEnabled,
+			Attr_Shareable:          *i.Shareable,
+			Attr_Size:               *i.Size,
+			Attr_State:              *i.State,
+			Attr_Type:               *i.DiskType,
 		}
 		if i.Crn != "" {
 			l[Attr_CRN] = i.Crn
@@ -155,6 +185,13 @@ func flattenVolumesInstances(list []*models.VolumeReference, meta interface{}) [
 			}
 			l[Attr_UserTags] = tags
 		}
+		if i.FreezeTime != nil {
+			l[Attr_FreezeTime] = i.FreezeTime.String()
+		}
+		if len(i.ReplicationSites) > 0 {
+			l[Attr_ReplicationSites] = i.ReplicationSites
+		}
+
 		result = append(result, l)
 	}
 	return result

--- a/ibm/service/power/data_source_ibm_pi_volume.go
+++ b/ibm/service/power/data_source_ibm_pi_volume.go
@@ -59,9 +59,19 @@ func DataSourceIBMPIVolume() *schema.Resource {
 				Description: "Consistency group name if volume is a part of volume group.",
 				Type:        schema.TypeString,
 			},
+			Attr_CreationDate: {
+				Computed:    true,
+				Description: "Date volume was created.",
+				Type:        schema.TypeString,
+			},
 			Attr_DiskType: {
 				Computed:    true,
 				Description: "The disk type that is used for the volume.",
+				Type:        schema.TypeString,
+			},
+			Attr_FreezeTime: {
+				Computed:    true,
+				Description: "The freeze time of remote copy.",
 				Type:        schema.TypeString,
 			},
 			Attr_GroupID: {
@@ -72,6 +82,11 @@ func DataSourceIBMPIVolume() *schema.Resource {
 			Attr_IOThrottleRate: {
 				Computed:    true,
 				Description: "Amount of iops assigned to the volume",
+				Type:        schema.TypeString,
+			},
+			Attr_LastUpdateDate: {
+				Computed:    true,
+				Description: "The last updated date of the volume.",
 				Type:        schema.TypeString,
 			},
 			Attr_MasterVolumeName: {
@@ -93,6 +108,12 @@ func DataSourceIBMPIVolume() *schema.Resource {
 				Computed:    true,
 				Description: "Indicates if the volume should be replication enabled or not.",
 				Type:        schema.TypeBool,
+			},
+			Attr_ReplicationSites: {
+				Computed:    true,
+				Description: "List of replication sites for volume replication.",
+				Elem:        &schema.Schema{Type: schema.TypeString},
+				Type:        schema.TypeList,
 			},
 			Attr_ReplicationStatus: {
 				Computed:    true,
@@ -158,6 +179,7 @@ func dataSourceIBMPIVolumeRead(ctx context.Context, d *schema.ResourceData, meta
 	d.Set(Attr_AuxiliaryVolumeName, volumedata.AuxVolumeName)
 	d.Set(Attr_Bootable, volumedata.Bootable)
 	d.Set(Attr_ConsistencyGroupName, volumedata.ConsistencyGroupName)
+	d.Set(Attr_CreationDate, volumedata.CreationDate.String())
 	if volumedata.Crn != "" {
 		d.Set(Attr_CRN, volumedata.Crn)
 		tags, err := flex.GetTagsUsingCRN(meta, string(volumedata.Crn))
@@ -167,13 +189,20 @@ func dataSourceIBMPIVolumeRead(ctx context.Context, d *schema.ResourceData, meta
 		d.Set(Attr_UserTags, tags)
 	}
 	d.Set(Attr_DiskType, volumedata.DiskType)
+	if volumedata.FreezeTime != nil {
+		d.Set(Attr_FreezeTime, volumedata.FreezeTime.String())
+	}
 	d.Set(Attr_GroupID, volumedata.GroupID)
 	d.Set(Attr_IOThrottleRate, volumedata.IoThrottleRate)
+	d.Set(Attr_LastUpdateDate, volumedata.LastUpdateDate.String())
 	d.Set(Attr_MasterVolumeName, volumedata.MasterVolumeName)
 	d.Set(Attr_MirroringState, volumedata.MirroringState)
 	d.Set(Attr_PrimaryRole, volumedata.PrimaryRole)
 	d.Set(Attr_ReplicationEnabled, volumedata.ReplicationEnabled)
 	d.Set(Attr_ReplicationType, volumedata.ReplicationType)
+	if len(volumedata.ReplicationSites) > 0 {
+		d.Set(Attr_ReplicationSites, volumedata.ReplicationSites)
+	}
 	d.Set(Attr_ReplicationStatus, volumedata.ReplicationStatus)
 	d.Set(Attr_State, volumedata.State)
 	d.Set(Attr_Shareable, volumedata.Shareable)

--- a/website/docs/d/pi_instance_volumes.html.markdown
+++ b/website/docs/d/pi_instance_volumes.html.markdown
@@ -53,11 +53,16 @@ In addition to all argument reference list, you can access the following attribu
 
   Nested scheme for `instance_volumes`:
   - `bootable`- (Boolean) Indicates if the volume is boot capable.
+  - `creation_date` - (String) Date of volume creation.
   - `crn` - (String) The CRN of this resource.
+  - `freeze_time` - (String) Time of remote copy relationship.
   - `href` - (String) The hyper link of the volume.
   - `id` - (String) The unique identifier of the volume.
+  - `last_update_date` - (String) The date when the volume last updated.
   - `name` - (String) The name of the volume.
   - `pool` - (String) Volume pool, name of storage pool where the volume is located.
+  - `replication_enabled` - (Boolean) Indicates whether replication is enabled on the volume.
+  - `replication_sites` - (List) List of replication sites for volume replication.
   - `shareable` - (Boolean) Indicates if the volume is shareable between VMs.
   - `size` - (Integer) The size of this volume in GB.
   - `state` - (String) The state of the volume.

--- a/website/docs/d/pi_volume.html.markdown
+++ b/website/docs/d/pi_volume.html.markdown
@@ -48,20 +48,24 @@ Review the argument references that you can specify for your data source.
 
 In addition to all argument reference list, you can access the following attribute references after your data source is created.
 
-- `auxiliary` - (Boolean) Indicates if the volume is auxiliary or not.
+- `auxiliary` - (Boolean) Indicates if the volume is auxiliary.
 - `auxiliary_volume_name` - (String) The auxiliary volume name.
 - `bootable` -  (Boolean) Indicates if the volume is boot capable.
 - `consistency_group_name` - (String) Consistency group name if volume is a part of volume group.
+- `creation_date` - (String) Date of volume creation.
 - `crn` - (String) The CRN of this resource.
 - `disk_type` - (String) The disk type that is used for the volume.
+- `freeze_time` - (String) Time of remote copy relationship.
 - `group_id` - (String) The volume group id in which the volume belongs.
 - `id` - (String) The unique identifier of the volume.
 - `io_throttle_rate` - (String) Amount of iops assigned to the volume.
+- `last_update_date` - (String) The date when the volume last updated.
 - `master_volume_name` - (String) The master volume name.
 - `mirroring_state` - (String) Mirroring state for replication enabled volume.
 - `primary_role` - (String) Indicates whether `master`/`auxiliary` volume is playing the primary role.
 - `replication_enabled` - (Boolean) Indicates if the volume should be replication enabled or not.
-- `replication_status` - (String) The replication status of the volume.
+- `replication_sites` - (List) List of replication sites for volume replication.
+- `replication_status` - (String) The replication status of the volume. 
 - `replication_type` - (String) The replication type of the volume, `metro` or `global`.
 - `shareable` - (String) Indicates if the volume is shareable between VMs.
 - `size` - (Integer) The size of the volume in GB.


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/IBM-Cloud/terraform-provider-ibm/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Output from acceptance testing:

pi_volume (d):

```
=== RUN   TestAccIBMPIVolumeDataSource_basic
--- PASS: TestAccIBMPIVolumeDataSource_basic (6.67s)
PASS
```

```
=== RUN   TestAccIBMPIVolumeDataSource_replication
--- PASS: TestAccIBMPIVolumeDataSource_replication (11.99s)
PASS
```

pi_instance_volumes (d):

```
=== RUN   TestAccIBMPIVolumesDataSource_basic
--- PASS: TestAccIBMPIVolumesDataSource_basic (18.04s)
PASS
```

Description:

Added replication_sites, creation_date, last_update_date, and freeze_time attributes to pi_instance_volumes and pi_volume data sources. 

Added replication_enabled attribute to volumes returned by pi_instance_volumes data source.

