### PR TITLE
Fix incorrect handling of trusted profile static CRN identities

### DIFF
--- a/ibm/service/iamidentity/resource_ibm_iam_trusted_profile_identity_test.go
+++ b/ibm/service/iamidentity/resource_ibm_iam_trusted_profile_identity_test.go
@@ -119,7 +119,7 @@ func testAccCheckIBMIamTrustedProfileIdentityExists(n string, obj iamidentityv1.
 
 		getProfileIdentityOptions := &iamidentityv1.GetProfileIdentityOptions{}
 
-		parts, err := flex.SepIdParts(rs.Primary.ID, "/")
+		parts, err := flex.SepIdParts(rs.Primary.ID, "|")
 		if err != nil {
 			return err
 		}
@@ -150,7 +150,7 @@ func testAccCheckIBMIamTrustedProfileIdentityDestroy(s *terraform.State) error {
 
 		getProfileIdentityOptions := &iamidentityv1.GetProfileIdentityOptions{}
 
-		parts, err := flex.SepIdParts(rs.Primary.ID, "/")
+		parts, err := flex.SepIdParts(rs.Primary.ID, "|")
 		if err != nil {
 			return err
 		}

--- a/website/docs/r/iam_trusted_profile_identity.html.markdown
+++ b/website/docs/r/iam_trusted_profile_identity.html.markdown
@@ -38,7 +38,7 @@ Review the argument reference that you can specify for your resource.
 
 In addition to all argument references listed, you can access the following attribute references after your resource is created.
 
-* `id` - The unique identifier of the iam_trusted_profile_identity. Id is combination of `profile_id`/ `identity-type`/ `identifier-id`.
+* `id` - The unique identifier of the iam_trusted_profile_identity. Id is combination of `profile_id`| `identity-type`| `identifier-id`.
 
 
 ## Import
@@ -47,7 +47,7 @@ You can import the `ibm_iam_trusted_profile_identity` resource by using `iam_id`
 The `iam_id` property can be formed from `profile-id`, `identity-type`, and `identifier-id` in the following format:
 
 ```
-<profile-id>/<identity-type>/<identifier-id>
+<profile-id>|<identity-type>|<identifier-id>
 ```
 * `profile-id`: A string. ID of the trusted profile.
 * `identity-type`: A string. Type of the identity.
@@ -55,5 +55,5 @@ The `iam_id` property can be formed from `profile-id`, `identity-type`, and `ide
 
 # Syntax
 ```
-$ terraform import ibm_iam_trusted_profile_identity.iam_trusted_profile_identity <profile-id>/<identity-type>/<identifier-id>
+$ terraform import ibm_iam_trusted_profile_identity.iam_trusted_profile_identity <profile-id>|<identity-type>|<identifier-id>
 ```


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/IBM-Cloud/terraform-provider-ibm/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->

Fixes a bug handling identity id when that id contains a CRN. 

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TEST=./ibm/service/iamidentity/resource_ibm_iam_trusted_profile_identity_test.go

=== RUN   TestAccIBMIamTrustedProfileIdentityBasic
--- PASS: TestAccIBMIamTrustedProfileIdentityBasic (43.22s)

=== RUN   TestAccIBMIamTrustedProfileIdentityAllArgs
--- PASS: TestAccIBMIamTrustedProfileIdentityAllArgs (35.84s)
PASS
```
