### PR TITLE
fix: update error diagnostic reporting in existing Event Streams code

### DIFF
--- a/ibm/service/eventstreams/data_source_ibm_event_streams_schema.go
+++ b/ibm/service/eventstreams/data_source_ibm_event_streams_schema.go
@@ -9,6 +9,7 @@ import (
 	"log"
 
 	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/conns"
+	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/flex"
 	"github.com/IBM/eventstreams-go-sdk/pkg/schemaregistryv1"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -41,14 +42,16 @@ func DataSourceIBMEventStreamsSchema() *schema.Resource {
 func dataSourceIBMEventStreamsSchemaRead(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	schemaregistryClient, err := meta.(conns.ClientSession).ESschemaRegistrySession()
 	if err != nil {
-		log.Printf("[DEBUG] dataSourceIBMEventStreamsSchemaRead schemaregistryClient err %s", err)
-		return diag.FromErr(err)
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("dataSourceIBMEventStreamsSchemaRead schemaregistryClient: %s", err), "ibm_event_streams_schema", "read")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	adminURL, instanceCRN, err := getInstanceURL(d, meta)
 	if err != nil {
-		log.Printf("[DEBUG] dataSourceIBMEventStreamsSchemaRead getInstanceURL err %s", err)
-		return diag.FromErr(err)
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("dataSourceIBMEventStreamsSchemaRead getInstanceURL: %s", err), "ibm_event_streams_schema", "read")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 	schemaregistryClient.SetServiceURL(adminURL)
 
@@ -59,8 +62,9 @@ func dataSourceIBMEventStreamsSchemaRead(context context.Context, d *schema.Reso
 
 	schema, response, err := schemaregistryClient.GetLatestSchemaWithContext(context, getLatestSchemaOptions)
 	if err != nil || schema == nil {
-		log.Printf("[DEBUG] GetLatestSchemaWithContext failed with error: %s and response:\n%s", err, response)
-		return diag.FromErr(fmt.Errorf("GetLatestSchemaWithContext failed with error: %s\n and response:%s", err, response))
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("dataSourceIBMEventStreamsSchemaRead GetLatestSchemaWithContext failed with error: %s and response:\n%s", err, response), "ibm_event_streams_schema", "read")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 	uniqueID := getUniqueSchemaID(instanceCRN, schemaID)
 

--- a/ibm/service/eventstreams/data_source_ibm_event_streams_topic.go
+++ b/ibm/service/eventstreams/data_source_ibm_event_streams_topic.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"log"
 
+	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/flex"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
@@ -54,13 +55,15 @@ func DataSourceIBMEventStreamsTopic() *schema.Resource {
 func dataSourceIBMEventStreamsTopicRead(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	adminClient, instanceCRN, err := createSaramaAdminClient(d, meta)
 	if err != nil {
-		log.Printf("[DEBUG]dataSourceIBMEventStreamsTopicRead createSaramaAdminClient err %s", err)
-		return diag.FromErr(err)
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("dataSourceIBMEventStreamsTopicRead createSaramaAdminClient: %s", err), "ibm_event_streams_topic", "read")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 	topics, err := adminClient.ListTopics()
 	if err != nil {
-		log.Printf("[DEBUG]dataSourceIBMEventStreamsTopicRead ListTopics err %s", err)
-		return diag.FromErr(err)
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("dataSourceIBMEventStreamsTopicRead ListTopics: %s", err), "ibm_event_streams_topic", "read")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 	topicName := d.Get("name").(string)
 	for name := range topics {
@@ -72,6 +75,8 @@ func dataSourceIBMEventStreamsTopicRead(context context.Context, d *schema.Resou
 			return nil
 		}
 	}
-	log.Printf("[DEBUG]dataSourceIBMEventStreamsTopicRead topic %s does not exist", topicName)
-	return diag.FromErr(fmt.Errorf("topic %s does not exist", topicName))
+	tfErr := flex.TerraformErrorf(fmt.Errorf("topic %s does not exist", topicName),
+		fmt.Sprintf("dataSourceIBMEventStreamsTopicRead topic %s does not exist", topicName), "ibm_event_streams_topic", "read")
+	log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+	return tfErr.GetDiag()
 }

--- a/ibm/service/eventstreams/resource_ibm_event_streams_schema.go
+++ b/ibm/service/eventstreams/resource_ibm_event_streams_schema.go
@@ -175,11 +175,15 @@ func validateName(s map[string]interface{}, t string) error {
 func resourceIBMEventStreamsSchemaCreate(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	schemaregistryClient, err := meta.(conns.ClientSession).ESschemaRegistrySession()
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("resourceIBMEventStreamsSchemaCreate schemaregistryClient: %s", err), "ibm_event_streams_schema", "create")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 	adminURL, instanceCRN, err := getInstanceURL(d, meta)
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("resourceIBMEventStreamsSchemaCreate getInstanceURL: %s", err), "ibm_event_streams_schema", "create")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 	schemaregistryClient.SetServiceURL(adminURL)
 	createSchemaOptions := &schemaregistryv1.CreateSchemaOptions{}
@@ -195,8 +199,9 @@ func resourceIBMEventStreamsSchemaCreate(context context.Context, d *schema.Reso
 
 	schemaMetadata, response, err := schemaregistryClient.CreateSchemaWithContext(context, createSchemaOptions)
 	if err != nil || schemaMetadata == nil {
-		log.Printf("[DEBUG] CreateSchemaWithContext failed with error: %s and response: \n%s", err, response)
-		return diag.FromErr(fmt.Errorf("CreateSchemaWithContext failed with eror: %s and response: \n%s", err, response))
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("resourceIBMEventStreamsSchemaCreate CreateSchemaWithContext failed with error: %s and response:\n%s", err, response), "ibm_event_streams_schema", "create")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 	uniqueID := getUniqueSchemaID(instanceCRN, *schemaMetadata.ID)
 	d.SetId(uniqueID)
@@ -207,12 +212,16 @@ func resourceIBMEventStreamsSchemaCreate(context context.Context, d *schema.Reso
 func resourceIBMEventStreamsSchemaRead(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	schemaregistryClient, err := meta.(conns.ClientSession).ESschemaRegistrySession()
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("resourceIBMEventStreamsSchemaRead schemaregistryClient: %s", err), "ibm_event_streams_schema", "read")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	adminURL, instanceCRN, err := getInstanceURL(d, meta)
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("resourceIBMEventStreamsSchemaRead getInstanceURL: %s", err), "ibm_event_streams_schema", "read")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 	schemaregistryClient.SetServiceURL(adminURL)
 
@@ -223,21 +232,27 @@ func resourceIBMEventStreamsSchemaRead(context context.Context, d *schema.Resour
 
 	avroSchema, response, err := schemaregistryClient.GetLatestSchemaWithContext(context, getSchemaOptions)
 	if err != nil || avroSchema == nil {
-		log.Printf("[DEBUG] GetSchemaWithContext failed with error: %s and response: \n%s", err, response)
 		if response != nil && response.StatusCode == 404 {
+			log.Printf("[DEBUG] GetSchemaWithContext failed with 404 Not Found error and response: \n%s", response)
 			d.SetId("")
 			return nil
 		}
-		return diag.FromErr(fmt.Errorf("GetSchemaWithContext failed %s\n%s", err, response))
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("resourceIBMEventStreamsSchemaRead GetLatestSchemaWithContext failed with error: %s and response:\n%s", err, response), "ibm_event_streams_schema", "read")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	s, err := json.Marshal(avroSchema)
 	if err != nil {
-		return diag.FromErr(fmt.Errorf("[ERROR] Error marshalling the created schema: %s", err))
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("resourceIBMEventStreamsSchemaRead marshalling the schema failed with error: %s", err), "ibm_event_streams_schema", "read")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	if err = d.Set("schema", string(s)); err != nil {
-		return diag.FromErr(fmt.Errorf("[ERROR] Error setting the schema: %s", err))
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("resourceIBMEventStreamsSchemaRead setting the schema failed error: %s", err), "ibm_event_streams_schema", "read")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 	d.Set("resource_instance_id", instanceCRN)
 	d.Set("schema_id", schemaID)
@@ -248,12 +263,16 @@ func resourceIBMEventStreamsSchemaRead(context context.Context, d *schema.Resour
 func resourceIBMEventStreamsSchemaUpdate(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	schemaregistryClient, err := meta.(conns.ClientSession).ESschemaRegistrySession()
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("resourceIBMEventStreamsSchemaUpdate schemaregistryClient: %s", err), "ibm_event_streams_schema", "update")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	adminURL, _, err := getInstanceURL(d, meta)
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("resourceIBMEventStreamsSchemaUpdate getInstanceURL: %s", err), "ibm_event_streams_schema", "update")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 	schemaregistryClient.SetServiceURL(adminURL)
 
@@ -269,8 +288,9 @@ func resourceIBMEventStreamsSchemaUpdate(context context.Context, d *schema.Reso
 		}
 		schemaMetadata, response, err := schemaregistryClient.UpdateSchemaWithContext(context, updateSchemaOptions)
 		if err != nil || schemaMetadata == nil {
-			log.Printf("[DEBUG] UpdateSchemaWithContext failed with error: %s\n and response: %s", err, response)
-			return diag.FromErr(fmt.Errorf("UpdateSchemaWithContext failed with error: %s and response: \n%s", err, response))
+			tfErr := flex.TerraformErrorf(err, fmt.Sprintf("resourceIBMEventStreamsSchemaUpdate UpdateSchema failed with error: %s and response:\n%s", err, response), "ibm_event_streams_schema", "update")
+			log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+			return tfErr.GetDiag()
 		}
 	}
 
@@ -280,12 +300,16 @@ func resourceIBMEventStreamsSchemaUpdate(context context.Context, d *schema.Reso
 func resourceIBMEventStreamsSchemaDelete(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	schemaregistryClient, err := meta.(conns.ClientSession).ESschemaRegistrySession()
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("resourceIBMEventStreamsSchemaDelete schemaregistryClient: %s", err), "ibm_event_streams_schema", "delete")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	adminURL, _, err := getInstanceURL(d, meta)
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("resourceIBMEventStreamsSchemaDelete getInstanceURL: %s", err), "ibm_event_streams_schema", "delete")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 	schemaregistryClient.SetServiceURL(adminURL)
 
@@ -300,13 +324,16 @@ func resourceIBMEventStreamsSchemaDelete(context context.Context, d *schema.Reso
 	// set schema state to disabled before deleting
 	response, err := schemaregistryClient.SetSchemaStateWithContext(context, setSchemaOptions)
 	if err != nil {
-		log.Printf("[DEBUG] SetSchemaStateWithContext failed %s\n%s", err, response)
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("resourceIBMEventStreamsSchemaDelete SetSchemaState failed with error: %s and response:\n%s", err, response), "ibm_event_streams_schema", "delete")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	response, err = schemaregistryClient.DeleteSchemaWithContext(context, deleteSchemaOptions)
 	if err != nil {
-		log.Printf("[DEBUG] DeleteSchemaWithContext failed %s\n%s", err, response)
-		return diag.FromErr(fmt.Errorf("DeleteSchemaWithContext failed %s\n%s", err, response))
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("resourceIBMEventStreamsSchemaDelete DeleteSchema failed with error: %s and response:\n%s", err, response), "ibm_event_streams_schema", "delete")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	d.SetId("")

--- a/ibm/service/eventstreams/resource_ibm_event_streams_topic.go
+++ b/ibm/service/eventstreams/resource_ibm_event_streams_topic.go
@@ -127,8 +127,9 @@ func resourceIBMEventStreamsTopicCreate(context context.Context, d *schema.Resou
 	log.Printf("[DEBUG] resourceIBMEventStreamsTopicCreate")
 	adminClient, instanceCRN, err := createSaramaAdminClient(d, meta)
 	if err != nil {
-		log.Printf("[DEBUG] resourceIBMEventStreamsTopicCreate createSaramaAdminClient err %s", err)
-		return diag.FromErr(err)
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("resourceIBMEventStreamsTopicCreate createSaramaAdminClient: %s", err), "ibm_event_streams_topic", "create")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 	topicName := d.Get("name").(string)
 	partitions := d.Get("partitions").(int)
@@ -144,8 +145,9 @@ func resourceIBMEventStreamsTopicCreate(context context.Context, d *schema.Resou
 			if kafkaErr != nil && kafkaErr.Err == sarama.ErrTopicAlreadyExists {
 				exists, err := resourceIBMEventStreamsTopicExists(context, d, meta)
 				if err != nil {
-					log.Printf("[DEBUG] resourceIBMEventStreamsTopicCreate resourceIBMEventStreamsTopicExists: %s, err %s", topicName, err)
-					return diag.FromErr(err)
+					tfErr := flex.TerraformErrorf(err, fmt.Sprintf("resourceIBMEventStreamsTopicCreate resourceIBMEventStreamsTopicExists %s: %s", topicName, err), "ibm_event_streams_topic", "create")
+					log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+					return tfErr.GetDiag()
 				}
 				if exists {
 					d.SetId(getTopicID(instanceCRN, topicName))
@@ -153,8 +155,9 @@ func resourceIBMEventStreamsTopicCreate(context context.Context, d *schema.Resou
 				}
 			}
 		}
-		log.Printf("[ERROR] resourceIBMEventStreamsTopicCreate CreateTopic: %s, err %s", topicName, err)
-		return diag.FromErr(err)
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("resourceIBMEventStreamsTopicCreate CreateTopic %s: %s", topicName, err), "ibm_event_streams_topic", "create")
+		log.Printf("[ERROR]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 	log.Printf("[INFO] resourceIBMEventStreamsTopicCreate CreateTopic: topic is %s, detail is %v", topicName, topicDetail)
 	d.SetId(getTopicID(instanceCRN, topicName))
@@ -165,15 +168,17 @@ func resourceIBMEventStreamsTopicRead(context context.Context, d *schema.Resourc
 	log.Printf("[DEBUG] resourceIBMEventStreamsTopicRead")
 	adminClient, instanceCRN, err := createSaramaAdminClient(d, meta)
 	if err != nil {
-		log.Printf("[DEBUG] resourceIBMEventStreamsTopicRead createSaramaAdminClient err %s", err)
-		return diag.FromErr(err)
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("resourceIBMEventStreamsTopicRead createSaramaAdminClient: %s", err), "ibm_event_streams_topic", "read")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 	topicID := d.Id()
 	topicName := getTopicName(topicID)
 	topics, err := adminClient.ListTopics()
 	if err != nil {
-		log.Printf("[DEBUG] resourceIBMEventStreamsTopicRead ListTopics err %s", err)
-		return diag.FromErr(err)
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("resourceIBMEventStreamsTopicRead ListTopics: %s", err), "ibm_event_streams_topic", "read")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 	for name, detail := range topics {
 		if name == topicName {
@@ -201,8 +206,9 @@ func resourceIBMEventStreamsTopicUpdate(context context.Context, d *schema.Resou
 	log.Printf("[DEBUG] resourceIBMEventStreamsTopicUpdate")
 	adminClient, _, err := createSaramaAdminClient(d, meta)
 	if err != nil {
-		log.Printf("[DEBUG] resourceIBMEventStreamsTopicUpdate createSaramaAdminClient err %s", err)
-		return diag.FromErr(err)
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("resourceIBMEventStreamsTopicUpdate createSaramaAdminClient: %s", err), "ibm_event_streams_topic", "update")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 	topicName := d.Get("name").(string)
 	if d.HasChange("partitions") {
@@ -212,8 +218,9 @@ func resourceIBMEventStreamsTopicUpdate(context context.Context, d *schema.Resou
 		log.Printf("[INFO]resourceIBMEventStreamsTopicUpdate Updating partitions from %d to %d", oldPartitions, newPartitions)
 		err = adminClient.CreatePartitions(topicName, int32(newPartitions), nil, false)
 		if err != nil {
-			log.Printf("[DEBUG]resourceIBMEventStreamsTopicUpdate CreatePartitions err %s", err)
-			return diag.FromErr(err)
+			tfErr := flex.TerraformErrorf(err, fmt.Sprintf("resourceIBMEventStreamsTopicUpdate CreatePartitions: %s", err), "ibm_event_streams_topic", "update")
+			log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+			return tfErr.GetDiag()
 		}
 		d.Set("partitions", int32(newPartitions))
 		log.Printf("[INFO]resourceIBMEventStreamsTopicUpdate partitions is set to %d", newPartitions)
@@ -223,8 +230,9 @@ func resourceIBMEventStreamsTopicUpdate(context context.Context, d *schema.Resou
 		configEntries := config2TopicDetail(config)
 		err = adminClient.AlterConfig(sarama.TopicResource, topicName, configEntries, false)
 		if err != nil {
-			log.Printf("[DEBUG]resourceIBMEventStreamsTopicUpdate AlterConfig err %s", err)
-			return diag.FromErr(err)
+			tfErr := flex.TerraformErrorf(err, fmt.Sprintf("resourceIBMEventStreamsTopicUpdate AlterConfig: %s", err), "ibm_event_streams_topic", "update")
+			log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+			return tfErr.GetDiag()
 		}
 		d.Set("config", topicDetail2Config(configEntries))
 		log.Printf("[INFO]resourceIBMEventStreamsTopicUpdate config is set to %v", topicDetail2Config(configEntries))
@@ -236,8 +244,9 @@ func resourceIBMEventStreamsTopicDelete(context context.Context, d *schema.Resou
 	log.Printf("[DEBUG] resourceIBMEventStreamsTopicDelete")
 	adminClient, _, err := createSaramaAdminClient(d, meta)
 	if err != nil {
-		log.Printf("[DEBUG] resourceIBMEventStreamsTopicDelete createSaramaAdminClient err %s", err)
-		return diag.FromErr(err)
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("resourceIBMEventStreamsTopicDelete createSaramaAdminClient: %s", err), "ibm_event_streams_topic", "delete")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 	topicName := d.Get("name").(string)
 	err = adminClient.DeleteTopic(topicName)
@@ -249,8 +258,9 @@ func resourceIBMEventStreamsTopicDelete(context context.Context, d *schema.Resou
 				return nil
 			}
 		}
-		log.Printf("[DEBUG] resourceIBMEventStreamsTopicDelete DeleteTopic err %s", err)
-		return diag.FromErr(err)
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("resourceIBMEventStreamsTopicDelete DeleteClient: %s", err), "ibm_event_streams_topic", "delete")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 	d.SetId("")
 	log.Printf("[INFO]resourceIBMEventStreamsTopicDelete topic %s deleted", topicName)


### PR DESCRIPTION
### What has been done

Update the contextualized error messages in existing Event Streams code to use the `flex.TerraformErrorf` package, as in https://github.ibm.com/CloudEngineering/client-error-toolchain/wiki/Terraform-Support-Instructions.

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```

% make testacc TEST=./ibm/service/eventstreams TESTARGS='-run=TestAccIBMEventStreamsTopicDataSourceBasic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./ibm/service/eventstreams -v -run=TestAccIBMEventStreamsTopicDataSourceBasic -timeout 700m
=== RUN   TestAccIBMEventStreamsTopicDataSourceBasic
--- PASS: TestAccIBMEventStreamsTopicDataSourceBasic (220.34s)
PASS
ok  	github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/eventstreams	222.988s

% make testacc TEST=./ibm/service/eventstreams TESTARGS='-run=TestAccIBMEventStreamsTopicResourceWithExistingInstance'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./ibm/service/eventstreams -v -run=TestAccIBMEventStreamsTopicResourceWithExistingInstance -timeout 700m
=== RUN   TestAccIBMEventStreamsTopicResourceWithExistingInstance
--- PASS: TestAccIBMEventStreamsTopicResourceWithExistingInstance (63.17s)
PASS
ok  	github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/eventstreams	65.980s

% make testacc TEST=./ibm/service/eventstreams TESTARGS='-run=TestAccIBMEventStreamsTopicResourceBasic'               
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./ibm/service/eventstreams -v -run=TestAccIBMEventStreamsTopicResourceBasic -timeout 700m
=== RUN   TestAccIBMEventStreamsTopicResourceBasic
--- PASS: TestAccIBMEventStreamsTopicResourceBasic (77.67s)
PASS
ok  	github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/eventstreams	80.384s

% make testacc TEST=./ibm/service/eventstreams TESTARGS='-run=TestAccIBMEventStreamsTopicImport'       
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./ibm/service/eventstreams -v -run=TestAccIBMEventStreamsTopicImport -timeout 700m
=== RUN   TestAccIBMEventStreamsTopicImport
--- PASS: TestAccIBMEventStreamsTopicImport (57.77s)
PASS
ok  	github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/eventstreams	60.471s

% make testacc TEST=./ibm/service/eventstreams TESTARGS='-run=TestAccIBMEventStreamsSchemaDataSourceBasic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./ibm/service/eventstreams -v -run=TestAccIBMEventStreamsSchemaDataSourceBasic -timeout 700m
=== RUN   TestAccIBMEventStreamsSchemaDataSourceBasic
--- PASS: TestAccIBMEventStreamsSchemaDataSourceBasic (185.74s)
PASS
ok  	github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/eventstreams	188.384s

% make testacc TEST=./ibm/service/eventstreams TESTARGS='-run=TestAccIBMEventStreamsSchemaBasic'          
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./ibm/service/eventstreams -v -run=TestAccIBMEventStreamsSchemaBasic -timeout 700m
=== RUN   TestAccIBMEventStreamsSchemaBasic
--- PASS: TestAccIBMEventStreamsSchemaBasic (74.48s)
PASS
ok  	github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/eventstreams	77.159s


% make testacc TEST=./ibm/service/eventstreams TESTARGS='-run=TestAccIBMEventStreamsSchemaAllArgs'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./ibm/service/eventstreams -v -run=TestAccIBMEventStreamsSchemaAllArgs -timeout 700m
=== RUN   TestAccIBMEventStreamsSchemaAllArgs
--- PASS: TestAccIBMEventStreamsSchemaAllArgs (36.94s)
PASS
ok  	github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/eventstreams	39.653s


% make testacc TEST=./ibm/service/eventstreams TESTARGS='-run=TestAccIBMEventStreamsSchemaImport' 
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./ibm/service/eventstreams -v -run=TestAccIBMEventStreamsSchemaImport -timeout 700m
=== RUN   TestAccIBMEventStreamsSchemaImport
--- PASS: TestAccIBMEventStreamsSchemaImport (43.85s)
PASS
ok  	github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/eventstreams	46.520s

...
```
