### PR TITLE
feat(Catalog Management): support new offering version limit

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -20,7 +20,7 @@ require (
 	github.com/IBM/eventstreams-go-sdk v1.4.0
 	github.com/IBM/go-sdk-core v1.1.0
 	github.com/IBM/go-sdk-core/v3 v3.2.4
-	github.com/IBM/go-sdk-core/v5 v5.17.4
+	github.com/IBM/go-sdk-core/v5 v5.17.5
 	github.com/IBM/ibm-cos-sdk-go v1.10.3
 	github.com/IBM/ibm-cos-sdk-go-config/v2 v2.1.0
 	github.com/IBM/ibm-hpcs-tke-sdk v0.0.0-20211109141421-a4b61b05f7d1
@@ -30,7 +30,7 @@ require (
 	github.com/IBM/logs-router-go-sdk v1.0.5
 	github.com/IBM/mqcloud-go-sdk v0.1.0
 	github.com/IBM/networking-go-sdk v0.49.0
-	github.com/IBM/platform-services-go-sdk v0.68.1
+	github.com/IBM/platform-services-go-sdk v0.69.1
 	github.com/IBM/project-go-sdk v0.3.5
 	github.com/IBM/push-notifications-go-sdk v0.0.0-20210310100607-5790b96c47f5
 	github.com/IBM/sarama v1.41.2

--- a/go.sum
+++ b/go.sum
@@ -152,8 +152,9 @@ github.com/IBM/go-sdk-core/v5 v5.6.3/go.mod h1:tt/B9rxLkRtglE7pvqLuYikgCXaZFL3bt
 github.com/IBM/go-sdk-core/v5 v5.7.0/go.mod h1:+YbdhrjCHC84ls4MeBp+Hj4NZCni+tDAc0XQUqRO9Jc=
 github.com/IBM/go-sdk-core/v5 v5.9.5/go.mod h1:YlOwV9LeuclmT/qi/LAK2AsobbAP42veV0j68/rlZsE=
 github.com/IBM/go-sdk-core/v5 v5.10.2/go.mod h1:WZPFasUzsKab/2mzt29xPcfruSk5js2ywAPwW4VJjdI=
-github.com/IBM/go-sdk-core/v5 v5.17.4 h1:VGb9+mRrnS2HpHZFM5hy4J6ppIWnwNrw0G+tLSgcJLc=
 github.com/IBM/go-sdk-core/v5 v5.17.4/go.mod h1:KsAAI7eStAWwQa4F96MLy+whYSh39JzNjklZRbN/8ns=
+github.com/IBM/go-sdk-core/v5 v5.17.5 h1:AjGC7xNee5tgDIjndekBDW5AbypdERHSgib3EZ1KNsA=
+github.com/IBM/go-sdk-core/v5 v5.17.5/go.mod h1:KsAAI7eStAWwQa4F96MLy+whYSh39JzNjklZRbN/8ns=
 github.com/IBM/ibm-cos-sdk-go v1.10.3 h1:YfZSLqMiCrqDPbr3r+amY2sicIXlrd+3L5pok6QRXIQ=
 github.com/IBM/ibm-cos-sdk-go v1.10.3/go.mod h1:T9x7pC47DUd5jD/TMFzlvly39P6EdW5wOemA78XEo2g=
 github.com/IBM/ibm-cos-sdk-go-config/v2 v2.1.0 h1:U7EmXSfv7jtugRpTpOkPUmgS/xiNKtGfKVH3BGyC1hg=
@@ -173,8 +174,8 @@ github.com/IBM/mqcloud-go-sdk v0.1.0 h1:fWt4uisg5GbbsfNmAxx5/6c5gQIPM+VrEsTtnimE
 github.com/IBM/mqcloud-go-sdk v0.1.0/go.mod h1:LesMQlKHXvdks4jqQLZH7HfATY5lvTzHuwQU5+y7b2g=
 github.com/IBM/networking-go-sdk v0.49.0 h1:lPS34u3C0JVrbxH+Ulua76Nwl6Frv8BEfq6LRkyvOv0=
 github.com/IBM/networking-go-sdk v0.49.0/go.mod h1:G9CKbmPE8gSLjN+ABh4hIZ1bMx076enl5Eekvj6zQnA=
-github.com/IBM/platform-services-go-sdk v0.68.1 h1:RXGzEmdllzSj5OzCJO7AoTeQ+cgTTNa20CrrpLQe5KQ=
-github.com/IBM/platform-services-go-sdk v0.68.1/go.mod h1:6rYd3stLSnotYmZlxclw45EJPaQuLmh5f7c+Mg7rOg4=
+github.com/IBM/platform-services-go-sdk v0.69.1 h1:Wb8BYVpsPIppWbOQCgF7ytm+BbSOXdWWCf9zcZ6xGA4=
+github.com/IBM/platform-services-go-sdk v0.69.1/go.mod h1:ZP3zUDxR1qRdUqzFdnJOlQN0QpVYol2eOUCv4uk03Jc=
 github.com/IBM/project-go-sdk v0.3.5 h1:L+YClFUa14foS0B/hOOY9n7sIdsT5/XQicnXOyJSpyM=
 github.com/IBM/project-go-sdk v0.3.5/go.mod h1:FOJM9ihQV3EEAY6YigcWiTNfVCThtdY8bLC/nhQHFvo=
 github.com/IBM/push-notifications-go-sdk v0.0.0-20210310100607-5790b96c47f5 h1:NPUhkoOCRuv3OFWt19PmwjXGGTKlvmbuPg9fUrBUNe4=

--- a/ibm/service/catalogmanagement/data_source_ibm_cm_offering.go
+++ b/ibm/service/catalogmanagement/data_source_ibm_cm_offering.go
@@ -2450,7 +2450,7 @@ func dataSourceIBMCmOfferingRead(context context.Context, d *schema.ResourceData
 	getOfferingOptions.SetCatalogIdentifier(d.Get("catalog_id").(string))
 	getOfferingOptions.SetOfferingID(d.Get("offering_id").(string))
 
-	offering, response, err := catalogManagementClient.GetOfferingWithContext(context, getOfferingOptions)
+	offering, response, err := FetchOfferingWithAllVersions(context, catalogManagementClient, getOfferingOptions)
 	if err != nil {
 		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("GetOfferingWithContext failed %s\n%s", err, response), "(Data) ibm_cm_object", "read")
 		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())

--- a/ibm/service/catalogmanagement/resource_ibm_cm_offering.go
+++ b/ibm/service/catalogmanagement/resource_ibm_cm_offering.go
@@ -2559,6 +2559,8 @@ func resourceIBMCmOfferingCreate(context context.Context, d *schema.ResourceData
 		getOfferingOptions.SetCatalogIdentifier(d.Get("catalog_id").(string))
 		getOfferingOptions.SetOfferingID(d.Get("offering_id").(string))
 
+		// Don't need to get full offering with all versions here because we call resourceIBMCmOfferingRead which does
+		// This get is just to see if the offering exists and set state id
 		offering, response, err := catalogManagementClient.GetOfferingWithContext(context, getOfferingOptions)
 		if err != nil {
 			if response != nil && response.StatusCode == 404 {
@@ -2817,7 +2819,7 @@ func resourceIBMCmOfferingRead(context context.Context, d *schema.ResourceData, 
 	getOfferingOptions.SetCatalogIdentifier(d.Get("catalog_id").(string))
 	getOfferingOptions.SetOfferingID(d.Id())
 
-	offering, response, err := catalogManagementClient.GetOfferingWithContext(context, getOfferingOptions)
+	offering, response, err := FetchOfferingWithAllVersions(context, catalogManagementClient, getOfferingOptions)
 	if err != nil {
 		if response != nil && response.StatusCode == 404 {
 			d.SetId("")

--- a/ibm/service/catalogmanagement/utils.go
+++ b/ibm/service/catalogmanagement/utils.go
@@ -1,9 +1,80 @@
 package catalogmanagement
 
+import (
+	"context"
+	"fmt"
+
+	"github.com/IBM/go-sdk-core/v5/core"
+	"github.com/IBM/platform-services-go-sdk/catalogmanagementv1"
+)
+
 func SIToSS(i []interface{}) []string {
 	var ss []string
 	for _, iface := range i {
 		ss = append(ss, iface.(string))
 	}
 	return ss
+}
+
+// FetchOfferingWithAllVersions fetches an offering and its additional versions
+func FetchOfferingWithAllVersions(ctx context.Context, client *catalogmanagementv1.CatalogManagementV1, getOfferingOptions *catalogmanagementv1.GetOfferingOptions) (*catalogmanagementv1.Offering, *core.DetailedResponse, error) {
+	offering, response, err := client.GetOfferingWithContext(ctx, getOfferingOptions)
+	if err != nil {
+		return offering, response, err
+	}
+
+	// Fetch additional versions for the offering
+	if err := FetchAdditionalVersions(ctx, client, offering); err != nil {
+		return offering, response, err
+	}
+
+	return offering, response, nil
+}
+
+// FetchAdditionalVersions fetches all versions for each kind in the offering
+func FetchAdditionalVersions(ctx context.Context, client *catalogmanagementv1.CatalogManagementV1, offering *catalogmanagementv1.Offering) error {
+	// Define the recursive function to fetch versions for a kind
+	var fetchVersionsForKind func(kind *catalogmanagementv1.Kind, start *string) error
+
+	fetchVersionsForKind = func(kind *catalogmanagementv1.Kind, start *string) error {
+		fmt.Println("START STRING: ", start)
+		// Fetch versions for the kind
+		getVersionsOptions := &catalogmanagementv1.GetVersionsOptions{
+			CatalogIdentifier: offering.CatalogID,
+			OfferingID:        offering.ID,
+			KindID:            kind.ID,
+			Start:             start,
+		}
+
+		result, _, err := client.GetVersionsWithContext(ctx, getVersionsOptions)
+		if err != nil {
+			return err
+		}
+
+		if result.Versions != nil {
+			// Append fetched versions to the kind
+			kind.Versions = append(kind.Versions, result.Versions...)
+		}
+
+		// Check if there are more versions to fetch
+		if result.Next != nil && result.Next.Start != nil && *result.Next.Start != "" {
+			// If there are more versions to fetch, call recursively
+			return fetchVersionsForKind(kind, result.Next.Start)
+		}
+
+		return nil
+	}
+
+	// Iterate over kinds in the offering and fetch additional versions
+	for i := range offering.Kinds {
+		kind := &offering.Kinds[i] // Use a pointer to modify the original kind
+		if kind.AllVersions != nil && kind.AllVersions.Next != nil && kind.AllVersions.Next.Start != nil && *kind.AllVersions.Next.Start != "" {
+			// Load additional versions for this kind
+			if err := fetchVersionsForKind(kind, kind.AllVersions.Next.Start); err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
 }

--- a/website/docs/r/cm_version.html.markdown
+++ b/website/docs/r/cm_version.html.markdown
@@ -152,6 +152,7 @@ Nested scheme for **licenses**:
 	* `name` - (Optional, String) license name.
 	* `type` - (Optional, String) type of license e.g., Apache xxx.
 	* `url` - (Optional, String) URL for the license text.
+* `long_description` - (Optional, String) Long description for the version.
 * `name` - (Optional, Forces new resource, String) Name of version. Required for virtual server image for VPC.
 * `offering_id` - (Required, Forces new resource, String) Offering identification.
 * `pre_install` - (Optional, List) Optional pre-install instructions.


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/IBM-Cloud/terraform-provider-ibm/blob/master/.github/CONTRIBUTING.md --->

Supports new method of fetching all versions of an offering when doing read offering. Also added support for updating version with patch version instead of using patch offering.

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->

Output from acceptance testing:
<details>
  <summary>Test results</summary>

```
TF_ACC=1 go test $(go list ./... |grep -v 'vendor') -v -run TestAccIBMCmCatalogBasic -timeout 700m
=== RUN   TestAccIBMCmCatalogBasic
--- PASS: TestAccIBMCmCatalogBasic (16.56s)

TF_ACC=1 go test $(go list ./... |grep -v 'vendor') -v -run TestAccIBMCmCatalogSimpleArgs -timeout 700m
=== RUN   TestAccIBMCmCatalogSimpleArgs
--- PASS: TestAccIBMCmCatalogSimpleArgs (20.93s)

TF_ACC=1 go test $(go list ./... |grep -v 'vendor') -v -run TestAccIBMCmCatalogDataSourceBasic -timeout 700m
=== RUN   TestAccIBMCmCatalogDataSourceBasic
--- PASS: TestAccIBMCmCatalogDataSourceBasic (15.78s)

TF_ACC=1 go test $(go list ./... |grep -v 'vendor') -v -run TestAccIBMCmCatalogDataSourceSimpleArgs -timeout 700m
=== RUN   TestAccIBMCmCatalogDataSourceSimpleArgs
--- PASS: TestAccIBMCmCatalogDataSourceSimpleArgs (14.87s)

TF_ACC=1 go test $(go list ./... |grep -v 'vendor') -v -run TestAccIBMCmOfferingBasic -timeout 700m
=== RUN   TestAccIBMCmOfferingBasic
--- PASS: TestAccIBMCmOfferingBasic (13.74s)

TF_ACC=1 go test $(go list ./... |grep -v 'vendor') -v -run TestAccIBMCmOfferingSimpleArgs -timeout 700m
=== RUN   TestAccIBMCmOfferingSimpleArgs
--- PASS: TestAccIBMCmOfferingSimpleArgs (21.55s)

TF_ACC=1 go test $(go list ./... |grep -v 'vendor') -v -run TestAccIBMCmOfferingDataSourceBasic -timeout 700m
=== RUN   TestAccIBMCmOfferingDataSourceBasic
--- PASS: TestAccIBMCmOfferingDataSourceBasic (16.42s)

TF_ACC=1 go test $(go list ./... |grep -v 'vendor') -v -run TestAccIBMCmOfferingDataSourceSimpleArgs -timeout 700m
=== RUN   TestAccIBMCmOfferingDataSourceSimpleArgs
--- PASS: TestAccIBMCmOfferingDataSourceSimpleArgs (16.74s)

TF_ACC=1 go test $(go list ./... |grep -v 'vendor') -v -run TestAccIBMCmVersionBasic -timeout 700m
=== RUN   TestAccIBMCmVersionBasic
--- PASS: TestAccIBMCmVersionBasic (29.45s)

TF_ACC=1 go test $(go list ./... |grep -v 'vendor') -v -run TestAccIBMCmVersionSimpleArgs -timeout 700m
=== RUN   TestAccIBMCmVersionSimpleArgs
--- PASS: TestAccIBMCmVersionSimpleArgs (16.33s)

TF_ACC=1 go test $(go list ./... |grep -v 'vendor') -v -run TestAccIBMCmVersionDataSourceSimpleArgs -timeout 700m
=== RUN   TestAccIBMCmVersionDataSourceSimpleArgs
--- PASS: TestAccIBMCmVersionDataSourceSimpleArgs (17.64s)
```
</details>