### PR TITLE
config changes

### DIFF
--- a/examples/ibm-configuration-aggregator/README.md
+++ b/examples/ibm-configuration-aggregator/README.md
@@ -40,9 +40,9 @@ resource "ibm_config_aggregator_settings" "config_aggregator_settings_instance" 
 | Name | Description | Type | Required |
 |------|-------------|------|---------|
 | ibmcloud\_api\_key | IBM Cloud API key | `string` | true |
-| resource_collection_enabled | The field denoting if the resource collection is enabled. | `bool` | false |
-| trusted_profile_id | The trusted profile id that provides Reader access to the App Configuration instance to collect resource metadata. | `string` | false |
-| regions | The list of regions across which the resource collection is enabled. | `list(string)` | false |
+| resource_collection_enabled | The field denoting if the resource collection is enabled. | `bool` | true |
+| trusted_profile_id | The trusted profile id that provides Reader access to the App Configuration instance to collect resource metadata. | `string` | true |
+| regions | The list of regions across which the resource collection is enabled. | `list(string)` | true |
 | additional_scope | The additional scope that enables resource collection for Enterprise acccounts. | `list()` | false |
 
 ## Configuration Aggregator data sources
@@ -119,5 +119,10 @@ data "ibm_config_aggregator_resource_collection_status" "config_aggregator_resou
 
 | Name | Version |
 |------|---------|
-| terraform | ~> 1.9.6 |
+| terraform | ~> 0.12 |
 
+## Providers
+
+| Name | Version |
+|------|---------|
+| ibm | 1.13.1 |

--- a/examples/ibm-configuration-aggregator/README.md
+++ b/examples/ibm-configuration-aggregator/README.md
@@ -40,9 +40,9 @@ resource "ibm_config_aggregator_settings" "config_aggregator_settings_instance" 
 | Name | Description | Type | Required |
 |------|-------------|------|---------|
 | ibmcloud\_api\_key | IBM Cloud API key | `string` | true |
-| resource_collection_enabled | The field denoting if the resource collection is enabled. | `bool` | true |
-| trusted_profile_id | The trusted profile id that provides Reader access to the App Configuration instance to collect resource metadata. | `string` | true |
-| regions | The list of regions across which the resource collection is enabled. | `list(string)` | true |
+| resource_collection_enabled | The field denoting if the resource collection is enabled. | `bool` | false |
+| trusted_profile_id | The trusted profile id that provides Reader access to the App Configuration instance to collect resource metadata. | `string` | false |
+| regions | The list of regions across which the resource collection is enabled. | `list(string)` | false |
 | additional_scope | The additional scope that enables resource collection for Enterprise acccounts. | `list()` | false |
 
 ## Configuration Aggregator data sources

--- a/examples/ibm-configuration-aggregator/README.md
+++ b/examples/ibm-configuration-aggregator/README.md
@@ -1,0 +1,123 @@
+# Examples for Configuration Aggregator
+
+These examples illustrate how to use the resources and data sources associated with Configuration Aggregator.
+
+The following resources are supported:
+* ibm_config_aggregator_settings
+
+The following data sources are supported:
+* ibm_config_aggregator_configurations
+* ibm_config_aggregator_settings
+* ibm_config_aggregator_resource_collection_status
+
+## Usage
+
+To run this example, execute the following commands:
+
+```bash
+$ terraform init
+$ terraform plan
+$ terraform apply
+```
+
+Run `terraform destroy` when you don't need these resources.
+
+## Configuration Aggregator resources
+
+### Resource: ibm_config_aggregator_settings
+
+```hcl
+resource "ibm_config_aggregator_settings" "config_aggregator_settings_instance" {
+  resource_collection_enabled = var.config_aggregator_settings_resource_collection_enabled
+  trusted_profile_id = var.config_aggregator_settings_trusted_profile_id
+  regions = var.config_aggregator_settings_regions
+  additional_scope = var.config_aggregator_settings_additional_scope
+}
+```
+
+#### Inputs
+
+| Name | Description | Type | Required |
+|------|-------------|------|---------|
+| ibmcloud\_api\_key | IBM Cloud API key | `string` | true |
+| resource_collection_enabled | The field denoting if the resource collection is enabled. | `bool` | false |
+| trusted_profile_id | The trusted profile id that provides Reader access to the App Configuration instance to collect resource metadata. | `string` | false |
+| regions | The list of regions across which the resource collection is enabled. | `list(string)` | false |
+| additional_scope | The additional scope that enables resource collection for Enterprise acccounts. | `list()` | false |
+
+## Configuration Aggregator data sources
+
+### Data source: ibm_config_aggregator_configurations
+
+```hcl
+data "ibm_config_aggregator_configurations" "config_aggregator_configurations_instance" {
+  config_type = var.config_aggregator_configurations_config_type
+  service_name = var.config_aggregator_configurations_service_name
+  resource_group_id = var.config_aggregator_configurations_resource_group_id
+  location = var.config_aggregator_configurations_location
+  resource_crn = var.config_aggregator_configurations_resource_crn
+}
+```
+
+#### Inputs
+
+| Name | Description | Type | Required |
+|------|-------------|------|---------|
+| config_type | The type of resource configuration that are to be retrieved. | `string` | false |
+| service_name | The name of the IBM Cloud service for which resources are to be retrieved. | `string` | false |
+| resource_group_id | The resource group id of the resources. | `string` | false |
+| location | The location or region in which the resources are created. | `string` | false |
+| resource_crn | The crn of the resource. | `string` | false |
+
+#### Outputs
+
+| Name | Description |
+|------|-------------|
+| prev | The reference to the previous page of entries. |
+| configs | Array of resource configurations. |
+
+### Data source: ibm_config_aggregator_settings
+
+```hcl
+data "ibm_config_aggregator_settings" "config_aggregator_settings_instance" {
+}
+```
+
+#### Outputs
+
+| Name | Description |
+|------|-------------|
+| resource_collection_enabled | The field to check if the resource collection is enabled. |
+| trusted_profile_id | The trusted profile ID that provides access to App Configuration instance to retrieve resource metadata. |
+| last_updated | The last time the settings was last updated. |
+| regions | Regions for which the resource collection is enabled. |
+| additional_scope | The additional scope that enables resource collection for Enterprise acccounts. |
+
+### Data source: ibm_config_aggregator_resource_collection_status
+
+```hcl
+data "ibm_config_aggregator_resource_collection_status" "config_aggregator_resource_collection_status_instance" {
+}
+```
+
+#### Outputs
+
+| Name | Description |
+|------|-------------|
+| last_config_refresh_time | The timestamp at which the configuration was last refreshed. |
+| status | Status of the resource collection. |
+
+## Assumptions
+
+1. TODO
+
+## Notes
+
+1. TODO
+
+## Requirements
+
+| Name | Version |
+|------|---------|
+| terraform | ~> 1.9.6 |
+

--- a/examples/ibm-configuration-aggregator/main.tf
+++ b/examples/ibm-configuration-aggregator/main.tf
@@ -14,16 +14,17 @@ resource "ibm_config_aggregator_settings" "config_aggregator_settings_instance" 
 // Uncomment if an existing data source instance exists
 /*
 // Create config_aggregator_configurations data source
+
+
+*/
+
 data "ibm_config_aggregator_configurations" "config_aggregator_configurations_instance" {
-  account_id                 = var.account_id
   config_type                = var.config_type
   location                   = var.location
   resource_crn               = var.resource_crn
   resource_group_id          = var.resource_group_id
-  resource_name              = var.resource_name
   service_name               = var.service_name
 }
-*/
 
 // Data source is not linked to a resource instance
 // Uncomment if an existing data source instance exists

--- a/examples/ibm-configuration-aggregator/main.tf
+++ b/examples/ibm-configuration-aggregator/main.tf
@@ -2,40 +2,27 @@ provider "ibm" {
   ibmcloud_api_key = var.ibmcloud_api_key
 }
 
-// Provision config_aggregator_settings resource instance
 resource "ibm_config_aggregator_settings" "config_aggregator_settings_instance" {
   instance_id=var.instance_id
+  region =var.region
   resource_collection_enabled = var.config_aggregator_settings_resource_collection_enabled
   trusted_profile_id          = var.config_aggregator_settings_trusted_profile_id
-  regions                     = var.config_aggregator_settings_regions
+  resource_collection_regions                    = var.config_aggregator_settings_regions
 }
 
+data "ibm_config_aggregator_configurations" "config_aggregator_configurations_instance" {
+  instance_id=var.instance_id
+  region =var.region
 
-// Data source is not linked to a resource instance
-// Uncomment if an existing data source instance exists
-/*
-// Create config_aggregator_configurations data source
+}
 
-
-*/
-
-// Data source is not linked to a resource instance
-// Uncomment if an existing data source instance exists
-/*
-// Create config_aggregator_settings data source
-
-*/
 
 data "ibm_config_aggregator_settings" "config_aggregator_settings_instance" {
     instance_id=var.instance_id
+    region =var.region
 }
 
-// Data source is not linked to a resource instance
-// Uncomment if an existing data source instance exists
-/*
-// Create config_aggregator_resource_collection_status data source
 data "ibm_config_aggregator_resource_collection_status" "config_aggregator_resource_collection_status_instance" {
     instance_id=var.instance_id
-    status = "complete"
+    region =var.region
 }
-*/

--- a/examples/ibm-configuration-aggregator/main.tf
+++ b/examples/ibm-configuration-aggregator/main.tf
@@ -4,6 +4,7 @@ provider "ibm" {
 
 // Provision config_aggregator_settings resource instance
 resource "ibm_config_aggregator_settings" "config_aggregator_settings_instance" {
+  instance_id=var.instance_id
   resource_collection_enabled = var.config_aggregator_settings_resource_collection_enabled
   trusted_profile_id          = var.config_aggregator_settings_trusted_profile_id
   regions                     = var.config_aggregator_settings_regions
@@ -18,26 +19,23 @@ resource "ibm_config_aggregator_settings" "config_aggregator_settings_instance" 
 
 */
 
-data "ibm_config_aggregator_configurations" "config_aggregator_configurations_instance" {
-
-}
-
 // Data source is not linked to a resource instance
 // Uncomment if an existing data source instance exists
 /*
 // Create config_aggregator_settings data source
-data "ibm_config_aggregator_settings" "config_aggregator_settings_instance" {
-    resource_collection_enabled = var.config_aggregator_settings_resource_collection_enabled
-    trusted_profile_id          = var.config_aggregator_settings_trusted_profile_id
-    regions                     = var.config_aggregator_settings_regions
-}
+
 */
+
+data "ibm_config_aggregator_settings" "config_aggregator_settings_instance" {
+    instance_id=var.instance_id
+}
 
 // Data source is not linked to a resource instance
 // Uncomment if an existing data source instance exists
 /*
 // Create config_aggregator_resource_collection_status data source
 data "ibm_config_aggregator_resource_collection_status" "config_aggregator_resource_collection_status_instance" {
+    instance_id=var.instance_id
     status = "complete"
 }
 */

--- a/examples/ibm-configuration-aggregator/main.tf
+++ b/examples/ibm-configuration-aggregator/main.tf
@@ -19,11 +19,7 @@ resource "ibm_config_aggregator_settings" "config_aggregator_settings_instance" 
 */
 
 data "ibm_config_aggregator_configurations" "config_aggregator_configurations_instance" {
-  config_type                = var.config_type
-  location                   = var.location
-  resource_crn               = var.resource_crn
-  resource_group_id          = var.resource_group_id
-  service_name               = var.service_name
+
 }
 
 // Data source is not linked to a resource instance

--- a/examples/ibm-configuration-aggregator/main.tf
+++ b/examples/ibm-configuration-aggregator/main.tf
@@ -1,0 +1,46 @@
+provider "ibm" {
+  ibmcloud_api_key = var.ibmcloud_api_key
+}
+
+// Provision config_aggregator_settings resource instance
+resource "ibm_config_aggregator_settings" "config_aggregator_settings_instance" {
+  resource_collection_enabled = var.config_aggregator_settings_resource_collection_enabled
+  trusted_profile_id          = var.config_aggregator_settings_trusted_profile_id
+  regions                     = var.config_aggregator_settings_regions
+}
+
+
+// Data source is not linked to a resource instance
+// Uncomment if an existing data source instance exists
+/*
+// Create config_aggregator_configurations data source
+data "ibm_config_aggregator_configurations" "config_aggregator_configurations_instance" {
+  account_id                 = var.account_id
+  config_type                = var.config_type
+  location                   = var.location
+  resource_crn               = var.resource_crn
+  resource_group_id          = var.resource_group_id
+  resource_name              = var.resource_name
+  service_name               = var.service_name
+}
+*/
+
+// Data source is not linked to a resource instance
+// Uncomment if an existing data source instance exists
+/*
+// Create config_aggregator_settings data source
+data "ibm_config_aggregator_settings" "config_aggregator_settings_instance" {
+    resource_collection_enabled = var.config_aggregator_settings_resource_collection_enabled
+    trusted_profile_id          = var.config_aggregator_settings_trusted_profile_id
+    regions                     = var.config_aggregator_settings_regions
+}
+*/
+
+// Data source is not linked to a resource instance
+// Uncomment if an existing data source instance exists
+/*
+// Create config_aggregator_resource_collection_status data source
+data "ibm_config_aggregator_resource_collection_status" "config_aggregator_resource_collection_status_instance" {
+    status = "complete"
+}
+*/

--- a/examples/ibm-configuration-aggregator/outputs.tf
+++ b/examples/ibm-configuration-aggregator/outputs.tf
@@ -1,0 +1,42 @@
+// This output allows config_aggregator_settings data to be referenced by other resources and the terraform CLI
+// Modify this output if only certain data should be exposed
+output "config_aggregator_settings" {
+  value = {
+    additional_scope            = []
+    regions                     = ["all"]
+    resource_collection_enabled  = ibm_config_aggregator_settings.config_aggregator_settings_instance.resource_collection_enabled
+    trusted_profile_id           = ibm_config_aggregator_settings.config_aggregator_settings_instance.trusted_profile_id
+  }
+}
+
+output "aggregator_settings" {
+  value = {
+    additional_scope            = []
+    regions                     = ["all"]
+    resource_collection_enabled  = ibm_config_aggregator_settings.config_aggregator_settings_instance.resource_collection_enabled
+    trusted_profile_id           = ibm_config_aggregator_settings.config_aggregator_settings_instance.trusted_profile_id
+  }
+}
+
+output "config_aggregator_configurations" {
+  value = {
+    about = {
+      account_id               = data.ibm_config_aggregator_configurations.config_aggregator_configurations_instance.account_id
+      config_type              = data.ibm_config_aggregator_configurations.config_aggregator_configurations_instance.config_type
+      location                 = data.ibm_config_aggregator_configurations.config_aggregator_configurations_instance.location
+      resource_crn             = data.ibm_config_aggregator_configurations.config_aggregator_configurations_instance.resource_crn
+      resource_group_id        = data.ibm_config_aggregator_configurations.config_aggregator_configurations_instance.resource_group_id
+      resource_name            = data.ibm_config_aggregator_configurations.config_aggregator_configurations_instance.resource_name
+      service_name             = data.ibm_config_aggregator_configurations.config_aggregator_configurations_instance.service_name
+    },
+    config = {
+      event_notification_enabled = data.ibm_config_aggregator_configurations.config_aggregator_configurations_instance.event_notification_enabled
+    }
+  }
+}
+
+output "config_aggregator_resource_collection_status"{
+    value={
+        status = "complete"
+    }
+}

--- a/examples/ibm-configuration-aggregator/outputs.tf
+++ b/examples/ibm-configuration-aggregator/outputs.tf
@@ -18,9 +18,12 @@ output "aggregator_settings" {
   }
 }
 
+output "ibm_config_aggregator_configurations" {
+  value = data.ibm_config_aggregator_configurations.config_aggregator_configurations_instance
+}
 
 output "config_aggregator_resource_collection_status"{
     value={
-        status = "complete"
+      status=data.ibm_config_aggregator_resource_collection_status.config_aggregator_resource_collection_status_instance.status
     }
 }

--- a/examples/ibm-configuration-aggregator/outputs.tf
+++ b/examples/ibm-configuration-aggregator/outputs.tf
@@ -18,19 +18,14 @@ output "aggregator_settings" {
   }
 }
 
-output "config_aggregator_configurations" {
+output "ibm_config_aggregator_configurations" {
   value = {
     about = {
-      account_id               = data.ibm_config_aggregator_configurations.config_aggregator_configurations_instance.account_id
       config_type              = data.ibm_config_aggregator_configurations.config_aggregator_configurations_instance.config_type
       location                 = data.ibm_config_aggregator_configurations.config_aggregator_configurations_instance.location
       resource_crn             = data.ibm_config_aggregator_configurations.config_aggregator_configurations_instance.resource_crn
       resource_group_id        = data.ibm_config_aggregator_configurations.config_aggregator_configurations_instance.resource_group_id
-      resource_name            = data.ibm_config_aggregator_configurations.config_aggregator_configurations_instance.resource_name
       service_name             = data.ibm_config_aggregator_configurations.config_aggregator_configurations_instance.service_name
-    },
-    config = {
-      event_notification_enabled = data.ibm_config_aggregator_configurations.config_aggregator_configurations_instance.event_notification_enabled
     }
   }
 }

--- a/examples/ibm-configuration-aggregator/outputs.tf
+++ b/examples/ibm-configuration-aggregator/outputs.tf
@@ -19,15 +19,7 @@ output "aggregator_settings" {
 }
 
 output "ibm_config_aggregator_configurations" {
-  value = {
-    about = {
-      config_type              = data.ibm_config_aggregator_configurations.config_aggregator_configurations_instance.config_type
-      location                 = data.ibm_config_aggregator_configurations.config_aggregator_configurations_instance.location
-      resource_crn             = data.ibm_config_aggregator_configurations.config_aggregator_configurations_instance.resource_crn
-      resource_group_id        = data.ibm_config_aggregator_configurations.config_aggregator_configurations_instance.resource_group_id
-      service_name             = data.ibm_config_aggregator_configurations.config_aggregator_configurations_instance.service_name
-    }
-  }
+  value = data.ibm_config_aggregator_configurations.config_aggregator_configurations_instance
 }
 
 output "config_aggregator_resource_collection_status"{

--- a/examples/ibm-configuration-aggregator/outputs.tf
+++ b/examples/ibm-configuration-aggregator/outputs.tf
@@ -18,9 +18,6 @@ output "aggregator_settings" {
   }
 }
 
-output "ibm_config_aggregator_configurations" {
-  value = data.ibm_config_aggregator_configurations.config_aggregator_configurations_instance
-}
 
 output "config_aggregator_resource_collection_status"{
     value={

--- a/examples/ibm-configuration-aggregator/variables.tf
+++ b/examples/ibm-configuration-aggregator/variables.tf
@@ -6,13 +6,11 @@ variable "ibmcloud_api_key" {
 variable "region"{
   description="Config Aggregator Instance ID"
   type=string
-  default="us-south"
 }
 
 variable "instance_id"{
   description="Config Aggregator Instance ID"
   type=string
-  default="d3e4c771-fc45-4699-ab13-faecc6e1fc74"
 }
 
 // Resource arguments for config_aggregator_settings

--- a/examples/ibm-configuration-aggregator/variables.tf
+++ b/examples/ibm-configuration-aggregator/variables.tf
@@ -3,6 +3,18 @@ variable "ibmcloud_api_key" {
   type        = string
 }
 
+variable "region"{
+  description="Config Aggregator Instance ID"
+  type=string
+  default="us-south"
+}
+
+variable "instance_id"{
+  description="Config Aggregator Instance ID"
+  type=string
+  default="d3e4c771-fc45-4699-ab13-faecc6e1fc74"
+}
+
 // Resource arguments for config_aggregator_settings
 variable "config_aggregator_settings_resource_collection_enabled" {
   description = "The field denoting if the resource collection is enabled."
@@ -12,7 +24,7 @@ variable "config_aggregator_settings_resource_collection_enabled" {
 variable "config_aggregator_settings_trusted_profile_id" {
   description = "The trusted profile id that provides Reader access to the App Configuration instance to collect resource metadata."
   type        = string
-  default     = "Profile-7d935dbb-7ee5-44e1-9e85-38e65d722398"
+  default="Profile-2546925a-7b46-40dd-81ff-48015a49ff43"
 }
 variable "config_aggregator_settings_regions" {
   description = "The list of regions across which the resource collection is enabled."
@@ -21,56 +33,30 @@ variable "config_aggregator_settings_regions" {
 }
 
 // Data source arguments for config_aggregator_configurations
-variable "account_id" {
-  description = "Account ID for the IBM Cloud instance"
+variable "config_aggregator_configurations_config_type" {
+  description = "The type of resource configuration that are to be retrieved."
   type        = string
-  default     = "18b006922637405389523fb06338e363"
+  default     = "placeholder"
+}
+variable "config_aggregator_configurations_service_name" {
+  description = "The name of the IBM Cloud service for which resources are to be retrieved."
+  type        = string
+  default     = "placeholder"
+}
+variable "config_aggregator_configurations_resource_group_id" {
+  description = "The resource group id of the resources."
+  type        = string
+  default     = "placeholder"
+}
+variable "config_aggregator_configurations_location" {
+  description = "The location or region in which the resources are created."
+  type        = string
+  default     = "placeholder"
+}
+variable "config_aggregator_configurations_resource_crn" {
+  description = "The crn of the resource."
+  type        = string
+  default     = "placeholder"
 }
 
-variable "config_type" {
-  description = "Configuration type for the resource"
-  type        = string
-  default     = "instance"
-}
 
-variable "last_config_refresh_time" {
-  description = "Last configuration refresh time"
-  type        = string
-  default     = "2024-09-16T00:30:22Z"
-}
-
-variable "location" {
-  description = "Location of the resource"
-  type        = string
-  default     = "us-south"
-}
-
-variable "resource_crn" {
-  description = "Resource CRN"
-  type        = string
-  default     = "crn:v1:staging:public:project:us-south:a/18b006922637405389523fb06338e363:3fdba864-9ab0-4cbd-a705-a78ce1e757ea::"
-}
-
-variable "resource_group_id" {
-  description = "Resource Group ID"
-  type        = string
-  default     = "c5450ce8dde54581bdfb8e785d27d292"
-}
-
-variable "resource_name" {
-  description = "Resource Name"
-  type        = string
-  default     = "logdna"
-}
-
-variable "service_name" {
-  description = "Service Name"
-  type        = string
-  default     = "project"
-}
-
-variable "event_notification_enabled" {
-  description = "Whether event notification is enabled"
-  type        = bool
-  default     = true
-}

--- a/examples/ibm-configuration-aggregator/variables.tf
+++ b/examples/ibm-configuration-aggregator/variables.tf
@@ -1,0 +1,76 @@
+variable "ibmcloud_api_key" {
+  description = "IBM Cloud API key"
+  type        = string
+}
+
+// Resource arguments for config_aggregator_settings
+variable "config_aggregator_settings_resource_collection_enabled" {
+  description = "The field denoting if the resource collection is enabled."
+  type        = bool
+  default     = true
+}
+variable "config_aggregator_settings_trusted_profile_id" {
+  description = "The trusted profile id that provides Reader access to the App Configuration instance to collect resource metadata."
+  type        = string
+  default     = "Profile-7d935dbb-7ee5-44e1-9e85-38e65d722398"
+}
+variable "config_aggregator_settings_regions" {
+  description = "The list of regions across which the resource collection is enabled."
+  type        = list(string)
+  default     = ["all"]
+}
+
+// Data source arguments for config_aggregator_configurations
+variable "account_id" {
+  description = "Account ID for the IBM Cloud instance"
+  type        = string
+  default     = "18b006922637405389523fb06338e363"
+}
+
+variable "config_type" {
+  description = "Configuration type for the resource"
+  type        = string
+  default     = "instance"
+}
+
+variable "last_config_refresh_time" {
+  description = "Last configuration refresh time"
+  type        = string
+  default     = "2024-09-16T00:30:22Z"
+}
+
+variable "location" {
+  description = "Location of the resource"
+  type        = string
+  default     = "us-south"
+}
+
+variable "resource_crn" {
+  description = "Resource CRN"
+  type        = string
+  default     = "crn:v1:staging:public:project:us-south:a/18b006922637405389523fb06338e363:3fdba864-9ab0-4cbd-a705-a78ce1e757ea::"
+}
+
+variable "resource_group_id" {
+  description = "Resource Group ID"
+  type        = string
+  default     = "c5450ce8dde54581bdfb8e785d27d292"
+}
+
+variable "resource_name" {
+  description = "Resource Name"
+  type        = string
+  default     = "logdna"
+}
+
+variable "service_name" {
+  description = "Service Name"
+  type        = string
+  default     = "project"
+}
+
+variable "event_notification_enabled" {
+  description = "Whether event notification is enabled"
+  type        = bool
+  default     = true
+}

--- a/examples/ibm-configuration-aggregator/versions.tf
+++ b/examples/ibm-configuration-aggregator/versions.tf
@@ -1,0 +1,7 @@
+terraform {
+  required_providers {
+    ibm = {
+      source = "IBM-Cloud/ibm"
+    }
+  }
+}

--- a/examples/ibm-configuration-aggregator/versions.tf
+++ b/examples/ibm-configuration-aggregator/versions.tf
@@ -1,7 +1,8 @@
 terraform {
+  required_version = ">= 1.0"
   required_providers {
     ibm = {
-      source = "IBM-Cloud/ibm"
+      source  = "terraform.local/ibm-cloud/ibm"
     }
   }
 }

--- a/go.mod
+++ b/go.mod
@@ -39,7 +39,7 @@ require (
 	github.com/IBM/schematics-go-sdk v0.3.0
 	github.com/IBM/secrets-manager-go-sdk/v2 v2.0.6
 	github.com/IBM/vmware-go-sdk v0.1.2
-	github.com/IBM/vpc-beta-go-sdk v0.6.0
+	github.com/IBM/vpc-beta-go-sdk v0.8.0
 	github.com/IBM/vpc-go-sdk v0.58.0
 	github.com/ScaleFT/sshkeys v0.0.0-20200327173127-6142f742bca5
 	github.com/akamai/AkamaiOPEN-edgegrid-golang v1.2.2
@@ -177,8 +177,6 @@ require (
 	github.com/mitchellh/copystructure v1.2.0 // indirect
 	github.com/mitchellh/go-testing-interface v1.14.1 // indirect
 	github.com/mitchellh/go-wordwrap v1.0.0 // indirect
-	github.com/mitchellh/gox v1.0.1 // indirect
-	github.com/mitchellh/iochan v1.0.0 // indirect
 	github.com/mitchellh/mapstructure v1.5.0 // indirect
 	github.com/mitchellh/reflectwalk v1.0.2 // indirect
 	github.com/moby/spdystream v0.2.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/IBM/appid-management-go-sdk v0.0.0-20210908164609-dd0e0eaf732f
 	github.com/IBM/cloud-databases-go-sdk v0.7.0
 	github.com/IBM/cloudant-go-sdk v0.8.0
-	github.com/IBM/code-engine-go-sdk v0.0.0-20240126185534-a6e054aa01ed
+	github.com/IBM/code-engine-go-sdk v0.0.0-20240808131715-b9d168602dac
 	github.com/IBM/configuration-aggregator-go-sdk v0.0.1
 	github.com/IBM/container-registry-go-sdk v1.1.0
 	github.com/IBM/continuous-delivery-go-sdk v1.6.0

--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,8 @@ require (
 	github.com/IBM/appid-management-go-sdk v0.0.0-20210908164609-dd0e0eaf732f
 	github.com/IBM/cloud-databases-go-sdk v0.7.0
 	github.com/IBM/cloudant-go-sdk v0.8.0
-	github.com/IBM/code-engine-go-sdk v0.0.0-20240808131715-b9d168602dac
+	github.com/IBM/code-engine-go-sdk v0.0.0-20240126185534-a6e054aa01ed
+	github.com/IBM/configuration-aggregator-go-sdk v0.0.1
 	github.com/IBM/container-registry-go-sdk v1.1.0
 	github.com/IBM/continuous-delivery-go-sdk v1.6.0
 	github.com/IBM/event-notifications-go-admin-sdk v0.9.0
@@ -51,7 +52,7 @@ require (
 	github.com/google/go-cmp v0.6.0
 	github.com/google/uuid v1.6.0
 	github.com/hashicorp/go-uuid v1.0.3
-	github.com/hashicorp/go-version v1.6.0
+	github.com/hashicorp/go-version v1.7.0
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.29.0
 	github.com/jinzhu/copier v0.3.2
 	github.com/minsikl/netscaler-nitro-go v0.0.0-20170827154432-5b14ce3643e3
@@ -176,6 +177,8 @@ require (
 	github.com/mitchellh/copystructure v1.2.0 // indirect
 	github.com/mitchellh/go-testing-interface v1.14.1 // indirect
 	github.com/mitchellh/go-wordwrap v1.0.0 // indirect
+	github.com/mitchellh/gox v1.0.1 // indirect
+	github.com/mitchellh/iochan v1.0.0 // indirect
 	github.com/mitchellh/mapstructure v1.5.0 // indirect
 	github.com/mitchellh/reflectwalk v1.0.2 // indirect
 	github.com/moby/spdystream v0.2.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -134,8 +134,6 @@ github.com/IBM/cloudant-go-sdk v0.8.0 h1:XzaqZFy5fm1Q9+iK52X5zRW39SHaahT9pf5SRgV
 github.com/IBM/cloudant-go-sdk v0.8.0/go.mod h1:zDGBs8ideVtn9MehXbIQNI3852B68BsMtKJvq3iPn/Q=
 github.com/IBM/code-engine-go-sdk v0.0.0-20240808131715-b9d168602dac h1:9Y5TB9Ar2SM6JPr2kM6c9pHSdSuHMDCIcbvTa/hNTj4=
 github.com/IBM/code-engine-go-sdk v0.0.0-20240808131715-b9d168602dac/go.mod h1:sy4CocPPaCiS+T1znqVdw83dkoyxSMUFxkksqahUhbY=
-github.com/IBM/configuration-aggregator-go-sdk v0.0.1 h1:bgJqfd39hzKqtLxgrmOZ7UgjhB2lgZ4jWqRfgqa0VTk=
-github.com/IBM/configuration-aggregator-go-sdk v0.0.1/go.mod h1:iMQUJgo42cbRk1XW06lmeHzm9/Nfk5/laBscGdPnSqY=
 github.com/IBM/container-registry-go-sdk v1.1.0 h1:sYyknIod8R4RJZQqAheiduP6wbSTphE9Ag8ho28yXjc=
 github.com/IBM/container-registry-go-sdk v1.1.0/go.mod h1:4TwsCnQtVfZ4Vkapy/KPvQBKFc3VOyUZYkwRU4FTPrs=
 github.com/IBM/continuous-delivery-go-sdk v1.6.0 h1:eAL/jIWHrDFlWDF+Qd9Y5UN99Pr5Mjd/H/bvTbXUbz4=
@@ -191,8 +189,8 @@ github.com/IBM/secrets-manager-go-sdk/v2 v2.0.6 h1:bF6bAdI4wDZSje6+Yx1mJxvirboxO
 github.com/IBM/secrets-manager-go-sdk/v2 v2.0.6/go.mod h1:XWYnbcc5vN1RnKwk/fCzfD8aZd7At/Y1/b6c+oDyliU=
 github.com/IBM/vmware-go-sdk v0.1.2 h1:5lKWFyInWz9e2hwGsoFTEoLa1jYkD30SReN0fQ10w9M=
 github.com/IBM/vmware-go-sdk v0.1.2/go.mod h1:2UGPBJju3jiv5VKKBBm9a5L6bzF/aJdKOKAzJ7HaOjA=
-github.com/IBM/vpc-beta-go-sdk v0.6.0 h1:wfM3AcW3zOM3xsRtZ+EA6+sESlGUjQ6Yf4n5QQyz4uc=
-github.com/IBM/vpc-beta-go-sdk v0.6.0/go.mod h1:fzHDAQIqH/5yJmYsKodKHLcqxMDT+yfH6vZjdiw8CQA=
+github.com/IBM/vpc-beta-go-sdk v0.8.0 h1:cEPpv4iw3Ba5W2d0AWg3TIbKeJ8y1nPuUuibR5Jt9eE=
+github.com/IBM/vpc-beta-go-sdk v0.8.0/go.mod h1:hORgIyTFRzXrZIK9IohaWmCRBBlYiDRagsufi7M6akE=
 github.com/IBM/vpc-go-sdk v0.58.0 h1:Slk1jkcV7tPnf0iECQV2Oja7W8Bom0z7k9M4fMBY4bI=
 github.com/IBM/vpc-go-sdk v0.58.0/go.mod h1:swmxiYLT+OfBsBYqJWGeRd6NPmBk4u/het2PZdtzIaw=
 github.com/Jeffail/gabs v1.1.1 h1:V0uzR08Hj22EX8+8QMhyI9sX2hwRu+/RJhJUmnwda/E=

--- a/go.sum
+++ b/go.sum
@@ -950,10 +950,11 @@ github.com/hashicorp/go-uuid v1.0.2-0.20191001231223-f32f5fe8d6a8/go.mod h1:6SBZ
 github.com/hashicorp/go-uuid v1.0.2/go.mod h1:6SBZvOh/SIDV7/2o3Jml5SYk/TvGqwFJ/bN7x4byOro=
 github.com/hashicorp/go-uuid v1.0.3 h1:2gKiV6YVmrJ1i2CKKa9obLvRieoRGviZFL26PcT/Co8=
 github.com/hashicorp/go-uuid v1.0.3/go.mod h1:6SBZvOh/SIDV7/2o3Jml5SYk/TvGqwFJ/bN7x4byOro=
+github.com/hashicorp/go-version v1.0.0/go.mod h1:fltr4n8CU8Ke44wwGCBoEymUuxUHl09ZGVZPK5anwXA=
 github.com/hashicorp/go-version v1.1.0/go.mod h1:fltr4n8CU8Ke44wwGCBoEymUuxUHl09ZGVZPK5anwXA=
 github.com/hashicorp/go-version v1.2.0/go.mod h1:fltr4n8CU8Ke44wwGCBoEymUuxUHl09ZGVZPK5anwXA=
-github.com/hashicorp/go-version v1.6.0 h1:feTTfFNnjP967rlCxM/I9g701jU+RN74YKx2mOkIeek=
-github.com/hashicorp/go-version v1.6.0/go.mod h1:fltr4n8CU8Ke44wwGCBoEymUuxUHl09ZGVZPK5anwXA=
+github.com/hashicorp/go-version v1.7.0 h1:5tqGy27NaOTB8yJKUZELlFAS/LTKJkrmONwQKeRZfjY=
+github.com/hashicorp/go-version v1.7.0/go.mod h1:fltr4n8CU8Ke44wwGCBoEymUuxUHl09ZGVZPK5anwXA=
 github.com/hashicorp/go.net v0.0.1/go.mod h1:hjKkEWcCURg++eb33jQU7oqQcI9XDCnUzHA0oac0k90=
 github.com/hashicorp/golang-lru v0.0.0-20180201235237-0fb14efe8c47/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hashicorp/golang-lru v0.5.0/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
@@ -1260,7 +1261,10 @@ github.com/mitchellh/go-testing-interface v1.14.1/go.mod h1:gfgS7OtZj6MA4U1UrDRp
 github.com/mitchellh/go-wordwrap v1.0.0 h1:6GlHJ/LTGMrIJbwgdqdl2eEH8o+Exx/0m8ir9Gns0u4=
 github.com/mitchellh/go-wordwrap v1.0.0/go.mod h1:ZXFpozHsX6DPmq2I0TCekCxypsnAUbP2oI0UX1GXzOo=
 github.com/mitchellh/gox v0.4.0/go.mod h1:Sd9lOJ0+aimLBi73mGofS1ycjY8lL3uZM3JPS42BGNg=
+github.com/mitchellh/gox v1.0.1 h1:x0jD3dcHk9a9xPSDN6YEL4xL6Qz0dvNYm8yZqui5chI=
+github.com/mitchellh/gox v1.0.1/go.mod h1:ED6BioOGXMswlXa2zxfh/xdd5QhwYliBFn9V18Ap4z4=
 github.com/mitchellh/hashstructure v1.0.0/go.mod h1:QjSHrPWS+BGUVBYkbTZWEnOh3G1DutKwClXU/ABz6AQ=
+github.com/mitchellh/iochan v1.0.0 h1:C+X3KsSTLFVBr/tK1eYN/vs4rJcvsiLU338UhYPJWeY=
 github.com/mitchellh/iochan v1.0.0/go.mod h1:JwYml1nuB7xOzsp52dPpHFffvOCDupsG0QubkSMEySY=
 github.com/mitchellh/mapstructure v0.0.0-20160808181253-ca63d7c062ee/go.mod h1:FVVH3fgwuzCH5S8UJGiWEs2h04kUh9fWfEaFds41c1Y=
 github.com/mitchellh/mapstructure v1.1.2/go.mod h1:FVVH3fgwuzCH5S8UJGiWEs2h04kUh9fWfEaFds41c1Y=

--- a/go.sum
+++ b/go.sum
@@ -134,6 +134,8 @@ github.com/IBM/cloudant-go-sdk v0.8.0 h1:XzaqZFy5fm1Q9+iK52X5zRW39SHaahT9pf5SRgV
 github.com/IBM/cloudant-go-sdk v0.8.0/go.mod h1:zDGBs8ideVtn9MehXbIQNI3852B68BsMtKJvq3iPn/Q=
 github.com/IBM/code-engine-go-sdk v0.0.0-20240808131715-b9d168602dac h1:9Y5TB9Ar2SM6JPr2kM6c9pHSdSuHMDCIcbvTa/hNTj4=
 github.com/IBM/code-engine-go-sdk v0.0.0-20240808131715-b9d168602dac/go.mod h1:sy4CocPPaCiS+T1znqVdw83dkoyxSMUFxkksqahUhbY=
+github.com/IBM/configuration-aggregator-go-sdk v0.0.1 h1:bgJqfd39hzKqtLxgrmOZ7UgjhB2lgZ4jWqRfgqa0VTk=
+github.com/IBM/configuration-aggregator-go-sdk v0.0.1/go.mod h1:iMQUJgo42cbRk1XW06lmeHzm9/Nfk5/laBscGdPnSqY=
 github.com/IBM/container-registry-go-sdk v1.1.0 h1:sYyknIod8R4RJZQqAheiduP6wbSTphE9Ag8ho28yXjc=
 github.com/IBM/container-registry-go-sdk v1.1.0/go.mod h1:4TwsCnQtVfZ4Vkapy/KPvQBKFc3VOyUZYkwRU4FTPrs=
 github.com/IBM/continuous-delivery-go-sdk v1.6.0 h1:eAL/jIWHrDFlWDF+Qd9Y5UN99Pr5Mjd/H/bvTbXUbz4=
@@ -950,7 +952,6 @@ github.com/hashicorp/go-uuid v1.0.2-0.20191001231223-f32f5fe8d6a8/go.mod h1:6SBZ
 github.com/hashicorp/go-uuid v1.0.2/go.mod h1:6SBZvOh/SIDV7/2o3Jml5SYk/TvGqwFJ/bN7x4byOro=
 github.com/hashicorp/go-uuid v1.0.3 h1:2gKiV6YVmrJ1i2CKKa9obLvRieoRGviZFL26PcT/Co8=
 github.com/hashicorp/go-uuid v1.0.3/go.mod h1:6SBZvOh/SIDV7/2o3Jml5SYk/TvGqwFJ/bN7x4byOro=
-github.com/hashicorp/go-version v1.0.0/go.mod h1:fltr4n8CU8Ke44wwGCBoEymUuxUHl09ZGVZPK5anwXA=
 github.com/hashicorp/go-version v1.1.0/go.mod h1:fltr4n8CU8Ke44wwGCBoEymUuxUHl09ZGVZPK5anwXA=
 github.com/hashicorp/go-version v1.2.0/go.mod h1:fltr4n8CU8Ke44wwGCBoEymUuxUHl09ZGVZPK5anwXA=
 github.com/hashicorp/go-version v1.7.0 h1:5tqGy27NaOTB8yJKUZELlFAS/LTKJkrmONwQKeRZfjY=
@@ -1261,10 +1262,7 @@ github.com/mitchellh/go-testing-interface v1.14.1/go.mod h1:gfgS7OtZj6MA4U1UrDRp
 github.com/mitchellh/go-wordwrap v1.0.0 h1:6GlHJ/LTGMrIJbwgdqdl2eEH8o+Exx/0m8ir9Gns0u4=
 github.com/mitchellh/go-wordwrap v1.0.0/go.mod h1:ZXFpozHsX6DPmq2I0TCekCxypsnAUbP2oI0UX1GXzOo=
 github.com/mitchellh/gox v0.4.0/go.mod h1:Sd9lOJ0+aimLBi73mGofS1ycjY8lL3uZM3JPS42BGNg=
-github.com/mitchellh/gox v1.0.1 h1:x0jD3dcHk9a9xPSDN6YEL4xL6Qz0dvNYm8yZqui5chI=
-github.com/mitchellh/gox v1.0.1/go.mod h1:ED6BioOGXMswlXa2zxfh/xdd5QhwYliBFn9V18Ap4z4=
 github.com/mitchellh/hashstructure v1.0.0/go.mod h1:QjSHrPWS+BGUVBYkbTZWEnOh3G1DutKwClXU/ABz6AQ=
-github.com/mitchellh/iochan v1.0.0 h1:C+X3KsSTLFVBr/tK1eYN/vs4rJcvsiLU338UhYPJWeY=
 github.com/mitchellh/iochan v1.0.0/go.mod h1:JwYml1nuB7xOzsp52dPpHFffvOCDupsG0QubkSMEySY=
 github.com/mitchellh/mapstructure v0.0.0-20160808181253-ca63d7c062ee/go.mod h1:FVVH3fgwuzCH5S8UJGiWEs2h04kUh9fWfEaFds41c1Y=
 github.com/mitchellh/mapstructure v1.1.2/go.mod h1:FVVH3fgwuzCH5S8UJGiWEs2h04kUh9fWfEaFds41c1Y=

--- a/ibm/acctest/acctest.go
+++ b/ibm/acctest/acctest.go
@@ -1516,6 +1516,16 @@ func init() {
 		fmt.Println("[INFO] Set the environment variable SATELLITE_RESOURCE_INSTANCE_ID for ibm_cos_bucket satellite location resource or datasource else tests will fail if this is not set correctly")
 	}
 
+	ConfigAggregatorEndpoint := os.Getenv("IBMCLOUD_CONFIG_AGGREGATOR_ENDPOINT")
+	if ConfigAggregatorEndpoint == "" {
+		fmt.Println("[WARN] Set the environment variable IBMCLOUD_CONFIG_AGGREGATOR_ENDPOINT with a VALID SCC API ENDPOINT")
+	}
+
+	ConfigAggregatorInstanceID := os.Getenv("IBMCLOUD_CONFIG_AGGREGATOR_INSTANCE_ID")
+	if ConfigAggregatorInstanceID == "" {
+		fmt.Println("[WARN] Set the environment variable IBMCLOUD_CONFIG_AGGREGATOR_INSTANCE_ID with a VALID SCC INSTANCE ID")
+	}
+
 	SccInstanceID = os.Getenv("IBMCLOUD_SCC_INSTANCE_ID")
 	if SccInstanceID == "" {
 		fmt.Println("[WARN] Set the environment variable IBMCLOUD_SCC_INSTANCE_ID with a VALID SCC INSTANCE ID")

--- a/ibm/conns/config.go
+++ b/ibm/conns/config.go
@@ -2393,27 +2393,31 @@ func (c *Config) ClientSession() (interface{}, error) {
 	}
 
 	// Construct an instance of the 'Configuration Aggregator' service.
-	instance_id := "ConfigAggregatorInstanceID"
-	configURL := fmt.Sprintf("https://%s.apprapp.cloud.ibm.com/apprapp/config_aggregator/v1/instances/", c.Region, instance_id)
-	if session.configurationAggregatorClientErr == nil {
-		// Construct the service options.
-		configurationAggregatorClientOptions := &configurationaggregatorv1.ConfigurationAggregatorV1Options{
-			Authenticator: authenticator,
-			URL:           configURL,
-		}
+	var configBaseURL string
+	fmt.Println("Priniting the location of config aggregator URL")
+	fmt.Println(c.Region)
+	configBaseURL = ContructEndpoint(fmt.Sprintf("%s.apprapp", c.Region), cloudEndpoint)
+	fmt.Println("Priniting the location of config aggregator URL - configBaseURL")
+	fmt.Println(configBaseURL)
 
-		// Construct the service client.
-		session.configurationAggregatorClient, err = configurationaggregatorv1.NewConfigurationAggregatorV1(configurationAggregatorClientOptions)
-		if err == nil {
-			// Enable retries for API calls
-			session.configurationAggregatorClient.Service.EnableRetries(c.RetryCount, c.RetryDelay)
-			// Add custom header for analytics
-			session.configurationAggregatorClient.SetDefaultHeaders(gohttp.Header{
-				"X-Original-User-Agent": {fmt.Sprintf("terraform-provider-ibm/%s", version.Version)},
-			})
-		} else {
-			session.configurationAggregatorClientErr = fmt.Errorf("Error occurred while constructing 'Configuration Aggregator' service client: %q", err)
-		}
+	configurationAggregatorClientOptions := &configurationaggregatorv1.ConfigurationAggregatorV1Options{
+		Authenticator: authenticator,
+		URL:           configBaseURL,
+	}
+	fmt.Println("Config Aggregator Client URL")
+	fmt.Println(configurationAggregatorClientOptions.URL)
+
+	// Construct the service client.
+	session.configurationAggregatorClient, err = configurationaggregatorv1.NewConfigurationAggregatorV1(configurationAggregatorClientOptions)
+	if err == nil {
+		// Enable retries for API calls
+		session.configurationAggregatorClient.Service.EnableRetries(c.RetryCount, c.RetryDelay)
+		// Add custom header for analytics
+		session.configurationAggregatorClient.SetDefaultHeaders(gohttp.Header{
+			"X-Original-User-Agent": {fmt.Sprintf("terraform-provider-ibm/%s", version.Version)},
+		})
+	} else {
+		session.configurationAggregatorClientErr = fmt.Errorf("Error occurred while constructing 'Configuration Aggregator' service client: %q", err)
 	}
 
 	// CIS Service instances starts here.

--- a/ibm/conns/config.go
+++ b/ibm/conns/config.go
@@ -2393,11 +2393,13 @@ func (c *Config) ClientSession() (interface{}, error) {
 	}
 
 	// Construct an instance of the 'Configuration Aggregator' service.
+	instance_id := "ConfigAggregatorInstanceID"
+	configURL := "https://us-south.apprapp.cloud.ibm.com/apprapp/config_aggregator/v1/instances/" + instance_id
 	if session.configurationAggregatorClientErr == nil {
 		// Construct the service options.
 		configurationAggregatorClientOptions := &configurationaggregatorv1.ConfigurationAggregatorV1Options{
-			URL:           EnvFallBack([]string{"IBMCLOUD_IAM_API_ENDPOINT"}, iamURL),
 			Authenticator: authenticator,
+			URL:           configURL,
 		}
 
 		// Construct the service client.

--- a/ibm/conns/config.go
+++ b/ibm/conns/config.go
@@ -93,6 +93,8 @@ import (
 	jwt "github.com/golang-jwt/jwt"
 	slsession "github.com/softlayer/softlayer-go/session"
 
+	"github.com/IBM/configuration-aggregator-go-sdk/configurationaggregatorv1"
+
 	bluemix "github.com/IBM-Cloud/bluemix-go"
 	"github.com/IBM-Cloud/bluemix-go/api/account/accountv1"
 	"github.com/IBM-Cloud/bluemix-go/api/account/accountv2"
@@ -220,6 +222,7 @@ type ClientSession interface {
 	ContainerAPI() (containerv1.ContainerServiceAPI, error)
 	VpcContainerAPI() (containerv2.ContainerServiceAPI, error)
 	ContainerRegistryV1() (*containerregistryv1.ContainerRegistryV1, error)
+	ConfigurationAggregatorV1() (*configurationaggregatorv1.ConfigurationAggregatorV1, error)
 	FunctionClient() (*whisk.Client, error)
 	GlobalSearchAPI() (globalsearchv2.GlobalSearchServiceAPI, error)
 	GlobalTaggingAPI() (globaltaggingv3.GlobalTaggingServiceAPI, error)
@@ -326,6 +329,9 @@ type clientSession struct {
 
 	accountV1ConfigErr     error
 	bmxAccountv1ServiceAPI accountv1.AccountServiceAPI
+
+	configurationAggregatorClient    *configurationaggregatorv1.ConfigurationAggregatorV1
+	configurationAggregatorClientErr error
 
 	bmxUserDetails  *UserConfig
 	bmxUserFetchErr error
@@ -665,6 +671,11 @@ func (session clientSession) UsageReportsV4() (*usagereportsv4.UsageReportsV4, e
 
 func (session clientSession) PartnerCenterSellV1() (*partnercentersellv1.PartnerCenterSellV1, error) {
 	return session.partnerCenterSellClient, session.partnerCenterSellClientErr
+}
+
+// Configuration Aggregator
+func (session clientSession) ConfigurationAggregatorV1() (*configurationaggregatorv1.ConfigurationAggregatorV1, error) {
+	return session.configurationAggregatorClient, session.configurationAggregatorClientErr
 }
 
 // AppIDAPI provides AppID Service APIs ...
@@ -2379,6 +2390,28 @@ func (c *Config) ClientSession() (interface{}, error) {
 		// session.transitgatewayAPI.SetDefaultHeaders(gohttp.Header{
 		// 	"X-Original-User-Agent": {fmt.Sprintf("terraform-provider-ibm/%s", version.Version)},
 		// })
+	}
+
+	// Construct an instance of the 'Configuration Aggregator' service.
+	if session.configurationAggregatorClientErr == nil {
+		// Construct the service options.
+		configurationAggregatorClientOptions := &configurationaggregatorv1.ConfigurationAggregatorV1Options{
+			URL:           EnvFallBack([]string{"IBMCLOUD_IAM_API_ENDPOINT"}, iamURL),
+			Authenticator: authenticator,
+		}
+
+		// Construct the service client.
+		session.configurationAggregatorClient, err = configurationaggregatorv1.NewConfigurationAggregatorV1(configurationAggregatorClientOptions)
+		if err == nil {
+			// Enable retries for API calls
+			session.configurationAggregatorClient.Service.EnableRetries(c.RetryCount, c.RetryDelay)
+			// Add custom header for analytics
+			session.configurationAggregatorClient.SetDefaultHeaders(gohttp.Header{
+				"X-Original-User-Agent": {fmt.Sprintf("terraform-provider-ibm/%s", version.Version)},
+			})
+		} else {
+			session.configurationAggregatorClientErr = fmt.Errorf("Error occurred while constructing 'Configuration Aggregator' service client: %q", err)
+		}
 	}
 
 	// CIS Service instances starts here.

--- a/ibm/conns/config.go
+++ b/ibm/conns/config.go
@@ -2394,7 +2394,7 @@ func (c *Config) ClientSession() (interface{}, error) {
 
 	// Construct an instance of the 'Configuration Aggregator' service.
 	instance_id := "ConfigAggregatorInstanceID"
-	configURL := "https://us-south.apprapp.cloud.ibm.com/apprapp/config_aggregator/v1/instances/" + instance_id
+	configURL := fmt.Sprintf("https://%s.apprapp.cloud.ibm.com/apprapp/config_aggregator/v1/instances/", c.Region, instance_id)
 	if session.configurationAggregatorClientErr == nil {
 		// Construct the service options.
 		configurationAggregatorClientOptions := &configurationaggregatorv1.ConfigurationAggregatorV1Options{

--- a/ibm/conns/config.go
+++ b/ibm/conns/config.go
@@ -2394,18 +2394,12 @@ func (c *Config) ClientSession() (interface{}, error) {
 
 	// Construct an instance of the 'Configuration Aggregator' service.
 	var configBaseURL string
-	fmt.Println("Priniting the location of config aggregator URL")
-	fmt.Println(c.Region)
 	configBaseURL = ContructEndpoint(fmt.Sprintf("%s.apprapp", c.Region), cloudEndpoint)
-	fmt.Println("Priniting the location of config aggregator URL - configBaseURL")
-	fmt.Println(configBaseURL)
 
 	configurationAggregatorClientOptions := &configurationaggregatorv1.ConfigurationAggregatorV1Options{
 		Authenticator: authenticator,
 		URL:           configBaseURL,
 	}
-	fmt.Println("Config Aggregator Client URL")
-	fmt.Println(configurationAggregatorClientOptions.URL)
 
 	// Construct the service client.
 	session.configurationAggregatorClient, err = configurationaggregatorv1.NewConfigurationAggregatorV1(configurationAggregatorClientOptions)

--- a/ibm/provider/provider.go
+++ b/ibm/provider/provider.go
@@ -237,9 +237,9 @@ func Provider() *schema.Provider {
 			"ibm_app_domain_private":               cloudfoundry.DataSourceIBMAppDomainPrivate(),
 			"ibm_app_domain_shared":                cloudfoundry.DataSourceIBMAppDomainShared(),
 			"ibm_app_route":                        cloudfoundry.DataSourceIBMAppRoute(),
-			"ibm_config_aggregator_configurations": configurationaggregator.DataSourceIbmConfigAggregatorConfigurations(),
-			"ibm_config_aggregator_settings":       configurationaggregator.DataSourceIbmConfigAggregatorSettings(),
-			"ibm_config_aggregator_resource_collection_status": configurationaggregator.DataSourceIbmConfigAggregatorResourceCollectionStatus(),
+			"ibm_config_aggregator_configurations": configurationaggregator.AddConfigurationAggregatorInstanceFields(configurationaggregator.DataSourceIbmConfigAggregatorConfigurations()),
+			"ibm_config_aggregator_settings":       configurationaggregator.AddConfigurationAggregatorInstanceFields(configurationaggregator.DataSourceIbmConfigAggregatorSettings()),
+			"ibm_config_aggregator_resource_collection_status": configurationaggregator.AddConfigurationAggregatorInstanceFields(configurationaggregator.DataSourceIbmConfigAggregatorResourceCollectionStatus()),
 
 			// // AppID
 			"ibm_appid_action_url":               appid.DataSourceIBMAppIDActionURL(),
@@ -981,7 +981,7 @@ func Provider() *schema.Provider {
 			"ibm_app_domain_private":                cloudfoundry.ResourceIBMAppDomainPrivate(),
 			"ibm_app_domain_shared":                 cloudfoundry.ResourceIBMAppDomainShared(),
 			"ibm_app_route":                         cloudfoundry.ResourceIBMAppRoute(),
-			"ibm_config_aggregator_settings":        configurationaggregator.ResourceIbmConfigAggregatorSettings(),
+			"ibm_config_aggregator_settings":        configurationaggregator.AddConfigurationAggregatorInstanceFields(configurationaggregator.ResourceIbmConfigAggregatorSettings()),
 
 			// AppID
 			"ibm_appid_action_url":               appid.ResourceIBMAppIDActionURL(),

--- a/ibm/provider/provider.go
+++ b/ibm/provider/provider.go
@@ -30,6 +30,7 @@ import (
 	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/cloudfoundry"
 	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/cloudshell"
 	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/codeengine"
+	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/configurationaggregator"
 	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/contextbasedrestrictions"
 	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/cos"
 	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/database"
@@ -230,12 +231,15 @@ func Provider() *schema.Provider {
 		},
 
 		DataSourcesMap: map[string]*schema.Resource{
-			"ibm_api_gateway":        apigateway.DataSourceIBMApiGateway(),
-			"ibm_account":            cloudfoundry.DataSourceIBMAccount(),
-			"ibm_app":                cloudfoundry.DataSourceIBMApp(),
-			"ibm_app_domain_private": cloudfoundry.DataSourceIBMAppDomainPrivate(),
-			"ibm_app_domain_shared":  cloudfoundry.DataSourceIBMAppDomainShared(),
-			"ibm_app_route":          cloudfoundry.DataSourceIBMAppRoute(),
+			"ibm_api_gateway":                      apigateway.DataSourceIBMApiGateway(),
+			"ibm_account":                          cloudfoundry.DataSourceIBMAccount(),
+			"ibm_app":                              cloudfoundry.DataSourceIBMApp(),
+			"ibm_app_domain_private":               cloudfoundry.DataSourceIBMAppDomainPrivate(),
+			"ibm_app_domain_shared":                cloudfoundry.DataSourceIBMAppDomainShared(),
+			"ibm_app_route":                        cloudfoundry.DataSourceIBMAppRoute(),
+			"ibm_config_aggregator_configurations": configurationaggregator.DataSourceIbmConfigAggregatorConfigurations(),
+			"ibm_config_aggregator_settings":       configurationaggregator.DataSourceIbmConfigAggregatorSettings(),
+			"ibm_config_aggregator_resource_collection_status": configurationaggregator.DataSourceIbmConfigAggregatorResourceCollectionStatus(),
 
 			// // AppID
 			"ibm_appid_action_url":               appid.DataSourceIBMAppIDActionURL(),
@@ -977,6 +981,7 @@ func Provider() *schema.Provider {
 			"ibm_app_domain_private":                cloudfoundry.ResourceIBMAppDomainPrivate(),
 			"ibm_app_domain_shared":                 cloudfoundry.ResourceIBMAppDomainShared(),
 			"ibm_app_route":                         cloudfoundry.ResourceIBMAppRoute(),
+			"ibm_config_aggregator_settings":        configurationaggregator.ResourceIbmConfigAggregatorSettings(),
 
 			// AppID
 			"ibm_appid_action_url":               appid.ResourceIBMAppIDActionURL(),
@@ -1818,6 +1823,7 @@ func Validator() validate.ValidatorDict {
 				"ibm_hpcs_keystore":                            hpcs.ResourceIbmKeystoreValidator(),
 				"ibm_hpcs_key_template":                        hpcs.ResourceIbmKeyTemplateValidator(),
 				"ibm_hpcs_vault":                               hpcs.ResourceIbmVaultValidator(),
+				"ibm_config_aggregator_settings":               configurationaggregator.ResourceIbmConfigAggregatorSettingsValidator(),
 
 				// MQ on Cloud
 				"ibm_mqcloud_queue_manager":          mqcloud.ResourceIbmMqcloudQueueManagerValidator(),

--- a/ibm/service/configurationaggregator/README.md
+++ b/ibm/service/configurationaggregator/README.md
@@ -4,5 +4,8 @@ This area is primarily for IBM provider contributors and maintainers. For inform
 
 
 ## Handy Links
+* [Find out about contributing](../../../CONTRIBUTING.md) to the IBM provider!
+* IBM Provider Docs: [Home](https://registry.terraform.io/providers/IBM-Cloud/ibm/latest/docs)
+* IBM Provider Docs: [One of the  resources](https://registry.terraform.io/providers/IBM-Cloud/ibm/latest/docs/resources/config_aggregator_settings)
 * IBM API Docs: [IBM API Docs for ]()
-* IBM  SDK: [IBM SDK for ](https://github.com/IBM/configuration-aggregator-go-sdk/tree/main/configurationaggregatorv1")
+* IBM  SDK: [IBM SDK for ](https://github.com/IBM/appconfiguration-go-admin-sdk/tree/master/configurationaggregatorv1)

--- a/ibm/service/configurationaggregator/README.md
+++ b/ibm/service/configurationaggregator/README.md
@@ -1,0 +1,8 @@
+# Terraform IBM Provider 
+<!-- markdownlint-disable MD026 -->
+This area is primarily for IBM provider contributors and maintainers. For information on _using_ Terraform and the IBM provider, see the links below.
+
+
+## Handy Links
+* IBM API Docs: [IBM API Docs for ]()
+* IBM  SDK: [IBM SDK for ](https://github.com/IBM/configuration-aggregator-go-sdk/tree/main/configurationaggregatorv1")

--- a/ibm/service/configurationaggregator/data_source_ibm_config_aggregator_configurations.go
+++ b/ibm/service/configurationaggregator/data_source_ibm_config_aggregator_configurations.go
@@ -1,0 +1,281 @@
+// Copyright IBM Corp. 2024 All Rights Reserved.
+// Licensed under the Mozilla Public License v2.0
+
+/*
+ * IBM OpenAPI Terraform Generator Version: 3.92.0-af5c89a5-20240617-153232
+ */
+
+package configurationaggregator
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"time"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/IBM/configuration-aggregator-go-sdk/configurationaggregatorv1"
+
+	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/conns"
+	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/flex"
+)
+
+func DataSourceIbmConfigAggregatorConfigurations() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceIbmConfigAggregatorConfigurationsRead,
+
+		Schema: map[string]*schema.Schema{
+			"config_type": &schema.Schema{
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "The type of resource configuration that are to be retrieved.",
+			},
+			"service_name": &schema.Schema{
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "The name of the IBM Cloud service for which resources are to be retrieved.",
+			},
+			"resource_group_id": &schema.Schema{
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "The resource group id of the resources.",
+			},
+			"location": &schema.Schema{
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "The location or region in which the resources are created.",
+			},
+			"resource_crn": &schema.Schema{
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "The crn of the resource.",
+			},
+			"prev": &schema.Schema{
+				Type:        schema.TypeList,
+				Computed:    true,
+				Description: "The reference to the previous page of entries.",
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"href": &schema.Schema{
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "The reference to the previous page of entries.",
+						},
+						"start": &schema.Schema{
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "the start string for the query to view the page.",
+						},
+					},
+				},
+			},
+			"configs": &schema.Schema{
+				Type:        schema.TypeList,
+				Computed:    true,
+				Description: "Array of resource configurations.",
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"about": &schema.Schema{
+							Type:        schema.TypeList,
+							Computed:    true,
+							Description: "The basic metadata fetched from the query API.",
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"account_id": &schema.Schema{
+										Type:        schema.TypeString,
+										Computed:    true,
+										Description: "The account ID in which the resource exists.",
+									},
+									"config_type": &schema.Schema{
+										Type:        schema.TypeString,
+										Computed:    true,
+										Description: "The type of configuration of the retrieved resource.",
+									},
+									"resource_crn": &schema.Schema{
+										Type:        schema.TypeString,
+										Computed:    true,
+										Description: "The unique CRN of the IBM Cloud resource.",
+									},
+									"resource_group_id": &schema.Schema{
+										Type:        schema.TypeString,
+										Computed:    true,
+										Description: "The account ID.",
+									},
+									"service_name": &schema.Schema{
+										Type:        schema.TypeString,
+										Computed:    true,
+										Description: "The name of the service to which the resources belongs.",
+									},
+									"resource_name": &schema.Schema{
+										Type:        schema.TypeString,
+										Computed:    true,
+										Description: "User defined name of the resource.",
+									},
+									"last_config_refresh_time": &schema.Schema{
+										Type:        schema.TypeString,
+										Computed:    true,
+										Description: "Date/time stamp identifying when the information was last collected. Must be in the RFC 3339 format.",
+									},
+									"location": &schema.Schema{
+										Type:        schema.TypeString,
+										Computed:    true,
+										Description: "Location of the resource specified.",
+									},
+									"tags": &schema.Schema{
+										Type:        schema.TypeList,
+										Computed:    true,
+										Description: "Tags associated with the resource.",
+										Elem: &schema.Resource{
+											Schema: map[string]*schema.Schema{
+												"tag": &schema.Schema{
+													Type:        schema.TypeString,
+													Computed:    true,
+													Description: "The name of the tag.",
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+						"config": &schema.Schema{
+							Type:        schema.TypeList,
+							Computed:    true,
+							Description: "The configuration of the resource.",
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func dataSourceIbmConfigAggregatorConfigurationsRead(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	configurationAggregatorClient, err := meta.(conns.ClientSession).ConfigurationAggregatorV1()
+	if err != nil {
+		tfErr := flex.TerraformErrorf(err, err.Error(), "(Data) ibm_config_aggregator_configurations", "read")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
+	}
+
+	listConfigsOptions := &configurationaggregatorv1.ListConfigsOptions{}
+
+	if _, ok := d.GetOk("config_type"); ok {
+		listConfigsOptions.SetConfigType(d.Get("config_type").(string))
+	}
+	if _, ok := d.GetOk("service_name"); ok {
+		listConfigsOptions.SetServiceName(d.Get("service_name").(string))
+	}
+	if _, ok := d.GetOk("resource_group_id"); ok {
+		listConfigsOptions.SetResourceGroupID(d.Get("resource_group_id").(string))
+	}
+	if _, ok := d.GetOk("location"); ok {
+		listConfigsOptions.SetLocation(d.Get("location").(string))
+	}
+	if _, ok := d.GetOk("resource_crn"); ok {
+		listConfigsOptions.SetResourceCrn(d.Get("resource_crn").(string))
+	}
+
+	var pager *configurationaggregatorv1.ConfigsPager
+	pager, err = configurationAggregatorClient.NewConfigsPager(listConfigsOptions)
+	if err != nil {
+		tfErr := flex.TerraformErrorf(err, err.Error(), "(Data) ibm_config_aggregator_configurations", "read")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
+	}
+
+	allItems, err := pager.GetAll()
+	if err != nil {
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("ConfigsPager.GetAll() failed %s", err), "(Data) ibm_config_aggregator_configurations", "read")
+		log.Printf("[DEBUG] %s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
+	}
+
+	d.SetId(dataSourceIbmConfigAggregatorConfigurationsID(d))
+
+	mapSlice := []map[string]interface{}{}
+	for _, modelItem := range allItems {
+		modelMap, err := DataSourceIbmConfigAggregatorConfigurationsConfigToMap(&modelItem)
+		if err != nil {
+			tfErr := flex.TerraformErrorf(err, err.Error(), "(Data) ibm_config_aggregator_configurations", "read")
+			return tfErr.GetDiag()
+		}
+		mapSlice = append(mapSlice, modelMap)
+	}
+
+	if err = d.Set("configs", mapSlice); err != nil {
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("Error setting configs %s", err), "(Data) ibm_config_aggregator_configurations", "read")
+		return tfErr.GetDiag()
+	}
+
+	return nil
+}
+
+// dataSourceIbmConfigAggregatorConfigurationsID returns a reasonable ID for the list.
+func dataSourceIbmConfigAggregatorConfigurationsID(d *schema.ResourceData) string {
+	return time.Now().UTC().String()
+}
+
+func DataSourceIbmConfigAggregatorConfigurationsPaginatedPreviousToMap(model *configurationaggregatorv1.PaginatedPrevious) (map[string]interface{}, error) {
+	modelMap := make(map[string]interface{})
+	if model.Href != nil {
+		modelMap["href"] = *model.Href
+	}
+	if model.Start != nil {
+		modelMap["start"] = *model.Start
+	}
+	return modelMap, nil
+}
+
+func DataSourceIbmConfigAggregatorConfigurationsConfigToMap(model *configurationaggregatorv1.Config) (map[string]interface{}, error) {
+	modelMap := make(map[string]interface{})
+	aboutMap, err := DataSourceIbmConfigAggregatorConfigurationsAboutToMap(model.About)
+	if err != nil {
+		return modelMap, err
+	}
+	modelMap["about"] = []map[string]interface{}{aboutMap}
+	configMap, err := DataSourceIbmConfigAggregatorConfigurationsConfigurationToMap(model.Config)
+	if err != nil {
+		return modelMap, err
+	}
+	modelMap["config"] = []map[string]interface{}{configMap}
+	return modelMap, nil
+}
+
+func DataSourceIbmConfigAggregatorConfigurationsAboutToMap(model *configurationaggregatorv1.About) (map[string]interface{}, error) {
+	modelMap := make(map[string]interface{})
+	modelMap["account_id"] = *model.AccountID
+	modelMap["config_type"] = *model.ConfigType
+	modelMap["resource_crn"] = *model.ResourceCrn
+	modelMap["resource_group_id"] = *model.ResourceGroupID
+	modelMap["service_name"] = *model.ServiceName
+	modelMap["resource_name"] = *model.ResourceName
+	modelMap["last_config_refresh_time"] = model.LastConfigRefreshTime.String()
+	modelMap["location"] = *model.Location
+	if model.Tags != nil {
+		tagsMap, err := DataSourceIbmConfigAggregatorConfigurationsTagsToMap(model.Tags)
+		if err != nil {
+			return modelMap, err
+		}
+		modelMap["tags"] = []map[string]interface{}{tagsMap}
+	}
+	return modelMap, nil
+}
+
+func DataSourceIbmConfigAggregatorConfigurationsTagsToMap(model *configurationaggregatorv1.Tags) (map[string]interface{}, error) {
+	modelMap := make(map[string]interface{})
+	if model.Tag != nil {
+		modelMap["tag"] = *model.Tag
+	}
+	return modelMap, nil
+}
+
+func DataSourceIbmConfigAggregatorConfigurationsConfigurationToMap(model *configurationaggregatorv1.Configuration) (map[string]interface{}, error) {
+	modelMap := make(map[string]interface{})
+	return modelMap, nil
+}

--- a/ibm/service/configurationaggregator/data_source_ibm_config_aggregator_configurations.go
+++ b/ibm/service/configurationaggregator/data_source_ibm_config_aggregator_configurations.go
@@ -26,11 +26,6 @@ func DataSourceIbmConfigAggregatorConfigurations() *schema.Resource {
 		ReadContext: dataSourceIbmConfigAggregatorConfigurationsRead,
 
 		Schema: map[string]*schema.Schema{
-			"account_id": &schema.Schema{
-				Type:        schema.TypeString,
-				Optional:    true,
-				Description: "The account id of the resource.",
-			},
 			"config_type": &schema.Schema{
 				Type:        schema.TypeString,
 				Optional:    true,
@@ -45,11 +40,6 @@ func DataSourceIbmConfigAggregatorConfigurations() *schema.Resource {
 				Type:        schema.TypeString,
 				Optional:    true,
 				Description: "The resource group id of the resources.",
-			},
-			"resource_name": &schema.Schema{
-				Type:        schema.TypeString,
-				Optional:    true,
-				Description: "The name of the resource.",
 			},
 			"location": &schema.Schema{
 				Type:        schema.TypeString,
@@ -172,16 +162,17 @@ func dataSourceIbmConfigAggregatorConfigurationsRead(context context.Context, d 
 		return tfErr.GetDiag()
 	}
 
+	region := getConfigurationInstanceRegion(configurationAggregatorClient, d)
+	instanceId := d.Get("instance_id").(string)
+	log.Printf("Fetching config for instance_id: %s", instanceId)
+	configurationAggregatorClient = getClientWithConfigurationInstanceEndpoint(configurationAggregatorClient, instanceId, region)
+	fmt.Println("Logging endpoint from datasource")
+	fmt.Println(configurationAggregatorClient.GetServiceURL())
+
 	listConfigsOptions := &configurationaggregatorv1.ListConfigsOptions{}
 
 	if _, ok := d.GetOk("config_type"); ok {
 		listConfigsOptions.SetConfigType(d.Get("config_type").(string))
-	}
-	if _, ok := d.GetOk("account_id"); ok {
-		listConfigsOptions.SetConfigType(d.Get("account_id").(string))
-	}
-	if _, ok := d.GetOk("resource_name"); ok {
-		listConfigsOptions.SetConfigType(d.Get("resource_name").(string))
 	}
 	if _, ok := d.GetOk("service_name"); ok {
 		listConfigsOptions.SetServiceName(d.Get("service_name").(string))

--- a/ibm/service/configurationaggregator/data_source_ibm_config_aggregator_configurations.go
+++ b/ibm/service/configurationaggregator/data_source_ibm_config_aggregator_configurations.go
@@ -16,10 +16,9 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 
-	"github.com/IBM/configuration-aggregator-go-sdk/configurationaggregatorv1"
-
 	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/conns"
 	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/flex"
+	"github.com/IBM/configuration-aggregator-go-sdk/configurationaggregatorv1"
 )
 
 func DataSourceIbmConfigAggregatorConfigurations() *schema.Resource {
@@ -27,6 +26,11 @@ func DataSourceIbmConfigAggregatorConfigurations() *schema.Resource {
 		ReadContext: dataSourceIbmConfigAggregatorConfigurationsRead,
 
 		Schema: map[string]*schema.Schema{
+			"account_id": &schema.Schema{
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "The account id of the resource.",
+			},
 			"config_type": &schema.Schema{
 				Type:        schema.TypeString,
 				Optional:    true,
@@ -41,6 +45,11 @@ func DataSourceIbmConfigAggregatorConfigurations() *schema.Resource {
 				Type:        schema.TypeString,
 				Optional:    true,
 				Description: "The resource group id of the resources.",
+			},
+			"resource_name": &schema.Schema{
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "The name of the resource.",
 			},
 			"location": &schema.Schema{
 				Type:        schema.TypeString,
@@ -167,6 +176,12 @@ func dataSourceIbmConfigAggregatorConfigurationsRead(context context.Context, d 
 
 	if _, ok := d.GetOk("config_type"); ok {
 		listConfigsOptions.SetConfigType(d.Get("config_type").(string))
+	}
+	if _, ok := d.GetOk("account_id"); ok {
+		listConfigsOptions.SetConfigType(d.Get("account_id").(string))
+	}
+	if _, ok := d.GetOk("resource_name"); ok {
+		listConfigsOptions.SetConfigType(d.Get("resource_name").(string))
 	}
 	if _, ok := d.GetOk("service_name"); ok {
 		listConfigsOptions.SetServiceName(d.Get("service_name").(string))

--- a/ibm/service/configurationaggregator/data_source_ibm_config_aggregator_configurations_test.go
+++ b/ibm/service/configurationaggregator/data_source_ibm_config_aggregator_configurations_test.go
@@ -11,53 +11,45 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/IBM/configuration-aggregator-go-sdk/configurationaggregatorv1"
-
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 
 	acc "github.com/IBM-Cloud/terraform-provider-ibm/ibm/acctest"
-	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/configurationaggregator"
-	. "github.com/IBM-Cloud/terraform-provider-ibm/ibm/unittest"
-	"github.com/stretchr/testify/assert"
 )
 
 func TestAccIbmConfigAggregatorConfigurationsDataSourceBasic(t *testing.T) {
+	var configType = "your-config-type"
+	var location = "your-location"
+	var resourceCrn = "your-resource-crn"
+	var resourceGroupID = "your-resource-group-id"
+	var serviceName = "your-service-name"
+
 	resource.Test(t, resource.TestCase{
 		PreCheck:  func() { acc.TestAccPreCheck(t) },
 		Providers: acc.TestAccProviders,
 		Steps: []resource.TestStep{
-			resource.TestStep{
-				Config: testAccCheckIbmConfigAggregatorConfigurationsDataSourceConfigBasic(),
+			{
+				Config: testAccCheckIbmConfigAggregatorConfigurationsDataSourceConfigBasic(configType, location, resourceCrn, resourceGroupID, serviceName),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrSet("data.ibm_config_aggregator_configurations.config_aggregator_configurations_instance", "id"),
+					resource.TestCheckResourceAttr("data.ibm_config_aggregator_configurations.config_aggregator_configurations_instance", "config_type", configType),
+					resource.TestCheckResourceAttr("data.ibm_config_aggregator_configurations.config_aggregator_configurations_instance", "location", location),
+					resource.TestCheckResourceAttr("data.ibm_config_aggregator_configurations.config_aggregator_configurations_instance", "resource_crn", resourceCrn),
+					resource.TestCheckResourceAttr("data.ibm_config_aggregator_configurations.config_aggregator_configurations_instance", "resource_group_id", resourceGroupID),
+					resource.TestCheckResourceAttr("data.ibm_config_aggregator_configurations.config_aggregator_configurations_instance", "service_name", serviceName),
 				),
 			},
 		},
 	})
 }
 
-func testAccCheckIbmConfigAggregatorConfigurationsDataSourceConfigBasic() string {
+func testAccCheckIbmConfigAggregatorConfigurationsDataSourceConfigBasic(configType, location, resourceCrn, resourceGroupID, serviceName string) string {
 	return fmt.Sprintf(`
-		 data "ibm_config_aggregator_configurations" "config_aggregator_configurations_instance" {
-			 config_type = "config_type"
-			 service_name = "service_name"
-			 resource_group_id = "resource_group_id"
-			 location = "location"
-			 resource_crn = "resource_crn"
-		 }
-	 `)
-}
-
-func TestDataSourceIbmConfigAggregatorConfigurationsConfigurationToMap(t *testing.T) {
-	checkResult := func(result map[string]interface{}) {
-		model := make(map[string]interface{})
-
-		assert.Equal(t, result, model)
-	}
-
-	model := new(configurationaggregatorv1.Configuration)
-
-	result, err := configurationaggregator.DataSourceIbmConfigAggregatorConfigurationsConfigurationToMap(model)
-	assert.Nil(t, err)
-	checkResult(result)
+		data "ibm_config_aggregator_configurations" "config_aggregator_configurations_instance" {
+			config_type       = "%s"
+			location          = "%s"
+			resource_crn      = "%s"
+			resource_group_id = "%s"
+			service_name      = "%s"
+		}
+	`, configType, location, resourceCrn, resourceGroupID, serviceName)
 }

--- a/ibm/service/configurationaggregator/data_source_ibm_config_aggregator_configurations_test.go
+++ b/ibm/service/configurationaggregator/data_source_ibm_config_aggregator_configurations_test.go
@@ -17,6 +17,7 @@ import (
 )
 
 func TestAccIbmConfigAggregatorConfigurationsDataSourceBasic(t *testing.T) {
+	instanceID := "instance_id"
 	var configType = "your-config-type"
 	var location = "your-location"
 	var resourceCrn = "your-resource-crn"
@@ -28,7 +29,7 @@ func TestAccIbmConfigAggregatorConfigurationsDataSourceBasic(t *testing.T) {
 		Providers: acc.TestAccProviders,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckIbmConfigAggregatorConfigurationsDataSourceConfigBasic(configType, location, resourceCrn, resourceGroupID, serviceName),
+				Config: testAccCheckIbmConfigAggregatorConfigurationsDataSourceConfigBasic(instanceID, configType, location, resourceCrn, resourceGroupID, serviceName),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrSet("data.ibm_config_aggregator_configurations.config_aggregator_configurations_instance", "id"),
 					resource.TestCheckResourceAttr("data.ibm_config_aggregator_configurations.config_aggregator_configurations_instance", "config_type", configType),
@@ -42,14 +43,15 @@ func TestAccIbmConfigAggregatorConfigurationsDataSourceBasic(t *testing.T) {
 	})
 }
 
-func testAccCheckIbmConfigAggregatorConfigurationsDataSourceConfigBasic(configType, location, resourceCrn, resourceGroupID, serviceName string) string {
+func testAccCheckIbmConfigAggregatorConfigurationsDataSourceConfigBasic(instanceID, configType, location, resourceCrn, resourceGroupID, serviceName string) string {
 	return fmt.Sprintf(`
 		data "ibm_config_aggregator_configurations" "config_aggregator_configurations_instance" {
+			instance_id ="%s"
 			config_type       = "%s"
 			location          = "%s"
 			resource_crn      = "%s"
 			resource_group_id = "%s"
 			service_name      = "%s"
 		}
-	`, configType, location, resourceCrn, resourceGroupID, serviceName)
+	`, instanceID, configType, location, resourceCrn, resourceGroupID, serviceName)
 }

--- a/ibm/service/configurationaggregator/data_source_ibm_config_aggregator_configurations_test.go
+++ b/ibm/service/configurationaggregator/data_source_ibm_config_aggregator_configurations_test.go
@@ -1,0 +1,63 @@
+// Copyright IBM Corp. 2024 All Rights Reserved.
+// Licensed under the Mozilla Public License v2.0
+
+/*
+ * IBM OpenAPI Terraform Generator Version: 3.92.0-af5c89a5-20240617-153232
+ */
+
+package configurationaggregator_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/IBM/configuration-aggregator-go-sdk/configurationaggregatorv1"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	acc "github.com/IBM-Cloud/terraform-provider-ibm/ibm/acctest"
+	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/configurationaggregator"
+	. "github.com/IBM-Cloud/terraform-provider-ibm/ibm/unittest"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestAccIbmConfigAggregatorConfigurationsDataSourceBasic(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { acc.TestAccPreCheck(t) },
+		Providers: acc.TestAccProviders,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccCheckIbmConfigAggregatorConfigurationsDataSourceConfigBasic(),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet("data.ibm_config_aggregator_configurations.config_aggregator_configurations_instance", "id"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckIbmConfigAggregatorConfigurationsDataSourceConfigBasic() string {
+	return fmt.Sprintf(`
+		 data "ibm_config_aggregator_configurations" "config_aggregator_configurations_instance" {
+			 config_type = "config_type"
+			 service_name = "service_name"
+			 resource_group_id = "resource_group_id"
+			 location = "location"
+			 resource_crn = "resource_crn"
+		 }
+	 `)
+}
+
+func TestDataSourceIbmConfigAggregatorConfigurationsConfigurationToMap(t *testing.T) {
+	checkResult := func(result map[string]interface{}) {
+		model := make(map[string]interface{})
+
+		assert.Equal(t, result, model)
+	}
+
+	model := new(configurationaggregatorv1.Configuration)
+
+	result, err := configurationaggregator.DataSourceIbmConfigAggregatorConfigurationsConfigurationToMap(model)
+	assert.Nil(t, err)
+	checkResult(result)
+}

--- a/ibm/service/configurationaggregator/data_source_ibm_config_aggregator_resource_collection_status.go
+++ b/ibm/service/configurationaggregator/data_source_ibm_config_aggregator_resource_collection_status.go
@@ -42,6 +42,9 @@ func DataSourceIbmConfigAggregatorResourceCollectionStatus() *schema.Resource {
 
 func dataSourceIbmConfigAggregatorResourceCollectionStatusRead(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	configurationAggregatorClient, err := meta.(conns.ClientSession).ConfigurationAggregatorV1()
+	region := getConfigurationInstanceRegion(configurationAggregatorClient, d)
+	instanceId := d.Get("instance_id").(string)
+	configurationAggregatorClient = getClientWithConfigurationInstanceEndpoint(configurationAggregatorClient, instanceId, region)
 	if err != nil {
 		// Error is coming from SDK client, so it doesn't need to be discriminated.
 		tfErr := flex.TerraformErrorf(err, err.Error(), "(Data) ibm_config_aggregator_resource_collection_status", "read")

--- a/ibm/service/configurationaggregator/data_source_ibm_config_aggregator_resource_collection_status.go
+++ b/ibm/service/configurationaggregator/data_source_ibm_config_aggregator_resource_collection_status.go
@@ -1,0 +1,78 @@
+// Copyright IBM Corp. 2024 All Rights Reserved.
+// Licensed under the Mozilla Public License v2.0
+
+/*
+ * IBM OpenAPI Terraform Generator Version: 3.92.0-af5c89a5-20240617-153232
+ */
+
+package configurationaggregator
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"time"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/IBM/configuration-aggregator-go-sdk/configurationaggregatorv1"
+
+	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/conns"
+	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/flex"
+)
+
+func DataSourceIbmConfigAggregatorResourceCollectionStatus() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceIbmConfigAggregatorResourceCollectionStatusRead,
+
+		Schema: map[string]*schema.Schema{
+			"last_config_refresh_time": &schema.Schema{
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The timestamp at which the configuration was last refreshed.",
+			},
+			"status": &schema.Schema{
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "Status of the resource collection.",
+			},
+		},
+	}
+}
+
+func dataSourceIbmConfigAggregatorResourceCollectionStatusRead(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	configurationAggregatorClient, err := meta.(conns.ClientSession).ConfigurationAggregatorV1()
+	if err != nil {
+		// Error is coming from SDK client, so it doesn't need to be discriminated.
+		tfErr := flex.TerraformErrorf(err, err.Error(), "(Data) ibm_config_aggregator_resource_collection_status", "read")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
+	}
+
+	getResourceCollectionStatusOptions := &configurationaggregatorv1.GetResourceCollectionStatusOptions{}
+
+	statusResponse, _, err := configurationAggregatorClient.GetResourceCollectionStatusWithContext(context, getResourceCollectionStatusOptions)
+	if err != nil {
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("GetResourceCollectionStatusWithContext failed: %s", err.Error()), "(Data) ibm_config_aggregator_resource_collection_status", "read")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
+	}
+
+	d.SetId(dataSourceIbmConfigAggregatorResourceCollectionStatusID(d))
+
+	if err = d.Set("last_config_refresh_time", flex.DateTimeToString(statusResponse.LastConfigRefreshTime)); err != nil {
+		return flex.DiscriminatedTerraformErrorf(err, fmt.Sprintf("Error setting last_config_refresh_time: %s", err), "(Data) ibm_config_aggregator_resource_collection_status", "read", "set-last_config_refresh_time").GetDiag()
+	}
+
+	if err = d.Set("status", statusResponse.Status); err != nil {
+		return flex.DiscriminatedTerraformErrorf(err, fmt.Sprintf("Error setting status: %s", err), "(Data) ibm_config_aggregator_resource_collection_status", "read", "set-status").GetDiag()
+	}
+
+	return nil
+}
+
+// dataSourceIbmConfigAggregatorResourceCollectionStatusID returns a reasonable ID for the list.
+func dataSourceIbmConfigAggregatorResourceCollectionStatusID(d *schema.ResourceData) string {
+	return time.Now().UTC().String()
+}

--- a/ibm/service/configurationaggregator/data_source_ibm_config_aggregator_resource_collection_status.go
+++ b/ibm/service/configurationaggregator/data_source_ibm_config_aggregator_resource_collection_status.go
@@ -16,10 +16,9 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 
-	"github.com/IBM/configuration-aggregator-go-sdk/configurationaggregatorv1"
-
 	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/conns"
 	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/flex"
+	"github.com/IBM/configuration-aggregator-go-sdk/configurationaggregatorv1"
 )
 
 func DataSourceIbmConfigAggregatorResourceCollectionStatus() *schema.Resource {

--- a/ibm/service/configurationaggregator/data_source_ibm_config_aggregator_resource_collection_status_test.go
+++ b/ibm/service/configurationaggregator/data_source_ibm_config_aggregator_resource_collection_status_test.go
@@ -17,12 +17,13 @@ import (
 )
 
 func TestAccIbmConfigAggregatorResourceCollectionStatusDataSourceBasic(t *testing.T) {
+	instanceID := "instance_id"
 	resource.Test(t, resource.TestCase{
 		PreCheck:  func() { acc.TestAccPreCheck(t) },
 		Providers: acc.TestAccProviders,
 		Steps: []resource.TestStep{
 			resource.TestStep{
-				Config: testAccCheckIbmConfigAggregatorResourceCollectionStatusDataSourceConfigBasic(),
+				Config: testAccCheckIbmConfigAggregatorResourceCollectionStatusDataSourceConfigBasic(instanceID),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrSet("data.ibm_config_aggregator_resource_collection_status.config_aggregator_resource_collection_status_instance", "id"),
 				),
@@ -31,9 +32,10 @@ func TestAccIbmConfigAggregatorResourceCollectionStatusDataSourceBasic(t *testin
 	})
 }
 
-func testAccCheckIbmConfigAggregatorResourceCollectionStatusDataSourceConfigBasic() string {
+func testAccCheckIbmConfigAggregatorResourceCollectionStatusDataSourceConfigBasic(instanceID string) string {
 	return fmt.Sprintf(`
 		data "ibm_config_aggregator_resource_collection_status" "config_aggregator_resource_collection_status_instance" {
+			instance_id="%s"
 		}
-	`)
+	`, instanceID)
 }

--- a/ibm/service/configurationaggregator/data_source_ibm_config_aggregator_resource_collection_status_test.go
+++ b/ibm/service/configurationaggregator/data_source_ibm_config_aggregator_resource_collection_status_test.go
@@ -1,0 +1,39 @@
+// Copyright IBM Corp. 2024 All Rights Reserved.
+// Licensed under the Mozilla Public License v2.0
+
+/*
+ * IBM OpenAPI Terraform Generator Version: 3.92.0-af5c89a5-20240617-153232
+ */
+
+package configurationaggregator_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	acc "github.com/IBM-Cloud/terraform-provider-ibm/ibm/acctest"
+)
+
+func TestAccIbmConfigAggregatorResourceCollectionStatusDataSourceBasic(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { acc.TestAccPreCheck(t) },
+		Providers: acc.TestAccProviders,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccCheckIbmConfigAggregatorResourceCollectionStatusDataSourceConfigBasic(),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet("data.ibm_config_aggregator_resource_collection_status.config_aggregator_resource_collection_status_instance", "id"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckIbmConfigAggregatorResourceCollectionStatusDataSourceConfigBasic() string {
+	return fmt.Sprintf(`
+		 data "ibm_config_aggregator_resource_collection_status" "config_aggregator_resource_collection_status_instance" {
+		 }
+	 `)
+}

--- a/ibm/service/configurationaggregator/data_source_ibm_config_aggregator_resource_collection_status_test.go
+++ b/ibm/service/configurationaggregator/data_source_ibm_config_aggregator_resource_collection_status_test.go
@@ -33,7 +33,7 @@ func TestAccIbmConfigAggregatorResourceCollectionStatusDataSourceBasic(t *testin
 
 func testAccCheckIbmConfigAggregatorResourceCollectionStatusDataSourceConfigBasic() string {
 	return fmt.Sprintf(`
-		 data "ibm_config_aggregator_resource_collection_status" "config_aggregator_resource_collection_status_instance" {
-		 }
-	 `)
+		data "ibm_config_aggregator_resource_collection_status" "config_aggregator_resource_collection_status_instance" {
+		}
+	`)
 }

--- a/ibm/service/configurationaggregator/data_source_ibm_config_aggregator_settings.go
+++ b/ibm/service/configurationaggregator/data_source_ibm_config_aggregator_settings.go
@@ -1,0 +1,176 @@
+// Copyright IBM Corp. 2024 All Rights Reserved.
+// Licensed under the Mozilla Public License v2.0
+
+/*
+ * IBM OpenAPI Terraform Generator Version: 3.92.0-af5c89a5-20240617-153232
+ */
+
+package configurationaggregator
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"time"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/IBM/configuration-aggregator-go-sdk/configurationaggregatorv1"
+
+	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/conns"
+	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/flex"
+)
+
+func DataSourceIbmConfigAggregatorSettings() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceIbmConfigAggregatorSettingsRead,
+
+		Schema: map[string]*schema.Schema{
+			"resource_collection_enabled": &schema.Schema{
+				Type:        schema.TypeBool,
+				Computed:    true,
+				Description: "The field to check if the resource collection is enabled.",
+			},
+			"trusted_profile_id": &schema.Schema{
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The trusted profile ID that provides access to App Configuration instance to retrieve resource metadata.",
+			},
+			"last_updated": &schema.Schema{
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The last time the settings was last updated.",
+			},
+			"regions": &schema.Schema{
+				Type:        schema.TypeList,
+				Computed:    true,
+				Description: "Regions for which the resource collection is enabled.",
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
+			},
+			"additional_scope": &schema.Schema{
+				Type:        schema.TypeList,
+				Computed:    true,
+				Description: "The additional scope that enables resource collection for Enterprise acccounts.",
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"type": &schema.Schema{
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "The type of scope. Currently allowed value is Enterprise.",
+						},
+						"enterprise_id": &schema.Schema{
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "The Enterprise ID.",
+						},
+						"profile_template": &schema.Schema{
+							Type:        schema.TypeList,
+							Computed:    true,
+							Description: "The Profile Template details applied on the enterprise account.",
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"id": &schema.Schema{
+										Type:        schema.TypeString,
+										Computed:    true,
+										Description: "The Profile Template ID created in the enterprise account that provides access to App Configuration instance for resource collection.",
+									},
+									"trusted_profile_id": &schema.Schema{
+										Type:        schema.TypeString,
+										Computed:    true,
+										Description: "The trusted profile ID that provides access to App Configuration instance to retrieve template information.",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func dataSourceIbmConfigAggregatorSettingsRead(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	configurationAggregatorClient, err := meta.(conns.ClientSession).ConfigurationAggregatorV1()
+	if err != nil {
+		// Error is coming from SDK client, so it doesn't need to be discriminated.
+		tfErr := flex.TerraformErrorf(err, err.Error(), "(Data) ibm_config_aggregator_settings", "read")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
+	}
+
+	getSettingsOptions := &configurationaggregatorv1.GetSettingsOptions{}
+
+	settingsResponse, _, err := configurationAggregatorClient.GetSettingsWithContext(context, getSettingsOptions)
+	if err != nil {
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("GetSettingsWithContext failed: %s", err.Error()), "(Data) ibm_config_aggregator_settings", "read")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
+	}
+
+	d.SetId(dataSourceIbmConfigAggregatorSettingsID(d))
+
+	if err = d.Set("resource_collection_enabled", settingsResponse.ResourceCollectionEnabled); err != nil {
+		return flex.DiscriminatedTerraformErrorf(err, fmt.Sprintf("Error setting resource_collection_enabled: %s", err), "(Data) ibm_config_aggregator_settings", "read", "set-resource_collection_enabled").GetDiag()
+	}
+
+	if err = d.Set("trusted_profile_id", settingsResponse.TrustedProfileID); err != nil {
+		return flex.DiscriminatedTerraformErrorf(err, fmt.Sprintf("Error setting trusted_profile_id: %s", err), "(Data) ibm_config_aggregator_settings", "read", "set-trusted_profile_id").GetDiag()
+	}
+
+	if err = d.Set("last_updated", flex.DateTimeToString(settingsResponse.LastUpdated)); err != nil {
+		return flex.DiscriminatedTerraformErrorf(err, fmt.Sprintf("Error setting last_updated: %s", err), "(Data) ibm_config_aggregator_settings", "read", "set-last_updated").GetDiag()
+	}
+
+	additionalScope := []map[string]interface{}{}
+	if settingsResponse.AdditionalScope != nil {
+		for _, modelItem := range settingsResponse.AdditionalScope {
+			modelMap, err := DataSourceIbmConfigAggregatorSettingsAdditionalScopeToMap(&modelItem)
+			if err != nil {
+				return flex.DiscriminatedTerraformErrorf(err, err.Error(), "(Data) ibm_config_aggregator_settings", "read", "additional_scope-to-map").GetDiag()
+			}
+			additionalScope = append(additionalScope, modelMap)
+		}
+	}
+	if err = d.Set("additional_scope", additionalScope); err != nil {
+		return flex.DiscriminatedTerraformErrorf(err, fmt.Sprintf("Error setting additional_scope: %s", err), "(Data) ibm_config_aggregator_settings", "read", "set-additional_scope").GetDiag()
+	}
+
+	return nil
+}
+
+// dataSourceIbmConfigAggregatorSettingsID returns a reasonable ID for the list.
+func dataSourceIbmConfigAggregatorSettingsID(d *schema.ResourceData) string {
+	return time.Now().UTC().String()
+}
+
+func DataSourceIbmConfigAggregatorSettingsAdditionalScopeToMap(model *configurationaggregatorv1.AdditionalScope) (map[string]interface{}, error) {
+	modelMap := make(map[string]interface{})
+	if model.Type != nil {
+		modelMap["type"] = *model.Type
+	}
+	if model.EnterpriseID != nil {
+		modelMap["enterprise_id"] = *model.EnterpriseID
+	}
+	if model.ProfileTemplate != nil {
+		profileTemplateMap, err := DataSourceIbmConfigAggregatorSettingsProfileTemplateToMap(model.ProfileTemplate)
+		if err != nil {
+			return modelMap, err
+		}
+		modelMap["profile_template"] = []map[string]interface{}{profileTemplateMap}
+	}
+	return modelMap, nil
+}
+
+func DataSourceIbmConfigAggregatorSettingsProfileTemplateToMap(model *configurationaggregatorv1.ProfileTemplate) (map[string]interface{}, error) {
+	modelMap := make(map[string]interface{})
+	if model.ID != nil {
+		modelMap["id"] = *model.ID
+	}
+	if model.TrustedProfileID != nil {
+		modelMap["trusted_profile_id"] = *model.TrustedProfileID
+	}
+	return modelMap, nil
+}

--- a/ibm/service/configurationaggregator/data_source_ibm_config_aggregator_settings.go
+++ b/ibm/service/configurationaggregator/data_source_ibm_config_aggregator_settings.go
@@ -16,10 +16,9 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 
-	"github.com/IBM/configuration-aggregator-go-sdk/configurationaggregatorv1"
-
 	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/conns"
 	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/flex"
+	"github.com/IBM/configuration-aggregator-go-sdk/configurationaggregatorv1"
 )
 
 func DataSourceIbmConfigAggregatorSettings() *schema.Resource {

--- a/ibm/service/configurationaggregator/data_source_ibm_config_aggregator_settings.go
+++ b/ibm/service/configurationaggregator/data_source_ibm_config_aggregator_settings.go
@@ -93,6 +93,9 @@ func DataSourceIbmConfigAggregatorSettings() *schema.Resource {
 
 func dataSourceIbmConfigAggregatorSettingsRead(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	configurationAggregatorClient, err := meta.(conns.ClientSession).ConfigurationAggregatorV1()
+	region := getConfigurationInstanceRegion(configurationAggregatorClient, d)
+	instanceId := d.Get("instance_id").(string)
+	configurationAggregatorClient = getClientWithConfigurationInstanceEndpoint(configurationAggregatorClient, instanceId, region)
 	if err != nil {
 		// Error is coming from SDK client, so it doesn't need to be discriminated.
 		tfErr := flex.TerraformErrorf(err, err.Error(), "(Data) ibm_config_aggregator_settings", "read")

--- a/ibm/service/configurationaggregator/data_source_ibm_config_aggregator_settings_test.go
+++ b/ibm/service/configurationaggregator/data_source_ibm_config_aggregator_settings_test.go
@@ -1,0 +1,90 @@
+// Copyright IBM Corp. 2024 All Rights Reserved.
+// Licensed under the Mozilla Public License v2.0
+
+/*
+ * IBM OpenAPI Terraform Generator Version: 3.92.0-af5c89a5-20240617-153232
+ */
+
+package configurationaggregator_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/IBM/configuration-aggregator-go-sdk/configurationaggregatorv1"
+
+	acc "github.com/IBM-Cloud/terraform-provider-ibm/ibm/acctest"
+	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/configurationaggregator"
+	"github.com/IBM/go-sdk-core/v5/core"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestAccIbmConfigAggregatorSettingsDataSourceBasic(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { acc.TestAccPreCheck(t) },
+		Providers: acc.TestAccProviders,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccCheckIbmConfigAggregatorSettingsDataSourceConfigBasic(),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet("data.ibm_config_aggregator_settings.config_aggregator_settings_instance", "id"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckIbmConfigAggregatorSettingsDataSourceConfigBasic() string {
+	return fmt.Sprintf(`
+		 data "ibm_config_aggregator_settings" "config_aggregator_settings_instance" {
+		 }
+	 `)
+}
+
+func TestDataSourceIbmConfigAggregatorSettingsAdditionalScopeToMap(t *testing.T) {
+	checkResult := func(result map[string]interface{}) {
+		profileTemplateModel := make(map[string]interface{})
+		profileTemplateModel["id"] = "ProfileTemplate-adb55769-ae22-4c60-aead-bd1f84f93c57"
+		profileTemplateModel["trusted_profile_id"] = "Profile-6bb60124-8fc3-4d18-b63d-0b99560865d3"
+
+		model := make(map[string]interface{})
+		model["type"] = "Enterprise"
+		model["enterprise_id"] = "testString"
+		model["profile_template"] = []map[string]interface{}{profileTemplateModel}
+
+		assert.Equal(t, result, model)
+	}
+
+	profileTemplateModel := new(configurationaggregatorv1.ProfileTemplate)
+	profileTemplateModel.ID = core.StringPtr("ProfileTemplate-adb55769-ae22-4c60-aead-bd1f84f93c57")
+	profileTemplateModel.TrustedProfileID = core.StringPtr("Profile-6bb60124-8fc3-4d18-b63d-0b99560865d3")
+
+	model := new(configurationaggregatorv1.AdditionalScope)
+	model.Type = core.StringPtr("Enterprise")
+	model.EnterpriseID = core.StringPtr("testString")
+	model.ProfileTemplate = profileTemplateModel
+
+	result, err := configurationaggregator.DataSourceIbmConfigAggregatorSettingsAdditionalScopeToMap(model)
+	assert.Nil(t, err)
+	checkResult(result)
+}
+
+func TestDataSourceIbmConfigAggregatorSettingsProfileTemplateToMap(t *testing.T) {
+	checkResult := func(result map[string]interface{}) {
+		model := make(map[string]interface{})
+		model["id"] = "ProfileTemplate-adb55769-ae22-4c60-aead-bd1f84f93c57"
+		model["trusted_profile_id"] = "Profile-6bb60124-8fc3-4d18-b63d-0b99560865d3"
+
+		assert.Equal(t, result, model)
+	}
+
+	model := new(configurationaggregatorv1.ProfileTemplate)
+	model.ID = core.StringPtr("ProfileTemplate-adb55769-ae22-4c60-aead-bd1f84f93c57")
+	model.TrustedProfileID = core.StringPtr("Profile-6bb60124-8fc3-4d18-b63d-0b99560865d3")
+
+	result, err := configurationaggregator.DataSourceIbmConfigAggregatorSettingsProfileTemplateToMap(model)
+	assert.Nil(t, err)
+	checkResult(result)
+}

--- a/ibm/service/configurationaggregator/data_source_ibm_config_aggregator_settings_test.go
+++ b/ibm/service/configurationaggregator/data_source_ibm_config_aggregator_settings_test.go
@@ -13,10 +13,9 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 
-	"github.com/IBM/configuration-aggregator-go-sdk/configurationaggregatorv1"
-
 	acc "github.com/IBM-Cloud/terraform-provider-ibm/ibm/acctest"
 	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/configurationaggregator"
+	"github.com/IBM/configuration-aggregator-go-sdk/configurationaggregatorv1"
 	"github.com/IBM/go-sdk-core/v5/core"
 	"github.com/stretchr/testify/assert"
 )
@@ -38,9 +37,9 @@ func TestAccIbmConfigAggregatorSettingsDataSourceBasic(t *testing.T) {
 
 func testAccCheckIbmConfigAggregatorSettingsDataSourceConfigBasic() string {
 	return fmt.Sprintf(`
-		 data "ibm_config_aggregator_settings" "config_aggregator_settings_instance" {
-		 }
-	 `)
+		data "ibm_config_aggregator_settings" "config_aggregator_settings_instance" {
+		}
+	`)
 }
 
 func TestDataSourceIbmConfigAggregatorSettingsAdditionalScopeToMap(t *testing.T) {

--- a/ibm/service/configurationaggregator/data_source_ibm_config_aggregator_settings_test.go
+++ b/ibm/service/configurationaggregator/data_source_ibm_config_aggregator_settings_test.go
@@ -21,12 +21,13 @@ import (
 )
 
 func TestAccIbmConfigAggregatorSettingsDataSourceBasic(t *testing.T) {
+	instanceID := "instance_id"
 	resource.Test(t, resource.TestCase{
 		PreCheck:  func() { acc.TestAccPreCheck(t) },
 		Providers: acc.TestAccProviders,
 		Steps: []resource.TestStep{
 			resource.TestStep{
-				Config: testAccCheckIbmConfigAggregatorSettingsDataSourceConfigBasic(),
+				Config: testAccCheckIbmConfigAggregatorSettingsDataSourceConfigBasic(instanceID),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrSet("data.ibm_config_aggregator_settings.config_aggregator_settings_instance", "id"),
 				),
@@ -35,11 +36,12 @@ func TestAccIbmConfigAggregatorSettingsDataSourceBasic(t *testing.T) {
 	})
 }
 
-func testAccCheckIbmConfigAggregatorSettingsDataSourceConfigBasic() string {
+func testAccCheckIbmConfigAggregatorSettingsDataSourceConfigBasic(instanceID string) string {
 	return fmt.Sprintf(`
 		data "ibm_config_aggregator_settings" "config_aggregator_settings_instance" {
+		instance_id="%s"
 		}
-	`)
+	`, instanceID)
 }
 
 func TestDataSourceIbmConfigAggregatorSettingsAdditionalScopeToMap(t *testing.T) {

--- a/ibm/service/configurationaggregator/resource_ibm_config_aggregator_settings.go
+++ b/ibm/service/configurationaggregator/resource_ibm_config_aggregator_settings.go
@@ -1,0 +1,234 @@
+// Copyright IBM Corp. 2024 All Rights Reserved.
+// Licensed under the Mozilla Public License v2.0
+
+package configurationaggregator
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	"github.com/IBM/configuration-aggregator-go-sdk/configurationaggregatorv1"
+
+	acc "github.com/IBM-Cloud/terraform-provider-ibm/ibm/acctest"
+	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/conns"
+	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/configurationaggregator"
+	"github.com/IBM/go-sdk-core/v5/core"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestAccIbmConfigAggregatorSettingsBasic(t *testing.T) {
+	var conf configurationaggregatorv1.SettingsResponse
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { acc.TestAccPreCheck(t) },
+		Providers:    acc.TestAccProviders,
+		CheckDestroy: testAccCheckIbmConfigAggregatorSettingsDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccCheckIbmConfigAggregatorSettingsConfigBasic(),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckIbmConfigAggregatorSettingsExists("ibm_config_aggregator_settings.config_aggregator_settings_instance", conf),
+				),
+			},
+		},
+	})
+}
+
+func TestAccIbmConfigAggregatorSettingsAllArgs(t *testing.T) {
+	var conf configurationaggregatorv1.SettingsResponse
+	resourceCollectionEnabled := "false"
+	trustedProfileID := fmt.Sprintf("tf_trusted_profile_id_%d", acctest.RandIntRange(10, 100))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { acc.TestAccPreCheck(t) },
+		Providers:    acc.TestAccProviders,
+		CheckDestroy: testAccCheckIbmConfigAggregatorSettingsDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccCheckIbmConfigAggregatorSettingsConfig(resourceCollectionEnabled, trustedProfileID),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckIbmConfigAggregatorSettingsExists("ibm_config_aggregator_settings.config_aggregator_settings_instance", conf),
+					resource.TestCheckResourceAttr("ibm_config_aggregator_settings.config_aggregator_settings_instance", "resource_collection_enabled", resourceCollectionEnabled),
+					resource.TestCheckResourceAttr("ibm_config_aggregator_settings.config_aggregator_settings_instance", "trusted_profile_id", trustedProfileID),
+				),
+			},
+			resource.TestStep{
+				ResourceName:      "ibm_config_aggregator_settings.config_aggregator_settings",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testAccCheckIbmConfigAggregatorSettingsConfigBasic() string {
+	return fmt.Sprintf(`
+		resource "ibm_config_aggregator_settings" "config_aggregator_settings_instance" {
+		}
+	`)
+}
+
+func testAccCheckIbmConfigAggregatorSettingsConfig(resourceCollectionEnabled string, trustedProfileID string) string {
+	return fmt.Sprintf(`
+
+		resource "ibm_config_aggregator_settings" "config_aggregator_settings_instance" {
+			resource_collection_enabled = %s
+			trusted_profile_id = "%s"
+			regions = "FIXME"
+			additional_scope {
+				type = "Enterprise"
+				enterprise_id = "enterprise_id"
+				profile_template {
+					id = "ProfileTemplate-adb55769-ae22-4c60-aead-bd1f84f93c57"
+					trusted_profile_id = "Profile-6bb60124-8fc3-4d18-b63d-0b99560865d3"
+				}
+			}
+		}
+	`, resourceCollectionEnabled, trustedProfileID)
+}
+
+func testAccCheckIbmConfigAggregatorSettingsExists(n string, obj configurationaggregatorv1.SettingsResponse) resource.TestCheckFunc {
+
+	return func(s *terraform.State) error {
+		_, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+
+		configurationAggregatorClient, err := acc.TestAccProvider.Meta().(conns.ClientSession).ConfigurationAggregatorV1()
+		if err != nil {
+			return err
+		}
+
+		getSettingsOptions := &configurationaggregatorv1.GetSettingsOptions{}
+
+		updateSettings, _, err := configurationAggregatorClient.GetSettings(getSettingsOptions)
+		if err != nil {
+			return err
+		}
+
+		obj = *updateSettings
+		return nil
+	}
+}
+
+func testAccCheckIbmConfigAggregatorSettingsDestroy(s *terraform.State) error {
+	configurationAggregatorClient, err := acc.TestAccProvider.Meta().(conns.ClientSession).ConfigurationAggregatorV1()
+	if err != nil {
+		return err
+	}
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "ibm_config_aggregator_settings" {
+			continue
+		}
+
+		getSettingsOptions := &configurationaggregatorv1.GetSettingsOptions{}
+
+		// Try to find the key
+		_, response, err := configurationAggregatorClient.GetSettings(getSettingsOptions)
+
+		if err == nil {
+			return fmt.Errorf("config_aggregator_settings still exists: %s", rs.Primary.ID)
+		} else if response.StatusCode != 404 {
+			return fmt.Errorf("Error checking for config_aggregator_settings (%s) has been destroyed: %s", rs.Primary.ID, err)
+		}
+	}
+
+	return nil
+}
+
+func TestResourceIbmConfigAggregatorSettingsAdditionalScopeToMap(t *testing.T) {
+	checkResult := func(result map[string]interface{}) {
+		profileTemplateModel := make(map[string]interface{})
+		profileTemplateModel["id"] = "ProfileTemplate-adb55769-ae22-4c60-aead-bd1f84f93c57"
+		profileTemplateModel["trusted_profile_id"] = "Profile-6bb60124-8fc3-4d18-b63d-0b99560865d3"
+
+		model := make(map[string]interface{})
+		model["type"] = "Enterprise"
+		model["enterprise_id"] = "testString"
+		model["profile_template"] = []map[string]interface{}{profileTemplateModel}
+
+		assert.Equal(t, result, model)
+	}
+
+	profileTemplateModel := new(configurationaggregatorv1.ProfileTemplate)
+	profileTemplateModel.ID = core.StringPtr("ProfileTemplate-adb55769-ae22-4c60-aead-bd1f84f93c57")
+	profileTemplateModel.TrustedProfileID = core.StringPtr("Profile-6bb60124-8fc3-4d18-b63d-0b99560865d3")
+
+	model := new(configurationaggregatorv1.AdditionalScope)
+	model.Type = core.StringPtr("Enterprise")
+	model.EnterpriseID = core.StringPtr("testString")
+	model.ProfileTemplate = profileTemplateModel
+
+	result, err := configurationaggregator.ResourceIbmConfigAggregatorSettingsAdditionalScopeToMap(model)
+	assert.Nil(t, err)
+	checkResult(result)
+}
+
+func TestResourceIbmConfigAggregatorSettingsProfileTemplateToMap(t *testing.T) {
+	checkResult := func(result map[string]interface{}) {
+		model := make(map[string]interface{})
+		model["id"] = "ProfileTemplate-adb55769-ae22-4c60-aead-bd1f84f93c57"
+		model["trusted_profile_id"] = "Profile-6bb60124-8fc3-4d18-b63d-0b99560865d3"
+
+		assert.Equal(t, result, model)
+	}
+
+	model := new(configurationaggregatorv1.ProfileTemplate)
+	model.ID = core.StringPtr("ProfileTemplate-adb55769-ae22-4c60-aead-bd1f84f93c57")
+	model.TrustedProfileID = core.StringPtr("Profile-6bb60124-8fc3-4d18-b63d-0b99560865d3")
+
+	result, err := configurationaggregator.ResourceIbmConfigAggregatorSettingsProfileTemplateToMap(model)
+	assert.Nil(t, err)
+	checkResult(result)
+}
+
+func TestResourceIbmConfigAggregatorSettingsMapToAdditionalScope(t *testing.T) {
+	checkResult := func(result *configurationaggregatorv1.AdditionalScope) {
+		profileTemplateModel := new(configurationaggregatorv1.ProfileTemplate)
+		profileTemplateModel.ID = core.StringPtr("ProfileTemplate-adb55769-ae22-4c60-aead-bd1f84f93c57")
+		profileTemplateModel.TrustedProfileID = core.StringPtr("Profile-6bb60124-8fc3-4d18-b63d-0b99560865d3")
+
+		model := new(configurationaggregatorv1.AdditionalScope)
+		model.Type = core.StringPtr("Enterprise")
+		model.EnterpriseID = core.StringPtr("testString")
+		model.ProfileTemplate = profileTemplateModel
+
+		assert.Equal(t, result, model)
+	}
+
+	profileTemplateModel := make(map[string]interface{})
+	profileTemplateModel["id"] = "ProfileTemplate-adb55769-ae22-4c60-aead-bd1f84f93c57"
+	profileTemplateModel["trusted_profile_id"] = "Profile-6bb60124-8fc3-4d18-b63d-0b99560865d3"
+
+	model := make(map[string]interface{})
+	model["type"] = "Enterprise"
+	model["enterprise_id"] = "testString"
+	model["profile_template"] = []interface{}{profileTemplateModel}
+
+	result, err := configurationaggregator.ResourceIbmConfigAggregatorSettingsMapToAdditionalScope(model)
+	assert.Nil(t, err)
+	checkResult(result)
+}
+
+func TestResourceIbmConfigAggregatorSettingsMapToProfileTemplate(t *testing.T) {
+	checkResult := func(result *configurationaggregatorv1.ProfileTemplate) {
+		model := new(configurationaggregatorv1.ProfileTemplate)
+		model.ID = core.StringPtr("ProfileTemplate-adb55769-ae22-4c60-aead-bd1f84f93c57")
+		model.TrustedProfileID = core.StringPtr("Profile-6bb60124-8fc3-4d18-b63d-0b99560865d3")
+
+		assert.Equal(t, result, model)
+	}
+
+	model := make(map[string]interface{})
+	model["id"] = "ProfileTemplate-adb55769-ae22-4c60-aead-bd1f84f93c57"
+	model["trusted_profile_id"] = "Profile-6bb60124-8fc3-4d18-b63d-0b99560865d3"
+
+	result, err := configurationaggregator.ResourceIbmConfigAggregatorSettingsMapToProfileTemplate(model)
+	assert.Nil(t, err)
+	checkResult(result)
+}

--- a/ibm/service/configurationaggregator/resource_ibm_config_aggregator_settings.go
+++ b/ibm/service/configurationaggregator/resource_ibm_config_aggregator_settings.go
@@ -1,234 +1,272 @@
 // Copyright IBM Corp. 2024 All Rights Reserved.
 // Licensed under the Mozilla Public License v2.0
 
+/*
+ * IBM OpenAPI Terraform Generator Version: 3.92.0-af5c89a5-20240617-153232
+ */
+
 package configurationaggregator
 
 import (
+	"context"
 	"fmt"
-	"testing"
+	"log"
 
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 
-	"github.com/IBM/configuration-aggregator-go-sdk/configurationaggregatorv1"
-
-	acc "github.com/IBM-Cloud/terraform-provider-ibm/ibm/acctest"
 	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/conns"
-	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/configurationaggregator"
+	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/flex"
+	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/validate"
+	"github.com/IBM/configuration-aggregator-go-sdk/configurationaggregatorv1"
 	"github.com/IBM/go-sdk-core/v5/core"
-	"github.com/stretchr/testify/assert"
 )
 
-func TestAccIbmConfigAggregatorSettingsBasic(t *testing.T) {
-	var conf configurationaggregatorv1.SettingsResponse
+func ResourceIbmConfigAggregatorSettings() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceIbmConfigAggregatorSettingsCreate,
+		ReadContext:   resourceIbmConfigAggregatorSettingsRead,
+		DeleteContext: resourceIbmConfigAggregatorSettingsDelete,
+		Importer:      &schema.ResourceImporter{},
 
-	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { acc.TestAccPreCheck(t) },
-		Providers:    acc.TestAccProviders,
-		CheckDestroy: testAccCheckIbmConfigAggregatorSettingsDestroy,
-		Steps: []resource.TestStep{
-			resource.TestStep{
-				Config: testAccCheckIbmConfigAggregatorSettingsConfigBasic(),
-				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckIbmConfigAggregatorSettingsExists("ibm_config_aggregator_settings.config_aggregator_settings_instance", conf),
-				),
+		Schema: map[string]*schema.Schema{
+			"resource_collection_enabled": &schema.Schema{
+				Type:        schema.TypeBool,
+				Required:    true,
+				ForceNew:    true,
+				Description: "The field denoting if the resource collection is enabled.",
+			},
+			"trusted_profile_id": &schema.Schema{
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: validate.InvokeValidator("ibm_config_aggregator_settings", "trusted_profile_id"),
+				Description:  "The trusted profile id that provides Reader access to the App Configuration instance to collect resource metadata.",
+			},
+			"regions": &schema.Schema{
+				Type:        schema.TypeList,
+				Required:    true,
+				ForceNew:    true,
+				Description: "The list of regions across which the resource collection is enabled.",
+				Elem:        &schema.Schema{Type: schema.TypeString},
+			},
+			"additional_scope": &schema.Schema{
+				Type:        schema.TypeList,
+				Optional:    true,
+				ForceNew:    true,
+				Description: "The additional scope that enables resource collection for Enterprise acccounts.",
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"type": &schema.Schema{
+							Type:        schema.TypeString,
+							Optional:    true,
+							Description: "The type of scope. Currently allowed value is Enterprise.",
+						},
+						"enterprise_id": &schema.Schema{
+							Type:        schema.TypeString,
+							Optional:    true,
+							Description: "The Enterprise ID.",
+						},
+						"profile_template": &schema.Schema{
+							Type:        schema.TypeList,
+							MaxItems:    1,
+							Optional:    true,
+							Description: "The Profile Template details applied on the enterprise account.",
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"id": &schema.Schema{
+										Type:        schema.TypeString,
+										Optional:    true,
+										Description: "The Profile Template ID created in the enterprise account that provides access to App Configuration instance for resource collection.",
+									},
+									"trusted_profile_id": &schema.Schema{
+										Type:        schema.TypeString,
+										Optional:    true,
+										Description: "The trusted profile ID that provides access to App Configuration instance to retrieve template information.",
+									},
+								},
+							},
+						},
+					},
+				},
 			},
 		},
-	})
-}
-
-func TestAccIbmConfigAggregatorSettingsAllArgs(t *testing.T) {
-	var conf configurationaggregatorv1.SettingsResponse
-	resourceCollectionEnabled := "false"
-	trustedProfileID := fmt.Sprintf("tf_trusted_profile_id_%d", acctest.RandIntRange(10, 100))
-
-	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { acc.TestAccPreCheck(t) },
-		Providers:    acc.TestAccProviders,
-		CheckDestroy: testAccCheckIbmConfigAggregatorSettingsDestroy,
-		Steps: []resource.TestStep{
-			resource.TestStep{
-				Config: testAccCheckIbmConfigAggregatorSettingsConfig(resourceCollectionEnabled, trustedProfileID),
-				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckIbmConfigAggregatorSettingsExists("ibm_config_aggregator_settings.config_aggregator_settings_instance", conf),
-					resource.TestCheckResourceAttr("ibm_config_aggregator_settings.config_aggregator_settings_instance", "resource_collection_enabled", resourceCollectionEnabled),
-					resource.TestCheckResourceAttr("ibm_config_aggregator_settings.config_aggregator_settings_instance", "trusted_profile_id", trustedProfileID),
-				),
-			},
-			resource.TestStep{
-				ResourceName:      "ibm_config_aggregator_settings.config_aggregator_settings",
-				ImportState:       true,
-				ImportStateVerify: true,
-			},
-		},
-	})
-}
-
-func testAccCheckIbmConfigAggregatorSettingsConfigBasic() string {
-	return fmt.Sprintf(`
-		resource "ibm_config_aggregator_settings" "config_aggregator_settings_instance" {
-		}
-	`)
-}
-
-func testAccCheckIbmConfigAggregatorSettingsConfig(resourceCollectionEnabled string, trustedProfileID string) string {
-	return fmt.Sprintf(`
-
-		resource "ibm_config_aggregator_settings" "config_aggregator_settings_instance" {
-			resource_collection_enabled = %s
-			trusted_profile_id = "%s"
-			regions = "FIXME"
-			additional_scope {
-				type = "Enterprise"
-				enterprise_id = "enterprise_id"
-				profile_template {
-					id = "ProfileTemplate-adb55769-ae22-4c60-aead-bd1f84f93c57"
-					trusted_profile_id = "Profile-6bb60124-8fc3-4d18-b63d-0b99560865d3"
-				}
-			}
-		}
-	`, resourceCollectionEnabled, trustedProfileID)
-}
-
-func testAccCheckIbmConfigAggregatorSettingsExists(n string, obj configurationaggregatorv1.SettingsResponse) resource.TestCheckFunc {
-
-	return func(s *terraform.State) error {
-		_, ok := s.RootModule().Resources[n]
-		if !ok {
-			return fmt.Errorf("Not found: %s", n)
-		}
-
-		configurationAggregatorClient, err := acc.TestAccProvider.Meta().(conns.ClientSession).ConfigurationAggregatorV1()
-		if err != nil {
-			return err
-		}
-
-		getSettingsOptions := &configurationaggregatorv1.GetSettingsOptions{}
-
-		updateSettings, _, err := configurationAggregatorClient.GetSettings(getSettingsOptions)
-		if err != nil {
-			return err
-		}
-
-		obj = *updateSettings
-		return nil
 	}
 }
 
-func testAccCheckIbmConfigAggregatorSettingsDestroy(s *terraform.State) error {
-	configurationAggregatorClient, err := acc.TestAccProvider.Meta().(conns.ClientSession).ConfigurationAggregatorV1()
+func ResourceIbmConfigAggregatorSettingsValidator() *validate.ResourceValidator {
+	validateSchema := make([]validate.ValidateSchema, 0)
+	validateSchema = append(validateSchema,
+		validate.ValidateSchema{
+			Identifier:                 "trusted_profile_id",
+			ValidateFunctionIdentifier: validate.ValidateRegexpLen,
+			Type:                       validate.TypeString,
+			Required:                   true,
+			Regexp:                     `^[a-zA-Z0-9-]*$`,
+			MinValueLength:             44,
+			MaxValueLength:             44,
+		},
+	)
+
+	resourceValidator := validate.ResourceValidator{ResourceName: "ibm_config_aggregator_settings", Schema: validateSchema}
+	return &resourceValidator
+}
+
+func resourceIbmConfigAggregatorSettingsCreate(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	configurationAggregatorClient, err := meta.(conns.ClientSession).ConfigurationAggregatorV1()
 	if err != nil {
-		return err
+		// Error is coming from SDK client, so it doesn't need to be discriminated.
+		tfErr := flex.TerraformErrorf(err, err.Error(), "ibm_config_aggregator_settings", "create")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
-	for _, rs := range s.RootModule().Resources {
-		if rs.Type != "ibm_config_aggregator_settings" {
-			continue
+
+	replaceSettingsOptions := &configurationaggregatorv1.ReplaceSettingsOptions{}
+
+	replaceSettingsOptions.SetResourceCollectionEnabled(d.Get("resource_collection_enabled").(bool))
+	replaceSettingsOptions.SetTrustedProfileID(d.Get("trusted_profile_id").(string))
+	var regions []string
+	for _, v := range d.Get("regions").([]interface{}) {
+		regionsItem := v.(string)
+		regions = append(regions, regionsItem)
+	}
+	replaceSettingsOptions.SetRegions(regions)
+	if _, ok := d.GetOk("additional_scope"); ok {
+		var additionalScope []configurationaggregatorv1.AdditionalScope
+		for _, v := range d.Get("additional_scope").([]interface{}) {
+			value := v.(map[string]interface{})
+			additionalScopeItem, err := ResourceIbmConfigAggregatorSettingsMapToAdditionalScope(value)
+			if err != nil {
+				return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_config_aggregator_settings", "create", "parse-additional_scope").GetDiag()
+			}
+			additionalScope = append(additionalScope, *additionalScopeItem)
 		}
+		replaceSettingsOptions.SetAdditionalScope(additionalScope)
+	}
 
-		getSettingsOptions := &configurationaggregatorv1.GetSettingsOptions{}
+	settingsResponse, _, err := configurationAggregatorClient.ReplaceSettingsWithContext(context, replaceSettingsOptions)
+	if err != nil {
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("ReplaceSettingsWithContext failed: %s", err.Error()), "ibm_config_aggregator_settings", "create")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
+	}
 
-		// Try to find the key
-		_, response, err := configurationAggregatorClient.GetSettings(getSettingsOptions)
+	d.SetId(*settingsResponse.TrustedProfileID)
 
-		if err == nil {
-			return fmt.Errorf("config_aggregator_settings still exists: %s", rs.Primary.ID)
-		} else if response.StatusCode != 404 {
-			return fmt.Errorf("Error checking for config_aggregator_settings (%s) has been destroyed: %s", rs.Primary.ID, err)
+	return resourceIbmConfigAggregatorSettingsRead(context, d, meta)
+}
+
+func resourceIbmConfigAggregatorSettingsRead(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	configurationAggregatorClient, err := meta.(conns.ClientSession).ConfigurationAggregatorV1()
+	if err != nil {
+		tfErr := flex.TerraformErrorf(err, err.Error(), "ibm_config_aggregator_settings", "read")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
+	}
+
+	getSettingsOptions := &configurationaggregatorv1.GetSettingsOptions{}
+
+	settingsResponse, response, err := configurationAggregatorClient.GetSettingsWithContext(context, getSettingsOptions)
+	if err != nil {
+		if response != nil && response.StatusCode == 404 {
+			d.SetId("")
+			return nil
+		}
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("GetSettingsWithContext failed: %s", err.Error()), "ibm_config_aggregator_settings", "read")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
+	}
+
+	if err = d.Set("resource_collection_enabled", settingsResponse.ResourceCollectionEnabled); err != nil {
+		err = fmt.Errorf("Error setting resource_collection_enabled: %s", err)
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_config_aggregator_settings", "read", "set-resource_collection_enabled").GetDiag()
+	}
+	if err = d.Set("trusted_profile_id", settingsResponse.TrustedProfileID); err != nil {
+		err = fmt.Errorf("Error setting trusted_profile_id: %s", err)
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_config_aggregator_settings", "read", "set-trusted_profile_id").GetDiag()
+	}
+	if err = d.Set("regions", settingsResponse.Regions); err != nil {
+		err = fmt.Errorf("Error setting regions: %s", err)
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_config_aggregator_settings", "read", "set-regions").GetDiag()
+	}
+	if !core.IsNil(settingsResponse.AdditionalScope) {
+		additionalScope := []map[string]interface{}{}
+		for _, additionalScopeItem := range settingsResponse.AdditionalScope {
+			additionalScopeItemMap, err := ResourceIbmConfigAggregatorSettingsAdditionalScopeToMap(&additionalScopeItem)
+			if err != nil {
+				return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_config_aggregator_settings", "read", "additional_scope-to-map").GetDiag()
+			}
+			additionalScope = append(additionalScope, additionalScopeItemMap)
+		}
+		if err = d.Set("additional_scope", additionalScope); err != nil {
+			err = fmt.Errorf("Error setting additional_scope: %s", err)
+			return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_config_aggregator_settings", "read", "set-additional_scope").GetDiag()
 		}
 	}
 
 	return nil
 }
 
-func TestResourceIbmConfigAggregatorSettingsAdditionalScopeToMap(t *testing.T) {
-	checkResult := func(result map[string]interface{}) {
-		profileTemplateModel := make(map[string]interface{})
-		profileTemplateModel["id"] = "ProfileTemplate-adb55769-ae22-4c60-aead-bd1f84f93c57"
-		profileTemplateModel["trusted_profile_id"] = "Profile-6bb60124-8fc3-4d18-b63d-0b99560865d3"
-
-		model := make(map[string]interface{})
-		model["type"] = "Enterprise"
-		model["enterprise_id"] = "testString"
-		model["profile_template"] = []map[string]interface{}{profileTemplateModel}
-
-		assert.Equal(t, result, model)
-	}
-
-	profileTemplateModel := new(configurationaggregatorv1.ProfileTemplate)
-	profileTemplateModel.ID = core.StringPtr("ProfileTemplate-adb55769-ae22-4c60-aead-bd1f84f93c57")
-	profileTemplateModel.TrustedProfileID = core.StringPtr("Profile-6bb60124-8fc3-4d18-b63d-0b99560865d3")
-
-	model := new(configurationaggregatorv1.AdditionalScope)
-	model.Type = core.StringPtr("Enterprise")
-	model.EnterpriseID = core.StringPtr("testString")
-	model.ProfileTemplate = profileTemplateModel
-
-	result, err := configurationaggregator.ResourceIbmConfigAggregatorSettingsAdditionalScopeToMap(model)
-	assert.Nil(t, err)
-	checkResult(result)
+func resourceIbmConfigAggregatorSettingsDelete(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	// This resource does not support a "delete" operation.
+	d.SetId("")
+	return nil
 }
 
-func TestResourceIbmConfigAggregatorSettingsProfileTemplateToMap(t *testing.T) {
-	checkResult := func(result map[string]interface{}) {
-		model := make(map[string]interface{})
-		model["id"] = "ProfileTemplate-adb55769-ae22-4c60-aead-bd1f84f93c57"
-		model["trusted_profile_id"] = "Profile-6bb60124-8fc3-4d18-b63d-0b99560865d3"
-
-		assert.Equal(t, result, model)
+func ResourceIbmConfigAggregatorSettingsMapToAdditionalScope(modelMap map[string]interface{}) (*configurationaggregatorv1.AdditionalScope, error) {
+	model := &configurationaggregatorv1.AdditionalScope{}
+	if modelMap["type"] != nil && modelMap["type"].(string) != "" {
+		model.Type = core.StringPtr(modelMap["type"].(string))
 	}
-
-	model := new(configurationaggregatorv1.ProfileTemplate)
-	model.ID = core.StringPtr("ProfileTemplate-adb55769-ae22-4c60-aead-bd1f84f93c57")
-	model.TrustedProfileID = core.StringPtr("Profile-6bb60124-8fc3-4d18-b63d-0b99560865d3")
-
-	result, err := configurationaggregator.ResourceIbmConfigAggregatorSettingsProfileTemplateToMap(model)
-	assert.Nil(t, err)
-	checkResult(result)
+	if modelMap["enterprise_id"] != nil && modelMap["enterprise_id"].(string) != "" {
+		model.EnterpriseID = core.StringPtr(modelMap["enterprise_id"].(string))
+	}
+	if modelMap["profile_template"] != nil && len(modelMap["profile_template"].([]interface{})) > 0 {
+		ProfileTemplateModel, err := ResourceIbmConfigAggregatorSettingsMapToProfileTemplate(modelMap["profile_template"].([]interface{})[0].(map[string]interface{}))
+		if err != nil {
+			return model, err
+		}
+		model.ProfileTemplate = ProfileTemplateModel
+	}
+	return model, nil
 }
 
-func TestResourceIbmConfigAggregatorSettingsMapToAdditionalScope(t *testing.T) {
-	checkResult := func(result *configurationaggregatorv1.AdditionalScope) {
-		profileTemplateModel := new(configurationaggregatorv1.ProfileTemplate)
-		profileTemplateModel.ID = core.StringPtr("ProfileTemplate-adb55769-ae22-4c60-aead-bd1f84f93c57")
-		profileTemplateModel.TrustedProfileID = core.StringPtr("Profile-6bb60124-8fc3-4d18-b63d-0b99560865d3")
-
-		model := new(configurationaggregatorv1.AdditionalScope)
-		model.Type = core.StringPtr("Enterprise")
-		model.EnterpriseID = core.StringPtr("testString")
-		model.ProfileTemplate = profileTemplateModel
-
-		assert.Equal(t, result, model)
+func ResourceIbmConfigAggregatorSettingsMapToProfileTemplate(modelMap map[string]interface{}) (*configurationaggregatorv1.ProfileTemplate, error) {
+	model := &configurationaggregatorv1.ProfileTemplate{}
+	if modelMap["id"] != nil && modelMap["id"].(string) != "" {
+		model.ID = core.StringPtr(modelMap["id"].(string))
 	}
-
-	profileTemplateModel := make(map[string]interface{})
-	profileTemplateModel["id"] = "ProfileTemplate-adb55769-ae22-4c60-aead-bd1f84f93c57"
-	profileTemplateModel["trusted_profile_id"] = "Profile-6bb60124-8fc3-4d18-b63d-0b99560865d3"
-
-	model := make(map[string]interface{})
-	model["type"] = "Enterprise"
-	model["enterprise_id"] = "testString"
-	model["profile_template"] = []interface{}{profileTemplateModel}
-
-	result, err := configurationaggregator.ResourceIbmConfigAggregatorSettingsMapToAdditionalScope(model)
-	assert.Nil(t, err)
-	checkResult(result)
+	if modelMap["trusted_profile_id"] != nil && modelMap["trusted_profile_id"].(string) != "" {
+		model.TrustedProfileID = core.StringPtr(modelMap["trusted_profile_id"].(string))
+	}
+	return model, nil
 }
 
-func TestResourceIbmConfigAggregatorSettingsMapToProfileTemplate(t *testing.T) {
-	checkResult := func(result *configurationaggregatorv1.ProfileTemplate) {
-		model := new(configurationaggregatorv1.ProfileTemplate)
-		model.ID = core.StringPtr("ProfileTemplate-adb55769-ae22-4c60-aead-bd1f84f93c57")
-		model.TrustedProfileID = core.StringPtr("Profile-6bb60124-8fc3-4d18-b63d-0b99560865d3")
-
-		assert.Equal(t, result, model)
+func ResourceIbmConfigAggregatorSettingsAdditionalScopeToMap(model *configurationaggregatorv1.AdditionalScope) (map[string]interface{}, error) {
+	modelMap := make(map[string]interface{})
+	if model.Type != nil {
+		modelMap["type"] = *model.Type
 	}
+	if model.EnterpriseID != nil {
+		modelMap["enterprise_id"] = *model.EnterpriseID
+	}
+	if model.ProfileTemplate != nil {
+		profileTemplateMap, err := ResourceIbmConfigAggregatorSettingsProfileTemplateToMap(model.ProfileTemplate)
+		if err != nil {
+			return modelMap, err
+		}
+		modelMap["profile_template"] = []map[string]interface{}{profileTemplateMap}
+	}
+	return modelMap, nil
+}
 
-	model := make(map[string]interface{})
-	model["id"] = "ProfileTemplate-adb55769-ae22-4c60-aead-bd1f84f93c57"
-	model["trusted_profile_id"] = "Profile-6bb60124-8fc3-4d18-b63d-0b99560865d3"
-
-	result, err := configurationaggregator.ResourceIbmConfigAggregatorSettingsMapToProfileTemplate(model)
-	assert.Nil(t, err)
-	checkResult(result)
+func ResourceIbmConfigAggregatorSettingsProfileTemplateToMap(model *configurationaggregatorv1.ProfileTemplate) (map[string]interface{}, error) {
+	modelMap := make(map[string]interface{})
+	if model.ID != nil {
+		modelMap["id"] = *model.ID
+	}
+	if model.TrustedProfileID != nil {
+		modelMap["trusted_profile_id"] = *model.TrustedProfileID
+	}
+	return modelMap, nil
 }

--- a/ibm/service/configurationaggregator/resource_ibm_config_aggregator_settings_test.go
+++ b/ibm/service/configurationaggregator/resource_ibm_config_aggregator_settings_test.go
@@ -7,194 +7,40 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 
 	acc "github.com/IBM-Cloud/terraform-provider-ibm/ibm/acctest"
-	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/conns"
-	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/configurationaggregator"
-	"github.com/IBM/configuration-aggregator-go-sdk/configurationaggregatorv1"
-	"github.com/IBM/go-sdk-core/v5/core"
-	"github.com/stretchr/testify/assert"
 )
 
 func TestAccIbmConfigAggregatorSettingsBasic(t *testing.T) {
-	var conf configurationaggregatorv1.SettingsResponse
-	resourceCollectionEnabled := "false"
-	trustedProfileID := fmt.Sprintf("tf_trusted_profile_id_%d", acctest.RandIntRange(10, 100))
+
+	instanceID := "instance_id"
+	resourceCollectionEnabled := false
+	trustedProfileID := "Profile-2546925a-7b46-40dd-81ff-48015a49ff43"
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { acc.TestAccPreCheck(t) },
-		Providers:    acc.TestAccProviders,
-		CheckDestroy: testAccCheckIbmConfigAggregatorSettingsDestroy,
+		PreCheck:  func() { acc.TestAccPreCheck(t) },
+		Providers: acc.TestAccProviders,
 		Steps: []resource.TestStep{
 			resource.TestStep{
-				Config: testAccCheckIbmConfigAggregatorSettingsConfigBasic(resourceCollectionEnabled, trustedProfileID),
+				Config: testAccCheckIbmConfigAggregatorSettingsConfigBasic(instanceID, resourceCollectionEnabled, trustedProfileID),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckIbmConfigAggregatorSettingsExists("ibm_config_aggregator_settings.config_aggregator_settings_instance", conf),
-					resource.TestCheckResourceAttr("ibm_config_aggregator_settings.config_aggregator_settings_instance", "resource_collection_enabled", resourceCollectionEnabled),
+					resource.TestCheckResourceAttr("ibm_config_aggregator_settings.config_aggregator_settings_instance", "resource_collection_enabled", fmt.Sprintf("%t", resourceCollectionEnabled)),
 					resource.TestCheckResourceAttr("ibm_config_aggregator_settings.config_aggregator_settings_instance", "trusted_profile_id", trustedProfileID),
+					resource.TestCheckResourceAttr("ibm_config_aggregator_settings.config_aggregator_settings_instance", "instance_id", instanceID),
 				),
-			},
-			resource.TestStep{
-				ResourceName:      "ibm_config_aggregator_settings.config_aggregator_settings",
-				ImportState:       true,
-				ImportStateVerify: true,
 			},
 		},
 	})
 }
 
-func testAccCheckIbmConfigAggregatorSettingsConfigBasic(resourceCollectionEnabled string, trustedProfileID string) string {
+func testAccCheckIbmConfigAggregatorSettingsConfigBasic(instanceID string, resourceCollectionEnabled bool, trustedProfileID string) string {
 	return fmt.Sprintf(`
-		resource "ibm_config_aggregator_settings" "config_aggregator_settings_instance" {
-			instance_id = s
-			resource_collection_enabled = %s
-			trusted_profile_id = "%s"
-			regions = "FIXME"
-		}
-	`, resourceCollectionEnabled, trustedProfileID)
-}
-
-func testAccCheckIbmConfigAggregatorSettingsExists(n string, obj configurationaggregatorv1.SettingsResponse) resource.TestCheckFunc {
-
-	return func(s *terraform.State) error {
-		_, ok := s.RootModule().Resources[n]
-		if !ok {
-			return fmt.Errorf("Not found: %s", n)
-		}
-
-		configurationAggregatorClient, err := acc.TestAccProvider.Meta().(conns.ClientSession).ConfigurationAggregatorV1()
-		if err != nil {
-			return err
-		}
-
-		getSettingsOptions := &configurationaggregatorv1.GetSettingsOptions{}
-
-		settingsResponse, _, err := configurationAggregatorClient.GetSettings(getSettingsOptions)
-		if err != nil {
-			return err
-		}
-
-		obj = *settingsResponse
-		return nil
-	}
-}
-
-func testAccCheckIbmConfigAggregatorSettingsDestroy(s *terraform.State) error {
-	configurationAggregatorClient, err := acc.TestAccProvider.Meta().(conns.ClientSession).ConfigurationAggregatorV1()
-	if err != nil {
-		return err
-	}
-	for _, rs := range s.RootModule().Resources {
-		if rs.Type != "ibm_config_aggregator_settings" {
-			continue
-		}
-
-		getSettingsOptions := &configurationaggregatorv1.GetSettingsOptions{}
-
-		// Try to find the key
-		_, response, err := configurationAggregatorClient.GetSettings(getSettingsOptions)
-
-		if err == nil {
-			return fmt.Errorf("config_aggregator_settings still exists: %s", rs.Primary.ID)
-		} else if response.StatusCode != 404 {
-			return fmt.Errorf("Error checking for config_aggregator_settings (%s) has been destroyed: %s", rs.Primary.ID, err)
-		}
-	}
-
-	return nil
-}
-
-func TestResourceIbmConfigAggregatorSettingsAdditionalScopeToMap(t *testing.T) {
-	checkResult := func(result map[string]interface{}) {
-		profileTemplateModel := make(map[string]interface{})
-		profileTemplateModel["id"] = "ProfileTemplate-adb55769-ae22-4c60-aead-bd1f84f93c57"
-		profileTemplateModel["trusted_profile_id"] = "Profile-6bb60124-8fc3-4d18-b63d-0b99560865d3"
-
-		model := make(map[string]interface{})
-		model["type"] = "Enterprise"
-		model["enterprise_id"] = "testString"
-		model["profile_template"] = []map[string]interface{}{profileTemplateModel}
-
-		assert.Equal(t, result, model)
-	}
-
-	profileTemplateModel := new(configurationaggregatorv1.ProfileTemplate)
-	profileTemplateModel.ID = core.StringPtr("ProfileTemplate-adb55769-ae22-4c60-aead-bd1f84f93c57")
-	profileTemplateModel.TrustedProfileID = core.StringPtr("Profile-6bb60124-8fc3-4d18-b63d-0b99560865d3")
-
-	model := new(configurationaggregatorv1.AdditionalScope)
-	model.Type = core.StringPtr("Enterprise")
-	model.EnterpriseID = core.StringPtr("testString")
-	model.ProfileTemplate = profileTemplateModel
-
-	result, err := configurationaggregator.ResourceIbmConfigAggregatorSettingsAdditionalScopeToMap(model)
-	assert.Nil(t, err)
-	checkResult(result)
-}
-
-func TestResourceIbmConfigAggregatorSettingsProfileTemplateToMap(t *testing.T) {
-	checkResult := func(result map[string]interface{}) {
-		model := make(map[string]interface{})
-		model["id"] = "ProfileTemplate-adb55769-ae22-4c60-aead-bd1f84f93c57"
-		model["trusted_profile_id"] = "Profile-6bb60124-8fc3-4d18-b63d-0b99560865d3"
-
-		assert.Equal(t, result, model)
-	}
-
-	model := new(configurationaggregatorv1.ProfileTemplate)
-	model.ID = core.StringPtr("ProfileTemplate-adb55769-ae22-4c60-aead-bd1f84f93c57")
-	model.TrustedProfileID = core.StringPtr("Profile-6bb60124-8fc3-4d18-b63d-0b99560865d3")
-
-	result, err := configurationaggregator.ResourceIbmConfigAggregatorSettingsProfileTemplateToMap(model)
-	assert.Nil(t, err)
-	checkResult(result)
-}
-
-func TestResourceIbmConfigAggregatorSettingsMapToAdditionalScope(t *testing.T) {
-	checkResult := func(result *configurationaggregatorv1.AdditionalScope) {
-		profileTemplateModel := new(configurationaggregatorv1.ProfileTemplate)
-		profileTemplateModel.ID = core.StringPtr("ProfileTemplate-adb55769-ae22-4c60-aead-bd1f84f93c57")
-		profileTemplateModel.TrustedProfileID = core.StringPtr("Profile-6bb60124-8fc3-4d18-b63d-0b99560865d3")
-
-		model := new(configurationaggregatorv1.AdditionalScope)
-		model.Type = core.StringPtr("Enterprise")
-		model.EnterpriseID = core.StringPtr("testString")
-		model.ProfileTemplate = profileTemplateModel
-
-		assert.Equal(t, result, model)
-	}
-
-	profileTemplateModel := make(map[string]interface{})
-	profileTemplateModel["id"] = "ProfileTemplate-adb55769-ae22-4c60-aead-bd1f84f93c57"
-	profileTemplateModel["trusted_profile_id"] = "Profile-6bb60124-8fc3-4d18-b63d-0b99560865d3"
-
-	model := make(map[string]interface{})
-	model["type"] = "Enterprise"
-	model["enterprise_id"] = "testString"
-	model["profile_template"] = []interface{}{profileTemplateModel}
-
-	result, err := configurationaggregator.ResourceIbmConfigAggregatorSettingsMapToAdditionalScope(model)
-	assert.Nil(t, err)
-	checkResult(result)
-}
-
-func TestResourceIbmConfigAggregatorSettingsMapToProfileTemplate(t *testing.T) {
-	checkResult := func(result *configurationaggregatorv1.ProfileTemplate) {
-		model := new(configurationaggregatorv1.ProfileTemplate)
-		model.ID = core.StringPtr("ProfileTemplate-adb55769-ae22-4c60-aead-bd1f84f93c57")
-		model.TrustedProfileID = core.StringPtr("Profile-6bb60124-8fc3-4d18-b63d-0b99560865d3")
-
-		assert.Equal(t, result, model)
-	}
-
-	model := make(map[string]interface{})
-	model["id"] = "ProfileTemplate-adb55769-ae22-4c60-aead-bd1f84f93c57"
-	model["trusted_profile_id"] = "Profile-6bb60124-8fc3-4d18-b63d-0b99560865d3"
-
-	result, err := configurationaggregator.ResourceIbmConfigAggregatorSettingsMapToProfileTemplate(model)
-	assert.Nil(t, err)
-	checkResult(result)
+        resource "ibm_config_aggregator_settings" "config_aggregator_settings_instance" {
+            instance_id = "%s"
+            resource_collection_enabled = %t
+            trusted_profile_id = "%s"
+            resource_collection_regions = ["all"]
+        }
+    `, instanceID, resourceCollectionEnabled, trustedProfileID)
 }

--- a/ibm/service/configurationaggregator/resource_ibm_config_aggregator_settings_test.go
+++ b/ibm/service/configurationaggregator/resource_ibm_config_aggregator_settings_test.go
@@ -1,0 +1,285 @@
+// Copyright IBM Corp. 2024 All Rights Reserved.
+// Licensed under the Mozilla Public License v2.0
+
+/*
+ * IBM OpenAPI Terraform Generator Version: 3.92.0-af5c89a5-20240617-153232
+ */
+
+package configurationaggregator_test
+
+import (
+	"context"
+	"fmt"
+	"log"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/IBM/configuration-aggregator-go-sdk/configurationaggregatorv1"
+
+	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/conns"
+	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/flex"
+	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/validate"
+	"github.com/IBM/go-sdk-core/v5/core"
+)
+
+func ResourceIbmConfigAggregatorSettings() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceIbmConfigAggregatorSettingsCreate,
+		ReadContext:   resourceIbmConfigAggregatorSettingsRead,
+		DeleteContext: resourceIbmConfigAggregatorSettingsDelete,
+		Importer:      &schema.ResourceImporter{},
+
+		Schema: map[string]*schema.Schema{
+			"resource_collection_enabled": &schema.Schema{
+				Type:        schema.TypeBool,
+				Optional:    true,
+				ForceNew:    true,
+				Description: "The field denoting if the resource collection is enabled.",
+			},
+			"trusted_profile_id": &schema.Schema{
+				Type:         schema.TypeString,
+				Optional:     true,
+				ForceNew:     true,
+				ValidateFunc: validate.InvokeValidator("ibm_config_aggregator_settings", "trusted_profile_id"),
+				Description:  "The trusted profile id that provides Reader access to the App Configuration instance to collect resource metadata.",
+			},
+			"regions": &schema.Schema{
+				Type:        schema.TypeList,
+				Optional:    true,
+				ForceNew:    true,
+				Description: "The list of regions across which the resource collection is enabled.",
+				Elem:        &schema.Schema{Type: schema.TypeString},
+			},
+			"additional_scope": &schema.Schema{
+				Type:        schema.TypeList,
+				Optional:    true,
+				ForceNew:    true,
+				Description: "The additional scope that enables resource collection for Enterprise acccounts.",
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"type": &schema.Schema{
+							Type:        schema.TypeString,
+							Optional:    true,
+							Description: "The type of scope. Currently allowed value is Enterprise.",
+						},
+						"enterprise_id": &schema.Schema{
+							Type:        schema.TypeString,
+							Optional:    true,
+							Description: "The Enterprise ID.",
+						},
+						"profile_template": &schema.Schema{
+							Type:        schema.TypeList,
+							MaxItems:    1,
+							Optional:    true,
+							Description: "The Profile Template details applied on the enterprise account.",
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"id": &schema.Schema{
+										Type:        schema.TypeString,
+										Optional:    true,
+										Description: "The Profile Template ID created in the enterprise account that provides access to App Configuration instance for resource collection.",
+									},
+									"trusted_profile_id": &schema.Schema{
+										Type:        schema.TypeString,
+										Optional:    true,
+										Description: "The trusted profile ID that provides access to App Configuration instance to retrieve template information.",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func ResourceIbmConfigAggregatorSettingsValidator() *validate.ResourceValidator {
+	validateSchema := make([]validate.ValidateSchema, 0)
+	validateSchema = append(validateSchema,
+		validate.ValidateSchema{
+			Identifier:                 "trusted_profile_id",
+			ValidateFunctionIdentifier: validate.ValidateRegexpLen,
+			Type:                       validate.TypeString,
+			Optional:                   true,
+			Regexp:                     `^[a-zA-Z0-9-]*$`,
+			MinValueLength:             44,
+			MaxValueLength:             44,
+		},
+	)
+
+	resourceValidator := validate.ResourceValidator{ResourceName: "ibm_config_aggregator_settings", Schema: validateSchema}
+	return &resourceValidator
+}
+
+func resourceIbmConfigAggregatorSettingsCreate(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	configurationAggregatorClient, err := meta.(conns.ClientSession).ConfigurationAggregatorV1()
+	if err != nil {
+		// Error is coming from SDK client, so it doesn't need to be discriminated.
+		tfErr := flex.TerraformErrorf(err, err.Error(), "ibm_config_aggregator_settings", "create")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
+	}
+
+	replaceSettingsOptions := &configurationaggregatorv1.ReplaceSettingsOptions{}
+
+	if _, ok := d.GetOk("resource_collection_enabled"); ok {
+		replaceSettingsOptions.SetResourceCollectionEnabled(d.Get("resource_collection_enabled").(bool))
+	}
+	if _, ok := d.GetOk("trusted_profile_id"); ok {
+		replaceSettingsOptions.SetTrustedProfileID(d.Get("trusted_profile_id").(string))
+	}
+	if _, ok := d.GetOk("regions"); ok {
+		var regions []string
+		for _, v := range d.Get("regions").([]interface{}) {
+			regionsItem := v.(string)
+			regions = append(regions, regionsItem)
+		}
+		replaceSettingsOptions.SetRegions(regions)
+	}
+	if _, ok := d.GetOk("additional_scope"); ok {
+		var additionalScope []configurationaggregatorv1.AdditionalScope
+		for _, v := range d.Get("additional_scope").([]interface{}) {
+			value := v.(map[string]interface{})
+			additionalScopeItem, err := ResourceIbmConfigAggregatorSettingsMapToAdditionalScope(value)
+			if err != nil {
+				return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_config_aggregator_settings", "create", "parse-additional_scope").GetDiag()
+			}
+			additionalScope = append(additionalScope, *additionalScopeItem)
+		}
+		replaceSettingsOptions.SetAdditionalScope(additionalScope)
+	}
+
+	settingsResponse, _, err := configurationAggregatorClient.ReplaceSettingsWithContext(context, replaceSettingsOptions)
+	if err != nil {
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("ReplaceSettingsWithContext failed: %s", err.Error()), "ibm_config_aggregator_settings", "create")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
+	}
+
+	d.SetId(*settingsResponse.TrustedProfileID)
+
+	return resourceIbmConfigAggregatorSettingsRead(context, d, meta)
+}
+
+func resourceIbmConfigAggregatorSettingsRead(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	configurationAggregatorClient, err := meta.(conns.ClientSession).ConfigurationAggregatorV1()
+	if err != nil {
+		tfErr := flex.TerraformErrorf(err, err.Error(), "ibm_config_aggregator_settings", "read")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
+	}
+
+	getSettingsOptions := &configurationaggregatorv1.GetSettingsOptions{}
+
+	settingsResponse, response, err := configurationAggregatorClient.GetSettingsWithContext(context, getSettingsOptions)
+	if err != nil {
+		if response != nil && response.StatusCode == 404 {
+			d.SetId("")
+			return nil
+		}
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("GetSettingsWithContext failed: %s", err.Error()), "ibm_config_aggregator_settings", "read")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
+	}
+
+	if !core.IsNil(settingsResponse.ResourceCollectionEnabled) {
+		if err = d.Set("resource_collection_enabled", settingsResponse.ResourceCollectionEnabled); err != nil {
+			err = fmt.Errorf("Error setting resource_collection_enabled: %s", err)
+			return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_config_aggregator_settings", "read", "set-resource_collection_enabled").GetDiag()
+		}
+	}
+	if !core.IsNil(settingsResponse.TrustedProfileID) {
+		if err = d.Set("trusted_profile_id", settingsResponse.TrustedProfileID); err != nil {
+			err = fmt.Errorf("Error setting trusted_profile_id: %s", err)
+			return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_config_aggregator_settings", "read", "set-trusted_profile_id").GetDiag()
+		}
+	}
+	if !core.IsNil(settingsResponse.Regions) {
+		if err = d.Set("regions", settingsResponse.Regions); err != nil {
+			err = fmt.Errorf("Error setting regions: %s", err)
+			return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_config_aggregator_settings", "read", "set-regions").GetDiag()
+		}
+	}
+	if !core.IsNil(settingsResponse.AdditionalScope) {
+		additionalScope := []map[string]interface{}{}
+		for _, additionalScopeItem := range settingsResponse.AdditionalScope {
+			additionalScopeItemMap, err := ResourceIbmConfigAggregatorSettingsAdditionalScopeToMap(&additionalScopeItem)
+			if err != nil {
+				return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_config_aggregator_settings", "read", "additional_scope-to-map").GetDiag()
+			}
+			additionalScope = append(additionalScope, additionalScopeItemMap)
+		}
+		if err = d.Set("additional_scope", additionalScope); err != nil {
+			err = fmt.Errorf("Error setting additional_scope: %s", err)
+			return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_config_aggregator_settings", "read", "set-additional_scope").GetDiag()
+		}
+	}
+
+	return nil
+}
+
+func resourceIbmConfigAggregatorSettingsDelete(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	// This resource does not support a "delete" operation.
+	d.SetId("")
+	return nil
+}
+
+func ResourceIbmConfigAggregatorSettingsMapToAdditionalScope(modelMap map[string]interface{}) (*configurationaggregatorv1.AdditionalScope, error) {
+	model := &configurationaggregatorv1.AdditionalScope{}
+	if modelMap["type"] != nil && modelMap["type"].(string) != "" {
+		model.Type = core.StringPtr(modelMap["type"].(string))
+	}
+	if modelMap["enterprise_id"] != nil && modelMap["enterprise_id"].(string) != "" {
+		model.EnterpriseID = core.StringPtr(modelMap["enterprise_id"].(string))
+	}
+	if modelMap["profile_template"] != nil && len(modelMap["profile_template"].([]interface{})) > 0 {
+		ProfileTemplateModel, err := ResourceIbmConfigAggregatorSettingsMapToProfileTemplate(modelMap["profile_template"].([]interface{})[0].(map[string]interface{}))
+		if err != nil {
+			return model, err
+		}
+		model.ProfileTemplate = ProfileTemplateModel
+	}
+	return model, nil
+}
+
+func ResourceIbmConfigAggregatorSettingsMapToProfileTemplate(modelMap map[string]interface{}) (*configurationaggregatorv1.ProfileTemplate, error) {
+	model := &configurationaggregatorv1.ProfileTemplate{}
+	if modelMap["id"] != nil && modelMap["id"].(string) != "" {
+		model.ID = core.StringPtr(modelMap["id"].(string))
+	}
+	if modelMap["trusted_profile_id"] != nil && modelMap["trusted_profile_id"].(string) != "" {
+		model.TrustedProfileID = core.StringPtr(modelMap["trusted_profile_id"].(string))
+	}
+	return model, nil
+}
+
+func ResourceIbmConfigAggregatorSettingsAdditionalScopeToMap(model *configurationaggregatorv1.AdditionalScope) (map[string]interface{}, error) {
+	modelMap := make(map[string]interface{})
+	if model.Type != nil {
+		modelMap["type"] = *model.Type
+	}
+	if model.EnterpriseID != nil {
+		modelMap["enterprise_id"] = *model.EnterpriseID
+	}
+	if model.ProfileTemplate != nil {
+		profileTemplateMap, err := ResourceIbmConfigAggregatorSettingsProfileTemplateToMap(model.ProfileTemplate)
+		if err != nil {
+			return modelMap, err
+		}
+		modelMap["profile_template"] = []map[string]interface{}{profileTemplateMap}
+	}
+	return modelMap, nil
+}
+
+func ResourceIbmConfigAggregatorSettingsProfileTemplateToMap(model *configurationaggregatorv1.ProfileTemplate) (map[string]interface{}, error) {
+	modelMap := make(map[string]interface{})
+	if model.ID != nil {
+		modelMap["id"] = *model.ID
+	}
+	if model.TrustedProfileID != nil {
+		modelMap["trusted_profile_id"] = *model.TrustedProfileID
+	}
+	return modelMap, nil
+}

--- a/ibm/service/configurationaggregator/resource_ibm_config_aggregator_settings_test.go
+++ b/ibm/service/configurationaggregator/resource_ibm_config_aggregator_settings_test.go
@@ -49,6 +49,7 @@ func TestAccIbmConfigAggregatorSettingsBasic(t *testing.T) {
 func testAccCheckIbmConfigAggregatorSettingsConfigBasic(resourceCollectionEnabled string, trustedProfileID string) string {
 	return fmt.Sprintf(`
 		resource "ibm_config_aggregator_settings" "config_aggregator_settings_instance" {
+			instance_id = s
 			resource_collection_enabled = %s
 			trusted_profile_id = "%s"
 			regions = "FIXME"

--- a/ibm/service/configurationaggregator/utils.go
+++ b/ibm/service/configurationaggregator/utils.go
@@ -21,9 +21,7 @@ func getConfigurationInstanceRegion(originalClient *configurationaggregatorv1.Co
 		return d.Get("region").(string)
 	}
 	baseUrl := originalClient.Service.GetServiceURL()
-	fmt.Println("Base URL Components")
 	url_01 := strings.Split(baseUrl, ".")[0]
-	fmt.Println(strings.Split(baseUrl, ".")[0])
 	return (strings.Split(url_01, "://")[1])
 }
 
@@ -39,8 +37,6 @@ func getClientWithConfigurationInstanceEndpoint(originalClient *configurationagg
 	newClient := &configurationaggregatorv1.ConfigurationAggregatorV1{
 		Service: originalClient.Service.Clone(),
 	}
-	fmt.Println("Print Endpoint from utils.go")
-	fmt.Println(endpoint)
 
 	newClient.Service.SetServiceURL(endpoint)
 

--- a/ibm/service/configurationaggregator/utils.go
+++ b/ibm/service/configurationaggregator/utils.go
@@ -1,0 +1,80 @@
+package configurationaggregator
+
+import (
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/flex"
+	"github.com/IBM/configuration-aggregator-go-sdk/configurationaggregatorv1"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+const (
+	cloudEndpoint     = "cloud.ibm.com"
+	testCloudEndpoint = "test.cloud.ibm.com"
+)
+
+func getConfigurationInstanceRegion(originalClient *configurationaggregatorv1.ConfigurationAggregatorV1, d *schema.ResourceData) string {
+	_, ok := d.GetOk("region")
+	if ok {
+		return d.Get("region").(string)
+	}
+	baseUrl := originalClient.Service.GetServiceURL()
+	fmt.Println("Base URL Components")
+	url_01 := strings.Split(baseUrl, ".")[0]
+	fmt.Println(strings.Split(baseUrl, ".")[0])
+	return (strings.Split(url_01, "://")[1])
+}
+
+func getClientWithConfigurationInstanceEndpoint(originalClient *configurationaggregatorv1.ConfigurationAggregatorV1, instanceId string, region string) *configurationaggregatorv1.ConfigurationAggregatorV1 {
+	// build the api endpoint
+	domain := cloudEndpoint
+	if strings.Contains(os.Getenv("IBMCLOUD_IAM_API_ENDPOINT"), "test") {
+		domain = testCloudEndpoint
+	}
+	endpoint := fmt.Sprintf("https://%s.apprapp.%s/apprapp/config_aggregator/v1/instances/%s", region, domain, instanceId)
+
+	// clone the client and set endpoint
+	newClient := &configurationaggregatorv1.ConfigurationAggregatorV1{
+		Service: originalClient.Service.Clone(),
+	}
+	fmt.Println("Print Endpoint from utils.go")
+	fmt.Println(endpoint)
+
+	newClient.Service.SetServiceURL(endpoint)
+
+	return newClient
+}
+
+func AddConfigurationAggregatorInstanceFields(resource *schema.Resource) *schema.Resource {
+	resource.Schema["instance_id"] = &schema.Schema{
+		Type:        schema.TypeString,
+		Required:    true,
+		ForceNew:    true,
+		Description: "The ID of the configuration aggregator instance.",
+	}
+	resource.Schema["region"] = &schema.Schema{
+		Type:        schema.TypeString,
+		Optional:    true,
+		Computed:    true,
+		ForceNew:    true,
+		Description: "The region of the configuration aggregator instance.",
+	}
+	return resource
+}
+
+func updateClientURLWithInstanceEndpoint(id string, configsClient *configurationaggregatorv1.ConfigurationAggregatorV1, d *schema.ResourceData) (*configurationaggregatorv1.ConfigurationAggregatorV1, string, string, error) {
+
+	idList, err := flex.IdParts(id)
+	if err != nil || len(idList) < 2 {
+		return configsClient, "", "", fmt.Errorf("Invalid Id %s. Error: %s", id, err)
+	}
+
+	region := idList[0]
+	instanceId := idList[1]
+
+	configsClient = getClientWithConfigurationInstanceEndpoint(configsClient, instanceId, region)
+
+	return configsClient, region, instanceId, nil
+}

--- a/website/allowed-subcategories.txt
+++ b/website/allowed-subcategories.txt
@@ -9,6 +9,7 @@ Cloud Foundry
 Cloudant Databases
 Code Engine
 Container Registry
+Configuration Aggregator
 Context Based Restrictions
 CD Tekton Pipeline
 Direct Link Gateway

--- a/website/docs/d/config_aggregator_configurations.html.markdown
+++ b/website/docs/d/config_aggregator_configurations.html.markdown
@@ -14,13 +14,16 @@ Provides a read-only data source to retrieve information about config_aggregator
 
 ```hcl
 data "ibm_config_aggregator_configurations" "config_aggregator_configurations" {
+	instance_id=var.instance_id
+	region=var.region
 }
 ```
 
 ## Argument Reference
 
 You can specify the following arguments for this data source.
-
+* `instance_id` - (Required, Forces new resource, String) The GUID of the Configuration Aggregator instance.
+* `region` - (Optional, Forces new resource, String) The region of the Configuration Aggregator instance. If not provided defaults to the region defined in the IBM provider configuration.
 * `config_type` - (Optional, String) The type of resource configuration that are to be retrieved.
   * Constraints: The maximum length is `1024` characters. The minimum length is `1` character. The value must match regular expression `/^[a-zA-Z0-9 ,\\-_]+$/`.
 * `location` - (Optional, String) The location or region in which the resources are created.

--- a/website/docs/d/config_aggregator_configurations.html.markdown
+++ b/website/docs/d/config_aggregator_configurations.html.markdown
@@ -1,0 +1,70 @@
+---
+layout: "ibm"
+page_title: "IBM : ibm_config_aggregator_configurations"
+description: |-
+  Get information about config_aggregator_configurations
+subcategory: "Configuration Aggregator"
+---
+
+# ibm_config_aggregator_configurations
+
+Provides a read-only data source to retrieve information about config_aggregator_configurations. You can then reference the fields of the data source in other resources within the same configuration by using interpolation syntax.
+
+## Example Usage
+
+```hcl
+data "ibm_config_aggregator_configurations" "config_aggregator_configurations" {
+}
+```
+
+## Argument Reference
+
+You can specify the following arguments for this data source.
+
+* `config_type` - (Optional, String) The type of resource configuration that are to be retrieved.
+  * Constraints: The maximum length is `1024` characters. The minimum length is `1` character. The value must match regular expression `/^[a-zA-Z0-9 ,\\-_]+$/`.
+* `location` - (Optional, String) The location or region in which the resources are created.
+  * Constraints: The maximum length is `32` characters. The minimum length is `0` characters. The value must match regular expression `/^$|[a-z]-[a-z]/`.
+* `resource_crn` - (Optional, String) The crn of the resource.
+  * Constraints: The maximum length is `1000` characters. The minimum length is `1` character. The value must match regular expression `/^[a-zA-Z0-9.\\:\/-]+$/`.
+* `resource_group_id` - (Optional, String) The resource group id of the resources.
+  * Constraints: The maximum length is `32` characters. The minimum length is `0` characters. The value must match regular expression `/^[a-zA-Z0-9-]*$/`.
+* `service_name` - (Optional, String) The name of the IBM Cloud service for which resources are to be retrieved.
+  * Constraints: The maximum length is `1024` characters. The minimum length is `1` character. The value must match regular expression `/^[a-zA-Z0-9 ,\\-_]+$/`.
+
+## Attribute Reference
+
+After your data source is created, you can read values from the following attributes.
+
+* `id` - The unique identifier of the config_aggregator_configurations.
+* `configs` - (List) Array of resource configurations.
+  * Constraints: The maximum length is `100` items. The minimum length is `0` items.
+Nested schema for **configs**:
+	* `about` - (List) The basic metadata fetched from the query API.
+	Nested schema for **about**:
+		* `account_id` - (String) The account ID in which the resource exists.
+		  * Constraints: The maximum length is `32` characters. The minimum length is `0` characters. The value must match regular expression `/^[a-zA-Z0-9-]*$/`.
+		* `config_type` - (String) The type of configuration of the retrieved resource.
+		  * Constraints: The maximum length is `1000` characters. The minimum length is `1` character. The value must match regular expression `/^[a-zA-Z0-9.\\:\/-]+$/`.
+		* `last_config_refresh_time` - (String) Date/time stamp identifying when the information was last collected. Must be in the RFC 3339 format.
+		* `location` - (String) Location of the resource specified.
+		  * Constraints: The maximum length is `1000` characters. The minimum length is `0` characters. The value must match regular expression `/^$|[a-z]-[a-z]/`.
+		* `resource_crn` - (String) The unique CRN of the IBM Cloud resource.
+		  * Constraints: The maximum length is `1000` characters. The minimum length is `1` character. The value must match regular expression `/^[a-zA-Z0-9.\\:\/-]+$/`.
+		* `resource_group_id` - (String) The account ID.
+		  * Constraints: The maximum length is `32` characters. The minimum length is `0` characters. The value must match regular expression `/^[a-zA-Z0-9-]*$/`.
+		* `resource_name` - (String) User defined name of the resource.
+		  * Constraints: The maximum length is `1000` characters. The minimum length is `1` character. The value must match regular expression `/^[a-zA-Z0-9.\\:\/-]+$/`.
+		* `service_name` - (String) The name of the service to which the resources belongs.
+		  * Constraints: The maximum length is `1000` characters. The minimum length is `1` character. The value must match regular expression `/^[a-zA-Z0-9.\\:\/-]+$/`.
+		* `tags` - (List) Tags associated with the resource.
+		Nested schema for **tags**:
+			* `tag` - (String) The name of the tag.
+			  * Constraints: The maximum length is `32` characters. The minimum length is `0` characters. The value must match regular expression `/^[a-zA-Z0-9-]*$/`.
+	* `config` - (List) The configuration of the resource.
+	Nested schema for **config**:
+* `prev` - (List) The reference to the previous page of entries.
+Nested schema for **prev**:
+	* `href` - (String) The reference to the previous page of entries.
+	* `start` - (String) the start string for the query to view the page.
+

--- a/website/docs/d/config_aggregator_resource_collection_status.html.markdown
+++ b/website/docs/d/config_aggregator_resource_collection_status.html.markdown
@@ -14,6 +14,8 @@ Provides a read-only data source to retrieve information about config_aggregator
 
 ```hcl
 data "ibm_config_aggregator_resource_collection_status" "config_aggregator_resource_collection_status" {
+	instance_id=var.instance_id
+	region=var.region
 }
 ```
 
@@ -21,7 +23,8 @@ data "ibm_config_aggregator_resource_collection_status" "config_aggregator_resou
 ## Attribute Reference
 
 After your data source is created, you can read values from the following attributes.
-
+* `instance_id` - (Required, Forces new resource, String) The GUID of the Configuration Aggregator instance.
+* `region` - (Optional, Forces new resource, String) The region of the Configuration Aggregator instance. If not provided defaults to the region defined in the IBM provider configuration.
 * `id` - The unique identifier of the config_aggregator_resource_collection_status.
 * `last_config_refresh_time` - (String) The timestamp at which the configuration was last refreshed.
 * `status` - (String) Status of the resource collection.

--- a/website/docs/d/config_aggregator_resource_collection_status.html.markdown
+++ b/website/docs/d/config_aggregator_resource_collection_status.html.markdown
@@ -1,0 +1,29 @@
+---
+layout: "ibm"
+page_title: "IBM : ibm_config_aggregator_resource_collection_status"
+description: |-
+  Get information about config_aggregator_resource_collection_status
+subcategory: "Configuration Aggregator"
+---
+
+# ibm_config_aggregator_resource_collection_status
+
+Provides a read-only data source to retrieve information about config_aggregator_resource_collection_status. You can then reference the fields of the data source in other resources within the same configuration by using interpolation syntax.
+
+## Example Usage
+
+```hcl
+data "ibm_config_aggregator_resource_collection_status" "config_aggregator_resource_collection_status" {
+}
+```
+
+
+## Attribute Reference
+
+After your data source is created, you can read values from the following attributes.
+
+* `id` - The unique identifier of the config_aggregator_resource_collection_status.
+* `last_config_refresh_time` - (String) The timestamp at which the configuration was last refreshed.
+* `status` - (String) Status of the resource collection.
+  * Constraints: Allowable values are: `initiated`, `inprogress`, `complete`.
+

--- a/website/docs/d/config_aggregator_settings.html.markdown
+++ b/website/docs/d/config_aggregator_settings.html.markdown
@@ -40,7 +40,7 @@ Nested schema for **additional_scope**:
 	* `type` - (String) The type of scope. Currently allowed value is Enterprise.
 	  * Constraints: The maximum length is `64` characters. The minimum length is `0` characters. The value must match regular expression `/[a-zA-Z0-9]/`.
 * `last_updated` - (String) The last time the settings was last updated.
-* `regions` - (List) Regions for which the resource collection is enabled.
+* `resource_collection_regions` - (List) Regions for which the resource collection is enabled.
   * Constraints: The list items must match regular expression `/^[a-zA-Z0-9-]*$/`. The maximum length is `10` items. The minimum length is `0` items.
 * `resource_collection_enabled` - (Boolean) The field to check if the resource collection is enabled.
 * `trusted_profile_id` - (String) The trusted profile ID that provides access to App Configuration instance to retrieve resource metadata.

--- a/website/docs/d/config_aggregator_settings.html.markdown
+++ b/website/docs/d/config_aggregator_settings.html.markdown
@@ -2,73 +2,44 @@
 layout: "ibm"
 page_title: "IBM : ibm_config_aggregator_settings"
 description: |-
-  Manages config_aggregator_settings.
+  Get information about config_aggregator_settings
 subcategory: "Configuration Aggregator"
 ---
 
 # ibm_config_aggregator_settings
 
-Create, update, and delete config_aggregator_settingss with this resource.
+Provides a read-only data source to retrieve information about config_aggregator_settings. You can then reference the fields of the data source in other resources within the same configuration by using interpolation syntax.
 
 ## Example Usage
 
 ```hcl
-resource "ibm_config_aggregator_settings" "config_aggregator_settings_instance" {
-  additional_scope {
-		type = "Enterprise"
-		enterprise_id = "enterprise_id"
-		profile_template {
-			id = "ProfileTemplate-adb55769-ae22-4c60-aead-bd1f84f93c57"
-			trusted_profile_id = "Profile-6bb60124-8fc3-4d18-b63d-0b99560865d3"
-		}
-  }
-  regions = us-south
-  resource_collection_enabled = true
-  trusted_profile_id = "Profile-1260aec2-f2fc-44e2-8697-2cc15a447560"
+data "ibm_config_aggregator_settings" "config_aggregator_settings" {
 }
 ```
 
-## Argument Reference
-
-You can specify the following arguments for this resource.
-
-* `additional_scope` - (Optional, Forces new resource, List) The additional scope that enables resource collection for Enterprise acccounts.
-  * Constraints: The maximum length is `10` items. The minimum length is `0` items.
-Nested schema for **additional_scope**:
-	* `enterprise_id` - (Optional, String) The Enterprise ID.
-	  * Constraints: The maximum length is `32` characters. The minimum length is `0` characters. The value must match regular expression `/[a-zA-Z0-9]/`.
-	* `profile_template` - (Optional, List) The Profile Template details applied on the enterprise account.
-	Nested schema for **profile_template**:
-		* `id` - (Optional, String) The Profile Template ID created in the enterprise account that provides access to App Configuration instance for resource collection.
-		  * Constraints: The maximum length is `52` characters. The minimum length is `52` characters. The value must match regular expression `/[a-zA-Z0-9-]/`.
-		* `trusted_profile_id` - (Optional, String) The trusted profile ID that provides access to App Configuration instance to retrieve template information.
-		  * Constraints: The maximum length is `44` characters. The minimum length is `44` characters. The value must match regular expression `/^[a-zA-Z0-9-]*$/`.
-	* `type` - (Optional, String) The type of scope. Currently allowed value is Enterprise.
-	  * Constraints: The maximum length is `64` characters. The minimum length is `0` characters. The value must match regular expression `/[a-zA-Z0-9]/`.
-* `regions` - (Optional, Forces new resource, List) The list of regions across which the resource collection is enabled.
-  * Constraints: The list items must match regular expression `/^[a-zA-Z0-9-]*$/`. The maximum length is `10` items. The minimum length is `0` items.
-* `resource_collection_enabled` - (Optional, Forces new resource, Boolean) The field denoting if the resource collection is enabled.
-* `trusted_profile_id` - (Optional, Forces new resource, String) The trusted profile id that provides Reader access to the App Configuration instance to collect resource metadata.
-  * Constraints: The maximum length is `44` characters. The minimum length is `44` characters. The value must match regular expression `/^[a-zA-Z0-9-]*$/`.
 
 ## Attribute Reference
 
-After your resource is created, you can read values from the listed arguments and the following attributes.
+After your data source is created, you can read values from the following attributes.
 
 * `id` - The unique identifier of the config_aggregator_settings.
+* `additional_scope` - (List) The additional scope that enables resource collection for Enterprise acccounts.
+  * Constraints: The maximum length is `10` items. The minimum length is `0` items.
+Nested schema for **additional_scope**:
+	* `enterprise_id` - (String) The Enterprise ID.
+	  * Constraints: The maximum length is `32` characters. The minimum length is `0` characters. The value must match regular expression `/[a-zA-Z0-9]/`.
+	* `profile_template` - (List) The Profile Template details applied on the enterprise account.
+	Nested schema for **profile_template**:
+		* `id` - (String) The Profile Template ID created in the enterprise account that provides access to App Configuration instance for resource collection.
+		  * Constraints: The maximum length is `52` characters. The minimum length is `52` characters. The value must match regular expression `/[a-zA-Z0-9-]/`.
+		* `trusted_profile_id` - (String) The trusted profile ID that provides access to App Configuration instance to retrieve template information.
+		  * Constraints: The maximum length is `44` characters. The minimum length is `44` characters. The value must match regular expression `/^[a-zA-Z0-9-]*$/`.
+	* `type` - (String) The type of scope. Currently allowed value is Enterprise.
+	  * Constraints: The maximum length is `64` characters. The minimum length is `0` characters. The value must match regular expression `/[a-zA-Z0-9]/`.
+* `last_updated` - (String) The last time the settings was last updated.
+* `regions` - (List) Regions for which the resource collection is enabled.
+  * Constraints: The list items must match regular expression `/^[a-zA-Z0-9-]*$/`. The maximum length is `10` items. The minimum length is `0` items.
+* `resource_collection_enabled` - (Boolean) The field to check if the resource collection is enabled.
+* `trusted_profile_id` - (String) The trusted profile ID that provides access to App Configuration instance to retrieve resource metadata.
+  * Constraints: The maximum length is `44` characters. The minimum length is `44` characters. The value must match regular expression `/^[a-zA-Z0-9-]*$/`.
 
-
-## Import
-
-You can import the `ibm_config_aggregator_settings` resource by using `trusted_profile_id`. The trusted profile id that provides Reader access to the App Configuration instance to collect resource metadata.
-For more information, see [the documentation](https://cloud.ibm.com/docs/app-configuration)
-
-# Syntax
-<pre>
-$ terraform import ibm_config_aggregator_settings.config_aggregator_settings &lt;trusted_profile_id&gt;
-</pre>
-
-# Example
-```
-$ terraform import ibm_config_aggregator_settings.config_aggregator_settings Profile-6bb60124-8fc3-4d18-b63d-0b99560865d3
-```

--- a/website/docs/d/config_aggregator_settings.html.markdown
+++ b/website/docs/d/config_aggregator_settings.html.markdown
@@ -1,0 +1,74 @@
+---
+layout: "ibm"
+page_title: "IBM : ibm_config_aggregator_settings"
+description: |-
+  Manages config_aggregator_settings.
+subcategory: "Configuration Aggregator"
+---
+
+# ibm_config_aggregator_settings
+
+Create, update, and delete config_aggregator_settingss with this resource.
+
+## Example Usage
+
+```hcl
+resource "ibm_config_aggregator_settings" "config_aggregator_settings_instance" {
+  additional_scope {
+		type = "Enterprise"
+		enterprise_id = "enterprise_id"
+		profile_template {
+			id = "ProfileTemplate-adb55769-ae22-4c60-aead-bd1f84f93c57"
+			trusted_profile_id = "Profile-6bb60124-8fc3-4d18-b63d-0b99560865d3"
+		}
+  }
+  regions = us-south
+  resource_collection_enabled = true
+  trusted_profile_id = "Profile-1260aec2-f2fc-44e2-8697-2cc15a447560"
+}
+```
+
+## Argument Reference
+
+You can specify the following arguments for this resource.
+
+* `additional_scope` - (Optional, Forces new resource, List) The additional scope that enables resource collection for Enterprise acccounts.
+  * Constraints: The maximum length is `10` items. The minimum length is `0` items.
+Nested schema for **additional_scope**:
+	* `enterprise_id` - (Optional, String) The Enterprise ID.
+	  * Constraints: The maximum length is `32` characters. The minimum length is `0` characters. The value must match regular expression `/[a-zA-Z0-9]/`.
+	* `profile_template` - (Optional, List) The Profile Template details applied on the enterprise account.
+	Nested schema for **profile_template**:
+		* `id` - (Optional, String) The Profile Template ID created in the enterprise account that provides access to App Configuration instance for resource collection.
+		  * Constraints: The maximum length is `52` characters. The minimum length is `52` characters. The value must match regular expression `/[a-zA-Z0-9-]/`.
+		* `trusted_profile_id` - (Optional, String) The trusted profile ID that provides access to App Configuration instance to retrieve template information.
+		  * Constraints: The maximum length is `44` characters. The minimum length is `44` characters. The value must match regular expression `/^[a-zA-Z0-9-]*$/`.
+	* `type` - (Optional, String) The type of scope. Currently allowed value is Enterprise.
+	  * Constraints: The maximum length is `64` characters. The minimum length is `0` characters. The value must match regular expression `/[a-zA-Z0-9]/`.
+* `regions` - (Optional, Forces new resource, List) The list of regions across which the resource collection is enabled.
+  * Constraints: The list items must match regular expression `/^[a-zA-Z0-9-]*$/`. The maximum length is `10` items. The minimum length is `0` items.
+* `resource_collection_enabled` - (Optional, Forces new resource, Boolean) The field denoting if the resource collection is enabled.
+* `trusted_profile_id` - (Optional, Forces new resource, String) The trusted profile id that provides Reader access to the App Configuration instance to collect resource metadata.
+  * Constraints: The maximum length is `44` characters. The minimum length is `44` characters. The value must match regular expression `/^[a-zA-Z0-9-]*$/`.
+
+## Attribute Reference
+
+After your resource is created, you can read values from the listed arguments and the following attributes.
+
+* `id` - The unique identifier of the config_aggregator_settings.
+
+
+## Import
+
+You can import the `ibm_config_aggregator_settings` resource by using `trusted_profile_id`. The trusted profile id that provides Reader access to the App Configuration instance to collect resource metadata.
+For more information, see [the documentation](https://cloud.ibm.com/docs/app-configuration)
+
+# Syntax
+<pre>
+$ terraform import ibm_config_aggregator_settings.config_aggregator_settings &lt;trusted_profile_id&gt;
+</pre>
+
+# Example
+```
+$ terraform import ibm_config_aggregator_settings.config_aggregator_settings Profile-6bb60124-8fc3-4d18-b63d-0b99560865d3
+```

--- a/website/docs/d/config_aggregator_settings.html.markdown
+++ b/website/docs/d/config_aggregator_settings.html.markdown
@@ -14,6 +14,8 @@ Provides a read-only data source to retrieve information about config_aggregator
 
 ```hcl
 data "ibm_config_aggregator_settings" "config_aggregator_settings" {
+	instance_id=var.instance_id
+	region=var.region	
 }
 ```
 
@@ -21,7 +23,8 @@ data "ibm_config_aggregator_settings" "config_aggregator_settings" {
 ## Attribute Reference
 
 After your data source is created, you can read values from the following attributes.
-
+* `instance_id` - (Required, Forces new resource, String) The GUID of the Configuration Aggregator instance.
+* `region` - (Optional, Forces new resource, String) The region of the Configuration Aggregator instance. If not provided defaults to the region defined in the IBM provider configuration.
 * `id` - The unique identifier of the config_aggregator_settings.
 * `additional_scope` - (List) The additional scope that enables resource collection for Enterprise acccounts.
   * Constraints: The maximum length is `10` items. The minimum length is `0` items.

--- a/website/docs/r/config_aggregator_settings.html.markdown
+++ b/website/docs/r/config_aggregator_settings.html.markdown
@@ -45,10 +45,10 @@ Nested schema for **additional_scope**:
 		  * Constraints: The maximum length is `44` characters. The minimum length is `44` characters. The value must match regular expression `/^[a-zA-Z0-9-]*$/`.
 	* `type` - (Optional, String) The type of scope. Currently allowed value is Enterprise.
 	  * Constraints: The maximum length is `64` characters. The minimum length is `0` characters. The value must match regular expression `/[a-zA-Z0-9]/`.
-* `regions` - (Required, Forces new resource, List) The list of regions across which the resource collection is enabled.
+* `regions` - (Optional, Forces new resource, List) The list of regions across which the resource collection is enabled.
   * Constraints: The list items must match regular expression `/^[a-zA-Z0-9-]*$/`. The maximum length is `10` items. The minimum length is `0` items.
-* `resource_collection_enabled` - (Required, Forces new resource, Boolean) The field denoting if the resource collection is enabled.
-* `trusted_profile_id` - (Required, Forces new resource, String) The trusted profile id that provides Reader access to the App Configuration instance to collect resource metadata.
+* `resource_collection_enabled` - (Optional, Forces new resource, Boolean) The field denoting if the resource collection is enabled.
+* `trusted_profile_id` - (Optional, Forces new resource, String) The trusted profile id that provides Reader access to the App Configuration instance to collect resource metadata.
   * Constraints: The maximum length is `44` characters. The minimum length is `44` characters. The value must match regular expression `/^[a-zA-Z0-9-]*$/`.
 
 ## Attribute Reference

--- a/website/docs/r/config_aggregator_settings.html.markdown
+++ b/website/docs/r/config_aggregator_settings.html.markdown
@@ -1,0 +1,74 @@
+---
+layout: "ibm"
+page_title: "IBM : ibm_config_aggregator_settings"
+description: |-
+  Manages config_aggregator_settings.
+subcategory: "Configuration Aggregator"
+---
+
+# ibm_config_aggregator_settings
+
+Create, update, and delete config_aggregator_settingss with this resource.
+
+## Example Usage
+
+```hcl
+resource "ibm_config_aggregator_settings" "config_aggregator_settings_instance" {
+  additional_scope {
+		type = "Enterprise"
+		enterprise_id = "enterprise_id"
+		profile_template {
+			id = "ProfileTemplate-adb55769-ae22-4c60-aead-bd1f84f93c57"
+			trusted_profile_id = "Profile-6bb60124-8fc3-4d18-b63d-0b99560865d3"
+		}
+  }
+  regions = us-south
+  resource_collection_enabled = true
+  trusted_profile_id = "Profile-1260aec2-f2fc-44e2-8697-2cc15a447560"
+}
+```
+
+## Argument Reference
+
+You can specify the following arguments for this resource.
+
+* `additional_scope` - (Optional, Forces new resource, List) The additional scope that enables resource collection for Enterprise acccounts.
+  * Constraints: The maximum length is `10` items. The minimum length is `0` items.
+Nested schema for **additional_scope**:
+	* `enterprise_id` - (Optional, String) The Enterprise ID.
+	  * Constraints: The maximum length is `32` characters. The minimum length is `0` characters. The value must match regular expression `/[a-zA-Z0-9]/`.
+	* `profile_template` - (Optional, List) The Profile Template details applied on the enterprise account.
+	Nested schema for **profile_template**:
+		* `id` - (Optional, String) The Profile Template ID created in the enterprise account that provides access to App Configuration instance for resource collection.
+		  * Constraints: The maximum length is `52` characters. The minimum length is `52` characters. The value must match regular expression `/[a-zA-Z0-9-]/`.
+		* `trusted_profile_id` - (Optional, String) The trusted profile ID that provides access to App Configuration instance to retrieve template information.
+		  * Constraints: The maximum length is `44` characters. The minimum length is `44` characters. The value must match regular expression `/^[a-zA-Z0-9-]*$/`.
+	* `type` - (Optional, String) The type of scope. Currently allowed value is Enterprise.
+	  * Constraints: The maximum length is `64` characters. The minimum length is `0` characters. The value must match regular expression `/[a-zA-Z0-9]/`.
+* `regions` - (Required, Forces new resource, List) The list of regions across which the resource collection is enabled.
+  * Constraints: The list items must match regular expression `/^[a-zA-Z0-9-]*$/`. The maximum length is `10` items. The minimum length is `0` items.
+* `resource_collection_enabled` - (Required, Forces new resource, Boolean) The field denoting if the resource collection is enabled.
+* `trusted_profile_id` - (Required, Forces new resource, String) The trusted profile id that provides Reader access to the App Configuration instance to collect resource metadata.
+  * Constraints: The maximum length is `44` characters. The minimum length is `44` characters. The value must match regular expression `/^[a-zA-Z0-9-]*$/`.
+
+## Attribute Reference
+
+After your resource is created, you can read values from the listed arguments and the following attributes.
+
+* `id` - The unique identifier of the config_aggregator_settings.
+
+
+## Import
+
+You can import the `ibm_config_aggregator_settings` resource by using `trusted_profile_id`. The trusted profile id that provides Reader access to the App Configuration instance to collect resource metadata.
+For more information, see [the documentation](https://cloud.ibm.com/docs/app-configuration)
+
+# Syntax
+<pre>
+$ terraform import ibm_config_aggregator_settings.config_aggregator_settings &lt;trusted_profile_id&gt;
+</pre>
+
+# Example
+```
+$ terraform import ibm_config_aggregator_settings.config_aggregator_settings Profile-6bb60124-8fc3-4d18-b63d-0b99560865d3
+```

--- a/website/docs/r/config_aggregator_settings.html.markdown
+++ b/website/docs/r/config_aggregator_settings.html.markdown
@@ -24,7 +24,7 @@ resource "ibm_config_aggregator_settings" "config_aggregator_settings_instance" 
 			trusted_profile_id = "Profile-6bb60124-8fc3-4d18-b63d-0b99560865d3"
 		}
   }
-  regions = us-south
+  resource_collection_regions = us-south
   resource_collection_enabled = true
   trusted_profile_id = "Profile-1260aec2-f2fc-44e2-8697-2cc15a447560"
 }
@@ -34,7 +34,7 @@ resource "ibm_config_aggregator_settings" "config_aggregator_settings_instance" 
 
 You can specify the following arguments for this resource.
 * `instance_id` - (Required, Forces new resource, String) The GUID of the Configuration Aggregator instance.
-* `region` - (Optional, Forces new resource, String) The region of the Configuration Aggregator instance. If not provided defaults to the region defined in the IBM provider configuration.
+* `resource_collection_regions` - (Optional, Forces new resource, String) The region of the Configuration Aggregator instance. If not provided defaults to the region defined in the IBM provider configuration.
 * `additional_scope` - (Optional, Forces new resource, List) The additional scope that enables resource collection for Enterprise acccounts.
   * Constraints: The maximum length is `10` items. The minimum length is `0` items.
 Nested schema for **additional_scope**:

--- a/website/docs/r/config_aggregator_settings.html.markdown
+++ b/website/docs/r/config_aggregator_settings.html.markdown
@@ -14,6 +14,8 @@ Create, update, and delete config_aggregator_settingss with this resource.
 
 ```hcl
 resource "ibm_config_aggregator_settings" "config_aggregator_settings_instance" {
+  instance_id=var.instance_id
+  region=var.region
   additional_scope {
 		type = "Enterprise"
 		enterprise_id = "enterprise_id"
@@ -31,7 +33,8 @@ resource "ibm_config_aggregator_settings" "config_aggregator_settings_instance" 
 ## Argument Reference
 
 You can specify the following arguments for this resource.
-
+* `instance_id` - (Required, Forces new resource, String) The GUID of the Configuration Aggregator instance.
+* `region` - (Optional, Forces new resource, String) The region of the Configuration Aggregator instance. If not provided defaults to the region defined in the IBM provider configuration.
 * `additional_scope` - (Optional, Forces new resource, List) The additional scope that enables resource collection for Enterprise acccounts.
   * Constraints: The maximum length is `10` items. The minimum length is `0` items.
 Nested schema for **additional_scope**:


### PR DESCRIPTION
git issue : https://github.ibm.com/devx-app-services/configuration-aggregator-planning/issues/326


terraform output 

```
ramyac@Ramyas-MacBook-Pro ibm-configuration-aggregator % terraform apply
ibm_config_aggregator_settings.config_aggregator_settings_instance: Refreshing state... [id=Profile-7d935dbb-7ee5-44e1-9e85-38e65d722398]

Changes to Outputs:
  + config_aggregator_settings       = {
      + additional_scope            = []
      + last_updated                = "2024-09-20T06:18:06Z"
      + regions                     = [
          + "all",
        ]
      + resource_collection_enabled = true
      + trusted_profile_id          = "Profile-7d935dbb-7ee5-44e1-9e85-38e65d722398"
    }
  - config_aggregator_settings_clean = {
      - additional_scope            = []
      - regions                     = [
          - "all",
        ]
      - resource_collection_enabled = true
      - trusted_profile_id          = "Profile-7d935dbb-7ee5-44e1-9e85-38e65d722398"
    } -> null

You can apply this plan to save these new output values to the Terraform state, without changing any real infrastructure.

Do you want to perform these actions?
  Terraform will perform the actions described above.
  Only 'yes' will be accepted to approve.

  Enter a value: yes


Apply complete! Resources: 1 added, 0 changed, 0 destroyed.

Outputs:

config_aggregator_settings = {
  "additional_scope" = []
  "last_updated" = "2024-09-20T06:18:06Z"
  "regions" = [
    "all",
  ]
  "resource_collection_enabled" = true
  "trusted_profile_id" = "Profile-7d935dbb-7ee5-44e1-9e85-38e65d722398"
}
```



the test case o/p 


```

[WARN] Set the environment variable IBM_PROJECTS_CONFIG_APIKEY for testing IBM Projects Config resources, the tests will fail if this is not set
[WARN] Set the environment variable IBM_APPID_TENANT_ID for testing AppID resources, AppID tests will fail if this is not set
[WARN] Set the environment variable IBM_APPID_TEST_USER_EMAIL for testing AppID user resources, the tests will fail if this is not set
[WARN] Set the environment variable IBM_ORG for testing ibm_org  resource Some tests for that resource will fail if this is not set correctly
[WARN] Set the environment variable IBM_SPACE for testing ibm_space  resource Some tests for that resource will fail if this is not set correctly
[WARN] Set the environment variable IBM_ID1 for testing ibm_space resource Some tests for that resource will fail if this is not set correctly
[WARN] Set the environment variable IBM_ID2 for testing ibm_space resource Some tests for that resource will fail if this is not set correctly
[WARN] Set the environment variable IBM_IAMUSER for testing ibm_iam_user_policy resource Some tests for that resource will fail if this is not set correctly
[WARN] Set the environment variable IBM_IAMACCOUNTID for testing ibm_iam_trusted_profile resource Some tests for that resource will fail if this is not set correctly
[WARN] Set the environment variable IBM_IAM_SERVICE_ID for testing ibm_iam_trusted_profile_identity resource Some tests for that resource will fail if this is not set correctly
[WARN] Set the environment variable IBM_IAM_TRUSTED_PROFILE_ID for testing ibm_iam_trusted_profile_identity resource Some tests for that resource will fail if this is not set correctly
[WARN] Set the environment variable IBM_DATACENTER for testing ibm_container_cluster resource else it is set to default value 'par01'
[WARN] Set the environment variable IBM_MACHINE_TYPE for testing ibm_container_cluster resource else it is set to default value 'b3c.4x16'
[WARN] Set the environment variable IBM_CERT_CRN for testing ibm_container_alb_cert or ibm_container_ingress_secret_tls resource else it is set to default value
[WARN] Set the environment variable IBM_UPDATE_CERT_CRN for testing ibm_container_alb_cert or ibm_container_ingress_secret_tls resource else it is set to default value
[WARN] Set the environment variable IBM_SECRET_CRN for testing ibm_container_ingress_secret_opaque resource else it is set to default value
[WARN] Set the environment variable IBM_SECRET_CRN_2 for testing ibm_container_ingress_secret_opaque resource else it is set to default value
[WARN] Set the environment variable IBM_INGRESS_INSTANCE_CRN for testing ibm_container_ingress_instance resource. Some tests for that resource will fail if this is not set correctly
[WARN] Set the environment variable IBM_INGRESS_INSTANCE_SECRET_GROUP_ID for testing ibm_container_ingress_instance resource. Some tests for that resource will fail if this is not set correctly
[WARN] Set the environment variable IBM_CONTAINER_REGION for testing ibm_container resources else it is set to default value 'eu-de'
[WARN] Set the environment variable IBM_CIS_INSTANCE with a VALID CIS Instance NAME for testing ibm_cis resources on staging/test
[WARN] Set the environment variable IBM_CIS_DOMAIN_STATIC with the Domain name registered with the CIS instance on test/staging. Domain must be predefined in CIS to avoid CIS billing costs due to domain delete/create
[WARN] Set the environment variable IBM_CIS_DOMAIN_TEST with a VALID Domain name for testing the one time create and delete of a domain in CIS. Note each create/delete will trigger a monthly billing instance. Only to be run in staging/test
[WARN] Set the environment variable IBM_CIS_RESOURCE_GROUP with the resource group for the CIS Instance 
[WARN] Set the environment variable IBM_COS_CRN with a VALID COS instance CRN for testing ibm_cos_* resources
[WARN] Set the environment variable IBM_COS_Bucket_CRN with a VALID BUCKET CRN for testing ibm_cos_bucket* resources
[WARN] Set the environment variable IBM_COS_ACTIVITY_TRACKER_CRN with a VALID ACTIVITY TRACKER INSTANCE CRN in valid region for testing ibm_cos_bucket* resources
[WARN] Set the environment variable IBM_COS_METRICS_MONITORING_CRN with a VALID METRICS MONITORING CRN for testing ibm_cos_bucket* resources
[WARN] Set the environment variable IBM_COS_BUCKET_NAME with a VALID BUCKET Name for testing ibm_cos_bucket* resources
[WARN] Set the environment variable IBM_COS_NAME with a VALID COS instance name for testing resources with cos deps
[WARN] Set the environment variable IBM_TRUSTED_MACHINE_TYPE for testing ibm_container_cluster resource else it is set to default value 'mb1c.16x64'
[WARN] Set the environment variable IBM_BM_EXTENDED_HW_TESTING to true/false for testing ibm_compute_bare_metal resource else it is set to default value 'false'
[WARN] Set the environment variable IBM_PUBLIC_VLAN_ID for testing ibm_container_cluster resource else it is set to default value '2393319'
[WARN] Set the environment variable IBM_PRIVATE_VLAN_ID for testing ibm_container_cluster resource else it is set to default value '2393321'
[WARN] Set the environment variable IBM_KUBE_VERSION for testing ibm_container_cluster resource else it is set to default value '1.18.14'
[WARN] Set the environment variable IBM_KUBE_UPDATE_VERSION for testing ibm_container_cluster resource else it is set to default value '1.19.6'
[WARN] Set the environment variable IBM_PRIVATE_SUBNET_ID for testing ibm_container_cluster resource else it is set to default value '1636107'
[WARN] Set the environment variable IBM_PUBLIC_SUBNET_ID for testing ibm_container_cluster resource else it is set to default value '1165645'
[WARN] Set the environment variable IBM_SUBNET_ID for testing ibm_container_cluster resource else it is set to default value '1165645'
[INFO] Set the environment variable IBM_IPSEC_DATACENTER for testing ibm_ipsec_vpn resource else it is set to default value 'tok02'
[INFO] Set the environment variable IBM_IPSEC_CUSTOMER_SUBNET_ID for testing ibm_ipsec_vpn resource else it is set to default value '123456'
[INFO] Set the environment variable IBM_IPSEC_CUSTOMER_PEER_IP for testing ibm_ipsec_vpn resource else it is set to default value '192.168.0.1'
[WARN] Set the environment variable IBM_LBAAS_DATACENTER for testing ibm_lbaas resource else it is set to default value 'dal13'
[WARN] Set the environment variable IBM_LBAAS_SUBNETID for testing ibm_lbaas resource else it is set to default value '2144241'
[WARN] Set the environment variable IBM_LB_LISTENER_CERTIFICATE_INSTANCE for testing ibm_is_lb_listener resource for https redirect else it is set to default value 'crn:v1:staging:public:cloudcerts:us-south:a/2d1bace7b46e4815a81e52c6ffeba5cf:af925157-b125-4db2-b642-adacb8b9c7f5:certificate:c81627a1bf6f766379cc4b98fd2a44ed'
[WARN] Set the environment variable IBM_DEDICATED_HOSTNAME for testing ibm_compute_vm_instance resource else it is set to default value 'terraform-dedicatedhost'
[WARN] Set the environment variable IBM_DEDICATED_HOST_ID for testing ibm_compute_vm_instance resource else it is set to default value '30301'
[WARN] Set the environment variable IBM_WORKER_POOL_ZONE for testing ibm_container_worker_pool_zone_attachment resource else it is set to default value 'ams03'
[WARN] Set the environment variable IBM_WORKER_POOL_ZONE_PRIVATE_VLAN for testing ibm_container_worker_pool_zone_attachment resource else it is set to default value '2538975'
[WARN] Set the environment variable IBM_WORKER_POOL_ZONE_PUBLIC_VLAN for testing ibm_container_worker_pool_zone_attachment resource else it is set to default value '2538967'
[WARN] Set the environment variable IBM_WORKER_POOL_ZONE_UPDATE_PRIVATE_VLAN for testing ibm_container_worker_pool_zone_attachment resource else it is set to default value '2388377'
[WARN] Set the environment variable IBM_WORKER_POOL_ZONE_UPDATE_PUBLIC_VLAN for testing ibm_container_worker_pool_zone_attachment resource else it is set to default value '2388375'
[WARN] Set the environment variable IBM_WORKER_POOL_SECONDARY_STORAGE for testing secondary_storage attachment to IKS workerpools
[WARN] Set the environment variable IBM_PLACEMENT_GROUP_NAME for testing ibm_compute_vm_instance resource else it is set to default value 'terraform-group'
[INFO] Set the environment variable SL_REGION for testing ibm_is_region datasource else it is set to default value 'us-south'
[INFO] Set the environment variable SL_ZONE for testing ibm_is_zone datasource else it is set to default value 'us-south-1'
[INFO] Set the environment variable SL_ZONE_2 for testing ibm_is_zone datasource else it is set to default value 'us-south-2'
[INFO] Set the environment variable SL_ZONE_3 for testing ibm_is_zone datasource else it is set to default value 'us-south-3'
[INFO] Set the environment variable SL_CIDR for testing ibm_is_subnet else it is set to default value '10.240.0.0/24'
[INFO] Set the environment variable SL_CIDR_2 for testing ibm_is_subnet else it is set to default value '10.240.64.0/24'
[INFO] Set the environment variable SL_CIDR_2 for testing ibm_is_subnet else it is set to default value '10.240.64.0/24'
[INFO] Set the environment variable SL_CIDR_2 for testing ibm_is_instance datasource else it is set to default value './test-fixtures/.ssh/pkcs8_rsa.pub'
[INFO] Set the environment variable IS_PRIVATE_SSH_KEY_PATH for testing ibm_is_instance datasource else it is set to default value './test-fixtures/.ssh/pkcs8_rsa'
[INFO] Set the environment variable SL_RESOURCE_GROUP_ID for testing with different resource group id else it is set to default value 'c01d34dff4364763476834c990398zz8'
[INFO] Set the environment variable IS_RESOURCE_CRN for testing with created resource instance
[INFO] Set the environment variable IS_IMAGE for testing ibm_is_instance, ibm_is_floating_ip else it is set to default value 'r006-907911a7-0ffe-467e-8821-3cc9a0d82a39'
[INFO] Set the environment variable IS_IMAGE2 for testing ibm_is_instance, ibm_is_floating_ip else it is set to default value 'r134-f47cc24c-e020-4db5-ad96-1e5be8b5853b'
[INFO] Set the environment variable IS_WIN_IMAGE for testing ibm_is_instance data source else it is set to default value 'r006-d2e0d0e9-0a4f-4c45-afd7-cab787030776'
[INFO] Set the environment variable IS_COS_BUCKET_NAME for testing ibm_is_image_export_job else it is set to default value 'bucket-27200-lwx4cfvcue'
[INFO] Set the environment variable IS_COS_BUCKET_CRN for testing ibm_is_image_export_job else it is set to default value 'bucket-27200-lwx4cfvcue'
[INFO] Set the environment variable IS_INSTANCE_NAME for testing ibm_is_instance resource else it is set to default value 'instance-01'
[INFO] Set the environment variable IS_BACKUP_POLICY_JOB_ID for testing ibm_is_backup_policy_job datasource
[INFO] Set the environment variable IS_BACKUP_POLICY_ID for testing ibm_is_backup_policy_jobs datasource
[INFO] Set the environment variable IS_REMOTE_CP_BAAS_ENCRYPTION_KEY_CRN for testing remote_copies_policy with Baas plans, else it is set to default value, 'crn:v1:bluemix:public:kms:us-south:a/dffc98a0f1f0f95f6613b3b752286b87:e4a29d1a-2ef0-42a6-8fd2-350deb1c647e:key:5437653b-c4b1-447f-9646-b2a2a4cd6179'
[INFO] Set the environment variable SL_INSTANCE_PROFILE for testing ibm_is_instance resource else it is set to default value 'cx2-2x4'
[INFO] Set the environment variable SL_KMS_INSTANCE_ID for testing ibm_kms_key resource else it is set to default value '30222bb5-1c6d-3834-8d78-ae6348cf8z61'
[INFO] Set the environment variable SL_KMS_KEY_NAME for testing ibm_kms_key resource else it is set to default value 'tfp-test-key'
[INFO] Set the environment variable SL_INSTANCE_PROFILE_UPDATE for testing ibm_is_instance resource else it is set to default value 'cx2-4x8'
[INFO] Set the environment variable IS_BARE_METAL_SERVER_PROFILE for testing ibm_is_bare_metal_server resource else it is set to default value 'bx2-metal-96x384'
[INFO] Set the environment variable IsBareMetalServerImage for testing ibm_is_bare_metal_server resource else it is set to default value 'r006-2d1f36b0-df65-4570-82eb-df7ae5f778b1'
[INFO] Set the environment variable IsBareMetalServerImage2 for testing ibm_is_bare_metal_server resource else it is set to default value 'r006-2d1f36b0-df65-4570-82eb-df7ae5f778b1'
[INFO] Set the environment variable IS_DNS_INSTANCE_CRN for testing ibm_is_lb resource else it is set to default value 'crn:v1:staging:public:dns-svcs:global:a/efe5afc483594adaa8325e2b4d1290df:82df2e3c-53a5-43c6-89ce-dcf78be18668::'
[INFO] Set the environment variable IS_DNS_INSTANCE_CRN1 for testing ibm_is_lb resource else it is set to default value 'crn:v1:staging:public:dns-svcs:global:a/efe5afc483594adaa8325e2b4d1290df:599ae4aa-c554-4a88-8bb2-b199b9a3c046::'
[INFO] Set the environment variable IS_DNS_ZONE_ID for testing ibm_is_lb resource else it is set to default value 'dd501d1d-490b-4bb4-a05d-a31954a1c59e'
[INFO] Set the environment variable IS_DNS_ZONE_ID_1 for testing ibm_is_lb resource else it is set to default value 'b1def78d-51b3-4ea5-a746-1b64c992fcab'
[INFO] Set the environment variable IS_DEDICATED_HOST_NAME for testing ibm_is_instance resource else it is set to default value 'tf-dhost-01'
[INFO] Set the environment variable IS_DEDICATED_HOST_GROUP_ID for testing ibm_is_instance resource else it is set to default value '0717-9104e7b5-77ad-44ad-9eaa-091e6b6efce1'
[INFO] Set the environment variable IS_DEDICATED_HOST_PROFILE for testing ibm_is_instance resource else it is set to default value 'bx2d-host-152x608'
[INFO] Set the environment variable IS_DEDICATED_HOST_GROUP_CLASS for testing ibm_is_instance resource else it is set to default value 'bx2d'
[INFO] Set the environment variable IS_DEDICATED_HOST_GROUP_FAMILY for testing ibm_is_instance resource else it is set to default value 'balanced'
[INFO] Set the environment variable SL_INSTANCE_PROFILE for testing ibm_is_instance resource else it is set to default value 'bx2d-16x64'
[INFO] Set the environment variable IS_SHARE_PROFILE for testing ibm_is_instance resource else it is set to default value 'tier-3iops'
[INFO] Set the environment variable IS_SHARE_PROFILE for testing ibm_is_instance resource else it is set to default value
[INFO] Set the environment variable IS_SHARE_PROFILE for testing ibm_is_instance resource else it is set to default value
[INFO] Set the environment variable IS_VOLUME_PROFILE for testing ibm_is_volume_profile else it is set to default value 'general-purpose'
[INFO] Set the environment variable IS_VIRTUAL_NETWORK_INTERFACE for testing ibm_is_virtual_network_interface else it is set to default value 'c93dc4c6-e85a-4da2-9ea6-f24576256122'
[INFO] Set the environment variable IS_UNATTACHED_BOOT_VOLUME_NAME for testing ibm_is_image else it is set to default value 'r006-1cbe9f0a-7101-4d25-ae72-2a2d725e530e'
[INFO] Set the environment variable IS_VSI_DATA_VOLUME_ID for testing ibm_is_image else it is set to default value 'r006-1cbe9f0a-7101-4d25-ae72-2a2d725e530e'
[INFO] Set the environment variable SL_ROUTE_NEXTHOP else it is set to default value '10.0.0.4'
[INFO] Set the environment variable ISSnapshotCRN for ibm_is_snapshot resource else it is set to default value 'crn:v1:bluemix:public:is:ca-tor:a/xxxxxxxx::snapshot:xxxx-xxxxc-xxx-xxxx-xxxx-xxxxxxxxxx'
[INFO] Set the environment variable ICD_DB_DEPLOYMENT_ID for testing ibm_cloud_databases else it is set to default value 'crn:v1:bluemix:public:databases-for-redis:au-syd:a/40ddc34a953a8c02f10987b59085b60e:5042afe1-72c2-4231-89cc-c949e5d56251::'
[INFO] Set the environment variable ICD_DB_BACKUP_ID for testing ibm_cloud_databases else it is set to default value 'crn:v1:bluemix:public:databases-for-redis:au-syd:a/40ddc34a953a8c02f10987b59085b60e:5042afe1-72c2-4231-89cc-c949e5d56251:backup:0d862fdb-4faa-42e5-aecb-5057f4d399c3'
[INFO] Set the environment variable ICD_DB_TASK_ID for testing ibm_cloud_databases else it is set to default value 'crn:v1:bluemix:public:databases-for-redis:au-syd:a/40ddc34a953a8c02f10987b59085b60e:367b0a22-05bb-41e3-a1ed-ded1ff0889e5:task:882013a6-2751-4df7-a77a-98d258638704'
[INFO] Set the environment variable PI_IMAGE for testing ibm_pi_image resource else it is set to default value '7200-03-03'
[INFO] Set the environment variable PI_SAP_IMAGE for testing ibm_pi_image resource else it is set to default value 'Linux-RHEL-SAP-8-2'
[INFO] Set the environment variable PI_IMAGE_BUCKET_NAME for testing ibm_pi_image resource else it is set to default value 'images-public-bucket'
[INFO] Set the environment variable PI_IMAGE_BUCKET_FILE_NAME for testing ibm_pi_image resource else it is set to default value 'rhel.ova.gz'
[INFO] Set the environment variable PI_IMAGE_BUCKET_ACCESS_KEY for testing ibm_pi_image_export resource else it is set to default value 'images-bucket-access-key'
[INFO] Set the environment variable PI_IMAGE_BUCKET_SECRET_KEY for testing ibm_pi_image_export resource else it is set to default value 'PI_IMAGE_BUCKET_SECRET_KEY'
[INFO] Set the environment variable PI_IMAGE_BUCKET_REGION for testing ibm_pi_image_export resource else it is set to default value 'us-east'
[INFO] Set the environment variable PI_KEY_NAME for testing ibm_pi_key_name resource else it is set to default value 'terraform-test-power'
[INFO] Set the environment variable PI_NETWORK_NAME for testing ibm_pi_network_name resource else it is set to default value 'terraform-test-power'
[INFO] Set the environment variable PI_VOLUME_NAME for testing ibm_pi_network_name resource else it is set to default value 'terraform-test-power'
[INFO] Set the environment variable PI_VOLUME_ID for testing ibm_pi_volume_flash_copy_mappings resource else it is set to default value 'terraform-test-power'
[INFO] Set the environment variable PI_REPLICATION_VOLUME_NAME for testing ibm_pi_volume resource else it is set to default value 'terraform-test-power'
[INFO] Set the environment variable PI_VOLUME_ONBARDING_SOURCE_CRN for testing ibm_pi_volume_onboarding resource else it is set to default value 'terraform-test-power'
[INFO] Set the environment variable PI_AUXILIARY_VOLUME_NAME for testing ibm_pi_volume_onboarding resource else it is set to default value 'terraform-test-power'
[INFO] Set the environment variable PI_VOLUME_GROUP_NAME for testing ibm_pi_volume_group resource else it is set to default value 'terraform-test-power'
[INFO] Set the environment variable PI_VOLUME_GROUP_ID for testing ibm_pi_volume_group_storage_details data source else it is set to default value 'terraform-test-power'
[INFO] Set the environment variable PI_VOLUME_ONBOARDING_ID for testing ibm_pi_volume_onboarding resource else it is set to default value 'terraform-test-power'
[INFO] Set the environment variable PI_CLOUDINSTANCE_ID for testing ibm_pi_image resource else it is set to default value 'd16705bd-7f1a-48c9-9e0e-1c17b71e7331'
[INFO] Set the environment variable PI_SNAPSHOT_ID for testing ibm_pi_instance_snapshot data source else it is set to default value '1ea33118-4c43-4356-bfce-904d0658de82'
[INFO] Set the environment variable PI_PVM_INSTANCE_ID for testing Pi_instance_name resource else it is set to default value 'terraform-test-power'
[INFO] Set the environment variable PI_DHCP_ID for testing ibm_pi_dhcp resource else it is set to default value 'terraform-test-power'
[INFO] Set the environment variable PI_CLOUD_CONNECTION_NAME for testing ibm_pi_cloud_connection resource else it is set to default value 'terraform-test-power'
[INFO] Set the environment variable PI_SAP_PROFILE_ID for testing ibm_pi_sap_profile resource else it is set to default value 'terraform-test-power'
[WARN] Set the environment variable PI_PLACEMENT_GROUP_NAME for testing ibm_pi_placement_group resource else it is set to default value 'tf-pi-placement-group'
[WARN] Set the environment variable PI_SPP_PLACEMENT_GROUP_ID for testing ibm_pi_spp_placement_group resource else it is set to default value 'tf-pi-spp-placement-group'
[INFO] Set the environment variable PI_STORAGE_POOL for testing ibm_pi_storage_pool_capacity else it is set to default value 'terraform-test-power'
[INFO] Set the environment variable PI_STORAGE_TYPE for testing ibm_pi_storage_type_capacity else it is set to default value 'terraform-test-power'
[INFO] Set the environment variable PI_CAPTURE_STORAGE_IMAGE_PATH for testing Pi_capture_storage_image_path resource else it is set to default value 'terraform-test-power'
[INFO] Set the environment variable PI_CAPTURE_CLOUD_STORAGE_ACCESS_KEY for testing Pi_capture_cloud_storage_access_key resource else it is set to default value 'terraform-test-power'
[INFO] Set the environment variable PI_CAPTURE_CLOUD_STORAGE_SECRET_KEY for testing Pi_capture_cloud_storage_secret_key resource else it is set to default value 'terraform-test-power'
[WARN] Set the environment variable PI_SHARED_PROCESSOR_POOL_ID for testing ibm_pi_shared_processor_pool resource else it is set to default value 'tf-pi-shared-processor-pool'
[INFO] Set the environment variable PI_TARGET_STORAGE_TIER for testing Pi_target_storage_tier resource else it is set to default value 'terraform-test-tier'
[INFO] Set the environment variable PI_VOLUME_CLONE_TASK_ID for testing Pi_volume_clone_task_id resource else it is set to default value 'terraform-test-volume-clone-task-id'
[WARN] Set the environment variable PI_RESOURCE_GROUP_ID for testing ibm_pi_workspace resource else it is set to default value ''
[WARN] Set the environment variable PI_HOST_GROUP_ID for testing ibm_pi_host resource else it is set to default value ''
[WARN] Set the environment variable PI_HOST_ID for testing ibm_pi_host resource else it is set to default value ''
[INFO] Set the environment variable SCHEMATICS_WORKSPACE_ID for testing schematics resources else it is set to default value
[INFO] Set the environment variable SCHEMATICS_TEMPLATE_ID for testing schematics resources else it is set to default value
[INFO] Set the environment variable SCHEMATICS_ACTION_ID for testing schematics resources else it is set to default value
[INFO] Set the environment variable SCHEMATICS_JOB_ID for testing schematics resources else it is set to default value
[INFO] Set the environment variable SCHEMATICS_REPO_URL for testing schematics resources else tests will fail if this is not set correctly
[INFO] Set the environment variable SCHEMATICS_REPO_BRANCH for testing schematics resources else tests will fail if this is not set correctly
[WARN] Set the environment variable IMAGE_COS_URL with a VALID COS Image SQL URL for testing ibm_is_image resources on staging/test
[WARN] Set the environment variable IS_DELEGATED_VPC with a VALID created vpc name for testing ibm_is_vpc data source on staging/test
[WARN] Set the environment variable IMAGE_COS_URL_ENCRYPTED with a VALID COS Image SQL URL for testing ibm_is_image resources on staging/test
[WARN] Set the environment variable IMAGE_OPERATING_SYSTEM with a VALID Operating system for testing ibm_is_image resources on staging/test
[INFO] Set the environment variable IS_IMAGE_NAME for testing data source ibm_is_image else it is set to default value `ibm-ubuntu-18-04-1-minimal-amd64-2`
[INFO] Set the environment variable IS_IMAGE_NAME2 for testing data source ibm_is_image else it is set to default value `ibm-ubuntu-20-04-6-minimal-amd64-5`
[INFO] Set the environment variable IS_IMAGE_ENCRYPTED_DATA_KEY for testing resource ibm_is_image else it is set to default value
[INFO] Set the environment variable IS_IMAGE_ENCRYPTION_KEY for testing resource ibm_is_image else it is set to default value
[INFO] Set the environment variable IBM_FUNCTION_NAMESPACE for testing ibm_function_package, ibm_function_action, ibm_function_rule, ibm_function_trigger resource else  tests will fail if this is not set correctly
[INFO] Set the environment variable HPCS_INSTANCE_ID for testing data_source_ibm_kms_key_test else it is set to default value
[INFO] Set the environment variable SECRETS_MANAGER_INSTANCE_ID for testing Secrets Manager's tests else tests will fail if this is not set correctly
[INFO] Set the environment variable SECRETS_MANAGER_INSTANCE_REGION for testing Secrets Manager's tests else tests will fail if this is not set correctly
[INFO] Set the environment variable SECRETS_MANAGER_EN_INSTANCE_CRN for testing Event Notifications for Secrets Manager tests else tests will fail if this is not set correctly
[INFO] Set the environment variable SECRETS_MANAGER_EN_INSTANCE_CRN for testing IAM Credentials secret's tests else tests will assume that IAM Credentials engine is already configured and fail if not set correctly
[INFO] Set the environment variable SECRETS_MANAGER_IAM_CREDENTIALS_SECRET_SERVICE_ID or SECRETS_MANAGER_IAM_CREDENTIALS_SECRET_ACCESS_GROUP for testing IAM Credentials secret's tests, else tests fail if not set correctly
[INFO] Set the environment variable SECRETS_MANAGER_PUBLIC_CERTIFICATE_LETS_ENCRYPT_ENVIRONMENT for testing public certificate's tests, else it is set to default value ('production'). For public certificate's tests, tests will fail if this is not set correctly
[INFO] Set the environment variable SECRETS_MANAGER_PUBLIC_CERTIFICATE_LETS_ENCRYPT_PRIVATE_KEY for testing public certificate's tests, else tests fail if not set correctly
[INFO] Set the environment variable SECRETS_MANAGER_PUBLIC_CERTIFICATE_COMMON_NAME for testing public certificate's tests, else tests fail if not set correctly
[INFO] Set the environment variable SECRETS_MANAGER_VALIDATE_MANUAL_DNS_CIS_ZONE_ID for testing validate manual dns' test, else tests fail if not set correctly
[INFO] Set the environment variable SECRETS_MANAGER_PUBLIC_CERTIFICATE_CIS_CRN for testing public certificate's tests, else tests fail if not set correctly
[INFO] Set the environment variable SECRETS_MANAGER_PUBLIC_CLASSIC_INFRASTRUCTURE_USERNAME for testing public certificate's tests, else tests fail if not set correctly
[INFO] Set the environment variable SECRETS_MANAGER_PUBLIC_CLASSIC_INFRASTRUCTURE_PASSWORD for testing public certificate's tests, else tests fail if not set correctly
[INFO] Set the environment variable SECRETS_MANAGER_IMPORTED_CERTIFICATE_PATH_TO_CERTIFICATE for testing imported certificate's tests, else tests fail if not set correctly
[INFO] Set the environment variable SECRETS_MANAGER_SERVICE_CREDENTIALS_COS_CRN for testing service credentials' tests, else tests fail if not set correctly
[INFO] Set the environment variable SECRETS_MANAGER_PRIVATE_CERTIFICATE_CONFIGURATION_CRYPTO_KEY_IAM_SECRET_SERVICE_ID for testing private certificate's configuration with crypto key tests, else tests fail if not set correctly
[INFO] Set the environment variable SECRETS_MANAGER_PRIVATE_CERTIFICATE_CONFIGURATION_CRYPTO_KEY_PROVIDER_TYPE for testing private certificate's configuration with crypto key tests, else tests fail if not set correctly
[INFO] Set the environment variable SECRETS_MANAGER_PRIVATE_CERTIFICATE_CONFIGURATION_CRYPTO_KEY_PROVIDER_INSTANCE_CRN for testing private certificate's configuration with crypto key tests, else tests fail if not set correctly
[INFO] Set the environment variable SECRETS_MANAGER_PRIVATE_CERTIFICATE_CONFIGURATION_CRYPTO_KEY_PROVIDER_PRIVATE_KEYSTORE_ID for testing private certificate's configuration with crypto key tests, else tests fail if not set correctly
[INFO] Set the environment variable IBM_TG_CROSS_ACCOUNT_API_KEY for testing ibm_tg_connection resource else  tests will fail if this is not set correctly
[INFO] Set the environment variable IBM_TG_CROSS_ACCOUNT_ID for testing ibm_tg_connection resource else  tests will fail if this is not set correctly
[INFO] Set the environment variable IBM_TG_CROSS_NETWORK_ID for testing ibm_tg_connection resource else  tests will fail if this is not set correctly
[INFO] Set the environment variable IBM_TG_POWER_VS_NETWORK_ID for testing ibm_tg_connection resource else tests will fail if this is not set correctly
[INFO] Set the environment variable ACCOUNT_TO_BE_IMPORTED for testing import enterprise account resource else  tests will fail if this is not set correctly
[INFO] Set the environment variable COS_BUCKET for testing CRUD operations on billing snapshot configuration APIs
[INFO] Set the environment variable COS_LOCATION for testing CRUD operations on billing snapshot configuration APIs
[INFO] Set the environment variable COS_BUCKET_UPDATE for testing update operation on billing snapshot configuration API
[INFO] Set the environment variable COS_LOCATION_UPDATE for testing update operation on billing snapshot configuration API
[INFO] Set the environment variable COS_REPORTS_FOLDER for testing CRUD operations on billing snapshot configuration APIs
[INFO] Set the environment variable SNAPSHOT_DATE_FROM for testing CRUD operations on billing snapshot configuration APIs
[INFO] Set the environment variable SNAPSHOT_DATE_TO for testing CRUD operations on billing snapshot configuration APIs
[INFO] Set the environment variable SNAPSHOT_MONTH for testing CRUD operations on billing snapshot configuration APIs
[WARN] Set the environment variable IBM_HPCS_ADMIN1 with a VALID HPCS Admin Key1 Path
[WARN] Set the environment variable IBM_HPCS_TOKEN1 with a VALID token for HPCS Admin Key1
[WARN] Set the environment variable IBM_HPCS_ADMIN2 with a VALID HPCS Admin Key2 Path
[WARN] Set the environment variable IBM_IAM_REALM_NAME with a VALID realm name for iam trusted profile claim rule
[WARN] Set the environment variable IBM_IAM_IKS_SA with a VALID realm name for iam trusted profile link
[WARN] Set the environment variable IBM_HPCS_TOKEN2 with a VALID token for HPCS Admin Key2
[WARN] Set the environment variable IBM_HPCS_ROOTKEY_CRN with a VALID CRN for a root key created in the HPCS instance
[INFO] Set the environment variable IBM_CLOUD_SHELL_ACCOUNT_ID for ibm-cloud-shell resource or datasource else tests will fail if this is not set correctly
[WARN] Set the environment variable IBM_CLUSTER_VPC_ID for testing ibm_container_vpc_alb_create resources, ibm_container_vpc_alb_create tests will fail if this is not set
[WARN] Set the environment variable IBM_CLUSTER_VPC_SUBNET_ID for testing ibm_container_vpc_alb_create resources, ibm_container_vpc_alb_creates tests will fail if this is not set
[WARN] Set the environment variable IBM_CLUSTER_VPC_RESOURCE_GROUP_ID for testing ibm_container_vpc_alb_create resources, ibm_container_vpc_alb_creates tests will fail if this is not set
[INFO] Set the environment variable IBM_CONTAINER_CLUSTER_NAME for ibm_container_nlb_dns resource or datasource else tests will fail if this is not set correctly
[INFO] Set the environment variable SATELLITE_LOCATION_ID for ibm_cos_bucket satellite location resource or datasource else tests will fail if this is not set correctly
[INFO] Set the environment variable SATELLITE_RESOURCE_INSTANCE_ID for ibm_cos_bucket satellite location resource or datasource else tests will fail if this is not set correctly
[WARN] Set the environment variable IBMCLOUD_SCC_INSTANCE_ID with a VALID SCC INSTANCE ID
[WARN] Set the environment variable IBMCLOUD_SCC_API_ENDPOINT with a VALID SCC API ENDPOINT
[WARN] Set the environment variable IBMCLOUD_SCC_REPORT_ID with a VALID SCC REPORT ID
[WARN] Set the environment variable IBMCLOUD_SCC_PROVIDER_TYPE_ATTRIBUTES with a VALID SCC PROVIDER TYPE ATTRIBUTE
[WARN] Set the environment variable IBMCLOUD_SCC_PROVIDER_TYPE_ID with a VALID SCC PROVIDER TYPE ID
[WARN] Set the environment variable IBMCLOUD_SCC_EVENT_NOTIFICATION_CRN
[WARN] Set the environment variable IBMCLOUD_SCC_OBJECT_STORAGE_CRN with a valid cloud object storage crn
[WARN] Set the environment variable IBMCLOUD_SCC_OBJECT_STORAGE_BUCKET with a valid cloud object storage bucket
[INFO] Set the environment variable IBM_CONTAINER_DEDICATEDHOST_POOL_ID for ibm_container_vpc_cluster resource to test dedicated host functionality
[INFO] Set the environment variable IBM_KMS_INSTANCE_ID for ibm_container_vpc_cluster resource or datasource else tests will fail if this is not set correctly
[INFO] Set the environment variable IBM_CRK_ID for ibm_container_vpc_cluster resource or datasource else tests will fail if this is not set correctly
[INFO] Set the environment variable IBM_KMS_ACCOUNT_ID for ibm_container_vpc_cluster resource or datasource else tests will fail if this is not set correctly
[INFO] Set the environment variable IBM_CLUSTER_ID for ibm_container_vpc_worker_pool resource or datasource else tests will fail if this is not set correctly
[WARN] Set the environment variable IBM_CD_RESOURCE_GROUP_NAME for testing CD resources, CD tests will fail if this is not set
[WARN] Set the environment variable IBM_CD_APPCONFIG_INSTANCE_NAME for testing CD resources, CD tests will fail if this is not set
[WARN] Set the environment variable IBM_CD_KEYPROTECT_INSTANCE_NAME for testing CD resources, CD tests will fail if this is not set
[WARN] Set the environment variable IBM_CD_SECRETSMANAGER_INSTANCE_NAME for testing CD resources, CD tests will fail if this is not set
[WARN] Set the environment variable IBM_CD_SLACK_CHANNEL_NAME for testing CD resources, CD tests will fail if this is not set
[WARN] Set the environment variable IBM_CD_SLACK_TEAM_NAME for testing CD resources, CD tests will fail if this is not set
[WARN] Set the environment variable IBM_CD_SLACK_WEBHOOK for testing CD resources, CD tests will fail if this is not set
[WARN] Set the environment variable IBM_CD_JIRA_PROJECT_KEY for testing CD resources, CD tests will fail if this is not set
[WARN] Set the environment variable IBM_CD_JIRA_API_URL for testing CD resources, CD tests will fail if this is not set
[WARN] Set the environment variable IBM_CD_JIRA_USERNAME for testing CD resources, CD tests will fail if this is not set
[WARN] Set the environment variable IBM_CD_JIRA_API_TOKEN for testing CD resources, CD tests will fail if this is not set
[WARN] Set the environment variable IBM_CD_SAUCELABS_ACCESS_KEY for testing CD resources, CD tests will fail if this is not set
[WARN] Set the environment variable IBM_CD_SAUCELABS_USERNAME for testing CD resources, CD tests will fail if this is not set
[WARN] Set the environment variable IBM_CD_BITBUCKET_REPO_URL for testing CD resources, CD tests will fail if this is not set
[WARN] Set the environment variable IBM_CD_GITHUB_CONSOLIDATED_REPO_URL for testing CD resources, CD tests will fail if this is not set
[WARN] Set the environment variable IBM_CD_GITLAB_REPO_URL for testing CD resources, CD tests will fail if this is not set
[WARN] Set the environment variable IBM_CD_HOSTED_GIT_REPO_URL for testing CD resources, CD tests will fail if this is not set
[WARN] Set the environment variable IBM_CD_EVENTNOTIFICATIONS_INSTANCE_NAME for testing CD resources, CD tests will fail if this is not set
[INFO] Set the environment variable IS_CERTIFICATE_CRN for testing ibm_is_vpn_server resource
[INFO] Set the environment variable IS_CLIENT_CA_CRN for testing ibm_is_vpn_server resource
[INFO] Set the environment variable IBM_AccountID_REPL for setting up authorization policy to enable replication feature resource or datasource else tests will fail if this is not set correctly
[WARN] Set the environment variable COS_API_KEY for testing COS targets, the tests will fail if this is not set
[WARN] Set the environment variable INGESTION_KEY for testing Logdna targets, the tests will fail if this is not set
[WARN] Set the environment variable IES_API_KEY for testing Event streams targets, the tests will fail if this is not set
[WARN] Set the environment variable ENTERPRISE_CRN for testing enterprise backup policy, the tests will fail if this is not set
[WARN] Set the environment variable IBM_CODE_ENGINE_RESOURCE_GROUP_ID with the resource group for Code Engine
[WARN] Set the environment variable IBM_CODE_ENGINE_PROJECT_INSTANCE_ID with the ID of a Code Engine project instance
[WARN] Set the environment variable IBM_CODE_ENGINE_SERVICE_INSTANCE_ID with the ID of a IBM Cloud service instance, e.g. for COS
[WARN] Set the environment variable IBM_CODE_ENGINE_RESOURCE_KEY_ID with the ID of a resource key to access a service instance
[WARN] Set the environment variable IBM_CODE_ENGINE_DOMAIN_MAPPING_NAME with the name of a domain mapping
[WARN] Set the environment variable IBM_CODE_ENGINE_TLS_CERT with the TLS certificate in base64 format
[WARN] Set the environment variable IBM_CODE_ENGINE_TLS_KEY with a TLS key in base64 format
[WARN] Set the environment variable IBM_CODE_ENGINE_TLS_CERT_KEY_PATH to point to CERT KEY file path
[WARN] Set the environment variable IBM_CODE_ENGINE_TLS_CERT_PATH to point to CERT file path
[WARN] Set the environment variable IBM_SATELLITE_SSH_PUB_KEY with a ssh public key or ibm_satellite_* tests may fail
[INFO] Set the environment variable IBMCLOUD_MQCLOUD_CONFIG_ENDPOINT for ibm_mqcloud service else tests will fail if this is not set correctly
[INFO] Set the environment variable IBM_MQCLOUD_INSTANCE_ID for ibm_mqcloud_queue_manager resource or datasource else tests will fail if this is not set correctly
[INFO] Set the environment variable IBM_MQCLOUD_QUEUEMANAGER_ID for ibm_mqcloud_queue_manager resource or datasource else tests will fail if this is not set correctly
[INFO] Set the environment variable IBM_MQCLOUD_KS_CERT_PATH for ibm_mqcloud_keystore_certificate resource or datasource else tests will fail if this is not set correctly
[INFO] Set the environment variable IBM_MQCLOUD_TS_CERT_PATH for ibm_mqcloud_truststore_certificate resource or datasource else tests will fail if this is not set correctly
[INFO] Set the environment variable IBM_MQCLOUD_QUEUEMANAGER_LOCATION for ibm_mqcloud_queue_manager resource or datasource else tests will fail if this is not set correctly
[INFO] Set the environment variable IBM_MQCLOUD_QUEUEMANAGER_VERSION for ibm_mqcloud_queue_manager resource or datasource else tests will fail if this is not set correctly
[INFO] Set the environment variable IBM_MQCLOUD_QUEUEMANAGER_VERSIONUPDATE for ibm_mqcloud_queue_manager resource or datasource else tests will fail if this is not set correctly
[INFO] Set the environment variable IBMCLOUD_LOGS_SERVICE_INSTANCE_ID for testing cloud logs related operations
[INFO] Set the environment variable IBMCLOUD_LOGS_SERVICE_INSTANCE_REGION for testing cloud logs related operations
[INFO] Set the environment variable IBMCLOUD_LOGS_SERVICE_EVENT_NOTIFICATIONS_INSTANCE_ID for testing cloud logs related operations
[INFO] Set the environment variable IBMCLOUD_LOGS_SERVICE_EVENT_NOTIFICATIONS_INSTANCE_REGION for testing cloud logs related operations
[WARN] Set the environment variable IBM_PAG_COS_INSTANCE_NAME for testing IBM PAG resource, the tests will fail if this is not set
[WARN] Set the environment variable IBM_PAG_COS_BUCKET_NAME for testing IBM PAG resource, the tests will fail if this is not set
[WARN] Set the environment variable IBM_PAG_COS_BUCKET_REGION for testing IBM PAG resource, the tests will fail if this is not set
[WARN] Set the environment variable IBM_PAG_VPC_NAME for testing IBM PAG resource, the tests will fail if this is not set
[WARN] Set the environment variable IBM_PAG_SERVICE_PLAN for testing IBM PAG resource, the tests will fail if this is not set
[WARN] Set the environment variable IBM_PAG_VPC_SUBNET_INS_1 for testing IBM PAG resource, the tests will fail if this is not set
[WARN] Set the environment variable IBM_PAG_VPC_SUBNET_INS_2 for testing IBM PAG resource, the tests will fail if this is not set
[WARN] Set the environment variable IBM_PAG_VPC_SUBNET_INS_2 for testing IBM PAG resource, the tests will fail if this is not set
[WARN] Set the environment variable IBM_PAG_VPC_SUBNET_INS_2 for testing IBM PAG resource, the tests will fail if this is not set
[WARN] Set the environment variable IBM_VMAAS_DS_ID for testing ibm_vmaas_vdc resource else tests will fail if this is not set correctly
[WARN] Set the environment variable IBM_VMAAS_DS_PVDC_ID for testing ibm_vmaas_vdc resource else tests will fail if this is not set correctly
[INFO] Set the environment variable IBM_POLICY_ASSIGNMENT_TARGET_ACCOUNT_ID for testing ibm_iam_policy_assignment resource else tests will fail if this is not set correctly
[WARN] Set the environment variable PCS_REGISTRATION_ACCOUNT_ID for testing iam_onboarding resource else tests will fail if this is not set correctly
[WARN] Set the environment variable PCS_PRODUCT_WITH_APPROVED_PROGRAMMATIC_NAME for testing iam_onboarding resource else tests will fail if this is not set correctly
[WARN] Set the environment variable PCS_PRODUCT_WITH_APPROVED_PROGRAMMATIC_NAME_2 for testing iam_onboarding resource else tests will fail if this is not set correctly
[WARN] Set the environment variable PCS_PRODUCT_WITH_CATALOG_PRODUCT for testing iam_onboarding resource else tests will fail if this is not set correctly
[WARN] Set the environment variable PCS_CATALOG_PRODUCT for testing iam_onboarding resource else tests will fail if this is not set correctly
[WARN] Set the environment variable PCS_CATALOG_PLAN for testing iam_onboarding resource else tests will fail if this is not set correctly
[WARN] Set the environment variable PCS_IAM_TEGISTRATION_ID for testing iam_onboarding resource else tests will fail if this is not set correctly
PASS
ok  	github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/configurationaggregator	1.873s


```