### PR TITLE
feat(tekton): add support for fork feature

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/IBM/cloudant-go-sdk v0.8.0
 	github.com/IBM/code-engine-go-sdk v0.0.0-20240808131715-b9d168602dac
 	github.com/IBM/container-registry-go-sdk v1.1.0
-	github.com/IBM/continuous-delivery-go-sdk v1.6.0
+	github.com/IBM/continuous-delivery-go-sdk v1.8.1
 	github.com/IBM/event-notifications-go-admin-sdk v0.9.0
 	github.com/IBM/eventstreams-go-sdk v1.4.0
 	github.com/IBM/go-sdk-core v1.1.0

--- a/go.sum
+++ b/go.sum
@@ -138,8 +138,8 @@ github.com/IBM/code-engine-go-sdk v0.0.0-20240808131715-b9d168602dac h1:9Y5TB9Ar
 github.com/IBM/code-engine-go-sdk v0.0.0-20240808131715-b9d168602dac/go.mod h1:sy4CocPPaCiS+T1znqVdw83dkoyxSMUFxkksqahUhbY=
 github.com/IBM/container-registry-go-sdk v1.1.0 h1:sYyknIod8R4RJZQqAheiduP6wbSTphE9Ag8ho28yXjc=
 github.com/IBM/container-registry-go-sdk v1.1.0/go.mod h1:4TwsCnQtVfZ4Vkapy/KPvQBKFc3VOyUZYkwRU4FTPrs=
-github.com/IBM/continuous-delivery-go-sdk v1.6.0 h1:eAL/jIWHrDFlWDF+Qd9Y5UN99Pr5Mjd/H/bvTbXUbz4=
-github.com/IBM/continuous-delivery-go-sdk v1.6.0/go.mod h1:nZdKUnubXNLo+zo28R4Rd+TGDqiJ/xoE8WO/A3kLw1E=
+github.com/IBM/continuous-delivery-go-sdk v1.8.1 h1:BWmp58XODXqAe3DRQE3I0Lnrwewf8HzXH1FVCBYlAa0=
+github.com/IBM/continuous-delivery-go-sdk v1.8.1/go.mod h1:5umVUaXEoTP2ULARgXRBPcR3vWDCmKD66P6XgNqpzZk=
 github.com/IBM/event-notifications-go-admin-sdk v0.9.0 h1:eaCd+GkxhNyot+8rA9WkAQdlVYrRD20LYiXjEytFO6M=
 github.com/IBM/event-notifications-go-admin-sdk v0.9.0/go.mod h1:OByvqfrNVxs7G6ggv8pwQCEVw10/TBJCLh7NM3z707w=
 github.com/IBM/eventstreams-go-sdk v1.4.0 h1:yS/Ns29sBOe8W2tynQmz9HTKqQZ0ckse4Py5Oy/F2rM=

--- a/ibm/service/cdtektonpipeline/data_source_ibm_cd_tekton_pipeline.go
+++ b/ibm/service/cdtektonpipeline/data_source_ibm_cd_tekton_pipeline.go
@@ -327,6 +327,11 @@ func DataSourceIBMCdTektonPipeline() *schema.Resource {
 							Computed:    true,
 							Description: "Mark the trigger as a favorite.",
 						},
+						"enable_events_from_forks": &schema.Schema{
+							Type:        schema.TypeBool,
+							Computed:    true,
+							Description: "When enabled, pull request events from forks of the selected repository will trigger a pipeline run.",
+						},
 						"source": &schema.Schema{
 							Type:        schema.TypeList,
 							Computed:    true,
@@ -805,6 +810,9 @@ func dataSourceIBMCdTektonPipelineTriggerToMap(model cdtektonpipelinev2.TriggerI
 		if model.Favorite != nil {
 			modelMap["favorite"] = model.Favorite
 		}
+		if model.EnableEventsFromForks != nil {
+			modelMap["enable_events_from_forks"] = model.EnableEventsFromForks
+		}
 		if model.Source != nil {
 			sourceMap, err := dataSourceIBMCdTektonPipelineTriggerSourceToMap(model.Source)
 			if err != nil {
@@ -1002,6 +1010,9 @@ func dataSourceIBMCdTektonPipelineTriggerScmTriggerToMap(model *cdtektonpipeline
 	modelMap["enabled"] = model.Enabled
 	if model.Favorite != nil {
 		modelMap["favorite"] = model.Favorite
+	}
+	if model.EnableEventsFromForks != nil {
+		modelMap["enable_events_from_forks"] = model.EnableEventsFromForks
 	}
 	if model.Source != nil {
 		sourceMap, err := dataSourceIBMCdTektonPipelineTriggerSourceToMap(model.Source)

--- a/ibm/service/cdtektonpipeline/data_source_ibm_cd_tekton_pipeline_definition.go
+++ b/ibm/service/cdtektonpipeline/data_source_ibm_cd_tekton_pipeline_definition.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2023 All Rights Reserved.
+// Copyright IBM Corp. 2024 All Rights Reserved.
 // Licensed under the Mozilla Public License v2.0
 
 package cdtektonpipeline

--- a/ibm/service/cdtektonpipeline/data_source_ibm_cd_tekton_pipeline_definition_test.go
+++ b/ibm/service/cdtektonpipeline/data_source_ibm_cd_tekton_pipeline_definition_test.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2023 All Rights Reserved.
+// Copyright IBM Corp. 2024 All Rights Reserved.
 // Licensed under the Mozilla Public License v2.0
 
 package cdtektonpipeline_test

--- a/ibm/service/cdtektonpipeline/data_source_ibm_cd_tekton_pipeline_test.go
+++ b/ibm/service/cdtektonpipeline/data_source_ibm_cd_tekton_pipeline_test.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2023 All Rights Reserved.
+// Copyright IBM Corp. 2024 All Rights Reserved.
 // Licensed under the Mozilla Public License v2.0
 
 package cdtektonpipeline_test

--- a/ibm/service/cdtektonpipeline/data_source_ibm_cd_tekton_pipeline_trigger.go
+++ b/ibm/service/cdtektonpipeline/data_source_ibm_cd_tekton_pipeline_trigger.go
@@ -145,6 +145,11 @@ func DataSourceIBMCdTektonPipelineTrigger() *schema.Resource {
 				Computed:    true,
 				Description: "Mark the trigger as a favorite.",
 			},
+			"enable_events_from_forks": &schema.Schema{
+				Type:        schema.TypeBool,
+				Computed:    true,
+				Description: "When enabled, pull request events from forks of the selected repository will trigger a pipeline run.",
+			},
 			"source": &schema.Schema{
 				Type:        schema.TypeList,
 				Computed:    true,
@@ -357,6 +362,10 @@ func dataSourceIBMCdTektonPipelineTriggerRead(context context.Context, d *schema
 
 	if err = d.Set("favorite", trigger.Favorite); err != nil {
 		return diag.FromErr(fmt.Errorf("Error setting favorite: %s", err))
+	}
+
+	if err = d.Set("enable_events_from_forks", trigger.EnableEventsFromForks); err != nil {
+		return diag.FromErr(fmt.Errorf("Error setting enable_events_from_forks: %s", err))
 	}
 
 	source := []map[string]interface{}{}

--- a/ibm/service/cdtektonpipeline/data_source_ibm_cd_tekton_pipeline_trigger_test.go
+++ b/ibm/service/cdtektonpipeline/data_source_ibm_cd_tekton_pipeline_trigger_test.go
@@ -69,7 +69,6 @@ func TestAccIBMCdTektonPipelineTriggerDataSourceAllArgs(t *testing.T) {
 					resource.TestCheckResourceAttrSet("data.ibm_cd_tekton_pipeline_trigger.cd_tekton_pipeline_trigger", "favorite"),
 					resource.TestCheckResourceAttrSet("data.ibm_cd_tekton_pipeline_trigger.cd_tekton_pipeline_trigger", "enable_events_from_forks"),
 					resource.TestCheckResourceAttrSet("data.ibm_cd_tekton_pipeline_trigger.cd_tekton_pipeline_trigger", "source.#"),
-					resource.TestCheckResourceAttrSet("data.ibm_cd_tekton_pipeline_trigger.cd_tekton_pipeline_trigger", "filter"),
 					resource.TestCheckResourceAttrSet("data.ibm_cd_tekton_pipeline_trigger.cd_tekton_pipeline_trigger", "secret.#"),
 				),
 			},

--- a/ibm/service/cdtektonpipeline/data_source_ibm_cd_tekton_pipeline_trigger_test.go
+++ b/ibm/service/cdtektonpipeline/data_source_ibm_cd_tekton_pipeline_trigger_test.go
@@ -46,13 +46,14 @@ func TestAccIBMCdTektonPipelineTriggerDataSourceAllArgs(t *testing.T) {
 	triggerTimezone := fmt.Sprintf("tf_timezone_%d", acctest.RandIntRange(10, 100))
 	triggerFilter := fmt.Sprintf("tf_filter_%d", acctest.RandIntRange(10, 100))
 	triggerFavorite := "true"
+	triggerEnableEventsFromForks := "true"
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:  func() { acc.TestAccPreCheck(t) },
 		Providers: acc.TestAccProviders,
 		Steps: []resource.TestStep{
 			resource.TestStep{
-				Config: testAccCheckIBMCdTektonPipelineTriggerDataSourceConfig(triggerPipelineID, triggerType, triggerName, triggerEventListener, triggerMaxConcurrentRuns, triggerEnabled, triggerCron, triggerTimezone, triggerFilter, triggerFavorite),
+				Config: testAccCheckIBMCdTektonPipelineTriggerDataSourceConfig(triggerPipelineID, triggerType, triggerName, triggerEventListener, triggerMaxConcurrentRuns, triggerEnabled, triggerCron, triggerTimezone, triggerFilter, triggerFavorite, triggerEnableEventsFromForks),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrSet("data.ibm_cd_tekton_pipeline_trigger.cd_tekton_pipeline_trigger", "id"),
 					resource.TestCheckResourceAttrSet("data.ibm_cd_tekton_pipeline_trigger.cd_tekton_pipeline_trigger", "pipeline_id"),
@@ -66,7 +67,9 @@ func TestAccIBMCdTektonPipelineTriggerDataSourceAllArgs(t *testing.T) {
 					resource.TestCheckResourceAttrSet("data.ibm_cd_tekton_pipeline_trigger.cd_tekton_pipeline_trigger", "max_concurrent_runs"),
 					resource.TestCheckResourceAttrSet("data.ibm_cd_tekton_pipeline_trigger.cd_tekton_pipeline_trigger", "enabled"),
 					resource.TestCheckResourceAttrSet("data.ibm_cd_tekton_pipeline_trigger.cd_tekton_pipeline_trigger", "favorite"),
+					resource.TestCheckResourceAttrSet("data.ibm_cd_tekton_pipeline_trigger.cd_tekton_pipeline_trigger", "enable_events_from_forks"),
 					resource.TestCheckResourceAttrSet("data.ibm_cd_tekton_pipeline_trigger.cd_tekton_pipeline_trigger", "source.#"),
+					resource.TestCheckResourceAttrSet("data.ibm_cd_tekton_pipeline_trigger.cd_tekton_pipeline_trigger", "filter"),
 					resource.TestCheckResourceAttrSet("data.ibm_cd_tekton_pipeline_trigger.cd_tekton_pipeline_trigger", "secret.#"),
 				),
 			},
@@ -141,7 +144,7 @@ func testAccCheckIBMCdTektonPipelineTriggerDataSourceConfigBasic(triggerPipeline
 	`, rgName, tcName, triggerType, triggerName, triggerEventListener)
 }
 
-func testAccCheckIBMCdTektonPipelineTriggerDataSourceConfig(triggerPipelineID string, triggerType string, triggerName string, triggerEventListener string, triggerMaxConcurrentRuns string, triggerEnabled string, triggerCron string, triggerTimezone string, triggerFilter string, triggerFavorite string) string {
+func testAccCheckIBMCdTektonPipelineTriggerDataSourceConfig(triggerPipelineID string, triggerType string, triggerName string, triggerEventListener string, triggerMaxConcurrentRuns string, triggerEnabled string, triggerCron string, triggerTimezone string, triggerFilter string, triggerFavorite string, triggerEnableEventsFromForks string) string {
 	rgName := acc.CdResourceGroupName
 	tcName := fmt.Sprintf("tf_name_%d", acctest.RandIntRange(10, 100))
 	return fmt.Sprintf(`

--- a/ibm/service/cdtektonpipeline/resource_ibm_cd_tekton_pipeline.go
+++ b/ibm/service/cdtektonpipeline/resource_ibm_cd_tekton_pipeline.go
@@ -374,6 +374,12 @@ func ResourceIBMCdTektonPipeline() *schema.Resource {
 							Default:     false,
 							Description: "Mark the trigger as a favorite.",
 						},
+						"enable_events_from_forks": &schema.Schema{
+							Type:        schema.TypeBool,
+							Optional:    true,
+							Default:     false,
+							Description: "When enabled, pull request events from forks of the selected repository will trigger a pipeline run.",
+						},
 						"source": &schema.Schema{
 							Type:        schema.TypeList,
 							MaxItems:    1,
@@ -937,6 +943,9 @@ func resourceIBMCdTektonPipelineTriggerToMap(model cdtektonpipelinev2.TriggerInt
 		if model.Favorite != nil {
 			modelMap["favorite"] = model.Favorite
 		}
+		if model.EnableEventsFromForks != nil {
+			modelMap["enable_events_from_forks"] = model.EnableEventsFromForks
+		}
 		if model.Source != nil {
 			sourceMap, err := resourceIBMCdTektonPipelineTriggerSourceToMap(model.Source)
 			if err != nil {
@@ -1134,6 +1143,9 @@ func resourceIBMCdTektonPipelineTriggerScmTriggerToMap(model *cdtektonpipelinev2
 	modelMap["enabled"] = model.Enabled
 	if model.Favorite != nil {
 		modelMap["favorite"] = model.Favorite
+	}
+	if model.EnableEventsFromForks != nil {
+		modelMap["enable_events_from_forks"] = model.EnableEventsFromForks
 	}
 	if model.Source != nil {
 		sourceMap, err := resourceIBMCdTektonPipelineTriggerSourceToMap(model.Source)

--- a/ibm/service/cdtektonpipeline/resource_ibm_cd_tekton_pipeline_definition.go
+++ b/ibm/service/cdtektonpipeline/resource_ibm_cd_tekton_pipeline_definition.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2023 All Rights Reserved.
+// Copyright IBM Corp. 2024 All Rights Reserved.
 // Licensed under the Mozilla Public License v2.0
 
 package cdtektonpipeline

--- a/ibm/service/cdtektonpipeline/resource_ibm_cd_tekton_pipeline_definition_test.go
+++ b/ibm/service/cdtektonpipeline/resource_ibm_cd_tekton_pipeline_definition_test.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2023 All Rights Reserved.
+// Copyright IBM Corp. 2024 All Rights Reserved.
 // Licensed under the Mozilla Public License v2.0
 
 package cdtektonpipeline_test

--- a/ibm/service/cdtektonpipeline/resource_ibm_cd_tekton_pipeline_test.go
+++ b/ibm/service/cdtektonpipeline/resource_ibm_cd_tekton_pipeline_test.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2023 All Rights Reserved.
+// Copyright IBM Corp. 2024 All Rights Reserved.
 // Licensed under the Mozilla Public License v2.0
 
 package cdtektonpipeline_test

--- a/ibm/service/cdtektonpipeline/resource_ibm_cd_tekton_pipeline_trigger.go
+++ b/ibm/service/cdtektonpipeline/resource_ibm_cd_tekton_pipeline_trigger.go
@@ -194,6 +194,12 @@ func ResourceIBMCdTektonPipelineTrigger() *schema.Resource {
 				Default:     false,
 				Description: "Mark the trigger as a favorite.",
 			},
+			"enable_events_from_forks": &schema.Schema{
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Default:     false,
+				Description: "Only used for SCM triggers. When enabled, pull request events from forks of the selected repository will trigger a pipeline run.",
+			},
 			"href": &schema.Schema{
 				Type:        schema.TypeString,
 				Computed:    true,
@@ -398,6 +404,9 @@ func resourceIBMCdTektonPipelineTriggerCreate(context context.Context, d *schema
 	if _, ok := d.GetOk("favorite"); ok {
 		createTektonPipelineTriggerOptions.SetFavorite(d.Get("favorite").(bool))
 	}
+	if _, ok := d.GetOk("enable_events_from_forks"); ok {
+		createTektonPipelineTriggerOptions.SetEnableEventsFromForks(d.Get("enable_events_from_forks").(bool))
+	}
 
 	triggerIntf, response, err := cdTektonPipelineClient.CreateTektonPipelineTriggerWithContext(context, createTektonPipelineTriggerOptions)
 	if err != nil {
@@ -517,6 +526,11 @@ func resourceIBMCdTektonPipelineTriggerRead(context context.Context, d *schema.R
 			return diag.FromErr(fmt.Errorf("Error setting favorite: %s", err))
 		}
 	}
+	if !core.IsNil(trigger.EnableEventsFromForks) {
+		if err = d.Set("enable_events_from_forks", trigger.EnableEventsFromForks); err != nil {
+			return diag.FromErr(fmt.Errorf("Error setting enable_events_from_forks: %s", err))
+		}
+	}
 	if !core.IsNil(trigger.Href) {
 		if err = d.Set("href", trigger.Href); err != nil {
 			return diag.FromErr(fmt.Errorf("Error setting href: %s", err))
@@ -602,12 +616,6 @@ func resourceIBMCdTektonPipelineTriggerUpdate(context context.Context, d *schema
 		patchVals.MaxConcurrentRuns = &newMaxConcurrentRuns
 		hasChange = true
 	}
-	if d.HasChange("favorite") {
-		newFavorite := d.Get("favorite").(bool)
-		patchVals.Favorite = &newFavorite
-		hasChange = true
-	}
-
 	if d.HasChange("enabled") {
 		newEnabled := d.Get("enabled").(bool)
 		patchVals.Enabled = &newEnabled
@@ -647,6 +655,22 @@ func resourceIBMCdTektonPipelineTriggerUpdate(context context.Context, d *schema
 		}
 		sort.Strings(events)
 		patchVals.Events = events
+		hasChange = true
+	}
+
+	if d.HasChange("filter") {
+		newFilter := d.Get("filter").(string)
+		patchVals.Filter = &newFilter
+		hasChange = true
+	}
+	if d.HasChange("favorite") {
+		newFavorite := d.Get("favorite").(bool)
+		patchVals.Favorite = &newFavorite
+		hasChange = true
+	}
+	if d.HasChange("enable_events_from_forks") {
+		newEnableEventsFromForks := d.Get("enable_events_from_forks").(bool)
+		patchVals.EnableEventsFromForks = &newEnableEventsFromForks
 		hasChange = true
 	}
 

--- a/ibm/service/cdtektonpipeline/resource_ibm_cd_tekton_pipeline_trigger_test.go
+++ b/ibm/service/cdtektonpipeline/resource_ibm_cd_tekton_pipeline_trigger_test.go
@@ -66,6 +66,7 @@ func TestAccIBMCdTektonPipelineTriggerAllArgs(t *testing.T) {
 	timezone := "Europe/London"
 	filter := "test"
 	favorite := "false"
+	enableEventsFromForks := "false"
 	typeVarUpdate := "generic"
 	nameUpdate := fmt.Sprintf("tf_name_%d", acctest.RandIntRange(10, 100))
 	eventListenerUpdate := fmt.Sprintf("tf_event_listener_%d", acctest.RandIntRange(10, 100))
@@ -75,6 +76,7 @@ func TestAccIBMCdTektonPipelineTriggerAllArgs(t *testing.T) {
 	timezoneUpdate := "America/New_York"
 	filterUpdate := "true"
 	favoriteUpdate := "true"
+	enableEventsFromForksUpdate := "true"
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { acc.TestAccPreCheck(t) },
@@ -82,7 +84,7 @@ func TestAccIBMCdTektonPipelineTriggerAllArgs(t *testing.T) {
 		CheckDestroy: testAccCheckIBMCdTektonPipelineTriggerDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
-				Config: testAccCheckIBMCdTektonPipelineTriggerConfig(pipelineID, typeVar, name, eventListener, maxConcurrentRuns, enabled, cron, timezone, filter, favorite),
+				Config: testAccCheckIBMCdTektonPipelineTriggerConfig(pipelineID, typeVar, name, eventListener, maxConcurrentRuns, enabled, cron, timezone, filter, favorite, enableEventsFromForks),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckIBMCdTektonPipelineTriggerExists("ibm_cd_tekton_pipeline_trigger.cd_tekton_pipeline_trigger", conf),
 					testAccCheckIBMCdTektonPipelineTriggerExists("ibm_cd_tekton_pipeline_trigger.cd_tekton_pipeline_trigger2", conf),
@@ -92,6 +94,7 @@ func TestAccIBMCdTektonPipelineTriggerAllArgs(t *testing.T) {
 					resource.TestCheckResourceAttr("ibm_cd_tekton_pipeline_trigger.cd_tekton_pipeline_trigger", "enabled", enabled),
 					resource.TestCheckResourceAttr("ibm_cd_tekton_pipeline_trigger.cd_tekton_pipeline_trigger2", "cron", cron),
 					resource.TestCheckResourceAttr("ibm_cd_tekton_pipeline_trigger.cd_tekton_pipeline_trigger2", "timezone", timezone),
+					resource.TestCheckResourceAttr("ibm_cd_tekton_pipeline_trigger.cd_tekton_pipeline_trigger", "filter", filter),
 					resource.TestCheckResourceAttr("ibm_cd_tekton_pipeline_trigger.cd_tekton_pipeline_trigger", "favorite", favorite),
 					resource.TestCheckResourceAttrSet("ibm_cd_tekton_pipeline_trigger.cd_tekton_pipeline_trigger", "pipeline_id"),
 					resource.TestCheckResourceAttrSet("ibm_cd_tekton_pipeline_trigger.cd_tekton_pipeline_trigger", "trigger_id"),
@@ -108,13 +111,14 @@ func TestAccIBMCdTektonPipelineTriggerAllArgs(t *testing.T) {
 				),
 			},
 			resource.TestStep{
-				Config: testAccCheckIBMCdTektonPipelineTriggerConfig(pipelineID, typeVarUpdate, nameUpdate, eventListenerUpdate, maxConcurrentRunsUpdate, enabledUpdate, cronUpdate, timezoneUpdate, filterUpdate, favoriteUpdate),
+				Config: testAccCheckIBMCdTektonPipelineTriggerConfig(pipelineID, typeVarUpdate, nameUpdate, eventListenerUpdate, maxConcurrentRunsUpdate, enabledUpdate, cronUpdate, timezoneUpdate, filterUpdate, favoriteUpdate, enableEventsFromForksUpdate),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr("ibm_cd_tekton_pipeline_trigger.cd_tekton_pipeline_trigger", "name", nameUpdate),
 					resource.TestCheckResourceAttr("ibm_cd_tekton_pipeline_trigger.cd_tekton_pipeline_trigger", "max_concurrent_runs", maxConcurrentRunsUpdate),
 					resource.TestCheckResourceAttr("ibm_cd_tekton_pipeline_trigger.cd_tekton_pipeline_trigger", "enabled", enabledUpdate),
 					resource.TestCheckResourceAttr("ibm_cd_tekton_pipeline_trigger.cd_tekton_pipeline_trigger2", "cron", cronUpdate),
 					resource.TestCheckResourceAttr("ibm_cd_tekton_pipeline_trigger.cd_tekton_pipeline_trigger2", "timezone", timezoneUpdate),
+					resource.TestCheckResourceAttr("ibm_cd_tekton_pipeline_trigger.cd_tekton_pipeline_trigger", "filter", filterUpdate),
 					resource.TestCheckResourceAttr("ibm_cd_tekton_pipeline_trigger.cd_tekton_pipeline_trigger", "favorite", favoriteUpdate),
 					resource.TestCheckResourceAttrSet("ibm_cd_tekton_pipeline_trigger.cd_tekton_pipeline_trigger", "pipeline_id"),
 					resource.TestCheckResourceAttrSet("ibm_cd_tekton_pipeline_trigger.cd_tekton_pipeline_trigger", "trigger_id"),
@@ -201,7 +205,7 @@ func testAccCheckIBMCdTektonPipelineTriggerConfigBasic(pipelineID string, typeVa
 	`, rgName, tcName, typeVar, name, eventListener)
 }
 
-func testAccCheckIBMCdTektonPipelineTriggerConfig(pipelineID string, typeVar string, name string, eventListener string, maxConcurrentRuns string, enabled string, cron string, timezone string, filter string, favorite string) string {
+func testAccCheckIBMCdTektonPipelineTriggerConfig(pipelineID string, typeVar string, name string, eventListener string, maxConcurrentRuns string, enabled string, cron string, timezone string, filter string, favorite string, enableEventsFromForks string) string {
 	rgName := acc.CdResourceGroupName
 	tcName := fmt.Sprintf("tf_name_%d", acctest.RandIntRange(10, 100))
 	return fmt.Sprintf(`

--- a/website/docs/d/cd_tekton_pipeline.html.markdown
+++ b/website/docs/d/cd_tekton_pipeline.html.markdown
@@ -114,6 +114,8 @@ Nested schema for **toolchain**:
 Nested schema for **triggers**:
 	* `cron` - (String) Only needed for timer triggers. CRON expression that indicates when this trigger will activate. Maximum frequency is every 5 minutes. The string is based on UNIX crontab syntax: minute, hour, day of month, month, day of week. Example: The CRON expression 0 *_/2 * * * - translates to - every 2 hours.
 	  * Constraints: The maximum length is `253` characters. The minimum length is `5` characters. The value must match regular expression `/^[-0-9a-zA-Z,\\*\/ ]{5,253}$/`.
+	* `enable_events_from_forks` - (Boolean) When enabled, pull request events from forks of the selected repository will trigger a pipeline run.
+	  * Constraints: The default value is `false`.
 	* `enabled` - (Boolean) Flag to check if the trigger is enabled.
 	  * Constraints: The default value is `true`.
 	* `event_listener` - (String) Event listener name. The name of the event listener to which the trigger is associated. The event listeners are defined in the definition repositories of the Tekton pipeline.

--- a/website/docs/d/cd_tekton_pipeline_trigger.html.markdown
+++ b/website/docs/d/cd_tekton_pipeline_trigger.html.markdown
@@ -36,6 +36,9 @@ In addition to all argument references listed, you can access the following attr
 * `cron` - (String) Only needed for timer triggers. CRON expression that indicates when this trigger will activate. Maximum frequency is every 5 minutes. The string is based on UNIX crontab syntax: minute, hour, day of month, month, day of week. Example: The CRON expression 0 *_/2 * * * - translates to - every 2 hours.
   * Constraints: The maximum length is `253` characters. The minimum length is `5` characters. The value must match regular expression `/^[-0-9a-zA-Z,\\*\/ ]{5,253}$/`.
 
+* `enable_events_from_forks` - (Boolean) When enabled, pull request events from forks of the selected repository will trigger a pipeline run.
+  * Constraints: The default value is `false`.
+
 * `enabled` - (Boolean) Flag to check if the trigger is enabled.
   * Constraints: The default value is `true`.
 

--- a/website/docs/r/cd_tekton_pipeline.html.markdown
+++ b/website/docs/r/cd_tekton_pipeline.html.markdown
@@ -112,6 +112,8 @@ Nested schema for **toolchain**:
 Nested schema for **triggers**:
 	* `cron` - (String) Only needed for timer triggers. CRON expression that indicates when this trigger will activate. Maximum frequency is every 5 minutes. The string is based on UNIX crontab syntax: minute, hour, day of month, month, day of week. Example: The CRON expression 0 *_/2 * * * - translates to - every 2 hours.
 	  * Constraints: The maximum length is `253` characters. The minimum length is `5` characters. The value must match regular expression `/^[-0-9a-zA-Z,\\*\/ ]{5,253}$/`.
+	* `enable_events_from_forks` - (Boolean) When enabled, pull request events from forks of the selected repository will trigger a pipeline run.
+	  * Constraints: The default value is `false`.
 	* `enabled` - (Boolean) Flag to check if the trigger is enabled.
 	  * Constraints: The default value is `true`.
 	* `event_listener` - (String) Event listener name. The name of the event listener to which the trigger is associated. The event listeners are defined in the definition repositories of the Tekton pipeline.

--- a/website/docs/r/cd_tekton_pipeline_trigger.html.markdown
+++ b/website/docs/r/cd_tekton_pipeline_trigger.html.markdown
@@ -31,6 +31,8 @@ Review the argument reference that you can specify for your resource.
 
 * `cron` - (Optional, String) Only needed for timer triggers. CRON expression that indicates when this trigger will activate. Maximum frequency is every 5 minutes. The string is based on UNIX crontab syntax: minute, hour, day of month, month, day of week. Example: The CRON expression 0 *_/2 * * * - translates to - every 2 hours.
   * Constraints: The maximum length is `253` characters. The minimum length is `5` characters. The value must match regular expression `/^[-0-9a-zA-Z,\\*\/ ]{5,253}$/`.
+* `enable_events_from_forks` - (Optional, Boolean) Only used for SCM triggers. When enabled, pull request events from forks of the selected repository will trigger a pipeline run.
+  * Constraints: The default value is `false`.
 * `enabled` - (Optional, Boolean) Flag to check if the trigger is enabled. If omitted the trigger is enabled by default.
   * Constraints: The default value is `true`.
 * `event_listener` - (Required, String) Event listener name. The name of the event listener to which the trigger is associated. The event listeners are defined in the definition repositories of the Tekton pipeline.


### PR DESCRIPTION
#### Description

Add support for the `enable_events_from_forks` property of Git Triggers in Tekton Pipeline

#### Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TEST=./ibm/service/cdtektonpipeline TESTARGS='-run=TestAccIBMCdTekton*'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./ibm/service/cdtektonpipeline -v -run=TestAccIBMCdTekton* -timeout 700m
=== RUN   TestAccIBMCdTektonPipelineDefinitionDataSourceBasic
--- PASS: TestAccIBMCdTektonPipelineDefinitionDataSourceBasic (88.86s)
=== RUN   TestAccIBMCdTektonPipelinePropertyDataSourceBasic
--- PASS: TestAccIBMCdTektonPipelinePropertyDataSourceBasic (75.59s)
=== RUN   TestAccIBMCdTektonPipelinePropertyDataSourceAllArgs
--- PASS: TestAccIBMCdTektonPipelinePropertyDataSourceAllArgs (70.66s)
=== RUN   TestAccIBMCdTektonPipelineDataSourceBasic
--- PASS: TestAccIBMCdTektonPipelineDataSourceBasic (71.94s)
=== RUN   TestAccIBMCdTektonPipelineDataSourceAllArgs
--- PASS: TestAccIBMCdTektonPipelineDataSourceAllArgs (75.31s)
=== RUN   TestAccIBMCdTektonPipelineTriggerPropertyDataSourceBasic
--- PASS: TestAccIBMCdTektonPipelineTriggerPropertyDataSourceBasic (72.71s)
=== RUN   TestAccIBMCdTektonPipelineTriggerPropertyDataSourceAllArgs
--- PASS: TestAccIBMCdTektonPipelineTriggerPropertyDataSourceAllArgs (79.58s)
=== RUN   TestAccIBMCdTektonPipelineTriggerDataSourceBasic
--- PASS: TestAccIBMCdTektonPipelineTriggerDataSourceBasic (78.41s)
=== RUN   TestAccIBMCdTektonPipelineTriggerDataSourceAllArgs
--- PASS: TestAccIBMCdTektonPipelineTriggerDataSourceAllArgs (81.62s)
=== RUN   TestAccIBMCdTektonPipelineDefinitionBasic
--- PASS: TestAccIBMCdTektonPipelineDefinitionBasic (107.04s)
=== RUN   TestAccIBMCdTektonPipelinePropertyBasic
--- PASS: TestAccIBMCdTektonPipelinePropertyBasic (94.69s)
=== RUN   TestAccIBMCdTektonPipelinePropertyAllArgs
--- PASS: TestAccIBMCdTektonPipelinePropertyAllArgs (154.73s)
=== RUN   TestAccIBMCdTektonPipelineBasic
--- PASS: TestAccIBMCdTektonPipelineBasic (88.09s)
=== RUN   TestAccIBMCdTektonPipelineAllArgs
--- PASS: TestAccIBMCdTektonPipelineAllArgs (142.32s)
=== RUN   TestAccIBMCdTektonPipelineTriggerPropertyBasic
--- PASS: TestAccIBMCdTektonPipelineTriggerPropertyBasic (122.09s)
=== RUN   TestAccIBMCdTektonPipelineTriggerPropertyAllArgs
--- PASS: TestAccIBMCdTektonPipelineTriggerPropertyAllArgs (158.99s)
=== RUN   TestAccIBMCdTektonPipelineTriggerBasic
--- PASS: TestAccIBMCdTektonPipelineTriggerBasic (145.59s)
=== RUN   TestAccIBMCdTektonPipelineTriggerAllArgs
--- PASS: TestAccIBMCdTektonPipelineTriggerAllArgs (168.15s)
PASS
ok      github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/cdtektonpipeline        1796.127s
```
