### PR TITLE
add orphan_resource_on_delete argument to worker pool resources

### DIFF
--- a/ibm/service/kubernetes/resource_ibm_container_vpc_worker_pool.go
+++ b/ibm/service/kubernetes/resource_ibm_container_vpc_worker_pool.go
@@ -211,13 +211,13 @@ func ResourceIBMContainerVpcWorkerPool() *schema.Resource {
 				Type:             schema.TypeBool,
 				Optional:         true,
 				DiffSuppressFunc: flex.ApplyOnce,
-				Description:      "Import an existing WorkerPool from the cluster, instead of creating a new",
+				Description:      "Import an existing workerpool from the cluster instead of creating a new",
 			},
 
 			"orphan_on_delete": {
 				Type:        schema.TypeBool,
 				Optional:    true,
-				Description: "Orphan the Worker Pool resource, instead of deleting it",
+				Description: "Orphan the workerpool resource instead of deleting it",
 			},
 
 			"autoscale_enabled": {

--- a/ibm/service/kubernetes/resource_ibm_container_vpc_worker_pool.go
+++ b/ibm/service/kubernetes/resource_ibm_container_vpc_worker_pool.go
@@ -721,12 +721,12 @@ func resourceIBMContainerVpcWorkerPoolDelete(d *schema.ResourceData, meta interf
 	if err != nil {
 		return err
 	}
-	var orphan_resource bool = false
+	var orphan_on_delete bool = false
 	if orod, ok := d.GetOk("orphan_on_delete"); ok {
-		orphan_resource = orod.(bool)
+		orphan_on_delete = orod.(bool)
 	}
 
-	if orphan_resource {
+	if orphan_on_delete {
 		log.Printf("[WARN] orphaning %s workerpool", workerPoolNameorID)
 	} else {
 		err = workerPoolsAPI.DeleteWorkerPool(clusterNameorID, workerPoolNameorID, targetEnv)

--- a/ibm/service/kubernetes/resource_ibm_container_vpc_worker_pool.go
+++ b/ibm/service/kubernetes/resource_ibm_container_vpc_worker_pool.go
@@ -214,7 +214,7 @@ func ResourceIBMContainerVpcWorkerPool() *schema.Resource {
 				Description:      "Import an existing WorkerPool from the cluster, instead of creating a new",
 			},
 
-			"orphan_resource_on_delete": {
+			"orphan_on_delete": {
 				Type:        schema.TypeBool,
 				Optional:    true,
 				Description: "Orphan the Worker Pool resource, instead of deleting it",
@@ -722,7 +722,7 @@ func resourceIBMContainerVpcWorkerPoolDelete(d *schema.ResourceData, meta interf
 		return err
 	}
 	var orphan_resource bool = false
-	if orod, ok := d.GetOk("orphan_resource_on_delete"); ok {
+	if orod, ok := d.GetOk("orphan_on_delete"); ok {
 		orphan_resource = orod.(bool)
 	}
 

--- a/ibm/service/kubernetes/resource_ibm_container_vpc_worker_pool.go
+++ b/ibm/service/kubernetes/resource_ibm_container_vpc_worker_pool.go
@@ -214,6 +214,12 @@ func ResourceIBMContainerVpcWorkerPool() *schema.Resource {
 				Description:      "Import an existing WorkerPool from the cluster, instead of creating a new",
 			},
 
+			"orphan_resource_on_delete": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Description: "Orphan the Worker Pool resource, instead of deleting it",
+			},
+
 			"autoscale_enabled": {
 				Type:        schema.TypeBool,
 				Computed:    true,
@@ -715,14 +721,22 @@ func resourceIBMContainerVpcWorkerPoolDelete(d *schema.ResourceData, meta interf
 	if err != nil {
 		return err
 	}
-
-	err = workerPoolsAPI.DeleteWorkerPool(clusterNameorID, workerPoolNameorID, targetEnv)
-	if err != nil {
-		return err
+	var orphan_resource bool = false
+	if orod, ok := d.GetOk("orphan_resource_on_delete"); ok {
+		orphan_resource = orod.(bool)
 	}
-	_, err = WaitForVpcWorkerDelete(clusterNameorID, workerPoolNameorID, meta, d.Timeout(schema.TimeoutDelete), targetEnv)
-	if err != nil {
-		return fmt.Errorf("[ERROR] Error waiting for removing workers of worker pool (%s) of cluster (%s): %s", workerPoolNameorID, clusterNameorID, err)
+
+	if orphan_resource {
+		log.Printf("[WARN] orphaning %s workerpool", workerPoolNameorID)
+	} else {
+		err = workerPoolsAPI.DeleteWorkerPool(clusterNameorID, workerPoolNameorID, targetEnv)
+		if err != nil {
+			return err
+		}
+		_, err = WaitForVpcWorkerDelete(clusterNameorID, workerPoolNameorID, meta, d.Timeout(schema.TimeoutDelete), targetEnv)
+		if err != nil {
+			return fmt.Errorf("[ERROR] Error waiting for removing workers of worker pool (%s) of cluster (%s): %s", workerPoolNameorID, clusterNameorID, err)
+		}
 	}
 	d.SetId("")
 	return nil
@@ -788,7 +802,7 @@ func WaitForWorkerPoolAvailable(d *schema.ResourceData, meta interface{}, cluste
 
 func vpcWorkerPoolStateRefreshFunc(client v2.Workers, instanceID string, workerPoolNameOrID string, target v2.ClusterTargetHeader) resource.StateRefreshFunc {
 	return func() (interface{}, string, error) {
-		workerFields, err := client.ListByWorkerPool(instanceID, "", false, target)
+		workerFields, err := client.ListByWorkerPool(instanceID, workerPoolNameOrID, false, target)
 		if err != nil {
 			return nil, "", fmt.Errorf("[ERROR] Error retrieving workers for cluster: %s", err)
 		}

--- a/ibm/service/kubernetes/resource_ibm_container_vpc_worker_pool_test.go
+++ b/ibm/service/kubernetes/resource_ibm_container_vpc_worker_pool_test.go
@@ -75,7 +75,7 @@ func TestAccIBMContainerVpcClusterWorkerPoolBasic(t *testing.T) {
 				ResourceName:            "ibm_container_vpc_worker_pool.test_pool",
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"orphan_resource_on_delete", "import_on_create"},
+				ImportStateVerifyIgnore: []string{"orphan_on_delete", "import_on_create"},
 			},
 			{
 				Config:  testAccCheckIBMVpcContainerWorkerPoolUpdate(name),
@@ -349,7 +349,7 @@ func testAccCheckIBMVpcContainerWorkerPoolUpdate(cluster_name string) string {
 	  depends_on = [
 		  ibm_container_vpc_worker_pool.default_pool
 	  ]
-	  orphan_resource_on_delete = "true"
+	  orphan_on_delete = "true"
 	}
 		`, acc.IksClusterVpcID, acc.IksClusterSubnetID, cluster_name, workerpool_name)
 }

--- a/ibm/service/kubernetes/resource_ibm_container_worker_pool.go
+++ b/ibm/service/kubernetes/resource_ibm_container_worker_pool.go
@@ -5,6 +5,7 @@ package kubernetes
 
 import (
 	"fmt"
+	"log"
 	"strings"
 	"time"
 
@@ -196,7 +197,13 @@ func ResourceIBMContainerWorkerPool() *schema.Resource {
 				Type:             schema.TypeBool,
 				Optional:         true,
 				DiffSuppressFunc: flex.ApplyOnce,
-				Description:      "Import a workerpool from a cluster",
+				Description:      "Import an existing workerpool from the cluster instead of creating a new",
+			},
+
+			"orphan_on_delete": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Description: "Orphan the workerpool resource instead of deleting it",
 			},
 
 			"autoscale_enabled": {
@@ -475,13 +482,22 @@ func resourceIBMContainerWorkerPoolDelete(d *schema.ResourceData, meta interface
 		return err
 	}
 
-	err = workerPoolsAPI.DeleteWorkerPool(clusterNameorID, workerPoolNameorID, targetEnv)
-	if err != nil {
-		return err
+	var orphan_resource bool = false
+	if orod, ok := d.GetOk("orphan_on_delete"); ok {
+		orphan_resource = orod.(bool)
 	}
-	_, err = WaitForWorkerDelete(clusterNameorID, workerPoolNameorID, meta, d.Timeout(schema.TimeoutUpdate), targetEnv)
-	if err != nil {
-		return fmt.Errorf("[ERROR] Error waiting for removing workers of worker pool (%s) of cluster (%s): %s", workerPoolNameorID, clusterNameorID, err)
+
+	if orphan_resource {
+		log.Printf("[WARN] orphaning %s workerpool", workerPoolNameorID)
+	} else {
+		err = workerPoolsAPI.DeleteWorkerPool(clusterNameorID, workerPoolNameorID, targetEnv)
+		if err != nil {
+			return err
+		}
+		_, err = WaitForWorkerDelete(clusterNameorID, workerPoolNameorID, meta, d.Timeout(schema.TimeoutUpdate), targetEnv)
+		if err != nil {
+			return fmt.Errorf("[ERROR] Error waiting for removing workers of worker pool (%s) of cluster (%s): %s", workerPoolNameorID, clusterNameorID, err)
+		}
 	}
 	return nil
 }

--- a/ibm/service/kubernetes/resource_ibm_container_worker_pool.go
+++ b/ibm/service/kubernetes/resource_ibm_container_worker_pool.go
@@ -482,12 +482,12 @@ func resourceIBMContainerWorkerPoolDelete(d *schema.ResourceData, meta interface
 		return err
 	}
 
-	var orphan_resource bool = false
+	var orphan_on_delete bool = false
 	if orod, ok := d.GetOk("orphan_on_delete"); ok {
-		orphan_resource = orod.(bool)
+		orphan_on_delete = orod.(bool)
 	}
 
-	if orphan_resource {
+	if orphan_on_delete {
 		log.Printf("[WARN] orphaning %s workerpool", workerPoolNameorID)
 	} else {
 		err = workerPoolsAPI.DeleteWorkerPool(clusterNameorID, workerPoolNameorID, targetEnv)

--- a/ibm/service/kubernetes/resource_ibm_container_worker_pool_test.go
+++ b/ibm/service/kubernetes/resource_ibm_container_worker_pool_test.go
@@ -44,6 +44,12 @@ func TestAccIBMContainerWorkerPoolBasic(t *testing.T) {
 						"ibm_container_worker_pool.test_pool", "disk_encryption", "true"),
 					resource.TestCheckResourceAttr(
 						"ibm_container_worker_pool.test_pool", "hardware", "shared"),
+					resource.TestCheckResourceAttr(
+						"ibm_container_worker_pool.default_pool", "size_per_zone", "1"),
+					resource.TestCheckResourceAttr(
+						"ibm_container_worker_pool.default_pool", "labels.%", "0"),
+					resource.TestCheckResourceAttr(
+						"ibm_container_worker_pool.default_pool", "hardware", "shared"),
 				),
 			},
 			{
@@ -61,6 +67,12 @@ func TestAccIBMContainerWorkerPoolBasic(t *testing.T) {
 						"ibm_container_worker_pool.test_pool", "disk_encryption", "true"),
 					resource.TestCheckResourceAttr(
 						"ibm_container_worker_pool.test_pool", "hardware", "shared"),
+					resource.TestCheckResourceAttr(
+						"ibm_container_worker_pool.default_pool", "size_per_zone", "2"),
+					resource.TestCheckResourceAttr(
+						"ibm_container_worker_pool.default_pool", "labels.%", "2"),
+					resource.TestCheckResourceAttr(
+						"ibm_container_worker_pool.default_pool", "hardware", "shared"),
 				),
 			},
 			{
@@ -181,13 +193,13 @@ func testAccCheckIBMContainerWorkerPoolBasic(clusterName, workerPoolName string)
 	return fmt.Sprintf(`
 
 resource "ibm_container_cluster" "testacc_cluster" {
-  name             = "%s"
-  datacenter       = "%s"
-  machine_type     = "%s"
+  name             = "%[1]s"
+  datacenter       = "%[2]s"
+  machine_type     = "%[3]s"
   hardware         = "shared"
-  public_vlan_id   = "%s"
-  private_vlan_id  = "%s"
-  kube_version     = "%s"
+  public_vlan_id   = "%[4]s"
+  private_vlan_id  = "%[5]s"
+  kube_version     = "%[6]s"
   wait_till        = "OneWorkerNodeReady"
   operating_system = "UBUNTU_20_64"
   taints {
@@ -197,9 +209,22 @@ resource "ibm_container_cluster" "testacc_cluster" {
   }
 }
 
+resource "ibm_container_worker_pool" "default_pool" {
+  worker_pool_name = "default"
+  machine_type     = "%[3]s"
+  cluster          = ibm_container_cluster.testacc_cluster.id
+  size_per_zone    = 1
+  import_on_create = "true"
+  taints {
+	key    = "key1"
+	value  = "value1"
+	effect = "NoSchedule"
+  }
+}
+
 resource "ibm_container_worker_pool" "test_pool" {
-  worker_pool_name = "%s"
-  machine_type     = "%s"
+  worker_pool_name = "%[7]s"
+  machine_type     = "%[8]s"
   cluster          = ibm_container_cluster.testacc_cluster.id
   size_per_zone    = 1
   hardware         = "shared"
@@ -220,19 +245,40 @@ func testAccCheckIBMContainerWorkerPoolUpdate(clusterName, workerPoolName string
 	return fmt.Sprintf(`
 
 resource "ibm_container_cluster" "testacc_cluster" {
-  name            = "%s"
-  datacenter      = "%s"
-  machine_type    = "%s"
+  name            = "%[1]s"
+  datacenter      = "%[2]s"
+  machine_type    = "%[3]s"
   hardware        = "shared"
-  public_vlan_id  = "%s"
-  private_vlan_id = "%s"
-  kube_version    = "%s"
+  public_vlan_id  = "%[4]s"
+  private_vlan_id = "%[5]s"
+  kube_version    = "%[6]s"
   wait_till         = "OneWorkerNodeReady"
 }
 
+resource "ibm_container_worker_pool" "default_pool" {
+  worker_pool_name = "default"
+  machine_type     = "%[3]s"
+  cluster          = ibm_container_cluster.testacc_cluster.id
+  size_per_zone    = 2
+  import_on_create = "true"
+  taints {
+	key    = "key1"
+	value  = "value1"
+	effect = "NoSchedule"
+  }
+  labels = {
+    "test"  = "test-pool"
+    "test1" = "test-pool1"
+  }
+  depends_on = [
+		  ibm_container_worker_pool.test_pool
+	  ]
+  orphan_on_delete = "true"
+}
+
 resource "ibm_container_worker_pool" "test_pool" {
-  worker_pool_name = "%s"
-  machine_type     = "%s"
+  worker_pool_name = "%[7]s"
+  machine_type     = "%[8]s"
   cluster          = ibm_container_cluster.testacc_cluster.id
   size_per_zone    = 2
   hardware         = "shared"
@@ -326,140 +372,4 @@ resource "ibm_container_worker_pool" "test_pool" {
     "test1" = "test-pool1"
   }
 }`, workerPoolName, acc.MachineType, clusterName)
-}
-
-func TestAccIBMContainerWorkerPoolImportOnCreate(t *testing.T) {
-
-	clusterName := fmt.Sprintf("tf-cluster-worker-%d", acctest.RandIntRange(10, 100))
-
-	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { acc.TestAccPreCheck(t) },
-		Providers:    acc.TestAccProviders,
-		CheckDestroy: testAccCheckIBMContainerWorkerPoolDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccCheckIBMContainerWorkerPoolImportOnCreate(clusterName),
-				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(
-						"ibm_container_worker_pool.test_pool", "worker_pool_name", "default"),
-					resource.TestCheckResourceAttr(
-						"ibm_container_worker_pool.test_pool", "size_per_zone", "1"),
-					resource.TestCheckResourceAttr(
-						"ibm_container_worker_pool.test_pool", "labels.%", "2"),
-					resource.TestCheckResourceAttr(
-						"ibm_container_worker_pool.test_pool", "hardware", "shared"),
-				),
-			},
-			{
-				Config: testAccCheckIBMContainerWorkerPoolImportOnCreateClusterUpdate(clusterName),
-				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(
-						"ibm_container_worker_pool.test_pool", "worker_pool_name", "default"),
-					resource.TestCheckResourceAttr(
-						"ibm_container_worker_pool.test_pool", "size_per_zone", "1"),
-					resource.TestCheckResourceAttr(
-						"ibm_container_worker_pool.test_pool", "labels.%", "2"),
-					resource.TestCheckResourceAttr(
-						"ibm_container_worker_pool.test_pool", "hardware", "shared"),
-				),
-			},
-			{
-				Config: testAccCheckIBMContainerWorkerPoolImportOnCreateWPUpdate(clusterName),
-				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(
-						"ibm_container_worker_pool.test_pool", "worker_pool_name", "default"),
-					resource.TestCheckResourceAttr(
-						"ibm_container_worker_pool.test_pool", "size_per_zone", "3"),
-					resource.TestCheckResourceAttr(
-						"ibm_container_worker_pool.test_pool", "labels.%", "2"),
-					resource.TestCheckResourceAttr(
-						"ibm_container_worker_pool.test_pool", "hardware", "shared"),
-				),
-			},
-		},
-	})
-}
-
-func testAccCheckIBMContainerWorkerPoolImportOnCreate(clusterName string) string {
-	return fmt.Sprintf(`
-
-resource "ibm_container_cluster" "testacc_cluster" {
-  name              = "%s"
-  datacenter        = "%s"
-  machine_type      = "%s"
-  hardware          = "shared"
-  public_vlan_id    = "%s"
-  private_vlan_id   = "%s"
-  kube_version      = "%s"
-  wait_till         = "OneWorkerNodeReady"
-  default_pool_size = 1
-  labels = {
-    "test"  = "test-pool"
-    "test1" = "test-pool1"
-  }
-}
-
-resource "ibm_container_worker_pool" "test_pool" {
-  worker_pool_name = "default"
-  machine_type     = "%[3]s"
-  cluster          = ibm_container_cluster.testacc_cluster.id
-  size_per_zone    = 1
-  import_on_create = "true"
-}`, clusterName, acc.Datacenter, acc.MachineType, acc.PublicVlanID, acc.PrivateVlanID, acc.KubeVersion)
-}
-
-func testAccCheckIBMContainerWorkerPoolImportOnCreateClusterUpdate(clusterName string) string {
-	return fmt.Sprintf(`
-
-resource "ibm_container_cluster" "testacc_cluster" {
-  name              = "%s"
-  datacenter        = "%s"
-  machine_type      = "%s"
-  hardware          = "shared"
-  public_vlan_id    = "%s"
-  private_vlan_id   = "%s"
-  kube_version      = "%s"
-  wait_till         = "OneWorkerNodeReady"
-  default_pool_size = 3
-  labels = {
-    "test"  = "test-pool"
-    "test1" = "test-pool1"
-  }
-}
-
-resource "ibm_container_worker_pool" "test_pool" {
-  worker_pool_name = "default"
-  machine_type     = "%[3]s"
-  cluster          = ibm_container_cluster.testacc_cluster.id
-  size_per_zone    = 1
-  import_on_create = "true"
-}`, clusterName, acc.Datacenter, acc.MachineType, acc.PublicVlanID, acc.PrivateVlanID, acc.KubeVersion)
-}
-
-func testAccCheckIBMContainerWorkerPoolImportOnCreateWPUpdate(clusterName string) string {
-	return fmt.Sprintf(`
-
-resource "ibm_container_cluster" "testacc_cluster" {
-  name              = "%s"
-  datacenter        = "%s"
-  machine_type      = "%s"
-  hardware          = "shared"
-  public_vlan_id    = "%s"
-  private_vlan_id   = "%s"
-  kube_version      = "%s"
-  wait_till         = "OneWorkerNodeReady"
-  default_pool_size = 1
-  labels = {
-    "test"  = "test-pool"
-    "test1" = "test-pool1"
-  }
-}
-
-resource "ibm_container_worker_pool" "test_pool" {
-  worker_pool_name = "default"
-  machine_type     = "%[3]s"
-  cluster          = ibm_container_cluster.testacc_cluster.id
-  size_per_zone    = 3
-  import_on_create = "true"
-}`, clusterName, acc.Datacenter, acc.MachineType, acc.PublicVlanID, acc.PrivateVlanID, acc.KubeVersion)
 }

--- a/website/docs/r/container_vpc_worker_pool.html.markdown
+++ b/website/docs/r/container_vpc_worker_pool.html.markdown
@@ -105,7 +105,7 @@ Review the argument references that you can specify for your resource.
 - `kms_instance_id` - Instance ID for boot volume encryption. 
 - `kms_account_id` - Account ID for boot volume encryption, if other account is providing the kms.
 - `import_on_create` - (Optional, Bool) Import an existing WorkerPool from the cluster, instead of creating a new.
-- `orphan_on_delete` - (Optional, Bool) Orphan the Worker Pool resource, instead of deleting it. The argument allows to remove the worker pool from the state, without deleting the actual cloud resource. The worker pool can be re-imported into the state using the `import_on_create` argument.
+- `orphan_on_delete` - (Optional, Bool) Orphan the Worker Pool resource, instead of deleting it. The argument allows the user to remove the worker pool from the state, without deleting the actual cloud resource. The worker pool can be re-imported into the state using the `import_on_create` argument.
 - `security_groups` - (Optional, List) Enables users to define specific security groups for their workers.
 
 ## Attribute reference

--- a/website/docs/r/container_vpc_worker_pool.html.markdown
+++ b/website/docs/r/container_vpc_worker_pool.html.markdown
@@ -105,7 +105,7 @@ Review the argument references that you can specify for your resource.
 - `kms_instance_id` - Instance ID for boot volume encryption. 
 - `kms_account_id` - Account ID for boot volume encryption, if other account is providing the kms.
 - `import_on_create` - (Optional, Bool) Import an existing WorkerPool from the cluster, instead of creating a new.
-- `orphan_resource_on_delete` - (Optional, Bool) Orphan the Worker Pool resource, instead of deleting it. The argument allows to remove the worker pool from the state, without deleting the actual cloud resource.
+- `orphan_resource_on_delete` - (Optional, Bool) Orphan the Worker Pool resource, instead of deleting it. The argument allows to remove the worker pool from the state, without deleting the actual cloud resource. The worker pool can be re-imported into the state using the `import_on_create` argument.
 - `security_groups` - (Optional, List) Enables users to define specific security groups for their workers.
 
 ## Attribute reference

--- a/website/docs/r/container_vpc_worker_pool.html.markdown
+++ b/website/docs/r/container_vpc_worker_pool.html.markdown
@@ -105,7 +105,7 @@ Review the argument references that you can specify for your resource.
 - `kms_instance_id` - Instance ID for boot volume encryption. 
 - `kms_account_id` - Account ID for boot volume encryption, if other account is providing the kms.
 - `import_on_create` - (Optional, Bool) Import an existing WorkerPool from the cluster, instead of creating a new.
-- `orphan_resource_on_delete` - (Optional, Bool) Orphan the Worker Pool resource, instead of deleting it. The argument allows to remove the worker pool from the state, without deleting the actual cloud resource. The worker pool can be re-imported into the state using the `import_on_create` argument.
+- `orphan_on_delete` - (Optional, Bool) Orphan the Worker Pool resource, instead of deleting it. The argument allows to remove the worker pool from the state, without deleting the actual cloud resource. The worker pool can be re-imported into the state using the `import_on_create` argument.
 - `security_groups` - (Optional, List) Enables users to define specific security groups for their workers.
 
 ## Attribute reference

--- a/website/docs/r/container_vpc_worker_pool.html.markdown
+++ b/website/docs/r/container_vpc_worker_pool.html.markdown
@@ -105,6 +105,7 @@ Review the argument references that you can specify for your resource.
 - `kms_instance_id` - Instance ID for boot volume encryption. 
 - `kms_account_id` - Account ID for boot volume encryption, if other account is providing the kms.
 - `import_on_create` - (Optional, Bool) Import an existing WorkerPool from the cluster, instead of creating a new.
+- `orphan_resource_on_delete` - (Optional, Bool) Orphan the Worker Pool resource, instead of deleting it. The argument allows to remove the worker pool from the state, without deleting the actual cloud resource.
 - `security_groups` - (Optional, List) Enables users to define specific security groups for their workers.
 
 ## Attribute reference

--- a/website/docs/r/container_worker_pool.html.markdown
+++ b/website/docs/r/container_worker_pool.html.markdown
@@ -78,7 +78,7 @@ Review the argument references that you can specify for your resource.
   - `value` - (Required, String) Value for taint.
   - `effect` - (Required, String) Effect for taint. Accepted values are `NoSchedule`, `PreferNoSchedule`, and `NoExecute`.
 - `import_on_create` - (Optional, Bool) Import an existing WorkerPool from the cluster, instead of creating a new.
-- `orphan_on_delete` - (Optional, Bool) Orphan the Worker Pool resource, instead of deleting it. The argument allows to remove the worker pool from the state, without deleting the actual cloud resource. The worker pool can be re-imported into the state using the `import_on_create` argument.
+- `orphan_on_delete` - (Optional, Bool) Orphan the Worker Pool resource, instead of deleting it. The argument allows the user to remove the worker pool from the state, without deleting the actual cloud resource. The worker pool can be re-imported into the state using the `import_on_create` argument.
  
 
 **Deprecated reference**

--- a/website/docs/r/container_worker_pool.html.markdown
+++ b/website/docs/r/container_worker_pool.html.markdown
@@ -77,6 +77,8 @@ Review the argument references that you can specify for your resource.
   - `key` - (Required, String) Key for taint.
   - `value` - (Required, String) Value for taint.
   - `effect` - (Required, String) Effect for taint. Accepted values are `NoSchedule`, `PreferNoSchedule`, and `NoExecute`.
+- `import_on_create` - (Optional, Bool) Import an existing WorkerPool from the cluster, instead of creating a new.
+- `orphan_on_delete` - (Optional, Bool) Orphan the Worker Pool resource, instead of deleting it. The argument allows to remove the worker pool from the state, without deleting the actual cloud resource. The worker pool can be re-imported into the state using the `import_on_create` argument.
  
 
 **Deprecated reference**


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/IBM-Cloud/terraform-provider-ibm/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
=== RUN   TestAccIBMContainerVpcClusterWorkerPoolBasic
--- PASS: TestAccIBMContainerVpcClusterWorkerPoolBasic (1332.86s)
PASS
ok      github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/kubernetes      1336.034s

=== RUN   TestAccIBMContainerWorkerPoolBasic
--- PASS: TestAccIBMContainerWorkerPoolBasic (1584.97s)
PASS
ok      github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/kubernetes      1588.354s

after rebase the tests look good

=== RUN   TestAccIBMContainerWorkerPoolBasic
--- PASS: TestAccIBMContainerWorkerPoolBasic (1656.27s)
PASS
ok      github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/kubernetes      1670.290s

=== RUN   TestAccIBMContainerVpcClusterWorkerPoolBasic
--- PASS: TestAccIBMContainerVpcClusterWorkerPoolBasic (2232.08s)
PASS
ok      github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/kubernetes      2239.474s

after var renames

=== RUN   TestAccIBMContainerVpcClusterWorkerPoolBasic
--- PASS: TestAccIBMContainerVpcClusterWorkerPoolBasic (1545.40s)
PASS
ok      github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/kubernetes      1552.393s

=== RUN   TestAccIBMContainerWorkerPoolBasic
--- PASS: TestAccIBMContainerWorkerPoolBasic (1711.53s)
PASS
ok      github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/kubernetes      1721.652s
```
