### PR TITLE
sat location name now mutable

### DIFF
--- a/ibm/service/satellite/resource_ibm_satellite_location.go
+++ b/ibm/service/satellite/resource_ibm_satellite_location.go
@@ -65,7 +65,7 @@ func ResourceIBMSatelliteLocation() *schema.Resource {
 				return flex.ResourceTagsCustomizeDiff(diff)
 			},
 			func(_ context.Context, diff *schema.ResourceDiff, v interface{}) error {
-				return flex.ImmutableResourceCustomizeDiff([]string{satLocation, sateLocZone, "resource_group_id", "zones"}, diff)
+				return flex.ImmutableResourceCustomizeDiff([]string{sateLocZone, "resource_group_id", "zones"}, diff)
 			},
 		),
 
@@ -471,14 +471,14 @@ func resourceIBMSatelliteLocationUpdate(d *schema.ResourceData, meta interface{}
 }
 
 func resourceIBMSatelliteLocationDelete(d *schema.ResourceData, meta interface{}) error {
+	ID := d.Id()
 	satClient, err := meta.(conns.ClientSession).SatelliteClientSession()
 	if err != nil {
 		return err
 	}
 
 	removeSatLocOptions := &kubernetesserviceapiv1.RemoveSatelliteLocationOptions{}
-	name := d.Get(satLocation).(string)
-	removeSatLocOptions.Controller = &name
+	removeSatLocOptions.Controller = &ID
 
 	response, err := satClient.RemoveSatelliteLocation(removeSatLocOptions)
 	if err != nil && response.StatusCode != 404 {
@@ -486,7 +486,7 @@ func resourceIBMSatelliteLocationDelete(d *schema.ResourceData, meta interface{}
 	}
 
 	//Wait for location to delete
-	_, err = waitForLocationDelete(name, d, meta)
+	_, err = waitForLocationDelete(ID, d, meta)
 	if err != nil {
 		return fmt.Errorf("[ERROR] Error waiting for deleting location instance: %s", err)
 	}


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/IBM-Cloud/terraform-provider-ibm/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```
