### PR TITLE
ibm_container_vpc_worker_pool - remove Computed for secondary_storage property

### DIFF
--- a/ibm/acctest/acctest.go
+++ b/ibm/acctest/acctest.go
@@ -1655,7 +1655,7 @@ func init() {
 	}
 
 	KmsAccountID = os.Getenv("IBM_KMS_ACCOUNT_ID")
-	if CrkID == "" {
+	if KmsAccountID == "" {
 		fmt.Println("[INFO] Set the environment variable IBM_KMS_ACCOUNT_ID for ibm_container_vpc_cluster resource or datasource else tests will fail if this is not set correctly")
 	}
 

--- a/ibm/service/kubernetes/data_source_ibm_container_vpc_worker_pool_test.go
+++ b/ibm/service/kubernetes/data_source_ibm_container_vpc_worker_pool_test.go
@@ -116,7 +116,7 @@ func testAccCheckIBMContainerVPCClusterWorkerPoolDataSourceConfigDedicatedHost(n
 }
 
 func testAccCheckIBMContainerVPCClusterWorkerPoolDataSourceEnvvar(name string) string {
-	return testAccCheckIBMVpcContainerWorkerPoolEnvvar(name) + `
+	return testAccCheckIBMVpcContainerWorkerPoolBasic(name) + `
 	data "ibm_container_vpc_cluster_worker_pool" "testacc_ds_worker_pool" {
 	    cluster = "${ibm_container_vpc_worker_pool.test_pool.cluster}"
 	    worker_pool_name = "${ibm_container_vpc_worker_pool.test_pool.worker_pool_name}"
@@ -125,7 +125,7 @@ func testAccCheckIBMContainerVPCClusterWorkerPoolDataSourceEnvvar(name string) s
 }
 
 func testAccCheckIBMContainerVPCClusterWorkerPoolDataSourceKmsAccountEnvvar(name string) string {
-	return testAccCheckIBMVpcContainerWorkerPoolKmsAccountEnvvar(name) + `
+	return testAccCheckIBMVpcContainerWorkerPoolKmsAccount(name) + `
 	data "ibm_container_vpc_cluster_worker_pool" "testacc_ds_kms_worker_pool" {
 	    cluster = "${ibm_container_vpc_worker_pool.test_pool.cluster}"
 	    worker_pool_name = "${ibm_container_vpc_worker_pool.test_pool.worker_pool_name}"

--- a/ibm/service/kubernetes/data_source_ibm_container_vpc_worker_pool_test.go
+++ b/ibm/service/kubernetes/data_source_ibm_container_vpc_worker_pool_test.go
@@ -13,8 +13,44 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 )
 
-func TestAccIBMContainerVPCClusterWorkerPoolDataSource_basic(t *testing.T) {
-	name := fmt.Sprintf("tf-vpc-worker-%d", acctest.RandIntRange(10, 100))
+func testAccIBMContainerVPCClusterWorkerPoolDataSourceBase(cluster_name string) string {
+	return fmt.Sprintf(`
+	data "ibm_resource_group" "resource_group" {
+		is_default=true
+	}
+	
+	resource "ibm_container_vpc_cluster" "cluster" {
+	  name              = "%[3]s"
+	  vpc_id            = "%[1]s"
+	  flavor            = "cx2.2x4"
+	  worker_count      = 1
+	  resource_group_id = data.ibm_resource_group.resource_group.id
+	  wait_till         = "MasterNodeReady"
+	  zones {
+		subnet_id = "%[2]s"
+		name      = "us-south-1"
+	  }
+	}
+
+	resource "ibm_container_vpc_worker_pool" "test_pool" {
+		cluster           = ibm_container_vpc_cluster.cluster.id
+		vpc_id            = "%[1]s"
+		flavor            = "cx2.2x4"
+		worker_count      = 1
+		worker_pool_name  = "default"
+		zones {
+			subnet_id = "%[2]s"
+			name      = "us-south-1"
+		}
+		import_on_create  = "true"
+		orphan_on_delete = "true"
+	}
+		`, acc.IksClusterVpcID, acc.IksClusterSubnetID, cluster_name)
+}
+
+// TestAccIBMContainerVpcClusterWorkerPoolDataSourceBasic ...
+func TestAccIBMContainerVpcClusterWorkerPoolDataSourceBasic(t *testing.T) {
+	name := fmt.Sprintf("tf-vpc-wp-ds-basic-%d", acctest.RandIntRange(10, 100))
 	resource.Test(t, resource.TestCase{
 		PreCheck:  func() { acc.TestAccPreCheck(t) },
 		Providers: acc.TestAccProviders,
@@ -29,8 +65,23 @@ func TestAccIBMContainerVPCClusterWorkerPoolDataSource_basic(t *testing.T) {
 	})
 }
 
-func TestAccIBMContainerVPCClusterWorkerPoolDataSource_dedicatedhost(t *testing.T) {
-	name := fmt.Sprintf("tf-vpc-worker-%d", acctest.RandIntRange(10, 100))
+func testAccCheckIBMContainerVPCClusterWorkerPoolDataSourceConfig(name string) string {
+	return testAccIBMContainerVPCClusterWorkerPoolDataSourceBase(name) + `
+	data "ibm_container_vpc_cluster_worker_pool" "testacc_ds_worker_pool" {
+	    cluster = "${ibm_container_vpc_cluster.cluster.id}"
+	    worker_pool_name = "${ibm_container_vpc_worker_pool.test_pool.worker_pool_name}"
+	}
+`
+}
+
+// TestAccIBMContainerVpcClusterWorkerPoolDataSourceDedicatedHost ...
+func TestAccIBMContainerVpcClusterWorkerPoolDataSourceDedicatedHost(t *testing.T) {
+	if acc.HostPoolID == "" {
+		fmt.Println("[WARN] Skipping TestAccIBMContainerVpcClusterWorkerPoolResourceDedicatedHost - IBM_CONTAINER_DEDICATEDHOST_POOL_ID is unset")
+		return
+	}
+
+	name := fmt.Sprintf("tf-vpc-wp-ds-dhost-%d", acctest.RandIntRange(10, 100))
 	hostpoolID := acc.HostPoolID
 	resource.Test(t, resource.TestCase{
 		PreCheck:  func() { acc.TestAccPreCheck(t) },
@@ -40,62 +91,6 @@ func TestAccIBMContainerVPCClusterWorkerPoolDataSource_dedicatedhost(t *testing.
 				Config: testAccCheckIBMContainerVPCClusterWorkerPoolDataSourceConfigDedicatedHost(name, hostpoolID),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("data.ibm_container_vpc_worker_pool.vpc_worker_pool", "host_pool_id", hostpoolID),
-				),
-			},
-		},
-	})
-}
-
-func testAccCheckIBMContainerVPCClusterWorkerPoolDataSourceConfig(name string) string {
-	return testAccCheckIBMVpcContainerWorkerPoolBasic(name) + `
-	data "ibm_container_vpc_cluster_worker_pool" "testacc_ds_worker_pool" {
-	    cluster = "${ibm_container_vpc_cluster.cluster.id}"
-	    worker_pool_name = "${ibm_container_vpc_worker_pool.test_pool.worker_pool_name}"
-	}
-`
-}
-
-func TestAccIBMContainerVPCClusterWorkerPoolDataSourceEnvvar(t *testing.T) {
-	name := fmt.Sprintf("tf-vpc-wp-%d", acctest.RandIntRange(10, 100))
-	testChecks := []resource.TestCheckFunc{
-		resource.TestCheckResourceAttrSet("data.ibm_container_vpc_cluster_worker_pool.testacc_ds_worker_pool", "id"),
-		resource.TestCheckResourceAttr("data.ibm_container_vpc_cluster_worker_pool.testacc_ds_worker_pool", "autoscale_enabled", "false"),
-	}
-	if acc.CrkID != "" {
-		testChecks = append(testChecks,
-			resource.TestCheckResourceAttr("data.ibm_container_vpc_cluster_worker_pool.testacc_ds_worker_pool", "crk", acc.CrkID),
-			resource.TestCheckResourceAttr("data.ibm_container_vpc_cluster_worker_pool.testacc_ds_worker_pool", "kms_instance_id", acc.KmsInstanceID),
-		)
-	}
-	if acc.WorkerPoolSecondaryStorage != "" {
-		testChecks = append(testChecks, resource.TestCheckResourceAttr(
-			"data.ibm_container_vpc_cluster_worker_pool.testacc_ds_worker_pool", "secondary_storage.0.name", acc.WorkerPoolSecondaryStorage))
-	}
-	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { acc.TestAccPreCheck(t) },
-		Providers: acc.TestAccProviders,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccCheckIBMContainerVPCClusterWorkerPoolDataSourceEnvvar(name),
-				Check:  resource.ComposeTestCheckFunc(testChecks...),
-			},
-		},
-	})
-}
-
-func TestAccIBMContainerVPCClusterWorkerPoolDataSourceKmsAccountEnvvar(t *testing.T) {
-	name := fmt.Sprintf("tf-vpc-wp-%d", acctest.RandIntRange(10, 100))
-	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { acc.TestAccPreCheck(t) },
-		Providers: acc.TestAccProviders,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccCheckIBMContainerVPCClusterWorkerPoolDataSourceKmsAccountEnvvar(name),
-				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttrSet("data.ibm_container_vpc_cluster_worker_pool.testacc_ds_kms_worker_pool", "id"),
-					resource.TestCheckResourceAttr("data.ibm_container_vpc_cluster_worker_pool.testacc_ds_kms_worker_pool", "crk", acc.CrkID),
-					resource.TestCheckResourceAttr("data.ibm_container_vpc_cluster_worker_pool.testacc_ds_kms_worker_pool", "kms_instance_id", acc.KmsInstanceID),
-					resource.TestCheckResourceAttr("data.ibm_container_vpc_cluster_worker_pool.testacc_ds_kms_worker_pool", "kms_account_id", acc.KmsAccountID),
 				),
 			},
 		},
@@ -115,8 +110,59 @@ func testAccCheckIBMContainerVPCClusterWorkerPoolDataSourceConfigDedicatedHost(n
 `
 }
 
-func testAccCheckIBMContainerVPCClusterWorkerPoolDataSourceEnvvar(name string) string {
-	return testAccCheckIBMVpcContainerWorkerPoolBasic(name) + `
+// TestAccIBMContainerVpcClusterWorkerPoolDataSourceSecondaryStorage ...
+func TestAccIBMContainerVpcClusterWorkerPoolDataSourceSecondaryStorage(t *testing.T) {
+	name := fmt.Sprintf("tf-vpc-wp-ds-secstorage-%d", acctest.RandIntRange(10, 100))
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { acc.TestAccPreCheck(t) },
+		Providers: acc.TestAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckIBMContainerVPCClusterWorkerPoolDataSourceSecStorage(name),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet("data.ibm_container_vpc_cluster_worker_pool.testacc_ds_worker_pool", "id"),
+					resource.TestCheckResourceAttr(
+						"data.ibm_container_vpc_cluster_worker_pool.testacc_ds_worker_pool", "secondary_storage.0.name", acc.WorkerPoolSecondaryStorage)),
+			},
+		},
+	})
+}
+
+func testAccCheckIBMContainerVPCClusterWorkerPoolDataSourceSecStorage(name string) string {
+	return testAccCheckIBMVpcContainerWorkerPoolSecStorage(name) + `
+	data "ibm_container_vpc_cluster_worker_pool" "testacc_ds_worker_pool" {
+	    cluster = "${ibm_container_vpc_worker_pool.test_pool.cluster}"
+	    worker_pool_name = "${ibm_container_vpc_worker_pool.test_pool.worker_pool_name}"
+	}
+	`
+}
+
+// TestAccIBMContainerVpcClusterWorkerPoolDataSourceKMS ...
+func TestAccIBMContainerVpcClusterWorkerPoolDataSourceKMS(t *testing.T) {
+	if acc.CrkID == "" {
+		fmt.Println("[WARN] Skipping TestAccIBMContainerVpcClusterWorkerPoolDataSourceKMS - IBM_CRK_ID is unset")
+		return
+	}
+	name := fmt.Sprintf("tf-vpc-wp-ds-kms-%d", acctest.RandIntRange(10, 100))
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { acc.TestAccPreCheck(t) },
+		Providers: acc.TestAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckIBMContainerVPCClusterWorkerPoolDataSourceKMS(name),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet("data.ibm_container_vpc_cluster_worker_pool.testacc_ds_worker_pool", "id"),
+					resource.TestCheckResourceAttr("data.ibm_container_vpc_cluster_worker_pool.testacc_ds_worker_pool", "autoscale_enabled", "false"),
+					resource.TestCheckResourceAttr("data.ibm_container_vpc_cluster_worker_pool.testacc_ds_worker_pool", "crk", acc.CrkID),
+					resource.TestCheckResourceAttr("data.ibm_container_vpc_cluster_worker_pool.testacc_ds_worker_pool", "kms_instance_id", acc.KmsInstanceID),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckIBMContainerVPCClusterWorkerPoolDataSourceKMS(name string) string {
+	return testAccCheckIBMVpcContainerWorkerPoolKMS(name) + `
 	data "ibm_container_vpc_cluster_worker_pool" "testacc_ds_worker_pool" {
 	    cluster = "${ibm_container_vpc_worker_pool.test_pool.cluster}"
 	    worker_pool_name = "${ibm_container_vpc_worker_pool.test_pool.worker_pool_name}"
@@ -124,7 +170,30 @@ func testAccCheckIBMContainerVPCClusterWorkerPoolDataSourceEnvvar(name string) s
 `
 }
 
-func testAccCheckIBMContainerVPCClusterWorkerPoolDataSourceKmsAccountEnvvar(name string) string {
+// TestAccIBMContainerVpcClusterWorkerPoolDataSourceKmsAccount ...
+func TestAccIBMContainerVpcClusterWorkerPoolDataSourceKmsAccount(t *testing.T) {
+	if acc.KmsAccountID == "" {
+		fmt.Println("[WARN] Skipping TestAccIBMContainerVpcClusterWorkerPoolDataSourceKmsAccount - IBM_KMS_ACCOUNT_ID is unset")
+		return
+	}
+	name := fmt.Sprintf("tf-vpc-wp-ds-kmsacc-%d", acctest.RandIntRange(10, 100))
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { acc.TestAccPreCheck(t) },
+		Providers: acc.TestAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckIBMContainerVPCClusterWorkerPoolDataSourceKmsAccount(name),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet("data.ibm_container_vpc_cluster_worker_pool.testacc_ds_kms_worker_pool", "id"),
+					resource.TestCheckResourceAttr("data.ibm_container_vpc_cluster_worker_pool.testacc_ds_kms_worker_pool", "crk", acc.CrkID),
+					resource.TestCheckResourceAttr("data.ibm_container_vpc_cluster_worker_pool.testacc_ds_kms_worker_pool", "kms_instance_id", acc.KmsInstanceID),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckIBMContainerVPCClusterWorkerPoolDataSourceKmsAccount(name string) string {
 	return testAccCheckIBMVpcContainerWorkerPoolKmsAccount(name) + `
 	data "ibm_container_vpc_cluster_worker_pool" "testacc_ds_kms_worker_pool" {
 	    cluster = "${ibm_container_vpc_worker_pool.test_pool.cluster}"

--- a/ibm/service/kubernetes/resource_ibm_container_vpc_worker_pool.go
+++ b/ibm/service/kubernetes/resource_ibm_container_vpc_worker_pool.go
@@ -165,7 +165,6 @@ func ResourceIBMContainerVpcWorkerPool() *schema.Resource {
 			"secondary_storage": {
 				Type:        schema.TypeString,
 				Optional:    true,
-				Computed:    true,
 				ForceNew:    true,
 				Description: "The secondary storage option for the workers in the worker pool.",
 			},


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/IBM-Cloud/terraform-provider-ibm/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
% make testacc TEST=./ibm/service/kubernetes TESTARGS='-run=TestAccIBMContainerVpcClusterWorkerPool'
...
=== RUN   TestAccIBMContainerVpcClusterWorkerPoolDataSourceBasic
--- PASS: TestAccIBMContainerVpcClusterWorkerPoolDataSourceBasic (1081.74s)
=== RUN   TestAccIBMContainerVpcClusterWorkerPoolDataSourceDedicatedHost
[WARN] Skipping TestAccIBMContainerVpcClusterWorkerPoolResourceDedicatedHost - IBM_CONTAINER_DEDICATEDHOST_POOL_ID is unset
--- PASS: TestAccIBMContainerVpcClusterWorkerPoolDataSourceDedicatedHost (0.00s)
=== RUN   TestAccIBMContainerVpcClusterWorkerPoolDataSourceSecondaryStorage
--- PASS: TestAccIBMContainerVpcClusterWorkerPoolDataSourceSecondaryStorage (1293.06s)
=== RUN   TestAccIBMContainerVpcClusterWorkerPoolDataSourceKMS
--- PASS: TestAccIBMContainerVpcClusterWorkerPoolDataSourceKMS (1363.61s)
=== RUN   TestAccIBMContainerVpcClusterWorkerPoolDataSourceKmsAccount
--- PASS: TestAccIBMContainerVpcClusterWorkerPoolDataSourceKmsAccount (1422.21s)
=== RUN   TestAccIBMContainerVpcClusterWorkerPoolResourceBasic
--- PASS: TestAccIBMContainerVpcClusterWorkerPoolResourceBasic (1487.21s)
=== RUN   TestAccIBMContainerVpcClusterWorkerPoolResourceSecurityGroups
--- PASS: TestAccIBMContainerVpcClusterWorkerPoolResourceSecurityGroups (1341.94s)
=== RUN   TestAccIBMContainerVpcClusterWorkerPoolResourceDedicatedHost
[WARN] Skipping TestAccIBMContainerVpcClusterWorkerPoolResourceDedicatedHost - IBM_CONTAINER_DEDICATEDHOST_POOL_ID is unset
--- PASS: TestAccIBMContainerVpcClusterWorkerPoolResourceDedicatedHost (0.00s)
=== RUN   TestAccIBMContainerVpcClusterWorkerPoolResourceSecondaryStorage
--- PASS: TestAccIBMContainerVpcClusterWorkerPoolResourceSecondaryStorage (1605.29s)
=== RUN   TestAccIBMContainerVpcClusterWorkerPoolResourceKMS
--- PASS: TestAccIBMContainerVpcClusterWorkerPoolResourceKMS (1437.07s)
=== RUN   TestAccIBMContainerVpcClusterWorkerPoolResourceKmsAccount
--- PASS: TestAccIBMContainerVpcClusterWorkerPoolResourceKmsAccount (1569.82s)
PASS
ok      github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/kubernetes      12607.506s
...
```
