### PR TITLE
Fix potential null pointer bug in pi capture user tags during creation

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -140,8 +140,6 @@ github.com/IBM/container-registry-go-sdk v1.1.0 h1:sYyknIod8R4RJZQqAheiduP6wbSTp
 github.com/IBM/container-registry-go-sdk v1.1.0/go.mod h1:4TwsCnQtVfZ4Vkapy/KPvQBKFc3VOyUZYkwRU4FTPrs=
 github.com/IBM/continuous-delivery-go-sdk/v2 v2.0.2 h1:yCJJnSLNYkpF7v9n0tw8CpQbSy43E/NbFOopRf1PgoM=
 github.com/IBM/continuous-delivery-go-sdk/v2 v2.0.2/go.mod h1:2MajFr6C5H2jyj7qtjBxAPnZAjbPiK4CAJNk3fKNnPo=
-github.com/IBM/event-notifications-go-admin-sdk v0.10.0 h1:SbEG6Z9lJWQxNYexYmLRzF+seFokOW7bRKBgiyfYsls=
-github.com/IBM/event-notifications-go-admin-sdk v0.10.0/go.mod h1:za2mdfBpox6hdsKaYTbE5ooCv2im8BYPq5yuKc7x5Ao=
 github.com/IBM/event-notifications-go-admin-sdk v0.11.0 h1:X/GhBE6dGRx8s79xYrdmv88ljD/8hSCyh9jMSUPCcCc=
 github.com/IBM/event-notifications-go-admin-sdk v0.11.0/go.mod h1:za2mdfBpox6hdsKaYTbE5ooCv2im8BYPq5yuKc7x5Ao=
 github.com/IBM/eventstreams-go-sdk v1.4.0 h1:yS/Ns29sBOe8W2tynQmz9HTKqQZ0ckse4Py5Oy/F2rM=

--- a/ibm/service/power/resource_ibm_pi_capture.go
+++ b/ibm/service/power/resource_ibm_pi_capture.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"fmt"
 	"log"
+	"strings"
 	"time"
 
 	st "github.com/IBM-Cloud/power-go-client/clients/instance"
@@ -196,7 +197,10 @@ func resourceIBMPICaptureCreate(ctx context.Context, d *schema.ResourceData, met
 		imageClient := st.NewIBMPIImageClient(ctx, sess, cloudInstanceID)
 		imagedata, err := imageClient.Get(capturename)
 		if err != nil {
-			log.Printf("Error on get of ibm pi capture (%s) while applying pi_user_tags: %s", capturename, err)
+			if strings.Contains(err.Error(), NotFound) {
+				d.SetId("")
+			}
+			return diag.Errorf("Error on get of ibm pi capture (%s) while applying pi_user_tags: %s", capturename, err)
 		}
 		if imagedata.Crn != "" {
 			oldList, newList := d.GetChange(Arg_UserTags)


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/IBM-Cloud/terraform-provider-ibm/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Description:
Fixes bug where capture image data CRN was read even though it could be nil during user tag handling in the creation function, which would cause an error.

Output from acceptance testing:

```
=== RUN   TestAccIBMPICaptureBasic
--- PASS: TestAccIBMPICaptureBasic (81.80s)
PASS
```

```
=== RUN   TestAccIBMPICaptureUserTags
--- PASS: TestAccIBMPICaptureUserTags (124.27s)
PASS
```
