### PR TITLE
update kp operations to use flex logger

### DIFF
--- a/ibm/service/kms/data_source_ibm_kms_key.go
+++ b/ibm/service/kms/data_source_ibm_kms_key.go
@@ -5,7 +5,6 @@ package kms
 
 import (
 	"context"
-	"fmt"
 	"log"
 
 	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/flex"
@@ -201,7 +200,7 @@ func dataSourceIBMKMSKeyRead(d *schema.ResourceData, meta interface{}) error {
 		if limitVal == 0 {
 			keys, err := api.GetKeys(context.Background(), 0, offset)
 			if err != nil {
-				return fmt.Errorf("[ERROR] Get Keys failed with error: %s", err)
+				return flex.FmtErrorf("[ERROR] Get Keys failed with error: %s", err)
 			}
 			retreivedKeys := keys.Keys
 			totalKeys = append(totalKeys, retreivedKeys...)
@@ -212,7 +211,7 @@ func dataSourceIBMKMSKeyRead(d *schema.ResourceData, meta interface{}) error {
 					if (limitVal - offset) < pageSize {
 						keys, err := api.GetKeys(context.Background(), (limitVal - offset), offset)
 						if err != nil {
-							return fmt.Errorf("[ERROR] Get Keys failed with error: %s", err)
+							return flex.FmtErrorf("[ERROR] Get Keys failed with error: %s", err)
 						}
 						retreivedKeys := keys.Keys
 						totalKeys = append(totalKeys, retreivedKeys...)
@@ -220,7 +219,7 @@ func dataSourceIBMKMSKeyRead(d *schema.ResourceData, meta interface{}) error {
 					} else {
 						keys, err := api.GetKeys(context.Background(), pageSize, offset)
 						if err != nil {
-							return fmt.Errorf("[ERROR] Get Keys failed with error: %s", err)
+							return flex.FmtErrorf("[ERROR] Get Keys failed with error: %s", err)
 						}
 						numOfKeysFetched := keys.Metadata.NumberOfKeys
 						retreivedKeys := keys.Keys
@@ -236,7 +235,7 @@ func dataSourceIBMKMSKeyRead(d *schema.ResourceData, meta interface{}) error {
 		}
 
 		if len(totalKeys) == 0 {
-			return fmt.Errorf("[ERROR] No keys in instance %s", instanceID)
+			return flex.FmtErrorf("[ERROR] No keys in instance %s", instanceID)
 		}
 		var keyName string
 		var matchKeys []kp.Key
@@ -251,7 +250,7 @@ func dataSourceIBMKMSKeyRead(d *schema.ResourceData, meta interface{}) error {
 			matchKeys = totalKeys
 		}
 		if len(matchKeys) == 0 {
-			return fmt.Errorf("[ERROR] No keys with name %s in instance  %s", keyName, instanceID)
+			return flex.FmtErrorf("[ERROR] No keys with name %s in instance  %s", keyName, instanceID)
 		}
 
 		keyMap := make([]map[string]interface{}, 0, len(matchKeys))
@@ -267,7 +266,7 @@ func dataSourceIBMKMSKeyRead(d *schema.ResourceData, meta interface{}) error {
 			keyInstance["description"] = key.Description
 			policies, err := api.GetPolicies(context.Background(), key.ID)
 			if err != nil {
-				return fmt.Errorf("[ERROR] Failed to read policies: %s", err)
+				return flex.FmtErrorf("[ERROR] Failed to read policies: %s", err)
 			}
 			if len(policies) == 0 {
 				log.Printf("No Policy Configurations read\n")
@@ -283,7 +282,7 @@ func dataSourceIBMKMSKeyRead(d *schema.ResourceData, meta interface{}) error {
 	} else if v, ok := d.GetOk("key_id"); ok {
 		key, err := api.GetKey(context.Background(), v.(string))
 		if err != nil {
-			return fmt.Errorf("[ERROR] Get Keys failed with error: %s", err)
+			return flex.FmtErrorf("[ERROR] Get Keys failed with error: %s", err)
 		}
 		keyMap := make([]map[string]interface{}, 0, 1)
 		keyInstance := make(map[string]interface{})
@@ -296,7 +295,7 @@ func dataSourceIBMKMSKeyRead(d *schema.ResourceData, meta interface{}) error {
 		keyInstance["key_ring_id"] = key.KeyRingID
 		policies, err := api.GetPolicies(context.Background(), key.ID)
 		if err != nil {
-			return fmt.Errorf("[ERROR] Failed to read policies: %s", err)
+			return flex.FmtErrorf("[ERROR] Failed to read policies: %s", err)
 		}
 		if len(policies) == 0 {
 			log.Printf("No Policy Configurations read\n")
@@ -312,7 +311,7 @@ func dataSourceIBMKMSKeyRead(d *schema.ResourceData, meta interface{}) error {
 		aliasName := d.Get("alias").(string)
 		key, err := api.GetKey(context.Background(), aliasName)
 		if err != nil {
-			return fmt.Errorf("[ERROR] Get Keys failed with error: %s", err)
+			return flex.FmtErrorf("[ERROR] Get Keys failed with error: %s", err)
 		}
 		keyMap := make([]map[string]interface{}, 0, 1)
 		keyInstance := make(map[string]interface{})
@@ -325,7 +324,7 @@ func dataSourceIBMKMSKeyRead(d *schema.ResourceData, meta interface{}) error {
 		keyInstance["key_ring_id"] = key.KeyRingID
 		policies, err := api.GetPolicies(context.Background(), key.ID)
 		if err != nil {
-			return fmt.Errorf("[ERROR] Failed to read policies: %s", err)
+			return flex.FmtErrorf("[ERROR] Failed to read policies: %s", err)
 		}
 		if len(policies) == 0 {
 			log.Printf("No Policy Configurations read\n")

--- a/ibm/service/kms/data_source_ibm_kms_key_rings.go
+++ b/ibm/service/kms/data_source_ibm_kms_key_rings.go
@@ -5,10 +5,10 @@ package kms
 
 import (
 	"context"
-	"fmt"
 
 	//kp "github.com/IBM/keyprotect-go-client"
 
+	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/flex"
 	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/validate"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
@@ -65,10 +65,10 @@ func dataSourceIBMKMSKeyRingsRead(d *schema.ResourceData, meta interface{}) erro
 	endpointType := d.Get("endpoint_type").(string)
 	keys, err := api.GetKeyRings(context.Background())
 	if err != nil || keys == nil {
-		return fmt.Errorf("[ERROR] Get Key Rings failed with error: %s", err)
+		return flex.FmtErrorf("[ERROR] Get Key Rings failed with error: %s", err)
 	}
 	if keys.KeyRings == nil || len(keys.KeyRings) == 0 {
-		return fmt.Errorf("[ERROR] No key Rings in instance  %s", instanceID)
+		return flex.FmtErrorf("[ERROR] No key Rings in instance  %s", instanceID)
 	}
 
 	keyRingMap := make([]map[string]interface{}, 0, len(keys.KeyRings))

--- a/ibm/service/kms/data_source_ibm_kms_keys.go
+++ b/ibm/service/kms/data_source_ibm_kms_keys.go
@@ -5,7 +5,6 @@ package kms
 
 import (
 	"context"
-	"fmt"
 	"log"
 
 	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/flex"
@@ -195,7 +194,7 @@ func dataSourceIBMKMSKeysRead(d *schema.ResourceData, meta interface{}) error {
 		aliasName := v.(string)
 		key, err := api.GetKey(context.Background(), aliasName)
 		if err != nil {
-			return fmt.Errorf("[ERROR] Get Keys failed with error: %s", err)
+			return flex.FmtErrorf("[ERROR] Get Keys failed with error: %s", err)
 		}
 		keyMap := make([]map[string]interface{}, 0, 1)
 		keyInstance := make(map[string]interface{})
@@ -208,7 +207,7 @@ func dataSourceIBMKMSKeysRead(d *schema.ResourceData, meta interface{}) error {
 		keyInstance["key_ring_id"] = key.KeyRingID
 		policies, err := api.GetPolicies(context.Background(), key.ID)
 		if err != nil {
-			return fmt.Errorf("[ERROR] Failed to read policies: %s", err)
+			return flex.FmtErrorf("[ERROR] Failed to read policies: %s", err)
 		}
 		if len(policies) == 0 {
 			log.Printf("No Policy Configurations read\n")
@@ -221,7 +220,7 @@ func dataSourceIBMKMSKeysRead(d *schema.ResourceData, meta interface{}) error {
 	} else if v, ok := d.GetOk("key_id"); ok {
 		key, err := api.GetKey(context.Background(), v.(string))
 		if err != nil {
-			return fmt.Errorf("[ERROR] Get Keys failed with error: %s", err)
+			return flex.FmtErrorf("[ERROR] Get Keys failed with error: %s", err)
 		}
 		keyMap := make([]map[string]interface{}, 0, 1)
 		keyInstance := make(map[string]interface{})
@@ -234,7 +233,7 @@ func dataSourceIBMKMSKeysRead(d *schema.ResourceData, meta interface{}) error {
 		keyInstance["key_ring_id"] = key.KeyRingID
 		policies, err := api.GetPolicies(context.Background(), key.ID)
 		if err != nil {
-			return fmt.Errorf("[ERROR] Failed to read policies: %s", err)
+			return flex.FmtErrorf("[ERROR] Failed to read policies: %s", err)
 		}
 		if len(policies) == 0 {
 			log.Printf("No Policy Configurations read\n")
@@ -259,7 +258,7 @@ func dataSourceIBMKMSKeysRead(d *schema.ResourceData, meta interface{}) error {
 			{
 				keys, err := api.GetKeys(context.Background(), 0, offset)
 				if err != nil {
-					return fmt.Errorf("[ERROR] Get Keys failed with error: %s", err)
+					return flex.FmtErrorf("[ERROR] Get Keys failed with error: %s", err)
 				}
 				retreivedKeys := keys.Keys
 				totalKeys = append(totalKeys, retreivedKeys...)
@@ -271,7 +270,7 @@ func dataSourceIBMKMSKeysRead(d *schema.ResourceData, meta interface{}) error {
 					if (limitVal - offset) < pageSize {
 						keys, err := api.GetKeys(context.Background(), (limitVal - offset), offset)
 						if err != nil {
-							return fmt.Errorf("[ERROR] Get Keys failed with error: %s", err)
+							return flex.FmtErrorf("[ERROR] Get Keys failed with error: %s", err)
 						}
 						retreivedKeys := keys.Keys
 						totalKeys = append(totalKeys, retreivedKeys...)
@@ -279,7 +278,7 @@ func dataSourceIBMKMSKeysRead(d *schema.ResourceData, meta interface{}) error {
 					} else {
 						keys, err := api.GetKeys(context.Background(), pageSize, offset)
 						if err != nil {
-							return fmt.Errorf("[ERROR] Get Keys failed with error: %s", err)
+							return flex.FmtErrorf("[ERROR] Get Keys failed with error: %s", err)
 						}
 						numOfKeysFetched := keys.Metadata.NumberOfKeys
 						retreivedKeys := keys.Keys
@@ -294,7 +293,7 @@ func dataSourceIBMKMSKeysRead(d *schema.ResourceData, meta interface{}) error {
 			}
 		}
 		if len(totalKeys) == 0 {
-			return fmt.Errorf("[ERROR] No keys in instance %s", instanceID)
+			return flex.FmtErrorf("[ERROR] No keys in instance %s", instanceID)
 		}
 		var keyName string
 		var matchKeys []kp.Key
@@ -310,7 +309,7 @@ func dataSourceIBMKMSKeysRead(d *schema.ResourceData, meta interface{}) error {
 		}
 
 		if len(matchKeys) == 0 {
-			return fmt.Errorf("[ERROR] No keys with name %s in instance  %s", keyName, instanceID)
+			return flex.FmtErrorf("[ERROR] No keys with name %s in instance  %s", keyName, instanceID)
 		}
 
 		keyMap := make([]map[string]interface{}, 0, len(matchKeys))

--- a/ibm/service/kms/data_source_ibm_kms_kmip_adapters.go
+++ b/ibm/service/kms/data_source_ibm_kms_kmip_adapters.go
@@ -5,8 +5,8 @@ package kms
 
 import (
 	"context"
-	"fmt"
 
+	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/flex"
 	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/validate"
 	kp "github.com/IBM/keyprotect-go-client"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -87,7 +87,7 @@ func dataSourceIBMKMSKmipAdaptersList(d *schema.ResourceData, meta interface{}) 
 
 	adapters, err := api.GetKMIPAdapters(context.Background(), opts)
 	if err != nil {
-		return fmt.Errorf("[ERROR] Error listing KMIP adapters: %s", err)
+		return flex.FmtErrorf("[ERROR] Error listing KMIP adapters: %s", err)
 	}
 
 	adaptersList := adapters.Adapters

--- a/ibm/service/kms/data_source_ibm_kms_kmip_client_certificate.go
+++ b/ibm/service/kms/data_source_ibm_kms_kmip_client_certificate.go
@@ -5,8 +5,8 @@ package kms
 
 import (
 	"context"
-	"fmt"
 
+	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/flex"
 	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/validate"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
@@ -114,13 +114,13 @@ func dataSourceIBMKmsKMIPClientCertRead(d *schema.ResourceData, meta interface{}
 	ctx := context.Background()
 	adapter, err := kpAPI.GetKMIPAdapter(ctx, adapterNameOrID)
 	if err != nil {
-		return fmt.Errorf("[ERROR] Error while retriving KMIP adapter to get certificate: %s", err)
+		return flex.FmtErrorf("[ERROR] Error while retriving KMIP adapter to get certificate: %s", err)
 	}
 	if err = d.Set("adapter_id", adapter.ID); err != nil {
-		return fmt.Errorf("[ERROR] Error setting adapter_id: %s", err)
+		return flex.FmtErrorf("[ERROR] Error setting adapter_id: %s", err)
 	}
 	if err = d.Set("adapter_name", adapter.Name); err != nil {
-		return fmt.Errorf("[ERROR] Error setting adapter_name: %s", err)
+		return flex.FmtErrorf("[ERROR] Error setting adapter_name: %s", err)
 	}
 
 	cert, err := kpAPI.GetKMIPClientCertificate(ctx, adapterNameOrID, certNameOrID)

--- a/ibm/service/kms/data_source_ibm_kms_kmip_client_certificates.go
+++ b/ibm/service/kms/data_source_ibm_kms_kmip_client_certificates.go
@@ -5,8 +5,8 @@ package kms
 
 import (
 	"context"
-	"fmt"
 
+	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/flex"
 	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/validate"
 	kp "github.com/IBM/keyprotect-go-client"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -111,18 +111,18 @@ func dataSourceIBMKmsKMIPClientCertList(d *schema.ResourceData, meta interface{}
 	ctx := context.Background()
 	adapter, err := api.GetKMIPAdapter(ctx, adapterNameOrID)
 	if err != nil {
-		return fmt.Errorf("[ERROR] Error while retriving KMIP adapter to list certificates: %s", err)
+		return flex.FmtErrorf("[ERROR] Error while retriving KMIP adapter to list certificates: %s", err)
 	}
 	if err = d.Set("adapter_id", adapter.ID); err != nil {
-		return fmt.Errorf("[ERROR] Error setting adapter_id: %s", err)
+		return flex.FmtErrorf("[ERROR] Error setting adapter_id: %s", err)
 	}
 	if err = d.Set("adapter_name", adapter.Name); err != nil {
-		return fmt.Errorf("[ERROR] Error setting adapter_name: %s", err)
+		return flex.FmtErrorf("[ERROR] Error setting adapter_name: %s", err)
 	}
 
 	certs, err := api.GetKMIPClientCertificates(ctx, adapter.ID, opts)
 	if err != nil {
-		return fmt.Errorf("[ERROR] Error while listing KMIP certs for adapter %s: %s", adapter.ID, err)
+		return flex.FmtErrorf("[ERROR] Error while listing KMIP certs for adapter %s: %s", adapter.ID, err)
 	}
 
 	certsList := certs.Certificates

--- a/ibm/service/kms/data_source_ibm_kms_kmip_object.go
+++ b/ibm/service/kms/data_source_ibm_kms_kmip_object.go
@@ -5,8 +5,8 @@ package kms
 
 import (
 	"context"
-	"fmt"
 
+	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/flex"
 	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/validate"
 	kp "github.com/IBM/keyprotect-go-client"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -139,13 +139,13 @@ func dataSourceIBMKmsKMIPObjectRead(d *schema.ResourceData, meta interface{}) er
 	ctx := context.Background()
 	adapter, err := kpAPI.GetKMIPAdapter(ctx, adapterNameOrID)
 	if err != nil {
-		return fmt.Errorf("[ERROR] Error while retriving KMIP adapter to get KMIP object: %s", err)
+		return flex.FmtErrorf("[ERROR] Error while retriving KMIP adapter to get KMIP object: %s", err)
 	}
 	if err = d.Set("adapter_id", adapter.ID); err != nil {
-		return fmt.Errorf("[ERROR] Error setting adapter_id: %s", err)
+		return flex.FmtErrorf("[ERROR] Error setting adapter_id: %s", err)
 	}
 	if err = d.Set("adapter_name", adapter.Name); err != nil {
-		return fmt.Errorf("[ERROR] Error setting adapter_name: %s", err)
+		return flex.FmtErrorf("[ERROR] Error setting adapter_name: %s", err)
 	}
 
 	object, err := kpAPI.GetKMIPObject(ctx, adapterNameOrID, objectID)
@@ -161,45 +161,45 @@ func dataSourceIBMKmsKMIPObjectRead(d *schema.ResourceData, meta interface{}) er
 
 func populateKMIPObjectSchemaDataFromStruct(d *schema.ResourceData, object kp.KMIPObject) (err error) {
 	if err = d.Set("object_id", object.ID); err != nil {
-		return fmt.Errorf("[ERROR] Error setting object_id: %s", err)
+		return flex.FmtErrorf("[ERROR] Error setting object_id: %s", err)
 	}
 	if err = d.Set("object_type", object.KMIPObjectType); err != nil {
-		return fmt.Errorf("[ERROR] Error setting object_type: %s", err)
+		return flex.FmtErrorf("[ERROR] Error setting object_type: %s", err)
 	}
 	if err = d.Set("object_state", object.ObjectState); err != nil {
-		return fmt.Errorf("[ERROR] Error setting object_state: %s", err)
+		return flex.FmtErrorf("[ERROR] Error setting object_state: %s", err)
 	}
 	if object.CreatedAt != nil {
 		if err = d.Set("created_at", object.CreatedAt.String()); err != nil {
-			return fmt.Errorf("[ERROR] Error setting created_at: %s", err)
+			return flex.FmtErrorf("[ERROR] Error setting created_at: %s", err)
 		}
 		if err = d.Set("created_by", object.CreatedBy); err != nil {
-			return fmt.Errorf("[ERROR] Error setting created_by: %s", err)
+			return flex.FmtErrorf("[ERROR] Error setting created_by: %s", err)
 		}
 		if err = d.Set("created_by_cert_id", object.CreatedByCertID); err != nil {
-			return fmt.Errorf("[ERROR] Error setting created_by_cert_id: %s", err)
+			return flex.FmtErrorf("[ERROR] Error setting created_by_cert_id: %s", err)
 		}
 	}
 	if object.UpdatedAt != nil {
 		if err = d.Set("updated_at", object.UpdatedAt.String()); err != nil {
-			return fmt.Errorf("[ERROR] Error setting updated_at: %s", err)
+			return flex.FmtErrorf("[ERROR] Error setting updated_at: %s", err)
 		}
 		if err = d.Set("updated_by", object.UpdatedBy); err != nil {
-			return fmt.Errorf("[ERROR] Error setting created_by: %s", err)
+			return flex.FmtErrorf("[ERROR] Error setting created_by: %s", err)
 		}
 		if err = d.Set("updated_by_cert_id", object.UpdatedByCertID); err != nil {
-			return fmt.Errorf("[ERROR] Error setting updated_by_cert_id: %s", err)
+			return flex.FmtErrorf("[ERROR] Error setting updated_by_cert_id: %s", err)
 		}
 	}
 	if object.DestroyedAt != nil {
 		if err = d.Set("destroyed_at", object.DestroyedAt.String()); err != nil {
-			return fmt.Errorf("[ERROR] Error setting destroyed_at: %s", err)
+			return flex.FmtErrorf("[ERROR] Error setting destroyed_at: %s", err)
 		}
 		if err = d.Set("destroyed_by", object.DestroyedBy); err != nil {
-			return fmt.Errorf("[ERROR] Error setting destroyed_by: %s", err)
+			return flex.FmtErrorf("[ERROR] Error setting destroyed_by: %s", err)
 		}
 		if err = d.Set("destroyed_by_cert_id", object.DestroyedByCertID); err != nil {
-			return fmt.Errorf("[ERROR] Error setting destroyed_by_cert_id: %s", err)
+			return flex.FmtErrorf("[ERROR] Error setting destroyed_by_cert_id: %s", err)
 		}
 	}
 	d.SetId(object.ID)

--- a/ibm/service/kms/data_source_ibm_kms_kmip_objects.go
+++ b/ibm/service/kms/data_source_ibm_kms_kmip_objects.go
@@ -5,8 +5,8 @@ package kms
 
 import (
 	"context"
-	"fmt"
 
+	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/flex"
 	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/validate"
 	kp "github.com/IBM/keyprotect-go-client"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -119,7 +119,7 @@ func dataSourceIBMKmsKMIPObjectList(d *schema.ResourceData, meta interface{}) er
 	if stateFilter, ok := d.GetOk("object_state_filter"); ok {
 		arrayVal, ok2 := stateFilter.([]any)
 		if !ok2 {
-			return fmt.Errorf("[ERROR] Error converting object_state_filter into []any")
+			return flex.FmtErrorf("[ERROR] Error converting object_state_filter into []any")
 		}
 		int32Arr := make([]int32, 0, len(arrayVal))
 		for _, myint := range arrayVal {
@@ -131,17 +131,17 @@ func dataSourceIBMKmsKMIPObjectList(d *schema.ResourceData, meta interface{}) er
 	ctx := context.Background()
 	adapter, err := kpAPI.GetKMIPAdapter(ctx, adapterNameOrID)
 	if err != nil {
-		return fmt.Errorf("[ERROR] Error while retriving KMIP adapter to list KMIP objects: %s", err)
+		return flex.FmtErrorf("[ERROR] Error while retriving KMIP adapter to list KMIP objects: %s", err)
 	}
 	if err = d.Set("adapter_id", adapter.ID); err != nil {
-		return fmt.Errorf("[ERROR] Error setting adapter_id: %s", err)
+		return flex.FmtErrorf("[ERROR] Error setting adapter_id: %s", err)
 	}
 	if err = d.Set("adapter_name", adapter.Name); err != nil {
-		return fmt.Errorf("[ERROR] Error setting adapter_name: %s", err)
+		return flex.FmtErrorf("[ERROR] Error setting adapter_name: %s", err)
 	}
 	objs, err := kpAPI.GetKMIPObjects(ctx, adapterNameOrID, opts)
 	if err != nil {
-		return fmt.Errorf("[ERROR] Error while retriving KMIP objects associated with adapter ID '%s': %v", adapter.ID, err)
+		return flex.FmtErrorf("[ERROR] Error while retriving KMIP objects associated with adapter ID '%s': %v", adapter.ID, err)
 	}
 	objsList := objs.Objects
 	// set computed values

--- a/ibm/service/kms/data_source_ibm_kp_key.go
+++ b/ibm/service/kms/data_source_ibm_kp_key.go
@@ -5,9 +5,9 @@ package kms
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/conns"
+	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/flex"
 	kp "github.com/IBM/keyprotect-go-client"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
@@ -64,12 +64,12 @@ func dataSourceIBMKeyRead(d *schema.ResourceData, meta interface{}) error {
 	api.Config.InstanceID = instanceID
 	keys, err := api.GetKeys(context.Background(), 100, 0)
 	if err != nil {
-		return fmt.Errorf(
+		return flex.FmtErrorf(
 			"Get Keys failed with error: %s", err)
 	}
 	retreivedKeys := keys.Keys
 	if len(retreivedKeys) == 0 {
-		return fmt.Errorf("No keys in instance  %s", instanceID)
+		return flex.FmtErrorf("No keys in instance  %s", instanceID)
 	}
 	var keyName string
 	var matchKeys []kp.Key
@@ -85,7 +85,7 @@ func dataSourceIBMKeyRead(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	if len(matchKeys) == 0 {
-		return fmt.Errorf("No keys with name %s in instance  %s", keyName, instanceID)
+		return flex.FmtErrorf("No keys with name %s in instance  %s", keyName, instanceID)
 	}
 
 	keyMap := make([]map[string]interface{}, 0, len(matchKeys))

--- a/ibm/service/kms/resource_ibm_kms_instance_policies.go
+++ b/ibm/service/kms/resource_ibm_kms_instance_policies.go
@@ -5,15 +5,15 @@ package kms
 
 import (
 	"context"
-	"fmt"
+	"log"
+	"strings"
+	"time"
+
 	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/flex"
 	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/validate"
 	kp "github.com/IBM/keyprotect-go-client"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"log"
-	"strings"
-	"time"
 )
 
 func ResourceIBMKmsInstancePolicy() *schema.Resource {
@@ -366,7 +366,7 @@ func policyCreateOrUpdate(context context.Context, d *schema.ResourceData, kpAPI
 	}
 	err := kpAPI.SetInstancePolicies(context, mulPolicy)
 	if err != nil {
-		return fmt.Errorf("[ERROR] Error while setting instance policies: %s", err)
+		return flex.FmtErrorf("[ERROR] Error while setting instance policies: %s", err)
 	}
 	return nil
 

--- a/ibm/service/kms/resource_ibm_kms_key.go
+++ b/ibm/service/kms/resource_ibm_kms_key.go
@@ -217,7 +217,7 @@ func resourceIBMKmsKeyCreate(d *schema.ResourceData, meta interface{}) error {
 		kp.WithPayload(keyData.Payload, &keyData.EncryptedNonce, &keyData.IV, false),
 		kp.WithDescription(keyData.Description))
 	if err != nil {
-		return fmt.Errorf("[ERROR] Error while creating key: %s", err)
+		return flex.FmtErrorf("[ERROR] Error while creating key: %s", err)
 	}
 
 	d.SetId(key.CRN)
@@ -262,9 +262,9 @@ func resourceIBMKmsKeyDelete(d *schema.ResourceData, meta interface{}) error {
 				r := registration.(map[string]interface{})
 				resourceCrns = append(resourceCrns, r["resource_crn"].(string))
 			}
-			registrationLog = fmt.Errorf(". The key has the following active registrations which may interfere with deletion: %v", resourceCrns)
+			registrationLog = flex.FmtErrorf(". The key has the following active registrations which may interfere with deletion: %v", resourceCrns)
 		}
-		return fmt.Errorf("[ERROR] Error while deleting: %s%s", err1, registrationLog)
+		return flex.FmtErrorf("[ERROR] Error while deleting: %s%s", err1, registrationLog)
 	}
 	d.SetId("")
 	return nil
@@ -314,7 +314,7 @@ func populateKPClient(d *schema.ResourceData, meta interface{}, instanceID strin
 
 	instanceData, resp, err := rsConClient.GetResourceInstance(&resourceInstanceGet)
 	if err != nil || instanceData == nil {
-		return nil, nil, fmt.Errorf("[ERROR] Error retrieving resource instance: %s with resp code: %s", err, resp)
+		return nil, nil, flex.FmtErrorf("[ERROR] Error retrieving resource instance: %s with resp code: %s", err, resp)
 	}
 	extensions := instanceData.Extensions
 	kpAPI.URL, err = KmsEndpointURL(kpAPI, endpointType, extensions)
@@ -411,7 +411,7 @@ func KmsEndpointURL(kpAPI *kp.Client, endpointType string, extensions map[string
 	}
 	u, err := url.Parse(url1)
 	if err != nil {
-		return nil, fmt.Errorf("[ERROR] Error Parsing KMS EndpointURL")
+		return nil, flex.FmtErrorf("[ERROR] Error Parsing KMS EndpointURL")
 	}
 	return u, nil
 }
@@ -425,7 +425,7 @@ func ExtractAndValidateKeyDataFromSchema(d *schema.ResourceData, meta interface{
 		// parse string to required time format
 		expiration_time, err := time.Parse(time.RFC3339, expiration_string)
 		if err != nil {
-			return kp.Key{}, "", fmt.Errorf("[ERROR] Invalid time format (the date format follows RFC 3339): %s", err)
+			return kp.Key{}, "", flex.FmtErrorf("[ERROR] Invalid time format (the date format follows RFC 3339): %s", err)
 		}
 		expiration = &expiration_time
 	} else {
@@ -462,7 +462,7 @@ func populateSchemaData(d *schema.ResourceData, meta interface{}) (*kp.Client, e
 				return nil, nil
 			}
 		}
-		return nil, fmt.Errorf("[ERROR] Get Key failed with error while reading Key: %s", err)
+		return nil, flex.FmtErrorf("[ERROR] Get Key failed with error while reading Key: %s", err)
 	} else if key.State == 5 { //Refers to Deleted state of the Key
 		d.SetId("")
 		return nil, nil

--- a/ibm/service/kms/resource_ibm_kms_key_alias.go
+++ b/ibm/service/kms/resource_ibm_kms_key_alias.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/flex"
 	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/validate"
 	kp "github.com/IBM/keyprotect-go-client"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -75,11 +76,11 @@ func resourceIBMKmsKeyAliasCreate(d *schema.ResourceData, meta interface{}) erro
 	}
 	stkey, err := kpAPI.CreateKeyAlias(context.Background(), aliasName, id)
 	if err != nil {
-		return fmt.Errorf("[ERROR] Error while creating alias name for the key: %s", err)
+		return flex.FmtErrorf("[ERROR] Error while creating alias name for the key: %s", err)
 	}
 	key, err := kpAPI.GetKey(context.Background(), stkey.KeyID)
 	if err != nil {
-		return fmt.Errorf("[ERROR] Get Key failed with error: %s", err)
+		return flex.FmtErrorf("[ERROR] Get Key failed with error: %s", err)
 	}
 	d.SetId(fmt.Sprintf("%s:alias:%s", stkey.Alias, key.CRN))
 
@@ -89,7 +90,7 @@ func resourceIBMKmsKeyAliasCreate(d *schema.ResourceData, meta interface{}) erro
 func resourceIBMKmsKeyAliasRead(d *schema.ResourceData, meta interface{}) error {
 	id := strings.Split(d.Id(), ":alias:")
 	if len(id) < 2 {
-		return fmt.Errorf("[ERROR] Incorrect ID %s: Id should be a combination of keyAlias:alias:keyCRN", d.Id())
+		return flex.FmtErrorf("[ERROR] Incorrect ID %s: Id should be a combination of keyAlias:alias:keyCRN", d.Id())
 	}
 	_, instanceID, keyid := getInstanceAndKeyDataFromCRN(id[1])
 	kpAPI, _, err := populateKPClient(d, meta, instanceID)
@@ -104,7 +105,7 @@ func resourceIBMKmsKeyAliasRead(d *schema.ResourceData, meta interface{}) error 
 				return nil
 			}
 		}
-		return fmt.Errorf("[ERROR] Get Key failed with error while reading policies: %s", err)
+		return flex.FmtErrorf("[ERROR] Get Key failed with error while reading policies: %s", err)
 	} else if key.State == 5 { //Refers to Deleted state of the Key
 		d.SetId("")
 		return nil
@@ -135,7 +136,7 @@ func resourceIBMKmsKeyAliasDelete(d *schema.ResourceData, meta interface{}) erro
 				return nil
 			}
 		}
-		return fmt.Errorf(" failed to Destroy alias with error: %s", err1)
+		return flex.FmtErrorf(" failed to Destroy alias with error: %s", err1)
 	}
 	return nil
 }

--- a/ibm/service/kms/resource_ibm_kms_key_policies.go
+++ b/ibm/service/kms/resource_ibm_kms_key_policies.go
@@ -5,7 +5,6 @@ package kms
 
 import (
 	"context"
-	"fmt"
 	"log"
 	"net/url"
 	"strconv"
@@ -305,18 +304,18 @@ func resourceUpdatePolicies(context context.Context, d *schema.ResourceData, kpA
 			if rotationEnable {
 				_, err := kpAPI.EnableRotationPolicy(context, key_id)
 				if err != nil {
-					return fmt.Errorf("[ERROR] Error while enabling key rotation policies: %s", err)
+					return flex.FmtErrorf("[ERROR] Error while enabling key rotation policies: %s", err)
 				}
 			} else if !rotationEnable {
 				_, err := kpAPI.DisableRotationPolicy(context, key_id)
 				if err != nil {
-					return fmt.Errorf("[ERROR] Error while disabling key rotation policies: %s", err)
+					return flex.FmtErrorf("[ERROR] Error while disabling key rotation policies: %s", err)
 				}
 			}
 		} else {
 			_, err := kpAPI.SetRotationPolicy(context, key_id, rotationInterval, rotationEnable)
 			if err != nil {
-				return fmt.Errorf("[ERROR] Error while disabling key rotation policies: %s", err)
+				return flex.FmtErrorf("[ERROR] Error while disabling key rotation policies: %s", err)
 			}
 		}
 	}
@@ -324,7 +323,7 @@ func resourceUpdatePolicies(context context.Context, d *schema.ResourceData, kpA
 		dualAuthEnable = *policy.DualAuth.Enabled
 		_, err := kpAPI.SetDualAuthDeletePolicy(context, key_id, dualAuthEnable)
 		if err != nil {
-			return fmt.Errorf("[ERROR] Error while setting dual_auth_delete policies: %s", err)
+			return flex.FmtErrorf("[ERROR] Error while setting dual_auth_delete policies: %s", err)
 		}
 	}
 	return nil
@@ -347,7 +346,7 @@ func resourceHandlePolicies(context context.Context, d *schema.ResourceData, kpA
 	}
 	_, err := kpAPI.SetPolicies(context, key_id, setRotation, rotationInterval, setDualAuthDelete, dualAuthEnable, rotationEnable)
 	if err != nil {
-		return fmt.Errorf("[ERROR] Error while creating policies: %s", err)
+		return flex.FmtErrorf("[ERROR] Error while creating policies: %s", err)
 	}
 	return nil
 }

--- a/ibm/service/kms/resource_ibm_kms_key_rings.go
+++ b/ibm/service/kms/resource_ibm_kms_key_rings.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/flex"
 	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/validate"
 	kp "github.com/IBM/keyprotect-go-client"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -84,12 +85,12 @@ func resourceIBMKmsKeyRingCreate(d *schema.ResourceData, meta interface{}) error
 
 	err = kpAPI.CreateKeyRing(context.Background(), keyRingID)
 	if err != nil {
-		return fmt.Errorf("[ERROR] Error while creating key ring : %s", err)
+		return flex.FmtErrorf("[ERROR] Error while creating key ring : %s", err)
 	}
 	var keyRing string
 	keyRings, err := kpAPI.GetKeyRings(context.Background())
 	if err != nil {
-		return fmt.Errorf("[ERROR] Error while fetching key ring : %s", err)
+		return flex.FmtErrorf("[ERROR] Error while fetching key ring : %s", err)
 	}
 	for _, v := range keyRings.KeyRings {
 		if v.ID == keyRingID {
@@ -115,7 +116,7 @@ func resourceIBMKmsKeyRingUpdate(d *schema.ResourceData, meta interface{}) error
 func resourceIBMKmsKeyRingRead(d *schema.ResourceData, meta interface{}) error {
 	id := strings.Split(d.Id(), ":keyRing:")
 	if len(id) < 2 {
-		return fmt.Errorf("[ERROR] Incorrect ID %s: Id should be a combination of keyRingID:keyRing:InstanceCRN", d.Id())
+		return flex.FmtErrorf("[ERROR] Incorrect ID %s: Id should be a combination of keyRingID:keyRing:InstanceCRN", d.Id())
 	}
 	instanceID := getInstanceIDFromCRN(id[1])
 	kpAPI, _, err := populateKPClient(d, meta, instanceID)
@@ -130,7 +131,7 @@ func resourceIBMKmsKeyRingRead(d *schema.ResourceData, meta interface{}) error {
 				return nil
 			}
 		}
-		return fmt.Errorf("[ERROR] Get Key Rings failed with error: %s", err)
+		return flex.FmtErrorf("[ERROR] Get Key Rings failed with error: %s", err)
 	}
 
 	d.Set("instance_id", instanceID)

--- a/ibm/service/kms/resource_ibm_kms_kmip_adapter.go
+++ b/ibm/service/kms/resource_ibm_kms_kmip_adapter.go
@@ -125,7 +125,7 @@ func resourceIBMKmsKMIPAdapterCreate(d *schema.ResourceData, meta interface{}) e
 		kp.WithKMIPAdapterDescription(adapterToCreate.Description),
 	)
 	if err != nil {
-		return fmt.Errorf("[ERROR] Error while creating KMIP adapter: %s", err)
+		return flex.FmtErrorf("[ERROR] Error while creating KMIP adapter: %s", err)
 	}
 	return populateKMIPAdapterSchemaDataFromStruct(d, *adapter, instanceID)
 }
@@ -165,7 +165,7 @@ func resourceIBMKmsKMIPAdapterDelete(d *schema.ResourceData, meta interface{}) e
 	ctx := context.Background()
 	objects, err := kpAPI.GetKMIPObjects(ctx, adapterID, nil)
 	if err != nil {
-		return fmt.Errorf("[ERROR] Failed to fetch KMIP objects associated with adapter '%s' for deletion: %v", adapterID, err)
+		return flex.FmtErrorf("[ERROR] Failed to fetch KMIP objects associated with adapter '%s' for deletion: %v", adapterID, err)
 	}
 
 	for _, object := range objects.Objects {
@@ -177,7 +177,7 @@ func resourceIBMKmsKMIPAdapterDelete(d *schema.ResourceData, meta interface{}) e
 					continue
 				}
 			}
-			return fmt.Errorf("[ERROR] Failed to delete KMIP object associated with adapter (%s): %s",
+			return flex.FmtErrorf("[ERROR] Failed to delete KMIP object associated with adapter (%s): %s",
 				adapterID,
 				err,
 			)
@@ -215,7 +215,7 @@ func ExtractAndValidateKMIPAdapterDataFromSchema(d *schema.ResourceData) (adapte
 	instanceID = getInstanceIDFromResourceData(d, "instance_id")
 	profile, ok := d.Get("profile").(string)
 	if !ok {
-		err = fmt.Errorf("[ERROR] Error converting profile to string")
+		err = flex.FmtErrorf("[ERROR] Error converting profile to string")
 		return
 	}
 	adapter = kp.KMIPAdapter{
@@ -224,7 +224,7 @@ func ExtractAndValidateKMIPAdapterDataFromSchema(d *schema.ResourceData) (adapte
 	if name, ok := d.GetOk("name"); ok {
 		nameStr, ok2 := name.(string)
 		if !ok2 {
-			err = fmt.Errorf("[ERROR] Error converting name to string")
+			err = flex.FmtErrorf("[ERROR] Error converting name to string")
 			return
 		}
 		adapter.Name = nameStr
@@ -232,7 +232,7 @@ func ExtractAndValidateKMIPAdapterDataFromSchema(d *schema.ResourceData) (adapte
 	if desc, ok := d.GetOk("description"); ok {
 		descStr, ok2 := desc.(string)
 		if !ok2 {
-			err = fmt.Errorf("[ERROR] Error converting description to string")
+			err = flex.FmtErrorf("[ERROR] Error converting description to string")
 			return
 		}
 		adapter.Description = descStr
@@ -240,7 +240,7 @@ func ExtractAndValidateKMIPAdapterDataFromSchema(d *schema.ResourceData) (adapte
 	if data, ok := d.GetOk("profile_data"); ok {
 		dataMap, ok2 := data.(map[string]interface{})
 		if !ok2 {
-			err = fmt.Errorf("[ERROR] Error converting profile data to map[string]interface{}")
+			err = flex.FmtErrorf("[ERROR] Error converting profile data to map[string]interface{}")
 			return
 		}
 		profileData := map[string]string{}
@@ -248,7 +248,7 @@ func ExtractAndValidateKMIPAdapterDataFromSchema(d *schema.ResourceData) (adapte
 			if val, ok := dataMap[key].(string); ok {
 				profileData[key] = val
 			} else {
-				err = fmt.Errorf("[ERROR] Error converting value with key {%s} into string", key)
+				err = flex.FmtErrorf("[ERROR] Error converting value with key {%s} into string", key)
 				return
 			}
 		}
@@ -261,34 +261,34 @@ func populateKMIPAdapterSchemaDataFromStruct(d *schema.ResourceData, adapter kp.
 	d.SetId(fmt.Sprintf("%s/%s", instanceID, adapter.ID))
 
 	if err = d.Set("name", adapter.Name); err != nil {
-		return fmt.Errorf("[ERROR] Error setting name: %s", err)
+		return flex.FmtErrorf("[ERROR] Error setting name: %s", err)
 	}
 	if err = d.Set("adapter_id", adapter.ID); err != nil {
-		return fmt.Errorf("[ERROR] Error setting adapter_id: %s", err)
+		return flex.FmtErrorf("[ERROR] Error setting adapter_id: %s", err)
 	}
 	if err = d.Set("instance_id", instanceID); err != nil {
-		return fmt.Errorf("[ERROR] Error setting instance_id: %s", err)
+		return flex.FmtErrorf("[ERROR] Error setting instance_id: %s", err)
 	}
 	if err = d.Set("description", adapter.Description); err != nil {
-		return fmt.Errorf("[ERROR] Error setting description: %s", err)
+		return flex.FmtErrorf("[ERROR] Error setting description: %s", err)
 	}
 	if err = d.Set("profile", adapter.Profile); err != nil {
-		return fmt.Errorf("[ERROR] Error setting profile: %s", err)
+		return flex.FmtErrorf("[ERROR] Error setting profile: %s", err)
 	}
 	if err = d.Set("profile_data", adapter.ProfileData); err != nil {
-		return fmt.Errorf("[ERROR] Error setting profile_data: %s", err)
+		return flex.FmtErrorf("[ERROR] Error setting profile_data: %s", err)
 	}
 	if err = d.Set("created_at", adapter.CreatedAt.String()); err != nil {
-		return fmt.Errorf("[ERROR] Error setting created_at: %s", err)
+		return flex.FmtErrorf("[ERROR] Error setting created_at: %s", err)
 	}
 	if err = d.Set("created_by", adapter.CreatedBy); err != nil {
-		return fmt.Errorf("[ERROR] Error setting created_by: %s", err)
+		return flex.FmtErrorf("[ERROR] Error setting created_by: %s", err)
 	}
 	if err = d.Set("updated_at", adapter.UpdatedAt.String()); err != nil {
-		return fmt.Errorf("[ERROR] Error setting updated_at: %s", err)
+		return flex.FmtErrorf("[ERROR] Error setting updated_at: %s", err)
 	}
 	if err = d.Set("updated_by", adapter.UpdatedBy); err != nil {
-		return fmt.Errorf("[ERROR] Error setting updated_by: %s", err)
+		return flex.FmtErrorf("[ERROR] Error setting updated_by: %s", err)
 	}
 	return nil
 }
@@ -299,11 +299,11 @@ func splitAdapterID(terraformId string) (instanceID, adapterID string, err error
 		return "", "", err
 	}
 	if len(split) != 2 {
-		return "", "", fmt.Errorf("[ERROR] The given id %s does not contain all expected sections, should be of format instance_id/adapter_id", terraformId)
+		return "", "", flex.FmtErrorf("[ERROR] The given id %s does not contain all expected sections, should be of format instance_id/adapter_id", terraformId)
 	}
 	for index, id := range split {
 		if uuid.Validate(id) != nil {
-			return "", "", fmt.Errorf("[ERROR] The given id %s at index %d of instance_id/adapter_id is not a valid UUID", id, index)
+			return "", "", flex.FmtErrorf("[ERROR] The given id %s at index %d of instance_id/adapter_id is not a valid UUID", id, index)
 		}
 	}
 	return split[0], split[1], nil

--- a/ibm/service/kms/resource_ibm_kms_kmip_client_cert.go
+++ b/ibm/service/kms/resource_ibm_kms_kmip_client_cert.go
@@ -98,7 +98,7 @@ func resourceIBMKmsKMIPClientCertCreate(d *schema.ResourceData, meta interface{}
 		kp.WithKMIPClientCertName(certToCreate.Name),
 	)
 	if err != nil {
-		return fmt.Errorf("[ERROR] Error while creating KMIP client certificate: %s", err)
+		return flex.FmtErrorf("[ERROR] Error while creating KMIP client certificate: %s", err)
 	}
 	return populateKMIPClientCertSchemaDataFromStruct(d, *cert, adapterID, instanceID)
 }
@@ -176,7 +176,7 @@ func ExtractAndValidateKMIPClientCertDataFromSchema(d *schema.ResourceData) (cer
 	if name, ok := d.GetOk("name"); ok {
 		nameStr, ok2 := name.(string)
 		if !ok2 {
-			err = fmt.Errorf("[ERROR] Error converting name to string")
+			err = flex.FmtErrorf("[ERROR] Error converting name to string")
 			return
 		}
 		cert.Name = nameStr
@@ -184,7 +184,7 @@ func ExtractAndValidateKMIPClientCertDataFromSchema(d *schema.ResourceData) (cer
 	if certPayload, ok := d.GetOk("certificate"); ok {
 		certStr, ok2 := certPayload.(string)
 		if !ok2 {
-			err = fmt.Errorf("[ERROR] Error converting certificate to string")
+			err = flex.FmtErrorf("[ERROR] Error converting certificate to string")
 			return
 		}
 		cert.Certificate = certStr
@@ -199,26 +199,26 @@ func populateKMIPClientCertSchemaDataFromStruct(d *schema.ResourceData, cert kp.
 	d.SetId(fmt.Sprintf("%s/%s/%s", instanceID, adapterID, cert.ID))
 
 	if err = d.Set("name", cert.Name); err != nil {
-		return fmt.Errorf("[ERROR] Error setting name: %s", err)
+		return flex.FmtErrorf("[ERROR] Error setting name: %s", err)
 	}
 	if err = d.Set("adapter_id", adapterID); err != nil {
-		return fmt.Errorf("[ERROR] Error setting adapter_id: %s", err)
+		return flex.FmtErrorf("[ERROR] Error setting adapter_id: %s", err)
 	}
 	if err = d.Set("instance_id", instanceID); err != nil {
-		return fmt.Errorf("[ERROR] Error setting instance_id: %s", err)
+		return flex.FmtErrorf("[ERROR] Error setting instance_id: %s", err)
 	}
 	if err = d.Set("cert_id", cert.ID); err != nil {
-		return fmt.Errorf("[ERROR] Error setting cert_id: %s", err)
+		return flex.FmtErrorf("[ERROR] Error setting cert_id: %s", err)
 	}
 	if err = d.Set("certificate", cert.Certificate); err != nil {
-		return fmt.Errorf("[ERROR] Error setting certificate: %s", err)
+		return flex.FmtErrorf("[ERROR] Error setting certificate: %s", err)
 	}
 	if cert.CreatedAt != nil {
 		if err = d.Set("created_at", cert.CreatedAt.String()); err != nil {
-			return fmt.Errorf("[ERROR] Error setting created_at: %s", err)
+			return flex.FmtErrorf("[ERROR] Error setting created_at: %s", err)
 		}
 		if err = d.Set("created_by", cert.CreatedBy); err != nil {
-			return fmt.Errorf("[ERROR] Error setting created_by: %s", err)
+			return flex.FmtErrorf("[ERROR] Error setting created_by: %s", err)
 		}
 	}
 	return nil
@@ -230,11 +230,11 @@ func splitCertID(terraformId string) (instanceID, adapterID, certID string, err 
 		return "", "", "", err
 	}
 	if len(split) != 3 {
-		return "", "", "", fmt.Errorf("[ERROR] The given id %s does not contain all expected sections, should be of format instance_id/adapter_id/cert_id", terraformId)
+		return "", "", "", flex.FmtErrorf("[ERROR] The given id %s does not contain all expected sections, should be of format instance_id/adapter_id/cert_id", terraformId)
 	}
 	for index, id := range split {
 		if uuid.Validate(id) != nil {
-			return "", "", "", fmt.Errorf("[ERROR] The given id %s at index %d of instance_id/adapter_id/cert_id is not a valid UUID", id, index)
+			return "", "", "", flex.FmtErrorf("[ERROR] The given id %s at index %d of instance_id/adapter_id/cert_id is not a valid UUID", id, index)
 		}
 	}
 	return split[0], split[1], split[2], nil

--- a/ibm/service/kms/resource_ibm_kp_key.go
+++ b/ibm/service/kms/resource_ibm_kp_key.go
@@ -5,7 +5,6 @@ package kms
 
 import (
 	"context"
-	"fmt"
 	"net/url"
 	"strconv"
 	"strings"
@@ -133,7 +132,7 @@ func resourceIBMKeyCreate(d *schema.ResourceData, meta interface{}) error {
 			payload := v.(string)
 			stkey, err := api.CreateImportedStandardKey(context.Background(), name, nil, payload)
 			if err != nil {
-				return fmt.Errorf(
+				return flex.FmtErrorf(
 					"Error while creating standard key: %s", err)
 			}
 			keyCRN = stkey.CRN
@@ -141,7 +140,7 @@ func resourceIBMKeyCreate(d *schema.ResourceData, meta interface{}) error {
 			//create standard key
 			stkey, err := api.CreateStandardKey(context.Background(), name, nil)
 			if err != nil {
-				return fmt.Errorf(
+				return flex.FmtErrorf(
 					"Error while creating standard key: %s", err)
 			}
 			keyCRN = stkey.CRN
@@ -154,14 +153,14 @@ func resourceIBMKeyCreate(d *schema.ResourceData, meta interface{}) error {
 			iv := d.Get("iv_value").(string)
 			stkey, err := api.CreateImportedRootKey(context.Background(), name, nil, payload, encryptedNonce, iv)
 			if err != nil {
-				return fmt.Errorf(
+				return flex.FmtErrorf(
 					"Error while creating Root key: %s", err)
 			}
 			keyCRN = stkey.CRN
 		} else {
 			stkey, err := api.CreateRootKey(context.Background(), name, nil)
 			if err != nil {
-				return fmt.Errorf(
+				return flex.FmtErrorf(
 					"Error while creating Root key: %s", err)
 			}
 			keyCRN = stkey.CRN
@@ -189,7 +188,7 @@ func resourceIBMKeyRead(d *schema.ResourceData, meta interface{}) error {
 	// keyid := d.Id()
 	key, err := api.GetKey(context.Background(), keyid)
 	if err != nil {
-		return fmt.Errorf(
+		return flex.FmtErrorf(
 			"Get Key failed with error: %s", err)
 	}
 	d.Set("key_id", keyid)
@@ -245,7 +244,7 @@ func resourceIBMKeyDelete(d *schema.ResourceData, meta interface{}) error {
 	}
 	_, err1 := api.DeleteKey(context.Background(), keyid, kp.ReturnRepresentation, f)
 	if err1 != nil {
-		return fmt.Errorf(
+		return flex.FmtErrorf(
 			"Error while deleting: %s", err1)
 	}
 	d.SetId("")

--- a/ibm/service/kms/utils.go
+++ b/ibm/service/kms/utils.go
@@ -1,10 +1,10 @@
 package kms
 
-import "fmt"
+import "github.com/IBM-Cloud/terraform-provider-ibm/ibm/flex"
 
 // Copyright IBM Corp. 2017, 2021 All Rights Reserved.
 // Licensed under the Mozilla Public License v2.0
 
 func wrapError(err error, msg string) error {
-	return fmt.Errorf("[ERROR] %s: %s", msg, err)
+	return flex.FmtErrorf("[ERROR] %s: %s", msg, err)
 }

--- a/ibm/service/kms/utils_test.go
+++ b/ibm/service/kms/utils_test.go
@@ -17,13 +17,13 @@ const (
 // 		F: func(region string) error {
 // 			rsConClient, err := meta.(conns.ClientSession).ResourceControllerV2API()
 // 			if err != nil {
-// 				return fmt.Errorf("Error getting client: %s", err)
+// 				return flex.FmtErrorf("Error getting client: %s", err)
 // 			}
 // 			conn := client.(*ExampleClient)
 
 // 			instances, err := conn.DescribeComputeInstances()
 // 			if err != nil {
-// 				return fmt.Errorf("Error getting instances: %s", err)
+// 				return flex.FmtErrorf("Error getting instances: %s", err)
 // 			}
 // 			for _, instance := range instances {
 // 				if strings.HasPrefix(instance.Name, "test-acc") {


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/IBM-Cloud/terraform-provider-ibm/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Output from acceptance testing:
sample error format
```
ibm_kms_key.key2: Creating...
╷
│ Error: [ERROR] Error while creating key: kp.Error: correlation_id='9d344201-315e-4b9d-9917-a0bb0e19b9bb', msg='Bad Request: Key could not be created: Please see `reasons` for more details (INVALID_FIELD_ERR)', reasons='[INVALID_FIELD_ERR: The field `expirationDate` must be: a valid RFC3339 future expiration date - FOR_MORE_INFO_REFER: https://cloud.ibm.com/apidocs/key-protect]'
│ 
│   with ibm_kms_key.key2,
│   on main.tf line 25, in resource "ibm_kms_key" "key2":
│   25: resource "ibm_kms_key" "key2" {
│ 
│ ---
│ id: terraform-9bec2680
│ summary: '[ERROR] Error while creating key: kp.Error: correlation_id=''9d344201-315e-4b9d-9917-a0bb0e19b9bb'',
│   msg=''Bad Request: Key could not be created: Please see `reasons` for more details
│   (INVALID_FIELD_ERR)'', reasons=''[INVALID_FIELD_ERR: The field `expirationDate`
│   must be: a valid RFC3339 future expiration date - FOR_MORE_INFO_REFER: https://cloud.ibm.com/apidocs/key-protect]'''
│ severity: error
│ resource: ibm_kms_key
│ operation: create
│ component:
│   name: github.com/IBM-Cloud/terraform-provider-ibm
│   version: 1.70.0
│ ---
│ 
╵
```


<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
(base) wsiew@Williams-MacBook-Pro terraform-provider-ibm % make testacc TEST=./ibm/service/kms TESTARGS='-run=TestAccIBMKMS'   
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./ibm/service/kms -v -run=TestAccIBMKMS -timeout 700m
[WARN] Set the environment variable IBM_PROJECTS_CONFIG_APIKEY for testing IBM Projects Config resources, the tests will fail if this is not set
[WARN] Set the environment variable IBM_APPID_TENANT_ID for testing AppID resources, AppID tests will fail if this is not set
[WARN] Set the environment variable IBM_APPID_TEST_USER_EMAIL for testing AppID user resources, the tests will fail if this is not set
[WARN] Set the environment variable IBM_ORG for testing ibm_org  resource Some tests for that resource will fail if this is not set correctly
[WARN] Set the environment variable IBM_SPACE for testing ibm_space  resource Some tests for that resource will fail if this is not set correctly
[WARN] Set the environment variable IBM_ID1 for testing ibm_space resource Some tests for that resource will fail if this is not set correctly
[WARN] Set the environment variable IBM_ID2 for testing ibm_space resource Some tests for that resource will fail if this is not set correctly
[WARN] Set the environment variable IBM_IAMUSER for testing ibm_iam_user_policy resource Some tests for that resource will fail if this is not set correctly
[WARN] Set the environment variable IBM_IAMACCOUNTID for testing ibm_iam_trusted_profile resource Some tests for that resource will fail if this is not set correctly
[WARN] Set the environment variable IBM_IAM_SERVICE_ID for testing ibm_iam_trusted_profile_identity resource Some tests for that resource will fail if this is not set correctly
[WARN] Set the environment variable IBM_IAM_TRUSTED_PROFILE_ID for testing ibm_iam_trusted_profile_identity resource Some tests for that resource will fail if this is not set correctly
[WARN] Set the environment variable IBM_DATACENTER for testing ibm_container_cluster resource else it is set to default value 'par01'
[WARN] Set the environment variable IBM_MACHINE_TYPE for testing ibm_container_cluster resource else it is set to default value 'b3c.4x16'
[WARN] Set the environment variable IBM_CERT_CRN for testing ibm_container_alb_cert or ibm_container_ingress_secret_tls resource else it is set to default value
[WARN] Set the environment variable IBM_UPDATE_CERT_CRN for testing ibm_container_alb_cert or ibm_container_ingress_secret_tls resource else it is set to default value
[WARN] Set the environment variable IBM_SECRET_CRN for testing ibm_container_ingress_secret_opaque resource else it is set to default value
[WARN] Set the environment variable IBM_SECRET_CRN_2 for testing ibm_container_ingress_secret_opaque resource else it is set to default value
[WARN] Set the environment variable IBM_INGRESS_INSTANCE_CRN for testing ibm_container_ingress_instance resource. Some tests for that resource will fail if this is not set correctly
[WARN] Set the environment variable IBM_INGRESS_INSTANCE_SECRET_GROUP_ID for testing ibm_container_ingress_instance resource. Some tests for that resource will fail if this is not set correctly
[WARN] Set the environment variable IBM_CONTAINER_REGION for testing ibm_container resources else it is set to default value 'eu-de'
[WARN] Set the environment variable IBM_CIS_INSTANCE with a VALID CIS Instance NAME for testing ibm_cis resources on staging/test
[WARN] Set the environment variable IBM_CIS_DOMAIN_STATIC with the Domain name registered with the CIS instance on test/staging. Domain must be predefined in CIS to avoid CIS billing costs due to domain delete/create
[WARN] Set the environment variable IBM_CIS_DOMAIN_TEST with a VALID Domain name for testing the one time create and delete of a domain in CIS. Note each create/delete will trigger a monthly billing instance. Only to be run in staging/test
[WARN] Set the environment variable IBM_CIS_RESOURCE_GROUP with the resource group for the CIS Instance 
[WARN] Set the environment variable IBM_COS_CRN with a VALID COS instance CRN for testing ibm_cos_* resources
[WARN] Set the environment variable IBM_COS_Bucket_CRN with a VALID BUCKET CRN for testing ibm_cos_bucket* resources
[WARN] Set the environment variable IBM_COS_ACTIVITY_TRACKER_CRN with a VALID ACTIVITY TRACKER INSTANCE CRN in valid region for testing ibm_cos_bucket* resources
[WARN] Set the environment variable IBM_COS_METRICS_MONITORING_CRN with a VALID METRICS MONITORING CRN for testing ibm_cos_bucket* resources
[WARN] Set the environment variable IBM_COS_BUCKET_NAME with a VALID BUCKET Name for testing ibm_cos_bucket* resources
[WARN] Set the environment variable IBM_COS_NAME with a VALID COS instance name for testing resources with cos deps
[WARN] Set the environment variable IBM_TRUSTED_MACHINE_TYPE for testing ibm_container_cluster resource else it is set to default value 'mb1c.16x64'
[WARN] Set the environment variable IBM_BM_EXTENDED_HW_TESTING to true/false for testing ibm_compute_bare_metal resource else it is set to default value 'false'
[WARN] Set the environment variable IBM_PUBLIC_VLAN_ID for testing ibm_container_cluster resource else it is set to default value '2393319'
[WARN] Set the environment variable IBM_PRIVATE_VLAN_ID for testing ibm_container_cluster resource else it is set to default value '2393321'
[WARN] Set the environment variable IBM_KUBE_VERSION for testing ibm_container_cluster resource else it is set to default value '1.18.14'
[WARN] Set the environment variable IBM_KUBE_UPDATE_VERSION for testing ibm_container_cluster resource else it is set to default value '1.19.6'
[WARN] Set the environment variable IBM_PRIVATE_SUBNET_ID for testing ibm_container_cluster resource else it is set to default value '1636107'
[WARN] Set the environment variable IBM_PUBLIC_SUBNET_ID for testing ibm_container_cluster resource else it is set to default value '1165645'
[WARN] Set the environment variable IBM_SUBNET_ID for testing ibm_container_cluster resource else it is set to default value '1165645'
[INFO] Set the environment variable IBM_IPSEC_DATACENTER for testing ibm_ipsec_vpn resource else it is set to default value 'tok02'
[INFO] Set the environment variable IBM_IPSEC_CUSTOMER_SUBNET_ID for testing ibm_ipsec_vpn resource else it is set to default value '123456'
[INFO] Set the environment variable IBM_IPSEC_CUSTOMER_PEER_IP for testing ibm_ipsec_vpn resource else it is set to default value '192.168.0.1'
[WARN] Set the environment variable IBM_LBAAS_DATACENTER for testing ibm_lbaas resource else it is set to default value 'dal13'
[WARN] Set the environment variable IBM_LBAAS_SUBNETID for testing ibm_lbaas resource else it is set to default value '2144241'
[WARN] Set the environment variable IBM_LB_LISTENER_CERTIFICATE_INSTANCE for testing ibm_is_lb_listener resource for https redirect else it is set to default value 'crn:v1:staging:public:cloudcerts:us-south:a/2d1bace7b46e4815a81e52c6ffeba5cf:af925157-b125-4db2-b642-adacb8b9c7f5:certificate:c81627a1bf6f766379cc4b98fd2a44ed'
[WARN] Set the environment variable IBM_DEDICATED_HOSTNAME for testing ibm_compute_vm_instance resource else it is set to default value 'terraform-dedicatedhost'
[WARN] Set the environment variable IBM_DEDICATED_HOST_ID for testing ibm_compute_vm_instance resource else it is set to default value '30301'
[WARN] Set the environment variable IBM_WORKER_POOL_ZONE for testing ibm_container_worker_pool_zone_attachment resource else it is set to default value 'ams03'
[WARN] Set the environment variable IBM_WORKER_POOL_ZONE_PRIVATE_VLAN for testing ibm_container_worker_pool_zone_attachment resource else it is set to default value '2538975'
[WARN] Set the environment variable IBM_WORKER_POOL_ZONE_PUBLIC_VLAN for testing ibm_container_worker_pool_zone_attachment resource else it is set to default value '2538967'
[WARN] Set the environment variable IBM_WORKER_POOL_ZONE_UPDATE_PRIVATE_VLAN for testing ibm_container_worker_pool_zone_attachment resource else it is set to default value '2388377'
[WARN] Set the environment variable IBM_WORKER_POOL_ZONE_UPDATE_PUBLIC_VLAN for testing ibm_container_worker_pool_zone_attachment resource else it is set to default value '2388375'
[WARN] Set the environment variable IBM_WORKER_POOL_SECONDARY_STORAGE for testing secondary_storage attachment to IKS workerpools
[WARN] Set the environment variable IBM_PLACEMENT_GROUP_NAME for testing ibm_compute_vm_instance resource else it is set to default value 'terraform-group'
[INFO] Set the environment variable SL_REGION for testing ibm_is_region datasource else it is set to default value 'us-south'
[INFO] Set the environment variable SL_ZONE for testing ibm_is_zone datasource else it is set to default value 'us-south-1'
[INFO] Set the environment variable SL_ZONE_2 for testing ibm_is_zone datasource else it is set to default value 'us-south-2'
[INFO] Set the environment variable SL_ZONE_3 for testing ibm_is_zone datasource else it is set to default value 'us-south-3'
[INFO] Set the environment variable SL_CIDR for testing ibm_is_subnet else it is set to default value '10.240.0.0/24'
[INFO] Set the environment variable SL_CIDR_2 for testing ibm_is_subnet else it is set to default value '10.240.64.0/24'
[INFO] Set the environment variable SL_CIDR_2 for testing ibm_is_subnet else it is set to default value '10.240.64.0/24'
[INFO] Set the environment variable SL_CIDR_2 for testing ibm_is_instance datasource else it is set to default value './test-fixtures/.ssh/pkcs8_rsa.pub'
[INFO] Set the environment variable IS_PRIVATE_SSH_KEY_PATH for testing ibm_is_instance datasource else it is set to default value './test-fixtures/.ssh/pkcs8_rsa'
[INFO] Set the environment variable SL_RESOURCE_GROUP_ID for testing with different resource group id else it is set to default value 'c01d34dff4364763476834c990398zz8'
[INFO] Set the environment variable IS_RESOURCE_CRN for testing with created resource instance
[INFO] Set the environment variable IS_IMAGE for testing ibm_is_instance, ibm_is_floating_ip else it is set to default value 'r006-907911a7-0ffe-467e-8821-3cc9a0d82a39'
[INFO] Set the environment variable IS_IMAGE2 for testing ibm_is_instance, ibm_is_floating_ip else it is set to default value 'r134-f47cc24c-e020-4db5-ad96-1e5be8b5853b'
[INFO] Set the environment variable IS_WIN_IMAGE for testing ibm_is_instance data source else it is set to default value 'r006-d2e0d0e9-0a4f-4c45-afd7-cab787030776'
[INFO] Set the environment variable IS_COS_BUCKET_NAME for testing ibm_is_image_export_job else it is set to default value 'bucket-27200-lwx4cfvcue'
[INFO] Set the environment variable IS_COS_BUCKET_CRN for testing ibm_is_image_export_job else it is set to default value 'bucket-27200-lwx4cfvcue'
[INFO] Set the environment variable IS_INSTANCE_NAME for testing ibm_is_instance resource else it is set to default value 'instance-01'
[INFO] Set the environment variable IS_BACKUP_POLICY_JOB_ID for testing ibm_is_backup_policy_job datasource
[INFO] Set the environment variable IS_BACKUP_POLICY_ID for testing ibm_is_backup_policy_jobs datasource
[INFO] Set the environment variable IS_REMOTE_CP_BAAS_ENCRYPTION_KEY_CRN for testing remote_copies_policy with Baas plans, else it is set to default value, 'crn:v1:bluemix:public:kms:us-south:a/dffc98a0f1f0f95f6613b3b752286b87:e4a29d1a-2ef0-42a6-8fd2-350deb1c647e:key:5437653b-c4b1-447f-9646-b2a2a4cd6179'
[INFO] Set the environment variable SL_INSTANCE_PROFILE for testing ibm_is_instance resource else it is set to default value 'cx2-2x4'
[INFO] Set the environment variable SL_KMS_INSTANCE_ID for testing ibm_kms_key resource else it is set to default value '30222bb5-1c6d-3834-8d78-ae6348cf8z61'
[INFO] Set the environment variable SL_KMS_KEY_NAME for testing ibm_kms_key resource else it is set to default value 'tfp-test-key'
[INFO] Set the environment variable SL_INSTANCE_PROFILE_UPDATE for testing ibm_is_instance resource else it is set to default value 'cx2-4x8'
[INFO] Set the environment variable IS_BARE_METAL_SERVER_PROFILE for testing ibm_is_bare_metal_server resource else it is set to default value 'bx2-metal-96x384'
[INFO] Set the environment variable IsBareMetalServerImage for testing ibm_is_bare_metal_server resource else it is set to default value 'r006-2d1f36b0-df65-4570-82eb-df7ae5f778b1'
[INFO] Set the environment variable IsBareMetalServerImage2 for testing ibm_is_bare_metal_server resource else it is set to default value 'r006-2d1f36b0-df65-4570-82eb-df7ae5f778b1'
[INFO] Set the environment variable IS_DNS_INSTANCE_CRN for testing ibm_is_lb resource else it is set to default value 'crn:v1:staging:public:dns-svcs:global:a/efe5afc483594adaa8325e2b4d1290df:82df2e3c-53a5-43c6-89ce-dcf78be18668::'
[INFO] Set the environment variable IS_DNS_INSTANCE_CRN1 for testing ibm_is_lb resource else it is set to default value 'crn:v1:staging:public:dns-svcs:global:a/efe5afc483594adaa8325e2b4d1290df:599ae4aa-c554-4a88-8bb2-b199b9a3c046::'
[INFO] Set the environment variable IS_DNS_ZONE_ID for testing ibm_is_lb resource else it is set to default value 'dd501d1d-490b-4bb4-a05d-a31954a1c59e'
[INFO] Set the environment variable IS_DNS_ZONE_ID_1 for testing ibm_is_lb resource else it is set to default value 'b1def78d-51b3-4ea5-a746-1b64c992fcab'
[INFO] Set the environment variable IS_DEDICATED_HOST_NAME for testing ibm_is_instance resource else it is set to default value 'tf-dhost-01'
[INFO] Set the environment variable IS_DEDICATED_HOST_GROUP_ID for testing ibm_is_instance resource else it is set to default value '0717-9104e7b5-77ad-44ad-9eaa-091e6b6efce1'
[INFO] Set the environment variable IS_DEDICATED_HOST_PROFILE for testing ibm_is_instance resource else it is set to default value 'bx2d-host-152x608'
[INFO] Set the environment variable IS_DEDICATED_HOST_GROUP_CLASS for testing ibm_is_instance resource else it is set to default value 'bx2d'
[INFO] Set the environment variable IS_DEDICATED_HOST_GROUP_FAMILY for testing ibm_is_instance resource else it is set to default value 'balanced'
[INFO] Set the environment variable SL_INSTANCE_PROFILE for testing ibm_is_instance resource else it is set to default value 'bx2d-16x64'
[INFO] Set the environment variable IS_SHARE_PROFILE for testing ibm_is_instance resource else it is set to default value 'tier-3iops'
[INFO] Set the environment variable IS_SHARE_PROFILE for testing ibm_is_instance resource else it is set to default value
[INFO] Set the environment variable IS_SHARE_PROFILE for testing ibm_is_instance resource else it is set to default value
[INFO] Set the environment variable IS_VOLUME_PROFILE for testing ibm_is_volume_profile else it is set to default value 'general-purpose'
[INFO] Set the environment variable IS_VIRTUAL_NETWORK_INTERFACE for testing ibm_is_virtual_network_interface else it is set to default value 'c93dc4c6-e85a-4da2-9ea6-f24576256122'
[INFO] Set the environment variable IS_UNATTACHED_BOOT_VOLUME_NAME for testing ibm_is_image else it is set to default value 'r006-1cbe9f0a-7101-4d25-ae72-2a2d725e530e'
[INFO] Set the environment variable IS_VSI_DATA_VOLUME_ID for testing ibm_is_image else it is set to default value 'r006-1cbe9f0a-7101-4d25-ae72-2a2d725e530e'
[INFO] Set the environment variable SL_ROUTE_NEXTHOP else it is set to default value '10.0.0.4'
[INFO] Set the environment variable ISSnapshotCRN for ibm_is_snapshot resource else it is set to default value 'crn:v1:bluemix:public:is:ca-tor:a/xxxxxxxx::snapshot:xxxx-xxxxc-xxx-xxxx-xxxx-xxxxxxxxxx'
[INFO] Set the environment variable ICD_DB_DEPLOYMENT_ID for testing ibm_cloud_databases else it is set to default value 'crn:v1:bluemix:public:databases-for-redis:au-syd:a/40ddc34a953a8c02f10987b59085b60e:5042afe1-72c2-4231-89cc-c949e5d56251::'
[INFO] Set the environment variable ICD_DB_BACKUP_ID for testing ibm_cloud_databases else it is set to default value 'crn:v1:bluemix:public:databases-for-redis:au-syd:a/40ddc34a953a8c02f10987b59085b60e:5042afe1-72c2-4231-89cc-c949e5d56251:backup:0d862fdb-4faa-42e5-aecb-5057f4d399c3'
[INFO] Set the environment variable ICD_DB_TASK_ID for testing ibm_cloud_databases else it is set to default value 'crn:v1:bluemix:public:databases-for-redis:au-syd:a/40ddc34a953a8c02f10987b59085b60e:367b0a22-05bb-41e3-a1ed-ded1ff0889e5:task:882013a6-2751-4df7-a77a-98d258638704'
[INFO] Set the environment variable PI_IMAGE for testing ibm_pi_image resource else it is set to default value '7200-03-03'
[INFO] Set the environment variable PI_SAP_IMAGE for testing ibm_pi_image resource else it is set to default value 'Linux-RHEL-SAP-8-2'
[INFO] Set the environment variable PI_IMAGE_BUCKET_NAME for testing ibm_pi_image resource else it is set to default value 'images-public-bucket'
[INFO] Set the environment variable PI_IMAGE_BUCKET_FILE_NAME for testing ibm_pi_image resource else it is set to default value 'rhel.ova.gz'
[INFO] Set the environment variable PI_IMAGE_BUCKET_ACCESS_KEY for testing ibm_pi_image_export resource else it is set to default value 'images-bucket-access-key'
[INFO] Set the environment variable PI_IMAGE_BUCKET_SECRET_KEY for testing ibm_pi_image_export resource else it is set to default value 'PI_IMAGE_BUCKET_SECRET_KEY'
[INFO] Set the environment variable PI_IMAGE_BUCKET_REGION for testing ibm_pi_image resource else it is set to default value 'us-east'
[INFO] Set the environment variable PI_IMAGE_ID for testing ibm_pi_image resource else it is set to default value 'IBMi-72-09-2924-11'
[INFO] Set the environment variable PI_KEY_NAME for testing ibm_pi_key_name resource else it is set to default value 'terraform-test-power'
[INFO] Set the environment variable PI_NETWORK_NAME for testing ibm_pi_network_name resource else it is set to default value 'terraform-test-power'
[INFO] Set the environment variable PI_NETWORK_ID for testing ibm_pi_network_interface resource else it is set to default value 'terraform-test-power'
[INFO] Set the environment variable PI_NETWORK_INTERFACE_ID for testing ibm_pi_network_interface resource else it is set to default value 'terraform-test-power'
[INFO] Set the environment variable PI_VOLUME_NAME for testing ibm_pi_network_name resource else it is set to default value 'terraform-test-power'
[INFO] Set the environment variable PI_VOLUME_ID for testing ibm_pi_volume_flash_copy_mappings resource else it is set to default value 'terraform-test-power'
[INFO] Set the environment variable PI_REPLICATION_VOLUME_NAME for testing ibm_pi_volume resource else it is set to default value 'terraform-test-power'
[INFO] Set the environment variable PI_VOLUME_ONBARDING_SOURCE_CRN for testing ibm_pi_volume_onboarding resource else it is set to default value 'terraform-test-power'
[INFO] Set the environment variable PI_AUXILIARY_VOLUME_NAME for testing ibm_pi_volume_onboarding resource else it is set to default value 'terraform-test-power'
[INFO] Set the environment variable PI_VOLUME_GROUP_NAME for testing ibm_pi_volume_group resource else it is set to default value 'terraform-test-power'
[INFO] Set the environment variable PI_VOLUME_GROUP_ID for testing ibm_pi_volume_group_storage_details data source else it is set to default value 'terraform-test-power'
[INFO] Set the environment variable PI_VOLUME_ONBOARDING_ID for testing ibm_pi_volume_onboarding resource else it is set to default value 'terraform-test-power'
[INFO] Set the environment variable PI_CLOUDINSTANCE_ID for testing ibm_pi_image resource else it is set to default value 'd16705bd-7f1a-48c9-9e0e-1c17b71e7331'
[INFO] Set the environment variable PI_SNAPSHOT_ID for testing ibm_pi_instance_snapshot data source else it is set to default value '1ea33118-4c43-4356-bfce-904d0658de82'
[INFO] Set the environment variable PI_PVM_INSTANCE_ID for testing Pi_instance_name resource else it is set to default value 'terraform-test-power'
[INFO] Set the environment variable PI_DHCP_ID for testing ibm_pi_dhcp resource else it is set to default value 'terraform-test-power'
[INFO] Set the environment variable PI_CLOUD_CONNECTION_NAME for testing ibm_pi_cloud_connection resource else it is set to default value 'terraform-test-power'
[INFO] Set the environment variable PI_SAP_PROFILE_ID for testing ibm_pi_sap_profile resource else it is set to default value 'terraform-test-power'
[WARN] Set the environment variable PI_PLACEMENT_GROUP_NAME for testing ibm_pi_placement_group resource else it is set to default value 'tf-pi-placement-group'
[WARN] Set the environment variable PI_SPP_PLACEMENT_GROUP_ID for testing ibm_pi_spp_placement_group resource else it is set to default value 'tf-pi-spp-placement-group'
[INFO] Set the environment variable PI_STORAGE_POOL for testing ibm_pi_storage_pool_capacity else it is set to default value 'terraform-test-power'
[INFO] Set the environment variable PI_STORAGE_TYPE for testing ibm_pi_storage_type_capacity else it is set to default value 'terraform-test-power'
[INFO] Set the environment variable PI_CAPTURE_STORAGE_IMAGE_PATH for testing Pi_capture_storage_image_path resource else it is set to default value 'terraform-test-power'
[INFO] Set the environment variable PI_CAPTURE_CLOUD_STORAGE_ACCESS_KEY for testing Pi_capture_cloud_storage_access_key resource else it is set to default value 'terraform-test-power'
[INFO] Set the environment variable PI_CAPTURE_CLOUD_STORAGE_SECRET_KEY for testing Pi_capture_cloud_storage_secret_key resource else it is set to default value 'terraform-test-power'
[WARN] Set the environment variable PI_SHARED_PROCESSOR_POOL_ID for testing ibm_pi_shared_processor_pool resource else it is set to default value 'tf-pi-shared-processor-pool'
[WARN] Set the environment variable PI_STORAGE_CONNECTION for testing pi_storage_connection resource else it is empty
[INFO] Set the environment variable PI_TARGET_STORAGE_TIER for testing Pi_target_storage_tier resource else it is set to default value 'terraform-test-tier'
[INFO] Set the environment variable PI_VOLUME_CLONE_TASK_ID for testing Pi_volume_clone_task_id resource else it is set to default value 'terraform-test-volume-clone-task-id'
[WARN] Set the environment variable PI_RESOURCE_GROUP_ID for testing ibm_pi_workspace resource else it is set to default value ''
[WARN] Set the environment variable PI_HOST_GROUP_ID for testing ibm_pi_host resource else it is set to default value ''
[WARN] Set the environment variable PI_HOST_ID for testing ibm_pi_host resource else it is set to default value ''
[INFO] Set the environment variable PI_NETWORK_ADDRESS_GROUP_ID for testing ibm_pi_network_address_group data source else it is set to default value 'terraform-test-power'
[INFO] Set the environment variable SCHEMATICS_WORKSPACE_ID for testing schematics resources else it is set to default value
[INFO] Set the environment variable SCHEMATICS_TEMPLATE_ID for testing schematics resources else it is set to default value
[INFO] Set the environment variable SCHEMATICS_ACTION_ID for testing schematics resources else it is set to default value
[INFO] Set the environment variable SCHEMATICS_JOB_ID for testing schematics resources else it is set to default value
[INFO] Set the environment variable SCHEMATICS_REPO_URL for testing schematics resources else tests will fail if this is not set correctly
[INFO] Set the environment variable SCHEMATICS_REPO_BRANCH for testing schematics resources else tests will fail if this is not set correctly
[WARN] Set the environment variable IMAGE_COS_URL with a VALID COS Image SQL URL for testing ibm_is_image resources on staging/test
[WARN] Set the environment variable IS_DELEGATED_VPC with a VALID created vpc name for testing ibm_is_vpc data source on staging/test
[WARN] Set the environment variable IMAGE_COS_URL_ENCRYPTED with a VALID COS Image SQL URL for testing ibm_is_image resources on staging/test
[WARN] Set the environment variable IMAGE_OPERATING_SYSTEM with a VALID Operating system for testing ibm_is_image resources on staging/test
[INFO] Set the environment variable IS_IMAGE_NAME for testing data source ibm_is_image else it is set to default value `ibm-ubuntu-18-04-1-minimal-amd64-2`
[INFO] Set the environment variable IS_IMAGE_NAME2 for testing data source ibm_is_image else it is set to default value `ibm-ubuntu-20-04-6-minimal-amd64-5`
[INFO] Set the environment variable IS_IMAGE_ENCRYPTED_DATA_KEY for testing resource ibm_is_image else it is set to default value
[INFO] Set the environment variable IS_IMAGE_ENCRYPTION_KEY for testing resource ibm_is_image else it is set to default value
[INFO] Set the environment variable IBM_FUNCTION_NAMESPACE for testing ibm_function_package, ibm_function_action, ibm_function_rule, ibm_function_trigger resource else  tests will fail if this is not set correctly
[INFO] Set the environment variable HPCS_INSTANCE_ID for testing data_source_ibm_kms_key_test else it is set to default value
[INFO] Set the environment variable SECRETS_MANAGER_INSTANCE_ID for testing Secrets Manager's tests else tests will fail if this is not set correctly
[INFO] Set the environment variable SECRETS_MANAGER_INSTANCE_REGION for testing Secrets Manager's tests else tests will fail if this is not set correctly
[INFO] Set the environment variable SECRETS_MANAGER_EN_INSTANCE_CRN for testing Event Notifications for Secrets Manager tests else tests will fail if this is not set correctly
[INFO] Set the environment variable SECRETS_MANAGER_EN_INSTANCE_CRN for testing IAM Credentials secret's tests else tests will assume that IAM Credentials engine is already configured and fail if not set correctly
[INFO] Set the environment variable SECRETS_MANAGER_IAM_CREDENTIALS_SECRET_SERVICE_ID or SECRETS_MANAGER_IAM_CREDENTIALS_SECRET_ACCESS_GROUP for testing IAM Credentials secret's tests, else tests fail if not set correctly
[INFO] Set the environment variable SECRETS_MANAGER_PUBLIC_CERTIFICATE_LETS_ENCRYPT_ENVIRONMENT for testing public certificate's tests, else it is set to default value ('production'). For public certificate's tests, tests will fail if this is not set correctly
[INFO] Set the environment variable SECRETS_MANAGER_PUBLIC_CERTIFICATE_LETS_ENCRYPT_PRIVATE_KEY for testing public certificate's tests, else tests fail if not set correctly
[INFO] Set the environment variable SECRETS_MANAGER_PUBLIC_CERTIFICATE_COMMON_NAME for testing public certificate's tests, else tests fail if not set correctly
[INFO] Set the environment variable SECRETS_MANAGER_VALIDATE_MANUAL_DNS_CIS_ZONE_ID for testing validate manual dns' test, else tests fail if not set correctly
[INFO] Set the environment variable SECRETS_MANAGER_PUBLIC_CERTIFICATE_CIS_CRN for testing public certificate's tests, else tests fail if not set correctly
[INFO] Set the environment variable SECRETS_MANAGER_PUBLIC_CLASSIC_INFRASTRUCTURE_USERNAME for testing public certificate's tests, else tests fail if not set correctly
[INFO] Set the environment variable SECRETS_MANAGER_PUBLIC_CLASSIC_INFRASTRUCTURE_PASSWORD for testing public certificate's tests, else tests fail if not set correctly
[INFO] Set the environment variable SECRETS_MANAGER_IMPORTED_CERTIFICATE_PATH_TO_CERTIFICATE for testing imported certificate's tests, else tests fail if not set correctly
[INFO] Set the environment variable SECRETS_MANAGER_SERVICE_CREDENTIALS_COS_CRN for testing service credentials' tests, else tests fail if not set correctly
[INFO] Set the environment variable SECRETS_MANAGER_PRIVATE_CERTIFICATE_CONFIGURATION_CRYPTO_KEY_IAM_SECRET_SERVICE_ID for testing private certificate's configuration with crypto key tests, else tests fail if not set correctly
[INFO] Set the environment variable SECRETS_MANAGER_PRIVATE_CERTIFICATE_CONFIGURATION_CRYPTO_KEY_PROVIDER_TYPE for testing private certificate's configuration with crypto key tests, else tests fail if not set correctly
[INFO] Set the environment variable SECRETS_MANAGER_PRIVATE_CERTIFICATE_CONFIGURATION_CRYPTO_KEY_PROVIDER_INSTANCE_CRN for testing private certificate's configuration with crypto key tests, else tests fail if not set correctly
[INFO] Set the environment variable SECRETS_MANAGER_PRIVATE_CERTIFICATE_CONFIGURATION_CRYPTO_KEY_PROVIDER_PRIVATE_KEYSTORE_ID for testing private certificate's configuration with crypto key tests, else tests fail if not set correctly
[INFO] Set the environment variable IBM_TG_CROSS_ACCOUNT_API_KEY for testing ibm_tg_connection resource else  tests will fail if this is not set correctly
[INFO] Set the environment variable IBM_TG_CROSS_ACCOUNT_ID for testing ibm_tg_connection resource else  tests will fail if this is not set correctly
[INFO] Set the environment variable IBM_TG_CROSS_NETWORK_ID for testing ibm_tg_connection resource else  tests will fail if this is not set correctly
[INFO] Set the environment variable IBM_TG_POWER_VS_NETWORK_ID for testing ibm_tg_connection resource else tests will fail if this is not set correctly
[INFO] Set the environment variable ACCOUNT_TO_BE_IMPORTED for testing import enterprise account resource else  tests will fail if this is not set correctly
[INFO] Set the environment variable COS_BUCKET for testing CRUD operations on billing snapshot configuration APIs
[INFO] Set the environment variable COS_LOCATION for testing CRUD operations on billing snapshot configuration APIs
[INFO] Set the environment variable COS_BUCKET_UPDATE for testing update operation on billing snapshot configuration API
[INFO] Set the environment variable COS_LOCATION_UPDATE for testing update operation on billing snapshot configuration API
[INFO] Set the environment variable COS_REPORTS_FOLDER for testing CRUD operations on billing snapshot configuration APIs
[INFO] Set the environment variable SNAPSHOT_DATE_FROM for testing CRUD operations on billing snapshot configuration APIs
[INFO] Set the environment variable SNAPSHOT_DATE_TO for testing CRUD operations on billing snapshot configuration APIs
[INFO] Set the environment variable SNAPSHOT_MONTH for testing CRUD operations on billing snapshot configuration APIs
[WARN] Set the environment variable IBM_HPCS_ADMIN1 with a VALID HPCS Admin Key1 Path
[WARN] Set the environment variable IBM_HPCS_TOKEN1 with a VALID token for HPCS Admin Key1
[WARN] Set the environment variable IBM_HPCS_ADMIN2 with a VALID HPCS Admin Key2 Path
[WARN] Set the environment variable IBM_IAM_REALM_NAME with a VALID realm name for iam trusted profile claim rule
[WARN] Set the environment variable IBM_IAM_IKS_SA with a VALID realm name for iam trusted profile link
[WARN] Set the environment variable IBM_HPCS_TOKEN2 with a VALID token for HPCS Admin Key2
[WARN] Set the environment variable IBM_HPCS_ROOTKEY_CRN with a VALID CRN for a root key created in the HPCS instance
[INFO] Set the environment variable IBM_CLOUD_SHELL_ACCOUNT_ID for ibm-cloud-shell resource or datasource else tests will fail if this is not set correctly
[WARN] Set the environment variable IBM_CLUSTER_VPC_ID for testing ibm_container_vpc_alb_create resources, ibm_container_vpc_alb_create tests will fail if this is not set
[WARN] Set the environment variable IBM_CLUSTER_VPC_SUBNET_ID for testing ibm_container_vpc_alb_create resources, ibm_container_vpc_alb_creates tests will fail if this is not set
[WARN] Set the environment variable IBM_CLUSTER_VPC_RESOURCE_GROUP_ID for testing ibm_container_vpc_alb_create resources, ibm_container_vpc_alb_creates tests will fail if this is not set
[INFO] Set the environment variable IBM_CONTAINER_CLUSTER_NAME for ibm_container_nlb_dns resource or datasource else tests will fail if this is not set correctly
[INFO] Set the environment variable SATELLITE_LOCATION_ID for ibm_cos_bucket satellite location resource or datasource else tests will fail if this is not set correctly
[INFO] Set the environment variable SATELLITE_RESOURCE_INSTANCE_ID for ibm_cos_bucket satellite location resource or datasource else tests will fail if this is not set correctly
[WARN] Set the environment variable IBMCLOUD_CONFIG_AGGREGATOR_ENDPOINT with a VALID SCC API ENDPOINT
[WARN] Set the environment variable IBMCLOUD_CONFIG_AGGREGATOR_INSTANCE_ID with a VALID SCC INSTANCE ID
[WARN] Set the environment variable IBMCLOUD_SCC_INSTANCE_ID with a VALID SCC INSTANCE ID
[WARN] Set the environment variable IBMCLOUD_SCC_API_ENDPOINT with a VALID SCC API ENDPOINT
[WARN] Set the environment variable IBMCLOUD_SCC_REPORT_ID with a VALID SCC REPORT ID
[WARN] Set the environment variable IBMCLOUD_SCC_PROVIDER_TYPE_ATTRIBUTES with a VALID SCC PROVIDER TYPE ATTRIBUTE
[WARN] Set the environment variable IBMCLOUD_SCC_PROVIDER_TYPE_ID with a VALID SCC PROVIDER TYPE ID
[WARN] Set the environment variable IBMCLOUD_SCC_EVENT_NOTIFICATION_CRN
[WARN] Set the environment variable IBMCLOUD_SCC_OBJECT_STORAGE_CRN with a valid cloud object storage crn
[WARN] Set the environment variable IBMCLOUD_SCC_OBJECT_STORAGE_BUCKET with a valid cloud object storage bucket
[INFO] Set the environment variable IBM_CONTAINER_DEDICATEDHOST_POOL_ID for ibm_container_vpc_cluster resource to test dedicated host functionality
[INFO] Set the environment variable IBM_KMS_INSTANCE_ID for ibm_container_vpc_cluster resource or datasource else tests will fail if this is not set correctly
[INFO] Set the environment variable IBM_CRK_ID for ibm_container_vpc_cluster resource or datasource else tests will fail if this is not set correctly
[INFO] Set the environment variable IBM_KMS_ACCOUNT_ID for ibm_container_vpc_cluster resource or datasource else tests will fail if this is not set correctly
[INFO] Set the environment variable IBM_CLUSTER_ID for ibm_container_vpc_worker_pool resource or datasource else tests will fail if this is not set correctly
[WARN] Set the environment variable IBM_CD_RESOURCE_GROUP_NAME for testing CD resources, CD tests will fail if this is not set
[WARN] Set the environment variable IBM_CD_APPCONFIG_INSTANCE_NAME for testing CD resources, CD tests will fail if this is not set
[WARN] Set the environment variable IBM_CD_KEYPROTECT_INSTANCE_NAME for testing CD resources, CD tests will fail if this is not set
[WARN] Set the environment variable IBM_CD_SECRETSMANAGER_INSTANCE_NAME for testing CD resources, CD tests will fail if this is not set
[WARN] Set the environment variable IBM_CD_SLACK_CHANNEL_NAME for testing CD resources, CD tests will fail if this is not set
[WARN] Set the environment variable IBM_CD_SLACK_TEAM_NAME for testing CD resources, CD tests will fail if this is not set
[WARN] Set the environment variable IBM_CD_SLACK_WEBHOOK for testing CD resources, CD tests will fail if this is not set
[WARN] Set the environment variable IBM_CD_JIRA_PROJECT_KEY for testing CD resources, CD tests will fail if this is not set
[WARN] Set the environment variable IBM_CD_JIRA_API_URL for testing CD resources, CD tests will fail if this is not set
[WARN] Set the environment variable IBM_CD_JIRA_USERNAME for testing CD resources, CD tests will fail if this is not set
[WARN] Set the environment variable IBM_CD_JIRA_API_TOKEN for testing CD resources, CD tests will fail if this is not set
[WARN] Set the environment variable IBM_CD_SAUCELABS_ACCESS_KEY for testing CD resources, CD tests will fail if this is not set
[WARN] Set the environment variable IBM_CD_SAUCELABS_USERNAME for testing CD resources, CD tests will fail if this is not set
[WARN] Set the environment variable IBM_CD_BITBUCKET_REPO_URL for testing CD resources, CD tests will fail if this is not set
[WARN] Set the environment variable IBM_CD_GITHUB_CONSOLIDATED_REPO_URL for testing CD resources, CD tests will fail if this is not set
[WARN] Set the environment variable IBM_CD_GITLAB_REPO_URL for testing CD resources, CD tests will fail if this is not set
[WARN] Set the environment variable IBM_CD_HOSTED_GIT_REPO_URL for testing CD resources, CD tests will fail if this is not set
[WARN] Set the environment variable IBM_CD_EVENTNOTIFICATIONS_INSTANCE_NAME for testing CD resources, CD tests will fail if this is not set
[INFO] Set the environment variable IS_CERTIFICATE_CRN for testing ibm_is_vpn_server resource
[INFO] Set the environment variable IS_CLIENT_CA_CRN for testing ibm_is_vpn_server resource
[INFO] Set the environment variable IBM_AccountID_REPL for setting up authorization policy to enable replication feature resource or datasource else tests will fail if this is not set correctly
[WARN] Set the environment variable COS_API_KEY for testing COS targets, the tests will fail if this is not set
[WARN] Set the environment variable INGESTION_KEY for testing Logdna targets, the tests will fail if this is not set
[WARN] Set the environment variable IES_API_KEY for testing Event streams targets, the tests will fail if this is not set
[WARN] Set the environment variable ENTERPRISE_CRN for testing enterprise backup policy, the tests will fail if this is not set
[WARN] Set the environment variable IBM_CODE_ENGINE_RESOURCE_GROUP_ID with the resource group for Code Engine
[WARN] Set the environment variable IBM_CODE_ENGINE_PROJECT_INSTANCE_ID with the ID of a Code Engine project instance
[WARN] Set the environment variable IBM_CODE_ENGINE_SERVICE_INSTANCE_ID with the ID of a IBM Cloud service instance, e.g. for COS
[WARN] Set the environment variable IBM_CODE_ENGINE_RESOURCE_KEY_ID with the ID of a resource key to access a service instance
[WARN] Set the environment variable IBM_CODE_ENGINE_DOMAIN_MAPPING_NAME with the name of a domain mapping
[WARN] Set the environment variable IBM_CODE_ENGINE_TLS_CERT with the TLS certificate in base64 format
[WARN] Set the environment variable IBM_CODE_ENGINE_TLS_KEY with a TLS key in base64 format
[WARN] Set the environment variable IBM_CODE_ENGINE_TLS_CERT_KEY_PATH to point to CERT KEY file path
[WARN] Set the environment variable IBM_CODE_ENGINE_TLS_CERT_PATH to point to CERT file path
[WARN] Set the environment variable IBM_SATELLITE_SSH_PUB_KEY with a ssh public key or ibm_satellite_* tests may fail
[INFO] Set the environment variable IBMCLOUD_MQCLOUD_CONFIG_ENDPOINT for ibm_mqcloud service else tests will fail if this is not set correctly
[INFO] Set the environment variable IBM_MQCLOUD_INSTANCE_ID for ibm_mqcloud_queue_manager resource or datasource else tests will fail if this is not set correctly
[INFO] Set the environment variable IBM_MQCLOUD_QUEUEMANAGER_ID for ibm_mqcloud_queue_manager resource or datasource else tests will fail if this is not set correctly
[INFO] Set the environment variable IBM_MQCLOUD_KS_CERT_PATH for ibm_mqcloud_keystore_certificate resource or datasource else tests will fail if this is not set correctly
[INFO] Set the environment variable IBM_MQCLOUD_TS_CERT_PATH for ibm_mqcloud_truststore_certificate resource or datasource else tests will fail if this is not set correctly
[INFO] Set the environment variable IBM_MQCLOUD_QUEUEMANAGER_LOCATION for ibm_mqcloud_queue_manager resource or datasource else tests will fail if this is not set correctly
[INFO] Set the environment variable IBM_MQCLOUD_QUEUEMANAGER_VERSION for ibm_mqcloud_queue_manager resource or datasource else tests will fail if this is not set correctly
[INFO] Set the environment variable IBM_MQCLOUD_QUEUEMANAGER_VERSIONUPDATE for ibm_mqcloud_queue_manager resource or datasource else tests will fail if this is not set correctly
[INFO] Set the environment variable IBMCLOUD_LOGS_SERVICE_INSTANCE_ID for testing cloud logs related operations
[INFO] Set the environment variable IBMCLOUD_LOGS_SERVICE_INSTANCE_REGION for testing cloud logs related operations
[INFO] Set the environment variable IBMCLOUD_LOGS_SERVICE_EVENT_NOTIFICATIONS_INSTANCE_ID for testing cloud logs related operations
[INFO] Set the environment variable IBMCLOUD_LOGS_SERVICE_EVENT_NOTIFICATIONS_INSTANCE_REGION for testing cloud logs related operations
[WARN] Set the environment variable IBM_PAG_COS_INSTANCE_NAME for testing IBM PAG resource, the tests will fail if this is not set
[WARN] Set the environment variable IBM_PAG_COS_BUCKET_NAME for testing IBM PAG resource, the tests will fail if this is not set
[WARN] Set the environment variable IBM_PAG_COS_BUCKET_REGION for testing IBM PAG resource, the tests will fail if this is not set
[WARN] Set the environment variable IBM_PAG_VPC_NAME for testing IBM PAG resource, the tests will fail if this is not set
[WARN] Set the environment variable IBM_PAG_SERVICE_PLAN for testing IBM PAG resource, the tests will fail if this is not set
[WARN] Set the environment variable IBM_PAG_VPC_SUBNET_INS_1 for testing IBM PAG resource, the tests will fail if this is not set
[WARN] Set the environment variable IBM_PAG_VPC_SUBNET_INS_2 for testing IBM PAG resource, the tests will fail if this is not set
[WARN] Set the environment variable IBM_PAG_VPC_SUBNET_INS_2 for testing IBM PAG resource, the tests will fail if this is not set
[WARN] Set the environment variable IBM_PAG_VPC_SUBNET_INS_2 for testing IBM PAG resource, the tests will fail if this is not set
[WARN] Set the environment variable IBM_VMAAS_DS_ID for testing ibm_vmaas_vdc resource else tests will fail if this is not set correctly
[WARN] Set the environment variable IBM_VMAAS_DS_PVDC_ID for testing ibm_vmaas_vdc resource else tests will fail if this is not set correctly
[INFO] Set the environment variable IBM_POLICY_ASSIGNMENT_TARGET_ACCOUNT_ID for testing ibm_iam_policy_assignment resource else tests will fail if this is not set correctly
[INFO] Set the environment variable IBM_POLICY_ASSIGNMENT_TARGET_ENTERPRISE_ID for testing ibm_iam_policy_assignment resource else tests will fail if this is not set correctly
[WARN] Set the environment variable PCS_REGISTRATION_ACCOUNT_ID for testing iam_onboarding resource else tests will fail if this is not set correctly
[WARN] Set the environment variable PCS_PRODUCT_WITH_APPROVED_PROGRAMMATIC_NAME for testing iam_onboarding resource else tests will fail if this is not set correctly
[WARN] Set the environment variable PCS_PRODUCT_WITH_APPROVED_PROGRAMMATIC_NAME_2 for testing iam_onboarding resource else tests will fail if this is not set correctly
[WARN] Set the environment variable PCS_PRODUCT_WITH_CATALOG_PRODUCT for testing iam_onboarding resource else tests will fail if this is not set correctly
[WARN] Set the environment variable PCS_CATALOG_PRODUCT for testing iam_onboarding resource else tests will fail if this is not set correctly
[WARN] Set the environment variable PCS_CATALOG_PLAN for testing iam_onboarding resource else tests will fail if this is not set correctly
[WARN] Set the environment variable PCS_IAM_TEGISTRATION_ID for testing iam_onboarding resource else tests will fail if this is not set correctly
=== RUN   TestAccIBMKMSDataSourceKeyPolicy_basicNew
--- PASS: TestAccIBMKMSDataSourceKeyPolicy_basicNew (54.95s)
=== RUN   TestAccIBMKMSKeyRingDataSource_basic
--- PASS: TestAccIBMKMSKeyRingDataSource_basic (48.42s)
=== RUN   TestAccIBMKMSKeyDataSource_basic
--- PASS: TestAccIBMKMSKeyDataSource_basic (57.76s)
=== RUN   TestAccIBMKMSKeyDataSource_description
--- PASS: TestAccIBMKMSKeyDataSource_description (59.34s)
=== RUN   TestAccIBMKMSKeyDataSource_Key
--- PASS: TestAccIBMKMSKeyDataSource_Key (54.05s)
=== RUN   TestAccIBMKMSKeyDataSourceHPCS_basic
    data_source_ibm_kms_key_test.go:77: 
--- SKIP: TestAccIBMKMSKeyDataSourceHPCS_basic (0.00s)
=== RUN   TestAccIBMKMSDataSource_basic
--- PASS: TestAccIBMKMSDataSource_basic (49.94s)
=== RUN   TestAccIBMKMSHPCSDataSource_basic
    data_source_ibm_kms_keys_test.go:36: 
--- SKIP: TestAccIBMKMSHPCSDataSource_basic (0.00s)
=== RUN   TestAccIBMKMSKeyDataSource_Keys
--- PASS: TestAccIBMKMSKeyDataSource_Keys (53.30s)
=== RUN   TestAccIBMKMSKMIPAdapterDataSource_basic
--- PASS: TestAccIBMKMSKMIPAdapterDataSource_basic (73.76s)
=== RUN   TestAccIBMKMSKMIPAdaptersDataSource_basic
--- PASS: TestAccIBMKMSKMIPAdaptersDataSource_basic (70.70s)
=== RUN   TestAccIBMKMSKMIPClientCertDataSource_basic
--- PASS: TestAccIBMKMSKMIPClientCertDataSource_basic (83.57s)
=== RUN   TestAccIBMKMSKMIPClientCertsDataSource_basic
--- PASS: TestAccIBMKMSKMIPClientCertsDataSource_basic (105.17s)
=== RUN   TestAccIBMKMSKMIPObjectDataSource_basic
--- PASS: TestAccIBMKMSKMIPObjectDataSource_basic (40.81s)
=== RUN   TestAccIBMKMSKMIPObjectsDataSource_basic
--- PASS: TestAccIBMKMSKMIPObjectsDataSource_basic (76.67s)
=== RUN   TestAccIBMKMSInstancePolicy_basic_check
--- PASS: TestAccIBMKMSInstancePolicy_basic_check (63.25s)
=== RUN   TestAccIBMKMSInstancePolicy_rotation_check
--- PASS: TestAccIBMKMSInstancePolicy_rotation_check (46.43s)
=== RUN   TestAccIBMKMSInstancePolicy_dualAuth_check
--- PASS: TestAccIBMKMSInstancePolicy_dualAuth_check (47.02s)
=== RUN   TestAccIBMKMSInstancePolicy_metrics_check
--- PASS: TestAccIBMKMSInstancePolicy_metrics_check (45.67s)
=== RUN   TestAccIBMKMSInstancePolicy_kcia_check
--- PASS: TestAccIBMKMSInstancePolicy_kcia_check (47.16s)
=== RUN   TestAccIBMKMSInstancePolicy_kcia_attributes_check
--- PASS: TestAccIBMKMSInstancePolicy_kcia_attributes_check (45.64s)
=== RUN   TestAccIBMKMSInstancePolicyWithKey
--- PASS: TestAccIBMKMSInstancePolicyWithKey (51.92s)
=== RUN   TestAccIBMKMSInstancePolicy_invalid_interval_check
--- PASS: TestAccIBMKMSInstancePolicy_invalid_interval_check (1.25s)
=== RUN   TestAccIBMKMSResource_Key_Alias_Name
--- PASS: TestAccIBMKMSResource_Key_Alias_Name (52.17s)
=== RUN   TestAccIBMKMSResource_Key_Alias_Duplicate
--- PASS: TestAccIBMKMSResource_Key_Alias_Duplicate (39.59s)
=== RUN   TestAccIBMKMSResource_Key_Alias_Key_Check
--- PASS: TestAccIBMKMSResource_Key_Alias_Key_Check (102.03s)
=== RUN   TestAccIBMKMSResource_Key_Alias_Key_Limit
--- PASS: TestAccIBMKMSResource_Key_Alias_Key_Limit (62.84s)
=== RUN   TestAccIBMKMSKeyPolicy_basic_check
--- PASS: TestAccIBMKMSKeyPolicy_basic_check (71.02s)
=== RUN   TestAccIBMKMSKeyPolicy_basic_check_enable
--- PASS: TestAccIBMKMSKeyPolicy_basic_check_enable (109.05s)
=== RUN   TestAccIBMKMSKeyPolicy_rotation_check
--- PASS: TestAccIBMKMSKeyPolicy_rotation_check (56.92s)
=== RUN   TestAccIBMKMSKeyPolicy_dualAuth_check
--- PASS: TestAccIBMKMSKeyPolicy_dualAuth_check (54.37s)
=== RUN   TestAccIBMKMSKeyPolicy_dualAuth_check_with_Alias
--- PASS: TestAccIBMKMSKeyPolicy_dualAuth_check_with_Alias (54.09s)
=== RUN   TestAccIBMKMSResource_Key_Ring_Name
--- PASS: TestAccIBMKMSResource_Key_Ring_Name (46.32s)
=== RUN   TestAccIBMKMSResource_Key_Ring_Key
--- PASS: TestAccIBMKMSResource_Key_Ring_Key (71.32s)
=== RUN   TestAccIBMKMSResource_Key_Ring_Not_Exist
--- PASS: TestAccIBMKMSResource_Key_Ring_Not_Exist (34.38s)
=== RUN   TestAccIBMKMSResource_Key_Ring_AlwaysForceDeleteTrue
--- PASS: TestAccIBMKMSResource_Key_Ring_AlwaysForceDeleteTrue (62.55s)
=== RUN   TestAccIBMKMSResource_basic
There is no lifecycle configuration on the bucket
There is no lifecycle configuration on the bucket
There is no lifecycle configuration on the bucket
--- PASS: TestAccIBMKMSResource_basic (180.17s)
=== RUN   TestAccIBMKMSHPCSResource_basic
    resource_ibm_kms_key_test.go:78: 
--- SKIP: TestAccIBMKMSHPCSResource_basic (0.00s)
=== RUN   TestAccIBMKMSResource_ValidExpDate
--- PASS: TestAccIBMKMSResource_ValidExpDate (68.11s)
=== RUN   TestAccIBMKMSResource_InvalidExpDate
--- PASS: TestAccIBMKMSResource_InvalidExpDate (52.66s)
=== RUN   TestAccIBMKMSKeyWithPolicyOverridesResource_basic
--- PASS: TestAccIBMKMSKeyWithPolicyOverridesResource_basic (111.02s)
=== RUN   TestAccIBMKMSKeyWithPolicyOverridesResource_ValidExpDate
--- PASS: TestAccIBMKMSKeyWithPolicyOverridesResource_ValidExpDate (65.58s)
=== RUN   TestAccIBMKMSKeyWithPolicyOverridesResource_InvalidExpDate
--- PASS: TestAccIBMKMSKeyWithPolicyOverridesResource_InvalidExpDate (39.86s)
=== RUN   TestAccIBMKMSKeyWithPolicyOverridesResource_Policies
--- PASS: TestAccIBMKMSKeyWithPolicyOverridesResource_Policies (57.96s)
=== RUN   TestAccIBMKMSKeyWithPolicyOverridesResource_update
--- PASS: TestAccIBMKMSKeyWithPolicyOverridesResource_update (78.23s)
=== RUN   TestAccIBMKMSKMIPAdapterResource_basic
--- PASS: TestAccIBMKMSKMIPAdapterResource_basic (49.32s)
=== RUN   TestAccIBMKMSKMIPAdapterResource_InvalidCRKStandardKeyErr
--- PASS: TestAccIBMKMSKMIPAdapterResource_InvalidCRKStandardKeyErr (50.98s)
=== RUN   TestAccIBMKMSKMIPAdapterResource_DuplicateAdapterNameErr
--- PASS: TestAccIBMKMSKMIPAdapterResource_DuplicateAdapterNameErr (39.82s)
=== RUN   TestAccIBMKMSKMIPAdapterResource_CRKNotFoundErr
--- PASS: TestAccIBMKMSKMIPAdapterResource_CRKNotFoundErr (35.70s)
=== RUN   TestAccIBMKMSKMIPClientCertResource_basic
--- PASS: TestAccIBMKMSKMIPClientCertResource_basic (53.95s)
=== RUN   TestAccIBMKMSKMIPClientCertResource_DuplicateCertError
--- PASS: TestAccIBMKMSKMIPClientCertResource_DuplicateCertError (43.85s)
=== RUN   TestAccIBMKMSKMIPClientCertResource_InvalidCert
--- PASS: TestAccIBMKMSKMIPClientCertResource_InvalidCert (38.20s)
=== RUN   TestAccIBMKMSKMIPClientCertResource_DuplicateNameError
--- PASS: TestAccIBMKMSKMIPClientCertResource_DuplicateNameError (43.15s)
PASS
ok      github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/kms     3005.850s
(base) wsiew@Williams-MacBook-Pro terraform-provider-ibm % 
...
```
