### PR TITLE
added support for identifier in volume datasource

### DIFF
--- a/ibm/service/vpc/data_source_ibm_is_volume.go
+++ b/ibm/service/vpc/data_source_ibm_is_volume.go
@@ -334,7 +334,7 @@ func DataSourceIBMISVolumeValidator() *validate.ResourceValidator {
 			Type:                       validate.TypeString})
 	validateSchema = append(validateSchema,
 		validate.ValidateSchema{
-			Identifier:                 isSubnetName,
+			Identifier:                 isVolumeName,
 			ValidateFunctionIdentifier: validate.ValidateNoZeroValues,
 			Type:                       validate.TypeString})
 

--- a/ibm/service/vpc/data_source_ibm_is_volume_test.go
+++ b/ibm/service/vpc/data_source_ibm_is_volume_test.go
@@ -49,6 +49,60 @@ func TestAccIBMISVolumeDatasource_basic(t *testing.T) {
 		},
 	})
 }
+func TestAccIBMISVolumeDatasourceIdnetifier_basic(t *testing.T) {
+	name := fmt.Sprintf("tf-vol-%d", acctest.RandIntRange(10, 100))
+	zone := acc.ISZoneName
+	resName := "data.ibm_is_volume.testacc_dsvol"
+	resNameId := "data.ibm_is_volume.testacc_dsvolidentifier"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { acc.TestAccPreCheck(t) },
+		Providers: acc.TestAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckIBMISVolumeDataSourceWithIdentifierConfig(name, zone),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(
+						resName, "name", name),
+					resource.TestCheckResourceAttr(
+						resName, "zone", zone),
+					resource.TestCheckResourceAttrSet(
+						resName, "active"),
+					resource.TestCheckResourceAttrSet(
+						resName, "attachment_state"),
+					resource.TestCheckResourceAttrSet(
+						resName, "bandwidth"),
+					resource.TestCheckResourceAttrSet(
+						resName, "busy"),
+					resource.TestCheckResourceAttrSet(
+						resName, "created_at"),
+					resource.TestCheckResourceAttrSet(
+						resName, "resource_group"),
+					resource.TestCheckResourceAttrSet(
+						resName, "profile"),
+					resource.TestCheckResourceAttr(
+						resNameId, "name", name),
+					resource.TestCheckResourceAttr(
+						resNameId, "zone", zone),
+					resource.TestCheckResourceAttrSet(
+						resNameId, "active"),
+					resource.TestCheckResourceAttrSet(
+						resNameId, "attachment_state"),
+					resource.TestCheckResourceAttrSet(
+						resNameId, "bandwidth"),
+					resource.TestCheckResourceAttrSet(
+						resNameId, "busy"),
+					resource.TestCheckResourceAttrSet(
+						resNameId, "created_at"),
+					resource.TestCheckResourceAttrSet(
+						resNameId, "resource_group"),
+					resource.TestCheckResourceAttrSet(
+						resNameId, "profile"),
+				),
+			},
+		},
+	})
+}
 func TestAccIBMISVolumeDatasource_Sdp(t *testing.T) {
 	name := fmt.Sprintf("tf-vol-%d", acctest.RandIntRange(10, 100))
 	zone := "eu-gb-1"
@@ -192,6 +246,22 @@ func testAccCheckIBMISVolumeDataSourceConfig(name, zone string) string {
 	data "ibm_is_volume" "testacc_dsvol" {
 		name = ibm_is_volume.testacc_volume.name
 	}`, name, zone)
+}
+func testAccCheckIBMISVolumeDataSourceWithIdentifierConfig(name, zone string) string {
+	return fmt.Sprintf(`
+	resource "ibm_is_volume" "testacc_volume"{
+		name = "%s"
+		profile = "10iops-tier"
+		zone = "%s"
+	}
+	data "ibm_is_volume" "testacc_dsvol" {
+		name = ibm_is_volume.testacc_volume.name
+	}
+	data "ibm_is_volume" "testacc_dsvolidentifier" {
+		identifier = ibm_is_volume.testacc_volume.id
+	}
+		
+	`, name, zone)
 }
 func testAccCheckIBMISVolumeDataSourceSdpConfig(name, zone string) string {
 	return fmt.Sprintf(`

--- a/website/docs/d/is_volume.html.markdown
+++ b/website/docs/d/is_volume.html.markdown
@@ -37,7 +37,8 @@ data "ibm_is_volume" "example" {
 ## Argument reference
 Review the argument references that you can specify for your data source. 
 
-- `name` - (Required, String) The name of the volume.
+- `identifier` - (Optional, String) The id of the volume. (one of `identifier`, `name` is required)
+- `name` - (Optional, String) The name of the volume. (one of `identifier`, `name` is required)
 - `zone` - (Optional, String) The zone name of the volume.
 
 ## Attribute reference


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/IBM-Cloud/terraform-provider-ibm/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
% make testacc TEST=./ibm/service/vpc TESTARGS='-run=TestAccIBMISVolumeDatasourceIdnetifier_basic'
=== RUN   TestAccIBMISVolumeDatasourceIdnetifier_basic
--- PASS: TestAccIBMISVolumeDatasourceIdnetifier_basic (59.01s)
PASS
ok      github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/vpc     60.905s
```
