### PR TITLE
fix(toolchain): adopt new error formats

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -77,7 +77,6 @@ require (
 require (
 	cloud.google.com/go/kms v1.10.1 // indirect
 	cloud.google.com/go/monitoring v1.13.0 // indirect
-	github.com/IBM/vmware-go-sdk v0.1.2 // indirect
 	github.com/Logicalis/asn1 v0.0.0-20190312173541-d60463189a56 // indirect
 	github.com/PromonLogicalis/asn1 v0.0.0-20190312173541-d60463189a56 // indirect
 	github.com/ProtonMail/go-crypto v0.0.0-20230828082145-3c4c8a2d2371 // indirect

--- a/go.mod
+++ b/go.mod
@@ -77,6 +77,7 @@ require (
 require (
 	cloud.google.com/go/kms v1.10.1 // indirect
 	cloud.google.com/go/monitoring v1.13.0 // indirect
+	github.com/IBM/vmware-go-sdk v0.1.2 // indirect
 	github.com/Logicalis/asn1 v0.0.0-20190312173541-d60463189a56 // indirect
 	github.com/PromonLogicalis/asn1 v0.0.0-20190312173541-d60463189a56 // indirect
 	github.com/ProtonMail/go-crypto v0.0.0-20230828082145-3c4c8a2d2371 // indirect

--- a/ibm/acctest/acctest.go
+++ b/ibm/acctest/acctest.go
@@ -1697,41 +1697,41 @@ func init() {
 	}
 
 	CdSlackChannelName = os.Getenv("IBM_CD_SLACK_CHANNEL_NAME")
-	if CdSecretsManagerInstanceName == "" {
+	if CdSlackChannelName == "" {
 		fmt.Println("[WARN] Set the environment variable IBM_CD_SLACK_CHANNEL_NAME for testing CD resources, CD tests will fail if this is not set")
 	}
 	CdSlackTeamName = os.Getenv("IBM_CD_SLACK_TEAM_NAME")
-	if CdSecretsManagerInstanceName == "" {
+	if CdSlackTeamName == "" {
 		fmt.Println("[WARN] Set the environment variable IBM_CD_SLACK_TEAM_NAME for testing CD resources, CD tests will fail if this is not set")
 	}
 	CdSlackWebhook = os.Getenv("IBM_CD_SLACK_WEBHOOK")
-	if CdSecretsManagerInstanceName == "" {
+	if CdSlackWebhook == "" {
 		fmt.Println("[WARN] Set the environment variable IBM_CD_SLACK_WEBHOOK for testing CD resources, CD tests will fail if this is not set")
 	}
 
 	CdJiraProjectKey = os.Getenv("IBM_CD_JIRA_PROJECT_KEY")
-	if CdSecretsManagerInstanceName == "" {
+	if CdJiraProjectKey == "" {
 		fmt.Println("[WARN] Set the environment variable IBM_CD_JIRA_PROJECT_KEY for testing CD resources, CD tests will fail if this is not set")
 	}
 	CdJiraApiUrl = os.Getenv("IBM_CD_JIRA_API_URL")
-	if CdSecretsManagerInstanceName == "" {
+	if CdJiraApiUrl == "" {
 		fmt.Println("[WARN] Set the environment variable IBM_CD_JIRA_API_URL for testing CD resources, CD tests will fail if this is not set")
 	}
 	CdJiraUsername = os.Getenv("IBM_CD_JIRA_USERNAME")
-	if CdSecretsManagerInstanceName == "" {
+	if CdJiraUsername == "" {
 		fmt.Println("[WARN] Set the environment variable IBM_CD_JIRA_USERNAME for testing CD resources, CD tests will fail if this is not set")
 	}
 	CdJiraApiToken = os.Getenv("IBM_CD_JIRA_API_TOKEN")
-	if CdSecretsManagerInstanceName == "" {
+	if CdJiraApiToken == "" {
 		fmt.Println("[WARN] Set the environment variable IBM_CD_JIRA_API_TOKEN for testing CD resources, CD tests will fail if this is not set")
 	}
 
 	CdSaucelabsAccessKey = os.Getenv("IBM_CD_SAUCELABS_ACCESS_KEY")
-	if CdSecretsManagerInstanceName == "" {
+	if CdSaucelabsAccessKey == "" {
 		fmt.Println("[WARN] Set the environment variable IBM_CD_SAUCELABS_ACCESS_KEY for testing CD resources, CD tests will fail if this is not set")
 	}
 	CdSaucelabsUsername = os.Getenv("IBM_CD_SAUCELABS_USERNAME")
-	if CdSecretsManagerInstanceName == "" {
+	if CdSaucelabsUsername == "" {
 		fmt.Println("[WARN] Set the environment variable IBM_CD_SAUCELABS_USERNAME for testing CD resources, CD tests will fail if this is not set")
 	}
 

--- a/ibm/service/cdtoolchain/data_source_ibm_cd_toolchain.go
+++ b/ibm/service/cdtoolchain/data_source_ibm_cd_toolchain.go
@@ -1,5 +1,9 @@
-// Copyright IBM Corp. 2023 All Rights Reserved.
+// Copyright IBM Corp. 2024 All Rights Reserved.
 // Licensed under the Mozilla Public License v2.0
+
+/*
+ * IBM OpenAPI Terraform Generator Version: 3.96.0-d6dec9d7-20241008-212902
+ */
 
 package cdtoolchain
 
@@ -94,20 +98,23 @@ func DataSourceIBMCdToolchain() *schema.Resource {
 func dataSourceIBMCdToolchainRead(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	cdToolchainClient, err := meta.(conns.ClientSession).CdToolchainV2()
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.DiscriminatedTerraformErrorf(err, err.Error(), "(Data) ibm_cd_toolchain", "read", "initialize-client")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	getToolchainByIDOptions := &cdtoolchainv2.GetToolchainByIDOptions{}
 
 	getToolchainByIDOptions.SetToolchainID(d.Get("toolchain_id").(string))
 
-	toolchain, response, err := cdToolchainClient.GetToolchainByIDWithContext(context, getToolchainByIDOptions)
+	toolchain, _, err := cdToolchainClient.GetToolchainByIDWithContext(context, getToolchainByIDOptions)
 	if err != nil {
-		log.Printf("[DEBUG] GetToolchainByIDWithContext failed %s\n%s", err, response)
-		return diag.FromErr(fmt.Errorf("GetToolchainByIDWithContext failed %s\n%s", err, response))
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("GetToolchainByIDWithContext failed: %s", err.Error()), "(Data) ibm_cd_toolchain", "read")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
-	d.SetId(fmt.Sprintf("%s", *getToolchainByIDOptions.ToolchainID))
+	d.SetId(*getToolchainByIDOptions.ToolchainID)
 
 	tags, err := flex.GetTagsUsingCRN(meta, *toolchain.CRN)
 	if err != nil {
@@ -117,47 +124,47 @@ func dataSourceIBMCdToolchainRead(context context.Context, d *schema.ResourceDat
 	d.Set("tags", tags)
 
 	if err = d.Set("name", toolchain.Name); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting name: %s", err))
+		return flex.DiscriminatedTerraformErrorf(err, fmt.Sprintf("Error setting name: %s", err), "(Data) ibm_cd_toolchain", "read", "set-name").GetDiag()
 	}
 
 	if err = d.Set("description", toolchain.Description); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting description: %s", err))
+		return flex.DiscriminatedTerraformErrorf(err, fmt.Sprintf("Error setting description: %s", err), "(Data) ibm_cd_toolchain", "read", "set-description").GetDiag()
 	}
 
 	if err = d.Set("account_id", toolchain.AccountID); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting account_id: %s", err))
+		return flex.DiscriminatedTerraformErrorf(err, fmt.Sprintf("Error setting account_id: %s", err), "(Data) ibm_cd_toolchain", "read", "set-account_id").GetDiag()
 	}
 
 	if err = d.Set("location", toolchain.Location); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting location: %s", err))
+		return flex.DiscriminatedTerraformErrorf(err, fmt.Sprintf("Error setting location: %s", err), "(Data) ibm_cd_toolchain", "read", "set-location").GetDiag()
 	}
 
 	if err = d.Set("resource_group_id", toolchain.ResourceGroupID); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting resource_group_id: %s", err))
+		return flex.DiscriminatedTerraformErrorf(err, fmt.Sprintf("Error setting resource_group_id: %s", err), "(Data) ibm_cd_toolchain", "read", "set-resource_group_id").GetDiag()
 	}
 
 	if err = d.Set("crn", toolchain.CRN); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting crn: %s", err))
+		return flex.DiscriminatedTerraformErrorf(err, fmt.Sprintf("Error setting crn: %s", err), "(Data) ibm_cd_toolchain", "read", "set-crn").GetDiag()
 	}
 
 	if err = d.Set("href", toolchain.Href); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting href: %s", err))
+		return flex.DiscriminatedTerraformErrorf(err, fmt.Sprintf("Error setting href: %s", err), "(Data) ibm_cd_toolchain", "read", "set-href").GetDiag()
 	}
 
 	if err = d.Set("ui_href", toolchain.UIHref); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting ui_href: %s", err))
+		return flex.DiscriminatedTerraformErrorf(err, fmt.Sprintf("Error setting ui_href: %s", err), "(Data) ibm_cd_toolchain", "read", "set-ui_href").GetDiag()
 	}
 
 	if err = d.Set("created_at", flex.DateTimeToString(toolchain.CreatedAt)); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting created_at: %s", err))
+		return flex.DiscriminatedTerraformErrorf(err, fmt.Sprintf("Error setting created_at: %s", err), "(Data) ibm_cd_toolchain", "read", "set-created_at").GetDiag()
 	}
 
 	if err = d.Set("updated_at", flex.DateTimeToString(toolchain.UpdatedAt)); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting updated_at: %s", err))
+		return flex.DiscriminatedTerraformErrorf(err, fmt.Sprintf("Error setting updated_at: %s", err), "(Data) ibm_cd_toolchain", "read", "set-updated_at").GetDiag()
 	}
 
 	if err = d.Set("created_by", toolchain.CreatedBy); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting created_by: %s", err))
+		return flex.DiscriminatedTerraformErrorf(err, fmt.Sprintf("Error setting created_by: %s", err), "(Data) ibm_cd_toolchain", "read", "set-created_by").GetDiag()
 	}
 
 	return nil

--- a/ibm/service/cdtoolchain/data_source_ibm_cd_toolchain_test.go
+++ b/ibm/service/cdtoolchain/data_source_ibm_cd_toolchain_test.go
@@ -73,7 +73,7 @@ func TestAccIBMCdToolchainDataSourceAllArgs(t *testing.T) {
 					resource.TestCheckResourceAttrSet("data.ibm_cd_toolchain.cd_toolchain", "created_at"),
 					resource.TestCheckResourceAttrSet("data.ibm_cd_toolchain.cd_toolchain", "updated_at"),
 					resource.TestCheckResourceAttrSet("data.ibm_cd_toolchain.cd_toolchain", "created_by"),
-					resource.TestCheckResourceAttr("data.ibm_cd_toolchain.cd_toolchain", "tags.#", "2"),
+					resource.TestCheckResourceAttr("data.ibm_cd_toolchain.cd_toolchain", "tags.#", "0"),
 				),
 			},
 		},
@@ -107,7 +107,6 @@ func testAccCheckIBMCdToolchainDataSourceConfig(toolchainName string, toolchainR
 			name = "%s"
 			resource_group_id = data.ibm_resource_group.resource_group.id
 			description = "%s"
-			tags = ["tag1","tag2"]
 		}
 
 		resource "time_sleep" "wait_time" {

--- a/ibm/service/cdtoolchain/data_source_ibm_cd_toolchain_tool_appconfig.go
+++ b/ibm/service/cdtoolchain/data_source_ibm_cd_toolchain_tool_appconfig.go
@@ -1,5 +1,9 @@
-// Copyright IBM Corp. 2023 All Rights Reserved.
+// Copyright IBM Corp. 2024 All Rights Reserved.
 // Licensed under the Mozilla Public License v2.0
+
+/*
+ * IBM OpenAPI Terraform Generator Version: 3.96.0-d6dec9d7-20241008-212902
+ */
 
 package cdtoolchain
 
@@ -14,6 +18,7 @@ import (
 	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/conns"
 	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/flex"
 	"github.com/IBM/continuous-delivery-go-sdk/cdtoolchainv2"
+	"github.com/IBM/go-sdk-core/v5/core"
 )
 
 func DataSourceIBMCdToolchainToolAppconfig() *schema.Resource {
@@ -131,7 +136,9 @@ func DataSourceIBMCdToolchainToolAppconfig() *schema.Resource {
 func dataSourceIBMCdToolchainToolAppconfigRead(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	cdToolchainClient, err := meta.(conns.ClientSession).CdToolchainV2()
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.DiscriminatedTerraformErrorf(err, err.Error(), "(Data) ibm_cd_toolchain_tool_appconfig", "read", "initialize-client")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	getToolByIDOptions := &cdtoolchainv2.GetToolByIDOptions{}
@@ -139,84 +146,83 @@ func dataSourceIBMCdToolchainToolAppconfigRead(context context.Context, d *schem
 	getToolByIDOptions.SetToolchainID(d.Get("toolchain_id").(string))
 	getToolByIDOptions.SetToolID(d.Get("tool_id").(string))
 
-	toolchainTool, response, err := cdToolchainClient.GetToolByIDWithContext(context, getToolByIDOptions)
+	toolchainTool, _, err := cdToolchainClient.GetToolByIDWithContext(context, getToolByIDOptions)
 	if err != nil {
-		log.Printf("[DEBUG] GetToolByIDWithContext failed %s\n%s", err, response)
-		return diag.FromErr(fmt.Errorf("GetToolByIDWithContext failed %s\n%s", err, response))
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("GetToolByIDWithContext failed: %s", err.Error()), "(Data) ibm_cd_toolchain_tool_appconfig", "read")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	if *toolchainTool.ToolTypeID != "appconfig" {
-		return diag.FromErr(fmt.Errorf("Retrieved tool is not the correct type: %s", *toolchainTool.ToolTypeID))
+		return flex.TerraformErrorf(err, fmt.Sprintf("Retrieved tool is not the correct type: %s", err), "(Data) ibm_cd_toolchain_tool", "read").GetDiag()
 	}
 
 	d.SetId(fmt.Sprintf("%s/%s", *getToolByIDOptions.ToolchainID, *getToolByIDOptions.ToolID))
 
 	if err = d.Set("resource_group_id", toolchainTool.ResourceGroupID); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting resource_group_id: %s", err))
+		return flex.DiscriminatedTerraformErrorf(err, fmt.Sprintf("Error setting resource_group_id: %s", err), "(Data) ibm_cd_toolchain_tool_appconfig", "read", "set-resource_group_id").GetDiag()
 	}
 
 	if err = d.Set("crn", toolchainTool.CRN); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting crn: %s", err))
+		return flex.DiscriminatedTerraformErrorf(err, fmt.Sprintf("Error setting crn: %s", err), "(Data) ibm_cd_toolchain_tool_appconfig", "read", "set-crn").GetDiag()
 	}
 
 	if err = d.Set("toolchain_crn", toolchainTool.ToolchainCRN); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting toolchain_crn: %s", err))
+		return flex.DiscriminatedTerraformErrorf(err, fmt.Sprintf("Error setting toolchain_crn: %s", err), "(Data) ibm_cd_toolchain_tool_appconfig", "read", "set-toolchain_crn").GetDiag()
 	}
 
 	if err = d.Set("href", toolchainTool.Href); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting href: %s", err))
+		return flex.DiscriminatedTerraformErrorf(err, fmt.Sprintf("Error setting href: %s", err), "(Data) ibm_cd_toolchain_tool_appconfig", "read", "set-href").GetDiag()
 	}
 
 	referent := []map[string]interface{}{}
-	if toolchainTool.Referent != nil {
-		modelMap, err := dataSourceIBMCdToolchainToolAppconfigToolModelReferentToMap(toolchainTool.Referent)
-		if err != nil {
-			return diag.FromErr(err)
-		}
-		referent = append(referent, modelMap)
+	referentMap, err := DataSourceIBMCdToolchainToolAppconfigToolModelReferentToMap(toolchainTool.Referent)
+	if err != nil {
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "(Data) ibm_cd_toolchain_tool_appconfig", "read", "referent-to-map").GetDiag()
 	}
+	referent = append(referent, referentMap)
 	if err = d.Set("referent", referent); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting referent %s", err))
+		return flex.DiscriminatedTerraformErrorf(err, fmt.Sprintf("Error setting referent: %s", err), "(Data) ibm_cd_toolchain_tool_appconfig", "read", "set-referent").GetDiag()
 	}
 
-	if err = d.Set("name", toolchainTool.Name); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting name: %s", err))
+	if !core.IsNil(toolchainTool.Name) {
+		if err = d.Set("name", toolchainTool.Name); err != nil {
+			return flex.DiscriminatedTerraformErrorf(err, fmt.Sprintf("Error setting name: %s", err), "(Data) ibm_cd_toolchain_tool_appconfig", "read", "set-name").GetDiag()
+		}
 	}
 
 	if err = d.Set("updated_at", flex.DateTimeToString(toolchainTool.UpdatedAt)); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting updated_at: %s", err))
+		return flex.DiscriminatedTerraformErrorf(err, fmt.Sprintf("Error setting updated_at: %s", err), "(Data) ibm_cd_toolchain_tool_appconfig", "read", "set-updated_at").GetDiag()
 	}
 
 	parameters := []map[string]interface{}{}
-	if toolchainTool.Parameters != nil {
-		remapFields := map[string]string{
-			"location":            "region",
-			"resource_group_name": "resource-group",
-			"instance_id":         "instance-name",
-			"environment_id":      "environment-name",
-			"collection_id":       "collection-name",
-		}
-		modelMap := GetParametersFromRead(toolchainTool.Parameters, DataSourceIBMCdToolchainToolAppconfig(), remapFields)
-		parameters = append(parameters, modelMap)
+	remapFields := map[string]string{
+		"location":            "region",
+		"resource_group_name": "resource-group",
+		"instance_id":         "instance-name",
+		"environment_id":      "environment-name",
+		"collection_id":       "collection-name",
 	}
+	parametersMap := GetParametersFromRead(toolchainTool.Parameters, DataSourceIBMCdToolchainToolAppconfig(), remapFields)
+	parameters = append(parameters, parametersMap)
 	if err = d.Set("parameters", parameters); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting parameters %s", err))
+		return flex.DiscriminatedTerraformErrorf(err, fmt.Sprintf("Error setting parameters: %s", err), "(Data) ibm_cd_toolchain_tool_appconfig", "read", "set-parameters").GetDiag()
 	}
 
 	if err = d.Set("state", toolchainTool.State); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting state: %s", err))
+		return flex.DiscriminatedTerraformErrorf(err, fmt.Sprintf("Error setting state: %s", err), "(Data) ibm_cd_toolchain_tool_appconfig", "read", "set-state").GetDiag()
 	}
 
 	return nil
 }
 
-func dataSourceIBMCdToolchainToolAppconfigToolModelReferentToMap(model *cdtoolchainv2.ToolModelReferent) (map[string]interface{}, error) {
+func DataSourceIBMCdToolchainToolAppconfigToolModelReferentToMap(model *cdtoolchainv2.ToolModelReferent) (map[string]interface{}, error) {
 	modelMap := make(map[string]interface{})
 	if model.UIHref != nil {
-		modelMap["ui_href"] = model.UIHref
+		modelMap["ui_href"] = *model.UIHref
 	}
 	if model.APIHref != nil {
-		modelMap["api_href"] = model.APIHref
+		modelMap["api_href"] = *model.APIHref
 	}
 	return modelMap, nil
 }

--- a/ibm/service/cdtoolchain/data_source_ibm_cd_toolchain_tool_artifactory.go
+++ b/ibm/service/cdtoolchain/data_source_ibm_cd_toolchain_tool_artifactory.go
@@ -1,5 +1,9 @@
-// Copyright IBM Corp. 2023 All Rights Reserved.
+// Copyright IBM Corp. 2024 All Rights Reserved.
 // Licensed under the Mozilla Public License v2.0
+
+/*
+ * IBM OpenAPI Terraform Generator Version: 3.96.0-d6dec9d7-20241008-212902
+ */
 
 package cdtoolchain
 
@@ -14,6 +18,7 @@ import (
 	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/conns"
 	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/flex"
 	"github.com/IBM/continuous-delivery-go-sdk/cdtoolchainv2"
+	"github.com/IBM/go-sdk-core/v5/core"
 )
 
 func DataSourceIBMCdToolchainToolArtifactory() *schema.Resource {
@@ -152,7 +157,9 @@ func DataSourceIBMCdToolchainToolArtifactory() *schema.Resource {
 func dataSourceIBMCdToolchainToolArtifactoryRead(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	cdToolchainClient, err := meta.(conns.ClientSession).CdToolchainV2()
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.DiscriminatedTerraformErrorf(err, err.Error(), "(Data) ibm_cd_toolchain_tool_artifactory", "read", "initialize-client")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	getToolByIDOptions := &cdtoolchainv2.GetToolByIDOptions{}
@@ -160,77 +167,76 @@ func dataSourceIBMCdToolchainToolArtifactoryRead(context context.Context, d *sch
 	getToolByIDOptions.SetToolchainID(d.Get("toolchain_id").(string))
 	getToolByIDOptions.SetToolID(d.Get("tool_id").(string))
 
-	toolchainTool, response, err := cdToolchainClient.GetToolByIDWithContext(context, getToolByIDOptions)
+	toolchainTool, _, err := cdToolchainClient.GetToolByIDWithContext(context, getToolByIDOptions)
 	if err != nil {
-		log.Printf("[DEBUG] GetToolByIDWithContext failed %s\n%s", err, response)
-		return diag.FromErr(fmt.Errorf("GetToolByIDWithContext failed %s\n%s", err, response))
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("GetToolByIDWithContext failed: %s", err.Error()), "(Data) ibm_cd_toolchain_tool_artifactory", "read")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	if *toolchainTool.ToolTypeID != "artifactory" {
-		return diag.FromErr(fmt.Errorf("Retrieved tool is not the correct type: %s", *toolchainTool.ToolTypeID))
+		return flex.TerraformErrorf(err, fmt.Sprintf("Retrieved tool is not the correct type: %s", err), "(Data) ibm_cd_toolchain_tool", "read").GetDiag()
 	}
 
 	d.SetId(fmt.Sprintf("%s/%s", *getToolByIDOptions.ToolchainID, *getToolByIDOptions.ToolID))
 
 	if err = d.Set("resource_group_id", toolchainTool.ResourceGroupID); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting resource_group_id: %s", err))
+		return flex.DiscriminatedTerraformErrorf(err, fmt.Sprintf("Error setting resource_group_id: %s", err), "(Data) ibm_cd_toolchain_tool_artifactory", "read", "set-resource_group_id").GetDiag()
 	}
 
 	if err = d.Set("crn", toolchainTool.CRN); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting crn: %s", err))
+		return flex.DiscriminatedTerraformErrorf(err, fmt.Sprintf("Error setting crn: %s", err), "(Data) ibm_cd_toolchain_tool_artifactory", "read", "set-crn").GetDiag()
 	}
 
 	if err = d.Set("toolchain_crn", toolchainTool.ToolchainCRN); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting toolchain_crn: %s", err))
+		return flex.DiscriminatedTerraformErrorf(err, fmt.Sprintf("Error setting toolchain_crn: %s", err), "(Data) ibm_cd_toolchain_tool_artifactory", "read", "set-toolchain_crn").GetDiag()
 	}
 
 	if err = d.Set("href", toolchainTool.Href); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting href: %s", err))
+		return flex.DiscriminatedTerraformErrorf(err, fmt.Sprintf("Error setting href: %s", err), "(Data) ibm_cd_toolchain_tool_artifactory", "read", "set-href").GetDiag()
 	}
 
 	referent := []map[string]interface{}{}
-	if toolchainTool.Referent != nil {
-		modelMap, err := dataSourceIBMCdToolchainToolArtifactoryToolModelReferentToMap(toolchainTool.Referent)
-		if err != nil {
-			return diag.FromErr(err)
-		}
-		referent = append(referent, modelMap)
+	referentMap, err := DataSourceIBMCdToolchainToolArtifactoryToolModelReferentToMap(toolchainTool.Referent)
+	if err != nil {
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "(Data) ibm_cd_toolchain_tool_artifactory", "read", "referent-to-map").GetDiag()
 	}
+	referent = append(referent, referentMap)
 	if err = d.Set("referent", referent); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting referent %s", err))
+		return flex.DiscriminatedTerraformErrorf(err, fmt.Sprintf("Error setting referent: %s", err), "(Data) ibm_cd_toolchain_tool_artifactory", "read", "set-referent").GetDiag()
 	}
 
-	if err = d.Set("name", toolchainTool.Name); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting name: %s", err))
+	if !core.IsNil(toolchainTool.Name) {
+		if err = d.Set("name", toolchainTool.Name); err != nil {
+			return flex.DiscriminatedTerraformErrorf(err, fmt.Sprintf("Error setting name: %s", err), "(Data) ibm_cd_toolchain_tool_artifactory", "read", "set-name").GetDiag()
+		}
 	}
 
 	if err = d.Set("updated_at", flex.DateTimeToString(toolchainTool.UpdatedAt)); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting updated_at: %s", err))
+		return flex.DiscriminatedTerraformErrorf(err, fmt.Sprintf("Error setting updated_at: %s", err), "(Data) ibm_cd_toolchain_tool_artifactory", "read", "set-updated_at").GetDiag()
 	}
 
 	parameters := []map[string]interface{}{}
-	if toolchainTool.Parameters != nil {
-		modelMap := GetParametersFromRead(toolchainTool.Parameters, DataSourceIBMCdToolchainToolArtifactory(), nil)
-		parameters = append(parameters, modelMap)
-	}
+	parametersMap := GetParametersFromRead(toolchainTool.Parameters, DataSourceIBMCdToolchainToolArtifactory(), nil)
+	parameters = append(parameters, parametersMap)
 	if err = d.Set("parameters", parameters); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting parameters %s", err))
+		return flex.DiscriminatedTerraformErrorf(err, fmt.Sprintf("Error setting parameters: %s", err), "(Data) ibm_cd_toolchain_tool_artifactory", "read", "set-parameters").GetDiag()
 	}
 
 	if err = d.Set("state", toolchainTool.State); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting state: %s", err))
+		return flex.DiscriminatedTerraformErrorf(err, fmt.Sprintf("Error setting state: %s", err), "(Data) ibm_cd_toolchain_tool_artifactory", "read", "set-state").GetDiag()
 	}
 
 	return nil
 }
 
-func dataSourceIBMCdToolchainToolArtifactoryToolModelReferentToMap(model *cdtoolchainv2.ToolModelReferent) (map[string]interface{}, error) {
+func DataSourceIBMCdToolchainToolArtifactoryToolModelReferentToMap(model *cdtoolchainv2.ToolModelReferent) (map[string]interface{}, error) {
 	modelMap := make(map[string]interface{})
 	if model.UIHref != nil {
-		modelMap["ui_href"] = model.UIHref
+		modelMap["ui_href"] = *model.UIHref
 	}
 	if model.APIHref != nil {
-		modelMap["api_href"] = model.APIHref
+		modelMap["api_href"] = *model.APIHref
 	}
 	return modelMap, nil
 }

--- a/ibm/service/cdtoolchain/data_source_ibm_cd_toolchain_tool_bitbucketgit.go
+++ b/ibm/service/cdtoolchain/data_source_ibm_cd_toolchain_tool_bitbucketgit.go
@@ -1,5 +1,9 @@
-// Copyright IBM Corp. 2023 All Rights Reserved.
+// Copyright IBM Corp. 2024 All Rights Reserved.
 // Licensed under the Mozilla Public License v2.0
+
+/*
+ * IBM OpenAPI Terraform Generator Version: 3.96.0-d6dec9d7-20241008-212902
+ */
 
 package cdtoolchain
 
@@ -14,6 +18,7 @@ import (
 	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/conns"
 	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/flex"
 	"github.com/IBM/continuous-delivery-go-sdk/cdtoolchainv2"
+	"github.com/IBM/go-sdk-core/v5/core"
 )
 
 func DataSourceIBMCdToolchainToolBitbucketgit() *schema.Resource {
@@ -171,7 +176,9 @@ func DataSourceIBMCdToolchainToolBitbucketgit() *schema.Resource {
 func dataSourceIBMCdToolchainToolBitbucketgitRead(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	cdToolchainClient, err := meta.(conns.ClientSession).CdToolchainV2()
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.DiscriminatedTerraformErrorf(err, err.Error(), "(Data) ibm_cd_toolchain_tool_bitbucketgit", "read", "initialize-client")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	getToolByIDOptions := &cdtoolchainv2.GetToolByIDOptions{}
@@ -179,80 +186,79 @@ func dataSourceIBMCdToolchainToolBitbucketgitRead(context context.Context, d *sc
 	getToolByIDOptions.SetToolchainID(d.Get("toolchain_id").(string))
 	getToolByIDOptions.SetToolID(d.Get("tool_id").(string))
 
-	toolchainTool, response, err := cdToolchainClient.GetToolByIDWithContext(context, getToolByIDOptions)
+	toolchainTool, _, err := cdToolchainClient.GetToolByIDWithContext(context, getToolByIDOptions)
 	if err != nil {
-		log.Printf("[DEBUG] GetToolByIDWithContext failed %s\n%s", err, response)
-		return diag.FromErr(fmt.Errorf("GetToolByIDWithContext failed %s\n%s", err, response))
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("GetToolByIDWithContext failed: %s", err.Error()), "(Data) ibm_cd_toolchain_tool_bitbucketgit", "read")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	if *toolchainTool.ToolTypeID != "bitbucketgit" {
-		return diag.FromErr(fmt.Errorf("Retrieved tool is not the correct type: %s", *toolchainTool.ToolTypeID))
+		return flex.TerraformErrorf(err, fmt.Sprintf("Retrieved tool is not the correct type: %s", err), "(Data) ibm_cd_toolchain_tool", "read").GetDiag()
 	}
 
 	d.SetId(fmt.Sprintf("%s/%s", *getToolByIDOptions.ToolchainID, *getToolByIDOptions.ToolID))
 
 	if err = d.Set("resource_group_id", toolchainTool.ResourceGroupID); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting resource_group_id: %s", err))
+		return flex.DiscriminatedTerraformErrorf(err, fmt.Sprintf("Error setting resource_group_id: %s", err), "(Data) ibm_cd_toolchain_tool_bitbucketgit", "read", "set-resource_group_id").GetDiag()
 	}
 
 	if err = d.Set("crn", toolchainTool.CRN); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting crn: %s", err))
+		return flex.DiscriminatedTerraformErrorf(err, fmt.Sprintf("Error setting crn: %s", err), "(Data) ibm_cd_toolchain_tool_bitbucketgit", "read", "set-crn").GetDiag()
 	}
 
 	if err = d.Set("toolchain_crn", toolchainTool.ToolchainCRN); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting toolchain_crn: %s", err))
+		return flex.DiscriminatedTerraformErrorf(err, fmt.Sprintf("Error setting toolchain_crn: %s", err), "(Data) ibm_cd_toolchain_tool_bitbucketgit", "read", "set-toolchain_crn").GetDiag()
 	}
 
 	if err = d.Set("href", toolchainTool.Href); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting href: %s", err))
+		return flex.DiscriminatedTerraformErrorf(err, fmt.Sprintf("Error setting href: %s", err), "(Data) ibm_cd_toolchain_tool_bitbucketgit", "read", "set-href").GetDiag()
 	}
 
 	referent := []map[string]interface{}{}
-	if toolchainTool.Referent != nil {
-		modelMap, err := dataSourceIBMCdToolchainToolBitbucketgitToolModelReferentToMap(toolchainTool.Referent)
-		if err != nil {
-			return diag.FromErr(err)
-		}
-		referent = append(referent, modelMap)
+	referentMap, err := DataSourceIBMCdToolchainToolBitbucketgitToolModelReferentToMap(toolchainTool.Referent)
+	if err != nil {
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "(Data) ibm_cd_toolchain_tool_bitbucketgit", "read", "referent-to-map").GetDiag()
 	}
+	referent = append(referent, referentMap)
 	if err = d.Set("referent", referent); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting referent %s", err))
+		return flex.DiscriminatedTerraformErrorf(err, fmt.Sprintf("Error setting referent: %s", err), "(Data) ibm_cd_toolchain_tool_bitbucketgit", "read", "set-referent").GetDiag()
 	}
 
-	if err = d.Set("name", toolchainTool.Name); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting name: %s", err))
+	if !core.IsNil(toolchainTool.Name) {
+		if err = d.Set("name", toolchainTool.Name); err != nil {
+			return flex.DiscriminatedTerraformErrorf(err, fmt.Sprintf("Error setting name: %s", err), "(Data) ibm_cd_toolchain_tool_bitbucketgit", "read", "set-name").GetDiag()
+		}
 	}
 
 	if err = d.Set("updated_at", flex.DateTimeToString(toolchainTool.UpdatedAt)); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting updated_at: %s", err))
+		return flex.DiscriminatedTerraformErrorf(err, fmt.Sprintf("Error setting updated_at: %s", err), "(Data) ibm_cd_toolchain_tool_bitbucketgit", "read", "set-updated_at").GetDiag()
 	}
 
 	parameters := []map[string]interface{}{}
-	if toolchainTool.Parameters != nil {
-		remapFields := map[string]string{
-			"toolchain_issues_enabled": "has_issues",
-		}
-		modelMap := GetParametersFromRead(toolchainTool.Parameters, DataSourceIBMCdToolchainToolBitbucketgit(), remapFields)
-		parameters = append(parameters, modelMap)
+	remapFields := map[string]string{
+		"toolchain_issues_enabled": "has_issues",
 	}
+	parametersMap := GetParametersFromRead(toolchainTool.Parameters, DataSourceIBMCdToolchainToolBitbucketgit(), remapFields)
+	parameters = append(parameters, parametersMap)
 	if err = d.Set("parameters", parameters); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting parameters %s", err))
+		return flex.DiscriminatedTerraformErrorf(err, fmt.Sprintf("Error setting parameters: %s", err), "(Data) ibm_cd_toolchain_tool_bitbucketgit", "read", "set-parameters").GetDiag()
 	}
 
 	if err = d.Set("state", toolchainTool.State); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting state: %s", err))
+		return flex.DiscriminatedTerraformErrorf(err, fmt.Sprintf("Error setting state: %s", err), "(Data) ibm_cd_toolchain_tool_bitbucketgit", "read", "set-state").GetDiag()
 	}
 
 	return nil
 }
 
-func dataSourceIBMCdToolchainToolBitbucketgitToolModelReferentToMap(model *cdtoolchainv2.ToolModelReferent) (map[string]interface{}, error) {
+func DataSourceIBMCdToolchainToolBitbucketgitToolModelReferentToMap(model *cdtoolchainv2.ToolModelReferent) (map[string]interface{}, error) {
 	modelMap := make(map[string]interface{})
 	if model.UIHref != nil {
-		modelMap["ui_href"] = model.UIHref
+		modelMap["ui_href"] = *model.UIHref
 	}
 	if model.APIHref != nil {
-		modelMap["api_href"] = model.APIHref
+		modelMap["api_href"] = *model.APIHref
 	}
 	return modelMap, nil
 }

--- a/ibm/service/cdtoolchain/data_source_ibm_cd_toolchain_tool_custom.go
+++ b/ibm/service/cdtoolchain/data_source_ibm_cd_toolchain_tool_custom.go
@@ -1,5 +1,9 @@
-// Copyright IBM Corp. 2023 All Rights Reserved.
+// Copyright IBM Corp. 2024 All Rights Reserved.
 // Licensed under the Mozilla Public License v2.0
+
+/*
+ * IBM OpenAPI Terraform Generator Version: 3.96.0-d6dec9d7-20241008-212902
+ */
 
 package cdtoolchain
 
@@ -14,6 +18,7 @@ import (
 	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/conns"
 	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/flex"
 	"github.com/IBM/continuous-delivery-go-sdk/cdtoolchainv2"
+	"github.com/IBM/go-sdk-core/v5/core"
 )
 
 func DataSourceIBMCdToolchainToolCustom() *schema.Resource {
@@ -141,7 +146,9 @@ func DataSourceIBMCdToolchainToolCustom() *schema.Resource {
 func dataSourceIBMCdToolchainToolCustomRead(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	cdToolchainClient, err := meta.(conns.ClientSession).CdToolchainV2()
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.DiscriminatedTerraformErrorf(err, err.Error(), "(Data) ibm_cd_toolchain_tool_custom", "read", "initialize-client")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	getToolByIDOptions := &cdtoolchainv2.GetToolByIDOptions{}
@@ -149,83 +156,82 @@ func dataSourceIBMCdToolchainToolCustomRead(context context.Context, d *schema.R
 	getToolByIDOptions.SetToolchainID(d.Get("toolchain_id").(string))
 	getToolByIDOptions.SetToolID(d.Get("tool_id").(string))
 
-	toolchainTool, response, err := cdToolchainClient.GetToolByIDWithContext(context, getToolByIDOptions)
+	toolchainTool, _, err := cdToolchainClient.GetToolByIDWithContext(context, getToolByIDOptions)
 	if err != nil {
-		log.Printf("[DEBUG] GetToolByIDWithContext failed %s\n%s", err, response)
-		return diag.FromErr(fmt.Errorf("GetToolByIDWithContext failed %s\n%s", err, response))
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("GetToolByIDWithContext failed: %s", err.Error()), "(Data) ibm_cd_toolchain_tool_custom", "read")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	if *toolchainTool.ToolTypeID != "customtool" {
-		return diag.FromErr(fmt.Errorf("Retrieved tool is not the correct type: %s", *toolchainTool.ToolTypeID))
+		return flex.TerraformErrorf(err, fmt.Sprintf("Retrieved tool is not the correct type: %s", err), "(Data) ibm_cd_toolchain_tool", "read").GetDiag()
 	}
 
 	d.SetId(fmt.Sprintf("%s/%s", *getToolByIDOptions.ToolchainID, *getToolByIDOptions.ToolID))
 
 	if err = d.Set("resource_group_id", toolchainTool.ResourceGroupID); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting resource_group_id: %s", err))
+		return flex.DiscriminatedTerraformErrorf(err, fmt.Sprintf("Error setting resource_group_id: %s", err), "(Data) ibm_cd_toolchain_tool_custom", "read", "set-resource_group_id").GetDiag()
 	}
 
 	if err = d.Set("crn", toolchainTool.CRN); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting crn: %s", err))
+		return flex.DiscriminatedTerraformErrorf(err, fmt.Sprintf("Error setting crn: %s", err), "(Data) ibm_cd_toolchain_tool_custom", "read", "set-crn").GetDiag()
 	}
 
 	if err = d.Set("toolchain_crn", toolchainTool.ToolchainCRN); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting toolchain_crn: %s", err))
+		return flex.DiscriminatedTerraformErrorf(err, fmt.Sprintf("Error setting toolchain_crn: %s", err), "(Data) ibm_cd_toolchain_tool_custom", "read", "set-toolchain_crn").GetDiag()
 	}
 
 	if err = d.Set("href", toolchainTool.Href); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting href: %s", err))
+		return flex.DiscriminatedTerraformErrorf(err, fmt.Sprintf("Error setting href: %s", err), "(Data) ibm_cd_toolchain_tool_custom", "read", "set-href").GetDiag()
 	}
 
 	referent := []map[string]interface{}{}
-	if toolchainTool.Referent != nil {
-		modelMap, err := dataSourceIBMCdToolchainToolCustomToolModelReferentToMap(toolchainTool.Referent)
-		if err != nil {
-			return diag.FromErr(err)
-		}
-		referent = append(referent, modelMap)
+	referentMap, err := DataSourceIBMCdToolchainToolCustomToolModelReferentToMap(toolchainTool.Referent)
+	if err != nil {
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "(Data) ibm_cd_toolchain_tool_custom", "read", "referent-to-map").GetDiag()
 	}
+	referent = append(referent, referentMap)
 	if err = d.Set("referent", referent); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting referent %s", err))
+		return flex.DiscriminatedTerraformErrorf(err, fmt.Sprintf("Error setting referent: %s", err), "(Data) ibm_cd_toolchain_tool_custom", "read", "set-referent").GetDiag()
 	}
 
-	if err = d.Set("name", toolchainTool.Name); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting name: %s", err))
+	if !core.IsNil(toolchainTool.Name) {
+		if err = d.Set("name", toolchainTool.Name); err != nil {
+			return flex.DiscriminatedTerraformErrorf(err, fmt.Sprintf("Error setting name: %s", err), "(Data) ibm_cd_toolchain_tool_custom", "read", "set-name").GetDiag()
+		}
 	}
 
 	if err = d.Set("updated_at", flex.DateTimeToString(toolchainTool.UpdatedAt)); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting updated_at: %s", err))
+		return flex.DiscriminatedTerraformErrorf(err, fmt.Sprintf("Error setting updated_at: %s", err), "(Data) ibm_cd_toolchain_tool_custom", "read", "set-updated_at").GetDiag()
 	}
 
 	parameters := []map[string]interface{}{}
-	if toolchainTool.Parameters != nil {
-		remapFields := map[string]string{
-			"lifecycle_phase":       "lifecyclePhase",
-			"image_url":             "imageUrl",
-			"documentation_url":     "documentationUrl",
-			"additional_properties": "additional-properties",
-		}
-		modelMap := GetParametersFromRead(toolchainTool.Parameters, DataSourceIBMCdToolchainToolCustom(), remapFields)
-		parameters = append(parameters, modelMap)
+	remapFields := map[string]string{
+		"lifecycle_phase":       "lifecyclePhase",
+		"image_url":             "imageUrl",
+		"documentation_url":     "documentationUrl",
+		"additional_properties": "additional-properties",
 	}
+	parametersMap := GetParametersFromRead(toolchainTool.Parameters, DataSourceIBMCdToolchainToolCustom(), remapFields)
+	parameters = append(parameters, parametersMap)
 	if err = d.Set("parameters", parameters); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting parameters %s", err))
+		return flex.DiscriminatedTerraformErrorf(err, fmt.Sprintf("Error setting parameters: %s", err), "(Data) ibm_cd_toolchain_tool_custom", "read", "set-parameters").GetDiag()
 	}
 
 	if err = d.Set("state", toolchainTool.State); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting state: %s", err))
+		return flex.DiscriminatedTerraformErrorf(err, fmt.Sprintf("Error setting state: %s", err), "(Data) ibm_cd_toolchain_tool_custom", "read", "set-state").GetDiag()
 	}
 
 	return nil
 }
 
-func dataSourceIBMCdToolchainToolCustomToolModelReferentToMap(model *cdtoolchainv2.ToolModelReferent) (map[string]interface{}, error) {
+func DataSourceIBMCdToolchainToolCustomToolModelReferentToMap(model *cdtoolchainv2.ToolModelReferent) (map[string]interface{}, error) {
 	modelMap := make(map[string]interface{})
 	if model.UIHref != nil {
-		modelMap["ui_href"] = model.UIHref
+		modelMap["ui_href"] = *model.UIHref
 	}
 	if model.APIHref != nil {
-		modelMap["api_href"] = model.APIHref
+		modelMap["api_href"] = *model.APIHref
 	}
 	return modelMap, nil
 }

--- a/ibm/service/cdtoolchain/data_source_ibm_cd_toolchain_tool_devopsinsights.go
+++ b/ibm/service/cdtoolchain/data_source_ibm_cd_toolchain_tool_devopsinsights.go
@@ -1,5 +1,9 @@
-// Copyright IBM Corp. 2023 All Rights Reserved.
+// Copyright IBM Corp. 2024 All Rights Reserved.
 // Licensed under the Mozilla Public License v2.0
+
+/*
+ * IBM OpenAPI Terraform Generator Version: 3.96.0-d6dec9d7-20241008-212902
+ */
 
 package cdtoolchain
 
@@ -14,6 +18,7 @@ import (
 	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/conns"
 	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/flex"
 	"github.com/IBM/continuous-delivery-go-sdk/cdtoolchainv2"
+	"github.com/IBM/go-sdk-core/v5/core"
 )
 
 func DataSourceIBMCdToolchainToolDevopsinsights() *schema.Resource {
@@ -92,7 +97,9 @@ func DataSourceIBMCdToolchainToolDevopsinsights() *schema.Resource {
 func dataSourceIBMCdToolchainToolDevopsinsightsRead(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	cdToolchainClient, err := meta.(conns.ClientSession).CdToolchainV2()
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.DiscriminatedTerraformErrorf(err, err.Error(), "(Data) ibm_cd_toolchain_tool_devopsinsights", "read", "initialize-client")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	getToolByIDOptions := &cdtoolchainv2.GetToolByIDOptions{}
@@ -100,68 +107,69 @@ func dataSourceIBMCdToolchainToolDevopsinsightsRead(context context.Context, d *
 	getToolByIDOptions.SetToolchainID(d.Get("toolchain_id").(string))
 	getToolByIDOptions.SetToolID(d.Get("tool_id").(string))
 
-	toolchainTool, response, err := cdToolchainClient.GetToolByIDWithContext(context, getToolByIDOptions)
+	toolchainTool, _, err := cdToolchainClient.GetToolByIDWithContext(context, getToolByIDOptions)
 	if err != nil {
-		log.Printf("[DEBUG] GetToolByIDWithContext failed %s\n%s", err, response)
-		return diag.FromErr(fmt.Errorf("GetToolByIDWithContext failed %s\n%s", err, response))
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("GetToolByIDWithContext failed: %s", err.Error()), "(Data) ibm_cd_toolchain_tool_devopsinsights", "read")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	if *toolchainTool.ToolTypeID != "draservicebroker" {
-		return diag.FromErr(fmt.Errorf("Retrieved tool is not the correct type: %s", *toolchainTool.ToolTypeID))
+		return flex.TerraformErrorf(err, fmt.Sprintf("Retrieved tool is not the correct type: %s", err), "(Data) ibm_cd_toolchain_tool", "read").GetDiag()
 	}
 
 	d.SetId(fmt.Sprintf("%s/%s", *getToolByIDOptions.ToolchainID, *getToolByIDOptions.ToolID))
 
 	if err = d.Set("resource_group_id", toolchainTool.ResourceGroupID); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting resource_group_id: %s", err))
+		return flex.DiscriminatedTerraformErrorf(err, fmt.Sprintf("Error setting resource_group_id: %s", err), "(Data) ibm_cd_toolchain_tool_devopsinsights", "read", "set-resource_group_id").GetDiag()
 	}
 
 	if err = d.Set("crn", toolchainTool.CRN); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting crn: %s", err))
+		return flex.DiscriminatedTerraformErrorf(err, fmt.Sprintf("Error setting crn: %s", err), "(Data) ibm_cd_toolchain_tool_devopsinsights", "read", "set-crn").GetDiag()
 	}
 
 	if err = d.Set("toolchain_crn", toolchainTool.ToolchainCRN); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting toolchain_crn: %s", err))
+		return flex.DiscriminatedTerraformErrorf(err, fmt.Sprintf("Error setting toolchain_crn: %s", err), "(Data) ibm_cd_toolchain_tool_devopsinsights", "read", "set-toolchain_crn").GetDiag()
 	}
 
 	if err = d.Set("href", toolchainTool.Href); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting href: %s", err))
+		return flex.DiscriminatedTerraformErrorf(err, fmt.Sprintf("Error setting href: %s", err), "(Data) ibm_cd_toolchain_tool_devopsinsights", "read", "set-href").GetDiag()
 	}
 
 	referent := []map[string]interface{}{}
-	if toolchainTool.Referent != nil {
-		modelMap, err := dataSourceIBMCdToolchainToolDevopsinsightsToolModelReferentToMap(toolchainTool.Referent)
-		if err != nil {
-			return diag.FromErr(err)
-		}
-		referent = append(referent, modelMap)
+	referentMap, err := DataSourceIBMCdToolchainToolDevopsinsightsToolModelReferentToMap(toolchainTool.Referent)
+	if err != nil {
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "(Data) ibm_cd_toolchain_tool_devopsinsights", "read", "referent-to-map").GetDiag()
 	}
+	referent = append(referent, referentMap)
 	if err = d.Set("referent", referent); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting referent %s", err))
+		return flex.DiscriminatedTerraformErrorf(err, fmt.Sprintf("Error setting referent: %s", err), "(Data) ibm_cd_toolchain_tool_devopsinsights", "read", "set-referent").GetDiag()
 	}
 
-	if err = d.Set("name", toolchainTool.Name); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting name: %s", err))
+	if !core.IsNil(toolchainTool.Name) {
+		if err = d.Set("name", toolchainTool.Name); err != nil {
+			return flex.DiscriminatedTerraformErrorf(err, fmt.Sprintf("Error setting name: %s", err), "(Data) ibm_cd_toolchain_tool_devopsinsights", "read", "set-name").GetDiag()
+		}
 	}
 
 	if err = d.Set("updated_at", flex.DateTimeToString(toolchainTool.UpdatedAt)); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting updated_at: %s", err))
+		return flex.DiscriminatedTerraformErrorf(err, fmt.Sprintf("Error setting updated_at: %s", err), "(Data) ibm_cd_toolchain_tool_devopsinsights", "read", "set-updated_at").GetDiag()
 	}
 
 	if err = d.Set("state", toolchainTool.State); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting state: %s", err))
+		return flex.DiscriminatedTerraformErrorf(err, fmt.Sprintf("Error setting state: %s", err), "(Data) ibm_cd_toolchain_tool_devopsinsights", "read", "set-state").GetDiag()
 	}
 
 	return nil
 }
 
-func dataSourceIBMCdToolchainToolDevopsinsightsToolModelReferentToMap(model *cdtoolchainv2.ToolModelReferent) (map[string]interface{}, error) {
+func DataSourceIBMCdToolchainToolDevopsinsightsToolModelReferentToMap(model *cdtoolchainv2.ToolModelReferent) (map[string]interface{}, error) {
 	modelMap := make(map[string]interface{})
 	if model.UIHref != nil {
-		modelMap["ui_href"] = model.UIHref
+		modelMap["ui_href"] = *model.UIHref
 	}
 	if model.APIHref != nil {
-		modelMap["api_href"] = model.APIHref
+		modelMap["api_href"] = *model.APIHref
 	}
 	return modelMap, nil
 }

--- a/ibm/service/cdtoolchain/data_source_ibm_cd_toolchain_tool_eventnotifications.go
+++ b/ibm/service/cdtoolchain/data_source_ibm_cd_toolchain_tool_eventnotifications.go
@@ -1,5 +1,9 @@
-// Copyright IBM Corp. 2023 All Rights Reserved.
+// Copyright IBM Corp. 2024 All Rights Reserved.
 // Licensed under the Mozilla Public License v2.0
+
+/*
+ * IBM OpenAPI Terraform Generator Version: 3.96.0-d6dec9d7-20241008-212902
+ */
 
 package cdtoolchain
 
@@ -14,6 +18,7 @@ import (
 	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/conns"
 	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/flex"
 	"github.com/IBM/continuous-delivery-go-sdk/cdtoolchainv2"
+	"github.com/IBM/go-sdk-core/v5/core"
 )
 
 func DataSourceIBMCdToolchainToolEventnotifications() *schema.Resource {
@@ -111,7 +116,9 @@ func DataSourceIBMCdToolchainToolEventnotifications() *schema.Resource {
 func dataSourceIBMCdToolchainToolEventnotificationsRead(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	cdToolchainClient, err := meta.(conns.ClientSession).CdToolchainV2()
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.DiscriminatedTerraformErrorf(err, err.Error(), "(Data) ibm_cd_toolchain_tool_eventnotifications", "read", "initialize-client")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	getToolByIDOptions := &cdtoolchainv2.GetToolByIDOptions{}
@@ -119,80 +126,79 @@ func dataSourceIBMCdToolchainToolEventnotificationsRead(context context.Context,
 	getToolByIDOptions.SetToolchainID(d.Get("toolchain_id").(string))
 	getToolByIDOptions.SetToolID(d.Get("tool_id").(string))
 
-	toolchainTool, response, err := cdToolchainClient.GetToolByIDWithContext(context, getToolByIDOptions)
+	toolchainTool, _, err := cdToolchainClient.GetToolByIDWithContext(context, getToolByIDOptions)
 	if err != nil {
-		log.Printf("[DEBUG] GetToolByIDWithContext failed %s\n%s", err, response)
-		return diag.FromErr(fmt.Errorf("GetToolByIDWithContext failed %s\n%s", err, response))
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("GetToolByIDWithContext failed: %s", err.Error()), "(Data) ibm_cd_toolchain_tool_eventnotifications", "read")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	if *toolchainTool.ToolTypeID != "eventnotifications" {
-		return diag.FromErr(fmt.Errorf("Retrieved tool is not the correct type: %s", *toolchainTool.ToolTypeID))
+		return flex.TerraformErrorf(err, fmt.Sprintf("Retrieved tool is not the correct type: %s", err), "(Data) ibm_cd_toolchain_tool", "read").GetDiag()
 	}
 
 	d.SetId(fmt.Sprintf("%s/%s", *getToolByIDOptions.ToolchainID, *getToolByIDOptions.ToolID))
 
 	if err = d.Set("resource_group_id", toolchainTool.ResourceGroupID); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting resource_group_id: %s", err))
+		return flex.DiscriminatedTerraformErrorf(err, fmt.Sprintf("Error setting resource_group_id: %s", err), "(Data) ibm_cd_toolchain_tool_eventnotifications", "read", "set-resource_group_id").GetDiag()
 	}
 
 	if err = d.Set("crn", toolchainTool.CRN); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting crn: %s", err))
+		return flex.DiscriminatedTerraformErrorf(err, fmt.Sprintf("Error setting crn: %s", err), "(Data) ibm_cd_toolchain_tool_eventnotifications", "read", "set-crn").GetDiag()
 	}
 
 	if err = d.Set("toolchain_crn", toolchainTool.ToolchainCRN); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting toolchain_crn: %s", err))
+		return flex.DiscriminatedTerraformErrorf(err, fmt.Sprintf("Error setting toolchain_crn: %s", err), "(Data) ibm_cd_toolchain_tool_eventnotifications", "read", "set-toolchain_crn").GetDiag()
 	}
 
 	if err = d.Set("href", toolchainTool.Href); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting href: %s", err))
+		return flex.DiscriminatedTerraformErrorf(err, fmt.Sprintf("Error setting href: %s", err), "(Data) ibm_cd_toolchain_tool_eventnotifications", "read", "set-href").GetDiag()
 	}
 
 	referent := []map[string]interface{}{}
-	if toolchainTool.Referent != nil {
-		modelMap, err := dataSourceIBMCdToolchainToolEventnotificationsToolModelReferentToMap(toolchainTool.Referent)
-		if err != nil {
-			return diag.FromErr(err)
-		}
-		referent = append(referent, modelMap)
+	referentMap, err := DataSourceIBMCdToolchainToolEventnotificationsToolModelReferentToMap(toolchainTool.Referent)
+	if err != nil {
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "(Data) ibm_cd_toolchain_tool_eventnotifications", "read", "referent-to-map").GetDiag()
 	}
+	referent = append(referent, referentMap)
 	if err = d.Set("referent", referent); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting referent %s", err))
+		return flex.DiscriminatedTerraformErrorf(err, fmt.Sprintf("Error setting referent: %s", err), "(Data) ibm_cd_toolchain_tool_eventnotifications", "read", "set-referent").GetDiag()
 	}
 
-	if err = d.Set("name", toolchainTool.Name); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting name: %s", err))
+	if !core.IsNil(toolchainTool.Name) {
+		if err = d.Set("name", toolchainTool.Name); err != nil {
+			return flex.DiscriminatedTerraformErrorf(err, fmt.Sprintf("Error setting name: %s", err), "(Data) ibm_cd_toolchain_tool_eventnotifications", "read", "set-name").GetDiag()
+		}
 	}
 
 	if err = d.Set("updated_at", flex.DateTimeToString(toolchainTool.UpdatedAt)); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting updated_at: %s", err))
+		return flex.DiscriminatedTerraformErrorf(err, fmt.Sprintf("Error setting updated_at: %s", err), "(Data) ibm_cd_toolchain_tool_eventnotifications", "read", "set-updated_at").GetDiag()
 	}
 
 	parameters := []map[string]interface{}{}
-	if toolchainTool.Parameters != nil {
-		remapFields := map[string]string{
-			"instance_crn": "instance-crn",
-		}
-		modelMap := GetParametersFromRead(toolchainTool.Parameters, DataSourceIBMCdToolchainToolEventnotifications(), remapFields)
-		parameters = append(parameters, modelMap)
+	remapFields := map[string]string{
+		"instance_crn": "instance-crn",
 	}
+	parametersMap := GetParametersFromRead(toolchainTool.Parameters, DataSourceIBMCdToolchainToolEventnotifications(), remapFields)
+	parameters = append(parameters, parametersMap)
 	if err = d.Set("parameters", parameters); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting parameters %s", err))
+		return flex.DiscriminatedTerraformErrorf(err, fmt.Sprintf("Error setting parameters: %s", err), "(Data) ibm_cd_toolchain_tool_eventnotifications", "read", "set-parameters").GetDiag()
 	}
 
 	if err = d.Set("state", toolchainTool.State); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting state: %s", err))
+		return flex.DiscriminatedTerraformErrorf(err, fmt.Sprintf("Error setting state: %s", err), "(Data) ibm_cd_toolchain_tool_eventnotifications", "read", "set-state").GetDiag()
 	}
 
 	return nil
 }
 
-func dataSourceIBMCdToolchainToolEventnotificationsToolModelReferentToMap(model *cdtoolchainv2.ToolModelReferent) (map[string]interface{}, error) {
+func DataSourceIBMCdToolchainToolEventnotificationsToolModelReferentToMap(model *cdtoolchainv2.ToolModelReferent) (map[string]interface{}, error) {
 	modelMap := make(map[string]interface{})
 	if model.UIHref != nil {
-		modelMap["ui_href"] = model.UIHref
+		modelMap["ui_href"] = *model.UIHref
 	}
 	if model.APIHref != nil {
-		modelMap["api_href"] = model.APIHref
+		modelMap["api_href"] = *model.APIHref
 	}
 	return modelMap, nil
 }

--- a/ibm/service/cdtoolchain/data_source_ibm_cd_toolchain_tool_githubconsolidated.go
+++ b/ibm/service/cdtoolchain/data_source_ibm_cd_toolchain_tool_githubconsolidated.go
@@ -1,5 +1,9 @@
-// Copyright IBM Corp. 2023 All Rights Reserved.
+// Copyright IBM Corp. 2024 All Rights Reserved.
 // Licensed under the Mozilla Public License v2.0
+
+/*
+ * IBM OpenAPI Terraform Generator Version: 3.96.0-d6dec9d7-20241008-212902
+ */
 
 package cdtoolchain
 
@@ -14,6 +18,7 @@ import (
 	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/conns"
 	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/flex"
 	"github.com/IBM/continuous-delivery-go-sdk/cdtoolchainv2"
+	"github.com/IBM/go-sdk-core/v5/core"
 )
 
 func DataSourceIBMCdToolchainToolGithubconsolidated() *schema.Resource {
@@ -202,7 +207,9 @@ func DataSourceIBMCdToolchainToolGithubconsolidated() *schema.Resource {
 func dataSourceIBMCdToolchainToolGithubconsolidatedRead(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	cdToolchainClient, err := meta.(conns.ClientSession).CdToolchainV2()
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.DiscriminatedTerraformErrorf(err, err.Error(), "(Data) ibm_cd_toolchain_tool_githubconsolidated", "read", "initialize-client")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	getToolByIDOptions := &cdtoolchainv2.GetToolByIDOptions{}
@@ -210,80 +217,79 @@ func dataSourceIBMCdToolchainToolGithubconsolidatedRead(context context.Context,
 	getToolByIDOptions.SetToolchainID(d.Get("toolchain_id").(string))
 	getToolByIDOptions.SetToolID(d.Get("tool_id").(string))
 
-	toolchainTool, response, err := cdToolchainClient.GetToolByIDWithContext(context, getToolByIDOptions)
+	toolchainTool, _, err := cdToolchainClient.GetToolByIDWithContext(context, getToolByIDOptions)
 	if err != nil {
-		log.Printf("[DEBUG] GetToolByIDWithContext failed %s\n%s", err, response)
-		return diag.FromErr(fmt.Errorf("GetToolByIDWithContext failed %s\n%s", err, response))
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("GetToolByIDWithContext failed: %s", err.Error()), "(Data) ibm_cd_toolchain_tool_githubconsolidated", "read")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	if *toolchainTool.ToolTypeID != "githubconsolidated" {
-		return diag.FromErr(fmt.Errorf("Retrieved tool is not the correct type: %s", *toolchainTool.ToolTypeID))
+		return flex.TerraformErrorf(err, fmt.Sprintf("Retrieved tool is not the correct type: %s", err), "(Data) ibm_cd_toolchain_tool", "read").GetDiag()
 	}
 
 	d.SetId(fmt.Sprintf("%s/%s", *getToolByIDOptions.ToolchainID, *getToolByIDOptions.ToolID))
 
 	if err = d.Set("resource_group_id", toolchainTool.ResourceGroupID); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting resource_group_id: %s", err))
+		return flex.DiscriminatedTerraformErrorf(err, fmt.Sprintf("Error setting resource_group_id: %s", err), "(Data) ibm_cd_toolchain_tool_githubconsolidated", "read", "set-resource_group_id").GetDiag()
 	}
 
 	if err = d.Set("crn", toolchainTool.CRN); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting crn: %s", err))
+		return flex.DiscriminatedTerraformErrorf(err, fmt.Sprintf("Error setting crn: %s", err), "(Data) ibm_cd_toolchain_tool_githubconsolidated", "read", "set-crn").GetDiag()
 	}
 
 	if err = d.Set("toolchain_crn", toolchainTool.ToolchainCRN); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting toolchain_crn: %s", err))
+		return flex.DiscriminatedTerraformErrorf(err, fmt.Sprintf("Error setting toolchain_crn: %s", err), "(Data) ibm_cd_toolchain_tool_githubconsolidated", "read", "set-toolchain_crn").GetDiag()
 	}
 
 	if err = d.Set("href", toolchainTool.Href); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting href: %s", err))
+		return flex.DiscriminatedTerraformErrorf(err, fmt.Sprintf("Error setting href: %s", err), "(Data) ibm_cd_toolchain_tool_githubconsolidated", "read", "set-href").GetDiag()
 	}
 
 	referent := []map[string]interface{}{}
-	if toolchainTool.Referent != nil {
-		modelMap, err := dataSourceIBMCdToolchainToolGithubconsolidatedToolModelReferentToMap(toolchainTool.Referent)
-		if err != nil {
-			return diag.FromErr(err)
-		}
-		referent = append(referent, modelMap)
+	referentMap, err := DataSourceIBMCdToolchainToolGithubconsolidatedToolModelReferentToMap(toolchainTool.Referent)
+	if err != nil {
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "(Data) ibm_cd_toolchain_tool_githubconsolidated", "read", "referent-to-map").GetDiag()
 	}
+	referent = append(referent, referentMap)
 	if err = d.Set("referent", referent); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting referent %s", err))
+		return flex.DiscriminatedTerraformErrorf(err, fmt.Sprintf("Error setting referent: %s", err), "(Data) ibm_cd_toolchain_tool_githubconsolidated", "read", "set-referent").GetDiag()
 	}
 
-	if err = d.Set("name", toolchainTool.Name); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting name: %s", err))
+	if !core.IsNil(toolchainTool.Name) {
+		if err = d.Set("name", toolchainTool.Name); err != nil {
+			return flex.DiscriminatedTerraformErrorf(err, fmt.Sprintf("Error setting name: %s", err), "(Data) ibm_cd_toolchain_tool_githubconsolidated", "read", "set-name").GetDiag()
+		}
 	}
 
 	if err = d.Set("updated_at", flex.DateTimeToString(toolchainTool.UpdatedAt)); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting updated_at: %s", err))
+		return flex.DiscriminatedTerraformErrorf(err, fmt.Sprintf("Error setting updated_at: %s", err), "(Data) ibm_cd_toolchain_tool_githubconsolidated", "read", "set-updated_at").GetDiag()
 	}
 
 	parameters := []map[string]interface{}{}
-	if toolchainTool.Parameters != nil {
-		remapFields := map[string]string{
-			"toolchain_issues_enabled": "has_issues",
-		}
-		modelMap := GetParametersFromRead(toolchainTool.Parameters, DataSourceIBMCdToolchainToolGithubconsolidated(), remapFields)
-		parameters = append(parameters, modelMap)
+	remapFields := map[string]string{
+		"toolchain_issues_enabled": "has_issues",
 	}
+	parametersMap := GetParametersFromRead(toolchainTool.Parameters, DataSourceIBMCdToolchainToolGithubconsolidated(), remapFields)
+	parameters = append(parameters, parametersMap)
 	if err = d.Set("parameters", parameters); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting parameters %s", err))
+		return flex.DiscriminatedTerraformErrorf(err, fmt.Sprintf("Error setting parameters: %s", err), "(Data) ibm_cd_toolchain_tool_githubconsolidated", "read", "set-parameters").GetDiag()
 	}
 
 	if err = d.Set("state", toolchainTool.State); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting state: %s", err))
+		return flex.DiscriminatedTerraformErrorf(err, fmt.Sprintf("Error setting state: %s", err), "(Data) ibm_cd_toolchain_tool_githubconsolidated", "read", "set-state").GetDiag()
 	}
 
 	return nil
 }
 
-func dataSourceIBMCdToolchainToolGithubconsolidatedToolModelReferentToMap(model *cdtoolchainv2.ToolModelReferent) (map[string]interface{}, error) {
+func DataSourceIBMCdToolchainToolGithubconsolidatedToolModelReferentToMap(model *cdtoolchainv2.ToolModelReferent) (map[string]interface{}, error) {
 	modelMap := make(map[string]interface{})
 	if model.UIHref != nil {
-		modelMap["ui_href"] = model.UIHref
+		modelMap["ui_href"] = *model.UIHref
 	}
 	if model.APIHref != nil {
-		modelMap["api_href"] = model.APIHref
+		modelMap["api_href"] = *model.APIHref
 	}
 	return modelMap, nil
 }

--- a/ibm/service/cdtoolchain/data_source_ibm_cd_toolchain_tool_gitlab.go
+++ b/ibm/service/cdtoolchain/data_source_ibm_cd_toolchain_tool_gitlab.go
@@ -1,5 +1,9 @@
-// Copyright IBM Corp. 2023 All Rights Reserved.
+// Copyright IBM Corp. 2024 All Rights Reserved.
 // Licensed under the Mozilla Public License v2.0
+
+/*
+ * IBM OpenAPI Terraform Generator Version: 3.96.0-d6dec9d7-20241008-212902
+ */
 
 package cdtoolchain
 
@@ -14,6 +18,7 @@ import (
 	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/conns"
 	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/flex"
 	"github.com/IBM/continuous-delivery-go-sdk/cdtoolchainv2"
+	"github.com/IBM/go-sdk-core/v5/core"
 )
 
 func DataSourceIBMCdToolchainToolGitlab() *schema.Resource {
@@ -197,7 +202,9 @@ func DataSourceIBMCdToolchainToolGitlab() *schema.Resource {
 func dataSourceIBMCdToolchainToolGitlabRead(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	cdToolchainClient, err := meta.(conns.ClientSession).CdToolchainV2()
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.DiscriminatedTerraformErrorf(err, err.Error(), "(Data) ibm_cd_toolchain_tool_gitlab", "read", "initialize-client")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	getToolByIDOptions := &cdtoolchainv2.GetToolByIDOptions{}
@@ -205,80 +212,79 @@ func dataSourceIBMCdToolchainToolGitlabRead(context context.Context, d *schema.R
 	getToolByIDOptions.SetToolchainID(d.Get("toolchain_id").(string))
 	getToolByIDOptions.SetToolID(d.Get("tool_id").(string))
 
-	toolchainTool, response, err := cdToolchainClient.GetToolByIDWithContext(context, getToolByIDOptions)
+	toolchainTool, _, err := cdToolchainClient.GetToolByIDWithContext(context, getToolByIDOptions)
 	if err != nil {
-		log.Printf("[DEBUG] GetToolByIDWithContext failed %s\n%s", err, response)
-		return diag.FromErr(fmt.Errorf("GetToolByIDWithContext failed %s\n%s", err, response))
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("GetToolByIDWithContext failed: %s", err.Error()), "(Data) ibm_cd_toolchain_tool_gitlab", "read")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	if *toolchainTool.ToolTypeID != "gitlab" {
-		return diag.FromErr(fmt.Errorf("Retrieved tool is not the correct type: %s", *toolchainTool.ToolTypeID))
+		return flex.TerraformErrorf(err, fmt.Sprintf("Retrieved tool is not the correct type: %s", err), "(Data) ibm_cd_toolchain_tool", "read").GetDiag()
 	}
 
 	d.SetId(fmt.Sprintf("%s/%s", *getToolByIDOptions.ToolchainID, *getToolByIDOptions.ToolID))
 
 	if err = d.Set("resource_group_id", toolchainTool.ResourceGroupID); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting resource_group_id: %s", err))
+		return flex.DiscriminatedTerraformErrorf(err, fmt.Sprintf("Error setting resource_group_id: %s", err), "(Data) ibm_cd_toolchain_tool_gitlab", "read", "set-resource_group_id").GetDiag()
 	}
 
 	if err = d.Set("crn", toolchainTool.CRN); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting crn: %s", err))
+		return flex.DiscriminatedTerraformErrorf(err, fmt.Sprintf("Error setting crn: %s", err), "(Data) ibm_cd_toolchain_tool_gitlab", "read", "set-crn").GetDiag()
 	}
 
 	if err = d.Set("toolchain_crn", toolchainTool.ToolchainCRN); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting toolchain_crn: %s", err))
+		return flex.DiscriminatedTerraformErrorf(err, fmt.Sprintf("Error setting toolchain_crn: %s", err), "(Data) ibm_cd_toolchain_tool_gitlab", "read", "set-toolchain_crn").GetDiag()
 	}
 
 	if err = d.Set("href", toolchainTool.Href); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting href: %s", err))
+		return flex.DiscriminatedTerraformErrorf(err, fmt.Sprintf("Error setting href: %s", err), "(Data) ibm_cd_toolchain_tool_gitlab", "read", "set-href").GetDiag()
 	}
 
 	referent := []map[string]interface{}{}
-	if toolchainTool.Referent != nil {
-		modelMap, err := dataSourceIBMCdToolchainToolGitlabToolModelReferentToMap(toolchainTool.Referent)
-		if err != nil {
-			return diag.FromErr(err)
-		}
-		referent = append(referent, modelMap)
+	referentMap, err := DataSourceIBMCdToolchainToolGitlabToolModelReferentToMap(toolchainTool.Referent)
+	if err != nil {
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "(Data) ibm_cd_toolchain_tool_gitlab", "read", "referent-to-map").GetDiag()
 	}
+	referent = append(referent, referentMap)
 	if err = d.Set("referent", referent); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting referent %s", err))
+		return flex.DiscriminatedTerraformErrorf(err, fmt.Sprintf("Error setting referent: %s", err), "(Data) ibm_cd_toolchain_tool_gitlab", "read", "set-referent").GetDiag()
 	}
 
-	if err = d.Set("name", toolchainTool.Name); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting name: %s", err))
+	if !core.IsNil(toolchainTool.Name) {
+		if err = d.Set("name", toolchainTool.Name); err != nil {
+			return flex.DiscriminatedTerraformErrorf(err, fmt.Sprintf("Error setting name: %s", err), "(Data) ibm_cd_toolchain_tool_gitlab", "read", "set-name").GetDiag()
+		}
 	}
 
 	if err = d.Set("updated_at", flex.DateTimeToString(toolchainTool.UpdatedAt)); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting updated_at: %s", err))
+		return flex.DiscriminatedTerraformErrorf(err, fmt.Sprintf("Error setting updated_at: %s", err), "(Data) ibm_cd_toolchain_tool_gitlab", "read", "set-updated_at").GetDiag()
 	}
 
 	parameters := []map[string]interface{}{}
-	if toolchainTool.Parameters != nil {
-		remapFields := map[string]string{
-			"toolchain_issues_enabled": "has_issues",
-		}
-		modelMap := GetParametersFromRead(toolchainTool.Parameters, DataSourceIBMCdToolchainToolGitlab(), remapFields)
-		parameters = append(parameters, modelMap)
+	remapFields := map[string]string{
+		"toolchain_issues_enabled": "has_issues",
 	}
+	parametersMap := GetParametersFromRead(toolchainTool.Parameters, DataSourceIBMCdToolchainToolGitlab(), remapFields)
+	parameters = append(parameters, parametersMap)
 	if err = d.Set("parameters", parameters); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting parameters %s", err))
+		return flex.DiscriminatedTerraformErrorf(err, fmt.Sprintf("Error setting parameters: %s", err), "(Data) ibm_cd_toolchain_tool_gitlab", "read", "set-parameters").GetDiag()
 	}
 
 	if err = d.Set("state", toolchainTool.State); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting state: %s", err))
+		return flex.DiscriminatedTerraformErrorf(err, fmt.Sprintf("Error setting state: %s", err), "(Data) ibm_cd_toolchain_tool_gitlab", "read", "set-state").GetDiag()
 	}
 
 	return nil
 }
 
-func dataSourceIBMCdToolchainToolGitlabToolModelReferentToMap(model *cdtoolchainv2.ToolModelReferent) (map[string]interface{}, error) {
+func DataSourceIBMCdToolchainToolGitlabToolModelReferentToMap(model *cdtoolchainv2.ToolModelReferent) (map[string]interface{}, error) {
 	modelMap := make(map[string]interface{})
 	if model.UIHref != nil {
-		modelMap["ui_href"] = model.UIHref
+		modelMap["ui_href"] = *model.UIHref
 	}
 	if model.APIHref != nil {
-		modelMap["api_href"] = model.APIHref
+		modelMap["api_href"] = *model.APIHref
 	}
 	return modelMap, nil
 }

--- a/ibm/service/cdtoolchain/data_source_ibm_cd_toolchain_tool_hashicorpvault.go
+++ b/ibm/service/cdtoolchain/data_source_ibm_cd_toolchain_tool_hashicorpvault.go
@@ -1,5 +1,9 @@
-// Copyright IBM Corp. 2023 All Rights Reserved.
+// Copyright IBM Corp. 2024 All Rights Reserved.
 // Licensed under the Mozilla Public License v2.0
+
+/*
+ * IBM OpenAPI Terraform Generator Version: 3.96.0-d6dec9d7-20241008-212902
+ */
 
 package cdtoolchain
 
@@ -14,6 +18,7 @@ import (
 	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/conns"
 	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/flex"
 	"github.com/IBM/continuous-delivery-go-sdk/cdtoolchainv2"
+	"github.com/IBM/go-sdk-core/v5/core"
 )
 
 func DataSourceIBMCdToolchainToolHashicorpvault() *schema.Resource {
@@ -165,7 +170,9 @@ func DataSourceIBMCdToolchainToolHashicorpvault() *schema.Resource {
 func dataSourceIBMCdToolchainToolHashicorpvaultRead(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	cdToolchainClient, err := meta.(conns.ClientSession).CdToolchainV2()
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.DiscriminatedTerraformErrorf(err, err.Error(), "(Data) ibm_cd_toolchain_tool_hashicorpvault", "read", "initialize-client")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	getToolByIDOptions := &cdtoolchainv2.GetToolByIDOptions{}
@@ -173,77 +180,76 @@ func dataSourceIBMCdToolchainToolHashicorpvaultRead(context context.Context, d *
 	getToolByIDOptions.SetToolchainID(d.Get("toolchain_id").(string))
 	getToolByIDOptions.SetToolID(d.Get("tool_id").(string))
 
-	toolchainTool, response, err := cdToolchainClient.GetToolByIDWithContext(context, getToolByIDOptions)
+	toolchainTool, _, err := cdToolchainClient.GetToolByIDWithContext(context, getToolByIDOptions)
 	if err != nil {
-		log.Printf("[DEBUG] GetToolByIDWithContext failed %s\n%s", err, response)
-		return diag.FromErr(fmt.Errorf("GetToolByIDWithContext failed %s\n%s", err, response))
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("GetToolByIDWithContext failed: %s", err.Error()), "(Data) ibm_cd_toolchain_tool_hashicorpvault", "read")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	if *toolchainTool.ToolTypeID != "hashicorpvault" {
-		return diag.FromErr(fmt.Errorf("Retrieved tool is not the correct type: %s", *toolchainTool.ToolTypeID))
+		return flex.TerraformErrorf(err, fmt.Sprintf("Retrieved tool is not the correct type: %s", err), "(Data) ibm_cd_toolchain_tool", "read").GetDiag()
 	}
 
 	d.SetId(fmt.Sprintf("%s/%s", *getToolByIDOptions.ToolchainID, *getToolByIDOptions.ToolID))
 
 	if err = d.Set("resource_group_id", toolchainTool.ResourceGroupID); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting resource_group_id: %s", err))
+		return flex.DiscriminatedTerraformErrorf(err, fmt.Sprintf("Error setting resource_group_id: %s", err), "(Data) ibm_cd_toolchain_tool_hashicorpvault", "read", "set-resource_group_id").GetDiag()
 	}
 
 	if err = d.Set("crn", toolchainTool.CRN); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting crn: %s", err))
+		return flex.DiscriminatedTerraformErrorf(err, fmt.Sprintf("Error setting crn: %s", err), "(Data) ibm_cd_toolchain_tool_hashicorpvault", "read", "set-crn").GetDiag()
 	}
 
 	if err = d.Set("toolchain_crn", toolchainTool.ToolchainCRN); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting toolchain_crn: %s", err))
+		return flex.DiscriminatedTerraformErrorf(err, fmt.Sprintf("Error setting toolchain_crn: %s", err), "(Data) ibm_cd_toolchain_tool_hashicorpvault", "read", "set-toolchain_crn").GetDiag()
 	}
 
 	if err = d.Set("href", toolchainTool.Href); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting href: %s", err))
+		return flex.DiscriminatedTerraformErrorf(err, fmt.Sprintf("Error setting href: %s", err), "(Data) ibm_cd_toolchain_tool_hashicorpvault", "read", "set-href").GetDiag()
 	}
 
 	referent := []map[string]interface{}{}
-	if toolchainTool.Referent != nil {
-		modelMap, err := dataSourceIBMCdToolchainToolHashicorpvaultToolModelReferentToMap(toolchainTool.Referent)
-		if err != nil {
-			return diag.FromErr(err)
-		}
-		referent = append(referent, modelMap)
+	referentMap, err := DataSourceIBMCdToolchainToolHashicorpvaultToolModelReferentToMap(toolchainTool.Referent)
+	if err != nil {
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "(Data) ibm_cd_toolchain_tool_hashicorpvault", "read", "referent-to-map").GetDiag()
 	}
+	referent = append(referent, referentMap)
 	if err = d.Set("referent", referent); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting referent %s", err))
+		return flex.DiscriminatedTerraformErrorf(err, fmt.Sprintf("Error setting referent: %s", err), "(Data) ibm_cd_toolchain_tool_hashicorpvault", "read", "set-referent").GetDiag()
 	}
 
-	if err = d.Set("name", toolchainTool.Name); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting name: %s", err))
+	if !core.IsNil(toolchainTool.Name) {
+		if err = d.Set("name", toolchainTool.Name); err != nil {
+			return flex.DiscriminatedTerraformErrorf(err, fmt.Sprintf("Error setting name: %s", err), "(Data) ibm_cd_toolchain_tool_hashicorpvault", "read", "set-name").GetDiag()
+		}
 	}
 
 	if err = d.Set("updated_at", flex.DateTimeToString(toolchainTool.UpdatedAt)); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting updated_at: %s", err))
+		return flex.DiscriminatedTerraformErrorf(err, fmt.Sprintf("Error setting updated_at: %s", err), "(Data) ibm_cd_toolchain_tool_hashicorpvault", "read", "set-updated_at").GetDiag()
 	}
 
 	parameters := []map[string]interface{}{}
-	if toolchainTool.Parameters != nil {
-		modelMap := GetParametersFromRead(toolchainTool.Parameters, DataSourceIBMCdToolchainToolHashicorpvault(), nil)
-		parameters = append(parameters, modelMap)
-	}
+	parametersMap := GetParametersFromRead(toolchainTool.Parameters, DataSourceIBMCdToolchainToolHashicorpvault(), nil)
+	parameters = append(parameters, parametersMap)
 	if err = d.Set("parameters", parameters); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting parameters %s", err))
+		return flex.DiscriminatedTerraformErrorf(err, fmt.Sprintf("Error setting parameters: %s", err), "(Data) ibm_cd_toolchain_tool_hashicorpvault", "read", "set-parameters").GetDiag()
 	}
 
 	if err = d.Set("state", toolchainTool.State); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting state: %s", err))
+		return flex.DiscriminatedTerraformErrorf(err, fmt.Sprintf("Error setting state: %s", err), "(Data) ibm_cd_toolchain_tool_hashicorpvault", "read", "set-state").GetDiag()
 	}
 
 	return nil
 }
 
-func dataSourceIBMCdToolchainToolHashicorpvaultToolModelReferentToMap(model *cdtoolchainv2.ToolModelReferent) (map[string]interface{}, error) {
+func DataSourceIBMCdToolchainToolHashicorpvaultToolModelReferentToMap(model *cdtoolchainv2.ToolModelReferent) (map[string]interface{}, error) {
 	modelMap := make(map[string]interface{})
 	if model.UIHref != nil {
-		modelMap["ui_href"] = model.UIHref
+		modelMap["ui_href"] = *model.UIHref
 	}
 	if model.APIHref != nil {
-		modelMap["api_href"] = model.APIHref
+		modelMap["api_href"] = *model.APIHref
 	}
 	return modelMap, nil
 }

--- a/ibm/service/cdtoolchain/data_source_ibm_cd_toolchain_tool_hostedgit.go
+++ b/ibm/service/cdtoolchain/data_source_ibm_cd_toolchain_tool_hostedgit.go
@@ -1,5 +1,9 @@
-// Copyright IBM Corp. 2023 All Rights Reserved.
+// Copyright IBM Corp. 2024 All Rights Reserved.
 // Licensed under the Mozilla Public License v2.0
+
+/*
+ * IBM OpenAPI Terraform Generator Version: 3.96.0-d6dec9d7-20241008-212902
+ */
 
 package cdtoolchain
 
@@ -14,6 +18,7 @@ import (
 	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/conns"
 	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/flex"
 	"github.com/IBM/continuous-delivery-go-sdk/cdtoolchainv2"
+	"github.com/IBM/go-sdk-core/v5/core"
 )
 
 func DataSourceIBMCdToolchainToolHostedgit() *schema.Resource {
@@ -182,7 +187,9 @@ func DataSourceIBMCdToolchainToolHostedgit() *schema.Resource {
 func dataSourceIBMCdToolchainToolHostedgitRead(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	cdToolchainClient, err := meta.(conns.ClientSession).CdToolchainV2()
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.DiscriminatedTerraformErrorf(err, err.Error(), "(Data) ibm_cd_toolchain_tool_hostedgit", "read", "initialize-client")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	getToolByIDOptions := &cdtoolchainv2.GetToolByIDOptions{}
@@ -190,80 +197,79 @@ func dataSourceIBMCdToolchainToolHostedgitRead(context context.Context, d *schem
 	getToolByIDOptions.SetToolchainID(d.Get("toolchain_id").(string))
 	getToolByIDOptions.SetToolID(d.Get("tool_id").(string))
 
-	toolchainTool, response, err := cdToolchainClient.GetToolByIDWithContext(context, getToolByIDOptions)
+	toolchainTool, _, err := cdToolchainClient.GetToolByIDWithContext(context, getToolByIDOptions)
 	if err != nil {
-		log.Printf("[DEBUG] GetToolByIDWithContext failed %s\n%s", err, response)
-		return diag.FromErr(fmt.Errorf("GetToolByIDWithContext failed %s\n%s", err, response))
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("GetToolByIDWithContext failed: %s", err.Error()), "(Data) ibm_cd_toolchain_tool_hostedgit", "read")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	if *toolchainTool.ToolTypeID != "hostedgit" {
-		return diag.FromErr(fmt.Errorf("Retrieved tool is not the correct type: %s", *toolchainTool.ToolTypeID))
+		return flex.TerraformErrorf(err, fmt.Sprintf("Retrieved tool is not the correct type: %s", err), "(Data) ibm_cd_toolchain_tool", "read").GetDiag()
 	}
 
 	d.SetId(fmt.Sprintf("%s/%s", *getToolByIDOptions.ToolchainID, *getToolByIDOptions.ToolID))
 
 	if err = d.Set("resource_group_id", toolchainTool.ResourceGroupID); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting resource_group_id: %s", err))
+		return flex.DiscriminatedTerraformErrorf(err, fmt.Sprintf("Error setting resource_group_id: %s", err), "(Data) ibm_cd_toolchain_tool_hostedgit", "read", "set-resource_group_id").GetDiag()
 	}
 
 	if err = d.Set("crn", toolchainTool.CRN); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting crn: %s", err))
+		return flex.DiscriminatedTerraformErrorf(err, fmt.Sprintf("Error setting crn: %s", err), "(Data) ibm_cd_toolchain_tool_hostedgit", "read", "set-crn").GetDiag()
 	}
 
 	if err = d.Set("toolchain_crn", toolchainTool.ToolchainCRN); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting toolchain_crn: %s", err))
+		return flex.DiscriminatedTerraformErrorf(err, fmt.Sprintf("Error setting toolchain_crn: %s", err), "(Data) ibm_cd_toolchain_tool_hostedgit", "read", "set-toolchain_crn").GetDiag()
 	}
 
 	if err = d.Set("href", toolchainTool.Href); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting href: %s", err))
+		return flex.DiscriminatedTerraformErrorf(err, fmt.Sprintf("Error setting href: %s", err), "(Data) ibm_cd_toolchain_tool_hostedgit", "read", "set-href").GetDiag()
 	}
 
 	referent := []map[string]interface{}{}
-	if toolchainTool.Referent != nil {
-		modelMap, err := dataSourceIBMCdToolchainToolHostedgitToolModelReferentToMap(toolchainTool.Referent)
-		if err != nil {
-			return diag.FromErr(err)
-		}
-		referent = append(referent, modelMap)
+	referentMap, err := DataSourceIBMCdToolchainToolHostedgitToolModelReferentToMap(toolchainTool.Referent)
+	if err != nil {
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "(Data) ibm_cd_toolchain_tool_hostedgit", "read", "referent-to-map").GetDiag()
 	}
+	referent = append(referent, referentMap)
 	if err = d.Set("referent", referent); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting referent %s", err))
+		return flex.DiscriminatedTerraformErrorf(err, fmt.Sprintf("Error setting referent: %s", err), "(Data) ibm_cd_toolchain_tool_hostedgit", "read", "set-referent").GetDiag()
 	}
 
-	if err = d.Set("name", toolchainTool.Name); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting name: %s", err))
+	if !core.IsNil(toolchainTool.Name) {
+		if err = d.Set("name", toolchainTool.Name); err != nil {
+			return flex.DiscriminatedTerraformErrorf(err, fmt.Sprintf("Error setting name: %s", err), "(Data) ibm_cd_toolchain_tool_hostedgit", "read", "set-name").GetDiag()
+		}
 	}
 
 	if err = d.Set("updated_at", flex.DateTimeToString(toolchainTool.UpdatedAt)); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting updated_at: %s", err))
+		return flex.DiscriminatedTerraformErrorf(err, fmt.Sprintf("Error setting updated_at: %s", err), "(Data) ibm_cd_toolchain_tool_hostedgit", "read", "set-updated_at").GetDiag()
 	}
 
 	parameters := []map[string]interface{}{}
-	if toolchainTool.Parameters != nil {
-		remapFields := map[string]string{
-			"toolchain_issues_enabled": "has_issues",
-		}
-		modelMap := GetParametersFromRead(toolchainTool.Parameters, DataSourceIBMCdToolchainToolHostedgit(), remapFields)
-		parameters = append(parameters, modelMap)
+	remapFields := map[string]string{
+		"toolchain_issues_enabled": "has_issues",
 	}
+	parametersMap := GetParametersFromRead(toolchainTool.Parameters, DataSourceIBMCdToolchainToolHostedgit(), remapFields)
+	parameters = append(parameters, parametersMap)
 	if err = d.Set("parameters", parameters); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting parameters %s", err))
+		return flex.DiscriminatedTerraformErrorf(err, fmt.Sprintf("Error setting parameters: %s", err), "(Data) ibm_cd_toolchain_tool_hostedgit", "read", "set-parameters").GetDiag()
 	}
 
 	if err = d.Set("state", toolchainTool.State); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting state: %s", err))
+		return flex.DiscriminatedTerraformErrorf(err, fmt.Sprintf("Error setting state: %s", err), "(Data) ibm_cd_toolchain_tool_hostedgit", "read", "set-state").GetDiag()
 	}
 
 	return nil
 }
 
-func dataSourceIBMCdToolchainToolHostedgitToolModelReferentToMap(model *cdtoolchainv2.ToolModelReferent) (map[string]interface{}, error) {
+func DataSourceIBMCdToolchainToolHostedgitToolModelReferentToMap(model *cdtoolchainv2.ToolModelReferent) (map[string]interface{}, error) {
 	modelMap := make(map[string]interface{})
 	if model.UIHref != nil {
-		modelMap["ui_href"] = model.UIHref
+		modelMap["ui_href"] = *model.UIHref
 	}
 	if model.APIHref != nil {
-		modelMap["api_href"] = model.APIHref
+		modelMap["api_href"] = *model.APIHref
 	}
 	return modelMap, nil
 }

--- a/ibm/service/cdtoolchain/data_source_ibm_cd_toolchain_tool_jenkins.go
+++ b/ibm/service/cdtoolchain/data_source_ibm_cd_toolchain_tool_jenkins.go
@@ -1,5 +1,9 @@
-// Copyright IBM Corp. 2023 All Rights Reserved.
+// Copyright IBM Corp. 2024 All Rights Reserved.
 // Licensed under the Mozilla Public License v2.0
+
+/*
+ * IBM OpenAPI Terraform Generator Version: 3.96.0-d6dec9d7-20241008-212902
+ */
 
 package cdtoolchain
 
@@ -14,6 +18,7 @@ import (
 	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/conns"
 	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/flex"
 	"github.com/IBM/continuous-delivery-go-sdk/cdtoolchainv2"
+	"github.com/IBM/go-sdk-core/v5/core"
 )
 
 func DataSourceIBMCdToolchainToolJenkins() *schema.Resource {
@@ -128,7 +133,9 @@ func DataSourceIBMCdToolchainToolJenkins() *schema.Resource {
 func dataSourceIBMCdToolchainToolJenkinsRead(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	cdToolchainClient, err := meta.(conns.ClientSession).CdToolchainV2()
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.DiscriminatedTerraformErrorf(err, err.Error(), "(Data) ibm_cd_toolchain_tool_jenkins", "read", "initialize-client")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	getToolByIDOptions := &cdtoolchainv2.GetToolByIDOptions{}
@@ -136,77 +143,76 @@ func dataSourceIBMCdToolchainToolJenkinsRead(context context.Context, d *schema.
 	getToolByIDOptions.SetToolchainID(d.Get("toolchain_id").(string))
 	getToolByIDOptions.SetToolID(d.Get("tool_id").(string))
 
-	toolchainTool, response, err := cdToolchainClient.GetToolByIDWithContext(context, getToolByIDOptions)
+	toolchainTool, _, err := cdToolchainClient.GetToolByIDWithContext(context, getToolByIDOptions)
 	if err != nil {
-		log.Printf("[DEBUG] GetToolByIDWithContext failed %s\n%s", err, response)
-		return diag.FromErr(fmt.Errorf("GetToolByIDWithContext failed %s\n%s", err, response))
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("GetToolByIDWithContext failed: %s", err.Error()), "(Data) ibm_cd_toolchain_tool_jenkins", "read")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	if *toolchainTool.ToolTypeID != "jenkins" {
-		return diag.FromErr(fmt.Errorf("Retrieved tool is not the correct type: %s", *toolchainTool.ToolTypeID))
+		return flex.TerraformErrorf(err, fmt.Sprintf("Retrieved tool is not the correct type: %s", err), "(Data) ibm_cd_toolchain_tool", "read").GetDiag()
 	}
 
 	d.SetId(fmt.Sprintf("%s/%s", *getToolByIDOptions.ToolchainID, *getToolByIDOptions.ToolID))
 
 	if err = d.Set("resource_group_id", toolchainTool.ResourceGroupID); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting resource_group_id: %s", err))
+		return flex.DiscriminatedTerraformErrorf(err, fmt.Sprintf("Error setting resource_group_id: %s", err), "(Data) ibm_cd_toolchain_tool_jenkins", "read", "set-resource_group_id").GetDiag()
 	}
 
 	if err = d.Set("crn", toolchainTool.CRN); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting crn: %s", err))
+		return flex.DiscriminatedTerraformErrorf(err, fmt.Sprintf("Error setting crn: %s", err), "(Data) ibm_cd_toolchain_tool_jenkins", "read", "set-crn").GetDiag()
 	}
 
 	if err = d.Set("toolchain_crn", toolchainTool.ToolchainCRN); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting toolchain_crn: %s", err))
+		return flex.DiscriminatedTerraformErrorf(err, fmt.Sprintf("Error setting toolchain_crn: %s", err), "(Data) ibm_cd_toolchain_tool_jenkins", "read", "set-toolchain_crn").GetDiag()
 	}
 
 	if err = d.Set("href", toolchainTool.Href); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting href: %s", err))
+		return flex.DiscriminatedTerraformErrorf(err, fmt.Sprintf("Error setting href: %s", err), "(Data) ibm_cd_toolchain_tool_jenkins", "read", "set-href").GetDiag()
 	}
 
 	referent := []map[string]interface{}{}
-	if toolchainTool.Referent != nil {
-		modelMap, err := dataSourceIBMCdToolchainToolJenkinsToolModelReferentToMap(toolchainTool.Referent)
-		if err != nil {
-			return diag.FromErr(err)
-		}
-		referent = append(referent, modelMap)
+	referentMap, err := DataSourceIBMCdToolchainToolJenkinsToolModelReferentToMap(toolchainTool.Referent)
+	if err != nil {
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "(Data) ibm_cd_toolchain_tool_jenkins", "read", "referent-to-map").GetDiag()
 	}
+	referent = append(referent, referentMap)
 	if err = d.Set("referent", referent); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting referent %s", err))
+		return flex.DiscriminatedTerraformErrorf(err, fmt.Sprintf("Error setting referent: %s", err), "(Data) ibm_cd_toolchain_tool_jenkins", "read", "set-referent").GetDiag()
 	}
 
-	if err = d.Set("name", toolchainTool.Name); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting name: %s", err))
+	if !core.IsNil(toolchainTool.Name) {
+		if err = d.Set("name", toolchainTool.Name); err != nil {
+			return flex.DiscriminatedTerraformErrorf(err, fmt.Sprintf("Error setting name: %s", err), "(Data) ibm_cd_toolchain_tool_jenkins", "read", "set-name").GetDiag()
+		}
 	}
 
 	if err = d.Set("updated_at", flex.DateTimeToString(toolchainTool.UpdatedAt)); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting updated_at: %s", err))
+		return flex.DiscriminatedTerraformErrorf(err, fmt.Sprintf("Error setting updated_at: %s", err), "(Data) ibm_cd_toolchain_tool_jenkins", "read", "set-updated_at").GetDiag()
 	}
 
 	parameters := []map[string]interface{}{}
-	if toolchainTool.Parameters != nil {
-		modelMap := GetParametersFromRead(toolchainTool.Parameters, DataSourceIBMCdToolchainToolJenkins(), nil)
-		parameters = append(parameters, modelMap)
-	}
+	parametersMap := GetParametersFromRead(toolchainTool.Parameters, DataSourceIBMCdToolchainToolJenkins(), nil)
+	parameters = append(parameters, parametersMap)
 	if err = d.Set("parameters", parameters); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting parameters %s", err))
+		return flex.DiscriminatedTerraformErrorf(err, fmt.Sprintf("Error setting parameters: %s", err), "(Data) ibm_cd_toolchain_tool_jenkins", "read", "set-parameters").GetDiag()
 	}
 
 	if err = d.Set("state", toolchainTool.State); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting state: %s", err))
+		return flex.DiscriminatedTerraformErrorf(err, fmt.Sprintf("Error setting state: %s", err), "(Data) ibm_cd_toolchain_tool_jenkins", "read", "set-state").GetDiag()
 	}
 
 	return nil
 }
 
-func dataSourceIBMCdToolchainToolJenkinsToolModelReferentToMap(model *cdtoolchainv2.ToolModelReferent) (map[string]interface{}, error) {
+func DataSourceIBMCdToolchainToolJenkinsToolModelReferentToMap(model *cdtoolchainv2.ToolModelReferent) (map[string]interface{}, error) {
 	modelMap := make(map[string]interface{})
 	if model.UIHref != nil {
-		modelMap["ui_href"] = model.UIHref
+		modelMap["ui_href"] = *model.UIHref
 	}
 	if model.APIHref != nil {
-		modelMap["api_href"] = model.APIHref
+		modelMap["api_href"] = *model.APIHref
 	}
 	return modelMap, nil
 }

--- a/ibm/service/cdtoolchain/data_source_ibm_cd_toolchain_tool_jira.go
+++ b/ibm/service/cdtoolchain/data_source_ibm_cd_toolchain_tool_jira.go
@@ -1,5 +1,9 @@
-// Copyright IBM Corp. 2023 All Rights Reserved.
+// Copyright IBM Corp. 2024 All Rights Reserved.
 // Licensed under the Mozilla Public License v2.0
+
+/*
+ * IBM OpenAPI Terraform Generator Version: 3.96.0-d6dec9d7-20241008-212902
+ */
 
 package cdtoolchain
 
@@ -14,6 +18,7 @@ import (
 	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/conns"
 	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/flex"
 	"github.com/IBM/continuous-delivery-go-sdk/cdtoolchainv2"
+	"github.com/IBM/go-sdk-core/v5/core"
 )
 
 func DataSourceIBMCdToolchainToolJira() *schema.Resource {
@@ -127,7 +132,9 @@ func DataSourceIBMCdToolchainToolJira() *schema.Resource {
 func dataSourceIBMCdToolchainToolJiraRead(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	cdToolchainClient, err := meta.(conns.ClientSession).CdToolchainV2()
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.DiscriminatedTerraformErrorf(err, err.Error(), "(Data) ibm_cd_toolchain_tool_jira", "read", "initialize-client")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	getToolByIDOptions := &cdtoolchainv2.GetToolByIDOptions{}
@@ -135,80 +142,79 @@ func dataSourceIBMCdToolchainToolJiraRead(context context.Context, d *schema.Res
 	getToolByIDOptions.SetToolchainID(d.Get("toolchain_id").(string))
 	getToolByIDOptions.SetToolID(d.Get("tool_id").(string))
 
-	toolchainTool, response, err := cdToolchainClient.GetToolByIDWithContext(context, getToolByIDOptions)
+	toolchainTool, _, err := cdToolchainClient.GetToolByIDWithContext(context, getToolByIDOptions)
 	if err != nil {
-		log.Printf("[DEBUG] GetToolByIDWithContext failed %s\n%s", err, response)
-		return diag.FromErr(fmt.Errorf("GetToolByIDWithContext failed %s\n%s", err, response))
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("GetToolByIDWithContext failed: %s", err.Error()), "(Data) ibm_cd_toolchain_tool_jira", "read")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	if *toolchainTool.ToolTypeID != "jira" {
-		return diag.FromErr(fmt.Errorf("Retrieved tool is not the correct type: %s", *toolchainTool.ToolTypeID))
+		return flex.TerraformErrorf(err, fmt.Sprintf("Retrieved tool is not the correct type: %s", err), "(Data) ibm_cd_toolchain_tool", "read").GetDiag()
 	}
 
 	d.SetId(fmt.Sprintf("%s/%s", *getToolByIDOptions.ToolchainID, *getToolByIDOptions.ToolID))
 
 	if err = d.Set("resource_group_id", toolchainTool.ResourceGroupID); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting resource_group_id: %s", err))
+		return flex.DiscriminatedTerraformErrorf(err, fmt.Sprintf("Error setting resource_group_id: %s", err), "(Data) ibm_cd_toolchain_tool_jira", "read", "set-resource_group_id").GetDiag()
 	}
 
 	if err = d.Set("crn", toolchainTool.CRN); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting crn: %s", err))
+		return flex.DiscriminatedTerraformErrorf(err, fmt.Sprintf("Error setting crn: %s", err), "(Data) ibm_cd_toolchain_tool_jira", "read", "set-crn").GetDiag()
 	}
 
 	if err = d.Set("toolchain_crn", toolchainTool.ToolchainCRN); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting toolchain_crn: %s", err))
+		return flex.DiscriminatedTerraformErrorf(err, fmt.Sprintf("Error setting toolchain_crn: %s", err), "(Data) ibm_cd_toolchain_tool_jira", "read", "set-toolchain_crn").GetDiag()
 	}
 
 	if err = d.Set("href", toolchainTool.Href); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting href: %s", err))
+		return flex.DiscriminatedTerraformErrorf(err, fmt.Sprintf("Error setting href: %s", err), "(Data) ibm_cd_toolchain_tool_jira", "read", "set-href").GetDiag()
 	}
 
 	referent := []map[string]interface{}{}
-	if toolchainTool.Referent != nil {
-		modelMap, err := dataSourceIBMCdToolchainToolJiraToolModelReferentToMap(toolchainTool.Referent)
-		if err != nil {
-			return diag.FromErr(err)
-		}
-		referent = append(referent, modelMap)
+	referentMap, err := DataSourceIBMCdToolchainToolJiraToolModelReferentToMap(toolchainTool.Referent)
+	if err != nil {
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "(Data) ibm_cd_toolchain_tool_jira", "read", "referent-to-map").GetDiag()
 	}
+	referent = append(referent, referentMap)
 	if err = d.Set("referent", referent); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting referent %s", err))
+		return flex.DiscriminatedTerraformErrorf(err, fmt.Sprintf("Error setting referent: %s", err), "(Data) ibm_cd_toolchain_tool_jira", "read", "set-referent").GetDiag()
 	}
 
-	if err = d.Set("name", toolchainTool.Name); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting name: %s", err))
+	if !core.IsNil(toolchainTool.Name) {
+		if err = d.Set("name", toolchainTool.Name); err != nil {
+			return flex.DiscriminatedTerraformErrorf(err, fmt.Sprintf("Error setting name: %s", err), "(Data) ibm_cd_toolchain_tool_jira", "read", "set-name").GetDiag()
+		}
 	}
 
 	if err = d.Set("updated_at", flex.DateTimeToString(toolchainTool.UpdatedAt)); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting updated_at: %s", err))
+		return flex.DiscriminatedTerraformErrorf(err, fmt.Sprintf("Error setting updated_at: %s", err), "(Data) ibm_cd_toolchain_tool_jira", "read", "set-updated_at").GetDiag()
 	}
 
 	parameters := []map[string]interface{}{}
-	if toolchainTool.Parameters != nil {
-		remapFields := map[string]string{
-			"api_token": "password",
-		}
-		modelMap := GetParametersFromRead(toolchainTool.Parameters, DataSourceIBMCdToolchainToolJira(), remapFields)
-		parameters = append(parameters, modelMap)
+	remapFields := map[string]string{
+		"api_token": "password",
 	}
+	parametersMap := GetParametersFromRead(toolchainTool.Parameters, DataSourceIBMCdToolchainToolJira(), remapFields)
+	parameters = append(parameters, parametersMap)
 	if err = d.Set("parameters", parameters); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting parameters %s", err))
+		return flex.DiscriminatedTerraformErrorf(err, fmt.Sprintf("Error setting parameters: %s", err), "(Data) ibm_cd_toolchain_tool_jira", "read", "set-parameters").GetDiag()
 	}
 
 	if err = d.Set("state", toolchainTool.State); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting state: %s", err))
+		return flex.DiscriminatedTerraformErrorf(err, fmt.Sprintf("Error setting state: %s", err), "(Data) ibm_cd_toolchain_tool_jira", "read", "set-state").GetDiag()
 	}
 
 	return nil
 }
 
-func dataSourceIBMCdToolchainToolJiraToolModelReferentToMap(model *cdtoolchainv2.ToolModelReferent) (map[string]interface{}, error) {
+func DataSourceIBMCdToolchainToolJiraToolModelReferentToMap(model *cdtoolchainv2.ToolModelReferent) (map[string]interface{}, error) {
 	modelMap := make(map[string]interface{})
 	if model.UIHref != nil {
-		modelMap["ui_href"] = model.UIHref
+		modelMap["ui_href"] = *model.UIHref
 	}
 	if model.APIHref != nil {
-		modelMap["api_href"] = model.APIHref
+		modelMap["api_href"] = *model.APIHref
 	}
 	return modelMap, nil
 }

--- a/ibm/service/cdtoolchain/data_source_ibm_cd_toolchain_tool_keyprotect.go
+++ b/ibm/service/cdtoolchain/data_source_ibm_cd_toolchain_tool_keyprotect.go
@@ -1,5 +1,9 @@
-// Copyright IBM Corp. 2023 All Rights Reserved.
+// Copyright IBM Corp. 2024 All Rights Reserved.
 // Licensed under the Mozilla Public License v2.0
+
+/*
+ * IBM OpenAPI Terraform Generator Version: 3.96.0-d6dec9d7-20241008-212902
+ */
 
 package cdtoolchain
 
@@ -14,6 +18,7 @@ import (
 	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/conns"
 	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/flex"
 	"github.com/IBM/continuous-delivery-go-sdk/cdtoolchainv2"
+	"github.com/IBM/go-sdk-core/v5/core"
 )
 
 func DataSourceIBMCdToolchainToolKeyprotect() *schema.Resource {
@@ -121,7 +126,9 @@ func DataSourceIBMCdToolchainToolKeyprotect() *schema.Resource {
 func dataSourceIBMCdToolchainToolKeyprotectRead(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	cdToolchainClient, err := meta.(conns.ClientSession).CdToolchainV2()
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.DiscriminatedTerraformErrorf(err, err.Error(), "(Data) ibm_cd_toolchain_tool_keyprotect", "read", "initialize-client")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	getToolByIDOptions := &cdtoolchainv2.GetToolByIDOptions{}
@@ -129,82 +136,81 @@ func dataSourceIBMCdToolchainToolKeyprotectRead(context context.Context, d *sche
 	getToolByIDOptions.SetToolchainID(d.Get("toolchain_id").(string))
 	getToolByIDOptions.SetToolID(d.Get("tool_id").(string))
 
-	toolchainTool, response, err := cdToolchainClient.GetToolByIDWithContext(context, getToolByIDOptions)
+	toolchainTool, _, err := cdToolchainClient.GetToolByIDWithContext(context, getToolByIDOptions)
 	if err != nil {
-		log.Printf("[DEBUG] GetToolByIDWithContext failed %s\n%s", err, response)
-		return diag.FromErr(fmt.Errorf("GetToolByIDWithContext failed %s\n%s", err, response))
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("GetToolByIDWithContext failed: %s", err.Error()), "(Data) ibm_cd_toolchain_tool_keyprotect", "read")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	if *toolchainTool.ToolTypeID != "keyprotect" {
-		return diag.FromErr(fmt.Errorf("Retrieved tool is not the correct type: %s", *toolchainTool.ToolTypeID))
+		return flex.TerraformErrorf(err, fmt.Sprintf("Retrieved tool is not the correct type: %s", err), "(Data) ibm_cd_toolchain_tool", "read").GetDiag()
 	}
 
 	d.SetId(fmt.Sprintf("%s/%s", *getToolByIDOptions.ToolchainID, *getToolByIDOptions.ToolID))
 
 	if err = d.Set("resource_group_id", toolchainTool.ResourceGroupID); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting resource_group_id: %s", err))
+		return flex.DiscriminatedTerraformErrorf(err, fmt.Sprintf("Error setting resource_group_id: %s", err), "(Data) ibm_cd_toolchain_tool_keyprotect", "read", "set-resource_group_id").GetDiag()
 	}
 
 	if err = d.Set("crn", toolchainTool.CRN); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting crn: %s", err))
+		return flex.DiscriminatedTerraformErrorf(err, fmt.Sprintf("Error setting crn: %s", err), "(Data) ibm_cd_toolchain_tool_keyprotect", "read", "set-crn").GetDiag()
 	}
 
 	if err = d.Set("toolchain_crn", toolchainTool.ToolchainCRN); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting toolchain_crn: %s", err))
+		return flex.DiscriminatedTerraformErrorf(err, fmt.Sprintf("Error setting toolchain_crn: %s", err), "(Data) ibm_cd_toolchain_tool_keyprotect", "read", "set-toolchain_crn").GetDiag()
 	}
 
 	if err = d.Set("href", toolchainTool.Href); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting href: %s", err))
+		return flex.DiscriminatedTerraformErrorf(err, fmt.Sprintf("Error setting href: %s", err), "(Data) ibm_cd_toolchain_tool_keyprotect", "read", "set-href").GetDiag()
 	}
 
 	referent := []map[string]interface{}{}
-	if toolchainTool.Referent != nil {
-		modelMap, err := dataSourceIBMCdToolchainToolKeyprotectToolModelReferentToMap(toolchainTool.Referent)
-		if err != nil {
-			return diag.FromErr(err)
-		}
-		referent = append(referent, modelMap)
+	referentMap, err := DataSourceIBMCdToolchainToolKeyprotectToolModelReferentToMap(toolchainTool.Referent)
+	if err != nil {
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "(Data) ibm_cd_toolchain_tool_keyprotect", "read", "referent-to-map").GetDiag()
 	}
+	referent = append(referent, referentMap)
 	if err = d.Set("referent", referent); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting referent %s", err))
+		return flex.DiscriminatedTerraformErrorf(err, fmt.Sprintf("Error setting referent: %s", err), "(Data) ibm_cd_toolchain_tool_keyprotect", "read", "set-referent").GetDiag()
 	}
 
-	if err = d.Set("name", toolchainTool.Name); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting name: %s", err))
+	if !core.IsNil(toolchainTool.Name) {
+		if err = d.Set("name", toolchainTool.Name); err != nil {
+			return flex.DiscriminatedTerraformErrorf(err, fmt.Sprintf("Error setting name: %s", err), "(Data) ibm_cd_toolchain_tool_keyprotect", "read", "set-name").GetDiag()
+		}
 	}
 
 	if err = d.Set("updated_at", flex.DateTimeToString(toolchainTool.UpdatedAt)); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting updated_at: %s", err))
+		return flex.DiscriminatedTerraformErrorf(err, fmt.Sprintf("Error setting updated_at: %s", err), "(Data) ibm_cd_toolchain_tool_keyprotect", "read", "set-updated_at").GetDiag()
 	}
 
 	parameters := []map[string]interface{}{}
-	if toolchainTool.Parameters != nil {
-		remapFields := map[string]string{
-			"location":            "region",
-			"resource_group_name": "resource-group",
-			"instance_name":       "instance-name",
-		}
-		modelMap := GetParametersFromRead(toolchainTool.Parameters, DataSourceIBMCdToolchainToolKeyprotect(), remapFields)
-		parameters = append(parameters, modelMap)
+	remapFields := map[string]string{
+		"location":            "region",
+		"resource_group_name": "resource-group",
+		"instance_name":       "instance-name",
 	}
+	parametersMap := GetParametersFromRead(toolchainTool.Parameters, DataSourceIBMCdToolchainToolKeyprotect(), remapFields)
+	parameters = append(parameters, parametersMap)
 	if err = d.Set("parameters", parameters); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting parameters %s", err))
+		return flex.DiscriminatedTerraformErrorf(err, fmt.Sprintf("Error setting parameters: %s", err), "(Data) ibm_cd_toolchain_tool_keyprotect", "read", "set-parameters").GetDiag()
 	}
 
 	if err = d.Set("state", toolchainTool.State); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting state: %s", err))
+		return flex.DiscriminatedTerraformErrorf(err, fmt.Sprintf("Error setting state: %s", err), "(Data) ibm_cd_toolchain_tool_keyprotect", "read", "set-state").GetDiag()
 	}
 
 	return nil
 }
 
-func dataSourceIBMCdToolchainToolKeyprotectToolModelReferentToMap(model *cdtoolchainv2.ToolModelReferent) (map[string]interface{}, error) {
+func DataSourceIBMCdToolchainToolKeyprotectToolModelReferentToMap(model *cdtoolchainv2.ToolModelReferent) (map[string]interface{}, error) {
 	modelMap := make(map[string]interface{})
 	if model.UIHref != nil {
-		modelMap["ui_href"] = model.UIHref
+		modelMap["ui_href"] = *model.UIHref
 	}
 	if model.APIHref != nil {
-		modelMap["api_href"] = model.APIHref
+		modelMap["api_href"] = *model.APIHref
 	}
 	return modelMap, nil
 }

--- a/ibm/service/cdtoolchain/data_source_ibm_cd_toolchain_tool_nexus.go
+++ b/ibm/service/cdtoolchain/data_source_ibm_cd_toolchain_tool_nexus.go
@@ -1,5 +1,9 @@
-// Copyright IBM Corp. 2023 All Rights Reserved.
+// Copyright IBM Corp. 2024 All Rights Reserved.
 // Licensed under the Mozilla Public License v2.0
+
+/*
+ * IBM OpenAPI Terraform Generator Version: 3.96.0-d6dec9d7-20241008-212902
+ */
 
 package cdtoolchain
 
@@ -14,6 +18,7 @@ import (
 	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/conns"
 	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/flex"
 	"github.com/IBM/continuous-delivery-go-sdk/cdtoolchainv2"
+	"github.com/IBM/go-sdk-core/v5/core"
 )
 
 func DataSourceIBMCdToolchainToolNexus() *schema.Resource {
@@ -142,7 +147,9 @@ func DataSourceIBMCdToolchainToolNexus() *schema.Resource {
 func dataSourceIBMCdToolchainToolNexusRead(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	cdToolchainClient, err := meta.(conns.ClientSession).CdToolchainV2()
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.DiscriminatedTerraformErrorf(err, err.Error(), "(Data) ibm_cd_toolchain_tool_nexus", "read", "initialize-client")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	getToolByIDOptions := &cdtoolchainv2.GetToolByIDOptions{}
@@ -150,80 +157,79 @@ func dataSourceIBMCdToolchainToolNexusRead(context context.Context, d *schema.Re
 	getToolByIDOptions.SetToolchainID(d.Get("toolchain_id").(string))
 	getToolByIDOptions.SetToolID(d.Get("tool_id").(string))
 
-	toolchainTool, response, err := cdToolchainClient.GetToolByIDWithContext(context, getToolByIDOptions)
+	toolchainTool, _, err := cdToolchainClient.GetToolByIDWithContext(context, getToolByIDOptions)
 	if err != nil {
-		log.Printf("[DEBUG] GetToolByIDWithContext failed %s\n%s", err, response)
-		return diag.FromErr(fmt.Errorf("GetToolByIDWithContext failed %s\n%s", err, response))
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("GetToolByIDWithContext failed: %s", err.Error()), "(Data) ibm_cd_toolchain_tool_nexus", "read")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	if *toolchainTool.ToolTypeID != "nexus" {
-		return diag.FromErr(fmt.Errorf("Retrieved tool is not the correct type: %s", *toolchainTool.ToolTypeID))
+		return flex.TerraformErrorf(err, fmt.Sprintf("Retrieved tool is not the correct type: %s", err), "(Data) ibm_cd_toolchain_tool", "read").GetDiag()
 	}
 
 	d.SetId(fmt.Sprintf("%s/%s", *getToolByIDOptions.ToolchainID, *getToolByIDOptions.ToolID))
 
 	if err = d.Set("resource_group_id", toolchainTool.ResourceGroupID); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting resource_group_id: %s", err))
+		return flex.DiscriminatedTerraformErrorf(err, fmt.Sprintf("Error setting resource_group_id: %s", err), "(Data) ibm_cd_toolchain_tool_nexus", "read", "set-resource_group_id").GetDiag()
 	}
 
 	if err = d.Set("crn", toolchainTool.CRN); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting crn: %s", err))
+		return flex.DiscriminatedTerraformErrorf(err, fmt.Sprintf("Error setting crn: %s", err), "(Data) ibm_cd_toolchain_tool_nexus", "read", "set-crn").GetDiag()
 	}
 
 	if err = d.Set("toolchain_crn", toolchainTool.ToolchainCRN); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting toolchain_crn: %s", err))
+		return flex.DiscriminatedTerraformErrorf(err, fmt.Sprintf("Error setting toolchain_crn: %s", err), "(Data) ibm_cd_toolchain_tool_nexus", "read", "set-toolchain_crn").GetDiag()
 	}
 
 	if err = d.Set("href", toolchainTool.Href); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting href: %s", err))
+		return flex.DiscriminatedTerraformErrorf(err, fmt.Sprintf("Error setting href: %s", err), "(Data) ibm_cd_toolchain_tool_nexus", "read", "set-href").GetDiag()
 	}
 
 	referent := []map[string]interface{}{}
-	if toolchainTool.Referent != nil {
-		modelMap, err := dataSourceIBMCdToolchainToolNexusToolModelReferentToMap(toolchainTool.Referent)
-		if err != nil {
-			return diag.FromErr(err)
-		}
-		referent = append(referent, modelMap)
+	referentMap, err := DataSourceIBMCdToolchainToolNexusToolModelReferentToMap(toolchainTool.Referent)
+	if err != nil {
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "(Data) ibm_cd_toolchain_tool_nexus", "read", "referent-to-map").GetDiag()
 	}
+	referent = append(referent, referentMap)
 	if err = d.Set("referent", referent); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting referent %s", err))
+		return flex.DiscriminatedTerraformErrorf(err, fmt.Sprintf("Error setting referent: %s", err), "(Data) ibm_cd_toolchain_tool_nexus", "read", "set-referent").GetDiag()
 	}
 
-	if err = d.Set("name", toolchainTool.Name); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting name: %s", err))
+	if !core.IsNil(toolchainTool.Name) {
+		if err = d.Set("name", toolchainTool.Name); err != nil {
+			return flex.DiscriminatedTerraformErrorf(err, fmt.Sprintf("Error setting name: %s", err), "(Data) ibm_cd_toolchain_tool_nexus", "read", "set-name").GetDiag()
+		}
 	}
 
 	if err = d.Set("updated_at", flex.DateTimeToString(toolchainTool.UpdatedAt)); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting updated_at: %s", err))
+		return flex.DiscriminatedTerraformErrorf(err, fmt.Sprintf("Error setting updated_at: %s", err), "(Data) ibm_cd_toolchain_tool_nexus", "read", "set-updated_at").GetDiag()
 	}
 
 	parameters := []map[string]interface{}{}
-	if toolchainTool.Parameters != nil {
-		remapFields := map[string]string{
-			"server_url": "dashboard_url",
-		}
-		modelMap := GetParametersFromRead(toolchainTool.Parameters, DataSourceIBMCdToolchainToolNexus(), remapFields)
-		parameters = append(parameters, modelMap)
+	remapFields := map[string]string{
+		"server_url": "dashboard_url",
 	}
+	parametersMap := GetParametersFromRead(toolchainTool.Parameters, DataSourceIBMCdToolchainToolNexus(), remapFields)
+	parameters = append(parameters, parametersMap)
 	if err = d.Set("parameters", parameters); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting parameters %s", err))
+		return flex.DiscriminatedTerraformErrorf(err, fmt.Sprintf("Error setting parameters: %s", err), "(Data) ibm_cd_toolchain_tool_nexus", "read", "set-parameters").GetDiag()
 	}
 
 	if err = d.Set("state", toolchainTool.State); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting state: %s", err))
+		return flex.DiscriminatedTerraformErrorf(err, fmt.Sprintf("Error setting state: %s", err), "(Data) ibm_cd_toolchain_tool_nexus", "read", "set-state").GetDiag()
 	}
 
 	return nil
 }
 
-func dataSourceIBMCdToolchainToolNexusToolModelReferentToMap(model *cdtoolchainv2.ToolModelReferent) (map[string]interface{}, error) {
+func DataSourceIBMCdToolchainToolNexusToolModelReferentToMap(model *cdtoolchainv2.ToolModelReferent) (map[string]interface{}, error) {
 	modelMap := make(map[string]interface{})
 	if model.UIHref != nil {
-		modelMap["ui_href"] = model.UIHref
+		modelMap["ui_href"] = *model.UIHref
 	}
 	if model.APIHref != nil {
-		modelMap["api_href"] = model.APIHref
+		modelMap["api_href"] = *model.APIHref
 	}
 	return modelMap, nil
 }

--- a/ibm/service/cdtoolchain/data_source_ibm_cd_toolchain_tool_pagerduty.go
+++ b/ibm/service/cdtoolchain/data_source_ibm_cd_toolchain_tool_pagerduty.go
@@ -1,5 +1,9 @@
-// Copyright IBM Corp. 2023 All Rights Reserved.
+// Copyright IBM Corp. 2024 All Rights Reserved.
 // Licensed under the Mozilla Public License v2.0
+
+/*
+ * IBM OpenAPI Terraform Generator Version: 3.96.0-d6dec9d7-20241008-212902
+ */
 
 package cdtoolchain
 
@@ -14,6 +18,7 @@ import (
 	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/conns"
 	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/flex"
 	"github.com/IBM/continuous-delivery-go-sdk/cdtoolchainv2"
+	"github.com/IBM/go-sdk-core/v5/core"
 )
 
 func DataSourceIBMCdToolchainToolPagerduty() *schema.Resource {
@@ -117,7 +122,9 @@ func DataSourceIBMCdToolchainToolPagerduty() *schema.Resource {
 func dataSourceIBMCdToolchainToolPagerdutyRead(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	cdToolchainClient, err := meta.(conns.ClientSession).CdToolchainV2()
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.DiscriminatedTerraformErrorf(err, err.Error(), "(Data) ibm_cd_toolchain_tool_pagerduty", "read", "initialize-client")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	getToolByIDOptions := &cdtoolchainv2.GetToolByIDOptions{}
@@ -125,77 +132,76 @@ func dataSourceIBMCdToolchainToolPagerdutyRead(context context.Context, d *schem
 	getToolByIDOptions.SetToolchainID(d.Get("toolchain_id").(string))
 	getToolByIDOptions.SetToolID(d.Get("tool_id").(string))
 
-	toolchainTool, response, err := cdToolchainClient.GetToolByIDWithContext(context, getToolByIDOptions)
+	toolchainTool, _, err := cdToolchainClient.GetToolByIDWithContext(context, getToolByIDOptions)
 	if err != nil {
-		log.Printf("[DEBUG] GetToolByIDWithContext failed %s\n%s", err, response)
-		return diag.FromErr(fmt.Errorf("GetToolByIDWithContext failed %s\n%s", err, response))
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("GetToolByIDWithContext failed: %s", err.Error()), "(Data) ibm_cd_toolchain_tool_pagerduty", "read")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	if *toolchainTool.ToolTypeID != "pagerduty" {
-		return diag.FromErr(fmt.Errorf("Retrieved tool is not the correct type: %s", *toolchainTool.ToolTypeID))
+		return flex.TerraformErrorf(err, fmt.Sprintf("Retrieved tool is not the correct type: %s", err), "(Data) ibm_cd_toolchain_tool", "read").GetDiag()
 	}
 
 	d.SetId(fmt.Sprintf("%s/%s", *getToolByIDOptions.ToolchainID, *getToolByIDOptions.ToolID))
 
 	if err = d.Set("resource_group_id", toolchainTool.ResourceGroupID); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting resource_group_id: %s", err))
+		return flex.DiscriminatedTerraformErrorf(err, fmt.Sprintf("Error setting resource_group_id: %s", err), "(Data) ibm_cd_toolchain_tool_pagerduty", "read", "set-resource_group_id").GetDiag()
 	}
 
 	if err = d.Set("crn", toolchainTool.CRN); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting crn: %s", err))
+		return flex.DiscriminatedTerraformErrorf(err, fmt.Sprintf("Error setting crn: %s", err), "(Data) ibm_cd_toolchain_tool_pagerduty", "read", "set-crn").GetDiag()
 	}
 
 	if err = d.Set("toolchain_crn", toolchainTool.ToolchainCRN); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting toolchain_crn: %s", err))
+		return flex.DiscriminatedTerraformErrorf(err, fmt.Sprintf("Error setting toolchain_crn: %s", err), "(Data) ibm_cd_toolchain_tool_pagerduty", "read", "set-toolchain_crn").GetDiag()
 	}
 
 	if err = d.Set("href", toolchainTool.Href); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting href: %s", err))
+		return flex.DiscriminatedTerraformErrorf(err, fmt.Sprintf("Error setting href: %s", err), "(Data) ibm_cd_toolchain_tool_pagerduty", "read", "set-href").GetDiag()
 	}
 
 	referent := []map[string]interface{}{}
-	if toolchainTool.Referent != nil {
-		modelMap, err := dataSourceIBMCdToolchainToolPagerdutyToolModelReferentToMap(toolchainTool.Referent)
-		if err != nil {
-			return diag.FromErr(err)
-		}
-		referent = append(referent, modelMap)
+	referentMap, err := DataSourceIBMCdToolchainToolPagerdutyToolModelReferentToMap(toolchainTool.Referent)
+	if err != nil {
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "(Data) ibm_cd_toolchain_tool_pagerduty", "read", "referent-to-map").GetDiag()
 	}
+	referent = append(referent, referentMap)
 	if err = d.Set("referent", referent); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting referent %s", err))
+		return flex.DiscriminatedTerraformErrorf(err, fmt.Sprintf("Error setting referent: %s", err), "(Data) ibm_cd_toolchain_tool_pagerduty", "read", "set-referent").GetDiag()
 	}
 
-	if err = d.Set("name", toolchainTool.Name); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting name: %s", err))
+	if !core.IsNil(toolchainTool.Name) {
+		if err = d.Set("name", toolchainTool.Name); err != nil {
+			return flex.DiscriminatedTerraformErrorf(err, fmt.Sprintf("Error setting name: %s", err), "(Data) ibm_cd_toolchain_tool_pagerduty", "read", "set-name").GetDiag()
+		}
 	}
 
 	if err = d.Set("updated_at", flex.DateTimeToString(toolchainTool.UpdatedAt)); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting updated_at: %s", err))
+		return flex.DiscriminatedTerraformErrorf(err, fmt.Sprintf("Error setting updated_at: %s", err), "(Data) ibm_cd_toolchain_tool_pagerduty", "read", "set-updated_at").GetDiag()
 	}
 
 	parameters := []map[string]interface{}{}
-	if toolchainTool.Parameters != nil {
-		modelMap := GetParametersFromRead(toolchainTool.Parameters, DataSourceIBMCdToolchainToolPagerduty(), nil)
-		parameters = append(parameters, modelMap)
-	}
+	parametersMap := GetParametersFromRead(toolchainTool.Parameters, DataSourceIBMCdToolchainToolPagerduty(), nil)
+	parameters = append(parameters, parametersMap)
 	if err = d.Set("parameters", parameters); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting parameters %s", err))
+		return flex.DiscriminatedTerraformErrorf(err, fmt.Sprintf("Error setting parameters: %s", err), "(Data) ibm_cd_toolchain_tool_pagerduty", "read", "set-parameters").GetDiag()
 	}
 
 	if err = d.Set("state", toolchainTool.State); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting state: %s", err))
+		return flex.DiscriminatedTerraformErrorf(err, fmt.Sprintf("Error setting state: %s", err), "(Data) ibm_cd_toolchain_tool_pagerduty", "read", "set-state").GetDiag()
 	}
 
 	return nil
 }
 
-func dataSourceIBMCdToolchainToolPagerdutyToolModelReferentToMap(model *cdtoolchainv2.ToolModelReferent) (map[string]interface{}, error) {
+func DataSourceIBMCdToolchainToolPagerdutyToolModelReferentToMap(model *cdtoolchainv2.ToolModelReferent) (map[string]interface{}, error) {
 	modelMap := make(map[string]interface{})
 	if model.UIHref != nil {
-		modelMap["ui_href"] = model.UIHref
+		modelMap["ui_href"] = *model.UIHref
 	}
 	if model.APIHref != nil {
-		modelMap["api_href"] = model.APIHref
+		modelMap["api_href"] = *model.APIHref
 	}
 	return modelMap, nil
 }

--- a/ibm/service/cdtoolchain/data_source_ibm_cd_toolchain_tool_pipeline.go
+++ b/ibm/service/cdtoolchain/data_source_ibm_cd_toolchain_tool_pipeline.go
@@ -1,5 +1,9 @@
-// Copyright IBM Corp. 2023 All Rights Reserved.
+// Copyright IBM Corp. 2024 All Rights Reserved.
 // Licensed under the Mozilla Public License v2.0
+
+/*
+ * IBM OpenAPI Terraform Generator Version: 3.96.0-d6dec9d7-20241008-212902
+ */
 
 package cdtoolchain
 
@@ -14,6 +18,7 @@ import (
 	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/conns"
 	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/flex"
 	"github.com/IBM/continuous-delivery-go-sdk/cdtoolchainv2"
+	"github.com/IBM/go-sdk-core/v5/core"
 )
 
 func DataSourceIBMCdToolchainToolPipeline() *schema.Resource {
@@ -106,7 +111,9 @@ func DataSourceIBMCdToolchainToolPipeline() *schema.Resource {
 func dataSourceIBMCdToolchainToolPipelineRead(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	cdToolchainClient, err := meta.(conns.ClientSession).CdToolchainV2()
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.DiscriminatedTerraformErrorf(err, err.Error(), "(Data) ibm_cd_toolchain_tool_pipeline", "read", "initialize-client")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	getToolByIDOptions := &cdtoolchainv2.GetToolByIDOptions{}
@@ -114,77 +121,76 @@ func dataSourceIBMCdToolchainToolPipelineRead(context context.Context, d *schema
 	getToolByIDOptions.SetToolchainID(d.Get("toolchain_id").(string))
 	getToolByIDOptions.SetToolID(d.Get("tool_id").(string))
 
-	toolchainTool, response, err := cdToolchainClient.GetToolByIDWithContext(context, getToolByIDOptions)
+	toolchainTool, _, err := cdToolchainClient.GetToolByIDWithContext(context, getToolByIDOptions)
 	if err != nil {
-		log.Printf("[DEBUG] GetToolByIDWithContext failed %s\n%s", err, response)
-		return diag.FromErr(fmt.Errorf("GetToolByIDWithContext failed %s\n%s", err, response))
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("GetToolByIDWithContext failed: %s", err.Error()), "(Data) ibm_cd_toolchain_tool_pipeline", "read")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	if *toolchainTool.ToolTypeID != "pipeline" {
-		return diag.FromErr(fmt.Errorf("Retrieved tool is not the correct type: %s", *toolchainTool.ToolTypeID))
+		return flex.TerraformErrorf(err, fmt.Sprintf("Retrieved tool is not the correct type: %s", err), "(Data) ibm_cd_toolchain_tool", "read").GetDiag()
 	}
 
 	d.SetId(fmt.Sprintf("%s/%s", *getToolByIDOptions.ToolchainID, *getToolByIDOptions.ToolID))
 
 	if err = d.Set("resource_group_id", toolchainTool.ResourceGroupID); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting resource_group_id: %s", err))
+		return flex.DiscriminatedTerraformErrorf(err, fmt.Sprintf("Error setting resource_group_id: %s", err), "(Data) ibm_cd_toolchain_tool_pipeline", "read", "set-resource_group_id").GetDiag()
 	}
 
 	if err = d.Set("crn", toolchainTool.CRN); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting crn: %s", err))
+		return flex.DiscriminatedTerraformErrorf(err, fmt.Sprintf("Error setting crn: %s", err), "(Data) ibm_cd_toolchain_tool_pipeline", "read", "set-crn").GetDiag()
 	}
 
 	if err = d.Set("toolchain_crn", toolchainTool.ToolchainCRN); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting toolchain_crn: %s", err))
+		return flex.DiscriminatedTerraformErrorf(err, fmt.Sprintf("Error setting toolchain_crn: %s", err), "(Data) ibm_cd_toolchain_tool_pipeline", "read", "set-toolchain_crn").GetDiag()
 	}
 
 	if err = d.Set("href", toolchainTool.Href); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting href: %s", err))
+		return flex.DiscriminatedTerraformErrorf(err, fmt.Sprintf("Error setting href: %s", err), "(Data) ibm_cd_toolchain_tool_pipeline", "read", "set-href").GetDiag()
 	}
 
 	referent := []map[string]interface{}{}
-	if toolchainTool.Referent != nil {
-		modelMap, err := dataSourceIBMCdToolchainToolPipelineToolModelReferentToMap(toolchainTool.Referent)
-		if err != nil {
-			return diag.FromErr(err)
-		}
-		referent = append(referent, modelMap)
+	referentMap, err := DataSourceIBMCdToolchainToolPipelineToolModelReferentToMap(toolchainTool.Referent)
+	if err != nil {
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "(Data) ibm_cd_toolchain_tool_pipeline", "read", "referent-to-map").GetDiag()
 	}
+	referent = append(referent, referentMap)
 	if err = d.Set("referent", referent); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting referent %s", err))
+		return flex.DiscriminatedTerraformErrorf(err, fmt.Sprintf("Error setting referent: %s", err), "(Data) ibm_cd_toolchain_tool_pipeline", "read", "set-referent").GetDiag()
 	}
 
-	if err = d.Set("name", toolchainTool.Name); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting name: %s", err))
+	if !core.IsNil(toolchainTool.Name) {
+		if err = d.Set("name", toolchainTool.Name); err != nil {
+			return flex.DiscriminatedTerraformErrorf(err, fmt.Sprintf("Error setting name: %s", err), "(Data) ibm_cd_toolchain_tool_pipeline", "read", "set-name").GetDiag()
+		}
 	}
 
 	if err = d.Set("updated_at", flex.DateTimeToString(toolchainTool.UpdatedAt)); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting updated_at: %s", err))
+		return flex.DiscriminatedTerraformErrorf(err, fmt.Sprintf("Error setting updated_at: %s", err), "(Data) ibm_cd_toolchain_tool_pipeline", "read", "set-updated_at").GetDiag()
 	}
 
 	parameters := []map[string]interface{}{}
-	if toolchainTool.Parameters != nil {
-		modelMap := GetParametersFromRead(toolchainTool.Parameters, DataSourceIBMCdToolchainToolPipeline(), nil)
-		parameters = append(parameters, modelMap)
-	}
+	parametersMap := GetParametersFromRead(toolchainTool.Parameters, DataSourceIBMCdToolchainToolPipeline(), nil)
+	parameters = append(parameters, parametersMap)
 	if err = d.Set("parameters", parameters); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting parameters %s", err))
+		return flex.DiscriminatedTerraformErrorf(err, fmt.Sprintf("Error setting parameters: %s", err), "(Data) ibm_cd_toolchain_tool_pipeline", "read", "set-parameters").GetDiag()
 	}
 
 	if err = d.Set("state", toolchainTool.State); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting state: %s", err))
+		return flex.DiscriminatedTerraformErrorf(err, fmt.Sprintf("Error setting state: %s", err), "(Data) ibm_cd_toolchain_tool_pipeline", "read", "set-state").GetDiag()
 	}
 
 	return nil
 }
 
-func dataSourceIBMCdToolchainToolPipelineToolModelReferentToMap(model *cdtoolchainv2.ToolModelReferent) (map[string]interface{}, error) {
+func DataSourceIBMCdToolchainToolPipelineToolModelReferentToMap(model *cdtoolchainv2.ToolModelReferent) (map[string]interface{}, error) {
 	modelMap := make(map[string]interface{})
 	if model.UIHref != nil {
-		modelMap["ui_href"] = model.UIHref
+		modelMap["ui_href"] = *model.UIHref
 	}
 	if model.APIHref != nil {
-		modelMap["api_href"] = model.APIHref
+		modelMap["api_href"] = *model.APIHref
 	}
 	return modelMap, nil
 }

--- a/ibm/service/cdtoolchain/data_source_ibm_cd_toolchain_tool_privateworker.go
+++ b/ibm/service/cdtoolchain/data_source_ibm_cd_toolchain_tool_privateworker.go
@@ -1,5 +1,9 @@
-// Copyright IBM Corp. 2023 All Rights Reserved.
+// Copyright IBM Corp. 2024 All Rights Reserved.
 // Licensed under the Mozilla Public License v2.0
+
+/*
+ * IBM OpenAPI Terraform Generator Version: 3.96.0-d6dec9d7-20241008-212902
+ */
 
 package cdtoolchain
 
@@ -14,6 +18,7 @@ import (
 	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/conns"
 	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/flex"
 	"github.com/IBM/continuous-delivery-go-sdk/cdtoolchainv2"
+	"github.com/IBM/go-sdk-core/v5/core"
 )
 
 func DataSourceIBMCdToolchainToolPrivateworker() *schema.Resource {
@@ -117,7 +122,9 @@ func DataSourceIBMCdToolchainToolPrivateworker() *schema.Resource {
 func dataSourceIBMCdToolchainToolPrivateworkerRead(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	cdToolchainClient, err := meta.(conns.ClientSession).CdToolchainV2()
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.DiscriminatedTerraformErrorf(err, err.Error(), "(Data) ibm_cd_toolchain_tool_privateworker", "read", "initialize-client")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	getToolByIDOptions := &cdtoolchainv2.GetToolByIDOptions{}
@@ -125,81 +132,80 @@ func dataSourceIBMCdToolchainToolPrivateworkerRead(context context.Context, d *s
 	getToolByIDOptions.SetToolchainID(d.Get("toolchain_id").(string))
 	getToolByIDOptions.SetToolID(d.Get("tool_id").(string))
 
-	toolchainTool, response, err := cdToolchainClient.GetToolByIDWithContext(context, getToolByIDOptions)
+	toolchainTool, _, err := cdToolchainClient.GetToolByIDWithContext(context, getToolByIDOptions)
 	if err != nil {
-		log.Printf("[DEBUG] GetToolByIDWithContext failed %s\n%s", err, response)
-		return diag.FromErr(fmt.Errorf("GetToolByIDWithContext failed %s\n%s", err, response))
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("GetToolByIDWithContext failed: %s", err.Error()), "(Data) ibm_cd_toolchain_tool_privateworker", "read")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	if *toolchainTool.ToolTypeID != "private_worker" {
-		return diag.FromErr(fmt.Errorf("Retrieved tool is not the correct type: %s", *toolchainTool.ToolTypeID))
+		return flex.TerraformErrorf(err, fmt.Sprintf("Retrieved tool is not the correct type: %s", err), "(Data) ibm_cd_toolchain_tool", "read").GetDiag()
 	}
 
 	d.SetId(fmt.Sprintf("%s/%s", *getToolByIDOptions.ToolchainID, *getToolByIDOptions.ToolID))
 
 	if err = d.Set("resource_group_id", toolchainTool.ResourceGroupID); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting resource_group_id: %s", err))
+		return flex.DiscriminatedTerraformErrorf(err, fmt.Sprintf("Error setting resource_group_id: %s", err), "(Data) ibm_cd_toolchain_tool_privateworker", "read", "set-resource_group_id").GetDiag()
 	}
 
 	if err = d.Set("crn", toolchainTool.CRN); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting crn: %s", err))
+		return flex.DiscriminatedTerraformErrorf(err, fmt.Sprintf("Error setting crn: %s", err), "(Data) ibm_cd_toolchain_tool_privateworker", "read", "set-crn").GetDiag()
 	}
 
 	if err = d.Set("toolchain_crn", toolchainTool.ToolchainCRN); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting toolchain_crn: %s", err))
+		return flex.DiscriminatedTerraformErrorf(err, fmt.Sprintf("Error setting toolchain_crn: %s", err), "(Data) ibm_cd_toolchain_tool_privateworker", "read", "set-toolchain_crn").GetDiag()
 	}
 
 	if err = d.Set("href", toolchainTool.Href); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting href: %s", err))
+		return flex.DiscriminatedTerraformErrorf(err, fmt.Sprintf("Error setting href: %s", err), "(Data) ibm_cd_toolchain_tool_privateworker", "read", "set-href").GetDiag()
 	}
 
 	referent := []map[string]interface{}{}
-	if toolchainTool.Referent != nil {
-		modelMap, err := dataSourceIBMCdToolchainToolPrivateworkerToolModelReferentToMap(toolchainTool.Referent)
-		if err != nil {
-			return diag.FromErr(err)
-		}
-		referent = append(referent, modelMap)
+	referentMap, err := DataSourceIBMCdToolchainToolPrivateworkerToolModelReferentToMap(toolchainTool.Referent)
+	if err != nil {
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "(Data) ibm_cd_toolchain_tool_privateworker", "read", "referent-to-map").GetDiag()
 	}
+	referent = append(referent, referentMap)
 	if err = d.Set("referent", referent); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting referent %s", err))
+		return flex.DiscriminatedTerraformErrorf(err, fmt.Sprintf("Error setting referent: %s", err), "(Data) ibm_cd_toolchain_tool_privateworker", "read", "set-referent").GetDiag()
 	}
 
-	if err = d.Set("name", toolchainTool.Name); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting name: %s", err))
+	if !core.IsNil(toolchainTool.Name) {
+		if err = d.Set("name", toolchainTool.Name); err != nil {
+			return flex.DiscriminatedTerraformErrorf(err, fmt.Sprintf("Error setting name: %s", err), "(Data) ibm_cd_toolchain_tool_privateworker", "read", "set-name").GetDiag()
+		}
 	}
 
 	if err = d.Set("updated_at", flex.DateTimeToString(toolchainTool.UpdatedAt)); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting updated_at: %s", err))
+		return flex.DiscriminatedTerraformErrorf(err, fmt.Sprintf("Error setting updated_at: %s", err), "(Data) ibm_cd_toolchain_tool_privateworker", "read", "set-updated_at").GetDiag()
 	}
 
 	parameters := []map[string]interface{}{}
-	if toolchainTool.Parameters != nil {
-		remapFields := map[string]string{
-			"worker_queue_credentials": "workerQueueCredentials",
-			"worker_queue_identifier":  "workerQueueIdentifier",
-		}
-		modelMap := GetParametersFromRead(toolchainTool.Parameters, DataSourceIBMCdToolchainToolPrivateworker(), remapFields)
-		parameters = append(parameters, modelMap)
+	remapFields := map[string]string{
+		"worker_queue_credentials": "workerQueueCredentials",
+		"worker_queue_identifier":  "workerQueueIdentifier",
 	}
+	parametersMap := GetParametersFromRead(toolchainTool.Parameters, DataSourceIBMCdToolchainToolPrivateworker(), remapFields)
+	parameters = append(parameters, parametersMap)
 	if err = d.Set("parameters", parameters); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting parameters %s", err))
+		return flex.DiscriminatedTerraformErrorf(err, fmt.Sprintf("Error setting parameters: %s", err), "(Data) ibm_cd_toolchain_tool_privateworker", "read", "set-parameters").GetDiag()
 	}
 
 	if err = d.Set("state", toolchainTool.State); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting state: %s", err))
+		return flex.DiscriminatedTerraformErrorf(err, fmt.Sprintf("Error setting state: %s", err), "(Data) ibm_cd_toolchain_tool_privateworker", "read", "set-state").GetDiag()
 	}
 
 	return nil
 }
 
-func dataSourceIBMCdToolchainToolPrivateworkerToolModelReferentToMap(model *cdtoolchainv2.ToolModelReferent) (map[string]interface{}, error) {
+func DataSourceIBMCdToolchainToolPrivateworkerToolModelReferentToMap(model *cdtoolchainv2.ToolModelReferent) (map[string]interface{}, error) {
 	modelMap := make(map[string]interface{})
 	if model.UIHref != nil {
-		modelMap["ui_href"] = model.UIHref
+		modelMap["ui_href"] = *model.UIHref
 	}
 	if model.APIHref != nil {
-		modelMap["api_href"] = model.APIHref
+		modelMap["api_href"] = *model.APIHref
 	}
 	return modelMap, nil
 }

--- a/ibm/service/cdtoolchain/data_source_ibm_cd_toolchain_tool_saucelabs.go
+++ b/ibm/service/cdtoolchain/data_source_ibm_cd_toolchain_tool_saucelabs.go
@@ -1,5 +1,9 @@
-// Copyright IBM Corp. 2023 All Rights Reserved.
+// Copyright IBM Corp. 2024 All Rights Reserved.
 // Licensed under the Mozilla Public License v2.0
+
+/*
+ * IBM OpenAPI Terraform Generator Version: 3.96.0-d6dec9d7-20241008-212902
+ */
 
 package cdtoolchain
 
@@ -14,6 +18,7 @@ import (
 	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/conns"
 	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/flex"
 	"github.com/IBM/continuous-delivery-go-sdk/cdtoolchainv2"
+	"github.com/IBM/go-sdk-core/v5/core"
 )
 
 func DataSourceIBMCdToolchainToolSaucelabs() *schema.Resource {
@@ -112,7 +117,9 @@ func DataSourceIBMCdToolchainToolSaucelabs() *schema.Resource {
 func dataSourceIBMCdToolchainToolSaucelabsRead(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	cdToolchainClient, err := meta.(conns.ClientSession).CdToolchainV2()
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.DiscriminatedTerraformErrorf(err, err.Error(), "(Data) ibm_cd_toolchain_tool_saucelabs", "read", "initialize-client")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	getToolByIDOptions := &cdtoolchainv2.GetToolByIDOptions{}
@@ -120,80 +127,79 @@ func dataSourceIBMCdToolchainToolSaucelabsRead(context context.Context, d *schem
 	getToolByIDOptions.SetToolchainID(d.Get("toolchain_id").(string))
 	getToolByIDOptions.SetToolID(d.Get("tool_id").(string))
 
-	toolchainTool, response, err := cdToolchainClient.GetToolByIDWithContext(context, getToolByIDOptions)
+	toolchainTool, _, err := cdToolchainClient.GetToolByIDWithContext(context, getToolByIDOptions)
 	if err != nil {
-		log.Printf("[DEBUG] GetToolByIDWithContext failed %s\n%s", err, response)
-		return diag.FromErr(fmt.Errorf("GetToolByIDWithContext failed %s\n%s", err, response))
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("GetToolByIDWithContext failed: %s", err.Error()), "(Data) ibm_cd_toolchain_tool_saucelabs", "read")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	if *toolchainTool.ToolTypeID != "saucelabs" {
-		return diag.FromErr(fmt.Errorf("Retrieved tool is not the correct type: %s", *toolchainTool.ToolTypeID))
+		return flex.TerraformErrorf(err, fmt.Sprintf("Retrieved tool is not the correct type: %s", err), "(Data) ibm_cd_toolchain_tool", "read").GetDiag()
 	}
 
 	d.SetId(fmt.Sprintf("%s/%s", *getToolByIDOptions.ToolchainID, *getToolByIDOptions.ToolID))
 
 	if err = d.Set("resource_group_id", toolchainTool.ResourceGroupID); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting resource_group_id: %s", err))
+		return flex.DiscriminatedTerraformErrorf(err, fmt.Sprintf("Error setting resource_group_id: %s", err), "(Data) ibm_cd_toolchain_tool_saucelabs", "read", "set-resource_group_id").GetDiag()
 	}
 
 	if err = d.Set("crn", toolchainTool.CRN); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting crn: %s", err))
+		return flex.DiscriminatedTerraformErrorf(err, fmt.Sprintf("Error setting crn: %s", err), "(Data) ibm_cd_toolchain_tool_saucelabs", "read", "set-crn").GetDiag()
 	}
 
 	if err = d.Set("toolchain_crn", toolchainTool.ToolchainCRN); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting toolchain_crn: %s", err))
+		return flex.DiscriminatedTerraformErrorf(err, fmt.Sprintf("Error setting toolchain_crn: %s", err), "(Data) ibm_cd_toolchain_tool_saucelabs", "read", "set-toolchain_crn").GetDiag()
 	}
 
 	if err = d.Set("href", toolchainTool.Href); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting href: %s", err))
+		return flex.DiscriminatedTerraformErrorf(err, fmt.Sprintf("Error setting href: %s", err), "(Data) ibm_cd_toolchain_tool_saucelabs", "read", "set-href").GetDiag()
 	}
 
 	referent := []map[string]interface{}{}
-	if toolchainTool.Referent != nil {
-		modelMap, err := dataSourceIBMCdToolchainToolSaucelabsToolModelReferentToMap(toolchainTool.Referent)
-		if err != nil {
-			return diag.FromErr(err)
-		}
-		referent = append(referent, modelMap)
+	referentMap, err := DataSourceIBMCdToolchainToolSaucelabsToolModelReferentToMap(toolchainTool.Referent)
+	if err != nil {
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "(Data) ibm_cd_toolchain_tool_saucelabs", "read", "referent-to-map").GetDiag()
 	}
+	referent = append(referent, referentMap)
 	if err = d.Set("referent", referent); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting referent %s", err))
+		return flex.DiscriminatedTerraformErrorf(err, fmt.Sprintf("Error setting referent: %s", err), "(Data) ibm_cd_toolchain_tool_saucelabs", "read", "set-referent").GetDiag()
 	}
 
-	if err = d.Set("name", toolchainTool.Name); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting name: %s", err))
+	if !core.IsNil(toolchainTool.Name) {
+		if err = d.Set("name", toolchainTool.Name); err != nil {
+			return flex.DiscriminatedTerraformErrorf(err, fmt.Sprintf("Error setting name: %s", err), "(Data) ibm_cd_toolchain_tool_saucelabs", "read", "set-name").GetDiag()
+		}
 	}
 
 	if err = d.Set("updated_at", flex.DateTimeToString(toolchainTool.UpdatedAt)); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting updated_at: %s", err))
+		return flex.DiscriminatedTerraformErrorf(err, fmt.Sprintf("Error setting updated_at: %s", err), "(Data) ibm_cd_toolchain_tool_saucelabs", "read", "set-updated_at").GetDiag()
 	}
 
 	parameters := []map[string]interface{}{}
-	if toolchainTool.Parameters != nil {
-		remapFields := map[string]string{
-			"access_key": "key",
-		}
-		modelMap := GetParametersFromRead(toolchainTool.Parameters, DataSourceIBMCdToolchainToolSaucelabs(), remapFields)
-		parameters = append(parameters, modelMap)
+	remapFields := map[string]string{
+		"access_key": "key",
 	}
+	parametersMap := GetParametersFromRead(toolchainTool.Parameters, DataSourceIBMCdToolchainToolSaucelabs(), remapFields)
+	parameters = append(parameters, parametersMap)
 	if err = d.Set("parameters", parameters); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting parameters %s", err))
+		return flex.DiscriminatedTerraformErrorf(err, fmt.Sprintf("Error setting parameters: %s", err), "(Data) ibm_cd_toolchain_tool_saucelabs", "read", "set-parameters").GetDiag()
 	}
 
 	if err = d.Set("state", toolchainTool.State); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting state: %s", err))
+		return flex.DiscriminatedTerraformErrorf(err, fmt.Sprintf("Error setting state: %s", err), "(Data) ibm_cd_toolchain_tool_saucelabs", "read", "set-state").GetDiag()
 	}
 
 	return nil
 }
 
-func dataSourceIBMCdToolchainToolSaucelabsToolModelReferentToMap(model *cdtoolchainv2.ToolModelReferent) (map[string]interface{}, error) {
+func DataSourceIBMCdToolchainToolSaucelabsToolModelReferentToMap(model *cdtoolchainv2.ToolModelReferent) (map[string]interface{}, error) {
 	modelMap := make(map[string]interface{})
 	if model.UIHref != nil {
-		modelMap["ui_href"] = model.UIHref
+		modelMap["ui_href"] = *model.UIHref
 	}
 	if model.APIHref != nil {
-		modelMap["api_href"] = model.APIHref
+		modelMap["api_href"] = *model.APIHref
 	}
 	return modelMap, nil
 }

--- a/ibm/service/cdtoolchain/data_source_ibm_cd_toolchain_tool_secretsmanager.go
+++ b/ibm/service/cdtoolchain/data_source_ibm_cd_toolchain_tool_secretsmanager.go
@@ -1,5 +1,9 @@
-// Copyright IBM Corp. 2023 All Rights Reserved.
+// Copyright IBM Corp. 2024 All Rights Reserved.
 // Licensed under the Mozilla Public License v2.0
+
+/*
+ * IBM OpenAPI Terraform Generator Version: 3.96.0-d6dec9d7-20241008-212902
+ */
 
 package cdtoolchain
 
@@ -14,6 +18,7 @@ import (
 	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/conns"
 	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/flex"
 	"github.com/IBM/continuous-delivery-go-sdk/cdtoolchainv2"
+	"github.com/IBM/go-sdk-core/v5/core"
 )
 
 func DataSourceIBMCdToolchainToolSecretsmanager() *schema.Resource {
@@ -131,7 +136,9 @@ func DataSourceIBMCdToolchainToolSecretsmanager() *schema.Resource {
 func dataSourceIBMCdToolchainToolSecretsmanagerRead(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	cdToolchainClient, err := meta.(conns.ClientSession).CdToolchainV2()
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.DiscriminatedTerraformErrorf(err, err.Error(), "(Data) ibm_cd_toolchain_tool_secretsmanager", "read", "initialize-client")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	getToolByIDOptions := &cdtoolchainv2.GetToolByIDOptions{}
@@ -139,84 +146,83 @@ func dataSourceIBMCdToolchainToolSecretsmanagerRead(context context.Context, d *
 	getToolByIDOptions.SetToolchainID(d.Get("toolchain_id").(string))
 	getToolByIDOptions.SetToolID(d.Get("tool_id").(string))
 
-	toolchainTool, response, err := cdToolchainClient.GetToolByIDWithContext(context, getToolByIDOptions)
+	toolchainTool, _, err := cdToolchainClient.GetToolByIDWithContext(context, getToolByIDOptions)
 	if err != nil {
-		log.Printf("[DEBUG] GetToolByIDWithContext failed %s\n%s", err, response)
-		return diag.FromErr(fmt.Errorf("GetToolByIDWithContext failed %s\n%s", err, response))
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("GetToolByIDWithContext failed: %s", err.Error()), "(Data) ibm_cd_toolchain_tool_secretsmanager", "read")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	if *toolchainTool.ToolTypeID != "secretsmanager" {
-		return diag.FromErr(fmt.Errorf("Retrieved tool is not the correct type: %s", *toolchainTool.ToolTypeID))
+		return flex.TerraformErrorf(err, fmt.Sprintf("Retrieved tool is not the correct type: %s", err), "(Data) ibm_cd_toolchain_tool", "read").GetDiag()
 	}
 
 	d.SetId(fmt.Sprintf("%s/%s", *getToolByIDOptions.ToolchainID, *getToolByIDOptions.ToolID))
 
 	if err = d.Set("resource_group_id", toolchainTool.ResourceGroupID); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting resource_group_id: %s", err))
+		return flex.DiscriminatedTerraformErrorf(err, fmt.Sprintf("Error setting resource_group_id: %s", err), "(Data) ibm_cd_toolchain_tool_secretsmanager", "read", "set-resource_group_id").GetDiag()
 	}
 
 	if err = d.Set("crn", toolchainTool.CRN); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting crn: %s", err))
+		return flex.DiscriminatedTerraformErrorf(err, fmt.Sprintf("Error setting crn: %s", err), "(Data) ibm_cd_toolchain_tool_secretsmanager", "read", "set-crn").GetDiag()
 	}
 
 	if err = d.Set("toolchain_crn", toolchainTool.ToolchainCRN); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting toolchain_crn: %s", err))
+		return flex.DiscriminatedTerraformErrorf(err, fmt.Sprintf("Error setting toolchain_crn: %s", err), "(Data) ibm_cd_toolchain_tool_secretsmanager", "read", "set-toolchain_crn").GetDiag()
 	}
 
 	if err = d.Set("href", toolchainTool.Href); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting href: %s", err))
+		return flex.DiscriminatedTerraformErrorf(err, fmt.Sprintf("Error setting href: %s", err), "(Data) ibm_cd_toolchain_tool_secretsmanager", "read", "set-href").GetDiag()
 	}
 
 	referent := []map[string]interface{}{}
-	if toolchainTool.Referent != nil {
-		modelMap, err := dataSourceIBMCdToolchainToolSecretsmanagerToolModelReferentToMap(toolchainTool.Referent)
-		if err != nil {
-			return diag.FromErr(err)
-		}
-		referent = append(referent, modelMap)
+	referentMap, err := DataSourceIBMCdToolchainToolSecretsmanagerToolModelReferentToMap(toolchainTool.Referent)
+	if err != nil {
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "(Data) ibm_cd_toolchain_tool_secretsmanager", "read", "referent-to-map").GetDiag()
 	}
+	referent = append(referent, referentMap)
 	if err = d.Set("referent", referent); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting referent %s", err))
+		return flex.DiscriminatedTerraformErrorf(err, fmt.Sprintf("Error setting referent: %s", err), "(Data) ibm_cd_toolchain_tool_secretsmanager", "read", "set-referent").GetDiag()
 	}
 
-	if err = d.Set("name", toolchainTool.Name); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting name: %s", err))
+	if !core.IsNil(toolchainTool.Name) {
+		if err = d.Set("name", toolchainTool.Name); err != nil {
+			return flex.DiscriminatedTerraformErrorf(err, fmt.Sprintf("Error setting name: %s", err), "(Data) ibm_cd_toolchain_tool_secretsmanager", "read", "set-name").GetDiag()
+		}
 	}
 
 	if err = d.Set("updated_at", flex.DateTimeToString(toolchainTool.UpdatedAt)); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting updated_at: %s", err))
+		return flex.DiscriminatedTerraformErrorf(err, fmt.Sprintf("Error setting updated_at: %s", err), "(Data) ibm_cd_toolchain_tool_secretsmanager", "read", "set-updated_at").GetDiag()
 	}
 
 	parameters := []map[string]interface{}{}
-	if toolchainTool.Parameters != nil {
-		remapFields := map[string]string{
-			"instance_id_type":    "instance-id-type",
-			"location":            "region",
-			"resource_group_name": "resource-group",
-			"instance_name":       "instance-name",
-			"instance_crn":        "instance-crn",
-		}
-		modelMap := GetParametersFromRead(toolchainTool.Parameters, DataSourceIBMCdToolchainToolSecretsmanager(), remapFields)
-		parameters = append(parameters, modelMap)
+	remapFields := map[string]string{
+		"instance_id_type":    "instance-id-type",
+		"location":            "region",
+		"resource_group_name": "resource-group",
+		"instance_name":       "instance-name",
+		"instance_crn":        "instance-crn",
 	}
+	parametersMap := GetParametersFromRead(toolchainTool.Parameters, DataSourceIBMCdToolchainToolSecretsmanager(), remapFields)
+	parameters = append(parameters, parametersMap)
 	if err = d.Set("parameters", parameters); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting parameters %s", err))
+		return flex.DiscriminatedTerraformErrorf(err, fmt.Sprintf("Error setting parameters: %s", err), "(Data) ibm_cd_toolchain_tool_secretsmanager", "read", "set-parameters").GetDiag()
 	}
 
 	if err = d.Set("state", toolchainTool.State); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting state: %s", err))
+		return flex.DiscriminatedTerraformErrorf(err, fmt.Sprintf("Error setting state: %s", err), "(Data) ibm_cd_toolchain_tool_secretsmanager", "read", "set-state").GetDiag()
 	}
 
 	return nil
 }
 
-func dataSourceIBMCdToolchainToolSecretsmanagerToolModelReferentToMap(model *cdtoolchainv2.ToolModelReferent) (map[string]interface{}, error) {
+func DataSourceIBMCdToolchainToolSecretsmanagerToolModelReferentToMap(model *cdtoolchainv2.ToolModelReferent) (map[string]interface{}, error) {
 	modelMap := make(map[string]interface{})
 	if model.UIHref != nil {
-		modelMap["ui_href"] = model.UIHref
+		modelMap["ui_href"] = *model.UIHref
 	}
 	if model.APIHref != nil {
-		modelMap["api_href"] = model.APIHref
+		modelMap["api_href"] = *model.APIHref
 	}
 	return modelMap, nil
 }

--- a/ibm/service/cdtoolchain/data_source_ibm_cd_toolchain_tool_securitycompliance.go
+++ b/ibm/service/cdtoolchain/data_source_ibm_cd_toolchain_tool_securitycompliance.go
@@ -1,6 +1,10 @@
 // Copyright IBM Corp. 2024 All Rights Reserved.
 // Licensed under the Mozilla Public License v2.0
 
+/*
+ * IBM OpenAPI Terraform Generator Version: 3.96.0-d6dec9d7-20241008-212902
+ */
+
 package cdtoolchain
 
 import (
@@ -14,6 +18,7 @@ import (
 	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/conns"
 	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/flex"
 	"github.com/IBM/continuous-delivery-go-sdk/cdtoolchainv2"
+	"github.com/IBM/go-sdk-core/v5/core"
 )
 
 func DataSourceIBMCdToolchainToolSecuritycompliance() *schema.Resource {
@@ -147,7 +152,9 @@ func DataSourceIBMCdToolchainToolSecuritycompliance() *schema.Resource {
 func dataSourceIBMCdToolchainToolSecuritycomplianceRead(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	cdToolchainClient, err := meta.(conns.ClientSession).CdToolchainV2()
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.DiscriminatedTerraformErrorf(err, err.Error(), "(Data) ibm_cd_toolchain_tool_securitycompliance", "read", "initialize-client")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	getToolByIDOptions := &cdtoolchainv2.GetToolByIDOptions{}
@@ -155,80 +162,79 @@ func dataSourceIBMCdToolchainToolSecuritycomplianceRead(context context.Context,
 	getToolByIDOptions.SetToolchainID(d.Get("toolchain_id").(string))
 	getToolByIDOptions.SetToolID(d.Get("tool_id").(string))
 
-	toolchainTool, response, err := cdToolchainClient.GetToolByIDWithContext(context, getToolByIDOptions)
+	toolchainTool, _, err := cdToolchainClient.GetToolByIDWithContext(context, getToolByIDOptions)
 	if err != nil {
-		log.Printf("[DEBUG] GetToolByIDWithContext failed %s\n%s", err, response)
-		return diag.FromErr(fmt.Errorf("GetToolByIDWithContext failed %s\n%s", err, response))
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("GetToolByIDWithContext failed: %s", err.Error()), "(Data) ibm_cd_toolchain_tool_securitycompliance", "read")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	if *toolchainTool.ToolTypeID != "security_compliance" {
-		return diag.FromErr(fmt.Errorf("Retrieved tool is not the correct type: %s", *toolchainTool.ToolTypeID))
+		return flex.TerraformErrorf(err, fmt.Sprintf("Retrieved tool is not the correct type: %s", err), "(Data) ibm_cd_toolchain_tool", "read").GetDiag()
 	}
 
 	d.SetId(fmt.Sprintf("%s/%s", *getToolByIDOptions.ToolchainID, *getToolByIDOptions.ToolID))
 
 	if err = d.Set("resource_group_id", toolchainTool.ResourceGroupID); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting resource_group_id: %s", err))
+		return flex.DiscriminatedTerraformErrorf(err, fmt.Sprintf("Error setting resource_group_id: %s", err), "(Data) ibm_cd_toolchain_tool_securitycompliance", "read", "set-resource_group_id").GetDiag()
 	}
 
 	if err = d.Set("crn", toolchainTool.CRN); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting crn: %s", err))
+		return flex.DiscriminatedTerraformErrorf(err, fmt.Sprintf("Error setting crn: %s", err), "(Data) ibm_cd_toolchain_tool_securitycompliance", "read", "set-crn").GetDiag()
 	}
 
 	if err = d.Set("toolchain_crn", toolchainTool.ToolchainCRN); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting toolchain_crn: %s", err))
+		return flex.DiscriminatedTerraformErrorf(err, fmt.Sprintf("Error setting toolchain_crn: %s", err), "(Data) ibm_cd_toolchain_tool_securitycompliance", "read", "set-toolchain_crn").GetDiag()
 	}
 
 	if err = d.Set("href", toolchainTool.Href); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting href: %s", err))
+		return flex.DiscriminatedTerraformErrorf(err, fmt.Sprintf("Error setting href: %s", err), "(Data) ibm_cd_toolchain_tool_securitycompliance", "read", "set-href").GetDiag()
 	}
 
 	referent := []map[string]interface{}{}
-	if toolchainTool.Referent != nil {
-		modelMap, err := dataSourceIBMCdToolchainToolSecuritycomplianceToolModelReferentToMap(toolchainTool.Referent)
-		if err != nil {
-			return diag.FromErr(err)
-		}
-		referent = append(referent, modelMap)
+	referentMap, err := DataSourceIBMCdToolchainToolSecuritycomplianceToolModelReferentToMap(toolchainTool.Referent)
+	if err != nil {
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "(Data) ibm_cd_toolchain_tool_securitycompliance", "read", "referent-to-map").GetDiag()
 	}
+	referent = append(referent, referentMap)
 	if err = d.Set("referent", referent); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting referent %s", err))
+		return flex.DiscriminatedTerraformErrorf(err, fmt.Sprintf("Error setting referent: %s", err), "(Data) ibm_cd_toolchain_tool_securitycompliance", "read", "set-referent").GetDiag()
 	}
 
-	if err = d.Set("name", toolchainTool.Name); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting name: %s", err))
+	if !core.IsNil(toolchainTool.Name) {
+		if err = d.Set("name", toolchainTool.Name); err != nil {
+			return flex.DiscriminatedTerraformErrorf(err, fmt.Sprintf("Error setting name: %s", err), "(Data) ibm_cd_toolchain_tool_securitycompliance", "read", "set-name").GetDiag()
+		}
 	}
 
 	if err = d.Set("updated_at", flex.DateTimeToString(toolchainTool.UpdatedAt)); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting updated_at: %s", err))
+		return flex.DiscriminatedTerraformErrorf(err, fmt.Sprintf("Error setting updated_at: %s", err), "(Data) ibm_cd_toolchain_tool_securitycompliance", "read", "set-updated_at").GetDiag()
 	}
 
 	parameters := []map[string]interface{}{}
-	if toolchainTool.Parameters != nil {
-		remapFields := map[string]string{
-			"evidence_repo_url": "evidence_repo_name",
-		}
-		modelMap := GetParametersFromRead(toolchainTool.Parameters, DataSourceIBMCdToolchainToolSecuritycompliance(), remapFields)
-		parameters = append(parameters, modelMap)
+	remapFields := map[string]string{
+		"evidence_repo_url": "evidence_repo_name",
 	}
+	parametersMap := GetParametersFromRead(toolchainTool.Parameters, DataSourceIBMCdToolchainToolSecuritycompliance(), remapFields)
+	parameters = append(parameters, parametersMap)
 	if err = d.Set("parameters", parameters); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting parameters %s", err))
+		return flex.DiscriminatedTerraformErrorf(err, fmt.Sprintf("Error setting parameters: %s", err), "(Data) ibm_cd_toolchain_tool_securitycompliance", "read", "set-parameters").GetDiag()
 	}
 
 	if err = d.Set("state", toolchainTool.State); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting state: %s", err))
+		return flex.DiscriminatedTerraformErrorf(err, fmt.Sprintf("Error setting state: %s", err), "(Data) ibm_cd_toolchain_tool_securitycompliance", "read", "set-state").GetDiag()
 	}
 
 	return nil
 }
 
-func dataSourceIBMCdToolchainToolSecuritycomplianceToolModelReferentToMap(model *cdtoolchainv2.ToolModelReferent) (map[string]interface{}, error) {
+func DataSourceIBMCdToolchainToolSecuritycomplianceToolModelReferentToMap(model *cdtoolchainv2.ToolModelReferent) (map[string]interface{}, error) {
 	modelMap := make(map[string]interface{})
 	if model.UIHref != nil {
-		modelMap["ui_href"] = model.UIHref
+		modelMap["ui_href"] = *model.UIHref
 	}
 	if model.APIHref != nil {
-		modelMap["api_href"] = model.APIHref
+		modelMap["api_href"] = *model.APIHref
 	}
 	return modelMap, nil
 }

--- a/ibm/service/cdtoolchain/data_source_ibm_cd_toolchain_tool_slack.go
+++ b/ibm/service/cdtoolchain/data_source_ibm_cd_toolchain_tool_slack.go
@@ -1,5 +1,9 @@
-// Copyright IBM Corp. 2023 All Rights Reserved.
+// Copyright IBM Corp. 2024 All Rights Reserved.
 // Licensed under the Mozilla Public License v2.0
+
+/*
+ * IBM OpenAPI Terraform Generator Version: 3.96.0-d6dec9d7-20241008-212902
+ */
 
 package cdtoolchain
 
@@ -14,6 +18,7 @@ import (
 	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/conns"
 	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/flex"
 	"github.com/IBM/continuous-delivery-go-sdk/cdtoolchainv2"
+	"github.com/IBM/go-sdk-core/v5/core"
 )
 
 func DataSourceIBMCdToolchainToolSlack() *schema.Resource {
@@ -142,7 +147,9 @@ func DataSourceIBMCdToolchainToolSlack() *schema.Resource {
 func dataSourceIBMCdToolchainToolSlackRead(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	cdToolchainClient, err := meta.(conns.ClientSession).CdToolchainV2()
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.DiscriminatedTerraformErrorf(err, err.Error(), "(Data) ibm_cd_toolchain_tool_slack", "read", "initialize-client")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	getToolByIDOptions := &cdtoolchainv2.GetToolByIDOptions{}
@@ -150,81 +157,80 @@ func dataSourceIBMCdToolchainToolSlackRead(context context.Context, d *schema.Re
 	getToolByIDOptions.SetToolchainID(d.Get("toolchain_id").(string))
 	getToolByIDOptions.SetToolID(d.Get("tool_id").(string))
 
-	toolchainTool, response, err := cdToolchainClient.GetToolByIDWithContext(context, getToolByIDOptions)
+	toolchainTool, _, err := cdToolchainClient.GetToolByIDWithContext(context, getToolByIDOptions)
 	if err != nil {
-		log.Printf("[DEBUG] GetToolByIDWithContext failed %s\n%s", err, response)
-		return diag.FromErr(fmt.Errorf("GetToolByIDWithContext failed %s\n%s", err, response))
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("GetToolByIDWithContext failed: %s", err.Error()), "(Data) ibm_cd_toolchain_tool_slack", "read")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	if *toolchainTool.ToolTypeID != "slack" {
-		return diag.FromErr(fmt.Errorf("Retrieved tool is not the correct type: %s", *toolchainTool.ToolTypeID))
+		return flex.TerraformErrorf(err, fmt.Sprintf("Retrieved tool is not the correct type: %s", err), "(Data) ibm_cd_toolchain_tool", "read").GetDiag()
 	}
 
 	d.SetId(fmt.Sprintf("%s/%s", *getToolByIDOptions.ToolchainID, *getToolByIDOptions.ToolID))
 
 	if err = d.Set("resource_group_id", toolchainTool.ResourceGroupID); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting resource_group_id: %s", err))
+		return flex.DiscriminatedTerraformErrorf(err, fmt.Sprintf("Error setting resource_group_id: %s", err), "(Data) ibm_cd_toolchain_tool_slack", "read", "set-resource_group_id").GetDiag()
 	}
 
 	if err = d.Set("crn", toolchainTool.CRN); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting crn: %s", err))
+		return flex.DiscriminatedTerraformErrorf(err, fmt.Sprintf("Error setting crn: %s", err), "(Data) ibm_cd_toolchain_tool_slack", "read", "set-crn").GetDiag()
 	}
 
 	if err = d.Set("toolchain_crn", toolchainTool.ToolchainCRN); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting toolchain_crn: %s", err))
+		return flex.DiscriminatedTerraformErrorf(err, fmt.Sprintf("Error setting toolchain_crn: %s", err), "(Data) ibm_cd_toolchain_tool_slack", "read", "set-toolchain_crn").GetDiag()
 	}
 
 	if err = d.Set("href", toolchainTool.Href); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting href: %s", err))
+		return flex.DiscriminatedTerraformErrorf(err, fmt.Sprintf("Error setting href: %s", err), "(Data) ibm_cd_toolchain_tool_slack", "read", "set-href").GetDiag()
 	}
 
 	referent := []map[string]interface{}{}
-	if toolchainTool.Referent != nil {
-		modelMap, err := dataSourceIBMCdToolchainToolSlackToolModelReferentToMap(toolchainTool.Referent)
-		if err != nil {
-			return diag.FromErr(err)
-		}
-		referent = append(referent, modelMap)
+	referentMap, err := DataSourceIBMCdToolchainToolSlackToolModelReferentToMap(toolchainTool.Referent)
+	if err != nil {
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "(Data) ibm_cd_toolchain_tool_slack", "read", "referent-to-map").GetDiag()
 	}
+	referent = append(referent, referentMap)
 	if err = d.Set("referent", referent); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting referent %s", err))
+		return flex.DiscriminatedTerraformErrorf(err, fmt.Sprintf("Error setting referent: %s", err), "(Data) ibm_cd_toolchain_tool_slack", "read", "set-referent").GetDiag()
 	}
 
-	if err = d.Set("name", toolchainTool.Name); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting name: %s", err))
+	if !core.IsNil(toolchainTool.Name) {
+		if err = d.Set("name", toolchainTool.Name); err != nil {
+			return flex.DiscriminatedTerraformErrorf(err, fmt.Sprintf("Error setting name: %s", err), "(Data) ibm_cd_toolchain_tool_slack", "read", "set-name").GetDiag()
+		}
 	}
 
 	if err = d.Set("updated_at", flex.DateTimeToString(toolchainTool.UpdatedAt)); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting updated_at: %s", err))
+		return flex.DiscriminatedTerraformErrorf(err, fmt.Sprintf("Error setting updated_at: %s", err), "(Data) ibm_cd_toolchain_tool_slack", "read", "set-updated_at").GetDiag()
 	}
 
 	parameters := []map[string]interface{}{}
-	if toolchainTool.Parameters != nil {
-		remapFields := map[string]string{
-			"webhook":   "api_token",
-			"team_name": "team_url",
-		}
-		modelMap := GetParametersFromRead(toolchainTool.Parameters, DataSourceIBMCdToolchainToolSlack(), remapFields)
-		parameters = append(parameters, modelMap)
+	remapFields := map[string]string{
+		"webhook":   "api_token",
+		"team_name": "team_url",
 	}
+	parametersMap := GetParametersFromRead(toolchainTool.Parameters, DataSourceIBMCdToolchainToolSlack(), remapFields)
+	parameters = append(parameters, parametersMap)
 	if err = d.Set("parameters", parameters); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting parameters %s", err))
+		return flex.DiscriminatedTerraformErrorf(err, fmt.Sprintf("Error setting parameters: %s", err), "(Data) ibm_cd_toolchain_tool_slack", "read", "set-parameters").GetDiag()
 	}
 
 	if err = d.Set("state", toolchainTool.State); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting state: %s", err))
+		return flex.DiscriminatedTerraformErrorf(err, fmt.Sprintf("Error setting state: %s", err), "(Data) ibm_cd_toolchain_tool_slack", "read", "set-state").GetDiag()
 	}
 
 	return nil
 }
 
-func dataSourceIBMCdToolchainToolSlackToolModelReferentToMap(model *cdtoolchainv2.ToolModelReferent) (map[string]interface{}, error) {
+func DataSourceIBMCdToolchainToolSlackToolModelReferentToMap(model *cdtoolchainv2.ToolModelReferent) (map[string]interface{}, error) {
 	modelMap := make(map[string]interface{})
 	if model.UIHref != nil {
-		modelMap["ui_href"] = model.UIHref
+		modelMap["ui_href"] = *model.UIHref
 	}
 	if model.APIHref != nil {
-		modelMap["api_href"] = model.APIHref
+		modelMap["api_href"] = *model.APIHref
 	}
 	return modelMap, nil
 }

--- a/ibm/service/cdtoolchain/data_source_ibm_cd_toolchain_tool_sonarqube.go
+++ b/ibm/service/cdtoolchain/data_source_ibm_cd_toolchain_tool_sonarqube.go
@@ -1,5 +1,9 @@
-// Copyright IBM Corp. 2023 All Rights Reserved.
+// Copyright IBM Corp. 2024 All Rights Reserved.
 // Licensed under the Mozilla Public License v2.0
+
+/*
+ * IBM OpenAPI Terraform Generator Version: 3.96.0-d6dec9d7-20241008-212902
+ */
 
 package cdtoolchain
 
@@ -14,6 +18,7 @@ import (
 	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/conns"
 	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/flex"
 	"github.com/IBM/continuous-delivery-go-sdk/cdtoolchainv2"
+	"github.com/IBM/go-sdk-core/v5/core"
 )
 
 func DataSourceIBMCdToolchainToolSonarqube() *schema.Resource {
@@ -127,7 +132,9 @@ func DataSourceIBMCdToolchainToolSonarqube() *schema.Resource {
 func dataSourceIBMCdToolchainToolSonarqubeRead(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	cdToolchainClient, err := meta.(conns.ClientSession).CdToolchainV2()
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.DiscriminatedTerraformErrorf(err, err.Error(), "(Data) ibm_cd_toolchain_tool_sonarqube", "read", "initialize-client")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	getToolByIDOptions := &cdtoolchainv2.GetToolByIDOptions{}
@@ -135,80 +142,79 @@ func dataSourceIBMCdToolchainToolSonarqubeRead(context context.Context, d *schem
 	getToolByIDOptions.SetToolchainID(d.Get("toolchain_id").(string))
 	getToolByIDOptions.SetToolID(d.Get("tool_id").(string))
 
-	toolchainTool, response, err := cdToolchainClient.GetToolByIDWithContext(context, getToolByIDOptions)
+	toolchainTool, _, err := cdToolchainClient.GetToolByIDWithContext(context, getToolByIDOptions)
 	if err != nil {
-		log.Printf("[DEBUG] GetToolByIDWithContext failed %s\n%s", err, response)
-		return diag.FromErr(fmt.Errorf("GetToolByIDWithContext failed %s\n%s", err, response))
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("GetToolByIDWithContext failed: %s", err.Error()), "(Data) ibm_cd_toolchain_tool_sonarqube", "read")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	if *toolchainTool.ToolTypeID != "sonarqube" {
-		return diag.FromErr(fmt.Errorf("Retrieved tool is not the correct type: %s", *toolchainTool.ToolTypeID))
+		return flex.TerraformErrorf(err, fmt.Sprintf("Retrieved tool is not the correct type: %s", err), "(Data) ibm_cd_toolchain_tool", "read").GetDiag()
 	}
 
 	d.SetId(fmt.Sprintf("%s/%s", *getToolByIDOptions.ToolchainID, *getToolByIDOptions.ToolID))
 
 	if err = d.Set("resource_group_id", toolchainTool.ResourceGroupID); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting resource_group_id: %s", err))
+		return flex.DiscriminatedTerraformErrorf(err, fmt.Sprintf("Error setting resource_group_id: %s", err), "(Data) ibm_cd_toolchain_tool_sonarqube", "read", "set-resource_group_id").GetDiag()
 	}
 
 	if err = d.Set("crn", toolchainTool.CRN); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting crn: %s", err))
+		return flex.DiscriminatedTerraformErrorf(err, fmt.Sprintf("Error setting crn: %s", err), "(Data) ibm_cd_toolchain_tool_sonarqube", "read", "set-crn").GetDiag()
 	}
 
 	if err = d.Set("toolchain_crn", toolchainTool.ToolchainCRN); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting toolchain_crn: %s", err))
+		return flex.DiscriminatedTerraformErrorf(err, fmt.Sprintf("Error setting toolchain_crn: %s", err), "(Data) ibm_cd_toolchain_tool_sonarqube", "read", "set-toolchain_crn").GetDiag()
 	}
 
 	if err = d.Set("href", toolchainTool.Href); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting href: %s", err))
+		return flex.DiscriminatedTerraformErrorf(err, fmt.Sprintf("Error setting href: %s", err), "(Data) ibm_cd_toolchain_tool_sonarqube", "read", "set-href").GetDiag()
 	}
 
 	referent := []map[string]interface{}{}
-	if toolchainTool.Referent != nil {
-		modelMap, err := dataSourceIBMCdToolchainToolSonarqubeToolModelReferentToMap(toolchainTool.Referent)
-		if err != nil {
-			return diag.FromErr(err)
-		}
-		referent = append(referent, modelMap)
+	referentMap, err := DataSourceIBMCdToolchainToolSonarqubeToolModelReferentToMap(toolchainTool.Referent)
+	if err != nil {
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "(Data) ibm_cd_toolchain_tool_sonarqube", "read", "referent-to-map").GetDiag()
 	}
+	referent = append(referent, referentMap)
 	if err = d.Set("referent", referent); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting referent %s", err))
+		return flex.DiscriminatedTerraformErrorf(err, fmt.Sprintf("Error setting referent: %s", err), "(Data) ibm_cd_toolchain_tool_sonarqube", "read", "set-referent").GetDiag()
 	}
 
-	if err = d.Set("name", toolchainTool.Name); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting name: %s", err))
+	if !core.IsNil(toolchainTool.Name) {
+		if err = d.Set("name", toolchainTool.Name); err != nil {
+			return flex.DiscriminatedTerraformErrorf(err, fmt.Sprintf("Error setting name: %s", err), "(Data) ibm_cd_toolchain_tool_sonarqube", "read", "set-name").GetDiag()
+		}
 	}
 
 	if err = d.Set("updated_at", flex.DateTimeToString(toolchainTool.UpdatedAt)); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting updated_at: %s", err))
+		return flex.DiscriminatedTerraformErrorf(err, fmt.Sprintf("Error setting updated_at: %s", err), "(Data) ibm_cd_toolchain_tool_sonarqube", "read", "set-updated_at").GetDiag()
 	}
 
 	parameters := []map[string]interface{}{}
-	if toolchainTool.Parameters != nil {
-		remapFields := map[string]string{
-			"server_url": "dashboard_url",
-		}
-		modelMap := GetParametersFromRead(toolchainTool.Parameters, DataSourceIBMCdToolchainToolSonarqube(), remapFields)
-		parameters = append(parameters, modelMap)
+	remapFields := map[string]string{
+		"server_url": "dashboard_url",
 	}
+	parametersMap := GetParametersFromRead(toolchainTool.Parameters, DataSourceIBMCdToolchainToolSonarqube(), remapFields)
+	parameters = append(parameters, parametersMap)
 	if err = d.Set("parameters", parameters); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting parameters %s", err))
+		return flex.DiscriminatedTerraformErrorf(err, fmt.Sprintf("Error setting parameters: %s", err), "(Data) ibm_cd_toolchain_tool_sonarqube", "read", "set-parameters").GetDiag()
 	}
 
 	if err = d.Set("state", toolchainTool.State); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting state: %s", err))
+		return flex.DiscriminatedTerraformErrorf(err, fmt.Sprintf("Error setting state: %s", err), "(Data) ibm_cd_toolchain_tool_sonarqube", "read", "set-state").GetDiag()
 	}
 
 	return nil
 }
 
-func dataSourceIBMCdToolchainToolSonarqubeToolModelReferentToMap(model *cdtoolchainv2.ToolModelReferent) (map[string]interface{}, error) {
+func DataSourceIBMCdToolchainToolSonarqubeToolModelReferentToMap(model *cdtoolchainv2.ToolModelReferent) (map[string]interface{}, error) {
 	modelMap := make(map[string]interface{})
 	if model.UIHref != nil {
-		modelMap["ui_href"] = model.UIHref
+		modelMap["ui_href"] = *model.UIHref
 	}
 	if model.APIHref != nil {
-		modelMap["api_href"] = model.APIHref
+		modelMap["api_href"] = *model.APIHref
 	}
 	return modelMap, nil
 }

--- a/ibm/service/cdtoolchain/data_source_ibm_cd_toolchains.go
+++ b/ibm/service/cdtoolchain/data_source_ibm_cd_toolchains.go
@@ -1,5 +1,9 @@
-// Copyright IBM Corp. 2023 All Rights Reserved.
+// Copyright IBM Corp. 2024 All Rights Reserved.
 // Licensed under the Mozilla Public License v2.0
+
+/*
+ * IBM OpenAPI Terraform Generator Version: 3.96.0-d6dec9d7-20241008-212902
+ */
 
 package cdtoolchain
 
@@ -13,6 +17,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 
 	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/conns"
+	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/flex"
 	"github.com/IBM/continuous-delivery-go-sdk/cdtoolchainv2"
 )
 
@@ -29,7 +34,7 @@ func DataSourceIBMCdToolchains() *schema.Resource {
 			"name": &schema.Schema{
 				Type:        schema.TypeString,
 				Optional:    true,
-				Description: "Name of toolchain to look up.",
+				Description: "Exact name of toolchain to look up. This parameter is case sensitive.",
 			},
 			"toolchains": &schema.Schema{
 				Type:        schema.TypeList,
@@ -107,7 +112,9 @@ func DataSourceIBMCdToolchains() *schema.Resource {
 func dataSourceIBMCdToolchainsRead(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	cdToolchainClient, err := meta.(conns.ClientSession).CdToolchainV2()
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.DiscriminatedTerraformErrorf(err, err.Error(), "(Data) ibm_cd_toolchains", "read", "initialize-client")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	listToolchainsOptions := &cdtoolchainv2.ListToolchainsOptions{}
@@ -120,28 +127,31 @@ func dataSourceIBMCdToolchainsRead(context context.Context, d *schema.ResourceDa
 	var pager *cdtoolchainv2.ToolchainsPager
 	pager, err = cdToolchainClient.NewToolchainsPager(listToolchainsOptions)
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.TerraformErrorf(err, err.Error(), "(Data) ibm_cd_toolchains", "read")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	allItems, err := pager.GetAll()
 	if err != nil {
-		log.Printf("[DEBUG] ToolchainsPager.GetAll() failed %s", err)
-		return diag.FromErr(fmt.Errorf("ToolchainsPager.GetAll() failed %s", err))
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("ToolchainsPager.GetAll() failed %s", err), "(Data) ibm_cd_toolchains", "read")
+		log.Printf("[DEBUG] %s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	d.SetId(dataSourceIBMCdToolchainsID(d))
 
 	mapSlice := []map[string]interface{}{}
 	for _, modelItem := range allItems {
-		modelMap, err := dataSourceIBMCdToolchainsToolchainModelToMap(&modelItem)
+		modelMap, err := DataSourceIBMCdToolchainsToolchainModelToMap(&modelItem) // #nosec G601
 		if err != nil {
-			return diag.FromErr(err)
+			return flex.DiscriminatedTerraformErrorf(err, err.Error(), "(Data) ibm_cd_toolchains", "read", "Toolchains-to-map").GetDiag()
 		}
 		mapSlice = append(mapSlice, modelMap)
 	}
 
 	if err = d.Set("toolchains", mapSlice); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting toolchains %s", err))
+		return flex.DiscriminatedTerraformErrorf(err, fmt.Sprintf("Error setting toolchains %s", err), "(Data) ibm_cd_toolchains", "read", "toolchains-set").GetDiag()
 	}
 
 	return nil
@@ -152,19 +162,19 @@ func dataSourceIBMCdToolchainsID(d *schema.ResourceData) string {
 	return time.Now().UTC().String()
 }
 
-func dataSourceIBMCdToolchainsToolchainModelToMap(model *cdtoolchainv2.ToolchainModel) (map[string]interface{}, error) {
+func DataSourceIBMCdToolchainsToolchainModelToMap(model *cdtoolchainv2.ToolchainModel) (map[string]interface{}, error) {
 	modelMap := make(map[string]interface{})
-	modelMap["id"] = model.ID
-	modelMap["name"] = model.Name
-	modelMap["description"] = model.Description
-	modelMap["account_id"] = model.AccountID
-	modelMap["location"] = model.Location
-	modelMap["resource_group_id"] = model.ResourceGroupID
-	modelMap["crn"] = model.CRN
-	modelMap["href"] = model.Href
-	modelMap["ui_href"] = model.UIHref
+	modelMap["id"] = *model.ID
+	modelMap["name"] = *model.Name
+	modelMap["description"] = *model.Description
+	modelMap["account_id"] = *model.AccountID
+	modelMap["location"] = *model.Location
+	modelMap["resource_group_id"] = *model.ResourceGroupID
+	modelMap["crn"] = *model.CRN
+	modelMap["href"] = *model.Href
+	modelMap["ui_href"] = *model.UIHref
 	modelMap["created_at"] = model.CreatedAt.String()
 	modelMap["updated_at"] = model.UpdatedAt.String()
-	modelMap["created_by"] = model.CreatedBy
+	modelMap["created_by"] = *model.CreatedBy
 	return modelMap, nil
 }

--- a/ibm/service/cdtoolchain/resource_ibm_cd_toolchain.go
+++ b/ibm/service/cdtoolchain/resource_ibm_cd_toolchain.go
@@ -1,5 +1,9 @@
-// Copyright IBM Corp. 2023 All Rights Reserved.
+// Copyright IBM Corp. 2024 All Rights Reserved.
 // Licensed under the Mozilla Public License v2.0
+
+/*
+ * IBM OpenAPI Terraform Generator Version: 3.96.0-d6dec9d7-20241008-212902
+ */
 
 package cdtoolchain
 
@@ -154,7 +158,9 @@ func ResourceIBMCdToolchainValidator() *validate.ResourceValidator {
 func resourceIBMCdToolchainCreate(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	cdToolchainClient, err := meta.(conns.ClientSession).CdToolchainV2()
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cd_toolchain", "create", "initialize-client")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	createToolchainOptions := &cdtoolchainv2.CreateToolchainOptions{}
@@ -165,10 +171,11 @@ func resourceIBMCdToolchainCreate(context context.Context, d *schema.ResourceDat
 		createToolchainOptions.SetDescription(d.Get("description").(string))
 	}
 
-	toolchainPost, response, err := cdToolchainClient.CreateToolchainWithContext(context, createToolchainOptions)
+	toolchainPost, _, err := cdToolchainClient.CreateToolchainWithContext(context, createToolchainOptions)
 	if err != nil {
-		log.Printf("[DEBUG] CreateToolchainWithContext failed %s\n%s", err, response)
-		return diag.FromErr(fmt.Errorf("CreateToolchainWithContext failed %s\n%s", err, response))
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("CreateToolchainWithContext failed: %s", err.Error()), "ibm_cd_toolchain", "create")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	d.SetId(*toolchainPost.ID)
@@ -189,7 +196,9 @@ func resourceIBMCdToolchainCreate(context context.Context, d *schema.ResourceDat
 func resourceIBMCdToolchainRead(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	cdToolchainClient, err := meta.(conns.ClientSession).CdToolchainV2()
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cd_toolchain", "read", "initialize-client")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	getToolchainByIDOptions := &cdtoolchainv2.GetToolchainByIDOptions{}
@@ -216,8 +225,9 @@ func resourceIBMCdToolchainRead(context context.Context, d *schema.ResourceData,
 			d.SetId("")
 			return nil
 		}
-		log.Printf("[DEBUG] GetToolchainByIDWithContext failed %s\n%s", err, response)
-		return diag.FromErr(fmt.Errorf("GetToolchainByIDWithContext failed %s\n%s", err, response))
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("GetToolchainByIDWithContext failed: %s", err.Error()), "ibm_cd_toolchain", "read")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	tags, err := flex.GetTagsUsingCRN(meta, *toolchain.CRN)
@@ -228,39 +238,50 @@ func resourceIBMCdToolchainRead(context context.Context, d *schema.ResourceData,
 	d.Set("tags", tags)
 
 	if err = d.Set("name", toolchain.Name); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting name: %s", err))
+		err = fmt.Errorf("Error setting name: %s", err)
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cd_toolchain", "read", "set-name").GetDiag()
 	}
 	if !core.IsNil(toolchain.Description) {
 		if err = d.Set("description", toolchain.Description); err != nil {
-			return diag.FromErr(fmt.Errorf("Error setting description: %s", err))
+			err = fmt.Errorf("Error setting description: %s", err)
+			return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cd_toolchain", "read", "set-description").GetDiag()
 		}
 	}
 	if err = d.Set("resource_group_id", toolchain.ResourceGroupID); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting resource_group_id: %s", err))
+		err = fmt.Errorf("Error setting resource_group_id: %s", err)
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cd_toolchain", "read", "set-resource_group_id").GetDiag()
 	}
 	if err = d.Set("account_id", toolchain.AccountID); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting account_id: %s", err))
+		err = fmt.Errorf("Error setting account_id: %s", err)
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cd_toolchain", "read", "set-account_id").GetDiag()
 	}
 	if err = d.Set("location", toolchain.Location); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting location: %s", err))
+		err = fmt.Errorf("Error setting location: %s", err)
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cd_toolchain", "read", "set-location").GetDiag()
 	}
 	if err = d.Set("crn", toolchain.CRN); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting crn: %s", err))
+		err = fmt.Errorf("Error setting crn: %s", err)
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cd_toolchain", "read", "set-crn").GetDiag()
 	}
 	if err = d.Set("href", toolchain.Href); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting href: %s", err))
+		err = fmt.Errorf("Error setting href: %s", err)
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cd_toolchain", "read", "set-href").GetDiag()
 	}
 	if err = d.Set("ui_href", toolchain.UIHref); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting ui_href: %s", err))
+		err = fmt.Errorf("Error setting ui_href: %s", err)
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cd_toolchain", "read", "set-ui_href").GetDiag()
 	}
 	if err = d.Set("created_at", flex.DateTimeToString(toolchain.CreatedAt)); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting created_at: %s", err))
+		err = fmt.Errorf("Error setting created_at: %s", err)
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cd_toolchain", "read", "set-created_at").GetDiag()
 	}
 	if err = d.Set("updated_at", flex.DateTimeToString(toolchain.UpdatedAt)); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting updated_at: %s", err))
+		err = fmt.Errorf("Error setting updated_at: %s", err)
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cd_toolchain", "read", "set-updated_at").GetDiag()
 	}
 	if err = d.Set("created_by", toolchain.CreatedBy); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting created_by: %s", err))
+		err = fmt.Errorf("Error setting created_by: %s", err)
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cd_toolchain", "read", "set-created_by").GetDiag()
 	}
 
 	return nil
@@ -269,7 +290,9 @@ func resourceIBMCdToolchainRead(context context.Context, d *schema.ResourceData,
 func resourceIBMCdToolchainUpdate(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	cdToolchainClient, err := meta.(conns.ClientSession).CdToolchainV2()
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cd_toolchain", "update", "initialize-client")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	updateToolchainOptions := &cdtoolchainv2.UpdateToolchainOptions{}
@@ -300,11 +323,16 @@ func resourceIBMCdToolchainUpdate(context context.Context, d *schema.ResourceDat
 	}
 
 	if hasChange {
-		updateToolchainOptions.ToolchainPrototypePatch, _ = patchVals.AsPatch()
-		_, response, err := cdToolchainClient.UpdateToolchainWithContext(context, updateToolchainOptions)
+		// Fields with `nil` values are omitted from the generic map,
+		// so we need to re-add them to support removing arguments
+		// in merge-patch operations sent to the service.
+		updateToolchainOptions.ToolchainPrototypePatch = ResourceIBMCdToolchainToolchainPrototypePatchAsPatch(patchVals, d)
+
+		_, _, err = cdToolchainClient.UpdateToolchainWithContext(context, updateToolchainOptions)
 		if err != nil {
-			log.Printf("[DEBUG] UpdateToolchainWithContext failed %s\n%s", err, response)
-			return diag.FromErr(fmt.Errorf("UpdateToolchainWithContext failed %s\n%s", err, response))
+			tfErr := flex.TerraformErrorf(err, fmt.Sprintf("UpdateToolchainWithContext failed: %s", err.Error()), "ibm_cd_toolchain", "update")
+			log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+			return tfErr.GetDiag()
 		}
 	}
 
@@ -314,20 +342,39 @@ func resourceIBMCdToolchainUpdate(context context.Context, d *schema.ResourceDat
 func resourceIBMCdToolchainDelete(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	cdToolchainClient, err := meta.(conns.ClientSession).CdToolchainV2()
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cd_toolchain", "delete", "initialize-client")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	deleteToolchainOptions := &cdtoolchainv2.DeleteToolchainOptions{}
 
 	deleteToolchainOptions.SetToolchainID(d.Id())
 
-	response, err := cdToolchainClient.DeleteToolchainWithContext(context, deleteToolchainOptions)
+	_, err = cdToolchainClient.DeleteToolchainWithContext(context, deleteToolchainOptions)
 	if err != nil {
-		log.Printf("[DEBUG] DeleteToolchainWithContext failed %s\n%s", err, response)
-		return diag.FromErr(fmt.Errorf("DeleteToolchainWithContext failed %s\n%s", err, response))
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("DeleteToolchainWithContext failed: %s", err.Error()), "ibm_cd_toolchain", "delete")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	d.SetId("")
 
 	return nil
+}
+
+func ResourceIBMCdToolchainToolchainPrototypePatchAsPatch(patchVals *cdtoolchainv2.ToolchainPrototypePatch, d *schema.ResourceData) map[string]interface{} {
+	patch, _ := patchVals.AsPatch()
+	var path string
+
+	path = "name"
+	if _, exists := d.GetOk(path); d.HasChange(path) && !exists {
+		patch["name"] = nil
+	}
+	path = "description"
+	if _, exists := d.GetOk(path); d.HasChange(path) && !exists {
+		patch["description"] = nil
+	}
+
+	return patch
 }

--- a/ibm/service/cdtoolchain/resource_ibm_cd_toolchain_test.go
+++ b/ibm/service/cdtoolchain/resource_ibm_cd_toolchain_test.go
@@ -51,10 +51,8 @@ func TestAccIBMCdToolchainAllArgs(t *testing.T) {
 	name := fmt.Sprintf("tf_name_%d", acctest.RandIntRange(10, 100))
 	rgName := acc.CdResourceGroupName
 	description := fmt.Sprintf("tf_description_%d", acctest.RandIntRange(10, 100))
-	tags := `["tag1", "tag2"]`
 	nameUpdate := fmt.Sprintf("tf_name_%d", acctest.RandIntRange(10, 100))
 	descriptionUpdate := fmt.Sprintf("tf_description_%d", acctest.RandIntRange(10, 100))
-	tagsUpdate := `["tag1","tag2","tag3"]`
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { acc.TestAccPreCheck(t) },
@@ -62,22 +60,20 @@ func TestAccIBMCdToolchainAllArgs(t *testing.T) {
 		CheckDestroy: testAccCheckIBMCdToolchainDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
-				Config: testAccCheckIBMCdToolchainConfig(name, rgName, description, tags),
+				Config: testAccCheckIBMCdToolchainConfig(name, rgName, description),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckIBMCdToolchainExists("ibm_cd_toolchain.cd_toolchain", conf),
 					resource.TestCheckResourceAttr("ibm_cd_toolchain.cd_toolchain", "name", name),
 					resource.TestCheckResourceAttrSet("ibm_cd_toolchain.cd_toolchain", "resource_group_id"),
 					resource.TestCheckResourceAttr("ibm_cd_toolchain.cd_toolchain", "description", description),
-					resource.TestCheckResourceAttr("ibm_cd_toolchain.cd_toolchain", "tags.#", "2"),
 				),
 			},
 			resource.TestStep{
-				Config: testAccCheckIBMCdToolchainConfig(nameUpdate, rgName, descriptionUpdate, tagsUpdate),
+				Config: testAccCheckIBMCdToolchainConfig(nameUpdate, rgName, descriptionUpdate),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr("ibm_cd_toolchain.cd_toolchain", "name", nameUpdate),
 					resource.TestCheckResourceAttrSet("ibm_cd_toolchain.cd_toolchain", "resource_group_id"),
 					resource.TestCheckResourceAttr("ibm_cd_toolchain.cd_toolchain", "description", descriptionUpdate),
-					resource.TestCheckResourceAttr("ibm_cd_toolchain.cd_toolchain", "tags.#", "3"),
 				),
 			},
 			resource.TestStep{
@@ -102,7 +98,7 @@ func testAccCheckIBMCdToolchainConfigBasic(name string, rgName string) string {
 	`, rgName, name)
 }
 
-func testAccCheckIBMCdToolchainConfig(name string, rgName string, description string, tags string) string {
+func testAccCheckIBMCdToolchainConfig(name string, rgName string, description string) string {
 	return fmt.Sprintf(`
 		data "ibm_resource_group" "resource_group" {
 			name = "%s"
@@ -112,9 +108,8 @@ func testAccCheckIBMCdToolchainConfig(name string, rgName string, description st
 			name = "%s"
 			resource_group_id = data.ibm_resource_group.resource_group.id
 			description = "%s"
-			tags = %s
 		}
-	`, rgName, name, description, tags)
+	`, rgName, name, description)
 }
 
 func testAccCheckIBMCdToolchainExists(n string, obj cdtoolchainv2.Toolchain) resource.TestCheckFunc {

--- a/ibm/service/cdtoolchain/resource_ibm_cd_toolchain_tool_appconfig.go
+++ b/ibm/service/cdtoolchain/resource_ibm_cd_toolchain_tool_appconfig.go
@@ -1,5 +1,9 @@
-// Copyright IBM Corp. 2023 All Rights Reserved.
+// Copyright IBM Corp. 2024 All Rights Reserved.
 // Licensed under the Mozilla Public License v2.0
+
+/*
+ * IBM OpenAPI Terraform Generator Version: 3.96.0-d6dec9d7-20241008-212902
+ */
 
 package cdtoolchain
 
@@ -112,11 +116,13 @@ func ResourceIBMCdToolchainToolAppconfig() *schema.Resource {
 						"ui_href": &schema.Schema{
 							Type:        schema.TypeString,
 							Optional:    true,
+							Computed:    true,
 							Description: "URI representing this resource through the UI.",
 						},
 						"api_href": &schema.Schema{
 							Type:        schema.TypeString,
 							Optional:    true,
+							Computed:    true,
 							Description: "URI representing this resource through an API.",
 						},
 					},
@@ -171,7 +177,9 @@ func ResourceIBMCdToolchainToolAppconfigValidator() *validate.ResourceValidator 
 func resourceIBMCdToolchainToolAppconfigCreate(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	cdToolchainClient, err := meta.(conns.ClientSession).CdToolchainV2()
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cd_toolchain_tool_appconfig", "create", "initialize-client")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	createToolOptions := &cdtoolchainv2.CreateToolOptions{}
@@ -191,10 +199,11 @@ func resourceIBMCdToolchainToolAppconfigCreate(context context.Context, d *schem
 		createToolOptions.SetName(d.Get("name").(string))
 	}
 
-	toolchainToolPost, response, err := cdToolchainClient.CreateToolWithContext(context, createToolOptions)
+	toolchainToolPost, _, err := cdToolchainClient.CreateToolWithContext(context, createToolOptions)
 	if err != nil {
-		log.Printf("[DEBUG] CreateToolWithContext failed %s\n%s", err, response)
-		return diag.FromErr(fmt.Errorf("CreateToolWithContext failed %s\n%s", err, response))
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("CreateToolWithContext failed: %s", err.Error()), "ibm_cd_toolchain_tool_appconfig", "create")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	d.SetId(fmt.Sprintf("%s/%s", *createToolOptions.ToolchainID, *toolchainToolPost.ID))
@@ -205,14 +214,16 @@ func resourceIBMCdToolchainToolAppconfigCreate(context context.Context, d *schem
 func resourceIBMCdToolchainToolAppconfigRead(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	cdToolchainClient, err := meta.(conns.ClientSession).CdToolchainV2()
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cd_toolchain_tool_appconfig", "read", "initialize-client")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	getToolByIDOptions := &cdtoolchainv2.GetToolByIDOptions{}
 
 	parts, err := flex.SepIdParts(d.Id(), "/")
 	if err != nil {
-		return diag.FromErr(err)
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cd_toolchain_tool_appconfig", "read", "sep-id-parts").GetDiag()
 	}
 
 	getToolByIDOptions.SetToolchainID(parts[0])
@@ -238,16 +249,19 @@ func resourceIBMCdToolchainToolAppconfigRead(context context.Context, d *schema.
 			d.SetId("")
 			return nil
 		}
-		log.Printf("[DEBUG] GetToolByIDWithContext failed %s\n%s", err, response)
-		return diag.FromErr(fmt.Errorf("GetToolByIDWithContext failed %s\n%s", err, response))
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("GetToolByIDWithContext failed: %s", err.Error()), "ibm_cd_toolchain_tool_appconfig", "read")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	if err = d.Set("toolchain_id", toolchainTool.ToolchainID); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting toolchain_id: %s", err))
+		err = fmt.Errorf("Error setting toolchain_id: %s", err)
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cd_toolchain_tool_appconfig", "read", "set-toolchain_id").GetDiag()
 	}
 	if !core.IsNil(toolchainTool.Name) {
 		if err = d.Set("name", toolchainTool.Name); err != nil {
-			return diag.FromErr(fmt.Errorf("Error setting name: %s", err))
+			err = fmt.Errorf("Error setting name: %s", err)
+			return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cd_toolchain_tool_appconfig", "read", "set-name").GetDiag()
 		}
 	}
 	remapFields := map[string]string{
@@ -259,35 +273,44 @@ func resourceIBMCdToolchainToolAppconfigRead(context context.Context, d *schema.
 	}
 	parametersMap := GetParametersFromRead(toolchainTool.Parameters, ResourceIBMCdToolchainToolAppconfig(), remapFields)
 	if err = d.Set("parameters", []map[string]interface{}{parametersMap}); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting parameters: %s", err))
+		err = fmt.Errorf("Error setting parameters: %s", err)
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cd_toolchain_tool_appconfig", "read", "set-parameters").GetDiag()
 	}
 	if err = d.Set("resource_group_id", toolchainTool.ResourceGroupID); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting resource_group_id: %s", err))
+		err = fmt.Errorf("Error setting resource_group_id: %s", err)
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cd_toolchain_tool_appconfig", "read", "set-resource_group_id").GetDiag()
 	}
 	if err = d.Set("crn", toolchainTool.CRN); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting crn: %s", err))
+		err = fmt.Errorf("Error setting crn: %s", err)
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cd_toolchain_tool_appconfig", "read", "set-crn").GetDiag()
 	}
 	if err = d.Set("toolchain_crn", toolchainTool.ToolchainCRN); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting toolchain_crn: %s", err))
+		err = fmt.Errorf("Error setting toolchain_crn: %s", err)
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cd_toolchain_tool_appconfig", "read", "set-toolchain_crn").GetDiag()
 	}
 	if err = d.Set("href", toolchainTool.Href); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting href: %s", err))
+		err = fmt.Errorf("Error setting href: %s", err)
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cd_toolchain_tool_appconfig", "read", "set-href").GetDiag()
 	}
-	referentMap, err := resourceIBMCdToolchainToolAppconfigToolModelReferentToMap(toolchainTool.Referent)
+	referentMap, err := ResourceIBMCdToolchainToolAppconfigToolModelReferentToMap(toolchainTool.Referent)
 	if err != nil {
-		return diag.FromErr(err)
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cd_toolchain_tool_appconfig", "read", "referent-to-map").GetDiag()
 	}
 	if err = d.Set("referent", []map[string]interface{}{referentMap}); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting referent: %s", err))
+		err = fmt.Errorf("Error setting referent: %s", err)
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cd_toolchain_tool_appconfig", "read", "set-referent").GetDiag()
 	}
 	if err = d.Set("updated_at", flex.DateTimeToString(toolchainTool.UpdatedAt)); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting updated_at: %s", err))
+		err = fmt.Errorf("Error setting updated_at: %s", err)
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cd_toolchain_tool_appconfig", "read", "set-updated_at").GetDiag()
 	}
 	if err = d.Set("state", toolchainTool.State); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting state: %s", err))
+		err = fmt.Errorf("Error setting state: %s", err)
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cd_toolchain_tool_appconfig", "read", "set-state").GetDiag()
 	}
 	if err = d.Set("tool_id", toolchainTool.ID); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting tool_id: %s", err))
+		err = fmt.Errorf("Error setting tool_id: %s", err)
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cd_toolchain_tool_appconfig", "read", "set-tool_id").GetDiag()
 	}
 
 	return nil
@@ -296,14 +319,16 @@ func resourceIBMCdToolchainToolAppconfigRead(context context.Context, d *schema.
 func resourceIBMCdToolchainToolAppconfigUpdate(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	cdToolchainClient, err := meta.(conns.ClientSession).CdToolchainV2()
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cd_toolchain_tool_appconfig", "update", "initialize-client")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	updateToolOptions := &cdtoolchainv2.UpdateToolOptions{}
 
 	parts, err := flex.SepIdParts(d.Id(), "/")
 	if err != nil {
-		return diag.FromErr(err)
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cd_toolchain_tool_appconfig", "update", "sep-id-parts").GetDiag()
 	}
 
 	updateToolOptions.SetToolchainID(parts[0])
@@ -313,8 +338,9 @@ func resourceIBMCdToolchainToolAppconfigUpdate(context context.Context, d *schem
 
 	patchVals := &cdtoolchainv2.ToolchainToolPrototypePatch{}
 	if d.HasChange("toolchain_id") {
-		return diag.FromErr(fmt.Errorf("Cannot update resource property \"%s\" with the ForceNew annotation."+
-			" The resource must be re-created to update this property.", "toolchain_id"))
+		errMsg := fmt.Sprintf("Cannot update resource property \"%s\" with the ForceNew annotation."+
+			" The resource must be re-created to update this property.", "toolchain_id")
+		return flex.DiscriminatedTerraformErrorf(nil, errMsg, "ibm_cd_toolchain_tool_appconfig", "update", "toolchain_id-forces-new").GetDiag()
 	}
 	if d.HasChange("name") {
 		newName := d.Get("name").(string)
@@ -335,11 +361,16 @@ func resourceIBMCdToolchainToolAppconfigUpdate(context context.Context, d *schem
 	}
 
 	if hasChange {
-		updateToolOptions.ToolchainToolPrototypePatch, _ = patchVals.AsPatch()
-		_, response, err := cdToolchainClient.UpdateToolWithContext(context, updateToolOptions)
+		// Fields with `nil` values are omitted from the generic map,
+		// so we need to re-add them to support removing arguments
+		// in merge-patch operations sent to the service.
+		updateToolOptions.ToolchainToolPrototypePatch = ResourceIBMCdToolchainToolAppconfigToolchainToolPrototypePatchAsPatch(patchVals, d)
+
+		_, _, err = cdToolchainClient.UpdateToolWithContext(context, updateToolOptions)
 		if err != nil {
-			log.Printf("[DEBUG] UpdateToolWithContext failed %s\n%s", err, response)
-			return diag.FromErr(fmt.Errorf("UpdateToolWithContext failed %s\n%s", err, response))
+			tfErr := flex.TerraformErrorf(err, fmt.Sprintf("UpdateToolWithContext failed: %s", err.Error()), "ibm_cd_toolchain_tool_appconfig", "update")
+			log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+			return tfErr.GetDiag()
 		}
 	}
 
@@ -349,23 +380,26 @@ func resourceIBMCdToolchainToolAppconfigUpdate(context context.Context, d *schem
 func resourceIBMCdToolchainToolAppconfigDelete(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	cdToolchainClient, err := meta.(conns.ClientSession).CdToolchainV2()
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cd_toolchain_tool_appconfig", "delete", "initialize-client")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	deleteToolOptions := &cdtoolchainv2.DeleteToolOptions{}
 
 	parts, err := flex.SepIdParts(d.Id(), "/")
 	if err != nil {
-		return diag.FromErr(err)
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cd_toolchain_tool_appconfig", "delete", "sep-id-parts").GetDiag()
 	}
 
 	deleteToolOptions.SetToolchainID(parts[0])
 	deleteToolOptions.SetToolID(parts[1])
 
-	response, err := cdToolchainClient.DeleteToolWithContext(context, deleteToolOptions)
+	_, err = cdToolchainClient.DeleteToolWithContext(context, deleteToolOptions)
 	if err != nil {
-		log.Printf("[DEBUG] DeleteToolWithContext failed %s\n%s", err, response)
-		return diag.FromErr(fmt.Errorf("DeleteToolWithContext failed %s\n%s", err, response))
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("DeleteToolWithContext failed: %s", err.Error()), "ibm_cd_toolchain_tool_appconfig", "delete")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	d.SetId("")
@@ -373,13 +407,33 @@ func resourceIBMCdToolchainToolAppconfigDelete(context context.Context, d *schem
 	return nil
 }
 
-func resourceIBMCdToolchainToolAppconfigToolModelReferentToMap(model *cdtoolchainv2.ToolModelReferent) (map[string]interface{}, error) {
+func ResourceIBMCdToolchainToolAppconfigToolModelReferentToMap(model *cdtoolchainv2.ToolModelReferent) (map[string]interface{}, error) {
 	modelMap := make(map[string]interface{})
 	if model.UIHref != nil {
-		modelMap["ui_href"] = model.UIHref
+		modelMap["ui_href"] = *model.UIHref
 	}
 	if model.APIHref != nil {
-		modelMap["api_href"] = model.APIHref
+		modelMap["api_href"] = *model.APIHref
 	}
 	return modelMap, nil
+}
+
+func ResourceIBMCdToolchainToolAppconfigToolchainToolPrototypePatchAsPatch(patchVals *cdtoolchainv2.ToolchainToolPrototypePatch, d *schema.ResourceData) map[string]interface{} {
+	patch, _ := patchVals.AsPatch()
+	var path string
+
+	path = "name"
+	if _, exists := d.GetOk(path); d.HasChange(path) && !exists {
+		patch["name"] = nil
+	}
+	path = "tool_type_id"
+	if _, exists := d.GetOk(path); d.HasChange(path) && !exists {
+		patch["tool_type_id"] = nil
+	}
+	path = "parameters"
+	if _, exists := d.GetOk(path); d.HasChange(path) && !exists {
+		patch["parameters"] = nil
+	}
+
+	return patch
 }

--- a/ibm/service/cdtoolchain/resource_ibm_cd_toolchain_tool_artifactory.go
+++ b/ibm/service/cdtoolchain/resource_ibm_cd_toolchain_tool_artifactory.go
@@ -1,5 +1,9 @@
-// Copyright IBM Corp. 2023 All Rights Reserved.
+// Copyright IBM Corp. 2024 All Rights Reserved.
 // Licensed under the Mozilla Public License v2.0
+
+/*
+ * IBM OpenAPI Terraform Generator Version: 3.96.0-d6dec9d7-20241008-212902
+ */
 
 package cdtoolchain
 
@@ -134,11 +138,13 @@ func ResourceIBMCdToolchainToolArtifactory() *schema.Resource {
 						"ui_href": &schema.Schema{
 							Type:        schema.TypeString,
 							Optional:    true,
+							Computed:    true,
 							Description: "URI representing this resource through the UI.",
 						},
 						"api_href": &schema.Schema{
 							Type:        schema.TypeString,
 							Optional:    true,
+							Computed:    true,
 							Description: "URI representing this resource through an API.",
 						},
 					},
@@ -193,7 +199,9 @@ func ResourceIBMCdToolchainToolArtifactoryValidator() *validate.ResourceValidato
 func resourceIBMCdToolchainToolArtifactoryCreate(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	cdToolchainClient, err := meta.(conns.ClientSession).CdToolchainV2()
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cd_toolchain_tool_artifactory", "create", "initialize-client")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	createToolOptions := &cdtoolchainv2.CreateToolOptions{}
@@ -206,10 +214,11 @@ func resourceIBMCdToolchainToolArtifactoryCreate(context context.Context, d *sch
 		createToolOptions.SetName(d.Get("name").(string))
 	}
 
-	toolchainToolPost, response, err := cdToolchainClient.CreateToolWithContext(context, createToolOptions)
+	toolchainToolPost, _, err := cdToolchainClient.CreateToolWithContext(context, createToolOptions)
 	if err != nil {
-		log.Printf("[DEBUG] CreateToolWithContext failed %s\n%s", err, response)
-		return diag.FromErr(fmt.Errorf("CreateToolWithContext failed %s\n%s", err, response))
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("CreateToolWithContext failed: %s", err.Error()), "ibm_cd_toolchain_tool_artifactory", "create")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	d.SetId(fmt.Sprintf("%s/%s", *createToolOptions.ToolchainID, *toolchainToolPost.ID))
@@ -220,14 +229,16 @@ func resourceIBMCdToolchainToolArtifactoryCreate(context context.Context, d *sch
 func resourceIBMCdToolchainToolArtifactoryRead(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	cdToolchainClient, err := meta.(conns.ClientSession).CdToolchainV2()
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cd_toolchain_tool_artifactory", "read", "initialize-client")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	getToolByIDOptions := &cdtoolchainv2.GetToolByIDOptions{}
 
 	parts, err := flex.SepIdParts(d.Id(), "/")
 	if err != nil {
-		return diag.FromErr(err)
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cd_toolchain_tool_artifactory", "read", "sep-id-parts").GetDiag()
 	}
 
 	getToolByIDOptions.SetToolchainID(parts[0])
@@ -253,49 +264,61 @@ func resourceIBMCdToolchainToolArtifactoryRead(context context.Context, d *schem
 			d.SetId("")
 			return nil
 		}
-		log.Printf("[DEBUG] GetToolByIDWithContext failed %s\n%s", err, response)
-		return diag.FromErr(fmt.Errorf("GetToolByIDWithContext failed %s\n%s", err, response))
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("GetToolByIDWithContext failed: %s", err.Error()), "ibm_cd_toolchain_tool_artifactory", "read")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	if err = d.Set("toolchain_id", toolchainTool.ToolchainID); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting toolchain_id: %s", err))
+		err = fmt.Errorf("Error setting toolchain_id: %s", err)
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cd_toolchain_tool_artifactory", "read", "set-toolchain_id").GetDiag()
 	}
 	if !core.IsNil(toolchainTool.Name) {
 		if err = d.Set("name", toolchainTool.Name); err != nil {
-			return diag.FromErr(fmt.Errorf("Error setting name: %s", err))
+			err = fmt.Errorf("Error setting name: %s", err)
+			return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cd_toolchain_tool_artifactory", "read", "set-name").GetDiag()
 		}
 	}
 	parametersMap := GetParametersFromRead(toolchainTool.Parameters, ResourceIBMCdToolchainToolArtifactory(), nil)
 	if err = d.Set("parameters", []map[string]interface{}{parametersMap}); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting parameters: %s", err))
+		err = fmt.Errorf("Error setting parameters: %s", err)
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cd_toolchain_tool_artifactory", "read", "set-parameters").GetDiag()
 	}
 	if err = d.Set("resource_group_id", toolchainTool.ResourceGroupID); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting resource_group_id: %s", err))
+		err = fmt.Errorf("Error setting resource_group_id: %s", err)
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cd_toolchain_tool_artifactory", "read", "set-resource_group_id").GetDiag()
 	}
 	if err = d.Set("crn", toolchainTool.CRN); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting crn: %s", err))
+		err = fmt.Errorf("Error setting crn: %s", err)
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cd_toolchain_tool_artifactory", "read", "set-crn").GetDiag()
 	}
 	if err = d.Set("toolchain_crn", toolchainTool.ToolchainCRN); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting toolchain_crn: %s", err))
+		err = fmt.Errorf("Error setting toolchain_crn: %s", err)
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cd_toolchain_tool_artifactory", "read", "set-toolchain_crn").GetDiag()
 	}
 	if err = d.Set("href", toolchainTool.Href); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting href: %s", err))
+		err = fmt.Errorf("Error setting href: %s", err)
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cd_toolchain_tool_artifactory", "read", "set-href").GetDiag()
 	}
-	referentMap, err := resourceIBMCdToolchainToolArtifactoryToolModelReferentToMap(toolchainTool.Referent)
+	referentMap, err := ResourceIBMCdToolchainToolArtifactoryToolModelReferentToMap(toolchainTool.Referent)
 	if err != nil {
-		return diag.FromErr(err)
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cd_toolchain_tool_artifactory", "read", "referent-to-map").GetDiag()
 	}
 	if err = d.Set("referent", []map[string]interface{}{referentMap}); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting referent: %s", err))
+		err = fmt.Errorf("Error setting referent: %s", err)
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cd_toolchain_tool_artifactory", "read", "set-referent").GetDiag()
 	}
 	if err = d.Set("updated_at", flex.DateTimeToString(toolchainTool.UpdatedAt)); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting updated_at: %s", err))
+		err = fmt.Errorf("Error setting updated_at: %s", err)
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cd_toolchain_tool_artifactory", "read", "set-updated_at").GetDiag()
 	}
 	if err = d.Set("state", toolchainTool.State); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting state: %s", err))
+		err = fmt.Errorf("Error setting state: %s", err)
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cd_toolchain_tool_artifactory", "read", "set-state").GetDiag()
 	}
 	if err = d.Set("tool_id", toolchainTool.ID); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting tool_id: %s", err))
+		err = fmt.Errorf("Error setting tool_id: %s", err)
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cd_toolchain_tool_artifactory", "read", "set-tool_id").GetDiag()
 	}
 
 	return nil
@@ -304,14 +327,16 @@ func resourceIBMCdToolchainToolArtifactoryRead(context context.Context, d *schem
 func resourceIBMCdToolchainToolArtifactoryUpdate(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	cdToolchainClient, err := meta.(conns.ClientSession).CdToolchainV2()
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cd_toolchain_tool_artifactory", "update", "initialize-client")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	updateToolOptions := &cdtoolchainv2.UpdateToolOptions{}
 
 	parts, err := flex.SepIdParts(d.Id(), "/")
 	if err != nil {
-		return diag.FromErr(err)
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cd_toolchain_tool_artifactory", "update", "sep-id-parts").GetDiag()
 	}
 
 	updateToolOptions.SetToolchainID(parts[0])
@@ -321,8 +346,9 @@ func resourceIBMCdToolchainToolArtifactoryUpdate(context context.Context, d *sch
 
 	patchVals := &cdtoolchainv2.ToolchainToolPrototypePatch{}
 	if d.HasChange("toolchain_id") {
-		return diag.FromErr(fmt.Errorf("Cannot update resource property \"%s\" with the ForceNew annotation."+
-			" The resource must be re-created to update this property.", "toolchain_id"))
+		errMsg := fmt.Sprintf("Cannot update resource property \"%s\" with the ForceNew annotation."+
+			" The resource must be re-created to update this property.", "toolchain_id")
+		return flex.DiscriminatedTerraformErrorf(nil, errMsg, "ibm_cd_toolchain_tool_artifactory", "update", "toolchain_id-forces-new").GetDiag()
 	}
 	if d.HasChange("name") {
 		newName := d.Get("name").(string)
@@ -336,11 +362,16 @@ func resourceIBMCdToolchainToolArtifactoryUpdate(context context.Context, d *sch
 	}
 
 	if hasChange {
-		updateToolOptions.ToolchainToolPrototypePatch, _ = patchVals.AsPatch()
-		_, response, err := cdToolchainClient.UpdateToolWithContext(context, updateToolOptions)
+		// Fields with `nil` values are omitted from the generic map,
+		// so we need to re-add them to support removing arguments
+		// in merge-patch operations sent to the service.
+		updateToolOptions.ToolchainToolPrototypePatch = ResourceIBMCdToolchainToolArtifactoryToolchainToolPrototypePatchAsPatch(patchVals, d)
+
+		_, _, err = cdToolchainClient.UpdateToolWithContext(context, updateToolOptions)
 		if err != nil {
-			log.Printf("[DEBUG] UpdateToolWithContext failed %s\n%s", err, response)
-			return diag.FromErr(fmt.Errorf("UpdateToolWithContext failed %s\n%s", err, response))
+			tfErr := flex.TerraformErrorf(err, fmt.Sprintf("UpdateToolWithContext failed: %s", err.Error()), "ibm_cd_toolchain_tool_artifactory", "update")
+			log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+			return tfErr.GetDiag()
 		}
 	}
 
@@ -350,23 +381,26 @@ func resourceIBMCdToolchainToolArtifactoryUpdate(context context.Context, d *sch
 func resourceIBMCdToolchainToolArtifactoryDelete(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	cdToolchainClient, err := meta.(conns.ClientSession).CdToolchainV2()
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cd_toolchain_tool_artifactory", "delete", "initialize-client")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	deleteToolOptions := &cdtoolchainv2.DeleteToolOptions{}
 
 	parts, err := flex.SepIdParts(d.Id(), "/")
 	if err != nil {
-		return diag.FromErr(err)
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cd_toolchain_tool_artifactory", "delete", "sep-id-parts").GetDiag()
 	}
 
 	deleteToolOptions.SetToolchainID(parts[0])
 	deleteToolOptions.SetToolID(parts[1])
 
-	response, err := cdToolchainClient.DeleteToolWithContext(context, deleteToolOptions)
+	_, err = cdToolchainClient.DeleteToolWithContext(context, deleteToolOptions)
 	if err != nil {
-		log.Printf("[DEBUG] DeleteToolWithContext failed %s\n%s", err, response)
-		return diag.FromErr(fmt.Errorf("DeleteToolWithContext failed %s\n%s", err, response))
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("DeleteToolWithContext failed: %s", err.Error()), "ibm_cd_toolchain_tool_artifactory", "delete")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	d.SetId("")
@@ -374,13 +408,72 @@ func resourceIBMCdToolchainToolArtifactoryDelete(context context.Context, d *sch
 	return nil
 }
 
-func resourceIBMCdToolchainToolArtifactoryToolModelReferentToMap(model *cdtoolchainv2.ToolModelReferent) (map[string]interface{}, error) {
+func ResourceIBMCdToolchainToolArtifactoryToolModelReferentToMap(model *cdtoolchainv2.ToolModelReferent) (map[string]interface{}, error) {
 	modelMap := make(map[string]interface{})
 	if model.UIHref != nil {
-		modelMap["ui_href"] = model.UIHref
+		modelMap["ui_href"] = *model.UIHref
 	}
 	if model.APIHref != nil {
-		modelMap["api_href"] = model.APIHref
+		modelMap["api_href"] = *model.APIHref
 	}
 	return modelMap, nil
+}
+
+func ResourceIBMCdToolchainToolArtifactoryToolchainToolPrototypePatchAsPatch(patchVals *cdtoolchainv2.ToolchainToolPrototypePatch, d *schema.ResourceData) map[string]interface{} {
+	patch, _ := patchVals.AsPatch()
+	var path string
+
+	path = "name"
+	if _, exists := d.GetOk(path); d.HasChange(path) && !exists {
+		patch["name"] = nil
+	}
+	path = "tool_type_id"
+	if _, exists := d.GetOk(path); d.HasChange(path) && !exists {
+		patch["tool_type_id"] = nil
+	}
+	path = "parameters"
+	if _, exists := d.GetOk(path); d.HasChange(path) && !exists {
+		patch["parameters"] = nil
+	} else if exists && patch["parameters"] != nil {
+		ResourceIBMCdToolchainToolArtifactoryToolModelParametersAsPatch(patch["parameters"].(map[string]interface{}), d)
+	}
+
+	return patch
+}
+
+func ResourceIBMCdToolchainToolArtifactoryToolModelParametersAsPatch(patch map[string]interface{}, d *schema.ResourceData) {
+	var path string
+
+	path = "parameters.0.dashboard_url"
+	if _, exists := d.GetOk(path); d.HasChange(path) && !exists {
+		patch["dashboard_url"] = nil
+	}
+	path = "parameters.0.user_id"
+	if _, exists := d.GetOk(path); d.HasChange(path) && !exists {
+		patch["user_id"] = nil
+	}
+	path = "parameters.0.token"
+	if _, exists := d.GetOk(path); d.HasChange(path) && !exists {
+		patch["token"] = nil
+	}
+	path = "parameters.0.release_url"
+	if _, exists := d.GetOk(path); d.HasChange(path) && !exists {
+		patch["release_url"] = nil
+	}
+	path = "parameters.0.mirror_url"
+	if _, exists := d.GetOk(path); d.HasChange(path) && !exists {
+		patch["mirror_url"] = nil
+	}
+	path = "parameters.0.snapshot_url"
+	if _, exists := d.GetOk(path); d.HasChange(path) && !exists {
+		patch["snapshot_url"] = nil
+	}
+	path = "parameters.0.repository_name"
+	if _, exists := d.GetOk(path); d.HasChange(path) && !exists {
+		patch["repository_name"] = nil
+	}
+	path = "parameters.0.repository_url"
+	if _, exists := d.GetOk(path); d.HasChange(path) && !exists {
+		patch["repository_url"] = nil
+	}
 }

--- a/ibm/service/cdtoolchain/resource_ibm_cd_toolchain_tool_bitbucketgit.go
+++ b/ibm/service/cdtoolchain/resource_ibm_cd_toolchain_tool_bitbucketgit.go
@@ -1,5 +1,9 @@
-// Copyright IBM Corp. 2023 All Rights Reserved.
+// Copyright IBM Corp. 2024 All Rights Reserved.
 // Licensed under the Mozilla Public License v2.0
+
+/*
+ * IBM OpenAPI Terraform Generator Version: 3.96.0-d6dec9d7-20241008-212902
+ */
 
 package cdtoolchain
 
@@ -52,51 +56,61 @@ func ResourceIBMCdToolchainToolBitbucketgit() *schema.Resource {
 					Schema: map[string]*schema.Schema{
 						"git_id": &schema.Schema{
 							Type:        schema.TypeString,
+							Optional:    true,
 							Computed:    true,
 							Description: "Set this value to 'bitbucketgit' for bitbucket.org, or to the GUID of a custom Bitbucket server.",
 						},
 						"api_root_url": &schema.Schema{
 							Type:        schema.TypeString,
+							Optional:    true,
 							Computed:    true,
 							Description: "The API root URL for the Bitbucket Server.",
 						},
 						"default_branch": &schema.Schema{
 							Type:        schema.TypeString,
+							Optional:    true,
 							Computed:    true,
 							Description: "The default branch of the git repository.",
 						},
 						"owner_id": &schema.Schema{
 							Type:        schema.TypeString,
+							Optional:    true,
 							Computed:    true,
 							Description: "The Bitbucket user or group that owns the repository.  This parameter is required when creating a new repository, cloning, or forking a repository.  The value will be computed when linking to an existing repository.",
 						},
 						"repo_name": &schema.Schema{
 							Type:        schema.TypeString,
+							Optional:    true,
 							Computed:    true,
 							Description: "The name of the new Bitbucket repository to create.  This parameter is required when creating a new repository, cloning, or forking a repository.  The value will be computed when linking to an existing repository.",
 						},
 						"repo_url": &schema.Schema{
 							Type:        schema.TypeString,
+							Optional:    true,
 							Computed:    true,
 							Description: "The URL of the bitbucket repository for this tool integration.  This parameter is required when linking to an existing repository.  The value will be computed when creating a new repository, cloning, or forking a repository.",
 						},
 						"source_repo_url": &schema.Schema{
 							Type:        schema.TypeString,
+							Optional:    true,
 							Computed:    true,
 							Description: "The URL of the repository that you are forking or cloning.  This parameter is required when forking or cloning a repository.  It is not used when creating a new repository or linking to an existing repository.",
 						},
 						"token_url": &schema.Schema{
 							Type:        schema.TypeString,
+							Optional:    true,
 							Computed:    true,
 							Description: "The token URL used for authorizing with the Bitbucket server.",
 						},
 						"type": &schema.Schema{
 							Type:        schema.TypeString,
+							Optional:    true,
 							Computed:    true,
 							Description: "The operation that should be performed to initialize the new tool integration. Use 'new' or 'new_if_not_exists' to create a new git repository, 'clone' or 'clone_if_not_exists' to clone an existing repository into a new git repository, 'fork' or 'fork_if_not_exists' to fork an existing git repository, or 'link' to link to an existing git repository. If you attempt to apply a resource with type 'new', 'clone', or 'fork' when the target repo already exists, the attempt will fail. If you apply a resource with type 'new_if_not_exists`, 'clone_if_not_exists', or 'fork_if_not_exists' when the target repo already exists, the existing repo will be used as-is.",
 						},
 						"private_repo": &schema.Schema{
 							Type:        schema.TypeBool,
+							Optional:    true,
 							Computed:    true,
 							Description: "Set this value to 'true' to make the repository private when creating a new repository or when cloning or forking a repository.  This parameter is not used when linking to an existing repository.",
 						},
@@ -114,6 +128,7 @@ func ResourceIBMCdToolchainToolBitbucketgit() *schema.Resource {
 						},
 						"repo_id": &schema.Schema{
 							Type:        schema.TypeString,
+							Optional:    true,
 							Computed:    true,
 							Description: "The ID of the Bitbucket repository.",
 						},
@@ -208,11 +223,13 @@ func ResourceIBMCdToolchainToolBitbucketgit() *schema.Resource {
 						"ui_href": &schema.Schema{
 							Type:        schema.TypeString,
 							Optional:    true,
+							Computed:    true,
 							Description: "URI representing this resource through the UI.",
 						},
 						"api_href": &schema.Schema{
 							Type:        schema.TypeString,
 							Optional:    true,
+							Computed:    true,
 							Description: "URI representing this resource through an API.",
 						},
 					},
@@ -267,7 +284,9 @@ func ResourceIBMCdToolchainToolBitbucketgitValidator() *validate.ResourceValidat
 func resourceIBMCdToolchainToolBitbucketgitCreate(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	cdToolchainClient, err := meta.(conns.ClientSession).CdToolchainV2()
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cd_toolchain_tool_bitbucketgit", "create", "initialize-client")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	createToolOptions := &cdtoolchainv2.CreateToolOptions{}
@@ -283,10 +302,11 @@ func resourceIBMCdToolchainToolBitbucketgitCreate(context context.Context, d *sc
 		createToolOptions.SetName(d.Get("name").(string))
 	}
 
-	toolchainToolPost, response, err := cdToolchainClient.CreateToolWithContext(context, createToolOptions)
+	toolchainToolPost, _, err := cdToolchainClient.CreateToolWithContext(context, createToolOptions)
 	if err != nil {
-		log.Printf("[DEBUG] CreateToolWithContext failed %s\n%s", err, response)
-		return diag.FromErr(fmt.Errorf("CreateToolWithContext failed %s\n%s", err, response))
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("CreateToolWithContext failed: %s", err.Error()), "ibm_cd_toolchain_tool_bitbucketgit", "create")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	d.SetId(fmt.Sprintf("%s/%s", *createToolOptions.ToolchainID, *toolchainToolPost.ID))
@@ -297,14 +317,16 @@ func resourceIBMCdToolchainToolBitbucketgitCreate(context context.Context, d *sc
 func resourceIBMCdToolchainToolBitbucketgitRead(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	cdToolchainClient, err := meta.(conns.ClientSession).CdToolchainV2()
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cd_toolchain_tool_bitbucketgit", "read", "initialize-client")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	getToolByIDOptions := &cdtoolchainv2.GetToolByIDOptions{}
 
 	parts, err := flex.SepIdParts(d.Id(), "/")
 	if err != nil {
-		return diag.FromErr(err)
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cd_toolchain_tool_bitbucketgit", "read", "sep-id-parts").GetDiag()
 	}
 
 	getToolByIDOptions.SetToolchainID(parts[0])
@@ -330,16 +352,19 @@ func resourceIBMCdToolchainToolBitbucketgitRead(context context.Context, d *sche
 			d.SetId("")
 			return nil
 		}
-		log.Printf("[DEBUG] GetToolByIDWithContext failed %s\n%s", err, response)
-		return diag.FromErr(fmt.Errorf("GetToolByIDWithContext failed %s\n%s", err, response))
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("GetToolByIDWithContext failed: %s", err.Error()), "ibm_cd_toolchain_tool_bitbucketgit", "read")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	if err = d.Set("toolchain_id", toolchainTool.ToolchainID); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting toolchain_id: %s", err))
+		err = fmt.Errorf("Error setting toolchain_id: %s", err)
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cd_toolchain_tool_bitbucketgit", "read", "set-toolchain_id").GetDiag()
 	}
 	if !core.IsNil(toolchainTool.Name) {
 		if err = d.Set("name", toolchainTool.Name); err != nil {
-			return diag.FromErr(fmt.Errorf("Error setting name: %s", err))
+			err = fmt.Errorf("Error setting name: %s", err)
+			return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cd_toolchain_tool_bitbucketgit", "read", "set-name").GetDiag()
 		}
 	}
 	remapFields := map[string]string{
@@ -347,35 +372,44 @@ func resourceIBMCdToolchainToolBitbucketgitRead(context context.Context, d *sche
 	}
 	parametersMap := GetParametersFromRead(toolchainTool.Parameters, ResourceIBMCdToolchainToolBitbucketgit(), remapFields)
 	if err = d.Set("parameters", []map[string]interface{}{parametersMap}); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting parameters: %s", err))
+		err = fmt.Errorf("Error setting parameters: %s", err)
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cd_toolchain_tool_bitbucketgit", "read", "set-parameters").GetDiag()
 	}
 	if err = d.Set("resource_group_id", toolchainTool.ResourceGroupID); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting resource_group_id: %s", err))
+		err = fmt.Errorf("Error setting resource_group_id: %s", err)
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cd_toolchain_tool_bitbucketgit", "read", "set-resource_group_id").GetDiag()
 	}
 	if err = d.Set("crn", toolchainTool.CRN); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting crn: %s", err))
+		err = fmt.Errorf("Error setting crn: %s", err)
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cd_toolchain_tool_bitbucketgit", "read", "set-crn").GetDiag()
 	}
 	if err = d.Set("toolchain_crn", toolchainTool.ToolchainCRN); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting toolchain_crn: %s", err))
+		err = fmt.Errorf("Error setting toolchain_crn: %s", err)
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cd_toolchain_tool_bitbucketgit", "read", "set-toolchain_crn").GetDiag()
 	}
 	if err = d.Set("href", toolchainTool.Href); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting href: %s", err))
+		err = fmt.Errorf("Error setting href: %s", err)
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cd_toolchain_tool_bitbucketgit", "read", "set-href").GetDiag()
 	}
-	referentMap, err := resourceIBMCdToolchainToolBitbucketgitToolModelReferentToMap(toolchainTool.Referent)
+	referentMap, err := ResourceIBMCdToolchainToolBitbucketgitToolModelReferentToMap(toolchainTool.Referent)
 	if err != nil {
-		return diag.FromErr(err)
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cd_toolchain_tool_bitbucketgit", "read", "referent-to-map").GetDiag()
 	}
 	if err = d.Set("referent", []map[string]interface{}{referentMap}); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting referent: %s", err))
+		err = fmt.Errorf("Error setting referent: %s", err)
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cd_toolchain_tool_bitbucketgit", "read", "set-referent").GetDiag()
 	}
 	if err = d.Set("updated_at", flex.DateTimeToString(toolchainTool.UpdatedAt)); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting updated_at: %s", err))
+		err = fmt.Errorf("Error setting updated_at: %s", err)
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cd_toolchain_tool_bitbucketgit", "read", "set-updated_at").GetDiag()
 	}
 	if err = d.Set("state", toolchainTool.State); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting state: %s", err))
+		err = fmt.Errorf("Error setting state: %s", err)
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cd_toolchain_tool_bitbucketgit", "read", "set-state").GetDiag()
 	}
 	if err = d.Set("tool_id", toolchainTool.ID); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting tool_id: %s", err))
+		err = fmt.Errorf("Error setting tool_id: %s", err)
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cd_toolchain_tool_bitbucketgit", "read", "set-tool_id").GetDiag()
 	}
 
 	return nil
@@ -384,14 +418,16 @@ func resourceIBMCdToolchainToolBitbucketgitRead(context context.Context, d *sche
 func resourceIBMCdToolchainToolBitbucketgitUpdate(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	cdToolchainClient, err := meta.(conns.ClientSession).CdToolchainV2()
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cd_toolchain_tool_bitbucketgit", "update", "initialize-client")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	updateToolOptions := &cdtoolchainv2.UpdateToolOptions{}
 
 	parts, err := flex.SepIdParts(d.Id(), "/")
 	if err != nil {
-		return diag.FromErr(err)
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cd_toolchain_tool_bitbucketgit", "update", "sep-id-parts").GetDiag()
 	}
 
 	updateToolOptions.SetToolchainID(parts[0])
@@ -401,8 +437,9 @@ func resourceIBMCdToolchainToolBitbucketgitUpdate(context context.Context, d *sc
 
 	patchVals := &cdtoolchainv2.ToolchainToolPrototypePatch{}
 	if d.HasChange("toolchain_id") {
-		return diag.FromErr(fmt.Errorf("Cannot update resource property \"%s\" with the ForceNew annotation."+
-			" The resource must be re-created to update this property.", "toolchain_id"))
+		errMsg := fmt.Sprintf("Cannot update resource property \"%s\" with the ForceNew annotation."+
+			" The resource must be re-created to update this property.", "toolchain_id")
+		return flex.DiscriminatedTerraformErrorf(nil, errMsg, "ibm_cd_toolchain_tool_bitbucketgit", "update", "toolchain_id-forces-new").GetDiag()
 	}
 	if d.HasChange("name") {
 		newName := d.Get("name").(string)
@@ -419,11 +456,16 @@ func resourceIBMCdToolchainToolBitbucketgitUpdate(context context.Context, d *sc
 	}
 
 	if hasChange {
-		updateToolOptions.ToolchainToolPrototypePatch, _ = patchVals.AsPatch()
-		_, response, err := cdToolchainClient.UpdateToolWithContext(context, updateToolOptions)
+		// Fields with `nil` values are omitted from the generic map,
+		// so we need to re-add them to support removing arguments
+		// in merge-patch operations sent to the service.
+		updateToolOptions.ToolchainToolPrototypePatch = ResourceIBMCdToolchainToolBitbucketgitToolchainToolPrototypePatchAsPatch(patchVals, d)
+
+		_, _, err = cdToolchainClient.UpdateToolWithContext(context, updateToolOptions)
 		if err != nil {
-			log.Printf("[DEBUG] UpdateToolWithContext failed %s\n%s", err, response)
-			return diag.FromErr(fmt.Errorf("UpdateToolWithContext failed %s\n%s", err, response))
+			tfErr := flex.TerraformErrorf(err, fmt.Sprintf("UpdateToolWithContext failed: %s", err.Error()), "ibm_cd_toolchain_tool_bitbucketgit", "update")
+			log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+			return tfErr.GetDiag()
 		}
 	}
 
@@ -433,23 +475,26 @@ func resourceIBMCdToolchainToolBitbucketgitUpdate(context context.Context, d *sc
 func resourceIBMCdToolchainToolBitbucketgitDelete(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	cdToolchainClient, err := meta.(conns.ClientSession).CdToolchainV2()
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cd_toolchain_tool_bitbucketgit", "delete", "initialize-client")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	deleteToolOptions := &cdtoolchainv2.DeleteToolOptions{}
 
 	parts, err := flex.SepIdParts(d.Id(), "/")
 	if err != nil {
-		return diag.FromErr(err)
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cd_toolchain_tool_bitbucketgit", "delete", "sep-id-parts").GetDiag()
 	}
 
 	deleteToolOptions.SetToolchainID(parts[0])
 	deleteToolOptions.SetToolID(parts[1])
 
-	response, err := cdToolchainClient.DeleteToolWithContext(context, deleteToolOptions)
+	_, err = cdToolchainClient.DeleteToolWithContext(context, deleteToolOptions)
 	if err != nil {
-		log.Printf("[DEBUG] DeleteToolWithContext failed %s\n%s", err, response)
-		return diag.FromErr(fmt.Errorf("DeleteToolWithContext failed %s\n%s", err, response))
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("DeleteToolWithContext failed: %s", err.Error()), "ibm_cd_toolchain_tool_bitbucketgit", "delete")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	d.SetId("")
@@ -457,13 +502,96 @@ func resourceIBMCdToolchainToolBitbucketgitDelete(context context.Context, d *sc
 	return nil
 }
 
-func resourceIBMCdToolchainToolBitbucketgitToolModelReferentToMap(model *cdtoolchainv2.ToolModelReferent) (map[string]interface{}, error) {
+func ResourceIBMCdToolchainToolBitbucketgitToolModelReferentToMap(model *cdtoolchainv2.ToolModelReferent) (map[string]interface{}, error) {
 	modelMap := make(map[string]interface{})
 	if model.UIHref != nil {
-		modelMap["ui_href"] = model.UIHref
+		modelMap["ui_href"] = *model.UIHref
 	}
 	if model.APIHref != nil {
-		modelMap["api_href"] = model.APIHref
+		modelMap["api_href"] = *model.APIHref
 	}
 	return modelMap, nil
+}
+
+func ResourceIBMCdToolchainToolBitbucketgitToolchainToolPrototypePatchAsPatch(patchVals *cdtoolchainv2.ToolchainToolPrototypePatch, d *schema.ResourceData) map[string]interface{} {
+	patch, _ := patchVals.AsPatch()
+	var path string
+
+	path = "name"
+	if _, exists := d.GetOk(path); d.HasChange(path) && !exists {
+		patch["name"] = nil
+	}
+	path = "tool_type_id"
+	if _, exists := d.GetOk(path); d.HasChange(path) && !exists {
+		patch["tool_type_id"] = nil
+	}
+	path = "parameters"
+	if _, exists := d.GetOk(path); d.HasChange(path) && !exists {
+		patch["parameters"] = nil
+	} else if exists && patch["parameters"] != nil {
+		ResourceIBMCdToolchainToolBitbucketgitToolModelParametersAsPatch(patch["parameters"].(map[string]interface{}), d)
+	}
+
+	return patch
+}
+
+func ResourceIBMCdToolchainToolBitbucketgitToolModelParametersAsPatch(patch map[string]interface{}, d *schema.ResourceData) {
+	var path string
+
+	path = "parameters.0.git_id"
+	if _, exists := d.GetOk(path); d.HasChange(path) && !exists {
+		patch["git_id"] = nil
+	}
+	path = "parameters.0.api_root_url"
+	if _, exists := d.GetOk(path); d.HasChange(path) && !exists {
+		patch["api_root_url"] = nil
+	}
+	path = "parameters.0.default_branch"
+	if _, exists := d.GetOk(path); d.HasChange(path) && !exists {
+		patch["default_branch"] = nil
+	}
+	path = "parameters.0.owner_id"
+	if _, exists := d.GetOk(path); d.HasChange(path) && !exists {
+		patch["owner_id"] = nil
+	}
+	path = "parameters.0.repo_name"
+	if _, exists := d.GetOk(path); d.HasChange(path) && !exists {
+		patch["repo_name"] = nil
+	}
+	path = "parameters.0.repo_url"
+	if _, exists := d.GetOk(path); d.HasChange(path) && !exists {
+		patch["repo_url"] = nil
+	}
+	path = "parameters.0.source_repo_url"
+	if _, exists := d.GetOk(path); d.HasChange(path) && !exists {
+		patch["source_repo_url"] = nil
+	}
+	path = "parameters.0.token_url"
+	if _, exists := d.GetOk(path); d.HasChange(path) && !exists {
+		patch["token_url"] = nil
+	}
+	path = "parameters.0.type"
+	if _, exists := d.GetOk(path); d.HasChange(path) && !exists {
+		patch["type"] = nil
+	}
+	path = "parameters.0.private_repo"
+	if _, exists := d.GetOk(path); d.HasChange(path) && !exists {
+		patch["private_repo"] = nil
+	}
+	path = "parameters.0.enable_traceability"
+	if _, exists := d.GetOk(path); d.HasChange(path) && !exists {
+		patch["enable_traceability"] = nil
+	}
+	path = "parameters.0.integration_owner"
+	if _, exists := d.GetOk(path); d.HasChange(path) && !exists {
+		patch["integration_owner"] = nil
+	}
+	path = "parameters.0.repo_id"
+	if _, exists := d.GetOk(path); d.HasChange(path) && !exists {
+		patch["repo_id"] = nil
+	}
+	path = "parameters.0.toolchain_issues_enabled"
+	if _, exists := d.GetOk(path); d.HasChange(path) && !exists {
+		patch["toolchain_issues_enabled"] = nil
+	}
 }

--- a/ibm/service/cdtoolchain/resource_ibm_cd_toolchain_tool_custom.go
+++ b/ibm/service/cdtoolchain/resource_ibm_cd_toolchain_tool_custom.go
@@ -1,5 +1,9 @@
-// Copyright IBM Corp. 2023 All Rights Reserved.
+// Copyright IBM Corp. 2024 All Rights Reserved.
 // Licensed under the Mozilla Public License v2.0
+
+/*
+ * IBM OpenAPI Terraform Generator Version: 3.96.0-d6dec9d7-20241008-212902
+ */
 
 package cdtoolchain
 
@@ -122,11 +126,13 @@ func ResourceIBMCdToolchainToolCustom() *schema.Resource {
 						"ui_href": &schema.Schema{
 							Type:        schema.TypeString,
 							Optional:    true,
+							Computed:    true,
 							Description: "URI representing this resource through the UI.",
 						},
 						"api_href": &schema.Schema{
 							Type:        schema.TypeString,
 							Optional:    true,
+							Computed:    true,
 							Description: "URI representing this resource through an API.",
 						},
 					},
@@ -181,7 +187,9 @@ func ResourceIBMCdToolchainToolCustomValidator() *validate.ResourceValidator {
 func resourceIBMCdToolchainToolCustomCreate(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	cdToolchainClient, err := meta.(conns.ClientSession).CdToolchainV2()
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cd_toolchain_tool_custom", "create", "initialize-client")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	createToolOptions := &cdtoolchainv2.CreateToolOptions{}
@@ -200,10 +208,11 @@ func resourceIBMCdToolchainToolCustomCreate(context context.Context, d *schema.R
 		createToolOptions.SetName(d.Get("name").(string))
 	}
 
-	toolchainToolPost, response, err := cdToolchainClient.CreateToolWithContext(context, createToolOptions)
+	toolchainToolPost, _, err := cdToolchainClient.CreateToolWithContext(context, createToolOptions)
 	if err != nil {
-		log.Printf("[DEBUG] CreateToolWithContext failed %s\n%s", err, response)
-		return diag.FromErr(fmt.Errorf("CreateToolWithContext failed %s\n%s", err, response))
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("CreateToolWithContext failed: %s", err.Error()), "ibm_cd_toolchain_tool_custom", "create")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	d.SetId(fmt.Sprintf("%s/%s", *createToolOptions.ToolchainID, *toolchainToolPost.ID))
@@ -214,14 +223,16 @@ func resourceIBMCdToolchainToolCustomCreate(context context.Context, d *schema.R
 func resourceIBMCdToolchainToolCustomRead(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	cdToolchainClient, err := meta.(conns.ClientSession).CdToolchainV2()
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cd_toolchain_tool_custom", "read", "initialize-client")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	getToolByIDOptions := &cdtoolchainv2.GetToolByIDOptions{}
 
 	parts, err := flex.SepIdParts(d.Id(), "/")
 	if err != nil {
-		return diag.FromErr(err)
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cd_toolchain_tool_custom", "read", "sep-id-parts").GetDiag()
 	}
 
 	getToolByIDOptions.SetToolchainID(parts[0])
@@ -247,16 +258,19 @@ func resourceIBMCdToolchainToolCustomRead(context context.Context, d *schema.Res
 			d.SetId("")
 			return nil
 		}
-		log.Printf("[DEBUG] GetToolByIDWithContext failed %s\n%s", err, response)
-		return diag.FromErr(fmt.Errorf("GetToolByIDWithContext failed %s\n%s", err, response))
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("GetToolByIDWithContext failed: %s", err.Error()), "ibm_cd_toolchain_tool_custom", "read")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	if err = d.Set("toolchain_id", toolchainTool.ToolchainID); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting toolchain_id: %s", err))
+		err = fmt.Errorf("Error setting toolchain_id: %s", err)
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cd_toolchain_tool_custom", "read", "set-toolchain_id").GetDiag()
 	}
 	if !core.IsNil(toolchainTool.Name) {
 		if err = d.Set("name", toolchainTool.Name); err != nil {
-			return diag.FromErr(fmt.Errorf("Error setting name: %s", err))
+			err = fmt.Errorf("Error setting name: %s", err)
+			return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cd_toolchain_tool_custom", "read", "set-name").GetDiag()
 		}
 	}
 	remapFields := map[string]string{
@@ -267,35 +281,44 @@ func resourceIBMCdToolchainToolCustomRead(context context.Context, d *schema.Res
 	}
 	parametersMap := GetParametersFromRead(toolchainTool.Parameters, ResourceIBMCdToolchainToolCustom(), remapFields)
 	if err = d.Set("parameters", []map[string]interface{}{parametersMap}); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting parameters: %s", err))
+		err = fmt.Errorf("Error setting parameters: %s", err)
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cd_toolchain_tool_custom", "read", "set-parameters").GetDiag()
 	}
 	if err = d.Set("resource_group_id", toolchainTool.ResourceGroupID); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting resource_group_id: %s", err))
+		err = fmt.Errorf("Error setting resource_group_id: %s", err)
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cd_toolchain_tool_custom", "read", "set-resource_group_id").GetDiag()
 	}
 	if err = d.Set("crn", toolchainTool.CRN); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting crn: %s", err))
+		err = fmt.Errorf("Error setting crn: %s", err)
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cd_toolchain_tool_custom", "read", "set-crn").GetDiag()
 	}
 	if err = d.Set("toolchain_crn", toolchainTool.ToolchainCRN); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting toolchain_crn: %s", err))
+		err = fmt.Errorf("Error setting toolchain_crn: %s", err)
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cd_toolchain_tool_custom", "read", "set-toolchain_crn").GetDiag()
 	}
 	if err = d.Set("href", toolchainTool.Href); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting href: %s", err))
+		err = fmt.Errorf("Error setting href: %s", err)
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cd_toolchain_tool_custom", "read", "set-href").GetDiag()
 	}
-	referentMap, err := resourceIBMCdToolchainToolCustomToolModelReferentToMap(toolchainTool.Referent)
+	referentMap, err := ResourceIBMCdToolchainToolCustomToolModelReferentToMap(toolchainTool.Referent)
 	if err != nil {
-		return diag.FromErr(err)
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cd_toolchain_tool_custom", "read", "referent-to-map").GetDiag()
 	}
 	if err = d.Set("referent", []map[string]interface{}{referentMap}); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting referent: %s", err))
+		err = fmt.Errorf("Error setting referent: %s", err)
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cd_toolchain_tool_custom", "read", "set-referent").GetDiag()
 	}
 	if err = d.Set("updated_at", flex.DateTimeToString(toolchainTool.UpdatedAt)); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting updated_at: %s", err))
+		err = fmt.Errorf("Error setting updated_at: %s", err)
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cd_toolchain_tool_custom", "read", "set-updated_at").GetDiag()
 	}
 	if err = d.Set("state", toolchainTool.State); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting state: %s", err))
+		err = fmt.Errorf("Error setting state: %s", err)
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cd_toolchain_tool_custom", "read", "set-state").GetDiag()
 	}
 	if err = d.Set("tool_id", toolchainTool.ID); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting tool_id: %s", err))
+		err = fmt.Errorf("Error setting tool_id: %s", err)
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cd_toolchain_tool_custom", "read", "set-tool_id").GetDiag()
 	}
 
 	return nil
@@ -304,14 +327,16 @@ func resourceIBMCdToolchainToolCustomRead(context context.Context, d *schema.Res
 func resourceIBMCdToolchainToolCustomUpdate(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	cdToolchainClient, err := meta.(conns.ClientSession).CdToolchainV2()
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cd_toolchain_tool_custom", "update", "initialize-client")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	updateToolOptions := &cdtoolchainv2.UpdateToolOptions{}
 
 	parts, err := flex.SepIdParts(d.Id(), "/")
 	if err != nil {
-		return diag.FromErr(err)
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cd_toolchain_tool_custom", "update", "sep-id-parts").GetDiag()
 	}
 
 	updateToolOptions.SetToolchainID(parts[0])
@@ -321,8 +346,9 @@ func resourceIBMCdToolchainToolCustomUpdate(context context.Context, d *schema.R
 
 	patchVals := &cdtoolchainv2.ToolchainToolPrototypePatch{}
 	if d.HasChange("toolchain_id") {
-		return diag.FromErr(fmt.Errorf("Cannot update resource property \"%s\" with the ForceNew annotation."+
-			" The resource must be re-created to update this property.", "toolchain_id"))
+		errMsg := fmt.Sprintf("Cannot update resource property \"%s\" with the ForceNew annotation."+
+			" The resource must be re-created to update this property.", "toolchain_id")
+		return flex.DiscriminatedTerraformErrorf(nil, errMsg, "ibm_cd_toolchain_tool_custom", "update", "toolchain_id-forces-new").GetDiag()
 	}
 	if d.HasChange("name") {
 		newName := d.Get("name").(string)
@@ -342,11 +368,16 @@ func resourceIBMCdToolchainToolCustomUpdate(context context.Context, d *schema.R
 	}
 
 	if hasChange {
-		updateToolOptions.ToolchainToolPrototypePatch, _ = patchVals.AsPatch()
-		_, response, err := cdToolchainClient.UpdateToolWithContext(context, updateToolOptions)
+		// Fields with `nil` values are omitted from the generic map,
+		// so we need to re-add them to support removing arguments
+		// in merge-patch operations sent to the service.
+		updateToolOptions.ToolchainToolPrototypePatch = ResourceIBMCdToolchainToolCustomToolchainToolPrototypePatchAsPatch(patchVals, d)
+
+		_, _, err = cdToolchainClient.UpdateToolWithContext(context, updateToolOptions)
 		if err != nil {
-			log.Printf("[DEBUG] UpdateToolWithContext failed %s\n%s", err, response)
-			return diag.FromErr(fmt.Errorf("UpdateToolWithContext failed %s\n%s", err, response))
+			tfErr := flex.TerraformErrorf(err, fmt.Sprintf("UpdateToolWithContext failed: %s", err.Error()), "ibm_cd_toolchain_tool_custom", "update")
+			log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+			return tfErr.GetDiag()
 		}
 	}
 
@@ -356,23 +387,26 @@ func resourceIBMCdToolchainToolCustomUpdate(context context.Context, d *schema.R
 func resourceIBMCdToolchainToolCustomDelete(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	cdToolchainClient, err := meta.(conns.ClientSession).CdToolchainV2()
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cd_toolchain_tool_custom", "delete", "initialize-client")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	deleteToolOptions := &cdtoolchainv2.DeleteToolOptions{}
 
 	parts, err := flex.SepIdParts(d.Id(), "/")
 	if err != nil {
-		return diag.FromErr(err)
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cd_toolchain_tool_custom", "delete", "sep-id-parts").GetDiag()
 	}
 
 	deleteToolOptions.SetToolchainID(parts[0])
 	deleteToolOptions.SetToolID(parts[1])
 
-	response, err := cdToolchainClient.DeleteToolWithContext(context, deleteToolOptions)
+	_, err = cdToolchainClient.DeleteToolWithContext(context, deleteToolOptions)
 	if err != nil {
-		log.Printf("[DEBUG] DeleteToolWithContext failed %s\n%s", err, response)
-		return diag.FromErr(fmt.Errorf("DeleteToolWithContext failed %s\n%s", err, response))
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("DeleteToolWithContext failed: %s", err.Error()), "ibm_cd_toolchain_tool_custom", "delete")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	d.SetId("")
@@ -380,13 +414,56 @@ func resourceIBMCdToolchainToolCustomDelete(context context.Context, d *schema.R
 	return nil
 }
 
-func resourceIBMCdToolchainToolCustomToolModelReferentToMap(model *cdtoolchainv2.ToolModelReferent) (map[string]interface{}, error) {
+func ResourceIBMCdToolchainToolCustomToolModelReferentToMap(model *cdtoolchainv2.ToolModelReferent) (map[string]interface{}, error) {
 	modelMap := make(map[string]interface{})
 	if model.UIHref != nil {
-		modelMap["ui_href"] = model.UIHref
+		modelMap["ui_href"] = *model.UIHref
 	}
 	if model.APIHref != nil {
-		modelMap["api_href"] = model.APIHref
+		modelMap["api_href"] = *model.APIHref
 	}
 	return modelMap, nil
+}
+
+func ResourceIBMCdToolchainToolCustomToolchainToolPrototypePatchAsPatch(patchVals *cdtoolchainv2.ToolchainToolPrototypePatch, d *schema.ResourceData) map[string]interface{} {
+	patch, _ := patchVals.AsPatch()
+	var path string
+
+	path = "name"
+	if _, exists := d.GetOk(path); d.HasChange(path) && !exists {
+		patch["name"] = nil
+	}
+	path = "tool_type_id"
+	if _, exists := d.GetOk(path); d.HasChange(path) && !exists {
+		patch["tool_type_id"] = nil
+	}
+	path = "parameters"
+	if _, exists := d.GetOk(path); d.HasChange(path) && !exists {
+		patch["parameters"] = nil
+	} else if exists && patch["parameters"] != nil {
+		ResourceIBMCdToolchainToolCustomToolModelParametersAsPatch(patch["parameters"].(map[string]interface{}), d)
+	}
+
+	return patch
+}
+
+func ResourceIBMCdToolchainToolCustomToolModelParametersAsPatch(patch map[string]interface{}, d *schema.ResourceData) {
+	var path string
+
+	path = "parameters.0.image_url"
+	if _, exists := d.GetOk(path); d.HasChange(path) && !exists {
+		patch["image_url"] = nil
+	}
+	path = "parameters.0.documentation_url"
+	if _, exists := d.GetOk(path); d.HasChange(path) && !exists {
+		patch["documentation_url"] = nil
+	}
+	path = "parameters.0.description"
+	if _, exists := d.GetOk(path); d.HasChange(path) && !exists {
+		patch["description"] = nil
+	}
+	path = "parameters.0.additional_properties"
+	if _, exists := d.GetOk(path); d.HasChange(path) && !exists {
+		patch["additional_properties"] = nil
+	}
 }

--- a/ibm/service/cdtoolchain/resource_ibm_cd_toolchain_tool_devopsinsights.go
+++ b/ibm/service/cdtoolchain/resource_ibm_cd_toolchain_tool_devopsinsights.go
@@ -1,5 +1,9 @@
-// Copyright IBM Corp. 2023 All Rights Reserved.
+// Copyright IBM Corp. 2024 All Rights Reserved.
 // Licensed under the Mozilla Public License v2.0
+
+/*
+ * IBM OpenAPI Terraform Generator Version: 3.96.0-d6dec9d7-20241008-212902
+ */
 
 package cdtoolchain
 
@@ -71,11 +75,13 @@ func ResourceIBMCdToolchainToolDevopsinsights() *schema.Resource {
 						"ui_href": &schema.Schema{
 							Type:        schema.TypeString,
 							Optional:    true,
+							Computed:    true,
 							Description: "URI representing this resource through the UI.",
 						},
 						"api_href": &schema.Schema{
 							Type:        schema.TypeString,
 							Optional:    true,
+							Computed:    true,
 							Description: "URI representing this resource through an API.",
 						},
 					},
@@ -130,7 +136,9 @@ func ResourceIBMCdToolchainToolDevopsinsightsValidator() *validate.ResourceValid
 func resourceIBMCdToolchainToolDevopsinsightsCreate(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	cdToolchainClient, err := meta.(conns.ClientSession).CdToolchainV2()
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cd_toolchain_tool_devopsinsights", "create", "initialize-client")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	createToolOptions := &cdtoolchainv2.CreateToolOptions{}
@@ -141,10 +149,11 @@ func resourceIBMCdToolchainToolDevopsinsightsCreate(context context.Context, d *
 		createToolOptions.SetName(d.Get("name").(string))
 	}
 
-	toolchainToolPost, response, err := cdToolchainClient.CreateToolWithContext(context, createToolOptions)
+	toolchainToolPost, _, err := cdToolchainClient.CreateToolWithContext(context, createToolOptions)
 	if err != nil {
-		log.Printf("[DEBUG] CreateToolWithContext failed %s\n%s", err, response)
-		return diag.FromErr(fmt.Errorf("CreateToolWithContext failed %s\n%s", err, response))
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("CreateToolWithContext failed: %s", err.Error()), "ibm_cd_toolchain_tool_devopsinsights", "create")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	d.SetId(fmt.Sprintf("%s/%s", *createToolOptions.ToolchainID, *toolchainToolPost.ID))
@@ -155,14 +164,16 @@ func resourceIBMCdToolchainToolDevopsinsightsCreate(context context.Context, d *
 func resourceIBMCdToolchainToolDevopsinsightsRead(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	cdToolchainClient, err := meta.(conns.ClientSession).CdToolchainV2()
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cd_toolchain_tool_devopsinsights", "read", "initialize-client")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	getToolByIDOptions := &cdtoolchainv2.GetToolByIDOptions{}
 
 	parts, err := flex.SepIdParts(d.Id(), "/")
 	if err != nil {
-		return diag.FromErr(err)
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cd_toolchain_tool_devopsinsights", "read", "sep-id-parts").GetDiag()
 	}
 
 	getToolByIDOptions.SetToolchainID(parts[0])
@@ -188,45 +199,56 @@ func resourceIBMCdToolchainToolDevopsinsightsRead(context context.Context, d *sc
 			d.SetId("")
 			return nil
 		}
-		log.Printf("[DEBUG] GetToolByIDWithContext failed %s\n%s", err, response)
-		return diag.FromErr(fmt.Errorf("GetToolByIDWithContext failed %s\n%s", err, response))
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("GetToolByIDWithContext failed: %s", err.Error()), "ibm_cd_toolchain_tool_devopsinsights", "read")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	if err = d.Set("toolchain_id", toolchainTool.ToolchainID); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting toolchain_id: %s", err))
+		err = fmt.Errorf("Error setting toolchain_id: %s", err)
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cd_toolchain_tool_devopsinsights", "read", "set-toolchain_id").GetDiag()
 	}
 	if !core.IsNil(toolchainTool.Name) {
 		if err = d.Set("name", toolchainTool.Name); err != nil {
-			return diag.FromErr(fmt.Errorf("Error setting name: %s", err))
+			err = fmt.Errorf("Error setting name: %s", err)
+			return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cd_toolchain_tool_devopsinsights", "read", "set-name").GetDiag()
 		}
 	}
 	if err = d.Set("resource_group_id", toolchainTool.ResourceGroupID); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting resource_group_id: %s", err))
+		err = fmt.Errorf("Error setting resource_group_id: %s", err)
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cd_toolchain_tool_devopsinsights", "read", "set-resource_group_id").GetDiag()
 	}
 	if err = d.Set("crn", toolchainTool.CRN); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting crn: %s", err))
+		err = fmt.Errorf("Error setting crn: %s", err)
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cd_toolchain_tool_devopsinsights", "read", "set-crn").GetDiag()
 	}
 	if err = d.Set("toolchain_crn", toolchainTool.ToolchainCRN); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting toolchain_crn: %s", err))
+		err = fmt.Errorf("Error setting toolchain_crn: %s", err)
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cd_toolchain_tool_devopsinsights", "read", "set-toolchain_crn").GetDiag()
 	}
 	if err = d.Set("href", toolchainTool.Href); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting href: %s", err))
+		err = fmt.Errorf("Error setting href: %s", err)
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cd_toolchain_tool_devopsinsights", "read", "set-href").GetDiag()
 	}
-	referentMap, err := resourceIBMCdToolchainToolDevopsinsightsToolModelReferentToMap(toolchainTool.Referent)
+	referentMap, err := ResourceIBMCdToolchainToolDevopsinsightsToolModelReferentToMap(toolchainTool.Referent)
 	if err != nil {
-		return diag.FromErr(err)
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cd_toolchain_tool_devopsinsights", "read", "referent-to-map").GetDiag()
 	}
 	if err = d.Set("referent", []map[string]interface{}{referentMap}); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting referent: %s", err))
+		err = fmt.Errorf("Error setting referent: %s", err)
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cd_toolchain_tool_devopsinsights", "read", "set-referent").GetDiag()
 	}
 	if err = d.Set("updated_at", flex.DateTimeToString(toolchainTool.UpdatedAt)); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting updated_at: %s", err))
+		err = fmt.Errorf("Error setting updated_at: %s", err)
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cd_toolchain_tool_devopsinsights", "read", "set-updated_at").GetDiag()
 	}
 	if err = d.Set("state", toolchainTool.State); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting state: %s", err))
+		err = fmt.Errorf("Error setting state: %s", err)
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cd_toolchain_tool_devopsinsights", "read", "set-state").GetDiag()
 	}
 	if err = d.Set("tool_id", toolchainTool.ID); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting tool_id: %s", err))
+		err = fmt.Errorf("Error setting tool_id: %s", err)
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cd_toolchain_tool_devopsinsights", "read", "set-tool_id").GetDiag()
 	}
 
 	return nil
@@ -235,14 +257,16 @@ func resourceIBMCdToolchainToolDevopsinsightsRead(context context.Context, d *sc
 func resourceIBMCdToolchainToolDevopsinsightsUpdate(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	cdToolchainClient, err := meta.(conns.ClientSession).CdToolchainV2()
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cd_toolchain_tool_devopsinsights", "update", "initialize-client")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	updateToolOptions := &cdtoolchainv2.UpdateToolOptions{}
 
 	parts, err := flex.SepIdParts(d.Id(), "/")
 	if err != nil {
-		return diag.FromErr(err)
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cd_toolchain_tool_devopsinsights", "update", "sep-id-parts").GetDiag()
 	}
 
 	updateToolOptions.SetToolchainID(parts[0])
@@ -252,8 +276,9 @@ func resourceIBMCdToolchainToolDevopsinsightsUpdate(context context.Context, d *
 
 	patchVals := &cdtoolchainv2.ToolchainToolPrototypePatch{}
 	if d.HasChange("toolchain_id") {
-		return diag.FromErr(fmt.Errorf("Cannot update resource property \"%s\" with the ForceNew annotation."+
-			" The resource must be re-created to update this property.", "toolchain_id"))
+		errMsg := fmt.Sprintf("Cannot update resource property \"%s\" with the ForceNew annotation."+
+			" The resource must be re-created to update this property.", "toolchain_id")
+		return flex.DiscriminatedTerraformErrorf(nil, errMsg, "ibm_cd_toolchain_tool_devopsinsights", "update", "toolchain_id-forces-new").GetDiag()
 	}
 	if d.HasChange("name") {
 		newName := d.Get("name").(string)
@@ -262,11 +287,16 @@ func resourceIBMCdToolchainToolDevopsinsightsUpdate(context context.Context, d *
 	}
 
 	if hasChange {
-		updateToolOptions.ToolchainToolPrototypePatch, _ = patchVals.AsPatch()
-		_, response, err := cdToolchainClient.UpdateToolWithContext(context, updateToolOptions)
+		// Fields with `nil` values are omitted from the generic map,
+		// so we need to re-add them to support removing arguments
+		// in merge-patch operations sent to the service.
+		updateToolOptions.ToolchainToolPrototypePatch = ResourceIBMCdToolchainToolDevopsinsightsToolchainToolPrototypePatchAsPatch(patchVals, d)
+
+		_, _, err = cdToolchainClient.UpdateToolWithContext(context, updateToolOptions)
 		if err != nil {
-			log.Printf("[DEBUG] UpdateToolWithContext failed %s\n%s", err, response)
-			return diag.FromErr(fmt.Errorf("UpdateToolWithContext failed %s\n%s", err, response))
+			tfErr := flex.TerraformErrorf(err, fmt.Sprintf("UpdateToolWithContext failed: %s", err.Error()), "ibm_cd_toolchain_tool_devopsinsights", "update")
+			log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+			return tfErr.GetDiag()
 		}
 	}
 
@@ -276,23 +306,26 @@ func resourceIBMCdToolchainToolDevopsinsightsUpdate(context context.Context, d *
 func resourceIBMCdToolchainToolDevopsinsightsDelete(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	cdToolchainClient, err := meta.(conns.ClientSession).CdToolchainV2()
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cd_toolchain_tool_devopsinsights", "delete", "initialize-client")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	deleteToolOptions := &cdtoolchainv2.DeleteToolOptions{}
 
 	parts, err := flex.SepIdParts(d.Id(), "/")
 	if err != nil {
-		return diag.FromErr(err)
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cd_toolchain_tool_devopsinsights", "delete", "sep-id-parts").GetDiag()
 	}
 
 	deleteToolOptions.SetToolchainID(parts[0])
 	deleteToolOptions.SetToolID(parts[1])
 
-	response, err := cdToolchainClient.DeleteToolWithContext(context, deleteToolOptions)
+	_, err = cdToolchainClient.DeleteToolWithContext(context, deleteToolOptions)
 	if err != nil {
-		log.Printf("[DEBUG] DeleteToolWithContext failed %s\n%s", err, response)
-		return diag.FromErr(fmt.Errorf("DeleteToolWithContext failed %s\n%s", err, response))
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("DeleteToolWithContext failed: %s", err.Error()), "ibm_cd_toolchain_tool_devopsinsights", "delete")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	d.SetId("")
@@ -300,13 +333,29 @@ func resourceIBMCdToolchainToolDevopsinsightsDelete(context context.Context, d *
 	return nil
 }
 
-func resourceIBMCdToolchainToolDevopsinsightsToolModelReferentToMap(model *cdtoolchainv2.ToolModelReferent) (map[string]interface{}, error) {
+func ResourceIBMCdToolchainToolDevopsinsightsToolModelReferentToMap(model *cdtoolchainv2.ToolModelReferent) (map[string]interface{}, error) {
 	modelMap := make(map[string]interface{})
 	if model.UIHref != nil {
-		modelMap["ui_href"] = model.UIHref
+		modelMap["ui_href"] = *model.UIHref
 	}
 	if model.APIHref != nil {
-		modelMap["api_href"] = model.APIHref
+		modelMap["api_href"] = *model.APIHref
 	}
 	return modelMap, nil
+}
+
+func ResourceIBMCdToolchainToolDevopsinsightsToolchainToolPrototypePatchAsPatch(patchVals *cdtoolchainv2.ToolchainToolPrototypePatch, d *schema.ResourceData) map[string]interface{} {
+	patch, _ := patchVals.AsPatch()
+	var path string
+
+	path = "name"
+	if _, exists := d.GetOk(path); d.HasChange(path) && !exists {
+		patch["name"] = nil
+	}
+	path = "tool_type_id"
+	if _, exists := d.GetOk(path); d.HasChange(path) && !exists {
+		patch["tool_type_id"] = nil
+	}
+
+	return patch
 }

--- a/ibm/service/cdtoolchain/resource_ibm_cd_toolchain_tool_eventnotifications.go
+++ b/ibm/service/cdtoolchain/resource_ibm_cd_toolchain_tool_eventnotifications.go
@@ -1,5 +1,9 @@
-// Copyright IBM Corp. 2023 All Rights Reserved.
+// Copyright IBM Corp. 2024 All Rights Reserved.
 // Licensed under the Mozilla Public License v2.0
+
+/*
+ * IBM OpenAPI Terraform Generator Version: 3.96.0-d6dec9d7-20241008-212902
+ */
 
 package cdtoolchain
 
@@ -92,11 +96,13 @@ func ResourceIBMCdToolchainToolEventnotifications() *schema.Resource {
 						"ui_href": &schema.Schema{
 							Type:        schema.TypeString,
 							Optional:    true,
+							Computed:    true,
 							Description: "URI representing this resource through the UI.",
 						},
 						"api_href": &schema.Schema{
 							Type:        schema.TypeString,
 							Optional:    true,
+							Computed:    true,
 							Description: "URI representing this resource through an API.",
 						},
 					},
@@ -151,7 +157,9 @@ func ResourceIBMCdToolchainToolEventnotificationsValidator() *validate.ResourceV
 func resourceIBMCdToolchainToolEventnotificationsCreate(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	cdToolchainClient, err := meta.(conns.ClientSession).CdToolchainV2()
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cd_toolchain_tool_eventnotifications", "create", "initialize-client")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	createToolOptions := &cdtoolchainv2.CreateToolOptions{}
@@ -167,10 +175,11 @@ func resourceIBMCdToolchainToolEventnotificationsCreate(context context.Context,
 		createToolOptions.SetName(d.Get("name").(string))
 	}
 
-	toolchainToolPost, response, err := cdToolchainClient.CreateToolWithContext(context, createToolOptions)
+	toolchainToolPost, _, err := cdToolchainClient.CreateToolWithContext(context, createToolOptions)
 	if err != nil {
-		log.Printf("[DEBUG] CreateToolWithContext failed %s\n%s", err, response)
-		return diag.FromErr(fmt.Errorf("CreateToolWithContext failed %s\n%s", err, response))
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("CreateToolWithContext failed: %s", err.Error()), "ibm_cd_toolchain_tool_eventnotifications", "create")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	d.SetId(fmt.Sprintf("%s/%s", *createToolOptions.ToolchainID, *toolchainToolPost.ID))
@@ -181,14 +190,16 @@ func resourceIBMCdToolchainToolEventnotificationsCreate(context context.Context,
 func resourceIBMCdToolchainToolEventnotificationsRead(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	cdToolchainClient, err := meta.(conns.ClientSession).CdToolchainV2()
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cd_toolchain_tool_eventnotifications", "read", "initialize-client")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	getToolByIDOptions := &cdtoolchainv2.GetToolByIDOptions{}
 
 	parts, err := flex.SepIdParts(d.Id(), "/")
 	if err != nil {
-		return diag.FromErr(err)
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cd_toolchain_tool_eventnotifications", "read", "sep-id-parts").GetDiag()
 	}
 
 	getToolByIDOptions.SetToolchainID(parts[0])
@@ -214,16 +225,19 @@ func resourceIBMCdToolchainToolEventnotificationsRead(context context.Context, d
 			d.SetId("")
 			return nil
 		}
-		log.Printf("[DEBUG] GetToolByIDWithContext failed %s\n%s", err, response)
-		return diag.FromErr(fmt.Errorf("GetToolByIDWithContext failed %s\n%s", err, response))
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("GetToolByIDWithContext failed: %s", err.Error()), "ibm_cd_toolchain_tool_eventnotifications", "read")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	if err = d.Set("toolchain_id", toolchainTool.ToolchainID); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting toolchain_id: %s", err))
+		err = fmt.Errorf("Error setting toolchain_id: %s", err)
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cd_toolchain_tool_eventnotifications", "read", "set-toolchain_id").GetDiag()
 	}
 	if !core.IsNil(toolchainTool.Name) {
 		if err = d.Set("name", toolchainTool.Name); err != nil {
-			return diag.FromErr(fmt.Errorf("Error setting name: %s", err))
+			err = fmt.Errorf("Error setting name: %s", err)
+			return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cd_toolchain_tool_eventnotifications", "read", "set-name").GetDiag()
 		}
 	}
 	remapFields := map[string]string{
@@ -231,35 +245,44 @@ func resourceIBMCdToolchainToolEventnotificationsRead(context context.Context, d
 	}
 	parametersMap := GetParametersFromRead(toolchainTool.Parameters, ResourceIBMCdToolchainToolEventnotifications(), remapFields)
 	if err = d.Set("parameters", []map[string]interface{}{parametersMap}); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting parameters: %s", err))
+		err = fmt.Errorf("Error setting parameters: %s", err)
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cd_toolchain_tool_eventnotifications", "read", "set-parameters").GetDiag()
 	}
 	if err = d.Set("resource_group_id", toolchainTool.ResourceGroupID); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting resource_group_id: %s", err))
+		err = fmt.Errorf("Error setting resource_group_id: %s", err)
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cd_toolchain_tool_eventnotifications", "read", "set-resource_group_id").GetDiag()
 	}
 	if err = d.Set("crn", toolchainTool.CRN); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting crn: %s", err))
+		err = fmt.Errorf("Error setting crn: %s", err)
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cd_toolchain_tool_eventnotifications", "read", "set-crn").GetDiag()
 	}
 	if err = d.Set("toolchain_crn", toolchainTool.ToolchainCRN); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting toolchain_crn: %s", err))
+		err = fmt.Errorf("Error setting toolchain_crn: %s", err)
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cd_toolchain_tool_eventnotifications", "read", "set-toolchain_crn").GetDiag()
 	}
 	if err = d.Set("href", toolchainTool.Href); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting href: %s", err))
+		err = fmt.Errorf("Error setting href: %s", err)
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cd_toolchain_tool_eventnotifications", "read", "set-href").GetDiag()
 	}
-	referentMap, err := resourceIBMCdToolchainToolEventnotificationsToolModelReferentToMap(toolchainTool.Referent)
+	referentMap, err := ResourceIBMCdToolchainToolEventnotificationsToolModelReferentToMap(toolchainTool.Referent)
 	if err != nil {
-		return diag.FromErr(err)
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cd_toolchain_tool_eventnotifications", "read", "referent-to-map").GetDiag()
 	}
 	if err = d.Set("referent", []map[string]interface{}{referentMap}); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting referent: %s", err))
+		err = fmt.Errorf("Error setting referent: %s", err)
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cd_toolchain_tool_eventnotifications", "read", "set-referent").GetDiag()
 	}
 	if err = d.Set("updated_at", flex.DateTimeToString(toolchainTool.UpdatedAt)); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting updated_at: %s", err))
+		err = fmt.Errorf("Error setting updated_at: %s", err)
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cd_toolchain_tool_eventnotifications", "read", "set-updated_at").GetDiag()
 	}
 	if err = d.Set("state", toolchainTool.State); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting state: %s", err))
+		err = fmt.Errorf("Error setting state: %s", err)
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cd_toolchain_tool_eventnotifications", "read", "set-state").GetDiag()
 	}
 	if err = d.Set("tool_id", toolchainTool.ID); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting tool_id: %s", err))
+		err = fmt.Errorf("Error setting tool_id: %s", err)
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cd_toolchain_tool_eventnotifications", "read", "set-tool_id").GetDiag()
 	}
 
 	return nil
@@ -268,14 +291,16 @@ func resourceIBMCdToolchainToolEventnotificationsRead(context context.Context, d
 func resourceIBMCdToolchainToolEventnotificationsUpdate(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	cdToolchainClient, err := meta.(conns.ClientSession).CdToolchainV2()
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cd_toolchain_tool_eventnotifications", "update", "initialize-client")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	updateToolOptions := &cdtoolchainv2.UpdateToolOptions{}
 
 	parts, err := flex.SepIdParts(d.Id(), "/")
 	if err != nil {
-		return diag.FromErr(err)
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cd_toolchain_tool_eventnotifications", "update", "sep-id-parts").GetDiag()
 	}
 
 	updateToolOptions.SetToolchainID(parts[0])
@@ -285,8 +310,9 @@ func resourceIBMCdToolchainToolEventnotificationsUpdate(context context.Context,
 
 	patchVals := &cdtoolchainv2.ToolchainToolPrototypePatch{}
 	if d.HasChange("toolchain_id") {
-		return diag.FromErr(fmt.Errorf("Cannot update resource property \"%s\" with the ForceNew annotation."+
-			" The resource must be re-created to update this property.", "toolchain_id"))
+		errMsg := fmt.Sprintf("Cannot update resource property \"%s\" with the ForceNew annotation."+
+			" The resource must be re-created to update this property.", "toolchain_id")
+		return flex.DiscriminatedTerraformErrorf(nil, errMsg, "ibm_cd_toolchain_tool_eventnotifications", "update", "toolchain_id-forces-new").GetDiag()
 	}
 	if d.HasChange("name") {
 		newName := d.Get("name").(string)
@@ -303,11 +329,16 @@ func resourceIBMCdToolchainToolEventnotificationsUpdate(context context.Context,
 	}
 
 	if hasChange {
-		updateToolOptions.ToolchainToolPrototypePatch, _ = patchVals.AsPatch()
-		_, response, err := cdToolchainClient.UpdateToolWithContext(context, updateToolOptions)
+		// Fields with `nil` values are omitted from the generic map,
+		// so we need to re-add them to support removing arguments
+		// in merge-patch operations sent to the service.
+		updateToolOptions.ToolchainToolPrototypePatch = ResourceIBMCdToolchainToolEventnotificationsToolchainToolPrototypePatchAsPatch(patchVals, d)
+
+		_, _, err = cdToolchainClient.UpdateToolWithContext(context, updateToolOptions)
 		if err != nil {
-			log.Printf("[DEBUG] UpdateToolWithContext failed %s\n%s", err, response)
-			return diag.FromErr(fmt.Errorf("UpdateToolWithContext failed %s\n%s", err, response))
+			tfErr := flex.TerraformErrorf(err, fmt.Sprintf("UpdateToolWithContext failed: %s", err.Error()), "ibm_cd_toolchain_tool_eventnotifications", "update")
+			log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+			return tfErr.GetDiag()
 		}
 	}
 
@@ -317,23 +348,26 @@ func resourceIBMCdToolchainToolEventnotificationsUpdate(context context.Context,
 func resourceIBMCdToolchainToolEventnotificationsDelete(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	cdToolchainClient, err := meta.(conns.ClientSession).CdToolchainV2()
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cd_toolchain_tool_eventnotifications", "delete", "initialize-client")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	deleteToolOptions := &cdtoolchainv2.DeleteToolOptions{}
 
 	parts, err := flex.SepIdParts(d.Id(), "/")
 	if err != nil {
-		return diag.FromErr(err)
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cd_toolchain_tool_eventnotifications", "delete", "sep-id-parts").GetDiag()
 	}
 
 	deleteToolOptions.SetToolchainID(parts[0])
 	deleteToolOptions.SetToolID(parts[1])
 
-	response, err := cdToolchainClient.DeleteToolWithContext(context, deleteToolOptions)
+	_, err = cdToolchainClient.DeleteToolWithContext(context, deleteToolOptions)
 	if err != nil {
-		log.Printf("[DEBUG] DeleteToolWithContext failed %s\n%s", err, response)
-		return diag.FromErr(fmt.Errorf("DeleteToolWithContext failed %s\n%s", err, response))
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("DeleteToolWithContext failed: %s", err.Error()), "ibm_cd_toolchain_tool_eventnotifications", "delete")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	d.SetId("")
@@ -341,13 +375,33 @@ func resourceIBMCdToolchainToolEventnotificationsDelete(context context.Context,
 	return nil
 }
 
-func resourceIBMCdToolchainToolEventnotificationsToolModelReferentToMap(model *cdtoolchainv2.ToolModelReferent) (map[string]interface{}, error) {
+func ResourceIBMCdToolchainToolEventnotificationsToolModelReferentToMap(model *cdtoolchainv2.ToolModelReferent) (map[string]interface{}, error) {
 	modelMap := make(map[string]interface{})
 	if model.UIHref != nil {
-		modelMap["ui_href"] = model.UIHref
+		modelMap["ui_href"] = *model.UIHref
 	}
 	if model.APIHref != nil {
-		modelMap["api_href"] = model.APIHref
+		modelMap["api_href"] = *model.APIHref
 	}
 	return modelMap, nil
+}
+
+func ResourceIBMCdToolchainToolEventnotificationsToolchainToolPrototypePatchAsPatch(patchVals *cdtoolchainv2.ToolchainToolPrototypePatch, d *schema.ResourceData) map[string]interface{} {
+	patch, _ := patchVals.AsPatch()
+	var path string
+
+	path = "name"
+	if _, exists := d.GetOk(path); d.HasChange(path) && !exists {
+		patch["name"] = nil
+	}
+	path = "tool_type_id"
+	if _, exists := d.GetOk(path); d.HasChange(path) && !exists {
+		patch["tool_type_id"] = nil
+	}
+	path = "parameters"
+	if _, exists := d.GetOk(path); d.HasChange(path) && !exists {
+		patch["parameters"] = nil
+	}
+
+	return patch
 }

--- a/ibm/service/cdtoolchain/resource_ibm_cd_toolchain_tool_githubconsolidated.go
+++ b/ibm/service/cdtoolchain/resource_ibm_cd_toolchain_tool_githubconsolidated.go
@@ -1,5 +1,9 @@
-// Copyright IBM Corp. 2023 All Rights Reserved.
+// Copyright IBM Corp. 2024 All Rights Reserved.
 // Licensed under the Mozilla Public License v2.0
+
+/*
+ * IBM OpenAPI Terraform Generator Version: 3.96.0-d6dec9d7-20241008-212902
+ */
 
 package cdtoolchain
 
@@ -52,71 +56,85 @@ func ResourceIBMCdToolchainToolGithubconsolidated() *schema.Resource {
 					Schema: map[string]*schema.Schema{
 						"git_id": &schema.Schema{
 							Type:        schema.TypeString,
+							Optional:    true,
 							Computed:    true,
 							Description: "Set this value to 'github' for github.com, or 'githubcustom' for a custom GitHub Enterprise server.",
 						},
 						"title": &schema.Schema{
 							Type:        schema.TypeString,
+							Optional:    true,
 							Computed:    true,
 							Description: "The title of the server. e.g. My GitHub Enterprise Server.",
 						},
 						"api_root_url": &schema.Schema{
 							Type:        schema.TypeString,
+							Optional:    true,
 							Computed:    true,
 							Description: "The API root URL for the GitHub server.",
 						},
 						"default_branch": &schema.Schema{
 							Type:        schema.TypeString,
+							Optional:    true,
 							Computed:    true,
 							Description: "The default branch of the git repository.",
 						},
 						"root_url": &schema.Schema{
 							Type:        schema.TypeString,
+							Optional:    true,
 							Computed:    true,
 							Description: "The Root URL of the server. e.g. https://github.example.com.",
 						},
 						"blind_connection": &schema.Schema{
 							Type:        schema.TypeBool,
+							Optional:    true,
 							Computed:    true,
 							Description: "Setting this value to true means the server is not addressable on the public internet. IBM Cloud will not be able to validate the connection details you provide. Certain functionality that requires API access to the git server will be disabled. Delivery pipeline will only work using a private worker that has network access to the git server.",
 						},
 						"owner_id": &schema.Schema{
 							Type:        schema.TypeString,
+							Optional:    true,
 							Computed:    true,
 							Description: "The GitHub user or organization that owns the repository.  This parameter is required when creating a new repository, cloning, or forking a repository.  The value will be computed when linking to an existing repository.",
 						},
 						"repo_name": &schema.Schema{
 							Type:        schema.TypeString,
+							Optional:    true,
 							Computed:    true,
 							Description: "The name of the new GitHub repository to create.  This parameter is required when creating a new repository, cloning, or forking a repository.  The value will be computed when linking to an existing repository.",
 						},
 						"repo_url": &schema.Schema{
 							Type:        schema.TypeString,
+							Optional:    true,
 							Computed:    true,
 							Description: "The URL of the GitHub repository for this tool integration.  This parameter is required when linking to an existing repository.  The value will be computed when creating a new repository, cloning, or forking a repository.",
 						},
 						"source_repo_url": &schema.Schema{
 							Type:        schema.TypeString,
+							Optional:    true,
 							Computed:    true,
 							Description: "The URL of the repository that you are forking or cloning.  This parameter is required when forking or cloning a repository.  It is not used when creating a new repository or linking to an existing repository.",
 						},
 						"token_url": &schema.Schema{
 							Type:        schema.TypeString,
+							Optional:    true,
 							Computed:    true,
 							Description: "The token URL used for authorizing with the GitHub server.",
 						},
 						"type": &schema.Schema{
 							Type:        schema.TypeString,
+							Optional:    true,
 							Computed:    true,
 							Description: "The operation that should be performed to initialize the new tool integration. Use 'new' or 'new_if_not_exists' to create a new git repository, 'clone' or 'clone_if_not_exists' to clone an existing repository into a new git repository, 'fork' or 'fork_if_not_exists' to fork an existing git repository, or 'link' to link to an existing git repository. If you attempt to apply a resource with type 'new', 'clone', or 'fork' when the target repo already exists, the attempt will fail. If you apply a resource with type 'new_if_not_exists`, 'clone_if_not_exists', or 'fork_if_not_exists' when the target repo already exists, the existing repo will be used as-is.",
 						},
 						"private_repo": &schema.Schema{
 							Type:        schema.TypeBool,
+							Optional:    true,
 							Computed:    true,
 							Description: "Set this value to 'true' to make the repository private when creating a new repository or when cloning or forking a repository.  This parameter is not used when linking to an existing repository.",
 						},
 						"auto_init": &schema.Schema{
 							Type:        schema.TypeBool,
+							Optional:    true,
 							Computed:    true,
 							Description: "Setting this value to true will initialize this repository with a README.  This parameter is only used when creating a new repository.",
 						},
@@ -134,6 +152,7 @@ func ResourceIBMCdToolchainToolGithubconsolidated() *schema.Resource {
 						},
 						"repo_id": &schema.Schema{
 							Type:        schema.TypeString,
+							Optional:    true,
 							Computed:    true,
 							Description: "The ID of the GitHub repository.",
 						},
@@ -266,11 +285,13 @@ func ResourceIBMCdToolchainToolGithubconsolidated() *schema.Resource {
 						"ui_href": &schema.Schema{
 							Type:        schema.TypeString,
 							Optional:    true,
+							Computed:    true,
 							Description: "URI representing this resource through the UI.",
 						},
 						"api_href": &schema.Schema{
 							Type:        schema.TypeString,
 							Optional:    true,
+							Computed:    true,
 							Description: "URI representing this resource through an API.",
 						},
 					},
@@ -325,7 +346,9 @@ func ResourceIBMCdToolchainToolGithubconsolidatedValidator() *validate.ResourceV
 func resourceIBMCdToolchainToolGithubconsolidatedCreate(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	cdToolchainClient, err := meta.(conns.ClientSession).CdToolchainV2()
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cd_toolchain_tool_githubconsolidated", "create", "initialize-client")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	createToolOptions := &cdtoolchainv2.CreateToolOptions{}
@@ -341,10 +364,11 @@ func resourceIBMCdToolchainToolGithubconsolidatedCreate(context context.Context,
 		createToolOptions.SetName(d.Get("name").(string))
 	}
 
-	toolchainToolPost, response, err := cdToolchainClient.CreateToolWithContext(context, createToolOptions)
+	toolchainToolPost, _, err := cdToolchainClient.CreateToolWithContext(context, createToolOptions)
 	if err != nil {
-		log.Printf("[DEBUG] CreateToolWithContext failed %s\n%s", err, response)
-		return diag.FromErr(fmt.Errorf("CreateToolWithContext failed %s\n%s", err, response))
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("CreateToolWithContext failed: %s", err.Error()), "ibm_cd_toolchain_tool_githubconsolidated", "create")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	d.SetId(fmt.Sprintf("%s/%s", *createToolOptions.ToolchainID, *toolchainToolPost.ID))
@@ -355,14 +379,16 @@ func resourceIBMCdToolchainToolGithubconsolidatedCreate(context context.Context,
 func resourceIBMCdToolchainToolGithubconsolidatedRead(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	cdToolchainClient, err := meta.(conns.ClientSession).CdToolchainV2()
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cd_toolchain_tool_githubconsolidated", "read", "initialize-client")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	getToolByIDOptions := &cdtoolchainv2.GetToolByIDOptions{}
 
 	parts, err := flex.SepIdParts(d.Id(), "/")
 	if err != nil {
-		return diag.FromErr(err)
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cd_toolchain_tool_githubconsolidated", "read", "sep-id-parts").GetDiag()
 	}
 
 	getToolByIDOptions.SetToolchainID(parts[0])
@@ -388,16 +414,19 @@ func resourceIBMCdToolchainToolGithubconsolidatedRead(context context.Context, d
 			d.SetId("")
 			return nil
 		}
-		log.Printf("[DEBUG] GetToolByIDWithContext failed %s\n%s", err, response)
-		return diag.FromErr(fmt.Errorf("GetToolByIDWithContext failed %s\n%s", err, response))
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("GetToolByIDWithContext failed: %s", err.Error()), "ibm_cd_toolchain_tool_githubconsolidated", "read")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	if err = d.Set("toolchain_id", toolchainTool.ToolchainID); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting toolchain_id: %s", err))
+		err = fmt.Errorf("Error setting toolchain_id: %s", err)
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cd_toolchain_tool_githubconsolidated", "read", "set-toolchain_id").GetDiag()
 	}
 	if !core.IsNil(toolchainTool.Name) {
 		if err = d.Set("name", toolchainTool.Name); err != nil {
-			return diag.FromErr(fmt.Errorf("Error setting name: %s", err))
+			err = fmt.Errorf("Error setting name: %s", err)
+			return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cd_toolchain_tool_githubconsolidated", "read", "set-name").GetDiag()
 		}
 	}
 	remapFields := map[string]string{
@@ -405,35 +434,44 @@ func resourceIBMCdToolchainToolGithubconsolidatedRead(context context.Context, d
 	}
 	parametersMap := GetParametersFromRead(toolchainTool.Parameters, ResourceIBMCdToolchainToolGithubconsolidated(), remapFields)
 	if err = d.Set("parameters", []map[string]interface{}{parametersMap}); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting parameters: %s", err))
+		err = fmt.Errorf("Error setting parameters: %s", err)
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cd_toolchain_tool_githubconsolidated", "read", "set-parameters").GetDiag()
 	}
 	if err = d.Set("resource_group_id", toolchainTool.ResourceGroupID); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting resource_group_id: %s", err))
+		err = fmt.Errorf("Error setting resource_group_id: %s", err)
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cd_toolchain_tool_githubconsolidated", "read", "set-resource_group_id").GetDiag()
 	}
 	if err = d.Set("crn", toolchainTool.CRN); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting crn: %s", err))
+		err = fmt.Errorf("Error setting crn: %s", err)
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cd_toolchain_tool_githubconsolidated", "read", "set-crn").GetDiag()
 	}
 	if err = d.Set("toolchain_crn", toolchainTool.ToolchainCRN); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting toolchain_crn: %s", err))
+		err = fmt.Errorf("Error setting toolchain_crn: %s", err)
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cd_toolchain_tool_githubconsolidated", "read", "set-toolchain_crn").GetDiag()
 	}
 	if err = d.Set("href", toolchainTool.Href); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting href: %s", err))
+		err = fmt.Errorf("Error setting href: %s", err)
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cd_toolchain_tool_githubconsolidated", "read", "set-href").GetDiag()
 	}
-	referentMap, err := resourceIBMCdToolchainToolGithubconsolidatedToolModelReferentToMap(toolchainTool.Referent)
+	referentMap, err := ResourceIBMCdToolchainToolGithubconsolidatedToolModelReferentToMap(toolchainTool.Referent)
 	if err != nil {
-		return diag.FromErr(err)
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cd_toolchain_tool_githubconsolidated", "read", "referent-to-map").GetDiag()
 	}
 	if err = d.Set("referent", []map[string]interface{}{referentMap}); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting referent: %s", err))
+		err = fmt.Errorf("Error setting referent: %s", err)
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cd_toolchain_tool_githubconsolidated", "read", "set-referent").GetDiag()
 	}
 	if err = d.Set("updated_at", flex.DateTimeToString(toolchainTool.UpdatedAt)); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting updated_at: %s", err))
+		err = fmt.Errorf("Error setting updated_at: %s", err)
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cd_toolchain_tool_githubconsolidated", "read", "set-updated_at").GetDiag()
 	}
 	if err = d.Set("state", toolchainTool.State); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting state: %s", err))
+		err = fmt.Errorf("Error setting state: %s", err)
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cd_toolchain_tool_githubconsolidated", "read", "set-state").GetDiag()
 	}
 	if err = d.Set("tool_id", toolchainTool.ID); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting tool_id: %s", err))
+		err = fmt.Errorf("Error setting tool_id: %s", err)
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cd_toolchain_tool_githubconsolidated", "read", "set-tool_id").GetDiag()
 	}
 
 	return nil
@@ -442,14 +480,16 @@ func resourceIBMCdToolchainToolGithubconsolidatedRead(context context.Context, d
 func resourceIBMCdToolchainToolGithubconsolidatedUpdate(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	cdToolchainClient, err := meta.(conns.ClientSession).CdToolchainV2()
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cd_toolchain_tool_githubconsolidated", "update", "initialize-client")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	updateToolOptions := &cdtoolchainv2.UpdateToolOptions{}
 
 	parts, err := flex.SepIdParts(d.Id(), "/")
 	if err != nil {
-		return diag.FromErr(err)
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cd_toolchain_tool_githubconsolidated", "update", "sep-id-parts").GetDiag()
 	}
 
 	updateToolOptions.SetToolchainID(parts[0])
@@ -459,8 +499,9 @@ func resourceIBMCdToolchainToolGithubconsolidatedUpdate(context context.Context,
 
 	patchVals := &cdtoolchainv2.ToolchainToolPrototypePatch{}
 	if d.HasChange("toolchain_id") {
-		return diag.FromErr(fmt.Errorf("Cannot update resource property \"%s\" with the ForceNew annotation."+
-			" The resource must be re-created to update this property.", "toolchain_id"))
+		errMsg := fmt.Sprintf("Cannot update resource property \"%s\" with the ForceNew annotation."+
+			" The resource must be re-created to update this property.", "toolchain_id")
+		return flex.DiscriminatedTerraformErrorf(nil, errMsg, "ibm_cd_toolchain_tool_githubconsolidated", "update", "toolchain_id-forces-new").GetDiag()
 	}
 	if d.HasChange("name") {
 		newName := d.Get("name").(string)
@@ -477,11 +518,16 @@ func resourceIBMCdToolchainToolGithubconsolidatedUpdate(context context.Context,
 	}
 
 	if hasChange {
-		updateToolOptions.ToolchainToolPrototypePatch, _ = patchVals.AsPatch()
-		_, response, err := cdToolchainClient.UpdateToolWithContext(context, updateToolOptions)
+		// Fields with `nil` values are omitted from the generic map,
+		// so we need to re-add them to support removing arguments
+		// in merge-patch operations sent to the service.
+		updateToolOptions.ToolchainToolPrototypePatch = ResourceIBMCdToolchainToolGithubconsolidatedToolchainToolPrototypePatchAsPatch(patchVals, d)
+
+		_, _, err = cdToolchainClient.UpdateToolWithContext(context, updateToolOptions)
 		if err != nil {
-			log.Printf("[DEBUG] UpdateToolWithContext failed %s\n%s", err, response)
-			return diag.FromErr(fmt.Errorf("UpdateToolWithContext failed %s\n%s", err, response))
+			tfErr := flex.TerraformErrorf(err, fmt.Sprintf("UpdateToolWithContext failed: %s", err.Error()), "ibm_cd_toolchain_tool_githubconsolidated", "update")
+			log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+			return tfErr.GetDiag()
 		}
 	}
 
@@ -491,23 +537,26 @@ func resourceIBMCdToolchainToolGithubconsolidatedUpdate(context context.Context,
 func resourceIBMCdToolchainToolGithubconsolidatedDelete(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	cdToolchainClient, err := meta.(conns.ClientSession).CdToolchainV2()
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cd_toolchain_tool_githubconsolidated", "delete", "initialize-client")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	deleteToolOptions := &cdtoolchainv2.DeleteToolOptions{}
 
 	parts, err := flex.SepIdParts(d.Id(), "/")
 	if err != nil {
-		return diag.FromErr(err)
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cd_toolchain_tool_githubconsolidated", "delete", "sep-id-parts").GetDiag()
 	}
 
 	deleteToolOptions.SetToolchainID(parts[0])
 	deleteToolOptions.SetToolID(parts[1])
 
-	response, err := cdToolchainClient.DeleteToolWithContext(context, deleteToolOptions)
+	_, err = cdToolchainClient.DeleteToolWithContext(context, deleteToolOptions)
 	if err != nil {
-		log.Printf("[DEBUG] DeleteToolWithContext failed %s\n%s", err, response)
-		return diag.FromErr(fmt.Errorf("DeleteToolWithContext failed %s\n%s", err, response))
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("DeleteToolWithContext failed: %s", err.Error()), "ibm_cd_toolchain_tool_githubconsolidated", "delete")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	d.SetId("")
@@ -515,13 +564,120 @@ func resourceIBMCdToolchainToolGithubconsolidatedDelete(context context.Context,
 	return nil
 }
 
-func resourceIBMCdToolchainToolGithubconsolidatedToolModelReferentToMap(model *cdtoolchainv2.ToolModelReferent) (map[string]interface{}, error) {
+func ResourceIBMCdToolchainToolGithubconsolidatedToolModelReferentToMap(model *cdtoolchainv2.ToolModelReferent) (map[string]interface{}, error) {
 	modelMap := make(map[string]interface{})
 	if model.UIHref != nil {
-		modelMap["ui_href"] = model.UIHref
+		modelMap["ui_href"] = *model.UIHref
 	}
 	if model.APIHref != nil {
-		modelMap["api_href"] = model.APIHref
+		modelMap["api_href"] = *model.APIHref
 	}
 	return modelMap, nil
+}
+
+func ResourceIBMCdToolchainToolGithubconsolidatedToolchainToolPrototypePatchAsPatch(patchVals *cdtoolchainv2.ToolchainToolPrototypePatch, d *schema.ResourceData) map[string]interface{} {
+	patch, _ := patchVals.AsPatch()
+	var path string
+
+	path = "name"
+	if _, exists := d.GetOk(path); d.HasChange(path) && !exists {
+		patch["name"] = nil
+	}
+	path = "tool_type_id"
+	if _, exists := d.GetOk(path); d.HasChange(path) && !exists {
+		patch["tool_type_id"] = nil
+	}
+	path = "parameters"
+	if _, exists := d.GetOk(path); d.HasChange(path) && !exists {
+		patch["parameters"] = nil
+	} else if exists && patch["parameters"] != nil {
+		ResourceIBMCdToolchainToolGithubconsolidatedToolModelParametersAsPatch(patch["parameters"].(map[string]interface{}), d)
+	}
+
+	return patch
+}
+
+func ResourceIBMCdToolchainToolGithubconsolidatedToolModelParametersAsPatch(patch map[string]interface{}, d *schema.ResourceData) {
+	var path string
+
+	path = "parameters.0.git_id"
+	if _, exists := d.GetOk(path); d.HasChange(path) && !exists {
+		patch["git_id"] = nil
+	}
+	path = "parameters.0.title"
+	if _, exists := d.GetOk(path); d.HasChange(path) && !exists {
+		patch["title"] = nil
+	}
+	path = "parameters.0.api_root_url"
+	if _, exists := d.GetOk(path); d.HasChange(path) && !exists {
+		patch["api_root_url"] = nil
+	}
+	path = "parameters.0.default_branch"
+	if _, exists := d.GetOk(path); d.HasChange(path) && !exists {
+		patch["default_branch"] = nil
+	}
+	path = "parameters.0.root_url"
+	if _, exists := d.GetOk(path); d.HasChange(path) && !exists {
+		patch["root_url"] = nil
+	}
+	path = "parameters.0.blind_connection"
+	if _, exists := d.GetOk(path); d.HasChange(path) && !exists {
+		patch["blind_connection"] = nil
+	}
+	path = "parameters.0.owner_id"
+	if _, exists := d.GetOk(path); d.HasChange(path) && !exists {
+		patch["owner_id"] = nil
+	}
+	path = "parameters.0.repo_name"
+	if _, exists := d.GetOk(path); d.HasChange(path) && !exists {
+		patch["repo_name"] = nil
+	}
+	path = "parameters.0.repo_url"
+	if _, exists := d.GetOk(path); d.HasChange(path) && !exists {
+		patch["repo_url"] = nil
+	}
+	path = "parameters.0.source_repo_url"
+	if _, exists := d.GetOk(path); d.HasChange(path) && !exists {
+		patch["source_repo_url"] = nil
+	}
+	path = "parameters.0.token_url"
+	if _, exists := d.GetOk(path); d.HasChange(path) && !exists {
+		patch["token_url"] = nil
+	}
+	path = "parameters.0.type"
+	if _, exists := d.GetOk(path); d.HasChange(path) && !exists {
+		patch["type"] = nil
+	}
+	path = "parameters.0.private_repo"
+	if _, exists := d.GetOk(path); d.HasChange(path) && !exists {
+		patch["private_repo"] = nil
+	}
+	path = "parameters.0.auto_init"
+	if _, exists := d.GetOk(path); d.HasChange(path) && !exists {
+		patch["auto_init"] = nil
+	}
+	path = "parameters.0.enable_traceability"
+	if _, exists := d.GetOk(path); d.HasChange(path) && !exists {
+		patch["enable_traceability"] = nil
+	}
+	path = "parameters.0.integration_owner"
+	if _, exists := d.GetOk(path); d.HasChange(path) && !exists {
+		patch["integration_owner"] = nil
+	}
+	path = "parameters.0.repo_id"
+	if _, exists := d.GetOk(path); d.HasChange(path) && !exists {
+		patch["repo_id"] = nil
+	}
+	path = "parameters.0.auth_type"
+	if _, exists := d.GetOk(path); d.HasChange(path) && !exists {
+		patch["auth_type"] = nil
+	}
+	path = "parameters.0.api_token"
+	if _, exists := d.GetOk(path); d.HasChange(path) && !exists {
+		patch["api_token"] = nil
+	}
+	path = "parameters.0.toolchain_issues_enabled"
+	if _, exists := d.GetOk(path); d.HasChange(path) && !exists {
+		patch["toolchain_issues_enabled"] = nil
+	}
 }

--- a/ibm/service/cdtoolchain/resource_ibm_cd_toolchain_tool_gitlab.go
+++ b/ibm/service/cdtoolchain/resource_ibm_cd_toolchain_tool_gitlab.go
@@ -1,5 +1,9 @@
-// Copyright IBM Corp. 2023 All Rights Reserved.
+// Copyright IBM Corp. 2024 All Rights Reserved.
 // Licensed under the Mozilla Public License v2.0
+
+/*
+ * IBM OpenAPI Terraform Generator Version: 3.96.0-d6dec9d7-20241008-212902
+ */
 
 package cdtoolchain
 
@@ -52,66 +56,79 @@ func ResourceIBMCdToolchainToolGitlab() *schema.Resource {
 					Schema: map[string]*schema.Schema{
 						"git_id": &schema.Schema{
 							Type:        schema.TypeString,
+							Optional:    true,
 							Computed:    true,
 							Description: "Set this value to 'gitlab' for gitlab.com, or 'gitlabcustom' for a custom GitLab server.",
 						},
 						"title": &schema.Schema{
 							Type:        schema.TypeString,
+							Optional:    true,
 							Computed:    true,
 							Description: "The title of the server. e.g. My GitLab Enterprise Server.",
 						},
 						"api_root_url": &schema.Schema{
 							Type:        schema.TypeString,
+							Optional:    true,
 							Computed:    true,
 							Description: "The API root URL for the GitLab Server.",
 						},
 						"default_branch": &schema.Schema{
 							Type:        schema.TypeString,
+							Optional:    true,
 							Computed:    true,
 							Description: "The default branch of the git repository.",
 						},
 						"root_url": &schema.Schema{
 							Type:        schema.TypeString,
+							Optional:    true,
 							Computed:    true,
 							Description: "The Root URL of the server. e.g. https://gitlab.example.com.",
 						},
 						"blind_connection": &schema.Schema{
 							Type:        schema.TypeBool,
+							Optional:    true,
 							Computed:    true,
 							Description: "Setting this value to true means the server is not addressable on the public internet. IBM Cloud will not be able to validate the connection details you provide. Certain functionality that requires API access to the git server will be disabled. Delivery pipeline will only work using a private worker that has network access to the git server.",
 						},
 						"owner_id": &schema.Schema{
 							Type:        schema.TypeString,
+							Optional:    true,
 							Computed:    true,
 							Description: "The GitLab user or group that owns the repository.  This parameter is required when creating a new repository, cloning, or forking a repository.  The value will be computed when linking to an existing repository.",
 						},
 						"repo_name": &schema.Schema{
 							Type:        schema.TypeString,
+							Optional:    true,
 							Computed:    true,
 							Description: "The name of the new GitLab repository to create.  This parameter is required when creating a new repository, cloning, or forking a repository.  The value will be computed when linking to an existing repository.",
 						},
 						"repo_url": &schema.Schema{
 							Type:        schema.TypeString,
+							Optional:    true,
 							Computed:    true,
 							Description: "The URL of the GitLab repository for this tool integration.  This parameter is required when linking to an existing repository.  The value will be computed when creating a new repository, cloning, or forking a repository.",
 						},
 						"source_repo_url": &schema.Schema{
 							Type:        schema.TypeString,
+							Optional:    true,
 							Computed:    true,
 							Description: "The URL of the repository that you are forking or cloning.  This parameter is required when forking or cloning a repository.  It is not used when creating a new repository or linking to an existing repository.",
 						},
 						"token_url": &schema.Schema{
 							Type:        schema.TypeString,
+							Optional:    true,
 							Computed:    true,
 							Description: "The token URL used for authorizing with the GitLab server.",
 						},
 						"type": &schema.Schema{
 							Type:        schema.TypeString,
+							Optional:    true,
 							Computed:    true,
 							Description: "The operation that should be performed to initialize the new tool integration. Use 'new' or 'new_if_not_exists' to create a new git repository, 'clone' or 'clone_if_not_exists' to clone an existing repository into a new git repository, 'fork' or 'fork_if_not_exists' to fork an existing git repository, or 'link' to link to an existing git repository. If you attempt to apply a resource with type 'new', 'clone', or 'fork' when the target repo already exists, the attempt will fail. If you apply a resource with type 'new_if_not_exists`, 'clone_if_not_exists', or 'fork_if_not_exists' when the target repo already exists, the existing repo will be used as-is.",
 						},
 						"private_repo": &schema.Schema{
 							Type:        schema.TypeBool,
+							Optional:    true,
 							Computed:    true,
 							Description: "Set this value to 'true' to make the repository private when creating a new repository or when cloning or forking a repository.  This parameter is not used when linking to an existing repository.",
 						},
@@ -129,6 +146,7 @@ func ResourceIBMCdToolchainToolGitlab() *schema.Resource {
 						},
 						"repo_id": &schema.Schema{
 							Type:        schema.TypeString,
+							Optional:    true,
 							Computed:    true,
 							Description: "The ID of the GitLab project.",
 						},
@@ -254,11 +272,13 @@ func ResourceIBMCdToolchainToolGitlab() *schema.Resource {
 						"ui_href": &schema.Schema{
 							Type:        schema.TypeString,
 							Optional:    true,
+							Computed:    true,
 							Description: "URI representing this resource through the UI.",
 						},
 						"api_href": &schema.Schema{
 							Type:        schema.TypeString,
 							Optional:    true,
+							Computed:    true,
 							Description: "URI representing this resource through an API.",
 						},
 					},
@@ -313,7 +333,9 @@ func ResourceIBMCdToolchainToolGitlabValidator() *validate.ResourceValidator {
 func resourceIBMCdToolchainToolGitlabCreate(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	cdToolchainClient, err := meta.(conns.ClientSession).CdToolchainV2()
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cd_toolchain_tool_gitlab", "create", "initialize-client")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	createToolOptions := &cdtoolchainv2.CreateToolOptions{}
@@ -329,10 +351,11 @@ func resourceIBMCdToolchainToolGitlabCreate(context context.Context, d *schema.R
 		createToolOptions.SetName(d.Get("name").(string))
 	}
 
-	toolchainToolPost, response, err := cdToolchainClient.CreateToolWithContext(context, createToolOptions)
+	toolchainToolPost, _, err := cdToolchainClient.CreateToolWithContext(context, createToolOptions)
 	if err != nil {
-		log.Printf("[DEBUG] CreateToolWithContext failed %s\n%s", err, response)
-		return diag.FromErr(fmt.Errorf("CreateToolWithContext failed %s\n%s", err, response))
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("CreateToolWithContext failed: %s", err.Error()), "ibm_cd_toolchain_tool_gitlab", "create")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	d.SetId(fmt.Sprintf("%s/%s", *createToolOptions.ToolchainID, *toolchainToolPost.ID))
@@ -343,14 +366,16 @@ func resourceIBMCdToolchainToolGitlabCreate(context context.Context, d *schema.R
 func resourceIBMCdToolchainToolGitlabRead(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	cdToolchainClient, err := meta.(conns.ClientSession).CdToolchainV2()
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cd_toolchain_tool_gitlab", "read", "initialize-client")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	getToolByIDOptions := &cdtoolchainv2.GetToolByIDOptions{}
 
 	parts, err := flex.SepIdParts(d.Id(), "/")
 	if err != nil {
-		return diag.FromErr(err)
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cd_toolchain_tool_gitlab", "read", "sep-id-parts").GetDiag()
 	}
 
 	getToolByIDOptions.SetToolchainID(parts[0])
@@ -376,16 +401,19 @@ func resourceIBMCdToolchainToolGitlabRead(context context.Context, d *schema.Res
 			d.SetId("")
 			return nil
 		}
-		log.Printf("[DEBUG] GetToolByIDWithContext failed %s\n%s", err, response)
-		return diag.FromErr(fmt.Errorf("GetToolByIDWithContext failed %s\n%s", err, response))
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("GetToolByIDWithContext failed: %s", err.Error()), "ibm_cd_toolchain_tool_gitlab", "read")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	if err = d.Set("toolchain_id", toolchainTool.ToolchainID); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting toolchain_id: %s", err))
+		err = fmt.Errorf("Error setting toolchain_id: %s", err)
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cd_toolchain_tool_gitlab", "read", "set-toolchain_id").GetDiag()
 	}
 	if !core.IsNil(toolchainTool.Name) {
 		if err = d.Set("name", toolchainTool.Name); err != nil {
-			return diag.FromErr(fmt.Errorf("Error setting name: %s", err))
+			err = fmt.Errorf("Error setting name: %s", err)
+			return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cd_toolchain_tool_gitlab", "read", "set-name").GetDiag()
 		}
 	}
 	remapFields := map[string]string{
@@ -393,35 +421,44 @@ func resourceIBMCdToolchainToolGitlabRead(context context.Context, d *schema.Res
 	}
 	parametersMap := GetParametersFromRead(toolchainTool.Parameters, ResourceIBMCdToolchainToolGitlab(), remapFields)
 	if err = d.Set("parameters", []map[string]interface{}{parametersMap}); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting parameters: %s", err))
+		err = fmt.Errorf("Error setting parameters: %s", err)
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cd_toolchain_tool_gitlab", "read", "set-parameters").GetDiag()
 	}
 	if err = d.Set("resource_group_id", toolchainTool.ResourceGroupID); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting resource_group_id: %s", err))
+		err = fmt.Errorf("Error setting resource_group_id: %s", err)
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cd_toolchain_tool_gitlab", "read", "set-resource_group_id").GetDiag()
 	}
 	if err = d.Set("crn", toolchainTool.CRN); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting crn: %s", err))
+		err = fmt.Errorf("Error setting crn: %s", err)
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cd_toolchain_tool_gitlab", "read", "set-crn").GetDiag()
 	}
 	if err = d.Set("toolchain_crn", toolchainTool.ToolchainCRN); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting toolchain_crn: %s", err))
+		err = fmt.Errorf("Error setting toolchain_crn: %s", err)
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cd_toolchain_tool_gitlab", "read", "set-toolchain_crn").GetDiag()
 	}
 	if err = d.Set("href", toolchainTool.Href); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting href: %s", err))
+		err = fmt.Errorf("Error setting href: %s", err)
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cd_toolchain_tool_gitlab", "read", "set-href").GetDiag()
 	}
-	referentMap, err := resourceIBMCdToolchainToolGitlabToolModelReferentToMap(toolchainTool.Referent)
+	referentMap, err := ResourceIBMCdToolchainToolGitlabToolModelReferentToMap(toolchainTool.Referent)
 	if err != nil {
-		return diag.FromErr(err)
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cd_toolchain_tool_gitlab", "read", "referent-to-map").GetDiag()
 	}
 	if err = d.Set("referent", []map[string]interface{}{referentMap}); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting referent: %s", err))
+		err = fmt.Errorf("Error setting referent: %s", err)
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cd_toolchain_tool_gitlab", "read", "set-referent").GetDiag()
 	}
 	if err = d.Set("updated_at", flex.DateTimeToString(toolchainTool.UpdatedAt)); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting updated_at: %s", err))
+		err = fmt.Errorf("Error setting updated_at: %s", err)
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cd_toolchain_tool_gitlab", "read", "set-updated_at").GetDiag()
 	}
 	if err = d.Set("state", toolchainTool.State); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting state: %s", err))
+		err = fmt.Errorf("Error setting state: %s", err)
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cd_toolchain_tool_gitlab", "read", "set-state").GetDiag()
 	}
 	if err = d.Set("tool_id", toolchainTool.ID); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting tool_id: %s", err))
+		err = fmt.Errorf("Error setting tool_id: %s", err)
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cd_toolchain_tool_gitlab", "read", "set-tool_id").GetDiag()
 	}
 
 	return nil
@@ -430,14 +467,16 @@ func resourceIBMCdToolchainToolGitlabRead(context context.Context, d *schema.Res
 func resourceIBMCdToolchainToolGitlabUpdate(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	cdToolchainClient, err := meta.(conns.ClientSession).CdToolchainV2()
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cd_toolchain_tool_gitlab", "update", "initialize-client")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	updateToolOptions := &cdtoolchainv2.UpdateToolOptions{}
 
 	parts, err := flex.SepIdParts(d.Id(), "/")
 	if err != nil {
-		return diag.FromErr(err)
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cd_toolchain_tool_gitlab", "update", "sep-id-parts").GetDiag()
 	}
 
 	updateToolOptions.SetToolchainID(parts[0])
@@ -447,8 +486,9 @@ func resourceIBMCdToolchainToolGitlabUpdate(context context.Context, d *schema.R
 
 	patchVals := &cdtoolchainv2.ToolchainToolPrototypePatch{}
 	if d.HasChange("toolchain_id") {
-		return diag.FromErr(fmt.Errorf("Cannot update resource property \"%s\" with the ForceNew annotation."+
-			" The resource must be re-created to update this property.", "toolchain_id"))
+		errMsg := fmt.Sprintf("Cannot update resource property \"%s\" with the ForceNew annotation."+
+			" The resource must be re-created to update this property.", "toolchain_id")
+		return flex.DiscriminatedTerraformErrorf(nil, errMsg, "ibm_cd_toolchain_tool_gitlab", "update", "toolchain_id-forces-new").GetDiag()
 	}
 	if d.HasChange("name") {
 		newName := d.Get("name").(string)
@@ -465,11 +505,16 @@ func resourceIBMCdToolchainToolGitlabUpdate(context context.Context, d *schema.R
 	}
 
 	if hasChange {
-		updateToolOptions.ToolchainToolPrototypePatch, _ = patchVals.AsPatch()
-		_, response, err := cdToolchainClient.UpdateToolWithContext(context, updateToolOptions)
+		// Fields with `nil` values are omitted from the generic map,
+		// so we need to re-add them to support removing arguments
+		// in merge-patch operations sent to the service.
+		updateToolOptions.ToolchainToolPrototypePatch = ResourceIBMCdToolchainToolGitlabToolchainToolPrototypePatchAsPatch(patchVals, d)
+
+		_, _, err = cdToolchainClient.UpdateToolWithContext(context, updateToolOptions)
 		if err != nil {
-			log.Printf("[DEBUG] UpdateToolWithContext failed %s\n%s", err, response)
-			return diag.FromErr(fmt.Errorf("UpdateToolWithContext failed %s\n%s", err, response))
+			tfErr := flex.TerraformErrorf(err, fmt.Sprintf("UpdateToolWithContext failed: %s", err.Error()), "ibm_cd_toolchain_tool_gitlab", "update")
+			log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+			return tfErr.GetDiag()
 		}
 	}
 
@@ -479,23 +524,26 @@ func resourceIBMCdToolchainToolGitlabUpdate(context context.Context, d *schema.R
 func resourceIBMCdToolchainToolGitlabDelete(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	cdToolchainClient, err := meta.(conns.ClientSession).CdToolchainV2()
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cd_toolchain_tool_gitlab", "delete", "initialize-client")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	deleteToolOptions := &cdtoolchainv2.DeleteToolOptions{}
 
 	parts, err := flex.SepIdParts(d.Id(), "/")
 	if err != nil {
-		return diag.FromErr(err)
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cd_toolchain_tool_gitlab", "delete", "sep-id-parts").GetDiag()
 	}
 
 	deleteToolOptions.SetToolchainID(parts[0])
 	deleteToolOptions.SetToolID(parts[1])
 
-	response, err := cdToolchainClient.DeleteToolWithContext(context, deleteToolOptions)
+	_, err = cdToolchainClient.DeleteToolWithContext(context, deleteToolOptions)
 	if err != nil {
-		log.Printf("[DEBUG] DeleteToolWithContext failed %s\n%s", err, response)
-		return diag.FromErr(fmt.Errorf("DeleteToolWithContext failed %s\n%s", err, response))
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("DeleteToolWithContext failed: %s", err.Error()), "ibm_cd_toolchain_tool_gitlab", "delete")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	d.SetId("")
@@ -503,13 +551,116 @@ func resourceIBMCdToolchainToolGitlabDelete(context context.Context, d *schema.R
 	return nil
 }
 
-func resourceIBMCdToolchainToolGitlabToolModelReferentToMap(model *cdtoolchainv2.ToolModelReferent) (map[string]interface{}, error) {
+func ResourceIBMCdToolchainToolGitlabToolModelReferentToMap(model *cdtoolchainv2.ToolModelReferent) (map[string]interface{}, error) {
 	modelMap := make(map[string]interface{})
 	if model.UIHref != nil {
-		modelMap["ui_href"] = model.UIHref
+		modelMap["ui_href"] = *model.UIHref
 	}
 	if model.APIHref != nil {
-		modelMap["api_href"] = model.APIHref
+		modelMap["api_href"] = *model.APIHref
 	}
 	return modelMap, nil
+}
+
+func ResourceIBMCdToolchainToolGitlabToolchainToolPrototypePatchAsPatch(patchVals *cdtoolchainv2.ToolchainToolPrototypePatch, d *schema.ResourceData) map[string]interface{} {
+	patch, _ := patchVals.AsPatch()
+	var path string
+
+	path = "name"
+	if _, exists := d.GetOk(path); d.HasChange(path) && !exists {
+		patch["name"] = nil
+	}
+	path = "tool_type_id"
+	if _, exists := d.GetOk(path); d.HasChange(path) && !exists {
+		patch["tool_type_id"] = nil
+	}
+	path = "parameters"
+	if _, exists := d.GetOk(path); d.HasChange(path) && !exists {
+		patch["parameters"] = nil
+	} else if exists && patch["parameters"] != nil {
+		ResourceIBMCdToolchainToolGitlabToolModelParametersAsPatch(patch["parameters"].(map[string]interface{}), d)
+	}
+
+	return patch
+}
+
+func ResourceIBMCdToolchainToolGitlabToolModelParametersAsPatch(patch map[string]interface{}, d *schema.ResourceData) {
+	var path string
+
+	path = "parameters.0.git_id"
+	if _, exists := d.GetOk(path); d.HasChange(path) && !exists {
+		patch["git_id"] = nil
+	}
+	path = "parameters.0.title"
+	if _, exists := d.GetOk(path); d.HasChange(path) && !exists {
+		patch["title"] = nil
+	}
+	path = "parameters.0.api_root_url"
+	if _, exists := d.GetOk(path); d.HasChange(path) && !exists {
+		patch["api_root_url"] = nil
+	}
+	path = "parameters.0.default_branch"
+	if _, exists := d.GetOk(path); d.HasChange(path) && !exists {
+		patch["default_branch"] = nil
+	}
+	path = "parameters.0.root_url"
+	if _, exists := d.GetOk(path); d.HasChange(path) && !exists {
+		patch["root_url"] = nil
+	}
+	path = "parameters.0.blind_connection"
+	if _, exists := d.GetOk(path); d.HasChange(path) && !exists {
+		patch["blind_connection"] = nil
+	}
+	path = "parameters.0.owner_id"
+	if _, exists := d.GetOk(path); d.HasChange(path) && !exists {
+		patch["owner_id"] = nil
+	}
+	path = "parameters.0.repo_name"
+	if _, exists := d.GetOk(path); d.HasChange(path) && !exists {
+		patch["repo_name"] = nil
+	}
+	path = "parameters.0.repo_url"
+	if _, exists := d.GetOk(path); d.HasChange(path) && !exists {
+		patch["repo_url"] = nil
+	}
+	path = "parameters.0.source_repo_url"
+	if _, exists := d.GetOk(path); d.HasChange(path) && !exists {
+		patch["source_repo_url"] = nil
+	}
+	path = "parameters.0.token_url"
+	if _, exists := d.GetOk(path); d.HasChange(path) && !exists {
+		patch["token_url"] = nil
+	}
+	path = "parameters.0.type"
+	if _, exists := d.GetOk(path); d.HasChange(path) && !exists {
+		patch["type"] = nil
+	}
+	path = "parameters.0.private_repo"
+	if _, exists := d.GetOk(path); d.HasChange(path) && !exists {
+		patch["private_repo"] = nil
+	}
+	path = "parameters.0.enable_traceability"
+	if _, exists := d.GetOk(path); d.HasChange(path) && !exists {
+		patch["enable_traceability"] = nil
+	}
+	path = "parameters.0.integration_owner"
+	if _, exists := d.GetOk(path); d.HasChange(path) && !exists {
+		patch["integration_owner"] = nil
+	}
+	path = "parameters.0.repo_id"
+	if _, exists := d.GetOk(path); d.HasChange(path) && !exists {
+		patch["repo_id"] = nil
+	}
+	path = "parameters.0.auth_type"
+	if _, exists := d.GetOk(path); d.HasChange(path) && !exists {
+		patch["auth_type"] = nil
+	}
+	path = "parameters.0.api_token"
+	if _, exists := d.GetOk(path); d.HasChange(path) && !exists {
+		patch["api_token"] = nil
+	}
+	path = "parameters.0.toolchain_issues_enabled"
+	if _, exists := d.GetOk(path); d.HasChange(path) && !exists {
+		patch["toolchain_issues_enabled"] = nil
+	}
 }

--- a/ibm/service/cdtoolchain/resource_ibm_cd_toolchain_tool_hashicorpvault.go
+++ b/ibm/service/cdtoolchain/resource_ibm_cd_toolchain_tool_hashicorpvault.go
@@ -1,5 +1,9 @@
-// Copyright IBM Corp. 2023 All Rights Reserved.
+// Copyright IBM Corp. 2024 All Rights Reserved.
 // Licensed under the Mozilla Public License v2.0
+
+/*
+ * IBM OpenAPI Terraform Generator Version: 3.96.0-d6dec9d7-20241008-212902
+ */
 
 package cdtoolchain
 
@@ -150,11 +154,13 @@ func ResourceIBMCdToolchainToolHashicorpvault() *schema.Resource {
 						"ui_href": &schema.Schema{
 							Type:        schema.TypeString,
 							Optional:    true,
+							Computed:    true,
 							Description: "URI representing this resource through the UI.",
 						},
 						"api_href": &schema.Schema{
 							Type:        schema.TypeString,
 							Optional:    true,
+							Computed:    true,
 							Description: "URI representing this resource through an API.",
 						},
 					},
@@ -209,7 +215,9 @@ func ResourceIBMCdToolchainToolHashicorpvaultValidator() *validate.ResourceValid
 func resourceIBMCdToolchainToolHashicorpvaultCreate(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	cdToolchainClient, err := meta.(conns.ClientSession).CdToolchainV2()
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cd_toolchain_tool_hashicorpvault", "create", "initialize-client")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	createToolOptions := &cdtoolchainv2.CreateToolOptions{}
@@ -222,10 +230,11 @@ func resourceIBMCdToolchainToolHashicorpvaultCreate(context context.Context, d *
 		createToolOptions.SetName(d.Get("name").(string))
 	}
 
-	toolchainToolPost, response, err := cdToolchainClient.CreateToolWithContext(context, createToolOptions)
+	toolchainToolPost, _, err := cdToolchainClient.CreateToolWithContext(context, createToolOptions)
 	if err != nil {
-		log.Printf("[DEBUG] CreateToolWithContext failed %s\n%s", err, response)
-		return diag.FromErr(fmt.Errorf("CreateToolWithContext failed %s\n%s", err, response))
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("CreateToolWithContext failed: %s", err.Error()), "ibm_cd_toolchain_tool_hashicorpvault", "create")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	d.SetId(fmt.Sprintf("%s/%s", *createToolOptions.ToolchainID, *toolchainToolPost.ID))
@@ -236,14 +245,16 @@ func resourceIBMCdToolchainToolHashicorpvaultCreate(context context.Context, d *
 func resourceIBMCdToolchainToolHashicorpvaultRead(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	cdToolchainClient, err := meta.(conns.ClientSession).CdToolchainV2()
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cd_toolchain_tool_hashicorpvault", "read", "initialize-client")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	getToolByIDOptions := &cdtoolchainv2.GetToolByIDOptions{}
 
 	parts, err := flex.SepIdParts(d.Id(), "/")
 	if err != nil {
-		return diag.FromErr(err)
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cd_toolchain_tool_hashicorpvault", "read", "sep-id-parts").GetDiag()
 	}
 
 	getToolByIDOptions.SetToolchainID(parts[0])
@@ -269,49 +280,61 @@ func resourceIBMCdToolchainToolHashicorpvaultRead(context context.Context, d *sc
 			d.SetId("")
 			return nil
 		}
-		log.Printf("[DEBUG] GetToolByIDWithContext failed %s\n%s", err, response)
-		return diag.FromErr(fmt.Errorf("GetToolByIDWithContext failed %s\n%s", err, response))
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("GetToolByIDWithContext failed: %s", err.Error()), "ibm_cd_toolchain_tool_hashicorpvault", "read")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	if err = d.Set("toolchain_id", toolchainTool.ToolchainID); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting toolchain_id: %s", err))
+		err = fmt.Errorf("Error setting toolchain_id: %s", err)
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cd_toolchain_tool_hashicorpvault", "read", "set-toolchain_id").GetDiag()
 	}
 	if !core.IsNil(toolchainTool.Name) {
 		if err = d.Set("name", toolchainTool.Name); err != nil {
-			return diag.FromErr(fmt.Errorf("Error setting name: %s", err))
+			err = fmt.Errorf("Error setting name: %s", err)
+			return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cd_toolchain_tool_hashicorpvault", "read", "set-name").GetDiag()
 		}
 	}
 	parametersMap := GetParametersFromRead(toolchainTool.Parameters, ResourceIBMCdToolchainToolHashicorpvault(), nil)
 	if err = d.Set("parameters", []map[string]interface{}{parametersMap}); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting parameters: %s", err))
+		err = fmt.Errorf("Error setting parameters: %s", err)
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cd_toolchain_tool_hashicorpvault", "read", "set-parameters").GetDiag()
 	}
 	if err = d.Set("resource_group_id", toolchainTool.ResourceGroupID); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting resource_group_id: %s", err))
+		err = fmt.Errorf("Error setting resource_group_id: %s", err)
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cd_toolchain_tool_hashicorpvault", "read", "set-resource_group_id").GetDiag()
 	}
 	if err = d.Set("crn", toolchainTool.CRN); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting crn: %s", err))
+		err = fmt.Errorf("Error setting crn: %s", err)
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cd_toolchain_tool_hashicorpvault", "read", "set-crn").GetDiag()
 	}
 	if err = d.Set("toolchain_crn", toolchainTool.ToolchainCRN); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting toolchain_crn: %s", err))
+		err = fmt.Errorf("Error setting toolchain_crn: %s", err)
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cd_toolchain_tool_hashicorpvault", "read", "set-toolchain_crn").GetDiag()
 	}
 	if err = d.Set("href", toolchainTool.Href); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting href: %s", err))
+		err = fmt.Errorf("Error setting href: %s", err)
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cd_toolchain_tool_hashicorpvault", "read", "set-href").GetDiag()
 	}
-	referentMap, err := resourceIBMCdToolchainToolHashicorpvaultToolModelReferentToMap(toolchainTool.Referent)
+	referentMap, err := ResourceIBMCdToolchainToolHashicorpvaultToolModelReferentToMap(toolchainTool.Referent)
 	if err != nil {
-		return diag.FromErr(err)
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cd_toolchain_tool_hashicorpvault", "read", "referent-to-map").GetDiag()
 	}
 	if err = d.Set("referent", []map[string]interface{}{referentMap}); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting referent: %s", err))
+		err = fmt.Errorf("Error setting referent: %s", err)
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cd_toolchain_tool_hashicorpvault", "read", "set-referent").GetDiag()
 	}
 	if err = d.Set("updated_at", flex.DateTimeToString(toolchainTool.UpdatedAt)); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting updated_at: %s", err))
+		err = fmt.Errorf("Error setting updated_at: %s", err)
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cd_toolchain_tool_hashicorpvault", "read", "set-updated_at").GetDiag()
 	}
 	if err = d.Set("state", toolchainTool.State); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting state: %s", err))
+		err = fmt.Errorf("Error setting state: %s", err)
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cd_toolchain_tool_hashicorpvault", "read", "set-state").GetDiag()
 	}
 	if err = d.Set("tool_id", toolchainTool.ID); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting tool_id: %s", err))
+		err = fmt.Errorf("Error setting tool_id: %s", err)
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cd_toolchain_tool_hashicorpvault", "read", "set-tool_id").GetDiag()
 	}
 
 	return nil
@@ -320,14 +343,16 @@ func resourceIBMCdToolchainToolHashicorpvaultRead(context context.Context, d *sc
 func resourceIBMCdToolchainToolHashicorpvaultUpdate(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	cdToolchainClient, err := meta.(conns.ClientSession).CdToolchainV2()
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cd_toolchain_tool_hashicorpvault", "update", "initialize-client")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	updateToolOptions := &cdtoolchainv2.UpdateToolOptions{}
 
 	parts, err := flex.SepIdParts(d.Id(), "/")
 	if err != nil {
-		return diag.FromErr(err)
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cd_toolchain_tool_hashicorpvault", "update", "sep-id-parts").GetDiag()
 	}
 
 	updateToolOptions.SetToolchainID(parts[0])
@@ -337,8 +362,9 @@ func resourceIBMCdToolchainToolHashicorpvaultUpdate(context context.Context, d *
 
 	patchVals := &cdtoolchainv2.ToolchainToolPrototypePatch{}
 	if d.HasChange("toolchain_id") {
-		return diag.FromErr(fmt.Errorf("Cannot update resource property \"%s\" with the ForceNew annotation."+
-			" The resource must be re-created to update this property.", "toolchain_id"))
+		errMsg := fmt.Sprintf("Cannot update resource property \"%s\" with the ForceNew annotation."+
+			" The resource must be re-created to update this property.", "toolchain_id")
+		return flex.DiscriminatedTerraformErrorf(nil, errMsg, "ibm_cd_toolchain_tool_hashicorpvault", "update", "toolchain_id-forces-new").GetDiag()
 	}
 	if d.HasChange("name") {
 		newName := d.Get("name").(string)
@@ -352,11 +378,16 @@ func resourceIBMCdToolchainToolHashicorpvaultUpdate(context context.Context, d *
 	}
 
 	if hasChange {
-		updateToolOptions.ToolchainToolPrototypePatch, _ = patchVals.AsPatch()
-		_, response, err := cdToolchainClient.UpdateToolWithContext(context, updateToolOptions)
+		// Fields with `nil` values are omitted from the generic map,
+		// so we need to re-add them to support removing arguments
+		// in merge-patch operations sent to the service.
+		updateToolOptions.ToolchainToolPrototypePatch = ResourceIBMCdToolchainToolHashicorpvaultToolchainToolPrototypePatchAsPatch(patchVals, d)
+
+		_, _, err = cdToolchainClient.UpdateToolWithContext(context, updateToolOptions)
 		if err != nil {
-			log.Printf("[DEBUG] UpdateToolWithContext failed %s\n%s", err, response)
-			return diag.FromErr(fmt.Errorf("UpdateToolWithContext failed %s\n%s", err, response))
+			tfErr := flex.TerraformErrorf(err, fmt.Sprintf("UpdateToolWithContext failed: %s", err.Error()), "ibm_cd_toolchain_tool_hashicorpvault", "update")
+			log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+			return tfErr.GetDiag()
 		}
 	}
 
@@ -366,23 +397,26 @@ func resourceIBMCdToolchainToolHashicorpvaultUpdate(context context.Context, d *
 func resourceIBMCdToolchainToolHashicorpvaultDelete(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	cdToolchainClient, err := meta.(conns.ClientSession).CdToolchainV2()
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cd_toolchain_tool_hashicorpvault", "delete", "initialize-client")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	deleteToolOptions := &cdtoolchainv2.DeleteToolOptions{}
 
 	parts, err := flex.SepIdParts(d.Id(), "/")
 	if err != nil {
-		return diag.FromErr(err)
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cd_toolchain_tool_hashicorpvault", "delete", "sep-id-parts").GetDiag()
 	}
 
 	deleteToolOptions.SetToolchainID(parts[0])
 	deleteToolOptions.SetToolID(parts[1])
 
-	response, err := cdToolchainClient.DeleteToolWithContext(context, deleteToolOptions)
+	_, err = cdToolchainClient.DeleteToolWithContext(context, deleteToolOptions)
 	if err != nil {
-		log.Printf("[DEBUG] DeleteToolWithContext failed %s\n%s", err, response)
-		return diag.FromErr(fmt.Errorf("DeleteToolWithContext failed %s\n%s", err, response))
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("DeleteToolWithContext failed: %s", err.Error()), "ibm_cd_toolchain_tool_hashicorpvault", "delete")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	d.SetId("")
@@ -390,13 +424,68 @@ func resourceIBMCdToolchainToolHashicorpvaultDelete(context context.Context, d *
 	return nil
 }
 
-func resourceIBMCdToolchainToolHashicorpvaultToolModelReferentToMap(model *cdtoolchainv2.ToolModelReferent) (map[string]interface{}, error) {
+func ResourceIBMCdToolchainToolHashicorpvaultToolModelReferentToMap(model *cdtoolchainv2.ToolModelReferent) (map[string]interface{}, error) {
 	modelMap := make(map[string]interface{})
 	if model.UIHref != nil {
-		modelMap["ui_href"] = model.UIHref
+		modelMap["ui_href"] = *model.UIHref
 	}
 	if model.APIHref != nil {
-		modelMap["api_href"] = model.APIHref
+		modelMap["api_href"] = *model.APIHref
 	}
 	return modelMap, nil
+}
+
+func ResourceIBMCdToolchainToolHashicorpvaultToolchainToolPrototypePatchAsPatch(patchVals *cdtoolchainv2.ToolchainToolPrototypePatch, d *schema.ResourceData) map[string]interface{} {
+	patch, _ := patchVals.AsPatch()
+	var path string
+
+	path = "name"
+	if _, exists := d.GetOk(path); d.HasChange(path) && !exists {
+		patch["name"] = nil
+	}
+	path = "tool_type_id"
+	if _, exists := d.GetOk(path); d.HasChange(path) && !exists {
+		patch["tool_type_id"] = nil
+	}
+	path = "parameters"
+	if _, exists := d.GetOk(path); d.HasChange(path) && !exists {
+		patch["parameters"] = nil
+	} else if exists && patch["parameters"] != nil {
+		ResourceIBMCdToolchainToolHashicorpvaultToolModelParametersAsPatch(patch["parameters"].(map[string]interface{}), d)
+	}
+
+	return patch
+}
+
+func ResourceIBMCdToolchainToolHashicorpvaultToolModelParametersAsPatch(patch map[string]interface{}, d *schema.ResourceData) {
+	var path string
+
+	path = "parameters.0.token"
+	if _, exists := d.GetOk(path); d.HasChange(path) && !exists {
+		patch["token"] = nil
+	}
+	path = "parameters.0.role_id"
+	if _, exists := d.GetOk(path); d.HasChange(path) && !exists {
+		patch["role_id"] = nil
+	}
+	path = "parameters.0.secret_id"
+	if _, exists := d.GetOk(path); d.HasChange(path) && !exists {
+		patch["secret_id"] = nil
+	}
+	path = "parameters.0.secret_filter"
+	if _, exists := d.GetOk(path); d.HasChange(path) && !exists {
+		patch["secret_filter"] = nil
+	}
+	path = "parameters.0.default_secret"
+	if _, exists := d.GetOk(path); d.HasChange(path) && !exists {
+		patch["default_secret"] = nil
+	}
+	path = "parameters.0.username"
+	if _, exists := d.GetOk(path); d.HasChange(path) && !exists {
+		patch["username"] = nil
+	}
+	path = "parameters.0.password"
+	if _, exists := d.GetOk(path); d.HasChange(path) && !exists {
+		patch["password"] = nil
+	}
 }

--- a/ibm/service/cdtoolchain/resource_ibm_cd_toolchain_tool_hostedgit.go
+++ b/ibm/service/cdtoolchain/resource_ibm_cd_toolchain_tool_hostedgit.go
@@ -1,5 +1,9 @@
-// Copyright IBM Corp. 2023 All Rights Reserved.
+// Copyright IBM Corp. 2024 All Rights Reserved.
 // Licensed under the Mozilla Public License v2.0
+
+/*
+ * IBM OpenAPI Terraform Generator Version: 3.96.0-d6dec9d7-20241008-212902
+ */
 
 package cdtoolchain
 
@@ -52,51 +56,61 @@ func ResourceIBMCdToolchainToolHostedgit() *schema.Resource {
 					Schema: map[string]*schema.Schema{
 						"git_id": &schema.Schema{
 							Type:        schema.TypeString,
+							Optional:    true,
 							Computed:    true,
 							Description: "Set this value to 'hostedgit' to target Git Repos and Issue Tracking.",
 						},
 						"api_root_url": &schema.Schema{
 							Type:        schema.TypeString,
+							Optional:    true,
 							Computed:    true,
 							Description: "The API root URL for the GitLab server.",
 						},
 						"default_branch": &schema.Schema{
 							Type:        schema.TypeString,
+							Optional:    true,
 							Computed:    true,
 							Description: "The default branch of the git repository.",
 						},
 						"owner_id": &schema.Schema{
 							Type:        schema.TypeString,
+							Optional:    true,
 							Computed:    true,
 							Description: "The GitLab user or group that owns the repository.  This parameter is required when creating a new repository, cloning, or forking a repository.  The value will be computed when linking to an existing repository.",
 						},
 						"repo_name": &schema.Schema{
 							Type:        schema.TypeString,
+							Optional:    true,
 							Computed:    true,
 							Description: "The name of the new GitLab repository to create.  This parameter is required when creating a new repository, cloning, or forking a repository.  The value will be computed when linking to an existing repository.",
 						},
 						"repo_url": &schema.Schema{
 							Type:        schema.TypeString,
+							Optional:    true,
 							Computed:    true,
 							Description: "The URL of the GitLab repository for this tool integration.  This parameter is required when linking to an existing repository.  The value will be computed when creating a new repository, cloning, or forking a repository.",
 						},
 						"source_repo_url": &schema.Schema{
 							Type:        schema.TypeString,
+							Optional:    true,
 							Computed:    true,
 							Description: "The URL of the repository that you are forking or cloning.  This parameter is required when forking or cloning a repository.  It is not used when creating a new repository or linking to an existing repository.",
 						},
 						"token_url": &schema.Schema{
 							Type:        schema.TypeString,
+							Optional:    true,
 							Computed:    true,
 							Description: "The token URL used for authorizing with the Bitbucket server.",
 						},
 						"type": &schema.Schema{
 							Type:        schema.TypeString,
+							Optional:    true,
 							Computed:    true,
 							Description: "The operation that should be performed to initialize the new tool integration. Use 'new' or 'new_if_not_exists' to create a new git repository, 'clone' or 'clone_if_not_exists' to clone an existing repository into a new git repository, 'fork' or 'fork_if_not_exists' to fork an existing git repository, or 'link' to link to an existing git repository. If you attempt to apply a resource with type 'new', 'clone', or 'fork' when the target repo already exists, the attempt will fail. If you apply a resource with type 'new_if_not_exists`, 'clone_if_not_exists', or 'fork_if_not_exists' when the target repo already exists, the existing repo will be used as-is.",
 						},
 						"private_repo": &schema.Schema{
 							Type:        schema.TypeBool,
+							Optional:    true,
 							Computed:    true,
 							Description: "Set this value to 'true' to make the repository private when creating a new repository or when cloning or forking a repository.  This parameter is not used when linking to an existing repository.",
 						},
@@ -114,6 +128,7 @@ func ResourceIBMCdToolchainToolHostedgit() *schema.Resource {
 						},
 						"repo_id": &schema.Schema{
 							Type:        schema.TypeString,
+							Optional:    true,
 							Computed:    true,
 							Description: "The ID of the Git Repos and Issue Tracking project.",
 						},
@@ -220,11 +235,13 @@ func ResourceIBMCdToolchainToolHostedgit() *schema.Resource {
 						"ui_href": &schema.Schema{
 							Type:        schema.TypeString,
 							Optional:    true,
+							Computed:    true,
 							Description: "URI representing this resource through the UI.",
 						},
 						"api_href": &schema.Schema{
 							Type:        schema.TypeString,
 							Optional:    true,
+							Computed:    true,
 							Description: "URI representing this resource through an API.",
 						},
 					},
@@ -279,7 +296,9 @@ func ResourceIBMCdToolchainToolHostedgitValidator() *validate.ResourceValidator 
 func resourceIBMCdToolchainToolHostedgitCreate(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	cdToolchainClient, err := meta.(conns.ClientSession).CdToolchainV2()
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cd_toolchain_tool_hostedgit", "create", "initialize-client")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	createToolOptions := &cdtoolchainv2.CreateToolOptions{}
@@ -295,10 +314,11 @@ func resourceIBMCdToolchainToolHostedgitCreate(context context.Context, d *schem
 		createToolOptions.SetName(d.Get("name").(string))
 	}
 
-	toolchainToolPost, response, err := cdToolchainClient.CreateToolWithContext(context, createToolOptions)
+	toolchainToolPost, _, err := cdToolchainClient.CreateToolWithContext(context, createToolOptions)
 	if err != nil {
-		log.Printf("[DEBUG] CreateToolWithContext failed %s\n%s", err, response)
-		return diag.FromErr(fmt.Errorf("CreateToolWithContext failed %s\n%s", err, response))
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("CreateToolWithContext failed: %s", err.Error()), "ibm_cd_toolchain_tool_hostedgit", "create")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	d.SetId(fmt.Sprintf("%s/%s", *createToolOptions.ToolchainID, *toolchainToolPost.ID))
@@ -309,14 +329,16 @@ func resourceIBMCdToolchainToolHostedgitCreate(context context.Context, d *schem
 func resourceIBMCdToolchainToolHostedgitRead(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	cdToolchainClient, err := meta.(conns.ClientSession).CdToolchainV2()
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cd_toolchain_tool_hostedgit", "read", "initialize-client")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	getToolByIDOptions := &cdtoolchainv2.GetToolByIDOptions{}
 
 	parts, err := flex.SepIdParts(d.Id(), "/")
 	if err != nil {
-		return diag.FromErr(err)
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cd_toolchain_tool_hostedgit", "read", "sep-id-parts").GetDiag()
 	}
 
 	getToolByIDOptions.SetToolchainID(parts[0])
@@ -342,16 +364,19 @@ func resourceIBMCdToolchainToolHostedgitRead(context context.Context, d *schema.
 			d.SetId("")
 			return nil
 		}
-		log.Printf("[DEBUG] GetToolByIDWithContext failed %s\n%s", err, response)
-		return diag.FromErr(fmt.Errorf("GetToolByIDWithContext failed %s\n%s", err, response))
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("GetToolByIDWithContext failed: %s", err.Error()), "ibm_cd_toolchain_tool_hostedgit", "read")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	if err = d.Set("toolchain_id", toolchainTool.ToolchainID); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting toolchain_id: %s", err))
+		err = fmt.Errorf("Error setting toolchain_id: %s", err)
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cd_toolchain_tool_hostedgit", "read", "set-toolchain_id").GetDiag()
 	}
 	if !core.IsNil(toolchainTool.Name) {
 		if err = d.Set("name", toolchainTool.Name); err != nil {
-			return diag.FromErr(fmt.Errorf("Error setting name: %s", err))
+			err = fmt.Errorf("Error setting name: %s", err)
+			return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cd_toolchain_tool_hostedgit", "read", "set-name").GetDiag()
 		}
 	}
 	remapFields := map[string]string{
@@ -359,35 +384,44 @@ func resourceIBMCdToolchainToolHostedgitRead(context context.Context, d *schema.
 	}
 	parametersMap := GetParametersFromRead(toolchainTool.Parameters, ResourceIBMCdToolchainToolHostedgit(), remapFields)
 	if err = d.Set("parameters", []map[string]interface{}{parametersMap}); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting parameters: %s", err))
+		err = fmt.Errorf("Error setting parameters: %s", err)
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cd_toolchain_tool_hostedgit", "read", "set-parameters").GetDiag()
 	}
 	if err = d.Set("resource_group_id", toolchainTool.ResourceGroupID); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting resource_group_id: %s", err))
+		err = fmt.Errorf("Error setting resource_group_id: %s", err)
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cd_toolchain_tool_hostedgit", "read", "set-resource_group_id").GetDiag()
 	}
 	if err = d.Set("crn", toolchainTool.CRN); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting crn: %s", err))
+		err = fmt.Errorf("Error setting crn: %s", err)
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cd_toolchain_tool_hostedgit", "read", "set-crn").GetDiag()
 	}
 	if err = d.Set("toolchain_crn", toolchainTool.ToolchainCRN); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting toolchain_crn: %s", err))
+		err = fmt.Errorf("Error setting toolchain_crn: %s", err)
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cd_toolchain_tool_hostedgit", "read", "set-toolchain_crn").GetDiag()
 	}
 	if err = d.Set("href", toolchainTool.Href); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting href: %s", err))
+		err = fmt.Errorf("Error setting href: %s", err)
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cd_toolchain_tool_hostedgit", "read", "set-href").GetDiag()
 	}
-	referentMap, err := resourceIBMCdToolchainToolHostedgitToolModelReferentToMap(toolchainTool.Referent)
+	referentMap, err := ResourceIBMCdToolchainToolHostedgitToolModelReferentToMap(toolchainTool.Referent)
 	if err != nil {
-		return diag.FromErr(err)
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cd_toolchain_tool_hostedgit", "read", "referent-to-map").GetDiag()
 	}
 	if err = d.Set("referent", []map[string]interface{}{referentMap}); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting referent: %s", err))
+		err = fmt.Errorf("Error setting referent: %s", err)
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cd_toolchain_tool_hostedgit", "read", "set-referent").GetDiag()
 	}
 	if err = d.Set("updated_at", flex.DateTimeToString(toolchainTool.UpdatedAt)); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting updated_at: %s", err))
+		err = fmt.Errorf("Error setting updated_at: %s", err)
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cd_toolchain_tool_hostedgit", "read", "set-updated_at").GetDiag()
 	}
 	if err = d.Set("state", toolchainTool.State); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting state: %s", err))
+		err = fmt.Errorf("Error setting state: %s", err)
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cd_toolchain_tool_hostedgit", "read", "set-state").GetDiag()
 	}
 	if err = d.Set("tool_id", toolchainTool.ID); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting tool_id: %s", err))
+		err = fmt.Errorf("Error setting tool_id: %s", err)
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cd_toolchain_tool_hostedgit", "read", "set-tool_id").GetDiag()
 	}
 
 	return nil
@@ -396,14 +430,16 @@ func resourceIBMCdToolchainToolHostedgitRead(context context.Context, d *schema.
 func resourceIBMCdToolchainToolHostedgitUpdate(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	cdToolchainClient, err := meta.(conns.ClientSession).CdToolchainV2()
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cd_toolchain_tool_hostedgit", "update", "initialize-client")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	updateToolOptions := &cdtoolchainv2.UpdateToolOptions{}
 
 	parts, err := flex.SepIdParts(d.Id(), "/")
 	if err != nil {
-		return diag.FromErr(err)
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cd_toolchain_tool_hostedgit", "update", "sep-id-parts").GetDiag()
 	}
 
 	updateToolOptions.SetToolchainID(parts[0])
@@ -413,8 +449,9 @@ func resourceIBMCdToolchainToolHostedgitUpdate(context context.Context, d *schem
 
 	patchVals := &cdtoolchainv2.ToolchainToolPrototypePatch{}
 	if d.HasChange("toolchain_id") {
-		return diag.FromErr(fmt.Errorf("Cannot update resource property \"%s\" with the ForceNew annotation."+
-			" The resource must be re-created to update this property.", "toolchain_id"))
+		errMsg := fmt.Sprintf("Cannot update resource property \"%s\" with the ForceNew annotation."+
+			" The resource must be re-created to update this property.", "toolchain_id")
+		return flex.DiscriminatedTerraformErrorf(nil, errMsg, "ibm_cd_toolchain_tool_hostedgit", "update", "toolchain_id-forces-new").GetDiag()
 	}
 	if d.HasChange("name") {
 		newName := d.Get("name").(string)
@@ -431,11 +468,16 @@ func resourceIBMCdToolchainToolHostedgitUpdate(context context.Context, d *schem
 	}
 
 	if hasChange {
-		updateToolOptions.ToolchainToolPrototypePatch, _ = patchVals.AsPatch()
-		_, response, err := cdToolchainClient.UpdateToolWithContext(context, updateToolOptions)
+		// Fields with `nil` values are omitted from the generic map,
+		// so we need to re-add them to support removing arguments
+		// in merge-patch operations sent to the service.
+		updateToolOptions.ToolchainToolPrototypePatch = ResourceIBMCdToolchainToolHostedgitToolchainToolPrototypePatchAsPatch(patchVals, d)
+
+		_, _, err = cdToolchainClient.UpdateToolWithContext(context, updateToolOptions)
 		if err != nil {
-			log.Printf("[DEBUG] UpdateToolWithContext failed %s\n%s", err, response)
-			return diag.FromErr(fmt.Errorf("UpdateToolWithContext failed %s\n%s", err, response))
+			tfErr := flex.TerraformErrorf(err, fmt.Sprintf("UpdateToolWithContext failed: %s", err.Error()), "ibm_cd_toolchain_tool_hostedgit", "update")
+			log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+			return tfErr.GetDiag()
 		}
 	}
 
@@ -445,23 +487,26 @@ func resourceIBMCdToolchainToolHostedgitUpdate(context context.Context, d *schem
 func resourceIBMCdToolchainToolHostedgitDelete(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	cdToolchainClient, err := meta.(conns.ClientSession).CdToolchainV2()
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cd_toolchain_tool_hostedgit", "delete", "initialize-client")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	deleteToolOptions := &cdtoolchainv2.DeleteToolOptions{}
 
 	parts, err := flex.SepIdParts(d.Id(), "/")
 	if err != nil {
-		return diag.FromErr(err)
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cd_toolchain_tool_hostedgit", "delete", "sep-id-parts").GetDiag()
 	}
 
 	deleteToolOptions.SetToolchainID(parts[0])
 	deleteToolOptions.SetToolID(parts[1])
 
-	response, err := cdToolchainClient.DeleteToolWithContext(context, deleteToolOptions)
+	_, err = cdToolchainClient.DeleteToolWithContext(context, deleteToolOptions)
 	if err != nil {
-		log.Printf("[DEBUG] DeleteToolWithContext failed %s\n%s", err, response)
-		return diag.FromErr(fmt.Errorf("DeleteToolWithContext failed %s\n%s", err, response))
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("DeleteToolWithContext failed: %s", err.Error()), "ibm_cd_toolchain_tool_hostedgit", "delete")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	d.SetId("")
@@ -469,13 +514,104 @@ func resourceIBMCdToolchainToolHostedgitDelete(context context.Context, d *schem
 	return nil
 }
 
-func resourceIBMCdToolchainToolHostedgitToolModelReferentToMap(model *cdtoolchainv2.ToolModelReferent) (map[string]interface{}, error) {
+func ResourceIBMCdToolchainToolHostedgitToolModelReferentToMap(model *cdtoolchainv2.ToolModelReferent) (map[string]interface{}, error) {
 	modelMap := make(map[string]interface{})
 	if model.UIHref != nil {
-		modelMap["ui_href"] = model.UIHref
+		modelMap["ui_href"] = *model.UIHref
 	}
 	if model.APIHref != nil {
-		modelMap["api_href"] = model.APIHref
+		modelMap["api_href"] = *model.APIHref
 	}
 	return modelMap, nil
+}
+
+func ResourceIBMCdToolchainToolHostedgitToolchainToolPrototypePatchAsPatch(patchVals *cdtoolchainv2.ToolchainToolPrototypePatch, d *schema.ResourceData) map[string]interface{} {
+	patch, _ := patchVals.AsPatch()
+	var path string
+
+	path = "name"
+	if _, exists := d.GetOk(path); d.HasChange(path) && !exists {
+		patch["name"] = nil
+	}
+	path = "tool_type_id"
+	if _, exists := d.GetOk(path); d.HasChange(path) && !exists {
+		patch["tool_type_id"] = nil
+	}
+	path = "parameters"
+	if _, exists := d.GetOk(path); d.HasChange(path) && !exists {
+		patch["parameters"] = nil
+	} else if exists && patch["parameters"] != nil {
+		ResourceIBMCdToolchainToolHostedgitToolModelParametersAsPatch(patch["parameters"].(map[string]interface{}), d)
+	}
+
+	return patch
+}
+
+func ResourceIBMCdToolchainToolHostedgitToolModelParametersAsPatch(patch map[string]interface{}, d *schema.ResourceData) {
+	var path string
+
+	path = "parameters.0.git_id"
+	if _, exists := d.GetOk(path); d.HasChange(path) && !exists {
+		patch["git_id"] = nil
+	}
+	path = "parameters.0.api_root_url"
+	if _, exists := d.GetOk(path); d.HasChange(path) && !exists {
+		patch["api_root_url"] = nil
+	}
+	path = "parameters.0.default_branch"
+	if _, exists := d.GetOk(path); d.HasChange(path) && !exists {
+		patch["default_branch"] = nil
+	}
+	path = "parameters.0.owner_id"
+	if _, exists := d.GetOk(path); d.HasChange(path) && !exists {
+		patch["owner_id"] = nil
+	}
+	path = "parameters.0.repo_name"
+	if _, exists := d.GetOk(path); d.HasChange(path) && !exists {
+		patch["repo_name"] = nil
+	}
+	path = "parameters.0.repo_url"
+	if _, exists := d.GetOk(path); d.HasChange(path) && !exists {
+		patch["repo_url"] = nil
+	}
+	path = "parameters.0.source_repo_url"
+	if _, exists := d.GetOk(path); d.HasChange(path) && !exists {
+		patch["source_repo_url"] = nil
+	}
+	path = "parameters.0.token_url"
+	if _, exists := d.GetOk(path); d.HasChange(path) && !exists {
+		patch["token_url"] = nil
+	}
+	path = "parameters.0.type"
+	if _, exists := d.GetOk(path); d.HasChange(path) && !exists {
+		patch["type"] = nil
+	}
+	path = "parameters.0.private_repo"
+	if _, exists := d.GetOk(path); d.HasChange(path) && !exists {
+		patch["private_repo"] = nil
+	}
+	path = "parameters.0.enable_traceability"
+	if _, exists := d.GetOk(path); d.HasChange(path) && !exists {
+		patch["enable_traceability"] = nil
+	}
+	path = "parameters.0.integration_owner"
+	if _, exists := d.GetOk(path); d.HasChange(path) && !exists {
+		patch["integration_owner"] = nil
+	}
+	path = "parameters.0.repo_id"
+	if _, exists := d.GetOk(path); d.HasChange(path) && !exists {
+		patch["repo_id"] = nil
+	}
+	path = "parameters.0.auth_type"
+	if _, exists := d.GetOk(path); d.HasChange(path) && !exists {
+		patch["auth_type"] = nil
+	}
+	path = "parameters.0.api_token"
+	if _, exists := d.GetOk(path); d.HasChange(path) && !exists {
+		patch["api_token"] = nil
+	}
+	path = "parameters.0.toolchain_issues_enabled"
+	if _, exists := d.GetOk(path); d.HasChange(path) && !exists {
+		patch["toolchain_issues_enabled"] = nil
+	}
 }

--- a/ibm/service/cdtoolchain/resource_ibm_cd_toolchain_tool_jenkins.go
+++ b/ibm/service/cdtoolchain/resource_ibm_cd_toolchain_tool_jenkins.go
@@ -1,5 +1,9 @@
-// Copyright IBM Corp. 2023 All Rights Reserved.
+// Copyright IBM Corp. 2024 All Rights Reserved.
 // Licensed under the Mozilla Public License v2.0
+
+/*
+ * IBM OpenAPI Terraform Generator Version: 3.96.0-d6dec9d7-20241008-212902
+ */
 
 package cdtoolchain
 
@@ -62,6 +66,7 @@ func ResourceIBMCdToolchainToolJenkins() *schema.Resource {
 						},
 						"webhook_url": &schema.Schema{
 							Type:        schema.TypeString,
+							Optional:    true,
 							Computed:    true,
 							Sensitive:   true,
 							Description: "The webhook to use in your Jenkins jobs to send notifications to other tools in your toolchain.",
@@ -110,11 +115,13 @@ func ResourceIBMCdToolchainToolJenkins() *schema.Resource {
 						"ui_href": &schema.Schema{
 							Type:        schema.TypeString,
 							Optional:    true,
+							Computed:    true,
 							Description: "URI representing this resource through the UI.",
 						},
 						"api_href": &schema.Schema{
 							Type:        schema.TypeString,
 							Optional:    true,
+							Computed:    true,
 							Description: "URI representing this resource through an API.",
 						},
 					},
@@ -169,7 +176,9 @@ func ResourceIBMCdToolchainToolJenkinsValidator() *validate.ResourceValidator {
 func resourceIBMCdToolchainToolJenkinsCreate(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	cdToolchainClient, err := meta.(conns.ClientSession).CdToolchainV2()
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cd_toolchain_tool_jenkins", "create", "initialize-client")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	createToolOptions := &cdtoolchainv2.CreateToolOptions{}
@@ -182,10 +191,11 @@ func resourceIBMCdToolchainToolJenkinsCreate(context context.Context, d *schema.
 		createToolOptions.SetName(d.Get("name").(string))
 	}
 
-	toolchainToolPost, response, err := cdToolchainClient.CreateToolWithContext(context, createToolOptions)
+	toolchainToolPost, _, err := cdToolchainClient.CreateToolWithContext(context, createToolOptions)
 	if err != nil {
-		log.Printf("[DEBUG] CreateToolWithContext failed %s\n%s", err, response)
-		return diag.FromErr(fmt.Errorf("CreateToolWithContext failed %s\n%s", err, response))
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("CreateToolWithContext failed: %s", err.Error()), "ibm_cd_toolchain_tool_jenkins", "create")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	d.SetId(fmt.Sprintf("%s/%s", *createToolOptions.ToolchainID, *toolchainToolPost.ID))
@@ -196,14 +206,16 @@ func resourceIBMCdToolchainToolJenkinsCreate(context context.Context, d *schema.
 func resourceIBMCdToolchainToolJenkinsRead(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	cdToolchainClient, err := meta.(conns.ClientSession).CdToolchainV2()
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cd_toolchain_tool_jenkins", "read", "initialize-client")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	getToolByIDOptions := &cdtoolchainv2.GetToolByIDOptions{}
 
 	parts, err := flex.SepIdParts(d.Id(), "/")
 	if err != nil {
-		return diag.FromErr(err)
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cd_toolchain_tool_jenkins", "read", "sep-id-parts").GetDiag()
 	}
 
 	getToolByIDOptions.SetToolchainID(parts[0])
@@ -229,49 +241,61 @@ func resourceIBMCdToolchainToolJenkinsRead(context context.Context, d *schema.Re
 			d.SetId("")
 			return nil
 		}
-		log.Printf("[DEBUG] GetToolByIDWithContext failed %s\n%s", err, response)
-		return diag.FromErr(fmt.Errorf("GetToolByIDWithContext failed %s\n%s", err, response))
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("GetToolByIDWithContext failed: %s", err.Error()), "ibm_cd_toolchain_tool_jenkins", "read")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	if err = d.Set("toolchain_id", toolchainTool.ToolchainID); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting toolchain_id: %s", err))
+		err = fmt.Errorf("Error setting toolchain_id: %s", err)
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cd_toolchain_tool_jenkins", "read", "set-toolchain_id").GetDiag()
 	}
 	if !core.IsNil(toolchainTool.Name) {
 		if err = d.Set("name", toolchainTool.Name); err != nil {
-			return diag.FromErr(fmt.Errorf("Error setting name: %s", err))
+			err = fmt.Errorf("Error setting name: %s", err)
+			return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cd_toolchain_tool_jenkins", "read", "set-name").GetDiag()
 		}
 	}
 	parametersMap := GetParametersFromRead(toolchainTool.Parameters, ResourceIBMCdToolchainToolJenkins(), nil)
 	if err = d.Set("parameters", []map[string]interface{}{parametersMap}); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting parameters: %s", err))
+		err = fmt.Errorf("Error setting parameters: %s", err)
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cd_toolchain_tool_jenkins", "read", "set-parameters").GetDiag()
 	}
 	if err = d.Set("resource_group_id", toolchainTool.ResourceGroupID); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting resource_group_id: %s", err))
+		err = fmt.Errorf("Error setting resource_group_id: %s", err)
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cd_toolchain_tool_jenkins", "read", "set-resource_group_id").GetDiag()
 	}
 	if err = d.Set("crn", toolchainTool.CRN); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting crn: %s", err))
+		err = fmt.Errorf("Error setting crn: %s", err)
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cd_toolchain_tool_jenkins", "read", "set-crn").GetDiag()
 	}
 	if err = d.Set("toolchain_crn", toolchainTool.ToolchainCRN); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting toolchain_crn: %s", err))
+		err = fmt.Errorf("Error setting toolchain_crn: %s", err)
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cd_toolchain_tool_jenkins", "read", "set-toolchain_crn").GetDiag()
 	}
 	if err = d.Set("href", toolchainTool.Href); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting href: %s", err))
+		err = fmt.Errorf("Error setting href: %s", err)
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cd_toolchain_tool_jenkins", "read", "set-href").GetDiag()
 	}
-	referentMap, err := resourceIBMCdToolchainToolJenkinsToolModelReferentToMap(toolchainTool.Referent)
+	referentMap, err := ResourceIBMCdToolchainToolJenkinsToolModelReferentToMap(toolchainTool.Referent)
 	if err != nil {
-		return diag.FromErr(err)
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cd_toolchain_tool_jenkins", "read", "referent-to-map").GetDiag()
 	}
 	if err = d.Set("referent", []map[string]interface{}{referentMap}); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting referent: %s", err))
+		err = fmt.Errorf("Error setting referent: %s", err)
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cd_toolchain_tool_jenkins", "read", "set-referent").GetDiag()
 	}
 	if err = d.Set("updated_at", flex.DateTimeToString(toolchainTool.UpdatedAt)); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting updated_at: %s", err))
+		err = fmt.Errorf("Error setting updated_at: %s", err)
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cd_toolchain_tool_jenkins", "read", "set-updated_at").GetDiag()
 	}
 	if err = d.Set("state", toolchainTool.State); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting state: %s", err))
+		err = fmt.Errorf("Error setting state: %s", err)
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cd_toolchain_tool_jenkins", "read", "set-state").GetDiag()
 	}
 	if err = d.Set("tool_id", toolchainTool.ID); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting tool_id: %s", err))
+		err = fmt.Errorf("Error setting tool_id: %s", err)
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cd_toolchain_tool_jenkins", "read", "set-tool_id").GetDiag()
 	}
 
 	return nil
@@ -280,14 +304,16 @@ func resourceIBMCdToolchainToolJenkinsRead(context context.Context, d *schema.Re
 func resourceIBMCdToolchainToolJenkinsUpdate(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	cdToolchainClient, err := meta.(conns.ClientSession).CdToolchainV2()
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cd_toolchain_tool_jenkins", "update", "initialize-client")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	updateToolOptions := &cdtoolchainv2.UpdateToolOptions{}
 
 	parts, err := flex.SepIdParts(d.Id(), "/")
 	if err != nil {
-		return diag.FromErr(err)
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cd_toolchain_tool_jenkins", "update", "sep-id-parts").GetDiag()
 	}
 
 	updateToolOptions.SetToolchainID(parts[0])
@@ -297,8 +323,9 @@ func resourceIBMCdToolchainToolJenkinsUpdate(context context.Context, d *schema.
 
 	patchVals := &cdtoolchainv2.ToolchainToolPrototypePatch{}
 	if d.HasChange("toolchain_id") {
-		return diag.FromErr(fmt.Errorf("Cannot update resource property \"%s\" with the ForceNew annotation."+
-			" The resource must be re-created to update this property.", "toolchain_id"))
+		errMsg := fmt.Sprintf("Cannot update resource property \"%s\" with the ForceNew annotation."+
+			" The resource must be re-created to update this property.", "toolchain_id")
+		return flex.DiscriminatedTerraformErrorf(nil, errMsg, "ibm_cd_toolchain_tool_jenkins", "update", "toolchain_id-forces-new").GetDiag()
 	}
 	if d.HasChange("name") {
 		newName := d.Get("name").(string)
@@ -312,11 +339,16 @@ func resourceIBMCdToolchainToolJenkinsUpdate(context context.Context, d *schema.
 	}
 
 	if hasChange {
-		updateToolOptions.ToolchainToolPrototypePatch, _ = patchVals.AsPatch()
-		_, response, err := cdToolchainClient.UpdateToolWithContext(context, updateToolOptions)
+		// Fields with `nil` values are omitted from the generic map,
+		// so we need to re-add them to support removing arguments
+		// in merge-patch operations sent to the service.
+		updateToolOptions.ToolchainToolPrototypePatch = ResourceIBMCdToolchainToolJenkinsToolchainToolPrototypePatchAsPatch(patchVals, d)
+
+		_, _, err = cdToolchainClient.UpdateToolWithContext(context, updateToolOptions)
 		if err != nil {
-			log.Printf("[DEBUG] UpdateToolWithContext failed %s\n%s", err, response)
-			return diag.FromErr(fmt.Errorf("UpdateToolWithContext failed %s\n%s", err, response))
+			tfErr := flex.TerraformErrorf(err, fmt.Sprintf("UpdateToolWithContext failed: %s", err.Error()), "ibm_cd_toolchain_tool_jenkins", "update")
+			log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+			return tfErr.GetDiag()
 		}
 	}
 
@@ -326,23 +358,26 @@ func resourceIBMCdToolchainToolJenkinsUpdate(context context.Context, d *schema.
 func resourceIBMCdToolchainToolJenkinsDelete(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	cdToolchainClient, err := meta.(conns.ClientSession).CdToolchainV2()
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cd_toolchain_tool_jenkins", "delete", "initialize-client")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	deleteToolOptions := &cdtoolchainv2.DeleteToolOptions{}
 
 	parts, err := flex.SepIdParts(d.Id(), "/")
 	if err != nil {
-		return diag.FromErr(err)
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cd_toolchain_tool_jenkins", "delete", "sep-id-parts").GetDiag()
 	}
 
 	deleteToolOptions.SetToolchainID(parts[0])
 	deleteToolOptions.SetToolID(parts[1])
 
-	response, err := cdToolchainClient.DeleteToolWithContext(context, deleteToolOptions)
+	_, err = cdToolchainClient.DeleteToolWithContext(context, deleteToolOptions)
 	if err != nil {
-		log.Printf("[DEBUG] DeleteToolWithContext failed %s\n%s", err, response)
-		return diag.FromErr(fmt.Errorf("DeleteToolWithContext failed %s\n%s", err, response))
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("DeleteToolWithContext failed: %s", err.Error()), "ibm_cd_toolchain_tool_jenkins", "delete")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	d.SetId("")
@@ -350,13 +385,52 @@ func resourceIBMCdToolchainToolJenkinsDelete(context context.Context, d *schema.
 	return nil
 }
 
-func resourceIBMCdToolchainToolJenkinsToolModelReferentToMap(model *cdtoolchainv2.ToolModelReferent) (map[string]interface{}, error) {
+func ResourceIBMCdToolchainToolJenkinsToolModelReferentToMap(model *cdtoolchainv2.ToolModelReferent) (map[string]interface{}, error) {
 	modelMap := make(map[string]interface{})
 	if model.UIHref != nil {
-		modelMap["ui_href"] = model.UIHref
+		modelMap["ui_href"] = *model.UIHref
 	}
 	if model.APIHref != nil {
-		modelMap["api_href"] = model.APIHref
+		modelMap["api_href"] = *model.APIHref
 	}
 	return modelMap, nil
+}
+
+func ResourceIBMCdToolchainToolJenkinsToolchainToolPrototypePatchAsPatch(patchVals *cdtoolchainv2.ToolchainToolPrototypePatch, d *schema.ResourceData) map[string]interface{} {
+	patch, _ := patchVals.AsPatch()
+	var path string
+
+	path = "name"
+	if _, exists := d.GetOk(path); d.HasChange(path) && !exists {
+		patch["name"] = nil
+	}
+	path = "tool_type_id"
+	if _, exists := d.GetOk(path); d.HasChange(path) && !exists {
+		patch["tool_type_id"] = nil
+	}
+	path = "parameters"
+	if _, exists := d.GetOk(path); d.HasChange(path) && !exists {
+		patch["parameters"] = nil
+	} else if exists && patch["parameters"] != nil {
+		ResourceIBMCdToolchainToolJenkinsToolModelParametersAsPatch(patch["parameters"].(map[string]interface{}), d)
+	}
+
+	return patch
+}
+
+func ResourceIBMCdToolchainToolJenkinsToolModelParametersAsPatch(patch map[string]interface{}, d *schema.ResourceData) {
+	var path string
+
+	path = "parameters.0.webhook_url"
+	if _, exists := d.GetOk(path); d.HasChange(path) && !exists {
+		patch["webhook_url"] = nil
+	}
+	path = "parameters.0.api_user_name"
+	if _, exists := d.GetOk(path); d.HasChange(path) && !exists {
+		patch["api_user_name"] = nil
+	}
+	path = "parameters.0.api_token"
+	if _, exists := d.GetOk(path); d.HasChange(path) && !exists {
+		patch["api_token"] = nil
+	}
 }

--- a/ibm/service/cdtoolchain/resource_ibm_cd_toolchain_tool_jira.go
+++ b/ibm/service/cdtoolchain/resource_ibm_cd_toolchain_tool_jira.go
@@ -1,5 +1,9 @@
-// Copyright IBM Corp. 2023 All Rights Reserved.
+// Copyright IBM Corp. 2024 All Rights Reserved.
 // Licensed under the Mozilla Public License v2.0
+
+/*
+ * IBM OpenAPI Terraform Generator Version: 3.96.0-d6dec9d7-20241008-212902
+ */
 
 package cdtoolchain
 
@@ -110,11 +114,13 @@ func ResourceIBMCdToolchainToolJira() *schema.Resource {
 						"ui_href": &schema.Schema{
 							Type:        schema.TypeString,
 							Optional:    true,
+							Computed:    true,
 							Description: "URI representing this resource through the UI.",
 						},
 						"api_href": &schema.Schema{
 							Type:        schema.TypeString,
 							Optional:    true,
+							Computed:    true,
 							Description: "URI representing this resource through an API.",
 						},
 					},
@@ -169,7 +175,9 @@ func ResourceIBMCdToolchainToolJiraValidator() *validate.ResourceValidator {
 func resourceIBMCdToolchainToolJiraCreate(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	cdToolchainClient, err := meta.(conns.ClientSession).CdToolchainV2()
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cd_toolchain_tool_jira", "create", "initialize-client")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	createToolOptions := &cdtoolchainv2.CreateToolOptions{}
@@ -186,10 +194,11 @@ func resourceIBMCdToolchainToolJiraCreate(context context.Context, d *schema.Res
 		createToolOptions.SetName(d.Get("name").(string))
 	}
 
-	toolchainToolPost, response, err := cdToolchainClient.CreateToolWithContext(context, createToolOptions)
+	toolchainToolPost, _, err := cdToolchainClient.CreateToolWithContext(context, createToolOptions)
 	if err != nil {
-		log.Printf("[DEBUG] CreateToolWithContext failed %s\n%s", err, response)
-		return diag.FromErr(fmt.Errorf("CreateToolWithContext failed %s\n%s", err, response))
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("CreateToolWithContext failed: %s", err.Error()), "ibm_cd_toolchain_tool_jira", "create")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	d.SetId(fmt.Sprintf("%s/%s", *createToolOptions.ToolchainID, *toolchainToolPost.ID))
@@ -200,14 +209,16 @@ func resourceIBMCdToolchainToolJiraCreate(context context.Context, d *schema.Res
 func resourceIBMCdToolchainToolJiraRead(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	cdToolchainClient, err := meta.(conns.ClientSession).CdToolchainV2()
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cd_toolchain_tool_jira", "read", "initialize-client")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	getToolByIDOptions := &cdtoolchainv2.GetToolByIDOptions{}
 
 	parts, err := flex.SepIdParts(d.Id(), "/")
 	if err != nil {
-		return diag.FromErr(err)
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cd_toolchain_tool_jira", "read", "sep-id-parts").GetDiag()
 	}
 
 	getToolByIDOptions.SetToolchainID(parts[0])
@@ -233,16 +244,19 @@ func resourceIBMCdToolchainToolJiraRead(context context.Context, d *schema.Resou
 			d.SetId("")
 			return nil
 		}
-		log.Printf("[DEBUG] GetToolByIDWithContext failed %s\n%s", err, response)
-		return diag.FromErr(fmt.Errorf("GetToolByIDWithContext failed %s\n%s", err, response))
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("GetToolByIDWithContext failed: %s", err.Error()), "ibm_cd_toolchain_tool_jira", "read")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	if err = d.Set("toolchain_id", toolchainTool.ToolchainID); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting toolchain_id: %s", err))
+		err = fmt.Errorf("Error setting toolchain_id: %s", err)
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cd_toolchain_tool_jira", "read", "set-toolchain_id").GetDiag()
 	}
 	if !core.IsNil(toolchainTool.Name) {
 		if err = d.Set("name", toolchainTool.Name); err != nil {
-			return diag.FromErr(fmt.Errorf("Error setting name: %s", err))
+			err = fmt.Errorf("Error setting name: %s", err)
+			return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cd_toolchain_tool_jira", "read", "set-name").GetDiag()
 		}
 	}
 	remapFields := map[string]string{
@@ -250,35 +264,44 @@ func resourceIBMCdToolchainToolJiraRead(context context.Context, d *schema.Resou
 	}
 	parametersMap := GetParametersFromRead(toolchainTool.Parameters, ResourceIBMCdToolchainToolJira(), remapFields)
 	if err = d.Set("parameters", []map[string]interface{}{parametersMap}); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting parameters: %s", err))
+		err = fmt.Errorf("Error setting parameters: %s", err)
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cd_toolchain_tool_jira", "read", "set-parameters").GetDiag()
 	}
 	if err = d.Set("resource_group_id", toolchainTool.ResourceGroupID); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting resource_group_id: %s", err))
+		err = fmt.Errorf("Error setting resource_group_id: %s", err)
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cd_toolchain_tool_jira", "read", "set-resource_group_id").GetDiag()
 	}
 	if err = d.Set("crn", toolchainTool.CRN); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting crn: %s", err))
+		err = fmt.Errorf("Error setting crn: %s", err)
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cd_toolchain_tool_jira", "read", "set-crn").GetDiag()
 	}
 	if err = d.Set("toolchain_crn", toolchainTool.ToolchainCRN); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting toolchain_crn: %s", err))
+		err = fmt.Errorf("Error setting toolchain_crn: %s", err)
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cd_toolchain_tool_jira", "read", "set-toolchain_crn").GetDiag()
 	}
 	if err = d.Set("href", toolchainTool.Href); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting href: %s", err))
+		err = fmt.Errorf("Error setting href: %s", err)
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cd_toolchain_tool_jira", "read", "set-href").GetDiag()
 	}
-	referentMap, err := resourceIBMCdToolchainToolJiraToolModelReferentToMap(toolchainTool.Referent)
+	referentMap, err := ResourceIBMCdToolchainToolJiraToolModelReferentToMap(toolchainTool.Referent)
 	if err != nil {
-		return diag.FromErr(err)
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cd_toolchain_tool_jira", "read", "referent-to-map").GetDiag()
 	}
 	if err = d.Set("referent", []map[string]interface{}{referentMap}); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting referent: %s", err))
+		err = fmt.Errorf("Error setting referent: %s", err)
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cd_toolchain_tool_jira", "read", "set-referent").GetDiag()
 	}
 	if err = d.Set("updated_at", flex.DateTimeToString(toolchainTool.UpdatedAt)); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting updated_at: %s", err))
+		err = fmt.Errorf("Error setting updated_at: %s", err)
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cd_toolchain_tool_jira", "read", "set-updated_at").GetDiag()
 	}
 	if err = d.Set("state", toolchainTool.State); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting state: %s", err))
+		err = fmt.Errorf("Error setting state: %s", err)
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cd_toolchain_tool_jira", "read", "set-state").GetDiag()
 	}
 	if err = d.Set("tool_id", toolchainTool.ID); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting tool_id: %s", err))
+		err = fmt.Errorf("Error setting tool_id: %s", err)
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cd_toolchain_tool_jira", "read", "set-tool_id").GetDiag()
 	}
 
 	return nil
@@ -287,14 +310,16 @@ func resourceIBMCdToolchainToolJiraRead(context context.Context, d *schema.Resou
 func resourceIBMCdToolchainToolJiraUpdate(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	cdToolchainClient, err := meta.(conns.ClientSession).CdToolchainV2()
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cd_toolchain_tool_jira", "update", "initialize-client")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	updateToolOptions := &cdtoolchainv2.UpdateToolOptions{}
 
 	parts, err := flex.SepIdParts(d.Id(), "/")
 	if err != nil {
-		return diag.FromErr(err)
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cd_toolchain_tool_jira", "update", "sep-id-parts").GetDiag()
 	}
 
 	updateToolOptions.SetToolchainID(parts[0])
@@ -304,8 +329,9 @@ func resourceIBMCdToolchainToolJiraUpdate(context context.Context, d *schema.Res
 
 	patchVals := &cdtoolchainv2.ToolchainToolPrototypePatch{}
 	if d.HasChange("toolchain_id") {
-		return diag.FromErr(fmt.Errorf("Cannot update resource property \"%s\" with the ForceNew annotation."+
-			" The resource must be re-created to update this property.", "toolchain_id"))
+		errMsg := fmt.Sprintf("Cannot update resource property \"%s\" with the ForceNew annotation."+
+			" The resource must be re-created to update this property.", "toolchain_id")
+		return flex.DiscriminatedTerraformErrorf(nil, errMsg, "ibm_cd_toolchain_tool_jira", "update", "toolchain_id-forces-new").GetDiag()
 	}
 	if d.HasChange("name") {
 		newName := d.Get("name").(string)
@@ -322,11 +348,16 @@ func resourceIBMCdToolchainToolJiraUpdate(context context.Context, d *schema.Res
 	}
 
 	if hasChange {
-		updateToolOptions.ToolchainToolPrototypePatch, _ = patchVals.AsPatch()
-		_, response, err := cdToolchainClient.UpdateToolWithContext(context, updateToolOptions)
+		// Fields with `nil` values are omitted from the generic map,
+		// so we need to re-add them to support removing arguments
+		// in merge-patch operations sent to the service.
+		updateToolOptions.ToolchainToolPrototypePatch = ResourceIBMCdToolchainToolJiraToolchainToolPrototypePatchAsPatch(patchVals, d)
+
+		_, _, err = cdToolchainClient.UpdateToolWithContext(context, updateToolOptions)
 		if err != nil {
-			log.Printf("[DEBUG] UpdateToolWithContext failed %s\n%s", err, response)
-			return diag.FromErr(fmt.Errorf("UpdateToolWithContext failed %s\n%s", err, response))
+			tfErr := flex.TerraformErrorf(err, fmt.Sprintf("UpdateToolWithContext failed: %s", err.Error()), "ibm_cd_toolchain_tool_jira", "update")
+			log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+			return tfErr.GetDiag()
 		}
 	}
 
@@ -336,23 +367,26 @@ func resourceIBMCdToolchainToolJiraUpdate(context context.Context, d *schema.Res
 func resourceIBMCdToolchainToolJiraDelete(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	cdToolchainClient, err := meta.(conns.ClientSession).CdToolchainV2()
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cd_toolchain_tool_jira", "delete", "initialize-client")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	deleteToolOptions := &cdtoolchainv2.DeleteToolOptions{}
 
 	parts, err := flex.SepIdParts(d.Id(), "/")
 	if err != nil {
-		return diag.FromErr(err)
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cd_toolchain_tool_jira", "delete", "sep-id-parts").GetDiag()
 	}
 
 	deleteToolOptions.SetToolchainID(parts[0])
 	deleteToolOptions.SetToolID(parts[1])
 
-	response, err := cdToolchainClient.DeleteToolWithContext(context, deleteToolOptions)
+	_, err = cdToolchainClient.DeleteToolWithContext(context, deleteToolOptions)
 	if err != nil {
-		log.Printf("[DEBUG] DeleteToolWithContext failed %s\n%s", err, response)
-		return diag.FromErr(fmt.Errorf("DeleteToolWithContext failed %s\n%s", err, response))
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("DeleteToolWithContext failed: %s", err.Error()), "ibm_cd_toolchain_tool_jira", "delete")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	d.SetId("")
@@ -360,13 +394,52 @@ func resourceIBMCdToolchainToolJiraDelete(context context.Context, d *schema.Res
 	return nil
 }
 
-func resourceIBMCdToolchainToolJiraToolModelReferentToMap(model *cdtoolchainv2.ToolModelReferent) (map[string]interface{}, error) {
+func ResourceIBMCdToolchainToolJiraToolModelReferentToMap(model *cdtoolchainv2.ToolModelReferent) (map[string]interface{}, error) {
 	modelMap := make(map[string]interface{})
 	if model.UIHref != nil {
-		modelMap["ui_href"] = model.UIHref
+		modelMap["ui_href"] = *model.UIHref
 	}
 	if model.APIHref != nil {
-		modelMap["api_href"] = model.APIHref
+		modelMap["api_href"] = *model.APIHref
 	}
 	return modelMap, nil
+}
+
+func ResourceIBMCdToolchainToolJiraToolchainToolPrototypePatchAsPatch(patchVals *cdtoolchainv2.ToolchainToolPrototypePatch, d *schema.ResourceData) map[string]interface{} {
+	patch, _ := patchVals.AsPatch()
+	var path string
+
+	path = "name"
+	if _, exists := d.GetOk(path); d.HasChange(path) && !exists {
+		patch["name"] = nil
+	}
+	path = "tool_type_id"
+	if _, exists := d.GetOk(path); d.HasChange(path) && !exists {
+		patch["tool_type_id"] = nil
+	}
+	path = "parameters"
+	if _, exists := d.GetOk(path); d.HasChange(path) && !exists {
+		patch["parameters"] = nil
+	} else if exists && patch["parameters"] != nil {
+		ResourceIBMCdToolchainToolJiraToolModelParametersAsPatch(patch["parameters"].(map[string]interface{}), d)
+	}
+
+	return patch
+}
+
+func ResourceIBMCdToolchainToolJiraToolModelParametersAsPatch(patch map[string]interface{}, d *schema.ResourceData) {
+	var path string
+
+	path = "parameters.0.username"
+	if _, exists := d.GetOk(path); d.HasChange(path) && !exists {
+		patch["username"] = nil
+	}
+	path = "parameters.0.enable_traceability"
+	if _, exists := d.GetOk(path); d.HasChange(path) && !exists {
+		patch["enable_traceability"] = nil
+	}
+	path = "parameters.0.api_token"
+	if _, exists := d.GetOk(path); d.HasChange(path) && !exists {
+		patch["api_token"] = nil
+	}
 }

--- a/ibm/service/cdtoolchain/resource_ibm_cd_toolchain_tool_keyprotect.go
+++ b/ibm/service/cdtoolchain/resource_ibm_cd_toolchain_tool_keyprotect.go
@@ -1,5 +1,9 @@
-// Copyright IBM Corp. 2023 All Rights Reserved.
+// Copyright IBM Corp. 2024 All Rights Reserved.
 // Licensed under the Mozilla Public License v2.0
+
+/*
+ * IBM OpenAPI Terraform Generator Version: 3.96.0-d6dec9d7-20241008-212902
+ */
 
 package cdtoolchain
 
@@ -102,11 +106,13 @@ func ResourceIBMCdToolchainToolKeyprotect() *schema.Resource {
 						"ui_href": &schema.Schema{
 							Type:        schema.TypeString,
 							Optional:    true,
+							Computed:    true,
 							Description: "URI representing this resource through the UI.",
 						},
 						"api_href": &schema.Schema{
 							Type:        schema.TypeString,
 							Optional:    true,
+							Computed:    true,
 							Description: "URI representing this resource through an API.",
 						},
 					},
@@ -161,7 +167,9 @@ func ResourceIBMCdToolchainToolKeyprotectValidator() *validate.ResourceValidator
 func resourceIBMCdToolchainToolKeyprotectCreate(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	cdToolchainClient, err := meta.(conns.ClientSession).CdToolchainV2()
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cd_toolchain_tool_keyprotect", "create", "initialize-client")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	createToolOptions := &cdtoolchainv2.CreateToolOptions{}
@@ -179,10 +187,11 @@ func resourceIBMCdToolchainToolKeyprotectCreate(context context.Context, d *sche
 		createToolOptions.SetName(d.Get("name").(string))
 	}
 
-	toolchainToolPost, response, err := cdToolchainClient.CreateToolWithContext(context, createToolOptions)
+	toolchainToolPost, _, err := cdToolchainClient.CreateToolWithContext(context, createToolOptions)
 	if err != nil {
-		log.Printf("[DEBUG] CreateToolWithContext failed %s\n%s", err, response)
-		return diag.FromErr(fmt.Errorf("CreateToolWithContext failed %s\n%s", err, response))
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("CreateToolWithContext failed: %s", err.Error()), "ibm_cd_toolchain_tool_keyprotect", "create")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	d.SetId(fmt.Sprintf("%s/%s", *createToolOptions.ToolchainID, *toolchainToolPost.ID))
@@ -193,14 +202,16 @@ func resourceIBMCdToolchainToolKeyprotectCreate(context context.Context, d *sche
 func resourceIBMCdToolchainToolKeyprotectRead(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	cdToolchainClient, err := meta.(conns.ClientSession).CdToolchainV2()
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cd_toolchain_tool_keyprotect", "read", "initialize-client")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	getToolByIDOptions := &cdtoolchainv2.GetToolByIDOptions{}
 
 	parts, err := flex.SepIdParts(d.Id(), "/")
 	if err != nil {
-		return diag.FromErr(err)
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cd_toolchain_tool_keyprotect", "read", "sep-id-parts").GetDiag()
 	}
 
 	getToolByIDOptions.SetToolchainID(parts[0])
@@ -226,16 +237,19 @@ func resourceIBMCdToolchainToolKeyprotectRead(context context.Context, d *schema
 			d.SetId("")
 			return nil
 		}
-		log.Printf("[DEBUG] GetToolByIDWithContext failed %s\n%s", err, response)
-		return diag.FromErr(fmt.Errorf("GetToolByIDWithContext failed %s\n%s", err, response))
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("GetToolByIDWithContext failed: %s", err.Error()), "ibm_cd_toolchain_tool_keyprotect", "read")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	if err = d.Set("toolchain_id", toolchainTool.ToolchainID); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting toolchain_id: %s", err))
+		err = fmt.Errorf("Error setting toolchain_id: %s", err)
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cd_toolchain_tool_keyprotect", "read", "set-toolchain_id").GetDiag()
 	}
 	if !core.IsNil(toolchainTool.Name) {
 		if err = d.Set("name", toolchainTool.Name); err != nil {
-			return diag.FromErr(fmt.Errorf("Error setting name: %s", err))
+			err = fmt.Errorf("Error setting name: %s", err)
+			return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cd_toolchain_tool_keyprotect", "read", "set-name").GetDiag()
 		}
 	}
 	remapFields := map[string]string{
@@ -245,35 +259,44 @@ func resourceIBMCdToolchainToolKeyprotectRead(context context.Context, d *schema
 	}
 	parametersMap := GetParametersFromRead(toolchainTool.Parameters, ResourceIBMCdToolchainToolKeyprotect(), remapFields)
 	if err = d.Set("parameters", []map[string]interface{}{parametersMap}); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting parameters: %s", err))
+		err = fmt.Errorf("Error setting parameters: %s", err)
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cd_toolchain_tool_keyprotect", "read", "set-parameters").GetDiag()
 	}
 	if err = d.Set("resource_group_id", toolchainTool.ResourceGroupID); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting resource_group_id: %s", err))
+		err = fmt.Errorf("Error setting resource_group_id: %s", err)
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cd_toolchain_tool_keyprotect", "read", "set-resource_group_id").GetDiag()
 	}
 	if err = d.Set("crn", toolchainTool.CRN); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting crn: %s", err))
+		err = fmt.Errorf("Error setting crn: %s", err)
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cd_toolchain_tool_keyprotect", "read", "set-crn").GetDiag()
 	}
 	if err = d.Set("toolchain_crn", toolchainTool.ToolchainCRN); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting toolchain_crn: %s", err))
+		err = fmt.Errorf("Error setting toolchain_crn: %s", err)
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cd_toolchain_tool_keyprotect", "read", "set-toolchain_crn").GetDiag()
 	}
 	if err = d.Set("href", toolchainTool.Href); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting href: %s", err))
+		err = fmt.Errorf("Error setting href: %s", err)
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cd_toolchain_tool_keyprotect", "read", "set-href").GetDiag()
 	}
-	referentMap, err := resourceIBMCdToolchainToolKeyprotectToolModelReferentToMap(toolchainTool.Referent)
+	referentMap, err := ResourceIBMCdToolchainToolKeyprotectToolModelReferentToMap(toolchainTool.Referent)
 	if err != nil {
-		return diag.FromErr(err)
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cd_toolchain_tool_keyprotect", "read", "referent-to-map").GetDiag()
 	}
 	if err = d.Set("referent", []map[string]interface{}{referentMap}); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting referent: %s", err))
+		err = fmt.Errorf("Error setting referent: %s", err)
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cd_toolchain_tool_keyprotect", "read", "set-referent").GetDiag()
 	}
 	if err = d.Set("updated_at", flex.DateTimeToString(toolchainTool.UpdatedAt)); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting updated_at: %s", err))
+		err = fmt.Errorf("Error setting updated_at: %s", err)
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cd_toolchain_tool_keyprotect", "read", "set-updated_at").GetDiag()
 	}
 	if err = d.Set("state", toolchainTool.State); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting state: %s", err))
+		err = fmt.Errorf("Error setting state: %s", err)
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cd_toolchain_tool_keyprotect", "read", "set-state").GetDiag()
 	}
 	if err = d.Set("tool_id", toolchainTool.ID); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting tool_id: %s", err))
+		err = fmt.Errorf("Error setting tool_id: %s", err)
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cd_toolchain_tool_keyprotect", "read", "set-tool_id").GetDiag()
 	}
 
 	return nil
@@ -282,14 +305,16 @@ func resourceIBMCdToolchainToolKeyprotectRead(context context.Context, d *schema
 func resourceIBMCdToolchainToolKeyprotectUpdate(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	cdToolchainClient, err := meta.(conns.ClientSession).CdToolchainV2()
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cd_toolchain_tool_keyprotect", "update", "initialize-client")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	updateToolOptions := &cdtoolchainv2.UpdateToolOptions{}
 
 	parts, err := flex.SepIdParts(d.Id(), "/")
 	if err != nil {
-		return diag.FromErr(err)
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cd_toolchain_tool_keyprotect", "update", "sep-id-parts").GetDiag()
 	}
 
 	updateToolOptions.SetToolchainID(parts[0])
@@ -299,8 +324,9 @@ func resourceIBMCdToolchainToolKeyprotectUpdate(context context.Context, d *sche
 
 	patchVals := &cdtoolchainv2.ToolchainToolPrototypePatch{}
 	if d.HasChange("toolchain_id") {
-		return diag.FromErr(fmt.Errorf("Cannot update resource property \"%s\" with the ForceNew annotation."+
-			" The resource must be re-created to update this property.", "toolchain_id"))
+		errMsg := fmt.Sprintf("Cannot update resource property \"%s\" with the ForceNew annotation."+
+			" The resource must be re-created to update this property.", "toolchain_id")
+		return flex.DiscriminatedTerraformErrorf(nil, errMsg, "ibm_cd_toolchain_tool_keyprotect", "update", "toolchain_id-forces-new").GetDiag()
 	}
 	if d.HasChange("name") {
 		newName := d.Get("name").(string)
@@ -319,11 +345,16 @@ func resourceIBMCdToolchainToolKeyprotectUpdate(context context.Context, d *sche
 	}
 
 	if hasChange {
-		updateToolOptions.ToolchainToolPrototypePatch, _ = patchVals.AsPatch()
-		_, response, err := cdToolchainClient.UpdateToolWithContext(context, updateToolOptions)
+		// Fields with `nil` values are omitted from the generic map,
+		// so we need to re-add them to support removing arguments
+		// in merge-patch operations sent to the service.
+		updateToolOptions.ToolchainToolPrototypePatch = ResourceIBMCdToolchainToolKeyprotectToolchainToolPrototypePatchAsPatch(patchVals, d)
+
+		_, _, err = cdToolchainClient.UpdateToolWithContext(context, updateToolOptions)
 		if err != nil {
-			log.Printf("[DEBUG] UpdateToolWithContext failed %s\n%s", err, response)
-			return diag.FromErr(fmt.Errorf("UpdateToolWithContext failed %s\n%s", err, response))
+			tfErr := flex.TerraformErrorf(err, fmt.Sprintf("UpdateToolWithContext failed: %s", err.Error()), "ibm_cd_toolchain_tool_keyprotect", "update")
+			log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+			return tfErr.GetDiag()
 		}
 	}
 
@@ -333,23 +364,26 @@ func resourceIBMCdToolchainToolKeyprotectUpdate(context context.Context, d *sche
 func resourceIBMCdToolchainToolKeyprotectDelete(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	cdToolchainClient, err := meta.(conns.ClientSession).CdToolchainV2()
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cd_toolchain_tool_keyprotect", "delete", "initialize-client")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	deleteToolOptions := &cdtoolchainv2.DeleteToolOptions{}
 
 	parts, err := flex.SepIdParts(d.Id(), "/")
 	if err != nil {
-		return diag.FromErr(err)
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cd_toolchain_tool_keyprotect", "delete", "sep-id-parts").GetDiag()
 	}
 
 	deleteToolOptions.SetToolchainID(parts[0])
 	deleteToolOptions.SetToolID(parts[1])
 
-	response, err := cdToolchainClient.DeleteToolWithContext(context, deleteToolOptions)
+	_, err = cdToolchainClient.DeleteToolWithContext(context, deleteToolOptions)
 	if err != nil {
-		log.Printf("[DEBUG] DeleteToolWithContext failed %s\n%s", err, response)
-		return diag.FromErr(fmt.Errorf("DeleteToolWithContext failed %s\n%s", err, response))
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("DeleteToolWithContext failed: %s", err.Error()), "ibm_cd_toolchain_tool_keyprotect", "delete")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	d.SetId("")
@@ -357,13 +391,33 @@ func resourceIBMCdToolchainToolKeyprotectDelete(context context.Context, d *sche
 	return nil
 }
 
-func resourceIBMCdToolchainToolKeyprotectToolModelReferentToMap(model *cdtoolchainv2.ToolModelReferent) (map[string]interface{}, error) {
+func ResourceIBMCdToolchainToolKeyprotectToolModelReferentToMap(model *cdtoolchainv2.ToolModelReferent) (map[string]interface{}, error) {
 	modelMap := make(map[string]interface{})
 	if model.UIHref != nil {
-		modelMap["ui_href"] = model.UIHref
+		modelMap["ui_href"] = *model.UIHref
 	}
 	if model.APIHref != nil {
-		modelMap["api_href"] = model.APIHref
+		modelMap["api_href"] = *model.APIHref
 	}
 	return modelMap, nil
+}
+
+func ResourceIBMCdToolchainToolKeyprotectToolchainToolPrototypePatchAsPatch(patchVals *cdtoolchainv2.ToolchainToolPrototypePatch, d *schema.ResourceData) map[string]interface{} {
+	patch, _ := patchVals.AsPatch()
+	var path string
+
+	path = "name"
+	if _, exists := d.GetOk(path); d.HasChange(path) && !exists {
+		patch["name"] = nil
+	}
+	path = "tool_type_id"
+	if _, exists := d.GetOk(path); d.HasChange(path) && !exists {
+		patch["tool_type_id"] = nil
+	}
+	path = "parameters"
+	if _, exists := d.GetOk(path); d.HasChange(path) && !exists {
+		patch["parameters"] = nil
+	}
+
+	return patch
 }

--- a/ibm/service/cdtoolchain/resource_ibm_cd_toolchain_tool_nexus.go
+++ b/ibm/service/cdtoolchain/resource_ibm_cd_toolchain_tool_nexus.go
@@ -1,5 +1,9 @@
-// Copyright IBM Corp. 2023 All Rights Reserved.
+// Copyright IBM Corp. 2024 All Rights Reserved.
 // Licensed under the Mozilla Public License v2.0
+
+/*
+ * IBM OpenAPI Terraform Generator Version: 3.96.0-d6dec9d7-20241008-212902
+ */
 
 package cdtoolchain
 
@@ -124,11 +128,13 @@ func ResourceIBMCdToolchainToolNexus() *schema.Resource {
 						"ui_href": &schema.Schema{
 							Type:        schema.TypeString,
 							Optional:    true,
+							Computed:    true,
 							Description: "URI representing this resource through the UI.",
 						},
 						"api_href": &schema.Schema{
 							Type:        schema.TypeString,
 							Optional:    true,
+							Computed:    true,
 							Description: "URI representing this resource through an API.",
 						},
 					},
@@ -183,7 +189,9 @@ func ResourceIBMCdToolchainToolNexusValidator() *validate.ResourceValidator {
 func resourceIBMCdToolchainToolNexusCreate(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	cdToolchainClient, err := meta.(conns.ClientSession).CdToolchainV2()
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cd_toolchain_tool_nexus", "create", "initialize-client")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	createToolOptions := &cdtoolchainv2.CreateToolOptions{}
@@ -199,10 +207,11 @@ func resourceIBMCdToolchainToolNexusCreate(context context.Context, d *schema.Re
 		createToolOptions.SetName(d.Get("name").(string))
 	}
 
-	toolchainToolPost, response, err := cdToolchainClient.CreateToolWithContext(context, createToolOptions)
+	toolchainToolPost, _, err := cdToolchainClient.CreateToolWithContext(context, createToolOptions)
 	if err != nil {
-		log.Printf("[DEBUG] CreateToolWithContext failed %s\n%s", err, response)
-		return diag.FromErr(fmt.Errorf("CreateToolWithContext failed %s\n%s", err, response))
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("CreateToolWithContext failed: %s", err.Error()), "ibm_cd_toolchain_tool_nexus", "create")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	d.SetId(fmt.Sprintf("%s/%s", *createToolOptions.ToolchainID, *toolchainToolPost.ID))
@@ -213,14 +222,16 @@ func resourceIBMCdToolchainToolNexusCreate(context context.Context, d *schema.Re
 func resourceIBMCdToolchainToolNexusRead(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	cdToolchainClient, err := meta.(conns.ClientSession).CdToolchainV2()
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cd_toolchain_tool_nexus", "read", "initialize-client")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	getToolByIDOptions := &cdtoolchainv2.GetToolByIDOptions{}
 
 	parts, err := flex.SepIdParts(d.Id(), "/")
 	if err != nil {
-		return diag.FromErr(err)
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cd_toolchain_tool_nexus", "read", "sep-id-parts").GetDiag()
 	}
 
 	getToolByIDOptions.SetToolchainID(parts[0])
@@ -246,16 +257,19 @@ func resourceIBMCdToolchainToolNexusRead(context context.Context, d *schema.Reso
 			d.SetId("")
 			return nil
 		}
-		log.Printf("[DEBUG] GetToolByIDWithContext failed %s\n%s", err, response)
-		return diag.FromErr(fmt.Errorf("GetToolByIDWithContext failed %s\n%s", err, response))
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("GetToolByIDWithContext failed: %s", err.Error()), "ibm_cd_toolchain_tool_nexus", "read")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	if err = d.Set("toolchain_id", toolchainTool.ToolchainID); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting toolchain_id: %s", err))
+		err = fmt.Errorf("Error setting toolchain_id: %s", err)
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cd_toolchain_tool_nexus", "read", "set-toolchain_id").GetDiag()
 	}
 	if !core.IsNil(toolchainTool.Name) {
 		if err = d.Set("name", toolchainTool.Name); err != nil {
-			return diag.FromErr(fmt.Errorf("Error setting name: %s", err))
+			err = fmt.Errorf("Error setting name: %s", err)
+			return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cd_toolchain_tool_nexus", "read", "set-name").GetDiag()
 		}
 	}
 	remapFields := map[string]string{
@@ -263,35 +277,44 @@ func resourceIBMCdToolchainToolNexusRead(context context.Context, d *schema.Reso
 	}
 	parametersMap := GetParametersFromRead(toolchainTool.Parameters, ResourceIBMCdToolchainToolNexus(), remapFields)
 	if err = d.Set("parameters", []map[string]interface{}{parametersMap}); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting parameters: %s", err))
+		err = fmt.Errorf("Error setting parameters: %s", err)
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cd_toolchain_tool_nexus", "read", "set-parameters").GetDiag()
 	}
 	if err = d.Set("resource_group_id", toolchainTool.ResourceGroupID); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting resource_group_id: %s", err))
+		err = fmt.Errorf("Error setting resource_group_id: %s", err)
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cd_toolchain_tool_nexus", "read", "set-resource_group_id").GetDiag()
 	}
 	if err = d.Set("crn", toolchainTool.CRN); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting crn: %s", err))
+		err = fmt.Errorf("Error setting crn: %s", err)
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cd_toolchain_tool_nexus", "read", "set-crn").GetDiag()
 	}
 	if err = d.Set("toolchain_crn", toolchainTool.ToolchainCRN); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting toolchain_crn: %s", err))
+		err = fmt.Errorf("Error setting toolchain_crn: %s", err)
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cd_toolchain_tool_nexus", "read", "set-toolchain_crn").GetDiag()
 	}
 	if err = d.Set("href", toolchainTool.Href); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting href: %s", err))
+		err = fmt.Errorf("Error setting href: %s", err)
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cd_toolchain_tool_nexus", "read", "set-href").GetDiag()
 	}
-	referentMap, err := resourceIBMCdToolchainToolNexusToolModelReferentToMap(toolchainTool.Referent)
+	referentMap, err := ResourceIBMCdToolchainToolNexusToolModelReferentToMap(toolchainTool.Referent)
 	if err != nil {
-		return diag.FromErr(err)
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cd_toolchain_tool_nexus", "read", "referent-to-map").GetDiag()
 	}
 	if err = d.Set("referent", []map[string]interface{}{referentMap}); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting referent: %s", err))
+		err = fmt.Errorf("Error setting referent: %s", err)
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cd_toolchain_tool_nexus", "read", "set-referent").GetDiag()
 	}
 	if err = d.Set("updated_at", flex.DateTimeToString(toolchainTool.UpdatedAt)); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting updated_at: %s", err))
+		err = fmt.Errorf("Error setting updated_at: %s", err)
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cd_toolchain_tool_nexus", "read", "set-updated_at").GetDiag()
 	}
 	if err = d.Set("state", toolchainTool.State); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting state: %s", err))
+		err = fmt.Errorf("Error setting state: %s", err)
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cd_toolchain_tool_nexus", "read", "set-state").GetDiag()
 	}
 	if err = d.Set("tool_id", toolchainTool.ID); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting tool_id: %s", err))
+		err = fmt.Errorf("Error setting tool_id: %s", err)
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cd_toolchain_tool_nexus", "read", "set-tool_id").GetDiag()
 	}
 
 	return nil
@@ -300,14 +323,16 @@ func resourceIBMCdToolchainToolNexusRead(context context.Context, d *schema.Reso
 func resourceIBMCdToolchainToolNexusUpdate(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	cdToolchainClient, err := meta.(conns.ClientSession).CdToolchainV2()
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cd_toolchain_tool_nexus", "update", "initialize-client")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	updateToolOptions := &cdtoolchainv2.UpdateToolOptions{}
 
 	parts, err := flex.SepIdParts(d.Id(), "/")
 	if err != nil {
-		return diag.FromErr(err)
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cd_toolchain_tool_nexus", "update", "sep-id-parts").GetDiag()
 	}
 
 	updateToolOptions.SetToolchainID(parts[0])
@@ -317,8 +342,9 @@ func resourceIBMCdToolchainToolNexusUpdate(context context.Context, d *schema.Re
 
 	patchVals := &cdtoolchainv2.ToolchainToolPrototypePatch{}
 	if d.HasChange("toolchain_id") {
-		return diag.FromErr(fmt.Errorf("Cannot update resource property \"%s\" with the ForceNew annotation."+
-			" The resource must be re-created to update this property.", "toolchain_id"))
+		errMsg := fmt.Sprintf("Cannot update resource property \"%s\" with the ForceNew annotation."+
+			" The resource must be re-created to update this property.", "toolchain_id")
+		return flex.DiscriminatedTerraformErrorf(nil, errMsg, "ibm_cd_toolchain_tool_nexus", "update", "toolchain_id-forces-new").GetDiag()
 	}
 	if d.HasChange("name") {
 		newName := d.Get("name").(string)
@@ -335,11 +361,16 @@ func resourceIBMCdToolchainToolNexusUpdate(context context.Context, d *schema.Re
 	}
 
 	if hasChange {
-		updateToolOptions.ToolchainToolPrototypePatch, _ = patchVals.AsPatch()
-		_, response, err := cdToolchainClient.UpdateToolWithContext(context, updateToolOptions)
+		// Fields with `nil` values are omitted from the generic map,
+		// so we need to re-add them to support removing arguments
+		// in merge-patch operations sent to the service.
+		updateToolOptions.ToolchainToolPrototypePatch = ResourceIBMCdToolchainToolNexusToolchainToolPrototypePatchAsPatch(patchVals, d)
+
+		_, _, err = cdToolchainClient.UpdateToolWithContext(context, updateToolOptions)
 		if err != nil {
-			log.Printf("[DEBUG] UpdateToolWithContext failed %s\n%s", err, response)
-			return diag.FromErr(fmt.Errorf("UpdateToolWithContext failed %s\n%s", err, response))
+			tfErr := flex.TerraformErrorf(err, fmt.Sprintf("UpdateToolWithContext failed: %s", err.Error()), "ibm_cd_toolchain_tool_nexus", "update")
+			log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+			return tfErr.GetDiag()
 		}
 	}
 
@@ -349,23 +380,26 @@ func resourceIBMCdToolchainToolNexusUpdate(context context.Context, d *schema.Re
 func resourceIBMCdToolchainToolNexusDelete(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	cdToolchainClient, err := meta.(conns.ClientSession).CdToolchainV2()
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cd_toolchain_tool_nexus", "delete", "initialize-client")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	deleteToolOptions := &cdtoolchainv2.DeleteToolOptions{}
 
 	parts, err := flex.SepIdParts(d.Id(), "/")
 	if err != nil {
-		return diag.FromErr(err)
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cd_toolchain_tool_nexus", "delete", "sep-id-parts").GetDiag()
 	}
 
 	deleteToolOptions.SetToolchainID(parts[0])
 	deleteToolOptions.SetToolID(parts[1])
 
-	response, err := cdToolchainClient.DeleteToolWithContext(context, deleteToolOptions)
+	_, err = cdToolchainClient.DeleteToolWithContext(context, deleteToolOptions)
 	if err != nil {
-		log.Printf("[DEBUG] DeleteToolWithContext failed %s\n%s", err, response)
-		return diag.FromErr(fmt.Errorf("DeleteToolWithContext failed %s\n%s", err, response))
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("DeleteToolWithContext failed: %s", err.Error()), "ibm_cd_toolchain_tool_nexus", "delete")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	d.SetId("")
@@ -373,13 +407,64 @@ func resourceIBMCdToolchainToolNexusDelete(context context.Context, d *schema.Re
 	return nil
 }
 
-func resourceIBMCdToolchainToolNexusToolModelReferentToMap(model *cdtoolchainv2.ToolModelReferent) (map[string]interface{}, error) {
+func ResourceIBMCdToolchainToolNexusToolModelReferentToMap(model *cdtoolchainv2.ToolModelReferent) (map[string]interface{}, error) {
 	modelMap := make(map[string]interface{})
 	if model.UIHref != nil {
-		modelMap["ui_href"] = model.UIHref
+		modelMap["ui_href"] = *model.UIHref
 	}
 	if model.APIHref != nil {
-		modelMap["api_href"] = model.APIHref
+		modelMap["api_href"] = *model.APIHref
 	}
 	return modelMap, nil
+}
+
+func ResourceIBMCdToolchainToolNexusToolchainToolPrototypePatchAsPatch(patchVals *cdtoolchainv2.ToolchainToolPrototypePatch, d *schema.ResourceData) map[string]interface{} {
+	patch, _ := patchVals.AsPatch()
+	var path string
+
+	path = "name"
+	if _, exists := d.GetOk(path); d.HasChange(path) && !exists {
+		patch["name"] = nil
+	}
+	path = "tool_type_id"
+	if _, exists := d.GetOk(path); d.HasChange(path) && !exists {
+		patch["tool_type_id"] = nil
+	}
+	path = "parameters"
+	if _, exists := d.GetOk(path); d.HasChange(path) && !exists {
+		patch["parameters"] = nil
+	} else if exists && patch["parameters"] != nil {
+		ResourceIBMCdToolchainToolNexusToolModelParametersAsPatch(patch["parameters"].(map[string]interface{}), d)
+	}
+
+	return patch
+}
+
+func ResourceIBMCdToolchainToolNexusToolModelParametersAsPatch(patch map[string]interface{}, d *schema.ResourceData) {
+	var path string
+
+	path = "parameters.0.user_id"
+	if _, exists := d.GetOk(path); d.HasChange(path) && !exists {
+		patch["user_id"] = nil
+	}
+	path = "parameters.0.token"
+	if _, exists := d.GetOk(path); d.HasChange(path) && !exists {
+		patch["token"] = nil
+	}
+	path = "parameters.0.release_url"
+	if _, exists := d.GetOk(path); d.HasChange(path) && !exists {
+		patch["release_url"] = nil
+	}
+	path = "parameters.0.mirror_url"
+	if _, exists := d.GetOk(path); d.HasChange(path) && !exists {
+		patch["mirror_url"] = nil
+	}
+	path = "parameters.0.snapshot_url"
+	if _, exists := d.GetOk(path); d.HasChange(path) && !exists {
+		patch["snapshot_url"] = nil
+	}
+	path = "parameters.0.server_url"
+	if _, exists := d.GetOk(path); d.HasChange(path) && !exists {
+		patch["server_url"] = nil
+	}
 }

--- a/ibm/service/cdtoolchain/resource_ibm_cd_toolchain_tool_pagerduty.go
+++ b/ibm/service/cdtoolchain/resource_ibm_cd_toolchain_tool_pagerduty.go
@@ -1,5 +1,9 @@
-// Copyright IBM Corp. 2023 All Rights Reserved.
+// Copyright IBM Corp. 2024 All Rights Reserved.
 // Licensed under the Mozilla Public License v2.0
+
+/*
+ * IBM OpenAPI Terraform Generator Version: 3.96.0-d6dec9d7-20241008-212902
+ */
 
 package cdtoolchain
 
@@ -64,6 +68,7 @@ func ResourceIBMCdToolchainToolPagerduty() *schema.Resource {
 						},
 						"service_id": &schema.Schema{
 							Type:        schema.TypeString,
+							Optional:    true,
 							Computed:    true,
 							Description: "The service ID of the PagerDuty service.",
 						},
@@ -99,11 +104,13 @@ func ResourceIBMCdToolchainToolPagerduty() *schema.Resource {
 						"ui_href": &schema.Schema{
 							Type:        schema.TypeString,
 							Optional:    true,
+							Computed:    true,
 							Description: "URI representing this resource through the UI.",
 						},
 						"api_href": &schema.Schema{
 							Type:        schema.TypeString,
 							Optional:    true,
+							Computed:    true,
 							Description: "URI representing this resource through an API.",
 						},
 					},
@@ -158,7 +165,9 @@ func ResourceIBMCdToolchainToolPagerdutyValidator() *validate.ResourceValidator 
 func resourceIBMCdToolchainToolPagerdutyCreate(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	cdToolchainClient, err := meta.(conns.ClientSession).CdToolchainV2()
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cd_toolchain_tool_pagerduty", "create", "initialize-client")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	createToolOptions := &cdtoolchainv2.CreateToolOptions{}
@@ -172,10 +181,11 @@ func resourceIBMCdToolchainToolPagerdutyCreate(context context.Context, d *schem
 		createToolOptions.SetName(d.Get("name").(string))
 	}
 
-	toolchainToolPost, response, err := cdToolchainClient.CreateToolWithContext(context, createToolOptions)
+	toolchainToolPost, _, err := cdToolchainClient.CreateToolWithContext(context, createToolOptions)
 	if err != nil {
-		log.Printf("[DEBUG] CreateToolWithContext failed %s\n%s", err, response)
-		return diag.FromErr(fmt.Errorf("CreateToolWithContext failed %s\n%s", err, response))
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("CreateToolWithContext failed: %s", err.Error()), "ibm_cd_toolchain_tool_pagerduty", "create")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	d.SetId(fmt.Sprintf("%s/%s", *createToolOptions.ToolchainID, *toolchainToolPost.ID))
@@ -186,14 +196,16 @@ func resourceIBMCdToolchainToolPagerdutyCreate(context context.Context, d *schem
 func resourceIBMCdToolchainToolPagerdutyRead(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	cdToolchainClient, err := meta.(conns.ClientSession).CdToolchainV2()
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cd_toolchain_tool_pagerduty", "read", "initialize-client")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	getToolByIDOptions := &cdtoolchainv2.GetToolByIDOptions{}
 
 	parts, err := flex.SepIdParts(d.Id(), "/")
 	if err != nil {
-		return diag.FromErr(err)
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cd_toolchain_tool_pagerduty", "read", "sep-id-parts").GetDiag()
 	}
 
 	getToolByIDOptions.SetToolchainID(parts[0])
@@ -219,49 +231,61 @@ func resourceIBMCdToolchainToolPagerdutyRead(context context.Context, d *schema.
 			d.SetId("")
 			return nil
 		}
-		log.Printf("[DEBUG] GetToolByIDWithContext failed %s\n%s", err, response)
-		return diag.FromErr(fmt.Errorf("GetToolByIDWithContext failed %s\n%s", err, response))
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("GetToolByIDWithContext failed: %s", err.Error()), "ibm_cd_toolchain_tool_pagerduty", "read")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	if err = d.Set("toolchain_id", toolchainTool.ToolchainID); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting toolchain_id: %s", err))
+		err = fmt.Errorf("Error setting toolchain_id: %s", err)
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cd_toolchain_tool_pagerduty", "read", "set-toolchain_id").GetDiag()
 	}
 	if !core.IsNil(toolchainTool.Name) {
 		if err = d.Set("name", toolchainTool.Name); err != nil {
-			return diag.FromErr(fmt.Errorf("Error setting name: %s", err))
+			err = fmt.Errorf("Error setting name: %s", err)
+			return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cd_toolchain_tool_pagerduty", "read", "set-name").GetDiag()
 		}
 	}
 	parametersMap := GetParametersFromRead(toolchainTool.Parameters, ResourceIBMCdToolchainToolPagerduty(), nil)
 	if err = d.Set("parameters", []map[string]interface{}{parametersMap}); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting parameters: %s", err))
+		err = fmt.Errorf("Error setting parameters: %s", err)
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cd_toolchain_tool_pagerduty", "read", "set-parameters").GetDiag()
 	}
 	if err = d.Set("resource_group_id", toolchainTool.ResourceGroupID); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting resource_group_id: %s", err))
+		err = fmt.Errorf("Error setting resource_group_id: %s", err)
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cd_toolchain_tool_pagerduty", "read", "set-resource_group_id").GetDiag()
 	}
 	if err = d.Set("crn", toolchainTool.CRN); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting crn: %s", err))
+		err = fmt.Errorf("Error setting crn: %s", err)
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cd_toolchain_tool_pagerduty", "read", "set-crn").GetDiag()
 	}
 	if err = d.Set("toolchain_crn", toolchainTool.ToolchainCRN); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting toolchain_crn: %s", err))
+		err = fmt.Errorf("Error setting toolchain_crn: %s", err)
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cd_toolchain_tool_pagerduty", "read", "set-toolchain_crn").GetDiag()
 	}
 	if err = d.Set("href", toolchainTool.Href); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting href: %s", err))
+		err = fmt.Errorf("Error setting href: %s", err)
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cd_toolchain_tool_pagerduty", "read", "set-href").GetDiag()
 	}
-	referentMap, err := resourceIBMCdToolchainToolPagerdutyToolModelReferentToMap(toolchainTool.Referent)
+	referentMap, err := ResourceIBMCdToolchainToolPagerdutyToolModelReferentToMap(toolchainTool.Referent)
 	if err != nil {
-		return diag.FromErr(err)
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cd_toolchain_tool_pagerduty", "read", "referent-to-map").GetDiag()
 	}
 	if err = d.Set("referent", []map[string]interface{}{referentMap}); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting referent: %s", err))
+		err = fmt.Errorf("Error setting referent: %s", err)
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cd_toolchain_tool_pagerduty", "read", "set-referent").GetDiag()
 	}
 	if err = d.Set("updated_at", flex.DateTimeToString(toolchainTool.UpdatedAt)); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting updated_at: %s", err))
+		err = fmt.Errorf("Error setting updated_at: %s", err)
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cd_toolchain_tool_pagerduty", "read", "set-updated_at").GetDiag()
 	}
 	if err = d.Set("state", toolchainTool.State); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting state: %s", err))
+		err = fmt.Errorf("Error setting state: %s", err)
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cd_toolchain_tool_pagerduty", "read", "set-state").GetDiag()
 	}
 	if err = d.Set("tool_id", toolchainTool.ID); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting tool_id: %s", err))
+		err = fmt.Errorf("Error setting tool_id: %s", err)
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cd_toolchain_tool_pagerduty", "read", "set-tool_id").GetDiag()
 	}
 
 	return nil
@@ -270,14 +294,16 @@ func resourceIBMCdToolchainToolPagerdutyRead(context context.Context, d *schema.
 func resourceIBMCdToolchainToolPagerdutyUpdate(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	cdToolchainClient, err := meta.(conns.ClientSession).CdToolchainV2()
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cd_toolchain_tool_pagerduty", "update", "initialize-client")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	updateToolOptions := &cdtoolchainv2.UpdateToolOptions{}
 
 	parts, err := flex.SepIdParts(d.Id(), "/")
 	if err != nil {
-		return diag.FromErr(err)
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cd_toolchain_tool_pagerduty", "update", "sep-id-parts").GetDiag()
 	}
 
 	updateToolOptions.SetToolchainID(parts[0])
@@ -287,8 +313,9 @@ func resourceIBMCdToolchainToolPagerdutyUpdate(context context.Context, d *schem
 
 	patchVals := &cdtoolchainv2.ToolchainToolPrototypePatch{}
 	if d.HasChange("toolchain_id") {
-		return diag.FromErr(fmt.Errorf("Cannot update resource property \"%s\" with the ForceNew annotation."+
-			" The resource must be re-created to update this property.", "toolchain_id"))
+		errMsg := fmt.Sprintf("Cannot update resource property \"%s\" with the ForceNew annotation."+
+			" The resource must be re-created to update this property.", "toolchain_id")
+		return flex.DiscriminatedTerraformErrorf(nil, errMsg, "ibm_cd_toolchain_tool_pagerduty", "update", "toolchain_id-forces-new").GetDiag()
 	}
 	if d.HasChange("name") {
 		newName := d.Get("name").(string)
@@ -302,11 +329,16 @@ func resourceIBMCdToolchainToolPagerdutyUpdate(context context.Context, d *schem
 	}
 
 	if hasChange {
-		updateToolOptions.ToolchainToolPrototypePatch, _ = patchVals.AsPatch()
-		_, response, err := cdToolchainClient.UpdateToolWithContext(context, updateToolOptions)
+		// Fields with `nil` values are omitted from the generic map,
+		// so we need to re-add them to support removing arguments
+		// in merge-patch operations sent to the service.
+		updateToolOptions.ToolchainToolPrototypePatch = ResourceIBMCdToolchainToolPagerdutyToolchainToolPrototypePatchAsPatch(patchVals, d)
+
+		_, _, err = cdToolchainClient.UpdateToolWithContext(context, updateToolOptions)
 		if err != nil {
-			log.Printf("[DEBUG] UpdateToolWithContext failed %s\n%s", err, response)
-			return diag.FromErr(fmt.Errorf("UpdateToolWithContext failed %s\n%s", err, response))
+			tfErr := flex.TerraformErrorf(err, fmt.Sprintf("UpdateToolWithContext failed: %s", err.Error()), "ibm_cd_toolchain_tool_pagerduty", "update")
+			log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+			return tfErr.GetDiag()
 		}
 	}
 
@@ -316,23 +348,26 @@ func resourceIBMCdToolchainToolPagerdutyUpdate(context context.Context, d *schem
 func resourceIBMCdToolchainToolPagerdutyDelete(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	cdToolchainClient, err := meta.(conns.ClientSession).CdToolchainV2()
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cd_toolchain_tool_pagerduty", "delete", "initialize-client")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	deleteToolOptions := &cdtoolchainv2.DeleteToolOptions{}
 
 	parts, err := flex.SepIdParts(d.Id(), "/")
 	if err != nil {
-		return diag.FromErr(err)
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cd_toolchain_tool_pagerduty", "delete", "sep-id-parts").GetDiag()
 	}
 
 	deleteToolOptions.SetToolchainID(parts[0])
 	deleteToolOptions.SetToolID(parts[1])
 
-	response, err := cdToolchainClient.DeleteToolWithContext(context, deleteToolOptions)
+	_, err = cdToolchainClient.DeleteToolWithContext(context, deleteToolOptions)
 	if err != nil {
-		log.Printf("[DEBUG] DeleteToolWithContext failed %s\n%s", err, response)
-		return diag.FromErr(fmt.Errorf("DeleteToolWithContext failed %s\n%s", err, response))
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("DeleteToolWithContext failed: %s", err.Error()), "ibm_cd_toolchain_tool_pagerduty", "delete")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	d.SetId("")
@@ -340,13 +375,44 @@ func resourceIBMCdToolchainToolPagerdutyDelete(context context.Context, d *schem
 	return nil
 }
 
-func resourceIBMCdToolchainToolPagerdutyToolModelReferentToMap(model *cdtoolchainv2.ToolModelReferent) (map[string]interface{}, error) {
+func ResourceIBMCdToolchainToolPagerdutyToolModelReferentToMap(model *cdtoolchainv2.ToolModelReferent) (map[string]interface{}, error) {
 	modelMap := make(map[string]interface{})
 	if model.UIHref != nil {
-		modelMap["ui_href"] = model.UIHref
+		modelMap["ui_href"] = *model.UIHref
 	}
 	if model.APIHref != nil {
-		modelMap["api_href"] = model.APIHref
+		modelMap["api_href"] = *model.APIHref
 	}
 	return modelMap, nil
+}
+
+func ResourceIBMCdToolchainToolPagerdutyToolchainToolPrototypePatchAsPatch(patchVals *cdtoolchainv2.ToolchainToolPrototypePatch, d *schema.ResourceData) map[string]interface{} {
+	patch, _ := patchVals.AsPatch()
+	var path string
+
+	path = "name"
+	if _, exists := d.GetOk(path); d.HasChange(path) && !exists {
+		patch["name"] = nil
+	}
+	path = "tool_type_id"
+	if _, exists := d.GetOk(path); d.HasChange(path) && !exists {
+		patch["tool_type_id"] = nil
+	}
+	path = "parameters"
+	if _, exists := d.GetOk(path); d.HasChange(path) && !exists {
+		patch["parameters"] = nil
+	} else if exists && patch["parameters"] != nil {
+		ResourceIBMCdToolchainToolPagerdutyToolModelParametersAsPatch(patch["parameters"].(map[string]interface{}), d)
+	}
+
+	return patch
+}
+
+func ResourceIBMCdToolchainToolPagerdutyToolModelParametersAsPatch(patch map[string]interface{}, d *schema.ResourceData) {
+	var path string
+
+	path = "parameters.0.service_id"
+	if _, exists := d.GetOk(path); d.HasChange(path) && !exists {
+		patch["service_id"] = nil
+	}
 }

--- a/ibm/service/cdtoolchain/resource_ibm_cd_toolchain_tool_pipeline.go
+++ b/ibm/service/cdtoolchain/resource_ibm_cd_toolchain_tool_pipeline.go
@@ -1,5 +1,9 @@
-// Copyright IBM Corp. 2023 All Rights Reserved.
+// Copyright IBM Corp. 2024 All Rights Reserved.
 // Licensed under the Mozilla Public License v2.0
+
+/*
+ * IBM OpenAPI Terraform Generator Version: 3.96.0-d6dec9d7-20241008-212902
+ */
 
 package cdtoolchain
 
@@ -87,11 +91,13 @@ func ResourceIBMCdToolchainToolPipeline() *schema.Resource {
 						"ui_href": &schema.Schema{
 							Type:        schema.TypeString,
 							Optional:    true,
+							Computed:    true,
 							Description: "URI representing this resource through the UI.",
 						},
 						"api_href": &schema.Schema{
 							Type:        schema.TypeString,
 							Optional:    true,
+							Computed:    true,
 							Description: "URI representing this resource through an API.",
 						},
 					},
@@ -146,7 +152,9 @@ func ResourceIBMCdToolchainToolPipelineValidator() *validate.ResourceValidator {
 func resourceIBMCdToolchainToolPipelineCreate(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	cdToolchainClient, err := meta.(conns.ClientSession).CdToolchainV2()
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cd_toolchain_tool_pipeline", "create", "initialize-client")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	createToolOptions := &cdtoolchainv2.CreateToolOptions{}
@@ -160,10 +168,11 @@ func resourceIBMCdToolchainToolPipelineCreate(context context.Context, d *schema
 		createToolOptions.SetName(d.Get("name").(string))
 	}
 
-	toolchainToolPost, response, err := cdToolchainClient.CreateToolWithContext(context, createToolOptions)
+	toolchainToolPost, _, err := cdToolchainClient.CreateToolWithContext(context, createToolOptions)
 	if err != nil {
-		log.Printf("[DEBUG] CreateToolWithContext failed %s\n%s", err, response)
-		return diag.FromErr(fmt.Errorf("CreateToolWithContext failed %s\n%s", err, response))
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("CreateToolWithContext failed: %s", err.Error()), "ibm_cd_toolchain_tool_pipeline", "create")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	d.SetId(fmt.Sprintf("%s/%s", *createToolOptions.ToolchainID, *toolchainToolPost.ID))
@@ -174,14 +183,16 @@ func resourceIBMCdToolchainToolPipelineCreate(context context.Context, d *schema
 func resourceIBMCdToolchainToolPipelineRead(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	cdToolchainClient, err := meta.(conns.ClientSession).CdToolchainV2()
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cd_toolchain_tool_pipeline", "read", "initialize-client")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	getToolByIDOptions := &cdtoolchainv2.GetToolByIDOptions{}
 
 	parts, err := flex.SepIdParts(d.Id(), "/")
 	if err != nil {
-		return diag.FromErr(err)
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cd_toolchain_tool_pipeline", "read", "sep-id-parts").GetDiag()
 	}
 
 	getToolByIDOptions.SetToolchainID(parts[0])
@@ -207,49 +218,61 @@ func resourceIBMCdToolchainToolPipelineRead(context context.Context, d *schema.R
 			d.SetId("")
 			return nil
 		}
-		log.Printf("[DEBUG] GetToolByIDWithContext failed %s\n%s", err, response)
-		return diag.FromErr(fmt.Errorf("GetToolByIDWithContext failed %s\n%s", err, response))
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("GetToolByIDWithContext failed: %s", err.Error()), "ibm_cd_toolchain_tool_pipeline", "read")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	if err = d.Set("toolchain_id", toolchainTool.ToolchainID); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting toolchain_id: %s", err))
+		err = fmt.Errorf("Error setting toolchain_id: %s", err)
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cd_toolchain_tool_pipeline", "read", "set-toolchain_id").GetDiag()
 	}
 	if !core.IsNil(toolchainTool.Name) {
 		if err = d.Set("name", toolchainTool.Name); err != nil {
-			return diag.FromErr(fmt.Errorf("Error setting name: %s", err))
+			err = fmt.Errorf("Error setting name: %s", err)
+			return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cd_toolchain_tool_pipeline", "read", "set-name").GetDiag()
 		}
 	}
 	parametersMap := GetParametersFromRead(toolchainTool.Parameters, ResourceIBMCdToolchainToolPipeline(), nil)
 	if err = d.Set("parameters", []map[string]interface{}{parametersMap}); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting parameters: %s", err))
+		err = fmt.Errorf("Error setting parameters: %s", err)
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cd_toolchain_tool_pipeline", "read", "set-parameters").GetDiag()
 	}
 	if err = d.Set("resource_group_id", toolchainTool.ResourceGroupID); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting resource_group_id: %s", err))
+		err = fmt.Errorf("Error setting resource_group_id: %s", err)
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cd_toolchain_tool_pipeline", "read", "set-resource_group_id").GetDiag()
 	}
 	if err = d.Set("crn", toolchainTool.CRN); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting crn: %s", err))
+		err = fmt.Errorf("Error setting crn: %s", err)
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cd_toolchain_tool_pipeline", "read", "set-crn").GetDiag()
 	}
 	if err = d.Set("toolchain_crn", toolchainTool.ToolchainCRN); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting toolchain_crn: %s", err))
+		err = fmt.Errorf("Error setting toolchain_crn: %s", err)
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cd_toolchain_tool_pipeline", "read", "set-toolchain_crn").GetDiag()
 	}
 	if err = d.Set("href", toolchainTool.Href); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting href: %s", err))
+		err = fmt.Errorf("Error setting href: %s", err)
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cd_toolchain_tool_pipeline", "read", "set-href").GetDiag()
 	}
-	referentMap, err := resourceIBMCdToolchainToolPipelineToolModelReferentToMap(toolchainTool.Referent)
+	referentMap, err := ResourceIBMCdToolchainToolPipelineToolModelReferentToMap(toolchainTool.Referent)
 	if err != nil {
-		return diag.FromErr(err)
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cd_toolchain_tool_pipeline", "read", "referent-to-map").GetDiag()
 	}
 	if err = d.Set("referent", []map[string]interface{}{referentMap}); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting referent: %s", err))
+		err = fmt.Errorf("Error setting referent: %s", err)
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cd_toolchain_tool_pipeline", "read", "set-referent").GetDiag()
 	}
 	if err = d.Set("updated_at", flex.DateTimeToString(toolchainTool.UpdatedAt)); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting updated_at: %s", err))
+		err = fmt.Errorf("Error setting updated_at: %s", err)
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cd_toolchain_tool_pipeline", "read", "set-updated_at").GetDiag()
 	}
 	if err = d.Set("state", toolchainTool.State); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting state: %s", err))
+		err = fmt.Errorf("Error setting state: %s", err)
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cd_toolchain_tool_pipeline", "read", "set-state").GetDiag()
 	}
 	if err = d.Set("tool_id", toolchainTool.ID); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting tool_id: %s", err))
+		err = fmt.Errorf("Error setting tool_id: %s", err)
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cd_toolchain_tool_pipeline", "read", "set-tool_id").GetDiag()
 	}
 
 	return nil
@@ -258,14 +281,16 @@ func resourceIBMCdToolchainToolPipelineRead(context context.Context, d *schema.R
 func resourceIBMCdToolchainToolPipelineUpdate(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	cdToolchainClient, err := meta.(conns.ClientSession).CdToolchainV2()
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cd_toolchain_tool_pipeline", "update", "initialize-client")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	updateToolOptions := &cdtoolchainv2.UpdateToolOptions{}
 
 	parts, err := flex.SepIdParts(d.Id(), "/")
 	if err != nil {
-		return diag.FromErr(err)
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cd_toolchain_tool_pipeline", "update", "sep-id-parts").GetDiag()
 	}
 
 	updateToolOptions.SetToolchainID(parts[0])
@@ -275,8 +300,9 @@ func resourceIBMCdToolchainToolPipelineUpdate(context context.Context, d *schema
 
 	patchVals := &cdtoolchainv2.ToolchainToolPrototypePatch{}
 	if d.HasChange("toolchain_id") {
-		return diag.FromErr(fmt.Errorf("Cannot update resource property \"%s\" with the ForceNew annotation."+
-			" The resource must be re-created to update this property.", "toolchain_id"))
+		errMsg := fmt.Sprintf("Cannot update resource property \"%s\" with the ForceNew annotation."+
+			" The resource must be re-created to update this property.", "toolchain_id")
+		return flex.DiscriminatedTerraformErrorf(nil, errMsg, "ibm_cd_toolchain_tool_pipeline", "update", "toolchain_id-forces-new").GetDiag()
 	}
 	if d.HasChange("name") {
 		newName := d.Get("name").(string)
@@ -290,11 +316,16 @@ func resourceIBMCdToolchainToolPipelineUpdate(context context.Context, d *schema
 	}
 
 	if hasChange {
-		updateToolOptions.ToolchainToolPrototypePatch, _ = patchVals.AsPatch()
-		_, response, err := cdToolchainClient.UpdateToolWithContext(context, updateToolOptions)
+		// Fields with `nil` values are omitted from the generic map,
+		// so we need to re-add them to support removing arguments
+		// in merge-patch operations sent to the service.
+		updateToolOptions.ToolchainToolPrototypePatch = ResourceIBMCdToolchainToolPipelineToolchainToolPrototypePatchAsPatch(patchVals, d)
+
+		_, _, err = cdToolchainClient.UpdateToolWithContext(context, updateToolOptions)
 		if err != nil {
-			log.Printf("[DEBUG] UpdateToolWithContext failed %s\n%s", err, response)
-			return diag.FromErr(fmt.Errorf("UpdateToolWithContext failed %s\n%s", err, response))
+			tfErr := flex.TerraformErrorf(err, fmt.Sprintf("UpdateToolWithContext failed: %s", err.Error()), "ibm_cd_toolchain_tool_pipeline", "update")
+			log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+			return tfErr.GetDiag()
 		}
 	}
 
@@ -304,23 +335,26 @@ func resourceIBMCdToolchainToolPipelineUpdate(context context.Context, d *schema
 func resourceIBMCdToolchainToolPipelineDelete(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	cdToolchainClient, err := meta.(conns.ClientSession).CdToolchainV2()
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cd_toolchain_tool_pipeline", "delete", "initialize-client")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	deleteToolOptions := &cdtoolchainv2.DeleteToolOptions{}
 
 	parts, err := flex.SepIdParts(d.Id(), "/")
 	if err != nil {
-		return diag.FromErr(err)
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cd_toolchain_tool_pipeline", "delete", "sep-id-parts").GetDiag()
 	}
 
 	deleteToolOptions.SetToolchainID(parts[0])
 	deleteToolOptions.SetToolID(parts[1])
 
-	response, err := cdToolchainClient.DeleteToolWithContext(context, deleteToolOptions)
+	_, err = cdToolchainClient.DeleteToolWithContext(context, deleteToolOptions)
 	if err != nil {
-		log.Printf("[DEBUG] DeleteToolWithContext failed %s\n%s", err, response)
-		return diag.FromErr(fmt.Errorf("DeleteToolWithContext failed %s\n%s", err, response))
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("DeleteToolWithContext failed: %s", err.Error()), "ibm_cd_toolchain_tool_pipeline", "delete")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	d.SetId("")
@@ -328,13 +362,44 @@ func resourceIBMCdToolchainToolPipelineDelete(context context.Context, d *schema
 	return nil
 }
 
-func resourceIBMCdToolchainToolPipelineToolModelReferentToMap(model *cdtoolchainv2.ToolModelReferent) (map[string]interface{}, error) {
+func ResourceIBMCdToolchainToolPipelineToolModelReferentToMap(model *cdtoolchainv2.ToolModelReferent) (map[string]interface{}, error) {
 	modelMap := make(map[string]interface{})
 	if model.UIHref != nil {
-		modelMap["ui_href"] = model.UIHref
+		modelMap["ui_href"] = *model.UIHref
 	}
 	if model.APIHref != nil {
-		modelMap["api_href"] = model.APIHref
+		modelMap["api_href"] = *model.APIHref
 	}
 	return modelMap, nil
+}
+
+func ResourceIBMCdToolchainToolPipelineToolchainToolPrototypePatchAsPatch(patchVals *cdtoolchainv2.ToolchainToolPrototypePatch, d *schema.ResourceData) map[string]interface{} {
+	patch, _ := patchVals.AsPatch()
+	var path string
+
+	path = "name"
+	if _, exists := d.GetOk(path); d.HasChange(path) && !exists {
+		patch["name"] = nil
+	}
+	path = "tool_type_id"
+	if _, exists := d.GetOk(path); d.HasChange(path) && !exists {
+		patch["tool_type_id"] = nil
+	}
+	path = "parameters"
+	if _, exists := d.GetOk(path); d.HasChange(path) && !exists {
+		patch["parameters"] = nil
+	} else if exists && patch["parameters"] != nil {
+		ResourceIBMCdToolchainToolPipelineToolModelParametersAsPatch(patch["parameters"].(map[string]interface{}), d)
+	}
+
+	return patch
+}
+
+func ResourceIBMCdToolchainToolPipelineToolModelParametersAsPatch(patch map[string]interface{}, d *schema.ResourceData) {
+	var path string
+
+	path = "parameters.0.name"
+	if _, exists := d.GetOk(path); d.HasChange(path) && !exists {
+		patch["name"] = nil
+	}
 }

--- a/ibm/service/cdtoolchain/resource_ibm_cd_toolchain_tool_privateworker.go
+++ b/ibm/service/cdtoolchain/resource_ibm_cd_toolchain_tool_privateworker.go
@@ -1,5 +1,9 @@
-// Copyright IBM Corp. 2023 All Rights Reserved.
+// Copyright IBM Corp. 2024 All Rights Reserved.
 // Licensed under the Mozilla Public License v2.0
+
+/*
+ * IBM OpenAPI Terraform Generator Version: 3.96.0-d6dec9d7-20241008-212902
+ */
 
 package cdtoolchain
 
@@ -64,6 +68,7 @@ func ResourceIBMCdToolchainToolPrivateworker() *schema.Resource {
 						},
 						"worker_queue_identifier": &schema.Schema{
 							Type:        schema.TypeString,
+							Optional:    true,
 							Computed:    true,
 							Description: "The service ID which identifies this private workers run request queue.",
 						},
@@ -99,11 +104,13 @@ func ResourceIBMCdToolchainToolPrivateworker() *schema.Resource {
 						"ui_href": &schema.Schema{
 							Type:        schema.TypeString,
 							Optional:    true,
+							Computed:    true,
 							Description: "URI representing this resource through the UI.",
 						},
 						"api_href": &schema.Schema{
 							Type:        schema.TypeString,
 							Optional:    true,
+							Computed:    true,
 							Description: "URI representing this resource through an API.",
 						},
 					},
@@ -158,7 +165,9 @@ func ResourceIBMCdToolchainToolPrivateworkerValidator() *validate.ResourceValida
 func resourceIBMCdToolchainToolPrivateworkerCreate(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	cdToolchainClient, err := meta.(conns.ClientSession).CdToolchainV2()
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cd_toolchain_tool_privateworker", "create", "initialize-client")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	createToolOptions := &cdtoolchainv2.CreateToolOptions{}
@@ -175,10 +184,11 @@ func resourceIBMCdToolchainToolPrivateworkerCreate(context context.Context, d *s
 		createToolOptions.SetName(d.Get("name").(string))
 	}
 
-	toolchainToolPost, response, err := cdToolchainClient.CreateToolWithContext(context, createToolOptions)
+	toolchainToolPost, _, err := cdToolchainClient.CreateToolWithContext(context, createToolOptions)
 	if err != nil {
-		log.Printf("[DEBUG] CreateToolWithContext failed %s\n%s", err, response)
-		return diag.FromErr(fmt.Errorf("CreateToolWithContext failed %s\n%s", err, response))
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("CreateToolWithContext failed: %s", err.Error()), "ibm_cd_toolchain_tool_privateworker", "create")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	d.SetId(fmt.Sprintf("%s/%s", *createToolOptions.ToolchainID, *toolchainToolPost.ID))
@@ -189,14 +199,16 @@ func resourceIBMCdToolchainToolPrivateworkerCreate(context context.Context, d *s
 func resourceIBMCdToolchainToolPrivateworkerRead(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	cdToolchainClient, err := meta.(conns.ClientSession).CdToolchainV2()
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cd_toolchain_tool_privateworker", "read", "initialize-client")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	getToolByIDOptions := &cdtoolchainv2.GetToolByIDOptions{}
 
 	parts, err := flex.SepIdParts(d.Id(), "/")
 	if err != nil {
-		return diag.FromErr(err)
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cd_toolchain_tool_privateworker", "read", "sep-id-parts").GetDiag()
 	}
 
 	getToolByIDOptions.SetToolchainID(parts[0])
@@ -222,16 +234,19 @@ func resourceIBMCdToolchainToolPrivateworkerRead(context context.Context, d *sch
 			d.SetId("")
 			return nil
 		}
-		log.Printf("[DEBUG] GetToolByIDWithContext failed %s\n%s", err, response)
-		return diag.FromErr(fmt.Errorf("GetToolByIDWithContext failed %s\n%s", err, response))
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("GetToolByIDWithContext failed: %s", err.Error()), "ibm_cd_toolchain_tool_privateworker", "read")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	if err = d.Set("toolchain_id", toolchainTool.ToolchainID); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting toolchain_id: %s", err))
+		err = fmt.Errorf("Error setting toolchain_id: %s", err)
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cd_toolchain_tool_privateworker", "read", "set-toolchain_id").GetDiag()
 	}
 	if !core.IsNil(toolchainTool.Name) {
 		if err = d.Set("name", toolchainTool.Name); err != nil {
-			return diag.FromErr(fmt.Errorf("Error setting name: %s", err))
+			err = fmt.Errorf("Error setting name: %s", err)
+			return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cd_toolchain_tool_privateworker", "read", "set-name").GetDiag()
 		}
 	}
 	remapFields := map[string]string{
@@ -240,35 +255,44 @@ func resourceIBMCdToolchainToolPrivateworkerRead(context context.Context, d *sch
 	}
 	parametersMap := GetParametersFromRead(toolchainTool.Parameters, ResourceIBMCdToolchainToolPrivateworker(), remapFields)
 	if err = d.Set("parameters", []map[string]interface{}{parametersMap}); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting parameters: %s", err))
+		err = fmt.Errorf("Error setting parameters: %s", err)
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cd_toolchain_tool_privateworker", "read", "set-parameters").GetDiag()
 	}
 	if err = d.Set("resource_group_id", toolchainTool.ResourceGroupID); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting resource_group_id: %s", err))
+		err = fmt.Errorf("Error setting resource_group_id: %s", err)
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cd_toolchain_tool_privateworker", "read", "set-resource_group_id").GetDiag()
 	}
 	if err = d.Set("crn", toolchainTool.CRN); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting crn: %s", err))
+		err = fmt.Errorf("Error setting crn: %s", err)
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cd_toolchain_tool_privateworker", "read", "set-crn").GetDiag()
 	}
 	if err = d.Set("toolchain_crn", toolchainTool.ToolchainCRN); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting toolchain_crn: %s", err))
+		err = fmt.Errorf("Error setting toolchain_crn: %s", err)
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cd_toolchain_tool_privateworker", "read", "set-toolchain_crn").GetDiag()
 	}
 	if err = d.Set("href", toolchainTool.Href); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting href: %s", err))
+		err = fmt.Errorf("Error setting href: %s", err)
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cd_toolchain_tool_privateworker", "read", "set-href").GetDiag()
 	}
-	referentMap, err := resourceIBMCdToolchainToolPrivateworkerToolModelReferentToMap(toolchainTool.Referent)
+	referentMap, err := ResourceIBMCdToolchainToolPrivateworkerToolModelReferentToMap(toolchainTool.Referent)
 	if err != nil {
-		return diag.FromErr(err)
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cd_toolchain_tool_privateworker", "read", "referent-to-map").GetDiag()
 	}
 	if err = d.Set("referent", []map[string]interface{}{referentMap}); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting referent: %s", err))
+		err = fmt.Errorf("Error setting referent: %s", err)
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cd_toolchain_tool_privateworker", "read", "set-referent").GetDiag()
 	}
 	if err = d.Set("updated_at", flex.DateTimeToString(toolchainTool.UpdatedAt)); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting updated_at: %s", err))
+		err = fmt.Errorf("Error setting updated_at: %s", err)
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cd_toolchain_tool_privateworker", "read", "set-updated_at").GetDiag()
 	}
 	if err = d.Set("state", toolchainTool.State); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting state: %s", err))
+		err = fmt.Errorf("Error setting state: %s", err)
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cd_toolchain_tool_privateworker", "read", "set-state").GetDiag()
 	}
 	if err = d.Set("tool_id", toolchainTool.ID); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting tool_id: %s", err))
+		err = fmt.Errorf("Error setting tool_id: %s", err)
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cd_toolchain_tool_privateworker", "read", "set-tool_id").GetDiag()
 	}
 
 	return nil
@@ -277,14 +301,16 @@ func resourceIBMCdToolchainToolPrivateworkerRead(context context.Context, d *sch
 func resourceIBMCdToolchainToolPrivateworkerUpdate(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	cdToolchainClient, err := meta.(conns.ClientSession).CdToolchainV2()
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cd_toolchain_tool_privateworker", "update", "initialize-client")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	updateToolOptions := &cdtoolchainv2.UpdateToolOptions{}
 
 	parts, err := flex.SepIdParts(d.Id(), "/")
 	if err != nil {
-		return diag.FromErr(err)
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cd_toolchain_tool_privateworker", "update", "sep-id-parts").GetDiag()
 	}
 
 	updateToolOptions.SetToolchainID(parts[0])
@@ -294,8 +320,9 @@ func resourceIBMCdToolchainToolPrivateworkerUpdate(context context.Context, d *s
 
 	patchVals := &cdtoolchainv2.ToolchainToolPrototypePatch{}
 	if d.HasChange("toolchain_id") {
-		return diag.FromErr(fmt.Errorf("Cannot update resource property \"%s\" with the ForceNew annotation."+
-			" The resource must be re-created to update this property.", "toolchain_id"))
+		errMsg := fmt.Sprintf("Cannot update resource property \"%s\" with the ForceNew annotation."+
+			" The resource must be re-created to update this property.", "toolchain_id")
+		return flex.DiscriminatedTerraformErrorf(nil, errMsg, "ibm_cd_toolchain_tool_privateworker", "update", "toolchain_id-forces-new").GetDiag()
 	}
 	if d.HasChange("name") {
 		newName := d.Get("name").(string)
@@ -313,11 +340,16 @@ func resourceIBMCdToolchainToolPrivateworkerUpdate(context context.Context, d *s
 	}
 
 	if hasChange {
-		updateToolOptions.ToolchainToolPrototypePatch, _ = patchVals.AsPatch()
-		_, response, err := cdToolchainClient.UpdateToolWithContext(context, updateToolOptions)
+		// Fields with `nil` values are omitted from the generic map,
+		// so we need to re-add them to support removing arguments
+		// in merge-patch operations sent to the service.
+		updateToolOptions.ToolchainToolPrototypePatch = ResourceIBMCdToolchainToolPrivateworkerToolchainToolPrototypePatchAsPatch(patchVals, d)
+
+		_, _, err = cdToolchainClient.UpdateToolWithContext(context, updateToolOptions)
 		if err != nil {
-			log.Printf("[DEBUG] UpdateToolWithContext failed %s\n%s", err, response)
-			return diag.FromErr(fmt.Errorf("UpdateToolWithContext failed %s\n%s", err, response))
+			tfErr := flex.TerraformErrorf(err, fmt.Sprintf("UpdateToolWithContext failed: %s", err.Error()), "ibm_cd_toolchain_tool_privateworker", "update")
+			log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+			return tfErr.GetDiag()
 		}
 	}
 
@@ -327,23 +359,26 @@ func resourceIBMCdToolchainToolPrivateworkerUpdate(context context.Context, d *s
 func resourceIBMCdToolchainToolPrivateworkerDelete(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	cdToolchainClient, err := meta.(conns.ClientSession).CdToolchainV2()
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cd_toolchain_tool_privateworker", "delete", "initialize-client")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	deleteToolOptions := &cdtoolchainv2.DeleteToolOptions{}
 
 	parts, err := flex.SepIdParts(d.Id(), "/")
 	if err != nil {
-		return diag.FromErr(err)
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cd_toolchain_tool_privateworker", "delete", "sep-id-parts").GetDiag()
 	}
 
 	deleteToolOptions.SetToolchainID(parts[0])
 	deleteToolOptions.SetToolID(parts[1])
 
-	response, err := cdToolchainClient.DeleteToolWithContext(context, deleteToolOptions)
+	_, err = cdToolchainClient.DeleteToolWithContext(context, deleteToolOptions)
 	if err != nil {
-		log.Printf("[DEBUG] DeleteToolWithContext failed %s\n%s", err, response)
-		return diag.FromErr(fmt.Errorf("DeleteToolWithContext failed %s\n%s", err, response))
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("DeleteToolWithContext failed: %s", err.Error()), "ibm_cd_toolchain_tool_privateworker", "delete")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	d.SetId("")
@@ -351,13 +386,44 @@ func resourceIBMCdToolchainToolPrivateworkerDelete(context context.Context, d *s
 	return nil
 }
 
-func resourceIBMCdToolchainToolPrivateworkerToolModelReferentToMap(model *cdtoolchainv2.ToolModelReferent) (map[string]interface{}, error) {
+func ResourceIBMCdToolchainToolPrivateworkerToolModelReferentToMap(model *cdtoolchainv2.ToolModelReferent) (map[string]interface{}, error) {
 	modelMap := make(map[string]interface{})
 	if model.UIHref != nil {
-		modelMap["ui_href"] = model.UIHref
+		modelMap["ui_href"] = *model.UIHref
 	}
 	if model.APIHref != nil {
-		modelMap["api_href"] = model.APIHref
+		modelMap["api_href"] = *model.APIHref
 	}
 	return modelMap, nil
+}
+
+func ResourceIBMCdToolchainToolPrivateworkerToolchainToolPrototypePatchAsPatch(patchVals *cdtoolchainv2.ToolchainToolPrototypePatch, d *schema.ResourceData) map[string]interface{} {
+	patch, _ := patchVals.AsPatch()
+	var path string
+
+	path = "name"
+	if _, exists := d.GetOk(path); d.HasChange(path) && !exists {
+		patch["name"] = nil
+	}
+	path = "tool_type_id"
+	if _, exists := d.GetOk(path); d.HasChange(path) && !exists {
+		patch["tool_type_id"] = nil
+	}
+	path = "parameters"
+	if _, exists := d.GetOk(path); d.HasChange(path) && !exists {
+		patch["parameters"] = nil
+	} else if exists && patch["parameters"] != nil {
+		ResourceIBMCdToolchainToolPrivateworkerToolModelParametersAsPatch(patch["parameters"].(map[string]interface{}), d)
+	}
+
+	return patch
+}
+
+func ResourceIBMCdToolchainToolPrivateworkerToolModelParametersAsPatch(patch map[string]interface{}, d *schema.ResourceData) {
+	var path string
+
+	path = "parameters.0.worker_queue_identifier"
+	if _, exists := d.GetOk(path); d.HasChange(path) && !exists {
+		patch["worker_queue_identifier"] = nil
+	}
 }

--- a/ibm/service/cdtoolchain/resource_ibm_cd_toolchain_tool_saucelabs.go
+++ b/ibm/service/cdtoolchain/resource_ibm_cd_toolchain_tool_saucelabs.go
@@ -1,5 +1,9 @@
-// Copyright IBM Corp. 2023 All Rights Reserved.
+// Copyright IBM Corp. 2024 All Rights Reserved.
 // Licensed under the Mozilla Public License v2.0
+
+/*
+ * IBM OpenAPI Terraform Generator Version: 3.96.0-d6dec9d7-20241008-212902
+ */
 
 package cdtoolchain
 
@@ -94,11 +98,13 @@ func ResourceIBMCdToolchainToolSaucelabs() *schema.Resource {
 						"ui_href": &schema.Schema{
 							Type:        schema.TypeString,
 							Optional:    true,
+							Computed:    true,
 							Description: "URI representing this resource through the UI.",
 						},
 						"api_href": &schema.Schema{
 							Type:        schema.TypeString,
 							Optional:    true,
+							Computed:    true,
 							Description: "URI representing this resource through an API.",
 						},
 					},
@@ -153,7 +159,9 @@ func ResourceIBMCdToolchainToolSaucelabsValidator() *validate.ResourceValidator 
 func resourceIBMCdToolchainToolSaucelabsCreate(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	cdToolchainClient, err := meta.(conns.ClientSession).CdToolchainV2()
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cd_toolchain_tool_saucelabs", "create", "initialize-client")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	createToolOptions := &cdtoolchainv2.CreateToolOptions{}
@@ -169,10 +177,11 @@ func resourceIBMCdToolchainToolSaucelabsCreate(context context.Context, d *schem
 		createToolOptions.SetName(d.Get("name").(string))
 	}
 
-	toolchainToolPost, response, err := cdToolchainClient.CreateToolWithContext(context, createToolOptions)
+	toolchainToolPost, _, err := cdToolchainClient.CreateToolWithContext(context, createToolOptions)
 	if err != nil {
-		log.Printf("[DEBUG] CreateToolWithContext failed %s\n%s", err, response)
-		return diag.FromErr(fmt.Errorf("CreateToolWithContext failed %s\n%s", err, response))
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("CreateToolWithContext failed: %s", err.Error()), "ibm_cd_toolchain_tool_saucelabs", "create")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	d.SetId(fmt.Sprintf("%s/%s", *createToolOptions.ToolchainID, *toolchainToolPost.ID))
@@ -183,14 +192,16 @@ func resourceIBMCdToolchainToolSaucelabsCreate(context context.Context, d *schem
 func resourceIBMCdToolchainToolSaucelabsRead(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	cdToolchainClient, err := meta.(conns.ClientSession).CdToolchainV2()
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cd_toolchain_tool_saucelabs", "read", "initialize-client")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	getToolByIDOptions := &cdtoolchainv2.GetToolByIDOptions{}
 
 	parts, err := flex.SepIdParts(d.Id(), "/")
 	if err != nil {
-		return diag.FromErr(err)
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cd_toolchain_tool_saucelabs", "read", "sep-id-parts").GetDiag()
 	}
 
 	getToolByIDOptions.SetToolchainID(parts[0])
@@ -216,16 +227,19 @@ func resourceIBMCdToolchainToolSaucelabsRead(context context.Context, d *schema.
 			d.SetId("")
 			return nil
 		}
-		log.Printf("[DEBUG] GetToolByIDWithContext failed %s\n%s", err, response)
-		return diag.FromErr(fmt.Errorf("GetToolByIDWithContext failed %s\n%s", err, response))
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("GetToolByIDWithContext failed: %s", err.Error()), "ibm_cd_toolchain_tool_saucelabs", "read")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	if err = d.Set("toolchain_id", toolchainTool.ToolchainID); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting toolchain_id: %s", err))
+		err = fmt.Errorf("Error setting toolchain_id: %s", err)
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cd_toolchain_tool_saucelabs", "read", "set-toolchain_id").GetDiag()
 	}
 	if !core.IsNil(toolchainTool.Name) {
 		if err = d.Set("name", toolchainTool.Name); err != nil {
-			return diag.FromErr(fmt.Errorf("Error setting name: %s", err))
+			err = fmt.Errorf("Error setting name: %s", err)
+			return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cd_toolchain_tool_saucelabs", "read", "set-name").GetDiag()
 		}
 	}
 	remapFields := map[string]string{
@@ -233,35 +247,44 @@ func resourceIBMCdToolchainToolSaucelabsRead(context context.Context, d *schema.
 	}
 	parametersMap := GetParametersFromRead(toolchainTool.Parameters, ResourceIBMCdToolchainToolSaucelabs(), remapFields)
 	if err = d.Set("parameters", []map[string]interface{}{parametersMap}); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting parameters: %s", err))
+		err = fmt.Errorf("Error setting parameters: %s", err)
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cd_toolchain_tool_saucelabs", "read", "set-parameters").GetDiag()
 	}
 	if err = d.Set("resource_group_id", toolchainTool.ResourceGroupID); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting resource_group_id: %s", err))
+		err = fmt.Errorf("Error setting resource_group_id: %s", err)
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cd_toolchain_tool_saucelabs", "read", "set-resource_group_id").GetDiag()
 	}
 	if err = d.Set("crn", toolchainTool.CRN); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting crn: %s", err))
+		err = fmt.Errorf("Error setting crn: %s", err)
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cd_toolchain_tool_saucelabs", "read", "set-crn").GetDiag()
 	}
 	if err = d.Set("toolchain_crn", toolchainTool.ToolchainCRN); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting toolchain_crn: %s", err))
+		err = fmt.Errorf("Error setting toolchain_crn: %s", err)
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cd_toolchain_tool_saucelabs", "read", "set-toolchain_crn").GetDiag()
 	}
 	if err = d.Set("href", toolchainTool.Href); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting href: %s", err))
+		err = fmt.Errorf("Error setting href: %s", err)
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cd_toolchain_tool_saucelabs", "read", "set-href").GetDiag()
 	}
-	referentMap, err := resourceIBMCdToolchainToolSaucelabsToolModelReferentToMap(toolchainTool.Referent)
+	referentMap, err := ResourceIBMCdToolchainToolSaucelabsToolModelReferentToMap(toolchainTool.Referent)
 	if err != nil {
-		return diag.FromErr(err)
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cd_toolchain_tool_saucelabs", "read", "referent-to-map").GetDiag()
 	}
 	if err = d.Set("referent", []map[string]interface{}{referentMap}); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting referent: %s", err))
+		err = fmt.Errorf("Error setting referent: %s", err)
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cd_toolchain_tool_saucelabs", "read", "set-referent").GetDiag()
 	}
 	if err = d.Set("updated_at", flex.DateTimeToString(toolchainTool.UpdatedAt)); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting updated_at: %s", err))
+		err = fmt.Errorf("Error setting updated_at: %s", err)
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cd_toolchain_tool_saucelabs", "read", "set-updated_at").GetDiag()
 	}
 	if err = d.Set("state", toolchainTool.State); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting state: %s", err))
+		err = fmt.Errorf("Error setting state: %s", err)
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cd_toolchain_tool_saucelabs", "read", "set-state").GetDiag()
 	}
 	if err = d.Set("tool_id", toolchainTool.ID); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting tool_id: %s", err))
+		err = fmt.Errorf("Error setting tool_id: %s", err)
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cd_toolchain_tool_saucelabs", "read", "set-tool_id").GetDiag()
 	}
 
 	return nil
@@ -270,14 +293,16 @@ func resourceIBMCdToolchainToolSaucelabsRead(context context.Context, d *schema.
 func resourceIBMCdToolchainToolSaucelabsUpdate(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	cdToolchainClient, err := meta.(conns.ClientSession).CdToolchainV2()
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cd_toolchain_tool_saucelabs", "update", "initialize-client")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	updateToolOptions := &cdtoolchainv2.UpdateToolOptions{}
 
 	parts, err := flex.SepIdParts(d.Id(), "/")
 	if err != nil {
-		return diag.FromErr(err)
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cd_toolchain_tool_saucelabs", "update", "sep-id-parts").GetDiag()
 	}
 
 	updateToolOptions.SetToolchainID(parts[0])
@@ -287,8 +312,9 @@ func resourceIBMCdToolchainToolSaucelabsUpdate(context context.Context, d *schem
 
 	patchVals := &cdtoolchainv2.ToolchainToolPrototypePatch{}
 	if d.HasChange("toolchain_id") {
-		return diag.FromErr(fmt.Errorf("Cannot update resource property \"%s\" with the ForceNew annotation."+
-			" The resource must be re-created to update this property.", "toolchain_id"))
+		errMsg := fmt.Sprintf("Cannot update resource property \"%s\" with the ForceNew annotation."+
+			" The resource must be re-created to update this property.", "toolchain_id")
+		return flex.DiscriminatedTerraformErrorf(nil, errMsg, "ibm_cd_toolchain_tool_saucelabs", "update", "toolchain_id-forces-new").GetDiag()
 	}
 	if d.HasChange("name") {
 		newName := d.Get("name").(string)
@@ -305,11 +331,16 @@ func resourceIBMCdToolchainToolSaucelabsUpdate(context context.Context, d *schem
 	}
 
 	if hasChange {
-		updateToolOptions.ToolchainToolPrototypePatch, _ = patchVals.AsPatch()
-		_, response, err := cdToolchainClient.UpdateToolWithContext(context, updateToolOptions)
+		// Fields with `nil` values are omitted from the generic map,
+		// so we need to re-add them to support removing arguments
+		// in merge-patch operations sent to the service.
+		updateToolOptions.ToolchainToolPrototypePatch = ResourceIBMCdToolchainToolSaucelabsToolchainToolPrototypePatchAsPatch(patchVals, d)
+
+		_, _, err = cdToolchainClient.UpdateToolWithContext(context, updateToolOptions)
 		if err != nil {
-			log.Printf("[DEBUG] UpdateToolWithContext failed %s\n%s", err, response)
-			return diag.FromErr(fmt.Errorf("UpdateToolWithContext failed %s\n%s", err, response))
+			tfErr := flex.TerraformErrorf(err, fmt.Sprintf("UpdateToolWithContext failed: %s", err.Error()), "ibm_cd_toolchain_tool_saucelabs", "update")
+			log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+			return tfErr.GetDiag()
 		}
 	}
 
@@ -319,23 +350,26 @@ func resourceIBMCdToolchainToolSaucelabsUpdate(context context.Context, d *schem
 func resourceIBMCdToolchainToolSaucelabsDelete(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	cdToolchainClient, err := meta.(conns.ClientSession).CdToolchainV2()
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cd_toolchain_tool_saucelabs", "delete", "initialize-client")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	deleteToolOptions := &cdtoolchainv2.DeleteToolOptions{}
 
 	parts, err := flex.SepIdParts(d.Id(), "/")
 	if err != nil {
-		return diag.FromErr(err)
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cd_toolchain_tool_saucelabs", "delete", "sep-id-parts").GetDiag()
 	}
 
 	deleteToolOptions.SetToolchainID(parts[0])
 	deleteToolOptions.SetToolID(parts[1])
 
-	response, err := cdToolchainClient.DeleteToolWithContext(context, deleteToolOptions)
+	_, err = cdToolchainClient.DeleteToolWithContext(context, deleteToolOptions)
 	if err != nil {
-		log.Printf("[DEBUG] DeleteToolWithContext failed %s\n%s", err, response)
-		return diag.FromErr(fmt.Errorf("DeleteToolWithContext failed %s\n%s", err, response))
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("DeleteToolWithContext failed: %s", err.Error()), "ibm_cd_toolchain_tool_saucelabs", "delete")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	d.SetId("")
@@ -343,13 +377,33 @@ func resourceIBMCdToolchainToolSaucelabsDelete(context context.Context, d *schem
 	return nil
 }
 
-func resourceIBMCdToolchainToolSaucelabsToolModelReferentToMap(model *cdtoolchainv2.ToolModelReferent) (map[string]interface{}, error) {
+func ResourceIBMCdToolchainToolSaucelabsToolModelReferentToMap(model *cdtoolchainv2.ToolModelReferent) (map[string]interface{}, error) {
 	modelMap := make(map[string]interface{})
 	if model.UIHref != nil {
-		modelMap["ui_href"] = model.UIHref
+		modelMap["ui_href"] = *model.UIHref
 	}
 	if model.APIHref != nil {
-		modelMap["api_href"] = model.APIHref
+		modelMap["api_href"] = *model.APIHref
 	}
 	return modelMap, nil
+}
+
+func ResourceIBMCdToolchainToolSaucelabsToolchainToolPrototypePatchAsPatch(patchVals *cdtoolchainv2.ToolchainToolPrototypePatch, d *schema.ResourceData) map[string]interface{} {
+	patch, _ := patchVals.AsPatch()
+	var path string
+
+	path = "name"
+	if _, exists := d.GetOk(path); d.HasChange(path) && !exists {
+		patch["name"] = nil
+	}
+	path = "tool_type_id"
+	if _, exists := d.GetOk(path); d.HasChange(path) && !exists {
+		patch["tool_type_id"] = nil
+	}
+	path = "parameters"
+	if _, exists := d.GetOk(path); d.HasChange(path) && !exists {
+		patch["parameters"] = nil
+	}
+
+	return patch
 }

--- a/ibm/service/cdtoolchain/resource_ibm_cd_toolchain_tool_secretsmanager.go
+++ b/ibm/service/cdtoolchain/resource_ibm_cd_toolchain_tool_secretsmanager.go
@@ -1,5 +1,9 @@
-// Copyright IBM Corp. 2023 All Rights Reserved.
+// Copyright IBM Corp. 2024 All Rights Reserved.
 // Licensed under the Mozilla Public License v2.0
+
+/*
+ * IBM OpenAPI Terraform Generator Version: 3.96.0-d6dec9d7-20241008-212902
+ */
 
 package cdtoolchain
 
@@ -112,11 +116,13 @@ func ResourceIBMCdToolchainToolSecretsmanager() *schema.Resource {
 						"ui_href": &schema.Schema{
 							Type:        schema.TypeString,
 							Optional:    true,
+							Computed:    true,
 							Description: "URI representing this resource through the UI.",
 						},
 						"api_href": &schema.Schema{
 							Type:        schema.TypeString,
 							Optional:    true,
+							Computed:    true,
 							Description: "URI representing this resource through an API.",
 						},
 					},
@@ -171,7 +177,9 @@ func ResourceIBMCdToolchainToolSecretsmanagerValidator() *validate.ResourceValid
 func resourceIBMCdToolchainToolSecretsmanagerCreate(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	cdToolchainClient, err := meta.(conns.ClientSession).CdToolchainV2()
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cd_toolchain_tool_secretsmanager", "create", "initialize-client")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	createToolOptions := &cdtoolchainv2.CreateToolOptions{}
@@ -191,10 +199,11 @@ func resourceIBMCdToolchainToolSecretsmanagerCreate(context context.Context, d *
 		createToolOptions.SetName(d.Get("name").(string))
 	}
 
-	toolchainToolPost, response, err := cdToolchainClient.CreateToolWithContext(context, createToolOptions)
+	toolchainToolPost, _, err := cdToolchainClient.CreateToolWithContext(context, createToolOptions)
 	if err != nil {
-		log.Printf("[DEBUG] CreateToolWithContext failed %s\n%s", err, response)
-		return diag.FromErr(fmt.Errorf("CreateToolWithContext failed %s\n%s", err, response))
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("CreateToolWithContext failed: %s", err.Error()), "ibm_cd_toolchain_tool_secretsmanager", "create")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	d.SetId(fmt.Sprintf("%s/%s", *createToolOptions.ToolchainID, *toolchainToolPost.ID))
@@ -205,14 +214,16 @@ func resourceIBMCdToolchainToolSecretsmanagerCreate(context context.Context, d *
 func resourceIBMCdToolchainToolSecretsmanagerRead(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	cdToolchainClient, err := meta.(conns.ClientSession).CdToolchainV2()
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cd_toolchain_tool_secretsmanager", "read", "initialize-client")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	getToolByIDOptions := &cdtoolchainv2.GetToolByIDOptions{}
 
 	parts, err := flex.SepIdParts(d.Id(), "/")
 	if err != nil {
-		return diag.FromErr(err)
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cd_toolchain_tool_secretsmanager", "read", "sep-id-parts").GetDiag()
 	}
 
 	getToolByIDOptions.SetToolchainID(parts[0])
@@ -238,16 +249,19 @@ func resourceIBMCdToolchainToolSecretsmanagerRead(context context.Context, d *sc
 			d.SetId("")
 			return nil
 		}
-		log.Printf("[DEBUG] GetToolByIDWithContext failed %s\n%s", err, response)
-		return diag.FromErr(fmt.Errorf("GetToolByIDWithContext failed %s\n%s", err, response))
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("GetToolByIDWithContext failed: %s", err.Error()), "ibm_cd_toolchain_tool_secretsmanager", "read")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	if err = d.Set("toolchain_id", toolchainTool.ToolchainID); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting toolchain_id: %s", err))
+		err = fmt.Errorf("Error setting toolchain_id: %s", err)
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cd_toolchain_tool_secretsmanager", "read", "set-toolchain_id").GetDiag()
 	}
 	if !core.IsNil(toolchainTool.Name) {
 		if err = d.Set("name", toolchainTool.Name); err != nil {
-			return diag.FromErr(fmt.Errorf("Error setting name: %s", err))
+			err = fmt.Errorf("Error setting name: %s", err)
+			return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cd_toolchain_tool_secretsmanager", "read", "set-name").GetDiag()
 		}
 	}
 	remapFields := map[string]string{
@@ -259,35 +273,44 @@ func resourceIBMCdToolchainToolSecretsmanagerRead(context context.Context, d *sc
 	}
 	parametersMap := GetParametersFromRead(toolchainTool.Parameters, ResourceIBMCdToolchainToolSecretsmanager(), remapFields)
 	if err = d.Set("parameters", []map[string]interface{}{parametersMap}); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting parameters: %s", err))
+		err = fmt.Errorf("Error setting parameters: %s", err)
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cd_toolchain_tool_secretsmanager", "read", "set-parameters").GetDiag()
 	}
 	if err = d.Set("resource_group_id", toolchainTool.ResourceGroupID); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting resource_group_id: %s", err))
+		err = fmt.Errorf("Error setting resource_group_id: %s", err)
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cd_toolchain_tool_secretsmanager", "read", "set-resource_group_id").GetDiag()
 	}
 	if err = d.Set("crn", toolchainTool.CRN); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting crn: %s", err))
+		err = fmt.Errorf("Error setting crn: %s", err)
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cd_toolchain_tool_secretsmanager", "read", "set-crn").GetDiag()
 	}
 	if err = d.Set("toolchain_crn", toolchainTool.ToolchainCRN); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting toolchain_crn: %s", err))
+		err = fmt.Errorf("Error setting toolchain_crn: %s", err)
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cd_toolchain_tool_secretsmanager", "read", "set-toolchain_crn").GetDiag()
 	}
 	if err = d.Set("href", toolchainTool.Href); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting href: %s", err))
+		err = fmt.Errorf("Error setting href: %s", err)
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cd_toolchain_tool_secretsmanager", "read", "set-href").GetDiag()
 	}
-	referentMap, err := resourceIBMCdToolchainToolSecretsmanagerToolModelReferentToMap(toolchainTool.Referent)
+	referentMap, err := ResourceIBMCdToolchainToolSecretsmanagerToolModelReferentToMap(toolchainTool.Referent)
 	if err != nil {
-		return diag.FromErr(err)
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cd_toolchain_tool_secretsmanager", "read", "referent-to-map").GetDiag()
 	}
 	if err = d.Set("referent", []map[string]interface{}{referentMap}); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting referent: %s", err))
+		err = fmt.Errorf("Error setting referent: %s", err)
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cd_toolchain_tool_secretsmanager", "read", "set-referent").GetDiag()
 	}
 	if err = d.Set("updated_at", flex.DateTimeToString(toolchainTool.UpdatedAt)); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting updated_at: %s", err))
+		err = fmt.Errorf("Error setting updated_at: %s", err)
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cd_toolchain_tool_secretsmanager", "read", "set-updated_at").GetDiag()
 	}
 	if err = d.Set("state", toolchainTool.State); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting state: %s", err))
+		err = fmt.Errorf("Error setting state: %s", err)
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cd_toolchain_tool_secretsmanager", "read", "set-state").GetDiag()
 	}
 	if err = d.Set("tool_id", toolchainTool.ID); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting tool_id: %s", err))
+		err = fmt.Errorf("Error setting tool_id: %s", err)
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cd_toolchain_tool_secretsmanager", "read", "set-tool_id").GetDiag()
 	}
 
 	return nil
@@ -296,14 +319,16 @@ func resourceIBMCdToolchainToolSecretsmanagerRead(context context.Context, d *sc
 func resourceIBMCdToolchainToolSecretsmanagerUpdate(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	cdToolchainClient, err := meta.(conns.ClientSession).CdToolchainV2()
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cd_toolchain_tool_secretsmanager", "update", "initialize-client")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	updateToolOptions := &cdtoolchainv2.UpdateToolOptions{}
 
 	parts, err := flex.SepIdParts(d.Id(), "/")
 	if err != nil {
-		return diag.FromErr(err)
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cd_toolchain_tool_secretsmanager", "update", "sep-id-parts").GetDiag()
 	}
 
 	updateToolOptions.SetToolchainID(parts[0])
@@ -313,8 +338,9 @@ func resourceIBMCdToolchainToolSecretsmanagerUpdate(context context.Context, d *
 
 	patchVals := &cdtoolchainv2.ToolchainToolPrototypePatch{}
 	if d.HasChange("toolchain_id") {
-		return diag.FromErr(fmt.Errorf("Cannot update resource property \"%s\" with the ForceNew annotation."+
-			" The resource must be re-created to update this property.", "toolchain_id"))
+		errMsg := fmt.Sprintf("Cannot update resource property \"%s\" with the ForceNew annotation."+
+			" The resource must be re-created to update this property.", "toolchain_id")
+		return flex.DiscriminatedTerraformErrorf(nil, errMsg, "ibm_cd_toolchain_tool_secretsmanager", "update", "toolchain_id-forces-new").GetDiag()
 	}
 	if d.HasChange("name") {
 		newName := d.Get("name").(string)
@@ -335,11 +361,16 @@ func resourceIBMCdToolchainToolSecretsmanagerUpdate(context context.Context, d *
 	}
 
 	if hasChange {
-		updateToolOptions.ToolchainToolPrototypePatch, _ = patchVals.AsPatch()
-		_, response, err := cdToolchainClient.UpdateToolWithContext(context, updateToolOptions)
+		// Fields with `nil` values are omitted from the generic map,
+		// so we need to re-add them to support removing arguments
+		// in merge-patch operations sent to the service.
+		updateToolOptions.ToolchainToolPrototypePatch = ResourceIBMCdToolchainToolSecretsmanagerToolchainToolPrototypePatchAsPatch(patchVals, d)
+
+		_, _, err = cdToolchainClient.UpdateToolWithContext(context, updateToolOptions)
 		if err != nil {
-			log.Printf("[DEBUG] UpdateToolWithContext failed %s\n%s", err, response)
-			return diag.FromErr(fmt.Errorf("UpdateToolWithContext failed %s\n%s", err, response))
+			tfErr := flex.TerraformErrorf(err, fmt.Sprintf("UpdateToolWithContext failed: %s", err.Error()), "ibm_cd_toolchain_tool_secretsmanager", "update")
+			log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+			return tfErr.GetDiag()
 		}
 	}
 
@@ -349,23 +380,26 @@ func resourceIBMCdToolchainToolSecretsmanagerUpdate(context context.Context, d *
 func resourceIBMCdToolchainToolSecretsmanagerDelete(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	cdToolchainClient, err := meta.(conns.ClientSession).CdToolchainV2()
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cd_toolchain_tool_secretsmanager", "delete", "initialize-client")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	deleteToolOptions := &cdtoolchainv2.DeleteToolOptions{}
 
 	parts, err := flex.SepIdParts(d.Id(), "/")
 	if err != nil {
-		return diag.FromErr(err)
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cd_toolchain_tool_secretsmanager", "delete", "sep-id-parts").GetDiag()
 	}
 
 	deleteToolOptions.SetToolchainID(parts[0])
 	deleteToolOptions.SetToolID(parts[1])
 
-	response, err := cdToolchainClient.DeleteToolWithContext(context, deleteToolOptions)
+	_, err = cdToolchainClient.DeleteToolWithContext(context, deleteToolOptions)
 	if err != nil {
-		log.Printf("[DEBUG] DeleteToolWithContext failed %s\n%s", err, response)
-		return diag.FromErr(fmt.Errorf("DeleteToolWithContext failed %s\n%s", err, response))
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("DeleteToolWithContext failed: %s", err.Error()), "ibm_cd_toolchain_tool_secretsmanager", "delete")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	d.SetId("")
@@ -373,13 +407,60 @@ func resourceIBMCdToolchainToolSecretsmanagerDelete(context context.Context, d *
 	return nil
 }
 
-func resourceIBMCdToolchainToolSecretsmanagerToolModelReferentToMap(model *cdtoolchainv2.ToolModelReferent) (map[string]interface{}, error) {
+func ResourceIBMCdToolchainToolSecretsmanagerToolModelReferentToMap(model *cdtoolchainv2.ToolModelReferent) (map[string]interface{}, error) {
 	modelMap := make(map[string]interface{})
 	if model.UIHref != nil {
-		modelMap["ui_href"] = model.UIHref
+		modelMap["ui_href"] = *model.UIHref
 	}
 	if model.APIHref != nil {
-		modelMap["api_href"] = model.APIHref
+		modelMap["api_href"] = *model.APIHref
 	}
 	return modelMap, nil
+}
+
+func ResourceIBMCdToolchainToolSecretsmanagerToolchainToolPrototypePatchAsPatch(patchVals *cdtoolchainv2.ToolchainToolPrototypePatch, d *schema.ResourceData) map[string]interface{} {
+	patch, _ := patchVals.AsPatch()
+	var path string
+
+	path = "name"
+	if _, exists := d.GetOk(path); d.HasChange(path) && !exists {
+		patch["name"] = nil
+	}
+	path = "tool_type_id"
+	if _, exists := d.GetOk(path); d.HasChange(path) && !exists {
+		patch["tool_type_id"] = nil
+	}
+	path = "parameters"
+	if _, exists := d.GetOk(path); d.HasChange(path) && !exists {
+		patch["parameters"] = nil
+	} else if exists && patch["parameters"] != nil {
+		ResourceIBMCdToolchainToolSecretsmanagerToolModelParametersAsPatch(patch["parameters"].(map[string]interface{}), d)
+	}
+
+	return patch
+}
+
+func ResourceIBMCdToolchainToolSecretsmanagerToolModelParametersAsPatch(patch map[string]interface{}, d *schema.ResourceData) {
+	var path string
+
+	path = "parameters.0.instance_id_type"
+	if _, exists := d.GetOk(path); d.HasChange(path) && !exists {
+		patch["instance_id_type"] = nil
+	}
+	path = "parameters.0.instance_name"
+	if _, exists := d.GetOk(path); d.HasChange(path) && !exists {
+		patch["instance_name"] = nil
+	}
+	path = "parameters.0.instance_crn"
+	if _, exists := d.GetOk(path); d.HasChange(path) && !exists {
+		patch["instance_crn"] = nil
+	}
+	path = "parameters.0.location"
+	if _, exists := d.GetOk(path); d.HasChange(path) && !exists {
+		patch["location"] = nil
+	}
+	path = "parameters.0.resource_group_name"
+	if _, exists := d.GetOk(path); d.HasChange(path) && !exists {
+		patch["resource_group_name"] = nil
+	}
 }

--- a/ibm/service/cdtoolchain/resource_ibm_cd_toolchain_tool_securitycompliance.go
+++ b/ibm/service/cdtoolchain/resource_ibm_cd_toolchain_tool_securitycompliance.go
@@ -1,6 +1,10 @@
 // Copyright IBM Corp. 2024 All Rights Reserved.
 // Licensed under the Mozilla Public License v2.0
 
+/*
+ * IBM OpenAPI Terraform Generator Version: 3.96.0-d6dec9d7-20241008-212902
+ */
+
 package cdtoolchain
 
 import (
@@ -129,11 +133,13 @@ func ResourceIBMCdToolchainToolSecuritycompliance() *schema.Resource {
 						"ui_href": &schema.Schema{
 							Type:        schema.TypeString,
 							Optional:    true,
+							Computed:    true,
 							Description: "URI representing this resource through the UI.",
 						},
 						"api_href": &schema.Schema{
 							Type:        schema.TypeString,
 							Optional:    true,
+							Computed:    true,
 							Description: "URI representing this resource through an API.",
 						},
 					},
@@ -188,7 +194,9 @@ func ResourceIBMCdToolchainToolSecuritycomplianceValidator() *validate.ResourceV
 func resourceIBMCdToolchainToolSecuritycomplianceCreate(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	cdToolchainClient, err := meta.(conns.ClientSession).CdToolchainV2()
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cd_toolchain_tool_securitycompliance", "create", "initialize-client")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	createToolOptions := &cdtoolchainv2.CreateToolOptions{}
@@ -204,10 +212,11 @@ func resourceIBMCdToolchainToolSecuritycomplianceCreate(context context.Context,
 		createToolOptions.SetName(d.Get("name").(string))
 	}
 
-	toolchainToolPost, response, err := cdToolchainClient.CreateToolWithContext(context, createToolOptions)
+	toolchainToolPost, _, err := cdToolchainClient.CreateToolWithContext(context, createToolOptions)
 	if err != nil {
-		log.Printf("[DEBUG] CreateToolWithContext failed %s\n%s", err, response)
-		return diag.FromErr(fmt.Errorf("CreateToolWithContext failed %s\n%s", err, response))
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("CreateToolWithContext failed: %s", err.Error()), "ibm_cd_toolchain_tool_securitycompliance", "create")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	d.SetId(fmt.Sprintf("%s/%s", *createToolOptions.ToolchainID, *toolchainToolPost.ID))
@@ -218,14 +227,16 @@ func resourceIBMCdToolchainToolSecuritycomplianceCreate(context context.Context,
 func resourceIBMCdToolchainToolSecuritycomplianceRead(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	cdToolchainClient, err := meta.(conns.ClientSession).CdToolchainV2()
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cd_toolchain_tool_securitycompliance", "read", "initialize-client")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	getToolByIDOptions := &cdtoolchainv2.GetToolByIDOptions{}
 
 	parts, err := flex.SepIdParts(d.Id(), "/")
 	if err != nil {
-		return diag.FromErr(err)
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cd_toolchain_tool_securitycompliance", "read", "sep-id-parts").GetDiag()
 	}
 
 	getToolByIDOptions.SetToolchainID(parts[0])
@@ -251,16 +262,19 @@ func resourceIBMCdToolchainToolSecuritycomplianceRead(context context.Context, d
 			d.SetId("")
 			return nil
 		}
-		log.Printf("[DEBUG] GetToolByIDWithContext failed %s\n%s", err, response)
-		return diag.FromErr(fmt.Errorf("GetToolByIDWithContext failed %s\n%s", err, response))
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("GetToolByIDWithContext failed: %s", err.Error()), "ibm_cd_toolchain_tool_securitycompliance", "read")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	if err = d.Set("toolchain_id", toolchainTool.ToolchainID); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting toolchain_id: %s", err))
+		err = fmt.Errorf("Error setting toolchain_id: %s", err)
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cd_toolchain_tool_securitycompliance", "read", "set-toolchain_id").GetDiag()
 	}
 	if !core.IsNil(toolchainTool.Name) {
 		if err = d.Set("name", toolchainTool.Name); err != nil {
-			return diag.FromErr(fmt.Errorf("Error setting name: %s", err))
+			err = fmt.Errorf("Error setting name: %s", err)
+			return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cd_toolchain_tool_securitycompliance", "read", "set-name").GetDiag()
 		}
 	}
 	remapFields := map[string]string{
@@ -268,35 +282,44 @@ func resourceIBMCdToolchainToolSecuritycomplianceRead(context context.Context, d
 	}
 	parametersMap := GetParametersFromRead(toolchainTool.Parameters, ResourceIBMCdToolchainToolSecuritycompliance(), remapFields)
 	if err = d.Set("parameters", []map[string]interface{}{parametersMap}); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting parameters: %s", err))
+		err = fmt.Errorf("Error setting parameters: %s", err)
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cd_toolchain_tool_securitycompliance", "read", "set-parameters").GetDiag()
 	}
 	if err = d.Set("resource_group_id", toolchainTool.ResourceGroupID); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting resource_group_id: %s", err))
+		err = fmt.Errorf("Error setting resource_group_id: %s", err)
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cd_toolchain_tool_securitycompliance", "read", "set-resource_group_id").GetDiag()
 	}
 	if err = d.Set("crn", toolchainTool.CRN); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting crn: %s", err))
+		err = fmt.Errorf("Error setting crn: %s", err)
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cd_toolchain_tool_securitycompliance", "read", "set-crn").GetDiag()
 	}
 	if err = d.Set("toolchain_crn", toolchainTool.ToolchainCRN); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting toolchain_crn: %s", err))
+		err = fmt.Errorf("Error setting toolchain_crn: %s", err)
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cd_toolchain_tool_securitycompliance", "read", "set-toolchain_crn").GetDiag()
 	}
 	if err = d.Set("href", toolchainTool.Href); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting href: %s", err))
+		err = fmt.Errorf("Error setting href: %s", err)
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cd_toolchain_tool_securitycompliance", "read", "set-href").GetDiag()
 	}
-	referentMap, err := resourceIBMCdToolchainToolSecuritycomplianceToolModelReferentToMap(toolchainTool.Referent)
+	referentMap, err := ResourceIBMCdToolchainToolSecuritycomplianceToolModelReferentToMap(toolchainTool.Referent)
 	if err != nil {
-		return diag.FromErr(err)
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cd_toolchain_tool_securitycompliance", "read", "referent-to-map").GetDiag()
 	}
 	if err = d.Set("referent", []map[string]interface{}{referentMap}); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting referent: %s", err))
+		err = fmt.Errorf("Error setting referent: %s", err)
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cd_toolchain_tool_securitycompliance", "read", "set-referent").GetDiag()
 	}
 	if err = d.Set("updated_at", flex.DateTimeToString(toolchainTool.UpdatedAt)); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting updated_at: %s", err))
+		err = fmt.Errorf("Error setting updated_at: %s", err)
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cd_toolchain_tool_securitycompliance", "read", "set-updated_at").GetDiag()
 	}
 	if err = d.Set("state", toolchainTool.State); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting state: %s", err))
+		err = fmt.Errorf("Error setting state: %s", err)
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cd_toolchain_tool_securitycompliance", "read", "set-state").GetDiag()
 	}
 	if err = d.Set("tool_id", toolchainTool.ID); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting tool_id: %s", err))
+		err = fmt.Errorf("Error setting tool_id: %s", err)
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cd_toolchain_tool_securitycompliance", "read", "set-tool_id").GetDiag()
 	}
 
 	return nil
@@ -305,14 +328,16 @@ func resourceIBMCdToolchainToolSecuritycomplianceRead(context context.Context, d
 func resourceIBMCdToolchainToolSecuritycomplianceUpdate(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	cdToolchainClient, err := meta.(conns.ClientSession).CdToolchainV2()
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cd_toolchain_tool_securitycompliance", "update", "initialize-client")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	updateToolOptions := &cdtoolchainv2.UpdateToolOptions{}
 
 	parts, err := flex.SepIdParts(d.Id(), "/")
 	if err != nil {
-		return diag.FromErr(err)
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cd_toolchain_tool_securitycompliance", "update", "sep-id-parts").GetDiag()
 	}
 
 	updateToolOptions.SetToolchainID(parts[0])
@@ -322,8 +347,9 @@ func resourceIBMCdToolchainToolSecuritycomplianceUpdate(context context.Context,
 
 	patchVals := &cdtoolchainv2.ToolchainToolPrototypePatch{}
 	if d.HasChange("toolchain_id") {
-		return diag.FromErr(fmt.Errorf("Cannot update resource property \"%s\" with the ForceNew annotation."+
-			" The resource must be re-created to update this property.", "toolchain_id"))
+		errMsg := fmt.Sprintf("Cannot update resource property \"%s\" with the ForceNew annotation."+
+			" The resource must be re-created to update this property.", "toolchain_id")
+		return flex.DiscriminatedTerraformErrorf(nil, errMsg, "ibm_cd_toolchain_tool_securitycompliance", "update", "toolchain_id-forces-new").GetDiag()
 	}
 	if d.HasChange("name") {
 		newName := d.Get("name").(string)
@@ -340,11 +366,16 @@ func resourceIBMCdToolchainToolSecuritycomplianceUpdate(context context.Context,
 	}
 
 	if hasChange {
-		updateToolOptions.ToolchainToolPrototypePatch, _ = patchVals.AsPatch()
-		_, response, err := cdToolchainClient.UpdateToolWithContext(context, updateToolOptions)
+		// Fields with `nil` values are omitted from the generic map,
+		// so we need to re-add them to support removing arguments
+		// in merge-patch operations sent to the service.
+		updateToolOptions.ToolchainToolPrototypePatch = ResourceIBMCdToolchainToolSecuritycomplianceToolchainToolPrototypePatchAsPatch(patchVals, d)
+
+		_, _, err = cdToolchainClient.UpdateToolWithContext(context, updateToolOptions)
 		if err != nil {
-			log.Printf("[DEBUG] UpdateToolWithContext failed %s\n%s", err, response)
-			return diag.FromErr(fmt.Errorf("UpdateToolWithContext failed %s\n%s", err, response))
+			tfErr := flex.TerraformErrorf(err, fmt.Sprintf("UpdateToolWithContext failed: %s", err.Error()), "ibm_cd_toolchain_tool_securitycompliance", "update")
+			log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+			return tfErr.GetDiag()
 		}
 	}
 
@@ -354,23 +385,26 @@ func resourceIBMCdToolchainToolSecuritycomplianceUpdate(context context.Context,
 func resourceIBMCdToolchainToolSecuritycomplianceDelete(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	cdToolchainClient, err := meta.(conns.ClientSession).CdToolchainV2()
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cd_toolchain_tool_securitycompliance", "delete", "initialize-client")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	deleteToolOptions := &cdtoolchainv2.DeleteToolOptions{}
 
 	parts, err := flex.SepIdParts(d.Id(), "/")
 	if err != nil {
-		return diag.FromErr(err)
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cd_toolchain_tool_securitycompliance", "delete", "sep-id-parts").GetDiag()
 	}
 
 	deleteToolOptions.SetToolchainID(parts[0])
 	deleteToolOptions.SetToolID(parts[1])
 
-	response, err := cdToolchainClient.DeleteToolWithContext(context, deleteToolOptions)
+	_, err = cdToolchainClient.DeleteToolWithContext(context, deleteToolOptions)
 	if err != nil {
-		log.Printf("[DEBUG] DeleteToolWithContext failed %s\n%s", err, response)
-		return diag.FromErr(fmt.Errorf("DeleteToolWithContext failed %s\n%s", err, response))
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("DeleteToolWithContext failed: %s", err.Error()), "ibm_cd_toolchain_tool_securitycompliance", "delete")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	d.SetId("")
@@ -378,13 +412,68 @@ func resourceIBMCdToolchainToolSecuritycomplianceDelete(context context.Context,
 	return nil
 }
 
-func resourceIBMCdToolchainToolSecuritycomplianceToolModelReferentToMap(model *cdtoolchainv2.ToolModelReferent) (map[string]interface{}, error) {
+func ResourceIBMCdToolchainToolSecuritycomplianceToolModelReferentToMap(model *cdtoolchainv2.ToolModelReferent) (map[string]interface{}, error) {
 	modelMap := make(map[string]interface{})
 	if model.UIHref != nil {
-		modelMap["ui_href"] = model.UIHref
+		modelMap["ui_href"] = *model.UIHref
 	}
 	if model.APIHref != nil {
-		modelMap["api_href"] = model.APIHref
+		modelMap["api_href"] = *model.APIHref
 	}
 	return modelMap, nil
+}
+
+func ResourceIBMCdToolchainToolSecuritycomplianceToolchainToolPrototypePatchAsPatch(patchVals *cdtoolchainv2.ToolchainToolPrototypePatch, d *schema.ResourceData) map[string]interface{} {
+	patch, _ := patchVals.AsPatch()
+	var path string
+
+	path = "name"
+	if _, exists := d.GetOk(path); d.HasChange(path) && !exists {
+		patch["name"] = nil
+	}
+	path = "tool_type_id"
+	if _, exists := d.GetOk(path); d.HasChange(path) && !exists {
+		patch["tool_type_id"] = nil
+	}
+	path = "parameters"
+	if _, exists := d.GetOk(path); d.HasChange(path) && !exists {
+		patch["parameters"] = nil
+	} else if exists && patch["parameters"] != nil {
+		ResourceIBMCdToolchainToolSecuritycomplianceToolModelParametersAsPatch(patch["parameters"].(map[string]interface{}), d)
+	}
+
+	return patch
+}
+
+func ResourceIBMCdToolchainToolSecuritycomplianceToolModelParametersAsPatch(patch map[string]interface{}, d *schema.ResourceData) {
+	var path string
+
+	path = "parameters.0.evidence_namespace"
+	if _, exists := d.GetOk(path); d.HasChange(path) && !exists {
+		patch["evidence_namespace"] = nil
+	}
+	path = "parameters.0.use_profile_attachment"
+	if _, exists := d.GetOk(path); d.HasChange(path) && !exists {
+		patch["use_profile_attachment"] = nil
+	}
+	path = "parameters.0.scc_api_key"
+	if _, exists := d.GetOk(path); d.HasChange(path) && !exists {
+		patch["scc_api_key"] = nil
+	}
+	path = "parameters.0.instance_crn"
+	if _, exists := d.GetOk(path); d.HasChange(path) && !exists {
+		patch["instance_crn"] = nil
+	}
+	path = "parameters.0.profile_name"
+	if _, exists := d.GetOk(path); d.HasChange(path) && !exists {
+		patch["profile_name"] = nil
+	}
+	path = "parameters.0.profile_version"
+	if _, exists := d.GetOk(path); d.HasChange(path) && !exists {
+		patch["profile_version"] = nil
+	}
+	path = "parameters.0.attachment_id"
+	if _, exists := d.GetOk(path); d.HasChange(path) && !exists {
+		patch["attachment_id"] = nil
+	}
 }

--- a/ibm/service/cdtoolchain/resource_ibm_cd_toolchain_tool_slack.go
+++ b/ibm/service/cdtoolchain/resource_ibm_cd_toolchain_tool_slack.go
@@ -1,5 +1,9 @@
-// Copyright IBM Corp. 2023 All Rights Reserved.
+// Copyright IBM Corp. 2024 All Rights Reserved.
 // Licensed under the Mozilla Public License v2.0
+
+/*
+ * IBM OpenAPI Terraform Generator Version: 3.96.0-d6dec9d7-20241008-212902
+ */
 
 package cdtoolchain
 
@@ -129,11 +133,13 @@ func ResourceIBMCdToolchainToolSlack() *schema.Resource {
 						"ui_href": &schema.Schema{
 							Type:        schema.TypeString,
 							Optional:    true,
+							Computed:    true,
 							Description: "URI representing this resource through the UI.",
 						},
 						"api_href": &schema.Schema{
 							Type:        schema.TypeString,
 							Optional:    true,
+							Computed:    true,
 							Description: "URI representing this resource through an API.",
 						},
 					},
@@ -188,7 +194,9 @@ func ResourceIBMCdToolchainToolSlackValidator() *validate.ResourceValidator {
 func resourceIBMCdToolchainToolSlackCreate(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	cdToolchainClient, err := meta.(conns.ClientSession).CdToolchainV2()
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cd_toolchain_tool_slack", "create", "initialize-client")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	createToolOptions := &cdtoolchainv2.CreateToolOptions{}
@@ -205,10 +213,11 @@ func resourceIBMCdToolchainToolSlackCreate(context context.Context, d *schema.Re
 		createToolOptions.SetName(d.Get("name").(string))
 	}
 
-	toolchainToolPost, response, err := cdToolchainClient.CreateToolWithContext(context, createToolOptions)
+	toolchainToolPost, _, err := cdToolchainClient.CreateToolWithContext(context, createToolOptions)
 	if err != nil {
-		log.Printf("[DEBUG] CreateToolWithContext failed %s\n%s", err, response)
-		return diag.FromErr(fmt.Errorf("CreateToolWithContext failed %s\n%s", err, response))
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("CreateToolWithContext failed: %s", err.Error()), "ibm_cd_toolchain_tool_slack", "create")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	d.SetId(fmt.Sprintf("%s/%s", *createToolOptions.ToolchainID, *toolchainToolPost.ID))
@@ -219,14 +228,16 @@ func resourceIBMCdToolchainToolSlackCreate(context context.Context, d *schema.Re
 func resourceIBMCdToolchainToolSlackRead(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	cdToolchainClient, err := meta.(conns.ClientSession).CdToolchainV2()
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cd_toolchain_tool_slack", "read", "initialize-client")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	getToolByIDOptions := &cdtoolchainv2.GetToolByIDOptions{}
 
 	parts, err := flex.SepIdParts(d.Id(), "/")
 	if err != nil {
-		return diag.FromErr(err)
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cd_toolchain_tool_slack", "read", "sep-id-parts").GetDiag()
 	}
 
 	getToolByIDOptions.SetToolchainID(parts[0])
@@ -252,16 +263,19 @@ func resourceIBMCdToolchainToolSlackRead(context context.Context, d *schema.Reso
 			d.SetId("")
 			return nil
 		}
-		log.Printf("[DEBUG] GetToolByIDWithContext failed %s\n%s", err, response)
-		return diag.FromErr(fmt.Errorf("GetToolByIDWithContext failed %s\n%s", err, response))
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("GetToolByIDWithContext failed: %s", err.Error()), "ibm_cd_toolchain_tool_slack", "read")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	if err = d.Set("toolchain_id", toolchainTool.ToolchainID); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting toolchain_id: %s", err))
+		err = fmt.Errorf("Error setting toolchain_id: %s", err)
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cd_toolchain_tool_slack", "read", "set-toolchain_id").GetDiag()
 	}
 	if !core.IsNil(toolchainTool.Name) {
 		if err = d.Set("name", toolchainTool.Name); err != nil {
-			return diag.FromErr(fmt.Errorf("Error setting name: %s", err))
+			err = fmt.Errorf("Error setting name: %s", err)
+			return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cd_toolchain_tool_slack", "read", "set-name").GetDiag()
 		}
 	}
 	remapFields := map[string]string{
@@ -270,35 +284,44 @@ func resourceIBMCdToolchainToolSlackRead(context context.Context, d *schema.Reso
 	}
 	parametersMap := GetParametersFromRead(toolchainTool.Parameters, ResourceIBMCdToolchainToolSlack(), remapFields)
 	if err = d.Set("parameters", []map[string]interface{}{parametersMap}); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting parameters: %s", err))
+		err = fmt.Errorf("Error setting parameters: %s", err)
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cd_toolchain_tool_slack", "read", "set-parameters").GetDiag()
 	}
 	if err = d.Set("resource_group_id", toolchainTool.ResourceGroupID); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting resource_group_id: %s", err))
+		err = fmt.Errorf("Error setting resource_group_id: %s", err)
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cd_toolchain_tool_slack", "read", "set-resource_group_id").GetDiag()
 	}
 	if err = d.Set("crn", toolchainTool.CRN); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting crn: %s", err))
+		err = fmt.Errorf("Error setting crn: %s", err)
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cd_toolchain_tool_slack", "read", "set-crn").GetDiag()
 	}
 	if err = d.Set("toolchain_crn", toolchainTool.ToolchainCRN); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting toolchain_crn: %s", err))
+		err = fmt.Errorf("Error setting toolchain_crn: %s", err)
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cd_toolchain_tool_slack", "read", "set-toolchain_crn").GetDiag()
 	}
 	if err = d.Set("href", toolchainTool.Href); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting href: %s", err))
+		err = fmt.Errorf("Error setting href: %s", err)
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cd_toolchain_tool_slack", "read", "set-href").GetDiag()
 	}
-	referentMap, err := resourceIBMCdToolchainToolSlackToolModelReferentToMap(toolchainTool.Referent)
+	referentMap, err := ResourceIBMCdToolchainToolSlackToolModelReferentToMap(toolchainTool.Referent)
 	if err != nil {
-		return diag.FromErr(err)
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cd_toolchain_tool_slack", "read", "referent-to-map").GetDiag()
 	}
 	if err = d.Set("referent", []map[string]interface{}{referentMap}); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting referent: %s", err))
+		err = fmt.Errorf("Error setting referent: %s", err)
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cd_toolchain_tool_slack", "read", "set-referent").GetDiag()
 	}
 	if err = d.Set("updated_at", flex.DateTimeToString(toolchainTool.UpdatedAt)); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting updated_at: %s", err))
+		err = fmt.Errorf("Error setting updated_at: %s", err)
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cd_toolchain_tool_slack", "read", "set-updated_at").GetDiag()
 	}
 	if err = d.Set("state", toolchainTool.State); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting state: %s", err))
+		err = fmt.Errorf("Error setting state: %s", err)
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cd_toolchain_tool_slack", "read", "set-state").GetDiag()
 	}
 	if err = d.Set("tool_id", toolchainTool.ID); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting tool_id: %s", err))
+		err = fmt.Errorf("Error setting tool_id: %s", err)
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cd_toolchain_tool_slack", "read", "set-tool_id").GetDiag()
 	}
 
 	return nil
@@ -307,14 +330,16 @@ func resourceIBMCdToolchainToolSlackRead(context context.Context, d *schema.Reso
 func resourceIBMCdToolchainToolSlackUpdate(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	cdToolchainClient, err := meta.(conns.ClientSession).CdToolchainV2()
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cd_toolchain_tool_slack", "update", "initialize-client")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	updateToolOptions := &cdtoolchainv2.UpdateToolOptions{}
 
 	parts, err := flex.SepIdParts(d.Id(), "/")
 	if err != nil {
-		return diag.FromErr(err)
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cd_toolchain_tool_slack", "update", "sep-id-parts").GetDiag()
 	}
 
 	updateToolOptions.SetToolchainID(parts[0])
@@ -324,8 +349,9 @@ func resourceIBMCdToolchainToolSlackUpdate(context context.Context, d *schema.Re
 
 	patchVals := &cdtoolchainv2.ToolchainToolPrototypePatch{}
 	if d.HasChange("toolchain_id") {
-		return diag.FromErr(fmt.Errorf("Cannot update resource property \"%s\" with the ForceNew annotation."+
-			" The resource must be re-created to update this property.", "toolchain_id"))
+		errMsg := fmt.Sprintf("Cannot update resource property \"%s\" with the ForceNew annotation."+
+			" The resource must be re-created to update this property.", "toolchain_id")
+		return flex.DiscriminatedTerraformErrorf(nil, errMsg, "ibm_cd_toolchain_tool_slack", "update", "toolchain_id-forces-new").GetDiag()
 	}
 	if d.HasChange("name") {
 		newName := d.Get("name").(string)
@@ -343,11 +369,16 @@ func resourceIBMCdToolchainToolSlackUpdate(context context.Context, d *schema.Re
 	}
 
 	if hasChange {
-		updateToolOptions.ToolchainToolPrototypePatch, _ = patchVals.AsPatch()
-		_, response, err := cdToolchainClient.UpdateToolWithContext(context, updateToolOptions)
+		// Fields with `nil` values are omitted from the generic map,
+		// so we need to re-add them to support removing arguments
+		// in merge-patch operations sent to the service.
+		updateToolOptions.ToolchainToolPrototypePatch = ResourceIBMCdToolchainToolSlackToolchainToolPrototypePatchAsPatch(patchVals, d)
+
+		_, _, err = cdToolchainClient.UpdateToolWithContext(context, updateToolOptions)
 		if err != nil {
-			log.Printf("[DEBUG] UpdateToolWithContext failed %s\n%s", err, response)
-			return diag.FromErr(fmt.Errorf("UpdateToolWithContext failed %s\n%s", err, response))
+			tfErr := flex.TerraformErrorf(err, fmt.Sprintf("UpdateToolWithContext failed: %s", err.Error()), "ibm_cd_toolchain_tool_slack", "update")
+			log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+			return tfErr.GetDiag()
 		}
 	}
 
@@ -357,23 +388,26 @@ func resourceIBMCdToolchainToolSlackUpdate(context context.Context, d *schema.Re
 func resourceIBMCdToolchainToolSlackDelete(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	cdToolchainClient, err := meta.(conns.ClientSession).CdToolchainV2()
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cd_toolchain_tool_slack", "delete", "initialize-client")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	deleteToolOptions := &cdtoolchainv2.DeleteToolOptions{}
 
 	parts, err := flex.SepIdParts(d.Id(), "/")
 	if err != nil {
-		return diag.FromErr(err)
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cd_toolchain_tool_slack", "delete", "sep-id-parts").GetDiag()
 	}
 
 	deleteToolOptions.SetToolchainID(parts[0])
 	deleteToolOptions.SetToolID(parts[1])
 
-	response, err := cdToolchainClient.DeleteToolWithContext(context, deleteToolOptions)
+	_, err = cdToolchainClient.DeleteToolWithContext(context, deleteToolOptions)
 	if err != nil {
-		log.Printf("[DEBUG] DeleteToolWithContext failed %s\n%s", err, response)
-		return diag.FromErr(fmt.Errorf("DeleteToolWithContext failed %s\n%s", err, response))
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("DeleteToolWithContext failed: %s", err.Error()), "ibm_cd_toolchain_tool_slack", "delete")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	d.SetId("")
@@ -381,13 +415,64 @@ func resourceIBMCdToolchainToolSlackDelete(context context.Context, d *schema.Re
 	return nil
 }
 
-func resourceIBMCdToolchainToolSlackToolModelReferentToMap(model *cdtoolchainv2.ToolModelReferent) (map[string]interface{}, error) {
+func ResourceIBMCdToolchainToolSlackToolModelReferentToMap(model *cdtoolchainv2.ToolModelReferent) (map[string]interface{}, error) {
 	modelMap := make(map[string]interface{})
 	if model.UIHref != nil {
-		modelMap["ui_href"] = model.UIHref
+		modelMap["ui_href"] = *model.UIHref
 	}
 	if model.APIHref != nil {
-		modelMap["api_href"] = model.APIHref
+		modelMap["api_href"] = *model.APIHref
 	}
 	return modelMap, nil
+}
+
+func ResourceIBMCdToolchainToolSlackToolchainToolPrototypePatchAsPatch(patchVals *cdtoolchainv2.ToolchainToolPrototypePatch, d *schema.ResourceData) map[string]interface{} {
+	patch, _ := patchVals.AsPatch()
+	var path string
+
+	path = "name"
+	if _, exists := d.GetOk(path); d.HasChange(path) && !exists {
+		patch["name"] = nil
+	}
+	path = "tool_type_id"
+	if _, exists := d.GetOk(path); d.HasChange(path) && !exists {
+		patch["tool_type_id"] = nil
+	}
+	path = "parameters"
+	if _, exists := d.GetOk(path); d.HasChange(path) && !exists {
+		patch["parameters"] = nil
+	} else if exists && patch["parameters"] != nil {
+		ResourceIBMCdToolchainToolSlackToolModelParametersAsPatch(patch["parameters"].(map[string]interface{}), d)
+	}
+
+	return patch
+}
+
+func ResourceIBMCdToolchainToolSlackToolModelParametersAsPatch(patch map[string]interface{}, d *schema.ResourceData) {
+	var path string
+
+	path = "parameters.0.pipeline_start"
+	if _, exists := d.GetOk(path); d.HasChange(path) && !exists {
+		patch["pipeline_start"] = nil
+	}
+	path = "parameters.0.pipeline_success"
+	if _, exists := d.GetOk(path); d.HasChange(path) && !exists {
+		patch["pipeline_success"] = nil
+	}
+	path = "parameters.0.pipeline_fail"
+	if _, exists := d.GetOk(path); d.HasChange(path) && !exists {
+		patch["pipeline_fail"] = nil
+	}
+	path = "parameters.0.toolchain_bind"
+	if _, exists := d.GetOk(path); d.HasChange(path) && !exists {
+		patch["toolchain_bind"] = nil
+	}
+	path = "parameters.0.toolchain_unbind"
+	if _, exists := d.GetOk(path); d.HasChange(path) && !exists {
+		patch["toolchain_unbind"] = nil
+	}
+	path = "parameters.0.team_name"
+	if _, exists := d.GetOk(path); d.HasChange(path) && !exists {
+		patch["team_name"] = nil
+	}
 }

--- a/ibm/service/cdtoolchain/resource_ibm_cd_toolchain_tool_sonarqube.go
+++ b/ibm/service/cdtoolchain/resource_ibm_cd_toolchain_tool_sonarqube.go
@@ -1,5 +1,9 @@
-// Copyright IBM Corp. 2023 All Rights Reserved.
+// Copyright IBM Corp. 2024 All Rights Reserved.
 // Licensed under the Mozilla Public License v2.0
+
+/*
+ * IBM OpenAPI Terraform Generator Version: 3.96.0-d6dec9d7-20241008-212902
+ */
 
 package cdtoolchain
 
@@ -110,11 +114,13 @@ func ResourceIBMCdToolchainToolSonarqube() *schema.Resource {
 						"ui_href": &schema.Schema{
 							Type:        schema.TypeString,
 							Optional:    true,
+							Computed:    true,
 							Description: "URI representing this resource through the UI.",
 						},
 						"api_href": &schema.Schema{
 							Type:        schema.TypeString,
 							Optional:    true,
+							Computed:    true,
 							Description: "URI representing this resource through an API.",
 						},
 					},
@@ -169,7 +175,9 @@ func ResourceIBMCdToolchainToolSonarqubeValidator() *validate.ResourceValidator 
 func resourceIBMCdToolchainToolSonarqubeCreate(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	cdToolchainClient, err := meta.(conns.ClientSession).CdToolchainV2()
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cd_toolchain_tool_sonarqube", "create", "initialize-client")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	createToolOptions := &cdtoolchainv2.CreateToolOptions{}
@@ -185,10 +193,11 @@ func resourceIBMCdToolchainToolSonarqubeCreate(context context.Context, d *schem
 		createToolOptions.SetName(d.Get("name").(string))
 	}
 
-	toolchainToolPost, response, err := cdToolchainClient.CreateToolWithContext(context, createToolOptions)
+	toolchainToolPost, _, err := cdToolchainClient.CreateToolWithContext(context, createToolOptions)
 	if err != nil {
-		log.Printf("[DEBUG] CreateToolWithContext failed %s\n%s", err, response)
-		return diag.FromErr(fmt.Errorf("CreateToolWithContext failed %s\n%s", err, response))
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("CreateToolWithContext failed: %s", err.Error()), "ibm_cd_toolchain_tool_sonarqube", "create")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	d.SetId(fmt.Sprintf("%s/%s", *createToolOptions.ToolchainID, *toolchainToolPost.ID))
@@ -199,14 +208,16 @@ func resourceIBMCdToolchainToolSonarqubeCreate(context context.Context, d *schem
 func resourceIBMCdToolchainToolSonarqubeRead(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	cdToolchainClient, err := meta.(conns.ClientSession).CdToolchainV2()
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cd_toolchain_tool_sonarqube", "read", "initialize-client")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	getToolByIDOptions := &cdtoolchainv2.GetToolByIDOptions{}
 
 	parts, err := flex.SepIdParts(d.Id(), "/")
 	if err != nil {
-		return diag.FromErr(err)
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cd_toolchain_tool_sonarqube", "read", "sep-id-parts").GetDiag()
 	}
 
 	getToolByIDOptions.SetToolchainID(parts[0])
@@ -232,16 +243,19 @@ func resourceIBMCdToolchainToolSonarqubeRead(context context.Context, d *schema.
 			d.SetId("")
 			return nil
 		}
-		log.Printf("[DEBUG] GetToolByIDWithContext failed %s\n%s", err, response)
-		return diag.FromErr(fmt.Errorf("GetToolByIDWithContext failed %s\n%s", err, response))
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("GetToolByIDWithContext failed: %s", err.Error()), "ibm_cd_toolchain_tool_sonarqube", "read")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	if err = d.Set("toolchain_id", toolchainTool.ToolchainID); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting toolchain_id: %s", err))
+		err = fmt.Errorf("Error setting toolchain_id: %s", err)
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cd_toolchain_tool_sonarqube", "read", "set-toolchain_id").GetDiag()
 	}
 	if !core.IsNil(toolchainTool.Name) {
 		if err = d.Set("name", toolchainTool.Name); err != nil {
-			return diag.FromErr(fmt.Errorf("Error setting name: %s", err))
+			err = fmt.Errorf("Error setting name: %s", err)
+			return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cd_toolchain_tool_sonarqube", "read", "set-name").GetDiag()
 		}
 	}
 	remapFields := map[string]string{
@@ -249,35 +263,44 @@ func resourceIBMCdToolchainToolSonarqubeRead(context context.Context, d *schema.
 	}
 	parametersMap := GetParametersFromRead(toolchainTool.Parameters, ResourceIBMCdToolchainToolSonarqube(), remapFields)
 	if err = d.Set("parameters", []map[string]interface{}{parametersMap}); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting parameters: %s", err))
+		err = fmt.Errorf("Error setting parameters: %s", err)
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cd_toolchain_tool_sonarqube", "read", "set-parameters").GetDiag()
 	}
 	if err = d.Set("resource_group_id", toolchainTool.ResourceGroupID); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting resource_group_id: %s", err))
+		err = fmt.Errorf("Error setting resource_group_id: %s", err)
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cd_toolchain_tool_sonarqube", "read", "set-resource_group_id").GetDiag()
 	}
 	if err = d.Set("crn", toolchainTool.CRN); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting crn: %s", err))
+		err = fmt.Errorf("Error setting crn: %s", err)
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cd_toolchain_tool_sonarqube", "read", "set-crn").GetDiag()
 	}
 	if err = d.Set("toolchain_crn", toolchainTool.ToolchainCRN); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting toolchain_crn: %s", err))
+		err = fmt.Errorf("Error setting toolchain_crn: %s", err)
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cd_toolchain_tool_sonarqube", "read", "set-toolchain_crn").GetDiag()
 	}
 	if err = d.Set("href", toolchainTool.Href); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting href: %s", err))
+		err = fmt.Errorf("Error setting href: %s", err)
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cd_toolchain_tool_sonarqube", "read", "set-href").GetDiag()
 	}
-	referentMap, err := resourceIBMCdToolchainToolSonarqubeToolModelReferentToMap(toolchainTool.Referent)
+	referentMap, err := ResourceIBMCdToolchainToolSonarqubeToolModelReferentToMap(toolchainTool.Referent)
 	if err != nil {
-		return diag.FromErr(err)
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cd_toolchain_tool_sonarqube", "read", "referent-to-map").GetDiag()
 	}
 	if err = d.Set("referent", []map[string]interface{}{referentMap}); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting referent: %s", err))
+		err = fmt.Errorf("Error setting referent: %s", err)
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cd_toolchain_tool_sonarqube", "read", "set-referent").GetDiag()
 	}
 	if err = d.Set("updated_at", flex.DateTimeToString(toolchainTool.UpdatedAt)); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting updated_at: %s", err))
+		err = fmt.Errorf("Error setting updated_at: %s", err)
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cd_toolchain_tool_sonarqube", "read", "set-updated_at").GetDiag()
 	}
 	if err = d.Set("state", toolchainTool.State); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting state: %s", err))
+		err = fmt.Errorf("Error setting state: %s", err)
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cd_toolchain_tool_sonarqube", "read", "set-state").GetDiag()
 	}
 	if err = d.Set("tool_id", toolchainTool.ID); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting tool_id: %s", err))
+		err = fmt.Errorf("Error setting tool_id: %s", err)
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cd_toolchain_tool_sonarqube", "read", "set-tool_id").GetDiag()
 	}
 
 	return nil
@@ -286,14 +309,16 @@ func resourceIBMCdToolchainToolSonarqubeRead(context context.Context, d *schema.
 func resourceIBMCdToolchainToolSonarqubeUpdate(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	cdToolchainClient, err := meta.(conns.ClientSession).CdToolchainV2()
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cd_toolchain_tool_sonarqube", "update", "initialize-client")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	updateToolOptions := &cdtoolchainv2.UpdateToolOptions{}
 
 	parts, err := flex.SepIdParts(d.Id(), "/")
 	if err != nil {
-		return diag.FromErr(err)
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cd_toolchain_tool_sonarqube", "update", "sep-id-parts").GetDiag()
 	}
 
 	updateToolOptions.SetToolchainID(parts[0])
@@ -303,8 +328,9 @@ func resourceIBMCdToolchainToolSonarqubeUpdate(context context.Context, d *schem
 
 	patchVals := &cdtoolchainv2.ToolchainToolPrototypePatch{}
 	if d.HasChange("toolchain_id") {
-		return diag.FromErr(fmt.Errorf("Cannot update resource property \"%s\" with the ForceNew annotation."+
-			" The resource must be re-created to update this property.", "toolchain_id"))
+		errMsg := fmt.Sprintf("Cannot update resource property \"%s\" with the ForceNew annotation."+
+			" The resource must be re-created to update this property.", "toolchain_id")
+		return flex.DiscriminatedTerraformErrorf(nil, errMsg, "ibm_cd_toolchain_tool_sonarqube", "update", "toolchain_id-forces-new").GetDiag()
 	}
 	if d.HasChange("name") {
 		newName := d.Get("name").(string)
@@ -321,11 +347,16 @@ func resourceIBMCdToolchainToolSonarqubeUpdate(context context.Context, d *schem
 	}
 
 	if hasChange {
-		updateToolOptions.ToolchainToolPrototypePatch, _ = patchVals.AsPatch()
-		_, response, err := cdToolchainClient.UpdateToolWithContext(context, updateToolOptions)
+		// Fields with `nil` values are omitted from the generic map,
+		// so we need to re-add them to support removing arguments
+		// in merge-patch operations sent to the service.
+		updateToolOptions.ToolchainToolPrototypePatch = ResourceIBMCdToolchainToolSonarqubeToolchainToolPrototypePatchAsPatch(patchVals, d)
+
+		_, _, err = cdToolchainClient.UpdateToolWithContext(context, updateToolOptions)
 		if err != nil {
-			log.Printf("[DEBUG] UpdateToolWithContext failed %s\n%s", err, response)
-			return diag.FromErr(fmt.Errorf("UpdateToolWithContext failed %s\n%s", err, response))
+			tfErr := flex.TerraformErrorf(err, fmt.Sprintf("UpdateToolWithContext failed: %s", err.Error()), "ibm_cd_toolchain_tool_sonarqube", "update")
+			log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+			return tfErr.GetDiag()
 		}
 	}
 
@@ -335,23 +366,26 @@ func resourceIBMCdToolchainToolSonarqubeUpdate(context context.Context, d *schem
 func resourceIBMCdToolchainToolSonarqubeDelete(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	cdToolchainClient, err := meta.(conns.ClientSession).CdToolchainV2()
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cd_toolchain_tool_sonarqube", "delete", "initialize-client")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	deleteToolOptions := &cdtoolchainv2.DeleteToolOptions{}
 
 	parts, err := flex.SepIdParts(d.Id(), "/")
 	if err != nil {
-		return diag.FromErr(err)
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cd_toolchain_tool_sonarqube", "delete", "sep-id-parts").GetDiag()
 	}
 
 	deleteToolOptions.SetToolchainID(parts[0])
 	deleteToolOptions.SetToolID(parts[1])
 
-	response, err := cdToolchainClient.DeleteToolWithContext(context, deleteToolOptions)
+	_, err = cdToolchainClient.DeleteToolWithContext(context, deleteToolOptions)
 	if err != nil {
-		log.Printf("[DEBUG] DeleteToolWithContext failed %s\n%s", err, response)
-		return diag.FromErr(fmt.Errorf("DeleteToolWithContext failed %s\n%s", err, response))
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("DeleteToolWithContext failed: %s", err.Error()), "ibm_cd_toolchain_tool_sonarqube", "delete")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	d.SetId("")
@@ -359,13 +393,52 @@ func resourceIBMCdToolchainToolSonarqubeDelete(context context.Context, d *schem
 	return nil
 }
 
-func resourceIBMCdToolchainToolSonarqubeToolModelReferentToMap(model *cdtoolchainv2.ToolModelReferent) (map[string]interface{}, error) {
+func ResourceIBMCdToolchainToolSonarqubeToolModelReferentToMap(model *cdtoolchainv2.ToolModelReferent) (map[string]interface{}, error) {
 	modelMap := make(map[string]interface{})
 	if model.UIHref != nil {
-		modelMap["ui_href"] = model.UIHref
+		modelMap["ui_href"] = *model.UIHref
 	}
 	if model.APIHref != nil {
-		modelMap["api_href"] = model.APIHref
+		modelMap["api_href"] = *model.APIHref
 	}
 	return modelMap, nil
+}
+
+func ResourceIBMCdToolchainToolSonarqubeToolchainToolPrototypePatchAsPatch(patchVals *cdtoolchainv2.ToolchainToolPrototypePatch, d *schema.ResourceData) map[string]interface{} {
+	patch, _ := patchVals.AsPatch()
+	var path string
+
+	path = "name"
+	if _, exists := d.GetOk(path); d.HasChange(path) && !exists {
+		patch["name"] = nil
+	}
+	path = "tool_type_id"
+	if _, exists := d.GetOk(path); d.HasChange(path) && !exists {
+		patch["tool_type_id"] = nil
+	}
+	path = "parameters"
+	if _, exists := d.GetOk(path); d.HasChange(path) && !exists {
+		patch["parameters"] = nil
+	} else if exists && patch["parameters"] != nil {
+		ResourceIBMCdToolchainToolSonarqubeToolModelParametersAsPatch(patch["parameters"].(map[string]interface{}), d)
+	}
+
+	return patch
+}
+
+func ResourceIBMCdToolchainToolSonarqubeToolModelParametersAsPatch(patch map[string]interface{}, d *schema.ResourceData) {
+	var path string
+
+	path = "parameters.0.user_login"
+	if _, exists := d.GetOk(path); d.HasChange(path) && !exists {
+		patch["user_login"] = nil
+	}
+	path = "parameters.0.user_password"
+	if _, exists := d.GetOk(path); d.HasChange(path) && !exists {
+		patch["user_password"] = nil
+	}
+	path = "parameters.0.blind_connection"
+	if _, exists := d.GetOk(path); d.HasChange(path) && !exists {
+		patch["blind_connection"] = nil
+	}
 }


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/IBM-Cloud/terraform-provider-ibm/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes https://github.ibm.com/org-ids/roadmap/issues/27748

Output from acceptance testing:
```
=== RUN   TestAccIBMCdToolchainDataSourceBasic
--- PASS: TestAccIBMCdToolchainDataSourceBasic (40.93s)
=== RUN   TestAccIBMCdToolchainDataSourceAllArgs
--- PASS: TestAccIBMCdToolchainDataSourceAllArgs (48.03s)
=== RUN   TestAccIBMCdToolchainToolAppconfigDataSourceBasic
--- PASS: TestAccIBMCdToolchainToolAppconfigDataSourceBasic (50.88s)
=== RUN   TestAccIBMCdToolchainToolAppconfigDataSourceAllArgs
--- PASS: TestAccIBMCdToolchainToolAppconfigDataSourceAllArgs (51.21s)
=== RUN   TestAccIBMCdToolchainToolArtifactoryDataSourceBasic
--- PASS: TestAccIBMCdToolchainToolArtifactoryDataSourceBasic (41.49s)
=== RUN   TestAccIBMCdToolchainToolArtifactoryDataSourceAllArgs
--- PASS: TestAccIBMCdToolchainToolArtifactoryDataSourceAllArgs (37.46s)
=== RUN   TestAccIBMCdToolchainToolBitbucketgitDataSourceBasic
--- PASS: TestAccIBMCdToolchainToolBitbucketgitDataSourceBasic (36.50s)
=== RUN   TestAccIBMCdToolchainToolBitbucketgitDataSourceAllArgs
--- PASS: TestAccIBMCdToolchainToolBitbucketgitDataSourceAllArgs (35.93s)
=== RUN   TestAccIBMCdToolchainToolCustomDataSourceBasic
--- PASS: TestAccIBMCdToolchainToolCustomDataSourceBasic (36.75s)
=== RUN   TestAccIBMCdToolchainToolCustomDataSourceAllArgs
--- PASS: TestAccIBMCdToolchainToolCustomDataSourceAllArgs (36.29s)
=== RUN   TestAccIBMCdToolchainToolDevopsinsightsDataSourceBasic
--- PASS: TestAccIBMCdToolchainToolDevopsinsightsDataSourceBasic (34.05s)
=== RUN   TestAccIBMCdToolchainToolDevopsinsightsDataSourceAllArgs
--- PASS: TestAccIBMCdToolchainToolDevopsinsightsDataSourceAllArgs (35.71s)
=== RUN   TestAccIBMCdToolchainToolEventnotificationsDataSourceBasic
--- PASS: TestAccIBMCdToolchainToolEventnotificationsDataSourceBasic (47.59s)
=== RUN   TestAccIBMCdToolchainToolEventnotificationsDataSourceAllArgs
--- PASS: TestAccIBMCdToolchainToolEventnotificationsDataSourceAllArgs (48.64s)
=== RUN   TestAccIBMCdToolchainToolGithubconsolidatedDataSourceBasic
--- PASS: TestAccIBMCdToolchainToolGithubconsolidatedDataSourceBasic (35.15s)
=== RUN   TestAccIBMCdToolchainToolGithubconsolidatedDataSourceAllArgs
--- PASS: TestAccIBMCdToolchainToolGithubconsolidatedDataSourceAllArgs (37.80s)
=== RUN   TestAccIBMCdToolchainToolGitlabDataSourceBasic
--- PASS: TestAccIBMCdToolchainToolGitlabDataSourceBasic (40.16s)
=== RUN   TestAccIBMCdToolchainToolGitlabDataSourceAllArgs
--- PASS: TestAccIBMCdToolchainToolGitlabDataSourceAllArgs (36.90s)
=== RUN   TestAccIBMCdToolchainToolHashicorpvaultDataSourceBasic
--- PASS: TestAccIBMCdToolchainToolHashicorpvaultDataSourceBasic (37.74s)
=== RUN   TestAccIBMCdToolchainToolHashicorpvaultDataSourceAllArgs
--- PASS: TestAccIBMCdToolchainToolHashicorpvaultDataSourceAllArgs (37.47s)
=== RUN   TestAccIBMCdToolchainToolHostedgitDataSourceBasic
--- PASS: TestAccIBMCdToolchainToolHostedgitDataSourceBasic (38.05s)
=== RUN   TestAccIBMCdToolchainToolHostedgitDataSourceAllArgs
--- PASS: TestAccIBMCdToolchainToolHostedgitDataSourceAllArgs (38.03s)
=== RUN   TestAccIBMCdToolchainToolJenkinsDataSourceBasic
--- PASS: TestAccIBMCdToolchainToolJenkinsDataSourceBasic (34.84s)
=== RUN   TestAccIBMCdToolchainToolJenkinsDataSourceAllArgs
--- PASS: TestAccIBMCdToolchainToolJenkinsDataSourceAllArgs (34.50s)
=== RUN   TestAccIBMCdToolchainToolJiraDataSourceBasic
--- PASS: TestAccIBMCdToolchainToolJiraDataSourceBasic (34.89s)
=== RUN   TestAccIBMCdToolchainToolJiraDataSourceAllArgs
--- PASS: TestAccIBMCdToolchainToolJiraDataSourceAllArgs (34.33s)
=== RUN   TestAccIBMCdToolchainToolKeyprotectDataSourceBasic
--- PASS: TestAccIBMCdToolchainToolKeyprotectDataSourceBasic (36.66s)
=== RUN   TestAccIBMCdToolchainToolKeyprotectDataSourceAllArgs
--- PASS: TestAccIBMCdToolchainToolKeyprotectDataSourceAllArgs (35.01s)
=== RUN   TestAccIBMCdToolchainToolNexusDataSourceBasic
--- PASS: TestAccIBMCdToolchainToolNexusDataSourceBasic (36.38s)
=== RUN   TestAccIBMCdToolchainToolNexusDataSourceAllArgs
--- PASS: TestAccIBMCdToolchainToolNexusDataSourceAllArgs (35.05s)
=== RUN   TestAccIBMCdToolchainToolPagerdutyDataSourceBasic
--- PASS: TestAccIBMCdToolchainToolPagerdutyDataSourceBasic (36.41s)
=== RUN   TestAccIBMCdToolchainToolPagerdutyDataSourceAllArgs
--- PASS: TestAccIBMCdToolchainToolPagerdutyDataSourceAllArgs (34.59s)
=== RUN   TestAccIBMCdToolchainToolPipelineDataSourceBasic
--- PASS: TestAccIBMCdToolchainToolPipelineDataSourceBasic (35.95s)
=== RUN   TestAccIBMCdToolchainToolPipelineDataSourceAllArgs
--- PASS: TestAccIBMCdToolchainToolPipelineDataSourceAllArgs (37.98s)
=== RUN   TestAccIBMCdToolchainToolPrivateworkerDataSourceBasic
--- PASS: TestAccIBMCdToolchainToolPrivateworkerDataSourceBasic (34.24s)
=== RUN   TestAccIBMCdToolchainToolPrivateworkerDataSourceAllArgs
--- PASS: TestAccIBMCdToolchainToolPrivateworkerDataSourceAllArgs (33.81s)
=== RUN   TestAccIBMCdToolchainToolSaucelabsDataSourceBasic
--- PASS: TestAccIBMCdToolchainToolSaucelabsDataSourceBasic (38.05s)
=== RUN   TestAccIBMCdToolchainToolSaucelabsDataSourceAllArgs
--- PASS: TestAccIBMCdToolchainToolSaucelabsDataSourceAllArgs (36.73s)
=== RUN   TestAccIBMCdToolchainToolSecretsmanagerDataSourceBasic
--- PASS: TestAccIBMCdToolchainToolSecretsmanagerDataSourceBasic (34.54s)
=== RUN   TestAccIBMCdToolchainToolSecretsmanagerDataSourceAllArgs
--- PASS: TestAccIBMCdToolchainToolSecretsmanagerDataSourceAllArgs (36.35s)
=== RUN   TestAccIBMCdToolchainToolSecuritycomplianceDataSourceBasic
--- PASS: TestAccIBMCdToolchainToolSecuritycomplianceDataSourceBasic (32.26s)
=== RUN   TestAccIBMCdToolchainToolSecuritycomplianceDataSourceAllArgs
--- PASS: TestAccIBMCdToolchainToolSecuritycomplianceDataSourceAllArgs (32.91s)
=== RUN   TestAccIBMCdToolchainToolSlackDataSourceBasic
--- PASS: TestAccIBMCdToolchainToolSlackDataSourceBasic (39.07s)
=== RUN   TestAccIBMCdToolchainToolSlackDataSourceAllArgs
--- PASS: TestAccIBMCdToolchainToolSlackDataSourceAllArgs (34.23s)
=== RUN   TestAccIBMCdToolchainToolSonarqubeDataSourceBasic
--- PASS: TestAccIBMCdToolchainToolSonarqubeDataSourceBasic (36.05s)
=== RUN   TestAccIBMCdToolchainToolSonarqubeDataSourceAllArgs
--- PASS: TestAccIBMCdToolchainToolSonarqubeDataSourceAllArgs (34.76s)
=== RUN   TestAccIBMCdToolchainsDataSourceBasic
--- PASS: TestAccIBMCdToolchainsDataSourceBasic (31.80s)
=== RUN   TestAccIBMCdToolchainBasic
--- PASS: TestAccIBMCdToolchainBasic (54.61s)
=== RUN   TestAccIBMCdToolchainAllArgs
--- PASS: TestAccIBMCdToolchainAllArgs (56.86s)
=== RUN   TestAccIBMCdToolchainToolAppconfigBasic
--- PASS: TestAccIBMCdToolchainToolAppconfigBasic (41.73s)
=== RUN   TestAccIBMCdToolchainToolAppconfigAllArgs
--- PASS: TestAccIBMCdToolchainToolAppconfigAllArgs (86.62s)
=== RUN   TestAccIBMCdToolchainToolArtifactoryBasic
--- PASS: TestAccIBMCdToolchainToolArtifactoryBasic (33.99s)
=== RUN   TestAccIBMCdToolchainToolArtifactoryAllArgs
--- PASS: TestAccIBMCdToolchainToolArtifactoryAllArgs (61.05s)
=== RUN   TestAccIBMCdToolchainToolBitbucketgitBasic
--- PASS: TestAccIBMCdToolchainToolBitbucketgitBasic (33.09s)
=== RUN   TestAccIBMCdToolchainToolBitbucketgitAllArgs
--- PASS: TestAccIBMCdToolchainToolBitbucketgitAllArgs (65.05s)
=== RUN   TestAccIBMCdToolchainToolCustomBasic
--- PASS: TestAccIBMCdToolchainToolCustomBasic (34.30s)
=== RUN   TestAccIBMCdToolchainToolCustomAllArgs
--- PASS: TestAccIBMCdToolchainToolCustomAllArgs (61.38s)
=== RUN   TestAccIBMCdToolchainToolDevopsinsightsBasic
--- PASS: TestAccIBMCdToolchainToolDevopsinsightsBasic (33.20s)
=== RUN   TestAccIBMCdToolchainToolDevopsinsightsAllArgs
--- PASS: TestAccIBMCdToolchainToolDevopsinsightsAllArgs (59.21s)
=== RUN   TestAccIBMCdToolchainToolEventnotificationsBasic
--- PASS: TestAccIBMCdToolchainToolEventnotificationsBasic (45.89s)
=== RUN   TestAccIBMCdToolchainToolEventnotificationsAllArgs
--- PASS: TestAccIBMCdToolchainToolEventnotificationsAllArgs (97.69s)
=== RUN   TestAccIBMCdToolchainToolGithubconsolidatedBasic
--- PASS: TestAccIBMCdToolchainToolGithubconsolidatedBasic (36.01s)
=== RUN   TestAccIBMCdToolchainToolGithubconsolidatedAllArgs
--- PASS: TestAccIBMCdToolchainToolGithubconsolidatedAllArgs (62.38s)
=== RUN   TestAccIBMCdToolchainToolGitlabBasic
--- PASS: TestAccIBMCdToolchainToolGitlabBasic (34.39s)
=== RUN   TestAccIBMCdToolchainToolGitlabAllArgs
--- PASS: TestAccIBMCdToolchainToolGitlabAllArgs (61.38s)
=== RUN   TestAccIBMCdToolchainToolHashicorpvaultBasic
--- PASS: TestAccIBMCdToolchainToolHashicorpvaultBasic (32.57s)
=== RUN   TestAccIBMCdToolchainToolHashicorpvaultAllArgs
--- PASS: TestAccIBMCdToolchainToolHashicorpvaultAllArgs (61.00s)
=== RUN   TestAccIBMCdToolchainToolHostedgitBasic
--- PASS: TestAccIBMCdToolchainToolHostedgitBasic (35.25s)
=== RUN   TestAccIBMCdToolchainToolHostedgitAllArgs
--- PASS: TestAccIBMCdToolchainToolHostedgitAllArgs (64.38s)
=== RUN   TestAccIBMCdToolchainToolJenkinsBasic
--- PASS: TestAccIBMCdToolchainToolJenkinsBasic (35.80s)
=== RUN   TestAccIBMCdToolchainToolJenkinsAllArgs
--- PASS: TestAccIBMCdToolchainToolJenkinsAllArgs (61.78s)
=== RUN   TestAccIBMCdToolchainToolJiraBasic
--- PASS: TestAccIBMCdToolchainToolJiraBasic (33.80s)
=== RUN   TestAccIBMCdToolchainToolJiraAllArgs
--- PASS: TestAccIBMCdToolchainToolJiraAllArgs (62.69s)
=== RUN   TestAccIBMCdToolchainToolKeyprotectBasic
--- PASS: TestAccIBMCdToolchainToolKeyprotectBasic (32.68s)
=== RUN   TestAccIBMCdToolchainToolKeyprotectAllArgs
--- PASS: TestAccIBMCdToolchainToolKeyprotectAllArgs (63.88s)
=== RUN   TestAccIBMCdToolchainToolNexusBasic
--- PASS: TestAccIBMCdToolchainToolNexusBasic (34.88s)
=== RUN   TestAccIBMCdToolchainToolNexusAllArgs
--- PASS: TestAccIBMCdToolchainToolNexusAllArgs (59.10s)
=== RUN   TestAccIBMCdToolchainToolPagerdutyBasic
--- PASS: TestAccIBMCdToolchainToolPagerdutyBasic (32.91s)
=== RUN   TestAccIBMCdToolchainToolPagerdutyAllArgs
--- PASS: TestAccIBMCdToolchainToolPagerdutyAllArgs (61.50s)
=== RUN   TestAccIBMCdToolchainToolPipelineBasic
--- PASS: TestAccIBMCdToolchainToolPipelineBasic (33.94s)
=== RUN   TestAccIBMCdToolchainToolPipelineAllArgs
--- PASS: TestAccIBMCdToolchainToolPipelineAllArgs (60.28s)
=== RUN   TestAccIBMCdToolchainToolPrivateworkerBasic
--- PASS: TestAccIBMCdToolchainToolPrivateworkerBasic (37.61s)
=== RUN   TestAccIBMCdToolchainToolPrivateworkerAllArgs
--- PASS: TestAccIBMCdToolchainToolPrivateworkerAllArgs (64.13s)
=== RUN   TestAccIBMCdToolchainToolSaucelabsBasic
--- PASS: TestAccIBMCdToolchainToolSaucelabsBasic (36.67s)
=== RUN   TestAccIBMCdToolchainToolSaucelabsAllArgs
--- PASS: TestAccIBMCdToolchainToolSaucelabsAllArgs (65.39s)
=== RUN   TestAccIBMCdToolchainToolSecretsmanagerBasic
--- PASS: TestAccIBMCdToolchainToolSecretsmanagerBasic (36.05s)
=== RUN   TestAccIBMCdToolchainToolSecretsmanagerAllArgs
--- PASS: TestAccIBMCdToolchainToolSecretsmanagerAllArgs (65.04s)
=== RUN   TestAccIBMCdToolchainToolSecuritycomplianceBasic
--- PASS: TestAccIBMCdToolchainToolSecuritycomplianceBasic (35.97s)
=== RUN   TestAccIBMCdToolchainToolSecuritycomplianceAllArgs
--- PASS: TestAccIBMCdToolchainToolSecuritycomplianceAllArgs (60.50s)
=== RUN   TestAccIBMCdToolchainToolSlackBasic
--- PASS: TestAccIBMCdToolchainToolSlackBasic (34.12s)
=== RUN   TestAccIBMCdToolchainToolSlackAllArgs
--- PASS: TestAccIBMCdToolchainToolSlackAllArgs (68.49s)
=== RUN   TestAccIBMCdToolchainToolSonarqubeBasic
--- PASS: TestAccIBMCdToolchainToolSonarqubeBasic (33.40s)
=== RUN   TestAccIBMCdToolchainToolSonarqubeAllArgs
--- PASS: TestAccIBMCdToolchainToolSonarqubeAllArgs (63.14s)
PASS
ok      github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/cdtoolchain     4611.998s
```
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TEST=./ibm/service/cdtoolchain TESTARGS='-run=TestAccIBMCdToolchain*'

...
```
