### PR TITLE
404 error fix on ibm_is_virtual_network_interface_floating_ip datasource

### DIFF
--- a/ibm/acctest/acctest.go
+++ b/ibm/acctest/acctest.go
@@ -112,6 +112,7 @@ var (
 	SourceShareCRN                  string
 	ShareEncryptionKey              string
 	VNIId                           string
+	FloatingIpID                    string
 	VolumeProfileName               string
 	VSIUnattachedBootVolumeID       string
 	VSIDataVolumeID                 string
@@ -990,6 +991,11 @@ func init() {
 	if VNIId == "" {
 		VNIId = "c93dc4c6-e85a-4da2-9ea6-f24576256122"
 		fmt.Println("[INFO] Set the environment variable IS_VIRTUAL_NETWORK_INTERFACE for testing ibm_is_virtual_network_interface else it is set to default value 'c93dc4c6-e85a-4da2-9ea6-f24576256122'")
+	}
+	FloatingIpID = os.Getenv("IS_FLOATING_IP")
+	if FloatingIpID == "" {
+		FloatingIpID = "r006-9fc3948f-1b01-406c-baa5-e86b185e559f"
+		fmt.Println("[INFO] Set the environment variable IS_FLOATING_IP for testing ibm_is_virtual_network_interface else it is set to default value 'r006-9fc3948f-1b01-406c-baa5-e86b185e559f'")
 	}
 
 	VSIUnattachedBootVolumeID = os.Getenv("IS_VSI_UNATTACHED_BOOT_VOLUME_ID")

--- a/ibm/service/vpc/data_source_ibm_is_virtual_network_interface_floating_ip.go
+++ b/ibm/service/vpc/data_source_ibm_is_virtual_network_interface_floating_ip.go
@@ -82,10 +82,6 @@ func dataSourceIBMIsVirtualNetworkInterfaceFloatingIPRead(context context.Contex
 
 	floatingIP, response, err := sess.GetNetworkInterfaceFloatingIPWithContext(context, getNetworkInterfaceFloatingIPOptions)
 	if err != nil {
-		if response != nil && response.StatusCode == 404 {
-			d.SetId("")
-			return nil
-		}
 		log.Printf("[DEBUG] GetVirtualNetworkInterfaceFloatingIPWithContext failed %s\n%s", err, response)
 		return diag.FromErr(fmt.Errorf("GetVirtualNetworkInterfaceFloatingIPWithContext failed %s\n%s", err, response))
 	}

--- a/ibm/service/vpc/data_source_ibm_is_virtual_network_interface_floating_ip_test.go
+++ b/ibm/service/vpc/data_source_ibm_is_virtual_network_interface_floating_ip_test.go
@@ -5,6 +5,7 @@ package vpc_test
 
 import (
 	"fmt"
+	"regexp"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
@@ -37,6 +38,22 @@ func TestAccIBMIsVirtualNetworkInterfaceFloatingIPDataSourceBasic(t *testing.T) 
 		},
 	})
 }
+func TestAccIBMIsVirtualNetworkInterfaceFloatingIPDataSource404(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { acc.TestAccPreCheck(t) },
+		Providers: acc.TestAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccCheckIBMIsVirtualNetworkInterfaceFloatingIPDataSourceConfigVNI404(),
+				ExpectError: regexp.MustCompile("GetVirtualNetworkInterfaceFloatingIPWithContext failed"),
+			},
+			{
+				Config:      testAccCheckIBMIsVirtualNetworkInterfaceFloatingIPDataSourceConfigFIP404(),
+				ExpectError: regexp.MustCompile("GetVirtualNetworkInterfaceFloatingIPWithContext failed"),
+			},
+		},
+	})
+}
 
 func testAccCheckIBMIsVirtualNetworkInterfaceFloatingIPDataSourceConfigBasic(vpcname, subnetname, vniname, floatingipname string) string {
 	return testAccCheckIBMIsVirtualNetworkInterfaceFloatingIPConfigBasic(vpcname, subnetname, vniname, floatingipname) + fmt.Sprintf(`
@@ -45,4 +62,20 @@ func testAccCheckIBMIsVirtualNetworkInterfaceFloatingIPDataSourceConfigBasic(vpc
 			floating_ip = ibm_is_virtual_network_interface_floating_ip.testacc_vni_floatingip.floating_ip
 		}
 	`)
+}
+func testAccCheckIBMIsVirtualNetworkInterfaceFloatingIPDataSourceConfigVNI404() string {
+	return fmt.Sprintf(`
+		data "ibm_is_virtual_network_interface_floating_ip" "is_floating_ip" {
+			virtual_network_interface = "%s"
+			floating_ip = "%s"
+		}
+	`, acc.VNIId, acc.VNIId)
+}
+func testAccCheckIBMIsVirtualNetworkInterfaceFloatingIPDataSourceConfigFIP404() string {
+	return fmt.Sprintf(`
+		data "ibm_is_virtual_network_interface_floating_ip" "is_floating_ip" {
+			virtual_network_interface = "%s"
+			floating_ip = "%s"
+		}
+	`, acc.FloatingIpID, acc.FloatingIpID)
 }


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/IBM-Cloud/terraform-provider-ibm/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #5757

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
% make testacc TEST=./ibm/service/vpc TESTARGS='-run=TestAccIBMIsVirtualNetworkInterfaceFloatingIPDataSource404'
=== RUN   TestAccIBMIsVirtualNetworkInterfaceFloatingIPDataSource404
--- PASS: TestAccIBMIsVirtualNetworkInterfaceFloatingIPDataSource404 (11.68s)
PASS
ok      github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/vpc     13.576s
```
