### PR TITLE
fix(ibm_is_image): 404 error fix on datasource

### DIFF
--- a/ibm/service/vpc/data_source_ibm_is_image.go
+++ b/ibm/service/vpc/data_source_ibm_is_image.go
@@ -386,10 +386,7 @@ func imageGetById(d *schema.ResourceData, meta interface{}, identifier string) e
 
 	image, response, err := sess.GetImage(getImageOptions)
 	if err != nil {
-		if response.StatusCode == 404 {
-			return fmt.Errorf("[ERROR] No image found with id  %s", identifier)
-		}
-		return fmt.Errorf("[ERROR] Error Fetching Images %s\n%s", err, response)
+		return fmt.Errorf("[ERROR] Error fetching image with id(%s) %s\n%s", identifier, err, response)
 	}
 
 	d.SetId(*image.ID)

--- a/ibm/service/vpc/data_source_ibm_is_image_test.go
+++ b/ibm/service/vpc/data_source_ibm_is_image_test.go
@@ -5,6 +5,7 @@ package vpc_test
 
 import (
 	"fmt"
+	"regexp"
 	"testing"
 
 	acc "github.com/IBM-Cloud/terraform-provider-ibm/ibm/acctest"
@@ -30,6 +31,20 @@ func TestAccIBMISImageDataSource_basic(t *testing.T) {
 					resource.TestCheckResourceAttrSet(resName, "visibility"),
 					resource.TestCheckResourceAttrSet(resName, "status"),
 				),
+			},
+		},
+	})
+}
+func TestAccIBMISImageDataSource_id404(t *testing.T) {
+	imageId := "8843-5fr454ft-f6-4565-9555-5f889f5f3f7777"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { acc.TestAccPreCheck(t) },
+		Providers: acc.TestAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccCheckIBMISImageDataSource404Config(imageId),
+				ExpectError: regexp.MustCompile("Error fetching image with id"),
 			},
 		},
 	})
@@ -169,6 +184,13 @@ func testAccCheckIBMISImageDataSourceConfig(imageName string) string {
 	data "ibm_is_image" "test1" {
 		name = ibm_is_image.isExampleImage.name
 	}`, acc.Image_cos_url, imageName, acc.Image_operating_system)
+}
+
+func testAccCheckIBMISImageDataSource404Config(imageId string) string {
+	return fmt.Sprintf(`
+	data "ibm_is_image" "test1" {
+		identifier = "%s"
+	}`, imageId)
 }
 
 func testAccCheckIBMISImageDataSourceAllConfig(imageName string) string {


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/IBM-Cloud/terraform-provider-ibm/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
% make testacc TEST=./ibm/service/vpc TESTARGS='-run=TestAccIBMISImageDataSource_id404'
=== RUN   TestAccIBMISImageDataSource_id404
--- PASS: TestAccIBMISImageDataSource_id404 (2.92s)
PASS
ok      github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/vpc     4.615s
```
