### PR TITLE
fix(ibm_is_share): 404 error fix on datasource

### DIFF
--- a/ibm/service/vpc/data_source_ibm_is_share.go
+++ b/ibm/service/vpc/data_source_ibm_is_share.go
@@ -552,15 +552,8 @@ func dataSourceIbmIsShareRead(context context.Context, d *schema.ResourceData, m
 
 		shareItem, response, err := vpcClient.GetShareWithContext(context, getShareOptions)
 		if err != nil {
-			if response != nil {
-				if response.StatusCode == 404 {
-					d.SetId("")
-				}
-				log.Printf("[DEBUG] GetShareWithContext failed %s\n%s", err, response)
-				return nil
-			}
-			log.Printf("[DEBUG] GetShareWithContext failed %s\n", err)
-			return diag.FromErr(err)
+			log.Printf("[DEBUG] GetShareWithContext failed %s\n%s", err, response)
+			return diag.FromErr(fmt.Errorf("[ERROR] GetShareWithContext failed %s\n%s", err, response))
 		}
 		share = shareItem
 	} else if shareName != "" {

--- a/ibm/service/vpc/data_source_ibm_is_share_test.go
+++ b/ibm/service/vpc/data_source_ibm_is_share_test.go
@@ -5,6 +5,7 @@ package vpc_test
 
 import (
 	"fmt"
+	"regexp"
 	"testing"
 
 	acc "github.com/IBM-Cloud/terraform-provider-ibm/ibm/acctest"
@@ -35,6 +36,19 @@ func TestAccIbmIsShareDataSourceBasic(t *testing.T) {
 					resource.TestCheckResourceAttrSet("data.ibm_is_share.is_share", "size"),
 					resource.TestCheckResourceAttrSet("data.ibm_is_share.is_share", "zone"),
 				),
+			},
+		},
+	})
+}
+func TestAccIbmIsShareDataSource404(t *testing.T) {
+	shareId := "8843-5fr454ft-f6-4565-9555-5f889f5f3f7777"
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { acc.TestAccPreCheck(t) },
+		Providers: acc.TestAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccCheckIbmIsShareDataSourceConfig404(shareId),
+				ExpectError: regexp.MustCompile("GetShareWithContext failed"),
 			},
 		},
 	})
@@ -92,6 +106,13 @@ func testAccCheckIbmIsShareDataSourceConfigBasic(name string) string {
 			share = ibm_is_share.is_share.id
 		}
 	`, name, acc.ShareProfileName)
+}
+func testAccCheckIbmIsShareDataSourceConfig404(id string) string {
+	return fmt.Sprintf(`
+		data "ibm_is_share" "is_share" {
+			share = "%s"
+		}
+	`, id)
 }
 
 func testAccCheckIbmIsShareDataSourceConfig(vpcName, shareName string, shareSize int, shareTargetName string) string {

--- a/ibm/service/vpc/data_source_ibm_is_source_share.go
+++ b/ibm/service/vpc/data_source_ibm_is_source_share.go
@@ -62,15 +62,8 @@ func dataSourceIbmIsSourceShareRead(context context.Context, d *schema.ResourceD
 
 	share, response, err := vpcClient.GetShareSourceWithContext(context, getShareSourceOptions)
 	if err != nil {
-		if response != nil {
-			if response.StatusCode == 404 {
-				d.SetId("")
-			}
-			log.Printf("[DEBUG] GetShareWithContext failed %s\n%s", err, response)
-			return nil
-		}
-		log.Printf("[DEBUG] GetShareWithContext failed %s\n", err)
-		return diag.FromErr(fmt.Errorf("[DEBUG] GetShareWithContext failed %s\n", err))
+		log.Printf("[DEBUG] GetShareSourceWithContext failed %s\n%s", err, response)
+		return diag.FromErr(fmt.Errorf("[ERROR] GetShareSourceWithContext failed %s\n%s", err, response))
 	}
 
 	d.SetId(*share.ID)

--- a/ibm/service/vpc/data_source_ibm_is_source_share_test.go
+++ b/ibm/service/vpc/data_source_ibm_is_source_share_test.go
@@ -5,6 +5,7 @@ package vpc_test
 
 import (
 	"fmt"
+	"regexp"
 	"testing"
 
 	acc "github.com/IBM-Cloud/terraform-provider-ibm/ibm/acctest"
@@ -53,4 +54,26 @@ func testAccCheckIbmIsSourceShareDataSourceConfigBasic(vpcname, vpcname1, shareN
 			share_replica = ibm_is_share.replica.id
 		}
 	`)
+}
+func TestAccIbmIsSourceShareDataSource404(t *testing.T) {
+	srId := "8843-5fr454ft-f6-4565-9555-5f889f5f3f7777"
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { acc.TestAccPreCheck(t) },
+		Providers: acc.TestAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccCheckIbmIsSourceShareDataSourceConfig404(srId),
+				ExpectError: regexp.MustCompile("GetShareSourceWithContext failed"),
+			},
+		},
+	})
+}
+
+func testAccCheckIbmIsSourceShareDataSourceConfig404(srId string) string {
+	return fmt.Sprintf(`
+		
+		data "ibm_is_source_share" "test" {
+			share_replica = "%s"
+		}
+	`, srId)
 }


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/IBM-Cloud/terraform-provider-ibm/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
 % make testacc TEST=./ibm/service/vpc TESTARGS='-run=TestAccIbmIsShareDataSource404'
=== RUN   TestAccIbmIsShareDataSource404
--- PASS: TestAccIbmIsShareDataSource404 (2.70s)
PASS
ok      github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/vpc     4.360s
```
```
% make testacc TEST=./ibm/service/vpc TESTARGS='-run=TestAccIbmIsSourceShareDataSource404'
=== RUN   TestAccIbmIsSourceShareDataSource404
--- PASS: TestAccIbmIsSourceShareDataSource404 (3.36s)
PASS
ok      github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/vpc     5.387s
```