### PR TITLE
fix(ibm_is_snapshot): 404 error fix on datasource

### DIFF
--- a/ibm/service/vpc/data_source_ibm_is_snapshot.go
+++ b/ibm/service/vpc/data_source_ibm_is_snapshot.go
@@ -614,10 +614,7 @@ func snapshotGetByNameOrID(d *schema.ResourceData, meta interface{}, name, id st
 		}
 		snapshot, response, err := sess.GetSnapshot(getSnapshotOptions)
 		if err != nil {
-			return fmt.Errorf("[ERROR] Error fetching snapshot %s\n%s", err, response)
-		}
-		if (response != nil && response.StatusCode == 404) || snapshot == nil {
-			return fmt.Errorf("[ERROR] No snapshot found with id %s", id)
+			return fmt.Errorf("[ERROR] Error fetching snapshot with id(%s) %s\n%s", id, err, response)
 		}
 		d.SetId(*snapshot.ID)
 		d.Set(isSnapshotName, *snapshot.Name)

--- a/ibm/service/vpc/data_source_ibm_is_snapshot_test.go
+++ b/ibm/service/vpc/data_source_ibm_is_snapshot_test.go
@@ -5,6 +5,7 @@ package vpc_test
 
 import (
 	"fmt"
+	"regexp"
 	"strings"
 	"testing"
 
@@ -43,6 +44,21 @@ ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCKVmnMOlHKcZK8tpt3MP1lqOLAcqcJzhsvJcjscgVE
 					resource.TestCheckResourceAttrSet(snpName, "encryption"),
 					// resource.TestCheckResourceAttrSet(snpName, "captured_at"), // Commented as the attribute is optional.
 				),
+			},
+		},
+	})
+}
+func TestAccIBMISSnapshotDatasource_404(t *testing.T) {
+	snpId := "8843-5fr454ft-f6-4565-9555-5f889f5f3f7777"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { acc.TestAccPreCheck(t) },
+		Providers:    acc.TestAccProviders,
+		CheckDestroy: testAccCheckIBMISSnapshotDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config:      testDSCheckIBMISSnapshotConfig404(snpId),
+				ExpectError: regexp.MustCompile("Error fetching snapshot with id"),
 			},
 		},
 	})
@@ -240,6 +256,13 @@ func testDSCheckIBMISSnapshotConfig(vpcname, subnetname, sshname, publicKey, vol
 		name 		= "%s"
 	}
 `, vpcname, subnetname, acc.ISZoneName, sshname, publicKey, name, acc.IsImage, acc.InstanceProfileName, acc.ISZoneName, sname, sname)
+}
+func testDSCheckIBMISSnapshotConfig404(sid string) string {
+	return fmt.Sprintf(`
+	data "ibm_is_snapshot" "ds_snapshot" {
+		identifier 		= "%s"
+	}
+`, sid)
 }
 func testDSCheckIBMISSnapshotClonesBasicConfig(vpcname, subnetname, sshname, publicKey, volname, name, sname string) string {
 	return fmt.Sprintf(`


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/IBM-Cloud/terraform-provider-ibm/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
% make testacc TEST=./ibm/service/vpc TESTARGS='-run=TestAccIBMISSnapshotDatasource_404'
=== RUN   TestAccIBMISSnapshotDatasource_404
--- PASS: TestAccIBMISSnapshotDatasource_404 (3.42s)
PASS
ok      github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/vpc     5.395s
```
