### PR TITLE
Add SDSaaS to terraform provider

### DIFF
--- a/examples/ibm-sdsaas/README.md
+++ b/examples/ibm-sdsaas/README.md
@@ -1,0 +1,97 @@
+# Examples for sdsaas
+
+These examples illustrate how to use the resources and data sources associated with sdsaas.
+
+The following resources are supported:
+* ibm_sds_volume
+* ibm_sds_host
+
+## Usage
+
+To run this example, execute the following commands:
+
+```bash
+$ terraform init
+$ terraform plan
+$ terraform apply
+```
+
+Run `terraform destroy` when you don't need these resources.
+
+## sdsaas resources
+
+### Resource: ibm_sds_volume
+
+```hcl
+resource "ibm_sds_volume" "sds_volume_instance" {
+  hostnqnstring = var.sds_volume_hostnqnstring
+  capacity = var.sds_volume_capacity
+  name = var.sds_volume_name
+}
+```
+
+#### Inputs
+
+| Name | Description | Type | Required |
+|------|-------------|------|---------|
+| ibmcloud\_api\_key | IBM Cloud API key | `string` | true |
+| hostnqnstring | The host nqn. | `string` | false |
+| capacity | The capacity of the volume (in gigabytes). | `number` | true |
+| name | The name of the volume. | `string` | false |
+
+#### Outputs
+
+| Name | Description |
+|------|-------------|
+| host_mappings | List of host details that volume is mapped to. |
+| created_at | The date and time that the volume was created. |
+| resource_type | The resource type of the volume. |
+| status | The current status of the volume. |
+| status_reasons | Reasons for the current status of the volume. |
+
+### Resource: ibm_sds_host
+
+```hcl
+resource "ibm_sds_host" "sds_host_instance" {
+  name = var.sds_host_name
+  nqn = var.sds_host_nqn
+  volume_mappings = var.sds_host_volume_mappings
+}
+```
+
+#### Inputs
+
+| Name | Description | Type | Required |
+|------|-------------|------|---------|
+| ibmcloud\_api\_key | IBM Cloud API key | `string` | true |
+| name | The name for this host. The name must not be used by another host.  If unspecified, the name will be a hyphenated list of randomly-selected words. | `string` | false |
+| nqn | The NQN of the host configured in customer's environment. | `string` | true |
+| volume_mappings | The host-to-volume map. | `list()` | false |
+
+#### Outputs
+
+| Name | Description |
+|------|-------------|
+| created_at | The date and time that the host was created. |
+| service_instance_id | The service instance ID this host should be created in. |
+
+
+## Assumptions
+
+1. TODO
+
+## Notes
+
+1. TODO
+
+## Requirements
+
+| Name | Version |
+|------|---------|
+| terraform | ~> 0.12 |
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| ibm | 1.13.1 |

--- a/examples/ibm-sdsaas/README.md
+++ b/examples/ibm-sdsaas/README.md
@@ -43,8 +43,10 @@ resource "ibm_sds_volume" "sds_volume_instance" {
 
 | Name | Description |
 |------|-------------|
-| host_mappings | List of host details that volume is mapped to. |
+| bandwidth | The maximum bandwidth (in megabits per second) for the volume. |
 | created_at | The date and time that the volume was created. |
+| hosts | List of host details that volume is mapped to. |
+| iops | Iops The maximum I/O operations per second (IOPS) for this volume. |
 | resource_type | The resource type of the volume. |
 | status | The current status of the volume. |
 | status_reasons | Reasons for the current status of the volume. |
@@ -55,7 +57,7 @@ resource "ibm_sds_volume" "sds_volume_instance" {
 resource "ibm_sds_host" "sds_host_instance" {
   name = var.sds_host_name
   nqn = var.sds_host_nqn
-  volume_mappings = var.sds_host_volume_mappings
+  volumes = var.sds_host_volumes
 }
 ```
 
@@ -66,19 +68,22 @@ resource "ibm_sds_host" "sds_host_instance" {
 | ibmcloud\_api\_key | IBM Cloud API key | `string` | true |
 | name | The name for this host. The name must not be used by another host.  If unspecified, the name will be a hyphenated list of randomly-selected words. | `string` | false |
 | nqn | The NQN of the host configured in customer's environment. | `string` | true |
-| volume_mappings | The host-to-volume map. | `list()` | false |
+| volumes | The host-to-volume map. | `list()` | false |
 
 #### Outputs
 
 | Name | Description |
 |------|-------------|
 | created_at | The date and time that the host was created. |
-| service_instance_id | The service instance ID this host should be created in. |
 
 
 ## Assumptions
 
-The `IBMCLOUD_SDS_ENDPOINT` is required to be set by the user before running the terraform commands. This is the endpoint provided to customers to perform operations against their service.
+1. TODO
+
+## Notes
+
+1. TODO
 
 ## Requirements
 

--- a/examples/ibm-sdsaas/README.md
+++ b/examples/ibm-sdsaas/README.md
@@ -79,11 +79,7 @@ resource "ibm_sds_host" "sds_host_instance" {
 
 ## Assumptions
 
-1. TODO
-
-## Notes
-
-1. TODO
+The `IBMCLOUD_SDS_ENDPOINT` is required to be set by the user before running the terraform commands. This is the endpoint provided to customers to perform operations against their service.
 
 ## Requirements
 

--- a/examples/ibm-sdsaas/README.md
+++ b/examples/ibm-sdsaas/README.md
@@ -24,6 +24,7 @@ Run `terraform destroy` when you don't need these resources.
 
 ```hcl
 resource "ibm_sds_volume" "sds_volume_instance" {
+  sds_endpoint = var.sds_endpoint
   hostnqnstring = var.sds_volume_hostnqnstring
   capacity = var.sds_volume_capacity
   name = var.sds_volume_name
@@ -35,6 +36,7 @@ resource "ibm_sds_volume" "sds_volume_instance" {
 | Name | Description | Type | Required |
 |------|-------------|------|---------|
 | ibmcloud\_api\_key | IBM Cloud API key | `string` | true |
+| sds_endpoint | IBM Cloud Endpoint | `string` | false |
 | hostnqnstring | The host nqn. | `string` | false |
 | capacity | The capacity of the volume (in gigabytes). | `number` | true |
 | name | The name of the volume. | `string` | false |
@@ -55,6 +57,7 @@ resource "ibm_sds_volume" "sds_volume_instance" {
 
 ```hcl
 resource "ibm_sds_host" "sds_host_instance" {
+  sds_endpoint = var.sds_endpoint
   name = var.sds_host_name
   nqn = var.sds_host_nqn
   volumes = var.sds_host_volumes
@@ -66,6 +69,7 @@ resource "ibm_sds_host" "sds_host_instance" {
 | Name | Description | Type | Required |
 |------|-------------|------|---------|
 | ibmcloud\_api\_key | IBM Cloud API key | `string` | true |
+| sds_endpoint | IBM Cloud Endpoint | `string` | false |
 | name | The name for this host. The name must not be used by another host.  If unspecified, the name will be a hyphenated list of randomly-selected words. | `string` | false |
 | nqn | The NQN of the host configured in customer's environment. | `string` | true |
 | volumes | The host-to-volume map. | `list()` | false |
@@ -79,7 +83,7 @@ resource "ibm_sds_host" "sds_host_instance" {
 
 ## Assumptions
 
-The `IBMCLOUD_SDS_ENDPOINT` is required to be set by the user before running the terraform commands. This is the endpoint provided to customers to perform operations against their service.
+The `IBMCLOUD_SDS_ENDPOINT` can optionally be set instead of setting `sds_endpoint` in each of the resources. This is the endpoint provided to customers to perform operations against their service.
 
 ## Requirements
 

--- a/examples/ibm-sdsaas/README.md
+++ b/examples/ibm-sdsaas/README.md
@@ -78,11 +78,7 @@ resource "ibm_sds_host" "sds_host_instance" {
 
 ## Assumptions
 
-1. TODO
-
-## Notes
-
-1. TODO
+The `IBMCLOUD_SDS_ENDPOINT` is required to be set by the user before running the terraform commands. This is the endpoint provided to customers to perform operations against their service.
 
 ## Requirements
 

--- a/examples/ibm-sdsaas/main.tf
+++ b/examples/ibm-sdsaas/main.tf
@@ -21,11 +21,11 @@ resource "ibm_sds_host" "sds_host_instance" {
 
   name = var.sds_host_name
   nqn = var.sds_host_nqn
-  volume_mappings {
+  volumes {
     volume_id = ibm_sds_volume.sds_volume_instance_1.id
     volume_name = ibm_sds_volume.sds_volume_instance_1.name
   }
-  volume_mappings {
+  volumes {
     volume_id = ibm_sds_volume.sds_volume_instance_2.id
     volume_name = ibm_sds_volume.sds_volume_instance_2.name
   }

--- a/examples/ibm-sdsaas/main.tf
+++ b/examples/ibm-sdsaas/main.tf
@@ -1,0 +1,32 @@
+provider "ibm" {
+  ibmcloud_api_key = var.ibmcloud_api_key
+}
+
+// Provision sds_volume resource instance
+resource "ibm_sds_volume" "sds_volume_instance_1" {
+  hostnqnstring = var.sds_volume_hostnqnstring
+  capacity = var.sds_volume_capacity
+  name = var.sds_volume_name_1
+}
+
+// Provision sds_volume resource instance
+resource "ibm_sds_volume" "sds_volume_instance_2" {
+  hostnqnstring = var.sds_volume_hostnqnstring
+  capacity = var.sds_volume_capacity
+  name = var.sds_volume_name_2
+}
+
+// Provision sds_host resource instance
+resource "ibm_sds_host" "sds_host_instance" {
+
+  name = var.sds_host_name
+  nqn = var.sds_host_nqn
+  volume_mappings {
+    volume_id = ibm_sds_volume.sds_volume_instance_1.id
+    volume_name = ibm_sds_volume.sds_volume_instance_1.name
+  }
+  volume_mappings {
+    volume_id = ibm_sds_volume.sds_volume_instance_2.id
+    volume_name = ibm_sds_volume.sds_volume_instance_2.name
+  }
+}

--- a/examples/ibm-sdsaas/main.tf
+++ b/examples/ibm-sdsaas/main.tf
@@ -4,6 +4,8 @@ provider "ibm" {
 
 // Provision sds_volume resource instance
 resource "ibm_sds_volume" "sds_volume_instance_1" {
+  sds_endpoint = var.sds_endpoint
+
   hostnqnstring = var.sds_volume_hostnqnstring
   capacity = var.sds_volume_capacity
   name = var.sds_volume_name_1
@@ -11,6 +13,8 @@ resource "ibm_sds_volume" "sds_volume_instance_1" {
 
 // Provision sds_volume resource instance
 resource "ibm_sds_volume" "sds_volume_instance_2" {
+  sds_endpoint = var.sds_endpoint
+
   hostnqnstring = var.sds_volume_hostnqnstring
   capacity = var.sds_volume_capacity
   name = var.sds_volume_name_2
@@ -18,6 +22,7 @@ resource "ibm_sds_volume" "sds_volume_instance_2" {
 
 // Provision sds_host resource instance
 resource "ibm_sds_host" "sds_host_instance" {
+  sds_endpoint = var.sds_endpoint
 
   name = var.sds_host_name
   nqn = var.sds_host_nqn

--- a/examples/ibm-sdsaas/outputs.tf
+++ b/examples/ibm-sdsaas/outputs.tf
@@ -1,0 +1,12 @@
+// This output allows sds_volume data to be referenced by other resources and the terraform CLI
+// Modify this output if only certain data should be exposed
+output "ibm_sds_volume" {
+  value       = [ibm_sds_volume.sds_volume_instance_1, ibm_sds_volume.sds_volume_instance_2]
+  description = "sds_volume resource instance"
+}
+// This output allows sds_host data to be referenced by other resources and the terraform CLI
+// Modify this output if only certain data should be exposed
+output "ibm_sds_host" {
+  value       = ibm_sds_host.sds_host_instance
+  description = "sds_host resource instance"
+}

--- a/examples/ibm-sdsaas/variables.tf
+++ b/examples/ibm-sdsaas/variables.tf
@@ -3,6 +3,12 @@ variable "ibmcloud_api_key" {
   type        = string
 }
 
+variable "sds_endpoint" {
+  description = "IBM SDS Endpoint"
+  type        = string
+  default     = "<endpoint>"
+}
+
 variable "sds_volume_hostnqnstring" {
   description = "The host nqn."
   type        = string

--- a/examples/ibm-sdsaas/variables.tf
+++ b/examples/ibm-sdsaas/variables.tf
@@ -1,0 +1,37 @@
+variable "ibmcloud_api_key" {
+  description = "IBM Cloud API key"
+  type        = string
+}
+
+variable "sds_volume_hostnqnstring" {
+  description = "The host nqn."
+  type        = string
+  default     = "nqn.2014-06.org:9345"
+}
+variable "sds_volume_capacity" {
+  description = "The capacity of the volume (in gigabytes)."
+  type        = number
+  default     = 10
+}
+variable "sds_volume_name_1" {
+  description = "The name of the volume."
+  type        = string
+  default     = "demo-volume-1"
+}
+
+variable "sds_volume_name_2" {
+  description = "The name of the volume."
+  type        = string
+  default     = "demo-volume-2"
+}
+
+variable "sds_host_name" {
+  description = "The name for this host. The name must not be used by another host.  If unspecified, the name will be a hyphenated list of randomly-selected words."
+  type        = string
+  default     = "demo-host"
+}
+variable "sds_host_nqn" {
+  description = "The NQN of the host configured in customer's environment."
+  type        = string
+  default     = "nqn.2014-06.org:9345"
+}

--- a/examples/ibm-sdsaas/versions.tf
+++ b/examples/ibm-sdsaas/versions.tf
@@ -1,0 +1,9 @@
+terraform {
+  required_version = ">= 1.0"
+  required_providers {
+    ibm = {
+      source = "IBM-Cloud/ibm"
+      version = "1.71.0-beta1"
+    }
+  }
+}

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/IBM-Cloud/terraform-provider-ibm
 
-go 1.23.0
+go 1.22.5
 
 toolchain go1.23.2
 
@@ -29,7 +29,7 @@ require (
 	github.com/IBM/ibm-hpcs-tke-sdk v0.0.0-20211109141421-a4b61b05f7d1
 	github.com/IBM/ibm-hpcs-uko-sdk v0.0.20-beta
 	github.com/IBM/keyprotect-go-client v0.15.1
-	github.com/IBM/logs-go-sdk v0.3.0
+	github.com/IBM/logs-go-sdk v0.4.0
 	github.com/IBM/logs-router-go-sdk v1.0.5
 	github.com/IBM/mqcloud-go-sdk v0.2.0
 	github.com/IBM/networking-go-sdk v0.49.0
@@ -39,7 +39,7 @@ require (
 	github.com/IBM/sarama v1.41.2
 	github.com/IBM/scc-go-sdk/v5 v5.4.1
 	github.com/IBM/schematics-go-sdk v0.3.0
-	github.com/IBM/sds-go-sdk v0.0.3
+	github.com/IBM/sds-go-sdk v0.0.4
 	github.com/IBM/secrets-manager-go-sdk/v2 v2.0.7
 	github.com/IBM/vmware-go-sdk v0.1.2
 	github.com/IBM/vpc-beta-go-sdk v0.8.0
@@ -205,6 +205,7 @@ require (
 	go.opentelemetry.io/otel v1.28.0 // indirect
 	go.opentelemetry.io/otel/metric v1.28.0 // indirect
 	go.opentelemetry.io/otel/trace v1.28.0 // indirect
+	go.uber.org/atomic v1.9.0 // indirect
 	go.uber.org/ratelimit v0.2.0 // indirect
 	go.uber.org/zap v1.27.0 // indirect
 	golang.org/x/mod v0.21.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -39,6 +39,7 @@ require (
 	github.com/IBM/sarama v1.41.2
 	github.com/IBM/scc-go-sdk/v5 v5.4.1
 	github.com/IBM/schematics-go-sdk v0.3.0
+	github.com/IBM/sds-go-sdk v0.0.0
 	github.com/IBM/secrets-manager-go-sdk/v2 v2.0.7
 	github.com/IBM/vmware-go-sdk v0.1.2
 	github.com/IBM/vpc-beta-go-sdk v0.8.0
@@ -100,10 +101,11 @@ require (
 	github.com/emicklei/go-restful/v3 v3.12.1 // indirect
 	github.com/evanphx/json-patch/v5 v5.9.0 // indirect
 	github.com/fatih/color v1.16.0 // indirect
-	github.com/fxamacker/cbor/v2 v2.7.0 // indirect
-	github.com/gabriel-vasile/mimetype v1.4.5 // indirect
-	github.com/go-jose/go-jose/v4 v4.0.1 // indirect
-	github.com/go-logr/logr v1.4.2 // indirect
+	github.com/frankban/quicktest v1.14.3 // indirect
+	github.com/fsnotify/fsnotify v1.7.0 // indirect
+	github.com/gabriel-vasile/mimetype v1.4.6 // indirect
+	github.com/go-jose/go-jose/v3 v3.0.3 // indirect
+	github.com/go-logr/logr v1.4.1 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/go-openapi/analysis v0.21.5 // indirect
 	github.com/go-openapi/errors v0.22.0 // indirect
@@ -198,13 +200,10 @@ require (
 	github.com/vmihailenco/msgpack v4.0.4+incompatible // indirect
 	github.com/vmihailenco/msgpack/v5 v5.4.1 // indirect
 	github.com/vmihailenco/tagparser/v2 v2.0.0 // indirect
-	github.com/x448/float16 v0.8.4 // indirect
-	github.com/zclconf/go-cty v1.15.0 // indirect
-	go.mongodb.org/mongo-driver v1.16.1 // indirect
-	go.opentelemetry.io/otel v1.28.0 // indirect
-	go.opentelemetry.io/otel/metric v1.28.0 // indirect
-	go.opentelemetry.io/otel/trace v1.28.0 // indirect
-	go.uber.org/atomic v1.9.0 // indirect
+	github.com/zclconf/go-cty v1.14.1 // indirect
+	go.mongodb.org/mongo-driver v1.17.1 // indirect
+	go.opentelemetry.io/otel v1.14.0 // indirect
+	go.opentelemetry.io/otel/trace v1.14.0 // indirect
 	go.uber.org/ratelimit v0.2.0 // indirect
 	go.uber.org/zap v1.27.0 // indirect
 	golang.org/x/mod v0.21.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -102,7 +102,7 @@ require (
 	github.com/evanphx/json-patch/v5 v5.9.0 // indirect
 	github.com/fatih/color v1.16.0 // indirect
 	github.com/frankban/quicktest v1.14.3 // indirect
-	github.com/fsnotify/fsnotify v1.7.0 // indirect
+	github.com/fsnotify/fsnotify v1.8.0 // indirect
 	github.com/gabriel-vasile/mimetype v1.4.6 // indirect
 	github.com/go-jose/go-jose/v3 v3.0.3 // indirect
 	github.com/go-logr/logr v1.4.1 // indirect

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/IBM-Cloud/terraform-provider-ibm
 
-go 1.22.5
+go 1.23.0
 
 toolchain go1.23.2
 
@@ -39,7 +39,7 @@ require (
 	github.com/IBM/sarama v1.41.2
 	github.com/IBM/scc-go-sdk/v5 v5.4.1
 	github.com/IBM/schematics-go-sdk v0.3.0
-	github.com/IBM/sds-go-sdk v0.0.0
+	github.com/IBM/sds-go-sdk v0.0.3
 	github.com/IBM/secrets-manager-go-sdk/v2 v2.0.7
 	github.com/IBM/vmware-go-sdk v0.1.2
 	github.com/IBM/vpc-beta-go-sdk v0.8.0
@@ -101,11 +101,10 @@ require (
 	github.com/emicklei/go-restful/v3 v3.12.1 // indirect
 	github.com/evanphx/json-patch/v5 v5.9.0 // indirect
 	github.com/fatih/color v1.16.0 // indirect
-	github.com/frankban/quicktest v1.14.3 // indirect
-	github.com/fsnotify/fsnotify v1.8.0 // indirect
+	github.com/fxamacker/cbor/v2 v2.7.0 // indirect
 	github.com/gabriel-vasile/mimetype v1.4.6 // indirect
-	github.com/go-jose/go-jose/v3 v3.0.3 // indirect
-	github.com/go-logr/logr v1.4.1 // indirect
+	github.com/go-jose/go-jose/v4 v4.0.1 // indirect
+	github.com/go-logr/logr v1.4.2 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/go-openapi/analysis v0.21.5 // indirect
 	github.com/go-openapi/errors v0.22.0 // indirect
@@ -200,10 +199,12 @@ require (
 	github.com/vmihailenco/msgpack v4.0.4+incompatible // indirect
 	github.com/vmihailenco/msgpack/v5 v5.4.1 // indirect
 	github.com/vmihailenco/tagparser/v2 v2.0.0 // indirect
-	github.com/zclconf/go-cty v1.14.1 // indirect
+	github.com/x448/float16 v0.8.4 // indirect
+	github.com/zclconf/go-cty v1.15.0 // indirect
 	go.mongodb.org/mongo-driver v1.17.1 // indirect
-	go.opentelemetry.io/otel v1.14.0 // indirect
-	go.opentelemetry.io/otel/trace v1.14.0 // indirect
+	go.opentelemetry.io/otel v1.28.0 // indirect
+	go.opentelemetry.io/otel/metric v1.28.0 // indirect
+	go.opentelemetry.io/otel/trace v1.28.0 // indirect
 	go.uber.org/ratelimit v0.2.0 // indirect
 	go.uber.org/zap v1.27.0 // indirect
 	golang.org/x/mod v0.21.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -148,8 +148,8 @@ github.com/IBM/ibm-hpcs-uko-sdk v0.0.20-beta/go.mod h1:MLVNHMYoKsvovJZ4v1gQCpIYt
 github.com/IBM/keyprotect-go-client v0.5.1/go.mod h1:5TwDM/4FRJq1ZOlwQL1xFahLWQ3TveR88VmL1u3njyI=
 github.com/IBM/keyprotect-go-client v0.15.1 h1:m4qzqF5zOumRxKZ8s7vtK7A/UV/D278L8xpRG+WgT0s=
 github.com/IBM/keyprotect-go-client v0.15.1/go.mod h1:asXtHwL/4uCHA221Vd/7SkXEi2pcRHDzPyyksc1DthE=
-github.com/IBM/logs-go-sdk v0.3.0 h1:FHzTCCMyp9DvQGXgkppzcOPywC4ggt7x8xu0MR5h8xI=
-github.com/IBM/logs-go-sdk v0.3.0/go.mod h1:yv/GCXC4/p+MZEeXl4xjZAOMvDAVRwu61WyHZFKFXQM=
+github.com/IBM/logs-go-sdk v0.4.0 h1:CyUjm19EUtcJjf4mxsj6Rc7gkZDT8JEY5rLUIz8Eoag=
+github.com/IBM/logs-go-sdk v0.4.0/go.mod h1:yv/GCXC4/p+MZEeXl4xjZAOMvDAVRwu61WyHZFKFXQM=
 github.com/IBM/logs-router-go-sdk v1.0.5 h1:r0kC1+HfmSeQCD6zQTUp4PDI/zp4Ueo1Zo19ipHuNlw=
 github.com/IBM/logs-router-go-sdk v1.0.5/go.mod h1:tCN2vFgu5xG0ob9iJcxi5M4bJ6mWmu3nhmRPnvlwev0=
 github.com/IBM/mqcloud-go-sdk v0.2.0 h1:QOWk8ZGk0QfIL0MOGTKzNdM3Qe0Hk+ifAFtNSFQo5HU=
@@ -168,8 +168,8 @@ github.com/IBM/scc-go-sdk/v5 v5.4.1 h1:RXIuxOo9/hxkWyHCI69ae+KIJgSbXcAkJwTEl+fO3
 github.com/IBM/scc-go-sdk/v5 v5.4.1/go.mod h1:2xQTDgNXG5QMEfQxBDKB067z+5ha6OgcaKCTcdGDAo8=
 github.com/IBM/schematics-go-sdk v0.3.0 h1:Vwxw85SONflakiBsNHAfViKLyp9zJiH5/hh6SewOP5Q=
 github.com/IBM/schematics-go-sdk v0.3.0/go.mod h1:Tw2OSAPdpC69AxcwoyqcYYaGTTW6YpERF9uNEU+BFRQ=
-github.com/IBM/sds-go-sdk v0.0.3 h1:AlC2SOFdiD8hPHei7DIcwNLNq2ami3jDvb0MxZLpIE0=
-github.com/IBM/sds-go-sdk v0.0.3/go.mod h1:mUak/6lrP0H7Pr5XBoZfosPe92cmV4emWMI4amRvAhQ=
+github.com/IBM/sds-go-sdk v0.0.4 h1:zkkqDzc+TgFYU/BK4Oknv8cMBXJ08WKUu7yKCyzslvE=
+github.com/IBM/sds-go-sdk v0.0.4/go.mod h1:HcqZfsgKMqfFxbU1RcRfF934ls+vQY97oXPGPSoIWPg=
 github.com/IBM/secrets-manager-go-sdk/v2 v2.0.7 h1:5lKt1rHuKaAaiZtbPfsF8dgiko/gGbVgreiut3zU128=
 github.com/IBM/secrets-manager-go-sdk/v2 v2.0.7/go.mod h1:RglK3v6CPe3T1myRtQCD6z+nBygXvNJwufAon0qcZok=
 github.com/IBM/vmware-go-sdk v0.1.2 h1:5lKWFyInWz9e2hwGsoFTEoLa1jYkD30SReN0fQ10w9M=
@@ -1290,8 +1290,9 @@ go.opentelemetry.io/otel/trace v1.28.0/go.mod h1:jPyXzNPg6da9+38HEwElrQiHlVMTnVf
 go.opentelemetry.io/proto/otlp v0.7.0/go.mod h1:PqfVotwruBrMGOCsRd/89rSnXhoiJIqeYNgFYFoEGnI=
 go.uber.org/atomic v1.3.2/go.mod h1:gD2HeocX3+yG+ygLZcrzQJaqmWj9AIm7n08wl/qW/PE=
 go.uber.org/atomic v1.4.0/go.mod h1:gD2HeocX3+yG+ygLZcrzQJaqmWj9AIm7n08wl/qW/PE=
-go.uber.org/atomic v1.7.0 h1:ADUqmZGgLDDfbSL9ZmPxKTybcoEYHgpYfELNoN+7hsw=
 go.uber.org/atomic v1.7.0/go.mod h1:fEN4uk6kAWBTFdckzkM89CLk9XfWZrxpCo0nPH17wJc=
+go.uber.org/atomic v1.9.0 h1:ECmE8Bn/WFTYwEW/bpKD3M8VtR/zQVbavAoalC1PYyE=
+go.uber.org/atomic v1.9.0/go.mod h1:fEN4uk6kAWBTFdckzkM89CLk9XfWZrxpCo0nPH17wJc=
 go.uber.org/multierr v1.1.0/go.mod h1:wR5kodmAFQ0UK8QlbwjlSNy0Z68gJhDJUG5sjR94q/0=
 go.uber.org/multierr v1.11.0 h1:blXXJkSxSSfBVBlC76pxqeO+LN3aDfLQo+309xJstO0=
 go.uber.org/multierr v1.11.0/go.mod h1:20+QtiLqy0Nd6FdQB9TLXag12DsQkrbs3htMFfDN80Y=

--- a/go.sum
+++ b/go.sum
@@ -168,8 +168,8 @@ github.com/IBM/scc-go-sdk/v5 v5.4.1 h1:RXIuxOo9/hxkWyHCI69ae+KIJgSbXcAkJwTEl+fO3
 github.com/IBM/scc-go-sdk/v5 v5.4.1/go.mod h1:2xQTDgNXG5QMEfQxBDKB067z+5ha6OgcaKCTcdGDAo8=
 github.com/IBM/schematics-go-sdk v0.3.0 h1:Vwxw85SONflakiBsNHAfViKLyp9zJiH5/hh6SewOP5Q=
 github.com/IBM/schematics-go-sdk v0.3.0/go.mod h1:Tw2OSAPdpC69AxcwoyqcYYaGTTW6YpERF9uNEU+BFRQ=
-github.com/IBM/sds-go-sdk v0.0.0 h1:N269p6vCIDSzJh2dy+hLeSVExH9ZB2yLmBnZZB+3HMs=
-github.com/IBM/sds-go-sdk v0.0.0/go.mod h1:YMEsGRcyYRd1eYM0DEZPucVsRwPbzWoqVDczXIJInOY=
+github.com/IBM/sds-go-sdk v0.0.3 h1:AlC2SOFdiD8hPHei7DIcwNLNq2ami3jDvb0MxZLpIE0=
+github.com/IBM/sds-go-sdk v0.0.3/go.mod h1:mUak/6lrP0H7Pr5XBoZfosPe92cmV4emWMI4amRvAhQ=
 github.com/IBM/secrets-manager-go-sdk/v2 v2.0.7 h1:5lKt1rHuKaAaiZtbPfsF8dgiko/gGbVgreiut3zU128=
 github.com/IBM/secrets-manager-go-sdk/v2 v2.0.7/go.mod h1:RglK3v6CPe3T1myRtQCD6z+nBygXvNJwufAon0qcZok=
 github.com/IBM/vmware-go-sdk v0.1.2 h1:5lKWFyInWz9e2hwGsoFTEoLa1jYkD30SReN0fQ10w9M=
@@ -372,8 +372,6 @@ github.com/fxamacker/cbor/v2 v2.7.0/go.mod h1:pxXPTn3joSm21Gbwsv0w9OSA2y1HFR9qXE
 github.com/gabriel-vasile/mimetype v1.4.3/go.mod h1:d8uq/6HKRL6CGdk+aubisF/M5GcPfT7nKyLpA0lbSSk=
 github.com/gabriel-vasile/mimetype v1.4.6 h1:3+PzJTKLkvgjeTbts6msPJt4DixhT4YtFNf1gtGe3zc=
 github.com/gabriel-vasile/mimetype v1.4.6/go.mod h1:JX1qVKqZd40hUPpAfiNTe0Sne7hdfKSbOqqmkq8GCXc=
-github.com/gammazero/deque v0.0.0-20190130191400-2afb3858e9c7/go.mod h1:GeIq9qoE43YdGnDXURnmKTnGg15pQz4mYkXSTChbneI=
-github.com/gammazero/workerpool v0.0.0-20190406235159-88d534f22b56/go.mod h1:w9RqFVO2BM3xwWEcAB8Fwp0OviTBBEiRmSBDfbXnd3w=
 github.com/getkin/kin-openapi v0.76.0/go.mod h1:660oXbgy5JFMKreazJaQTw7o+X00qeSyhcnluiMv+Xg=
 github.com/ghodss/yaml v0.0.0-20150909031657-73d445a93680/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
@@ -1274,9 +1272,6 @@ go.mongodb.org/mongo-driver v1.11.3/go.mod h1:PTSz5yu21bkT/wXpkS7WR5f0ddqw5queth
 go.mongodb.org/mongo-driver v1.14.0/go.mod h1:Vzb0Mk/pa7e6cWw85R4F/endUC3u0U9jGcNU603k65c=
 go.mongodb.org/mongo-driver v1.17.1 h1:Wic5cJIwJgSpBhe3lx3+/RybR5PiYRMpVFgO7cOHyIM=
 go.mongodb.org/mongo-driver v1.17.1/go.mod h1:wwWm/+BuOddhcq3n68LKRmgk2wXzmF6s0SFOa0GINL4=
-go.opencensus.io v0.19.1/go.mod h1:gug0GbSHa8Pafr0d2urOSgoXHZ6x/RUlaiT0d9pqb4A=
-go.opencensus.io v0.19.2/go.mod h1:NO/8qkisMZLZ1FCsKNqtJPwc8/TaclWyY0B6wcYNg9M=
-go.opencensus.io v0.20.1/go.mod h1:6WKK9ahsWS3RSO+PY9ZHZUfv2irvY6gN279GOPZjmmk=
 go.opencensus.io v0.21.0/go.mod h1:mSImk1erAIZhrmZN+AvHh14ztQfjbGwt4TtuofqLduU=
 go.opencensus.io v0.22.0/go.mod h1:+kGneAE2xo2IficOXnaByMWTGM9T73dGwxeWcUqIpI8=
 go.opencensus.io v0.22.2/go.mod h1:yxeiOL68Rb0Xd1ddK5vPZ/oVn4vY4Ynel7k9FzqtOIw=
@@ -1295,9 +1290,8 @@ go.opentelemetry.io/otel/trace v1.28.0/go.mod h1:jPyXzNPg6da9+38HEwElrQiHlVMTnVf
 go.opentelemetry.io/proto/otlp v0.7.0/go.mod h1:PqfVotwruBrMGOCsRd/89rSnXhoiJIqeYNgFYFoEGnI=
 go.uber.org/atomic v1.3.2/go.mod h1:gD2HeocX3+yG+ygLZcrzQJaqmWj9AIm7n08wl/qW/PE=
 go.uber.org/atomic v1.4.0/go.mod h1:gD2HeocX3+yG+ygLZcrzQJaqmWj9AIm7n08wl/qW/PE=
+go.uber.org/atomic v1.7.0 h1:ADUqmZGgLDDfbSL9ZmPxKTybcoEYHgpYfELNoN+7hsw=
 go.uber.org/atomic v1.7.0/go.mod h1:fEN4uk6kAWBTFdckzkM89CLk9XfWZrxpCo0nPH17wJc=
-go.uber.org/atomic v1.9.0 h1:ECmE8Bn/WFTYwEW/bpKD3M8VtR/zQVbavAoalC1PYyE=
-go.uber.org/atomic v1.9.0/go.mod h1:fEN4uk6kAWBTFdckzkM89CLk9XfWZrxpCo0nPH17wJc=
 go.uber.org/multierr v1.1.0/go.mod h1:wR5kodmAFQ0UK8QlbwjlSNy0Z68gJhDJUG5sjR94q/0=
 go.uber.org/multierr v1.11.0 h1:blXXJkSxSSfBVBlC76pxqeO+LN3aDfLQo+309xJstO0=
 go.uber.org/multierr v1.11.0/go.mod h1:20+QtiLqy0Nd6FdQB9TLXag12DsQkrbs3htMFfDN80Y=

--- a/go.sum
+++ b/go.sum
@@ -168,6 +168,8 @@ github.com/IBM/scc-go-sdk/v5 v5.4.1 h1:RXIuxOo9/hxkWyHCI69ae+KIJgSbXcAkJwTEl+fO3
 github.com/IBM/scc-go-sdk/v5 v5.4.1/go.mod h1:2xQTDgNXG5QMEfQxBDKB067z+5ha6OgcaKCTcdGDAo8=
 github.com/IBM/schematics-go-sdk v0.3.0 h1:Vwxw85SONflakiBsNHAfViKLyp9zJiH5/hh6SewOP5Q=
 github.com/IBM/schematics-go-sdk v0.3.0/go.mod h1:Tw2OSAPdpC69AxcwoyqcYYaGTTW6YpERF9uNEU+BFRQ=
+github.com/IBM/sds-go-sdk v0.0.0 h1:N269p6vCIDSzJh2dy+hLeSVExH9ZB2yLmBnZZB+3HMs=
+github.com/IBM/sds-go-sdk v0.0.0/go.mod h1:YMEsGRcyYRd1eYM0DEZPucVsRwPbzWoqVDczXIJInOY=
 github.com/IBM/secrets-manager-go-sdk/v2 v2.0.7 h1:5lKt1rHuKaAaiZtbPfsF8dgiko/gGbVgreiut3zU128=
 github.com/IBM/secrets-manager-go-sdk/v2 v2.0.7/go.mod h1:RglK3v6CPe3T1myRtQCD6z+nBygXvNJwufAon0qcZok=
 github.com/IBM/vmware-go-sdk v0.1.2 h1:5lKWFyInWz9e2hwGsoFTEoLa1jYkD30SReN0fQ10w9M=
@@ -368,8 +370,10 @@ github.com/fsnotify/fsnotify v1.8.0/go.mod h1:8jBTzvmWwFyi3Pb8djgCCO5IBqzKJ/Jwo8
 github.com/fxamacker/cbor/v2 v2.7.0 h1:iM5WgngdRBanHcxugY4JySA0nk1wZorNOpTgCMedv5E=
 github.com/fxamacker/cbor/v2 v2.7.0/go.mod h1:pxXPTn3joSm21Gbwsv0w9OSA2y1HFR9qXEeXQVeNoDQ=
 github.com/gabriel-vasile/mimetype v1.4.3/go.mod h1:d8uq/6HKRL6CGdk+aubisF/M5GcPfT7nKyLpA0lbSSk=
-github.com/gabriel-vasile/mimetype v1.4.5 h1:J7wGKdGu33ocBOhGy0z653k/lFKLFDPJMG8Gql0kxn4=
-github.com/gabriel-vasile/mimetype v1.4.5/go.mod h1:ibHel+/kbxn9x2407k1izTA1S81ku1z/DlgOW2QE0M4=
+github.com/gabriel-vasile/mimetype v1.4.6 h1:3+PzJTKLkvgjeTbts6msPJt4DixhT4YtFNf1gtGe3zc=
+github.com/gabriel-vasile/mimetype v1.4.6/go.mod h1:JX1qVKqZd40hUPpAfiNTe0Sne7hdfKSbOqqmkq8GCXc=
+github.com/gammazero/deque v0.0.0-20190130191400-2afb3858e9c7/go.mod h1:GeIq9qoE43YdGnDXURnmKTnGg15pQz4mYkXSTChbneI=
+github.com/gammazero/workerpool v0.0.0-20190406235159-88d534f22b56/go.mod h1:w9RqFVO2BM3xwWEcAB8Fwp0OviTBBEiRmSBDfbXnd3w=
 github.com/getkin/kin-openapi v0.76.0/go.mod h1:660oXbgy5JFMKreazJaQTw7o+X00qeSyhcnluiMv+Xg=
 github.com/ghodss/yaml v0.0.0-20150909031657-73d445a93680/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
@@ -1268,8 +1272,11 @@ go.mongodb.org/mongo-driver v1.7.5/go.mod h1:VXEWRZ6URJIkUq2SCAyapmhH0ZLRBP+FT4x
 go.mongodb.org/mongo-driver v1.10.0/go.mod h1:wsihk0Kdgv8Kqu1Anit4sfK+22vSFbUrAVEYRhCXrA8=
 go.mongodb.org/mongo-driver v1.11.3/go.mod h1:PTSz5yu21bkT/wXpkS7WR5f0ddqw5quethTUn9WM+2g=
 go.mongodb.org/mongo-driver v1.14.0/go.mod h1:Vzb0Mk/pa7e6cWw85R4F/endUC3u0U9jGcNU603k65c=
-go.mongodb.org/mongo-driver v1.16.1 h1:rIVLL3q0IHM39dvE+z2ulZLp9ENZKThVfuvN/IiN4l8=
-go.mongodb.org/mongo-driver v1.16.1/go.mod h1:oB6AhJQvFQL4LEHyXi6aJzQJtBiTQHiAd83l0GdFaiw=
+go.mongodb.org/mongo-driver v1.17.1 h1:Wic5cJIwJgSpBhe3lx3+/RybR5PiYRMpVFgO7cOHyIM=
+go.mongodb.org/mongo-driver v1.17.1/go.mod h1:wwWm/+BuOddhcq3n68LKRmgk2wXzmF6s0SFOa0GINL4=
+go.opencensus.io v0.19.1/go.mod h1:gug0GbSHa8Pafr0d2urOSgoXHZ6x/RUlaiT0d9pqb4A=
+go.opencensus.io v0.19.2/go.mod h1:NO/8qkisMZLZ1FCsKNqtJPwc8/TaclWyY0B6wcYNg9M=
+go.opencensus.io v0.20.1/go.mod h1:6WKK9ahsWS3RSO+PY9ZHZUfv2irvY6gN279GOPZjmmk=
 go.opencensus.io v0.21.0/go.mod h1:mSImk1erAIZhrmZN+AvHh14ztQfjbGwt4TtuofqLduU=
 go.opencensus.io v0.22.0/go.mod h1:+kGneAE2xo2IficOXnaByMWTGM9T73dGwxeWcUqIpI8=
 go.opencensus.io v0.22.2/go.mod h1:yxeiOL68Rb0Xd1ddK5vPZ/oVn4vY4Ynel7k9FzqtOIw=

--- a/ibm/conns/config.go
+++ b/ibm/conns/config.go
@@ -3611,7 +3611,6 @@ func (c *Config) ClientSession() (interface{}, error) {
 	if session.sdsaasClientErr == nil {
 		// Construct the service options.
 		sdsaasClientOptions := &sdsaasv1.SdsaasV1Options{
-			URL:           EnvFallBack([]string{"IBMCLOUD_SDS_ENDPOINT"}, ""),
 			Authenticator: authenticator,
 		}
 

--- a/ibm/conns/config.go
+++ b/ibm/conns/config.go
@@ -86,6 +86,7 @@ import (
 	project "github.com/IBM/project-go-sdk/projectv1"
 	"github.com/IBM/push-notifications-go-sdk/pushservicev1"
 	schematicsv1 "github.com/IBM/schematics-go-sdk/schematicsv1"
+	"github.com/IBM/sds-go-sdk/sdsaasv1"
 	"github.com/IBM/vmware-go-sdk/vmwarev1"
 	vpcbeta "github.com/IBM/vpc-beta-go-sdk/vpcbetav1"
 	"github.com/IBM/vpc-go-sdk/common"
@@ -319,6 +320,7 @@ type ClientSession interface {
 	MqcloudV1() (*mqcloudv1.MqcloudV1, error)
 	VmwareV1() (*vmwarev1.VmwareV1, error)
 	LogsV0() (*logsv0.LogsV0, error)
+	SdsaasV1() (*sdsaasv1.SdsaasV1, error)
 }
 
 type clientSession struct {
@@ -677,9 +679,15 @@ type clientSession struct {
 	ibmCloudLogsRoutingClient    *ibmcloudlogsroutingv0.IBMCloudLogsRoutingV0
 	ibmCloudLogsRoutingClientErr error
 
+<<<<<<< HEAD
 	// db2 saas
 	db2saasClient    *db2saasv1.Db2saasV1
 	db2saasClientErr error
+=======
+	// Software Defined Storage
+	sdsaasClient    *sdsaasv1.SdsaasV1
+	sdsaasClientErr error
+>>>>>>> f12d12b17 (Add SDSaaS to terraform provider)
 }
 
 // Usage Reports
@@ -1284,7 +1292,16 @@ func (session clientSession) ProjectV1() (*project.ProjectV1, error) {
 	return session.projectClient, session.projectClientErr
 }
 
+<<<<<<< HEAD
 // MQaaS
+=======
+// sdsaas
+func (session clientSession) SdsaasV1() (*sdsaasv1.SdsaasV1, error) {
+	return session.sdsaasClient, session.sdsaasClientErr
+}
+
+// MQ on Cloud
+>>>>>>> f12d12b17 (Add SDSaaS to terraform provider)
 func (session clientSession) MqcloudV1() (*mqcloudv1.MqcloudV1, error) {
 	if session.mqcloudClientErr != nil {
 		sessionMqcloudClient := session.mqcloudClient
@@ -3593,6 +3610,28 @@ func (c *Config) ClientSession() (interface{}, error) {
 		})
 	} else {
 		session.codeEngineClientErr = fmt.Errorf("Error occurred while configuring Code Engine service: %q", err)
+	}
+
+	// Construct an instance of the 'sdsaas' service.
+	if session.sdsaasClientErr == nil {
+		// Construct the service options.
+		sdsaasClientOptions := &sdsaasv1.SdsaasV1Options{
+			URL:           EnvFallBack([]string{"IBMCLOUD_SDS_ENDPOINT"}, ""),
+			Authenticator: authenticator,
+		}
+
+		// Construct the service client.
+		session.sdsaasClient, err = sdsaasv1.NewSdsaasV1(sdsaasClientOptions)
+		if err == nil {
+			// Enable retries for API calls
+			session.sdsaasClient.Service.EnableRetries(c.RetryCount, c.RetryDelay)
+			// Add custom header for analytics
+			session.sdsaasClient.SetDefaultHeaders(gohttp.Header{
+				"X-Original-User-Agent": {fmt.Sprintf("terraform-provider-ibm/%s", version.Version)},
+			})
+		} else {
+			session.sdsaasClientErr = fmt.Errorf("Error occurred while constructing 'sdsaas' service client: %q", err)
+		}
 	}
 
 	if os.Getenv("TF_LOG") != "" {

--- a/ibm/conns/config.go
+++ b/ibm/conns/config.go
@@ -8,7 +8,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"github.com/IBM/cloud-db2-go-sdk/db2saasv1"
 	"io"
 	"io/ioutil"
 	"log"
@@ -17,6 +16,8 @@ import (
 	"os"
 	"strings"
 	"time"
+
+	"github.com/IBM/cloud-db2-go-sdk/db2saasv1"
 
 	// Added code for the Power Colo Offering
 
@@ -679,15 +680,13 @@ type clientSession struct {
 	ibmCloudLogsRoutingClient    *ibmcloudlogsroutingv0.IBMCloudLogsRoutingV0
 	ibmCloudLogsRoutingClientErr error
 
-<<<<<<< HEAD
 	// db2 saas
 	db2saasClient    *db2saasv1.Db2saasV1
 	db2saasClientErr error
-=======
+
 	// Software Defined Storage
 	sdsaasClient    *sdsaasv1.SdsaasV1
 	sdsaasClientErr error
->>>>>>> f12d12b17 (Add SDSaaS to terraform provider)
 }
 
 // Usage Reports
@@ -1292,16 +1291,7 @@ func (session clientSession) ProjectV1() (*project.ProjectV1, error) {
 	return session.projectClient, session.projectClientErr
 }
 
-<<<<<<< HEAD
 // MQaaS
-=======
-// sdsaas
-func (session clientSession) SdsaasV1() (*sdsaasv1.SdsaasV1, error) {
-	return session.sdsaasClient, session.sdsaasClientErr
-}
-
-// MQ on Cloud
->>>>>>> f12d12b17 (Add SDSaaS to terraform provider)
 func (session clientSession) MqcloudV1() (*mqcloudv1.MqcloudV1, error) {
 	if session.mqcloudClientErr != nil {
 		sessionMqcloudClient := session.mqcloudClient
@@ -1309,6 +1299,11 @@ func (session clientSession) MqcloudV1() (*mqcloudv1.MqcloudV1, error) {
 		return session.mqcloudClient, session.mqcloudClientErr
 	}
 	return session.mqcloudClient.Clone(), nil
+}
+
+// sdsaas
+func (session clientSession) SdsaasV1() (*sdsaasv1.SdsaasV1, error) {
+	return session.sdsaasClient, session.sdsaasClientErr
 }
 
 // VMware as a Service API

--- a/ibm/provider/provider.go
+++ b/ibm/provider/provider.go
@@ -64,6 +64,7 @@ import (
 	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/satellite"
 	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/scc"
 	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/schematics"
+	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/sdsaas"
 	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/secretsmanager"
 	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/transitgateway"
 	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/usagereports"
@@ -1385,6 +1386,10 @@ func Provider() *schema.Provider {
 			"ibm_cdn":                                      classicinfrastructure.ResourceIBMCDN(),
 			"ibm_hardware_firewall_shared":                 classicinfrastructure.ResourceIBMFirewallShared(),
 
+			// Software Defined Storage as a Service
+			"ibm_sds_volume": sdsaas.ResourceIBMSdsVolume(),
+			"ibm_sds_host":   sdsaas.ResourceIBMSdsHost(),
+
 			// Partner Center Sell
 			"ibm_onboarding_registration":       partnercentersell.ResourceIbmOnboardingRegistration(),
 			"ibm_onboarding_product":            partnercentersell.ResourceIbmOnboardingProduct(),
@@ -2177,6 +2182,10 @@ func Validator() validate.ValidatorDict {
 
 				// Added for Logs Router Service
 				"ibm_logs_router_tenant": logsrouting.ResourceIBMLogsRouterTenantValidator(),
+
+				// Added for Software Defined Storage as a Service
+				"ibm_sds_volume": sdsaas.ResourceIBMSdsVolumeValidator(),
+				"ibm_sds_host":   sdsaas.ResourceIBMSdsHostValidator(),
 			},
 			DataSourceValidatorDictionary: map[string]*validate.ResourceValidator{
 				"ibm_is_subnet":                     vpc.DataSourceIBMISSubnetValidator(),

--- a/ibm/service/sdsaas/README.md
+++ b/ibm/service/sdsaas/README.md
@@ -1,4 +1,4 @@
-# Terraform IBM Provider 
+# Terraform IBM Provider
 <!-- markdownlint-disable MD026 -->
 This area is primarily for IBM provider contributors and maintainers. For information on _using_ Terraform and the IBM provider, see the links below.
 
@@ -6,6 +6,6 @@ This area is primarily for IBM provider contributors and maintainers. For inform
 ## Handy Links
 * [Find out about contributing](../../../CONTRIBUTING.md) to the IBM provider!
 * IBM Provider Docs: [Home](https://registry.terraform.io/providers/IBM-Cloud/ibm/latest/docs)
-* IBM Provider Docs: [One of the  resources](https://registry.terraform.io/providers/IBM-Cloud/ibm/latest/docs/resources/sds_volume)
-* IBM API Docs: [IBM API Docs for ]()
-* IBM  SDK: [IBM SDK for ](https://github.com/IBM/appconfiguration-go-admin-sdk/tree/master/sdsaasv1)
+* IBM Provider Docs: [One of the resources](https://registry.terraform.io/providers/IBM-Cloud/ibm/latest/docs/resources/sds_volume)
+* IBM API Docs: [IBM API Docs for block](https://cloud.ibm.com/apidocs/block-storage). [IBM API Docs for storage](https://cloud.ibm.com/apidocs/object-storage)
+* IBM  SDK: [IBM SDK for software defined storage](https://github.com/IBM/sds-go-sdk/tree/master/sdsaasv1)

--- a/ibm/service/sdsaas/README.md
+++ b/ibm/service/sdsaas/README.md
@@ -1,0 +1,11 @@
+# Terraform IBM Provider 
+<!-- markdownlint-disable MD026 -->
+This area is primarily for IBM provider contributors and maintainers. For information on _using_ Terraform and the IBM provider, see the links below.
+
+
+## Handy Links
+* [Find out about contributing](../../../CONTRIBUTING.md) to the IBM provider!
+* IBM Provider Docs: [Home](https://registry.terraform.io/providers/IBM-Cloud/ibm/latest/docs)
+* IBM Provider Docs: [One of the  resources](https://registry.terraform.io/providers/IBM-Cloud/ibm/latest/docs/resources/sds_volume)
+* IBM API Docs: [IBM API Docs for ]()
+* IBM  SDK: [IBM SDK for ](https://github.com/IBM/appconfiguration-go-admin-sdk/tree/master/sdsaasv1)

--- a/ibm/service/sdsaas/resource_ibm_sds_host.go
+++ b/ibm/service/sdsaas/resource_ibm_sds_host.go
@@ -1,0 +1,388 @@
+// Copyright IBM Corp. 2024 All Rights Reserved.
+// Licensed under the Mozilla Public License v2.0
+
+/*
+ * IBM OpenAPI Terraform Generator Version: 3.96.0-d6dec9d7-20241008-212902
+ */
+
+package sdsaas
+
+import (
+	"context"
+	"fmt"
+	"log"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/conns"
+	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/flex"
+	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/validate"
+	"github.com/IBM/go-sdk-core/v5/core"
+	"github.com/IBM/sds-go-sdk/sdsaasv1"
+)
+
+func ResourceIBMSdsHost() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceIBMSdsHostCreate,
+		ReadContext:   resourceIBMSdsHostRead,
+		UpdateContext: resourceIBMSdsHostUpdate,
+		DeleteContext: resourceIBMSdsHostDelete,
+		Importer:      &schema.ResourceImporter{},
+
+		Schema: map[string]*schema.Schema{
+			"name": &schema.Schema{
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validate.InvokeValidator("ibm_sds_host", "name"),
+				Description:  "The name for this host. The name must not be used by another host.  If unspecified, the name will be a hyphenated list of randomly-selected words.",
+			},
+			"nqn": &schema.Schema{
+				Type:         schema.TypeString,
+				Required:     true,
+				ValidateFunc: validate.InvokeValidator("ibm_sds_host", "nqn"),
+				Description:  "The NQN of the host configured in customer's environment.",
+			},
+			"volume_mappings": &schema.Schema{
+				Type:        schema.TypeList,
+				Optional:    true,
+				Description: "The host-to-volume map.",
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"status": &schema.Schema{
+							Type:        schema.TypeString,
+							Optional:    true,
+							Description: "The current status of a volume/host mapping attempt.",
+						},
+						"volume_id": &schema.Schema{
+							Type:        schema.TypeString,
+							Required:    true,
+							Description: "The volume ID that needs to be mapped with a host.",
+						},
+						"volume_name": &schema.Schema{
+							Type:        schema.TypeString,
+							Required:    true,
+							Description: "The volume name.",
+						},
+						"storage_identifiers": &schema.Schema{
+							Type:        schema.TypeList,
+							MaxItems:    1,
+							Optional:    true,
+							Description: "Storage network and ID information associated with a volume/host mapping.",
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"id": &schema.Schema{
+										Type:        schema.TypeString,
+										Optional:    true,
+										Description: "The storage ID associated with a volume/host mapping.",
+									},
+									"namespace_id": &schema.Schema{
+										Type:        schema.TypeInt,
+										Optional:    true,
+										Description: "The namespace ID associated with a volume/host mapping.",
+									},
+									"namespace_uuid": &schema.Schema{
+										Type:        schema.TypeString,
+										Optional:    true,
+										Description: "The namespace UUID associated with a volume/host mapping.",
+									},
+									"network_info": &schema.Schema{
+										Type:        schema.TypeList,
+										Optional:    true,
+										Description: "The IP and port for volume/host mappings.",
+										Elem: &schema.Resource{
+											Schema: map[string]*schema.Schema{
+												"gateway_ip": &schema.Schema{
+													Type:        schema.TypeString,
+													Optional:    true,
+													Description: "Network information for volume/host mappings.",
+												},
+												"port": &schema.Schema{
+													Type:        schema.TypeInt,
+													Optional:    true,
+													Description: "Network information for volume/host mappings.",
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			"created_at": &schema.Schema{
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The date and time that the host was created.",
+			},
+			"service_instance_id": &schema.Schema{
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The service instance ID this host should be created in.",
+			},
+		},
+	}
+}
+
+func ResourceIBMSdsHostValidator() *validate.ResourceValidator {
+	validateSchema := make([]validate.ValidateSchema, 0)
+	validateSchema = append(validateSchema,
+		validate.ValidateSchema{
+			Identifier:                 "name",
+			ValidateFunctionIdentifier: validate.ValidateRegexpLen,
+			Type:                       validate.TypeString,
+			Optional:                   true,
+			Regexp:                     `^-?([a-z]|[a-z][-a-z0-9]*[a-z0-9]|[0-9][-a-z0-9]*([a-z]|[-a-z][-a-z0-9]*[a-z0-9]))$`,
+			MinValueLength:             1,
+			MaxValueLength:             64,
+		},
+		validate.ValidateSchema{
+			Identifier:                 "nqn",
+			ValidateFunctionIdentifier: validate.ValidateRegexpLen,
+			Type:                       validate.TypeString,
+			Required:                   true,
+			Regexp:                     `^nqn\.\d{4}-\d{2}\.[a-z0-9-]+(?:\.[a-z0-9-]+)*:[a-zA-Z0-9.\-:]+$`,
+			MinValueLength:             1,
+			MaxValueLength:             64,
+		},
+	)
+
+	resourceValidator := validate.ResourceValidator{ResourceName: "ibm_sds_host", Schema: validateSchema}
+	return &resourceValidator
+}
+
+func resourceIBMSdsHostCreate(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	sdsaasClient, err := meta.(conns.ClientSession).SdsaasV1()
+	if err != nil {
+		tfErr := flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_sds_host", "create", "initialize-client")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
+	}
+
+	hostCreateOptions := &sdsaasv1.HostCreateOptions{}
+
+	hostCreateOptions.SetNqn(d.Get("nqn").(string))
+	if _, ok := d.GetOk("name"); ok {
+		hostCreateOptions.SetName(d.Get("name").(string))
+	}
+	if _, ok := d.GetOk("volume_mappings"); ok {
+		var volumeMappings []sdsaasv1.VolumeMappingIdentity
+		for _, v := range d.Get("volume_mappings").([]interface{}) {
+			value := v.(map[string]interface{})
+			volumeMappingsItem, err := ResourceIBMSdsHostMapToVolumeMappingIdentity(value)
+			if err != nil {
+				return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_sds_host", "create", "parse-volume_mappings").GetDiag()
+			}
+			volumeMappings = append(volumeMappings, *volumeMappingsItem)
+		}
+		hostCreateOptions.SetVolumeMappings(volumeMappings)
+	}
+
+	host, _, err := sdsaasClient.HostCreateWithContext(context, hostCreateOptions)
+	if err != nil {
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("HostCreateWithContext failed: %s", err.Error()), "ibm_sds_host", "create")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
+	}
+
+	d.SetId(*host.ID)
+
+	return resourceIBMSdsHostRead(context, d, meta)
+}
+
+func resourceIBMSdsHostRead(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	sdsaasClient, err := meta.(conns.ClientSession).SdsaasV1()
+	if err != nil {
+		tfErr := flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_sds_host", "read", "initialize-client")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
+	}
+
+	hostOptions := &sdsaasv1.HostOptions{}
+
+	hostOptions.SetHostID(d.Id())
+
+	host, response, err := sdsaasClient.HostWithContext(context, hostOptions)
+	if err != nil {
+		if response != nil && response.StatusCode == 404 {
+			d.SetId("")
+			return nil
+		}
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("HostWithContext failed: %s", err.Error()), "ibm_sds_host", "read")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
+	}
+
+	if !core.IsNil(host.Name) {
+		if err = d.Set("name", host.Name); err != nil {
+			err = fmt.Errorf("Error setting name: %s", err)
+			return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_sds_host", "read", "set-name").GetDiag()
+		}
+	}
+	if err = d.Set("nqn", host.Nqn); err != nil {
+		err = fmt.Errorf("Error setting nqn: %s", err)
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_sds_host", "read", "set-nqn").GetDiag()
+	}
+	if !core.IsNil(host.VolumeMappings) {
+		volumeMappings := []map[string]interface{}{}
+		for _, volumeMappingsItem := range host.VolumeMappings {
+			volumeMappingsItemMap, err := ResourceIBMSdsHostVolumeMappingReferenceToMap(&volumeMappingsItem) // #nosec G601
+			if err != nil {
+				return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_sds_host", "read", "volume_mappings-to-map").GetDiag()
+			}
+			volumeMappings = append(volumeMappings, volumeMappingsItemMap)
+		}
+		if err = d.Set("volume_mappings", volumeMappings); err != nil {
+			err = fmt.Errorf("Error setting volume_mappings: %s", err)
+			return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_sds_host", "read", "set-volume_mappings").GetDiag()
+		}
+	}
+	if !core.IsNil(host.CreatedAt) {
+		if err = d.Set("created_at", host.CreatedAt); err != nil {
+			err = fmt.Errorf("Error setting created_at: %s", err)
+			return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_sds_host", "read", "set-created_at").GetDiag()
+		}
+	}
+	if !core.IsNil(host.ServiceInstanceID) {
+		if err = d.Set("service_instance_id", host.ServiceInstanceID); err != nil {
+			err = fmt.Errorf("Error setting service_instance_id: %s", err)
+			return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_sds_host", "read", "set-service_instance_id").GetDiag()
+		}
+	}
+
+	return nil
+}
+
+func resourceIBMSdsHostUpdate(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	sdsaasClient, err := meta.(conns.ClientSession).SdsaasV1()
+	if err != nil {
+		tfErr := flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_sds_host", "update", "initialize-client")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
+	}
+
+	hostUpdateOptions := &sdsaasv1.HostUpdateOptions{}
+
+	hostUpdateOptions.SetHostID(d.Id())
+
+	hasChange := false
+
+	patchVals := &sdsaasv1.HostPatch{}
+	if d.HasChange("name") {
+		newName := d.Get("name").(string)
+		patchVals.Name = &newName
+		hasChange = true
+	}
+
+	if hasChange {
+		// Fields with `nil` values are omitted from the generic map,
+		// so we need to re-add them to support removing arguments
+		// in merge-patch operations sent to the service.
+		hostUpdateOptions.HostPatch = ResourceIBMSdsHostHostPatchAsPatch(patchVals, d)
+
+		_, _, err = sdsaasClient.HostUpdateWithContext(context, hostUpdateOptions)
+		if err != nil {
+			tfErr := flex.TerraformErrorf(err, fmt.Sprintf("HostUpdateWithContext failed: %s", err.Error()), "ibm_sds_host", "update")
+			log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+			return tfErr.GetDiag()
+		}
+	}
+
+	return resourceIBMSdsHostRead(context, d, meta)
+}
+
+func resourceIBMSdsHostDelete(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	sdsaasClient, err := meta.(conns.ClientSession).SdsaasV1()
+	if err != nil {
+		tfErr := flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_sds_host", "delete", "initialize-client")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
+	}
+
+	hostDeleteOptions := &sdsaasv1.HostDeleteOptions{}
+
+	hostDeleteOptions.SetHostID(d.Id())
+
+	_, err = sdsaasClient.HostDeleteWithContext(context, hostDeleteOptions)
+	if err != nil {
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("HostDeleteWithContext failed: %s", err.Error()), "ibm_sds_host", "delete")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
+	}
+
+	d.SetId("")
+
+	return nil
+}
+
+func ResourceIBMSdsHostMapToVolumeMappingIdentity(modelMap map[string]interface{}) (*sdsaasv1.VolumeMappingIdentity, error) {
+	model := &sdsaasv1.VolumeMappingIdentity{}
+	model.VolumeID = core.StringPtr(modelMap["volume_id"].(string))
+	return model, nil
+}
+
+func ResourceIBMSdsHostVolumeMappingReferenceToMap(model *sdsaasv1.VolumeMappingReference) (map[string]interface{}, error) {
+	modelMap := make(map[string]interface{})
+	if model.Status != nil {
+		modelMap["status"] = *model.Status
+	}
+	modelMap["volume_id"] = *model.VolumeID
+	modelMap["volume_name"] = *model.VolumeName
+	if model.StorageIdentifiers != nil {
+		storageIdentifiersMap, err := ResourceIBMSdsHostStorageIdentifiersReferenceToMap(model.StorageIdentifiers)
+		if err != nil {
+			return modelMap, err
+		}
+		modelMap["storage_identifiers"] = []map[string]interface{}{storageIdentifiersMap}
+	}
+	return modelMap, nil
+}
+
+func ResourceIBMSdsHostStorageIdentifiersReferenceToMap(model *sdsaasv1.StorageIdentifiersReference) (map[string]interface{}, error) {
+	modelMap := make(map[string]interface{})
+	if model.ID != nil {
+		modelMap["id"] = *model.ID
+	}
+	if model.NamespaceID != nil {
+		modelMap["namespace_id"] = flex.IntValue(model.NamespaceID)
+	}
+	if model.NamespaceUUID != nil {
+		modelMap["namespace_uuid"] = *model.NamespaceUUID
+	}
+	if model.NetworkInfo != nil {
+		networkInfo := []map[string]interface{}{}
+		for _, networkInfoItem := range model.NetworkInfo {
+			networkInfoItemMap, err := ResourceIBMSdsHostNetworkInfoReferenceToMap(&networkInfoItem) // #nosec G601
+			if err != nil {
+				return modelMap, err
+			}
+			networkInfo = append(networkInfo, networkInfoItemMap)
+		}
+		modelMap["network_info"] = networkInfo
+	}
+	return modelMap, nil
+}
+
+func ResourceIBMSdsHostNetworkInfoReferenceToMap(model *sdsaasv1.NetworkInfoReference) (map[string]interface{}, error) {
+	modelMap := make(map[string]interface{})
+	if model.GatewayIP != nil {
+		modelMap["gateway_ip"] = *model.GatewayIP
+	}
+	if model.Port != nil {
+		modelMap["port"] = flex.IntValue(model.Port)
+	}
+	return modelMap, nil
+}
+
+func ResourceIBMSdsHostHostPatchAsPatch(patchVals *sdsaasv1.HostPatch, d *schema.ResourceData) map[string]interface{} {
+	patch, _ := patchVals.AsPatch()
+	var path string
+
+	path = "name"
+	if _, exists := d.GetOk(path); d.HasChange(path) && !exists {
+		patch["name"] = nil
+	}
+
+	return patch
+}

--- a/ibm/service/sdsaas/resource_ibm_sds_host.go
+++ b/ibm/service/sdsaas/resource_ibm_sds_host.go
@@ -15,7 +15,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 
-	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/conns"
 	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/flex"
 	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/validate"
 	"github.com/IBM/go-sdk-core/v5/core"
@@ -31,6 +30,11 @@ func ResourceIBMSdsHost() *schema.Resource {
 		Importer:      &schema.ResourceImporter{},
 
 		Schema: map[string]*schema.Schema{
+			"sds_endpoint": &schema.Schema{
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "The endpoint to use for operations",
+			},
 			"name": &schema.Schema{
 				Type:         schema.TypeString,
 				Optional:     true,
@@ -148,7 +152,8 @@ func ResourceIBMSdsHostValidator() *validate.ResourceValidator {
 }
 
 func resourceIBMSdsHostCreate(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	sdsaasClient, err := meta.(conns.ClientSession).SdsaasV1()
+	endpoint := d.Get("sds_endpoint").(string)
+	sdsaasClient, err := getSDSConfigClient(meta, endpoint)
 	if err != nil {
 		tfErr := flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_sds_host", "create", "initialize-client")
 		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
@@ -187,7 +192,8 @@ func resourceIBMSdsHostCreate(context context.Context, d *schema.ResourceData, m
 }
 
 func resourceIBMSdsHostRead(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	sdsaasClient, err := meta.(conns.ClientSession).SdsaasV1()
+	endpoint := d.Get("sds_endpoint").(string)
+	sdsaasClient, err := getSDSConfigClient(meta, endpoint)
 	if err != nil {
 		tfErr := flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_sds_host", "read", "initialize-client")
 		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
@@ -244,7 +250,8 @@ func resourceIBMSdsHostRead(context context.Context, d *schema.ResourceData, met
 }
 
 func resourceIBMSdsHostUpdate(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	sdsaasClient, err := meta.(conns.ClientSession).SdsaasV1()
+	endpoint := d.Get("sds_endpoint").(string)
+	sdsaasClient, err := getSDSConfigClient(meta, endpoint)
 	if err != nil {
 		tfErr := flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_sds_host", "update", "initialize-client")
 		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
@@ -282,7 +289,8 @@ func resourceIBMSdsHostUpdate(context context.Context, d *schema.ResourceData, m
 }
 
 func resourceIBMSdsHostDelete(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	sdsaasClient, err := meta.(conns.ClientSession).SdsaasV1()
+	endpoint := d.Get("sds_endpoint").(string)
+	sdsaasClient, err := getSDSConfigClient(meta, endpoint)
 	if err != nil {
 		tfErr := flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_sds_host", "delete", "initialize-client")
 		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())

--- a/ibm/service/sdsaas/resource_ibm_sds_host_test.go
+++ b/ibm/service/sdsaas/resource_ibm_sds_host_test.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2024 All Rights Reserved.
+// Copyright IBM Corp. 2025 All Rights Reserved.
 // Licensed under the Mozilla Public License v2.0
 
 package sdsaas_test
@@ -105,7 +105,7 @@ func testAccCheckIBMSdsHostConfig(name string, nqn string) string {
 		resource "ibm_sds_host" "sds_host_instance" {
 			name = "%s"
 			nqn = "%s"
-			volume_mappings {
+			volumes {
 				volume_name = ibm_sds_volume.sds_volume_instance.name
 				volume_id = ibm_sds_volume.sds_volume_instance.id
 			}

--- a/ibm/service/sdsaas/resource_ibm_sds_host_test.go
+++ b/ibm/service/sdsaas/resource_ibm_sds_host_test.go
@@ -1,0 +1,274 @@
+// Copyright IBM Corp. 2024 All Rights Reserved.
+// Licensed under the Mozilla Public License v2.0
+
+package sdsaas_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	acc "github.com/IBM-Cloud/terraform-provider-ibm/ibm/acctest"
+	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/conns"
+	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/sdsaas"
+	"github.com/IBM/go-sdk-core/v5/core"
+	"github.com/IBM/sds-go-sdk/sdsaasv1"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestAccIBMSdsHostBasic(t *testing.T) {
+	var conf sdsaasv1.Host
+	nqn := "nqn.2014-06.org:9345"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { acc.TestAccPreCheck(t) },
+		Providers:    acc.TestAccProviders,
+		CheckDestroy: testAccCheckIBMSdsHostDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccCheckIBMSdsHostConfigBasic(nqn),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckIBMSdsHostExists("ibm_sds_host.sds_host_instance", conf),
+					resource.TestCheckResourceAttr("ibm_sds_host.sds_host_instance", "nqn", nqn),
+				),
+			},
+		},
+	})
+}
+
+// NOTE: This test maps a volume to a host. When the test attempts to cleanup the host, the host is still mapped to
+// a volume. At this time, the API doesn't support the unmapping between the host and volume at the same time as a delete meaning
+// this can't be completed solely through terraform.
+
+// func TestAccIBMSdsHostAllArgs(t *testing.T) {
+// 	var conf sdsaasv1.Host
+// 	nqn := "nqn.2014-06.org:9345"
+// 	name := "terraform-host-name"
+// 	nameUpdate := "terraform-host-name-updated"
+
+// 	resource.Test(t, resource.TestCase{
+// 		PreCheck:     func() { acc.TestAccPreCheck(t) },
+// 		Providers:    acc.TestAccProviders,
+// 		CheckDestroy: testAccCheckIBMSdsHostDestroy,
+// 		Steps: []resource.TestStep{
+// 			resource.TestStep{
+// 				Config: testAccCheckIBMSdsHostConfig(name, nqn),
+// 				Check: resource.ComposeAggregateTestCheckFunc(
+// 					testAccCheckIBMSdsHostExists("ibm_sds_host.sds_host_instance", conf),
+// 					resource.TestCheckResourceAttr("ibm_sds_host.sds_host_instance", "name", name),
+// 					resource.TestCheckResourceAttr("ibm_sds_host.sds_host_instance", "nqn", nqn),
+// 				),
+// 			},
+// 			resource.TestStep{
+// 				Config: testAccCheckIBMSdsHostConfig(nameUpdate, nqn),
+// 				Check: resource.ComposeAggregateTestCheckFunc(
+// 					resource.TestCheckResourceAttr("ibm_sds_host.sds_host_instance", "name", nameUpdate),
+// 					resource.TestCheckResourceAttr("ibm_sds_host.sds_host_instance", "nqn", nqn),
+// 				),
+// 			},
+// 			resource.TestStep{
+// 				ResourceName:      "ibm_sds_host.sds_host",
+// 				ImportState:       true,
+// 				ImportStateVerify: true,
+// 			},
+// 		},
+// 	})
+// }
+
+func testAccCheckIBMSdsHostConfigBasic(nqn string) string {
+	return fmt.Sprintf(`
+		resource "ibm_sds_volume" "sds_volume_instance" {
+			capacity = 10
+			name = "my-volume"
+		}
+		resource "ibm_sds_host" "sds_host_instance" {
+			nqn = "%s"
+			name = "my-host"
+		}
+	`, nqn)
+}
+
+func testAccCheckIBMSdsHostConfig(name string, nqn string) string {
+	return fmt.Sprintf(`
+
+		output "ibm_sds_volume" {
+			value       = [ibm_sds_volume.sds_volume_instance]
+			description = "sds_volume resource instance"
+		}
+		resource "ibm_sds_volume" "sds_volume_instance" {
+			capacity = 10
+			name = "my-volume"
+		}
+
+		resource "ibm_sds_host" "sds_host_instance" {
+			name = "%s"
+			nqn = "%s"
+			volume_mappings {
+				volume_name = ibm_sds_volume.sds_volume_instance.name
+				volume_id = ibm_sds_volume.sds_volume_instance.id
+			}
+		}
+	`, name, nqn)
+}
+
+func testAccCheckIBMSdsHostExists(n string, obj sdsaasv1.Host) resource.TestCheckFunc {
+
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+
+		sdsaasClient, err := acc.TestAccProvider.Meta().(conns.ClientSession).SdsaasV1()
+		if err != nil {
+			return err
+		}
+
+		hostOptions := &sdsaasv1.HostOptions{}
+
+		hostOptions.SetHostID(rs.Primary.ID)
+
+		host, _, err := sdsaasClient.Host(hostOptions)
+		if err != nil {
+			return err
+		}
+
+		obj = *host
+		return nil
+	}
+}
+
+func testAccCheckIBMSdsHostDestroy(s *terraform.State) error {
+	sdsaasClient, err := acc.TestAccProvider.Meta().(conns.ClientSession).SdsaasV1()
+	if err != nil {
+		return err
+	}
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "ibm_sds_host" {
+			continue
+		}
+
+		hostOptions := &sdsaasv1.HostOptions{}
+
+		hostOptions.SetHostID(rs.Primary.ID)
+
+		// Try to find the key
+		_, response, err := sdsaasClient.Host(hostOptions)
+
+		if err == nil {
+			return fmt.Errorf("sds_host still exists: %s", rs.Primary.ID)
+		} else if response.StatusCode != 404 {
+			return fmt.Errorf("Error checking for sds_host (%s) has been destroyed: %s", rs.Primary.ID, err)
+		}
+	}
+
+	return nil
+}
+
+func TestResourceIBMSdsHostVolumeMappingReferenceToMap(t *testing.T) {
+	checkResult := func(result map[string]interface{}) {
+		networkInfoReferenceModel := make(map[string]interface{})
+		networkInfoReferenceModel["gateway_ip"] = "testString"
+		networkInfoReferenceModel["port"] = int(38)
+
+		storageIdentifiersReferenceModel := make(map[string]interface{})
+		storageIdentifiersReferenceModel["id"] = "testString"
+		storageIdentifiersReferenceModel["namespace_id"] = int(38)
+		storageIdentifiersReferenceModel["namespace_uuid"] = "testString"
+		storageIdentifiersReferenceModel["network_info"] = []map[string]interface{}{networkInfoReferenceModel}
+
+		model := make(map[string]interface{})
+		model["status"] = "testString"
+		model["volume_id"] = "testString"
+		model["volume_name"] = "testString"
+		model["storage_identifiers"] = []map[string]interface{}{storageIdentifiersReferenceModel}
+
+		assert.Equal(t, result, model)
+	}
+
+	networkInfoReferenceModel := new(sdsaasv1.NetworkInfoReference)
+	networkInfoReferenceModel.GatewayIP = core.StringPtr("testString")
+	networkInfoReferenceModel.Port = core.Int64Ptr(int64(38))
+
+	storageIdentifiersReferenceModel := new(sdsaasv1.StorageIdentifiersReference)
+	storageIdentifiersReferenceModel.ID = core.StringPtr("testString")
+	storageIdentifiersReferenceModel.NamespaceID = core.Int64Ptr(int64(38))
+	storageIdentifiersReferenceModel.NamespaceUUID = core.StringPtr("testString")
+	storageIdentifiersReferenceModel.NetworkInfo = []sdsaasv1.NetworkInfoReference{*networkInfoReferenceModel}
+
+	model := new(sdsaasv1.VolumeMappingReference)
+	model.Status = core.StringPtr("testString")
+	model.VolumeID = core.StringPtr("testString")
+	model.VolumeName = core.StringPtr("testString")
+	model.StorageIdentifiers = storageIdentifiersReferenceModel
+
+	result, err := sdsaas.ResourceIBMSdsHostVolumeMappingReferenceToMap(model)
+	assert.Nil(t, err)
+	checkResult(result)
+}
+
+func TestResourceIBMSdsHostStorageIdentifiersReferenceToMap(t *testing.T) {
+	checkResult := func(result map[string]interface{}) {
+		networkInfoReferenceModel := make(map[string]interface{})
+		networkInfoReferenceModel["gateway_ip"] = "testString"
+		networkInfoReferenceModel["port"] = int(38)
+
+		model := make(map[string]interface{})
+		model["id"] = "testString"
+		model["namespace_id"] = int(38)
+		model["namespace_uuid"] = "testString"
+		model["network_info"] = []map[string]interface{}{networkInfoReferenceModel}
+
+		assert.Equal(t, result, model)
+	}
+
+	networkInfoReferenceModel := new(sdsaasv1.NetworkInfoReference)
+	networkInfoReferenceModel.GatewayIP = core.StringPtr("testString")
+	networkInfoReferenceModel.Port = core.Int64Ptr(int64(38))
+
+	model := new(sdsaasv1.StorageIdentifiersReference)
+	model.ID = core.StringPtr("testString")
+	model.NamespaceID = core.Int64Ptr(int64(38))
+	model.NamespaceUUID = core.StringPtr("testString")
+	model.NetworkInfo = []sdsaasv1.NetworkInfoReference{*networkInfoReferenceModel}
+
+	result, err := sdsaas.ResourceIBMSdsHostStorageIdentifiersReferenceToMap(model)
+	assert.Nil(t, err)
+	checkResult(result)
+}
+
+func TestResourceIBMSdsHostNetworkInfoReferenceToMap(t *testing.T) {
+	checkResult := func(result map[string]interface{}) {
+		model := make(map[string]interface{})
+		model["gateway_ip"] = "testString"
+		model["port"] = int(38)
+
+		assert.Equal(t, result, model)
+	}
+
+	model := new(sdsaasv1.NetworkInfoReference)
+	model.GatewayIP = core.StringPtr("testString")
+	model.Port = core.Int64Ptr(int64(38))
+
+	result, err := sdsaas.ResourceIBMSdsHostNetworkInfoReferenceToMap(model)
+	assert.Nil(t, err)
+	checkResult(result)
+}
+
+func TestResourceIBMSdsHostMapToVolumeMappingIdentity(t *testing.T) {
+	checkResult := func(result *sdsaasv1.VolumeMappingIdentity) {
+		model := new(sdsaasv1.VolumeMappingIdentity)
+		model.VolumeID = core.StringPtr("testString")
+
+		assert.Equal(t, result, model)
+	}
+
+	model := make(map[string]interface{})
+	model["volume_id"] = "testString"
+
+	result, err := sdsaas.ResourceIBMSdsHostMapToVolumeMappingIdentity(model)
+	assert.Nil(t, err)
+	checkResult(result)
+}

--- a/ibm/service/sdsaas/resource_ibm_sds_volume.go
+++ b/ibm/service/sdsaas/resource_ibm_sds_volume.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2024 All Rights Reserved.
+// Copyright IBM Corp. 2025 All Rights Reserved.
 // Licensed under the Mozilla Public License v2.0
 
 /*
@@ -48,7 +48,17 @@ func ResourceIBMSdsVolume() *schema.Resource {
 				ValidateFunc: validate.InvokeValidator("ibm_sds_volume", "name"),
 				Description:  "The name of the volume.",
 			},
-			"host_mappings": &schema.Schema{
+			"bandwidth": &schema.Schema{
+				Type:        schema.TypeInt,
+				Computed:    true,
+				Description: "The maximum bandwidth (in megabits per second) for the volume.",
+			},
+			"created_at": &schema.Schema{
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The date and time that the volume was created.",
+			},
+			"hosts": &schema.Schema{
 				Type:        schema.TypeList,
 				Computed:    true,
 				Description: "List of host details that volume is mapped to.",
@@ -75,10 +85,10 @@ func ResourceIBMSdsVolume() *schema.Resource {
 					},
 				},
 			},
-			"created_at": &schema.Schema{
-				Type:        schema.TypeString,
+			"iops": &schema.Schema{
+				Type:        schema.TypeInt,
 				Computed:    true,
-				Description: "The date and time that the volume was created.",
+				Description: "Iops The maximum I/O operations per second (IOPS) for this volume.",
 			},
 			"resource_type": &schema.Schema{
 				Type:        schema.TypeString,
@@ -190,24 +200,36 @@ func resourceIBMSdsVolumeRead(context context.Context, d *schema.ResourceData, m
 			return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_sds_volume", "read", "set-name").GetDiag()
 		}
 	}
-	if !core.IsNil(volume.HostMappings) {
-		hostMappings := []map[string]interface{}{}
-		for _, hostMappingsItem := range volume.HostMappings {
-			hostMappingsItemMap, err := ResourceIBMSdsVolumeHostMappingToMap(&hostMappingsItem) // #nosec G601
-			if err != nil {
-				return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_sds_volume", "read", "host_mappings-to-map").GetDiag()
-			}
-			hostMappings = append(hostMappings, hostMappingsItemMap)
-		}
-		if err = d.Set("host_mappings", hostMappings); err != nil {
-			err = fmt.Errorf("Error setting host_mappings: %s", err)
-			return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_sds_volume", "read", "set-host_mappings").GetDiag()
+	if !core.IsNil(volume.Bandwidth) {
+		if err = d.Set("bandwidth", flex.IntValue(volume.Bandwidth)); err != nil {
+			err = fmt.Errorf("Error setting bandwidth: %s", err)
+			return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_sds_volume", "read", "set-bandwidth").GetDiag()
 		}
 	}
 	if !core.IsNil(volume.CreatedAt) {
 		if err = d.Set("created_at", volume.CreatedAt); err != nil {
 			err = fmt.Errorf("Error setting created_at: %s", err)
 			return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_sds_volume", "read", "set-created_at").GetDiag()
+		}
+	}
+	if !core.IsNil(volume.Hosts) {
+		hosts := []map[string]interface{}{}
+		for _, hostsItem := range volume.Hosts {
+			hostsItemMap, err := ResourceIBMSdsVolumeHostMappingToMap(&hostsItem) // #nosec G601
+			if err != nil {
+				return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_sds_volume", "read", "hosts-to-map").GetDiag()
+			}
+			hosts = append(hosts, hostsItemMap)
+		}
+		if err = d.Set("hosts", hosts); err != nil {
+			err = fmt.Errorf("Error setting hosts: %s", err)
+			return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_sds_volume", "read", "set-hosts").GetDiag()
+		}
+	}
+	if !core.IsNil(volume.Iops) {
+		if err = d.Set("iops", flex.IntValue(volume.Iops)); err != nil {
+			err = fmt.Errorf("Error setting iops: %s", err)
+			return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_sds_volume", "read", "set-iops").GetDiag()
 		}
 	}
 	if !core.IsNil(volume.ResourceType) {

--- a/ibm/service/sdsaas/resource_ibm_sds_volume.go
+++ b/ibm/service/sdsaas/resource_ibm_sds_volume.go
@@ -1,0 +1,330 @@
+// Copyright IBM Corp. 2024 All Rights Reserved.
+// Licensed under the Mozilla Public License v2.0
+
+/*
+ * IBM OpenAPI Terraform Generator Version: 3.96.0-d6dec9d7-20241008-212902
+ */
+
+package sdsaas
+
+import (
+	"context"
+	"fmt"
+	"log"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/conns"
+	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/flex"
+	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/validate"
+	"github.com/IBM/go-sdk-core/v5/core"
+	"github.com/IBM/sds-go-sdk/sdsaasv1"
+)
+
+func ResourceIBMSdsVolume() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceIBMSdsVolumeCreate,
+		ReadContext:   resourceIBMSdsVolumeRead,
+		UpdateContext: resourceIBMSdsVolumeUpdate,
+		DeleteContext: resourceIBMSdsVolumeDelete,
+		Importer:      &schema.ResourceImporter{},
+
+		Schema: map[string]*schema.Schema{
+			"hostnqnstring": &schema.Schema{
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validate.InvokeValidator("ibm_sds_volume", "hostnqnstring"),
+				Description:  "The host nqn.",
+			},
+			"capacity": &schema.Schema{
+				Type:        schema.TypeInt,
+				Required:    true,
+				Description: "The capacity of the volume (in gigabytes).",
+			},
+			"name": &schema.Schema{
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validate.InvokeValidator("ibm_sds_volume", "name"),
+				Description:  "The name of the volume.",
+			},
+			"host_mappings": &schema.Schema{
+				Type:        schema.TypeList,
+				Computed:    true,
+				Description: "List of host details that volume is mapped to.",
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"host_id": &schema.Schema{
+							Type:        schema.TypeString,
+							Optional:    true,
+							Computed:    true,
+							Description: "Unique identifer of the host.",
+						},
+						"host_name": &schema.Schema{
+							Type:        schema.TypeString,
+							Optional:    true,
+							Computed:    true,
+							Description: "Unique name of the host.",
+						},
+						"host_nqn": &schema.Schema{
+							Type:        schema.TypeString,
+							Optional:    true,
+							Computed:    true,
+							Description: "The NQN of the host configured in customer's environment.",
+						},
+					},
+				},
+			},
+			"created_at": &schema.Schema{
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The date and time that the volume was created.",
+			},
+			"resource_type": &schema.Schema{
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The resource type of the volume.",
+			},
+			"status": &schema.Schema{
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The current status of the volume.",
+			},
+			"status_reasons": &schema.Schema{
+				Type:        schema.TypeList,
+				Computed:    true,
+				Description: "Reasons for the current status of the volume.",
+				Elem:        &schema.Schema{Type: schema.TypeString},
+			},
+		},
+	}
+}
+
+func ResourceIBMSdsVolumeValidator() *validate.ResourceValidator {
+	validateSchema := make([]validate.ValidateSchema, 0)
+	validateSchema = append(validateSchema,
+		validate.ValidateSchema{
+			Identifier:                 "hostnqnstring",
+			ValidateFunctionIdentifier: validate.ValidateRegexpLen,
+			Type:                       validate.TypeString,
+			Optional:                   true,
+			Regexp:                     `^nqn\.\d{4}-\d{2}\.[a-z0-9-]+(?:\.[a-z0-9-]+)*:[a-zA-Z0-9.\-:]+$`,
+			MinValueLength:             1,
+			MaxValueLength:             200,
+		},
+		validate.ValidateSchema{
+			Identifier:                 "name",
+			ValidateFunctionIdentifier: validate.ValidateRegexpLen,
+			Type:                       validate.TypeString,
+			Optional:                   true,
+			Regexp:                     `^.*$`,
+			MinValueLength:             1,
+			MaxValueLength:             63,
+		},
+	)
+
+	resourceValidator := validate.ResourceValidator{ResourceName: "ibm_sds_volume", Schema: validateSchema}
+	return &resourceValidator
+}
+
+func resourceIBMSdsVolumeCreate(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	sdsaasClient, err := meta.(conns.ClientSession).SdsaasV1()
+	if err != nil {
+		tfErr := flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_sds_volume", "create", "initialize-client")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
+	}
+
+	volumeCreateOptions := &sdsaasv1.VolumeCreateOptions{}
+
+	volumeCreateOptions.SetCapacity(int64(d.Get("capacity").(int)))
+	if _, ok := d.GetOk("name"); ok {
+		volumeCreateOptions.SetName(d.Get("name").(string))
+	}
+	if _, ok := d.GetOk("hostnqnstring"); ok {
+		volumeCreateOptions.SetHostnqnstring(d.Get("hostnqnstring").(string))
+	}
+
+	volume, _, err := sdsaasClient.VolumeCreateWithContext(context, volumeCreateOptions)
+	if err != nil {
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("VolumeCreateWithContext failed: %s", err.Error()), "ibm_sds_volume", "create")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
+	}
+
+	d.SetId(*volume.ID)
+
+	return resourceIBMSdsVolumeRead(context, d, meta)
+}
+
+func resourceIBMSdsVolumeRead(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	sdsaasClient, err := meta.(conns.ClientSession).SdsaasV1()
+	if err != nil {
+		tfErr := flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_sds_volume", "read", "initialize-client")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
+	}
+
+	volumeOptions := &sdsaasv1.VolumeOptions{}
+
+	volumeOptions.SetVolumeID(d.Id())
+
+	volume, response, err := sdsaasClient.VolumeWithContext(context, volumeOptions)
+	if err != nil {
+		if response != nil && response.StatusCode == 404 {
+			d.SetId("")
+			return nil
+		}
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("VolumeWithContext failed: %s", err.Error()), "ibm_sds_volume", "read")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
+	}
+
+	if err = d.Set("capacity", flex.IntValue(volume.Capacity)); err != nil {
+		err = fmt.Errorf("Error setting capacity: %s", err)
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_sds_volume", "read", "set-capacity").GetDiag()
+	}
+	if !core.IsNil(volume.Name) {
+		if err = d.Set("name", volume.Name); err != nil {
+			err = fmt.Errorf("Error setting name: %s", err)
+			return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_sds_volume", "read", "set-name").GetDiag()
+		}
+	}
+	if !core.IsNil(volume.HostMappings) {
+		hostMappings := []map[string]interface{}{}
+		for _, hostMappingsItem := range volume.HostMappings {
+			hostMappingsItemMap, err := ResourceIBMSdsVolumeHostMappingToMap(&hostMappingsItem) // #nosec G601
+			if err != nil {
+				return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_sds_volume", "read", "host_mappings-to-map").GetDiag()
+			}
+			hostMappings = append(hostMappings, hostMappingsItemMap)
+		}
+		if err = d.Set("host_mappings", hostMappings); err != nil {
+			err = fmt.Errorf("Error setting host_mappings: %s", err)
+			return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_sds_volume", "read", "set-host_mappings").GetDiag()
+		}
+	}
+	if !core.IsNil(volume.CreatedAt) {
+		if err = d.Set("created_at", volume.CreatedAt); err != nil {
+			err = fmt.Errorf("Error setting created_at: %s", err)
+			return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_sds_volume", "read", "set-created_at").GetDiag()
+		}
+	}
+	if !core.IsNil(volume.ResourceType) {
+		if err = d.Set("resource_type", volume.ResourceType); err != nil {
+			err = fmt.Errorf("Error setting resource_type: %s", err)
+			return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_sds_volume", "read", "set-resource_type").GetDiag()
+		}
+	}
+	if !core.IsNil(volume.Status) {
+		if err = d.Set("status", volume.Status); err != nil {
+			err = fmt.Errorf("Error setting status: %s", err)
+			return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_sds_volume", "read", "set-status").GetDiag()
+		}
+	}
+	if !core.IsNil(volume.StatusReasons) {
+		if err = d.Set("status_reasons", volume.StatusReasons); err != nil {
+			err = fmt.Errorf("Error setting status_reasons: %s", err)
+			return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_sds_volume", "read", "set-status_reasons").GetDiag()
+		}
+	}
+
+	return nil
+}
+
+func resourceIBMSdsVolumeUpdate(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	sdsaasClient, err := meta.(conns.ClientSession).SdsaasV1()
+	if err != nil {
+		tfErr := flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_sds_volume", "update", "initialize-client")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
+	}
+
+	volumeUpdateOptions := &sdsaasv1.VolumeUpdateOptions{}
+
+	volumeUpdateOptions.SetVolumeID(d.Id())
+
+	hasChange := false
+
+	patchVals := &sdsaasv1.VolumePatch{}
+	if d.HasChange("capacity") {
+		newCapacity := int64(d.Get("capacity").(int))
+		patchVals.Capacity = &newCapacity
+		hasChange = true
+	}
+	if d.HasChange("name") {
+		newName := d.Get("name").(string)
+		patchVals.Name = &newName
+		hasChange = true
+	}
+
+	if hasChange {
+		// Fields with `nil` values are omitted from the generic map,
+		// so we need to re-add them to support removing arguments
+		// in merge-patch operations sent to the service.
+		volumeUpdateOptions.VolumePatch = ResourceIBMSdsVolumeVolumePatchAsPatch(patchVals, d)
+
+		_, _, err = sdsaasClient.VolumeUpdateWithContext(context, volumeUpdateOptions)
+		if err != nil {
+			tfErr := flex.TerraformErrorf(err, fmt.Sprintf("VolumeUpdateWithContext failed: %s", err.Error()), "ibm_sds_volume", "update")
+			log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+			return tfErr.GetDiag()
+		}
+	}
+
+	return resourceIBMSdsVolumeRead(context, d, meta)
+}
+
+func resourceIBMSdsVolumeDelete(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	sdsaasClient, err := meta.(conns.ClientSession).SdsaasV1()
+	if err != nil {
+		tfErr := flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_sds_volume", "delete", "initialize-client")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
+	}
+
+	volumeDeleteOptions := &sdsaasv1.VolumeDeleteOptions{}
+
+	volumeDeleteOptions.SetVolumeID(d.Id())
+
+	_, err = sdsaasClient.VolumeDeleteWithContext(context, volumeDeleteOptions)
+	if err != nil {
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("VolumeDeleteWithContext failed: %s", err.Error()), "ibm_sds_volume", "delete")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
+	}
+
+	d.SetId("")
+
+	return nil
+}
+
+func ResourceIBMSdsVolumeHostMappingToMap(model *sdsaasv1.HostMapping) (map[string]interface{}, error) {
+	modelMap := make(map[string]interface{})
+	if model.HostID != nil {
+		modelMap["host_id"] = *model.HostID
+	}
+	if model.HostName != nil {
+		modelMap["host_name"] = *model.HostName
+	}
+	if model.HostNqn != nil {
+		modelMap["host_nqn"] = *model.HostNqn
+	}
+	return modelMap, nil
+}
+
+func ResourceIBMSdsVolumeVolumePatchAsPatch(patchVals *sdsaasv1.VolumePatch, d *schema.ResourceData) map[string]interface{} {
+	patch, _ := patchVals.AsPatch()
+	var path string
+
+	path = "capacity"
+	if _, exists := d.GetOk(path); d.HasChange(path) && !exists {
+		patch["capacity"] = nil
+	}
+	path = "name"
+	if _, exists := d.GetOk(path); d.HasChange(path) && !exists {
+		patch["name"] = nil
+	}
+
+	return patch
+}

--- a/ibm/service/sdsaas/resource_ibm_sds_volume.go
+++ b/ibm/service/sdsaas/resource_ibm_sds_volume.go
@@ -31,6 +31,11 @@ func ResourceIBMSdsVolume() *schema.Resource {
 		Importer:      &schema.ResourceImporter{},
 
 		Schema: map[string]*schema.Schema{
+			"sds_endpoint": &schema.Schema{
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "The endpoint to use for operations",
+			},
 			"hostnqnstring": &schema.Schema{
 				Type:         schema.TypeString,
 				Optional:     true,
@@ -110,6 +115,16 @@ func ResourceIBMSdsVolume() *schema.Resource {
 	}
 }
 
+func getSDSConfigClient(meta interface{}, endpoint string) (*sdsaasv1.SdsaasV1, error) {
+	sdsconfigClient, err := meta.(conns.ClientSession).SdsaasV1()
+	if err != nil {
+		return nil, err
+	}
+	url := conns.EnvFallBack([]string{"IBMCLOUD_SDS_ENDPOINT"}, endpoint)
+	sdsconfigClient.Service.Options.URL = url
+	return sdsconfigClient, nil
+}
+
 func ResourceIBMSdsVolumeValidator() *validate.ResourceValidator {
 	validateSchema := make([]validate.ValidateSchema, 0)
 	validateSchema = append(validateSchema,
@@ -138,7 +153,8 @@ func ResourceIBMSdsVolumeValidator() *validate.ResourceValidator {
 }
 
 func resourceIBMSdsVolumeCreate(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	sdsaasClient, err := meta.(conns.ClientSession).SdsaasV1()
+	endpoint := d.Get("sds_endpoint").(string)
+	sdsaasClient, err := getSDSConfigClient(meta, endpoint)
 	if err != nil {
 		tfErr := flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_sds_volume", "create", "initialize-client")
 		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
@@ -168,7 +184,8 @@ func resourceIBMSdsVolumeCreate(context context.Context, d *schema.ResourceData,
 }
 
 func resourceIBMSdsVolumeRead(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	sdsaasClient, err := meta.(conns.ClientSession).SdsaasV1()
+	endpoint := d.Get("sds_endpoint").(string)
+	sdsaasClient, err := getSDSConfigClient(meta, endpoint)
 	if err != nil {
 		tfErr := flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_sds_volume", "read", "initialize-client")
 		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
@@ -255,7 +272,8 @@ func resourceIBMSdsVolumeRead(context context.Context, d *schema.ResourceData, m
 }
 
 func resourceIBMSdsVolumeUpdate(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	sdsaasClient, err := meta.(conns.ClientSession).SdsaasV1()
+	endpoint := d.Get("sds_endpoint").(string)
+	sdsaasClient, err := getSDSConfigClient(meta, endpoint)
 	if err != nil {
 		tfErr := flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_sds_volume", "update", "initialize-client")
 		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
@@ -298,7 +316,8 @@ func resourceIBMSdsVolumeUpdate(context context.Context, d *schema.ResourceData,
 }
 
 func resourceIBMSdsVolumeDelete(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	sdsaasClient, err := meta.(conns.ClientSession).SdsaasV1()
+	endpoint := d.Get("sds_endpoint").(string)
+	sdsaasClient, err := getSDSConfigClient(meta, endpoint)
 	if err != nil {
 		tfErr := flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_sds_volume", "delete", "initialize-client")
 		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())

--- a/ibm/service/sdsaas/resource_ibm_sds_volume_test.go
+++ b/ibm/service/sdsaas/resource_ibm_sds_volume_test.go
@@ -24,7 +24,6 @@ func TestAccIBMSdsVolumeBasic(t *testing.T) {
 	var conf sdsaasv1.Volume
 	capacity := fmt.Sprintf("%d", acctest.RandIntRange(1, 5))
 	name := "terraform-test-1"
-	capacityUpdate := fmt.Sprintf("%d", acctest.RandIntRange(6, 10))
 	nameUpdate := "terraform-test-name-updated"
 
 	resource.Test(t, resource.TestCase{
@@ -41,16 +40,9 @@ func TestAccIBMSdsVolumeBasic(t *testing.T) {
 				),
 			},
 			resource.TestStep{
-				Config: testAccCheckIBMSdsVolumeConfigBasic(capacityUpdate, name),
+				Config: testAccCheckIBMSdsVolumeConfigBasic(capacity, nameUpdate),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr("ibm_sds_volume.sds_volume_instance", "capacity", capacityUpdate),
-					resource.TestCheckResourceAttr("ibm_sds_volume.sds_volume_instance", "name", name),
-				),
-			},
-			resource.TestStep{
-				Config: testAccCheckIBMSdsVolumeConfigBasic(capacityUpdate, nameUpdate),
-				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr("ibm_sds_volume.sds_volume_instance", "capacity", capacityUpdate),
+					resource.TestCheckResourceAttr("ibm_sds_volume.sds_volume_instance", "capacity", capacity),
 					resource.TestCheckResourceAttr("ibm_sds_volume.sds_volume_instance", "name", nameUpdate),
 				),
 			},
@@ -63,7 +55,6 @@ func TestAccIBMSdsVolumeAllArgs(t *testing.T) {
 	hostnqnstring := "nqn.2014-06.org:9345"
 	capacity := fmt.Sprintf("%d", acctest.RandIntRange(1, 5))
 	name := "terraform-test-name-1"
-	capacityUpdate := fmt.Sprintf("%d", acctest.RandIntRange(6, 10))
 	nameUpdate := "terraform-test-name-updated"
 
 	resource.Test(t, resource.TestCase{
@@ -81,18 +72,10 @@ func TestAccIBMSdsVolumeAllArgs(t *testing.T) {
 				),
 			},
 			resource.TestStep{
-				Config: testAccCheckIBMSdsVolumeConfig(hostnqnstring, capacityUpdate, name),
+				Config: testAccCheckIBMSdsVolumeConfig(hostnqnstring, capacity, nameUpdate),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr("ibm_sds_volume.sds_volume_instance", "hostnqnstring", hostnqnstring),
-					resource.TestCheckResourceAttr("ibm_sds_volume.sds_volume_instance", "capacity", capacityUpdate),
-					resource.TestCheckResourceAttr("ibm_sds_volume.sds_volume_instance", "name", name),
-				),
-			},
-			resource.TestStep{
-				Config: testAccCheckIBMSdsVolumeConfig(hostnqnstring, capacityUpdate, nameUpdate),
-				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr("ibm_sds_volume.sds_volume_instance", "hostnqnstring", hostnqnstring),
-					resource.TestCheckResourceAttr("ibm_sds_volume.sds_volume_instance", "capacity", capacityUpdate),
+					resource.TestCheckResourceAttr("ibm_sds_volume.sds_volume_instance", "capacity", capacity),
 					resource.TestCheckResourceAttr("ibm_sds_volume.sds_volume_instance", "name", nameUpdate),
 				),
 			},

--- a/ibm/service/sdsaas/resource_ibm_sds_volume_test.go
+++ b/ibm/service/sdsaas/resource_ibm_sds_volume_test.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2024 All Rights Reserved.
+// Copyright IBM Corp. 2025 All Rights Reserved.
 // Licensed under the Mozilla Public License v2.0
 
 package sdsaas_test

--- a/ibm/service/sdsaas/resource_ibm_sds_volume_test.go
+++ b/ibm/service/sdsaas/resource_ibm_sds_volume_test.go
@@ -1,0 +1,202 @@
+// Copyright IBM Corp. 2024 All Rights Reserved.
+// Licensed under the Mozilla Public License v2.0
+
+package sdsaas_test
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	acc "github.com/IBM-Cloud/terraform-provider-ibm/ibm/acctest"
+	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/conns"
+	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/sdsaas"
+	"github.com/IBM/go-sdk-core/v5/core"
+	"github.com/stretchr/testify/assert"
+	"github.com/IBM/sds-go-sdk/sdsaasv1"
+)
+
+func TestAccIBMSdsVolumeBasic(t *testing.T) {
+	var conf sdsaasv1.Volume
+	capacity := fmt.Sprintf("%d", acctest.RandIntRange(1, 5))
+	name := "terraform-test-1"
+	capacityUpdate := fmt.Sprintf("%d", acctest.RandIntRange(6, 10))
+	nameUpdate := "terraform-test-name-updated"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { acc.TestAccPreCheck(t) },
+		Providers:    acc.TestAccProviders,
+		CheckDestroy: testAccCheckIBMSdsVolumeDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccCheckIBMSdsVolumeConfigBasic(capacity, name),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckIBMSdsVolumeExists("ibm_sds_volume.sds_volume_instance", conf),
+					resource.TestCheckResourceAttr("ibm_sds_volume.sds_volume_instance", "capacity", capacity),
+					resource.TestCheckResourceAttr("ibm_sds_volume.sds_volume_instance", "name", name),
+				),
+			},
+			resource.TestStep{
+				Config: testAccCheckIBMSdsVolumeConfigBasic(capacityUpdate, name),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("ibm_sds_volume.sds_volume_instance", "capacity", capacityUpdate),
+					resource.TestCheckResourceAttr("ibm_sds_volume.sds_volume_instance", "name", name),
+				),
+			},
+			resource.TestStep{
+				Config: testAccCheckIBMSdsVolumeConfigBasic(capacityUpdate, nameUpdate),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("ibm_sds_volume.sds_volume_instance", "capacity", capacityUpdate),
+					resource.TestCheckResourceAttr("ibm_sds_volume.sds_volume_instance", "name", nameUpdate),
+				),
+			},
+		},
+	})
+}
+
+func TestAccIBMSdsVolumeAllArgs(t *testing.T) {
+	var conf sdsaasv1.Volume
+	hostnqnstring := "nqn.2014-06.org:9345"
+	capacity := fmt.Sprintf("%d", acctest.RandIntRange(1, 5))
+	name := "terraform-test-name-1"
+	capacityUpdate := fmt.Sprintf("%d", acctest.RandIntRange(6, 10))
+	nameUpdate := "terraform-test-name-updated"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { acc.TestAccPreCheck(t) },
+		Providers:    acc.TestAccProviders,
+		CheckDestroy: testAccCheckIBMSdsVolumeDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccCheckIBMSdsVolumeConfig(hostnqnstring, capacity, name),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckIBMSdsVolumeExists("ibm_sds_volume.sds_volume_instance", conf),
+					resource.TestCheckResourceAttr("ibm_sds_volume.sds_volume_instance", "hostnqnstring", hostnqnstring),
+					resource.TestCheckResourceAttr("ibm_sds_volume.sds_volume_instance", "capacity", capacity),
+					resource.TestCheckResourceAttr("ibm_sds_volume.sds_volume_instance", "name", name),
+				),
+			},
+			resource.TestStep{
+				Config: testAccCheckIBMSdsVolumeConfig(hostnqnstring, capacityUpdate, name),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("ibm_sds_volume.sds_volume_instance", "hostnqnstring", hostnqnstring),
+					resource.TestCheckResourceAttr("ibm_sds_volume.sds_volume_instance", "capacity", capacityUpdate),
+					resource.TestCheckResourceAttr("ibm_sds_volume.sds_volume_instance", "name", name),
+				),
+			},
+			resource.TestStep{
+				Config: testAccCheckIBMSdsVolumeConfig(hostnqnstring, capacityUpdate, nameUpdate),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("ibm_sds_volume.sds_volume_instance", "hostnqnstring", hostnqnstring),
+					resource.TestCheckResourceAttr("ibm_sds_volume.sds_volume_instance", "capacity", capacityUpdate),
+					resource.TestCheckResourceAttr("ibm_sds_volume.sds_volume_instance", "name", nameUpdate),
+				),
+			},
+			resource.TestStep{
+				ResourceName: "ibm_sds_volume.sds_volume_instance",
+				ImportState:  true,
+			},
+		},
+	})
+}
+
+func testAccCheckIBMSdsVolumeConfigBasic(capacity string, name string) string {
+	return fmt.Sprintf(`
+		resource "ibm_sds_volume" "sds_volume_instance" {
+			capacity = %s
+			name = "%s"
+		}
+	`, capacity, name)
+}
+
+func testAccCheckIBMSdsVolumeConfig(hostnqnstring string, capacity string, name string) string {
+	return fmt.Sprintf(`
+
+		resource "ibm_sds_volume" "sds_volume_instance" {
+			hostnqnstring = "%s"
+			capacity = %s
+			name = "%s"
+		}
+	`, hostnqnstring, capacity, name)
+}
+
+func testAccCheckIBMSdsVolumeExists(n string, obj sdsaasv1.Volume) resource.TestCheckFunc {
+
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+
+		sdsaasClient, err := acc.TestAccProvider.Meta().(conns.ClientSession).SdsaasV1()
+		if err != nil {
+			return err
+		}
+
+		volumeOptions := &sdsaasv1.VolumeOptions{}
+
+		volumeOptions.SetVolumeID(rs.Primary.ID)
+
+		volume, _, err := sdsaasClient.Volume(volumeOptions)
+		if err != nil {
+			return err
+		}
+
+		obj = *volume
+		return nil
+	}
+}
+
+func testAccCheckIBMSdsVolumeDestroy(s *terraform.State) error {
+	sdsaasClient, err := acc.TestAccProvider.Meta().(conns.ClientSession).SdsaasV1()
+	if err != nil {
+		return err
+	}
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "ibm_sds_volume" {
+			continue
+		}
+
+		volumeOptions := &sdsaasv1.VolumeOptions{}
+
+		volumeOptions.SetVolumeID(rs.Primary.ID)
+
+		// Give time for the volume to fully delete before checking its state
+		time.Sleep(5 * time.Second)
+
+		// Try to find the key
+		_, response, err := sdsaasClient.Volume(volumeOptions)
+
+		if err == nil {
+			return fmt.Errorf("sds_volume still exists: %s", rs.Primary.ID)
+		} else if response.StatusCode != 404 {
+			return fmt.Errorf("Error checking for sds_volume (%s) has been destroyed: %s", rs.Primary.ID, err)
+		}
+	}
+
+	return nil
+}
+
+func TestResourceIBMSdsVolumeHostMappingToMap(t *testing.T) {
+	checkResult := func(result map[string]interface{}) {
+		model := make(map[string]interface{})
+		model["host_id"] = "testString"
+		model["host_name"] = "testString"
+		model["host_nqn"] = "testString"
+
+		assert.Equal(t, result, model)
+	}
+
+	model := new(sdsaasv1.HostMapping)
+	model.HostID = core.StringPtr("testString")
+	model.HostName = core.StringPtr("testString")
+	model.HostNqn = core.StringPtr("testString")
+
+	result, err := sdsaas.ResourceIBMSdsVolumeHostMappingToMap(model)
+	assert.Nil(t, err)
+	checkResult(result)
+}

--- a/ibm/service/sdsaas/resource_ibm_sds_volume_test.go
+++ b/ibm/service/sdsaas/resource_ibm_sds_volume_test.go
@@ -16,8 +16,8 @@ import (
 	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/conns"
 	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/sdsaas"
 	"github.com/IBM/go-sdk-core/v5/core"
-	"github.com/stretchr/testify/assert"
 	"github.com/IBM/sds-go-sdk/sdsaasv1"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestAccIBMSdsVolumeBasic(t *testing.T) {

--- a/website/allowed-subcategories.txt
+++ b/website/allowed-subcategories.txt
@@ -40,6 +40,7 @@ Push Notifications
 Resource management
 Satellite
 Schematics
+sdsaas
 Secrets Manager
 Security and Compliance Center
 Transit Gateway

--- a/website/docs/r/sds_host.html.markdown
+++ b/website/docs/r/sds_host.html.markdown
@@ -16,7 +16,7 @@ Create, update, and delete sds_hosts with this resource.
 resource "ibm_sds_host" "sds_host_instance" {
   name = "my-host"
   nqn = "nqn.2014-06.org:9345"
-  volume_mappings {
+  volumes {
 		status = "status"
 		volume_id = "volume_id"
 		volume_name = "volume_name"
@@ -38,24 +38,31 @@ resource "ibm_sds_host" "sds_host_instance" {
 You can specify the following arguments for this resource.
 
 * `name` - (Optional, String) The name for this host. The name must not be used by another host.  If unspecified, the name will be a hyphenated list of randomly-selected words.
-  * Constraints: The maximum length is `64` characters. The minimum length is `1` character.
+  * Constraints: The maximum length is `64` characters. The minimum length is `1` character. The value must match regular expression `/^\\S+$/`.
 * `nqn` - (Required, String) The NQN of the host configured in customer's environment.
-* `volume_mappings` - (Optional, List) The host-to-volume map.
+  * Constraints: The maximum length is `100` characters. The minimum length is `1` character. The value must match regular expression `/^\\S+$/`.
+* `volumes` - (Optional, List) The host-to-volume map.
   * Constraints: The maximum length is `100` items. The minimum length is `0` items.
-Nested schema for **volume_mappings**:
+Nested schema for **volumes**:
 	* `status` - (Optional, String) The current status of a volume/host mapping attempt.
+	  * Constraints: The maximum length is `100` characters. The minimum length is `1` character. The value must match regular expression `/^\\S+$/`.
 	* `storage_identifiers` - (Optional, List) Storage network and ID information associated with a volume/host mapping.
 	Nested schema for **storage_identifiers**:
 		* `id` - (Optional, String) The storage ID associated with a volume/host mapping.
+		  * Constraints: The maximum length is `100` characters. The minimum length is `1` character. The value must match regular expression `/^\\S+$/`.
 		* `namespace_id` - (Optional, Integer) The namespace ID associated with a volume/host mapping.
 		* `namespace_uuid` - (Optional, String) The namespace UUID associated with a volume/host mapping.
+		  * Constraints: The maximum length is `100` characters. The minimum length is `1` character. The value must match regular expression `/^\\S+$/`.
 		* `network_info` - (Optional, List) The IP and port for volume/host mappings.
 		  * Constraints: The maximum length is `200` items. The minimum length is `1` item.
 		Nested schema for **network_info**:
 			* `gateway_ip` - (Optional, String) Network information for volume/host mappings.
+			  * Constraints: The maximum length is `100` characters. The minimum length is `1` character. The value must match regular expression `/^\\S+$/`.
 			* `port` - (Optional, Integer) Network information for volume/host mappings.
 	* `volume_id` - (Required, String) The volume ID that needs to be mapped with a host.
+	  * Constraints: The maximum length is `100` characters. The minimum length is `1` character. The value must match regular expression `/^\\S+$/`.
 	* `volume_name` - (Required, String) The volume name.
+	  * Constraints: The maximum length is `100` characters. The minimum length is `1` character. The value must match regular expression `/^\\S+$/`.
 
 ## Attribute Reference
 
@@ -63,8 +70,7 @@ After your resource is created, you can read values from the listed arguments an
 
 * `id` - The unique identifier of the sds_host.
 * `created_at` - (String) The date and time that the host was created.
-* `service_instance_id` - (String) The service instance ID this host should be created in.
-  * Constraints: The maximum length is `64` characters. The minimum length is `1` character.
+  * Constraints: The maximum length is `100` characters. The minimum length is `1` character. The value must match regular expression `/^\\S+$/`.
 
 
 ## Import

--- a/website/docs/r/sds_host.html.markdown
+++ b/website/docs/r/sds_host.html.markdown
@@ -1,0 +1,82 @@
+---
+layout: "ibm"
+page_title: "IBM : ibm_sds_host"
+description: |-
+  Manages sds_host.
+subcategory: "sdsaas"
+---
+
+# ibm_sds_host
+
+Create, update, and delete sds_hosts with this resource.
+
+## Example Usage
+
+```hcl
+resource "ibm_sds_host" "sds_host_instance" {
+  name = "my-host"
+  nqn = "nqn.2014-06.org:9345"
+  volume_mappings {
+		status = "status"
+		volume_id = "volume_id"
+		volume_name = "volume_name"
+		storage_identifiers {
+			id = "id"
+			namespace_id = 1
+			namespace_uuid = "namespace_uuid"
+			network_info {
+				gateway_ip = "gateway_ip"
+				port = 1
+			}
+		}
+  }
+}
+```
+
+## Argument Reference
+
+You can specify the following arguments for this resource.
+
+* `name` - (Optional, String) The name for this host. The name must not be used by another host.  If unspecified, the name will be a hyphenated list of randomly-selected words.
+  * Constraints: The maximum length is `64` characters. The minimum length is `1` character.
+* `nqn` - (Required, String) The NQN of the host configured in customer's environment.
+* `volume_mappings` - (Optional, List) The host-to-volume map.
+  * Constraints: The maximum length is `100` items. The minimum length is `0` items.
+Nested schema for **volume_mappings**:
+	* `status` - (Optional, String) The current status of a volume/host mapping attempt.
+	* `storage_identifiers` - (Optional, List) Storage network and ID information associated with a volume/host mapping.
+	Nested schema for **storage_identifiers**:
+		* `id` - (Optional, String) The storage ID associated with a volume/host mapping.
+		* `namespace_id` - (Optional, Integer) The namespace ID associated with a volume/host mapping.
+		* `namespace_uuid` - (Optional, String) The namespace UUID associated with a volume/host mapping.
+		* `network_info` - (Optional, List) The IP and port for volume/host mappings.
+		  * Constraints: The maximum length is `200` items. The minimum length is `1` item.
+		Nested schema for **network_info**:
+			* `gateway_ip` - (Optional, String) Network information for volume/host mappings.
+			* `port` - (Optional, Integer) Network information for volume/host mappings.
+	* `volume_id` - (Required, String) The volume ID that needs to be mapped with a host.
+	* `volume_name` - (Required, String) The volume name.
+
+## Attribute Reference
+
+After your resource is created, you can read values from the listed arguments and the following attributes.
+
+* `id` - The unique identifier of the sds_host.
+* `created_at` - (String) The date and time that the host was created.
+* `service_instance_id` - (String) The service instance ID this host should be created in.
+  * Constraints: The maximum length is `64` characters. The minimum length is `1` character.
+
+
+## Import
+
+You can import the `ibm_sds_host` resource by using `id`. The unique identifier for this host.
+
+# Syntax
+<pre>
+$ terraform import ibm_sds_host.sds_host &lt;id&gt;
+</pre>
+
+# Example
+```
+$ terraform import ibm_sds_host.sds_host 1a6b7274-678d-4dfb-8981-c71dd9d4daa5
+```

--- a/website/docs/r/sds_volume.html.markdown
+++ b/website/docs/r/sds_volume.html.markdown
@@ -1,0 +1,57 @@
+---
+layout: "ibm"
+page_title: "IBM : ibm_sds_volume"
+description: |-
+  Manages sds_volume.
+subcategory: "sdsaas"
+---
+
+# ibm_sds_volume
+
+Create, update, and delete sds_volumes with this resource.
+
+## Example Usage
+
+```hcl
+resource "ibm_sds_volume" "sds_volume_instance" {
+  capacity = 10
+  hostnqnstring = "nqn.2024-07.org:1234"
+  name = "my-volume"
+}
+```
+
+## Argument Reference
+
+You can specify the following arguments for this resource.
+
+* `capacity` - (Required, Integer) The capacity of the volume (in gigabytes).
+* `hostnqnstring` - (Optional, String) The host nqn.
+  * Constraints: The maximum length is `200` characters. The minimum length is `1` character. The value must match regular expression `/^nqn\\.\\d{4}-\\d{2}\\.[a-z0-9-]+(?:\\.[a-z0-9-]+)*:[a-zA-Z0-9.\\-:]+$/`.
+* `name` - (Optional, String) The name of the volume.
+
+## Attribute Reference
+
+After your resource is created, you can read values from the listed arguments and the following attributes.
+
+* `id` - The unique identifier of the sds_volume.
+* `created_at` - (String) The date and time that the volume was created.
+* `host_mappings` - (List) List of host details that volume is mapped to.
+  * Constraints: The maximum length is `200` items. The minimum length is `0` items.
+Nested schema for **host_mappings**:
+	* `host_id` - (String) Unique identifer of the host.
+	* `host_name` - (String) Unique name of the host.
+	* `host_nqn` - (String) The NQN of the host configured in customer's environment.
+* `resource_type` - (String) The resource type of the volume.
+* `status` - (String) The current status of the volume.
+* `status_reasons` - (List) Reasons for the current status of the volume.
+  * Constraints: The maximum length is `200` items. The minimum length is `0` items.
+
+
+## Import
+
+You can import the `ibm_sds_volume` resource by using `id`. The volume profile id.
+
+# Syntax
+<pre>
+$ terraform import ibm_sds_volume.sds_volume &lt;id&gt;
+</pre>

--- a/website/docs/r/sds_volume.html.markdown
+++ b/website/docs/r/sds_volume.html.markdown
@@ -28,23 +28,32 @@ You can specify the following arguments for this resource.
 * `hostnqnstring` - (Optional, String) The host nqn.
   * Constraints: The maximum length is `200` characters. The minimum length is `1` character. The value must match regular expression `/^nqn\\.\\d{4}-\\d{2}\\.[a-z0-9-]+(?:\\.[a-z0-9-]+)*:[a-zA-Z0-9.\\-:]+$/`.
 * `name` - (Optional, String) The name of the volume.
+  * Constraints: The maximum length is `100` characters. The minimum length is `1` character. The value must match regular expression `/^\\S+$/`.
 
 ## Attribute Reference
 
 After your resource is created, you can read values from the listed arguments and the following attributes.
 
 * `id` - The unique identifier of the sds_volume.
+* `bandwidth` - (Integer) The maximum bandwidth (in megabits per second) for the volume.
 * `created_at` - (String) The date and time that the volume was created.
-* `host_mappings` - (List) List of host details that volume is mapped to.
+  * Constraints: The maximum length is `100` characters. The minimum length is `1` character. The value must match regular expression `/^\\S+$/`.
+* `hosts` - (List) List of host details that volume is mapped to.
   * Constraints: The maximum length is `200` items. The minimum length is `0` items.
-Nested schema for **host_mappings**:
+Nested schema for **hosts**:
 	* `host_id` - (String) Unique identifer of the host.
+	  * Constraints: The maximum length is `100` characters. The minimum length is `1` character. The value must match regular expression `/^\\S+$/`.
 	* `host_name` - (String) Unique name of the host.
+	  * Constraints: The maximum length is `100` characters. The minimum length is `1` character. The value must match regular expression `/^\\S+$/`.
 	* `host_nqn` - (String) The NQN of the host configured in customer's environment.
+	  * Constraints: The maximum length is `100` characters. The minimum length is `1` character. The value must match regular expression `/^\\S+$/`.
+* `iops` - (Integer) Iops The maximum I/O operations per second (IOPS) for this volume.
 * `resource_type` - (String) The resource type of the volume.
+  * Constraints: The maximum length is `100` characters. The minimum length is `1` character. The value must match regular expression `/^\\S+$/`.
 * `status` - (String) The current status of the volume.
+  * Constraints: The maximum length is `100` characters. The minimum length is `1` character. The value must match regular expression `/^\\S+$/`.
 * `status_reasons` - (List) Reasons for the current status of the volume.
-  * Constraints: The maximum length is `200` items. The minimum length is `0` items.
+  * Constraints: The list items must match regular expression `/^\\S+$/`. The maximum length is `200` items. The minimum length is `0` items.
 
 
 ## Import


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/IBM-Cloud/terraform-provider-ibm/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

This PR adds terraform support for the software defined storage offering (Ceph as a Service). Terraform resources include volumes and hosts. 

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->


Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
# Setup
$ export IC_API_KEY="<redacted>"                             
$ export IAAS_CLASSIC_USERNAME="<redacted>"     
$ export IAAS_CLASSIC_API_KEY="<redacted>"
$ export IBMCLOUD_SDS_ENDPOINT="<redacted>"
                         
$ make testacc TEST=./ibm/service/sdsaas                                    
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./ibm/service/sdsaas -v  -timeout 700m 
[WARN] Set the environment variable IBM_PROJECTS_CONFIG_APIKEY for testing IBM Projects Config resources, the tests will fail if this is not set
[WARN] Set the environment variable IBM_APPID_TENANT_ID for testing AppID resources, AppID tests will fail if this is not set
[WARN] Set the environment variable IBM_APPID_TEST_USER_EMAIL for testing AppID user resources, the tests will fail if this is not set
[WARN] Set the environment variable IBM_ORG for testing ibm_org  resource Some tests for that resource will fail if this is not set correctly
[WARN] Set the environment variable IBM_SPACE for testing ibm_space  resource Some tests for that resource will fail if this is not set correctly
[WARN] Set the environment variable IBM_ID1 for testing ibm_space resource Some tests for that resource will fail if this is not set correctly
[WARN] Set the environment variable IBM_ID2 for testing ibm_space resource Some tests for that resource will fail if this is not set correctly
[WARN] Set the environment variable IBM_IAMUSER for testing ibm_iam_user_policy resource Some tests for that resource will fail if this is not set correctly
[WARN] Set the environment variable IBM_IAMACCOUNTID for testing ibm_iam_trusted_profile resource Some tests for that resource will fail if this is not set correctly
[WARN] Set the environment variable IBM_IAM_SERVICE_ID for testing ibm_iam_trusted_profile_identity resource Some tests for that resource will fail if this is not set correctly
[WARN] Set the environment variable IBM_IAM_TRUSTED_PROFILE_ID for testing ibm_iam_trusted_profile_identity resource Some tests for that resource will fail if this is not set correctly
[WARN] Set the environment variable IBM_DATACENTER for testing ibm_container_cluster resource else it is set to default value 'par01'
[WARN] Set the environment variable IBM_MACHINE_TYPE for testing ibm_container_cluster resource else it is set to default value 'b3c.4x16'
[WARN] Set the environment variable IBM_CERT_CRN for testing ibm_container_alb_cert or ibm_container_ingress_secret_tls resource else it is set to default value
[WARN] Set the environment variable IBM_UPDATE_CERT_CRN for testing ibm_container_alb_cert or ibm_container_ingress_secret_tls resource else it is set to default value
[WARN] Set the environment variable IBM_SECRET_CRN for testing ibm_container_ingress_secret_opaque resource else it is set to default value
[WARN] Set the environment variable IBM_SECRET_CRN_2 for testing ibm_container_ingress_secret_opaque resource else it is set to default value
[WARN] Set the environment variable IBM_INGRESS_INSTANCE_CRN for testing ibm_container_ingress_instance resource. Some tests for that resource will fail if this is not set correctly
[WARN] Set the environment variable IBM_INGRESS_INSTANCE_SECRET_GROUP_ID for testing ibm_container_ingress_instance resource. Some tests for that resource will fail if this is not set correctly
[WARN] Set the environment variable IBM_CONTAINER_REGION for testing ibm_container resources else it is set to default value 'eu-de'
[WARN] Set the environment variable IBM_CIS_INSTANCE with a VALID CIS Instance NAME for testing ibm_cis resources on staging/test
[WARN] Set the environment variable IBM_CIS_DOMAIN_STATIC with the Domain name registered with the CIS instance on test/staging. Domain must be predefined in CIS to avoid CIS billing costs due to domain delete/create
[WARN] Set the environment variable IBM_CIS_DOMAIN_TEST with a VALID Domain name for testing the one time create and delete of a domain in CIS. Note each create/delete will trigger a monthly billing instance. Only to be run in staging/test
[WARN] Set the environment variable IBM_CIS_RESOURCE_GROUP with the resource group for the CIS Instance 
[WARN] Set the environment variable IBM_COS_CRN with a VALID COS instance CRN for testing ibm_cos_* resources
[WARN] Set the environment variable IBM_COS_Bucket_CRN with a VALID BUCKET CRN for testing ibm_cos_bucket* resources
[WARN] Set the environment variable IBM_COS_Backup_Vault with a VALID BACKUP VAULT NAME  for testing ibm_cos_backup_vault* resources
[WARN] Set the environment variable IBM_KMS_KEY_CRN with a VALID key crn for a KP/HPCS root key
[WARN] Set the environment variable IBM_COS_Backup_Policy_Id with a VALID POLICYS ID for testing ibm_cos_backup_policy* resources
[WARN] Set the environment variable IBM_COS_ACTIVITY_TRACKER_CRN with a VALID ACTIVITY TRACKER INSTANCE CRN in valid region for testing ibm_cos_bucket* resources
[WARN] Set the environment variable IBM_COS_METRICS_MONITORING_CRN with a VALID METRICS MONITORING CRN for testing ibm_cos_bucket* resources
[WARN] Set the environment variable IBM_COS_BUCKET_NAME with a VALID BUCKET Name for testing ibm_cos_bucket* resources
[WARN] Set the environment variable IBM_COS_NAME with a VALID COS instance name for testing resources with cos deps
[WARN] Set the environment variable IBM_TRUSTED_MACHINE_TYPE for testing ibm_container_cluster resource else it is set to default value 'mb1c.16x64'
[WARN] Set the environment variable IBM_BM_EXTENDED_HW_TESTING to true/false for testing ibm_compute_bare_metal resource else it is set to default value 'false'
[WARN] Set the environment variable IBM_PUBLIC_VLAN_ID for testing ibm_container_cluster resource else it is set to default value '2393319'
[WARN] Set the environment variable IBM_PRIVATE_VLAN_ID for testing ibm_container_cluster resource else it is set to default value '2393321'
[WARN] Set the environment variable IBM_KUBE_VERSION for testing ibm_container_cluster resource else it is set to default value '1.18.14'
[WARN] Set the environment variable IBM_KUBE_UPDATE_VERSION for testing ibm_container_cluster resource else it is set to default value '1.19.6'
[WARN] Set the environment variable IBM_PRIVATE_SUBNET_ID for testing ibm_container_cluster resource else it is set to default value '1636107'
[WARN] Set the environment variable IBM_PUBLIC_SUBNET_ID for testing ibm_container_cluster resource else it is set to default value '1165645'
[WARN] Set the environment variable IBM_SUBNET_ID for testing ibm_container_cluster resource else it is set to default value '1165645'
[INFO] Set the environment variable IBM_IPSEC_DATACENTER for testing ibm_ipsec_vpn resource else it is set to default value 'tok02'
[INFO] Set the environment variable IBM_IPSEC_CUSTOMER_SUBNET_ID for testing ibm_ipsec_vpn resource else it is set to default value '123456'
[INFO] Set the environment variable IBM_IPSEC_CUSTOMER_PEER_IP for testing ibm_ipsec_vpn resource else it is set to default value '192.168.0.1'
[WARN] Set the environment variable IBM_LBAAS_DATACENTER for testing ibm_lbaas resource else it is set to default value 'dal13'
[WARN] Set the environment variable IBM_LBAAS_SUBNETID for testing ibm_lbaas resource else it is set to default value '2144241'
[WARN] Set the environment variable IBM_LB_LISTENER_CERTIFICATE_INSTANCE for testing ibm_is_lb_listener resource for https redirect else it is set to default value 'crn:v1:staging:public:cloudcerts:us-south:a/2d1bace7b46e4815a81e52c6ffeba5cf:af925157-b125-4db2-b642-adacb8b9c7f5:certificate:c81627a1bf6f766379cc4b98fd2a44ed'
[WARN] Set the environment variable IBM_DEDICATED_HOSTNAME for testing ibm_compute_vm_instance resource else it is set to default value 'terraform-dedicatedhost'
[WARN] Set the environment variable IBM_DEDICATED_HOST_ID for testing ibm_compute_vm_instance resource else it is set to default value '30301'
[WARN] Set the environment variable IBM_WORKER_POOL_ZONE for testing ibm_container_worker_pool_zone_attachment resource else it is set to default value 'ams03'
[WARN] Set the environment variable IBM_WORKER_POOL_ZONE_PRIVATE_VLAN for testing ibm_container_worker_pool_zone_attachment resource else it is set to default value '2538975'
[WARN] Set the environment variable IBM_WORKER_POOL_ZONE_PUBLIC_VLAN for testing ibm_container_worker_pool_zone_attachment resource else it is set to default value '2538967'
[WARN] Set the environment variable IBM_WORKER_POOL_ZONE_UPDATE_PRIVATE_VLAN for testing ibm_container_worker_pool_zone_attachment resource else it is set to default value '2388377'
[WARN] Set the environment variable IBM_WORKER_POOL_ZONE_UPDATE_PUBLIC_VLAN for testing ibm_container_worker_pool_zone_attachment resource else it is set to default value '2388375'
[WARN] Set the environment variable IBM_WORKER_POOL_SECONDARY_STORAGE for testing secondary_storage attachment to IKS workerpools
[WARN] Set the environment variable IBM_PLACEMENT_GROUP_NAME for testing ibm_compute_vm_instance resource else it is set to default value 'terraform-group'
[INFO] Set the environment variable SL_REGION for testing ibm_is_region datasource else it is set to default value 'us-south'
[INFO] Set the environment variable SL_ZONE for testing ibm_is_zone datasource else it is set to default value 'us-south-1'
[INFO] Set the environment variable SL_ZONE_2 for testing ibm_is_zone datasource else it is set to default value 'us-south-2'
[INFO] Set the environment variable SL_ZONE_3 for testing ibm_is_zone datasource else it is set to default value 'us-south-3'
[INFO] Set the environment variable SL_CIDR for testing ibm_is_subnet else it is set to default value '10.240.0.0/24'
[INFO] Set the environment variable SL_CIDR_2 for testing ibm_is_subnet else it is set to default value '10.240.64.0/24'
[INFO] Set the environment variable IS_IPV4_ADDRESS for testing ibm_is_instance else it is set to default value '10.240.0.6'
[INFO] Set the environment variable IS_ACCOUNT_ID for testing private_path_service_gateway_account_policy else it is set to default value 'fee82deba12e4c0fb69c3b09d1f12345'
[INFO] Set the environment variable IS_CLUSTER_NETWORK_PROFILE_NAME for testing cluster_network_profile else it is set to default value 'h100'
[INFO] Set the environment variable IS_INSTANCE_GPU_PROFILE_NAME for testing cluster_network_attachments else it is set to default value 'gx3d-160x1792x8h100'
[INFO] Set the environment variable IS_CLUSTER_NETWORK_SUBNET_PREFIXES_CIDR for testing cluster_network else it is set to default value '10.1.0.0/24'
[INFO] Set the environment variable SL_ADDRESS_PREFIX_CIDR for testing ibm_is_vpc_address_prefix else it is set to default value '10.120.0.0/24'
[INFO] Set the environment variable SL_CIDR_2 for testing ibm_is_subnet else it is set to default value '10.240.64.0/24'
[INFO] Set the environment variable SL_CIDR_2 for testing ibm_is_instance datasource else it is set to default value './test-fixtures/.ssh/pkcs8_rsa.pub'
[INFO] Set the environment variable IS_PRIVATE_SSH_KEY_PATH for testing ibm_is_instance datasource else it is set to default value './test-fixtures/.ssh/pkcs8_rsa'
[INFO] Set the environment variable SL_RESOURCE_GROUP_ID for testing with different resource group id else it is set to default value 'c01d34dff4364763476834c990398zz8'
[INFO] Set the environment variable IS_RESOURCE_CRN for testing with created resource instance
[INFO] Set the environment variable IS_IMAGE for testing ibm_is_instance, ibm_is_floating_ip else it is set to default value 'r006-587a041d-9246-44f0-980b-56a327cf5bd7'
[INFO] Set the environment variable IS_IMAGE2 for testing ibm_is_instance, ibm_is_floating_ip else it is set to default value 'r134-f47cc24c-e020-4db5-ad96-1e5be8b5853b'
[INFO] Set the environment variable IS_WIN_IMAGE for testing ibm_is_instance data source else it is set to default value 'r006-d2e0d0e9-0a4f-4c45-afd7-cab787030776'
[INFO] Set the environment variable IS_COS_BUCKET_NAME for testing ibm_is_image_export_job else it is set to default value 'bucket-27200-lwx4cfvcue'
[INFO] Set the environment variable IS_COS_BUCKET_CRN for testing ibm_is_image_export_job else it is set to default value 'bucket-27200-lwx4cfvcue'
[INFO] Set the environment variable IS_INSTANCE_NAME for testing ibm_is_instance resource else it is set to default value 'instance-01'
[INFO] Set the environment variable IS_BACKUP_POLICY_JOB_ID for testing ibm_is_backup_policy_job datasource
[INFO] Set the environment variable IS_BACKUP_POLICY_ID for testing ibm_is_backup_policy_jobs datasource
[INFO] Set the environment variable IS_REMOTE_CP_BAAS_ENCRYPTION_KEY_CRN for testing remote_copies_policy with Baas plans, else it is set to default value, 'crn:v1:bluemix:public:kms:us-south:a/dffc98a0f1f0f95f6613b3b752286b87:e4a29d1a-2ef0-42a6-8fd2-350deb1c647e:key:5437653b-c4b1-447f-9646-b2a2a4cd6179'
[INFO] Set the environment variable SL_INSTANCE_PROFILE for testing ibm_is_instance resource else it is set to default value 'cx2-2x4'
[INFO] Set the environment variable SL_KMS_INSTANCE_ID for testing ibm_kms_key resource else it is set to default value '30222bb5-1c6d-3834-8d78-ae6348cf8z61'
[INFO] Set the environment variable SL_KMS_KEY_NAME for testing ibm_kms_key resource else it is set to default value 'tfp-test-key'
[INFO] Set the environment variable SL_INSTANCE_PROFILE_UPDATE for testing ibm_is_instance resource else it is set to default value 'cx2-4x8'
[INFO] Set the environment variable IS_BARE_METAL_SERVER_PROFILE for testing ibm_is_bare_metal_server resource else it is set to default value 'bx2-metal-96x384'
[INFO] Set the environment variable IsBareMetalServerImage for testing ibm_is_bare_metal_server resource else it is set to default value 'r006-2d1f36b0-df65-4570-82eb-df7ae5f778b1'
[INFO] Set the environment variable IsBareMetalServerImage2 for testing ibm_is_bare_metal_server resource else it is set to default value 'r006-2d1f36b0-df65-4570-82eb-df7ae5f778b1'
[INFO] Set the environment variable IS_DNS_INSTANCE_CRN for testing ibm_is_lb resource else it is set to default value 'crn:v1:staging:public:dns-svcs:global:a/efe5afc483594adaa8325e2b4d1290df:82df2e3c-53a5-43c6-89ce-dcf78be18668::'
[INFO] Set the environment variable IS_DNS_INSTANCE_CRN1 for testing ibm_is_lb resource else it is set to default value 'crn:v1:staging:public:dns-svcs:global:a/efe5afc483594adaa8325e2b4d1290df:599ae4aa-c554-4a88-8bb2-b199b9a3c046::'
[INFO] Set the environment variable IS_DNS_ZONE_ID for testing ibm_is_lb resource else it is set to default value 'dd501d1d-490b-4bb4-a05d-a31954a1c59e'
[INFO] Set the environment variable IS_DNS_ZONE_ID_1 for testing ibm_is_lb resource else it is set to default value 'b1def78d-51b3-4ea5-a746-1b64c992fcab'
[INFO] Set the environment variable IS_DEDICATED_HOST_NAME for testing ibm_is_instance resource else it is set to default value 'tf-dhost-01'
[INFO] Set the environment variable IS_DEDICATED_HOST_GROUP_ID for testing ibm_is_instance resource else it is set to default value '0717-9104e7b5-77ad-44ad-9eaa-091e6b6efce1'
[INFO] Set the environment variable IS_DEDICATED_HOST_PROFILE for testing ibm_is_instance resource else it is set to default value 'bx2d-host-152x608'
[INFO] Set the environment variable IS_DEDICATED_HOST_GROUP_CLASS for testing ibm_is_instance resource else it is set to default value 'bx2d'
[INFO] Set the environment variable IS_DEDICATED_HOST_GROUP_FAMILY for testing ibm_is_instance resource else it is set to default value 'balanced'
[INFO] Set the environment variable SL_INSTANCE_PROFILE for testing ibm_is_instance resource else it is set to default value 'bx2d-16x64'
[INFO] Set the environment variable IS_SHARE_PROFILE for testing ibm_is_instance resource else it is set to default value 'tier-3iops'
[INFO] Set the environment variable IS_SHARE_PROFILE for testing ibm_is_instance resource else it is set to default value
[INFO] Set the environment variable IS_SHARE_PROFILE for testing ibm_is_instance resource else it is set to default value
[INFO] Set the environment variable IS_VOLUME_PROFILE for testing ibm_is_volume_profile else it is set to default value 'general-purpose'
[INFO] Set the environment variable IS_VIRTUAL_NETWORK_INTERFACE for testing ibm_is_virtual_network_interface else it is set to default value 'c93dc4c6-e85a-4da2-9ea6-f24576256122'
[INFO] Set the environment variable IS_FLOATING_IP for testing ibm_is_virtual_network_interface else it is set to default value 'r006-9fc3948f-1b01-406c-baa5-e86b185e559f'
[INFO] Set the environment variable IS_UNATTACHED_BOOT_VOLUME_NAME for testing ibm_is_image else it is set to default value 'r006-1cbe9f0a-7101-4d25-ae72-2a2d725e530e'
[INFO] Set the environment variable IS_VSI_DATA_VOLUME_ID for testing ibm_is_image else it is set to default value 'r006-1cbe9f0a-7101-4d25-ae72-2a2d725e530e'
[INFO] Set the environment variable SL_ROUTE_NEXTHOP else it is set to default value '10.0.0.4'
[INFO] Set the environment variable ISSnapshotCRN for ibm_is_snapshot resource else it is set to default value 'crn:v1:bluemix:public:is:ca-tor:a/xxxxxxxx::snapshot:xxxx-xxxxc-xxx-xxxx-xxxx-xxxxxxxxxx'
[INFO] Set the environment variable ICD_DB_DEPLOYMENT_ID for testing ibm_cloud_databases else it is set to default value 'crn:v1:bluemix:public:databases-for-redis:au-syd:a/40ddc34a953a8c02f10987b59085b60e:5042afe1-72c2-4231-89cc-c949e5d56251::'
[INFO] Set the environment variable ICD_DB_BACKUP_ID for testing ibm_cloud_databases else it is set to default value 'crn:v1:bluemix:public:databases-for-redis:au-syd:a/40ddc34a953a8c02f10987b59085b60e:5042afe1-72c2-4231-89cc-c949e5d56251:backup:0d862fdb-4faa-42e5-aecb-5057f4d399c3'
[INFO] Set the environment variable ICD_DB_TASK_ID for testing ibm_cloud_databases else it is set to default value 'crn:v1:bluemix:public:databases-for-redis:au-syd:a/40ddc34a953a8c02f10987b59085b60e:367b0a22-05bb-41e3-a1ed-ded1ff0889e5:task:882013a6-2751-4df7-a77a-98d258638704'
[INFO] Set the environment variable PI_IMAGE for testing ibm_pi_image resource else it is set to default value '7200-03-03'
[INFO] Set the environment variable PI_SAP_IMAGE for testing ibm_pi_image resource else it is set to default value 'Linux-RHEL-SAP-8-2'
[INFO] Set the environment variable PI_IMAGE_BUCKET_NAME for testing ibm_pi_image resource else it is set to default value 'images-public-bucket'
[INFO] Set the environment variable PI_IMAGE_BUCKET_FILE_NAME for testing ibm_pi_image resource else it is set to default value 'rhel.ova.gz'
[INFO] Set the environment variable PI_IMAGE_BUCKET_ACCESS_KEY for testing ibm_pi_image_export resource else it is set to default value 'images-bucket-access-key'
[INFO] Set the environment variable PI_IMAGE_BUCKET_SECRET_KEY for testing ibm_pi_image_export resource else it is set to default value 'PI_IMAGE_BUCKET_SECRET_KEY'
[INFO] Set the environment variable PI_IMAGE_BUCKET_REGION for testing ibm_pi_image resource else it is set to default value 'us-east'
[INFO] Set the environment variable PI_IMAGE_ID for testing ibm_pi_image resource else it is set to default value 'IBMi-72-09-2924-11'
[INFO] Set the environment variable PI_KEY_NAME for testing ibm_pi_key_name resource else it is set to default value 'terraform-test-power'
[INFO] Set the environment variable PI_NETWORK_NAME for testing ibm_pi_network_name resource else it is set to default value 'terraform-test-power'
[INFO] Set the environment variable PI_NETWORK_ID for testing ibm_pi_network_interface resource else it is set to default value 'terraform-test-power'
[INFO] Set the environment variable PI_NETWORK_INTERFACE_ID for testing ibm_pi_network_interface resource else it is set to default value 'terraform-test-power'
[INFO] Set the environment variable PI_NETWORK_SECURITY_GROUP_ID for testing ibm_pi_network_security_group resource else it is set to default value 'terraform-test-power'
[INFO] Set the environment variable PI_NETWORK_SECURITY_GROUP_RULE_ID for testing ibm_pi_network_security_group resource else it is set to default value 'terraform-test-power'
[INFO] Set the environment variable PI_NETWORK_SECURITY_GROUP_ID for testing ibm_pi_network_security_group resource else it is set to default value 'terraform-test-power'
[INFO] Set the environment variable PI_NETWORK_SECURITY_GROUP_RULE_ID for testing ibm_pi_network_security_group resource else it is set to default value 'terraform-test-power'
[INFO] Set the environment variable PI_VOLUME_NAME for testing ibm_pi_network_name resource else it is set to default value 'terraform-test-power'
[INFO] Set the environment variable PI_VOLUME_ID for testing ibm_pi_volume_flash_copy_mappings resource else it is set to default value 'terraform-test-power'
[INFO] Set the environment variable PI_REPLICATION_VOLUME_NAME for testing ibm_pi_volume resource else it is set to default value 'terraform-test-power'
[INFO] Set the environment variable PI_VOLUME_ONBARDING_SOURCE_CRN for testing ibm_pi_volume_onboarding resource else it is set to default value 'terraform-test-power'
[INFO] Set the environment variable PI_AUXILIARY_VOLUME_NAME for testing ibm_pi_volume_onboarding resource else it is set to default value 'terraform-test-power'
[INFO] Set the environment variable PI_VOLUME_GROUP_NAME for testing ibm_pi_volume_group resource else it is set to default value 'terraform-test-power'
[INFO] Set the environment variable PI_VOLUME_GROUP_ID for testing ibm_pi_volume_group_storage_details data source else it is set to default value 'terraform-test-power'
[INFO] Set the environment variable PI_VOLUME_ONBOARDING_ID for testing ibm_pi_volume_onboarding resource else it is set to default value 'terraform-test-power'
[INFO] Set the environment variable PI_CLOUDINSTANCE_ID for testing ibm_pi_image resource else it is set to default value 'd16705bd-7f1a-48c9-9e0e-1c17b71e7331'
[INFO] Set the environment variable PI_SNAPSHOT_ID for testing ibm_pi_instance_snapshot data source else it is set to default value '1ea33118-4c43-4356-bfce-904d0658de82'
[INFO] Set the environment variable PI_PVM_INSTANCE_ID for testing Pi_instance_name resource else it is set to default value 'terraform-test-power'
[INFO] Set the environment variable PI_DHCP_ID for testing ibm_pi_dhcp resource else it is set to default value 'terraform-test-power'
[INFO] Set the environment variable PI_CLOUD_CONNECTION_NAME for testing ibm_pi_cloud_connection resource else it is set to default value 'terraform-test-power'
[INFO] Set the environment variable PI_SAP_PROFILE_ID for testing ibm_pi_sap_profile resource else it is set to default value 'terraform-test-power'
[WARN] Set the environment variable PI_PLACEMENT_GROUP_NAME for testing ibm_pi_placement_group resource else it is set to default value 'tf-pi-placement-group'
[WARN] Set the environment variable PI_REMOTE_ID for testing ibm_pi_network_security_group resource else it is set to default value 'terraform-test-power'
[WARN] Set the environment variable PI_REMOTE_TYPE for testing ibm_pi_network_security_group resource else it is set to default value 'terraform-test-power'
[WARN] Set the environment variable PI_SPP_PLACEMENT_GROUP_ID for testing ibm_pi_spp_placement_group resource else it is set to default value 'tf-pi-spp-placement-group'
[INFO] Set the environment variable PI_STORAGE_POOL for testing ibm_pi_storage_pool_capacity else it is set to default value 'terraform-test-power'
[INFO] Set the environment variable PI_STORAGE_TYPE for testing ibm_pi_storage_type_capacity else it is set to default value 'terraform-test-power'
[INFO] Set the environment variable PI_CAPTURE_STORAGE_IMAGE_PATH for testing Pi_capture_storage_image_path resource else it is set to default value 'terraform-test-power'
[INFO] Set the environment variable PI_CAPTURE_CLOUD_STORAGE_ACCESS_KEY for testing Pi_capture_cloud_storage_access_key resource else it is set to default value 'terraform-test-power'
[INFO] Set the environment variable PI_CAPTURE_CLOUD_STORAGE_SECRET_KEY for testing Pi_capture_cloud_storage_secret_key resource else it is set to default value 'terraform-test-power'
[WARN] Set the environment variable PI_SHARED_PROCESSOR_POOL_ID for testing ibm_pi_shared_processor_pool resource else it is set to default value 'tf-pi-shared-processor-pool'
[WARN] Set the environment variable PI_STORAGE_CONNECTION for testing pi_storage_connection resource else it is empty
[INFO] Set the environment variable PI_TARGET_STORAGE_TIER for testing Pi_target_storage_tier resource else it is set to default value 'terraform-test-tier'
[INFO] Set the environment variable PI_VOLUME_CLONE_TASK_ID for testing Pi_volume_clone_task_id resource else it is set to default value 'terraform-test-volume-clone-task-id'
[INFO] Set the environment variable PI_VIRTUAL_SERIAL_NUMBER for testing ibm_pi_virtual_serial_number data source else it is set to default value 'terraform-test-power'
[WARN] Set the environment variable PI_RESOURCE_GROUP_ID for testing ibm_pi_workspace resource else it is set to default value ''
[WARN] Set the environment variable PI_HOST_GROUP_ID for testing ibm_pi_host resource else it is set to default value ''
[WARN] Set the environment variable PI_HOST_ID for testing ibm_pi_host resource else it is set to default value ''
[INFO] Set the environment variable PI_NETWORK_ADDRESS_GROUP_ID for testing ibm_pi_network_address_group data source else it is set to default value 'terraform-test-power'
[INFO] Set the environment variable SCHEMATICS_WORKSPACE_ID for testing schematics resources else it is set to default value
[INFO] Set the environment variable SCHEMATICS_TEMPLATE_ID for testing schematics resources else it is set to default value
[INFO] Set the environment variable SCHEMATICS_ACTION_ID for testing schematics resources else it is set to default value
[INFO] Set the environment variable SCHEMATICS_AGENT_ID for testing schematics resources else it is set to default value
[INFO] Set the environment variable SCHEMATICS_JOB_ID for testing schematics resources else it is set to default value
[INFO] Set the environment variable SCHEMATICS_REPO_URL for testing schematics resources else tests will fail if this is not set correctly
[INFO] Set the environment variable SCHEMATICS_REPO_BRANCH for testing schematics resources else tests will fail if this is not set correctly
[WARN] Set the environment variable IMAGE_COS_URL with a VALID COS Image SQL URL for testing ibm_is_image resources on staging/test
[WARN] Set the environment variable IS_DELEGATED_VPC with a VALID created vpc name for testing ibm_is_vpc data source on staging/test
[WARN] Set the environment variable IMAGE_COS_URL_ENCRYPTED with a VALID COS Image SQL URL for testing ibm_is_image resources on staging/test
[WARN] Set the environment variable IMAGE_OPERATING_SYSTEM with a VALID Operating system for testing ibm_is_image resources on staging/test
[INFO] Set the environment variable IS_IMAGE_NAME for testing data source ibm_is_image else it is set to default value `ibm-ubuntu-18-04-1-minimal-amd64-2`
[INFO] Set the environment variable IS_IMAGE_NAME2 for testing data source ibm_is_image else it is set to default value `ibm-ubuntu-20-04-6-minimal-amd64-5`
[INFO] Set the environment variable IS_IMAGE_ENCRYPTED_DATA_KEY for testing resource ibm_is_image else it is set to default value
[INFO] Set the environment variable IS_IMAGE_ENCRYPTION_KEY for testing resource ibm_is_image else it is set to default value
[INFO] Set the environment variable IBM_FUNCTION_NAMESPACE for testing ibm_function_package, ibm_function_action, ibm_function_rule, ibm_function_trigger resource else  tests will fail if this is not set correctly
[INFO] Set the environment variable HPCS_INSTANCE_ID for testing data_source_ibm_kms_key_test else it is set to default value
[INFO] Set the environment variable SECRETS_MANAGER_INSTANCE_ID for testing Secrets Manager's tests else tests will fail if this is not set correctly
[INFO] Set the environment variable SECRETS_MANAGER_INSTANCE_REGION for testing Secrets Manager's tests else tests will fail if this is not set correctly
[INFO] Set the environment variable SECRETS_MANAGER_EN_INSTANCE_CRN for testing Event Notifications for Secrets Manager tests else tests will fail if this is not set correctly
[INFO] Set the environment variable SECRETS_MANAGER_EN_INSTANCE_CRN for testing IAM Credentials secret's tests else tests will assume that IAM Credentials engine is already configured and fail if not set correctly
[INFO] Set the environment variable SECRETS_MANAGER_IAM_CREDENTIALS_SECRET_SERVICE_ID or SECRETS_MANAGER_IAM_CREDENTIALS_SECRET_ACCESS_GROUP for testing IAM Credentials secret's tests, else tests fail if not set correctly
[INFO] Set the environment variable SECRETS_MANAGER_PUBLIC_CERTIFICATE_LETS_ENCRYPT_ENVIRONMENT for testing public certificate's tests, else it is set to default value ('production'). For public certificate's tests, tests will fail if this is not set correctly
[INFO] Set the environment variable SECRETS_MANAGER_PUBLIC_CERTIFICATE_LETS_ENCRYPT_PRIVATE_KEY for testing public certificate's tests, else tests fail if not set correctly
[INFO] Set the environment variable SECRETS_MANAGER_PUBLIC_CERTIFICATE_COMMON_NAME for testing public certificate's tests, else tests fail if not set correctly
[INFO] Set the environment variable SECRETS_MANAGER_VALIDATE_MANUAL_DNS_CIS_ZONE_ID for testing validate manual dns' test, else tests fail if not set correctly
[INFO] Set the environment variable SECRETS_MANAGER_PUBLIC_CERTIFICATE_CIS_CRN for testing public certificate's tests, else tests fail if not set correctly
[INFO] Set the environment variable SECRETS_MANAGER_PUBLIC_CLASSIC_INFRASTRUCTURE_USERNAME for testing public certificate's tests, else tests fail if not set correctly
[INFO] Set the environment variable SECRETS_MANAGER_PUBLIC_CLASSIC_INFRASTRUCTURE_PASSWORD for testing public certificate's tests, else tests fail if not set correctly
[INFO] Set the environment variable SECRETS_MANAGER_IMPORTED_CERTIFICATE_PATH_TO_CERTIFICATE for testing imported certificate's tests, else tests fail if not set correctly
[INFO] Set the environment variable SECRETS_MANAGER_SERVICE_CREDENTIALS_COS_CRN for testing service credentials' tests, else tests fail if not set correctly
[INFO] Set the environment variable SECRETS_MANAGER_PRIVATE_CERTIFICATE_CONFIGURATION_CRYPTO_KEY_IAM_SECRET_SERVICE_ID for testing private certificate's configuration with crypto key tests, else tests fail if not set correctly
[INFO] Set the environment variable SECRETS_MANAGER_PRIVATE_CERTIFICATE_CONFIGURATION_CRYPTO_KEY_PROVIDER_TYPE for testing private certificate's configuration with crypto key tests, else tests fail if not set correctly
[INFO] Set the environment variable SECRETS_MANAGER_PRIVATE_CERTIFICATE_CONFIGURATION_CRYPTO_KEY_PROVIDER_INSTANCE_CRN for testing private certificate's configuration with crypto key tests, else tests fail if not set correctly
[INFO] Set the environment variable SECRETS_MANAGER_PRIVATE_CERTIFICATE_CONFIGURATION_CRYPTO_KEY_PROVIDER_PRIVATE_KEYSTORE_ID for testing private certificate's configuration with crypto key tests, else tests fail if not set correctly
[INFO] Set the environment variable IBM_TG_CROSS_ACCOUNT_API_KEY for testing ibm_tg_connection resource else  tests will fail if this is not set correctly
[INFO] Set the environment variable IBM_TG_CROSS_ACCOUNT_ID for testing ibm_tg_connection resource else  tests will fail if this is not set correctly
[INFO] Set the environment variable IBM_TG_CROSS_NETWORK_ID for testing ibm_tg_connection resource else  tests will fail if this is not set correctly
[INFO] Set the environment variable IBM_TG_POWER_VS_NETWORK_ID for testing ibm_tg_connection resource else tests will fail if this is not set correctly
[INFO] Set the environment variable ACCOUNT_TO_BE_IMPORTED for testing import enterprise account resource else  tests will fail if this is not set correctly
[INFO] Set the environment variable COS_BUCKET for testing CRUD operations on billing snapshot configuration APIs
[INFO] Set the environment variable COS_LOCATION for testing CRUD operations on billing snapshot configuration APIs
[INFO] Set the environment variable COS_BUCKET_UPDATE for testing update operation on billing snapshot configuration API
[INFO] Set the environment variable COS_LOCATION_UPDATE for testing update operation on billing snapshot configuration API
[INFO] Set the environment variable COS_REPORTS_FOLDER for testing CRUD operations on billing snapshot configuration APIs
[INFO] Set the environment variable SNAPSHOT_DATE_FROM for testing CRUD operations on billing snapshot configuration APIs
[INFO] Set the environment variable SNAPSHOT_DATE_TO for testing CRUD operations on billing snapshot configuration APIs
[INFO] Set the environment variable SNAPSHOT_MONTH for testing CRUD operations on billing snapshot configuration APIs
[WARN] Set the environment variable IBM_HPCS_ADMIN1 with a VALID HPCS Admin Key1 Path
[WARN] Set the environment variable IBM_HPCS_TOKEN1 with a VALID token for HPCS Admin Key1
[WARN] Set the environment variable IBM_HPCS_ADMIN2 with a VALID HPCS Admin Key2 Path
[WARN] Set the environment variable IBM_IAM_REALM_NAME with a VALID realm name for iam trusted profile claim rule
[WARN] Set the environment variable IBM_IAM_IKS_SA with a VALID realm name for iam trusted profile link
[WARN] Set the environment variable IBM_HPCS_TOKEN2 with a VALID token for HPCS Admin Key2
[WARN] Set the environment variable IBM_HPCS_ROOTKEY_CRN with a VALID CRN for a root key created in the HPCS instance
[INFO] Set the environment variable IBM_CLOUD_SHELL_ACCOUNT_ID for ibm-cloud-shell resource or datasource else tests will fail if this is not set correctly
[WARN] Set the environment variable IBM_CLUSTER_VPC_ID for testing ibm_container_vpc_alb_create resources, ibm_container_vpc_alb_create tests will fail if this is not set
[WARN] Set the environment variable IBM_CLUSTER_VPC_SUBNET_ID for testing ibm_container_vpc_alb_create resources, ibm_container_vpc_alb_creates tests will fail if this is not set
[WARN] Set the environment variable IBM_CLUSTER_VPC_RESOURCE_GROUP_ID for testing ibm_container_vpc_alb_create resources, ibm_container_vpc_alb_creates tests will fail if this is not set
[INFO] Set the environment variable IBM_CONTAINER_CLUSTER_NAME for ibm_container_nlb_dns resource or datasource else tests will fail if this is not set correctly
[INFO] Set the environment variable SATELLITE_LOCATION_ID for ibm_cos_bucket satellite location resource or datasource else tests will fail if this is not set correctly
[INFO] Set the environment variable SATELLITE_RESOURCE_INSTANCE_ID for ibm_cos_bucket satellite location resource or datasource else tests will fail if this is not set correctly
[WARN] Set the environment variable IBMCLOUD_CONFIG_AGGREGATOR_ENDPOINT with a VALID SCC API ENDPOINT
[WARN] Set the environment variable IBMCLOUD_CONFIG_AGGREGATOR_INSTANCE_ID with a VALID SCC INSTANCE ID
[WARN] Set the environment variable IBMCLOUD_SCC_INSTANCE_ID with a VALID SCC INSTANCE ID
[WARN] Set the environment variable IBMCLOUD_SCC_API_ENDPOINT with a VALID SCC API ENDPOINT
[WARN] Set the environment variable IBMCLOUD_SCC_REPORT_ID with a VALID SCC REPORT ID
[WARN] Set the environment variable IBMCLOUD_SCC_PROVIDER_TYPE_ATTRIBUTES with a VALID SCC PROVIDER TYPE ATTRIBUTE
[WARN] Set the environment variable IBMCLOUD_SCC_PROVIDER_TYPE_ID with a VALID SCC PROVIDER TYPE ID
[WARN] Set the environment variable IBMCLOUD_SCC_EVENT_NOTIFICATION_CRN
[WARN] Set the environment variable IBMCLOUD_SCC_OBJECT_STORAGE_CRN with a valid cloud object storage crn
[WARN] Set the environment variable IBMCLOUD_SCC_OBJECT_STORAGE_BUCKET with a valid cloud object storage bucket
[INFO] Set the environment variable IBM_CONTAINER_DEDICATEDHOST_POOL_ID for ibm_container_vpc_cluster resource to test dedicated host functionality
[INFO] Set the environment variable IBM_KMS_INSTANCE_ID for ibm_container_vpc_cluster resource or datasource else tests will fail if this is not set correctly
[INFO] Set the environment variable IBM_CRK_ID for ibm_container_vpc_cluster resource or datasource else tests will fail if this is not set correctly
[INFO] Set the environment variable IBM_KMS_ACCOUNT_ID for ibm_container_vpc_cluster resource or datasource else tests will fail if this is not set correctly
[INFO] Set the environment variable IBM_CLUSTER_ID for ibm_container_vpc_worker_pool resource or datasource else tests will fail if this is not set correctly
[WARN] Set the environment variable IBM_CD_RESOURCE_GROUP_NAME for testing CD resources, CD tests will fail if this is not set
[WARN] Set the environment variable IBM_CD_APPCONFIG_INSTANCE_NAME for testing CD resources, CD tests will fail if this is not set
[WARN] Set the environment variable IBM_CD_KEYPROTECT_INSTANCE_NAME for testing CD resources, CD tests will fail if this is not set
[WARN] Set the environment variable IBM_CD_SECRETSMANAGER_INSTANCE_NAME for testing CD resources, CD tests will fail if this is not set
[WARN] Set the environment variable IBM_CD_SLACK_CHANNEL_NAME for testing CD resources, CD tests will fail if this is not set
[WARN] Set the environment variable IBM_CD_SLACK_TEAM_NAME for testing CD resources, CD tests will fail if this is not set
[WARN] Set the environment variable IBM_CD_SLACK_WEBHOOK for testing CD resources, CD tests will fail if this is not set
[WARN] Set the environment variable IBM_CD_JIRA_PROJECT_KEY for testing CD resources, CD tests will fail if this is not set
[WARN] Set the environment variable IBM_CD_JIRA_API_URL for testing CD resources, CD tests will fail if this is not set
[WARN] Set the environment variable IBM_CD_JIRA_USERNAME for testing CD resources, CD tests will fail if this is not set
[WARN] Set the environment variable IBM_CD_JIRA_API_TOKEN for testing CD resources, CD tests will fail if this is not set
[WARN] Set the environment variable IBM_CD_SAUCELABS_ACCESS_KEY for testing CD resources, CD tests will fail if this is not set
[WARN] Set the environment variable IBM_CD_SAUCELABS_USERNAME for testing CD resources, CD tests will fail if this is not set
[WARN] Set the environment variable IBM_CD_BITBUCKET_REPO_URL for testing CD resources, CD tests will fail if this is not set
[WARN] Set the environment variable IBM_CD_GITHUB_CONSOLIDATED_REPO_URL for testing CD resources, CD tests will fail if this is not set
[WARN] Set the environment variable IBM_CD_GITLAB_REPO_URL for testing CD resources, CD tests will fail if this is not set
[WARN] Set the environment variable IBM_CD_HOSTED_GIT_REPO_URL for testing CD resources, CD tests will fail if this is not set
[WARN] Set the environment variable IBM_CD_EVENTNOTIFICATIONS_INSTANCE_NAME for testing CD resources, CD tests will fail if this is not set
[INFO] Set the environment variable IS_CERTIFICATE_CRN for testing ibm_is_vpn_server resource
[INFO] Set the environment variable IS_CLIENT_CA_CRN for testing ibm_is_vpn_server resource
[INFO] Set the environment variable IBM_AccountID_REPL for setting up authorization policy to enable replication feature resource or datasource else tests will fail if this is not set correctly
[WARN] Set the environment variable COS_API_KEY for testing COS targets, the tests will fail if this is not set
[WARN] Set the environment variable INGESTION_KEY for testing Logdna targets, the tests will fail if this is not set
[WARN] Set the environment variable IES_API_KEY for testing Event streams targets, the tests will fail if this is not set
[WARN] Set the environment variable ENTERPRISE_CRN for testing enterprise backup policy, the tests will fail if this is not set
[WARN] Set the environment variable IBM_CODE_ENGINE_RESOURCE_GROUP_ID with the resource group for Code Engine
[WARN] Set the environment variable IBM_CODE_ENGINE_PROJECT_INSTANCE_ID with the ID of a Code Engine project instance
[WARN] Set the environment variable IBM_CODE_ENGINE_SERVICE_INSTANCE_ID with the ID of a IBM Cloud service instance, e.g. for COS
[WARN] Set the environment variable IBM_CODE_ENGINE_RESOURCE_KEY_ID with the ID of a resource key to access a service instance
[WARN] Set the environment variable IBM_CODE_ENGINE_DOMAIN_MAPPING_NAME with the name of a domain mapping
[WARN] Set the environment variable IBM_CODE_ENGINE_TLS_CERT with the TLS certificate in base64 format
[WARN] Set the environment variable IBM_CODE_ENGINE_TLS_KEY with a TLS key in base64 format
[WARN] Set the environment variable IBM_CODE_ENGINE_TLS_CERT_KEY_PATH to point to CERT KEY file path
[WARN] Set the environment variable IBM_CODE_ENGINE_TLS_CERT_PATH to point to CERT file path
[WARN] Set the environment variable IBM_SATELLITE_SSH_PUB_KEY with a ssh public key or ibm_satellite_* tests may fail
[INFO] Set the environment variable IBMCLOUD_MQCLOUD_CONFIG_ENDPOINT for ibm_mqcloud service else tests will fail if this is not set correctly
[INFO] Set the environment variable IBM_MQCLOUD_DEPLOYMENT_ID for ibm_mqcloud_queue_manager resource or datasource else tests will fail if this is not set correctly
[INFO] Set the environment variable IBM_MQCLOUD_DEPLOYMENT_ID for ibm_mqcloud_queue_manager resource or datasource else tests will fail if this is not set correctly
[INFO] Set the environment variable IBM_MQCLOUD_QUEUEMANAGER_ID for ibm_mqcloud_queue_manager resource or datasource else tests will fail if this is not set correctly
[INFO] Set the environment variable IBM_MQCLOUD_KS_CERT_PATH for ibm_mqcloud_keystore_certificate resource or datasource else tests will fail if this is not set correctly
[INFO] Set the environment variable IBM_MQCLOUD_TS_CERT_PATH for ibm_mqcloud_truststore_certificate resource or datasource else tests will fail if this is not set correctly
[INFO] Set the environment variable IBM_MQCLOUD_QUEUEMANAGER_LOCATION for ibm_mqcloud_queue_manager resource or datasource else tests will fail if this is not set correctly
[INFO] Set the environment variable IBM_MQCLOUD_QUEUEMANAGER_VERSION for ibm_mqcloud_queue_manager resource or datasource else tests will fail if this is not set correctly
[INFO] Set the environment variable IBM_MQCLOUD_QUEUEMANAGER_VERSIONUPDATE for ibm_mqcloud_queue_manager resource or datasource else tests will fail if this is not set correctly
[INFO] Set the environment variable IBM_MQCLOUD_TARGET_CRN for ibm_mqcloud_virtual_private_endpoint resource or datasource else tests will fail if this is not set correctly
[INFO] Set the environment variable IBM_MQCLOUD_TRUSTED_PROFILE for ibm_mqcloud_virtual_private_endpoint resource or datasource else tests will fail if this is not set correctly
[INFO] Set the environment variable IBMCLOUD_LOGS_SERVICE_INSTANCE_ID for testing cloud logs related operations
[INFO] Set the environment variable IBMCLOUD_LOGS_SERVICE_INSTANCE_REGION for testing cloud logs related operations
[INFO] Set the environment variable IBMCLOUD_LOGS_SERVICE_EVENT_NOTIFICATIONS_INSTANCE_ID for testing cloud logs related operations
[INFO] Set the environment variable IBMCLOUD_LOGS_SERVICE_EVENT_NOTIFICATIONS_INSTANCE_REGION for testing cloud logs related operations
[WARN] Set the environment variable IBM_PAG_COS_INSTANCE_NAME for testing IBM PAG resource, the tests will fail if this is not set
[WARN] Set the environment variable IBM_PAG_COS_BUCKET_NAME for testing IBM PAG resource, the tests will fail if this is not set
[WARN] Set the environment variable IBM_PAG_COS_BUCKET_REGION for testing IBM PAG resource, the tests will fail if this is not set
[WARN] Set the environment variable IBM_PAG_VPC_NAME for testing IBM PAG resource, the tests will fail if this is not set
[WARN] Set the environment variable IBM_PAG_SERVICE_PLAN for testing IBM PAG resource, the tests will fail if this is not set
[WARN] Set the environment variable IBM_PAG_VPC_SUBNET_INS_1 for testing IBM PAG resource, the tests will fail if this is not set
[WARN] Set the environment variable IBM_PAG_VPC_SUBNET_INS_2 for testing IBM PAG resource, the tests will fail if this is not set
[WARN] Set the environment variable IBM_PAG_VPC_SUBNET_INS_2 for testing IBM PAG resource, the tests will fail if this is not set
[WARN] Set the environment variable IBM_PAG_VPC_SUBNET_INS_2 for testing IBM PAG resource, the tests will fail if this is not set
[WARN] Set the environment variable IBM_VMAAS_DS_ID for testing ibm_vmaas_vdc resource else tests will fail if this is not set correctly
[WARN] Set the environment variable IBM_VMAAS_DS_PVDC_ID for testing ibm_vmaas_vdc resource else tests will fail if this is not set correctly
[INFO] Set the environment variable IBM_POLICY_ASSIGNMENT_TARGET_ACCOUNT_ID for testing ibm_iam_policy_assignment resource else tests will fail if this is not set correctly
[INFO] Set the environment variable IBM_POLICY_ASSIGNMENT_TARGET_ENTERPRISE_ID for testing ibm_iam_policy_assignment resource else tests will fail if this is not set correctly
[WARN] Set the environment variable PCS_REGISTRATION_ACCOUNT_ID for testing iam_onboarding resource else tests will fail if this is not set correctly
[WARN] Set the environment variable PCS_PRODUCT_WITH_APPROVED_PROGRAMMATIC_NAME for testing iam_onboarding resource else tests will fail if this is not set correctly
[WARN] Set the environment variable PCS_PRODUCT_WITH_APPROVED_PROGRAMMATIC_NAME_2 for testing iam_onboarding resource else tests will fail if this is not set correctly
[WARN] Set the environment variable PCS_PRODUCT_WITH_CATALOG_PRODUCT for testing iam_onboarding resource else tests will fail if this is not set correctly
[WARN] Set the environment variable PCS_CATALOG_PRODUCT for testing iam_onboarding resource else tests will fail if this is not set correctly
[WARN] Set the environment variable PCS_CATALOG_PLAN for testing iam_onboarding resource else tests will fail if this is not set correctly
[WARN] Set the environment variable PCS_IAM_TEGISTRATION_ID for testing iam_onboarding resource else tests will fail if this is not set correctly
=== RUN   TestAccIBMSdsHostBasic
--- PASS: TestAccIBMSdsHostBasic (19.78s)
=== RUN   TestResourceIBMSdsHostVolumeMappingReferenceToMap
--- PASS: TestResourceIBMSdsHostVolumeMappingReferenceToMap (0.00s)
=== RUN   TestResourceIBMSdsHostStorageIdentifiersReferenceToMap
--- PASS: TestResourceIBMSdsHostStorageIdentifiersReferenceToMap (0.00s)
=== RUN   TestResourceIBMSdsHostNetworkInfoReferenceToMap
--- PASS: TestResourceIBMSdsHostNetworkInfoReferenceToMap (0.00s)
=== RUN   TestResourceIBMSdsHostMapToVolumeMappingIdentity
--- PASS: TestResourceIBMSdsHostMapToVolumeMappingIdentity (0.00s)
=== RUN   TestAccIBMSdsVolumeBasic
--- PASS: TestAccIBMSdsVolumeBasic (36.29s)
=== RUN   TestAccIBMSdsVolumeAllArgs
--- PASS: TestAccIBMSdsVolumeAllArgs (38.99s)
=== RUN   TestResourceIBMSdsVolumeHostMappingToMap
--- PASS: TestResourceIBMSdsVolumeHostMappingToMap (0.00s)
PASS
ok      github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/sdsaas  96.846s
```
