### PR TITLE
Change template identity iam_id from Required to Computed

### DIFF
--- a/ibm/service/iamidentity/resource_ibm_iam_trusted_profile_template.go
+++ b/ibm/service/iamidentity/resource_ibm_iam_trusted_profile_template.go
@@ -122,7 +122,7 @@ func ResourceIBMTrustedProfileTemplate() *schema.Resource {
 								Schema: map[string]*schema.Schema{
 									"iam_id": {
 										Type:        schema.TypeString,
-										Required:    true,
+										Computed:    true,
 										Description: "IAM ID of the identity.",
 									},
 									"identifier": {

--- a/ibm/service/iamidentity/resource_ibm_iam_trusted_profile_template_test.go
+++ b/ibm/service/iamidentity/resource_ibm_iam_trusted_profile_template_test.go
@@ -170,7 +170,6 @@ func testAccCheckIBMTrustedProfileTemplateConfig(name string, description string
 					}
 				}
 				identities {
-					iam_id = "crn-crn:v1:staging:public:iam-identity::a/684e0f537b4548eb8d2c9593881a6b03:::"
 					identifier = "crn:v1:staging:public:iam-identity::a/684e0f537b4548eb8d2c9593881a6b03:::"
 					type = "crn"
 				}

--- a/website/docs/r/trusted_profile_template.html.markdown
+++ b/website/docs/r/trusted_profile_template.html.markdown
@@ -31,7 +31,6 @@ resource "ibm_iam_trusted_profile_template" "trusted_profile_template_instance" 
 			}
 		}
 		identities {
-			iam_id = "IBMid-123456789"
 			identifier = "IBMid-123456789"
 			type = "user"
 			accounts = ["3213asv21s3d2vsd6bv54sfb321dfb"]
@@ -66,7 +65,6 @@ Nested schema for **profile**:
 	  Nested schema for **identities**:
 		* `accounts` - (Optional, List) Only valid for the type user. Accounts from which a user can assume the trusted profile.
 		* `description` - (Optional, String) Description of the identity that can assume the trusted profile. This is optional field for all the types of identities. When this field is not set for the identity type 'serviceid' then the description of the service id is used. Description is recommended for the identity type 'crn' E.g. 'Instance 1234 of IBM Cloud Service project'.
-		* `iam_id` - (Required, String) IAM ID of the identity.
 		* `identifier` - (Required, String) Identifier of the identity that can assume the trusted profiles. This can be a user identifier (IAM id), serviceid or crn. Internally it uses account id of the service id for the identifier 'serviceid' and for the identifier 'crn' it uses account id contained in the CRN.
 		* `type` - (Required, String) Type of the identity.
 			* Constraints: Allowable values are: `user`, `serviceid`, `crn`.


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/IBM-Cloud/terraform-provider-ibm/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

The `iam_id` is not a publicly documented parameter for the request and is not required by the API. Our logs indicate there is no recent usage of this parameter.

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
▶ make testacc TEST=./ibm/service/iamidentity/resource_ibm_iam_trusted_profile_template_test.go
==> Checking that code complies with gofmt requirements...
=== RUN   TestAccIBMTrustedProfileTemplateBasic
--- PASS: TestAccIBMTrustedProfileTemplateBasic (57.97s)
=== RUN   TestAccIBMTrustedProfileTemplateVersionBasic
--- PASS: TestAccIBMTrustedProfileTemplateVersionBasic (36.24s)
=== RUN   TestAccIBMTrustedProfileTemplateAllArgs
--- PASS: TestAccIBMTrustedProfileTemplateAllArgs (80.24s)
PASS
ok  	command-line-arguments	176.291s
```
