### PR TITLE
fix: adjust validation for Code Engine application `scale_concurrency_target`

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "go.mod|go.sum|.*.map|^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2024-11-07T15:32:37Z",
+  "generated_at": "2024-11-15T07:40:53Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -1902,7 +1902,7 @@
         "hashed_secret": "b732fb611fd46a38e8667f9972e0cde777fbe37f",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 727,
+        "line_number": 737,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1910,7 +1910,7 @@
         "hashed_secret": "3c956707ac29b4a200e47fceffa923341eed7e4f",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 962,
+        "line_number": 972,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -5024,7 +5024,7 @@
       }
     ]
   },
-  "version": "0.13.1+ibm.62.dss",
+  "version": "0.13.1+ibm.61.dss",
   "word_list": {
     "file": null,
     "hash": null

--- a/ibm/service/codeengine/resource_ibm_code_engine_app.go
+++ b/ibm/service/codeengine/resource_ibm_code_engine_app.go
@@ -269,9 +269,11 @@ func ResourceIbmCodeEngineApp() *schema.Resource {
 				Description: "Optional maximum number of requests that can be processed concurrently per instance.",
 			},
 			"scale_concurrency_target": {
-				Type:        schema.TypeInt,
-				Optional:    true,
-				Description: "Optional threshold of concurrent requests per instance at which one or more additional instances are created. Use this value to scale up instances based on concurrent number of requests. This option defaults to the value of the `scale_concurrency` option, if not specified.",
+				Type:         schema.TypeInt,
+				Optional:     true,
+				Default:      100,
+				ValidateFunc: validate.InvokeValidator("ibm_code_engine_app", "scale_concurrency_target"),
+				Description:  "Optional threshold of concurrent requests per instance at which one or more additional instances are created. Use this value to scale up instances based on concurrent number of requests. This option defaults to the value of the `scale_concurrency` option, if not specified.",
 			},
 			"scale_cpu_limit": {
 				Type:         schema.TypeString,
@@ -466,6 +468,14 @@ func ResourceIbmCodeEngineAppValidator() *validate.ResourceValidator {
 			AllowedValues:              "default, manager, none, reader, writer",
 			Regexp:                     `^(manager|reader|writer|none|default)$`,
 			MinValueLength:             0,
+		},
+		validate.ValidateSchema{
+			Identifier:                 "scale_concurrency_target",
+			ValidateFunctionIdentifier: validate.IntBetween,
+			Type:                       validate.TypeInt,
+			Optional:                   true,
+			MinValue:                   "1",
+			MaxValue:                   "1000",
 		},
 		validate.ValidateSchema{
 			Identifier:                 "scale_cpu_limit",

--- a/website/docs/d/code_engine_app.html.markdown
+++ b/website/docs/d/code_engine_app.html.markdown
@@ -148,7 +148,7 @@ Nested schema for **run_volume_mounts**:
   * Constraints: The default value is `100`.
 
 * `scale_concurrency_target` - (Integer) Optional threshold of concurrent requests per instance at which one or more additional instances are created. Use this value to scale up instances based on concurrent number of requests. This option defaults to the value of the `scale_concurrency` option, if not specified.
-
+  * Constraints: The default value is `100`. The maximum value is `1000`. The minimum value is `1`.
 * `scale_cpu_limit` - (String) Optional number of CPU set for the instance of the app. For valid values see [Supported memory and CPU combinations](https://cloud.ibm.com/docs/codeengine?topic=codeengine-mem-cpu-combo).
   * Constraints: The default value is `1`. The maximum length is `10` characters. The minimum length is `0` characters. The value must match regular expression `/^([0-9.]+)([eEinumkKMGTPB]*)$/`.
 

--- a/website/docs/r/code_engine_app.html.markdown
+++ b/website/docs/r/code_engine_app.html.markdown
@@ -124,6 +124,7 @@ Nested schema for **run_volume_mounts**:
 * `scale_concurrency` - (Optional, Integer) Optional maximum number of requests that can be processed concurrently per instance.
   * Constraints: The default value is `100`.
 * `scale_concurrency_target` - (Optional, Integer) Optional threshold of concurrent requests per instance at which one or more additional instances are created. Use this value to scale up instances based on concurrent number of requests. This option defaults to the value of the `scale_concurrency` option, if not specified.
+	* Constraints: The default value is `100`. The maximum value is `1000`. The minimum value is `1`.
 * `scale_cpu_limit` - (Optional, String) Optional number of CPU set for the instance of the app. For valid values see [Supported memory and CPU combinations](https://cloud.ibm.com/docs/codeengine?topic=codeengine-mem-cpu-combo).
   * Constraints: The default value is `1`. The maximum length is `10` characters. The minimum length is `0` characters. The value must match regular expression `/^([0-9.]+)([eEinumkKMGTPB]*)$/`.
 * `scale_down_delay` - (Optional, Integer) Optional amount of time in seconds that delays the scale-down behavior for an app instance.

--- a/website/docs/r/code_engine_app.html.markdown
+++ b/website/docs/r/code_engine_app.html.markdown
@@ -124,7 +124,7 @@ Nested schema for **run_volume_mounts**:
 * `scale_concurrency` - (Optional, Integer) Optional maximum number of requests that can be processed concurrently per instance.
   * Constraints: The default value is `100`.
 * `scale_concurrency_target` - (Optional, Integer) Optional threshold of concurrent requests per instance at which one or more additional instances are created. Use this value to scale up instances based on concurrent number of requests. This option defaults to the value of the `scale_concurrency` option, if not specified.
-	* Constraints: The default value is `100`. The maximum value is `1000`. The minimum value is `1`.
+  * Constraints: The default value is `100`. The maximum value is `1000`. The minimum value is `1`.
 * `scale_cpu_limit` - (Optional, String) Optional number of CPU set for the instance of the app. For valid values see [Supported memory and CPU combinations](https://cloud.ibm.com/docs/codeengine?topic=codeengine-mem-cpu-combo).
   * Constraints: The default value is `1`. The maximum length is `10` characters. The minimum length is `0` characters. The value must match regular expression `/^([0-9.]+)([eEinumkKMGTPB]*)$/`.
 * `scale_down_delay` - (Optional, Integer) Optional amount of time in seconds that delays the scale-down behavior for an app instance.


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/IBM-Cloud/terraform-provider-ibm/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes a bug that was reported through the customer product support.

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccIbmCodeEngineAppBasic'
...
=== RUN   TestAccIbmCodeEngineAppBasic
--- PASS: TestAccIbmCodeEngineAppBasic (152.98s)
PASS
ok      github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/codeengine      161.841s
...
```

```
$ make testacc TESTARGS='-run=TestAccIbmCodeEngineAppExtended'
...
=== RUN   TestAccIbmCodeEngineAppExtended
--- PASS: TestAccIbmCodeEngineAppExtended (156.58s)
PASS
ok      github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/codeengine      165.746s
...
```

```
$ make testacc TESTARGS='-run=TestAccIbmCodeEngineAppDataSourceBasic'
...
=== RUN   TestAccIbmCodeEngineAppDataSourceBasic
--- PASS: TestAccIbmCodeEngineAppDataSourceBasic (77.75s)
PASS
ok      github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/codeengine      86.017s
...
```

```
$ make testacc TESTARGS='-run=TestAccIbmCodeEngineAppDataSourceExtended'
...
=== RUN   TestAccIbmCodeEngineAppDataSourceExtended
--- PASS: TestAccIbmCodeEngineAppDataSourceExtended (79.72s)
PASS
ok      github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/codeengine      87.443s
...
```