### PR TITLE
Import a resource provisioned with key_protect_id and key_protect_instance attributes set

### DIFF
--- a/ibm/service/database/resource_ibm_database.go
+++ b/ibm/service/database/resource_ibm_database.go
@@ -1604,6 +1604,14 @@ func resourceIBMDatabaseInstanceRead(context context.Context, d *schema.Resource
 		if endpoint, ok := instance.Parameters["service-endpoints"]; ok {
 			d.Set("service_endpoints", endpoint)
 		}
+
+		if encryptionInstance, ok := instance.Parameters["disk_encryption_instance_crn"]; ok {
+			d.Set("key_protect_instance", encryptionInstance)
+		}
+
+		if encryptionKey, ok := instance.Parameters["disk_encryption_key_crn"]; ok {
+			d.Set("key_protect_key", encryptionKey)
+		}
 	}
 
 	d.Set(flex.ResourceName, *instance.Name)

--- a/ibm/service/database/resource_ibm_database_elasticsearch_platinum_test.go
+++ b/ibm/service/database/resource_ibm_database_elasticsearch_platinum_test.go
@@ -274,7 +274,7 @@ func TestAccIBMDatabaseInstanceElasticsearchPlatinumImport(t *testing.T) {
 				ImportState:       true,
 				ImportStateVerify: true,
 				ImportStateVerifyIgnore: []string{
-					"wait_time_minutes", "plan_validation"},
+					"wait_time_minutes", "plan_validation", "deletion_protection"},
 			},
 		},
 	})

--- a/ibm/service/database/resource_ibm_database_elasticsearch_test.go
+++ b/ibm/service/database/resource_ibm_database_elasticsearch_test.go
@@ -271,7 +271,7 @@ func TestAccIBMDatabaseInstanceElasticsearchImport(t *testing.T) {
 				ImportState:       true,
 				ImportStateVerify: true,
 				ImportStateVerifyIgnore: []string{
-					"wait_time_minutes"},
+					"wait_time_minutes", "deletion_protection"},
 			},
 		},
 	})

--- a/ibm/service/database/resource_ibm_database_etcd_test.go
+++ b/ibm/service/database/resource_ibm_database_etcd_test.go
@@ -101,7 +101,7 @@ func TestAccIBMDatabaseInstanceEtcdImport(t *testing.T) {
 				ImportState:       true,
 				ImportStateVerify: true,
 				ImportStateVerifyIgnore: []string{
-					"wait_time_minutes"},
+					"wait_time_minutes", "deletion_protection"},
 			},
 		},
 	})

--- a/ibm/service/database/resource_ibm_database_postgresql_test.go
+++ b/ibm/service/database/resource_ibm_database_postgresql_test.go
@@ -210,8 +210,7 @@ func TestAccIBMDatabaseInstancePostgresImport(t *testing.T) {
 				ImportState:       true,
 				ImportStateVerify: true,
 				ImportStateVerifyIgnore: []string{
-					"wait_time_minutes",
-					"deletion_protection"},
+					"wait_time_minutes", "deletion_protection"},
 			},
 		},
 	})

--- a/ibm/service/database/resource_ibm_database_postgresql_test.go
+++ b/ibm/service/database/resource_ibm_database_postgresql_test.go
@@ -210,7 +210,8 @@ func TestAccIBMDatabaseInstancePostgresImport(t *testing.T) {
 				ImportState:       true,
 				ImportStateVerify: true,
 				ImportStateVerifyIgnore: []string{
-					"wait_time_minutes"},
+					"wait_time_minutes",
+					"deletion_protection"},
 			},
 		},
 	})

--- a/ibm/service/database/resource_ibm_database_rabbitmq_test.go
+++ b/ibm/service/database/resource_ibm_database_rabbitmq_test.go
@@ -108,7 +108,7 @@ func TestAccIBMDatabaseInstanceRabbitmqImport(t *testing.T) {
 				ImportState:       true,
 				ImportStateVerify: true,
 				ImportStateVerifyIgnore: []string{
-					"wait_time_minutes"},
+					"wait_time_minutes", "deletion_protection"},
 			},
 		},
 	})

--- a/ibm/service/database/resource_ibm_database_redis_test.go
+++ b/ibm/service/database/resource_ibm_database_redis_test.go
@@ -113,7 +113,7 @@ func TestAccIBMDatabaseInstanceRedisImport(t *testing.T) {
 				ImportState:       true,
 				ImportStateVerify: true,
 				ImportStateVerifyIgnore: []string{
-					"wait_time_minutes"},
+					"wait_time_minutes", "deletion_protection"},
 			},
 		},
 	})


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/IBM-Cloud/terraform-provider-ibm/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Ticket: https://github.ibm.com/compose/App/issues/1600

**Summary:**
When importing an `ibm_database` terraform resource with `key_protect_key` and `key_protect_instance` attributes set, these values are not read or persisted from the remote state. This causes the resource to be marked for deletion.

**Fix:**
- Add `disk_encryption_instance_crn` and `disk_encryption_key_crn` to `resourceIBMDatabaseInstanceRead`
- Update import tests to ignore `deletion_protection`

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TEST=./ibm/service/database TESTARGS='-run=TestAccIBMDatabaseInstanceRedisImport'
...
=== RUN   TestAccIBMDatabaseInstanceRedisImport
=== PAUSE TestAccIBMDatabaseInstanceRedisImport
=== CONT  TestAccIBMDatabaseInstanceRedisImport
--- PASS: TestAccIBMDatabaseInstanceRedisImport (357.97s)
PASS
...
```
