### PR TITLE
fix: eventstreams sarama clientid

### DIFF
--- a/ibm/service/eventstreams/resource_ibm_event_streams_topic.go
+++ b/ibm/service/eventstreams/resource_ibm_event_streams_topic.go
@@ -7,7 +7,6 @@ import (
 	"context"
 	"fmt"
 	"log"
-	"os"
 	"slices"
 	"strings"
 	"time"
@@ -305,7 +304,7 @@ func createSaramaAdminClient(d *schema.ResourceData, meta interface{}) (sarama.C
 	tenantID := strings.TrimPrefix(strings.Split(adminURL, ".")[0], "https://")
 
 	config := sarama.NewConfig()
-	config.ClientID, _ = os.Hostname()
+	config.ClientID = "terraform-provider-ibm"
 	config.Net.SASL.Enable = true
 	if tenantID != "" && tenantID != "admin" {
 		config.Net.SASL.AuthIdentity = tenantID


### PR DESCRIPTION
**What was done:** A customer reported an error running the provider, 
```
'resourceIBMEventStreamsTopicCreate createSaramaAdminClient: kafka: invalid configuration (ClientID is invalid)'
```
The root cause is the use of `os.Hostname()` for the ClientID, which in rare cases has an illegal value (either it is `""`, or it contains an illegal character such as `$` or `#`).  Change the ClientID to `terraform-provider-ibm` which is legal.

Note: the ClientID has no effect on the Event Streams or Kafka operations. It is just used in some log messages.

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Output from acceptance testing:

Since the same Sarama client is used by all the Event Streams topics tests, it's sufficient to just run the basic tests.

```
% make testacc TEST=./ibm/service/eventstreams TESTARGS='-run=TestAccIBMEventStreamsTopicDataSourceBasic'
   (skipping messages about environment variables)
=== RUN   TestAccIBMEventStreamsTopicDataSourceBasic
=== RUN   TestAccIBMEventStreamsTopicDataSourceBasic
--- PASS: TestAccIBMEventStreamsTopicDataSourceBasic (99.39s)
PASS
ok  	github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/eventstreams	100.978s


% make testacc TEST=./ibm/service/eventstreams TESTARGS='-run=TestAccIBMEventStreamsTopicResourceBasic'
   (skipping messages about environment variables)
=== RUN   TestAccIBMEventStreamsTopicResourceBasic
--- PASS: TestAccIBMEventStreamsTopicResourceBasic (189.22s)
PASS
ok  	github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/eventstreams	191.228s
```

