### PR TITLE
feat(MQaaS): Add Virtual Private Endpoint Gateway Resource

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -34,7 +34,7 @@ test: fmtcheck
 		xargs -t -n4 go test $(TESTARGS) -timeout=30s -parallel=4
 
 testacc: fmtcheck
-	TF_ACC=1 go test -parallel 4 $(TEST) -v $(TESTARGS) -timeout $(TEST_TIMEOUT)
+	TF_ACC=1 go test $(TEST) -v $(TESTARGS) -timeout $(TEST_TIMEOUT) 
 
 testrace: fmtcheck
 	TF_ACC= go test -race $(TEST) $(TESTARGS)

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -34,7 +34,7 @@ test: fmtcheck
 		xargs -t -n4 go test $(TESTARGS) -timeout=30s -parallel=4
 
 testacc: fmtcheck
-	TF_ACC=1 go test $(TEST) -v $(TESTARGS) -timeout $(TEST_TIMEOUT)
+	TF_ACC=1 go test -parallel 4 $(TEST) -v $(TESTARGS) -timeout $(TEST_TIMEOUT)
 
 testrace: fmtcheck
 	TF_ACC= go test -race $(TEST) $(TESTARGS)

--- a/examples/ibm-mqcloud/README.md
+++ b/examples/ibm-mqcloud/README.md
@@ -1,6 +1,6 @@
-# Examples for MQ on Cloud
+# Examples for MQaaS
 
-These examples illustrate how to use the resources and data sources associated with MQ on Cloud.
+These examples illustrate how to use the resources and data sources associated with MQaaS.
 
 The following resources are supported:
 * ibm_mqcloud_queue_manager
@@ -8,6 +8,7 @@ The following resources are supported:
 * ibm_mqcloud_user
 * ibm_mqcloud_keystore_certificate
 * ibm_mqcloud_truststore_certificate
+* ibm_mqcloud_virtual_private_endpoint_gateway
 
 The following data sources are supported:
 * ibm_mqcloud_queue_manager_options
@@ -17,6 +18,8 @@ The following data sources are supported:
 * ibm_mqcloud_user
 * ibm_mqcloud_truststore_certificate
 * ibm_mqcloud_keystore_certificate
+* ibm_mqcloud_virtual_private_endpoint_gateways
+* ibm_mqcloud_virtual_private_endpoint_gateway
 
 ## Usage
 
@@ -30,7 +33,7 @@ $ terraform apply
 
 Run `terraform destroy` when you don't need these resources.
 
-## MQ on Cloud resources
+## MQaaS resources
 
 ### Resource: ibm_mqcloud_queue_manager
 
@@ -50,7 +53,7 @@ resource "ibm_mqcloud_queue_manager" "mqcloud_queue_manager_instance" {
 | Name | Description | Type | Required |
 |------|-------------|------|---------|
 | ibmcloud\_api\_key | IBM Cloud API key | `string` | true |
-| service_instance_guid | The GUID that uniquely identifies the MQ on Cloud service instance. | `string` | true |
+| service_instance_guid | The GUID that uniquely identifies the MQaaS service instance. | `string` | true |
 | name | A queue manager name conforming to MQ restrictions. | `string` | true |
 | display_name | A displayable name for the queue manager - limited only in length. | `string` | false |
 | location | The locations in which the queue manager could be deployed. | `string` | true |
@@ -86,7 +89,7 @@ resource "ibm_mqcloud_application" "mqcloud_application_instance" {
 | Name | Description | Type | Required |
 |------|-------------|------|---------|
 | ibmcloud\_api\_key | IBM Cloud API key | `string` | true |
-| service_instance_guid | The GUID that uniquely identifies the MQ on Cloud service instance. | `string` | true |
+| service_instance_guid | The GUID that uniquely identifies the MQaaS service instance. | `string` | true |
 | name | The name of the application - conforming to MQ rules. | `string` | true |
 
 #### Outputs
@@ -112,7 +115,7 @@ resource "ibm_mqcloud_user" "mqcloud_user_instance" {
 | Name | Description | Type | Required |
 |------|-------------|------|---------|
 | ibmcloud\_api\_key | IBM Cloud API key | `string` | true |
-| service_instance_guid | The GUID that uniquely identifies the MQ on Cloud service instance. | `string` | true |
+| service_instance_guid | The GUID that uniquely identifies the MQaaS service instance. | `string` | true |
 | name | The shortname of the user that will be used as the IBM MQ administrator in interactions with a queue manager for this service instance. | `string` | true |
 | email | The email of the user. | `string` | true |
 
@@ -147,7 +150,7 @@ resource "ibm_mqcloud_keystore_certificate" "mqcloud_keystore_certificate_instan
 | Name | Description | Type | Required |
 |------|-------------|------|---------|
 | ibmcloud\_api\_key | IBM Cloud API key | `string` | true |
-| service_instance_guid | The GUID that uniquely identifies the MQ on Cloud service instance. | `string` | true |
+| service_instance_guid | The GUID that uniquely identifies the MQaaS service instance. | `string` | true |
 | queue_manager_id | The id of the queue manager to retrieve its full details. | `string` | true |
 | label | The label to use for the certificate to be uploaded. | `string` | true |
 | certificate_file | The filename and path of the certificate to be uploaded. | `base64-encoded string` | true |
@@ -187,7 +190,7 @@ resource "ibm_mqcloud_truststore_certificate" "mqcloud_truststore_certificate_in
 | Name | Description | Type | Required |
 |------|-------------|------|---------|
 | ibmcloud\_api\_key | IBM Cloud API key | `string` | true |
-| service_instance_guid | The GUID that uniquely identifies the MQ on Cloud service instance. | `string` | true |
+| service_instance_guid | The GUID that uniquely identifies the MQaaS service instance. | `string` | true |
 | queue_manager_id | The id of the queue manager to retrieve its full details. | `string` | true |
 | label | The label to use for the certificate to be uploaded. | `string` | true |
 | certificate_file | The filename and path of the certificate to be uploaded. | `base64-encoded string` | true |
@@ -208,7 +211,36 @@ resource "ibm_mqcloud_truststore_certificate" "mqcloud_truststore_certificate_in
 | href | The URL for this trust store certificate. |
 | certificate_id | Id of the certificate. |
 
-## MQ on Cloud data sources
+### Resource: ibm_mqcloud_virtual_private_endpoint_gateway
+
+```hcl
+resource "ibm_mqcloud_virtual_private_endpoint_gateway" "mqcloud_virtual_private_endpoint_gateway_instance" {
+  service_instance_guid = var.mqcloud_virtual_private_endpoint_gateway_service_instance_guid
+  trusted_profile = var.mqcloud_virtual_private_endpoint_gateway_trusted_profile
+  name = var.mqcloud_virtual_private_endpoint_gateway_name
+  target_crn = var.mqcloud_virtual_private_endpoint_gateway_target_crn
+}
+```
+
+#### Inputs
+
+| Name | Description | Type | Required |
+|------|-------------|------|---------|
+| ibmcloud\_api\_key | IBM Cloud API key | `string` | true |
+| service_instance_guid | The GUID that uniquely identifies the MQaaS service instance. | `string` | true |
+| trusted_profile | The CRN of the trusted profile to assume for this request. | `string` | false |
+| name | The name of the virtual private endpoint gateway, created by the user. | `string` | true |
+| target_crn | The CRN of the reserved capacity service instance the user is trying to connect to. | `string` | true |
+
+#### Outputs
+
+| Name | Description |
+|------|-------------|
+| href | URL for the details of the virtual private endpoint gateway. |
+| status | The lifecycle state of this virtual privage endpoint. |
+| virtual_private_endpoint_gateway_guid | The ID of the virtual private endpoint gateway which was allocated on creation. |
+
+## MQaaS data sources
 
 ### Data source: ibm_mqcloud_queue_manager_options
 
@@ -222,7 +254,7 @@ data "ibm_mqcloud_queue_manager_options" "mqcloud_queue_manager_options_instance
 
 | Name | Description | Type | Required |
 |------|-------------|------|---------|
-| service_instance_guid | The GUID that uniquely identifies the MQ on Cloud service instance. | `string` | true |
+| service_instance_guid | The GUID that uniquely identifies the MQaaS service instance. | `string` | true |
 
 #### Outputs
 
@@ -246,7 +278,7 @@ data "ibm_mqcloud_queue_manager" "mqcloud_queue_manager_instance" {
 
 | Name | Description | Type | Required |
 |------|-------------|------|---------|
-| service_instance_guid | The GUID that uniquely identifies the MQ on Cloud service instance. | `string` | true |
+| service_instance_guid | The GUID that uniquely identifies the MQaaS service instance. | `string` | true |
 | name | A queue manager name conforming to MQ restrictions. | `string` | false |
 
 #### Outputs
@@ -268,7 +300,7 @@ data "ibm_mqcloud_queue_manager_status" "mqcloud_queue_manager_status_instance" 
 
 | Name | Description | Type | Required |
 |------|-------------|------|---------|
-| service_instance_guid | The GUID that uniquely identifies the MQ on Cloud service instance. | `string` | true |
+| service_instance_guid | The GUID that uniquely identifies the MQaaS service instance. | `string` | true |
 | queue_manager_id | The id of the queue manager to retrieve its full details. | `string` | true |
 
 #### Outputs
@@ -290,7 +322,7 @@ data "ibm_mqcloud_application" "mqcloud_application_instance" {
 
 | Name | Description | Type | Required |
 |------|-------------|------|---------|
-| service_instance_guid | The GUID that uniquely identifies the MQ on Cloud service instance. | `string` | true |
+| service_instance_guid | The GUID that uniquely identifies the MQaaS service instance. | `string` | true |
 | name | The name of the application - conforming to MQ rules. | `string` | false |
 
 #### Outputs
@@ -312,7 +344,7 @@ data "ibm_mqcloud_user" "mqcloud_user_instance" {
 
 | Name | Description | Type | Required |
 |------|-------------|------|---------|
-| service_instance_guid | The GUID that uniquely identifies the MQ on Cloud service instance. | `string` | true |
+| service_instance_guid | The GUID that uniquely identifies the MQaaS service instance. | `string` | true |
 | name | The shortname of the user that will be used as the IBM MQ administrator in interactions with a queue manager for this service instance. | `string` | false |
 
 #### Outputs
@@ -335,7 +367,7 @@ data "ibm_mqcloud_truststore_certificate" "mqcloud_truststore_certificate_instan
 
 | Name | Description | Type | Required |
 |------|-------------|------|---------|
-| service_instance_guid | The GUID that uniquely identifies the MQ on Cloud service instance. | `string` | true |
+| service_instance_guid | The GUID that uniquely identifies the MQaaS service instance. | `string` | true |
 | queue_manager_id | The id of the queue manager to retrieve its full details. | `string` | true |
 | label | Certificate label in queue manager store. | `string` | false |
 
@@ -360,7 +392,7 @@ data "ibm_mqcloud_keystore_certificate" "mqcloud_keystore_certificate_instance" 
 
 | Name | Description | Type | Required |
 |------|-------------|------|---------|
-| service_instance_guid | The GUID that uniquely identifies the MQ on Cloud service instance. | `string` | true |
+| service_instance_guid | The GUID that uniquely identifies the MQaaS service instance. | `string` | true |
 | queue_manager_id | The id of the queue manager to retrieve its full details. | `string` | true |
 | label | Certificate label in queue manager store. | `string` | false |
 
@@ -370,6 +402,57 @@ data "ibm_mqcloud_keystore_certificate" "mqcloud_keystore_certificate_instance" 
 |------|-------------|
 | total_count | The total count of key store certificates. |
 | key_store | The list of key store certificates. |
+
+### Data source: ibm_mqcloud_virtual_private_endpoint_gateways
+
+```hcl
+data "ibm_mqcloud_virtual_private_endpoint_gateways" "mqcloud_virtual_private_endpoint_gateways_instance" {
+  service_instance_guid = var.mqcloud_virtual_private_endpoint_gateways_service_instance_guid
+  trusted_profile = var.mqcloud_virtual_private_endpoint_gateways_trusted_profile
+  name = var.mqcloud_virtual_private_endpoint_gateways_name
+}
+```
+
+#### Inputs
+
+| Name | Description | Type | Required |
+|------|-------------|------|---------|
+| service_instance_guid | The GUID that uniquely identifies the MQaaS service instance. | `string` | true |
+| trusted_profile | The CRN of the trusted profile to assume for this request. | `string` | false |
+| name | The name of the virtual private endpoint gateway, created by the user. | `string` | false |
+
+#### Outputs
+
+| Name | Description |
+|------|-------------|
+| virtual_private_endpoint_gateways | List of virtual private endpoint gateways. |
+
+### Data source: ibm_mqcloud_virtual_private_endpoint_gateway
+
+```hcl
+data "ibm_mqcloud_virtual_private_endpoint_gateway" "mqcloud_virtual_private_endpoint_gateway_instance" {
+  service_instance_guid = var.data_mqcloud_virtual_private_endpoint_gateway_service_instance_guid
+  virtual_private_endpoint_gateway_guid = var.data_mqcloud_virtual_private_endpoint_gateway_virtual_private_endpoint_gateway_guid
+  trusted_profile = var.data_mqcloud_virtual_private_endpoint_gateway_trusted_profile
+}
+```
+
+#### Inputs
+
+| Name | Description | Type | Required |
+|------|-------------|------|---------|
+| service_instance_guid | The GUID that uniquely identifies the MQaaS service instance. | `string` | true |
+| virtual_private_endpoint_gateway_guid | The id of the virtual private endpoint gateway. | `string` | true |
+| trusted_profile | The CRN of the trusted profile to assume for this request. | `string` | false |
+
+#### Outputs
+
+| Name | Description |
+|------|-------------|
+| href | URL for the details of the virtual private endpoint gateway. |
+| name | The name of the virtual private endpoint gateway, created by the user. |
+| target_crn | The CRN of the reserved capacity service instance the user is trying to connect to. |
+| status | The lifecycle state of this virtual privage endpoint. |
 
 ## Assumptions
 

--- a/examples/ibm-mqcloud/main.tf
+++ b/examples/ibm-mqcloud/main.tf
@@ -5,24 +5,24 @@ provider "ibm" {
 // Provision mqcloud_queue_manager resource instance
 resource "ibm_mqcloud_queue_manager" "mqcloud_queue_manager_instance" {
   service_instance_guid = var.mqcloud_queue_manager_service_instance_guid
-  name                  = var.mqcloud_queue_manager_name
-  display_name          = var.mqcloud_queue_manager_display_name
-  location              = var.mqcloud_queue_manager_location
-  size                  = var.mqcloud_queue_manager_size
-  version               = var.mqcloud_queue_manager_version
+  name = var.mqcloud_queue_manager_name
+  display_name = var.mqcloud_queue_manager_display_name
+  location = var.mqcloud_queue_manager_location
+  size = var.mqcloud_queue_manager_size
+  version = var.mqcloud_queue_manager_version
 }
 
 // Provision mqcloud_application resource instance
 resource "ibm_mqcloud_application" "mqcloud_application_instance" {
   service_instance_guid = var.mqcloud_application_service_instance_guid
-  name                  = var.mqcloud_application_name
+  name = var.mqcloud_application_name
 }
 
 // Provision mqcloud_user resource instance
 resource "ibm_mqcloud_user" "mqcloud_user_instance" {
   service_instance_guid = var.mqcloud_user_service_instance_guid
-  name                  = var.mqcloud_user_name
-  email                 = var.mqcloud_user_email
+  name = var.mqcloud_user_name
+  email = var.mqcloud_user_email
 }
 
 // Provision mqcloud_keystore_certificate resource instance
@@ -30,6 +30,8 @@ resource "ibm_mqcloud_keystore_certificate" "mqcloud_keystore_certificate_instan
   service_instance_guid = var.mqcloud_keystore_certificate_service_instance_guid
   queue_manager_id      = var.mqcloud_keystore_certificate_queue_manager_id
   label                 = var.mqcloud_keystore_certificate_label
+  certificate_file      = var.mqcloud_keystore_certificate_certificate_file
+
   certificate_file      = var.mqcloud_keystore_certificate_certificate_file
 
   config {
@@ -44,9 +46,17 @@ resource "ibm_mqcloud_keystore_certificate" "mqcloud_keystore_certificate_instan
 // Provision mqcloud_truststore_certificate resource instance
 resource "ibm_mqcloud_truststore_certificate" "mqcloud_truststore_certificate_instance" {
   service_instance_guid = var.mqcloud_truststore_certificate_service_instance_guid
-  queue_manager_id      = var.mqcloud_truststore_certificate_queue_manager_id
-  label                 = var.mqcloud_truststore_certificate_label
-  certificate_file      = var.mqcloud_truststore_certificate_certificate_file
+  queue_manager_id = var.mqcloud_truststore_certificate_queue_manager_id
+  label = var.mqcloud_truststore_certificate_label
+  certificate_file = var.mqcloud_truststore_certificate_certificate_file
+}
+
+// Provision mqcloud_virtual_private_endpoint_gateway resource instance
+resource "ibm_mqcloud_virtual_private_endpoint_gateway" "mqcloud_virtual_private_endpoint_gateway_instance" {
+  service_instance_guid = var.mqcloud_virtual_private_endpoint_gateway_service_instance_guid
+  trusted_profile = var.mqcloud_virtual_private_endpoint_gateway_trusted_profile
+  name = var.mqcloud_virtual_private_endpoint_gateway_name
+  target_crn = var.mqcloud_virtual_private_endpoint_gateway_target_crn
 }
 
 // Data source is not linked to a resource instance
@@ -117,5 +127,27 @@ data "ibm_mqcloud_keystore_certificate" "mqcloud_keystore_certificate_instance" 
   service_instance_guid = var.data_mqcloud_keystore_certificate_service_instance_guid
   queue_manager_id = var.data_mqcloud_keystore_certificate_queue_manager_id
   label = var.data_mqcloud_keystore_certificate_label
+}
+*/
+
+// Data source is not linked to a resource instance
+// Uncomment if an existing data source instance exists
+/*
+// Create mqcloud_virtual_private_endpoint_gateways data source
+data "ibm_mqcloud_virtual_private_endpoint_gateways" "mqcloud_virtual_private_endpoint_gateways_instance" {
+  service_instance_guid = var.mqcloud_virtual_private_endpoint_gateways_service_instance_guid
+  trusted_profile = var.mqcloud_virtual_private_endpoint_gateways_trusted_profile
+  name = var.mqcloud_virtual_private_endpoint_gateways_name
+}
+*/
+
+// Data source is not linked to a resource instance
+// Uncomment if an existing data source instance exists
+/*
+// Create mqcloud_virtual_private_endpoint_gateway data source
+data "ibm_mqcloud_virtual_private_endpoint_gateway" "mqcloud_virtual_private_endpoint_gateway_instance" {
+  service_instance_guid = var.data_mqcloud_virtual_private_endpoint_gateway_service_instance_guid
+  virtual_private_endpoint_gateway_guid = var.data_mqcloud_virtual_private_endpoint_gateway_virtual_private_endpoint_gateway_guid
+  trusted_profile = var.data_mqcloud_virtual_private_endpoint_gateway_trusted_profile
 }
 */

--- a/examples/ibm-mqcloud/outputs.tf
+++ b/examples/ibm-mqcloud/outputs.tf
@@ -28,3 +28,9 @@ output "ibm_mqcloud_truststore_certificate" {
   value       = ibm_mqcloud_truststore_certificate.mqcloud_truststore_certificate_instance
   description = "mqcloud_truststore_certificate resource instance"
 }
+// This output allows mqcloud_virtual_private_endpoint_gateway data to be referenced by other resources and the terraform CLI
+// Modify this output if only certain data should be exposed
+output "ibm_mqcloud_virtual_private_endpoint_gateway" {
+  value       = ibm_mqcloud_virtual_private_endpoint_gateway.mqcloud_virtual_private_endpoint_gateway_instance
+  description = "mqcloud_virtual_private_endpoint_gateway resource instance"
+}

--- a/examples/ibm-mqcloud/variables.tf
+++ b/examples/ibm-mqcloud/variables.tf
@@ -5,7 +5,7 @@ variable "ibmcloud_api_key" {
 
 // Resource arguments for mqcloud_queue_manager
 variable "mqcloud_queue_manager_service_instance_guid" {
-  description = "The GUID that uniquely identifies the MQ on Cloud service instance."
+  description = "The GUID that uniquely identifies the MQaaS service instance."
   type        = string
   default     = "Service Instance ID"
 }
@@ -37,7 +37,7 @@ variable "mqcloud_queue_manager_version" {
 
 // Resource arguments for mqcloud_application
 variable "mqcloud_application_service_instance_guid" {
-  description = "The GUID that uniquely identifies the MQ on Cloud service instance."
+  description = "The GUID that uniquely identifies the MQaaS service instance."
   type        = string
   default     = "Service Instance ID"
 }
@@ -49,7 +49,7 @@ variable "mqcloud_application_name" {
 
 // Resource arguments for mqcloud_user
 variable "mqcloud_user_service_instance_guid" {
-  description = "The GUID that uniquely identifies the MQ on Cloud service instance."
+  description = "The GUID that uniquely identifies the MQaaS service instance."
   type        = string
   default     = "Service Instance ID"
 }
@@ -66,7 +66,7 @@ variable "mqcloud_user_email" {
 
 // Resource arguments for mqcloud_keystore_certificate
 variable "mqcloud_keystore_certificate_service_instance_guid" {
-  description = "The GUID that uniquely identifies the MQ on Cloud service instance."
+  description = "The GUID that uniquely identifies the MQaaS service instance."
   type        = string
   default     = "Service Instance ID"
 }
@@ -85,6 +85,7 @@ variable "mqcloud_keystore_certificate_certificate_file" {
   type        = string
   default     = "SGVsbG8gd29ybGQ="
 }
+
 variable "mqcloud_keystore_certificate_config_ams_channel_name" {
   description = "A channel's information that is configured with this certificate."
   type        = string
@@ -93,7 +94,7 @@ variable "mqcloud_keystore_certificate_config_ams_channel_name" {
 
 // Resource arguments for mqcloud_truststore_certificate
 variable "mqcloud_truststore_certificate_service_instance_guid" {
-  description = "The GUID that uniquely identifies the MQ on Cloud service instance."
+  description = "The GUID that uniquely identifies the MQaaS service instance."
   type        = string
   default     = "Service Instance ID"
 }
@@ -113,16 +114,38 @@ variable "mqcloud_truststore_certificate_certificate_file" {
   default     = "SGVsbG8gd29ybGQ="
 }
 
+// Resource arguments for mqcloud_virtual_private_endpoint_gateway
+variable "mqcloud_virtual_private_endpoint_gateway_service_instance_guid" {
+  description = "The GUID that uniquely identifies the MQaaS service instance."
+  type        = string
+  default     = "Service Instance ID"
+}
+variable "mqcloud_virtual_private_endpoint_gateway_trusted_profile" {
+  description = "The CRN of the trusted profile to assume for this request."
+  type        = string
+  default     = "CRN of Trusted Profile"
+}
+variable "mqcloud_virtual_private_endpoint_gateway_name" {
+  description = "The name of the virtual private endpoint gateway, created by the user."
+  type        = string
+  default     = "vpe-gateway1-to-vpe-gateway2"
+}
+variable "mqcloud_virtual_private_endpoint_gateway_target_crn" {
+  description = "The CRN of the reserved capacity service instance the user is trying to connect to."
+  type        = string
+  default     = "Virtual Private Endpoint CRN"
+}
+
 // Data source arguments for mqcloud_queue_manager_options
 variable "mqcloud_queue_manager_options_service_instance_guid" {
-  description = "The GUID that uniquely identifies the MQ on Cloud service instance."
+  description = "The GUID that uniquely identifies the MQaaS service instance."
   type        = string
   default     = "Service Instance ID"
 }
 
 // Data source arguments for mqcloud_queue_manager
 variable "data_mqcloud_queue_manager_service_instance_guid" {
-  description = "The GUID that uniquely identifies the MQ on Cloud service instance."
+  description = "The GUID that uniquely identifies the MQaaS service instance."
   type        = string
   default     = "Service Instance ID"
 }
@@ -134,7 +157,7 @@ variable "data_mqcloud_queue_manager_name" {
 
 // Data source arguments for mqcloud_queue_manager_status
 variable "mqcloud_queue_manager_status_service_instance_guid" {
-  description = "The GUID that uniquely identifies the MQ on Cloud service instance."
+  description = "The GUID that uniquely identifies the MQaaS service instance."
   type        = string
   default     = "Service Instance ID"
 }
@@ -146,7 +169,7 @@ variable "mqcloud_queue_manager_status_queue_manager_id" {
 
 // Data source arguments for mqcloud_application
 variable "data_mqcloud_application_service_instance_guid" {
-  description = "The GUID that uniquely identifies the MQ on Cloud service instance."
+  description = "The GUID that uniquely identifies the MQaaS service instance."
   type        = string
   default     = "Service Instance ID"
 }
@@ -158,7 +181,7 @@ variable "data_mqcloud_application_name" {
 
 // Data source arguments for mqcloud_user
 variable "data_mqcloud_user_service_instance_guid" {
-  description = "The GUID that uniquely identifies the MQ on Cloud service instance."
+  description = "The GUID that uniquely identifies the MQaaS service instance."
   type        = string
   default     = "Service Instance ID"
 }
@@ -170,7 +193,7 @@ variable "data_mqcloud_user_name" {
 
 // Data source arguments for mqcloud_truststore_certificate
 variable "data_mqcloud_truststore_certificate_service_instance_guid" {
-  description = "The GUID that uniquely identifies the MQ on Cloud service instance."
+  description = "The GUID that uniquely identifies the MQaaS service instance."
   type        = string
   default     = "Service Instance ID"
 }
@@ -187,7 +210,7 @@ variable "data_mqcloud_truststore_certificate_label" {
 
 // Data source arguments for mqcloud_keystore_certificate
 variable "data_mqcloud_keystore_certificate_service_instance_guid" {
-  description = "The GUID that uniquely identifies the MQ on Cloud service instance."
+  description = "The GUID that uniquely identifies the MQaaS service instance."
   type        = string
   default     = "Service Instance ID"
 }
@@ -200,4 +223,38 @@ variable "data_mqcloud_keystore_certificate_label" {
   description = "Certificate label in queue manager store."
   type        = string
   default     = "label"
+}
+
+// Data source arguments for mqcloud_virtual_private_endpoint_gateways
+variable "mqcloud_virtual_private_endpoint_gateways_service_instance_guid" {
+  description = "The GUID that uniquely identifies the MQaaS service instance."
+  type        = string
+  default     = "a2b4d4bc-dadb-4637-bcec-9b7d1e723af8"
+}
+variable "mqcloud_virtual_private_endpoint_gateways_trusted_profile" {
+  description = "The CRN of the trusted profile to assume for this request."
+  type        = string
+  default     = "crn:v1:staging:public:mq-eude-stackname:eu-de:::endpoint:qm1.private.stackname.mq2.test.appdomain.cloud"
+}
+variable "mqcloud_virtual_private_endpoint_gateways_name" {
+  description = "The name of the virtual private endpoint gateway, created by the user."
+  type        = string
+  default     = "name"
+}
+
+// Data source arguments for mqcloud_virtual_private_endpoint_gateway
+variable "data_mqcloud_virtual_private_endpoint_gateway_service_instance_guid" {
+  description = "The GUID that uniquely identifies the MQaaS service instance."
+  type        = string
+  default     = "a2b4d4bc-dadb-4637-bcec-9b7d1e723af8"
+}
+variable "data_mqcloud_virtual_private_endpoint_gateway_virtual_private_endpoint_gateway_guid" {
+  description = "The id of the virtual private endpoint gateway."
+  type        = string
+  default     = "r010-ebab3c08-c9a8-40c4-8869-61c09ddf7b44"
+}
+variable "data_mqcloud_virtual_private_endpoint_gateway_trusted_profile" {
+  description = "The CRN of the trusted profile to assume for this request."
+  type        = string
+  default     = "crn:v1:staging:public:mq-eude-stackname:eu-de:::endpoint:qm1.private.stackname.mq2.test.appdomain.cloud"
 }

--- a/go.mod
+++ b/go.mod
@@ -29,7 +29,7 @@ require (
 	github.com/IBM/keyprotect-go-client v0.15.1
 	github.com/IBM/logs-go-sdk v0.3.0
 	github.com/IBM/logs-router-go-sdk v1.0.5
-	github.com/IBM/mqcloud-go-sdk v0.1.0
+	github.com/IBM/mqcloud-go-sdk v0.2.0
 	github.com/IBM/networking-go-sdk v0.49.0
 	github.com/IBM/platform-services-go-sdk v0.70.0
 	github.com/IBM/project-go-sdk v0.3.5

--- a/ibm/acctest/acctest.go
+++ b/ibm/acctest/acctest.go
@@ -132,15 +132,17 @@ var (
 
 // MQ on Cloud
 var (
-	MqcloudConfigEndpoint            string
-	MqcloudDeploymentID              string
-	MqcloudCapacityID                string
-	MqcloudQueueManagerID            string
-	MqcloudKSCertFilePath            string
-	MqcloudTSCertFilePath            string
-	MqCloudQueueManagerLocation      string
-	MqCloudQueueManagerVersion       string
-	MqCloudQueueManagerVersionUpdate string
+	MqcloudConfigEndpoint                       string
+	MqcloudDeploymentID                         string
+	MqcloudCapacityID                           string
+	MqcloudQueueManagerID                       string
+	MqcloudKSCertFilePath                       string
+	MqcloudTSCertFilePath                       string
+	MqCloudQueueManagerLocation                 string
+	MqCloudQueueManagerVersion                  string
+	MqCloudQueueManagerVersionUpdate            string
+	MqCloudVirtualPrivateEndPointTargetCrn      string
+	MqCloudVirtualPrivateEndPointTrustedProfile string
 )
 
 // Logs
@@ -1900,6 +1902,14 @@ func init() {
 	MqCloudQueueManagerVersionUpdate = os.Getenv(("IBM_MQCLOUD_QUEUEMANAGER_VERSIONUPDATE"))
 	if MqCloudQueueManagerVersionUpdate == "" {
 		fmt.Println("[INFO] Set the environment variable IBM_MQCLOUD_QUEUEMANAGER_VERSIONUPDATE for ibm_mqcloud_queue_manager resource or datasource else tests will fail if this is not set correctly")
+	}
+	MqCloudVirtualPrivateEndPointTargetCrn = os.Getenv(("IBM_MQCLOUD_TARGET_CRN"))
+	if MqCloudVirtualPrivateEndPointTargetCrn == "" {
+		fmt.Println("[INFO] Set the environment variable IBM_MQCLOUD_TARGET_CRN for ibm_mqcloud_virtual_private_endpoint resource or datasource else tests will fail if this is not set correctly")
+	}
+	MqCloudVirtualPrivateEndPointTrustedProfile = os.Getenv(("IBM_MQCLOUD_TRUSTED_PROFILE"))
+	if MqCloudVirtualPrivateEndPointTrustedProfile == "" {
+		fmt.Println("[INFO] Set the environment variable IBM_MQCLOUD_TRUSTED_PROFILE for ibm_mqcloud_virtual_private_endpoint resource or datasource else tests will fail if this is not set correctly")
 	}
 	LogsInstanceId = os.Getenv("IBMCLOUD_LOGS_SERVICE_INSTANCE_ID")
 	if LogsInstanceId == "" {

--- a/ibm/acctest/acctest.go
+++ b/ibm/acctest/acctest.go
@@ -133,7 +133,8 @@ var (
 // MQ on Cloud
 var (
 	MqcloudConfigEndpoint            string
-	MqcloudInstanceID                string
+	MqcloudDeploymentID              string
+	MqcloudCapacityID                string
 	MqcloudQueueManagerID            string
 	MqcloudKSCertFilePath            string
 	MqcloudTSCertFilePath            string
@@ -1868,9 +1869,13 @@ func init() {
 		fmt.Println("[INFO] Set the environment variable IBMCLOUD_MQCLOUD_CONFIG_ENDPOINT for ibm_mqcloud service else tests will fail if this is not set correctly")
 	}
 
-	MqcloudInstanceID = os.Getenv("IBM_MQCLOUD_INSTANCE_ID")
-	if MqcloudInstanceID == "" {
-		fmt.Println("[INFO] Set the environment variable IBM_MQCLOUD_INSTANCE_ID for ibm_mqcloud_queue_manager resource or datasource else tests will fail if this is not set correctly")
+	MqcloudDeploymentID = os.Getenv("IBM_MQCLOUD_DEPLOYMENT_ID")
+	if MqcloudDeploymentID == "" {
+		fmt.Println("[INFO] Set the environment variable IBM_MQCLOUD_DEPLOYMENT_ID for ibm_mqcloud_queue_manager resource or datasource else tests will fail if this is not set correctly")
+	}
+	MqcloudCapacityID = os.Getenv("IBM_MQCLOUD_CAPACITY_ID")
+	if MqcloudCapacityID == "" {
+		fmt.Println("[INFO] Set the environment variable IBM_MQCLOUD_DEPLOYMENT_ID for ibm_mqcloud_queue_manager resource or datasource else tests will fail if this is not set correctly")
 	}
 	MqcloudQueueManagerID = os.Getenv("IBM_MQCLOUD_QUEUEMANAGER_ID")
 	if MqcloudQueueManagerID == "" {
@@ -2267,8 +2272,11 @@ func TestAccPreCheckMqcloud(t *testing.T) {
 	if MqcloudConfigEndpoint == "" {
 		t.Fatal("IBMCLOUD_MQCLOUD_CONFIG_ENDPOINT must be set for acceptance tests")
 	}
-	if MqcloudInstanceID == "" {
-		t.Fatal("IBM_MQCLOUD_INSTANCE_ID must be set for acceptance tests")
+	if MqcloudDeploymentID == "" {
+		t.Fatal("IBM_MQCLOUD_DEPLOYMENT_ID must be set for acceptance tests")
+	}
+	if MqcloudCapacityID == "" {
+		t.Fatal("IBM_MQCLOUD_CAPACITY_ID must be set for acceptance tests")
 	}
 	if MqcloudQueueManagerID == "" {
 		t.Fatal("IBM_MQCLOUD_QUEUEMANAGER_ID must be set for acceptance tests")

--- a/ibm/conns/config.go
+++ b/ibm/conns/config.go
@@ -1262,7 +1262,7 @@ func (session clientSession) ProjectV1() (*project.ProjectV1, error) {
 	return session.projectClient, session.projectClientErr
 }
 
-// MQ on Cloud
+// MQaaS
 func (session clientSession) MqcloudV1() (*mqcloudv1.MqcloudV1, error) {
 	if session.mqcloudClientErr != nil {
 		sessionMqcloudClient := session.mqcloudClient
@@ -1567,20 +1567,10 @@ func (c *Config) ClientSession() (interface{}, error) {
 
 	var authenticator core.Authenticator
 
-	if c.BluemixAPIKey != "" || sess.BluemixSession.Config.IAMRefreshToken != "" {
-		if c.BluemixAPIKey != "" {
-			authenticator = &core.IamAuthenticator{
-				ApiKey: c.BluemixAPIKey,
-				URL:    EnvFallBack([]string{"IBMCLOUD_IAM_API_ENDPOINT"}, iamURL),
-			}
-		} else {
-			// Construct the IamAuthenticator with the IAM refresh token.
-			authenticator = &core.IamAuthenticator{
-				RefreshToken: sess.BluemixSession.Config.IAMRefreshToken,
-				ClientId:     "bx",
-				ClientSecret: "bx",
-				URL:          EnvFallBack([]string{"IBMCLOUD_IAM_API_ENDPOINT"}, iamURL),
-			}
+	if c.BluemixAPIKey != "" {
+		authenticator = &core.IamAuthenticator{
+			ApiKey: c.BluemixAPIKey,
+			URL:    EnvFallBack([]string{"IBMCLOUD_IAM_API_ENDPOINT"}, "https://iam.cloud.ibm.com") + "/identity/token",
 		}
 	} else if strings.HasPrefix(sess.BluemixSession.Config.IAMAccessToken, "Bearer") {
 		authenticator = &core.BearerTokenAuthenticator{
@@ -3448,7 +3438,7 @@ func (c *Config) ClientSession() (interface{}, error) {
 		session.cdTektonPipelineClientErr = fmt.Errorf("Error occurred while configuring CD Tekton Pipeline service: %q", err)
 	}
 
-	// MQ Cloud Service Configuration
+	// MQaaS Service Configuration
 	mqCloudURL := ContructEndpoint(fmt.Sprintf("api.%s.mq2", c.Region), cloudEndpoint)
 	if c.Visibility == "private" || c.Visibility == "public-and-private" {
 		mqCloudURL = ContructEndpoint(fmt.Sprintf("api.private.%s.mq2", c.Region), cloudEndpoint)
@@ -3463,7 +3453,7 @@ func (c *Config) ClientSession() (interface{}, error) {
 		URL:            EnvFallBack([]string{"IBMCLOUD_MQCLOUD_CONFIG_ENDPOINT"}, mqCloudURL),
 	}
 
-	// Construct the service client for MQ Cloud.
+	// Construct the service client for MQaaS.
 	session.mqcloudClient, err = mqcloudv1.NewMqcloudV1(mqcloudClientOptions)
 	if err == nil {
 		// Enable retries for API calls
@@ -3473,7 +3463,7 @@ func (c *Config) ClientSession() (interface{}, error) {
 			"X-Original-User-Agent": {fmt.Sprintf("terraform-provider-ibm/%s", version.Version)},
 		})
 	} else {
-		session.mqcloudClientErr = fmt.Errorf("Error occurred while configuring MQ on Cloud service: %q", err)
+		session.mqcloudClientErr = fmt.Errorf("Error occurred while configuringMQaaS service: %q", err)
 	}
 
 	// VMware as a Service

--- a/ibm/provider/provider.go
+++ b/ibm/provider/provider.go
@@ -817,13 +817,15 @@ func Provider() *schema.Provider {
 			"ibm_metrics_router_routes":  metricsrouter.DataSourceIBMMetricsRouterRoutes(),
 
 			// MQ on Cloud
-			"ibm_mqcloud_queue_manager_options":  mqcloud.DataSourceIbmMqcloudQueueManagerOptions(),
-			"ibm_mqcloud_queue_manager":          mqcloud.DataSourceIbmMqcloudQueueManager(),
-			"ibm_mqcloud_queue_manager_status":   mqcloud.DataSourceIbmMqcloudQueueManagerStatus(),
-			"ibm_mqcloud_application":            mqcloud.DataSourceIbmMqcloudApplication(),
-			"ibm_mqcloud_user":                   mqcloud.DataSourceIbmMqcloudUser(),
-			"ibm_mqcloud_truststore_certificate": mqcloud.DataSourceIbmMqcloudTruststoreCertificate(),
-			"ibm_mqcloud_keystore_certificate":   mqcloud.DataSourceIbmMqcloudKeystoreCertificate(),
+			"ibm_mqcloud_queue_manager_options":             mqcloud.DataSourceIbmMqcloudQueueManagerOptions(),
+			"ibm_mqcloud_queue_manager":                     mqcloud.DataSourceIbmMqcloudQueueManager(),
+			"ibm_mqcloud_queue_manager_status":              mqcloud.DataSourceIbmMqcloudQueueManagerStatus(),
+			"ibm_mqcloud_application":                       mqcloud.DataSourceIbmMqcloudApplication(),
+			"ibm_mqcloud_user":                              mqcloud.DataSourceIbmMqcloudUser(),
+			"ibm_mqcloud_truststore_certificate":            mqcloud.DataSourceIbmMqcloudTruststoreCertificate(),
+			"ibm_mqcloud_keystore_certificate":              mqcloud.DataSourceIbmMqcloudKeystoreCertificate(),
+			"ibm_mqcloud_virtual_private_endpoint_gateways": mqcloud.DataSourceIbmMqcloudVirtualPrivateEndpointGateways(),
+			"ibm_mqcloud_virtual_private_endpoint_gateway":  mqcloud.DataSourceIbmMqcloudVirtualPrivateEndpointGateway(),
 
 			// Security and Complaince Center(soon to be deprecated)
 			"ibm_scc_account_location":              scc.DataSourceIBMSccAccountLocation(),
@@ -1461,11 +1463,12 @@ func Provider() *schema.Provider {
 			"ibm_metrics_router_settings": metricsrouter.ResourceIBMMetricsRouterSettings(),
 
 			// MQ on Cloud
-			"ibm_mqcloud_queue_manager":          mqcloud.ResourceIbmMqcloudQueueManager(),
-			"ibm_mqcloud_application":            mqcloud.ResourceIbmMqcloudApplication(),
-			"ibm_mqcloud_user":                   mqcloud.ResourceIbmMqcloudUser(),
-			"ibm_mqcloud_keystore_certificate":   mqcloud.ResourceIbmMqcloudKeystoreCertificate(),
-			"ibm_mqcloud_truststore_certificate": mqcloud.ResourceIbmMqcloudTruststoreCertificate(),
+			"ibm_mqcloud_queue_manager":                    mqcloud.ResourceIbmMqcloudQueueManager(),
+			"ibm_mqcloud_application":                      mqcloud.ResourceIbmMqcloudApplication(),
+			"ibm_mqcloud_user":                             mqcloud.ResourceIbmMqcloudUser(),
+			"ibm_mqcloud_keystore_certificate":             mqcloud.ResourceIbmMqcloudKeystoreCertificate(),
+			"ibm_mqcloud_truststore_certificate":           mqcloud.ResourceIbmMqcloudTruststoreCertificate(),
+			"ibm_mqcloud_virtual_private_endpoint_gateway": mqcloud.ResourceIbmMqcloudVirtualPrivateEndpointGateway(),
 
 			// Security and Compliance Center(soon to be deprecated)
 			"ibm_scc_account_settings":    scc.ResourceIBMSccAccountSettings(),
@@ -1857,11 +1860,12 @@ func Validator() validate.ValidatorDict {
 				"ibm_config_aggregator_settings":               configurationaggregator.ResourceIbmConfigAggregatorSettingsValidator(),
 
 				// MQ on Cloud
-				"ibm_mqcloud_queue_manager":          mqcloud.ResourceIbmMqcloudQueueManagerValidator(),
-				"ibm_mqcloud_application":            mqcloud.ResourceIbmMqcloudApplicationValidator(),
-				"ibm_mqcloud_user":                   mqcloud.ResourceIbmMqcloudUserValidator(),
-				"ibm_mqcloud_keystore_certificate":   mqcloud.ResourceIbmMqcloudKeystoreCertificateValidator(),
-				"ibm_mqcloud_truststore_certificate": mqcloud.ResourceIbmMqcloudTruststoreCertificateValidator(),
+				"ibm_mqcloud_queue_manager":                    mqcloud.ResourceIbmMqcloudQueueManagerValidator(),
+				"ibm_mqcloud_application":                      mqcloud.ResourceIbmMqcloudApplicationValidator(),
+				"ibm_mqcloud_user":                             mqcloud.ResourceIbmMqcloudUserValidator(),
+				"ibm_mqcloud_keystore_certificate":             mqcloud.ResourceIbmMqcloudKeystoreCertificateValidator(),
+				"ibm_mqcloud_truststore_certificate":           mqcloud.ResourceIbmMqcloudTruststoreCertificateValidator(),
+				"ibm_mqcloud_virtual_private_endpoint_gateway": mqcloud.ResourceIbmMqcloudVirtualPrivateEndpointGatewayValidator(),
 
 				"ibm_is_backup_policy":      vpc.ResourceIBMIsBackupPolicyValidator(),
 				"ibm_is_backup_policy_plan": vpc.ResourceIBMIsBackupPolicyPlanValidator(),

--- a/ibm/service/mqcloud/README.md
+++ b/ibm/service/mqcloud/README.md
@@ -1,4 +1,4 @@
-# Terraform IBM Provider MQ on Cloud
+# Terraform IBM Provider MQaaS
 <!-- markdownlint-disable MD026 -->
 This area is primarily for IBM provider contributors and maintainers. For information on _using_ Terraform and the IBM provider, see the links below.
 
@@ -6,6 +6,6 @@ This area is primarily for IBM provider contributors and maintainers. For inform
 ## Handy Links
 * [Find out about contributing](../../../CONTRIBUTING.md) to the IBM provider!
 * IBM Provider Docs: [Home](https://registry.terraform.io/providers/IBM-Cloud/ibm/latest/docs)
-* IBM Provider Docs: [One of the MQ on Cloud resources](https://registry.terraform.io/providers/IBM-Cloud/ibm/latest/docs/resources/mqcloud_queue_manager)
-* IBM API Docs: [IBM API Docs for MQ on Cloud](https://cloud.ibm.com/apidocs/mq-on-cloud)
-* IBM MQ on Cloud SDK: [IBM SDK for MQ on Cloud](https://github.com/IBM/mqcloud-go-sdk/tree/main/mqcloudv1)
+* IBM Provider Docs: [One of the MQaaS resources](https://registry.terraform.io/providers/IBM-Cloud/ibm/latest/docs/resources/mqcloud_queue_manager)
+* IBM API Docs: [IBM API Docs for MQaaS](https://cloud.ibm.com/apidocs/mq-on-cloud)
+* IBM MQaaS SDK: [IBM SDK for MQaaS](https://github.com/IBM/mqcloud-go-sdk/tree/main/mqcloudv1)

--- a/ibm/service/mqcloud/data_source_ibm_mqcloud_application.go
+++ b/ibm/service/mqcloud/data_source_ibm_mqcloud_application.go
@@ -2,7 +2,7 @@
 // Licensed under the Mozilla Public License v2.0
 
 /*
- * IBM OpenAPI Terraform Generator Version: 3.90.0-5aad763d-20240506-203857
+ * IBM OpenAPI Terraform Generator Version: 3.95.2-120e65bc-20240924-152329
  */
 
 package mqcloud
@@ -29,7 +29,7 @@ func DataSourceIbmMqcloudApplication() *schema.Resource {
 			"service_instance_guid": {
 				Type:        schema.TypeString,
 				Required:    true,
-				Description: "The GUID that uniquely identifies the MQ on Cloud service instance.",
+				Description: "The GUID that uniquely identifies the MQaaS service instance.",
 			},
 			"name": {
 				Type:        schema.TypeString,
@@ -134,7 +134,7 @@ func dataSourceIbmMqcloudApplicationRead(context context.Context, d *schema.Reso
 	mapSlice := []map[string]interface{}{}
 	for _, modelItem := range allItems {
 		modelItem := modelItem
-		modelMap, err := DataSourceIbmMqcloudApplicationApplicationDetailsToMap(&modelItem)
+		modelMap, err := DataSourceIbmMqcloudApplicationApplicationDetailsToMap(&modelItem) // #nosec G601
 		if err != nil {
 			tfErr := flex.TerraformErrorf(err, err.Error(), "(Data) ibm_mqcloud_application", "read")
 			return tfErr.GetDiag()

--- a/ibm/service/mqcloud/data_source_ibm_mqcloud_application_test.go
+++ b/ibm/service/mqcloud/data_source_ibm_mqcloud_application_test.go
@@ -2,7 +2,7 @@
 // Licensed under the Mozilla Public License v2.0
 
 /*
- * IBM OpenAPI Terraform Generator Version: 3.90.0-5aad763d-20240506-203857
+ * IBM OpenAPI Terraform Generator Version: 3.95.2-120e65bc-20240924-152329
  */
 
 package mqcloud_test
@@ -22,7 +22,7 @@ import (
 
 func TestAccIbmMqcloudApplicationDataSourceBasic(t *testing.T) {
 	t.Parallel()
-	applicationDetailsServiceInstanceGuid := acc.MqcloudInstanceID
+	applicationDetailsServiceInstanceGuid := acc.MqcloudDeploymentID
 	applicationDetailsName := "appdsbasic"
 
 	resource.Test(t, resource.TestCase{
@@ -57,6 +57,7 @@ func testAccCheckIbmMqcloudApplicationDataSourceConfigBasic(applicationDetailsSe
 }
 
 func TestDataSourceIbmMqcloudApplicationApplicationDetailsToMap(t *testing.T) {
+	t.Parallel()
 	checkResult := func(result map[string]interface{}) {
 		model := make(map[string]interface{})
 		model["id"] = "testString"

--- a/ibm/service/mqcloud/data_source_ibm_mqcloud_keystore_certificate.go
+++ b/ibm/service/mqcloud/data_source_ibm_mqcloud_keystore_certificate.go
@@ -2,7 +2,7 @@
 // Licensed under the Mozilla Public License v2.0
 
 /*
- * IBM OpenAPI Terraform Generator Version: 3.90.0-5aad763d-20240506-203857
+ * IBM OpenAPI Terraform Generator Version: 3.95.2-120e65bc-20240924-152329
  */
 
 package mqcloud
@@ -29,7 +29,7 @@ func DataSourceIbmMqcloudKeystoreCertificate() *schema.Resource {
 			"service_instance_guid": {
 				Type:        schema.TypeString,
 				Required:    true,
-				Description: "The GUID that uniquely identifies the MQ on Cloud service instance.",
+				Description: "The GUID that uniquely identifies the MQaaS service instance.",
 			},
 			"queue_manager_id": {
 				Type:        schema.TypeString,
@@ -285,7 +285,7 @@ func DataSourceIbmMqcloudKeystoreCertificateChannelsDetailsToMap(model *mqcloudv
 	channels := []map[string]interface{}{}
 	for _, channelsItem := range model.Channels {
 		channelsItem := channelsItem
-		channelsItemMap, err := DataSourceIbmMqcloudKeystoreCertificateChannelDetailsToMap(&channelsItem)
+		channelsItemMap, err := DataSourceIbmMqcloudKeystoreCertificateChannelDetailsToMap(&channelsItem) // #nosec G601
 		if err != nil {
 			return modelMap, err
 		}

--- a/ibm/service/mqcloud/data_source_ibm_mqcloud_keystore_certificate_test.go
+++ b/ibm/service/mqcloud/data_source_ibm_mqcloud_keystore_certificate_test.go
@@ -10,7 +10,6 @@ package mqcloud_test
 import (
 	"fmt"
 	"testing"
-	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
@@ -32,7 +31,6 @@ func TestAccIbmMqcloudKeystoreCertificateDataSourceBasic(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			acc.TestAccPreCheckMqcloud(t)
-			time.Sleep(60 * time.Second) //This to allow for completion of certificate processing
 		},
 		Providers: acc.TestAccProviders,
 		Steps: []resource.TestStep{

--- a/ibm/service/mqcloud/data_source_ibm_mqcloud_keystore_certificate_test.go
+++ b/ibm/service/mqcloud/data_source_ibm_mqcloud_keystore_certificate_test.go
@@ -2,7 +2,7 @@
 // Licensed under the Mozilla Public License v2.0
 
 /*
- * IBM OpenAPI Terraform Generator Version: 3.90.0-5aad763d-20240506-203857
+ * IBM OpenAPI Terraform Generator Version: 3.95.2-120e65bc-20240924-152329
  */
 
 package mqcloud_test
@@ -10,6 +10,7 @@ package mqcloud_test
 import (
 	"fmt"
 	"testing"
+	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
@@ -23,14 +24,16 @@ import (
 )
 
 func TestAccIbmMqcloudKeystoreCertificateDataSourceBasic(t *testing.T) {
-	t.Parallel()
-	keyStoreCertificateDetailsServiceInstanceGuid := acc.MqcloudInstanceID
+	keyStoreCertificateDetailsServiceInstanceGuid := acc.MqcloudDeploymentID
 	keyStoreCertificateDetailsQueueManagerID := acc.MqcloudQueueManagerID
 	keyStoreCertificateDetailsLabel := fmt.Sprintf("tf_label_%d", acctest.RandIntRange(10, 100))
 	keyStoreCertificateDetailsCertificateFile := acc.MqcloudKSCertFilePath
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { acc.TestAccPreCheckMqcloud(t) },
+		PreCheck: func() {
+			acc.TestAccPreCheckMqcloud(t)
+			time.Sleep(60 * time.Second) //This to allow for completion of certificate processing
+		},
 		Providers: acc.TestAccProviders,
 		Steps: []resource.TestStep{
 			{

--- a/ibm/service/mqcloud/data_source_ibm_mqcloud_queue_manager.go
+++ b/ibm/service/mqcloud/data_source_ibm_mqcloud_queue_manager.go
@@ -2,7 +2,7 @@
 // Licensed under the Mozilla Public License v2.0
 
 /*
- * IBM OpenAPI Terraform Generator Version: 3.90.0-5aad763d-20240506-203857
+ * IBM OpenAPI Terraform Generator Version: 3.95.2-120e65bc-20240924-152329
  */
 
 package mqcloud
@@ -29,7 +29,7 @@ func DataSourceIbmMqcloudQueueManager() *schema.Resource {
 			"service_instance_guid": {
 				Type:        schema.TypeString,
 				Required:    true,
-				Description: "The GUID that uniquely identifies the MQ on Cloud service instance.",
+				Description: "The GUID that uniquely identifies the MQaaS service instance.",
 			},
 			"name": {
 				Type:        schema.TypeString,
@@ -189,7 +189,7 @@ func dataSourceIbmMqcloudQueueManagerRead(context context.Context, d *schema.Res
 	mapSlice := []map[string]interface{}{}
 	for _, modelItem := range allItems {
 		modelItem := modelItem
-		modelMap, err := DataSourceIbmMqcloudQueueManagerQueueManagerDetailsToMap(&modelItem)
+		modelMap, err := DataSourceIbmMqcloudQueueManagerQueueManagerDetailsToMap(&modelItem) // #nosec G601
 		if err != nil {
 			tfErr := flex.TerraformErrorf(err, err.Error(), "(Data) ibm_mqcloud_queue_manager", "read")
 			return tfErr.GetDiag()

--- a/ibm/service/mqcloud/data_source_ibm_mqcloud_queue_manager_options.go
+++ b/ibm/service/mqcloud/data_source_ibm_mqcloud_queue_manager_options.go
@@ -2,7 +2,7 @@
 // Licensed under the Mozilla Public License v2.0
 
 /*
- * IBM OpenAPI Terraform Generator Version: 3.90.0-5aad763d-20240506-203857
+ * IBM OpenAPI Terraform Generator Version: 3.95.2-120e65bc-20240924-152329
  */
 
 package mqcloud
@@ -29,7 +29,7 @@ func DataSourceIbmMqcloudQueueManagerOptions() *schema.Resource {
 			"service_instance_guid": {
 				Type:        schema.TypeString,
 				Required:    true,
-				Description: "The GUID that uniquely identifies the MQ on Cloud service instance.",
+				Description: "The GUID that uniquely identifies the MQaaS service instance.",
 			},
 			"locations": {
 				Type:        schema.TypeList,
@@ -108,6 +108,7 @@ func dataSourceIbmMqcloudQueueManagerOptionsRead(context context.Context, d *sch
 	if err = d.Set("sizes", configurationOptions.Sizes); err != nil {
 		return flex.DiscriminatedTerraformErrorf(err, fmt.Sprintf("Error setting sizes: %s", err), "(Data) ibm_mqcloud_queue_manager_options", "read", "set-sizes").GetDiag()
 	}
+
 	return nil
 }
 

--- a/ibm/service/mqcloud/data_source_ibm_mqcloud_queue_manager_options_test.go
+++ b/ibm/service/mqcloud/data_source_ibm_mqcloud_queue_manager_options_test.go
@@ -2,7 +2,7 @@
 // Licensed under the Mozilla Public License v2.0
 
 /*
- * IBM OpenAPI Terraform Generator Version: 3.90.0-5aad763d-20240506-203857
+ * IBM OpenAPI Terraform Generator Version: 3.95.2-120e65bc-20240924-152329
  */
 
 package mqcloud_test
@@ -18,7 +18,7 @@ import (
 
 func TestAccIbmMqcloudQueueManagerOptionsDataSourceBasic(t *testing.T) {
 	t.Parallel()
-	service_instance_guid := acc.MqcloudInstanceID
+	service_instance_guid := acc.MqcloudDeploymentID
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:  func() { acc.TestAccPreCheckMqcloud(t) },

--- a/ibm/service/mqcloud/data_source_ibm_mqcloud_queue_manager_status.go
+++ b/ibm/service/mqcloud/data_source_ibm_mqcloud_queue_manager_status.go
@@ -2,7 +2,7 @@
 // Licensed under the Mozilla Public License v2.0
 
 /*
- * IBM OpenAPI Terraform Generator Version: 3.90.0-5aad763d-20240506-203857
+ * IBM OpenAPI Terraform Generator Version: 3.95.2-120e65bc-20240924-152329
  */
 
 package mqcloud
@@ -29,7 +29,7 @@ func DataSourceIbmMqcloudQueueManagerStatus() *schema.Resource {
 			"service_instance_guid": {
 				Type:        schema.TypeString,
 				Required:    true,
-				Description: "The GUID that uniquely identifies the MQ on Cloud service instance.",
+				Description: "The GUID that uniquely identifies the MQaaS service instance.",
 			},
 			"queue_manager_id": {
 				Type:        schema.TypeString,

--- a/ibm/service/mqcloud/data_source_ibm_mqcloud_queue_manager_status_test.go
+++ b/ibm/service/mqcloud/data_source_ibm_mqcloud_queue_manager_status_test.go
@@ -2,7 +2,7 @@
 // Licensed under the Mozilla Public License v2.0
 
 /*
- * IBM OpenAPI Terraform Generator Version: 3.90.0-5aad763d-20240506-203857
+* IBM OpenAPI Terraform Generator Version: 3.95.2-120e65bc-20240924-152329
  */
 
 package mqcloud_test
@@ -18,7 +18,7 @@ import (
 
 func TestAccIbmMqcloudQueueManagerStatusDataSourceBasic(t *testing.T) {
 	t.Parallel()
-	service_instance_guid := acc.MqcloudInstanceID
+	service_instance_guid := acc.MqcloudDeploymentID
 	queue_manager_id := acc.MqcloudQueueManagerID
 
 	resource.Test(t, resource.TestCase{

--- a/ibm/service/mqcloud/data_source_ibm_mqcloud_queue_manager_test.go
+++ b/ibm/service/mqcloud/data_source_ibm_mqcloud_queue_manager_test.go
@@ -2,7 +2,7 @@
 // Licensed under the Mozilla Public License v2.0
 
 /*
- * IBM OpenAPI Terraform Generator Version: 3.90.0-5aad763d-20240506-203857
+ * IBM OpenAPI Terraform Generator Version: 3.95.2-120e65bc-20240924-152329
  */
 
 package mqcloud_test
@@ -24,7 +24,7 @@ import (
 
 func TestAccIbmMqcloudQueueManagerDataSourceBasic(t *testing.T) {
 	t.Parallel()
-	queueManagerDetailsServiceInstanceGuid := acc.MqcloudInstanceID
+	queueManagerDetailsServiceInstanceGuid := acc.MqcloudDeploymentID
 	queueManagerDetailsName := fmt.Sprintf("tf_queue_manager_ds_basic%d", acctest.RandIntRange(10, 100))
 	queueManagerDetailsLocation := acc.MqCloudQueueManagerLocation
 	queueManagerDetailsSize := "xsmall"
@@ -50,7 +50,7 @@ func TestAccIbmMqcloudQueueManagerDataSourceBasic(t *testing.T) {
 
 func TestAccIbmMqcloudQueueManagerDataSourceAllArgs(t *testing.T) {
 	t.Parallel()
-	queueManagerDetailsServiceInstanceGuid := acc.MqcloudInstanceID
+	queueManagerDetailsServiceInstanceGuid := acc.MqcloudDeploymentID
 	queueManagerDetailsName := fmt.Sprintf("tf_queue_manager_ds_allargs%d", acctest.RandIntRange(10, 100))
 	queueManagerDetailsDisplayName := queueManagerDetailsName
 	queueManagerDetailsLocation := acc.MqCloudQueueManagerLocation
@@ -124,6 +124,7 @@ func testAccCheckIbmMqcloudQueueManagerDataSourceConfig(queueManagerDetailsServi
 }
 
 func TestDataSourceIbmMqcloudQueueManagerQueueManagerDetailsToMap(t *testing.T) {
+	t.Parallel()
 	checkResult := func(result map[string]interface{}) {
 		model := make(map[string]interface{})
 		model["id"] = "testString"

--- a/ibm/service/mqcloud/data_source_ibm_mqcloud_truststore_certificate.go
+++ b/ibm/service/mqcloud/data_source_ibm_mqcloud_truststore_certificate.go
@@ -2,7 +2,7 @@
 // Licensed under the Mozilla Public License v2.0
 
 /*
- * IBM OpenAPI Terraform Generator Version: 3.90.0-5aad763d-20240506-203857
+ * IBM OpenAPI Terraform Generator Version: 3.95.2-120e65bc-20240924-152329
  */
 
 package mqcloud
@@ -29,7 +29,7 @@ func DataSourceIbmMqcloudTruststoreCertificate() *schema.Resource {
 			"service_instance_guid": {
 				Type:        schema.TypeString,
 				Required:    true,
-				Description: "The GUID that uniquely identifies the MQ on Cloud service instance.",
+				Description: "The GUID that uniquely identifies the MQaaS service instance.",
 			},
 			"queue_manager_id": {
 				Type:        schema.TypeString,
@@ -177,7 +177,6 @@ func dataSourceIbmMqcloudTruststoreCertificateRead(context context.Context, d *s
 	if err = d.Set("total_count", flex.IntValue(trustStoreCertificateDetailsCollection.TotalCount)); err != nil {
 		return flex.DiscriminatedTerraformErrorf(err, fmt.Sprintf("Error setting total_count: %s", err), "(Data) ibm_mqcloud_truststore_certificate", "read", "set-total_count").GetDiag()
 	}
-
 	trustStore := []map[string]interface{}{}
 	if trustStoreCertificateDetailsCollection.TrustStore != nil {
 		for _, modelItem := range trustStoreCertificateDetailsCollection.TrustStore {

--- a/ibm/service/mqcloud/data_source_ibm_mqcloud_truststore_certificate_test.go
+++ b/ibm/service/mqcloud/data_source_ibm_mqcloud_truststore_certificate_test.go
@@ -2,7 +2,7 @@
 // Licensed under the Mozilla Public License v2.0
 
 /*
- * IBM OpenAPI Terraform Generator Version: 3.90.0-5aad763d-20240506-203857
+ * IBM OpenAPI Terraform Generator Version: 3.95.2-120e65bc-20240924-152329
  */
 
 package mqcloud_test
@@ -10,6 +10,7 @@ package mqcloud_test
 import (
 	"fmt"
 	"testing"
+	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
@@ -23,14 +24,16 @@ import (
 )
 
 func TestAccIbmMqcloudTruststoreCertificateDataSourceBasic(t *testing.T) {
-	t.Parallel()
-	trustStoreCertificateDetailsServiceInstanceGuid := acc.MqcloudInstanceID
+	trustStoreCertificateDetailsServiceInstanceGuid := acc.MqcloudDeploymentID
 	trustStoreCertificateDetailsQueueManagerID := acc.MqcloudQueueManagerID
 	trustStoreCertificateDetailsLabel := fmt.Sprintf("tf_label_%d", acctest.RandIntRange(10, 100))
 	trustStoreCertificateDetailsCertificateFile := acc.MqcloudTSCertFilePath
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { acc.TestAccPreCheckMqcloud(t) },
+		PreCheck: func() {
+			acc.TestAccPreCheckMqcloud(t)
+			time.Sleep(60 * time.Second) //This to allow for completion of certificate processing
+		},
 		Providers: acc.TestAccProviders,
 		Steps: []resource.TestStep{
 			{

--- a/ibm/service/mqcloud/data_source_ibm_mqcloud_truststore_certificate_test.go
+++ b/ibm/service/mqcloud/data_source_ibm_mqcloud_truststore_certificate_test.go
@@ -10,7 +10,6 @@ package mqcloud_test
 import (
 	"fmt"
 	"testing"
-	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
@@ -32,7 +31,6 @@ func TestAccIbmMqcloudTruststoreCertificateDataSourceBasic(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			acc.TestAccPreCheckMqcloud(t)
-			time.Sleep(60 * time.Second) //This to allow for completion of certificate processing
 		},
 		Providers: acc.TestAccProviders,
 		Steps: []resource.TestStep{

--- a/ibm/service/mqcloud/data_source_ibm_mqcloud_user.go
+++ b/ibm/service/mqcloud/data_source_ibm_mqcloud_user.go
@@ -2,7 +2,7 @@
 // Licensed under the Mozilla Public License v2.0
 
 /*
- * IBM OpenAPI Terraform Generator Version: 3.90.0-5aad763d-20240506-203857
+ * IBM OpenAPI Terraform Generator Version: 3.95.2-120e65bc-20240924-152329
  */
 
 package mqcloud
@@ -29,7 +29,7 @@ func DataSourceIbmMqcloudUser() *schema.Resource {
 			"service_instance_guid": {
 				Type:        schema.TypeString,
 				Required:    true,
-				Description: "The GUID that uniquely identifies the MQ on Cloud service instance.",
+				Description: "The GUID that uniquely identifies the MQaaS service instance.",
 			},
 			"name": {
 				Type:        schema.TypeString,
@@ -134,7 +134,7 @@ func dataSourceIbmMqcloudUserRead(context context.Context, d *schema.ResourceDat
 	mapSlice := []map[string]interface{}{}
 	for _, modelItem := range allItems {
 		modelItem := modelItem
-		modelMap, err := DataSourceIbmMqcloudUserUserDetailsToMap(&modelItem)
+		modelMap, err := DataSourceIbmMqcloudUserUserDetailsToMap(&modelItem) // #nosec G601
 		if err != nil {
 			tfErr := flex.TerraformErrorf(err, err.Error(), "(Data) ibm_mqcloud_user", "read")
 			return tfErr.GetDiag()

--- a/ibm/service/mqcloud/data_source_ibm_mqcloud_user_test.go
+++ b/ibm/service/mqcloud/data_source_ibm_mqcloud_user_test.go
@@ -2,7 +2,7 @@
 // Licensed under the Mozilla Public License v2.0
 
 /*
- * IBM OpenAPI Terraform Generator Version: 3.90.0-5aad763d-20240506-203857
+ * IBM OpenAPI Terraform Generator Version: 3.95.2-120e65bc-20240924-152329
  */
 
 package mqcloud_test
@@ -23,7 +23,7 @@ import (
 
 func TestAccIbmMqcloudUserDataSourceBasic(t *testing.T) {
 	t.Parallel()
-	userDetailsServiceInstanceGuid := acc.MqcloudInstanceID
+	userDetailsServiceInstanceGuid := acc.MqcloudDeploymentID
 	userDetailsName := fmt.Sprintf("tfname%d", acctest.RandIntRange(10, 100))
 	userDetailsEmail := fmt.Sprintf("tfemail%d@ibm.com", acctest.RandIntRange(10, 100))
 

--- a/ibm/service/mqcloud/data_source_ibm_mqcloud_virtual_private_endpoint_gateway.go
+++ b/ibm/service/mqcloud/data_source_ibm_mqcloud_virtual_private_endpoint_gateway.go
@@ -1,0 +1,109 @@
+// Copyright IBM Corp. 2024 All Rights Reserved.
+// Licensed under the Mozilla Public License v2.0
+
+/*
+ * IBM OpenAPI Terraform Generator Version: 3.96.0-d6dec9d7-20241008-212902
+ */
+
+package mqcloud
+
+import (
+	"context"
+	"fmt"
+	"log"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/conns"
+	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/flex"
+	"github.com/IBM/mqcloud-go-sdk/mqcloudv1"
+)
+
+func DataSourceIbmMqcloudVirtualPrivateEndpointGateway() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceIbmMqcloudVirtualPrivateEndpointGatewayRead,
+
+		Schema: map[string]*schema.Schema{
+			"service_instance_guid": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "The GUID that uniquely identifies the MQaaS service instance.",
+			},
+			"virtual_private_endpoint_gateway_guid": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "The id of the virtual private endpoint gateway.",
+			},
+			"trusted_profile": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "The CRN of the trusted profile to assume for this request.",
+			},
+			"href": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "URL for the details of the virtual private endpoint gateway.",
+			},
+			"name": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The name of the virtual private endpoint gateway, created by the user.",
+			},
+			"target_crn": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The CRN of the reserved capacity service instance the user is trying to connect to.",
+			},
+			"status": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The lifecycle state of this virtual privage endpoint.",
+			},
+		},
+	}
+}
+
+func dataSourceIbmMqcloudVirtualPrivateEndpointGatewayRead(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	mqcloudClient, err := meta.(conns.ClientSession).MqcloudV1()
+	if err != nil {
+		tfErr := flex.DiscriminatedTerraformErrorf(err, err.Error(), "(Data) ibm_mqcloud_virtual_private_endpoint_gateway", "read", "initialize-client")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
+	}
+
+	getVirtualPrivateEndpointGatewayOptions := &mqcloudv1.GetVirtualPrivateEndpointGatewayOptions{}
+
+	getVirtualPrivateEndpointGatewayOptions.SetServiceInstanceGuid(d.Get("service_instance_guid").(string))
+	getVirtualPrivateEndpointGatewayOptions.SetVirtualPrivateEndpointGatewayGuid(d.Get("virtual_private_endpoint_gateway_guid").(string))
+	if _, ok := d.GetOk("trusted_profile"); ok {
+		getVirtualPrivateEndpointGatewayOptions.SetTrustedProfile(d.Get("trusted_profile").(string))
+	}
+
+	virtualPrivateEndpointGatewayDetails, _, err := mqcloudClient.GetVirtualPrivateEndpointGatewayWithContext(context, getVirtualPrivateEndpointGatewayOptions)
+	if err != nil {
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("GetVirtualPrivateEndpointGatewayWithContext failed: %s", err.Error()), "(Data) ibm_mqcloud_virtual_private_endpoint_gateway", "read")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
+	}
+
+	d.SetId(fmt.Sprintf("%s/%s", *getVirtualPrivateEndpointGatewayOptions.ServiceInstanceGuid, *getVirtualPrivateEndpointGatewayOptions.VirtualPrivateEndpointGatewayGuid))
+
+	if err = d.Set("href", virtualPrivateEndpointGatewayDetails.Href); err != nil {
+		return flex.DiscriminatedTerraformErrorf(err, fmt.Sprintf("Error setting href: %s", err), "(Data) ibm_mqcloud_virtual_private_endpoint_gateway", "read", "set-href").GetDiag()
+	}
+
+	if err = d.Set("name", virtualPrivateEndpointGatewayDetails.Name); err != nil {
+		return flex.DiscriminatedTerraformErrorf(err, fmt.Sprintf("Error setting name: %s", err), "(Data) ibm_mqcloud_virtual_private_endpoint_gateway", "read", "set-name").GetDiag()
+	}
+
+	if err = d.Set("target_crn", virtualPrivateEndpointGatewayDetails.TargetCrn); err != nil {
+		return flex.DiscriminatedTerraformErrorf(err, fmt.Sprintf("Error setting target_crn: %s", err), "(Data) ibm_mqcloud_virtual_private_endpoint_gateway", "read", "set-target_crn").GetDiag()
+	}
+
+	if err = d.Set("status", virtualPrivateEndpointGatewayDetails.Status); err != nil {
+		return flex.DiscriminatedTerraformErrorf(err, fmt.Sprintf("Error setting status: %s", err), "(Data) ibm_mqcloud_virtual_private_endpoint_gateway", "read", "set-status").GetDiag()
+	}
+
+	return nil
+}

--- a/ibm/service/mqcloud/data_source_ibm_mqcloud_virtual_private_endpoint_gateway_test.go
+++ b/ibm/service/mqcloud/data_source_ibm_mqcloud_virtual_private_endpoint_gateway_test.go
@@ -1,0 +1,105 @@
+// Copyright IBM Corp. 2024 All Rights Reserved.
+// Licensed under the Mozilla Public License v2.0
+
+/*
+ * IBM OpenAPI Terraform Generator Version: 3.96.0-d6dec9d7-20241008-212902
+ */
+
+package mqcloud_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	acc "github.com/IBM-Cloud/terraform-provider-ibm/ibm/acctest"
+)
+
+func TestAccIbmMqcloudVirtualPrivateEndpointGatewayDataSourceBasic(t *testing.T) {
+	t.Parallel()
+	virtualPrivateEndpointGatewayDetailsServiceInstanceGuid := acc.MqcloudCapacityID
+	virtualPrivateEndpointGatewayDetailsName := fmt.Sprintf("tf-name-%d", acctest.RandIntRange(10, 100))
+	virtualPrivateEndpointGatewayDetailsTargetCrn := acc.MqCloudVirtualPrivateEndPointTargetCrn
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { acc.TestAccPreCheck(t) },
+		Providers: acc.TestAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckIbmMqcloudVirtualPrivateEndpointGatewayDataSourceConfigBasic(virtualPrivateEndpointGatewayDetailsServiceInstanceGuid, virtualPrivateEndpointGatewayDetailsName, virtualPrivateEndpointGatewayDetailsTargetCrn),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet("data.ibm_mqcloud_virtual_private_endpoint_gateway.mqcloud_virtual_private_endpoint_gateway_instance", "id"),
+					resource.TestCheckResourceAttrSet("data.ibm_mqcloud_virtual_private_endpoint_gateway.mqcloud_virtual_private_endpoint_gateway_instance", "service_instance_guid"),
+					resource.TestCheckResourceAttrSet("data.ibm_mqcloud_virtual_private_endpoint_gateway.mqcloud_virtual_private_endpoint_gateway_instance", "virtual_private_endpoint_gateway_guid"),
+					resource.TestCheckResourceAttrSet("data.ibm_mqcloud_virtual_private_endpoint_gateway.mqcloud_virtual_private_endpoint_gateway_instance", "href"),
+					resource.TestCheckResourceAttrSet("data.ibm_mqcloud_virtual_private_endpoint_gateway.mqcloud_virtual_private_endpoint_gateway_instance", "name"),
+					resource.TestCheckResourceAttrSet("data.ibm_mqcloud_virtual_private_endpoint_gateway.mqcloud_virtual_private_endpoint_gateway_instance", "target_crn"),
+					resource.TestCheckResourceAttrSet("data.ibm_mqcloud_virtual_private_endpoint_gateway.mqcloud_virtual_private_endpoint_gateway_instance", "status"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccIbmMqcloudVirtualPrivateEndpointGatewayDataSourceAllArgs(t *testing.T) {
+	t.Parallel()
+	virtualPrivateEndpointGatewayDetailsServiceInstanceGuid := acc.MqcloudDeploymentID
+	virtualPrivateEndpointGatewayDetailsTrustedProfile := acc.MqCloudVirtualPrivateEndPointTrustedProfile
+	virtualPrivateEndpointGatewayDetailsName := fmt.Sprintf("tf-name-%d", acctest.RandIntRange(10, 100))
+	virtualPrivateEndpointGatewayDetailsTargetCrn := acc.MqCloudVirtualPrivateEndPointTargetCrn
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { acc.TestAccPreCheck(t) },
+		Providers: acc.TestAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckIbmMqcloudVirtualPrivateEndpointGatewayDataSourceConfig(virtualPrivateEndpointGatewayDetailsServiceInstanceGuid, virtualPrivateEndpointGatewayDetailsTrustedProfile, virtualPrivateEndpointGatewayDetailsName, virtualPrivateEndpointGatewayDetailsTargetCrn),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet("data.ibm_mqcloud_virtual_private_endpoint_gateway.mqcloud_virtual_private_endpoint_gateway_instance", "id"),
+					resource.TestCheckResourceAttrSet("data.ibm_mqcloud_virtual_private_endpoint_gateway.mqcloud_virtual_private_endpoint_gateway_instance", "service_instance_guid"),
+					resource.TestCheckResourceAttrSet("data.ibm_mqcloud_virtual_private_endpoint_gateway.mqcloud_virtual_private_endpoint_gateway_instance", "virtual_private_endpoint_gateway_guid"),
+					resource.TestCheckResourceAttrSet("data.ibm_mqcloud_virtual_private_endpoint_gateway.mqcloud_virtual_private_endpoint_gateway_instance", "trusted_profile"),
+					resource.TestCheckResourceAttrSet("data.ibm_mqcloud_virtual_private_endpoint_gateway.mqcloud_virtual_private_endpoint_gateway_instance", "href"),
+					resource.TestCheckResourceAttrSet("data.ibm_mqcloud_virtual_private_endpoint_gateway.mqcloud_virtual_private_endpoint_gateway_instance", "name"),
+					resource.TestCheckResourceAttrSet("data.ibm_mqcloud_virtual_private_endpoint_gateway.mqcloud_virtual_private_endpoint_gateway_instance", "target_crn"),
+					resource.TestCheckResourceAttrSet("data.ibm_mqcloud_virtual_private_endpoint_gateway.mqcloud_virtual_private_endpoint_gateway_instance", "status"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckIbmMqcloudVirtualPrivateEndpointGatewayDataSourceConfigBasic(virtualPrivateEndpointGatewayDetailsServiceInstanceGuid string, virtualPrivateEndpointGatewayDetailsName string, virtualPrivateEndpointGatewayDetailsTargetCrn string) string {
+	return fmt.Sprintf(`
+		resource "ibm_mqcloud_virtual_private_endpoint_gateway" "mqcloud_virtual_private_endpoint_gateway_instance" {
+			service_instance_guid = "%s"
+			name = "%s"
+			target_crn = "%s"
+		}
+
+		data "ibm_mqcloud_virtual_private_endpoint_gateway" "mqcloud_virtual_private_endpoint_gateway_instance" {
+			service_instance_guid = ibm_mqcloud_virtual_private_endpoint_gateway.mqcloud_virtual_private_endpoint_gateway_instance.service_instance_guid
+			virtual_private_endpoint_gateway_guid = ibm_mqcloud_virtual_private_endpoint_gateway.mqcloud_virtual_private_endpoint_gateway_instance.virtual_private_endpoint_gateway_guid
+			trusted_profile = ibm_mqcloud_virtual_private_endpoint_gateway.mqcloud_virtual_private_endpoint_gateway_instance.trusted_profile
+		}
+	`, virtualPrivateEndpointGatewayDetailsServiceInstanceGuid, virtualPrivateEndpointGatewayDetailsName, virtualPrivateEndpointGatewayDetailsTargetCrn)
+}
+
+func testAccCheckIbmMqcloudVirtualPrivateEndpointGatewayDataSourceConfig(virtualPrivateEndpointGatewayDetailsServiceInstanceGuid string, virtualPrivateEndpointGatewayDetailsTrustedProfile string, virtualPrivateEndpointGatewayDetailsName string, virtualPrivateEndpointGatewayDetailsTargetCrn string) string {
+	return fmt.Sprintf(`
+		resource "ibm_mqcloud_virtual_private_endpoint_gateway" "mqcloud_virtual_private_endpoint_gateway_instance" {
+			service_instance_guid = "%s"
+			trusted_profile = "%s"
+			name = "%s"
+			target_crn = "%s"
+		}
+
+		data "ibm_mqcloud_virtual_private_endpoint_gateway" "mqcloud_virtual_private_endpoint_gateway_instance" {
+			service_instance_guid = ibm_mqcloud_virtual_private_endpoint_gateway.mqcloud_virtual_private_endpoint_gateway_instance.service_instance_guid
+			virtual_private_endpoint_gateway_guid = ibm_mqcloud_virtual_private_endpoint_gateway.mqcloud_virtual_private_endpoint_gateway_instance.virtual_private_endpoint_gateway_guid
+			trusted_profile = ibm_mqcloud_virtual_private_endpoint_gateway.mqcloud_virtual_private_endpoint_gateway_instance.trusted_profile
+		}
+	`, virtualPrivateEndpointGatewayDetailsServiceInstanceGuid, virtualPrivateEndpointGatewayDetailsTrustedProfile, virtualPrivateEndpointGatewayDetailsName, virtualPrivateEndpointGatewayDetailsTargetCrn)
+}

--- a/ibm/service/mqcloud/data_source_ibm_mqcloud_virtual_private_endpoint_gateway_test.go
+++ b/ibm/service/mqcloud/data_source_ibm_mqcloud_virtual_private_endpoint_gateway_test.go
@@ -45,7 +45,7 @@ func TestAccIbmMqcloudVirtualPrivateEndpointGatewayDataSourceBasic(t *testing.T)
 
 func TestAccIbmMqcloudVirtualPrivateEndpointGatewayDataSourceAllArgs(t *testing.T) {
 	t.Parallel()
-	virtualPrivateEndpointGatewayDetailsServiceInstanceGuid := acc.MqcloudDeploymentID
+	virtualPrivateEndpointGatewayDetailsServiceInstanceGuid := acc.MqcloudCapacityID
 	virtualPrivateEndpointGatewayDetailsTrustedProfile := acc.MqCloudVirtualPrivateEndPointTrustedProfile
 	virtualPrivateEndpointGatewayDetailsName := fmt.Sprintf("tf-name-%d", acctest.RandIntRange(10, 100))
 	virtualPrivateEndpointGatewayDetailsTargetCrn := acc.MqCloudVirtualPrivateEndPointTargetCrn

--- a/ibm/service/mqcloud/data_source_ibm_mqcloud_virtual_private_endpoint_gateways.go
+++ b/ibm/service/mqcloud/data_source_ibm_mqcloud_virtual_private_endpoint_gateways.go
@@ -1,0 +1,150 @@
+// Copyright IBM Corp. 2024 All Rights Reserved.
+// Licensed under the Mozilla Public License v2.0
+
+/*
+ * IBM OpenAPI Terraform Generator Version: 3.96.0-d6dec9d7-20241008-212902
+ */
+
+package mqcloud
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"time"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/conns"
+	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/flex"
+	"github.com/IBM/mqcloud-go-sdk/mqcloudv1"
+)
+
+func DataSourceIbmMqcloudVirtualPrivateEndpointGateways() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceIbmMqcloudVirtualPrivateEndpointGatewaysRead,
+
+		Schema: map[string]*schema.Schema{
+			"service_instance_guid": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "The GUID that uniquely identifies the MQaaS service instance.",
+			},
+			"trusted_profile": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "The CRN of the trusted profile to assume for this request.",
+			},
+			"name": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "The name of the virtual private endpoint gateway, created by the user.",
+			},
+			"virtual_private_endpoint_gateways": {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Description: "List of virtual private endpoint gateways.",
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"href": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "URL for the details of the virtual private endpoint gateway.",
+						},
+						"id": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "The ID of the virtual private endpoint gateway which was allocated on creation.",
+						},
+						"name": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "The name of the virtual private endpoint gateway, created by the user.",
+						},
+						"target_crn": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "The CRN of the reserved capacity service instance the user is trying to connect to.",
+						},
+						"status": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "The lifecycle state of this virtual privage endpoint.",
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func dataSourceIbmMqcloudVirtualPrivateEndpointGatewaysRead(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	mqcloudClient, err := meta.(conns.ClientSession).MqcloudV1()
+	if err != nil {
+		tfErr := flex.DiscriminatedTerraformErrorf(err, err.Error(), "(Data) ibm_mqcloud_virtual_private_endpoint_gateways", "read", "initialize-client")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
+	}
+
+	listVirtualPrivateEndpointGatewaysOptions := &mqcloudv1.ListVirtualPrivateEndpointGatewaysOptions{}
+
+	listVirtualPrivateEndpointGatewaysOptions.SetServiceInstanceGuid(d.Get("service_instance_guid").(string))
+	if _, ok := d.GetOk("trusted_profile"); ok {
+		listVirtualPrivateEndpointGatewaysOptions.SetTrustedProfile(d.Get("trusted_profile").(string))
+	}
+
+	var pager *mqcloudv1.VirtualPrivateEndpointGatewaysPager
+	pager, err = mqcloudClient.NewVirtualPrivateEndpointGatewaysPager(listVirtualPrivateEndpointGatewaysOptions)
+	if err != nil {
+		tfErr := flex.TerraformErrorf(err, err.Error(), "(Data) ibm_mqcloud_virtual_private_endpoint_gateways", "read")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
+	}
+
+	allItems, err := pager.GetAll()
+	if err != nil {
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("VirtualPrivateEndpointGatewaysPager.GetAll() failed %s", err), "(Data) ibm_mqcloud_virtual_private_endpoint_gateways", "read")
+		log.Printf("[DEBUG] %s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
+	}
+
+	var name string
+
+	if v, ok := d.GetOk("name"); ok {
+		name = v.(string)
+		d.SetId(name)
+	} else {
+		d.SetId(dataSourceIbmMqcloudVirtualPrivateEndpointGatewaysID(d))
+	}
+
+	mapSlice := []map[string]interface{}{}
+	for _, modelItem := range allItems {
+		modelMap, err := DataSourceIbmMqcloudVirtualPrivateEndpointGatewaysVirtualPrivateEndpointGatewayDetailsToMap(&modelItem) // #nosec G601
+		if err != nil {
+			return flex.DiscriminatedTerraformErrorf(err, err.Error(), "(Data) ibm_mqcloud_virtual_private_endpoint_gateways", "read", "VirtualPrivateEndpointsGateways-to-map").GetDiag()
+		}
+		mapSlice = append(mapSlice, modelMap)
+	}
+
+	if err = d.Set("virtual_private_endpoint_gateways", mapSlice); err != nil {
+		return flex.DiscriminatedTerraformErrorf(err, fmt.Sprintf("Error setting virtual_private_endpoint_gateways %s", err), "(Data) ibm_mqcloud_virtual_private_endpoint_gateways", "read", "virtual_private_endpoint_gateways-set").GetDiag()
+	}
+
+	return nil
+}
+
+// dataSourceIbmMqcloudVirtualPrivateEndpointGatewaysID returns a reasonable ID for the list.
+func dataSourceIbmMqcloudVirtualPrivateEndpointGatewaysID(d *schema.ResourceData) string {
+	return time.Now().UTC().String()
+}
+
+func DataSourceIbmMqcloudVirtualPrivateEndpointGatewaysVirtualPrivateEndpointGatewayDetailsToMap(model *mqcloudv1.VirtualPrivateEndpointGatewayDetails) (map[string]interface{}, error) {
+	modelMap := make(map[string]interface{})
+	modelMap["href"] = *model.Href
+	modelMap["id"] = *model.ID
+	modelMap["name"] = *model.Name
+	modelMap["target_crn"] = *model.TargetCrn
+	modelMap["status"] = *model.Status
+	return modelMap, nil
+}

--- a/ibm/service/mqcloud/data_source_ibm_mqcloud_virtual_private_endpoint_gateways_test.go
+++ b/ibm/service/mqcloud/data_source_ibm_mqcloud_virtual_private_endpoint_gateways_test.go
@@ -1,0 +1,134 @@
+// Copyright IBM Corp. 2024 All Rights Reserved.
+// Licensed under the Mozilla Public License v2.0
+
+/*
+ * IBM OpenAPI Terraform Generator Version: 3.96.0-d6dec9d7-20241008-212902
+ */
+
+package mqcloud_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	acc "github.com/IBM-Cloud/terraform-provider-ibm/ibm/acctest"
+	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/mqcloud"
+	"github.com/IBM/go-sdk-core/v5/core"
+	"github.com/IBM/mqcloud-go-sdk/mqcloudv1"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestAccIbmMqcloudVirtualPrivateEndpointGatewaysDataSourceBasic(t *testing.T) {
+	t.Parallel()
+	virtualPrivateEndpointGatewayDetailsServiceInstanceGuid := acc.MqcloudCapacityID
+	virtualPrivateEndpointGatewayDetailsName := fmt.Sprintf("tf-name-%d", acctest.RandIntRange(10, 100))
+	virtualPrivateEndpointGatewayDetailsTargetCrn := acc.MqCloudVirtualPrivateEndPointTargetCrn
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { acc.TestAccPreCheck(t) },
+		Providers: acc.TestAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckIbmMqcloudVirtualPrivateEndpointGatewaysDataSourceConfigBasic(virtualPrivateEndpointGatewayDetailsServiceInstanceGuid, virtualPrivateEndpointGatewayDetailsName, virtualPrivateEndpointGatewayDetailsTargetCrn),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet("data.ibm_mqcloud_virtual_private_endpoint_gateways.mqcloud_virtual_private_endpoint_gateways_instance", "id"),
+					resource.TestCheckResourceAttrSet("data.ibm_mqcloud_virtual_private_endpoint_gateways.mqcloud_virtual_private_endpoint_gateways_instance", "service_instance_guid"),
+					resource.TestCheckResourceAttrSet("data.ibm_mqcloud_virtual_private_endpoint_gateways.mqcloud_virtual_private_endpoint_gateways_instance", "virtual_private_endpoint_gateways.#"),
+					resource.TestCheckResourceAttr("data.ibm_mqcloud_virtual_private_endpoint_gateways.mqcloud_virtual_private_endpoint_gateways_instance", "virtual_private_endpoint_gateways.0.name", virtualPrivateEndpointGatewayDetailsName),
+					resource.TestCheckResourceAttr("data.ibm_mqcloud_virtual_private_endpoint_gateways.mqcloud_virtual_private_endpoint_gateways_instance", "virtual_private_endpoint_gateways.0.target_crn", virtualPrivateEndpointGatewayDetailsTargetCrn),
+				),
+			},
+		},
+	})
+}
+
+func TestAccIbmMqcloudVirtualPrivateEndpointGatewaysDataSourceAllArgs(t *testing.T) {
+	t.Parallel()
+	virtualPrivateEndpointGatewayDetailsServiceInstanceGuid := acc.MqcloudCapacityID
+	virtualPrivateEndpointGatewayDetailsTrustedProfile := acc.MqCloudVirtualPrivateEndPointTrustedProfile
+	virtualPrivateEndpointGatewayDetailsName := fmt.Sprintf("tf-name-%d", acctest.RandIntRange(10, 100))
+	virtualPrivateEndpointGatewayDetailsTargetCrn := acc.MqCloudVirtualPrivateEndPointTargetCrn
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { acc.TestAccPreCheck(t) },
+		Providers: acc.TestAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckIbmMqcloudVirtualPrivateEndpointGatewaysDataSourceConfig(virtualPrivateEndpointGatewayDetailsServiceInstanceGuid, virtualPrivateEndpointGatewayDetailsTrustedProfile, virtualPrivateEndpointGatewayDetailsName, virtualPrivateEndpointGatewayDetailsTargetCrn),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet("data.ibm_mqcloud_virtual_private_endpoint_gateways.mqcloud_virtual_private_endpoint_gateways_instance", "id"),
+					resource.TestCheckResourceAttrSet("data.ibm_mqcloud_virtual_private_endpoint_gateways.mqcloud_virtual_private_endpoint_gateways_instance", "service_instance_guid"),
+					resource.TestCheckResourceAttrSet("data.ibm_mqcloud_virtual_private_endpoint_gateways.mqcloud_virtual_private_endpoint_gateways_instance", "trusted_profile"),
+					resource.TestCheckResourceAttrSet("data.ibm_mqcloud_virtual_private_endpoint_gateways.mqcloud_virtual_private_endpoint_gateways_instance", "name"),
+					resource.TestCheckResourceAttrSet("data.ibm_mqcloud_virtual_private_endpoint_gateways.mqcloud_virtual_private_endpoint_gateways_instance", "virtual_private_endpoint_gateways.#"),
+					resource.TestCheckResourceAttrSet("data.ibm_mqcloud_virtual_private_endpoint_gateways.mqcloud_virtual_private_endpoint_gateways_instance", "virtual_private_endpoint_gateways.0.href"),
+					resource.TestCheckResourceAttrSet("data.ibm_mqcloud_virtual_private_endpoint_gateways.mqcloud_virtual_private_endpoint_gateways_instance", "virtual_private_endpoint_gateways.0.id"),
+					resource.TestCheckResourceAttr("data.ibm_mqcloud_virtual_private_endpoint_gateways.mqcloud_virtual_private_endpoint_gateways_instance", "virtual_private_endpoint_gateways.0.name", virtualPrivateEndpointGatewayDetailsName),
+					resource.TestCheckResourceAttr("data.ibm_mqcloud_virtual_private_endpoint_gateways.mqcloud_virtual_private_endpoint_gateways_instance", "virtual_private_endpoint_gateways.0.target_crn", virtualPrivateEndpointGatewayDetailsTargetCrn),
+					resource.TestCheckResourceAttrSet("data.ibm_mqcloud_virtual_private_endpoint_gateways.mqcloud_virtual_private_endpoint_gateways_instance", "virtual_private_endpoint_gateways.0.status"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckIbmMqcloudVirtualPrivateEndpointGatewaysDataSourceConfigBasic(virtualPrivateEndpointGatewayDetailsServiceInstanceGuid string, virtualPrivateEndpointGatewayDetailsName string, virtualPrivateEndpointGatewayDetailsTargetCrn string) string {
+	return fmt.Sprintf(`
+		resource "ibm_mqcloud_virtual_private_endpoint_gateway" "mqcloud_virtual_private_endpoint_gateway_instance" {
+			service_instance_guid = "%s"
+			name = "%s"
+			target_crn = "%s"
+		}
+
+		data "ibm_mqcloud_virtual_private_endpoint_gateways" "mqcloud_virtual_private_endpoint_gateways_instance" {
+			service_instance_guid = ibm_mqcloud_virtual_private_endpoint_gateway.mqcloud_virtual_private_endpoint_gateway_instance.service_instance_guid
+			trusted_profile = ibm_mqcloud_virtual_private_endpoint_gateway.mqcloud_virtual_private_endpoint_gateway_instance.trusted_profile
+			name = ibm_mqcloud_virtual_private_endpoint_gateway.mqcloud_virtual_private_endpoint_gateway_instance.name
+		}
+	`, virtualPrivateEndpointGatewayDetailsServiceInstanceGuid, virtualPrivateEndpointGatewayDetailsName, virtualPrivateEndpointGatewayDetailsTargetCrn)
+}
+
+func testAccCheckIbmMqcloudVirtualPrivateEndpointGatewaysDataSourceConfig(virtualPrivateEndpointGatewayDetailsServiceInstanceGuid string, virtualPrivateEndpointGatewayDetailsTrustedProfile string, virtualPrivateEndpointGatewayDetailsName string, virtualPrivateEndpointGatewayDetailsTargetCrn string) string {
+	return fmt.Sprintf(`
+		resource "ibm_mqcloud_virtual_private_endpoint_gateway" "mqcloud_virtual_private_endpoint_gateway_instance" {
+			service_instance_guid = "%s"
+			trusted_profile = "%s"
+			name = "%s"
+			target_crn = "%s"
+		}
+
+		data "ibm_mqcloud_virtual_private_endpoint_gateways" "mqcloud_virtual_private_endpoint_gateways_instance" {
+			service_instance_guid = ibm_mqcloud_virtual_private_endpoint_gateway.mqcloud_virtual_private_endpoint_gateway_instance.service_instance_guid
+			trusted_profile = ibm_mqcloud_virtual_private_endpoint_gateway.mqcloud_virtual_private_endpoint_gateway_instance.trusted_profile
+			name = ibm_mqcloud_virtual_private_endpoint_gateway.mqcloud_virtual_private_endpoint_gateway_instance.name
+		}
+	`, virtualPrivateEndpointGatewayDetailsServiceInstanceGuid, virtualPrivateEndpointGatewayDetailsTrustedProfile, virtualPrivateEndpointGatewayDetailsName, virtualPrivateEndpointGatewayDetailsTargetCrn)
+}
+
+func TestDataSourceIbmMqcloudVirtualPrivateEndpointGatewaysVirtualPrivateEndpointGatewayDetailsToMap(t *testing.T) {
+	t.Parallel()
+	checkResult := func(result map[string]interface{}) {
+		model := make(map[string]interface{})
+		model["href"] = "testString"
+		model["id"] = "testString"
+		model["name"] = "testString"
+		model["target_crn"] = "testString"
+		model["status"] = "testString"
+
+		assert.Equal(t, result, model)
+	}
+
+	model := new(mqcloudv1.VirtualPrivateEndpointGatewayDetails)
+	model.Href = core.StringPtr("testString")
+	model.ID = core.StringPtr("testString")
+	model.Name = core.StringPtr("testString")
+	model.TargetCrn = core.StringPtr("testString")
+	model.Status = core.StringPtr("testString")
+
+	result, err := mqcloud.DataSourceIbmMqcloudVirtualPrivateEndpointGatewaysVirtualPrivateEndpointGatewayDetailsToMap(model)
+	assert.Nil(t, err)
+	checkResult(result)
+}

--- a/ibm/service/mqcloud/resource_ibm_mqcloud_application.go
+++ b/ibm/service/mqcloud/resource_ibm_mqcloud_application.go
@@ -2,7 +2,7 @@
 // Licensed under the Mozilla Public License v2.0
 
 /*
- * IBM OpenAPI Terraform Generator Version: 3.90.0-5aad763d-20240506-203857
+ * IBM OpenAPI Terraform Generator Version: 3.95.2-120e65bc-20240924-152329
  */
 
 package mqcloud
@@ -34,7 +34,7 @@ func ResourceIbmMqcloudApplication() *schema.Resource {
 				Required:     true,
 				ForceNew:     true,
 				ValidateFunc: validate.InvokeValidator("ibm_mqcloud_application", "service_instance_guid"),
-				Description:  "The GUID that uniquely identifies the MQ on Cloud service instance.",
+				Description:  "The GUID that uniquely identifies the MQaaS service instance.",
 			},
 			"name": {
 				Type:         schema.TypeString,

--- a/ibm/service/mqcloud/resource_ibm_mqcloud_application_test.go
+++ b/ibm/service/mqcloud/resource_ibm_mqcloud_application_test.go
@@ -19,7 +19,7 @@ import (
 func TestAccIbmMqcloudApplicationBasic(t *testing.T) {
 	t.Parallel()
 	var conf mqcloudv1.ApplicationDetails
-	serviceInstanceGuid := acc.MqcloudInstanceID
+	serviceInstanceGuid := acc.MqcloudDeploymentID
 	name := "appbasic"
 
 	resource.Test(t, resource.TestCase{

--- a/ibm/service/mqcloud/resource_ibm_mqcloud_keystore_certificate.go
+++ b/ibm/service/mqcloud/resource_ibm_mqcloud_keystore_certificate.go
@@ -2,7 +2,7 @@
 // Licensed under the Mozilla Public License v2.0
 
 /*
- * IBM OpenAPI Terraform Generator Version: 3.90.0-5aad763d-20240506-203857
+ * IBM OpenAPI Terraform Generator Version: 3.95.2-120e65bc-20240924-152329
  */
 
 package mqcloud
@@ -39,7 +39,7 @@ func ResourceIbmMqcloudKeystoreCertificate() *schema.Resource {
 				Required:     true,
 				ForceNew:     true,
 				ValidateFunc: validate.InvokeValidator("ibm_mqcloud_keystore_certificate", "service_instance_guid"),
-				Description:  "The GUID that uniquely identifies the MQ on Cloud service instance.",
+				Description:  "The GUID that uniquely identifies the MQaaS service instance.",
 			},
 			"queue_manager_id": {
 				Type:         schema.TypeString,
@@ -143,6 +143,7 @@ func ResourceIbmMqcloudKeystoreCertificate() *schema.Resource {
 												"name": {
 													Type:        schema.TypeString,
 													Optional:    true,
+													Computed:    true,
 													Description: "The name of the channel.",
 												},
 											},
@@ -521,7 +522,7 @@ func ResourceIbmMqcloudKeystoreCertificateChannelsDetailsToMap(model *mqcloudv1.
 	channels := []map[string]interface{}{}
 	for _, channelsItem := range model.Channels {
 		channelsItem := channelsItem
-		channelsItemMap, err := ResourceIbmMqcloudKeystoreCertificateChannelDetailsToMap(&channelsItem)
+		channelsItemMap, err := ResourceIbmMqcloudKeystoreCertificateChannelDetailsToMap(&channelsItem) // #nosec G601
 		if err != nil {
 			return modelMap, err
 		}

--- a/ibm/service/mqcloud/resource_ibm_mqcloud_keystore_certificate_test.go
+++ b/ibm/service/mqcloud/resource_ibm_mqcloud_keystore_certificate_test.go
@@ -6,7 +6,6 @@ package mqcloud_test
 import (
 	"fmt"
 	"testing"
-	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
@@ -31,7 +30,6 @@ func TestAccIbmMqcloudKeystoreCertificateBasic(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			acc.TestAccPreCheckMqcloud(t)
-			time.Sleep(60 * time.Second) //This to allow for completion of certificate processing
 		},
 		Providers:    acc.TestAccProviders,
 		CheckDestroy: testAccCheckIbmMqcloudKeystoreCertificateDestroy,

--- a/ibm/service/mqcloud/resource_ibm_mqcloud_keystore_certificate_test.go
+++ b/ibm/service/mqcloud/resource_ibm_mqcloud_keystore_certificate_test.go
@@ -6,6 +6,7 @@ package mqcloud_test
 import (
 	"fmt"
 	"testing"
+	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
@@ -21,15 +22,17 @@ import (
 )
 
 func TestAccIbmMqcloudKeystoreCertificateBasic(t *testing.T) {
-	t.Parallel()
 	var conf mqcloudv1.KeyStoreCertificateDetails
-	serviceInstanceGuid := acc.MqcloudInstanceID
+	serviceInstanceGuid := acc.MqcloudDeploymentID
 	queueManagerID := acc.MqcloudQueueManagerID
 	label := fmt.Sprintf("tf_label_%d", acctest.RandIntRange(10, 100))
 	certificateFile := acc.MqcloudKSCertFilePath
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { acc.TestAccPreCheckMqcloud(t) },
+		PreCheck: func() {
+			acc.TestAccPreCheckMqcloud(t)
+			time.Sleep(60 * time.Second) //This to allow for completion of certificate processing
+		},
 		Providers:    acc.TestAccProviders,
 		CheckDestroy: testAccCheckIbmMqcloudKeystoreCertificateDestroy,
 		Steps: []resource.TestStep{

--- a/ibm/service/mqcloud/resource_ibm_mqcloud_queue_manager.go
+++ b/ibm/service/mqcloud/resource_ibm_mqcloud_queue_manager.go
@@ -2,7 +2,7 @@
 // Licensed under the Mozilla Public License v2.0
 
 /*
- * IBM OpenAPI Terraform Generator Version: 3.90.0-5aad763d-20240506-203857
+ * IBM OpenAPI Terraform Generator Version: 3.95.2-120e65bc-20240924-152329
  */
 
 package mqcloud
@@ -43,7 +43,7 @@ func ResourceIbmMqcloudQueueManager() *schema.Resource {
 				Required:     true,
 				ForceNew:     true,
 				ValidateFunc: validate.InvokeValidator("ibm_mqcloud_queue_manager", "service_instance_guid"),
-				Description:  "The GUID that uniquely identifies the MQ on Cloud service instance.",
+				Description:  "The GUID that uniquely identifies the MQaaS service instance.",
 			},
 			"name": {
 				Type:         schema.TypeString,
@@ -232,6 +232,7 @@ func resourceIbmMqcloudQueueManagerCreate(context context.Context, d *schema.Res
 	}
 
 	d.SetId(fmt.Sprintf("%s/%s", *createQueueManagerOptions.ServiceInstanceGuid, *queueManagerTaskStatus.QueueManagerID))
+
 	if waitForQmStatus {
 		_, err = waitForQmStatusUpdate(context, d, meta)
 		if err != nil {
@@ -274,7 +275,6 @@ func resourceIbmMqcloudQueueManagerRead(context context.Context, d *schema.Resou
 
 		return nil
 	})
-
 	if err != nil {
 		if response != nil && response.StatusCode == 404 {
 			d.SetId("")

--- a/ibm/service/mqcloud/resource_ibm_mqcloud_queue_manager_test.go
+++ b/ibm/service/mqcloud/resource_ibm_mqcloud_queue_manager_test.go
@@ -20,7 +20,7 @@ import (
 func TestAccIbmMqcloudQueueManagerBasic(t *testing.T) {
 	t.Parallel()
 	var conf mqcloudv1.QueueManagerDetails
-	serviceInstanceGuid := acc.MqcloudInstanceID
+	serviceInstanceGuid := acc.MqcloudDeploymentID
 	name := fmt.Sprintf("tf_queue_manager_basic%d", acctest.RandIntRange(10, 100))
 	location := acc.MqCloudQueueManagerLocation
 	size := "xsmall"
@@ -47,7 +47,7 @@ func TestAccIbmMqcloudQueueManagerBasic(t *testing.T) {
 func TestAccIbmMqcloudQueueManagerAllArgs(t *testing.T) {
 	t.Parallel()
 	var conf mqcloudv1.QueueManagerDetails
-	serviceInstanceGuid := acc.MqcloudInstanceID
+	serviceInstanceGuid := acc.MqcloudDeploymentID
 	name := fmt.Sprintf("tf_queue_manager_allargs%d", acctest.RandIntRange(10, 100))
 	displayName := name
 	location := acc.MqCloudQueueManagerLocation

--- a/ibm/service/mqcloud/resource_ibm_mqcloud_truststore_certificate.go
+++ b/ibm/service/mqcloud/resource_ibm_mqcloud_truststore_certificate.go
@@ -2,7 +2,7 @@
 // Licensed under the Mozilla Public License v2.0
 
 /*
- * IBM OpenAPI Terraform Generator Version: 3.90.0-5aad763d-20240506-203857
+ * IBM OpenAPI Terraform Generator Version: 3.95.2-120e65bc-20240924-152329
  */
 
 package mqcloud
@@ -37,7 +37,7 @@ func ResourceIbmMqcloudTruststoreCertificate() *schema.Resource {
 				Required:     true,
 				ForceNew:     true,
 				ValidateFunc: validate.InvokeValidator("ibm_mqcloud_truststore_certificate", "service_instance_guid"),
-				Description:  "The GUID that uniquely identifies the MQ on Cloud service instance.",
+				Description:  "The GUID that uniquely identifies the MQaaS service instance.",
 			},
 			"queue_manager_id": {
 				Type:         schema.TypeString,

--- a/ibm/service/mqcloud/resource_ibm_mqcloud_truststore_certificate_test.go
+++ b/ibm/service/mqcloud/resource_ibm_mqcloud_truststore_certificate_test.go
@@ -6,7 +6,6 @@ package mqcloud_test
 import (
 	"fmt"
 	"testing"
-	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
@@ -28,7 +27,6 @@ func TestAccIbmMqcloudTruststoreCertificateBasic(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			acc.TestAccPreCheckMqcloud(t)
-			time.Sleep(60 * time.Second) //This to allow for completion of certificate processing
 		},
 		Providers:    acc.TestAccProviders,
 		CheckDestroy: testAccCheckIbmMqcloudTruststoreCertificateDestroy,

--- a/ibm/service/mqcloud/resource_ibm_mqcloud_truststore_certificate_test.go
+++ b/ibm/service/mqcloud/resource_ibm_mqcloud_truststore_certificate_test.go
@@ -6,6 +6,7 @@ package mqcloud_test
 import (
 	"fmt"
 	"testing"
+	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
@@ -18,15 +19,17 @@ import (
 )
 
 func TestAccIbmMqcloudTruststoreCertificateBasic(t *testing.T) {
-	t.Parallel()
 	var conf mqcloudv1.TrustStoreCertificateDetails
-	serviceInstanceGuid := acc.MqcloudInstanceID
+	serviceInstanceGuid := acc.MqcloudDeploymentID
 	queueManagerID := acc.MqcloudQueueManagerID
 	label := fmt.Sprintf("tf_label_%d", acctest.RandIntRange(10, 100))
 	certificateFile := acc.MqcloudTSCertFilePath
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { acc.TestAccPreCheckMqcloud(t) },
+		PreCheck: func() {
+			acc.TestAccPreCheckMqcloud(t)
+			time.Sleep(60 * time.Second) //This to allow for completion of certificate processing
+		},
 		Providers:    acc.TestAccProviders,
 		CheckDestroy: testAccCheckIbmMqcloudTruststoreCertificateDestroy,
 		Steps: []resource.TestStep{

--- a/ibm/service/mqcloud/resource_ibm_mqcloud_user.go
+++ b/ibm/service/mqcloud/resource_ibm_mqcloud_user.go
@@ -2,7 +2,7 @@
 // Licensed under the Mozilla Public License v2.0
 
 /*
- * IBM OpenAPI Terraform Generator Version: 3.90.0-5aad763d-20240506-203857
+ * IBM OpenAPI Terraform Generator Version: 3.95.2-120e65bc-20240924-152329
  */
 
 package mqcloud
@@ -34,7 +34,7 @@ func ResourceIbmMqcloudUser() *schema.Resource {
 				Required:     true,
 				ForceNew:     true,
 				ValidateFunc: validate.InvokeValidator("ibm_mqcloud_user", "service_instance_guid"),
-				Description:  "The GUID that uniquely identifies the MQ on Cloud service instance.",
+				Description:  "The GUID that uniquely identifies the MQaaS service instance.",
 			},
 			"name": {
 				Type:         schema.TypeString,
@@ -165,7 +165,6 @@ func resourceIbmMqcloudUserRead(context context.Context, d *schema.ResourceData,
 		err = fmt.Errorf("Error setting service_instance_guid: %s", err)
 		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_mqcloud_user", "read", "set-service_instance_guid").GetDiag()
 	}
-
 	if err = d.Set("name", userDetails.Name); err != nil {
 		err = fmt.Errorf("Error setting name: %s", err)
 		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_mqcloud_user", "read", "set-name").GetDiag()

--- a/ibm/service/mqcloud/resource_ibm_mqcloud_user_test.go
+++ b/ibm/service/mqcloud/resource_ibm_mqcloud_user_test.go
@@ -20,7 +20,7 @@ import (
 func TestAccIbmMqcloudUserBasic(t *testing.T) {
 	t.Parallel()
 	var conf mqcloudv1.UserDetails
-	serviceInstanceGuid := acc.MqcloudInstanceID
+	serviceInstanceGuid := acc.MqcloudDeploymentID
 	name := fmt.Sprintf("tfname%d", acctest.RandIntRange(10, 100))
 	email := fmt.Sprintf("tfemail%d@ibm.com", acctest.RandIntRange(10, 100))
 

--- a/ibm/service/mqcloud/resource_ibm_mqcloud_virtual_private_endpoint_gateway.go
+++ b/ibm/service/mqcloud/resource_ibm_mqcloud_virtual_private_endpoint_gateway.go
@@ -1,0 +1,254 @@
+// Copyright IBM Corp. 2024 All Rights Reserved.
+// Licensed under the Mozilla Public License v2.0
+
+/*
+ * IBM OpenAPI Terraform Generator Version: 3.96.0-d6dec9d7-20241008-212902
+ */
+
+package mqcloud
+
+import (
+	"context"
+	"fmt"
+	"log"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/conns"
+	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/flex"
+	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/validate"
+	"github.com/IBM/mqcloud-go-sdk/mqcloudv1"
+)
+
+func ResourceIbmMqcloudVirtualPrivateEndpointGateway() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceIbmMqcloudVirtualPrivateEndpointGatewayCreate,
+		ReadContext:   resourceIbmMqcloudVirtualPrivateEndpointGatewayRead,
+		DeleteContext: resourceIbmMqcloudVirtualPrivateEndpointGatewayDelete,
+		Importer:      &schema.ResourceImporter{},
+
+		Schema: map[string]*schema.Schema{
+			"service_instance_guid": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: validate.InvokeValidator("ibm_mqcloud_virtual_private_endpoint_gateway", "service_instance_guid"),
+				Description:  "The GUID that uniquely identifies the MQaaS service instance.",
+			},
+			"trusted_profile": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ForceNew:     true,
+				ValidateFunc: validate.InvokeValidator("ibm_mqcloud_virtual_private_endpoint_gateway", "trusted_profile"),
+				Description:  "The CRN of the trusted profile to assume for this request.",
+			},
+			"name": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: validate.InvokeValidator("ibm_mqcloud_virtual_private_endpoint_gateway", "name"),
+				Description:  "The name of the virtual private endpoint gateway, created by the user.",
+			},
+			"target_crn": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: validate.InvokeValidator("ibm_mqcloud_virtual_private_endpoint_gateway", "target_crn"),
+				Description:  "The CRN of the reserved capacity service instance the user is trying to connect to.",
+			},
+			"href": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "URL for the details of the virtual private endpoint gateway.",
+			},
+			"status": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The lifecycle state of this virtual privage endpoint.",
+			},
+			"virtual_private_endpoint_gateway_guid": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The ID of the virtual private endpoint gateway which was allocated on creation.",
+			},
+		},
+	}
+}
+
+func ResourceIbmMqcloudVirtualPrivateEndpointGatewayValidator() *validate.ResourceValidator {
+	validateSchema := make([]validate.ValidateSchema, 0)
+	validateSchema = append(validateSchema,
+		validate.ValidateSchema{
+			Identifier:                 "service_instance_guid",
+			ValidateFunctionIdentifier: validate.ValidateRegexpLen,
+			Type:                       validate.TypeString,
+			Required:                   true,
+			Regexp:                     `^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$`,
+			MinValueLength:             36,
+			MaxValueLength:             36,
+		},
+		validate.ValidateSchema{
+			Identifier:                 "trusted_profile",
+			ValidateFunctionIdentifier: validate.ValidateRegexpLen,
+			Type:                       validate.TypeString,
+			Optional:                   true,
+			Regexp:                     `^crn:v[0-9]+:[a-z0-9-]+:[a-z0-9-]+:[a-z0-9-]+:[a-z0-9-]*:([a-z]\/[a-z0-9-]+)?:[a-z0-9-]*:[a-z0-9-]*:[a-zA-Z0-9-_\.\/]*$|^crn:\[\.\.\.\]$`,
+			MinValueLength:             9,
+			MaxValueLength:             512,
+		},
+		validate.ValidateSchema{
+			Identifier:                 "name",
+			ValidateFunctionIdentifier: validate.ValidateRegexpLen,
+			Type:                       validate.TypeString,
+			Required:                   true,
+			Regexp:                     `^[a-z]|[a-z][-a-z0-9]*[a-z0-9]$`,
+			MinValueLength:             1,
+			MaxValueLength:             63,
+		},
+		validate.ValidateSchema{
+			Identifier:                 "target_crn",
+			ValidateFunctionIdentifier: validate.ValidateRegexpLen,
+			Type:                       validate.TypeString,
+			Required:                   true,
+			Regexp:                     `^crn:v[0-9]+:[a-z0-9-]+:[a-z0-9-]+:[a-z0-9-]+:[a-z0-9-]*:([a-z]\/[a-z0-9-]+)?:[a-z0-9-]*:[a-z0-9-]*:[a-zA-Z0-9-_\.\/]*$|^crn:\[\.\.\.\]$`,
+			MinValueLength:             9,
+			MaxValueLength:             512,
+		},
+	)
+
+	resourceValidator := validate.ResourceValidator{ResourceName: "ibm_mqcloud_virtual_private_endpoint_gateway", Schema: validateSchema}
+	return &resourceValidator
+}
+
+func resourceIbmMqcloudVirtualPrivateEndpointGatewayCreate(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	mqcloudClient, err := meta.(conns.ClientSession).MqcloudV1()
+	if err != nil {
+		tfErr := flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_mqcloud_virtual_private_endpoint_gateway", "create", "initialize-client")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
+	}
+
+	err = checkSIPlan(d, meta)
+	if err != nil {
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("Create Virtual Private Endpoint Gateway failed: %s", err.Error()), "ibm_mqcloud_virtual_private_endpoint_gateway", "create")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
+	}
+
+	createVirtualPrivateEndpointGatewayOptions := &mqcloudv1.CreateVirtualPrivateEndpointGatewayOptions{}
+
+	createVirtualPrivateEndpointGatewayOptions.SetServiceInstanceGuid(d.Get("service_instance_guid").(string))
+	createVirtualPrivateEndpointGatewayOptions.SetName(d.Get("name").(string))
+	createVirtualPrivateEndpointGatewayOptions.SetTargetCrn(d.Get("target_crn").(string))
+	if _, ok := d.GetOk("trusted_profile"); ok {
+		createVirtualPrivateEndpointGatewayOptions.SetTrustedProfile(d.Get("trusted_profile").(string))
+	}
+
+	virtualPrivateEndpointGatewayDetails, _, err := mqcloudClient.CreateVirtualPrivateEndpointGatewayWithContext(context, createVirtualPrivateEndpointGatewayOptions)
+	if err != nil {
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("CreateVirtualPrivateEndpointGatewayWithContext failed: %s", err.Error()), "ibm_mqcloud_virtual_private_endpoint_gateway", "create")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
+	}
+
+	d.SetId(fmt.Sprintf("%s/%s", *createVirtualPrivateEndpointGatewayOptions.ServiceInstanceGuid, *virtualPrivateEndpointGatewayDetails.ID))
+
+	return resourceIbmMqcloudVirtualPrivateEndpointGatewayRead(context, d, meta)
+}
+
+func resourceIbmMqcloudVirtualPrivateEndpointGatewayRead(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	mqcloudClient, err := meta.(conns.ClientSession).MqcloudV1()
+	if err != nil {
+		tfErr := flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_mqcloud_virtual_private_endpoint_gateway", "read", "initialize-client")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
+	}
+
+	getVirtualPrivateEndpointGatewayOptions := &mqcloudv1.GetVirtualPrivateEndpointGatewayOptions{}
+
+	parts, err := flex.SepIdParts(d.Id(), "/")
+	if err != nil {
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_mqcloud_virtual_private_endpoint_gateway", "read", "sep-id-parts").GetDiag()
+	}
+
+	getVirtualPrivateEndpointGatewayOptions.SetServiceInstanceGuid(parts[0])
+	getVirtualPrivateEndpointGatewayOptions.SetVirtualPrivateEndpointGatewayGuid(parts[1])
+	if _, ok := d.GetOk("trusted_profile"); ok {
+		getVirtualPrivateEndpointGatewayOptions.SetTrustedProfile(d.Get("trusted_profile").(string))
+	}
+
+	virtualPrivateEndpointGatewayDetails, response, err := mqcloudClient.GetVirtualPrivateEndpointGatewayWithContext(context, getVirtualPrivateEndpointGatewayOptions)
+	if err != nil {
+		if response != nil && response.StatusCode == 404 {
+			d.SetId("")
+			return nil
+		}
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("GetVirtualPrivateEndpointGatewayWithContext failed: %s", err.Error()), "ibm_mqcloud_virtual_private_endpoint_gateway", "read")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
+	}
+
+	if err = d.Set("name", virtualPrivateEndpointGatewayDetails.Name); err != nil {
+		err = fmt.Errorf("Error setting name: %s", err)
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_mqcloud_virtual_private_endpoint_gateway", "read", "set-name").GetDiag()
+	}
+	if err = d.Set("target_crn", virtualPrivateEndpointGatewayDetails.TargetCrn); err != nil {
+		err = fmt.Errorf("Error setting target_crn: %s", err)
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_mqcloud_virtual_private_endpoint_gateway", "read", "set-target_crn").GetDiag()
+	}
+	if err = d.Set("href", virtualPrivateEndpointGatewayDetails.Href); err != nil {
+		err = fmt.Errorf("Error setting href: %s", err)
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_mqcloud_virtual_private_endpoint_gateway", "read", "set-href").GetDiag()
+	}
+	if err = d.Set("status", virtualPrivateEndpointGatewayDetails.Status); err != nil {
+		err = fmt.Errorf("Error setting status: %s", err)
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_mqcloud_virtual_private_endpoint_gateway", "read", "set-status").GetDiag()
+	}
+	if err = d.Set("virtual_private_endpoint_gateway_guid", virtualPrivateEndpointGatewayDetails.ID); err != nil {
+		err = fmt.Errorf("Error setting virtual_private_endpoint_gateway_guid: %s", err)
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_mqcloud_virtual_private_endpoint_gateway", "read", "set-virtual_private_endpoint_gateway_guid").GetDiag()
+	}
+
+	return nil
+}
+
+func resourceIbmMqcloudVirtualPrivateEndpointGatewayDelete(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	mqcloudClient, err := meta.(conns.ClientSession).MqcloudV1()
+	if err != nil {
+		tfErr := flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_mqcloud_virtual_private_endpoint_gateway", "delete", "initialize-client")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
+	}
+
+	err = checkSIPlan(d, meta)
+	if err != nil {
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("Delete Virtual Private Endpoint Gateway failed: %s", err.Error()), "ibm_mqcloud_virtual_private_endpoint_gateway", "delete")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
+	}
+
+	deleteVirtualPrivateEndpointGatewayOptions := &mqcloudv1.DeleteVirtualPrivateEndpointGatewayOptions{}
+
+	parts, err := flex.SepIdParts(d.Id(), "/")
+	if err != nil {
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_mqcloud_virtual_private_endpoint_gateway", "delete", "sep-id-parts").GetDiag()
+	}
+
+	deleteVirtualPrivateEndpointGatewayOptions.SetServiceInstanceGuid(parts[0])
+	deleteVirtualPrivateEndpointGatewayOptions.SetVirtualPrivateEndpointGatewayGuid(parts[1])
+	if _, ok := d.GetOk("trusted_profile"); ok {
+		deleteVirtualPrivateEndpointGatewayOptions.SetTrustedProfile(d.Get("trusted_profile").(string))
+	}
+
+	_, err = mqcloudClient.DeleteVirtualPrivateEndpointGatewayWithContext(context, deleteVirtualPrivateEndpointGatewayOptions)
+	if err != nil {
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("DeleteVirtualPrivateEndpointGatewayWithContext failed: %s", err.Error()), "ibm_mqcloud_virtual_private_endpoint_gateway", "delete")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
+	}
+
+	d.SetId("")
+
+	return nil
+}

--- a/ibm/service/mqcloud/resource_ibm_mqcloud_virtual_private_endpoint_gateway_test.go
+++ b/ibm/service/mqcloud/resource_ibm_mqcloud_virtual_private_endpoint_gateway_test.go
@@ -1,0 +1,162 @@
+// Copyright IBM Corp. 2024 All Rights Reserved.
+// Licensed under the Mozilla Public License v2.0
+
+package mqcloud_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	acc "github.com/IBM-Cloud/terraform-provider-ibm/ibm/acctest"
+	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/conns"
+	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/flex"
+	"github.com/IBM/mqcloud-go-sdk/mqcloudv1"
+)
+
+func TestAccIbmMqcloudVirtualPrivateEndpointGatewayBasic(t *testing.T) {
+	t.Parallel()
+	var conf mqcloudv1.VirtualPrivateEndpointGatewayDetails
+	serviceInstanceGuid := acc.MqcloudCapacityID
+	name := fmt.Sprintf("tf-name-%d", acctest.RandIntRange(10, 100))
+	targetCrn := acc.MqCloudVirtualPrivateEndPointTargetCrn
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { acc.TestAccPreCheckMqcloud(t) },
+		Providers:    acc.TestAccProviders,
+		CheckDestroy: testAccCheckIbmMqcloudVirtualPrivateEndpointGatewayDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckIbmMqcloudVirtualPrivateEndpointGatewayConfigBasic(serviceInstanceGuid, name, targetCrn),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckIbmMqcloudVirtualPrivateEndpointGatewayExists("ibm_mqcloud_virtual_private_endpoint_gateway.mqcloud_virtual_private_endpoint_gateway_instance", conf),
+					resource.TestCheckResourceAttr("ibm_mqcloud_virtual_private_endpoint_gateway.mqcloud_virtual_private_endpoint_gateway_instance", "service_instance_guid", serviceInstanceGuid),
+					resource.TestCheckResourceAttr("ibm_mqcloud_virtual_private_endpoint_gateway.mqcloud_virtual_private_endpoint_gateway_instance", "name", name),
+					resource.TestCheckResourceAttr("ibm_mqcloud_virtual_private_endpoint_gateway.mqcloud_virtual_private_endpoint_gateway_instance", "target_crn", targetCrn),
+				),
+			},
+		},
+	})
+}
+
+func TestAccIbmMqcloudVirtualPrivateEndpointGatewayAllArgs(t *testing.T) {
+	t.Parallel()
+	var conf mqcloudv1.VirtualPrivateEndpointGatewayDetails
+	serviceInstanceGuid := acc.MqcloudCapacityID
+	trustedProfile := acc.MqCloudVirtualPrivateEndPointTrustedProfile
+	name := fmt.Sprintf("tf-name-%d", acctest.RandIntRange(10, 100))
+	targetCrn := acc.MqCloudVirtualPrivateEndPointTargetCrn
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { acc.TestAccPreCheck(t) },
+		Providers:    acc.TestAccProviders,
+		CheckDestroy: testAccCheckIbmMqcloudVirtualPrivateEndpointGatewayDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckIbmMqcloudVirtualPrivateEndpointGatewayConfig(serviceInstanceGuid, trustedProfile, name, targetCrn),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckIbmMqcloudVirtualPrivateEndpointGatewayExists("ibm_mqcloud_virtual_private_endpoint_gateway.mqcloud_virtual_private_endpoint_gateway_instance", conf),
+					resource.TestCheckResourceAttr("ibm_mqcloud_virtual_private_endpoint_gateway.mqcloud_virtual_private_endpoint_gateway_instance", "service_instance_guid", serviceInstanceGuid),
+					resource.TestCheckResourceAttr("ibm_mqcloud_virtual_private_endpoint_gateway.mqcloud_virtual_private_endpoint_gateway_instance", "trusted_profile", trustedProfile),
+					resource.TestCheckResourceAttr("ibm_mqcloud_virtual_private_endpoint_gateway.mqcloud_virtual_private_endpoint_gateway_instance", "name", name),
+					resource.TestCheckResourceAttr("ibm_mqcloud_virtual_private_endpoint_gateway.mqcloud_virtual_private_endpoint_gateway_instance", "target_crn", targetCrn),
+				),
+			},
+			{
+				ResourceName:      "ibm_mqcloud_virtual_private_endpoint_gateway.mqcloud_virtual_private_endpoint_gateway",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testAccCheckIbmMqcloudVirtualPrivateEndpointGatewayConfigBasic(serviceInstanceGuid string, name string, targetCrn string) string {
+	return fmt.Sprintf(`
+		resource "ibm_mqcloud_virtual_private_endpoint_gateway" "mqcloud_virtual_private_endpoint_gateway_instance" {
+			service_instance_guid = "%s"
+			name = "%s"
+			target_crn = "%s"
+		}
+	`, serviceInstanceGuid, name, targetCrn)
+}
+
+func testAccCheckIbmMqcloudVirtualPrivateEndpointGatewayConfig(serviceInstanceGuid string, trustedProfile string, name string, targetCrn string) string {
+	return fmt.Sprintf(`
+
+		resource "ibm_mqcloud_virtual_private_endpoint_gateway" "mqcloud_virtual_private_endpoint_gateway_instance" {
+			service_instance_guid = "%s"
+			trusted_profile = "%s"
+			name = "%s"
+			target_crn = "%s"
+		}
+	`, serviceInstanceGuid, trustedProfile, name, targetCrn)
+}
+
+func testAccCheckIbmMqcloudVirtualPrivateEndpointGatewayExists(n string, obj mqcloudv1.VirtualPrivateEndpointGatewayDetails) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+
+		mqcloudClient, err := acc.TestAccProvider.Meta().(conns.ClientSession).MqcloudV1()
+		if err != nil {
+			return err
+		}
+
+		getVirtualPrivateEndpointGatewayOptions := &mqcloudv1.GetVirtualPrivateEndpointGatewayOptions{}
+
+		parts, err := flex.SepIdParts(rs.Primary.ID, "/")
+		if err != nil {
+			return err
+		}
+
+		getVirtualPrivateEndpointGatewayOptions.SetServiceInstanceGuid(parts[0])
+		getVirtualPrivateEndpointGatewayOptions.SetVirtualPrivateEndpointGatewayGuid(parts[1])
+
+		virtualPrivateEndpointGatewayDetails, _, err := mqcloudClient.GetVirtualPrivateEndpointGateway(getVirtualPrivateEndpointGatewayOptions)
+		if err != nil {
+			return err
+		}
+
+		obj = *virtualPrivateEndpointGatewayDetails
+		return nil
+	}
+}
+
+func testAccCheckIbmMqcloudVirtualPrivateEndpointGatewayDestroy(s *terraform.State) error {
+	mqcloudClient, err := acc.TestAccProvider.Meta().(conns.ClientSession).MqcloudV1()
+	if err != nil {
+		return err
+	}
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "ibm_mqcloud_virtual_private_endpoint_gateway" {
+			continue
+		}
+
+		getVirtualPrivateEndpointGatewayOptions := &mqcloudv1.GetVirtualPrivateEndpointGatewayOptions{}
+
+		parts, err := flex.SepIdParts(rs.Primary.ID, "/")
+		if err != nil {
+			return err
+		}
+
+		getVirtualPrivateEndpointGatewayOptions.SetServiceInstanceGuid(parts[0])
+		getVirtualPrivateEndpointGatewayOptions.SetVirtualPrivateEndpointGatewayGuid(parts[1])
+
+		// Try to find the key
+		_, response, err := mqcloudClient.GetVirtualPrivateEndpointGateway(getVirtualPrivateEndpointGatewayOptions)
+
+		if err == nil {
+			return fmt.Errorf("mqcloud_virtual_private_endpoint_gateway still exists: %s", rs.Primary.ID)
+		} else if response.StatusCode != 404 {
+			return fmt.Errorf("Error checking for mqcloud_virtual_private_endpoint_gateway (%s) has been destroyed: %s", rs.Primary.ID, err)
+		}
+	}
+
+	return nil
+}

--- a/ibm/service/mqcloud/resource_ibm_mqcloud_virtual_private_endpoint_gateway_test.go
+++ b/ibm/service/mqcloud/resource_ibm_mqcloud_virtual_private_endpoint_gateway_test.go
@@ -66,9 +66,10 @@ func TestAccIbmMqcloudVirtualPrivateEndpointGatewayAllArgs(t *testing.T) {
 				),
 			},
 			{
-				ResourceName:      "ibm_mqcloud_virtual_private_endpoint_gateway.mqcloud_virtual_private_endpoint_gateway",
-				ImportState:       true,
-				ImportStateVerify: true,
+				ResourceName:            "ibm_mqcloud_virtual_private_endpoint_gateway.mqcloud_virtual_private_endpoint_gateway_instance",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"trusted_profile", "service_instance_guid"},
 			},
 		},
 	})

--- a/ibm/service/mqcloud/utils.go
+++ b/ibm/service/mqcloud/utils.go
@@ -216,7 +216,7 @@ func fetchServicePlan(meta interface{}, instanceID string) (string, error) {
 
 func handlePlanCheck(plan string, instanceID string) error {
 	if !strings.Contains(plan, reservedDeploymentPlan) && !strings.Contains(plan, reservedCapacityPlan) && !strings.Contains(plan, reservedCapacitySubscriptionPlan) {
-		return fmt.Errorf("[ERROR] Terraform is only supported for Reserved Deployment, Reserved Capacity, and Subscription Plans. Your Service Plan is: %s for the instance %s", plan, instanceID)
+		return fmt.Errorf("[ERROR] Terraform is only supported for Reserved Deployment, Reserved Capacity, and Reserved Capacity Subscription Plans. Your Service Plan is: %s for the instance %s", plan, instanceID)
 	}
 	return nil
 }

--- a/ibm/service/mqcloud/utils.go
+++ b/ibm/service/mqcloud/utils.go
@@ -32,6 +32,8 @@ const qmCreating = "initializing"
 const isQueueManagerDeleting = "true"
 const isQueueManagerDeleteDone = "true"
 const reservedDeploymentPlan = "reserved-deployment"
+const reservedCapacityPlan = "reserved-capacity"
+const reservedCapacitySubscriptionPlan = "reserved-capacity-subscription"
 const enforceReservedDeploymentPlan = true // change to false for testing in IKS clusters.
 
 // waitForQmStatusUpdate waits for Queue Manager to be in running state
@@ -213,8 +215,8 @@ func fetchServicePlan(meta interface{}, instanceID string) (string, error) {
 }
 
 func handlePlanCheck(plan string, instanceID string) error {
-	if !strings.Contains(plan, reservedDeploymentPlan) {
-		return fmt.Errorf("[ERROR] Terraform is only supported for Reserved Deployment Plan. Your Service Plan is: %s for the instance %s", plan, instanceID)
+	if !strings.Contains(plan, reservedDeploymentPlan) && !strings.Contains(plan, reservedCapacityPlan) && !strings.Contains(plan, reservedCapacitySubscriptionPlan) {
+		return fmt.Errorf("[ERROR] Terraform is only supported for Reserved Deployment, Reserved Capacity, and Subscription Plans. Your Service Plan is: %s for the instance %s", plan, instanceID)
 	}
 	return nil
 }

--- a/ibm/service/mqcloud/utils.go
+++ b/ibm/service/mqcloud/utils.go
@@ -216,7 +216,7 @@ func fetchServicePlan(meta interface{}, instanceID string) (string, error) {
 
 func handlePlanCheck(plan string, instanceID string) error {
 	if !strings.Contains(plan, reservedDeploymentPlan) && !strings.Contains(plan, reservedCapacityPlan) && !strings.Contains(plan, reservedCapacitySubscriptionPlan) {
-		return fmt.Errorf("[ERROR] Terraform is only supported for Reserved Deployment, Reserved Capacity, and Reserved Capacity Subscription Plans. Your Service Plan is: %s for the instance %s", plan, instanceID)
+		return fmt.Errorf("[ERROR] Terraform is only supported for Reserved Deployment, Reserved Capacity, and Subscription Plans. Your Service Plan is: %s for the instance %s", plan, instanceID)
 	}
 	return nil
 }

--- a/ibm/service/mqcloud/utils_test.go
+++ b/ibm/service/mqcloud/utils_test.go
@@ -92,7 +92,7 @@ func TestHandlePlanCheck(t *testing.T) {
 		{"reserved-deployment", "123", false, ""},
 
 		// Test with non-matching plan
-		{"Basic_Plan", "123", true, "[ERROR] Terraform is only supported for Reserved Deployment, Reserved Capacity, and Subscription Plans. Your Service Plan is: Basic_Plan for the instance 123"},
+		{"Basic_Plan", "123", true, "[ERROR] Terraform is only supported for Reserved Deployment, Reserved Capacity, and Reserved Capacity Subscription Plans. Your Service Plan is: Basic_Plan for the instance 123"},
 	}
 
 	for _, tt := range tests {
@@ -145,7 +145,7 @@ func Test_checkSIPlan(t *testing.T) {
 			name:                 "Cache Hit: Default Plan",
 			cachePlan:            "cached-default-plan",
 			wantErr:              true,
-			expectedErrorMessage: "[ERROR] Terraform is only supported for Reserved Deployment, Reserved Capacity, and Subscription Plans. Your Service Plan is: cached-default-plan for the instance cached-default-plan",
+			expectedErrorMessage: "[ERROR] Terraform is only supported for Reserved Deployment, Reserved Capacity, and Reserved Capacity Subscription Plans. Your Service Plan is: cached-default-plan for the instance cached-default-plan",
 		},
 		{
 			name:      "Reserved Deployment Plan Wildcard",
@@ -161,7 +161,7 @@ func Test_checkSIPlan(t *testing.T) {
 			name:                 "Default Plan",
 			cachePlan:            "default_plan_id",
 			wantErr:              true,
-			expectedErrorMessage: "[ERROR] Terraform is only supported for Reserved Deployment, Reserved Capacity, and Subscription Plans. Your Service Plan is: default for the instance default_plan_id",
+			expectedErrorMessage: "[ERROR] Terraform is only supported for Reserved Deployment, Reserved Capacity, and Reserved Capacity Subscription Plans. Your Service Plan is: default for the instance default_plan_id",
 		},
 		{
 			name:                 "fetchServicePlanFunc Error: Invalid id",

--- a/ibm/service/mqcloud/utils_test.go
+++ b/ibm/service/mqcloud/utils_test.go
@@ -92,7 +92,7 @@ func TestHandlePlanCheck(t *testing.T) {
 		{"reserved-deployment", "123", false, ""},
 
 		// Test with non-matching plan
-		{"Basic_Plan", "123", true, "[ERROR] Terraform is only supported for Reserved Deployment Plan. Your Service Plan is: Basic_Plan for the instance 123"},
+		{"Basic_Plan", "123", true, "[ERROR] Terraform is only supported for Reserved Deployment, Reserved Capacity, and Subscription Plans. Your Service Plan is: Basic_Plan for the instance 123"},
 	}
 
 	for _, tt := range tests {
@@ -145,7 +145,7 @@ func Test_checkSIPlan(t *testing.T) {
 			name:                 "Cache Hit: Default Plan",
 			cachePlan:            "cached-default-plan",
 			wantErr:              true,
-			expectedErrorMessage: "[ERROR] Terraform is only supported for Reserved Deployment Plan. Your Service Plan is: cached-default-plan for the instance cached-default-plan",
+			expectedErrorMessage: "[ERROR] Terraform is only supported for Reserved Deployment, Reserved Capacity, and Subscription Plans. Your Service Plan is: cached-default-plan for the instance cached-default-plan",
 		},
 		{
 			name:      "Reserved Deployment Plan Wildcard",
@@ -161,7 +161,7 @@ func Test_checkSIPlan(t *testing.T) {
 			name:                 "Default Plan",
 			cachePlan:            "default_plan_id",
 			wantErr:              true,
-			expectedErrorMessage: "[ERROR] Terraform is only supported for Reserved Deployment Plan. Your Service Plan is: default for the instance default_plan_id",
+			expectedErrorMessage: "[ERROR] Terraform is only supported for Reserved Deployment, Reserved Capacity, and Subscription Plans. Your Service Plan is: default for the instance default_plan_id",
 		},
 		{
 			name:                 "fetchServicePlanFunc Error: Invalid id",

--- a/website/allowed-subcategories.txt
+++ b/website/allowed-subcategories.txt
@@ -28,7 +28,7 @@ Key Management Service
 Kubernetes Service
 Logs Routing
 Metrics Router
-MQ on Cloud
+MQaaS
 Object Storage
 Partner Center Sell
 Power Systems

--- a/website/docs/d/mqcloud_application.html.markdown
+++ b/website/docs/d/mqcloud_application.html.markdown
@@ -3,14 +3,14 @@ layout: "ibm"
 page_title: "IBM : ibm_mqcloud_application"
 description: |-
   Get information about mqcloud_application
-subcategory: "MQ on Cloud"
+subcategory: "MQaaS"
 ---
 
 # ibm_mqcloud_application
 
 Provides a read-only data source to retrieve information about a mqcloud_application. You can then reference the fields of the data source in other resources within the same configuration by using interpolation syntax.
 
-> **Note:** The MQ on Cloud Terraform provider access is restricted to users of the reserved deployment plan.
+> **Note:** The MQaaS Terraform provider access is restricted to users of the reserved deployment, reserved capacity, and reserved capacity subscription plans.
 
 ## Example Usage
 
@@ -27,7 +27,7 @@ You can specify the following arguments for this data source.
 
 * `name` - (Optional, String) The name of the application - conforming to MQ rules.
   * Constraints: The maximum length is `12` characters. The minimum length is `1` character.
-* `service_instance_guid` - (Required, Forces new resource, String) The GUID that uniquely identifies the MQ on Cloud service instance.
+* `service_instance_guid` - (Required, Forces new resource, String) The GUID that uniquely identifies the MQaaS service instance.
   * Constraints: The maximum length is `36` characters. The minimum length is `36` characters. The value must match regular expression `/^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$/`.
 
 ## Attribute Reference

--- a/website/docs/d/mqcloud_keystore_certificate.html.markdown
+++ b/website/docs/d/mqcloud_keystore_certificate.html.markdown
@@ -3,14 +3,14 @@ layout: "ibm"
 page_title: "IBM : ibm_mqcloud_keystore_certificate"
 description: |-
   Get information about mqcloud_keystore_certificate
-subcategory: "MQ on Cloud"
+subcategory: "MQaaS"
 ---
 
 # ibm_mqcloud_keystore_certificate
 
 Provides a read-only data source to retrieve information about a mqcloud_keystore_certificate. You can then reference the fields of the data source in other resources within the same configuration by using interpolation syntax.
 
-> **Note:** The MQ on Cloud Terraform provider access is restricted to users of the reserved deployment plan.
+> **Note:** The MQaaS Terraform provider access is restricted to users of the reserved deployment, reserved capacity, and reserved capacity subscription plans.
 
 ## Example Usage
 
@@ -30,7 +30,7 @@ You can specify the following arguments for this data source.
   * Constraints: The maximum length is `64` characters. The minimum length is `1` character. The value must match regular expression `/^[a-zA-Z0-9_.]*$/`.
 * `queue_manager_id` - (Required, Forces new resource, String) The id of the queue manager to retrieve its full details.
   * Constraints: The maximum length is `32` characters. The minimum length is `32` characters. The value must match regular expression `/^[0-9a-fA-F]{32}$/`.
-* `service_instance_guid` - (Required, Forces new resource, String) The GUID that uniquely identifies the MQ on Cloud service instance.
+* `service_instance_guid` - (Required, Forces new resource, String) The GUID that uniquely identifies the MQaaS service instance.
   * Constraints: The maximum length is `36` characters. The minimum length is `36` characters. The value must match regular expression `/^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$/`.
 
 ## Attribute Reference

--- a/website/docs/d/mqcloud_queue_manager.html.markdown
+++ b/website/docs/d/mqcloud_queue_manager.html.markdown
@@ -3,14 +3,14 @@ layout: "ibm"
 page_title: "IBM : ibm_mqcloud_queue_manager"
 description: |-
   Get information about mqcloud_queue_manager
-subcategory: "MQ on Cloud"
+subcategory: "MQaaS"
 ---
 
 # ibm_mqcloud_queue_manager
 
 Provides a read-only data source to retrieve information about a mqcloud_queue_manager. You can then reference the fields of the data source in other resources within the same configuration by using interpolation syntax.
 
-> **Note:** The MQ on Cloud Terraform provider access is restricted to users of the reserved deployment plan.
+> **Note:** The MQaaS Terraform provider access is restricted to users of the reserved deployment, reserved capacity, and reserved capacity subscription plans.
 
 ## Example Usage
 
@@ -27,7 +27,7 @@ You can specify the following arguments for this data source.
 
 * `name` - (Optional, String) A queue manager name conforming to MQ restrictions.
   * Constraints: The maximum length is `48` characters. The minimum length is `1` character. The value must match regular expression `/^[a-zA-Z0-9._]*$/`.
-* `service_instance_guid` - (Required, Forces new resource, String) The GUID that uniquely identifies the MQ on Cloud service instance.
+* `service_instance_guid` - (Required, String) The GUID that uniquely identifies the MQaaS service instance.
   * Constraints: The maximum length is `36` characters. The minimum length is `36` characters. The value must match regular expression `/^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$/`.
 
 ## Attribute Reference

--- a/website/docs/d/mqcloud_queue_manager_options.html.markdown
+++ b/website/docs/d/mqcloud_queue_manager_options.html.markdown
@@ -3,14 +3,14 @@ layout: "ibm"
 page_title: "IBM : ibm_mqcloud_queue_manager_options"
 description: |-
   Get information about mqcloud_queue_manager_options
-subcategory: "MQ on Cloud"
+subcategory: "MQaaS"
 ---
 
 # ibm_mqcloud_queue_manager_options
 
 Provides a read-only data source to retrieve information about mqcloud_queue_manager_options. You can then reference the fields of the data source in other resources within the same configuration by using interpolation syntax.
 
-> **Note:** The MQ on Cloud Terraform provider access is restricted to users of the reserved deployment plan.
+> **Note:** The MQaaS Terraform provider access is restricted to users of the reserved deployment, reserved capacity, and reserved capacity subscription plans.
 
 ## Example Usage
 
@@ -24,7 +24,7 @@ data "ibm_mqcloud_queue_manager_options" "mqcloud_queue_manager_options" {
 
 You can specify the following arguments for this data source.
 
-* `service_instance_guid` - (Required, Forces new resource, String) The GUID that uniquely identifies the MQ on Cloud service instance.
+* `service_instance_guid` - (Required, Forces new resource, String) The GUID that uniquely identifies the MQaaS service instance.
   * Constraints: The maximum length is `36` characters. The minimum length is `36` characters. The value must match regular expression `/^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$/`.
 
 ## Attribute Reference

--- a/website/docs/d/mqcloud_queue_manager_status.html.markdown
+++ b/website/docs/d/mqcloud_queue_manager_status.html.markdown
@@ -3,14 +3,14 @@ layout: "ibm"
 page_title: "IBM : ibm_mqcloud_queue_manager_status"
 description: |-
   Get information about mqcloud_queue_manager_status
-subcategory: "MQ on Cloud"
+subcategory: "MQaaS"
 ---
 
 # ibm_mqcloud_queue_manager_status
 
 Provides a read-only data source to retrieve information about mqcloud_queue_manager_status. You can then reference the fields of the data source in other resources within the same configuration by using interpolation syntax.
 
-> **Note:** The MQ on Cloud Terraform provider access is restricted to users of the reserved deployment plan.
+> **Note:** The MQaaS Terraform provider access is restricted to users of the reserved deployment, reserved capacity, and reserved capacity subscription plans.
 
 ## Example Usage
 
@@ -27,7 +27,7 @@ You can specify the following arguments for this data source.
 
 * `queue_manager_id` - (Required, Forces new resource, String) The id of the queue manager to retrieve its full details.
   * Constraints: The maximum length is `32` characters. The minimum length is `32` characters. The value must match regular expression `/^[0-9a-fA-F]{32}$/`.
-* `service_instance_guid` - (Required, Forces new resource, String) The GUID that uniquely identifies the MQ on Cloud service instance.
+* `service_instance_guid` - (Required, Forces new resource, String) The GUID that uniquely identifies the MQaaS service instance.
   * Constraints: The maximum length is `36` characters. The minimum length is `36` characters. The value must match regular expression `/^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$/`.
 
 ## Attribute Reference

--- a/website/docs/d/mqcloud_truststore_certificate.html.markdown
+++ b/website/docs/d/mqcloud_truststore_certificate.html.markdown
@@ -3,14 +3,14 @@ layout: "ibm"
 page_title: "IBM : ibm_mqcloud_truststore_certificate"
 description: |-
   Get information about mqcloud_truststore_certificate
-subcategory: "MQ on Cloud"
+subcategory: "MQaaS"
 ---
 
 # ibm_mqcloud_truststore_certificate
 
 Provides a read-only data source to retrieve information about a mqcloud_truststore_certificate. You can then reference the fields of the data source in other resources within the same configuration by using interpolation syntax.
 
-> **Note:** The MQ on Cloud Terraform provider access is restricted to users of the reserved deployment plan.
+> **Note:** The MQaaS Terraform provider access is restricted to users of the reserved deployment, reserved capacity, and reserved capacity subscription plans.
 
 ## Example Usage
 
@@ -30,7 +30,7 @@ You can specify the following arguments for this data source.
   * Constraints: The maximum length is `64` characters. The minimum length is `1` character. The value must match regular expression `/^[a-zA-Z0-9_.]*$/`.
 * `queue_manager_id` - (Required, Forces new resource, String) The id of the queue manager to retrieve its full details.
   * Constraints: The maximum length is `32` characters. The minimum length is `32` characters. The value must match regular expression `/^[0-9a-fA-F]{32}$/`.
-* `service_instance_guid` - (Required, Forces new resource, String) The GUID that uniquely identifies the MQ on Cloud service instance.
+* `service_instance_guid` - (Required, Forces new resource, String) The GUID that uniquely identifies the MQaaS service instance.
   * Constraints: The maximum length is `36` characters. The minimum length is `36` characters. The value must match regular expression `/^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$/`.
 
 ## Attribute Reference

--- a/website/docs/d/mqcloud_user.html.markdown
+++ b/website/docs/d/mqcloud_user.html.markdown
@@ -3,14 +3,14 @@ layout: "ibm"
 page_title: "IBM : ibm_mqcloud_user"
 description: |-
   Get information about mqcloud_user
-subcategory: "MQ on Cloud"
+subcategory: "MQaaS"
 ---
 
 # ibm_mqcloud_user
 
 Provides a read-only data source to retrieve information about a mqcloud_user. You can then reference the fields of the data source in other resources within the same configuration by using interpolation syntax.
 
-> **Note:** The MQ on Cloud Terraform provider access is restricted to users of the reserved deployment plan.
+> **Note:** The MQaaS Terraform provider access is restricted to users of the reserved deployment, reserved capacity, and reserved capacity subscription plans.
 
 ## Example Usage
 
@@ -27,7 +27,7 @@ You can specify the following arguments for this data source.
 
 * `name` - (Optional, String) The shortname of the user that will be used as the IBM MQ administrator in interactions with a queue manager for this service instance.
   * Constraints: The maximum length is `12` characters. The minimum length is `1` character. The value must match regular expression `/^[a-z][-a-z0-9]*$/`.
-* `service_instance_guid` - (Required, Forces new resource, String) The GUID that uniquely identifies the MQ on Cloud service instance.
+* `service_instance_guid` - (Required, Forces new resource, String) The GUID that uniquely identifies the MQaaS service instance.
   * Constraints: The maximum length is `36` characters. The minimum length is `36` characters. The value must match regular expression `/^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$/`.
 
 ## Attribute Reference

--- a/website/docs/d/mqcloud_virtual_private_endpoint_gateway.html.markdown
+++ b/website/docs/d/mqcloud_virtual_private_endpoint_gateway.html.markdown
@@ -1,0 +1,49 @@
+---
+layout: "ibm"
+page_title: "IBM : ibm_mqcloud_virtual_private_endpoint_gateway"
+description: |-
+  Get information about mqcloud_virtual_private_endpoint_gateway
+subcategory: "MQaaS"
+---
+
+# ibm_mqcloud_virtual_private_endpoint_gateway
+
+Provides a read-only data source to retrieve information about a mqcloud_virtual_private_endpoint_gateway. You can then reference the fields of the data source in other resources within the same configuration by using interpolation syntax.
+
+> **Note:** The MQaaS Terraform provider access is restricted to users of the reserved deployment, reserved capacity, and reserved capacity subscription plans.
+
+## Example Usage
+
+```hcl
+data "ibm_mqcloud_virtual_private_endpoint_gateway" "mqcloud_virtual_private_endpoint_gateway" {
+	service_instance_guid = ibm_mqcloud_virtual_private_endpoint_gateway.mqcloud_virtual_private_endpoint_gateway_instance.service_instance_guid
+	trusted_profile = ibm_mqcloud_virtual_private_endpoint_gateway.mqcloud_virtual_private_endpoint_gateway_instance.trusted_profile
+	virtual_private_endpoint_gateway_guid = ibm_mqcloud_virtual_private_endpoint_gateway.mqcloud_virtual_private_endpoint_gateway_instance.virtual_private_endpoint_gateway_guid
+}
+```
+
+## Argument Reference
+
+You can specify the following arguments for this data source.
+
+* `service_instance_guid` - (Required, Forces new resource, String) The GUID that uniquely identifies the MQaaS service instance.
+  * Constraints: The maximum length is `36` characters. The minimum length is `36` characters. The value must match regular expression `/^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$/`.
+* `trusted_profile` - (Optional, String) The CRN of the trusted profile to assume for this request.
+  * Constraints: The maximum length is `512` characters. The minimum length is `9` characters. The value must match regular expression `/^crn:v[0-9]+:[a-z0-9-]+:[a-z0-9-]+:[a-z0-9-]+:[a-z0-9-]*:([a-z]\/[a-z0-9-]+)?:[a-z0-9-]*:[a-z0-9-]*:[a-zA-Z0-9-_\\.\/]*$|^crn:\\[\\.\\.\\.\\]$/`.
+* `virtual_private_endpoint_gateway_guid` - (Required, Forces new resource, String) The id of the virtual private endpoint gateway.
+  * Constraints: The maximum length is `41` characters. The minimum length is `41` characters. The value must match regular expression `/^[0-9a-zA-Z]{4}-[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$/`.
+
+## Attribute Reference
+
+After your data source is created, you can read values from the following attributes.
+
+* `id` - The unique identifier of the mqcloud_virtual_private_endpoint_gateway.
+* `href` - (String) URL for the details of the virtual private endpoint gateway.
+  * Constraints: The maximum length is `8000` characters. The minimum length is `10` characters. The value must match regular expression `/^http(s)?:\/\/([^\/?#]*)([^?#]*)(\\?([^#]*))?(#(.*))?$/`.
+* `name` - (Forces new resource, String) The name of the virtual private endpoint gateway, created by the user.
+  * Constraints: The maximum length is `63` characters. The minimum length is `1` character. The value must match regular expression `/^[a-z]|[a-z][-a-z0-9]*[a-z0-9]$/`.
+* `status` - (String) The lifecycle state of this virtual privage endpoint.
+  * Constraints: The maximum length is `12` characters. The minimum length is `2` characters. The value must match regular expression `/^deleting$|failed$|pending$|stable$|suspended$|updating$|waiting$/`.
+* `target_crn` - (String) The CRN of the reserved capacity service instance the user is trying to connect to.
+  * Constraints: The maximum length is `512` characters. The minimum length is `9` characters. The value must match regular expression `/^crn:v[0-9]+:[a-z0-9-]+:[a-z0-9-]+:[a-z0-9-]+:[a-z0-9-]*:([a-z]\/[a-z0-9-]+)?:[a-z0-9-]*:[a-z0-9-]*:[a-zA-Z0-9-_\\.\/]*$|^crn:\\[\\.\\.\\.\\]$/`.
+

--- a/website/docs/d/mqcloud_virtual_private_endpoint_gateways.html.markdown
+++ b/website/docs/d/mqcloud_virtual_private_endpoint_gateways.html.markdown
@@ -1,0 +1,54 @@
+---
+layout: "ibm"
+page_title: "IBM : ibm_mqcloud_virtual_private_endpoint_gateways"
+description: |-
+  Get information about mqcloud_virtual_private_endpoint_gateways
+subcategory: "MQaaS"
+---
+
+# ibm_mqcloud_virtual_private_endpoint_gateways
+
+Provides a read-only data source to retrieve information about mqcloud_virtual_private_endpoint_gateways. You can then reference the fields of the data source in other resources within the same configuration by using interpolation syntax.
+
+> **Note:** The MQaaS Terraform provider access is restricted to users of the reserved deployment, reserved capacity, and reserved capacity subscription plans.
+
+## Example Usage
+
+```hcl
+data "ibm_mqcloud_virtual_private_endpoint_gateways" "mqcloud_virtual_private_endpoint_gateways" {
+	name = ibm_mqcloud_virtual_private_endpoint_gateway.mqcloud_virtual_private_endpoint_gateway_instance.name
+	service_instance_guid = ibm_mqcloud_virtual_private_endpoint_gateway.mqcloud_virtual_private_endpoint_gateway_instance.service_instance_guid
+	trusted_profile = ibm_mqcloud_virtual_private_endpoint_gateway.mqcloud_virtual_private_endpoint_gateway_instance.trusted_profile
+}
+```
+
+## Argument Reference
+
+You can specify the following arguments for this data source.
+
+* `name` - (Optional, Forces new resource, String) The name of the virtual private endpoint gateway, created by the user.
+  * Constraints: The maximum length is `63` characters. The minimum length is `1` character. The value must match regular expression `/^[a-z]|[a-z][-a-z0-9]*[a-z0-9]$/`.
+* `service_instance_guid` - (Required, Forces new resource, String) The GUID that uniquely identifies the MQaaS service instance.
+  * Constraints: The maximum length is `36` characters. The minimum length is `36` characters. The value must match regular expression `/^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$/`.
+* `trusted_profile` - (Optional, String) The CRN of the trusted profile to assume for this request.
+  * Constraints: The maximum length is `512` characters. The minimum length is `9` characters. The value must match regular expression `/^crn:v[0-9]+:[a-z0-9-]+:[a-z0-9-]+:[a-z0-9-]+:[a-z0-9-]*:([a-z]\/[a-z0-9-]+)?:[a-z0-9-]*:[a-z0-9-]*:[a-zA-Z0-9-_\\.\/]*$|^crn:\\[\\.\\.\\.\\]$/`.
+
+## Attribute Reference
+
+After your data source is created, you can read values from the following attributes.
+
+* `id` - The unique identifier of the mqcloud_virtual_private_endpoint_gateways.
+* `virtual_private_endpoint_gateways` - (List) List of virtual private endpoint gateways.
+  * Constraints: The maximum length is `50` items. The minimum length is `0` items.
+Nested schema for **virtual_private_endpoint_gateways**:
+	* `href` - (String) URL for the details of the virtual private endpoint gateway.
+	  * Constraints: The maximum length is `8000` characters. The minimum length is `10` characters. The value must match regular expression `/^http(s)?:\/\/([^\/?#]*)([^?#]*)(\\?([^#]*))?(#(.*))?$/`.
+	* `id` - (String) The ID of the virtual private endpoint gateway which was allocated on creation.
+	  * Constraints: The maximum length is `41` characters. The minimum length is `41` characters. The value must match regular expression `/^[0-9a-zA-Z]{4}-[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$/`.
+	* `name` - (Forces new resource, String) The name of the virtual private endpoint gateway, created by the user.
+	  * Constraints: The maximum length is `63` characters. The minimum length is `1` character. The value must match regular expression `/^[a-z]|[a-z][-a-z0-9]*[a-z0-9]$/`.
+	* `status` - (String) The lifecycle state of this virtual privage endpoint.
+	  * Constraints: The maximum length is `12` characters. The minimum length is `2` characters. The value must match regular expression `/^deleting$|failed$|pending$|stable$|suspended$|updating$|waiting$/`.
+	* `target_crn` - (String) The CRN of the reserved capacity service instance the user is trying to connect to.
+	  * Constraints: The maximum length is `512` characters. The minimum length is `9` characters. The value must match regular expression `/^crn:v[0-9]+:[a-z0-9-]+:[a-z0-9-]+:[a-z0-9-]+:[a-z0-9-]*:([a-z]\/[a-z0-9-]+)?:[a-z0-9-]*:[a-z0-9-]*:[a-zA-Z0-9-_\\.\/]*$|^crn:\\[\\.\\.\\.\\]$/`.
+

--- a/website/docs/r/mqcloud_application.html.markdown
+++ b/website/docs/r/mqcloud_application.html.markdown
@@ -3,14 +3,14 @@ layout: "ibm"
 page_title: "IBM : ibm_mqcloud_application"
 description: |-
   Manages mqcloud_application.
-subcategory: "MQ on Cloud"
+subcategory: "MQaaS"
 ---
 
 # ibm_mqcloud_application
 
 Create, update, and delete mqcloud_applications with this resource.
 
-> **Note:** The MQ on Cloud Terraform provider access is restricted to users of the reserved deployment plan.
+> **Note:** The MQaaS Terraform provider access is restricted to users of the reserved deployment, reserved capacity, and reserved capacity subscription plans.
 
 ## Example Usage
 
@@ -27,7 +27,7 @@ You can specify the following arguments for this resource.
 
 * `name` - (Required, Forces new resource, String) The name of the application - conforming to MQ rules.
   * Constraints: The maximum length is `12` characters. The minimum length is `1` character.
-* `service_instance_guid` - (Required, Forces new resource, String) The GUID that uniquely identifies the MQ on Cloud service instance.
+* `service_instance_guid` - (Required, Forces new resource, String) The GUID that uniquely identifies the MQaaS service instance.
   * Constraints: The maximum length is `36` characters. The minimum length is `36` characters. The value must match regular expression `/^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$/`.
 
 ## Attribute Reference
@@ -48,7 +48,7 @@ The `id` property can be formed from `service_instance_guid`, and `application_i
 <pre>
 &lt;service_instance_guid&gt;/&lt;application_id&gt;
 </pre>
-* `service_instance_guid`: A string in the format `a2b4d4bc-dadb-4637-bcec-9b7d1e723af8`. The GUID that uniquely identifies the MQ on Cloud service instance.
+* `service_instance_guid`: A string in the format `a2b4d4bc-dadb-4637-bcec-9b7d1e723af8`. The GUID that uniquely identifies the MQaaS service instance.
 * `application_id`: A string. The ID of the application which was allocated on creation, and can be used for delete calls.
 
 # Syntax

--- a/website/docs/r/mqcloud_keystore_certificate.html.markdown
+++ b/website/docs/r/mqcloud_keystore_certificate.html.markdown
@@ -3,14 +3,14 @@ layout: "ibm"
 page_title: "IBM : ibm_mqcloud_keystore_certificate"
 description: |-
   Manages mqcloud_keystore_certificate.
-subcategory: "MQ on Cloud"
+subcategory: "MQaaS"
 ---
 
 # ibm_mqcloud_keystore_certificate
 
 Create, update, and delete mqcloud_keystore_certificates with this resource.
 
-> **Note:** The MQ on Cloud Terraform provider access is restricted to users of the reserved deployment plan.
+> **Note:** The MQaaS Terraform provider access is restricted to users of the reserved deployment, reserved capacity, and reserved capacity subscription plans.
 
 ## Example Usage
 
@@ -20,7 +20,6 @@ resource "ibm_mqcloud_keystore_certificate" "mqcloud_keystore_certificate_instan
   label = "certlabel"
   queue_manager_id = var.queue_manager_id
   service_instance_guid = var.service_instance_guid
-
   config {
     ams {
       channels {
@@ -41,7 +40,7 @@ You can specify the following arguments for this resource.
   * Constraints: The maximum length is `64` characters. The minimum length is `1` character. The value must match regular expression `/^[a-zA-Z0-9_.]*$/`.
 * `queue_manager_id` - (Required, Forces new resource, String) The id of the queue manager to retrieve its full details.
   * Constraints: The maximum length is `32` characters. The minimum length is `32` characters. The value must match regular expression `/^[0-9a-fA-F]{32}$/`.
-* `service_instance_guid` - (Required, Forces new resource, String) The GUID that uniquely identifies the MQ on Cloud service instance.
+* `service_instance_guid` - (Required, Forces new resource, String) The GUID that uniquely identifies the MQaaS service instance.
   * Constraints: The maximum length is `36` characters. The minimum length is `36` characters. The value must match regular expression `/^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$/`.
 
 ## Attribute Reference
@@ -85,7 +84,7 @@ The `id` property can be formed from `service_instance_guid`, `queue_manager_id`
 <pre>
 &lt;service_instance_guid&gt;/&lt;queue_manager_id&gt;/&lt;certificate_id&gt;
 </pre>
-* `service_instance_guid`: A string in the format `a2b4d4bc-dadb-4637-bcec-9b7d1e723af8`. The GUID that uniquely identifies the MQ on Cloud service instance.
+* `service_instance_guid`: A string in the format `a2b4d4bc-dadb-4637-bcec-9b7d1e723af8`. The GUID that uniquely identifies the MQaaS service instance.
 * `queue_manager_id`: A string in the format `b8e1aeda078009cf3db74e90d5d42328`. The id of the queue manager to retrieve its full details.
 * `certificate_id`: A string. ID of the certificate.
 

--- a/website/docs/r/mqcloud_queue_manager.html.markdown
+++ b/website/docs/r/mqcloud_queue_manager.html.markdown
@@ -3,15 +3,14 @@ layout: "ibm"
 page_title: "IBM : ibm_mqcloud_queue_manager"
 description: |-
   Manages mqcloud_queue_manager.
-subcategory: "MQ on Cloud"
+subcategory: "MQaaS"
 ---
-
 
 # ibm_mqcloud_queue_manager
 
-Create, update, and delete mqcloud_queue_managers with this resource. 
+Create, update, and delete mqcloud_queue_managers with this resource.
 
-> **Note:** The MQ on Cloud Terraform provider access is restricted to users of the reserved deployment plan.
+> **Note:** The MQaaS Terraform provider access is restricted to users of the reserved deployment, reserved capacity, and reserved capacity subscription plans.
 
 ## Example Usage
 
@@ -27,7 +26,6 @@ resource "ibm_resource_instance" "mqcloud_deployment" {
   service = "mqcloud"
   tags    = var.tags
 }
-
 data "ibm_mqcloud_queue_manager_options" "mqcloud_options" {
   service_instance_guid = ibm_resource_instance.mqcloud_deployment.guid
   depends_on = [
@@ -48,6 +46,14 @@ resource "ibm_mqcloud_queue_manager" "mqcloud_queue_manager_instance" {
 }
 ```
 
+## Timeouts
+
+mqcloud_queue_manager provides the following [Timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) configuration options:
+
+* `create` - (Default 15 minutes) Used for creating a mqcloud_queue_manager.
+* `update` - (Default 5 minutes) Used for updating a mqcloud_queue_manager.
+* `delete` - (Default 5 minutes) Used for deleting a mqcloud_queue_manager.
+
 ## Argument Reference
 
 You can specify the following arguments for this resource.
@@ -55,15 +61,15 @@ You can specify the following arguments for this resource.
 * `display_name` - (Optional, String) A displayable name for the queue manager - limited only in length.
   * Constraints: The maximum length is `150` characters.
 * `location` - (Required, String) The location in which the queue manager could be deployed.
-  * Constraints: The maximum length is `150` characters. The minimum length is `2` characters. The value must match regular expression `/^([^[:ascii:]]|[a-zA-Z0-9-._: ])+$/`. Details of applicable locations can be found from either the use of the `ibm_mqcloud_queue_manager_options` datasource for the resource instance or can be found using the [IBM API for MQ on Cloud](https://cloud.ibm.com/apidocs/mq-on-cloud) and be set as a variable.
+  * Constraints: The maximum length is `150` characters. The minimum length is `2` characters. The value must match regular expression `/^([^[:ascii:]]|[a-zA-Z0-9-._: ])+$/`. Details of applicable locations can be found from either the use of the `ibm_mqcloud_queue_manager_options` datasource for the resource instance or can be found using the [IBM API for MQaaS](https://cloud.ibm.com/apidocs/mq-on-cloud) and be set as a variable.
 * `name` - (Required, String) A queue manager name conforming to MQ restrictions.
   * Constraints: The maximum length is `48` characters. The minimum length is `1` character. The value must match regular expression `/^[a-zA-Z0-9._]*$/`.
-* `service_instance_guid` - (Required, Forces new resource, String) The GUID that uniquely identifies the MQ on Cloud service instance.
+* `service_instance_guid` - (Required, Forces new resource, String) The GUID that uniquely identifies the MQaaS service instance.
   * Constraints: The maximum length is `36` characters. The minimum length is `36` characters. The value must match regular expression `/^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$/`.
 * `size` - (Required, String) The queue manager sizes of deployment available.
   * Constraints: Allowable values are: `xsmall`, `small`, `medium`, `large`.
 * `version` - (Optional, String) The MQ version of the queue manager.
-  * Constraints: The maximum length is `15` characters. The minimum length is `7` characters. The value must match regular expression `/^[0-9]+.[0-9]+.[0-9]+_[0-9]+$/`. Details of applicable versions can be found from either the use of the `ibm_mqcloud_queue_manager_options` datasource for the resource instance, can be found using the [IBM API for MQ on Cloud](https://cloud.ibm.com/apidocs/mq-on-cloud) or with the variable not included at all to default to the latest version.
+  * Constraints: The maximum length is `15` characters. The minimum length is `7` characters. The value must match regular expression `/^[0-9]+.[0-9]+.[0-9]+_[0-9]+$/`. Details of applicable versions can be found from either the use of the `ibm_mqcloud_queue_manager_options` datasource for the resource instance, can be found using the [IBM API for MQaaS](https://cloud.ibm.com/apidocs/mq-on-cloud) or with the variable not included at all to default to the latest version.
 
 ## Attribute Reference
 
@@ -90,7 +96,7 @@ The `id` property can be formed from `service_instance_guid`, and `queue_manager
 <pre>
 &lt;service_instance_guid&gt;/&lt;queue_manager_id&gt;
 </pre>
-* `service_instance_guid`: A string in the format `a2b4d4bc-dadb-4637-bcec-9b7d1e723af8`. The GUID that uniquely identifies the MQ on Cloud service instance.
+* `service_instance_guid`: A string in the format `a2b4d4bc-dadb-4637-bcec-9b7d1e723af8`. The GUID that uniquely identifies the MQaaS service instance.
 * `queue_manager_id`: A string. The ID of the queue manager which was allocated on creation, and can be used for delete calls.
 
 # Syntax

--- a/website/docs/r/mqcloud_truststore_certificate.html.markdown
+++ b/website/docs/r/mqcloud_truststore_certificate.html.markdown
@@ -3,14 +3,14 @@ layout: "ibm"
 page_title: "IBM : ibm_mqcloud_truststore_certificate"
 description: |-
   Manages mqcloud_truststore_certificate.
-subcategory: "MQ on Cloud"
+subcategory: "MQaaS"
 ---
 
 # ibm_mqcloud_truststore_certificate
 
 Create, update, and delete mqcloud_truststore_certificates with this resource.
 
-> **Note:** The MQ on Cloud Terraform provider access is restricted to users of the reserved deployment plan.
+> **Note:** The MQaaS Terraform provider access is restricted to users of the reserved deployment, reserved capacity, and reserved capacity subscription plans.
 
 ## Example Usage
 
@@ -33,7 +33,7 @@ You can specify the following arguments for this resource.
   * Constraints: The maximum length is `64` characters. The minimum length is `1` character. The value must match regular expression `/^[a-zA-Z0-9_.]*$/`.
 * `queue_manager_id` - (Required, Forces new resource, String) The id of the queue manager to retrieve its full details.
   * Constraints: The maximum length is `32` characters. The minimum length is `32` characters. The value must match regular expression `/^[0-9a-fA-F]{32}$/`.
-* `service_instance_guid` - (Required, Forces new resource, String) The GUID that uniquely identifies the MQ on Cloud service instance.
+* `service_instance_guid` - (Required, Forces new resource, String) The GUID that uniquely identifies the MQaaS service instance.
   * Constraints: The maximum length is `36` characters. The minimum length is `36` characters. The value must match regular expression `/^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$/`.
 
 ## Attribute Reference
@@ -65,7 +65,7 @@ The `id` property can be formed from `service_instance_guid`, `queue_manager_id`
 <pre>
 &lt;service_instance_guid&gt;/&lt;queue_manager_id&gt;/&lt;certificate_id&gt;
 </pre>
-* `service_instance_guid`: A string in the format `a2b4d4bc-dadb-4637-bcec-9b7d1e723af8`. The GUID that uniquely identifies the MQ on Cloud service instance.
+* `service_instance_guid`: A string in the format `a2b4d4bc-dadb-4637-bcec-9b7d1e723af8`. The GUID that uniquely identifies the MQaaS service instance.
 * `queue_manager_id`: A string in the format `b8e1aeda078009cf3db74e90d5d42328`. The id of the queue manager to retrieve its full details.
 * `certificate_id`: A string. Id of the certificate.
 

--- a/website/docs/r/mqcloud_user.html.markdown
+++ b/website/docs/r/mqcloud_user.html.markdown
@@ -3,14 +3,14 @@ layout: "ibm"
 page_title: "IBM : ibm_mqcloud_user"
 description: |-
   Manages mqcloud_user.
-subcategory: "MQ on Cloud"
+subcategory: "MQaaS"
 ---
 
 # ibm_mqcloud_user
 
 Create, update, and delete mqcloud_users with this resource.
 
-> **Note:** The MQ on Cloud Terraform provider access is restricted to users of the reserved deployment plan.
+> **Note:** The MQaaS Terraform provider access is restricted to users of the reserved deployment, reserved capacity, and reserved capacity subscription plans.
 
 ## Example Usage
 
@@ -30,7 +30,7 @@ You can specify the following arguments for this resource.
   * Constraints: The maximum length is `253` characters. The minimum length is `5` characters.
 * `name` - (Required, Forces new resource, String) The shortname of the user that will be used as the IBM MQ administrator in interactions with a queue manager for this service instance.
   * Constraints: The maximum length is `12` characters. The minimum length is `1` character. The value must match regular expression `/^[a-z][-a-z0-9]*$/`.
-* `service_instance_guid` - (Required, Forces new resource, String) The GUID that uniquely identifies the MQ on Cloud service instance.
+* `service_instance_guid` - (Required, Forces new resource, String) The GUID that uniquely identifies the MQaaS service instance.
   * Constraints: The maximum length is `36` characters. The minimum length is `36` characters. The value must match regular expression `/^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$/`.
 
 ## Attribute Reference
@@ -50,7 +50,7 @@ The `id` property can be formed from `service_instance_guid`, and `user_id` in t
 <pre>
 &lt;service_instance_guid&gt;/&lt;user_id&gt;
 </pre>
-* `service_instance_guid`: A string in the format `a2b4d4bc-dadb-4637-bcec-9b7d1e723af8`. The GUID that uniquely identifies the MQ on Cloud service instance.
+* `service_instance_guid`: A string in the format `a2b4d4bc-dadb-4637-bcec-9b7d1e723af8`. The GUID that uniquely identifies the MQaaS service instance.
 * `user_id`: A string. The ID of the user which was allocated on creation, and can be used for delete calls.
 
 # Syntax

--- a/website/docs/r/mqcloud_virtual_private_endpoint_gateway.html.markdown
+++ b/website/docs/r/mqcloud_virtual_private_endpoint_gateway.html.markdown
@@ -1,0 +1,66 @@
+---
+layout: "ibm"
+page_title: "IBM : ibm_mqcloud_virtual_private_endpoint_gateway"
+description: |-
+  Manages mqcloud_virtual_private_endpoint_gateway.
+subcategory: "MQaaS"
+---
+
+# ibm_mqcloud_virtual_private_endpoint_gateway
+
+Create, update, and delete mqcloud_virtual_private_endpoint_gateways with this resource.
+
+> **Note:** The MQaaS Terraform provider access is restricted to users of the reserved deployment, reserved capacity, and reserved capacity subscription plans.
+
+## Example Usage
+
+```hcl
+resource "ibm_mqcloud_virtual_private_endpoint_gateway" "mqcloud_virtual_private_endpoint_gateway_instance" {
+  name = "vpe_gateway1-to-vpe_gateway2"
+  service_instance_guid = "a2b4d4bc-dadb-4637-bcec-9b7d1e723af8"
+  target_crn = "crn:v1:staging:public:mq-eude-stackname:eu-de:::endpoint:qm1.private.stackname.mq2.test.appdomain.cloud"
+  trusted_profile = "crn:v1:staging:public:mq-eude-stackname:eu-de:::endpoint:qm1.private.stackname.mq2.test.appdomain.cloud"
+}
+```
+
+## Argument Reference
+
+You can specify the following arguments for this resource.
+
+* `name` - (Required, Forces new resource, String) The name of the virtual private endpoint gateway, created by the user.
+  * Constraints: The maximum length is `63` characters. The minimum length is `1` character. The value must match regular expression `/^[a-z]|[a-z][-a-z0-9]*[a-z0-9]$/`.
+* `service_instance_guid` - (Required, Forces new resource, String) The GUID that uniquely identifies the MQaaS service instance.
+  * Constraints: The maximum length is `36` characters. The minimum length is `36` characters. The value must match regular expression `/^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$/`.
+* `target_crn` - (Required, Forces new resource, String) The CRN of the reserved capacity service instance the user is trying to connect to.
+  * Constraints: The maximum length is `512` characters. The minimum length is `9` characters. The value must match regular expression `/^crn:v[0-9]+:[a-z0-9-]+:[a-z0-9-]+:[a-z0-9-]+:[a-z0-9-]*:([a-z]\/[a-z0-9-]+)?:[a-z0-9-]*:[a-z0-9-]*:[a-zA-Z0-9-_\\.\/]*$|^crn:\\[\\.\\.\\.\\]$/`.
+* `trusted_profile` - (Optional, Forces new resource, String) The CRN of the trusted profile to assume for this request.
+  * Constraints: The maximum length is `512` characters. The minimum length is `9` characters. The value must match regular expression `/^crn:v[0-9]+:[a-z0-9-]+:[a-z0-9-]+:[a-z0-9-]+:[a-z0-9-]*:([a-z]\/[a-z0-9-]+)?:[a-z0-9-]*:[a-z0-9-]*:[a-zA-Z0-9-_\\.\/]*$|^crn:\\[\\.\\.\\.\\]$/`.
+
+## Attribute Reference
+
+After your resource is created, you can read values from the listed arguments and the following attributes.
+
+* `id` - The unique identifier of the mqcloud_virtual_private_endpoint_gateway.
+* `href` - (String) URL for the details of the virtual private endpoint gateway.
+  * Constraints: The maximum length is `8000` characters. The minimum length is `10` characters. The value must match regular expression `/^http(s)?:\/\/([^\/?#]*)([^?#]*)(\\?([^#]*))?(#(.*))?$/`.
+* `status` - (String) The lifecycle state of this virtual privage endpoint.
+  * Constraints: The maximum length is `12` characters. The minimum length is `2` characters. The value must match regular expression `/^deleting$|failed$|pending$|stable$|suspended$|updating$|waiting$/`.
+* `virtual_private_endpoint_gateway_guid` - (String) The ID of the virtual private endpoint gateway which was allocated on creation.
+  * Constraints: The maximum length is `41` characters. The minimum length is `41` characters. The value must match regular expression `/^[0-9a-zA-Z]{4}-[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$/`.
+
+
+## Import
+
+You can import the `ibm_mqcloud_virtual_private_endpoint_gateway` resource by using `id`.
+The `id` property can be formed from `service_instance_guid`, and `virtual_private_endpoint_gateway_guid` in the following format:
+
+<pre>
+&lt;service_instance_guid&gt;/&lt;virtual_private_endpoint_gateway_guid&gt;
+</pre>
+* `service_instance_guid`: A string in the format `a2b4d4bc-dadb-4637-bcec-9b7d1e723af8`. The GUID that uniquely identifies the MQaaS service instance.
+* `virtual_private_endpoint_gateway_guid`: A string. The ID of the virtual private endpoint gateway which was allocated on creation.
+
+# Syntax
+<pre>
+$ terraform import ibm_mqcloud_virtual_private_endpoint_gateway.mqcloud_virtual_private_endpoint_gateway &lt;service_instance_guid&gt;/&lt;virtual_private_endpoint_gateway_guid&gt;
+</pre>


### PR DESCRIPTION
MQ on Cloud is now renamed to MQ as a Service (MQaaS)

**Description:**
- Addition of the `virtual_private_endpoint_gateway` and `virtual_private_endpoint_gateways` data sources.
- Addition of the `virtual_private_endpoint_gateway` resource.
- Update to the handling of service plans to include capacity plans.
- Update instructions for running acceptance tests to include new environment variables, and a few edge-cases.
- Update of all documentation to point to `MQaaS` instead of `MQ on Cloud`.


<!--- See what makes a good Pull Request at : https://github.com/IBM-Cloud/terraform-provider-ibm/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TEST=./ibm/service/mqcloud/... 
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test -parallel 4 ./ibm/service/mqcloud/... -v  -timeout 700m
=== RUN   TestString
--- PASS: TestString (0.00s)
=== RUN   TestString_positiveIndex
--- PASS: TestString_positiveIndex (0.00s)
PASS
ok  	github.com/IBM-Cloud/terraform-provider-ibm/ibm/conns	0.232s
=== RUN   TestStringifyString
--- PASS: TestStringifyString (0.00s)
=== RUN   TestStringifyDate
--- PASS: TestStringifyDate (0.00s)
=== RUN   TestStringifyDateTime
--- PASS: TestStringifyDateTime (0.00s)
=== RUN   TestStringifyUUID
--- PASS: TestStringifyUUID (0.00s)
=== RUN   TestStringifyBoolean
--- PASS: TestStringifyBoolean (0.00s)
=== RUN   TestStringifyNumber
--- PASS: TestStringifyNumber (0.00s)
=== RUN   TestStringifyList
--- PASS: TestStringifyList (0.00s)
=== RUN   TestStringifyMap
--- PASS: TestStringifyMap (0.00s)
=== RUN   TestTerraformProblemEmbedsIBMProblem
--- PASS: TestTerraformProblemEmbedsIBMProblem (0.00s)
=== RUN   TestTerraformProblemGetConsoleMessage
--- PASS: TestTerraformProblemGetConsoleMessage (0.00s)
=== RUN   TestTerraformProblemGetDebugMessage
--- PASS: TestTerraformProblemGetDebugMessage (0.00s)
=== RUN   TestTerraformProblemGetID
--- PASS: TestTerraformProblemGetID (0.00s)
=== RUN   TestTerraformProblemGetConsoleOrderedMaps
--- PASS: TestTerraformProblemGetConsoleOrderedMaps (0.00s)
=== RUN   TestTerraformProblemGetDebugOrderedMaps
--- PASS: TestTerraformProblemGetDebugOrderedMaps (0.00s)
=== RUN   TestTerraformProblemGetDiag
--- PASS: TestTerraformProblemGetDiag (0.00s)
=== RUN   TestTerraformErrorf
--- PASS: TestTerraformErrorf (0.00s)
=== RUN   TestFmtErrorfWithProblem
--- PASS: TestFmtErrorfWithProblem (0.00s)
=== RUN   TestFmtErrorfWithNoError
--- PASS: TestFmtErrorfWithNoError (0.00s)
=== RUN   TestFmtErrorfWithProblemInServiceErrorResponse
--- PASS: TestFmtErrorfWithProblemInServiceErrorResponse (0.00s)
=== RUN   TestDiscriminatedTerraformErrorf
--- PASS: TestDiscriminatedTerraformErrorf (0.00s)
=== RUN   TestGetComponentInfo
--- PASS: TestGetComponentInfo (0.00s)
PASS
ok  	github.com/IBM-Cloud/terraform-provider-ibm/ibm/flex	0.360s
=== RUN   TestLoadWaitForQmStatusEnvVar
=== RUN   TestLoadWaitForQmStatusEnvVar/EnvVar_Set_To_True
=== RUN   TestLoadWaitForQmStatusEnvVar/EnvVar_Set_To_False
=== RUN   TestLoadWaitForQmStatusEnvVar/EnvVar_Not_Set
=== RUN   TestLoadWaitForQmStatusEnvVar/EnvVar_Set_To_Random_String
--- PASS: TestLoadWaitForQmStatusEnvVar (0.00s)
    --- PASS: TestLoadWaitForQmStatusEnvVar/EnvVar_Set_To_True (0.00s)
    --- PASS: TestLoadWaitForQmStatusEnvVar/EnvVar_Set_To_False (0.00s)
    --- PASS: TestLoadWaitForQmStatusEnvVar/EnvVar_Not_Set (0.00s)
    --- PASS: TestLoadWaitForQmStatusEnvVar/EnvVar_Set_To_Random_String (0.00s)
=== RUN   TestIsVersionDowngrade
=== RUN   TestIsVersionDowngrade/1.2.3_to_1.2.2
=== RUN   TestIsVersionDowngrade/1.2.3_to_1.2.4
=== RUN   TestIsVersionDowngrade/1.2.3_to_1.3.0
=== RUN   TestIsVersionDowngrade/1.2.3_to_1.2.3
=== RUN   TestIsVersionDowngrade/_to_1.0.0
=== RUN   TestIsVersionDowngrade/1.0.0_to_
=== RUN   TestIsVersionDowngrade/abc.def.ghi_to_1.2.3
--- PASS: TestIsVersionDowngrade (0.00s)
    --- PASS: TestIsVersionDowngrade/1.2.3_to_1.2.2 (0.00s)
    --- PASS: TestIsVersionDowngrade/1.2.3_to_1.2.4 (0.00s)
    --- PASS: TestIsVersionDowngrade/1.2.3_to_1.3.0 (0.00s)
    --- PASS: TestIsVersionDowngrade/1.2.3_to_1.2.3 (0.00s)
    --- PASS: TestIsVersionDowngrade/_to_1.0.0 (0.00s)
    --- PASS: TestIsVersionDowngrade/1.0.0_to_ (0.00s)
    --- PASS: TestIsVersionDowngrade/abc.def.ghi_to_1.2.3 (0.00s)
=== RUN   TestHandlePlanCheck
=== RUN   TestHandlePlanCheck/reserved-deployment
=== RUN   TestHandlePlanCheck/Basic_Plan
--- PASS: TestHandlePlanCheck (0.00s)
    --- PASS: TestHandlePlanCheck/reserved-deployment (0.00s)
    --- PASS: TestHandlePlanCheck/Basic_Plan (0.00s)
=== RUN   Test_checkSIPlan
=== RUN   Test_checkSIPlan/Cache_Hit:_Reserved_Deployment_Plan
=== RUN   Test_checkSIPlan/Cache_Hit:_Default_Plan
=== RUN   Test_checkSIPlan/Reserved_Deployment_Plan_Wildcard
=== RUN   Test_checkSIPlan/Reserved_Deployment_Plan
=== RUN   Test_checkSIPlan/Default_Plan
=== RUN   Test_checkSIPlan/fetchServicePlanFunc_Error:_Invalid_id
--- PASS: Test_checkSIPlan (0.00s)
    --- PASS: Test_checkSIPlan/Cache_Hit:_Reserved_Deployment_Plan (0.00s)
    --- PASS: Test_checkSIPlan/Cache_Hit:_Default_Plan (0.00s)
    --- PASS: Test_checkSIPlan/Reserved_Deployment_Plan_Wildcard (0.00s)
    --- PASS: Test_checkSIPlan/Reserved_Deployment_Plan (0.00s)
    --- PASS: Test_checkSIPlan/Default_Plan (0.00s)
    --- PASS: Test_checkSIPlan/fetchServicePlanFunc_Error:_Invalid_id (0.00s)
=== RUN   TestAccIbmMqcloudApplicationDataSourceBasic
--- PASS: TestAccIbmMqcloudApplicationDataSourceBasic (71.15s)
=== RUN   TestDataSourceIbmMqcloudApplicationApplicationDetailsToMap
--- PASS: TestDataSourceIbmMqcloudApplicationApplicationDetailsToMap (0.00s)
=== RUN   TestAccIbmMqcloudKeystoreCertificateDataSourceBasic
--- PASS: TestAccIbmMqcloudKeystoreCertificateDataSourceBasic (228.36s)
=== RUN   TestDataSourceIbmMqcloudKeystoreCertificateKeyStoreCertificateDetailsToMap
--- PASS: TestDataSourceIbmMqcloudKeystoreCertificateKeyStoreCertificateDetailsToMap (0.00s)
=== RUN   TestDataSourceIbmMqcloudKeystoreCertificateCertificateConfigurationToMap
--- PASS: TestDataSourceIbmMqcloudKeystoreCertificateCertificateConfigurationToMap (0.00s)
=== RUN   TestDataSourceIbmMqcloudKeystoreCertificateChannelsDetailsToMap
--- PASS: TestDataSourceIbmMqcloudKeystoreCertificateChannelsDetailsToMap (0.00s)
=== RUN   TestDataSourceIbmMqcloudKeystoreCertificateChannelDetailsToMap
--- PASS: TestDataSourceIbmMqcloudKeystoreCertificateChannelDetailsToMap (0.00s)
=== RUN   TestAccIbmMqcloudQueueManagerOptionsDataSourceBasic
--- PASS: TestAccIbmMqcloudQueueManagerOptionsDataSourceBasic (11.11s)
=== RUN   TestAccIbmMqcloudQueueManagerStatusDataSourceBasic
--- PASS: TestAccIbmMqcloudQueueManagerStatusDataSourceBasic (7.15s)
=== RUN   TestAccIbmMqcloudQueueManagerDataSourceBasic
--- PASS: TestAccIbmMqcloudQueueManagerDataSourceBasic (296.00s)
=== RUN   TestAccIbmMqcloudQueueManagerDataSourceAllArgs
--- PASS: TestAccIbmMqcloudQueueManagerDataSourceAllArgs (229.93s)
=== RUN   TestDataSourceIbmMqcloudQueueManagerQueueManagerDetailsToMap
--- PASS: TestDataSourceIbmMqcloudQueueManagerQueueManagerDetailsToMap (0.00s)
=== RUN   TestAccIbmMqcloudTruststoreCertificateDataSourceBasic
--- PASS: TestAccIbmMqcloudTruststoreCertificateDataSourceBasic (95.28s)
=== RUN   TestDataSourceIbmMqcloudTruststoreCertificateTrustStoreCertificateDetailsToMap
--- PASS: TestDataSourceIbmMqcloudTruststoreCertificateTrustStoreCertificateDetailsToMap (0.00s)
=== RUN   TestAccIbmMqcloudUserDataSourceBasic
=== PAUSE TestAccIbmMqcloudUserDataSourceBasic
=== CONT  TestAccIbmMqcloudUserDataSourceBasic
--- PASS: TestAccIbmMqcloudUserDataSourceBasic (74.77s)
=== RUN   TestDataSourceIbmMqcloudUserUserDetailsToMap
--- PASS: TestDataSourceIbmMqcloudUserUserDetailsToMap (0.00s)
=== RUN   TestAccIbmMqcloudVirtualPrivateEndpointGatewayDataSourceBasic
=== PAUSE TestAccIbmMqcloudVirtualPrivateEndpointGatewayDataSourceBasic
=== CONT  TestAccIbmMqcloudVirtualPrivateEndpointGatewayDataSourceBasic
--- PASS: TestAccIbmMqcloudVirtualPrivateEndpointGatewayDataSourceBasic (106.85s)
=== RUN   TestAccIbmMqcloudVirtualPrivateEndpointGatewayDataSourceAllArgs
=== PAUSE TestAccIbmMqcloudVirtualPrivateEndpointGatewayDataSourceAllArgs
=== CONT  TestAccIbmMqcloudVirtualPrivateEndpointGatewayDataSourceAllArgs
--- PASS: TestAccIbmMqcloudVirtualPrivateEndpointGatewayDataSourceAllArgs (107.23s)
=== RUN   TestAccIbmMqcloudVirtualPrivateEndpointGatewaysDataSourceBasic
=== PAUSE TestAccIbmMqcloudVirtualPrivateEndpointGatewaysDataSourceBasic
=== CONT  TestAccIbmMqcloudVirtualPrivateEndpointGatewaysDataSourceBasic
--- PASS: TestAccIbmMqcloudVirtualPrivateEndpointGatewaysDataSourceBasic (111.31s)
=== RUN   TestAccIbmMqcloudVirtualPrivateEndpointGatewaysDataSourceAllArgs
=== PAUSE TestAccIbmMqcloudVirtualPrivateEndpointGatewaysDataSourceAllArgs
=== CONT  TestAccIbmMqcloudVirtualPrivateEndpointGatewaysDataSourceAllArgs
--- PASS: TestAccIbmMqcloudVirtualPrivateEndpointGatewaysDataSourceAllArgs (110.24s)
=== RUN   TestDataSourceIbmMqcloudVirtualPrivateEndpointGatewaysVirtualPrivateEndpointGatewayDetailsToMap
--- PASS: TestDataSourceIbmMqcloudVirtualPrivateEndpointGatewaysVirtualPrivateEndpointGatewayDetailsToMap (0.00s)
=== RUN   TestAccIbmMqcloudApplicationBasic
--- PASS: TestAccIbmMqcloudApplicationBasic (131.45s)
=== RUN   TestAccIbmMqcloudKeystoreCertificateBasic
--- PASS: TestAccIbmMqcloudKeystoreCertificateBasic (268.60s)
=== RUN   TestResourceIbmMqcloudKeystoreCertificateCertificateConfigurationToMap
--- PASS: TestResourceIbmMqcloudKeystoreCertificateCertificateConfigurationToMap (0.00s)
=== RUN   TestResourceIbmMqcloudKeystoreCertificateChannelsDetailsToMap
--- PASS: TestResourceIbmMqcloudKeystoreCertificateChannelsDetailsToMap (0.00s)
=== RUN   TestResourceIbmMqcloudKeystoreCertificateChannelDetailsToMap
--- PASS: TestResourceIbmMqcloudKeystoreCertificateChannelDetailsToMap (0.00s)
=== RUN   TestAccIbmMqcloudQueueManagerBasic
--- PASS: TestAccIbmMqcloudQueueManagerBasic (351.77s)
=== RUN   TestAccIbmMqcloudQueueManagerAllArgs
--- PASS: TestAccIbmMqcloudQueueManagerAllArgs (373.59s)
=== RUN   TestAccIbmMqcloudTruststoreCertificateBasic
--- PASS: TestAccIbmMqcloudTruststoreCertificateBasic (154.80s)
=== RUN   TestAccIbmMqcloudUserBasic
--- PASS: TestAccIbmMqcloudUserBasic (129.38s)
=== RUN   TestAccIbmMqcloudVirtualPrivateEndpointGatewayBasic
=== PAUSE TestAccIbmMqcloudVirtualPrivateEndpointGatewayBasic
=== CONT  TestAccIbmMqcloudVirtualPrivateEndpointGatewayBasic
--- PASS: TestAccIbmMqcloudVirtualPrivateEndpointGatewayBasic (38.67s)
=== RUN   TestAccIbmMqcloudVirtualPrivateEndpointGatewayAllArgs
=== PAUSE TestAccIbmMqcloudVirtualPrivateEndpointGatewayAllArgs
=== CONT  TestAccIbmMqcloudVirtualPrivateEndpointGatewayAllArgs
--- PASS: TestAccIbmMqcloudVirtualPrivateEndpointGatewayAllArgs (46.95s)

PASS	github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/mqcloud	1731.716s
...
```

