### PR TITLE
fix(cloud-databases): Refactor tests Part 1

### DIFF
--- a/ibm/service/database/resource_ibm_database_postgresql_test.go
+++ b/ibm/service/database/resource_ibm_database_postgresql_test.go
@@ -5,33 +5,12 @@ package database_test
 
 import (
 	"fmt"
-	"reflect"
-	"strings"
 	"testing"
 
-	"time"
-
 	acc "github.com/IBM-Cloud/terraform-provider-ibm/ibm/acctest"
-	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/conns"
-	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/flex"
 
-	rc "github.com/IBM/platform-services-go-sdk/resourcecontrollerv2"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-
-	"github.com/IBM-Cloud/bluemix-go/bmxerror"
-	"github.com/IBM-Cloud/bluemix-go/models"
-)
-
-const (
-	databaseInstanceSuccessStatus      = "active"
-	databaseInstanceProvisioningStatus = "provisioning"
-	databaseInstanceProgressStatus     = "in progress"
-	databaseInstanceInactiveStatus     = "inactive"
-	databaseInstanceFailStatus         = "failed"
-	databaseInstanceRemovedStatus      = "removed"
-	databaseInstanceReclamation        = "pending_reclamation"
 )
 
 func TestAccIBMDatabaseInstancePostgresBasic(t *testing.T) {
@@ -83,11 +62,6 @@ func TestAccIBMDatabaseInstancePostgresBasic(t *testing.T) {
 					resource.TestCheckResourceAttr(name, "logical_replication_slot.#", "2"),
 				),
 			},
-			// {
-			// 	ResourceName:      name,
-			// 	ImportState:       true,
-			// 	ImportStateVerify: true,
-			// },
 		},
 	})
 }
@@ -184,10 +158,12 @@ func TestAccIBMDatabaseInstancePostgresGroup(t *testing.T) {
 
 func TestAccIBMDatabaseInstancePostgresImport(t *testing.T) {
 	t.Parallel()
+
 	databaseResourceGroup := "default"
+
 	var databaseInstanceOne string
+
 	serviceName := fmt.Sprintf("tf-Pgress-%d", acctest.RandIntRange(10, 100))
-	//serviceName := "test_acc"
 	resourceName := "ibm_database." + serviceName
 
 	resource.Test(t, resource.TestCase{
@@ -218,13 +194,16 @@ func TestAccIBMDatabaseInstancePostgresImport(t *testing.T) {
 
 func TestAccIBMDatabaseInstancePostgresPITR(t *testing.T) {
 	t.Parallel()
+
 	databaseResourceGroup := "default"
+
 	var databaseInstanceOne string
 	var databaseInstanceTwo string
+
 	serviceName := fmt.Sprintf("tf-Pgress-%d", acctest.RandIntRange(10, 100))
-	//serviceName := "test_acc"
 	pitrServiceName := serviceName + "-pitr"
-	resourceName := "ibm_database." + serviceName
+
+	sourceResource := "ibm_database." + serviceName
 	pitrResource := "ibm_database." + pitrServiceName
 
 	resource.Test(t, resource.TestCase{
@@ -235,15 +214,17 @@ func TestAccIBMDatabaseInstancePostgresPITR(t *testing.T) {
 			{
 				Config: testAccCheckIBMDatabaseInstancePostgresMinimal(databaseResourceGroup, serviceName),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckIBMDatabaseInstanceExists(resourceName, &databaseInstanceOne),
-					resource.TestCheckResourceAttr(resourceName, "name", serviceName),
-					resource.TestCheckResourceAttr(resourceName, "service", "databases-for-postgresql"),
-					resource.TestCheckResourceAttr(resourceName, "plan", "standard"),
-					resource.TestCheckResourceAttr(resourceName, "location", acc.Region()),
+					testAccCheckIBMDatabaseInstanceExists(sourceResource, &databaseInstanceOne),
+					resource.TestCheckResourceAttr(sourceResource, "name", serviceName),
+					resource.TestCheckResourceAttr(sourceResource, "service", "databases-for-postgresql"),
+					resource.TestCheckResourceAttr(sourceResource, "plan", "standard"),
+					resource.TestCheckResourceAttr(sourceResource, "location", acc.Region()),
 				),
 			},
 			{
-				Config: testAccCheckIBMDatabaseInstancePostgresMinimal_PITR(databaseResourceGroup, serviceName),
+				Config: acc.ConfigCompose(
+					testAccCheckIBMDatabaseInstancePostgresMinimal(databaseResourceGroup, serviceName),
+					testAccCheckIBMDatabaseInstancePostgresMinimal_PITR(databaseResourceGroup, serviceName)),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckIBMDatabaseInstanceExists(pitrResource, &databaseInstanceTwo),
 					resource.TestCheckResourceAttr(pitrResource, "name", pitrServiceName),
@@ -315,128 +296,6 @@ func TestAccIBMDatabaseInstancePostgresReadReplicaPromotion(t *testing.T) {
 	})
 }
 
-func testAccCheckIBMDatabaseInstanceDestroy(s *terraform.State) error {
-	rsContClient, err := acc.TestAccProvider.Meta().(conns.ClientSession).ResourceControllerV2API()
-	if err != nil {
-		return err
-	}
-	for _, rs := range s.RootModule().Resources {
-		if rs.Type != "ibm_database" {
-			continue
-		}
-
-		instanceID := rs.Primary.ID
-
-		rsInst := rc.GetResourceInstanceOptions{
-			ID: &instanceID,
-		}
-		instance, response, err := rsContClient.GetResourceInstance(&rsInst)
-		if err == nil {
-			if !reflect.DeepEqual(instance, models.ServiceInstance{}) && *instance.State == "active" {
-				return fmt.Errorf("Database still exists: %s", rs.Primary.ID)
-			}
-		} else {
-			if !strings.Contains(err.Error(), "404") {
-				return fmt.Errorf("[ERROR] Error checking if database (%s) has been destroyed: %s %s", rs.Primary.ID, err, response)
-			}
-		}
-	}
-	return nil
-}
-
-func testAccDatabaseInstanceManuallyDelete(tfDatabaseID *string) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		_ = testAccDatabaseInstanceManuallyDeleteUnwrapped(s, tfDatabaseID)
-		return nil
-	}
-}
-
-func testAccDatabaseInstanceManuallyDeleteUnwrapped(s *terraform.State, tfDatabaseID *string) error {
-	rsConClient, err := acc.TestAccProvider.Meta().(conns.ClientSession).ResourceControllerV2API()
-	if err != nil {
-		return err
-	}
-	instance := *tfDatabaseID
-	var instanceID string
-	if strings.HasPrefix(instance, "crn") {
-		instanceID = instance
-	} else {
-		_, instanceID, _ = flex.ConvertTftoCisTwoVar(instance)
-	}
-	recursive := true
-	deleteReq := rc.DeleteResourceInstanceOptions{
-		ID:        &instanceID,
-		Recursive: &recursive,
-	}
-	response, err := rsConClient.DeleteResourceInstance(&deleteReq)
-	if err != nil {
-		return fmt.Errorf("[ERROR] Error deleting resource instance: %s %s", err, response)
-	}
-
-	_ = &resource.StateChangeConf{
-		Pending: []string{databaseInstanceProgressStatus, databaseInstanceInactiveStatus, databaseInstanceSuccessStatus},
-		Target:  []string{databaseInstanceRemovedStatus},
-		Refresh: func() (interface{}, string, error) {
-			rsInst := rc.GetResourceInstanceOptions{
-				ID: &instanceID,
-			}
-			instance, response, err := rsConClient.GetResourceInstance(&rsInst)
-			if err != nil {
-				if apiErr, ok := err.(bmxerror.RequestFailure); ok && apiErr.StatusCode() == 404 {
-					return instance, databaseInstanceSuccessStatus, nil
-				}
-				return nil, "", err
-			}
-			if *instance.State == databaseInstanceFailStatus {
-				return instance, *instance.State, fmt.Errorf("[ERROR] The resource instance %s failed to delete: %v %s", instanceID, err, response)
-			}
-			return instance, *instance.State, nil
-		},
-		Timeout:    90 * time.Second,
-		Delay:      10 * time.Second,
-		MinTimeout: 10 * time.Second,
-	}
-	if err != nil {
-		return fmt.Errorf("[ERROR] Error waiting for resource instance (%s) to be deleted: %s", instanceID, err)
-	}
-	return nil
-}
-
-func testAccCheckIBMDatabaseInstanceExists(n string, tfDatabaseID *string) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		rs, ok := s.RootModule().Resources[n]
-		if !ok {
-			return fmt.Errorf("Not found: %s", n)
-		}
-
-		rsContClient, err := acc.TestAccProvider.Meta().(conns.ClientSession).ResourceControllerV2API()
-		if err != nil {
-			return err
-		}
-		instanceID := rs.Primary.ID
-
-		rsInst := rc.GetResourceInstanceOptions{
-			ID: &instanceID,
-		}
-		instance, response, err := rsContClient.GetResourceInstance(&rsInst)
-		if err != nil {
-			if strings.Contains(err.Error(), "Object not found") ||
-				strings.Contains(err.Error(), "status code: 404") {
-				*tfDatabaseID = ""
-				return nil
-			}
-			return fmt.Errorf("[ERROR] Error retrieving resource instance: %s %s", err, response)
-		}
-		if strings.Contains(*instance.State, "removed") {
-			*tfDatabaseID = ""
-			return nil
-		}
-
-		*tfDatabaseID = instanceID
-		return nil
-	}
-}
-
 func testAccCheckIBMDatabaseInstancePostgresBasic(databaseResourceGroup string, name string) string {
 	return fmt.Sprintf(`
 	data "ibm_resource_group" "test_acc" {
@@ -485,7 +344,7 @@ func testAccCheckIBMDatabaseInstancePostgresBasic(databaseResourceGroup string, 
 			plugin_type = "wal2json"
 		}
 	}
-				`, databaseResourceGroup, name, acc.Region())
+	`, databaseResourceGroup, name, acc.Region())
 }
 
 func testAccCheckIBMDatabaseInstancePostgresFullyspecified(databaseResourceGroup string, name string) string {
@@ -556,7 +415,7 @@ func testAccCheckIBMDatabaseInstancePostgresFullyspecified(databaseResourceGroup
 			plugin_type = "wal2json"
 		}
 	}
-				`, databaseResourceGroup, name, acc.Region())
+	`, databaseResourceGroup, name, acc.Region())
 }
 
 func testAccCheckIBMDatabaseInstancePostgresGroupBasic(databaseResourceGroup string, name string) string {
@@ -601,7 +460,7 @@ func testAccCheckIBMDatabaseInstancePostgresGroupBasic(databaseResourceGroup str
 			description = "desc1"
 		}
 	}
-				`, databaseResourceGroup, name, acc.Region())
+	`, databaseResourceGroup, name, acc.Region())
 }
 
 func testAccCheckIBMDatabaseInstancePostgresGroupFullyspecified(databaseResourceGroup string, name string) string {
@@ -654,7 +513,7 @@ func testAccCheckIBMDatabaseInstancePostgresGroupFullyspecified(databaseResource
 			description = "desc"
 		}
 	}
-				`, databaseResourceGroup, name, acc.Region())
+	`, databaseResourceGroup, name, acc.Region())
 }
 
 func testAccCheckIBMDatabaseInstancePostgresGroupReduced(databaseResourceGroup string, name string) string {
@@ -691,7 +550,7 @@ func testAccCheckIBMDatabaseInstancePostgresGroupReduced(databaseResourceGroup s
 			}
 		}
 	}
-				`, databaseResourceGroup, name, acc.Region())
+	`, databaseResourceGroup, name, acc.Region())
 }
 
 func testAccCheckIBMDatabaseInstancePostgresGroupScaleOut(databaseResourceGroup string, name string) string {
@@ -728,7 +587,7 @@ func testAccCheckIBMDatabaseInstancePostgresGroupScaleOut(databaseResourceGroup 
 		service_endpoints            = "public"
 		tags                         = ["one:two"]
 	}
-				`, databaseResourceGroup, name, acc.Region())
+	`, databaseResourceGroup, name, acc.Region())
 }
 
 func testAccCheckIBMDatabaseInstancePostgresImport(databaseResourceGroup string, name string) string {
@@ -746,7 +605,7 @@ func testAccCheckIBMDatabaseInstancePostgresImport(databaseResourceGroup string,
 		location          = "%[3]s"
 		service_endpoints = "public-and-private"
 	  }
-				`, databaseResourceGroup, name, acc.Region())
+	`, databaseResourceGroup, name, acc.Region())
 }
 
 func testAccCheckIBMDatabaseInstancePostgresMinimal(databaseResourceGroup string, name string) string {
@@ -764,25 +623,11 @@ func testAccCheckIBMDatabaseInstancePostgresMinimal(databaseResourceGroup string
 		location          = "%[3]s"
 		service_endpoints            = "public-and-private"
 	}
-				`, databaseResourceGroup, name, acc.Region())
+	`, databaseResourceGroup, name, acc.Region())
 }
 
 func testAccCheckIBMDatabaseInstancePostgresMinimal_PITR(databaseResourceGroup string, name string) string {
 	return fmt.Sprintf(`
-	data "ibm_resource_group" "test_acc" {
-		is_default = true
-		# name = "%[1]s"
-	}
-
-	resource "ibm_database" "%[2]s" {
-		resource_group_id = data.ibm_resource_group.test_acc.id
-		name              = "%[2]s"
-		service           = "databases-for-postgresql"
-		plan              = "standard"
-		location          = "%[3]s"
-		service_endpoints = "public-and-private"
-	}
-
 	resource "ibm_database" "%[2]s-pitr" {
 		resource_group_id                     = data.ibm_resource_group.test_acc.id
 		name                                  = "%[2]s-pitr"
@@ -793,7 +638,7 @@ func testAccCheckIBMDatabaseInstancePostgresMinimal_PITR(databaseResourceGroup s
 		point_in_time_recovery_time           = ""
 		service_endpoints                     = "public-and-private"
 	}
-				`, databaseResourceGroup, name, acc.Region())
+	`, databaseResourceGroup, name, acc.Region())
 }
 
 func testAccCheckIBMDatabaseInstancePostgresMinimal_ReadReplica(databaseResourceGroup string, name string) string {

--- a/ibm/service/database/resource_ibm_helpers_test.go
+++ b/ibm/service/database/resource_ibm_helpers_test.go
@@ -1,0 +1,152 @@
+package database_test
+
+import (
+	"fmt"
+	"reflect"
+	"strings"
+
+	"time"
+
+	acc "github.com/IBM-Cloud/terraform-provider-ibm/ibm/acctest"
+	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/conns"
+	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/flex"
+
+	rc "github.com/IBM/platform-services-go-sdk/resourcecontrollerv2"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	"github.com/IBM-Cloud/bluemix-go/bmxerror"
+	"github.com/IBM-Cloud/bluemix-go/models"
+)
+
+const (
+	databaseInstanceSuccessStatus      = "active"
+	databaseInstanceProvisioningStatus = "provisioning"
+	databaseInstanceProgressStatus     = "in progress"
+	databaseInstanceInactiveStatus     = "inactive"
+	databaseInstanceFailStatus         = "failed"
+	databaseInstanceRemovedStatus      = "removed"
+	databaseInstanceReclamation        = "pending_reclamation"
+)
+
+func testAccCheckIBMDatabaseInstanceDestroy(s *terraform.State) error {
+	rsContClient, err := acc.TestAccProvider.Meta().(conns.ClientSession).ResourceControllerV2API()
+	if err != nil {
+		return err
+	}
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "ibm_database" {
+			continue
+		}
+
+		instanceID := rs.Primary.ID
+
+		rsInst := rc.GetResourceInstanceOptions{
+			ID: &instanceID,
+		}
+		instance, response, err := rsContClient.GetResourceInstance(&rsInst)
+		if err == nil {
+			if !reflect.DeepEqual(instance, models.ServiceInstance{}) && *instance.State == "active" {
+				return fmt.Errorf("Database still exists: %s", rs.Primary.ID)
+			}
+		} else {
+			if !strings.Contains(err.Error(), "404") {
+				return fmt.Errorf("[ERROR] Error checking if database (%s) has been destroyed: %s %s", rs.Primary.ID, err, response)
+			}
+		}
+	}
+	return nil
+}
+
+func testAccDatabaseInstanceManuallyDelete(tfDatabaseID *string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		_ = testAccDatabaseInstanceManuallyDeleteUnwrapped(s, tfDatabaseID)
+		return nil
+	}
+}
+
+func testAccDatabaseInstanceManuallyDeleteUnwrapped(s *terraform.State, tfDatabaseID *string) error {
+	rsConClient, err := acc.TestAccProvider.Meta().(conns.ClientSession).ResourceControllerV2API()
+	if err != nil {
+		return err
+	}
+	instance := *tfDatabaseID
+	var instanceID string
+	if strings.HasPrefix(instance, "crn") {
+		instanceID = instance
+	} else {
+		_, instanceID, _ = flex.ConvertTftoCisTwoVar(instance)
+	}
+	recursive := true
+	deleteReq := rc.DeleteResourceInstanceOptions{
+		ID:        &instanceID,
+		Recursive: &recursive,
+	}
+	response, err := rsConClient.DeleteResourceInstance(&deleteReq)
+	if err != nil {
+		return fmt.Errorf("[ERROR] Error deleting resource instance: %s %s", err, response)
+	}
+
+	_ = &resource.StateChangeConf{
+		Pending: []string{databaseInstanceProgressStatus, databaseInstanceInactiveStatus, databaseInstanceSuccessStatus},
+		Target:  []string{databaseInstanceRemovedStatus},
+		Refresh: func() (interface{}, string, error) {
+			rsInst := rc.GetResourceInstanceOptions{
+				ID: &instanceID,
+			}
+			instance, response, err := rsConClient.GetResourceInstance(&rsInst)
+			if err != nil {
+				if apiErr, ok := err.(bmxerror.RequestFailure); ok && apiErr.StatusCode() == 404 {
+					return instance, databaseInstanceSuccessStatus, nil
+				}
+				return nil, "", err
+			}
+			if *instance.State == databaseInstanceFailStatus {
+				return instance, *instance.State, fmt.Errorf("[ERROR] The resource instance %s failed to delete: %v %s", instanceID, err, response)
+			}
+			return instance, *instance.State, nil
+		},
+		Timeout:    90 * time.Second,
+		Delay:      10 * time.Second,
+		MinTimeout: 10 * time.Second,
+	}
+	if err != nil {
+		return fmt.Errorf("[ERROR] Error waiting for resource instance (%s) to be deleted: %s", instanceID, err)
+	}
+	return nil
+}
+
+func testAccCheckIBMDatabaseInstanceExists(n string, tfDatabaseID *string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+
+		rsContClient, err := acc.TestAccProvider.Meta().(conns.ClientSession).ResourceControllerV2API()
+		if err != nil {
+			return err
+		}
+		instanceID := rs.Primary.ID
+
+		rsInst := rc.GetResourceInstanceOptions{
+			ID: &instanceID,
+		}
+		instance, response, err := rsContClient.GetResourceInstance(&rsInst)
+		if err != nil {
+			if strings.Contains(err.Error(), "Object not found") ||
+				strings.Contains(err.Error(), "status code: 404") {
+				*tfDatabaseID = ""
+				return nil
+			}
+			return fmt.Errorf("[ERROR] Error retrieving resource instance: %s %s", err, response)
+		}
+		if strings.Contains(*instance.State, "removed") {
+			*tfDatabaseID = ""
+			return nil
+		}
+
+		*tfDatabaseID = instanceID
+		return nil
+	}
+}


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/IBM-Cloud/terraform-provider-ibm/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Ticket: https://github.ibm.com/compose/App/issues/1412

Refactoring acceptance tests is time consuming as running the tests takes a long time so refactoring bit by bit
- Removed common test functions into new file and out of PG file
- concatenate PG PITR test

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccIBMDatabaseInstancePostgresPITR'
=== RUN   TestAccIBMDatabaseInstancePostgresPITR
=== PAUSE TestAccIBMDatabaseInstancePostgresPITR
=== CONT  TestAccIBMDatabaseInstancePostgresPITR
--- PASS: TestAccIBMDatabaseInstancePostgresPITR (1266.04s)
PASS
ok      github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/database        1270.265s
...
```
