### PR TITLE
fix(cloud-databases): Acceptance test fixes

### DIFF
--- a/ibm/service/database/data_source_ibm_database_point_in_time_recovery_test.go
+++ b/ibm/service/database/data_source_ibm_database_point_in_time_recovery_test.go
@@ -47,9 +47,9 @@ func testAccCheckIBMDatabaseDataSourceConfig3(name string) string {
 		plan              = "standard"
 		location          = "%[2]s"
 		tags              = ["one:two"]
+		service_endpoints = "private"
 	}
-
-				`, name, acc.Region())
+	`, name, acc.Region())
 }
 
 func testAccCheckIBMDatabasePitrDataSourceConfigBasic(name string) string {

--- a/ibm/service/database/data_source_ibm_database_remotes_test.go
+++ b/ibm/service/database/data_source_ibm_database_remotes_test.go
@@ -51,6 +51,7 @@ func testAccCheckIBMDatabaseDataSourceConfig4(name string) string {
 		plan              = "standard"
 		location          = "%[2]s"
 		tags              = ["one:two"]
+		service_endpoints = "private"
 	}
 
 	resource "ibm_database" "db_replica" {
@@ -61,6 +62,7 @@ func testAccCheckIBMDatabaseDataSourceConfig4(name string) string {
 		plan              = "standard"
 		location          = "%[2]s"
 		tags              = ["one:two"]
+		service_endpoints = "private"
 
     depends_on = [
       ibm_database.db,

--- a/ibm/service/database/data_source_ibm_database_test.go
+++ b/ibm/service/database/data_source_ibm_database_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 )
 
-func TestAccIBMDatabaseDataSource_basic(t *testing.T) {
+func TestAccIBMDatabaseDataSourceBasic(t *testing.T) {
 	t.Parallel()
 	databaseResourceGroup := "default"
 	var databaseInstanceOne string
@@ -36,7 +36,7 @@ func TestAccIBMDatabaseDataSource_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(dataName, "plan", "standard"),
 					resource.TestCheckResourceAttr(dataName, "location", acc.Region()),
 					resource.TestCheckResourceAttr(dataName, "adminuser", "admin"),
-					resource.TestCheckResourceAttr(dataName, "groups.0.memory.0.allocation_mb", "2048"),
+					resource.TestCheckResourceAttr(dataName, "groups.0.memory.0.allocation_mb", "8192"),
 					resource.TestCheckResourceAttr(dataName, "groups.0.disk.0.allocation_mb", "10240"),
 					resource.TestCheckResourceAttr(dataName, "allowlist.#", "0"),
 					resource.TestCheckResourceAttr(dataName, "tags.#", "1"),
@@ -65,7 +65,15 @@ func testAccCheckIBMDatabaseDataSourceConfig(databaseResourceGroup string, name 
 		location          = "%[3]s"
 		tags              = ["one:two"]
 		service_endpoints = "public"
+
+		group {
+			group_id = "member"
+
+			host_flavor {
+				id = "multitenant"
+			}
+		}
 	}
 
-				`, databaseResourceGroup, name, acc.Region())
+	`, databaseResourceGroup, name, acc.Region())
 }

--- a/ibm/service/database/resource_ibm_database_edb_test.go
+++ b/ibm/service/database/resource_ibm_database_edb_test.go
@@ -37,7 +37,7 @@ func TestAccIBMEDBDatabaseInstanceBasic(t *testing.T) {
 					resource.TestCheckResourceAttr(name, "adminuser", "admin"),
 					resource.TestCheckResourceAttr(name, "groups.0.memory.0.allocation_mb", "49152"),
 					resource.TestCheckResourceAttr(name, "groups.0.disk.0.allocation_mb", "61440"),
-					resource.TestCheckResourceAttr(name, "service_endpoints", "public"),
+					resource.TestCheckResourceAttr(name, "service_endpoints", "public-and-private"),
 					resource.TestCheckResourceAttr(name, "allowlist.#", "1"),
 					resource.TestCheckResourceAttr(name, "users.#", "1"),
 					resource.TestCheckResourceAttr(name, "tags.#", "1"),
@@ -159,6 +159,7 @@ func testAccCheckIBMDatabaseInstanceEDBMinimal(databaseResourceGroup string, nam
 		plan              = "standard"
 		location          = "%[3]s"
 		service_endpoints = "public-and-private"
+
 		group {
 			group_id = "member"
 			host_flavor {

--- a/ibm/service/database/resource_ibm_database_elasticsearch_platinum_test.go
+++ b/ibm/service/database/resource_ibm_database_elasticsearch_platinum_test.go
@@ -248,10 +248,12 @@ func TestAccIBMDatabaseInstance_ElasticsearchPlatinum_Group(t *testing.T) {
 
 func TestAccIBMDatabaseInstanceElasticsearchPlatinumImport(t *testing.T) {
 	t.Parallel()
+
 	databaseResourceGroup := "default"
+
 	var databaseInstanceOne string
+
 	serviceName := fmt.Sprintf("tf-Es-%d", acctest.RandIntRange(10, 100))
-	//serviceName := "test_acc"
 	resourceName := "ibm_database." + serviceName
 
 	resource.Test(t, resource.TestCase{
@@ -322,7 +324,7 @@ func testAccCheckIBMDatabaseInstanceElasticsearchPlatinumBasic(databaseResourceG
 			delete = "15m"
 		}
 	}
-				`, databaseResourceGroup, name, acc.Region())
+	`, databaseResourceGroup, name, acc.Region())
 }
 
 func testAccCheckIBMDatabaseInstanceElasticsearchPlatinumFullyspecified(databaseResourceGroup string, name string) string {
@@ -371,7 +373,7 @@ func testAccCheckIBMDatabaseInstanceElasticsearchPlatinumFullyspecified(database
 		}
 	}
 
-				`, databaseResourceGroup, name, acc.Region())
+	`, databaseResourceGroup, name, acc.Region())
 }
 
 func testAccCheckIBMDatabaseInstanceElasticsearchPlatinumReduced(databaseResourceGroup string, name string) string {
@@ -403,7 +405,7 @@ func testAccCheckIBMDatabaseInstanceElasticsearchPlatinumReduced(databaseResourc
 			delete = "15m"
 		}
 	}
-				`, databaseResourceGroup, name, acc.Region())
+	`, databaseResourceGroup, name, acc.Region())
 }
 
 func testAccCheckIBMDatabaseInstanceElasticsearchPlatinumGroupMigration(databaseResourceGroup string, name string) string {
@@ -439,7 +441,7 @@ func testAccCheckIBMDatabaseInstanceElasticsearchPlatinumGroupMigration(database
 			delete = "15m"
 		}
 	}
-				`, databaseResourceGroup, name, acc.Region())
+	`, databaseResourceGroup, name, acc.Region())
 }
 
 func testAccCheckIBMDatabaseInstanceElasticsearchPlatinumNodeBasic(databaseResourceGroup string, name string) string {
@@ -485,7 +487,7 @@ func testAccCheckIBMDatabaseInstanceElasticsearchPlatinumNodeBasic(databaseResou
 			delete = "15m"
 		}
 	}
-				`, databaseResourceGroup, name, acc.Region())
+	`, databaseResourceGroup, name, acc.Region())
 }
 
 func testAccCheckIBMDatabaseInstanceElasticsearchPlatinumNodeFullyspecified(databaseResourceGroup string, name string) string {
@@ -538,7 +540,7 @@ func testAccCheckIBMDatabaseInstanceElasticsearchPlatinumNodeFullyspecified(data
 			delete = "15m"
 		}
 	}
-				`, databaseResourceGroup, name, acc.Region())
+	`, databaseResourceGroup, name, acc.Region())
 }
 
 func testAccCheckIBMDatabaseInstanceElasticsearchPlatinumNodeReduced(databaseResourceGroup string, name string) string {
@@ -575,7 +577,7 @@ func testAccCheckIBMDatabaseInstanceElasticsearchPlatinumNodeReduced(databaseRes
 			delete = "15m"
 		}
 	}
-				`, databaseResourceGroup, name, acc.Region())
+	`, databaseResourceGroup, name, acc.Region())
 }
 
 func testAccCheckIBMDatabaseInstanceElasticsearchPlatinumNodeScaleOut(databaseResourceGroup string, name string) string {
@@ -612,7 +614,7 @@ func testAccCheckIBMDatabaseInstanceElasticsearchPlatinumNodeScaleOut(databaseRe
 			delete = "15m"
 		}
 	}
-				`, databaseResourceGroup, name, acc.Region())
+	`, databaseResourceGroup, name, acc.Region())
 }
 
 func testAccCheckIBMDatabaseInstanceElasticsearchPlatinumGroupBasic(databaseResourceGroup string, name string) string {
@@ -659,7 +661,7 @@ func testAccCheckIBMDatabaseInstanceElasticsearchPlatinumGroupBasic(databaseReso
 			delete = "15m"
 		}
 	}
-				`, databaseResourceGroup, name, acc.Region())
+	`, databaseResourceGroup, name, acc.Region())
 }
 
 func testAccCheckIBMDatabaseInstanceElasticsearchPlatinumGroupFullyspecified(databaseResourceGroup string, name string) string {
@@ -714,7 +716,7 @@ func testAccCheckIBMDatabaseInstanceElasticsearchPlatinumGroupFullyspecified(dat
 		}
 	}
 
-				`, databaseResourceGroup, name, acc.Region())
+	`, databaseResourceGroup, name, acc.Region())
 }
 
 func testAccCheckIBMDatabaseInstanceElasticsearchPlatinumGroupReduced(databaseResourceGroup string, name string) string {
@@ -752,7 +754,7 @@ func testAccCheckIBMDatabaseInstanceElasticsearchPlatinumGroupReduced(databaseRe
 			delete = "15m"
 		}
 	}
-				`, databaseResourceGroup, name, acc.Region())
+	`, databaseResourceGroup, name, acc.Region())
 }
 
 func testAccCheckIBMDatabaseInstanceElasticsearchPlatinumGroupScaleOut(databaseResourceGroup string, name string) string {
@@ -789,7 +791,7 @@ func testAccCheckIBMDatabaseInstanceElasticsearchPlatinumGroupScaleOut(databaseR
 			delete = "15m"
 		}
 	}
-				`, databaseResourceGroup, name, acc.Region())
+	`, databaseResourceGroup, name, acc.Region())
 }
 
 func testAccCheckIBMDatabaseInstanceElasticsearchPlatinumImport(databaseResourceGroup string, name string) string {
@@ -805,7 +807,7 @@ func testAccCheckIBMDatabaseInstanceElasticsearchPlatinumImport(databaseResource
 		service           = "databases-for-elasticsearch"
 		plan              = "platinum"
 		location          = "%[3]s"
-		service_endpoints            = "public-and-private"
+		service_endpoints = "public-and-private"
 
 		timeouts {
 			create = "120m"
@@ -814,5 +816,5 @@ func testAccCheckIBMDatabaseInstanceElasticsearchPlatinumImport(databaseResource
 		}
 	}
 
-				`, databaseResourceGroup, name, acc.Region())
+	`, databaseResourceGroup, name, acc.Region())
 }

--- a/ibm/service/database/resource_ibm_database_mongodb_enterprise_test.go
+++ b/ibm/service/database/resource_ibm_database_mongodb_enterprise_test.go
@@ -80,7 +80,7 @@ func TestAccIBMMongoDBEnterpriseDatabaseInstanceBasic(t *testing.T) {
 				ImportState:       true,
 				ImportStateVerify: true,
 				ImportStateVerifyIgnore: []string{
-					"wait_time_minutes", "adminpassword", "group"},
+					"wait_time_minutes", "adminpassword", "group", "deletion_protection"},
 			},
 		},
 	})

--- a/ibm/service/database/resource_ibm_database_mongodb_test.go
+++ b/ibm/service/database/resource_ibm_database_mongodb_test.go
@@ -84,8 +84,8 @@ func TestAccIBMDatabaseInstanceMongodbImport(t *testing.T) {
 	t.Parallel()
 	databaseResourceGroup := "default"
 	var databaseInstanceOne string
+
 	serviceName := fmt.Sprintf("tf-Mongo-%d", acctest.RandIntRange(10, 100))
-	//serviceName := "test_acc"
 	resourceName := "ibm_database." + serviceName
 
 	resource.Test(t, resource.TestCase{
@@ -108,7 +108,7 @@ func TestAccIBMDatabaseInstanceMongodbImport(t *testing.T) {
 				ImportState:       true,
 				ImportStateVerify: true,
 				ImportStateVerifyIgnore: []string{
-					"wait_time_minutes"},
+					"wait_time_minutes", "deletion_protection"},
 			},
 		},
 	})


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/IBM-Cloud/terraform-provider-ibm/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Ticket: https://github.ibm.com/compose/App/issues/1697
- Fix 5 tests from ticket
- Formatting

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccIBMDatabaseDataSourceBasic'
=== RUN   TestAccIBMDatabaseDataSourceBasic
=== PAUSE TestAccIBMDatabaseDataSourceBasic
=== CONT  TestAccIBMDatabaseDataSourceBasic
--- PASS: TestAccIBMDatabaseDataSourceBasic (577.20s)
PASS
ok      github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/database        580.765s
___________________________________________________________________________________________

$ make testacc TESTARGS='-run=TestAccIBMDatabasePointInTimeRecoveryDataSourceBasic'
=== RUN   TestAccIBMDatabasePointInTimeRecoveryDataSourceBasic
--- PASS: TestAccIBMDatabasePointInTimeRecoveryDataSourceBasic (784.59s)
PASS
ok      github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/database        787.515s
___________________________________________________________________________________________

$ make testacc TESTARGS='-run=TestAccIBMDatabaseInstanceMongodbImport'
=== RUN   TestAccIBMDatabaseInstanceMongodbImport
=== PAUSE TestAccIBMDatabaseInstanceMongodbImport
=== CONT  TestAccIBMDatabaseInstanceMongodbImport
--- PASS: TestAccIBMDatabaseInstanceMongodbImport (454.97s)
PASS
ok      github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/database        458.295s
___________________________________________________________________________________________

$ make testacc TESTARGS='-run=TestAccIBMDatabaseRemotesDataSourceBasic'
=== RUN   TestAccIBMDatabaseRemotesDataSourceBasic
--- PASS: TestAccIBMDatabaseRemotesDataSourceBasic (1205.61s)
PASS
ok      github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/database        1209.015s
___________________________________________________________________________________________

$ make testacc TESTARGS='-run=TestAccIBMMongoDBEnterpriseDatabaseInstanceBasic'
=== RUN   TestAccIBMMongoDBEnterpriseDatabaseInstanceBasic
=== PAUSE TestAccIBMMongoDBEnterpriseDatabaseInstanceBasic
=== CONT  TestAccIBMMongoDBEnterpriseDatabaseInstanceBasic
--- PASS: TestAccIBMMongoDBEnterpriseDatabaseInstanceBasic (6824.28s)
PASS
ok      github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/database        6827.924s
```
