### PR TITLE
vol fix for snapshot crn

### DIFF
--- a/ibm/service/vpc/resource_ibm_is_volume.go
+++ b/ibm/service/vpc/resource_ibm_is_volume.go
@@ -470,80 +470,36 @@ func volCreate(d *schema.ResourceData, meta interface{}, volName, profile, zone 
 	if err != nil {
 		return err
 	}
-	options := &vpcv1.CreateVolumeOptions{
-		VolumePrototype: &vpcv1.VolumePrototype{
-			Name: &volName,
-			Zone: &vpcv1.ZoneIdentity{
-				Name: &zone,
-			},
-			Profile: &vpcv1.VolumeProfileIdentity{
-				Name: &profile,
-			},
+	options := &vpcv1.CreateVolumeOptions{}
+	volTemplate := &vpcv1.VolumePrototype{
+		Name: &volName,
+		Zone: &vpcv1.ZoneIdentity{
+			Name: &zone,
+		},
+		Profile: &vpcv1.VolumeProfileIdentity{
+			Name: &profile,
 		},
 	}
-	volTemplate := options.VolumePrototype.(*vpcv1.VolumePrototype)
 
-	var volCapacity int64
 	if sourceSnapsht, ok := d.GetOk(isVolumeSourceSnapshot); ok {
 		sourceSnapshot := sourceSnapsht.(string)
 		snapshotIdentity := &vpcv1.SnapshotIdentity{
 			ID: &sourceSnapshot,
 		}
 		volTemplate.SourceSnapshot = snapshotIdentity
-		getSnapshotOptions := &vpcv1.GetSnapshotOptions{
-			ID: &sourceSnapshot,
-		}
-		snapshot, response, err := sess.GetSnapshot(getSnapshotOptions)
-		if err != nil {
-			return fmt.Errorf("[ERROR] Error fetching snapshot %s\n%s", err, response)
-		}
-		if (response != nil && response.StatusCode == 404) || snapshot == nil {
-			return fmt.Errorf("[ERROR] No snapshot found with id %s", sourceSnapshot)
-		}
-		minimumCapacity := *snapshot.MinimumCapacity
-		if capacity, ok := d.GetOk(isVolumeCapacity); ok {
-			if int64(capacity.(int)) > minimumCapacity {
-				volCapacity = int64(capacity.(int))
-			} else {
-				volCapacity = minimumCapacity
-			}
-			volTemplate.Capacity = &volCapacity
-		}
-	} else if sourceSnapshtCrn, ok := d.GetOk(isVolumeSourceSnapshot); ok {
+	} else if sourceSnapshtCrn, ok := d.GetOk(isVolumeSourceSnapshotCrn); ok {
 		sourceSnapshot := sourceSnapshtCrn.(string)
 
 		snapshotIdentity := &vpcv1.SnapshotIdentity{
 			CRN: &sourceSnapshot,
 		}
 		volTemplate.SourceSnapshot = snapshotIdentity
-		getSnapshotOptions := &vpcv1.GetSnapshotOptions{
-			ID: &sourceSnapshot,
-		}
-		snapshot, response, err := sess.GetSnapshot(getSnapshotOptions)
-		if err != nil {
-			return fmt.Errorf("[ERROR] Error fetching snapshot %s\n%s", err, response)
-		}
-		if (response != nil && response.StatusCode == 404) || snapshot == nil {
-			return fmt.Errorf("[ERROR] No snapshot found with id %s", sourceSnapshot)
-		}
-		minimumCapacity := *snapshot.MinimumCapacity
-		if capacity, ok := d.GetOk(isVolumeCapacity); ok {
-			if int64(capacity.(int)) > minimumCapacity {
-				volCapacity = int64(capacity.(int))
-			} else {
-				volCapacity = minimumCapacity
-			}
+	}
+	if capacity, ok := d.GetOk(isVolumeCapacity); ok {
+		if int64(capacity.(int)) > 0 {
+			volCapacity := int64(capacity.(int))
 			volTemplate.Capacity = &volCapacity
 		}
-	} else {
-		if capacity, ok := d.GetOk(isVolumeCapacity); ok {
-			if int64(capacity.(int)) > 0 {
-				volCapacity = int64(capacity.(int))
-			}
-		} else {
-			volCapacity = 100
-		}
-		volTemplate.Capacity = &volCapacity
 	}
 
 	if key, ok := d.GetOk(isVolumeEncryptionKey); ok {
@@ -583,7 +539,7 @@ func volCreate(d *schema.ResourceData, meta interface{}, volName, profile, zone 
 			volTemplate.UserTags = userTagsArray
 		}
 	}
-
+	options.VolumePrototype = volTemplate
 	vol, response, err := sess.CreateVolume(options)
 	if err != nil {
 		return fmt.Errorf("[DEBUG] Create volume err %s\n%s", err, response)


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/IBM-Cloud/terraform-provider-ibm/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
% make testacc TEST=./ibm/service/vpc TESTARGS='-run=TestAccIBMISVolume_snapshotcrn'
=== RUN   TestAccIBMISVolume_snapshotcrn
--- PASS: TestAccIBMISVolume_snapshotcrn (254.98s)
PASS
ok      github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/vpc     257.024s
```
