### PR TITLE
fix: HOT FIX to include properties from issue 5579

### DIFF
--- a/ibm/service/scc/resource_ibm_scc_instance_settings.go
+++ b/ibm/service/scc/resource_ibm_scc_instance_settings.go
@@ -34,7 +34,20 @@ func ResourceIbmSccInstanceSettings() *schema.Resource {
 						"instance_crn": &schema.Schema{
 							Type:        schema.TypeString,
 							Optional:    true,
+							Computed:    true,
 							Description: "The Event Notifications instance CRN.",
+						},
+						"source_description": &schema.Schema{
+							Type:        schema.TypeString,
+							Optional:    true,
+							Computed:    true,
+							Description: "The description of the source in Event Notifications connected Security and Compliance Center",
+						},
+						"source_name": &schema.Schema{
+							Type:        schema.TypeString,
+							Optional:    true,
+							Computed:    true,
+							Description: "The name of the Event Notifications source connected Security and Compliance Center instance CRN.",
 						},
 						"updated_on": &schema.Schema{
 							Type:        schema.TypeString,
@@ -123,11 +136,8 @@ func resourceIbmSccInstanceSettingsCreate(context context.Context, d *schema.Res
 			return diag.FromErr(err)
 		}
 		eventNotificationsModel = eventNotificationsData
-		eventNotificationsModel.SourceName = core.StringPtr("compliance")
-		eventNotificationsModel.SourceDescription = core.StringPtr("This source is used for integration with IBM Cloud Security and Compliance Center.")
 	} else {
 		eventNotificationsModel = &securityandcompliancecenterapiv3.EventNotifications{}
-		eventNotificationsModel.InstanceCrn = core.StringPtr("")
 	}
 	updateSettingsOptions.SetEventNotifications(eventNotificationsModel)
 
@@ -139,8 +149,7 @@ func resourceIbmSccInstanceSettingsCreate(context context.Context, d *schema.Res
 		}
 		objectStorageModel = objectStorageData
 	} else {
-		objectStorageModel := &securityandcompliancecenterapiv3.ObjectStorage{}
-		objectStorageModel.InstanceCrn = core.StringPtr("")
+		objectStorageModel = &securityandcompliancecenterapiv3.ObjectStorage{}
 	}
 	updateSettingsOptions.SetObjectStorage(objectStorageModel)
 
@@ -217,10 +226,6 @@ func resourceIbmSccInstanceSettingsUpdate(context context.Context, d *schema.Res
 		if err != nil {
 			return diag.FromErr(err)
 		}
-		if eventNotifications.InstanceCrn != nil && *eventNotifications.InstanceCrn != "" {
-			eventNotifications.SourceName = core.StringPtr("compliance")
-			eventNotifications.SourceDescription = core.StringPtr("This source is used for integration with IBM Cloud Security and Compliance Center.")
-		}
 		updateSettingsOptions.SetEventNotifications(eventNotifications)
 		hasChange = true
 	}
@@ -233,6 +238,7 @@ func resourceIbmSccInstanceSettingsUpdate(context context.Context, d *schema.Res
 		hasChange = true
 	}
 
+	log.Printf("[INFO] UpdateSettingsWithContext payload EventNotifications: %#v\n", updateSettingsOptions.EventNotifications)
 	if hasChange {
 		_, response, err := adminClient.UpdateSettingsWithContext(context, updateSettingsOptions)
 		if err != nil {
@@ -265,6 +271,12 @@ func resourceIbmSccInstanceSettingsMapToEventNotifications(modelMap map[string]i
 	}
 	if modelMap["source_id"] != nil && modelMap["source_id"].(string) != "" {
 		model.SourceID = core.StringPtr(modelMap["source_id"].(string))
+	}
+	if modelMap["source_name"] != nil && modelMap["source_name"].(string) != "" {
+		model.SourceName = core.StringPtr(modelMap["source_name"].(string))
+	}
+	if modelMap["source_description"] != nil && modelMap["source_description"].(string) != "" {
+		model.SourceDescription = core.StringPtr(modelMap["source_description"].(string))
 	}
 	return model, nil
 }

--- a/ibm/service/scc/resource_ibm_scc_instance_settings_test.go
+++ b/ibm/service/scc/resource_ibm_scc_instance_settings_test.go
@@ -66,7 +66,7 @@ func TestAccIbmSccInstanceSettingsAllArgs(t *testing.T) {
 func testAccCheckIbmSccInstanceSettingsConfigBasic(instanceID string) string {
 	return fmt.Sprintf(`
 		resource "ibm_scc_instance_settings" "scc_instance_settings_instance" {
-      instance_id = "%s"
+			instance_id = "%s"
 			event_notifications { }
 			object_storage { }
 		}
@@ -79,8 +79,7 @@ func testAccCheckIbmSccInstanceSettingsConfig(instanceID, enInstanceCRN, objStor
 			instance_id = "%s"
 			event_notifications {
 				instance_crn = "%s"
-        source_description = "This source is used by the scc instance"
-        source_name = "scc compliance"
+				source_name = "scc compliance"
 			}
 			object_storage {
 				instance_crn = "%s"

--- a/ibm/service/scc/resource_ibm_scc_instance_settings_test.go
+++ b/ibm/service/scc/resource_ibm_scc_instance_settings_test.go
@@ -24,7 +24,7 @@ func TestAccIbmSccInstanceSettingsBasic(t *testing.T) {
 		Providers:    acc.TestAccProviders,
 		CheckDestroy: testAccCheckIbmSccInstanceSettingsDestroy,
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: testAccCheckIbmSccInstanceSettingsConfigBasic(acc.SccInstanceID),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckIbmSccInstanceSettingsExists("ibm_scc_instance_settings.scc_instance_settings_instance", conf),
@@ -42,19 +42,19 @@ func TestAccIbmSccInstanceSettingsAllArgs(t *testing.T) {
 		Providers:    acc.TestAccProviders,
 		CheckDestroy: testAccCheckIbmSccInstanceSettingsDestroy,
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: testAccCheckIbmSccInstanceSettingsConfigBasic(acc.SccInstanceID),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckIbmSccInstanceSettingsExists("ibm_scc_instance_settings.scc_instance_settings_instance", conf),
 				),
 			},
-			resource.TestStep{
+			{
 				Config: testAccCheckIbmSccInstanceSettingsConfig(acc.SccInstanceID, acc.SccEventNotificationsCRN, acc.SccObjectStorageCRN, acc.SccObjectStorageBucket),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckIbmSccInstanceSettingsExists("ibm_scc_instance_settings.scc_instance_settings_instance", conf),
 				),
 			},
-			resource.TestStep{
+			{
 				ResourceName:      "ibm_scc_instance_settings.scc_instance_settings_instance",
 				ImportState:       true,
 				ImportStateVerify: true,
@@ -79,6 +79,8 @@ func testAccCheckIbmSccInstanceSettingsConfig(instanceID, enInstanceCRN, objStor
 			instance_id = "%s"
 			event_notifications {
 				instance_crn = "%s"
+        source_description = "This source is used by the scc instance"
+        source_name = "scc compliance"
 			}
 			object_storage {
 				instance_crn = "%s"
@@ -89,7 +91,6 @@ func testAccCheckIbmSccInstanceSettingsConfig(instanceID, enInstanceCRN, objStor
 }
 
 func testAccCheckIbmSccInstanceSettingsExists(n string, obj securityandcompliancecenterapiv3.Settings) resource.TestCheckFunc {
-
 	return func(s *terraform.State) error {
 		_, ok := s.RootModule().Resources[n]
 		if !ok {

--- a/website/docs/r/scc_instance_settings.html.markdown
+++ b/website/docs/r/scc_instance_settings.html.markdown
@@ -39,6 +39,8 @@ Nested schema for **event_notifications**:
 	* `source_id` - (Computed, String) The connected Security and Compliance Center instance CRN.
 	  * Constraints: The maximum length is `512` characters. The minimum length is `1` character. The value must match regular expression `/([A-Za-z0-9]+(:[A-Za-z0-9]+)+)/`.
 	* `updated_on` - (Optional, String) The date when the Event Notifications connection was updated.
+	* `source_description` - (Optional,Computed, String) The description of the Event Notifications connection source.
+	* `source_name` - (Optional,Computed, String) The name of the Event Notifications connection source.
 * `object_storage` - (Optional, List) The Cloud Object Storage settings.
 Nested schema for **object_storage**:
 	* `bucket` - (Optional, String) The connected Cloud Object Storage bucket name.


### PR DESCRIPTION
- include the following properties to scc_instance_settings:
  - source_description
  - source_name

<!--- See what makes a good Pull Request at : https://github.com/IBM-Cloud/terraform-provider-ibm/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000
#5817 
#5579 

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TEST=./ibm/service/scc  TESTARGS="-run TestAccIbmSccInstance*"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./ibm/service/scc -v -run TestAccIbmSccInstance* -timeout 700m
...
=== RUN   TestAccIbmSccInstanceSettingsDataSourceBasic
--- PASS: TestAccIbmSccInstanceSettingsDataSourceBasic (14.45s)
=== RUN   TestAccIbmSccInstanceSettingsBasic
--- PASS: TestAccIbmSccInstanceSettingsBasic (15.98s)
=== RUN   TestAccIbmSccInstanceSettingsAllArgs
--- PASS: TestAccIbmSccInstanceSettingsAllArgs (32.19s)
PASS
ok      github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/scc     63.066s
```
