### PR TITLE
fix(Cloud-Databases): Revert "Add version validation (#5791)"

### DIFF
--- a/ibm/service/database/resource_ibm_database.go
+++ b/ibm/service/database/resource_ibm_database.go
@@ -141,7 +141,6 @@ func ResourceIBMDatabaseInstance() *schema.Resource {
 			resourceIBMDatabaseInstanceDiff,
 			validateGroupsDiff,
 			validateUsersDiff,
-			validateVersionDiff,
 			validateRemoteLeaderIDDiff),
 
 		Importer: &schema.ResourceImporter{},
@@ -242,11 +241,11 @@ func ResourceIBMDatabaseInstance() *schema.Resource {
 				Description: "The configuration schema in JSON format",
 			},
 			"version": {
-				Description:      "The database version to provision if specified",
-				Type:             schema.TypeString,
-				Optional:         true,
-				Computed:         true,
-				DiffSuppressFunc: flex.ApplyOnce,
+				Description: "The database version to provision if specified",
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				ForceNew:    true,
 			},
 			"service_endpoints": {
 				Description:  "Types of the service endpoints. Possible values are 'public', 'private', 'public-and-private'.",
@@ -2963,16 +2962,6 @@ func getCpuEnforcementRatios(service string, plan string, hostFlavor string, met
 	}
 
 	return nil, 0, 0
-}
-
-func validateVersionDiff(_ context.Context, diff *schema.ResourceDiff, meta interface{}) (err error) {
-	version, configVersion := diff.GetChange("version")
-
-	if version != configVersion {
-		return fmt.Errorf("[ERROR] The version in your configuration file (%s) does not match the version of your remote instance (%s). Make sure that you have the same version in your configuration as the version on the remote instance. Learn more about the versioning policy here: https://cloud.ibm.com/docs/cloud-databases?topic=cloud-databases-versioning-policy ", configVersion, version)
-	}
-
-	return nil
 }
 
 func validateUsersDiff(_ context.Context, diff *schema.ResourceDiff, meta interface{}) (err error) {

--- a/website/docs/r/database.html.markdown
+++ b/website/docs/r/database.html.markdown
@@ -686,7 +686,7 @@ Review the argument reference that you can specify for your resource.
 - `service` - (Required, Forces new resource, String) The type of Cloud Databases that you want to create. Only the following services are currently accepted: `databases-for-etcd`, `databases-for-postgresql`, `databases-for-redis`, `databases-for-elasticsearch`, `messages-for-rabbitmq`,`databases-for-mongodb`,`databases-for-mysql`, and `databases-for-enterprisedb`.
 - `service_endpoints` - (Required, String) Specify whether you want to enable the public, private, or both service endpoints. Supported values are `public`, `private`, or `public-and-private`.
 - `tags` (Optional, Array of Strings) A list of tags that you want to add to your instance.
-- `version` - (Optional, String) The version of the database to be provisioned. If omitted, the database is created with the most recent major and minor version. For more information, see our [versioning policy](https://cloud.ibm.com/docs/cloud-databases?topic=cloud-databases-versioning-policy).
+- `version` - (Optional, Forces new resource, String) The version of the database to be provisioned. If omitted, the database is created with the most recent major and minor version.
 - `deletion_protection` - (Optional, Boolean) If the DB instance should have deletion protection within terraform enabled. This is not a property of the resource and does not prevent deletion outside of terraform. The database can't be deleted by terraform when this value is set to `true`. The default is `false`.
 - `users` - (Optional, List of Objects) A list of users that you want to create on the database. Multiple blocks are allowed.
 


### PR DESCRIPTION
This reverts commit f5425502e500d119ca517d45c268df36c86549b9.

<!--- See what makes a good Pull Request at : https://github.com/IBM-Cloud/terraform-provider-ibm/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Reverts this PR that is causing issues
https://github.com/IBM-Cloud/terraform-provider-ibm/pull/5791

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$  make testacc TEST=./ibm/service/database TESTARGS='-run=TestAccIBMDatabaseInstance_Redis_Basic'
=== RUN   TestAccIBMDatabaseInstance_Redis_Basic
=== PAUSE TestAccIBMDatabaseInstance_Redis_Basic
=== CONT  TestAccIBMDatabaseInstance_Redis_Basic
--- PASS: TestAccIBMDatabaseInstance_Redis_Basic (1242.09s)
PASS
ok      github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/database        1245.936s
```
