### PR TITLE
Added 100 default capacity to the volume when no attributes is set

### DIFF
--- a/ibm/service/vpc/resource_ibm_is_volume.go
+++ b/ibm/service/vpc/resource_ibm_is_volume.go
@@ -487,6 +487,12 @@ func volCreate(d *schema.ResourceData, meta interface{}, volName, profile, zone 
 			ID: &sourceSnapshot,
 		}
 		volTemplate.SourceSnapshot = snapshotIdentity
+		if capacity, ok := d.GetOk(isVolumeCapacity); ok {
+			if int64(capacity.(int)) > 0 {
+				volCapacity := int64(capacity.(int))
+				volTemplate.Capacity = &volCapacity
+			}
+		}
 	} else if sourceSnapshtCrn, ok := d.GetOk(isVolumeSourceSnapshotCrn); ok {
 		sourceSnapshot := sourceSnapshtCrn.(string)
 
@@ -494,12 +500,20 @@ func volCreate(d *schema.ResourceData, meta interface{}, volName, profile, zone 
 			CRN: &sourceSnapshot,
 		}
 		volTemplate.SourceSnapshot = snapshotIdentity
-	}
-	if capacity, ok := d.GetOk(isVolumeCapacity); ok {
+		if capacity, ok := d.GetOk(isVolumeCapacity); ok {
+			if int64(capacity.(int)) > 0 {
+				volCapacity := int64(capacity.(int))
+				volTemplate.Capacity = &volCapacity
+			}
+		}
+	} else if capacity, ok := d.GetOk(isVolumeCapacity); ok {
 		if int64(capacity.(int)) > 0 {
 			volCapacity := int64(capacity.(int))
 			volTemplate.Capacity = &volCapacity
 		}
+	} else {
+		volCapacity := int64(100)
+		volTemplate.Capacity = &volCapacity
 	}
 
 	if key, ok := d.GetOk(isVolumeEncryptionKey); ok {


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/IBM-Cloud/terraform-provider-ibm/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```
