### PR TITLE
[Bug Fix] Fix hanging after name update when vm shutdown, fix null po…

### DIFF
--- a/ibm/service/power/ibm_pi_constants.go
+++ b/ibm/service/power/ibm_pi_constants.go
@@ -475,6 +475,7 @@ const (
 	DeploymentTypeEpic         = "EPIC"
 	DeploymentTypeVMNoStorage  = "VMNoStorage"
 	DestinationUnreach         = "destination-unreach"
+	Detach                     = "detach"
 	DHCPVlan                   = "dhcp-vlan"
 	Disable                    = "disable"
 	Echo                       = "echo"

--- a/ibm/service/power/resource_ibm_pi_instance_test.go
+++ b/ibm/service/power/resource_ibm_pi_instance_test.go
@@ -703,7 +703,6 @@ func TestAccIBMPIInstanceUpdateActiveState(t *testing.T) {
 					testAccCheckIBMPIInstanceExists(instanceRes),
 					resource.TestCheckResourceAttr(instanceRes, "pi_instance_name", name),
 				),
-				ExpectNonEmptyPlan: true,
 			},
 		},
 	})
@@ -731,7 +730,6 @@ func TestAccIBMPIInstanceUpdateStoppedState(t *testing.T) {
 					testAccCheckIBMPIInstanceExists(instanceRes),
 					resource.TestCheckResourceAttr(instanceRes, "pi_instance_name", name),
 				),
-				ExpectNonEmptyPlan: true,
 			},
 		},
 	})


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/IBM-Cloud/terraform-provider-ibm/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

Description:
- Fixes bug where pi_instance hangs when name is updated while instance is shutdown
- Fixes null pointer exception when updating virtual optic device
- Adds new wait for update function, waits for both shutdown and active status, used when name/VOD is updated and when memory/cores are updated.

Output from acceptance testing:

pi_instance (r)
```
=== RUN   TestAccIBMPIInstanceBasic
--- PASS: TestAccIBMPIInstanceBasic (593.46s)
PASS

=== RUN   TestAccIBMPIInstanceUpdateActiveState
--- PASS: TestAccIBMPIInstanceUpdateActiveState (1498.25s)
PASS

=== RUN   TestAccIBMPIInstanceUpdateStoppedState
--- PASS: TestAccIBMPIInstanceUpdateStoppedState (2648.59s)
PASS

```