### PR TITLE
IBM Cloud Shell: re-gen provider for adopting the new error toolchain

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "go.mod|go.sum|.*.map|^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2025-01-06T04:50:55Z",
+  "generated_at": "2025-01-08T04:55:16Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -926,7 +926,7 @@
         "hashed_secret": "c8b6f5ef11b9223ac35a5663975a466ebe7ebba9",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2352,
+        "line_number": 2355,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -934,7 +934,7 @@
         "hashed_secret": "8abf4899c01104241510ba87685ad4de76b0c437",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2358,
+        "line_number": 2361,
         "type": "Secret Keyword",
         "verified_result": null
       }

--- a/go.mod
+++ b/go.mod
@@ -33,7 +33,7 @@ require (
 	github.com/IBM/logs-router-go-sdk v1.0.5
 	github.com/IBM/mqcloud-go-sdk v0.2.0
 	github.com/IBM/networking-go-sdk v0.49.0
-	github.com/IBM/platform-services-go-sdk v0.71.1
+	github.com/IBM/platform-services-go-sdk v0.72.0
 	github.com/IBM/project-go-sdk v0.3.5
 	github.com/IBM/push-notifications-go-sdk v0.0.0-20210310100607-5790b96c47f5
 	github.com/IBM/sarama v1.41.2

--- a/go.sum
+++ b/go.sum
@@ -156,8 +156,8 @@ github.com/IBM/mqcloud-go-sdk v0.2.0 h1:QOWk8ZGk0QfIL0MOGTKzNdM3Qe0Hk+ifAFtNSFQo
 github.com/IBM/mqcloud-go-sdk v0.2.0/go.mod h1:VZQKMtqmcdXKhmLhLiPuS/UHMs/5yo2tA/nD83cQt9E=
 github.com/IBM/networking-go-sdk v0.49.0 h1:lPS34u3C0JVrbxH+Ulua76Nwl6Frv8BEfq6LRkyvOv0=
 github.com/IBM/networking-go-sdk v0.49.0/go.mod h1:G9CKbmPE8gSLjN+ABh4hIZ1bMx076enl5Eekvj6zQnA=
-github.com/IBM/platform-services-go-sdk v0.71.1 h1:EyqSctlLVqj092yU6K9hyTyx7JIpzhE192n6eG+Daac=
-github.com/IBM/platform-services-go-sdk v0.71.1/go.mod h1:ApFkvqw7NaluWJ5Uq+afdM/2jQqo5ILc0SzKSVobYNw=
+github.com/IBM/platform-services-go-sdk v0.72.0 h1:AfJe6bgqmTQU4ff/2URu3wkRLZD0XIzojn7SLf2yIns=
+github.com/IBM/platform-services-go-sdk v0.72.0/go.mod h1:ApFkvqw7NaluWJ5Uq+afdM/2jQqo5ILc0SzKSVobYNw=
 github.com/IBM/project-go-sdk v0.3.5 h1:L+YClFUa14foS0B/hOOY9n7sIdsT5/XQicnXOyJSpyM=
 github.com/IBM/project-go-sdk v0.3.5/go.mod h1:FOJM9ihQV3EEAY6YigcWiTNfVCThtdY8bLC/nhQHFvo=
 github.com/IBM/push-notifications-go-sdk v0.0.0-20210310100607-5790b96c47f5 h1:NPUhkoOCRuv3OFWt19PmwjXGGTKlvmbuPg9fUrBUNe4=

--- a/ibm/provider/provider.go
+++ b/ibm/provider/provider.go
@@ -1939,6 +1939,9 @@ func Validator() validate.ValidatorDict {
 				"ibm_hpcs_vault":                               hpcs.ResourceIbmVaultValidator(),
 				"ibm_config_aggregator_settings":               configurationaggregator.ResourceIbmConfigAggregatorSettingsValidator(),
 
+				// Cloudshell
+				"ibm_cloud_shell_account_settings": cloudshell.ResourceIBMCloudShellAccountSettingsValidator(),
+
 				// MQ on Cloud
 				"ibm_mqcloud_queue_manager":                    mqcloud.ResourceIbmMqcloudQueueManagerValidator(),
 				"ibm_mqcloud_application":                      mqcloud.ResourceIbmMqcloudApplicationValidator(),

--- a/ibm/service/cloudshell/data_source_ibm_cloud_shell_account_settings.go
+++ b/ibm/service/cloudshell/data_source_ibm_cloud_shell_account_settings.go
@@ -1,5 +1,9 @@
-// Copyright IBM Corp. 2021 All Rights Reserved.
+// Copyright IBM Corp. 2024 All Rights Reserved.
 // Licensed under the Mozilla Public License v2.0
+
+/*
+ * IBM OpenAPI Terraform Generator Version: 3.98.0-8be2046a-20241205-162752
+ */
 
 package cloudshell
 
@@ -8,11 +12,12 @@ import (
 	"fmt"
 	"log"
 
-	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/conns"
-	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/flex"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 
+	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/conns"
+	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/flex"
+	"github.com/IBM/go-sdk-core/v5/core"
 	"github.com/IBM/platform-services-go-sdk/ibmcloudshellv1"
 )
 
@@ -21,53 +26,53 @@ func DataSourceIBMCloudShellAccountSettings() *schema.Resource {
 		ReadContext: dataSourceIBMCloudShellAccountSettingsRead,
 
 		Schema: map[string]*schema.Schema{
-			"account_id": {
+			"account_id": &schema.Schema{
 				Type:        schema.TypeString,
 				Required:    true,
 				Description: "The account ID in which the account settings belong to.",
 			},
-			"rev": {
+			"rev": &schema.Schema{
 				Type:        schema.TypeString,
 				Computed:    true,
 				Description: "Unique revision number for the settings object.",
 			},
-			"created_at": {
+			"created_at": &schema.Schema{
 				Type:        schema.TypeInt,
 				Computed:    true,
 				Description: "Creation timestamp in Unix epoch time.",
 			},
-			"created_by": {
+			"created_by": &schema.Schema{
 				Type:        schema.TypeString,
 				Computed:    true,
 				Description: "IAM ID of creator.",
 			},
-			"default_enable_new_features": {
+			"default_enable_new_features": &schema.Schema{
 				Type:        schema.TypeBool,
 				Computed:    true,
 				Description: "You can choose which Cloud Shell features are available in the account and whether any new features are enabled as they become available. The feature settings apply only to the enabled Cloud Shell locations.",
 			},
-			"default_enable_new_regions": {
+			"default_enable_new_regions": &schema.Schema{
 				Type:        schema.TypeBool,
 				Computed:    true,
 				Description: "Set whether Cloud Shell is enabled in a specific location for the account. The location determines where user and session data are stored. By default, users are routed to the nearest available location.",
 			},
-			"enabled": {
+			"enabled": &schema.Schema{
 				Type:        schema.TypeBool,
 				Computed:    true,
 				Description: "When enabled, Cloud Shell is available to all users in the account.",
 			},
-			"features": {
+			"features": &schema.Schema{
 				Type:        schema.TypeList,
 				Computed:    true,
 				Description: "List of Cloud Shell features.",
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
-						"enabled": {
+						"enabled": &schema.Schema{
 							Type:        schema.TypeBool,
 							Computed:    true,
 							Description: "State of the feature.",
 						},
-						"key": {
+						"key": &schema.Schema{
 							Type:        schema.TypeString,
 							Computed:    true,
 							Description: "Name of the feature.",
@@ -75,18 +80,18 @@ func DataSourceIBMCloudShellAccountSettings() *schema.Resource {
 					},
 				},
 			},
-			"regions": {
+			"regions": &schema.Schema{
 				Type:        schema.TypeList,
 				Computed:    true,
 				Description: "List of Cloud Shell region settings.",
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
-						"enabled": {
+						"enabled": &schema.Schema{
 							Type:        schema.TypeBool,
 							Computed:    true,
 							Description: "State of the region.",
 						},
-						"key": {
+						"key": &schema.Schema{
 							Type:        schema.TypeString,
 							Computed:    true,
 							Description: "Name of the region.",
@@ -94,17 +99,17 @@ func DataSourceIBMCloudShellAccountSettings() *schema.Resource {
 					},
 				},
 			},
-			"type": {
+			"type": &schema.Schema{
 				Type:        schema.TypeString,
 				Computed:    true,
 				Description: "Type of api response object.",
 			},
-			"updated_at": {
+			"updated_at": &schema.Schema{
 				Type:        schema.TypeInt,
 				Computed:    true,
 				Description: "Timestamp of last update in Unix epoch time.",
 			},
-			"updated_by": {
+			"updated_by": &schema.Schema{
 				Type:        schema.TypeString,
 				Computed:    true,
 				Description: "IAM ID of last updater.",
@@ -116,103 +121,127 @@ func DataSourceIBMCloudShellAccountSettings() *schema.Resource {
 func dataSourceIBMCloudShellAccountSettingsRead(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	ibmCloudShellClient, err := meta.(conns.ClientSession).IBMCloudShellV1()
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.DiscriminatedTerraformErrorf(err, err.Error(), "(Data) ibm_cloud_shell_account_settings", "read", "initialize-client")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	getAccountSettingsOptions := &ibmcloudshellv1.GetAccountSettingsOptions{}
 
 	getAccountSettingsOptions.SetAccountID(d.Get("account_id").(string))
 
-	accountSettings, response, err := ibmCloudShellClient.GetAccountSettingsWithContext(context, getAccountSettingsOptions)
-	if err != nil || accountSettings == nil {
-		log.Printf("[DEBUG] GetAccountSettingsWithContext failed %s\n%s", err, response)
-		return diag.FromErr(fmt.Errorf("GetAccountSettingsWithContext failed %s\n%s", err, response))
+	accountSettings, _, err := ibmCloudShellClient.GetAccountSettingsWithContext(context, getAccountSettingsOptions)
+	if err != nil {
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("GetAccountSettingsWithContext failed: %s", err.Error()), "(Data) ibm_cloud_shell_account_settings", "read")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
-	d.SetId(*accountSettings.AccountID)
-	if err = d.Set("rev", accountSettings.Rev); err != nil {
-		return diag.FromErr(fmt.Errorf("[ERROR] Error setting rev: %s", err))
-	}
-	if err = d.Set("created_at", flex.IntValue(accountSettings.CreatedAt)); err != nil {
-		return diag.FromErr(fmt.Errorf("[ERROR] Error setting created_at: %s", err))
-	}
-	if err = d.Set("created_by", accountSettings.CreatedBy); err != nil {
-		return diag.FromErr(fmt.Errorf("[ERROR] Error setting created_by: %s", err))
-	}
-	if err = d.Set("default_enable_new_features", accountSettings.DefaultEnableNewFeatures); err != nil {
-		return diag.FromErr(fmt.Errorf("[ERROR] Error setting default_enable_new_features: %s", err))
-	}
-	if err = d.Set("default_enable_new_regions", accountSettings.DefaultEnableNewRegions); err != nil {
-		return diag.FromErr(fmt.Errorf("[ERROR] Error setting default_enable_new_regions: %s", err))
-	}
-	if err = d.Set("enabled", accountSettings.Enabled); err != nil {
-		return diag.FromErr(fmt.Errorf("[ERROR] Error setting enabled: %s", err))
-	}
+	d.SetId(*getAccountSettingsOptions.AccountID)
 
-	if accountSettings.Features != nil {
-		err = d.Set("features", dataSourceAccountSettingsFlattenFeatures(accountSettings.Features))
-		if err != nil {
-			return diag.FromErr(fmt.Errorf("[ERROR] Error setting features %s", err))
+	if !core.IsNil(accountSettings.Rev) {
+		if err = d.Set("rev", accountSettings.Rev); err != nil {
+			return flex.DiscriminatedTerraformErrorf(err, fmt.Sprintf("Error setting rev: %s", err), "(Data) ibm_cloud_shell_account_settings", "read", "set-rev").GetDiag()
 		}
 	}
 
-	if accountSettings.Regions != nil {
-		err = d.Set("regions", dataSourceAccountSettingsFlattenRegions(accountSettings.Regions))
-		if err != nil {
-			return diag.FromErr(fmt.Errorf("[ERROR] Error setting regions %s", err))
+	if !core.IsNil(accountSettings.CreatedAt) {
+		if err = d.Set("created_at", flex.IntValue(accountSettings.CreatedAt)); err != nil {
+			return flex.DiscriminatedTerraformErrorf(err, fmt.Sprintf("Error setting created_at: %s", err), "(Data) ibm_cloud_shell_account_settings", "read", "set-created_at").GetDiag()
 		}
 	}
-	if err = d.Set("type", accountSettings.Type); err != nil {
-		return diag.FromErr(fmt.Errorf("[ERROR] Error setting type: %s", err))
+
+	if !core.IsNil(accountSettings.CreatedBy) {
+		if err = d.Set("created_by", accountSettings.CreatedBy); err != nil {
+			return flex.DiscriminatedTerraformErrorf(err, fmt.Sprintf("Error setting created_by: %s", err), "(Data) ibm_cloud_shell_account_settings", "read", "set-created_by").GetDiag()
+		}
 	}
-	if err = d.Set("updated_at", flex.IntValue(accountSettings.UpdatedAt)); err != nil {
-		return diag.FromErr(fmt.Errorf("[ERROR] Error setting updated_at: %s", err))
+
+	if !core.IsNil(accountSettings.DefaultEnableNewFeatures) {
+		if err = d.Set("default_enable_new_features", accountSettings.DefaultEnableNewFeatures); err != nil {
+			return flex.DiscriminatedTerraformErrorf(err, fmt.Sprintf("Error setting default_enable_new_features: %s", err), "(Data) ibm_cloud_shell_account_settings", "read", "set-default_enable_new_features").GetDiag()
+		}
 	}
-	if err = d.Set("updated_by", accountSettings.UpdatedBy); err != nil {
-		return diag.FromErr(fmt.Errorf("[ERROR] Error setting updated_by: %s", err))
+
+	if !core.IsNil(accountSettings.DefaultEnableNewRegions) {
+		if err = d.Set("default_enable_new_regions", accountSettings.DefaultEnableNewRegions); err != nil {
+			return flex.DiscriminatedTerraformErrorf(err, fmt.Sprintf("Error setting default_enable_new_regions: %s", err), "(Data) ibm_cloud_shell_account_settings", "read", "set-default_enable_new_regions").GetDiag()
+		}
+	}
+
+	if !core.IsNil(accountSettings.Enabled) {
+		if err = d.Set("enabled", accountSettings.Enabled); err != nil {
+			return flex.DiscriminatedTerraformErrorf(err, fmt.Sprintf("Error setting enabled: %s", err), "(Data) ibm_cloud_shell_account_settings", "read", "set-enabled").GetDiag()
+		}
+	}
+
+	if !core.IsNil(accountSettings.Features) {
+		features := []map[string]interface{}{}
+		for _, featuresItem := range accountSettings.Features {
+			featuresItemMap, err := DataSourceIBMCloudShellAccountSettingsFeatureToMap(&featuresItem) // #nosec G601
+			if err != nil {
+				return flex.DiscriminatedTerraformErrorf(err, err.Error(), "(Data) ibm_cloud_shell_account_settings", "read", "features-to-map").GetDiag()
+			}
+			features = append(features, featuresItemMap)
+		}
+		if err = d.Set("features", features); err != nil {
+			return flex.DiscriminatedTerraformErrorf(err, fmt.Sprintf("Error setting features: %s", err), "(Data) ibm_cloud_shell_account_settings", "read", "set-features").GetDiag()
+		}
+	}
+
+	if !core.IsNil(accountSettings.Regions) {
+		regions := []map[string]interface{}{}
+		for _, regionsItem := range accountSettings.Regions {
+			regionsItemMap, err := DataSourceIBMCloudShellAccountSettingsRegionSettingToMap(&regionsItem) // #nosec G601
+			if err != nil {
+				return flex.DiscriminatedTerraformErrorf(err, err.Error(), "(Data) ibm_cloud_shell_account_settings", "read", "regions-to-map").GetDiag()
+			}
+			regions = append(regions, regionsItemMap)
+		}
+		if err = d.Set("regions", regions); err != nil {
+			return flex.DiscriminatedTerraformErrorf(err, fmt.Sprintf("Error setting regions: %s", err), "(Data) ibm_cloud_shell_account_settings", "read", "set-regions").GetDiag()
+		}
+	}
+
+	if !core.IsNil(accountSettings.Type) {
+		if err = d.Set("type", accountSettings.Type); err != nil {
+			return flex.DiscriminatedTerraformErrorf(err, fmt.Sprintf("Error setting type: %s", err), "(Data) ibm_cloud_shell_account_settings", "read", "set-type").GetDiag()
+		}
+	}
+
+	if !core.IsNil(accountSettings.UpdatedAt) {
+		if err = d.Set("updated_at", flex.IntValue(accountSettings.UpdatedAt)); err != nil {
+			return flex.DiscriminatedTerraformErrorf(err, fmt.Sprintf("Error setting updated_at: %s", err), "(Data) ibm_cloud_shell_account_settings", "read", "set-updated_at").GetDiag()
+		}
+	}
+
+	if !core.IsNil(accountSettings.UpdatedBy) {
+		if err = d.Set("updated_by", accountSettings.UpdatedBy); err != nil {
+			return flex.DiscriminatedTerraformErrorf(err, fmt.Sprintf("Error setting updated_by: %s", err), "(Data) ibm_cloud_shell_account_settings", "read", "set-updated_by").GetDiag()
+		}
 	}
 
 	return nil
 }
 
-func dataSourceAccountSettingsFlattenFeatures(result []ibmcloudshellv1.Feature) (features []map[string]interface{}) {
-	for _, featuresItem := range result {
-		features = append(features, dataSourceAccountSettingsFeaturesToMap(featuresItem))
+func DataSourceIBMCloudShellAccountSettingsFeatureToMap(model *ibmcloudshellv1.Feature) (map[string]interface{}, error) {
+	modelMap := make(map[string]interface{})
+	if model.Enabled != nil {
+		modelMap["enabled"] = *model.Enabled
 	}
-
-	return features
+	if model.Key != nil {
+		modelMap["key"] = *model.Key
+	}
+	return modelMap, nil
 }
 
-func dataSourceAccountSettingsFeaturesToMap(featuresItem ibmcloudshellv1.Feature) (featuresMap map[string]interface{}) {
-	featuresMap = map[string]interface{}{}
-
-	if featuresItem.Enabled != nil {
-		featuresMap["enabled"] = featuresItem.Enabled
+func DataSourceIBMCloudShellAccountSettingsRegionSettingToMap(model *ibmcloudshellv1.RegionSetting) (map[string]interface{}, error) {
+	modelMap := make(map[string]interface{})
+	if model.Enabled != nil {
+		modelMap["enabled"] = *model.Enabled
 	}
-	if featuresItem.Key != nil {
-		featuresMap["key"] = featuresItem.Key
+	if model.Key != nil {
+		modelMap["key"] = *model.Key
 	}
-
-	return featuresMap
-}
-
-func dataSourceAccountSettingsFlattenRegions(result []ibmcloudshellv1.RegionSetting) (regions []map[string]interface{}) {
-	for _, regionsItem := range result {
-		regions = append(regions, dataSourceAccountSettingsRegionsToMap(regionsItem))
-	}
-
-	return regions
-}
-
-func dataSourceAccountSettingsRegionsToMap(regionsItem ibmcloudshellv1.RegionSetting) (regionsMap map[string]interface{}) {
-	regionsMap = map[string]interface{}{}
-
-	if regionsItem.Enabled != nil {
-		regionsMap["enabled"] = regionsItem.Enabled
-	}
-	if regionsItem.Key != nil {
-		regionsMap["key"] = regionsItem.Key
-	}
-
-	return regionsMap
+	return modelMap, nil
 }

--- a/ibm/service/cloudshell/data_source_ibm_cloud_shell_account_settings_test.go
+++ b/ibm/service/cloudshell/data_source_ibm_cloud_shell_account_settings_test.go
@@ -1,5 +1,9 @@
-// Copyright IBM Corp. 2021 All Rights Reserved.
+// Copyright IBM Corp. 2024 All Rights Reserved.
 // Licensed under the Mozilla Public License v2.0
+
+/*
+ * IBM OpenAPI Terraform Generator Version: 3.98.0-8be2046a-20241205-162752
+ */
 
 package cloudshell_test
 
@@ -7,23 +11,21 @@ import (
 	"fmt"
 	"testing"
 
-	acc "github.com/IBM-Cloud/terraform-provider-ibm/ibm/acctest"
-
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	acc "github.com/IBM-Cloud/terraform-provider-ibm/ibm/acctest"
 )
 
 func TestAccIBMCloudShellAccountSettingsDataSourceBasic(t *testing.T) {
-
 	resource.Test(t, resource.TestCase{
 		PreCheck:  func() { acc.TestAccPreCheckCloudShell(t) },
 		Providers: acc.TestAccProviders,
 		Steps: []resource.TestStep{
-			{
-				Destroy: false,
-				Config:  testAccCheckIBMCloudShellAccountSettingsDataSourceConfigBasic(acc.CloudShellAccountID),
+			resource.TestStep{
+				Config: testAccCheckIBMCloudShellAccountSettingsDataSourceConfigBasic(acc.CloudShellAccountID),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttrSet("data.ibm_cloud_shell_account_settings.cloud_shell_account_settings", "id"),
-					resource.TestCheckResourceAttrSet("data.ibm_cloud_shell_account_settings.cloud_shell_account_settings", "account_id"),
+					resource.TestCheckResourceAttrSet("data.ibm_cloud_shell_account_settings.cloud_shell_account_settings_instance", "id"),
+					resource.TestCheckResourceAttrSet("data.ibm_cloud_shell_account_settings.cloud_shell_account_settings_instance", "account_id"),
 				),
 			},
 		},
@@ -33,16 +35,16 @@ func TestAccIBMCloudShellAccountSettingsDataSourceBasic(t *testing.T) {
 func TestAccIBMCloudShellAccountSettingsDataSourceAllArgs(t *testing.T) {
 	accountSettingsDefaultEnableNewFeatures := "false"
 	accountSettingsDefaultEnableNewRegions := "true"
-	accountSettingsEnabled := "false"
+	accountSettingsEnabled := "true"
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:  func() { acc.TestAccPreCheckCloudShell(t) },
 		Providers: acc.TestAccProviders,
 		Steps: []resource.TestStep{
-			{
+			resource.TestStep{
 				Config: testAccCheckIBMCloudShellAccountSettingsDataSourceConfig(acc.CloudShellAccountID, accountSettingsDefaultEnableNewFeatures, accountSettingsDefaultEnableNewRegions, accountSettingsEnabled),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr("data.ibm_cloud_shell_account_settings.account_settings_after_update", "id", fmt.Sprintf("ac-%s", acc.CloudShellAccountID)),
+					resource.TestCheckResourceAttr("data.ibm_cloud_shell_account_settings.account_settings_after_update", "id", acc.CloudShellAccountID),
 					resource.TestCheckResourceAttr("data.ibm_cloud_shell_account_settings.account_settings_after_update", "account_id", acc.CloudShellAccountID),
 					resource.TestCheckResourceAttrSet("data.ibm_cloud_shell_account_settings.account_settings_after_update", "rev"),
 					resource.TestCheckResourceAttrSet("data.ibm_cloud_shell_account_settings.account_settings_after_update", "created_at"),
@@ -58,11 +60,9 @@ func TestAccIBMCloudShellAccountSettingsDataSourceAllArgs(t *testing.T) {
 					resource.TestCheckResourceAttrSet("data.ibm_cloud_shell_account_settings.account_settings_after_update", "regions.#"),
 					resource.TestCheckResourceAttr("data.ibm_cloud_shell_account_settings.account_settings_after_update", "regions.0.enabled", "true"),
 					resource.TestCheckResourceAttr("data.ibm_cloud_shell_account_settings.account_settings_after_update", "regions.0.key", "eu-de"),
-					resource.TestCheckResourceAttr("data.ibm_cloud_shell_account_settings.account_settings_after_update", "regions.1.enabled", "true"),
-					resource.TestCheckResourceAttr("data.ibm_cloud_shell_account_settings.account_settings_after_update", "regions.1.key", "jp-tok"),
-					resource.TestCheckResourceAttr("data.ibm_cloud_shell_account_settings.account_settings_after_update", "regions.2.enabled", "false"),
-					resource.TestCheckResourceAttr("data.ibm_cloud_shell_account_settings.account_settings_after_update", "regions.2.key", "us-south"),
-					resource.TestCheckResourceAttrSet("data.ibm_cloud_shell_account_settings.account_settings_after_update", "updated_at"),
+					resource.TestCheckResourceAttr("data.ibm_cloud_shell_account_settings.account_settings_after_update", "regions.1.enabled", "false"),
+					resource.TestCheckResourceAttr("data.ibm_cloud_shell_account_settings.account_settings_after_update", "regions.1.key", "us-south"),
+					resource.TestCheckResourceAttrSet("data.ibm_cloud_shell_account_settings.account_settings_after_update", "type"),
 				),
 			},
 		},
@@ -71,49 +71,45 @@ func TestAccIBMCloudShellAccountSettingsDataSourceAllArgs(t *testing.T) {
 
 func testAccCheckIBMCloudShellAccountSettingsDataSourceConfigBasic(accountSettingsAccountID string) string {
 	return fmt.Sprintf(`
-		data "ibm_cloud_shell_account_settings" "cloud_shell_account_settings" {
-			account_id = "%s"
-		}
-	`, accountSettingsAccountID)
+		 data "ibm_cloud_shell_account_settings" "cloud_shell_account_settings_instance" {
+			 account_id = "%s"
+		 }
+	 `, accountSettingsAccountID)
 }
 
 func testAccCheckIBMCloudShellAccountSettingsDataSourceConfig(accountSettingsAccountID string, accountSettingsDefaultEnableNewFeatures string, accountSettingsDefaultEnableNewRegions string, accountSettingsEnabled string) string {
 	// first need to retrieve the existing account settings revision field (rev) before updating account settings.
 	return fmt.Sprintf(`
-		data "ibm_cloud_shell_account_settings" "account_settings_before_update" {
-			account_id = "%s"
-		}
-	
-		resource "ibm_cloud_shell_account_settings" "cloud_shell_account_settings" {
-			account_id = "%s"
-			rev = data.ibm_cloud_shell_account_settings.account_settings_before_update.rev
-			default_enable_new_features = %s
-			default_enable_new_regions = %s
-			enabled = %s
-			features {
-				enabled = true
-				key = "server.file_manager"
-			}
-			features {
-				enabled = false
-				key = "server.web_preview"
-			}
-			regions {
-				enabled = true
-				key = "eu-de"
-			}
-			regions {
-				enabled = true
-				key = "jp-tok"
-			}
-			regions {
-				enabled = false
-				key = "us-south"
-			}
-		}
-
-		data "ibm_cloud_shell_account_settings" "account_settings_after_update" {
-			account_id = ibm_cloud_shell_account_settings.cloud_shell_account_settings.account_id
-		}
-	`, accountSettingsAccountID, accountSettingsAccountID, accountSettingsDefaultEnableNewFeatures, accountSettingsDefaultEnableNewRegions, accountSettingsEnabled)
+		 data "ibm_cloud_shell_account_settings" "account_settings_before_update" {
+			 account_id = "%s"
+		 }
+ 
+		 resource "ibm_cloud_shell_account_settings" "cloud_shell_account_settings" {
+			 account_id = "%s"
+			 rev = data.ibm_cloud_shell_account_settings.account_settings_before_update.rev
+			 default_enable_new_features = %s
+			 default_enable_new_regions = %s
+			 enabled = %s
+			 features {
+				 enabled = true
+				 key = "server.file_manager"
+			 }
+			 features {
+				 enabled = false
+				 key = "server.web_preview"
+			 }
+			 regions {
+				 enabled = true
+				 key = "eu-de"
+			 }
+			 regions {
+				 enabled = false
+				 key = "us-south"
+			 }
+		 }
+ 
+		 data "ibm_cloud_shell_account_settings" "account_settings_after_update" {
+			 account_id = ibm_cloud_shell_account_settings.cloud_shell_account_settings.account_id
+		 }
+	 `, accountSettingsAccountID, accountSettingsAccountID, accountSettingsDefaultEnableNewFeatures, accountSettingsDefaultEnableNewRegions, accountSettingsEnabled)
 }

--- a/ibm/service/cloudshell/resource_ibm_cloud_shell_account_settings.go
+++ b/ibm/service/cloudshell/resource_ibm_cloud_shell_account_settings.go
@@ -1,5 +1,9 @@
-// Copyright IBM Corp. 2021 All Rights Reserved.
+// Copyright IBM Corp. 2024 All Rights Reserved.
 // Licensed under the Mozilla Public License v2.0
+
+/*
+ * IBM OpenAPI Terraform Generator Version: 3.98.0-8be2046a-20241205-162752
+ */
 
 package cloudshell
 
@@ -9,11 +13,12 @@ import (
 	"log"
 	"strings"
 
-	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/conns"
-	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/flex"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 
+	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/conns"
+	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/flex"
+	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/validate"
 	"github.com/IBM/go-sdk-core/v5/core"
 	"github.com/IBM/platform-services-go-sdk/ibmcloudshellv1"
 )
@@ -27,46 +32,46 @@ func ResourceIBMCloudShellAccountSettings() *schema.Resource {
 		Importer:      &schema.ResourceImporter{},
 
 		Schema: map[string]*schema.Schema{
-			"account_id": {
-				Type:        schema.TypeString,
-				Required:    true,
-				ForceNew:    true,
-				Description: "The account ID in which the account settings belong to.",
+			"account_id": &schema.Schema{
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: validate.InvokeValidator("ibm_cloud_shell_account_settings", "account_id"),
+				Description:  "The account ID in which the account settings belong to.",
 			},
-			"rev": {
-				Type:        schema.TypeString,
-				Optional:    true,
-				Computed:    true,
-				Description: "Unique revision number for the settings object.",
+			"rev": &schema.Schema{
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validate.InvokeValidator("ibm_cloud_shell_account_settings", "rev"),
+				Description:  "Unique revision number for the settings object.",
 			},
-			"default_enable_new_features": {
+			"default_enable_new_features": &schema.Schema{
 				Type:        schema.TypeBool,
 				Optional:    true,
 				Description: "You can choose which Cloud Shell features are available in the account and whether any new features are enabled as they become available. The feature settings apply only to the enabled Cloud Shell locations.",
 			},
-			"default_enable_new_regions": {
+			"default_enable_new_regions": &schema.Schema{
 				Type:        schema.TypeBool,
 				Optional:    true,
 				Description: "Set whether Cloud Shell is enabled in a specific location for the account. The location determines where user and session data are stored. By default, users are routed to the nearest available location.",
 			},
-			"enabled": {
+			"enabled": &schema.Schema{
 				Type:        schema.TypeBool,
 				Optional:    true,
 				Description: "When enabled, Cloud Shell is available to all users in the account.",
 			},
-			"features": {
+			"features": &schema.Schema{
 				Type:        schema.TypeList,
 				Optional:    true,
-				Computed:    true,
 				Description: "List of Cloud Shell features.",
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
-						"enabled": {
+						"enabled": &schema.Schema{
 							Type:        schema.TypeBool,
 							Optional:    true,
 							Description: "State of the feature.",
 						},
-						"key": {
+						"key": &schema.Schema{
 							Type:        schema.TypeString,
 							Optional:    true,
 							Description: "Name of the feature.",
@@ -74,19 +79,18 @@ func ResourceIBMCloudShellAccountSettings() *schema.Resource {
 					},
 				},
 			},
-			"regions": {
+			"regions": &schema.Schema{
 				Type:        schema.TypeList,
 				Optional:    true,
-				Computed:    true,
 				Description: "List of Cloud Shell region settings.",
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
-						"enabled": {
+						"enabled": &schema.Schema{
 							Type:        schema.TypeBool,
 							Optional:    true,
 							Description: "State of the region.",
 						},
-						"key": {
+						"key": &schema.Schema{
 							Type:        schema.TypeString,
 							Optional:    true,
 							Description: "Name of the region.",
@@ -94,27 +98,32 @@ func ResourceIBMCloudShellAccountSettings() *schema.Resource {
 					},
 				},
 			},
-			"created_at": {
+			"id": &schema.Schema{
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "Unique id of the settings object.",
+			},
+			"created_at": &schema.Schema{
 				Type:        schema.TypeInt,
 				Computed:    true,
 				Description: "Creation timestamp in Unix epoch time.",
 			},
-			"created_by": {
+			"created_by": &schema.Schema{
 				Type:        schema.TypeString,
 				Computed:    true,
 				Description: "IAM ID of creator.",
 			},
-			"type": {
+			"type": &schema.Schema{
 				Type:        schema.TypeString,
 				Computed:    true,
 				Description: "Type of api response object.",
 			},
-			"updated_at": {
+			"updated_at": &schema.Schema{
 				Type:        schema.TypeInt,
 				Computed:    true,
 				Description: "Timestamp of last update in Unix epoch time.",
 			},
-			"updated_by": {
+			"updated_by": &schema.Schema{
 				Type:        schema.TypeString,
 				Computed:    true,
 				Description: "IAM ID of last updater.",
@@ -123,10 +132,39 @@ func ResourceIBMCloudShellAccountSettings() *schema.Resource {
 	}
 }
 
+func ResourceIBMCloudShellAccountSettingsValidator() *validate.ResourceValidator {
+	validateSchema := make([]validate.ValidateSchema, 0)
+	validateSchema = append(validateSchema,
+		validate.ValidateSchema{
+			Identifier:                 "account_id",
+			ValidateFunctionIdentifier: validate.ValidateRegexpLen,
+			Type:                       validate.TypeString,
+			Required:                   true,
+			Regexp:                     `^[a-zA-Z0-9-]*$`,
+			MinValueLength:             1,
+			MaxValueLength:             100,
+		},
+		validate.ValidateSchema{
+			Identifier:                 "rev",
+			ValidateFunctionIdentifier: validate.ValidateRegexpLen,
+			Type:                       validate.TypeString,
+			Optional:                   true,
+			Regexp:                     `^[a-zA-Z0-9-]*$`,
+			MinValueLength:             1,
+			MaxValueLength:             100,
+		},
+	)
+
+	resourceValidator := validate.ResourceValidator{ResourceName: "ibm_cloud_shell_account_settings", Schema: validateSchema}
+	return &resourceValidator
+}
+
 func resourceIBMCloudShellAccountSettingsCreate(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	ibmCloudShellClient, err := meta.(conns.ClientSession).IBMCloudShellV1()
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cloud_shell_account_settings", "delete", "initialize-client")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	updateAccountSettingsOptions := &ibmcloudshellv1.UpdateAccountSettingsOptions{}
@@ -146,64 +184,47 @@ func resourceIBMCloudShellAccountSettingsCreate(context context.Context, d *sche
 	}
 	if _, ok := d.GetOk("features"); ok {
 		var features []ibmcloudshellv1.Feature
-		for _, e := range d.Get("features").([]interface{}) {
-			value := e.(map[string]interface{})
-			featuresItem := resourceIBMCloudShellAccountSettingsMapToFeature(value)
-			features = append(features, featuresItem)
+		for _, v := range d.Get("features").([]interface{}) {
+			value := v.(map[string]interface{})
+			featuresItem, err := ResourceIBMCloudShellAccountSettingsMapToFeature(value)
+			if err != nil {
+				return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cloud_shell_account_settings", "delete", "parse-features").GetDiag()
+			}
+			features = append(features, *featuresItem)
 		}
 		updateAccountSettingsOptions.SetFeatures(features)
 	}
 	if _, ok := d.GetOk("regions"); ok {
 		var regions []ibmcloudshellv1.RegionSetting
-		for _, e := range d.Get("regions").([]interface{}) {
-			value := e.(map[string]interface{})
-			regionsItem := resourceIBMCloudShellAccountSettingsMapToRegionSetting(value)
-			regions = append(regions, regionsItem)
+		for _, v := range d.Get("regions").([]interface{}) {
+			value := v.(map[string]interface{})
+			regionsItem, err := ResourceIBMCloudShellAccountSettingsMapToRegionSetting(value)
+			if err != nil {
+				return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cloud_shell_account_settings", "delete", "parse-regions").GetDiag()
+			}
+			regions = append(regions, *regionsItem)
 		}
 		updateAccountSettingsOptions.SetRegions(regions)
 	}
 
-	accountSettings, response, err := ibmCloudShellClient.UpdateAccountSettingsWithContext(context, updateAccountSettingsOptions)
-	if err != nil || accountSettings == nil {
-		log.Printf("[DEBUG] UpdateAccountSettingsWithContext failed %s\n%s", err, response)
-		return diag.FromErr(fmt.Errorf("UpdateAccountSettingsWithContext failed %s\n%s", err, response))
+	accountSettings, _, err := ibmCloudShellClient.UpdateAccountSettingsWithContext(context, updateAccountSettingsOptions)
+	if err != nil {
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("UpdateAccountSettingsWithContext failed: %s", err.Error()), "ibm_cloud_shell_account_settings", "delete")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
-	d.SetId(*accountSettings.ID)
+	d.SetId(*accountSettings.AccountID)
 
 	return resourceIBMCloudShellAccountSettingsRead(context, d, meta)
-}
-
-func resourceIBMCloudShellAccountSettingsMapToFeature(featureMap map[string]interface{}) ibmcloudshellv1.Feature {
-	feature := ibmcloudshellv1.Feature{}
-
-	if featureMap["enabled"] != nil {
-		feature.Enabled = core.BoolPtr(featureMap["enabled"].(bool))
-	}
-	if featureMap["key"] != nil {
-		feature.Key = core.StringPtr(featureMap["key"].(string))
-	}
-
-	return feature
-}
-
-func resourceIBMCloudShellAccountSettingsMapToRegionSetting(regionSettingMap map[string]interface{}) ibmcloudshellv1.RegionSetting {
-	regionSetting := ibmcloudshellv1.RegionSetting{}
-
-	if regionSettingMap["enabled"] != nil {
-		regionSetting.Enabled = core.BoolPtr(regionSettingMap["enabled"].(bool))
-	}
-	if regionSettingMap["key"] != nil {
-		regionSetting.Key = core.StringPtr(regionSettingMap["key"].(string))
-	}
-
-	return regionSetting
 }
 
 func resourceIBMCloudShellAccountSettingsRead(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	ibmCloudShellClient, err := meta.(conns.ClientSession).IBMCloudShellV1()
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cloud_shell_account_settings", "read", "initialize-client")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	getAccountSettingsOptions := &ibmcloudshellv1.GetAccountSettingsOptions{}
@@ -211,144 +232,169 @@ func resourceIBMCloudShellAccountSettingsRead(context context.Context, d *schema
 	getAccountSettingsOptions.SetAccountID(strings.TrimPrefix(d.Id(), "ac-"))
 
 	accountSettings, response, err := ibmCloudShellClient.GetAccountSettingsWithContext(context, getAccountSettingsOptions)
-	if err != nil || accountSettings == nil {
+	if err != nil {
 		if response != nil && response.StatusCode == 404 {
 			d.SetId("")
 			return nil
 		}
-		log.Printf("[DEBUG] GetAccountSettingsWithContext failed %s\n%s", err, response)
-		return diag.FromErr(fmt.Errorf("GetAccountSettingsWithContext failed %s\n%s", err, response))
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("GetAccountSettingsWithContext failed: %s", err.Error()), "ibm_cloud_shell_account_settings", "read")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	if err = d.Set("account_id", accountSettings.AccountID); err != nil {
-		return diag.FromErr(fmt.Errorf("[ERROR] Error setting account_id: %s", err))
+		err = fmt.Errorf("Error setting account_id: %s", err)
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cloud_shell_account_settings", "read", "set-account_id").GetDiag()
 	}
-	if err = d.Set("rev", accountSettings.Rev); err != nil {
-		return diag.FromErr(fmt.Errorf("[ERROR] Error setting rev: %s", err))
+	if !core.IsNil(accountSettings.Rev) {
+		if err = d.Set("rev", accountSettings.Rev); err != nil {
+			err = fmt.Errorf("Error setting rev: %s", err)
+			return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cloud_shell_account_settings", "read", "set-rev").GetDiag()
+		}
 	}
-	if err = d.Set("default_enable_new_features", accountSettings.DefaultEnableNewFeatures); err != nil {
-		return diag.FromErr(fmt.Errorf("[ERROR] Error setting default_enable_new_features: %s", err))
+	if !core.IsNil(accountSettings.DefaultEnableNewFeatures) {
+		if err = d.Set("default_enable_new_features", accountSettings.DefaultEnableNewFeatures); err != nil {
+			err = fmt.Errorf("Error setting default_enable_new_features: %s", err)
+			return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cloud_shell_account_settings", "read", "set-default_enable_new_features").GetDiag()
+		}
 	}
-	if err = d.Set("default_enable_new_regions", accountSettings.DefaultEnableNewRegions); err != nil {
-		return diag.FromErr(fmt.Errorf("[ERROR] Error setting default_enable_new_regions: %s", err))
+	if !core.IsNil(accountSettings.DefaultEnableNewRegions) {
+		if err = d.Set("default_enable_new_regions", accountSettings.DefaultEnableNewRegions); err != nil {
+			err = fmt.Errorf("Error setting default_enable_new_regions: %s", err)
+			return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cloud_shell_account_settings", "read", "set-default_enable_new_regions").GetDiag()
+		}
 	}
-	if err = d.Set("enabled", accountSettings.Enabled); err != nil {
-		return diag.FromErr(fmt.Errorf("[ERROR] Error setting enabled: %s", err))
+	if !core.IsNil(accountSettings.Enabled) {
+		if err = d.Set("enabled", accountSettings.Enabled); err != nil {
+			err = fmt.Errorf("Error setting enabled: %s", err)
+			return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cloud_shell_account_settings", "read", "set-enabled").GetDiag()
+		}
 	}
-	if accountSettings.Features != nil {
+	if !core.IsNil(accountSettings.Features) {
 		features := []map[string]interface{}{}
 		for _, featuresItem := range accountSettings.Features {
-			featuresItemMap := resourceIBMCloudShellAccountSettingsFeatureToMap(featuresItem)
+			featuresItemMap, err := ResourceIBMCloudShellAccountSettingsFeatureToMap(&featuresItem) // #nosec G601
+			if err != nil {
+				return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cloud_shell_account_settings", "read", "features-to-map").GetDiag()
+			}
 			features = append(features, featuresItemMap)
 		}
 		if err = d.Set("features", features); err != nil {
-			return diag.FromErr(fmt.Errorf("[ERROR] Error setting features: %s", err))
+			err = fmt.Errorf("Error setting features: %s", err)
+			return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cloud_shell_account_settings", "read", "set-features").GetDiag()
 		}
 	}
-	if accountSettings.Regions != nil {
+	if !core.IsNil(accountSettings.Regions) {
 		regions := []map[string]interface{}{}
 		for _, regionsItem := range accountSettings.Regions {
-			regionsItemMap := resourceIBMCloudShellAccountSettingsRegionSettingToMap(regionsItem)
+			regionsItemMap, err := ResourceIBMCloudShellAccountSettingsRegionSettingToMap(&regionsItem) // #nosec G601
+			if err != nil {
+				return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cloud_shell_account_settings", "read", "regions-to-map").GetDiag()
+			}
 			regions = append(regions, regionsItemMap)
 		}
 		if err = d.Set("regions", regions); err != nil {
-			return diag.FromErr(fmt.Errorf("[ERROR] Error setting regions: %s", err))
+			err = fmt.Errorf("Error setting regions: %s", err)
+			return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cloud_shell_account_settings", "read", "set-regions").GetDiag()
 		}
 	}
-	if err = d.Set("created_at", flex.IntValue(accountSettings.CreatedAt)); err != nil {
-		return diag.FromErr(fmt.Errorf("[ERROR] Error setting created_at: %s", err))
+	if !core.IsNil(accountSettings.ID) {
+		if err = d.Set("id", accountSettings.ID); err != nil {
+			err = fmt.Errorf("Error setting id: %s", err)
+			return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cloud_shell_account_settings", "read", "set-id").GetDiag()
+		}
 	}
-	if err = d.Set("created_by", accountSettings.CreatedBy); err != nil {
-		return diag.FromErr(fmt.Errorf("[ERROR] Error setting created_by: %s", err))
+	if !core.IsNil(accountSettings.CreatedAt) {
+		if err = d.Set("created_at", flex.IntValue(accountSettings.CreatedAt)); err != nil {
+			err = fmt.Errorf("Error setting created_at: %s", err)
+			return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cloud_shell_account_settings", "read", "set-created_at").GetDiag()
+		}
 	}
-	if err = d.Set("type", accountSettings.Type); err != nil {
-		return diag.FromErr(fmt.Errorf("[ERROR] Error setting type: %s", err))
+	if !core.IsNil(accountSettings.CreatedBy) {
+		if err = d.Set("created_by", accountSettings.CreatedBy); err != nil {
+			err = fmt.Errorf("Error setting created_by: %s", err)
+			return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cloud_shell_account_settings", "read", "set-created_by").GetDiag()
+		}
 	}
-	if err = d.Set("updated_at", flex.IntValue(accountSettings.UpdatedAt)); err != nil {
-		return diag.FromErr(fmt.Errorf("[ERROR] Error setting updated_at: %s", err))
+	if !core.IsNil(accountSettings.Type) {
+		if err = d.Set("type", accountSettings.Type); err != nil {
+			err = fmt.Errorf("Error setting type: %s", err)
+			return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cloud_shell_account_settings", "read", "set-type").GetDiag()
+		}
 	}
-	if err = d.Set("updated_by", accountSettings.UpdatedBy); err != nil {
-		return diag.FromErr(fmt.Errorf("[ERROR] Error setting updated_by: %s", err))
+	if !core.IsNil(accountSettings.UpdatedAt) {
+		if err = d.Set("updated_at", flex.IntValue(accountSettings.UpdatedAt)); err != nil {
+			err = fmt.Errorf("Error setting updated_at: %s", err)
+			return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cloud_shell_account_settings", "read", "set-updated_at").GetDiag()
+		}
+	}
+	if !core.IsNil(accountSettings.UpdatedBy) {
+		if err = d.Set("updated_by", accountSettings.UpdatedBy); err != nil {
+			err = fmt.Errorf("Error setting updated_by: %s", err)
+			return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cloud_shell_account_settings", "read", "set-updated_by").GetDiag()
+		}
 	}
 
 	return nil
 }
 
-func resourceIBMCloudShellAccountSettingsFeatureToMap(feature ibmcloudshellv1.Feature) map[string]interface{} {
-	featureMap := map[string]interface{}{}
-
-	if feature.Enabled != nil {
-		featureMap["enabled"] = feature.Enabled
-	}
-	if feature.Key != nil {
-		featureMap["key"] = feature.Key
-	}
-
-	return featureMap
-}
-
-func resourceIBMCloudShellAccountSettingsRegionSettingToMap(regionSetting ibmcloudshellv1.RegionSetting) map[string]interface{} {
-	regionSettingMap := map[string]interface{}{}
-
-	if regionSetting.Enabled != nil {
-		regionSettingMap["enabled"] = regionSetting.Enabled
-	}
-	if regionSetting.Key != nil {
-		regionSettingMap["key"] = regionSetting.Key
-	}
-
-	return regionSettingMap
-}
-
 func resourceIBMCloudShellAccountSettingsUpdate(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	ibmCloudShellClient, err := meta.(conns.ClientSession).IBMCloudShellV1()
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cloud_shell_account_settings", "delete", "initialize-client")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	updateAccountSettingsOptions := &ibmcloudshellv1.UpdateAccountSettingsOptions{}
 
 	updateAccountSettingsOptions.SetAccountID(strings.TrimPrefix(d.Id(), "ac-"))
+
 	hasChange := false
+
 	updateAccountSettingsOptions.SetRev(d.Get("rev").(string))
-	if d.HasChange("default_enable_new_features") {
-		updateAccountSettingsOptions.SetDefaultEnableNewFeatures(d.Get("default_enable_new_features").(bool))
-		hasChange = true
-	}
-	if d.HasChange("default_enable_new_regions") {
-		updateAccountSettingsOptions.SetDefaultEnableNewRegions(d.Get("default_enable_new_regions").(bool))
-		hasChange = true
-	}
-	if d.HasChange("enabled") {
-		updateAccountSettingsOptions.SetEnabled(d.Get("enabled").(bool))
-		hasChange = true
-	}
-	if d.HasChange("features") {
-		var features []ibmcloudshellv1.Feature
-		for _, e := range d.Get("features").([]interface{}) {
-			value := e.(map[string]interface{})
-			featuresItem := resourceIBMCloudShellAccountSettingsMapToFeature(value)
-			features = append(features, featuresItem)
+	updateAccountSettingsOptions.SetDefaultEnableNewFeatures(d.Get("default_enable_new_features").(bool))
+	updateAccountSettingsOptions.SetDefaultEnableNewRegions(d.Get("default_enable_new_regions").(bool))
+	updateAccountSettingsOptions.SetEnabled(d.Get("enabled").(bool))
+
+	var features []ibmcloudshellv1.Feature
+	for _, v := range d.Get("features").([]interface{}) {
+		value := v.(map[string]interface{})
+		featuresItem, err := ResourceIBMCloudShellAccountSettingsMapToFeature(value)
+		if err != nil {
+			return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cloud_shell_account_settings", "delete", "parse-features").GetDiag()
 		}
-		updateAccountSettingsOptions.SetFeatures(features)
-		hasChange = true
+		features = append(features, *featuresItem)
 	}
-	if d.HasChange("regions") {
-		var regions []ibmcloudshellv1.RegionSetting
-		for _, e := range d.Get("regions").([]interface{}) {
-			value := e.(map[string]interface{})
-			regionsItem := resourceIBMCloudShellAccountSettingsMapToRegionSetting(value)
-			regions = append(regions, regionsItem)
+	updateAccountSettingsOptions.SetFeatures(features)
+
+	var regions []ibmcloudshellv1.RegionSetting
+	for _, v := range d.Get("regions").([]interface{}) {
+		value := v.(map[string]interface{})
+		regionsItem, err := ResourceIBMCloudShellAccountSettingsMapToRegionSetting(value)
+		if err != nil {
+			return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cloud_shell_account_settings", "delete", "parse-regions").GetDiag()
 		}
-		updateAccountSettingsOptions.SetRegions(regions)
+		regions = append(regions, *regionsItem)
+	}
+	updateAccountSettingsOptions.SetRegions(regions)
+
+	if d.HasChange("account_id") {
+		errMsg := fmt.Sprintf("Cannot update resource property \"%s\" with the ForceNew annotation."+
+			" The resource must be re-created to update this property.", "account_id")
+		return flex.DiscriminatedTerraformErrorf(nil, errMsg, "ibm_cloud_shell_account_settings", "delete", "account_id-forces-new").GetDiag()
+	}
+
+	if d.HasChange("default_enable_new_features") || d.HasChange("default_enable_new_regions") || d.HasChange("enabled") || d.HasChange("features") || d.HasChange("regions") {
 		hasChange = true
 	}
 
 	if hasChange {
-		accountSettings, response, err := ibmCloudShellClient.UpdateAccountSettingsWithContext(context, updateAccountSettingsOptions)
-		if err != nil || accountSettings == nil {
-			log.Printf("[DEBUG] UpdateAccountSettingsWithContext failed %s\n%s", err, response)
-			return diag.FromErr(fmt.Errorf("UpdateAccountSettingsWithContext failed %s\n%s", err, response))
+		_, _, err = ibmCloudShellClient.UpdateAccountSettingsWithContext(context, updateAccountSettingsOptions)
+		if err != nil {
+			tfErr := flex.TerraformErrorf(err, fmt.Sprintf("UpdateAccountSettingsWithContext failed: %s", err.Error()), "ibm_cloud_shell_account_settings", "delete")
+			log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+			return tfErr.GetDiag()
 		}
 	}
 
@@ -358,4 +404,48 @@ func resourceIBMCloudShellAccountSettingsUpdate(context context.Context, d *sche
 func resourceIBMCloudShellAccountSettingsDelete(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	// Cloud Shell does not support delete of account settings subsequently delete is a no-op.
 	return nil
+}
+
+func ResourceIBMCloudShellAccountSettingsMapToFeature(modelMap map[string]interface{}) (*ibmcloudshellv1.Feature, error) {
+	model := &ibmcloudshellv1.Feature{}
+	if modelMap["enabled"] != nil {
+		model.Enabled = core.BoolPtr(modelMap["enabled"].(bool))
+	}
+	if modelMap["key"] != nil && modelMap["key"].(string) != "" {
+		model.Key = core.StringPtr(modelMap["key"].(string))
+	}
+	return model, nil
+}
+
+func ResourceIBMCloudShellAccountSettingsMapToRegionSetting(modelMap map[string]interface{}) (*ibmcloudshellv1.RegionSetting, error) {
+	model := &ibmcloudshellv1.RegionSetting{}
+	if modelMap["enabled"] != nil {
+		model.Enabled = core.BoolPtr(modelMap["enabled"].(bool))
+	}
+	if modelMap["key"] != nil && modelMap["key"].(string) != "" {
+		model.Key = core.StringPtr(modelMap["key"].(string))
+	}
+	return model, nil
+}
+
+func ResourceIBMCloudShellAccountSettingsFeatureToMap(model *ibmcloudshellv1.Feature) (map[string]interface{}, error) {
+	modelMap := make(map[string]interface{})
+	if model.Enabled != nil {
+		modelMap["enabled"] = *model.Enabled
+	}
+	if model.Key != nil {
+		modelMap["key"] = *model.Key
+	}
+	return modelMap, nil
+}
+
+func ResourceIBMCloudShellAccountSettingsRegionSettingToMap(model *ibmcloudshellv1.RegionSetting) (map[string]interface{}, error) {
+	modelMap := make(map[string]interface{})
+	if model.Enabled != nil {
+		modelMap["enabled"] = *model.Enabled
+	}
+	if model.Key != nil {
+		modelMap["key"] = *model.Key
+	}
+	return modelMap, nil
 }

--- a/ibm/service/cloudshell/resource_ibm_cloud_shell_account_settings.go
+++ b/ibm/service/cloudshell/resource_ibm_cloud_shell_account_settings.go
@@ -214,7 +214,7 @@ func resourceIBMCloudShellAccountSettingsCreate(context context.Context, d *sche
 		return tfErr.GetDiag()
 	}
 
-	d.SetId(*accountSettings.AccountID)
+	d.SetId(*accountSettings.ID)
 
 	return resourceIBMCloudShellAccountSettingsRead(context, d, meta)
 }

--- a/ibm/service/cloudshell/resource_ibm_cloud_shell_account_settings_test.go
+++ b/ibm/service/cloudshell/resource_ibm_cloud_shell_account_settings_test.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2021 All Rights Reserved.
+// Copyright IBM Corp. 2024 All Rights Reserved.
 // Licensed under the Mozilla Public License v2.0
 
 package cloudshell_test
@@ -7,9 +7,9 @@ import (
 	"fmt"
 	"testing"
 
-	acc "github.com/IBM-Cloud/terraform-provider-ibm/ibm/acctest"
-
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	acc "github.com/IBM-Cloud/terraform-provider-ibm/ibm/acctest"
 )
 
 func TestAccIBMCloudShellAccountSettingsBasic(t *testing.T) {
@@ -17,7 +17,7 @@ func TestAccIBMCloudShellAccountSettingsBasic(t *testing.T) {
 		PreCheck:  func() { acc.TestAccPreCheckCloudShell(t) },
 		Providers: acc.TestAccProviders,
 		Steps: []resource.TestStep{
-			{
+			resource.TestStep{
 				Config: testAccCheckIBMCloudShellAccountSettingsConfigBasic(acc.CloudShellAccountID),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr("ibm_cloud_shell_account_settings.cloud_shell_account_settings", "account_id", acc.CloudShellAccountID),
@@ -32,21 +32,22 @@ func TestAccIBMCloudShellAccountSettingsAllArgs(t *testing.T) {
 	defaultEnableNewRegions := "true"
 	enabled := "false"
 	featureWebPreview := "false"
-	regionJpTok := "false"
+	regionUsSouth := "false"
+
 	defaultEnableNewFeaturesUpdate := "true"
 	defaultEnableNewRegionsUpdate := "false"
 	enabledUpdate := "true"
 	featureWebPreviewUpdate := "true"
-	regionJpTokUpdate := "true"
+	regionUsSouthUpdate := "true"
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:  func() { acc.TestAccPreCheckCloudShell(t) },
 		Providers: acc.TestAccProviders,
 		Steps: []resource.TestStep{
-			{
-				Config: testAccCheckIBMCloudShellAccountSettingsConfig("1", acc.CloudShellAccountID, defaultEnableNewFeatures, defaultEnableNewRegions, enabled, featureWebPreview, regionJpTok),
+			resource.TestStep{
+				Config: testAccCheckIBMCloudShellAccountSettingsConfig("1", acc.CloudShellAccountID, defaultEnableNewFeatures, defaultEnableNewRegions, enabled, featureWebPreview, regionUsSouth),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr("ibm_cloud_shell_account_settings.cloud_shell_account_settings1", "id", fmt.Sprintf("ac-%s", acc.CloudShellAccountID)),
+					resource.TestCheckResourceAttr("ibm_cloud_shell_account_settings.cloud_shell_account_settings1", "id", acc.CloudShellAccountID),
 					resource.TestCheckResourceAttr("ibm_cloud_shell_account_settings.cloud_shell_account_settings1", "account_id", acc.CloudShellAccountID),
 					resource.TestCheckResourceAttrSet("ibm_cloud_shell_account_settings.cloud_shell_account_settings1", "rev"),
 					resource.TestCheckResourceAttr("ibm_cloud_shell_account_settings.cloud_shell_account_settings1", "default_enable_new_features", defaultEnableNewFeatures),
@@ -56,14 +57,14 @@ func TestAccIBMCloudShellAccountSettingsAllArgs(t *testing.T) {
 					resource.TestCheckResourceAttr("ibm_cloud_shell_account_settings.cloud_shell_account_settings1", "features.1.enabled", featureWebPreview),
 					resource.TestCheckResourceAttr("ibm_cloud_shell_account_settings.cloud_shell_account_settings1", "features.1.key", "server.web_preview"),
 					resource.TestCheckResourceAttrSet("ibm_cloud_shell_account_settings.cloud_shell_account_settings1", "regions.#"),
-					resource.TestCheckResourceAttr("ibm_cloud_shell_account_settings.cloud_shell_account_settings1", "regions.1.enabled", regionJpTok),
-					resource.TestCheckResourceAttr("ibm_cloud_shell_account_settings.cloud_shell_account_settings1", "regions.1.key", "jp-tok"),
+					resource.TestCheckResourceAttr("ibm_cloud_shell_account_settings.cloud_shell_account_settings1", "regions.1.enabled", regionUsSouth),
+					resource.TestCheckResourceAttr("ibm_cloud_shell_account_settings.cloud_shell_account_settings1", "regions.1.key", "us-south"),
 				),
 			},
-			{
-				Config: testAccCheckIBMCloudShellAccountSettingsConfig("2", acc.CloudShellAccountID, defaultEnableNewFeaturesUpdate, defaultEnableNewRegionsUpdate, enabledUpdate, featureWebPreviewUpdate, regionJpTokUpdate),
+			resource.TestStep{
+				Config: testAccCheckIBMCloudShellAccountSettingsConfig("2", acc.CloudShellAccountID, defaultEnableNewFeaturesUpdate, defaultEnableNewRegionsUpdate, enabledUpdate, featureWebPreviewUpdate, regionUsSouthUpdate),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr("ibm_cloud_shell_account_settings.cloud_shell_account_settings2", "id", fmt.Sprintf("ac-%s", acc.CloudShellAccountID)),
+					resource.TestCheckResourceAttr("ibm_cloud_shell_account_settings.cloud_shell_account_settings2", "id", acc.CloudShellAccountID),
 					resource.TestCheckResourceAttr("ibm_cloud_shell_account_settings.cloud_shell_account_settings2", "account_id", acc.CloudShellAccountID),
 					resource.TestCheckResourceAttrSet("ibm_cloud_shell_account_settings.cloud_shell_account_settings2", "rev"),
 					resource.TestCheckResourceAttr("ibm_cloud_shell_account_settings.cloud_shell_account_settings2", "default_enable_new_features", defaultEnableNewFeaturesUpdate),
@@ -73,8 +74,8 @@ func TestAccIBMCloudShellAccountSettingsAllArgs(t *testing.T) {
 					resource.TestCheckResourceAttr("ibm_cloud_shell_account_settings.cloud_shell_account_settings2", "features.1.enabled", featureWebPreviewUpdate),
 					resource.TestCheckResourceAttr("ibm_cloud_shell_account_settings.cloud_shell_account_settings2", "features.1.key", "server.web_preview"),
 					resource.TestCheckResourceAttrSet("ibm_cloud_shell_account_settings.cloud_shell_account_settings2", "regions.#"),
-					resource.TestCheckResourceAttr("ibm_cloud_shell_account_settings.cloud_shell_account_settings2", "regions.1.enabled", regionJpTokUpdate),
-					resource.TestCheckResourceAttr("ibm_cloud_shell_account_settings.cloud_shell_account_settings2", "regions.1.key", "jp-tok"),
+					resource.TestCheckResourceAttr("ibm_cloud_shell_account_settings.cloud_shell_account_settings2", "regions.1.enabled", regionUsSouthUpdate),
+					resource.TestCheckResourceAttr("ibm_cloud_shell_account_settings.cloud_shell_account_settings2", "regions.1.key", "us-south"),
 				),
 			},
 		},
@@ -107,48 +108,40 @@ func testAccCheckIBMCloudShellAccountSettingsConfigBasic(accountID string) strin
 		}
 		regions {
 			enabled = true
-			key = "jp-tok"
-		}
-		regions {
-			enabled = false
 			key = "us-south"
 		}
 	}
 	`, accountID, accountID)
 }
 
-func testAccCheckIBMCloudShellAccountSettingsConfig(suffix, accountID string, defaultEnableNewFeatures string, defaultEnableNewRegions string, enabled string, featureWebPreview string, regionJpTok string) string {
+func testAccCheckIBMCloudShellAccountSettingsConfig(suffix, accountID string, defaultEnableNewFeatures string, defaultEnableNewRegions string, enabled string, featureWebPreview string, regionUsSouth string) string {
 	return fmt.Sprintf(`
-	data "ibm_cloud_shell_account_settings" "account_settings%s" {
-		account_id = "%s"
-	}
+		data "ibm_cloud_shell_account_settings" "account_settings%s" {
+			account_id = "%s"
+		}
 
-	resource "ibm_cloud_shell_account_settings" "cloud_shell_account_settings%s" {
-		account_id = "%s"
-		rev = data.ibm_cloud_shell_account_settings.account_settings%s.rev
-		default_enable_new_features = %s
-		default_enable_new_regions = %s
-		enabled = %s
-		features {
-			enabled = true
-			key = "server.file_manager"
-		}
-		features {
+		resource "ibm_cloud_shell_account_settings" "cloud_shell_account_settings%s" {
+			account_id = "%s"
+			rev = data.ibm_cloud_shell_account_settings.account_settings%s.rev
+			default_enable_new_features = %s
+			default_enable_new_regions = %s
 			enabled = %s
-			key = "server.web_preview"
-		}
-		regions {
-			enabled = true
-			key = "eu-de"
-		}
-		regions {
-			enabled = %s
-			key = "jp-tok"
-		}
-		regions {
-			enabled = false
-			key = "us-south"
-		}
+			features {
+				enabled = true
+				key = "server.file_manager"
+			}
+			features {
+				enabled = %s
+				key = "server.web_preview"
+			}
+			regions {
+				enabled = true
+				key = "eu-de"
+			}
+			regions {
+				enabled = %s
+				key = "us-south"
+			}
 	}
-	`, suffix, accountID, suffix, accountID, suffix, defaultEnableNewFeatures, defaultEnableNewRegions, enabled, featureWebPreview, regionJpTok)
+	`, suffix, accountID, suffix, accountID, suffix, defaultEnableNewFeatures, defaultEnableNewRegions, enabled, featureWebPreview, regionUsSouth)
 }

--- a/website/docs/d/cloud_shell_account_settings.html.markdown
+++ b/website/docs/d/cloud_shell_account_settings.html.markdown
@@ -1,6 +1,6 @@
 ---
 layout: "ibm"
-page_title: "IBM : cloud_shell_account_settings"
+page_title: "IBM : ibm_cloud_shell_account_settings"
 description: |-
   Get information about cloud_shell_account_settings
 subcategory: "IBM Cloud Shell"
@@ -8,51 +8,51 @@ subcategory: "IBM Cloud Shell"
 
 # ibm_cloud_shell_account_settings
 
-Provides a read-only data source for cloud_shell_account_settings. You can then reference the fields of the data source in other resources within the same configuration using interpolation syntax.
+Provides a read-only data source to retrieve information about cloud_shell_account_settings. You can then reference the fields of the data source in other resources within the same configuration by using interpolation syntax.
 
-## Example usage
+## Example Usage
 
-```terraform
-data "cloud_shell_account_settings" "cloud_shell_account_settings" {
-	account_id = "account_id"
+```hcl
+data "ibm_cloud_shell_account_settings" "cloud_shell_account_settings" {
+	account_id = ibm_cloud_shell_account_settings.cloud_shell_account_settings_instance.account_id
 }
 ```
 
-## Argument reference
+## Argument Reference
 
-The following arguments are supported:
+You can specify the following arguments for this data source.
 
-* `account_id` - (Required, string) The account ID in which the account settings belong to.
+* `account_id` - (Required, Forces new resource, String) The account ID in which the account settings belong to.
+  * Constraints: The maximum length is `100` characters. The minimum length is `1` character. The value must match regular expression `/^[a-zA-Z0-9-]*$/`.
 
-## Attribute reference
+## Attribute Reference
 
-In addition to all arguments above, the following attributes are exported:
+After your data source is created, you can read values from the following attributes.
 
 * `id` - The unique identifier of the cloud_shell_account_settings.
-
-* `rev` - Unique revision number for the settings object.
-
-* `created_at` - Creation timestamp in Unix epoch time.
-
-* `created_by` - IAM ID of creator.
-
-* `default_enable_new_features` - You can choose which Cloud Shell features are available in the account and whether any new features are enabled as they become available. The feature settings apply only to the enabled Cloud Shell locations.
-
-* `default_enable_new_regions` - Set whether Cloud Shell is enabled in a specific location for the account. The location determines where user and session data are stored. By default, users are routed to the nearest available location.
-
-* `enabled` - When enabled, Cloud Shell is available to all users in the account.
-
-* `features` - List of Cloud Shell features. Nested `features` blocks have the following structure:
-	* `enabled` - State of the feature.
-	* `key` - Name of the feature.
-
-* `regions` - List of Cloud Shell region settings. Nested `regions` blocks have the following structure:
-	* `enabled` - State of the region.
-	* `key` - Name of the region.
-
-* `type` - Type of api response object.
-
-* `updated_at` - Timestamp of last update in Unix epoch time.
-
-* `updated_by` - IAM ID of last updater.
+* `created_at` - (Integer) Creation timestamp in Unix epoch time.
+* `created_by` - (String) IAM ID of creator.
+  * Constraints: The maximum length is `100` characters. The minimum length is `1` character. The value must match regular expression `/^[a-zA-Z0-9-]*$/`.
+* `default_enable_new_features` - (Boolean) You can choose which Cloud Shell features are available in the account and whether any new features are enabled as they become available. The feature settings apply only to the enabled Cloud Shell locations.
+* `default_enable_new_regions` - (Boolean) Set whether Cloud Shell is enabled in a specific location for the account. The location determines where user and session data are stored. By default, users are routed to the nearest available location.
+* `enabled` - (Boolean) When enabled, Cloud Shell is available to all users in the account.
+* `features` - (List) List of Cloud Shell features.
+  * Constraints: The maximum length is `2` items. The minimum length is `0` items.
+Nested schema for **features**:
+	* `enabled` - (Boolean) State of the feature.
+	* `key` - (String) Name of the feature.
+	  * Constraints: The maximum length is `100` characters. The minimum length is `1` character. The value must match regular expression `/^[a-zA-Z0-9_.]*$/`.
+* `regions` - (List) List of Cloud Shell region settings.
+  * Constraints: The maximum length is `3` items. The minimum length is `0` items.
+Nested schema for **regions**:
+	* `enabled` - (Boolean) State of the region.
+	* `key` - (String) Name of the region.
+	  * Constraints: The maximum length is `100` characters. The minimum length is `1` character. The value must match regular expression `/^[a-zA-Z-]*$/`.
+* `rev` - (String) Unique revision number for the settings object.
+  * Constraints: The maximum length is `100` characters. The minimum length is `1` character. The value must match regular expression `/^[a-zA-Z0-9-]*$/`.
+* `type` - (String) Type of api response object.
+  * Constraints: The maximum length is `100` characters. The minimum length is `1` character. The value must match regular expression `/^[a-z_]*$/`.
+* `updated_at` - (Integer) Timestamp of last update in Unix epoch time.
+* `updated_by` - (String) IAM ID of last updater.
+  * Constraints: The maximum length is `100` characters. The minimum length is `1` character. The value must match regular expression `/^[a-zA-Z0-9-]*$/`.
 

--- a/website/docs/r/cloud_shell_account_settings.html.markdown
+++ b/website/docs/r/cloud_shell_account_settings.html.markdown
@@ -1,6 +1,6 @@
 ---
 layout: "ibm"
-page_title: "IBM : cloud_shell_account_settings"
+page_title: "IBM : ibm_cloud_shell_account_settings"
 description: |-
   Manages cloud_shell_account_settings.
 subcategory: "IBM Cloud Shell"
@@ -8,9 +8,9 @@ subcategory: "IBM Cloud Shell"
 
 # ibm_cloud_shell_account_settings
 
-Provides a resource for cloud_shell_account_settings. This allows cloud_shell_account_settings to be updated.
+Create, update, and delete cloud_shell_account_settingss with this resource.
 
-## Example usage
+## Example Usage
 
 ```terraform
 resource "ibm_cloud_shell_account_settings" "cloud_shell_account_settings" {
@@ -33,61 +33,63 @@ resource "ibm_cloud_shell_account_settings" "cloud_shell_account_settings" {
   }
   regions {
   	enabled = true
-  	key = "jp-tok"
-  }
-  regions {
-  	enabled = true
   	key = "us-south"
   }
 }
 ```
 
-## Argument reference
+## Argument Reference
 
-The following arguments are supported:
+You can specify the following arguments for this resource.
 
-* `account_id` - (Required, Forces new resource, string) The account ID in which the account settings belong to.
-* `default_enable_new_features` - (Optional, bool) You can choose which Cloud Shell features are available in the account and whether any new features are enabled as they become available. The feature settings apply only to the enabled Cloud Shell locations.
-* `default_enable_new_regions` - (Optional, bool) Set whether Cloud Shell is enabled in a specific location for the account. The location determines where user and session data are stored. By default, users are routed to the nearest available location.
-* `enabled` - (Optional, bool) When enabled, Cloud Shell is available to all users in the account.
+* `account_id` - (Required, Forces new resource, String) The account ID in which the account settings belong to.
+  * Constraints: The maximum length is `100` characters. The minimum length is `1` character. The value must match regular expression `/^[a-zA-Z0-9-]*$/`.
+* `default_enable_new_features` - (Optional, Boolean) You can choose which Cloud Shell features are available in the account and whether any new features are enabled as they become available. The feature settings apply only to the enabled Cloud Shell locations.
+* `default_enable_new_regions` - (Optional, Boolean) Set whether Cloud Shell is enabled in a specific location for the account. The location determines where user and session data are stored. By default, users are routed to the nearest available location.
+* `enabled` - (Optional, Boolean) When enabled, Cloud Shell is available to all users in the account.
 * `features` - (Optional, List) List of Cloud Shell features.
-  * `enabled` - (Optional, bool) State of the feature.
-  * `key` - (Optional, string) Name of the feature.
+  * Constraints: The maximum length is `2` items. The minimum length is `0` items.
+Nested schema for **features**:
+	* `enabled` - (Optional, Boolean) State of the feature.
+	* `key` - (Optional, String) Name of the feature.
+	  * Constraints: The maximum length is `100` characters. The minimum length is `1` character. The value must match regular expression `/^[a-zA-Z0-9_.]*$/`.
 * `regions` - (Optional, List) List of Cloud Shell region settings.
-  * `enabled` - (Optional, bool) State of the region.
-  * `key` - (Optional, string) Name of the region.
-* `rev` - (Required, string) Unique revision number for the settings object.  Required it this field is available from the data source.
+  * Constraints: The maximum length is `3` items. The minimum length is `0` items.
+Nested schema for **regions**:
+	* `enabled` - (Optional, Boolean) State of the region.
+	* `key` - (Optional, String) Name of the region.
+	  * Constraints: The maximum length is `100` characters. The minimum length is `1` character. The value must match regular expression `/^[a-zA-Z-]*$/`.
+* `rev` - (Optional, String) Unique revision number for the settings object.
+  * Constraints: The maximum length is `100` characters. The minimum length is `1` character. The value must match regular expression `/^[a-zA-Z0-9-]*$/`.
 
-## Attribute reference
+## Attribute Reference
 
-In addition to all arguments above, the following attributes are exported:
+After your resource is created, you can read values from the listed arguments and the following attributes.
 
 * `id` - The unique identifier of the cloud_shell_account_settings.
-* `created_at` - Creation timestamp in Unix epoch time.
-* `created_by` - IAM ID of creator.
-* `default_enable_new_features` - You can choose which Cloud Shell features are available in the account and whether any new features are enabled as they become available. The feature settings apply only to the enabled Cloud Shell locations.
-* `default_enable_new_regions` - Set whether Cloud Shell is enabled in a specific location for the account. The location determines where user and session data are stored. By default, users are routed to the nearest available location.
-* `enabled` - When enabled, Cloud Shell is available to all users in the account.
-* `features` - List of Cloud Shell features. Nested `features` blocks have the following structure:
-	* `enabled` - State of the feature.
-	* `key` - Name of the feature.
-* `regions` - List of Cloud Shell region settings. Nested `regions` blocks have the following structure:
-	* `enabled` - State of the region.
-	* `key` - Name of the region.
-* `rev` - Unique revision number for the settings object.
-* `type` - Type of api response object.
-* `updated_at` - Timestamp of last update in Unix epoch time.
-* `updated_by` - IAM ID of last updater.
+* `created_at` - (Integer) Creation timestamp in Unix epoch time.
+* `created_by` - (String) IAM ID of creator.
+  * Constraints: The maximum length is `100` characters. The minimum length is `1` character. The value must match regular expression `/^[a-zA-Z0-9-]*$/`.
+* `id` - (String) Unique id of the settings object.
+  * Constraints: The maximum length is `100` characters. The minimum length is `1` character. The value must match regular expression `/^[a-zA-Z0-9-]*$/`.
+* `type` - (String) Type of api response object.
+  * Constraints: The maximum length is `100` characters. The minimum length is `1` character. The value must match regular expression `/^[a-z_]*$/`.
+* `updated_at` - (Integer) Timestamp of last update in Unix epoch time.
+* `updated_by` - (String) IAM ID of last updater.
+  * Constraints: The maximum length is `100` characters. The minimum length is `1` character. The value must match regular expression `/^[a-zA-Z0-9-]*$/`.
+
 
 ## Import
 
-You can import the `cloud_shell_account_settings` resource by using `account_id`.
+You can import the `ibm_cloud_shell_account_settings` resource by using `account_id`.
+The `account_id` property can be formed from and `account_id` in the following format:
 
-```
-<account_id>
-```
+<pre>
+&lt;account_id&gt;
+</pre>
 * `account_id`: A string. The account ID in which the account settings belong to.
 
-```
-$ terraform import cloud_shell_account_settings.cloud_shell_account_settings <account_id>
-```
+# Syntax
+<pre>
+$ terraform import ibm_cloud_shell_account_settings.cloud_shell_account_settings &lt;account_id&gt;
+</pre>


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/IBM-Cloud/terraform-provider-ibm/blob/master/.github/CONTRIBUTING.md --->

### PR Details

- Changes for IBM Cloud Shell - Optimize Terraform Error Messaging.
- New version of `platform-services-go-sdk` - 0.72.0 to Optimize Terraform Error Messaging for cloudshell.

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Output from acceptance testing:

1. make build

<img width="716" alt="Screenshot 2025-01-08 at 10 49 13 AM" src="https://github.com/user-attachments/assets/bce61fdf-80b7-4981-ac2b-e343e25c0335" />

2. Unit tests

<img width="1346" alt="Screenshot 2025-01-08 at 10 42 36 AM" src="https://github.com/user-attachments/assets/429b2e92-28df-472e-b5a4-a282a773df15" />


<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```
