### PR TITLE
Add Custom Endpoints to Logs Routing Service

### DIFF
--- a/examples/ibm-logs-routing/README.md
+++ b/examples/ibm-logs-routing/README.md
@@ -128,6 +128,9 @@ data "ibm_logs_router_targets" "logs_router_targets_instance" {
 
 ### The Logs Routing URL can be set in endpoints.json
 
+Use the `IBMCLOUD_ENDPOINTS_FILE_PATH` or `IC_ENDPOINTS_FILE_PATH` environment variable to export the path to your endpoints file.
+To use the provided endpoints file, set the visibility to either `public` or `pivate` by using the `IC_VISIBILITY` or `IBMCLOUD_VISIBILITY` environment variable.
+
 **Example**:
 
 ```json

--- a/examples/ibm-logs-routing/README.md
+++ b/examples/ibm-logs-routing/README.md
@@ -128,8 +128,8 @@ data "ibm_logs_router_targets" "logs_router_targets_instance" {
 
 ### The Logs Routing URL can be set in endpoints.json
 
-Use the `IBMCLOUD_ENDPOINTS_FILE_PATH` or `IC_ENDPOINTS_FILE_PATH` environment variable to export the path to your endpoints file.
-To use the provided endpoints file, set the visibility to either `public` or `pivate` by using the `IC_VISIBILITY` or `IBMCLOUD_VISIBILITY` environment variable.
+You can declare the service endpoints in a JSON file and either reference this file in your provider block by using the `endpoints_file_path` argument, or export the path to your file with the `IBMCLOUD_ENDPOINTS_FILE_PATH` or `IC_ENDPOINTS_FILE_PATH` environment variable.
+To use the provided endpoints file, set the visibility to either `public` or `pivate` by using the `IC_VISIBILITY` or `IBMCLOUD_VISIBILITY` environment variable, or by setting the `visibility` field in your provider block.
 
 **Example**:
 

--- a/examples/ibm-logs-routing/main.tf
+++ b/examples/ibm-logs-routing/main.tf
@@ -1,6 +1,12 @@
 provider "ibm" {
   ibmcloud_api_key = var.ibmcloud_api_key
-  region = "us-south"
+  region = "us-east"
+}
+
+provider "ibm" {
+  ibmcloud_api_key = var.ibmcloud_api_key
+  region = "eu-de"
+  alias = "provider-eu-de"
 }
 
 // Provision logs_router_tenant resource instance
@@ -27,6 +33,7 @@ resource "ibm_logs_router_tenant" "logs_router_tenant_instance" {
 }
 
 resource "ibm_logs_router_tenant" "logs_router_tenant_instance_eu_de" {
+  provider = ibm.provider-eu-de
   name = "eu-de-tenant"
   region = "eu-de"
   targets {

--- a/go.mod
+++ b/go.mod
@@ -30,7 +30,7 @@ require (
 	github.com/IBM/ibm-hpcs-uko-sdk v0.0.20-beta
 	github.com/IBM/keyprotect-go-client v0.15.1
 	github.com/IBM/logs-go-sdk v0.4.0
-	github.com/IBM/logs-router-go-sdk v1.0.5
+	github.com/IBM/logs-router-go-sdk v1.0.7
 	github.com/IBM/mqcloud-go-sdk v0.2.0
 	github.com/IBM/networking-go-sdk v0.51.1
 	github.com/IBM/platform-services-go-sdk v0.73.0

--- a/go.sum
+++ b/go.sum
@@ -152,6 +152,8 @@ github.com/IBM/logs-go-sdk v0.4.0 h1:CyUjm19EUtcJjf4mxsj6Rc7gkZDT8JEY5rLUIz8Eoag
 github.com/IBM/logs-go-sdk v0.4.0/go.mod h1:yv/GCXC4/p+MZEeXl4xjZAOMvDAVRwu61WyHZFKFXQM=
 github.com/IBM/logs-router-go-sdk v1.0.5 h1:r0kC1+HfmSeQCD6zQTUp4PDI/zp4Ueo1Zo19ipHuNlw=
 github.com/IBM/logs-router-go-sdk v1.0.5/go.mod h1:tCN2vFgu5xG0ob9iJcxi5M4bJ6mWmu3nhmRPnvlwev0=
+github.com/IBM/logs-router-go-sdk v1.0.7 h1:uQjQAAcQdo3XvhY6MC7HakhZaXIUsGfUmKj2d5vkjnY=
+github.com/IBM/logs-router-go-sdk v1.0.7/go.mod h1:tCN2vFgu5xG0ob9iJcxi5M4bJ6mWmu3nhmRPnvlwev0=
 github.com/IBM/mqcloud-go-sdk v0.2.0 h1:QOWk8ZGk0QfIL0MOGTKzNdM3Qe0Hk+ifAFtNSFQo5HU=
 github.com/IBM/mqcloud-go-sdk v0.2.0/go.mod h1:VZQKMtqmcdXKhmLhLiPuS/UHMs/5yo2tA/nD83cQt9E=
 github.com/IBM/networking-go-sdk v0.51.1 h1:xRlDFxSMejMmJ7JPFZ9cflL86uJpbqUzuL/1D/pP7/g=

--- a/ibm/service/logsrouting/data_source_ibm_logs-router_targets.go
+++ b/ibm/service/logsrouting/data_source_ibm_logs-router_targets.go
@@ -119,6 +119,7 @@ func dataSourceIBMLogsRouterTargetsRead(context context.Context, d *schema.Resou
 		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
 		return tfErr.GetDiag()
 	}
+	ibmCloudLogsRoutingClient, _, err = updateClientURLWithEndpoint(ibmCloudLogsRoutingClient, d)
 
 	listTenantTargetsOptions := &ibmcloudlogsroutingv0.ListTenantTargetsOptions{}
 
@@ -131,7 +132,7 @@ func dataSourceIBMLogsRouterTargetsRead(context context.Context, d *schema.Resou
 		listTenantTargetsOptions.SetRegion(d.Get("region").(string))
 	}
 
-	targetTypeCollection, _, err := ibmCloudLogsRoutingClient.ListTenantTargetsWithContext(context, listTenantTargetsOptions)
+	targetTypeCollection, _, err := ibmCloudLogsRoutingClient.ListTenantTargetsWithContextEndpoint(context, listTenantTargetsOptions)
 	if err != nil {
 		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("ListTenantTargetsWithContext failed: %s", err.Error()), "(Data) ibm_logs_router_targets", "read")
 		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())

--- a/ibm/service/logsrouting/data_source_ibm_logs-router_tenants.go
+++ b/ibm/service/logsrouting/data_source_ibm_logs-router_tenants.go
@@ -151,6 +151,7 @@ func dataSourceIBMLogsRouterTenantsRead(context context.Context, d *schema.Resou
 		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
 		return tfErr.GetDiag()
 	}
+	ibmCloudLogsRoutingClient, _, err = updateClientURLWithEndpoint(ibmCloudLogsRoutingClient, d)
 
 	listTenantsOptions := &ibmcloudlogsroutingv0.ListTenantsOptions{}
 
@@ -162,7 +163,7 @@ func dataSourceIBMLogsRouterTenantsRead(context context.Context, d *schema.Resou
 		listTenantsOptions.SetRegion(d.Get("region").(string))
 	}
 
-	tenantCollection, _, err := ibmCloudLogsRoutingClient.ListTenantsWithContext(context, listTenantsOptions)
+	tenantCollection, _, err := ibmCloudLogsRoutingClient.ListTenantsWithContextEndpoint(context, listTenantsOptions)
 	if err != nil {
 		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("ListTenantsWithContext failed: %s", err.Error()), "(Data) ibm_logs_router_tenants", "read")
 		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())

--- a/ibm/service/logsrouting/resource_ibm_logs-router_tenant.go
+++ b/ibm/service/logsrouting/resource_ibm_logs-router_tenant.go
@@ -194,6 +194,7 @@ func resourceIBMLogsRouterTenantCreate(context context.Context, d *schema.Resour
 		return tfErr.GetDiag()
 	}
 
+	ibmCloudLogsRoutingClient, _, err = updateClientURLWithEndpoint(ibmCloudLogsRoutingClient, d)
 	createTenantOptions := &ibmcloudlogsroutingv0.CreateTenantOptions{}
 
 	createTenantOptions.SetName(d.Get("name").(string))
@@ -209,7 +210,7 @@ func resourceIBMLogsRouterTenantCreate(context context.Context, d *schema.Resour
 	}
 	createTenantOptions.SetTargets(targets)
 
-	tenant, _, err := ibmCloudLogsRoutingClient.CreateTenantWithContext(context, createTenantOptions)
+	tenant, _, err := ibmCloudLogsRoutingClient.CreateTenantWithContextEndpoint(context, createTenantOptions)
 	if err != nil {
 		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("CreateTenantWithContext failed: %s", err.Error()), "ibm_logs_router_tenant", "create")
 		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
@@ -229,13 +230,14 @@ func resourceIBMLogsRouterTenantRead(context context.Context, d *schema.Resource
 		return tfErr.GetDiag()
 	}
 
+	ibmCloudLogsRoutingClient, _, err = updateClientURLWithEndpoint(ibmCloudLogsRoutingClient, d)
 	getTenantDetailOptions := &ibmcloudlogsroutingv0.GetTenantDetailOptions{}
 
 	tenantId := strfmt.UUID(d.Id())
 	getTenantDetailOptions.SetTenantID(&tenantId)
 	getTenantDetailOptions.SetRegion(d.Get("region").(string))
 
-	tenant, response, err := ibmCloudLogsRoutingClient.GetTenantDetailWithContext(context, getTenantDetailOptions)
+	tenant, response, err := ibmCloudLogsRoutingClient.GetTenantDetailWithContextEndpoint(context, getTenantDetailOptions)
 	if err != nil {
 		if response != nil && response.StatusCode == 404 {
 			d.SetId("")
@@ -345,6 +347,7 @@ func resourceIBMLogsRouterTenantUpdate(context context.Context, d *schema.Resour
 		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
 		return tfErr.GetDiag()
 	}
+	ibmCloudLogsRoutingClient, _, err = updateClientURLWithEndpoint(ibmCloudLogsRoutingClient, d)
 
 	updateTenantOptions := &ibmcloudlogsroutingv0.UpdateTenantOptions{}
 
@@ -462,7 +465,7 @@ func resourceIBMLogsRouterTenantUpdate(context context.Context, d *schema.Resour
 			updateTenantOptions.TenantPatch["name"] = nil
 		}
 
-		_, _, err = ibmCloudLogsRoutingClient.UpdateTenantWithContext(context, updateTenantOptions)
+		_, _, err = ibmCloudLogsRoutingClient.UpdateTenantWithContextEndpoint(context, updateTenantOptions)
 		if err != nil {
 			tfErr := flex.TerraformErrorf(err, fmt.Sprintf("UpdateTenantWithContext failed: %s", err.Error()), "ibm_logs_router_tenant", "update")
 			log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
@@ -493,9 +496,9 @@ func resourceIBMLogsRouterTenantUpdate(context context.Context, d *schema.Resour
 		_, newCRN := d.GetChange("targets.0.log_sink_crn")
 		if crn, ok := newCRN.(string); ok {
 			if strings.Contains(crn, ":logs:") {
-				_, _, err = ibmCloudLogsRoutingClient.UpdateLogsTargetWithContext(context, updateTarget0Options)
+				_, _, err = ibmCloudLogsRoutingClient.UpdateLogsTargetWithContextEndpoint(context, updateTarget0Options)
 			} else {
-				_, _, err = ibmCloudLogsRoutingClient.UpdateTargetWithContext(context, updateTarget0Options)
+				_, _, err = ibmCloudLogsRoutingClient.UpdateTargetWithContextEndpoint(context, updateTarget0Options)
 			}
 		}
 
@@ -507,7 +510,7 @@ func resourceIBMLogsRouterTenantUpdate(context context.Context, d *schema.Resour
 	}
 
 	if target1Create {
-		_, _, err := ibmCloudLogsRoutingClient.CreateTargetWithContext(context, createTarget1Options)
+		_, _, err := ibmCloudLogsRoutingClient.CreateTargetWithContextEndpoint(context, createTarget1Options)
 		if err != nil {
 			tfErr := flex.TerraformErrorf(err, fmt.Sprintf("CreateTargetWithContext failed: %s", err.Error()), "ibm_logs_router_target", "create")
 			log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
@@ -535,7 +538,7 @@ func resourceIBMLogsRouterTenantUpdate(context context.Context, d *schema.Resour
 			deleteTargetOptions.SetTenantID(&tenantId)
 			deleteTargetOptions.SetTargetID(&target1ID)
 			deleteTargetOptions.SetRegion(d.Get("region").(string))
-			_, err = ibmCloudLogsRoutingClient.DeleteTargetWithContext(context, deleteTargetOptions)
+			_, err = ibmCloudLogsRoutingClient.DeleteTargetWithContextEndpoint(context, deleteTargetOptions)
 			if err != nil {
 				tfErr := flex.TerraformErrorf(err, fmt.Sprintf("DeleteTargetWithContext failed: %s", err.Error()), "ibm_logs_router_target", "delete")
 				log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
@@ -546,9 +549,9 @@ func resourceIBMLogsRouterTenantUpdate(context context.Context, d *schema.Resour
 			_, newCRN := d.GetChange("targets.1.log_sink_crn")
 			if crn, ok := newCRN.(string); ok {
 				if strings.Contains(crn, ":logs:") {
-					_, _, err = ibmCloudLogsRoutingClient.UpdateLogsTargetWithContext(context, updateTarget1Options)
+					_, _, err = ibmCloudLogsRoutingClient.UpdateLogsTargetWithContextEndpoint(context, updateTarget1Options)
 				} else {
-					_, _, err = ibmCloudLogsRoutingClient.UpdateTargetWithContext(context, updateTarget1Options)
+					_, _, err = ibmCloudLogsRoutingClient.UpdateTargetWithContextEndpoint(context, updateTarget1Options)
 				}
 			}
 			if err != nil {
@@ -578,9 +581,9 @@ func resourceIBMLogsRouterTenantUpdate(context context.Context, d *schema.Resour
 		_, newCRN := d.GetChange("targets.0.log_sink_crn")
 		if crn, ok := newCRN.(string); ok {
 			if strings.Contains(crn, ":logs:") {
-				_, _, err = ibmCloudLogsRoutingClient.UpdateLogsTargetWithContext(context, updateTarget0Options)
+				_, _, err = ibmCloudLogsRoutingClient.UpdateLogsTargetWithContextEndpoint(context, updateTarget0Options)
 			} else {
-				_, _, err = ibmCloudLogsRoutingClient.UpdateTargetWithContext(context, updateTarget0Options)
+				_, _, err = ibmCloudLogsRoutingClient.UpdateTargetWithContextEndpoint(context, updateTarget0Options)
 			}
 		}
 		if err != nil {
@@ -601,13 +604,14 @@ func resourceIBMLogsRouterTenantDelete(context context.Context, d *schema.Resour
 		return tfErr.GetDiag()
 	}
 
+	ibmCloudLogsRoutingClient, _, err = updateClientURLWithEndpoint(ibmCloudLogsRoutingClient, d)
 	deleteTenantOptions := &ibmcloudlogsroutingv0.DeleteTenantOptions{}
 
 	tenantId := strfmt.UUID(d.Id())
 	deleteTenantOptions.SetTenantID(&tenantId)
 	deleteTenantOptions.SetRegion(d.Get("region").(string))
 
-	_, err = ibmCloudLogsRoutingClient.DeleteTenantWithContext(context, deleteTenantOptions)
+	_, err = ibmCloudLogsRoutingClient.DeleteTenantWithContextEndpoint(context, deleteTenantOptions)
 	if err != nil {
 		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("DeleteTenantWithContext failed: %s", err.Error()), "ibm_logs_router_tenant", "delete")
 		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())

--- a/ibm/service/logsrouting/utils.go
+++ b/ibm/service/logsrouting/utils.go
@@ -1,0 +1,45 @@
+package logsrouting
+
+import (
+	"log"
+
+	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/conns"
+
+	"github.com/IBM/logs-router-go-sdk/ibmcloudlogsroutingv0"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+// Clones the logs routing client and sets the correct URL. Public, private, or custom
+func updateClientURLWithEndpoint(logsRoutingClient *ibmcloudlogsroutingv0.IBMCloudLogsRoutingV0, d *schema.ResourceData) (*ibmcloudlogsroutingv0.IBMCloudLogsRoutingV0, string, error) {
+
+	region := d.Get("region").(string)
+
+	originalConfigServiceURL := logsRoutingClient.GetServiceURL()
+
+	f := conns.EnvFallBack([]string{"IBMCLOUD_ENDPOINTS_FILE_PATH", "IC_ENDPOINTS_FILE_PATH"}, "")
+	visibility := conns.EnvFallBack([]string{"IBMCLOUD_VISIBILITY", "IC_VISIBILITY"}, "")
+
+	var logsrouterClientURL string
+	var logsrouterURLErr error
+
+	if f != "" && visibility != "public-and-private" {
+		logsrouterClientURL = conns.FileFallBack(f, visibility, "IBMCLOUD_LOGS_ROUTING_API_ENDPOINT", region, ibmcloudlogsroutingv0.DefaultServiceURL)
+	} else if visibility == "private" {
+		logsrouterClientURL, logsrouterURLErr = ibmcloudlogsroutingv0.GetServiceURLForRegion("private." + region)
+	} else {
+		logsrouterClientURL, logsrouterURLErr = ibmcloudlogsroutingv0.GetServiceURLForRegion(region)
+	}
+	if logsrouterURLErr != nil {
+		logsrouterClientURL = originalConfigServiceURL
+	}
+
+	newClient := &ibmcloudlogsroutingv0.IBMCloudLogsRoutingV0{
+		Service: logsRoutingClient.Service.Clone(),
+	}
+
+	log.Printf("Constructing client with new service URL %s", logsrouterClientURL)
+
+	newClient.Service.SetServiceURL(logsrouterClientURL)
+
+	return newClient, region, nil
+}


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/IBM-Cloud/terraform-provider-ibm/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccXXX'
make testacc
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test $(go list ./... | grep 'logsrouting') -v  -timeout 700m
=== RUN   TestAccIBMLogsRouterTargetsDataSourceBasic
--- PASS: TestAccIBMLogsRouterTargetsDataSourceBasic (74.38s)
=== RUN   TestDataSourceIBMLogsRouterTargetsTargetTypeToMap
--- PASS: TestDataSourceIBMLogsRouterTargetsTargetTypeToMap (0.00s)
=== RUN   TestDataSourceIBMLogsRouterTargetsTargetParametersTypeLogDnaToMap
--- PASS: TestDataSourceIBMLogsRouterTargetsTargetParametersTypeLogDnaToMap (0.00s)
=== RUN   TestDataSourceIBMLogsRouterTargetsTargetTypeLogDnaToMap
--- PASS: TestDataSourceIBMLogsRouterTargetsTargetTypeLogDnaToMap (0.00s)
=== RUN   TestDataSourceIBMLogsRouterTargetsTargetTypeLogsToMap
--- PASS: TestDataSourceIBMLogsRouterTargetsTargetTypeLogsToMap (0.00s)
=== RUN   TestDataSourceIBMLogsRouterTargetsTargetParametersTypeLogsToMap
--- PASS: TestDataSourceIBMLogsRouterTargetsTargetParametersTypeLogsToMap (0.00s)
=== RUN   TestAccIBMLogsRouterTenantsDataSourceBasic
--- PASS: TestAccIBMLogsRouterTenantsDataSourceBasic (74.28s)
=== RUN   TestDataSourceIBMLogsRouterTenantsTenantToMap
--- PASS: TestDataSourceIBMLogsRouterTenantsTenantToMap (0.00s)
=== RUN   TestDataSourceIBMLogsRouterTenantsTargetTypeToMap
--- PASS: TestDataSourceIBMLogsRouterTenantsTargetTypeToMap (0.00s)
=== RUN   TestDataSourceIBMLogsRouterTenantsTargetParametersTypeLogDnaToMap
--- PASS: TestDataSourceIBMLogsRouterTenantsTargetParametersTypeLogDnaToMap (0.00s)
=== RUN   TestDataSourceIBMLogsRouterTenantsTargetTypeLogDnaToMap
--- PASS: TestDataSourceIBMLogsRouterTenantsTargetTypeLogDnaToMap (0.00s)
=== RUN   TestDataSourceIBMLogsRouterTenantsTargetTypeLogsToMap
--- PASS: TestDataSourceIBMLogsRouterTenantsTargetTypeLogsToMap (0.00s)
=== RUN   TestDataSourceIBMLogsRouterTenantsTargetParametersTypeLogsToMap
--- PASS: TestDataSourceIBMLogsRouterTenantsTargetParametersTypeLogsToMap (0.00s)
=== RUN   TestAccIBMLogsRouterTenantBasic
--- PASS: TestAccIBMLogsRouterTenantBasic (78.74s)
=== RUN   TestAccIBMLogsRouterTenantAllArgs
--- PASS: TestAccIBMLogsRouterTenantAllArgs (80.57s)
=== RUN   TestResourceIBMLogsRouterTenantTargetTypeToMap
--- PASS: TestResourceIBMLogsRouterTenantTargetTypeToMap (0.00s)
=== RUN   TestResourceIBMLogsRouterTenantTargetParametersTypeLogDnaToMap
--- PASS: TestResourceIBMLogsRouterTenantTargetParametersTypeLogDnaToMap (0.00s)
=== RUN   TestResourceIBMLogsRouterTenantTargetTypeLogDnaToMap
--- PASS: TestResourceIBMLogsRouterTenantTargetTypeLogDnaToMap (0.00s)
=== RUN   TestResourceIBMLogsRouterTenantTargetTypeLogsToMap
--- PASS: TestResourceIBMLogsRouterTenantTargetTypeLogsToMap (0.00s)
=== RUN   TestResourceIBMLogsRouterTenantTargetParametersTypeLogsToMap
--- PASS: TestResourceIBMLogsRouterTenantTargetParametersTypeLogsToMap (0.00s)
=== RUN   TestResourceIBMLogsRouterTenantMapToTargetTypePrototype
--- PASS: TestResourceIBMLogsRouterTenantMapToTargetTypePrototype (0.00s)
=== RUN   TestResourceIBMLogsRouterTenantMapToTargetParametersTypeLogDnaPrototype
--- PASS: TestResourceIBMLogsRouterTenantMapToTargetParametersTypeLogDnaPrototype (0.00s)
=== RUN   TestResourceIBMLogsRouterTenantMapToTargetTypePrototypeTargetTypeLogDnaPrototype
--- PASS: TestResourceIBMLogsRouterTenantMapToTargetTypePrototypeTargetTypeLogDnaPrototype (0.00s)
=== RUN   TestResourceIBMLogsRouterTenantMapToTargetTypePrototypeTargetTypeLogsPrototype
--- PASS: TestResourceIBMLogsRouterTenantMapToTargetTypePrototypeTargetTypeLogsPrototype (0.00s)
=== RUN   TestResourceIBMLogsRouterTenantMapToTargetParametersTypeLogsPrototype
--- PASS: TestResourceIBMLogsRouterTenantMapToTargetParametersTypeLogsPrototype (0.00s)
PASS
ok  	github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/logsrouting	311.426s
```
