### PR TITLE
Add Custom Endpoints Support for Logs Routing service

### DIFF
--- a/ibm/service/logsrouting/data_source_ibm_logs-router_targets.go
+++ b/ibm/service/logsrouting/data_source_ibm_logs-router_targets.go
@@ -119,7 +119,15 @@ func dataSourceIBMLogsRouterTargetsRead(context context.Context, d *schema.Resou
 		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
 		return tfErr.GetDiag()
 	}
-	ibmCloudLogsRoutingClient, _, err = updateClientURLWithEndpoint(ibmCloudLogsRoutingClient, d)
+
+	bxSession, err := meta.(conns.ClientSession).BluemixSession()
+	if err != nil {
+		tfErr := flex.TerraformErrorf(err, err.Error(), "ibm_logs_router_tenant", "create")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
+	}
+
+	ibmCloudLogsRoutingClient, _, err = updateClientURLWithEndpoint(ibmCloudLogsRoutingClient, d, bxSession)
 
 	listTenantTargetsOptions := &ibmcloudlogsroutingv0.ListTenantTargetsOptions{}
 

--- a/ibm/service/logsrouting/data_source_ibm_logs-router_tenants.go
+++ b/ibm/service/logsrouting/data_source_ibm_logs-router_tenants.go
@@ -151,7 +151,15 @@ func dataSourceIBMLogsRouterTenantsRead(context context.Context, d *schema.Resou
 		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
 		return tfErr.GetDiag()
 	}
-	ibmCloudLogsRoutingClient, _, err = updateClientURLWithEndpoint(ibmCloudLogsRoutingClient, d)
+
+	bxSession, err := meta.(conns.ClientSession).BluemixSession()
+	if err != nil {
+		tfErr := flex.TerraformErrorf(err, err.Error(), "ibm_logs_router_tenant", "create")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
+	}
+
+	ibmCloudLogsRoutingClient, _, err = updateClientURLWithEndpoint(ibmCloudLogsRoutingClient, d, bxSession)
 
 	listTenantsOptions := &ibmcloudlogsroutingv0.ListTenantsOptions{}
 

--- a/ibm/service/logsrouting/resource_ibm_logs-router_tenant.go
+++ b/ibm/service/logsrouting/resource_ibm_logs-router_tenant.go
@@ -194,7 +194,14 @@ func resourceIBMLogsRouterTenantCreate(context context.Context, d *schema.Resour
 		return tfErr.GetDiag()
 	}
 
-	ibmCloudLogsRoutingClient, _, err = updateClientURLWithEndpoint(ibmCloudLogsRoutingClient, d)
+	bxSession, err := meta.(conns.ClientSession).BluemixSession()
+	if err != nil {
+		tfErr := flex.TerraformErrorf(err, err.Error(), "ibm_logs_router_tenant", "create")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
+	}
+
+	ibmCloudLogsRoutingClient, _, err = updateClientURLWithEndpoint(ibmCloudLogsRoutingClient, d, bxSession)
 	createTenantOptions := &ibmcloudlogsroutingv0.CreateTenantOptions{}
 
 	createTenantOptions.SetName(d.Get("name").(string))
@@ -230,7 +237,14 @@ func resourceIBMLogsRouterTenantRead(context context.Context, d *schema.Resource
 		return tfErr.GetDiag()
 	}
 
-	ibmCloudLogsRoutingClient, _, err = updateClientURLWithEndpoint(ibmCloudLogsRoutingClient, d)
+	bxSession, err := meta.(conns.ClientSession).BluemixSession()
+	if err != nil {
+		tfErr := flex.TerraformErrorf(err, err.Error(), "ibm_logs_router_tenant", "create")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
+	}
+
+	ibmCloudLogsRoutingClient, _, err = updateClientURLWithEndpoint(ibmCloudLogsRoutingClient, d, bxSession)
 	getTenantDetailOptions := &ibmcloudlogsroutingv0.GetTenantDetailOptions{}
 
 	tenantId := strfmt.UUID(d.Id())
@@ -347,7 +361,15 @@ func resourceIBMLogsRouterTenantUpdate(context context.Context, d *schema.Resour
 		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
 		return tfErr.GetDiag()
 	}
-	ibmCloudLogsRoutingClient, _, err = updateClientURLWithEndpoint(ibmCloudLogsRoutingClient, d)
+
+	bxSession, err := meta.(conns.ClientSession).BluemixSession()
+	if err != nil {
+		tfErr := flex.TerraformErrorf(err, err.Error(), "ibm_logs_router_tenant", "create")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
+	}
+
+	ibmCloudLogsRoutingClient, _, err = updateClientURLWithEndpoint(ibmCloudLogsRoutingClient, d, bxSession)
 
 	updateTenantOptions := &ibmcloudlogsroutingv0.UpdateTenantOptions{}
 
@@ -604,7 +626,14 @@ func resourceIBMLogsRouterTenantDelete(context context.Context, d *schema.Resour
 		return tfErr.GetDiag()
 	}
 
-	ibmCloudLogsRoutingClient, _, err = updateClientURLWithEndpoint(ibmCloudLogsRoutingClient, d)
+	bxSession, err := meta.(conns.ClientSession).BluemixSession()
+	if err != nil {
+		tfErr := flex.TerraformErrorf(err, err.Error(), "ibm_logs_router_tenant", "create")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
+	}
+
+	ibmCloudLogsRoutingClient, _, err = updateClientURLWithEndpoint(ibmCloudLogsRoutingClient, d, bxSession)
 	deleteTenantOptions := &ibmcloudlogsroutingv0.DeleteTenantOptions{}
 
 	tenantId := strfmt.UUID(d.Id())


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/IBM-Cloud/terraform-provider-ibm/blob/master/.github/CONTRIBUTING.md --->
This PR adds the ability to set custom endpoints for the Logs Routing service as described in https://registry.terraform.io/providers/IBM-Cloud/ibm/latest/docs/guides/custom-service-endpoints
<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates ---> 

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccXXX'
make testacc
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test $(go list ./... |grep 'routing') -v  -timeout 700m
[WARN] Set the environment variable INGESTION_KEY for testing Logdna targets, the tests will fail if this is not set
=== RUN   TestAccIBMLogsRouterTargetsDataSourceBasic
--- PASS: TestAccIBMLogsRouterTargetsDataSourceBasic (90.95s)
=== RUN   TestDataSourceIBMLogsRouterTargetsTargetTypeToMap
--- PASS: TestDataSourceIBMLogsRouterTargetsTargetTypeToMap (0.00s)
=== RUN   TestDataSourceIBMLogsRouterTargetsTargetParametersTypeLogDnaToMap
--- PASS: TestDataSourceIBMLogsRouterTargetsTargetParametersTypeLogDnaToMap (0.00s)
=== RUN   TestDataSourceIBMLogsRouterTargetsTargetTypeLogDnaToMap
--- PASS: TestDataSourceIBMLogsRouterTargetsTargetTypeLogDnaToMap (0.00s)
=== RUN   TestDataSourceIBMLogsRouterTargetsTargetTypeLogsToMap
--- PASS: TestDataSourceIBMLogsRouterTargetsTargetTypeLogsToMap (0.00s)
=== RUN   TestDataSourceIBMLogsRouterTargetsTargetParametersTypeLogsToMap
--- PASS: TestDataSourceIBMLogsRouterTargetsTargetParametersTypeLogsToMap (0.00s)
=== RUN   TestAccIBMLogsRouterTenantsDataSourceBasic
--- PASS: TestAccIBMLogsRouterTenantsDataSourceBasic (97.13s)
=== RUN   TestDataSourceIBMLogsRouterTenantsTenantToMap
--- PASS: TestDataSourceIBMLogsRouterTenantsTenantToMap (0.00s)
=== RUN   TestDataSourceIBMLogsRouterTenantsTargetTypeToMap
--- PASS: TestDataSourceIBMLogsRouterTenantsTargetTypeToMap (0.00s)
=== RUN   TestDataSourceIBMLogsRouterTenantsTargetParametersTypeLogDnaToMap
--- PASS: TestDataSourceIBMLogsRouterTenantsTargetParametersTypeLogDnaToMap (0.00s)
=== RUN   TestDataSourceIBMLogsRouterTenantsTargetTypeLogDnaToMap
--- PASS: TestDataSourceIBMLogsRouterTenantsTargetTypeLogDnaToMap (0.00s)
=== RUN   TestDataSourceIBMLogsRouterTenantsTargetTypeLogsToMap
--- PASS: TestDataSourceIBMLogsRouterTenantsTargetTypeLogsToMap (0.00s)
=== RUN   TestDataSourceIBMLogsRouterTenantsTargetParametersTypeLogsToMap
--- PASS: TestDataSourceIBMLogsRouterTenantsTargetParametersTypeLogsToMap (0.00s)
=== RUN   TestAccIBMLogsRouterTenantBasic
--- PASS: TestAccIBMLogsRouterTenantBasic (97.96s)
=== RUN   TestAccIBMLogsRouterTenantAllArgs
--- PASS: TestAccIBMLogsRouterTenantAllArgs (117.64s)
=== RUN   TestResourceIBMLogsRouterTenantTargetTypeToMap
--- PASS: TestResourceIBMLogsRouterTenantTargetTypeToMap (0.00s)
=== RUN   TestResourceIBMLogsRouterTenantTargetParametersTypeLogDnaToMap
--- PASS: TestResourceIBMLogsRouterTenantTargetParametersTypeLogDnaToMap (0.00s)
=== RUN   TestResourceIBMLogsRouterTenantTargetTypeLogDnaToMap
--- PASS: TestResourceIBMLogsRouterTenantTargetTypeLogDnaToMap (0.00s)
=== RUN   TestResourceIBMLogsRouterTenantTargetTypeLogsToMap
--- PASS: TestResourceIBMLogsRouterTenantTargetTypeLogsToMap (0.00s)
=== RUN   TestResourceIBMLogsRouterTenantTargetParametersTypeLogsToMap
--- PASS: TestResourceIBMLogsRouterTenantTargetParametersTypeLogsToMap (0.00s)
=== RUN   TestResourceIBMLogsRouterTenantMapToTargetTypePrototype
--- PASS: TestResourceIBMLogsRouterTenantMapToTargetTypePrototype (0.00s)
=== RUN   TestResourceIBMLogsRouterTenantMapToTargetParametersTypeLogDnaPrototype
--- PASS: TestResourceIBMLogsRouterTenantMapToTargetParametersTypeLogDnaPrototype (0.00s)
=== RUN   TestResourceIBMLogsRouterTenantMapToTargetTypePrototypeTargetTypeLogDnaPrototype
--- PASS: TestResourceIBMLogsRouterTenantMapToTargetTypePrototypeTargetTypeLogDnaPrototype (0.00s)
=== RUN   TestResourceIBMLogsRouterTenantMapToTargetTypePrototypeTargetTypeLogsPrototype
--- PASS: TestResourceIBMLogsRouterTenantMapToTargetTypePrototypeTargetTypeLogsPrototype (0.00s)
=== RUN   TestResourceIBMLogsRouterTenantMapToTargetParametersTypeLogsPrototype
--- PASS: TestResourceIBMLogsRouterTenantMapToTargetParametersTypeLogsPrototype (0.00s)
PASS
ok  	github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/logsrouting	408.136s
```
