### PR TITLE
feat(Cloud Databases): Update Database Password Complexity Validation

### DIFF
--- a/ibm/service/database/resource_ibm_database.go
+++ b/ibm/service/database/resource_ibm_database.go
@@ -215,7 +215,7 @@ func ResourceIBMDatabaseInstance() *schema.Resource {
 				Type:        schema.TypeString,
 				Optional:    true,
 				ValidateFunc: validation.All(
-					validation.StringLenBetween(15, 32),
+					validation.StringLenBetween(15, 72),
 					DatabaseUserPasswordValidator("database"),
 				),
 				Sensitive: true,
@@ -3295,7 +3295,8 @@ func (u *DatabaseUser) ValidatePassword() (err error) {
 
 	var allowedCharacters = regexp.MustCompile(fmt.Sprintf("^(?:[a-zA-Z0-9]|%s)+$", specialCharPattern))
 	var beginWithSpecialChar = regexp.MustCompile(fmt.Sprintf("^(?:%s)", specialCharPattern))
-	var containsLetter = regexp.MustCompile("[a-zA-Z]")
+	var containsLower = regexp.MustCompile("[a-z]")
+	var containsUpper = regexp.MustCompile("[A-Z]")
 	var containsNumber = regexp.MustCompile("[0-9]")
 	var containsSpecialChar = regexp.MustCompile(fmt.Sprintf("(?:%s)", specialCharPattern))
 
@@ -3309,8 +3310,12 @@ func (u *DatabaseUser) ValidatePassword() (err error) {
 			"password must not begin with a special character (%s)", specialChars))
 	}
 
-	if !containsLetter.MatchString(u.Password) {
-		errs = append(errs, errors.New("password must contain at least one letter"))
+	if !containsLower.MatchString(u.Password) {
+		errs = append(errs, errors.New("password must contain at least one lower case letter"))
+	}
+
+	if !containsUpper.MatchString(u.Password) {
+		errs = append(errs, errors.New("password must contain at least one upper case letter"))
 	}
 
 	if !containsNumber.MatchString(u.Password) {

--- a/ibm/service/database/resource_ibm_database_edb_test.go
+++ b/ibm/service/database/resource_ibm_database_edb_test.go
@@ -185,7 +185,7 @@ func testAccCheckIBMDatabaseInstanceEDBBasic(databaseResourceGroup string, name 
 		service                      = "databases-for-enterprisedb"
 		plan                         = "standard"
 		location                     = "%[3]s"
-		adminpassword                = "password12345678"
+		adminpassword                = "secure-Password12345"
 		group {
 			group_id = "member"
 			host_flavor {
@@ -199,7 +199,7 @@ func testAccCheckIBMDatabaseInstanceEDBBasic(databaseResourceGroup string, name 
 		tags                         = ["one:two"]
 		users {
 		  name     = "user123"
-		  password = "password12345678"
+		  password = "secure-Password12345"
 		}
 		allowlist {
 		  address     = "172.168.1.2/32"
@@ -226,7 +226,7 @@ func testAccCheckIBMDatabaseInstanceEDBFullyspecified(databaseResourceGroup stri
 		service                      = "databases-for-enterprisedb"
 		plan                         = "standard"
 		location                     = "%[3]s"
-		adminpassword                = "password12345678"
+		adminpassword                = "secure-Password12345"
 		group {
 			group_id = "member"
 			host_flavor {
@@ -240,11 +240,11 @@ func testAccCheckIBMDatabaseInstanceEDBFullyspecified(databaseResourceGroup stri
 		tags                         = ["one:two"]
 		users {
 		  name     = "user123"
-		  password = "password12345678"
+		  password = "secure-Password12345"
 		}
 		users {
 		  name     = "user124"
-		  password = "password12345678"
+		  password = "secure-Password12345"
 		}
 		allowlist {
 		  address     = "172.168.1.2/32"
@@ -275,7 +275,7 @@ func testAccCheckIBMDatabaseInstanceEDBReduced(databaseResourceGroup string, nam
 		service                      = "databases-for-enterprisedb"
 		plan                         = "standard"
 		location                     = "%[3]s"
-		adminpassword                = "password12345678"
+		adminpassword                = "secure-Password12345"
 		group {
 			group_id = "member"
 			host_flavor {

--- a/ibm/service/database/resource_ibm_database_elasticsearch_platinum_test.go
+++ b/ibm/service/database/resource_ibm_database_elasticsearch_platinum_test.go
@@ -297,7 +297,7 @@ func testAccCheckIBMDatabaseInstanceElasticsearchPlatinumBasic(databaseResourceG
 		service                      = "databases-for-elasticsearch"
 		plan                         = "platinum"
 		location                     = "%[3]s"
-		adminpassword                = "password12345678"
+		adminpassword                = "secure-Password12345"
 		service_endpoints            = "public-and-private"
 		group {
 			group_id = "member"
@@ -311,7 +311,7 @@ func testAccCheckIBMDatabaseInstanceElasticsearchPlatinumBasic(databaseResourceG
 		}
 		users {
 		  name     = "user123"
-		  password = "password12345678"
+		  password = "secure-Password12345"
 		}
 		allowlist {
 		  address     = "172.168.1.2/32"
@@ -340,7 +340,7 @@ func testAccCheckIBMDatabaseInstanceElasticsearchPlatinumFullyspecified(database
 		service                      = "databases-for-elasticsearch"
 		plan                         = "platinum"
 		location                     = "%[3]s"
-		adminpassword                = "password12345678"
+		adminpassword                = "secure-Password12345"
 		service_endpoints            = "public-and-private"
 		group {
 			group_id = "member"
@@ -351,11 +351,11 @@ func testAccCheckIBMDatabaseInstanceElasticsearchPlatinumFullyspecified(database
 		}
 		users {
 		  name     = "user123"
-		  password = "password12345678"
+		  password = "secure-Password12345"
 		}
 		users {
 		  name     = "user124"
-		  password = "password12345678"
+		  password = "secure-Password12345"
 		}
 		allowlist {
 		  address     = "172.168.1.2/32"
@@ -389,7 +389,7 @@ func testAccCheckIBMDatabaseInstanceElasticsearchPlatinumReduced(databaseResourc
 		service                      = "databases-for-elasticsearch"
 		plan                         = "platinum"
 		location                     = "%[3]s"
-		adminpassword                = "password12345678"
+		adminpassword                = "secure-Password12345"
 		service_endpoints            = "public-and-private"
 		group {
 			group_id = "member"
@@ -421,7 +421,7 @@ func testAccCheckIBMDatabaseInstanceElasticsearchPlatinumGroupMigration(database
 		service                      = "databases-for-elasticsearch"
 		plan                         = "platinum"
 		location                     = "%[3]s"
-		adminpassword                = "password12345678"
+		adminpassword                = "secure-Password12345"
 		service_endpoints            = "public-and-private"
 
 		group {
@@ -457,7 +457,7 @@ func testAccCheckIBMDatabaseInstanceElasticsearchPlatinumNodeBasic(databaseResou
 		service                      = "databases-for-elasticsearch"
 		plan                         = "platinum"
 		location                     = "%[3]s"
-		adminpassword                = "password12345678"
+		adminpassword                = "secure-Password12345"
 		service_endpoints            = "public-and-private"
 		group {
 			group_id = "member"
@@ -474,7 +474,7 @@ func testAccCheckIBMDatabaseInstanceElasticsearchPlatinumNodeBasic(databaseResou
 
 		users {
 		  name     = "user123"
-		  password = "password12345678"
+		  password = "secure-Password12345"
 		}
 		allowlist {
 		  address     = "172.168.1.2/32"
@@ -503,7 +503,7 @@ func testAccCheckIBMDatabaseInstanceElasticsearchPlatinumNodeFullyspecified(data
 		service                      = "databases-for-elasticsearch"
 		plan                         = "platinum"
 		location                     = "%[3]s"
-		adminpassword                = "password12345678"
+		adminpassword                = "secure-Password12345"
 		service_endpoints            = "public-and-private"
 		group {
 			group_id = "member"
@@ -519,11 +519,11 @@ func testAccCheckIBMDatabaseInstanceElasticsearchPlatinumNodeFullyspecified(data
 		}
 		users {
 		  name     = "user123"
-		  password = "password12345678"
+		  password = "secure-Password12345"
 		}
 		users {
 		  name     = "user124"
-		  password = "password12345678"
+		  password = "secure-Password12345"
 		}
 		allowlist {
 		  address     = "172.168.1.2/32"
@@ -556,7 +556,7 @@ func testAccCheckIBMDatabaseInstanceElasticsearchPlatinumNodeReduced(databaseRes
 		service                      = "databases-for-elasticsearch"
 		plan                         = "platinum"
 		location                     = "%[3]s"
-		adminpassword                = "password12345678"
+		adminpassword                = "secure-Password12345"
 		service_endpoints            = "public-and-private"
 		group {
 			group_id = "member"
@@ -593,7 +593,7 @@ func testAccCheckIBMDatabaseInstanceElasticsearchPlatinumNodeScaleOut(databaseRe
 		service                      = "databases-for-elasticsearch"
 		plan                         = "platinum"
 		location                     = "%[3]s"
-		adminpassword                = "password12345678"
+		adminpassword                = "secure-Password12345"
 		service_endpoints            = "public-and-private"
 		group {
 			group_id = "member"
@@ -630,7 +630,7 @@ func testAccCheckIBMDatabaseInstanceElasticsearchPlatinumGroupBasic(databaseReso
 		service                      = "databases-for-elasticsearch"
 		plan                         = "platinum"
 		location                     = "%[3]s"
-		adminpassword                = "password12345678"
+		adminpassword                = "secure-Password12345"
 		service_endpoints            = "public-and-private"
 
 		group {
@@ -648,7 +648,7 @@ func testAccCheckIBMDatabaseInstanceElasticsearchPlatinumGroupBasic(databaseReso
 
 		users {
 		  name     = "user123"
-		  password = "password12345678"
+		  password = "secure-Password12345"
 		}
 		allowlist {
 		  address     = "172.168.1.2/32"
@@ -677,7 +677,7 @@ func testAccCheckIBMDatabaseInstanceElasticsearchPlatinumGroupFullyspecified(dat
 		service                      = "databases-for-elasticsearch"
 		plan                         = "platinum"
 		location                     = "%[3]s"
-		adminpassword                = "password12345678"
+		adminpassword                = "secure-Password12345"
 		service_endpoints            = "public-and-private"
 
 		group {
@@ -694,11 +694,11 @@ func testAccCheckIBMDatabaseInstanceElasticsearchPlatinumGroupFullyspecified(dat
 		}
 		users {
 		  name     = "user123"
-		  password = "password12345678"
+		  password = "secure-Password12345"
 		}
 		users {
 		  name     = "user124"
-		  password = "password12345678"
+		  password = "secure-Password12345"
 		}
 		allowlist {
 		  address     = "172.168.1.2/32"
@@ -732,7 +732,7 @@ func testAccCheckIBMDatabaseInstanceElasticsearchPlatinumGroupReduced(databaseRe
 		service                      = "databases-for-elasticsearch"
 		plan                         = "platinum"
 		location                     = "%[3]s"
-		adminpassword                = "password12345678"
+		adminpassword                = "secure-Password12345"
 		service_endpoints            = "public-and-private"
 
 		group {
@@ -770,7 +770,7 @@ func testAccCheckIBMDatabaseInstanceElasticsearchPlatinumGroupScaleOut(databaseR
 		service                      = "databases-for-elasticsearch"
 		plan                         = "platinum"
 		location                     = "%[3]s"
-		adminpassword                = "password12345678"
+		adminpassword                = "secure-Password12345"
 		service_endpoints            = "public-and-private"
 
 		group {

--- a/ibm/service/database/resource_ibm_database_elasticsearch_test.go
+++ b/ibm/service/database/resource_ibm_database_elasticsearch_test.go
@@ -292,11 +292,11 @@ func testAccCheckIBMDatabaseInstanceElasticsearchBasic(databaseResourceGroup str
 		service                      = "databases-for-elasticsearch"
 		plan                         = "standard"
 		location                     = "%[3]s"
-		adminpassword                = "password12345678"
+		adminpassword                = "secure-Password12345"
 		service_endpoints            = "public"
 		users {
 		  name     = "user123"
-		  password = "password12345678"
+		  password = "secure-Password12345"
 		}
 		allowlist {
 		  address     = "172.168.1.2/32"
@@ -335,15 +335,15 @@ func testAccCheckIBMDatabaseInstanceElasticsearchFullyspecified(databaseResource
 		service                      = "databases-for-elasticsearch"
 		plan                         = "standard"
 		location                     = "%[3]s"
-		adminpassword                = "password12345678"
+		adminpassword                = "secure-Password12345"
 		service_endpoints            = "public"
 		users {
 		  name     = "user123"
-		  password = "password12345678"
+		  password = "secure-Password12345"
 		}
 		users {
 		  name     = "user124"
-		  password = "password12345678"
+		  password = "secure-Password12345"
 		}
 		allowlist {
 		  address     = "172.168.1.2/32"
@@ -387,7 +387,7 @@ func testAccCheckIBMDatabaseInstanceElasticsearchReduced(databaseResourceGroup s
 		service                      = "databases-for-elasticsearch"
 		plan                         = "standard"
 		location                     = "%[3]s"
-		adminpassword                = "password12345678"
+		adminpassword                = "secure-Password12345"
 		service_endpoints            = "public"
 
 		group {
@@ -422,7 +422,7 @@ func testAccCheckIBMDatabaseInstanceElasticsearchGroupMigration(databaseResource
 		service                      = "databases-for-elasticsearch"
 		plan                         = "standard"
 		location                     = "%[3]s"
-		adminpassword                = "password12345678"
+		adminpassword                = "secure-Password12345"
 		service_endpoints            = "public"
 
 		group {
@@ -461,7 +461,7 @@ func testAccCheckIBMDatabaseInstanceElasticsearchNodeBasic(databaseResourceGroup
 		service                      = "databases-for-elasticsearch"
 		plan                         = "standard"
 		location                     = "%[3]s"
-		adminpassword                = "password12345678"
+		adminpassword                = "secure-Password12345"
 		service_endpoints            = "public"
 
 		group {
@@ -484,7 +484,7 @@ func testAccCheckIBMDatabaseInstanceElasticsearchNodeBasic(databaseResourceGroup
 		}
 		users {
 		  name     = "user123"
-		  password = "password12345678"
+		  password = "secure-Password12345"
 		}
 		allowlist {
 		  address     = "172.168.1.2/32"
@@ -513,7 +513,7 @@ func testAccCheckIBMDatabaseInstanceElasticsearchNodeFullyspecified(databaseReso
 		service                      = "databases-for-elasticsearch"
 		plan                         = "standard"
 		location                     = "%[3]s"
-		adminpassword                = "password12345678"
+		adminpassword                = "secure-Password12345"
 		service_endpoints            = "public"
 		group {
 			group_id = "member"
@@ -535,11 +535,11 @@ func testAccCheckIBMDatabaseInstanceElasticsearchNodeFullyspecified(databaseReso
 		}
 		users {
 		  name     = "user123"
-		  password = "password12345678"
+		  password = "secure-Password12345"
 		}
 		users {
 		  name     = "user124"
-		  password = "password12345678"
+		  password = "secure-Password12345"
 		}
 		allowlist {
 		  address     = "172.168.1.2/32"
@@ -572,7 +572,7 @@ func testAccCheckIBMDatabaseInstanceElasticsearchNodeReduced(databaseResourceGro
 		service                      = "databases-for-elasticsearch"
 		plan                         = "standard"
 		location                     = "%[3]s"
-		adminpassword                = "password12345678"
+		adminpassword                = "secure-Password12345"
 		service_endpoints            = "public"
 		group {
 			group_id = "member"
@@ -615,7 +615,7 @@ func testAccCheckIBMDatabaseInstanceElasticsearchNodeScaleOut(databaseResourceGr
 		service                      = "databases-for-elasticsearch"
 		plan                         = "standard"
 		location                     = "%[3]s"
-		adminpassword                = "password12345678"
+		adminpassword                = "secure-Password12345"
 		service_endpoints            = "public"
 		group {
 			group_id = "member"
@@ -658,7 +658,7 @@ func testAccCheckIBMDatabaseInstanceElasticsearchGroupBasic(databaseResourceGrou
 		service                      = "databases-for-elasticsearch"
 		plan                         = "standard"
 		location                     = "%[3]s"
-		adminpassword                = "password12345678"
+		adminpassword                = "secure-Password12345"
 		service_endpoints            = "public"
 
 		group {
@@ -682,7 +682,7 @@ func testAccCheckIBMDatabaseInstanceElasticsearchGroupBasic(databaseResourceGrou
 
 		users {
 		  name     = "user123"
-		  password = "password12345678"
+		  password = "secure-Password12345"
 		}
 		allowlist {
 		  address     = "172.168.1.2/32"
@@ -711,7 +711,7 @@ func testAccCheckIBMDatabaseInstanceElasticsearchGroupFullyspecified(databaseRes
 		service                      = "databases-for-elasticsearch"
 		plan                         = "standard"
 		location                     = "%[3]s"
-		adminpassword                = "password12345678"
+		adminpassword                = "secure-Password12345"
 		service_endpoints            = "public"
 
 		group {
@@ -734,11 +734,11 @@ func testAccCheckIBMDatabaseInstanceElasticsearchGroupFullyspecified(databaseRes
 		}
 		users {
 		  name     = "user123"
-		  password = "password12345678"
+		  password = "secure-Password12345"
 		}
 		users {
 		  name     = "user124"
-		  password = "password12345678"
+		  password = "secure-Password12345"
 		}
 		allowlist {
 		  address     = "172.168.1.2/32"
@@ -772,7 +772,7 @@ func testAccCheckIBMDatabaseInstanceElasticsearchGroupReduced(databaseResourceGr
 		service                      = "databases-for-elasticsearch"
 		plan                         = "standard"
 		location                     = "%[3]s"
-		adminpassword                = "password12345678"
+		adminpassword                = "secure-Password12345"
 		service_endpoints            = "public"
 
 		group {
@@ -816,7 +816,7 @@ func testAccCheckIBMDatabaseInstanceElasticsearchGroupScaleOut(databaseResourceG
 		service                      = "databases-for-elasticsearch"
 		plan                         = "standard"
 		location                     = "%[3]s"
-		adminpassword                = "password12345678"
+		adminpassword                = "secure-Password12345"
 		service_endpoints            = "public"
 
 		group {

--- a/ibm/service/database/resource_ibm_database_etcd_test.go
+++ b/ibm/service/database/resource_ibm_database_etcd_test.go
@@ -122,7 +122,7 @@ func testAccCheckIBMDatabaseInstanceEtcdBasic(databaseResourceGroup string, name
 		service                      = "databases-for-etcd"
 		plan                         = "standard"
 		location                     = "%[3]s"
-		adminpassword                = "password12345678"
+		adminpassword                = "secure-Password12345"
 		service_endpoints            = "public-and-private"
 		group {
 			group_id = "member"
@@ -138,7 +138,7 @@ func testAccCheckIBMDatabaseInstanceEtcdBasic(databaseResourceGroup string, name
 		}
 		users {
 		  name     = "user123"
-		  password = "password12345678"
+		  password = "secure-Password12345"
 		}
 		allowlist {
 		  address     = "172.168.1.2/32"
@@ -161,7 +161,7 @@ func testAccCheckIBMDatabaseInstanceEtcdFullyspecified(databaseResourceGroup str
 		service                      = "databases-for-etcd"
 		plan                         = "standard"
 		location                     = "%[3]s"
-		adminpassword                = "password12345678"
+		adminpassword                = "secure-Password12345"
 		service_endpoints            = "public-and-private"
 		group {
 			group_id = "member"
@@ -174,11 +174,11 @@ func testAccCheckIBMDatabaseInstanceEtcdFullyspecified(databaseResourceGroup str
 		}
 		users {
 		  name     = "user123"
-		  password = "password12345678"
+		  password = "secure-Password12345"
 		}
 		users {
 		  name     = "user124"
-		  password = "password12345678"
+		  password = "secure-Password12345"
 		}
 		allowlist {
 		  address     = "172.168.1.2/32"
@@ -206,7 +206,7 @@ func testAccCheckIBMDatabaseInstanceEtcdReduced(databaseResourceGroup string, na
 		service                      = "databases-for-etcd"
 		plan                         = "standard"
 		location                     = "%[3]s"
-		adminpassword                = "password12345678"
+		adminpassword                = "secure-Password12345"
 		service_endpoints            = "public-and-private"
 		group {
 			group_id = "member"

--- a/ibm/service/database/resource_ibm_database_mongodb_enterprise_test.go
+++ b/ibm/service/database/resource_ibm_database_mongodb_enterprise_test.go
@@ -189,7 +189,7 @@ func testAccCheckIBMDatabaseInstanceMongoDBEnterpriseBasic(databaseResourceGroup
 		service                      = "databases-for-mongodb"
 		plan                         = "enterprise"
 		location                     = "%[3]s"
-		adminpassword                = "password12345678"
+		adminpassword                = "secure-Password12345"
 		tags                         = ["one:two"]
 		service_endpoints            = "public"
 		group {
@@ -203,7 +203,7 @@ func testAccCheckIBMDatabaseInstanceMongoDBEnterpriseBasic(databaseResourceGroup
 		}
 		users {
 		  name     = "user123"
-		  password = "password12345678"
+		  password = "secure-Password12345"
 		  type     = "database"
 		}
 		allowlist {
@@ -231,7 +231,7 @@ func testAccCheckIBMDatabaseInstanceMongoDBEnterpriseFullyspecified(databaseReso
 		service                      = "databases-for-mongodb"
 		plan                         = "enterprise"
 		location                     = "%[3]s"
-		adminpassword                = "password12345678"
+		adminpassword                = "secure-Password12345"
 		tags                         = ["one:two"]
 		service_endpoints            = "public"
 		group {
@@ -245,12 +245,12 @@ func testAccCheckIBMDatabaseInstanceMongoDBEnterpriseFullyspecified(databaseReso
 		}
 		users {
 		  name     = "user123"
-		  password = "password12345678"
+		  password = "secure-Password12345"
 		  type     = "database"
 		}
 		users {
 		  name     = "user124"
-		  password = "password12345678$password"
+		  password = "secure-Password12345$password"
 		  type     = "ops_manager"
 		}
 		allowlist {
@@ -282,7 +282,7 @@ func testAccCheckIBMDatabaseInstanceMongoDBEnterpriseReduced(databaseResourceGro
 		service                      = "databases-for-mongodb"
 		plan                         = "enterprise"
 		location                     = "%[3]s"
-		adminpassword                = "password12345678"
+		adminpassword                = "secure-Password12345"
 		service_endpoints            = "public"
 		tags                         = ["one:two"]
 		group {
@@ -315,7 +315,7 @@ func testAccCheckIBMDatabaseInstanceMongoDBEnterpriseGroupBasic(databaseResource
 		service                      = "databases-for-mongodb"
 		plan                         = "enterprise"
 		location                     = "%[3]s"
-		adminpassword                = "password12345678"
+		adminpassword                = "secure-Password12345"
 		tags                         = ["one:two"]
 		service_endpoints            = "public"
 

--- a/ibm/service/database/resource_ibm_database_mongodb_sharding_test.go
+++ b/ibm/service/database/resource_ibm_database_mongodb_sharding_test.go
@@ -85,7 +85,7 @@ func testAccCheckIBMDatabaseInstanceMongoDBShardingBasic(databaseResourceGroup s
 		service                      = "databases-for-mongodb"
 		plan                         = "enterprise-sharding"
 		location                     = "%[3]s"
-		adminpassword                = "password12345678"
+		adminpassword                = "secure-Password12345"
 		group {
 			group_id = "member"
 			host_flavor {
@@ -98,7 +98,7 @@ func testAccCheckIBMDatabaseInstanceMongoDBShardingBasic(databaseResourceGroup s
 		service_endpoints            = "public"
 		users {
 		  name     = "user123"
-		  password = "password12345678"
+		  password = "secure-Password12345"
 		  type     = "database"
 		}
 		allowlist {
@@ -126,7 +126,7 @@ func testAccCheckIBMDatabaseInstanceMongoDBShardingFullyspecified(databaseResour
 		service                      = "databases-for-mongodb"
 		plan                         = "enterprise-sharding"
 		location                     = "%[3]s"
-		adminpassword                = "password12345678"
+		adminpassword                = "secure-Password12345"
 		group {
 			group_id = "member"
 			host_flavor {
@@ -139,12 +139,12 @@ func testAccCheckIBMDatabaseInstanceMongoDBShardingFullyspecified(databaseResour
 		service_endpoints            = "public"
 		users {
 		  name     = "user123"
-		  password = "password12345678"
+		  password = "secure-Password12345"
 		  type     = "database"
 		}
 		users {
 		  name     = "user124"
-		  password = "password$12password"
+		  password = "password$12Password"
 		  type     = "ops_manager"
 		}
 		allowlist {
@@ -176,7 +176,7 @@ func testAccCheckIBMDatabaseInstanceMongoDBShardingReduced(databaseResourceGroup
 		service                      = "databases-for-mongodb"
 		plan                         = "enterprise-sharding"
 		location                     = "%[3]s"
-		adminpassword                = "password12345678"
+		adminpassword                = "secure-Password12345"
 		group {
 			group_id = "member"
 			host_flavor {

--- a/ibm/service/database/resource_ibm_database_mongodb_test.go
+++ b/ibm/service/database/resource_ibm_database_mongodb_test.go
@@ -126,7 +126,7 @@ func testAccCheckIBMDatabaseInstanceMongodbBasic(databaseResourceGroup string, n
 		service                      = "databases-for-mongodb"
 		plan                         = "standard"
 		location                     = "%[3]s"
-		adminpassword                = "password12345678"
+		adminpassword                = "secure-Password12345"
 		service_endpoints            = "public"
 		group {
 			group_id = "member"
@@ -142,7 +142,7 @@ func testAccCheckIBMDatabaseInstanceMongodbBasic(databaseResourceGroup string, n
 		}
 		users {
 		  name     = "user123"
-		  password = "password12345678"
+		  password = "secure-Password12345"
 		}
 		allowlist {
 		  address     = "172.168.1.2/32"
@@ -164,7 +164,7 @@ func testAccCheckIBMDatabaseInstanceMongodbFullyspecified(databaseResourceGroup 
 		service                      = "databases-for-mongodb"
 		plan                         = "standard"
 		location                     = "%[3]s"
-		adminpassword                = "password12345678"
+		adminpassword                = "secure-Password12345"
 		service_endpoints            = "public"
 		group {
 			group_id = "member"
@@ -180,11 +180,11 @@ func testAccCheckIBMDatabaseInstanceMongodbFullyspecified(databaseResourceGroup 
 		}
 		users {
 		  name     = "user123"
-		  password = "password12345678"
+		  password = "secure-Password12345"
 		}
 		users {
 		  name     = "user124"
-		  password = "password12345678"
+		  password = "secure-Password12345"
 		}
 		allowlist {
 		  address     = "172.168.1.2/32"
@@ -210,7 +210,7 @@ func testAccCheckIBMDatabaseInstanceMongodbReduced(databaseResourceGroup string,
 		service                      = "databases-for-mongodb"
 		plan                         = "standard"
 		location                     = "%[3]s"
-		adminpassword                = "password12345678"
+		adminpassword                = "secure-Password12345"
 		service_endpoints            = "public"
 		group {
 			group_id = "member"

--- a/ibm/service/database/resource_ibm_database_mysql_test.go
+++ b/ibm/service/database/resource_ibm_database_mysql_test.go
@@ -180,7 +180,7 @@ func testAccCheckIBMDatabaseInstanceMysqlBasic(databaseResourceGroup string, nam
 		service                      = "databases-for-mysql"
 		plan                         = "standard"
 		location                     = "%[3]s"
-		adminpassword                = "password12345678"
+		adminpassword                = "secure-Password12345"
 		group {
 			group_id = "member"
 			memory {
@@ -197,7 +197,7 @@ func testAccCheckIBMDatabaseInstanceMysqlBasic(databaseResourceGroup string, nam
 		tags                         = ["one:two"]
 		users {
 			name     = "user123"
-			password = "password12345678"
+			password = "secure-Password12345"
 		}
 		allowlist {
 			address     = "172.168.1.2/32"
@@ -224,7 +224,7 @@ func testAccCheckIBMDatabaseInstanceMysqlFullyspecified(databaseResourceGroup st
 		service                      = "databases-for-mysql"
 		plan                         = "standard"
 		location                     = "%[3]s"
-		adminpassword                = "password12345678"
+		adminpassword                = "secure-Password12345"
 		group {
 			group_id = "member"
 			memory {
@@ -244,11 +244,11 @@ func testAccCheckIBMDatabaseInstanceMysqlFullyspecified(databaseResourceGroup st
 		tags                         = ["one:two"]
 		users {
 			name     = "user123"
-			password = "password12345678"
+			password = "secure-Password12345"
 		}
 		users {
 			name     = "user124"
-			password = "password12345678"
+			password = "secure-Password12345"
 		}
 		allowlist {
 			address     = "172.168.1.2/32"

--- a/ibm/service/database/resource_ibm_database_postgresql_test.go
+++ b/ibm/service/database/resource_ibm_database_postgresql_test.go
@@ -308,10 +308,11 @@ func testAccCheckIBMDatabaseInstancePostgresBasic(databaseResourceGroup string, 
 		service                      = "databases-for-postgresql"
 		plan                         = "standard"
 		location                     = "%[3]s"
-		adminpassword                = "password12345678"
+		adminpassword                = "secure-Password12345"
 		service_endpoints            = "public"
 		group {
 			group_id = "member"
+
 			memory {
 			  allocation_mb = 4096
 			}
@@ -325,7 +326,7 @@ func testAccCheckIBMDatabaseInstancePostgresBasic(databaseResourceGroup string, 
 		tags                         = ["one:two"]
 		users {
 			name     = "user123"
-			password = "password12345678"
+			password = "secure-Password12345"
 		}
 		allowlist {
 			address     = "172.168.1.2/32"
@@ -359,7 +360,7 @@ func testAccCheckIBMDatabaseInstancePostgresFullyspecified(databaseResourceGroup
 		service                      = "databases-for-postgresql"
 		plan                         = "standard"
 		location                     = "%[3]s"
-		adminpassword                = "password12345678"
+		adminpassword                = "secure-Password12345"
 		group {
 			group_id = "member"
 			memory {
@@ -379,15 +380,15 @@ func testAccCheckIBMDatabaseInstancePostgresFullyspecified(databaseResourceGroup
 		tags                         = ["one:two"]
 		users {
 			name     = "user123"
-			password = "password12345678"
+			password = "secure-Password12345"
 		}
 		users {
 			name     = "user124"
-			password = "password12345678"
+			password = "secure-Password12345"
 		}
 		users {
 			name     = "repl"
-			password = "repl123456password"
+			password = "repl123456Password"
 		}
 		configuration                   = <<CONFIGURATION
 		{
@@ -430,7 +431,7 @@ func testAccCheckIBMDatabaseInstancePostgresGroupBasic(databaseResourceGroup str
 		service                      = "databases-for-postgresql"
 		plan                         = "standard"
 		location                     = "%[3]s"
-		adminpassword                = "password12345678"
+		adminpassword                = "secure-Password12345"
 		tags                         = ["one:two"]
 		group {
 			group_id = "member"
@@ -453,7 +454,7 @@ func testAccCheckIBMDatabaseInstancePostgresGroupBasic(databaseResourceGroup str
 		service_endpoints            = "public"
 		users {
 			name     = "user123"
-			password = "password12345678"
+			password = "secure-Password12345"
 		}
 		allowlist {
 			address     = "172.168.1.2/32"
@@ -475,7 +476,7 @@ func testAccCheckIBMDatabaseInstancePostgresGroupFullyspecified(databaseResource
 		service                      = "databases-for-postgresql"
 		plan                         = "standard"
 		location                     = "%[3]s"
-		adminpassword                = "password12345678"
+		adminpassword                = "secure-Password12345"
 		service_endpoints            = "public-and-private"
 		tags                         = ["one:two"]
 		group {
@@ -498,11 +499,11 @@ func testAccCheckIBMDatabaseInstancePostgresGroupFullyspecified(databaseResource
 		}
 		users {
 			name     = "user123"
-			password = "password12345678"
+			password = "secure-Password12345"
 		}
 		users {
 			name     = "user124"
-			password = "password12345678"
+			password = "secure-Password12345"
 		}
 		allowlist {
 			address     = "172.168.1.2/32"
@@ -528,7 +529,7 @@ func testAccCheckIBMDatabaseInstancePostgresGroupReduced(databaseResourceGroup s
 		service                      = "databases-for-postgresql"
 		plan                         = "standard"
 		location                     = "%[3]s"
-		adminpassword                = "password12345678"
+		adminpassword                = "secure-Password12345"
 		service_endpoints            = "public"
 		tags                         = ["one:two"]
 		group {
@@ -565,7 +566,7 @@ func testAccCheckIBMDatabaseInstancePostgresGroupScaleOut(databaseResourceGroup 
 		service                      = "databases-for-postgresql"
 		plan                         = "standard"
 		location                     = "%[3]s"
-		adminpassword                = "password12345678"
+		adminpassword                = "secure-Password12345"
 		group {
 			group_id = "member"
 			members {

--- a/ibm/service/database/resource_ibm_database_rabbitmq_test.go
+++ b/ibm/service/database/resource_ibm_database_rabbitmq_test.go
@@ -129,7 +129,7 @@ func testAccCheckIBMDatabaseInstanceRabbitmqBasic(databaseResourceGroup string, 
 		service                      = "messages-for-rabbitmq"
 		plan                         = "standard"
 		location                     = "%[3]s"
-		adminpassword                = "password12345678"
+		adminpassword                = "secure-Password12345"
 		service_endpoints            = "public"
 		group {
 			group_id = "member"
@@ -145,7 +145,7 @@ func testAccCheckIBMDatabaseInstanceRabbitmqBasic(databaseResourceGroup string, 
 		}
 		users {
 			name     = "user123"
-			password = "password12345678"
+			password = "secure-Password12345"
 		}
 		allowlist {
 			address     = "172.168.1.2/32"
@@ -173,7 +173,7 @@ func testAccCheckIBMDatabaseInstanceRabbitmqFullyspecified(databaseResourceGroup
 		service                      = "messages-for-rabbitmq"
 		plan                         = "standard"
 		location                     = "%[3]s"
-		adminpassword                = "password12345678"
+		adminpassword                = "secure-Password12345"
 		service_endpoints            = "public"
 		group {
 			group_id = "member"
@@ -189,11 +189,11 @@ func testAccCheckIBMDatabaseInstanceRabbitmqFullyspecified(databaseResourceGroup
 		}
 		users {
 			name     = "user123"
-			password = "password12345678"
+			password = "secure-Password12345"
 		}
 		users {
 			name     = "user124"
-			password = "password12345678"
+			password = "secure-Password12345"
 		}
 		allowlist {
 			address     = "172.168.1.2/32"
@@ -221,7 +221,7 @@ func testAccCheckIBMDatabaseInstanceRabbitmqReduced(databaseResourceGroup string
 		service                      = "messages-for-rabbitmq"
 		plan                         = "standard"
 		location                     = "%[3]s"
-		adminpassword                = "password12345678"
+		adminpassword                = "secure-Password12345"
 		service_endpoints            = "public"
 		group {
 			group_id = "member"

--- a/ibm/service/database/resource_ibm_database_redis_test.go
+++ b/ibm/service/database/resource_ibm_database_redis_test.go
@@ -164,7 +164,7 @@ func testAccCheckIBMDatabaseInstanceRedisBasic(databaseResourceGroup string, nam
 		service                      = "databases-for-redis"
 		plan                         = "standard"
 		location                     = "%[3]s"
-		adminpassword                = "password12345678"
+		adminpassword                = "secure-Password12345"
 		service_endpoints            = "public"
 		group {
 			group_id = "member"
@@ -208,7 +208,7 @@ func testAccCheckIBMDatabaseInstanceRedisFullyspecified(databaseResourceGroup st
 		service                      = "databases-for-redis"
 		plan                         = "standard"
 		location                     = "%[3]s"
-		adminpassword                = "password12345678"
+		adminpassword                = "secure-Password12345"
 		service_endpoints            = "public"
 		group {
 			group_id = "member"
@@ -247,7 +247,7 @@ func testAccCheckIBMDatabaseInstanceRedisReduced(databaseResourceGroup string, n
 		service                      = "databases-for-redis"
 		plan                         = "standard"
 		location                     = "%[3]s"
-		adminpassword                = "password12345678"
+		adminpassword                = "secure-Password12345"
 		service_endpoints            = "public"
 		group {
 			group_id = "member"
@@ -277,7 +277,7 @@ func testAccCheckIBMDatabaseInstanceRedisUserRole(databaseResourceGroup string, 
 		service                      = "databases-for-redis"
 		plan                         = "standard"
 		location                     = "%[3]s"
-		adminpassword                = "password12345678"
+		adminpassword                = "secure-Password12345"
 		service_endpoints            = "public"
 
 		group {
@@ -296,7 +296,7 @@ func testAccCheckIBMDatabaseInstanceRedisUserRole(databaseResourceGroup string, 
 
 		users {
 			name = "coolguy"
-    		password = "securepassword123"
+    		password = "securePassword123"
       		role     = "-@all +@read"
 	 	}
   	}

--- a/ibm/service/database/resource_ibm_database_test.go
+++ b/ibm/service/database/resource_ibm_database_test.go
@@ -19,7 +19,7 @@ func TestValidateUserPassword(t *testing.T) {
 		{
 			user: DatabaseUser{
 				Username: "testy",
-				Password: "pizzapizzapizza",
+				Password: "Pizzapizzapizza",
 				Type:     "database",
 			},
 			expectedError: "database user (testy) validation error:\npassword must contain at least one number",
@@ -27,10 +27,10 @@ func TestValidateUserPassword(t *testing.T) {
 		{
 			user: DatabaseUser{
 				Username: "testy",
-				Password: "-_pizzapizzapizza",
+				Password: "-_Pizzapizzapizza123",
 				Type:     "database",
 			},
-			expectedError: "database user (testy) validation error:\npassword must not begin with a special character (_-)\npassword must contain at least one number",
+			expectedError: "database user (testy) validation error:\npassword must not begin with a special character (_-)",
 		},
 		{
 			user: DatabaseUser{
@@ -38,15 +38,15 @@ func TestValidateUserPassword(t *testing.T) {
 				Password: "111111111111111",
 				Type:     "database",
 			},
-			expectedError: "database user (testy) validation error:\npassword must contain at least one letter",
+			expectedError: "database user (testy) validation error:\npassword must contain at least one lower case letter\npassword must contain at least one upper case letter",
 		},
 		{
 			user: DatabaseUser{
 				Username: "testy",
-				Password: "$$$$$$$$$$$$$$a1",
+				Password: "abcd-ABCD-12345_coolguy",
 				Type:     "database",
 			},
-			expectedError: "database user (testy) validation error:\npassword must not contain invalid characters",
+			expectedError: "",
 		},
 		{
 			user: DatabaseUser{
@@ -54,12 +54,12 @@ func TestValidateUserPassword(t *testing.T) {
 				Password: "$",
 				Type:     "database",
 			},
-			expectedError: "database user (testy) validation error:\npassword must contain at least one letter\npassword must contain at least one number\npassword must not contain invalid characters",
+			expectedError: "database user (testy) validation error:\npassword must contain at least one lower case letter\npassword must contain at least one upper case letter\npassword must contain at least one number\npassword must not contain invalid characters",
 		},
 		{
 			user: DatabaseUser{
 				Username: "testy",
-				Password: "aaaaa11111aaaa",
+				Password: "aaaaa11111aaaaA",
 				Type:     "ops_manager",
 			},
 			expectedError: "database user (testy) validation error:\npassword must contain at least one special character (~!@#$%^&*()=+[]{}|;:,.<>/?_-)",
@@ -67,7 +67,7 @@ func TestValidateUserPassword(t *testing.T) {
 		{
 			user: DatabaseUser{
 				Username: "testy",
-				Password: "password12345678$password",
+				Password: "secure-Password12345$Password",
 				Type:     "ops_manager",
 			},
 			expectedError: "",
@@ -78,12 +78,12 @@ func TestValidateUserPassword(t *testing.T) {
 				Password: "~!@#$%^&*()=+[]{}|;:,.<>/?_-",
 				Type:     "ops_manager",
 			},
-			expectedError: "database user (testy) validation error:\npassword must contain at least one letter\npassword must contain at least one number",
+			expectedError: "database user (testy) validation error:\npassword must contain at least one lower case letter\npassword must contain at least one upper case letter\npassword must contain at least one number",
 		},
 		{
 			user: DatabaseUser{
 				Username: "testy",
-				Password: "~!@#$%^&*()=+[]{}|;:,.<>/?_-a1",
+				Password: "~!@#$%^&*()=+[]{}|;:,.<>/?_-aA1",
 				Type:     "ops_manager",
 			},
 			expectedError: "",
@@ -91,7 +91,7 @@ func TestValidateUserPassword(t *testing.T) {
 		{
 			user: DatabaseUser{
 				Username: "testy",
-				Password: "pizza1pizzapizza1",
+				Password: "Pizza1pizzapizza1",
 				Type:     "database",
 			},
 			expectedError: "",
@@ -101,7 +101,8 @@ func TestValidateUserPassword(t *testing.T) {
 		err := tc.user.ValidatePassword()
 		if tc.expectedError == "" {
 			if err != nil {
-				t.Errorf("TestValidateUserPassword: %q, %q unexpected error: %q", tc.user.Username, tc.user.Password, err.Error())
+				t.Logf("TestValidateUserPassword: %q, %q unexpected error: %q", tc.user.Username, tc.user.Password, err.Error())
+				t.Fail()
 			}
 		} else {
 			assert.Equal(t, tc.expectedError, err.Error())


### PR DESCRIPTION
This reverts commit 768de219360537b8bd0e49e9c383bd27f2b9c413.

Original PR: https://github.com/IBM-Cloud/terraform-provider-ibm/pull/5701

> IBM Cloud Databases will begin enforcing password complexity validation for database users created using the IBM Cloud console, CLI, API and Terraform. Database user passwords will be required to be a minimum of 15 characters, contain at least one letter and number and a mix of uppercase and lowercase letters.

This PR will enforce the new password complexity requirements for the `ibm_database` resource

<!--- See what makes a good Pull Request at : https://github.com/IBM-Cloud/terraform-provider-ibm/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
make testacc TESTARGS='-run=TestAccIBMDatabaseInstance'

--- PASS: TestAccIBMDatabaseInstanceEDBReadReplicaPromotion (2582.95s)
--- PASS: TestAccIBMDatabaseInstanceElasticsearchImport (362.50s)
--- PASS: TestAccIBMDatabaseInstanceEtcdImport (564.16s)
--- PASS: TestAccIBMDatabaseInstanceMongodbBasic (1137.46s)
--- PASS: TestAccIBMDatabaseInstanceMongodbImport (413.52s)
--- PASS: TestAccIBMDatabaseInstanceMySQLReadReplicaPromotion (1232.17s)
--- PASS: TestAccIBMDatabaseInstancePostgresBasic (1247.36s)
--- PASS: TestAccIBMDatabaseInstancePostgresGroup (2089.95s)
--- PASS: TestAccIBMDatabaseInstancePostgresImport (629.16s)
--- PASS: TestAccIBMDatabaseInstancePostgresPITR (1444.50s)
--- PASS: TestAccIBMDatabaseInstancePostgresReadReplicaPromotion (1473.86s)
--- PASS: TestAccIBMDatabaseInstanceRabbitmqImport (465.61s)
--- PASS: TestAccIBMDatabaseInstanceRedisImport (478.76s)
--- PASS: TestAccIBMDatabaseInstance_ElasticsearchPlatinum_Group (1334.44s)
--- PASS: TestAccIBMDatabaseInstance_ElasticsearchPlatinum_Node (1820.28s)
--- PASS: TestAccIBMDatabaseInstance_Elasticsearch_Basic (722.37s)
--- PASS: TestAccIBMDatabaseInstance_Elasticsearch_Node (1829.77s)
--- PASS: TestAccIBMDatabaseInstance_Etcd_Basic (2921.06s)
--- PASS: TestAccIBMDatabaseInstance_Rabbitmq_Basic (933.21s)
--- PASS: TestAccIBMDatabaseInstance_Redis_Basic (1010.33s)

$ go test github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/database 
 
ok  	github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/database	0.923s

...
```
