### PR TITLE
Update NSG datasources and resources

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -99,6 +99,10 @@ github.com/IBM-Cloud/container-services-go-sdk v0.0.0-20240725064144-454a2ae2311
 github.com/IBM-Cloud/ibm-cloud-cli-sdk v0.5.3/go.mod h1:RiUvKuHKTBmBApDMUQzBL14pQUGKcx/IioKQPIcRQjs=
 github.com/IBM-Cloud/power-go-client v1.10.0 h1:yBUHWwvNBmLkWpbZJQJEXoxBa1Dm+eJgMSbk9ljmXUU=
 github.com/IBM-Cloud/power-go-client v1.10.0/go.mod h1:UDyXeIKEp6r7yWUXYu3r0ZnFSlNZ2YeQTHwM2Tmlgv0=
+github.com/IBM-Cloud/power-go-client v1.10.0-beta7 h1:nxAuY/0axYwOq2jb2jVZqu3nmPP/7/sFC6HCi8RhMUA=
+github.com/IBM-Cloud/power-go-client v1.10.0-beta7/go.mod h1:UDyXeIKEp6r7yWUXYu3r0ZnFSlNZ2YeQTHwM2Tmlgv0=
+github.com/IBM-Cloud/power-go-client v1.10.0 h1:yBUHWwvNBmLkWpbZJQJEXoxBa1Dm+eJgMSbk9ljmXUU=
+github.com/IBM-Cloud/power-go-client v1.10.0/go.mod h1:UDyXeIKEp6r7yWUXYu3r0ZnFSlNZ2YeQTHwM2Tmlgv0=
 github.com/IBM-Cloud/softlayer-go v1.0.5-tf h1:koUAyF9b6X78lLLruGYPSOmrfY2YcGYKOj/Ug9nbKNw=
 github.com/IBM-Cloud/softlayer-go v1.0.5-tf/go.mod h1:6HepcfAXROz0Rf63krk5hPZyHT6qyx2MNvYyHof7ik4=
 github.com/IBM/apigateway-go-sdk v0.0.0-20210714141226-a5d5d49caaca h1:crniVcf+YcmgF03NmmfonXwSQ73oJF+IohFYBwknMxs=

--- a/ibm/service/power/data_source_ibm_pi_network_security_group.go
+++ b/ibm/service/power/data_source_ibm_pi_network_security_group.go
@@ -41,6 +41,11 @@ func DataSourceIBMPINetworkSecurityGroup() *schema.Resource {
 				Description: "The network security group's crn.",
 				Type:        schema.TypeString,
 			},
+			Attr_Default: {
+				Computed:    true,
+				Description: "Indicates if the network security group is the default network security group in the workspace.",
+				Type:        schema.TypeBool,
+			},
 			Attr_Members: {
 				Computed:    true,
 				Description: "The list of IPv4 addresses and, or network interfaces in the network security group.",
@@ -54,6 +59,11 @@ func DataSourceIBMPINetworkSecurityGroup() *schema.Resource {
 						Attr_MacAddress: {
 							Computed:    true,
 							Description: "The mac address of a network interface included if the type is network-interface.",
+							Type:        schema.TypeString,
+						},
+						Attr_NetworkInterfaceID: {
+							Computed:    true,
+							Description: "The network ID of a network interface included if the type is network-interface.",
 							Type:        schema.TypeString,
 						},
 						Attr_Target: {
@@ -218,6 +228,7 @@ func dataSourceIBMPINetworkSecurityGroupRead(ctx context.Context, d *schema.Reso
 		}
 		d.Set(Attr_UserTags, userTags)
 	}
+	d.Set(Attr_Default, networkSecurityGroup.Default)
 
 	if len(networkSecurityGroup.Members) > 0 {
 		members := []map[string]interface{}{}
@@ -247,6 +258,9 @@ func networkSecurityGroupMemberToMap(mbr *models.NetworkSecurityGroupMember) map
 	mbrMap[Attr_ID] = mbr.ID
 	if mbr.MacAddress != "" {
 		mbrMap[Attr_MacAddress] = mbr.MacAddress
+	}
+	if mbr.NetworkInterfaceNetworkID != "" {
+		mbrMap[Attr_NetworkInterfaceID] = mbr.NetworkInterfaceNetworkID
 	}
 	mbrMap[Attr_Target] = mbr.Target
 	mbrMap[Attr_Type] = mbr.Type

--- a/ibm/service/power/data_source_ibm_pi_network_security_groups.go
+++ b/ibm/service/power/data_source_ibm_pi_network_security_groups.go
@@ -41,6 +41,11 @@ func DataSourceIBMPINetworkSecurityGroups() *schema.Resource {
 							Description: "The network security group's crn.",
 							Type:        schema.TypeString,
 						},
+						Attr_Default: {
+							Computed:    true,
+							Description: "Indicates if the network security group is the default network security group in the workspace.",
+							Type:        schema.TypeBool,
+						},
 						Attr_ID: {
 							Computed:    true,
 							Description: "The ID of the network security group.",
@@ -59,6 +64,11 @@ func DataSourceIBMPINetworkSecurityGroups() *schema.Resource {
 									Attr_MacAddress: {
 										Computed:    true,
 										Description: "The mac address of a network interface included if the type is network-interface.",
+										Type:        schema.TypeString,
+									},
+									Attr_NetworkInterfaceID: {
+										Computed:    true,
+										Description: "The network ID of a network interface included if the type is network-interface.",
 										Type:        schema.TypeString,
 									},
 									Attr_Target: {
@@ -243,6 +253,7 @@ func networkSecurityGroupToMap(nsg *models.NetworkSecurityGroup, meta interface{
 		}
 		networkSecurityGroup[Attr_UserTags] = userTags
 	}
+	networkSecurityGroup[Attr_Default] = nsg.Default
 
 	networkSecurityGroup[Attr_ID] = nsg.ID
 	if len(nsg.Members) > 0 {

--- a/ibm/service/power/resource_ibm_pi_network_security_group.go
+++ b/ibm/service/power/resource_ibm_pi_network_security_group.go
@@ -68,6 +68,11 @@ func ResourceIBMPINetworkSecurityGroup() *schema.Resource {
 				Description: "The network security group's crn.",
 				Type:        schema.TypeString,
 			},
+			Attr_Default: {
+				Computed:    true,
+				Description: "Indicates if the network security group is the default network security group in the workspace.",
+				Type:        schema.TypeBool,
+			},
 			Attr_Members: {
 				Computed:    true,
 				Description: "The list of IPv4 addresses and, or network interfaces in the network security group.",
@@ -81,6 +86,11 @@ func ResourceIBMPINetworkSecurityGroup() *schema.Resource {
 						Attr_MacAddress: {
 							Computed:    true,
 							Description: "The mac address of a network interface included if the type is network-interface.",
+							Type:        schema.TypeString,
+						},
+						Attr_NetworkInterfaceID: {
+							Computed:    true,
+							Description: "The network ID of a network interface included if the type is network-interface.",
 							Type:        schema.TypeString,
 						},
 						Attr_Target: {
@@ -280,6 +290,7 @@ func resourceIBMPINetworkSecurityGroupRead(ctx context.Context, d *schema.Resour
 		}
 		d.Set(Arg_UserTags, userTags)
 	}
+	d.Set(Attr_Default, networkSecurityGroup.Default)
 
 	if len(networkSecurityGroup.Members) > 0 {
 		members := []map[string]interface{}{}

--- a/ibm/service/power/resource_ibm_pi_network_security_group_member.go
+++ b/ibm/service/power/resource_ibm_pi_network_security_group_member.go
@@ -79,6 +79,11 @@ func ResourceIBMPINetworkSecurityGroupMember() *schema.Resource {
 				Description: "The network security group's crn.",
 				Type:        schema.TypeString,
 			},
+			Attr_Default: {
+				Computed:    true,
+				Description: "Indicates if the network security group is the default network security group in the workspace.",
+				Type:        schema.TypeBool,
+			},
 			Attr_Members: {
 				Computed:    true,
 				Description: "The list of IPv4 addresses and, or network interfaces in the network security group.",
@@ -92,6 +97,11 @@ func ResourceIBMPINetworkSecurityGroupMember() *schema.Resource {
 						Attr_MacAddress: {
 							Computed:    true,
 							Description: "The mac address of a network interface included if the type is network-interface.",
+							Type:        schema.TypeString,
+						},
+						Attr_NetworkInterfaceID: {
+							Computed:    true,
+							Description: "The network ID of a network interface included if the type is network-interface.",
 							Type:        schema.TypeString,
 						},
 						Attr_Target: {
@@ -303,6 +313,7 @@ func resourceIBMPINetworkSecurityGroupMemberRead(ctx context.Context, d *schema.
 		}
 		d.Set(Attr_UserTags, userTags)
 	}
+	d.Set(Attr_Default, networkSecurityGroup.Default)
 	if len(networkSecurityGroup.Members) > 0 {
 		members := []map[string]interface{}{}
 		for _, mbr := range networkSecurityGroup.Members {

--- a/ibm/service/power/resource_ibm_pi_network_security_group_rule.go
+++ b/ibm/service/power/resource_ibm_pi_network_security_group_rule.go
@@ -228,6 +228,11 @@ func ResourceIBMPINetworkSecurityGroupRule() *schema.Resource {
 				Description: "The network security group's crn.",
 				Type:        schema.TypeString,
 			},
+			Attr_Default: {
+				Computed:    true,
+				Description: "Indicates if the network security group is the default network security group in the workspace.",
+				Type:        schema.TypeBool,
+			},
 			Attr_Members: {
 				Computed:    true,
 				Description: "The list of IPv4 addresses and, or network interfaces in the network security group.",
@@ -241,6 +246,11 @@ func ResourceIBMPINetworkSecurityGroupRule() *schema.Resource {
 						Attr_MacAddress: {
 							Computed:    true,
 							Description: "The mac address of a network interface included if the type is network-interface.",
+							Type:        schema.TypeString,
+						},
+						Attr_NetworkInterfaceID: {
+							Computed:    true,
+							Description: "The network ID of a network interface included if the type is network-interface.",
 							Type:        schema.TypeString,
 						},
 						Attr_Target: {
@@ -445,10 +455,11 @@ func resourceIBMPINetworkSecurityGroupRuleCreate(ctx context.Context, d *schema.
 		}
 
 		networkSecurityGroup, err := nsgClient.AddRule(nsgID, &networkSecurityGroupAddRule)
-		ruleID := *networkSecurityGroup.ID
 		if err != nil {
 			return diag.FromErr(err)
 		}
+		ruleID := *networkSecurityGroup.ID
+
 		_, err = isWaitForIBMPINetworkSecurityGroupRuleAdd(ctx, nsgClient, nsgID, ruleID, d.Timeout(schema.TimeoutCreate))
 		if err != nil {
 			return diag.FromErr(err)
@@ -483,6 +494,7 @@ func resourceIBMPINetworkSecurityGroupRuleRead(ctx context.Context, d *schema.Re
 		}
 		d.Set(Attr_UserTags, userTags)
 	}
+	d.Set(Attr_Default, networkSecurityGroup.Default)
 
 	if len(networkSecurityGroup.Members) > 0 {
 		members := []map[string]interface{}{}

--- a/ibm/service/power/resource_ibm_pi_network_security_group_rule_test.go
+++ b/ibm/service/power/resource_ibm_pi_network_security_group_rule_test.go
@@ -123,6 +123,9 @@ func testAccCheckIBMPINetworkSecurityGroupRuleConfigAddRuleTCP() string {
 				tcp_flags {
 					flag = "syn"
 				}
+				tcp_flags {
+					flag = "fin"
+				}
 				type       = "tcp"
 			}
 			pi_remote {

--- a/website/docs/d/pi_network_security_group.html.markdown
+++ b/website/docs/d/pi_network_security_group.html.markdown
@@ -47,12 +47,14 @@ You can specify the following arguments for this data source.
 In addition to all argument reference list, you can access the following attribute references after your data source is created.
 
 - `crn` - (String) The network security group's crn.
+- `default` - (Boolean) Indicates if the network security group is the default network security group in the workspace.
 
 - `members` - (List) The list of IPv4 addresses and\or network interfaces in the network security group.
 
   Nested schema for `members`:
   - `id` - (String) The id of the member in a network security group.
   - `mac_address` - (String) The mac address of a network interface included if the type is `network-interface`.
+  - `network_interface_id` - (String) The network ID of a network interface included if the type is `network-interface`.
   - `target` - (String) If `ipv4-address` type, then IPv4 address or if `network-interface` type, then network interface id.
   - `type` - (String) The type of member. Supported values are: `ipv4-address`, `network-interface`.
 

--- a/website/docs/d/pi_network_security_groups.html.markdown
+++ b/website/docs/d/pi_network_security_groups.html.markdown
@@ -48,12 +48,14 @@ After your data source is created, you can read values from the following attrib
   
   Nested schema for `network_security_groups`:
   - `crn` - (String) The network security group's crn.
+  - `default` - (Boolean) Indicates if the network security group is the default network security group in the workspace.
   - `id` - (String) The id of the network security group.
   - `members` - (List) The list of IPv4 addresses and\or network Interfaces in the network security group.
 
       Nested schema for `members`:
         - `id` - (String) The id of the member in a network security group.
         - `mac_address` - (String) The mac address of a network Interface included if the type is `network-interface`.
+        - `network_interface_id` - (String) The network ID of a network interface included if the type is `network-interface`.
         - `target` - (String) If `ipv4-address` type, then IPv4 address or if `network-interface` type, then network interface id.
     - `type` - (String) The type of member. Supported values are: `ipv4-address`, `network-interface`.
   - `name` - (String) The name of the network security group.

--- a/website/docs/r/pi_network_security_group.html.markdown
+++ b/website/docs/r/pi_network_security_group.html.markdown
@@ -55,12 +55,14 @@ Review the argument references that you can specify for your resource.
 In addition to all argument reference list, you can access the following attribute reference after your resource is created.
 
 - `crn` - (String) The network security group's crn.
+- `default` - (Boolean) Indicates if the network security group is the default network security group in the workspace.
 - `id` - (String) The unique identifier of the network security group resource. Composed of `<cloud_instance_id>/<network_security_group_id>`
 - `members` - (List) The list of IPv4 addresses and\or network interfaces in the network security group.
 
     Nested schema for `members`:
   - `id` - (String) The id of the member in a network security group.
   - `mac_address` - (String) The mac address of a network interface included if the type is `network-interface`.
+  - `network_interface_id` - (String) The network ID of a network interface included if the type is `network-interface`.
   - `target` - (String) If `ipv4-address` type, then IPv4 address or if `network-interface` type, then network interface id.
   - `type` - (String) The type of member. Supported values are: `ipv4-address`, `network-interface`.
 

--- a/website/docs/r/pi_network_security_group_member.html.markdown
+++ b/website/docs/r/pi_network_security_group_member.html.markdown
@@ -58,12 +58,14 @@ Review the argument references that you can specify for your resource.
 In addition to all argument reference list, you can access the following attribute reference after your resource is created.
 
 - `crn` - (String) The network security group's crn.
+- `default` - (Boolean) Indicates if the network security group is the default network security group in the workspace.
 - `id` - (String) The unique identifier of the network security group resource. Composed of `<cloud_instance_id>/<network_security_group_id>/<network_security_group_member_id>`
 - `members` - (List) The list of IPv4 addresses and\or network interfaces in the network security group.
 
     Nested schema for `members`:
       - `id` - (String) The id of the member in a network security group.
       - `mac_address` - (String) The mac address of a network interface included if the type is `network-interface`.
+      - `network_interface_id` - (String) The network ID of a network interface included if the type is `network-interface`.
       - `target` - (String) If `ipv4-address` type, then IPv4 address or if `network-interface` type, then network interface id.
       - `type` - (String) The type of member. Supported values are: `ipv4-address`, `network-interface`.
 

--- a/website/docs/r/pi_network_security_group_rule.html.markdown
+++ b/website/docs/r/pi_network_security_group_rule.html.markdown
@@ -114,12 +114,14 @@ Review the argument references that you can specify for your resource.
 In addition to all argument reference list, you can access the following attribute reference after your resource is created.
 
 - `crn` - (String) The network security group's crn.
+- `default` - (Boolean) Indicates if the network security group is the default network security group in the workspace.
 - `id` - (String) The unique identifier of the network security group resource. Composed of `<cloud_instance_id>/<network_security_group_id/rule_id>`
 - `members` - (List) The list of IPv4 addresses and\or network interfaces in the network security group.
 
     Nested schema for `members`:
   - `id` - (String) The id of the member in a network security group.
   - `mac_address` - (String) The mac address of a network interface included if the type is `network-interface`.
+  - `network_interface_id` - (String) The network ID of a network interface included if the type is `network-interface`.
   - `target` - (String) If `ipv4-address` type, then IPv4 address or if `network-interface` type, then network interface id.
   - `type` - (String) The type of member. Supported values are: `ipv4-address`, `network-interface`.
 


### PR DESCRIPTION
Add network_interface_id and default to NSG
<!--- See what makes a good Pull Request at : https://github.com/IBM-Cloud/terraform-provider-ibm/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
=== RUN   TestAccIBMPINetworkSecurityGroupDataSourceBasic
--- PASS: TestAccIBMPINetworkSecurityGroupDataSourceBasic (75.18s)
PASS

=== RUN   TestAccIBMPINetworkSecurityGroupsDataSourceBasic
--- PASS: TestAccIBMPINetworkSecurityGroupsDataSourceBasic (86.18s)
PASS

=== RUN   TestAccIBMPINetworkSecurityGroupMemberBasic
--- PASS: TestAccIBMPINetworkSecurityGroupMemberBasic (201.51s)
PASS

=== RUN   TestAccIBMPINetworkSecurityGroupRuleBasic
--- PASS: TestAccIBMPINetworkSecurityGroupRuleBasic (116.08s)
PASS

=== RUN   TestAccIBMPINetworkSecurityGroupRuleTCP
--- PASS: TestAccIBMPINetworkSecurityGroupRuleTCP (114.93s)
PASS

=== RUN   TestAccIBMPINetworkSecurityGroupBasic
--- PASS: TestAccIBMPINetworkSecurityGroupBasic (173.11s)
PASS
```
