### PR TITLE
Add support for managed CSR in Secrets Manager Imported Certificate secret

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,11 +3,8 @@
     "files": "go.mod|go.sum|.*.map|^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2025-02-06T19:26:40Z",
+  "generated_at": "2025-02-18T10:20:14Z",
   "plugins_used": [
-    {
-      "name": "AWSKeyDetector"
-    },
     {
       "name": "ArtifactoryDetector"
     },
@@ -20,12 +17,6 @@
     },
     {
       "name": "BasicAuthDetector"
-    },
-    {
-      "name": "BoxDetector"
-    },
-    {
-      "name": "CloudantDetector"
     },
     {
       "ghe_instance": "github.ibm.com",
@@ -52,9 +43,6 @@
       "name": "KeywordDetector"
     },
     {
-      "name": "MailchimpDetector"
-    },
-    {
       "name": "NpmDetector"
     },
     {
@@ -68,12 +56,6 @@
     },
     {
       "name": "SquareOAuthDetector"
-    },
-    {
-      "name": "StripeDetector"
-    },
-    {
-      "name": "TwilioKeyDetector"
     }
   ],
   "results": {
@@ -610,7 +592,7 @@
         "hashed_secret": "4fe2c50d3e572f60977cb06e8995a5d7c368758d",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 277,
+        "line_number": 282,
         "type": "Hex High Entropy String",
         "verified_result": null
       }
@@ -888,7 +870,7 @@
         "hashed_secret": "1f614c2eb6b3da22d89bd1b9fd47d7cb7c8fc670",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 3659,
+        "line_number": 3657,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -896,7 +878,7 @@
         "hashed_secret": "7abfce65b8504403afc25c9790f358d513dfbcc6",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 3672,
+        "line_number": 3670,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -904,7 +886,7 @@
         "hashed_secret": "0c2d85bf9a9b1579b16f220a4ea8c3d62b2e24b1",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 3713,
+        "line_number": 3711,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -2329,7 +2311,7 @@
     ],
     "ibm/service/database/resource_ibm_database_edb_test.go": [
       {
-        "hashed_secret": "2317aa72dafa0a07f05af47baa2e388f95dcf6f3",
+        "hashed_secret": "6c6728efbf3da1eadeb8c21e829d70f6dfd4bf8d",
         "is_secret": false,
         "is_verified": false,
         "line_number": 278,
@@ -2339,7 +2321,7 @@
     ],
     "ibm/service/database/resource_ibm_database_elasticsearch_platinum_test.go": [
       {
-        "hashed_secret": "2317aa72dafa0a07f05af47baa2e388f95dcf6f3",
+        "hashed_secret": "6c6728efbf3da1eadeb8c21e829d70f6dfd4bf8d",
         "is_secret": false,
         "is_verified": false,
         "line_number": 773,
@@ -2349,7 +2331,7 @@
     ],
     "ibm/service/database/resource_ibm_database_elasticsearch_test.go": [
       {
-        "hashed_secret": "2317aa72dafa0a07f05af47baa2e388f95dcf6f3",
+        "hashed_secret": "6c6728efbf3da1eadeb8c21e829d70f6dfd4bf8d",
         "is_secret": false,
         "is_verified": false,
         "line_number": 819,
@@ -2359,7 +2341,7 @@
     ],
     "ibm/service/database/resource_ibm_database_etcd_test.go": [
       {
-        "hashed_secret": "2317aa72dafa0a07f05af47baa2e388f95dcf6f3",
+        "hashed_secret": "6c6728efbf3da1eadeb8c21e829d70f6dfd4bf8d",
         "is_secret": false,
         "is_verified": false,
         "line_number": 209,
@@ -2369,7 +2351,7 @@
     ],
     "ibm/service/database/resource_ibm_database_mongodb_enterprise_test.go": [
       {
-        "hashed_secret": "8cbbbfad0206e5953901f679b0d26d583c4f5ffe",
+        "hashed_secret": "74f75c4c7dc7e33193565dc5c56b7ab6f72db4df",
         "is_secret": false,
         "is_verified": false,
         "line_number": 253,
@@ -2377,7 +2359,7 @@
         "verified_result": null
       },
       {
-        "hashed_secret": "2317aa72dafa0a07f05af47baa2e388f95dcf6f3",
+        "hashed_secret": "6c6728efbf3da1eadeb8c21e829d70f6dfd4bf8d",
         "is_secret": false,
         "is_verified": false,
         "line_number": 318,
@@ -2395,7 +2377,7 @@
         "verified_result": null
       },
       {
-        "hashed_secret": "2317aa72dafa0a07f05af47baa2e388f95dcf6f3",
+        "hashed_secret": "6c6728efbf3da1eadeb8c21e829d70f6dfd4bf8d",
         "is_secret": false,
         "is_verified": false,
         "line_number": 179,
@@ -2405,7 +2387,7 @@
     ],
     "ibm/service/database/resource_ibm_database_mongodb_test.go": [
       {
-        "hashed_secret": "2317aa72dafa0a07f05af47baa2e388f95dcf6f3",
+        "hashed_secret": "6c6728efbf3da1eadeb8c21e829d70f6dfd4bf8d",
         "is_secret": false,
         "is_verified": false,
         "line_number": 213,
@@ -2415,7 +2397,7 @@
     ],
     "ibm/service/database/resource_ibm_database_mysql_test.go": [
       {
-        "hashed_secret": "2317aa72dafa0a07f05af47baa2e388f95dcf6f3",
+        "hashed_secret": "6c6728efbf3da1eadeb8c21e829d70f6dfd4bf8d",
         "is_secret": false,
         "is_verified": false,
         "line_number": 251,
@@ -2428,22 +2410,22 @@
         "hashed_secret": "728e83f156932be9b1dc48a5c3f7a3bfbeeb08ce",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 390,
+        "line_number": 391,
         "type": "Secret Keyword",
         "verified_result": null
       },
       {
-        "hashed_secret": "2317aa72dafa0a07f05af47baa2e388f95dcf6f3",
+        "hashed_secret": "6c6728efbf3da1eadeb8c21e829d70f6dfd4bf8d",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 568,
+        "line_number": 569,
         "type": "Secret Keyword",
         "verified_result": null
       }
     ],
     "ibm/service/database/resource_ibm_database_rabbitmq_test.go": [
       {
-        "hashed_secret": "2317aa72dafa0a07f05af47baa2e388f95dcf6f3",
+        "hashed_secret": "6c6728efbf3da1eadeb8c21e829d70f6dfd4bf8d",
         "is_secret": false,
         "is_verified": false,
         "line_number": 224,
@@ -2453,7 +2435,7 @@
     ],
     "ibm/service/database/resource_ibm_database_redis_test.go": [
       {
-        "hashed_secret": "2317aa72dafa0a07f05af47baa2e388f95dcf6f3",
+        "hashed_secret": "6c6728efbf3da1eadeb8c21e829d70f6dfd4bf8d",
         "is_secret": false,
         "is_verified": false,
         "line_number": 280,
@@ -2479,7 +2461,7 @@
         "verified_result": null
       },
       {
-        "hashed_secret": "d67007844d8f7fbc45ea3b27c4bea0bffafb53a0",
+        "hashed_secret": "92ec408a50ecf51d35e7d26656a9372e50c06a07",
         "is_secret": false,
         "is_verified": false,
         "line_number": 30,
@@ -2495,7 +2477,15 @@
         "verified_result": null
       },
       {
-        "hashed_secret": "dad6fac3e5b6be7bb6f274970b4c50739a7e26ee",
+        "hashed_secret": "2ca8c980f5947600f2749adb4f177fd357d2df53",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 46,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "64034663b9f3ba170ea9281f5e833f93b55f91a1",
         "is_secret": false,
         "is_verified": false,
         "line_number": 62,
@@ -2503,7 +2493,7 @@
         "verified_result": null
       },
       {
-        "hashed_secret": "8cbbbfad0206e5953901f679b0d26d583c4f5ffe",
+        "hashed_secret": "74f75c4c7dc7e33193565dc5c56b7ab6f72db4df",
         "is_secret": false,
         "is_verified": false,
         "line_number": 70,
@@ -2530,7 +2520,7 @@
         "hashed_secret": "1f5e25be9b575e9f5d39c82dfd1d9f4d73f1975c",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 165,
+        "line_number": 166,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -2538,7 +2528,7 @@
         "hashed_secret": "e03932ac8a17ed1819fe161fd253bf323e0e3ec9",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 174,
+        "line_number": 175,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -2830,15 +2820,15 @@
         "hashed_secret": "b02fa7fd7ca08b5dc86c2548e40f8a21171ef977",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 275,
+        "line_number": 316,
         "type": "Secret Keyword",
         "verified_result": null
       },
       {
-        "hashed_secret": "d4c3d66fd0c38547a3c7a4c6bdc29c36911bc030",
+        "hashed_secret": "1f7e33de15e22de9d2eaf502df284ed25ca40018",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 313,
+        "line_number": 390,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -3211,12 +3201,12 @@
         "verified_result": null
       }
     ],
-    "ibm/service/partnercentersell/resource_ibm_onboarding_catalog_product.go": [
+    "ibm/service/partnercentersell/resource_ibm_onboarding_catalog_deployment.go": [
       {
         "hashed_secret": "3046d9f6cfaaeea6eed9bb7a4ab010fe49b0cfd4",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 351,
+        "line_number": 194,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -3224,7 +3214,43 @@
         "hashed_secret": "a2277f800807615d59cc7925271ea2c54de5fb96",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2375,
+        "line_number": 1549,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "ibm/service/partnercentersell/resource_ibm_onboarding_catalog_plan.go": [
+      {
+        "hashed_secret": "3046d9f6cfaaeea6eed9bb7a4ab010fe49b0cfd4",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 350,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "a2277f800807615d59cc7925271ea2c54de5fb96",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 1373,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "ibm/service/partnercentersell/resource_ibm_onboarding_catalog_product.go": [
+      {
+        "hashed_secret": "3046d9f6cfaaeea6eed9bb7a4ab010fe49b0cfd4",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 367,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "a2277f800807615d59cc7925271ea2c54de5fb96",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 2450,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -3232,7 +3258,7 @@
         "hashed_secret": "b5366a2d2ac98dae978423083f8b09e5cddc705d",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 3172,
+        "line_number": 3244,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -3416,7 +3442,7 @@
         "hashed_secret": "b732fb611fd46a38e8667f9972e0cde777fbe37f",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 177,
+        "line_number": 211,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -3594,7 +3620,7 @@
         "hashed_secret": "3046d9f6cfaaeea6eed9bb7a4ab010fe49b0cfd4",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 189,
+        "line_number": 359,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -3826,7 +3852,7 @@
         "hashed_secret": "3046d9f6cfaaeea6eed9bb7a4ab010fe49b0cfd4",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 108,
+        "line_number": 110,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -3834,7 +3860,7 @@
         "hashed_secret": "9beb31de125498074813c6f31c0e4df3e54a5489",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 678,
+        "line_number": 1101,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -3844,7 +3870,7 @@
         "hashed_secret": "1348b145fa1a555461c1b790a2f66614781091e9",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 136,
+        "line_number": 283,
         "type": "Private Key",
         "verified_result": null
       },
@@ -3852,7 +3878,7 @@
         "hashed_secret": "1ccdffdaa7d44feca6d6db090e83db7c58f64981",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 136,
+        "line_number": 283,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -5038,7 +5064,7 @@
         "hashed_secret": "d47dcacc720a39e236679ac3e311a0d58bb6519e",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 124,
+        "line_number": 190,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -5046,7 +5072,7 @@
         "hashed_secret": "e66e7d67fdf3c596c435fc7828b13205e4950a0f",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 126,
+        "line_number": 192,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -5318,7 +5344,7 @@
       }
     ]
   },
-  "version": "0.13.1+ibm.62.dss",
+  "version": "0.13.1+ibm.61.dss",
   "word_list": {
     "file": null,
     "hash": null

--- a/go.mod
+++ b/go.mod
@@ -40,7 +40,7 @@ require (
 	github.com/IBM/scc-go-sdk/v5 v5.4.1
 	github.com/IBM/schematics-go-sdk v0.3.0
 	github.com/IBM/sds-go-sdk v0.0.4
-	github.com/IBM/secrets-manager-go-sdk/v2 v2.0.7
+	github.com/IBM/secrets-manager-go-sdk/v2 v2.0.10
 	github.com/IBM/vmware-go-sdk v0.1.3
 	github.com/IBM/vpc-beta-go-sdk v0.8.0
 	github.com/IBM/vpc-go-sdk v0.64.0
@@ -81,7 +81,6 @@ require (
 require github.com/BurntSushi/toml v1.2.0 // indirect
 
 require (
-	github.com/Bowery/prompt v0.0.0-20190916142128-fa8279994f75 // indirect
 	github.com/Logicalis/asn1 v0.0.0-20190312173541-d60463189a56 // indirect
 	github.com/Masterminds/semver/v3 v3.2.1 // indirect
 	github.com/PromonLogicalis/asn1 v0.0.0-20190312173541-d60463189a56 // indirect
@@ -97,7 +96,6 @@ require (
 	github.com/containernetworking/cni v1.2.0-rc1 // indirect
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
 	github.com/dchest/bcrypt_pbkdf v0.0.0-20150205184540-83f37f9c154a // indirect
-	github.com/dchest/safefile v0.0.0-20151022103144-855e8d98f185 // indirect
 	github.com/dgrijalva/jwt-go v3.2.0+incompatible // indirect
 	github.com/eapache/go-resiliency v1.7.0 // indirect
 	github.com/eapache/go-xerial-snappy v0.0.0-20230731223053-c322873962e3 // indirect
@@ -130,7 +128,6 @@ require (
 	github.com/google/gnostic-models v0.6.8 // indirect
 	github.com/google/go-querystring v1.1.0 // indirect
 	github.com/google/gofuzz v1.2.0 // indirect
-	github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510 // indirect
 	github.com/gorilla/websocket v1.5.0 // indirect
 	github.com/hashicorp/errwrap v1.1.0 // indirect
 	github.com/hashicorp/go-checkpoint v0.5.0 // indirect
@@ -170,7 +167,6 @@ require (
 	github.com/josharian/intern v1.0.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
 	github.com/k8snetworkplumbingwg/network-attachment-definition-client v1.7.0 // indirect
-	github.com/kardianos/govendor v1.0.9 // indirect
 	github.com/klauspost/compress v1.17.11 // indirect
 	github.com/kube-object-storage/lib-bucket-provisioner v0.0.0-20221122204822-d1a8c34382f1 // indirect
 	github.com/leodido/go-urn v1.4.0 // indirect
@@ -181,8 +177,6 @@ require (
 	github.com/mitchellh/copystructure v1.2.0 // indirect
 	github.com/mitchellh/go-testing-interface v1.14.1 // indirect
 	github.com/mitchellh/go-wordwrap v1.0.1 // indirect
-	github.com/mitchellh/gox v1.0.1 // indirect
-	github.com/mitchellh/iochan v1.0.0 // indirect
 	github.com/mitchellh/mapstructure v1.5.0 // indirect
 	github.com/mitchellh/reflectwalk v1.0.2 // indirect
 	github.com/moby/spdystream v0.4.0 // indirect
@@ -225,8 +219,6 @@ require (
 	golang.org/x/text v0.21.0 // indirect
 	golang.org/x/time v0.3.0 // indirect
 	golang.org/x/tools v0.26.0 // indirect
-	golang.org/x/tools/cmd/cover v0.1.0-deprecated // indirect
-	golang.org/x/tools/go/vcs v0.1.0-deprecated // indirect
 	google.golang.org/appengine v1.6.8 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20240814211410-ddb44dafa142 // indirect
 	google.golang.org/grpc v1.67.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -85,8 +85,6 @@ github.com/Azure/go-autorest/logger v0.2.0/go.mod h1:T9E3cAhj2VqvPOtCYAvby9aBXkZ
 github.com/Azure/go-autorest/logger v0.2.1/go.mod h1:T9E3cAhj2VqvPOtCYAvby9aBXkZmbF5NWuPV8+WeEW8=
 github.com/Azure/go-autorest/tracing v0.5.0/go.mod h1:r/s2XiOKccPW3HrqB+W0TQzfbtp2fGCgRFtBroKn4Dk=
 github.com/Azure/go-autorest/tracing v0.6.0/go.mod h1:+vhtPC754Xsa23ID7GlGsrdKBpUA79WCAKPPZVC2DeU=
-github.com/Bowery/prompt v0.0.0-20190916142128-fa8279994f75 h1:xGHheKK44eC6K0u5X+DZW/fRaR1LnDdqPHMZMWx5fv8=
-github.com/Bowery/prompt v0.0.0-20190916142128-fa8279994f75/go.mod h1:4/6eNcqZ09BZ9wLK3tZOjBA1nDj+B0728nlX5YRlSmQ=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/BurntSushi/toml v1.2.0 h1:Rt8g24XnyGTyglgET/PRUNlrUeu9F5L+7FilkXfZgs0=
 github.com/BurntSushi/toml v1.2.0/go.mod h1:CxXYINrC8qIiEnFrOxCa7Jy5BFHlXnUU2pbicEuybxQ=
@@ -172,8 +170,8 @@ github.com/IBM/schematics-go-sdk v0.3.0 h1:Vwxw85SONflakiBsNHAfViKLyp9zJiH5/hh6S
 github.com/IBM/schematics-go-sdk v0.3.0/go.mod h1:Tw2OSAPdpC69AxcwoyqcYYaGTTW6YpERF9uNEU+BFRQ=
 github.com/IBM/sds-go-sdk v0.0.4 h1:zkkqDzc+TgFYU/BK4Oknv8cMBXJ08WKUu7yKCyzslvE=
 github.com/IBM/sds-go-sdk v0.0.4/go.mod h1:HcqZfsgKMqfFxbU1RcRfF934ls+vQY97oXPGPSoIWPg=
-github.com/IBM/secrets-manager-go-sdk/v2 v2.0.7 h1:5lKt1rHuKaAaiZtbPfsF8dgiko/gGbVgreiut3zU128=
-github.com/IBM/secrets-manager-go-sdk/v2 v2.0.7/go.mod h1:RglK3v6CPe3T1myRtQCD6z+nBygXvNJwufAon0qcZok=
+github.com/IBM/secrets-manager-go-sdk/v2 v2.0.10 h1:R9ZMCCi7yJnDIe88+UKKQf0CFBB74E6k8mOp+++kL4w=
+github.com/IBM/secrets-manager-go-sdk/v2 v2.0.10/go.mod h1:Bmy0woaAxxNPVHCqusarnTZVyVMnLRVwemF6gvGHcLo=
 github.com/IBM/vmware-go-sdk v0.1.3 h1:uJL3kwzM0jAKsT6Gj9tE5xT9SZBVXVaJvZdxrSMx8b8=
 github.com/IBM/vmware-go-sdk v0.1.3/go.mod h1:OyQKRInGGsBaOyE5LIZCqH7b1DZ01BvIYa8BgGy+wWo=
 github.com/IBM/vpc-beta-go-sdk v0.8.0 h1:cEPpv4iw3Ba5W2d0AWg3TIbKeJ8y1nPuUuibR5Jt9eE=
@@ -312,8 +310,6 @@ github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/dchest/bcrypt_pbkdf v0.0.0-20150205184540-83f37f9c154a h1:saTgr5tMLFnmy/yg3qDTft4rE5DY2uJ/cCxCe3q0XTU=
 github.com/dchest/bcrypt_pbkdf v0.0.0-20150205184540-83f37f9c154a/go.mod h1:Bw9BbhOJVNR+t0jCqx2GC6zv0TGBsShs56Y3gfSCvl0=
-github.com/dchest/safefile v0.0.0-20151022103144-855e8d98f185 h1:3T8ZyTDp5QxTx3NU48JVb2u+75xc040fofcBaN+6jPA=
-github.com/dchest/safefile v0.0.0-20151022103144-855e8d98f185/go.mod h1:cFRxtTwTOJkz2x3rQUNCYKWC93yP1VKjR8NUhqFxZNU=
 github.com/dgryski/go-sip13 v0.0.0-20181026042036-e10d5fee7954/go.mod h1:vAd38F8PWV+bWy6jNmig1y/TA+kYO4g3RSRF0IAv0no=
 github.com/docker/docker v0.7.3-0.20190327010347-be7ac8be2ae0/go.mod h1:eEKB0N0r5NX/I1kEveEz05bcu8tLC/8azJZsviup8Sk=
 github.com/docker/go-units v0.3.3/go.mod h1:fgPhTUdO+D/Jk86RDLlptpiXQzgHJF7gydDDbaIK4Dk=
@@ -654,8 +650,6 @@ github.com/google/pprof v0.0.0-20210720184732-4bb14d4b1be1/go.mod h1:kpwsk12EmLe
 github.com/google/pprof v0.0.0-20241029153458-d1b30febd7db h1:097atOisP2aRj7vFgYQBbFN4U4JNXUNYpxael3UzMyo=
 github.com/google/pprof v0.0.0-20241029153458-d1b30febd7db/go.mod h1:vavhavw2zAxS5dIdcRluK6cSGGPlZynqzFM8NdvU144=
 github.com/google/renameio v0.1.0/go.mod h1:KWCgfxg9yswjAJkECMjeO8J8rahYeXnNhOm40UhjYkI=
-github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510 h1:El6M4kTTCOh6aBiKaUGG7oYTSPP8MxqL4YI3kZKwcP4=
-github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510/go.mod h1:pupxD2MaaD3pAXIBCelhxNneeOaAeabZDe5s4K6zSpQ=
 github.com/google/uuid v1.0.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/google/uuid v1.1.1/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/google/uuid v1.1.2/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
@@ -747,7 +741,6 @@ github.com/hashicorp/go-uuid v1.0.1/go.mod h1:6SBZvOh/SIDV7/2o3Jml5SYk/TvGqwFJ/b
 github.com/hashicorp/go-uuid v1.0.2/go.mod h1:6SBZvOh/SIDV7/2o3Jml5SYk/TvGqwFJ/bN7x4byOro=
 github.com/hashicorp/go-uuid v1.0.3 h1:2gKiV6YVmrJ1i2CKKa9obLvRieoRGviZFL26PcT/Co8=
 github.com/hashicorp/go-uuid v1.0.3/go.mod h1:6SBZvOh/SIDV7/2o3Jml5SYk/TvGqwFJ/bN7x4byOro=
-github.com/hashicorp/go-version v1.0.0/go.mod h1:fltr4n8CU8Ke44wwGCBoEymUuxUHl09ZGVZPK5anwXA=
 github.com/hashicorp/go-version v1.2.1/go.mod h1:fltr4n8CU8Ke44wwGCBoEymUuxUHl09ZGVZPK5anwXA=
 github.com/hashicorp/go-version v1.7.0 h1:5tqGy27NaOTB8yJKUZELlFAS/LTKJkrmONwQKeRZfjY=
 github.com/hashicorp/go-version v1.7.0/go.mod h1:fltr4n8CU8Ke44wwGCBoEymUuxUHl09ZGVZPK5anwXA=
@@ -777,8 +770,6 @@ github.com/hashicorp/terraform-plugin-log v0.9.0 h1:i7hOA+vdAItN1/7UrfBqBwvYPQ9T
 github.com/hashicorp/terraform-plugin-log v0.9.0/go.mod h1:rKL8egZQ/eXSyDqzLUuwUYLVdlYeamldAHSxjUFADow=
 github.com/hashicorp/terraform-plugin-sdk/v2 v2.35.0 h1:wyKCCtn6pBBL46c1uIIBNUOWlNfYXfXpVo16iDyLp8Y=
 github.com/hashicorp/terraform-plugin-sdk/v2 v2.35.0/go.mod h1:B0Al8NyYVr8Mp/KLwssKXG1RqnTk7FySqSn4fRuLNgw=
-github.com/hashicorp/terraform-plugin-testing v1.11.0 h1:MeDT5W3YHbONJt2aPQyaBsgQeAIckwPX41EUHXEn29A=
-github.com/hashicorp/terraform-plugin-testing v1.11.0/go.mod h1:WNAHQ3DcgV/0J+B15WTE6hDvxcUdkPPpnB1FR3M910U=
 github.com/hashicorp/terraform-registry-address v0.2.3 h1:2TAiKJ1A3MAkZlH1YI/aTVcLZRu7JseiXNRHbOAyoTI=
 github.com/hashicorp/terraform-registry-address v0.2.3/go.mod h1:lFHA76T8jfQteVfT7caREqguFrW3c4MFSPhZB7HHgUM=
 github.com/hashicorp/terraform-svchost v0.1.1 h1:EZZimZ1GxdqFRinZ1tpJwVxxt49xc/S52uzrw4x0jKQ=
@@ -853,8 +844,6 @@ github.com/jtolds/gls v4.20.0+incompatible/go.mod h1:QJZ7F/aHp+rZTRtaJ1ow/lLfFfV
 github.com/julienschmidt/httprouter v1.2.0/go.mod h1:SYymIcj16QtmaHHD7aYtjjsJG7VTCxuUUipMqKk8s4w=
 github.com/k8snetworkplumbingwg/network-attachment-definition-client v1.7.0 h1:47q2PIbDYHmOaqLxgGnvpLq96v9UKDsJfNW6j/KbfpQ=
 github.com/k8snetworkplumbingwg/network-attachment-definition-client v1.7.0/go.mod h1:KDX0bPKeuhMakcNzLf2sWXKPNZ30wH01bsY/KJZLxFY=
-github.com/kardianos/govendor v1.0.9 h1:WOH3FcVI9eOgnIZYg96iwUwrL4eOVx+aQ66oyX2R8Yc=
-github.com/kardianos/govendor v1.0.9/go.mod h1:yvmR6q9ZZ7nSF5Wvh40v0wfP+3TwwL8zYQp+itoZSVM=
 github.com/karrick/godirwalk v1.8.0/go.mod h1:H5KPZjojv4lE+QYImBI8xVtrBRgYrIVsaRPx4tDPEn4=
 github.com/karrick/godirwalk v1.10.3/go.mod h1:RoGL9dQei4vP9ilrpETWE8CLOZ1kiN0LhBygSwrAsHA=
 github.com/kevinburke/ssh_config v1.2.0 h1:x584FjTGwHzMwvHx18PXxbBVzfnxogHaAReU4gf13a4=
@@ -950,10 +939,6 @@ github.com/mitchellh/go-testing-interface v1.14.1/go.mod h1:gfgS7OtZj6MA4U1UrDRp
 github.com/mitchellh/go-wordwrap v1.0.0/go.mod h1:ZXFpozHsX6DPmq2I0TCekCxypsnAUbP2oI0UX1GXzOo=
 github.com/mitchellh/go-wordwrap v1.0.1 h1:TLuKupo69TCn6TQSyGxwI1EblZZEsQ0vMlAFQflz0v0=
 github.com/mitchellh/go-wordwrap v1.0.1/go.mod h1:R62XHJLzvMFRBbcrT7m7WgmE1eOyTSsCt+hzestvNj0=
-github.com/mitchellh/gox v1.0.1 h1:x0jD3dcHk9a9xPSDN6YEL4xL6Qz0dvNYm8yZqui5chI=
-github.com/mitchellh/gox v1.0.1/go.mod h1:ED6BioOGXMswlXa2zxfh/xdd5QhwYliBFn9V18Ap4z4=
-github.com/mitchellh/iochan v1.0.0 h1:C+X3KsSTLFVBr/tK1eYN/vs4rJcvsiLU338UhYPJWeY=
-github.com/mitchellh/iochan v1.0.0/go.mod h1:JwYml1nuB7xOzsp52dPpHFffvOCDupsG0QubkSMEySY=
 github.com/mitchellh/mapstructure v0.0.0-20160808181253-ca63d7c062ee/go.mod h1:FVVH3fgwuzCH5S8UJGiWEs2h04kUh9fWfEaFds41c1Y=
 github.com/mitchellh/mapstructure v1.1.2/go.mod h1:FVVH3fgwuzCH5S8UJGiWEs2h04kUh9fWfEaFds41c1Y=
 github.com/mitchellh/mapstructure v1.3.3/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RRV2QTWOzhPopBRo=
@@ -1058,8 +1043,8 @@ github.com/onsi/gomega v1.27.8/go.mod h1:2J8vzI/s+2shY9XHRApDkdgPo1TKT7P2u6fXeJK
 github.com/onsi/gomega v1.27.10/go.mod h1:RsS8tutOdbdgzbPtzzATp12yT7kM5I5aElG3evPbQ0M=
 github.com/onsi/gomega v1.30.0/go.mod h1:9sxs+SwGrKI0+PWe4Fxa9tFQQBG5xSsSbMXOI8PPpoQ=
 github.com/onsi/gomega v1.31.1/go.mod h1:y40C95dwAD1Nz36SsEnxvfFe8FFfNxzI5eJ0EYGyAy0=
-github.com/onsi/gomega v1.36.1 h1:bJDPBO7ibjxcbHMgSCoo4Yj18UWbKDlLwX1x9sybDcw=
-github.com/onsi/gomega v1.36.1/go.mod h1:PvZbdDc8J6XJEpDK4HCuRBm8a6Fzp9/DmhC9C7yFlog=
+github.com/onsi/gomega v1.36.2 h1:koNYke6TVk6ZmnyHrCXba/T/MoLBXFjeC1PtvYgw0A8=
+github.com/onsi/gomega v1.36.2/go.mod h1:DdwyADRjrc825LhMEkD76cHR5+pUnjhUN8GlHlRPHzY=
 github.com/openshift/api v0.0.0-20210105115604-44119421ec6b/go.mod h1:aqU5Cq+kqKKPbDMqxo9FojgDeSpNJI7iuskjXjtojDg=
 github.com/openshift/api v0.0.0-20240301093301-ce10821dc999 h1:+S998xHiJApsJZjRAO8wyedU9GfqFd8mtwWly6LqHDo=
 github.com/openshift/api v0.0.0-20240301093301-ce10821dc999/go.mod h1:CxgbWAlvu2iQB0UmKTtRu1YfepRg1/vJ64n2DlIEVz4=
@@ -1799,10 +1784,6 @@ golang.org/x/tools v0.13.0/go.mod h1:HvlwmtVNQAhOuCjW7xxvovg8wbNq7LwfXh/k7wXUl58
 golang.org/x/tools v0.16.1/go.mod h1:kYVVN6I1mBNoB1OX+noeBjbRk4IUEPa7JJ+TJMEooJ0=
 golang.org/x/tools v0.26.0 h1:v/60pFQmzmT9ExmjDv2gGIfi3OqfKoEP6I5+umXlbnQ=
 golang.org/x/tools v0.26.0/go.mod h1:TPVVj70c7JJ3WCazhD8OdXcZg/og+b9+tH/KxylGwH0=
-golang.org/x/tools/cmd/cover v0.1.0-deprecated h1:Rwy+mWYz6loAF+LnG1jHG/JWMHRMMC2/1XX3Ejkx9lA=
-golang.org/x/tools/cmd/cover v0.1.0-deprecated/go.mod h1:hMDiIvlpN1NoVgmjLjUJE9tMHyxHjFX7RuQ+rW12mSA=
-golang.org/x/tools/go/vcs v0.1.0-deprecated h1:cOIJqWBl99H1dH5LWizPa+0ImeeJq3t3cJjaeOWUAL4=
-golang.org/x/tools/go/vcs v0.1.0-deprecated/go.mod h1:zUrvATBAvEI9535oC0yWYsLsHIV4Z7g63sNPVMtuBy8=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=

--- a/ibm/service/secretsmanager/data_source_ibm_sm_imported_certificate.go
+++ b/ibm/service/secretsmanager/data_source_ibm_sm_imported_certificate.go
@@ -125,6 +125,11 @@ func DataSourceIbmSmImportedCertificate() *schema.Resource {
 				Computed:    true,
 				Description: "The Common Name (AKA CN) represents the server name protected by the SSL certificate.",
 			},
+			"csr": &schema.Schema{
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The certificate signing request.",
+			},
 			"expiration_date": &schema.Schema{
 				Type:        schema.TypeString,
 				Computed:    true,
@@ -170,6 +175,171 @@ func DataSourceIbmSmImportedCertificate() *schema.Resource {
 							Type:        schema.TypeString,
 							Computed:    true,
 							Description: "The date-time format follows RFC 3339.",
+						},
+					},
+				},
+			},
+			"managed_csr": &schema.Schema{
+				Type:        schema.TypeList,
+				Computed:    true,
+				Description: "The data specified to create the CSR and the private key.",
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"alt_names": &schema.Schema{
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "With the Subject Alternative Name field, you can specify additional hostnames to be protected by a single SSL certificate.",
+						},
+						"client_flag": &schema.Schema{
+							Type:        schema.TypeBool,
+							Computed:    true,
+							Description: "This field indicates whether certificate is flagged for client use.",
+						},
+						"code_signing_flag": &schema.Schema{
+							Type:        schema.TypeBool,
+							Computed:    true,
+							Description: "This field indicates whether certificate is flagged for code signing use.",
+						},
+						"common_name": &schema.Schema{
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "The Common Name (CN) represents the server name protected by the SSL certificate.",
+						},
+						"csr": &schema.Schema{
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "The certificate signing request.",
+						},
+						"country": &schema.Schema{
+							Type:        schema.TypeList,
+							Computed:    true,
+							Description: "The Country (C) values to define in the subject field of the resulting certificate.",
+							Elem: &schema.Schema{
+								Type: schema.TypeString,
+							},
+						},
+						"email_protection_flag": &schema.Schema{
+							Type:        schema.TypeBool,
+							Computed:    true,
+							Description: "This field indicates whether certificate is flagged for email protection use.",
+						},
+						"exclude_cn_from_sans": &schema.Schema{
+							Type:        schema.TypeBool,
+							Computed:    true,
+							Description: "This parameter controls whether the common name is excluded from Subject Alternative Names (SANs).",
+						},
+						"ext_key_usage": &schema.Schema{
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "The allowed extended key usage constraint on certificate, in a comma-delimited list.",
+						},
+						"ext_key_usage_oids": &schema.Schema{
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "A comma-delimited list of extended key usage Object Identifiers (OIDs).",
+						},
+						"ip_sans": &schema.Schema{
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "The IP Subject Alternative Names to define for the certificate, in a comma-delimited list.",
+						},
+						"key_bits": &schema.Schema{
+							Type:        schema.TypeInt,
+							Computed:    true,
+							Description: "The number of bits to use to generate the private key.",
+						},
+						"key_type": &schema.Schema{
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "The type of private key to generate.",
+						},
+						"key_usage": &schema.Schema{
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "The allowed key usage constraint to define for certificate, in a comma-delimited list.",
+						},
+						"locality": &schema.Schema{
+							Type:        schema.TypeList,
+							Computed:    true,
+							Description: "The Locality (L) values to define in the subject field of the resulting certificate.",
+							Elem: &schema.Schema{
+								Type: schema.TypeString,
+							},
+						},
+						"organization": &schema.Schema{
+							Type:        schema.TypeList,
+							Computed:    true,
+							Description: "The Organization (O) values to define in the subject field of the resulting certificate.",
+							Elem: &schema.Schema{
+								Type: schema.TypeString,
+							},
+						},
+						"other_sans": &schema.Schema{
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "The custom Object Identifier (OID) or UTF8-string Subject Alternative Names to define for the certificate, in a comma-delimited list.",
+						},
+						"ou": &schema.Schema{
+							Type:        schema.TypeList,
+							Computed:    true,
+							Description: "The Organizational Unit (OU) values to define in the subject field of the resulting certificate.",
+							Elem: &schema.Schema{
+								Type: schema.TypeString,
+							},
+						},
+						"policy_identifiers": &schema.Schema{
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "A comma-delimited list of policy Object Identifiers (OIDs).",
+						},
+						"postal_code": &schema.Schema{
+							Type:        schema.TypeList,
+							Computed:    true,
+							Description: "The postal code values to define in the subject field of the resulting certificate.",
+							Elem: &schema.Schema{
+								Type: schema.TypeString,
+							},
+						},
+						"province": &schema.Schema{
+							Type:        schema.TypeList,
+							Computed:    true,
+							Description: "The Province (ST) values to define in the subject field of the resulting certificate.",
+							Elem: &schema.Schema{
+								Type: schema.TypeString,
+							},
+						},
+						"require_cn": &schema.Schema{
+							Type:        schema.TypeBool,
+							Computed:    true,
+							Description: "If set to false, makes the common_name field optional while generating a certificate.",
+						},
+						"rotate_keys": &schema.Schema{
+							Type:        schema.TypeBool,
+							Computed:    true,
+							Description: "This field indicates whether the private key will be rotated.",
+						},
+						"server_flag": &schema.Schema{
+							Type:        schema.TypeBool,
+							Computed:    true,
+							Description: "This field indicates whether certificate is flagged for server use.",
+						},
+						"street_address": &schema.Schema{
+							Type:        schema.TypeList,
+							Computed:    true,
+							Description: "The street address values to define in the subject field of the resulting certificate.",
+							Elem: &schema.Schema{
+								Type: schema.TypeString,
+							},
+						},
+						"uri_sans": &schema.Schema{
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "The URI Subject Alternative Names to define for the certificate, in a comma-delimited list.",
+						},
+						"user_ids": &schema.Schema{
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "Specifies the list of requested User ID (OID 0.9.2342.19200300.100.1.1) Subject values to be placed on the signed certificate.",
 						},
 					},
 				},
@@ -360,6 +530,13 @@ func dataSourceIbmSmImportedCertificateRead(context context.Context, d *schema.R
 		return tfErr.GetDiag()
 	}
 
+	if importedCertificate.ManagedCsr != nil {
+		managedCsrMap := managedCsrToMap(importedCertificate.ManagedCsr)
+		if err = d.Set("managed_csr", []map[string]interface{}{managedCsrMap}); err != nil {
+			tfErr := flex.TerraformErrorf(err, fmt.Sprintf("Error setting managed_csr"), ImportedCertSecretResourceName, "read")
+			return tfErr.GetDiag()
+		}
+	}
 	return nil
 }
 

--- a/ibm/service/secretsmanager/data_source_ibm_sm_imported_certificate_metadata.go
+++ b/ibm/service/secretsmanager/data_source_ibm_sm_imported_certificate_metadata.go
@@ -137,6 +137,171 @@ func DataSourceIbmSmImportedCertificateMetadata() *schema.Resource {
 				Computed:    true,
 				Description: "The identifier for the cryptographic algorithm used to generate the public key that is associated with the certificate.",
 			},
+			"managed_csr": &schema.Schema{
+				Type:        schema.TypeList,
+				Computed:    true,
+				Description: "The data specified to create the CSR and the private key.",
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"alt_names": &schema.Schema{
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "With the Subject Alternative Name field, you can specify additional hostnames to be protected by a single SSL certificate.",
+						},
+						"client_flag": &schema.Schema{
+							Type:        schema.TypeBool,
+							Computed:    true,
+							Description: "This field indicates whether certificate is flagged for client use.",
+						},
+						"code_signing_flag": &schema.Schema{
+							Type:        schema.TypeBool,
+							Computed:    true,
+							Description: "This field indicates whether certificate is flagged for code signing use.",
+						},
+						"common_name": &schema.Schema{
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "The Common Name (CN) represents the server name protected by the SSL certificate.",
+						},
+						"csr": &schema.Schema{
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "The certificate signing request.",
+						},
+						"country": &schema.Schema{
+							Type:        schema.TypeList,
+							Computed:    true,
+							Description: "The Country (C) values to define in the subject field of the resulting certificate.",
+							Elem: &schema.Schema{
+								Type: schema.TypeString,
+							},
+						},
+						"email_protection_flag": &schema.Schema{
+							Type:        schema.TypeBool,
+							Computed:    true,
+							Description: "This field indicates whether certificate is flagged for email protection use.",
+						},
+						"exclude_cn_from_sans": &schema.Schema{
+							Type:        schema.TypeBool,
+							Computed:    true,
+							Description: "This parameter controls whether the common name is excluded from Subject Alternative Names (SANs).",
+						},
+						"ext_key_usage": &schema.Schema{
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "The allowed extended key usage constraint on certificate, in a comma-delimited list.",
+						},
+						"ext_key_usage_oids": &schema.Schema{
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "A comma-delimited list of extended key usage Object Identifiers (OIDs).",
+						},
+						"ip_sans": &schema.Schema{
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "The IP Subject Alternative Names to define for the certificate, in a comma-delimited list.",
+						},
+						"key_bits": &schema.Schema{
+							Type:        schema.TypeInt,
+							Computed:    true,
+							Description: "The number of bits to use to generate the private key.",
+						},
+						"key_type": &schema.Schema{
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "The type of private key to generate.",
+						},
+						"key_usage": &schema.Schema{
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "The allowed key usage constraint to define for certificate, in a comma-delimited list.",
+						},
+						"locality": &schema.Schema{
+							Type:        schema.TypeList,
+							Computed:    true,
+							Description: "The Locality (L) values to define in the subject field of the resulting certificate.",
+							Elem: &schema.Schema{
+								Type: schema.TypeString,
+							},
+						},
+						"organization": &schema.Schema{
+							Type:        schema.TypeList,
+							Computed:    true,
+							Description: "The Organization (O) values to define in the subject field of the resulting certificate.",
+							Elem: &schema.Schema{
+								Type: schema.TypeString,
+							},
+						},
+						"other_sans": &schema.Schema{
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "The custom Object Identifier (OID) or UTF8-string Subject Alternative Names to define for the certificate, in a comma-delimited list.",
+						},
+						"ou": &schema.Schema{
+							Type:        schema.TypeList,
+							Computed:    true,
+							Description: "The Organizational Unit (OU) values to define in the subject field of the resulting certificate.",
+							Elem: &schema.Schema{
+								Type: schema.TypeString,
+							},
+						},
+						"policy_identifiers": &schema.Schema{
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "A comma-delimited list of policy Object Identifiers (OIDs).",
+						},
+						"postal_code": &schema.Schema{
+							Type:        schema.TypeList,
+							Computed:    true,
+							Description: "The postal code values to define in the subject field of the resulting certificate.",
+							Elem: &schema.Schema{
+								Type: schema.TypeString,
+							},
+						},
+						"province": &schema.Schema{
+							Type:        schema.TypeList,
+							Computed:    true,
+							Description: "The Province (ST) values to define in the subject field of the resulting certificate.",
+							Elem: &schema.Schema{
+								Type: schema.TypeString,
+							},
+						},
+						"require_cn": &schema.Schema{
+							Type:        schema.TypeBool,
+							Computed:    true,
+							Description: "If set to false, makes the common_name field optional while generating a certificate.",
+						},
+						"rotate_keys": &schema.Schema{
+							Type:        schema.TypeBool,
+							Computed:    true,
+							Description: "This field indicates whether the private key will be rotated.",
+						},
+						"server_flag": &schema.Schema{
+							Type:        schema.TypeBool,
+							Computed:    true,
+							Description: "This field indicates whether certificate is flagged for server use.",
+						},
+						"street_address": &schema.Schema{
+							Type:        schema.TypeList,
+							Computed:    true,
+							Description: "The street address values to define in the subject field of the resulting certificate.",
+							Elem: &schema.Schema{
+								Type: schema.TypeString,
+							},
+						},
+						"uri_sans": &schema.Schema{
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "The URI Subject Alternative Names to define for the certificate, in a comma-delimited list.",
+						},
+						"user_ids": &schema.Schema{
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "Specifies the list of requested User ID (OID 0.9.2342.19200300.100.1.1) Subject values to be placed on the signed certificate.",
+						},
+					},
+				},
+			},
 			"private_key_included": &schema.Schema{
 				Type:        schema.TypeBool,
 				Computed:    true,
@@ -334,6 +499,14 @@ func dataSourceIbmSmImportedCertificateMetadataRead(context context.Context, d *
 	if err = d.Set("validity", validity); err != nil {
 		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("Error setting validity"), fmt.Sprintf("(Data) %s_metadata", ImportedCertSecretResourceName), "read")
 		return tfErr.GetDiag()
+	}
+
+	if importedCertificateMetadata.ManagedCsr != nil {
+		managedCsrMap := managedCsrToMap(importedCertificateMetadata.ManagedCsr)
+		if err = d.Set("managed_csr", []map[string]interface{}{managedCsrMap}); err != nil {
+			tfErr := flex.TerraformErrorf(err, fmt.Sprintf("Error setting managed_csr"), ImportedCertSecretResourceName, "read")
+			return tfErr.GetDiag()
+		}
 	}
 
 	return nil

--- a/ibm/service/secretsmanager/data_source_ibm_sm_imported_certificate_metadata_test.go
+++ b/ibm/service/secretsmanager/data_source_ibm_sm_imported_certificate_metadata_test.go
@@ -42,6 +42,49 @@ func TestAccIbmSmImportedCertificateMetadataDataSourceBasic(t *testing.T) {
 	})
 }
 
+func TestAccIbmSmImportedCertificateMetadataDataSourceManagedCSR(t *testing.T) {
+	dataSourceName := "data.ibm_sm_imported_certificate_metadata.managed_csr"
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { acc.TestAccPreCheck(t) },
+		Providers: acc.TestAccProviders,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccCheckIbmSmImportedCertificateMetadataDataSourceManagedCSR(),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet(dataSourceName, "secret_id"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "instance_id"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "crn"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "secret_type"),
+					resource.TestCheckResourceAttr(dataSourceName, "managed_csr.0.common_name", "example.com"),
+					resource.TestCheckResourceAttr(dataSourceName, "managed_csr.0.alt_names", "alt1"),
+					resource.TestCheckResourceAttr(dataSourceName, "managed_csr.0.client_flag", "true"),
+					resource.TestCheckResourceAttr(dataSourceName, "managed_csr.0.code_signing_flag", "false"),
+					resource.TestCheckResourceAttr(dataSourceName, "managed_csr.0.organization.0", "IBM"),
+					resource.TestCheckResourceAttr(dataSourceName, "managed_csr.0.country.0", "IL"),
+					resource.TestCheckResourceAttr(dataSourceName, "managed_csr.0.ou.0", "ILSL"),
+					resource.TestCheckResourceAttr(dataSourceName, "managed_csr.0.postal_code.0", "5320047"),
+					resource.TestCheckResourceAttr(dataSourceName, "managed_csr.0.province.0", "DAN"),
+					resource.TestCheckResourceAttr(dataSourceName, "managed_csr.0.locality.0", "Givatayim"),
+					resource.TestCheckResourceAttr(dataSourceName, "managed_csr.0.email_protection_flag", "false"),
+					resource.TestCheckResourceAttr(dataSourceName, "managed_csr.0.exclude_cn_from_sans", "false"),
+					resource.TestCheckResourceAttr(dataSourceName, "managed_csr.0.ext_key_usage", "timestamping"),
+					resource.TestCheckResourceAttr(dataSourceName, "managed_csr.0.ip_sans", "127.0.0.1"),
+					resource.TestCheckResourceAttr(dataSourceName, "managed_csr.0.key_bits", "2048"),
+					resource.TestCheckResourceAttr(dataSourceName, "managed_csr.0.key_type", "rsa"),
+					resource.TestCheckResourceAttr(dataSourceName, "managed_csr.0.key_usage", "DigitalSignature"),
+					resource.TestCheckResourceAttr(dataSourceName, "managed_csr.0.other_sans", "1.3.6.1.4.1.311.21.2.3;utf8:*.example.com"),
+					resource.TestCheckResourceAttr(dataSourceName, "managed_csr.0.policy_identifiers", ""),
+					resource.TestCheckResourceAttr(dataSourceName, "managed_csr.0.uri_sans", "https://www.example.com/test"),
+					resource.TestCheckResourceAttr(dataSourceName, "managed_csr.0.user_ids", "user"),
+					resource.TestCheckResourceAttr(dataSourceName, "managed_csr.0.require_cn", "true"),
+					resource.TestCheckResourceAttr(dataSourceName, "managed_csr.0.rotate_keys", "false"),
+					resource.TestCheckResourceAttr(dataSourceName, "managed_csr.0.server_flag", "true"),
+				),
+			},
+		},
+	})
+}
+
 func testAccCheckIbmSmImportedCertificateMetadataDataSourceConfigBasic() string {
 	return fmt.Sprintf(`
 		resource "ibm_sm_imported_certificate" "sm_imported_certificate_instance" {
@@ -60,4 +103,49 @@ func testAccCheckIbmSmImportedCertificateMetadataDataSourceConfigBasic() string 
 			secret_id = ibm_sm_imported_certificate.sm_imported_certificate_instance.secret_id
 		}
 	`, acc.SecretsManagerInstanceID, acc.SecretsManagerInstanceRegion, acc.SecretsManagerImportedCertificatePathToCertificate, acc.SecretsManagerInstanceID, acc.SecretsManagerInstanceRegion)
+}
+
+func testAccCheckIbmSmImportedCertificateMetadataDataSourceManagedCSR() string {
+	return fmt.Sprintf(`
+		resource "ibm_sm_imported_certificate" "managed_csr" {
+			instance_id   = "%s"
+			region        = "%s"
+			name = "imported_cert_terraform_test_managed_csr"
+			managed_csr {
+				alt_names = "alt1"
+				client_flag = true
+				code_signing_flag = false
+				common_name = "example.com"
+				country = ["IL"]
+				email_protection_flag = false
+				exclude_cn_from_sans = false
+				ext_key_usage = "timestamping"
+				ext_key_usage_oids = "1.3.6.1.5.5.7.3.67"
+				ip_sans = "127.0.0.1"
+				key_bits = 2048
+				key_type = "rsa"
+				key_usage = "DigitalSignature"
+				locality = ["Givatayim"]
+				policy_identifiers = ""
+				organization = ["IBM"]
+				other_sans = "1.3.6.1.4.1.311.21.2.3;utf8:*.example.com"
+				ou = ["ILSL"]
+				postal_code = ["5320047"]
+				province = ["DAN"]
+				require_cn = true
+				rotate_keys = false
+				server_flag = true
+				street_address = ["Ariel Sharon 4"]
+				uri_sans = "https://www.example.com/test"
+				user_ids = "user"
+			}
+		}
+
+		data "ibm_sm_imported_certificate_metadata" "managed_csr" {
+			instance_id = "%s"
+			region = "%s"
+			secret_id = ibm_sm_imported_certificate.managed_csr.secret_id
+		}
+
+	`, acc.SecretsManagerInstanceID, acc.SecretsManagerInstanceRegion, acc.SecretsManagerInstanceID, acc.SecretsManagerInstanceRegion)
 }

--- a/ibm/service/secretsmanager/data_source_ibm_sm_imported_certificate_test.go
+++ b/ibm/service/secretsmanager/data_source_ibm_sm_imported_certificate_test.go
@@ -45,6 +45,49 @@ func TestAccIbmSmImportedCertificateDataSourceBasic(t *testing.T) {
 	})
 }
 
+func TestAccIbmSmImportedCertificateDataSourceManagedCSR(t *testing.T) {
+	dataSourceName := "data.ibm_sm_imported_certificate.managed_csr"
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { acc.TestAccPreCheck(t) },
+		Providers: acc.TestAccProviders,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccCheckIbmSmImportedCertificateDataSourceManagedCSR(),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet(dataSourceName, "secret_id"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "instance_id"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "crn"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "secret_type"),
+					resource.TestCheckResourceAttr(dataSourceName, "managed_csr.0.common_name", "example.com"),
+					resource.TestCheckResourceAttr(dataSourceName, "managed_csr.0.alt_names", "alt1"),
+					resource.TestCheckResourceAttr(dataSourceName, "managed_csr.0.client_flag", "true"),
+					resource.TestCheckResourceAttr(dataSourceName, "managed_csr.0.code_signing_flag", "false"),
+					resource.TestCheckResourceAttr(dataSourceName, "managed_csr.0.organization.0", "IBM"),
+					resource.TestCheckResourceAttr(dataSourceName, "managed_csr.0.country.0", "IL"),
+					resource.TestCheckResourceAttr(dataSourceName, "managed_csr.0.ou.0", "ILSL"),
+					resource.TestCheckResourceAttr(dataSourceName, "managed_csr.0.postal_code.0", "5320047"),
+					resource.TestCheckResourceAttr(dataSourceName, "managed_csr.0.province.0", "DAN"),
+					resource.TestCheckResourceAttr(dataSourceName, "managed_csr.0.locality.0", "Givatayim"),
+					resource.TestCheckResourceAttr(dataSourceName, "managed_csr.0.email_protection_flag", "false"),
+					resource.TestCheckResourceAttr(dataSourceName, "managed_csr.0.exclude_cn_from_sans", "false"),
+					resource.TestCheckResourceAttr(dataSourceName, "managed_csr.0.ext_key_usage", "timestamping"),
+					resource.TestCheckResourceAttr(dataSourceName, "managed_csr.0.ip_sans", "127.0.0.1"),
+					resource.TestCheckResourceAttr(dataSourceName, "managed_csr.0.key_bits", "2048"),
+					resource.TestCheckResourceAttr(dataSourceName, "managed_csr.0.key_type", "rsa"),
+					resource.TestCheckResourceAttr(dataSourceName, "managed_csr.0.key_usage", "DigitalSignature"),
+					resource.TestCheckResourceAttr(dataSourceName, "managed_csr.0.other_sans", "1.3.6.1.4.1.311.21.2.3;utf8:*.example.com"),
+					resource.TestCheckResourceAttr(dataSourceName, "managed_csr.0.policy_identifiers", ""),
+					resource.TestCheckResourceAttr(dataSourceName, "managed_csr.0.uri_sans", "https://www.example.com/test"),
+					resource.TestCheckResourceAttr(dataSourceName, "managed_csr.0.user_ids", "user"),
+					resource.TestCheckResourceAttr(dataSourceName, "managed_csr.0.require_cn", "true"),
+					resource.TestCheckResourceAttr(dataSourceName, "managed_csr.0.rotate_keys", "false"),
+					resource.TestCheckResourceAttr(dataSourceName, "managed_csr.0.server_flag", "true"),
+				),
+			},
+		},
+	})
+}
+
 func testAccCheckIbmSmImportedCertificateDataSourceConfigBasic() string {
 	return fmt.Sprintf(`
 		resource "ibm_sm_imported_certificate" "sm_imported_certificate_instance" {
@@ -71,4 +114,49 @@ func testAccCheckIbmSmImportedCertificateDataSourceConfigBasic() string {
 			secret_group_name = "default"
 		}
 	`, acc.SecretsManagerInstanceID, acc.SecretsManagerInstanceRegion, acc.SecretsManagerImportedCertificatePathToCertificate, acc.SecretsManagerInstanceID, acc.SecretsManagerInstanceRegion, acc.SecretsManagerInstanceID, acc.SecretsManagerInstanceRegion)
+}
+
+func testAccCheckIbmSmImportedCertificateDataSourceManagedCSR() string {
+	return fmt.Sprintf(`
+		resource "ibm_sm_imported_certificate" "managed_csr" {
+			instance_id   = "%s"
+			region        = "%s"
+			name = "imported_cert_terraform_test_managed_csr"
+			managed_csr {
+				alt_names = "alt1"
+				client_flag = true
+				code_signing_flag = false
+				common_name = "example.com"
+				country = ["IL"]
+				email_protection_flag = false
+				exclude_cn_from_sans = false
+				ext_key_usage = "timestamping"
+				ext_key_usage_oids = "1.3.6.1.5.5.7.3.67"
+				ip_sans = "127.0.0.1"
+				key_bits = 2048
+				key_type = "rsa"
+				key_usage = "DigitalSignature"
+				locality = ["Givatayim"]
+				policy_identifiers = ""
+				organization = ["IBM"]
+				other_sans = "1.3.6.1.4.1.311.21.2.3;utf8:*.example.com"
+				ou = ["ILSL"]
+				postal_code = ["5320047"]
+				province = ["DAN"]
+				require_cn = true
+				rotate_keys = false
+				server_flag = true
+				street_address = ["Ariel Sharon 4"]
+				uri_sans = "https://www.example.com/test"
+				user_ids = "user"
+			}
+		}
+
+		data "ibm_sm_imported_certificate" "managed_csr" {
+			instance_id = "%s"
+			region = "%s"
+			secret_id = ibm_sm_imported_certificate.managed_csr.secret_id
+		}
+
+	`, acc.SecretsManagerInstanceID, acc.SecretsManagerInstanceRegion, acc.SecretsManagerInstanceID, acc.SecretsManagerInstanceRegion)
 }

--- a/ibm/service/secretsmanager/resource_ibm_sm_imported_certificate.go
+++ b/ibm/service/secretsmanager/resource_ibm_sm_imported_certificate.go
@@ -6,13 +6,10 @@ package secretsmanager
 import (
 	"context"
 	"fmt"
-	"github.com/IBM-Cloud/bluemix-go/bmxerror"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"log"
 	"strings"
-	"time"
 
 	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/conns"
 	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/flex"
@@ -29,6 +26,11 @@ func ResourceIbmSmImportedCertificate() *schema.Resource {
 		Importer:      &schema.ResourceImporter{},
 
 		Schema: map[string]*schema.Schema{
+			"csr": &schema.Schema{
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The certificate signing request.",
+			},
 			"custom_metadata": &schema.Schema{
 				Type:        schema.TypeMap,
 				Optional:    true,
@@ -83,7 +85,7 @@ func ResourceIbmSmImportedCertificate() *schema.Resource {
 			},
 			"certificate": &schema.Schema{
 				Type:      schema.TypeString,
-				Required:  true,
+				Optional:  true,
 				Sensitive: true,
 				DiffSuppressFunc: func(k, oldValue, newValue string, d *schema.ResourceData) bool {
 					if removeNewLineFromCertificate(oldValue) == removeNewLineFromCertificate(newValue) {
@@ -110,12 +112,204 @@ func ResourceIbmSmImportedCertificate() *schema.Resource {
 				Optional:  true,
 				Sensitive: true,
 				DiffSuppressFunc: func(k, oldValue, newValue string, d *schema.ResourceData) bool {
+					lenManagedCsr := 0
+					rawManagedCsr, managedCsrExists := d.GetOkExists("managed_csr")
+					if managedCsrExists {
+						lenManagedCsr = len(rawManagedCsr.([]interface{}))
+					}
+					isManagedCsr := lenManagedCsr > 0
+					if isManagedCsr {
+						return true
+					}
 					if removeNewLineFromCertificate(oldValue) == removeNewLineFromCertificate(newValue) {
 						return true
 					}
 					return false
 				},
-				Description: "(Optional) The PEM-encoded private key to associate with the certificate.",
+				Description: "(Optional for non managed CSR secrets) The PEM-encoded private key to associate with the certificate.",
+			},
+			"managed_csr": &schema.Schema{
+				Type:        schema.TypeList,
+				MaxItems:    1,
+				Optional:    true,
+				Computed:    true,
+				Description: "The data specified to create the CSR and the private key.",
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"alt_names": &schema.Schema{
+							Type:        schema.TypeString,
+							Optional:    true,
+							Description: "With the Subject Alternative Name field, you can specify additional hostnames to be protected by a single SSL certificate.",
+						},
+						"client_flag": &schema.Schema{
+							Type:        schema.TypeBool,
+							Default:     true,
+							Optional:    true,
+							Description: "This field indicates whether certificate is flagged for client use.",
+						},
+						"code_signing_flag": &schema.Schema{
+							Type:        schema.TypeBool,
+							Default:     false,
+							Optional:    true,
+							Description: "This field indicates whether certificate is flagged for code signing use.",
+						},
+						"common_name": &schema.Schema{
+							Type:        schema.TypeString,
+							Optional:    true,
+							Description: "The Common Name (CN) represents the server name protected by the SSL certificate.",
+						},
+						"csr": &schema.Schema{
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "The certificate signing request.",
+						},
+						"country": &schema.Schema{
+							Type:        schema.TypeList,
+							Computed:    true,
+							Optional:    true,
+							Description: "The Country (C) values to define in the subject field of the resulting certificate.",
+							Elem: &schema.Schema{
+								Type: schema.TypeString,
+							},
+						},
+						"email_protection_flag": &schema.Schema{
+							Type:        schema.TypeBool,
+							Default:     false,
+							Optional:    true,
+							Description: "This field indicates whether certificate is flagged for email protection use.",
+						},
+						"exclude_cn_from_sans": &schema.Schema{
+							Type:        schema.TypeBool,
+							Default:     false,
+							Optional:    true,
+							Description: "This parameter controls whether the common name is excluded from Subject Alternative Names (SANs).",
+						},
+						"ext_key_usage": &schema.Schema{
+							Type:        schema.TypeString,
+							Optional:    true,
+							Description: "The allowed extended key usage constraint on certificate, in a comma-delimited list.",
+						},
+						"ext_key_usage_oids": &schema.Schema{
+							Type:        schema.TypeString,
+							Optional:    true,
+							Description: "A comma-delimited list of extended key usage Object Identifiers (OIDs).",
+						},
+						"ip_sans": &schema.Schema{
+							Type:        schema.TypeString,
+							Optional:    true,
+							Description: "The IP Subject Alternative Names to define for the certificate, in a comma-delimited list.",
+						},
+						"key_bits": &schema.Schema{
+							Type:        schema.TypeInt,
+							Optional:    true,
+							Computed:    true,
+							Description: "The number of bits to use to generate the private key.",
+						},
+						"key_type": &schema.Schema{
+							Type:        schema.TypeString,
+							Optional:    true,
+							Default:     "rsa",
+							Description: "The type of private key to generate.",
+						},
+						"key_usage": &schema.Schema{
+							Type:        schema.TypeString,
+							Optional:    true,
+							Description: "The allowed key usage constraint to define for certificate, in a comma-delimited list.",
+						},
+						"locality": &schema.Schema{
+							Type:        schema.TypeList,
+							Computed:    true,
+							Optional:    true,
+							Description: "The Locality (L) values to define in the subject field of the resulting certificate.",
+							Elem: &schema.Schema{
+								Type: schema.TypeString,
+							},
+						},
+						"organization": &schema.Schema{
+							Type:        schema.TypeList,
+							Computed:    true,
+							Optional:    true,
+							Description: "The Organization (O) values to define in the subject field of the resulting certificate.",
+							Elem: &schema.Schema{
+								Type: schema.TypeString,
+							},
+						},
+						"other_sans": &schema.Schema{
+							Type:        schema.TypeString,
+							Optional:    true,
+							Description: "The custom Object Identifier (OID) or UTF8-string Subject Alternative Names to define for the certificate, in a comma-delimited list.",
+						},
+						"ou": &schema.Schema{
+							Type:        schema.TypeList,
+							Computed:    true,
+							Optional:    true,
+							Description: "The Organizational Unit (OU) values to define in the subject field of the resulting certificate.",
+							Elem: &schema.Schema{
+								Type: schema.TypeString,
+							},
+						},
+						"policy_identifiers": &schema.Schema{
+							Type:        schema.TypeString,
+							Optional:    true,
+							Description: "A comma-delimited list of policy Object Identifiers (OIDs).",
+						},
+						"postal_code": &schema.Schema{
+							Type:        schema.TypeList,
+							Computed:    true,
+							Optional:    true,
+							Description: "The postal code values to define in the subject field of the resulting certificate.",
+							Elem: &schema.Schema{
+								Type: schema.TypeString,
+							},
+						},
+						"province": &schema.Schema{
+							Type:        schema.TypeList,
+							Computed:    true,
+							Optional:    true,
+							Description: "The Province (ST) values to define in the subject field of the resulting certificate.",
+							Elem: &schema.Schema{
+								Type: schema.TypeString,
+							},
+						},
+						"require_cn": &schema.Schema{
+							Type:        schema.TypeBool,
+							Default:     true,
+							Optional:    true,
+							Description: "If set to false, makes the common_name field optional while generating a certificate.",
+						},
+						"rotate_keys": &schema.Schema{
+							Type:        schema.TypeBool,
+							Default:     false,
+							Optional:    true,
+							Description: "This field indicates whether the private key will be rotated.",
+						},
+						"server_flag": &schema.Schema{
+							Type:        schema.TypeBool,
+							Default:     true,
+							Optional:    true,
+							Description: "This field indicates whether certificate is flagged for server use.",
+						},
+						"street_address": &schema.Schema{
+							Type:        schema.TypeList,
+							Computed:    true,
+							Optional:    true,
+							Description: "The street address values to define in the subject field of the resulting certificate.",
+							Elem: &schema.Schema{
+								Type: schema.TypeString,
+							},
+						},
+						"uri_sans": &schema.Schema{
+							Type:        schema.TypeString,
+							Optional:    true,
+							Description: "The URI Subject Alternative Names to define for the certificate, in a comma-delimited list.",
+						},
+						"user_ids": &schema.Schema{
+							Type:        schema.TypeString,
+							Optional:    true,
+							Description: "Specifies the list of requested User ID (OID 0.9.2342.19200300.100.1.1) Subject values to be placed on the signed certificate.",
+						},
+					},
+				},
 			},
 			"common_name": &schema.Schema{
 				Type:        schema.TypeString,
@@ -251,47 +445,7 @@ func resourceIbmSmImportedCertificateCreate(context context.Context, d *schema.R
 	d.SetId(fmt.Sprintf("%s/%s/%s", region, instanceId, *secret.ID))
 	d.Set("secret_id", *secret.ID)
 
-	_, err = waitForIbmSmImportedCertificateCreate(secretsManagerClient, d)
-	if err != nil {
-		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("Error waiting for resource IbmSmImportedCertificate (%s) to be created: %s", d.Id(), err.Error()), ImportedCertSecretResourceName, "create")
-		return tfErr.GetDiag()
-	}
-
 	return resourceIbmSmImportedCertificateRead(context, d, meta)
-}
-
-func waitForIbmSmImportedCertificateCreate(secretsManagerClient *secretsmanagerv2.SecretsManagerV2, d *schema.ResourceData) (interface{}, error) {
-	getSecretOptions := &secretsmanagerv2.GetSecretOptions{}
-
-	id := strings.Split(d.Id(), "/")
-	secretId := id[2]
-
-	getSecretOptions.SetID(secretId)
-
-	stateConf := &resource.StateChangeConf{
-		Pending: []string{"pre_activation"},
-		Target:  []string{"active"},
-		Refresh: func() (interface{}, string, error) {
-			stateObjIntf, response, err := secretsManagerClient.GetSecret(getSecretOptions)
-			stateObj := stateObjIntf.(*secretsmanagerv2.ImportedCertificate)
-			if err != nil {
-				if apiErr, ok := err.(bmxerror.RequestFailure); ok && apiErr.StatusCode() == 404 {
-					return nil, "", fmt.Errorf("The instance %s does not exist anymore: %s\n%s", "getSecretOptions", err, response)
-				}
-				return nil, "", err
-			}
-			failStates := map[string]bool{"destroyed": true}
-			if failStates[*stateObj.StateDescription] {
-				return stateObj, *stateObj.StateDescription, fmt.Errorf("The instance %s failed: %s\n%s", "getSecretOptions", err, response)
-			}
-			return stateObj, *stateObj.StateDescription, nil
-		},
-		Timeout:    d.Timeout(schema.TimeoutCreate),
-		Delay:      0 * time.Second,
-		MinTimeout: 5 * time.Second,
-	}
-
-	return stateConf.WaitForState()
 }
 
 func resourceIbmSmImportedCertificateRead(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
@@ -400,81 +554,192 @@ func resourceIbmSmImportedCertificateRead(context context.Context, d *schema.Res
 		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("Error setting versions_total"), ImportedCertSecretResourceName, "read")
 		return tfErr.GetDiag()
 	}
-	if err = d.Set("signing_algorithm", secret.SigningAlgorithm); err != nil {
-		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("Error setting signing_algorithm"), ImportedCertSecretResourceName, "read")
-		return tfErr.GetDiag()
+	if secret.ManagedCsr != nil {
+		managedCsrMap := managedCsrToMap(secret.ManagedCsr)
+		if err = d.Set("managed_csr", []map[string]interface{}{managedCsrMap}); err != nil {
+			tfErr := flex.TerraformErrorf(err, fmt.Sprintf("Error setting managed_csr"), ImportedCertSecretResourceName, "read")
+			return tfErr.GetDiag()
+		}
 	}
-	if err = d.Set("common_name", secret.CommonName); err != nil {
-		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("Error setting common_name"), ImportedCertSecretResourceName, "read")
-		return tfErr.GetDiag()
-	}
-	if err = d.Set("expiration_date", DateTimeToRFC3339(secret.ExpirationDate)); err != nil {
-		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("Error setting expiration_date"), ImportedCertSecretResourceName, "read")
-		return tfErr.GetDiag()
-	}
-	if err = d.Set("intermediate_included", secret.IntermediateIncluded); err != nil {
-		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("Error setting intermediate_included"), ImportedCertSecretResourceName, "read")
-		return tfErr.GetDiag()
-	}
-	if err = d.Set("issuer", secret.Issuer); err != nil {
-		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("Error setting issuer"), ImportedCertSecretResourceName, "read")
-		return tfErr.GetDiag()
-	}
-	if err = d.Set("key_algorithm", secret.KeyAlgorithm); err != nil {
-		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("Error setting key_algorithm"), ImportedCertSecretResourceName, "read")
-		return tfErr.GetDiag()
-	}
-	if err = d.Set("private_key_included", secret.PrivateKeyIncluded); err != nil {
-		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("Error setting private_key_included"), ImportedCertSecretResourceName, "read")
-		return tfErr.GetDiag()
-	}
-	if err = d.Set("serial_number", secret.SerialNumber); err != nil {
-		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("Error setting serial_number"), ImportedCertSecretResourceName, "read")
-		return tfErr.GetDiag()
-	}
-	validityMap, err := resourceIbmSmImportedCertificateCertificateValidityToMap(secret.Validity)
-	if err != nil {
-		tfErr := flex.TerraformErrorf(err, "", ImportedCertSecretResourceName, "read")
-		return tfErr.GetDiag()
-	}
-	if err = d.Set("validity", []map[string]interface{}{validityMap}); err != nil {
-		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("Error setting validity"), ImportedCertSecretResourceName, "read")
-		return tfErr.GetDiag()
-	}
-	if err = d.Set("certificate", secret.Certificate); err != nil {
-		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("Error setting certificate"), ImportedCertSecretResourceName, "read")
-		return tfErr.GetDiag()
-	}
-	if err = d.Set("intermediate", secret.Intermediate); err != nil {
-		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("Error setting intermediate"), ImportedCertSecretResourceName, "read")
-		return tfErr.GetDiag()
-	}
-	if err = d.Set("private_key", secret.PrivateKey); err != nil {
-		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("Error setting private_key"), ImportedCertSecretResourceName, "read")
-		return tfErr.GetDiag()
-	}
+	if d.Get("versions_total") != 0 {
+		if err = d.Set("signing_algorithm", secret.SigningAlgorithm); err != nil {
+			tfErr := flex.TerraformErrorf(err, fmt.Sprintf("Error setting signing_algorithm"), ImportedCertSecretResourceName, "read")
+			return tfErr.GetDiag()
+		}
+		if err = d.Set("common_name", secret.CommonName); err != nil {
+			tfErr := flex.TerraformErrorf(err, fmt.Sprintf("Error setting common_name"), ImportedCertSecretResourceName, "read")
+			return tfErr.GetDiag()
+		}
+		if err = d.Set("expiration_date", DateTimeToRFC3339(secret.ExpirationDate)); err != nil {
+			tfErr := flex.TerraformErrorf(err, fmt.Sprintf("Error setting expiration_date"), ImportedCertSecretResourceName, "read")
+			return tfErr.GetDiag()
+		}
+		if err = d.Set("intermediate_included", secret.IntermediateIncluded); err != nil {
+			tfErr := flex.TerraformErrorf(err, fmt.Sprintf("Error setting intermediate_included"), ImportedCertSecretResourceName, "read")
+			return tfErr.GetDiag()
+		}
+		if err = d.Set("issuer", secret.Issuer); err != nil {
+			tfErr := flex.TerraformErrorf(err, fmt.Sprintf("Error setting issuer"), ImportedCertSecretResourceName, "read")
+			return tfErr.GetDiag()
+		}
+		if err = d.Set("key_algorithm", secret.KeyAlgorithm); err != nil {
+			tfErr := flex.TerraformErrorf(err, fmt.Sprintf("Error setting key_algorithm"), ImportedCertSecretResourceName, "read")
+			return tfErr.GetDiag()
+		}
+		if err = d.Set("private_key_included", secret.PrivateKeyIncluded); err != nil {
+			tfErr := flex.TerraformErrorf(err, fmt.Sprintf("Error setting private_key_included"), ImportedCertSecretResourceName, "read")
+			return tfErr.GetDiag()
+		}
+		if err = d.Set("serial_number", secret.SerialNumber); err != nil {
+			tfErr := flex.TerraformErrorf(err, fmt.Sprintf("Error setting serial_number"), ImportedCertSecretResourceName, "read")
+			return tfErr.GetDiag()
+		}
+		log.Printf("[DEBUG] secret validity is null %t", secret.Validity == nil)
+		if secret.Validity != nil {
+			validityMap, err := resourceIbmSmImportedCertificateCertificateValidityToMap(secret.Validity)
+			if err != nil {
+				tfErr := flex.TerraformErrorf(err, "", ImportedCertSecretResourceName, "read")
+				return tfErr.GetDiag()
+			}
+			if err = d.Set("validity", []map[string]interface{}{validityMap}); err != nil {
+				tfErr := flex.TerraformErrorf(err, fmt.Sprintf("Error setting validity"), ImportedCertSecretResourceName, "read")
+				return tfErr.GetDiag()
+			}
+		}
+		if err = d.Set("certificate", secret.Certificate); err != nil {
+			tfErr := flex.TerraformErrorf(err, fmt.Sprintf("Error setting certificate"), ImportedCertSecretResourceName, "read")
+			return tfErr.GetDiag()
+		}
+		if err = d.Set("intermediate", secret.Intermediate); err != nil {
+			tfErr := flex.TerraformErrorf(err, fmt.Sprintf("Error setting intermediate"), ImportedCertSecretResourceName, "read")
+			return tfErr.GetDiag()
+		}
+		if err = d.Set("private_key", secret.PrivateKey); err != nil {
+			tfErr := flex.TerraformErrorf(err, fmt.Sprintf("Error setting private_key"), ImportedCertSecretResourceName, "read")
+			return tfErr.GetDiag()
+		}
+		if secret.Csr != nil {
+			if err = d.Set("csr", secret.Csr); err != nil {
+				tfErr := flex.TerraformErrorf(err, fmt.Sprintf("Error setting csr"), ImportedCertSecretResourceName, "read")
+				return tfErr.GetDiag()
+			}
+		}
+		// Call get version metadata API to get the current version_custom_metadata
+		getVersionMetdataOptions := &secretsmanagerv2.GetSecretVersionMetadataOptions{}
+		getVersionMetdataOptions.SetSecretID(secretId)
+		getVersionMetdataOptions.SetID("current")
 
-	// Call get version metadata API to get the current version_custom_metadata
-	getVersionMetdataOptions := &secretsmanagerv2.GetSecretVersionMetadataOptions{}
-	getVersionMetdataOptions.SetSecretID(secretId)
-	getVersionMetdataOptions.SetID("current")
+		versionMetadataIntf, response, err := secretsManagerClient.GetSecretVersionMetadataWithContext(context, getVersionMetdataOptions)
+		if err != nil {
+			log.Printf("[DEBUG] GetSecretVersionMetadataWithContext failed %s\n%s", err, response)
+			tfErr := flex.TerraformErrorf(err, fmt.Sprintf("GetSecretVersionMetadataWithContext failed %s\n%s", err, response), ImportedCertSecretResourceName, "read")
+			return tfErr.GetDiag()
+		}
 
-	versionMetadataIntf, response, err := secretsManagerClient.GetSecretVersionMetadataWithContext(context, getVersionMetdataOptions)
-	if err != nil {
-		log.Printf("[DEBUG] GetSecretVersionMetadataWithContext failed %s\n%s", err, response)
-		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("GetSecretVersionMetadataWithContext failed %s\n%s", err, response), ImportedCertSecretResourceName, "read")
-		return tfErr.GetDiag()
-	}
-
-	versionMetadata := versionMetadataIntf.(*secretsmanagerv2.ImportedCertificateVersionMetadata)
-	if versionMetadata.VersionCustomMetadata != nil {
-		if err = d.Set("version_custom_metadata", versionMetadata.VersionCustomMetadata); err != nil {
-			tfErr := flex.TerraformErrorf(err, fmt.Sprintf("Error setting version_custom_metadata"), ImportedCertSecretResourceName, "read")
+		versionMetadata := versionMetadataIntf.(*secretsmanagerv2.ImportedCertificateVersionMetadata)
+		if versionMetadata.VersionCustomMetadata != nil {
+			if err = d.Set("version_custom_metadata", versionMetadata.VersionCustomMetadata); err != nil {
+				tfErr := flex.TerraformErrorf(err, fmt.Sprintf("Error setting version_custom_metadata"), ImportedCertSecretResourceName, "read")
+				return tfErr.GetDiag()
+			}
+		}
+	} else {
+		if err = d.Set("validity", []map[string]interface{}{}); err != nil {
+			tfErr := flex.TerraformErrorf(err, fmt.Sprintf("Error setting validity"), ImportedCertSecretResourceName, "read")
 			return tfErr.GetDiag()
 		}
 	}
 
 	return nil
+}
+
+func managedCsrToMap(managedCsr *secretsmanagerv2.ImportedCertificateManagedCsrResponse) map[string]interface{} {
+	modelMap := make(map[string]interface{})
+	if managedCsr.AltNames != nil {
+		modelMap["alt_names"] = managedCsr.AltNames
+	}
+	if managedCsr.ClientFlag != nil {
+		modelMap["client_flag"] = managedCsr.ClientFlag
+	}
+	if managedCsr.CodeSigningFlag != nil {
+		modelMap["code_signing_flag"] = managedCsr.CodeSigningFlag
+	}
+	if managedCsr.CommonName != nil {
+		modelMap["common_name"] = managedCsr.CommonName
+	}
+	if managedCsr.Csr != nil {
+		modelMap["csr"] = managedCsr.Csr
+	}
+	if managedCsr.Country != nil {
+		modelMap["country"] = managedCsr.Country
+	}
+	if managedCsr.EmailProtectionFlag != nil {
+		modelMap["email_protection_flag"] = managedCsr.EmailProtectionFlag
+	}
+	if managedCsr.ExcludeCnFromSans != nil {
+		modelMap["exclude_cn_from_sans"] = managedCsr.ExcludeCnFromSans
+	}
+	if managedCsr.ExtKeyUsage != nil {
+		modelMap["ext_key_usage"] = managedCsr.ExtKeyUsage
+	}
+	if managedCsr.ExtKeyUsageOids != nil {
+		modelMap["ext_key_usage_oids"] = managedCsr.ExtKeyUsageOids
+	}
+	if managedCsr.IpSans != nil {
+		modelMap["ip_sans"] = managedCsr.IpSans
+	}
+	if managedCsr.IpSans != nil {
+		modelMap["ip_sans"] = managedCsr.IpSans
+	}
+	if managedCsr.KeyBits != nil {
+		modelMap["key_bits"] = managedCsr.KeyBits
+	}
+	if managedCsr.KeyType != nil {
+		modelMap["key_type"] = managedCsr.KeyType
+	}
+	if managedCsr.KeyUsage != nil {
+		modelMap["key_usage"] = managedCsr.KeyUsage
+	}
+	if managedCsr.Locality != nil {
+		modelMap["locality"] = managedCsr.Locality
+	}
+	if managedCsr.Organization != nil {
+		modelMap["organization"] = managedCsr.Organization
+	}
+	if managedCsr.OtherSans != nil {
+		modelMap["other_sans"] = managedCsr.OtherSans
+	}
+	if managedCsr.Ou != nil {
+		modelMap["ou"] = managedCsr.Ou
+	}
+	if managedCsr.PolicyIdentifiers != nil {
+		modelMap["policy_identifiers"] = managedCsr.PolicyIdentifiers
+	}
+	if managedCsr.PostalCode != nil {
+		modelMap["postal_code"] = managedCsr.PostalCode
+	}
+	if managedCsr.Province != nil {
+		modelMap["province"] = managedCsr.Province
+	}
+	if managedCsr.RequireCn != nil {
+		modelMap["require_cn"] = managedCsr.RequireCn
+	}
+	if managedCsr.RotateKeys != nil {
+		modelMap["rotate_keys"] = managedCsr.RotateKeys
+	}
+	if managedCsr.ServerFlag != nil {
+		modelMap["server_flag"] = managedCsr.ServerFlag
+	}
+	if managedCsr.StreetAddress != nil {
+		modelMap["street_address"] = managedCsr.StreetAddress
+	}
+	if managedCsr.UriSans != nil {
+		modelMap["uri_sans"] = managedCsr.UriSans
+	}
+	if managedCsr.UserIds != nil {
+		modelMap["user_ids"] = managedCsr.UserIds
+	}
+	return modelMap
 }
 
 func resourceIbmSmImportedCertificateUpdate(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
@@ -520,15 +785,14 @@ func resourceIbmSmImportedCertificateUpdate(context context.Context, d *schema.R
 		hasChange = true
 	}
 
-	// Apply change in metadata (if changed)
-	if hasChange {
-		updateSecretMetadataOptions.SecretMetadataPatch, _ = patchVals.AsPatch()
-		_, response, err := secretsManagerClient.UpdateSecretMetadataWithContext(context, updateSecretMetadataOptions)
+	if d.HasChange("managed_csr") {
+		managedCsr, err := mapManagedCsrOnCreate(d)
 		if err != nil {
-			log.Printf("[DEBUG] UpdateSecretMetadataWithContext failed %s\n%s", err, response)
-			tfErr := flex.TerraformErrorf(err, fmt.Sprintf("UpdateSecretMetadataWithContext failed %s\n%s", err, response), ImportedCertSecretResourceName, "update")
+			tfErr := flex.TerraformErrorf(err, "", ImportedCertSecretResourceName, "update")
 			return tfErr.GetDiag()
 		}
+		patchVals.ManagedCsr = managedCsr
+		hasChange = true
 	}
 
 	// Apply change in secret data (if changed)
@@ -583,6 +847,19 @@ func resourceIbmSmImportedCertificateUpdate(context context.Context, d *schema.R
 			return tfErr.GetDiag()
 		}
 	}
+
+	// Apply change in metadata (if changed)
+	if hasChange {
+
+		updateSecretMetadataOptions.SecretMetadataPatch, _ = patchVals.AsPatch()
+		_, response, err := secretsManagerClient.UpdateSecretMetadataWithContext(context, updateSecretMetadataOptions)
+		if err != nil {
+			log.Printf("[DEBUG] UpdateSecretMetadataWithContext failed %s\n%s", err, response)
+			tfErr := flex.TerraformErrorf(err, fmt.Sprintf("UpdateSecretMetadataWithContext failed %s\n%s", err, response), ImportedCertSecretResourceName, "update")
+			return tfErr.GetDiag()
+		}
+	}
+
 	return resourceIbmSmImportedCertificateRead(context, d, meta)
 }
 
@@ -654,7 +931,153 @@ func resourceIbmSmImportedCertificateMapToSecretPrototype(d *schema.ResourceData
 		model.PrivateKey = core.StringPtr(formatCertificate(d.Get("private_key").(string)))
 	}
 
+	if _, ok := d.GetOkExists("managed_csr"); ok {
+		managedCsrModel, err := mapManagedCsrOnCreate(d)
+		if err != nil {
+			return model, err
+		}
+		model.ManagedCsr = managedCsrModel
+	}
+
 	return model, nil
+}
+
+func mapManagedCsrOnCreate(d *schema.ResourceData) (*secretsmanagerv2.ImportedCertificateManagedCsr, error) {
+	modelMap := d.Get("managed_csr").([]interface{})[0].(map[string]interface{})
+	mainModel := &secretsmanagerv2.ImportedCertificateManagedCsr{}
+	altNames, ok := d.GetOkExists("managed_csr.0.alt_names")
+	if ok {
+		mainModel.AltNames = core.StringPtr(altNames.(string))
+	}
+	clientFlag, ok := d.GetOkExists("managed_csr.0.client_flag")
+	if ok {
+		mainModel.ClientFlag = core.BoolPtr(clientFlag.(bool))
+	}
+	codeSigningFlag, ok := d.GetOkExists("managed_csr.0.code_signing_flag")
+	if ok {
+		mainModel.CodeSigningFlag = core.BoolPtr(codeSigningFlag.(bool))
+	}
+	commonName, ok := d.GetOkExists("managed_csr.0.common_name")
+	if ok {
+		mainModel.CommonName = core.StringPtr(commonName.(string))
+	}
+	if modelMap["country"] != nil {
+		country := modelMap["country"].([]interface{})
+		countryParsed := make([]string, len(country))
+		for i, v := range country {
+			countryParsed[i] = fmt.Sprint(v)
+		}
+		mainModel.Country = countryParsed
+	}
+	emailProtectionFlag, ok := d.GetOkExists("managed_csr.0.email_protection_flag")
+	if ok {
+		mainModel.EmailProtectionFlag = core.BoolPtr(emailProtectionFlag.(bool))
+	}
+	excludeCnFromSans, ok := d.GetOkExists("managed_csr.0.exclude_cn_from_sans")
+	if ok {
+		mainModel.ExcludeCnFromSans = core.BoolPtr(excludeCnFromSans.(bool))
+	}
+	extKeyUsage, ok := d.GetOkExists("managed_csr.0.ext_key_usage")
+	if ok {
+		mainModel.ExtKeyUsage = core.StringPtr(extKeyUsage.(string))
+	}
+	extKeyUsageOids, ok := d.GetOkExists("managed_csr.0.ext_key_usage_oids")
+	if ok {
+		mainModel.ExtKeyUsageOids = core.StringPtr(extKeyUsageOids.(string))
+	}
+	ipSans, ok := d.GetOkExists("managed_csr.0.ip_sans")
+	if ok {
+		mainModel.IpSans = core.StringPtr(ipSans.(string))
+	}
+	keyBits, ok := d.GetOkExists("managed_csr.0.key_bits")
+	if ok {
+		mainModel.KeyBits = core.Int64Ptr(int64(keyBits.(int)))
+	}
+	keyType, ok := d.GetOkExists("managed_csr.0.key_type")
+	if ok {
+		mainModel.KeyType = core.StringPtr(keyType.(string))
+	}
+	keyUsage, ok := d.GetOkExists("managed_csr.0.key_usage")
+	if ok {
+		mainModel.KeyUsage = core.StringPtr(keyUsage.(string))
+	}
+	if modelMap["locality"] != nil {
+		locality := modelMap["locality"].([]interface{})
+		localityParsed := make([]string, len(locality))
+		for i, v := range locality {
+			localityParsed[i] = fmt.Sprint(v)
+		}
+		mainModel.Locality = localityParsed
+	}
+	if modelMap["organization"] != nil {
+		organization := modelMap["organization"].([]interface{})
+		organizationParsed := make([]string, len(organization))
+		for i, v := range organization {
+			organizationParsed[i] = fmt.Sprint(v)
+		}
+		mainModel.Organization = organizationParsed
+	}
+	otherSans, ok := d.GetOkExists("managed_csr.0.other_sans")
+	if ok {
+		mainModel.OtherSans = core.StringPtr(otherSans.(string))
+	}
+	if modelMap["ou"] != nil {
+		ou := modelMap["ou"].([]interface{})
+		ouParsed := make([]string, len(ou))
+		for i, v := range ou {
+			ouParsed[i] = fmt.Sprint(v)
+		}
+		mainModel.Ou = ouParsed
+	}
+	policyIdentifiers, ok := d.GetOkExists("managed_csr.0.policy_identifiers")
+	if ok {
+		mainModel.PolicyIdentifiers = core.StringPtr(policyIdentifiers.(string))
+	}
+	if modelMap["postal_code"] != nil {
+		postalCode := modelMap["postal_code"].([]interface{})
+		postalCodeParsed := make([]string, len(postalCode))
+		for i, v := range postalCode {
+			postalCodeParsed[i] = fmt.Sprint(v)
+		}
+		mainModel.PostalCode = postalCodeParsed
+	}
+	if modelMap["province"] != nil {
+		province := modelMap["province"].([]interface{})
+		provinceParsed := make([]string, len(province))
+		for i, v := range province {
+			provinceParsed[i] = fmt.Sprint(v)
+		}
+		mainModel.Province = provinceParsed
+	}
+	requireCn, ok := d.GetOkExists("managed_csr.0.require_cn")
+	if ok {
+		mainModel.RequireCn = core.BoolPtr(requireCn.(bool))
+	}
+	rotateKeys, ok := d.GetOkExists("managed_csr.0.rotate_keys")
+	if ok {
+		mainModel.RotateKeys = core.BoolPtr(rotateKeys.(bool))
+	}
+	serverFlag, ok := d.GetOkExists("managed_csr.0.server_flag")
+	if ok {
+		mainModel.ServerFlag = core.BoolPtr(serverFlag.(bool))
+	}
+	if modelMap["street_address"] != nil {
+		streetAddress := modelMap["street_address"].([]interface{})
+		streetAddressParsed := make([]string, len(streetAddress))
+		for i, v := range streetAddress {
+			streetAddressParsed[i] = fmt.Sprint(v)
+		}
+		mainModel.StreetAddress = streetAddressParsed
+	}
+	uriSans, ok := d.GetOkExists("managed_csr.0.uri_sans")
+	if ok {
+		mainModel.UriSans = core.StringPtr(uriSans.(string))
+	}
+	userIds, ok := d.GetOkExists("managed_csr.0.user_ids")
+	if ok {
+		mainModel.UserIds = core.StringPtr(userIds.(string))
+	}
+	return mainModel, nil
 }
 
 func resourceIbmSmImportedCertificateImportedCertificatePrototypeToMap(model *secretsmanagerv2.ImportedCertificatePrototype) (map[string]interface{}, error) {

--- a/ibm/service/secretsmanager/resource_ibm_sm_imported_certificate_test.go
+++ b/ibm/service/secretsmanager/resource_ibm_sm_imported_certificate_test.go
@@ -109,6 +109,89 @@ func TestAccIbmSmImportedCertificateAllArgs(t *testing.T) {
 	})
 }
 
+func TestAccIbmSmImportedCertificateManagedCSR(t *testing.T) {
+	resourceName := "ibm_sm_imported_certificate.managed_csr"
+
+	resource.Test(t, resource.TestCase{
+
+		PreCheck:     func() { acc.TestAccPreCheck(t) },
+		Providers:    acc.TestAccProviders,
+		CheckDestroy: testAccCheckIbmSmImportedCertificateDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: importedCertificateConfigManagedCSR(),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckIbmSmManagedCsrCreated(resourceName),
+					resource.TestCheckResourceAttrSet(resourceName, "secret_id"),
+					resource.TestCheckResourceAttrSet(resourceName, "created_by"),
+					resource.TestCheckResourceAttrSet(resourceName, "created_at"),
+					resource.TestCheckResourceAttrSet(resourceName, "updated_at"),
+					resource.TestCheckResourceAttrSet(resourceName, "crn"),
+					resource.TestCheckResourceAttrSet(resourceName, "downloaded"),
+					resource.TestCheckResourceAttr(resourceName, "state", "0"),
+					resource.TestCheckResourceAttr(resourceName, "state_description", "pre_activation"),
+					resource.TestCheckResourceAttr(resourceName, "versions_total", "0"),
+					resource.TestCheckResourceAttrSet(resourceName, "managed_csr.0.csr"),
+					resource.TestCheckResourceAttr(resourceName, "managed_csr.0.common_name", "example.com"),
+					resource.TestCheckResourceAttr(resourceName, "managed_csr.0.alt_names", "alt1"),
+					resource.TestCheckResourceAttr(resourceName, "managed_csr.0.client_flag", "true"),
+					resource.TestCheckResourceAttr(resourceName, "managed_csr.0.code_signing_flag", "false"),
+					resource.TestCheckResourceAttr(resourceName, "managed_csr.0.organization.0", "IBM"),
+					resource.TestCheckResourceAttr(resourceName, "managed_csr.0.country.0", "IL"),
+					resource.TestCheckResourceAttr(resourceName, "managed_csr.0.ou.0", "ILSL"),
+					resource.TestCheckResourceAttr(resourceName, "managed_csr.0.postal_code.0", "5320047"),
+					resource.TestCheckResourceAttr(resourceName, "managed_csr.0.province.0", "DAN"),
+					resource.TestCheckResourceAttr(resourceName, "managed_csr.0.locality.0", "Givatayim"),
+					resource.TestCheckResourceAttr(resourceName, "managed_csr.0.email_protection_flag", "false"),
+					resource.TestCheckResourceAttr(resourceName, "managed_csr.0.exclude_cn_from_sans", "false"),
+					resource.TestCheckResourceAttr(resourceName, "managed_csr.0.ext_key_usage", "timestamping"),
+					resource.TestCheckResourceAttr(resourceName, "managed_csr.0.ip_sans", "127.0.0.1"),
+					resource.TestCheckResourceAttr(resourceName, "managed_csr.0.key_bits", "2048"),
+					resource.TestCheckResourceAttr(resourceName, "managed_csr.0.key_type", "rsa"),
+					resource.TestCheckResourceAttr(resourceName, "managed_csr.0.key_usage", "DigitalSignature"),
+					resource.TestCheckResourceAttr(resourceName, "managed_csr.0.other_sans", "1.3.6.1.4.1.311.21.2.3;utf8:*.example.com"),
+					resource.TestCheckResourceAttr(resourceName, "managed_csr.0.policy_identifiers", ""),
+					resource.TestCheckResourceAttr(resourceName, "managed_csr.0.uri_sans", "https://www.example.com/test"),
+					resource.TestCheckResourceAttr(resourceName, "managed_csr.0.user_ids", "user"),
+					resource.TestCheckResourceAttr(resourceName, "managed_csr.0.require_cn", "true"),
+					resource.TestCheckResourceAttr(resourceName, "managed_csr.0.rotate_keys", "false"),
+					resource.TestCheckResourceAttr(resourceName, "managed_csr.0.server_flag", "true"),
+				),
+			},
+			{
+				Config: mangedCSRConfigUpdated(),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckIbmSmManagedCsrUpdated(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "managed_csr.0.common_name", "example.com"),
+					resource.TestCheckResourceAttr(resourceName, "managed_csr.0.alt_names", "alt2"),
+					resource.TestCheckResourceAttr(resourceName, "managed_csr.0.client_flag", "false"),
+					resource.TestCheckResourceAttr(resourceName, "managed_csr.0.code_signing_flag", "true"),
+					resource.TestCheckResourceAttr(resourceName, "managed_csr.0.country.0", "USA"),
+					resource.TestCheckResourceAttr(resourceName, "managed_csr.0.email_protection_flag", "true"),
+					resource.TestCheckResourceAttr(resourceName, "managed_csr.0.exclude_cn_from_sans", "true"),
+					resource.TestCheckResourceAttr(resourceName, "managed_csr.0.ext_key_usage", ""),
+					resource.TestCheckResourceAttr(resourceName, "managed_csr.0.ip_sans", ""),
+					resource.TestCheckResourceAttr(resourceName, "managed_csr.0.key_bits", "2048"),
+					resource.TestCheckResourceAttr(resourceName, "managed_csr.0.key_type", "rsa"),
+					resource.TestCheckResourceAttr(resourceName, "managed_csr.0.key_usage", ""),
+					resource.TestCheckResourceAttr(resourceName, "managed_csr.0.other_sans", ""),
+					resource.TestCheckResourceAttr(resourceName, "managed_csr.0.policy_identifiers", ""),
+					resource.TestCheckResourceAttr(resourceName, "managed_csr.0.uri_sans", ""),
+					resource.TestCheckResourceAttr(resourceName, "managed_csr.0.user_ids", "user"),
+					resource.TestCheckResourceAttr(resourceName, "managed_csr.0.require_cn", "false"),
+					resource.TestCheckResourceAttr(resourceName, "managed_csr.0.rotate_keys", "true"),
+					resource.TestCheckResourceAttr(resourceName, "managed_csr.0.server_flag", "false"),
+				),
+			},
+			resource.TestStep{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
 var importedCertBasicConfigFormat = `
 		resource "ibm_sm_imported_certificate" "sm_imported_certificate_basic" {
 			instance_id   = "%s"
@@ -126,6 +209,70 @@ var importedCertFullConfigFormat = `
   			labels = ["%s"]
   			custom_metadata = %s
 			secret_group_id = "default"`
+
+var importedCertWithManagedCsrFormat = `
+		resource "ibm_sm_imported_certificate" "managed_csr" {
+			instance_id   = "%s"
+  			region        = "%s"
+			name = "%s"
+  			description = "%s"
+  			labels = ["%s"]
+  			custom_metadata = %s
+			secret_group_id = "default"
+			managed_csr %s
+        }`
+
+var managedCsrConfigFormat = `{
+		alt_names = "alt1"
+		client_flag = true
+		code_signing_flag = false
+		common_name = "example.com"
+		country = ["IL"]
+		email_protection_flag = false
+		exclude_cn_from_sans = false
+		ext_key_usage = "timestamping"
+		ext_key_usage_oids = "1.3.6.1.5.5.7.3.67"
+		ip_sans = "127.0.0.1"
+		key_bits = 2048
+		key_type = "rsa"
+		key_usage = "DigitalSignature"
+		locality = ["Givatayim"]
+		policy_identifiers = ""
+		organization = ["IBM"]
+		other_sans = "1.3.6.1.4.1.311.21.2.3;utf8:*.example.com"
+		ou = ["ILSL"]
+		postal_code = ["5320047"]
+		province = ["DAN"]
+		require_cn = true
+		rotate_keys = false
+		server_flag = true
+		street_address = ["Ariel Sharon 4"]
+		uri_sans = "https://www.example.com/test"
+		user_ids = "user"
+	}`
+
+var managedCsrModified = `{
+		alt_names = "alt2"
+		client_flag = false
+		code_signing_flag = true
+		common_name = "example.com"
+		country = ["USA"]
+		email_protection_flag = true
+		exclude_cn_from_sans = true
+		key_bits = 2048
+		key_type = "rsa"
+		locality = ["Givatayim"]
+		policy_identifiers = ""
+		organization = ["IBM"]
+		ou = ["ILSL"]
+		postal_code = ["5320047"]
+		province = ["DAN"]
+		require_cn = false
+		rotate_keys = true
+		server_flag = false
+		street_address = ["Ariel Sharon 4"]
+		user_ids = "user"
+	}`
 
 var firstImportedCertData = `
 			certificate = "-----BEGIN CERTIFICATE-----\r\nMIICsDCCAhmgAwIBAgIJALrogcLQxAOqMA0GCSqGSIb3DQEBCwUAMHExCzAJBgNV\r\nBAYTAnVzMREwDwYDVQQIDAh1cy1zb3V0aDEPMA0GA1UEBwwGRGFsLTEwMQwwCgYD\r\nVQQKDANJQk0xEzARBgNVBAsMCkNsb3VkQ2VydHMxGzAZBgNVBAMMEiouY2VydG1n\r\nbXQtZGV2LmNvbTAeFw0xODA0MjUwODM5NTlaFw00NTA5MTAwODM5NTlaMHExCzAJ\r\nBgNVBAYTAnVzMREwDwYDVQQIDAh1cy1zb3V0aDEPMA0GA1UEBwwGRGFsLTEwMQww\r\nCgYDVQQKDANJQk0xEzARBgNVBAsMCkNsb3VkQ2VydHMxGzAZBgNVBAMMEiouY2Vy\r\ndG1nbXQtZGV2LmNvbTCBnzANBgkqhkiG9w0BAQEFAAOBjQAwgYkCgYEAmy/4uEEw\r\nAn75rBuAIv5zi+1b2ycUnlw94x3QzYtY3QHQysFu73U3rczVHOsQNd9VIoC0z8py\r\npMZZu7W6dv6cjOSXlpiLfd7Y9TWzO43mNUH0qrnFpSgXM9ZXN3PJWjmTH3yxAsdK\r\nd5wtRdSv9AwrHWo8hHoTumoXYNMDuehyVJ8CAwEAAaNQME4wHQYDVR0OBBYEFMNC\r\nbcvQ+Smn8ikBDrMKhPc4C+f5MB8GA1UdIwQYMBaAFMNCbcvQ+Smn8ikBDrMKhPc4\r\nC+f5MAwGA1UdEwQFMAMBAf8wDQYJKoZIhvcNAQELBQADgYEAFe2fCmzTcmCHeijV\r\nq0+EOvMRVNF/FTYyjb24gUGTbouZOkfv7JK94lAt/u5mPhpftYX+b1wUlkz0Kyl5\r\n4IgM0XXpcPYDdxQ87c0l/nAUF7Pi++u7CVmJBlclyDOL6AmBpUE0HyquQT4rSp/K\r\n+5qcqSxVjznd5XgQrWQGHLI2tnY=\r\n-----END CERTIFICATE-----"
@@ -152,6 +299,16 @@ func importedCertificateConfigUpdated() string {
 	return fmt.Sprintf(importedCertFullConfigFormat, acc.SecretsManagerInstanceID, acc.SecretsManagerInstanceRegion,
 		modifiedImportedCertName, modifiedDescription, modifiedLabel, modifiedCustomMetadata) +
 		secondImportedCertData + `}`
+}
+
+func importedCertificateConfigManagedCSR() string {
+	return fmt.Sprintf(importedCertWithManagedCsrFormat, acc.SecretsManagerInstanceID, acc.SecretsManagerInstanceRegion,
+		importedCertName, description, label, customMetadata, managedCsrConfigFormat)
+}
+
+func mangedCSRConfigUpdated() string {
+	return fmt.Sprintf(importedCertWithManagedCsrFormat, acc.SecretsManagerInstanceID, acc.SecretsManagerInstanceRegion,
+		importedCertName, description, label, customMetadata, managedCsrModified)
 }
 
 func testAccCheckIbmSmImportedCertificateCreated(n string) resource.TestCheckFunc {
@@ -202,6 +359,119 @@ func testAccCheckIbmSmImportedCertificateUpdated(n string) resource.TestCheckFun
 			return err
 		}
 		if err := verifyJsonAttr(secret.CustomMetadata, modifiedCustomMetadata, "custom metadata after update"); err != nil {
+			return err
+		}
+		return nil
+	}
+}
+
+func testAccCheckIbmSmManagedCsrCreated(n string) resource.TestCheckFunc {
+
+	return func(s *terraform.State) error {
+		importedCertIntf, err := getSecret(s, n)
+		if err != nil {
+			return err
+		}
+		secret := importedCertIntf.(*secretsmanagerv2.ImportedCertificate)
+		managedCsr := secret.ManagedCsr
+		if err := verifyAttr(*managedCsr.CommonName, "example.com", "common_name"); err != nil {
+			return err
+		}
+		if err := verifyAttr(*managedCsr.AltNames, "alt1", "alt_names"); err != nil {
+			return err
+		}
+		if err := verifyAttr(managedCsr.Organization[0], "IBM", "organization"); err != nil {
+			return err
+		}
+		if err := verifyAttr(managedCsr.Ou[0], "ILSL", "ou"); err != nil {
+			return err
+		}
+		if err := verifyAttr(managedCsr.Country[0], "IL", "country"); err != nil {
+			return err
+		}
+		if err := verifyAttr(*managedCsr.ExtKeyUsage, "timestamping", "ext_key_usage"); err != nil {
+			return err
+		}
+		if err := verifyAttr(*managedCsr.IpSans, "127.0.0.1", "ip_sans"); err != nil {
+			return err
+		}
+		if err := verifyAttr(*managedCsr.KeyType, "rsa", "key_type"); err != nil {
+			return err
+		}
+		if err := verifyIntAttr(int(*managedCsr.KeyBits), 2048, "key_bits"); err != nil {
+			return err
+		}
+		if err := verifyAttr(*managedCsr.KeyUsage, "DigitalSignature", "key_usage"); err != nil {
+			return err
+		}
+		if err := verifyAttr(*managedCsr.OtherSans, "1.3.6.1.4.1.311.21.2.3;utf8:*.example.com", "other_sans"); err != nil {
+			return err
+		}
+		if err := verifyAttr(*managedCsr.UriSans, "https://www.example.com/test", "uri_sans"); err != nil {
+			return err
+		}
+		if err := verifyAttr(*managedCsr.UserIds, "user", "user_ids"); err != nil {
+			return err
+		}
+		if err := verifyBoolAttr(*managedCsr.ClientFlag, true, "client_flag"); err != nil {
+			return err
+		}
+		if err := verifyBoolAttr(*managedCsr.ServerFlag, true, "server_flag"); err != nil {
+			return err
+		}
+		if err := verifyBoolAttr(*managedCsr.CodeSigningFlag, false, "code_signing_flag"); err != nil {
+			return err
+		}
+		if err := verifyBoolAttr(*managedCsr.EmailProtectionFlag, false, "email_protection_flag"); err != nil {
+			return err
+		}
+		if err := verifyBoolAttr(*managedCsr.ExcludeCnFromSans, false, "exclude_cn_from_sans"); err != nil {
+			return err
+		}
+		if err := verifyBoolAttr(*managedCsr.RequireCn, true, "require_cn"); err != nil {
+			return err
+		}
+		if err := verifyBoolAttr(*managedCsr.RotateKeys, false, "rotate_keys"); err != nil {
+			return err
+		}
+		return nil
+	}
+}
+
+func testAccCheckIbmSmManagedCsrUpdated(n string) resource.TestCheckFunc {
+
+	return func(s *terraform.State) error {
+		importedCertIntf, err := getSecret(s, n)
+		if err != nil {
+			return err
+		}
+		secret := importedCertIntf.(*secretsmanagerv2.ImportedCertificate)
+		managedCsr := secret.ManagedCsr
+		if err := verifyAttr(*managedCsr.AltNames, "alt2", "alt_names"); err != nil {
+			return err
+		}
+		if err := verifyAttr(managedCsr.Country[0], "USA", "country"); err != nil {
+			return err
+		}
+		if err := verifyBoolAttr(*managedCsr.ClientFlag, false, "client_flag"); err != nil {
+			return err
+		}
+		if err := verifyBoolAttr(*managedCsr.ServerFlag, false, "server_flag"); err != nil {
+			return err
+		}
+		if err := verifyBoolAttr(*managedCsr.CodeSigningFlag, true, "code_signing_flag"); err != nil {
+			return err
+		}
+		if err := verifyBoolAttr(*managedCsr.EmailProtectionFlag, true, "email_protection_flag"); err != nil {
+			return err
+		}
+		if err := verifyBoolAttr(*managedCsr.ExcludeCnFromSans, true, "exclude_cn_from_sans"); err != nil {
+			return err
+		}
+		if err := verifyBoolAttr(*managedCsr.RequireCn, false, "require_cn"); err != nil {
+			return err
+		}
+		if err := verifyBoolAttr(*managedCsr.RotateKeys, true, "rotate_keys"); err != nil {
 			return err
 		}
 		return nil

--- a/website/docs/d/sm_imported_certificate.html.markdown
+++ b/website/docs/d/sm_imported_certificate.html.markdown
@@ -68,6 +68,8 @@ In addition to all argument references listed, you can access the following attr
 * `crn` - (String) A CRN that uniquely identifies an IBM Cloud resource.
   * Constraints: The maximum length is `512` characters. The minimum length is `9` characters. The value must match regular expression `/^crn:v[0-9](:([A-Za-z0-9-._~!$&'()*+,;=@\/]|%[0-9A-Z]{2})*){8}$/`.
 
+* `csr` - (String) The certificate signing request generated based on the parameters in the `managed_csr` data. The value may differ from the `csr` attribute within `managed_csr` if the `managed_csr` attributes have been modified.
+
 * `custom_metadata` - (Map) The secret metadata that a user can customize.
 
 * `description` - (String) An extended description of your secret.To protect your privacy, do not use personal data, such as your name or location, as a description for your secret group.
@@ -93,6 +95,36 @@ In addition to all argument references listed, you can access the following attr
 
 * `locks_total` - (Integer) The number of locks of the secret.
   * Constraints: The maximum value is `1000`. The minimum value is `0`.
+
+* `managed_csr` - (List) The data specified to create the CSR and the private key.
+  Nested scheme for **managed_csr**:
+  * `alt_names` - (String) With the Subject Alternative Name field, you can specify additional hostnames to be protected by a single SSL certificate.
+  * `client_flag` - (Boolean) This field indicates whether certificate is flagged for client use. 
+  * `code_signing_flag` - ( Boolean) This field indicates whether certificate is flagged for code signing use.
+  * `common_name` - (String) The Common Name (CN) represents the server name protected by the SSL certificate.
+  * `csr` - (String) The certificate signing request generated based on the parameters in the `managed_csr` data.
+  * `country` - (List) The Country (C) values to define in the subject field of the resulting certificate.
+  * `email_protection_flag` - (String) This field indicates whether certificate is flagged for email protection use.
+  * `exclude_cn_from_sans` - (String) This parameter controls whether the common name is excluded from Subject Alternative Names (SANs).
+  * `ext_key_usage` - (String) The allowed extended key usage constraint on certificate, in a comma-delimited list.
+  * `ext_key_usage_oids` - (String) A comma-delimited list of extended key usage Object Identifiers (OIDs).
+  * `ip_sans` - (String) The IP Subject Alternative Names to define for the certificate, in a comma-delimited list.
+  * `key_bits` - (Integer) The number of bits to use to generate the private key.
+  * `key_type` - (String) The type of private key to generate.
+  * `key_usage` - (String) The allowed key usage constraint to define for certificate, in a comma-delimited list.
+  * `locality` - (List) The Locality (L) values to define in the subject field of the resulting certificate.
+  * `organization` - (List) The Organization (O) values to define in the subject field of the resulting certificate.
+  * `other_sans` - (String) The custom Object Identifier (OID) or UTF8-string Subject Alternative Names to define for the certificate, in a comma-delimited list.
+  * `ou` - (List) The Organizational Unit (OU) values to define in the subject field of the resulting certificate.
+  * `policy_identifiers` - (String) A comma-delimited list of policy Object Identifiers (OIDs).
+  * `postal_code` - (List) The postal code values to define in the subject field of the resulting certificate.
+  * `province` - (List) The Province (ST) values to define in the subject field of the resulting certificate.
+  * `require_cn` - (Boolean) If set to false, makes the common_name field optional while generating a certificate.
+  * `rotate_keys` - (Boolean) This field indicates whether the private key will be rotated.
+  * `server_flag` - (Boolean) This field indicates whether certificate is flagged for server use.
+  * `street_address` - (List) The street address values to define in the subject field of the resulting certificate.
+  * `uri_sans` - (String) The URI Subject Alternative Names to define for the certificate, in a comma-delimited list.
+  * `user_ids` - (String) Specifies the list of requested User ID (OID 0.9.2342.19200300.100.1.1) Subject values to be placed on the signed certificate.
 
 * `name` - (String) The human-readable name of your secret.
   * Constraints: The maximum length is `256` characters. The minimum length is `2` characters.
@@ -124,8 +156,8 @@ In addition to all argument references listed, you can access the following attr
 
 * `validity` - (List) The date and time that the certificate validity period begins and ends.
 Nested scheme for **validity**:
-	* `not_after` - (String) The date-time format follows RFC 3339.
-	* `not_before` - (String) The date-time format follows RFC 3339.
+    * `not_after` - (String) The date-time format follows RFC 3339.
+    * `not_before` - (String) The date-time format follows RFC 3339.
 
 * `versions_total` - (Integer) The number of versions of the secret.
   * Constraints: The maximum value is `50`. The minimum value is `0`.

--- a/website/docs/d/sm_imported_certificate_metadata.html.markdown
+++ b/website/docs/d/sm_imported_certificate_metadata.html.markdown
@@ -48,6 +48,8 @@ In addition to all argument references listed, you can access the following attr
 * `crn` - (String) A CRN that uniquely identifies an IBM Cloud resource.
   * Constraints: The maximum length is `512` characters. The minimum length is `9` characters. The value must match regular expression `/^crn:v[0-9](:([A-Za-z0-9-._~!$&'()*+,;=@\/]|%[0-9A-Z]{2})*){8}$/`.
 
+* `csr` - (String) The certificate signing request generated based on the parameters in the `managed_csr` data. The value may differ from the `csr` attribute within `managed_csr` if the `managed_csr` attributes have been modified.
+
 * `custom_metadata` - (Map) The secret metadata that a user can customize.
 
 * `description` - (String) An extended description of your secret.To protect your privacy, do not use personal data, such as your name or location, as a description for your secret group.
@@ -70,6 +72,36 @@ In addition to all argument references listed, you can access the following attr
 
 * `locks_total` - (Integer) The number of locks of the secret.
   * Constraints: The maximum value is `1000`. The minimum value is `0`.
+
+* `managed_csr` - (List) The data specified to create the CSR and the private key.
+  Nested scheme for **managed_csr**:
+  * `alt_names` - (String) With the Subject Alternative Name field, you can specify additional hostnames to be protected by a single SSL certificate.
+  * `client_flag` - (Boolean) This field indicates whether certificate is flagged for client use.
+  * `code_signing_flag` - ( Boolean) This field indicates whether certificate is flagged for code signing use.
+  * `common_name` - (String) The Common Name (CN) represents the server name protected by the SSL certificate.
+  * `csr` - (String) The certificate signing request generated based on the parameters in the `managed_csr` data.
+  * `country` - (List) The Country (C) values to define in the subject field of the resulting certificate.
+  * `email_protection_flag` - (String) This field indicates whether certificate is flagged for email protection use.
+  * `exclude_cn_from_sans` - (String) This parameter controls whether the common name is excluded from Subject Alternative Names (SANs).
+  * `ext_key_usage` - (String) The allowed extended key usage constraint on certificate, in a comma-delimited list.
+  * `ext_key_usage_oids` - (String) A comma-delimited list of extended key usage Object Identifiers (OIDs).
+  * `ip_sans` - (String) The IP Subject Alternative Names to define for the certificate, in a comma-delimited list.
+  * `key_bits` - (Integer) The number of bits to use to generate the private key.
+  * `key_type` - (String) The type of private key to generate.
+  * `key_usage` - (String) The allowed key usage constraint to define for certificate, in a comma-delimited list.
+  * `locality` - (List) The Locality (L) values to define in the subject field of the resulting certificate.
+  * `organization` - (List) The Organization (O) values to define in the subject field of the resulting certificate.
+  * `other_sans` - (String) The custom Object Identifier (OID) or UTF8-string Subject Alternative Names to define for the certificate, in a comma-delimited list.
+  * `ou` - (List) The Organizational Unit (OU) values to define in the subject field of the resulting certificate.
+  * `policy_identifiers` - (String) A comma-delimited list of policy Object Identifiers (OIDs).
+  * `postal_code` - (List) The postal code values to define in the subject field of the resulting certificate.
+  * `province` - (List) The Province (ST) values to define in the subject field of the resulting certificate.
+  * `require_cn` - (Boolean) If set to false, makes the common_name field optional while generating a certificate.
+  * `rotate_keys` - (Boolean) This field indicates whether the private key will be rotated.
+  * `server_flag` - (Boolean) This field indicates whether certificate is flagged for server use.
+  * `street_address` - (List) The street address values to define in the subject field of the resulting certificate.
+  * `uri_sans` - (String) The URI Subject Alternative Names to define for the certificate, in a comma-delimited list.
+  * `user_ids` - (String) Specifies the list of requested User ID (OID 0.9.2342.19200300.100.1.1) Subject values to be placed on the signed certificate.
 
 * `name` - (String) The human-readable name of your secret.
   * Constraints: The maximum length is `256` characters. The minimum length is `2` characters.

--- a/website/docs/r/sm_imported_certificate.html.markdown
+++ b/website/docs/r/sm_imported_certificate.html.markdown
@@ -23,6 +23,42 @@ resource "ibm_sm_imported_certificate" "sm_imported_certificate" {
   secret_group_id = ibm_sm_secret_group.sm_secret_group.secret_group_id
   certificate = "-----BEGIN CERTIFICATE-----\nMIIE3jCCBGSgAwIBAgIUZfTbf3adn87l5J2Q2Aw+6Vk/qhowCgYIKoZIzj0EAwIw\n-----END CERTIFICATE-----"
 }
+
+An imported certificate with managed CSR:
+
+resource "ibm_sm_imported_certificate" "sm_imported_certificate" {
+  instance_id   = ibm_resource_instance.sm_instance.guid
+  region        = "us-south"
+  name 			= "secret-name"
+  custom_metadata = {"key":"value"}
+  description = "Extended description for this secret."
+  labels = ["my-label"]
+  secret_group_id = ibm_sm_secret_group.sm_secret_group.secret_group_id
+  managed_csr {
+    alt_names = "altname"
+    client_flag = true
+    code_signing_flag = false
+    common_name = "example.com"
+    country = ["US"]
+    email_protection_flag = false
+    exclude_cn_from_sans = false
+    ext_key_usage = "timestamping"
+    ext_key_usage_oids = "1.3.6.1.5.5.7.3.67"
+    ip_sans = "127.0.0.1"
+    key_bits = 2048
+    key_type = "rsa"
+    key_usage = "DigitalSignature"
+    locality = ["Boston"]
+    organization = ["IBM"]
+    other_sans = "1.3.6.1.4.1.311.21.2.3;utf8:*.example.com"
+    ou = ["ILSL"]
+    require_cn = true
+    rotate_keys = false
+    server_flag = true
+    uri_sans = "https://www.example.com/test"
+    user_ids = "user"
+  }
+}
 ```
 
 ## Argument Reference
@@ -33,7 +69,7 @@ Review the argument reference that you can specify for your resource.
 * `region` - (Optional, Forces new resource, String) The region of the Secrets Manager instance. If not provided defaults to the region defined in the IBM provider configuration.
 * `endpoint_type` - (Optional, String) - The endpoint type. If not provided the endpoint type is determined by the `visibility` argument provided in the provider configuration.
   * Constraints: Allowable values are: `private`, `public`.
-* `certificate` - (Required, String) The PEM-encoded contents of your certificate. You can manually rotate the secret by modifying this argument, together with the optional arguments `intermediate` and `private_key`. Modifying the certificate creates a new version of the secret.
+* `certificate` - (Optional, String) The PEM-encoded contents of your certificate. You can manually rotate the secret by modifying this argument, together with the optional arguments `intermediate` and `private_key`. Modifying the certificate creates a new version of the secret. If the secret is used to generate a Certificate Signing Reques (CSR) no certificate should be provided initially. Add the certificate value only after the CSR is signed.
   * Constraints: The maximum length is `100000` characters. The minimum length is `50` characters. The value must match regular expression `/^(-{5}BEGIN.+?-{5}[\\s\\S]+-{5}END.+?-{5})$/`.
 * `custom_metadata` - (Optional, Map) The secret metadata that a user can customize.
 * `description` - (Optional, String) An extended description of your secret.To protect your privacy, do not use personal data, such as your name or location, as a description for your secret group.
@@ -43,6 +79,35 @@ Review the argument reference that you can specify for your resource.
   * Constraints: The maximum length is `100000` characters. The minimum length is `50` characters. The value must match regular expression `/^(-{5}BEGIN.+?-{5}[\\s\\S]+-{5}END.+?-{5})$/`.
 * `labels` - (Optional, List) Labels that you can use to search for secrets in your instance.Up to 30 labels can be created.
   * Constraints: The list items must match regular expression `/(.*?)/`. The maximum length is `30` items. The minimum length is `0` items.
+* `managed_csr` - (Optional, List) The data specified to create the CSR and the private key.
+  Nested scheme for **managed_csr**:
+  * `alt_names` - (Optional, String) With the Subject Alternative Name field, you can specify additional hostnames to be protected by a single SSL certificate.
+  * `client_flag` - (Optional, Boolean) This field indicates whether certificate is flagged for client use. The default is `true`.
+  * `code_signing_flag` - (Optional, Boolean) This field indicates whether certificate is flagged for code signing use. The default is `true`.
+  * `common_name` - (Optional, String) The Common Name (CN) represents the server name protected by the SSL certificate.
+  * `csr` - (Computed, String) The certificate signing request generated based on the parameters in the `managed_csr` data.
+  * `country` - (Optional, List) The Country (C) values to define in the subject field of the resulting certificate.
+  * `email_protection_flag` - (Optional, String) This field indicates whether certificate is flagged for email protection use. The default is `false`.
+  * `exclude_cn_from_sans` - (Optional, String) This parameter controls whether the common name is excluded from Subject Alternative Names (SANs). The default is `false`.
+  * `ext_key_usage` - (Optional, String) The allowed extended key usage constraint on certificate, in a comma-delimited list.
+  * `ext_key_usage_oids` - (Optional, String) A comma-delimited list of extended key usage Object Identifiers (OIDs).
+  * `ip_sans` - (Optional, String) The IP Subject Alternative Names to define for the certificate, in a comma-delimited list.
+  * `key_bits` - (Optional, Integer) The number of bits to use to generate the private key.
+  * `key_type` - (Optional, String) The type of private key to generate. The default is `rsa`.
+  * `key_usage` - (Optional, String) The allowed key usage constraint to define for certificate, in a comma-delimited list.
+  * `locality` - (Optional, List) The Locality (L) values to define in the subject field of the resulting certificate.
+  * `organization` - (Optional, List) The Organization (O) values to define in the subject field of the resulting certificate.
+  * `other_sans` - (Optional, String) The custom Object Identifier (OID) or UTF8-string Subject Alternative Names to define for the certificate, in a comma-delimited list.
+  * `ou` - (Optional, List) The Organizational Unit (OU) values to define in the subject field of the resulting certificate.
+  * `policy_identifiers` - (Optional, String) A comma-delimited list of policy Object Identifiers (OIDs).
+  * `postal_code` - (Optional, List) The postal code values to define in the subject field of the resulting certificate.
+  * `province` - (Optional, List) The Province (ST) values to define in the subject field of the resulting certificate.
+  * `require_cn` - (Optional, Boolean) If set to false, makes the common_name field optional while generating a certificate. The default is `true`.
+  * `rotate_keys` - (Optional, Boolean) This field indicates whether the private key will be rotated. The default is `false`.
+  * `server_flag` - (Optional, Boolean) This field indicates whether certificate is flagged for server use. The default is `true`.
+  * `street_address` - (Optional, List) The street address values to define in the subject field of the resulting certificate.
+  * `uri_sans` - (Optional, String) The URI Subject Alternative Names to define for the certificate, in a comma-delimited list.
+  * `user_ids` - (Optional, String) Specifies the list of requested User ID (OID 0.9.2342.19200300.100.1.1) Subject values to be placed on the signed certificate.
 * `name` - (Required, String) The human-readable name of your secret.
   * Constraints: The maximum length is `256` characters. The minimum length is `2` characters. The value must match regular expression `^[A-Za-z0-9_][A-Za-z0-9_]*(?:_*-*\.*[A-Za-z0-9]*)*[A-Za-z0-9]+$`.
 * `private_key` - (Computed, String) (Optional) The PEM-encoded private key to associate with the certificate.
@@ -62,6 +127,7 @@ In addition to all argument references listed, you can access the following attr
   * Constraints: The maximum length is `128` characters. The minimum length is `4` characters.
 * `crn` - (String) A CRN that uniquely identifies an IBM Cloud resource.
   * Constraints: The maximum length is `512` characters. The minimum length is `9` characters. The value must match regular expression `/^crn:v[0-9](:([A-Za-z0-9-._~!$&'()*+,;=@\/]|%[0-9A-Z]{2})*){8}$/`.
+* `csr` - (String) The certificate signing request generated based on the parameters in the `managed_csr` data. The value may differ from the `csr` attribute within `managed_csr` if the `managed_csr` attributes have been modified.
 * `downloaded` - (Boolean) Indicates whether the secret data that is associated with a secret version was retrieved in a call to the service API.
 * `intermediate_included` - (Boolean) Indicates whether the certificate was imported with an associated intermediate certificate.
 * `issuer` - (Forces new resource, String) The distinguished name that identifies the entity that signed and issued the certificate.
@@ -84,8 +150,8 @@ In addition to all argument references listed, you can access the following attr
 * `updated_at` - (String) The date when a resource was recently modified. The date format follows RFC 3339.
 * `validity` - (List) The date and time that the certificate validity period begins and ends.
 Nested scheme for **validity**:
-	* `not_after` - (String) The date-time format follows RFC 3339.
-	* `not_before` - (String) The date-time format follows RFC 3339.
+    * `not_after` - (String) The date-time format follows RFC 3339.
+    * `not_before` - (String) The date-time format follows RFC 3339.
 * `versions_total` - (Integer) The number of versions of the secret.
   * Constraints: The maximum value is `50`. The minimum value is `0`.
 


### PR DESCRIPTION
Add support for managed CSR in Secrets Manager Imported Certificate secret

<!--- See what makes a good Pull Request at : https://github.com/IBM-Cloud/terraform-provider-ibm/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
haims@Haims-MacBook-Pro terraform-provider-ibm % make testacc TEST=./ibm/service/secretsmanager
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./ibm/service/secretsmanager -v  -timeout 700m 
[WARN] Set the environment variable IBM_PROJECTS_CONFIG_APIKEY for testing IBM Projects Config resources, the tests will fail if this is not set
[WARN] Set the environment variable IBM_APPID_TENANT_ID for testing AppID resources, AppID tests will fail if this is not set
[WARN] Set the environment variable IBM_APPID_TEST_USER_EMAIL for testing AppID user resources, the tests will fail if this is not set
[WARN] Set the environment variable IBM_ORG for testing ibm_org  resource Some tests for that resource will fail if this is not set correctly
[WARN] Set the environment variable IBM_SPACE for testing ibm_space  resource Some tests for that resource will fail if this is not set correctly
[WARN] Set the environment variable IBM_ID1 for testing ibm_space resource Some tests for that resource will fail if this is not set correctly
[WARN] Set the environment variable IBM_ID2 for testing ibm_space resource Some tests for that resource will fail if this is not set correctly
[WARN] Set the environment variable IBM_IAMUSER for testing ibm_iam_user_policy resource Some tests for that resource will fail if this is not set correctly
[WARN] Set the environment variable IBM_IAMACCOUNTID for testing ibm_iam_trusted_profile resource Some tests for that resource will fail if this is not set correctly
[WARN] Set the environment variable IBM_IAM_SERVICE_ID for testing ibm_iam_trusted_profile_identity resource Some tests for that resource will fail if this is not set correctly
[WARN] Set the environment variable IBM_IAM_TRUSTED_PROFILE_ID for testing ibm_iam_trusted_profile_identity resource Some tests for that resource will fail if this is not set correctly
[WARN] Set the environment variable IBM_DATACENTER for testing ibm_container_cluster resource else it is set to default value 'par01'
[WARN] Set the environment variable IBM_MACHINE_TYPE for testing ibm_container_cluster resource else it is set to default value 'b3c.4x16'
[WARN] Set the environment variable IBM_CERT_CRN for testing ibm_container_alb_cert or ibm_container_ingress_secret_tls resource else it is set to default value
[WARN] Set the environment variable IBM_UPDATE_CERT_CRN for testing ibm_container_alb_cert or ibm_container_ingress_secret_tls resource else it is set to default value
[WARN] Set the environment variable IBM_SECRET_CRN for testing ibm_container_ingress_secret_opaque resource else it is set to default value
[WARN] Set the environment variable IBM_SECRET_CRN_2 for testing ibm_container_ingress_secret_opaque resource else it is set to default value
[WARN] Set the environment variable IBM_INGRESS_INSTANCE_CRN for testing ibm_container_ingress_instance resource. Some tests for that resource will fail if this is not set correctly
[WARN] Set the environment variable IBM_INGRESS_INSTANCE_SECRET_GROUP_ID for testing ibm_container_ingress_instance resource. Some tests for that resource will fail if this is not set correctly
[WARN] Set the environment variable IBM_CONTAINER_REGION for testing ibm_container resources else it is set to default value 'eu-de'
[WARN] Set the environment variable IBM_CIS_INSTANCE with a VALID CIS Instance NAME for testing ibm_cis resources on staging/test
[WARN] Set the environment variable IBM_CIS_DOMAIN_STATIC with the Domain name registered with the CIS instance on test/staging. Domain must be predefined in CIS to avoid CIS billing costs due to domain delete/create
[WARN] Set the environment variable IBM_CIS_DOMAIN_TEST with a VALID Domain name for testing the one time create and delete of a domain in CIS. Note each create/delete will trigger a monthly billing instance. Only to be run in staging/test
[WARN] Set the environment variable IBM_CIS_RESOURCE_GROUP with the resource group for the CIS Instance 
[WARN] Set the environment variable IBM_COS_CRN with a VALID COS instance CRN for testing ibm_cos_* resources
[WARN] Set the environment variable IBM_COS_Bucket_CRN with a VALID BUCKET CRN for testing ibm_cos_bucket* resources
[WARN] Set the environment variable IBM_COS_Backup_Vault with a VALID BACKUP VAULT NAME  for testing ibm_cos_backup_vault* resources
[WARN] Set the environment variable IBM_KMS_KEY_CRN with a VALID key crn for a KP/HPCS root key
[WARN] Set the environment variable IBM_COS_Backup_Policy_Id with a VALID POLICYS ID for testing ibm_cos_backup_policy* resources
[WARN] Set the environment variable IBM_COS_ACTIVITY_TRACKER_CRN with a VALID ACTIVITY TRACKER INSTANCE CRN in valid region for testing ibm_cos_bucket* resources
[WARN] Set the environment variable IBM_COS_METRICS_MONITORING_CRN with a VALID METRICS MONITORING CRN for testing ibm_cos_bucket* resources
[WARN] Set the environment variable IBM_COS_BUCKET_NAME with a VALID BUCKET Name for testing ibm_cos_bucket* resources
[WARN] Set the environment variable IBM_COS_NAME with a VALID COS instance name for testing resources with cos deps
[WARN] Set the environment variable IBM_TRUSTED_MACHINE_TYPE for testing ibm_container_cluster resource else it is set to default value 'mb1c.16x64'
[WARN] Set the environment variable IBM_BM_EXTENDED_HW_TESTING to true/false for testing ibm_compute_bare_metal resource else it is set to default value 'false'
[WARN] Set the environment variable IBM_PUBLIC_VLAN_ID for testing ibm_container_cluster resource else it is set to default value '2393319'
[WARN] Set the environment variable IBM_PRIVATE_VLAN_ID for testing ibm_container_cluster resource else it is set to default value '2393321'
[WARN] Set the environment variable IBM_KUBE_VERSION for testing ibm_container_cluster resource else it is set to default value '1.18.14'
[WARN] Set the environment variable IBM_KUBE_UPDATE_VERSION for testing ibm_container_cluster resource else it is set to default value '1.19.6'
[WARN] Set the environment variable IBM_PRIVATE_SUBNET_ID for testing ibm_container_cluster resource else it is set to default value '1636107'
[WARN] Set the environment variable IBM_PUBLIC_SUBNET_ID for testing ibm_container_cluster resource else it is set to default value '1165645'
[WARN] Set the environment variable IBM_SUBNET_ID for testing ibm_container_cluster resource else it is set to default value '1165645'
[INFO] Set the environment variable IBM_IPSEC_DATACENTER for testing ibm_ipsec_vpn resource else it is set to default value 'tok02'
[INFO] Set the environment variable IBM_IPSEC_CUSTOMER_SUBNET_ID for testing ibm_ipsec_vpn resource else it is set to default value '123456'
[INFO] Set the environment variable IBM_IPSEC_CUSTOMER_PEER_IP for testing ibm_ipsec_vpn resource else it is set to default value '192.168.0.1'
[WARN] Set the environment variable IBM_LBAAS_DATACENTER for testing ibm_lbaas resource else it is set to default value 'dal13'
[WARN] Set the environment variable IBM_LBAAS_SUBNETID for testing ibm_lbaas resource else it is set to default value '2144241'
[WARN] Set the environment variable IBM_LB_LISTENER_CERTIFICATE_INSTANCE for testing ibm_is_lb_listener resource for https redirect else it is set to default value 'crn:v1:staging:public:cloudcerts:us-south:a/2d1bace7b46e4815a81e52c6ffeba5cf:af925157-b125-4db2-b642-adacb8b9c7f5:certificate:c81627a1bf6f766379cc4b98fd2a44ed'
[WARN] Set the environment variable IBM_DEDICATED_HOSTNAME for testing ibm_compute_vm_instance resource else it is set to default value 'terraform-dedicatedhost'
[WARN] Set the environment variable IBM_DEDICATED_HOST_ID for testing ibm_compute_vm_instance resource else it is set to default value '30301'
[WARN] Set the environment variable IBM_WORKER_POOL_ZONE for testing ibm_container_worker_pool_zone_attachment resource else it is set to default value 'ams03'
[WARN] Set the environment variable IBM_WORKER_POOL_ZONE_PRIVATE_VLAN for testing ibm_container_worker_pool_zone_attachment resource else it is set to default value '2538975'
[WARN] Set the environment variable IBM_WORKER_POOL_ZONE_PUBLIC_VLAN for testing ibm_container_worker_pool_zone_attachment resource else it is set to default value '2538967'
[WARN] Set the environment variable IBM_WORKER_POOL_ZONE_UPDATE_PRIVATE_VLAN for testing ibm_container_worker_pool_zone_attachment resource else it is set to default value '2388377'
[WARN] Set the environment variable IBM_WORKER_POOL_ZONE_UPDATE_PUBLIC_VLAN for testing ibm_container_worker_pool_zone_attachment resource else it is set to default value '2388375'
[WARN] Set the environment variable IBM_WORKER_POOL_SECONDARY_STORAGE for testing secondary_storage attachment to IKS workerpools
[WARN] Set the environment variable IBM_PLACEMENT_GROUP_NAME for testing ibm_compute_vm_instance resource else it is set to default value 'terraform-group'
[INFO] Set the environment variable SL_REGION for testing ibm_is_region datasource else it is set to default value 'us-south'
[INFO] Set the environment variable SL_ZONE for testing ibm_is_zone datasource else it is set to default value 'us-south-1'
[INFO] Set the environment variable SL_ZONE_2 for testing ibm_is_zone datasource else it is set to default value 'us-south-2'
[INFO] Set the environment variable SL_ZONE_3 for testing ibm_is_zone datasource else it is set to default value 'us-south-3'
[INFO] Set the environment variable SL_CIDR for testing ibm_is_subnet else it is set to default value '10.240.0.0/24'
[INFO] Set the environment variable SL_CIDR_2 for testing ibm_is_subnet else it is set to default value '10.240.64.0/24'
[INFO] Set the environment variable IS_IPV4_ADDRESS for testing ibm_is_instance else it is set to default value '10.240.0.6'
[INFO] Set the environment variable IS_ACCOUNT_ID for testing private_path_service_gateway_account_policy else it is set to default value 'fee82deba12e4c0fb69c3b09d1f12345'
[INFO] Set the environment variable IS_CLUSTER_NETWORK_PROFILE_NAME for testing cluster_network_profile else it is set to default value 'h100'
[INFO] Set the environment variable IS_INSTANCE_GPU_PROFILE_NAME for testing cluster_network_attachments else it is set to default value 'gx3d-160x1792x8h100'
[INFO] Set the environment variable IS_CLUSTER_NETWORK_SUBNET_PREFIXES_CIDR for testing cluster_network else it is set to default value '10.1.0.0/24'
[INFO] Set the environment variable SL_ADDRESS_PREFIX_CIDR for testing ibm_is_vpc_address_prefix else it is set to default value '10.120.0.0/24'
[INFO] Set the environment variable SL_CIDR_2 for testing ibm_is_subnet else it is set to default value '10.240.64.0/24'
[INFO] Set the environment variable SL_CIDR_2 for testing ibm_is_instance datasource else it is set to default value './test-fixtures/.ssh/pkcs8_rsa.pub'
[INFO] Set the environment variable IS_PRIVATE_SSH_KEY_PATH for testing ibm_is_instance datasource else it is set to default value './test-fixtures/.ssh/pkcs8_rsa'
[INFO] Set the environment variable SL_RESOURCE_GROUP_ID for testing with different resource group id else it is set to default value 'c01d34dff4364763476834c990398zz8'
[INFO] Set the environment variable IS_RESOURCE_CRN for testing with created resource instance
[INFO] Set the environment variable IS_IMAGE for testing ibm_is_instance, ibm_is_floating_ip else it is set to default value 'r006-587a041d-9246-44f0-980b-56a327cf5bd7'
[INFO] Set the environment variable IS_IMAGE2 for testing ibm_is_instance, ibm_is_floating_ip else it is set to default value 'r134-f47cc24c-e020-4db5-ad96-1e5be8b5853b'
[INFO] Set the environment variable IS_WIN_IMAGE for testing ibm_is_instance data source else it is set to default value 'r006-d2e0d0e9-0a4f-4c45-afd7-cab787030776'
[INFO] Set the environment variable IS_COS_BUCKET_NAME for testing ibm_is_image_export_job else it is set to default value 'bucket-27200-lwx4cfvcue'
[INFO] Set the environment variable IS_COS_BUCKET_CRN for testing ibm_is_image_export_job else it is set to default value 'bucket-27200-lwx4cfvcue'
[INFO] Set the environment variable IS_INSTANCE_NAME for testing ibm_is_instance resource else it is set to default value 'instance-01'
[INFO] Set the environment variable IS_BACKUP_POLICY_JOB_ID for testing ibm_is_backup_policy_job datasource
[INFO] Set the environment variable IS_BACKUP_POLICY_ID for testing ibm_is_backup_policy_jobs datasource
[INFO] Set the environment variable IS_REMOTE_CP_BAAS_ENCRYPTION_KEY_CRN for testing remote_copies_policy with Baas plans, else it is set to default value, 'crn:v1:bluemix:public:kms:us-south:a/dffc98a0f1f0f95f6613b3b752286b87:e4a29d1a-2ef0-42a6-8fd2-350deb1c647e:key:5437653b-c4b1-447f-9646-b2a2a4cd6179'
[INFO] Set the environment variable SL_INSTANCE_PROFILE for testing ibm_is_instance resource else it is set to default value 'cx2-2x4'
[INFO] Set the environment variable SL_KMS_INSTANCE_ID for testing ibm_kms_key resource else it is set to default value '30222bb5-1c6d-3834-8d78-ae6348cf8z61'
[INFO] Set the environment variable SL_KMS_KEY_NAME for testing ibm_kms_key resource else it is set to default value 'tfp-test-key'
[INFO] Set the environment variable SL_INSTANCE_PROFILE_UPDATE for testing ibm_is_instance resource else it is set to default value 'cx2-4x8'
[INFO] Set the environment variable IS_BARE_METAL_SERVER_PROFILE for testing ibm_is_bare_metal_server resource else it is set to default value 'bx2-metal-96x384'
[INFO] Set the environment variable IsBareMetalServerImage for testing ibm_is_bare_metal_server resource else it is set to default value 'r006-2d1f36b0-df65-4570-82eb-df7ae5f778b1'
[INFO] Set the environment variable IsBareMetalServerImage2 for testing ibm_is_bare_metal_server resource else it is set to default value 'r006-2d1f36b0-df65-4570-82eb-df7ae5f778b1'
[INFO] Set the environment variable IS_DNS_INSTANCE_CRN for testing ibm_is_lb resource else it is set to default value 'crn:v1:staging:public:dns-svcs:global:a/efe5afc483594adaa8325e2b4d1290df:82df2e3c-53a5-43c6-89ce-dcf78be18668::'
[INFO] Set the environment variable IS_DNS_INSTANCE_CRN1 for testing ibm_is_lb resource else it is set to default value 'crn:v1:staging:public:dns-svcs:global:a/efe5afc483594adaa8325e2b4d1290df:599ae4aa-c554-4a88-8bb2-b199b9a3c046::'
[INFO] Set the environment variable IS_DNS_ZONE_ID for testing ibm_is_lb resource else it is set to default value 'dd501d1d-490b-4bb4-a05d-a31954a1c59e'
[INFO] Set the environment variable IS_DNS_ZONE_ID_1 for testing ibm_is_lb resource else it is set to default value 'b1def78d-51b3-4ea5-a746-1b64c992fcab'
[INFO] Set the environment variable IS_DEDICATED_HOST_NAME for testing ibm_is_instance resource else it is set to default value 'tf-dhost-01'
[INFO] Set the environment variable IS_DEDICATED_HOST_GROUP_ID for testing ibm_is_instance resource else it is set to default value '0717-9104e7b5-77ad-44ad-9eaa-091e6b6efce1'
[INFO] Set the environment variable IS_DEDICATED_HOST_PROFILE for testing ibm_is_instance resource else it is set to default value 'bx2d-host-152x608'
[INFO] Set the environment variable IS_DEDICATED_HOST_GROUP_CLASS for testing ibm_is_instance resource else it is set to default value 'bx2d'
[INFO] Set the environment variable IS_DEDICATED_HOST_GROUP_FAMILY for testing ibm_is_instance resource else it is set to default value 'balanced'
[INFO] Set the environment variable SL_INSTANCE_PROFILE for testing ibm_is_instance resource else it is set to default value 'bx2d-16x64'
[INFO] Set the environment variable IS_SHARE_PROFILE for testing ibm_is_instance resource else it is set to default value 'tier-3iops'
[INFO] Set the environment variable IS_SHARE_PROFILE for testing ibm_is_instance resource else it is set to default value
[INFO] Set the environment variable IS_SHARE_PROFILE for testing ibm_is_instance resource else it is set to default value
[INFO] Set the environment variable IS_VOLUME_PROFILE for testing ibm_is_volume_profile else it is set to default value 'general-purpose'
[INFO] Set the environment variable IS_VIRTUAL_NETWORK_INTERFACE for testing ibm_is_virtual_network_interface else it is set to default value 'c93dc4c6-e85a-4da2-9ea6-f24576256122'
[INFO] Set the environment variable IS_FLOATING_IP for testing ibm_is_virtual_network_interface else it is set to default value 'r006-9fc3948f-1b01-406c-baa5-e86b185e559f'
[INFO] Set the environment variable IS_UNATTACHED_BOOT_VOLUME_NAME for testing ibm_is_image else it is set to default value 'r006-1cbe9f0a-7101-4d25-ae72-2a2d725e530e'
[INFO] Set the environment variable IS_VSI_DATA_VOLUME_ID for testing ibm_is_image else it is set to default value 'r006-1cbe9f0a-7101-4d25-ae72-2a2d725e530e'
[INFO] Set the environment variable SL_ROUTE_NEXTHOP else it is set to default value '10.0.0.4'
[INFO] Set the environment variable ISSnapshotCRN for ibm_is_snapshot resource else it is set to default value 'crn:v1:bluemix:public:is:ca-tor:a/xxxxxxxx::snapshot:xxxx-xxxxc-xxx-xxxx-xxxx-xxxxxxxxxx'
[INFO] Set the environment variable ICD_DB_DEPLOYMENT_ID for testing ibm_cloud_databases else it is set to default value 'crn:v1:bluemix:public:databases-for-redis:au-syd:a/40ddc34a953a8c02f10987b59085b60e:5042afe1-72c2-4231-89cc-c949e5d56251::'
[INFO] Set the environment variable ICD_DB_BACKUP_ID for testing ibm_cloud_databases else it is set to default value 'crn:v1:bluemix:public:databases-for-redis:au-syd:a/40ddc34a953a8c02f10987b59085b60e:5042afe1-72c2-4231-89cc-c949e5d56251:backup:0d862fdb-4faa-42e5-aecb-5057f4d399c3'
[INFO] Set the environment variable ICD_DB_TASK_ID for testing ibm_cloud_databases else it is set to default value 'crn:v1:bluemix:public:databases-for-redis:au-syd:a/40ddc34a953a8c02f10987b59085b60e:367b0a22-05bb-41e3-a1ed-ded1ff0889e5:task:882013a6-2751-4df7-a77a-98d258638704'
[INFO] Set the environment variable PI_IMAGE for testing ibm_pi_image resource else it is set to default value '7200-03-03'
[INFO] Set the environment variable PI_SAP_IMAGE for testing ibm_pi_image resource else it is set to default value 'Linux-RHEL-SAP-8-2'
[INFO] Set the environment variable PI_IMAGE_BUCKET_NAME for testing ibm_pi_image resource else it is set to default value 'images-public-bucket'
[INFO] Set the environment variable PI_IMAGE_BUCKET_FILE_NAME for testing ibm_pi_image resource else it is set to default value 'rhel.ova.gz'
[INFO] Set the environment variable PI_IMAGE_BUCKET_ACCESS_KEY for testing ibm_pi_image_export resource else it is set to default value 'images-bucket-access-key'
[INFO] Set the environment variable PI_IMAGE_BUCKET_SECRET_KEY for testing ibm_pi_image_export resource else it is set to default value 'PI_IMAGE_BUCKET_SECRET_KEY'
[INFO] Set the environment variable PI_IMAGE_BUCKET_REGION for testing ibm_pi_image resource else it is set to default value 'us-east'
[INFO] Set the environment variable PI_IMAGE_ID for testing ibm_pi_image resource else it is set to default value 'IBMi-72-09-2924-11'
[INFO] Set the environment variable PI_KEY_NAME for testing ibm_pi_key_name resource else it is set to default value 'terraform-test-power'
[INFO] Set the environment variable PI_NETWORK_NAME for testing ibm_pi_network_name resource else it is set to default value 'terraform-test-power'
[INFO] Set the environment variable PI_NETWORK_ID for testing ibm_pi_network_interface resource else it is set to default value 'terraform-test-power'
[INFO] Set the environment variable PI_NETWORK_INTERFACE_ID for testing ibm_pi_network_interface resource else it is set to default value 'terraform-test-power'
[INFO] Set the environment variable PI_NETWORK_SECURITY_GROUP_ID for testing ibm_pi_network_security_group resource else it is set to default value 'terraform-test-power'
[INFO] Set the environment variable PI_NETWORK_SECURITY_GROUP_RULE_ID for testing ibm_pi_network_security_group resource else it is set to default value 'terraform-test-power'
[INFO] Set the environment variable PI_NETWORK_SECURITY_GROUP_ID for testing ibm_pi_network_security_group resource else it is set to default value 'terraform-test-power'
[INFO] Set the environment variable PI_NETWORK_SECURITY_GROUP_RULE_ID for testing ibm_pi_network_security_group resource else it is set to default value 'terraform-test-power'
[INFO] Set the environment variable PI_VOLUME_NAME for testing ibm_pi_network_name resource else it is set to default value 'terraform-test-power'
[INFO] Set the environment variable PI_VOLUME_ID for testing ibm_pi_volume_flash_copy_mappings resource else it is set to default value 'terraform-test-power'
[INFO] Set the environment variable PI_REPLICATION_VOLUME_NAME for testing ibm_pi_volume resource else it is set to default value 'terraform-test-power'
[INFO] Set the environment variable PI_VOLUME_ONBARDING_SOURCE_CRN for testing ibm_pi_volume_onboarding resource else it is set to default value 'terraform-test-power'
[INFO] Set the environment variable PI_AUXILIARY_VOLUME_NAME for testing ibm_pi_volume_onboarding resource else it is set to default value 'terraform-test-power'
[INFO] Set the environment variable PI_VOLUME_GROUP_NAME for testing ibm_pi_volume_group resource else it is set to default value 'terraform-test-power'
[INFO] Set the environment variable PI_VOLUME_GROUP_ID for testing ibm_pi_volume_group_storage_details data source else it is set to default value 'terraform-test-power'
[INFO] Set the environment variable PI_VOLUME_ONBOARDING_ID for testing ibm_pi_volume_onboarding resource else it is set to default value 'terraform-test-power'
[INFO] Set the environment variable PI_CLOUDINSTANCE_ID for testing ibm_pi_image resource else it is set to default value 'd16705bd-7f1a-48c9-9e0e-1c17b71e7331'
[INFO] Set the environment variable PI_SNAPSHOT_ID for testing ibm_pi_instance_snapshot data source else it is set to default value '1ea33118-4c43-4356-bfce-904d0658de82'
[INFO] Set the environment variable PI_PVM_INSTANCE_ID for testing Pi_instance_name resource else it is set to default value 'terraform-test-power'
[INFO] Set the environment variable PI_DHCP_ID for testing ibm_pi_dhcp resource else it is set to default value 'terraform-test-power'
[INFO] Set the environment variable PI_CLOUD_CONNECTION_NAME for testing ibm_pi_cloud_connection resource else it is set to default value 'terraform-test-power'
[INFO] Set the environment variable PI_SAP_PROFILE_ID for testing ibm_pi_sap_profile resource else it is set to default value 'terraform-test-power'
[WARN] Set the environment variable PI_PLACEMENT_GROUP_NAME for testing ibm_pi_placement_group resource else it is set to default value 'tf-pi-placement-group'
[WARN] Set the environment variable PI_REMOTE_ID for testing ibm_pi_network_security_group resource else it is set to default value 'terraform-test-power'
[WARN] Set the environment variable PI_REMOTE_TYPE for testing ibm_pi_network_security_group resource else it is set to default value 'terraform-test-power'
[WARN] Set the environment variable PI_SPP_PLACEMENT_GROUP_ID for testing ibm_pi_spp_placement_group resource else it is set to default value 'tf-pi-spp-placement-group'
[INFO] Set the environment variable PI_STORAGE_POOL for testing ibm_pi_storage_pool_capacity else it is set to default value 'terraform-test-power'
[INFO] Set the environment variable PI_STORAGE_TYPE for testing ibm_pi_storage_type_capacity else it is set to default value 'terraform-test-power'
[INFO] Set the environment variable PI_CAPTURE_STORAGE_IMAGE_PATH for testing Pi_capture_storage_image_path resource else it is set to default value 'terraform-test-power'
[INFO] Set the environment variable PI_CAPTURE_CLOUD_STORAGE_ACCESS_KEY for testing Pi_capture_cloud_storage_access_key resource else it is set to default value 'terraform-test-power'
[INFO] Set the environment variable PI_CAPTURE_CLOUD_STORAGE_SECRET_KEY for testing Pi_capture_cloud_storage_secret_key resource else it is set to default value 'terraform-test-power'
[INFO] Set the environment variable PI_CAPTURE_CLOUD_STORAGE_REGION for testing Pi_capture_cloud_storage_region resource else it is set to default value 'us-south'
[WARN] Set the environment variable PI_SHARED_PROCESSOR_POOL_ID for testing ibm_pi_shared_processor_pool resource else it is set to default value 'tf-pi-shared-processor-pool'
[WARN] Set the environment variable PI_STORAGE_CONNECTION for testing pi_storage_connection resource else it is empty
[INFO] Set the environment variable PI_TARGET_STORAGE_TIER for testing Pi_target_storage_tier resource else it is set to default value 'terraform-test-tier'
[INFO] Set the environment variable PI_VOLUME_CLONE_TASK_ID for testing Pi_volume_clone_task_id resource else it is set to default value 'terraform-test-volume-clone-task-id'
[INFO] Set the environment variable PI_VIRTUAL_SERIAL_NUMBER for testing ibm_pi_virtual_serial_number data source else it is set to default value 'terraform-test-power'
[WARN] Set the environment variable PI_RESOURCE_GROUP_ID for testing ibm_pi_workspace resource else it is set to default value ''
[WARN] Set the environment variable PI_HOST_GROUP_ID for testing ibm_pi_host resource else it is set to default value ''
[WARN] Set the environment variable PI_HOST_ID for testing ibm_pi_host resource else it is set to default value ''
[INFO] Set the environment variable PI_NETWORK_ADDRESS_GROUP_ID for testing ibm_pi_network_address_group data source else it is set to default value 'terraform-test-power'
[INFO] Set the environment variable SCHEMATICS_WORKSPACE_ID for testing schematics resources else it is set to default value
[INFO] Set the environment variable SCHEMATICS_TEMPLATE_ID for testing schematics resources else it is set to default value
[INFO] Set the environment variable SCHEMATICS_ACTION_ID for testing schematics resources else it is set to default value
[INFO] Set the environment variable SCHEMATICS_AGENT_ID for testing schematics resources else it is set to default value
[INFO] Set the environment variable SCHEMATICS_JOB_ID for testing schematics resources else it is set to default value
[INFO] Set the environment variable SCHEMATICS_REPO_URL for testing schematics resources else tests will fail if this is not set correctly
[INFO] Set the environment variable SCHEMATICS_REPO_BRANCH for testing schematics resources else tests will fail if this is not set correctly
[WARN] Set the environment variable IMAGE_COS_URL with a VALID COS Image SQL URL for testing ibm_is_image resources on staging/test
[WARN] Set the environment variable IS_DELEGATED_VPC with a VALID created vpc name for testing ibm_is_vpc data source on staging/test
[WARN] Set the environment variable IMAGE_COS_URL_ENCRYPTED with a VALID COS Image SQL URL for testing ibm_is_image resources on staging/test
[WARN] Set the environment variable IMAGE_OPERATING_SYSTEM with a VALID Operating system for testing ibm_is_image resources on staging/test
[INFO] Set the environment variable IS_IMAGE_NAME for testing data source ibm_is_image else it is set to default value `ibm-ubuntu-18-04-1-minimal-amd64-2`
[INFO] Set the environment variable IS_IMAGE_NAME2 for testing data source ibm_is_image else it is set to default value `ibm-ubuntu-20-04-6-minimal-amd64-5`
[INFO] Set the environment variable IS_IMAGE_ENCRYPTED_DATA_KEY for testing resource ibm_is_image else it is set to default value
[INFO] Set the environment variable IS_IMAGE_ENCRYPTION_KEY for testing resource ibm_is_image else it is set to default value
[INFO] Set the environment variable IBM_FUNCTION_NAMESPACE for testing ibm_function_package, ibm_function_action, ibm_function_rule, ibm_function_trigger resource else  tests will fail if this is not set correctly
[INFO] Set the environment variable HPCS_INSTANCE_ID for testing data_source_ibm_kms_key_test else it is set to default value
[INFO] Set the environment variable IBM_TG_CROSS_ACCOUNT_API_KEY for testing ibm_tg_connection resource else  tests will fail if this is not set correctly
[INFO] Set the environment variable IBM_TG_CROSS_ACCOUNT_ID for testing ibm_tg_connection resource else  tests will fail if this is not set correctly
[INFO] Set the environment variable IBM_TG_CROSS_NETWORK_ID for testing ibm_tg_connection resource else  tests will fail if this is not set correctly
[INFO] Set the environment variable IBM_TG_POWER_VS_NETWORK_ID for testing ibm_tg_connection resource else tests will fail if this is not set correctly
[INFO] Set the environment variable ACCOUNT_TO_BE_IMPORTED for testing import enterprise account resource else  tests will fail if this is not set correctly
[INFO] Set the environment variable COS_BUCKET for testing CRUD operations on billing snapshot configuration APIs
[INFO] Set the environment variable COS_LOCATION for testing CRUD operations on billing snapshot configuration APIs
[INFO] Set the environment variable COS_BUCKET_UPDATE for testing update operation on billing snapshot configuration API
[INFO] Set the environment variable COS_LOCATION_UPDATE for testing update operation on billing snapshot configuration API
[INFO] Set the environment variable COS_REPORTS_FOLDER for testing CRUD operations on billing snapshot configuration APIs
[INFO] Set the environment variable SNAPSHOT_DATE_FROM for testing CRUD operations on billing snapshot configuration APIs
[INFO] Set the environment variable SNAPSHOT_DATE_TO for testing CRUD operations on billing snapshot configuration APIs
[INFO] Set the environment variable SNAPSHOT_MONTH for testing CRUD operations on billing snapshot configuration APIs
[WARN] Set the environment variable IBM_HPCS_ADMIN1 with a VALID HPCS Admin Key1 Path
[WARN] Set the environment variable IBM_HPCS_TOKEN1 with a VALID token for HPCS Admin Key1
[WARN] Set the environment variable IBM_HPCS_ADMIN2 with a VALID HPCS Admin Key2 Path
[WARN] Set the environment variable IBM_IAM_REALM_NAME with a VALID realm name for iam trusted profile claim rule
[WARN] Set the environment variable IBM_IAM_IKS_SA with a VALID realm name for iam trusted profile link
[WARN] Set the environment variable IBM_HPCS_TOKEN2 with a VALID token for HPCS Admin Key2
[WARN] Set the environment variable IBM_HPCS_ROOTKEY_CRN with a VALID CRN for a root key created in the HPCS instance
[INFO] Set the environment variable IBM_CLOUD_SHELL_ACCOUNT_ID for ibm-cloud-shell resource or datasource else tests will fail if this is not set correctly
[WARN] Set the environment variable IBM_CLUSTER_VPC_ID for testing ibm_container_vpc_alb_create resources, ibm_container_vpc_alb_create tests will fail if this is not set
[WARN] Set the environment variable IBM_CLUSTER_VPC_SUBNET_ID for testing ibm_container_vpc_alb_create resources, ibm_container_vpc_alb_creates tests will fail if this is not set
[WARN] Set the environment variable IBM_CLUSTER_VPC_RESOURCE_GROUP_ID for testing ibm_container_vpc_alb_create resources, ibm_container_vpc_alb_creates tests will fail if this is not set
[INFO] Set the environment variable IBM_CONTAINER_CLUSTER_NAME for ibm_container_nlb_dns resource or datasource else tests will fail if this is not set correctly
[INFO] Set the environment variable SATELLITE_LOCATION_ID for ibm_cos_bucket satellite location resource or datasource else tests will fail if this is not set correctly
[INFO] Set the environment variable SATELLITE_RESOURCE_INSTANCE_ID for ibm_cos_bucket satellite location resource or datasource else tests will fail if this is not set correctly
[WARN] Set the environment variable IBMCLOUD_CONFIG_AGGREGATOR_ENDPOINT with a VALID SCC API ENDPOINT
[WARN] Set the environment variable IBMCLOUD_CONFIG_AGGREGATOR_INSTANCE_ID with a VALID SCC INSTANCE ID
[WARN] Set the environment variable IBMCLOUD_SCC_INSTANCE_ID with a VALID SCC INSTANCE ID
[WARN] Set the environment variable IBMCLOUD_SCC_API_ENDPOINT with a VALID SCC API ENDPOINT
[WARN] Set the environment variable IBMCLOUD_SCC_REPORT_ID with a VALID SCC REPORT ID
[WARN] Set the environment variable IBMCLOUD_SCC_PROVIDER_TYPE_ATTRIBUTES with a VALID SCC PROVIDER TYPE ATTRIBUTE
[WARN] Set the environment variable IBMCLOUD_SCC_PROVIDER_TYPE_ID with a VALID SCC PROVIDER TYPE ID
[WARN] Set the environment variable IBMCLOUD_SCC_EVENT_NOTIFICATION_CRN
[WARN] Set the environment variable IBMCLOUD_SCC_OBJECT_STORAGE_CRN with a valid cloud object storage crn
[WARN] Set the environment variable IBMCLOUD_SCC_OBJECT_STORAGE_BUCKET with a valid cloud object storage bucket
[INFO] Set the environment variable IBM_CONTAINER_DEDICATEDHOST_POOL_ID for ibm_container_vpc_cluster resource to test dedicated host functionality
[INFO] Set the environment variable IBM_KMS_INSTANCE_ID for ibm_container_vpc_cluster resource or datasource else tests will fail if this is not set correctly
[INFO] Set the environment variable IBM_CRK_ID for ibm_container_vpc_cluster resource or datasource else tests will fail if this is not set correctly
[INFO] Set the environment variable IBM_KMS_ACCOUNT_ID for ibm_container_vpc_cluster resource or datasource else tests will fail if this is not set correctly
[INFO] Set the environment variable IBM_CLUSTER_ID for ibm_container_vpc_worker_pool resource or datasource else tests will fail if this is not set correctly
[WARN] Set the environment variable IBM_CD_RESOURCE_GROUP_NAME for testing CD resources, CD tests will fail if this is not set
[WARN] Set the environment variable IBM_CD_APPCONFIG_INSTANCE_NAME for testing CD resources, CD tests will fail if this is not set
[WARN] Set the environment variable IBM_CD_KEYPROTECT_INSTANCE_NAME for testing CD resources, CD tests will fail if this is not set
[WARN] Set the environment variable IBM_CD_SECRETSMANAGER_INSTANCE_NAME for testing CD resources, CD tests will fail if this is not set
[WARN] Set the environment variable IBM_CD_SLACK_CHANNEL_NAME for testing CD resources, CD tests will fail if this is not set
[WARN] Set the environment variable IBM_CD_SLACK_TEAM_NAME for testing CD resources, CD tests will fail if this is not set
[WARN] Set the environment variable IBM_CD_SLACK_WEBHOOK for testing CD resources, CD tests will fail if this is not set
[WARN] Set the environment variable IBM_CD_JIRA_PROJECT_KEY for testing CD resources, CD tests will fail if this is not set
[WARN] Set the environment variable IBM_CD_JIRA_API_URL for testing CD resources, CD tests will fail if this is not set
[WARN] Set the environment variable IBM_CD_JIRA_USERNAME for testing CD resources, CD tests will fail if this is not set
[WARN] Set the environment variable IBM_CD_JIRA_API_TOKEN for testing CD resources, CD tests will fail if this is not set
[WARN] Set the environment variable IBM_CD_SAUCELABS_ACCESS_KEY for testing CD resources, CD tests will fail if this is not set
[WARN] Set the environment variable IBM_CD_SAUCELABS_USERNAME for testing CD resources, CD tests will fail if this is not set
[WARN] Set the environment variable IBM_CD_BITBUCKET_REPO_URL for testing CD resources, CD tests will fail if this is not set
[WARN] Set the environment variable IBM_CD_GITHUB_CONSOLIDATED_REPO_URL for testing CD resources, CD tests will fail if this is not set
[WARN] Set the environment variable IBM_CD_GITLAB_REPO_URL for testing CD resources, CD tests will fail if this is not set
[WARN] Set the environment variable IBM_CD_HOSTED_GIT_REPO_URL for testing CD resources, CD tests will fail if this is not set
[WARN] Set the environment variable IBM_CD_EVENTNOTIFICATIONS_INSTANCE_NAME for testing CD resources, CD tests will fail if this is not set
[INFO] Set the environment variable IS_CERTIFICATE_CRN for testing ibm_is_vpn_server resource
[INFO] Set the environment variable IS_CLIENT_CA_CRN for testing ibm_is_vpn_server resource
[INFO] Set the environment variable IBM_AccountID_REPL for setting up authorization policy to enable replication feature resource or datasource else tests will fail if this is not set correctly
[WARN] Set the environment variable COS_API_KEY for testing COS targets, the tests will fail if this is not set
[WARN] Set the environment variable INGESTION_KEY for testing Logdna targets, the tests will fail if this is not set
[WARN] Set the environment variable IES_API_KEY for testing Event streams targets, the tests will fail if this is not set
[WARN] Set the environment variable ENTERPRISE_CRN for testing enterprise backup policy, the tests will fail if this is not set
[WARN] Set the environment variable IBM_CODE_ENGINE_RESOURCE_GROUP_ID with the resource group for Code Engine
[WARN] Set the environment variable IBM_CODE_ENGINE_PROJECT_INSTANCE_ID with the ID of a Code Engine project instance
[WARN] Set the environment variable IBM_CODE_ENGINE_SERVICE_INSTANCE_ID with the ID of a IBM Cloud service instance, e.g. for COS
[WARN] Set the environment variable IBM_CODE_ENGINE_RESOURCE_KEY_ID with the ID of a resource key to access a service instance
[WARN] Set the environment variable IBM_CODE_ENGINE_DOMAIN_MAPPING_NAME with the name of a domain mapping
[WARN] Set the environment variable IBM_CODE_ENGINE_TLS_CERT with the TLS certificate in base64 format
[WARN] Set the environment variable IBM_CODE_ENGINE_TLS_KEY with a TLS key in base64 format
[WARN] Set the environment variable IBM_CODE_ENGINE_TLS_CERT_KEY_PATH to point to CERT KEY file path
[WARN] Set the environment variable IBM_CODE_ENGINE_TLS_CERT_PATH to point to CERT file path
[WARN] Set the environment variable IBM_SATELLITE_SSH_PUB_KEY with a ssh public key or ibm_satellite_* tests may fail
[INFO] Set the environment variable IBMCLOUD_MQCLOUD_CONFIG_ENDPOINT for ibm_mqcloud service else tests will fail if this is not set correctly
[INFO] Set the environment variable IBM_MQCLOUD_DEPLOYMENT_ID for ibm_mqcloud_queue_manager resource or datasource else tests will fail if this is not set correctly
[INFO] Set the environment variable IBM_MQCLOUD_DEPLOYMENT_ID for ibm_mqcloud_queue_manager resource or datasource else tests will fail if this is not set correctly
[INFO] Set the environment variable IBM_MQCLOUD_QUEUEMANAGER_ID for ibm_mqcloud_queue_manager resource or datasource else tests will fail if this is not set correctly
[INFO] Set the environment variable IBM_MQCLOUD_KS_CERT_PATH for ibm_mqcloud_keystore_certificate resource or datasource else tests will fail if this is not set correctly
[INFO] Set the environment variable IBM_MQCLOUD_TS_CERT_PATH for ibm_mqcloud_truststore_certificate resource or datasource else tests will fail if this is not set correctly
[INFO] Set the environment variable IBM_MQCLOUD_QUEUEMANAGER_LOCATION for ibm_mqcloud_queue_manager resource or datasource else tests will fail if this is not set correctly
[INFO] Set the environment variable IBM_MQCLOUD_QUEUEMANAGER_VERSION for ibm_mqcloud_queue_manager resource or datasource else tests will fail if this is not set correctly
[INFO] Set the environment variable IBM_MQCLOUD_QUEUEMANAGER_VERSIONUPDATE for ibm_mqcloud_queue_manager resource or datasource else tests will fail if this is not set correctly
[INFO] Set the environment variable IBM_MQCLOUD_TARGET_CRN for ibm_mqcloud_virtual_private_endpoint resource or datasource else tests will fail if this is not set correctly
[INFO] Set the environment variable IBM_MQCLOUD_TRUSTED_PROFILE for ibm_mqcloud_virtual_private_endpoint resource or datasource else tests will fail if this is not set correctly
[INFO] Set the environment variable IBMCLOUD_LOGS_SERVICE_INSTANCE_ID for testing cloud logs related operations
[INFO] Set the environment variable IBMCLOUD_LOGS_SERVICE_INSTANCE_REGION for testing cloud logs related operations
[INFO] Set the environment variable IBMCLOUD_LOGS_SERVICE_EVENT_NOTIFICATIONS_INSTANCE_ID for testing cloud logs related operations
[INFO] Set the environment variable IBMCLOUD_LOGS_SERVICE_EVENT_NOTIFICATIONS_INSTANCE_REGION for testing cloud logs related operations
[WARN] Set the environment variable IBM_PAG_COS_INSTANCE_NAME for testing IBM PAG resource, the tests will fail if this is not set
[WARN] Set the environment variable IBM_PAG_COS_BUCKET_NAME for testing IBM PAG resource, the tests will fail if this is not set
[WARN] Set the environment variable IBM_PAG_COS_BUCKET_REGION for testing IBM PAG resource, the tests will fail if this is not set
[WARN] Set the environment variable IBM_PAG_VPC_NAME for testing IBM PAG resource, the tests will fail if this is not set
[WARN] Set the environment variable IBM_PAG_SERVICE_PLAN for testing IBM PAG resource, the tests will fail if this is not set
[WARN] Set the environment variable IBM_PAG_VPC_SUBNET_INS_1 for testing IBM PAG resource, the tests will fail if this is not set
[WARN] Set the environment variable IBM_PAG_VPC_SUBNET_INS_2 for testing IBM PAG resource, the tests will fail if this is not set
[WARN] Set the environment variable IBM_PAG_VPC_SUBNET_INS_2 for testing IBM PAG resource, the tests will fail if this is not set
[WARN] Set the environment variable IBM_PAG_VPC_SUBNET_INS_2 for testing IBM PAG resource, the tests will fail if this is not set
[WARN] Set the environment variable IBM_VMAAS_DS_ID for testing ibm_vmaas_vdc resource else tests will fail if this is not set correctly
[WARN] Set the environment variable IBM_VMAAS_DS_PVDC_ID for testing ibm_vmaas_vdc resource else tests will fail if this is not set correctly
[INFO] Set the environment variable IBM_POLICY_ASSIGNMENT_TARGET_ACCOUNT_ID for testing ibm_iam_policy_assignment resource else tests will fail if this is not set correctly
[INFO] Set the environment variable IBM_POLICY_ASSIGNMENT_TARGET_ENTERPRISE_ID for testing ibm_iam_policy_assignment resource else tests will fail if this is not set correctly
[WARN] Set the environment variable PCS_REGISTRATION_ACCOUNT_ID for testing iam_onboarding resource else tests will fail if this is not set correctly
[WARN] Set the environment variable PCS_PRODUCT_WITH_APPROVED_PROGRAMMATIC_NAME for testing iam_onboarding resource else tests will fail if this is not set correctly
[WARN] Set the environment variable PCS_PRODUCT_WITH_APPROVED_PROGRAMMATIC_NAME_2 for testing iam_onboarding resource else tests will fail if this is not set correctly
[WARN] Set the environment variable PCS_PRODUCT_WITH_CATALOG_PRODUCT for testing iam_onboarding resource else tests will fail if this is not set correctly
[WARN] Set the environment variable PCS_CATALOG_PRODUCT for testing iam_onboarding resource else tests will fail if this is not set correctly
[WARN] Set the environment variable PCS_CATALOG_PLAN for testing iam_onboarding resource else tests will fail if this is not set correctly
[WARN] Set the environment variable PCS_IAM_TEGISTRATION_ID for testing iam_onboarding resource else tests will fail if this is not set correctly
=== RUN   TestAccIbmSmArbitrarySecretMetadataDataSourceBasic
--- PASS: TestAccIbmSmArbitrarySecretMetadataDataSourceBasic (26.12s)
=== RUN   TestAccIbmSmArbitrarySecretDataSourceBasic
--- PASS: TestAccIbmSmArbitrarySecretDataSourceBasic (23.65s)
=== RUN   TestAccIbmSmConfigurationsDataSourceCryptoKey
--- PASS: TestAccIbmSmConfigurationsDataSourceCryptoKey (54.29s)
=== RUN   TestAccIbmSmEnRegistrationDataSourceBasic
--- PASS: TestAccIbmSmEnRegistrationDataSourceBasic (22.77s)
=== RUN   TestAccIbmSmIamCredentialsConfigurationDataSourceBasic
--- PASS: TestAccIbmSmIamCredentialsConfigurationDataSourceBasic (21.13s)
=== RUN   TestAccIbmSmIamCredentialsSecretMetadataDataSourceBasic
--- PASS: TestAccIbmSmIamCredentialsSecretMetadataDataSourceBasic (28.01s)
=== RUN   TestAccIbmSmIamCredentialsSecretDataSourceBasic
--- PASS: TestAccIbmSmIamCredentialsSecretDataSourceBasic (28.29s)
=== RUN   TestAccIbmSmImportedCertificateMetadataDataSourceBasic
--- PASS: TestAccIbmSmImportedCertificateMetadataDataSourceBasic (22.18s)
=== RUN   TestAccIbmSmImportedCertificateMetadataDataSourceManagedCSR
--- PASS: TestAccIbmSmImportedCertificateMetadataDataSourceManagedCSR (23.24s)
=== RUN   TestAccIbmSmImportedCertificateDataSourceBasic
--- PASS: TestAccIbmSmImportedCertificateDataSourceBasic (23.23s)
=== RUN   TestAccIbmSmImportedCertificateDataSourceManagedCSR
--- PASS: TestAccIbmSmImportedCertificateDataSourceManagedCSR (21.06s)
=== RUN   TestAccIbmSmKvSecretMetadataDataSourceBasic
--- PASS: TestAccIbmSmKvSecretMetadataDataSourceBasic (22.35s)
=== RUN   TestAccIbmSmKvSecretDataSourceBasic
--- PASS: TestAccIbmSmKvSecretDataSourceBasic (23.74s)
=== RUN   TestAccIbmSmPrivateCertificateConfigurationIntermediateCADataSourceBasic
--- PASS: TestAccIbmSmPrivateCertificateConfigurationIntermediateCADataSourceBasic (26.86s)
=== RUN   TestAccIbmSmPrivateCertificateConfigurationIntermediateCADataSourceCryptoKey
--- PASS: TestAccIbmSmPrivateCertificateConfigurationIntermediateCADataSourceCryptoKey (49.34s)
=== RUN   TestAccIbmSmPrivateCertificateConfigurationRootCADataSourceBasic
--- PASS: TestAccIbmSmPrivateCertificateConfigurationRootCADataSourceBasic (23.32s)
=== RUN   TestAccIbmSmPrivateCertificateConfigurationRootCADataSourceCryptoKey
--- PASS: TestAccIbmSmPrivateCertificateConfigurationRootCADataSourceCryptoKey (40.45s)
=== RUN   TestAccIbmSmPrivateCertificateConfigurationTemplateDataSourceBasic
--- PASS: TestAccIbmSmPrivateCertificateConfigurationTemplateDataSourceBasic (29.45s)
=== RUN   TestAccIbmSmPrivateCertificateMetadataDataSourceBasic
--- PASS: TestAccIbmSmPrivateCertificateMetadataDataSourceBasic (33.25s)
=== RUN   TestAccIbmSmPrivateCertificateDataSourceBasic
--- PASS: TestAccIbmSmPrivateCertificateDataSourceBasic (35.89s)
=== RUN   TestAccIbmSmPublicCertificateConfigurationCALetsEncryptDataSourceBasic
--- PASS: TestAccIbmSmPublicCertificateConfigurationCALetsEncryptDataSourceBasic (21.04s)
=== RUN   TestAccIbmSmPublicCertificateConfigurationDnsClassicInfrastructureDataSourceBasic
--- PASS: TestAccIbmSmPublicCertificateConfigurationDnsClassicInfrastructureDataSourceBasic (20.50s)
=== RUN   TestAccIbmSmPublicCertificateDataSourceBasic
--- PASS: TestAccIbmSmPublicCertificateDataSourceBasic (171.29s)
=== RUN   TestAccIbmSmSecretGroupDataSourceBasic
--- PASS: TestAccIbmSmSecretGroupDataSourceBasic (20.45s)
=== RUN   TestAccIbmSmSecretGroupDataSourceAllArgs
--- PASS: TestAccIbmSmSecretGroupDataSourceAllArgs (21.28s)
=== RUN   TestAccIbmSmSecretGroupsDataSourceBasic
--- PASS: TestAccIbmSmSecretGroupsDataSourceBasic (22.30s)
=== RUN   TestAccIbmSmSecretGroupsDataSourceAllArgs
--- PASS: TestAccIbmSmSecretGroupsDataSourceAllArgs (22.44s)
=== RUN   TestAccIbmSmSecretsDataSourceBasic
--- PASS: TestAccIbmSmSecretsDataSourceBasic (25.35s)
=== RUN   TestAccIbmSmServiceCredentialsSecretMetadataDataSourceBasic
--- PASS: TestAccIbmSmServiceCredentialsSecretMetadataDataSourceBasic (29.07s)
=== RUN   TestAccIbmSmServiceCredentialsSecretDataSourceBasic
--- PASS: TestAccIbmSmServiceCredentialsSecretDataSourceBasic (28.40s)
=== RUN   TestAccIbmSmUsernamePasswordSecretMetadataDataSourceBasic
--- PASS: TestAccIbmSmUsernamePasswordSecretMetadataDataSourceBasic (23.53s)
=== RUN   TestAccIbmSmUsernamePasswordSecretDataSourceBasic
--- PASS: TestAccIbmSmUsernamePasswordSecretDataSourceBasic (23.80s)
=== RUN   TestAccIbmSmArbitrarySecretBasic
--- PASS: TestAccIbmSmArbitrarySecretBasic (24.60s)
=== RUN   TestAccIbmSmArbitrarySecretAllArgs
--- PASS: TestAccIbmSmArbitrarySecretAllArgs (44.53s)
=== RUN   TestAccIbmSmEnRegistrationBasic
--- PASS: TestAccIbmSmEnRegistrationBasic (21.13s)
=== RUN   TestAccIbmSmIamCredentialsConfigurationBasic
--- PASS: TestAccIbmSmIamCredentialsConfigurationBasic (24.93s)
=== RUN   TestAccIbmSmIamCredentialsSecretBasic
--- PASS: TestAccIbmSmIamCredentialsSecretBasic (31.52s)
=== RUN   TestAccIbmSmIamCredentialsSecretAllArgs
--- PASS: TestAccIbmSmIamCredentialsSecretAllArgs (50.15s)
=== RUN   TestAccIbmSmImportedCertificateBasic
--- PASS: TestAccIbmSmImportedCertificateBasic (24.67s)
=== RUN   TestAccIbmSmImportedCertificateAllArgs
--- PASS: TestAccIbmSmImportedCertificateAllArgs (42.52s)
=== RUN   TestAccIbmSmImportedCertificateManagedCSR
--- PASS: TestAccIbmSmImportedCertificateManagedCSR (40.26s)
=== RUN   TestAccIbmSmKvSecretBasic
--- PASS: TestAccIbmSmKvSecretBasic (24.27s)
=== RUN   TestAccIbmSmKvSecretAllArgs
--- PASS: TestAccIbmSmKvSecretAllArgs (43.59s)
=== RUN   TestAccIbmSmPrivateCertificateConfigurationActionSetSignedBasic
--- PASS: TestAccIbmSmPrivateCertificateConfigurationActionSetSignedBasic (25.12s)
=== RUN   TestAccIbmSmPrivateCertificateConfigurationActionSignCsrBasic
--- PASS: TestAccIbmSmPrivateCertificateConfigurationActionSignCsrBasic (24.14s)
=== RUN   TestAccIbmSmPrivateCertificateConfigurationIntermediateCABasic
--- PASS: TestAccIbmSmPrivateCertificateConfigurationIntermediateCABasic (29.00s)
=== RUN   TestAccIbmSmPrivateCertificateConfigurationIntermediateCAllArgs
--- PASS: TestAccIbmSmPrivateCertificateConfigurationIntermediateCAllArgs (45.38s)
=== RUN   TestAccIbmSmPrivateCertificateConfigurationIntermediateCACryptoKey
--- PASS: TestAccIbmSmPrivateCertificateConfigurationIntermediateCACryptoKey (54.63s)
=== RUN   TestAccIbmSmPrivateCertificateConfigurationRootCABasic
--- PASS: TestAccIbmSmPrivateCertificateConfigurationRootCABasic (23.52s)
=== RUN   TestAccIbmSmPrivateCertificateConfigurationRootCAllArgs
--- PASS: TestAccIbmSmPrivateCertificateConfigurationRootCAllArgs (39.59s)
=== RUN   TestAccIbmSmPrivateCertificateConfigurationRootCACryptoKey
--- PASS: TestAccIbmSmPrivateCertificateConfigurationRootCACryptoKey (41.61s)
=== RUN   TestAccIbmSmPrivateCertificateConfigurationTemplateBasic
--- PASS: TestAccIbmSmPrivateCertificateConfigurationTemplateBasic (30.96s)
=== RUN   TestAccIbmSmPrivateCertificateConfigurationTemplateAllArgs
--- PASS: TestAccIbmSmPrivateCertificateConfigurationTemplateAllArgs (48.89s)
=== RUN   TestAccIbmSmPrivateCertificateBasic
--- PASS: TestAccIbmSmPrivateCertificateBasic (34.42s)
=== RUN   TestAccIbmSmPrivateCertificateAllArgs
--- PASS: TestAccIbmSmPrivateCertificateAllArgs (56.21s)
=== RUN   TestAccIbmSmPublicCertificateConfigurationCALetsEncryptBasic
--- PASS: TestAccIbmSmPublicCertificateConfigurationCALetsEncryptBasic (22.69s)
=== RUN   TestAccIbmSmPublicCertificateConfigurationDNSClassicInfrastructureBasic
--- PASS: TestAccIbmSmPublicCertificateConfigurationDNSClassicInfrastructureBasic (21.68s)
=== RUN   TestAccIbmSmSecretGroupBasic
--- PASS: TestAccIbmSmSecretGroupBasic (34.69s)
=== RUN   TestAccIbmSmSecretGroupAllArgs
--- PASS: TestAccIbmSmSecretGroupAllArgs (36.68s)
=== RUN   TestAccIbmSmServiceCredentialsSecretBasic
--- PASS: TestAccIbmSmServiceCredentialsSecretBasic (32.89s)
=== RUN   TestAccIbmSmServiceCredentialsSecretAllArgs
--- PASS: TestAccIbmSmServiceCredentialsSecretAllArgs (56.76s)
=== RUN   TestAccIbmSmUsernamePasswordSecretBasic
--- PASS: TestAccIbmSmUsernamePasswordSecretBasic (23.77s)
=== RUN   TestAccIbmSmUsernamePasswordSecretAllArgs
--- PASS: TestAccIbmSmUsernamePasswordSecretAllArgs (44.05s)
PASS
ok      github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/secretsmanager  2108.975s

...
```
