### PR TITLE
added support for created_at and href support in is_ssh_key

### DIFF
--- a/ibm/service/vpc/data_source_ibm_is_ssh_key.go
+++ b/ibm/service/vpc/data_source_ibm_is_ssh_key.go
@@ -36,7 +36,17 @@ func DataSourceIBMISSSHKey() *schema.Resource {
 				Required:    true,
 				Description: "The name of the ssh key",
 			},
-
+			// missing schema added
+			"created_at": &schema.Schema{
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The date and time that the key was created.",
+			},
+			"href": &schema.Schema{
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The URL for this key.",
+			},
 			isKeyType: {
 				Type:        schema.TypeString,
 				Computed:    true,
@@ -146,6 +156,12 @@ func keyGetByName(d *schema.ResourceData, meta interface{}, name string) error {
 			d.Set(isKeyLength, *key.Length)
 			controller, err := flex.GetBaseController(meta)
 			if err != nil {
+				return err
+			}
+			if err = d.Set("created_at", flex.DateTimeToString(key.CreatedAt)); err != nil {
+				return err
+			}
+			if err = d.Set("href", key.Href); err != nil {
 				return err
 			}
 			d.Set(flex.ResourceControllerURL, controller+"/vpc/compute/sshKeys")

--- a/ibm/service/vpc/data_source_ibm_is_ssh_key_test.go
+++ b/ibm/service/vpc/data_source_ibm_is_ssh_key_test.go
@@ -51,6 +51,47 @@ ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCKVmnMOlHKcZK8tpt3MP1lqOLAcqcJzhsvJcjscgVE
 	})
 }
 
+func TestAccIBMISSSHKeyDatasource_CreatedAtHref(t *testing.T) {
+	name1 := fmt.Sprintf("tfssh-name-%d", acctest.RandIntRange(10, 100))
+	publicKey := strings.TrimSpace(`
+ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCKVmnMOlHKcZK8tpt3MP1lqOLAcqcJzhsvJcjscgVERRN7/9484SOBJ3HSKxxNG5JN8owAjy5f9yYwcUg+JaUVuytn5Pv3aeYROHGGg+5G346xaq3DAwX6Y5ykr2fvjObgncQBnuU5KHWCECO/4h8uWuwh/kfniXPVjFToc+gnkqA+3RKpAecZhFXwfalQ9mMuYGFxn+fwn8cYEApsJbsEmb0iJwPiZ5hjFC8wREuiTlhPHDgkBLOiycd20op2nXzDbHfCHInquEe/gYxEitALONxm0swBOwJZwlTDOB7C6y2dzlrtxr1L59m7pCkWI4EtTRLvleehBoj3u7jB4usR
+`)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { acc.TestAccPreCheck(t) },
+		Providers: acc.TestAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testDSCheckIBMISSSHKeyConfig(publicKey, name1),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(
+						"data.ibm_is_ssh_key.ds_key", "name", name1),
+					resource.TestCheckResourceAttrSet(
+						"data.ibm_is_ssh_key.ds_key", "crn"),
+					resource.TestCheckResourceAttrSet(
+						"data.ibm_is_ssh_key.ds_key", "created_at"),
+					resource.TestCheckResourceAttrSet(
+						"data.ibm_is_ssh_key.ds_key", "fingerprint"),
+					resource.TestCheckResourceAttrSet(
+						"data.ibm_is_ssh_key.ds_key", "href"),
+					resource.TestCheckResourceAttrSet(
+						"data.ibm_is_ssh_key.ds_key", "id"),
+					resource.TestCheckResourceAttrSet(
+						"data.ibm_is_ssh_key.ds_key", "length"),
+					resource.TestCheckResourceAttrSet(
+						"data.ibm_is_ssh_key.ds_key", "public_key"),
+					resource.TestCheckResourceAttrSet(
+						"data.ibm_is_ssh_key.ds_key", "type"),
+					resource.TestCheckResourceAttrSet(
+						"data.ibm_is_ssh_key.ds_key", "tags.#"),
+					resource.TestCheckResourceAttr(
+						"data.ibm_is_ssh_key.ds_key", "tags.#", "3"),
+				),
+			},
+		},
+	})
+}
+
 func testDSCheckIBMISSSHKeyConfig(publicKey, name string) string {
 	return fmt.Sprintf(`
 		resource "ibm_is_ssh_key" "key" {

--- a/ibm/service/vpc/resource_ibm_is_ssh_key.go
+++ b/ibm/service/vpc/resource_ibm_is_ssh_key.go
@@ -108,7 +108,17 @@ func ResourceIBMISSSHKey() *schema.Resource {
 				Computed:    true,
 				Description: "Resource group ID",
 			},
-
+			// missing schema
+			"href": &schema.Schema{
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The URL for this key.",
+			},
+			"created_at": &schema.Schema{
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The date and time that the key was created.",
+			},
 			flex.ResourceControllerURL: {
 				Type:        schema.TypeString,
 				Computed:    true,
@@ -282,6 +292,12 @@ func keyGet(d *schema.ResourceData, meta interface{}, id string) error {
 	d.Set(isKeyType, *key.Type)
 	d.Set(isKeyFingerprint, *key.Fingerprint)
 	d.Set(isKeyLength, *key.Length)
+	if err = d.Set("created_at", flex.DateTimeToString(key.CreatedAt)); err != nil {
+		return fmt.Errorf("Error setting created_at: %s", err)
+	}
+	if err = d.Set("href", key.Href); err != nil {
+		return fmt.Errorf("Error setting href: %s", err)
+	}
 	tags, err := flex.GetGlobalTagsUsingCRN(meta, *key.CRN, "", isKeyUserTagType)
 	if err != nil {
 		log.Printf(

--- a/ibm/service/vpc/resource_ibm_is_ssh_key_test.go
+++ b/ibm/service/vpc/resource_ibm_is_ssh_key_test.go
@@ -40,6 +40,32 @@ ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCKVmnMOlHKcZK8tpt3MP1lqOLAcqcJzhsvJcjscgVE
 		},
 	})
 }
+func TestAccIBMISSSHKey_CreatedAtHref(t *testing.T) {
+	var key string
+	publicKey := strings.TrimSpace(`
+ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCKVmnMOlHKcZK8tpt3MP1lqOLAcqcJzhsvJcjscgVERRN7/9484SOBJ3HSKxxNG5JN8owAjy5f9yYwcUg+JaUVuytn5Pv3aeYROHGGg+5G346xaq3DAwX6Y5ykr2fvjObgncQBnuU5KHWCECO/4h8uWuwh/kfniXPVjFToc+gnkqA+3RKpAecZhFXwfalQ9mMuYGFxn+fwn8cYEApsJbsEmb0iJwPiZ5hjFC8wREuiTlhPHDgkBLOiycd20op2nXzDbHfCHInquEe/gYxEitALONxm0swBOwJZwlTDOB7C6y2dzlrtxr1L59m7pCkWI4EtTRLvleehBoj3u7jB4usR
+`)
+	name := fmt.Sprintf("tfssh-createname-%d", acctest.RandIntRange(10, 100))
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { acc.TestAccPreCheck(t) },
+		Providers:    acc.TestAccProviders,
+		CheckDestroy: checkKeyDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckIBMISKeyConfig(publicKey, name),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckIBMISKeyExists("ibm_is_ssh_key.isExampleKey", key),
+					resource.TestCheckResourceAttr(
+						"ibm_is_ssh_key.isExampleKey", "name", name),
+					resource.TestCheckResourceAttrSet(
+						"ibm_is_ssh_key.isExampleKey", "created_at"),
+					resource.TestCheckResourceAttrSet(
+						"ibm_is_ssh_key.isExampleKey", "href"),
+				),
+			},
+		},
+	})
+}
 func TestAccIBMISSSHKey_Newlinebasic(t *testing.T) {
 	var key, key1 string
 	publicKeyTrim := strings.TrimSpace(`ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQDKd3e4uoENwyLGDxpUyxkeC008r6JOHGkeF4HxEUrE2ZkTXvuOyRaF8Utyv12U5Jvpf/NQVGmdlG3rQPY5VRELthr8mhNWexY5WYo/zXSZNjHCjozpL101bcxfNG498y6uv6UoTk6geJcmckVjOYY/2T9F2B1q6dQxIsYIghjfZBFM6+wA136Nx0nof2lZiK7KAIzIlgUY3g3hhno0x5FmJHM9waoHXFLgQA0psz8XUcSt2Zr0JGFOm5U6HV/tvoP4AVB5YrhRatHry2Ulfh4acy0wswgRM0zieU0U/nLJbCgDVLwZyABEC6WcLTfrkkI53I9oYb8XyeWpyRFQLfT7AIIjfgT7q0q4gzSKTJSDR85SHhOmC/bhCDBuJ9s1ICyschF1y8lPjL/maxweNorg3RfuqsZZdmNHR9RKSxt7CPM98Z6yu5wMWRVLC6Ux5MGp6m0mDIJOfaZla6uvp8d/G6cjWCdU5eCeBh6XdQn4UDXwEB/s86lpgbDsPLMCleP8J+w8uZPQA1KZ+uWGBjoswhtOCa6bU/6ZuTqGpQVOGjVOWUGOq/ocvR03ucj6fBKViFWxV75ABXfJLarKkkIMlv9IeJ05NZG6kQjiCRN4T2I0gd9lAm0YqcITEqcN4Wgbm1z2zPwvMyWuMCW3LY4932JHKQkCEXgGBAtsnrXhZw==`)

--- a/website/docs/d/is_ssh_key.html.markdown
+++ b/website/docs/d/is_ssh_key.html.markdown
@@ -39,9 +39,11 @@ Review the argument references that you can specify for your data source.
 In addition to all argument reference list, you can access the following attribute references after your data source is created. 
 
 - `access_tags`  - (List) Access management tags associated for the ssh key.
+- `created_at` - (String) The date and time that the key was created.
 - `crn` - (String) The CRN for this key.
 - `id` - (String) The ID of the SSH key.
 - `fingerprint`-  (String) The SHA256 fingerprint of the public key.
+- `href` - (String) The URL for this key.
 - `length` - (String) The length of the SSH key.
 - `public_key` - (String) The public SSH key value.
 - `tags` - (List) User tags associated for the ssh key.

--- a/website/docs/r/is_ssh_key.html.markdown
+++ b/website/docs/r/is_ssh_key.html.markdown
@@ -55,9 +55,11 @@ Review the argument references that you can specify for your resource.
 ## Attribute reference
 In addition to all argument reference list, you can access the following attribute reference after your resource is created.
 
+- `id` - (String) The ID of the SSH key.
+- `created_at` - (String) The date and time that the key was created.
 - `crn` - (String) The CRN for this key.
 - `fingerprint`-  (String) The SHA256 fingerprint of the public key.
-- `id` - (String) The ID of the SSH key.
+- `href` - (String) The URL for this key.
 - `length` - (String) The length of this key.
 
 ## Import


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/IBM-Cloud/terraform-provider-ibm/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
% make testacc TEST=./ibm/service/vpc TESTARGS='-run=TestAccIBMISSSHKey_CreatedAtHref'
=== RUN   TestAccIBMISSSHKey_CreatedAtHref
--- PASS: TestAccIBMISSSHKey_CreatedAtHref (36.03s)
PASS
ok      github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/vpc     38.097s
```

```
% make testacc TEST=./ibm/service/vpc TESTARGS='-run=TestAccIBMISSSHKeyDatasource_CreatedAtHref'
=== RUN   TestAccIBMISSSHKeyDatasource_CreatedAtHref
--- PASS: TestAccIBMISSSHKeyDatasource_CreatedAtHref (47.39s)
PASS
ok      github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/vpc     49.427s
```
