### PR TITLE
Remove vtl deprecation message

### DIFF
--- a/ibm/service/power/data_source_ibm_pi_catalog_images.go
+++ b/ibm/service/power/data_source_ibm_pi_catalog_images.go
@@ -32,7 +32,6 @@ func DataSourceIBMPICatalogImages() *schema.Resource {
 				Type:        schema.TypeBool,
 			},
 			Arg_VTL: {
-				Deprecated:  "This field is deprecated.",
 				Description: "Set true to include VTL images. The default value is false.",
 				Optional:    true,
 				Type:        schema.TypeBool,

--- a/website/docs/d/pi_catalog_images.html.markdown
+++ b/website/docs/d/pi_catalog_images.html.markdown
@@ -37,7 +37,7 @@ Review the argument reference that you can specify for your data source.
 
 - `pi_cloud_instance_id` - (Required, String) The GUID of the service instance associated with an account.
 - `sap` - (Optional, Bool) Set `true` to include SAP images. The default value is `false`.
-- `vtl` - (Deprecated, Optional, Bool) Set `true` to include VTL images. The default value is `false`.
+- `vtl` - (Optional, Bool) Set `true` to include VTL images. The default value is `false`.
 
 ## Attribute reference
 In addition to the argument reference list, you can access the following attribute references after your data source is created.


### PR DESCRIPTION
Removed vtl deprecation message. This will continue to be supported.