### PR TITLE
Added data source ibm_iam_access_tag

### DIFF
--- a/ibm/provider/provider.go
+++ b/ibm/provider/provider.go
@@ -858,7 +858,8 @@ func Provider() *schema.Provider {
 			"ibm_cm_object":            catalogmanagement.DataSourceIBMCmObject(),
 
 			// Added for Resource Tag
-			"ibm_resource_tag": globaltagging.DataSourceIBMResourceTag(),
+			"ibm_resource_tag":   globaltagging.DataSourceIBMResourceTag(),
+			"ibm_iam_access_tag": globaltagging.DataSourceIBMIamAccessTag(),
 
 			// Atracker
 			"ibm_atracker_targets": atracker.DataSourceIBMAtrackerTargets(),

--- a/ibm/service/globaltagging/data_source_ibm_iam_access_tag.go
+++ b/ibm/service/globaltagging/data_source_ibm_iam_access_tag.go
@@ -1,0 +1,67 @@
+// Copyright IBM Corp. 2017, 2024 All Rights Reserved.
+// Licensed under the Mozilla Public License v2.0
+
+package globaltagging
+
+import (
+	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/conns"
+	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/flex"
+	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/validate"
+	"github.com/IBM/platform-services-go-sdk/globaltaggingv1"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+func DataSourceIBMIamAccessTag() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceIBMIamAccessTag,
+
+		Schema: map[string]*schema.Schema{
+
+			"name": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: validate.InvokeValidator("ibm_iam_access_tag", "name"),
+				Set:          flex.ResourceIBMVPCHash,
+				Description:  "Name of the access tag to be fetched",
+			},
+			tagType: {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "Type of the tag(access)",
+			},
+		},
+	}
+}
+
+func dataSourceIBMIamAccessTag(d *schema.ResourceData, meta interface{}) error {
+	tagName := ""
+	if t, ok := d.GetOk("name"); ok && t != nil {
+		tagName = t.(string)
+	}
+	gtClient, err := meta.(conns.ClientSession).GlobalTaggingAPIv1()
+	if err != nil {
+		return err
+	}
+	accessTagType := "access"
+	listTagsOptions := &globaltaggingv1.ListTagsOptions{
+		TagType: &accessTagType,
+	}
+	taggingResult, _, err := gtClient.ListTags(listTagsOptions)
+	if err != nil {
+		return flex.FmtErrorf("[ERROR] Error retrieving access tag (%s): %s", tagName, err)
+	}
+
+	var taglist []string
+	for _, item := range taggingResult.Items {
+		taglist = append(taglist, *item.Name)
+	}
+	existingAccessTags := flex.NewStringSet(flex.ResourceIBMVPCHash, taglist)
+	if !existingAccessTags.Contains(tagName) {
+		return flex.FmtErrorf("[ERROR] Access tag %s not found", tagName)
+	}
+	d.SetId(tagName)
+	d.Set("name", tagName)
+	d.Set(tagType, accessTagType)
+	return nil
+}

--- a/ibm/service/globaltagging/data_source_ibm_iam_access_tag_test.go
+++ b/ibm/service/globaltagging/data_source_ibm_iam_access_tag_test.go
@@ -1,0 +1,57 @@
+// Copyright IBM Corp. 2017, 2021 All Rights Reserved.
+// Licensed under the Mozilla Public License v2.0
+
+package globaltagging_test
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	acc "github.com/IBM-Cloud/terraform-provider-ibm/ibm/acctest"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+func TestAccIamAccessTagDataSource_basic(t *testing.T) {
+	name := "access:synthetics"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { acc.TestAccPreCheck(t) },
+		Providers: acc.TestAccProviders,
+		Steps: []resource.TestStep{
+
+			{
+				Config: testAccCheckIamAccessTagReadDataSource(name),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("data.ibm_iam_access_tag.example_access_tag", "id", name),
+					resource.TestCheckResourceAttr("data.ibm_iam_access_tag.example_access_tag", "name", name),
+					resource.TestCheckResourceAttr("data.ibm_iam_access_tag.example_access_tag", "tag_type", "access"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccIamAccessTagDataSource_NotFoundExpectingError(t *testing.T) {
+	name := "access:syntheticsxxxxx"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { acc.TestAccPreCheck(t) },
+		Providers: acc.TestAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccCheckIamAccessTagReadDataSource(name),
+				ExpectError: regexp.MustCompile("not found"),
+			},
+		},
+	})
+}
+
+func testAccCheckIamAccessTagReadDataSource(name string) string {
+	return fmt.Sprintf(`
+	data "ibm_iam_access_tag" "example_access_tag" {
+		name = "%s"
+	}
+`, name)
+}

--- a/website/docs/d/iam_access_tag.html.markdown
+++ b/website/docs/d/iam_access_tag.html.markdown
@@ -1,0 +1,34 @@
+---
+subcategory: "Global Tagging"
+layout: "ibm"
+page_title: "IBM : iam_access_tag"
+description: |-
+  Retrieve iam access tag.
+---
+
+# ibm_iam_access_tag
+
+Retrieve an existing IBM Cloud access management tag as a read-only data source. For more information, about access tags, see [IBM Cloud access management tags](https://cloud.ibm.com/apidocs/tagging#create-tag).
+
+## Example usage
+
+###  Sample to retrieve an access tag
+
+```terraform
+
+data "ibm_iam_access_tag" "example_access_tag" {
+  name  = var.access_tag_name
+}
+
+```
+
+## Argument reference
+Review the argument references that you can specify for your data source. 
+
+- `name` - (Required, String) The name of the access management tag.
+
+## Attributes reference
+In addition to all argument reference list, you can access the following attribute references after your data source is created.
+
+- `id` - (String) The unique identifier of the access tag. Same as `name`.
+- `tag_type` - (String) Type of the tag(`access`)


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/IBM-Cloud/terraform-provider-ibm/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->

Added missing data source for `ibm_iam_access_tag` terraform resource.

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TEST=./ibm/service/globaltagging TESTARGS='-run=TestAccIamAccessTagDataSource_basic -count=1'
...
=== RUN   TestAccIamAccessTagDataSource_basic
--- PASS: TestAccIamAccessTagDataSource_basic (32.18s)
PASS
ok      github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/globaltagging   34.253s
```

```
$ make testacc TEST=./ibm/service/globaltagging TESTARGS='-run=TestAccIamAccessTagDataSource_NotFoundExpectingError  -count=1'
...
=== RUN   TestAccIamAccessTagDataSource_NotFoundExpectingError
--- PASS: TestAccIamAccessTagDataSource_NotFoundExpectingError (8.59s)
PASS
ok      github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/globaltagging   10.289s
```
