### PR TITLE
Added support for default address prefixes in vpc(s) datasource

### DIFF
--- a/ibm/service/vpc/data_source_ibm_is_vpc.go
+++ b/ibm/service/vpc/data_source_ibm_is_vpc.go
@@ -36,6 +36,15 @@ func DataSourceIBMISVPC() *schema.Resource {
 				Computed:    true,
 				Description: "Default routing table associated with VPC",
 			},
+			// address prefixes
+			"default_address_prefixes": {
+				Type: schema.TypeMap,
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
+				Computed:    true,
+				Description: "Default address prefixes for each zone.",
+			},
 
 			isVPCName: {
 				Type:         schema.TypeString,
@@ -618,6 +627,52 @@ func setVpcDetails(d *schema.ResourceData, vpc *vpcv1.VPC, meta interface{}, ses
 		if err != nil {
 			return err
 		}
+
+		// address prefixes
+		vpcID := d.Id() // Assuming the VPC ID is stored in the resource ID
+
+		// Fetch all address prefixes for the VPC
+		startAdd := ""
+		allRecs := []vpcv1.AddressPrefix{}
+		for {
+			listVpcAddressPrefixesOptions := &vpcv1.ListVPCAddressPrefixesOptions{
+				VPCID: &vpcID,
+			}
+
+			if startAdd != "" {
+				listVpcAddressPrefixesOptions.Start = &startAdd
+			}
+
+			addressPrefixCollection, response, err := sess.ListVPCAddressPrefixes(listVpcAddressPrefixesOptions)
+			if err != nil {
+				log.Printf("[DEBUG] ListVpcAddressPrefixesWithContext failed %s\n%s", err, response)
+				return fmt.Errorf("ListVpcAddressPrefixesWithContext failed %s\n%s", err, response)
+			}
+
+			allRecs = append(allRecs, addressPrefixCollection.AddressPrefixes...)
+			startAdd = flex.GetNext(addressPrefixCollection.Next)
+			if startAdd == "" {
+				break
+			}
+		}
+
+		// Process address prefixes
+		defaultAddressPrefixes := map[string]string{}
+
+		for _, prefix := range allRecs {
+			zoneName := *prefix.Zone.Name
+			cidr := *prefix.CIDR
+			// Populate default_address_prefixes
+			if *prefix.IsDefault {
+				defaultAddressPrefixes[zoneName] = cidr
+			}
+		}
+
+		// Set the default_address_prefixes attribute in the Terraform state
+		if err := d.Set("default_address_prefixes", defaultAddressPrefixes); err != nil {
+			return fmt.Errorf("error setting default_address_prefixes: %w", err)
+		}
+
 		d.Set(flex.ResourceControllerURL, controller+"/vpc-ext/network/vpcs")
 		d.Set(flex.ResourceName, *vpc.Name)
 		d.Set(flex.ResourceCRN, *vpc.CRN)

--- a/ibm/service/vpc/data_source_ibm_is_vpc_test.go
+++ b/ibm/service/vpc/data_source_ibm_is_vpc_test.go
@@ -87,13 +87,13 @@ func TestAccIBMISVPCDatasource_basicDefaultAddressPrefixes(t *testing.T) {
 					resource.TestCheckResourceAttrSet("data.ibm_is_vpc.ds_vpc", "default_security_group_name"),
 					resource.TestCheckResourceAttrSet("data.ibm_is_vpc.ds_vpc", "default_routing_table_name"),
 					resource.TestCheckResourceAttr(
-						"ibm_is_vpc.ds_vpc", "default_address_prefixes.#", "0"),
+						"data.ibm_is_vpc.ds_vpc", "default_address_prefixes.#", "0"),
 					resource.TestCheckResourceAttrSet("data.ibm_is_vpc.ds_vpc_by_id", "cse_source_addresses.#"),
 					resource.TestCheckResourceAttrSet("data.ibm_is_vpc.ds_vpc_by_id", "default_network_acl_name"),
 					resource.TestCheckResourceAttrSet("data.ibm_is_vpc.ds_vpc_by_id", "default_security_group_name"),
 					resource.TestCheckResourceAttrSet("data.ibm_is_vpc.ds_vpc_by_id", "default_routing_table_name"),
 					resource.TestCheckResourceAttr(
-						"ibm_is_vpc.ds_vpc_by_id", "default_address_prefixes.#", "0"),
+						"data.ibm_is_vpc.ds_vpc_by_id", "default_address_prefixes.#", "0"),
 				),
 			},
 		},

--- a/ibm/service/vpc/data_source_ibm_is_vpc_test.go
+++ b/ibm/service/vpc/data_source_ibm_is_vpc_test.go
@@ -65,13 +65,13 @@ func TestAccIBMISVPCDatasource_basicDefaultAddressPrefixes(t *testing.T) {
 					resource.TestCheckResourceAttrSet("data.ibm_is_vpc.ds_vpc", "default_security_group_name"),
 					resource.TestCheckResourceAttrSet("data.ibm_is_vpc.ds_vpc", "default_routing_table_name"),
 					resource.TestCheckResourceAttrSet(
-						"ibm_is_vpc.ds_vpc", "default_address_prefixes.%"),
+						"data.ibm_is_vpc.ds_vpc", "default_address_prefixes.%"),
 					resource.TestCheckResourceAttrSet("data.ibm_is_vpc.ds_vpc_by_id", "cse_source_addresses.#"),
 					resource.TestCheckResourceAttrSet("data.ibm_is_vpc.ds_vpc_by_id", "default_network_acl_name"),
 					resource.TestCheckResourceAttrSet("data.ibm_is_vpc.ds_vpc_by_id", "default_security_group_name"),
 					resource.TestCheckResourceAttrSet("data.ibm_is_vpc.ds_vpc_by_id", "default_routing_table_name"),
 					resource.TestCheckResourceAttrSet(
-						"ibm_is_vpc.ds_vpc_by_id", "default_address_prefixes.%"),
+						"data.ibm_is_vpc.ds_vpc_by_id", "default_address_prefixes.%"),
 				),
 			},
 			{

--- a/ibm/service/vpc/data_source_ibm_is_vpc_test.go
+++ b/ibm/service/vpc/data_source_ibm_is_vpc_test.go
@@ -43,6 +43,62 @@ func TestAccIBMISVPCDatasource_basic(t *testing.T) {
 		},
 	})
 }
+func TestAccIBMISVPCDatasource_basicDefaultAddressPrefixes(t *testing.T) {
+	var vpc string
+	name := fmt.Sprintf("tfc-vpc-name-%d", acctest.RandIntRange(10, 100))
+	apm := "manual"
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { acc.TestAccPreCheck(t) },
+		Providers:    acc.TestAccProviders,
+		CheckDestroy: testAccCheckIBMISVPCDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testDSCheckIBMISVPCConfig(name),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckIBMISVPCExists("ibm_is_vpc.testacc_vpc", vpc),
+					resource.TestCheckResourceAttr(
+						"data.ibm_is_vpc.ds_vpc", "name", name),
+					resource.TestCheckResourceAttr(
+						"data.ibm_is_vpc.ds_vpc", "tags.#", "1"),
+					resource.TestCheckResourceAttrSet("data.ibm_is_vpc.ds_vpc", "cse_source_addresses.#"),
+					resource.TestCheckResourceAttrSet("data.ibm_is_vpc.ds_vpc", "default_network_acl_name"),
+					resource.TestCheckResourceAttrSet("data.ibm_is_vpc.ds_vpc", "default_security_group_name"),
+					resource.TestCheckResourceAttrSet("data.ibm_is_vpc.ds_vpc", "default_routing_table_name"),
+					resource.TestCheckResourceAttrSet(
+						"ibm_is_vpc.ds_vpc", "default_address_prefixes.%"),
+					resource.TestCheckResourceAttrSet("data.ibm_is_vpc.ds_vpc_by_id", "cse_source_addresses.#"),
+					resource.TestCheckResourceAttrSet("data.ibm_is_vpc.ds_vpc_by_id", "default_network_acl_name"),
+					resource.TestCheckResourceAttrSet("data.ibm_is_vpc.ds_vpc_by_id", "default_security_group_name"),
+					resource.TestCheckResourceAttrSet("data.ibm_is_vpc.ds_vpc_by_id", "default_routing_table_name"),
+					resource.TestCheckResourceAttrSet(
+						"ibm_is_vpc.ds_vpc_by_id", "default_address_prefixes.%"),
+				),
+			},
+			{
+				Config: testDSCheckIBMISVPCConfig1(name, apm),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckIBMISVPCExists("ibm_is_vpc.testacc_vpc", vpc),
+					resource.TestCheckResourceAttr(
+						"data.ibm_is_vpc.ds_vpc", "name", name),
+					resource.TestCheckResourceAttr(
+						"data.ibm_is_vpc.ds_vpc", "tags.#", "1"),
+					resource.TestCheckResourceAttrSet("data.ibm_is_vpc.ds_vpc", "cse_source_addresses.#"),
+					resource.TestCheckResourceAttrSet("data.ibm_is_vpc.ds_vpc", "default_network_acl_name"),
+					resource.TestCheckResourceAttrSet("data.ibm_is_vpc.ds_vpc", "default_security_group_name"),
+					resource.TestCheckResourceAttrSet("data.ibm_is_vpc.ds_vpc", "default_routing_table_name"),
+					resource.TestCheckResourceAttr(
+						"ibm_is_vpc.ds_vpc", "default_address_prefixes.#", "0"),
+					resource.TestCheckResourceAttrSet("data.ibm_is_vpc.ds_vpc_by_id", "cse_source_addresses.#"),
+					resource.TestCheckResourceAttrSet("data.ibm_is_vpc.ds_vpc_by_id", "default_network_acl_name"),
+					resource.TestCheckResourceAttrSet("data.ibm_is_vpc.ds_vpc_by_id", "default_security_group_name"),
+					resource.TestCheckResourceAttrSet("data.ibm_is_vpc.ds_vpc_by_id", "default_routing_table_name"),
+					resource.TestCheckResourceAttr(
+						"ibm_is_vpc.ds_vpc_by_id", "default_address_prefixes.#", "0"),
+				),
+			},
+		},
+	})
+}
 func TestAccIBMISVPCDatasource_dns(t *testing.T) {
 	var vpc string
 	name := acc.ISDelegegatedVPC
@@ -115,6 +171,22 @@ func testDSCheckIBMISVPCConfig(name string) string {
 		    identifier = "${ibm_is_vpc.testacc_vpc.id}"
 		}`, name)
 }
+
+func testDSCheckIBMISVPCConfig1(name, apm string) string {
+	return fmt.Sprintf(`
+		resource "ibm_is_vpc" "testacc_vpc" {
+			name 						= "%s"
+			address_prefix_management 	= "%s"
+			tags 						= ["tag1"]
+		}
+		data "ibm_is_vpc" "ds_vpc" {
+		    name = "${ibm_is_vpc.testacc_vpc.name}"
+		}
+		data "ibm_is_vpc" "ds_vpc_by_id" {
+		    identifier = "${ibm_is_vpc.testacc_vpc.id}"
+		}`, name, apm)
+}
+
 func testDSCheckIBMISVPCDnsConfig(name, server1Add string, enableHubTrue bool) string {
 	return testAccCheckIBMISVPCDnsManualConfig(name, server1Add, enableHubTrue) + fmt.Sprintf(`
 		data "ibm_is_vpc" "ds_vpc" {

--- a/ibm/service/vpc/data_source_ibm_is_vpcs.go
+++ b/ibm/service/vpc/data_source_ibm_is_vpcs.go
@@ -84,7 +84,15 @@ func DataSourceIBMISVPCs() *schema.Resource {
 							Computed:    true,
 							Description: "Default security group name",
 						},
-
+						// address prefixes
+						"default_address_prefixes": {
+							Type: schema.TypeMap,
+							Elem: &schema.Schema{
+								Type: schema.TypeString,
+							},
+							Computed:    true,
+							Description: "Default address prefixes for each zone.",
+						},
 						isVPCDefaultSecurityGroupCRN: {
 							Type:        schema.TypeString,
 							Computed:    true,
@@ -607,6 +615,49 @@ func dataSourceIBMISVPCListRead(context context.Context, d *schema.ResourceData,
 			}
 			l[cseSourceAddresses] = cseSourceIpsList
 		}
+
+		// address prefixes
+		vpcID := *vpc.ID // Assuming the VPC ID is stored in the resource ID
+
+		// Fetch all address prefixes for the VPC
+		startAdd := ""
+		allRecs := []vpcv1.AddressPrefix{}
+		for {
+			listVpcAddressPrefixesOptions := &vpcv1.ListVPCAddressPrefixesOptions{
+				VPCID: &vpcID,
+			}
+
+			if startAdd != "" {
+				listVpcAddressPrefixesOptions.Start = &startAdd
+			}
+
+			addressPrefixCollection, response, err := sess.ListVPCAddressPrefixes(listVpcAddressPrefixesOptions)
+			if err != nil {
+				log.Printf("[DEBUG] ListVpcAddressPrefixesWithContext failed %s\n%s", err, response)
+				diag.FromErr(fmt.Errorf("ListVpcAddressPrefixesWithContext failed %s\n%s", err, response))
+			}
+
+			allRecs = append(allRecs, addressPrefixCollection.AddressPrefixes...)
+			startAdd = flex.GetNext(addressPrefixCollection.Next)
+			if startAdd == "" {
+				break
+			}
+		}
+
+		// Process address prefixes
+		defaultAddressPrefixes := map[string]string{}
+
+		for _, prefix := range allRecs {
+			zoneName := *prefix.Zone.Name
+			cidr := *prefix.CIDR
+			// Populate default_address_prefixes
+			if *prefix.IsDefault {
+				defaultAddressPrefixes[zoneName] = cidr
+			}
+		}
+
+		// Set the default_address_prefixes attribute in the Terraform state
+		l["default_address_prefixes"] = defaultAddressPrefixes
 
 		// adding pagination support for subnets inside vpc
 

--- a/ibm/service/vpc/data_source_ibm_is_vpcs_test.go
+++ b/ibm/service/vpc/data_source_ibm_is_vpcs_test.go
@@ -29,6 +29,33 @@ func TestAccIBMISVPCsDatasource_basic(t *testing.T) {
 		},
 	})
 }
+func TestAccIBMISVPCsDatasource_basicDefaultAddressPrefixes(t *testing.T) {
+	node := "data.ibm_is_vpcs.test1"
+	apm := "manual"
+	vpcname := fmt.Sprintf("tf-vpcname-%d", acctest.RandIntRange(100, 200))
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { acc.TestAccPreCheck(t) },
+		Providers: acc.TestAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testDSCheckIBMISVPCsConfig(vpcname),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet(node, "vpcs.#"),
+					resource.TestCheckResourceAttrSet(
+						node, "vpcs.0.default_address_prefixes.%"),
+				),
+			},
+			{
+				Config: testDSCheckIBMISVPCsConfig1(vpcname, apm),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet(node, "vpcs.#"),
+					resource.TestCheckResourceAttr(
+						node, "vpcs.0.default_address_prefixes.#", "0"),
+				),
+			},
+		},
+	})
+}
 
 func testDSCheckIBMISVPCsConfig(vpcname string) string {
 	return fmt.Sprintf(`
@@ -41,4 +68,18 @@ func testDSCheckIBMISVPCsConfig(vpcname string) string {
 	}
 
 	`, vpcname)
+}
+func testDSCheckIBMISVPCsConfig1(vpcname, apm string) string {
+	return fmt.Sprintf(`
+
+	resource "ibm_is_vpc" "test_vpc1" {
+  		name 						= "%s"
+		address_prefix_management 	= "%s"
+	}
+
+	data "ibm_is_vpcs" "test1" {
+		depends_on = [ ibm_is_vpc.test_vpc1 ]
+	}
+
+	`, vpcname, apm)
 }

--- a/website/docs/d/is_vpc.html.markdown
+++ b/website/docs/d/is_vpc.html.markdown
@@ -49,6 +49,16 @@ In addition to all argument reference list, you can access the following attribu
   Nested scheme for `cse_source_addresses`:
 	- `address` - (String) The IP address of the cloud service endpoint.
 	- `zone_name` - (String) The zone where the cloud service endpoint is located.
+- `default_address_prefixes` - (Map) A map of default address prefixes for each zone in the VPC. The keys are the zone names, and the values are the corresponding address prefixes.
+  Example:
+  ```hcl
+    default_address_prefixes    = {
+        "us-south-1" = "10.240.0.0/18"
+        "us-south-2" = "10.240.64.0/18"
+        "us-south-3" = "10.240.128.0/18"
+        "us-south-4" = "10.240.192.0/18"
+    }
+  ```
 - `default_network_acl` - (String) The ID of the default network ACL.
 - `default_network_acl_crn` - (String)  The CRN of the default network ACL.
 - `default_network_acl_name` - (String)  The name of the default network ACL.

--- a/website/docs/d/is_vpcs.html.markdown
+++ b/website/docs/d/is_vpcs.html.markdown
@@ -51,6 +51,16 @@ You can access the following attribute references after your data source is crea
       Nested scheme for `cse_source_addresses`:
       - `address` - (String) The IP address of the cloud service endpoint.
       - `zone_name` - (String) The zone where the cloud service endpoint is located.
+    - `default_address_prefixes` - (Map) A map of default address prefixes for each zone in the VPC. The keys are the zone names, and the values are the corresponding address prefixes.
+    Example:
+    ```hcl
+      default_address_prefixes    = {
+          "us-south-1" = "10.240.0.0/18"
+          "us-south-2" = "10.240.64.0/18"
+          "us-south-3" = "10.240.128.0/18"
+          "us-south-4" = "10.240.192.0/18"
+      }
+    ```
     - `default_network_acl` - (String) The ID of the default network ACL.
     - `default_network_acl_crn` - (String) The CRN of the default network ACL.
     - `default_network_acl_name` - (String) The name of the default network ACL.


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/IBM-Cloud/terraform-provider-ibm/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
--- PASS: TestAccIBMISVPCsDatasource_basicDefaultAddressPrefixes (142.60s)
PASS
ok      github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/vpc     144.611s
```

```
--- PASS: TestAccIBMISVPCDatasource_basicDefaultAddressPrefixes (147.65s)
PASS
ok      github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/vpc     149.612s
```
