### PR TITLE
Change parameter updates in code engine to prevent panic #5939

### DIFF
--- a/ibm/service/codeengine/resource_ibm_code_engine_app.go
+++ b/ibm/service/codeengine/resource_ibm_code_engine_app.go
@@ -1414,7 +1414,7 @@ func ResourceIbmCodeEngineAppAppPatchAsPatch(patchVals *codeenginev2.AppPatch, d
 	if _, exists := d.GetOk(path); d.HasChange(path) && !exists {
 		patch["run_env_variables"] = nil
 	} else if exists && patch["run_env_variables"] != nil {
-		ResourceIbmCodeEngineAppEnvVarPrototypeAsPatch(patch["run_env_variables"].([]interface{})[0].(map[string]interface{}), d)
+		ResourceIbmCodeEngineAppEnvVarPrototypeAsPatch(patch["run_env_variables"].(map[string]interface{}), d)
 	}
 	path = "run_service_account"
 	if _, exists := d.GetOk(path); d.HasChange(path) && !exists {
@@ -1424,7 +1424,7 @@ func ResourceIbmCodeEngineAppAppPatchAsPatch(patchVals *codeenginev2.AppPatch, d
 	if _, exists := d.GetOk(path); d.HasChange(path) && !exists {
 		patch["run_volume_mounts"] = nil
 	} else if exists && patch["run_volume_mounts"] != nil {
-		ResourceIbmCodeEngineAppVolumeMountPrototypeAsPatch(patch["run_volume_mounts"].([]interface{})[0].(map[string]interface{}), d)
+		ResourceIbmCodeEngineAppVolumeMountPrototypeAsPatch(patch["run_volume_mounts"].(map[string]interface{}), d)
 	}
 	path = "scale_concurrency"
 	if _, exists := d.GetOk(path); d.HasChange(path) && !exists {

--- a/ibm/service/codeengine/resource_ibm_code_engine_function.go
+++ b/ibm/service/codeengine/resource_ibm_code_engine_function.go
@@ -915,7 +915,7 @@ func ResourceIbmCodeEngineFunctionFunctionPatchAsPatch(patchVals *codeenginev2.F
 	if _, exists := d.GetOk(path); d.HasChange(path) && !exists {
 		patch["run_env_variables"] = nil
 	} else if exists && patch["run_env_variables"] != nil {
-		ResourceIbmCodeEngineFunctionEnvVarPrototypeAsPatch(patch["run_env_variables"].([]interface{})[0].(map[string]interface{}), d)
+		ResourceIbmCodeEngineFunctionEnvVarPrototypeAsPatch(patch["run_volume_mounts"].(map[string]interface{}), d)
 	}
 	path = "runtime"
 	if _, exists := d.GetOk(path); d.HasChange(path) && !exists {

--- a/ibm/service/codeengine/resource_ibm_code_engine_job.go
+++ b/ibm/service/codeengine/resource_ibm_code_engine_job.go
@@ -958,7 +958,7 @@ func ResourceIbmCodeEngineJobJobPatchAsPatch(patchVals *codeenginev2.JobPatch, d
 	if _, exists := d.GetOk(path); d.HasChange(path) && !exists {
 		patch["run_env_variables"] = nil
 	} else if exists && patch["run_env_variables"] != nil {
-		ResourceIbmCodeEngineJobEnvVarPrototypeAsPatch(patch["run_env_variables"].([]interface{})[0].(map[string]interface{}), d)
+		ResourceIbmCodeEngineJobEnvVarPrototypeAsPatch(patch["run_env_variables"].(map[string]interface{}), d)
 	}
 	path = "run_mode"
 	if _, exists := d.GetOk(path); d.HasChange(path) && !exists {
@@ -972,7 +972,7 @@ func ResourceIbmCodeEngineJobJobPatchAsPatch(patchVals *codeenginev2.JobPatch, d
 	if _, exists := d.GetOk(path); d.HasChange(path) && !exists {
 		patch["run_volume_mounts"] = nil
 	} else if exists && patch["run_volume_mounts"] != nil {
-		ResourceIbmCodeEngineJobVolumeMountPrototypeAsPatch(patch["run_volume_mounts"].([]interface{})[0].(map[string]interface{}), d)
+		ResourceIbmCodeEngineJobVolumeMountPrototypeAsPatch(patch["run_volume_mounts"].(map[string]interface{}), d)
 	}
 	path = "scale_array_spec"
 	if _, exists := d.GetOk(path); d.HasChange(path) && !exists {


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/IBM-Cloud/terraform-provider-ibm/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #5939 

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
**code_engine_application**
```
$ make testacc TESTARGS='-run=TestAccIbmCodeEngineAppBasic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test $(go list ./... |grep -v 'vendor') -v -run TestAccIbmCodeEngineAppBasic -timeout 700m 
=== RUN   TestAccIbmCodeEngineAppBasic
--- PASS: TestAccIbmCodeEngineAppBasic (155.17s)
PASS
ok      github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/codeengine      156.936s
...
```
```
$ make testacc TESTARGS='-run=TestAccIbmCodeEngineAppExtended'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test $(go list ./... |grep -v 'vendor') -v -run TestAccIbmCodeEngineAppExtended -timeout 700m 
=== RUN   TestAccIbmCodeEngineAppExtended
--- PASS: TestAccIbmCodeEngineAppExtended (192.34s)
PASS
ok      github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/codeengine      225.238s
...
```

**code_engine_function**
```
$ make testacc TESTARGS='-run=TestAccIbmCodeEngineFunctionBasic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test $(go list ./... |grep -v 'vendor') -v -run TestAccIbmCodeEngineFunctionBasic -timeout 700m 
=== RUN   TestAccIbmCodeEngineFunctionBasic
--- PASS: TestAccIbmCodeEngineFunctionBasic (102.87s)
PASS
ok      github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/codeengine      111.915s
...
```
```
$ make testacc TESTARGS='-run=TestAccIbmCodeEngineFunctionExtended'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test $(go list ./... |grep -v 'vendor') -v -run TestAccIbmCodeEngineFunctionExtended -timeout 700m 
=== RUN   TestAccIbmCodeEngineFunctionExtended
--- PASS: TestAccIbmCodeEngineFunctionExtended (110.02s)
PASS
ok      github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/codeengine      120.889s
...
```

**code_engine_job**
```
$ make testacc TESTARGS='-run=TestAccIbmCodeEngineJobBasic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test $(go list ./... |grep -v 'vendor') -v -run TestAccIbmCodeEngineJobBasic -timeout 700m 
=== RUN   TestAccIbmCodeEngineJobBasic
--- PASS: TestAccIbmCodeEngineJobBasic (43.10s)
PASS
ok      github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/codeengine      65.920s
...
```
```
$ make testacc TESTARGS='-run=TestAccIbmCodeEngineJobExtended'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test $(go list ./... |grep -v 'vendor') -v -run TestAccIbmCodeEngineJobExtended -timeout 700m 
=== RUN   TestAccIbmCodeEngineJobExtended
--- PASS: TestAccIbmCodeEngineJobExtended (79.98s)
PASS
ok      github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/codeengine      101.549s
...
```