### PR TITLE
Sm fixes

### DIFF
--- a/ibm/service/secretsmanager/resource_ibm_sm_public_certificate.go
+++ b/ibm/service/secretsmanager/resource_ibm_sm_public_certificate.go
@@ -70,7 +70,8 @@ func ResourceIbmSmPublicCertificate() *schema.Resource {
 			"common_name": &schema.Schema{
 				Type:        schema.TypeString,
 				ForceNew:    true,
-				Required:    true,
+				Optional:    true,
+				Computed:    true,
 				Description: "The Common Name (AKA CN) represents the server name that is protected by the SSL certificate.",
 			},
 			"alt_names": &schema.Schema{

--- a/website/docs/r/sm_private_certificate_configuration_intermediate_ca.html.markdown
+++ b/website/docs/r/sm_private_certificate_configuration_intermediate_ca.html.markdown
@@ -8,18 +8,42 @@ subcategory: "Secrets Manager"
 
 # ibm_sm_private_certificate_configuration_intermediate_ca
 
-Provides a resource for PrivateCertificateConfigurationIntermediateCA. This allows PrivateCertificateConfigurationIntermediateCA to be created, updated and deleted.
+Provides a resource for an intermediate certificate authority. This allows an intermediate CA to be created, updated and deleted. Note that an intermediate CA cannot be deleted if it contains one or more certificate templates. Therefore, arguments that are marked as `Forces new resource` should not be modified if certificate template configurations exist for the CA.
 
 ## Example Usage
 
 ```hcl
 resource "ibm_sm_private_certificate_configuration_intermediate_ca" "intermediate_CA" {
+  depends_on     = [ ibm_sm_private_certificate_configuration_root_ca.private_certificate_root_CA ]
   instance_id    = ibm_resource_instance.sm_instance.guid
   name           = "my_intermediate_ca"
-  common_name    = "ibm.com"
   signing_method = "internal"
-  issuer         = "my_root_ca"
-  max_ttl        = "8760h"
+  issuer         = ibm_sm_private_certificate_configuration_root_ca.private_certificate_root_CA.name
+  common_name    = "ibm.com"
+  alt_names     = ["alt-name-1", "alt-name-2"]
+  permitted_dns_domains = ["exampleString"]
+  ou            = ["example_ou"]
+  organization  = ["example_organization"]
+  country       = ["US"]
+  locality      = ["example_locality"]
+  province      = ["example_province"]
+  street_address  = ["example street address"]
+  postal_code   = ["example_postal_code"]
+  ip_sans       = "127.0.0.1"
+  uri_sans      = "https://www.example.com/test"
+  other_sans    = ["1.2.3.5.4.3.201.10.4.3;utf8:test@example.com"]
+  exclude_cn_from_sans = false
+  ttl           = "2100h"
+  max_ttl       = "8760h"
+  max_path_length = -1
+  issuing_certificates_urls_encoded = true
+  key_type      = "rsa"
+  key_bits      = 4096
+  format        = "pem"
+  private_key_format = "der"
+  crl_expiry    = "72h"
+  crl_disable   = false
+  crl_distribution_points_encoded   = true
 }
 ```
 
@@ -39,6 +63,7 @@ Review the argument reference that you can specify for your resource.
     * Constraints: The list items must match regular expression `/(.*?)/`. The maximum length is `10` items. The minimum length is `0` items.
 * `crl_disable` - (Optional, Boolean) Disables or enables certificate revocation list (CRL) building.If CRL building is disabled, a signed but zero-length CRL is returned when downloading the CRL. If CRL building is enabled, it will rebuild the CRL.
 * `crl_distribution_points_encoded` - (Optional, Boolean) Determines whether to encode the certificate revocation list (CRL) distribution points in the certificates that are issued by this certificate authority.
+* `crl_expiry` - (Optional, Boolean) The time until the certificate revocation list (CRL) expires.The value can be supplied as a string representation of a duration in hours, such as `48h`. The default is 72 hours.
 * `exclude_cn_from_sans` - (Optional, Forces new resource, Boolean) Controls whether the common name is excluded from Subject Alternative Names (SANs).If the common name set to `true`, it is not included in DNS or Email SANs if they apply. This field can be useful if the common name is a human-readable identifier, instead of a hostname or an email address.
 * `expiration_date` - (Optional, Forces new resource, String) The date a secret is expired. The date format follows RFC 3339.
 * `format` - (Optional, Forces new resource, String) The format of the returned data.

--- a/website/docs/r/sm_private_certificate_configuration_root_ca.html.markdown
+++ b/website/docs/r/sm_private_certificate_configuration_root_ca.html.markdown
@@ -8,7 +8,7 @@ subcategory: "Secrets Manager"
 
 # ibm_sm_private_certificate_configuration_root_ca
 
-Provides a resource for PrivateCertificateConfigurationRootCA. This allows PrivateCertificateConfigurationRootCA to be created, updated and deleted.
+Provides a resource for an internally signed root certificate authority. This allows a root CA to be created, updated and deleted. Note that a root CA cannot be deleted if there are intermediate CAs signed by it. Therefore, arguments that are marked as `Forces new resource` should not be modified if there are dependent intermediate CAs.
 
 ## Example Usage
 
@@ -18,7 +18,30 @@ resource "ibm_sm_private_certificate_configuration_root_ca" "private_certificate
   region        = "us-south"
   name          = "my_root_ca"
   common_name   = "ibm.com"
+  alt_names     = ["alt-name-1", "alt-name-2"]
+  permitted_dns_domains = ["exampleString"]
+  ou            = ["example_ou"]
+  organization  = ["example_organization"]
+  country       = ["US"]
+  locality      = ["example_locality"]
+  province      = ["example_province"]
+  street_address  = ["example street address"]
+  postal_code   = ["example_postal_code"]
+  ip_sans       = "127.0.0.1"
+  uri_sans      = "https://www.example.com/test"
+  other_sans    = ["1.2.3.5.4.3.201.10.4.3;utf8:test@example.com"]
+  exclude_cn_from_sans = false
+  ttl           = "2190h"
   max_ttl       = "8760h"
+  max_path_length = -1
+  issuing_certificates_urls_encoded = true
+  key_type      = "rsa"
+  key_bits      = 4096
+  format        = "pem"
+  private_key_format = "der"
+  crl_expiry    = "72h"
+  crl_disable   = false
+  crl_distribution_points_encoded   = true
 }
 ```
 
@@ -38,6 +61,7 @@ Review the argument reference that you can specify for your resource.
     * Constraints: The list items must match regular expression `/(.*?)/`. The maximum length is `10` items. The minimum length is `0` items.
 * `crl_disable` - (Optional, Boolean) Disables or enables certificate revocation list (CRL) building.If CRL building is disabled, a signed but zero-length CRL is returned when downloading the CRL. If CRL building is enabled, it will rebuild the CRL.
 * `crl_distribution_points_encoded` - (Optional, Boolean) Determines whether to encode the certificate revocation list (CRL) distribution points in the certificates that are issued by this certificate authority.
+* `crl_expiry` - (Optional, Boolean) The time until the certificate revocation list (CRL) expires.The value can be supplied as a string representation of a duration in hours, such as `48h`. The default is 72 hours.
 * `exclude_cn_from_sans` - (Optional, Forces new resource, Boolean) Controls whether the common name is excluded from Subject Alternative Names (SANs).If the common name set to `true`, it is not included in DNS or Email SANs if they apply. This field can be useful if the common name is a human-readable identifier, instead of a hostname or an email address.
 * `expiration_date` - (Optional, Forces new resource, String) The date a secret is expired. The date format follows RFC 3339.
 * `format` - (Optional, Forces new resource, String) The format of the returned data.

--- a/website/docs/r/sm_private_certificate_configuration_template.html.markdown
+++ b/website/docs/r/sm_private_certificate_configuration_template.html.markdown
@@ -8,17 +8,49 @@ subcategory: "Secrets Manager"
 
 # ibm_sm_private_certificate_configuration_template
 
-Provides a resource for PrivateCertificateConfigurationTemplate. This allows PrivateCertificateConfigurationTemplate to be created, updated and deleted.
+Provides a resource for a certificate template for private certificate secrets. This allows a certificate template to be created, updated and deleted. Note that a certificate template cannot be deleted if one or more private certificates exist that were generated with this template. Therefore, arguments that are marked as `Forces new resource` should not be modified if secrets generated with this template exist.
 
 ## Example Usage
 
 ```hcl
 resource "ibm_sm_private_certificate_configuration_template" "certificate_template" {
-  instance_id           = ibm_resource_instance.sm_instance.guid
+  depends_on     = [ ibm_sm_private_certificate_configuration_intermediate_ca.intermediate_CA ]
+  instance_id    = ibm_resource_instance.sm_instance.guid
   region                = "us-south"
   name                  = "my_template"
-  certificate_authority = "my_intermediate_ca"
-  allowed_domains       = ["example.com"]
+  certificate_authority = ibm_sm_private_certificate_configuration_intermediate_ca.intermediate_CA.name
+  ou            = ["example_ou"]
+  organization  = ["example_organization"]
+  country       = ["US"]
+  locality      = ["example_locality"]
+  province      = ["example_province"]
+  street_address  = ["example street address"]
+  postal_code   = ["example_postal_code"]
+  ttl           = "2190h"
+  max_ttl       = "8760h"
+  key_type      = "rsa"
+  key_bits      = 4096
+  allowed_domains    = ["example.com"]
+  allow_any_name    = true
+  allow_bare_domains = false
+  allow_glob_domains = false
+  allow_ip_sans      = true
+  allow_localhost    = true
+  allow_subdomains   = false
+  allowed_domains_template = false
+  allowed_other_sans = []
+  allowed_uri_sans   = ["https://www.example.com/test"]
+  enforce_hostnames  = false
+  server_flag           = false
+  client_flag           = false
+  code_signing_flag     = false
+  email_protection_flag = false
+  key_usage           = ["DigitalSignature","KeyAgreement","KeyEncipherment"]
+  use_csr_common_name = true
+  use_csr_sans        = true
+  require_cn          = true
+  basic_constraints_valid_for_non_ca = false
+  not_before_duration = "30s"
 }
 ```
 

--- a/website/docs/r/sm_public_certificate.html.markdown
+++ b/website/docs/r/sm_public_certificate.html.markdown
@@ -8,7 +8,7 @@ subcategory: "Secrets Manager"
 
 # ibm_sm_public_certificate
 
-Provides a resource for PublicCertificate. This allows PublicCertificate to be created, updated and deleted.
+Provides a resource for Secrets Manager public certificate secret. This allows a public certificate secret to be created, updated and deleted.
 
 ## Example Usage
 
@@ -42,7 +42,7 @@ Review the argument reference that you can specify for your resource.
 * `name` - (Required, String) The human-readable name of your secret.
   * Constraints: The maximum length is `256` characters. The minimum length is `2` characters. The value must match regular expression `^[A-Za-z0-9_][A-Za-z0-9_]*(?:_*-*\.*[A-Za-z0-9]*)*[A-Za-z0-9]+$`.
 * `ca` - (Required, Forces new resource, String) The name of the certificate authority configuration.
-* `common_name` - (Required, Forces new resource, String) The Common Name (AKA CN) represents the server name protected by the SSL certificate.
+* `common_name` - (Optional, Forces new resource, String) The Common Name (AKA CN) represents the server name protected by the SSL certificate.
   * Constraints: The maximum length is `64` characters. The minimum length is `4` characters. The value must match regular expression `/^(\\*\\.)?(([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\\-]*[a-zA-Z0-9])\\.)*([A-Za-z0-9]|[A-Za-z0-9][A-Za-z0-9\\-]*[A-Za-z0-9])\\.?$/`.
 * `custom_metadata` - (Optional, Map) The secret metadata that a user can customize.
 * `description` - (Optional, String) An extended description of your secret.To protect your privacy, do not use personal data, such as your name or location, as a description for your secret group.


### PR DESCRIPTION
This PR includes the following changes:
- The common_name parameter in public certificate resource is no longer required. This allows creating a public certificate without providing a common name.
- Improve documentation of private certificate configuration resources, as requested in https://github.com/IBM-Cloud/terraform-provider-ibm/issues/5968

<!--- See what makes a good Pull Request at : https://github.com/IBM-Cloud/terraform-provider-ibm/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #5968

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
haims@Haims-MBP terraform-provider-ibm % make testacc TEST=./ibm/service/secretsmanager
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./ibm/service/secretsmanager -v  -timeout 700m 
[WARN] Set the environment variable IBM_PROJECTS_CONFIG_APIKEY for testing IBM Projects Config resources, the tests will fail if this is not set
[WARN] Set the environment variable IBM_APPID_TENANT_ID for testing AppID resources, AppID tests will fail if this is not set
[WARN] Set the environment variable IBM_APPID_TEST_USER_EMAIL for testing AppID user resources, the tests will fail if this is not set
[WARN] Set the environment variable IBM_ORG for testing ibm_org  resource Some tests for that resource will fail if this is not set correctly
[WARN] Set the environment variable IBM_SPACE for testing ibm_space  resource Some tests for that resource will fail if this is not set correctly
[WARN] Set the environment variable IBM_ID1 for testing ibm_space resource Some tests for that resource will fail if this is not set correctly
[WARN] Set the environment variable IBM_ID2 for testing ibm_space resource Some tests for that resource will fail if this is not set correctly
[WARN] Set the environment variable IBM_IAMUSER for testing ibm_iam_user_policy resource Some tests for that resource will fail if this is not set correctly
[WARN] Set the environment variable IBM_IAMACCOUNTID for testing ibm_iam_trusted_profile resource Some tests for that resource will fail if this is not set correctly
[WARN] Set the environment variable IBM_IAM_SERVICE_ID for testing ibm_iam_trusted_profile_identity resource Some tests for that resource will fail if this is not set correctly
[WARN] Set the environment variable IBM_IAM_TRUSTED_PROFILE_ID for testing ibm_iam_trusted_profile_identity resource Some tests for that resource will fail if this is not set correctly
[WARN] Set the environment variable IBM_DATACENTER for testing ibm_container_cluster resource else it is set to default value 'par01'
[WARN] Set the environment variable IBM_MACHINE_TYPE for testing ibm_container_cluster resource else it is set to default value 'b3c.4x16'
[WARN] Set the environment variable IBM_CERT_CRN for testing ibm_container_alb_cert or ibm_container_ingress_secret_tls resource else it is set to default value
[WARN] Set the environment variable IBM_UPDATE_CERT_CRN for testing ibm_container_alb_cert or ibm_container_ingress_secret_tls resource else it is set to default value
[WARN] Set the environment variable IBM_SECRET_CRN for testing ibm_container_ingress_secret_opaque resource else it is set to default value
[WARN] Set the environment variable IBM_SECRET_CRN_2 for testing ibm_container_ingress_secret_opaque resource else it is set to default value
[WARN] Set the environment variable IBM_INGRESS_INSTANCE_CRN for testing ibm_container_ingress_instance resource. Some tests for that resource will fail if this is not set correctly
[WARN] Set the environment variable IBM_INGRESS_INSTANCE_SECRET_GROUP_ID for testing ibm_container_ingress_instance resource. Some tests for that resource will fail if this is not set correctly
[WARN] Set the environment variable IBM_CONTAINER_REGION for testing ibm_container resources else it is set to default value 'eu-de'
[WARN] Set the environment variable IBM_CIS_INSTANCE with a VALID CIS Instance NAME for testing ibm_cis resources on staging/test
[WARN] Set the environment variable IBM_CIS_DOMAIN_STATIC with the Domain name registered with the CIS instance on test/staging. Domain must be predefined in CIS to avoid CIS billing costs due to domain delete/create
[WARN] Set the environment variable IBM_CIS_DOMAIN_TEST with a VALID Domain name for testing the one time create and delete of a domain in CIS. Note each create/delete will trigger a monthly billing instance. Only to be run in staging/test
[WARN] Set the environment variable IBM_CIS_RESOURCE_GROUP with the resource group for the CIS Instance 
[WARN] Set the environment variable IBM_COS_CRN with a VALID COS instance CRN for testing ibm_cos_* resources
[WARN] Set the environment variable IBM_COS_Bucket_CRN with a VALID BUCKET CRN for testing ibm_cos_bucket* resources
[WARN] Set the environment variable IBM_COS_Backup_Vault with a VALID BACKUP VAULT NAME  for testing ibm_cos_backup_vault* resources
[WARN] Set the environment variable IBM_KMS_KEY_CRN with a VALID key crn for a KP/HPCS root key
[WARN] Set the environment variable IBM_COS_Backup_Policy_Id with a VALID POLICYS ID for testing ibm_cos_backup_policy* resources
[WARN] Set the environment variable IBM_COS_ACTIVITY_TRACKER_CRN with a VALID ACTIVITY TRACKER INSTANCE CRN in valid region for testing ibm_cos_bucket* resources
[WARN] Set the environment variable IBM_COS_METRICS_MONITORING_CRN with a VALID METRICS MONITORING CRN for testing ibm_cos_bucket* resources
[WARN] Set the environment variable IBM_COS_BUCKET_NAME with a VALID BUCKET Name for testing ibm_cos_bucket* resources
[WARN] Set the environment variable IBM_COS_NAME with a VALID COS instance name for testing resources with cos deps
[WARN] Set the environment variable IBM_TRUSTED_MACHINE_TYPE for testing ibm_container_cluster resource else it is set to default value 'mb1c.16x64'
[WARN] Set the environment variable IBM_BM_EXTENDED_HW_TESTING to true/false for testing ibm_compute_bare_metal resource else it is set to default value 'false'
[WARN] Set the environment variable IBM_PUBLIC_VLAN_ID for testing ibm_container_cluster resource else it is set to default value '2393319'
[WARN] Set the environment variable IBM_PRIVATE_VLAN_ID for testing ibm_container_cluster resource else it is set to default value '2393321'
[WARN] Set the environment variable IBM_KUBE_VERSION for testing ibm_container_cluster resource else it is set to default value '1.18.14'
[WARN] Set the environment variable IBM_KUBE_UPDATE_VERSION for testing ibm_container_cluster resource else it is set to default value '1.19.6'
[WARN] Set the environment variable IBM_PRIVATE_SUBNET_ID for testing ibm_container_cluster resource else it is set to default value '1636107'
[WARN] Set the environment variable IBM_PUBLIC_SUBNET_ID for testing ibm_container_cluster resource else it is set to default value '1165645'
[WARN] Set the environment variable IBM_SUBNET_ID for testing ibm_container_cluster resource else it is set to default value '1165645'
[INFO] Set the environment variable IBM_IPSEC_DATACENTER for testing ibm_ipsec_vpn resource else it is set to default value 'tok02'
[INFO] Set the environment variable IBM_IPSEC_CUSTOMER_SUBNET_ID for testing ibm_ipsec_vpn resource else it is set to default value '123456'
[INFO] Set the environment variable IBM_IPSEC_CUSTOMER_PEER_IP for testing ibm_ipsec_vpn resource else it is set to default value '192.168.0.1'
[WARN] Set the environment variable IBM_LBAAS_DATACENTER for testing ibm_lbaas resource else it is set to default value 'dal13'
[WARN] Set the environment variable IBM_LBAAS_SUBNETID for testing ibm_lbaas resource else it is set to default value '2144241'
[WARN] Set the environment variable IBM_LB_LISTENER_CERTIFICATE_INSTANCE for testing ibm_is_lb_listener resource for https redirect else it is set to default value 'crn:v1:staging:public:cloudcerts:us-south:a/2d1bace7b46e4815a81e52c6ffeba5cf:af925157-b125-4db2-b642-adacb8b9c7f5:certificate:c81627a1bf6f766379cc4b98fd2a44ed'
[WARN] Set the environment variable IBM_DEDICATED_HOSTNAME for testing ibm_compute_vm_instance resource else it is set to default value 'terraform-dedicatedhost'
[WARN] Set the environment variable IBM_DEDICATED_HOST_ID for testing ibm_compute_vm_instance resource else it is set to default value '30301'
[WARN] Set the environment variable IBM_WORKER_POOL_ZONE for testing ibm_container_worker_pool_zone_attachment resource else it is set to default value 'ams03'
[WARN] Set the environment variable IBM_WORKER_POOL_ZONE_PRIVATE_VLAN for testing ibm_container_worker_pool_zone_attachment resource else it is set to default value '2538975'
[WARN] Set the environment variable IBM_WORKER_POOL_ZONE_PUBLIC_VLAN for testing ibm_container_worker_pool_zone_attachment resource else it is set to default value '2538967'
[WARN] Set the environment variable IBM_WORKER_POOL_ZONE_UPDATE_PRIVATE_VLAN for testing ibm_container_worker_pool_zone_attachment resource else it is set to default value '2388377'
[WARN] Set the environment variable IBM_WORKER_POOL_ZONE_UPDATE_PUBLIC_VLAN for testing ibm_container_worker_pool_zone_attachment resource else it is set to default value '2388375'
[WARN] Set the environment variable IBM_WORKER_POOL_SECONDARY_STORAGE for testing secondary_storage attachment to IKS workerpools
[WARN] Set the environment variable IBM_PLACEMENT_GROUP_NAME for testing ibm_compute_vm_instance resource else it is set to default value 'terraform-group'
[INFO] Set the environment variable SL_REGION for testing ibm_is_region datasource else it is set to default value 'us-south'
[INFO] Set the environment variable SL_ZONE for testing ibm_is_zone datasource else it is set to default value 'us-south-1'
[INFO] Set the environment variable SL_ZONE_2 for testing ibm_is_zone datasource else it is set to default value 'us-south-2'
[INFO] Set the environment variable SL_ZONE_3 for testing ibm_is_zone datasource else it is set to default value 'us-south-3'
[INFO] Set the environment variable SL_CIDR for testing ibm_is_subnet else it is set to default value '10.240.0.0/24'
[INFO] Set the environment variable SL_CIDR_2 for testing ibm_is_subnet else it is set to default value '10.240.64.0/24'
[INFO] Set the environment variable IS_IPV4_ADDRESS for testing ibm_is_instance else it is set to default value '10.240.0.6'
[INFO] Set the environment variable IS_ACCOUNT_ID for testing private_path_service_gateway_account_policy else it is set to default value 'fee82deba12e4c0fb69c3b09d1f12345'
[INFO] Set the environment variable IS_CLUSTER_NETWORK_PROFILE_NAME for testing cluster_network_profile else it is set to default value 'h100'
[INFO] Set the environment variable IS_INSTANCE_GPU_PROFILE_NAME for testing cluster_network_attachments else it is set to default value 'gx3d-160x1792x8h100'
[INFO] Set the environment variable IS_CLUSTER_NETWORK_SUBNET_PREFIXES_CIDR for testing cluster_network else it is set to default value '10.1.0.0/24'
[INFO] Set the environment variable SL_ADDRESS_PREFIX_CIDR for testing ibm_is_vpc_address_prefix else it is set to default value '10.120.0.0/24'
[INFO] Set the environment variable SL_CIDR_2 for testing ibm_is_subnet else it is set to default value '10.240.64.0/24'
[INFO] Set the environment variable SL_CIDR_2 for testing ibm_is_instance datasource else it is set to default value './test-fixtures/.ssh/pkcs8_rsa.pub'
[INFO] Set the environment variable IS_PRIVATE_SSH_KEY_PATH for testing ibm_is_instance datasource else it is set to default value './test-fixtures/.ssh/pkcs8_rsa'
[INFO] Set the environment variable SL_RESOURCE_GROUP_ID for testing with different resource group id else it is set to default value 'c01d34dff4364763476834c990398zz8'
[INFO] Set the environment variable IS_RESOURCE_CRN for testing with created resource instance
[INFO] Set the environment variable IS_IMAGE for testing ibm_is_instance, ibm_is_floating_ip else it is set to default value 'r006-587a041d-9246-44f0-980b-56a327cf5bd7'
[INFO] Set the environment variable IS_IMAGE2 for testing ibm_is_instance, ibm_is_floating_ip else it is set to default value 'r134-f47cc24c-e020-4db5-ad96-1e5be8b5853b'
[INFO] Set the environment variable IS_WIN_IMAGE for testing ibm_is_instance data source else it is set to default value 'r006-d2e0d0e9-0a4f-4c45-afd7-cab787030776'
[INFO] Set the environment variable IS_COS_BUCKET_NAME for testing ibm_is_image_export_job else it is set to default value 'bucket-27200-lwx4cfvcue'
[INFO] Set the environment variable IS_COS_BUCKET_CRN for testing ibm_is_image_export_job else it is set to default value 'bucket-27200-lwx4cfvcue'
[INFO] Set the environment variable IS_INSTANCE_NAME for testing ibm_is_instance resource else it is set to default value 'instance-01'
[INFO] Set the environment variable IS_BACKUP_POLICY_JOB_ID for testing ibm_is_backup_policy_job datasource
[INFO] Set the environment variable IS_BACKUP_POLICY_ID for testing ibm_is_backup_policy_jobs datasource
[INFO] Set the environment variable IS_REMOTE_CP_BAAS_ENCRYPTION_KEY_CRN for testing remote_copies_policy with Baas plans, else it is set to default value, 'crn:v1:bluemix:public:kms:us-south:a/dffc98a0f1f0f95f6613b3b752286b87:e4a29d1a-2ef0-42a6-8fd2-350deb1c647e:key:5437653b-c4b1-447f-9646-b2a2a4cd6179'
[INFO] Set the environment variable SL_INSTANCE_PROFILE for testing ibm_is_instance resource else it is set to default value 'cx2-2x4'
[INFO] Set the environment variable SL_KMS_INSTANCE_ID for testing ibm_kms_key resource else it is set to default value '30222bb5-1c6d-3834-8d78-ae6348cf8z61'
[INFO] Set the environment variable SL_KMS_KEY_NAME for testing ibm_kms_key resource else it is set to default value 'tfp-test-key'
[INFO] Set the environment variable SL_INSTANCE_PROFILE_UPDATE for testing ibm_is_instance resource else it is set to default value 'cx2-4x8'
[INFO] Set the environment variable IS_BARE_METAL_SERVER_PROFILE for testing ibm_is_bare_metal_server resource else it is set to default value 'bx2-metal-96x384'
[INFO] Set the environment variable IsBareMetalServerImage for testing ibm_is_bare_metal_server resource else it is set to default value 'r006-2d1f36b0-df65-4570-82eb-df7ae5f778b1'
[INFO] Set the environment variable IsBareMetalServerImage2 for testing ibm_is_bare_metal_server resource else it is set to default value 'r006-2d1f36b0-df65-4570-82eb-df7ae5f778b1'
[INFO] Set the environment variable IS_DNS_INSTANCE_CRN for testing ibm_is_lb resource else it is set to default value 'crn:v1:staging:public:dns-svcs:global:a/efe5afc483594adaa8325e2b4d1290df:82df2e3c-53a5-43c6-89ce-dcf78be18668::'
[INFO] Set the environment variable IS_DNS_INSTANCE_CRN1 for testing ibm_is_lb resource else it is set to default value 'crn:v1:staging:public:dns-svcs:global:a/efe5afc483594adaa8325e2b4d1290df:599ae4aa-c554-4a88-8bb2-b199b9a3c046::'
[INFO] Set the environment variable IS_DNS_ZONE_ID for testing ibm_is_lb resource else it is set to default value 'dd501d1d-490b-4bb4-a05d-a31954a1c59e'
[INFO] Set the environment variable IS_DNS_ZONE_ID_1 for testing ibm_is_lb resource else it is set to default value 'b1def78d-51b3-4ea5-a746-1b64c992fcab'
[INFO] Set the environment variable IS_DEDICATED_HOST_NAME for testing ibm_is_instance resource else it is set to default value 'tf-dhost-01'
[INFO] Set the environment variable IS_DEDICATED_HOST_GROUP_ID for testing ibm_is_instance resource else it is set to default value '0717-9104e7b5-77ad-44ad-9eaa-091e6b6efce1'
[INFO] Set the environment variable IS_DEDICATED_HOST_PROFILE for testing ibm_is_instance resource else it is set to default value 'bx2d-host-152x608'
[INFO] Set the environment variable IS_DEDICATED_HOST_GROUP_CLASS for testing ibm_is_instance resource else it is set to default value 'bx2d'
[INFO] Set the environment variable IS_DEDICATED_HOST_GROUP_FAMILY for testing ibm_is_instance resource else it is set to default value 'balanced'
[INFO] Set the environment variable SL_INSTANCE_PROFILE for testing ibm_is_instance resource else it is set to default value 'bx2d-16x64'
[INFO] Set the environment variable IS_SHARE_PROFILE for testing ibm_is_instance resource else it is set to default value 'tier-3iops'
[INFO] Set the environment variable IS_SHARE_PROFILE for testing ibm_is_instance resource else it is set to default value
[INFO] Set the environment variable IS_SHARE_PROFILE for testing ibm_is_instance resource else it is set to default value
[INFO] Set the environment variable IS_VOLUME_PROFILE for testing ibm_is_volume_profile else it is set to default value 'general-purpose'
[INFO] Set the environment variable IS_VIRTUAL_NETWORK_INTERFACE for testing ibm_is_virtual_network_interface else it is set to default value 'c93dc4c6-e85a-4da2-9ea6-f24576256122'
[INFO] Set the environment variable IS_FLOATING_IP for testing ibm_is_virtual_network_interface else it is set to default value 'r006-9fc3948f-1b01-406c-baa5-e86b185e559f'
[INFO] Set the environment variable IS_UNATTACHED_BOOT_VOLUME_NAME for testing ibm_is_image else it is set to default value 'r006-1cbe9f0a-7101-4d25-ae72-2a2d725e530e'
[INFO] Set the environment variable IS_VSI_DATA_VOLUME_ID for testing ibm_is_image else it is set to default value 'r006-1cbe9f0a-7101-4d25-ae72-2a2d725e530e'
[INFO] Set the environment variable SL_ROUTE_NEXTHOP else it is set to default value '10.0.0.4'
[INFO] Set the environment variable ISSnapshotCRN for ibm_is_snapshot resource else it is set to default value 'crn:v1:bluemix:public:is:ca-tor:a/xxxxxxxx::snapshot:xxxx-xxxxc-xxx-xxxx-xxxx-xxxxxxxxxx'
[INFO] Set the environment variable ICD_DB_DEPLOYMENT_ID for testing ibm_cloud_databases else it is set to default value 'crn:v1:bluemix:public:databases-for-redis:au-syd:a/40ddc34a953a8c02f10987b59085b60e:5042afe1-72c2-4231-89cc-c949e5d56251::'
[INFO] Set the environment variable ICD_DB_BACKUP_ID for testing ibm_cloud_databases else it is set to default value 'crn:v1:bluemix:public:databases-for-redis:au-syd:a/40ddc34a953a8c02f10987b59085b60e:5042afe1-72c2-4231-89cc-c949e5d56251:backup:0d862fdb-4faa-42e5-aecb-5057f4d399c3'
[INFO] Set the environment variable ICD_DB_TASK_ID for testing ibm_cloud_databases else it is set to default value 'crn:v1:bluemix:public:databases-for-redis:au-syd:a/40ddc34a953a8c02f10987b59085b60e:367b0a22-05bb-41e3-a1ed-ded1ff0889e5:task:882013a6-2751-4df7-a77a-98d258638704'
[INFO] Set the environment variable PI_IMAGE for testing ibm_pi_image resource else it is set to default value '7200-03-03'
[INFO] Set the environment variable PI_SAP_IMAGE for testing ibm_pi_image resource else it is set to default value 'Linux-RHEL-SAP-8-2'
[INFO] Set the environment variable PI_IMAGE_BUCKET_NAME for testing ibm_pi_image resource else it is set to default value 'images-public-bucket'
[INFO] Set the environment variable PI_IMAGE_BUCKET_FILE_NAME for testing ibm_pi_image resource else it is set to default value 'rhel.ova.gz'
[INFO] Set the environment variable PI_IMAGE_BUCKET_ACCESS_KEY for testing ibm_pi_image_export resource else it is set to default value 'images-bucket-access-key'
[INFO] Set the environment variable PI_IMAGE_BUCKET_SECRET_KEY for testing ibm_pi_image_export resource else it is set to default value 'PI_IMAGE_BUCKET_SECRET_KEY'
[INFO] Set the environment variable PI_IMAGE_BUCKET_REGION for testing ibm_pi_image resource else it is set to default value 'us-east'
[INFO] Set the environment variable PI_IMAGE_ID for testing ibm_pi_image resource else it is set to default value 'IBMi-72-09-2924-11'
[INFO] Set the environment variable PI_KEY_NAME for testing ibm_pi_key_name resource else it is set to default value 'terraform-test-power'
[INFO] Set the environment variable PI_NETWORK_NAME for testing ibm_pi_network_name resource else it is set to default value 'terraform-test-power'
[INFO] Set the environment variable PI_NETWORK_ID for testing ibm_pi_network_interface resource else it is set to default value 'terraform-test-power'
[INFO] Set the environment variable PI_NETWORK_INTERFACE_ID for testing ibm_pi_network_interface resource else it is set to default value 'terraform-test-power'
[INFO] Set the environment variable PI_NETWORK_SECURITY_GROUP_ID for testing ibm_pi_network_security_group resource else it is set to default value 'terraform-test-power'
[INFO] Set the environment variable PI_NETWORK_SECURITY_GROUP_RULE_ID for testing ibm_pi_network_security_group resource else it is set to default value 'terraform-test-power'
[INFO] Set the environment variable PI_NETWORK_SECURITY_GROUP_ID for testing ibm_pi_network_security_group resource else it is set to default value 'terraform-test-power'
[INFO] Set the environment variable PI_NETWORK_SECURITY_GROUP_RULE_ID for testing ibm_pi_network_security_group resource else it is set to default value 'terraform-test-power'
[INFO] Set the environment variable PI_VOLUME_NAME for testing ibm_pi_network_name resource else it is set to default value 'terraform-test-power'
[INFO] Set the environment variable PI_VOLUME_ID for testing ibm_pi_volume_flash_copy_mappings resource else it is set to default value 'terraform-test-power'
[INFO] Set the environment variable PI_REPLICATION_VOLUME_NAME for testing ibm_pi_volume resource else it is set to default value 'terraform-test-power'
[INFO] Set the environment variable PI_VOLUME_ONBARDING_SOURCE_CRN for testing ibm_pi_volume_onboarding resource else it is set to default value 'terraform-test-power'
[INFO] Set the environment variable PI_AUXILIARY_VOLUME_NAME for testing ibm_pi_volume_onboarding resource else it is set to default value 'terraform-test-power'
[INFO] Set the environment variable PI_VOLUME_GROUP_NAME for testing ibm_pi_volume_group resource else it is set to default value 'terraform-test-power'
[INFO] Set the environment variable PI_VOLUME_GROUP_ID for testing ibm_pi_volume_group_storage_details data source else it is set to default value 'terraform-test-power'
[INFO] Set the environment variable PI_VOLUME_ONBOARDING_ID for testing ibm_pi_volume_onboarding resource else it is set to default value 'terraform-test-power'
[INFO] Set the environment variable PI_CLOUDINSTANCE_ID for testing ibm_pi_image resource else it is set to default value 'd16705bd-7f1a-48c9-9e0e-1c17b71e7331'
[INFO] Set the environment variable PI_SNAPSHOT_ID for testing ibm_pi_instance_snapshot data source else it is set to default value '1ea33118-4c43-4356-bfce-904d0658de82'
[INFO] Set the environment variable PI_PVM_INSTANCE_ID for testing Pi_instance_name resource else it is set to default value 'terraform-test-power'
[INFO] Set the environment variable PI_DHCP_ID for testing ibm_pi_dhcp resource else it is set to default value 'terraform-test-power'
[INFO] Set the environment variable PI_CLOUD_CONNECTION_NAME for testing ibm_pi_cloud_connection resource else it is set to default value 'terraform-test-power'
[INFO] Set the environment variable PI_SAP_PROFILE_ID for testing ibm_pi_sap_profile resource else it is set to default value 'terraform-test-power'
[WARN] Set the environment variable PI_PLACEMENT_GROUP_NAME for testing ibm_pi_placement_group resource else it is set to default value 'tf-pi-placement-group'
[WARN] Set the environment variable PI_REMOTE_ID for testing ibm_pi_network_security_group resource else it is set to default value 'terraform-test-power'
[WARN] Set the environment variable PI_REMOTE_TYPE for testing ibm_pi_network_security_group resource else it is set to default value 'terraform-test-power'
[WARN] Set the environment variable PI_SPP_PLACEMENT_GROUP_ID for testing ibm_pi_spp_placement_group resource else it is set to default value 'tf-pi-spp-placement-group'
[INFO] Set the environment variable PI_STORAGE_POOL for testing ibm_pi_storage_pool_capacity else it is set to default value 'terraform-test-power'
[INFO] Set the environment variable PI_STORAGE_TYPE for testing ibm_pi_storage_type_capacity else it is set to default value 'terraform-test-power'
[INFO] Set the environment variable PI_CAPTURE_STORAGE_IMAGE_PATH for testing Pi_capture_storage_image_path resource else it is set to default value 'terraform-test-power'
[INFO] Set the environment variable PI_CAPTURE_CLOUD_STORAGE_ACCESS_KEY for testing Pi_capture_cloud_storage_access_key resource else it is set to default value 'terraform-test-power'
[INFO] Set the environment variable PI_CAPTURE_CLOUD_STORAGE_SECRET_KEY for testing Pi_capture_cloud_storage_secret_key resource else it is set to default value 'terraform-test-power'
[INFO] Set the environment variable PI_CAPTURE_CLOUD_STORAGE_REGION for testing Pi_capture_cloud_storage_region resource else it is set to default value 'us-south'
[WARN] Set the environment variable PI_SHARED_PROCESSOR_POOL_ID for testing ibm_pi_shared_processor_pool resource else it is set to default value 'tf-pi-shared-processor-pool'
[WARN] Set the environment variable PI_STORAGE_CONNECTION for testing pi_storage_connection resource else it is empty
[INFO] Set the environment variable PI_TARGET_STORAGE_TIER for testing Pi_target_storage_tier resource else it is set to default value 'terraform-test-tier'
[INFO] Set the environment variable PI_VOLUME_CLONE_TASK_ID for testing Pi_volume_clone_task_id resource else it is set to default value 'terraform-test-volume-clone-task-id'
[INFO] Set the environment variable PI_VIRTUAL_SERIAL_NUMBER for testing ibm_pi_virtual_serial_number data source else it is set to default value 'terraform-test-power'
[WARN] Set the environment variable PI_RESOURCE_GROUP_ID for testing ibm_pi_workspace resource else it is set to default value ''
[WARN] Set the environment variable PI_HOST_GROUP_ID for testing ibm_pi_host resource else it is set to default value ''
[WARN] Set the environment variable PI_HOST_ID for testing ibm_pi_host resource else it is set to default value ''
[INFO] Set the environment variable PI_NETWORK_ADDRESS_GROUP_ID for testing ibm_pi_network_address_group data source else it is set to default value 'terraform-test-power'
[INFO] Set the environment variable SCHEMATICS_WORKSPACE_ID for testing schematics resources else it is set to default value
[INFO] Set the environment variable SCHEMATICS_TEMPLATE_ID for testing schematics resources else it is set to default value
[INFO] Set the environment variable SCHEMATICS_ACTION_ID for testing schematics resources else it is set to default value
[INFO] Set the environment variable SCHEMATICS_AGENT_ID for testing schematics resources else it is set to default value
[INFO] Set the environment variable SCHEMATICS_JOB_ID for testing schematics resources else it is set to default value
[INFO] Set the environment variable SCHEMATICS_REPO_URL for testing schematics resources else tests will fail if this is not set correctly
[INFO] Set the environment variable SCHEMATICS_REPO_BRANCH for testing schematics resources else tests will fail if this is not set correctly
[WARN] Set the environment variable IMAGE_COS_URL with a VALID COS Image SQL URL for testing ibm_is_image resources on staging/test
[WARN] Set the environment variable IS_DELEGATED_VPC with a VALID created vpc name for testing ibm_is_vpc data source on staging/test
[WARN] Set the environment variable IMAGE_COS_URL_ENCRYPTED with a VALID COS Image SQL URL for testing ibm_is_image resources on staging/test
[WARN] Set the environment variable IMAGE_OPERATING_SYSTEM with a VALID Operating system for testing ibm_is_image resources on staging/test
[INFO] Set the environment variable IS_IMAGE_NAME for testing data source ibm_is_image else it is set to default value `ibm-ubuntu-18-04-1-minimal-amd64-2`
[INFO] Set the environment variable IS_IMAGE_NAME2 for testing data source ibm_is_image else it is set to default value `ibm-ubuntu-20-04-6-minimal-amd64-5`
[INFO] Set the environment variable IS_IMAGE_ENCRYPTED_DATA_KEY for testing resource ibm_is_image else it is set to default value
[INFO] Set the environment variable IS_IMAGE_ENCRYPTION_KEY for testing resource ibm_is_image else it is set to default value
[INFO] Set the environment variable IBM_FUNCTION_NAMESPACE for testing ibm_function_package, ibm_function_action, ibm_function_rule, ibm_function_trigger resource else  tests will fail if this is not set correctly
[INFO] Set the environment variable HPCS_INSTANCE_ID for testing data_source_ibm_kms_key_test else it is set to default value
[INFO] Set the environment variable IBM_TG_CROSS_ACCOUNT_API_KEY for testing ibm_tg_connection resource else  tests will fail if this is not set correctly
[INFO] Set the environment variable IBM_TG_CROSS_ACCOUNT_ID for testing ibm_tg_connection resource else  tests will fail if this is not set correctly
[INFO] Set the environment variable IBM_TG_CROSS_NETWORK_ID for testing ibm_tg_connection resource else  tests will fail if this is not set correctly
[INFO] Set the environment variable IBM_TG_POWER_VS_NETWORK_ID for testing ibm_tg_connection resource else tests will fail if this is not set correctly
[INFO] Set the environment variable ACCOUNT_TO_BE_IMPORTED for testing import enterprise account resource else  tests will fail if this is not set correctly
[INFO] Set the environment variable COS_BUCKET for testing CRUD operations on billing snapshot configuration APIs
[INFO] Set the environment variable COS_LOCATION for testing CRUD operations on billing snapshot configuration APIs
[INFO] Set the environment variable COS_BUCKET_UPDATE for testing update operation on billing snapshot configuration API
[INFO] Set the environment variable COS_LOCATION_UPDATE for testing update operation on billing snapshot configuration API
[INFO] Set the environment variable COS_REPORTS_FOLDER for testing CRUD operations on billing snapshot configuration APIs
[INFO] Set the environment variable SNAPSHOT_DATE_FROM for testing CRUD operations on billing snapshot configuration APIs
[INFO] Set the environment variable SNAPSHOT_DATE_TO for testing CRUD operations on billing snapshot configuration APIs
[INFO] Set the environment variable SNAPSHOT_MONTH for testing CRUD operations on billing snapshot configuration APIs
[WARN] Set the environment variable IBM_HPCS_ADMIN1 with a VALID HPCS Admin Key1 Path
[WARN] Set the environment variable IBM_HPCS_TOKEN1 with a VALID token for HPCS Admin Key1
[WARN] Set the environment variable IBM_HPCS_ADMIN2 with a VALID HPCS Admin Key2 Path
[WARN] Set the environment variable IBM_IAM_REALM_NAME with a VALID realm name for iam trusted profile claim rule
[WARN] Set the environment variable IBM_IAM_IKS_SA with a VALID realm name for iam trusted profile link
[WARN] Set the environment variable IBM_HPCS_TOKEN2 with a VALID token for HPCS Admin Key2
[WARN] Set the environment variable IBM_HPCS_ROOTKEY_CRN with a VALID CRN for a root key created in the HPCS instance
[INFO] Set the environment variable IBM_CLOUD_SHELL_ACCOUNT_ID for ibm-cloud-shell resource or datasource else tests will fail if this is not set correctly
[WARN] Set the environment variable IBM_CLUSTER_VPC_ID for testing ibm_container_vpc_alb_create resources, ibm_container_vpc_alb_create tests will fail if this is not set
[WARN] Set the environment variable IBM_CLUSTER_VPC_SUBNET_ID for testing ibm_container_vpc_alb_create resources, ibm_container_vpc_alb_creates tests will fail if this is not set
[WARN] Set the environment variable IBM_CLUSTER_VPC_RESOURCE_GROUP_ID for testing ibm_container_vpc_alb_create resources, ibm_container_vpc_alb_creates tests will fail if this is not set
[INFO] Set the environment variable IBM_CONTAINER_CLUSTER_NAME for ibm_container_nlb_dns resource or datasource else tests will fail if this is not set correctly
[INFO] Set the environment variable SATELLITE_LOCATION_ID for ibm_cos_bucket satellite location resource or datasource else tests will fail if this is not set correctly
[INFO] Set the environment variable SATELLITE_RESOURCE_INSTANCE_ID for ibm_cos_bucket satellite location resource or datasource else tests will fail if this is not set correctly
[WARN] Set the environment variable IBMCLOUD_CONFIG_AGGREGATOR_ENDPOINT with a VALID SCC API ENDPOINT
[WARN] Set the environment variable IBMCLOUD_CONFIG_AGGREGATOR_INSTANCE_ID with a VALID SCC INSTANCE ID
[WARN] Set the environment variable IBMCLOUD_SCC_INSTANCE_ID with a VALID SCC INSTANCE ID
[WARN] Set the environment variable IBMCLOUD_SCC_API_ENDPOINT with a VALID SCC API ENDPOINT
[WARN] Set the environment variable IBMCLOUD_SCC_REPORT_ID with a VALID SCC REPORT ID
[WARN] Set the environment variable IBMCLOUD_SCC_PROVIDER_TYPE_ATTRIBUTES with a VALID SCC PROVIDER TYPE ATTRIBUTE
[WARN] Set the environment variable IBMCLOUD_SCC_PROVIDER_TYPE_ID with a VALID SCC PROVIDER TYPE ID
[WARN] Set the environment variable IBMCLOUD_SCC_EVENT_NOTIFICATION_CRN
[WARN] Set the environment variable IBMCLOUD_SCC_OBJECT_STORAGE_CRN with a valid cloud object storage crn
[WARN] Set the environment variable IBMCLOUD_SCC_OBJECT_STORAGE_BUCKET with a valid cloud object storage bucket
[INFO] Set the environment variable IBM_CONTAINER_DEDICATEDHOST_POOL_ID for ibm_container_vpc_cluster resource to test dedicated host functionality
[INFO] Set the environment variable IBM_KMS_INSTANCE_ID for ibm_container_vpc_cluster resource or datasource else tests will fail if this is not set correctly
[INFO] Set the environment variable IBM_CRK_ID for ibm_container_vpc_cluster resource or datasource else tests will fail if this is not set correctly
[INFO] Set the environment variable IBM_KMS_ACCOUNT_ID for ibm_container_vpc_cluster resource or datasource else tests will fail if this is not set correctly
[INFO] Set the environment variable IBM_CLUSTER_ID for ibm_container_vpc_worker_pool resource or datasource else tests will fail if this is not set correctly
[WARN] Set the environment variable IBM_CD_RESOURCE_GROUP_NAME for testing CD resources, CD tests will fail if this is not set
[WARN] Set the environment variable IBM_CD_APPCONFIG_INSTANCE_NAME for testing CD resources, CD tests will fail if this is not set
[WARN] Set the environment variable IBM_CD_KEYPROTECT_INSTANCE_NAME for testing CD resources, CD tests will fail if this is not set
[WARN] Set the environment variable IBM_CD_SECRETSMANAGER_INSTANCE_NAME for testing CD resources, CD tests will fail if this is not set
[WARN] Set the environment variable IBM_CD_SLACK_CHANNEL_NAME for testing CD resources, CD tests will fail if this is not set
[WARN] Set the environment variable IBM_CD_SLACK_TEAM_NAME for testing CD resources, CD tests will fail if this is not set
[WARN] Set the environment variable IBM_CD_SLACK_WEBHOOK for testing CD resources, CD tests will fail if this is not set
[WARN] Set the environment variable IBM_CD_JIRA_PROJECT_KEY for testing CD resources, CD tests will fail if this is not set
[WARN] Set the environment variable IBM_CD_JIRA_API_URL for testing CD resources, CD tests will fail if this is not set
[WARN] Set the environment variable IBM_CD_JIRA_USERNAME for testing CD resources, CD tests will fail if this is not set
[WARN] Set the environment variable IBM_CD_JIRA_API_TOKEN for testing CD resources, CD tests will fail if this is not set
[WARN] Set the environment variable IBM_CD_SAUCELABS_ACCESS_KEY for testing CD resources, CD tests will fail if this is not set
[WARN] Set the environment variable IBM_CD_SAUCELABS_USERNAME for testing CD resources, CD tests will fail if this is not set
[WARN] Set the environment variable IBM_CD_BITBUCKET_REPO_URL for testing CD resources, CD tests will fail if this is not set
[WARN] Set the environment variable IBM_CD_GITHUB_CONSOLIDATED_REPO_URL for testing CD resources, CD tests will fail if this is not set
[WARN] Set the environment variable IBM_CD_GITLAB_REPO_URL for testing CD resources, CD tests will fail if this is not set
[WARN] Set the environment variable IBM_CD_HOSTED_GIT_REPO_URL for testing CD resources, CD tests will fail if this is not set
[WARN] Set the environment variable IBM_CD_EVENTNOTIFICATIONS_INSTANCE_NAME for testing CD resources, CD tests will fail if this is not set
[INFO] Set the environment variable IS_CERTIFICATE_CRN for testing ibm_is_vpn_server resource
[INFO] Set the environment variable IS_CLIENT_CA_CRN for testing ibm_is_vpn_server resource
[INFO] Set the environment variable IBM_AccountID_REPL for setting up authorization policy to enable replication feature resource or datasource else tests will fail if this is not set correctly
[WARN] Set the environment variable COS_API_KEY for testing COS targets, the tests will fail if this is not set
[WARN] Set the environment variable INGESTION_KEY for testing Logdna targets, the tests will fail if this is not set
[WARN] Set the environment variable IES_API_KEY for testing Event streams targets, the tests will fail if this is not set
[WARN] Set the environment variable ENTERPRISE_CRN for testing enterprise backup policy, the tests will fail if this is not set
[WARN] Set the environment variable IBM_CODE_ENGINE_RESOURCE_GROUP_ID with the resource group for Code Engine
[WARN] Set the environment variable IBM_CODE_ENGINE_PROJECT_INSTANCE_ID with the ID of a Code Engine project instance
[WARN] Set the environment variable IBM_CODE_ENGINE_SERVICE_INSTANCE_ID with the ID of a IBM Cloud service instance, e.g. for COS
[WARN] Set the environment variable IBM_CODE_ENGINE_RESOURCE_KEY_ID with the ID of a resource key to access a service instance
[WARN] Set the environment variable IBM_CODE_ENGINE_DOMAIN_MAPPING_NAME with the name of a domain mapping
[WARN] Set the environment variable IBM_CODE_ENGINE_TLS_CERT with the TLS certificate in base64 format
[WARN] Set the environment variable IBM_CODE_ENGINE_TLS_KEY with a TLS key in base64 format
[WARN] Set the environment variable IBM_CODE_ENGINE_TLS_CERT_KEY_PATH to point to CERT KEY file path
[WARN] Set the environment variable IBM_CODE_ENGINE_TLS_CERT_PATH to point to CERT file path
[WARN] Set the environment variable IBM_SATELLITE_SSH_PUB_KEY with a ssh public key or ibm_satellite_* tests may fail
[INFO] Set the environment variable IBMCLOUD_MQCLOUD_CONFIG_ENDPOINT for ibm_mqcloud service else tests will fail if this is not set correctly
[INFO] Set the environment variable IBM_MQCLOUD_DEPLOYMENT_ID for ibm_mqcloud_queue_manager resource or datasource else tests will fail if this is not set correctly
[INFO] Set the environment variable IBM_MQCLOUD_DEPLOYMENT_ID for ibm_mqcloud_queue_manager resource or datasource else tests will fail if this is not set correctly
[INFO] Set the environment variable IBM_MQCLOUD_QUEUEMANAGER_ID for ibm_mqcloud_queue_manager resource or datasource else tests will fail if this is not set correctly
[INFO] Set the environment variable IBM_MQCLOUD_KS_CERT_PATH for ibm_mqcloud_keystore_certificate resource or datasource else tests will fail if this is not set correctly
[INFO] Set the environment variable IBM_MQCLOUD_TS_CERT_PATH for ibm_mqcloud_truststore_certificate resource or datasource else tests will fail if this is not set correctly
[INFO] Set the environment variable IBM_MQCLOUD_QUEUEMANAGER_LOCATION for ibm_mqcloud_queue_manager resource or datasource else tests will fail if this is not set correctly
[INFO] Set the environment variable IBM_MQCLOUD_QUEUEMANAGER_VERSION for ibm_mqcloud_queue_manager resource or datasource else tests will fail if this is not set correctly
[INFO] Set the environment variable IBM_MQCLOUD_QUEUEMANAGER_VERSIONUPDATE for ibm_mqcloud_queue_manager resource or datasource else tests will fail if this is not set correctly
[INFO] Set the environment variable IBM_MQCLOUD_TARGET_CRN for ibm_mqcloud_virtual_private_endpoint resource or datasource else tests will fail if this is not set correctly
[INFO] Set the environment variable IBM_MQCLOUD_TRUSTED_PROFILE for ibm_mqcloud_virtual_private_endpoint resource or datasource else tests will fail if this is not set correctly
[INFO] Set the environment variable IBMCLOUD_LOGS_SERVICE_INSTANCE_ID for testing cloud logs related operations
[INFO] Set the environment variable IBMCLOUD_LOGS_SERVICE_INSTANCE_REGION for testing cloud logs related operations
[INFO] Set the environment variable IBMCLOUD_LOGS_SERVICE_EVENT_NOTIFICATIONS_INSTANCE_ID for testing cloud logs related operations
[INFO] Set the environment variable IBMCLOUD_LOGS_SERVICE_EVENT_NOTIFICATIONS_INSTANCE_REGION for testing cloud logs related operations
[WARN] Set the environment variable IBM_PAG_COS_INSTANCE_NAME for testing IBM PAG resource, the tests will fail if this is not set
[WARN] Set the environment variable IBM_PAG_COS_BUCKET_NAME for testing IBM PAG resource, the tests will fail if this is not set
[WARN] Set the environment variable IBM_PAG_COS_BUCKET_REGION for testing IBM PAG resource, the tests will fail if this is not set
[WARN] Set the environment variable IBM_PAG_VPC_NAME for testing IBM PAG resource, the tests will fail if this is not set
[WARN] Set the environment variable IBM_PAG_SERVICE_PLAN for testing IBM PAG resource, the tests will fail if this is not set
[WARN] Set the environment variable IBM_PAG_VPC_SUBNET_INS_1 for testing IBM PAG resource, the tests will fail if this is not set
[WARN] Set the environment variable IBM_PAG_VPC_SUBNET_INS_2 for testing IBM PAG resource, the tests will fail if this is not set
[WARN] Set the environment variable IBM_PAG_VPC_SUBNET_INS_2 for testing IBM PAG resource, the tests will fail if this is not set
[WARN] Set the environment variable IBM_PAG_VPC_SUBNET_INS_2 for testing IBM PAG resource, the tests will fail if this is not set
[WARN] Set the environment variable IBM_VMAAS_DS_ID for testing ibm_vmaas_vdc resource else tests will fail if this is not set correctly
[WARN] Set the environment variable IBM_VMAAS_DS_PVDC_ID for testing ibm_vmaas_vdc resource else tests will fail if this is not set correctly
[INFO] Set the environment variable IBM_POLICY_ASSIGNMENT_TARGET_ACCOUNT_ID for testing ibm_iam_policy_assignment resource else tests will fail if this is not set correctly
[INFO] Set the environment variable IBM_POLICY_ASSIGNMENT_TARGET_ENTERPRISE_ID for testing ibm_iam_policy_assignment resource else tests will fail if this is not set correctly
[WARN] Set the environment variable PCS_REGISTRATION_ACCOUNT_ID for testing iam_onboarding resource else tests will fail if this is not set correctly
[WARN] Set the environment variable PCS_PRODUCT_WITH_APPROVED_PROGRAMMATIC_NAME for testing iam_onboarding resource else tests will fail if this is not set correctly
[WARN] Set the environment variable PCS_PRODUCT_WITH_APPROVED_PROGRAMMATIC_NAME_2 for testing iam_onboarding resource else tests will fail if this is not set correctly
[WARN] Set the environment variable PCS_PRODUCT_WITH_CATALOG_PRODUCT for testing iam_onboarding resource else tests will fail if this is not set correctly
[WARN] Set the environment variable PCS_CATALOG_PRODUCT for testing iam_onboarding resource else tests will fail if this is not set correctly
[WARN] Set the environment variable PCS_CATALOG_PLAN for testing iam_onboarding resource else tests will fail if this is not set correctly
[WARN] Set the environment variable PCS_IAM_TEGISTRATION_ID for testing iam_onboarding resource else tests will fail if this is not set correctly
=== RUN   TestAccIbmSmArbitrarySecretMetadataDataSourceBasic
--- PASS: TestAccIbmSmArbitrarySecretMetadataDataSourceBasic (25.36s)
=== RUN   TestAccIbmSmArbitrarySecretDataSourceBasic
--- PASS: TestAccIbmSmArbitrarySecretDataSourceBasic (24.56s)
=== RUN   TestAccIbmSmConfigurationsDataSourceBasic
--- PASS: TestAccIbmSmConfigurationsDataSourceBasic (40.00s)
=== RUN   TestAccIbmSmConfigurationsDataSourceCryptoKey
--- PASS: TestAccIbmSmConfigurationsDataSourceCryptoKey (59.39s)
=== RUN   TestAccIbmSmEnRegistrationDataSourceBasic
--- PASS: TestAccIbmSmEnRegistrationDataSourceBasic (21.91s)
=== RUN   TestAccIbmSmIamCredentialsConfigurationDataSourceBasic
--- PASS: TestAccIbmSmIamCredentialsConfigurationDataSourceBasic (22.35s)
=== RUN   TestAccIbmSmIamCredentialsSecretMetadataDataSourceBasic
--- PASS: TestAccIbmSmIamCredentialsSecretMetadataDataSourceBasic (28.83s)
=== RUN   TestAccIbmSmIamCredentialsSecretDataSourceBasic
--- PASS: TestAccIbmSmIamCredentialsSecretDataSourceBasic (32.17s)
=== RUN   TestAccIbmSmImportedCertificateMetadataDataSourceBasic
--- PASS: TestAccIbmSmImportedCertificateMetadataDataSourceBasic (23.02s)
=== RUN   TestAccIbmSmImportedCertificateMetadataDataSourceManagedCSR
--- PASS: TestAccIbmSmImportedCertificateMetadataDataSourceManagedCSR (22.45s)
=== RUN   TestAccIbmSmImportedCertificateDataSourceBasic
--- PASS: TestAccIbmSmImportedCertificateDataSourceBasic (22.89s)
=== RUN   TestAccIbmSmImportedCertificateDataSourceManagedCSR
--- PASS: TestAccIbmSmImportedCertificateDataSourceManagedCSR (23.10s)
=== RUN   TestAccIbmSmKvSecretMetadataDataSourceBasic
--- PASS: TestAccIbmSmKvSecretMetadataDataSourceBasic (24.09s)
=== RUN   TestAccIbmSmKvSecretDataSourceBasic
--- PASS: TestAccIbmSmKvSecretDataSourceBasic (23.66s)
=== RUN   TestAccIbmSmPrivateCertificateConfigurationIntermediateCADataSourceBasic
--- PASS: TestAccIbmSmPrivateCertificateConfigurationIntermediateCADataSourceBasic (33.94s)
=== RUN   TestAccIbmSmPrivateCertificateConfigurationIntermediateCADataSourceCryptoKey
--- PASS: TestAccIbmSmPrivateCertificateConfigurationIntermediateCADataSourceCryptoKey (60.21s)
=== RUN   TestAccIbmSmPrivateCertificateConfigurationRootCADataSourceBasic
--- PASS: TestAccIbmSmPrivateCertificateConfigurationRootCADataSourceBasic (24.97s)
=== RUN   TestAccIbmSmPrivateCertificateConfigurationRootCADataSourceCryptoKey
--- PASS: TestAccIbmSmPrivateCertificateConfigurationRootCADataSourceCryptoKey (44.75s)
=== RUN   TestAccIbmSmPrivateCertificateConfigurationTemplateDataSourceBasic
--- PASS: TestAccIbmSmPrivateCertificateConfigurationTemplateDataSourceBasic (41.52s)
=== RUN   TestAccIbmSmPrivateCertificateMetadataDataSourceBasic
--- PASS: TestAccIbmSmPrivateCertificateMetadataDataSourceBasic (38.63s)
=== RUN   TestAccIbmSmPrivateCertificateDataSourceBasic
--- PASS: TestAccIbmSmPrivateCertificateDataSourceBasic (40.04s)
=== RUN   TestAccIbmSmPublicCertificateConfigurationCALetsEncryptDataSourceBasic
--- PASS: TestAccIbmSmPublicCertificateConfigurationCALetsEncryptDataSourceBasic (21.30s)
=== RUN   TestAccIbmSmPublicCertificateConfigurationDnsCisDataSourceBasic
--- PASS: TestAccIbmSmPublicCertificateConfigurationDnsCisDataSourceBasic (22.48s)
=== RUN   TestAccIbmSmPublicCertificateConfigurationDnsClassicInfrastructureDataSourceBasic
--- PASS: TestAccIbmSmPublicCertificateConfigurationDnsClassicInfrastructureDataSourceBasic (21.96s)
=== RUN   TestAccIbmSmPublicCertificateMetadataDataSourceBasic
--- PASS: TestAccIbmSmPublicCertificateMetadataDataSourceBasic (140.35s)
=== RUN   TestAccIbmSmPublicCertificateDataSourceBasic
--- PASS: TestAccIbmSmPublicCertificateDataSourceBasic (140.73s)
=== RUN   TestAccIbmSmSecretGroupDataSourceBasic
--- PASS: TestAccIbmSmSecretGroupDataSourceBasic (21.44s)
=== RUN   TestAccIbmSmSecretGroupDataSourceAllArgs
--- PASS: TestAccIbmSmSecretGroupDataSourceAllArgs (20.45s)
=== RUN   TestAccIbmSmSecretGroupsDataSourceBasic
--- PASS: TestAccIbmSmSecretGroupsDataSourceBasic (22.45s)
=== RUN   TestAccIbmSmSecretGroupsDataSourceAllArgs
--- PASS: TestAccIbmSmSecretGroupsDataSourceAllArgs (22.62s)
=== RUN   TestAccIbmSmSecretsDataSourceBasic
--- PASS: TestAccIbmSmSecretsDataSourceBasic (36.99s)
=== RUN   TestAccIbmSmServiceCredentialsSecretMetadataDataSourceBasic
--- PASS: TestAccIbmSmServiceCredentialsSecretMetadataDataSourceBasic (26.51s)
=== RUN   TestAccIbmSmServiceCredentialsSecretDataSourceBasic
--- PASS: TestAccIbmSmServiceCredentialsSecretDataSourceBasic (34.80s)
=== RUN   TestAccIbmSmUsernamePasswordSecretMetadataDataSourceBasic
--- PASS: TestAccIbmSmUsernamePasswordSecretMetadataDataSourceBasic (22.89s)
=== RUN   TestAccIbmSmUsernamePasswordSecretDataSourceBasic
--- PASS: TestAccIbmSmUsernamePasswordSecretDataSourceBasic (23.04s)
=== RUN   TestAccIbmSmArbitrarySecretBasic
--- PASS: TestAccIbmSmArbitrarySecretBasic (24.80s)
=== RUN   TestAccIbmSmArbitrarySecretAllArgs
--- PASS: TestAccIbmSmArbitrarySecretAllArgs (43.00s)
=== RUN   TestAccIbmSmEnRegistrationBasic
--- PASS: TestAccIbmSmEnRegistrationBasic (19.21s)
=== RUN   TestAccIbmSmIamCredentialsConfigurationBasic
--- PASS: TestAccIbmSmIamCredentialsConfigurationBasic (25.08s)
=== RUN   TestAccIbmSmIamCredentialsSecretBasic
--- PASS: TestAccIbmSmIamCredentialsSecretBasic (30.67s)
=== RUN   TestAccIbmSmIamCredentialsSecretAllArgs
--- PASS: TestAccIbmSmIamCredentialsSecretAllArgs (51.60s)
=== RUN   TestAccIbmSmImportedCertificateBasic
--- PASS: TestAccIbmSmImportedCertificateBasic (23.62s)
=== RUN   TestAccIbmSmImportedCertificateAllArgs
--- PASS: TestAccIbmSmImportedCertificateAllArgs (43.61s)
=== RUN   TestAccIbmSmImportedCertificateManagedCSR
--- PASS: TestAccIbmSmImportedCertificateManagedCSR (39.99s)
=== RUN   TestAccIbmSmKvSecretBasic
--- PASS: TestAccIbmSmKvSecretBasic (25.23s)
=== RUN   TestAccIbmSmKvSecretAllArgs
--- PASS: TestAccIbmSmKvSecretAllArgs (45.40s)
=== RUN   TestAccIbmSmPrivateCertificateConfigurationActionSetSignedBasic
--- PASS: TestAccIbmSmPrivateCertificateConfigurationActionSetSignedBasic (29.75s)
=== RUN   TestAccIbmSmPrivateCertificateConfigurationActionSignCsrBasic
--- PASS: TestAccIbmSmPrivateCertificateConfigurationActionSignCsrBasic (42.29s)
=== RUN   TestAccIbmSmPrivateCertificateConfigurationIntermediateCABasic
--- PASS: TestAccIbmSmPrivateCertificateConfigurationIntermediateCABasic (30.93s)
=== RUN   TestAccIbmSmPrivateCertificateConfigurationIntermediateCAllArgs
--- PASS: TestAccIbmSmPrivateCertificateConfigurationIntermediateCAllArgs (53.16s)
=== RUN   TestAccIbmSmPrivateCertificateConfigurationIntermediateCACryptoKey
--- PASS: TestAccIbmSmPrivateCertificateConfigurationIntermediateCACryptoKey (60.04s)
=== RUN   TestAccIbmSmPrivateCertificateConfigurationRootCABasic
--- PASS: TestAccIbmSmPrivateCertificateConfigurationRootCABasic (25.81s)
=== RUN   TestAccIbmSmPrivateCertificateConfigurationRootCAllArgs
--- PASS: TestAccIbmSmPrivateCertificateConfigurationRootCAllArgs (43.35s)
=== RUN   TestAccIbmSmPrivateCertificateConfigurationRootCACryptoKey
--- PASS: TestAccIbmSmPrivateCertificateConfigurationRootCACryptoKey (44.98s)
=== RUN   TestAccIbmSmPrivateCertificateConfigurationTemplateBasic
--- PASS: TestAccIbmSmPrivateCertificateConfigurationTemplateBasic (36.36s)
=== RUN   TestAccIbmSmPrivateCertificateConfigurationTemplateAllArgs
--- PASS: TestAccIbmSmPrivateCertificateConfigurationTemplateAllArgs (60.82s)
=== RUN   TestAccIbmSmPrivateCertificateBasic
--- PASS: TestAccIbmSmPrivateCertificateBasic (41.28s)
=== RUN   TestAccIbmSmPrivateCertificateAllArgs
--- PASS: TestAccIbmSmPrivateCertificateAllArgs (62.11s)
=== RUN   TestAccIbmSmPublicCertificateActionValidateManualDnsBasic
--- PASS: TestAccIbmSmPublicCertificateActionValidateManualDnsBasic (36.42s)
=== RUN   TestAccIbmSmPublicCertificateConfigurationCALetsEncryptBasic
--- PASS: TestAccIbmSmPublicCertificateConfigurationCALetsEncryptBasic (22.50s)
=== RUN   TestAccIbmSmConfigurationPublicCertificateDnsCisBasic
--- PASS: TestAccIbmSmConfigurationPublicCertificateDnsCisBasic (24.10s)
=== RUN   TestAccIbmSmPublicCertificateConfigurationDNSClassicInfrastructureBasic
--- PASS: TestAccIbmSmPublicCertificateConfigurationDNSClassicInfrastructureBasic (22.81s)
=== RUN   TestAccIbmSmPublicCertificateBasic
--- PASS: TestAccIbmSmPublicCertificateBasic (142.18s)
=== RUN   TestAccIbmSmPublicCertificateAllArgs
--- PASS: TestAccIbmSmPublicCertificateAllArgs (160.05s)
=== RUN   TestAccIbmSmSecretGroupBasic
--- PASS: TestAccIbmSmSecretGroupBasic (35.12s)
=== RUN   TestAccIbmSmSecretGroupAllArgs
--- PASS: TestAccIbmSmSecretGroupAllArgs (36.59s)
=== RUN   TestAccIbmSmServiceCredentialsSecretBasic
--- PASS: TestAccIbmSmServiceCredentialsSecretBasic (28.04s)
=== RUN   TestAccIbmSmServiceCredentialsSecretAllArgs
--- PASS: TestAccIbmSmServiceCredentialsSecretAllArgs (58.43s)
=== RUN   TestAccIbmSmUsernamePasswordSecretBasic
--- PASS: TestAccIbmSmUsernamePasswordSecretBasic (24.24s)
=== RUN   TestAccIbmSmUsernamePasswordSecretAllArgs
--- PASS: TestAccIbmSmUsernamePasswordSecretAllArgs (42.77s)
PASS
ok  	github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/secretsmanager	2794.230s
...
```
