### PR TITLE
fix: always use sasl oauthbearer for sarama client

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -52,7 +52,6 @@ require (
 	github.com/ghodss/yaml v1.0.1-0.20190212211648-25d852aebe32
 	github.com/go-openapi/strfmt v0.23.0
 	github.com/golang-jwt/jwt v3.2.2+incompatible
-	github.com/golang-jwt/jwt/v5 v5.2.1
 	github.com/google/go-cmp v0.6.0
 	github.com/google/uuid v1.6.0
 	github.com/hashicorp/go-uuid v1.0.3

--- a/go.sum
+++ b/go.sum
@@ -10,7 +10,6 @@ cloud.google.com/go v0.51.0/go.mod h1:hWtGJ6gnXH+KgDv+V0zFGDvpi07n3z8ZNj3T1RW0Gc
 cloud.google.com/go v0.52.0/go.mod h1:pXajvRH/6o3+F9jDHZWQ5PbGhn+o8w9qiu/CffaVdO4=
 cloud.google.com/go v0.53.0/go.mod h1:fp/UouUEsRkN6ryDKNW/Upv/JBKnv6WDthjR6+vze6M=
 cloud.google.com/go v0.54.0/go.mod h1:1rq2OEkV3YMf6n/9ZvGWI3GWw0VoqH/1x2nd8Is/bPc=
-cloud.google.com/go v0.54.0/go.mod h1:1rq2OEkV3YMf6n/9ZvGWI3GWw0VoqH/1x2nd8Is/bPc=
 cloud.google.com/go v0.56.0/go.mod h1:jr7tqZxxKOVYizybht9+26Z/gUq7tiRzu+ACVAMbKVk=
 cloud.google.com/go v0.57.0/go.mod h1:oXiQ6Rzq3RAkkY7N6t3TcE6jE+CIBBbA36lwQ1JyzZs=
 cloud.google.com/go v0.62.0/go.mod h1:jmCYTdRCQuc1PHIIJ/maLInMho30T/Y0M4hTdTShOYc=
@@ -552,8 +551,6 @@ github.com/golang-jwt/jwt v3.2.2+incompatible/go.mod h1:8pz2t5EyA70fFQQSrl6XZXzq
 github.com/golang-jwt/jwt/v4 v4.0.0/go.mod h1:/xlHOz8bRuivTWchD4jCa+NbatV+wEUSzwAxVc6locg=
 github.com/golang-jwt/jwt/v4 v4.2.0/go.mod h1:/xlHOz8bRuivTWchD4jCa+NbatV+wEUSzwAxVc6locg=
 github.com/golang-jwt/jwt/v4 v4.3.0/go.mod h1:/xlHOz8bRuivTWchD4jCa+NbatV+wEUSzwAxVc6locg=
-github.com/golang-jwt/jwt/v5 v5.2.1 h1:OuVbFODueb089Lh128TAcimifWaLhJwVflnrgM17wHk=
-github.com/golang-jwt/jwt/v5 v5.2.1/go.mod h1:pqrtFR0X4osieyHYxtmOUWsAWrfe1Q5UVIyoH402zdk=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=
 github.com/golang/groupcache v0.0.0-20160516000752-02826c3e7903/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
 github.com/golang/groupcache v0.0.0-20180513044358-24b0969c4cb7/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=

--- a/ibm/service/eventstreams/resource_ibm_event_streams_topic.go
+++ b/ibm/service/eventstreams/resource_ibm_event_streams_topic.go
@@ -278,12 +278,6 @@ func createSaramaAdminClient(d *schema.ResourceData, meta interface{}) (sarama.C
 		}
 		instanceCRN = getInstanceCRN(topicID)
 	}
-	var adminClient sarama.ClusterAdmin
-	var ok bool
-	if adminClient, ok = clientPool[instanceCRN]; ok {
-		log.Printf("[DEBUG] createSaramaAdminClient got client from pool for instance %s", instanceCRN)
-		return adminClient, instanceCRN, nil
-	}
 	instance, err := getInstanceDetails(instanceCRN, meta)
 	if err != nil {
 		return nil, "", err
@@ -295,6 +289,12 @@ func createSaramaAdminClient(d *schema.ResourceData, meta interface{}) (sarama.C
 	slices.Sort(brokerAddress)
 	d.Set("kafka_brokers_sasl", brokerAddress)
 	log.Printf("[INFO] createSaramaAdminClient kafka_brokers_sasl is set to %s", brokerAddress)
+	var adminClient sarama.ClusterAdmin
+	var ok bool
+	if adminClient, ok = clientPool[instanceCRN]; ok {
+		log.Printf("[DEBUG] createSaramaAdminClient got client from pool for instance %s", instanceCRN)
+		return adminClient, instanceCRN, nil
+	}
 	config := sarama.NewConfig()
 	config.ClientID = fmt.Sprintf("terraform-provider-ibm/%s", version.Version)
 	config.Net.SASL.Enable = true


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/IBM-Cloud/terraform-provider-ibm/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

a followup fix for https://github.com/IBM-Cloud/terraform-provider-ibm/pull/5822 which broke acceptance test.
this PR always uses sasl oauthbearer to configure sarama/kafka client no matter apikey or refresh token is configured in the session.
and uses `IamAuthenticator` from new [platform-sdk](https://github.com/IBM/platform-services-go-sdk) to build required token provider for sarama/kafka client, which simplifies the token fetch and validation because `IamAuthenticator` will be responsible for fetching token from cache or from IAM, and refreshing token when expired.
It is also used to support `iam_token_only` parameter when setting to true, in which case sasl plain authentication is disabled thus sasl plain will not work. Related [PR](https://github.com/terraform-ibm-modules/terraform-ibm-event-streams/pull/381) in event-streams module.


acceptance test
```
15:26:27 ~/workspace/src/github.com/JunliWang/terraform-provider-ibm master $ ./test.sh
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./ibm/service/eventstreams -v -run=^TestAccIBMEventStreamsTopic.* -timeout 700m 
......
=== RUN   TestAccIBMEventStreamsTopicDataSourceBasic
--- PASS: TestAccIBMEventStreamsTopicDataSourceBasic (93.36s)
=== RUN   TestAccIBMEventStreamsTopicResourceBasic
--- PASS: TestAccIBMEventStreamsTopicResourceBasic (74.41s)
=== RUN   TestAccIBMEventStreamsTopicResourceWithExistingInstance
--- PASS: TestAccIBMEventStreamsTopicResourceWithExistingInstance (61.87s)
=== RUN   TestAccIBMEventStreamsTopicImport
--- PASS: TestAccIBMEventStreamsTopicImport (54.74s)
PASS
ok      github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/eventstreams    286.151s
```



debug logs from the test run when configure apikey

```
2025-02-24T11:04:36.726-0800 [INFO]  provider.terraform-provider-ibm_v1.75.3: 2025/02/24 11:04:36 [INFO] createSaramaAdminClient kafka_http_url is set to https://mh-int-wtpvzfbwcnlyhggp-6fc3ea743571ba7392ba4250a5946fd9-0000.us-south.containers.appdomain.cloud: timestamp=2025-02-24T11:04:36.726-0800
2025-02-24T11:04:36.726-0800 [INFO]  provider.terraform-provider-ibm_v1.75.3: 2025/02/24 11:04:36 [INFO] createSaramaAdminClient kafka_brokers_sasl is set to [kafka-0.mh-int-wtpvzfbwcnlyhggp-6fc3ea743571ba7392ba4250a5946fd9-0000.us-south.containers.appdomain.cloud:9093 kafka-1.mh-int-wtpvzfbwcnlyhggp-6fc3ea743571ba7392ba4250a5946fd9-0000.us-south.containers.appdomain.cloud:9093 kafka-2.mh-int-wtpvzfbwcnlyhggp-6fc3ea743571ba7392ba4250a5946fd9-0000.us-south.containers.appdomain.cloud:9093]: timestamp=2025-02-24T11:04:36.726-0800
2025-02-24T11:04:37.321-0800 [INFO]  provider.terraform-provider-ibm_v1.75.3: 2025/02/24 11:04:37 [Debug] Performing synchronous token fetch...: timestamp=2025-02-24T11:04:37.320-0800
2025-02-24T11:04:37.321-0800 [INFO]  provider.terraform-provider-ibm_v1.75.3: 2025/02/24 11:04:37 [Debug] Request:
POST /identity/token HTTP/1.1
Host: iam.test.cloud.ibm.com
User-Agent: ibm-go-sdk-core/iam-authenticator-5.18.5 (arch=arm64; os=darwin; go.version=go1.23.6)
Content-Length: 135
Accept: application/json
Authorization: [redacted]
Content-Type: application/x-www-form-urlencoded
Accept-Encoding: gzip

apikey=[redacted]&grant_type=urn%3Aibm%3Aparams%3Aoauth%3Agrant-type%3Aapikey&response_type=cloud_iam: timestamp=2025-02-24T11:04:37.321-0800
2025-02-24T11:04:37.321-0800 [INFO]  provider.terraform-provider-ibm_v1.75.3: 2025/02/24 11:04:37 [Debug] Invoking IAM 'get token' operation: https://iam.test.cloud.ibm.com/identity/token: timestamp=2025-02-24T11:04:37.321-0800
2025-02-24T11:04:37.829-0800 [INFO]  provider.terraform-provider-ibm_v1.75.3: 2025/02/24 11:04:37 [Debug] Returned from IAM 'get token' operation, received status code 200: timestamp=2025-02-24T11:04:37.829-0800
2025-02-24T11:04:37.833-0800 [INFO]  provider.terraform-provider-ibm_v1.75.3: 2025/02/24 11:04:37 [Debug] Response:
HTTP/1.1 200 OK
Akamai-Grn: 0.c8764017.1740423877.148ed2db
Cache-Control: no-cache, no-store, must-revalidate
Connection: keep-alive
Content-Language: en-US
Content-Type: application/json
Date: Mon, 24 Feb 2025 19:04:37 GMT
Expires: 0
Pragma: no-cache
Strict-Transport-Security: max-age=31536000; includeSubDomains
Transaction-Id: bG5sZng-374ae2cdb75a4400a0adbfcb25d3bf43
Vary: Accept-Encoding
X-Content-Type-Options: nosniff
X-Correlation-Id: bG5sZng-374ae2cdb75a4400a0adbfcb25d3bf43
X-Proxy-Upstream-Service-Time: 88
X-Request-Id: ef05d2d8-ea65-4e74-834c-a1ff466d0429

{"access_token":"[redacted]","refresh_token":"[redacted]","token_type":"Bearer","expires_in":3600,"expiration":1740427474,"refresh_token_expiration":1740683074,"scope":"ibm openid"}: timestamp=2025-02-24T11:04:37.833-0800
2025-02-24T11:04:38.590-0800 [INFO]  provider.terraform-provider-ibm_v1.75.3: 2025/02/24 11:04:38 [INFO] createSaramaAdminClient instance crn:v1:staging:public:messagehub-vnext-integration:us-south:a/ede5a9c048204c1a87c0560db9620f8e:6dbec4b4-5024-4a03-ba03-19a1212bae2a:: 's client is initialized: timestamp=2025-02-24T11:04:38.590-0800
2025-02-24T11:04:38.859-0800 [INFO]  provider.terraform-provider-ibm_v1.75.3: 2025/02/24 11:04:38 [Debug] Using cached access token...: timestamp=2025-02-24T11:04:38.858-0800
2025-02-24T11:04:39.428-0800 [INFO]  provider.terraform-provider-ibm_v1.75.3: 2025/02/24 11:04:39 [INFO] resourceIBMEventStreamsTopicCreate CreateTopic: topic is 000, detail is {1 3 map[] map[cleanup.policy:0x140035c9b70 retention.bytes:0x140035c9b80 retention.ms:0x140035c9ba0 segment.bytes:0x140035c9b90]}: timestamp=2025-02-24T11:04:39.428-0800
2025-02-24T11:04:39.428-0800 [INFO]  provider.terraform-provider-ibm_v1.75.3: 2025/02/24 11:04:39 [DEBUG] resourceIBMEventStreamsTopicRead: timestamp=2025-02-24T11:04:39.428-0800
2025-02-24T11:04:39.428-0800 [INFO]  provider.terraform-provider-ibm_v1.75.3: 2025/02/24 11:04:39 [DEBUG] createSaramaAdminClient got client from pool for instance crn:v1:staging:public:messagehub-vnext-integration:us-south:a/ede5a9c048204c1a87c0560db9620f8e:6dbec4b4-5024-4a03-ba03-19a1212bae2a::: timestamp=2025-02-24T11:04:39.428-0800
2025-02-24T11:04:39.770-0800 [INFO]  provider.terraform-provider-ibm_v1.75.3: 2025/02/24 11:04:39 [Debug] Using cached access token...: timestamp=2025-02-24T11:04:39.770-0800
ibm_event_streams_topic.my-es-topic-001["000"]: Creation complete after 4s [id=crn:v1:staging:public:messagehub-vnext-integration:us-south:a/ede5a9c048204c1a87c0560db9620f8e:6dbec4b4-5024-4a03-ba03-19a1212bae2a:topic:000]
```

debug log from test run when configure refresh token
```
2025-02-24T11:22:01.245-0800 [INFO]  provider.terraform-provider-ibm_v1.75.3: 2025/02/24 11:22:01 [INFO] createSaramaAdminClient kafka_http_url is set to https://mh-int-wtpvzfbwcnlyhggp-6fc3ea743571ba7392ba4250a5946fd9-0000.us-south.containers.appdomain.cloud: timestamp=2025-02-24T11:22:01.245-0800
2025-02-24T11:22:01.245-0800 [INFO]  provider.terraform-provider-ibm_v1.75.3: 2025/02/24 11:22:01 [INFO] createSaramaAdminClient kafka_brokers_sasl is set to [kafka-0.mh-int-wtpvzfbwcnlyhggp-6fc3ea743571ba7392ba4250a5946fd9-0000.us-south.containers.appdomain.cloud:9093 kafka-1.mh-int-wtpvzfbwcnlyhggp-6fc3ea743571ba7392ba4250a5946fd9-0000.us-south.containers.appdomain.cloud:9093 kafka-2.mh-int-wtpvzfbwcnlyhggp-6fc3ea743571ba7392ba4250a5946fd9-0000.us-south.containers.appdomain.cloud:9093]: timestamp=2025-02-24T11:22:01.245-0800
2025-02-24T11:22:01.820-0800 [INFO]  provider.terraform-provider-ibm_v1.75.3: 2025/02/24 11:22:01 [Debug] Performing synchronous token fetch...: timestamp=2025-02-24T11:22:01.820-0800
2025-02-24T11:22:01.821-0800 [INFO]  provider.terraform-provider-ibm_v1.75.3: 2025/02/24 11:22:01 [Debug] Request:
POST /identity/token HTTP/1.1
Host: iam.test.cloud.ibm.com
User-Agent: ibm-go-sdk-core/iam-authenticator-5.18.5 (arch=arm64; os=darwin; go.version=go1.23.6)
Content-Length: 1667
Accept: application/json
Authorization: [redacted]
Content-Type: application/x-www-form-urlencoded
Accept-Encoding: gzip

grant_type=refresh_token&refresh_token=[redacted]&response_type=cloud_iam: timestamp=2025-02-24T11:22:01.821-0800
2025-02-24T11:22:01.821-0800 [INFO]  provider.terraform-provider-ibm_v1.75.3: 2025/02/24 11:22:01 [Debug] Invoking IAM 'get token' operation: https://iam.test.cloud.ibm.com/identity/token: timestamp=2025-02-24T11:22:01.821-0800
2025-02-24T11:22:02.210-0800 [INFO]  provider.terraform-provider-ibm_v1.75.3: 2025/02/24 11:22:02 [Debug] Returned from IAM 'get token' operation, received status code 200: timestamp=2025-02-24T11:22:02.210-0800
2025-02-24T11:22:02.212-0800 [INFO]  provider.terraform-provider-ibm_v1.75.3: 2025/02/24 11:22:02 [Debug] Response:
HTTP/1.1 200 OK
Akamai-Grn: 0.2064cd17.1740424922.f27cc52
Cache-Control: no-cache, no-store, must-revalidate
Connection: keep-alive
Content-Language: en-US
Content-Type: application/json
Date: Mon, 24 Feb 2025 19:22:02 GMT
Expires: 0
Pragma: no-cache
Strict-Transport-Security: max-age=31536000; includeSubDomains
Transaction-Id: Y3h4NW4-f11e58ebaccc40db8154dfd4bddc4f8f
Vary: Accept-Encoding
X-Content-Type-Options: nosniff
X-Correlation-Id: Y3h4NW4-f11e58ebaccc40db8154dfd4bddc4f8f
X-Proxy-Upstream-Service-Time: 41
X-Request-Id: d66392a2-9fe9-4f7c-b8ea-3d68922bba0e

{"access_token":"[redacted]","refresh_token":"[redacted]","token_type":"Bearer","expires_in":1200,"expiration":1740426119,"refresh_token_expiration":1740509840,"scope":"ibm openid","session_id":"C-61fdb595-28ab-4ba5-94e9-efad1ee08a16"}: timestamp=2025-02-24T11:22:02.212-0800
2025-02-24T11:22:02.477-0800 [INFO]  provider.terraform-provider-ibm_v1.75.3: 2025/02/24 11:22:02 [INFO] createSaramaAdminClient instance crn:v1:staging:public:messagehub-vnext-integration:us-south:a/ede5a9c048204c1a87c0560db9620f8e:6dbec4b4-5024-4a03-ba03-19a1212bae2a:: 's client is initialized: timestamp=2025-02-24T11:22:02.477-0800
2025-02-24T11:22:02.731-0800 [INFO]  provider.terraform-provider-ibm_v1.75.3: 2025/02/24 11:22:02 [Debug] Using cached access token...: timestamp=2025-02-24T11:22:02.731-0800
2025-02-24T11:22:03.255-0800 [INFO]  provider.terraform-provider-ibm_v1.75.3: 2025/02/24 11:22:03 [INFO] resourceIBMEventStreamsTopicCreate CreateTopic: topic is 001, detail is {1 3 map[] map[cleanup.policy:0x14003734250 retention.bytes:0x14003734260 retention.ms:0x14003734270 segment.bytes:0x14003734280]}: timestamp=2025-02-24T11:22:03.255-0800
2025-02-24T11:22:03.255-0800 [INFO]  provider.terraform-provider-ibm_v1.75.3: 2025/02/24 11:22:03 [DEBUG] resourceIBMEventStreamsTopicRead: timestamp=2025-02-24T11:22:03.255-0800
2025-02-24T11:22:03.255-0800 [INFO]  provider.terraform-provider-ibm_v1.75.3: 2025/02/24 11:22:03 [DEBUG] createSaramaAdminClient got client from pool for instance crn:v1:staging:public:messagehub-vnext-integration:us-south:a/ede5a9c048204c1a87c0560db9620f8e:6dbec4b4-5024-4a03-ba03-19a1212bae2a::: timestamp=2025-02-24T11:22:03.255-0800
2025-02-24T11:22:03.633-0800 [INFO]  provider.terraform-provider-ibm_v1.75.3: 2025/02/24 11:22:03 [Debug] Using cached access token...: timestamp=2025-02-24T11:22:03.632-0800
ibm_event_streams_topic.my-es-topic-001["001"]: Creation complete after 4s [id=crn:v1:staging:public:messagehub-vnext-integration:us-south:a/ede5a9c048204c1a87c0560db9620f8e:6dbec4b4-5024-4a03-ba03-19a1212bae2a:topic:001]
```
