### PR TITLE
fix: fix the wrong error return value

### DIFF
--- a/ibm/service/apigateway/resource_ibm_api_gateway_endpoint.go
+++ b/ibm/service/apigateway/resource_ibm_api_gateway_endpoint.go
@@ -130,8 +130,8 @@ func resourceIBMApiGatewayEndPointCreate(d *schema.ResourceData, meta interface{
 			}
 			y2j, yErr := yaml.YAMLToJSON(data)
 			if yErr != nil {
-				fmt.Println("Error parsing yaml file", err)
-				return err
+				fmt.Println("Error parsing yaml file", yErr)
+				return yErr
 			}
 			document = y2j
 		} else {
@@ -267,8 +267,8 @@ func resourceIBMApiGatewayEndPointUpdate(d *schema.ResourceData, meta interface{
 			}
 			y2j, yErr := yaml.YAMLToJSON(data)
 			if yErr != nil {
-				fmt.Println("Error parsing yaml file", err)
-				return err
+				fmt.Println("Error parsing yaml file", yErr)
+				return yErr
 			}
 			document = y2j
 		} else {
@@ -337,8 +337,8 @@ func resourceIBMApiGatewayEndPointUpdate(d *schema.ResourceData, meta interface{
 				}
 				y2j, yErr := yaml.YAMLToJSON(data)
 				if yErr != nil {
-					fmt.Println("Error parsing yaml file", err)
-					return err
+					fmt.Println("Error parsing yaml file", yErr)
+					return yErr
 				}
 				document = y2j
 			} else {


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/IBM-Cloud/terraform-provider-ibm/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```


In fact, err is incorrect and should be yErr.
