### PR TITLE
fix: correct the resource name being printed in ibm_en_integration logging

### DIFF
--- a/ibm/service/eventnotification/resource_ibm_en_integration.go
+++ b/ibm/service/eventnotification/resource_ibm_en_integration.go
@@ -16,6 +16,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
+const resourceIbmEnIntegration = "ibm_en_integration"
+
 func ResourceIBMEnIntegration() *schema.Resource {
 	return &schema.Resource{
 		CreateContext: resourceIBMEnIntegrationCreate,
@@ -77,7 +79,7 @@ func ResourceIBMEnIntegration() *schema.Resource {
 func resourceIBMEnIntegrationCreate(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	enClient, err := meta.(conns.ClientSession).EventNotificationsApiV1()
 	if err != nil {
-		tfErr := flex.TerraformErrorf(err, err.Error(), "ibm_en_integration_cos", "create")
+		tfErr := flex.TerraformErrorf(err, err.Error(), resourceIbmEnIntegration, "create")
 		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
 		return tfErr.GetDiag()
 		// return diag.FromErr(err)
@@ -96,7 +98,7 @@ func resourceIBMEnIntegrationCreate(context context.Context, d *schema.ResourceD
 
 	result, _, err := enClient.ReplaceIntegrationWithContext(context, options)
 	if err != nil {
-		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("ReplaceIntegrationWithContext failed: %s", err.Error()), "ibm_en_integration_cos", "create")
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("ReplaceIntegrationWithContext failed: %s", err.Error()), resourceIbmEnIntegration, "create")
 		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
 		return tfErr.GetDiag()
 		// return diag.FromErr(fmt.Errorf("ReplaceIntegrationWithContext failed %s\n%s", err, response))
@@ -110,7 +112,7 @@ func resourceIBMEnIntegrationCreate(context context.Context, d *schema.ResourceD
 func resourceIBMEnIntegrationRead(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	enClient, err := meta.(conns.ClientSession).EventNotificationsApiV1()
 	if err != nil {
-		tfErr := flex.TerraformErrorf(err, err.Error(), "ibm_en_integration_cos", "read")
+		tfErr := flex.TerraformErrorf(err, err.Error(), resourceIbmEnIntegration, "read")
 		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
 		return tfErr.GetDiag()
 		// return diag.FromErr(err)
@@ -120,7 +122,7 @@ func resourceIBMEnIntegrationRead(context context.Context, d *schema.ResourceDat
 
 	parts, err := flex.SepIdParts(d.Id(), "/")
 	if err != nil {
-		tfErr := flex.TerraformErrorf(err, err.Error(), "ibm_en_integration_cos", "read")
+		tfErr := flex.TerraformErrorf(err, err.Error(), resourceIbmEnIntegration, "read")
 		return tfErr.GetDiag()
 		// return diag.FromErr(err)
 	}
@@ -134,7 +136,7 @@ func resourceIBMEnIntegrationRead(context context.Context, d *schema.ResourceDat
 			d.SetId(d.Get("integration_id").(string))
 			return nil
 		}
-		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("GetIntegrationWithContext failed: %s", err.Error()), "ibm_en_integration_cos", "read")
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("GetIntegrationWithContext failed: %s", err.Error()), resourceIbmEnIntegration, "read")
 		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
 		return tfErr.GetDiag()
 		// return diag.FromErr(fmt.Errorf("GetIntegrationWithContext failed %s\n%s", err, response))
@@ -161,7 +163,7 @@ func resourceIBMEnIntegrationRead(context context.Context, d *schema.ResourceDat
 func resourceIBMEnIntegrationUpdate(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	enClient, err := meta.(conns.ClientSession).EventNotificationsApiV1()
 	if err != nil {
-		tfErr := flex.TerraformErrorf(err, err.Error(), "ibm_en_integration_cos", "update")
+		tfErr := flex.TerraformErrorf(err, err.Error(), resourceIbmEnIntegration, "update")
 		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
 		return tfErr.GetDiag()
 		// return diag.FromErr(err)
@@ -171,7 +173,7 @@ func resourceIBMEnIntegrationUpdate(context context.Context, d *schema.ResourceD
 
 	parts, err := flex.SepIdParts(d.Id(), "/")
 	if err != nil {
-		tfErr := flex.TerraformErrorf(err, err.Error(), "ibm_en_integration_cos", "update")
+		tfErr := flex.TerraformErrorf(err, err.Error(), resourceIbmEnIntegration, "update")
 		return tfErr.GetDiag()
 		// return diag.FromErr(err)
 	}
@@ -189,7 +191,7 @@ func resourceIBMEnIntegrationUpdate(context context.Context, d *schema.ResourceD
 
 		_, _, err := enClient.ReplaceIntegrationWithContext(context, options)
 		if err != nil {
-			tfErr := flex.TerraformErrorf(err, fmt.Sprintf("ReplaceIntegrationWithContext failed: %s", err.Error()), "ibm_en_integration_cos", "update")
+			tfErr := flex.TerraformErrorf(err, fmt.Sprintf("ReplaceIntegrationWithContext failed: %s", err.Error()), resourceIbmEnIntegration, "update")
 			log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
 			return tfErr.GetDiag()
 			// return diag.FromErr(fmt.Errorf("ReplaceIntegrationWithContext failed %s\n%s", err, response))


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/IBM-Cloud/terraform-provider-ibm/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->

The `ibm_en_integration` resource is printing `ibm_en_integration_cos` instead of  instead of `ibm_en_integration` in its logging. For example:
```
 2025/03/03 11:00:46 Terraform apply | Error: ---
 2025/03/03 11:00:46 Terraform apply | id: terraform-afa76cbf
 2025/03/03 11:00:46 Terraform apply | summary: 'ReplaceIntegrationWithContext failed: Gateway Timeout'
 2025/03/03 11:00:46 Terraform apply | severity: error
 2025/03/03 11:00:46 Terraform apply | resource: ibm_en_integration_cos
 2025/03/03 11:00:46 Terraform apply | operation: create
 2025/03/03 11:00:46 Terraform apply | component:
 2025/03/03 11:00:46 Terraform apply |   name: github.com/IBM-Cloud/terraform-provider-ibm
 2025/03/03 11:00:46 Terraform apply |   version: 1.75.2
 2025/03/03 11:00:46 Terraform apply | ---
```
and
![image](https://github.com/user-attachments/assets/b167537c-843d-4f43-b4fa-c68462c721d8)


Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```
