### PR TITLE
docs: Add the types for tekton trigger

### DIFF
--- a/website/docs/r/cd_tekton_pipeline_trigger.html.markdown
+++ b/website/docs/r/cd_tekton_pipeline_trigger.html.markdown
@@ -84,7 +84,7 @@ Nested schema for **source**:
 * `timezone` - (Optional, String) Only used for timer triggers. Specify the timezone used for this timer trigger, which will ensure the CRON activates this trigger relative to the specified timezone. If no timezone is specified, the default timezone used is UTC. Valid timezones are those listed in the IANA timezone database, https://www.iana.org/time-zones.
   * Constraints: The maximum length is `253` characters. The minimum length is `1` character. The value must match regular expression `/^[-0-9a-zA-Z+_., \/]{1,253}$/`.
 * `type` - (Required, String) Trigger type.
-  * Constraints: Allowable values are: .
+  * Constraints: Allowable values are: `manual`, `scm`, `timer`, `generic`.
 * `worker` - (Optional, List) Details of the worker used to run the trigger.
 Nested schema for **worker**:
 	* `id` - (Required, String) ID of the worker.


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/IBM-Cloud/terraform-provider-ibm/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #5416 

## New or Affected Resource(s) or Datasource(s)
ibm_cd_tekton_pipeline_trigger
## Description
Docs do not say what are the available types are
```
[type] - (Required, String) Trigger type.

    Constraints: Allowable values are: .
```
## Changes made

```
[type] - (Required, String) Trigger type.

    Constraints: Allowable values are: `manual`, `scm`, `timer`, `generic`.
```

## Reference
https://registry.terraform.io/providers/IBM-Cloud/ibm/latest/docs/resources/cd_tekton_pipeline_trigger
ver: 1.75.2
