### PR TITLE
Added support for id in is_ssh_key data source

### DIFF
--- a/ibm/service/vpc/data_source_ibm_is_ssh_key.go
+++ b/ibm/service/vpc/data_source_ibm_is_ssh_key.go
@@ -22,6 +22,12 @@ func DataSourceIBMISSSHKey() *schema.Resource {
 				Optional:    true,
 				Description: "Resource group ID",
 			},
+			"id": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ExactlyOneOf: []string{"name", "id"},
+				Description:  "SSH key ID",
+			},
 
 			"tags": {
 				Type:        schema.TypeSet,
@@ -32,9 +38,10 @@ func DataSourceIBMISSSHKey() *schema.Resource {
 			},
 
 			isKeyName: {
-				Type:        schema.TypeString,
-				Required:    true,
-				Description: "The name of the ssh key",
+				Type:         schema.TypeString,
+				Optional:     true,
+				ExactlyOneOf: []string{"name", "id"},
+				Description:  "The name of the ssh key",
 			},
 			// missing schema added
 			"created_at": &schema.Schema{
@@ -113,81 +120,106 @@ func DataSourceIBMISSSHKey() *schema.Resource {
 }
 
 func dataSourceIBMISSSHKeyRead(d *schema.ResourceData, meta interface{}) error {
-	name := d.Get(isKeyName).(string)
+	name := ""
+	if nameOk, ok := d.GetOk(isKeyName); ok {
+		name = nameOk.(string)
+	}
+	id := ""
+	if idOk, ok := d.GetOk("id"); ok {
+		id = idOk.(string)
+	}
 
-	err := keyGetByName(d, meta, name)
+	err := keyGetByNameOrId(d, meta, name, id)
 	if err != nil {
 		return err
 	}
 	return nil
 }
 
-func keyGetByName(d *schema.ResourceData, meta interface{}, name string) error {
+func keyGetByNameOrId(d *schema.ResourceData, meta interface{}, name, id string) error {
 	sess, err := vpcClient(meta)
 	if err != nil {
 		return err
 	}
-	listKeysOptions := &vpcv1.ListKeysOptions{}
+	var key vpcv1.Key
 
-	start := ""
-	allrecs := []vpcv1.Key{}
-	for {
-		if start != "" {
-			listKeysOptions.Start = &start
+	if id != "" {
+		getKeyOptions := &vpcv1.GetKeyOptions{
+			ID: &id,
 		}
-
-		keys, response, err := sess.ListKeys(listKeysOptions)
+		keyintf, response, err := sess.GetKey(getKeyOptions)
 		if err != nil {
-			return fmt.Errorf("[ERROR] Error fetching Keys %s\n%s", err, response)
+			return fmt.Errorf("[ERROR] Error GetKey %s\n%s", err, response)
 		}
-		start = flex.GetNext(keys.Next)
-		allrecs = append(allrecs, keys.Keys...)
-		if start == "" {
-			break
-		}
-	}
+		key = *keyintf
 
-	for _, key := range allrecs {
-		if *key.Name == name {
-			d.SetId(*key.ID)
-			d.Set("name", *key.Name)
-			d.Set(isKeyType, *key.Type)
-			d.Set(isKeyFingerprint, *key.Fingerprint)
-			d.Set(isKeyLength, *key.Length)
-			controller, err := flex.GetBaseController(meta)
+	} else {
+		listKeysOptions := &vpcv1.ListKeysOptions{}
+
+		start := ""
+		allrecs := []vpcv1.Key{}
+		for {
+			if start != "" {
+				listKeysOptions.Start = &start
+			}
+
+			keys, response, err := sess.ListKeys(listKeysOptions)
 			if err != nil {
-				return err
+				return fmt.Errorf("[ERROR] Error fetching Keys %s\n%s", err, response)
 			}
-			if err = d.Set("created_at", flex.DateTimeToString(key.CreatedAt)); err != nil {
-				return err
+			start = flex.GetNext(keys.Next)
+			allrecs = append(allrecs, keys.Keys...)
+			if start == "" {
+				break
 			}
-			if err = d.Set("href", key.Href); err != nil {
-				return err
+		}
+		found := false
+		for _, keyintf := range allrecs {
+			if *keyintf.Name == name {
+				key = keyintf
+				found = true
 			}
-			d.Set(flex.ResourceControllerURL, controller+"/vpc/compute/sshKeys")
-			d.Set(flex.ResourceName, *key.Name)
-			d.Set(flex.ResourceCRN, *key.CRN)
-			d.Set(IsKeyCRN, *key.CRN)
-			if key.ResourceGroup != nil {
-				d.Set(flex.ResourceGroupName, *key.ResourceGroup.ID)
-			}
-			if key.PublicKey != nil {
-				d.Set(isKeyPublicKey, *key.PublicKey)
-			}
-			tags, err := flex.GetGlobalTagsUsingCRN(meta, *key.CRN, "", isUserTagType)
-			if err != nil {
-				log.Printf(
-					"Error on get of resource vpc ssh key (%s) tags: %s", d.Id(), err)
-			}
-			d.Set("tags", tags)
-			accesstags, err := flex.GetGlobalTagsUsingCRN(meta, *key.CRN, "", isKeyAccessTagType)
-			if err != nil {
-				log.Printf(
-					"Error on get of resource SSH Key (%s) access tags: %s", d.Id(), err)
-			}
-			d.Set(isKeyAccessTags, accesstags)
-			return nil
+		}
+		if !found {
+			return fmt.Errorf("[ERROR] No SSH Key found with name %s", name)
 		}
 	}
-	return fmt.Errorf("[ERROR] No SSH Key found with name %s", name)
+	d.SetId(*key.ID)
+	d.Set("name", *key.Name)
+	d.Set(isKeyType, *key.Type)
+	d.Set(isKeyFingerprint, *key.Fingerprint)
+	d.Set(isKeyLength, *key.Length)
+	controller, err := flex.GetBaseController(meta)
+	if err != nil {
+		return err
+	}
+	if err = d.Set("created_at", flex.DateTimeToString(key.CreatedAt)); err != nil {
+		return err
+	}
+	if err = d.Set("href", key.Href); err != nil {
+		return err
+	}
+	d.Set(flex.ResourceControllerURL, controller+"/vpc/compute/sshKeys")
+	d.Set(flex.ResourceName, *key.Name)
+	d.Set(flex.ResourceCRN, *key.CRN)
+	d.Set(IsKeyCRN, *key.CRN)
+	if key.ResourceGroup != nil {
+		d.Set(flex.ResourceGroupName, *key.ResourceGroup.ID)
+	}
+	if key.PublicKey != nil {
+		d.Set(isKeyPublicKey, *key.PublicKey)
+	}
+	tags, err := flex.GetGlobalTagsUsingCRN(meta, *key.CRN, "", isUserTagType)
+	if err != nil {
+		log.Printf(
+			"Error on get of resource vpc ssh key (%s) tags: %s", d.Id(), err)
+	}
+	d.Set("tags", tags)
+	accesstags, err := flex.GetGlobalTagsUsingCRN(meta, *key.CRN, "", isKeyAccessTagType)
+	if err != nil {
+		log.Printf(
+			"Error on get of resource SSH Key (%s) access tags: %s", d.Id(), err)
+	}
+	d.Set(isKeyAccessTags, accesstags)
+	return nil
 }

--- a/ibm/service/vpc/data_source_ibm_is_ssh_key_test.go
+++ b/ibm/service/vpc/data_source_ibm_is_ssh_key_test.go
@@ -50,6 +50,60 @@ ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCKVmnMOlHKcZK8tpt3MP1lqOLAcqcJzhsvJcjscgVE
 		},
 	})
 }
+func TestAccIBMISSSHKeyDatasource_basicidname(t *testing.T) {
+	name1 := fmt.Sprintf("tfssh-name-%d", acctest.RandIntRange(10, 100))
+	publicKey := strings.TrimSpace(`
+ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCKVmnMOlHKcZK8tpt3MP1lqOLAcqcJzhsvJcjscgVERRN7/9484SOBJ3HSKxxNG5JN8owAjy5f9yYwcUg+JaUVuytn5Pv3aeYROHGGg+5G346xaq3DAwX6Y5ykr2fvjObgncQBnuU5KHWCECO/4h8uWuwh/kfniXPVjFToc+gnkqA+3RKpAecZhFXwfalQ9mMuYGFxn+fwn8cYEApsJbsEmb0iJwPiZ5hjFC8wREuiTlhPHDgkBLOiycd20op2nXzDbHfCHInquEe/gYxEitALONxm0swBOwJZwlTDOB7C6y2dzlrtxr1L59m7pCkWI4EtTRLvleehBoj3u7jB4usR
+`)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { acc.TestAccPreCheck(t) },
+		Providers: acc.TestAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testDSCheckIBMISSSHKeyIdNameConfig(publicKey, name1),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(
+						"data.ibm_is_ssh_key.ds_key", "name", name1),
+					resource.TestCheckResourceAttrSet(
+						"data.ibm_is_ssh_key.ds_key", "crn"),
+					resource.TestCheckResourceAttrSet(
+						"data.ibm_is_ssh_key.ds_key", "fingerprint"),
+					resource.TestCheckResourceAttrSet(
+						"data.ibm_is_ssh_key.ds_key", "id"),
+					resource.TestCheckResourceAttrSet(
+						"data.ibm_is_ssh_key.ds_key", "length"),
+					resource.TestCheckResourceAttrSet(
+						"data.ibm_is_ssh_key.ds_key", "public_key"),
+					resource.TestCheckResourceAttrSet(
+						"data.ibm_is_ssh_key.ds_key", "type"),
+					resource.TestCheckResourceAttrSet(
+						"data.ibm_is_ssh_key.ds_key", "tags.#"),
+					resource.TestCheckResourceAttr(
+						"data.ibm_is_ssh_key.ds_key", "tags.#", "3"),
+					resource.TestCheckResourceAttr(
+						"data.ibm_is_ssh_key.ds_key_id", "name", name1),
+					resource.TestCheckResourceAttrSet(
+						"data.ibm_is_ssh_key.ds_key_id", "crn"),
+					resource.TestCheckResourceAttrSet(
+						"data.ibm_is_ssh_key.ds_key_id", "fingerprint"),
+					resource.TestCheckResourceAttrSet(
+						"data.ibm_is_ssh_key.ds_key_id", "id"),
+					resource.TestCheckResourceAttrSet(
+						"data.ibm_is_ssh_key.ds_key_id", "length"),
+					resource.TestCheckResourceAttrSet(
+						"data.ibm_is_ssh_key.ds_key_id", "public_key"),
+					resource.TestCheckResourceAttrSet(
+						"data.ibm_is_ssh_key.ds_key_id", "type"),
+					resource.TestCheckResourceAttrSet(
+						"data.ibm_is_ssh_key.ds_key_id", "tags.#"),
+					resource.TestCheckResourceAttr(
+						"data.ibm_is_ssh_key.ds_key_id", "tags.#", "3"),
+				),
+			},
+		},
+	})
+}
 
 func TestAccIBMISSSHKeyDatasource_CreatedAtHref(t *testing.T) {
 	name1 := fmt.Sprintf("tfssh-name-%d", acctest.RandIntRange(10, 100))
@@ -102,4 +156,20 @@ func testDSCheckIBMISSSHKeyConfig(publicKey, name string) string {
 		data "ibm_is_ssh_key" "ds_key" {
 		    name = "${ibm_is_ssh_key.key.name}"
 		}`, name, publicKey)
+}
+func testDSCheckIBMISSSHKeyIdNameConfig(publicKey, name string) string {
+	return fmt.Sprintf(`
+		resource "ibm_is_ssh_key" "key" {
+			name 		= "%s"
+			public_key 	= "%s"
+			tags		= ["test:1", "test:2", "test:3"]
+		}
+		data "ibm_is_ssh_key" "ds_key" {
+		    name = "${ibm_is_ssh_key.key.name}"
+		}
+		data "ibm_is_ssh_key" "ds_key_id" {
+		    id = "${ibm_is_ssh_key.key.id}"
+		}
+			
+		`, name, publicKey)
 }

--- a/website/docs/d/is_ssh_key.html.markdown
+++ b/website/docs/d/is_ssh_key.html.markdown
@@ -33,7 +33,8 @@ data "ibm_is_ssh_key" "example" {
 ## Argument reference
 Review the argument references that you can specify for your data source. 
 
-- `name` - (Required, String) The name of the SSH key.
+- `id` - (Optional, String) The id of the SSH key. {Exactly one of `id` or `name` is required}
+- `name` - (Optional, String) The name of the SSH key. {Exactly one of `id` or `name` is required}
 
 ## Attribute reference
 In addition to all argument reference list, you can access the following attribute references after your data source is created. 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/IBM-Cloud/terraform-provider-ibm/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
% make testacc TEST=./ibm/service/vpc TESTARGS='-run=TestAccIBMISSSHKeyDatasource_basicidname'
=== RUN   TestAccIBMISSSHKeyDatasource_basicidname
--- PASS: TestAccIBMISSSHKeyDatasource_basicidname (47.26s)
PASS
ok      github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/vpc     49.344s
```
