### PR TITLE
fix crashing provider due to Code Engine type casting #6013

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,8 +3,11 @@
     "files": "go.mod|go.sum|.*.map|^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2025-03-02T16:26:38Z",
+  "generated_at": "2025-03-11T12:24:02Z",
   "plugins_used": [
+    {
+      "name": "AWSKeyDetector"
+    },
     {
       "name": "ArtifactoryDetector"
     },
@@ -17,6 +20,12 @@
     },
     {
       "name": "BasicAuthDetector"
+    },
+    {
+      "name": "BoxDetector"
+    },
+    {
+      "name": "CloudantDetector"
     },
     {
       "ghe_instance": "github.ibm.com",
@@ -43,6 +52,9 @@
       "name": "KeywordDetector"
     },
     {
+      "name": "MailchimpDetector"
+    },
+    {
       "name": "NpmDetector"
     },
     {
@@ -56,6 +68,12 @@
     },
     {
       "name": "SquareOAuthDetector"
+    },
+    {
+      "name": "StripeDetector"
+    },
+    {
+      "name": "TwilioKeyDetector"
     }
   ],
   "results": {
@@ -5362,7 +5380,7 @@
       }
     ]
   },
-  "version": "0.13.1+ibm.62.dss",
+  "version": "0.13.1+ibm.61.dss",
   "word_list": {
     "file": null,
     "hash": null

--- a/ibm/service/codeengine/resource_ibm_code_engine_app.go
+++ b/ibm/service/codeengine/resource_ibm_code_engine_app.go
@@ -1391,8 +1391,6 @@ func ResourceIbmCodeEngineAppAppPatchAsPatch(patchVals *codeenginev2.AppPatch, d
 	path = "probe_liveness"
 	if _, exists := d.GetOk(path); d.HasChange(path) && !exists {
 		patch["probe_liveness"] = nil
-	} else if exists && patch["probe_liveness"] != nil {
-		ResourceIbmCodeEngineAppProbePrototypeAsPatch(patch["probe_liveness"].(map[string]interface{}), d)
 	}
 	path = "probe_readiness"
 	if _, exists := d.GetOk(path); d.HasChange(path) && !exists {
@@ -1412,9 +1410,8 @@ func ResourceIbmCodeEngineAppAppPatchAsPatch(patchVals *codeenginev2.AppPatch, d
 	}
 	path = "run_env_variables"
 	if _, exists := d.GetOk(path); d.HasChange(path) && !exists {
-		patch["run_env_variables"] = nil
-	} else if exists && patch["run_env_variables"] != nil {
-		ResourceIbmCodeEngineAppEnvVarPrototypeAsPatch(patch["run_env_variables"].(map[string]interface{}), d)
+		runEnvVariables := []map[string]interface{}{}
+		patch["run_env_variables"] = runEnvVariables
 	}
 	path = "run_service_account"
 	if _, exists := d.GetOk(path); d.HasChange(path) && !exists {
@@ -1422,9 +1419,8 @@ func ResourceIbmCodeEngineAppAppPatchAsPatch(patchVals *codeenginev2.AppPatch, d
 	}
 	path = "run_volume_mounts"
 	if _, exists := d.GetOk(path); d.HasChange(path) && !exists {
-		patch["run_volume_mounts"] = nil
-	} else if exists && patch["run_volume_mounts"] != nil {
-		ResourceIbmCodeEngineAppVolumeMountPrototypeAsPatch(patch["run_volume_mounts"].(map[string]interface{}), d)
+		runVolumeMounts := []map[string]interface{}{}
+		patch["run_volume_mounts"] = runVolumeMounts
 	}
 	path = "scale_concurrency"
 	if _, exists := d.GetOk(path); d.HasChange(path) && !exists {

--- a/ibm/service/codeengine/resource_ibm_code_engine_app_test.go
+++ b/ibm/service/codeengine/resource_ibm_code_engine_app_test.go
@@ -27,13 +27,19 @@ func TestAccIbmCodeEngineAppBasic(t *testing.T) {
 
 	projectID := acc.CeProjectId
 
+	envVars := `run_env_variables {
+			type  = "literal"
+			name  = "name"
+			value = "value"
+		}`
+
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { acc.TestAccPreCheck(t) },
 		Providers:    acc.TestAccProviders,
 		CheckDestroy: testAccCheckIbmCodeEngineAppDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
-				Config: testAccCheckIbmCodeEngineAppConfigBasic(projectID, imageReference, name),
+				Config: testAccCheckIbmCodeEngineAppConfigBasic(projectID, imageReference, name, envVars),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckIbmCodeEngineAppExists("ibm_code_engine_app.code_engine_app_instance", conf),
 					resource.TestCheckResourceAttrSet("ibm_code_engine_app.code_engine_app_instance", "app_id"),
@@ -53,10 +59,12 @@ func TestAccIbmCodeEngineAppBasic(t *testing.T) {
 					resource.TestCheckResourceAttr("ibm_code_engine_app.code_engine_app_instance", "scale_min_instances", "0"),
 					resource.TestCheckResourceAttr("ibm_code_engine_app.code_engine_app_instance", "scale_request_timeout", "300"),
 					resource.TestCheckResourceAttr("ibm_code_engine_app.code_engine_app_instance", "computed_env_variables.#", "6"),
+					resource.TestCheckResourceAttr("ibm_code_engine_app.code_engine_app_instance", "run_env_variables.#", "1"),
+					resource.TestCheckResourceAttr("ibm_code_engine_app.code_engine_app_instance", "run_volume_mounts.#", "0"),
 				),
 			},
 			resource.TestStep{
-				Config: testAccCheckIbmCodeEngineAppConfigBasic(projectID, imageReferenceUpdate, nameUpdate),
+				Config: testAccCheckIbmCodeEngineAppConfigBasic(projectID, imageReferenceUpdate, nameUpdate, ""),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttrSet("ibm_code_engine_app.code_engine_app_instance", "project_id"),
 					resource.TestCheckResourceAttrSet("ibm_code_engine_app.code_engine_app_instance", "app_id"),
@@ -75,6 +83,8 @@ func TestAccIbmCodeEngineAppBasic(t *testing.T) {
 					resource.TestCheckResourceAttr("ibm_code_engine_app.code_engine_app_instance", "scale_min_instances", "0"),
 					resource.TestCheckResourceAttr("ibm_code_engine_app.code_engine_app_instance", "scale_request_timeout", "300"),
 					resource.TestCheckResourceAttr("ibm_code_engine_app.code_engine_app_instance", "computed_env_variables.#", "6"),
+					resource.TestCheckResourceAttr("ibm_code_engine_app.code_engine_app_instance", "run_env_variables.#", "0"),
+					resource.TestCheckResourceAttr("ibm_code_engine_app.code_engine_app_instance", "run_volume_mounts.#", "0"),
 				),
 			},
 		},
@@ -101,6 +111,26 @@ func TestAccIbmCodeEngineAppExtended(t *testing.T) {
 	configMapName := "my-config-map"
 	configMapData := `{ "key" = "inner" }`
 
+	envVars := `run_env_variables {
+			type  = "literal"
+			name  = "key1"
+			value = "value1"
+		}
+
+		run_env_variables {
+			type  = "literal"
+			name  = "key2"
+			value = "value2"
+		}`
+
+	volumeMounts := `
+		run_volume_mounts {
+			mount_path = "/mount"
+			name       = "mymount"
+			reference  = ibm_code_engine_config_map.code_engine_config_map_instance.name
+			type       = "config_map"
+		}`
+
 	nameUpdate := fmt.Sprintf("tf-app-extended-update-%d", acctest.RandIntRange(10, 1000))
 	imageReferenceUpdate := "icr.io/codeengine/hello"
 	imagePortUpdate := "8080"
@@ -124,7 +154,7 @@ func TestAccIbmCodeEngineAppExtended(t *testing.T) {
 		CheckDestroy: testAccCheckIbmCodeEngineAppDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
-				Config: testAccCheckIbmCodeEngineAppConfig(projectID, configMapName, configMapData, imageReference, name, imagePort, managedDomainMappings, runAsUser, runServiceAccount, scaleConcurrency, scaleConcurrencyTarget, scaleCpuLimit, scaleEphemeralStorageLimit, scaleInitialInstances, scaleMaxInstances, scaleMemoryLimit, scaleMinInstances, scaleRequestTimeout),
+				Config: testAccCheckIbmCodeEngineAppConfig(projectID, configMapName, configMapData, imageReference, name, imagePort, managedDomainMappings, runAsUser, runServiceAccount, scaleConcurrency, scaleConcurrencyTarget, scaleCpuLimit, scaleEphemeralStorageLimit, scaleInitialInstances, scaleMaxInstances, scaleMemoryLimit, scaleMinInstances, scaleRequestTimeout, "", volumeMounts),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckIbmCodeEngineAppExists("ibm_code_engine_app.code_engine_app_instance", conf),
 					resource.TestCheckResourceAttr("ibm_code_engine_app.code_engine_app_instance", "project_id", projectID),
@@ -144,10 +174,12 @@ func TestAccIbmCodeEngineAppExtended(t *testing.T) {
 					resource.TestCheckResourceAttr("ibm_code_engine_app.code_engine_app_instance", "scale_min_instances", scaleMinInstances),
 					resource.TestCheckResourceAttr("ibm_code_engine_app.code_engine_app_instance", "scale_request_timeout", scaleRequestTimeout),
 					resource.TestCheckResourceAttr("ibm_code_engine_app.code_engine_app_instance", "computed_env_variables.#", "6"),
+					resource.TestCheckResourceAttr("ibm_code_engine_app.code_engine_app_instance", "run_env_variables.#", "2"),
+					resource.TestCheckResourceAttr("ibm_code_engine_app.code_engine_app_instance", "run_volume_mounts.#", "1"),
 				),
 			},
 			resource.TestStep{
-				Config: testAccCheckIbmCodeEngineAppConfig(projectID, configMapName, configMapData, imageReferenceUpdate, nameUpdate, imagePortUpdate, managedDomainMappingsUpdate, runAsUser, runServiceAccountUpdate, scaleConcurrencyUpdate, scaleConcurrencyTargetUpdate, scaleCpuLimitUpdate, scaleEphemeralStorageLimitUpdate, scaleInitialInstancesUpdate, scaleMaxInstancesUpdate, scaleMemoryLimitUpdate, scaleMinInstancesUpdate, scaleRequestTimeoutUpdate),
+				Config: testAccCheckIbmCodeEngineAppConfig(projectID, configMapName, configMapData, imageReferenceUpdate, nameUpdate, imagePortUpdate, managedDomainMappingsUpdate, runAsUser, runServiceAccountUpdate, scaleConcurrencyUpdate, scaleConcurrencyTargetUpdate, scaleCpuLimitUpdate, scaleEphemeralStorageLimitUpdate, scaleInitialInstancesUpdate, scaleMaxInstancesUpdate, scaleMemoryLimitUpdate, scaleMinInstancesUpdate, scaleRequestTimeoutUpdate, envVars, ""),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr("ibm_code_engine_app.code_engine_app_instance", "project_id", projectID),
 					resource.TestCheckResourceAttr("ibm_code_engine_app.code_engine_app_instance", "image_reference", imageReferenceUpdate),
@@ -167,6 +199,8 @@ func TestAccIbmCodeEngineAppExtended(t *testing.T) {
 					resource.TestCheckResourceAttr("ibm_code_engine_app.code_engine_app_instance", "scale_request_timeout", scaleRequestTimeoutUpdate),
 					resource.TestCheckResourceAttr("ibm_code_engine_app.code_engine_app_instance", "scale_request_timeout", scaleRequestTimeoutUpdate),
 					resource.TestCheckResourceAttr("ibm_code_engine_app.code_engine_app_instance", "computed_env_variables.#", "6"),
+					resource.TestCheckResourceAttr("ibm_code_engine_app.code_engine_app_instance", "run_env_variables.#", "4"),
+					resource.TestCheckResourceAttr("ibm_code_engine_app.code_engine_app_instance", "run_volume_mounts.#", "0"),
 				),
 			},
 			resource.TestStep{
@@ -178,7 +212,7 @@ func TestAccIbmCodeEngineAppExtended(t *testing.T) {
 	})
 }
 
-func testAccCheckIbmCodeEngineAppConfigBasic(projectID string, imageReference string, name string) string {
+func testAccCheckIbmCodeEngineAppConfigBasic(projectID string, imageReference string, name string, envVars string) string {
 	return fmt.Sprintf(`
 		data "ibm_code_engine_project" "code_engine_project_instance" {
 			project_id = "%s"
@@ -189,6 +223,8 @@ func testAccCheckIbmCodeEngineAppConfigBasic(projectID string, imageReference st
 			image_reference = "%s"
 			name = "%s"
 
+			%s
+
 			lifecycle {
 				ignore_changes = [
 					probe_liveness,
@@ -196,10 +232,10 @@ func testAccCheckIbmCodeEngineAppConfigBasic(projectID string, imageReference st
 				]
 			}
 		}
-	`, projectID, imageReference, name)
+	`, projectID, imageReference, name, envVars)
 }
 
-func testAccCheckIbmCodeEngineAppConfig(projectID string, configMapName string, configMapData string, imageReference string, name string, imagePort string, managedDomainMappings string, runAsUser string, runServiceAccount string, scaleConcurrency string, scaleConcurrencyTarget string, scaleCpuLimit string, scaleEphemeralStorageLimit string, scaleInitialInstances string, scaleMaxInstances string, scaleMemoryLimit string, scaleMinInstances string, scaleRequestTimeout string) string {
+func testAccCheckIbmCodeEngineAppConfig(projectID string, configMapName string, configMapData string, imageReference string, name string, imagePort string, managedDomainMappings string, runAsUser string, runServiceAccount string, scaleConcurrency string, scaleConcurrencyTarget string, scaleCpuLimit string, scaleEphemeralStorageLimit string, scaleInitialInstances string, scaleMaxInstances string, scaleMemoryLimit string, scaleMinInstances string, scaleRequestTimeout string, envVars string, volumeMounts string) string {
 	return fmt.Sprintf(`
 		data "ibm_code_engine_project" "code_engine_project_instance" {
 			project_id = "%s"
@@ -240,6 +276,10 @@ func testAccCheckIbmCodeEngineAppConfig(projectID string, configMapName string, 
 				value = "value"
 			}
 
+			%s
+
+			%s
+
 			lifecycle {
 				ignore_changes = [
 					probe_liveness,
@@ -247,7 +287,7 @@ func testAccCheckIbmCodeEngineAppConfig(projectID string, configMapName string, 
 				]
 			}
 		}
-	`, projectID, configMapName, configMapData, imageReference, name, imagePort, managedDomainMappings, runAsUser, runServiceAccount, scaleConcurrency, scaleConcurrencyTarget, scaleCpuLimit, scaleEphemeralStorageLimit, scaleInitialInstances, scaleMaxInstances, scaleMemoryLimit, scaleMinInstances, scaleRequestTimeout)
+	`, projectID, configMapName, configMapData, imageReference, name, imagePort, managedDomainMappings, runAsUser, runServiceAccount, scaleConcurrency, scaleConcurrencyTarget, scaleCpuLimit, scaleEphemeralStorageLimit, scaleInitialInstances, scaleMaxInstances, scaleMemoryLimit, scaleMinInstances, scaleRequestTimeout, envVars, volumeMounts)
 }
 
 func testAccCheckIbmCodeEngineAppExists(n string, obj codeenginev2.App) resource.TestCheckFunc {

--- a/ibm/service/codeengine/resource_ibm_code_engine_function.go
+++ b/ibm/service/codeengine/resource_ibm_code_engine_function.go
@@ -913,9 +913,8 @@ func ResourceIbmCodeEngineFunctionFunctionPatchAsPatch(patchVals *codeenginev2.F
 	}
 	path = "run_env_variables"
 	if _, exists := d.GetOk(path); d.HasChange(path) && !exists {
-		patch["run_env_variables"] = nil
-	} else if exists && patch["run_env_variables"] != nil {
-		ResourceIbmCodeEngineFunctionEnvVarPrototypeAsPatch(patch["run_volume_mounts"].(map[string]interface{}), d)
+		runEnvVariables := []map[string]interface{}{}
+		patch["run_env_variables"] = runEnvVariables
 	}
 	path = "runtime"
 	if _, exists := d.GetOk(path); d.HasChange(path) && !exists {

--- a/ibm/service/codeengine/resource_ibm_code_engine_function_test.go
+++ b/ibm/service/codeengine/resource_ibm_code_engine_function_test.go
@@ -25,6 +25,12 @@ func TestAccIbmCodeEngineFunctionBasic(t *testing.T) {
 
 	projectID := acc.CeProjectId
 
+	envVars := `run_env_variables {
+		type  = "literal"
+		name  = "name"
+		value = "value"
+	}`
+
 	functionCodeReferenceUpdate := "data:text/plain;base64,bar"
 
 	resource.Test(t, resource.TestCase{
@@ -33,7 +39,7 @@ func TestAccIbmCodeEngineFunctionBasic(t *testing.T) {
 		CheckDestroy: testAccCheckIbmCodeEngineFunctionDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
-				Config: testAccCheckIbmCodeEngineFunctionConfigBasic(projectID, functionCodeReference, functionName, functionRuntime),
+				Config: testAccCheckIbmCodeEngineFunctionConfigBasic(projectID, functionCodeReference, functionName, functionRuntime, envVars),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckIbmCodeEngineFunctionExists("ibm_code_engine_function.code_engine_function_instance", conf),
 					resource.TestCheckResourceAttr("ibm_code_engine_function.code_engine_function_instance", "project_id", projectID),
@@ -48,10 +54,11 @@ func TestAccIbmCodeEngineFunctionBasic(t *testing.T) {
 					resource.TestCheckResourceAttr("ibm_code_engine_function.code_engine_function_instance", "scale_max_execution_time", "60"),
 					resource.TestCheckResourceAttr("ibm_code_engine_function.code_engine_function_instance", "scale_memory_limit", "4G"),
 					resource.TestCheckResourceAttr("ibm_code_engine_function.code_engine_function_instance", "computed_env_variables.#", "6"),
+					resource.TestCheckResourceAttr("ibm_code_engine_function.code_engine_function_instance", "run_env_variables.#", "1"),
 				),
 			},
 			resource.TestStep{
-				Config: testAccCheckIbmCodeEngineFunctionConfigBasic(projectID, functionCodeReferenceUpdate, functionName, functionRuntime),
+				Config: testAccCheckIbmCodeEngineFunctionConfigBasic(projectID, functionCodeReferenceUpdate, functionName, functionRuntime, ""),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr("ibm_code_engine_function.code_engine_function_instance", "project_id", projectID),
 					resource.TestCheckResourceAttr("ibm_code_engine_function.code_engine_function_instance", "name", functionName),
@@ -65,6 +72,7 @@ func TestAccIbmCodeEngineFunctionBasic(t *testing.T) {
 					resource.TestCheckResourceAttr("ibm_code_engine_function.code_engine_function_instance", "scale_max_execution_time", "60"),
 					resource.TestCheckResourceAttr("ibm_code_engine_function.code_engine_function_instance", "scale_memory_limit", "4G"),
 					resource.TestCheckResourceAttr("ibm_code_engine_function.code_engine_function_instance", "computed_env_variables.#", "6"),
+					resource.TestCheckResourceAttr("ibm_code_engine_function.code_engine_function_instance", "run_env_variables.#", "0"),
 				),
 			},
 		},
@@ -92,13 +100,25 @@ func TestAccIbmCodeEngineFunctionExtended(t *testing.T) {
 	functionScaleMaxExecutionTimeUpdate := "30"
 	functionScaleMemoryLimitUpdate := "2G"
 
+	envVars := `run_env_variables {
+		type  = "literal"
+		name  = "key1"
+		value = "value1"
+	}
+
+	run_env_variables {
+		type  = "literal"
+		name  = "key2"
+		value = "value2"
+	}`
+
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { acc.TestAccPreCheck(t) },
 		Providers:    acc.TestAccProviders,
 		CheckDestroy: testAccCheckIbmCodeEngineFunctionDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
-				Config: testAccCheckIbmCodeEngineFunctionConfig(projectID, functionCodeReference, functionManagedDomainMappings, functionName, functionRuntime, functionScaleCpuLimit, functionScaleDownDelay, functionScaleMaxExecutionTime, functionScaleMemoryLimit),
+				Config: testAccCheckIbmCodeEngineFunctionConfig(projectID, functionCodeReference, functionManagedDomainMappings, functionName, functionRuntime, functionScaleCpuLimit, functionScaleDownDelay, functionScaleMaxExecutionTime, functionScaleMemoryLimit, envVars),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckIbmCodeEngineFunctionExists("ibm_code_engine_function.code_engine_function_instance", conf),
 					resource.TestCheckResourceAttr("ibm_code_engine_function.code_engine_function_instance", "project_id", projectID),
@@ -113,10 +133,11 @@ func TestAccIbmCodeEngineFunctionExtended(t *testing.T) {
 					resource.TestCheckResourceAttr("ibm_code_engine_function.code_engine_function_instance", "scale_max_execution_time", functionScaleMaxExecutionTime),
 					resource.TestCheckResourceAttr("ibm_code_engine_function.code_engine_function_instance", "scale_memory_limit", functionScaleMemoryLimit),
 					resource.TestCheckResourceAttr("ibm_code_engine_function.code_engine_function_instance", "computed_env_variables.#", "6"),
+					resource.TestCheckResourceAttr("ibm_code_engine_function.code_engine_function_instance", "run_env_variables.#", "3"),
 				),
 			},
 			resource.TestStep{
-				Config: testAccCheckIbmCodeEngineFunctionConfig(projectID, functionCodeReferenceUpdate, functionManagedDomainMappingsUpdate, functionName, functionRuntime, functionScaleCpuLimitUpdate, functionScaleDownDelayUpdate, functionScaleMaxExecutionTimeUpdate, functionScaleMemoryLimitUpdate),
+				Config: testAccCheckIbmCodeEngineFunctionConfig(projectID, functionCodeReferenceUpdate, functionManagedDomainMappingsUpdate, functionName, functionRuntime, functionScaleCpuLimitUpdate, functionScaleDownDelayUpdate, functionScaleMaxExecutionTimeUpdate, functionScaleMemoryLimitUpdate, ""),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr("ibm_code_engine_function.code_engine_function_instance", "project_id", projectID),
 					resource.TestCheckResourceAttr("ibm_code_engine_function.code_engine_function_instance", "name", functionName),
@@ -130,13 +151,14 @@ func TestAccIbmCodeEngineFunctionExtended(t *testing.T) {
 					resource.TestCheckResourceAttr("ibm_code_engine_function.code_engine_function_instance", "scale_max_execution_time", functionScaleMaxExecutionTimeUpdate),
 					resource.TestCheckResourceAttr("ibm_code_engine_function.code_engine_function_instance", "scale_memory_limit", functionScaleMemoryLimitUpdate),
 					resource.TestCheckResourceAttr("ibm_code_engine_function.code_engine_function_instance", "computed_env_variables.#", "6"),
+					resource.TestCheckResourceAttr("ibm_code_engine_function.code_engine_function_instance", "run_env_variables.#", "1"),
 				),
 			},
 		},
 	})
 }
 
-func testAccCheckIbmCodeEngineFunctionConfigBasic(projectID string, codeReference string, name string, runtime string) string {
+func testAccCheckIbmCodeEngineFunctionConfigBasic(projectID string, codeReference string, name string, runtime string, envVars string) string {
 	return fmt.Sprintf(`
 		data "ibm_code_engine_project" "code_engine_project_instance" {
 			project_id = "%s"
@@ -147,11 +169,13 @@ func testAccCheckIbmCodeEngineFunctionConfigBasic(projectID string, codeReferenc
 			code_reference = "%s"
 			name = "%s"
 			runtime = "%s"
+
+			%s
 		}
-	`, projectID, codeReference, name, runtime)
+	`, projectID, codeReference, name, runtime, envVars)
 }
 
-func testAccCheckIbmCodeEngineFunctionConfig(projectID string, codeReference string, managedDomainMappings string, name string, runtime string, scaleCpuLimit string, scaleDownDelay string, scaleMaxExecutionTime string, scaleMemoryLimit string) string {
+func testAccCheckIbmCodeEngineFunctionConfig(projectID string, codeReference string, managedDomainMappings string, name string, runtime string, scaleCpuLimit string, scaleDownDelay string, scaleMaxExecutionTime string, scaleMemoryLimit string, envVars string) string {
 	return fmt.Sprintf(`
 		data "ibm_code_engine_project" "code_engine_project_instance" {
 			project_id = "%s"
@@ -167,13 +191,16 @@ func testAccCheckIbmCodeEngineFunctionConfig(projectID string, codeReference str
 			scale_down_delay = %s
 			scale_max_execution_time = %s
 			scale_memory_limit = "%s"
-            run_env_variables {
+
+			run_env_variables {
 				type  = "literal"
 				name  = "name"
 				value = "value"
 			}
+
+			%s
 		}
-	`, projectID, codeReference, managedDomainMappings, name, runtime, scaleCpuLimit, scaleDownDelay, scaleMaxExecutionTime, scaleMemoryLimit)
+	`, projectID, codeReference, managedDomainMappings, name, runtime, scaleCpuLimit, scaleDownDelay, scaleMaxExecutionTime, scaleMemoryLimit, envVars)
 }
 
 func testAccCheckIbmCodeEngineFunctionExists(n string, obj codeenginev2.Function) resource.TestCheckFunc {

--- a/ibm/service/codeengine/resource_ibm_code_engine_job.go
+++ b/ibm/service/codeengine/resource_ibm_code_engine_job.go
@@ -956,9 +956,8 @@ func ResourceIbmCodeEngineJobJobPatchAsPatch(patchVals *codeenginev2.JobPatch, d
 	}
 	path = "run_env_variables"
 	if _, exists := d.GetOk(path); d.HasChange(path) && !exists {
-		patch["run_env_variables"] = nil
-	} else if exists && patch["run_env_variables"] != nil {
-		ResourceIbmCodeEngineJobEnvVarPrototypeAsPatch(patch["run_env_variables"].(map[string]interface{}), d)
+		runEnvVariables := []map[string]interface{}{}
+		patch["run_env_variables"] = runEnvVariables
 	}
 	path = "run_mode"
 	if _, exists := d.GetOk(path); d.HasChange(path) && !exists {
@@ -970,9 +969,8 @@ func ResourceIbmCodeEngineJobJobPatchAsPatch(patchVals *codeenginev2.JobPatch, d
 	}
 	path = "run_volume_mounts"
 	if _, exists := d.GetOk(path); d.HasChange(path) && !exists {
-		patch["run_volume_mounts"] = nil
-	} else if exists && patch["run_volume_mounts"] != nil {
-		ResourceIbmCodeEngineJobVolumeMountPrototypeAsPatch(patch["run_volume_mounts"].(map[string]interface{}), d)
+		runVolumeMounts := []map[string]interface{}{}
+		patch["run_volume_mounts"] = runVolumeMounts
 	}
 	path = "scale_array_spec"
 	if _, exists := d.GetOk(path); d.HasChange(path) && !exists {


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/IBM-Cloud/terraform-provider-ibm/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #6013

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
#### Resource: `ibm_code_engine_app`
```
$ make testacc TESTARGS="-run TestAccIbmCodeEngineAppBasic"

=== RUN   TestAccIbmCodeEngineAppBasic
--- PASS: TestAccIbmCodeEngineAppBasic (196.37s)
PASS
ok      github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/codeengine      206.201s
...
```
```
$ make testacc TESTARGS="-run TestAccIbmCodeEngineAppExtended"

=== RUN   TestAccIbmCodeEngineAppExtended
--- PASS: TestAccIbmCodeEngineAppExtended (193.84s)
PASS
ok      github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/codeengine      203.359s
...
```

#### Resource: `ibm_code_engine_function`
```
$ make testacc TESTARGS="-run TestAccIbmCodeEngineFunctionBasic"

=== RUN   TestAccIbmCodeEngineFunctionBasic
--- PASS: TestAccIbmCodeEngineFunctionBasic (135.80s)
PASS
ok      github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/codeengine      148.603s
```
```
$ make testacc TESTARGS="-run TestAccIbmCodeEngineFunctionExtended"

=== RUN   TestAccIbmCodeEngineFunctionExtended
--- PASS: TestAccIbmCodeEngineFunctionExtended (129.16s)
PASS
ok      github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/codeengine      140.044s
```

#### Resource: `ibm_code_engine_job`
```
$ make testacc TESTARGS="-run TestAccIbmCodeEngineJobBasic"

=== RUN   TestAccIbmCodeEngineJobBasic
--- PASS: TestAccIbmCodeEngineJobBasic (68.68s)
PASS
ok      github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/codeengine      79.348s
```
```
$ make testacc TESTARGS="-run TestAccIbmCodeEngineJobExtended"

=== RUN   TestAccIbmCodeEngineJobExtended
--- PASS: TestAccIbmCodeEngineJobExtended (75.92s)
PASS
ok      github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/codeengine      86.960s
```
------

#### Data source: `ibm_code_engine_app`
```
$ make testacc TESTARGS="-run TestAccIbmCodeEngineAppDataSourceBasic"

=== RUN   TestAccIbmCodeEngineAppDataSourceBasic
--- PASS: TestAccIbmCodeEngineAppDataSourceBasic (101.71s)
PASS
ok      github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/codeengine      112.695s
...
```
```
$ make testacc TESTARGS="-run TestAccIbmCodeEngineAppDataSourceExtended"

=== RUN   TestAccIbmCodeEngineAppDataSourceExtended
--- PASS: TestAccIbmCodeEngineAppDataSourceExtended (98.92s)
PASS
ok      github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/codeengine      108.481s
...
```

#### Data source: `ibm_code_engine_function`
```
$ make testacc TESTARGS="-run TestAccIbmCodeEngineFunctionDataSourceBasic"

=== RUN   TestAccIbmCodeEngineFunctionDataSourceBasic
--- PASS: TestAccIbmCodeEngineFunctionDataSourceBasic (100.81s)
PASS
ok      github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/codeengine      111.858s
```
```
$ make testacc TESTARGS="-run TestAccIbmCodeEngineFunctionDataSourceExtended"

=== RUN   TestAccIbmCodeEngineFunctionDataSourceExtended
--- PASS: TestAccIbmCodeEngineFunctionDataSourceExtended (104.14s)
PASS
ok      github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/codeengine      115.021s
```

#### Data source: `ibm_code_engine_job`
```
$ make testacc TESTARGS="-run TestAccIbmCodeEngineJobDataSourceBasic"

=== RUN   TestAccIbmCodeEngineJobDataSourceBasic
--- PASS: TestAccIbmCodeEngineJobDataSourceBasic (45.39s)
PASS
ok      github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/codeengine      56.280s
```
```
$ make testacc TESTARGS="-run TestAccIbmCodeEngineJobDataSourceExtended"

=== RUN   TestAccIbmCodeEngineJobDataSourceExtended
--- PASS: TestAccIbmCodeEngineJobDataSourceExtended (39.26s)
PASS
ok      github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/codeengine      49.898s
```
