### PR TITLE
fix(cis): don't panic when ZoneID/ZoneName not set

### DIFF
--- a/ibm/service/cis/data_source_ibm_cis_dns_records.go
+++ b/ibm/service/cis/data_source_ibm_cis_dns_records.go
@@ -206,7 +206,9 @@ func dataSourceIBMCISDNSRecordsRead(d *schema.ResourceData, meta interface{}) er
 		record := map[string]interface{}{}
 		record["id"] = flex.ConvertCisToTfThreeVar(*instance.ID, zoneID, crn)
 		record[cisDNSRecordID] = *instance.ID
-		record[cisZoneName] = *instance.ZoneName
+		if instance.ZoneName != nil {
+			record[cisZoneName] = *instance.ZoneName
+		}
 		record[cisDNSRecordCreatedOn] = *instance.CreatedOn
 		record[cisDNSRecordModifiedOn] = *instance.ModifiedOn
 		record[cisDNSRecordName] = *instance.Name
@@ -221,7 +223,11 @@ func dataSourceIBMCISDNSRecordsRead(d *schema.ResourceData, meta interface{}) er
 		record[cisDNSRecordProxied] = *instance.Proxied
 		record[cisDNSRecordTTL] = *instance.TTL
 		if instance.Data != nil {
-			d.Set(cisDNSRecordData, flattenData(instance.Data, *instance.ZoneName))
+			zoneName := ""
+			if instance.ZoneName != nil {
+				zoneName = *instance.ZoneName
+			}
+			d.Set(cisDNSRecordData, flattenData(instance.Data, zoneName))
 		}
 
 		records = append(records, record)

--- a/ibm/service/cis/resource_ibm_cis_dns_record.go
+++ b/ibm/service/cis/resource_ibm_cis_dns_record.go
@@ -468,9 +468,13 @@ func ResourceIBMCISDnsRecordRead(d *schema.ResourceData, meta interface{}) error
 	}
 
 	d.Set(cisID, crn)
-	d.Set(cisDomainID, *result.Result.ZoneID)
+	if result.Result.ZoneID != nil {
+		d.Set(cisDomainID, *result.Result.ZoneID)
+	}
 	d.Set(cisDNSRecordID, *result.Result.ID)
-	d.Set(cisZoneName, *result.Result.ZoneName)
+	if result.Result.ZoneName != nil {
+		d.Set(cisZoneName, *result.Result.ZoneName)
+	}
 	d.Set(cisDNSRecordCreatedOn, *result.Result.CreatedOn)
 	d.Set(cisDNSRecordModifiedOn, *result.Result.ModifiedOn)
 	d.Set(cisDNSRecordName, *result.Result.Name)
@@ -485,7 +489,11 @@ func ResourceIBMCISDnsRecordRead(d *schema.ResourceData, meta interface{}) error
 		d.Set(cisDNSRecordPriority, *result.Result.Priority)
 	}
 	if result.Result.Data != nil {
-		d.Set(cisDNSRecordData, flattenData(result.Result.Data, *result.Result.ZoneName))
+		zoneName := ""
+		if result.Result.ZoneName != nil {
+			zoneName = *result.Result.ZoneName
+		}
+		d.Set(cisDNSRecordData, flattenData(result.Result.Data, zoneName))
 	}
 	return nil
 }
@@ -906,7 +914,7 @@ func flattenData(inVal interface{}, zone string) map[string]string {
 	}
 	for k, v := range inVal.(map[string]interface{}) {
 		strValue := fmt.Sprintf("%v", v)
-		if k == "name" {
+		if k == "name" && zone != "" {
 			strValue = strings.Replace(strValue, "."+zone, "", -1)
 		}
 		outVal[k] = strValue


### PR DESCRIPTION
Currently, trying to create ibm_cis_dns_record resources causes the provider to panic and crash. For example, simple tf file

```hcl
resource "ibm_cis_dns_record" "record" {
  cis_id    = var.cis_id
  domain_id = var.domain_id
  name      = var.record_name
  content   = "foo.bar.baz"
  type      = "CNAME"
  ttl       = 0
}
```

results in:

```
ibm_cis_dns_record.record: Creating...
╷
│ Error: Plugin did not respond
│ 
│   with ibm_cis_dns_record.record,
│   on main.tf line 21, in resource "ibm_cis_dns_record" "record":
│   21: resource "ibm_cis_dns_record" "record" {
│ 
│ The plugin encountered an error, and failed to respond to the plugin.(*GRPCProvider).ApplyResourceChange call. The plugin logs may contain more details.
╵

Stack trace from the terraform-provider-ibm_v1.76.1 plugin:

panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x2a4bbf5]

goroutine 58 [running]:
github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/cis.ResourceIBMCISDnsRecordRead(0xc007629800, {0x5947ec0?, 0xc0076e8008?})
	github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/cis/resource_ibm_cis_dns_record.go:471 +0x375
github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/cis.ResourceIBMCISDnsRecordUpdate(0xc007629800, {0x5947ec0, 0xc0076e8008})
	github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/cis/resource_ibm_cis_dns_record.go:802 +0x20e5
github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/cis.ResourceIBMCISDnsRecordCreate(0xc007629800, {0x5947ec0, 0xc0076e8008})
	github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/cis/resource_ibm_cis_dns_record.go:437 +0x1d75
github.com/IBM-Cloud/terraform-provider-ibm/ibm/provider.wrapResource.wrapFunction.func2({0x639a140?, 0xc0041cca50?}, 0x1176592e000?, {0x5947ec0?, 0xc0076e8008?})
	github.com/IBM-Cloud/terraform-provider-ibm/ibm/provider/provider.go:1805 +0x5f
github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema.(*Resource).create(0xc0033a3960, {0x639a140, 0xc0041cca50}, 0xc007629800, {0x5947ec0, 0xc0076e8008})
	github.com/hashicorp/terraform-plugin-sdk/v2@v2.35.0/helper/schema/resource.go:806 +0x119
github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema.(*Resource).Apply(0xc0033a3960, {0x639a140, 0xc0041cca50}, 0xc000191040, 0xc007629680, {0x5947ec0, 0xc0076e8008})
	github.com/hashicorp/terraform-plugin-sdk/v2@v2.35.0/helper/schema/resource.go:937 +0xa69
github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema.(*GRPCProviderServer).ApplyResourceChange(0xc000810450, {0x639a140?, 0xc0041cc750?}, 0xc0042ee000)
	github.com/hashicorp/terraform-plugin-sdk/v2@v2.35.0/helper/schema/grpc_provider.go:1155 +0xd5c
github.com/hashicorp/terraform-plugin-go/tfprotov5/tf5server.(*server).ApplyResourceChange(0xc0007adae0, {0x639a140?, 0xc0041ca3f0?}, 0xc007626bd0)
	github.com/hashicorp/terraform-plugin-go@v0.25.0/tfprotov5/tf5server/server.go:865 +0x3bc
github.com/hashicorp/terraform-plugin-go/tfprotov5/internal/tfplugin5._Provider_ApplyResourceChange_Handler({0x5839fc0, 0xc0007adae0}, {0x639a140, 0xc0041ca3f0}, 0xc007628e00, 0x0)
	github.com/hashicorp/terraform-plugin-go@v0.25.0/tfprotov5/internal/tfplugin5/tfplugin5_grpc.pb.go:611 +0x1a6
google.golang.org/grpc.(*Server).processUnaryRPC(0xc0002ad000, {0x639a140, 0xc0041ca360}, {0x63a76e0, 0xc001ecc000}, 0xc0035710e0, 0xc0033ec030, 0x8c38878, 0x0)
	google.golang.org/grpc@v1.67.1/server.go:1394 +0xe2b
google.golang.org/grpc.(*Server).handleStream(0xc0002ad000, {0x63a76e0, 0xc001ecc000}, 0xc0035710e0)
	google.golang.org/grpc@v1.67.1/server.go:1805 +0xe8b
google.golang.org/grpc.(*Server).serveStreams.func2.1()
	google.golang.org/grpc@v1.67.1/server.go:1029 +0x7f
created by google.golang.org/grpc.(*Server).serveStreams.func2 in goroutine 39
	google.golang.org/grpc@v1.67.1/server.go:1040 +0x125

Error: The terraform-provider-ibm_v1.76.1 plugin crashed!

This is always indicative of a bug within the plugin. It would be immensely
helpful if you could report the crash with the plugin's maintainers so that it
can be fixed. The output above should help diagnose the issue.
```

It appears this is happening because the IBM cloud API is not returning ZoneID and ZoneName in the response.

This PR prevents the panic by not attempting to reference the nil values when they're not present in the API response.

----

<!--- See what makes a good Pull Request at : https://github.com/IBM-Cloud/terraform-provider-ibm/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```

These tests are failing due to missing environment variables for which I don't know the proper values.
```
=== RUN   TestAccIBMCisDNSRecordsDataSource_basic
    acctest.go:2105: IC_API_KEY must be set for acceptance tests
--- FAIL: TestAccIBMCisDNSRecordsDataSource_basic (0.00s)
=== RUN   TestAccIBMCisDNSRecord_Basic
    acctest.go:2105: IC_API_KEY must be set for acceptance tests
--- FAIL: TestAccIBMCisDNSRecord_Basic (0.00s)
=== RUN   TestAccIBMCisDNSRecord_PTR
    acctest.go:2105: IC_API_KEY must be set for acceptance tests
--- FAIL: TestAccIBMCisDNSRecord_PTR (0.00s)
=== RUN   TestAccIBMCisDNSRecord_import
    acctest.go:2105: IC_API_KEY must be set for acceptance tests
--- FAIL: TestAccIBMCisDNSRecord_import (0.00s)
=== RUN   TestAccIBMCisDNSRecord_CaseInsensitive
    acctest.go:2105: IC_API_KEY must be set for acceptance tests
--- FAIL: TestAccIBMCisDNSRecord_CaseInsensitive (0.00s)
=== RUN   TestAccIBMCisDNSRecord_Apex
    acctest.go:2105: IC_API_KEY must be set for acceptance tests
--- FAIL: TestAccIBMCisDNSRecord_Apex (0.00s)
=== RUN   TestAccIBMCisDNSRecord_CreateAfterManualDestroy
    acctest.go:2105: IC_API_KEY must be set for acceptance tests
--- FAIL: TestAccIBMCisDNSRecord_CreateAfterManualDestroy (0.00s)
=== RUN   TestAccIBMCisDNSRecordsImport_Basic
    acctest.go:2105: IC_API_KEY must be set for acceptance tests
--- FAIL: TestAccIBMCisDNSRecordsImport_Basic (0.00s)
FAIL
FAIL	github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/cis	0.064s
FAIL
```
