### PR TITLE
fix(identity) new error messages for Account Settings assignment

### DIFF
--- a/ibm/service/iamidentity/data_source_ibm_iam_account_settings_template_assignment.go
+++ b/ibm/service/iamidentity/data_source_ibm_iam_account_settings_template_assignment.go
@@ -1,5 +1,9 @@
-// Copyright IBM Corp. 2023 All Rights Reserved.
+// Copyright IBM Corp. 2025 All Rights Reserved.
 // Licensed under the Mozilla Public License v2.0
+
+/*
+ * IBM OpenAPI Terraform Generator Version: 3.98.0-8be2046a-20241205-162752
+ */
 
 package iamidentity
 
@@ -290,7 +294,9 @@ func DataSourceIBMAccountSettingsTemplateAssignment() *schema.Resource {
 func dataSourceIBMAccountSettingsTemplateAssignmentRead(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	iamIdentityClient, err := meta.(conns.ClientSession).IAMIdentityV1API()
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.DiscriminatedTerraformErrorf(err, err.Error(), "(Data) ibm_iam_account_settings_template_assignment", "read", "initialize-client")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	getAccountSettingsAssignmentOptions := &iamidentityv1.GetAccountSettingsAssignmentOptions{}
@@ -300,10 +306,11 @@ func dataSourceIBMAccountSettingsTemplateAssignmentRead(context context.Context,
 		getAccountSettingsAssignmentOptions.SetIncludeHistory(d.Get("include_history").(bool))
 	}
 
-	templateAssignmentResponse, response, err := iamIdentityClient.GetAccountSettingsAssignmentWithContext(context, getAccountSettingsAssignmentOptions)
+	templateAssignmentResponse, _, err := iamIdentityClient.GetAccountSettingsAssignmentWithContext(context, getAccountSettingsAssignmentOptions)
 	if err != nil {
-		log.Printf("[DEBUG] GetAccountSettingsAssignmentWithContext failed %s\n%s", err, response)
-		return diag.FromErr(fmt.Errorf("GetAccountSettingsAssignmentWithContext failed %s\n%s", err, response))
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("GetTrustedProfileAssignmentWithContext failed: %s", err.Error()), "(Data) ibm_iam_account_settings_template_assignment", "read")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	d.SetId(fmt.Sprintf("%s", *getAccountSettingsAssignmentOptions.AssignmentID))
@@ -312,40 +319,40 @@ func dataSourceIBMAccountSettingsTemplateAssignmentRead(context context.Context,
 	if templateAssignmentResponse.Context != nil {
 		modelMap, err := dataSourceIBMAccountSettingsTemplateAssignmentResponseContextToMap(templateAssignmentResponse.Context)
 		if err != nil {
-			return diag.FromErr(err)
+			return flex.DiscriminatedTerraformErrorf(err, err.Error(), "(Data) ibm_iam_account_settings_template_assignment", "read", "context-to-map").GetDiag()
 		}
 		respContext = append(respContext, modelMap)
 	}
 	if err = d.Set("context", respContext); err != nil {
-		return diag.FromErr(fmt.Errorf("error setting context %s", err))
+		return flex.DiscriminatedTerraformErrorf(err, fmt.Sprintf("Error setting context: %s", err), "(Data) ibm_iam_account_settings_template_assignment", "read", "set-context").GetDiag()
 	}
 
 	if err = d.Set("id", templateAssignmentResponse.ID); err != nil {
-		return diag.FromErr(fmt.Errorf("error setting id: %s", err))
+		return flex.DiscriminatedTerraformErrorf(err, fmt.Sprintf("Error setting id: %s", err), "(Data) ibm_iam_account_settings_template_assignment", "read", "set-id").GetDiag()
 	}
 
 	if err = d.Set("account_id", templateAssignmentResponse.AccountID); err != nil {
-		return diag.FromErr(fmt.Errorf("error setting account_id: %s", err))
+		return flex.DiscriminatedTerraformErrorf(err, fmt.Sprintf("Error setting account_id: %s", err), "(Data) ibm_iam_account_settings_template_assignment", "read", "set-account_id").GetDiag()
 	}
 
 	if err = d.Set("template_id", templateAssignmentResponse.TemplateID); err != nil {
-		return diag.FromErr(fmt.Errorf("error setting template_id: %s", err))
+		return flex.DiscriminatedTerraformErrorf(err, fmt.Sprintf("Error setting template_id: %s", err), "(Data) ibm_iam_account_settings_template_assignment", "read", "set-template_id").GetDiag()
 	}
 
 	if err = d.Set("template_version", flex.IntValue(templateAssignmentResponse.TemplateVersion)); err != nil {
-		return diag.FromErr(fmt.Errorf("error setting template_version: %s", err))
+		return flex.DiscriminatedTerraformErrorf(err, fmt.Sprintf("Error setting template_version: %s", err), "(Data) ibm_iam_account_settings_template_assignment", "read", "set-template_version").GetDiag()
 	}
 
 	if err = d.Set("target_type", templateAssignmentResponse.TargetType); err != nil {
-		return diag.FromErr(fmt.Errorf("error setting target_type: %s", err))
+		return flex.DiscriminatedTerraformErrorf(err, fmt.Sprintf("Error setting target_type: %s", err), "(Data) ibm_iam_account_settings_template_assignment", "read", "set-target_type").GetDiag()
 	}
 
 	if err = d.Set("target", templateAssignmentResponse.Target); err != nil {
-		return diag.FromErr(fmt.Errorf("error setting target: %s", err))
+		return flex.DiscriminatedTerraformErrorf(err, fmt.Sprintf("Error setting target: %s", err), "(Data) ibm_iam_account_settings_template_assignment", "read", "set-target").GetDiag()
 	}
 
 	if err = d.Set("status", templateAssignmentResponse.Status); err != nil {
-		return diag.FromErr(fmt.Errorf("error setting status: %s", err))
+		return flex.DiscriminatedTerraformErrorf(err, fmt.Sprintf("Error setting status: %s", err), "(Data) ibm_iam_account_settings_template_assignment", "read", "set-status").GetDiag()
 	}
 
 	var resources []map[string]interface{}
@@ -353,13 +360,13 @@ func dataSourceIBMAccountSettingsTemplateAssignmentRead(context context.Context,
 		for _, modelItem := range templateAssignmentResponse.Resources {
 			modelMap, err := dataSourceIBMAccountSettingsTemplateAssignmentTemplateAssignmentResponseResourceToMap(&modelItem)
 			if err != nil {
-				return diag.FromErr(err)
+				return flex.DiscriminatedTerraformErrorf(err, err.Error(), "(Data) ibm_iam_account_settings_template_assignment", "read", "resources-to-map").GetDiag()
 			}
 			resources = append(resources, modelMap)
 		}
 	}
 	if err = d.Set("resources", resources); err != nil {
-		return diag.FromErr(fmt.Errorf("error setting resources %s", err))
+		return flex.DiscriminatedTerraformErrorf(err, fmt.Sprintf("Error setting resources: %s", err), "(Data) ibm_iam_account_settings_template_assignment", "read", "set-resources").GetDiag()
 	}
 
 	var history []map[string]interface{}
@@ -367,37 +374,37 @@ func dataSourceIBMAccountSettingsTemplateAssignmentRead(context context.Context,
 		for _, modelItem := range templateAssignmentResponse.History {
 			modelMap, err := dataSourceIBMAccountSettingsTemplateAssignmentEnityHistoryRecordToMap(&modelItem)
 			if err != nil {
-				return diag.FromErr(err)
+				return flex.DiscriminatedTerraformErrorf(err, err.Error(), "(Data) ibm_iam_account_settings_template_assignment", "read", "history-to-map").GetDiag()
 			}
 			history = append(history, modelMap)
 		}
 	}
 	if err = d.Set("history", history); err != nil {
-		return diag.FromErr(fmt.Errorf("error setting history %s", err))
+		return flex.DiscriminatedTerraformErrorf(err, fmt.Sprintf("Error setting history: %s", err), "(Data) ibm_iam_account_settings_template_assignment", "read", "set-history").GetDiag()
 	}
 
 	if err = d.Set("href", templateAssignmentResponse.Href); err != nil {
-		return diag.FromErr(fmt.Errorf("error setting href: %s", err))
+		return flex.DiscriminatedTerraformErrorf(err, fmt.Sprintf("Error setting href: %s", err), "(Data) ibm_iam_account_settings_template_assignment", "read", "set-href").GetDiag()
 	}
 
 	if err = d.Set("created_at", templateAssignmentResponse.CreatedAt); err != nil {
-		return diag.FromErr(fmt.Errorf("error setting created_at: %s", err))
+		return flex.DiscriminatedTerraformErrorf(err, fmt.Sprintf("Error setting created_at: %s", err), "(Data) ibm_iam_account_settings_template_assignment", "read", "set-created_at").GetDiag()
 	}
 
 	if err = d.Set("created_by_id", templateAssignmentResponse.CreatedByID); err != nil {
-		return diag.FromErr(fmt.Errorf("error setting created_by_id: %s", err))
+		return flex.DiscriminatedTerraformErrorf(err, fmt.Sprintf("Error setting created_by_id: %s", err), "(Data) ibm_iam_account_settings_template_assignment", "read", "set-created_by_id").GetDiag()
 	}
 
 	if err = d.Set("last_modified_at", templateAssignmentResponse.LastModifiedAt); err != nil {
-		return diag.FromErr(fmt.Errorf("error setting last_modified_at: %s", err))
+		return flex.DiscriminatedTerraformErrorf(err, fmt.Sprintf("Error setting last_modified_at: %s", err), "(Data) ibm_iam_account_settings_template_assignment", "read", "set-last_modified_at").GetDiag()
 	}
 
 	if err = d.Set("last_modified_by_id", templateAssignmentResponse.LastModifiedByID); err != nil {
-		return diag.FromErr(fmt.Errorf("error setting last_modified_by_id: %s", err))
+		return flex.DiscriminatedTerraformErrorf(err, fmt.Sprintf("Error setting last_modified_by_id: %s", err), "(Data) ibm_iam_account_settings_template_assignment", "read", "set-last_modified_by_id").GetDiag()
 	}
 
 	if err = d.Set("entity_tag", templateAssignmentResponse.EntityTag); err != nil {
-		return diag.FromErr(fmt.Errorf("error setting entity_tag: %s", err))
+		return flex.DiscriminatedTerraformErrorf(err, fmt.Sprintf("Error setting entity_tag: %s", err), "(Data) ibm_iam_account_settings_template_assignment", "read", "set-entity_tag").GetDiag()
 	}
 
 	return nil

--- a/ibm/service/iamidentity/resource_ibm_iam_account_settings_template_assignment.go
+++ b/ibm/service/iamidentity/resource_ibm_iam_account_settings_template_assignment.go
@@ -1,16 +1,20 @@
-// Copyright IBM Corp. 2023 All Rights Reserved.
+// Copyright IBM Corp. 2025 All Rights Reserved.
 // Licensed under the Mozilla Public License v2.0
+
+/*
+ * IBM OpenAPI Terraform Generator Version: 3.98.0-8be2046a-20241205-162752
+ */
 
 package iamidentity
 
 import (
 	"context"
 	"fmt"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"log"
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 
 	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/conns"
@@ -293,15 +297,18 @@ func ResourceIBMAccountSettingsTemplateAssignmentValidator() *validate.ResourceV
 func resourceIBMAccountSettingsTemplateAssignmentCreate(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	iamIdentityClient, err := meta.(conns.ClientSession).IAMIdentityV1API()
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_iam_account_settings_template_assignment", "create", "initialize-client")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	createAccountSettingsAssignmentOptions := &iamidentityv1.CreateAccountSettingsAssignmentOptions{}
 
 	templateId, _, err := parseResourceId(d.Get("template_id").(string))
 	if err != nil {
-		log.Printf("[DEBUG] resourceIBMAccountSettingsTemplateRead failed %s", err)
-		return diag.FromErr(fmt.Errorf("resourceIBMAccountSettingsTemplateRead failed %s", err))
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("[DEBUG] resourceIBMAccountSettingsTemplateRead failed: %s", err.Error()), "ibm_iam_account_settings_template_assignment", "create")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	createAccountSettingsAssignmentOptions.SetTemplateID(templateId)
@@ -309,17 +316,18 @@ func resourceIBMAccountSettingsTemplateAssignmentCreate(context context.Context,
 	createAccountSettingsAssignmentOptions.SetTargetType(d.Get("target_type").(string))
 	createAccountSettingsAssignmentOptions.SetTarget(d.Get("target").(string))
 
-	templateAssignmentResponse, response, err := iamIdentityClient.CreateAccountSettingsAssignmentWithContext(context, createAccountSettingsAssignmentOptions)
+	templateAssignmentResponse, _, err := iamIdentityClient.CreateAccountSettingsAssignmentWithContext(context, createAccountSettingsAssignmentOptions)
 	if err != nil {
-		log.Printf("[DEBUG] CreateAccountSettingsAssignmentWithContext failed %s\n%s", err, response)
-		return diag.FromErr(fmt.Errorf("CreateAccountSettingsAssignmentWithContext failed %s\n%s", err, response))
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("CreateAccountSettingsAssignmentWithContext failed: %s", err.Error()), "ibm_iam_account_settings_template_assignment", "create")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	d.SetId(*templateAssignmentResponse.ID)
 
 	_, err = waitForAssignment(d.Timeout(schema.TimeoutCreate), meta, d, isAccountSettingsTemplateAssigned)
 	if err != nil {
-		return diag.FromErr(fmt.Errorf("error assigning %s", err))
+		flex.DiscriminatedTerraformErrorf(err, err.Error(), "error assigning", "create", "wait-for-assignment").GetDiag()
 	}
 
 	return resourceIBMAccountSettingsTemplateAssignmentRead(context, d, meta)
@@ -328,7 +336,9 @@ func resourceIBMAccountSettingsTemplateAssignmentCreate(context context.Context,
 func resourceIBMAccountSettingsTemplateAssignmentRead(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	iamIdentityClient, err := meta.(conns.ClientSession).IAMIdentityV1API()
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_iam_account_settings_template_assignment", "read", "initialize-client")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	getAccountSettingsAssignmentOptions := &iamidentityv1.GetAccountSettingsAssignmentOptions{}
@@ -341,48 +351,57 @@ func resourceIBMAccountSettingsTemplateAssignmentRead(context context.Context, d
 			d.SetId("")
 			return nil
 		}
-		log.Printf("[DEBUG] GetAccountSettingsAssignmentWithContext failed %s\n%s", err, response)
-		return diag.FromErr(fmt.Errorf("GetAccountSettingsAssignmentWithContext failed %s\n%s", err, response))
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("GetAccountSettingsAssignmentWithContext failed: %s", err.Error()), "ibm_iam_account_settings_template_assignment", "read")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	if err = d.Set("template_id", templateAssignmentResponse.TemplateID); err != nil {
-		return diag.FromErr(fmt.Errorf("error setting template_id: %s", err))
+		err = fmt.Errorf("Error setting template_id: %s", err)
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_iam_account_settings_template_assignment", "read", "set-template_id").GetDiag()
 	}
 	if err = d.Set("template_version", flex.IntValue(templateAssignmentResponse.TemplateVersion)); err != nil {
-		return diag.FromErr(fmt.Errorf("error setting template_version: %s", err))
+		err = fmt.Errorf("Error setting template_version: %s", err)
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_iam_account_settings_template_assignment", "read", "set-template_version").GetDiag()
 	}
 	if err = d.Set("target_type", templateAssignmentResponse.TargetType); err != nil {
-		return diag.FromErr(fmt.Errorf("error setting target_type: %s", err))
+		err = fmt.Errorf("Error setting target_type: %s", err)
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_iam_account_settings_template_assignment", "read", "set-target_type").GetDiag()
 	}
 	if err = d.Set("target", templateAssignmentResponse.Target); err != nil {
-		return diag.FromErr(fmt.Errorf("error setting target: %s", err))
+		err = fmt.Errorf("Error setting target: %s", err)
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_iam_account_settings_template_assignment", "read", "set-target").GetDiag()
 	}
 	if !core.IsNil(templateAssignmentResponse.Context) {
 		contextMap, err := resourceIBMAccountSettingsTemplateAssignmentResponseContextToMap(templateAssignmentResponse.Context)
 		if err != nil {
-			return diag.FromErr(err)
+			return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_iam_account_settings_template_assignment", "read", "context-to-map").GetDiag()
 		}
 		if err = d.Set("context", []map[string]interface{}{contextMap}); err != nil {
-			return diag.FromErr(fmt.Errorf("error setting context: %s", err))
+			err = fmt.Errorf("Error setting context: %s", err)
+			return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_iam_account_settings_template_assignment", "read", "set-context").GetDiag()
 		}
 	}
 	if err = d.Set("account_id", templateAssignmentResponse.AccountID); err != nil {
-		return diag.FromErr(fmt.Errorf("error setting account_id: %s", err))
+		err = fmt.Errorf("Error setting account_id: %s", err)
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_iam_account_settings_template_assignment", "read", "set-account_id").GetDiag()
 	}
 	if err = d.Set("status", templateAssignmentResponse.Status); err != nil {
-		return diag.FromErr(fmt.Errorf("error setting status: %s", err))
+		err = fmt.Errorf("Error setting status: %s", err)
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_iam_account_settings_template_assignment", "read", "set-status").GetDiag()
 	}
 	if !core.IsNil(templateAssignmentResponse.Resources) {
 		var resources []map[string]interface{}
 		for _, resourcesItem := range templateAssignmentResponse.Resources {
 			resourcesItemMap, err := resourceIBMAccountSettingsTemplateAssignmentTemplateAssignmentResponseResourceToMap(&resourcesItem)
 			if err != nil {
-				return diag.FromErr(err)
+				return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_iam_account_settings_template_assignment", "read", "resources-to-map").GetDiag()
 			}
 			resources = append(resources, resourcesItemMap)
 		}
 		if err = d.Set("resources", resources); err != nil {
-			return diag.FromErr(fmt.Errorf("error setting resources: %s", err))
+			err = fmt.Errorf("Error setting resources: %s", err)
+			return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_iam_account_settings_template_assignment", "read", "set-resources").GetDiag()
 		}
 	}
 	if !core.IsNil(templateAssignmentResponse.History) {
@@ -390,33 +409,40 @@ func resourceIBMAccountSettingsTemplateAssignmentRead(context context.Context, d
 		for _, historyItem := range templateAssignmentResponse.History {
 			historyItemMap, err := resourceIBMAccountSettingsTemplateAssignmentEnityHistoryRecordToMap(&historyItem)
 			if err != nil {
-				return diag.FromErr(err)
+				return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_iam_account_settings_template_assignment", "read", "history-to-map").GetDiag()
 			}
 			history = append(history, historyItemMap)
 		}
 		if err = d.Set("history", history); err != nil {
-			return diag.FromErr(fmt.Errorf("error setting history: %s", err))
+			err = fmt.Errorf("Error setting history: %s", err)
+			return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_iam_account_settings_template_assignment", "read", "set-history").GetDiag()
 		}
 	}
 	if !core.IsNil(templateAssignmentResponse.Href) {
 		if err = d.Set("href", templateAssignmentResponse.Href); err != nil {
-			return diag.FromErr(fmt.Errorf("error setting href: %s", err))
+			err = fmt.Errorf("Error setting href: %s", err)
+			return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_iam_account_settings_template_assignment", "read", "set-href").GetDiag()
 		}
 	}
 	if err = d.Set("created_at", templateAssignmentResponse.CreatedAt); err != nil {
-		return diag.FromErr(fmt.Errorf("error setting created_at: %s", err))
+		err = fmt.Errorf("Error setting created_at: %s", err)
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_iam_account_settings_template_assignment", "read", "set-created_at").GetDiag()
 	}
 	if err = d.Set("created_by_id", templateAssignmentResponse.CreatedByID); err != nil {
-		return diag.FromErr(fmt.Errorf("error setting created_by_id: %s", err))
+		err = fmt.Errorf("Error setting created_by_id: %s", err)
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_iam_account_settings_template_assignment", "read", "set-created_by_id").GetDiag()
 	}
 	if err = d.Set("last_modified_at", templateAssignmentResponse.LastModifiedAt); err != nil {
-		return diag.FromErr(fmt.Errorf("error setting last_modified_at: %s", err))
+		err = fmt.Errorf("Error setting last_modified_at: %s", err)
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_iam_account_settings_template_assignment", "read", "set-last_modified_at").GetDiag()
 	}
 	if err = d.Set("last_modified_by_id", templateAssignmentResponse.LastModifiedByID); err != nil {
-		return diag.FromErr(fmt.Errorf("error setting last_modified_by_id: %s", err))
+		err = fmt.Errorf("Error setting last_modified_by_id: %s", err)
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_iam_account_settings_template_assignment", "read", "set-last_modified_by_id").GetDiag()
 	}
 	if err = d.Set("entity_tag", templateAssignmentResponse.EntityTag); err != nil {
-		return diag.FromErr(fmt.Errorf("error setting entity_tag: %s", err))
+		err = fmt.Errorf("Error setting entity_tag: %s", err)
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_iam_account_settings_template_assignment", "read", "set-entity_tag").GetDiag()
 	}
 
 	return nil
@@ -425,7 +451,9 @@ func resourceIBMAccountSettingsTemplateAssignmentRead(context context.Context, d
 func resourceIBMAccountSettingsTemplateAssignmentUpdate(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	iamIdentityClient, err := meta.(conns.ClientSession).IAMIdentityV1API()
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_iam_account_settings_template_assignment", "update", "initialize-client")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	updateAccountSettingsAssignmentOptions := &iamidentityv1.UpdateAccountSettingsAssignmentOptions{}
@@ -448,7 +476,7 @@ func resourceIBMAccountSettingsTemplateAssignmentUpdate(context context.Context,
 
 		_, err = waitForAssignment(d.Timeout(schema.TimeoutUpdate), meta, d, isAccountSettingsTemplateAssigned)
 		if err != nil {
-			return diag.FromErr(fmt.Errorf("error assigning %s", err))
+			flex.DiscriminatedTerraformErrorf(err, err.Error(), "error assigning", "update", "wait-for-assignment").GetDiag()
 		}
 	}
 
@@ -458,22 +486,25 @@ func resourceIBMAccountSettingsTemplateAssignmentUpdate(context context.Context,
 func resourceIBMAccountSettingsTemplateAssignmentDelete(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	iamIdentityClient, err := meta.(conns.ClientSession).IAMIdentityV1API()
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_iam_account_settings_template_assignment", "delete", "initialize-client")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	deleteAccountSettingsAssignmentOptions := &iamidentityv1.DeleteAccountSettingsAssignmentOptions{}
 
 	deleteAccountSettingsAssignmentOptions.SetAssignmentID(d.Id())
 
-	_, response, err := iamIdentityClient.DeleteAccountSettingsAssignmentWithContext(context, deleteAccountSettingsAssignmentOptions)
+	_, _, err = iamIdentityClient.DeleteAccountSettingsAssignmentWithContext(context, deleteAccountSettingsAssignmentOptions)
 	if err != nil {
-		log.Printf("[DEBUG] DeleteAccountSettingsAssignmentWithContext failed %s\n%s", err, response)
-		return diag.FromErr(fmt.Errorf("DeleteAccountSettingsAssignmentWithContext failed %s\n%s", err, response))
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("DeleteAccountSettingsAssignmentWithContext failed: %s", err.Error()), "ibm_iam_account_settings_template_assignment", "delete")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	_, err = waitForAssignment(d.Timeout(schema.TimeoutDelete), meta, d, isAccountSettingsAssignmentRemoved)
 	if err != nil {
-		return diag.FromErr(fmt.Errorf("error removing assignment %s", err))
+		flex.DiscriminatedTerraformErrorf(err, err.Error(), "error assigning", "update", "wait-for-assignment").GetDiag()
 	}
 
 	d.SetId("")


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/IBM-Cloud/terraform-provider-ibm/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccXXX'

=== RUN   TestAccIBMAccountSettingsTemplateAssignmentBasic
--- PASS: TestAccIBMAccountSettingsTemplateAssignmentBasic (302.75s)
PASS
.
.
.
=== RUN   TestAccIBMAccountSettingsTemplateAssignmentDataSourceBasic
--- PASS: TestAccIBMAccountSettingsTemplateAssignmentDataSourceBasic (256.26s)
PASS


...
```
