### PR TITLE
enhanced the is-geography datasources errors

### DIFF
--- a/ibm/service/vpc/data_source_ibm_is_zone.go
+++ b/ibm/service/vpc/data_source_ibm_is_zone.go
@@ -4,9 +4,14 @@
 package vpc
 
 import (
+	"context"
 	"fmt"
+	"log"
 
+	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/flex"
+	"github.com/IBM/go-sdk-core/v5/core"
 	"github.com/IBM/vpc-go-sdk/vpcv1"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
@@ -21,7 +26,7 @@ const (
 
 func DataSourceIBMISZone() *schema.Resource {
 	return &schema.Resource{
-		Read: dataSourceIBMISZoneRead,
+		ReadContext: dataSourceIBMISZoneRead,
 
 		Schema: map[string]*schema.Schema{
 
@@ -50,37 +55,56 @@ func DataSourceIBMISZone() *schema.Resource {
 		},
 	}
 }
-
-func dataSourceIBMISZoneRead(d *schema.ResourceData, meta interface{}) error {
+func dataSourceIBMISZoneRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	regionName := d.Get(isZoneRegion).(string)
 	zoneName := d.Get(isZoneName).(string)
-	return zoneGet(d, meta, regionName, zoneName)
+	return zoneGet(ctx, d, meta, regionName, zoneName)
 }
 
-func zoneGet(d *schema.ResourceData, meta interface{}, regionName, zoneName string) error {
+func zoneGet(ctx context.Context, d *schema.ResourceData, meta interface{}, regionName, zoneName string) diag.Diagnostics {
 	sess, err := vpcClient(meta)
 	if err != nil {
-		return err
+		tfErr := flex.DiscriminatedTerraformErrorf(err, err.Error(), "(Data) ibm_is_zone", "read", "initialize-client")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 	getRegionZoneOptions := &vpcv1.GetRegionZoneOptions{
 		RegionName: &regionName,
 		Name:       &zoneName,
 	}
-	zone, _, err := sess.GetRegionZone(getRegionZoneOptions)
+	zone, _, err := sess.GetRegionZoneWithContext(ctx, getRegionZoneOptions)
 	if err != nil {
-		return err
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("GetRegionZoneWithContext failed: %s", err.Error()), "(Data) ibm_is_zone", "read")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 	// For lack of anything better, compose our id from region name + zone name.
 	id := fmt.Sprintf("%s.%s", *zone.Region.Name, *zone.Name)
 	d.SetId(id)
-	d.Set(isZoneName, *zone.Name)
-	d.Set(isZoneRegion, *zone.Region.Name)
-	d.Set(isZoneStatus, *zone.Status)
-	if zone.DataCenter != nil {
-		d.Set(isZoneDataCenter, *zone.DataCenter)
+	if !core.IsNil(zone.Name) {
+		if err = d.Set(isZoneName, zone.Name); err != nil {
+			return flex.DiscriminatedTerraformErrorf(err, fmt.Sprintf("Error setting name: %s", err), "(Data) ibm_is_zone", "read", "set-name").GetDiag()
+		}
 	}
-	if zone.UniversalName != nil {
-		d.Set(isZoneUniversalName, *zone.UniversalName)
+	if !core.IsNil(zone.Region) {
+		if err = d.Set(isZoneRegion, *zone.Region.Name); err != nil {
+			return flex.DiscriminatedTerraformErrorf(err, fmt.Sprintf("Error setting region: %s", err), "(Data) ibm_is_zone", "read", "set-region").GetDiag()
+		}
+	}
+	if err = d.Set("status", zone.Status); err != nil {
+		return flex.DiscriminatedTerraformErrorf(err, fmt.Sprintf("Error setting status: %s", err), "(Data) ibm_is_zone", "read", "set-status").GetDiag()
+	}
+
+	if !core.IsNil(zone.DataCenter) {
+		if err = d.Set("data_center", zone.DataCenter); err != nil {
+			return flex.DiscriminatedTerraformErrorf(err, fmt.Sprintf("Error setting data_center: %s", err), "(Data) ibm_is_zone", "read", "set-data_center").GetDiag()
+		}
+	}
+
+	if !core.IsNil(zone.UniversalName) {
+		if err = d.Set("universal_name", zone.UniversalName); err != nil {
+			return flex.DiscriminatedTerraformErrorf(err, fmt.Sprintf("Error setting universal_name: %s", err), "(Data) ibm_is_zone", "read", "set-universal_name").GetDiag()
+		}
 	}
 	return nil
 }


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/IBM-Cloud/terraform-provider-ibm/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
--- PASS: TestAccIBMISZoneDataSource_basic (25.84s)
PASS
ok      github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/vpc     27.949s
```
```
--- PASS: TestAccIBMISZonesDataSource_1 (29.32s)
PASS
ok      github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/vpc     31.149s

--- PASS: TestAccIBMISZonesDataSource_2 (30.17s)
PASS
ok      github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/vpc     32.002s

--- PASS: TestAccIBMISZonesDataSource_3 (29.37s)
PASS
ok      github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/vpc     31.174s
```
```
--- PASS: TestAccIBMISRegionDataSource_basic (18.64s)
PASS
ok      github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/vpc     20.432s
```
```
--- PASS: TestAccIBMISRegionsDataSource_basic (21.37s)
PASS
ok      github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/vpc     23.209s
```