### PR TITLE
Secrets Manager - allow configuring IAM endpoint with endpoints file

### DIFF
--- a/ibm/service/secretsmanager/data_source_ibm_sm_arbitrary_secret_metadata.go
+++ b/ibm/service/secretsmanager/data_source_ibm_sm_arbitrary_secret_metadata.go
@@ -117,7 +117,7 @@ func DataSourceIbmSmArbitrarySecretMetadata() *schema.Resource {
 }
 
 func dataSourceIbmSmArbitrarySecretMetadataRead(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	secretsManagerClient, err := meta.(conns.ClientSession).SecretsManagerV2()
+	secretsManagerClient, endpointsFile, err := getSecretsManagerSession(meta.(conns.ClientSession))
 	if err != nil {
 		tfErr := flex.TerraformErrorf(err, "", fmt.Sprintf("(Data) %s_metadata", ArbitrarySecretResourceName), "read")
 		return tfErr.GetDiag()
@@ -125,7 +125,7 @@ func dataSourceIbmSmArbitrarySecretMetadataRead(context context.Context, d *sche
 
 	region := getRegion(secretsManagerClient, d)
 	instanceId := d.Get("instance_id").(string)
-	secretsManagerClient = getClientWithInstanceEndpoint(secretsManagerClient, instanceId, region, getEndpointType(secretsManagerClient, d))
+	secretsManagerClient = getClientWithInstanceEndpoint(secretsManagerClient, instanceId, region, getEndpointType(secretsManagerClient, d), endpointsFile)
 
 	getSecretMetadataOptions := &secretsmanagerv2.GetSecretMetadataOptions{}
 

--- a/ibm/service/secretsmanager/data_source_ibm_sm_configurations.go
+++ b/ibm/service/secretsmanager/data_source_ibm_sm_configurations.go
@@ -200,7 +200,7 @@ func DataSourceIbmSmConfigurations() *schema.Resource {
 }
 
 func dataSourceIbmSmConfigurationsRead(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	secretsManagerClient, err := meta.(conns.ClientSession).SecretsManagerV2()
+	secretsManagerClient, endpointsFile, err := getSecretsManagerSession(meta.(conns.ClientSession))
 	if err != nil {
 		tfErr := flex.TerraformErrorf(err, "", fmt.Sprintf("(Data) %s", ConfigurationsResourceName), "read")
 		return tfErr.GetDiag()
@@ -208,7 +208,7 @@ func dataSourceIbmSmConfigurationsRead(context context.Context, d *schema.Resour
 
 	region := getRegion(secretsManagerClient, d)
 	instanceId := d.Get("instance_id").(string)
-	secretsManagerClient = getClientWithInstanceEndpoint(secretsManagerClient, instanceId, region, getEndpointType(secretsManagerClient, d))
+	secretsManagerClient = getClientWithInstanceEndpoint(secretsManagerClient, instanceId, region, getEndpointType(secretsManagerClient, d), endpointsFile)
 
 	listConfigurationsOptions := &secretsmanagerv2.ListConfigurationsOptions{}
 	sort, ok := d.GetOk("sort")

--- a/ibm/service/secretsmanager/data_source_ibm_sm_en_registration.go
+++ b/ibm/service/secretsmanager/data_source_ibm_sm_en_registration.go
@@ -30,7 +30,7 @@ func DataSourceIbmSmEnRegistration() *schema.Resource {
 }
 
 func dataSourceIbmSmEnRegistrationRead(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	secretsManagerClient, err := meta.(conns.ClientSession).SecretsManagerV2()
+	secretsManagerClient, endpointsFile, err := getSecretsManagerSession(meta.(conns.ClientSession))
 	if err != nil {
 		tfErr := flex.TerraformErrorf(err, "", fmt.Sprintf("(Data) %s", EnRegistrationResourceName), "read")
 		return tfErr.GetDiag()
@@ -38,7 +38,7 @@ func dataSourceIbmSmEnRegistrationRead(context context.Context, d *schema.Resour
 
 	region := getRegion(secretsManagerClient, d)
 	instanceId := d.Get("instance_id").(string)
-	secretsManagerClient = getClientWithInstanceEndpoint(secretsManagerClient, instanceId, region, getEndpointType(secretsManagerClient, d))
+	secretsManagerClient = getClientWithInstanceEndpoint(secretsManagerClient, instanceId, region, getEndpointType(secretsManagerClient, d), endpointsFile)
 
 	getNotificationsRegistrationOptions := &secretsmanagerv2.GetNotificationsRegistrationOptions{}
 

--- a/ibm/service/secretsmanager/data_source_ibm_sm_iam_credentials_configuration.go
+++ b/ibm/service/secretsmanager/data_source_ibm_sm_iam_credentials_configuration.go
@@ -67,7 +67,7 @@ func DataSourceIbmSmIamCredentialsConfiguration() *schema.Resource {
 }
 
 func dataSourceIbmSmIamCredentialsConfigurationRead(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	secretsManagerClient, err := meta.(conns.ClientSession).SecretsManagerV2()
+	secretsManagerClient, endpointsFile, err := getSecretsManagerSession(meta.(conns.ClientSession))
 	if err != nil {
 		tfErr := flex.TerraformErrorf(err, "", fmt.Sprintf("(Data) %s", IAMCredentialsConfigResourceName), "read")
 		return tfErr.GetDiag()
@@ -75,7 +75,7 @@ func dataSourceIbmSmIamCredentialsConfigurationRead(context context.Context, d *
 
 	region := getRegion(secretsManagerClient, d)
 	instanceId := d.Get("instance_id").(string)
-	secretsManagerClient = getClientWithInstanceEndpoint(secretsManagerClient, instanceId, region, getEndpointType(secretsManagerClient, d))
+	secretsManagerClient = getClientWithInstanceEndpoint(secretsManagerClient, instanceId, region, getEndpointType(secretsManagerClient, d), endpointsFile)
 
 	getConfigurationOptions := &secretsmanagerv2.GetConfigurationOptions{}
 

--- a/ibm/service/secretsmanager/data_source_ibm_sm_iam_credentials_secret_metadata.go
+++ b/ibm/service/secretsmanager/data_source_ibm_sm_iam_credentials_secret_metadata.go
@@ -184,7 +184,7 @@ func DataSourceIbmSmIamCredentialsSecretMetadata() *schema.Resource {
 }
 
 func dataSourceIbmSmIamCredentialsSecretMetadataRead(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	secretsManagerClient, err := meta.(conns.ClientSession).SecretsManagerV2()
+	secretsManagerClient, endpointsFile, err := getSecretsManagerSession(meta.(conns.ClientSession))
 	if err != nil {
 		tfErr := flex.TerraformErrorf(err, "", fmt.Sprintf("(Data) %s_metadata", IAMCredentialsSecretResourceName), "read")
 		return tfErr.GetDiag()
@@ -192,7 +192,7 @@ func dataSourceIbmSmIamCredentialsSecretMetadataRead(context context.Context, d 
 
 	region := getRegion(secretsManagerClient, d)
 	instanceId := d.Get("instance_id").(string)
-	secretsManagerClient = getClientWithInstanceEndpoint(secretsManagerClient, instanceId, region, getEndpointType(secretsManagerClient, d))
+	secretsManagerClient = getClientWithInstanceEndpoint(secretsManagerClient, instanceId, region, getEndpointType(secretsManagerClient, d), endpointsFile)
 
 	getSecretMetadataOptions := &secretsmanagerv2.GetSecretMetadataOptions{}
 

--- a/ibm/service/secretsmanager/data_source_ibm_sm_imported_certificate_metadata.go
+++ b/ibm/service/secretsmanager/data_source_ibm_sm_imported_certificate_metadata.go
@@ -336,7 +336,7 @@ func DataSourceIbmSmImportedCertificateMetadata() *schema.Resource {
 }
 
 func dataSourceIbmSmImportedCertificateMetadataRead(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	secretsManagerClient, err := meta.(conns.ClientSession).SecretsManagerV2()
+	secretsManagerClient, endpointsFile, err := getSecretsManagerSession(meta.(conns.ClientSession))
 	if err != nil {
 		tfErr := flex.TerraformErrorf(err, "", fmt.Sprintf("(Data) %s_metadata", ImportedCertSecretResourceName), "read")
 		return tfErr.GetDiag()
@@ -344,7 +344,7 @@ func dataSourceIbmSmImportedCertificateMetadataRead(context context.Context, d *
 
 	region := getRegion(secretsManagerClient, d)
 	instanceId := d.Get("instance_id").(string)
-	secretsManagerClient = getClientWithInstanceEndpoint(secretsManagerClient, instanceId, region, getEndpointType(secretsManagerClient, d))
+	secretsManagerClient = getClientWithInstanceEndpoint(secretsManagerClient, instanceId, region, getEndpointType(secretsManagerClient, d), endpointsFile)
 
 	getSecretMetadataOptions := &secretsmanagerv2.GetSecretMetadataOptions{}
 

--- a/ibm/service/secretsmanager/data_source_ibm_sm_kv_secret_metadata.go
+++ b/ibm/service/secretsmanager/data_source_ibm_sm_kv_secret_metadata.go
@@ -112,7 +112,7 @@ func DataSourceIbmSmKvSecretMetadata() *schema.Resource {
 }
 
 func dataSourceIbmSmKvSecretMetadataRead(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	secretsManagerClient, err := meta.(conns.ClientSession).SecretsManagerV2()
+	secretsManagerClient, endpointsFile, err := getSecretsManagerSession(meta.(conns.ClientSession))
 	if err != nil {
 		tfErr := flex.TerraformErrorf(err, "", fmt.Sprintf("(Data) %s_metadata", KvSecretResourceName), "read")
 		return tfErr.GetDiag()
@@ -120,7 +120,7 @@ func dataSourceIbmSmKvSecretMetadataRead(context context.Context, d *schema.Reso
 
 	region := getRegion(secretsManagerClient, d)
 	instanceId := d.Get("instance_id").(string)
-	secretsManagerClient = getClientWithInstanceEndpoint(secretsManagerClient, instanceId, region, getEndpointType(secretsManagerClient, d))
+	secretsManagerClient = getClientWithInstanceEndpoint(secretsManagerClient, instanceId, region, getEndpointType(secretsManagerClient, d), endpointsFile)
 
 	getSecretMetadataOptions := &secretsmanagerv2.GetSecretMetadataOptions{}
 

--- a/ibm/service/secretsmanager/data_source_ibm_sm_private_certificate_configuration_intermediate_ca.go
+++ b/ibm/service/secretsmanager/data_source_ibm_sm_private_certificate_configuration_intermediate_ca.go
@@ -307,7 +307,7 @@ func DataSourceIbmSmPrivateCertificateConfigurationIntermediateCA() *schema.Reso
 }
 
 func dataSourceIbmSmPrivateCertificateConfigurationIntermediateCARead(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	secretsManagerClient, err := meta.(conns.ClientSession).SecretsManagerV2()
+	secretsManagerClient, endpointsFile, err := getSecretsManagerSession(meta.(conns.ClientSession))
 	if err != nil {
 		tfErr := flex.TerraformErrorf(err, "", fmt.Sprintf("(Data) %s", PrivateCertConfigIntermediateCAResourceName), "read")
 		return tfErr.GetDiag()
@@ -315,7 +315,7 @@ func dataSourceIbmSmPrivateCertificateConfigurationIntermediateCARead(context co
 
 	region := getRegion(secretsManagerClient, d)
 	instanceId := d.Get("instance_id").(string)
-	secretsManagerClient = getClientWithInstanceEndpoint(secretsManagerClient, instanceId, region, getEndpointType(secretsManagerClient, d))
+	secretsManagerClient = getClientWithInstanceEndpoint(secretsManagerClient, instanceId, region, getEndpointType(secretsManagerClient, d), endpointsFile)
 
 	getConfigurationOptions := &secretsmanagerv2.GetConfigurationOptions{}
 

--- a/ibm/service/secretsmanager/data_source_ibm_sm_private_certificate_configuration_root_ca.go
+++ b/ibm/service/secretsmanager/data_source_ibm_sm_private_certificate_configuration_root_ca.go
@@ -331,7 +331,7 @@ func DataSourceIbmSmPrivateCertificateConfigurationRootCA() *schema.Resource {
 }
 
 func dataSourceIbmSmPrivateCertificateConfigurationRootCARead(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	secretsManagerClient, err := meta.(conns.ClientSession).SecretsManagerV2()
+	secretsManagerClient, endpointsFile, err := getSecretsManagerSession(meta.(conns.ClientSession))
 	if err != nil {
 		tfErr := flex.TerraformErrorf(err, "", fmt.Sprintf("(Data) %s", PrivateCertConfigRootCAResourceName), "read")
 		return tfErr.GetDiag()
@@ -339,7 +339,7 @@ func dataSourceIbmSmPrivateCertificateConfigurationRootCARead(context context.Co
 
 	region := getRegion(secretsManagerClient, d)
 	instanceId := d.Get("instance_id").(string)
-	secretsManagerClient = getClientWithInstanceEndpoint(secretsManagerClient, instanceId, region, getEndpointType(secretsManagerClient, d))
+	secretsManagerClient = getClientWithInstanceEndpoint(secretsManagerClient, instanceId, region, getEndpointType(secretsManagerClient, d), endpointsFile)
 
 	getConfigurationOptions := &secretsmanagerv2.GetConfigurationOptions{}
 

--- a/ibm/service/secretsmanager/data_source_ibm_sm_private_certificate_configuration_template.go
+++ b/ibm/service/secretsmanager/data_source_ibm_sm_private_certificate_configuration_template.go
@@ -288,7 +288,7 @@ func DataSourceIbmSmPrivateCertificateConfigurationTemplate() *schema.Resource {
 }
 
 func dataSourceIbmSmPrivateCertificateConfigurationTemplateRead(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	secretsManagerClient, err := meta.(conns.ClientSession).SecretsManagerV2()
+	secretsManagerClient, endpointsFile, err := getSecretsManagerSession(meta.(conns.ClientSession))
 	if err != nil {
 		tfErr := flex.TerraformErrorf(err, "", fmt.Sprintf("(Data) %s", PrivateCertConfigTemplateResourceName), "read")
 		return tfErr.GetDiag()
@@ -296,7 +296,7 @@ func dataSourceIbmSmPrivateCertificateConfigurationTemplateRead(context context.
 
 	region := getRegion(secretsManagerClient, d)
 	instanceId := d.Get("instance_id").(string)
-	secretsManagerClient = getClientWithInstanceEndpoint(secretsManagerClient, instanceId, region, getEndpointType(secretsManagerClient, d))
+	secretsManagerClient = getClientWithInstanceEndpoint(secretsManagerClient, instanceId, region, getEndpointType(secretsManagerClient, d), endpointsFile)
 
 	getConfigurationOptions := &secretsmanagerv2.GetConfigurationOptions{}
 

--- a/ibm/service/secretsmanager/data_source_ibm_sm_private_certificate_metadata.go
+++ b/ibm/service/secretsmanager/data_source_ibm_sm_private_certificate_metadata.go
@@ -218,7 +218,7 @@ func DataSourceIbmSmPrivateCertificateMetadata() *schema.Resource {
 }
 
 func dataSourceIbmSmPrivateCertificateMetadataRead(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	secretsManagerClient, err := meta.(conns.ClientSession).SecretsManagerV2()
+	secretsManagerClient, endpointsFile, err := getSecretsManagerSession(meta.(conns.ClientSession))
 	if err != nil {
 		tfErr := flex.TerraformErrorf(err, "", fmt.Sprintf("(Data) %s_metadata", PrivateCertSecretResourceName), "read")
 		return tfErr.GetDiag()
@@ -226,7 +226,7 @@ func dataSourceIbmSmPrivateCertificateMetadataRead(context context.Context, d *s
 
 	region := getRegion(secretsManagerClient, d)
 	instanceId := d.Get("instance_id").(string)
-	secretsManagerClient = getClientWithInstanceEndpoint(secretsManagerClient, instanceId, region, getEndpointType(secretsManagerClient, d))
+	secretsManagerClient = getClientWithInstanceEndpoint(secretsManagerClient, instanceId, region, getEndpointType(secretsManagerClient, d), endpointsFile)
 
 	getSecretMetadataOptions := &secretsmanagerv2.GetSecretMetadataOptions{}
 

--- a/ibm/service/secretsmanager/data_source_ibm_sm_public_certificate_configuration_ca_lets_encrypt.go
+++ b/ibm/service/secretsmanager/data_source_ibm_sm_public_certificate_configuration_ca_lets_encrypt.go
@@ -62,7 +62,7 @@ func DataSourceIbmSmPublicCertificateConfigurationCALetsEncrypt() *schema.Resour
 }
 
 func dataSourceIbmSmPublicCertificateConfigurationCALetsEncryptRead(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	secretsManagerClient, err := meta.(conns.ClientSession).SecretsManagerV2()
+	secretsManagerClient, endpointsFile, err := getSecretsManagerSession(meta.(conns.ClientSession))
 	if err != nil {
 		tfErr := flex.TerraformErrorf(err, "", fmt.Sprintf("(Data) %s", PublicCertConfigCALetsEncryptResourceName), "read")
 		return tfErr.GetDiag()
@@ -70,7 +70,7 @@ func dataSourceIbmSmPublicCertificateConfigurationCALetsEncryptRead(context cont
 
 	region := getRegion(secretsManagerClient, d)
 	instanceId := d.Get("instance_id").(string)
-	secretsManagerClient = getClientWithInstanceEndpoint(secretsManagerClient, instanceId, region, getEndpointType(secretsManagerClient, d))
+	secretsManagerClient = getClientWithInstanceEndpoint(secretsManagerClient, instanceId, region, getEndpointType(secretsManagerClient, d), endpointsFile)
 
 	getConfigurationOptions := &secretsmanagerv2.GetConfigurationOptions{}
 

--- a/ibm/service/secretsmanager/data_source_ibm_sm_public_certificate_configuration_dns_cis.go
+++ b/ibm/service/secretsmanager/data_source_ibm_sm_public_certificate_configuration_dns_cis.go
@@ -66,7 +66,7 @@ func DataSourceIbmSmConfigurationPublicCertificateDNSCis() *schema.Resource {
 }
 
 func dataSourceIbmSmConfigurationPublicCertificateDNSCisRead(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	secretsManagerClient, err := meta.(conns.ClientSession).SecretsManagerV2()
+	secretsManagerClient, endpointsFile, err := getSecretsManagerSession(meta.(conns.ClientSession))
 	if err != nil {
 		tfErr := flex.TerraformErrorf(err, "", fmt.Sprintf("(Data) %s", PublicCertConfigDnsCISResourceName), "read")
 		return tfErr.GetDiag()
@@ -74,7 +74,7 @@ func dataSourceIbmSmConfigurationPublicCertificateDNSCisRead(context context.Con
 
 	region := getRegion(secretsManagerClient, d)
 	instanceId := d.Get("instance_id").(string)
-	secretsManagerClient = getClientWithInstanceEndpoint(secretsManagerClient, instanceId, region, getEndpointType(secretsManagerClient, d))
+	secretsManagerClient = getClientWithInstanceEndpoint(secretsManagerClient, instanceId, region, getEndpointType(secretsManagerClient, d), endpointsFile)
 
 	getConfigurationOptions := &secretsmanagerv2.GetConfigurationOptions{}
 

--- a/ibm/service/secretsmanager/data_source_ibm_sm_public_certificate_configuration_dns_classic_infrastructure.go
+++ b/ibm/service/secretsmanager/data_source_ibm_sm_public_certificate_configuration_dns_classic_infrastructure.go
@@ -66,7 +66,7 @@ func DataSourceIbmSmPublicCertificateConfigurationDNSClassicInfrastructure() *sc
 }
 
 func dataSourceIbmSmPublicCertificateConfigurationDNSClassicInfrastructureRead(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	secretsManagerClient, err := meta.(conns.ClientSession).SecretsManagerV2()
+	secretsManagerClient, endpointsFile, err := getSecretsManagerSession(meta.(conns.ClientSession))
 	if err != nil {
 		tfErr := flex.TerraformErrorf(err, "", fmt.Sprintf("(Data) %s", PublicCertConfigDnsClassicInfrastructureResourceName), "read")
 		return tfErr.GetDiag()
@@ -74,7 +74,7 @@ func dataSourceIbmSmPublicCertificateConfigurationDNSClassicInfrastructureRead(c
 
 	region := getRegion(secretsManagerClient, d)
 	instanceId := d.Get("instance_id").(string)
-	secretsManagerClient = getClientWithInstanceEndpoint(secretsManagerClient, instanceId, region, getEndpointType(secretsManagerClient, d))
+	secretsManagerClient = getClientWithInstanceEndpoint(secretsManagerClient, instanceId, region, getEndpointType(secretsManagerClient, d), endpointsFile)
 
 	getConfigurationOptions := &secretsmanagerv2.GetConfigurationOptions{}
 

--- a/ibm/service/secretsmanager/data_source_ibm_sm_public_certificate_metadata.go
+++ b/ibm/service/secretsmanager/data_source_ibm_sm_public_certificate_metadata.go
@@ -281,7 +281,7 @@ func DataSourceIbmSmPublicCertificateMetadata() *schema.Resource {
 }
 
 func dataSourceIbmSmPublicCertificateMetadataRead(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	secretsManagerClient, err := meta.(conns.ClientSession).SecretsManagerV2()
+	secretsManagerClient, endpointsFile, err := getSecretsManagerSession(meta.(conns.ClientSession))
 	if err != nil {
 		tfErr := flex.TerraformErrorf(err, "", fmt.Sprintf("(Data) %s_metadata", PublicCertSecretResourceName), "read")
 		return tfErr.GetDiag()
@@ -289,7 +289,7 @@ func dataSourceIbmSmPublicCertificateMetadataRead(context context.Context, d *sc
 
 	region := getRegion(secretsManagerClient, d)
 	instanceId := d.Get("instance_id").(string)
-	secretsManagerClient = getClientWithInstanceEndpoint(secretsManagerClient, instanceId, region, getEndpointType(secretsManagerClient, d))
+	secretsManagerClient = getClientWithInstanceEndpoint(secretsManagerClient, instanceId, region, getEndpointType(secretsManagerClient, d), endpointsFile)
 
 	getSecretMetadataOptions := &secretsmanagerv2.GetSecretMetadataOptions{}
 

--- a/ibm/service/secretsmanager/data_source_ibm_sm_secret_group.go
+++ b/ibm/service/secretsmanager/data_source_ibm_sm_secret_group.go
@@ -51,7 +51,7 @@ func DataSourceIbmSmSecretGroup() *schema.Resource {
 }
 
 func dataSourceIbmSmSecretGroupRead(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	secretsManagerClient, err := meta.(conns.ClientSession).SecretsManagerV2()
+	secretsManagerClient, endpointsFile, err := getSecretsManagerSession(meta.(conns.ClientSession))
 	if err != nil {
 		tfErr := flex.TerraformErrorf(err, "", fmt.Sprintf("(Data) %s", SecretGroupResourceName), "read")
 		return tfErr.GetDiag()
@@ -59,7 +59,7 @@ func dataSourceIbmSmSecretGroupRead(context context.Context, d *schema.ResourceD
 
 	region := getRegion(secretsManagerClient, d)
 	instanceId := d.Get("instance_id").(string)
-	secretsManagerClient = getClientWithInstanceEndpoint(secretsManagerClient, instanceId, region, getEndpointType(secretsManagerClient, d))
+	secretsManagerClient = getClientWithInstanceEndpoint(secretsManagerClient, instanceId, region, getEndpointType(secretsManagerClient, d), endpointsFile)
 
 	getSecretGroupOptions := &secretsmanagerv2.GetSecretGroupOptions{}
 

--- a/ibm/service/secretsmanager/data_source_ibm_sm_secret_groups.go
+++ b/ibm/service/secretsmanager/data_source_ibm_sm_secret_groups.go
@@ -66,7 +66,7 @@ func DataSourceIbmSmSecretGroups() *schema.Resource {
 }
 
 func dataSourceIbmSmSecretGroupsRead(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	secretsManagerClient, err := meta.(conns.ClientSession).SecretsManagerV2()
+	secretsManagerClient, endpointsFile, err := getSecretsManagerSession(meta.(conns.ClientSession))
 	if err != nil {
 		tfErr := flex.TerraformErrorf(err, "", fmt.Sprintf("(Data) %s", SecretGroupsResourceName), "read")
 		return tfErr.GetDiag()
@@ -74,7 +74,7 @@ func dataSourceIbmSmSecretGroupsRead(context context.Context, d *schema.Resource
 
 	region := getRegion(secretsManagerClient, d)
 	instanceId := d.Get("instance_id").(string)
-	secretsManagerClient = getClientWithInstanceEndpoint(secretsManagerClient, instanceId, region, getEndpointType(secretsManagerClient, d))
+	secretsManagerClient = getClientWithInstanceEndpoint(secretsManagerClient, instanceId, region, getEndpointType(secretsManagerClient, d), endpointsFile)
 
 	listSecretGroupsOptions := &secretsmanagerv2.ListSecretGroupsOptions{}
 

--- a/ibm/service/secretsmanager/data_source_ibm_sm_secrets.go
+++ b/ibm/service/secretsmanager/data_source_ibm_sm_secrets.go
@@ -517,7 +517,7 @@ func DataSourceIbmSmSecrets() *schema.Resource {
 }
 
 func dataSourceIbmSmSecretsRead(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	secretsManagerClient, err := meta.(conns.ClientSession).SecretsManagerV2()
+	secretsManagerClient, endpointsFile, err := getSecretsManagerSession(meta.(conns.ClientSession))
 	if err != nil {
 		tfErr := flex.TerraformErrorf(err, "", fmt.Sprintf("(Data) %s", SecretsResourceName), "read")
 		return tfErr.GetDiag()
@@ -525,7 +525,7 @@ func dataSourceIbmSmSecretsRead(context context.Context, d *schema.ResourceData,
 
 	region := getRegion(secretsManagerClient, d)
 	instanceId := d.Get("instance_id").(string)
-	secretsManagerClient = getClientWithInstanceEndpoint(secretsManagerClient, instanceId, region, getEndpointType(secretsManagerClient, d))
+	secretsManagerClient = getClientWithInstanceEndpoint(secretsManagerClient, instanceId, region, getEndpointType(secretsManagerClient, d), endpointsFile)
 
 	listSecretsOptions := &secretsmanagerv2.ListSecretsOptions{}
 	sort, ok := d.GetOk("sort")

--- a/ibm/service/secretsmanager/data_source_ibm_sm_service_credentials_secret_metadata.go
+++ b/ibm/service/secretsmanager/data_source_ibm_sm_service_credentials_secret_metadata.go
@@ -263,7 +263,7 @@ func DataSourceIbmSmServiceCredentialsSecretMetadata() *schema.Resource {
 }
 
 func dataSourceIbmSmServiceCredentialsSecretMetadataRead(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	secretsManagerClient, err := meta.(conns.ClientSession).SecretsManagerV2()
+	secretsManagerClient, endpointsFile, err := getSecretsManagerSession(meta.(conns.ClientSession))
 	if err != nil {
 		tfErr := flex.TerraformErrorf(err, "", fmt.Sprintf("(Data) %s_metadata", ServiceCredentialsSecretResourceName), "read")
 		return tfErr.GetDiag()
@@ -271,7 +271,7 @@ func dataSourceIbmSmServiceCredentialsSecretMetadataRead(context context.Context
 
 	region := getRegion(secretsManagerClient, d)
 	instanceId := d.Get("instance_id").(string)
-	secretsManagerClient = getClientWithInstanceEndpoint(secretsManagerClient, instanceId, region, getEndpointType(secretsManagerClient, d))
+	secretsManagerClient = getClientWithInstanceEndpoint(secretsManagerClient, instanceId, region, getEndpointType(secretsManagerClient, d), endpointsFile)
 
 	getSecretMetadataOptions := &secretsmanagerv2.GetSecretMetadataOptions{}
 

--- a/ibm/service/secretsmanager/data_source_ibm_sm_username_password_secret_metadata.go
+++ b/ibm/service/secretsmanager/data_source_ibm_sm_username_password_secret_metadata.go
@@ -175,7 +175,7 @@ func DataSourceIbmSmUsernamePasswordSecretMetadata() *schema.Resource {
 }
 
 func dataSourceIbmSmUsernamePasswordSecretMetadataRead(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	secretsManagerClient, err := meta.(conns.ClientSession).SecretsManagerV2()
+	secretsManagerClient, endpointsFile, err := getSecretsManagerSession(meta.(conns.ClientSession))
 	if err != nil {
 		tfErr := flex.TerraformErrorf(err, "", fmt.Sprintf("(Data) %s_metadata", UsernamePasswordSecretResourceName), "read")
 		return tfErr.GetDiag()
@@ -183,7 +183,7 @@ func dataSourceIbmSmUsernamePasswordSecretMetadataRead(context context.Context, 
 
 	region := getRegion(secretsManagerClient, d)
 	instanceId := d.Get("instance_id").(string)
-	secretsManagerClient = getClientWithInstanceEndpoint(secretsManagerClient, instanceId, region, getEndpointType(secretsManagerClient, d))
+	secretsManagerClient = getClientWithInstanceEndpoint(secretsManagerClient, instanceId, region, getEndpointType(secretsManagerClient, d), endpointsFile)
 
 	getSecretMetadataOptions := &secretsmanagerv2.GetSecretMetadataOptions{}
 

--- a/ibm/service/secretsmanager/resource_ibm_sm_arbitrary_secret.go
+++ b/ibm/service/secretsmanager/resource_ibm_sm_arbitrary_secret.go
@@ -142,7 +142,7 @@ func ResourceIbmSmArbitrarySecret() *schema.Resource {
 }
 
 func resourceIbmSmArbitrarySecretCreate(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	secretsManagerClient, err := meta.(conns.ClientSession).SecretsManagerV2()
+	secretsManagerClient, endpointsFile, err := getSecretsManagerSession(meta.(conns.ClientSession))
 	if err != nil {
 		tfErr := flex.TerraformErrorf(err, "", ArbitrarySecretResourceName, "create")
 		return tfErr.GetDiag()
@@ -150,7 +150,7 @@ func resourceIbmSmArbitrarySecretCreate(context context.Context, d *schema.Resou
 
 	region := getRegion(secretsManagerClient, d)
 	instanceId := d.Get("instance_id").(string)
-	secretsManagerClient = getClientWithInstanceEndpoint(secretsManagerClient, instanceId, region, getEndpointType(secretsManagerClient, d))
+	secretsManagerClient = getClientWithInstanceEndpoint(secretsManagerClient, instanceId, region, getEndpointType(secretsManagerClient, d), endpointsFile)
 
 	createSecretOptions := &secretsmanagerv2.CreateSecretOptions{}
 
@@ -215,7 +215,7 @@ func waitForIbmSmArbitrarySecretCreate(secretsManagerClient *secretsmanagerv2.Se
 }
 
 func resourceIbmSmArbitrarySecretRead(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	secretsManagerClient, err := meta.(conns.ClientSession).SecretsManagerV2()
+	secretsManagerClient, endpointsFile, err := getSecretsManagerSession(meta.(conns.ClientSession))
 	if err != nil {
 		tfErr := flex.TerraformErrorf(err, "", ArbitrarySecretResourceName, "read")
 		return tfErr.GetDiag()
@@ -229,7 +229,7 @@ func resourceIbmSmArbitrarySecretRead(context context.Context, d *schema.Resourc
 	region := id[0]
 	instanceId := id[1]
 	secretId := id[2]
-	secretsManagerClient = getClientWithInstanceEndpoint(secretsManagerClient, instanceId, region, getEndpointType(secretsManagerClient, d))
+	secretsManagerClient = getClientWithInstanceEndpoint(secretsManagerClient, instanceId, region, getEndpointType(secretsManagerClient, d), endpointsFile)
 
 	getSecretOptions := &secretsmanagerv2.GetSecretOptions{}
 
@@ -354,7 +354,7 @@ func resourceIbmSmArbitrarySecretRead(context context.Context, d *schema.Resourc
 }
 
 func resourceIbmSmArbitrarySecretUpdate(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	secretsManagerClient, err := meta.(conns.ClientSession).SecretsManagerV2()
+	secretsManagerClient, endpointsFile, err := getSecretsManagerSession(meta.(conns.ClientSession))
 	if err != nil {
 		tfErr := flex.TerraformErrorf(err, "", ArbitrarySecretResourceName, "update")
 		return tfErr.GetDiag()
@@ -364,7 +364,7 @@ func resourceIbmSmArbitrarySecretUpdate(context context.Context, d *schema.Resou
 	region := id[0]
 	instanceId := id[1]
 	secretId := id[2]
-	secretsManagerClient = getClientWithInstanceEndpoint(secretsManagerClient, instanceId, region, getEndpointType(secretsManagerClient, d))
+	secretsManagerClient = getClientWithInstanceEndpoint(secretsManagerClient, instanceId, region, getEndpointType(secretsManagerClient, d), endpointsFile)
 
 	updateSecretMetadataOptions := &secretsmanagerv2.UpdateSecretMetadataOptions{}
 
@@ -475,7 +475,7 @@ func resourceIbmSmArbitrarySecretUpdate(context context.Context, d *schema.Resou
 }
 
 func resourceIbmSmArbitrarySecretDelete(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	secretsManagerClient, err := meta.(conns.ClientSession).SecretsManagerV2()
+	secretsManagerClient, endpointsFile, err := getSecretsManagerSession(meta.(conns.ClientSession))
 	if err != nil {
 		tfErr := flex.TerraformErrorf(err, "", ArbitrarySecretResourceName, "delete")
 		return tfErr.GetDiag()
@@ -485,7 +485,7 @@ func resourceIbmSmArbitrarySecretDelete(context context.Context, d *schema.Resou
 	region := id[0]
 	instanceId := id[1]
 	secretId := id[2]
-	secretsManagerClient = getClientWithInstanceEndpoint(secretsManagerClient, instanceId, region, getEndpointType(secretsManagerClient, d))
+	secretsManagerClient = getClientWithInstanceEndpoint(secretsManagerClient, instanceId, region, getEndpointType(secretsManagerClient, d), endpointsFile)
 
 	deleteSecretOptions := &secretsmanagerv2.DeleteSecretOptions{}
 

--- a/ibm/service/secretsmanager/resource_ibm_sm_en_registration.go
+++ b/ibm/service/secretsmanager/resource_ibm_sm_en_registration.go
@@ -89,7 +89,7 @@ func ResourceIbmSmEnRegistrationValidator() *validate.ResourceValidator {
 }
 
 func resourceIbmSmEnRegistrationCreate(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	secretsManagerClient, err := meta.(conns.ClientSession).SecretsManagerV2()
+	secretsManagerClient, endpointsFile, err := getSecretsManagerSession(meta.(conns.ClientSession))
 	if err != nil {
 		tfErr := flex.TerraformErrorf(err, "", EnRegistrationResourceName, "create")
 		return tfErr.GetDiag()
@@ -97,7 +97,7 @@ func resourceIbmSmEnRegistrationCreate(context context.Context, d *schema.Resour
 
 	region := getRegion(secretsManagerClient, d)
 	instanceId := d.Get("instance_id").(string)
-	secretsManagerClient = getClientWithInstanceEndpoint(secretsManagerClient, instanceId, region, getEndpointType(secretsManagerClient, d))
+	secretsManagerClient = getClientWithInstanceEndpoint(secretsManagerClient, instanceId, region, getEndpointType(secretsManagerClient, d), endpointsFile)
 
 	createNotificationsRegistrationOptions := &secretsmanagerv2.CreateNotificationsRegistrationOptions{}
 
@@ -120,7 +120,7 @@ func resourceIbmSmEnRegistrationCreate(context context.Context, d *schema.Resour
 }
 
 func resourceIbmSmEnRegistrationRead(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	secretsManagerClient, err := meta.(conns.ClientSession).SecretsManagerV2()
+	secretsManagerClient, endpointsFile, err := getSecretsManagerSession(meta.(conns.ClientSession))
 	if err != nil {
 		tfErr := flex.TerraformErrorf(err, "", EnRegistrationResourceName, "read")
 		return tfErr.GetDiag()
@@ -133,7 +133,7 @@ func resourceIbmSmEnRegistrationRead(context context.Context, d *schema.Resource
 	}
 	region := id[0]
 	instanceId := id[1]
-	secretsManagerClient = getClientWithInstanceEndpoint(secretsManagerClient, instanceId, region, getEndpointType(secretsManagerClient, d))
+	secretsManagerClient = getClientWithInstanceEndpoint(secretsManagerClient, instanceId, region, getEndpointType(secretsManagerClient, d), endpointsFile)
 
 	getNotificationsRegistrationOptions := &secretsmanagerv2.GetNotificationsRegistrationOptions{}
 
@@ -165,7 +165,7 @@ func resourceIbmSmEnRegistrationRead(context context.Context, d *schema.Resource
 }
 
 func resourceIbmSmEnRegistrationUpdate(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	secretsManagerClient, err := meta.(conns.ClientSession).SecretsManagerV2()
+	secretsManagerClient, endpointsFile, err := getSecretsManagerSession(meta.(conns.ClientSession))
 	if err != nil {
 		tfErr := flex.TerraformErrorf(err, fmt.Sprintf(""), EnRegistrationResourceName, "update")
 		return tfErr.GetDiag()
@@ -174,7 +174,7 @@ func resourceIbmSmEnRegistrationUpdate(context context.Context, d *schema.Resour
 	id := strings.Split(d.Id(), "/")
 	region := id[0]
 	instanceId := id[1]
-	secretsManagerClient = getClientWithInstanceEndpoint(secretsManagerClient, instanceId, region, getEndpointType(secretsManagerClient, d))
+	secretsManagerClient = getClientWithInstanceEndpoint(secretsManagerClient, instanceId, region, getEndpointType(secretsManagerClient, d), endpointsFile)
 
 	createNotificationsRegistrationOptions := &secretsmanagerv2.CreateNotificationsRegistrationOptions{}
 
@@ -203,7 +203,7 @@ func resourceIbmSmEnRegistrationUpdate(context context.Context, d *schema.Resour
 }
 
 func resourceIbmSmEnRegistrationDelete(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	secretsManagerClient, err := meta.(conns.ClientSession).SecretsManagerV2()
+	secretsManagerClient, endpointsFile, err := getSecretsManagerSession(meta.(conns.ClientSession))
 	if err != nil {
 		tfErr := flex.TerraformErrorf(err, "", EnRegistrationResourceName, "delete")
 		return tfErr.GetDiag()
@@ -212,7 +212,7 @@ func resourceIbmSmEnRegistrationDelete(context context.Context, d *schema.Resour
 	id := strings.Split(d.Id(), "/")
 	region := id[0]
 	instanceId := id[1]
-	secretsManagerClient = getClientWithInstanceEndpoint(secretsManagerClient, instanceId, region, getEndpointType(secretsManagerClient, d))
+	secretsManagerClient = getClientWithInstanceEndpoint(secretsManagerClient, instanceId, region, getEndpointType(secretsManagerClient, d), endpointsFile)
 
 	deleteNotificationsRegistrationOptions := &secretsmanagerv2.DeleteNotificationsRegistrationOptions{}
 

--- a/ibm/service/secretsmanager/resource_ibm_sm_iam_credentials_configuration.go
+++ b/ibm/service/secretsmanager/resource_ibm_sm_iam_credentials_configuration.go
@@ -75,7 +75,7 @@ func ResourceIbmSmIamCredentialsConfiguration() *schema.Resource {
 }
 
 func resourceIbmSmIamCredentialsConfigurationCreate(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	secretsManagerClient, err := meta.(conns.ClientSession).SecretsManagerV2()
+	secretsManagerClient, endpointsFile, err := getSecretsManagerSession(meta.(conns.ClientSession))
 	if err != nil {
 		tfErr := flex.TerraformErrorf(err, "", IAMCredentialsConfigResourceName, "create")
 		return tfErr.GetDiag()
@@ -83,7 +83,7 @@ func resourceIbmSmIamCredentialsConfigurationCreate(context context.Context, d *
 
 	region := getRegion(secretsManagerClient, d)
 	instanceId := d.Get("instance_id").(string)
-	secretsManagerClient = getClientWithInstanceEndpoint(secretsManagerClient, instanceId, region, getEndpointType(secretsManagerClient, d))
+	secretsManagerClient = getClientWithInstanceEndpoint(secretsManagerClient, instanceId, region, getEndpointType(secretsManagerClient, d), endpointsFile)
 
 	createConfigurationOptions := &secretsmanagerv2.CreateConfigurationOptions{}
 
@@ -108,7 +108,7 @@ func resourceIbmSmIamCredentialsConfigurationCreate(context context.Context, d *
 }
 
 func resourceIbmSmIamCredentialsConfigurationRead(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	secretsManagerClient, err := meta.(conns.ClientSession).SecretsManagerV2()
+	secretsManagerClient, endpointsFile, err := getSecretsManagerSession(meta.(conns.ClientSession))
 	if err != nil {
 		tfErr := flex.TerraformErrorf(err, "", IAMCredentialsConfigResourceName, "read")
 		return tfErr.GetDiag()
@@ -122,7 +122,7 @@ func resourceIbmSmIamCredentialsConfigurationRead(context context.Context, d *sc
 	region := id[0]
 	instanceId := id[1]
 	configName := id[2]
-	secretsManagerClient = getClientWithInstanceEndpoint(secretsManagerClient, instanceId, region, getEndpointType(secretsManagerClient, d))
+	secretsManagerClient = getClientWithInstanceEndpoint(secretsManagerClient, instanceId, region, getEndpointType(secretsManagerClient, d), endpointsFile)
 
 	getConfigurationOptions := &secretsmanagerv2.GetConfigurationOptions{}
 
@@ -181,7 +181,7 @@ func resourceIbmSmIamCredentialsConfigurationRead(context context.Context, d *sc
 }
 
 func resourceIbmSmIamCredentialsConfigurationUpdate(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	secretsManagerClient, err := meta.(conns.ClientSession).SecretsManagerV2()
+	secretsManagerClient, endpointsFile, err := getSecretsManagerSession(meta.(conns.ClientSession))
 	if err != nil {
 		tfErr := flex.TerraformErrorf(err, "", IAMCredentialsConfigResourceName, "update")
 		return tfErr.GetDiag()
@@ -191,7 +191,7 @@ func resourceIbmSmIamCredentialsConfigurationUpdate(context context.Context, d *
 	region := id[0]
 	instanceId := id[1]
 	configName := id[2]
-	secretsManagerClient = getClientWithInstanceEndpoint(secretsManagerClient, instanceId, region, getEndpointType(secretsManagerClient, d))
+	secretsManagerClient = getClientWithInstanceEndpoint(secretsManagerClient, instanceId, region, getEndpointType(secretsManagerClient, d), endpointsFile)
 
 	updateConfigurationOptions := &secretsmanagerv2.UpdateConfigurationOptions{}
 
@@ -226,7 +226,7 @@ func resourceIbmSmIamCredentialsConfigurationUpdate(context context.Context, d *
 }
 
 func resourceIbmSmIamCredentialsConfigurationDelete(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	secretsManagerClient, err := meta.(conns.ClientSession).SecretsManagerV2()
+	secretsManagerClient, endpointsFile, err := getSecretsManagerSession(meta.(conns.ClientSession))
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -235,7 +235,7 @@ func resourceIbmSmIamCredentialsConfigurationDelete(context context.Context, d *
 	region := id[0]
 	instanceId := id[1]
 	configName := id[2]
-	secretsManagerClient = getClientWithInstanceEndpoint(secretsManagerClient, instanceId, region, getEndpointType(secretsManagerClient, d))
+	secretsManagerClient = getClientWithInstanceEndpoint(secretsManagerClient, instanceId, region, getEndpointType(secretsManagerClient, d), endpointsFile)
 
 	deleteConfigurationOptions := &secretsmanagerv2.DeleteConfigurationOptions{}
 

--- a/ibm/service/secretsmanager/resource_ibm_sm_iam_credentials_secret.go
+++ b/ibm/service/secretsmanager/resource_ibm_sm_iam_credentials_secret.go
@@ -217,7 +217,7 @@ func ResourceIbmSmIamCredentialsSecret() *schema.Resource {
 }
 
 func resourceIbmSmIamCredentialsSecretCreate(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	secretsManagerClient, err := meta.(conns.ClientSession).SecretsManagerV2()
+	secretsManagerClient, endpointsFile, err := getSecretsManagerSession(meta.(conns.ClientSession))
 	if err != nil {
 		tfErr := flex.TerraformErrorf(err, "", IAMCredentialsSecretResourceName, "create")
 		return tfErr.GetDiag()
@@ -225,7 +225,7 @@ func resourceIbmSmIamCredentialsSecretCreate(context context.Context, d *schema.
 
 	region := getRegion(secretsManagerClient, d)
 	instanceId := d.Get("instance_id").(string)
-	secretsManagerClient = getClientWithInstanceEndpoint(secretsManagerClient, instanceId, region, getEndpointType(secretsManagerClient, d))
+	secretsManagerClient = getClientWithInstanceEndpoint(secretsManagerClient, instanceId, region, getEndpointType(secretsManagerClient, d), endpointsFile)
 
 	createSecretOptions := &secretsmanagerv2.CreateSecretOptions{}
 
@@ -295,7 +295,7 @@ func waitForIbmSmIamCredentialsSecretCreate(secretsManagerClient *secretsmanager
 }
 
 func resourceIbmSmIamCredentialsSecretRead(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	secretsManagerClient, err := meta.(conns.ClientSession).SecretsManagerV2()
+	secretsManagerClient, endpointsFile, err := getSecretsManagerSession(meta.(conns.ClientSession))
 	if err != nil {
 		tfErr := flex.TerraformErrorf(err, "", IAMCredentialsSecretResourceName, "read")
 		return tfErr.GetDiag()
@@ -309,7 +309,7 @@ func resourceIbmSmIamCredentialsSecretRead(context context.Context, d *schema.Re
 	region := id[0]
 	instanceId := id[1]
 	secretId := id[2]
-	secretsManagerClient = getClientWithInstanceEndpoint(secretsManagerClient, instanceId, region, getEndpointType(secretsManagerClient, d))
+	secretsManagerClient = getClientWithInstanceEndpoint(secretsManagerClient, instanceId, region, getEndpointType(secretsManagerClient, d), endpointsFile)
 
 	getSecretOptions := &secretsmanagerv2.GetSecretOptions{}
 
@@ -491,7 +491,7 @@ func resourceIbmSmIamCredentialsSecretRead(context context.Context, d *schema.Re
 }
 
 func resourceIbmSmIamCredentialsSecretUpdate(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	secretsManagerClient, err := meta.(conns.ClientSession).SecretsManagerV2()
+	secretsManagerClient, endpointsFile, err := getSecretsManagerSession(meta.(conns.ClientSession))
 	if err != nil {
 		tfErr := flex.TerraformErrorf(err, "", IAMCredentialsSecretResourceName, "update")
 		return tfErr.GetDiag()
@@ -501,7 +501,7 @@ func resourceIbmSmIamCredentialsSecretUpdate(context context.Context, d *schema.
 	region := id[0]
 	instanceId := id[1]
 	secretId := id[2]
-	secretsManagerClient = getClientWithInstanceEndpoint(secretsManagerClient, instanceId, region, getEndpointType(secretsManagerClient, d))
+	secretsManagerClient = getClientWithInstanceEndpoint(secretsManagerClient, instanceId, region, getEndpointType(secretsManagerClient, d), endpointsFile)
 
 	updateSecretMetadataOptions := &secretsmanagerv2.UpdateSecretMetadataOptions{}
 
@@ -583,7 +583,7 @@ func resourceIbmSmIamCredentialsSecretUpdate(context context.Context, d *schema.
 }
 
 func resourceIbmSmIamCredentialsSecretDelete(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	secretsManagerClient, err := meta.(conns.ClientSession).SecretsManagerV2()
+	secretsManagerClient, endpointsFile, err := getSecretsManagerSession(meta.(conns.ClientSession))
 	if err != nil {
 		tfErr := flex.TerraformErrorf(err, "", IAMCredentialsSecretResourceName, "delete")
 		return tfErr.GetDiag()
@@ -593,7 +593,7 @@ func resourceIbmSmIamCredentialsSecretDelete(context context.Context, d *schema.
 	region := id[0]
 	instanceId := id[1]
 	secretId := id[2]
-	secretsManagerClient = getClientWithInstanceEndpoint(secretsManagerClient, instanceId, region, getEndpointType(secretsManagerClient, d))
+	secretsManagerClient = getClientWithInstanceEndpoint(secretsManagerClient, instanceId, region, getEndpointType(secretsManagerClient, d), endpointsFile)
 
 	deleteSecretOptions := &secretsmanagerv2.DeleteSecretOptions{}
 

--- a/ibm/service/secretsmanager/resource_ibm_sm_imported_certificate.go
+++ b/ibm/service/secretsmanager/resource_ibm_sm_imported_certificate.go
@@ -415,7 +415,7 @@ func ResourceIbmSmImportedCertificate() *schema.Resource {
 }
 
 func resourceIbmSmImportedCertificateCreate(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	secretsManagerClient, err := meta.(conns.ClientSession).SecretsManagerV2()
+	secretsManagerClient, endpointsFile, err := getSecretsManagerSession(meta.(conns.ClientSession))
 	if err != nil {
 		tfErr := flex.TerraformErrorf(err, "", ImportedCertSecretResourceName, "create")
 		return tfErr.GetDiag()
@@ -423,7 +423,7 @@ func resourceIbmSmImportedCertificateCreate(context context.Context, d *schema.R
 
 	region := getRegion(secretsManagerClient, d)
 	instanceId := d.Get("instance_id").(string)
-	secretsManagerClient = getClientWithInstanceEndpoint(secretsManagerClient, instanceId, region, getEndpointType(secretsManagerClient, d))
+	secretsManagerClient = getClientWithInstanceEndpoint(secretsManagerClient, instanceId, region, getEndpointType(secretsManagerClient, d), endpointsFile)
 
 	createSecretOptions := &secretsmanagerv2.CreateSecretOptions{}
 
@@ -449,7 +449,7 @@ func resourceIbmSmImportedCertificateCreate(context context.Context, d *schema.R
 }
 
 func resourceIbmSmImportedCertificateRead(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	secretsManagerClient, err := meta.(conns.ClientSession).SecretsManagerV2()
+	secretsManagerClient, endpointsFile, err := getSecretsManagerSession(meta.(conns.ClientSession))
 	if err != nil {
 		tfErr := flex.TerraformErrorf(err, "", ImportedCertSecretResourceName, "read")
 		return tfErr.GetDiag()
@@ -463,7 +463,7 @@ func resourceIbmSmImportedCertificateRead(context context.Context, d *schema.Res
 	region := id[0]
 	instanceId := id[1]
 	secretId := id[2]
-	secretsManagerClient = getClientWithInstanceEndpoint(secretsManagerClient, instanceId, region, getEndpointType(secretsManagerClient, d))
+	secretsManagerClient = getClientWithInstanceEndpoint(secretsManagerClient, instanceId, region, getEndpointType(secretsManagerClient, d), endpointsFile)
 
 	getSecretOptions := &secretsmanagerv2.GetSecretOptions{}
 
@@ -743,7 +743,7 @@ func managedCsrToMap(managedCsr *secretsmanagerv2.ImportedCertificateManagedCsrR
 }
 
 func resourceIbmSmImportedCertificateUpdate(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	secretsManagerClient, err := meta.(conns.ClientSession).SecretsManagerV2()
+	secretsManagerClient, endpointsFile, err := getSecretsManagerSession(meta.(conns.ClientSession))
 	if err != nil {
 		tfErr := flex.TerraformErrorf(err, "", ImportedCertSecretResourceName, "update")
 		return tfErr.GetDiag()
@@ -753,7 +753,7 @@ func resourceIbmSmImportedCertificateUpdate(context context.Context, d *schema.R
 	region := id[0]
 	instanceId := id[1]
 	secretId := id[2]
-	secretsManagerClient = getClientWithInstanceEndpoint(secretsManagerClient, instanceId, region, getEndpointType(secretsManagerClient, d))
+	secretsManagerClient = getClientWithInstanceEndpoint(secretsManagerClient, instanceId, region, getEndpointType(secretsManagerClient, d), endpointsFile)
 
 	updateSecretMetadataOptions := &secretsmanagerv2.UpdateSecretMetadataOptions{}
 
@@ -864,7 +864,7 @@ func resourceIbmSmImportedCertificateUpdate(context context.Context, d *schema.R
 }
 
 func resourceIbmSmImportedCertificateDelete(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	secretsManagerClient, err := meta.(conns.ClientSession).SecretsManagerV2()
+	secretsManagerClient, endpointsFile, err := getSecretsManagerSession(meta.(conns.ClientSession))
 	if err != nil {
 		tfErr := flex.TerraformErrorf(err, "", ImportedCertSecretResourceName, "delete")
 		return tfErr.GetDiag()
@@ -874,7 +874,7 @@ func resourceIbmSmImportedCertificateDelete(context context.Context, d *schema.R
 	region := id[0]
 	instanceId := id[1]
 	secretId := id[2]
-	secretsManagerClient = getClientWithInstanceEndpoint(secretsManagerClient, instanceId, region, getEndpointType(secretsManagerClient, d))
+	secretsManagerClient = getClientWithInstanceEndpoint(secretsManagerClient, instanceId, region, getEndpointType(secretsManagerClient, d), endpointsFile)
 
 	deleteSecretOptions := &secretsmanagerv2.DeleteSecretOptions{}
 

--- a/ibm/service/secretsmanager/resource_ibm_sm_kv_secret.go
+++ b/ibm/service/secretsmanager/resource_ibm_sm_kv_secret.go
@@ -133,7 +133,7 @@ func ResourceIbmSmKvSecret() *schema.Resource {
 }
 
 func resourceIbmSmKvSecretCreate(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	secretsManagerClient, err := meta.(conns.ClientSession).SecretsManagerV2()
+	secretsManagerClient, endpointsFile, err := getSecretsManagerSession(meta.(conns.ClientSession))
 	if err != nil {
 		tfErr := flex.TerraformErrorf(err, "", KvSecretResourceName, "create")
 		return tfErr.GetDiag()
@@ -141,7 +141,7 @@ func resourceIbmSmKvSecretCreate(context context.Context, d *schema.ResourceData
 
 	region := getRegion(secretsManagerClient, d)
 	instanceId := d.Get("instance_id").(string)
-	secretsManagerClient = getClientWithInstanceEndpoint(secretsManagerClient, instanceId, region, getEndpointType(secretsManagerClient, d))
+	secretsManagerClient = getClientWithInstanceEndpoint(secretsManagerClient, instanceId, region, getEndpointType(secretsManagerClient, d), endpointsFile)
 
 	createSecretOptions := &secretsmanagerv2.CreateSecretOptions{}
 
@@ -207,7 +207,7 @@ func waitForIbmSmKvSecretCreate(secretsManagerClient *secretsmanagerv2.SecretsMa
 }
 
 func resourceIbmSmKvSecretRead(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	secretsManagerClient, err := meta.(conns.ClientSession).SecretsManagerV2()
+	secretsManagerClient, endpointsFile, err := getSecretsManagerSession(meta.(conns.ClientSession))
 	if err != nil {
 		tfErr := flex.TerraformErrorf(err, "", KvSecretResourceName, "read")
 		return tfErr.GetDiag()
@@ -221,7 +221,7 @@ func resourceIbmSmKvSecretRead(context context.Context, d *schema.ResourceData, 
 	region := id[0]
 	instanceId := id[1]
 	secretId := id[2]
-	secretsManagerClient = getClientWithInstanceEndpoint(secretsManagerClient, instanceId, region, getEndpointType(secretsManagerClient, d))
+	secretsManagerClient = getClientWithInstanceEndpoint(secretsManagerClient, instanceId, region, getEndpointType(secretsManagerClient, d), endpointsFile)
 
 	getSecretOptions := &secretsmanagerv2.GetSecretOptions{}
 
@@ -341,7 +341,7 @@ func resourceIbmSmKvSecretRead(context context.Context, d *schema.ResourceData, 
 }
 
 func resourceIbmSmKvSecretUpdate(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	secretsManagerClient, err := meta.(conns.ClientSession).SecretsManagerV2()
+	secretsManagerClient, endpointsFile, err := getSecretsManagerSession(meta.(conns.ClientSession))
 	if err != nil {
 		tfErr := flex.TerraformErrorf(err, "", KvSecretResourceName, "update")
 		return tfErr.GetDiag()
@@ -351,7 +351,7 @@ func resourceIbmSmKvSecretUpdate(context context.Context, d *schema.ResourceData
 	region := id[0]
 	instanceId := id[1]
 	secretId := id[2]
-	secretsManagerClient = getClientWithInstanceEndpoint(secretsManagerClient, instanceId, region, getEndpointType(secretsManagerClient, d))
+	secretsManagerClient = getClientWithInstanceEndpoint(secretsManagerClient, instanceId, region, getEndpointType(secretsManagerClient, d), endpointsFile)
 
 	updateSecretMetadataOptions := &secretsmanagerv2.UpdateSecretMetadataOptions{}
 
@@ -445,7 +445,7 @@ func resourceIbmSmKvSecretUpdate(context context.Context, d *schema.ResourceData
 }
 
 func resourceIbmSmKvSecretDelete(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	secretsManagerClient, err := meta.(conns.ClientSession).SecretsManagerV2()
+	secretsManagerClient, endpointsFile, err := getSecretsManagerSession(meta.(conns.ClientSession))
 	if err != nil {
 		tfErr := flex.TerraformErrorf(err, "", KvSecretResourceName, "delete")
 		return tfErr.GetDiag()
@@ -455,7 +455,7 @@ func resourceIbmSmKvSecretDelete(context context.Context, d *schema.ResourceData
 	region := id[0]
 	instanceId := id[1]
 	secretId := id[2]
-	secretsManagerClient = getClientWithInstanceEndpoint(secretsManagerClient, instanceId, region, getEndpointType(secretsManagerClient, d))
+	secretsManagerClient = getClientWithInstanceEndpoint(secretsManagerClient, instanceId, region, getEndpointType(secretsManagerClient, d), endpointsFile)
 
 	deleteSecretOptions := &secretsmanagerv2.DeleteSecretOptions{}
 

--- a/ibm/service/secretsmanager/resource_ibm_sm_private_certificate.go
+++ b/ibm/service/secretsmanager/resource_ibm_sm_private_certificate.go
@@ -318,7 +318,7 @@ func ResourceIbmSmPrivateCertificate() *schema.Resource {
 }
 
 func resourceIbmSmPrivateCertificateCreate(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	secretsManagerClient, err := meta.(conns.ClientSession).SecretsManagerV2()
+	secretsManagerClient, endpointsFile, err := getSecretsManagerSession(meta.(conns.ClientSession))
 	if err != nil {
 		tfErr := flex.TerraformErrorf(err, "", PrivateCertSecretResourceName, "create")
 		return tfErr.GetDiag()
@@ -326,7 +326,7 @@ func resourceIbmSmPrivateCertificateCreate(context context.Context, d *schema.Re
 
 	region := getRegion(secretsManagerClient, d)
 	instanceId := d.Get("instance_id").(string)
-	secretsManagerClient = getClientWithInstanceEndpoint(secretsManagerClient, instanceId, region, getEndpointType(secretsManagerClient, d))
+	secretsManagerClient = getClientWithInstanceEndpoint(secretsManagerClient, instanceId, region, getEndpointType(secretsManagerClient, d), endpointsFile)
 
 	createSecretOptions := &secretsmanagerv2.CreateSecretOptions{}
 
@@ -392,7 +392,7 @@ func waitForIbmSmPrivateCertificateCreate(secretsManagerClient *secretsmanagerv2
 }
 
 func resourceIbmSmPrivateCertificateRead(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	secretsManagerClient, err := meta.(conns.ClientSession).SecretsManagerV2()
+	secretsManagerClient, endpointsFile, err := getSecretsManagerSession(meta.(conns.ClientSession))
 	if err != nil {
 		tfErr := flex.TerraformErrorf(err, "", PrivateCertSecretResourceName, "read")
 		return tfErr.GetDiag()
@@ -406,7 +406,7 @@ func resourceIbmSmPrivateCertificateRead(context context.Context, d *schema.Reso
 	region := id[0]
 	instanceId := id[1]
 	secretId := id[2]
-	secretsManagerClient = getClientWithInstanceEndpoint(secretsManagerClient, instanceId, region, getEndpointType(secretsManagerClient, d))
+	secretsManagerClient = getClientWithInstanceEndpoint(secretsManagerClient, instanceId, region, getEndpointType(secretsManagerClient, d), endpointsFile)
 
 	getSecretOptions := &secretsmanagerv2.GetSecretOptions{}
 
@@ -612,7 +612,7 @@ func resourceIbmSmPrivateCertificateRead(context context.Context, d *schema.Reso
 }
 
 func resourceIbmSmPrivateCertificateUpdate(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	secretsManagerClient, err := meta.(conns.ClientSession).SecretsManagerV2()
+	secretsManagerClient, endpointsFile, err := getSecretsManagerSession(meta.(conns.ClientSession))
 	if err != nil {
 		tfErr := flex.TerraformErrorf(err, "", PrivateCertSecretResourceName, "update")
 		return tfErr.GetDiag()
@@ -622,7 +622,7 @@ func resourceIbmSmPrivateCertificateUpdate(context context.Context, d *schema.Re
 	region := id[0]
 	instanceId := id[1]
 	secretId := id[2]
-	secretsManagerClient = getClientWithInstanceEndpoint(secretsManagerClient, instanceId, region, getEndpointType(secretsManagerClient, d))
+	secretsManagerClient = getClientWithInstanceEndpoint(secretsManagerClient, instanceId, region, getEndpointType(secretsManagerClient, d), endpointsFile)
 
 	updateSecretMetadataOptions := &secretsmanagerv2.UpdateSecretMetadataOptions{}
 
@@ -700,7 +700,7 @@ func resourceIbmSmPrivateCertificateUpdate(context context.Context, d *schema.Re
 }
 
 func resourceIbmSmPrivateCertificateDelete(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	secretsManagerClient, err := meta.(conns.ClientSession).SecretsManagerV2()
+	secretsManagerClient, endpointsFile, err := getSecretsManagerSession(meta.(conns.ClientSession))
 	if err != nil {
 		tfErr := flex.TerraformErrorf(err, "", PrivateCertSecretResourceName, "delete")
 		return tfErr.GetDiag()
@@ -710,7 +710,7 @@ func resourceIbmSmPrivateCertificateDelete(context context.Context, d *schema.Re
 	region := id[0]
 	instanceId := id[1]
 	secretId := id[2]
-	secretsManagerClient = getClientWithInstanceEndpoint(secretsManagerClient, instanceId, region, getEndpointType(secretsManagerClient, d))
+	secretsManagerClient = getClientWithInstanceEndpoint(secretsManagerClient, instanceId, region, getEndpointType(secretsManagerClient, d), endpointsFile)
 
 	deleteSecretOptions := &secretsmanagerv2.DeleteSecretOptions{}
 

--- a/ibm/service/secretsmanager/resource_ibm_sm_private_certificate_configuration_action_set_signed.go
+++ b/ibm/service/secretsmanager/resource_ibm_sm_private_certificate_configuration_action_set_signed.go
@@ -46,7 +46,7 @@ func ResourceIbmSmPrivateCertificateConfigurationActionSetSigned() *schema.Resou
 }
 
 func resourceIbmSmPrivateCertificateConfigurationActionSetSignedCreateOrUpdate(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	secretsManagerClient, err := meta.(conns.ClientSession).SecretsManagerV2()
+	secretsManagerClient, endpointsFile, err := getSecretsManagerSession(meta.(conns.ClientSession))
 	if err != nil {
 		tfErr := flex.TerraformErrorf(err, "", PrivateCertConfigActionSetSigned, "create/update")
 		return tfErr.GetDiag()
@@ -54,7 +54,7 @@ func resourceIbmSmPrivateCertificateConfigurationActionSetSignedCreateOrUpdate(c
 
 	region := getRegion(secretsManagerClient, d)
 	instanceId := d.Get("instance_id").(string)
-	secretsManagerClient = getClientWithInstanceEndpoint(secretsManagerClient, instanceId, region, getEndpointType(secretsManagerClient, d))
+	secretsManagerClient = getClientWithInstanceEndpoint(secretsManagerClient, instanceId, region, getEndpointType(secretsManagerClient, d), endpointsFile)
 
 	createConfigurationActionOptions := &secretsmanagerv2.CreateConfigurationActionOptions{}
 

--- a/ibm/service/secretsmanager/resource_ibm_sm_private_certificate_configuration_action_sign_csr.go
+++ b/ibm/service/secretsmanager/resource_ibm_sm_private_certificate_configuration_action_sign_csr.go
@@ -210,7 +210,7 @@ func ResourceIbmSmPrivateCertificateConfigurationActionSignCsr() *schema.Resourc
 }
 
 func resourceIbmSmPrivateCertificateConfigurationActionSignCsrCreateOrUpdate(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	secretsManagerClient, err := meta.(conns.ClientSession).SecretsManagerV2()
+	secretsManagerClient, endpointsFile, err := getSecretsManagerSession(meta.(conns.ClientSession))
 	if err != nil {
 		tfErr := flex.TerraformErrorf(err, "", PrivateCertConfigActionSignCsr, "create/update")
 		return tfErr.GetDiag()
@@ -218,7 +218,7 @@ func resourceIbmSmPrivateCertificateConfigurationActionSignCsrCreateOrUpdate(con
 
 	region := getRegion(secretsManagerClient, d)
 	instanceId := d.Get("instance_id").(string)
-	secretsManagerClient = getClientWithInstanceEndpoint(secretsManagerClient, instanceId, region, getEndpointType(secretsManagerClient, d))
+	secretsManagerClient = getClientWithInstanceEndpoint(secretsManagerClient, instanceId, region, getEndpointType(secretsManagerClient, d), endpointsFile)
 
 	createConfigurationActionOptions := &secretsmanagerv2.CreateConfigurationActionOptions{}
 

--- a/ibm/service/secretsmanager/resource_ibm_sm_private_certificate_configuration_intermediate_ca.go
+++ b/ibm/service/secretsmanager/resource_ibm_sm_private_certificate_configuration_intermediate_ca.go
@@ -387,7 +387,7 @@ func ResourceIbmSmPrivateCertificateConfigurationIntermediateCA() *schema.Resour
 }
 
 func resourceIbmSmPrivateCertificateConfigurationIntermediateCACreate(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	secretsManagerClient, err := meta.(conns.ClientSession).SecretsManagerV2()
+	secretsManagerClient, endpointsFile, err := getSecretsManagerSession(meta.(conns.ClientSession))
 	if err != nil {
 		tfErr := flex.TerraformErrorf(err, "", PrivateCertConfigIntermediateCAResourceName, "create")
 		return tfErr.GetDiag()
@@ -395,7 +395,7 @@ func resourceIbmSmPrivateCertificateConfigurationIntermediateCACreate(context co
 
 	region := getRegion(secretsManagerClient, d)
 	instanceId := d.Get("instance_id").(string)
-	secretsManagerClient = getClientWithInstanceEndpoint(secretsManagerClient, instanceId, region, getEndpointType(secretsManagerClient, d))
+	secretsManagerClient = getClientWithInstanceEndpoint(secretsManagerClient, instanceId, region, getEndpointType(secretsManagerClient, d), endpointsFile)
 
 	createConfigurationOptions := &secretsmanagerv2.CreateConfigurationOptions{}
 
@@ -445,7 +445,7 @@ func resourceIbmSmPrivateCertificateConfigurationIntermediateCACreate(context co
 }
 
 func resourceIbmSmPrivateCertificateConfigurationIntermediateCARead(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	secretsManagerClient, err := meta.(conns.ClientSession).SecretsManagerV2()
+	secretsManagerClient, endpointsFile, err := getSecretsManagerSession(meta.(conns.ClientSession))
 	if err != nil {
 		tfErr := flex.TerraformErrorf(err, "", PrivateCertConfigIntermediateCAResourceName, "read")
 		return tfErr.GetDiag()
@@ -459,7 +459,7 @@ func resourceIbmSmPrivateCertificateConfigurationIntermediateCARead(context cont
 	region := id[0]
 	instanceId := id[1]
 	configName := id[2]
-	secretsManagerClient = getClientWithInstanceEndpoint(secretsManagerClient, instanceId, region, getEndpointType(secretsManagerClient, d))
+	secretsManagerClient = getClientWithInstanceEndpoint(secretsManagerClient, instanceId, region, getEndpointType(secretsManagerClient, d), endpointsFile)
 
 	getConfigurationOptions := &secretsmanagerv2.GetConfigurationOptions{}
 
@@ -705,7 +705,7 @@ func resourceIbmSmPrivateCertificateConfigurationCryptoKeyProviderToMap(provider
 }
 
 func resourceIbmSmPrivateCertificateConfigurationIntermediateCAUpdate(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	secretsManagerClient, err := meta.(conns.ClientSession).SecretsManagerV2()
+	secretsManagerClient, endpointsFile, err := getSecretsManagerSession(meta.(conns.ClientSession))
 	if err != nil {
 		tfErr := flex.TerraformErrorf(err, "", PrivateCertConfigIntermediateCAResourceName, "update")
 		return tfErr.GetDiag()
@@ -715,7 +715,7 @@ func resourceIbmSmPrivateCertificateConfigurationIntermediateCAUpdate(context co
 	region := id[0]
 	instanceId := id[1]
 	configName := id[2]
-	secretsManagerClient = getClientWithInstanceEndpoint(secretsManagerClient, instanceId, region, getEndpointType(secretsManagerClient, d))
+	secretsManagerClient = getClientWithInstanceEndpoint(secretsManagerClient, instanceId, region, getEndpointType(secretsManagerClient, d), endpointsFile)
 
 	updateConfigurationOptions := &secretsmanagerv2.UpdateConfigurationOptions{}
 
@@ -765,7 +765,7 @@ func resourceIbmSmPrivateCertificateConfigurationIntermediateCAUpdate(context co
 }
 
 func resourceIbmSmPrivateCertificateConfigurationIntermediateCADelete(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	secretsManagerClient, err := meta.(conns.ClientSession).SecretsManagerV2()
+	secretsManagerClient, endpointsFile, err := getSecretsManagerSession(meta.(conns.ClientSession))
 	if err != nil {
 		tfErr := flex.TerraformErrorf(err, "", PrivateCertConfigIntermediateCAResourceName, "delete")
 		return tfErr.GetDiag()
@@ -775,7 +775,7 @@ func resourceIbmSmPrivateCertificateConfigurationIntermediateCADelete(context co
 	region := id[0]
 	instanceId := id[1]
 	configName := id[2]
-	secretsManagerClient = getClientWithInstanceEndpoint(secretsManagerClient, instanceId, region, getEndpointType(secretsManagerClient, d))
+	secretsManagerClient = getClientWithInstanceEndpoint(secretsManagerClient, instanceId, region, getEndpointType(secretsManagerClient, d), endpointsFile)
 
 	deleteConfigurationOptions := &secretsmanagerv2.DeleteConfigurationOptions{}
 

--- a/ibm/service/secretsmanager/resource_ibm_sm_private_certificate_configuration_root_ca.go
+++ b/ibm/service/secretsmanager/resource_ibm_sm_private_certificate_configuration_root_ca.go
@@ -391,7 +391,7 @@ func ResourceIbmSmPrivateCertificateConfigurationRootCA() *schema.Resource {
 }
 
 func resourceIbmSmPrivateCertificateConfigurationRootCACreate(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	secretsManagerClient, err := meta.(conns.ClientSession).SecretsManagerV2()
+	secretsManagerClient, endpointsFile, err := getSecretsManagerSession(meta.(conns.ClientSession))
 	if err != nil {
 		tfErr := flex.TerraformErrorf(err, "", PrivateCertConfigRootCAResourceName, "create")
 		return tfErr.GetDiag()
@@ -399,7 +399,7 @@ func resourceIbmSmPrivateCertificateConfigurationRootCACreate(context context.Co
 
 	region := getRegion(secretsManagerClient, d)
 	instanceId := d.Get("instance_id").(string)
-	secretsManagerClient = getClientWithInstanceEndpoint(secretsManagerClient, instanceId, region, getEndpointType(secretsManagerClient, d))
+	secretsManagerClient = getClientWithInstanceEndpoint(secretsManagerClient, instanceId, region, getEndpointType(secretsManagerClient, d), endpointsFile)
 
 	createConfigurationOptions := &secretsmanagerv2.CreateConfigurationOptions{}
 
@@ -424,7 +424,7 @@ func resourceIbmSmPrivateCertificateConfigurationRootCACreate(context context.Co
 }
 
 func resourceIbmSmPrivateCertificateConfigurationRootCARead(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	secretsManagerClient, err := meta.(conns.ClientSession).SecretsManagerV2()
+	secretsManagerClient, endpointsFile, err := getSecretsManagerSession(meta.(conns.ClientSession))
 	if err != nil {
 		tfErr := flex.TerraformErrorf(err, "", PrivateCertConfigRootCAResourceName, "read")
 		return tfErr.GetDiag()
@@ -438,7 +438,7 @@ func resourceIbmSmPrivateCertificateConfigurationRootCARead(context context.Cont
 	region := id[0]
 	instanceId := id[1]
 	configName := id[2]
-	secretsManagerClient = getClientWithInstanceEndpoint(secretsManagerClient, instanceId, region, getEndpointType(secretsManagerClient, d))
+	secretsManagerClient = getClientWithInstanceEndpoint(secretsManagerClient, instanceId, region, getEndpointType(secretsManagerClient, d), endpointsFile)
 
 	getConfigurationOptions := &secretsmanagerv2.GetConfigurationOptions{}
 
@@ -660,7 +660,7 @@ func resourceIbmSmPrivateCertificateConfigurationRootCARead(context context.Cont
 }
 
 func resourceIbmSmPrivateCertificateConfigurationRootCAUpdate(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	secretsManagerClient, err := meta.(conns.ClientSession).SecretsManagerV2()
+	secretsManagerClient, endpointsFile, err := getSecretsManagerSession(meta.(conns.ClientSession))
 	if err != nil {
 		tfErr := flex.TerraformErrorf(err, "", PrivateCertConfigRootCAResourceName, "update")
 		return tfErr.GetDiag()
@@ -670,7 +670,7 @@ func resourceIbmSmPrivateCertificateConfigurationRootCAUpdate(context context.Co
 	region := id[0]
 	instanceId := id[1]
 	configName := id[2]
-	secretsManagerClient = getClientWithInstanceEndpoint(secretsManagerClient, instanceId, region, getEndpointType(secretsManagerClient, d))
+	secretsManagerClient = getClientWithInstanceEndpoint(secretsManagerClient, instanceId, region, getEndpointType(secretsManagerClient, d), endpointsFile)
 
 	updateConfigurationOptions := &secretsmanagerv2.UpdateConfigurationOptions{}
 
@@ -715,7 +715,7 @@ func resourceIbmSmPrivateCertificateConfigurationRootCAUpdate(context context.Co
 }
 
 func resourceIbmSmPrivateCertificateConfigurationRootCADelete(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	secretsManagerClient, err := meta.(conns.ClientSession).SecretsManagerV2()
+	secretsManagerClient, endpointsFile, err := getSecretsManagerSession(meta.(conns.ClientSession))
 	if err != nil {
 		tfErr := flex.TerraformErrorf(err, "", PrivateCertConfigRootCAResourceName, "delete")
 		return tfErr.GetDiag()
@@ -725,7 +725,7 @@ func resourceIbmSmPrivateCertificateConfigurationRootCADelete(context context.Co
 	region := id[0]
 	instanceId := id[1]
 	configName := id[2]
-	secretsManagerClient = getClientWithInstanceEndpoint(secretsManagerClient, instanceId, region, getEndpointType(secretsManagerClient, d))
+	secretsManagerClient = getClientWithInstanceEndpoint(secretsManagerClient, instanceId, region, getEndpointType(secretsManagerClient, d), endpointsFile)
 
 	deleteConfigurationOptions := &secretsmanagerv2.DeleteConfigurationOptions{}
 

--- a/ibm/service/secretsmanager/resource_ibm_sm_private_certificate_configuration_template.go
+++ b/ibm/service/secretsmanager/resource_ibm_sm_private_certificate_configuration_template.go
@@ -323,7 +323,7 @@ func ResourceIbmSmPrivateCertificateConfigurationTemplate() *schema.Resource {
 }
 
 func resourceIbmSmPrivateCertificateConfigurationTemplateCreate(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	secretsManagerClient, err := meta.(conns.ClientSession).SecretsManagerV2()
+	secretsManagerClient, endpointsFile, err := getSecretsManagerSession(meta.(conns.ClientSession))
 	if err != nil {
 		tfErr := flex.TerraformErrorf(err, "", PrivateCertConfigTemplateResourceName, "create")
 		return tfErr.GetDiag()
@@ -331,7 +331,7 @@ func resourceIbmSmPrivateCertificateConfigurationTemplateCreate(context context.
 
 	region := getRegion(secretsManagerClient, d)
 	instanceId := d.Get("instance_id").(string)
-	secretsManagerClient = getClientWithInstanceEndpoint(secretsManagerClient, instanceId, region, getEndpointType(secretsManagerClient, d))
+	secretsManagerClient = getClientWithInstanceEndpoint(secretsManagerClient, instanceId, region, getEndpointType(secretsManagerClient, d), endpointsFile)
 
 	createConfigurationOptions := &secretsmanagerv2.CreateConfigurationOptions{}
 
@@ -356,7 +356,7 @@ func resourceIbmSmPrivateCertificateConfigurationTemplateCreate(context context.
 }
 
 func resourceIbmSmPrivateCertificateConfigurationTemplateRead(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	secretsManagerClient, err := meta.(conns.ClientSession).SecretsManagerV2()
+	secretsManagerClient, endpointsFile, err := getSecretsManagerSession(meta.(conns.ClientSession))
 	if err != nil {
 		tfErr := flex.TerraformErrorf(err, "", PrivateCertConfigTemplateResourceName, "read")
 		return tfErr.GetDiag()
@@ -370,7 +370,7 @@ func resourceIbmSmPrivateCertificateConfigurationTemplateRead(context context.Co
 	region := id[0]
 	instanceId := id[1]
 	configName := id[2]
-	secretsManagerClient = getClientWithInstanceEndpoint(secretsManagerClient, instanceId, region, getEndpointType(secretsManagerClient, d))
+	secretsManagerClient = getClientWithInstanceEndpoint(secretsManagerClient, instanceId, region, getEndpointType(secretsManagerClient, d), endpointsFile)
 
 	getConfigurationOptions := &secretsmanagerv2.GetConfigurationOptions{}
 
@@ -589,7 +589,7 @@ func resourceIbmSmPrivateCertificateConfigurationTemplateRead(context context.Co
 }
 
 func resourceIbmSmPrivateCertificateConfigurationTemplateUpdate(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	secretsManagerClient, err := meta.(conns.ClientSession).SecretsManagerV2()
+	secretsManagerClient, endpointsFile, err := getSecretsManagerSession(meta.(conns.ClientSession))
 	if err != nil {
 		tfErr := flex.TerraformErrorf(err, "", PrivateCertConfigTemplateResourceName, "update")
 		return tfErr.GetDiag()
@@ -599,7 +599,7 @@ func resourceIbmSmPrivateCertificateConfigurationTemplateUpdate(context context.
 	region := id[0]
 	instanceId := id[1]
 	configName := id[2]
-	secretsManagerClient = getClientWithInstanceEndpoint(secretsManagerClient, instanceId, region, getEndpointType(secretsManagerClient, d))
+	secretsManagerClient = getClientWithInstanceEndpoint(secretsManagerClient, instanceId, region, getEndpointType(secretsManagerClient, d), endpointsFile)
 
 	updateConfigurationOptions := &secretsmanagerv2.UpdateConfigurationOptions{}
 
@@ -860,7 +860,7 @@ func resourceIbmSmPrivateCertificateConfigurationTemplateUpdate(context context.
 }
 
 func resourceIbmSmPrivateCertificateConfigurationTemplateDelete(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	secretsManagerClient, err := meta.(conns.ClientSession).SecretsManagerV2()
+	secretsManagerClient, endpointsFile, err := getSecretsManagerSession(meta.(conns.ClientSession))
 	if err != nil {
 		tfErr := flex.TerraformErrorf(err, "", PrivateCertConfigTemplateResourceName, "delete")
 		return tfErr.GetDiag()
@@ -870,7 +870,7 @@ func resourceIbmSmPrivateCertificateConfigurationTemplateDelete(context context.
 	region := id[0]
 	instanceId := id[1]
 	configName := id[2]
-	secretsManagerClient = getClientWithInstanceEndpoint(secretsManagerClient, instanceId, region, getEndpointType(secretsManagerClient, d))
+	secretsManagerClient = getClientWithInstanceEndpoint(secretsManagerClient, instanceId, region, getEndpointType(secretsManagerClient, d), endpointsFile)
 
 	deleteConfigurationOptions := &secretsmanagerv2.DeleteConfigurationOptions{}
 

--- a/ibm/service/secretsmanager/resource_ibm_sm_public_certificate.go
+++ b/ibm/service/secretsmanager/resource_ibm_sm_public_certificate.go
@@ -408,7 +408,7 @@ func ResourceIbmSmPublicCertificate() *schema.Resource {
 }
 
 func resourceIbmSmPublicCertificateCreate(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	secretsManagerClient, err := meta.(conns.ClientSession).SecretsManagerV2()
+	secretsManagerClient, endpointsFile, err := getSecretsManagerSession(meta.(conns.ClientSession))
 	if err != nil {
 		tfErr := flex.TerraformErrorf(err, "", PublicCertSecretResourceName, "create")
 		return tfErr.GetDiag()
@@ -416,7 +416,7 @@ func resourceIbmSmPublicCertificateCreate(context context.Context, d *schema.Res
 
 	region := getRegion(secretsManagerClient, d)
 	instanceId := d.Get("instance_id").(string)
-	secretsManagerClient = getClientWithInstanceEndpoint(secretsManagerClient, instanceId, region, getEndpointType(secretsManagerClient, d))
+	secretsManagerClient = getClientWithInstanceEndpoint(secretsManagerClient, instanceId, region, getEndpointType(secretsManagerClient, d), endpointsFile)
 
 	createSecretOptions := &secretsmanagerv2.CreateSecretOptions{}
 
@@ -486,7 +486,7 @@ func waitForIbmSmPublicCertificateCreate(secretsManagerClient *secretsmanagerv2.
 }
 
 func resourceIbmSmPublicCertificateRead(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	secretsManagerClient, err := meta.(conns.ClientSession).SecretsManagerV2()
+	secretsManagerClient, endpointsFile, err := getSecretsManagerSession(meta.(conns.ClientSession))
 	if err != nil {
 		tfErr := flex.TerraformErrorf(err, "", PublicCertSecretResourceName, "read")
 		return tfErr.GetDiag()
@@ -500,7 +500,7 @@ func resourceIbmSmPublicCertificateRead(context context.Context, d *schema.Resou
 	region := id[0]
 	instanceId := id[1]
 	secretId := id[2]
-	secretsManagerClient = getClientWithInstanceEndpoint(secretsManagerClient, instanceId, region, getEndpointType(secretsManagerClient, d))
+	secretsManagerClient = getClientWithInstanceEndpoint(secretsManagerClient, instanceId, region, getEndpointType(secretsManagerClient, d), endpointsFile)
 
 	getSecretOptions := &secretsmanagerv2.GetSecretOptions{}
 
@@ -712,7 +712,7 @@ func resourceIbmSmPublicCertificateRead(context context.Context, d *schema.Resou
 }
 
 func resourceIbmSmPublicCertificateUpdate(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	secretsManagerClient, err := meta.(conns.ClientSession).SecretsManagerV2()
+	secretsManagerClient, endpointsFile, err := getSecretsManagerSession(meta.(conns.ClientSession))
 	if err != nil {
 		tfErr := flex.TerraformErrorf(err, "", PublicCertSecretResourceName, "update")
 		return tfErr.GetDiag()
@@ -722,7 +722,7 @@ func resourceIbmSmPublicCertificateUpdate(context context.Context, d *schema.Res
 	region := id[0]
 	instanceId := id[1]
 	secretId := id[2]
-	secretsManagerClient = getClientWithInstanceEndpoint(secretsManagerClient, instanceId, region, getEndpointType(secretsManagerClient, d))
+	secretsManagerClient = getClientWithInstanceEndpoint(secretsManagerClient, instanceId, region, getEndpointType(secretsManagerClient, d), endpointsFile)
 
 	updateSecretMetadataOptions := &secretsmanagerv2.UpdateSecretMetadataOptions{}
 
@@ -800,7 +800,7 @@ func resourceIbmSmPublicCertificateUpdate(context context.Context, d *schema.Res
 }
 
 func resourceIbmSmPublicCertificateDelete(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	secretsManagerClient, err := meta.(conns.ClientSession).SecretsManagerV2()
+	secretsManagerClient, endpointsFile, err := getSecretsManagerSession(meta.(conns.ClientSession))
 	if err != nil {
 		tfErr := flex.TerraformErrorf(err, "", PublicCertSecretResourceName, "delete")
 		return tfErr.GetDiag()
@@ -810,7 +810,7 @@ func resourceIbmSmPublicCertificateDelete(context context.Context, d *schema.Res
 	region := id[0]
 	instanceId := id[1]
 	secretId := id[2]
-	secretsManagerClient = getClientWithInstanceEndpoint(secretsManagerClient, instanceId, region, getEndpointType(secretsManagerClient, d))
+	secretsManagerClient = getClientWithInstanceEndpoint(secretsManagerClient, instanceId, region, getEndpointType(secretsManagerClient, d), endpointsFile)
 
 	deleteSecretOptions := &secretsmanagerv2.DeleteSecretOptions{}
 

--- a/ibm/service/secretsmanager/resource_ibm_sm_public_certificate_action_validate_manual_dns.go
+++ b/ibm/service/secretsmanager/resource_ibm_sm_public_certificate_action_validate_manual_dns.go
@@ -39,7 +39,7 @@ func ResourceIbmSmPublicCertificateActionValidateManualDns() *schema.Resource {
 }
 
 func resourceIbmSmPublicCertificateActionValidateManualDnsCreateOrUpdate(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	secretsManagerClient, err := meta.(conns.ClientSession).SecretsManagerV2()
+	secretsManagerClient, endpointsFile, err := getSecretsManagerSession(meta.(conns.ClientSession))
 	if err != nil {
 		tfErr := flex.TerraformErrorf(err, "", PublicCertConfigActionValidateManualDNSResourceName, "create/update")
 		return tfErr.GetDiag()
@@ -47,7 +47,7 @@ func resourceIbmSmPublicCertificateActionValidateManualDnsCreateOrUpdate(context
 
 	region := getRegion(secretsManagerClient, d)
 	instanceId := d.Get("instance_id").(string)
-	secretsManagerClient = getClientWithInstanceEndpoint(secretsManagerClient, instanceId, region, getEndpointType(secretsManagerClient, d))
+	secretsManagerClient = getClientWithInstanceEndpoint(secretsManagerClient, instanceId, region, getEndpointType(secretsManagerClient, d), endpointsFile)
 
 	d.SetId(fmt.Sprintf("%s/%s/%s/validate_manual_dns", region, instanceId, d.Get("secret_id").(string)))
 

--- a/ibm/service/secretsmanager/resource_ibm_sm_public_certificate_configuration_ca_lets_encrypt.go
+++ b/ibm/service/secretsmanager/resource_ibm_sm_public_certificate_configuration_ca_lets_encrypt.go
@@ -69,7 +69,7 @@ func ResourceIbmSmPublicCertificateConfigurationCALetsEncrypt() *schema.Resource
 }
 
 func resourceIbmSmPublicCertificateConfigurationCALetsEncryptCreate(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	secretsManagerClient, err := meta.(conns.ClientSession).SecretsManagerV2()
+	secretsManagerClient, endpointsFile, err := getSecretsManagerSession(meta.(conns.ClientSession))
 	if err != nil {
 		tfErr := flex.TerraformErrorf(err, "", PublicCertConfigCALetsEncryptResourceName, "create")
 		return tfErr.GetDiag()
@@ -77,7 +77,7 @@ func resourceIbmSmPublicCertificateConfigurationCALetsEncryptCreate(context cont
 
 	region := getRegion(secretsManagerClient, d)
 	instanceId := d.Get("instance_id").(string)
-	secretsManagerClient = getClientWithInstanceEndpoint(secretsManagerClient, instanceId, region, getEndpointType(secretsManagerClient, d))
+	secretsManagerClient = getClientWithInstanceEndpoint(secretsManagerClient, instanceId, region, getEndpointType(secretsManagerClient, d), endpointsFile)
 
 	createConfigurationOptions := &secretsmanagerv2.CreateConfigurationOptions{}
 
@@ -101,7 +101,7 @@ func resourceIbmSmPublicCertificateConfigurationCALetsEncryptCreate(context cont
 }
 
 func resourceIbmSmPublicCertificateConfigurationCALetsEncryptRead(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	secretsManagerClient, err := meta.(conns.ClientSession).SecretsManagerV2()
+	secretsManagerClient, endpointsFile, err := getSecretsManagerSession(meta.(conns.ClientSession))
 	if err != nil {
 		tfErr := flex.TerraformErrorf(err, "", PublicCertConfigCALetsEncryptResourceName, "read")
 		return tfErr.GetDiag()
@@ -115,7 +115,7 @@ func resourceIbmSmPublicCertificateConfigurationCALetsEncryptRead(context contex
 	region := id[0]
 	instanceId := id[1]
 	configName := id[2]
-	secretsManagerClient = getClientWithInstanceEndpoint(secretsManagerClient, instanceId, region, getEndpointType(secretsManagerClient, d))
+	secretsManagerClient = getClientWithInstanceEndpoint(secretsManagerClient, instanceId, region, getEndpointType(secretsManagerClient, d), endpointsFile)
 
 	getConfigurationOptions := &secretsmanagerv2.GetConfigurationOptions{}
 
@@ -171,7 +171,7 @@ func resourceIbmSmPublicCertificateConfigurationCALetsEncryptRead(context contex
 }
 
 func resourceIbmSmPublicCertificateConfigurationCALetsEncryptUpdate(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	secretsManagerClient, err := meta.(conns.ClientSession).SecretsManagerV2()
+	secretsManagerClient, endpointsFile, err := getSecretsManagerSession(meta.(conns.ClientSession))
 	if err != nil {
 		tfErr := flex.TerraformErrorf(err, "", PublicCertConfigCALetsEncryptResourceName, "update")
 		return tfErr.GetDiag()
@@ -181,7 +181,7 @@ func resourceIbmSmPublicCertificateConfigurationCALetsEncryptUpdate(context cont
 	region := id[0]
 	instanceId := id[1]
 	configName := id[2]
-	secretsManagerClient = getClientWithInstanceEndpoint(secretsManagerClient, instanceId, region, getEndpointType(secretsManagerClient, d))
+	secretsManagerClient = getClientWithInstanceEndpoint(secretsManagerClient, instanceId, region, getEndpointType(secretsManagerClient, d), endpointsFile)
 
 	updateConfigurationOptions := &secretsmanagerv2.UpdateConfigurationOptions{}
 
@@ -221,7 +221,7 @@ func resourceIbmSmPublicCertificateConfigurationCALetsEncryptUpdate(context cont
 }
 
 func resourceIbmSmPublicCertificateConfigurationCALetsEncryptDelete(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	secretsManagerClient, err := meta.(conns.ClientSession).SecretsManagerV2()
+	secretsManagerClient, endpointsFile, err := getSecretsManagerSession(meta.(conns.ClientSession))
 	if err != nil {
 		tfErr := flex.TerraformErrorf(err, "", PublicCertConfigCALetsEncryptResourceName, "delete")
 		return tfErr.GetDiag()
@@ -231,7 +231,7 @@ func resourceIbmSmPublicCertificateConfigurationCALetsEncryptDelete(context cont
 	region := id[0]
 	instanceId := id[1]
 	configName := id[2]
-	secretsManagerClient = getClientWithInstanceEndpoint(secretsManagerClient, instanceId, region, getEndpointType(secretsManagerClient, d))
+	secretsManagerClient = getClientWithInstanceEndpoint(secretsManagerClient, instanceId, region, getEndpointType(secretsManagerClient, d), endpointsFile)
 
 	deleteConfigurationOptions := &secretsmanagerv2.DeleteConfigurationOptions{}
 

--- a/ibm/service/secretsmanager/resource_ibm_sm_public_certificate_configuration_dns_cis.go
+++ b/ibm/service/secretsmanager/resource_ibm_sm_public_certificate_configuration_dns_cis.go
@@ -103,7 +103,7 @@ func ResourceIbmSmConfigurationPublicCertificateDNSCisValidator() *validate.Reso
 }
 
 func resourceIbmSmConfigurationPublicCertificateDNSCisCreate(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	secretsManagerClient, err := meta.(conns.ClientSession).SecretsManagerV2()
+	secretsManagerClient, endpointsFile, err := getSecretsManagerSession(meta.(conns.ClientSession))
 	if err != nil {
 		tfErr := flex.TerraformErrorf(err, "", PublicCertConfigDnsCISResourceName, "create")
 		return tfErr.GetDiag()
@@ -111,7 +111,7 @@ func resourceIbmSmConfigurationPublicCertificateDNSCisCreate(context context.Con
 
 	region := getRegion(secretsManagerClient, d)
 	instanceId := d.Get("instance_id").(string)
-	secretsManagerClient = getClientWithInstanceEndpoint(secretsManagerClient, instanceId, region, getEndpointType(secretsManagerClient, d))
+	secretsManagerClient = getClientWithInstanceEndpoint(secretsManagerClient, instanceId, region, getEndpointType(secretsManagerClient, d), endpointsFile)
 	bodyModelMap := map[string]interface{}{}
 	createConfigurationOptions := &secretsmanagerv2.CreateConfigurationOptions{}
 
@@ -150,7 +150,7 @@ func resourceIbmSmConfigurationPublicCertificateDNSCisCreate(context context.Con
 }
 
 func resourceIbmSmConfigurationPublicCertificateDNSCisRead(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	secretsManagerClient, err := meta.(conns.ClientSession).SecretsManagerV2()
+	secretsManagerClient, endpointsFile, err := getSecretsManagerSession(meta.(conns.ClientSession))
 	if err != nil {
 		tfErr := flex.TerraformErrorf(err, "", PublicCertConfigDnsCISResourceName, "read")
 		return tfErr.GetDiag()
@@ -164,7 +164,7 @@ func resourceIbmSmConfigurationPublicCertificateDNSCisRead(context context.Conte
 	region := id[0]
 	instanceId := id[1]
 	configName := id[2]
-	secretsManagerClient = getClientWithInstanceEndpoint(secretsManagerClient, instanceId, region, getEndpointType(secretsManagerClient, d))
+	secretsManagerClient = getClientWithInstanceEndpoint(secretsManagerClient, instanceId, region, getEndpointType(secretsManagerClient, d), endpointsFile)
 	getConfigurationOptions := &secretsmanagerv2.GetConfigurationOptions{}
 
 	getConfigurationOptions.SetName(configName)
@@ -232,7 +232,7 @@ func resourceIbmSmConfigurationPublicCertificateDNSCisRead(context context.Conte
 }
 
 func resourceIbmSmConfigurationPublicCertificateDNSCisUpdate(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	secretsManagerClient, err := meta.(conns.ClientSession).SecretsManagerV2()
+	secretsManagerClient, endpointsFile, err := getSecretsManagerSession(meta.(conns.ClientSession))
 	if err != nil {
 		tfErr := flex.TerraformErrorf(err, "", PublicCertConfigDnsCISResourceName, "update")
 		return tfErr.GetDiag()
@@ -242,7 +242,7 @@ func resourceIbmSmConfigurationPublicCertificateDNSCisUpdate(context context.Con
 	region := id[0]
 	instanceId := id[1]
 	configName := id[2]
-	secretsManagerClient = getClientWithInstanceEndpoint(secretsManagerClient, instanceId, region, getEndpointType(secretsManagerClient, d))
+	secretsManagerClient = getClientWithInstanceEndpoint(secretsManagerClient, instanceId, region, getEndpointType(secretsManagerClient, d), endpointsFile)
 	updateConfigurationOptions := &secretsmanagerv2.UpdateConfigurationOptions{}
 
 	updateConfigurationOptions.SetName(configName)
@@ -275,7 +275,7 @@ func resourceIbmSmConfigurationPublicCertificateDNSCisUpdate(context context.Con
 }
 
 func resourceIbmSmConfigurationPublicCertificateDNSCisDelete(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	secretsManagerClient, err := meta.(conns.ClientSession).SecretsManagerV2()
+	secretsManagerClient, endpointsFile, err := getSecretsManagerSession(meta.(conns.ClientSession))
 	if err != nil {
 		tfErr := flex.TerraformErrorf(err, "", PublicCertConfigDnsCISResourceName, "delete")
 		return tfErr.GetDiag()
@@ -285,7 +285,7 @@ func resourceIbmSmConfigurationPublicCertificateDNSCisDelete(context context.Con
 	region := id[0]
 	instanceId := id[1]
 	configName := id[2]
-	secretsManagerClient = getClientWithInstanceEndpoint(secretsManagerClient, instanceId, region, getEndpointType(secretsManagerClient, d))
+	secretsManagerClient = getClientWithInstanceEndpoint(secretsManagerClient, instanceId, region, getEndpointType(secretsManagerClient, d), endpointsFile)
 	deleteConfigurationOptions := &secretsmanagerv2.DeleteConfigurationOptions{}
 
 	deleteConfigurationOptions.SetName(configName)

--- a/ibm/service/secretsmanager/resource_ibm_sm_public_certificate_configuration_dns_classic_infrastructure.go
+++ b/ibm/service/secretsmanager/resource_ibm_sm_public_certificate_configuration_dns_classic_infrastructure.go
@@ -103,7 +103,7 @@ func ResourceIbmSmPublicCertificateConfigurationDNSClassicInfrastructureValidato
 }
 
 func resourceIbmSmPublicCertificateConfigurationDNSClassicInfrastructureCreate(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	secretsManagerClient, err := meta.(conns.ClientSession).SecretsManagerV2()
+	secretsManagerClient, endpointsFile, err := getSecretsManagerSession(meta.(conns.ClientSession))
 	if err != nil {
 		tfErr := flex.TerraformErrorf(err, "", PublicCertConfigDnsClassicInfrastructureResourceName, "create")
 		return tfErr.GetDiag()
@@ -111,7 +111,7 @@ func resourceIbmSmPublicCertificateConfigurationDNSClassicInfrastructureCreate(c
 
 	region := getRegion(secretsManagerClient, d)
 	instanceId := d.Get("instance_id").(string)
-	secretsManagerClient = getClientWithInstanceEndpoint(secretsManagerClient, instanceId, region, getEndpointType(secretsManagerClient, d))
+	secretsManagerClient = getClientWithInstanceEndpoint(secretsManagerClient, instanceId, region, getEndpointType(secretsManagerClient, d), endpointsFile)
 	bodyModelMap := map[string]interface{}{}
 	createConfigurationOptions := &secretsmanagerv2.CreateConfigurationOptions{}
 
@@ -148,7 +148,7 @@ func resourceIbmSmPublicCertificateConfigurationDNSClassicInfrastructureCreate(c
 }
 
 func resourceIbmSmPublicCertificateConfigurationDNSClassicInfrastructureRead(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	secretsManagerClient, err := meta.(conns.ClientSession).SecretsManagerV2()
+	secretsManagerClient, endpointsFile, err := getSecretsManagerSession(meta.(conns.ClientSession))
 	if err != nil {
 		tfErr := flex.TerraformErrorf(err, "", PublicCertConfigDnsClassicInfrastructureResourceName, "read")
 		return tfErr.GetDiag()
@@ -162,7 +162,7 @@ func resourceIbmSmPublicCertificateConfigurationDNSClassicInfrastructureRead(con
 	region := id[0]
 	instanceId := id[1]
 	configName := id[2]
-	secretsManagerClient = getClientWithInstanceEndpoint(secretsManagerClient, instanceId, region, getEndpointType(secretsManagerClient, d))
+	secretsManagerClient = getClientWithInstanceEndpoint(secretsManagerClient, instanceId, region, getEndpointType(secretsManagerClient, d), endpointsFile)
 	getConfigurationOptions := &secretsmanagerv2.GetConfigurationOptions{}
 
 	getConfigurationOptions.SetName(configName)
@@ -230,7 +230,7 @@ func resourceIbmSmPublicCertificateConfigurationDNSClassicInfrastructureRead(con
 }
 
 func resourceIbmSmPublicCertificateConfigurationDNSClassicInfrastructureUpdate(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	secretsManagerClient, err := meta.(conns.ClientSession).SecretsManagerV2()
+	secretsManagerClient, endpointsFile, err := getSecretsManagerSession(meta.(conns.ClientSession))
 	if err != nil {
 		tfErr := flex.TerraformErrorf(err, "", PublicCertConfigDnsClassicInfrastructureResourceName, "update")
 		return tfErr.GetDiag()
@@ -240,7 +240,7 @@ func resourceIbmSmPublicCertificateConfigurationDNSClassicInfrastructureUpdate(c
 	region := id[0]
 	instanceId := id[1]
 	configName := id[2]
-	secretsManagerClient = getClientWithInstanceEndpoint(secretsManagerClient, instanceId, region, getEndpointType(secretsManagerClient, d))
+	secretsManagerClient = getClientWithInstanceEndpoint(secretsManagerClient, instanceId, region, getEndpointType(secretsManagerClient, d), endpointsFile)
 	updateConfigurationOptions := &secretsmanagerv2.UpdateConfigurationOptions{}
 
 	updateConfigurationOptions.SetName(configName)
@@ -273,7 +273,7 @@ func resourceIbmSmPublicCertificateConfigurationDNSClassicInfrastructureUpdate(c
 }
 
 func resourceIbmSmPublicCertificateConfigurationDNSClassicInfrastructureDelete(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	secretsManagerClient, err := meta.(conns.ClientSession).SecretsManagerV2()
+	secretsManagerClient, endpointsFile, err := getSecretsManagerSession(meta.(conns.ClientSession))
 	if err != nil {
 		tfErr := flex.TerraformErrorf(err, "", PublicCertConfigDnsClassicInfrastructureResourceName, "delete")
 		return tfErr.GetDiag()
@@ -283,7 +283,7 @@ func resourceIbmSmPublicCertificateConfigurationDNSClassicInfrastructureDelete(c
 	region := id[0]
 	instanceId := id[1]
 	configName := id[2]
-	secretsManagerClient = getClientWithInstanceEndpoint(secretsManagerClient, instanceId, region, getEndpointType(secretsManagerClient, d))
+	secretsManagerClient = getClientWithInstanceEndpoint(secretsManagerClient, instanceId, region, getEndpointType(secretsManagerClient, d), endpointsFile)
 	deleteConfigurationOptions := &secretsmanagerv2.DeleteConfigurationOptions{}
 
 	deleteConfigurationOptions.SetName(configName)

--- a/ibm/service/secretsmanager/resource_ibm_sm_secret_group.go
+++ b/ibm/service/secretsmanager/resource_ibm_sm_secret_group.go
@@ -86,7 +86,7 @@ func ResourceIbmSmSecretGroupValidator() *validate.ResourceValidator {
 }
 
 func resourceIbmSmSecretGroupCreate(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	secretsManagerClient, err := meta.(conns.ClientSession).SecretsManagerV2()
+	secretsManagerClient, endpointsFile, err := getSecretsManagerSession(meta.(conns.ClientSession))
 	if err != nil {
 		tfErr := flex.TerraformErrorf(err, "", SecretGroupResourceName, "create")
 		return tfErr.GetDiag()
@@ -94,7 +94,7 @@ func resourceIbmSmSecretGroupCreate(context context.Context, d *schema.ResourceD
 
 	region := getRegion(secretsManagerClient, d)
 	instanceId := d.Get("instance_id").(string)
-	secretsManagerClient = getClientWithInstanceEndpoint(secretsManagerClient, instanceId, region, getEndpointType(secretsManagerClient, d))
+	secretsManagerClient = getClientWithInstanceEndpoint(secretsManagerClient, instanceId, region, getEndpointType(secretsManagerClient, d), endpointsFile)
 
 	createSecretGroupOptions := &secretsmanagerv2.CreateSecretGroupOptions{}
 
@@ -117,7 +117,7 @@ func resourceIbmSmSecretGroupCreate(context context.Context, d *schema.ResourceD
 }
 
 func resourceIbmSmSecretGroupRead(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	secretsManagerClient, err := meta.(conns.ClientSession).SecretsManagerV2()
+	secretsManagerClient, endpointsFile, err := getSecretsManagerSession(meta.(conns.ClientSession))
 	if err != nil {
 		tfErr := flex.TerraformErrorf(err, "", SecretGroupResourceName, "read")
 		return tfErr.GetDiag()
@@ -131,7 +131,7 @@ func resourceIbmSmSecretGroupRead(context context.Context, d *schema.ResourceDat
 	region := id[0]
 	instanceId := id[1]
 	secretGroupId := id[2]
-	secretsManagerClient = getClientWithInstanceEndpoint(secretsManagerClient, instanceId, region, getEndpointType(secretsManagerClient, d))
+	secretsManagerClient = getClientWithInstanceEndpoint(secretsManagerClient, instanceId, region, getEndpointType(secretsManagerClient, d), endpointsFile)
 
 	getSecretGroupOptions := &secretsmanagerv2.GetSecretGroupOptions{}
 
@@ -181,7 +181,7 @@ func resourceIbmSmSecretGroupRead(context context.Context, d *schema.ResourceDat
 }
 
 func resourceIbmSmSecretGroupUpdate(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	secretsManagerClient, err := meta.(conns.ClientSession).SecretsManagerV2()
+	secretsManagerClient, endpointsFile, err := getSecretsManagerSession(meta.(conns.ClientSession))
 	if err != nil {
 		tfErr := flex.TerraformErrorf(err, "", SecretGroupResourceName, "update")
 		return tfErr.GetDiag()
@@ -191,7 +191,7 @@ func resourceIbmSmSecretGroupUpdate(context context.Context, d *schema.ResourceD
 	region := id[0]
 	instanceId := id[1]
 	secretGroupId := id[2]
-	secretsManagerClient = getClientWithInstanceEndpoint(secretsManagerClient, instanceId, region, getEndpointType(secretsManagerClient, d))
+	secretsManagerClient = getClientWithInstanceEndpoint(secretsManagerClient, instanceId, region, getEndpointType(secretsManagerClient, d), endpointsFile)
 
 	updateSecretGroupOptions := &secretsmanagerv2.UpdateSecretGroupOptions{}
 
@@ -225,7 +225,7 @@ func resourceIbmSmSecretGroupUpdate(context context.Context, d *schema.ResourceD
 }
 
 func resourceIbmSmSecretGroupDelete(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	secretsManagerClient, err := meta.(conns.ClientSession).SecretsManagerV2()
+	secretsManagerClient, endpointsFile, err := getSecretsManagerSession(meta.(conns.ClientSession))
 	if err != nil {
 		tfErr := flex.TerraformErrorf(err, "", SecretGroupResourceName, "delete")
 		return tfErr.GetDiag()
@@ -235,7 +235,7 @@ func resourceIbmSmSecretGroupDelete(context context.Context, d *schema.ResourceD
 	region := id[0]
 	instanceId := id[1]
 	secretGroupId := id[2]
-	secretsManagerClient = getClientWithInstanceEndpoint(secretsManagerClient, instanceId, region, getEndpointType(secretsManagerClient, d))
+	secretsManagerClient = getClientWithInstanceEndpoint(secretsManagerClient, instanceId, region, getEndpointType(secretsManagerClient, d), endpointsFile)
 
 	deleteSecretGroupOptions := &secretsmanagerv2.DeleteSecretGroupOptions{}
 

--- a/ibm/service/secretsmanager/resource_ibm_sm_service_credentials_secret.go
+++ b/ibm/service/secretsmanager/resource_ibm_sm_service_credentials_secret.go
@@ -305,7 +305,7 @@ func ResourceIbmSmServiceCredentialsSecret() *schema.Resource {
 }
 
 func resourceIbmSmServiceCredentialsSecretCreate(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	secretsManagerClient, err := meta.(conns.ClientSession).SecretsManagerV2()
+	secretsManagerClient, endpointsFile, err := getSecretsManagerSession(meta.(conns.ClientSession))
 	if err != nil {
 		tfErr := flex.TerraformErrorf(err, "", ServiceCredentialsSecretResourceName, "create")
 		return tfErr.GetDiag()
@@ -313,7 +313,7 @@ func resourceIbmSmServiceCredentialsSecretCreate(context context.Context, d *sch
 
 	region := getRegion(secretsManagerClient, d)
 	instanceId := d.Get("instance_id").(string)
-	secretsManagerClient = getClientWithInstanceEndpoint(secretsManagerClient, instanceId, region, getEndpointType(secretsManagerClient, d))
+	secretsManagerClient = getClientWithInstanceEndpoint(secretsManagerClient, instanceId, region, getEndpointType(secretsManagerClient, d), endpointsFile)
 
 	createSecretOptions := &secretsmanagerv2.CreateSecretOptions{}
 
@@ -339,7 +339,7 @@ func resourceIbmSmServiceCredentialsSecretCreate(context context.Context, d *sch
 }
 
 func resourceIbmSmServiceCredentialsSecretRead(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	secretsManagerClient, err := meta.(conns.ClientSession).SecretsManagerV2()
+	secretsManagerClient, endpointsFile, err := getSecretsManagerSession(meta.(conns.ClientSession))
 	if err != nil {
 		tfErr := flex.TerraformErrorf(err, "", ServiceCredentialsSecretResourceName, "read")
 		return tfErr.GetDiag()
@@ -353,7 +353,7 @@ func resourceIbmSmServiceCredentialsSecretRead(context context.Context, d *schem
 	region := id[0]
 	instanceId := id[1]
 	secretId := id[2]
-	secretsManagerClient = getClientWithInstanceEndpoint(secretsManagerClient, instanceId, region, getEndpointType(secretsManagerClient, d))
+	secretsManagerClient = getClientWithInstanceEndpoint(secretsManagerClient, instanceId, region, getEndpointType(secretsManagerClient, d), endpointsFile)
 
 	getSecretOptions := &secretsmanagerv2.GetSecretOptions{}
 
@@ -512,7 +512,7 @@ func resourceIbmSmServiceCredentialsSecretRead(context context.Context, d *schem
 }
 
 func resourceIbmSmServiceCredentialsSecretUpdate(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	secretsManagerClient, err := meta.(conns.ClientSession).SecretsManagerV2()
+	secretsManagerClient, endpointsFile, err := getSecretsManagerSession(meta.(conns.ClientSession))
 	if err != nil {
 		tfErr := flex.TerraformErrorf(err, "", ServiceCredentialsSecretResourceName, "update")
 		return tfErr.GetDiag()
@@ -522,7 +522,7 @@ func resourceIbmSmServiceCredentialsSecretUpdate(context context.Context, d *sch
 	region := id[0]
 	instanceId := id[1]
 	secretId := id[2]
-	secretsManagerClient = getClientWithInstanceEndpoint(secretsManagerClient, instanceId, region, getEndpointType(secretsManagerClient, d))
+	secretsManagerClient = getClientWithInstanceEndpoint(secretsManagerClient, instanceId, region, getEndpointType(secretsManagerClient, d), endpointsFile)
 
 	updateSecretMetadataOptions := &secretsmanagerv2.UpdateSecretMetadataOptions{}
 
@@ -605,7 +605,7 @@ func resourceIbmSmServiceCredentialsSecretUpdate(context context.Context, d *sch
 }
 
 func resourceIbmSmServiceCredentialsSecretDelete(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	secretsManagerClient, err := meta.(conns.ClientSession).SecretsManagerV2()
+	secretsManagerClient, endpointsFile, err := getSecretsManagerSession(meta.(conns.ClientSession))
 	if err != nil {
 		tfErr := flex.TerraformErrorf(err, "", ServiceCredentialsSecretResourceName, "delete")
 		return tfErr.GetDiag()
@@ -615,7 +615,7 @@ func resourceIbmSmServiceCredentialsSecretDelete(context context.Context, d *sch
 	region := id[0]
 	instanceId := id[1]
 	secretId := id[2]
-	secretsManagerClient = getClientWithInstanceEndpoint(secretsManagerClient, instanceId, region, getEndpointType(secretsManagerClient, d))
+	secretsManagerClient = getClientWithInstanceEndpoint(secretsManagerClient, instanceId, region, getEndpointType(secretsManagerClient, d), endpointsFile)
 
 	deleteSecretOptions := &secretsmanagerv2.DeleteSecretOptions{}
 

--- a/ibm/service/secretsmanager/resource_ibm_sm_username_password_secret.go
+++ b/ibm/service/secretsmanager/resource_ibm_sm_username_password_secret.go
@@ -216,7 +216,7 @@ func ResourceIbmSmUsernamePasswordSecret() *schema.Resource {
 }
 
 func resourceIbmSmUsernamePasswordSecretCreate(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	secretsManagerClient, err := meta.(conns.ClientSession).SecretsManagerV2()
+	secretsManagerClient, endpointsFile, err := getSecretsManagerSession(meta.(conns.ClientSession))
 	if err != nil {
 		tfErr := flex.TerraformErrorf(err, "", UsernamePasswordSecretResourceName, "create")
 		return tfErr.GetDiag()
@@ -224,7 +224,7 @@ func resourceIbmSmUsernamePasswordSecretCreate(context context.Context, d *schem
 
 	region := getRegion(secretsManagerClient, d)
 	instanceId := d.Get("instance_id").(string)
-	secretsManagerClient = getClientWithInstanceEndpoint(secretsManagerClient, instanceId, region, getEndpointType(secretsManagerClient, d))
+	secretsManagerClient = getClientWithInstanceEndpoint(secretsManagerClient, instanceId, region, getEndpointType(secretsManagerClient, d), endpointsFile)
 
 	createSecretOptions := &secretsmanagerv2.CreateSecretOptions{}
 
@@ -287,7 +287,7 @@ func waitForIbmSmUsernamePasswordSecretCreate(secretsManagerClient *secretsmanag
 }
 
 func resourceIbmSmUsernamePasswordSecretRead(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	secretsManagerClient, err := meta.(conns.ClientSession).SecretsManagerV2()
+	secretsManagerClient, endpointsFile, err := getSecretsManagerSession(meta.(conns.ClientSession))
 	if err != nil {
 		tfErr := flex.TerraformErrorf(err, "", UsernamePasswordSecretResourceName, "read")
 		return tfErr.GetDiag()
@@ -301,7 +301,7 @@ func resourceIbmSmUsernamePasswordSecretRead(context context.Context, d *schema.
 	region := id[0]
 	instanceId := id[1]
 	secretId := id[2]
-	secretsManagerClient = getClientWithInstanceEndpoint(secretsManagerClient, instanceId, region, getEndpointType(secretsManagerClient, d))
+	secretsManagerClient = getClientWithInstanceEndpoint(secretsManagerClient, instanceId, region, getEndpointType(secretsManagerClient, d), endpointsFile)
 
 	getSecretOptions := &secretsmanagerv2.GetSecretOptions{}
 
@@ -452,7 +452,7 @@ func resourceIbmSmUsernamePasswordSecretRead(context context.Context, d *schema.
 }
 
 func resourceIbmSmUsernamePasswordSecretUpdate(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	secretsManagerClient, err := meta.(conns.ClientSession).SecretsManagerV2()
+	secretsManagerClient, endpointsFile, err := getSecretsManagerSession(meta.(conns.ClientSession))
 	if err != nil {
 		tfErr := flex.TerraformErrorf(err, "", UsernamePasswordSecretResourceName, "update")
 		return tfErr.GetDiag()
@@ -462,7 +462,7 @@ func resourceIbmSmUsernamePasswordSecretUpdate(context context.Context, d *schem
 	region := id[0]
 	instanceId := id[1]
 	secretId := id[2]
-	secretsManagerClient = getClientWithInstanceEndpoint(secretsManagerClient, instanceId, region, getEndpointType(secretsManagerClient, d))
+	secretsManagerClient = getClientWithInstanceEndpoint(secretsManagerClient, instanceId, region, getEndpointType(secretsManagerClient, d), endpointsFile)
 
 	updateSecretMetadataOptions := &secretsmanagerv2.UpdateSecretMetadataOptions{}
 
@@ -593,7 +593,7 @@ func resourceIbmSmUsernamePasswordSecretUpdate(context context.Context, d *schem
 }
 
 func resourceIbmSmUsernamePasswordSecretDelete(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	secretsManagerClient, err := meta.(conns.ClientSession).SecretsManagerV2()
+	secretsManagerClient, endpointsFile, err := getSecretsManagerSession(meta.(conns.ClientSession))
 	if err != nil {
 		tfErr := flex.TerraformErrorf(err, "", UsernamePasswordSecretResourceName, "delete")
 		return tfErr.GetDiag()
@@ -603,7 +603,7 @@ func resourceIbmSmUsernamePasswordSecretDelete(context context.Context, d *schem
 	region := id[0]
 	instanceId := id[1]
 	secretId := id[2]
-	secretsManagerClient = getClientWithInstanceEndpoint(secretsManagerClient, instanceId, region, getEndpointType(secretsManagerClient, d))
+	secretsManagerClient = getClientWithInstanceEndpoint(secretsManagerClient, instanceId, region, getEndpointType(secretsManagerClient, d), endpointsFile)
 
 	deleteSecretOptions := &secretsmanagerv2.DeleteSecretOptions{}
 


### PR DESCRIPTION
Currently to run Secrets Manager resources in the staging environment you need to set the environment variable `IBMCLOUD_IAM_API_ENDPOINT` . The secrets manager resources do not use the endpoint file if configured. This PR is to allow setting the endpoints with an endpoints file.

<!--- See what makes a good Pull Request at : https://github.com/IBM-Cloud/terraform-provider-ibm/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
haims@Haims-MBP terraform-provider-ibm % make testacc TEST=./ibm/service/secretsmanager 
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./ibm/service/secretsmanager -v  -timeout 700m 
[WARN] Set the environment variable IBM_PROJECTS_CONFIG_APIKEY for testing IBM Projects Config resources, the tests will fail if this is not set
[WARN] Set the environment variable IBM_APPID_TENANT_ID for testing AppID resources, AppID tests will fail if this is not set
[WARN] Set the environment variable IBM_APPID_TEST_USER_EMAIL for testing AppID user resources, the tests will fail if this is not set
[WARN] Set the environment variable IBM_ORG for testing ibm_org  resource Some tests for that resource will fail if this is not set correctly
[WARN] Set the environment variable IBM_SPACE for testing ibm_space  resource Some tests for that resource will fail if this is not set correctly
[WARN] Set the environment variable IBM_ID1 for testing ibm_space resource Some tests for that resource will fail if this is not set correctly
[WARN] Set the environment variable IBM_ID2 for testing ibm_space resource Some tests for that resource will fail if this is not set correctly
[WARN] Set the environment variable IBM_IAMUSER for testing ibm_iam_user_policy resource Some tests for that resource will fail if this is not set correctly
[WARN] Set the environment variable IBM_IAMACCOUNTID for testing ibm_iam_trusted_profile resource Some tests for that resource will fail if this is not set correctly
[WARN] Set the environment variable IBM_IAM_SERVICE_ID for testing ibm_iam_trusted_profile_identity resource Some tests for that resource will fail if this is not set correctly
[WARN] Set the environment variable IBM_IAM_TRUSTED_PROFILE_ID for testing ibm_iam_trusted_profile_identity resource Some tests for that resource will fail if this is not set correctly
[WARN] Set the environment variable IBM_DATACENTER for testing ibm_container_cluster resource else it is set to default value 'par01'
[WARN] Set the environment variable IBM_MACHINE_TYPE for testing ibm_container_cluster resource else it is set to default value 'b3c.4x16'
[WARN] Set the environment variable IBM_CERT_CRN for testing ibm_container_alb_cert or ibm_container_ingress_secret_tls resource else it is set to default value
[WARN] Set the environment variable IBM_UPDATE_CERT_CRN for testing ibm_container_alb_cert or ibm_container_ingress_secret_tls resource else it is set to default value
[WARN] Set the environment variable IBM_SECRET_CRN for testing ibm_container_ingress_secret_opaque resource else it is set to default value
[WARN] Set the environment variable IBM_SECRET_CRN_2 for testing ibm_container_ingress_secret_opaque resource else it is set to default value
[WARN] Set the environment variable IBM_INGRESS_INSTANCE_CRN for testing ibm_container_ingress_instance resource. Some tests for that resource will fail if this is not set correctly
[WARN] Set the environment variable IBM_INGRESS_INSTANCE_SECRET_GROUP_ID for testing ibm_container_ingress_instance resource. Some tests for that resource will fail if this is not set correctly
[WARN] Set the environment variable IBM_CONTAINER_REGION for testing ibm_container resources else it is set to default value 'eu-de'
[WARN] Set the environment variable IBM_CIS_INSTANCE with a VALID CIS Instance NAME for testing ibm_cis resources on staging/test
[WARN] Set the environment variable IBM_CIS_DOMAIN_STATIC with the Domain name registered with the CIS instance on test/staging. Domain must be predefined in CIS to avoid CIS billing costs due to domain delete/create
[WARN] Set the environment variable IBM_CIS_DOMAIN_TEST with a VALID Domain name for testing the one time create and delete of a domain in CIS. Note each create/delete will trigger a monthly billing instance. Only to be run in staging/test
[WARN] Set the environment variable IBM_CIS_RESOURCE_GROUP with the resource group for the CIS Instance 
[WARN] Set the environment variable IBM_COS_CRN with a VALID COS instance CRN for testing ibm_cos_* resources
[WARN] Set the environment variable IBM_COS_Bucket_CRN with a VALID BUCKET CRN for testing ibm_cos_bucket* resources
[WARN] Set the environment variable IBM_COS_Backup_Vault with a VALID BACKUP VAULT NAME  for testing ibm_cos_backup_vault* resources
[WARN] Set the environment variable IBM_KMS_KEY_CRN with a VALID key crn for a KP/HPCS root key
[WARN] Set the environment variable IBM_COS_Backup_Policy_Id with a VALID POLICYS ID for testing ibm_cos_backup_policy* resources
[WARN] Set the environment variable IBM_COS_ACTIVITY_TRACKER_CRN with a VALID ACTIVITY TRACKER INSTANCE CRN in valid region for testing ibm_cos_bucket* resources
[WARN] Set the environment variable IBM_COS_METRICS_MONITORING_CRN with a VALID METRICS MONITORING CRN for testing ibm_cos_bucket* resources
[WARN] Set the environment variable IBM_COS_BUCKET_NAME with a VALID BUCKET Name for testing ibm_cos_bucket* resources
[WARN] Set the environment variable IBM_COS_NAME with a VALID COS instance name for testing resources with cos deps
[WARN] Set the environment variable IBM_TRUSTED_MACHINE_TYPE for testing ibm_container_cluster resource else it is set to default value 'mb1c.16x64'
[WARN] Set the environment variable IBM_BM_EXTENDED_HW_TESTING to true/false for testing ibm_compute_bare_metal resource else it is set to default value 'false'
[WARN] Set the environment variable IBM_PUBLIC_VLAN_ID for testing ibm_container_cluster resource else it is set to default value '2393319'
[WARN] Set the environment variable IBM_PRIVATE_VLAN_ID for testing ibm_container_cluster resource else it is set to default value '2393321'
[WARN] Set the environment variable IBM_KUBE_VERSION for testing ibm_container_cluster resource else it is set to default value '1.18.14'
[WARN] Set the environment variable IBM_KUBE_UPDATE_VERSION for testing ibm_container_cluster resource else it is set to default value '1.19.6'
[WARN] Set the environment variable IBM_PRIVATE_SUBNET_ID for testing ibm_container_cluster resource else it is set to default value '1636107'
[WARN] Set the environment variable IBM_PUBLIC_SUBNET_ID for testing ibm_container_cluster resource else it is set to default value '1165645'
[WARN] Set the environment variable IBM_SUBNET_ID for testing ibm_container_cluster resource else it is set to default value '1165645'
[INFO] Set the environment variable IBM_IPSEC_DATACENTER for testing ibm_ipsec_vpn resource else it is set to default value 'tok02'
[INFO] Set the environment variable IBM_IPSEC_CUSTOMER_SUBNET_ID for testing ibm_ipsec_vpn resource else it is set to default value '123456'
[INFO] Set the environment variable IBM_IPSEC_CUSTOMER_PEER_IP for testing ibm_ipsec_vpn resource else it is set to default value '192.168.0.1'
[WARN] Set the environment variable IBM_LBAAS_DATACENTER for testing ibm_lbaas resource else it is set to default value 'dal13'
[WARN] Set the environment variable IBM_LBAAS_SUBNETID for testing ibm_lbaas resource else it is set to default value '2144241'
[WARN] Set the environment variable IBM_LB_LISTENER_CERTIFICATE_INSTANCE for testing ibm_is_lb_listener resource for https redirect else it is set to default value 'crn:v1:staging:public:cloudcerts:us-south:a/2d1bace7b46e4815a81e52c6ffeba5cf:af925157-b125-4db2-b642-adacb8b9c7f5:certificate:c81627a1bf6f766379cc4b98fd2a44ed'
[WARN] Set the environment variable IBM_DEDICATED_HOSTNAME for testing ibm_compute_vm_instance resource else it is set to default value 'terraform-dedicatedhost'
[WARN] Set the environment variable IBM_DEDICATED_HOST_ID for testing ibm_compute_vm_instance resource else it is set to default value '30301'
[WARN] Set the environment variable IBM_WORKER_POOL_ZONE for testing ibm_container_worker_pool_zone_attachment resource else it is set to default value 'ams03'
[WARN] Set the environment variable IBM_WORKER_POOL_ZONE_PRIVATE_VLAN for testing ibm_container_worker_pool_zone_attachment resource else it is set to default value '2538975'
[WARN] Set the environment variable IBM_WORKER_POOL_ZONE_PUBLIC_VLAN for testing ibm_container_worker_pool_zone_attachment resource else it is set to default value '2538967'
[WARN] Set the environment variable IBM_WORKER_POOL_ZONE_UPDATE_PRIVATE_VLAN for testing ibm_container_worker_pool_zone_attachment resource else it is set to default value '2388377'
[WARN] Set the environment variable IBM_WORKER_POOL_ZONE_UPDATE_PUBLIC_VLAN for testing ibm_container_worker_pool_zone_attachment resource else it is set to default value '2388375'
[WARN] Set the environment variable IBM_WORKER_POOL_SECONDARY_STORAGE for testing secondary_storage attachment to IKS workerpools
[WARN] Set the environment variable IBM_PLACEMENT_GROUP_NAME for testing ibm_compute_vm_instance resource else it is set to default value 'terraform-group'
[INFO] Set the environment variable SL_REGION for testing ibm_is_region datasource else it is set to default value 'us-south'
[INFO] Set the environment variable SL_ZONE for testing ibm_is_zone datasource else it is set to default value 'us-south-1'
[INFO] Set the environment variable SL_ZONE_2 for testing ibm_is_zone datasource else it is set to default value 'us-south-2'
[INFO] Set the environment variable SL_ZONE_3 for testing ibm_is_zone datasource else it is set to default value 'us-south-3'
[INFO] Set the environment variable SL_CIDR for testing ibm_is_subnet else it is set to default value '10.240.0.0/24'
[INFO] Set the environment variable SL_CIDR_2 for testing ibm_is_subnet else it is set to default value '10.240.64.0/24'
[INFO] Set the environment variable IS_IPV4_ADDRESS for testing ibm_is_instance else it is set to default value '10.240.0.6'
[INFO] Set the environment variable IS_ACCOUNT_ID for testing private_path_service_gateway_account_policy else it is set to default value 'fee82deba12e4c0fb69c3b09d1f12345'
[INFO] Set the environment variable IS_CLUSTER_NETWORK_PROFILE_NAME for testing cluster_network_profile else it is set to default value 'h100'
[INFO] Set the environment variable IS_INSTANCE_GPU_PROFILE_NAME for testing cluster_network_attachments else it is set to default value 'gx3d-160x1792x8h100'
[INFO] Set the environment variable IS_CLUSTER_NETWORK_SUBNET_PREFIXES_CIDR for testing cluster_network else it is set to default value '10.1.0.0/24'
[INFO] Set the environment variable SL_ADDRESS_PREFIX_CIDR for testing ibm_is_vpc_address_prefix else it is set to default value '10.120.0.0/24'
[INFO] Set the environment variable SL_CIDR_2 for testing ibm_is_subnet else it is set to default value '10.240.64.0/24'
[INFO] Set the environment variable SL_CIDR_2 for testing ibm_is_instance datasource else it is set to default value './test-fixtures/.ssh/pkcs8_rsa.pub'
[INFO] Set the environment variable IS_PRIVATE_SSH_KEY_PATH for testing ibm_is_instance datasource else it is set to default value './test-fixtures/.ssh/pkcs8_rsa'
[INFO] Set the environment variable SL_RESOURCE_GROUP_ID for testing with different resource group id else it is set to default value 'c01d34dff4364763476834c990398zz8'
[INFO] Set the environment variable IS_RESOURCE_CRN for testing with created resource instance
[INFO] Set the environment variable IS_IMAGE for testing ibm_is_instance, ibm_is_floating_ip else it is set to default value 'r006-587a041d-9246-44f0-980b-56a327cf5bd7'
[INFO] Set the environment variable IS_IMAGE2 for testing ibm_is_instance, ibm_is_floating_ip else it is set to default value 'r134-f47cc24c-e020-4db5-ad96-1e5be8b5853b'
[INFO] Set the environment variable IS_WIN_IMAGE for testing ibm_is_instance data source else it is set to default value 'r006-d2e0d0e9-0a4f-4c45-afd7-cab787030776'
[INFO] Set the environment variable IS_COS_BUCKET_NAME for testing ibm_is_image_export_job else it is set to default value 'bucket-27200-lwx4cfvcue'
[INFO] Set the environment variable IS_COS_BUCKET_CRN for testing ibm_is_image_export_job else it is set to default value 'bucket-27200-lwx4cfvcue'
[INFO] Set the environment variable IS_INSTANCE_NAME for testing ibm_is_instance resource else it is set to default value 'instance-01'
[INFO] Set the environment variable IS_BACKUP_POLICY_JOB_ID for testing ibm_is_backup_policy_job datasource
[INFO] Set the environment variable IS_BACKUP_POLICY_ID for testing ibm_is_backup_policy_jobs datasource
[INFO] Set the environment variable IS_REMOTE_CP_BAAS_ENCRYPTION_KEY_CRN for testing remote_copies_policy with Baas plans, else it is set to default value, 'crn:v1:bluemix:public:kms:us-south:a/dffc98a0f1f0f95f6613b3b752286b87:e4a29d1a-2ef0-42a6-8fd2-350deb1c647e:key:5437653b-c4b1-447f-9646-b2a2a4cd6179'
[INFO] Set the environment variable SL_INSTANCE_PROFILE for testing ibm_is_instance resource else it is set to default value 'cx2-2x4'
[INFO] Set the environment variable SL_KMS_INSTANCE_ID for testing ibm_kms_key resource else it is set to default value '30222bb5-1c6d-3834-8d78-ae6348cf8z61'
[INFO] Set the environment variable SL_KMS_KEY_NAME for testing ibm_kms_key resource else it is set to default value 'tfp-test-key'
[INFO] Set the environment variable SL_INSTANCE_PROFILE_UPDATE for testing ibm_is_instance resource else it is set to default value 'cx2-4x8'
[INFO] Set the environment variable IS_BARE_METAL_SERVER_PROFILE for testing ibm_is_bare_metal_server resource else it is set to default value 'bx2-metal-96x384'
[INFO] Set the environment variable IsBareMetalServerImage for testing ibm_is_bare_metal_server resource else it is set to default value 'r006-55a03390-3245-450f-82c4-0cb47f632b59'
[INFO] Set the environment variable IsBareMetalServerImage2 for testing ibm_is_bare_metal_server resource else it is set to default value 'r006-2d1f36b0-df65-4570-82eb-df7ae5f778b1'
[INFO] Set the environment variable IS_DNS_INSTANCE_CRN for testing ibm_is_lb resource else it is set to default value 'crn:v1:staging:public:dns-svcs:global:a/efe5afc483594adaa8325e2b4d1290df:82df2e3c-53a5-43c6-89ce-dcf78be18668::'
[INFO] Set the environment variable IS_DNS_INSTANCE_CRN1 for testing ibm_is_lb resource else it is set to default value 'crn:v1:staging:public:dns-svcs:global:a/efe5afc483594adaa8325e2b4d1290df:599ae4aa-c554-4a88-8bb2-b199b9a3c046::'
[INFO] Set the environment variable IS_DNS_ZONE_ID for testing ibm_is_lb resource else it is set to default value 'dd501d1d-490b-4bb4-a05d-a31954a1c59e'
[INFO] Set the environment variable IS_DNS_ZONE_ID_1 for testing ibm_is_lb resource else it is set to default value 'b1def78d-51b3-4ea5-a746-1b64c992fcab'
[INFO] Set the environment variable IS_DEDICATED_HOST_NAME for testing ibm_is_instance resource else it is set to default value 'tf-dhost-01'
[INFO] Set the environment variable IS_DEDICATED_HOST_GROUP_ID for testing ibm_is_instance resource else it is set to default value '0717-9104e7b5-77ad-44ad-9eaa-091e6b6efce1'
[INFO] Set the environment variable IS_DEDICATED_HOST_PROFILE for testing ibm_is_instance resource else it is set to default value 'bx2d-host-152x608'
[INFO] Set the environment variable IS_DEDICATED_HOST_GROUP_CLASS for testing ibm_is_instance resource else it is set to default value 'bx2d'
[INFO] Set the environment variable IS_DEDICATED_HOST_GROUP_FAMILY for testing ibm_is_instance resource else it is set to default value 'balanced'
[INFO] Set the environment variable SL_INSTANCE_PROFILE for testing ibm_is_instance resource else it is set to default value 'bx2d-16x64'
[INFO] Set the environment variable IS_SHARE_PROFILE for testing ibm_is_instance resource else it is set to default value 'tier-3iops'
[INFO] Set the environment variable IS_SHARE_PROFILE for testing ibm_is_instance resource else it is set to default value
[INFO] Set the environment variable IS_SHARE_PROFILE for testing ibm_is_instance resource else it is set to default value
[INFO] Set the environment variable IS_VOLUME_PROFILE for testing ibm_is_volume_profile else it is set to default value 'general-purpose'
[INFO] Set the environment variable IS_VIRTUAL_NETWORK_INTERFACE for testing ibm_is_virtual_network_interface else it is set to default value 'c93dc4c6-e85a-4da2-9ea6-f24576256122'
[INFO] Set the environment variable IS_FLOATING_IP for testing ibm_is_virtual_network_interface else it is set to default value 'r006-9fc3948f-1b01-406c-baa5-e86b185e559f'
[INFO] Set the environment variable IS_UNATTACHED_BOOT_VOLUME_NAME for testing ibm_is_image else it is set to default value 'r006-1cbe9f0a-7101-4d25-ae72-2a2d725e530e'
[INFO] Set the environment variable IS_VSI_DATA_VOLUME_ID for testing ibm_is_image else it is set to default value 'r006-1cbe9f0a-7101-4d25-ae72-2a2d725e530e'
[INFO] Set the environment variable SL_ROUTE_NEXTHOP else it is set to default value '10.0.0.4'
[INFO] Set the environment variable ISSnapshotCRN for ibm_is_snapshot resource else it is set to default value 'crn:v1:bluemix:public:is:ca-tor:a/xxxxxxxx::snapshot:xxxx-xxxxc-xxx-xxxx-xxxx-xxxxxxxxxx'
[INFO] Set the environment variable ICD_DB_DEPLOYMENT_ID for testing ibm_cloud_databases else it is set to default value 'crn:v1:bluemix:public:databases-for-redis:au-syd:a/40ddc34a953a8c02f10987b59085b60e:5042afe1-72c2-4231-89cc-c949e5d56251::'
[INFO] Set the environment variable ICD_DB_BACKUP_ID for testing ibm_cloud_databases else it is set to default value 'crn:v1:bluemix:public:databases-for-redis:au-syd:a/40ddc34a953a8c02f10987b59085b60e:5042afe1-72c2-4231-89cc-c949e5d56251:backup:0d862fdb-4faa-42e5-aecb-5057f4d399c3'
[INFO] Set the environment variable ICD_DB_TASK_ID for testing ibm_cloud_databases else it is set to default value 'crn:v1:bluemix:public:databases-for-redis:au-syd:a/40ddc34a953a8c02f10987b59085b60e:367b0a22-05bb-41e3-a1ed-ded1ff0889e5:task:882013a6-2751-4df7-a77a-98d258638704'
[INFO] Set the environment variable PI_IMAGE for testing ibm_pi_image resource else it is set to default value '7200-03-03'
[INFO] Set the environment variable PI_SAP_IMAGE for testing ibm_pi_image resource else it is set to default value 'Linux-RHEL-SAP-8-2'
[INFO] Set the environment variable PI_IMAGE_BUCKET_NAME for testing ibm_pi_image resource else it is set to default value 'images-public-bucket'
[INFO] Set the environment variable PI_IMAGE_BUCKET_FILE_NAME for testing ibm_pi_image resource else it is set to default value 'rhel.ova.gz'
[INFO] Set the environment variable PI_IMAGE_BUCKET_ACCESS_KEY for testing ibm_pi_image_export resource else it is set to default value 'images-bucket-access-key'
[INFO] Set the environment variable PI_IMAGE_BUCKET_SECRET_KEY for testing ibm_pi_image_export resource else it is set to default value 'PI_IMAGE_BUCKET_SECRET_KEY'
[INFO] Set the environment variable PI_IMAGE_BUCKET_REGION for testing ibm_pi_image resource else it is set to default value 'us-east'
[INFO] Set the environment variable PI_IMAGE_ID for testing ibm_pi_image resource else it is set to default value 'IBMi-72-09-2924-11'
[INFO] Set the environment variable PI_KEY_NAME for testing ibm_pi_key_name resource else it is set to default value 'terraform-test-power'
[INFO] Set the environment variable PI_NETWORK_NAME for testing ibm_pi_network_name resource else it is set to default value 'terraform-test-power'
[INFO] Set the environment variable PI_NETWORK_ID for testing ibm_pi_network_interface resource else it is set to default value 'terraform-test-power'
[INFO] Set the environment variable PI_NETWORK_INTERFACE_ID for testing ibm_pi_network_interface resource else it is set to default value 'terraform-test-power'
[INFO] Set the environment variable PI_NETWORK_SECURITY_GROUP_ID for testing ibm_pi_network_security_group resource else it is set to default value 'terraform-test-power'
[INFO] Set the environment variable PI_NETWORK_SECURITY_GROUP_RULE_ID for testing ibm_pi_network_security_group resource else it is set to default value 'terraform-test-power'
[INFO] Set the environment variable PI_NETWORK_SECURITY_GROUP_ID for testing ibm_pi_network_security_group resource else it is set to default value 'terraform-test-power'
[INFO] Set the environment variable PI_NETWORK_SECURITY_GROUP_RULE_ID for testing ibm_pi_network_security_group resource else it is set to default value 'terraform-test-power'
[INFO] Set the environment variable PI_VOLUME_NAME for testing ibm_pi_network_name resource else it is set to default value 'terraform-test-power'
[INFO] Set the environment variable PI_VOLUME_ID for testing ibm_pi_volume_flash_copy_mappings resource else it is set to default value 'terraform-test-power'
[INFO] Set the environment variable PI_REPLICATION_VOLUME_NAME for testing ibm_pi_volume resource else it is set to default value 'terraform-test-power'
[INFO] Set the environment variable PI_VOLUME_ONBARDING_SOURCE_CRN for testing ibm_pi_volume_onboarding resource else it is set to default value 'terraform-test-power'
[INFO] Set the environment variable PI_AUXILIARY_VOLUME_NAME for testing ibm_pi_volume_onboarding resource else it is set to default value 'terraform-test-power'
[INFO] Set the environment variable PI_VOLUME_GROUP_NAME for testing ibm_pi_volume_group resource else it is set to default value 'terraform-test-power'
[INFO] Set the environment variable PI_VOLUME_GROUP_ID for testing ibm_pi_volume_group_storage_details data source else it is set to default value 'terraform-test-power'
[INFO] Set the environment variable PI_VOLUME_ONBOARDING_ID for testing ibm_pi_volume_onboarding resource else it is set to default value 'terraform-test-power'
[INFO] Set the environment variable PI_CLOUDINSTANCE_ID for testing ibm_pi_image resource else it is set to default value 'd16705bd-7f1a-48c9-9e0e-1c17b71e7331'
[INFO] Set the environment variable PI_SNAPSHOT_ID for testing ibm_pi_instance_snapshot data source else it is set to default value '1ea33118-4c43-4356-bfce-904d0658de82'
[INFO] Set the environment variable PI_PVM_INSTANCE_ID for testing Pi_instance_name resource else it is set to default value 'terraform-test-power'
[INFO] Set the environment variable PI_DHCP_ID for testing ibm_pi_dhcp resource else it is set to default value 'terraform-test-power'
[INFO] Set the environment variable PI_CLOUD_CONNECTION_NAME for testing ibm_pi_cloud_connection resource else it is set to default value 'terraform-test-power'
[INFO] Set the environment variable PI_SAP_PROFILE_ID for testing ibm_pi_sap_profile resource else it is set to default value 'terraform-test-power'
[WARN] Set the environment variable PI_PLACEMENT_GROUP_NAME for testing ibm_pi_placement_group resource else it is set to default value 'tf-pi-placement-group'
[WARN] Set the environment variable PI_REMOTE_ID for testing ibm_pi_network_security_group resource else it is set to default value 'terraform-test-power'
[WARN] Set the environment variable PI_REMOTE_TYPE for testing ibm_pi_network_security_group resource else it is set to default value 'terraform-test-power'
[WARN] Set the environment variable PI_SPP_PLACEMENT_GROUP_ID for testing ibm_pi_spp_placement_group resource else it is set to default value 'tf-pi-spp-placement-group'
[INFO] Set the environment variable PI_STORAGE_POOL for testing ibm_pi_storage_pool_capacity else it is set to default value 'terraform-test-power'
[INFO] Set the environment variable PI_STORAGE_TYPE for testing ibm_pi_storage_type_capacity else it is set to default value 'terraform-test-power'
[INFO] Set the environment variable PI_CAPTURE_STORAGE_IMAGE_PATH for testing Pi_capture_storage_image_path resource else it is set to default value 'terraform-test-power'
[INFO] Set the environment variable PI_CAPTURE_CLOUD_STORAGE_ACCESS_KEY for testing Pi_capture_cloud_storage_access_key resource else it is set to default value 'terraform-test-power'
[INFO] Set the environment variable PI_CAPTURE_CLOUD_STORAGE_SECRET_KEY for testing Pi_capture_cloud_storage_secret_key resource else it is set to default value 'terraform-test-power'
[INFO] Set the environment variable PI_CAPTURE_CLOUD_STORAGE_REGION for testing Pi_capture_cloud_storage_region resource else it is set to default value 'us-south'
[WARN] Set the environment variable PI_SHARED_PROCESSOR_POOL_ID for testing ibm_pi_shared_processor_pool resource else it is set to default value 'tf-pi-shared-processor-pool'
[WARN] Set the environment variable PI_STORAGE_CONNECTION for testing pi_storage_connection resource else it is empty
[INFO] Set the environment variable PI_TARGET_STORAGE_TIER for testing Pi_target_storage_tier resource else it is set to default value 'terraform-test-tier'
[INFO] Set the environment variable PI_VOLUME_CLONE_TASK_ID for testing Pi_volume_clone_task_id resource else it is set to default value 'terraform-test-volume-clone-task-id'
[INFO] Set the environment variable PI_VIRTUAL_SERIAL_NUMBER for testing ibm_pi_virtual_serial_number data source else it is set to default value 'terraform-test-power'
[WARN] Set the environment variable PI_RESOURCE_GROUP_ID for testing ibm_pi_workspace resource else it is set to default value ''
[WARN] Set the environment variable PI_HOST_GROUP_ID for testing ibm_pi_host resource else it is set to default value ''
[WARN] Set the environment variable PI_HOST_ID for testing ibm_pi_host resource else it is set to default value ''
[INFO] Set the environment variable PI_NETWORK_ADDRESS_GROUP_ID for testing ibm_pi_network_address_group data source else it is set to default value 'terraform-test-power'
[INFO] Set the environment variable SCHEMATICS_WORKSPACE_ID for testing schematics resources else it is set to default value
[INFO] Set the environment variable SCHEMATICS_TEMPLATE_ID for testing schematics resources else it is set to default value
[INFO] Set the environment variable SCHEMATICS_ACTION_ID for testing schematics resources else it is set to default value
[INFO] Set the environment variable SCHEMATICS_AGENT_ID for testing schematics resources else it is set to default value
[INFO] Set the environment variable SCHEMATICS_JOB_ID for testing schematics resources else it is set to default value
[INFO] Set the environment variable SCHEMATICS_REPO_URL for testing schematics resources else tests will fail if this is not set correctly
[INFO] Set the environment variable SCHEMATICS_REPO_BRANCH for testing schematics resources else tests will fail if this is not set correctly
[WARN] Set the environment variable IMAGE_COS_URL with a VALID COS Image SQL URL for testing ibm_is_image resources on staging/test
[WARN] Set the environment variable IS_DELEGATED_VPC with a VALID created vpc name for testing ibm_is_vpc data source on staging/test
[WARN] Set the environment variable IMAGE_COS_URL_ENCRYPTED with a VALID COS Image SQL URL for testing ibm_is_image resources on staging/test
[WARN] Set the environment variable IMAGE_OPERATING_SYSTEM with a VALID Operating system for testing ibm_is_image resources on staging/test
[INFO] Set the environment variable IS_IMAGE_NAME for testing data source ibm_is_image else it is set to default value `ibm-ubuntu-18-04-1-minimal-amd64-2`
[INFO] Set the environment variable IS_IMAGE_NAME2 for testing data source ibm_is_image else it is set to default value `ibm-ubuntu-20-04-6-minimal-amd64-5`
[INFO] Set the environment variable IS_IMAGE_ENCRYPTED_DATA_KEY for testing resource ibm_is_image else it is set to default value
[INFO] Set the environment variable IS_IMAGE_ENCRYPTION_KEY for testing resource ibm_is_image else it is set to default value
[INFO] Set the environment variable IBM_FUNCTION_NAMESPACE for testing ibm_function_package, ibm_function_action, ibm_function_rule, ibm_function_trigger resource else  tests will fail if this is not set correctly
[INFO] Set the environment variable HPCS_INSTANCE_ID for testing data_source_ibm_kms_key_test else it is set to default value
[INFO] Set the environment variable IBM_TG_CROSS_ACCOUNT_API_KEY for testing ibm_tg_connection resource else  tests will fail if this is not set correctly
[INFO] Set the environment variable IBM_TG_CROSS_ACCOUNT_ID for testing ibm_tg_connection resource else  tests will fail if this is not set correctly
[INFO] Set the environment variable IBM_TG_CROSS_NETWORK_ID for testing ibm_tg_connection resource else  tests will fail if this is not set correctly
[INFO] Set the environment variable IBM_TG_POWER_VS_NETWORK_ID for testing ibm_tg_connection resource else tests will fail if this is not set correctly
[INFO] Set the environment variable ACCOUNT_TO_BE_IMPORTED for testing import enterprise account resource else  tests will fail if this is not set correctly
[INFO] Set the environment variable COS_BUCKET for testing CRUD operations on billing snapshot configuration APIs
[INFO] Set the environment variable COS_LOCATION for testing CRUD operations on billing snapshot configuration APIs
[INFO] Set the environment variable COS_BUCKET_UPDATE for testing update operation on billing snapshot configuration API
[INFO] Set the environment variable COS_LOCATION_UPDATE for testing update operation on billing snapshot configuration API
[INFO] Set the environment variable COS_REPORTS_FOLDER for testing CRUD operations on billing snapshot configuration APIs
[INFO] Set the environment variable SNAPSHOT_DATE_FROM for testing CRUD operations on billing snapshot configuration APIs
[INFO] Set the environment variable SNAPSHOT_DATE_TO for testing CRUD operations on billing snapshot configuration APIs
[INFO] Set the environment variable SNAPSHOT_MONTH for testing CRUD operations on billing snapshot configuration APIs
[WARN] Set the environment variable IBM_HPCS_ADMIN1 with a VALID HPCS Admin Key1 Path
[WARN] Set the environment variable IBM_HPCS_TOKEN1 with a VALID token for HPCS Admin Key1
[WARN] Set the environment variable IBM_HPCS_ADMIN2 with a VALID HPCS Admin Key2 Path
[WARN] Set the environment variable IBM_IAM_REALM_NAME with a VALID realm name for iam trusted profile claim rule
[WARN] Set the environment variable IBM_IAM_IKS_SA with a VALID realm name for iam trusted profile link
[WARN] Set the environment variable IBM_HPCS_TOKEN2 with a VALID token for HPCS Admin Key2
[WARN] Set the environment variable IBM_HPCS_ROOTKEY_CRN with a VALID CRN for a root key created in the HPCS instance
[INFO] Set the environment variable IBM_CLOUD_SHELL_ACCOUNT_ID for ibm-cloud-shell resource or datasource else tests will fail if this is not set correctly
[WARN] Set the environment variable IBM_CLUSTER_VPC_ID for testing ibm_container_vpc_alb_create resources, ibm_container_vpc_alb_create tests will fail if this is not set
[WARN] Set the environment variable IBM_CLUSTER_VPC_SUBNET_ID for testing ibm_container_vpc_alb_create resources, ibm_container_vpc_alb_creates tests will fail if this is not set
[WARN] Set the environment variable IBM_CLUSTER_VPC_RESOURCE_GROUP_ID for testing ibm_container_vpc_alb_create resources, ibm_container_vpc_alb_creates tests will fail if this is not set
[INFO] Set the environment variable IBM_CONTAINER_CLUSTER_NAME for ibm_container_nlb_dns resource or datasource else tests will fail if this is not set correctly
[INFO] Set the environment variable SATELLITE_LOCATION_ID for ibm_cos_bucket satellite location resource or datasource else tests will fail if this is not set correctly
[INFO] Set the environment variable SATELLITE_RESOURCE_INSTANCE_ID for ibm_cos_bucket satellite location resource or datasource else tests will fail if this is not set correctly
[WARN] Set the environment variable IBMCLOUD_CONFIG_AGGREGATOR_ENDPOINT with a VALID SCC API ENDPOINT
[WARN] Set the environment variable IBMCLOUD_CONFIG_AGGREGATOR_INSTANCE_ID with a VALID SCC INSTANCE ID
[INFO] Set the environment variable IBM_CONTAINER_DEDICATEDHOST_POOL_ID for ibm_container_vpc_cluster resource to test dedicated host functionality
[INFO] Set the environment variable IBM_KMS_INSTANCE_ID for ibm_container_vpc_cluster resource or datasource else tests will fail if this is not set correctly
[INFO] Set the environment variable IBM_CRK_ID for ibm_container_vpc_cluster resource or datasource else tests will fail if this is not set correctly
[INFO] Set the environment variable IBM_KMS_ACCOUNT_ID for ibm_container_vpc_cluster resource or datasource else tests will fail if this is not set correctly
[INFO] Set the environment variable IBM_CLUSTER_ID for ibm_container_vpc_worker_pool resource or datasource else tests will fail if this is not set correctly
[WARN] Set the environment variable IBM_CD_RESOURCE_GROUP_NAME for testing CD resources, CD tests will fail if this is not set
[WARN] Set the environment variable IBM_CD_APPCONFIG_INSTANCE_NAME for testing CD resources, CD tests will fail if this is not set
[WARN] Set the environment variable IBM_CD_KEYPROTECT_INSTANCE_NAME for testing CD resources, CD tests will fail if this is not set
[WARN] Set the environment variable IBM_CD_SECRETSMANAGER_INSTANCE_NAME for testing CD resources, CD tests will fail if this is not set
[WARN] Set the environment variable IBM_CD_SLACK_CHANNEL_NAME for testing CD resources, CD tests will fail if this is not set
[WARN] Set the environment variable IBM_CD_SLACK_TEAM_NAME for testing CD resources, CD tests will fail if this is not set
[WARN] Set the environment variable IBM_CD_SLACK_WEBHOOK for testing CD resources, CD tests will fail if this is not set
[WARN] Set the environment variable IBM_CD_JIRA_PROJECT_KEY for testing CD resources, CD tests will fail if this is not set
[WARN] Set the environment variable IBM_CD_JIRA_API_URL for testing CD resources, CD tests will fail if this is not set
[WARN] Set the environment variable IBM_CD_JIRA_USERNAME for testing CD resources, CD tests will fail if this is not set
[WARN] Set the environment variable IBM_CD_JIRA_API_TOKEN for testing CD resources, CD tests will fail if this is not set
[WARN] Set the environment variable IBM_CD_SAUCELABS_ACCESS_KEY for testing CD resources, CD tests will fail if this is not set
[WARN] Set the environment variable IBM_CD_SAUCELABS_USERNAME for testing CD resources, CD tests will fail if this is not set
[WARN] Set the environment variable IBM_CD_BITBUCKET_REPO_URL for testing CD resources, CD tests will fail if this is not set
[WARN] Set the environment variable IBM_CD_GITHUB_CONSOLIDATED_REPO_URL for testing CD resources, CD tests will fail if this is not set
[WARN] Set the environment variable IBM_CD_GITLAB_REPO_URL for testing CD resources, CD tests will fail if this is not set
[WARN] Set the environment variable IBM_CD_HOSTED_GIT_REPO_URL for testing CD resources, CD tests will fail if this is not set
[WARN] Set the environment variable IBM_CD_EVENTNOTIFICATIONS_INSTANCE_NAME for testing CD resources, CD tests will fail if this is not set
[INFO] Set the environment variable IS_CERTIFICATE_CRN for testing ibm_is_vpn_server resource
[INFO] Set the environment variable IS_CLIENT_CA_CRN for testing ibm_is_vpn_server resource
[INFO] Set the environment variable IBM_AccountID_REPL for setting up authorization policy to enable replication feature resource or datasource else tests will fail if this is not set correctly
[WARN] Set the environment variable COS_API_KEY for testing COS targets, the tests will fail if this is not set
[WARN] Set the environment variable INGESTION_KEY for testing Logdna targets, the tests will fail if this is not set
[WARN] Set the environment variable IES_API_KEY for testing Event streams targets, the tests will fail if this is not set
[WARN] Set the environment variable ENTERPRISE_CRN for testing enterprise backup policy, the tests will fail if this is not set
[WARN] Set the environment variable IBM_CODE_ENGINE_RESOURCE_GROUP_ID with the resource group for Code Engine
[WARN] Set the environment variable IBM_CODE_ENGINE_PROJECT_INSTANCE_ID with the ID of a Code Engine project instance
[WARN] Set the environment variable IBM_CODE_ENGINE_SERVICE_INSTANCE_ID with the ID of a IBM Cloud service instance, e.g. for COS
[WARN] Set the environment variable IBM_CODE_ENGINE_RESOURCE_KEY_ID with the ID of a resource key to access a service instance
[WARN] Set the environment variable IBM_CODE_ENGINE_DOMAIN_MAPPING_NAME with the name of a domain mapping
[WARN] Set the environment variable IBM_CODE_ENGINE_TLS_CERT with the TLS certificate in base64 format
[WARN] Set the environment variable IBM_CODE_ENGINE_TLS_KEY with a TLS key in base64 format
[WARN] Set the environment variable IBM_CODE_ENGINE_TLS_CERT_KEY_PATH to point to CERT KEY file path
[WARN] Set the environment variable IBM_CODE_ENGINE_TLS_CERT_PATH to point to CERT file path
[WARN] Set the environment variable IBM_SATELLITE_SSH_PUB_KEY with a ssh public key or ibm_satellite_* tests may fail
[INFO] Set the environment variable IBMCLOUD_MQCLOUD_CONFIG_ENDPOINT for ibm_mqcloud service else tests will fail if this is not set correctly
[INFO] Set the environment variable IBM_MQCLOUD_DEPLOYMENT_ID for ibm_mqcloud_queue_manager resource or datasource else tests will fail if this is not set correctly
[INFO] Set the environment variable IBM_MQCLOUD_DEPLOYMENT_ID for ibm_mqcloud_queue_manager resource or datasource else tests will fail if this is not set correctly
[INFO] Set the environment variable IBM_MQCLOUD_QUEUEMANAGER_ID for ibm_mqcloud_queue_manager resource or datasource else tests will fail if this is not set correctly
[INFO] Set the environment variable IBM_MQCLOUD_KS_CERT_PATH for ibm_mqcloud_keystore_certificate resource or datasource else tests will fail if this is not set correctly
[INFO] Set the environment variable IBM_MQCLOUD_TS_CERT_PATH for ibm_mqcloud_truststore_certificate resource or datasource else tests will fail if this is not set correctly
[INFO] Set the environment variable IBM_MQCLOUD_QUEUEMANAGER_LOCATION for ibm_mqcloud_queue_manager resource or datasource else tests will fail if this is not set correctly
[INFO] Set the environment variable IBM_MQCLOUD_QUEUEMANAGER_VERSION for ibm_mqcloud_queue_manager resource or datasource else tests will fail if this is not set correctly
[INFO] Set the environment variable IBM_MQCLOUD_QUEUEMANAGER_VERSIONUPDATE for ibm_mqcloud_queue_manager resource or datasource else tests will fail if this is not set correctly
[INFO] Set the environment variable IBM_MQCLOUD_TARGET_CRN for ibm_mqcloud_virtual_private_endpoint resource or datasource else tests will fail if this is not set correctly
[INFO] Set the environment variable IBM_MQCLOUD_TRUSTED_PROFILE for ibm_mqcloud_virtual_private_endpoint resource or datasource else tests will fail if this is not set correctly
[INFO] Set the environment variable IBMCLOUD_LOGS_SERVICE_INSTANCE_ID for testing cloud logs related operations
[INFO] Set the environment variable IBMCLOUD_LOGS_SERVICE_INSTANCE_REGION for testing cloud logs related operations
[INFO] Set the environment variable IBMCLOUD_LOGS_SERVICE_EVENT_NOTIFICATIONS_INSTANCE_ID for testing cloud logs related operations
[INFO] Set the environment variable IBMCLOUD_LOGS_SERVICE_EVENT_NOTIFICATIONS_INSTANCE_REGION for testing cloud logs related operations
[WARN] Set the environment variable IBM_PAG_COS_INSTANCE_NAME for testing IBM PAG resource, the tests will fail if this is not set
[WARN] Set the environment variable IBM_PAG_COS_BUCKET_NAME for testing IBM PAG resource, the tests will fail if this is not set
[WARN] Set the environment variable IBM_PAG_COS_BUCKET_REGION for testing IBM PAG resource, the tests will fail if this is not set
[WARN] Set the environment variable IBM_PAG_VPC_NAME for testing IBM PAG resource, the tests will fail if this is not set
[WARN] Set the environment variable IBM_PAG_SERVICE_PLAN for testing IBM PAG resource, the tests will fail if this is not set
[WARN] Set the environment variable IBM_PAG_VPC_SUBNET_INS_1 for testing IBM PAG resource, the tests will fail if this is not set
[WARN] Set the environment variable IBM_PAG_VPC_SUBNET_INS_2 for testing IBM PAG resource, the tests will fail if this is not set
[WARN] Set the environment variable IBM_PAG_VPC_SUBNET_INS_2 for testing IBM PAG resource, the tests will fail if this is not set
[WARN] Set the environment variable IBM_PAG_VPC_SUBNET_INS_2 for testing IBM PAG resource, the tests will fail if this is not set
[WARN] Set the environment variable IBM_VMAAS_DS_ID for testing ibm_vmaas_vdc resource else tests will fail if this is not set correctly
[WARN] Set the environment variable IBM_VMAAS_DS_PVDC_ID for testing ibm_vmaas_vdc resource else tests will fail if this is not set correctly
[INFO] Set the environment variable IBM_POLICY_ASSIGNMENT_TARGET_ACCOUNT_ID for testing ibm_iam_policy_assignment resource else tests will fail if this is not set correctly
[INFO] Set the environment variable IBM_POLICY_ASSIGNMENT_TARGET_ENTERPRISE_ID for testing ibm_iam_policy_assignment resource else tests will fail if this is not set correctly
[WARN] Set the environment variable PCS_REGISTRATION_ACCOUNT_ID for testing iam_onboarding resource else tests will fail if this is not set correctly
[WARN] Set the environment variable PCS_PRODUCT_WITH_APPROVED_PROGRAMMATIC_NAME for testing iam_onboarding resource else tests will fail if this is not set correctly
[WARN] Set the environment variable PCS_PRODUCT_WITH_APPROVED_PROGRAMMATIC_NAME_2 for testing iam_onboarding resource else tests will fail if this is not set correctly
[WARN] Set the environment variable PCS_PRODUCT_WITH_CATALOG_PRODUCT for testing iam_onboarding resource else tests will fail if this is not set correctly
[WARN] Set the environment variable PCS_CATALOG_PRODUCT for testing iam_onboarding resource else tests will fail if this is not set correctly
[WARN] Set the environment variable PCS_CATALOG_PLAN for testing iam_onboarding resource else tests will fail if this is not set correctly
[WARN] Set the environment variable PCS_IAM_TEGISTRATION_ID for testing iam_onboarding resource else tests will fail if this is not set correctly
=== RUN   TestAccIbmSmArbitrarySecretMetadataDataSourceBasic
--- PASS: TestAccIbmSmArbitrarySecretMetadataDataSourceBasic (23.26s)
=== RUN   TestAccIbmSmArbitrarySecretDataSourceBasic
--- PASS: TestAccIbmSmArbitrarySecretDataSourceBasic (32.27s)
=== RUN   TestAccIbmSmConfigurationsDataSourceBasic
--- PASS: TestAccIbmSmConfigurationsDataSourceBasic (36.78s)
=== RUN   TestAccIbmSmConfigurationsDataSourceCryptoKey
--- PASS: TestAccIbmSmConfigurationsDataSourceCryptoKey (63.70s)
=== RUN   TestAccIbmSmEnRegistrationDataSourceBasic
--- PASS: TestAccIbmSmEnRegistrationDataSourceBasic (24.83s)
=== RUN   TestAccIbmSmIamCredentialsConfigurationDataSourceBasic
--- PASS: TestAccIbmSmIamCredentialsConfigurationDataSourceBasic (23.27s)
=== RUN   TestAccIbmSmIamCredentialsSecretMetadataDataSourceBasic
--- PASS: TestAccIbmSmIamCredentialsSecretMetadataDataSourceBasic (33.51s)
=== RUN   TestAccIbmSmIamCredentialsSecretDataSourceBasic
--- PASS: TestAccIbmSmIamCredentialsSecretDataSourceBasic (39.70s)
=== RUN   TestAccIbmSmImportedCertificateMetadataDataSourceBasic
--- PASS: TestAccIbmSmImportedCertificateMetadataDataSourceBasic (32.78s)
=== RUN   TestAccIbmSmImportedCertificateMetadataDataSourceManagedCSR
--- PASS: TestAccIbmSmImportedCertificateMetadataDataSourceManagedCSR (33.81s)
=== RUN   TestAccIbmSmImportedCertificateDataSourceBasic
--- PASS: TestAccIbmSmImportedCertificateDataSourceBasic (24.27s)
=== RUN   TestAccIbmSmImportedCertificateDataSourceManagedCSR
--- PASS: TestAccIbmSmImportedCertificateDataSourceManagedCSR (23.70s)
=== RUN   TestAccIbmSmKvSecretMetadataDataSourceBasic
--- PASS: TestAccIbmSmKvSecretMetadataDataSourceBasic (24.39s)
=== RUN   TestAccIbmSmKvSecretDataSourceBasic
--- PASS: TestAccIbmSmKvSecretDataSourceBasic (24.78s)
=== RUN   TestAccIbmSmPrivateCertificateConfigurationIntermediateCADataSourceBasic
--- PASS: TestAccIbmSmPrivateCertificateConfigurationIntermediateCADataSourceBasic (30.80s)
=== RUN   TestAccIbmSmPrivateCertificateConfigurationIntermediateCADataSourceCryptoKey
--- PASS: TestAccIbmSmPrivateCertificateConfigurationIntermediateCADataSourceCryptoKey (63.72s)
=== RUN   TestAccIbmSmPrivateCertificateConfigurationRootCADataSourceBasic
--- PASS: TestAccIbmSmPrivateCertificateConfigurationRootCADataSourceBasic (42.13s)
=== RUN   TestAccIbmSmPrivateCertificateConfigurationRootCADataSourceCryptoKey
--- PASS: TestAccIbmSmPrivateCertificateConfigurationRootCADataSourceCryptoKey (60.29s)
=== RUN   TestAccIbmSmPrivateCertificateConfigurationTemplateDataSourceBasic
--- PASS: TestAccIbmSmPrivateCertificateConfigurationTemplateDataSourceBasic (31.74s)
=== RUN   TestAccIbmSmPrivateCertificateMetadataDataSourceBasic
--- PASS: TestAccIbmSmPrivateCertificateMetadataDataSourceBasic (39.72s)
=== RUN   TestAccIbmSmPrivateCertificateDataSourceBasic
--- PASS: TestAccIbmSmPrivateCertificateDataSourceBasic (42.78s)
=== RUN   TestAccIbmSmPublicCertificateConfigurationCALetsEncryptDataSourceBasic
--- PASS: TestAccIbmSmPublicCertificateConfigurationCALetsEncryptDataSourceBasic (22.56s)
=== RUN   TestAccIbmSmPublicCertificateConfigurationDnsCisDataSourceBasic
--- PASS: TestAccIbmSmPublicCertificateConfigurationDnsCisDataSourceBasic (22.81s)
=== RUN   TestAccIbmSmPublicCertificateConfigurationDnsClassicInfrastructureDataSourceBasic
--- PASS: TestAccIbmSmPublicCertificateConfigurationDnsClassicInfrastructureDataSourceBasic (22.81s)
=== RUN   TestAccIbmSmPublicCertificateMetadataDataSourceBasic
--- PASS: TestAccIbmSmPublicCertificateMetadataDataSourceBasic (154.79s)
=== RUN   TestAccIbmSmPublicCertificateDataSourceBasic
--- PASS: TestAccIbmSmPublicCertificateDataSourceBasic (153.81s)
=== RUN   TestAccIbmSmSecretGroupDataSourceBasic
--- PASS: TestAccIbmSmSecretGroupDataSourceBasic (23.68s)
=== RUN   TestAccIbmSmSecretGroupDataSourceAllArgs
--- PASS: TestAccIbmSmSecretGroupDataSourceAllArgs (21.72s)
=== RUN   TestAccIbmSmSecretGroupsDataSourceBasic
--- PASS: TestAccIbmSmSecretGroupsDataSourceBasic (21.66s)
=== RUN   TestAccIbmSmSecretGroupsDataSourceAllArgs
--- PASS: TestAccIbmSmSecretGroupsDataSourceAllArgs (21.86s)
=== RUN   TestAccIbmSmSecretsDataSourceBasic
--- PASS: TestAccIbmSmSecretsDataSourceBasic (25.11s)
=== RUN   TestAccIbmSmServiceCredentialsSecretMetadataDataSourceBasic
--- PASS: TestAccIbmSmServiceCredentialsSecretMetadataDataSourceBasic (23.56s)
=== RUN   TestAccIbmSmServiceCredentialsSecretDataSourceBasic
--- PASS: TestAccIbmSmServiceCredentialsSecretDataSourceBasic (24.42s)
=== RUN   TestAccIbmSmUsernamePasswordSecretMetadataDataSourceBasic
--- PASS: TestAccIbmSmUsernamePasswordSecretMetadataDataSourceBasic (33.97s)
=== RUN   TestAccIbmSmUsernamePasswordSecretDataSourceBasic
--- PASS: TestAccIbmSmUsernamePasswordSecretDataSourceBasic (26.35s)
=== RUN   TestAccIbmSmArbitrarySecretBasic
--- PASS: TestAccIbmSmArbitrarySecretBasic (24.69s)
=== RUN   TestAccIbmSmArbitrarySecretAllArgs
--- PASS: TestAccIbmSmArbitrarySecretAllArgs (43.07s)
=== RUN   TestAccIbmSmEnRegistrationBasic
--- PASS: TestAccIbmSmEnRegistrationBasic (20.77s)
=== RUN   TestAccIbmSmIamCredentialsConfigurationBasic
--- PASS: TestAccIbmSmIamCredentialsConfigurationBasic (25.72s)
=== RUN   TestAccIbmSmIamCredentialsSecretBasic
--- PASS: TestAccIbmSmIamCredentialsSecretBasic (31.42s)
=== RUN   TestAccIbmSmIamCredentialsSecretAllArgs
--- PASS: TestAccIbmSmIamCredentialsSecretAllArgs (52.78s)
=== RUN   TestAccIbmSmImportedCertificateBasic
--- PASS: TestAccIbmSmImportedCertificateBasic (22.26s)
=== RUN   TestAccIbmSmImportedCertificateAllArgs
--- PASS: TestAccIbmSmImportedCertificateAllArgs (40.47s)
=== RUN   TestAccIbmSmImportedCertificateManagedCSR
--- PASS: TestAccIbmSmImportedCertificateManagedCSR (38.99s)
=== RUN   TestAccIbmSmKvSecretBasic
--- PASS: TestAccIbmSmKvSecretBasic (25.76s)
=== RUN   TestAccIbmSmKvSecretAllArgs
--- PASS: TestAccIbmSmKvSecretAllArgs (42.33s)
=== RUN   TestAccIbmSmPrivateCertificateConfigurationActionSetSignedBasic
--- PASS: TestAccIbmSmPrivateCertificateConfigurationActionSetSignedBasic (25.92s)
=== RUN   TestAccIbmSmPrivateCertificateConfigurationActionSignCsrBasic
--- PASS: TestAccIbmSmPrivateCertificateConfigurationActionSignCsrBasic (24.46s)
=== RUN   TestAccIbmSmPrivateCertificateConfigurationIntermediateCABasic
--- PASS: TestAccIbmSmPrivateCertificateConfigurationIntermediateCABasic (27.99s)
=== RUN   TestAccIbmSmPrivateCertificateConfigurationIntermediateCAllArgs
--- PASS: TestAccIbmSmPrivateCertificateConfigurationIntermediateCAllArgs (48.19s)
=== RUN   TestAccIbmSmPrivateCertificateConfigurationIntermediateCACryptoKey
--- PASS: TestAccIbmSmPrivateCertificateConfigurationIntermediateCACryptoKey (58.52s)
=== RUN   TestAccIbmSmPrivateCertificateConfigurationRootCABasic
--- PASS: TestAccIbmSmPrivateCertificateConfigurationRootCABasic (24.14s)
=== RUN   TestAccIbmSmPrivateCertificateConfigurationRootCAllArgs
--- PASS: TestAccIbmSmPrivateCertificateConfigurationRootCAllArgs (42.37s)
=== RUN   TestAccIbmSmPrivateCertificateConfigurationRootCACryptoKey
--- PASS: TestAccIbmSmPrivateCertificateConfigurationRootCACryptoKey (49.98s)
=== RUN   TestAccIbmSmPrivateCertificateConfigurationTemplateBasic
--- PASS: TestAccIbmSmPrivateCertificateConfigurationTemplateBasic (31.39s)
=== RUN   TestAccIbmSmPrivateCertificateConfigurationTemplateAllArgs
--- PASS: TestAccIbmSmPrivateCertificateConfigurationTemplateAllArgs (49.86s)
=== RUN   TestAccIbmSmPrivateCertificateBasic
--- PASS: TestAccIbmSmPrivateCertificateBasic (39.79s)
=== RUN   TestAccIbmSmPrivateCertificateAllArgs
--- PASS: TestAccIbmSmPrivateCertificateAllArgs (61.01s)
=== RUN   TestAccIbmSmPublicCertificateActionValidateManualDnsBasic
--- PASS: TestAccIbmSmPublicCertificateActionValidateManualDnsBasic (36.72s)
=== RUN   TestAccIbmSmPublicCertificateConfigurationCALetsEncryptBasic
--- PASS: TestAccIbmSmPublicCertificateConfigurationCALetsEncryptBasic (21.03s)
=== RUN   TestAccIbmSmConfigurationPublicCertificateDnsCisBasic
--- PASS: TestAccIbmSmConfigurationPublicCertificateDnsCisBasic (22.41s)
=== RUN   TestAccIbmSmPublicCertificateConfigurationDNSClassicInfrastructureBasic
--- PASS: TestAccIbmSmPublicCertificateConfigurationDNSClassicInfrastructureBasic (38.08s)
=== RUN   TestAccIbmSmPublicCertificateBasic
--- PASS: TestAccIbmSmPublicCertificateBasic (140.69s)
=== RUN   TestAccIbmSmPublicCertificateAllArgs
--- PASS: TestAccIbmSmPublicCertificateAllArgs (188.18s)
=== RUN   TestAccIbmSmSecretGroupBasic
--- PASS: TestAccIbmSmSecretGroupBasic (36.64s)
=== RUN   TestAccIbmSmSecretGroupAllArgs
--- PASS: TestAccIbmSmSecretGroupAllArgs (108.62s)
=== RUN   TestAccIbmSmServiceCredentialsSecretBasic
--- PASS: TestAccIbmSmServiceCredentialsSecretBasic (38.77s)
=== RUN   TestAccIbmSmServiceCredentialsSecretAllArgs
--- PASS: TestAccIbmSmServiceCredentialsSecretAllArgs (47.95s)
=== RUN   TestAccIbmSmUsernamePasswordSecretBasic
--- PASS: TestAccIbmSmUsernamePasswordSecretBasic (24.58s)
=== RUN   TestAccIbmSmUsernamePasswordSecretAllArgs
--- PASS: TestAccIbmSmUsernamePasswordSecretAllArgs (42.51s)
PASS
ok  	github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/secretsmanager	2951.187s
haims@Haims-MBP terraform-provider-ibm % 

...
```
