### PR TITLE
(atracker) Deprecate logdna_endpoint attribute and logdna target_type

### DIFF
--- a/examples/ibm-atracker/README.md
+++ b/examples/ibm-atracker/README.md
@@ -26,7 +26,7 @@ Run `terraform destroy` when you don't need these resources.
 atracker_target resource:
 
 ```hcl
-# Deprecation: logdna_endpoint is no longer in use and will be removed in the next major version of the provider.
+# Deprecated: logdna_endpoint is no longer in use and will be removed in the next major version of the provider.
 resource "atracker_target" "atracker_target_instance" {
   name = var.atracker_target_name
   target_type = var.atracker_target_target_type
@@ -102,9 +102,9 @@ data "atracker_routes" "atracker_routes_instance" {
 | name | The name of the target. The name must be 1000 characters or less, and cannot include any special characters other than `(space) - . _ :`. | `string` | true |
 | target_type | The type of the target. | `string` | true |
 | cos_endpoint | Property values for a Cloud Object Storage Endpoint. | `` | true |
-| eventstreams_endpoint | Property values for the Event Streams Endpoint in responses. | `` | false |
-| logdna_endpoint | Property values for a LogDNA Endpoint. Remove this attribute as it is no longer in use and it will be removed in the next major version of the provider.| `` | false |
-| cloudlogs_endpoint | Property values for the IBM Cloud Logs Endpoint in responses. | `` | false |
+| eventstreams_endpoint | Property values for the Event Streams Endpoint. | `` | false |
+| logdna_endpoint | Deprecated. Property values for a LogDNA Endpoint. Remove this attribute as it is no longer in use and it will be removed in the next major version of the provider.| `` | false |
+| cloudlogs_endpoint | Property values for the IBM Cloud Logs Endpoint. | `` | false |
 | name | The name of the route. The name must be 1000 characters or less and cannot include any special characters other than `(space) - . _ :`. | `string` | true |
 | rules | The routing rules that will be evaluated in their order of the array. Once a rule is matched, the remaining rules in the route definition will be skipped. | `list()` | true |
 | default_targets | The target ID List. In the event that no routing rule causes the event to be sent to a target, these targets will receive the event. | `list(string)` | false |

--- a/examples/ibm-atracker/README.md
+++ b/examples/ibm-atracker/README.md
@@ -26,6 +26,7 @@ Run `terraform destroy` when you don't need these resources.
 atracker_target resource:
 
 ```hcl
+# Deprecation: logdna_endpoint is no longer in use and will be removed in the next major version of the provider.
 resource "atracker_target" "atracker_target_instance" {
   name = var.atracker_target_name
   target_type = var.atracker_target_target_type
@@ -102,7 +103,7 @@ data "atracker_routes" "atracker_routes_instance" {
 | target_type | The type of the target. | `string` | true |
 | cos_endpoint | Property values for a Cloud Object Storage Endpoint. | `` | true |
 | eventstreams_endpoint | Property values for the Event Streams Endpoint in responses. | `` | false |
-| logdna_endpoint | Property values for a LogDNA Endpoint in responses. | `` | false |
+| logdna_endpoint | Property values for a LogDNA Endpoint. Remove this attribute as it is no longer in use and it will be removed in the next major version of the provider.| `` | false |
 | cloudlogs_endpoint | Property values for the IBM Cloud Logs Endpoint in responses. | `` | false |
 | name | The name of the route. The name must be 1000 characters or less and cannot include any special characters other than `(space) - . _ :`. | `string` | true |
 | rules | The routing rules that will be evaluated in their order of the array. Once a rule is matched, the remaining rules in the route definition will be skipped. | `list()` | true |

--- a/examples/ibm-atracker/main.tf
+++ b/examples/ibm-atracker/main.tf
@@ -15,16 +15,6 @@ resource "ibm_atracker_target" "atracker_target_instance" {
   region = var.atracker_target_region
 }
 
-resource "ibm_atracker_target" "atracker_target_logdna_instance" {
-  name = var.atracker_target_name
-  target_type = "logdna"
-  logdna_endpoint {
-    target_crn = "crn:v1:bluemix:public:logdna:us-south:a/11111111111111111111111111111111:22222222-2222-2222-2222-222222222222::"
-    ingestion_key = "xxxxxxxxxxxxxx"
-  }
-  region = var.atracker_target_region
-}
-
 resource "ibm_atracker_target" atracker_target_eventstreams_instance {
   name = var.atracker_target_name
   target_type = "event_streams"

--- a/ibm/service/atracker/README.md
+++ b/ibm/service/atracker/README.md
@@ -5,7 +5,7 @@ This area is primarily for IBM provider contributors and maintainers. For inform
 
 ## Environment variables to set for the tests
 * COS_API_KEY   : API Key used for creating COS targets
-* INGESTION_KEY : LogDNA Ingestion Key used for creating Logdna targets
+* INGESTION_KEY : LogDNA Ingestion Key used for creating Logdna targets. This attribute is no longer in use and will be removed in the next major version of the provider.
 * IES_API_KEY   : Event streams password used for creating Event streams targets
 
 ## Handy Links

--- a/ibm/service/atracker/README.md
+++ b/ibm/service/atracker/README.md
@@ -5,7 +5,7 @@ This area is primarily for IBM provider contributors and maintainers. For inform
 
 ## Environment variables to set for the tests
 * COS_API_KEY   : API Key used for creating COS targets
-* INGESTION_KEY : LogDNA Ingestion Key used for creating Logdna targets. This attribute is no longer in use and will be removed in the next major version of the provider.
+* INGESTION_KEY : Deprecated. LogDNA Ingestion Key used for creating Logdna targets. This variable is no longer in use and will be removed in the next major version of the provider.
 * IES_API_KEY   : Event streams password used for creating Event streams targets
 
 ## Handy Links

--- a/ibm/service/atracker/data_source_ibm_atracker_targets.go
+++ b/ibm/service/atracker/data_source_ibm_atracker_targets.go
@@ -104,9 +104,10 @@ func DataSourceIBMAtrackerTargets() *schema.Resource {
 							},
 						},
 						"logdna_endpoint": {
+							Deprecated:  "Remove this attribute's configuration as it is no longer in use and the attribute will be removed in the next major version of the provider.",
 							Type:        schema.TypeList,
 							Computed:    true,
-							Description: "Property values for a LogDNA Endpoint.",
+							Description: "(Deprecated) Property values for a LogDNA Endpoint.",
 							Elem: &schema.Resource{
 								Schema: map[string]*schema.Schema{
 									"target_crn": {

--- a/ibm/service/atracker/data_source_ibm_atracker_targets_test.go
+++ b/ibm/service/atracker/data_source_ibm_atracker_targets_test.go
@@ -97,10 +97,6 @@ func testAccCheckIBMAtrackerTargetsDataSourceConfig(targetName string, targetTar
 				api_key = "%s" // pragma: allowlist secret
 				service_to_service_enabled = true
 			}
-			logdna_endpoint {
-				target_crn = "crn:v1:bluemix:public:logdna:us-south:a/11111111111111111111111111111111:22222222-2222-2222-2222-222222222222::"
-				ingestion_key = "%s"
-			}
 			eventstreams_endpoint {
 				target_crn = "crn:v1:bluemix:public:messagehub:us-south:a/11111111111111111111111111111111:22222222-2222-2222-2222-222222222222::"
 				brokers = [ "kafka-x:9094" ]
@@ -116,5 +112,5 @@ func testAccCheckIBMAtrackerTargetsDataSourceConfig(targetName string, targetTar
 			name = ibm_atracker_target.atracker_target.name
 		}
 		
-	`, targetName, targetTargetType, targetRegion, acc.COSApiKey, acc.IngestionKey, acc.IesApiKey)
+	`, targetName, targetTargetType, targetRegion, acc.COSApiKey, acc.IesApiKey)
 }

--- a/ibm/service/atracker/resource_ibm_atracker_target.go
+++ b/ibm/service/atracker/resource_ibm_atracker_target.go
@@ -41,7 +41,7 @@ func ResourceIBMAtrackerTarget() *schema.Resource {
 				Required:         true,
 				ForceNew:         true,
 				ValidateFunc:     validate.InvokeValidator("ibm_atracker_target", "target_type"),
-				Description:      "The type of the target. It can be cloud_object_storage, logdna, event_streams, or cloud_logs. Based on this type you must include cos_endpoint, logdna_endpoint, eventstreams_endpoint or cloudlogs_endpoint.",
+				Description:      "The type of the target. It can be cloud_object_storage, logdna (deprecated), event_streams, or cloud_logs. Based on this type you must include cos_endpoint, logdna_endpoint (deprecated), eventstreams_endpoint or cloudlogs_endpoint.",
 			},
 			"cos_endpoint": {
 				Type:        schema.TypeList,
@@ -84,8 +84,9 @@ func ResourceIBMAtrackerTarget() *schema.Resource {
 				Type:        schema.TypeList,
 				MaxItems:    1,
 				Optional:    true,
-				Description: "Property values for a LogDNA Endpoint.",
+				Description: "(Deprecated) Property values for a LogDNA Endpoint.",
 				Elem: &schema.Resource{
+					DeprecationMessage: "Remove this attribute's configuration as it is no longer in use and the attribute will be removed in the next major version of the provider.",
 					Schema: map[string]*schema.Schema{
 						"target_crn": {
 							Type:        schema.TypeString,

--- a/website/docs/d/atracker_targets.html.markdown
+++ b/website/docs/d/atracker_targets.html.markdown
@@ -35,7 +35,7 @@ Nested scheme for **targets**:
 	* `name` - (String) The name of the target resource.
 	* `crn` - (String) The crn of the target resource.
 	* `target_type` - (String) The type of the target.
-	  * Constraints: Allowable values are: `cloud_object_storage`, `logdna`, `event_streams`, `cloud_logs`.
+	  * Constraints: Allowable values are: `cloud_object_storage`, `logdna` (**DEPRECATED**), `event_streams`, `cloud_logs`.
 	* `encrypt_key` - (String) The encryption key that is used to encrypt events before Activity Tracker services buffer them on storage. This credential is masked in the response.
 	* `region` - (String) Included this optional field if you used it to create a target in a different region other than the one you are connected.
 	* `cos_endpoint` - (List) Property values for a Cloud Object Storage Endpoint.
@@ -49,7 +49,7 @@ Nested scheme for **targets**:
 		* `service_to_service_enabled` - (Boolean) Determines if IBM Cloud Activity Tracker Event Routing has service to service authentication enabled. Set this flag to true if service to service is enabled and do not supply an apikey.
 		* `target_crn` - (String) The CRN of the Cloud Object Storage instance.
 		  * Constraints: The maximum length is `1000` characters. The minimum length is `3` characters. The value must match regular expression `/^[a-zA-Z0-9 -._:\/]+$/`.
-	* `logdna_endpoint` - (List) Property values for a LogDNA Endpoint.
+	* `logdna_endpoint` - **DEPRECATED** (List) Property values for a LogDNA Endpoint. This attribute is no longer in use and will be removed in the next major version of the provider.
 	Nested scheme for **logdna_endpoint**:
 		* `ingestion_key` - (String) The LogDNA ingestion key is used for routing logs to a specific LogDNA instance.
 		  * Constraints: The maximum length is `1000` characters. The minimum length is `3` characters. The value must match regular expression `/^[a-zA-Z0-9 -._:\/]+$/`.

--- a/website/docs/r/atracker_target.html.markdown
+++ b/website/docs/r/atracker_target.html.markdown
@@ -25,19 +25,9 @@ resource "ibm_atracker_target" "atracker_cos_target" {
   region = "us-south"
 }
 
-resource "ibm_atracker_target" "atracker_logdna_target" {
-  logdna_endpoint {
-    target_crn = "crn:v1:bluemix:public:logdna:us-south:a/11111111111111111111111111111111:22222222-2222-2222-2222-222222222222::"
-    ingestion_key = "xxxxxxxxxxxxxx"
-  }
-  name = "my-logdna-target"
-  target_type = "logdna"
-  region = "us-south"
-}
-
 resource "ibm_atracker_target" "atracker_eventstreams_target" {
   eventstreams_endpoint {
-    target_crn = "crn:v1:bluemix:public:logdna:us-south:a/11111111111111111111111111111111:22222222-2222-2222-2222-222222222222::"
+    target_crn = "crn:v1:bluemix:public:messagehub:us-south:a/11111111111111111111111111111111:22222222-2222-2222-2222-222222222222::"
     brokers = ["xxxxx.cloud.ibm.com:9093","yyyyy.cloud.ibm.com:9093"]
     topic = "my-topic"
     api_key = "api-key"  // pragma: allowlist secret
@@ -73,7 +63,7 @@ Nested scheme for **cos_endpoint**:
 	* `service_to_service_enabled` - (Optional, Boolean) Determines if IBM Cloud Activity Tracker Event Routing has service to service authentication enabled. Set this flag to true if service to service is enabled and do not supply an apikey.
 	* `target_crn` - (Required, String) The CRN of the Cloud Object Storage instance.
 	  * Constraints: The maximum length is `1000` characters. The minimum length is `3` characters. The value must match regular expression `/^[a-zA-Z0-9 -._:\/]+$/`.
-* `logdna_endpoint` - (Optional, List) Property values for a LogDNA Endpoint.
+* `logdna_endpoint` - **DEPRECATED** (Optional, List) Property values for a LogDNA Endpoint. Remove this attribute's configuration as it is no longer in use and the attribute will be removed in the next major version of the provider.
 Nested scheme for **logdna_endpoint**:
 	* `ingestion_key` - (Required, String) The LogDNA ingestion key is used for routing logs to a specific LogDNA instance.
 	  * Constraints: The maximum length is `1000` characters. The minimum length is `3` characters. The value must match regular expression `/^[a-zA-Z0-9 -._:\/]+$/`.
@@ -97,8 +87,8 @@ Nested scheme for **eventstreams_endpoint**:
   * Constraints: The maximum length is `1000` characters. The minimum length is `1` character. The value must match regular expression `/^[a-zA-Z0-9 -._:]+$/`.
 * `region` - (Optional, String) Include this optional field if you want to create a target in a different region other than the one you are connected.
   * Constraints: The maximum length is `1000` characters. The minimum length is `3` characters. The value must match regular expression `/^[a-zA-Z0-9 -._:]+$/`.
-* `target_type` - (Required, Forces new resource, String) The type of the target. It can be cloud_object_storage, logdna or event_streams. Based on this type you must include cos_endpoint, logdna_endpoint or eventstreams_endpoint.
-  * Constraints: Allowable values are: `cloud_object_storage`, `logdna`, `event_streams`, `cloud_logs`.
+* `target_type` - (Required, Forces new resource, String) The type of the target. It can be cloud_object_storage, logdna (**DEPRECATED**) or event_streams. Based on this type you must include cos_endpoint, logdna_endpoint (**DEPRECATED**) or eventstreams_endpoint.
+  * Constraints: Allowable values are: `cloud_object_storage`, `logdna` (**DEPRECATED**), `event_streams`, `cloud_logs`.
 
 ## Attribute reference
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/IBM-Cloud/terraform-provider-ibm/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TEST=./ibm/service/atracker TESTARGS='-run=TestAccIBMAtracker*

=== RUN   TestAccIBMAtrackerRoutesDataSourceBasic
--- PASS: TestAccIBMAtrackerRoutesDataSourceBasic (16.71s)
=== RUN   TestAccIBMAtrackerTargetsDataSourceBasic
--- PASS: TestAccIBMAtrackerTargetsDataSourceBasic (15.39s)
=== RUN   TestAccIBMAtrackerTargetsDataSourceAllArgs
--- PASS: TestAccIBMAtrackerTargetsDataSourceAllArgs (14.43s)
=== RUN   TestAccIBMAtrackerRouteBasic
--- PASS: TestAccIBMAtrackerRouteBasic (25.55s)
=== RUN   TestAccIBMAtrackerRouteBasicMultipleRules
--- PASS: TestAccIBMAtrackerRouteBasicMultipleRules (25.38s)
=== RUN   TestAccIBMAtrackerSettingsBasic
--- PASS: TestAccIBMAtrackerSettingsBasic (13.42s)
=== RUN   TestAccIBMAtrackerTargetBasic
--- PASS: TestAccIBMAtrackerTargetBasic (24.26s)
PASS
ok  	github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/atracker	137.037s

```
