### PR TITLE
Remove warnings from terraform image markdown files

### DIFF
--- a/website/docs/d/pi_catalog_images.html.markdown
+++ b/website/docs/d/pi_catalog_images.html.markdown
@@ -7,9 +7,11 @@ description: |-
 ---
 
 # ibm_pi_catalog_images
+
 Retrieve the details of an image that you can use in your Power Systems Virtual Server instance for copying into IBM Cloud instances. For more information, about catalog images, see [provisioning a virtual server instance from a third-party image](https://cloud.ibm.com/docs/virtual-servers?topic=virtual-servers-ordering-3P).
 
-## Example usage
+## Example Usage
+
 The following example shows how to retrieve information using `ibm_pi_catalog_images`.
 
 ```terraform
@@ -18,13 +20,15 @@ data "ibm_pi_catalog_images" "ds_images" {
 }
 ```
 
-**Notes**
+### Notes
+
 - Please find [supported Regions](https://cloud.ibm.com/apidocs/power-cloud#endpoint) for endpoints.
 - If a Power cloud instance is provisioned at `lon04`, The provider level attributes should be as follows:
   - `region` - `lon`
   - `zone` - `lon04`
   
 Example usage:
+
   ```terraform
     provider "ibm" {
       region    =   "lon"
@@ -32,33 +36,35 @@ Example usage:
     }
   ```
   
-## Argument reference
-Review the argument reference that you can specify for your data source. 
+## Argument Reference
+
+Review the argument reference that you can specify for your data source.
 
 - `pi_cloud_instance_id` - (Required, String) The GUID of the service instance associated with an account.
 - `sap` - (Optional, Bool) Set `true` to include SAP images. The default value is `false`.
 - `vtl` - (Optional, Bool) Set `true` to include VTL images. The default value is `false`.
 
-## Attribute reference
+## Attribute Reference
+
 In addition to the argument reference list, you can access the following attribute references after your data source is created.
 
 - `images`- (List) Lists all the images in the IBM Power Virtual Server Cloud.
 
   Nested scheme for `images`:
-	- `architecture` - (String) The CPU architecture that the image is designed for.
-	- `container_format` - (String) The container format.
-	- `creation_date` - (String) Date of image creation.
-	- `crn` - (String) The CRN of this resource.
-	- `description` - (String) The description of an image.
-	- `disk_format` - (String) The disk format.
-	- `endianness` - (String) The `Endianness` order.
-	- `href` - (String) The `href` of an image.
-	- `hypervisor_type` - (String) Hypervisor type.
-	- `image_id` - (String) The unique identifier of an image.
-	- `image_type` - (String) The identifier of this image type.
-	- `last_update_date` - (String) The last updated date of an image.
-	- `name` - (String) The name of the image.
-	- `operating_system` - (String)  Operating System.
-	- `state` - (String) The state of an Operating System.
-	- `storage_pool` - (String) Storage pool where image resides.
-	- `storage_type` - (String) The storage type of an image.
+  - `architecture` - (String) The CPU architecture that the image is designed for.
+  - `container_format` - (String) The container format.
+  - `creation_date` - (String) Date of image creation.
+  - `crn` - (String) The CRN of this resource.
+  - `description` - (String) The description of an image.
+  - `disk_format` - (String) The disk format.
+  - `endianness` - (String) The `Endianness` order.
+  - `href` - (String) The `href` of an image.
+  - `hypervisor_type` - (String) Hypervisor type.
+  - `image_id` - (String) The unique identifier of an image.
+  - `image_type` - (String) The identifier of this image type.
+  - `last_update_date` - (String) The last updated date of an image.
+  - `name` - (String) The name of the image.
+  - `operating_system` - (String)  Operating System.
+  - `state` - (String) The state of an Operating System.
+  - `storage_pool` - (String) Storage pool where image resides.
+  - `storage_type` - (String) The storage type of an image.

--- a/website/docs/d/pi_image.html.markdown
+++ b/website/docs/d/pi_image.html.markdown
@@ -10,7 +10,7 @@ description: |-
 
 Import the details of an existing IBM Power Virtual Server Cloud image as a read-only data source. For more information, about IBM power virtual server cloud, see [getting started with IBM Power Systems Virtual Servers](https://cloud.ibm.com/docs/power-iaas?topic=power-iaas-getting-started).
 
-## Example usage
+## Example Usage
 
 ```terraform
 data "ibm_pi_image" "ds_image" {
@@ -35,14 +35,14 @@ Example usage:
     }
   ```
   
-## Argument reference
+## Argument Reference
 
 Review the argument references that you can specify for your data source.
 
 - `pi_cloud_instance_id` - (Required, String) The GUID of the service instance associated with an account.
 - `pi_image_name` - (Required, String) The ID of the image. To find supported images, run the `ibmcloud pi images` command.
 
-## Attribute reference
+## Attribute Reference
 
 In addition to all argument reference list, you can access the following attribute references after your data source is created.
 

--- a/website/docs/d/pi_images.html.markdown
+++ b/website/docs/d/pi_images.html.markdown
@@ -10,7 +10,7 @@ description: |-
 
 Retrieve a list of supported images that you can use in your Power Systems Virtual Server instance. The image represents the version of the operation system that is installed in your Power Systems Virtual Server instance. For more information, about power instance images, see [capturing and exporting a virtual machine (VM)](https://cloud.ibm.com/docs/power-iaas?topic=power-iaas-capturing-exporting-vm).
 
-## Example usage
+## Example Usage
 
 The following example retrieves all images for a cloud instance ID.
 
@@ -36,13 +36,13 @@ Example usage:
     }
   ```
   
-## Argument reference
+## Argument Reference
 
 Review the argument references that you can specify for your data source.
 
 - `pi_cloud_instance_id` - (Required, String) The GUID of the service instance associated with an account.
 
-## Attribute reference
+## Attribute Reference
 
 In addition to all argument reference list, you can access the following attribute references after your data source is created.
 
@@ -50,7 +50,7 @@ In addition to all argument reference list, you can access the following attribu
 
   Nested scheme for `image_info`:
   - `crn` - (String) The CRN of this resource.
-  - `href` - (String) The hyper link of an image. 
+  - `href` - (String) The hyper link of an image.
   - `id` - (String) The unique identifier of an image.
   - `image_type` - (String) The identifier of this image type.
   - `name`-  (String) The name of an image.

--- a/website/docs/r/pi_image.html.markdown
+++ b/website/docs/r/pi_image.html.markdown
@@ -10,7 +10,7 @@ description: |-
 
 Create, update, or delete for a Power Systems Virtual Server image. For more information, about IBM power virtual server cloud, see [getting started with IBM Power Systems Virtual Servers](https://cloud.ibm.com/docs/power-iaas?topic=power-iaas-getting-started).
 
-## Example usage
+## Example Usage
 
 The following example enables you to create a image in your project:
 
@@ -61,7 +61,7 @@ The ibm_pi_image provides the following [timeouts](https://www.terraform.io/docs
 - **update** - (Default 10 minutes) Used for updating image.
 - **delete** - (Default 10 minutes) Used for deleting image.
 
-## Argument reference
+## Argument Reference
 
 Review the argument references that you can specify for your resource.
 
@@ -96,7 +96,7 @@ Review the argument references that you can specify for your resource.
   - `vendor` - (Required, String) Vendor supporting the product. Allowable value is: `SAP`.
 - `pi_user_tags` - (Optional, List) The user tags attached to this resource.
 
-## Attribute reference
+## Attribute Reference
 
 In addition to all argument reference list, you can access the following attribute reference after your resource is created.
 

--- a/website/docs/r/pi_image_export.html.markdown
+++ b/website/docs/r/pi_image_export.html.markdown
@@ -10,7 +10,7 @@ description: |-
 
 Export an image to IBM Cloud Object Storage for Power Systems Virtual Server instance. For more information, about IBM power virtual server cloud, see [getting started with IBM Power Systems Virtual Servers](https://cloud.ibm.com/docs/power-iaas?topic=power-iaas-getting-started).
 
-## Example usage
+## Example Usage
 
 The following example enables you to export an image:
 
@@ -48,7 +48,7 @@ The `ibm_pi_image_export` provides the following [timeouts](https://www.terrafor
 
 - **create** - (Default 60 minutes) used for exporting image to IBM Cloud Object Storage bucked. Considered failed if no response is received by timeout.
 
-## Argument reference
+## Argument Reference
 
 Review the argument references that you can specify for your resource.
 
@@ -59,7 +59,7 @@ Review the argument references that you can specify for your resource.
 - `pi_image_id` - (Required, String) The Image ID of existing source image; required for image export.
 - `pi_image_secret_key` - (Required, String, Sensitive) The Cloud Object Storage secret key; required for buckets with private access.
 
-## Attribute reference
+## Attribute Reference
 
 In addition to all argument reference list, you can access the following attribute reference after your resource is created.
 


### PR DESCRIPTION
This PR removes the remaining warnings from the image documentation.