### PR TITLE
Remove warnings from terraform network markdown files

### DIFF
--- a/website/docs/d/pi_network.html.markdown
+++ b/website/docs/d/pi_network.html.markdown
@@ -10,7 +10,7 @@ description: |-
 
 Retrieve information about the network that your Power Systems Virtual Server instance is connected to. For more information, about power virtual server instance network, see [setting up an IBM network install server](https://cloud.ibm.com/docs/power-iaas?topic=power-iaas-configuring-subnet).
 
-## Example usage
+## Example Usage
 
 ```terraform
 data "ibm_pi_network" "ds_network" {
@@ -35,14 +35,14 @@ Example usage:
     }
   ```
   
-## Argument reference
+## Argument Reference
 
 Review the argument references that you can specify for your data source.
 
 - `pi_cloud_instance_id` - (Required, String) The GUID of the service instance associated with an account.
 - `pi_network_name` - (Required, String) The name of the network.
 
-## Attribute reference
+## Attribute Reference
 
 In addition to all argument reference list, you can access the following attribute references after your data source is created.
 

--- a/website/docs/d/pi_network_address_groups.html.markdown
+++ b/website/docs/d/pi_network_address_groups.html.markdown
@@ -34,7 +34,7 @@ Example usage:
     }
   ```
 
-## Argument reference
+## Argument Reference
 
 Review the argument references that you can specify for your data source.
 

--- a/website/docs/d/pi_network_peers.html.markdown
+++ b/website/docs/d/pi_network_peers.html.markdown
@@ -34,7 +34,7 @@ Example usage:
     }
   ```
   
-## Argument reference
+## Argument Reference
 
 Review the argument references that you can specify for your data source.
 

--- a/website/docs/d/pi_network_port.html.markdown
+++ b/website/docs/d/pi_network_port.html.markdown
@@ -12,7 +12,7 @@ description: |-
 
 Retrieve information about a network port in the Power Virtual Server Cloud. For more information, about networks in IBM power virtual server, see [adding or removing a public network](https://cloud.ibm.com/docs/power-iaas?topic=power-iaas-modifying-server#adding-removing-network).
 
-## Example usage
+## Example Usage
 
 ```terraform
 data "ibm_pi_network_port" "test-network-port" {
@@ -37,14 +37,14 @@ Example usage:
     }
   ```
 
-## Argument reference
+## Argument Reference
 
 Review the argument references that you can specify for your data source.
 
 - `pi_cloud_instance_id` - (Required, String) The GUID of the service instance associated with an account.
 - `pi_network_name` - (Required, String) The unique identifier or name of a network.
 
-## Attribute reference
+## Attribute Reference
 
 In addition to all argument reference list, you can access the following attribute reference after your data source is created.
 

--- a/website/docs/d/pi_network_security_groups.html.markdown
+++ b/website/docs/d/pi_network_security_groups.html.markdown
@@ -34,7 +34,7 @@ Example usage:
     }
   ```
 
-## Argument reference
+## Argument Reference
 
 Review the argument references that you can specify for your data source.
 
@@ -57,7 +57,8 @@ After your data source is created, you can read values from the following attrib
         - `mac_address` - (String) The mac address of a network Interface included if the type is `network-interface`.
         - `network_interface_id` - (String) The network ID of a network interface included if the type is `network-interface`.
         - `target` - (String) If `ipv4-address` type, then IPv4 address or if `network-interface` type, then network interface id.
-    - `type` - (String) The type of member. Supported values are: `ipv4-address`, `network-interface`.
+        - `type` - (String) The type of member. Supported values are: `ipv4-address`, `network-interface`.
+
   - `name` - (String) The name of the network security group.
   - `rules` - (List) The list of rules in the network security group.
 
@@ -66,9 +67,8 @@ After your data source is created, you can read values from the following attrib
         - `destination_port` - (List) List of destination port.
 
             Nested schema for `destination_port`:
-              - `maximum` - (Integer) The end of the port range, if applicable. If the value is not present then the default value of 65535 will be the maximum port number.
-              - `minimum` - (Integer) The start of the port range, if applicable. If the value is not present then the default value of 1 will be the minimum port number.
-        
+            - `maximum` - (Integer) The end of the port range, if applicable. If the value is not present then the default value of 65535 will be the maximum port number.
+            - `minimum` - (Integer) The start of the port range, if applicable. If the value is not present then the default value of 1 will be the minimum port number.
         - `id` - (String) The id of the rule in a network security group.
         - `protocol` - (List) List of protocol.
 
@@ -77,7 +77,7 @@ After your data source is created, you can read values from the following attrib
             - `tcp_flags` - (String) If tcp type, the list of TCP flags and if not present then all flags are matched. Supported values are: `syn`, `ack`, `fin`, `rst`.
             - `type` - (String) The protocol of the network traffic. Supported values are: `icmp`, `tcp`, `udp`, `all`.
         - `remote` - (List) List of remote.
-            
+
             Nested schema for `remote`:
             - `id` - (String) The id of the remote network Address group or network security group the rules apply to. Not required for default-network-address-group.
             - `type` - (String) The type of remote group the rules apply to. Supported values are: `network-security-group`, `network-address-group`, `default-network-address-group`.

--- a/website/docs/d/pi_networks.html.markdown
+++ b/website/docs/d/pi_networks.html.markdown
@@ -10,7 +10,7 @@ description: |-
 
 Retrieve a list of networks that you can use in your Power Systems Virtual Server instance. For more information, about power virtual server instance networks, see [setting up an IBM network install server](https://cloud.ibm.com/docs/power-iaas?topic=power-iaas-configuring-subnet).
 
-## Example usage
+## Example Usage
 
 ```terraform
 data "ibm_pi_networks" "ds_network" {
@@ -34,13 +34,13 @@ Example usage:
     }
   ```
   
-## Argument reference
+## Argument Reference
 
 Review the argument references that you can specify for your data source.
 
 - `pi_cloud_instance_id` - (Required, String) The GUID of the service instance associated with an account.
 
-## Attribute reference
+## Attribute Reference
 
 In addition to all argument reference list, you can access the following attribute references after your data source is created.
 

--- a/website/docs/d/pi_public_network.html.markdown
+++ b/website/docs/d/pi_public_network.html.markdown
@@ -7,23 +7,26 @@ description: |-
 ---
 
 # ibm_pi_public_network
-Retrieve the details about a public network that is used for your Power Systems Virtual Server instance. For more information, about public network in IBM Power Systems Virtual Server, see [adding or removing a public network
-](https://cloud.ibm.com/docs/power-iaas?topic=power-iaas-modifying-server#adding-removing-network).
 
-## Example usage
+Retrieve the details about a public network that is used for your Power Systems Virtual Server instance. For more information, about public network in IBM Power Systems Virtual Server, see [adding or removing a public network](https://cloud.ibm.com/docs/power-iaas?topic=power-iaas-modifying-server#adding-removing-network).
+
+## Example Usage
+
 ```terraform
 data "ibm_pi_public_network" "ds_public_network" {
   pi_cloud_instance_id = "49fba6c9-23f8-40bc-9899-aca322ee7d5b"
 }
 ```
 
-**Notes**
+### Notes
+
 - Please find [supported Regions](https://cloud.ibm.com/apidocs/power-cloud#endpoint) for endpoints.
 - If a Power cloud instance is provisioned at `lon04`, The provider level attributes should be as follows:
   - `region` - `lon`
   - `zone` - `lon04`
 
 Example usage:
+
   ```terraform
     provider "ibm" {
       region    =   "lon"
@@ -31,13 +34,15 @@ Example usage:
     }
   ```
 
-## Argument reference
-Review the argument references that you can specify for your data source. 
+## Argument Reference
+
+Review the argument references that you can specify for your data source.
 
 - `pi_cloud_instance_id` - (Required, String) The GUID of the service instance associated with an account.
 
-## Attribute reference
-In addition to all argument reference list, you can access the following attribute references after your data source is created. 
+## Attribute Reference
+
+In addition to all argument reference list, you can access the following attribute references after your data source is created.
 
 - `crn` - (String) The CRN of this resource.
 - `id` - (String) The ID of the network.

--- a/website/docs/r/pi_network.html.markdown
+++ b/website/docs/r/pi_network.html.markdown
@@ -55,7 +55,7 @@ The `ibm_pi_network` provides the following [Timeouts](https://www.terraform.io/
 - **update** - (Default 60 minutes) Used for updating a network.
 - **delete** - (Default 60 minutes) Used for deleting a network.
 
-## Argument reference
+## Argument Reference
 
 Review the argument references that you can specify for your resource.
 
@@ -82,7 +82,7 @@ Review the argument references that you can specify for your resource.
   - `type` - (Optional, String) Type of the network peer. Allowable values are: `L2`, `L3BGP`, `L3Static`.
 - `pi_user_tags` - (Optional, List) The user tags attached to this resource.
 
-## Attribute reference
+## Attribute Reference
 
 In addition to all argument reference list, you can access the following attribute reference after your resource is created.
 

--- a/website/docs/r/pi_network_port_attach.html.markdown
+++ b/website/docs/r/pi_network_port_attach.html.markdown
@@ -13,7 +13,7 @@ description: |-
 
 Attaches a network port to a Power Systems Virtual Server instance. For more information, see [getting started with IBM Power Systems Virtual Servers](https://cloud.ibm.com/docs/power-iaas?topic=power-iaas-getting-started).
 
-## Example usage
+## Example Usage
 
 In the following example, you can create an network_port_attach resource:
 
@@ -49,7 +49,7 @@ ibm_pi_network_port_attach provides the following [timeouts](https://www.terrafo
 - **create** - (Default 60 minutes) Used for attaching a network port.
 - **delete** - (Default 60 minutes) Used for detaching a network port.
 
-## Argument reference
+## Argument Reference
 
 Review the argument references that you can specify for your resource.
 
@@ -60,7 +60,7 @@ Review the argument references that you can specify for your resource.
 - `pi_network_port_ipaddress` - (Optional, String) The requested ip address of this port.
 - `pi_user_tags` - (Optional, List) The user tags attached to this resource.
 
-## Attribute reference
+## Attribute Reference
 
 In addition to all argument reference list, you can access the following attribute reference after your resource is created.
 

--- a/website/docs/r/pi_network_security_group_rule.html.markdown
+++ b/website/docs/r/pi_network_security_group_rule.html.markdown
@@ -94,18 +94,18 @@ Review the argument references that you can specify for your resource.
 - `pi_remote` - (Optional, List) List of remote. Required if `pi_network_security_group_rule_id` is not provided.
 
     Nested schema for `pi_remote`:
-    - `id` - (Optional, String) The id of the remote network address group or network security group the rules apply to. Not required for default-network-address-group.
-    - `type` - (Optional, String) The type of remote group the rules apply to. Supported values are: `network-security-group`, `network-address-group`, `default-network-address-group`.
+      - `id` - (Optional, String) The id of the remote network address group or network security group the rules apply to. Not required for default-network-address-group.
+      - `type` - (Optional, String) The type of remote group the rules apply to. Supported values are: `network-security-group`, `network-address-group`, `default-network-address-group`.
 - `pi_source_port` - (Optional, List) List of source port
 
     Nested schema for `pi_source_port`:
-    - `maximum` - (Optional, Int) The end of the port range, if applicable. If the value is not present then the default value of 65535 will be the maximum port number.
-    - `minimum` - (Optional, Int) The start of the port range, if applicable. If the value is not present then the default value of 1 will be the minimum port number.
+      - `maximum` - (Optional, Int) The end of the port range, if applicable. If the value is not present then the default value of 65535 will be the maximum port number.
+      - `minimum` - (Optional, Int) The start of the port range, if applicable. If the value is not present then the default value of 1 will be the minimum port number.
 - `pi_source_ports` - (Deprecated, Optional, List) List of source port. Deprecated, please use `pi_source_port`.
 
     Nested schema for `pi_source_ports`:
-    - `maximum` - (Optional, Int) The end of the port range, if applicable. If the value is not present then the default value of 65535 will be the maximum port number.
-    - `minimum` - (Optional, Int) The start of the port range, if applicable. If the value is not present then the default value of 1 will be the minimum port number.
+      - `maximum` - (Optional, Int) The end of the port range, if applicable. If the value is not present then the default value of 65535 will be the maximum port number.
+      - `minimum` - (Optional, Int) The start of the port range, if applicable. If the value is not present then the default value of 1 will be the minimum port number.
 
 - `pi_name` - (Optional, String) The name of the network security group rule. Required if `pi_network_security_group_rule_id` is not provided.
 


### PR DESCRIPTION
This PR removes the remaining warnings from the networks documentation.