### PR TITLE
Remove warnings from terraform instance markdown files

### DIFF
--- a/website/docs/d/pi_instance.html.markdown
+++ b/website/docs/d/pi_instance.html.markdown
@@ -10,7 +10,7 @@ description: |-
 
 Retrieve information about a Power Systems Virtual Server instance. For more information, about Power Virtual Server instance, see [getting started with IBM Power Systems Virtual Servers](https://cloud.ibm.com/docs/power-iaas?topic=power-iaas-getting-started).
 
-## Example usage
+## Example Usage
 
 ```terraform
 data "ibm_pi_instance" "ds_instance" {
@@ -35,14 +35,14 @@ Example usage:
     }
   ```
 
-## Argument reference
+## Argument Reference
 
 Review the argument references that you can specify for your data source.
 
 - `pi_cloud_instance_id` - (Required, String) The GUID of the service instance associated with an account.
 - `pi_instance_name` - (Required, String) The unique identifier or name of the instance.
 
-## Attribute reference
+## Attribute Reference
 
 In addition to all argument reference list, you can access the following attribute references after your data source is created.
 

--- a/website/docs/d/pi_instance_ip.html.markdown
+++ b/website/docs/d/pi_instance_ip.html.markdown
@@ -10,7 +10,7 @@ description: |-
 
 Retrieve information about a Power Systems Virtual Server instance IP address. For more information, about Power Systems Virtual Server instance IP address, see [configuring and adding a private network subnet](https://cloud.ibm.com/docs/power-iaas?topic=power-iaas-configuring-subnet).
 
-## Example usage
+## Example Usage
 
 ```terraform
 data "ibm_pi_instance_ip" "ds_instance_ip" {
@@ -36,7 +36,7 @@ Example usage:
     }
   ```
   
-## Argument reference
+## Argument Reference
 
 Review the argument references that you can specify for your data source.
 
@@ -44,7 +44,7 @@ Review the argument references that you can specify for your data source.
 - `pi_instance_name` - (Required, String) The unique identifier or name of the instance.
 - `pi_network_name` - (Required, String) The subnet that the instance belongs to.
 
-## Attribute reference
+## Attribute Reference
 
 In addition to all argument reference list, you can access the following attribute references after your data source is created.
 

--- a/website/docs/d/pi_instance_snapshot.html.markdown
+++ b/website/docs/d/pi_instance_snapshot.html.markdown
@@ -10,7 +10,7 @@ description: |-
 
 Retrieve information about a Power Systems Virtual Server instance snapshot. For more information, about Power Virtual Server instance snapshot, see [getting started with IBM Power Systems Virtual Servers](https://cloud.ibm.com/docs/power-iaas?topic=power-iaas-getting-started).
 
-## Example usage
+## Example Usage
 
 ```terraform
 data "ibm_pi_instance_snapshot" "ds_instance_snapshot" {
@@ -35,14 +35,14 @@ Example usage:
     }
   ```
 
-## Argument reference
+## Argument Reference
 
 Review the argument references that you can specify for your data source.
 
 - `pi_cloud_instance_id` - (Required, String) The GUID of the service instance associated with an account.
 - `pi_snapshot_id` - (Required, String) The unique identifier of the Power Systems Virtual Machine instance snapshot.
 
-## Attribute reference
+## Attribute Reference
 
 In addition to all argument reference list, you can access the following attribute references after your data source is created.
 

--- a/website/docs/d/pi_instance_snapshots.html.markdown
+++ b/website/docs/d/pi_instance_snapshots.html.markdown
@@ -10,7 +10,7 @@ description: |-
 
 Retrieve information about a Power Systems Virtual Server instance snapshots. For more information, about Power Virtual Server instance snapshots, see [getting started with IBM Power Systems Virtual Servers](https://cloud.ibm.com/docs/power-iaas?topic=power-iaas-getting-started).
 
-## Example usage
+## Example Usage
 
 ```terraform
 data "ibm_pi_instance_snapshots" "ds_instance_snapshots" {
@@ -34,13 +34,13 @@ Example usage:
     }
   ```
 
-## Argument reference
+## Argument Reference
 
 Review the argument references that you can specify for your data source.
 
 - `pi_cloud_instance_id` - (Required, String) The GUID of the service instance associated with an account.
 
-## Attribute reference
+## Attribute Reference
 
 In addition to all argument reference list, you can access the following attribute references after your data source is created.
 

--- a/website/docs/d/pi_instance_volumes.html.markdown
+++ b/website/docs/d/pi_instance_volumes.html.markdown
@@ -10,7 +10,7 @@ description: |-
 
 Retrieves information about the persistent storage volumes that are mounted to a Power Systems Virtual Server instance. For more information, about power instance volume, see [snapshotting, cloning, and restoring](https://cloud.ibm.com/docs/power-iaas?topic=power-iaas-volume-snapshot-clone).
 
-## Example usage
+## Example Usage
 
 The following example retrieves information about the volumes attached to the `terraform-test-instance` instance.
 
@@ -37,14 +37,14 @@ Example usage:
     }
   ```
 
-## Argument reference
+## Argument Reference
 
 Review the argument references that you can specify for your data source.
 
 - `pi_cloud_instance_id` - (Required, String) The GUID of the service instance associated with an account.
 - `pi_instance_name` - (Required, String) The unique identifier or name of the instance.
 
-## Attribute reference
+## Attribute Reference
 
 In addition to all argument reference list, you can access the following attribute references after your data source is created.
 

--- a/website/docs/d/pi_instances.html.markdown
+++ b/website/docs/d/pi_instances.html.markdown
@@ -10,7 +10,7 @@ description: |-
 
 Retrieve information about all Power Systems Virtual Server instances for the given cloud instance. For more information, about Power Virtual Server instances, see [getting started with IBM Power Systems Virtual Servers](https://cloud.ibm.com/docs/power-iaas?topic=power-iaas-getting-started).
 
-## Example usage
+## Example Usage
 
 ```terraform
 data "ibm_pi_instances" "ds_instance" {
@@ -34,13 +34,13 @@ Example usage:
     }
   ```
 
-## Argument reference
+## Argument Reference
 
 Review the argument references that you can specify for your data source.
 
 - `pi_cloud_instance_id` - (Required, String) The GUID of the service instance associated with an account.
 
-## Attribute reference
+## Attribute Reference
 
 In addition to all argument reference list, you can access the following attribute references after your data source is created.
 

--- a/website/docs/r/pi_capture.html.markdown
+++ b/website/docs/r/pi_capture.html.markdown
@@ -10,12 +10,12 @@ description: |-
 
 Create or delete for Capture Power System Virtual Server Instance
 
-**Note:-**
+**Note:**
 If `pi_capture_destination` is `Cloud-Storage` then delete bucket object functionality not supported by this resource , hence user need to delete bucket object manually from `Cloud Storage bucket`.
 
 For more information, about IBM power virtual server cloud, see [getting started with IBM Power Systems Virtual Servers](https://cloud.ibm.com/docs/power-iaas?topic=power-iaas-getting-started).
 
-## Example usage
+## Example Usage
 
 The following example creates a Capture Power System Virtual Server Instance.
 
@@ -65,7 +65,7 @@ ibm_pi_capture provides the following [timeouts](https://www.terraform.io/docs/l
 - **update** - (Default 10 minutes) Used for updating capture instance.
 - **delete** - (Default 10 minutes) Used for deleting capture instance.
 
-## Argument reference
+## Argument Reference
 
 Review the argument references that you can specify for your resource.
 
@@ -80,7 +80,7 @@ Review the argument references that you can specify for your resource.
 - `pi_instance_name` - (Required, String) The name of the instance.
 - `pi_user_tags` - (Optional, List of String) List of user tags attached to the resource.
 
-## Attribute reference
+## Attribute Reference
 
 In addition to all argument reference list, you can access the following attribute reference after your resource is created.
 

--- a/website/docs/r/pi_instance.html.markdown
+++ b/website/docs/r/pi_instance.html.markdown
@@ -10,7 +10,7 @@ description: |-
 
 Create, delete or update a [Power Systems Virtual Server instance](https://cloud.ibm.com/docs/power-iaas?topic=power-iaas-creating-power-virtual-server).
 
-## Example usage
+## Example Usage
 
 The following example creates a Power Systems Virtual Server instance.
 
@@ -58,7 +58,7 @@ The `ibm_pi_instance` provides the following [timeouts](https://www.terraform.io
 - **update** - (Default 60 minutes) Used for updating an instance.
 - **delete** - (Default 60 minutes) Used for deleting an instance.
 
-## Argument reference
+## Argument Reference
 
 Review the argument references that you can specify for your resource.
 
@@ -132,7 +132,7 @@ Review the argument references that you can specify for your resource.
       ~> **Note** When set to "auto-assign", changes to `serial` outside of terraform will not be detected. In addition, if a new generated virtual serial number is needed, the old serial must be removed before a new one is generated.
 - `pi_volume_ids` - (Optional, List of String) The list of volume IDs that you want to attach to the instance during creation.
 
-## Attribute reference
+## Attribute Reference
 
 In addition to all argument reference list, you can access the following attribute reference after your resource is created.
 

--- a/website/docs/r/pi_instance_action.html.markdown
+++ b/website/docs/r/pi_instance_action.html.markdown
@@ -10,7 +10,7 @@ description: |-
 
 Performs an action on a [Power Systems Virtual Server instance](https://cloud.ibm.com/docs/power-iaas?topic=power-iaas-creating-power-virtual-server).
 
-## Example usage
+## Example Usage
 
 The following example perform an action "hard-reboot" on a Power Systems Virtual Server instance.
 
@@ -25,12 +25,12 @@ resource "ibm_pi_instance_action" "example" {
 
 ### Notes
 
-* Please find [supported Regions](https://cloud.ibm.com/apidocs/power-cloud#endpoint) for endpoints.
-* If a Power cloud instance is provisioned at `lon04`, The provider level attributes should be as follows:
-  * `region` - `lon`
-  * `zone` - `lon04`
+- Please find [supported Regions](https://cloud.ibm.com/apidocs/power-cloud#endpoint) for endpoints.
+- If a Power cloud instance is provisioned at `lon04`, The provider level attributes should be as follows:
+  - `region` - `lon`
+  - `zone` - `lon04`
 
-  Example usage:
+Example usage:
 
   ```terraform
     provider "ibm" {
@@ -43,26 +43,26 @@ resource "ibm_pi_instance_action" "example" {
 
 The `ibm_pi_instance_action` provides the following [timeouts](https://www.terraform.io/docs/language/resources/syntax.html) configuration options:
 
-* **create** - (Default 15 minutes) Used for taking action on the instance.
-* **update** - (Default 15 minutes) Used for updating action on the instance.
+- **create** - (Default 15 minutes) Used for taking action on the instance.
+- **update** - (Default 15 minutes) Used for updating action on the instance.
 
-## Argument references
+## Argument References
 
 Review the argument references that you can specify for your resource.
 
-* `pi_action` - (Required, String) Name of the action to take. Allowed values are `start`, `stop`, `hard-reboot`, `soft-reboot`, `immediate-shutdown`, `reset-state`.
-* `pi_cloud_instance_id` - (Required, String) The GUID of the service instance associated with an account.
-* `pi_health_status` - (Optional, String) Specifies if Terraform should poll for the health status to be `OK` or `WARNING`. The default value is `OK`. Ignored for `pi_action = "reset-state"`.
-* `pi_instance_id` - (Required, String) The ID of the pvm instance to perform an action on.
+- `pi_action` - (Required, String) Name of the action to take. Allowed values are `start`, `stop`, `hard-reboot`, `soft-reboot`, `immediate-shutdown`, `reset-state`.
+- `pi_cloud_instance_id` - (Required, String) The GUID of the service instance associated with an account.
+- `pi_health_status` - (Optional, String) Specifies if Terraform should poll for the health status to be `OK` or `WARNING`. The default value is `OK`. Ignored for `pi_action = "reset-state"`.
+- `pi_instance_id` - (Required, String) The ID of the pvm instance to perform an action on.
 
-## Attribute reference
+## Attribute Reference
 
 In addition to all argument reference list, you can access the following attribute reference after your resource is created.
 
-* `health_status` - (String) The health status of the VM.
-* `id` - (String) The unique identifier of the instance. The ID is composed of `<pi_cloud_instance_id>/<pi_instance_id>`.
-* `progress` - (Float) - The progress of the instance.
-* `status` - (String) - The status of the instance.
+- `health_status` - (String) The health status of the VM.
+- `id` - (String) The unique identifier of the instance. The ID is composed of `<pi_cloud_instance_id>/<pi_instance_id>`.
+- `progress` - (Float) - The progress of the instance.
+- `status` - (String) - The status of the instance.
 
 ## Import
 

--- a/website/docs/r/pi_instance_snapshot.html.markdown
+++ b/website/docs/r/pi_instance_snapshot.html.markdown
@@ -10,7 +10,7 @@ description: |-
 
 Manages instance snapshots in the Power Virtual Server Cloud. For more information, about snapshots in the Power Virutal Server, see [snapshots for PVM Instance](https://cloud.ibm.com/apidocs/power-cloud#pcloud-pvminstances-snapshots-post).
 
-## Example usage
+## Example Usage
 
 The following example enables you to create a snapshot:
 
@@ -48,7 +48,7 @@ The `ibm_pi_instance_snapshot` provides the following [Timeouts](https://www.ter
 - **update** - (Default 60 minutes) Used for Updating snapshot.
 - **delete** - (Default 10 minutes) Used for Deleting snapshot.
 
-## Argument reference
+## Argument Reference
 
 Review the argument references that you can specify for your resource.
 
@@ -59,7 +59,7 @@ Review the argument references that you can specify for your resource.
 - `pi_user_tags` - (Optional, List) The user tags attached to this resource.
 - `pi_volume_ids` - (Optional, List) A list of volume IDs of the instance that will be part of the snapshot. If none are provided, then all the volumes of the instance will be part of the snapshot.
 
-## Attribute reference
+## Attribute Reference
 
 In addition to all argument reference list, you can access the following attribute reference after your resource is created.
 


### PR DESCRIPTION
This PR removes the remaining warnings from the instance documentation.