### PR TITLE
Remove warnings from terraform host and host-group markdown files

### DIFF
--- a/website/docs/d/pi_host.html.markdown
+++ b/website/docs/d/pi_host.html.markdown
@@ -50,23 +50,23 @@ After your data source is created, you can read values from the following attrib
 - `capacity` - (List) Capacities of the host.
   
     Nested schema for `capacity`:
-    - `available_core` - (Float) Number of cores currently available.
-    - `available_memory` - (Float) Amount of memory currently available (in GB).
-    - `reserved_core` - (Float) Number of cores reserved for system use.
-    - `reserved_memory` - (Float) Amount of memory reserved for system use (in GB).
-    - `total_core` - (Float) Total number of cores of the host.
-    - `total_memory` - (Float) Total amount of memory of the host (in GB).
-    - `used_core` - (Float) Number of cores in use on the host.
-    - `used_memory` - (Float) Amount of memory used on the host (in GB).
+      - `available_core` - (Float) Number of cores currently available.
+      - `available_memory` - (Float) Amount of memory currently available (in GB).
+      - `reserved_core` - (Float) Number of cores reserved for system use.
+      - `reserved_memory` - (Float) Amount of memory reserved for system use (in GB).
+      - `total_core` - (Float) Total number of cores of the host.
+      - `total_memory` - (Float) Total amount of memory of the host (in GB).
+      - `used_core` - (Float) Number of cores in use on the host.
+      - `used_memory` - (Float) Amount of memory used on the host (in GB).
 
 - `crn` - (String) The CRN of this resource.
 - `display_name` - (String) Name of the host.
 - `host_group` - (Map)  Information about the owning host group.
   
     Nested schema for `host_group`:
-  - `access` - (String) Whether the host group is a primary or secondary host group.
-  - `href` - (String) Link to the host group resource.
-  - `name` - (String) Name of the host group.
+      - `access` - (String) Whether the host group is a primary or secondary host group.
+      - `href` - (String) Link to the host group resource.
+      - `name` - (String) Name of the host group.
 - `host_reference` - (Integer) Current physical ID of the host.
 - `state` - (String) State of the host `up` or `down`.
 - `id` - (String) The unique identifier of the host.
@@ -74,4 +74,3 @@ After your data source is created, you can read values from the following attrib
 - `sys_type` - (String) System type.
 
 - `user_tags` - (List) List of user tags attached to the resource.
-

--- a/website/docs/d/pi_host_group.html.markdown
+++ b/website/docs/d/pi_host_group.html.markdown
@@ -10,7 +10,7 @@ description: |-
 
 Provides a read-only data source to retrieve information about a host group you can use in Power Systems Virtual Server. For more information, about Power Systems Virtual Server host group, see [host groups](https://cloud.ibm.com/apidocs/power-cloud#endpoint).
 
-## Example usage
+## Example Usage
 
 ```terraform
 data "ibm_pi_host_group" "ds_host_group" {

--- a/website/docs/r/pi_host.html.markdown
+++ b/website/docs/r/pi_host.html.markdown
@@ -27,10 +27,10 @@ resource "ibm_pi_host" "host" {
 
 ### Notes
 
-* Please find [supported Regions](https://cloud.ibm.com/apidocs/power-cloud#endpoint) for endpoints.
-* If a Power cloud instance is provisioned at `lon04`, The provider level attributes should be as follows:
-  * `region` - `lon`
-  * `zone` - `lon04`
+- Please find [supported Regions](https://cloud.ibm.com/apidocs/power-cloud#endpoint) for endpoints.
+- If a Power cloud instance is provisioned at `lon04`, The provider level attributes should be as follows:
+  - `region` - `lon`
+  - `zone` - `lon04`
   
   Example usage:
   
@@ -61,7 +61,6 @@ You can specify the following arguments for this resource.
   - `user_tags` - (Optional, List) The user tags attached to this resource.
 - `pi_host_group_id` - (Required, String) ID of the host group to which the host should be added.
 
-
 ## Attribute Reference
 
 In addition to all argument reference list, you can access the following attribute reference after your resource is created.
@@ -69,22 +68,22 @@ In addition to all argument reference list, you can access the following attribu
 - `capacity` - (List) Capacities of the host.
 
     Nested schema for `capacity`:
-    - `available_core` - (Float) Number of cores currently available.
-    - `available_memory` - (Float) Amount of memory currently available (in GB).
-    - `reserved_core` - (Float) Number of cores reserved for system use.
-    - `reserved_memory` - (Float) Amount of memory reserved for system use (in GB).
-    - `total_core` - (Float) Total number of cores of the host.
-    - `total_memory` - (Float) Total amount of memory of the host (in GB).
-    - `used_core` - (Float) Number of cores in use on the host.
-    - `used_memory` - (Float) Amount of memory used on the host (in GB).
+      - `available_core` - (Float) Number of cores currently available.
+      - `available_memory` - (Float) Amount of memory currently available (in GB).
+      - `reserved_core` - (Float) Number of cores reserved for system use.
+      - `reserved_memory` - (Float) Amount of memory reserved for system use (in GB).
+      - `total_core` - (Float) Total number of cores of the host.
+      - `total_memory` - (Float) Total amount of memory of the host (in GB).
+      - `used_core` - (Float) Number of cores in use on the host.
+      - `used_memory` - (Float) Amount of memory used on the host (in GB).
 
 - `crn` - (String) The CRN of this resource.
 - `host_group` - (Map)  Information about the owning host group.
   
     Nested schema for `host_group`:
-    - `access` - (String) Whether the host group is a primary or secondary host group.
-    - `href` - (String) Link to the host group resource.
-    - `name` - (String) Name of the host group.
+      - `access` - (String) Whether the host group is a primary or secondary host group.
+      - `href` - (String) Link to the host group resource.
+      - `name` - (String) Name of the host group.
   
 - `host_id` - (String) ID of the host.
 - `id` - The unique identifier of the host. The ID is composed of `<pi_cloud_instance_id>/<host_id>`.

--- a/website/docs/r/pi_host_group.html.markdown
+++ b/website/docs/r/pi_host_group.html.markdown
@@ -31,10 +31,10 @@ resource "ibm_pi_host_group" "hostGroup" {
 
 ### Notes
 
-* Please find [supported Regions](https://cloud.ibm.com/apidocs/power-cloud#endpoint) for endpoints.
-* If a Power cloud instance is provisioned at `lon04`, The provider level attributes should be as follows:
-  * `region` - `lon`
-  * `zone` - `lon04`
+- Please find [supported Regions](https://cloud.ibm.com/apidocs/power-cloud#endpoint) for endpoints.
+- If a Power cloud instance is provisioned at `lon04`, The provider level attributes should be as follows:
+  - `region` - `lon`
+  - `zone` - `lon04`
   
   Example usage:
   


### PR DESCRIPTION
This PR removes the remaining warnings from the host and host-group documentation.