### PR TITLE
Remove warnings from terraform spp and pg markdown files

### DIFF
--- a/website/docs/d/pi_placement_group.html.markdown
+++ b/website/docs/d/pi_placement_group.html.markdown
@@ -7,9 +7,11 @@ description: |-
 ---
 
 # ibm_pi_placement_group
+
 Retrieve information about a placement group. For more information, about placement groups, see [Managing server placement groups](https://cloud.ibm.com/docs/power-iaas?topic=power-iaas-placement-groups).
 
 ## Example Usage
+
 ```terraform
 data "ibm_pi_placement_group" "ds_placement_group" {
   pi_placement_group_name   = "my-pg"
@@ -17,13 +19,15 @@ data "ibm_pi_placement_group" "ds_placement_group" {
 }
 ```
 
-**Notes**
+### Notes
+
 - Please find [supported Regions](https://cloud.ibm.com/apidocs/power-cloud#endpoint) for endpoints.
 - If a Power cloud instance is provisioned at `lon04`, The provider level attributes should be as follows:
   - `region` - `lon`
   - `zone` - `lon04`
   
 Example usage:
+
   ```terraform
     provider "ibm" {
       region    =   "lon"
@@ -31,14 +35,16 @@ Example usage:
     }
   ```
 
-## Argument reference
-Review the argument references that you can specify for your data source. 
+## Argument Reference
+
+Review the argument references that you can specify for your data source.
 
 - `pi_cloud_instance_id` - (Required, String) The GUID of the service instance associated with an account.
 - `pi_placement_group_name` - (Required, String) The name of the placement group.
 
-## Attribute reference
-In addition to all argument reference list, you can access the following attribute references after your data source is created. 
+## Attribute Reference
+
+In addition to all argument reference list, you can access the following attribute references after your data source is created.
 
 - `id` - (String) The ID of the placement group.
 - `members` - (List) List of server instances IDs that are members of the placement group.

--- a/website/docs/d/pi_placement_groups.html.markdown
+++ b/website/docs/d/pi_placement_groups.html.markdown
@@ -7,22 +7,26 @@ description: |-
 ---
 
 # ibm_pi_placement_groups
+
 Retrieve information about all placement groups. For more information, see [getting started with IBM Power Systems Virtual Servers](https://cloud.ibm.com/docs/power-iaas?topic=power-iaas-getting-started).
 
 ## Example usage
+
 ```terraform
 data "ibm_pi_placement_groups" "example" {
   pi_cloud_instance_id = "<value of the cloud_instance_id>"
 }
 ```
 
-**Notes**
+### Notes
+
 - Please find [supported Regions](https://cloud.ibm.com/apidocs/power-cloud#endpoint) for endpoints.
 - If a Power cloud instance is provisioned at `lon04`, The provider level attributes should be as follows:
   - `region` - `lon`
   - `zone` - `lon04`
 
 Example usage:
+
   ```terraform
     provider "ibm" {
       region    =   "lon"
@@ -30,12 +34,14 @@ Example usage:
     }
   ```
   
-## Argument reference
+## Argument Reference
+
 Review the argument references that you can specify for your data source.
 
 - `pi_cloud_instance_id` - (Required, String) The GUID of the service instance associated with an account.
 
-## Attribute reference
+## Attribute Reference
+
 In addition to all argument reference list, you can access the following attribute references after your data source is created.
 
 - `placement_groups` - (List) List of all the placement groups.

--- a/website/docs/d/pi_shared_processor_pool.html.markdown
+++ b/website/docs/d/pi_shared_processor_pool.html.markdown
@@ -35,14 +35,14 @@ Example usage:
     }
   ```
 
-## Argument reference
+## Argument Reference
 
 Review the argument references that you can specify for your data source.
 
 - `pi_cloud_instance_id` - (Required, String) The GUID of the service instance associated with an account.
 - `pi_shared_processor_pool_id` - (Required, String) The ID of the shared processor pool.
 
-## Attribute reference
+## Attribute Reference
 
 In addition to all argument reference list, you can access the following attribute references after your data source is created.
 

--- a/website/docs/d/pi_shared_processor_pools.html.markdown
+++ b/website/docs/d/pi_shared_processor_pools.html.markdown
@@ -34,13 +34,13 @@ Example usage:
     }
   ```
   
-## Argument reference
+## Argument Reference
 
 Review the argument references that you can specify for your data source.
 
 - `pi_cloud_instance_id` - (Required, String) The GUID of the service instance associated with an account.
 
-## Attribute reference
+## Attribute Reference
 
 In addition to all argument reference list, you can access the following attribute references after your data source is created.
 

--- a/website/docs/d/pi_spp_placement_group.html.markdown
+++ b/website/docs/d/pi_spp_placement_group.html.markdown
@@ -7,9 +7,11 @@ description: |-
 ---
 
 # ibm_pi_spp_placement_group
+
 Retrieve information about a shared processor pool placement group. For more information, see [getting started with IBM Power Systems Virtual Servers](https://cloud.ibm.com/docs/power-iaas?topic=power-iaas-getting-started).
 
 ## Example Usage
+
 ```terraform
 data "ibm_pi_spp_placement_group" "ds_placement_group" {
   pi_spp_placement_group_id   = "my-spppg"
@@ -17,13 +19,15 @@ data "ibm_pi_spp_placement_group" "ds_placement_group" {
 }
 ```
 
-**Notes**
+### Notes
+
 - Please find [supported Regions](https://cloud.ibm.com/apidocs/power-cloud#endpoint) for endpoints.
 - If a Power cloud instance is provisioned at `lon04`, The provider level attributes should be as follows:
   - `region` - `lon`
   - `zone` - `lon04`
   
 Example usage:
+
   ```terraform
     provider "ibm" {
       region    =   "lon"
@@ -31,14 +35,16 @@ Example usage:
     }
   ```
 
-## Argument reference
-Review the argument references that you can specify for your data source. 
+## Argument Reference
+
+Review the argument references that you can specify for your data source.
 
 - `pi_cloud_instance_id` - (Required, String) The GUID of the service instance associated with an account.
 - `pi_spp_placement_group_id` - (Required, String) The ID of the shared processor pool placement group.
 
-## Attribute reference
-In addition to all argument reference list, you can access the following attribute references after your data source is created. 
+## Attribute Reference
+
+In addition to all argument reference list, you can access the following attribute references after your data source is created.
 
 - `members` - (List) List of shared processor pool IDs that are members of the placement group.
 - `name` - (String) The name of the shared processor pool placement group.

--- a/website/docs/d/pi_spp_placement_groups.html.markdown
+++ b/website/docs/d/pi_spp_placement_groups.html.markdown
@@ -7,22 +7,26 @@ description: |-
 ---
 
 # ibm_pi_spp_placement_groups
+
 Retrieve information about all shared processor pool placement groups. For more information, see [getting started with IBM Power Systems Virtual Servers](https://cloud.ibm.com/docs/power-iaas?topic=power-iaas-getting-started).
 
-## Example usage
+## Example Usage
+
 ```terraform
 data "ibm_pi_spp_placement_groups" "example" {
   pi_cloud_instance_id = "<value of the cloud_instance_id>"
 }
 ```
 
-**Notes**
+### Notes
+
 - Please find [supported Regions](https://cloud.ibm.com/apidocs/power-cloud#endpoint) for endpoints.
 - If a Power cloud instance is provisioned at `lon04`, The provider level attributes should be as follows:
   - `region` - `lon`
   - `zone` - `lon04`
 
 Example usage:
+
   ```terraform
     provider "ibm" {
       region    =   "lon"
@@ -30,12 +34,14 @@ Example usage:
     }
   ```
   
-## Argument reference
+## Argument Reference
+
 Review the argument references that you can specify for your data source.
 
 - `pi_cloud_instance_id` - (Required, String) The GUID of the service instance associated with an account.
 
-## Attribute reference
+## Attribute Reference
+
 In addition to all argument reference list, you can access the following attribute references after your data source is created.
 
 - `spp_placement_groups` - (List) List of all the shared processor pool placement groups.

--- a/website/docs/r/pi_placement_group.html.markdown
+++ b/website/docs/r/pi_placement_group.html.markdown
@@ -10,7 +10,7 @@ description: |-
 
 Create or delete a placement group.
 
-## Example usage
+## Example Usage
 
 The following example enables you to create a placement group with a group policy of affinity:
 
@@ -29,7 +29,7 @@ resource "ibm_pi_placement_group" "testacc_placement_group" {
   - `region` - `lon`
   - `zone` - `lon04`
   
-  Example usage:
+Example usage:
 
   ```terraform
     provider "ibm" {
@@ -45,7 +45,7 @@ ibm_pi_placement_group provides the following [timeouts](https://www.terraform.i
 - **create** - (Default 60 minutes) Used for creating a placement group.
 - **delete** - (Default 60 minutes) Used for deleting a placement group.
 
-## Argument reference
+## Argument Reference
 
 Review the argument references that you can specify for your resource.
 
@@ -53,7 +53,7 @@ Review the argument references that you can specify for your resource.
 - `pi_placement_group_name`  - (Required, String) The name of the placement group.
 - `pi_placement_group_policy` - (Required, String) The value of the group's affinity policy. Valid values are `affinity` and `anti-affinity`.
 
-## Attribute reference
+## Attribute Reference
 
  In addition to all argument reference list, you can access the following attribute reference after your resource is created.
 

--- a/website/docs/r/pi_shared_processor_pool.html.markdown
+++ b/website/docs/r/pi_shared_processor_pool.html.markdown
@@ -10,7 +10,7 @@ description: |-
 
 Create, update or delete a shared processor pool.
 
-## Example usage
+## Example Usage
 
 The following example enables you to create a shared processor pool with a group 2 reserved cores on a s922 host group:
 
@@ -47,7 +47,7 @@ ibm_pi_shared_processor_pool provides the following [timeouts](https://www.terra
 - **delete** - (Default 60 minutes) Used for deleting a shared processor pool.
 - **update** - (Default 60 minutes) Used for updating a shared processor pool.
 
-## Argument reference
+## Argument Reference
 
 Review the argument references that you can specify for your resource.
 
@@ -60,7 +60,7 @@ Review the argument references that you can specify for your resource.
 - `pi_shared_processor_pool_reserved_cores` - (Required, Integer) The amount of reserved cores for the shared processor pool.
 - `pi_user_tags` - (Optional, List) The user tags attached to this resource.
 
-## Attribute reference
+## Attribute Reference
 
 In addition to all argument reference list, you can access the following attribute reference after your resource is created.
 

--- a/website/docs/r/pi_spp_placement_group.html.markdown
+++ b/website/docs/r/pi_spp_placement_group.html.markdown
@@ -7,9 +7,11 @@ description: |-
 ---
 
 # ibm_pi_spp_placement_group
+
 Create, update or delete a shared processor pool placement group.
 
-## Example usage
+## Example Usage
+
 The following example enables you to create a shared processor pool placement group with a group policy of affinity:
 
 ```terraform
@@ -20,13 +22,14 @@ resource "ibm_pi_spp_placement_group" "testacc_placement_group" {
 }
 ```
 
-**Note**
-* Please find [supported Regions](https://cloud.ibm.com/apidocs/power-cloud#endpoint) for endpoints.
-* If a Power cloud instance is provisioned at `lon04`, The provider level attributes should be as follows:
-  * `region` - `lon`
-  * `zone` - `lon04`
+### Notes
+
+- Please find [supported Regions](https://cloud.ibm.com/apidocs/power-cloud#endpoint) for endpoints.
+- If a Power cloud instance is provisioned at `lon04`, The provider level attributes should be as follows:
+  - `region` - `lon`
+  - `zone` - `lon04`
   
-  Example usage:
+Example usage:
 
   ```terraform
     provider "ibm" {
@@ -42,15 +45,16 @@ ibm_pi_spp_placement_group provides the following [timeouts](https://www.terrafo
 - **create** - (Default 60 minutes) Used for creating a shared processor pool placement group.
 - **delete** - (Default 60 minutes) Used for deleting a shared processor pool placement group.
 
-## Argument reference
-Review the argument references that you can specify for your resource. 
+## Argument Reference
+
+Review the argument references that you can specify for your resource.
 
 - `pi_cloud_instance_id` - (Required, String) The GUID of the service instance associated with an account.
-- `pi_spp_placement_group_name`  - (Required, String) The name of the shared processor pool placement group. 
-- `pi_spp_placement_group_policy` - (Required, String) The value of the group's affinity policy. Valid values are `affinity` and `anti-affinity`. 
+- `pi_spp_placement_group_name`  - (Required, String) The name of the shared processor pool placement group.
+- `pi_spp_placement_group_policy` - (Required, String) The value of the group's affinity policy. Valid values are `affinity` and `anti-affinity`.
 
+## Attribute Reference
 
-## Attribute reference
  In addition to all argument reference list, you can access the following attribute reference after your resource is created.
 
 - `id` - (String) The unique identifier of the placement group.
@@ -61,8 +65,8 @@ Review the argument references that you can specify for your resource.
 
 The `ibm_spp_pi_placement_group` resource can be imported by using `power_instance_id` and `spp_placement_group_id`.
 
-**Example**
+### Example
 
-```
-$ terraform import ibm_pi_spp_placement_group.example d7bec597-4726-451f-8a63-e62e6f19c32c/b17a2b7f-77ab-491c-811e-495f8d4c8947
+```bash
+terraform import ibm_pi_spp_placement_group.example d7bec597-4726-451f-8a63-e62e6f19c32c/b17a2b7f-77ab-491c-811e-495f8d4c8947
 ```


### PR DESCRIPTION
This PR removes the remaining warnings from the spp and placement-group documentation.