### PR TITLE
Remove warnings from terraform datacenter and workspace markdown files

### DIFF
--- a/website/docs/d/pi_datacenter.html.markdown
+++ b/website/docs/d/pi_datacenter.html.markdown
@@ -10,7 +10,7 @@ description: |-
 
 Retrieve information about a Power Systems Datacenter.
 
-## Example usage
+## Example Usage
 
 ```terraform
 data "ibm_pi_datacenter" "datacenter" {
@@ -34,14 +34,14 @@ Example usage:
     }
   ```
   
-## Argument reference
+## Argument Reference
 
 Review the argument references that you can specify for your data source.
 
 - `pi_cloud_instance_id` - (Optional, String) The GUID of the service instance associated with an account. Required if private datacenter.
 - `pi_datacenter_zone` - (Optional, String) Datacenter zone you want to retrieve. If no value is supplied, the `zone` configured within the IBM provider will be utilized.
 
-## Attribute reference
+## Attribute Reference
 
 In addition to all argument reference list, you can access the following attribute references after your data source is created.
 

--- a/website/docs/d/pi_datacenters.html.markdown
+++ b/website/docs/d/pi_datacenters.html.markdown
@@ -7,22 +7,26 @@ description: |-
 ---
 
 # ibm_pi_datacenters
+
 Retrieve information about Power Systems Datacenters.
 
-## Example usage
+## Example Usage
+
 The following example retrieves information about Power Systems Datacenters.
 
 ```terraform
 data "ibm_pi_datacenters" "datacenters" {}
 ```
 
-**Notes**
+### Notes
+
 - Please find [supported Regions](https://cloud.ibm.com/apidocs/power-cloud#endpoint) for endpoints.
 - If a Power cloud instance is provisioned at `lon04`, The provider level attributes should be as follows:
   - `region` - `lon`
   - `zone` - `lon04`
 
 Example usage:
+
   ```terraform
     provider "ibm" {
       region    =   "lon"
@@ -30,13 +34,14 @@ Example usage:
     }
   ```
 
-## Argument reference
+## Argument Reference
 
 Review the argument references that you can specify for your data source.
 
 - `pi_cloud_instance_id` - (Optional, String) The GUID of the service instance associated with an account. Required if private datacenter.
 
-## Attribute reference
+## Attribute Reference
+
 In addition to all argument reference list, you can access the following attribute references after your data source is created.
 
 - `datacenters` - (List) List of Datacenters

--- a/website/docs/d/pi_workspace.html.markdown
+++ b/website/docs/d/pi_workspace.html.markdown
@@ -10,7 +10,7 @@ description: |-
 
 Retrieve information about your Power Systems account workspace.
 
-## Example usage
+## Example Usage
 
 ```terraform
 data "ibm_pi_workspace" "workspace" {
@@ -34,13 +34,13 @@ Example usage:
     }
   ```
 
-## Argument reference
+## Argument Reference
 
 Review the argument references that you can specify for your data source.
 
 - `pi_cloud_instance_id` - (Required, String) Cloud Instance ID of a PCloud Instance under your account.
 
-## Attribute reference
+## Attribute Reference
 
 In addition to all argument reference listed, you can access the following attribute references after your data source is created.
 
@@ -48,7 +48,7 @@ In addition to all argument reference listed, you can access the following attri
 - `pi_workspace_capabilities` - (Map) Workspace Capabilities. Capabilities are `true` or `false`.
 
     Some of `pi_workspace_capabilities` are:
-    - `cloud-connections`, `power-edge-router`, `power-vpn-connections`,  `transit-gateway-connection`
+      - `cloud-connections`, `power-edge-router`, `power-vpn-connections`,  `transit-gateway-connection`
 
 - `pi_workspace_details` - (List) Workspace information.
 
@@ -58,13 +58,13 @@ In addition to all argument reference listed, you can access the following attri
   - `network_security_groups` - (List) Network security groups configuration.
 
       Nested schema for `network_security_groups`:
-      - `state` - (String) The state of a network security groups configuration.
+        - `state` - (String) The state of a network security groups configuration.
   - `power_edge_router` - (List) Power Edge Router information.
 
       Nested schema for `power_edge_router`:
-      - `migration_status` - (String) The migration status of a Power Edge Router.
-      - `status` - (String) The state of a Power Edge Router.
-      - `type` - (String) The Power Edge Router type.
+        - `migration_status` - (String) The migration status of a Power Edge Router.
+        - `status` - (String) The state of a Power Edge Router.
+        - `type` - (String) The Power Edge Router type.
 - `pi_workspace_location` - (Map) Workspace location.
 
     Nested schema for `Workspace location`:

--- a/website/docs/d/pi_workspaces.html.markdown
+++ b/website/docs/d/pi_workspaces.html.markdown
@@ -10,7 +10,7 @@ description: |-
 
 Retrieve information about  Power Systems workspaces.
 
-## Example usage
+## Example Usage
 
 ```terraform
 data "ibm_pi_workspaces" "workspaces" {
@@ -34,13 +34,13 @@ Example usage:
     }
   ```
 
-## Argument reference
+## Argument Reference
 
 Review the argument references that you can specify for your data source.
 
 - `pi_cloud_instance_id` - (Required, String) The GUID of the service instance associated with an account.
 
-## Attribute reference
+## Attribute Reference
 
 In addition to all argument reference listed, you can access the following attribute references after your data source is created.
 
@@ -49,18 +49,18 @@ In addition to all argument reference listed, you can access the following attri
   - `pi_workspace_capabilities` - (Map) Workspace Capabilities. Capabilities are `true` or `false`.
 
       Some of `pi_workspace_capabilities` are:
-      - `cloud-connections`, `power-edge-router`, `power-vpn-connections`, `transit-gateway-connection`
+        - `cloud-connections`, `power-edge-router`, `power-vpn-connections`, `transit-gateway-connection`
 
   - `pi_workspace_details` - (List) Workspace information.
 
-      Nested schema for `pi_workspace_details`:
-      - `creation_date` - (String) Date of workspace creation.
-      - `crn` - (String) Workspace crn.
-      - `network_security_groups` - (List) Network security groups configuration.
-        
+        Nested schema for `pi_workspace_details`:
+        - `creation_date` - (String) Date of workspace creation.
+        - `crn` - (String) Workspace crn.
+        - `network_security_groups` - (List) Network security groups configuration.
+
           Nested schema for `network_security_groups`:
           - `state` - (String) The state of a network security groups configuration.
-      - `power_edge_router` - (List) Power Edge Router information.
+        - `power_edge_router` - (List) Power Edge Router information.
 
           Nested schema for `power_edge_router`:
           - `migration_status` - (String) The migration status of a Power Edge Router.

--- a/website/docs/r/pi_workspace.html.markdown
+++ b/website/docs/r/pi_workspace.html.markdown
@@ -1,5 +1,4 @@
 ---
-
 subcategory: "Power Systems"
 layout: "ibm"
 page_title: "IBM: pi_workspace"
@@ -11,7 +10,7 @@ description: |-
 
 Create or Delete a PowerVS Workspace
 
-## Example usage
+## Example Usage
 
 ```terraform
 data "ibm_resource_group" "group" {
@@ -39,7 +38,7 @@ The `ibm_pi_workspace` provides the following [timeouts](https://developer.hashi
 - **create** - (Default 30 minutes) Used for creating powervs workspace.
 - **delete** - (Default 30 minutes) Used for deleting powervs workspace.
 
-## Argument reference
+## Argument Reference
 
 Review the argument references that you can specify for your resource.
 
@@ -49,7 +48,7 @@ Review the argument references that you can specify for your resource.
 - `pi_resource_group_id` - (Required, String) The ID of the resource group where you want to create the workspace. You can retrieve the value from data source `ibm_resource_group`.
 - `pi_user_tags` - (Optional, List) List of user tags attached to the resource.
 
-## Attribute reference
+## Attribute Reference
 
 In addition to all argument reference listed, you can access the following attribute references after your resource source is created.
 


### PR DESCRIPTION
This PR removes the remaining warnings from the datacenter and workspace documentation.