### PR TITLE
Remove warnings from terraform dhcp and ssh-key markdown files

### DIFF
--- a/website/docs/d/pi_dhcp.html.markdown
+++ b/website/docs/d/pi_dhcp.html.markdown
@@ -7,9 +7,11 @@ description: |-
 ---
 
 # ibm_pi_dhcp
+
 Retrieve information about a DHCP Server. For more information, see [getting started with IBM Power Systems Virtual Servers](https://cloud.ibm.com/docs/power-iaas?topic=power-iaas-getting-started).
 
-## Example usage
+## Example Usage
+
 ```terraform
 data "ibm_pi_dhcp" "example" {
   pi_cloud_instance_id = "<value of the cloud_instance_id>"
@@ -17,13 +19,15 @@ data "ibm_pi_dhcp" "example" {
 }
 ```
 
-**Notes**
+### Notes
+
 - Please find [supported Regions](https://cloud.ibm.com/apidocs/power-cloud#endpoint) for endpoints.
 - If a Power cloud instance is provisioned at `lon04`, The provider level attributes should be as follows:
   - `region` - `lon`
   - `zone` - `lon04`
 
 Example usage:
+
   ```terraform
     provider "ibm" {
       region    =   "lon"
@@ -31,13 +35,15 @@ Example usage:
     }
   ```
 
-## Argument reference
+## Argument Reference
+
 Review the argument references that you can specify for your data source.
 
 - `pi_cloud_instance_id` - (Required, String) The GUID of the service instance associated with an account.
 - `pi_dhcp_id` - (Required, String) ID of the DHCP Server.
 
-## Attribute reference
+## Attribute Reference
+
 In addition to all argument reference list, you can access the following attribute references after your data source is created.
 
 - `dhcp_id` - (Deprecated, String) ID of the DHCP Server.

--- a/website/docs/d/pi_dhcps.html.markdown
+++ b/website/docs/d/pi_dhcps.html.markdown
@@ -7,22 +7,26 @@ description: |-
 ---
 
 # ibm_pi_dhcps
+
 Retrieve information about all DHCP Servers. For more information, see [getting started with IBM Power Systems Virtual Servers](https://cloud.ibm.com/docs/power-iaas?topic=power-iaas-getting-started).
 
-## Example usage
+## Example Usage
+
 ```terraform
 data "ibm_pi_dhcps" "example" {
   pi_cloud_instance_id = "<value of the cloud_instance_id>"
 }
 ```
 
-**Notes**
+### Notes
+
 - Please find [supported Regions](https://cloud.ibm.com/apidocs/power-cloud#endpoint) for endpoints.
 - If a Power cloud instance is provisioned at `lon04`, The provider level attributes should be as follows:
   - `region` - `lon`
   - `zone` - `lon04`
 
 Example usage:
+
   ```terraform
     provider "ibm" {
       region    =   "lon"
@@ -30,12 +34,14 @@ Example usage:
     }
   ```
 
-## Argument reference
+## Argument Reference
+
 Review the argument references that you can specify for your data source.
 
 - `pi_cloud_instance_id` - (Required, String) The GUID of the service instance associated with an account.
 
-## Attribute reference
+## Attribute Reference
+
 In addition to all argument reference list, you can access the following attribute references after your data source is created.
 
 - `servers` - (List) List of all the DHCP Servers.

--- a/website/docs/d/pi_key.html.markdown
+++ b/website/docs/d/pi_key.html.markdown
@@ -7,9 +7,11 @@ description: |-
 ---
 
 # ibm_pi_key
+
 Retrieve information about the SSH key that is used for your Power Systems Virtual Server instance. The SSH key is used to access the instance after it is created. For more information, about [generating and using SSH Keys](https://cloud.ibm.com/docs/power-iaas?topic=power-iaas-creating-ssh-key).
 
-## Example usage
+## Example Usage
+
 ```terraform
 data "ibm_pi_key" "ds_instance" {
   pi_key_name          = "terraform-test-key"
@@ -17,13 +19,15 @@ data "ibm_pi_key" "ds_instance" {
 }
 ```
 
-**Notes**
+### Notes
+
 - Please find [supported Regions](https://cloud.ibm.com/apidocs/power-cloud#endpoint) for endpoints.
 - If a Power cloud instance is provisioned at `lon04`, The provider level attributes should be as follows:
   - `region` - `lon`
   - `zone` - `lon04`
 
 Example usage:
+
   ```terraform
     provider "ibm" {
       region    =   "lon"
@@ -31,15 +35,17 @@ Example usage:
     }
   ```
 
-## Argument reference
-Review the argument references that you can specify for your data source. 
+## Argument Reference
+
+Review the argument references that you can specify for your data source.
 
 - `pi_cloud_instance_id` - (Required, String) The GUID of the service instance associated with an account.
-- `pi_key_name`  - (Required, String) User defined name for the SSH key. 
+- `pi_key_name`  - (Required, String) User defined name for the SSH key.
 
-## Attribute reference
-In addition to all argument reference list, you can access the following attribute references after your data source is created. 
+## Attribute Reference
+
+In addition to all argument reference list, you can access the following attribute references after your data source is created.
 
 - `id` - (String) User defined name for the SSH key
-- `creation_date` - (String) Date of SSH Key creation. 
+- `creation_date` - (String) Date of SSH Key creation.
 - `ssh_key` - (String) SSH RSA key.

--- a/website/docs/d/pi_keys.html.markdown
+++ b/website/docs/d/pi_keys.html.markdown
@@ -7,22 +7,26 @@ description: |-
 ---
 
 # ibm_pi_keys
+
 Retrieve information about all SSH keys. For more information, about [generating and using SSH Keys](https://cloud.ibm.com/docs/power-iaas?topic=power-iaas-creating-ssh-key).
 
-## Example usage
+## Example Usage
+
 ```terraform
 data "ibm_pi_keys" "example" {
   pi_cloud_instance_id = "<value of the cloud_instance_id>"
 }
 ```
 
-**Notes**
+### Notes
+
 - Please find [supported Regions](https://cloud.ibm.com/apidocs/power-cloud#endpoint) for endpoints.
 - If a Power cloud instance is provisioned at `lon04`, The provider level attributes should be as follows:
   - `region` - `lon`
   - `zone` - `lon04`
 
 Example usage:
+
   ```terraform
     provider "ibm" {
       region    =   "lon"
@@ -30,17 +34,19 @@ Example usage:
     }
   ```
 
-## Argument reference
+## Argument Reference
+
 Review the argument references that you can specify for your data source.
 
 - `pi_cloud_instance_id` - (Required, String) The GUID of the service instance associated with an account.
 
-## Attribute reference
+## Attribute Reference
+
 In addition to all argument reference list, you can access the following attribute references after your data source is created.
 
 - `keys` - (List) List of all the SSH keys.
 
   Nested scheme for `keys`:
-  - `creation_date` - (String) Date of SSH Key creation. 
+  - `creation_date` - (String) Date of SSH Key creation.
   - `name` - (String) User defined name for the SSH key.
   - `ssh_key` - (String) SSH RSA key.

--- a/website/docs/r/pi_dhcp.html.markdown
+++ b/website/docs/r/pi_dhcp.html.markdown
@@ -1,5 +1,4 @@
 ---
-
 subcategory: "Power Systems"
 layout: "ibm"
 page_title: "IBM: pi_dhcp"
@@ -11,7 +10,7 @@ description: |-
 
 Create, update, or delete DHCP Server for your Power Systems Virtual Server instance. For more information, see [getting started with IBM Power Systems Virtual Servers](https://cloud.ibm.com/docs/power-iaas?topic=power-iaas-getting-started).
 
-## Example usage
+## Example Usage
 
 The following example enables you to create a DHCP Server:
 
@@ -21,7 +20,7 @@ resource "ibm_pi_dhcp" "example" {
 }
 ```
 
-## Argument reference
+## Argument Reference
 
 Review the argument references that you can specify for your resource.
 
@@ -32,7 +31,7 @@ Review the argument references that you can specify for your resource.
 - `pi_dhcp_snat_enabled` - (Optional, Bool) Indicates if SNAT will be enabled for the DHCP service. The default value is **true**.
 - `pi_dns_server` - (Optional, String) The DNS Server for the DHCP service.
 
-## Attribute reference
+## Attribute Reference
 
 In addition to all argument reference list, you can access the following attribute reference after your resource is created.
 
@@ -60,7 +59,7 @@ The `ibm_pi_dhcp` provides the following [timeouts](https://www.terraform.io/doc
   - `region` - `lon`
   - `zone` - `lon04`
   
-  Example usage:
+Example usage:
 
   ```terraform
     provider "ibm" {

--- a/website/docs/r/pi_key.html.markdown
+++ b/website/docs/r/pi_key.html.markdown
@@ -10,7 +10,7 @@ description: |-
 
 Create, update, or delete an SSH key for your Power Systems Virtual Server instance. The SSH key is used to access the instance after it is created. For more information, about SSH keys in Power Virtual Server, see [getting started with IBM Power Systems Virtual Servers](https://cloud.ibm.com/docs/power-iaas?topic=power-iaas-getting-started).
 
-## Example usage
+## Example Usage
 
 The following example enables you to create a SSH key to be used during creation of a power virtual server instance:
 
@@ -45,7 +45,7 @@ ibm_pi_key provides the following [timeouts](https://www.terraform.io/docs/langu
 - **create** - (Default 60 minutes) Used for creating a SSH key.
 - **delete** - (Default 60 minutes) Used for deleting a SSH key.
 
-## Argument reference
+## Argument Reference
 
 Review the argument references that you can specify for your resource.
 
@@ -53,7 +53,7 @@ Review the argument references that you can specify for your resource.
 - `pi_key_name`  - (Required, String) User defined name for the SSH key.
 - `pi_ssh_key` - (Required, String) SSH RSA key.
 
-## Attribute reference
+## Attribute Reference
 
  In addition to all argument reference list, you can access the following attribute reference after your resource is created.
 


### PR DESCRIPTION
This PR removes the remaining warnings from the dhcp and ssh-key documentation.