### PR TITLE
Remove warnings from terraform cloud connection and vsn markdown files

### DIFF
--- a/website/docs/d/pi_cloud_connection.html.markdown
+++ b/website/docs/d/pi_cloud_connection.html.markdown
@@ -10,7 +10,7 @@ description: |-
 
 Retrieve information about an existing IBM Cloud Power Virtual Server Cloud cloud connection. For more information, about IBM power virtual server cloud, see [getting started with IBM Power Systems Virtual Servers](https://cloud.ibm.com/docs/power-iaas?topic=power-iaas-getting-started).
 
-## Example usage
+## Example Usage
 
 ```terraform
 data "ibm_pi_cloud_connection" "example" {
@@ -35,14 +35,14 @@ Example usage:
     }
   ```
 
-## Argument reference
+## Argument Reference
 
 Review the argument references that you can specify for your data source.
 
 - `pi_cloud_instance_id` - (Required, String) The GUID of the service instance associated with an account.
 - `pi_cloud_connection_name` - (Required, String) The cloud connection name to be used.
 
-## Attribute reference
+## Attribute Reference
 
 In addition to all argument reference list, you can access the following attribute references after your data source is created.
 

--- a/website/docs/d/pi_cloud_connections.html.markdown
+++ b/website/docs/d/pi_cloud_connections.html.markdown
@@ -10,7 +10,7 @@ description: |-
 
 Retrieve information about all cloud connections as a read-only data source. For more information, about IBM power virtual server cloud, see [getting started with IBM Power Systems Virtual Servers](https://cloud.ibm.com/docs/power-iaas?topic=power-iaas-getting-started).
 
-## Example usage
+## Example Usage
 
 ```terraform
 data "ibm_pi_cloud_connections" "example" {
@@ -35,13 +35,13 @@ Example usage:
     }
   ```
 
-## Argument reference
+## Argument Reference
 
 Review the argument references that you can specify for your data source.
 
 - `pi_cloud_instance_id` - (Required, String) The GUID of the service instance associated with an account.
 
-## Attribute reference
+## Attribute Reference
 
 In addition to all argument reference list, you can access the following attribute references after your data source is created.
 

--- a/website/docs/d/pi_cloud_instance.html.markdown
+++ b/website/docs/d/pi_cloud_instance.html.markdown
@@ -7,22 +7,26 @@ description: |-
 ---
 
 # ibm_pi_cloud_instance
+
 Retrieve information about an existing IBM Power Virtual Server Cloud Instance as a read-only data source. For more information, about IBM power virtual server cloud, see [getting started with IBM Power Systems Virtual Servers](https://cloud.ibm.com/docs/power-iaas?topic=power-iaas-getting-started).
 
-## Example usage
+## Example Usage
+
 ```terraform
 data "ibm_pi_cloud_instance" "ds_cloud_instance" {
   pi_cloud_instance_id = "49fba6c9-23f8-40bc-9899-aca322ee7d5b"
 }
 ```
 
-**Notes**
+### Notes
+
 - Please find [supported Regions](https://cloud.ibm.com/apidocs/power-cloud#endpoint) for endpoints.
 - If a Power cloud instance is provisioned at `lon04`, The provider level attributes should be as follows:
   - `region` - `lon`
   - `zone` - `lon04`
 
 Example usage:
+
   ```terraform
     provider "ibm" {
       region    =   "lon"
@@ -30,12 +34,14 @@ Example usage:
     }
   ```
   
-## Argument reference
-Review the argument reference that you can specify for your data source. 
+## Argument Reference
 
-- `pi_cloud_instance_id` - (Required, string) The GUID of the service instance associated with an account. 
+Review the argument reference that you can specify for your data source.
 
-## Attribute reference
+- `pi_cloud_instance_id` - (Required, string) The GUID of the service instance associated with an account.
+
+## Attribute Reference
+
 In addition to the argument reference list, you can access the following attribute references after your data source is created.
 
 - `capabilities` - (String) Lists the capabilities for this cloud instance.

--- a/website/docs/d/pi_virtual_serial_number.html.markdown
+++ b/website/docs/d/pi_virtual_serial_number.html.markdown
@@ -7,9 +7,11 @@ description: |-
 ---
 
 # ibm_virtual_serial_number
+
 Retrieve information about an existing virtual serial number as a read-only data source. For more information, about IBM power virtual server cloud, see [getting started with IBM Power Systems Virtual Servers](https://cloud.ibm.com/docs/power-iaas?topic=power-iaas-getting-started).
 
-## Example usage
+## Example Usage
+
 ```terraform
 data "ibm_pi_virtual_serial_number" "ds_virtual_serial_number" {
   pi_cloud_instance_id     = "<cloud instance id>"
@@ -18,12 +20,14 @@ data "ibm_pi_virtual_serial_number" "ds_virtual_serial_number" {
 ```
 
 ### Notes
+
 - Please find [supported Regions](https://cloud.ibm.com/apidocs/power-cloud#endpoint) for endpoints.
 - If a Power cloud instance is provisioned at `lon04`, The provider level attributes should be as follows:
   - `region` - `lon`
   - `zone` - `lon04`
 
 Example usage:
+
   ```terraform
     provider "ibm" {
       region    =   "lon"
@@ -31,13 +35,15 @@ Example usage:
     }
   ```
   
-## Argument reference
-Review the argument reference that you can specify for your data source. 
+## Argument Reference
 
-- `pi_cloud_instance_id` - (Required, String) The GUID of the service instance associated with an account. 
+Review the argument reference that you can specify for your data source.
+
+- `pi_cloud_instance_id` - (Required, String) The GUID of the service instance associated with an account.
 - `pi_serial` - (Required, String) Virtual serial number.
 
-## Attribute reference
+## Attribute Reference
+
 In addition to the argument reference list, you can access the following attribute references after your data source is created.
 
 - `description` - (String) Description for virtual serial number.

--- a/website/docs/d/pi_virtual_serial_numbers.html.markdown
+++ b/website/docs/d/pi_virtual_serial_numbers.html.markdown
@@ -10,7 +10,7 @@ description: |-
 
 Retrieve information about existing virtual serial numbers as a read-only data source. For more information, about IBM power virtual server cloud, see [getting started with IBM Power Systems Virtual Servers](https://cloud.ibm.com/docs/power-iaas?topic=power-iaas-getting-started).
 
-## Example usage
+## Example Usage
 
 ```terraform
 data "ibm_pi_virtual_serial_numbers" "ds_virtual_serial_number" {
@@ -27,6 +27,7 @@ data "ibm_pi_virtual_serial_numbers" "ds_virtual_serial_number" {
   - `zone` - `lon04`
 
 Example usage:
+
   ```terraform
     provider "ibm" {
       region    =   "lon"
@@ -34,20 +35,20 @@ Example usage:
     }
   ```
   
-## Argument reference
+## Argument Reference
 
-Review the argument reference that you can specify for your data source. 
+Review the argument reference that you can specify for your data source.
 
-- `pi_cloud_instance_id` - (Required, String) The GUID of the service instance associated with an account. 
+- `pi_cloud_instance_id` - (Required, String) The GUID of the service instance associated with an account.
 - `pi_instance_id` - (Optional, String) Power virtual server instance ID.
 
-## Attribute reference
+## Attribute Reference
 
 In addition to the argument reference list, you can access the following attribute references after your data source is created.
 
 - `virtual_serial_numbers` - (List) List of virtual serial numbers
 
   Nested scheme for `virtual_serial_numbers`:
-    - `description` - (String) Description for virtual serial number.
-    - `pvm_instance_id` - (String) ID of PVM virtual serial number is attached to.
-    - `serial` - (String) Virtual serial number.
+  - `description` - (String) Description for virtual serial number.
+  - `pvm_instance_id` - (String) ID of PVM virtual serial number is attached to.
+  - `serial` - (String) Virtual serial number.

--- a/website/docs/r/pi_cloud_connection.html.markdown
+++ b/website/docs/r/pi_cloud_connection.html.markdown
@@ -12,7 +12,7 @@ Create, update, or delete for a Power Systems Virtual Server cloud connection. F
 
 ~> **NOTE:** `Cloud connection` are not supported in **new** workspaces in `DAL10 data center.`
 
-## Example usage
+## Example Usage
 
 The following example enables you to create a cloud connection:
 
@@ -48,7 +48,7 @@ The `ibm_pi_cloud_connection` provides the following [timeouts](https://www.terr
 - **update** - (Default 30 minutes) Used for updating cloud connection.
 - **delete** - (Default 30 minutes) Used for deleting cloud connection.
 
-## Argument reference
+## Argument Reference
 
 Review the argument references that you can specify for your resource.
 
@@ -65,7 +65,7 @@ Review the argument references that you can specify for your resource.
 - `pi_cloud_connection_vpc_enabled` - (Optional, Bool) Enable VPC for this cloud connection.
 - `pi_cloud_instance_id` - (Required, String) The GUID of the service instance associated with an account.
 
-## Attribute reference
+## Attribute Reference
 
 In addition to all argument reference list, you can access the following attribute reference after your resource is created.
 

--- a/website/docs/r/pi_cloud_connection_network_attach.html.markdown
+++ b/website/docs/r/pi_cloud_connection_network_attach.html.markdown
@@ -10,7 +10,7 @@ description: |-
 
 Attach, and detach a network to a cloud connection for a Power Systems Virtual Server. For more information, about IBM power virtual server cloud, see [getting started with IBM Power Systems Virtual Servers](https://cloud.ibm.com/docs/power-iaas?topic=power-iaas-getting-started).
 
-## Example usage
+## Example Usage
 
 The following example enables you attach a network to a cloud connection:
 
@@ -45,7 +45,7 @@ The `ibm_pi_cloud_connection_network_attach` provides the following [timeouts](h
 - **create** - (Default 30 minutes) Used for attaching a network from a cloud connection.
 - **delete** - (Default 30 minutes) Used for detaching a network from a cloud connection.
 
-## Argument reference
+## Argument Reference
 
 Review the argument references that you can specify for your resource.
 
@@ -53,7 +53,7 @@ Review the argument references that you can specify for your resource.
 - `pi_cloud_instance_id` - (Required, String) The GUID of the service instance associated with an account.
 - `pi_network_id` - (Required, String) The Network ID to attach to this cloud connection.
 
-## Attribute reference
+## Attribute Reference
 
 In addition to all argument reference list, you can access the following attribute reference after your resource is created.
 

--- a/website/docs/r/pi_virtual_serial_number.html.markdown
+++ b/website/docs/r/pi_virtual_serial_number.html.markdown
@@ -10,7 +10,7 @@ description: |-
 
 Create, get, update or delete an existing virtual serial number.
 
-## Example usage
+## Example Usage
 
 The following example enables you to create a virtual serial number:
 
@@ -38,8 +38,7 @@ Example usage:
     }
   ```
 
-**Note**
-- This resource is used to create a virtual serial number by assigning to a power instance using 'auto-assign'. Otherwise, it can only be used to manage an existing virtual serial number. If deleting an instance with a `ibm_pi_virtual_serial_number` resource assigned, it is recommended to unassign the virtual serial number resource from the instance before destruction.
+~> **Note** This resource is used to create a virtual serial number by assigning to a power instance using 'auto-assign'. Otherwise, it can only be used to manage an existing virtual serial number. If deleting an instance with a `ibm_pi_virtual_serial_number` resource assigned, it is recommended to unassign the virtual serial number resource from the instance before destruction.
 
 ## Timeouts
 
@@ -49,19 +48,20 @@ ibm_pi_virtual_serial_number provides the following [timeouts](https://www.terra
 - **update** - (Default 45 minutes) Used for updating a virtual serial number.
 - **delete** - (Default 45 minutes) Used for deleting a reserved virtual serial number.
 
-## Argument reference
+## Argument Reference
 
-Review the argument references that you can specify for your resource. 
+Review the argument references that you can specify for your resource.
 
-- `pi_cloud_instance_id` - (Required, String) The GUID of the service instance associated with an account. 
+- `pi_cloud_instance_id` - (Required, String) The GUID of the service instance associated with an account.
 - `pi_description` - (Optional, String) Desired description for virtual serial number.
 - `pi_instance_id` - (Optional, String) Power instance ID to assign created or existing virtual serial number to. Must unassign from previous power instance if different than current assignment. Cannot use the instance name, only ID. Please see note on `pi_virtual_serial_number` in the `ibm_pi_instance` resource documentation.
 - `pi_retain_virtual_serial_number` - (Optional, Boolean) Indicates whether to reserve or delete virtual serial number when detached from power instance during deletion. Required with `pi_instance_id`. Default behavior does not retain virtual serial number after deletion.
 - `pi_serial` - (Required, String) Virtual serial number of existing serial. Cannot use 'auto-assign' unless `pi_instance_id` is specified.
 
-    ~> **Note** When set to "auto-assign" in the configuration, changes to `pi_serial` outside of terraform will not be detected. 
+    ~> **Note** When set to "auto-assign" in the configuration, changes to `pi_serial` outside of terraform will not be detected.
 
-## Attribute reference
+## Attribute Reference
+
  In addition to all argument reference list, you can access the following attribute reference after your resource is created.
 
 - `id` - (String) The unique identifier of the virtual serial number. Composed of `<cloud_instance_id>/<virtual_serial_number>`
@@ -73,5 +73,5 @@ The `ibm_virtual_serial_number` resource can be imported by using `pi_cloud_inst
 ### Example
 
 ```bash
-$ terraform import ibm_pi_virtual_serial_number.example d7bec597-4726-451f-8a63-e62e6f19c32c/VS0762Y
+terraform import ibm_pi_virtual_serial_number.example d7bec597-4726-451f-8a63-e62e6f19c32c/VS0762Y
 ```


### PR DESCRIPTION
This PR removes the remaining warnings from the cloud connection and vsn documentation.