### PR TITLE
Added support for volume bandwidth in vpc resources

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -43,7 +43,7 @@ require (
 	github.com/IBM/secrets-manager-go-sdk/v2 v2.0.10
 	github.com/IBM/vmware-go-sdk v0.1.3
 	github.com/IBM/vpc-beta-go-sdk v0.8.0
-	github.com/IBM/vpc-go-sdk v0.65.0
+	github.com/IBM/vpc-go-sdk v0.66.0
 	github.com/ScaleFT/sshkeys v0.0.0-20200327173127-6142f742bca5
 	github.com/akamai/AkamaiOPEN-edgegrid-golang v1.2.2
 	github.com/akamai/AkamaiOPEN-edgegrid-golang/v5 v5.0.0

--- a/go.sum
+++ b/go.sum
@@ -176,8 +176,8 @@ github.com/IBM/vmware-go-sdk v0.1.3 h1:uJL3kwzM0jAKsT6Gj9tE5xT9SZBVXVaJvZdxrSMx8
 github.com/IBM/vmware-go-sdk v0.1.3/go.mod h1:OyQKRInGGsBaOyE5LIZCqH7b1DZ01BvIYa8BgGy+wWo=
 github.com/IBM/vpc-beta-go-sdk v0.8.0 h1:cEPpv4iw3Ba5W2d0AWg3TIbKeJ8y1nPuUuibR5Jt9eE=
 github.com/IBM/vpc-beta-go-sdk v0.8.0/go.mod h1:hORgIyTFRzXrZIK9IohaWmCRBBlYiDRagsufi7M6akE=
-github.com/IBM/vpc-go-sdk v0.65.0 h1:wCOm4pPdrsPnnHlpLHrqntLdzEmyjafK5BfZdke/ntI=
-github.com/IBM/vpc-go-sdk v0.65.0/go.mod h1:VL7sy61ybg6tvA60SepoQx7TFe20m7JyNUt+se2tHP4=
+github.com/IBM/vpc-go-sdk v0.66.0 h1:S0HW+f6Qf6OLSGESQ7WRgWLq1bDgvs+vvOJ7AWgUMbw=
+github.com/IBM/vpc-go-sdk v0.66.0/go.mod h1:VL7sy61ybg6tvA60SepoQx7TFe20m7JyNUt+se2tHP4=
 github.com/Logicalis/asn1 v0.0.0-20190312173541-d60463189a56 h1:vuquMR410psHNax14XKNWa0Ae/kYgWJcXi0IFuX60N0=
 github.com/Logicalis/asn1 v0.0.0-20190312173541-d60463189a56/go.mod h1:Zb3OT4l0mf7P/GOs2w2Ilj5sdm5Whoq3pa24dAEBHFc=
 github.com/Masterminds/semver/v3 v3.2.1 h1:RN9w6+7QoMeJVGyfmbcgs28Br8cvmnucEXnY0rYXWg0=

--- a/ibm/service/vpc/data_source_ibm_is_instance_template.go
+++ b/ibm/service/vpc/data_source_ibm_is_instance_template.go
@@ -292,6 +292,10 @@ func DataSourceIBMISInstanceTemplate() *schema.Resource {
 										Computed:    true,
 										Description: "The  globally unique name for the volume profile to use for this volume.",
 									},
+									"bandwidth": {
+										Type:     schema.TypeInt,
+										Computed: true,
+									},
 									isInstanceTemplateVolAttVolCapacity: {
 										Type:        schema.TypeInt,
 										Computed:    true,
@@ -856,6 +860,10 @@ func DataSourceIBMISInstanceTemplate() *schema.Resource {
 							Type:     schema.TypeInt,
 							Computed: true,
 						},
+						"bandwidth": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
 						isInstanceTemplateBootProfile: {
 							Type:     schema.TypeString,
 							Computed: true,
@@ -1242,7 +1250,10 @@ func dataSourceIBMISInstanceTemplateRead(context context.Context, d *schema.Reso
 				if volumeInst.ID != nil {
 					volumeAttach[isInstanceTemplateVolAttVolume] = *volumeInst.ID
 				}
-
+				// bandwidth changes
+				if volumeInst.Bandwidth != nil {
+					newVolume["bandwidth"] = volumeInst.Bandwidth
+				}
 				if volumeInst.Capacity != nil {
 					newVolume[isInstanceTemplateVolAttVolCapacity] = *volumeInst.Capacity
 				}
@@ -1278,6 +1289,10 @@ func dataSourceIBMISInstanceTemplateRead(context context.Context, d *schema.Reso
 				volumeIntf := instance.BootVolumeAttachment.Volume
 				bootVol[isInstanceTemplateName] = volumeIntf.Name
 				bootVol[isInstanceTemplateVol] = volumeIntf.Name
+				// bandwidth changes
+				if volumeIntf.Bandwidth != nil {
+					bootVol["bandwidth"] = volumeIntf.Bandwidth
+				}
 				bootVol[isInstanceTemplateBootSize] = volumeIntf.Capacity
 				if instance.BootVolumeAttachment.Volume.Profile != nil {
 					volProfIntf := instance.BootVolumeAttachment.Volume.Profile
@@ -1579,7 +1594,10 @@ func dataSourceIBMISInstanceTemplateRead(context context.Context, d *schema.Reso
 						if volumeInst.ID != nil {
 							volumeAttach[isInstanceTemplateVolAttVolume] = *volumeInst.ID
 						}
-
+						// bandwidth changes
+						if volumeInst.Bandwidth != nil {
+							newVolume["bandwidth"] = volumeInst.Bandwidth
+						}
 						if volumeInst.Capacity != nil {
 							newVolume[isInstanceTemplateVolAttVolCapacity] = *volumeInst.Capacity
 						}
@@ -1615,6 +1633,10 @@ func dataSourceIBMISInstanceTemplateRead(context context.Context, d *schema.Reso
 						volumeIntf := instance.BootVolumeAttachment.Volume
 						bootVol[isInstanceTemplateName] = volumeIntf.Name
 						bootVol[isInstanceTemplateVol] = volumeIntf.Name
+						// bandwidth changes
+						if volumeIntf.Bandwidth != nil {
+							bootVol["bandwidth"] = volumeIntf.Bandwidth
+						}
 						bootVol[isInstanceTemplateBootSize] = volumeIntf.Capacity
 						if instance.BootVolumeAttachment.Volume.Profile != nil {
 							volProfIntf := instance.BootVolumeAttachment.Volume.Profile

--- a/ibm/service/vpc/data_source_ibm_is_instance_templates.go
+++ b/ibm/service/vpc/data_source_ibm_is_instance_templates.go
@@ -314,6 +314,10 @@ func DataSourceIBMISInstanceTemplates() *schema.Resource {
 													Computed:    true,
 													Description: "The maximum I/O operations per second (IOPS) for the volume.",
 												},
+												"bandwidth": {
+													Type:     schema.TypeInt,
+													Computed: true,
+												},
 												isInstanceTemplateVolAttVolProfile: {
 													Type:        schema.TypeString,
 													Computed:    true,
@@ -914,6 +918,10 @@ func DataSourceIBMISInstanceTemplates() *schema.Resource {
 										Type:     schema.TypeString,
 										Computed: true,
 									},
+									"bandwidth": {
+										Type:     schema.TypeInt,
+										Computed: true,
+									},
 									isInstanceTemplateBootVolumeTags: {
 										Type:        schema.TypeSet,
 										Computed:    true,
@@ -1246,7 +1254,10 @@ func dataSourceIBMISInstanceTemplatesRead(d *schema.ResourceData, meta interface
 					profile := volumeInst.Profile.(*vpcv1.VolumeProfileIdentity)
 					newVolume[isInstanceTemplateVolAttVolProfile] = profile.Name
 				}
-
+				// bandwidth changes
+				if volumeInst.Bandwidth != nil {
+					newVolume["bandwidth"] = volumeInst.Bandwidth
+				}
 				if volumeInst.Iops != nil {
 					newVolume[isInstanceTemplateVolAttVolIops] = *volumeInst.Iops
 				}
@@ -1279,6 +1290,10 @@ func dataSourceIBMISInstanceTemplatesRead(d *schema.ResourceData, meta interface
 					volProfIntf := instance.BootVolumeAttachment.Volume.Profile
 					volProfInst := volProfIntf.(*vpcv1.VolumeProfileIdentity)
 					bootVol[isInstanceTemplateBootProfile] = volProfInst.Name
+				}
+				// bandwidth changes
+				if volumeIntf.Bandwidth != nil {
+					bootVol["bandwidth"] = volumeIntf.Bandwidth
 				}
 				if instance.BootVolumeAttachment.Volume.UserTags != nil {
 					bootVol[isInstanceTemplateBootVolumeTags] = instance.BootVolumeAttachment.Volume.UserTags

--- a/ibm/service/vpc/data_source_ibm_is_instance_volume_attachment.go
+++ b/ibm/service/vpc/data_source_ibm_is_instance_volume_attachment.go
@@ -75,6 +75,11 @@ func DataSourceIBMISInstanceVolumeAttachment() *schema.Resource {
 				Computed:    true,
 				Description: "The type of volume attachment one of [ boot, data ]",
 			},
+			"bandwidth": {
+				Type:        schema.TypeInt,
+				Computed:    true,
+				Description: "The maximum bandwidth (in megabits per second) for the volume when attached to this instance. This may be lower than the volume bandwidth depending on the configuration of the instance.",
+			},
 
 			isInstanceVolumeAttVolumeReference: {
 				Type:        schema.TypeList,
@@ -142,6 +147,8 @@ func instanceVolumeAttachmentGetByName(d *schema.ResourceData, meta interface{},
 		if *volumeAtt.Name == name {
 			d.SetId(makeTerraformVolAttID(instanceId, *volumeAtt.ID))
 			d.Set(isInstanceVolAttName, *volumeAtt.Name)
+			// bandwidth changes
+			d.Set("bandwidth", *volumeAtt.Bandwidth)
 			d.Set(isInstanceVolumeDeleteOnInstanceDelete, *volumeAtt.DeleteVolumeOnInstanceDelete)
 			d.Set(isInstanceVolumeAttDevice, *volumeAtt.Device.ID)
 			d.Set(isInstanceVolumeAttHref, *volumeAtt.Href)

--- a/ibm/service/vpc/data_source_ibm_is_instance_volume_attachments.go
+++ b/ibm/service/vpc/data_source_ibm_is_instance_volume_attachments.go
@@ -38,6 +38,11 @@ func DataSourceIBMISInstanceVolumeAttachments() *schema.Resource {
 							Computed:    true,
 							Description: "The user-defined name for this volume attachment.",
 						},
+						"bandwidth": {
+							Type:        schema.TypeInt,
+							Computed:    true,
+							Description: "The maximum bandwidth (in megabits per second) for the volume when attached to this instance. This may be lower than the volume bandwidth depending on the configuration of the instance.",
+						},
 
 						isInstanceVolumeAttDevice: {
 							Type:        schema.TypeString,
@@ -137,6 +142,8 @@ func instanceGetVolumeAttachments(d *schema.ResourceData, meta interface{}, inst
 	for _, volumeAtt := range allrecs {
 		currentVolAtt := map[string]interface{}{}
 		currentVolAtt[isInstanceVolAttName] = *volumeAtt.Name
+		// bandwidth changes
+		currentVolAtt["bandwidth"] = *volumeAtt.Bandwidth
 		currentVolAtt[isInstanceVolumeDeleteOnInstanceDelete] = *volumeAtt.DeleteVolumeOnInstanceDelete
 		currentVolAtt[isInstanceVolumeAttDevice] = *volumeAtt.Device.ID
 		currentVolAtt[isInstanceVolumeAttHref] = *volumeAtt.Href

--- a/ibm/service/vpc/resource_ibm_is_instance.go
+++ b/ibm/service/vpc/resource_ibm_is_instance.go
@@ -802,6 +802,13 @@ func ResourceIBMISInstance() *schema.Resource {
 							Set:         flex.ResourceIBMVPCHash,
 							Description: "UserTags for the volume instance",
 						},
+
+						"volume_bandwidth": {
+							Type:        schema.TypeInt,
+							Optional:    true,
+							Computed:    true,
+							Description: "The maximum bandwidth (in megabits per second) for the volume. For this property to be specified, the volume storage_generation must be 2.",
+						},
 					},
 				},
 			},
@@ -1535,6 +1542,12 @@ func ResourceIBMISInstance() *schema.Resource {
 							Default:     true,
 							Description: "Auto delete boot volume along with instance",
 						},
+						"bandwidth": {
+							Type:        schema.TypeInt,
+							Optional:    true,
+							Computed:    true,
+							Description: "The maximum bandwidth (in megabits per second) for the volume. For this property to be specified, the volume storage_generation must be 2.",
+						},
 						isInstanceBootAttachmentName: {
 							Type:         schema.TypeString,
 							Optional:     true,
@@ -2238,6 +2251,13 @@ func instanceCreateByImage(d *schema.ResourceData, meta interface{}, profile, na
 					}
 				}
 			}
+			// bandwidth changes
+			if volBandwidthOk, ok := d.GetOk(fmt.Sprintf("volume_prototypes.%d.volume_bandwidth", i)); ok {
+				volBandwidth := volBandwidthOk.(int)
+				if volBandwidth != 0 {
+					volumeattItemPrototypeModel.Bandwidth = core.Int64Ptr(int64(volBandwidth))
+				}
+			}
 			if volProfileOk, ok := d.GetOk(fmt.Sprintf("volume_prototypes.%d.volume_profile", i)); ok {
 				volProfile := volProfileOk.(string)
 				if volProfile != "" {
@@ -2346,6 +2366,13 @@ func instanceCreateByImage(d *schema.ResourceData, meta interface{}, profile, na
 		if size != 0 && ok {
 			sizeInt64 := int64(size)
 			volTemplate.Capacity = &sizeInt64
+		}
+		// bandwidth changes
+		bandwidthOk, ok := bootvol["bandwidth"]
+		bandwidth := bandwidthOk.(int)
+		if bandwidth != 0 && ok {
+			bandwidthInt64 := int64(bandwidth)
+			volTemplate.Bandwidth = &bandwidthInt64
 		}
 		iopsOk, ok := bootvol[isInstanceBootIOPS]
 		iops := iopsOk.(int)
@@ -2768,6 +2795,13 @@ func instanceCreateByCatalogOffering(d *schema.ResourceData, meta interface{}, p
 					}
 				}
 			}
+			// bandwidth changes
+			if volBandwidthOk, ok := d.GetOk(fmt.Sprintf("volume_prototypes.%d.volume_bandwidth", i)); ok {
+				volBandwidth := volBandwidthOk.(int)
+				if volBandwidth != 0 {
+					volumeattItemPrototypeModel.Bandwidth = core.Int64Ptr(int64(volBandwidth))
+				}
+			}
 			if volProfileOk, ok := d.GetOk(fmt.Sprintf("volume_prototypes.%d.volume_profile", i)); ok {
 				volProfile := volProfileOk.(string)
 				if volProfile != "" {
@@ -2908,6 +2942,13 @@ func instanceCreateByCatalogOffering(d *schema.ResourceData, meta interface{}, p
 		if size != 0 && ok {
 			sizeInt64 := int64(size)
 			volTemplate.Capacity = &sizeInt64
+		}
+		// bandwidth changes
+		bandwidthOk, ok := bootvol["bandwidth"]
+		bandwidth := bandwidthOk.(int)
+		if bandwidth != 0 && ok {
+			bandwidthInt64 := int64(bandwidth)
+			volTemplate.Bandwidth = &bandwidthInt64
 		}
 		iopsOk, ok := bootvol[isInstanceBootIOPS]
 		iops := iopsOk.(int)
@@ -3304,6 +3345,13 @@ func instanceCreateByTemplate(d *schema.ResourceData, meta interface{}, profile,
 					}
 				}
 			}
+			// bandwidth changes
+			if volBandwidthOk, ok := d.GetOk(fmt.Sprintf("volume_prototypes.%d.volume_bandwidth", i)); ok {
+				volBandwidth := volBandwidthOk.(int)
+				if volBandwidth != 0 {
+					volumeattItemPrototypeModel.Bandwidth = core.Int64Ptr(int64(volBandwidth))
+				}
+			}
 			if volProfileOk, ok := d.GetOk(fmt.Sprintf("volume_prototypes.%d.volume_profile", i)); ok {
 				volProfile := volProfileOk.(string)
 				if volProfile != "" {
@@ -3427,6 +3475,13 @@ func instanceCreateByTemplate(d *schema.ResourceData, meta interface{}, profile,
 		if size != 0 && ok {
 			sizeInt64 := int64(size)
 			volTemplate.Capacity = &sizeInt64
+		}
+		// bandwidth changes
+		bandwidthOk, ok := bootvol["bandwidth"]
+		bandwidth := bandwidthOk.(int)
+		if bandwidth != 0 && ok {
+			bandwidthInt64 := int64(bandwidth)
+			volTemplate.Bandwidth = &bandwidthInt64
 		}
 		iopsOk, ok := bootvol[isInstanceBootIOPS]
 		iops := iopsOk.(int)
@@ -3846,6 +3901,13 @@ func instanceCreateBySnapshot(d *schema.ResourceData, meta interface{}, profile,
 					}
 				}
 			}
+			// bandwidth changes
+			if volBandwidthOk, ok := d.GetOk(fmt.Sprintf("volume_prototypes.%d.volume_bandwidth", i)); ok {
+				volBandwidth := volBandwidthOk.(int)
+				if volBandwidth != 0 {
+					volumeattItemPrototypeModel.Bandwidth = core.Int64Ptr(int64(volBandwidth))
+				}
+			}
 			if volProfileOk, ok := d.GetOk(fmt.Sprintf("volume_prototypes.%d.volume_profile", i)); ok {
 				volProfile := volProfileOk.(string)
 				if volProfile != "" {
@@ -3945,6 +4007,13 @@ func instanceCreateBySnapshot(d *schema.ResourceData, meta interface{}, profile,
 		if size != 0 && ok {
 			sizeInt64 := int64(size)
 			volTemplate.Capacity = &sizeInt64
+		}
+		// bandwidth changes
+		bandwidthOk, ok := bootvol["bandwidth"]
+		bandwidth := bandwidthOk.(int)
+		if bandwidth != 0 && ok {
+			bandwidthInt64 := int64(bandwidth)
+			volTemplate.Bandwidth = &bandwidthInt64
 		}
 		iopsOk, ok := bootvol[isInstanceBootIOPS]
 		iops := iopsOk.(int)
@@ -4384,6 +4453,13 @@ func instanceCreateByVolume(d *schema.ResourceData, meta interface{}, profile, n
 					volumeattItemPrototypeModel.EncryptionKey = &vpcv1.EncryptionKeyIdentity{
 						CRN: &volEncKey,
 					}
+				}
+			}
+			// bandwidth changes
+			if volBandwidthOk, ok := d.GetOk(fmt.Sprintf("volume_prototypes.%d.volume_bandwidth", i)); ok {
+				volBandwidth := volBandwidthOk.(int)
+				if volBandwidth != 0 {
+					volumeattItemPrototypeModel.Bandwidth = core.Int64Ptr(int64(volBandwidth))
 				}
 			}
 			if volProfileOk, ok := d.GetOk(fmt.Sprintf("volume_prototypes.%d.volume_profile", i)); ok {
@@ -5440,6 +5516,7 @@ func instanceGet(d *schema.ResourceData, meta interface{}, id string) error {
 			if vol != nil {
 				bootVol[isInstanceBootSize] = *vol.Capacity
 				bootVol[isInstanceBootIOPS] = *vol.Iops
+				bootVol["bandwidth"] = vol.Bandwidth
 				bootVol[isInstanceBootProfile] = *vol.Profile.Name
 				if vol.EncryptionKey != nil {
 					bootVol[isInstanceBootEncryption] = *vol.EncryptionKey.CRN
@@ -6070,6 +6147,37 @@ func instanceUpdate(d *schema.ResourceData, meta interface{}) error {
 
 	bootVolSize := "boot_volume.0.size"
 	bootIopsSize := "boot_volume.0.iops"
+	bootVolBandwidth := "boot_volume.0.bandwidth"
+
+	// bandwidth changes
+	if d.HasChange(bootVolBandwidth) && !d.IsNewResource() {
+		newBandwidth := int64(d.Get(bootVolBandwidth).(int))
+		volId := d.Get("boot_volume.0.volume_id").(string)
+		updateVolumeOptions := &vpcv1.UpdateVolumeOptions{
+			ID: &volId,
+		}
+		volPatchModel := &vpcv1.VolumePatch{
+			Bandwidth: &newBandwidth,
+		}
+		volPatchModelAsPatch, err := volPatchModel.AsPatch()
+
+		if err != nil {
+			return (fmt.Errorf("[ERROR] Error encountered while apply as patch for boot volume bandwidth of instance %s", err))
+		}
+
+		updateVolumeOptions.VolumePatch = volPatchModelAsPatch
+
+		vol, res, err := instanceC.UpdateVolume(updateVolumeOptions)
+
+		if vol == nil || err != nil {
+			return (fmt.Errorf("[ERROR] Error encountered while expanding boot volume bandwidth of instance %s/n%s", err, res))
+		}
+
+		_, err = isWaitForVolumeAvailable(instanceC, volId, d.Timeout(schema.TimeoutUpdate))
+		if err != nil {
+			return err
+		}
+	}
 
 	if d.HasChange(bootVolSize) && !d.IsNewResource() {
 		old, new := d.GetChange(bootVolSize)
@@ -7007,11 +7115,11 @@ func instanceDelete(d *schema.ResourceData, meta interface{}, id string) error {
 	if err != nil {
 		return err
 	}
+	_, err = isWaitForInstanceDelete(instanceC, d, d.Id())
+	if err != nil {
+		return err
+	}
 	if cleanDelete {
-		_, err = isWaitForInstanceDelete(instanceC, d, d.Id())
-		if err != nil {
-			return err
-		}
 		if _, ok := d.GetOk(isInstanceBootVolume); ok {
 			autoDel := d.Get("boot_volume.0.auto_delete_volume").(bool)
 			if autoDel {
@@ -7805,6 +7913,7 @@ func volumesEqual(oldVol, newVol map[string]interface{}) bool {
 		"volume_source_snapshot",
 		"volume_encryption_key",
 		"volume_tags",
+		"volume_bandwidth",
 	}
 
 	for _, field := range fieldsToCompare {
@@ -7969,15 +8078,21 @@ func handleVolumePrototypesUpdate(d *schema.ResourceData, instanceC *vpcv1.VpcV1
 					return fmt.Errorf("error getting volume for patch for %s: %w", name, err)
 				}
 				eTag := res.Headers.Get("ETag")
+				volchanged := false
 				volumePatchModel := &vpcv1.VolumePatch{}
 				if newVol["volume_profile"].(string) != oldVol["volume_profile"].(string) && isTieredProfile(newVol["volume_profile"].(string)) {
 					volumePatchModel.Profile = &vpcv1.VolumeProfileIdentity{
 						Name: core.StringPtr(newVol["volume_profile"].(string)),
 					}
+					volchanged = true
 				}
 				if newVol["volume_name"].(string) != oldVol["volume_name"].(string) {
 					volumePatchModel.Name = core.StringPtr(newVol["volume_name"].(string))
+					volchanged = true
 				}
+				// if newVol["volume_bandwidth"].(int) != oldVol["volume_bandwidth"].(int) {
+				// 	volumePatchModel.Bandwidth = core.Int64Ptr(int64(newVol["volume_bandwidth"].(int)))
+				// }
 				if newVol["volume_tags"] == nil && oldVol["volume_tags"] == nil {
 					// do nothing
 				} else if newVol["volume_tags"] == nil && oldVol["volume_tags"] != nil {
@@ -7990,19 +8105,21 @@ func handleVolumePrototypesUpdate(d *schema.ResourceData, instanceC *vpcv1.VpcV1
 						userTagsArray[i] = userTagStr
 					}
 					volumePatchModel.UserTags = userTagsArray
+					volchanged = true
 				}
-				volumePatch, err := volumePatchModel.AsPatch()
-				if err != nil {
-					return fmt.Errorf("error creating volume patch for %s: %w", name, err)
+				if volchanged {
+					volumePatch, err := volumePatchModel.AsPatch()
+					if err != nil {
+						return fmt.Errorf("error creating volume patch for %s: %w", name, err)
+					}
+					voloptions.VolumePatch = volumePatch
+					voloptions.SetIfMatch(eTag)
+					_, response, err := instanceC.UpdateVolume(voloptions)
+					if err != nil {
+						return fmt.Errorf("error updating volume %s: %s\n%s", name, err, response)
+					}
+					eTag = response.Headers.Get("ETag")
 				}
-				voloptions.VolumePatch = volumePatch
-				voloptions.SetIfMatch(eTag)
-				_, response, err := instanceC.UpdateVolume(voloptions)
-				if err != nil {
-					return fmt.Errorf("error updating volume %s: %s\n%s", name, err, response)
-				}
-				eTag = response.Headers.Get("ETag")
-
 				// Only include IOPS for non-tiered profiles
 				if !isTieredProfile(newVol["volume_profile"].(string)) && (int64(newVol["volume_iops"].(int)) != int64(oldVol["volume_iops"].(int))) {
 					volumeIopsPatchModel := &vpcv1.VolumePatch{}
@@ -8037,12 +8154,30 @@ func handleVolumePrototypesUpdate(d *schema.ResourceData, instanceC *vpcv1.VpcV1
 					}
 					eTag = response.Headers.Get("ETag")
 				}
+				// Only include bandwidth update
+				if int64(newVol["volume_bandwidth"].(int)) != int64(oldVol["volume_bandwidth"].(int)) {
+					volumeBandwidthPatchModel := &vpcv1.VolumePatch{}
+					bandwidth := int64(newVol["volume_bandwidth"].(int))
+					volumeBandwidthPatchModel.Bandwidth = &bandwidth
+					volumePatch, err := volumeBandwidthPatchModel.AsPatch()
+					if err != nil {
+						return fmt.Errorf("error creating volume patch for bandwidth update %s: %w", name, err)
+					}
+					voloptions.SetIfMatch(eTag)
+					voloptions.VolumePatch = volumePatch
+					_, response, err := instanceC.UpdateVolume(voloptions)
+					if err != nil {
+						return fmt.Errorf("error updating volume during bandwidth update %s: %s\n%s", name, err, response)
+					}
+					eTag = response.Headers.Get("ETag")
+				}
 			}
 		} else {
 			// Handle addition
 			profile := newVol["volume_profile"].(string)
 			capacity := int64(newVol["volume_capacity"].(int))
 			volumeName := newVol["volume_name"].(string)
+			volumeBandwith := int64(newVol["volume_bandwidth"].(int))
 
 			createvolattoptions := &vpcv1.CreateInstanceVolumeAttachmentOptions{
 				InstanceID: &instanceID,
@@ -8052,7 +8187,8 @@ func handleVolumePrototypesUpdate(d *schema.ResourceData, instanceC *vpcv1.VpcV1
 				Profile: &vpcv1.VolumeProfileIdentity{
 					Name: &profile,
 				},
-				Capacity: &capacity,
+				Capacity:  &capacity,
+				Bandwidth: &volumeBandwith,
 			}
 			// Handle delete_volume_on_instance_delete using GetOkExists only for new volumes
 			if volAutoDelete, ok := d.GetOkExists(fmt.Sprintf("volume_prototypes.%d.delete_volume_on_instance_delete", i)); ok {
@@ -8062,7 +8198,9 @@ func handleVolumePrototypesUpdate(d *schema.ResourceData, instanceC *vpcv1.VpcV1
 			// Only set IOPS for non-tiered profiles
 			if !isTieredProfile(profile) {
 				iops := int64(newVol["volume_iops"].(int))
-				volAtt.Iops = &iops
+				if iops != int64(0) {
+					volAtt.Iops = &iops
+				}
 			}
 			createvolattoptions.Volume = volAtt
 			newVolume, _, err := instanceC.CreateInstanceVolumeAttachment(createvolattoptions)
@@ -8112,6 +8250,7 @@ func hasVolumeChanged(d *schema.ResourceData, newIndex int, oldVol, newVol map[s
 		"volume_name",
 		"volume_capacity",
 		"volume_profile",
+		"volume_bandwidth",
 	}
 
 	// Compare standard fields
@@ -8232,6 +8371,7 @@ func setVolumePrototypesInState(d *schema.ResourceData, instance *vpcv1.Instance
 					vol["volume_profile"] = *volumeRef.Profile.Name
 					vol["volume_iops"] = *volumeRef.Iops
 					vol["volume_capacity"] = *volumeRef.Capacity
+					vol["volume_bandwidth"] = volumeRef.Bandwidth
 					vol["volume_crn"] = *volume.Volume.CRN
 					vol["volume_resource_type"] = *volume.Volume.ResourceType
 				}

--- a/ibm/service/vpc/resource_ibm_is_instance_template_test.go
+++ b/ibm/service/vpc/resource_ibm_is_instance_template_test.go
@@ -405,6 +405,43 @@ func TestAccIBMISInstanceTemplate_WithVolumeAttachmentUserTag(t *testing.T) {
 	})
 }
 
+func TestAccIBMISInstanceTemplate_WithBootBandwidth(t *testing.T) {
+	randInt := acctest.RandIntRange(10, 100)
+
+	publicKey := strings.TrimSpace(`
+	ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDVtuCfWKVGKaRmaRG6JQZY8YdxnDgGzVOK93IrV9R5Hl0JP1oiLLWlZQS2reAKb8lBqyDVEREpaoRUDjqDqXG8J/kR42FKN51su914pjSBc86wJ02VtT1Wm1zRbSg67kT+g8/T1jCgB5XBODqbcICHVP8Z1lXkgbiHLwlUrbz6OZkGJHo/M/kD1Eme8lctceIYNz/Ilm7ewMXZA4fsidpto9AjyarrJLufrOBl4MRVcZTDSJ7rLP982aHpu9pi5eJAjOZc7Og7n4ns3NFppiCwgVMCVUQbN5GBlWhZ1OsT84ZiTf+Zy8ew+Yg5T7Il8HuC7loWnz+esQPf0s3xhC/kTsGgZreIDoh/rxJfD67wKXetNSh5RH/n5BqjaOuXPFeNXmMhKlhj9nJ8scayx/wsvOGuocEIkbyJSLj3sLUU403OafgatEdnJOwbqg6rUNNF5RIjpJpL7eEWlKIi1j9LyhmPJ+fEO7TmOES82VpCMHpLbe4gf/MhhJ/Xy8DKh9s= root@ffd8363b1226
+	`)
+	vpcName := fmt.Sprintf("tf-testvpc%d", randInt)
+	subnetName := fmt.Sprintf("tf-testsubnet%d", randInt)
+	templateName := fmt.Sprintf("tf-testtemplate%d", randInt)
+	volAttachName := fmt.Sprintf("tf-testvolattach%d", randInt)
+	sshKeyName := fmt.Sprintf("tf-testsshkey%d", randInt)
+	userTag := "tag-0"
+	bandwidth := int64(2000)
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { acc.TestAccPreCheck(t) },
+		Providers:    acc.TestAccProviders,
+		CheckDestroy: testAccCheckIBMISInstanceTemplateDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckIBMISInstanceTemplateWithBootBandwidth(vpcName, subnetName, sshKeyName, publicKey, templateName, volAttachName, userTag, bandwidth),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(
+						"ibm_is_instance_template.instancetemplate1", "name", templateName),
+					resource.TestCheckResourceAttrSet(
+						"ibm_is_instance_template.instancetemplate1", "profile"),
+					resource.TestCheckResourceAttr(
+						"ibm_is_instance_template.instancetemplate1", "boot_volume.0.tags.0", userTag),
+					resource.TestCheckResourceAttr(
+						"ibm_is_instance_template.instancetemplate1", "boot_volume.0.size", "250"),
+					resource.TestCheckResourceAttr(
+						"ibm_is_instance_template.instancetemplate1", "boot_volume.0.bandwidth", fmt.Sprintf("%d", bandwidth)),
+				),
+			},
+		},
+	})
+}
+
 func testAccCheckIBMISInstanceTemplateDestroy(s *terraform.State) error {
 	sess, _ := acc.TestAccProvider.Meta().(conns.ClientSession).VpcV1API()
 	for _, rs := range s.RootModule().Resources {
@@ -1094,5 +1131,47 @@ func testAccCheckIBMISInstanceTemplateClusterNetworkConfig(vpcname, clustersubne
 			
 		
 		`, vpcname, acc.ISClusterNetworkProfileName, acc.ISZoneName, clustersubnetname, clustersubnetreservedipname, clusternetworkinterfacename, subnetName, acc.ISZoneName, sshKeyName, publicKey, templateName, acc.IsImage, acc.ISInstanceGPUProfileName, acc.ISZoneName)
+
+}
+
+func testAccCheckIBMISInstanceTemplateWithBootBandwidth(vpcName, subnetName, sshKeyName, publicKey, templateName, volAttachName, userTag string, bandwidth int64) string {
+	return fmt.Sprintf(`	
+	resource "ibm_is_vpc" "vpc2" {
+	  name = "%s"
+	}
+	
+	resource "ibm_is_subnet" "subnet2" {
+	  name            			= "%s"
+	  vpc             			= ibm_is_vpc.vpc2.id
+	  zone            			= "%s"
+	  total_ipv4_address_count 	= 256
+	}
+	
+	resource "ibm_is_ssh_key" "sshkey" {
+	  name       = "%s"
+	  public_key = "%s"
+	}
+
+	resource "ibm_is_instance_template" "instancetemplate1" {
+	   name    = "%s"
+	   image   = "%s"
+	   profile = "bx2-8x32"
+	
+	   primary_network_interface {
+		 subnet = ibm_is_subnet.subnet2.id
+	   }
+	   boot_volume{
+		tags 			= ["%s"]
+		bandwidth 		= %d
+		profile 		= "sdp"
+		size			= 250
+	   }
+	   vpc       = ibm_is_vpc.vpc2.id
+	   zone      = "%s"
+	   keys      = [ibm_is_ssh_key.sshkey.id]
+	 }
+		
+	
+	`, vpcName, subnetName, acc.ISZoneName, sshKeyName, publicKey, templateName, acc.IsImage, userTag, bandwidth, acc.ISZoneName)
 
 }

--- a/ibm/service/vpc/resource_ibm_is_instance_test.go
+++ b/ibm/service/vpc/resource_ibm_is_instance_test.go
@@ -3836,3 +3836,177 @@ resource "ibm_is_instance" "testacc_instance" {
 	keys = [ibm_is_ssh_key.testacc_sshkey.id]
 }`, vpcname, subnetname, acc.ISZoneName, acc.ISCIDR, sshname, publicKey, name, acc.IsImage, acc.InstanceProfileName, resourceGroup, acc.ISZoneName)
 }
+
+// bandwidth changes
+
+func TestAccIBMISInstance_BootBandwidth(t *testing.T) {
+	var instance string
+	vpcname := fmt.Sprintf("tf-vpc-%d", acctest.RandIntRange(10, 100))
+	name := fmt.Sprintf("tf-instnace-%d", acctest.RandIntRange(10, 100))
+	subnetname := fmt.Sprintf("tf-subnet-%d", acctest.RandIntRange(10, 100))
+	publicKey := strings.TrimSpace(`
+ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCKVmnMOlHKcZK8tpt3MP1lqOLAcqcJzhsvJcjscgVERRN7/9484SOBJ3HSKxxNG5JN8owAjy5f9yYwcUg+JaUVuytn5Pv3aeYROHGGg+5G346xaq3DAwX6Y5ykr2fvjObgncQBnuU5KHWCECO/4h8uWuwh/kfniXPVjFToc+gnkqA+3RKpAecZhFXwfalQ9mMuYGFxn+fwn8cYEApsJbsEmb0iJwPiZ5hjFC8wREuiTlhPHDgkBLOiycd20op2nXzDbHfCHInquEe/gYxEitALONxm0swBOwJZwlTDOB7C6y2dzlrtxr1L59m7pCkWI4EtTRLvleehBoj3u7jB4usR
+`)
+	sshname := fmt.Sprintf("tf-ssh-%d", acctest.RandIntRange(10, 100))
+	userData1 := "a"
+	bandwidth1 := int64(2200)
+	bandwidth2 := int64(2500)
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { acc.TestAccPreCheck(t) },
+		Providers:    acc.TestAccProviders,
+		CheckDestroy: testAccCheckIBMISInstanceDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckIBMISInstanceBootBandwidthConfig(vpcname, subnetname, sshname, publicKey, name, userData1, bandwidth1),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckIBMISInstanceExists("ibm_is_instance.testacc_instance", instance),
+					resource.TestCheckResourceAttr(
+						"ibm_is_instance.testacc_instance", "name", name),
+					resource.TestCheckResourceAttr(
+						"ibm_is_instance.testacc_instance", "user_data", userData1),
+					resource.TestCheckResourceAttr(
+						"ibm_is_instance.testacc_instance", "boot_volume.0.bandwidth", fmt.Sprintf("%d", bandwidth1)),
+					resource.TestCheckResourceAttr(
+						"ibm_is_instance.testacc_instance", "zone", acc.ISZoneName),
+				),
+			},
+			{
+				Config: testAccCheckIBMISInstanceBootBandwidthConfig(vpcname, subnetname, sshname, publicKey, name, userData1, bandwidth2),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckIBMISInstanceExists("ibm_is_instance.testacc_instance", instance),
+					resource.TestCheckResourceAttr(
+						"ibm_is_instance.testacc_instance", "name", name),
+					resource.TestCheckResourceAttr(
+						"ibm_is_instance.testacc_instance", "user_data", userData1),
+					resource.TestCheckResourceAttr(
+						"ibm_is_instance.testacc_instance", "boot_volume.0.bandwidth", fmt.Sprintf("%d", bandwidth2)),
+					resource.TestCheckResourceAttr(
+						"ibm_is_instance.testacc_instance", "zone", acc.ISZoneName),
+				),
+			},
+		},
+	})
+}
+func TestAccIBMISInstance_VolumeBandwidth(t *testing.T) {
+	var instance string
+	vpcname := fmt.Sprintf("tf-vpc-%d", acctest.RandIntRange(10, 100))
+	name := fmt.Sprintf("tf-instnace-%d", acctest.RandIntRange(10, 100))
+	subnetname := fmt.Sprintf("tf-subnet-%d", acctest.RandIntRange(10, 100))
+	publicKey := strings.TrimSpace(`
+ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCKVmnMOlHKcZK8tpt3MP1lqOLAcqcJzhsvJcjscgVERRN7/9484SOBJ3HSKxxNG5JN8owAjy5f9yYwcUg+JaUVuytn5Pv3aeYROHGGg+5G346xaq3DAwX6Y5ykr2fvjObgncQBnuU5KHWCECO/4h8uWuwh/kfniXPVjFToc+gnkqA+3RKpAecZhFXwfalQ9mMuYGFxn+fwn8cYEApsJbsEmb0iJwPiZ5hjFC8wREuiTlhPHDgkBLOiycd20op2nXzDbHfCHInquEe/gYxEitALONxm0swBOwJZwlTDOB7C6y2dzlrtxr1L59m7pCkWI4EtTRLvleehBoj3u7jB4usR
+`)
+	sshname := fmt.Sprintf("tf-ssh-%d", acctest.RandIntRange(10, 100))
+	userData1 := "a"
+	bandwidth1 := int64(2200)
+	bandwidth2 := int64(2500)
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { acc.TestAccPreCheck(t) },
+		Providers:    acc.TestAccProviders,
+		CheckDestroy: testAccCheckIBMISInstanceDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckIBMISInstanceVolumeBandwidthConfig(vpcname, subnetname, sshname, publicKey, name, userData1, bandwidth1),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckIBMISInstanceExists("ibm_is_instance.testacc_instance", instance),
+					resource.TestCheckResourceAttr(
+						"ibm_is_instance.testacc_instance", "name", name),
+					resource.TestCheckResourceAttr(
+						"ibm_is_instance.testacc_instance", "user_data", userData1),
+					resource.TestCheckResourceAttr(
+						"ibm_is_instance.testacc_instance", "volume_prototypes.0.volume_bandwidth", fmt.Sprintf("%d", bandwidth1)),
+					resource.TestCheckResourceAttr(
+						"ibm_is_instance.testacc_instance", "zone", acc.ISZoneName),
+				),
+			},
+			{
+				Config: testAccCheckIBMISInstanceVolumeBandwidthConfig(vpcname, subnetname, sshname, publicKey, name, userData1, bandwidth2),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckIBMISInstanceExists("ibm_is_instance.testacc_instance", instance),
+					resource.TestCheckResourceAttr(
+						"ibm_is_instance.testacc_instance", "name", name),
+					resource.TestCheckResourceAttr(
+						"ibm_is_instance.testacc_instance", "user_data", userData1),
+					resource.TestCheckResourceAttr(
+						"ibm_is_instance.testacc_instance", "volume_prototypes.0.volume_bandwidth", fmt.Sprintf("%d", bandwidth2)),
+					resource.TestCheckResourceAttr(
+						"ibm_is_instance.testacc_instance", "zone", acc.ISZoneName),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckIBMISInstanceBootBandwidthConfig(vpcname, subnetname, sshname, publicKey, name, userData string, bandwidtth int64) string {
+	return fmt.Sprintf(`
+	resource "ibm_is_vpc" "testacc_vpc" {
+		name = "%s"
+	  }
+	  
+	  resource "ibm_is_subnet" "testacc_subnet" {
+		name            = "%s"
+		vpc             = ibm_is_vpc.testacc_vpc.id
+		zone            = "%s"
+		ipv4_cidr_block = "%s"
+	  }
+	  
+	  resource "ibm_is_ssh_key" "testacc_sshkey" {
+		name       = "%s"
+		public_key = "%s"
+	  }
+	  
+	  resource "ibm_is_instance" "testacc_instance" {
+		name    = "%s"
+		image   = "%s"
+		profile = "%s"
+		boot_volume {
+			profile 	= "sdp"
+			bandwidth 	= %d
+		}
+		primary_network_interface {
+		  subnet     = ibm_is_subnet.testacc_subnet.id
+		}
+		user_data = "%s"
+		vpc  = ibm_is_vpc.testacc_vpc.id
+		zone = "%s"
+		keys = [ibm_is_ssh_key.testacc_sshkey.id]
+	  }`, vpcname, subnetname, acc.ISZoneName, acc.ISCIDR, sshname, publicKey, name, acc.IsImage, acc.InstanceProfileName, bandwidtth, userData, acc.ISZoneName)
+}
+func testAccCheckIBMISInstanceVolumeBandwidthConfig(vpcname, subnetname, sshname, publicKey, name, userData string, bandwidtth int64) string {
+	return fmt.Sprintf(`
+	resource "ibm_is_vpc" "testacc_vpc" {
+		name = "%s"
+	  }
+	  
+	  resource "ibm_is_subnet" "testacc_subnet" {
+		name            = "%s"
+		vpc             = ibm_is_vpc.testacc_vpc.id
+		zone            = "%s"
+		ipv4_cidr_block = "%s"
+	  }
+	  
+	  resource "ibm_is_ssh_key" "testacc_sshkey" {
+		name       = "%s"
+		public_key = "%s"
+	  }
+	  
+	  resource "ibm_is_instance" "testacc_instance" {
+		name    = "%s"
+		image   = "%s"
+		profile = "%s"
+		volume_prototypes {
+			volume_profile 						= "sdp"
+			delete_volume_on_instance_delete	= true
+			name 								= "test-data-vol-bandwidth-att"
+			volume_name 						= "test-data-vol-bandwidth"
+			volume_bandwidth 					= %d
+			volume_capacity 					= 150
+		}
+		primary_network_interface {
+		  subnet     = ibm_is_subnet.testacc_subnet.id
+		}
+		user_data = "%s"
+		vpc  = ibm_is_vpc.testacc_vpc.id
+		zone = "%s"
+		keys = [ibm_is_ssh_key.testacc_sshkey.id]
+	  }`, vpcname, subnetname, acc.ISZoneName, acc.ISCIDR, sshname, publicKey, name, acc.IsImage, acc.InstanceProfileName, bandwidtth, userData, acc.ISZoneName)
+}

--- a/ibm/service/vpc/resource_ibm_is_instance_volume_attachment_test.go
+++ b/ibm/service/vpc/resource_ibm_is_instance_volume_attachment_test.go
@@ -169,6 +169,67 @@ ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCKVmnMOlHKcZK8tpt3MP1lqOLAcqcJzhsvJcjscgVE
 		},
 	})
 }
+func TestAccIBMISInstanceVolumeAttachment_bandwidth(t *testing.T) {
+	var instanceVolAtt string
+	vpcname := fmt.Sprintf("tf-vpc-%d", acctest.RandIntRange(10, 100))
+	name := fmt.Sprintf("tf-instnace-%d", acctest.RandIntRange(10, 100))
+	subnetname := fmt.Sprintf("tf-subnet-%d", acctest.RandIntRange(10, 100))
+	publicKey := strings.TrimSpace(`
+ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCKVmnMOlHKcZK8tpt3MP1lqOLAcqcJzhsvJcjscgVERRN7/9484SOBJ3HSKxxNG5JN8owAjy5f9yYwcUg+JaUVuytn5Pv3aeYROHGGg+5G346xaq3DAwX6Y5ykr2fvjObgncQBnuU5KHWCECO/4h8uWuwh/kfniXPVjFToc+gnkqA+3RKpAecZhFXwfalQ9mMuYGFxn+fwn8cYEApsJbsEmb0iJwPiZ5hjFC8wREuiTlhPHDgkBLOiycd20op2nXzDbHfCHInquEe/gYxEitALONxm0swBOwJZwlTDOB7C6y2dzlrtxr1L59m7pCkWI4EtTRLvleehBoj3u7jB4usR
+`)
+	sshname := fmt.Sprintf("tf-ssh-%d", acctest.RandIntRange(10, 100))
+	attName := fmt.Sprintf("tf-volatt-%d", acctest.RandIntRange(10, 100))
+	autoDelete := true
+	volName := fmt.Sprintf("tf-vol-%d", acctest.RandIntRange(10, 100))
+	volUpdateName := fmt.Sprintf("tf-vol-update-%d", acctest.RandIntRange(10, 100))
+	iops1 := int64(10000)
+
+	capacity1 := int64(1000)
+	bandwidth1 := int64(1800)
+	bandwidth2 := int64(2400)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { acc.TestAccPreCheck(t) },
+		Providers:    acc.TestAccProviders,
+		CheckDestroy: testAccCheckIBMISInstanceDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckIBMISInstanceVolumeAttachmentBandwidthConfig(vpcname, subnetname, sshname, publicKey, name, attName, volName, autoDelete, capacity1, iops1, bandwidth1),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckIBMISInstanceVolumeAttachmentExists("ibm_is_instance_volume_attachment.testacc_att", instanceVolAtt),
+					resource.TestCheckResourceAttr(
+						"ibm_is_instance_volume_attachment.testacc_att", "name", attName),
+					resource.TestCheckResourceAttr(
+						"ibm_is_instance_volume_attachment.testacc_att", "delete_volume_on_instance_delete", fmt.Sprintf("%t", autoDelete)),
+					resource.TestCheckResourceAttr(
+						"ibm_is_instance_volume_attachment.testacc_att", "capacity", fmt.Sprintf("%d", capacity1)),
+					resource.TestCheckResourceAttr(
+						"ibm_is_instance_volume_attachment.testacc_att", "iops", "10000"),
+					resource.TestCheckResourceAttr(
+						"ibm_is_instance_volume_attachment.testacc_att", "bandwidth", fmt.Sprintf("%d", bandwidth1)),
+				),
+			},
+			{
+				Config: testAccCheckIBMISInstanceVolumeAttachmentBandwidthConfig(vpcname, subnetname, sshname, publicKey, name, attName, volUpdateName, autoDelete, capacity1, iops1, bandwidth2),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckIBMISInstanceVolumeAttachmentExists("ibm_is_instance_volume_attachment.testacc_att", instanceVolAtt),
+					resource.TestCheckResourceAttr(
+						"ibm_is_instance_volume_attachment.testacc_att", "name", attName),
+					resource.TestCheckResourceAttr(
+						"ibm_is_instance_volume_attachment.testacc_att", "delete_volume_on_instance_delete", fmt.Sprintf("%t", autoDelete)),
+					resource.TestCheckResourceAttr(
+						"ibm_is_instance_volume_attachment.testacc_att", "capacity", fmt.Sprintf("%d", capacity1)),
+					resource.TestCheckResourceAttr(
+						"ibm_is_instance_volume_attachment.testacc_att", "iops", "10000"),
+					resource.TestCheckResourceAttr(
+						"ibm_is_instance_volume_attachment.testacc_att", "volume_name", volUpdateName),
+					resource.TestCheckResourceAttr(
+						"ibm_is_instance_volume_attachment.testacc_att", "bandwidth", fmt.Sprintf("%d", bandwidth2)),
+				),
+			},
+		},
+	})
+}
 func TestAccIBMISInstanceVolumeAttachment_crn(t *testing.T) {
 	var instanceVolAtt string
 	vpcname := fmt.Sprintf("tf-vpc-%d", acctest.RandIntRange(10, 100))
@@ -407,6 +468,54 @@ func testAccCheckIBMISInstanceVolumeAttachmentSdpConfig(vpcname, subnetname, ssh
 	  }
 	 
 	  `, vpcname, subnetname, acc.ISZoneName, sshname, publicKey, name, acc.IsImage, acc.InstanceProfileName, acc.ISZoneName, attName, capacity, iops, autoDelete, volName)
+}
+func testAccCheckIBMISInstanceVolumeAttachmentBandwidthConfig(vpcname, subnetname, sshname, publicKey, name, attName, volName string, autoDelete bool, capacity, iops, volBandwidth int64) string {
+	return fmt.Sprintf(`
+	resource "ibm_is_vpc" "testacc_vpc" {
+		name = "%s"
+	  }
+	  
+	  resource "ibm_is_subnet" "testacc_subnet" {
+		name            			= "%s"
+		vpc             			= ibm_is_vpc.testacc_vpc.id
+		zone            			= "%s"
+		total_ipv4_address_count 	= 16
+	  }
+	  
+	  resource "ibm_is_ssh_key" "testacc_sshkey" {
+		name       = "%s"
+		public_key = "%s"
+	  }
+	  
+	  resource "ibm_is_instance" "testacc_instance" {
+		name    = "%s"
+		image   = "%s"
+		profile = "%s"
+		primary_network_interface {
+		  subnet     = ibm_is_subnet.testacc_subnet.id
+		}
+		vpc  = ibm_is_vpc.testacc_vpc.id
+		zone = "%s"
+		keys = [ibm_is_ssh_key.testacc_sshkey.id]
+		network_interfaces {
+		  subnet = ibm_is_subnet.testacc_subnet.id
+		  name   = "eth1"
+		}
+	  }
+	  resource "ibm_is_instance_volume_attachment" "testacc_att" {
+		instance = ibm_is_instance.testacc_instance.id
+	
+		name 			= "%s"
+		profile 		= "sdp"
+		capacity	 	= %d
+		iops			= %d
+	
+		delete_volume_on_instance_delete = %t
+		volume_name = "%s"
+		bandwidth = %d
+	  }
+	 
+	  `, vpcname, subnetname, acc.ISZoneName, sshname, publicKey, name, acc.IsImage, acc.InstanceProfileName, acc.ISZoneName, attName, capacity, iops, autoDelete, volName, volBandwidth)
 }
 
 func testAccCheckIBMISInstanceVolumeAttachmentCrnConfig(vpcname, subnetname, sshname, publicKey, name, attName, volName string, autoDelete bool) string {

--- a/ibm/service/vpc/resource_ibm_is_snapshot.go
+++ b/ibm/service/vpc/resource_ibm_is_snapshot.go
@@ -1133,7 +1133,7 @@ func snapshotDelete(d *schema.ResourceData, meta interface{}, id string) error {
 	deleteSnapshotOptions := &vpcv1.DeleteSnapshotOptions{
 		ID: &id,
 	}
-	_, response, err = sess.DeleteSnapshot(deleteSnapshotOptions)
+	response, err = sess.DeleteSnapshot(deleteSnapshotOptions)
 	if err != nil {
 		return fmt.Errorf("[ERROR] Error deleting Snapshot : %s\n%s", err, response)
 	}

--- a/ibm/service/vpc/resource_ibm_is_volume.go
+++ b/ibm/service/vpc/resource_ibm_is_volume.go
@@ -103,6 +103,12 @@ func ResourceIBMISVolume() *schema.Resource {
 				Description:  "Volume profile name",
 			},
 
+			"bandwidth": {
+				Type:        schema.TypeInt,
+				Optional:    true,
+				Computed:    true,
+				Description: "The maximum bandwidth (in megabits per second) for the volume. For this property to be specified, the volume storage_generation must be 2.",
+			},
 			isVolumeZone: {
 				Type:        schema.TypeString,
 				Required:    true,
@@ -327,12 +333,6 @@ func ResourceIBMISVolume() *schema.Resource {
 				Description: "The resource group name in which resource is provisioned",
 			},
 
-			isVolumeBandwidth: {
-				Type:        schema.TypeInt,
-				Computed:    true,
-				Description: "The maximum bandwidth (in megabits per second) for the volume",
-			},
-
 			isVolumesOperatingSystem: &schema.Schema{
 				Type:        schema.TypeList,
 				Computed:    true,
@@ -533,6 +533,11 @@ func volCreate(d *schema.ResourceData, meta interface{}, volName, profile, zone 
 	if i, ok := d.GetOk(isVolumeIops); ok {
 		iops := int64(i.(int))
 		volTemplate.Iops = &iops
+	}
+	// bandwidth changes
+	if b, ok := d.GetOk("bandwidth"); ok {
+		bandwidth := int64(b.(int))
+		volTemplate.Bandwidth = &bandwidth
 	}
 
 	var userTags *schema.Set
@@ -791,13 +796,41 @@ func volUpdate(d *schema.ResourceData, meta interface{}, id, name string, hasNam
 	}
 	options.IfMatch = &eTag
 
-	//name update
+	// bandwidth update
+	hasBandwidthChanged := false
+	if d.HasChange("bandwidth") {
+		hasBandwidthChanged = true
+	}
+
+	//name || bandwidth update
 	volumeNamePatchModel := &vpcv1.VolumePatch{}
-	if hasNameChanged {
-		volumeNamePatchModel.Name = &name
+	if hasNameChanged || hasBandwidthChanged {
+		if hasNameChanged {
+			volumeNamePatchModel.Name = &name
+			volumeNamePatch, err := volumeNamePatchModel.AsPatch()
+			if err != nil {
+				return fmt.Errorf("[ERROR] Error calling asPatch for volumeNamePatch for name: %s", err)
+			}
+			options.VolumePatch = volumeNamePatch
+			_, response, err = sess.UpdateVolume(options)
+			if err != nil {
+				return err
+			}
+			_, err = isWaitForVolumeAvailable(sess, d.Id(), d.Timeout(schema.TimeoutCreate))
+			if err != nil {
+				return err
+			}
+			eTag = response.Headers.Get("ETag")
+			options.IfMatch = &eTag
+		}
+		if hasBandwidthChanged {
+			volumeNamePatchModel = &vpcv1.VolumePatch{}
+			bandwidth := int64(d.Get("bandwidth").(int))
+			volumeNamePatchModel.Bandwidth = &bandwidth
+		}
 		volumeNamePatch, err := volumeNamePatchModel.AsPatch()
 		if err != nil {
-			return fmt.Errorf("[ERROR] Error calling asPatch for volumeNamePatch: %s", err)
+			return fmt.Errorf("[ERROR] Error calling asPatch for volumeNamePatch for bandwidth: %s", err)
 		}
 		options.VolumePatch = volumeNamePatch
 		_, response, err = sess.UpdateVolume(options)

--- a/ibm/service/vpc/resource_ibm_is_volume_test.go
+++ b/ibm/service/vpc/resource_ibm_is_volume_test.go
@@ -83,6 +83,48 @@ func TestAccIBMISVolume_sdp(t *testing.T) {
 		},
 	})
 }
+
+// bandwidth changes
+func TestAccIBMISVolume_bandwidth(t *testing.T) {
+	var vol string
+	name := fmt.Sprintf("tf-vol-%d", acctest.RandIntRange(10, 100))
+	name1 := fmt.Sprintf("tf-vol-upd-%d", acctest.RandIntRange(10, 100))
+	capacity1 := 100
+	bandwidth1 := 5000
+	bandwidth2 := 6000
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { acc.TestAccPreCheck(t) },
+		Providers:    acc.TestAccProviders,
+		CheckDestroy: testAccCheckIBMISVolumeDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckIBMISVolumeBandwidthConfig(name, capacity1, bandwidth1),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckIBMISVolumeExists("ibm_is_volume.storage", vol),
+					resource.TestCheckResourceAttr(
+						"ibm_is_volume.storage", "name", name),
+					resource.TestCheckResourceAttr(
+						"ibm_is_volume.storage", "capacity", fmt.Sprintf("%d", capacity1)),
+					resource.TestCheckResourceAttr(
+						"ibm_is_volume.storage", "bandwidth", fmt.Sprintf("%d", bandwidth1)),
+				),
+			},
+
+			{
+				Config: testAccCheckIBMISVolumeBandwidthConfig(name1, capacity1, bandwidth2),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckIBMISVolumeExists("ibm_is_volume.storage", vol),
+					resource.TestCheckResourceAttr(
+						"ibm_is_volume.storage", "name", name1),
+					resource.TestCheckResourceAttr(
+						"ibm_is_volume.storage", "capacity", fmt.Sprintf("%d", capacity1)),
+					resource.TestCheckResourceAttr(
+						"ibm_is_volume.storage", "bandwidth", fmt.Sprintf("%d", bandwidth2)),
+				),
+			},
+		},
+	})
+}
 func TestAccIBMISVolume_sdpUpdate(t *testing.T) {
 	var vol string
 	name := fmt.Sprintf("tf-vol-%d", acctest.RandIntRange(10, 100))
@@ -492,6 +534,19 @@ func testAccCheckIBMISVolumeSdpConfig(name string, capacity int) string {
 		capacity		= %d
 	}
 `, name, capacity)
+
+}
+func testAccCheckIBMISVolumeBandwidthConfig(name string, capacity, bandwidth int) string {
+	return fmt.Sprintf(
+		`
+	resource "ibm_is_volume" "storage"{
+		name 			= "%s"
+		profile 		= "sdp"
+		zone 			= "eu-gb-1"
+		capacity		= %d
+		bandwidth		= %d
+	}
+`, name, capacity, bandwidth)
 
 }
 func testAccCheckIBMISVolumeSdpUpdateConfig(name string, iops, capacity int) string {

--- a/website/docs/d/is_instance_template.html.markdown
+++ b/website/docs/d/is_instance_template.html.markdown
@@ -50,6 +50,7 @@ You can access the following attribute references after your data source is crea
 - `boot_volume` - (List) A nested block describes the boot volume configuration for the template.
 
 	Nested scheme for `boot_volume`:
+	- `bandwidth` - (Optional, Integer) The maximum bandwidth (in megabits per second) for the volume. For this property to be specified, the volume storage_generation must be 2.
 	- `delete_volume_on_instance_delete` - (String) You can configure to delete the boot volume based on instance deletion.
 	- `encryption` - (String) The encryption key CRN such as HPCS, Key Protect, etc., is provided to encrypt the boot volume attached.
 	- `iops` - (String) The IOPS for the boot volume.
@@ -230,6 +231,7 @@ You can access the following attribute references after your data source is crea
 	- `volume_prototype` - (List) A nested block describing prototype for the volume.
 
 		Nested scheme for `volume_prototype`:
+		- `bandwidth` - (Optional, Integer) The maximum bandwidth (in megabits per second) for the volume. For this property to be specified, the volume storage_generation must be 2.
 		- `capacity` - (String) The capacity of the volume in gigabytes. The specified minimum and maximum capacity values for creating or updating volumes can expand in the future.
 		- `encryption_key` - (String) The CRN of the [Key Protect Root Key](https://cloud.ibm.com/docs/key-protect?topic=key-protect-getting-started-tutorial) or [Hyper Protect Crypto Service Root Key](https://cloud.ibm.com/docs/hs-crypto?topic=hs-crypto-get-started) for this resource.
 		- `iops` - (String) The maximum input/output operations per second (IOPS) for the volume.

--- a/website/docs/d/is_instance_templates.html.markdown
+++ b/website/docs/d/is_instance_templates.html.markdown
@@ -37,6 +37,7 @@ You can access the following attribute references after your data source is crea
 	- `boot_volume` - (List) A nested block describes the boot volume configuration for the template.
 
 	  Nested scheme for `boot_volume`:
+		- `bandwidth` - (Optional, Integer) The maximum bandwidth (in megabits per second) for the volume. For this property to be specified, the volume storage_generation must be 2.
 		- `delete_volume_on_instance_delete` - (String) You can configure to delete the boot volume based on instance deletion.
 		- `encryption` - (String) The encryption key CRN such as HPCS, Key Protect, etc., is provided to encrypt the boot volume attached.
 		- `iops` - (String) The IOPS for the boot volume.
@@ -211,6 +212,7 @@ You can access the following attribute references after your data source is crea
 	- `volume_attachments` - (List) A nested block describes the storage volume configuration for the template.
 
 	  Nested scheme for `volume_attachments`:
+		- `bandwidth` - (Optional, Integer) The maximum bandwidth (in megabits per second) for the volume. For this property to be specified, the volume storage_generation must be 2.
 		- `delete_volume_on_instance_delete` - (Bool) You can configure to delete the storage volume to delete based on instance deletion.
 		- `name` - (String) The name of the boot volume.
 		- `volume` - (String) The storage volume ID created in VPC.

--- a/website/docs/d/is_instance_volume_attachment.html.markdown
+++ b/website/docs/d/is_instance_volume_attachment.html.markdown
@@ -40,6 +40,7 @@ Review the argument references that you can specify for your data source.
 ## Attribute reference
 In addition to all argument reference list, you can access the following attribute references after your data source is created.
 
+- `bandwidth` - (Optional, Integer) The maximum bandwidth (in megabits per second) for the volume. For this property to be specified, the volume storage_generation must be 2.
 - `delete_volume_on_instance_delete` - (Boolean) If set to true, when deleting the instance the volume will also be deleted.
 - `device`-  (String) A unique identifier for the device which is exposed to the instance operating system.
 - `href` - (String) The URL for this volume attachment.

--- a/website/docs/d/is_instance_volume_attachments.html.markdown
+++ b/website/docs/d/is_instance_volume_attachments.html.markdown
@@ -41,6 +41,7 @@ In addition to all argument reference list, you can access the following attribu
 - `volume_attachments`- (List of Object) A list of volume attachments on an instance.
    
    Nested scheme for `volume_attachments`:
+  - `bandwidth` - (Optional, Integer) The maximum bandwidth (in megabits per second) for the volume. For this property to be specified, the volume storage_generation must be 2.
   - `delete_volume_on_instance_delete` - (Boolean) If set to **true**, when deleting the instance the volume will also be deleted.
   - `device`-  (String) A unique identifier for the device which is exposed to the instance operating system.
   - `href` - (String) The URL for this volume attachment.

--- a/website/docs/r/is_instance.html.markdown
+++ b/website/docs/r/is_instance.html.markdown
@@ -612,6 +612,7 @@ Review the argument references that you can specify for your resource.
 
   Nested scheme for `boot_volume`:
   - `auto_delete_volume` - (Optional, String) If set to **true**, when deleting the instance the volume will also be deleted
+  - `bandwidth` - (Optional, Integer) The maximum bandwidth (in megabits per second) for the volume. For this property to be specified, the volume storage_generation must be 2.
   - `encryption` - (Optional, String) The type of encryption to use for the boot volume.
   - `name` - (Optional, String) The name of the boot volume.
   - `size` - (Optional, Integer) The size of the boot volume.(The capacity of the volume in gigabytes. This defaults to minimum capacity of the image and maximum to `250`.)
@@ -864,6 +865,7 @@ Review the argument references that you can specify for your resource.
 - `volume_prototypes`- (List of Strings) A list of data volumes to attach to the instance. Mutually exclusive with `volumes`.
 
   Nested scheme for `volume_prototypes`:
+  - `bandwidth` - (Optional, Integer) The maximum bandwidth (in megabits per second) for the volume. For this property to be specified, the volume storage_generation must be 2.
   - `delete_volume_on_instance_delete` - (Bool) If set to **true**, automatically deletes the volumes that are attached to an instance. **Note** Setting this argument can bring some inconsistency in the volume resource, as the volumes is destroyed along with instances.
   - `encryption` - (String) The type of encryption that is used for the volume prototype.
   - `iops`- (Integer) The number of input and output operations per second of the volume prototype.

--- a/website/docs/r/is_instance_template.html.markdown
+++ b/website/docs/r/is_instance_template.html.markdown
@@ -264,9 +264,12 @@ Review the argument references that you can specify for your resource.
 - `boot_volume` - (Optional, List) A nested block describes the boot volume configuration for the template.
 
   Nested scheme for `boot_volume`:
+  - `bandwidth` - (Optional, Integer) The maximum bandwidth (in megabits per second) for the volume. For this property to be specified, the volume storage_generation must be 2.
 	- `delete_volume_on_instance_delete` - (Optional, Bool) You can configure to delete the boot volume based on instance deletion.
 	- `encryption` - (Optional, String) The encryption key CRN to encrypt the boot volume attached.
 	- `name` - (Optional, String) The name of the boot volume.
+	- `profile` - (Optional, String) The profile name for this boot volume.
+	- `size` - (Optional, Integer) The size for this boot volume.(in gigabytes)
   - `tags`- (Optional, Array of Strings) A list of user tags that you want to add to your volume. (https://cloud.ibm.com/apidocs/tagging#types-of-tags)
 
 - `catalog_offering` - (Optional, Forces new resource, List) The [catalog](https://cloud.ibm.com/docs/account?topic=account-restrict-by-user&interface=ui) offering or offering version to use when provisioning this virtual server instance. If an offering is specified, the latest version of that offering will be used. The specified offering or offering version may be in a different account in the same [enterprise](https://cloud.ibm.com/docs/account?topic=account-what-is-enterprise), subject to IAM policies.
@@ -454,6 +457,7 @@ Review the argument references that you can specify for your resource.
   - `volume_prototype` - (Optional, Forces new resource, List)
 
       Nested scheme for `volume_prototype`:
+      - `bandwidth` - (Optional, Integer) The maximum bandwidth (in megabits per second) for the volume. For this property to be specified, the volume storage_generation must be 2.
       - `capacity` - (Required, Forces new resource, Integer) The capacity of the volume in gigabytes. The specified minimum and maximum capacity values for creating or updating volumes may expand in the future.
       - `encryption_key` - (Optional, Forces new resource, String) The CRN of the [Key Protect Root Key](https://cloud.ibm.com/docs/key-protect?topic=key-protect-getting-started-tutorial) or [Hyper Protect Crypto Service Root Key](https://cloud.ibm.com/docs/hs-crypto?topic=hs-crypto-get-started) for the resource.
       - `iops` - (Optional, Forces new resource, Integer) The maximum input and output operations per second (IOPS) for the volume.

--- a/website/docs/r/is_instance_volume_attachment.html.markdown
+++ b/website/docs/r/is_instance_volume_attachment.html.markdown
@@ -152,8 +152,9 @@ The `ibm_is_instance_volume_attachment` resource provides the following [Timeout
 - **delete**: The deletion of the instance volume attachment is considered failed when no response is received for 10 minutes.
 
 ## Argument reference
-Review the argument references that you can specify for your resource. 
+Review the argument references that you can specify for your resource.
 
+- `bandwidth` - (Optional, Integer) The maximum bandwidth (in megabits per second) for the volume. For this property to be specified, the volume storage_generation must be 2.
 - `capacity` - (Optional, Integer) The capacity of the volume in gigabytes.
 
   ~> **NOTE**

--- a/website/docs/r/is_volume.html.markdown
+++ b/website/docs/r/is_volume.html.markdown
@@ -73,6 +73,7 @@ Review the argument references that you can specify for your resource.
   **&#x2022;** `access_tags` must be in the format `key:value`.
 - `adjustable_capacity_states` - (List) The attachment states that support adjustable capacity for this volume. Allowable list items are: `attached`, `unattached`, `unusable`. 
 - `adjustable_iops_states` - (List) The attachment states that support adjustable IOPS for this volume. Allowable list items are: `attached`, `unattached`, `unusable`.
+- `bandwidth` - (Optional, Integer) The maximum bandwidth (in megabits per second) for the volume. For this property to be specified, the volume storage_generation must be 2.
 - `capacity` - (Optional, Integer) (The capacity of the volume in gigabytes. This defaults to `100`, minimum to `10 ` and maximum to `16000`.
 
   ~> **NOTE:** Supports only expansion on update (must be attached to a running instance and must not be less than the current volume capacity). Can be updated only if volume is attached to an running virtual server instance. Stopped instance will be started on update of capacity of the volume.If `source_snapshot` is provided `capacity` must be at least the snapshot's minimum_capacity. The maximum value may increase in the future and If unspecified, the capacity will be the source snapshot's minimum_capacity.


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/IBM-Cloud/terraform-provider-ibm/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
% make testacc TEST=./ibm/service/vpc TESTARGS='-run=TestAccIBMISVolume_bandwidth'
=== RUN   TestAccIBMISVolume_bandwidth
--- PASS: TestAccIBMISVolume_bandwidth (121.89s)
PASS
ok      github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/vpc     123.714s
```

```
% make testacc TEST=./ibm/service/vpc TESTARGS='-run=TestAccIBMISInstanceTemplate_WithBootBandwidth'
=== RUN   TestAccIBMISInstanceTemplate_WithBootBandwidth
--- PASS: TestAccIBMISInstanceTemplate_WithBootBandwidth (86.03s)
PASS
ok      github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/vpc     88.087s
```
```
% make testacc TEST=./ibm/service/vpc TESTARGS='-run=TestAccIBMISInstanceVolumeAttachment_bandwidth'
=== RUN   TestAccIBMISInstanceVolumeAttachment_bandwidth
--- PASS: TestAccIBMISInstanceVolumeAttachment_bandwidth (240.38s)
PASS
ok      github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/vpc     242.447s
```

```
% make testacc TEST=./ibm/service/vpc TESTARGS='-run=TestAccIBMISInstance_BootBandwidth'
=== RUN   TestAccIBMISInstance_BootBandwidth
--- PASS: TestAccIBMISInstance_BootBandwidth (196.33s)
PASS
ok      github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/vpc     198.158s

--- PASS: TestAccIBMISInstance_VolumeBandwidth (205.21s)
PASS
ok      github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/vpc     207.282s
```