### PR TITLE
enhancement: improved error handling for is_ssh_key

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -5,6 +5,7 @@ TEST_TIMEOUT?=700m
 VERSION ?= 0.0.1
 OS_ARCH := $(shell go env GOOS)_$(shell go env GOARCH)
 PLUGIN_DIR := $(HOME)/.terraform.d/plugins/registry.terraform.io/ibm-cloud/ibm/$(VERSION)/$(OS_ARCH)
+TEST_NAME ?= ""
 
 default: build
 
@@ -35,6 +36,14 @@ test: fmtcheck
 
 testacc: fmtcheck
 	TF_ACC=1 go test $(TEST) -v $(TESTARGS) -timeout $(TEST_TIMEOUT) 
+
+test-vpc:
+	@if [ "$(TEST_NAME)" = "" ]; then \
+		echo "Error: Please provide a test name using TEST_NAME=YourTestName"; \
+		exit 1; \
+	fi
+	@echo "Running VPC test: $(TEST_NAME)"
+	@$(MAKE) testacc TEST=./ibm/service/vpc TESTARGS='-run=$(TEST_NAME)'
 
 testrace: fmtcheck
 	TF_ACC= go test -race $(TEST) $(TESTARGS)

--- a/ibm/service/vpc/data_source_ibm_is_ssh_key_test.go
+++ b/ibm/service/vpc/data_source_ibm_is_ssh_key_test.go
@@ -30,17 +30,31 @@ ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCKVmnMOlHKcZK8tpt3MP1lqOLAcqcJzhsvJcjscgVE
 					resource.TestCheckResourceAttr(
 						"data.ibm_is_ssh_key.ds_key", "name", name1),
 					resource.TestCheckResourceAttrSet(
+						"data.ibm_is_ssh_key.ds_key", "id"),
+					resource.TestCheckResourceAttrSet(
 						"data.ibm_is_ssh_key.ds_key", "crn"),
 					resource.TestCheckResourceAttrSet(
 						"data.ibm_is_ssh_key.ds_key", "fingerprint"),
-					resource.TestCheckResourceAttrSet(
-						"data.ibm_is_ssh_key.ds_key", "id"),
 					resource.TestCheckResourceAttrSet(
 						"data.ibm_is_ssh_key.ds_key", "length"),
 					resource.TestCheckResourceAttrSet(
 						"data.ibm_is_ssh_key.ds_key", "public_key"),
 					resource.TestCheckResourceAttrSet(
 						"data.ibm_is_ssh_key.ds_key", "type"),
+					resource.TestCheckResourceAttrSet(
+						"data.ibm_is_ssh_key.ds_key", "created_at"),
+					resource.TestCheckResourceAttrSet(
+						"data.ibm_is_ssh_key.ds_key", "href"),
+					resource.TestCheckResourceAttrSet(
+						"data.ibm_is_ssh_key.ds_key", "resource_controller_url"),
+					resource.TestCheckResourceAttrSet(
+						"data.ibm_is_ssh_key.ds_key", "resource_crn"),
+					// resource.TestCheckResourceAttrSet(
+					// 	"data.ibm_is_ssh_key.ds_key", "resource_group"),
+					resource.TestCheckResourceAttrSet(
+						"data.ibm_is_ssh_key.ds_key", "resource_group_name"),
+					resource.TestCheckResourceAttrSet(
+						"data.ibm_is_ssh_key.ds_key", "resource_name"),
 					resource.TestCheckResourceAttrSet(
 						"data.ibm_is_ssh_key.ds_key", "tags.#"),
 					resource.TestCheckResourceAttr(

--- a/ibm/service/vpc/data_source_ibm_is_ssh_keys.go
+++ b/ibm/service/vpc/data_source_ibm_is_ssh_keys.go
@@ -133,7 +133,9 @@ func DataSourceIBMIsSshKeys() *schema.Resource {
 func dataSourceIBMIsSshKeysRead(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	vpcClient, err := meta.(conns.ClientSession).VpcV1API()
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.DiscriminatedTerraformErrorf(err, err.Error(), "(Data) ibm_is_ssh_keys", "read", "initialize-client")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	start := ""
@@ -145,10 +147,11 @@ func dataSourceIBMIsSshKeysRead(context context.Context, d *schema.ResourceData,
 			listKeysOptions.Start = &start
 		}
 
-		keyCollection, response, err := vpcClient.ListKeysWithContext(context, listKeysOptions)
-		if err != nil || keyCollection == nil {
-			log.Printf("[DEBUG] ListKeysWithContext failed %s\n%s", err, response)
-			return diag.FromErr(fmt.Errorf("ListKeysWithContext failed %s\n%s", err, response))
+		keyCollection, _, err := vpcClient.ListKeysWithContext(context, listKeysOptions)
+		if err != nil {
+			tfErr := flex.TerraformErrorf(err, fmt.Sprintf("ListKeysWithContext failed %s", err), "(Data) ibm_is_ssh_keys", "read")
+			log.Printf("[DEBUG] %s", tfErr.GetDebugMessage())
+			return tfErr.GetDiag()
 		}
 
 		start = flex.GetNext(keyCollection.Next)
@@ -163,7 +166,7 @@ func dataSourceIBMIsSshKeysRead(context context.Context, d *schema.ResourceData,
 	d.SetId(dataSourceIBMIsSshKeysID(d))
 	err = d.Set(isKeys, dataSourceKeyCollectionFlattenKeys(allrecs, d, meta))
 	if err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting keys %s", err))
+		return flex.DiscriminatedTerraformErrorf(err, fmt.Sprintf("Error setting keys %s", err), "(Data) ibm_is_ssh_keys", "read", "keys-set").GetDiag()
 	}
 
 	return nil

--- a/ibm/service/vpc/data_source_ibm_is_ssh_keys_test.go
+++ b/ibm/service/vpc/data_source_ibm_is_ssh_keys_test.go
@@ -28,6 +28,54 @@ func TestAccIBMIsSshKeysDataSourceBasic(t *testing.T) {
 		},
 	})
 }
+func TestAccIBMIsSshKeysDataSourceComprehensive(t *testing.T) {
+	name1 := fmt.Sprintf("tfssh-name-%d", acctest.RandIntRange(10, 100))
+	publicKey := strings.TrimSpace(`
+ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCKVmnMOlHKcZK8tpt3MP1lqOLAcqcJzhsvJcjscgVERRN7/9484SOBJ3HSKxxNG5JN8owAjy5f9yYwcUg+JaUVuytn5Pv3aeYROHGGg+5G346xaq3DAwX6Y5ykr2fvjObgncQBnuU5KHWCECO/4h8uWuwh/kfniXPVjFToc+gnkqA+3RKpAecZhFXwfalQ9mMuYGFxn+fwn8cYEApsJbsEmb0iJwPiZ5hjFC8wREuiTlhPHDgkBLOiycd20op2nXzDbHfCHInquEe/gYxEitALONxm0swBOwJZwlTDOB7C6y2dzlrtxr1L59m7pCkWI4EtTRLvleehBoj3u7jB4usR
+`)
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { acc.TestAccPreCheck(t) },
+		Providers: acc.TestAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckIBMIsSshKeysDataSourceConfigComprehensive(publicKey, name1),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(
+						"ibm_is_ssh_key.key", "name", name1),
+					resource.TestCheckResourceAttr(
+						"ibm_is_ssh_key.key", "tags.#", "3"),
+					resource.TestCheckResourceAttrSet("data.ibm_is_ssh_keys.is_ssh_keys", "id"),
+					resource.TestCheckResourceAttrSet("data.ibm_is_ssh_keys.is_ssh_keys", "keys.#"),
+					// Check all fields in the first key in the list
+					resource.TestCheckResourceAttrSet("data.ibm_is_ssh_keys.is_ssh_keys", "keys.0.id"),
+					resource.TestCheckResourceAttrSet("data.ibm_is_ssh_keys.is_ssh_keys", "keys.0.name"),
+					resource.TestCheckResourceAttrSet("data.ibm_is_ssh_keys.is_ssh_keys", "keys.0.crn"),
+					resource.TestCheckResourceAttrSet("data.ibm_is_ssh_keys.is_ssh_keys", "keys.0.fingerprint"),
+					resource.TestCheckResourceAttrSet("data.ibm_is_ssh_keys.is_ssh_keys", "keys.0.length"),
+					resource.TestCheckResourceAttrSet("data.ibm_is_ssh_keys.is_ssh_keys", "keys.0.type"),
+					resource.TestCheckResourceAttrSet("data.ibm_is_ssh_keys.is_ssh_keys", "keys.0.public_key"),
+					resource.TestCheckResourceAttrSet("data.ibm_is_ssh_keys.is_ssh_keys", "keys.0.created_at"),
+					resource.TestCheckResourceAttrSet("data.ibm_is_ssh_keys.is_ssh_keys", "keys.0.href"),
+					resource.TestCheckResourceAttrSet("data.ibm_is_ssh_keys.is_ssh_keys", "keys.0.resource_group.0.id"),
+					resource.TestCheckResourceAttrSet("data.ibm_is_ssh_keys.is_ssh_keys", "keys.0.resource_group.0.name"),
+					resource.TestCheckResourceAttrSet("data.ibm_is_ssh_keys.is_ssh_keys", "keys.0.resource_group.0.href"),
+				),
+			},
+		},
+	})
+}
+func testAccCheckIBMIsSshKeysDataSourceConfigComprehensive(publicKey, name1 string) string {
+	return fmt.Sprintf(`
+		resource "ibm_is_ssh_key" "key" {
+			name 		= "%s"
+			public_key 	= "%s"
+			tags		= ["test:1", "test:2", "test:3"]
+		}
+		data "ibm_is_ssh_keys" "is_ssh_keys" {
+			depends_on = [ibm_is_ssh_key.key]
+		}
+	`, name1, publicKey)
+}
 func TestAccIBMIsSshKeysDataSourceTags(t *testing.T) {
 	name1 := fmt.Sprintf("tfssh-name-%d", acctest.RandIntRange(10, 100))
 	publicKey := strings.TrimSpace(`

--- a/ibm/service/vpc/resource_ibm_is_ssh_key_test.go
+++ b/ibm/service/vpc/resource_ibm_is_ssh_key_test.go
@@ -35,7 +35,32 @@ ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCKVmnMOlHKcZK8tpt3MP1lqOLAcqcJzhsvJcjscgVE
 					testAccCheckIBMISKeyExists("ibm_is_ssh_key.isExampleKey", key),
 					resource.TestCheckResourceAttr(
 						"ibm_is_ssh_key.isExampleKey", "name", name),
+					resource.TestCheckResourceAttr(
+						"ibm_is_ssh_key.isExampleKey", "public_key", publicKey),
+					resource.TestCheckResourceAttrSet(
+						"ibm_is_ssh_key.isExampleKey", "fingerprint"),
+					resource.TestCheckResourceAttrSet(
+						"ibm_is_ssh_key.isExampleKey", "length"),
+					resource.TestCheckResourceAttrSet(
+						"ibm_is_ssh_key.isExampleKey", "type"),
+					resource.TestCheckResourceAttrSet(
+						"ibm_is_ssh_key.isExampleKey", "crn"),
+					resource.TestCheckResourceAttrSet(
+						"ibm_is_ssh_key.isExampleKey", "created_at"),
+					resource.TestCheckResourceAttrSet(
+						"ibm_is_ssh_key.isExampleKey", "href"),
+					resource.TestCheckResourceAttrSet(
+						"ibm_is_ssh_key.isExampleKey", "resource_controller_url"),
+					resource.TestCheckResourceAttrSet(
+						"ibm_is_ssh_key.isExampleKey", "resource_crn"),
+					resource.TestCheckResourceAttrSet(
+						"ibm_is_ssh_key.isExampleKey", "resource_name"),
 				),
+			},
+			{
+				ResourceName:      "ibm_is_ssh_key.isExampleKey",
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 		},
 	})
@@ -199,4 +224,105 @@ func testAccCheckIBMISKeyNewlineConfig(name, name1 string) string {
         EOT
 		}
 	`, name, name1)
+}
+
+// Test with tags
+func TestAccIBMISSSHKey_WithTags(t *testing.T) {
+	var key string
+	publicKey := strings.TrimSpace(`
+ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCKVmnMOlHKcZK8tpt3MP1lqOLAcqcJzhsvJcjscgVERRN7/9484SOBJ3HSKxxNG5JN8owAjy5f9yYwcUg+JaUVuytn5Pv3aeYROHGGg+5G346xaq3DAwX6Y5ykr2fvjObgncQBnuU5KHWCECO/4h8uWuwh/kfniXPVjFToc+gnkqA+3RKpAecZhFXwfalQ9mMuYGFxn+fwn8cYEApsJbsEmb0iJwPiZ5hjFC8wREuiTlhPHDgkBLOiycd20op2nXzDbHfCHInquEe/gYxEitALONxm0swBOwJZwlTDOB7C6y2dzlrtxr1L59m7pCkWI4EtTRLvleehBoj3u7jB4usR
+`)
+	name := fmt.Sprintf("tfssh-tagname-%d", acctest.RandIntRange(10, 100))
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { acc.TestAccPreCheck(t) },
+		Providers:    acc.TestAccProviders,
+		CheckDestroy: checkKeyDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckIBMISKeyConfigWithTags(publicKey, name),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckIBMISKeyExists("ibm_is_ssh_key.isExampleKey", key),
+					resource.TestCheckResourceAttr(
+						"ibm_is_ssh_key.isExampleKey", "name", name),
+					resource.TestCheckResourceAttr(
+						"ibm_is_ssh_key.isExampleKey", "tags.#", "3"),
+					resource.TestCheckResourceAttrSet(
+						"ibm_is_ssh_key.isExampleKey", "fingerprint"),
+					resource.TestCheckResourceAttrSet(
+						"ibm_is_ssh_key.isExampleKey", "length"),
+					resource.TestCheckResourceAttrSet(
+						"ibm_is_ssh_key.isExampleKey", "type"),
+					resource.TestCheckResourceAttrSet(
+						"ibm_is_ssh_key.isExampleKey", "crn"),
+					resource.TestCheckResourceAttrSet(
+						"ibm_is_ssh_key.isExampleKey", "created_at"),
+					resource.TestCheckResourceAttrSet(
+						"ibm_is_ssh_key.isExampleKey", "href"),
+					resource.TestCheckResourceAttrSet(
+						"ibm_is_ssh_key.isExampleKey", "resource_controller_url"),
+					resource.TestCheckResourceAttrSet(
+						"ibm_is_ssh_key.isExampleKey", "resource_crn"),
+					resource.TestCheckResourceAttrSet(
+						"ibm_is_ssh_key.isExampleKey", "resource_group"),
+					resource.TestCheckResourceAttrSet(
+						"ibm_is_ssh_key.isExampleKey", "resource_group_name"),
+					resource.TestCheckResourceAttrSet(
+						"ibm_is_ssh_key.isExampleKey", "resource_name"),
+				),
+			},
+		},
+	})
+}
+
+// Add config with tags
+func testAccCheckIBMISKeyConfigWithTags(publicKey, name string) string {
+	return fmt.Sprintf(`
+		resource "ibm_is_ssh_key" "isExampleKey" {
+			name = "%s"
+			public_key = "%s"
+			tags = ["test:1", "test:2", "test:3"]
+		}
+	`, name, publicKey)
+}
+
+// Add Resource Group test
+func TestAccIBMISSSHKey_WithResourceGroup(t *testing.T) {
+	var key string
+	publicKey := strings.TrimSpace(`
+ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCKVmnMOlHKcZK8tpt3MP1lqOLAcqcJzhsvJcjscgVERRN7/9484SOBJ3HSKxxNG5JN8owAjy5f9yYwcUg+JaUVuytn5Pv3aeYROHGGg+5G346xaq3DAwX6Y5ykr2fvjObgncQBnuU5KHWCECO/4h8uWuwh/kfniXPVjFToc+gnkqA+3RKpAecZhFXwfalQ9mMuYGFxn+fwn8cYEApsJbsEmb0iJwPiZ5hjFC8wREuiTlhPHDgkBLOiycd20op2nXzDbHfCHInquEe/gYxEitALONxm0swBOwJZwlTDOB7C6y2dzlrtxr1L59m7pCkWI4EtTRLvleehBoj3u7jB4usR
+`)
+	name := fmt.Sprintf("tfssh-rgname-%d", acctest.RandIntRange(10, 100))
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { acc.TestAccPreCheck(t) },
+		Providers:    acc.TestAccProviders,
+		CheckDestroy: checkKeyDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckIBMISKeyConfigWithResourceGroup(publicKey, name),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckIBMISKeyExists("ibm_is_ssh_key.isExampleKey", key),
+					resource.TestCheckResourceAttr(
+						"ibm_is_ssh_key.isExampleKey", "name", name),
+					resource.TestCheckResourceAttrSet(
+						"ibm_is_ssh_key.isExampleKey", "resource_group"),
+					resource.TestCheckResourceAttrSet(
+						"ibm_is_ssh_key.isExampleKey", "resource_group_name"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckIBMISKeyConfigWithResourceGroup(publicKey, name string) string {
+	return fmt.Sprintf(`
+		data "ibm_resource_group" "default" {
+			is_default = true
+		}
+		
+		resource "ibm_is_ssh_key" "isExampleKey" {
+			name = "%s"
+			public_key = "%s"
+			resource_group = data.ibm_resource_group.default.id
+		}
+	`, name, publicKey)
 }


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/IBM-Cloud/terraform-provider-ibm/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
--- PASS: TestAccIBMISSSHKey_basic (39.70s)
PASS
ok      github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/vpc     41.849s

--- PASS: TestAccIBMISSSHKey_CreatedAtHref (36.38s)
PASS
ok      github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/vpc     38.170s

--- PASS: TestAccIBMISSSHKey_Newlinebasic (38.71s)
PASS
ok      github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/vpc     40.231s

--- PASS: TestAccIBMISSSHKey_ed25519 (39.86s)
PASS
ok      github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/vpc     41.365s

--- PASS: TestAccIBMISSSHKey_WithTags (44.24s)
PASS
ok      github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/vpc     46.004s

--- PASS: TestAccIBMISSSHKey_WithResourceGroup (33.89s)
PASS
ok      github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/vpc     35.721s

--- PASS: TestAccIBMISSSHKeyDatasource_basicidname (42.69s)
PASS
ok      github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/vpc     44.508s

--- PASS: TestAccIBMISSSHKeyDatasource_CreatedAtHref (46.07s)
PASS
ok      github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/vpc     47.565s

--- PASS: TestAccIBMIsSshKeysDataSourceBasic (28.51s)
PASS
ok      github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/vpc     30.595s

--- PASS: TestAccIBMIsSshKeysDataSourceComprehensive (56.81s)
PASS
ok      github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/vpc     58.645s

--- PASS: TestAccIBMIsSshKeysDataSourceTags (41.81s)
PASS
ok      github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/vpc     43.335s
```
