### PR TITLE
fix(tekton): fix null pointers when importing resources

### DIFF
--- a/ibm/service/cdtektonpipeline/data_source_ibm_cd_tekton_pipeline.go
+++ b/ibm/service/cdtektonpipeline/data_source_ibm_cd_tekton_pipeline.go
@@ -1,8 +1,8 @@
-// Copyright IBM Corp. 2024 All Rights Reserved.
+// Copyright IBM Corp. 2025 All Rights Reserved.
 // Licensed under the Mozilla Public License v2.0
 
 /*
- * IBM OpenAPI Terraform Generator Version: 3.95.2-120e65bc-20240924-152329
+ * IBM OpenAPI Terraform Generator Version: 3.103.0-e8b84313-20250402-201816
  */
 
 package cdtektonpipeline

--- a/ibm/service/cdtektonpipeline/data_source_ibm_cd_tekton_pipeline_definition.go
+++ b/ibm/service/cdtektonpipeline/data_source_ibm_cd_tekton_pipeline_definition.go
@@ -1,8 +1,8 @@
-// Copyright IBM Corp. 2024 All Rights Reserved.
+// Copyright IBM Corp. 2025 All Rights Reserved.
 // Licensed under the Mozilla Public License v2.0
 
 /*
- * IBM OpenAPI Terraform Generator Version: 3.95.2-120e65bc-20240924-152329
+ * IBM OpenAPI Terraform Generator Version: 3.103.0-e8b84313-20250402-201816
  */
 
 package cdtektonpipeline

--- a/ibm/service/cdtektonpipeline/data_source_ibm_cd_tekton_pipeline_definition_test.go
+++ b/ibm/service/cdtektonpipeline/data_source_ibm_cd_tekton_pipeline_definition_test.go
@@ -1,8 +1,8 @@
-// Copyright IBM Corp. 2024 All Rights Reserved.
+// Copyright IBM Corp. 2025 All Rights Reserved.
 // Licensed under the Mozilla Public License v2.0
 
 /*
- * IBM OpenAPI Terraform Generator Version: 3.95.2-120e65bc-20240924-152329
+ * IBM OpenAPI Terraform Generator Version: 3.103.0-e8b84313-20250402-201816
  */
 
 package cdtektonpipeline_test

--- a/ibm/service/cdtektonpipeline/data_source_ibm_cd_tekton_pipeline_property.go
+++ b/ibm/service/cdtektonpipeline/data_source_ibm_cd_tekton_pipeline_property.go
@@ -1,8 +1,8 @@
-// Copyright IBM Corp. 2024 All Rights Reserved.
+// Copyright IBM Corp. 2025 All Rights Reserved.
 // Licensed under the Mozilla Public License v2.0
 
 /*
- * IBM OpenAPI Terraform Generator Version: 3.95.2-120e65bc-20240924-152329
+ * IBM OpenAPI Terraform Generator Version: 3.103.0-e8b84313-20250402-201816
  */
 
 package cdtektonpipeline

--- a/ibm/service/cdtektonpipeline/data_source_ibm_cd_tekton_pipeline_property_test.go
+++ b/ibm/service/cdtektonpipeline/data_source_ibm_cd_tekton_pipeline_property_test.go
@@ -1,8 +1,8 @@
-// Copyright IBM Corp. 2024 All Rights Reserved.
+// Copyright IBM Corp. 2025 All Rights Reserved.
 // Licensed under the Mozilla Public License v2.0
 
 /*
- * IBM OpenAPI Terraform Generator Version: 3.95.2-120e65bc-20240924-152329
+ * IBM OpenAPI Terraform Generator Version: 3.103.0-e8b84313-20250402-201816
  */
 
 package cdtektonpipeline_test

--- a/ibm/service/cdtektonpipeline/data_source_ibm_cd_tekton_pipeline_test.go
+++ b/ibm/service/cdtektonpipeline/data_source_ibm_cd_tekton_pipeline_test.go
@@ -1,8 +1,8 @@
-// Copyright IBM Corp. 2024 All Rights Reserved.
+// Copyright IBM Corp. 2025 All Rights Reserved.
 // Licensed under the Mozilla Public License v2.0
 
 /*
- * IBM OpenAPI Terraform Generator Version: 3.95.2-120e65bc-20240924-152329
+ * IBM OpenAPI Terraform Generator Version: 3.103.0-e8b84313-20250402-201816
  */
 
 package cdtektonpipeline_test

--- a/ibm/service/cdtektonpipeline/data_source_ibm_cd_tekton_pipeline_trigger.go
+++ b/ibm/service/cdtektonpipeline/data_source_ibm_cd_tekton_pipeline_trigger.go
@@ -1,8 +1,8 @@
-// Copyright IBM Corp. 2024 All Rights Reserved.
+// Copyright IBM Corp. 2025 All Rights Reserved.
 // Licensed under the Mozilla Public License v2.0
 
 /*
- * IBM OpenAPI Terraform Generator Version: 3.95.2-120e65bc-20240924-152329
+ * IBM OpenAPI Terraform Generator Version: 3.103.0-e8b84313-20250402-201816
  */
 
 package cdtektonpipeline

--- a/ibm/service/cdtektonpipeline/data_source_ibm_cd_tekton_pipeline_trigger_property.go
+++ b/ibm/service/cdtektonpipeline/data_source_ibm_cd_tekton_pipeline_trigger_property.go
@@ -1,8 +1,8 @@
-// Copyright IBM Corp. 2024 All Rights Reserved.
+// Copyright IBM Corp. 2025 All Rights Reserved.
 // Licensed under the Mozilla Public License v2.0
 
 /*
- * IBM OpenAPI Terraform Generator Version: 3.95.2-120e65bc-20240924-152329
+ * IBM OpenAPI Terraform Generator Version: 3.103.0-e8b84313-20250402-201816
  */
 
 package cdtektonpipeline

--- a/ibm/service/cdtektonpipeline/data_source_ibm_cd_tekton_pipeline_trigger_property_test.go
+++ b/ibm/service/cdtektonpipeline/data_source_ibm_cd_tekton_pipeline_trigger_property_test.go
@@ -1,8 +1,8 @@
-// Copyright IBM Corp. 2024 All Rights Reserved.
+// Copyright IBM Corp. 2025 All Rights Reserved.
 // Licensed under the Mozilla Public License v2.0
 
 /*
- * IBM OpenAPI Terraform Generator Version: 3.95.2-120e65bc-20240924-152329
+ * IBM OpenAPI Terraform Generator Version: 3.103.0-e8b84313-20250402-201816
  */
 
 package cdtektonpipeline_test

--- a/ibm/service/cdtektonpipeline/data_source_ibm_cd_tekton_pipeline_trigger_test.go
+++ b/ibm/service/cdtektonpipeline/data_source_ibm_cd_tekton_pipeline_trigger_test.go
@@ -1,8 +1,8 @@
-// Copyright IBM Corp. 2024 All Rights Reserved.
+// Copyright IBM Corp. 2025 All Rights Reserved.
 // Licensed under the Mozilla Public License v2.0
 
 /*
- * IBM OpenAPI Terraform Generator Version: 3.95.2-120e65bc-20240924-152329
+ * IBM OpenAPI Terraform Generator Version: 3.103.0-e8b84313-20250402-201816
  */
 
 package cdtektonpipeline_test

--- a/ibm/service/cdtektonpipeline/resource_ibm_cd_tekton_pipeline.go
+++ b/ibm/service/cdtektonpipeline/resource_ibm_cd_tekton_pipeline.go
@@ -2,7 +2,7 @@
 // Licensed under the Mozilla Public License v2.0
 
 /*
- * IBM OpenAPI Terraform Generator Version: 3.95.2-120e65bc-20240924-152329
+ * IBM OpenAPI Terraform Generator Version: 3.103.0-e8b84313-20250402-201816
  */
 
 package cdtektonpipeline
@@ -192,7 +192,6 @@ func ResourceIBMCdTektonPipeline() *schema.Resource {
 						},
 						"href": &schema.Schema{
 							Type:        schema.TypeString,
-							Optional:    true,
 							Computed:    true,
 							Description: "API URL for interacting with the definition.",
 						},
@@ -225,7 +224,6 @@ func ResourceIBMCdTektonPipeline() *schema.Resource {
 						},
 						"href": &schema.Schema{
 							Type:        schema.TypeString,
-							Optional:    true,
 							Computed:    true,
 							Description: "API URL for interacting with the property.",
 						},
@@ -287,7 +285,6 @@ func ResourceIBMCdTektonPipeline() *schema.Resource {
 						},
 						"href": &schema.Schema{
 							Type:        schema.TypeString,
-							Optional:    true,
 							Computed:    true,
 							Description: "API URL for interacting with the trigger. Only included when fetching the list of pipeline triggers.",
 						},
@@ -299,13 +296,11 @@ func ResourceIBMCdTektonPipeline() *schema.Resource {
 						},
 						"id": &schema.Schema{
 							Type:        schema.TypeString,
-							Optional:    true,
 							Computed:    true,
 							Description: "The Trigger ID.",
 						},
 						"properties": &schema.Schema{
 							Type:        schema.TypeList,
-							Optional:    true,
 							Computed:    true,
 							Description: "Optional trigger properties are used to override or supplement the pipeline properties when triggering a pipeline run.",
 							Elem: &schema.Resource{
@@ -325,7 +320,6 @@ func ResourceIBMCdTektonPipeline() *schema.Resource {
 									},
 									"href": &schema.Schema{
 										Type:        schema.TypeString,
-										Optional:    true,
 										Computed:    true,
 										Description: "API URL for interacting with the trigger property.",
 									},
@@ -548,7 +542,6 @@ func ResourceIBMCdTektonPipeline() *schema.Resource {
 						},
 						"webhook_url": &schema.Schema{
 							Type:        schema.TypeString,
-							Optional:    true,
 							Computed:    true,
 							Description: "Webhook URL that can be used to trigger pipeline runs.",
 						},
@@ -1344,18 +1337,26 @@ func ResourceIBMCdTektonPipelineTektonPipelinePatchAsPatch(patchVals *cdtektonpi
 	path = "next_build_number"
 	if _, exists := d.GetOk(path); d.HasChange(path) && !exists {
 		patch["next_build_number"] = nil
+	} else if !exists {
+		delete(patch, "next_build_number")
 	}
 	path = "enable_notifications"
 	if _, exists := d.GetOkExists(path); d.HasChange(path) && !exists {
 		patch["enable_notifications"] = nil
+	} else if !exists {
+		delete(patch, "enable_notifications")
 	}
 	path = "enable_partial_cloning"
 	if _, exists := d.GetOkExists(path); d.HasChange(path) && !exists {
 		patch["enable_partial_cloning"] = nil
+	} else if !exists {
+		delete(patch, "enable_partial_cloning")
 	}
 	path = "worker"
 	if _, exists := d.GetOk(path); d.HasChange(path) && !exists {
 		patch["worker"] = nil
+	} else if !exists {
+		delete(patch, "worker")
 	}
 
 	return patch

--- a/ibm/service/cdtektonpipeline/resource_ibm_cd_tekton_pipeline.go
+++ b/ibm/service/cdtektonpipeline/resource_ibm_cd_tekton_pipeline.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2024 All Rights Reserved.
+// Copyright IBM Corp. 2025 All Rights Reserved.
 // Licensed under the Mozilla Public License v2.0
 
 /*
@@ -865,7 +865,9 @@ func resourceIBMCdTektonPipelineDelete(context context.Context, d *schema.Resour
 
 func ResourceIBMCdTektonPipelineMapToWorkerIdentity(modelMap map[string]interface{}) (*cdtektonpipelinev2.WorkerIdentity, error) {
 	model := &cdtektonpipelinev2.WorkerIdentity{}
-	model.ID = core.StringPtr(modelMap["id"].(string))
+	if modelMap["id"] != nil {
+		model.ID = core.StringPtr(modelMap["id"].(string))
+	}
 	return model, nil
 }
 
@@ -877,7 +879,9 @@ func ResourceIBMCdTektonPipelineWorkerToMap(model *cdtektonpipelinev2.Worker) (m
 	if model.Type != nil {
 		modelMap["type"] = *model.Type
 	}
-	modelMap["id"] = *model.ID
+	if model.ID != nil {
+		modelMap["id"] = *model.ID
+	}
 	return modelMap, nil
 }
 

--- a/ibm/service/cdtektonpipeline/resource_ibm_cd_tekton_pipeline_definition.go
+++ b/ibm/service/cdtektonpipeline/resource_ibm_cd_tekton_pipeline_definition.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2024 All Rights Reserved.
+// Copyright IBM Corp. 2025 All Rights Reserved.
 // Licensed under the Mozilla Public License v2.0
 
 /*
@@ -204,6 +204,10 @@ func resourceIBMCdTektonPipelineDefinitionRead(context context.Context, d *schem
 			err = fmt.Errorf("Error setting href: %s", err)
 			return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cd_tekton_pipeline_definition", "read", "set-href").GetDiag()
 		}
+	}
+	if err = d.Set("pipeline_id", parts[0]); err != nil {
+		err = fmt.Errorf("Error setting pipeline_id: %s", err)
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cd_tekton_pipeline_definition", "read", "set-pipeline_id").GetDiag()
 	}
 	if err = d.Set("definition_id", definition.ID); err != nil {
 		err = fmt.Errorf("Error setting definition_id: %s", err)

--- a/ibm/service/cdtektonpipeline/resource_ibm_cd_tekton_pipeline_definition.go
+++ b/ibm/service/cdtektonpipeline/resource_ibm_cd_tekton_pipeline_definition.go
@@ -2,7 +2,7 @@
 // Licensed under the Mozilla Public License v2.0
 
 /*
- * IBM OpenAPI Terraform Generator Version: 3.95.2-120e65bc-20240924-152329
+ * IBM OpenAPI Terraform Generator Version: 3.103.0-e8b84313-20250402-201816
  */
 
 package cdtektonpipeline
@@ -234,14 +234,10 @@ func resourceIBMCdTektonPipelineDefinitionUpdate(context context.Context, d *sch
 
 	replaceTektonPipelineDefinitionOptions.SetPipelineID(parts[0])
 	replaceTektonPipelineDefinitionOptions.SetDefinitionID(parts[1])
+	replaceTektonPipelineDefinitionOptions.SetPipelineID(d.Get("pipeline_id").(string))
 
 	hasChange := false
 
-	if d.HasChange("pipeline_id") {
-		errMsg := fmt.Sprintf("Cannot update resource property \"%s\" with the ForceNew annotation."+
-			" The resource must be re-created to update this property.", "pipeline_id")
-		return flex.DiscriminatedTerraformErrorf(nil, errMsg, "ibm_cd_tekton_pipeline_definition", "update", "pipeline_id-forces-new").GetDiag()
-	}
 	if d.HasChange("source") {
 		source, err := ResourceIBMCdTektonPipelineDefinitionMapToDefinitionSource(d.Get("source.0").(map[string]interface{}))
 		if err != nil {
@@ -250,7 +246,6 @@ func resourceIBMCdTektonPipelineDefinitionUpdate(context context.Context, d *sch
 		replaceTektonPipelineDefinitionOptions.SetSource(source)
 		hasChange = true
 	}
-
 	if hasChange {
 		_, _, err = cdTektonPipelineClient.ReplaceTektonPipelineDefinitionWithContext(context, replaceTektonPipelineDefinitionOptions)
 		if err != nil {

--- a/ibm/service/cdtektonpipeline/resource_ibm_cd_tekton_pipeline_definition_test.go
+++ b/ibm/service/cdtektonpipeline/resource_ibm_cd_tekton_pipeline_definition_test.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2024 All Rights Reserved.
+// Copyright IBM Corp. 2025 All Rights Reserved.
 // Licensed under the Mozilla Public License v2.0
 
 package cdtektonpipeline_test

--- a/ibm/service/cdtektonpipeline/resource_ibm_cd_tekton_pipeline_property.go
+++ b/ibm/service/cdtektonpipeline/resource_ibm_cd_tekton_pipeline_property.go
@@ -2,7 +2,7 @@
 // Licensed under the Mozilla Public License v2.0
 
 /*
- * IBM OpenAPI Terraform Generator Version: 3.95.2-120e65bc-20240924-152329
+ * IBM OpenAPI Terraform Generator Version: 3.103.0-e8b84313-20250402-201816
  */
 
 package cdtektonpipeline
@@ -273,26 +273,12 @@ func resourceIBMCdTektonPipelinePropertyUpdate(context context.Context, d *schem
 
 	replaceTektonPipelinePropertyOptions.SetPipelineID(parts[0])
 	replaceTektonPipelinePropertyOptions.SetPropertyName(parts[1])
+	replaceTektonPipelinePropertyOptions.SetPipelineID(d.Get("pipeline_id").(string))
 	replaceTektonPipelinePropertyOptions.SetName(d.Get("name").(string))
 	replaceTektonPipelinePropertyOptions.SetType(d.Get("type").(string))
 
 	hasChange := false
 
-	if d.HasChange("pipeline_id") {
-		errMsg := fmt.Sprintf("Cannot update resource property \"%s\" with the ForceNew annotation."+
-			" The resource must be re-created to update this property.", "pipeline_id")
-		return flex.DiscriminatedTerraformErrorf(nil, errMsg, "ibm_cd_tekton_pipeline_property", "update", "pipeline_id-forces-new").GetDiag()
-	}
-	if d.HasChange("name") {
-		errMsg := fmt.Sprintf("Cannot update resource property \"%s\" with the ForceNew annotation."+
-			" The resource must be re-created to update this property.", "name")
-		return flex.DiscriminatedTerraformErrorf(nil, errMsg, "ibm_cd_tekton_pipeline_property", "update", "name-forces-new").GetDiag()
-	}
-	if d.HasChange("type") {
-		errMsg := fmt.Sprintf("Cannot update resource property \"%s\" with the ForceNew annotation."+
-			" The resource must be re-created to update this property.", "type")
-		return flex.DiscriminatedTerraformErrorf(nil, errMsg, "ibm_cd_tekton_pipeline_property", "update", "type-forces-new").GetDiag()
-	}
 	if d.HasChange("locked") {
 		replaceTektonPipelinePropertyOptions.SetLocked(d.Get("locked").(bool))
 		hasChange = true

--- a/ibm/service/cdtektonpipeline/resource_ibm_cd_tekton_pipeline_property.go
+++ b/ibm/service/cdtektonpipeline/resource_ibm_cd_tekton_pipeline_property.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2024 All Rights Reserved.
+// Copyright IBM Corp. 2025 All Rights Reserved.
 // Licensed under the Mozilla Public License v2.0
 
 /*
@@ -210,6 +210,10 @@ func resourceIBMCdTektonPipelinePropertyRead(context context.Context, d *schema.
 		return tfErr.GetDiag()
 	}
 
+	if err = d.Set("pipeline_id", parts[0]); err != nil {
+		err = fmt.Errorf("Error setting pipeline_id: %s", err)
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cd_tekton_pipeline_property", "read", "set-pipeline_id").GetDiag()
+	}
 	if err = d.Set("name", property.Name); err != nil {
 		err = fmt.Errorf("Error setting name: %s", err)
 		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cd_tekton_pipeline_property", "read", "set-name").GetDiag()

--- a/ibm/service/cdtektonpipeline/resource_ibm_cd_tekton_pipeline_property_test.go
+++ b/ibm/service/cdtektonpipeline/resource_ibm_cd_tekton_pipeline_property_test.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2024 All Rights Reserved.
+// Copyright IBM Corp. 2025 All Rights Reserved.
 // Licensed under the Mozilla Public License v2.0
 
 package cdtektonpipeline_test

--- a/ibm/service/cdtektonpipeline/resource_ibm_cd_tekton_pipeline_test.go
+++ b/ibm/service/cdtektonpipeline/resource_ibm_cd_tekton_pipeline_test.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2024 All Rights Reserved.
+// Copyright IBM Corp. 2025 All Rights Reserved.
 // Licensed under the Mozilla Public License v2.0
 
 package cdtektonpipeline_test

--- a/ibm/service/cdtektonpipeline/resource_ibm_cd_tekton_pipeline_trigger.go
+++ b/ibm/service/cdtektonpipeline/resource_ibm_cd_tekton_pipeline_trigger.go
@@ -2,7 +2,7 @@
 // Licensed under the Mozilla Public License v2.0
 
 /*
- * IBM OpenAPI Terraform Generator Version: 3.95.2-120e65bc-20240924-152329
+ * IBM OpenAPI Terraform Generator Version: 3.103.0-e8b84313-20250402-201816
  */
 
 package cdtektonpipeline
@@ -264,7 +264,6 @@ func ResourceIBMCdTektonPipelineTrigger() *schema.Resource {
 						},
 						"href": &schema.Schema{
 							Type:        schema.TypeString,
-							Optional:    true,
 							Computed:    true,
 							Description: "API URL for interacting with the trigger property.",
 						},
@@ -951,90 +950,130 @@ func ResourceIBMCdTektonPipelineTriggerTriggerPatchAsPatch(patchVals *cdtektonpi
 	path = "type"
 	if _, exists := d.GetOk(path); d.HasChange(path) && !exists {
 		patch["type"] = nil
+	} else if !exists {
+		delete(patch, "type")
 	}
 	path = "name"
 	if _, exists := d.GetOk(path); d.HasChange(path) && !exists {
 		patch["name"] = nil
+	} else if !exists {
+		delete(patch, "name")
 	}
 	path = "event_listener"
 	if _, exists := d.GetOk(path); d.HasChange(path) && !exists {
 		patch["event_listener"] = nil
+	} else if !exists {
+		delete(patch, "event_listener")
 	}
 	path = "tags"
 	if _, exists := d.GetOk(path); d.HasChange(path) && !exists {
 		patch["tags"] = nil
+	} else if !exists {
+		delete(patch, "tags")
 	}
 	path = "worker"
 	if _, exists := d.GetOk(path); d.HasChange(path) && !exists {
 		patch["worker"] = nil
+	} else if !exists {
+		delete(patch, "worker")
 	}
 	path = "max_concurrent_runs"
 	if _, exists := d.GetOk(path); d.HasChange(path) && !exists {
 		patch["max_concurrent_runs"] = nil
+	} else if !exists {
+		delete(patch, "max_concurrent_runs")
 	}
 	path = "enabled"
 	if _, exists := d.GetOk(path); d.HasChange(path) && !exists {
 		patch["enabled"] = nil
+	} else if !exists {
+		delete(patch, "enabled")
 	}
 	path = "secret"
 	if _, exists := d.GetOk(path); d.HasChange(path) && !exists {
 		patch["secret"] = nil
 	} else if exists && patch["secret"] != nil {
-		ResourceIBMCdTektonPipelineTriggerGenericSecretAsPatch(patch["secret"].(map[string]interface{}), d)
+		ResourceIBMCdTektonPipelineTriggerGenericSecretAsPatch(patch["secret"].(map[string]interface{}), d, fmt.Sprintf("%s.0", path))
+	} else if !exists {
+		delete(patch, "secret")
 	}
 	path = "cron"
 	if _, exists := d.GetOk(path); d.HasChange(path) && !exists {
 		patch["cron"] = nil
+	} else if !exists {
+		delete(patch, "cron")
 	}
 	path = "timezone"
 	if _, exists := d.GetOk(path); d.HasChange(path) && !exists {
 		patch["timezone"] = nil
+	} else if !exists {
+		delete(patch, "timezone")
 	}
 	path = "source"
 	if _, exists := d.GetOk(path); d.HasChange(path) && !exists {
 		patch["source"] = nil
+	} else if !exists {
+		delete(patch, "source")
 	}
 	path = "events"
 	if _, exists := d.GetOk(path); d.HasChange(path) && !exists {
 		patch["events"] = nil
+	} else if !exists {
+		delete(patch, "events")
 	}
 	path = "filter"
 	if _, exists := d.GetOk(path); d.HasChange(path) && !exists {
 		patch["filter"] = nil
+	} else if !exists {
+		delete(patch, "filter")
 	}
 	path = "favorite"
 	if _, exists := d.GetOk(path); d.HasChange(path) && !exists {
 		patch["favorite"] = nil
+	} else if !exists {
+		delete(patch, "favorite")
 	}
 	path = "enable_events_from_forks"
 	if _, exists := d.GetOkExists(path); d.HasChange(path) && !exists {
 		patch["enable_events_from_forks"] = nil
+	} else if !exists {
+		delete(patch, "enable_events_from_forks")
 	}
 
 	return patch
 }
 
-func ResourceIBMCdTektonPipelineTriggerGenericSecretAsPatch(patch map[string]interface{}, d *schema.ResourceData) {
+func ResourceIBMCdTektonPipelineTriggerGenericSecretAsPatch(patch map[string]interface{}, d *schema.ResourceData, rootPath string) {
 	var path string
 
-	path = "secret.0.type"
+	path = rootPath + ".type"
 	if _, exists := d.GetOk(path); d.HasChange(path) && !exists {
 		patch["type"] = nil
+	} else if !exists {
+		delete(patch, "type")
 	}
-	path = "secret.0.value"
+	path = rootPath + ".value"
 	if _, exists := d.GetOk(path); d.HasChange(path) && !exists {
 		patch["value"] = nil
+	} else if !exists {
+		delete(patch, "value")
 	}
-	path = "secret.0.source"
+	path = rootPath + ".source"
 	if _, exists := d.GetOk(path); d.HasChange(path) && !exists {
 		patch["source"] = nil
+	} else if !exists {
+		delete(patch, "source")
 	}
-	path = "secret.0.key_name"
+	path = rootPath + ".key_name"
 	if _, exists := d.GetOk(path); d.HasChange(path) && !exists {
 		patch["key_name"] = nil
+	} else if !exists {
+		delete(patch, "key_name")
 	}
-	path = "secret.0.algorithm"
+	path = rootPath + ".algorithm"
 	if _, exists := d.GetOk(path); d.HasChange(path) && !exists {
 		patch["algorithm"] = nil
+	} else if !exists {
+		delete(patch, "algorithm")
 	}
 }

--- a/ibm/service/cdtektonpipeline/resource_ibm_cd_tekton_pipeline_trigger.go
+++ b/ibm/service/cdtektonpipeline/resource_ibm_cd_tekton_pipeline_trigger.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2024 All Rights Reserved.
+// Copyright IBM Corp. 2025 All Rights Reserved.
 // Licensed under the Mozilla Public License v2.0
 
 /*
@@ -497,6 +497,10 @@ func resourceIBMCdTektonPipelineTriggerRead(context context.Context, d *schema.R
 	}
 
 	trigger := triggerIntf.(*cdtektonpipelinev2.Trigger)
+	if err = d.Set("pipeline_id", parts[0]); err != nil {
+		err = fmt.Errorf("Error setting pipeline_id: %s", err)
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cd_tekton_pipeline_trigger", "read", "set-pipeline_id").GetDiag()
+	}
 	if err = d.Set("type", trigger.Type); err != nil {
 		err = fmt.Errorf("Error setting type: %s", err)
 		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cd_tekton_pipeline_trigger", "read", "set-type").GetDiag()
@@ -799,7 +803,9 @@ func resourceIBMCdTektonPipelineTriggerDelete(context context.Context, d *schema
 
 func ResourceIBMCdTektonPipelineTriggerMapToWorkerIdentity(modelMap map[string]interface{}) (*cdtektonpipelinev2.WorkerIdentity, error) {
 	model := &cdtektonpipelinev2.WorkerIdentity{}
-	model.ID = core.StringPtr(modelMap["id"].(string))
+	if modelMap["id"] != nil {
+		model.ID = core.StringPtr(modelMap["id"].(string))
+	}
 	return model, nil
 }
 

--- a/ibm/service/cdtektonpipeline/resource_ibm_cd_tekton_pipeline_trigger_property.go
+++ b/ibm/service/cdtektonpipeline/resource_ibm_cd_tekton_pipeline_trigger_property.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2024 All Rights Reserved.
+// Copyright IBM Corp. 2025 All Rights Reserved.
 // Licensed under the Mozilla Public License v2.0
 
 /*
@@ -228,6 +228,14 @@ func resourceIBMCdTektonPipelineTriggerPropertyRead(context context.Context, d *
 		return tfErr.GetDiag()
 	}
 
+	if err = d.Set("pipeline_id", parts[0]); err != nil {
+		err = fmt.Errorf("Error setting pipeline_id: %s", err)
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cd_tekton_pipeline_trigger_property", "read", "set-pipeline_id").GetDiag()
+	}
+	if err = d.Set("trigger_id", parts[1]); err != nil {
+		err = fmt.Errorf("Error setting trigger_id: %s", err)
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cd_tekton_pipeline_trigger_property", "read", "set-trigger_id").GetDiag()
+	}
 	if err = d.Set("name", triggerProperty.Name); err != nil {
 		err = fmt.Errorf("Error setting name: %s", err)
 		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cd_tekton_pipeline_trigger_property", "read", "set-name").GetDiag()

--- a/ibm/service/cdtektonpipeline/resource_ibm_cd_tekton_pipeline_trigger_property.go
+++ b/ibm/service/cdtektonpipeline/resource_ibm_cd_tekton_pipeline_trigger_property.go
@@ -2,7 +2,7 @@
 // Licensed under the Mozilla Public License v2.0
 
 /*
- * IBM OpenAPI Terraform Generator Version: 3.95.2-120e65bc-20240924-152329
+ * IBM OpenAPI Terraform Generator Version: 3.103.0-e8b84313-20250402-201816
  */
 
 package cdtektonpipeline
@@ -296,31 +296,13 @@ func resourceIBMCdTektonPipelineTriggerPropertyUpdate(context context.Context, d
 	replaceTektonPipelineTriggerPropertyOptions.SetPipelineID(parts[0])
 	replaceTektonPipelineTriggerPropertyOptions.SetTriggerID(parts[1])
 	replaceTektonPipelineTriggerPropertyOptions.SetPropertyName(parts[2])
+	replaceTektonPipelineTriggerPropertyOptions.SetPipelineID(d.Get("pipeline_id").(string))
+	replaceTektonPipelineTriggerPropertyOptions.SetTriggerID(d.Get("trigger_id").(string))
 	replaceTektonPipelineTriggerPropertyOptions.SetName(d.Get("name").(string))
 	replaceTektonPipelineTriggerPropertyOptions.SetType(d.Get("type").(string))
 
 	hasChange := false
 
-	if d.HasChange("pipeline_id") {
-		errMsg := fmt.Sprintf("Cannot update resource property \"%s\" with the ForceNew annotation."+
-			" The resource must be re-created to update this property.", "pipeline_id")
-		return flex.DiscriminatedTerraformErrorf(nil, errMsg, "ibm_cd_tekton_pipeline_trigger_property", "update", "pipeline_id-forces-new").GetDiag()
-	}
-	if d.HasChange("trigger_id") {
-		errMsg := fmt.Sprintf("Cannot update resource property \"%s\" with the ForceNew annotation."+
-			" The resource must be re-created to update this property.", "trigger_id")
-		return flex.DiscriminatedTerraformErrorf(nil, errMsg, "ibm_cd_tekton_pipeline_trigger_property", "update", "trigger_id-forces-new").GetDiag()
-	}
-	if d.HasChange("name") {
-		errMsg := fmt.Sprintf("Cannot update resource property \"%s\" with the ForceNew annotation."+
-			" The resource must be re-created to update this property.", "name")
-		return flex.DiscriminatedTerraformErrorf(nil, errMsg, "ibm_cd_tekton_pipeline_trigger_property", "update", "name-forces-new").GetDiag()
-	}
-	if d.HasChange("type") {
-		errMsg := fmt.Sprintf("Cannot update resource property \"%s\" with the ForceNew annotation."+
-			" The resource must be re-created to update this property.", "type")
-		return flex.DiscriminatedTerraformErrorf(nil, errMsg, "ibm_cd_tekton_pipeline_trigger_property", "update", "type-forces-new").GetDiag()
-	}
 	if d.HasChange("locked") {
 		replaceTektonPipelineTriggerPropertyOptions.SetLocked(d.Get("locked").(bool))
 		hasChange = true

--- a/ibm/service/cdtektonpipeline/resource_ibm_cd_tekton_pipeline_trigger_property_test.go
+++ b/ibm/service/cdtektonpipeline/resource_ibm_cd_tekton_pipeline_trigger_property_test.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2024 All Rights Reserved.
+// Copyright IBM Corp. 2025 All Rights Reserved.
 // Licensed under the Mozilla Public License v2.0
 
 package cdtektonpipeline_test

--- a/ibm/service/cdtektonpipeline/resource_ibm_cd_tekton_pipeline_trigger_test.go
+++ b/ibm/service/cdtektonpipeline/resource_ibm_cd_tekton_pipeline_trigger_test.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2024 All Rights Reserved.
+// Copyright IBM Corp. 2025 All Rights Reserved.
 // Licensed under the Mozilla Public License v2.0
 
 package cdtektonpipeline_test


### PR DESCRIPTION
### Description
Add some null pointer checks to fix errors when importing resources. Also make sure that pipeline_id and trigger_id are set in certain cases, to avoid resource replacement issues when importing existing resources.

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TEST=./ibm/service/cdtektonpipeline TESTARGS='-run=TestAccIBMCdTekton*'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./ibm/service/cdtektonpipeline -v -run=TestAccIBMCdTekton* -timeout 700m
=== RUN   TestAccIBMCdTektonPipelineDefinitionDataSourceBasic
--- PASS: TestAccIBMCdTektonPipelineDefinitionDataSourceBasic (71.72s)
=== RUN   TestAccIBMCdTektonPipelinePropertyDataSourceBasic
--- PASS: TestAccIBMCdTektonPipelinePropertyDataSourceBasic (63.20s)
=== RUN   TestAccIBMCdTektonPipelinePropertyDataSourceAllArgs
--- PASS: TestAccIBMCdTektonPipelinePropertyDataSourceAllArgs (55.81s)
=== RUN   TestAccIBMCdTektonPipelineDataSourceBasic
--- PASS: TestAccIBMCdTektonPipelineDataSourceBasic (63.05s)
=== RUN   TestAccIBMCdTektonPipelineDataSourceAllArgs
--- PASS: TestAccIBMCdTektonPipelineDataSourceAllArgs (60.40s)
=== RUN   TestAccIBMCdTektonPipelineTriggerPropertyDataSourceBasic
--- PASS: TestAccIBMCdTektonPipelineTriggerPropertyDataSourceBasic (67.93s)
=== RUN   TestAccIBMCdTektonPipelineTriggerPropertyDataSourceAllArgs
--- PASS: TestAccIBMCdTektonPipelineTriggerPropertyDataSourceAllArgs (69.81s)
=== RUN   TestAccIBMCdTektonPipelineTriggerDataSourceBasic
--- PASS: TestAccIBMCdTektonPipelineTriggerDataSourceBasic (62.04s)
=== RUN   TestAccIBMCdTektonPipelineTriggerDataSourceAllArgs
--- PASS: TestAccIBMCdTektonPipelineTriggerDataSourceAllArgs (68.46s)
=== RUN   TestAccIBMCdTektonPipelineDefinitionBasic
--- PASS: TestAccIBMCdTektonPipelineDefinitionBasic (89.48s)
=== RUN   TestAccIBMCdTektonPipelinePropertyBasic
--- PASS: TestAccIBMCdTektonPipelinePropertyBasic (81.96s)
=== RUN   TestAccIBMCdTektonPipelinePropertyAllArgs
--- PASS: TestAccIBMCdTektonPipelinePropertyAllArgs (130.50s)
=== RUN   TestAccIBMCdTektonPipelineBasic
--- PASS: TestAccIBMCdTektonPipelineBasic (81.03s)
=== RUN   TestAccIBMCdTektonPipelineAllArgs
--- PASS: TestAccIBMCdTektonPipelineAllArgs (132.07s)
=== RUN   TestAccIBMCdTektonPipelineTriggerPropertyBasic
--- PASS: TestAccIBMCdTektonPipelineTriggerPropertyBasic (88.16s)
=== RUN   TestAccIBMCdTektonPipelineTriggerPropertyAllArgs
--- PASS: TestAccIBMCdTektonPipelineTriggerPropertyAllArgs (141.47s)
=== RUN   TestAccIBMCdTektonPipelineTriggerBasic
--- PASS: TestAccIBMCdTektonPipelineTriggerBasic (130.25s)
=== RUN   TestAccIBMCdTektonPipelineTriggerAllArgs
--- PASS: TestAccIBMCdTektonPipelineTriggerAllArgs (182.70s)
PASS
ok      github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/cdtektonpipeline        1651.665s
```
