### PR TITLE
enhancement: improved error handling for is (ike/ipsec) policy

### DIFF
--- a/ibm/service/vpc/data_source_ibm_is_ike_policies.go
+++ b/ibm/service/vpc/data_source_ibm_is_ike_policies.go
@@ -160,7 +160,9 @@ func DataSourceIBMIsIkePolicies() *schema.Resource {
 func dataSourceIBMIsIkePoliciesRead(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	vpcClient, err := meta.(conns.ClientSession).VpcV1API()
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.DiscriminatedTerraformErrorf(err, err.Error(), "(Data) ibm_is_ike_policies", "read", "initialize-client")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	start := ""
@@ -170,10 +172,11 @@ func dataSourceIBMIsIkePoliciesRead(context context.Context, d *schema.ResourceD
 		if start != "" {
 			listIkePoliciesOptions.Start = &start
 		}
-		ikePolicyCollection, response, err := vpcClient.ListIkePoliciesWithContext(context, listIkePoliciesOptions)
+		ikePolicyCollection, _, err := vpcClient.ListIkePoliciesWithContext(context, listIkePoliciesOptions)
 		if err != nil || ikePolicyCollection == nil {
-			log.Printf("[DEBUG] ListIkePoliciesWithContext failed %s\n%s", err, response)
-			return diag.FromErr(fmt.Errorf("ListIkePoliciesWithContext failed %s\n%s", err, response))
+			tfErr := flex.TerraformErrorf(err, fmt.Sprintf("ListIkePoliciesWithContext failed %s", err), "(Data) ibm_is_ike_policies", "read")
+			log.Printf("[DEBUG] %s", tfErr.GetDebugMessage())
+			return tfErr.GetDiag()
 		}
 		start = flex.GetNext(ikePolicyCollection.Next)
 		allrecs = append(allrecs, ikePolicyCollection.IkePolicies...)
@@ -186,7 +189,7 @@ func dataSourceIBMIsIkePoliciesRead(context context.Context, d *schema.ResourceD
 
 	err = d.Set("ike_policies", dataSourceIkePolicyCollectionFlattenIkePolicies(allrecs))
 	if err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting ike_policies %s", err))
+		return flex.DiscriminatedTerraformErrorf(err, fmt.Sprintf("Error setting ike_policies %s", err), "(Data) ibm_is_ike_policies", "read", "ike_policies-set").GetDiag()
 	}
 
 	return nil

--- a/ibm/service/vpc/data_source_ibm_is_ike_policy.go
+++ b/ibm/service/vpc/data_source_ibm_is_ike_policy.go
@@ -152,7 +152,9 @@ func DataSourceIBMIsIkePolicy() *schema.Resource {
 func dataSourceIBMIsIkePolicyRead(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	vpcClient, err := meta.(conns.ClientSession).VpcV1API()
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.DiscriminatedTerraformErrorf(err, err.Error(), "(Data) ibm_is_ike_policy", "read", "initialize-client")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	name := d.Get("name").(string)
@@ -166,9 +168,11 @@ func dataSourceIBMIsIkePolicyRead(context context.Context, d *schema.ResourceDat
 			if start != "" {
 				listIkePoliciesyOptions.Start = &start
 			}
-			ikePolicies, response, err := vpcClient.ListIkePolicies(listIkePoliciesyOptions)
+			ikePolicies, _, err := vpcClient.ListIkePoliciesWithContext(context, listIkePoliciesyOptions)
 			if err != nil {
-				return diag.FromErr(fmt.Errorf("Error Fetching IKE Policies %s\n%s", err, response))
+				tfErr := flex.TerraformErrorf(err, fmt.Sprintf("ListIkePoliciesWithContext failed: %s", err.Error()), "(Data) ibm_is_ike_policy", "read")
+				log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+				return tfErr.GetDiag()
 			}
 			start = flex.GetNext(ikePolicies.Next)
 			allrecs = append(allrecs, ikePolicies.IkePolicies...)
@@ -185,8 +189,10 @@ func dataSourceIBMIsIkePolicyRead(context context.Context, d *schema.ResourceDat
 			}
 		}
 		if !ike_policy_found {
-			log.Printf("[DEBUG] No ike policy found with given name %s", name)
-			return diag.FromErr(fmt.Errorf("No ike policy found with given name %s", name))
+			err = fmt.Errorf("No ike policy found with given name %s", name)
+			tfErr := flex.TerraformErrorf(err, err.Error(), "(Data) ibm_is_ike_policy", "read")
+			log.Printf("[DEBUG] %s", tfErr.GetDebugMessage())
+			return tfErr.GetDiag()
 		}
 
 	} else {
@@ -194,58 +200,59 @@ func dataSourceIBMIsIkePolicyRead(context context.Context, d *schema.ResourceDat
 
 		getIkePolicyOptions.SetID(identifier)
 
-		ikePolicy1, response, err := vpcClient.GetIkePolicyWithContext(context, getIkePolicyOptions)
+		ikePolicy1, _, err := vpcClient.GetIkePolicyWithContext(context, getIkePolicyOptions)
 		if err != nil {
-			log.Printf("[DEBUG] GetIkePolicyWithContext failed %s\n%s", err, response)
-			return diag.FromErr(fmt.Errorf("GetIkePolicyWithContext failed %s\n%s", err, response))
+			tfErr := flex.TerraformErrorf(err, fmt.Sprintf("GetIkePolicyWithContext failed: %s", err.Error()), "(Data) ibm_is_ike_policy", "read")
+			log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+			return tfErr.GetDiag()
 		}
 		ikePolicy = ikePolicy1
 	}
 
 	d.SetId(*ikePolicy.ID)
 	if err = d.Set("authentication_algorithm", ikePolicy.AuthenticationAlgorithm); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting authentication_algorithm: %s", err))
+		return flex.DiscriminatedTerraformErrorf(err, fmt.Sprintf("Error setting authentication_algorithm: %s", err), "(Data) ibm_is_ike_policy", "read", "set-authentication_algorithm").GetDiag()
 	}
-
 	if ikePolicy.Connections != nil {
 		err = d.Set("connections", dataSourceIkePolicyFlattenConnections(ikePolicy.Connections))
 		if err != nil {
-			return diag.FromErr(fmt.Errorf("Error setting connections %s", err))
+			return flex.DiscriminatedTerraformErrorf(err, err.Error(), "(Data) ibm_is_ike_policy", "read", "connections-to-map").GetDiag()
 		}
 	}
 	if err = d.Set("created_at", flex.DateTimeToString(ikePolicy.CreatedAt)); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting created_at: %s", err))
+		return flex.DiscriminatedTerraformErrorf(err, fmt.Sprintf("Error setting created_at: %s", err), "(Data) ibm_is_ike_policy", "read", "set-created_at").GetDiag()
 	}
 	if err = d.Set("dh_group", flex.IntValue(ikePolicy.DhGroup)); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting dh_group: %s", err))
+		return flex.DiscriminatedTerraformErrorf(err, fmt.Sprintf("Error setting dh_group: %s", err), "(Data) ibm_is_ike_policy", "read", "set-dh_group").GetDiag()
 	}
 	if err = d.Set("encryption_algorithm", ikePolicy.EncryptionAlgorithm); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting encryption_algorithm: %s", err))
+		return flex.DiscriminatedTerraformErrorf(err, fmt.Sprintf("Error setting encryption_algorithm: %s", err), "(Data) ibm_is_ike_policy", "read", "set-encryption_algorithm").GetDiag()
 	}
 	if err = d.Set("href", ikePolicy.Href); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting href: %s", err))
+		return flex.DiscriminatedTerraformErrorf(err, fmt.Sprintf("Error setting href: %s", err), "(Data) ibm_is_ike_policy", "read", "set-href").GetDiag()
 	}
 	if err = d.Set("ike_version", flex.IntValue(ikePolicy.IkeVersion)); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting ike_version: %s", err))
+		return flex.DiscriminatedTerraformErrorf(err, fmt.Sprintf("Error setting ike_version: %s", err), "(Data) ibm_is_ike_policy", "read", "set-ike_version").GetDiag()
 	}
 	if err = d.Set("key_lifetime", flex.IntValue(ikePolicy.KeyLifetime)); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting key_lifetime: %s", err))
+		return flex.DiscriminatedTerraformErrorf(err, fmt.Sprintf("Error setting key_lifetime: %s", err), "(Data) ibm_is_ike_policy", "read", "set-key_lifetime").GetDiag()
 	}
+
 	if err = d.Set("name", ikePolicy.Name); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting name: %s", err))
+		return flex.DiscriminatedTerraformErrorf(err, fmt.Sprintf("Error setting name: %s", err), "(Data) ibm_is_ike_policy", "read", "set-name").GetDiag()
 	}
 	if err = d.Set("negotiation_mode", ikePolicy.NegotiationMode); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting negotiation_mode: %s", err))
+		return flex.DiscriminatedTerraformErrorf(err, fmt.Sprintf("Error setting negotiation_mode: %s", err), "(Data) ibm_is_ike_policy", "read", "set-negotiation_mode").GetDiag()
 	}
 
 	if ikePolicy.ResourceGroup != nil {
 		err = d.Set("resource_group", dataSourceIkePolicyFlattenResourceGroup(*ikePolicy.ResourceGroup))
 		if err != nil {
-			return diag.FromErr(fmt.Errorf("Error setting resource_group %s", err))
+			return flex.DiscriminatedTerraformErrorf(err, fmt.Sprintf("Error setting resource_group: %s", err), "(Data) ibm_is_ike_policy", "read", "set-resource_group").GetDiag()
 		}
 	}
 	if err = d.Set("resource_type", ikePolicy.ResourceType); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting resource_type: %s", err))
+		return flex.DiscriminatedTerraformErrorf(err, fmt.Sprintf("Error setting resource_type: %s", err), "(Data) ibm_is_ike_policy", "read", "set-resource_type").GetDiag()
 	}
 
 	return nil

--- a/ibm/service/vpc/data_source_ibm_is_ipsec_policies.go
+++ b/ibm/service/vpc/data_source_ibm_is_ipsec_policies.go
@@ -160,7 +160,9 @@ func DataSourceIBMIsIpsecPolicies() *schema.Resource {
 func dataSourceIBMIsIpsecPoliciesRead(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	vpcClient, err := meta.(conns.ClientSession).VpcV1API()
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.DiscriminatedTerraformErrorf(err, err.Error(), "(Data) ibm_is_ipsec_policies", "read", "initialize-client")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	start := ""
@@ -170,10 +172,11 @@ func dataSourceIBMIsIpsecPoliciesRead(context context.Context, d *schema.Resourc
 		if start != "" {
 			listIpsecPoliciesOptions.Start = &start
 		}
-		iPsecPolicyCollection, response, err := vpcClient.ListIpsecPoliciesWithContext(context, listIpsecPoliciesOptions)
+		iPsecPolicyCollection, _, err := vpcClient.ListIpsecPoliciesWithContext(context, listIpsecPoliciesOptions)
 		if err != nil || iPsecPolicyCollection == nil {
-			log.Printf("[DEBUG] ListIpsecPoliciesWithContext failed %s\n%s", err, response)
-			return diag.FromErr(fmt.Errorf("ListIpsecPoliciesWithContext failed %s\n%s", err, response))
+			tfErr := flex.TerraformErrorf(err, fmt.Sprintf("ListIpsecPoliciesWithContext failed %s", err), "(Data) ibm_is_ipsec_policies", "read")
+			log.Printf("[DEBUG] %s", tfErr.GetDebugMessage())
+			return tfErr.GetDiag()
 		}
 		start = flex.GetNext(iPsecPolicyCollection.Next)
 		allrecs = append(allrecs, iPsecPolicyCollection.IpsecPolicies...)
@@ -186,7 +189,7 @@ func dataSourceIBMIsIpsecPoliciesRead(context context.Context, d *schema.Resourc
 
 	err = d.Set("ipsec_policies", dataSourceIPsecPolicyCollectionFlattenIpsecPolicies(allrecs))
 	if err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting ipsec_policies %s", err))
+		return flex.DiscriminatedTerraformErrorf(err, fmt.Sprintf("Error setting ipsec_policies %s", err), "(Data) ibm_is_ipsec_policies", "read", "ipsec_policies-set").GetDiag()
 	}
 
 	return nil

--- a/ibm/service/vpc/data_source_ibm_is_ipsec_policy.go
+++ b/ibm/service/vpc/data_source_ibm_is_ipsec_policy.go
@@ -153,12 +153,14 @@ func DataSourceIBMIsIpsecPolicy() *schema.Resource {
 func dataSourceIBMIsIpsecPolicyRead(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	vpcClient, err := meta.(conns.ClientSession).VpcV1API()
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.DiscriminatedTerraformErrorf(err, err.Error(), "(Data) ibm_is_ipsec_policy", "read", "initialize-client")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	name := d.Get("name").(string)
 	identifier := d.Get("ipsec_policy").(string)
-	var IPSecPolicy *vpcv1.IPsecPolicy
+	var iPsecPolicy *vpcv1.IPsecPolicy
 	if name != "" {
 		start := ""
 		allrecs := []vpcv1.IPsecPolicy{}
@@ -167,9 +169,11 @@ func dataSourceIBMIsIpsecPolicyRead(context context.Context, d *schema.ResourceD
 			if start != "" {
 				listIPSecPoliciesyOptions.Start = &start
 			}
-			ipSecPolicy, response, err := vpcClient.ListIpsecPolicies(listIPSecPoliciesyOptions)
+			ipSecPolicy, _, err := vpcClient.ListIpsecPoliciesWithContext(context, listIPSecPoliciesyOptions)
 			if err != nil {
-				return diag.FromErr(fmt.Errorf("Error Fetching IPSec Policies %s\n%s", err, response))
+				tfErr := flex.TerraformErrorf(err, fmt.Sprintf("ListIpsecPoliciesWithContext failed: %s", err.Error()), "(Data) ibm_is_ipsec_policy", "read")
+				log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+				return tfErr.GetDiag()
 			}
 			start = flex.GetNext(ipSecPolicy.Next)
 			allrecs = append(allrecs, ipSecPolicy.IpsecPolicies...)
@@ -180,15 +184,17 @@ func dataSourceIBMIsIpsecPolicyRead(context context.Context, d *schema.ResourceD
 		ipsec_policy_found := false
 		for _, ipSecPolicyItem := range allrecs {
 			if *ipSecPolicyItem.Name == name {
-				IPSecPolicy = &ipSecPolicyItem
+				iPsecPolicy = &ipSecPolicyItem
 				ipsec_policy_found = true
 				break
 			}
 		}
 
 		if !ipsec_policy_found {
-			log.Printf("[DEBUG] No ipsec policy found with given name %s", name)
-			return diag.FromErr(fmt.Errorf("No ipsec policy found with given name %s", name))
+			err = fmt.Errorf("No ipsec policy found with given name %s", name)
+			tfErr := flex.TerraformErrorf(err, fmt.Sprintf("Not found failed: %s", err.Error()), "(Data) ibm_is_ipsec_policy", "read")
+			log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+			return tfErr.GetDiag()
 		}
 
 	} else {
@@ -196,60 +202,60 @@ func dataSourceIBMIsIpsecPolicyRead(context context.Context, d *schema.ResourceD
 
 		getIPSecPolicyOptions.SetID(identifier)
 
-		ipsecPolicy1, response, err := vpcClient.GetIpsecPolicyWithContext(context, getIPSecPolicyOptions)
+		ipsecPolicy1, _, err := vpcClient.GetIpsecPolicyWithContext(context, getIPSecPolicyOptions)
 		if err != nil {
-			log.Printf("[DEBUG] GetIpsecPolicyWithContext failed %s\n%s", err, response)
-			return diag.FromErr(fmt.Errorf("GetIpsecPolicyWithContext failed %s\n%s", err, response))
+			tfErr := flex.TerraformErrorf(err, fmt.Sprintf("GetIpsecPolicyWithContext failed: %s", err.Error()), "(Data) ibm_is_ipsec_policy", "read")
+			log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+			return tfErr.GetDiag()
 		}
-		IPSecPolicy = ipsecPolicy1
+		iPsecPolicy = ipsecPolicy1
 	}
 
-	d.SetId(*IPSecPolicy.ID)
-	if err = d.Set("authentication_algorithm", IPSecPolicy.AuthenticationAlgorithm); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting authentication_algorithm: %s", err))
+	d.SetId(*iPsecPolicy.ID)
+	if err = d.Set("authentication_algorithm", iPsecPolicy.AuthenticationAlgorithm); err != nil {
+		return flex.DiscriminatedTerraformErrorf(err, fmt.Sprintf("Error setting authentication_algorithm: %s", err), "(Data) ibm_is_ipsec_policy", "read", "set-authentication_algorithm").GetDiag()
 	}
 
-	if IPSecPolicy.Connections != nil {
-		err = d.Set("connections", dataSourceIPsecPolicyFlattenConnections(IPSecPolicy.Connections))
+	if iPsecPolicy.Connections != nil {
+		err = d.Set("connections", dataSourceIPsecPolicyFlattenConnections(iPsecPolicy.Connections))
 		if err != nil {
-			return diag.FromErr(fmt.Errorf("Error setting connections %s", err))
-		}
-	}
-	if err = d.Set("created_at", flex.DateTimeToString(IPSecPolicy.CreatedAt)); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting created_at: %s", err))
-	}
-	if err = d.Set("encapsulation_mode", IPSecPolicy.EncapsulationMode); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting encapsulation_mode: %s", err))
-	}
-	if err = d.Set("encryption_algorithm", IPSecPolicy.EncryptionAlgorithm); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting encryption_algorithm: %s", err))
-	}
-	if err = d.Set("href", IPSecPolicy.Href); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting href: %s", err))
-	}
-	if err = d.Set("key_lifetime", flex.IntValue(IPSecPolicy.KeyLifetime)); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting key_lifetime: %s", err))
-	}
-	if err = d.Set("name", IPSecPolicy.Name); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting name: %s", err))
-	}
-	if err = d.Set("pfs", IPSecPolicy.Pfs); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting pfs: %s", err))
-	}
-
-	if IPSecPolicy.ResourceGroup != nil {
-		err = d.Set("resource_group", dataSourceIPsecPolicyFlattenResourceGroup(*IPSecPolicy.ResourceGroup))
-		if err != nil {
-			return diag.FromErr(fmt.Errorf("Error setting resource_group %s", err))
+			return flex.DiscriminatedTerraformErrorf(err, err.Error(), "(Data) ibm_is_ipsec_policy", "read", "connections-to-map").GetDiag()
 		}
 	}
-	if err = d.Set("resource_type", IPSecPolicy.ResourceType); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting resource_type: %s", err))
+	if err = d.Set("created_at", flex.DateTimeToString(iPsecPolicy.CreatedAt)); err != nil {
+		return flex.DiscriminatedTerraformErrorf(err, fmt.Sprintf("Error setting created_at: %s", err), "(Data) ibm_is_ipsec_policy", "read", "set-created_at").GetDiag()
 	}
-	if err = d.Set("transform_protocol", IPSecPolicy.TransformProtocol); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting transform_protocol: %s", err))
+	if err = d.Set("encapsulation_mode", iPsecPolicy.EncapsulationMode); err != nil {
+		return flex.DiscriminatedTerraformErrorf(err, fmt.Sprintf("Error setting encapsulation_mode: %s", err), "(Data) ibm_is_ipsec_policy", "read", "set-encapsulation_mode").GetDiag()
+	}
+	if err = d.Set("encryption_algorithm", iPsecPolicy.EncryptionAlgorithm); err != nil {
+		return flex.DiscriminatedTerraformErrorf(err, fmt.Sprintf("Error setting encryption_algorithm: %s", err), "(Data) ibm_is_ipsec_policy", "read", "set-encryption_algorithm").GetDiag()
+	}
+	if err = d.Set("href", iPsecPolicy.Href); err != nil {
+		return flex.DiscriminatedTerraformErrorf(err, fmt.Sprintf("Error setting href: %s", err), "(Data) ibm_is_ipsec_policy", "read", "set-href").GetDiag()
+	}
+	if err = d.Set("key_lifetime", flex.IntValue(iPsecPolicy.KeyLifetime)); err != nil {
+		return flex.DiscriminatedTerraformErrorf(err, fmt.Sprintf("Error setting key_lifetime: %s", err), "(Data) ibm_is_ipsec_policy", "read", "set-key_lifetime").GetDiag()
+	}
+	if err = d.Set("name", iPsecPolicy.Name); err != nil {
+		return flex.DiscriminatedTerraformErrorf(err, fmt.Sprintf("Error setting name: %s", err), "(Data) ibm_is_ipsec_policy", "read", "set-name").GetDiag()
+	}
+	if err = d.Set("pfs", iPsecPolicy.Pfs); err != nil {
+		return flex.DiscriminatedTerraformErrorf(err, fmt.Sprintf("Error setting pfs: %s", err), "(Data) ibm_is_ipsec_policy", "read", "set-pfs").GetDiag()
 	}
 
+	if iPsecPolicy.ResourceGroup != nil {
+		err = d.Set("resource_group", dataSourceIPsecPolicyFlattenResourceGroup(*iPsecPolicy.ResourceGroup))
+		if err != nil {
+			return flex.DiscriminatedTerraformErrorf(err, err.Error(), "(Data) ibm_is_ipsec_policy", "read", "resource_group-to-map").GetDiag()
+		}
+	}
+	if err = d.Set("resource_type", iPsecPolicy.ResourceType); err != nil {
+		return flex.DiscriminatedTerraformErrorf(err, fmt.Sprintf("Error setting resource_type: %s", err), "(Data) ibm_is_ipsec_policy", "read", "set-resource_type").GetDiag()
+	}
+	if err = d.Set("transform_protocol", iPsecPolicy.TransformProtocol); err != nil {
+		return flex.DiscriminatedTerraformErrorf(err, fmt.Sprintf("Error setting transform_protocol: %s", err), "(Data) ibm_is_ipsec_policy", "read", "set-transform_protocol").GetDiag()
+	}
 	return nil
 }
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/IBM-Cloud/terraform-provider-ibm/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
--- PASS: TestAccIBMISIPSecPolicy_basic (45.26s)
PASS
ok      github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/vpc     47.435s

--- PASS: TestAccIBMISIKEPolicy_basic (47.55s)
PASS
ok      github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/vpc     49.393s

--- PASS: TestAccIBMIsIkePolicyDataSourceBasic (55.22s)
PASS
ok      github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/vpc     57.431s

--- PASS: TestAccIBMIsIkePoliciesDataSourceBasic (34.02s)
PASS
ok      github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/vpc     35.853s

--- PASS: TestAccIBMIsIpsecPoliciesDataSourceBasic (32.62s)
PASS
ok      github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/vpc     34.397s

--- PASS: TestAccIBMIsIpsecPolicyDataSourceBasic (56.68s)
PASS
ok      github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/vpc     58.543s
```


