### PR TITLE
Remove Logdna target option for IBM Cloud Logs Routing

### DIFF
--- a/ibm/service/logsrouting/data_source_ibm_logs-router_targets_test.go
+++ b/ibm/service/logsrouting/data_source_ibm_logs-router_targets_test.go
@@ -44,15 +44,14 @@ func testAccCheckIBMLogsRouterTargetsDataSourceConfigBasic(tenantName string) st
 	return fmt.Sprintf(`
 		 resource "ibm_logs_router_tenant" "logs_router_tenant_instance" {
 			 name = "%s"
-			 region = "br-sao"
+			 region = "ca-tor"
 			 targets {
-				 log_sink_crn = "crn:v1:bluemix:public:logdna:eu-de:a/3516b8fa0a174a71899f5affa4f18d78:3517d2ed-9429-af34-ad52-34278391cbc8::"
+				 log_sink_crn = "crn:v1:bluemix:public:logs:eu-de:a/3516b8fa0a174a71899f5affa4f18d78:3517d2ed-9429-af34-ad52-34278391cbc8::"
 				 name = "my-log-sink"
-				 type = "logdna"
+				 type = "logs"
 				 parameters {
 					 host = "www.example.com"
 					 port = 1
-					 access_credential = "%s"
 				 }
 			 }
 		 }	
@@ -61,7 +60,7 @@ func testAccCheckIBMLogsRouterTargetsDataSourceConfigBasic(tenantName string) st
 			 tenant_id = ibm_logs_router_tenant.logs_router_tenant_instance.id
 			 region = ibm_logs_router_tenant.logs_router_tenant_instance.region
 		 }
-	 `, tenantName, acc.IngestionKey)
+	 `, tenantName)
 }
 
 func TestDataSourceIBMLogsRouterTargetsTargetTypeToMap(t *testing.T) {

--- a/ibm/service/logsrouting/data_source_ibm_logs-router_tenants_test.go
+++ b/ibm/service/logsrouting/data_source_ibm_logs-router_tenants_test.go
@@ -43,15 +43,14 @@ func testAccCheckIBMLogsRouterTenantsDataSourceConfigBasic(tenantName string) st
 	return fmt.Sprintf(`
 		 resource "ibm_logs_router_tenant" "logs_router_tenant_instance" {
 			 name = "%s"
-			 region = "br-sao"
+			 region = "ca-tor"
 			 targets {
-				 log_sink_crn = "crn:v1:bluemix:public:logdna:eu-de:a/3516b8fa0a174a71899f5affa4f18d78:3517d2ed-9429-af34-ad52-34278391cbc8::"
+				 log_sink_crn = "crn:v1:bluemix:public:logs:eu-de:a/3516b8fa0a174a71899f5affa4f18d78:3517d2ed-9429-af34-ad52-34278391cbc8::"
 				 name = "my-log-sink"
-				 type = "logdna"
+				 type = "logs"
 				 parameters {
 					 host = "www.example.com"
 					 port = 1
-					 access_credential = "%s"
 				 }
 			 }
 		 }
@@ -60,7 +59,7 @@ func testAccCheckIBMLogsRouterTenantsDataSourceConfigBasic(tenantName string) st
 			 name = ibm_logs_router_tenant.logs_router_tenant_instance.name
 			 region = ibm_logs_router_tenant.logs_router_tenant_instance.region
 		 }
-	 `, tenantName, acc.IngestionKey)
+	 `, tenantName)
 }
 
 func TestDataSourceIBMLogsRouterTenantsTenantToMap(t *testing.T) {
@@ -71,10 +70,10 @@ func TestDataSourceIBMLogsRouterTenantsTenantToMap(t *testing.T) {
 
 		targetTypeModel := make(map[string]interface{})
 		targetTypeModel["id"] = "C1C1C838-A4AC-4BD7-8BC6-3173B272429D"
-		targetTypeModel["log_sink_crn"] = "crn:v1:bluemix:public:logdna:eu-de:a/3516b8fa0a174a71899f5affa4f18d78:3517d2ed-9429-af34-ad52-34278391cbc8::"
+		targetTypeModel["log_sink_crn"] = "crn:v1:bluemix:public:logs:eu-de:a/3516b8fa0a174a71899f5affa4f18d78:3517d2ed-9429-af34-ad52-34278391cbc8::"
 		targetTypeModel["name"] = "my-logdna-log-sink"
 		targetTypeModel["etag"] = "c3a43545a7f2675970671ac3a57b8db067a1866b2222e1b950ee8da612e347c6"
-		targetTypeModel["type"] = "logdna"
+		targetTypeModel["type"] = "logs"
 		targetTypeModel["created_at"] = "2024-06-20T18:30:00.143156Z"
 		targetTypeModel["updated_at"] = "2024-06-20T18:30:00.143156Z"
 		targetTypeModel["parameters"] = []map[string]interface{}{targetParametersTypeLogDnaModel}
@@ -83,8 +82,9 @@ func TestDataSourceIBMLogsRouterTenantsTenantToMap(t *testing.T) {
 		model["id"] = "8717db99-2cfb-4ba6-a033-89c994c2e9f0"
 		model["created_at"] = "2024-06-20T18:30:00.143156Z"
 		model["updated_at"] = "2024-06-20T18:30:00.143156Z"
-		model["crn"] = "crn:v1:bluemix:public:logs-router:eu-de:a/3516b8fa0a174a71899f5affa4f18d78:3517d2ed-9429-af34-ad52-34278391cbc8::"
+		model["crn"] = "crn:v1:bluemix:public:logs:eu-de:a/3516b8fa0a174a71899f5affa4f18d78:3517d2ed-9429-af34-ad52-34278391cbc8::"
 		model["name"] = "my-logging-tenant"
+		model["type"] = "logs"
 		model["etag"] = "822b4b5423e225206c1d75666595714a11925cd0f82b229839864443d6c3c049"
 		model["targets"] = []map[string]interface{}{targetTypeModel}
 
@@ -97,10 +97,10 @@ func TestDataSourceIBMLogsRouterTenantsTenantToMap(t *testing.T) {
 
 	targetTypeModel := new(ibmcloudlogsroutingv0.TargetTypeLogDna)
 	targetTypeModel.ID = CreateMockUUID("C1C1C838-A4AC-4BD7-8BC6-3173B272429D")
-	targetTypeModel.LogSinkCRN = core.StringPtr("crn:v1:bluemix:public:logdna:eu-de:a/3516b8fa0a174a71899f5affa4f18d78:3517d2ed-9429-af34-ad52-34278391cbc8::")
+	targetTypeModel.LogSinkCRN = core.StringPtr("crn:v1:bluemix:public:logs:eu-de:a/3516b8fa0a174a71899f5affa4f18d78:3517d2ed-9429-af34-ad52-34278391cbc8::")
 	targetTypeModel.Name = core.StringPtr("my-logdna-log-sink")
 	targetTypeModel.Etag = core.StringPtr("c3a43545a7f2675970671ac3a57b8db067a1866b2222e1b950ee8da612e347c6")
-	targetTypeModel.Type = core.StringPtr("logdna")
+	targetTypeModel.Type = core.StringPtr("logs")
 	targetTypeModel.CreatedAt = core.StringPtr("2024-06-20T18:30:00.143156Z")
 	targetTypeModel.UpdatedAt = core.StringPtr("2024-06-20T18:30:00.143156Z")
 	targetTypeModel.Parameters = targetParametersTypeLogDnaModel

--- a/ibm/service/logsrouting/resource_ibm_logs-router_tenant.go
+++ b/ibm/service/logsrouting/resource_ibm_logs-router_tenant.go
@@ -154,6 +154,32 @@ func ResourceIBMLogsRouterTenant() *schema.Resource {
 				Computed:    true,
 				Description: "Resource version identifier.",
 			},
+			"write_status": &schema.Schema{
+				Type:        schema.TypeList,
+				Computed:    true,
+				Description: "The status of the write attempt to the target with the provided endpoint parameters.",
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"status": &schema.Schema{
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "The status such as failed or success.",
+						},
+						"reason_for_last_failure": &schema.Schema{
+							Type:        schema.TypeString,
+							Optional:    true,
+							Computed:    true,
+							Description: "Detailed description of the cause of the failure.",
+						},
+						"last_failure": &schema.Schema{
+							Type:        schema.TypeString,
+							Optional:    true,
+							Computed:    true,
+							Description: "The timestamp of the failure.",
+						},
+					},
+				},
+			},
 		},
 	}
 }

--- a/ibm/service/logsrouting/resource_ibm_logs-router_tenant_test.go
+++ b/ibm/service/logsrouting/resource_ibm_logs-router_tenant_test.go
@@ -25,10 +25,10 @@ func TestAccIBMLogsRouterTenantBasic(t *testing.T) {
 	var conf ibmcloudlogsroutingv0.Tenant
 	name := fmt.Sprintf("tf-name-%d", acctest.RandIntRange(10, 100))
 	host := fmt.Sprintf("www.example.%d.com", acctest.RandIntRange(10, 100))
-	crn := "crn:v1:bluemix:public:logdna:eu-de:a/3516b8fa0a174a71899f5affa4f18d78:3517d2ed-9429-af34-ad52-34278391cbc8::"
+	crn := "crn:v1:bluemix:public:logs:eu-de:a/3516b8fa0a174a71899f5affa4f18d78:3517d2ed-9429-af34-ad52-34278391cbc8::"
 	nameUpdate := fmt.Sprintf("tf-name-%d", acctest.RandIntRange(10, 100))
 	hostUpdate := fmt.Sprintf("www.example.%d.com", acctest.RandIntRange(10, 100))
-	crnUpdate := "crn:v1:bluemix:public:logdna:eu-de:a/3516b8fa0a174a71899f5affa4f18d78:3517d2ed-9429-af34-ad52-34278391cbc8::"
+	crnUpdate := "crn:v1:bluemix:public:logs:eu-de:a/3516b8fa0a174a71899f5affa4f18d78:3517d2ed-9429-af34-ad52-34278391cbc8::"
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { acc.TestAccPreCheck(t) },
@@ -72,13 +72,11 @@ func TestAccIBMLogsRouterTenantAllArgs(t *testing.T) {
 	host0 := fmt.Sprintf("www.example.%d.com", acctest.RandIntRange(10, 100))
 	port0 := acctest.RandIntRange(1, 9999)
 	target0Name := fmt.Sprintf("target-%s", acctest.RandString(4))
-	accessCredential := fmt.Sprintf("access-%s", acctest.RandString(4))
 
 	nameUpdate := fmt.Sprintf("tenant-name-%d", acctest.RandIntRange(10, 100))
 	host0Update := fmt.Sprintf("www.example.%d.com", acctest.RandIntRange(10, 100))
 	port0Update := acctest.RandIntRange(1, 9999)
 	target0NameUpdate := fmt.Sprintf("target-%s", acctest.RandString(4))
-	accessCredentialUpdate := fmt.Sprintf("access-%s", acctest.RandString(4))
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { acc.TestAccPreCheck(t) },
@@ -86,14 +84,14 @@ func TestAccIBMLogsRouterTenantAllArgs(t *testing.T) {
 		CheckDestroy: testAccCheckIBMLogsRouterTenantDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
-				Config: testAccCheckIBMLogsRouterTenantConfigAllArgs(name, target0Name, host0, port0, accessCredential),
+				Config: testAccCheckIBMLogsRouterTenantConfigAllArgs(name, target0Name, host0, port0),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckIBMLogsRouterTenantExists("ibm_logs_router_tenant.logs_router_tenant_instance", conf),
 					resource.TestCheckResourceAttr("ibm_logs_router_tenant.logs_router_tenant_instance", "name", name),
 				),
 			},
 			resource.TestStep{
-				Config: testAccCheckIBMLogsRouterTenantConfigAllArgs(nameUpdate, target0NameUpdate, host0Update, port0Update, accessCredentialUpdate),
+				Config: testAccCheckIBMLogsRouterTenantConfigAllArgs(nameUpdate, target0NameUpdate, host0Update, port0Update),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr("ibm_logs_router_tenant.logs_router_tenant_instance", "name", nameUpdate),
 				),
@@ -119,36 +117,34 @@ func testAccCheckIBMLogsRouterTenantConfigBasic(name string, crn string, host st
 	return fmt.Sprintf(`
 		resource "ibm_logs_router_tenant" "logs_router_tenant_instance" {
 			name = "%s"
-			region = "br-sao"
+			region = "ca-tor"
 			targets {
 				log_sink_crn = "%s"
 				name = "my-log-sink"
 				parameters {
 					host = "%s"
 					port = 1
-					access_credential = "%s"
 				}
 			}
 		}
-		`, name, crn, host, acc.IngestionKey)
+		`, name, crn, host)
 }
 
-func testAccCheckIBMLogsRouterTenantConfigAllArgs(name string, target0Name string, host0 string, port0 int, accessCredential string) string {
+func testAccCheckIBMLogsRouterTenantConfigAllArgs(name string, target0Name string, host0 string, port0 int) string {
 	return fmt.Sprintf(`
 		resource "ibm_logs_router_tenant" "logs_router_tenant_instance" {
 			name = "%s"
-			region = "br-sao"
+			region = "ca-tor"
 			targets {
-				log_sink_crn = "crn:v1:bluemix:public:logdna:eu-de:a/3516b8fa0a174a71899f5affa4f18d78:3517d2ed-9429-af34-ad52-34278391cbc8::"
+				log_sink_crn = "crn:v1:bluemix:public:logs:eu-de:a/3516b8fa0a174a71899f5affa4f18d78:3517d2ed-9429-af34-ad52-34278391cbc8::"
 				name = "%s"
 				parameters {
 					host = "%s"
 					port = %d
-					access_credential = "%s"
 				}
 			}
 		}
-		`, name, target0Name, host0, port0, accessCredential)
+		`, name, target0Name, host0, port0)
 }
 
 func testAccCheckIBMLogsRouterTenantExists(n string, obj ibmcloudlogsroutingv0.Tenant) resource.TestCheckFunc {

--- a/website/docs/d/logs-router_targets.html.markdown
+++ b/website/docs/d/logs-router_targets.html.markdown
@@ -47,14 +47,14 @@ Nested schema for **targets**:
 	  * Constraints: The maximum length is `256` characters. The minimum length is `1` character. The value must match regular expression `/[a-z,A-Z,0-9,:,-]/`.
 	* `name` - (String) The name for this tenant target. The name is unique across all targets for this tenant.
 	  * Constraints: The maximum length is `35` characters. The minimum length is `1` character. The value must match regular expression `/[a-z,A-Z,0-9,-,.]/`.
-	* `parameters` - (List) List of properties returned from a successful list operation for a log-sink of type IBM Log Analysis (logdna).
+	* `parameters` - (List) List of properties returned from a successful list operation for a log-sink of type IBM Cloud Logs.
 	Nested schema for **parameters**:
 		* `host` - (String) Host name of the log-sink.
 		  * Constraints: The maximum length is `256` characters. The minimum length is `1` character. The value must match regular expression `/[a-z,A-Z,0-9,-,.]/`.
 		* `port` - (Integer) Network port of the log-sink.
 		  * Constraints: The maximum value is `65535`. The minimum value is `1`.
 	* `type` - (String) Type of log-sink. Identical to the <code>service-name</code> segment of <code>log_sink_crn</code>.
-	  * Constraints: Allowable values are: `logdna`.
+	  * Constraints: Allowable values are: `logs`.
 	* `updated_at` - (String) Time stamp the target was last updated.
 	  * Constraints: The maximum length is `36` characters. The minimum length is `1` character. The value must match regular expression `/[0-9,:,.,-,T,Z]/`.
 

--- a/website/docs/d/logs-router_tenants.html.markdown
+++ b/website/docs/d/logs-router_tenants.html.markdown
@@ -57,14 +57,14 @@ Nested schema for **tenants**:
 		  * Constraints: The maximum length is `256` characters. The minimum length is `1` character. The value must match regular expression `/[a-z,A-Z,0-9,:,-]/`.
 		* `name` - (String) The name for this tenant target. The name is unique across all targets for this tenant.
 		  * Constraints: The maximum length is `35` characters. The minimum length is `1` character. The value must match regular expression `/[a-z,A-Z,0-9,-,.]/`.
-		* `parameters` - (List) List of properties returned from a successful list operation for a log-sink of type IBM Log Analysis (logdna).
+		* `parameters` - (List) List of properties returned from a successful list operation for a log-sink of type IBM Cloud Logs.
 		Nested schema for **parameters**:
 			* `host` - (String) Host name of the log-sink.
 			  * Constraints: The maximum length is `256` characters. The minimum length is `1` character. The value must match regular expression `/[a-z,A-Z,0-9,-,.]/`.
 			* `port` - (Integer) Network port of the log-sink.
 			  * Constraints: The maximum value is `65535`. The minimum value is `1`.
 		* `type` - (String) Type of log-sink. Identical to the <code>service-name</code> segment of <code>log_sink_crn</code>.
-		  * Constraints: Allowable values are: `logdna`.
+		  * Constraints: Allowable values are: `logs`.
 		* `updated_at` - (String) Time stamp the target was last updated.
 		  * Constraints: The maximum length is `36` characters. The minimum length is `1` character. The value must match regular expression `/[0-9,:,.,-,T,Z]/`.
 	* `updated_at` - (String) Time stamp the tenant was last updated.

--- a/website/docs/r/logs-router_tenant.html.markdown
+++ b/website/docs/r/logs-router_tenant.html.markdown
@@ -56,13 +56,12 @@ Nested schema for **targets**:
 	  * Constraints: The maximum length is `256` characters. The minimum length is `1` character. The value must match regular expression `/[a-z,A-Z,0-9,:,-]/`.
 	* `name` - (Optional, String) The name for this tenant target. The name is unique across all targets for this tenant.
 	  * Constraints: The maximum length is `35` characters. The minimum length is `1` character. The value must match regular expression `/[a-z,A-Z,0-9,-,.]/`.
-	* `parameters` - (Required, List) List of properties returned from a successful list operation for a log-sink of type IBM Log Analysis (logdna).
+	* `parameters` - (Required, List) List of properties returned from a successful list operation for a log-sink of type IBM Cloud Logs.
 	Nested schema for **parameters**:
 		* `host` - (Required, String) Host name of the log-sink.
 		  * Constraints: The maximum length is `256` characters. The minimum length is `1` character. The value must match regular expression `/[a-z,A-Z,0-9,-,.]/`.
 		* `port` - (Required, Integer) Network port of the log-sink.
 		  * Constraints: The maximum value is `65535`. The minimum value is `1`.
-		* `access_credential` - (Optional, String) Secret to connect to the Mezmo log-sink. This is not required for log-sink of type Cloud Logs.
 
 
 ## Attribute Reference


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/IBM-Cloud/terraform-provider-ibm/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test $(go list ./... |grep 'routing') -v  -timeout 700m
[WARN] Set the environment variable INGESTION_KEY for testing Logdna targets, the tests will fail if this is not set
=== RUN   TestAccIBMLogsRouterTargetsDataSourceBasic
--- PASS: TestAccIBMLogsRouterTargetsDataSourceBasic (83.38s)
=== RUN   TestDataSourceIBMLogsRouterTargetsTargetTypeToMap
--- PASS: TestDataSourceIBMLogsRouterTargetsTargetTypeToMap (0.00s)
=== RUN   TestDataSourceIBMLogsRouterTargetsTargetParametersTypeLogDnaToMap
--- PASS: TestDataSourceIBMLogsRouterTargetsTargetParametersTypeLogDnaToMap (0.00s)
=== RUN   TestDataSourceIBMLogsRouterTargetsTargetTypeLogDnaToMap
--- PASS: TestDataSourceIBMLogsRouterTargetsTargetTypeLogDnaToMap (0.00s)
=== RUN   TestDataSourceIBMLogsRouterTargetsTargetTypeLogsToMap
--- PASS: TestDataSourceIBMLogsRouterTargetsTargetTypeLogsToMap (0.00s)
=== RUN   TestDataSourceIBMLogsRouterTargetsTargetParametersTypeLogsToMap
--- PASS: TestDataSourceIBMLogsRouterTargetsTargetParametersTypeLogsToMap (0.00s)
=== RUN   TestAccIBMLogsRouterTenantsDataSourceBasic
--- PASS: TestAccIBMLogsRouterTenantsDataSourceBasic (82.84s)
=== RUN   TestDataSourceIBMLogsRouterTenantsTargetTypeToMap
--- PASS: TestDataSourceIBMLogsRouterTenantsTargetTypeToMap (0.00s)
=== RUN   TestDataSourceIBMLogsRouterTenantsTargetParametersTypeLogDnaToMap
--- PASS: TestDataSourceIBMLogsRouterTenantsTargetParametersTypeLogDnaToMap (0.00s)
=== RUN   TestDataSourceIBMLogsRouterTenantsTargetTypeLogDnaToMap
--- PASS: TestDataSourceIBMLogsRouterTenantsTargetTypeLogDnaToMap (0.00s)
=== RUN   TestDataSourceIBMLogsRouterTenantsTargetTypeLogsToMap
--- PASS: TestDataSourceIBMLogsRouterTenantsTargetTypeLogsToMap (0.00s)
=== RUN   TestDataSourceIBMLogsRouterTenantsTargetParametersTypeLogsToMap
--- PASS: TestDataSourceIBMLogsRouterTenantsTargetParametersTypeLogsToMap (0.00s)
=== RUN   TestAccIBMLogsRouterTenantBasic
--- PASS: TestAccIBMLogsRouterTenantBasic (89.59s)
=== RUN   TestAccIBMLogsRouterTenantAllArgs
--- PASS: TestAccIBMLogsRouterTenantAllArgs (85.96s)
=== RUN   TestResourceIBMLogsRouterTenantTargetTypeToMap
--- PASS: TestResourceIBMLogsRouterTenantTargetTypeToMap (0.00s)
=== RUN   TestResourceIBMLogsRouterTenantTargetParametersTypeLogDnaToMap
--- PASS: TestResourceIBMLogsRouterTenantTargetParametersTypeLogDnaToMap (0.00s)
=== RUN   TestResourceIBMLogsRouterTenantTargetTypeLogDnaToMap
--- PASS: TestResourceIBMLogsRouterTenantTargetTypeLogDnaToMap (0.00s)
=== RUN   TestResourceIBMLogsRouterTenantTargetTypeLogsToMap
--- PASS: TestResourceIBMLogsRouterTenantTargetTypeLogsToMap (0.00s)
=== RUN   TestResourceIBMLogsRouterTenantTargetParametersTypeLogsToMap
--- PASS: TestResourceIBMLogsRouterTenantTargetParametersTypeLogsToMap (0.00s)
=== RUN   TestResourceIBMLogsRouterTenantMapToTargetTypePrototype
--- PASS: TestResourceIBMLogsRouterTenantMapToTargetTypePrototype (0.00s)
=== RUN   TestResourceIBMLogsRouterTenantMapToTargetParametersTypeLogDnaPrototype
--- PASS: TestResourceIBMLogsRouterTenantMapToTargetParametersTypeLogDnaPrototype (0.00s)
=== RUN   TestResourceIBMLogsRouterTenantMapToTargetTypePrototypeTargetTypeLogDnaPrototype
--- PASS: TestResourceIBMLogsRouterTenantMapToTargetTypePrototypeTargetTypeLogDnaPrototype (0.00s)
=== RUN   TestResourceIBMLogsRouterTenantMapToTargetTypePrototypeTargetTypeLogsPrototype
--- PASS: TestResourceIBMLogsRouterTenantMapToTargetTypePrototypeTargetTypeLogsPrototype (0.00s)
=== RUN   TestResourceIBMLogsRouterTenantMapToTargetParametersTypeLogsPrototype
--- PASS: TestResourceIBMLogsRouterTenantMapToTargetParametersTypeLogsPrototype (0.00s)
PASS
ok  	github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/logsrouting	408.136s
...
```
