### PR TITLE
enhancement: improved error handling for is_floating_ip(s)

### DIFF
--- a/ibm/service/vpc/data_source_ibm_is_floating_ip.go
+++ b/ibm/service/vpc/data_source_ibm_is_floating_ip.go
@@ -4,12 +4,15 @@
 package vpc
 
 import (
+	"context"
 	"fmt"
 	"log"
 	"reflect"
 
+	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/conns"
 	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/flex"
 	"github.com/IBM/vpc-go-sdk/vpcv1"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
@@ -39,7 +42,7 @@ const (
 
 func DataSourceIBMISFloatingIP() *schema.Resource {
 	return &schema.Resource{
-		Read: dataSourceIBMISFloatingIPRead,
+		ReadContext: dataSourceIBMISFloatingIPRead,
 
 		Schema: map[string]*schema.Schema{
 
@@ -181,19 +184,21 @@ func DataSourceIBMISFloatingIP() *schema.Resource {
 	}
 }
 
-func dataSourceIBMISFloatingIPRead(d *schema.ResourceData, meta interface{}) error {
+func dataSourceIBMISFloatingIPRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	floatingIPName := d.Get(isFloatingIPName).(string)
-	err := floatingIPGet(d, meta, floatingIPName)
-	if err != nil {
-		return err
+	diag := floatingIPGet(ctx, d, meta, floatingIPName)
+	if diag != nil {
+		return diag
 	}
 	return nil
 }
 
-func floatingIPGet(d *schema.ResourceData, meta interface{}, name string) error {
-	sess, err := vpcClient(meta)
+func floatingIPGet(ctx context.Context, d *schema.ResourceData, meta interface{}, name string) diag.Diagnostics { // Changed return type
+	vpcClient, err := meta.(conns.ClientSession).VpcV1API()
 	if err != nil {
-		return err
+		tfErr := flex.DiscriminatedTerraformErrorf(err, err.Error(), "(Data) ibm_ibm_is_floating_ip", "read", "initialize-client")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	start := ""
@@ -203,9 +208,11 @@ func floatingIPGet(d *schema.ResourceData, meta interface{}, name string) error 
 		if start != "" {
 			floatingIPOptions.Start = &start
 		}
-		floatingIPs, response, err := sess.ListFloatingIps(floatingIPOptions)
+		floatingIPs, _, err := vpcClient.ListFloatingIpsWithContext(ctx, floatingIPOptions) // Use WithContext
 		if err != nil {
-			return fmt.Errorf("[ERROR] Error Fetching floating IPs %s\n%s", err, response)
+			tfErr := flex.TerraformErrorf(err, fmt.Sprintf("ListFloatingIpsWithContext failed: %s", err.Error()), "(Data) ibm_ibm_is_floating_ip", "read")
+			log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+			return tfErr.GetDiag()
 		}
 		start = flex.GetNext(floatingIPs.Next)
 		allFloatingIPs = append(allFloatingIPs, floatingIPs.FloatingIps...)
@@ -214,42 +221,61 @@ func floatingIPGet(d *schema.ResourceData, meta interface{}, name string) error 
 		}
 	}
 
-	for _, ip := range allFloatingIPs {
-		if *ip.Name == name {
+	for _, floatingIP := range allFloatingIPs {
+		if *floatingIP.Name == name {
 
-			d.Set(floatingIPName, *ip.Name)
-			d.Set(floatingIPAddress, *ip.Address)
-			d.Set(floatingIPStatus, *ip.Status)
-			d.Set(floatingIPZone, *ip.Zone.Name)
+			if err = d.Set("name", floatingIP.Name); err != nil {
+				return flex.DiscriminatedTerraformErrorf(err, fmt.Sprintf("Error setting name: %s", err), "(Data) ibm_ibm_is_floating_ip", "read", "set-name").GetDiag()
+			}
+			if err = d.Set("address", floatingIP.Address); err != nil {
+				return flex.DiscriminatedTerraformErrorf(err, fmt.Sprintf("Error setting address: %s", err), "(Data) ibm_ibm_is_floating_ip", "read", "set-address").GetDiag()
+			}
+			if err = d.Set("status", floatingIP.Status); err != nil {
+				return flex.DiscriminatedTerraformErrorf(err, fmt.Sprintf("Error setting status: %s", err), "(Data) ibm_ibm_is_floating_ip", "read", "set-status").GetDiag()
+			}
+			if err = d.Set(floatingIPZone, *floatingIP.Zone.Name); err != nil {
+				return flex.DiscriminatedTerraformErrorf(err, fmt.Sprintf("Error setting zone: %s", err), "(Data) ibm_ibm_is_floating_ip", "read", "set-zone").GetDiag()
+			}
+			if err = d.Set("crn", floatingIP.CRN); err != nil {
+				return flex.DiscriminatedTerraformErrorf(err, fmt.Sprintf("Error setting crn: %s", err), "(Data) ibm_ibm_is_floating_ip", "read", "set-crn").GetDiag()
+			}
 
-			d.Set(floatingIPCRN, *ip.CRN)
-			if ip.Target != nil {
-				targetId, targetMap := dataSourceFloatingIPCollectionFloatingIpTargetToMap(ip.Target)
-				d.Set(floatingIPTarget, targetId)
+			if floatingIP.Target != nil {
+				targetId, targetMap := dataSourceFloatingIPCollectionFloatingIpTargetToMap(floatingIP.Target)
+				if err = d.Set(floatingIPTarget, targetId); err != nil { // We don't use targetID, it's not even useful in set
+					return flex.DiscriminatedTerraformErrorf(err, fmt.Sprintf("Error setting target: %s", err), "(Data) ibm_ibm_is_floating_ip", "read", "set-target").GetDiag()
+				}
 				targetList := []map[string]interface{}{}
 				targetList = append(targetList, targetMap)
-				d.Set(floatingIPTargets, targetList)
+				if err = d.Set(floatingIPTargets, targetList); err != nil {
+					return flex.DiscriminatedTerraformErrorf(err, fmt.Sprintf("Error setting target_list: %s", err), "(Data) ibm_ibm_is_floating_ip", "read", "set-target_list").GetDiag()
+				}
 			}
 
-			tags, err := flex.GetGlobalTagsUsingCRN(meta, *ip.CRN, "", isUserTagType)
+			tags, err := flex.GetGlobalTagsUsingCRN(meta, *floatingIP.CRN, "", isUserTagType)
 			if err != nil {
-				fmt.Printf("[ERROR] Error on get of vpc Floating IP (%s) tags: %s", *ip.Address, err)
+				log.Printf("Error on get of vpc Floating IP (%s) tags: %s", *floatingIP.Address, err)
+			}
+			if err = d.Set(floatingIPTags, tags); err != nil { // Use d.Set and check error
+				return flex.DiscriminatedTerraformErrorf(err, fmt.Sprintf("Error setting tags: %s", err), "(Data) ibm_ibm_is_floating_ip", "read", "set-tags").GetDiag()
 			}
 
-			d.Set(floatingIPTags, tags)
-			accesstags, err := flex.GetGlobalTagsUsingCRN(meta, *ip.CRN, "", isAccessTagType)
+			accesstags, err := flex.GetGlobalTagsUsingCRN(meta, *floatingIP.CRN, "", isAccessTagType)
 			if err != nil {
 				log.Printf(
 					"Error on get of resource floating ip (%s) access tags: %s", d.Id(), err)
 			}
-			d.Set(isFloatingIPAccessTags, accesstags)
-			d.SetId(*ip.ID)
+			if err = d.Set(isFloatingIPAccessTags, accesstags); err != nil { // Use d.Set and check error
+				return flex.DiscriminatedTerraformErrorf(err, fmt.Sprintf("Error setting access_tags: %s", err), "(Data) ibm_ibm_is_floating_ip", "read", "set-access_tags").GetDiag()
+			}
+			d.SetId(*floatingIP.ID)
 
 			return nil
 		}
 	}
 
-	return fmt.Errorf("[ERROR] No floatingIP found with name  %s", name)
+	err = fmt.Errorf("No floatingIP found with name %s", name)
+	return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_is_floating_ip", "read", "not-found").GetDiag()
 
 }
 

--- a/ibm/service/vpc/data_source_ibm_is_floating_ips_test.go
+++ b/ibm/service/vpc/data_source_ibm_is_floating_ips_test.go
@@ -15,7 +15,6 @@ import (
 )
 
 func TestAccIBMIsFloatingIpsDataSourceBasic(t *testing.T) {
-
 	vpcname := fmt.Sprintf("tfip-vpc-%d", acctest.RandIntRange(10, 100))
 	fipname := fmt.Sprintf("tfip-%d", acctest.RandIntRange(10, 100))
 	instancename := fmt.Sprintf("tfip-instance-%d", acctest.RandIntRange(10, 100))
@@ -24,6 +23,7 @@ func TestAccIBMIsFloatingIpsDataSourceBasic(t *testing.T) {
 ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCKVmnMOlHKcZK8tpt3MP1lqOLAcqcJzhsvJcjscgVERRN7/9484SOBJ3HSKxxNG5JN8owAjy5f9yYwcUg+JaUVuytn5Pv3aeYROHGGg+5G346xaq3DAwX6Y5ykr2fvjObgncQBnuU5KHWCECO/4h8uWuwh/kfniXPVjFToc+gnkqA+3RKpAecZhFXwfalQ9mMuYGFxn+fwn8cYEApsJbsEmb0iJwPiZ5hjFC8wREuiTlhPHDgkBLOiycd20op2nXzDbHfCHInquEe/gYxEitALONxm0swBOwJZwlTDOB7C6y2dzlrtxr1L59m7pCkWI4EtTRLvleehBoj3u7jB4usR
 `)
 	sshname := fmt.Sprintf("tfip-sshname-%d", acctest.RandIntRange(10, 100))
+	dataSourceName := "data.ibm_is_floating_ips.is_floating_ips"
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:  func() { acc.TestAccPreCheck(t) },
@@ -32,13 +32,49 @@ ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCKVmnMOlHKcZK8tpt3MP1lqOLAcqcJzhsvJcjscgVE
 			{
 				Config: testAccCheckIBMIsFloatingIpsDataSourceConfigBasic(vpcname, subnetname, sshname, publicKey, instancename, fipname),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttrSet("data.ibm_is_floating_ips.is_floating_ips", "id"),
-					resource.TestCheckResourceAttrSet("data.ibm_is_floating_ips.is_floating_ips", "floating_ips.#"),
-					resource.TestCheckResourceAttrSet("data.ibm_is_floating_ips.is_floating_ips", "floating_ips.0.target.0.primary_ip.0.address"),
-					resource.TestCheckResourceAttrSet("data.ibm_is_floating_ips.is_floating_ips", "floating_ips.0.target.0.primary_ip.0.name"),
-					resource.TestCheckResourceAttrSet("data.ibm_is_floating_ips.is_floating_ips", "floating_ips.0.target.0.primary_ip.0.href"),
-					resource.TestCheckResourceAttrSet("data.ibm_is_floating_ips.is_floating_ips", "floating_ips.0.target.0.primary_ip.0.reserved_ip"),
-					resource.TestCheckResourceAttrSet("data.ibm_is_floating_ips.is_floating_ips", "floating_ips.0.target.0.primary_ip.0.resource_type"),
+					// Check basic data source attributes
+					resource.TestCheckResourceAttrSet(dataSourceName, "id"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "floating_ips.#"),
+
+					// Verify we can find our created floating IP in the list
+					resource.TestCheckTypeSetElemNestedAttrs(dataSourceName, "floating_ips.*", map[string]string{
+						"name": fipname,
+					}),
+
+					// Check detailed attributes of the first floating IP
+					resource.TestCheckResourceAttrSet(dataSourceName, "floating_ips.0.id"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "floating_ips.0.name"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "floating_ips.0.address"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "floating_ips.0.status"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "floating_ips.0.crn"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "floating_ips.0.created_at"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "floating_ips.0.href"),
+
+					// Check zone information
+					resource.TestCheckResourceAttrSet(dataSourceName, "floating_ips.0.zone.#"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "floating_ips.0.zone.0.name"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "floating_ips.0.zone.0.href"),
+
+					// Check resource group
+					resource.TestCheckResourceAttrSet(dataSourceName, "floating_ips.0.resource_group.#"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "floating_ips.0.resource_group.0.id"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "floating_ips.0.resource_group.0.name"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "floating_ips.0.resource_group.0.href"),
+
+					// Check target information if it exists
+					resource.TestCheckResourceAttrSet(dataSourceName, "floating_ips.0.target.#"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "floating_ips.0.target.0.id"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "floating_ips.0.target.0.name"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "floating_ips.0.target.0.href"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "floating_ips.0.target.0.resource_type"),
+
+					// Check primary_ip information
+					resource.TestCheckResourceAttrSet(dataSourceName, "floating_ips.0.target.0.primary_ip.#"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "floating_ips.0.target.0.primary_ip.0.address"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "floating_ips.0.target.0.primary_ip.0.name"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "floating_ips.0.target.0.primary_ip.0.href"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "floating_ips.0.target.0.primary_ip.0.reserved_ip"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "floating_ips.0.target.0.primary_ip.0.resource_type"),
 				),
 			},
 		},
@@ -46,45 +82,88 @@ ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCKVmnMOlHKcZK8tpt3MP1lqOLAcqcJzhsvJcjscgVE
 }
 
 func testAccCheckIBMIsFloatingIpsDataSourceConfigBasic(vpcname, subnetname, sshname, publicKey, instancename, fipname string) string {
-	// status filter defaults to empty
 	return fmt.Sprintf(`
-
 	resource "ibm_is_vpc" "testacc_vpc" {
 		name = "%s"
-	  }
+	}
 	  
-	  resource "ibm_is_subnet" "testacc_subnet" {
+	resource "ibm_is_subnet" "testacc_subnet" {
 		name            = "%s"
 		vpc             = ibm_is_vpc.testacc_vpc.id
 		zone            = "%s"
 		ipv4_cidr_block = "%s"
-	  }
+	}
 	  
-	  resource "ibm_is_ssh_key" "testacc_sshkey" {
+	resource "ibm_is_ssh_key" "testacc_sshkey" {
 		name       = "%s"
 		public_key = "%s"
-	  }
+	}
 	  
-	  resource "ibm_is_instance" "testacc_instance" {
+	resource "ibm_is_instance" "testacc_instance" {
 		name    = "%s"
 		image   = "%s"
 		profile = "%s"
 		primary_network_interface {
-		  port_speed = "100"
-		  subnet     = ibm_is_subnet.testacc_subnet.id
+			subnet = ibm_is_subnet.testacc_subnet.id
 		}
 		vpc  = ibm_is_vpc.testacc_vpc.id
 		zone = "%s"
 		keys = [ibm_is_ssh_key.testacc_sshkey.id]
-	  }
+	}
 	  
-	  resource "ibm_is_floating_ip" "testacc_floatingip" {
+	resource "ibm_is_floating_ip" "testacc_floatingip" {
 		name   = "%s"
 		target = ibm_is_instance.testacc_instance.primary_network_interface[0].id
-	  }
+	}
 
-	  data "ibm_is_floating_ips" "is_floating_ips" {
-		name   = ibm_is_floating_ip.testacc_floatingip.name
-	  }
-	  `, vpcname, subnetname, acc.ISZoneName, acc.ISCIDR, sshname, publicKey, instancename, acc.IsImage, acc.InstanceProfileName, acc.ISZoneName, fipname)
+	data "ibm_is_floating_ips" "is_floating_ips" {
+		name = ibm_is_floating_ip.testacc_floatingip.name
+		depends_on = [ibm_is_floating_ip.testacc_floatingip]
+	}
+	`, vpcname, subnetname, acc.ISZoneName, acc.ISCIDR, sshname, publicKey, instancename, acc.IsImage, acc.InstanceProfileName, acc.ISZoneName, fipname)
+}
+
+func TestAccIBMIsFloatingIpsDataSourceWithResourceGroup(t *testing.T) {
+	vpcname := fmt.Sprintf("tfip-vpc-rg-%d", acctest.RandIntRange(10, 100))
+	fipname := fmt.Sprintf("tfip-rg-%d", acctest.RandIntRange(10, 100))
+	dataSourceName := "data.ibm_is_floating_ips.is_floating_ips_with_rg"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { acc.TestAccPreCheck(t) },
+		Providers: acc.TestAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckIBMIsFloatingIpsDataSourceWithResourceGroup(vpcname, fipname),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet(dataSourceName, "id"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "floating_ips.#"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "floating_ips.0.resource_group.0.id"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "floating_ips.0.resource_group.0.name"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckIBMIsFloatingIpsDataSourceWithResourceGroup(vpcname, fipname string) string {
+	return fmt.Sprintf(`
+	data "ibm_resource_group" "default" {
+		name = "Default"
+	}
+
+	resource "ibm_is_vpc" "testacc_vpc" {
+		name = "%s"
+	}
+
+	resource "ibm_is_floating_ip" "testacc_floatingip_rg" {
+		name = "%s"
+		zone = "%s"
+		resource_group = data.ibm_resource_group.default.id
+	}
+
+	data "ibm_is_floating_ips" "is_floating_ips_with_rg" {
+		resource_group = data.ibm_resource_group.default.id
+		depends_on = [ibm_is_floating_ip.testacc_floatingip_rg]
+	}
+	`, vpcname, fipname, acc.ISZoneName)
 }

--- a/ibm/service/vpc/resource_ibm_is_floating_ip.go
+++ b/ibm/service/vpc/resource_ibm_is_floating_ip.go
@@ -15,6 +15,7 @@ import (
 	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/flex"
 	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/validate"
 	"github.com/IBM/vpc-go-sdk/vpcv1"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/customdiff"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -40,12 +41,12 @@ const (
 
 func ResourceIBMISFloatingIP() *schema.Resource {
 	return &schema.Resource{
-		Create:   resourceIBMISFloatingIPCreate,
-		Read:     resourceIBMISFloatingIPRead,
-		Update:   resourceIBMISFloatingIPUpdate,
-		Delete:   resourceIBMISFloatingIPDelete,
-		Exists:   resourceIBMISFloatingIPExists,
-		Importer: &schema.ResourceImporter{},
+		CreateContext: resourceIBMISFloatingIPCreate,
+		ReadContext:   resourceIBMISFloatingIPRead,
+		UpdateContext: resourceIBMISFloatingIPUpdate,
+		DeleteContext: resourceIBMISFloatingIPDelete,
+		Exists:        resourceIBMISFloatingIPExists,
+		Importer:      &schema.ResourceImporter{},
 
 		Timeouts: &schema.ResourceTimeout{
 			Create: schema.DefaultTimeout(10 * time.Minute),
@@ -315,21 +316,22 @@ func ResourceIBMISFloatingIPValidator() *validate.ResourceValidator {
 	return &ibmISFloatingIPResourceValidator
 }
 
-func resourceIBMISFloatingIPCreate(d *schema.ResourceData, meta interface{}) error {
-
+func resourceIBMISFloatingIPCreate(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	name := d.Get(isFloatingIPName).(string)
-	err := fipCreate(d, meta, name)
+	err := fipCreate(context, d, meta, name)
 	if err != nil {
 		return err
 	}
 
-	return resourceIBMISFloatingIPRead(d, meta)
+	return resourceIBMISFloatingIPRead(context, d, meta)
 }
 
-func fipCreate(d *schema.ResourceData, meta interface{}, name string) error {
-	sess, err := vpcClient(meta)
+func fipCreate(context context.Context, d *schema.ResourceData, meta interface{}, name string) diag.Diagnostics {
+	vpcClient, err := meta.(conns.ClientSession).VpcV1API()
 	if err != nil {
-		return err
+		tfErr := flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_is_floating_ip", "create", "initialize-client")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	floatingIPPrototype := &vpcv1.FloatingIPPrototype{
@@ -351,7 +353,8 @@ func fipCreate(d *schema.ResourceData, meta interface{}, name string) error {
 	}
 
 	if zone == "" && target == "" {
-		return fmt.Errorf("%s or %s need to be provided", isFloatingIPZone, isFloatingIPTarget)
+		err = fmt.Errorf("%s or %s need to be provided", isFloatingIPZone, isFloatingIPTarget)
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_is_floating_ip", "create", "validation").GetDiag()
 	}
 
 	if rgrp, ok := d.GetOk(isFloatingIPResourceGroup); ok {
@@ -365,15 +368,17 @@ func fipCreate(d *schema.ResourceData, meta interface{}, name string) error {
 		FloatingIPPrototype: floatingIPPrototype,
 	}
 
-	floatingip, response, err := sess.CreateFloatingIP(createFloatingIPOptions)
+	floatingip, response, err := vpcClient.CreateFloatingIPWithContext(context, createFloatingIPOptions)
 	if err != nil {
-		return fmt.Errorf("[DEBUG] Floating IP err %s\n%s", err, response)
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("CreateFloatingIPWithContext failed: %s\n%s", err, response), "ibm_is_floating_ip", "create")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 	d.SetId(*floatingip.ID)
 	log.Printf("[INFO] Floating IP : %s[%s]", *floatingip.ID, *floatingip.Address)
-	_, err = isWaitForInstanceFloatingIP(sess, d.Id(), d)
+	_, err = isWaitForInstanceFloatingIP(vpcClient, d.Id(), d)
 	if err != nil {
-		return err
+		return diag.FromErr(err)
 	}
 	v := os.Getenv("IC_ENV_TAGS")
 	if _, ok := d.GetOk(isFloatingIPTags); ok || v != "" {
@@ -396,9 +401,9 @@ func fipCreate(d *schema.ResourceData, meta interface{}, name string) error {
 	return nil
 }
 
-func resourceIBMISFloatingIPRead(d *schema.ResourceData, meta interface{}) error {
+func resourceIBMISFloatingIPRead(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	id := d.Id()
-	err := fipGet(d, meta, id)
+	err := fipGet(context, d, meta, id)
 	if err != nil {
 		return err
 	}
@@ -406,89 +411,146 @@ func resourceIBMISFloatingIPRead(d *schema.ResourceData, meta interface{}) error
 	return nil
 }
 
-func fipGet(d *schema.ResourceData, meta interface{}, id string) error {
-	sess, err := vpcClient(meta)
+func fipGet(context context.Context, d *schema.ResourceData, meta interface{}, id string) diag.Diagnostics {
+	vpcClient, err := meta.(conns.ClientSession).VpcV1API()
 	if err != nil {
-		return err
+		tfErr := flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_is_floating_ip", "read", "initialize-client")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 	getFloatingIPOptions := &vpcv1.GetFloatingIPOptions{
 		ID: &id,
 	}
-	floatingip, response, err := sess.GetFloatingIP(getFloatingIPOptions)
+	floatingip, response, err := vpcClient.GetFloatingIPWithContext(context, getFloatingIPOptions)
 	if err != nil {
 		if response != nil && response.StatusCode == 404 {
 			d.SetId("")
 			return nil
 		}
-		return fmt.Errorf("[ERROR] Error Getting Floating IP (%s): %s\n%s", id, err, response)
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("GetFloatingIPWithContext failed: %s\n%s", err, response), "ibm_is_floating_ip", "read")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 
 	}
-	d.Set(isFloatingIPName, *floatingip.Name)
-	d.Set(isFloatingIPAddress, *floatingip.Address)
-	d.Set(isFloatingIPStatus, *floatingip.Status)
-	d.Set(isFloatingIPZone, *floatingip.Zone.Name)
+	if err = d.Set(isFloatingIPName, *floatingip.Name); err != nil {
+		err = fmt.Errorf("Error setting name: %s", err)
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_is_floating_ip", "read", "set-name").GetDiag()
+	}
+	if err = d.Set(isFloatingIPAddress, *floatingip.Address); err != nil {
+		err = fmt.Errorf("Error setting address: %s", err)
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_is_floating_ip", "read", "set-address").GetDiag()
+	}
+	if err = d.Set(isFloatingIPStatus, *floatingip.Status); err != nil {
+		err = fmt.Errorf("Error setting status: %s", err)
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_is_floating_ip", "read", "set-status").GetDiag()
+	}
+	if err = d.Set(isFloatingIPZone, *floatingip.Zone.Name); err != nil {
+		err = fmt.Errorf("Error setting zone: %s", err)
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_is_floating_ip", "read", "set-zone").GetDiag()
+	}
+	if err = d.Set(isFloatingIPCRN, *floatingip.CRN); err != nil {
+		err = fmt.Errorf("Error setting crn: %s", err)
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_is_floating_ip", "read", "set-crn").GetDiag()
+	}
+
 	targetId, targetMap := floatingIPCollectionFloatingIpTargetToMap(floatingip.Target)
 	if targetId != "" {
-		d.Set(isFloatingIPTarget, targetId)
+		if err = d.Set(isFloatingIPTarget, targetId); err != nil {
+			err = fmt.Errorf("Error setting target: %s", err)
+			return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_is_floating_ip", "read", "set-target").GetDiag()
+		}
 	} else {
-		d.Set(isFloatingIPTarget, "")
+		if err = d.Set(isFloatingIPTarget, ""); err != nil {
+			err = fmt.Errorf("Error setting target: %s", err)
+			return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_is_floating_ip", "read", "set-target").GetDiag()
+		}
 	}
 	targetList := make([]map[string]interface{}, 0)
 	targetList = append(targetList, targetMap)
-	d.Set(floatingIPTargets, targetList)
+	if err = d.Set(floatingIPTargets, targetList); err != nil {
+		err = fmt.Errorf("Error setting targets: %s", err)
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_is_floating_ip", "read", "set-targets").GetDiag()
+	}
 	tags, err := flex.GetGlobalTagsUsingCRN(meta, *floatingip.CRN, "", isUserTagType)
 	if err != nil {
 		log.Printf(
 			"Error on get of vpc Floating IP (%s) tags: %s", d.Id(), err)
 	}
-	d.Set(isFloatingIPTags, tags)
+	if err = d.Set(isFloatingIPTags, tags); err != nil {
+		err = fmt.Errorf("Error setting tags: %s", err)
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_is_floating_ip", "read", "set-tags").GetDiag()
+	}
 
 	accesstags, err := flex.GetGlobalTagsUsingCRN(meta, *floatingip.CRN, "", isAccessTagType)
 	if err != nil {
 		log.Printf(
 			"Error on get of resource Floating IP (%s) access tags: %s", d.Id(), err)
 	}
-
-	d.Set(isFloatingIPAccessTags, accesstags)
+	if err = d.Set(isFloatingIPAccessTags, accesstags); err != nil {
+		err = fmt.Errorf("Error setting access_tags: %s", err)
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_is_floating_ip", "read", "set-access_tags").GetDiag()
+	}
 
 	controller, err := flex.GetBaseController(meta)
 	if err != nil {
-		return err
+		return diag.FromErr(err)
 	}
-	d.Set(flex.ResourceControllerURL, controller+"/vpc-ext/network/floatingIPs")
-	d.Set(flex.ResourceName, *floatingip.Name)
-	d.Set(isFloatingIPCRN, *floatingip.CRN)
-	d.Set(flex.ResourceCRN, *floatingip.CRN)
-	d.Set(flex.ResourceStatus, *floatingip.Status)
+	if err = d.Set(flex.ResourceControllerURL, controller+"/vpc-ext/network/floatingIPs"); err != nil {
+		err = fmt.Errorf("Error setting controller_url: %s", err)
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_is_floating_ip", "read", "set-controller_url").GetDiag()
+	}
+	if err = d.Set(flex.ResourceName, *floatingip.Name); err != nil {
+		err = fmt.Errorf("Error setting name: %s", err)
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_is_floating_ip", "read", "set-flex_name").GetDiag()
+
+	}
+	if err = d.Set(flex.ResourceCRN, *floatingip.CRN); err != nil {
+		err = fmt.Errorf("Error setting crn: %s", err)
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_is_floating_ip", "read", "set-flex_crn").GetDiag()
+	}
+	if err = d.Set(flex.ResourceStatus, *floatingip.Status); err != nil {
+		err = fmt.Errorf("Error setting status: %s", err)
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_is_floating_ip", "read", "set-flex_status").GetDiag()
+	}
 	if floatingip.ResourceGroup != nil {
-		d.Set(flex.ResourceGroupName, floatingip.ResourceGroup.Name)
-		d.Set(isFloatingIPResourceGroup, floatingip.ResourceGroup.ID)
+		if err = d.Set(flex.ResourceGroupName, floatingip.ResourceGroup.Name); err != nil {
+			err = fmt.Errorf("Error setting resource_group_name: %s", err)
+			return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_is_floating_ip", "read", "set-flex_resource_group_name").GetDiag()
+		}
+		if err = d.Set(isFloatingIPResourceGroup, floatingip.ResourceGroup.ID); err != nil {
+			err = fmt.Errorf("Error setting resource_group: %s", err)
+			return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_is_floating_ip", "read", "set-resource_group").GetDiag()
+		}
 	}
 	return nil
 }
 
-func resourceIBMISFloatingIPUpdate(d *schema.ResourceData, meta interface{}) error {
+func resourceIBMISFloatingIPUpdate(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	id := d.Id()
-	err := fipUpdate(d, meta, id)
+	err := fipUpdate(context, d, meta, id)
 	if err != nil {
 		return err
 	}
-	return resourceIBMISFloatingIPRead(d, meta)
+	return resourceIBMISFloatingIPRead(context, d, meta)
 }
 
-func fipUpdate(d *schema.ResourceData, meta interface{}, id string) error {
-	sess, err := vpcClient(meta)
+func fipUpdate(context context.Context, d *schema.ResourceData, meta interface{}, id string) diag.Diagnostics {
+	vpcClient, err := meta.(conns.ClientSession).VpcV1API()
 	if err != nil {
-		return err
+		tfErr := flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_is_floating_ip", "update", "initialize-client")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	if d.HasChange(isFloatingIPTags) {
 		options := &vpcv1.GetFloatingIPOptions{
 			ID: &id,
 		}
-		fip, response, err := sess.GetFloatingIP(options)
+		fip, response, err := vpcClient.GetFloatingIPWithContext(context, options)
 		if err != nil {
-			return fmt.Errorf("[ERROR] Error getting Floating IP: %s\n%s", err, response)
+			tfErr := flex.TerraformErrorf(err, fmt.Sprintf("GetFloatingIPWithContext failed: %s\n%s", err, response), "ibm_is_floating_ip", "update")
+			log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+			return tfErr.GetDiag()
 		}
 
 		oldList, newList := d.GetChange(isFloatingIPTags)
@@ -502,9 +564,11 @@ func fipUpdate(d *schema.ResourceData, meta interface{}, id string) error {
 		options := &vpcv1.GetFloatingIPOptions{
 			ID: &id,
 		}
-		fip, response, err := sess.GetFloatingIP(options)
+		fip, response, err := vpcClient.GetFloatingIPWithContext(context, options)
 		if err != nil {
-			return fmt.Errorf("[ERROR] Error getting Floating IP: %s\n%s", err, response)
+			tfErr := flex.TerraformErrorf(err, fmt.Sprintf("GetFloatingIPWithContext failed: %s\n%s", err, response), "ibm_is_floating_ip", "update")
+			log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+			return tfErr.GetDiag()
 		}
 
 		oldList, newList := d.GetChange(isFloatingIPAccessTags)
@@ -526,7 +590,9 @@ func fipUpdate(d *schema.ResourceData, meta interface{}, id string) error {
 		hasChanged = true
 		floatingIPPatch, err := floatingIPPatchModel.AsPatch()
 		if err != nil {
-			return fmt.Errorf("[ERROR] Error calling asPatch for FloatingIPPatch: %s", err)
+			tfErr := flex.TerraformErrorf(err, fmt.Sprintf("Error calling asPatch for FloatingIPPatch: %s", err), "ibm_is_floating_ip", "update")
+			log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+			return tfErr.GetDiag()
 		}
 		options.FloatingIPPatch = floatingIPPatch
 	}
@@ -539,55 +605,64 @@ func fipUpdate(d *schema.ResourceData, meta interface{}, id string) error {
 		hasChanged = true
 		floatingIPPatch, err := floatingIPPatchModel.AsPatch()
 		if err != nil {
-			return fmt.Errorf("[ERROR] Error calling asPatch for floatingIPPatch: %s", err)
+			tfErr := flex.TerraformErrorf(err, fmt.Sprintf("Error calling asPatch for FloatingIPPatch: %s", err), "ibm_is_floating_ip", "update")
+			log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+			return tfErr.GetDiag()
 		}
 		options.FloatingIPPatch = floatingIPPatch
 	}
 	if hasChanged {
-		_, response, err := sess.UpdateFloatingIP(options)
+		_, response, err := vpcClient.UpdateFloatingIPWithContext(context, options)
 		if err != nil {
-			return fmt.Errorf("[ERROR] Error updating vpc Floating IP: %s\n%s", err, response)
+			tfErr := flex.TerraformErrorf(err, fmt.Sprintf("UpdateFloatingIPWithContext failed: %s\n%s", err, response), "ibm_is_floating_ip", "update")
+			log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+			return tfErr.GetDiag()
 		}
 	}
 	return nil
 }
 
-func resourceIBMISFloatingIPDelete(d *schema.ResourceData, meta interface{}) error {
+func resourceIBMISFloatingIPDelete(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	id := d.Id()
-	err := fipDelete(d, meta, id)
+	err := fipDelete(context, d, meta, id)
 	if err != nil {
 		return err
 	}
 	return nil
 }
 
-func fipDelete(d *schema.ResourceData, meta interface{}, id string) error {
-	sess, err := vpcClient(meta)
+func fipDelete(context context.Context, d *schema.ResourceData, meta interface{}, id string) diag.Diagnostics {
+	vpcClient, err := meta.(conns.ClientSession).VpcV1API()
 	if err != nil {
-		return err
+		tfErr := flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_is_floating_ip", "delete", "initialize-client")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 	getFloatingIpOptions := &vpcv1.GetFloatingIPOptions{
 		ID: &id,
 	}
-	_, response, err := sess.GetFloatingIP(getFloatingIpOptions)
+	_, response, err := vpcClient.GetFloatingIPWithContext(context, getFloatingIpOptions)
 	if err != nil {
 		if response != nil && response.StatusCode == 404 {
 			return nil
 		}
-
-		return fmt.Errorf("[ERROR] Error Getting Floating IP (%s): %s\n%s", id, err, response)
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("GetFloatingIPWithContext failed: %s\n%s", err, response), "ibm_is_floating_ip", "delete")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	options := &vpcv1.DeleteFloatingIPOptions{
 		ID: &id,
 	}
-	response, err = sess.DeleteFloatingIP(options)
+	response, err = vpcClient.DeleteFloatingIPWithContext(context, options)
 	if err != nil {
-		return fmt.Errorf("[ERROR] Error Deleting Floating IP : %s\n%s", err, response)
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("DeleteFloatingIPWithContext failed: %s\n%s", err, response), "ibm_is_floating_ip", "delete")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
-	_, err = isWaitForFloatingIPDeleted(sess, id, d.Timeout(schema.TimeoutDelete))
+	_, err = isWaitForFloatingIPDeleted(vpcClient, id, d.Timeout(schema.TimeoutDelete))
 	if err != nil {
-		return err
+		return diag.FromErr(err)
 	}
 	d.SetId("")
 	return nil
@@ -600,19 +675,19 @@ func resourceIBMISFloatingIPExists(d *schema.ResourceData, meta interface{}) (bo
 }
 
 func fipExists(d *schema.ResourceData, meta interface{}, id string) (bool, error) {
-	sess, err := vpcClient(meta)
+	vpcClient, err := meta.(conns.ClientSession).VpcV1API()
 	if err != nil {
 		return false, err
 	}
 	getFloatingIpOptions := &vpcv1.GetFloatingIPOptions{
 		ID: &id,
 	}
-	_, response, err := sess.GetFloatingIP(getFloatingIpOptions)
+	_, response, err := vpcClient.GetFloatingIP(getFloatingIpOptions)
 	if err != nil {
 		if response != nil && response.StatusCode == 404 {
 			return false, nil
 		}
-		return false, fmt.Errorf("[ERROR] Error getting floating IP: %s\n%s", err, response)
+		return false, fmt.Errorf("Error getting floating IP: %s\n%s", err, response)
 	}
 	return true, nil
 }

--- a/ibm/service/vpc/resource_ibm_is_floating_ip_test.go
+++ b/ibm/service/vpc/resource_ibm_is_floating_ip_test.go
@@ -22,6 +22,7 @@ func TestAccIBMISFloatingIP_basic(t *testing.T) {
 	var ip string
 	vpcname := fmt.Sprintf("tfip-vpc-%d", acctest.RandIntRange(10, 100))
 	name := fmt.Sprintf("tfip-%d", acctest.RandIntRange(10, 100))
+	updatedName := fmt.Sprintf("tfip-updated-%d", acctest.RandIntRange(10, 100))
 	instancename := fmt.Sprintf("tfip-instance-%d", acctest.RandIntRange(10, 100))
 	subnetname := fmt.Sprintf("tfip-subnet-%d", acctest.RandIntRange(10, 100))
 	publicKey := strings.TrimSpace(`
@@ -30,6 +31,7 @@ ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCKVmnMOlHKcZK8tpt3MP1lqOLAcqcJzhsvJcjscgVE
 	sshname := fmt.Sprintf("tfip-sshname-%d", acctest.RandIntRange(10, 100))
 	userData1 := "a"
 	userData2 := "b"
+	resourceKey := "ibm_is_floating_ip.testacc_floatingip"
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { acc.TestAccPreCheck(t) },
@@ -39,36 +41,61 @@ ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCKVmnMOlHKcZK8tpt3MP1lqOLAcqcJzhsvJcjscgVE
 			{
 				Config: testAccCheckIBMISFloatingIPConfig(vpcname, subnetname, sshname, publicKey, instancename, userData1, name),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckIBMISFloatingIPExists("ibm_is_floating_ip.testacc_floatingip", ip),
+					testAccCheckIBMISFloatingIPExists(resourceKey, ip),
 					resource.TestCheckResourceAttr(
 						"ibm_is_instance.testacc_instance", "user_data", userData1),
 					resource.TestCheckResourceAttr(
-						"ibm_is_floating_ip.testacc_floatingip", "name", name),
+						resourceKey, "name", name),
 					resource.TestCheckResourceAttr(
-						"ibm_is_floating_ip.testacc_floatingip", "zone", acc.ISZoneName),
-					resource.TestCheckResourceAttrSet("ibm_is_floating_ip.testacc_floatingip", "target_list.0.primary_ip.0.address"),
-					resource.TestCheckResourceAttrSet("ibm_is_floating_ip.testacc_floatingip", "target_list.0.primary_ip.0.name"),
-					resource.TestCheckResourceAttrSet("ibm_is_floating_ip.testacc_floatingip", "target_list.0.primary_ip.0.href"),
-					resource.TestCheckResourceAttrSet("ibm_is_floating_ip.testacc_floatingip", "target_list.0.primary_ip.0.reserved_ip"),
-					resource.TestCheckResourceAttrSet("ibm_is_floating_ip.testacc_floatingip", "target_list.0.primary_ip.0.resource_type"),
+						resourceKey, "zone", acc.ISZoneName),
+					resource.TestCheckResourceAttrSet(resourceKey, "address"),
+					resource.TestCheckResourceAttrSet(resourceKey, "status"),
+					resource.TestCheckResourceAttrSet(resourceKey, "target"),
+					resource.TestCheckResourceAttrSet(resourceKey, "target_list.0.primary_ip.0.address"),
+					resource.TestCheckResourceAttrSet(resourceKey, "target_list.0.primary_ip.0.name"),
+					resource.TestCheckResourceAttrSet(resourceKey, "target_list.0.primary_ip.0.href"),
+					resource.TestCheckResourceAttrSet(resourceKey, "target_list.0.primary_ip.0.reserved_ip"),
+					resource.TestCheckResourceAttrSet(resourceKey, "target_list.0.primary_ip.0.resource_type"),
+					resource.TestCheckResourceAttrSet(resourceKey, "crn"),
+					resource.TestCheckResourceAttrSet(resourceKey, "resource_controller_url"),
+					resource.TestCheckResourceAttrSet(resourceKey, "resource_name"),
+					resource.TestCheckResourceAttrSet(resourceKey, "resource_group_name"),
 				),
 			},
 			{
 				Config: testAccCheckIBMISFloatingIPConfig(vpcname, subnetname, sshname, publicKey, instancename, userData2, name),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckIBMISFloatingIPExists("ibm_is_floating_ip.testacc_floatingip", ip),
+					testAccCheckIBMISFloatingIPExists(resourceKey, ip),
 					resource.TestCheckResourceAttr(
 						"ibm_is_instance.testacc_instance", "user_data", userData2),
 					resource.TestCheckResourceAttr(
-						"ibm_is_floating_ip.testacc_floatingip", "name", name),
+						resourceKey, "name", name),
 					resource.TestCheckResourceAttr(
-						"ibm_is_floating_ip.testacc_floatingip", "zone", acc.ISZoneName),
-					resource.TestCheckResourceAttrSet("ibm_is_floating_ip.testacc_floatingip", "target_list.0.primary_ip.0.address"),
-					resource.TestCheckResourceAttrSet("ibm_is_floating_ip.testacc_floatingip", "target_list.0.primary_ip.0.name"),
-					resource.TestCheckResourceAttrSet("ibm_is_floating_ip.testacc_floatingip", "target_list.0.primary_ip.0.href"),
-					resource.TestCheckResourceAttrSet("ibm_is_floating_ip.testacc_floatingip", "target_list.0.primary_ip.0.reserved_ip"),
-					resource.TestCheckResourceAttrSet("ibm_is_floating_ip.testacc_floatingip", "target_list.0.primary_ip.0.resource_type"),
+						resourceKey, "zone", acc.ISZoneName),
+					resource.TestCheckResourceAttrSet(resourceKey, "target_list.0.primary_ip.0.address"),
+					resource.TestCheckResourceAttrSet(resourceKey, "target_list.0.primary_ip.0.name"),
+					resource.TestCheckResourceAttrSet(resourceKey, "target_list.0.primary_ip.0.href"),
+					resource.TestCheckResourceAttrSet(resourceKey, "target_list.0.primary_ip.0.reserved_ip"),
+					resource.TestCheckResourceAttrSet(resourceKey, "target_list.0.primary_ip.0.resource_type"),
 				),
+			},
+			// Test name update
+			{
+				Config: testAccCheckIBMISFloatingIPConfigNameUpdate(vpcname, subnetname, sshname, publicKey, instancename, userData2, updatedName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckIBMISFloatingIPExists(resourceKey, ip),
+					resource.TestCheckResourceAttr(
+						resourceKey, "name", updatedName),
+					resource.TestCheckResourceAttrSet(resourceKey, "address"),
+					resource.TestCheckResourceAttrSet(resourceKey, "status"),
+					resource.TestCheckResourceAttrSet(resourceKey, "target"),
+				),
+			},
+			// Test import
+			{
+				ResourceName:      resourceKey,
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 		},
 	})
@@ -77,6 +104,8 @@ ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCKVmnMOlHKcZK8tpt3MP1lqOLAcqcJzhsvJcjscgVE
 func TestAccIBMISFloatingIP_NoTarget(t *testing.T) {
 	var ip string
 	name := fmt.Sprintf("tfip-%d", acctest.RandIntRange(10, 100))
+	updatedName := fmt.Sprintf("tfip-updated-%d", acctest.RandIntRange(10, 100))
+	resourceKey := "ibm_is_floating_ip.testacc_floatingip"
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { acc.TestAccPreCheck(t) },
@@ -86,11 +115,95 @@ func TestAccIBMISFloatingIP_NoTarget(t *testing.T) {
 			{
 				Config: testAccCheckIBMISFloatingIPNoTargetConfig(name),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckIBMISFloatingIPExists("ibm_is_floating_ip.testacc_floatingip", ip),
+					testAccCheckIBMISFloatingIPExists(resourceKey, ip),
 					resource.TestCheckResourceAttr(
-						"ibm_is_floating_ip.testacc_floatingip", "name", name),
+						resourceKey, "name", name),
 					resource.TestCheckResourceAttr(
-						"ibm_is_floating_ip.testacc_floatingip", "zone", acc.ISZoneName),
+						resourceKey, "zone", acc.ISZoneName),
+					resource.TestCheckResourceAttrSet(resourceKey, "address"),
+					resource.TestCheckResourceAttrSet(resourceKey, "status"),
+					resource.TestCheckResourceAttr(resourceKey, "target", ""),
+				),
+			},
+			// Test name update for zone-based FIP
+			{
+				Config: testAccCheckIBMISFloatingIPNoTargetConfig(updatedName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckIBMISFloatingIPExists(resourceKey, ip),
+					resource.TestCheckResourceAttr(
+						resourceKey, "name", updatedName),
+					resource.TestCheckResourceAttr(
+						resourceKey, "zone", acc.ISZoneName),
+					resource.TestCheckResourceAttrSet(resourceKey, "address"),
+				),
+			},
+			// Test import
+			{
+				ResourceName:      resourceKey,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccIBMISFloatingIP_ResourceGroup(t *testing.T) {
+	var ip string
+	name := fmt.Sprintf("tfip-rg-%d", acctest.RandIntRange(10, 100))
+	resourceKey := "ibm_is_floating_ip.testacc_floatingip"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { acc.TestAccPreCheck(t) },
+		Providers:    acc.TestAccProviders,
+		CheckDestroy: testAccCheckIBMISFloatingIPDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckIBMISFloatingIPResourceGroupConfig(name),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckIBMISFloatingIPExists(resourceKey, ip),
+					resource.TestCheckResourceAttr(
+						resourceKey, "name", name),
+					resource.TestCheckResourceAttr(
+						resourceKey, "zone", acc.ISZoneName),
+					resource.TestCheckResourceAttrSet(resourceKey, "resource_group"),
+					resource.TestCheckResourceAttrSet(resourceKey, "resource_group_name"),
+					resource.TestCheckResourceAttrSet(resourceKey, "address"),
+					resource.TestCheckResourceAttrSet(resourceKey, "status"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccIBMISFloatingIP_Tags(t *testing.T) {
+	var ip string
+	name := fmt.Sprintf("tfip-tags-%d", acctest.RandIntRange(10, 100))
+	resourceKey := "ibm_is_floating_ip.testacc_floatingip"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { acc.TestAccPreCheck(t) },
+		Providers:    acc.TestAccProviders,
+		CheckDestroy: testAccCheckIBMISFloatingIPDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckIBMISFloatingIPTagsConfig(name),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckIBMISFloatingIPExists(resourceKey, ip),
+					resource.TestCheckResourceAttr(
+						resourceKey, "name", name),
+					resource.TestCheckResourceAttr(
+						resourceKey, "zone", acc.ISZoneName),
+					resource.TestCheckResourceAttr(resourceKey, "tags.#", "2"),
+					resource.TestCheckResourceAttrSet(resourceKey, "address"),
+					resource.TestCheckResourceAttrSet(resourceKey, "status"),
+				),
+			},
+			// Test tag update
+			{
+				Config: testAccCheckIBMISFloatingIPTagsUpdateConfig(name),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckIBMISFloatingIPExists(resourceKey, ip),
+					resource.TestCheckResourceAttr(resourceKey, "tags.#", "3"),
 				),
 			},
 		},
@@ -145,45 +258,117 @@ func testAccCheckIBMISFloatingIPConfig(vpcname, subnetname, sshname, publicKey, 
 	return fmt.Sprintf(`
 	resource "ibm_is_vpc" "testacc_vpc" {
 		name = "%s"
-	  }
-	  
-	  resource "ibm_is_subnet" "testacc_subnet" {
+	}
+	
+	resource "ibm_is_subnet" "testacc_subnet" {
 		name            = "%s"
 		vpc             = ibm_is_vpc.testacc_vpc.id
 		zone            = "%s"
 		ipv4_cidr_block = "%s"
-	  }
-	  
-	  resource "ibm_is_ssh_key" "testacc_sshkey" {
+	}
+	
+	resource "ibm_is_ssh_key" "testacc_sshkey" {
 		name       = "%s"
 		public_key = "%s"
-	  }
-	  
-	  resource "ibm_is_instance" "testacc_instance" {
+	}
+	
+	resource "ibm_is_instance" "testacc_instance" {
 		name    = "%s"
 		image   = "%s"
 		profile = "%s"
 		primary_network_interface {
-		  subnet     = ibm_is_subnet.testacc_subnet.id
+			subnet = ibm_is_subnet.testacc_subnet.id
 		}
 		user_data = "%s"
 		vpc  = ibm_is_vpc.testacc_vpc.id
 		zone = "%s"
 		keys = [ibm_is_ssh_key.testacc_sshkey.id]
-	  }
-	  
-	  resource "ibm_is_floating_ip" "testacc_floatingip" {
+	}
+	
+	resource "ibm_is_floating_ip" "testacc_floatingip" {
 		name   = "%s"
 		target = ibm_is_instance.testacc_instance.primary_network_interface[0].id
-	  }
+	}
+`, vpcname, subnetname, acc.ISZoneName, acc.ISCIDR, sshname, publicKey, instancename, acc.IsImage, acc.InstanceProfileName, userData, acc.ISZoneName, name)
+}
+
+func testAccCheckIBMISFloatingIPConfigNameUpdate(vpcname, subnetname, sshname, publicKey, instancename, userData, name string) string {
+	return fmt.Sprintf(`
+	resource "ibm_is_vpc" "testacc_vpc" {
+		name = "%s"
+	}
+	
+	resource "ibm_is_subnet" "testacc_subnet" {
+		name            = "%s"
+		vpc             = ibm_is_vpc.testacc_vpc.id
+		zone            = "%s"
+		ipv4_cidr_block = "%s"
+	}
+	
+	resource "ibm_is_ssh_key" "testacc_sshkey" {
+		name       = "%s"
+		public_key = "%s"
+	}
+	
+	resource "ibm_is_instance" "testacc_instance" {
+		name    = "%s"
+		image   = "%s"
+		profile = "%s"
+		primary_network_interface {
+			subnet = ibm_is_subnet.testacc_subnet.id
+		}
+		user_data = "%s"
+		vpc  = ibm_is_vpc.testacc_vpc.id
+		zone = "%s"
+		keys = [ibm_is_ssh_key.testacc_sshkey.id]
+	}
+	
+	resource "ibm_is_floating_ip" "testacc_floatingip" {
+		name   = "%s"
+		target = ibm_is_instance.testacc_instance.primary_network_interface[0].id
+	}
 `, vpcname, subnetname, acc.ISZoneName, acc.ISCIDR, sshname, publicKey, instancename, acc.IsImage, acc.InstanceProfileName, userData, acc.ISZoneName, name)
 }
 
 func testAccCheckIBMISFloatingIPNoTargetConfig(name string) string {
 	return fmt.Sprintf(`
-	  resource "ibm_is_floating_ip" "testacc_floatingip" {
-		name   = "%s"
-		zone   = "%s"
-	  }
+	resource "ibm_is_floating_ip" "testacc_floatingip" {
+		name = "%s"
+		zone = "%s"
+	}
+`, name, acc.ISZoneName)
+}
+
+func testAccCheckIBMISFloatingIPResourceGroupConfig(name string) string {
+	return fmt.Sprintf(`
+	data "ibm_resource_group" "test_group" {
+		name = "Default"
+	}
+	
+	resource "ibm_is_floating_ip" "testacc_floatingip" {
+		name = "%s"
+		zone = "%s"
+		resource_group = data.ibm_resource_group.test_group.id
+	}
+`, name, acc.ISZoneName)
+}
+
+func testAccCheckIBMISFloatingIPTagsConfig(name string) string {
+	return fmt.Sprintf(`
+	resource "ibm_is_floating_ip" "testacc_floatingip" {
+		name = "%s"
+		zone = "%s"
+		tags = ["tag1", "tag2"]
+	}
+`, name, acc.ISZoneName)
+}
+
+func testAccCheckIBMISFloatingIPTagsUpdateConfig(name string) string {
+	return fmt.Sprintf(`
+	resource "ibm_is_floating_ip" "testacc_floatingip" {
+		name = "%s"
+		zone = "%s"
+		tags = ["tag1", "tag2", "tag3"]
+	}
 `, name, acc.ISZoneName)
 }


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/IBM-Cloud/terraform-provider-ibm/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
% make testacc TEST=./ibm/service/vpc TESTARGS='-run=TestAccIBMISFloatingIP_basic'
=== RUN   TestAccIBMISFloatingIP_basic
--- PASS: TestAccIBMISFloatingIP_basic (378.23s)
PASS
ok      github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/vpc     380.080s


% make testacc TEST=./ibm/service/vpc TESTARGS='-run=TestAccIBMISFloatingIP_NoTarget'
=== RUN   TestAccIBMISFloatingIP_NoTarget
--- PASS: TestAccIBMISFloatingIP_NoTarget (93.49s)
PASS
ok      github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/vpc     95.838s

% make testacc TEST=./ibm/service/vpc TESTARGS='-run=TestAccIBMISFloatingIP_ResourceGroup'
=== RUN   TestAccIBMISFloatingIP_ResourceGroup
--- PASS: TestAccIBMISFloatingIP_ResourceGroup (57.60s)
PASS
ok      github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/vpc     59.499s


% make testacc TEST=./ibm/service/vpc TESTARGS='-run=TestAccIBMISFloatingIP_Tags' 
=== RUN   TestAccIBMISFloatingIP_Tags
--- PASS: TestAccIBMISFloatingIP_Tags (96.27s)
PASS
ok      github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/vpc     98.132s

% make testacc TEST=./ibm/service/vpc TESTARGS='-run=TestAccIBMISFloatingIPDataSource_basic'
=== RUN   TestAccIBMISFloatingIPDataSource_basic
--- PASS: TestAccIBMISFloatingIPDataSource_basic (283.41s)
PASS
ok      github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/vpc     285.272s

% make testacc TEST=./ibm/service/vpc TESTARGS='-run=TestAccIBMIsFloatingIpsDataSourceBasic'
=== RUN   TestAccIBMIsFloatingIpsDataSourceBasic
--- PASS: TestAccIBMIsFloatingIpsDataSourceBasic (195.17s)
PASS
ok      github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/vpc     197.128s

% make testacc TEST=./ibm/service/vpc TESTARGS='-run=TestAccIBMIsFloatingIpsDataSourceWithResourceGroup'
=== RUN   TestAccIBMIsFloatingIpsDataSourceWithResourceGroup
--- PASS: TestAccIBMIsFloatingIpsDataSourceWithResourceGroup (73.06s)
PASS
ok      github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/vpc     74.866s
```
