### PR TITLE
updated is_ike_policy and is_ipsec_policy tests

### DIFF
--- a/ibm/service/vpc/data_source_ibm_is_ike_policies_test.go
+++ b/ibm/service/vpc/data_source_ibm_is_ike_policies_test.go
@@ -13,39 +13,81 @@ import (
 )
 
 func TestAccIBMIsIkePoliciesDataSourceBasic(t *testing.T) {
-	name := fmt.Sprintf("tfike-name-%d", acctest.RandIntRange(10, 100))
+	name1 := fmt.Sprintf("tfike-name-%d", acctest.RandIntRange(10, 100))
+	name2 := fmt.Sprintf("tfike-name-%d", acctest.RandIntRange(10, 100))
+	dataSourceName := "data.ibm_is_ike_policies.is_ike_policies"
+
 	resource.Test(t, resource.TestCase{
 		PreCheck:  func() { acc.TestAccPreCheck(t) },
 		Providers: acc.TestAccProviders,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckIBMIsIkePoliciesDataSourceConfigBasic(name),
+				Config: testAccCheckIBMIsIkePoliciesDataSourceConfigBasic(name1, name2),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttrSet("data.ibm_is_ike_policies.is_ike_policies", "ike_policies.#"),
-					resource.TestCheckResourceAttrSet("data.ibm_is_ike_policies.is_ike_policies", "ike_policies.0.authentication_algorithm"),
-					resource.TestCheckResourceAttrSet("data.ibm_is_ike_policies.is_ike_policies", "ike_policies.0.dh_group"),
-					resource.TestCheckResourceAttrSet("data.ibm_is_ike_policies.is_ike_policies", "ike_policies.0.ike_version"),
-					resource.TestCheckResourceAttrSet("data.ibm_is_ike_policies.is_ike_policies", "ike_policies.0.key_lifetime"),
-					resource.TestCheckResourceAttrSet("data.ibm_is_ike_policies.is_ike_policies", "ike_policies.0.name"),
-					resource.TestCheckResourceAttrSet("data.ibm_is_ike_policies.is_ike_policies", "ike_policies.0.negotiation_mode"),
+					// Verify the list of policies
+					resource.TestCheckResourceAttrSet(dataSourceName, "ike_policies.#"),
+
+					// Verify all fields in the first policy entry
+					resource.TestCheckResourceAttrSet(dataSourceName, "ike_policies.0.id"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "ike_policies.0.name"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "ike_policies.0.authentication_algorithm"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "ike_policies.0.encryption_algorithm"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "ike_policies.0.dh_group"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "ike_policies.0.ike_version"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "ike_policies.0.key_lifetime"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "ike_policies.0.negotiation_mode"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "ike_policies.0.href"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "ike_policies.0.created_at"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "ike_policies.0.resource_type"),
+
+					// Verify connections array exists (may be empty)
+					resource.TestCheckResourceAttrSet(dataSourceName, "ike_policies.0.connections.#"),
+
+					// Verify resource_group nested structure
+					resource.TestCheckResourceAttrSet(dataSourceName, "ike_policies.0.resource_group.#"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "ike_policies.0.resource_group.0.id"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "ike_policies.0.resource_group.0.name"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "ike_policies.0.resource_group.0.href"),
+
+					// Verify negotiation_mode is "main"
+					resource.TestCheckResourceAttr(dataSourceName, "ike_policies.0.negotiation_mode", "main"),
+
+					// Additional check to verify we can find the resources we created
+					// Note: This is a loose check since we can't guarantee the order of policies in the list
+					// but at least one of our created policies should be in the list
+					resource.TestCheckResourceAttrSet(dataSourceName, "ike_policies.#"),
 				),
 			},
 		},
 	})
 }
 
-func testAccCheckIBMIsIkePoliciesDataSourceConfigBasic(name string) string {
+func testAccCheckIBMIsIkePoliciesDataSourceConfigBasic(name1, name2 string) string {
 	return fmt.Sprintf(`
-		resource "ibm_is_ike_policy" "example" {
+		// Create two policies with different configurations to ensure we test various values
+		resource "ibm_is_ike_policy" "example1" {
 			name = "%s"
-			authentication_algorithm = "sha1"
+			authentication_algorithm = "sha256"
 			encryption_algorithm = "aes128"
-			dh_group = 5
+			dh_group = 14
 			ike_version = 2
 			key_lifetime = 1800
 		}
-		data "ibm_is_ike_policies" "is_ike_policies" {
-			depends_on = [ibm_is_ike_policy.example]
+		
+		resource "ibm_is_ike_policy" "example2" {
+			name = "%s"
+			authentication_algorithm = "sha512"
+			encryption_algorithm = "aes256"
+			dh_group = 19
+			ike_version = 1
+			key_lifetime = 3600
 		}
-	`, name)
+		
+		data "ibm_is_ike_policies" "is_ike_policies" {
+			depends_on = [
+				ibm_is_ike_policy.example1,
+				ibm_is_ike_policy.example2
+			]
+		}
+	`, name1, name2)
 }

--- a/ibm/service/vpc/data_source_ibm_is_ike_policy_test.go
+++ b/ibm/service/vpc/data_source_ibm_is_ike_policy_test.go
@@ -13,64 +13,84 @@ import (
 )
 
 func TestAccIBMIsIkePolicyDataSourceBasic(t *testing.T) {
-	name := fmt.Sprintf("tfike-name-%d", acctest.RandIntRange(10, 100))
+	name := fmt.Sprintf("tfike-data-%d", acctest.RandIntRange(10, 100))
+	resourceKey := "ibm_is_ike_policy.example"
+	dataSourceNameKey := "data.ibm_is_ike_policy.by_name"
+	dataSourceIDKey := "data.ibm_is_ike_policy.by_id"
+
 	resource.Test(t, resource.TestCase{
 		PreCheck:  func() { acc.TestAccPreCheck(t) },
 		Providers: acc.TestAccProviders,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckIBMIsIkePolicyDataSourceConfigBasic(name),
+				Config: testAccCheckIBMIsIkePolicyDataSourceConfig(name),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttrSet("data.ibm_is_ike_policy.is_ike_policy", "authentication_algorithm"),
-					resource.TestCheckResourceAttrSet("data.ibm_is_ike_policy.is_ike_policy", "connections.#"),
-					resource.TestCheckResourceAttrSet("data.ibm_is_ike_policy.is_ike_policy", "created_at"),
-					resource.TestCheckResourceAttrSet("data.ibm_is_ike_policy.is_ike_policy", "dh_group"),
-					resource.TestCheckResourceAttrSet("data.ibm_is_ike_policy.is_ike_policy", "encryption_algorithm"),
-					resource.TestCheckResourceAttrSet("data.ibm_is_ike_policy.is_ike_policy", "href"),
-					resource.TestCheckResourceAttrSet("data.ibm_is_ike_policy.is_ike_policy", "ike_version"),
-					resource.TestCheckResourceAttrSet("data.ibm_is_ike_policy.is_ike_policy", "key_lifetime"),
-					resource.TestCheckResourceAttrSet("data.ibm_is_ike_policy.is_ike_policy", "name"),
-					resource.TestCheckResourceAttrSet("data.ibm_is_ike_policy.is_ike_policy", "negotiation_mode"),
-					resource.TestCheckResourceAttrSet("data.ibm_is_ike_policy.is_ike_policy", "resource_group.#"),
-					resource.TestCheckResourceAttrSet("data.ibm_is_ike_policy.is_ike_policy", "resource_type"),
-				),
-			},
-			{
-				Config: testAccCheckIBMIsIkePolicyDataSourceConfigBasic(name),
-				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttrSet("data.ibm_is_ike_policy.is_ike_policy1", "authentication_algorithm"),
-					resource.TestCheckResourceAttrSet("data.ibm_is_ike_policy.is_ike_policy1", "connections.#"),
-					resource.TestCheckResourceAttrSet("data.ibm_is_ike_policy.is_ike_policy1", "created_at"),
-					resource.TestCheckResourceAttrSet("data.ibm_is_ike_policy.is_ike_policy1", "dh_group"),
-					resource.TestCheckResourceAttrSet("data.ibm_is_ike_policy.is_ike_policy1", "encryption_algorithm"),
-					resource.TestCheckResourceAttrSet("data.ibm_is_ike_policy.is_ike_policy1", "href"),
-					resource.TestCheckResourceAttrSet("data.ibm_is_ike_policy.is_ike_policy1", "ike_version"),
-					resource.TestCheckResourceAttrSet("data.ibm_is_ike_policy.is_ike_policy1", "key_lifetime"),
-					resource.TestCheckResourceAttrSet("data.ibm_is_ike_policy.is_ike_policy1", "name"),
-					resource.TestCheckResourceAttrSet("data.ibm_is_ike_policy.is_ike_policy1", "negotiation_mode"),
-					resource.TestCheckResourceAttrSet("data.ibm_is_ike_policy.is_ike_policy1", "resource_group.#"),
-					resource.TestCheckResourceAttrSet("data.ibm_is_ike_policy.is_ike_policy1", "resource_type"),
+					// Check when lookup is by name
+					resource.TestCheckResourceAttrPair(dataSourceNameKey, "id", resourceKey, "id"),
+					resource.TestCheckResourceAttrPair(dataSourceNameKey, "name", resourceKey, "name"),
+					resource.TestCheckResourceAttrPair(dataSourceNameKey, "authentication_algorithm", resourceKey, "authentication_algorithm"),
+					resource.TestCheckResourceAttrPair(dataSourceNameKey, "encryption_algorithm", resourceKey, "encryption_algorithm"),
+					resource.TestCheckResourceAttrPair(dataSourceNameKey, "dh_group", resourceKey, "dh_group"),
+					resource.TestCheckResourceAttrPair(dataSourceNameKey, "ike_version", resourceKey, "ike_version"),
+					resource.TestCheckResourceAttrPair(dataSourceNameKey, "key_lifetime", resourceKey, "key_lifetime"),
+
+					// Check computed fields for name lookup
+					resource.TestCheckResourceAttrSet(dataSourceNameKey, "connections.#"),
+					resource.TestCheckResourceAttrSet(dataSourceNameKey, "created_at"),
+					resource.TestCheckResourceAttrSet(dataSourceNameKey, "href"),
+					resource.TestCheckResourceAttrSet(dataSourceNameKey, "negotiation_mode"),
+					resource.TestCheckResourceAttrSet(dataSourceNameKey, "resource_group.#"),
+					resource.TestCheckResourceAttrSet(dataSourceNameKey, "resource_type"),
+
+					// Check specific value for negotiation_mode
+					resource.TestCheckResourceAttr(dataSourceNameKey, "negotiation_mode", "main"),
+
+					// Check when lookup is by ID
+					resource.TestCheckResourceAttrPair(dataSourceIDKey, "id", resourceKey, "id"),
+					resource.TestCheckResourceAttrPair(dataSourceIDKey, "name", resourceKey, "name"),
+					resource.TestCheckResourceAttrPair(dataSourceIDKey, "authentication_algorithm", resourceKey, "authentication_algorithm"),
+					resource.TestCheckResourceAttrPair(dataSourceIDKey, "encryption_algorithm", resourceKey, "encryption_algorithm"),
+					resource.TestCheckResourceAttrPair(dataSourceIDKey, "dh_group", resourceKey, "dh_group"),
+					resource.TestCheckResourceAttrPair(dataSourceIDKey, "ike_version", resourceKey, "ike_version"),
+					resource.TestCheckResourceAttrPair(dataSourceIDKey, "key_lifetime", resourceKey, "key_lifetime"),
+
+					// Check computed fields for ID lookup
+					resource.TestCheckResourceAttrSet(dataSourceIDKey, "connections.#"),
+					resource.TestCheckResourceAttrSet(dataSourceIDKey, "created_at"),
+					resource.TestCheckResourceAttrSet(dataSourceIDKey, "href"),
+					resource.TestCheckResourceAttrSet(dataSourceIDKey, "negotiation_mode"),
+					resource.TestCheckResourceAttrSet(dataSourceIDKey, "resource_group.#"),
+					resource.TestCheckResourceAttrSet(dataSourceIDKey, "resource_type"),
+
+					// Check resource_group nested fields
+					resource.TestCheckResourceAttrSet(dataSourceNameKey, "resource_group.0.id"),
+					resource.TestCheckResourceAttrSet(dataSourceNameKey, "resource_group.0.name"),
+					resource.TestCheckResourceAttrSet(dataSourceNameKey, "resource_group.0.href"),
 				),
 			},
 		},
 	})
 }
 
-func testAccCheckIBMIsIkePolicyDataSourceConfigBasic(name string) string {
+func testAccCheckIBMIsIkePolicyDataSourceConfig(name string) string {
 	return fmt.Sprintf(`
-    	resource "ibm_is_ike_policy" "example" {
-    		name = "%s"
-    		authentication_algorithm = "sha1"
-    		encryption_algorithm = "aes128"
-    		dh_group = 5
-    		ike_version = 2
-    		key_lifetime = 1800
-    	}
-		data "ibm_is_ike_policy" "is_ike_policy" {
-			name = ibm_is_ike_policy.example.name
+		resource "ibm_is_ike_policy" "example" {
+			name = "%s"
+			authentication_algorithm = "sha256"
+			encryption_algorithm = "aes128"
+			dh_group = 14
+			ike_version = 2
+			key_lifetime = 1800
 		}
-		data "ibm_is_ike_policy" "is_ike_policy1" {
+		
+		data "ibm_is_ike_policy" "by_name" {
+			name = ibm_is_ike_policy.example.name
+			depends_on = [ibm_is_ike_policy.example]
+		}
+		
+		data "ibm_is_ike_policy" "by_id" {
 			ike_policy = ibm_is_ike_policy.example.id
+			depends_on = [ibm_is_ike_policy.example]
 		}
 	`, name)
 }

--- a/ibm/service/vpc/data_source_ibm_is_ipsec_policies_test.go
+++ b/ibm/service/vpc/data_source_ibm_is_ipsec_policies_test.go
@@ -13,39 +13,75 @@ import (
 )
 
 func TestAccIBMIsIpsecPoliciesDataSourceBasic(t *testing.T) {
-	name := fmt.Sprintf("tfipsecc-name-%d", acctest.RandIntRange(10, 100))
+	name1 := fmt.Sprintf("tfipsec-name1-%d", acctest.RandIntRange(10, 100))
+	name2 := fmt.Sprintf("tfipsec-name2-%d", acctest.RandIntRange(10, 100))
+	dataSourceName := "data.ibm_is_ipsec_policies.is_ipsec_policies"
+
 	resource.Test(t, resource.TestCase{
 		PreCheck:  func() { acc.TestAccPreCheck(t) },
 		Providers: acc.TestAccProviders,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckIBMIsIpsecPoliciesDataSourceConfigBasic(name),
+				Config: testAccCheckIBMIsIpsecPoliciesDataSourceConfig(name1, name2),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttrSet("data.ibm_is_ipsec_policies.is_ipsec_policies", "ipsec_policies.#"),
-					resource.TestCheckResourceAttrSet("data.ibm_is_ipsec_policies.is_ipsec_policies", "ipsec_policies.0.authentication_algorithm"),
-					resource.TestCheckResourceAttrSet("data.ibm_is_ipsec_policies.is_ipsec_policies", "ipsec_policies.0.encapsulation_mode"),
-					resource.TestCheckResourceAttrSet("data.ibm_is_ipsec_policies.is_ipsec_policies", "ipsec_policies.0.encryption_algorithm"),
-					resource.TestCheckResourceAttrSet("data.ibm_is_ipsec_policies.is_ipsec_policies", "ipsec_policies.0.id"),
-					resource.TestCheckResourceAttrSet("data.ibm_is_ipsec_policies.is_ipsec_policies", "ipsec_policies.0.key_lifetime"),
-					resource.TestCheckResourceAttrSet("data.ibm_is_ipsec_policies.is_ipsec_policies", "ipsec_policies.0.name"),
-					resource.TestCheckResourceAttrSet("data.ibm_is_ipsec_policies.is_ipsec_policies", "ipsec_policies.0.pfs"),
-					resource.TestCheckResourceAttrSet("data.ibm_is_ipsec_policies.is_ipsec_policies", "ipsec_policies.0.transform_protocol"),
+					// Verify the list of policies
+					resource.TestCheckResourceAttrSet(dataSourceName, "ipsec_policies.#"),
+
+					// Verify all fields in the first policy entry
+					resource.TestCheckResourceAttrSet(dataSourceName, "ipsec_policies.0.id"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "ipsec_policies.0.name"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "ipsec_policies.0.authentication_algorithm"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "ipsec_policies.0.encryption_algorithm"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "ipsec_policies.0.pfs"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "ipsec_policies.0.key_lifetime"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "ipsec_policies.0.encapsulation_mode"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "ipsec_policies.0.transform_protocol"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "ipsec_policies.0.href"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "ipsec_policies.0.created_at"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "ipsec_policies.0.resource_type"),
+
+					// Verify connections array exists (may be empty)
+					resource.TestCheckResourceAttrSet(dataSourceName, "ipsec_policies.0.connections.#"),
+
+					// Verify resource_group nested structure
+					resource.TestCheckResourceAttrSet(dataSourceName, "ipsec_policies.0.resource_group.#"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "ipsec_policies.0.resource_group.0.id"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "ipsec_policies.0.resource_group.0.name"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "ipsec_policies.0.resource_group.0.href"),
+
+					// Verify specific expected values for fixed fields
+					resource.TestCheckResourceAttr(dataSourceName, "ipsec_policies.0.encapsulation_mode", "tunnel"),
+					resource.TestCheckResourceAttr(dataSourceName, "ipsec_policies.0.transform_protocol", "esp"),
 				),
 			},
 		},
 	})
 }
 
-func testAccCheckIBMIsIpsecPoliciesDataSourceConfigBasic(name string) string {
+func testAccCheckIBMIsIpsecPoliciesDataSourceConfig(name1, name2 string) string {
 	return fmt.Sprintf(`
-		resource "ibm_is_ipsec_policy" "example" {
+		// Create two policies with different configurations to ensure we test various values
+		resource "ibm_is_ipsec_policy" "example1" {
 			name = "%s"
-			authentication_algorithm = "sha1"
+			authentication_algorithm = "sha256"
 			encryption_algorithm = "aes128"
-			pfs = "group_2"
+			pfs = "group_14"
+			key_lifetime = 3600
 		}
+		
+		resource "ibm_is_ipsec_policy" "example2" {
+			name = "%s"
+			authentication_algorithm = "sha512"
+			encryption_algorithm = "aes256"
+			pfs = "group_19"
+			key_lifetime = 7200
+		}
+		
 		data "ibm_is_ipsec_policies" "is_ipsec_policies" {
-			depends_on = [ibm_is_ipsec_policy.example]
+			depends_on = [
+				ibm_is_ipsec_policy.example1,
+				ibm_is_ipsec_policy.example2
+			]
 		}
-	`, name)
+	`, name1, name2)
 }

--- a/ibm/service/vpc/data_source_ibm_is_ipsec_policy_test.go
+++ b/ibm/service/vpc/data_source_ibm_is_ipsec_policy_test.go
@@ -13,62 +13,84 @@ import (
 )
 
 func TestAccIBMIsIpsecPolicyDataSourceBasic(t *testing.T) {
-	name := fmt.Sprintf("tfipsecc-name-%d", acctest.RandIntRange(10, 100))
+	name := fmt.Sprintf("tfipsec-data-%d", acctest.RandIntRange(10, 100))
+	resourceKey := "ibm_is_ipsec_policy.example"
+	dataSourceNameKey := "data.ibm_is_ipsec_policy.by_name"
+	dataSourceIDKey := "data.ibm_is_ipsec_policy.by_id"
+
 	resource.Test(t, resource.TestCase{
 		PreCheck:  func() { acc.TestAccPreCheck(t) },
 		Providers: acc.TestAccProviders,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckIBMIsIpsecPolicyDataSourceConfigBasic(name),
+				Config: testAccCheckIBMIsIpsecPolicyDataSourceConfig(name),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttrSet("data.ibm_is_ipsec_policy.is_ipsec_policy", "authentication_algorithm"),
-					resource.TestCheckResourceAttrSet("data.ibm_is_ipsec_policy.is_ipsec_policy", "connections.#"),
-					resource.TestCheckResourceAttrSet("data.ibm_is_ipsec_policy.is_ipsec_policy", "created_at"),
-					resource.TestCheckResourceAttrSet("data.ibm_is_ipsec_policy.is_ipsec_policy", "encapsulation_mode"),
-					resource.TestCheckResourceAttrSet("data.ibm_is_ipsec_policy.is_ipsec_policy", "encryption_algorithm"),
-					resource.TestCheckResourceAttrSet("data.ibm_is_ipsec_policy.is_ipsec_policy", "href"),
-					resource.TestCheckResourceAttrSet("data.ibm_is_ipsec_policy.is_ipsec_policy", "key_lifetime"),
-					resource.TestCheckResourceAttrSet("data.ibm_is_ipsec_policy.is_ipsec_policy", "name"),
-					resource.TestCheckResourceAttrSet("data.ibm_is_ipsec_policy.is_ipsec_policy", "pfs"),
-					resource.TestCheckResourceAttrSet("data.ibm_is_ipsec_policy.is_ipsec_policy", "resource_group.#"),
-					resource.TestCheckResourceAttrSet("data.ibm_is_ipsec_policy.is_ipsec_policy", "resource_type"),
-					resource.TestCheckResourceAttrSet("data.ibm_is_ipsec_policy.is_ipsec_policy", "transform_protocol"),
-				),
-			},
-			{
-				Config: testAccCheckIBMIsIpsecPolicyDataSourceConfigBasic(name),
-				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttrSet("data.ibm_is_ipsec_policy.is_ipsec_policy1", "authentication_algorithm"),
-					resource.TestCheckResourceAttrSet("data.ibm_is_ipsec_policy.is_ipsec_policy1", "connections.#"),
-					resource.TestCheckResourceAttrSet("data.ibm_is_ipsec_policy.is_ipsec_policy1", "created_at"),
-					resource.TestCheckResourceAttrSet("data.ibm_is_ipsec_policy.is_ipsec_policy1", "encapsulation_mode"),
-					resource.TestCheckResourceAttrSet("data.ibm_is_ipsec_policy.is_ipsec_policy1", "encryption_algorithm"),
-					resource.TestCheckResourceAttrSet("data.ibm_is_ipsec_policy.is_ipsec_policy1", "href"),
-					resource.TestCheckResourceAttrSet("data.ibm_is_ipsec_policy.is_ipsec_policy1", "key_lifetime"),
-					resource.TestCheckResourceAttrSet("data.ibm_is_ipsec_policy.is_ipsec_policy1", "name"),
-					resource.TestCheckResourceAttrSet("data.ibm_is_ipsec_policy.is_ipsec_policy1", "pfs"),
-					resource.TestCheckResourceAttrSet("data.ibm_is_ipsec_policy.is_ipsec_policy1", "resource_group.#"),
-					resource.TestCheckResourceAttrSet("data.ibm_is_ipsec_policy.is_ipsec_policy1", "resource_type"),
-					resource.TestCheckResourceAttrSet("data.ibm_is_ipsec_policy.is_ipsec_policy1", "transform_protocol"),
+					// Check when lookup is by name
+					resource.TestCheckResourceAttrPair(dataSourceNameKey, "id", resourceKey, "id"),
+					resource.TestCheckResourceAttrPair(dataSourceNameKey, "name", resourceKey, "name"),
+					resource.TestCheckResourceAttrPair(dataSourceNameKey, "authentication_algorithm", resourceKey, "authentication_algorithm"),
+					resource.TestCheckResourceAttrPair(dataSourceNameKey, "encryption_algorithm", resourceKey, "encryption_algorithm"),
+					resource.TestCheckResourceAttrPair(dataSourceNameKey, "pfs", resourceKey, "pfs"),
+					resource.TestCheckResourceAttrPair(dataSourceNameKey, "key_lifetime", resourceKey, "key_lifetime"),
+
+					// Check computed fields for name lookup
+					resource.TestCheckResourceAttrSet(dataSourceNameKey, "connections.#"),
+					resource.TestCheckResourceAttrSet(dataSourceNameKey, "created_at"),
+					resource.TestCheckResourceAttrSet(dataSourceNameKey, "href"),
+					resource.TestCheckResourceAttrSet(dataSourceNameKey, "encapsulation_mode"),
+					resource.TestCheckResourceAttrSet(dataSourceNameKey, "transform_protocol"),
+					resource.TestCheckResourceAttrSet(dataSourceNameKey, "resource_group.#"),
+					resource.TestCheckResourceAttrSet(dataSourceNameKey, "resource_type"),
+
+					// Check specific values for computed fields
+					resource.TestCheckResourceAttr(dataSourceNameKey, "encapsulation_mode", "tunnel"),
+					resource.TestCheckResourceAttr(dataSourceNameKey, "transform_protocol", "esp"),
+
+					// Check resource_group nested fields
+					resource.TestCheckResourceAttrSet(dataSourceNameKey, "resource_group.0.id"),
+					resource.TestCheckResourceAttrSet(dataSourceNameKey, "resource_group.0.name"),
+					resource.TestCheckResourceAttrSet(dataSourceNameKey, "resource_group.0.href"),
+
+					// Check when lookup is by ID
+					resource.TestCheckResourceAttrPair(dataSourceIDKey, "id", resourceKey, "id"),
+					resource.TestCheckResourceAttrPair(dataSourceIDKey, "name", resourceKey, "name"),
+					resource.TestCheckResourceAttrPair(dataSourceIDKey, "authentication_algorithm", resourceKey, "authentication_algorithm"),
+					resource.TestCheckResourceAttrPair(dataSourceIDKey, "encryption_algorithm", resourceKey, "encryption_algorithm"),
+					resource.TestCheckResourceAttrPair(dataSourceIDKey, "pfs", resourceKey, "pfs"),
+					resource.TestCheckResourceAttrPair(dataSourceIDKey, "key_lifetime", resourceKey, "key_lifetime"),
+
+					// Check computed fields for ID lookup
+					resource.TestCheckResourceAttrSet(dataSourceIDKey, "connections.#"),
+					resource.TestCheckResourceAttrSet(dataSourceIDKey, "created_at"),
+					resource.TestCheckResourceAttrSet(dataSourceIDKey, "href"),
+					resource.TestCheckResourceAttrSet(dataSourceIDKey, "encapsulation_mode"),
+					resource.TestCheckResourceAttrSet(dataSourceIDKey, "transform_protocol"),
+					resource.TestCheckResourceAttrSet(dataSourceIDKey, "resource_group.#"),
+					resource.TestCheckResourceAttrSet(dataSourceIDKey, "resource_type"),
 				),
 			},
 		},
 	})
 }
 
-func testAccCheckIBMIsIpsecPolicyDataSourceConfigBasic(name string) string {
+func testAccCheckIBMIsIpsecPolicyDataSourceConfig(name string) string {
 	return fmt.Sprintf(`
-    	resource "ibm_is_ipsec_policy" "example" {
-    		name = "%s"
-    		authentication_algorithm = "sha1"
-    		encryption_algorithm = "aes128"
-    		pfs = "group_2"
-    	}
-		data "ibm_is_ipsec_policy" "is_ipsec_policy" {
-			ipsec_policy = ibm_is_ipsec_policy.example.id
+		resource "ibm_is_ipsec_policy" "example" {
+			name = "%s"
+			authentication_algorithm = "sha256"
+			encryption_algorithm = "aes128"
+			pfs = "group_14"
+			key_lifetime = 3600
 		}
-		data "ibm_is_ipsec_policy" "is_ipsec_policy1" {
+		
+		data "ibm_is_ipsec_policy" "by_name" {
 			name = ibm_is_ipsec_policy.example.name
+			depends_on = [ibm_is_ipsec_policy.example]
+		}
+		
+		data "ibm_is_ipsec_policy" "by_id" {
+			ipsec_policy = ibm_is_ipsec_policy.example.id
+			depends_on = [ibm_is_ipsec_policy.example]
 		}
 	`, name)
 }

--- a/ibm/service/vpc/resource_ibm_is_ike_policy_test.go
+++ b/ibm/service/vpc/resource_ibm_is_ike_policy_test.go
@@ -19,6 +19,9 @@ import (
 
 func TestAccIBMISIKEPolicy_basic(t *testing.T) {
 	name := fmt.Sprintf("tfike-name-%d", acctest.RandIntRange(10, 100))
+	updatedName := fmt.Sprintf("tfike-updated-%d", acctest.RandIntRange(10, 100))
+	resourceKey := "ibm_is_ike_policy.example"
+
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { acc.TestAccPreCheck(t) },
 		Providers:    acc.TestAccProviders,
@@ -27,31 +30,208 @@ func TestAccIBMISIKEPolicy_basic(t *testing.T) {
 			{
 				Config: testAccCheckIBMISIKEPolicyConfig(name),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(
-						"ibm_is_ike_policy.example", "name", name),
-					resource.TestCheckResourceAttr(
-						"ibm_is_ike_policy.example", "authentication_algorithm", "sha256"),
-					resource.TestCheckResourceAttr(
-						"ibm_is_ike_policy.example", "encryption_algorithm", "aes128"),
-					resource.TestCheckResourceAttr(
-						"ibm_is_ike_policy.example", "dh_group", "14"),
-					resource.TestCheckResourceAttr(
-						"ibm_is_ike_policy.example", "ike_version", "1"),
+					resource.TestCheckResourceAttr(resourceKey, "name", name),
+					resource.TestCheckResourceAttr(resourceKey, "authentication_algorithm", "sha256"),
+					resource.TestCheckResourceAttr(resourceKey, "encryption_algorithm", "aes128"),
+					resource.TestCheckResourceAttr(resourceKey, "dh_group", "14"),
+					resource.TestCheckResourceAttr(resourceKey, "ike_version", "1"),
+					resource.TestCheckResourceAttr(resourceKey, "key_lifetime", "28800"), // Default value
+					resource.TestCheckResourceAttrSet(resourceKey, "negotiation_mode"),
+					resource.TestCheckResourceAttrSet(resourceKey, "href"),
 				),
 			},
 			{
 				Config: testAccCheckIBMISIKEPolicyConfigUpdate(name),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(
-						"ibm_is_ike_policy.example", "name", name),
-					resource.TestCheckResourceAttr(
-						"ibm_is_ike_policy.example", "authentication_algorithm", "sha384"),
-					resource.TestCheckResourceAttr(
-						"ibm_is_ike_policy.example", "encryption_algorithm", "aes256"),
-					resource.TestCheckResourceAttr(
-						"ibm_is_ike_policy.example", "dh_group", "15"),
-					resource.TestCheckResourceAttr(
-						"ibm_is_ike_policy.example", "ike_version", "2"),
+					resource.TestCheckResourceAttr(resourceKey, "name", name),
+					resource.TestCheckResourceAttr(resourceKey, "authentication_algorithm", "sha384"),
+					resource.TestCheckResourceAttr(resourceKey, "encryption_algorithm", "aes256"),
+					resource.TestCheckResourceAttr(resourceKey, "dh_group", "15"),
+					resource.TestCheckResourceAttr(resourceKey, "ike_version", "2"),
+					resource.TestCheckResourceAttr(resourceKey, "key_lifetime", "1800"), // Updated value
+				),
+			},
+			{
+				Config: testAccCheckIBMISIKEPolicyConfigUpdateAll(updatedName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceKey, "name", updatedName),
+					resource.TestCheckResourceAttr(resourceKey, "authentication_algorithm", "sha512"),
+					resource.TestCheckResourceAttr(resourceKey, "encryption_algorithm", "aes192"),
+					resource.TestCheckResourceAttr(resourceKey, "dh_group", "16"),
+					resource.TestCheckResourceAttr(resourceKey, "ike_version", "2"),
+					resource.TestCheckResourceAttr(resourceKey, "key_lifetime", "3600"),
+				),
+			},
+			// Test importing the resource
+			{
+				ResourceName:      resourceKey,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+// Test with resource group
+func TestAccIBMISIKEPolicy_withResourceGroup(t *testing.T) {
+	name := fmt.Sprintf("tfike-rg-%d", acctest.RandIntRange(10, 100))
+	resourceKey := "ibm_is_ike_policy.example_with_rg"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { acc.TestAccPreCheck(t) },
+		Providers:    acc.TestAccProviders,
+		CheckDestroy: checkIKEPolicyDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckIBMISIKEPolicyWithResourceGroupConfig(name),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceKey, "name", name),
+					resource.TestCheckResourceAttr(resourceKey, "authentication_algorithm", "sha256"),
+					resource.TestCheckResourceAttr(resourceKey, "encryption_algorithm", "aes192"),
+					resource.TestCheckResourceAttr(resourceKey, "dh_group", "19"),
+					resource.TestCheckResourceAttr(resourceKey, "ike_version", "1"),
+					resource.TestCheckResourceAttrSet(resourceKey, "resource_group"),
+					resource.TestCheckResourceAttrSet(resourceKey, "resource_group_name"),
+				),
+			},
+			// Test importing the resource
+			{
+				ResourceName:      resourceKey,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+// Test computed fields
+func TestAccIBMISIKEPolicy_ComputedFields(t *testing.T) {
+	name := fmt.Sprintf("tfike-computed-%d", acctest.RandIntRange(10, 100))
+	resourceKey := "ibm_is_ike_policy.computed_test"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { acc.TestAccPreCheck(t) },
+		Providers:    acc.TestAccProviders,
+		CheckDestroy: checkIKEPolicyDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckIBMISIKEPolicyConfigBasic(name),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceKey, "name", name),
+					// Check computed fields are set
+					resource.TestCheckResourceAttrSet(resourceKey, "negotiation_mode"),
+					resource.TestCheckResourceAttrSet(resourceKey, "href"),
+					resource.TestCheckResourceAttrSet(resourceKey, "resource_controller_url"),
+					resource.TestCheckResourceAttrSet(resourceKey, "resource_name"),
+					resource.TestCheckResourceAttrSet(resourceKey, "resource_group_name"),
+
+					// Additional check for vpn_connections if any exist
+					// Note: Since this is just a policy, there might not be connections yet
+					resource.TestCheckResourceAttr(resourceKey, "vpn_connections.#", "0"),
+				),
+			},
+		},
+	})
+}
+
+// Test various algorithm and dh_group combinations
+func TestAccIBMISIKEPolicy_Algorithms(t *testing.T) {
+	namePrefix := "tfike-alg-"
+
+	// Test different algorithm combinations
+	testCases := []struct {
+		name                string
+		authAlgorithm       string
+		encryptionAlgorithm string
+		dhGroup             int
+		ikeVersion          int
+	}{
+		{
+			name:                "sha384-aes128-group16-ike1",
+			authAlgorithm:       "sha384",
+			encryptionAlgorithm: "aes128",
+			dhGroup:             16,
+			ikeVersion:          1,
+		},
+		{
+			name:                "sha256-aes192-group15-ike2",
+			authAlgorithm:       "sha256",
+			encryptionAlgorithm: "aes192",
+			dhGroup:             15,
+			ikeVersion:          2,
+		},
+		{
+			name:                "sha384-aes256-group14-ike1",
+			authAlgorithm:       "sha384",
+			encryptionAlgorithm: "aes256",
+			dhGroup:             14,
+			ikeVersion:          1,
+		},
+		{
+			name:                "sha512-aes128-group19-ike2",
+			authAlgorithm:       "sha512",
+			encryptionAlgorithm: "aes128",
+			dhGroup:             19,
+			ikeVersion:          2,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			name := fmt.Sprintf("%s%d", namePrefix, acctest.RandIntRange(10, 100))
+			resourceKey := "ibm_is_ike_policy.algorithm_test"
+
+			resource.Test(t, resource.TestCase{
+				PreCheck:     func() { acc.TestAccPreCheck(t) },
+				Providers:    acc.TestAccProviders,
+				CheckDestroy: checkIKEPolicyDestroy,
+				Steps: []resource.TestStep{
+					{
+						Config: testAccCheckIBMISIKEPolicyAlgorithmConfig(name, tc.authAlgorithm, tc.encryptionAlgorithm, tc.dhGroup, tc.ikeVersion),
+						Check: resource.ComposeTestCheckFunc(
+							resource.TestCheckResourceAttr(resourceKey, "name", name),
+							resource.TestCheckResourceAttr(resourceKey, "authentication_algorithm", tc.authAlgorithm),
+							resource.TestCheckResourceAttr(resourceKey, "encryption_algorithm", tc.encryptionAlgorithm),
+							resource.TestCheckResourceAttr(resourceKey, "dh_group", fmt.Sprintf("%d", tc.dhGroup)),
+							resource.TestCheckResourceAttr(resourceKey, "ike_version", fmt.Sprintf("%d", tc.ikeVersion)),
+						),
+					},
+				},
+			})
+		})
+	}
+}
+
+// Test key_lifetime values and validation
+func TestAccIBMISIKEPolicy_KeyLifetime(t *testing.T) {
+	name := fmt.Sprintf("tfike-lifetime-%d", acctest.RandIntRange(10, 100))
+	resourceKey := "ibm_is_ike_policy.lifetime_test"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { acc.TestAccPreCheck(t) },
+		Providers:    acc.TestAccProviders,
+		CheckDestroy: checkIKEPolicyDestroy,
+		Steps: []resource.TestStep{
+			{
+				// Use default lifetime value
+				Config: testAccCheckIBMISIKEPolicyLifetimeConfig(name),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceKey, "name", name),
+					resource.TestCheckResourceAttr(resourceKey, "key_lifetime", "28800"), // Default value
+				),
+			},
+			{
+				// Update with minimum lifetime value
+				Config: testAccCheckIBMISIKEPolicyLifetimeConfigUpdate(name, 1800), // 30 minutes
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceKey, "key_lifetime", "1800"),
+				),
+			},
+			{
+				// Update with maximum lifetime value
+				Config: testAccCheckIBMISIKEPolicyLifetimeConfigUpdate(name, 86400), // 24 hours
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceKey, "key_lifetime", "86400"),
 				),
 			},
 		},
@@ -111,6 +291,7 @@ func testAccCheckIBMISIKEPolicyConfig(name string) string {
 			encryption_algorithm = "aes128"
 			dh_group = 14
 			ike_version = 1
+			# key_lifetime defaults to 28800
 		}
 	`, name)
 }
@@ -126,4 +307,82 @@ func testAccCheckIBMISIKEPolicyConfigUpdate(name string) string {
 			key_lifetime = 1800
 		}
 	`, name)
+}
+
+func testAccCheckIBMISIKEPolicyConfigUpdateAll(name string) string {
+	return fmt.Sprintf(`
+		resource "ibm_is_ike_policy" "example" {
+			name = "%s"
+			authentication_algorithm = "sha512"
+			encryption_algorithm = "aes192"
+			dh_group = 16
+			ike_version = 2
+			key_lifetime = 3600
+		}
+	`, name)
+}
+
+func testAccCheckIBMISIKEPolicyConfigBasic(name string) string {
+	return fmt.Sprintf(`
+		resource "ibm_is_ike_policy" "computed_test" {
+			name = "%s"
+			authentication_algorithm = "sha256"
+			encryption_algorithm = "aes128"
+			dh_group = 14
+			ike_version = 1
+		}
+	`, name)
+}
+
+func testAccCheckIBMISIKEPolicyWithResourceGroupConfig(name string) string {
+	return fmt.Sprintf(`
+		data "ibm_resource_group" "group" {
+			name = "Default" # Using Default resource group, change if needed
+		}
+		
+		resource "ibm_is_ike_policy" "example_with_rg" {
+			name = "%s"
+			authentication_algorithm = "sha256"
+			encryption_algorithm = "aes192"
+			dh_group = 19
+			ike_version = 1
+			resource_group = data.ibm_resource_group.group.id
+		}
+	`, name)
+}
+
+func testAccCheckIBMISIKEPolicyAlgorithmConfig(name, authAlg, encAlg string, dhGroup, ikeVersion int) string {
+	return fmt.Sprintf(`
+		resource "ibm_is_ike_policy" "algorithm_test" {
+			name = "%s"
+			authentication_algorithm = "%s"
+			encryption_algorithm = "%s"
+			dh_group = %d
+			ike_version = %d
+		}
+	`, name, authAlg, encAlg, dhGroup, ikeVersion)
+}
+
+func testAccCheckIBMISIKEPolicyLifetimeConfig(name string) string {
+	return fmt.Sprintf(`
+		resource "ibm_is_ike_policy" "lifetime_test" {
+			name = "%s"
+			authentication_algorithm = "sha256"
+			encryption_algorithm = "aes128"
+			dh_group = 14
+			ike_version = 1
+		}
+	`, name)
+}
+func testAccCheckIBMISIKEPolicyLifetimeConfigUpdate(name string, lifetime int) string {
+	return fmt.Sprintf(`
+		resource "ibm_is_ike_policy" "lifetime_test" {
+			name = "%s"
+			authentication_algorithm = "sha256"
+			encryption_algorithm = "aes128"
+			dh_group = 14
+			ike_version = 1
+			key_lifetime = %d
+		}
+	`, name, lifetime)
 }

--- a/ibm/service/vpc/resource_ibm_is_ipsec_policy_test.go
+++ b/ibm/service/vpc/resource_ibm_is_ipsec_policy_test.go
@@ -19,6 +19,9 @@ import (
 
 func TestAccIBMISIPSecPolicy_basic(t *testing.T) {
 	name := fmt.Sprintf("tfipsecc-name-%d", acctest.RandIntRange(10, 100))
+	updatedName := fmt.Sprintf("tfipsecc-updated-%d", acctest.RandIntRange(10, 100))
+	resourceKey := "ibm_is_ipsec_policy.example"
+
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { acc.TestAccPreCheck(t) },
 		Providers:    acc.TestAccProviders,
@@ -27,28 +30,71 @@ func TestAccIBMISIPSecPolicy_basic(t *testing.T) {
 			{
 				Config: testAccCheckIBMISIPSecPolicyConfig(name),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(
-						"ibm_is_ipsec_policy.example", "name", name),
-					resource.TestCheckResourceAttr(
-						"ibm_is_ipsec_policy.example", "authentication_algorithm", "sha256"),
-					resource.TestCheckResourceAttr(
-						"ibm_is_ipsec_policy.example", "encryption_algorithm", "aes128"),
-					resource.TestCheckResourceAttr(
-						"ibm_is_ipsec_policy.example", "pfs", "disabled"),
+					resource.TestCheckResourceAttr(resourceKey, "name", name),
+					resource.TestCheckResourceAttr(resourceKey, "authentication_algorithm", "sha256"),
+					resource.TestCheckResourceAttr(resourceKey, "encryption_algorithm", "aes128"),
+					resource.TestCheckResourceAttr(resourceKey, "pfs", "disabled"),
+					resource.TestCheckResourceAttr(resourceKey, "key_lifetime", "3600"), // Testing default value
+					resource.TestCheckResourceAttrSet(resourceKey, "encapsulation_mode"),
+					resource.TestCheckResourceAttrSet(resourceKey, "transform_protocol"),
 				),
 			},
 			{
 				Config: testAccCheckIBMISIPSecPolicyConfigUpdate(name),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(
-						"ibm_is_ipsec_policy.example", "name", name),
-					resource.TestCheckResourceAttr(
-						"ibm_is_ipsec_policy.example", "authentication_algorithm", "sha512"),
-					resource.TestCheckResourceAttr(
-						"ibm_is_ipsec_policy.example", "encryption_algorithm", "aes256"),
-					resource.TestCheckResourceAttr(
-						"ibm_is_ipsec_policy.example", "pfs", "group_14"),
+					resource.TestCheckResourceAttr(resourceKey, "name", name),
+					resource.TestCheckResourceAttr(resourceKey, "authentication_algorithm", "sha512"),
+					resource.TestCheckResourceAttr(resourceKey, "encryption_algorithm", "aes256"),
+					resource.TestCheckResourceAttr(resourceKey, "pfs", "group_14"),
+					resource.TestCheckResourceAttr(resourceKey, "key_lifetime", "7200"), // Testing updated value
 				),
+			},
+			{
+				Config: testAccCheckIBMISIPSecPolicyConfigUpdateAll(updatedName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceKey, "name", updatedName),
+					resource.TestCheckResourceAttr(resourceKey, "authentication_algorithm", "sha384"),
+					resource.TestCheckResourceAttr(resourceKey, "encryption_algorithm", "aes128"),
+					resource.TestCheckResourceAttr(resourceKey, "pfs", "group_14"),
+					resource.TestCheckResourceAttr(resourceKey, "key_lifetime", "10800"),
+				),
+			},
+			// Test importing the resource
+			{
+				ResourceName:      resourceKey,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+// Test with resource group
+func TestAccIBMISIPSecPolicy_withResourceGroup(t *testing.T) {
+	name := fmt.Sprintf("tfipsecc-name-%d", acctest.RandIntRange(10, 100))
+	resourceKey := "ibm_is_ipsec_policy.example_with_rg"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { acc.TestAccPreCheck(t) },
+		Providers:    acc.TestAccProviders,
+		CheckDestroy: checkPolicyDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckIBMISIPSecPolicyWithResourceGroupConfig(name),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceKey, "name", name),
+					resource.TestCheckResourceAttr(resourceKey, "authentication_algorithm", "sha256"),
+					resource.TestCheckResourceAttr(resourceKey, "encryption_algorithm", "aes128"),
+					resource.TestCheckResourceAttr(resourceKey, "pfs", "group_17"),
+					resource.TestCheckResourceAttrSet(resourceKey, "resource_group"),
+					resource.TestCheckResourceAttrSet(resourceKey, "resource_group_name"),
+				),
+			},
+			// Test importing the resource
+			{
+				ResourceName:      resourceKey,
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 		},
 	})
@@ -118,7 +164,142 @@ func testAccCheckIBMISIPSecPolicyConfigUpdate(name string) string {
 			name = "%s"
 			authentication_algorithm = "sha512"
 			encryption_algorithm = "aes256"
-			pfs = "group_2"
+			pfs = "group_14"
+			key_lifetime = 7200
+		}
+	`, name)
+}
+
+func testAccCheckIBMISIPSecPolicyConfigUpdateAll(name string) string {
+	return fmt.Sprintf(`
+		resource "ibm_is_ipsec_policy" "example" {
+			name = "%s"
+			authentication_algorithm = "sha384"
+			encryption_algorithm = "aes128"
+			pfs = "group_14" 
+			key_lifetime = 10800
+		}
+	`, name)
+}
+
+func testAccCheckIBMISIPSecPolicyWithResourceGroupConfig(name string) string {
+	return fmt.Sprintf(`
+		data "ibm_resource_group" "group" {
+			name = "Default"
+		}
+		
+		resource "ibm_is_ipsec_policy" "example_with_rg" {
+			name = "%s"
+			authentication_algorithm = "sha256"
+			encryption_algorithm = "aes128"
+			pfs = "group_17"
+			resource_group = data.ibm_resource_group.group.id
+		}
+	`, name)
+}
+
+func TestAccIBMISIPSecPolicy_Algorithms(t *testing.T) {
+	namePrefix := "tfipsecc-alg-"
+
+	// Test different algorithm combinations
+	testCases := []struct {
+		name                string
+		authAlgorithm       string
+		encryptionAlgorithm string
+		pfs                 string
+	}{
+		{
+			name:                "sha384-aes128-group_15",
+			authAlgorithm:       "sha384",
+			encryptionAlgorithm: "aes128",
+			pfs:                 "group_15",
+		},
+		{
+			name:                "disabled-aes128gcm16-group19",
+			authAlgorithm:       "disabled",
+			encryptionAlgorithm: "aes128gcm16",
+			pfs:                 "group_19",
+		},
+		{
+			name:                "sha512-aes256-group20",
+			authAlgorithm:       "sha512",
+			encryptionAlgorithm: "aes256",
+			pfs:                 "group_20",
+		},
+		{
+			name:                "disabled-aes256gcm16-group_31",
+			authAlgorithm:       "disabled",
+			encryptionAlgorithm: "aes256gcm16",
+			pfs:                 "group_31",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			name := fmt.Sprintf("%s%d", namePrefix, acctest.RandIntRange(10, 100))
+			resourceKey := "ibm_is_ipsec_policy.algorithm_test"
+
+			resource.Test(t, resource.TestCase{
+				PreCheck:     func() { acc.TestAccPreCheck(t) },
+				Providers:    acc.TestAccProviders,
+				CheckDestroy: checkPolicyDestroy,
+				Steps: []resource.TestStep{
+					{
+						Config: testAccCheckIBMISIPSecPolicyAlgorithmConfig(name, tc.authAlgorithm, tc.encryptionAlgorithm, tc.pfs),
+						Check: resource.ComposeTestCheckFunc(
+							resource.TestCheckResourceAttr(resourceKey, "name", name),
+							resource.TestCheckResourceAttr(resourceKey, "authentication_algorithm", tc.authAlgorithm),
+							resource.TestCheckResourceAttr(resourceKey, "encryption_algorithm", tc.encryptionAlgorithm),
+							resource.TestCheckResourceAttr(resourceKey, "pfs", tc.pfs),
+						),
+					},
+				},
+			})
+		})
+	}
+}
+
+func testAccCheckIBMISIPSecPolicyAlgorithmConfig(name, authAlg, encAlg, pfs string) string {
+	return fmt.Sprintf(`
+		resource "ibm_is_ipsec_policy" "algorithm_test" {
+			name = "%s"
+			authentication_algorithm = "%s"
+			encryption_algorithm = "%s"
+			pfs = "%s"
+		}
+	`, name, authAlg, encAlg, pfs)
+}
+func TestAccIBMISIPSecPolicy_ComputedFields(t *testing.T) {
+	name := fmt.Sprintf("tfipsecc-computed-%d", acctest.RandIntRange(10, 100))
+	resourceKey := "ibm_is_ipsec_policy.computed_test"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { acc.TestAccPreCheck(t) },
+		Providers:    acc.TestAccProviders,
+		CheckDestroy: checkPolicyDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckIBMISIPSecPolicyConfigBasic(name),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceKey, "name", name),
+					// Check computed fields are set
+					resource.TestCheckResourceAttrSet(resourceKey, "encapsulation_mode"),
+					resource.TestCheckResourceAttrSet(resourceKey, "transform_protocol"),
+					resource.TestCheckResourceAttrSet(resourceKey, "resource_controller_url"),
+					resource.TestCheckResourceAttrSet(resourceKey, "resource_name"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckIBMISIPSecPolicyConfigBasic(name string) string {
+	return fmt.Sprintf(`
+		resource "ibm_is_ipsec_policy" "computed_test" {
+			name = "%s"
+			authentication_algorithm = "sha256"
+			encryption_algorithm = "aes128"
+			pfs = "group_17"
 		}
 	`, name)
 }


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/IBM-Cloud/terraform-provider-ibm/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```

% make testacc TEST=./ibm/service/vpc TESTARGS='-run=TestAccIBMISIPSecPolicy_ComputedFields'
=== RUN   TestAccIBMISIPSecPolicy_ComputedFields
--- PASS: TestAccIBMISIPSecPolicy_ComputedFields (23.93s)
PASS
ok      github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/vpc     26.048s

% make testacc TEST=./ibm/service/vpc TESTARGS='-run=TestAccIBMISIPSecPolicy_basic'
=== RUN   TestAccIBMISIPSecPolicy_basic
--- PASS: TestAccIBMISIPSecPolicy_basic (70.50s)
PASS
ok      github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/vpc     72.790s

% make testacc TEST=./ibm/service/vpc TESTARGS='-run=TestAccIBMISIPSecPolicy_withResourceGroup'
=== RUN   TestAccIBMISIPSecPolicy_withResourceGroup
--- PASS: TestAccIBMISIPSecPolicy_withResourceGroup (37.21s)
PASS
ok      github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/vpc     39.288s

% make testacc TEST=./ibm/service/vpc TESTARGS='-run=TestAccIBMISIPSecPolicy_Algorithms'
=== RUN   TestAccIBMISIPSecPolicy_Algorithms
=== RUN   TestAccIBMISIPSecPolicy_Algorithms/sha384-aes128-group_15
=== RUN   TestAccIBMISIPSecPolicy_Algorithms/disabled-aes128gcm16-group19
=== RUN   TestAccIBMISIPSecPolicy_Algorithms/sha512-aes256-group20
=== RUN   TestAccIBMISIPSecPolicy_Algorithms/disabled-aes256gcm16-group_31
--- PASS: TestAccIBMISIPSecPolicy_Algorithms (94.83s)
    --- PASS: TestAccIBMISIPSecPolicy_Algorithms/sha384-aes128-group_15 (26.57s)
    --- PASS: TestAccIBMISIPSecPolicy_Algorithms/disabled-aes128gcm16-group19 (22.33s)
    --- PASS: TestAccIBMISIPSecPolicy_Algorithms/sha512-aes256-group20 (22.86s)
    --- PASS: TestAccIBMISIPSecPolicy_Algorithms/disabled-aes256gcm16-group_31 (23.06s)
PASS
ok      github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/vpc     96.923s

% make testacc TEST=./ibm/service/vpc TESTARGS='-run=TestAccIBMISIKEPolicy_basic'
=== RUN   TestAccIBMISIKEPolicy_basic
--- PASS: TestAccIBMISIKEPolicy_basic (66.89s)
PASS
ok      github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/vpc     68.957s


% make testacc TEST=./ibm/service/vpc TESTARGS='-run=TestAccIBMISIKEPolicy_withResourceGroup'
=== RUN   TestAccIBMISIKEPolicy_withResourceGroup
--- PASS: TestAccIBMISIKEPolicy_withResourceGroup (45.00s)
PASS
ok      github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/vpc     47.139s

% make testacc TEST=./ibm/service/vpc TESTARGS='-run=TestAccIBMISIKEPolicy_ComputedFields'
=== RUN   TestAccIBMISIKEPolicy_ComputedFields
--- PASS: TestAccIBMISIKEPolicy_ComputedFields (21.47s)
PASS
ok      github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/vpc     23.314s


% make testacc TEST=./ibm/service/vpc TESTARGS='-run=TestAccIBMISIKEPolicy_Algorithms'
=== RUN   TestAccIBMISIKEPolicy_Algorithms
=== RUN   TestAccIBMISIKEPolicy_Algorithms/sha384-aes128-group16-ike1
=== RUN   TestAccIBMISIKEPolicy_Algorithms/sha256-aes192-group15-ike2
=== RUN   TestAccIBMISIKEPolicy_Algorithms/sha384-aes256-group14-ike1
=== RUN   TestAccIBMISIKEPolicy_Algorithms/sha512-aes128-group19-ike2
--- PASS: TestAccIBMISIKEPolicy_Algorithms (90.55s)
    --- PASS: TestAccIBMISIKEPolicy_Algorithms/sha384-aes128-group16-ike1 (26.37s)
    --- PASS: TestAccIBMISIKEPolicy_Algorithms/sha256-aes192-group15-ike2 (22.14s)
    --- PASS: TestAccIBMISIKEPolicy_Algorithms/sha384-aes256-group14-ike1 (20.54s)
    --- PASS: TestAccIBMISIKEPolicy_Algorithms/sha512-aes128-group19-ike2 (21.50s)
PASS
ok      github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/vpc     92.408s

% make testacc TEST=./ibm/service/vpc TESTARGS='-run=TestAccIBMISIKEPolicy_KeyLifetime'
=== RUN   TestAccIBMISIKEPolicy_KeyLifetime
--- PASS: TestAccIBMISIKEPolicy_KeyLifetime (59.95s)
PASS
ok      github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/vpc     62.280s


% make testacc TEST=./ibm/service/vpc TESTARGS='-run=TestAccIBMIsIkePolicyDataSourceBasic'
=== RUN   TestAccIBMIsIkePolicyDataSourceBasic
--- PASS: TestAccIBMIsIkePolicyDataSourceBasic (36.60s)
PASS
ok      github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/vpc     38.684s

% make testacc TEST=./ibm/service/vpc TESTARGS='-run=TestAccIBMIsIkePoliciesDataSourceBasic'
=== RUN   TestAccIBMIsIkePoliciesDataSourceBasic
--- PASS: TestAccIBMIsIkePoliciesDataSourceBasic (33.10s)
PASS
ok      github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/vpc     35.231s

% make testacc TEST=./ibm/service/vpc TESTARGS='-run=TestAccIBMIsIpsecPoliciesDataSourceBasic'
=== RUN   TestAccIBMIsIpsecPoliciesDataSourceBasic
--- PASS: TestAccIBMIsIpsecPoliciesDataSourceBasic (26.92s)
PASS
ok      github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/vpc     28.732s

% make testacc TEST=./ibm/service/vpc TESTARGS='-run=TestAccIBMIsIpsecPolicyDataSourceBasic'
=== RUN   TestAccIBMIsIpsecPolicyDataSourceBasic
--- PASS: TestAccIBMIsIpsecPolicyDataSourceBasic (26.58s)
PASS
ok      github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/vpc     28.666s
```
