### PR TITLE
enhancement: improved error handling for vpc reservations

### DIFF
--- a/ibm/service/vpc/data_source_ibm_is_reservation.go
+++ b/ibm/service/vpc/data_source_ibm_is_reservation.go
@@ -221,7 +221,7 @@ func DataSourceIBMIsReservation() *schema.Resource {
 func dataSourceIBMIsReservationRead(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	sess, err := vpcClient(meta)
 	if err != nil {
-		tfErr := flex.DiscriminatedTerraformErrorf(err, err.Error(), "(Data) ibm_ibm_is_reservation", "read", "initialize-client")
+		tfErr := flex.DiscriminatedTerraformErrorf(err, err.Error(), "(Data) ibm_is_reservation", "read", "initialize-client")
 		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
 		return tfErr.GetDiag()
 	}
@@ -233,7 +233,7 @@ func dataSourceIBMIsReservationRead(context context.Context, d *schema.ResourceD
 		getReservationOptions.SetID(id)
 		reservationInfo, _, err := sess.GetReservationWithContext(context, getReservationOptions)
 		if err != nil {
-			tfErr := flex.TerraformErrorf(err, fmt.Sprintf("GetReservationWithContext failed: %s", err.Error()), "(Data) ibm_ibm_is_reservation", "read")
+			tfErr := flex.TerraformErrorf(err, fmt.Sprintf("GetReservationWithContext failed: %s", err.Error()), "(Data) ibm_is_reservation", "read")
 			log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
 			return tfErr.GetDiag()
 		}
@@ -252,7 +252,7 @@ func dataSourceIBMIsReservationRead(context context.Context, d *schema.ResourceD
 			}
 			reservationCollection, _, err := sess.ListReservationsWithContext(context, listReservationsOptions)
 			if err != nil {
-				tfErr := flex.TerraformErrorf(err, fmt.Sprintf("ListReservationsWithContext failed: %s", err.Error()), "(Data) ibm_ibm_is_reservation", "read")
+				tfErr := flex.TerraformErrorf(err, fmt.Sprintf("ListReservationsWithContext failed: %s", err.Error()), "(Data) ibm_is_reservation", "read")
 				log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
 				return tfErr.GetDiag()
 			}
@@ -272,7 +272,7 @@ func dataSourceIBMIsReservationRead(context context.Context, d *schema.ResourceD
 			}
 		}
 		if reservation == nil {
-			tfErr := flex.TerraformErrorf(err, fmt.Sprintf("No reservation found with name: %s", name), "(Data) ibm_ibm_is_reservation", "read")
+			tfErr := flex.TerraformErrorf(err, fmt.Sprintf("No reservation found with name: %s", name), "(Data) ibm_is_reservation", "read")
 			log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
 			return tfErr.GetDiag()
 		}
@@ -281,14 +281,14 @@ func dataSourceIBMIsReservationRead(context context.Context, d *schema.ResourceD
 	d.SetId(*reservation.ID)
 
 	if err = d.Set("affinity_policy", reservation.AffinityPolicy); err != nil {
-		return flex.DiscriminatedTerraformErrorf(err, fmt.Sprintf("Error setting affinity_policy: %s", err), "(Data) ibm_ibm_is_reservation", "read", "set-affinity_policy").GetDiag()
+		return flex.DiscriminatedTerraformErrorf(err, fmt.Sprintf("Error setting affinity_policy: %s", err), "(Data) ibm_is_reservation", "read", "set-affinity_policy").GetDiag()
 	}
 	if reservation.Capacity != nil {
 		capacityList := []map[string]interface{}{}
 		capacityMap := dataSourceReservationCapacityToMap(*reservation.Capacity)
 		capacityList = append(capacityList, capacityMap)
 		if err = d.Set("capacity", capacityList); err != nil {
-			return flex.DiscriminatedTerraformErrorf(err, fmt.Sprintf("Error setting capacity: %s", err), "(Data) ibm_ibm_is_reservation", "read", "set-capacity").GetDiag()
+			return flex.DiscriminatedTerraformErrorf(err, fmt.Sprintf("Error setting capacity: %s", err), "(Data) ibm_is_reservation", "read", "set-capacity").GetDiag()
 		}
 	}
 	if reservation.CommittedUse != nil {
@@ -296,23 +296,23 @@ func dataSourceIBMIsReservationRead(context context.Context, d *schema.ResourceD
 		committedUseMap := dataSourceReservationCommittedUseToMap(*reservation.CommittedUse)
 		committedUseList = append(committedUseList, committedUseMap)
 		if err = d.Set("committed_use", committedUseList); err != nil {
-			return flex.DiscriminatedTerraformErrorf(err, fmt.Sprintf("Error setting committed_use: %s", err), "(Data) ibm_ibm_is_reservation", "read", "set-committed_use").GetDiag()
+			return flex.DiscriminatedTerraformErrorf(err, fmt.Sprintf("Error setting committed_use: %s", err), "(Data) ibm_is_reservation", "read", "set-committed_use").GetDiag()
 		}
 	}
 	if err = d.Set("created_at", flex.DateTimeToString(reservation.CreatedAt)); err != nil {
-		return flex.DiscriminatedTerraformErrorf(err, fmt.Sprintf("Error setting created_at: %s", err), "(Data) ibm_ibm_is_reservation", "read", "set-created_at").GetDiag()
+		return flex.DiscriminatedTerraformErrorf(err, fmt.Sprintf("Error setting created_at: %s", err), "(Data) ibm_is_reservation", "read", "set-created_at").GetDiag()
 	}
 	if err = d.Set("crn", reservation.CRN); err != nil {
-		return flex.DiscriminatedTerraformErrorf(err, fmt.Sprintf("Error setting crn: %s", err), "(Data) ibm_ibm_is_reservation", "read", "set-crn").GetDiag()
+		return flex.DiscriminatedTerraformErrorf(err, fmt.Sprintf("Error setting crn: %s", err), "(Data) ibm_is_reservation", "read", "set-crn").GetDiag()
 	}
 	if err = d.Set("href", reservation.Href); err != nil {
-		return flex.DiscriminatedTerraformErrorf(err, fmt.Sprintf("Error setting href: %s", err), "(Data) ibm_ibm_is_reservation", "read", "set-href").GetDiag()
+		return flex.DiscriminatedTerraformErrorf(err, fmt.Sprintf("Error setting href: %s", err), "(Data) ibm_is_reservation", "read", "set-href").GetDiag()
 	}
 	if err = d.Set("lifecycle_state", reservation.LifecycleState); err != nil {
-		return flex.DiscriminatedTerraformErrorf(err, fmt.Sprintf("Error setting lifecycle_state: %s", err), "(Data) ibm_ibm_is_reservation", "read", "set-lifecycle_state").GetDiag()
+		return flex.DiscriminatedTerraformErrorf(err, fmt.Sprintf("Error setting lifecycle_state: %s", err), "(Data) ibm_is_reservation", "read", "set-lifecycle_state").GetDiag()
 	}
 	if err = d.Set("name", reservation.Name); err != nil {
-		return flex.DiscriminatedTerraformErrorf(err, fmt.Sprintf("Error setting name: %s", err), "(Data) ibm_ibm_is_reservation", "read", "set-name").GetDiag()
+		return flex.DiscriminatedTerraformErrorf(err, fmt.Sprintf("Error setting name: %s", err), "(Data) ibm_is_reservation", "read", "set-name").GetDiag()
 	}
 	if reservation.Profile != nil {
 		profileList := []map[string]interface{}{}
@@ -320,7 +320,7 @@ func dataSourceIBMIsReservationRead(context context.Context, d *schema.ResourceD
 		profileMap := dataSourceReservationProfileToMap(profile)
 		profileList = append(profileList, profileMap)
 		if err = d.Set("profile", profileList); err != nil {
-			return flex.DiscriminatedTerraformErrorf(err, fmt.Sprintf("Error setting profile: %s", err), "(Data) ibm_ibm_is_reservation", "read", "set-profile").GetDiag()
+			return flex.DiscriminatedTerraformErrorf(err, fmt.Sprintf("Error setting profile: %s", err), "(Data) ibm_is_reservation", "read", "set-profile").GetDiag()
 		}
 	}
 	if reservation.ResourceGroup != nil {
@@ -328,14 +328,14 @@ func dataSourceIBMIsReservationRead(context context.Context, d *schema.ResourceD
 		resourceGroupMap := dataSourceReservationResourceGroupToMap(*reservation.ResourceGroup)
 		resourceGroupList = append(resourceGroupList, resourceGroupMap)
 		if err = d.Set("resource_group", resourceGroupList); err != nil {
-			return flex.DiscriminatedTerraformErrorf(err, fmt.Sprintf("Error setting resource_group: %s", err), "(Data) ibm_ibm_is_reservation", "read", "set-resource_group").GetDiag()
+			return flex.DiscriminatedTerraformErrorf(err, fmt.Sprintf("Error setting resource_group: %s", err), "(Data) ibm_is_reservation", "read", "set-resource_group").GetDiag()
 		}
 	}
 	if err = d.Set("resource_type", reservation.ResourceType); err != nil {
-		return flex.DiscriminatedTerraformErrorf(err, fmt.Sprintf("Error setting resource_type: %s", err), "(Data) ibm_ibm_is_reservation", "read", "set-resource_type").GetDiag()
+		return flex.DiscriminatedTerraformErrorf(err, fmt.Sprintf("Error setting resource_type: %s", err), "(Data) ibm_is_reservation", "read", "set-resource_type").GetDiag()
 	}
 	if err = d.Set("status", reservation.Status); err != nil {
-		return flex.DiscriminatedTerraformErrorf(err, fmt.Sprintf("Error setting status: %s", err), "(Data) ibm_ibm_is_reservation", "read", "set-status").GetDiag()
+		return flex.DiscriminatedTerraformErrorf(err, fmt.Sprintf("Error setting status: %s", err), "(Data) ibm_is_reservation", "read", "set-status").GetDiag()
 	}
 	if reservation.StatusReasons != nil {
 		statusReasonsList := []map[string]interface{}{}
@@ -343,7 +343,7 @@ func dataSourceIBMIsReservationRead(context context.Context, d *schema.ResourceD
 			statusReasonsList = append(statusReasonsList, dataSourceReservationStatusReasonsToMap(statusReasonsItem))
 		}
 		if err = d.Set("status_reasons", statusReasonsList); err != nil {
-			return flex.DiscriminatedTerraformErrorf(err, fmt.Sprintf("Error setting status_reasons: %s", err), "(Data) ibm_ibm_is_reservation", "read", "set-status_reasons").GetDiag()
+			return flex.DiscriminatedTerraformErrorf(err, fmt.Sprintf("Error setting status_reasons: %s", err), "(Data) ibm_is_reservation", "read", "set-status_reasons").GetDiag()
 		}
 	}
 	zone := ""
@@ -351,7 +351,7 @@ func dataSourceIBMIsReservationRead(context context.Context, d *schema.ResourceD
 		zone = *reservation.Zone.Name
 	}
 	if err = d.Set("zone", zone); err != nil {
-		return flex.DiscriminatedTerraformErrorf(err, fmt.Sprintf("Error setting zone: %s", err), "(Data) ibm_ibm_is_reservation", "read", "set-zone").GetDiag()
+		return flex.DiscriminatedTerraformErrorf(err, fmt.Sprintf("Error setting zone: %s", err), "(Data) ibm_is_reservation", "read", "set-zone").GetDiag()
 	}
 	return nil
 }

--- a/ibm/service/vpc/data_source_ibm_is_reservation.go
+++ b/ibm/service/vpc/data_source_ibm_is_reservation.go
@@ -221,7 +221,9 @@ func DataSourceIBMIsReservation() *schema.Resource {
 func dataSourceIBMIsReservationRead(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	sess, err := vpcClient(meta)
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.DiscriminatedTerraformErrorf(err, err.Error(), "(Data) ibm_ibm_is_reservation", "read", "initialize-client")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 	var reservation *vpcv1.Reservation
 
@@ -229,10 +231,11 @@ func dataSourceIBMIsReservationRead(context context.Context, d *schema.ResourceD
 		id := v.(string)
 		getReservationOptions := &vpcv1.GetReservationOptions{}
 		getReservationOptions.SetID(id)
-		reservationInfo, response, err := sess.GetReservationWithContext(context, getReservationOptions)
+		reservationInfo, _, err := sess.GetReservationWithContext(context, getReservationOptions)
 		if err != nil {
-			log.Printf("[DEBUG] GetReservationWithContext failed %s\n%s", err, response)
-			return diag.FromErr(fmt.Errorf("[ERROR] GetReservationWithContext failed %s\n%s", err, response))
+			tfErr := flex.TerraformErrorf(err, fmt.Sprintf("GetReservationWithContext failed: %s", err.Error()), "(Data) ibm_ibm_is_reservation", "read")
+			log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+			return tfErr.GetDiag()
 		}
 		reservation = reservationInfo
 
@@ -247,10 +250,11 @@ func dataSourceIBMIsReservationRead(context context.Context, d *schema.ResourceD
 			if start != "" {
 				listReservationsOptions.Start = &start
 			}
-			reservationCollection, response, err := sess.ListReservationsWithContext(context, listReservationsOptions)
+			reservationCollection, _, err := sess.ListReservationsWithContext(context, listReservationsOptions)
 			if err != nil {
-				log.Printf("[DEBUG] ListReservationsWithContext failed %s\n%s", err, response)
-				return diag.FromErr(fmt.Errorf("[ERROR] ListReservationsWithContext failed %s\n%s", err, response))
+				tfErr := flex.TerraformErrorf(err, fmt.Sprintf("ListReservationsWithContext failed: %s", err.Error()), "(Data) ibm_ibm_is_reservation", "read")
+				log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+				return tfErr.GetDiag()
 			}
 			if reservationCollection != nil && *reservationCollection.TotalCount == int64(0) {
 				break
@@ -268,20 +272,23 @@ func dataSourceIBMIsReservationRead(context context.Context, d *schema.ResourceD
 			}
 		}
 		if reservation == nil {
-			return diag.FromErr(fmt.Errorf("[ERROR] No reservation found with name (%s)", name))
+			tfErr := flex.TerraformErrorf(err, fmt.Sprintf("No reservation found with name: %s", name), "(Data) ibm_ibm_is_reservation", "read")
+			log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+			return tfErr.GetDiag()
 		}
 	}
 
 	d.SetId(*reservation.ID)
+
 	if err = d.Set("affinity_policy", reservation.AffinityPolicy); err != nil {
-		return diag.FromErr(fmt.Errorf("[ERROR] Error setting affinity_policy: %s", err))
+		return flex.DiscriminatedTerraformErrorf(err, fmt.Sprintf("Error setting affinity_policy: %s", err), "(Data) ibm_ibm_is_reservation", "read", "set-affinity_policy").GetDiag()
 	}
 	if reservation.Capacity != nil {
 		capacityList := []map[string]interface{}{}
 		capacityMap := dataSourceReservationCapacityToMap(*reservation.Capacity)
 		capacityList = append(capacityList, capacityMap)
 		if err = d.Set("capacity", capacityList); err != nil {
-			return diag.FromErr(fmt.Errorf("[ERROR] Error setting capacity: %s", err))
+			return flex.DiscriminatedTerraformErrorf(err, fmt.Sprintf("Error setting capacity: %s", err), "(Data) ibm_ibm_is_reservation", "read", "set-capacity").GetDiag()
 		}
 	}
 	if reservation.CommittedUse != nil {
@@ -289,23 +296,23 @@ func dataSourceIBMIsReservationRead(context context.Context, d *schema.ResourceD
 		committedUseMap := dataSourceReservationCommittedUseToMap(*reservation.CommittedUse)
 		committedUseList = append(committedUseList, committedUseMap)
 		if err = d.Set("committed_use", committedUseList); err != nil {
-			return diag.FromErr(fmt.Errorf("[ERROR] Error setting committed_use: %s", err))
+			return flex.DiscriminatedTerraformErrorf(err, fmt.Sprintf("Error setting committed_use: %s", err), "(Data) ibm_ibm_is_reservation", "read", "set-committed_use").GetDiag()
 		}
 	}
-	if err = d.Set("created_at", reservation.CreatedAt.String()); err != nil {
-		return diag.FromErr(fmt.Errorf("[ERROR] Error setting created_at: %s", err))
+	if err = d.Set("created_at", flex.DateTimeToString(reservation.CreatedAt)); err != nil {
+		return flex.DiscriminatedTerraformErrorf(err, fmt.Sprintf("Error setting created_at: %s", err), "(Data) ibm_ibm_is_reservation", "read", "set-created_at").GetDiag()
 	}
 	if err = d.Set("crn", reservation.CRN); err != nil {
-		return diag.FromErr(fmt.Errorf("[ERROR] Error setting crn: %s", err))
+		return flex.DiscriminatedTerraformErrorf(err, fmt.Sprintf("Error setting crn: %s", err), "(Data) ibm_ibm_is_reservation", "read", "set-crn").GetDiag()
 	}
 	if err = d.Set("href", reservation.Href); err != nil {
-		return diag.FromErr(fmt.Errorf("[ERROR] Error setting href: %s", err))
+		return flex.DiscriminatedTerraformErrorf(err, fmt.Sprintf("Error setting href: %s", err), "(Data) ibm_ibm_is_reservation", "read", "set-href").GetDiag()
 	}
 	if err = d.Set("lifecycle_state", reservation.LifecycleState); err != nil {
-		return diag.FromErr(fmt.Errorf("[ERROR] Error setting lifecycle_state: %s", err))
+		return flex.DiscriminatedTerraformErrorf(err, fmt.Sprintf("Error setting lifecycle_state: %s", err), "(Data) ibm_ibm_is_reservation", "read", "set-lifecycle_state").GetDiag()
 	}
 	if err = d.Set("name", reservation.Name); err != nil {
-		return diag.FromErr(fmt.Errorf("[ERROR] Error setting name: %s", err))
+		return flex.DiscriminatedTerraformErrorf(err, fmt.Sprintf("Error setting name: %s", err), "(Data) ibm_ibm_is_reservation", "read", "set-name").GetDiag()
 	}
 	if reservation.Profile != nil {
 		profileList := []map[string]interface{}{}
@@ -313,7 +320,7 @@ func dataSourceIBMIsReservationRead(context context.Context, d *schema.ResourceD
 		profileMap := dataSourceReservationProfileToMap(profile)
 		profileList = append(profileList, profileMap)
 		if err = d.Set("profile", profileList); err != nil {
-			return diag.FromErr(fmt.Errorf("[ERROR] Error setting profile: %s", err))
+			return flex.DiscriminatedTerraformErrorf(err, fmt.Sprintf("Error setting profile: %s", err), "(Data) ibm_ibm_is_reservation", "read", "set-profile").GetDiag()
 		}
 	}
 	if reservation.ResourceGroup != nil {
@@ -321,14 +328,14 @@ func dataSourceIBMIsReservationRead(context context.Context, d *schema.ResourceD
 		resourceGroupMap := dataSourceReservationResourceGroupToMap(*reservation.ResourceGroup)
 		resourceGroupList = append(resourceGroupList, resourceGroupMap)
 		if err = d.Set("resource_group", resourceGroupList); err != nil {
-			return diag.FromErr(fmt.Errorf("[ERROR] Error setting resource_group: %s", err))
+			return flex.DiscriminatedTerraformErrorf(err, fmt.Sprintf("Error setting resource_group: %s", err), "(Data) ibm_ibm_is_reservation", "read", "set-resource_group").GetDiag()
 		}
 	}
 	if err = d.Set("resource_type", reservation.ResourceType); err != nil {
-		return diag.FromErr(fmt.Errorf("[ERROR] Error setting resource_type: %s", err))
+		return flex.DiscriminatedTerraformErrorf(err, fmt.Sprintf("Error setting resource_type: %s", err), "(Data) ibm_ibm_is_reservation", "read", "set-resource_type").GetDiag()
 	}
 	if err = d.Set("status", reservation.Status); err != nil {
-		return diag.FromErr(fmt.Errorf("[ERROR] Error setting status: %s", err))
+		return flex.DiscriminatedTerraformErrorf(err, fmt.Sprintf("Error setting status: %s", err), "(Data) ibm_ibm_is_reservation", "read", "set-status").GetDiag()
 	}
 	if reservation.StatusReasons != nil {
 		statusReasonsList := []map[string]interface{}{}
@@ -336,7 +343,7 @@ func dataSourceIBMIsReservationRead(context context.Context, d *schema.ResourceD
 			statusReasonsList = append(statusReasonsList, dataSourceReservationStatusReasonsToMap(statusReasonsItem))
 		}
 		if err = d.Set("status_reasons", statusReasonsList); err != nil {
-			return diag.FromErr(fmt.Errorf("[ERROR] Error setting status_reasons: %s", err))
+			return flex.DiscriminatedTerraformErrorf(err, fmt.Sprintf("Error setting status_reasons: %s", err), "(Data) ibm_ibm_is_reservation", "read", "set-status_reasons").GetDiag()
 		}
 	}
 	zone := ""
@@ -344,7 +351,7 @@ func dataSourceIBMIsReservationRead(context context.Context, d *schema.ResourceD
 		zone = *reservation.Zone.Name
 	}
 	if err = d.Set("zone", zone); err != nil {
-		return diag.FromErr(fmt.Errorf("[ERROR] Error setting zone: %s", err))
+		return flex.DiscriminatedTerraformErrorf(err, fmt.Sprintf("Error setting zone: %s", err), "(Data) ibm_ibm_is_reservation", "read", "set-zone").GetDiag()
 	}
 	return nil
 }

--- a/ibm/service/vpc/data_source_ibm_is_reservations.go
+++ b/ibm/service/vpc/data_source_ibm_is_reservations.go
@@ -235,7 +235,7 @@ func DataSourceIBMIsReservations() *schema.Resource {
 func dataSourceIBMIsReservationsRead(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	sess, err := vpcClient(meta)
 	if err != nil {
-		tfErr := flex.DiscriminatedTerraformErrorf(err, err.Error(), "(Data) ibm_ibm_is_reservations", "read", "initialize-client")
+		tfErr := flex.DiscriminatedTerraformErrorf(err, err.Error(), "(Data) ibm_is_reservations", "read", "initialize-client")
 		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
 		return tfErr.GetDiag()
 	}
@@ -267,7 +267,7 @@ func dataSourceIBMIsReservationsRead(context context.Context, d *schema.Resource
 		}
 		reservationCollection, _, err := sess.ListReservationsWithContext(context, listReservationsOptions)
 		if err != nil {
-			tfErr := flex.TerraformErrorf(err, fmt.Sprintf("ListReservationsWithContext failed %s", err), "(Data) ibm_ibm_is_reservations", "read")
+			tfErr := flex.TerraformErrorf(err, fmt.Sprintf("ListReservationsWithContext failed %s", err), "(Data) ibm_is_reservations", "read")
 			log.Printf("[DEBUG] %s", tfErr.GetDebugMessage())
 			return tfErr.GetDiag()
 		}
@@ -286,7 +286,7 @@ func dataSourceIBMIsReservationsRead(context context.Context, d *schema.Resource
 	if reservations != nil {
 		err = d.Set("reservations", dataSourceReservationCollectionFlattenReservations(reservations))
 		if err != nil {
-			return flex.DiscriminatedTerraformErrorf(err, fmt.Sprintf("Error setting reservations %s", err), "(Data) ibm_ibm_is_reservations", "read", "reservations-set").GetDiag()
+			return flex.DiscriminatedTerraformErrorf(err, fmt.Sprintf("Error setting reservations %s", err), "(Data) ibm_is_reservations", "read", "reservations-set").GetDiag()
 		}
 	}
 

--- a/ibm/service/vpc/data_source_ibm_is_reservations.go
+++ b/ibm/service/vpc/data_source_ibm_is_reservations.go
@@ -235,7 +235,9 @@ func DataSourceIBMIsReservations() *schema.Resource {
 func dataSourceIBMIsReservationsRead(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	sess, err := vpcClient(meta)
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.DiscriminatedTerraformErrorf(err, err.Error(), "(Data) ibm_ibm_is_reservations", "read", "initialize-client")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	zoneName := d.Get("zone_name").(string)
@@ -263,10 +265,11 @@ func dataSourceIBMIsReservationsRead(context context.Context, d *schema.Resource
 		if resourceGroupId != "" {
 			listReservationsOptions.SetResourceGroupID(resourceGroupId)
 		}
-		reservationCollection, response, err := sess.ListReservationsWithContext(context, listReservationsOptions)
+		reservationCollection, _, err := sess.ListReservationsWithContext(context, listReservationsOptions)
 		if err != nil {
-			log.Printf("[DEBUG] ListReservationsWithContext failed %s\n%s", err, response)
-			return diag.FromErr(fmt.Errorf("[ERROR] ListReservationsWithContext failed %s\n%s", err, response))
+			tfErr := flex.TerraformErrorf(err, fmt.Sprintf("ListReservationsWithContext failed %s", err), "(Data) ibm_ibm_is_reservations", "read")
+			log.Printf("[DEBUG] %s", tfErr.GetDebugMessage())
+			return tfErr.GetDiag()
 		}
 		if reservationCollection != nil && *reservationCollection.TotalCount == int64(0) {
 			break
@@ -283,7 +286,7 @@ func dataSourceIBMIsReservationsRead(context context.Context, d *schema.Resource
 	if reservations != nil {
 		err = d.Set("reservations", dataSourceReservationCollectionFlattenReservations(reservations))
 		if err != nil {
-			return diag.FromErr(fmt.Errorf("[ERROR] Error setting reservations %s", err))
+			return flex.DiscriminatedTerraformErrorf(err, fmt.Sprintf("Error setting reservations %s", err), "(Data) ibm_ibm_is_reservations", "read", "reservations-set").GetDiag()
 		}
 	}
 

--- a/ibm/service/vpc/resource_ibm_is_reservation.go
+++ b/ibm/service/vpc/resource_ibm_is_reservation.go
@@ -389,13 +389,13 @@ func resourceIBMISReservationCreate(context context.Context, d *schema.ResourceD
 	}
 	sess, err := vpcClient(meta)
 	if err != nil {
-		tfErr := flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_ibm_is_reservation", "create", "initialize-client")
+		tfErr := flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_is_reservation", "create", "initialize-client")
 		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
 		return tfErr.GetDiag()
 	}
 	reservation, _, err := sess.CreateReservationWithContext(context, createReservationOptions)
 	if err != nil {
-		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("CreateReservationWithContext failed: %s", err.Error()), "ibm_ibm_is_reservation", "create")
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("CreateReservationWithContext failed: %s", err.Error()), "ibm_is_reservation", "create")
 		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
 		return tfErr.GetDiag()
 	}
@@ -411,7 +411,7 @@ func resourceIBMISReservationRead(context context.Context, d *schema.ResourceDat
 
 	sess, err := vpcClient(meta)
 	if err != nil {
-		tfErr := flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_ibm_is_reservation", "read", "initialize-client")
+		tfErr := flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_is_reservation", "read", "initialize-client")
 		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
 		return tfErr.GetDiag()
 	}
@@ -424,7 +424,7 @@ func resourceIBMISReservationRead(context context.Context, d *schema.ResourceDat
 			d.SetId("")
 			return nil
 		}
-		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("GetReservationWithContext failed: %s", err.Error()), "ibm_ibm_is_reservation", "read")
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("GetReservationWithContext failed: %s", err.Error()), "ibm_is_reservation", "read")
 		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
 		return tfErr.GetDiag()
 	}
@@ -432,7 +432,7 @@ func resourceIBMISReservationRead(context context.Context, d *schema.ResourceDat
 	if !core.IsNil(reservation.AffinityPolicy) {
 		if err = d.Set("affinity_policy", reservation.AffinityPolicy); err != nil {
 			err = fmt.Errorf("Error setting affinity_policy: %s", err)
-			return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_ibm_is_reservation", "read", "set-affinity_policy").GetDiag()
+			return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_is_reservation", "read", "set-affinity_policy").GetDiag()
 		}
 	}
 
@@ -458,7 +458,7 @@ func resourceIBMISReservationRead(context context.Context, d *schema.ResourceDat
 		capacityMap = append(capacityMap, finalList)
 		if err = d.Set("capacity", capacityMap); err != nil {
 			err = fmt.Errorf("Error setting capacity: %s", err)
-			return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_ibm_is_reservation", "read", "set-capacity").GetDiag()
+			return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_is_reservation", "read", "set-capacity").GetDiag()
 		}
 	}
 
@@ -478,34 +478,34 @@ func resourceIBMISReservationRead(context context.Context, d *schema.ResourceDat
 		committedUseMap = append(committedUseMap, finalList)
 		if err = d.Set("committed_use", committedUseMap); err != nil {
 			err = fmt.Errorf("Error setting committed_use: %s", err)
-			return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_ibm_is_reservation", "read", "set-committed_use").GetDiag()
+			return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_is_reservation", "read", "set-committed_use").GetDiag()
 		}
 	}
 
 	if err = d.Set("created_at", flex.DateTimeToString(reservation.CreatedAt)); err != nil {
 		err = fmt.Errorf("Error setting created_at: %s", err)
-		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_ibm_is_reservation", "read", "set-created_at").GetDiag()
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_is_reservation", "read", "set-created_at").GetDiag()
 	}
 
 	if err = d.Set("crn", reservation.CRN); err != nil {
 		err = fmt.Errorf("Error setting crn: %s", err)
-		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_ibm_is_reservation", "read", "set-crn").GetDiag()
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_is_reservation", "read", "set-crn").GetDiag()
 	}
 
 	if err = d.Set("href", reservation.Href); err != nil {
 		err = fmt.Errorf("Error setting href: %s", err)
-		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_ibm_is_reservation", "read", "set-href").GetDiag()
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_is_reservation", "read", "set-href").GetDiag()
 	}
 
 	if err = d.Set("lifecycle_state", reservation.LifecycleState); err != nil {
 		err = fmt.Errorf("Error setting lifecycle_state: %s", err)
-		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_ibm_is_reservation", "read", "set-lifecycle_state").GetDiag()
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_is_reservation", "read", "set-lifecycle_state").GetDiag()
 	}
 
 	if !core.IsNil(reservation.Name) {
 		if err = d.Set("name", reservation.Name); err != nil {
 			err = fmt.Errorf("Error setting name: %s", err)
-			return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_ibm_is_reservation", "read", "set-name").GetDiag()
+			return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_is_reservation", "read", "set-name").GetDiag()
 		}
 	}
 
@@ -527,7 +527,7 @@ func resourceIBMISReservationRead(context context.Context, d *schema.ResourceDat
 		profileMap = append(profileMap, finalList)
 		if err = d.Set("profile", profileMap); err != nil {
 			err = fmt.Errorf("Error setting profile: %s", err)
-			return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_ibm_is_reservation", "read", "set-profile").GetDiag()
+			return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_is_reservation", "read", "set-profile").GetDiag()
 		}
 	}
 
@@ -547,18 +547,18 @@ func resourceIBMISReservationRead(context context.Context, d *schema.ResourceDat
 		rgMap = append(rgMap, finalList)
 		if err = d.Set("resource_group", rgMap); err != nil {
 			err = fmt.Errorf("Error setting resource_group: %s", err)
-			return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_ibm_is_reservation", "read", "set-resource_group").GetDiag()
+			return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_is_reservation", "read", "set-resource_group").GetDiag()
 		}
 	}
 
 	if err = d.Set("resource_type", reservation.ResourceType); err != nil {
 		err = fmt.Errorf("Error setting resource_type: %s", err)
-		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_ibm_is_reservation", "read", "set-resource_type").GetDiag()
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_is_reservation", "read", "set-resource_type").GetDiag()
 	}
 
 	if err = d.Set("status", reservation.Status); err != nil {
 		err = fmt.Errorf("Error setting status: %s", err)
-		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_ibm_is_reservation", "read", "set-status").GetDiag()
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_is_reservation", "read", "set-status").GetDiag()
 	}
 
 	if reservation.StatusReasons != nil {
@@ -570,14 +570,14 @@ func resourceIBMISReservationRead(context context.Context, d *schema.ResourceDat
 		}
 		if err = d.Set("status_reasons", srList); err != nil {
 			err = fmt.Errorf("Error setting status_reasons: %s", err)
-			return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_ibm_is_reservation", "read", "set-status_reasons").GetDiag()
+			return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_is_reservation", "read", "set-status_reasons").GetDiag()
 		}
 	}
 
 	if reservation.Zone != nil && reservation.Zone.Name != nil {
 		if err = d.Set("zone", reservation.Zone.Name); err != nil {
 			err = fmt.Errorf("Error setting zone: %s", err)
-			return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_ibm_is_reservation", "read", "set-zone").GetDiag()
+			return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_is_reservation", "read", "set-zone").GetDiag()
 		}
 	}
 	return nil
@@ -586,7 +586,7 @@ func resourceIBMISReservationRead(context context.Context, d *schema.ResourceDat
 func resourceIBMISReservationUpdate(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	sess, err := vpcClient(meta)
 	if err != nil {
-		tfErr := flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_ibm_is_reservation", "update", "initialize-client")
+		tfErr := flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_is_reservation", "update", "initialize-client")
 		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
 		return tfErr.GetDiag()
 	}
@@ -666,7 +666,7 @@ func resourceIBMISReservationUpdate(context context.Context, d *schema.ResourceD
 	if hasChanged {
 		reservationPatch, err := reservationPatchModel.AsPatch()
 		if err != nil {
-			tfErr := flex.TerraformErrorf(err, fmt.Sprintf("reservationPatchModel.AsPatch failed: %s", err.Error()), "ibm_ibm_is_reservation", "update")
+			tfErr := flex.TerraformErrorf(err, fmt.Sprintf("reservationPatchModel.AsPatch failed: %s", err.Error()), "ibm_is_reservation", "update")
 			log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
 			return tfErr.GetDiag()
 		}
@@ -675,7 +675,7 @@ func resourceIBMISReservationUpdate(context context.Context, d *schema.ResourceD
 		updateReservationOptions.ID = core.StringPtr(d.Id())
 		_, _, err = sess.UpdateReservationWithContext(context, updateReservationOptions)
 		if err != nil {
-			tfErr := flex.TerraformErrorf(err, fmt.Sprintf("UpdateReservationWithContext failed: %s", err.Error()), "ibm_ibm_is_reservation", "update")
+			tfErr := flex.TerraformErrorf(err, fmt.Sprintf("UpdateReservationWithContext failed: %s", err.Error()), "ibm_is_reservation", "update")
 			log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
 			return tfErr.GetDiag()
 		}
@@ -687,7 +687,7 @@ func resourceIBMISReservationDelete(context context.Context, d *schema.ResourceD
 	id := d.Id()
 	sess, err := vpcClient(meta)
 	if err != nil {
-		tfErr := flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_ibm_is_reservation", "delete", "initialize-client")
+		tfErr := flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_is_reservation", "delete", "initialize-client")
 		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
 		return tfErr.GetDiag()
 	}
@@ -697,7 +697,7 @@ func resourceIBMISReservationDelete(context context.Context, d *schema.ResourceD
 	}
 	_, _, err = sess.DeleteReservationWithContext(context, deleteReservationOptions)
 	if err != nil {
-		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("DeleteReservationWithContext failed: %s", err.Error()), "ibm_ibm_is_reservation", "delete")
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("DeleteReservationWithContext failed: %s", err.Error()), "ibm_is_reservation", "delete")
 		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
 		return tfErr.GetDiag()
 	}

--- a/ibm/service/vpc/resource_ibm_is_reservation.go
+++ b/ibm/service/vpc/resource_ibm_is_reservation.go
@@ -4,6 +4,7 @@
 package vpc
 
 import (
+	"context"
 	"fmt"
 	"log"
 
@@ -12,6 +13,7 @@ import (
 
 	"github.com/IBM/go-sdk-core/v5/core"
 	"github.com/IBM/vpc-go-sdk/vpcv1"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
@@ -56,11 +58,11 @@ const (
 
 func ResourceIBMISReservation() *schema.Resource {
 	return &schema.Resource{
-		Create:   resourceIBMISReservationCreate,
-		Read:     resourceIBMISReservationRead,
-		Update:   resourceIBMISReservationUpdate,
-		Delete:   resourceIBMISReservationDelete,
-		Importer: &schema.ResourceImporter{},
+		CreateContext: resourceIBMISReservationCreate,
+		ReadContext:   resourceIBMISReservationRead,
+		UpdateContext: resourceIBMISReservationUpdate,
+		DeleteContext: resourceIBMISReservationDelete,
+		Importer:      &schema.ResourceImporter{},
 
 		Schema: map[string]*schema.Schema{
 			isReservationAffinityPolicy: &schema.Schema{
@@ -320,7 +322,7 @@ func ResourceIBMISReservationValidator() *validate.ResourceValidator {
 	return &ibmISVPCResourceValidator
 }
 
-func resourceIBMISReservationCreate(d *schema.ResourceData, meta interface{}) error {
+func resourceIBMISReservationCreate(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 
 	createReservationOptions := &vpcv1.CreateReservationOptions{}
 	if _, ok := d.GetOk(isReservationCapacity); ok {
@@ -386,42 +388,51 @@ func resourceIBMISReservationCreate(d *schema.ResourceData, meta interface{}) er
 		}
 	}
 	sess, err := vpcClient(meta)
-
-	reservation, response, err := sess.CreateReservation(createReservationOptions)
 	if err != nil {
-		log.Printf("[DEBUG] Reservation creation err %s\n%s", err, response)
-		return fmt.Errorf("[ERROR] Error while creating Reservation %s\n%v", err, response)
+		tfErr := flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_ibm_is_reservation", "create", "initialize-client")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
+	}
+	reservation, _, err := sess.CreateReservationWithContext(context, createReservationOptions)
+	if err != nil {
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("CreateReservationWithContext failed: %s", err.Error()), "ibm_ibm_is_reservation", "create")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 	d.SetId(*reservation.ID)
 	log.Printf("[INFO] Reservation : %s", *reservation.ID)
 
-	return resourceIBMISReservationRead(d, meta)
+	return resourceIBMISReservationRead(context, d, meta)
 }
 
-func resourceIBMISReservationRead(d *schema.ResourceData, meta interface{}) error {
+func resourceIBMISReservationRead(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 
 	id := d.Id()
 
 	sess, err := vpcClient(meta)
 	if err != nil {
-		return err
+		tfErr := flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_ibm_is_reservation", "read", "initialize-client")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 	getReservationOptions := &vpcv1.GetReservationOptions{
 		ID: &id,
 	}
-	reservation, response, err := sess.GetReservation(getReservationOptions)
+	reservation, response, err := sess.GetReservationWithContext(context, getReservationOptions)
 	if err != nil {
 		if response != nil && response.StatusCode == 404 {
 			d.SetId("")
 			return nil
 		}
-		return fmt.Errorf("[ERROR] Error Getting Reservation (%s): %s\n%s", id, err, response)
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("GetReservationWithContext failed: %s", err.Error()), "ibm_ibm_is_reservation", "read")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
-	if reservation.AffinityPolicy != nil {
-		if err = d.Set(isReservationAffinityPolicy, reservation.AffinityPolicy); err != nil {
-			log.Printf("[ERROR] Error setting %s: %s", isReservationAffinityPolicy, err)
-			return fmt.Errorf("[ERROR] Error setting %s: %s", isReservationAffinityPolicy, err)
+	if !core.IsNil(reservation.AffinityPolicy) {
+		if err = d.Set("affinity_policy", reservation.AffinityPolicy); err != nil {
+			err = fmt.Errorf("Error setting affinity_policy: %s", err)
+			return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_ibm_is_reservation", "read", "set-affinity_policy").GetDiag()
 		}
 	}
 
@@ -445,7 +456,10 @@ func resourceIBMISReservationRead(d *schema.ResourceData, meta interface{}) erro
 			finalList[isReservationCapacityStatus] = reservation.Capacity.Status
 		}
 		capacityMap = append(capacityMap, finalList)
-		d.Set(isReservationCapacity, capacityMap)
+		if err = d.Set("capacity", capacityMap); err != nil {
+			err = fmt.Errorf("Error setting capacity: %s", err)
+			return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_ibm_is_reservation", "read", "set-capacity").GetDiag()
+		}
 	}
 
 	if reservation.CommittedUse != nil {
@@ -462,41 +476,36 @@ func resourceIBMISReservationRead(d *schema.ResourceData, meta interface{}) erro
 			finalList[isReservationComittedUseTerm] = *reservation.CommittedUse.Term
 		}
 		committedUseMap = append(committedUseMap, finalList)
-		d.Set(isReservationCommittedUse, committedUseMap)
-	}
-
-	if reservation.CreatedAt != nil {
-		if err = d.Set(isReservationCreatedAt, flex.DateTimeToString(reservation.CreatedAt)); err != nil {
-			log.Printf("[ERROR] Error setting %s: %s", isReservationCreatedAt, err)
-			return fmt.Errorf("[ERROR] Error setting %s: %s", isReservationCreatedAt, err)
+		if err = d.Set("committed_use", committedUseMap); err != nil {
+			err = fmt.Errorf("Error setting committed_use: %s", err)
+			return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_ibm_is_reservation", "read", "set-committed_use").GetDiag()
 		}
 	}
 
-	if reservation.CRN != nil {
-		if err = d.Set(isReservationCrn, reservation.CRN); err != nil {
-			log.Printf("[ERROR] Error setting %s: %s", isReservationCrn, err)
-			return fmt.Errorf("[ERROR] Error setting %s: %s", isReservationCrn, err)
-		}
+	if err = d.Set("created_at", flex.DateTimeToString(reservation.CreatedAt)); err != nil {
+		err = fmt.Errorf("Error setting created_at: %s", err)
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_ibm_is_reservation", "read", "set-created_at").GetDiag()
 	}
 
-	if reservation.Href != nil {
-		if err = d.Set(isReservationHref, reservation.Href); err != nil {
-			log.Printf("[ERROR] Error setting %s: %s", isReservationHref, err)
-			return fmt.Errorf("[ERROR] Error setting %s: %s", isReservationHref, err)
-		}
+	if err = d.Set("crn", reservation.CRN); err != nil {
+		err = fmt.Errorf("Error setting crn: %s", err)
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_ibm_is_reservation", "read", "set-crn").GetDiag()
 	}
 
-	if reservation.LifecycleState != nil {
-		if err = d.Set(isReservationLifecycleState, reservation.LifecycleState); err != nil {
-			log.Printf("[ERROR] Error setting %s: %s", isReservationLifecycleState, err)
-			return fmt.Errorf("[ERROR] Error setting %s: %s", isReservationLifecycleState, err)
-		}
+	if err = d.Set("href", reservation.Href); err != nil {
+		err = fmt.Errorf("Error setting href: %s", err)
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_ibm_is_reservation", "read", "set-href").GetDiag()
 	}
 
-	if reservation.Name != nil {
-		if err = d.Set(isReservationName, reservation.Name); err != nil {
-			log.Printf("[ERROR] Error setting %s: %s", isReservationName, err)
-			return fmt.Errorf("[ERROR] Error setting %s: %s", isReservationName, err)
+	if err = d.Set("lifecycle_state", reservation.LifecycleState); err != nil {
+		err = fmt.Errorf("Error setting lifecycle_state: %s", err)
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_ibm_is_reservation", "read", "set-lifecycle_state").GetDiag()
+	}
+
+	if !core.IsNil(reservation.Name) {
+		if err = d.Set("name", reservation.Name); err != nil {
+			err = fmt.Errorf("Error setting name: %s", err)
+			return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_ibm_is_reservation", "read", "set-name").GetDiag()
 		}
 	}
 
@@ -516,7 +525,10 @@ func resourceIBMISReservationRead(d *schema.ResourceData, meta interface{}) erro
 			finalList[isReservationProfileResourceType] = profileItem.ResourceType
 		}
 		profileMap = append(profileMap, finalList)
-		d.Set(isReservationProfile, profileMap)
+		if err = d.Set("profile", profileMap); err != nil {
+			err = fmt.Errorf("Error setting profile: %s", err)
+			return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_ibm_is_reservation", "read", "set-profile").GetDiag()
+		}
 	}
 
 	if reservation.ResourceGroup != nil {
@@ -533,21 +545,20 @@ func resourceIBMISReservationRead(d *schema.ResourceData, meta interface{}) erro
 			finalList[isReservationResourceGroupName] = reservation.ResourceGroup.Name
 		}
 		rgMap = append(rgMap, finalList)
-		d.Set(isReservationResourceGroup, rgMap)
-	}
-
-	if reservation.ResourceType != nil {
-		if err = d.Set(isReservationResourceType, reservation.ResourceType); err != nil {
-			log.Printf("[ERROR] Error setting %s: %s", isReservationResourceType, err)
-			return fmt.Errorf("[ERROR] Error setting %s: %s", isReservationResourceType, err)
+		if err = d.Set("resource_group", rgMap); err != nil {
+			err = fmt.Errorf("Error setting resource_group: %s", err)
+			return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_ibm_is_reservation", "read", "set-resource_group").GetDiag()
 		}
 	}
 
-	if reservation.Status != nil {
-		if err = d.Set(isReservationStatus, reservation.Status); err != nil {
-			log.Printf("[ERROR] Error setting %s: %s", isReservationStatus, err)
-			return fmt.Errorf("[ERROR] Error setting %s: %s", isReservationStatus, err)
-		}
+	if err = d.Set("resource_type", reservation.ResourceType); err != nil {
+		err = fmt.Errorf("Error setting resource_type: %s", err)
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_ibm_is_reservation", "read", "set-resource_type").GetDiag()
+	}
+
+	if err = d.Set("status", reservation.Status); err != nil {
+		err = fmt.Errorf("Error setting status: %s", err)
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_ibm_is_reservation", "read", "set-status").GetDiag()
 	}
 
 	if reservation.StatusReasons != nil {
@@ -557,22 +568,27 @@ func resourceIBMISReservationRead(d *schema.ResourceData, meta interface{}) erro
 		for i := 0; i < srLen; i++ {
 			srList = append(srList, reservation.StatusReasons[i])
 		}
-		d.Set(isReservationStatusReasons, srList)
+		if err = d.Set("status_reasons", srList); err != nil {
+			err = fmt.Errorf("Error setting status_reasons: %s", err)
+			return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_ibm_is_reservation", "read", "set-status_reasons").GetDiag()
+		}
 	}
 
 	if reservation.Zone != nil && reservation.Zone.Name != nil {
-		if err = d.Set(isReservationZone, reservation.Zone.Name); err != nil {
-			log.Printf("[ERROR] Error setting %s: %s", isReservationZone, err)
-			return fmt.Errorf("[ERROR] Error setting %s: %s", isReservationZone, err)
+		if err = d.Set("zone", reservation.Zone.Name); err != nil {
+			err = fmt.Errorf("Error setting zone: %s", err)
+			return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_ibm_is_reservation", "read", "set-zone").GetDiag()
 		}
 	}
 	return nil
 }
 
-func resourceIBMISReservationUpdate(d *schema.ResourceData, meta interface{}) error {
+func resourceIBMISReservationUpdate(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	sess, err := vpcClient(meta)
 	if err != nil {
-		return err
+		tfErr := flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_ibm_is_reservation", "update", "initialize-client")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 	hasChanged := false
 	name := ""
@@ -650,32 +666,40 @@ func resourceIBMISReservationUpdate(d *schema.ResourceData, meta interface{}) er
 	if hasChanged {
 		reservationPatch, err := reservationPatchModel.AsPatch()
 		if err != nil {
-			return fmt.Errorf("[ERROR] Error calling asPatch for ReservationPatch: %s", err)
+			tfErr := flex.TerraformErrorf(err, fmt.Sprintf("reservationPatchModel.AsPatch failed: %s", err.Error()), "ibm_ibm_is_reservation", "update")
+			log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+			return tfErr.GetDiag()
 		}
 		updateReservationOptions := &vpcv1.UpdateReservationOptions{}
 		updateReservationOptions.ReservationPatch = reservationPatch
 		updateReservationOptions.ID = core.StringPtr(d.Id())
-		_, response, err := sess.UpdateReservation(updateReservationOptions)
+		_, _, err = sess.UpdateReservationWithContext(context, updateReservationOptions)
 		if err != nil {
-			return fmt.Errorf("[ERROR] Error Updating Reservation : %s\n%s", err, response)
+			tfErr := flex.TerraformErrorf(err, fmt.Sprintf("UpdateReservationWithContext failed: %s", err.Error()), "ibm_ibm_is_reservation", "update")
+			log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+			return tfErr.GetDiag()
 		}
 	}
-	return resourceIBMISReservationRead(d, meta)
+	return resourceIBMISReservationRead(context, d, meta)
 }
 
-func resourceIBMISReservationDelete(d *schema.ResourceData, meta interface{}) error {
+func resourceIBMISReservationDelete(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	id := d.Id()
 	sess, err := vpcClient(meta)
 	if err != nil {
-		return err
+		tfErr := flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_ibm_is_reservation", "delete", "initialize-client")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	deleteReservationOptions := &vpcv1.DeleteReservationOptions{
 		ID: &id,
 	}
-	_, _, err = sess.DeleteReservation(deleteReservationOptions)
+	_, _, err = sess.DeleteReservationWithContext(context, deleteReservationOptions)
 	if err != nil {
-		return fmt.Errorf("[ERROR] Error Deleting Reservation : %s", err)
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("DeleteReservationWithContext failed: %s", err.Error()), "ibm_ibm_is_reservation", "delete")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 	d.SetId("")
 	return nil


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/IBM-Cloud/terraform-provider-ibm/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```
