### PR TITLE
Fix warnings in pi data source and resources

### DIFF
--- a/ibm/acctest/acctest.go
+++ b/ibm/acctest/acctest.go
@@ -239,6 +239,7 @@ var (
 	Pi_replication_volume_name        string
 	Pi_resource_group_id              string
 	Pi_sap_image                      string
+	Pi_sap_profile_id                 string
 	Pi_shared_processor_pool_id       string
 	Pi_snapshot_id                    string
 	Pi_spp_placement_group_id         string
@@ -253,7 +254,6 @@ var (
 	Pi_volume_onboarding_id           string
 	Pi_volume_onboarding_source_crn   string
 	PiCloudConnectionName             string
-	PiSAPProfileID                    string
 	PiStoragePool                     string
 	PiStorageType                     string
 )
@@ -1264,9 +1264,9 @@ func init() {
 		fmt.Println("[INFO] Set the environment variable PI_CLOUD_CONNECTION_NAME for testing ibm_pi_cloud_connection resource else it is set to default value 'terraform-test-power'")
 	}
 
-	PiSAPProfileID = os.Getenv("PI_SAP_PROFILE_ID")
-	if PiSAPProfileID == "" {
-		PiSAPProfileID = "terraform-test-power"
+	Pi_sap_profile_id = os.Getenv("PI_SAP_PROFILE_ID")
+	if Pi_sap_profile_id == "" {
+		Pi_sap_profile_id = "terraform-test-power"
 		fmt.Println("[INFO] Set the environment variable PI_SAP_PROFILE_ID for testing ibm_pi_sap_profile resource else it is set to default value 'terraform-test-power'")
 	}
 

--- a/ibm/service/power/data_source_ibm_pi_cloud_connection.go
+++ b/ibm/service/power/data_source_ibm_pi_cloud_connection.go
@@ -157,14 +157,14 @@ func dataSourceIBMPICloudConnectionRead(ctx context.Context, d *schema.ResourceD
 	d.Set(Arg_CloudInstanceID, cloudInstanceID)
 	d.Set(Arg_CloudConnectionName, cloudConnection.Name)
 
+	d.Set(Attr_ConnectionMode, cloudConnection.ConnectionMode)
 	d.Set(Attr_GlobalRouting, cloudConnection.GlobalRouting)
-	d.Set(Attr_Metered, cloudConnection.Metered)
 	d.Set(Attr_IBMIPAddress, cloudConnection.IbmIPAddress)
-	d.Set(Attr_UserIPAddress, cloudConnection.UserIPAddress)
-	d.Set(Attr_Status, cloudConnection.LinkStatus)
+	d.Set(Attr_Metered, cloudConnection.Metered)
 	d.Set(Attr_Port, cloudConnection.Port)
 	d.Set(Attr_Speed, cloudConnection.Speed)
-	d.Set(Attr_ConnectionMode, cloudConnection.ConnectionMode)
+	d.Set(Attr_Status, cloudConnection.LinkStatus)
+	d.Set(Attr_UserIPAddress, cloudConnection.UserIPAddress)
 	if cloudConnection.Networks != nil {
 		networks := make([]string, len(cloudConnection.Networks))
 		for i, ccNetwork := range cloudConnection.Networks {
@@ -183,7 +183,7 @@ func dataSourceIBMPICloudConnectionRead(ctx context.Context, d *schema.ResourceD
 	}
 	if cloudConnection.Vpc != nil {
 		d.Set(Attr_VPCEnabled, cloudConnection.Vpc.Enabled)
-		if cloudConnection.Vpc.Vpcs != nil && len(cloudConnection.Vpc.Vpcs) > 0 {
+		if len(cloudConnection.Vpc.Vpcs) > 0 {
 			vpcCRNs := make([]string, len(cloudConnection.Vpc.Vpcs))
 			for i, vpc := range cloudConnection.Vpc.Vpcs {
 				vpcCRNs[i] = *vpc.VpcID

--- a/ibm/service/power/data_source_ibm_pi_cloud_connections.go
+++ b/ibm/service/power/data_source_ibm_pi_cloud_connections.go
@@ -172,7 +172,7 @@ func dataSourceIBMPICloudConnectionsRead(ctx context.Context, d *schema.Resource
 		}
 		if cloudConnection.Vpc != nil {
 			cc[Attr_VPCEnabled] = cloudConnection.Vpc.Enabled
-			if cloudConnection.Vpc.Vpcs != nil && len(cloudConnection.Vpc.Vpcs) > 0 {
+			if len(cloudConnection.Vpc.Vpcs) > 0 {
 				vpcCRNs := make([]string, len(cloudConnection.Vpc.Vpcs))
 				for i, vpc := range cloudConnection.Vpc.Vpcs {
 					vpcCRNs[i] = *vpc.VpcID

--- a/ibm/service/power/data_source_ibm_pi_instance_volumes_test.go
+++ b/ibm/service/power/data_source_ibm_pi_instance_volumes_test.go
@@ -9,18 +9,16 @@ import (
 
 	acc "github.com/IBM-Cloud/terraform-provider-ibm/ibm/acctest"
 
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 )
 
 func TestAccIBMPIVolumesDataSource_basic(t *testing.T) {
-	name := fmt.Sprintf("tf-pi-volume-%d", acctest.RandIntRange(10, 100))
 	resource.Test(t, resource.TestCase{
 		PreCheck:  func() { acc.TestAccPreCheck(t) },
 		Providers: acc.TestAccProviders,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckIBMPIVolumesDataSourceConfig(name),
+				Config: testAccCheckIBMPIVolumesDataSourceConfig(),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrSet("data.ibm_pi_instance_volumes.testacc_ds_volumes", "id"),
 				),
@@ -29,7 +27,7 @@ func TestAccIBMPIVolumesDataSource_basic(t *testing.T) {
 	})
 }
 
-func testAccCheckIBMPIVolumesDataSourceConfig(name string) string {
+func testAccCheckIBMPIVolumesDataSourceConfig() string {
 	return fmt.Sprintf(`
 		data "ibm_pi_instance_volumes" "testacc_ds_volumes" {
 			pi_instance_name = "%s"

--- a/ibm/service/power/data_source_ibm_pi_sap_profile_test.go
+++ b/ibm/service/power/data_source_ibm_pi_sap_profile_test.go
@@ -21,7 +21,7 @@ func TestAccIBMPISAPProfileDataSourceBasic(t *testing.T) {
 				Config: testAccCheckIBMPISAPProfileDataSourceConfig(),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrSet("data.ibm_pi_sap_profile.test", "id"),
-					resource.TestCheckResourceAttr("data.ibm_pi_sap_profile.test", "id", acc.PiSAPProfileID),
+					resource.TestCheckResourceAttr("data.ibm_pi_sap_profile.test", "id", acc.Pi_sap_profile_id),
 				),
 			},
 		},
@@ -33,5 +33,5 @@ func testAccCheckIBMPISAPProfileDataSourceConfig() string {
 		data "ibm_pi_sap_profile" "test" {
 			pi_cloud_instance_id = "%s"
 			pi_sap_profile_id = "%s"
-		}`, acc.Pi_cloud_instance_id, acc.PiSAPProfileID)
+		}`, acc.Pi_cloud_instance_id, acc.Pi_sap_profile_id)
 }

--- a/ibm/service/power/resource_ibm_pi_capture.go
+++ b/ibm/service/power/resource_ibm_pi_capture.go
@@ -12,7 +12,6 @@ import (
 	"time"
 
 	"github.com/IBM-Cloud/power-go-client/clients/instance"
-	st "github.com/IBM-Cloud/power-go-client/clients/instance"
 	"github.com/IBM-Cloud/power-go-client/power/client/p_cloud_images"
 	"github.com/IBM-Cloud/power-go-client/power/models"
 	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/conns"
@@ -196,7 +195,7 @@ func resourceIBMPICaptureCreate(ctx context.Context, d *schema.ResourceData, met
 	}
 
 	if _, ok := d.GetOk(Arg_UserTags); ok && capturedestination != CloudStorage {
-		imageClient := st.NewIBMPIImageClient(ctx, sess, cloudInstanceID)
+		imageClient := instance.NewIBMPIImageClient(ctx, sess, cloudInstanceID)
 		imagedata, err := imageClient.Get(capturename)
 		if err != nil {
 			if strings.Contains(err.Error(), NotFound) {

--- a/ibm/service/power/resource_ibm_pi_capture_test.go
+++ b/ibm/service/power/resource_ibm_pi_capture_test.go
@@ -38,6 +38,7 @@ func TestAccIBMPICaptureBasic(t *testing.T) {
 		},
 	})
 }
+
 func TestAccIBMPICaptureWithVolume(t *testing.T) {
 	captureRes := "ibm_pi_capture.capture_instance"
 	name := fmt.Sprintf("tf-pi-capture-%d", acctest.RandIntRange(10, 100))

--- a/ibm/service/power/resource_ibm_pi_cloud_connection.go
+++ b/ibm/service/power/resource_ibm_pi_cloud_connection.go
@@ -461,7 +461,7 @@ func resourceIBMPICloudConnectionRead(ctx context.Context, d *schema.ResourceDat
 	}
 	if cloudConnection.Vpc != nil {
 		d.Set(Arg_CloudConnectionVPCEnabled, cloudConnection.Vpc.Enabled)
-		if cloudConnection.Vpc.Vpcs != nil && len(cloudConnection.Vpc.Vpcs) > 0 {
+		if len(cloudConnection.Vpc.Vpcs) > 0 {
 			vpcCRNs := make([]string, len(cloudConnection.Vpc.Vpcs))
 			for i, vpc := range cloudConnection.Vpc.Vpcs {
 				vpcCRNs[i] = *vpc.VpcID

--- a/ibm/service/power/resource_ibm_pi_host.go
+++ b/ibm/service/power/resource_ibm_pi_host.go
@@ -282,7 +282,7 @@ func resourceIBMPIHostRead(ctx context.Context, d *schema.ResourceData, meta int
 	if host.SysType != "" {
 		d.Set(Attr_SysType, host.SysType)
 	}
-	d.Set(Arg_Host, flattenHostArgumentToList(d, meta))
+	d.Set(Arg_Host, flattenHostArgumentToList(d))
 
 	return nil
 }
@@ -447,7 +447,7 @@ func isIBMPIHostRefreshFunc(client *instance.IBMPIHostGroupsClient, id string) r
 	}
 }
 
-func flattenHostArgumentToList(d *schema.ResourceData, meta interface{}) []map[string]interface{} {
+func flattenHostArgumentToList(d *schema.ResourceData) []map[string]interface{} {
 	hostListType := make([]map[string]interface{}, 0)
 	h := map[string]interface{}{}
 	if v, ok := d.GetOk(Attr_DisplayName); ok {

--- a/ibm/service/power/resource_ibm_pi_image.go
+++ b/ibm/service/power/resource_ibm_pi_image.go
@@ -454,7 +454,7 @@ func isWaitForIBMPIImageAvailable(ctx context.Context, client *instance.IBMPIIma
 	stateConf := &retry.StateChangeConf{
 		Pending:    []string{State_Retry, State_Queued},
 		Target:     []string{State_Active},
-		Refresh:    isIBMPIImageRefreshFunc(ctx, client, id),
+		Refresh:    isIBMPIImageRefreshFunc(client, id),
 		Timeout:    timeout,
 		Delay:      20 * time.Second,
 		MinTimeout: 10 * time.Second,
@@ -463,7 +463,7 @@ func isWaitForIBMPIImageAvailable(ctx context.Context, client *instance.IBMPIIma
 	return stateConf.WaitForStateContext(ctx)
 }
 
-func isIBMPIImageRefreshFunc(ctx context.Context, client *instance.IBMPIImageClient, id string) retry.StateRefreshFunc {
+func isIBMPIImageRefreshFunc(client *instance.IBMPIImageClient, id string) retry.StateRefreshFunc {
 
 	log.Printf("Calling the isIBMPIImageRefreshFunc Refresh Function....")
 	return func() (interface{}, string, error) {

--- a/ibm/service/power/resource_ibm_pi_network.go
+++ b/ibm/service/power/resource_ibm_pi_network.go
@@ -19,7 +19,6 @@ import (
 	"github.com/apparentlymart/go-cidr/cidr"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/customdiff"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
@@ -504,7 +503,7 @@ func isWaitForIBMPINetworkDeleted(ctx context.Context, client *instance.IBMPINet
 	return stateConf.WaitForStateContext(ctx)
 }
 
-func isIBMPINetworkRefreshDeleteFunc(client *instance.IBMPINetworkClient, id string) resource.StateRefreshFunc {
+func isIBMPINetworkRefreshDeleteFunc(client *instance.IBMPINetworkClient, id string) retry.StateRefreshFunc {
 	return func() (interface{}, string, error) {
 		network, err := client.Get(id)
 		if err != nil {

--- a/ibm/service/power/resource_ibm_pi_placement_group_test.go
+++ b/ibm/service/power/resource_ibm_pi_placement_group_test.go
@@ -65,7 +65,7 @@ func TestAccIBMPIPlacementGroupBasic(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccCheckIBMPICreateInstanceInPlacementGroup(name, policy, "tinytest-1x4"),
+				Config: testAccCheckIBMPICreateInstanceInPlacementGroup(name, policy),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrSet(
 						"ibm_pi_instance.power_instance", "pi_placement_group_id"),
@@ -79,7 +79,7 @@ func TestAccIBMPIPlacementGroupBasic(t *testing.T) {
 				ExpectNonEmptyPlan: true,
 			},
 			{
-				Config: testAccCheckIBMPIDeletePlacementGroup(name, policy, "tinytest-1x4"),
+				Config: testAccCheckIBMPIDeletePlacementGroup(name, policy),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckIBMPIPlacementGroupDelete("ibm_pi_instance.power_instance", "ibm_pi_instance.power_instance_in_pg"),
 				),
@@ -484,7 +484,7 @@ func testAccCheckIBMPIPlacementGroupRemoveMemberConfig(name string, policy strin
 		}`, acc.Pi_cloud_instance_id, name, policy, acc.Pi_image, acc.Pi_network_name)
 }
 
-func testAccCheckIBMPICreateInstanceInPlacementGroup(name string, policy string, sapProfile string) string {
+func testAccCheckIBMPICreateInstanceInPlacementGroup(name string, policy string) string {
 	return fmt.Sprintf(`
 		resource "ibm_pi_key" "key" {
 			pi_cloud_instance_id = "%[1]s"
@@ -546,10 +546,10 @@ func testAccCheckIBMPICreateInstanceInPlacementGroup(name string, policy string,
 			pi_cloud_instance_id      = "%[1]s"
 			pi_placement_group_name   = "%[2]s-2"
 			pi_placement_group_policy = "%[3]s"
-		}`, acc.Pi_cloud_instance_id, name, policy, acc.Pi_image, sapProfile, acc.Pi_sap_image, acc.Pi_network_name)
+		}`, acc.Pi_cloud_instance_id, name, policy, acc.Pi_image, acc.Pi_sap_profile_id, acc.Pi_sap_image, acc.Pi_network_name)
 }
 
-func testAccCheckIBMPIDeletePlacementGroup(name string, policy string, sapProfile string) string {
+func testAccCheckIBMPIDeletePlacementGroup(name string, policy string) string {
 	return fmt.Sprintf(`
 		resource "ibm_pi_key" "key" {
 			pi_cloud_instance_id = "%[1]s"
@@ -608,5 +608,5 @@ func testAccCheckIBMPIDeletePlacementGroup(name string, policy string, sapProfil
 			pi_cloud_instance_id      = "%[1]s"
 			pi_placement_group_name   = "%[2]s-2"
 			pi_placement_group_policy = "%[3]s"
-		}`, acc.Pi_cloud_instance_id, name, policy, acc.Pi_image, sapProfile, acc.Pi_sap_image, acc.Pi_network_name)
+		}`, acc.Pi_cloud_instance_id, name, policy, acc.Pi_image, acc.Pi_sap_profile_id, acc.Pi_sap_image, acc.Pi_network_name)
 }

--- a/ibm/service/power/resource_ibm_pi_placement_group_test.go
+++ b/ibm/service/power/resource_ibm_pi_placement_group_test.go
@@ -81,7 +81,7 @@ func TestAccIBMPIPlacementGroupBasic(t *testing.T) {
 			{
 				Config: testAccCheckIBMPIDeletePlacementGroup(name, policy, "tinytest-1x4"),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckIBMPIPlacementGroupDelete("ibm_pi_placement_group.power_placement_group", "ibm_pi_instance.power_instance", "ibm_pi_instance.power_instance_in_pg"),
+					testAccCheckIBMPIPlacementGroupDelete("ibm_pi_instance.power_instance", "ibm_pi_instance.power_instance_in_pg"),
 				),
 			},
 		},
@@ -304,7 +304,7 @@ func testAccCheckIBMPIPlacementGroupMemberExistsFromInstanceCreate(n string, ins
 	}
 }
 
-func testAccCheckIBMPIPlacementGroupDelete(n string, inst string, newInstance string) resource.TestCheckFunc {
+func testAccCheckIBMPIPlacementGroupDelete(inst string, newInstance string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		sess, err := acc.TestAccProvider.Meta().(conns.ClientSession).IBMPISession()
 		if err != nil {

--- a/ibm/service/power/resource_ibm_pi_spp_placement_group_test.go
+++ b/ibm/service/power/resource_ibm_pi_spp_placement_group_test.go
@@ -80,7 +80,7 @@ func TestAccIBMPISPPPlacementGroupBasic(t *testing.T) {
 			{
 				Config: testAccCheckIBMPIDeleteSPPPlacementGroup(name, policy),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckIBMPISPPPlacementGroupDelete("ibm_pi_spp_placement_group.spp_placement_group_another", "ibm_pi_shared_processor_pool.spp_pool", "ibm_pi_shared_processor_pool.spp_pool_2"),
+					testAccCheckIBMPISPPPlacementGroupDelete("ibm_pi_shared_processor_pool.spp_pool", "ibm_pi_shared_processor_pool.spp_pool_2"),
 				),
 			},
 			{
@@ -296,7 +296,7 @@ func testAccCheckIBMPISPPPlacementGroupMemberExistsFromSPPCreate(n string, pool 
 	}
 }
 
-func testAccCheckIBMPISPPPlacementGroupDelete(n string, pool string, newPool string) resource.TestCheckFunc {
+func testAccCheckIBMPISPPPlacementGroupDelete(pool string, newPool string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		sess, err := acc.TestAccProvider.Meta().(conns.ClientSession).IBMPISession()
 		if err != nil {

--- a/ibm/service/power/resource_ibm_pi_spp_placement_group_test.go
+++ b/ibm/service/power/resource_ibm_pi_spp_placement_group_test.go
@@ -94,7 +94,6 @@ func TestAccIBMPISPPPlacementGroupBasic(t *testing.T) {
 }
 
 func testAccCheckIBMPISPPPlacementGroupDestroy(s *terraform.State) error {
-
 	sess, err := acc.TestAccProvider.Meta().(conns.ClientSession).IBMPISession()
 	if err != nil {
 		return err
@@ -114,6 +113,7 @@ func testAccCheckIBMPISPPPlacementGroupDestroy(s *terraform.State) error {
 
 	return nil
 }
+
 func testAccCheckIBMPISPPPlacementGroupExists(n string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 
@@ -654,5 +654,5 @@ func testAccCheckIBMPICreateSAPInstanceWithSPP(name string, policy string) strin
 			}
 			pi_health_status		= "OK"
 			pi_shared_processor_pool = ibm_pi_shared_processor_pool.spp_pool_2.pi_shared_processor_pool_name
-		}`, acc.Pi_cloud_instance_id, name, policy, acc.Pi_image, acc.Pi_network_name, acc.Pi_sap_image, acc.PiSAPProfileID)
+		}`, acc.Pi_cloud_instance_id, name, policy, acc.Pi_image, acc.Pi_network_name, acc.Pi_sap_image, acc.Pi_sap_profile_id)
 }


### PR DESCRIPTION
This PR removes pending warnings in terraform code.

Removed nil check where it wasn't needed as len() for nil sliced is defined as zero.
Removed unused parameters.
Removed duplicate import.
Updated placement group resource tests to use environment variables for profile sap id.
Slightly improved readability in cloud_connection data source.

Output from acceptance testing:
```
--- PASS: TestAccIBMPICloudConnectionsDataSourceBasic (14.16s)
PASS

--- PASS: TestAccIBMPICloudConnectionDataSource_basic (22.93s)
PASS

--- PASS: TestAccIBMPIVolumesDataSource_basic (27.84s)
PASS

--- PASS: TestAccIBMPIImagebasic (55.48s)
PASS

--- PASS: TestAccIBMPIImageUserTags (100.23s)
PASS

--- PASS: TestAccIBMPICloudConnectionbasic (353.63s)
PASS

--- PASS: TestAccIBMPICloudConnectionNetworks (505.72s)
PASS

--- PASS: TestAccIBMPICloudConnectionClassic (493.95s)
PASS

--- PASS: TestAccIBMPICloudConnectionVPC (523.11s)
PASS

--- PASS: TestAccIBMPICloudConnectionTransitGateway (422.73s)
PASS

--- PASS: TestAccIBMPICloudConnectionTransitGateway (422.73s)
PASS

--- PASS: TestAccIBMPINetworkbasic (62.77s)
PASS

--- PASS: TestAccIBMPINetworkGatewaybasic (67.65s)
PASS

--- PASS: TestAccIBMPINetworkUserTags (73.50s)
PASS
```