### PR TITLE
[Datasource] Fix crash when vm has no volumes

### DIFF
--- a/ibm/service/power/data_source_ibm_pi_instance_volumes.go
+++ b/ibm/service/power/data_source_ibm_pi_instance_volumes.go
@@ -153,7 +153,10 @@ func dataSourceIBMPIInstanceVolumesRead(ctx context.Context, d *schema.ResourceD
 
 	var clientgenU, _ = uuid.GenerateUUID()
 	d.SetId(clientgenU)
-	d.Set(Attr_BootVolumeID, *volumedata.Volumes[0].VolumeID)
+	if len(volumedata.Volumes) > 0 {
+		d.Set(Attr_BootVolumeID, *volumedata.Volumes[0].VolumeID)
+	}
+
 	d.Set(Attr_InstanceVolumes, flattenVolumesInstances(volumedata.Volumes, meta))
 
 	return nil
@@ -162,7 +165,6 @@ func dataSourceIBMPIInstanceVolumesRead(ctx context.Context, d *schema.ResourceD
 func flattenVolumesInstances(list []*models.VolumeReference, meta interface{}) []map[string]interface{} {
 	result := make([]map[string]interface{}, 0, len(list))
 	for _, i := range list {
-
 		l := map[string]interface{}{
 			Attr_Bootable:           *i.Bootable,
 			Attr_CreationDate:       i.CreationDate.String(),
@@ -191,7 +193,6 @@ func flattenVolumesInstances(list []*models.VolumeReference, meta interface{}) [
 		if len(i.ReplicationSites) > 0 {
 			l[Attr_ReplicationSites] = i.ReplicationSites
 		}
-
 		result = append(result, l)
 	}
 	return result


### PR DESCRIPTION
This crash occurred because the vm has no volumes and we tried to list them. I think this changed within the last year, and it is now possible to have a vm with no volumes.

This crash occurred because the vm has no volumes and we tried to list them. I think this changed within the last year, and it is now possible to have a vm with no volumes.

Output from acceptance testing:
```
--- PASS: TestAccIBMPIVolumesDataSource_basic (28.58s)
PASS
```

List instance volumes from a vm with no volumes will look like
```
result = {
  "boot_volume_id" = tostring(null)
  "id" = "56349cd9-0269-1a8c-a609-60560b3c276d"
  "instance_volumes" = tolist([])
  "pi_cloud_instance_id" = "6021a723-bcab-4d3f-9985-d0cb2f864f35"
  "pi_instance_name" = "0ad61745-e796-4de2-bde5-89fac02f2618"
}
```