### PR TITLE
feat(is_security_group_target): Handle pending LB states during SG binding

### DIFF
--- a/ibm/service/vpc/resource_ibm_is_security_group_target.go
+++ b/ibm/service/vpc/resource_ibm_is_security_group_target.go
@@ -144,7 +144,7 @@ func resourceIBMISSecurityGroupTargetCreate(d *schema.ResourceData, meta interfa
 		if errsgt != nil {
 			return errsgt
 		}
-	} else if crn != nil && *crn != "" && strings.Contains(*crn, "virtual_network_interfaces") {
+	} else if crn != nil && *crn != "" && strings.Contains(*crn, "virtual-network-interface") {
 		vpcClient, err := meta.(conns.ClientSession).VpcV1API()
 		if err != nil {
 			return err

--- a/ibm/service/vpc/resource_ibm_is_security_group_target.go
+++ b/ibm/service/vpc/resource_ibm_is_security_group_target.go
@@ -196,12 +196,6 @@ func resourceIBMISSecurityGroupTargetRead(d *schema.ResourceData, meta interface
 	if target.ResourceType != nil && *target.ResourceType != "" {
 		d.Set(isSecurityGroupResourceType, *target.ResourceType)
 	}
-	if target != nil && *target.ResourceType == "load_balancer" {
-		_, waitErr := isWaitForSGTargetLBAvailable(sess, *target.ID, d.Timeout(schema.TimeoutCreate))
-		if waitErr != nil {
-			return fmt.Errorf("[ERROR] Error waiting for load balancer to become available while creating/updating Security Group Target Binding: %s", waitErr)
-		}
-	}
 
 	return nil
 }


### PR DESCRIPTION
Successfully tested with concurrent security group target attachments to the same load balancer.
<!--- See what makes a good Pull Request at : https://github.com/IBM-Cloud/terraform-provider-ibm/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #6150

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
% make testacc TEST=./ibm/service/vpc TESTARGS='-run=TestAccIBMISSecurityGroupTarget_UpdatePendingRetry'
=== RUN   TestAccIBMISSecurityGroupTarget_UpdatePendingRetry
--- PASS: TestAccIBMISSecurityGroupTarget_UpdatePendingRetry (1182.78s)
PASS
ok      github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/vpc     1187.631s
```
