### PR TITLE
enhancement: improved error handling for vpc backup policy

### DIFF
--- a/ibm/service/vpc/data_source_ibm_is_backup_policy_job.go
+++ b/ibm/service/vpc/data_source_ibm_is_backup_policy_job.go
@@ -412,7 +412,9 @@ func DataSourceIBMIsBackupPolicyJob() *schema.Resource {
 func dataSourceIBMIsBackupPolicyJobRead(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	vpcClient, err := vpcClient(meta)
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("vpcClient creation failed: %s", err.Error()), "(Data) ibm_is_backup_policy_job", "read")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	getBackupPolicyJobOptions := &vpcv1.GetBackupPolicyJobOptions{}

--- a/ibm/service/vpc/data_source_ibm_is_backup_policy_plan.go
+++ b/ibm/service/vpc/data_source_ibm_is_backup_policy_plan.go
@@ -149,7 +149,9 @@ func DataSourceIBMIsBackupPolicyPlan() *schema.Resource {
 func dataSourceIBMIsBackupPolicyPlanRead(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	sess, err := vpcClient(meta)
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("vpcClient creation failed: %s", err.Error()), "(Data) ibm_is_backup_policy_plan", "read")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 	var backupPolicyPlan *vpcv1.BackupPolicyPlan
 
@@ -162,8 +164,9 @@ func dataSourceIBMIsBackupPolicyPlanRead(context context.Context, d *schema.Reso
 
 		backupPolicyPlanInfo, response, err := sess.GetBackupPolicyPlanWithContext(context, getBackupPolicyPlanOptions)
 		if err != nil {
-			log.Printf("[DEBUG] GetBackupPolicyPlanWithContext failed %s\n%s", err, response)
-			return diag.FromErr(fmt.Errorf("[ERROR] GetBackupPolicyPlanWithContext failed %s\n%s", err, response))
+			tfErr := flex.TerraformErrorf(err, fmt.Sprintf("GetBackupPolicyPlanWithContext failed: %s\n%s", err.Error(), response), "(Data) ibm_is_backup_policy_plan", "read")
+			log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+			return tfErr.GetDiag()
 		}
 		backupPolicyPlan = backupPolicyPlanInfo
 	} else if v, ok := d.GetOk("name"); ok {
@@ -175,8 +178,9 @@ func dataSourceIBMIsBackupPolicyPlanRead(context context.Context, d *schema.Reso
 
 		backupPolicyPlanCollection, response, err := sess.ListBackupPolicyPlansWithContext(context, listBackupPolicyPlansOptions)
 		if err != nil {
-			log.Printf("[DEBUG] ListBackupPolicyPlansWithContext failed %s\n%s", err, response)
-			return diag.FromErr(fmt.Errorf("[ERROR] ListBackupPolicyPlansWithContext failed %s\n%s", err, response))
+			tfErr := flex.TerraformErrorf(err, fmt.Sprintf("ListBackupPolicyPlansWithContext failed: %s\n%s", err.Error(), response), "(Data) ibm_is_backup_policy_plan", "read")
+			log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+			return tfErr.GetDiag()
 		}
 		for _, backupPolicyPlanInfo := range backupPolicyPlanCollection.Plans {
 			if *backupPolicyPlanInfo.Name == name {
@@ -185,32 +189,35 @@ func dataSourceIBMIsBackupPolicyPlanRead(context context.Context, d *schema.Reso
 			}
 		}
 		if backupPolicyPlan == nil {
-			return diag.FromErr(fmt.Errorf("[ERROR] No backup policy plan found with name (%s)", name))
+			err = fmt.Errorf("[ERROR] No backup policy plan found with name (%s)", name)
+			tfErr := flex.TerraformErrorf(err, fmt.Sprintf("ListBackupPolicyPlansWithContext failed: %s\n%s", err.Error(), response), "(Data) ibm_is_backup_policy_plan", "read")
+			log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+			return tfErr.GetDiag()
 		}
 	}
 
 	d.SetId(*backupPolicyPlan.ID)
 
 	if err = d.Set("active", backupPolicyPlan.Active); err != nil {
-		return diag.FromErr(fmt.Errorf("[ERROR] Error setting active: %s", err))
+		return flex.DiscriminatedTerraformErrorf(err, fmt.Sprintf("Error setting active: %s", err), "(Data) ibm_is_backup_policy_plan", "read", "set-active").GetDiag()
 	}
 	if err = d.Set("attach_user_tags", backupPolicyPlan.AttachUserTags); err != nil {
-		return diag.FromErr(fmt.Errorf("[ERROR] Error setting attach_user_tags: %s", err))
+		return flex.DiscriminatedTerraformErrorf(err, fmt.Sprintf("Error setting active: %s", err), "(Data) ibm_is_backup_policy_plan", "read", "set-attach_user_tags").GetDiag()
 	}
 	if err = d.Set("copy_user_tags", backupPolicyPlan.CopyUserTags); err != nil {
-		return diag.FromErr(fmt.Errorf("[ERROR] Error setting copy_user_tags: %s", err))
+		return flex.DiscriminatedTerraformErrorf(err, fmt.Sprintf("Error setting copy_user_tags: %s", err), "(Data) ibm_is_backup_policy_plan", "read", "set-copy_user_tags").GetDiag()
 	}
 	if err = d.Set("created_at", flex.DateTimeToString(backupPolicyPlan.CreatedAt)); err != nil {
-		return diag.FromErr(fmt.Errorf("[ERROR] Error setting created_at: %s", err))
+		return flex.DiscriminatedTerraformErrorf(err, fmt.Sprintf("Error setting created_at: %s", err), "(Data) ibm_is_backup_policy_plan", "read", "set-created_at").GetDiag()
 	}
 	if err = d.Set("cron_spec", backupPolicyPlan.CronSpec); err != nil {
-		return diag.FromErr(fmt.Errorf("[ERROR] Error setting cron_spec: %s", err))
+		return flex.DiscriminatedTerraformErrorf(err, fmt.Sprintf("Error setting cron_spec: %s", err), "(Data) ibm_is_backup_policy_plan", "read", "set-cron_spec").GetDiag()
 	}
 
 	if backupPolicyPlan.DeletionTrigger != nil {
 		err = d.Set("deletion_trigger", dataSourceBackupPolicyPlanFlattenDeletionTrigger(*backupPolicyPlan.DeletionTrigger))
 		if err != nil {
-			return diag.FromErr(fmt.Errorf("[ERROR] Error setting deletion_trigger %s", err))
+			return flex.DiscriminatedTerraformErrorf(err, fmt.Sprintf("Error setting deletion_trigger: %s", err), "(Data) ibm_is_backup_policy_plan", "read", "set-deletion_trigger").GetDiag()
 		}
 	}
 	if backupPolicyPlan.ClonePolicy != nil {
@@ -231,29 +238,29 @@ func dataSourceIBMIsBackupPolicyPlanRead(context context.Context, d *schema.Reso
 		d.Set("clone_policy", backupPolicyPlanClonePolicyMap)
 	}
 	if err = d.Set("href", backupPolicyPlan.Href); err != nil {
-		return diag.FromErr(fmt.Errorf("[ERROR] Error setting href: %s", err))
+		return flex.DiscriminatedTerraformErrorf(err, fmt.Sprintf("Error setting href: %s", err), "(Data) ibm_is_backup_policy_plan", "read", "set-href").GetDiag()
 	}
 	if err = d.Set("lifecycle_state", backupPolicyPlan.LifecycleState); err != nil {
-		return diag.FromErr(fmt.Errorf("[ERROR] Error setting lifecycle_state: %s", err))
+		return flex.DiscriminatedTerraformErrorf(err, fmt.Sprintf("Error setting lifecycle_state: %s", err), "(Data) ibm_is_backup_policy_plan", "read", "set-lifecycle_state").GetDiag()
 	}
 	if err = d.Set("name", backupPolicyPlan.Name); err != nil {
-		return diag.FromErr(fmt.Errorf("[ERROR] Error setting name: %s", err))
+		return flex.DiscriminatedTerraformErrorf(err, fmt.Sprintf("Error setting name: %s", err), "(Data) ibm_is_backup_policy_plan", "read", "set-name").GetDiag()
 	}
 	remoteRegionPolicies := []map[string]interface{}{}
 	if backupPolicyPlan.RemoteRegionPolicies != nil {
 		for _, remoteCopyPolicy := range backupPolicyPlan.RemoteRegionPolicies {
 			remoteRegionPoliciesMap, err := dataSourceIBMIsVPCBackupPolicyPlanRemoteCopyPolicyItemToMap(&remoteCopyPolicy)
 			if err != nil {
-				return diag.FromErr(fmt.Errorf("[ERROR] Error setting remote copy policies: %s", err))
+				return flex.DiscriminatedTerraformErrorf(err, err.Error(), "(Data) ibm_is_backup_policy_plan", "read", "remote_region_policies-to-map").GetDiag()
 			}
 			remoteRegionPolicies = append(remoteRegionPolicies, remoteRegionPoliciesMap)
 		}
 	}
 	if err = d.Set("remote_region_policy", remoteRegionPolicies); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting remote_region_policy %s", err))
+		return flex.DiscriminatedTerraformErrorf(err, fmt.Sprintf("Error setting remote_region_policies: %s", err), "(Data) ibm_is_backup_policy_plan", "read", "set-remote_region_policies").GetDiag()
 	}
 	if err = d.Set("resource_type", backupPolicyPlan.ResourceType); err != nil {
-		return diag.FromErr(fmt.Errorf("[ERROR] Error setting resource_type: %s", err))
+		return flex.DiscriminatedTerraformErrorf(err, fmt.Sprintf("Error setting resource_type: %s", err), "(Data) ibm_is_backup_policy_plan", "read", "set-resource_type").GetDiag()
 	}
 
 	return nil

--- a/ibm/service/vpc/resource_ibm_is_backup_policy.go
+++ b/ibm/service/vpc/resource_ibm_is_backup_policy.go
@@ -215,9 +215,10 @@ func ResourceIBMIsBackupPolicyValidator() *validate.ResourceValidator {
 func resourceIBMIsBackupPolicyCreate(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	vpcClient, err := vpcClient(meta)
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("vpcClient creation failed: %s", err.Error()), "ibm_is_backup_policy", "create")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
-
 	createBackupPolicyOptions := &vpcv1.CreateBackupPolicyOptions{}
 	backupPolicyPrototype := &vpcv1.BackupPolicyPrototype{}
 
@@ -258,8 +259,9 @@ func resourceIBMIsBackupPolicyCreate(context context.Context, d *schema.Resource
 	createBackupPolicyOptions.SetBackupPolicyPrototype(backupPolicyPrototype)
 	backupPolicyIntf, response, err := vpcClient.CreateBackupPolicyWithContext(context, createBackupPolicyOptions)
 	if err != nil {
-		log.Printf("[DEBUG] CreateBackupPolicyWithContext failed %s\n%s", err, response)
-		return diag.FromErr(fmt.Errorf("[ERROR] CreateBackupPolicyWithContext failed %s\n%s", err, response))
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("CreateBackupPolicyWithContext failed: %s\n%s", err.Error(), response), "ibm_is_backup_policy", "create")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	backupPolicy := backupPolicyIntf.(*vpcv1.BackupPolicy)
@@ -271,7 +273,9 @@ func resourceIBMIsBackupPolicyCreate(context context.Context, d *schema.Resource
 func resourceIBMIsBackupPolicyRead(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	vpcClient, err := vpcClient(meta)
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("vpcClient creation failed: %s", err.Error()), "ibm_is_backup_policy", "read")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	getBackupPolicyOptions := &vpcv1.GetBackupPolicyOptions{}
@@ -285,7 +289,9 @@ func resourceIBMIsBackupPolicyRead(context context.Context, d *schema.ResourceDa
 			return nil
 		}
 		log.Printf("[DEBUG] GetBackupPolicyWithContext failed %s\n%s", err, response)
-		return diag.FromErr(fmt.Errorf("[ERROR] GetBackupPolicyWithContext failed %s\n%s", err, response))
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("GetBackupPolicyWithContext failed: %s/n%s", err.Error(), response), "ibm_is_backup_policy", "read")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 	backupPolicy := backupPolicyIntf.(*vpcv1.BackupPolicy)
 
@@ -293,67 +299,79 @@ func resourceIBMIsBackupPolicyRead(context context.Context, d *schema.ResourceDa
 		matchResourceTypes := *backupPolicy.MatchResourceType
 		matchResourceTypesList := []string{matchResourceTypes}
 		if err = d.Set("match_resource_types", matchResourceTypesList); err != nil {
-			return diag.FromErr(fmt.Errorf("[ERROR] Error setting match_resource_types: %s", err))
+			err = fmt.Errorf("Error setting match_resource_types: %s", err)
+			return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_is_backup_policy", "read", "set-match_resource_types").GetDiag()
 		}
 		if err = d.Set("match_resource_type", backupPolicy.MatchResourceType); err != nil {
-			return diag.FromErr(fmt.Errorf("[ERROR] Error setting match_resource_type: %s", err))
+			err = fmt.Errorf("Error setting match_resource_type: %s", err)
+			return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_is_backup_policy", "read", "set-match_resource_type").GetDiag()
 		}
 	}
 	if backupPolicy.IncludedContent != nil {
 		if err = d.Set("included_content", backupPolicy.IncludedContent); err != nil {
-			return diag.FromErr(fmt.Errorf("[ERROR] Error setting included_content: %s", err))
+			err = fmt.Errorf("Error setting included_content: %s", err)
+			return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_is_backup_policy", "read", "set-included_content").GetDiag()
 		}
 	}
 
 	if backupPolicy.MatchUserTags != nil {
 		if err = d.Set("match_user_tags", backupPolicy.MatchUserTags); err != nil {
-			return diag.FromErr(fmt.Errorf("[ERROR] Error setting match_user_tags: %s", err))
+			err = fmt.Errorf("Error setting match_user_tags: %s", err)
+			return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_is_backup_policy", "read", "set-match_user_tags").GetDiag()
 		}
 	}
 	if backupPolicy.Name != nil {
 		if err = d.Set("name", backupPolicy.Name); err != nil {
-			return diag.FromErr(fmt.Errorf("[ERROR] Error setting name: %s", err))
+			err = fmt.Errorf("Error setting name: %s", err)
+			return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_is_backup_policy", "read", "set-name").GetDiag()
 		}
 	}
 	if backupPolicy.ResourceGroup != nil {
 		resourceGroupID := *backupPolicy.ResourceGroup.ID
 		if err = d.Set("resource_group", resourceGroupID); err != nil {
-			return diag.FromErr(fmt.Errorf("[ERROR] Error setting resource_group: %s", err))
+			err = fmt.Errorf("Error setting resource_group: %s", err)
+			return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_is_backup_policy", "read", "set-resource_group").GetDiag()
 		}
 	}
 	if backupPolicy.CreatedAt != nil {
 		if err = d.Set("created_at", flex.DateTimeToString(backupPolicy.CreatedAt)); err != nil {
-			return diag.FromErr(fmt.Errorf("[ERROR] Error setting created_at: %s", err))
+			err = fmt.Errorf("Error setting created_at: %s", err)
+			return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_is_backup_policy", "read", "set-created_at").GetDiag()
 		}
 	}
 
 	if backupPolicy.CRN != nil {
 		if err = d.Set("crn", backupPolicy.CRN); err != nil {
-			return diag.FromErr(fmt.Errorf("[ERROR] Error setting crn: %s", err))
+			err = fmt.Errorf("Error setting crn: %s", err)
+			return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_is_backup_policy", "read", "set-crn").GetDiag()
 		}
 	}
 
 	if backupPolicy.Href != nil {
 		if err = d.Set("href", backupPolicy.Href); err != nil {
-			return diag.FromErr(fmt.Errorf("[ERROR] Error setting href: %s", err))
+			err = fmt.Errorf("Error setting href: %s", err)
+			return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_is_backup_policy", "read", "set-href").GetDiag()
 		}
 	}
 
 	if backupPolicy.LastJobCompletedAt != nil {
 		if err = d.Set("last_job_completed_at", flex.DateTimeToString(backupPolicy.LastJobCompletedAt)); err != nil {
-			return diag.FromErr(fmt.Errorf("[ERROR] Error setting last_job_completed_at: %s", err))
+			err = fmt.Errorf("Error setting last_job_completed_at: %s", err)
+			return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_is_backup_policy", "read", "set-last_job_completed_at").GetDiag()
 		}
 	}
 
 	if backupPolicy.LifecycleState != nil {
 		if err = d.Set("lifecycle_state", backupPolicy.LifecycleState); err != nil {
-			return diag.FromErr(fmt.Errorf("[ERROR] Error setting lifecycle_state: %s", err))
+			err = fmt.Errorf("Error setting lifecycle_state: %s", err)
+			return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_is_backup_policy", "read", "set-lifecycle_state").GetDiag()
 		}
 	}
 
 	if backupPolicy.ResourceType != nil {
 		if err = d.Set("resource_type", backupPolicy.ResourceType); err != nil {
-			return diag.FromErr(fmt.Errorf("[ERROR] Error setting resource_type: %s", err))
+			err = fmt.Errorf("Error setting resource_type: %s", err)
+			return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_is_backup_policy", "read", "set-resource_type").GetDiag()
 		}
 	}
 
@@ -373,7 +391,8 @@ func resourceIBMIsBackupPolicyRead(context context.Context, d *schema.ResourceDa
 		d.Set("health_reasons", healthReasonsList)
 	}
 	if err = d.Set("health_state", backupPolicy.HealthState); err != nil {
-		return diag.FromErr(fmt.Errorf("[ERROR] Error setting health_state: %s", err))
+		err = fmt.Errorf("Error setting health_state: %s", err)
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_is_backup_policy", "read", "set-health_state").GetDiag()
 	}
 
 	if backupPolicy.Scope != nil {
@@ -382,12 +401,13 @@ func resourceIBMIsBackupPolicyRead(context context.Context, d *schema.ResourceDa
 		scope = append(scope, scopeMap)
 
 		if err = d.Set("scope", scope); err != nil {
-			return diag.FromErr(fmt.Errorf("[ERROR] Error setting scope: %s", err))
+			err = fmt.Errorf("Error setting scope: %s", err)
+			return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_is_backup_policy", "read", "set-scope").GetDiag()
 		}
 	}
 
 	if err = d.Set("version", response.Headers.Get("Etag")); err != nil {
-		return diag.FromErr(fmt.Errorf("[ERROR] Error setting version: %s", err))
+		return flex.DiscriminatedTerraformErrorf(err, fmt.Sprintf("Error setting version: %s", err), "ibm_is_backup_policy", "read", "set-version").GetDiag()
 	}
 
 	return nil
@@ -406,7 +426,9 @@ func resourceIbmIsBackupPolicyScopeToMap(scope vpcv1.BackupPolicyScope) map[stri
 func resourceIBMIsBackupPolicyUpdate(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	vpcClient, err := vpcClient(meta)
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("vpcClient creation failed: %s", err.Error()), "ibm_is_backup_policy", "update")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 	updateBackupPolicyOptions := &vpcv1.UpdateBackupPolicyOptions{}
 	updateBackupPolicyOptions.SetID(d.Id())
@@ -429,8 +451,9 @@ func resourceIBMIsBackupPolicyUpdate(context context.Context, d *schema.Resource
 		updateBackupPolicyOptions.BackupPolicyPatch, _ = patchVals.AsPatch()
 		_, response, err := vpcClient.UpdateBackupPolicyWithContext(context, updateBackupPolicyOptions)
 		if err != nil {
-			log.Printf("[DEBUG] UpdateBackupPolicyWithContext failed %s\n%s", err, response)
-			return diag.FromErr(fmt.Errorf("[ERROR] UpdateBackupPolicyWithContext failed %s\n%s", err, response))
+			tfErr := flex.TerraformErrorf(err, fmt.Sprintf("UpdateBackupPolicyWithContext failed: %s\n%s", err.Error(), response), "ibm_is_backup_policy", "update")
+			log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+			return tfErr.GetDiag()
 		}
 	}
 
@@ -440,15 +463,18 @@ func resourceIBMIsBackupPolicyUpdate(context context.Context, d *schema.Resource
 func resourceIBMIsBackupPolicyDelete(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	vpcClient, err := vpcClient(meta)
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("vpcClient creation failed: %s", err.Error()), "ibm_is_backup_policy", "delete")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 	deleteBackupPolicyOptions := &vpcv1.DeleteBackupPolicyOptions{}
 	deleteBackupPolicyOptions.SetID(d.Id())
 	deleteBackupPolicyOptions.SetIfMatch(d.Get("version").(string))
 	_, response, err := vpcClient.DeleteBackupPolicyWithContext(context, deleteBackupPolicyOptions)
 	if err != nil {
-		log.Printf("[DEBUG] DeleteBackupPolicyWithContext failed %s\n%s", err, response)
-		return diag.FromErr(fmt.Errorf("[ERROR] DeleteBackupPolicyWithContext failed %s\n%s", err, response))
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("DeleteBackupPolicyWithContext failed: %s%\n%s", err.Error(), response), "ibm_is_backup_policy", "delete")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 	d.SetId("")
 	return nil

--- a/ibm/service/vpc/resource_ibm_is_backup_policy_plan.go
+++ b/ibm/service/vpc/resource_ibm_is_backup_policy_plan.go
@@ -209,7 +209,9 @@ func ResourceIBMIsBackupPolicyPlanValidator() *validate.ResourceValidator {
 func resourceIBMIsBackupPolicyPlanCreate(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	vpcClient, err := vpcClient(meta)
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("vpcClient creation failed: %s", err.Error()), "ibm_is_backup_policy_plan", "create")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	createBackupPolicyPlanOptions := &vpcv1.CreateBackupPolicyPlanOptions{}
@@ -258,13 +260,14 @@ func resourceIBMIsBackupPolicyPlanCreate(context context.Context, d *schema.Reso
 			if deleteOverCountString != "" && deleteOverCountString != "null" {
 				deleteOverCount, err := strconv.ParseInt(backupPolicyPlanDeletionTriggerPrototypeMap["delete_over_count"].(string), 10, 64)
 				if err != nil {
-					return diag.FromErr(fmt.Errorf("[ERROR] Error setting delete_over_count: %s", err))
+					return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_is_backup_policy_plan", "create", "parse-delete_over_count").GetDiag()
 				}
 				deleteOverCountint := int64(deleteOverCount)
 				if deleteOverCountint >= int64(0) {
 					backupPolicyPlanDeletionTriggerPrototype.DeleteOverCount = core.Int64Ptr(deleteOverCountint)
 				} else {
-					return diag.FromErr(fmt.Errorf("[ERROR] Error setting delete_over_count: Retention count and days cannot be both zero"))
+					err = fmt.Errorf("[ERROR] Error setting delete_over_count: Retention count and days cannot be both zero")
+					return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_is_backup_policy_plan", "create", "parse-delete_over_count").GetDiag()
 				}
 			}
 		}
@@ -276,7 +279,7 @@ func resourceIBMIsBackupPolicyPlanCreate(context context.Context, d *schema.Reso
 			value := policy.(map[string]interface{})
 			remoteCopyPoliciesItem, err := resourceIBMIsVPCBackupPolicyPlanMapToBackupPolicyPlanRemoteCopyPolicyPrototype(value)
 			if err != nil {
-				return diag.FromErr(err)
+				return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_is_backup_policy_plan", "create", "parse-remote_region_policies").GetDiag()
 			}
 			remoteCopyPolicies = append(remoteCopyPolicies, *remoteCopyPoliciesItem)
 		}
@@ -288,8 +291,9 @@ func resourceIBMIsBackupPolicyPlanCreate(context context.Context, d *schema.Reso
 
 	backupPolicyPlan, response, err := vpcClient.CreateBackupPolicyPlanWithContext(context, createBackupPolicyPlanOptions)
 	if err != nil {
-		log.Printf("[DEBUG] CreateBackupPolicyPlanWithContext failed %s\n%s", err, response)
-		return diag.FromErr(fmt.Errorf("[ERROR] CreateBackupPolicyPlanWithContext failed %s\n%s", err, response))
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("CreateBackupPolicyPlanWithContext failed: %s\n%s", err.Error(), response), "ibm_is_backup_policy_plan", "create")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	d.SetId(fmt.Sprintf("%s/%s", *createBackupPolicyPlanOptions.BackupPolicyID, *backupPolicyPlan.ID))
@@ -300,14 +304,16 @@ func resourceIBMIsBackupPolicyPlanCreate(context context.Context, d *schema.Reso
 func resourceIBMIsBackupPolicyPlanRead(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	vpcClient, err := vpcClient(meta)
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("vpcClient creation failed: %s", err.Error()), "ibm_is_backup_policy_plan", "read")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	getBackupPolicyPlanOptions := &vpcv1.GetBackupPolicyPlanOptions{}
 
 	parts, err := flex.SepIdParts(d.Id(), "/")
 	if err != nil {
-		return diag.FromErr(err)
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_is_backup_policy_plan", "read", "sep-id-parts").GetDiag()
 	}
 
 	getBackupPolicyPlanOptions.SetBackupPolicyID(parts[0])
@@ -319,8 +325,9 @@ func resourceIBMIsBackupPolicyPlanRead(context context.Context, d *schema.Resour
 			d.SetId("")
 			return nil
 		}
-		log.Printf("[DEBUG] GetBackupPolicyPlanWithContext failed %s\n%s", err, response)
-		return diag.FromErr(fmt.Errorf("[ERROR] GetBackupPolicyPlanWithContext failed %s\n%s", err, response))
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("GetBackupPolicyPlanWithContext failed: %s\n%s", err.Error(), response), "ibm_is_backup_policy_plan", "read")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	if getBackupPolicyPlanOptions.BackupPolicyID != nil {
@@ -331,19 +338,22 @@ func resourceIBMIsBackupPolicyPlanRead(context context.Context, d *schema.Resour
 
 	if getBackupPolicyPlanOptions.ID != nil {
 		if err = d.Set("backup_policy_plan_id", getBackupPolicyPlanOptions.ID); err != nil {
-			return diag.FromErr(fmt.Errorf("[ERROR] Error setting backup_policy_plan_id: %s", err))
+			err = fmt.Errorf("Error setting backup_policy_plan_id: %s", err)
+			return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_is_backup_policy_plan", "read", "set-backup_policy_plan_id").GetDiag()
 		}
 	}
 
 	if backupPolicyPlan.CronSpec != nil {
 		if err = d.Set("cron_spec", backupPolicyPlan.CronSpec); err != nil {
-			return diag.FromErr(fmt.Errorf("[ERROR] Error setting cron_spec: %s", err))
+			err = fmt.Errorf("Error setting cron_spec: %s", err)
+			return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_is_backup_policy_plan", "read", "set-cron_spec").GetDiag()
 		}
 	}
 
 	if backupPolicyPlan.Active != nil {
 		if err = d.Set("active", backupPolicyPlan.Active); err != nil {
-			return diag.FromErr(fmt.Errorf("[ERROR] Error setting active: %s", err))
+			err = fmt.Errorf("Error setting active: %s", err)
+			return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_is_backup_policy_plan", "read", "set-active").GetDiag()
 		}
 	}
 
@@ -367,20 +377,23 @@ func resourceIBMIsBackupPolicyPlanRead(context context.Context, d *schema.Resour
 
 	if backupPolicyPlan.AttachUserTags != nil {
 		if err = d.Set("attach_user_tags", backupPolicyPlan.AttachUserTags); err != nil {
-			return diag.FromErr(fmt.Errorf("[ERROR] Error setting attach_user_tags: %s", err))
+			err = fmt.Errorf("Error setting attach_user_tags: %s", err)
+			return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_is_backup_policy_plan", "read", "set-attach_user_tags").GetDiag()
 		}
 	}
 
 	if backupPolicyPlan.CopyUserTags != nil {
 		if err = d.Set("copy_user_tags", backupPolicyPlan.CopyUserTags); err != nil {
-			return diag.FromErr(fmt.Errorf("[ERROR] Error setting copy_user_tags: %s", err))
+			err = fmt.Errorf("Error setting copy_user_tags: %s", err)
+			return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_is_backup_policy_plan", "read", "set-copy_user_tags").GetDiag()
 		}
 	}
 
 	if backupPolicyPlan.DeletionTrigger != nil {
 		deletionTriggerMap := resourceIBMIsBackupPolicyPlanBackupPolicyPlanDeletionTriggerPrototypeToMap(*backupPolicyPlan.DeletionTrigger)
 		if err = d.Set("deletion_trigger", []map[string]interface{}{deletionTriggerMap}); err != nil {
-			return diag.FromErr(fmt.Errorf("[ERROR] Error setting deletion_trigger: %s", err))
+			err = fmt.Errorf("Error setting deletion_trigger: %s", err)
+			return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_is_backup_policy_plan", "read", "set-deletion_trigger").GetDiag()
 		}
 	}
 	if backupPolicyPlan.RemoteRegionPolicies != nil {
@@ -393,34 +406,40 @@ func resourceIBMIsBackupPolicyPlanRead(context context.Context, d *schema.Resour
 			remoteCopyPolicies = append(remoteCopyPolicies, remoteCopyPoliciesItemMap)
 		}
 		if err = d.Set("remote_region_policy", remoteCopyPolicies); err != nil {
-			return diag.FromErr(fmt.Errorf("[ERROR] Error setting remote_region_policy %s", err))
+			err = fmt.Errorf("Error setting remote_region_policies: %s", err)
+			return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_is_backup_policy_plan", "read", "set-remote_region_policies").GetDiag()
 		}
 	}
 	if backupPolicyPlan.Name != nil {
 		if err = d.Set("name", backupPolicyPlan.Name); err != nil {
-			return diag.FromErr(fmt.Errorf("[ERROR] Error setting name: %s", err))
+			err = fmt.Errorf("Error setting name: %s", err)
+			return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_is_backup_policy_plan", "read", "set-name").GetDiag()
 		}
 	}
 
 	if backupPolicyPlan.CreatedAt != nil {
 		if err = d.Set("created_at", flex.DateTimeToString(backupPolicyPlan.CreatedAt)); err != nil {
-			return diag.FromErr(fmt.Errorf("[ERROR] Error setting created_at: %s", err))
+			err = fmt.Errorf("Error setting created_at: %s", err)
+			return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_is_backup_policy_plan", "read", "set-created_at").GetDiag()
 		}
 	}
 
 	if err = d.Set("href", backupPolicyPlan.Href); err != nil {
-		return diag.FromErr(fmt.Errorf("[ERROR] Error setting href: %s", err))
+		err = fmt.Errorf("Error setting href: %s", err)
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_is_backup_policy_plan", "read", "set-href").GetDiag()
 	}
 	if err = d.Set("lifecycle_state", backupPolicyPlan.LifecycleState); err != nil {
-		return diag.FromErr(fmt.Errorf("[ERROR] Error setting lifecycle_state: %s", err))
+		err = fmt.Errorf("Error setting lifecycle_state: %s", err)
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_is_backup_policy_plan", "read", "set-lifecycle_state").GetDiag()
 	}
 	if err = d.Set("resource_type", backupPolicyPlan.ResourceType); err != nil {
-		return diag.FromErr(fmt.Errorf("[ERROR] Error setting resource_type: %s", err))
+		err = fmt.Errorf("Error setting resource_type: %s", err)
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_is_backup_policy_plan", "read", "set-resource_type").GetDiag()
 	}
 	if err = d.Set("version", response.Headers.Get("Etag")); err != nil {
-		return diag.FromErr(fmt.Errorf("[ERROR] Error setting version: %s", err))
+		err = fmt.Errorf("[ERROR] Error setting version: %s", err)
+		return flex.DiscriminatedTerraformErrorf(err, fmt.Sprintf("Error setting version: %s", err), "ibm_is_backup_policy_plan", "read", "set-version").GetDiag()
 	}
-
 	return nil
 }
 
@@ -435,21 +454,22 @@ func resourceIBMIsBackupPolicyPlanBackupPolicyPlanDeletionTriggerPrototypeToMap(
 	} else {
 		backupPolicyPlanDeletionTriggerPrototypeMap["delete_over_count"] = "null"
 	}
-
 	return backupPolicyPlanDeletionTriggerPrototypeMap
 }
 
 func resourceIBMIsBackupPolicyPlanUpdate(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	vpcClient, err := vpcClient(meta)
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("vpcClient creation failed: %s", err.Error()), "ibm_is_backup_policy_plan", "update")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	updateBackupPolicyPlanOptions := &vpcv1.UpdateBackupPolicyPlanOptions{}
 
 	parts, err := flex.SepIdParts(d.Id(), "/")
 	if err != nil {
-		return diag.FromErr(err)
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_is_backup_policy_plan", "update", "sep-id-parts").GetDiag()
 	}
 
 	updateBackupPolicyPlanOptions.SetBackupPolicyID(parts[0])
@@ -536,7 +556,7 @@ func resourceIBMIsBackupPolicyPlanUpdate(context context.Context, d *schema.Reso
 			value := policy.(map[string]interface{})
 			remoteCopyPoliciesItem, err := resourceIBMIsVPCBackupPolicyPlanMapToBackupPolicyPlanRemoteCopyPolicyPrototype(value)
 			if err != nil {
-				return diag.FromErr(err)
+				return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_is_backup_policy_plan", "update", "parse-remote_region_policies").GetDiag()
 			}
 			remoteCopyPolicies = append(remoteCopyPolicies, *remoteCopyPoliciesItem)
 		}
@@ -548,7 +568,9 @@ func resourceIBMIsBackupPolicyPlanUpdate(context context.Context, d *schema.Reso
 	if hasChange {
 		backupPolicyPlanPatch, err := patchVals.AsPatch()
 		if err != nil {
-			return diag.FromErr(fmt.Errorf("[ERROR] [ERROR] Error calling asPatch for BackupPolicyPlanPatch: %s", err))
+			tfErr := flex.TerraformErrorf(err, fmt.Sprintf("Error calling asPatch for BackupPolicyPlanPatch: %s", err.Error()), "ibm_is_backup_policy_plan", "update")
+			log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+			return tfErr.GetDiag()
 		}
 
 		if deleteOverCountBool {
@@ -561,25 +583,27 @@ func resourceIBMIsBackupPolicyPlanUpdate(context context.Context, d *schema.Reso
 		updateBackupPolicyPlanOptions.BackupPolicyPlanPatch = backupPolicyPlanPatch
 		_, response, err := vpcClient.UpdateBackupPolicyPlanWithContext(context, updateBackupPolicyPlanOptions)
 		if err != nil {
-			log.Printf("[DEBUG] UpdateBackupPolicyPlanWithContext failed %s\n%s", err, response)
-			return diag.FromErr(fmt.Errorf("[ERROR] UpdateBackupPolicyPlanWithContext failed %s\n%s", err, response))
+			tfErr := flex.TerraformErrorf(err, fmt.Sprintf("UpdateBackupPolicyPlanWithContext failed: %s\n%s", err.Error(), response), "ibm_is_backup_policy_plan", "update")
+			log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+			return tfErr.GetDiag()
 		}
 	}
-
 	return resourceIBMIsBackupPolicyPlanRead(context, d, meta)
 }
 
 func resourceIBMIsBackupPolicyPlanDelete(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	vpcClient, err := vpcClient(meta)
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("vpcClient creation failed: %s", err.Error()), "ibm_is_backup_policy_plan", "delete")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	deleteBackupPolicyPlanOptions := &vpcv1.DeleteBackupPolicyPlanOptions{}
 
 	parts, err := flex.SepIdParts(d.Id(), "/")
 	if err != nil {
-		return diag.FromErr(err)
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_is_backup_policy_plan", "delete", "sep-id-parts").GetDiag()
 	}
 
 	deleteBackupPolicyPlanOptions.SetBackupPolicyID(parts[0])
@@ -589,8 +613,9 @@ func resourceIBMIsBackupPolicyPlanDelete(context context.Context, d *schema.Reso
 
 	_, response, err := vpcClient.DeleteBackupPolicyPlanWithContext(context, deleteBackupPolicyPlanOptions)
 	if err != nil {
-		log.Printf("[DEBUG] DeleteBackupPolicyPlanWithContext failed %s\n%s", err, response)
-		return diag.FromErr(fmt.Errorf("[ERROR] DeleteBackupPolicyPlanWithContext failed %s\n%s", err, response))
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("DeleteBackupPolicyPlanWithContext failed: %s\n%s", err.Error(), response), "ibm_is_backup_policy_plan", "delete")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	d.SetId("")


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/IBM-Cloud/terraform-provider-ibm/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```
