### PR TITLE
Refactor terraform errors to use new toolchain

### DIFF
--- a/ibm/service/power/data_source_ibm_pi_available_hosts.go
+++ b/ibm/service/power/data_source_ibm_pi_available_hosts.go
@@ -5,10 +5,13 @@ package power
 
 import (
 	"context"
+	"fmt"
+	"log"
 
 	"github.com/IBM-Cloud/power-go-client/clients/instance"
 
 	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/conns"
+	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/flex"
 	"github.com/hashicorp/go-uuid"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -63,13 +66,17 @@ func DataSourceIBMPIAvailableHosts() *schema.Resource {
 func dataSourceIBMPIAvailableHostsRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	sess, err := meta.(conns.ClientSession).IBMPISession()
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("IBMPISession failed: %s", err.Error()), "ibm_pi_available_hosts", "read")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 	cloudInstanceID := d.Get(Arg_CloudInstanceID).(string)
 	hostClient := instance.NewIBMPIHostGroupsClient(ctx, sess, cloudInstanceID)
 	hostlist, err := hostClient.GetAvailableHosts()
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("GetAvailableHosts failed: %s", err.Error()), "ibm_pi_available_hosts", "read")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 	availableHosts := []map[string]interface{}{}
 	for _, value := range hostlist {

--- a/ibm/service/power/data_source_ibm_pi_catalog_images.go
+++ b/ibm/service/power/data_source_ibm_pi_catalog_images.go
@@ -5,10 +5,13 @@ package power
 
 import (
 	"context"
+	"fmt"
+	"log"
 	"time"
 
 	"github.com/IBM-Cloud/power-go-client/clients/instance"
 	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/conns"
+	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/flex"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
@@ -139,7 +142,9 @@ func DataSourceIBMPICatalogImages() *schema.Resource {
 func dataSourceIBMPICatalogImagesRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	sess, err := meta.(conns.ClientSession).IBMPISession()
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("IBMPISession failed: %s", err.Error()), "ibm_pi_catalog_images", "read")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	cloudInstanceID := d.Get(Arg_CloudInstanceID).(string)
@@ -148,7 +153,9 @@ func dataSourceIBMPICatalogImagesRead(ctx context.Context, d *schema.ResourceDat
 	imageC := instance.NewIBMPIImageClient(ctx, sess, cloudInstanceID)
 	stockImages, err := imageC.GetAllStockImages(includeSAP, includeVTL)
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("GetAllStockImages failed: %s", err.Error()), "ibm_pi_catalog_images", "read")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	images := make([]map[string]interface{}, 0)

--- a/ibm/service/power/data_source_ibm_pi_cloud_connections.go
+++ b/ibm/service/power/data_source_ibm_pi_cloud_connections.go
@@ -5,10 +5,12 @@ package power
 
 import (
 	"context"
+	"fmt"
 	"log"
 
 	"github.com/IBM-Cloud/power-go-client/clients/instance"
 	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/conns"
+	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/flex"
 	"github.com/hashicorp/go-uuid"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -127,7 +129,9 @@ func DataSourceIBMPICloudConnections() *schema.Resource {
 func dataSourceIBMPICloudConnectionsRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	sess, err := meta.(conns.ClientSession).IBMPISession()
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("IBMPISession failed: %s", err.Error()), "ibm_pi_cloud_connections", "read")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	cloudInstanceID := d.Get(Arg_CloudInstanceID).(string)
@@ -135,8 +139,9 @@ func dataSourceIBMPICloudConnectionsRead(ctx context.Context, d *schema.Resource
 
 	cloudConnections, err := client.GetAll()
 	if err != nil {
-		log.Printf("[DEBUG] get cloud connections failed %v", err)
-		return diag.FromErr(err)
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("GetAll failed: %s", err.Error()), "ibm_pi_cloud_connections", "read")
+		log.Printf("[DEBUG] get cloud connections failed\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	result := make([]map[string]interface{}, 0, len(cloudConnections.CloudConnections))

--- a/ibm/service/power/data_source_ibm_pi_cloud_instance.go
+++ b/ibm/service/power/data_source_ibm_pi_cloud_instance.go
@@ -5,6 +5,7 @@ package power
 
 import (
 	"context"
+	"fmt"
 	"log"
 
 	"github.com/IBM-Cloud/power-go-client/clients/instance"
@@ -126,7 +127,9 @@ func DataSourceIBMPICloudInstance() *schema.Resource {
 func dataSourceIBMPICloudInstanceRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	sess, err := meta.(conns.ClientSession).IBMPISession()
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("IBMPISession failed: %s", err.Error()), "ibm_pi_cloud_instance", "read")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	cloudInstanceID := d.Get(Arg_CloudInstanceID).(string)
@@ -134,7 +137,9 @@ func dataSourceIBMPICloudInstanceRead(ctx context.Context, d *schema.ResourceDat
 	cloud_instance := instance.NewIBMPICloudInstanceClient(ctx, sess, cloudInstanceID)
 	cloud_instance_data, err := cloud_instance.Get(cloudInstanceID)
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("Get failed: %s", err.Error()), "ibm_pi_cloud_instance", "read")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	d.SetId(*cloud_instance_data.CloudInstanceID)

--- a/ibm/service/power/data_source_ibm_pi_datacenter.go
+++ b/ibm/service/power/data_source_ibm_pi_datacenter.go
@@ -5,6 +5,8 @@ package power
 
 import (
 	"context"
+	"fmt"
+	"log"
 
 	"github.com/IBM-Cloud/power-go-client/clients/instance"
 	"github.com/IBM-Cloud/power-go-client/power/models"
@@ -178,7 +180,9 @@ func DataSourceIBMPIDatacenter() *schema.Resource {
 func dataSourceIBMPIDatacenterRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	sess, err := meta.(conns.ClientSession).IBMPISession()
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("IBMPISession failed: %s", err.Error()), "ibm_pi_datacenter", "read")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	datacenterZone := sess.Options.Zone
@@ -194,7 +198,9 @@ func dataSourceIBMPIDatacenterRead(ctx context.Context, d *schema.ResourceData, 
 
 	dcData, err := client.Get(datacenterZone)
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("Get failed: %s", err.Error()), "ibm_pi_datacenter", "read")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 	var genID, _ = uuid.GenerateUUID()
 	d.SetId(genID)
@@ -212,7 +218,9 @@ func dataSourceIBMPIDatacenterRead(ctx context.Context, d *schema.ResourceData, 
 	if dcData.CapabilitiesDetails != nil {
 		capabilityDetailsMap, err := capabilityDetailsToMap(dcData.CapabilitiesDetails)
 		if err != nil {
-			return diag.FromErr(err)
+			tfErr := flex.TerraformErrorf(err, fmt.Sprintf("capabilityDetailsToMap failed: %s", err.Error()), "ibm_pi_datacenter", "read")
+			log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+			return tfErr.GetDiag()
 		}
 		capabilityDetails = append(capabilityDetails, capabilityDetailsMap)
 	}

--- a/ibm/service/power/data_source_ibm_pi_datacenters.go
+++ b/ibm/service/power/data_source_ibm_pi_datacenters.go
@@ -5,9 +5,12 @@ package power
 
 import (
 	"context"
+	"fmt"
+	"log"
 
 	"github.com/IBM-Cloud/power-go-client/clients/instance"
 	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/conns"
+	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/flex"
 	"github.com/hashicorp/go-uuid"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -178,7 +181,9 @@ func DataSourceIBMPIDatacenters() *schema.Resource {
 func dataSourceIBMPIDatacentersRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	sess, err := meta.(conns.ClientSession).IBMPISession()
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("IBMPISession failed: %s", err.Error()), "ibm_pi_datacenters", "read")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 	cloudInstanceID := ""
 	if cloudInstance, ok := d.GetOk(Arg_CloudInstanceID); ok {
@@ -187,7 +192,9 @@ func dataSourceIBMPIDatacentersRead(ctx context.Context, d *schema.ResourceData,
 	client := instance.NewIBMPIDatacenterClient(ctx, sess, cloudInstanceID)
 	datacentersData, err := client.GetAll()
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("GetAll failed: %s", err.Error()), "ibm_pi_datacenters", "read")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 	datacenters := make([]map[string]interface{}, 0, len(datacentersData.Datacenters))
 	for _, datacenter := range datacentersData.Datacenters {

--- a/ibm/service/power/data_source_ibm_pi_dhcp.go
+++ b/ibm/service/power/data_source_ibm_pi_dhcp.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/IBM-Cloud/power-go-client/clients/instance"
 	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/conns"
+	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/flex"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
@@ -80,7 +81,9 @@ func DataSourceIBMPIDhcp() *schema.Resource {
 func dataSourceIBMPIDhcpRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	sess, err := meta.(conns.ClientSession).IBMPISession()
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("IBMPISession failed: %s", err.Error()), "ibm_pi_dhcp", "read")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	cloudInstanceID := d.Get(Arg_CloudInstanceID).(string)
@@ -88,8 +91,9 @@ func dataSourceIBMPIDhcpRead(ctx context.Context, d *schema.ResourceData, meta i
 	client := instance.NewIBMPIDhcpClient(ctx, sess, cloudInstanceID)
 	dhcpServer, err := client.Get(dhcpID)
 	if err != nil {
-		log.Printf("[DEBUG] get DHCP failed %v", err)
-		return diag.FromErr(err)
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("Get failed: %s", err.Error()), "ibm_pi_dhcp", "read")
+		log.Printf("[DEBUG] get DHCP failed \n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	d.SetId(fmt.Sprintf("%s/%s", cloudInstanceID, *dhcpServer.ID))

--- a/ibm/service/power/data_source_ibm_pi_dhcps.go
+++ b/ibm/service/power/data_source_ibm_pi_dhcps.go
@@ -5,10 +5,12 @@ package power
 
 import (
 	"context"
+	"fmt"
 	"log"
 
 	"github.com/IBM-Cloud/power-go-client/clients/instance"
 	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/conns"
+	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/flex"
 	"github.com/hashicorp/go-uuid"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -65,15 +67,18 @@ func DataSourceIBMPIDhcps() *schema.Resource {
 func dataSourceIBMPIDhcpServersRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	sess, err := meta.(conns.ClientSession).IBMPISession()
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("IBMPISession failed: %s", err.Error()), "ibm_pi_dhcps", "create")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	cloudInstanceID := d.Get(Arg_CloudInstanceID).(string)
 	client := instance.NewIBMPIDhcpClient(ctx, sess, cloudInstanceID)
 	dhcpServers, err := client.GetAll()
 	if err != nil {
-		log.Printf("[DEBUG] get all DHCP failed %v", err)
-		return diag.FromErr(err)
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("GetAll failed: %s", err.Error()), "ibm_pi_dhcps", "")
+		log.Printf("[DEBUG] get all DHCP failed \n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	servers := make([]map[string]interface{}, 0, len(dhcpServers))

--- a/ibm/service/power/data_source_ibm_pi_disaster_recovery_location.go
+++ b/ibm/service/power/data_source_ibm_pi_disaster_recovery_location.go
@@ -5,9 +5,12 @@ package power
 
 import (
 	"context"
+	"fmt"
+	"log"
 
 	"github.com/IBM-Cloud/power-go-client/clients/instance"
 	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/conns"
+	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/flex"
 	"github.com/hashicorp/go-uuid"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -77,14 +80,18 @@ func DataSourceIBMPIDisasterRecoveryLocation() *schema.Resource {
 func dataSourceIBMPIDisasterRecoveryLocation(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	sess, err := meta.(conns.ClientSession).IBMPISession()
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("IBMPISession failed: %s", err.Error()), "ibm_pi_disaster_recovery_location", "read")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	cloudInstanceID := d.Get(Arg_CloudInstanceID).(string)
 	drClient := instance.NewIBMPIDisasterRecoveryLocationClient(ctx, sess, cloudInstanceID)
 	drLocationSite, err := drClient.Get()
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("Get failed: %s", err.Error()), "ibm_pi_disaster_recovery_location", "read")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	result := make([]map[string]interface{}, 0, len(drLocationSite.ReplicationSites))

--- a/ibm/service/power/data_source_ibm_pi_disaster_recovery_locations.go
+++ b/ibm/service/power/data_source_ibm_pi_disaster_recovery_locations.go
@@ -5,9 +5,12 @@ package power
 
 import (
 	"context"
+	"fmt"
+	"log"
 
 	"github.com/IBM-Cloud/power-go-client/clients/instance"
 	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/conns"
+	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/flex"
 	"github.com/hashicorp/go-uuid"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -76,13 +79,17 @@ func DataSourceIBMPIDisasterRecoveryLocations() *schema.Resource {
 func dataSourceIBMPIDisasterRecoveryLocations(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	sess, err := meta.(conns.ClientSession).IBMPISession()
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("IBMPISession failed: %s", err.Error()), "ibm_pi_disaster_recovery_locations", "read")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	drClient := instance.NewIBMPIDisasterRecoveryLocationClient(ctx, sess, "")
 	drLocationSites, err := drClient.GetAll()
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("GetAll failed: %s", err.Error()), "ibm_pi_disaster_recovery_locations", "read")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	results := make([]map[string]interface{}, 0, len(drLocationSites.DisasterRecoveryLocations))

--- a/ibm/service/power/data_source_ibm_pi_host.go
+++ b/ibm/service/power/data_source_ibm_pi_host.go
@@ -5,6 +5,7 @@ package power
 
 import (
 	"context"
+	"fmt"
 	"log"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
@@ -135,7 +136,9 @@ func DataSourceIBMPIHost() *schema.Resource {
 func dataSourceIBMPIHostRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	sess, err := meta.(conns.ClientSession).IBMPISession()
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("IBMPISession failed: %s", err.Error()), "ibm_pi_host", "read")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	cloudInstanceID := d.Get(Arg_CloudInstanceID).(string)
@@ -143,7 +146,9 @@ func dataSourceIBMPIHostRead(ctx context.Context, d *schema.ResourceData, meta i
 	client := instance.NewIBMPIHostGroupsClient(ctx, sess, cloudInstanceID)
 	host, err := client.GetHost(hostID)
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("GetHost failed: %s", err.Error()), "ibm_pi_host", "read")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	d.SetId(host.ID)

--- a/ibm/service/power/data_source_ibm_pi_host_group.go
+++ b/ibm/service/power/data_source_ibm_pi_host_group.go
@@ -5,6 +5,7 @@ package power
 
 import (
 	"context"
+	"fmt"
 	"log"
 
 	"github.com/IBM-Cloud/power-go-client/clients/instance"
@@ -13,6 +14,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 
 	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/conns"
+	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/flex"
 )
 
 func DataSourceIBMPIHostGroup() *schema.Resource {
@@ -72,15 +74,18 @@ func DataSourceIBMPIHostGroup() *schema.Resource {
 func dataSourceIBMPIHostGroupRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	sess, err := meta.(conns.ClientSession).IBMPISession()
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("IBMPISession failed: %s", err.Error()), "ibm_pi_host_group", "read")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 	cloudInstanceID := d.Get(Arg_CloudInstanceID).(string)
 	hostGroupID := d.Get(Arg_HostGroupID).(string)
 	client := instance.NewIBMPIHostGroupsClient(ctx, sess, cloudInstanceID)
 	hostGroup, err := client.GetHostGroup(hostGroupID)
 	if err != nil {
-		log.Printf("[DEBUG] get host group %v", err)
-		return diag.FromErr(err)
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("GetHostGroup failed: %s", err.Error()), "ibm_pi_host_group", "read")
+		log.Printf("[DEBUG] get host group \n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	d.SetId(hostGroup.ID)

--- a/ibm/service/power/data_source_ibm_pi_host_groups.go
+++ b/ibm/service/power/data_source_ibm_pi_host_groups.go
@@ -5,6 +5,8 @@ package power
 
 import (
 	"context"
+	"fmt"
+	"log"
 
 	"github.com/hashicorp/go-uuid"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
@@ -14,6 +16,7 @@ import (
 	"github.com/IBM-Cloud/power-go-client/clients/instance"
 	"github.com/IBM-Cloud/power-go-client/power/models"
 	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/conns"
+	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/flex"
 )
 
 func DataSourceIBMPIHostGroups() *schema.Resource {
@@ -81,14 +84,18 @@ func DataSourceIBMPIHostGroups() *schema.Resource {
 func dataSourceIBMPIHostGroupsRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	sess, err := meta.(conns.ClientSession).IBMPISession()
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("IBMPISession failed: %s", err.Error()), "ibm_pi_host_groups", "read")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 	cloudInstanceID := d.Get(Arg_CloudInstanceID).(string)
 
 	client := instance.NewIBMPIHostGroupsClient(ctx, sess, cloudInstanceID)
 	hostGroups, err := client.GetHostGroups()
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("GetHostGroups failed: %s", err.Error()), "ibm_pi_host_groups", "read")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 	var clientgenU, _ = uuid.GenerateUUID()
 	d.SetId(clientgenU)

--- a/ibm/service/power/data_source_ibm_pi_hosts.go
+++ b/ibm/service/power/data_source_ibm_pi_hosts.go
@@ -5,6 +5,7 @@ package power
 
 import (
 	"context"
+	"fmt"
 	"log"
 
 	"github.com/hashicorp/go-uuid"
@@ -142,14 +143,18 @@ func DataSourceIBMPIHosts() *schema.Resource {
 func dataSourceIBMPIHostsRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	sess, err := meta.(conns.ClientSession).IBMPISession()
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("IBMPISession failed: %s", err.Error()), "ibm_pi_hosts", "read")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 	cloudInstanceID := d.Get(Arg_CloudInstanceID).(string)
 	client := instance.NewIBMPIHostGroupsClient(ctx, sess, cloudInstanceID)
 
 	hosts, err := client.GetHosts()
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("GetHosts failed: %s", err.Error()), "ibm_pi_hosts", "read")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 	var clientgenU, _ = uuid.GenerateUUID()
 	d.SetId(clientgenU)

--- a/ibm/service/power/data_source_ibm_pi_image.go
+++ b/ibm/service/power/data_source_ibm_pi_image.go
@@ -5,6 +5,7 @@ package power
 
 import (
 	"context"
+	"fmt"
 	"log"
 
 	"github.com/IBM-Cloud/power-go-client/clients/instance"
@@ -98,7 +99,9 @@ func DataSourceIBMPIImage() *schema.Resource {
 func dataSourceIBMPIImagesRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	sess, err := meta.(conns.ClientSession).IBMPISession()
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("IBMPISession failed: %s", err.Error()), "ibm_pi_image", "read")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	cloudInstanceID := d.Get(Arg_CloudInstanceID).(string)
@@ -106,7 +109,9 @@ func dataSourceIBMPIImagesRead(ctx context.Context, d *schema.ResourceData, meta
 	imageC := instance.NewIBMPIImageClient(ctx, sess, cloudInstanceID)
 	imagedata, err := imageC.Get(d.Get(Arg_ImageName).(string))
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("Get failed: %s", err.Error()), "ibm_pi_image", "read")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	d.SetId(*imagedata.ImageID)

--- a/ibm/service/power/data_source_ibm_pi_images.go
+++ b/ibm/service/power/data_source_ibm_pi_images.go
@@ -5,6 +5,7 @@ package power
 
 import (
 	"context"
+	"fmt"
 	"log"
 
 	"github.com/IBM-Cloud/power-go-client/clients/instance"
@@ -99,7 +100,9 @@ func DataSourceIBMPIImages() *schema.Resource {
 func dataSourceIBMPIImagesAllRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	sess, err := meta.(conns.ClientSession).IBMPISession()
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("IBMPISession failed: %s", err.Error()), "ibm_pi_images", "read")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	cloudInstanceID := d.Get(Arg_CloudInstanceID).(string)
@@ -107,7 +110,9 @@ func dataSourceIBMPIImagesAllRead(ctx context.Context, d *schema.ResourceData, m
 	imageC := instance.NewIBMPIImageClient(ctx, sess, cloudInstanceID)
 	imagedata, err := imageC.GetAll()
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("GetAll failed: %s", err.Error()), "ibm_pi_images", "read")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	var clientgenU, _ = uuid.GenerateUUID()

--- a/ibm/service/power/data_source_ibm_pi_instance.go
+++ b/ibm/service/power/data_source_ibm_pi_instance.go
@@ -5,6 +5,7 @@ package power
 
 import (
 	"context"
+	"fmt"
 	"log"
 
 	"github.com/IBM-Cloud/power-go-client/clients/instance"
@@ -280,7 +281,9 @@ func DataSourceIBMPIInstance() *schema.Resource {
 func dataSourceIBMPIInstancesRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	sess, err := meta.(conns.ClientSession).IBMPISession()
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("IBMPISession failed: %s", err.Error()), "ibm_pi_instance", "read")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	cloudInstanceID := d.Get(Arg_CloudInstanceID).(string)
@@ -288,7 +291,9 @@ func dataSourceIBMPIInstancesRead(ctx context.Context, d *schema.ResourceData, m
 	powerC := instance.NewIBMPIInstanceClient(ctx, sess, cloudInstanceID)
 	powervmdata, err := powerC.Get(d.Get(Arg_InstanceName).(string))
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("Get failed: %s", err.Error()), "ibm_pi_instance", "read")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	pvminstanceid := *powervmdata.PvmInstanceID

--- a/ibm/service/power/data_source_ibm_pi_instance_console_languages.go
+++ b/ibm/service/power/data_source_ibm_pi_instance_console_languages.go
@@ -5,9 +5,12 @@ package power
 
 import (
 	"context"
+	"fmt"
+	"log"
 
 	"github.com/IBM-Cloud/power-go-client/clients/instance"
 	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/conns"
+	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/flex"
 	"github.com/hashicorp/go-uuid"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -60,7 +63,9 @@ func DataSourceIBMPIInstanceConsoleLanguages() *schema.Resource {
 func dataSourceIBMPIInstanceConsoleLanguagesRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	sess, err := meta.(conns.ClientSession).IBMPISession()
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("IBMPISession failed: %s", err.Error()), "ibm_pi_instance_console_languages", "read")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	cloudInstanceID := d.Get(Arg_CloudInstanceID).(string)
@@ -69,7 +74,9 @@ func dataSourceIBMPIInstanceConsoleLanguagesRead(ctx context.Context, d *schema.
 	client := instance.NewIBMPIInstanceClient(ctx, sess, cloudInstanceID)
 	languages, err := client.GetConsoleLanguages(instanceName)
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("GetConsoleLanguages failed: %s", err.Error()), "ibm_pi_instance_console_languages", "read")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	var clientgenU, _ = uuid.GenerateUUID()

--- a/ibm/service/power/data_source_ibm_pi_instance_ip.go
+++ b/ibm/service/power/data_source_ibm_pi_instance_ip.go
@@ -5,11 +5,14 @@ package power
 
 import (
 	"context"
+	"fmt"
+	"log"
 	"net"
 	"strconv"
 
 	"github.com/IBM-Cloud/power-go-client/clients/instance"
 	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/conns"
+	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/flex"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
@@ -100,7 +103,9 @@ func DataSourceIBMPIInstanceIP() *schema.Resource {
 func dataSourceIBMPIInstancesIPRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	sess, err := meta.(conns.ClientSession).IBMPISession()
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("IBMPISession failed: %s", err.Error()), "ibm_pi_instance_ip", "read")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	cloudInstanceID := d.Get(Arg_CloudInstanceID).(string)
@@ -109,7 +114,9 @@ func dataSourceIBMPIInstancesIPRead(ctx context.Context, d *schema.ResourceData,
 
 	powervmdata, err := powerC.Get(d.Get(Arg_InstanceName).(string))
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("Get failed: %s", err.Error()), "ibm_pi_instance_ip", "read")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	for _, network := range powervmdata.Networks {

--- a/ibm/service/power/data_source_ibm_pi_instance_snapshot.go
+++ b/ibm/service/power/data_source_ibm_pi_instance_snapshot.go
@@ -5,6 +5,7 @@ package power
 
 import (
 	"context"
+	"fmt"
 	"log"
 
 	"github.com/IBM-Cloud/power-go-client/clients/instance"
@@ -93,14 +94,18 @@ func DataSourceIBMPIInstanceSnapshot() *schema.Resource {
 func dataSourceIBMPIInstanceSnapshotRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	sess, err := meta.(conns.ClientSession).IBMPISession()
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("IBMPISession failed: %s", err.Error()), "ibm_pi_instance_snapshot", "read")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	cloudInstanceID := d.Get(Arg_CloudInstanceID).(string)
 	snapshot := instance.NewIBMPISnapshotClient(ctx, sess, cloudInstanceID)
 	snapshotData, err := snapshot.Get(d.Get(Arg_SnapshotID).(string))
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("Get failed: %s", err.Error()), "ibm_pi_instance_snapshot", "read")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	d.SetId(*snapshotData.SnapshotID)

--- a/ibm/service/power/data_source_ibm_pi_instance_snapshots.go
+++ b/ibm/service/power/data_source_ibm_pi_instance_snapshots.go
@@ -5,6 +5,7 @@ package power
 
 import (
 	"context"
+	"fmt"
 	"log"
 
 	"github.com/IBM-Cloud/power-go-client/clients/instance"
@@ -103,14 +104,18 @@ func DataSourceIBMPIInstanceSnapshots() *schema.Resource {
 func dataSourceIBMPIInstanceSnapshotsRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	sess, err := meta.(conns.ClientSession).IBMPISession()
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("IBMPISession failed: %s", err.Error()), "ibm_pi_instance_snapshots", "read")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	cloudInstanceID := d.Get(Arg_CloudInstanceID).(string)
 	snapshot := instance.NewIBMPISnapshotClient(ctx, sess, cloudInstanceID)
 	snapshotData, err := snapshot.GetAll()
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("GetAll failed: %s", err.Error()), "ibm_pi_instance_snapshots", "read")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	var clientgenU, _ = uuid.GenerateUUID()

--- a/ibm/service/power/data_source_ibm_pi_instance_volumes.go
+++ b/ibm/service/power/data_source_ibm_pi_instance_volumes.go
@@ -5,6 +5,7 @@ package power
 
 import (
 	"context"
+	"fmt"
 	"log"
 
 	"github.com/IBM-Cloud/power-go-client/clients/instance"
@@ -140,7 +141,9 @@ func DataSourceIBMPIInstanceVolumes() *schema.Resource {
 func dataSourceIBMPIInstanceVolumesRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	sess, err := meta.(conns.ClientSession).IBMPISession()
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("IBMPISession failed: %s", err.Error()), "ibm_pi_instance_volumes", "read")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	cloudInstanceID := d.Get(Arg_CloudInstanceID).(string)
@@ -148,7 +151,9 @@ func dataSourceIBMPIInstanceVolumesRead(ctx context.Context, d *schema.ResourceD
 	volumeC := instance.NewIBMPIVolumeClient(ctx, sess, cloudInstanceID)
 	volumedata, err := volumeC.GetAllInstanceVolumes(d.Get(Arg_InstanceName).(string))
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf(" failed: %s", err.Error()), "ibm_pi_instance_volumes", "read")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	var clientgenU, _ = uuid.GenerateUUID()

--- a/ibm/service/power/data_source_ibm_pi_instances.go
+++ b/ibm/service/power/data_source_ibm_pi_instances.go
@@ -5,6 +5,7 @@ package power
 
 import (
 	"context"
+	"fmt"
 	"log"
 	"strconv"
 
@@ -260,7 +261,9 @@ func dataSourceIBMPIInstancesAllRead(ctx context.Context, d *schema.ResourceData
 	sess, err := meta.(conns.ClientSession).IBMPISession()
 
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("IBMPISession failed: %s", err.Error()), "ibm_pi_instances", "read")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	cloudInstanceID := d.Get(Arg_CloudInstanceID).(string)
@@ -269,7 +272,9 @@ func dataSourceIBMPIInstancesAllRead(ctx context.Context, d *schema.ResourceData
 	powervmdata, err := powerC.GetAll()
 
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("GetAll failed: %s", err.Error()), "ibm_pi_instances", "read")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	var clientgenU, _ = uuid.GenerateUUID()

--- a/ibm/service/power/data_source_ibm_pi_key.go
+++ b/ibm/service/power/data_source_ibm_pi_key.go
@@ -5,10 +5,13 @@ package power
 
 import (
 	"context"
+	"fmt"
+	"log"
 
 	"github.com/IBM-Cloud/power-go-client/clients/instance"
 	"github.com/IBM-Cloud/power-go-client/helpers"
 	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/conns"
+	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/flex"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
@@ -51,7 +54,9 @@ func DataSourceIBMPIKey() *schema.Resource {
 func dataSourceIBMPIKeyRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	sess, err := meta.(conns.ClientSession).IBMPISession()
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("IBMPISession failed: %s", err.Error()), "ibm_pi_key", "read")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	cloudInstanceID := d.Get(Arg_CloudInstanceID).(string)
@@ -59,7 +64,9 @@ func dataSourceIBMPIKeyRead(ctx context.Context, d *schema.ResourceData, meta in
 	sshkeyC := instance.NewIBMPIKeyClient(ctx, sess, cloudInstanceID)
 	sshkeydata, err := sshkeyC.Get(d.Get(helpers.PIKeyName).(string))
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("Get failed: %s", err.Error()), "ibm_pi_key", "read")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	d.SetId(*sshkeydata.Name)

--- a/ibm/service/power/data_source_ibm_pi_network.go
+++ b/ibm/service/power/data_source_ibm_pi_network.go
@@ -5,6 +5,7 @@ package power
 
 import (
 	"context"
+	"fmt"
 	"log"
 
 	"github.com/IBM-Cloud/power-go-client/clients/instance"
@@ -137,15 +138,26 @@ func DataSourceIBMPINetwork() *schema.Resource {
 func dataSourceIBMPINetworkRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	sess, err := meta.(conns.ClientSession).IBMPISession()
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("IBMPISession failed: %s", err.Error()), "ibm_pi_network", "read")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	cloudInstanceID := d.Get(Arg_CloudInstanceID).(string)
 
 	networkC := instance.NewIBMPINetworkClient(ctx, sess, cloudInstanceID)
 	networkdata, err := networkC.Get(d.Get(helpers.PINetworkName).(string))
-	if err != nil || networkdata == nil {
-		return diag.FromErr(err)
+	if err != nil {
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("Get failed: %s", err.Error()), "ibm_pi_network", "read")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
+	}
+
+	if networkdata == nil {
+		err = flex.FmtErrorf("response returned empty")
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("networkdata returned empty: %s", err.Error()), "ibm_pi_network", "read")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	d.SetId(*networkdata.NetworkID)

--- a/ibm/service/power/data_source_ibm_pi_network_address_group.go
+++ b/ibm/service/power/data_source_ibm_pi_network_address_group.go
@@ -5,6 +5,7 @@ package power
 
 import (
 	"context"
+	"fmt"
 	"log"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
@@ -77,7 +78,9 @@ func DataSourceIBMPINetworkAddressGroup() *schema.Resource {
 func dataSourceIBMPINetworkAddressGroupRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	sess, err := meta.(conns.ClientSession).IBMPISession()
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("IBMPISession failed: %s", err.Error()), "ibm_pi_network_address_group", "read")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	cloudInstanceID := d.Get(Arg_CloudInstanceID).(string)
@@ -85,7 +88,9 @@ func dataSourceIBMPINetworkAddressGroupRead(ctx context.Context, d *schema.Resou
 	nagC := instance.NewIBMPINetworkAddressGroupClient(ctx, sess, cloudInstanceID)
 	networkAddressGroup, err := nagC.Get(nagID)
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("Get failed: %s", err.Error()), "ibm_pi_network_address_group", "read")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	d.SetId(*networkAddressGroup.ID)

--- a/ibm/service/power/data_source_ibm_pi_network_address_groups.go
+++ b/ibm/service/power/data_source_ibm_pi_network_address_groups.go
@@ -5,6 +5,7 @@ package power
 
 import (
 	"context"
+	"fmt"
 	"log"
 
 	"github.com/IBM-Cloud/power-go-client/clients/instance"
@@ -88,14 +89,18 @@ func DataSourceIBMPINetworkAddressGroups() *schema.Resource {
 func dataSourceIBMPINetworkAddressGroupsRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	sess, err := meta.(conns.ClientSession).IBMPISession()
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("IBMPISession failed: %s", err.Error()), "ibm_pi_network_address_groups", "read")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	cloudInstanceID := d.Get(Arg_CloudInstanceID).(string)
 	nagC := instance.NewIBMPINetworkAddressGroupClient(ctx, sess, cloudInstanceID)
 	networkAddressGroups, err := nagC.GetAll()
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("GetAll failed: %s", err.Error()), "ibm_pi_network_address_groups", "read")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	var genID, _ = uuid.GenerateUUID()

--- a/ibm/service/power/data_source_ibm_pi_network_interface.go
+++ b/ibm/service/power/data_source_ibm_pi_network_interface.go
@@ -120,7 +120,9 @@ func DataSourceIBMPINetworkInterface() *schema.Resource {
 func dataSourceIBMPINetworkInterfaceRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	sess, err := meta.(conns.ClientSession).IBMPISession()
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("IBMPISession failed: %s", err.Error()), "ibm_pi_network_interface", "read")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	cloudInstanceID := d.Get(Arg_CloudInstanceID).(string)
@@ -129,7 +131,9 @@ func dataSourceIBMPINetworkInterfaceRead(ctx context.Context, d *schema.Resource
 	networkC := instance.NewIBMPINetworkClient(ctx, sess, cloudInstanceID)
 	networkInterface, err := networkC.GetNetworkInterface(networkID, networkInterfaceID)
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("GetNetworkInterface failed: %s", err.Error()), "ibm_pi_network_interfaces", "read")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	d.SetId(fmt.Sprintf("%s/%s", networkID, *networkInterface.ID))

--- a/ibm/service/power/data_source_ibm_pi_network_interfaces.go
+++ b/ibm/service/power/data_source_ibm_pi_network_interfaces.go
@@ -5,6 +5,7 @@ package power
 
 import (
 	"context"
+	"fmt"
 	"log"
 
 	"github.com/IBM-Cloud/power-go-client/clients/instance"
@@ -123,7 +124,9 @@ func dataSourceIBMPINetworkInterfacesRead(ctx context.Context, d *schema.Resourc
 	sess, err := meta.(conns.ClientSession).IBMPISession()
 
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("IBMPISession failed: %s", err.Error()), "ibm_pi_network_interfaces", "read")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	cloudInstanceID := d.Get(Arg_CloudInstanceID).(string)
@@ -131,7 +134,9 @@ func dataSourceIBMPINetworkInterfacesRead(ctx context.Context, d *schema.Resourc
 	networkC := instance.NewIBMPINetworkClient(ctx, sess, cloudInstanceID)
 	networkInterfaces, err := networkC.GetAllNetworkInterfaces(networkID)
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("GetAllNetworkInterfaces failed: %s", err.Error()), "ibm_pi_network_interfaces", "read")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	var genID, _ = uuid.GenerateUUID()

--- a/ibm/service/power/data_source_ibm_pi_network_peers.go
+++ b/ibm/service/power/data_source_ibm_pi_network_peers.go
@@ -5,6 +5,8 @@ package power
 
 import (
 	"context"
+	"fmt"
+	"log"
 
 	"github.com/hashicorp/go-uuid"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
@@ -14,6 +16,7 @@ import (
 	"github.com/IBM-Cloud/power-go-client/clients/instance"
 	"github.com/IBM-Cloud/power-go-client/power/models"
 	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/conns"
+	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/flex"
 )
 
 func DataSourceIBMPINetworkPeers() *schema.Resource {
@@ -66,14 +69,18 @@ func DataSourceIBMPINetworkPeers() *schema.Resource {
 func dataSourceIBMPINetworkPeersRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	sess, err := meta.(conns.ClientSession).IBMPISession()
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("IBMPISession failed: %s", err.Error()), "ibm_pi_network_peers", "read")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 	cloudInstanceID := d.Get(Arg_CloudInstanceID).(string)
 
 	networkC := instance.NewIBMPINetworkPeerClient(ctx, sess, cloudInstanceID)
 	networkdata, err := networkC.GetNetworkPeers()
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("GetNetworkPeers failed: %s", err.Error()), "ibm_pi_network_peers", "read")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 	var clientgenU, _ = uuid.GenerateUUID()
 	d.SetId(clientgenU)

--- a/ibm/service/power/data_source_ibm_pi_network_port.go
+++ b/ibm/service/power/data_source_ibm_pi_network_port.go
@@ -5,12 +5,14 @@ package power
 
 import (
 	"context"
+	"fmt"
 	"log"
 
 	"github.com/IBM-Cloud/power-go-client/clients/instance"
 	"github.com/IBM-Cloud/power-go-client/helpers"
 	"github.com/IBM-Cloud/power-go-client/power/models"
 	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/conns"
+	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/flex"
 	"github.com/hashicorp/go-uuid"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -93,7 +95,9 @@ func DataSourceIBMPINetworkPort() *schema.Resource {
 func dataSourceIBMPINetworkPortsRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	sess, err := meta.(conns.ClientSession).IBMPISession()
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("IBMPISession failed: %s", err.Error()), "ibm_pi_network_port", "read")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	cloudInstanceID := d.Get(Arg_CloudInstanceID).(string)
@@ -101,7 +105,9 @@ func dataSourceIBMPINetworkPortsRead(ctx context.Context, d *schema.ResourceData
 	networkportC := instance.NewIBMPINetworkClient(ctx, sess, cloudInstanceID)
 	networkportdata, err := networkportC.GetAllPorts(d.Get(helpers.PINetworkName).(string))
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("GetAllPorts failed: %s", err.Error()), "ibm_pi_network_port", "read")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 	var clientgenU, _ = uuid.GenerateUUID()
 	d.SetId(clientgenU)

--- a/ibm/service/power/data_source_ibm_pi_network_security_group.go
+++ b/ibm/service/power/data_source_ibm_pi_network_security_group.go
@@ -5,6 +5,7 @@ package power
 
 import (
 	"context"
+	"fmt"
 	"log"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
@@ -208,7 +209,9 @@ func DataSourceIBMPINetworkSecurityGroup() *schema.Resource {
 func dataSourceIBMPINetworkSecurityGroupRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	sess, err := meta.(conns.ClientSession).IBMPISession()
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("IBMPISession failed: %s", err.Error()), "ibm_pi_network_security_group", "read")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	cloudInstanceID := d.Get(Arg_CloudInstanceID).(string)
@@ -216,7 +219,9 @@ func dataSourceIBMPINetworkSecurityGroupRead(ctx context.Context, d *schema.Reso
 
 	networkSecurityGroup, err := nsgClient.Get(d.Get(Arg_NetworkSecurityGroupID).(string))
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("Get failed: %s", err.Error()), "ibm_pi_network_security_group", "read")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	d.SetId(*networkSecurityGroup.ID)

--- a/ibm/service/power/data_source_ibm_pi_network_security_groups.go
+++ b/ibm/service/power/data_source_ibm_pi_network_security_groups.go
@@ -5,6 +5,7 @@ package power
 
 import (
 	"context"
+	"fmt"
 	"log"
 
 	"github.com/hashicorp/go-uuid"
@@ -217,14 +218,18 @@ func DataSourceIBMPINetworkSecurityGroups() *schema.Resource {
 func dataSourceIBMPINetworkSecurityGroupsRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	sess, err := meta.(conns.ClientSession).IBMPISession()
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("IBMPISession failed: %s", err.Error()), "ibm_pi_network_security_groups", "read")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	cloudInstanceID := d.Get(Arg_CloudInstanceID).(string)
 	nsgClient := instance.NewIBMIPINetworkSecurityGroupClient(ctx, sess, cloudInstanceID)
 	nsgResp, err := nsgClient.GetAll()
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("GetAll failed: %s", err.Error()), "ibm_pi_network_security_groups", "read")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	var clientgenU, _ = uuid.GenerateUUID()

--- a/ibm/service/power/data_source_ibm_pi_networks.go
+++ b/ibm/service/power/data_source_ibm_pi_networks.go
@@ -5,6 +5,7 @@ package power
 
 import (
 	"context"
+	"fmt"
 	"log"
 
 	"github.com/IBM-Cloud/power-go-client/clients/instance"
@@ -104,7 +105,9 @@ func DataSourceIBMPINetworks() *schema.Resource {
 func dataSourceIBMPINetworksRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	sess, err := meta.(conns.ClientSession).IBMPISession()
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("IBMPISession failed: %s", err.Error()), "ibm_pi_networks", "read")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	cloudInstanceID := d.Get(Arg_CloudInstanceID).(string)
@@ -112,7 +115,9 @@ func dataSourceIBMPINetworksRead(ctx context.Context, d *schema.ResourceData, me
 	networkC := instance.NewIBMPINetworkClient(ctx, sess, cloudInstanceID)
 	networkdata, err := networkC.GetAll()
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("GetAll failed: %s", err.Error()), "ibm_pi_networks", "read")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	var clientgenU, _ = uuid.GenerateUUID()

--- a/ibm/service/power/data_source_ibm_pi_placement_group.go
+++ b/ibm/service/power/data_source_ibm_pi_placement_group.go
@@ -5,10 +5,12 @@ package power
 
 import (
 	"context"
+	"fmt"
 	"log"
 
 	"github.com/IBM-Cloud/power-go-client/clients/instance"
 	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/conns"
+	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/flex"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
@@ -51,7 +53,9 @@ func DataSourceIBMPIPlacementGroup() *schema.Resource {
 func dataSourceIBMPIPlacementGroupRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	sess, err := meta.(conns.ClientSession).IBMPISession()
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("IBMPISession failed: %s", err.Error()), "ibm_pi_placement_group", "read")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	cloudInstanceID := d.Get(Arg_CloudInstanceID).(string)
@@ -60,8 +64,9 @@ func dataSourceIBMPIPlacementGroupRead(ctx context.Context, d *schema.ResourceDa
 
 	response, err := client.Get(placementGroupName)
 	if err != nil {
-		log.Printf("[DEBUG]  err %s", err)
-		return diag.FromErr(err)
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("Get failed: %s", err.Error()), "ibm_pi_placement_group", "read")
+		log.Printf("[DEBUG]  err \n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	d.SetId(*response.ID)

--- a/ibm/service/power/data_source_ibm_pi_placement_groups.go
+++ b/ibm/service/power/data_source_ibm_pi_placement_groups.go
@@ -5,10 +5,12 @@ package power
 
 import (
 	"context"
+	"fmt"
 	"log"
 
 	"github.com/IBM-Cloud/power-go-client/clients/instance"
 	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/conns"
+	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/flex"
 	"github.com/hashicorp/go-uuid"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -64,7 +66,9 @@ func DataSourceIBMPIPlacementGroups() *schema.Resource {
 func dataSourceIBMPIPlacementGroupsRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	sess, err := meta.(conns.ClientSession).IBMPISession()
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("IBMPISession failed: %s", err.Error()), "ibm_pi_placement_groups", "read")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	cloudInstanceID := d.Get(Arg_CloudInstanceID).(string)
@@ -72,8 +76,9 @@ func dataSourceIBMPIPlacementGroupsRead(ctx context.Context, d *schema.ResourceD
 	client := instance.NewIBMPIPlacementGroupClient(ctx, sess, cloudInstanceID)
 	groups, err := client.GetAll()
 	if err != nil {
-		log.Printf("[ERROR] get all placement groups failed %v", err)
-		return diag.FromErr(err)
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("GetAll failed: %s", err.Error()), "ibm_pi_placement_groups", "read")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	result := make([]map[string]interface{}, 0, len(groups.PlacementGroups))

--- a/ibm/service/power/data_source_ibm_pi_pvm_snapshot.go
+++ b/ibm/service/power/data_source_ibm_pi_pvm_snapshot.go
@@ -5,6 +5,7 @@ package power
 
 import (
 	"context"
+	"fmt"
 	"log"
 
 	"github.com/IBM-Cloud/power-go-client/clients/instance"
@@ -108,7 +109,9 @@ func DataSourceIBMPIPVMSnapshot() *schema.Resource {
 func dataSourceIBMPISnapshotRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	sess, err := meta.(conns.ClientSession).IBMPISession()
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("IBMPISession failed: %s", err.Error()), "ibm_pi_pvm_snapshot", "read")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	cloudInstanceID := d.Get(Arg_CloudInstanceID).(string)
@@ -117,7 +120,9 @@ func dataSourceIBMPISnapshotRead(ctx context.Context, d *schema.ResourceData, me
 	snapshotData, err := snapshot.GetSnapShotVM(powerinstancename)
 
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("GetSnapShotVM failed: %s", err.Error()), "ibm_pi_pvm_snapshot", "read")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	var clientgenU, _ = uuid.GenerateUUID()

--- a/ibm/service/power/data_source_ibm_pi_sap_profile.go
+++ b/ibm/service/power/data_source_ibm_pi_sap_profile.go
@@ -5,10 +5,12 @@ package power
 
 import (
 	"context"
+	"fmt"
 	"log"
 
 	"github.com/IBM-Cloud/power-go-client/clients/instance"
 	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/conns"
+	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/flex"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
@@ -91,7 +93,9 @@ func DataSourceIBMPISAPProfile() *schema.Resource {
 func dataSourceIBMPISAPProfileRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	sess, err := meta.(conns.ClientSession).IBMPISession()
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("IBMPISession failed: %s", err.Error()), "ibm_pi_sap_profile", "read")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	cloudInstanceID := d.Get(Arg_CloudInstanceID).(string)
@@ -100,8 +104,9 @@ func dataSourceIBMPISAPProfileRead(ctx context.Context, d *schema.ResourceData, 
 	client := instance.NewIBMPISAPInstanceClient(ctx, sess, cloudInstanceID)
 	sapProfile, err := client.GetSAPProfile(profileID)
 	if err != nil {
-		log.Printf("[DEBUG] get sap profile failed %v", err)
-		return diag.FromErr(err)
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("GetSAPProfile failed: %s", err.Error()), "ibm_pi_sap_profile", "read")
+		log.Printf("[DEBUG] get sap profile failed \n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	d.SetId(*sapProfile.ProfileID)

--- a/ibm/service/power/data_source_ibm_pi_sap_profiles.go
+++ b/ibm/service/power/data_source_ibm_pi_sap_profiles.go
@@ -5,10 +5,12 @@ package power
 
 import (
 	"context"
+	"fmt"
 	"log"
 
 	"github.com/IBM-Cloud/power-go-client/clients/instance"
 	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/conns"
+	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/flex"
 	"github.com/hashicorp/go-uuid"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -100,7 +102,9 @@ func DataSourceIBMPISAPProfiles() *schema.Resource {
 func dataSourceIBMPISAPProfilesRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	sess, err := meta.(conns.ClientSession).IBMPISession()
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("IBMPISession failed: %s", err.Error()), "ibm_pi_sap_profiles", "read")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	cloudInstanceID := d.Get(Arg_CloudInstanceID).(string)
@@ -108,8 +112,9 @@ func dataSourceIBMPISAPProfilesRead(ctx context.Context, d *schema.ResourceData,
 	client := instance.NewIBMPISAPInstanceClient(ctx, sess, cloudInstanceID)
 	sapProfiles, err := client.GetAllSAPProfiles(cloudInstanceID)
 	if err != nil {
-		log.Printf("[DEBUG] get all sap profiles failed %v", err)
-		return diag.FromErr(err)
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("GetAllSAPProfiles failed: %s", err.Error()), "ibm_pi_sap_profiles", "read")
+		log.Printf("[DEBUG] get all sap profiles failed \n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	result := make([]map[string]interface{}, 0, len(sapProfiles.Profiles))

--- a/ibm/service/power/data_source_ibm_pi_spp_placement_group.go
+++ b/ibm/service/power/data_source_ibm_pi_spp_placement_group.go
@@ -5,9 +5,12 @@ package power
 
 import (
 	"context"
+	"fmt"
+	"log"
 
 	"github.com/IBM-Cloud/power-go-client/clients/instance"
 	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/conns"
+	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/flex"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
@@ -55,7 +58,9 @@ func DataSourceIBMPISPPPlacementGroup() *schema.Resource {
 func dataSourceIBMPISPPPlacementGroupRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	sess, err := meta.(conns.ClientSession).IBMPISession()
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("IBMPISession failed: %s", err.Error()), "ibm_pi_spp_placement_group", "read")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	cloudInstanceID := d.Get(Arg_CloudInstanceID).(string)
@@ -63,8 +68,16 @@ func dataSourceIBMPISPPPlacementGroupRead(ctx context.Context, d *schema.Resourc
 	client := instance.NewIBMPISPPPlacementGroupClient(ctx, sess, cloudInstanceID)
 
 	response, err := client.Get(placementGroupID)
-	if err != nil || response == nil {
-		return diag.Errorf("error fetching the spp placement group: %v", err)
+	if err != nil {
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("Get failed: %s", err.Error()), "ibm_pi_spp_placement_group", "read")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
+	}
+	if response == nil {
+		err = flex.FmtErrorf("response returned empty")
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("operation failed: %s", err.Error()), "ibm_pi_spp_placement_group", "read")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	d.SetId(*response.ID)

--- a/ibm/service/power/data_source_ibm_pi_spp_placement_groups.go
+++ b/ibm/service/power/data_source_ibm_pi_spp_placement_groups.go
@@ -5,9 +5,12 @@ package power
 
 import (
 	"context"
+	"fmt"
+	"log"
 
 	"github.com/IBM-Cloud/power-go-client/clients/instance"
 	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/conns"
+	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/flex"
 	"github.com/hashicorp/go-uuid"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -64,15 +67,25 @@ func DataSourceIBMPISPPPlacementGroups() *schema.Resource {
 func dataSourceIBMPISPPPlacementGroupsRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	sess, err := meta.(conns.ClientSession).IBMPISession()
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("IBMPISession failed: %s", err.Error()), "ibm_pi_spp_placement_groups", "read")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	cloudInstanceID := d.Get(Arg_CloudInstanceID).(string)
 
 	client := instance.NewIBMPISPPPlacementGroupClient(ctx, sess, cloudInstanceID)
 	groups, err := client.GetAll()
-	if err != nil || groups == nil {
-		return diag.Errorf("error fetching spp placement groups: %v", err)
+	if err != nil {
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("GetAll failed: %s", err.Error()), "ibm_pi_spp_placement_groups", "read")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
+	}
+	if groups == nil {
+		err = flex.FmtErrorf("response returned empty")
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("operation failed: %s", err.Error()), "ibm_pi_spp_placement_groups", "read")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	result := make([]map[string]interface{}, 0, len(groups.SppPlacementGroups))

--- a/ibm/service/power/data_source_ibm_pi_storage_pool_capacity.go
+++ b/ibm/service/power/data_source_ibm_pi_storage_pool_capacity.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/IBM-Cloud/power-go-client/clients/instance"
 	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/conns"
+	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/flex"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
@@ -61,7 +62,9 @@ func DataSourceIBMPIStoragePoolCapacity() *schema.Resource {
 func dataSourceIBMPIStoragePoolCapacityRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	sess, err := meta.(conns.ClientSession).IBMPISession()
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("IBMPISession failed: %s", err.Error()), "ibm_pi_storage_pool_capacity", "read")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	cloudInstanceID := d.Get(Arg_CloudInstanceID).(string)
@@ -70,8 +73,9 @@ func dataSourceIBMPIStoragePoolCapacityRead(ctx context.Context, d *schema.Resou
 	client := instance.NewIBMPIStorageCapacityClient(ctx, sess, cloudInstanceID)
 	sp, err := client.GetStoragePoolCapacity(storagePool)
 	if err != nil {
-		log.Printf("[ERROR] get storage pool capacity failed %v", err)
-		return diag.FromErr(err)
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("GetStoragePoolCapacity failed: %s", err.Error()), "ibm_pi_storage_pool_capacity", "read")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	d.SetId(fmt.Sprintf("%s/%s", cloudInstanceID, storagePool))

--- a/ibm/service/power/data_source_ibm_pi_storage_pools_capacity.go
+++ b/ibm/service/power/data_source_ibm_pi_storage_pools_capacity.go
@@ -5,6 +5,7 @@ package power
 
 import (
 	"context"
+	"fmt"
 	"log"
 
 	"github.com/IBM-Cloud/power-go-client/clients/instance"
@@ -75,7 +76,9 @@ func DataSourceIBMPIStoragePoolsCapacity() *schema.Resource {
 func dataSourceIBMPIStoragePoolsCapacityRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	sess, err := meta.(conns.ClientSession).IBMPISession()
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("IBMPISession failed: %s", err.Error()), "ibm_pi_storage_pools_capacity", "read")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	cloudInstanceID := d.Get(Arg_CloudInstanceID).(string)
@@ -83,8 +86,9 @@ func dataSourceIBMPIStoragePoolsCapacityRead(ctx context.Context, d *schema.Reso
 	client := instance.NewIBMPIStorageCapacityClient(ctx, sess, cloudInstanceID)
 	spc, err := client.GetAllStoragePoolsCapacity()
 	if err != nil {
-		log.Printf("[ERROR] get all storage pools capacity failed %v", err)
-		return diag.FromErr(err)
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("GetAllStoragePoolsCapacity failed: %s", err.Error()), "ibm_pi_storage_pools_capacity", "read")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	var genID, _ = uuid.GenerateUUID()

--- a/ibm/service/power/data_source_ibm_pi_storage_tiers.go
+++ b/ibm/service/power/data_source_ibm_pi_storage_tiers.go
@@ -5,6 +5,8 @@ package power
 
 import (
 	"context"
+	"fmt"
+	"log"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -13,6 +15,7 @@ import (
 	"github.com/IBM-Cloud/power-go-client/clients/instance"
 	"github.com/IBM-Cloud/power-go-client/power/models"
 	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/conns"
+	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/flex"
 	"github.com/hashicorp/go-uuid"
 )
 
@@ -60,7 +63,9 @@ func DataSourceIBMPIStorageTiers() *schema.Resource {
 func dataSourceIBMPIStorageTiersRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	sess, err := meta.(conns.ClientSession).IBMPISession()
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("IBMPISession failed: %s", err.Error()), "ibm_pi_storage_tiers", "read")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	cloudInstanceID := d.Get(Arg_CloudInstanceID).(string)
@@ -68,8 +73,11 @@ func dataSourceIBMPIStorageTiersRead(ctx context.Context, d *schema.ResourceData
 	client := instance.NewIBMPIStorageTierClient(ctx, sess, cloudInstanceID)
 	rst, err := client.GetAll()
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("IBMPISession failed: %s", err.Error()), "ibm_pi_storage_tiers", "read")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
+
 	var genID, _ = uuid.GenerateUUID()
 	d.SetId(genID)
 

--- a/ibm/service/power/data_source_ibm_pi_storage_type_capacity.go
+++ b/ibm/service/power/data_source_ibm_pi_storage_type_capacity.go
@@ -76,7 +76,9 @@ func DataSourceIBMPIStorageTypeCapacity() *schema.Resource {
 func dataSourceIBMPIStorageTypeCapacityRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	sess, err := meta.(conns.ClientSession).IBMPISession()
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("IBMPISession failed: %s", err.Error()), "ibm_pi_storage_type_capacity", "read")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	cloudInstanceID := d.Get(Arg_CloudInstanceID).(string)
@@ -85,8 +87,9 @@ func dataSourceIBMPIStorageTypeCapacityRead(ctx context.Context, d *schema.Resou
 	client := instance.NewIBMPIStorageCapacityClient(ctx, sess, cloudInstanceID)
 	stc, err := client.GetStorageTypeCapacity(storageType)
 	if err != nil {
-		log.Printf("[ERROR] get storage type capacity failed %v", err)
-		return diag.FromErr(err)
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("GetStorageTypeCapacity failed: %s", err.Error()), "ibm_pi_storage_type_capacity", "read")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	d.SetId(fmt.Sprintf("%s/%s", cloudInstanceID, storageType))

--- a/ibm/service/power/data_source_ibm_pi_storage_types_capacity.go
+++ b/ibm/service/power/data_source_ibm_pi_storage_types_capacity.go
@@ -5,6 +5,7 @@ package power
 
 import (
 	"context"
+	"fmt"
 	"log"
 
 	"github.com/IBM-Cloud/power-go-client/clients/instance"
@@ -89,7 +90,9 @@ func DataSourceIBMPIStorageTypesCapacity() *schema.Resource {
 func dataSourceIBMPIStorageTypesCapacityRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	sess, err := meta.(conns.ClientSession).IBMPISession()
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("IBMPISession failed: %s", err.Error()), "ibm_pi_storage_types_capacity", "read")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	cloudInstanceID := d.Get(Arg_CloudInstanceID).(string)
@@ -97,8 +100,9 @@ func dataSourceIBMPIStorageTypesCapacityRead(ctx context.Context, d *schema.Reso
 	client := instance.NewIBMPIStorageCapacityClient(ctx, sess, cloudInstanceID)
 	stc, err := client.GetAllStorageTypesCapacity()
 	if err != nil {
-		log.Printf("[ERROR] get all storage types capacity failed %v", err)
-		return diag.FromErr(err)
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("GetStorageTypeCapacity failed: %s", err.Error()), "ibm_pi_storage_types_capacity", "read")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	var genID, _ = uuid.GenerateUUID()

--- a/ibm/service/power/data_source_ibm_pi_system_pools.go
+++ b/ibm/service/power/data_source_ibm_pi_system_pools.go
@@ -5,6 +5,7 @@ package power
 
 import (
 	"context"
+	"fmt"
 	"log"
 
 	"github.com/IBM-Cloud/power-go-client/clients/instance"
@@ -111,7 +112,9 @@ func DataSourceIBMPISystemPools() *schema.Resource {
 func dataSourceIBMPISystemPoolsRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	sess, err := meta.(conns.ClientSession).IBMPISession()
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("IBMPISession failed: %s", err.Error()), "ibm_pi_system_pools", "read")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	cloudInstanceID := d.Get(Arg_CloudInstanceID).(string)
@@ -119,8 +122,9 @@ func dataSourceIBMPISystemPoolsRead(ctx context.Context, d *schema.ResourceData,
 	client := instance.NewIBMPISystemPoolClient(ctx, sess, cloudInstanceID)
 	sps, err := client.GetSystemPools()
 	if err != nil {
-		log.Printf("[ERROR] get system pools capacity failed %v", err)
-		return diag.FromErr(err)
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("GetSystemPools failed: %s", err.Error()), "ibm_pi_system_pools", "read")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	var genID, _ = uuid.GenerateUUID()

--- a/ibm/service/power/data_source_ibm_pi_tenant.go
+++ b/ibm/service/power/data_source_ibm_pi_tenant.go
@@ -5,9 +5,12 @@ package power
 
 import (
 	"context"
+	"fmt"
+	"log"
 
 	"github.com/IBM-Cloud/power-go-client/clients/instance"
 	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/conns"
+	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/flex"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
@@ -67,7 +70,9 @@ func DataSourceIBMPITenant() *schema.Resource {
 func dataSourceIBMPITenantRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	sess, err := meta.(conns.ClientSession).IBMPISession()
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("IBMPISession failed: %s", err.Error()), "ibm_pi_tenant", "read")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	cloudInstanceID := d.Get(Arg_CloudInstanceID).(string)
@@ -75,7 +80,9 @@ func dataSourceIBMPITenantRead(ctx context.Context, d *schema.ResourceData, meta
 	tenantC := instance.NewIBMPITenantClient(ctx, sess, cloudInstanceID)
 	tenantData, err := tenantC.GetSelfTenant()
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("GetSelfTenant failed: %s", err.Error()), "ibm_pi_tenant", "read")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	d.SetId(*tenantData.TenantID)

--- a/ibm/service/power/data_source_ibm_pi_virtual_serial_number.go
+++ b/ibm/service/power/data_source_ibm_pi_virtual_serial_number.go
@@ -5,9 +5,12 @@ package power
 
 import (
 	"context"
+	"fmt"
+	"log"
 
 	"github.com/IBM-Cloud/power-go-client/clients/instance"
 	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/conns"
+	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/flex"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
@@ -50,7 +53,9 @@ func DataSourceIBMPIVirtualSerialNumber() *schema.Resource {
 func dataSourceIBMPIVirtualSerialNumberRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	sess, err := meta.(conns.ClientSession).IBMPISession()
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("IBMPISession failed: %s", err.Error()), "ibm_pi_virtual_serial_number", "read")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	cloudInstanceID := d.Get(Arg_CloudInstanceID).(string)
@@ -59,7 +64,9 @@ func dataSourceIBMPIVirtualSerialNumberRead(ctx context.Context, d *schema.Resou
 	vsnInput := d.Get(Arg_Serial).(string)
 	virtualSerialNumberData, err := client.Get(vsnInput)
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("Get failed: %s", err.Error()), "ibm_pi_virtual_serial_number", "read")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	id := *virtualSerialNumberData.Serial

--- a/ibm/service/power/data_source_ibm_pi_virtual_serial_numbers.go
+++ b/ibm/service/power/data_source_ibm_pi_virtual_serial_numbers.go
@@ -5,9 +5,12 @@ package power
 
 import (
 	"context"
+	"fmt"
+	"log"
 
 	"github.com/IBM-Cloud/power-go-client/clients/instance"
 	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/conns"
+	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/flex"
 	"github.com/hashicorp/go-uuid"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -63,7 +66,9 @@ func DataSourceIBMPIVirtualSerialNumbers() *schema.Resource {
 func dataSourceIBMPIVirtualSerialNumbersRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	sess, err := meta.(conns.ClientSession).IBMPISession()
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("IBMPISession failed: %s", err.Error()), "ibm_pi_virtual_serial_numbers", "read")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	cloudInstanceID := d.Get(Arg_CloudInstanceID).(string)
@@ -77,7 +82,9 @@ func dataSourceIBMPIVirtualSerialNumbersRead(ctx context.Context, d *schema.Reso
 
 	vsns, err := client.GetAll(&pvmInstanceID)
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("GetAll failed: %s", err.Error()), "ibm_pi_virtual_serial_numbers", "read")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	vsnMapList := make([]map[string]interface{}, 0)

--- a/ibm/service/power/data_source_ibm_pi_volume.go
+++ b/ibm/service/power/data_source_ibm_pi_volume.go
@@ -5,6 +5,7 @@ package power
 
 import (
 	"context"
+	"fmt"
 	"log"
 
 	"github.com/IBM-Cloud/power-go-client/clients/instance"
@@ -164,14 +165,18 @@ func DataSourceIBMPIVolume() *schema.Resource {
 func dataSourceIBMPIVolumeRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	sess, err := meta.(conns.ClientSession).IBMPISession()
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("IBMPISession failed: %s", err.Error()), "ibm_pi_volume", "read")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	cloudInstanceID := d.Get(Arg_CloudInstanceID).(string)
 	volumeC := instance.NewIBMPIVolumeClient(ctx, sess, cloudInstanceID)
 	volumedata, err := volumeC.Get(d.Get(Arg_VolumeName).(string))
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("Get failed: %s", err.Error()), "ibm_pi_volume", "read")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	d.SetId(*volumedata.VolumeID)

--- a/ibm/service/power/data_source_ibm_pi_volume_clone.go
+++ b/ibm/service/power/data_source_ibm_pi_volume_clone.go
@@ -5,9 +5,12 @@ package power
 
 import (
 	"context"
+	"fmt"
+	"log"
 
 	"github.com/IBM-Cloud/power-go-client/clients/instance"
 	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/conns"
+	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/flex"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
@@ -73,14 +76,18 @@ func DataSourceIBMPIVolumeClone() *schema.Resource {
 func dataSourceIBMPIVolumeCloneRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	sess, err := meta.(conns.ClientSession).IBMPISession()
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("IBMPISession failed: %s", err.Error()), "ibm_pi_volume_clone", "read")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	cloudInstanceID := d.Get(Arg_CloudInstanceID).(string)
 	client := instance.NewIBMPICloneVolumeClient(ctx, sess, cloudInstanceID)
 	volClone, err := client.Get(d.Get(Arg_VolumeCloneTaskID).(string))
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("Get failed: %s", err.Error()), "ibm_pi_volume_clone", "read")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	d.SetId(d.Get(Arg_VolumeCloneTaskID).(string))

--- a/ibm/service/power/data_source_ibm_pi_volume_flash_copy_mappings.go
+++ b/ibm/service/power/data_source_ibm_pi_volume_flash_copy_mappings.go
@@ -5,9 +5,12 @@ package power
 
 import (
 	"context"
+	"fmt"
+	"log"
 
 	"github.com/IBM-Cloud/power-go-client/clients/instance"
 	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/conns"
+	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/flex"
 	"github.com/hashicorp/go-uuid"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -84,14 +87,18 @@ func DataSourceIBMPIVolumeFlashCopyMappings() *schema.Resource {
 func dataSourceIBMPIVolumeFlashCopyMappings(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	sess, err := meta.(conns.ClientSession).IBMPISession()
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("IBMPISession failed: %s", err.Error()), "ibm_pi_volume_flash_copy_mappings", "read")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	cloudInstanceID := d.Get(Arg_CloudInstanceID).(string)
 	volClient := instance.NewIBMPIVolumeClient(ctx, sess, cloudInstanceID)
 	volData, err := volClient.GetVolumeFlashCopyMappings(d.Get(Arg_VolumeID).(string))
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("GetVolumeFlashCopyMappings failed: %s", err.Error()), "ibm_pi_volume_flash_copy_mappings", "read")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	results := make([]map[string]interface{}, 0, len(volData))

--- a/ibm/service/power/data_source_ibm_pi_volume_group.go
+++ b/ibm/service/power/data_source_ibm_pi_volume_group.go
@@ -5,10 +5,13 @@ package power
 
 import (
 	"context"
+	"fmt"
+	"log"
 
 	"github.com/IBM-Cloud/power-go-client/clients/instance"
 	"github.com/IBM-Cloud/power-go-client/power/models"
 	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/conns"
+	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/flex"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
@@ -101,14 +104,18 @@ func DataSourceIBMPIVolumeGroup() *schema.Resource {
 func dataSourceIBMPIVolumeGroupRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	sess, err := meta.(conns.ClientSession).IBMPISession()
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("IBMPISession failed: %s", err.Error()), "ibm_pi_volume_group", "read")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	cloudInstanceID := d.Get(Arg_CloudInstanceID).(string)
 	vgClient := instance.NewIBMPIVolumeGroupClient(ctx, sess, cloudInstanceID)
 	vgData, err := vgClient.Get(d.Get(Arg_VolumeGroupID).(string))
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("Get failed: %s", err.Error()), "ibm_pi_volume_group", "read")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	d.SetId(*vgData.ID)

--- a/ibm/service/power/data_source_ibm_pi_volume_group_details.go
+++ b/ibm/service/power/data_source_ibm_pi_volume_group_details.go
@@ -5,9 +5,12 @@ package power
 
 import (
 	"context"
+	"fmt"
+	"log"
 
 	"github.com/IBM-Cloud/power-go-client/clients/instance"
 	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/conns"
+	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/flex"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
@@ -106,14 +109,18 @@ func DataSourceIBMPIVolumeGroupDetails() *schema.Resource {
 func dataSourceIBMPIVolumeGroupDetailsRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	sess, err := meta.(conns.ClientSession).IBMPISession()
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("IBMPISession failed: %s", err.Error()), "ibm_pi_volume_group_details", "read")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	cloudInstanceID := d.Get(Arg_CloudInstanceID).(string)
 	vgClient := instance.NewIBMPIVolumeGroupClient(ctx, sess, cloudInstanceID)
 	vgData, err := vgClient.GetDetails(d.Get(Arg_VolumeGroupID).(string))
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("GetDetails failed: %s", err.Error()), "ibm_pi_volume_group_details", "read")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	d.SetId(*vgData.ID)

--- a/ibm/service/power/data_source_ibm_pi_volume_group_remote_copy_relationships.go
+++ b/ibm/service/power/data_source_ibm_pi_volume_group_remote_copy_relationships.go
@@ -5,9 +5,12 @@ package power
 
 import (
 	"context"
+	"fmt"
+	"log"
 
 	"github.com/IBM-Cloud/power-go-client/clients/instance"
 	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/conns"
+	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/flex"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
@@ -118,14 +121,18 @@ func DataSourceIBMPIVolumeGroupRemoteCopyRelationships() *schema.Resource {
 func dataSourceIBMPIVolumeGroupRemoteCopyRelationshipsReads(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	sess, err := meta.(conns.ClientSession).IBMPISession()
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("IBMPISession failed: %s", err.Error()), "ibm_pi_volume_group_remote_copy_relationships", "read")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	cloudInstanceID := d.Get(Arg_CloudInstanceID).(string)
 	vgClient := instance.NewIBMPIVolumeGroupClient(ctx, sess, cloudInstanceID)
 	vgData, err := vgClient.GetVolumeGroupRemoteCopyRelationships(d.Get(Arg_VolumeGroupID).(string))
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("GetVolumeGroupRemoteCopyRelationships failed: %s", err.Error()), "ibm_pi_volume_group_remote_copy_relationships", "read")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	results := make([]map[string]interface{}, 0, len(vgData.RemoteCopyRelationships))

--- a/ibm/service/power/data_source_ibm_pi_volume_group_storage_details.go
+++ b/ibm/service/power/data_source_ibm_pi_volume_group_storage_details.go
@@ -5,9 +5,12 @@ package power
 
 import (
 	"context"
+	"fmt"
+	"log"
 
 	"github.com/IBM-Cloud/power-go-client/clients/instance"
 	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/conns"
+	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/flex"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
@@ -85,7 +88,9 @@ func DataSourceIBMPIVolumeGroupStorageDetails() *schema.Resource {
 func dataSourceIBMPIVolumeGroupStorageDetailsReads(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	sess, err := meta.(conns.ClientSession).IBMPISession()
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("IBMPISession failed: %s", err.Error()), "ibm_pi_volume_groups_storage_details", "read")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	cloudInstanceID := d.Get(Arg_CloudInstanceID).(string)
@@ -93,7 +98,9 @@ func dataSourceIBMPIVolumeGroupStorageDetailsReads(ctx context.Context, d *schem
 	vgID := d.Get(Arg_VolumeGroupID).(string)
 	vgData, err := vgClient.GetVolumeGroupLiveDetails(vgID)
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("GetVolumeGroupLiveDetails failed: %s", err.Error()), "ibm_pi_volume_groups_storage_details", "read")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	d.SetId(vgID)

--- a/ibm/service/power/data_source_ibm_pi_volume_groups.go
+++ b/ibm/service/power/data_source_ibm_pi_volume_groups.go
@@ -5,6 +5,7 @@ package power
 
 import (
 	"context"
+	"fmt"
 	"log"
 
 	"github.com/hashicorp/go-uuid"
@@ -15,6 +16,7 @@ import (
 	"github.com/IBM-Cloud/power-go-client/clients/instance"
 	"github.com/IBM-Cloud/power-go-client/power/models"
 	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/conns"
+	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/flex"
 )
 
 func DataSourceIBMPIVolumeGroups() *schema.Resource {
@@ -112,14 +114,18 @@ func DataSourceIBMPIVolumeGroups() *schema.Resource {
 func dataSourceIBMPIVolumeGroupsRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	sess, err := meta.(conns.ClientSession).IBMPISession()
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("IBMPISession failed: %s", err.Error()), "ibm_pi_volume_groups", "read")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	cloudInstanceID := d.Get(Arg_CloudInstanceID).(string)
 	vgClient := instance.NewIBMPIVolumeGroupClient(ctx, sess, cloudInstanceID)
 	vgData, err := vgClient.GetAll()
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("GetAll failed: %s", err.Error()), "ibm_pi_volume_groups", "read")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	var clientgenU, _ = uuid.GenerateUUID()

--- a/ibm/service/power/data_source_ibm_pi_volume_groups_details.go
+++ b/ibm/service/power/data_source_ibm_pi_volume_groups_details.go
@@ -5,6 +5,7 @@ package power
 
 import (
 	"context"
+	"fmt"
 	"log"
 
 	"github.com/hashicorp/go-uuid"
@@ -15,6 +16,7 @@ import (
 	"github.com/IBM-Cloud/power-go-client/clients/instance"
 	"github.com/IBM-Cloud/power-go-client/power/models"
 	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/conns"
+	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/flex"
 )
 
 func DataSourceIBMPIVolumeGroupsDetails() *schema.Resource {
@@ -118,14 +120,18 @@ func DataSourceIBMPIVolumeGroupsDetails() *schema.Resource {
 func dataSourceIBMPIVolumeGroupsDetailsRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	sess, err := meta.(conns.ClientSession).IBMPISession()
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("IBMPISession failed: %s", err.Error()), "ibm_pi_volume_groups_details", "read")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	cloudInstanceID := d.Get(Arg_CloudInstanceID).(string)
 	vgClient := instance.NewIBMPIVolumeGroupClient(ctx, sess, cloudInstanceID)
 	vgData, err := vgClient.GetAllDetails()
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("GetAllDetails failed: %s", err.Error()), "ibm_pi_volume_groups_details", "read")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	var clientgenU, _ = uuid.GenerateUUID()

--- a/ibm/service/power/data_source_ibm_pi_volume_onboarding.go
+++ b/ibm/service/power/data_source_ibm_pi_volume_onboarding.go
@@ -5,10 +5,13 @@ package power
 
 import (
 	"context"
+	"fmt"
+	"log"
 
 	"github.com/IBM-Cloud/power-go-client/clients/instance"
 	"github.com/IBM-Cloud/power-go-client/power/models"
 	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/conns"
+	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/flex"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
@@ -93,14 +96,18 @@ func DataSourceIBMPIVolumeOnboarding() *schema.Resource {
 func dataSourceIBMPIVolumeOnboardingReads(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	sess, err := meta.(conns.ClientSession).IBMPISession()
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("IBMPISession failed: %s", err.Error()), "ibm_pi_volume_onboarding", "read")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	cloudInstanceID := d.Get(Arg_CloudInstanceID).(string)
 	volOnboardClient := instance.NewIBMPIVolumeOnboardingClient(ctx, sess, cloudInstanceID)
 	volOnboarding, err := volOnboardClient.Get(d.Get(Arg_VolumeOnboardingID).(string))
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("Get failed: %s", err.Error()), "ibm_pi_volume_onboarding", "read")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	d.SetId(*volOnboarding.ID)

--- a/ibm/service/power/data_source_ibm_pi_volume_onboardings.go
+++ b/ibm/service/power/data_source_ibm_pi_volume_onboardings.go
@@ -5,11 +5,13 @@ package power
 
 import (
 	"context"
+	"fmt"
 	"log"
 
 	"github.com/IBM-Cloud/power-go-client/clients/instance"
 	"github.com/IBM-Cloud/power-go-client/power/models"
 	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/conns"
+	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/flex"
 	"github.com/hashicorp/go-uuid"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -66,14 +68,18 @@ func DataSourceIBMPIVolumeOnboardings() *schema.Resource {
 func dataSourceIBMPIVolumeOnboardingsReads(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	sess, err := meta.(conns.ClientSession).IBMPISession()
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("IBMPISession failed: %s", err.Error()), "ibm_pi_volume_onboardings", "read")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	cloudInstanceID := d.Get(Arg_CloudInstanceID).(string)
 	volOnboardClient := instance.NewIBMPIVolumeOnboardingClient(ctx, sess, cloudInstanceID)
 	volOnboardings, err := volOnboardClient.GetAll()
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("GetAll failed: %s", err.Error()), "ibm_pi_volume_onboardings", "read")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	var clientgenU, _ = uuid.GenerateUUID()

--- a/ibm/service/power/data_source_ibm_pi_volume_remote_copy_relationship.go
+++ b/ibm/service/power/data_source_ibm_pi_volume_remote_copy_relationship.go
@@ -5,9 +5,12 @@ package power
 
 import (
 	"context"
+	"fmt"
+	"log"
 
 	"github.com/IBM-Cloud/power-go-client/clients/instance"
 	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/conns"
+	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/flex"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
@@ -114,14 +117,18 @@ func DataSourceIBMPIVolumeRemoteCopyRelationship() *schema.Resource {
 func dataSourceIBMPIVolumeRemoteCopyRelationshipsReads(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	sess, err := meta.(conns.ClientSession).IBMPISession()
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("IBMPISession failed: %s", err.Error()), "ibm_pi_volume_remote_copy_relationship", "read")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	cloudInstanceID := d.Get(Arg_CloudInstanceID).(string)
 	volClient := instance.NewIBMPIVolumeClient(ctx, sess, cloudInstanceID)
 	volData, err := volClient.GetVolumeRemoteCopyRelationships(d.Get(Arg_VolumeID).(string))
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("GetVolumeRemoteCopyRelationships failed: %s", err.Error()), "ibm_pi_volume_remote_copy_relationship", "read")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	d.SetId(volData.ID)

--- a/ibm/service/power/data_source_ibm_pi_volume_snapshot.go
+++ b/ibm/service/power/data_source_ibm_pi_volume_snapshot.go
@@ -5,9 +5,12 @@ package power
 
 import (
 	"context"
+	"fmt"
+	"log"
 
 	"github.com/IBM-Cloud/power-go-client/clients/instance"
 	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/conns"
+	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/flex"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
@@ -75,7 +78,9 @@ func DataSourceIBMPIVolumeSnapshot() *schema.Resource {
 func dataSourceIBMPIVolumeSnapshotRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	sess, err := meta.(conns.ClientSession).IBMPISession()
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("IBMPISession failed: %s", err.Error()), "ibm_pi_volume_snapshot", "read")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	cloudInstanceID := d.Get(Arg_CloudInstanceID).(string)
@@ -84,7 +89,9 @@ func dataSourceIBMPIVolumeSnapshotRead(ctx context.Context, d *schema.ResourceDa
 	client := instance.NewIBMPISnapshotClient(ctx, sess, cloudInstanceID)
 	snapshot, err := client.V1VolumeSnapshotsGet(snapshotID)
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("V1VolumeSnapshotsGet failed: %s", err.Error()), "ibm_pi_volume_snapshot", "read")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 	d.SetId(*snapshot.ID)
 	d.Set(Attr_CreationDate, snapshot.CreationDate.String())

--- a/ibm/service/power/data_source_ibm_pi_workspace.go
+++ b/ibm/service/power/data_source_ibm_pi_workspace.go
@@ -5,6 +5,8 @@ package power
 
 import (
 	"context"
+	"fmt"
+	"log"
 
 	"github.com/IBM-Cloud/power-go-client/clients/instance"
 	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/conns"
@@ -117,14 +119,18 @@ func DatasourceIBMPIWorkspace() *schema.Resource {
 func dataSourceIBMPIWorkspaceRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	sess, err := meta.(conns.ClientSession).IBMPISession()
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("IBMPISession failed: %s", err.Error()), "ibm_pi_workspace", "read")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	cloudInstanceID := d.Get(Arg_CloudInstanceID).(string)
 	client := instance.NewIBMPIWorkspacesClient(ctx, sess, cloudInstanceID)
 	wsData, err := client.Get(cloudInstanceID)
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("Get failed: %s", err.Error()), "ibm_pi_workspace", "read")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	d.Set(Attr_WorkspaceName, wsData.Name)

--- a/ibm/service/power/data_source_ibm_pi_workspaces.go
+++ b/ibm/service/power/data_source_ibm_pi_workspaces.go
@@ -5,9 +5,12 @@ package power
 
 import (
 	"context"
+	"fmt"
+	"log"
 
 	"github.com/IBM-Cloud/power-go-client/clients/instance"
 	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/conns"
+	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/flex"
 	"github.com/hashicorp/go-uuid"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -130,14 +133,18 @@ func DatasourceIBMPIWorkspaces() *schema.Resource {
 func dataSourceIBMPIWorkspacesRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	sess, err := meta.(conns.ClientSession).IBMPISession()
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("IBMPISession failed: %s", err.Error()), "ibm_pi_workspaces", "read")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	cloudInstanceID := d.Get(Arg_CloudInstanceID).(string)
 	client := instance.NewIBMPIWorkspacesClient(ctx, sess, cloudInstanceID)
 	wsData, err := client.GetAll()
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("GetAll failed: %s", err.Error()), "ibm_pi_workspaces", "read")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 	workspaces := make([]map[string]interface{}, 0, len(wsData.Workspaces))
 	for _, ws := range wsData.Workspaces {

--- a/ibm/service/power/resource_ibm_pi_capture.go
+++ b/ibm/service/power/resource_ibm_pi_capture.go
@@ -134,7 +134,9 @@ func ResourceIBMPICapture() *schema.Resource {
 func resourceIBMPICaptureCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	sess, err := meta.(conns.ClientSession).IBMPISession()
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("IBMPISession failed: %s", err.Error()), "ibm_pi_capture", "create")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	name := d.Get(Arg_InstanceName).(string)
@@ -152,22 +154,34 @@ func resourceIBMPICaptureCreate(ctx context.Context, d *schema.ResourceData, met
 		if v, ok := d.GetOk(Arg_CaptureCloudStorageRegion); ok {
 			captureBody.CloudStorageRegion = v.(string)
 		} else {
-			return diag.Errorf("%s is required when capture destination is %s", Arg_CaptureCloudStorageRegion, capturedestination)
+			err = flex.FmtErrorf("%s is required when capture destination is %s", Arg_CaptureCloudStorageRegion, capturedestination)
+			tfErr := flex.TerraformErrorf(err, fmt.Sprintf("operation failed: %s", err.Error()), "ibm_pi_capture", "create")
+			log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+			return tfErr.GetDiag()
 		}
 		if v, ok := d.GetOk(Arg_CaptureCloudStorageAccessKey); ok {
 			captureBody.CloudStorageAccessKey = v.(string)
 		} else {
-			return diag.Errorf("%s is required when capture destination is %s ", Arg_CaptureCloudStorageAccessKey, capturedestination)
+			err = flex.FmtErrorf("%s is required when capture destination is %s", Arg_CaptureCloudStorageAccessKey, capturedestination)
+			tfErr := flex.TerraformErrorf(err, fmt.Sprintf("operation failed: %s", err.Error()), "ibm_pi_capture", "create")
+			log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+			return tfErr.GetDiag()
 		}
 		if v, ok := d.GetOk(Arg_CaptureStorageImagePath); ok {
 			captureBody.CloudStorageImagePath = v.(string)
 		} else {
-			return diag.Errorf("%s is required when capture destination is %s ", Arg_CaptureStorageImagePath, capturedestination)
+			err = flex.FmtErrorf("%s is required when capture destination is %s", Arg_CaptureStorageImagePath, capturedestination)
+			tfErr := flex.TerraformErrorf(err, fmt.Sprintf("operation failed: %s", err.Error()), "ibm_pi_capture", "create")
+			log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+			return tfErr.GetDiag()
 		}
 		if v, ok := d.GetOk(Arg_CaptureCloudStorageSecretKey); ok {
 			captureBody.CloudStorageSecretKey = v.(string)
 		} else {
-			return diag.Errorf("%s is required when capture destination is %s ", Arg_CaptureCloudStorageSecretKey, capturedestination)
+			err = flex.FmtErrorf("%s is required when capture destination is %s", Arg_CaptureCloudStorageSecretKey, capturedestination)
+			tfErr := flex.TerraformErrorf(err, fmt.Sprintf("operation failed: %s", err.Error()), "ibm_pi_capture", "create")
+			log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+			return tfErr.GetDiag()
 		}
 	}
 
@@ -185,14 +199,18 @@ func resourceIBMPICaptureCreate(ctx context.Context, d *schema.ResourceData, met
 	captureResponse, err := client.CaptureInstanceToImageCatalogV2(name, captureBody)
 
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("IBMPISession failed: %s", err.Error()), "ibm_pi_capture", "read")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	d.SetId(fmt.Sprintf("%s/%s/%s", cloudInstanceID, capturename, capturedestination))
 	jobClient := instance.NewIBMPIJobClient(ctx, sess, cloudInstanceID)
 	_, err = waitForIBMPIJobCompleted(ctx, jobClient, *captureResponse.ID, d.Timeout(schema.TimeoutCreate))
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("IBMPISession failed: %s", err.Error()), "ibm_pi_capture", "read")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	if _, ok := d.GetOk(Arg_UserTags); ok && capturedestination != CloudStorage {
@@ -202,7 +220,9 @@ func resourceIBMPICaptureCreate(ctx context.Context, d *schema.ResourceData, met
 			if strings.Contains(err.Error(), NotFound) {
 				d.SetId("")
 			}
-			return diag.Errorf("Error on get of ibm pi capture (%s) while applying pi_user_tags: %s", capturename, err)
+			tfErr := flex.TerraformErrorf(err, fmt.Sprintf("Error on get of ibm pi capture (%s) while applying pi_user_tags: : %s", capturename, err), "ibm_pi_capture", "")
+			log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+			return tfErr.GetDiag()
 		}
 		if imagedata.Crn != "" {
 			oldList, newList := d.GetChange(Arg_UserTags)
@@ -219,11 +239,15 @@ func resourceIBMPICaptureCreate(ctx context.Context, d *schema.ResourceData, met
 func resourceIBMPICaptureRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	sess, err := meta.(conns.ClientSession).IBMPISession()
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("IBMPISession failed: %s", err.Error()), "ibm_pi_capture", "read")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 	parts, err := flex.IdParts(d.Id())
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("IBMPISession failed: %s", err.Error()), "ibm_pi_capture", "read")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 	cloudInstanceID := parts[0]
 	captureID := parts[1]
@@ -235,12 +259,14 @@ func resourceIBMPICaptureRead(ctx context.Context, d *schema.ResourceData, meta 
 			uErr := errors.Unwrap(err)
 			switch uErr.(type) {
 			case *p_cloud_images.PcloudCloudinstancesImagesGetNotFound:
-				log.Printf("[DEBUG] image does not exist %v", err)
 				d.SetId("")
-				return diag.Errorf("image does not exist %v", err)
+				tfErr := flex.TerraformErrorf(err, fmt.Sprintf("Get failed: %s", err.Error()), "ibm_pi_capture", "read")
+				log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+				return tfErr.GetDiag()
 			}
-			log.Printf("[DEBUG] get image failed %v", err)
-			return diag.FromErr(err)
+			tfErr := flex.TerraformErrorf(err, fmt.Sprintf("Get failed: %s", err.Error()), "ibm_pi_capture", "read")
+			log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+			return tfErr.GetDiag()
 		}
 		imageid := *imagedata.ImageID
 		d.Set(Attr_ImageID, imageid)
@@ -260,11 +286,15 @@ func resourceIBMPICaptureRead(ctx context.Context, d *schema.ResourceData, meta 
 func resourceIBMPICaptureDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	sess, err := meta.(conns.ClientSession).IBMPISession()
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("IBMPISession failed: %s", err.Error()), "ibm_pi_capture", "delete")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 	parts, err := flex.IdParts(d.Id())
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("IdParts failed: %s", err.Error()), "ibm_pi_capture", "delete")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 	cloudInstanceID := parts[0]
 	captureID := parts[1]
@@ -280,8 +310,9 @@ func resourceIBMPICaptureDelete(ctx context.Context, d *schema.ResourceData, met
 				d.SetId("")
 				return nil
 			}
-			log.Printf("[DEBUG] delete image failed %v", err)
-			return diag.FromErr(err)
+			tfErr := flex.TerraformErrorf(err, fmt.Sprintf("Delete failed: %s", err.Error()), "ibm_pi_capture", "delete")
+			log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+			return tfErr.GetDiag()
 		}
 	}
 	d.SetId("")
@@ -291,7 +322,9 @@ func resourceIBMPICaptureDelete(ctx context.Context, d *schema.ResourceData, met
 func resourceIBMPICaptureUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	parts, err := flex.IdParts(d.Id())
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("IBMPISession failed: %s", err.Error()), "ibm_pi_capture", "read")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 	captureID := parts[1]
 	capturedestination := parts[2]

--- a/ibm/service/power/resource_ibm_pi_capture_test.go
+++ b/ibm/service/power/resource_ibm_pi_capture_test.go
@@ -136,7 +136,7 @@ func testAccCheckIBMPICaptureExists(n string) resource.TestCheckFunc {
 		rs, ok := s.RootModule().Resources[n]
 
 		if !ok {
-			return fmt.Errorf("Not found: %s", n)
+			return flex.FmtErrorf("Not found: %s", n)
 		}
 
 		if rs.Primary.ID == "" {
@@ -182,7 +182,7 @@ func testAccCheckIBMPICaptureDestroy(s *terraform.State) error {
 		imageClient := instance.NewIBMPIImageClient(context.Background(), sess, cloudInstanceID)
 		_, err = imageClient.Get(captureID)
 		if err == nil {
-			return fmt.Errorf("PI Image still exists: %s", rs.Primary.ID)
+			return flex.FmtErrorf("PI Image still exists: %s", rs.Primary.ID)
 		}
 	}
 

--- a/ibm/service/power/resource_ibm_pi_cloud_connection.go
+++ b/ibm/service/power/resource_ibm_pi_cloud_connection.go
@@ -162,7 +162,9 @@ func ResourceIBMPICloudConnection() *schema.Resource {
 func resourceIBMPICloudConnectionCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	sess, err := meta.(conns.ClientSession).IBMPISession()
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("IBMPISession failed: %s", err.Error()), "ibm_pi_cloud_connection", "create")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	cloudInstanceID := d.Get(Arg_CloudInstanceID).(string)
@@ -238,8 +240,9 @@ func resourceIBMPICloudConnectionCreate(ctx context.Context, d *schema.ResourceD
 			}, Create, err)
 		}
 		if err != nil {
-			log.Printf("[DEBUG] create cloud connection failed %v", err)
-			return diag.FromErr(err)
+			tfErr := flex.TerraformErrorf(err, fmt.Sprintf("Create failed: %s", err.Error()), "ibm_pi_cloud_connection", "create")
+			log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+			return tfErr.GetDiag()
 		}
 	}
 
@@ -253,7 +256,9 @@ func resourceIBMPICloudConnectionCreate(ctx context.Context, d *schema.ResourceD
 		client := instance.NewIBMPIJobClient(ctx, sess, cloudInstanceID)
 		_, err = waitForIBMPIJobCompleted(ctx, client, jobID, d.Timeout(schema.TimeoutCreate))
 		if err != nil {
-			return diag.FromErr(err)
+			tfErr := flex.TerraformErrorf(err, fmt.Sprintf("waitForIBMPIJobCompleted failed: %s", err.Error()), "ibm_pi_cloud_connection", "create")
+			log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+			return tfErr.GetDiag()
 		}
 	}
 
@@ -263,12 +268,16 @@ func resourceIBMPICloudConnectionCreate(ctx context.Context, d *schema.ResourceD
 func resourceIBMPICloudConnectionUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	sess, err := meta.(conns.ClientSession).IBMPISession()
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("IBMPISession failed: %s", err.Error()), "ibm_pi_cloud_connection", "update")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	parts, err := flex.IdParts(d.Id())
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("IdParts failed: %s", err.Error()), "ibm_pi_cloud_connection", "update")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	cloudInstanceID := parts[0]
@@ -353,14 +362,17 @@ func resourceIBMPICloudConnectionUpdate(ctx context.Context, d *schema.ResourceD
 				}, Update, err)
 			}
 			if err != nil {
-				log.Printf("[DEBUG] update cloud connection failed %v", err)
-				return diag.FromErr(err)
+				tfErr := flex.TerraformErrorf(err, fmt.Sprintf("Update failed: %s", err.Error()), "ibm_pi_cloud_connection", "update")
+				log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+				return tfErr.GetDiag()
 			}
 		}
 		if cloudConnectionJob != nil {
 			_, err = waitForIBMPIJobCompleted(ctx, jobClient, *cloudConnectionJob.ID, d.Timeout(schema.TimeoutCreate))
 			if err != nil {
-				return diag.FromErr(err)
+				tfErr := flex.TerraformErrorf(err, fmt.Sprintf("waitForIBMPIJobCompleted failed: %s", err.Error()), "ibm_pi_cloud_connection", "update")
+				log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+				return tfErr.GetDiag()
 			}
 		}
 	}
@@ -376,12 +388,16 @@ func resourceIBMPICloudConnectionUpdate(ctx context.Context, d *schema.ResourceD
 		for _, n := range flex.ExpandStringList(toAdd.List()) {
 			_, jobReference, err := client.AddNetwork(cloudConnectionID, n)
 			if err != nil {
-				return diag.FromErr(err)
+				tfErr := flex.TerraformErrorf(err, fmt.Sprintf("AddNetwork failed: %s", err.Error()), "ibm_pi_cloud_connection", "update")
+				log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+				return tfErr.GetDiag()
 			}
 			if jobReference != nil {
 				_, err = waitForIBMPIJobCompleted(ctx, jobClient, *jobReference.ID, d.Timeout(schema.TimeoutUpdate))
 				if err != nil {
-					return diag.FromErr(err)
+					tfErr := flex.TerraformErrorf(err, fmt.Sprintf("waitForIBMPIJobCompleted failed: %s", err.Error()), "ibm_pi_cloud_connection", "update")
+					log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+					return tfErr.GetDiag()
 				}
 			}
 		}
@@ -390,12 +406,16 @@ func resourceIBMPICloudConnectionUpdate(ctx context.Context, d *schema.ResourceD
 		for _, n := range flex.ExpandStringList(toRemove.List()) {
 			_, jobReference, err := client.DeleteNetwork(cloudConnectionID, n)
 			if err != nil {
-				return diag.FromErr(err)
+				tfErr := flex.TerraformErrorf(err, fmt.Sprintf("DeleteNetwork failed: %s", err.Error()), "ibm_pi_cloud_connection", "update")
+				log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+				return tfErr.GetDiag()
 			}
 			if jobReference != nil {
 				_, err = waitForIBMPIJobCompleted(ctx, jobClient, *jobReference.ID, d.Timeout(schema.TimeoutUpdate))
 				if err != nil {
-					return diag.FromErr(err)
+					tfErr := flex.TerraformErrorf(err, fmt.Sprintf("waitForIBMPIJobCompleted failed: %s", err.Error()), "ibm_pi_cloud_connection", "update")
+					log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+					return tfErr.GetDiag()
 				}
 			}
 		}
@@ -407,12 +427,16 @@ func resourceIBMPICloudConnectionUpdate(ctx context.Context, d *schema.ResourceD
 func resourceIBMPICloudConnectionRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	sess, err := meta.(conns.ClientSession).IBMPISession()
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("IBMPISession failed: %s", err.Error()), "ibm_pi_cloud_connection", "read")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	parts, err := flex.IdParts(d.Id())
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("IdParts failed: %s", err.Error()), "ibm_pi_cloud_connection", "read")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	cloudInstanceID := parts[0]
@@ -428,8 +452,9 @@ func resourceIBMPICloudConnectionRead(ctx context.Context, d *schema.ResourceDat
 			d.SetId("")
 			return nil
 		}
-		log.Printf("[DEBUG] get cloud connection failed %v", err)
-		return diag.FromErr(err)
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("Get failed: %s", err.Error()), "ibm_pi_cloud_connection", "read")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	d.Set(Arg_CloudConnectionGlobalRouting, cloudConnection.GlobalRouting)
@@ -476,12 +501,16 @@ func resourceIBMPICloudConnectionRead(ctx context.Context, d *schema.ResourceDat
 func resourceIBMPICloudConnectionDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	sess, err := meta.(conns.ClientSession).IBMPISession()
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("IBMPISession failed: %s", err.Error()), "ibm_pi_cloud_connection", "delete")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	parts, err := flex.IdParts(d.Id())
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("IdParts failed: %s", err.Error()), "ibm_pi_cloud_connection", "delete")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	cloudInstanceID := parts[0]
@@ -497,22 +526,26 @@ func resourceIBMPICloudConnectionDelete(ctx context.Context, d *schema.ResourceD
 			d.SetId("")
 			return nil
 		}
-		log.Printf("[DEBUG] get cloud connection failed %v", err)
-		return diag.FromErr(err)
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("Get failed: %s", err.Error()), "ibm_pi_cloud_connection", "delete")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 	log.Printf("[INFO] Found cloud connection with id %s", cloudConnectionID)
 
 	deleteJob, err := client.Delete(cloudConnectionID)
 	if err != nil {
-		log.Printf("[DEBUG] delete cloud connection failed %v", err)
-		return diag.FromErr(err)
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("Delete failed: %s", err.Error()), "ibm_pi_cloud_connection", "delete")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 	if deleteJob != nil {
 		jobID := *deleteJob.ID
 		client := instance.NewIBMPIJobClient(ctx, sess, cloudInstanceID)
 		_, err = waitForIBMPIJobCompleted(ctx, client, jobID, d.Timeout(schema.TimeoutDelete))
 		if err != nil {
-			return diag.FromErr(err)
+			tfErr := flex.TerraformErrorf(err, fmt.Sprintf("waitForIBMPIJobCompleted failed: %s", err.Error()), "ibm_pi_cloud_connection", "delete")
+			log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+			return tfErr.GetDiag()
 		}
 	}
 

--- a/ibm/service/power/resource_ibm_pi_cloud_connection_network_attach.go
+++ b/ibm/service/power/resource_ibm_pi_cloud_connection_network_attach.go
@@ -59,7 +59,9 @@ func ResourceIBMPICloudConnectionNetworkAttach() *schema.Resource {
 func resourceIBMPICloudConnectionNetworkAttachCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	sess, err := meta.(conns.ClientSession).IBMPISession()
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("IBMPISession failed: %s", err.Error()), "ibm_pi_cloud_connection_network_attach", "create")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	cloudInstanceID := d.Get(Arg_CloudInstanceID).(string)
@@ -71,14 +73,17 @@ func resourceIBMPICloudConnectionNetworkAttachCreate(ctx context.Context, d *sch
 
 	_, jobReference, err := client.AddNetwork(cloudConnectionID, networkID)
 	if err != nil {
-		log.Printf("[ERROR] attach network to cloud connection failed %v", err)
-		return diag.FromErr(err)
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("AddNetwork failed: %s", err.Error()), "ibm_pi_cloud_connection_network_attach", "create")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 	d.SetId(fmt.Sprintf("%s/%s/%s", cloudInstanceID, cloudConnectionID, networkID))
 	if jobReference != nil {
 		_, err = waitForIBMPIJobCompleted(ctx, jobClient, *jobReference.ID, d.Timeout(schema.TimeoutCreate))
 		if err != nil {
-			return diag.FromErr(err)
+			tfErr := flex.TerraformErrorf(err, fmt.Sprintf("waitForIBMPIJobCompleted failed: %s", err.Error()), "ibm_pi_cloud_connection_network_attach", "create")
+			log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+			return tfErr.GetDiag()
 		}
 	}
 
@@ -88,7 +93,9 @@ func resourceIBMPICloudConnectionNetworkAttachCreate(ctx context.Context, d *sch
 func resourceIBMPICloudConnectionNetworkAttachRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	parts, err := flex.IdParts(d.Id())
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("IBMPISession failed: %s", err.Error()), "ibm_pi_cloud_connection_network_attach", "read")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	cloudInstanceID := parts[0]
@@ -105,12 +112,16 @@ func resourceIBMPICloudConnectionNetworkAttachRead(ctx context.Context, d *schem
 func resourceIBMPICloudConnectionNetworkAttachDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	sess, err := meta.(conns.ClientSession).IBMPISession()
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("IBMPISession failed: %s", err.Error()), "ibm_pi_cloud_connection_network_attach", "delete")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	parts, err := flex.IdParts(d.Id())
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("IdParts failed: %s", err.Error()), "ibm_pi_cloud_connection_network_attach", "delete")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	cloudInstanceID := parts[0]
@@ -122,13 +133,16 @@ func resourceIBMPICloudConnectionNetworkAttachDelete(ctx context.Context, d *sch
 
 	_, jobReference, err := client.DeleteNetwork(cloudConnectionID, networkID)
 	if err != nil {
-		log.Printf("[DEBUG] detach network from cloud connection failed %v", err)
-		return diag.FromErr(err)
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("DeleteNetwork failed: %s", err.Error()), "ibm_pi_cloud_connection_network_attach", "delete")
+		log.Printf("[DEBUG] detach network from cloud connection failed \n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 	if jobReference != nil {
 		_, err = waitForIBMPIJobCompleted(ctx, jobClient, *jobReference.ID, d.Timeout(schema.TimeoutDelete))
 		if err != nil {
-			return diag.FromErr(err)
+			tfErr := flex.TerraformErrorf(err, fmt.Sprintf("waitForIBMPIJobCompleted failed: %s", err.Error()), "ibm_pi_cloud_connection_network_attach", "delete")
+			log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+			return tfErr.GetDiag()
 		}
 	}
 

--- a/ibm/service/power/resource_ibm_pi_cloud_connection_test.go
+++ b/ibm/service/power/resource_ibm_pi_cloud_connection_test.go
@@ -58,7 +58,7 @@ func testAccCheckIBMPICloudConnectionDestroy(s *terraform.State) error {
 		client := instance.NewIBMPICloudConnectionClient(context.Background(), sess, cloudInstanceID)
 		_, err = client.Get(cloudConnectionID)
 		if err == nil {
-			return fmt.Errorf("Cloud Connection still exists: %s", rs.Primary.ID)
+			return flex.FmtErrorf("Cloud Connection still exists: %s", rs.Primary.ID)
 		}
 	}
 	return nil
@@ -78,7 +78,7 @@ func testAccCheckIBMPICloudConnectionExists(n string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
 		if !ok {
-			return fmt.Errorf("Not found: %s", n)
+			return flex.FmtErrorf("Not found: %s", n)
 		}
 		if rs.Primary.ID == "" {
 			return errors.New("No Record ID is set")

--- a/ibm/service/power/resource_ibm_pi_dhcp_test.go
+++ b/ibm/service/power/resource_ibm_pi_dhcp_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 
 	acc "github.com/IBM-Cloud/terraform-provider-ibm/ibm/acctest"
+	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/flex"
 
 	"github.com/IBM-Cloud/power-go-client/clients/instance"
 	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/conns"
@@ -54,7 +55,7 @@ func testAccCheckIBMPIDhcpDestroy(s *terraform.State) error {
 		client := instance.NewIBMPIDhcpClient(context.Background(), sess, cloudInstanceID)
 		_, err = client.Get(dhcpID)
 		if err == nil {
-			return fmt.Errorf("PI DHCP still exists: %s", rs.Primary.ID)
+			return flex.FmtErrorf("PI DHCP still exists: %s", rs.Primary.ID)
 		}
 	}
 
@@ -65,7 +66,7 @@ func testAccCheckIBMPIDhcpExists(n string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
 		if !ok {
-			return fmt.Errorf("Not found: %s", n)
+			return flex.FmtErrorf("Not found: %s", n)
 		}
 		if rs.Primary.ID == "" {
 			return errors.New("No Record ID is set")

--- a/ibm/service/power/resource_ibm_pi_host_group.go
+++ b/ibm/service/power/resource_ibm_pi_host_group.go
@@ -154,7 +154,9 @@ func ResourceIBMPIHostGroup() *schema.Resource {
 func resourceIBMPIHostGroupCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	sess, err := meta.(conns.ClientSession).IBMPISession()
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("IBMPISession failed: %s", err.Error()), "ibm_pi_host_group", "create")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 	cloudInstanceID := d.Get(Arg_CloudInstanceID).(string)
 	name := d.Get(Arg_Name).(string)
@@ -181,7 +183,9 @@ func resourceIBMPIHostGroupCreate(ctx context.Context, d *schema.ResourceData, m
 
 	hg, err := client.CreateHostGroup(&body)
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("CreateHostGroup failed: %s", err.Error()), "ibm_pi_host_group", "create")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 	d.SetId(fmt.Sprintf("%s/%s", cloudInstanceID, hg.ID))
 
@@ -191,11 +195,15 @@ func resourceIBMPIHostGroupCreate(ctx context.Context, d *schema.ResourceData, m
 func resourceIBMPIHostGroupRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	sess, err := meta.(conns.ClientSession).IBMPISession()
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("IBMPISession failed: %s", err.Error()), "ibm_pi_host_group", "read")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 	cloudInstanceID, hostGroupID, err := splitID(d.Id())
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("splitID failed: %s", err.Error()), "ibm_pi_host_group", "read")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 	client := instance.NewIBMPIHostGroupsClient(ctx, sess, cloudInstanceID)
 	hostGroup, err := client.GetHostGroup(hostGroupID)
@@ -204,7 +212,9 @@ func resourceIBMPIHostGroupRead(ctx context.Context, d *schema.ResourceData, met
 			d.SetId("")
 			return nil
 		}
-		return diag.FromErr(err)
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("GetHostGroup failed: %s", err.Error()), "ibm_pi_host_group", "read")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 	d.Set(Attr_CreationDate, hostGroup.CreationDate.String())
 	d.Set(Attr_HostGroupID, hostGroup.ID)
@@ -218,11 +228,15 @@ func resourceIBMPIHostGroupRead(ctx context.Context, d *schema.ResourceData, met
 func resourceIBMPIHostGroupUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	sess, err := meta.(conns.ClientSession).IBMPISession()
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("IBMPISession failed: %s", err.Error()), "ibm_pi_host_group", "update")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 	cloudInstanceID, hostGroupID, err := splitID(d.Id())
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("splitID failed: %s", err.Error()), "ibm_pi_host_group", "update")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 	client := instance.NewIBMPIHostGroupsClient(ctx, sess, cloudInstanceID)
 	hostGroupUpdateBody := models.HostGroupShareOp{}
@@ -235,7 +249,10 @@ func resourceIBMPIHostGroupUpdate(ctx context.Context, d *schema.ResourceData, m
 	if d.HasChange(Arg_Secondaries) {
 		oldSecondaries, newSecondaries := d.GetChange(Arg_Secondaries)
 		if len(oldSecondaries.([]interface{})) == len(newSecondaries.([]interface{})) {
-			return diag.FromErr(fmt.Errorf("change in place not supported for: %v", Arg_Secondaries))
+			err = flex.FmtErrorf("change in place not supported for: %v", Arg_Secondaries)
+			tfErr := flex.TerraformErrorf(err, fmt.Sprintf("operation failed: %s", err.Error()), "ibm_pi_host_group", "update")
+			log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+			return tfErr.GetDiag()
 		}
 		var add []*models.Secondary
 		for _, v := range d.Get(Arg_Secondaries).([]interface{}) {
@@ -254,7 +271,9 @@ func resourceIBMPIHostGroupUpdate(ctx context.Context, d *schema.ResourceData, m
 				d.SetId("")
 				return nil
 			}
-			return diag.FromErr(err)
+			tfErr := flex.TerraformErrorf(err, fmt.Sprintf("UpdateHostGroup failed: %s", err.Error()), "ibm_pi_host_group", "update")
+			log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+			return tfErr.GetDiag()
 		}
 	}
 
@@ -264,11 +283,15 @@ func resourceIBMPIHostGroupUpdate(ctx context.Context, d *schema.ResourceData, m
 func resourceIBMPIHostGroupDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	sess, err := meta.(conns.ClientSession).IBMPISession()
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("IBMPISession failed: %s", err.Error()), "ibm_pi_host_group", "delete")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 	cloudInstanceID, hostGroupID, err := splitID(d.Id())
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("splitID failed: %s", err.Error()), "ibm_pi_host_group", "delete")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 	client := instance.NewIBMPIHostGroupsClient(ctx, sess, cloudInstanceID)
 	hostGroup, err := client.GetHostGroup(hostGroupID)
@@ -277,7 +300,9 @@ func resourceIBMPIHostGroupDelete(ctx context.Context, d *schema.ResourceData, m
 			d.SetId("")
 			return nil
 		}
-		return diag.FromErr(err)
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("GetHostGroup failed: %s", err.Error()), "ibm_pi_host_group", "delete")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 	for _, v := range hostGroup.Hosts {
 		ref, err := json.Marshal(v)
@@ -287,20 +312,28 @@ func resourceIBMPIHostGroupDelete(ctx context.Context, d *schema.ResourceData, m
 		hostRef := string(ref)
 		hostID, err := getLastPart(hostRef)
 		if err != nil {
-			return diag.FromErr(err)
+			tfErr := flex.TerraformErrorf(err, fmt.Sprintf("getLastPart failed: %s", err.Error()), "ibm_pi_host_group", "delete")
+			log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+			return tfErr.GetDiag()
 		}
 		err = client.DeleteHost(hostID)
 		if err != nil {
-			return diag.FromErr(err)
+			tfErr := flex.TerraformErrorf(err, fmt.Sprintf("DeleteHost failed: %s", err.Error()), "ibm_pi_host_group", "delete")
+			log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+			return tfErr.GetDiag()
 		}
 		_, err = isWaitForHostDeleted(ctx, client, hostID, d.Timeout(schema.TimeoutDelete))
 		if err != nil {
-			return diag.FromErr(err)
+			tfErr := flex.TerraformErrorf(err, fmt.Sprintf("isWaitForHostDeleted failed: %s", err.Error()), "ibm_pi_host_group", "delete")
+			log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+			return tfErr.GetDiag()
 		}
 	}
 	_, err = isWaitForHostGroupDeleted(ctx, client, hostGroupID, d.Timeout(schema.TimeoutDelete))
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("isWaitForHostGroupDeleted failed: %s", err.Error()), "ibm_pi_host_group", "delete")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 	d.SetId("")
 	return nil
@@ -378,7 +411,7 @@ func secondaryMapToSecondary(modelMap map[string]interface{}) *models.Secondary 
 func getLastPart(id string) (string, error) {
 	parts := strings.Split(id, "/")
 	if len(parts) < 2 {
-		return "", fmt.Errorf("invalid input format")
+		return "", flex.FmtErrorf("invalid input format")
 	}
 	lastPart := parts[len(parts)-1]
 	cleanedLastPart := strings.Trim(lastPart, `"`)

--- a/ibm/service/power/resource_ibm_pi_host_group_test.go
+++ b/ibm/service/power/resource_ibm_pi_host_group_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/IBM-Cloud/power-go-client/clients/instance"
 	acc "github.com/IBM-Cloud/terraform-provider-ibm/ibm/acctest"
 	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/conns"
+	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/flex"
 )
 
 func TestAccIBMPIHostGroupBasic(t *testing.T) {
@@ -56,7 +57,7 @@ func testAccCheckIBMPIHostGroupExists(n string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
 		if !ok {
-			return fmt.Errorf("Not found: %s", n)
+			return flex.FmtErrorf("Not found: %s", n)
 		}
 		if rs.Primary.ID == "" {
 			return errors.New("No Record ID is set")
@@ -95,7 +96,7 @@ func testAccCheckIBMPIHostGroupDestroy(s *terraform.State) error {
 		client := instance.NewIBMPIHostGroupsClient(context.Background(), sess, cloudInstanceID)
 		_, err = client.GetHostGroup(hostGroupID)
 		if err == nil {
-			return fmt.Errorf("PI host group still exists: %s", rs.Primary.ID)
+			return flex.FmtErrorf("PI host group still exists: %s", rs.Primary.ID)
 		}
 	}
 	return nil

--- a/ibm/service/power/resource_ibm_pi_host_test.go
+++ b/ibm/service/power/resource_ibm_pi_host_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/IBM-Cloud/power-go-client/clients/instance"
 	acc "github.com/IBM-Cloud/terraform-provider-ibm/ibm/acctest"
 	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/conns"
+	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/flex"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
@@ -118,7 +119,7 @@ func testAccCheckIBMPIHostDestroy(s *terraform.State) error {
 		client := instance.NewIBMPIHostGroupsClient(context.Background(), sess, cloudInstanceID)
 		_, err = client.GetHost(hostID)
 		if err == nil {
-			return fmt.Errorf("PI dedicated host still exists: %s", rs.Primary.ID)
+			return flex.FmtErrorf("PI dedicated host still exists: %s", rs.Primary.ID)
 		}
 	}
 	return nil
@@ -128,7 +129,7 @@ func testAccCheckIBMPIHostExists(n string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
 		if !ok {
-			return fmt.Errorf("Not found: %s", n)
+			return flex.FmtErrorf("Not found: %s", n)
 		}
 		if rs.Primary.ID == "" {
 			return errors.New("No Record ID is set")

--- a/ibm/service/power/resource_ibm_pi_image_test.go
+++ b/ibm/service/power/resource_ibm_pi_image_test.go
@@ -11,6 +11,7 @@ import (
 
 	acc "github.com/IBM-Cloud/terraform-provider-ibm/ibm/acctest"
 	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/conns"
+	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/flex"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
@@ -53,7 +54,7 @@ func testAccCheckIBMPIImageDestroy(s *terraform.State) error {
 		imageC := st.NewIBMPIImageClient(context.Background(), sess, cloudInstanceID)
 		_, err = imageC.Get(imageID)
 		if err == nil {
-			return fmt.Errorf("PI Image still exists: %s", rs.Primary.ID)
+			return flex.FmtErrorf("PI Image still exists: %s", rs.Primary.ID)
 		}
 	}
 
@@ -65,7 +66,7 @@ func testAccCheckIBMPIImageExists(n string) resource.TestCheckFunc {
 		rs, ok := s.RootModule().Resources[n]
 
 		if !ok {
-			return fmt.Errorf("Not found: %s", n)
+			return flex.FmtErrorf("Not found: %s", n)
 		}
 
 		if rs.Primary.ID == "" {

--- a/ibm/service/power/resource_ibm_pi_instance_console_language.go
+++ b/ibm/service/power/resource_ibm_pi_instance_console_language.go
@@ -12,6 +12,7 @@ import (
 	"github.com/IBM-Cloud/power-go-client/clients/instance"
 	"github.com/IBM-Cloud/power-go-client/power/models"
 	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/conns"
+	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/flex"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
@@ -56,7 +57,9 @@ func ResourceIBMPIInstanceConsoleLanguage() *schema.Resource {
 func resourceIBMPIInstanceConsoleLanguageCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	sess, err := meta.(conns.ClientSession).IBMPISession()
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("IBMPISession failed: %s", err.Error()), "ibm_pi_instance_console_language", "create")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	cloudInstanceID := d.Get(Arg_CloudInstanceID).(string)
@@ -71,8 +74,9 @@ func resourceIBMPIInstanceConsoleLanguageCreate(ctx context.Context, d *schema.R
 
 	_, err = client.UpdateConsoleLanguage(instanceName, consoleLanguage)
 	if err != nil {
-		log.Printf("[DEBUG] err %s", err)
-		return diag.FromErr(err)
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("UpdateConsoleLanguage failed: %s", err.Error()), "ibm_pi_instance_console_language", "create")
+		log.Printf("[DEBUG] err \n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	d.SetId(fmt.Sprintf("%s/%s", cloudInstanceID, instanceName))
@@ -88,7 +92,9 @@ func resourceIBMPIInstanceConsoleLanguageRead(ctx context.Context, d *schema.Res
 func resourceIBMPIInstanceConsoleLanguageUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	sess, err := meta.(conns.ClientSession).IBMPISession()
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("IBMPISession failed: %s", err.Error()), "ibm_pi_instance_console_language", "update")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	if d.HasChange(Arg_LanguageCode) {
@@ -103,8 +109,9 @@ func resourceIBMPIInstanceConsoleLanguageUpdate(ctx context.Context, d *schema.R
 		}
 		_, err = client.UpdateConsoleLanguage(instanceName, consoleLanguage)
 		if err != nil {
-			log.Printf("[DEBUG] err %s", err)
-			return diag.FromErr(err)
+			tfErr := flex.TerraformErrorf(err, fmt.Sprintf("UpdateConsoleLanguage failed: %s", err.Error()), "ibm_pi_instance_console_language", "update")
+			log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+			return tfErr.GetDiag()
 		}
 	}
 	return resourceIBMPIInstanceConsoleLanguageRead(ctx, d, meta)

--- a/ibm/service/power/resource_ibm_pi_instance_snapshot.go
+++ b/ibm/service/power/resource_ibm_pi_instance_snapshot.go
@@ -112,7 +112,9 @@ func ResourceIBMPIInstanceSnapshot() *schema.Resource {
 func resourceIBMPIInstanceSnapshotCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	sess, err := meta.(conns.ClientSession).IBMPISession()
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("IBMPISession failed: %s", err.Error()), "ibm_pi_instance_snapshot", "create")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	cloudInstanceID := d.Get(Arg_CloudInstanceID).(string)
@@ -141,8 +143,9 @@ func resourceIBMPIInstanceSnapshotCreate(ctx context.Context, d *schema.Resource
 
 	snapshotResponse, err := client.CreatePvmSnapShot(instanceid, snapshotBody)
 	if err != nil {
-		log.Printf("[DEBUG]  err %s", err)
-		return diag.FromErr(err)
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("CreatePvmSnapShot failed: %s", err.Error()), "ibm_pi_instance_snapshot", "create")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	d.SetId(fmt.Sprintf("%s/%s", cloudInstanceID, *snapshotResponse.SnapshotID))
@@ -150,7 +153,9 @@ func resourceIBMPIInstanceSnapshotCreate(ctx context.Context, d *schema.Resource
 	piSnapClient := instance.NewIBMPISnapshotClient(ctx, sess, cloudInstanceID)
 	_, err = isWaitForPIInstanceSnapshotAvailable(ctx, piSnapClient, *snapshotResponse.SnapshotID, d.Timeout(schema.TimeoutCreate))
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("isWaitForPIInstanceSnapshotAvailable failed: %s", err.Error()), "ibm_pi_instance_snapshot", "create")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	if _, ok := d.GetOk(Arg_UserTags); ok {
@@ -169,18 +174,24 @@ func resourceIBMPIInstanceSnapshotCreate(ctx context.Context, d *schema.Resource
 func resourceIBMPIInstanceSnapshotRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	sess, err := meta.(conns.ClientSession).IBMPISession()
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("IBMPISession failed: %s", err.Error()), "ibm_pi_instance_snapshot", "read")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	cloudInstanceID, snapshotID, err := splitID(d.Id())
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("splitID failed: %s", err.Error()), "ibm_pi_instance_snapshot", "read")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	snapshot := instance.NewIBMPISnapshotClient(ctx, sess, cloudInstanceID)
 	snapshotdata, err := snapshot.Get(snapshotID)
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("Get failed: %s", err.Error()), "ibm_pi_instance_snapshot", "read")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	d.Set(Arg_SnapshotName, snapshotdata.Name)
@@ -204,12 +215,16 @@ func resourceIBMPIInstanceSnapshotRead(ctx context.Context, d *schema.ResourceDa
 func resourceIBMPIInstanceSnapshotUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	sess, err := meta.(conns.ClientSession).IBMPISession()
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("IBMPISession failed: %s", err.Error()), "ibm_pi_instance_snapshot", "update")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	cloudInstanceID, snapshotID, err := splitID(d.Id())
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("IBMPISession failed: %s", err.Error()), "ibm_pi_instance_snapshot", "update")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	client := instance.NewIBMPISnapshotClient(ctx, sess, cloudInstanceID)
@@ -221,12 +236,16 @@ func resourceIBMPIInstanceSnapshotUpdate(ctx context.Context, d *schema.Resource
 
 		_, err := client.Update(snapshotID, snapshotBody)
 		if err != nil {
-			return diag.FromErr(err)
+			tfErr := flex.TerraformErrorf(err, fmt.Sprintf("Update failed: %s", err.Error()), "ibm_pi_instance_snapshot", "update")
+			log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+			return tfErr.GetDiag()
 		}
 
 		_, err = isWaitForPIInstanceSnapshotAvailable(ctx, client, snapshotID, d.Timeout(schema.TimeoutUpdate))
 		if err != nil {
-			return diag.FromErr(err)
+			tfErr := flex.TerraformErrorf(err, fmt.Sprintf("isWaitForPIInstanceSnapshotAvailable failed: %s", err.Error()), "ibm_pi_instance_snapshot", "update")
+			log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+			return tfErr.GetDiag()
 		}
 	}
 
@@ -246,23 +265,31 @@ func resourceIBMPIInstanceSnapshotUpdate(ctx context.Context, d *schema.Resource
 func resourceIBMPIInstanceSnapshotDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	sess, err := meta.(conns.ClientSession).IBMPISession()
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("IBMPISession failed: %s", err.Error()), "ibm_pi_instance_snapshot", "delete")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	cloudInstanceID, snapshotID, err := splitID(d.Id())
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("splitID failed: %s", err.Error()), "ibm_pi_instance_snapshot", "delete")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	client := instance.NewIBMPISnapshotClient(ctx, sess, cloudInstanceID)
 	err = client.Delete(snapshotID)
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("Delete failed: %s", err.Error()), "ibm_pi_instance_snapshot", "delete")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	_, err = isWaitForPIInstanceSnapshotDeleted(ctx, client, snapshotID, d.Timeout(schema.TimeoutDelete))
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("isWaitForPIInstanceSnapshotDeleted failed: %s", err.Error()), "ibm_pi_instance_snapshot", "delete")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	d.SetId("")

--- a/ibm/service/power/resource_ibm_pi_instance_snapshot_test.go
+++ b/ibm/service/power/resource_ibm_pi_instance_snapshot_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 
 	acc "github.com/IBM-Cloud/terraform-provider-ibm/ibm/acctest"
+	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/flex"
 
 	"github.com/IBM-Cloud/power-go-client/clients/instance"
 	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/conns"
@@ -95,7 +96,7 @@ func testAccCheckIBMPIInstanceSnapshotDestroy(s *terraform.State) error {
 		snapshotC := instance.NewIBMPISnapshotClient(context.Background(), sess, cloudInstanceID)
 		_, err = snapshotC.Get(snapshotID)
 		if err == nil {
-			return fmt.Errorf("PI Instance Snapshot still exists: %s", rs.Primary.ID)
+			return flex.FmtErrorf("PI Instance Snapshot still exists: %s", rs.Primary.ID)
 		}
 	}
 	return nil
@@ -105,7 +106,7 @@ func testAccCheckIBMPIInstanceSnapshotExists(n string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
 		if !ok {
-			return fmt.Errorf("Not found: %s", n)
+			return flex.FmtErrorf("Not found: %s", n)
 		}
 
 		if rs.Primary.ID == "" {

--- a/ibm/service/power/resource_ibm_pi_instance_test.go
+++ b/ibm/service/power/resource_ibm_pi_instance_test.go
@@ -990,7 +990,7 @@ func testAccCheckIBMPIInstanceDestroy(s *terraform.State) error {
 			client := st.NewIBMPIInstanceClient(context.Background(), sess, cloudInstanceID)
 			_, err = client.Get(instanceID)
 			if err == nil {
-				return fmt.Errorf("PI Instance still exists: %s", rs.Primary.ID)
+				return flex.FmtErrorf("PI Instance still exists: %s", rs.Primary.ID)
 			}
 		}
 	}
@@ -1002,7 +1002,7 @@ func testAccCheckIBMPIInstanceExists(n string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
 		if !ok {
-			return fmt.Errorf("Not found: %s", n)
+			return flex.FmtErrorf("Not found: %s", n)
 		}
 		if rs.Primary.ID == "" {
 			return errors.New("No Record ID is set")
@@ -1035,7 +1035,7 @@ func testAccCheckIBMPIInstanceStatus(n, status string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
 		if !ok {
-			return fmt.Errorf("Not found: %s", n)
+			return flex.FmtErrorf("Not found: %s", n)
 		}
 		if rs.Primary.ID == "" {
 			return errors.New("No Record ID is set")

--- a/ibm/service/power/resource_ibm_pi_key.go
+++ b/ibm/service/power/resource_ibm_pi_key.go
@@ -12,6 +12,7 @@ import (
 	"github.com/IBM-Cloud/power-go-client/clients/instance"
 	"github.com/IBM-Cloud/power-go-client/power/models"
 	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/conns"
+	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/flex"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
@@ -75,7 +76,9 @@ func resourceIBMPIKeyCreate(ctx context.Context, d *schema.ResourceData, meta in
 	// session
 	sess, err := meta.(conns.ClientSession).IBMPISession()
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("IBMPISession failed: %s", err.Error()), "ibm_pi_key", "create")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	// arguments
@@ -91,8 +94,9 @@ func resourceIBMPIKeyCreate(ctx context.Context, d *schema.ResourceData, meta in
 	}
 	sshResponse, err := client.Create(body)
 	if err != nil {
-		log.Printf("[DEBUG]  err %s", err)
-		return diag.FromErr(err)
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("Create failed: %s", err.Error()), "ibm_pi_key", "create")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	log.Printf("Printing the sshkey %+v", *sshResponse)
@@ -104,20 +108,26 @@ func resourceIBMPIKeyRead(ctx context.Context, d *schema.ResourceData, meta inte
 	// session
 	sess, err := meta.(conns.ClientSession).IBMPISession()
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("IBMPISession failed: %s", err.Error()), "ibm_pi_key", "read")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	// arguments
 	cloudInstanceID, key, err := splitID(d.Id())
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("splitID failed: %s", err.Error()), "ibm_pi_key", "read")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	// get key
 	sshkeyC := instance.NewIBMPIKeyClient(ctx, sess, cloudInstanceID)
 	sshkeydata, err := sshkeyC.Get(key)
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("Get failed: %s", err.Error()), "ibm_pi_key", "read")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	// set attributes
@@ -136,20 +146,26 @@ func resourceIBMPIKeyDelete(ctx context.Context, d *schema.ResourceData, meta in
 	// session
 	sess, err := meta.(conns.ClientSession).IBMPISession()
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("IBMPISession failed: %s", err.Error()), "ibm_pi_key", "delete")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	// arguments
 	cloudInstanceID, key, err := splitID(d.Id())
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("splitID failed: %s", err.Error()), "ibm_pi_key", "delete")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	// delete key
 	sshkeyC := instance.NewIBMPIKeyClient(ctx, sess, cloudInstanceID)
 	err = sshkeyC.Delete(key)
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("Delete failed: %s", err.Error()), "ibm_pi_key", "delete")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 	d.SetId("")
 	return nil

--- a/ibm/service/power/resource_ibm_pi_key_test.go
+++ b/ibm/service/power/resource_ibm_pi_key_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 
 	acc "github.com/IBM-Cloud/terraform-provider-ibm/ibm/acctest"
+	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/flex"
 
 	"github.com/IBM-Cloud/power-go-client/clients/instance"
 	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/conns"
@@ -57,7 +58,7 @@ func testAccCheckIBMPIKeyDestroy(s *terraform.State) error {
 		sshkeyC := instance.NewIBMPIKeyClient(context.Background(), sess, cloudInstanceID)
 		_, err = sshkeyC.Get(key)
 		if err == nil {
-			return fmt.Errorf("PI key still exists: %s", rs.Primary.ID)
+			return flex.FmtErrorf("PI key still exists: %s", rs.Primary.ID)
 		}
 	}
 	return nil
@@ -69,7 +70,7 @@ func testAccCheckIBMPIKeyExists(n string) resource.TestCheckFunc {
 		rs, ok := s.RootModule().Resources[n]
 
 		if !ok {
-			return fmt.Errorf("Not found: %s", n)
+			return flex.FmtErrorf("Not found: %s", n)
 		}
 
 		if rs.Primary.ID == "" {

--- a/ibm/service/power/resource_ibm_pi_network_address_group.go
+++ b/ibm/service/power/resource_ibm_pi_network_address_group.go
@@ -10,15 +10,14 @@ import (
 	"strings"
 	"time"
 
-	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/customdiff"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-
 	"github.com/IBM-Cloud/power-go-client/clients/instance"
 	"github.com/IBM-Cloud/power-go-client/power/models"
 	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/conns"
 	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/flex"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/customdiff"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 )
 
@@ -99,7 +98,9 @@ func ResourceIBMPINetworkAddressGroup() *schema.Resource {
 func resourceIBMPINetworkAddressGroupCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	sess, err := meta.(conns.ClientSession).IBMPISession()
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("IBMPISession failed: %s", err.Error()), "ibm_pi_network_address_group", "read")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	cloudInstanceID := d.Get(Arg_CloudInstanceID).(string)
@@ -115,7 +116,9 @@ func resourceIBMPINetworkAddressGroupCreate(ctx context.Context, d *schema.Resou
 
 	networkAddressGroup, err := nagC.Create(body)
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("Create failed: %s", err.Error()), "ibm_pi_network_address_group", "create")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 	if _, ok := d.GetOk(Arg_UserTags); ok {
 		if networkAddressGroup.Crn != nil {
@@ -134,12 +137,16 @@ func resourceIBMPINetworkAddressGroupCreate(ctx context.Context, d *schema.Resou
 func resourceIBMPINetworkAddressGroupRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	sess, err := meta.(conns.ClientSession).IBMPISession()
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("IBMPISession failed: %s", err.Error()), "ibm_pi_network_address_group", "read")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	cloudInstanceID, nagID, err := splitID(d.Id())
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("splitID failed: %s", err.Error()), "ibm_pi_network_address_group", "read")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 	nagC := instance.NewIBMPINetworkAddressGroupClient(ctx, sess, cloudInstanceID)
 	networkAddressGroup, err := nagC.Get(nagID)
@@ -148,7 +155,9 @@ func resourceIBMPINetworkAddressGroupRead(ctx context.Context, d *schema.Resourc
 			d.SetId("")
 			return nil
 		}
-		return diag.FromErr(err)
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("Get failed: %s", err.Error()), "ibm_pi_network_address_group", "read")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 	d.Set(Arg_Name, networkAddressGroup.Name)
 	if networkAddressGroup.Crn != nil {
@@ -178,12 +187,16 @@ func resourceIBMPINetworkAddressGroupRead(ctx context.Context, d *schema.Resourc
 func resourceIBMPINetworkAddressGroupUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	sess, err := meta.(conns.ClientSession).IBMPISession()
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("IBMPISession failed: %s", err.Error()), "ibm_pi_network_address_group", "read")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	parts, err := flex.IdParts(d.Id())
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("IdParts failed: %s", err.Error()), "ibm_pi_network_address_group", "read")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 	hasChange := false
 	body := &models.NetworkAddressGroupUpdate{}
@@ -204,7 +217,9 @@ func resourceIBMPINetworkAddressGroupUpdate(ctx context.Context, d *schema.Resou
 	if hasChange {
 		_, err := nagC.Update(parts[1], body)
 		if err != nil {
-			return diag.FromErr(err)
+			tfErr := flex.TerraformErrorf(err, fmt.Sprintf("Update failed: %s", err.Error()), "ibm_pi_network_address_group", "read")
+			log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+			return tfErr.GetDiag()
 		}
 	}
 
@@ -214,21 +229,28 @@ func resourceIBMPINetworkAddressGroupUpdate(ctx context.Context, d *schema.Resou
 func resourceIBMPINetworkAddressGroupDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	sess, err := meta.(conns.ClientSession).IBMPISession()
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("IBMPISession failed: %s", err.Error()), "ibm_pi_network_address_group", "read")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
-
 	parts, err := flex.IdParts(d.Id())
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("IdParts failed: %s", err.Error()), "ibm_pi_network_address_group", "read")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 	nagC := instance.NewIBMPINetworkAddressGroupClient(ctx, sess, parts[0])
 	err = nagC.Delete(parts[1])
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("Delete failed: %s", err.Error()), "ibm_pi_network_address_group", "read")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 	_, err = isWaitForIBMPINetworkAddressGroupDeleted(ctx, nagC, parts[1], d.Timeout(schema.TimeoutDelete))
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("isWaitForIBMPINetworkAddressGroupDeleted failed: %s", err.Error()), "ibm_pi_network_address_group", "read")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 	d.SetId("")
 
@@ -244,9 +266,9 @@ func isWaitForIBMPINetworkAddressGroupDeleted(ctx context.Context, client *insta
 		MinTimeout: 30 * time.Second,
 		Timeout:    timeout,
 	}
-
 	return stateConf.WaitForStateContext(ctx)
 }
+
 func isIBMPINetworkAddressGroupDeleteRefreshFunc(client *instance.IBMPINetworkAddressGroupClient, nagID string) retry.StateRefreshFunc {
 	return func() (interface{}, string, error) {
 		nag, err := client.Get(nagID)

--- a/ibm/service/power/resource_ibm_pi_network_address_group_member_test.go
+++ b/ibm/service/power/resource_ibm_pi_network_address_group_member_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/IBM-Cloud/power-go-client/clients/instance"
 	acc "github.com/IBM-Cloud/terraform-provider-ibm/ibm/acctest"
 	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/conns"
+	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/flex"
 	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/power"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
@@ -53,7 +54,7 @@ func testAccCheckIBMPINetworkAddressGroupMemberExists(n string) resource.TestChe
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
 		if !ok {
-			return fmt.Errorf("Not found: %s", n)
+			return flex.FmtErrorf("Not found: %s", n)
 		}
 
 		if rs.Primary.ID == "" {

--- a/ibm/service/power/resource_ibm_pi_network_address_group_test.go
+++ b/ibm/service/power/resource_ibm_pi_network_address_group_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/IBM-Cloud/power-go-client/clients/instance"
 	acc "github.com/IBM-Cloud/terraform-provider-ibm/ibm/acctest"
 	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/conns"
+	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/flex"
 	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/power"
 )
 
@@ -64,7 +65,7 @@ func testAccCheckIBMPINetworkAddressGroupExists(n string) resource.TestCheckFunc
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
 		if !ok {
-			return fmt.Errorf("Not found: %s", n)
+			return flex.FmtErrorf("Not found: %s", n)
 		}
 
 		if rs.Primary.ID == "" {
@@ -110,7 +111,7 @@ func testAccCheckIBMPINetworkAddressGroupDestroy(s *terraform.State) error {
 				return nil
 			}
 		}
-		return fmt.Errorf("network addess group still exists: %s", rs.Primary.ID)
+		return flex.FmtErrorf("network addess group still exists: %s", rs.Primary.ID)
 	}
 	return nil
 }

--- a/ibm/service/power/resource_ibm_pi_network_interface_test.go
+++ b/ibm/service/power/resource_ibm_pi_network_interface_test.go
@@ -96,7 +96,7 @@ func testAccCheckIBMPINetworkInterfaceExists(n string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
 		if !ok {
-			return fmt.Errorf("Not found: %s", n)
+			return flex.FmtErrorf("Not found: %s", n)
 		}
 		if rs.Primary.ID == "" {
 			return errors.New("No Record ID is set")
@@ -136,7 +136,7 @@ func testAccCheckIBMPINetworkInterfaceDestroy(s *terraform.State) error {
 		networkClient := instance.NewIBMPINetworkClient(context.Background(), sess, parts[0])
 		_, err = networkClient.GetNetworkInterface(parts[1], parts[2])
 		if err == nil {
-			return fmt.Errorf("pi_network_interface still exists: %s", rs.Primary.ID)
+			return flex.FmtErrorf("pi_network_interface still exists: %s", rs.Primary.ID)
 		}
 	}
 	return nil

--- a/ibm/service/power/resource_ibm_pi_network_port_attach_test.go
+++ b/ibm/service/power/resource_ibm_pi_network_port_attach_test.go
@@ -89,7 +89,7 @@ func testAccCheckIBMPINetworkPortAttachDestroy(s *terraform.State) error {
 		networkC := instance.NewIBMPINetworkClient(context.Background(), sess, cloudInstanceID)
 		_, err = networkC.GetPort(networkname, portID)
 		if err == nil {
-			return fmt.Errorf("PI Network Port still exists: %s", rs.Primary.ID)
+			return flex.FmtErrorf("PI Network Port still exists: %s", rs.Primary.ID)
 		}
 	}
 
@@ -102,7 +102,7 @@ func testAccCheckIBMPINetworkPortAttachExists(n string) resource.TestCheckFunc {
 		rs, ok := s.RootModule().Resources[n]
 
 		if !ok {
-			return fmt.Errorf("Not found: %s", n)
+			return flex.FmtErrorf("Not found: %s", n)
 		}
 
 		if rs.Primary.ID == "" {

--- a/ibm/service/power/resource_ibm_pi_network_security_group_member_test.go
+++ b/ibm/service/power/resource_ibm_pi_network_security_group_member_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/IBM-Cloud/power-go-client/clients/instance"
 	acc "github.com/IBM-Cloud/terraform-provider-ibm/ibm/acctest"
 	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/conns"
+	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/flex"
 	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/power"
 )
 
@@ -69,7 +70,7 @@ func testAccCheckIBMPINetworkSecurityGroupMemberExists(n string) resource.TestCh
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
 		if !ok {
-			return fmt.Errorf("Not found: %s", n)
+			return flex.FmtErrorf("Not found: %s", n)
 		}
 
 		if rs.Primary.ID == "" {

--- a/ibm/service/power/resource_ibm_pi_network_security_group_rule_test.go
+++ b/ibm/service/power/resource_ibm_pi_network_security_group_rule_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/IBM-Cloud/power-go-client/clients/instance"
 	acc "github.com/IBM-Cloud/terraform-provider-ibm/ibm/acctest"
 	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/conns"
+	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/flex"
 	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/power"
 )
 
@@ -172,7 +173,7 @@ func testAccCheckIBMPINetworkSecurityGroupRuleExists(n string) resource.TestChec
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
 		if !ok {
-			return fmt.Errorf("Not found: %s", n)
+			return flex.FmtErrorf("Not found: %s", n)
 		}
 
 		if rs.Primary.ID == "" {
@@ -199,7 +200,7 @@ func testAccCheckIBMPINetworkSecurityGroupRuleRemoved(n string, ruleID string) r
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
 		if !ok {
-			return fmt.Errorf("Not found: %s", n)
+			return flex.FmtErrorf("Not found: %s", n)
 		}
 
 		if rs.Primary.ID == "" {
@@ -228,7 +229,7 @@ func testAccCheckIBMPINetworkSecurityGroupRuleRemoved(n string, ruleID string) r
 			}
 		}
 		if foundRule {
-			return fmt.Errorf("NSG rule still exists")
+			return flex.FmtErrorf("NSG rule still exists")
 		}
 		return nil
 	}

--- a/ibm/service/power/resource_ibm_pi_network_security_group_test.go
+++ b/ibm/service/power/resource_ibm_pi_network_security_group_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/IBM-Cloud/power-go-client/clients/instance"
 	acc "github.com/IBM-Cloud/terraform-provider-ibm/ibm/acctest"
 	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/conns"
+	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/flex"
 	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/power"
 )
 
@@ -59,7 +60,7 @@ func testAccCheckIBMPINetworkSecurityGroupExists(n string) resource.TestCheckFun
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
 		if !ok {
-			return fmt.Errorf("Not found: %s", n)
+			return flex.FmtErrorf("Not found: %s", n)
 		}
 		if rs.Primary.ID == "" {
 			return errors.New("No Record ID is set")
@@ -98,7 +99,7 @@ func testAccCheckIBMPINetworkSecurityGroupDestroy(s *terraform.State) error {
 		nsgClient := instance.NewIBMIPINetworkSecurityGroupClient(context.Background(), sess, cloudInstanceID)
 		_, err = nsgClient.Get(nsgID)
 		if err == nil {
-			return fmt.Errorf("network_security_group still exists: %s", rs.Primary.ID)
+			return flex.FmtErrorf("network_security_group still exists: %s", rs.Primary.ID)
 		}
 	}
 

--- a/ibm/service/power/resource_ibm_pi_network_test.go
+++ b/ibm/service/power/resource_ibm_pi_network_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 
 	acc "github.com/IBM-Cloud/terraform-provider-ibm/ibm/acctest"
+	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/flex"
 
 	"github.com/IBM-Cloud/power-go-client/clients/instance"
 	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/conns"
@@ -224,7 +225,7 @@ func testAccCheckIBMPINetworkDestroy(s *terraform.State) error {
 		networkC := instance.NewIBMPINetworkClient(context.Background(), sess, cloudInstanceID)
 		_, err = networkC.Get(networkID)
 		if err == nil {
-			return fmt.Errorf("PI Network still exists: %s", rs.Primary.ID)
+			return flex.FmtErrorf("PI Network still exists: %s", rs.Primary.ID)
 		}
 	}
 
@@ -237,7 +238,7 @@ func testAccCheckIBMPINetworkExists(n string) resource.TestCheckFunc {
 		rs, ok := s.RootModule().Resources[n]
 
 		if !ok {
-			return fmt.Errorf("Not found: %s", n)
+			return flex.FmtErrorf("Not found: %s", n)
 		}
 
 		if rs.Primary.ID == "" {

--- a/ibm/service/power/resource_ibm_pi_placement_group.go
+++ b/ibm/service/power/resource_ibm_pi_placement_group.go
@@ -73,7 +73,9 @@ func ResourceIBMPIPlacementGroup() *schema.Resource {
 func resourceIBMPIPlacementGroupCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	sess, err := meta.(conns.ClientSession).IBMPISession()
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("IBMPISession failed: %s", err.Error()), "ibm_pi_placement_group", "create")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	cloudInstanceID := d.Get(Arg_CloudInstanceID).(string)
@@ -86,8 +88,16 @@ func resourceIBMPIPlacementGroupCreate(ctx context.Context, d *schema.ResourceDa
 	}
 
 	response, err := client.Create(body)
-	if err != nil || response == nil {
-		return diag.FromErr(fmt.Errorf("error creating the shared processor pool: %s", err))
+	if err != nil {
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("Create failed: %s", err.Error()), "ibm_pi_placement_group", "create")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
+	}
+	if response == nil {
+		err = flex.FmtErrorf("response returned empty")
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("operation failed: %s", err.Error()), "ibm_pi_placement_group", "create")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	log.Printf("Printing the placement group %+v", &response)
@@ -99,11 +109,15 @@ func resourceIBMPIPlacementGroupCreate(ctx context.Context, d *schema.ResourceDa
 func resourceIBMPIPlacementGroupRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	sess, err := meta.(conns.ClientSession).IBMPISession()
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("IBMPISession failed: %s", err.Error()), "ibm_pi_placement_group", "read")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 	parts, err := flex.IdParts(d.Id())
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("IdParts failed: %s", err.Error()), "ibm_pi_placement_group", "read")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	cloudInstanceID := parts[0]
@@ -111,8 +125,9 @@ func resourceIBMPIPlacementGroupRead(ctx context.Context, d *schema.ResourceData
 
 	response, err := client.Get(parts[1])
 	if err != nil {
-		log.Printf("[DEBUG]  err %s", err)
-		return diag.FromErr(err)
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("Get failed: %s", err.Error()), "ibm_pi_placement_group", "read")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	d.Set(Arg_PlacementGroupName, response.Name)
@@ -130,18 +145,23 @@ func resourceIBMPIPlacementGroupUpdate(ctx context.Context, d *schema.ResourceDa
 func resourceIBMPIPlacementGroupDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	sess, err := meta.(conns.ClientSession).IBMPISession()
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("IBMPISession failed: %s", err.Error()), "ibm_pi_placement_group", "delete")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 	parts, err := flex.IdParts(d.Id())
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("IdParts failed: %s", err.Error()), "ibm_pi_placement_group", "delete")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 	cloudInstanceID := parts[0]
 	client := instance.NewIBMPIPlacementGroupClient(ctx, sess, cloudInstanceID)
 	err = client.Delete(parts[1])
-
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("Delete failed: %s", err.Error()), "ibm_pi_placement_group", "delete")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 	d.SetId("")
 	return nil

--- a/ibm/service/power/resource_ibm_pi_placement_group_test.go
+++ b/ibm/service/power/resource_ibm_pi_placement_group_test.go
@@ -102,7 +102,7 @@ func testAccCheckIBMPIPlacementGroupDestroy(s *terraform.State) error {
 		placementGroupC := instance.NewIBMPIPlacementGroupClient(context.Background(), sess, cloudinstanceid)
 		_, err = placementGroupC.Get(parts[1])
 		if err == nil {
-			return fmt.Errorf("PI placement group still exists: %s", rs.Primary.ID)
+			return flex.FmtErrorf("PI placement group still exists: %s", rs.Primary.ID)
 		}
 	}
 	return nil
@@ -113,7 +113,7 @@ func testAccCheckIBMPIPlacementGroupExists(n string) resource.TestCheckFunc {
 		rs, ok := s.RootModule().Resources[n]
 
 		if !ok {
-			return fmt.Errorf("Not found: %s", n)
+			return flex.FmtErrorf("Not found: %s", n)
 		}
 
 		if rs.Primary.ID == "" {
@@ -145,7 +145,7 @@ func testAccCheckIBMPIPlacementGroupMemberExists(n string, inst string) resource
 		rs, ok := s.RootModule().Resources[n]
 
 		if !ok {
-			return fmt.Errorf("Not found: %s", n)
+			return flex.FmtErrorf("Not found: %s", n)
 		}
 
 		if rs.Primary.ID == "" {
@@ -171,7 +171,7 @@ func testAccCheckIBMPIPlacementGroupMemberExists(n string, inst string) resource
 
 		instancers, ok := s.RootModule().Resources[inst]
 		if !ok {
-			return fmt.Errorf("Not found: %s", inst)
+			return flex.FmtErrorf("Not found: %s", inst)
 		}
 		instanceParts, err := flex.IdParts(instancers.Primary.ID)
 		if err != nil {
@@ -185,7 +185,7 @@ func testAccCheckIBMPIPlacementGroupMemberExists(n string, inst string) resource
 			}
 		}
 		if !isInstanceFound {
-			return fmt.Errorf("Expected server ID %s in the PG members field but found %s", instanceParts[1], strings.Join(pg.Members[:], ","))
+			return flex.FmtErrorf("Expected server ID %s in the PG members field but found %s", instanceParts[1], strings.Join(pg.Members[:], ","))
 		}
 		return nil
 	}
@@ -197,7 +197,7 @@ func testAccCheckIBMPIPlacementGroupMemberDoesNotExist(n string, inst string) re
 		rs, ok := s.RootModule().Resources[n]
 
 		if !ok {
-			return fmt.Errorf("Not found: %s", n)
+			return flex.FmtErrorf("Not found: %s", n)
 		}
 
 		if rs.Primary.ID == "" {
@@ -223,14 +223,14 @@ func testAccCheckIBMPIPlacementGroupMemberDoesNotExist(n string, inst string) re
 
 		instancers, ok := s.RootModule().Resources[inst]
 		if !ok {
-			return fmt.Errorf("Not found: %s", inst)
+			return flex.FmtErrorf("Not found: %s", inst)
 		}
 		instanccParts, err := flex.IdParts(instancers.Primary.ID)
 		if err != nil {
 			return err
 		}
 		if len(pg.Members) > 0 {
-			return fmt.Errorf("Expected server ID %s to be removed so that the PG members field is empty but foumd %s", instanccParts[1], pg.Members[0])
+			return flex.FmtErrorf("Expected server ID %s to be removed so that the PG members field is empty but foumd %s", instanccParts[1], pg.Members[0])
 		}
 
 		return nil
@@ -252,7 +252,7 @@ func testAccCheckIBMPIPlacementGroupMemberExistsFromInstanceCreate(n string, ins
 		rs, ok := s.RootModule().Resources[n]
 
 		if !ok {
-			return fmt.Errorf("Not found: %s", n)
+			return flex.FmtErrorf("Not found: %s", n)
 		}
 
 		if rs.Primary.ID == "" {
@@ -278,7 +278,7 @@ func testAccCheckIBMPIPlacementGroupMemberExistsFromInstanceCreate(n string, ins
 
 		instancers, ok := s.RootModule().Resources[inst]
 		if !ok {
-			return fmt.Errorf("Not found: %s", inst)
+			return flex.FmtErrorf("Not found: %s", inst)
 		}
 		instanceParts, err := flex.IdParts(instancers.Primary.ID)
 		if err != nil {
@@ -287,7 +287,7 @@ func testAccCheckIBMPIPlacementGroupMemberExistsFromInstanceCreate(n string, ins
 
 		newinstancers, ok := s.RootModule().Resources[newInstance]
 		if !ok {
-			return fmt.Errorf("Not found: %s", newInstance)
+			return flex.FmtErrorf("Not found: %s", newInstance)
 		}
 		newinstanceParts, err := flex.IdParts(newinstancers.Primary.ID)
 		if err != nil {
@@ -295,10 +295,10 @@ func testAccCheckIBMPIPlacementGroupMemberExistsFromInstanceCreate(n string, ins
 		}
 
 		if !containsMember(pg.Members, instanceParts[1]) {
-			return fmt.Errorf("Expected server ID %s in the PG members field", instanceParts[1])
+			return flex.FmtErrorf("Expected server ID %s in the PG members field", instanceParts[1])
 		}
 		if !containsMember(pg.Members, newinstanceParts[1]) {
-			return fmt.Errorf("Expected new server ID %s in the PG members field", newinstanceParts[1])
+			return flex.FmtErrorf("Expected new server ID %s in the PG members field", newinstanceParts[1])
 		}
 		return nil
 	}
@@ -313,7 +313,7 @@ func testAccCheckIBMPIPlacementGroupDelete(n string, inst string, newInstance st
 
 		instancers, ok := s.RootModule().Resources[inst]
 		if !ok {
-			return fmt.Errorf("Not found: %s", inst)
+			return flex.FmtErrorf("Not found: %s", inst)
 		}
 		instanceParts, err := flex.IdParts(instancers.Primary.ID)
 		if err != nil {
@@ -322,7 +322,7 @@ func testAccCheckIBMPIPlacementGroupDelete(n string, inst string, newInstance st
 
 		newinstancers, ok := s.RootModule().Resources[newInstance]
 		if !ok {
-			return fmt.Errorf("Not found: %s", newInstance)
+			return flex.FmtErrorf("Not found: %s", newInstance)
 		}
 		newinstanceParts, err := flex.IdParts(newinstancers.Primary.ID)
 		if err != nil {
@@ -337,14 +337,14 @@ func testAccCheckIBMPIPlacementGroupDelete(n string, inst string, newInstance st
 		}
 
 		if *instance.PlacementGroup != "none" {
-			return fmt.Errorf("Expected no placement group ID in the PVM instance data but found %s", *instance.PlacementGroup)
+			return flex.FmtErrorf("Expected no placement group ID in the PVM instance data but found %s", *instance.PlacementGroup)
 		}
 		newinstance, err := inst_client.Get(newinstanceParts[1])
 		if err != nil {
 			return err
 		}
 		if *newinstance.PlacementGroup != "none" {
-			return fmt.Errorf("Expected no placement group ID in the PVM instance data but found %s", *newinstance.PlacementGroup)
+			return flex.FmtErrorf("Expected no placement group ID in the PVM instance data but found %s", *newinstance.PlacementGroup)
 		}
 		return nil
 	}

--- a/ibm/service/power/resource_ibm_pi_shared_processor_pool_test.go
+++ b/ibm/service/power/resource_ibm_pi_shared_processor_pool_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 
 	acc "github.com/IBM-Cloud/terraform-provider-ibm/ibm/acctest"
+	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/flex"
 
 	"github.com/IBM-Cloud/power-go-client/clients/instance"
 	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/conns"
@@ -89,7 +90,7 @@ func testAccCheckIBMPISPPDestroy(s *terraform.State) error {
 		sppC := instance.NewIBMPISharedProcessorPoolClient(context.Background(), sess, cloudInstanceID)
 		spp, err := sppC.Get(sppID)
 		if err == nil {
-			return fmt.Errorf("PI SPP still exists: %s", *spp.SharedProcessorPool.ID)
+			return flex.FmtErrorf("PI SPP still exists: %s", *spp.SharedProcessorPool.ID)
 		}
 	}
 
@@ -101,7 +102,7 @@ func testAccCheckIBMPISPPExists(n string) resource.TestCheckFunc {
 		rs, ok := s.RootModule().Resources[n]
 
 		if !ok {
-			return fmt.Errorf("Not found: %s", n)
+			return flex.FmtErrorf("Not found: %s", n)
 		}
 
 		if rs.Primary.ID == "" {

--- a/ibm/service/power/resource_ibm_pi_snapshot.go
+++ b/ibm/service/power/resource_ibm_pi_snapshot.go
@@ -120,7 +120,9 @@ func ResourceIBMPISnapshot() *schema.Resource {
 func resourceIBMPISnapshotCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	sess, err := meta.(conns.ClientSession).IBMPISession()
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("IBMPISession failed: %s", err.Error()), "ibm_pi_snapshot", "create")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	cloudInstanceID := d.Get(Arg_CloudInstanceID).(string)
@@ -149,8 +151,9 @@ func resourceIBMPISnapshotCreate(ctx context.Context, d *schema.ResourceData, me
 
 	snapshotResponse, err := client.CreatePvmSnapShot(instanceid, snapshotBody)
 	if err != nil {
-		log.Printf("[DEBUG]  err %s", err)
-		return diag.FromErr(err)
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("CreatePvmSnapShot failed: %s", err.Error()), "ibm_pi_snapshot", "create")
+		log.Printf("[DEBUG]  err \n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	d.SetId(fmt.Sprintf("%s/%s", cloudInstanceID, *snapshotResponse.SnapshotID))
@@ -158,7 +161,9 @@ func resourceIBMPISnapshotCreate(ctx context.Context, d *schema.ResourceData, me
 	piSnapClient := instance.NewIBMPISnapshotClient(ctx, sess, cloudInstanceID)
 	_, err = isWaitForPIInstanceSnapshotAvailable(ctx, piSnapClient, *snapshotResponse.SnapshotID, d.Timeout(schema.TimeoutCreate))
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("isWaitForPIInstanceSnapshotAvailable failed: %s", err.Error()), "ibm_pi_snapshot", "create")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	if _, ok := d.GetOk(Arg_UserTags); ok {
@@ -178,18 +183,24 @@ func resourceIBMPISnapshotRead(ctx context.Context, d *schema.ResourceData, meta
 	log.Printf("Calling the Snapshot Read function post create")
 	sess, err := meta.(conns.ClientSession).IBMPISession()
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("IBMPISession failed: %s", err.Error()), "ibm_pi_snapshot", "read")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	cloudInstanceID, snapshotID, err := splitID(d.Id())
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("splitID failed: %s", err.Error()), "ibm_pi_snapshot", "read")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	snapshot := instance.NewIBMPISnapshotClient(ctx, sess, cloudInstanceID)
 	snapshotdata, err := snapshot.Get(snapshotID)
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("Get failed: %s", err.Error()), "ibm_pi_snapshot", "read")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	d.Set(Arg_SnapShotName, snapshotdata.Name)
@@ -214,12 +225,16 @@ func resourceIBMPISnapshotUpdate(ctx context.Context, d *schema.ResourceData, me
 	log.Printf("Calling the IBM Power Snapshot update call")
 	sess, err := meta.(conns.ClientSession).IBMPISession()
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("IBMPISession failed: %s", err.Error()), "ibm_pi_snapshot", "update")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	cloudInstanceID, snapshotID, err := splitID(d.Id())
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("splitID failed: %s", err.Error()), "ibm_pi_snapshot", "update")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	client := instance.NewIBMPISnapshotClient(ctx, sess, cloudInstanceID)
@@ -231,12 +246,16 @@ func resourceIBMPISnapshotUpdate(ctx context.Context, d *schema.ResourceData, me
 
 		_, err := client.Update(snapshotID, snapshotBody)
 		if err != nil {
-			return diag.FromErr(err)
+			tfErr := flex.TerraformErrorf(err, fmt.Sprintf("Update failed: %s", err.Error()), "ibm_pi_snapshot", "update")
+			log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+			return tfErr.GetDiag()
 		}
 
 		_, err = isWaitForPIInstanceSnapshotAvailable(ctx, client, snapshotID, d.Timeout(schema.TimeoutUpdate))
 		if err != nil {
-			return diag.FromErr(err)
+			tfErr := flex.TerraformErrorf(err, fmt.Sprintf("isWaitForPIInstanceSnapshotAvailable failed: %s", err.Error()), "ibm_pi_snapshot", "update")
+			log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+			return tfErr.GetDiag()
 		}
 	}
 
@@ -256,12 +275,16 @@ func resourceIBMPISnapshotUpdate(ctx context.Context, d *schema.ResourceData, me
 func resourceIBMPISnapshotDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	sess, err := meta.(conns.ClientSession).IBMPISession()
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("IBMPISession failed: %s", err.Error()), "ibm_pi_snapshot", "delete")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	cloudInstanceID, snapshotID, err := splitID(d.Id())
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("splitID failed: %s", err.Error()), "ibm_pi_snapshot", "delete")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	client := instance.NewIBMPISnapshotClient(ctx, sess, cloudInstanceID)
@@ -276,12 +299,16 @@ func resourceIBMPISnapshotDelete(ctx context.Context, d *schema.ResourceData, me
 
 	err = client.Delete(snapshotID)
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("Delete failed: %s", err.Error()), "ibm_pi_snapshot", "delete")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	_, err = isWaitForPIInstanceSnapshotDeleted(ctx, client, snapshotID, d.Timeout(schema.TimeoutDelete))
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("isWaitForPIInstanceSnapshotDeleted failed: %s", err.Error()), "ibm_pi_snapshot", "delete")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	d.SetId("")

--- a/ibm/service/power/resource_ibm_pi_snapshot_test.go
+++ b/ibm/service/power/resource_ibm_pi_snapshot_test.go
@@ -9,10 +9,11 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/IBM-Cloud/power-go-client/clients/instance"
 	acc "github.com/IBM-Cloud/terraform-provider-ibm/ibm/acctest"
-	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/conns"
 
+	"github.com/IBM-Cloud/power-go-client/clients/instance"
+	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/conns"
+	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/flex"
 	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/power"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
@@ -95,7 +96,7 @@ func testAccCheckIBMPIInstanceSnapshotDestroyV0(s *terraform.State) error {
 		snapshotC := instance.NewIBMPISnapshotClient(context.Background(), sess, cloudInstanceID)
 		_, err = snapshotC.Get(snapshotID)
 		if err == nil {
-			return fmt.Errorf("PI Instance Snapshot still exists: %s", rs.Primary.ID)
+			return flex.FmtErrorf("PI Instance Snapshot still exists: %s", rs.Primary.ID)
 		}
 	}
 	return nil
@@ -105,7 +106,7 @@ func testAccCheckIBMPIInstanceSnapshotExistsV0(n string) resource.TestCheckFunc 
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
 		if !ok {
-			return fmt.Errorf("Not found: %s", n)
+			return flex.FmtErrorf("Not found: %s", n)
 		}
 
 		if rs.Primary.ID == "" {

--- a/ibm/service/power/resource_ibm_pi_spp_placement_group.go
+++ b/ibm/service/power/resource_ibm_pi_spp_placement_group.go
@@ -6,16 +6,16 @@ package power
 import (
 	"context"
 	"fmt"
+	"log"
 	"time"
 
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-
 	"github.com/IBM-Cloud/power-go-client/clients/instance"
-	models "github.com/IBM-Cloud/power-go-client/power/models"
+	"github.com/IBM-Cloud/power-go-client/power/models"
 	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/conns"
 	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/flex"
 	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/validate"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
 func ResourceIBMPISPPPlacementGroup() *schema.Resource {
@@ -38,14 +38,12 @@ func ResourceIBMPISPPPlacementGroup() *schema.Resource {
 				Required:    true,
 				Type:        schema.TypeString,
 			},
-
 			Arg_SPPPlacementGroupName: {
 				Description: "Name of the SPP placement group",
 				ForceNew:    true,
 				Required:    true,
 				Type:        schema.TypeString,
 			},
-
 			Arg_SPPPlacementGroupPolicy: {
 				Description:  "Policy of the SPP placement group",
 				ForceNew:     true,
@@ -60,7 +58,6 @@ func ResourceIBMPISPPPlacementGroup() *schema.Resource {
 				Description: "SPP placement group ID",
 				Type:        schema.TypeString,
 			},
-
 			Attr_SPPPlacementGroupMembers: {
 				Computed:    true,
 				Description: "Member SPP IDs that are the SPP placement group members",
@@ -74,7 +71,9 @@ func ResourceIBMPISPPPlacementGroup() *schema.Resource {
 func resourceIBMPISPPPlacementGroupCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	sess, err := meta.(conns.ClientSession).IBMPISession()
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("IBMPISession failed: %s", err.Error()), "ibm_pi_spp_placement_group", "create")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	cloudInstanceID := d.Get(Arg_CloudInstanceID).(string)
@@ -87,8 +86,16 @@ func resourceIBMPISPPPlacementGroupCreate(ctx context.Context, d *schema.Resourc
 	}
 
 	response, err := client.Create(body)
-	if err != nil || response == nil {
-		return diag.Errorf("error creating the spp placement group: %v", err)
+	if err != nil {
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("Create failed: %s", err.Error()), "ibm_pi_spp_placement_group", "create")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
+	}
+	if response == nil {
+		err = flex.FmtErrorf("response returned empty")
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("operation failed: %s", err.Error()), "ibm_pi_spp_placement_group", "create")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	d.SetId(fmt.Sprintf("%s/%s", cloudInstanceID, *response.ID))
@@ -96,49 +103,64 @@ func resourceIBMPISPPPlacementGroupCreate(ctx context.Context, d *schema.Resourc
 }
 
 func resourceIBMPISPPPlacementGroupRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-
 	sess, err := meta.(conns.ClientSession).IBMPISession()
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("IBMPISession failed: %s", err.Error()), "ibm_pi_spp_placement_group", "read")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 	parts, err := flex.IdParts(d.Id())
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("IdParts failed: %s", err.Error()), "ibm_pi_spp_placement_group", "read")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	cloudInstanceID := parts[0]
 	client := instance.NewIBMPISPPPlacementGroupClient(ctx, sess, cloudInstanceID)
 
 	response, err := client.Get(parts[1])
-	if err != nil || response == nil {
-		return diag.Errorf("error reading the spp placement group: %v", err)
+	if err != nil {
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("Get failed: %s", err.Error()), "ibm_pi_spp_placement_group", "read")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
+	}
+	if response == nil {
+		err = flex.FmtErrorf("response returned empty")
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("operation failed: %s", err.Error()), "ibm_pi_spp_placement_group", "read")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	d.Set(Arg_CloudInstanceID, cloudInstanceID)
-	d.Set(Attr_SPPPlacementGroupID, response.ID)
-	d.Set(Attr_SPPPlacementGroupMembers, response.MemberSharedProcessorPools)
 	d.Set(Arg_SPPPlacementGroupName, response.Name)
 	d.Set(Arg_SPPPlacementGroupPolicy, response.Policy)
+	d.Set(Attr_SPPPlacementGroupID, response.ID)
+	d.Set(Attr_SPPPlacementGroupMembers, response.MemberSharedProcessorPools)
 
 	return nil
-
 }
 
 func resourceIBMPISPPPlacementGroupDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	sess, err := meta.(conns.ClientSession).IBMPISession()
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("IBMPISession failed: %s", err.Error()), "ibm_pi_spp_placement_group", "delete")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 	parts, err := flex.IdParts(d.Id())
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("IdParts failed: %s", err.Error()), "ibm_pi_spp_placement_group", "delete")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 	cloudInstanceID := parts[0]
 	client := instance.NewIBMPISPPPlacementGroupClient(ctx, sess, cloudInstanceID)
 	err = client.Delete(parts[1])
-
 	if err != nil {
-		return diag.Errorf("error deleting the spp placement group: %v", err)
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("Delete failed: %s", err.Error()), "ibm_pi_spp_placement_group", "delete")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 	d.SetId("")
 	return nil

--- a/ibm/service/power/resource_ibm_pi_spp_placement_group_test.go
+++ b/ibm/service/power/resource_ibm_pi_spp_placement_group_test.go
@@ -108,7 +108,7 @@ func testAccCheckIBMPISPPPlacementGroupDestroy(s *terraform.State) error {
 		placementGroupC := st.NewIBMPISPPPlacementGroupClient(context.Background(), sess, cloudpoolid)
 		_, err = placementGroupC.Get(parts[1])
 		if err == nil {
-			return fmt.Errorf("PI SPP placement group still exists: %s", rs.Primary.ID)
+			return flex.FmtErrorf("PI SPP placement group still exists: %s", rs.Primary.ID)
 		}
 	}
 
@@ -120,7 +120,7 @@ func testAccCheckIBMPISPPPlacementGroupExists(n string) resource.TestCheckFunc {
 		rs, ok := s.RootModule().Resources[n]
 
 		if !ok {
-			return fmt.Errorf("Not found: %s", n)
+			return flex.FmtErrorf("Not found: %s", n)
 		}
 
 		if rs.Primary.ID == "" {
@@ -153,7 +153,7 @@ func testAccCheckIBMPISPPPlacementGroupMemberExists(sppPG string, pool string) r
 		pgResource, ok := s.RootModule().Resources[sppPG]
 
 		if !ok {
-			return fmt.Errorf("Not found: %s", sppPG)
+			return flex.FmtErrorf("Not found: %s", sppPG)
 		}
 
 		if pgResource.Primary.ID == "" {
@@ -179,7 +179,7 @@ func testAccCheckIBMPISPPPlacementGroupMemberExists(sppPG string, pool string) r
 
 		poolResource, ok := s.RootModule().Resources[pool]
 		if !ok {
-			return fmt.Errorf("Not found: %s", pool)
+			return flex.FmtErrorf("Not found: %s", pool)
 		}
 		poolName := poolResource.Primary.Attributes["pi_shared_processor_pool_name"]
 
@@ -191,7 +191,7 @@ func testAccCheckIBMPISPPPlacementGroupMemberExists(sppPG string, pool string) r
 			}
 		}
 		if !isPoolFound {
-			return fmt.Errorf("Expected pool ID %s in the PG members field but found %s", poolName, strings.Join(pg.MemberSharedProcessorPools[:], ","))
+			return flex.FmtErrorf("Expected pool ID %s in the PG members field but found %s", poolName, strings.Join(pg.MemberSharedProcessorPools[:], ","))
 		}
 		return nil
 	}
@@ -203,7 +203,7 @@ func testAccCheckIBMPISPPPlacementGroupMemberDoesNotExist(n string, pool string)
 		rs, ok := s.RootModule().Resources[n]
 
 		if !ok {
-			return fmt.Errorf("Not found: %s", n)
+			return flex.FmtErrorf("Not found: %s", n)
 		}
 
 		if rs.Primary.ID == "" {
@@ -229,14 +229,14 @@ func testAccCheckIBMPISPPPlacementGroupMemberDoesNotExist(n string, pool string)
 
 		poolrs, ok := s.RootModule().Resources[pool]
 		if !ok {
-			return fmt.Errorf("Not found: %s", pool)
+			return flex.FmtErrorf("Not found: %s", pool)
 		}
 		instanccParts, err := flex.IdParts(poolrs.Primary.ID)
 		if err != nil {
 			return err
 		}
 		if len(pg.MemberSharedProcessorPools) > 0 {
-			return fmt.Errorf("Expected pool ID %s to be removed so that the PG members field is empty but foumd %s", instanccParts[1], pg.MemberSharedProcessorPools[0])
+			return flex.FmtErrorf("Expected pool ID %s to be removed so that the PG members field is empty but foumd %s", instanccParts[1], pg.MemberSharedProcessorPools[0])
 		}
 
 		return nil
@@ -259,7 +259,7 @@ func testAccCheckIBMPISPPPlacementGroupMemberExistsFromSPPCreate(n string, pool 
 		rs, ok := s.RootModule().Resources[n]
 
 		if !ok {
-			return fmt.Errorf("Not found: %s", n)
+			return flex.FmtErrorf("Not found: %s", n)
 		}
 
 		if rs.Primary.ID == "" {
@@ -285,12 +285,12 @@ func testAccCheckIBMPISPPPlacementGroupMemberExistsFromSPPCreate(n string, pool 
 
 		poolrs, ok := s.RootModule().Resources[pool]
 		if !ok {
-			return fmt.Errorf("Not found: %s", pool)
+			return flex.FmtErrorf("Not found: %s", pool)
 		}
 		poolName := poolrs.Primary.Attributes["pi_shared_processor_pool_name"]
 
 		if !containsMemberPool(pg.MemberSharedProcessorPools, poolName) {
-			return fmt.Errorf("Expected pool %s in the PG members field", poolName)
+			return flex.FmtErrorf("Expected pool %s in the PG members field", poolName)
 		}
 		return nil
 	}
@@ -305,7 +305,7 @@ func testAccCheckIBMPISPPPlacementGroupDelete(n string, pool string, newPool str
 
 		poolrs, ok := s.RootModule().Resources[pool]
 		if !ok {
-			return fmt.Errorf("Not found: %s", pool)
+			return flex.FmtErrorf("Not found: %s", pool)
 		}
 		poolParts, err := flex.IdParts(poolrs.Primary.ID)
 		if err != nil {
@@ -314,7 +314,7 @@ func testAccCheckIBMPISPPPlacementGroupDelete(n string, pool string, newPool str
 
 		newpoolrs, ok := s.RootModule().Resources[newPool]
 		if !ok {
-			return fmt.Errorf("Not found: %s", newPool)
+			return flex.FmtErrorf("Not found: %s", newPool)
 		}
 		newpoolParts, err := flex.IdParts(newpoolrs.Primary.ID)
 		if err != nil {
@@ -329,14 +329,14 @@ func testAccCheckIBMPISPPPlacementGroupDelete(n string, pool string, newPool str
 		}
 
 		if len(pool.SharedProcessorPool.SharedProcessorPoolPlacementGroups) > 0 {
-			return fmt.Errorf("Expected no spp placement group ID in the spp placement groups array but found %s", *pool.SharedProcessorPool.SharedProcessorPoolPlacementGroups[0].ID)
+			return flex.FmtErrorf("Expected no spp placement group ID in the spp placement groups array but found %s", *pool.SharedProcessorPool.SharedProcessorPoolPlacementGroups[0].ID)
 		}
 		newpool, err := spp_client.Get(newpoolParts[1])
 		if err != nil {
 			return err
 		}
 		if len(newpool.SharedProcessorPool.SharedProcessorPoolPlacementGroups) > 0 {
-			return fmt.Errorf("Expected no spp placement group ID in the spp placement groups array but found %s", *newpool.SharedProcessorPool.SharedProcessorPoolPlacementGroups[0].ID)
+			return flex.FmtErrorf("Expected no spp placement group ID in the spp placement groups array but found %s", *newpool.SharedProcessorPool.SharedProcessorPoolPlacementGroups[0].ID)
 		}
 		return nil
 	}
@@ -348,7 +348,7 @@ func testAccCheckIBMPIInstanceInSPP(spp string, instance string) resource.TestCh
 		sppResource, ok := s.RootModule().Resources[spp]
 
 		if !ok {
-			return fmt.Errorf("Not found: %s", spp)
+			return flex.FmtErrorf("Not found: %s", spp)
 		}
 
 		if sppResource.Primary.ID == "" {
@@ -374,7 +374,7 @@ func testAccCheckIBMPIInstanceInSPP(spp string, instance string) resource.TestCh
 
 		instanceResource, ok := s.RootModule().Resources[instance]
 		if !ok {
-			return fmt.Errorf("Instance not found: %s", instance)
+			return flex.FmtErrorf("Instance not found: %s", instance)
 		}
 		instanceName := instanceResource.Primary.Attributes["pi_instance_name"]
 
@@ -386,7 +386,7 @@ func testAccCheckIBMPIInstanceInSPP(spp string, instance string) resource.TestCh
 			}
 		}
 		if !isInstanceFoundInSPPServersList {
-			return fmt.Errorf("Expected instance name %s in the SPP servers object but found %v", instanceName, sppFromSB.Servers)
+			return flex.FmtErrorf("Expected instance name %s in the SPP servers object but found %v", instanceName, sppFromSB.Servers)
 		}
 		return nil
 	}

--- a/ibm/service/power/resource_ibm_pi_virtual_serial_number_test.go
+++ b/ibm/service/power/resource_ibm_pi_virtual_serial_number_test.go
@@ -62,7 +62,7 @@ func testAccCheckIBMPIVirtualSerialNumberExists(n string) resource.TestCheckFunc
 		rs, ok := s.RootModule().Resources[n]
 
 		if !ok {
-			return fmt.Errorf("Not found: %s", n)
+			return flex.FmtErrorf("Not found: %s", n)
 		}
 
 		if rs.Primary.ID == "" {
@@ -103,7 +103,7 @@ func testAccCheckIBMPIVirtualSerialNumberDestroy(s *terraform.State) error {
 		vsnClient := st.NewIBMPIVSNClient(context.Background(), sess, cloudInstanceId)
 		_, err = vsnClient.Get(parts[1])
 		if err == nil {
-			return fmt.Errorf("PI virtual serial number still exists: %s", rs.Primary.ID)
+			return flex.FmtErrorf("PI virtual serial number still exists: %s", rs.Primary.ID)
 		}
 	}
 

--- a/ibm/service/power/resource_ibm_pi_volume_attach_test.go
+++ b/ibm/service/power/resource_ibm_pi_volume_attach_test.go
@@ -77,7 +77,7 @@ func testAccCheckIBMPIVolumeAttachDestroy(s *terraform.State) error {
 		volumeAttach, err := client.CheckVolumeAttach(pvmInstanceID, volumeID)
 		if err == nil {
 			log.Println("volume attach*****", volumeAttach.State)
-			return fmt.Errorf("PI Volume Attach still exists: %s", rs.Primary.ID)
+			return flex.FmtErrorf("PI Volume Attach still exists: %s", rs.Primary.ID)
 		}
 	}
 
@@ -89,7 +89,7 @@ func testAccCheckIBMPIVolumeAttachExists(n string) resource.TestCheckFunc {
 		rs, ok := s.RootModule().Resources[n]
 
 		if !ok {
-			return fmt.Errorf("Not found: %s", n)
+			return flex.FmtErrorf("Not found: %s", n)
 		}
 
 		if rs.Primary.ID == "" {

--- a/ibm/service/power/resource_ibm_pi_volume_clone_test.go
+++ b/ibm/service/power/resource_ibm_pi_volume_clone_test.go
@@ -46,7 +46,7 @@ func testAccCheckIBMPIVolumeCloneExists(n string) resource.TestCheckFunc {
 		rs, ok := s.RootModule().Resources[n]
 
 		if !ok {
-			return fmt.Errorf("Not found: %s", n)
+			return flex.FmtErrorf("Not found: %s", n)
 		}
 
 		if rs.Primary.ID == "" {

--- a/ibm/service/power/resource_ibm_pi_volume_group.go
+++ b/ibm/service/power/resource_ibm_pi_volume_group.go
@@ -121,7 +121,9 @@ func ResourceIBMPIVolumeGroup() *schema.Resource {
 func resourceIBMPIVolumeGroupCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	sess, err := meta.(conns.ClientSession).IBMPISession()
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("IBMPISession failed: %s", err.Error()), "ibm_pi_volume_group", "create")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	vgName := d.Get(Arg_VolumeGroupName).(string)
@@ -140,14 +142,18 @@ func resourceIBMPIVolumeGroupCreate(ctx context.Context, d *schema.ResourceData,
 	client := instance.NewIBMPIVolumeGroupClient(ctx, sess, cloudInstanceID)
 	vg, err := client.CreateVolumeGroup(body)
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("CreateVolumeGroup failed: %s", err.Error()), "ibm_pi_volume_group", "create")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	d.SetId(fmt.Sprintf("%s/%s", cloudInstanceID, *vg.ID))
 
 	_, err = isWaitForIBMPIVolumeGroupAvailable(ctx, client, *vg.ID, d.Timeout(schema.TimeoutCreate))
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("isWaitForIBMPIVolumeGroupAvailable failed: %s", err.Error()), "ibm_pi_volume_group", "create")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	return resourceIBMPIVolumeGroupRead(ctx, d, meta)
@@ -156,19 +162,25 @@ func resourceIBMPIVolumeGroupCreate(ctx context.Context, d *schema.ResourceData,
 func resourceIBMPIVolumeGroupRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	sess, err := meta.(conns.ClientSession).IBMPISession()
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("IBMPISession failed: %s", err.Error()), "ibm_pi_volume_group", "read")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	cloudInstanceID, vgID, err := splitID(d.Id())
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("splitID failed: %s", err.Error()), "ibm_pi_volume_group", "read")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	client := instance.NewIBMPIVolumeGroupClient(ctx, sess, cloudInstanceID)
 
 	vg, err := client.GetDetails(vgID)
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("GetDetails failed: %s", err.Error()), "ibm_pi_volume_group", "read")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	d.Set(Arg_VolumeGroupName, vg.Name)
@@ -186,15 +198,18 @@ func resourceIBMPIVolumeGroupRead(ctx context.Context, d *schema.ResourceData, m
 }
 
 func resourceIBMPIVolumeGroupUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-
 	sess, err := meta.(conns.ClientSession).IBMPISession()
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("IBMPISession failed: %s", err.Error()), "ibm_pi_volume_group", "update")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	cloudInstanceID, vgID, err := splitID(d.Id())
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("splitID failed: %s", err.Error()), "ibm_pi_volume_group", "update")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	client := instance.NewIBMPIVolumeGroupClient(ctx, sess, cloudInstanceID)
@@ -208,25 +223,34 @@ func resourceIBMPIVolumeGroupUpdate(ctx context.Context, d *schema.ResourceData,
 		}
 		err := client.UpdateVolumeGroup(vgID, body)
 		if err != nil {
-			return diag.FromErr(err)
+			tfErr := flex.TerraformErrorf(err, fmt.Sprintf("UpdateVolumeGroup failed: %s", err.Error()), "ibm_pi_volume_group", "update")
+			log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+			return tfErr.GetDiag()
 		}
 		_, err = isWaitForIBMPIVolumeGroupAvailable(ctx, client, vgID, d.Timeout(schema.TimeoutUpdate))
 		if err != nil {
-			return diag.FromErr(err)
+			tfErr := flex.TerraformErrorf(err, fmt.Sprintf("isWaitForIBMPIVolumeGroupAvailable failed: %s", err.Error()), "ibm_pi_volume_group", "update")
+			log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+			return tfErr.GetDiag()
 		}
 	}
 
 	return resourceIBMPIVolumeGroupRead(ctx, d, meta)
 }
+
 func resourceIBMPIVolumeGroupDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	sess, err := meta.(conns.ClientSession).IBMPISession()
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("IBMPISession failed: %s", err.Error()), "ibm_pi_volume_group", "delete")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	cloudInstanceID, vgID, err := splitID(d.Id())
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("splitID failed: %s", err.Error()), "ibm_pi_volume_group", "delete")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	client := instance.NewIBMPIVolumeGroupClient(ctx, sess, cloudInstanceID)
@@ -238,29 +262,37 @@ func resourceIBMPIVolumeGroupDelete(ctx context.Context, d *schema.ResourceData,
 		}
 		err = client.UpdateVolumeGroup(vgID, body)
 		if err != nil {
-			return diag.FromErr(err)
+			tfErr := flex.TerraformErrorf(err, fmt.Sprintf("UpdateVolumeGroup failed: %s", err.Error()), "ibm_pi_volume_group", "delete")
+			log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+			return tfErr.GetDiag()
 		}
 		_, err = isWaitForIBMPIVolumeGroupAvailable(ctx, client, vgID, d.Timeout(schema.TimeoutUpdate))
 		if err != nil {
-			return diag.FromErr(err)
+			tfErr := flex.TerraformErrorf(err, fmt.Sprintf("isWaitForIBMPIVolumeGroupAvailable failed: %s", err.Error()), "ibm_pi_volume_group", "delete")
+			log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+			return tfErr.GetDiag()
 		}
 	}
 
 	err = client.DeleteVolumeGroup(vgID)
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("DeleteVolumeGroup failed: %s", err.Error()), "ibm_pi_volume_group", "delete")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 	_, err = isWaitForIBMPIVolumeGroupDeleted(ctx, client, vgID, d.Timeout(schema.TimeoutDelete))
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("isWaitForIBMPIVolumeGroupDeleted failed: %s", err.Error()), "ibm_pi_volume_group", "delete")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	d.SetId("")
 	return nil
 }
+
 func isWaitForIBMPIVolumeGroupAvailable(ctx context.Context, client *instance.IBMPIVolumeGroupClient, id string, timeout time.Duration) (interface{}, error) {
 	log.Printf("Waiting for Volume Group (%s) to be available.", id)
-
 	stateConf := &retry.StateChangeConf{
 		Pending:    []string{State_Retry, State_Creating},
 		Target:     []string{State_Available},
@@ -269,7 +301,6 @@ func isWaitForIBMPIVolumeGroupAvailable(ctx context.Context, client *instance.IB
 		MinTimeout: 2 * time.Minute,
 		Timeout:    timeout,
 	}
-
 	return stateConf.WaitForStateContext(ctx)
 }
 
@@ -279,11 +310,9 @@ func isIBMPIVolumeGroupRefreshFunc(client *instance.IBMPIVolumeGroupClient, id s
 		if err != nil {
 			return nil, "", err
 		}
-
 		if vg.Status == State_Available {
 			return vg, State_Available, nil
 		}
-
 		return vg, State_Creating, nil
 	}
 }

--- a/ibm/service/power/resource_ibm_pi_volume_group_action_test.go
+++ b/ibm/service/power/resource_ibm_pi_volume_group_action_test.go
@@ -51,7 +51,7 @@ func testAccCheckIBMPIVolumeGroupActionExists(n string) resource.TestCheckFunc {
 		rs, ok := s.RootModule().Resources[n]
 
 		if !ok {
-			return fmt.Errorf("Not found: %s", n)
+			return flex.FmtErrorf("Not found: %s", n)
 		}
 
 		if rs.Primary.ID == "" {

--- a/ibm/service/power/resource_ibm_pi_volume_group_test.go
+++ b/ibm/service/power/resource_ibm_pi_volume_group_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 
 	acc "github.com/IBM-Cloud/terraform-provider-ibm/ibm/acctest"
+	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/flex"
 
 	"github.com/IBM-Cloud/power-go-client/clients/instance"
 	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/conns"
@@ -71,7 +72,7 @@ func testAccCheckIBMPIVolumeGroupDestroy(s *terraform.State) error {
 		vg, err := vgC.Get(vgID)
 		if err == nil {
 			log.Println("volume-group*****", vg.Status)
-			return fmt.Errorf("PI Volume Group still exists: %s", rs.Primary.ID)
+			return flex.FmtErrorf("PI Volume Group still exists: %s", rs.Primary.ID)
 		}
 	}
 
@@ -83,7 +84,7 @@ func testAccCheckIBMPIVolumeGroupExists(n string) resource.TestCheckFunc {
 		rs, ok := s.RootModule().Resources[n]
 
 		if !ok {
-			return fmt.Errorf("Not found: %s", n)
+			return flex.FmtErrorf("Not found: %s", n)
 		}
 
 		if rs.Primary.ID == "" {

--- a/ibm/service/power/resource_ibm_pi_volume_onboarding_test.go
+++ b/ibm/service/power/resource_ibm_pi_volume_onboarding_test.go
@@ -43,7 +43,7 @@ func testAccCheckIBMPIVolumeOnboardingExists(n string) resource.TestCheckFunc {
 		rs, ok := s.RootModule().Resources[n]
 
 		if !ok {
-			return fmt.Errorf("Not found: %s", n)
+			return flex.FmtErrorf("Not found: %s", n)
 		}
 
 		if rs.Primary.ID == "" {

--- a/ibm/service/power/resource_ibm_pi_volume_test.go
+++ b/ibm/service/power/resource_ibm_pi_volume_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 
 	acc "github.com/IBM-Cloud/terraform-provider-ibm/ibm/acctest"
+	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/flex"
 
 	"github.com/IBM-Cloud/power-go-client/clients/instance"
 	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/conns"
@@ -64,7 +65,7 @@ func testAccCheckIBMPIVolumeDestroy(s *terraform.State) error {
 		volume, err := volumeC.Get(volumeID)
 		if err == nil {
 			log.Println("volume*****", volume.State)
-			return fmt.Errorf("PI Volume still exists: %s", rs.Primary.ID)
+			return flex.FmtErrorf("PI Volume still exists: %s", rs.Primary.ID)
 		}
 	}
 
@@ -76,7 +77,7 @@ func testAccCheckIBMPIVolumeExists(n string) resource.TestCheckFunc {
 		rs, ok := s.RootModule().Resources[n]
 
 		if !ok {
-			return fmt.Errorf("Not found: %s", n)
+			return flex.FmtErrorf("Not found: %s", n)
 		}
 
 		if rs.Primary.ID == "" {

--- a/ibm/service/power/resource_ibm_pi_workspace_test.go
+++ b/ibm/service/power/resource_ibm_pi_workspace_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	acc "github.com/IBM-Cloud/terraform-provider-ibm/ibm/acctest"
+	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/flex"
 
 	"github.com/IBM-Cloud/power-go-client/clients/instance"
 	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/conns"
@@ -89,11 +90,11 @@ func testAccIBMPIWorkspaceDestroy(s *terraform.State) error {
 		workspace, resp, err := client.GetRC(cloudInstanceID)
 		if err == nil {
 			if *workspace.State == power.State_Active {
-				return fmt.Errorf("Resource Instance still exists: %s", rs.Primary.ID)
+				return flex.FmtErrorf("Resource Instance still exists: %s", rs.Primary.ID)
 			}
 		} else {
 			if !strings.Contains(err.Error(), "404") {
-				return fmt.Errorf("[ERROR] Error checking if Resource Instance (%s) has been destroyed: %s with resp code: %s", rs.Primary.ID, err, resp)
+				return flex.FmtErrorf("[ERROR] Error checking if Resource Instance (%s) has been destroyed: %s with resp code: %s", rs.Primary.ID, err, resp)
 			}
 		}
 	}
@@ -105,7 +106,7 @@ func testAccCheckIBMPIWorkspaceExists(n string) resource.TestCheckFunc {
 		rs, ok := s.RootModule().Resources[n]
 
 		if !ok {
-			return fmt.Errorf("Not found: %s", n)
+			return flex.FmtErrorf("Not found: %s", n)
 		}
 
 		if rs.Primary.ID == "" {


### PR DESCRIPTION
Have some questions on the new tool chain:

1. What is the benefit of the new toolchain? I'm not opposed to the new framework, I just don't understand the advantage. The issue for us at least was never, "oh we can't find where the error is." It was, "oh we misunderstood how something in terraform worked."
2. For some functions we check if the error is nil or the object returned empty. I'm assuming we have to split that in the two cases for the new toolchain cause otherwise there's no error object. I think there were a few other conditions for us where have to create the error object due to the migration.

from:
```
body := &models.SPPPlacementGroupCreate{
		Name:   &name,
		Policy: &policy,
	}

	response, err := client.Create(body)
	if err != nil || response == nil {
		return diag.Errorf("error creating the spp placement group: %v", err)
	} 
```
to:
```
body := &models.SPPPlacementGroupCreate{
		Name:   &name,
		Policy: &policy,
	}

	response, err := client.Create(body)
	if err != nil {
		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("Create failed: %s", err.Error()), "ibm_pi_spp_placement_group", "create")
		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
		return tfErr.GetDiag()
	}
	if response == nil {
		err = flex.FmtErrorf("response returned empty")
		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("operation failed: %s", err.Error()), "ibm_pi_spp_placement_group", "create")
		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
		return tfErr.GetDiag()
	}
```
?
3. Do we always replace fmt.Errorf with flex.FmtErrorF? Most of the instances of fmt.Errorf are in the terraform integration tests. Does it matter in that case?
from:
```
parts, _ := flex.IdParts(rs.Primary.ID)
		cloudpoolid := parts[0]
		placementGroupC := st.NewIBMPISPPPlacementGroupClient(context.Background(), sess, cloudpoolid)
		_, err = placementGroupC.Get(parts[1])
		if err == nil {
			return fmt.Errorf("PI SPP placement group still exists: %s", rs.Primary.ID)
		}
	}
```
to:
```
parts, _ := flex.IdParts(rs.Primary.ID)
		cloudpoolid := parts[0]
		placementGroupC := st.NewIBMPISPPPlacementGroupClient(context.Background(), sess, cloudpoolid)
		_, err = placementGroupC.Get(parts[1])
		if err == nil {
			return flex.FmtErrorF("PI SPP placement group still exists: %s", rs.Primary.ID)
		}
	}
```
4. We have some deprecated data source and resources in our provider, and there are some we know will be deprecated soon. Is it okay to skip these over?

@hkantare If you have some time please review these question.