### PR TITLE
fix(atracker) do not return region if it is not defined for resource

### DIFF
--- a/ibm/service/atracker/data_source_ibm_atracker_targets.go
+++ b/ibm/service/atracker/data_source_ibm_atracker_targets.go
@@ -215,10 +215,6 @@ func dataSourceIBMAtrackerTargetsRead(context context.Context, d *schema.Resourc
 
 	listTargetsOptions := &atrackerv2.ListTargetsOptions{}
 
-	if _, ok := d.GetOk("region"); ok {
-		listTargetsOptions.SetRegion(d.Get("region").(string))
-	}
-
 	targetList, _, err := atrackerClient.ListTargetsWithContext(context, listTargetsOptions)
 	if err != nil {
 		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("ListTargetsWithContext failed: %s", err.Error()), "(Data) ibm_atracker_targets", "read")

--- a/ibm/service/atracker/resource_ibm_atracker_target.go
+++ b/ibm/service/atracker/resource_ibm_atracker_target.go
@@ -370,8 +370,8 @@ func resourceIBMAtrackerTargetRead(context context.Context, d *schema.ResourceDa
 		}
 	}
 
-	if !core.IsNil(target.Region) {
-		if len(*target.Region) > 0 {
+	if _, exists := d.GetOk("region"); exists {
+		if !core.IsNil(target.Region) && len(*target.Region) > 0 {
 			if err = d.Set("region", *target.Region); err != nil {
 				err = fmt.Errorf("Error setting region: %s", err)
 				return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_atracker_target", "read", "set-region").GetDiag()
@@ -423,7 +423,7 @@ func resourceIBMAtrackerTargetUpdate(context context.Context, d *schema.Resource
 
 	hasChange := false
 
-	if d.HasChange("name") || d.HasChange("cos_endpoint") || d.HasChange("eventstreams_endpoint") || d.HasChange("cloudlogs_endpoint") {
+	if d.HasChange("name") || d.HasChange("cos_endpoint") || d.HasChange("region") || d.HasChange("eventstreams_endpoint") || d.HasChange("cloudlogs_endpoint") {
 		if _, ok := d.GetOk("name"); ok {
 			replaceTargetOptions.SetName(d.Get("name").(string))
 		}

--- a/ibm/service/atracker/resource_ibm_atracker_target_test.go
+++ b/ibm/service/atracker/resource_ibm_atracker_target_test.go
@@ -80,9 +80,10 @@ func TestAccIBMAtrackerTargetAllArgs(t *testing.T) {
 				),
 			},
 			resource.TestStep{
-				ResourceName:      "ibm_atracker_target.atracker_target_instance",
-				ImportState:       true,
-				ImportStateVerify: true,
+				ResourceName:            "ibm_atracker_target.atracker_target_instance",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"region"},
 			},
 		},
 	})
@@ -93,7 +94,6 @@ func testAccCheckIBMAtrackerTargetConfigBasic(name string, targetType string) st
 		resource "ibm_atracker_target" "atracker_target_instance" {
 			name = "%s"
 			target_type = "%s"
-			region = "us-south"
 			cos_endpoint {
 					endpoint = "s3.private.us-east.cloud-object-storage.appdomain.cloud"
 					target_crn = "crn:v1:bluemix:public:cloud-object-storage:global:a/11111111111111111111111111111111:22222222-2222-2222-2222-222222222222::"
@@ -107,7 +107,6 @@ func testAccCheckIBMAtrackerTargetConfigBasic(name string, targetType string) st
 
 func testAccCheckIBMAtrackerTargetConfig(name string, targetType string, region string) string {
 	return fmt.Sprintf(`
-
 		resource "ibm_atracker_target" "atracker_target_instance" {
 			name = "%s"
 			target_type = "%s"


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/IBM-Cloud/terraform-provider-ibm/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
### Test 1:
```
$ make testacc TEST=./ibm/service/atracker TESTARGS='-run=TestAccIBMAtracker*'
=== RUN   TestAccIBMAtrackerRoutesDataSourceBasic
--- PASS: TestAccIBMAtrackerRoutesDataSourceBasic (16.00s)
=== RUN   TestAccIBMAtrackerTargetsDataSourceBasic
--- PASS: TestAccIBMAtrackerTargetsDataSourceBasic (12.91s)
=== RUN   TestAccIBMAtrackerTargetsDataSourceAllArgs
--- PASS: TestAccIBMAtrackerTargetsDataSourceAllArgs (13.19s)
=== RUN   TestAccIBMAtrackerRouteBasic
--- PASS: TestAccIBMAtrackerRouteBasic (24.16s)
=== RUN   TestAccIBMAtrackerRouteBasicMultipleRules
--- PASS: TestAccIBMAtrackerRouteBasicMultipleRules (24.18s)
=== RUN   TestAccIBMAtrackerSettingsBasic
--- PASS: TestAccIBMAtrackerSettingsBasic (12.96s)
=== RUN   TestAccIBMAtrackerSettingsAllArgs
--- PASS: TestAccIBMAtrackerSettingsAllArgs (14.15s)
=== RUN   TestAccIBMAtrackerTargetBasic
--- PASS: TestAccIBMAtrackerTargetBasic (20.94s)
=== RUN   TestAccIBMAtrackerTargetAllArgs
--- PASS: TestAccIBMAtrackerTargetAllArgs (23.56s)
PASS
ok      github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/atracker        163.643s
```

### Test 2:
```
$ TF_ACC=1 go test ./ibm/service/atracker -timeout 700m -v
=== RUN   TestAccIBMAtrackerRoutesDataSourceBasic
--- PASS: TestAccIBMAtrackerRoutesDataSourceBasic (13.88s)
=== RUN   TestDataSourceIBMAtrackerRoutesRouteToMap
--- PASS: TestDataSourceIBMAtrackerRoutesRouteToMap (0.00s)
=== RUN   TestDataSourceIBMAtrackerRoutesRuleToMap
--- PASS: TestDataSourceIBMAtrackerRoutesRuleToMap (0.00s)
=== RUN   TestAccIBMAtrackerTargetsDataSourceBasic
--- PASS: TestAccIBMAtrackerTargetsDataSourceBasic (12.30s)
=== RUN   TestAccIBMAtrackerTargetsDataSourceAllArgs
--- PASS: TestAccIBMAtrackerTargetsDataSourceAllArgs (12.67s)
=== RUN   TestAccIBMAtrackerRouteBasic
--- PASS: TestAccIBMAtrackerRouteBasic (23.55s)
=== RUN   TestAccIBMAtrackerRouteBasicMultipleRules
--- PASS: TestAccIBMAtrackerRouteBasicMultipleRules (25.02s)
=== RUN   TestResourceIBMAtrackerRouteRuleToMap
--- PASS: TestResourceIBMAtrackerRouteRuleToMap (0.00s)
=== RUN   TestResourceIBMAtrackerRouteMapToRulePrototype
--- PASS: TestResourceIBMAtrackerRouteMapToRulePrototype (0.00s)
=== RUN   TestAccIBMAtrackerSettingsBasic
--- PASS: TestAccIBMAtrackerSettingsBasic (11.96s)
=== RUN   TestAccIBMAtrackerSettingsAllArgs
--- PASS: TestAccIBMAtrackerSettingsAllArgs (15.24s)
=== RUN   TestAccIBMAtrackerTargetBasic
--- PASS: TestAccIBMAtrackerTargetBasic (20.55s)
=== RUN   TestAccIBMAtrackerTargetAllArgs
--- PASS: TestAccIBMAtrackerTargetAllArgs (22.41s)
=== RUN   TestResourceIBMAtrackerTargetCosEndpointToMap
--- PASS: TestResourceIBMAtrackerTargetCosEndpointToMap (0.00s)
=== RUN   TestResourceIBMAtrackerTargetEventstreamsEndpointToMap
--- PASS: TestResourceIBMAtrackerTargetEventstreamsEndpointToMap (0.00s)
=== RUN   TestResourceIBMAtrackerTargetCloudLogsEndpointToMap
--- PASS: TestResourceIBMAtrackerTargetCloudLogsEndpointToMap (0.00s)
=== RUN   TestResourceIBMAtrackerTargetWriteStatusToMap
--- PASS: TestResourceIBMAtrackerTargetWriteStatusToMap (0.00s)
=== RUN   TestResourceIBMAtrackerTargetMapToCosEndpointPrototype
--- PASS: TestResourceIBMAtrackerTargetMapToCosEndpointPrototype (0.00s)
=== RUN   TestResourceIBMAtrackerTargetMapToEventstreamsEndpointPrototype
--- PASS: TestResourceIBMAtrackerTargetMapToEventstreamsEndpointPrototype (0.00s)
=== RUN   TestResourceIBMAtrackerTargetMapToCloudLogsEndpointPrototype
--- PASS: TestResourceIBMAtrackerTargetMapToCloudLogsEndpointPrototype (0.00s)
PASS
ok      github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/atracker        159.069s
```