### PR TITLE
fix(tekton): fix trigger booleans when set to false

### DIFF
--- a/ibm/service/cdtektonpipeline/resource_ibm_cd_tekton_pipeline_trigger.go
+++ b/ibm/service/cdtektonpipeline/resource_ibm_cd_tekton_pipeline_trigger.go
@@ -984,7 +984,7 @@ func ResourceIBMCdTektonPipelineTriggerTriggerPatchAsPatch(patchVals *cdtektonpi
 		delete(patch, "max_concurrent_runs")
 	}
 	path = "enabled"
-	if _, exists := d.GetOk(path); d.HasChange(path) && !exists {
+	if _, exists := d.GetOkExists(path); d.HasChange(path) && !exists {
 		patch["enabled"] = nil
 	} else if !exists {
 		delete(patch, "enabled")
@@ -1028,7 +1028,7 @@ func ResourceIBMCdTektonPipelineTriggerTriggerPatchAsPatch(patchVals *cdtektonpi
 		delete(patch, "filter")
 	}
 	path = "favorite"
-	if _, exists := d.GetOk(path); d.HasChange(path) && !exists {
+	if _, exists := d.GetOkExists(path); d.HasChange(path) && !exists {
 		patch["favorite"] = nil
 	} else if !exists {
 		delete(patch, "favorite")


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/IBM-Cloud/terraform-provider-ibm/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```
