### PR TITLE
Adding the fix for github issue #5778

### DIFF
--- a/ibm/service/cos/resource_ibm_cos_bucket.go
+++ b/ibm/service/cos/resource_ibm_cos_bucket.go
@@ -1328,7 +1328,7 @@ func resourceIBMCOSBucketRead(d *schema.ResourceData, meta interface{}) error {
 			d.Set("abort_incomplete_multipart_upload_days", abort_mpuRules)
 		}
 	} else {
-		fmt.Println("There is no lifecycle configuration on the bucket")
+		log.Printf("[DEBUG] There is no lifecycle configuration on the bucket")
 	}
 
 	// Read retention rule

--- a/ibm/service/cos/resource_ibm_cos_bucket_lifecycle_configuration.go
+++ b/ibm/service/cos/resource_ibm_cos_bucket_lifecycle_configuration.go
@@ -568,7 +568,7 @@ func resourceIBMCOSBucketLifecycleConfigurationRead(ctx context.Context, d *sche
 	}
 	//getBucketConfiguration
 	const (
-		lifecycleConfigurationRulesSteadyTimeout = 2 * time.Minute
+		lifecycleConfigurationRulesSteadyTimeout = 5 * time.Minute
 	)
 	getLifecycleConfigurationInput := &s3.GetBucketLifecycleConfigurationInput{
 		Bucket: aws.String(bucketName),
@@ -580,8 +580,7 @@ func resourceIBMCOSBucketLifecycleConfigurationRead(ctx context.Context, d *sche
 		var err error
 		output, err = s3Client.GetBucketLifecycleConfiguration(getLifecycleConfigurationInput)
 
-		if d.IsNewResource() && err != nil && strings.Contains(err.Error(), "NoSuchLifecycleConfiguration: The lifecycle configuration does not exist") {
-
+		if err != nil && strings.Contains(err.Error(), "NoSuchLifecycleConfiguration: The lifecycle configuration does not exist") {
 			return resource.RetryableError(err)
 		}
 		if err != nil {


### PR DESCRIPTION
Regression result :
```
=== RUN  TestAccIBMCosBucket_Basic
--- PASS: TestAccIBMCosBucket_Basic (107.10s)
=== RUN  TestAccIBMCosBucket_Basic_Single_Site_Location
--- PASS: TestAccIBMCosBucket_Basic_Single_Site_Location (64.43s)
=== RUN  TestAccIBMCosBucket_Lifecycle_Configuration_Expiration_With_Days
--- PASS: TestAccIBMCosBucket_Lifecycle_Configuration_Expiration_With_Days (77.43s)
=== RUN  TestAccIBMCosBucket_Lifecycle_Configuration_Expiration_With_Date
--- PASS: TestAccIBMCosBucket_Lifecycle_Configuration_Expiration_With_Date (68.67s)
=== RUN  TestAccIBMCosBucket_Lifecycle_Configuration_Transition_With_Days_Glacier
--- PASS: TestAccIBMCosBucket_Lifecycle_Configuration_Transition_With_Days_Glacier (72.72s)
=== RUN  TestAccIBMCosBucket_Lifecycle_Configuration_Transition_With_Date_Glacier
--- PASS: TestAccIBMCosBucket_Lifecycle_Configuration_Transition_With_Date_Glacier (74.53s)
=== RUN  TestAccIBMCosBucket_Lifecycle_Configuration_Transition_With_Days_Accelerated
--- PASS: TestAccIBMCosBucket_Lifecycle_Configuration_Transition_With_Days_Accelerated (73.10s)
=== RUN  TestAccIBMCosBucket_Lifecycle_Configuration_Expiration_With_Abort_Incomplete_Multipart_Upload
--- PASS: TestAccIBMCosBucket_Lifecycle_Configuration_Expiration_With_Abort_Incomplete_Multipart_Upload (68.49s)
=== RUN  TestAccIBMCosBucket_Lifecycle_Configuration_Abort_Incomplete_Multipart_Upload
--- PASS: TestAccIBMCosBucket_Lifecycle_Configuration_Abort_Incomplete_Multipart_Upload (72.78s)
=== RUN  TestAccIBMCosBucket_Lifecycle_Configuration_Transition_With_Date_Accelerated
--- PASS: TestAccIBMCosBucket_Lifecycle_Configuration_Transition_With_Date_Accelerated (72.42s)
=== RUN  TestAccIBMCosBucket_Lifecycle_Configuration_Expiration_With_Transition
--- PASS: TestAccIBMCosBucket_Lifecycle_Configuration_Expiration_With_Transition (74.67s)
=== RUN  TestAccIBMCosBucket_Lifecycle_Configuration_Transition_With_Abort_Incomplete_Multipart_Upload
--- PASS: TestAccIBMCosBucket_Lifecycle_Configuration_Transition_With_Abort_Incomplete_Multipart_Upload (69.22s)
=== RUN  TestAccIBMCosBucket_Lifecycle_Configuration_Expiration_With_Noncurrent_Version_Expiration
--- PASS: TestAccIBMCosBucket_Lifecycle_Configuration_Expiration_With_Noncurrent_Version_Expiration (70.96s)
=== RUN  TestAccIBMCosBucket_Lifecycle_Configuration_Expiration_With_Expired_Object_Delete_Marker
--- PASS: TestAccIBMCosBucket_Lifecycle_Configuration_Expiration_With_Expired_Object_Delete_Marker (73.05s)
=== RUN  TestAccIBMCosBucket_Lifecycle_Configuration_Expiration_With_Expired_Object_Delete_Marker_On_Versioning_enable_Bucket
--- PASS: TestAccIBMCosBucket_Lifecycle_Configuration_Expiration_With_Expired_Object_Delete_Marker_On_Versioning_enable_Bucket (75.13s)
=== RUN  TestAccIBMCosBucket_Lifecycle_Configuration_Expiration_Transition_Abort_Incomplete_Multipart_Upload_All--- PASS: TestAccIBMCosBucket_Lifecycle_Configuration_Expiration_Transition_Abort_Incomplete_Multipart_Upload_All (86.93s)
PASS
=== RUN  TestAccIBMCosBucket_Lifecycle_Configuration_With_No_Filter
--- PASS: TestAccIBMCosBucket_Lifecycle_Configuration_With_No_Filter (0.66s)
=== RUN  TestAccIBMCosBucket_Lifecycle_Configuration_Status_Disabled
--- PASS: TestAccIBMCosBucket_Lifecycle_Configuration_Status_Disabled (67.91s)
=== RUN  TestAccIBMCosBucket_Lifecycle_Configuration_Multiple_Rules
--- PASS: TestAccIBMCosBucket_Lifecycle_Configuration_Multiple_Rules (68.25s)
=== RUN  TestAccIBMCosBucket_Lifecycle_Configuration_Expiration_With_Invalid_Days
--- PASS: TestAccIBMCosBucket_Lifecycle_Configuration_Expiration_With_Invalid_Days (0.68s)
=== RUN  TestAccIBMCosBucket_Lifecycle_Configuration_Transition_With_Invalid_Days
--- PASS: TestAccIBMCosBucket_Lifecycle_Configuration_Transition_With_Invalid_Days (0.66s)
=== RUN  TestAccIBMCosBucket_Lifecycle_Configuration_Transition_With_Invalid_Storage_Class
--- PASS: TestAccIBMCosBucket_Lifecycle_Configuration_Transition_With_Invalid_Storage_Class (0.67s)
=== RUN  TestAccIBMCosBucket_Lifecycle_Configuration_Transition_Multiple_Rules
--- PASS: TestAccIBMCosBucket_Lifecycle_Configuration_Transition_Multiple_Rules (55.02s)
=== RUN  TestAccIBMCosBucket_Lifecycle_Configuration_Expiration_Filter_With_Valid_Prefix
--- PASS: TestAccIBMCosBucket_Lifecycle_Configuration_Expiration_Filter_With_Valid_Prefix (78.43s)
=== RUN  TestAccIBMCosBucket_Lifecycle_Configuration_Expiration_Filter_With_Valid_Tag
--- PASS: TestAccIBMCosBucket_Lifecycle_Configuration_Expiration_Filter_With_Valid_Tag (70.02s)
=== RUN  TestAccIBMCosBucket_Lifecycle_Configuration_Expiration_Filter_With_Valid_Object_Size_Greater_Than
--- PASS: TestAccIBMCosBucket_Lifecycle_Configuration_Expiration_Filter_With_Valid_Object_Size_Greater_Than (73.01s)
=== RUN  TestAccIBMCosBucket_Lifecycle_Configuration_Expiration_Filter_With_Valid_Object_Size_Less_Than
There is no lifecycle configuration on the bucket
--- PASS: TestAccIBMCosBucket_Lifecycle_Configuration_Expiration_Filter_With_Valid_Object_Size_Less_Than (67.19s)
=== RUN  TestAccIBMCosBucket_Lifecycle_Configuration_Expiration_Filter_With_Valid_All_With_And
--- PASS: TestAccIBMCosBucket_Lifecycle_Configuration_Expiration_Filter_With_Valid_All_With_And (74.05s)
=== RUN  TestAccIBMCosBucket_Lifecycle_Configuration_Expiration_Filter_With_Valid_Multiple_Tags
--- PASS: TestAccIBMCosBucket_Lifecycle_Configuration_Expiration_Filter_With_Valid_Multiple_Tags (69.16s)
=== RUN  TestAccIBMCosBucket_Lifecycle_Configuration_Expiration_Filter_With_Valid_All_Without_And
--- PASS: TestAccIBMCosBucket_Lifecycle_Configuration_Expiration_Filter_With_Valid_All_Without_And (51.16s)
=== RUN  TestAccIBMCosBucket_Lifecycle_Configuration_Expiration_Filter_With_Invalid_Object_Size_Greater_Than
--- PASS: TestAccIBMCosBucket_Lifecycle_Configuration_Expiration_Filter_With_Invalid_Object_Size_Greater_Than (0.67s)
=== RUN  TestAccIBMCosBucket_Lifecycle_Configuration_Expiration_Filter_With_Invalid_Object_Size_Less_Than
--- PASS: TestAccIBMCosBucket_Lifecycle_Configuration_Expiration_Filter_With_Invalid_Object_Size_Less_Than (0.66s)

```