### PR TITLE
fix status issue with vni on is_security_group_target

### DIFF
--- a/ibm/service/vpc/resource_ibm_is_security_group_target.go
+++ b/ibm/service/vpc/resource_ibm_is_security_group_target.go
@@ -366,7 +366,7 @@ func isWaitForVNISgTargetCreateAvailable(sess *vpcv1.VpcV1, vniId string, timeou
 
 	stateConf := &resource.StateChangeConf{
 		Pending:    []string{"pending", "updating", "waiting"},
-		Target:     []string{isLBProvisioningDone, ""},
+		Target:     []string{isLBProvisioningDone, "", "stable"},
 		Refresh:    isVNISgTargetRefreshFunc(sess, vniId),
 		Timeout:    timeout,
 		Delay:      10 * time.Second,
@@ -384,11 +384,11 @@ func isVNISgTargetRefreshFunc(vpcClient *vpcv1.VpcV1, vniId string) resource.Sta
 		}
 		vni, response, err := vpcClient.GetVirtualNetworkInterface(getVNIOptions)
 		if err != nil {
-			return nil, "", fmt.Errorf("[ERROR] Error Getting Load Balancer : %s\n%s", err, response)
+			return nil, "", fmt.Errorf("[ERROR] Error Getting virtual network interface : %s\n%s", err, response)
 		}
 
 		if *vni.LifecycleState == "failed" {
-			return vni, *vni.LifecycleState, fmt.Errorf("Network Interface creationg failed with status %s ", *vni.LifecycleState)
+			return vni, *vni.LifecycleState, fmt.Errorf("Virtual Network Interface creating failed with status %s ", *vni.LifecycleState)
 		}
 		return vni, *vni.LifecycleState, nil
 	}


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/IBM-Cloud/terraform-provider-ibm/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```
