### PR TITLE
Fix non-constant format string in call flex.FmtErrorf after go 1.24 upgrade

### DIFF
--- a/ibm/service/appconfiguration/data_source_ibm_app_config_environment.go
+++ b/ibm/service/appconfiguration/data_source_ibm_app_config_environment.go
@@ -77,7 +77,7 @@ func dataSourceIbmAppConfigEnvironmentRead(d *schema.ResourceData, meta interfac
 
 	appconfigClient, err := getAppConfigClient(meta, guid)
 	if err != nil {
-		return flex.FmtErrorf(fmt.Sprintf("%s", err))
+		return flex.FmtErrorf("%s", err)
 	}
 
 	options := &appconfigurationv1.GetEnvironmentOptions{}

--- a/ibm/service/appconfiguration/data_source_ibm_app_config_environments.go
+++ b/ibm/service/appconfiguration/data_source_ibm_app_config_environments.go
@@ -4,7 +4,6 @@
 package appconfiguration
 
 import (
-	"fmt"
 	"net/url"
 	"reflect"
 	"strconv"
@@ -165,7 +164,7 @@ func dataSourceIbmAppConfigEnvironmentsRead(d *schema.ResourceData, meta interfa
 
 	appconfigClient, err := getAppConfigClient(meta, guid)
 	if err != nil {
-		return flex.FmtErrorf(fmt.Sprintf("%s", err))
+		return flex.FmtErrorf("%s", err)
 	}
 
 	options := &appconfigurationv1.ListEnvironmentsOptions{}

--- a/ibm/service/appconfiguration/data_source_ibm_app_config_feature.go
+++ b/ibm/service/appconfiguration/data_source_ibm_app_config_feature.go
@@ -172,7 +172,7 @@ func dataSourceIbmAppConfigFeatureRead(d *schema.ResourceData, meta interface{})
 
 	appconfigClient, err := getAppConfigClient(meta, guid)
 	if err != nil {
-		return flex.FmtErrorf(fmt.Sprintf("%s", err))
+		return flex.FmtErrorf("%s", err)
 	}
 
 	options := &appconfigurationv1.GetFeatureOptions{}

--- a/ibm/service/appconfiguration/data_source_ibm_app_config_features.go
+++ b/ibm/service/appconfiguration/data_source_ibm_app_config_features.go
@@ -282,7 +282,7 @@ func dataSourceIbmAppConfigFeaturesRead(d *schema.ResourceData, meta interface{}
 
 	appconfigClient, err := getAppConfigClient(meta, guid)
 	if err != nil {
-		return flex.FmtErrorf(fmt.Sprintf("%s", err))
+		return flex.FmtErrorf("%s", err)
 	}
 
 	options := &appconfigurationv1.ListFeaturesOptions{}

--- a/ibm/service/appconfiguration/data_source_ibm_app_config_segment.go
+++ b/ibm/service/appconfiguration/data_source_ibm_app_config_segment.go
@@ -133,7 +133,7 @@ func dataSourceIbmAppConfigSegmentRead(d *schema.ResourceData, meta interface{})
 
 	appconfigClient, err := getAppConfigClient(meta, guid)
 	if err != nil {
-		return flex.FmtErrorf(fmt.Sprintf("%s", err))
+		return flex.FmtErrorf("%s", err)
 	}
 
 	options := &appconfigurationv1.GetSegmentOptions{}

--- a/ibm/service/appconfiguration/resource_ibm_app_config_collection_test.go
+++ b/ibm/service/appconfiguration/resource_ibm_app_config_collection_test.go
@@ -5,11 +5,12 @@ package appconfiguration_test
 
 import (
 	"fmt"
+	"testing"
+
 	acc "github.com/IBM-Cloud/terraform-provider-ibm/ibm/acctest"
 	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/flex"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"testing"
 
 	"github.com/IBM/appconfiguration-go-admin-sdk/appconfigurationv1"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
@@ -80,11 +81,11 @@ func testAccCheckIbmAppConfigCollectionExists(n string, obj appconfigurationv1.C
 		}
 		parts, err := flex.IdParts(rs.Primary.ID)
 		if err != nil {
-			return flex.FmtErrorf(fmt.Sprintf("%s", err))
+			return flex.FmtErrorf("%s", err)
 		}
 		appconfigClient, err := getAppConfigClient(acc.TestAccProvider.Meta(), parts[0])
 		if err != nil {
-			return flex.FmtErrorf(fmt.Sprintf("%s", err))
+			return flex.FmtErrorf("%s", err)
 		}
 
 		options := &appconfigurationv1.GetCollectionOptions{}
@@ -93,7 +94,7 @@ func testAccCheckIbmAppConfigCollectionExists(n string, obj appconfigurationv1.C
 
 		result, _, err := appconfigClient.GetCollection(options)
 		if err != nil {
-			return flex.FmtErrorf(fmt.Sprintf("%s", err))
+			return flex.FmtErrorf("%s", err)
 		}
 
 		obj = *result
@@ -109,11 +110,11 @@ func testAccCheckIbmAppConfigCollectionDestroy(s *terraform.State) error {
 		}
 		parts, err := flex.IdParts(rs.Primary.ID)
 		if err != nil {
-			return flex.FmtErrorf(fmt.Sprintf("%s", err))
+			return flex.FmtErrorf("%s", err)
 		}
 		appconfigClient, err := getAppConfigClient(acc.TestAccProvider.Meta(), parts[0])
 		if err != nil {
-			return flex.FmtErrorf(fmt.Sprintf("%s", err))
+			return flex.FmtErrorf("%s", err)
 		}
 		options := &appconfigurationv1.GetCollectionOptions{}
 

--- a/ibm/service/appconfiguration/resource_ibm_app_config_environment.go
+++ b/ibm/service/appconfiguration/resource_ibm_app_config_environment.go
@@ -90,7 +90,7 @@ func resourceEnvironmentCreate(d *schema.ResourceData, meta interface{}) error {
 	guid := d.Get("guid").(string)
 	appconfigClient, err := getAppConfigClient(meta, guid)
 	if err != nil {
-		return flex.FmtErrorf(fmt.Sprintf("%s", err))
+		return flex.FmtErrorf("%s", err)
 	}
 	options := &appconfigurationv1.CreateEnvironmentOptions{}
 
@@ -123,7 +123,7 @@ func resourceEnvironmentUpdate(d *schema.ResourceData, meta interface{}) error {
 		}
 		appconfigClient, err := getAppConfigClient(meta, parts[0])
 		if err != nil {
-			return flex.FmtErrorf(fmt.Sprintf("%s", err))
+			return flex.FmtErrorf("%s", err)
 		}
 
 		options := &appconfigurationv1.UpdateEnvironmentOptions{}
@@ -156,7 +156,7 @@ func resourceEnvironmentRead(d *schema.ResourceData, meta interface{}) error {
 	}
 	appconfigClient, err := getAppConfigClient(meta, parts[0])
 	if err != nil {
-		return flex.FmtErrorf(fmt.Sprintf("%s", err))
+		return flex.FmtErrorf("%s", err)
 	}
 
 	options := &appconfigurationv1.GetEnvironmentOptions{}
@@ -221,7 +221,7 @@ func resourceEnvironmentDelete(d *schema.ResourceData, meta interface{}) error {
 
 	appconfigClient, err := getAppConfigClient(meta, parts[0])
 	if err != nil {
-		return flex.FmtErrorf(fmt.Sprintf("%s", err))
+		return flex.FmtErrorf("%s", err)
 	}
 
 	options := &appconfigurationv1.DeleteEnvironmentOptions{}

--- a/ibm/service/appconfiguration/resource_ibm_app_config_environment_test.go
+++ b/ibm/service/appconfiguration/resource_ibm_app_config_environment_test.go
@@ -103,12 +103,12 @@ func testAccCheckIbmAppConfigEnvironmentExists(n string, obj appconfigurationv1.
 
 		parts, err := flex.IdParts(rs.Primary.ID)
 		if err != nil {
-			return flex.FmtErrorf(fmt.Sprintf("%s", err))
+			return flex.FmtErrorf("%s", err)
 		}
 
 		appconfigClient, err := getAppConfigClient(acc.TestAccProvider.Meta(), parts[0])
 		if err != nil {
-			return flex.FmtErrorf(fmt.Sprintf("%s", err))
+			return flex.FmtErrorf("%s", err)
 		}
 
 		options := &appconfigurationv1.GetEnvironmentOptions{}
@@ -116,7 +116,7 @@ func testAccCheckIbmAppConfigEnvironmentExists(n string, obj appconfigurationv1.
 
 		result, _, err := appconfigClient.GetEnvironment(options)
 		if err != nil {
-			return flex.FmtErrorf(fmt.Sprintf("%s", err))
+			return flex.FmtErrorf("%s", err)
 		}
 
 		obj = *result
@@ -132,12 +132,12 @@ func testAccCheckIbmAppConfigEnvironmentDestroy(s *terraform.State) error {
 
 		parts, err := flex.IdParts(rs.Primary.ID)
 		if err != nil {
-			return flex.FmtErrorf(fmt.Sprintf("%s", err))
+			return flex.FmtErrorf("%s", err)
 		}
 
 		appconfigClient, err := getAppConfigClient(acc.TestAccProvider.Meta(), parts[0])
 		if err != nil {
-			return flex.FmtErrorf(fmt.Sprintf("%s", err))
+			return flex.FmtErrorf("%s", err)
 		}
 		options := &appconfigurationv1.GetEnvironmentOptions{}
 		options.SetEnvironmentID(parts[1])

--- a/ibm/service/appconfiguration/resource_ibm_app_config_feature.go
+++ b/ibm/service/appconfiguration/resource_ibm_app_config_feature.go
@@ -166,7 +166,7 @@ func resourceIbmIbmAppConfigFeatureCreate(d *schema.ResourceData, meta interface
 	guid := d.Get("guid").(string)
 	appconfigClient, err := getAppConfigClient(meta, guid)
 	if err != nil {
-		return flex.FmtErrorf(fmt.Sprintf("%s", err))
+		return flex.FmtErrorf("%s", err)
 	}
 	options := &appconfigurationv1.CreateFeatureOptions{}
 	options.SetType(d.Get("type").(string))
@@ -197,7 +197,7 @@ func resourceIbmIbmAppConfigFeatureCreate(d *schema.ResourceData, meta interface
 			value := e.(map[string]interface{})
 			segmentRulesItem, err := resourceIbmAppConfigFeatureMapToSegmentRule(d, value)
 			if err != nil {
-				return flex.FmtErrorf(fmt.Sprintf("%s", err))
+				return flex.FmtErrorf("%s", err)
 			}
 			segmentRules = append(segmentRules, segmentRulesItem)
 		}
@@ -229,7 +229,7 @@ func resourceIbmIbmAppConfigFeatureUpdate(d *schema.ResourceData, meta interface
 	}
 	appconfigClient, err := getAppConfigClient(meta, parts[0])
 	if err != nil {
-		return flex.FmtErrorf(fmt.Sprintf("%s", err))
+		return flex.FmtErrorf("%s", err)
 	}
 
 	options := &appconfigurationv1.UpdateFeatureOptions{}
@@ -259,7 +259,7 @@ func resourceIbmIbmAppConfigFeatureUpdate(d *schema.ResourceData, meta interface
 				value := e.(map[string]interface{})
 				segmentRulesItem, err := resourceIbmAppConfigFeatureMapToSegmentRule(d, value)
 				if err != nil {
-					return flex.FmtErrorf(fmt.Sprintf("%s", err))
+					return flex.FmtErrorf("%s", err)
 				}
 				segmentRules = append(segmentRules, segmentRulesItem)
 			}
@@ -291,7 +291,7 @@ func resourceIbmIbmAppConfigFeatureRead(d *schema.ResourceData, meta interface{}
 	}
 	appconfigClient, err := getAppConfigClient(meta, parts[0])
 	if err != nil {
-		return flex.FmtErrorf(fmt.Sprintf("%s", err))
+		return flex.FmtErrorf("%s", err)
 	}
 
 	options := &appconfigurationv1.GetFeatureOptions{}
@@ -423,7 +423,7 @@ func resourceIbmIbmAppConfigFeatureDelete(d *schema.ResourceData, meta interface
 	}
 	appconfigClient, err := getAppConfigClient(meta, parts[0])
 	if err != nil {
-		return flex.FmtErrorf(fmt.Sprintf("%s", err))
+		return flex.FmtErrorf("%s", err)
 	}
 
 	options := &appconfigurationv1.DeleteFeatureOptions{}

--- a/ibm/service/appconfiguration/resource_ibm_app_config_feature_test.go
+++ b/ibm/service/appconfiguration/resource_ibm_app_config_feature_test.go
@@ -94,11 +94,11 @@ func testAccCheckIbmAppConfigFeatureExists(n string, obj appconfigurationv1.Feat
 		}
 		parts, err := flex.IdParts(rs.Primary.ID)
 		if err != nil {
-			return flex.FmtErrorf(fmt.Sprintf("%s", err))
+			return flex.FmtErrorf("%s", err)
 		}
 		appconfigClient, err := getAppConfigClient(acc.TestAccProvider.Meta(), parts[0])
 		if err != nil {
-			return flex.FmtErrorf(fmt.Sprintf("%s", err))
+			return flex.FmtErrorf("%s", err)
 		}
 
 		options := &appconfigurationv1.GetFeatureOptions{}
@@ -108,7 +108,7 @@ func testAccCheckIbmAppConfigFeatureExists(n string, obj appconfigurationv1.Feat
 
 		result, _, err := appconfigClient.GetFeature(options)
 		if err != nil {
-			return flex.FmtErrorf(fmt.Sprintf("%s", err))
+			return flex.FmtErrorf("%s", err)
 		}
 
 		obj = *result
@@ -124,11 +124,11 @@ func testAccCheckIbmAppConfigFeatureDestroy(s *terraform.State) error {
 		}
 		parts, err := flex.IdParts(rs.Primary.ID)
 		if err != nil {
-			return flex.FmtErrorf(fmt.Sprintf("%s", err))
+			return flex.FmtErrorf("%s", err)
 		}
 		appconfigClient, err := getAppConfigClient(acc.TestAccProvider.Meta(), parts[0])
 		if err != nil {
-			return flex.FmtErrorf(fmt.Sprintf("%s", err))
+			return flex.FmtErrorf("%s", err)
 		}
 		options := &appconfigurationv1.GetFeatureOptions{}
 

--- a/ibm/service/appconfiguration/resource_ibm_app_config_property.go
+++ b/ibm/service/appconfiguration/resource_ibm_app_config_property.go
@@ -184,7 +184,7 @@ func resourceIbmIbmAppConfigPropertyCreate(d *schema.ResourceData, meta interfac
 			value := e.(map[string]interface{})
 			segmentRulesItem, err := resourceIbmAppConfigPropertyMapToSegmentRule(d, value)
 			if err != nil {
-				return flex.FmtErrorf(fmt.Sprintf("%s", err))
+				return flex.FmtErrorf("%s", err)
 			}
 			segmentRules = append(segmentRules, segmentRulesItem)
 		}
@@ -350,7 +350,7 @@ func resourceIbmIbmAppConfigPropertyUpdate(d *schema.ResourceData, meta interfac
 				value := e.(map[string]interface{})
 				segmentRulesItem, err := resourceIbmAppConfigPropertyMapToSegmentRule(d, value)
 				if err != nil {
-					return flex.FmtErrorf(fmt.Sprintf("%s", err))
+					return flex.FmtErrorf("%s", err)
 				}
 				segmentRules = append(segmentRules, segmentRulesItem)
 			}

--- a/ibm/service/appconfiguration/resource_ibm_app_config_property_test.go
+++ b/ibm/service/appconfiguration/resource_ibm_app_config_property_test.go
@@ -5,11 +5,12 @@ package appconfiguration_test
 
 import (
 	"fmt"
+	"testing"
+
 	acc "github.com/IBM-Cloud/terraform-provider-ibm/ibm/acctest"
 	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/flex"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"testing"
 
 	"github.com/IBM/appconfiguration-go-admin-sdk/appconfigurationv1"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
@@ -90,12 +91,12 @@ func testAccCheckIbmAppConfigPropertyExists(n string, obj appconfigurationv1.Pro
 
 		parts, err := flex.IdParts(rs.Primary.ID)
 		if err != nil {
-			return flex.FmtErrorf(fmt.Sprintf("%s", err))
+			return flex.FmtErrorf("%s", err)
 		}
 
 		appconfigClient, err := getAppConfigClient(acc.TestAccProvider.Meta(), parts[0])
 		if err != nil {
-			return flex.FmtErrorf(fmt.Sprintf("%s", err))
+			return flex.FmtErrorf("%s", err)
 		}
 		options := &appconfigurationv1.GetPropertyOptions{}
 
@@ -104,7 +105,7 @@ func testAccCheckIbmAppConfigPropertyExists(n string, obj appconfigurationv1.Pro
 
 		property, _, err := appconfigClient.GetProperty(options)
 		if err != nil {
-			return flex.FmtErrorf(fmt.Sprintf("%s", err))
+			return flex.FmtErrorf("%s", err)
 		}
 
 		obj = *property
@@ -119,12 +120,12 @@ func testAccCheckIbmAppConfigPropertyDestroy(s *terraform.State) error {
 		}
 		parts, err := flex.IdParts(rs.Primary.ID)
 		if err != nil {
-			return flex.FmtErrorf(fmt.Sprintf("%s", err))
+			return flex.FmtErrorf("%s", err)
 		}
 
 		appconfigClient, err := getAppConfigClient(acc.TestAccProvider.Meta(), parts[0])
 		if err != nil {
-			return flex.FmtErrorf(fmt.Sprintf("%s", err))
+			return flex.FmtErrorf("%s", err)
 		}
 		options := &appconfigurationv1.GetPropertyOptions{}
 

--- a/ibm/service/appconfiguration/resource_ibm_app_config_segment.go
+++ b/ibm/service/appconfiguration/resource_ibm_app_config_segment.go
@@ -92,7 +92,7 @@ func resourceIbmIbmAppConfigSegmentCreate(d *schema.ResourceData, meta interface
 	guid := d.Get("guid").(string)
 	appconfigClient, err := getAppConfigClient(meta, guid)
 	if err != nil {
-		return flex.FmtErrorf(fmt.Sprintf("%s", err))
+		return flex.FmtErrorf("%s", err)
 	}
 	options := &appconfigurationv1.CreateSegmentOptions{}
 	options.SetName(d.Get("name").(string))
@@ -111,7 +111,7 @@ func resourceIbmIbmAppConfigSegmentCreate(d *schema.ResourceData, meta interface
 			value := e.(map[string]interface{})
 			segmentRulesItem, err := resourceIbmAppConfigMapToSegmentRule(value)
 			if err != nil {
-				return flex.FmtErrorf(fmt.Sprintf("%s", err))
+				return flex.FmtErrorf("%s", err)
 			}
 			segmentRules = append(segmentRules, segmentRulesItem)
 		}
@@ -151,7 +151,7 @@ func resourceIbmIbmAppConfigSegmentRead(d *schema.ResourceData, meta interface{}
 
 	appconfigClient, err := getAppConfigClient(meta, parts[0])
 	if err != nil {
-		return flex.FmtErrorf(fmt.Sprintf("%s", err))
+		return flex.FmtErrorf("%s", err)
 	}
 
 	options := &appconfigurationv1.GetSegmentOptions{}
@@ -234,7 +234,7 @@ func resourceIbmIbmAppConfigSegmentUpdate(d *schema.ResourceData, meta interface
 	}
 	appconfigClient, err := getAppConfigClient(meta, parts[0])
 	if err != nil {
-		return flex.FmtErrorf(fmt.Sprintf("%s", err))
+		return flex.FmtErrorf("%s", err)
 	}
 	options := &appconfigurationv1.UpdateSegmentOptions{}
 
@@ -257,7 +257,7 @@ func resourceIbmIbmAppConfigSegmentUpdate(d *schema.ResourceData, meta interface
 				value := e.(map[string]interface{})
 				segmentRulesItem, err := resourceIbmAppConfigMapToSegmentRule(value)
 				if err != nil {
-					return flex.FmtErrorf(fmt.Sprintf("%s", err))
+					return flex.FmtErrorf("%s", err)
 				}
 				segmentRules = append(segmentRules, segmentRulesItem)
 			}
@@ -280,7 +280,7 @@ func resourceIbmIbmAppConfigSegmentDelete(d *schema.ResourceData, meta interface
 	}
 	appconfigClient, err := getAppConfigClient(meta, parts[0])
 	if err != nil {
-		return flex.FmtErrorf(fmt.Sprintf("%s", err))
+		return flex.FmtErrorf("%s", err)
 	}
 
 	options := &appconfigurationv1.DeleteSegmentOptions{}

--- a/ibm/service/appconfiguration/resource_ibm_app_config_segment_test.go
+++ b/ibm/service/appconfiguration/resource_ibm_app_config_segment_test.go
@@ -2,11 +2,12 @@ package appconfiguration_test
 
 import (
 	"fmt"
+	"testing"
+
 	acc "github.com/IBM-Cloud/terraform-provider-ibm/ibm/acctest"
 	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/flex"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"testing"
 
 	"github.com/IBM/appconfiguration-go-admin-sdk/appconfigurationv1"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
@@ -79,11 +80,11 @@ func testAccCheckIbmAppConfigSegmentExists(n string, obj appconfigurationv1.Segm
 		}
 		parts, err := flex.IdParts(rs.Primary.ID)
 		if err != nil {
-			return flex.FmtErrorf(fmt.Sprintf("%s", err))
+			return flex.FmtErrorf("%s", err)
 		}
 		appconfigClient, err := getAppConfigClient(acc.TestAccProvider.Meta(), parts[0])
 		if err != nil {
-			return flex.FmtErrorf(fmt.Sprintf("%s", err))
+			return flex.FmtErrorf("%s", err)
 		}
 
 		options := &appconfigurationv1.GetSegmentOptions{}
@@ -92,7 +93,7 @@ func testAccCheckIbmAppConfigSegmentExists(n string, obj appconfigurationv1.Segm
 
 		result, _, err := appconfigClient.GetSegment(options)
 		if err != nil {
-			return flex.FmtErrorf(fmt.Sprintf("%s", err))
+			return flex.FmtErrorf("%s", err)
 		}
 
 		obj = *result
@@ -108,11 +109,11 @@ func testAccCheckIbmAppConfigSegmentDestroy(s *terraform.State) error {
 		}
 		parts, err := flex.IdParts(rs.Primary.ID)
 		if err != nil {
-			return flex.FmtErrorf(fmt.Sprintf("%s", err))
+			return flex.FmtErrorf("%s", err)
 		}
 		appconfigClient, err := getAppConfigClient(acc.TestAccProvider.Meta(), parts[0])
 		if err != nil {
-			return flex.FmtErrorf(fmt.Sprintf("%s", err))
+			return flex.FmtErrorf("%s", err)
 		}
 		options := &appconfigurationv1.GetSegmentOptions{}
 

--- a/ibm/service/appconfiguration/resource_ibm_app_config_snapshot.go
+++ b/ibm/service/appconfiguration/resource_ibm_app_config_snapshot.go
@@ -136,7 +136,7 @@ func resourceIbmIbmAppConfigSnapshotCreate(d *schema.ResourceData, meta interfac
 	guid := d.Get("guid").(string)
 	appconfigClient, err := getAppConfigClient(meta, guid)
 	if err != nil {
-		return flex.FmtErrorf(fmt.Sprintf("%s", err))
+		return flex.FmtErrorf("%s", err)
 	}
 	options := &appconfigurationv1.CreateGitconfigOptions{}
 
@@ -166,7 +166,7 @@ func resourceIbmIbmAppConfigSnapshotUpdate(d *schema.ResourceData, meta interfac
 	}
 	appconfigClient, err := getAppConfigClient(meta, parts[0])
 	if err != nil {
-		return flex.FmtErrorf(fmt.Sprintf("%s", err))
+		return flex.FmtErrorf("%s", err)
 	}
 
 	if ok := d.HasChanges("action"); ok {
@@ -219,7 +219,7 @@ func resourceIbmIbmAppConfigSnapshotRead(d *schema.ResourceData, meta interface{
 	}
 	appconfigClient, err := getAppConfigClient(meta, parts[0])
 	if err != nil {
-		return flex.FmtErrorf(fmt.Sprintf("%s", err))
+		return flex.FmtErrorf("%s", err)
 	}
 	if len(parts) != 2 {
 		return flex.FmtErrorf("Kindly check the id")
@@ -285,7 +285,7 @@ func resourceIbmIbmAppConfigSnapshotDelete(d *schema.ResourceData, meta interfac
 	}
 	appconfigClient, err := getAppConfigClient(meta, parts[0])
 	if err != nil {
-		return flex.FmtErrorf(fmt.Sprintf("%s", err))
+		return flex.FmtErrorf("%s", err)
 	}
 
 	options := &appconfigurationv1.DeleteGitconfigOptions{}

--- a/ibm/service/cis/data_source_ibm_cis_test.go
+++ b/ibm/service/cis/data_source_ibm_cis_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 func TestAccIBMCisDataSource_basic(t *testing.T) {
-	instanceName := fmt.Sprintf(acc.CisInstance)
+	instanceName := acc.CisInstance
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:  func() { acc.TestAccPreCheckCis(t) },

--- a/ibm/service/classicinfrastructure/resource_ibm_lb_vpx_vip.go
+++ b/ibm/service/classicinfrastructure/resource_ibm_lb_vpx_vip.go
@@ -545,7 +545,7 @@ func resourceIBMLbVpxVipUpdate105(d *schema.ResourceData, meta interface{}) erro
 	// Update the virtual server
 	err = nClient.Update(&lbvserverReq)
 	if err != nil {
-		return fmt.Errorf("[ERROR] Error updating Virtual Ip Address: " + err.Error())
+		return fmt.Errorf("[ERROR] Error updating Virtual Ip Address: %s", err.Error())
 	}
 
 	return resourceIBMLbVpxVipRead(d, meta)

--- a/ibm/service/hpcs/resource_ibm_hpcs_vault.go
+++ b/ibm/service/hpcs/resource_ibm_hpcs_vault.go
@@ -368,7 +368,7 @@ func getUkoUrl(context context.Context, region string, instance_id string, ukoCl
 			return "", err
 		}
 		url := (*uko)["public"]
-		log.Printf(url)
+		log.Println(url)
 		return "https://" + url, nil
 	}
 

--- a/ibm/service/power/resource_ibm_pi_network.go
+++ b/ibm/service/power/resource_ibm_pi_network.go
@@ -658,7 +658,7 @@ func createNetworkWithRetry(ctx context.Context, client *instance.IBMPINetworkCl
 
 	network, err := stateConf.WaitForStateContext(ctx)
 	if err != nil {
-		return nil, fmt.Errorf(lastErr)
+		return nil, fmt.Errorf("%s", lastErr)
 	}
 
 	networkResponse := network.(*models.Network)
@@ -703,7 +703,7 @@ func deleteNetworkWithRetry(ctx context.Context, client *instance.IBMPINetworkCl
 
 	_, err := stateConf.WaitForStateContext(ctx)
 	if err != nil {
-		return fmt.Errorf(lastErr)
+		return fmt.Errorf("%s", lastErr)
 	}
 
 	return nil


### PR DESCRIPTION
Fix the non format errors after go 1.24 upgrade

```
harinireddy@Harinis-MBP terraform-provider-ibm % make build
==> Checking that code complies with gofmt requirements...
go vet .
# github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/appconfiguration
ibm/service/appconfiguration/data_source_ibm_app_config_environment.go:80:25: non-constant format string in call to github.com/IBM-Cloud/terraform-provider-ibm/ibm/flex.FmtErrorf
ibm/service/appconfiguration/data_source_ibm_app_config_environments.go:168:25: non-constant format string in call to github.com/IBM-Cloud/terraform-provider-ibm/ibm/flex.FmtErrorf
ibm/service/appconfiguration/data_source_ibm_app_config_feature.go:175:25: non-constant format string in call to github.com/IBM-Cloud/terraform-provider-ibm/ibm/flex.FmtErrorf
ibm/service/appconfiguration/data_source_ibm_app_config_features.go:285:25: non-constant format string in call to github.com/IBM-Cloud/terraform-provider-ibm/ibm/flex.FmtErrorf
ibm/service/appconfiguration/data_source_ibm_app_config_segment.go:136:25: non-constant format string in call to github.com/IBM-Cloud/terraform-provider-ibm/ibm/flex.FmtErrorf
ibm/service/appconfiguration/resource_ibm_app_config_environment.go:93:25: non-constant format string in call to github.com/IBM-Cloud/terraform-provider-ibm/ibm/flex.FmtErrorf
ibm/service/appconfiguration/resource_ibm_app_config_environment.go:126:26: non-constant format string in call to github.com/IBM-Cloud/terraform-provider-ibm/ibm/flex.FmtErrorf
ibm/service/appconfiguration/resource_ibm_app_config_environment.go:159:25: non-constant format string in call to github.com/IBM-Cloud/terraform-provider-ibm/ibm/flex.FmtErrorf
ibm/service/appconfiguration/resource_ibm_app_config_environment.go:224:25: non-constant format string in call to github.com/IBM-Cloud/terraform-provider-ibm/ibm/flex.FmtErrorf
ibm/service/appconfiguration/resource_ibm_app_config_feature.go:169:25: non-constant format string in call to github.com/IBM-Cloud/terraform-provider-ibm/ibm/flex.FmtErrorf
ibm/service/appconfiguration/resource_ibm_app_config_feature.go:200:27: non-constant format string in call to github.com/IBM-Cloud/terraform-provider-ibm/ibm/flex.FmtErrorf
ibm/service/appconfiguration/resource_ibm_app_config_feature.go:232:25: non-constant format string in call to github.com/IBM-Cloud/terraform-provider-ibm/ibm/flex.FmtErrorf
ibm/service/appconfiguration/resource_ibm_app_config_feature.go:262:28: non-constant format string in call to github.com/IBM-Cloud/terraform-provider-ibm/ibm/flex.FmtErrorf
ibm/service/appconfiguration/resource_ibm_app_config_feature.go:294:25: non-constant format string in call to github.com/IBM-Cloud/terraform-provider-ibm/ibm/flex.FmtErrorf
ibm/service/appconfiguration/resource_ibm_app_config_feature.go:426:25: non-constant format string in call to github.com/IBM-Cloud/terraform-provider-ibm/ibm/flex.FmtErrorf
ibm/service/appconfiguration/resource_ibm_app_config_property.go:187:27: non-constant format string in call to github.com/IBM-Cloud/terraform-provider-ibm/ibm/flex.FmtErrorf
ibm/service/appconfiguration/resource_ibm_app_config_property.go:353:28: non-constant format string in call to github.com/IBM-Cloud/terraform-provider-ibm/ibm/flex.FmtErrorf
ibm/service/appconfiguration/resource_ibm_app_config_segment.go:95:25: non-constant format string in call to github.com/IBM-Cloud/terraform-provider-ibm/ibm/flex.FmtErrorf
ibm/service/appconfiguration/resource_ibm_app_config_segment.go:114:27: non-constant format string in call to github.com/IBM-Cloud/terraform-provider-ibm/ibm/flex.FmtErrorf
ibm/service/appconfiguration/resource_ibm_app_config_segment.go:154:25: non-constant format string in call to github.com/IBM-Cloud/terraform-provider-ibm/ibm/flex.FmtErrorf
ibm/service/appconfiguration/resource_ibm_app_config_segment.go:237:25: non-constant format string in call to github.com/IBM-Cloud/terraform-provider-ibm/ibm/flex.FmtErrorf
ibm/service/appconfiguration/resource_ibm_app_config_segment.go:260:28: non-constant format string in call to github.com/IBM-Cloud/terraform-provider-ibm/ibm/flex.FmtErrorf
ibm/service/appconfiguration/resource_ibm_app_config_segment.go:283:25: non-constant format string in call to github.com/IBM-Cloud/terraform-provider-ibm/ibm/flex.FmtErrorf
ibm/service/appconfiguration/resource_ibm_app_config_snapshot.go:139:25: non-constant format string in call to github.com/IBM-Cloud/terraform-provider-ibm/ibm/flex.FmtErrorf
ibm/service/appconfiguration/resource_ibm_app_config_snapshot.go:169:25: non-constant format string in call to github.com/IBM-Cloud/terraform-provider-ibm/ibm/flex.FmtErrorf
ibm/service/appconfiguration/resource_ibm_app_config_snapshot.go:222:25: non-constant format string in call to github.com/IBM-Cloud/terraform-provider-ibm/ibm/flex.FmtErrorf
ibm/service/appconfiguration/resource_ibm_app_config_snapshot.go:288:25: non-constant format string in call to github.com/IBM-Cloud/terraform-provider-ibm/ibm/flex.FmtErrorf
# github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/classicinfrastructure
ibm/service/classicinfrastructure/resource_ibm_lb_vpx_vip.go:548:21: non-constant format string in call to fmt.Errorf
# github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/hpcs
ibm/service/hpcs/resource_ibm_hpcs_vault.go:371:14: non-constant format string in call to log.Printf
# github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/power
ibm/service/power/resource_ibm_pi_network.go:661:26: non-constant format string in call to fmt.Errorf
ibm/service/power/resource_ibm_pi_network.go:706:21: non-constant format string in call to fmt.Errorf
# github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/appconfiguration_test
# [github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/appconfiguration_test]
ibm/service/appconfiguration/resource_ibm_app_config_collection_test.go:83:26: non-constant format string in call to github.com/IBM-Cloud/terraform-provider-ibm/ibm/flex.FmtErrorf
ibm/service/appconfiguration/resource_ibm_app_config_collection_test.go:87:26: non-constant format string in call to github.com/IBM-Cloud/terraform-provider-ibm/ibm/flex.FmtErrorf
ibm/service/appconfiguration/resource_ibm_app_config_collection_test.go:96:26: non-constant format string in call to github.com/IBM-Cloud/terraform-provider-ibm/ibm/flex.FmtErrorf
ibm/service/appconfiguration/resource_ibm_app_config_collection_test.go:112:26: non-constant format string in call to github.com/IBM-Cloud/terraform-provider-ibm/ibm/flex.FmtErrorf
ibm/service/appconfiguration/resource_ibm_app_config_collection_test.go:116:26: non-constant format string in call to github.com/IBM-Cloud/terraform-provider-ibm/ibm/flex.FmtErrorf
ibm/service/appconfiguration/resource_ibm_app_config_environment_test.go:106:26: non-constant format string in call to github.com/IBM-Cloud/terraform-provider-ibm/ibm/flex.FmtErrorf
ibm/service/appconfiguration/resource_ibm_app_config_environment_test.go:111:26: non-constant format string in call to github.com/IBM-Cloud/terraform-provider-ibm/ibm/flex.FmtErrorf
ibm/service/appconfiguration/resource_ibm_app_config_environment_test.go:119:26: non-constant format string in call to github.com/IBM-Cloud/terraform-provider-ibm/ibm/flex.FmtErrorf
ibm/service/appconfiguration/resource_ibm_app_config_environment_test.go:135:26: non-constant format string in call to github.com/IBM-Cloud/terraform-provider-ibm/ibm/flex.FmtErrorf
ibm/service/appconfiguration/resource_ibm_app_config_environment_test.go:140:26: non-constant format string in call to github.com/IBM-Cloud/terraform-provider-ibm/ibm/flex.FmtErrorf
ibm/service/appconfiguration/resource_ibm_app_config_feature_test.go:97:26: non-constant format string in call to github.com/IBM-Cloud/terraform-provider-ibm/ibm/flex.FmtErrorf
ibm/service/appconfiguration/resource_ibm_app_config_feature_test.go:101:26: non-constant format string in call to github.com/IBM-Cloud/terraform-provider-ibm/ibm/flex.FmtErrorf
ibm/service/appconfiguration/resource_ibm_app_config_feature_test.go:111:26: non-constant format string in call to github.com/IBM-Cloud/terraform-provider-ibm/ibm/flex.FmtErrorf
ibm/service/appconfiguration/resource_ibm_app_config_feature_test.go:127:26: non-constant format string in call to github.com/IBM-Cloud/terraform-provider-ibm/ibm/flex.FmtErrorf
ibm/service/appconfiguration/resource_ibm_app_config_feature_test.go:131:26: non-constant format string in call to github.com/IBM-Cloud/terraform-provider-ibm/ibm/flex.FmtErrorf
ibm/service/appconfiguration/resource_ibm_app_config_property_test.go:93:26: non-constant format string in call to github.com/IBM-Cloud/terraform-provider-ibm/ibm/flex.FmtErrorf
ibm/service/appconfiguration/resource_ibm_app_config_property_test.go:98:26: non-constant format string in call to github.com/IBM-Cloud/terraform-provider-ibm/ibm/flex.FmtErrorf
ibm/service/appconfiguration/resource_ibm_app_config_property_test.go:107:26: non-constant format string in call to github.com/IBM-Cloud/terraform-provider-ibm/ibm/flex.FmtErrorf
ibm/service/appconfiguration/resource_ibm_app_config_property_test.go:122:26: non-constant format string in call to github.com/IBM-Cloud/terraform-provider-ibm/ibm/flex.FmtErrorf
ibm/service/appconfiguration/resource_ibm_app_config_property_test.go:127:26: non-constant format string in call to github.com/IBM-Cloud/terraform-provider-ibm/ibm/flex.FmtErrorf
ibm/service/appconfiguration/resource_ibm_app_config_segment_test.go:82:26: non-constant format string in call to github.com/IBM-Cloud/terraform-provider-ibm/ibm/flex.FmtErrorf
ibm/service/appconfiguration/resource_ibm_app_config_segment_test.go:86:26: non-constant format string in call to github.com/IBM-Cloud/terraform-provider-ibm/ibm/flex.FmtErrorf
ibm/service/appconfiguration/resource_ibm_app_config_segment_test.go:95:26: non-constant format string in call to github.com/IBM-Cloud/terraform-provider-ibm/ibm/flex.FmtErrorf
ibm/service/appconfiguration/resource_ibm_app_config_segment_test.go:111:26: non-constant format string in call to github.com/IBM-Cloud/terraform-provider-ibm/ibm/flex.FmtErrorf
ibm/service/appconfiguration/resource_ibm_app_config_segment_test.go:115:26: non-constant format string in call to github.com/IBM-Cloud/terraform-provider-ibm/ibm/flex.FmtErrorf
# github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/cis_test
# [github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/cis_test]
ibm/service/cis/data_source_ibm_cis_test.go:16:30: non-constant format string in call to fmt.Sprintf

Vet found suspicious constructs. Please check the reported constructs
```
