### PR TITLE
[Datasource] Remove deprecation notice from VTL fields still in use by FalconStor

### DIFF
--- a/ibm/service/power/data_source_ibm_pi_instance.go
+++ b/ibm/service/power/data_source_ibm_pi_instance.go
@@ -81,7 +81,6 @@ func DataSourceIBMPIInstance() *schema.Resource {
 			},
 			Attr_LicenseRepositoryCapacity: {
 				Computed:    true,
-				Deprecated:  "This field is deprecated.",
 				Description: "The VTL license repository capacity TB value.",
 				Type:        schema.TypeInt,
 			},

--- a/ibm/service/power/data_source_ibm_pi_instances.go
+++ b/ibm/service/power/data_source_ibm_pi_instances.go
@@ -58,7 +58,6 @@ func DataSourceIBMPIInstances() *schema.Resource {
 						},
 						Attr_LicenseRepositoryCapacity: {
 							Computed:    true,
-							Deprecated:  "This field is deprecated.",
 							Description: "The VTL license repository capacity TB value.",
 							Type:        schema.TypeInt,
 						},

--- a/website/docs/d/pi_instance.html.markdown
+++ b/website/docs/d/pi_instance.html.markdown
@@ -66,7 +66,7 @@ In addition to all argument reference list, you can access the following attribu
 - `ibmi_rds` - (Boolean) IBM i Rational Dev Studio.
 - `ibmi_rds_users` - (Integer) IBM i Rational Dev Studio Number of User Licenses.
 - `id` - (String) The unique identifier of the instance.
-- `license_repository_capacity` - (Deprecated, Integer) The VTL license repository capacity TB value. Only available with VTL instances.
+- `license_repository_capacity` - (Integer) The VTL license repository capacity TB value. Only available with VTL instances.
 - `maxmem`- (Float) The maximum amount of memory that can be allocated to the instance without shutting down or rebooting the `LPAR`.
 - `maxproc`- (Float) The maximum number of processors that can be allocated to the instance without shutting down or rebooting the `LPAR`.
 - `max_virtual_cores` - (Integer) The maximum number of virtual cores that can be assigned without rebooting the instance.

--- a/website/docs/d/pi_instances.html.markdown
+++ b/website/docs/d/pi_instances.html.markdown
@@ -58,7 +58,7 @@ In addition to all argument reference list, you can access the following attribu
         - `message` -  (String) The fault message of the server.
 
   - `health_status` - (String) The health of the instance.
-  - `license_repository_capacity` - (Deprecated, Integer) The VTL license repository capacity TB value. Only available with VTL instances.
+  - `license_repository_capacity` - (Integer) The VTL license repository capacity TB value. Only available with VTL instances.
   - `memory` - (Float) The amount of memory that is allocated to the instance.
   - `minproc`- (Float) The minimum number of processors that must be allocated to the instance.
   - `maxproc`- (Float) The maximum number of processors that can be allocated to the instance without shutting down or rebooting the `LPAR`.


### PR DESCRIPTION
Remove deprecation note from license_repository_capacity attributes. Feature is still used by Falconstor. Previously only removed the notice from the argument. I missed the attributes in the first pass.