### PR TITLE
Improve test of private certificate secret

### DIFF
--- a/ibm/service/secretsmanager/resource_ibm_sm_private_certificate_configuration_intermediate_ca_test.go
+++ b/ibm/service/secretsmanager/resource_ibm_sm_private_certificate_configuration_intermediate_ca_test.go
@@ -185,8 +185,8 @@ func privateCertificateIntermediateCAConfigCryptoKey() string {
 			issuer = ibm_sm_private_certificate_configuration_root_ca.sm_private_cert_root_ca_crypto_key.name
 			common_name = "ibm.com"
 			crypto_key {
-				allow_generate_key = true
-				label = "e2e-tf-test"
+				allow_generate_key = false
+				label = "e2e-tf-ca"
 				provider {
 					type = "%s"
 					instance_crn = "%s"

--- a/ibm/service/secretsmanager/resource_ibm_sm_private_certificate_configuration_root_ca_test.go
+++ b/ibm/service/secretsmanager/resource_ibm_sm_private_certificate_configuration_root_ca_test.go
@@ -183,8 +183,8 @@ func privateCertificateRootCAConfigCryptoKey() string {
 			common_name   = "ibm.com"
 			alt_names = ["ddd.com", "aaa.com"]
 			crypto_key {
-				allow_generate_key = true
-				label = "e2e-tf-test"
+				allow_generate_key = false
+				label = "e2e-tf-ca"
 				provider {
 					type = "%s"
 					instance_crn = "%s"


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/IBM-Cloud/terraform-provider-ibm/blob/master/.github/CONTRIBUTING.md --->

This commit is just a change in some private cert tests. This change allows the tests to run without leaving behind left over keys in the test environment, so there's no need to run a cleanup process after running the tests.

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```
