### PR TITLE
fix formatting of ibm_is_backup_policy

### DIFF
--- a/ibm/service/vpc/resource_ibm_is_backup_policy.go
+++ b/ibm/service/vpc/resource_ibm_is_backup_policy.go
@@ -472,7 +472,7 @@ func resourceIBMIsBackupPolicyDelete(context context.Context, d *schema.Resource
 	deleteBackupPolicyOptions.SetIfMatch(d.Get("version").(string))
 	_, response, err := vpcClient.DeleteBackupPolicyWithContext(context, deleteBackupPolicyOptions)
 	if err != nil {
-		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("DeleteBackupPolicyWithContext failed: %s%\n%s", err.Error(), response), "ibm_is_backup_policy", "delete")
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("DeleteBackupPolicyWithContext failed: %s\n%s", err.Error(), response), "ibm_is_backup_policy", "delete")
 		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
 		return tfErr.GetDiag()
 	}


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/IBM-Cloud/terraform-provider-ibm/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```
