### PR TITLE
Add retry on GET for resource group and trusted profile

### DIFF
--- a/ibm/service/resourcemanager/resource_ibm_resource_group.go
+++ b/ibm/service/resourcemanager/resource_ibm_resource_group.go
@@ -4,12 +4,15 @@
 package resourcemanager
 
 import (
+	"context"
 	"fmt"
 	"log"
 	"time"
 
 	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/conns"
+	"github.com/IBM/go-sdk-core/v5/core"
 	rg "github.com/IBM/platform-services-go-sdk/resourcemanagerv2"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -17,12 +20,12 @@ import (
 
 func ResourceIBMResourceGroup() *schema.Resource {
 	return &schema.Resource{
-		Create:   resourceIBMResourceGroupCreate,
-		Read:     resourceIBMResourceGroupRead,
-		Update:   resourceIBMResourceGroupUpdate,
-		Delete:   resourceIBMResourceGroupDelete,
-		Exists:   resourceIBMResourceGroupExists,
-		Importer: &schema.ResourceImporter{},
+		CreateContext: resourceIBMResourceGroupCreate,
+		ReadContext:   resourceIBMResourceGroupRead,
+		UpdateContext: resourceIBMResourceGroupUpdate,
+		DeleteContext: resourceIBMResourceGroupDelete,
+		Exists:        resourceIBMResourceGroupExists,
+		Importer:      &schema.ResourceImporter{},
 
 		Timeouts: &schema.ResourceTimeout{
 			Delete: schema.DefaultTimeout(20 * time.Minute),
@@ -97,16 +100,16 @@ func ResourceIBMResourceGroup() *schema.Resource {
 	}
 }
 
-func resourceIBMResourceGroupCreate(d *schema.ResourceData, meta interface{}) error {
+func resourceIBMResourceGroupCreate(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	rMgtClient, err := meta.(conns.ClientSession).ResourceManagerV2API()
 	if err != nil {
-		return err
+		return diag.FromErr(err)
 	}
 	name := d.Get("name").(string)
 
 	userDetails, err := meta.(conns.ClientSession).BluemixUserDetails()
 	if err != nil {
-		return err
+		return diag.FromErr(err)
 	}
 	accountID := userDetails.UserAccount
 
@@ -117,34 +120,48 @@ func resourceIBMResourceGroupCreate(d *schema.ResourceData, meta interface{}) er
 
 	resourceGroup, resp, err := rMgtClient.CreateResourceGroup(&resourceGroupCreate)
 	if err != nil {
-		return fmt.Errorf("[ERROR] Error creating resource group: %s with response code  %s", err, resp)
+		return diag.FromErr(fmt.Errorf("[ERROR] Error creating resource group: %s with response code  %s", err, resp))
 	}
 
 	d.SetId(*resourceGroup.ID)
 
-	return resourceIBMResourceGroupRead(d, meta)
+	return resourceIBMResourceGroupRead(context, d, meta)
 }
 
-func resourceIBMResourceGroupRead(d *schema.ResourceData, meta interface{}) error {
+func resourceIBMResourceGroupRead(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	rMgtClient, err := meta.(conns.ClientSession).ResourceManagerV2API()
 	if err != nil {
-		return err
+		return diag.FromErr(err)
 	}
 	resourceGroupID := d.Id()
 	resourceGroupGet := rg.GetResourceGroupOptions{
 		ID: &resourceGroupID,
 	}
 
-	resourceGroup, resp, err := rMgtClient.GetResourceGroup(&resourceGroupGet)
-	if err != nil {
+	var resp *core.DetailedResponse
+	var resourceGroup *rg.ResourceGroup
+
+	err = retry.RetryContext(context, 5*time.Minute, func() *retry.RetryError {
+		resourceGroup, resp, err = rMgtClient.GetResourceGroup(&resourceGroupGet)
+		if err != nil || resourceGroup == nil {
+			if resp != nil && resp.StatusCode == 404 {
+				return retry.RetryableError(err)
+			}
+			return retry.NonRetryableError(err)
+		}
+		return nil
+	})
+
+	if conns.IsResourceTimeoutError(err) {
+		resourceGroup, resp, err = rMgtClient.GetResourceGroup(&resourceGroupGet)
+	}
+	if err != nil || resourceGroup == nil {
 		if resp != nil && resp.StatusCode == 404 {
-			log.Printf("[WARN] Resource Group is not found")
 			d.SetId("")
 			return nil
 		}
-		return fmt.Errorf("[ERROR] Error retrieving resource group: %s with response code  %s", err, resp)
+		return diag.FromErr(fmt.Errorf("[ERROR] Error retrieving resource group: %s. API Response: %s", err, resp))
 	}
-
 	d.Set("name", *resourceGroup.Name)
 	if resourceGroup.State != nil {
 		d.Set("state", *resourceGroup.State)
@@ -185,10 +202,10 @@ func resourceIBMResourceGroupRead(d *schema.ResourceData, meta interface{}) erro
 	return nil
 }
 
-func resourceIBMResourceGroupUpdate(d *schema.ResourceData, meta interface{}) error {
+func resourceIBMResourceGroupUpdate(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	rMgtClient, err := meta.(conns.ClientSession).ResourceManagerV2API()
 	if err != nil {
-		return err
+		return diag.FromErr(err)
 	}
 
 	resourceGroupID := d.Id()
@@ -205,17 +222,17 @@ func resourceIBMResourceGroupUpdate(d *schema.ResourceData, meta interface{}) er
 	if hasChange {
 		_, resp, err := rMgtClient.UpdateResourceGroup(&resourceGroupUpdate)
 		if err != nil {
-			return fmt.Errorf("[ERROR] Error updating resource group: %s with response code  %s", err, resp)
+			return diag.FromErr(fmt.Errorf("[ERROR] Error updating resource group: %s with response code  %s", err, resp))
 		}
 
 	}
-	return resourceIBMResourceGroupRead(d, meta)
+	return resourceIBMResourceGroupRead(context, d, meta)
 }
 
-func resourceIBMResourceGroupDelete(d *schema.ResourceData, meta interface{}) error {
+func resourceIBMResourceGroupDelete(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	rMgtClient, err := meta.(conns.ClientSession).ResourceManagerV2API()
 	if err != nil {
-		return err
+		return diag.FromErr(err)
 	}
 
 	resourceGroupID := d.Id()
@@ -252,11 +269,11 @@ func resourceIBMResourceGroupDelete(d *schema.ResourceData, meta interface{}) er
 					log.Printf("[WARN] Resource Group is not found")
 					return nil
 				}
-				return fmt.Errorf("[ERROR] Error Deleting resource group: %s with response code  %s", err, resp)
+				return diag.FromErr(fmt.Errorf("[ERROR] Error Deleting resource group: %s with response code  %s", err, resp))
 			}
 		} else {
 
-			return fmt.Errorf("[ERROR] Error Deleting resource group: %s with response code  %s", err, resp)
+			return diag.FromErr(fmt.Errorf("[ERROR] Error Deleting resource group: %s with response code  %s", err, resp))
 		}
 	}
 


### PR DESCRIPTION
```
Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  + create

Terraform will perform the following actions:

  # ibm_iam_trusted_profile.iam_trusted_profile_instance will be created
  + resource "ibm_iam_trusted_profile" "iam_trusted_profile_instance" {
      + account_id     = (known after apply)
      + assignment_id  = (known after apply)
      + created_at     = (known after apply)
      + crn            = (known after apply)
      + entity_tag     = (known after apply)
      + history        = (known after apply)
      + iam_id         = (known after apply)
      + id             = (known after apply)
      + ims_account_id = (known after apply)
      + ims_user_id    = (known after apply)
      + modified_at    = (known after apply)
      + name           = "newtrusted"
      + profile_id     = (known after apply)
      + template_id    = (known after apply)
    }

  # ibm_iam_trusted_profile.iam_trusted_profile_instance1 will be created
  + resource "ibm_iam_trusted_profile" "iam_trusted_profile_instance1" {
      + account_id     = (known after apply)
      + assignment_id  = (known after apply)
      + created_at     = (known after apply)
      + crn            = (known after apply)
      + entity_tag     = (known after apply)
      + history        = (known after apply)
      + iam_id         = (known after apply)
      + id             = (known after apply)
      + ims_account_id = (known after apply)
      + ims_user_id    = (known after apply)
      + modified_at    = (known after apply)
      + name           = "newtrusted1"
      + profile_id     = (known after apply)
      + template_id    = (known after apply)
    }

  # ibm_iam_trusted_profile.iam_trusted_profile_instance2 will be created
  + resource "ibm_iam_trusted_profile" "iam_trusted_profile_instance2" {
      + account_id     = (known after apply)
      + assignment_id  = (known after apply)
      + created_at     = (known after apply)
      + crn            = (known after apply)
      + entity_tag     = (known after apply)
      + history        = (known after apply)
      + iam_id         = (known after apply)
      + id             = (known after apply)
      + ims_account_id = (known after apply)
      + ims_user_id    = (known after apply)
      + modified_at    = (known after apply)
      + name           = "newtrusted2"
      + profile_id     = (known after apply)
      + template_id    = (known after apply)
    }

  # ibm_iam_trusted_profile.iam_trusted_profile_instance3 will be created
  + resource "ibm_iam_trusted_profile" "iam_trusted_profile_instance3" {
      + account_id     = (known after apply)
      + assignment_id  = (known after apply)
      + created_at     = (known after apply)
      + crn            = (known after apply)
      + entity_tag     = (known after apply)
      + history        = (known after apply)
      + iam_id         = (known after apply)
      + id             = (known after apply)
      + ims_account_id = (known after apply)
      + ims_user_id    = (known after apply)
      + modified_at    = (known after apply)
      + name           = "newtrusted3"
      + profile_id     = (known after apply)
      + template_id    = (known after apply)
    }

  # ibm_iam_trusted_profile.iam_trusted_profile_instance4 will be created
  + resource "ibm_iam_trusted_profile" "iam_trusted_profile_instance4" {
      + account_id     = (known after apply)
      + assignment_id  = (known after apply)
      + created_at     = (known after apply)
      + crn            = (known after apply)
      + entity_tag     = (known after apply)
      + history        = (known after apply)
      + iam_id         = (known after apply)
      + id             = (known after apply)
      + ims_account_id = (known after apply)
      + ims_user_id    = (known after apply)
      + modified_at    = (known after apply)
      + name           = "newtrusted4"
      + profile_id     = (known after apply)
      + template_id    = (known after apply)
    }

  # ibm_iam_trusted_profile.iam_trusted_profile_instance5 will be created
  + resource "ibm_iam_trusted_profile" "iam_trusted_profile_instance5" {
      + account_id     = (known after apply)
      + assignment_id  = (known after apply)
      + created_at     = (known after apply)
      + crn            = (known after apply)
      + entity_tag     = (known after apply)
      + history        = (known after apply)
      + iam_id         = (known after apply)
      + id             = (known after apply)
      + ims_account_id = (known after apply)
      + ims_user_id    = (known after apply)
      + modified_at    = (known after apply)
      + name           = "newtrusted5"
      + profile_id     = (known after apply)
      + template_id    = (known after apply)
    }

  # ibm_resource_group.resourceGroup will be created
  + resource "ibm_resource_group" "resourceGroup" {
      + created_at          = (known after apply)
      + crn                 = (known after apply)
      + default             = (known after apply)
      + id                  = (known after apply)
      + name                = "mynewrs5"
      + payment_methods_url = (known after apply)
      + quota_id            = (known after apply)
      + quota_url           = (known after apply)
      + resource_linkages   = (known after apply)
      + state               = (known after apply)
      + teams_url           = (known after apply)
      + updated_at          = (known after apply)
    }

  # ibm_resource_group.resourceGroup1 will be created
  + resource "ibm_resource_group" "resourceGroup1" {
      + created_at          = (known after apply)
      + crn                 = (known after apply)
      + default             = (known after apply)
      + id                  = (known after apply)
      + name                = "mynewrs6"
      + payment_methods_url = (known after apply)
      + quota_id            = (known after apply)
      + quota_url           = (known after apply)
      + resource_linkages   = (known after apply)
      + state               = (known after apply)
      + teams_url           = (known after apply)
      + updated_at          = (known after apply)
    }

  # ibm_resource_group.resourceGroup2 will be created
  + resource "ibm_resource_group" "resourceGroup2" {
      + created_at          = (known after apply)
      + crn                 = (known after apply)
      + default             = (known after apply)
      + id                  = (known after apply)
      + name                = "mynewrs7"
      + payment_methods_url = (known after apply)
      + quota_id            = (known after apply)
      + quota_url           = (known after apply)
      + resource_linkages   = (known after apply)
      + state               = (known after apply)
      + teams_url           = (known after apply)
      + updated_at          = (known after apply)
    }

  # ibm_resource_group.resourceGroup3 will be created
  + resource "ibm_resource_group" "resourceGroup3" {
      + created_at          = (known after apply)
      + crn                 = (known after apply)
      + default             = (known after apply)
      + id                  = (known after apply)
      + name                = "mynewrs8"
      + payment_methods_url = (known after apply)
      + quota_id            = (known after apply)
      + quota_url           = (known after apply)
      + resource_linkages   = (known after apply)
      + state               = (known after apply)
      + teams_url           = (known after apply)
      + updated_at          = (known after apply)
    }

  # ibm_resource_group.resourceGroup4 will be created
  + resource "ibm_resource_group" "resourceGroup4" {
      + created_at          = (known after apply)
      + crn                 = (known after apply)
      + default             = (known after apply)
      + id                  = (known after apply)
      + name                = "mynewrs9"
      + payment_methods_url = (known after apply)
      + quota_id            = (known after apply)
      + quota_url           = (known after apply)
      + resource_linkages   = (known after apply)
      + state               = (known after apply)
      + teams_url           = (known after apply)
      + updated_at          = (known after apply)
    }

  # ibm_resource_group.resourceGroup5 will be created
  + resource "ibm_resource_group" "resourceGroup5" {
      + created_at          = (known after apply)
      + crn                 = (known after apply)
      + default             = (known after apply)
      + id                  = (known after apply)
      + name                = "mynewrs10"
      + payment_methods_url = (known after apply)
      + quota_id            = (known after apply)
      + quota_url           = (known after apply)
      + resource_linkages   = (known after apply)
      + state               = (known after apply)
      + teams_url           = (known after apply)
      + updated_at          = (known after apply)
    }

Plan: 12 to add, 0 to change, 0 to destroy.

Do you want to perform these actions?
  Terraform will perform the actions described above.
  Only 'yes' will be accepted to approve.

  Enter a value: yes

ibm_iam_trusted_profile.iam_trusted_profile_instance1: Creating...
ibm_iam_trusted_profile.iam_trusted_profile_instance: Creating...
ibm_iam_trusted_profile.iam_trusted_profile_instance2: Creating...
ibm_iam_trusted_profile.iam_trusted_profile_instance4: Creating...
ibm_resource_group.resourceGroup1: Creating...
ibm_resource_group.resourceGroup5: Creating...
ibm_resource_group.resourceGroup4: Creating...
ibm_resource_group.resourceGroup3: Creating...
ibm_iam_trusted_profile.iam_trusted_profile_instance5: Creating...
ibm_resource_group.resourceGroup: Creating...
ibm_iam_trusted_profile.iam_trusted_profile_instance2: Creation complete after 2s [id=Profile-2cbc7325-a9c1-4c83-a9af-016a76eebb5d]
ibm_resource_group.resourceGroup2: Creating...
ibm_resource_group.resourceGroup1: Creation complete after 2s [id=67d73710b66748cf85ecc3bcd738b3cc]
ibm_resource_group.resourceGroup3: Creation complete after 2s [id=b8ebc5e53ff94535b6697cf403f9e745]
ibm_iam_trusted_profile.iam_trusted_profile_instance3: Creating...
ibm_resource_group.resourceGroup: Creation complete after 2s [id=2e03fff99aa14770a58cdc4db7dca1a8]
ibm_resource_group.resourceGroup4: Creation complete after 2s [id=68967302204f46c98008cf5f757e1766]
ibm_iam_trusted_profile.iam_trusted_profile_instance1: Creation complete after 2s [id=Profile-d25d4f4c-5b97-4a60-ba1c-5a38db5931af]
ibm_iam_trusted_profile.iam_trusted_profile_instance: Creation complete after 2s [id=Profile-d1e7c895-cab2-4aba-baeb-cc3e39499edf]
ibm_iam_trusted_profile.iam_trusted_profile_instance4: Creation complete after 2s [id=Profile-97ba3dd5-b659-4f0c-beb7-bf5691b1e3ef]
ibm_iam_trusted_profile.iam_trusted_profile_instance5: Creation complete after 2s [id=Profile-69c1b5b0-db0d-47a9-bad6-75e1779e7ddd]
ibm_resource_group.resourceGroup5: Creation complete after 2s [id=3b08c53fb45c49faaba4a91f235319fc]
ibm_iam_trusted_profile.iam_trusted_profile_instance3: Creation complete after 2s [id=Profile-502208ad-d618-4114-8096-2d98e1ffb377]
ibm_resource_group.resourceGroup2: Creation complete after 2s [id=6c6cc2847aec40f3bd798969ca3248b0]

Apply complete! Resources: 12 added, 0 changed, 0 destroyed.
```