### PR TITLE
fix(is-image): fixed the access_tags set on is_image

### DIFF
--- a/ibm/service/vpc/resource_ibm_is_image.go
+++ b/ibm/service/vpc/resource_ibm_is_image.go
@@ -860,7 +860,7 @@ func imgGet(context context.Context, d *schema.ResourceData, meta interface{}, i
 		log.Printf(
 			"Error on get of resource vpc Image (%s) access tags: %s", d.Id(), err)
 	}
-	if err = d.Set("encryption", accesstags); err != nil {
+	if err = d.Set("access_tags", accesstags); err != nil {
 		err = fmt.Errorf("Error setting access_tags: %s", err)
 		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_is_image", "read", "set-access_tags").GetDiag()
 	}

--- a/ibm/service/vpc/resource_ibm_is_image_test.go
+++ b/ibm/service/vpc/resource_ibm_is_image_test.go
@@ -40,6 +40,46 @@ func TestAccIBMISImage_basic(t *testing.T) {
 		},
 	})
 }
+
+func TestAccIBMISImage_accessTags(t *testing.T) {
+	var image string
+	name := fmt.Sprintf("tfimg-access-tags-%d", acctest.RandIntRange(10, 100))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { acc.TestAccPreCheckImage(t) },
+		Providers:    acc.TestAccProviders,
+		CheckDestroy: checkImageDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckIBMISImageAccessTagsConfig(name),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckIBMISImageExists("ibm_is_image.isExampleImage", image),
+					resource.TestCheckResourceAttr("ibm_is_image.isExampleImage", "name", name),
+					resource.TestCheckResourceAttr("ibm_is_image.isExampleImage", "operating_system", acc.Image_operating_system),
+					resource.TestCheckResourceAttrSet("ibm_is_image.isExampleImage", "user_data_format"),
+					resource.TestCheckResourceAttrSet("ibm_is_image.isExampleImage", "status"),
+					resource.TestCheckResourceAttrSet("ibm_is_image.isExampleImage", "visibility"),
+
+					// Access tags validation
+					resource.TestCheckResourceAttr("ibm_is_image.isExampleImage", "access_tags.#", "1"),
+					resource.TestCheckResourceAttr("ibm_is_image.isExampleImage", "access_tags.0", "test:access"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckIBMISImageAccessTagsConfig(name string) string {
+	return fmt.Sprintf(`
+		resource "ibm_is_image" "isExampleImage" {
+			href             = "%s"
+			name             = "%s"
+			operating_system = "%s"
+			access_tags      = ["test:access"]
+		}
+	`, acc.Image_cos_url, name, acc.Image_operating_system)
+}
+
 func TestAccIBMISImage_lifecycle(t *testing.T) {
 	var image string
 	name := fmt.Sprintf("tfimg-name-%d", acctest.RandIntRange(10, 100))


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/IBM-Cloud/terraform-provider-ibm/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
TF_ACC=1 go test ./ibm/service/vpc -v -run=TestAccIBMISImage_accessTags -timeout 700m 
=== RUN   TestAccIBMISImage_accessTags
--- PASS: TestAccIBMISImage_accessTags (184.58s)
PASS
ok      github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/vpc     186.194s
```
