### PR TITLE
fix(fs-mount-target): fix setting accesscontrolmode on mount target

### DIFF
--- a/ibm/service/vpc/data_source_ibm_is_share_mount_target.go
+++ b/ibm/service/vpc/data_source_ibm_is_share_mount_target.go
@@ -339,9 +339,10 @@ func dataSourceIBMIsShareTargetRead(context context.Context, d *schema.ResourceD
 
 	d.SetId(fmt.Sprintf("%s/%s", share_id, *shareTarget.ID))
 	if shareTarget.AccessControlMode != nil {
-		d.Set("access_control_mode", *shareTarget.AccessControlMode)
-		err = fmt.Errorf("Error setting access_control_mode: %s", err)
-		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "(Data) ibm_is_share_mount_target", "read", "set-access_control_mode").GetDiag()
+		if err = d.Set("access_control_mode", *shareTarget.AccessControlMode); err != nil {
+			err = fmt.Errorf("Error setting access_control_mode: %s", err)
+			return flex.DiscriminatedTerraformErrorf(err, err.Error(), "(Data) ibm_is_share_mount_target", "read", "set-access_control_mode").GetDiag()
+		}
 	}
 	if err = d.Set("created_at", shareTarget.CreatedAt.String()); err != nil {
 		err = fmt.Errorf("Error setting created_at: %s", err)


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/IBM-Cloud/terraform-provider-ibm/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```
