### PR TITLE
fix alerts metadata_labels

### DIFF
--- a/ibm/service/logs/resource_ibm_logs_alert_test.go
+++ b/ibm/service/logs/resource_ibm_logs_alert_test.go
@@ -107,27 +107,34 @@ func testAccCheckIbmLogsAlertConfigBasic(name string, isActive string, severity 
 		is_active   = %s
 		severity    = "%s"
 		condition {
-		  new_value {
+			new_value {
 			parameters {
-			  threshold          = 1.0
-			  timeframe          = "timeframe_12_h"
-			  group_by           = ["ibm.logId"]
-			  relative_timeframe = "hour_or_unspecified"
-			  cardinality_fields = []
+				threshold          = 1.0
+				timeframe          = "timeframe_12_h"
+				group_by           = ["ibm.logId"]
+				relative_timeframe = "hour_or_unspecified"
+				cardinality_fields = []
 			}
-		  }
+			}
 		}
 		notification_groups {
-		  group_by_fields = ["ibm.logId"]
+			group_by_fields = ["ibm.logId"]
 		}
 		filters {
-		  text        = "text"
-		  filter_type = "text_or_unspecified"
+			text        = "text"
+			filter_type = "text_or_unspecified"
 		}
-		meta_labels_strings = []
+		meta_labels {
+			key   = "label1"
+			value = "value"
+		}
+		meta_labels {
+			key   = "label2"
+			value = "true"
+		}
 		incident_settings {
-		  retriggering_period_seconds = 43200
-		  notify_on                   = "triggered_only"
+			retriggering_period_seconds = 43200
+			notify_on                   = "triggered_only"
 		}
 	}
 `, acc.LogsInstanceId, acc.LogsInstanceRegion, name, isActive, severity)
@@ -144,24 +151,35 @@ func testAccCheckIbmLogsAlertConfig(name string, description string, isActive st
 		severity    = "%s"
 		condition {
 			new_value {
-			  parameters {
+			parameters {
 				threshold          = 1.0
 				timeframe          = "timeframe_12_h"
 				group_by           = ["ibm.logId"]
 				relative_timeframe = "hour_or_unspecified"
 				cardinality_fields = []
-			  }
 			}
-		  }
-		  notification_groups {
+			}
+		}
+		notification_groups {
 			group_by_fields = ["ibm.logId"]
-		  }
-		  filters {
+		}
+		filters {
 			text        = "text"
 			filter_type = "text_or_unspecified"
-		  }
-		  meta_labels_strings = []
-		  incident_settings {
+		}
+		meta_labels {
+			key   = "label1"
+			value = "value"
+		}
+		meta_labels {
+			key   = "label2"
+			value = "value"
+		}
+		meta_labels {
+			key   = "label3"
+			value = "value"
+		}
+		incident_settings {
 			retriggering_period_seconds = 43200
 			notify_on                   = "triggered_only"
 		}

--- a/website/docs/r/logs_alert.html.markdown
+++ b/website/docs/r/logs_alert.html.markdown
@@ -43,7 +43,10 @@ resource "ibm_logs_alert" "logs_alert_instance" {
     text        = "text"
     filter_type = "text_or_unspecified"
   }
-  meta_labels_strings = []
+  meta_labels {
+	key   = "key"
+	value = "value"
+  }
   incident_settings {
     retriggering_period_seconds = 43200
     notify_on                   = "triggered_only"
@@ -475,14 +478,15 @@ Nested schema for **incident_settings**:
 	  * Constraints: The maximum value is `4294967295`. 
 	* `use_as_notification_settings` - (Optional, Boolean) Use these settings for all notificaion webhook.
 * `is_active` - (Required, Boolean) Alert is active.
-* `meta_labels` - (Optional, List) The Meta labels to add to the alert.
+* `meta_labels` - (Optional, Set) The Meta labels to add to the alert.
   * Constraints: The maximum length is `200` items. The minimum length is `0` items.
 Nested schema for **meta_labels**:
 	* `key` - (Optional, String) The key of the label.
 	  * Constraints: The maximum length is `4096` characters. The minimum length is `1` character. The value must match regular expression `/^[\\p{L}\\p{N}\\p{P}\\p{Z}\\p{S}\\p{M}]+$/`.
 	* `value` - (Optional, String) The value of the label.
 	  * Constraints: The maximum length is `4096` characters. The minimum length is `1` character. The value must match regular expression `/^[\\p{L}\\p{N}\\p{P}\\p{Z}\\p{S}\\p{M}]+$/`.
-* `meta_labels_strings` - (Optional, List) The Meta labels to add to the alert as string with ':' separator.
+* `meta_labels_strings` - (Optional, List) The Meta labels to add to the alert as string with ':' separator. 
+	~> **NOTE** `meta_labels_strings` argument is deprecated. Kindly use `meta_labels` instead.
   * Constraints: The list items must match regular expression `/^[\\p{L}\\p{N}\\p{P}\\p{Z}\\p{S}\\p{M}]+$/`. The maximum length is `4096` items. The minimum length is `0` items.
 * `name` - (Required, String) Alert name.
   * Constraints: The maximum length is `4096` characters. The minimum length is `1` character. The value must match regular expression `/^[\\p{L}\\p{N}\\p{P}\\p{Z}\\p{S}\\p{M}]+$/`.


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/IBM-Cloud/terraform-provider-ibm/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates - https://github.ibm.com/Observability/dragonlog-cx/issues/1712

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
=== RUN   TestAccIbmLogsAlertBasic
--- PASS: TestAccIbmLogsAlertBasic (39.14s)
PASS
ok  	github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/logs	40.355s

...
```
