### PR TITLE
fix(is_vpc): added an empty check for dns binding id

### DIFF
--- a/ibm/service/vpc/resource_ibm_is_vpc.go
+++ b/ibm/service/vpc/resource_ibm_is_vpc.go
@@ -1458,7 +1458,7 @@ func vpcUpdate(context context.Context, d *schema.ResourceData, meta interface{}
 		}
 		if d.HasChange("dns.0.resolver") {
 			_, newResolver := d.GetChange("dns.0.resolver")
-			if d.HasChange("dns.0.resolver.0.dns_binding_name") && (d.Get("dns.0.resolver.0.dns_binding_name").(string) != "null" || d.Get("dns.0.resolver.0.dns_binding_name").(string) != "") {
+			if d.HasChange("dns.0.resolver.0.dns_binding_name") && (d.Get("dns.0.resolver.0.dns_binding_id") != nil && d.Get("dns.0.resolver.0.dns_binding_id").(string) != "") && (d.Get("dns.0.resolver.0.dns_binding_name").(string) != "null" || d.Get("dns.0.resolver.0.dns_binding_name").(string) != "") {
 				dnsBindingName := d.Get("dns.0.resolver.0.dns_binding_name").(string)
 				dnsBindingId := d.Get("dns.0.resolver.0.dns_binding_id").(string)
 				vpcdnsResolutionBindingPatch := &vpcv1.VpcdnsResolutionBindingPatch{


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/IBM-Cloud/terraform-provider-ibm/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #6313 

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
% make test-vpc TEST_NAME=TestAccIBMISVPC_DnsResolverUpdate
=== RUN   TestAccIBMISVPC_DnsResolverUpdate
--- PASS: TestAccIBMISVPC_DnsResolverUpdate (328.29s)
PASS
ok      github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/vpc     330.022s
```
