### PR TITLE
(DUX) [ICD-CLI] Bug: Terraform CLI create DB with non-existing region

### DIFF
--- a/ibm/provider/provider.go
+++ b/ibm/provider/provider.go
@@ -72,6 +72,18 @@ import (
 	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/validate"
 )
 
+var regionLocationMap = map[string]struct{}{
+	"au-syd":   {},
+	"ca-tor":   {},
+	"eu-de":    {},
+	"eu-gb":    {},
+	"jp-tok":   {},
+	"jp-osa":   {},
+	"us-east":  {},
+	"us-south": {},
+	"br-sao":   {},
+}
+
 // Provider returns a *schema.Provider.
 func Provider() *schema.Provider {
 	provider := schema.Provider{
@@ -2415,6 +2427,11 @@ func providerConfigure(d *schema.ResourceData) (interface{}, error) {
 	if err != nil {
 		return nil, err
 	}
+
+	if isRegionValid(region) == false {
+		return nil, fmt.Errorf("[ERROR] Provider region %q is not supported. Valid provider region(s) are: %q", region, getRegionNames())
+	}
+
 	// Set environment variable to be used in DiffSupressFunction
 	if wskEnvVal.(string) == "" {
 		os.Setenv("FUNCTION_NAMESPACE", wskNameSpace)
@@ -2443,4 +2460,17 @@ func providerConfigure(d *schema.ResourceData) (interface{}, error) {
 	}
 
 	return config.ClientSession()
+}
+
+func isRegionValid(region string) bool {
+	_, exists := regionLocationMap[region]
+	return exists
+}
+
+func getRegionNames() []string {
+	regions := make([]string, 0, len(regionLocationMap))
+	for region := range regionLocationMap {
+		regions = append(regions, region)
+	}
+	return regions
 }


### PR DESCRIPTION
Issue: https://github.ibm.com/compose/App/issues/2087

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```
