### PR TITLE
feat(identity): added trusted profile identities

### DIFF
--- a/examples/ibm-iam-identities/README.md
+++ b/examples/ibm-iam-identities/README.md
@@ -1,0 +1,85 @@
+# Examples for IAM Identity Services
+
+These examples illustrate how to use the resources and data sources associated with IAM Identity Services.
+
+The following resources are supported:
+* ibm_iam_trusted_profile_identities
+
+The following data sources are supported:
+* ibm_iam_trusted_profile_identities
+
+## Usage
+
+To run this example, execute the following commands:
+
+```bash
+$ terraform init
+$ terraform plan
+$ terraform apply
+```
+
+Run `terraform destroy` when you don't need these resources.
+
+## IAM Identity Services resources
+
+### Resource: ibm_iam_trusted_profile_identities
+
+```hcl
+resource "ibm_iam_trusted_profile_identities" "iam_trusted_profile_identities_instance" {
+  profile_id = var.iam_trusted_profile_identities_profile_id
+  if_match = var.iam_trusted_profile_identities_if_match
+  identities = var.iam_trusted_profile_identities_identities
+}
+```
+
+#### Inputs
+
+| Name | Description | Type | Required |
+|------|-------------|------|---------|
+| ibmcloud\_api\_key | IBM Cloud API key | `string` | true |
+| profile_id | ID of the trusted profile. | `string` | true |
+| if_match | Entity tag of the Identities to be updated. Specify the tag that you retrieved when reading the Profile Identities. This value helps identify parallel usage of this API. Pass * to indicate updating any available version, which may result in stale updates. | `string` | true |
+| identities | List of identities. | `list()` | false |
+
+## IAM Identity Services data sources
+
+### Data source: ibm_iam_trusted_profile_identities
+
+```hcl
+data "ibm_iam_trusted_profile_identities" "iam_trusted_profile_identities_instance" {
+  profile_id = var.data_iam_trusted_profile_identities_profile_id
+}
+```
+
+#### Inputs
+
+| Name | Description | Type | Required |
+|------|-------------|------|---------|
+| profile_id | ID of the trusted profile. | `string` | true |
+
+#### Outputs
+
+| Name | Description |
+|------|-------------|
+| entity_tag | Entity tag of the profile identities response. |
+| identities | List of identities. |
+
+## Assumptions
+
+1. TODO
+
+## Notes
+
+1. TODO
+
+## Requirements
+
+| Name | Version |
+|------|---------|
+| terraform | ~> 0.12 |
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| ibm | 1.13.1 |

--- a/examples/ibm-iam-identities/main.tf
+++ b/examples/ibm-iam-identities/main.tf
@@ -1,0 +1,25 @@
+provider "ibm" {
+  ibmcloud_api_key = var.ibmcloud_api_key
+}
+
+// Provision iam_trusted_profile_identities resource instance
+resource "ibm_iam_trusted_profile_identities" "iam_trusted_profile_identities_instance" {
+  profile_id = var.iam_trusted_profile_identities_profile_id
+
+  dynamic "identities" {
+    for_each = var.iam_trusted_profile_identities
+    content {
+      iam_id      = identities.value.iam_id
+      type        = identities.value.type
+      identifier  = identities.value.identifier
+      accounts    = identities.value.accounts
+      description = identities.value.description
+    }
+  }
+}
+
+// Create iam_trusted_profile_identities data source
+data "ibm_iam_trusted_profile_identities" "iam_trusted_profile_identities_instance" {
+  profile_id = var.iam_trusted_profile_identities_profile_id
+}
+

--- a/examples/ibm-iam-identities/outputs.tf
+++ b/examples/ibm-iam-identities/outputs.tf
@@ -1,0 +1,6 @@
+// This output allows iam_trusted_profile_identities data to be referenced by other resources and the terraform CLI
+// Modify this output if only certain data should be exposed
+output "ibm_iam_trusted_profile_identities" {
+  value       = ibm_iam_trusted_profile_identities.iam_trusted_profile_identities_instance
+  description = "iam_trusted_profile_identities resource instance"
+}

--- a/examples/ibm-iam-identities/variables.tf
+++ b/examples/ibm-iam-identities/variables.tf
@@ -1,0 +1,43 @@
+variable "ibmcloud_api_key" {
+  description = "IBM Cloud API key"
+  type        = string
+}
+
+// Resource arguments for iam_trusted_profile_identities
+variable "iam_trusted_profile_identities_profile_id" {
+  description = "ID of the trusted profile."
+  type        = string
+  default     = "profile_id"
+}
+variable "iam_trusted_profile_identities_if_match" {
+  description = "Entity tag of the Identities to be updated. Specify the tag that you retrieved when reading the Profile Identities. This value helps identify parallel usage of this API. Pass * to indicate updating any available version, which may result in stale updates."
+  type        = string
+  default     = "if_match"
+}
+variable "iam_trusted_profile_identities" {
+  description = "List of identities for the trusted profile."
+  type = list(object({
+    iam_id      = string
+    type        = string
+    identifier  = string
+    accounts    = list(string)
+    description = string
+  }))
+  default = [
+    {
+      iam_id      = "IBMid-5500082WK4"
+      type        = "user"
+      identifier  = "IBMid-5500082WK4"
+      accounts    = ["86a1004d3f1848a291de32874cb48120"]
+      description = "tf_description_profile identity description"
+    }
+  ]
+}
+
+// Data source arguments for iam_trusted_profile_identities
+variable "data_iam_trusted_profile_identities_profile_id" {
+  description = "ID of the trusted profile."
+  type        = string
+  default     = "profile_id"
+}
+

--- a/examples/ibm-iam-identities/versions.tf
+++ b/examples/ibm-iam-identities/versions.tf
@@ -1,0 +1,9 @@
+terraform {
+  required_version = ">= 1.0"
+  required_providers {
+    ibm = {
+      source = "IBM-Cloud/ibm"
+      version = "1.51.0"
+    }
+  }
+}

--- a/ibm/provider/provider.go
+++ b/ibm/provider/provider.go
@@ -1257,6 +1257,7 @@ func Provider() *schema.Provider {
 			"ibm_iam_api_key":                               iamidentity.ResourceIBMIAMApiKey(),
 			"ibm_iam_trusted_profile":                       iamidentity.ResourceIBMIAMTrustedProfile(),
 			"ibm_iam_trusted_profile_identity":              iamidentity.ResourceIBMIamTrustedProfileIdentity(),
+			"ibm_iam_trusted_profile_identities":            iamidentity.ResourceIBMIamTrustedProfileIdentities(),
 			"ibm_iam_trusted_profile_claim_rule":            iamidentity.ResourceIBMIAMTrustedProfileClaimRule(),
 			"ibm_iam_trusted_profile_link":                  iamidentity.ResourceIBMIAMTrustedProfileLink(),
 			"ibm_iam_trusted_profile_policy":                iampolicy.ResourceIBMIAMTrustedProfilePolicy(),

--- a/ibm/service/iamidentity/data_source_ibm_iam_trusted_profile_identities.go
+++ b/ibm/service/iamidentity/data_source_ibm_iam_trusted_profile_identities.go
@@ -1,5 +1,9 @@
-// Copyright IBM Corp. 2023 All Rights Reserved.
+// Copyright IBM Corp. 2025 All Rights Reserved.
 // Licensed under the Mozilla Public License v2.0
+
+/*
+ * IBM OpenAPI Terraform Generator Version: 3.103.0-e8b84313-20250402-201816
+ */
 
 package iamidentity
 
@@ -7,12 +11,13 @@ import (
 	"context"
 	"fmt"
 	"log"
-	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 
 	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/conns"
+	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/flex"
+	"github.com/IBM/go-sdk-core/v5/core"
 	"github.com/IBM/platform-services-go-sdk/iamidentityv1"
 )
 
@@ -75,57 +80,57 @@ func DataSourceIBMIamTrustedProfileIdentities() *schema.Resource {
 func dataSourceIBMIamTrustedProfileIdentitiesRead(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	iamIdentityClient, err := meta.(conns.ClientSession).IAMIdentityV1API()
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.DiscriminatedTerraformErrorf(err, err.Error(), "(Data) ibm_iam_trusted_profile_identities", "read", "initialize-client")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	getProfileIdentitiesOptions := &iamidentityv1.GetProfileIdentitiesOptions{}
 
 	getProfileIdentitiesOptions.SetProfileID(d.Get("profile_id").(string))
 
-	profileIdentitiesResponse, response, err := iamIdentityClient.GetProfileIdentitiesWithContext(context, getProfileIdentitiesOptions)
+	profileIdentitiesResponse, _, err := iamIdentityClient.GetProfileIdentitiesWithContext(context, getProfileIdentitiesOptions)
 	if err != nil {
-		log.Printf("[DEBUG] GetProfileIdentitiesWithContext failed %s\n%s", err, response)
-		return diag.FromErr(fmt.Errorf("GetProfileIdentitiesWithContext failed %s\n%s", err, response))
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("GetProfileIdentitiesWithContext failed: %s", err.Error()), "(Data) ibm_iam_trusted_profile_identities", "read")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
-	d.SetId(dataSourceIBMIamTrustedProfileIdentitiesID(d))
+	d.SetId(*getProfileIdentitiesOptions.ProfileID)
 
-	if err = d.Set("entity_tag", profileIdentitiesResponse.EntityTag); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting entity_tag: %s", err))
-	}
-
-	identities := []map[string]interface{}{}
-	if profileIdentitiesResponse.Identities != nil {
-		for _, modelItem := range profileIdentitiesResponse.Identities {
-			modelMap, err := dataSourceIBMIamTrustedProfileIdentitiesProfileIdentityResponseToMap(&modelItem)
-			if err != nil {
-				return diag.FromErr(err)
-			}
-			identities = append(identities, modelMap)
+	if !core.IsNil(profileIdentitiesResponse.EntityTag) {
+		if err = d.Set("entity_tag", profileIdentitiesResponse.EntityTag); err != nil {
+			return flex.DiscriminatedTerraformErrorf(err, fmt.Sprintf("Error setting entity_tag: %s", err), "(Data) ibm_iam_trusted_profile_identities", "read", "set-entity_tag").GetDiag()
 		}
 	}
-	if err = d.Set("identities", identities); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting identities %s", err))
+
+	if !core.IsNil(profileIdentitiesResponse.Identities) {
+		identities := []map[string]interface{}{}
+		for _, identitiesItem := range profileIdentitiesResponse.Identities {
+			identitiesItemMap, err := DataSourceIBMIamTrustedProfileIdentitiesProfileIdentityResponseToMap(&identitiesItem) // #nosec G601
+			if err != nil {
+				return flex.DiscriminatedTerraformErrorf(err, err.Error(), "(Data) ibm_iam_trusted_profile_identities", "read", "identities-to-map").GetDiag()
+			}
+			identities = append(identities, identitiesItemMap)
+		}
+		if err = d.Set("identities", identities); err != nil {
+			return flex.DiscriminatedTerraformErrorf(err, fmt.Sprintf("Error setting identities: %s", err), "(Data) ibm_iam_trusted_profile_identities", "read", "set-identities").GetDiag()
+		}
 	}
 
 	return nil
 }
 
-// dataSourceIBMIamTrustedProfileIdentitiesID returns a reasonable ID for the list.
-func dataSourceIBMIamTrustedProfileIdentitiesID(d *schema.ResourceData) string {
-	return time.Now().UTC().String()
-}
-
-func dataSourceIBMIamTrustedProfileIdentitiesProfileIdentityResponseToMap(model *iamidentityv1.ProfileIdentityResponse) (map[string]interface{}, error) {
+func DataSourceIBMIamTrustedProfileIdentitiesProfileIdentityResponseToMap(model *iamidentityv1.ProfileIdentityResponse) (map[string]interface{}, error) {
 	modelMap := make(map[string]interface{})
-	modelMap["iam_id"] = model.IamID
-	modelMap["identifier"] = model.Identifier
-	modelMap["type"] = model.Type
+	modelMap["iam_id"] = *model.IamID
+	modelMap["identifier"] = *model.Identifier
+	modelMap["type"] = *model.Type
 	if model.Accounts != nil {
 		modelMap["accounts"] = model.Accounts
 	}
 	if model.Description != nil {
-		modelMap["description"] = model.Description
+		modelMap["description"] = *model.Description
 	}
 	return modelMap, nil
 }

--- a/ibm/service/iamidentity/data_source_ibm_iam_trusted_profile_identities_test.go
+++ b/ibm/service/iamidentity/data_source_ibm_iam_trusted_profile_identities_test.go
@@ -1,5 +1,9 @@
-// Copyright IBM Corp. 2023 All Rights Reserved.
+// Copyright IBM Corp. 2025 All Rights Reserved.
 // Licensed under the Mozilla Public License v2.0
+
+/*
+ * IBM OpenAPI Terraform Generator Version: 3.103.0-e8b84313-20250402-201816
+ */
 
 package iamidentity_test
 
@@ -7,32 +11,78 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 
 	acc "github.com/IBM-Cloud/terraform-provider-ibm/ibm/acctest"
+	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/iamidentity"
+	"github.com/IBM/go-sdk-core/v5/core"
+	"github.com/IBM/platform-services-go-sdk/iamidentityv1"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestAccIBMIamTrustedProfileIdentitiesDataSourceBasic(t *testing.T) {
+	profileIdentitiesResponseProfileID := acc.IAMTrustedProfileID
+	profileIdentitiesResponseIfMatch := fmt.Sprintf("tf_if_match_%d", acctest.RandIntRange(10, 100))
+	ibmID1 := acc.Ibmid1
+
 	resource.Test(t, resource.TestCase{
 		PreCheck:  func() { acc.TestAccPreCheck(t) },
 		Providers: acc.TestAccProviders,
 		Steps: []resource.TestStep{
-			{
-				Config: testAccCheckIBMIamTrustedProfileIdentitiesDataSourceConfigBasic(),
+			resource.TestStep{
+				Config: func() string {
+					var _ string = profileIdentitiesResponseIfMatch
+					return testAccCheckIBMIamTrustedProfileIdentitiesDataSourceConfigBasic(profileIdentitiesResponseProfileID, ibmID1)
+				}(),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttrSet("data.ibm_iam_trusted_profile_identities.iam_trusted_profile_identities", "id"),
-					resource.TestCheckResourceAttrSet("data.ibm_iam_trusted_profile_identities.iam_trusted_profile_identities", "profile_id"),
+					resource.TestCheckResourceAttrSet("data.ibm_iam_trusted_profile_identities.iam_trusted_profile_identities_instance", "id"),
+					resource.TestCheckResourceAttrSet("data.ibm_iam_trusted_profile_identities.iam_trusted_profile_identities_instance", "profile_id"),
 				),
 			},
 		},
 	})
 }
 
-func testAccCheckIBMIamTrustedProfileIdentitiesDataSourceConfigBasic() string {
-	profileID := acc.IAMTrustedProfileID
+func testAccCheckIBMIamTrustedProfileIdentitiesDataSourceConfigBasic(profileIdentitiesResponseProfileID, ibmID1 string) string {
 	return fmt.Sprintf(`
-		data "ibm_iam_trusted_profile_identities" "iam_trusted_profile_identities" {
+		resource "ibm_iam_trusted_profile_identities" "iam_trusted_profile_identities_instance" {
 			profile_id = "%s"
+		  identities {
+		    iam_id     = "%s"
+			type       = "user"
+			identifier = "%s"
+			accounts = ["86a1004d3f1848a291de32874cb48120"]
+			description = "tf_description_profile identity description"
+			}
 		}
-	`, profileID)
+
+		data "ibm_iam_trusted_profile_identities" "iam_trusted_profile_identities_instance" {
+			profile_id = ibm_iam_trusted_profile_identities.iam_trusted_profile_identities_instance.profile_id
+		}
+	`, profileIdentitiesResponseProfileID, ibmID1, ibmID1)
+}
+
+func TestDataSourceIBMIamTrustedProfileIdentitiesProfileIdentityResponseToMap(t *testing.T) {
+	checkResult := func(result map[string]interface{}) {
+		model := make(map[string]interface{})
+		model["iam_id"] = "testString"
+		model["identifier"] = "testString"
+		model["type"] = "user"
+		model["accounts"] = []string{"testString"}
+		model["description"] = "testString"
+
+		assert.Equal(t, result, model)
+	}
+
+	model := new(iamidentityv1.ProfileIdentityResponse)
+	model.IamID = core.StringPtr("testString")
+	model.Identifier = core.StringPtr("testString")
+	model.Type = core.StringPtr("user")
+	model.Accounts = []string{"testString"}
+	model.Description = core.StringPtr("testString")
+
+	result, err := iamidentity.DataSourceIBMIamTrustedProfileIdentitiesProfileIdentityResponseToMap(model)
+	assert.Nil(t, err)
+	checkResult(result)
 }

--- a/ibm/service/iamidentity/resource_ibm_iam_trusted_profile_identities.go
+++ b/ibm/service/iamidentity/resource_ibm_iam_trusted_profile_identities.go
@@ -1,0 +1,258 @@
+// Copyright IBM Corp. 2025 All Rights Reserved.
+// Licensed under the Mozilla Public License v2.0
+
+/*
+ * IBM OpenAPI Terraform Generator Version: 3.103.0-e8b84313-20250402-201816
+ */
+
+package iamidentity
+
+import (
+	"context"
+	"fmt"
+	"log"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/conns"
+	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/flex"
+	"github.com/IBM/go-sdk-core/v5/core"
+	"github.com/IBM/platform-services-go-sdk/iamidentityv1"
+)
+
+func ResourceIBMIamTrustedProfileIdentities() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceIBMIamTrustedProfileIdentitiesCreate,
+		ReadContext:   resourceIBMIamTrustedProfileIdentitiesRead,
+		UpdateContext: resourceIBMIamTrustedProfileIdentitiesUpdate,
+		DeleteContext: resourceIBMIamTrustedProfileIdentitiesDelete,
+		Importer:      &schema.ResourceImporter{},
+
+		Schema: map[string]*schema.Schema{
+			"profile_id": &schema.Schema{
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: "ID of the trusted profile.",
+			},
+			"if_match": &schema.Schema{
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "Entity tag of the Identities to be updated. Specify the tag that you retrieved when reading the Profile Identities. This value helps identify parallel usage of this API. Pass * to indicate updating any available version, which may result in stale updates.",
+			},
+			"identities": &schema.Schema{
+				Type:        schema.TypeList,
+				Optional:    true,
+				Description: "List of identities.",
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"iam_id": &schema.Schema{
+							Type:        schema.TypeString,
+							Required:    true,
+							Description: "IAM ID of the identity.",
+						},
+						"identifier": &schema.Schema{
+							Type:        schema.TypeString,
+							Required:    true,
+							Description: "Identifier of the identity that can assume the trusted profiles. This can be a user identifier (IAM id), serviceid or crn. Internally it uses account id of the service id for the identifier 'serviceid' and for the identifier 'crn' it uses account id contained in the CRN.",
+						},
+						"type": &schema.Schema{
+							Type:        schema.TypeString,
+							Required:    true,
+							Description: "Type of the identity.",
+						},
+						"accounts": &schema.Schema{
+							Type:        schema.TypeList,
+							Optional:    true,
+							Description: "Only valid for the type user. Accounts from which a user can assume the trusted profile.",
+							Elem:        &schema.Schema{Type: schema.TypeString},
+						},
+						"description": &schema.Schema{
+							Type:        schema.TypeString,
+							Optional:    true,
+							Description: "Description of the identity that can assume the trusted profile. This is optional field for all the types of identities. When this field is not set for the identity type 'serviceid' then the description of the service id is used. Description is recommended for the identity type 'crn' E.g. 'Instance 1234 of IBM Cloud Service project'.",
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func resourceIBMIamTrustedProfileIdentitiesCreate(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	iamIdentityClient, err := meta.(conns.ClientSession).IAMIdentityV1API()
+	if err != nil {
+		tfErr := flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_iam_trusted_profile_identities", "delete", "initialize-client")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
+	}
+
+	setProfileIdentitiesOptions := &iamidentityv1.SetProfileIdentitiesOptions{}
+
+	setProfileIdentitiesOptions.SetProfileID(d.Get("profile_id").(string))
+	setProfileIdentitiesOptions.SetIfMatch("*")
+	if _, ok := d.GetOk("identities"); ok {
+		var identities []iamidentityv1.ProfileIdentityRequest
+		for _, v := range d.Get("identities").([]interface{}) {
+			value := v.(map[string]interface{})
+			identitiesItem, err := ResourceIBMIamTrustedProfileIdentitiesMapToProfileIdentityRequest(value)
+			if err != nil {
+				return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_iam_trusted_profile_identities", "delete", "parse-identities").GetDiag()
+			}
+			identities = append(identities, *identitiesItem)
+		}
+		setProfileIdentitiesOptions.SetIdentities(identities)
+	}
+
+	_, _, err = iamIdentityClient.SetProfileIdentitiesWithContext(context, setProfileIdentitiesOptions)
+	if err != nil {
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("SetProfileIdentitiesWithContext failed: %s", err.Error()), "ibm_iam_trusted_profile_identities", "create")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
+	}
+
+	d.SetId(*setProfileIdentitiesOptions.ProfileID)
+
+	return resourceIBMIamTrustedProfileIdentitiesRead(context, d, meta)
+}
+
+func resourceIBMIamTrustedProfileIdentitiesRead(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	iamIdentityClient, err := meta.(conns.ClientSession).IAMIdentityV1API()
+	if err != nil {
+		tfErr := flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_iam_trusted_profile_identities", "read", "initialize-client")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
+	}
+
+	getProfileIdentitiesOptions := &iamidentityv1.GetProfileIdentitiesOptions{}
+
+	getProfileIdentitiesOptions.SetProfileID(d.Id())
+
+	profileIdentitiesResponse, response, err := iamIdentityClient.GetProfileIdentitiesWithContext(context, getProfileIdentitiesOptions)
+	if err != nil {
+		if response != nil && response.StatusCode == 404 {
+			d.SetId("")
+			return nil
+		}
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("GetProfileIdentitiesWithContext failed: %s", err.Error()), "ibm_iam_trusted_profile_identities", "read")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
+	}
+	if err := d.Set("profile_id", d.Id()); err != nil {
+		return diag.FromErr(fmt.Errorf("Error setting profile_id: %s", err))
+	}
+	if !core.IsNil(profileIdentitiesResponse.Identities) {
+		identities := []map[string]interface{}{}
+		for _, identitiesItem := range profileIdentitiesResponse.Identities {
+			identitiesItemMap, err := ResourceIBMIamTrustedProfileIdentitiesProfileIdentityResponseToMap(&identitiesItem) // #nosec G601
+			if err != nil {
+				return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_iam_trusted_profile_identities", "read", "identities-to-map").GetDiag()
+			}
+			identities = append(identities, identitiesItemMap)
+		}
+		if err = d.Set("identities", identities); err != nil {
+			err = fmt.Errorf("Error setting identities: %s", err)
+			return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_iam_trusted_profile_identities", "read", "set-identities").GetDiag()
+		}
+
+	} else {
+		// Always set an empty list if no identities
+		if err = d.Set("identities", []map[string]interface{}{}); err != nil {
+			err = fmt.Errorf("Error setting identities: %s", err)
+			return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_iam_trusted_profile_identities", "read", "set-identities").GetDiag()
+		}
+	}
+	if err = d.Set("if_match", response.Headers.Get("ETag")); err != nil {
+		return diag.FromErr(flex.FmtErrorf("Error setting etag: %s", err))
+	}
+
+	return nil
+}
+
+func resourceIBMIamTrustedProfileIdentitiesUpdate(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	iamIdentityClient, err := meta.(conns.ClientSession).IAMIdentityV1API()
+	if err != nil {
+		tfErr := flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_iam_trusted_profile_identities", "delete", "initialize-client")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
+	}
+
+	setProfileIdentitiesOptions := &iamidentityv1.SetProfileIdentitiesOptions{}
+
+	setProfileIdentitiesOptions.SetProfileID(d.Get("profile_id").(string))
+	setProfileIdentitiesOptions.SetIfMatch(d.Get("if_match").(string))
+	var identities []iamidentityv1.ProfileIdentityRequest
+	setProfileIdentitiesOptions.SetIdentities(identities)
+
+	_, _, err = iamIdentityClient.SetProfileIdentitiesWithContext(context, setProfileIdentitiesOptions)
+	if err != nil {
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("SetProfileIdentitiesWithContext failed: %s", err.Error()), "ibm_iam_trusted_profile_identities", "update")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
+	}
+
+	d.SetId(fmt.Sprintf("%s", *setProfileIdentitiesOptions.ProfileID))
+
+	return resourceIBMIamTrustedProfileIdentitiesRead(context, d, meta)
+}
+
+func resourceIBMIamTrustedProfileIdentitiesDelete(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	iamIdentityClient, err := meta.(conns.ClientSession).IAMIdentityV1API()
+	if err != nil {
+		tfErr := flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_iam_trusted_profile_identities", "delete", "initialize-client")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
+	}
+
+	setProfileIdentitiesOptions := &iamidentityv1.SetProfileIdentitiesOptions{}
+	setProfileIdentitiesOptions.SetIfMatch(d.Get("if_match").(string))
+	setProfileIdentitiesOptions.SetIdentities([]iamidentityv1.ProfileIdentityRequest{})
+
+	// This is a workaround to delete all identities from the profile
+	// as the SetProfileIdentities API does not support deleting identities directly.
+	// Instead, we set an empty list of identities to remove all existing identities.
+	setProfileIdentitiesOptions.SetProfileID(d.Id())
+
+	_, _, err = iamIdentityClient.SetProfileIdentitiesWithContext(context, setProfileIdentitiesOptions)
+	if err != nil {
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("SetProfileIdentitiesWithContext failed: %s", err.Error()), "ibm_iam_trusted_profile_identities", "delete")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
+	}
+
+	d.SetId("")
+
+	return nil
+}
+
+func ResourceIBMIamTrustedProfileIdentitiesMapToProfileIdentityRequest(modelMap map[string]interface{}) (*iamidentityv1.ProfileIdentityRequest, error) {
+	model := &iamidentityv1.ProfileIdentityRequest{}
+	model.Identifier = core.StringPtr(modelMap["identifier"].(string))
+	model.Type = core.StringPtr(modelMap["type"].(string))
+	if modelMap["accounts"] != nil {
+		accounts := []string{}
+		for _, accountsItem := range modelMap["accounts"].([]interface{}) {
+			accounts = append(accounts, accountsItem.(string))
+		}
+		model.Accounts = accounts
+	}
+	if modelMap["description"] != nil && modelMap["description"].(string) != "" {
+		model.Description = core.StringPtr(modelMap["description"].(string))
+	}
+	return model, nil
+}
+
+func ResourceIBMIamTrustedProfileIdentitiesProfileIdentityResponseToMap(model *iamidentityv1.ProfileIdentityResponse) (map[string]interface{}, error) {
+	modelMap := make(map[string]interface{})
+	modelMap["iam_id"] = *model.IamID
+	modelMap["identifier"] = *model.Identifier
+	modelMap["type"] = *model.Type
+	if model.Accounts != nil {
+		modelMap["accounts"] = model.Accounts
+	}
+	if model.Description != nil {
+		modelMap["description"] = *model.Description
+	}
+	return modelMap, nil
+}

--- a/ibm/service/iamidentity/resource_ibm_iam_trusted_profile_identities_test.go
+++ b/ibm/service/iamidentity/resource_ibm_iam_trusted_profile_identities_test.go
@@ -1,0 +1,179 @@
+// Copyright IBM Corp. 2025 All Rights Reserved.
+// Licensed under the Mozilla Public License v2.0
+
+package iamidentity_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/stretchr/testify/assert"
+
+	acc "github.com/IBM-Cloud/terraform-provider-ibm/ibm/acctest"
+	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/conns"
+	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/iamidentity"
+	"github.com/IBM/go-sdk-core/v5/core"
+	"github.com/IBM/platform-services-go-sdk/iamidentityv1"
+)
+
+func TestAccIBMIamTrustedProfileIdentitiesBasic(t *testing.T) {
+	var conf iamidentityv1.ProfileIdentitiesResponse
+	profileID := acc.IAMTrustedProfileID
+	ibmID1 := acc.Ibmid1
+	ibmID2 := acc.Ibmid2
+	identities := []map[string]interface{}{
+		{
+			"identity_type": "user",
+			"identifier":    acc.Ibmid2,
+			"type":          "user",
+			"description":   fmt.Sprintf("tf_description_%s", "profile identity description"),
+		},
+	}
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { acc.TestAccPreCheck(t) },
+		Providers:    acc.TestAccProviders,
+		CheckDestroy: testAccCheckIBMIamTrustedProfileIdentitiesDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccCheckIBMIamTrustedProfileIdentitiesConfigBasic(profileID, ibmID1, ibmID2),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckIBMIamTrustedProfileIdentitiesExists("ibm_iam_trusted_profile_identities.iam_trusted_profile_identities", conf),
+					resource.TestCheckResourceAttr("ibm_iam_trusted_profile_identities.iam_trusted_profile_identities", "profile_id", profileID),
+				),
+			},
+			resource.TestStep{
+				Config: testAccCheckIBMIamTrustedProfileIdentitiesConfigBasic(profileID, ibmID1, ibmID2),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("ibm_iam_trusted_profile_identities.iam_trusted_profile_identities", "profile_id", profileID),
+					resource.TestCheckResourceAttr("ibm_iam_trusted_profile_identities.iam_trusted_profile_identities", "identities.0.type", identities[0]["type"].(string)),
+				),
+			},
+			resource.TestStep{
+				ResourceName:      "ibm_iam_trusted_profile_identities.iam_trusted_profile_identities",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testAccCheckIBMIamTrustedProfileIdentitiesConfigBasic(profileID string, ibmID1 string, ibmID2 string) string {
+	return fmt.Sprintf(`
+		resource "ibm_iam_trusted_profile_identities" "iam_trusted_profile_identities" {
+          profile_id = "%s"
+		  identities {
+		    iam_id     = "%s"
+			type       = "user"
+			identifier = "%s"
+			accounts = ["86a1004d3f1848a291de32874cb48120"]
+			description = "tf_description_profile identity description"
+			}
+			identities {
+		    iam_id     = "%s"
+			type       = "user"
+			identifier = "%s"
+			accounts = ["86a1004d3f1848a291de32874cb48120"]
+			description = "tf_description_profile identity description"
+            }
+		}
+	`, profileID, ibmID1, ibmID1, ibmID2, ibmID2)
+}
+
+func testAccCheckIBMIamTrustedProfileIdentitiesExists(n string, obj iamidentityv1.ProfileIdentitiesResponse) resource.TestCheckFunc {
+
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+
+		iamIdentityClient, err := acc.TestAccProvider.Meta().(conns.ClientSession).IAMIdentityV1API()
+		if err != nil {
+			return err
+		}
+
+		getProfileIdentitiesOptions := &iamidentityv1.GetProfileIdentitiesOptions{}
+
+		getProfileIdentitiesOptions.SetProfileID(rs.Primary.ID)
+
+		profileIdentitiesResponse, _, err := iamIdentityClient.GetProfileIdentities(getProfileIdentitiesOptions)
+		if err != nil {
+			return err
+		}
+
+		obj = *profileIdentitiesResponse
+		return nil
+	}
+}
+
+func testAccCheckIBMIamTrustedProfileIdentitiesDestroy(s *terraform.State) error {
+	iamIdentityClient, err := acc.TestAccProvider.Meta().(conns.ClientSession).IAMIdentityV1API()
+	if err != nil {
+		return err
+	}
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "ibm_iam_trusted_profile_identities" {
+			continue
+		}
+
+		getProfileIdentitiesOptions := &iamidentityv1.GetProfileIdentitiesOptions{}
+		getProfileIdentitiesOptions.SetProfileID(rs.Primary.ID)
+
+		resp, _, err := iamIdentityClient.GetProfileIdentities(getProfileIdentitiesOptions)
+		if err != nil {
+			return err
+		}
+		if len(resp.Identities) > 0 {
+			return fmt.Errorf("iam_trusted_profile_identities still exist for profile: %s", rs.Primary.ID)
+		}
+	}
+	return nil
+}
+
+func TestResourceIBMIamTrustedProfileIdentitiesProfileIdentityResponseToMap(t *testing.T) {
+	checkResult := func(result map[string]interface{}) {
+		model := make(map[string]interface{})
+		model["iam_id"] = "testString"
+		model["identifier"] = "testString"
+		model["type"] = "user"
+		model["accounts"] = []string{"testString"}
+		model["description"] = "testString"
+
+		assert.Equal(t, result, model)
+	}
+
+	model := new(iamidentityv1.ProfileIdentityResponse)
+	model.IamID = core.StringPtr("testString")
+	model.Identifier = core.StringPtr("testString")
+	model.Type = core.StringPtr("user")
+	model.Accounts = []string{"testString"}
+	model.Description = core.StringPtr("testString")
+
+	result, err := iamidentity.ResourceIBMIamTrustedProfileIdentitiesProfileIdentityResponseToMap(model)
+	assert.Nil(t, err)
+	checkResult(result)
+}
+
+func TestResourceIBMIamTrustedProfileIdentitiesMapToProfileIdentityRequest(t *testing.T) {
+	checkResult := func(result *iamidentityv1.ProfileIdentityRequest) {
+		model := new(iamidentityv1.ProfileIdentityRequest)
+		model.Identifier = core.StringPtr("testString")
+		model.Type = core.StringPtr("user")
+		model.Accounts = []string{"testString"}
+		model.Description = core.StringPtr("testString")
+
+		assert.Equal(t, result, model)
+	}
+
+	model := make(map[string]interface{})
+	model["identifier"] = "testString"
+	model["type"] = "user"
+	model["accounts"] = []interface{}{"testString"}
+	model["description"] = "testString"
+
+	result, err := iamidentity.ResourceIBMIamTrustedProfileIdentitiesMapToProfileIdentityRequest(model)
+	assert.Nil(t, err)
+	checkResult(result)
+}

--- a/website/docs/d/iam_trusted_profile_identities.html.markdown
+++ b/website/docs/d/iam_trusted_profile_identities.html.markdown
@@ -8,37 +8,30 @@ subcategory: "IAM Identity Services"
 
 # ibm_iam_trusted_profile_identities
 
-Provides a read-only data source for iam_trusted_profile_identities. You can then reference the fields of the data source in other resources within the same configuration using interpolation syntax.
+Provides a read-only data source to retrieve information about iam_trusted_profile_identities. You can then reference the fields of the data source in other resources within the same configuration by using interpolation syntax.
 
 ## Example Usage
 
-```terraform
-resource "ibm_iam_trusted_profile" "iam_trusted_profile" {
-  name = "test"
-}
-
-
+```hcl
 data "ibm_iam_trusted_profile_identities" "iam_trusted_profile_identities" {
-	profile_id = ibm_iam_trusted_profile.iam_trusted_profile.id
+	profile_id = ibm_iam_trusted_profile_identities.iam_trusted_profile_identities_instance.profile_id
 }
 ```
 
 ## Argument Reference
 
-Review the argument reference that you can specify for your data source.
+You can specify the following arguments for this data source.
 
-* `profile_id` - (Required, String) ID of the trusted profile.
+* `profile_id` - (Required, Forces new resource, String) ID of the trusted profile.
 
 ## Attribute Reference
 
-In addition to all argument references listed, you can access the following attribute references after your data source is created.
+After your data source is created, you can read values from the following attributes.
 
 * `id` - The unique identifier of the iam_trusted_profile_identities.
-
 * `entity_tag` - (String) Entity tag of the profile identities response.
-
 * `identities` - (List) List of identities.
-Nested scheme for **identities**:
+Nested schema for **identities**:
 	* `accounts` - (List) Only valid for the type user. Accounts from which a user can assume the trusted profile.
 	* `description` - (String) Description of the identity that can assume the trusted profile. This is optional field for all the types of identities. When this field is not set for the identity type 'serviceid' then the description of the service id is used. Description is recommended for the identity type 'crn' E.g. 'Instance 1234 of IBM Cloud Service project'.
 	* `iam_id` - (String) IAM ID of the identity.

--- a/website/docs/r/iam_trusted_profile_identities.html.markdown
+++ b/website/docs/r/iam_trusted_profile_identities.html.markdown
@@ -1,0 +1,56 @@
+---
+layout: "ibm"
+page_title: "IBM : ibm_iam_trusted_profile_identities"
+description: |-
+  Manages iam_trusted_profile_identities.
+subcategory: "IAM Identity Services"
+---
+
+# ibm_iam_trusted_profile_identities
+
+Create, update, and delete iam_trusted_profile_identitiess with this resource.
+
+## Example Usage
+
+```hcl
+resource "ibm_iam_trusted_profile_identities" "iam_trusted_profile_identities_instance" {
+  identities {
+		iam_id = "iam_id"
+		identifier = "identifier"
+		type = "user"
+		accounts = [ "accounts" ]
+		description = "description"
+  }
+  profile_id = "profile_id"
+}
+```
+
+## Argument Reference
+
+You can specify the following arguments for this resource.
+
+* `identities` - (Optional, List) List of identities.
+Nested schema for **identities**:
+	* `accounts` - (Optional, List) Only valid for the type user. Accounts from which a user can assume the trusted profile.
+	* `description` - (Optional, String) Description of the identity that can assume the trusted profile. This is optional field for all the types of identities. When this field is not set for the identity type 'serviceid' then the description of the service id is used. Description is recommended for the identity type 'crn' E.g. 'Instance 1234 of IBM Cloud Service project'.
+	* `iam_id` - (Required, String) IAM ID of the identity.
+	* `identifier` - (Required, String) Identifier of the identity that can assume the trusted profiles. This can be a user identifier (IAM id), serviceid or crn. Internally it uses account id of the service id for the identifier 'serviceid' and for the identifier 'crn' it uses account id contained in the CRN.
+	* `type` - (Required, String) Type of the identity.
+	  * Constraints: Allowable values are: `user`, `serviceid`, `crn`.
+* `profile_id` - (Required, Forces new resource, String) ID of the trusted profile.
+
+## Attribute Reference
+
+After your resource is created, you can read values from the listed arguments and the following attributes.
+
+* `id` - The unique identifier of the iam_trusted_profile_identities.
+
+
+## Import
+
+You can import the `ibm_iam_trusted_profile_identities` resource by using `profile_id`. Profile id of the profile identities response.
+
+# Syntax
+<pre>
+$ terraform import ibm_iam_trusted_profile_identities.iam_trusted_profile_identities &lt;profile-id&gt;
+</pre>


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/IBM-Cloud/terraform-provider-ibm/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccXXX'

=== RUN   TestAccIBMIamTrustedProfileIdentitiesBasic
--- PASS: TestAccIBMIamTrustedProfileIdentitiesBasic (70.48s)
PASS
ok  	github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/iamidentity	85.655s
.
.
.
=== RUN   TestAccIBMIamTrustedProfileIdentitiesDataSourceBasic
--- PASS: TestAccIBMIamTrustedProfileIdentitiesDataSourceBasic (59.46s)
PASS
ok  	github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/iamidentity	76.605s

...
```
