### PR TITLE
Deprecate vpn resources

### DIFF
--- a/ibm/service/power/resource_ibm_pi_ike_policy.go
+++ b/ibm/service/power/resource_ibm_pi_ike_policy.go
@@ -95,6 +95,7 @@ func ResourceIBMPIIKEPolicy() *schema.Resource {
 				Description: "IKE Policy ID",
 			},
 		},
+		DeprecationMessage: "Resource ibm_pi_ike_policy is deprecated. VPN has reached end of life.",
 	}
 }
 

--- a/ibm/service/power/resource_ibm_pi_ipsec_policy.go
+++ b/ibm/service/power/resource_ibm_pi_ipsec_policy.go
@@ -85,6 +85,7 @@ func ResourceIBMPIIPSecPolicy() *schema.Resource {
 				Description: "IPSec policy ID",
 			},
 		},
+		DeprecationMessage: "Resource ibm_pi_ipsec_policy is deprecated. VPN has reached end of life.",
 	}
 }
 

--- a/ibm/service/power/resource_ibm_pi_vpn_connection.go
+++ b/ibm/service/power/resource_ibm_pi_vpn_connection.go
@@ -111,6 +111,7 @@ func ResourceIBMPIVPNConnection() *schema.Resource {
 				Description: "Dead Peer Detection",
 			},
 		},
+		DeprecationMessage: "Resource ibm_pi_vpn_connection is deprecated. VPN has reached end of life.",
 	}
 }
 

--- a/website/docs/r/pi_vpn_connection.html.markdown
+++ b/website/docs/r/pi_vpn_connection.html.markdown
@@ -8,34 +8,39 @@ description: |-
 ---
 
 # ibm_pi_vpn_connection
+
+~> This resource is deprecated and will be removed in the next major version. This resource has reached end of life.
+
 Update or delete a VPN connection. For more information, about IBM power virtual server cloud, see [getting started with IBM Power Systems Virtual Servers](https://cloud.ibm.com/docs/power-iaas?topic=power-iaas-getting-started).
 
 ~> **Deprecated:**
   Create VPN connection is deprecated and no longer supported. Existing `pi_vpn_connection` will still have support for `update` and `delete`. See [a new method for creating a VPN connection](https://cloud.ibm.com/docs/power-iaas?topic=power-iaas-VPN-connections)
   
-## Example usage
+## Example Usage
+
 The following example creates a VPN Connection.
 
 ```terraform
-	resource "ibm_pi_vpn_connection" "example" {
-		pi_cloud_instance_id    = "<value of the cloud_instance_id>"
-		pi_vpn_connection_name  = "test"
-		pi_ike_policy_id        = ibm_pi_ike_policy.policy.policy_id
-		pi_ipsec_policy_id      = ibm_pi_ipsec_policy.policy.policy_id
-		pi_vpn_connection_mode  = "policy"
-		pi_networks             = [ibm_pi_network.private_network1.network_id]
-		pi_peer_gateway_address = "1.22.124.1"
-		pi_peer_subnets         = ["107.0.0.0/24"]
-	}
+  resource "ibm_pi_vpn_connection" "example" {
+    pi_cloud_instance_id    = "<value of the cloud_instance_id>"
+    pi_vpn_connection_name  = "test"
+    pi_ike_policy_id        = ibm_pi_ike_policy.policy.policy_id
+    pi_ipsec_policy_id      = ibm_pi_ipsec_policy.policy.policy_id
+    pi_vpn_connection_mode  = "policy"
+    pi_networks             = [ibm_pi_network.private_network1.network_id]
+    pi_peer_gateway_address = "1.22.124.1"
+    pi_peer_subnets         = ["107.0.0.0/24"]
+  }
 ```
 
-**Note**
-* Please find [supported Regions](https://cloud.ibm.com/apidocs/power-cloud#endpoint) for endpoints.
-* If a Power cloud instance is provisioned at `lon04`, The provider level attributes should be as follows:
-  * `region` - `lon`
-  * `zone` - `lon04`
+### Notes
 
-  Example usage:
+- Please find [supported Regions](https://cloud.ibm.com/apidocs/power-cloud#endpoint) for endpoints.
+- If a Power cloud instance is provisioned at `lon04`, The provider level attributes should be as follows:
+  - `region` - `lon`
+  - `zone` - `lon04`
+
+Example usage:
   
   ```terraform
     provider "ibm" {
@@ -48,12 +53,13 @@ The following example creates a VPN Connection.
 
 ibm_pi_vpn_connection provides the following [timeouts](https://www.terraform.io/docs/language/resources/syntax.html) configuration options:
 
-
 - **update** - (Default 20 minutes) Used for updating VPN connection.
 - **delete** - (Default 20 minutes) Used for deleting VPN connection.
 
-## Argument reference 
-Review the argument references that you can specify for your resource. 
+## Argument Reference
+
+Review the argument references that you can specify for your resource.
+
 - `pi_cloud_instance_id` - (Required, String) The GUID of the service instance associated with an account.
 - `pi_ike_policy_id` - (Required, String) Unique identifier of IKE Policy selected for this VPN Connection.
 - `pi_ipsec_policy_id`- (Required, String) Unique identifier of IPSec Policy selected for this VPN Connection.
@@ -63,7 +69,8 @@ Review the argument references that you can specify for your resource.
 - `pi_vpn_connection_mode` - (Required, String) Mode used by this VPN Connection, either `policy` or `route`.
 - `pi_vpn_connection_name` - (Required, String) Name of the VPN Connection.
 
-## Attribute reference
+## Attribute Reference
+
 In addition to all argument reference list, you can access the following attribute reference after your resource is created.
 
 - `id` - (String) The unique identifier of the VPN Connection. The ID is composed of `<power_instance_id>/<vpn_connection_id>`.
@@ -78,13 +85,12 @@ In addition to all argument reference list, you can access the following attribu
 - `gateway_address` - (String) Public IP address of the VPN Gateway (vSRX) attached to this VPN Connection.
 - `local_gateway_address` - (String) Local Gateway address, only in `route` mode.
 
-
 ## Import
 
 The `ibm_pi_vpn_connection` resource can be imported by using `power_instance_id` and `vpn_connection_id`.
 
-**Example**
+### Example
 
-```
-$ terraform import ibm_pi_vpn_connection.example d7bec597-4726-451f-8a63-e62e6f19c32c/cea6651a-bc0a-4438-9f8a-a0770bbf451f
+```bash
+terraform import ibm_pi_vpn_connection.example d7bec597-4726-451f-8a63-e62e6f19c32c/cea6651a-bc0a-4438-9f8a-a0770bbf451f
 ```

--- a/website/docs/r/pi_vpn_ike_policy.html.markdown
+++ b/website/docs/r/pi_vpn_ike_policy.html.markdown
@@ -8,31 +8,36 @@ description: |-
 ---
 
 # ibm_pi_ike_policy
+
+~> This resource is deprecated and will be removed in the next major version. This resource has reached end of life.
+
 Create, update, or delete a IKE Policy. For more information, about IBM power virtual server cloud, see [getting started with IBM Power Systems Virtual Servers](https://cloud.ibm.com/docs/power-iaas?topic=power-iaas-getting-started).
 
-## Example usage
+## Example Usage
+
 The following example creates a IKE Policy.
 
 ```terraform
-	resource "ibm_pi_ike_policy" "example" {
-		pi_cloud_instance_id    = "<value of the cloud_instance_id>"
-		pi_policy_name          = "test"
-		pi_policy_dh_group = 1
-		pi_policy_encryption = "aes-256-cbc"
-		pi_policy_key_lifetime = 28800
-		pi_policy_preshared_key = "sample"
-		pi_policy_version = 1
-		pi_policy_authentication = "sha1"
-	}
+  resource "ibm_pi_ike_policy" "example" {
+    pi_cloud_instance_id    = "<value of the cloud_instance_id>"
+    pi_policy_name          = "test"
+    pi_policy_dh_group = 1
+    pi_policy_encryption = "aes-256-cbc"
+    pi_policy_key_lifetime = 28800
+    pi_policy_preshared_key = "sample"
+    pi_policy_version = 1
+    pi_policy_authentication = "sha1"
+  }
 ```
 
-**Note**
-* Please find [supported Regions](https://cloud.ibm.com/apidocs/power-cloud#endpoint) for endpoints.
-* If a Power cloud instance is provisioned at `lon04`, The provider level attributes should be as follows:
-  * `region` - `lon`
-  * `zone` - `lon04`
+### Notes
 
-  Example usage:
+- Please find [supported Regions](https://cloud.ibm.com/apidocs/power-cloud#endpoint) for endpoints.
+- If a Power cloud instance is provisioned at `lon04`, The provider level attributes should be as follows:
+  - `region` - `lon`
+  - `zone` - `lon04`
+
+Example usage:
   
   ```terraform
     provider "ibm" {
@@ -49,8 +54,10 @@ ibm_pi_ike_policy provides the following [timeouts](https://www.terraform.io/doc
 - **update** - (Default 10 minutes) Used for updating IKE Policy.
 - **delete** - (Default 10 minutes) Used for deleting IKE Policy.
 
-## Argument reference 
-Review the argument references that you can specify for your resource. 
+## Argument Reference
+
+Review the argument references that you can specify for your resource.
+
 - `pi_cloud_instance_id` - (Required, String) The GUID of the service instance associated with an account.
 - `pi_policy_authentication`  - (Optional, String) Authentication for the IKE Policy. Supported values are `none`(Default), `sha-256`, `sha-384`, `sha1`.
 - `pi_policy_dh_group` - (Required, Integer) DH group of the IKE Policy. Supported values are `1`,`2`,`5`,`14`,`19`,`20`,`24`.
@@ -60,7 +67,8 @@ Review the argument references that you can specify for your resource.
 - `pi_policy_preshared_key` - (Required, String) Preshared key used in this IKE Policy (length of preshared key must be even).
 - `pi_policy_version` - (Required, Integer) Version of the IKE Policy. Supported values are `1`,`2`.
 
-## Attribute reference
+## Attribute Reference
+
 In addition to all argument reference list, you can access the following attribute reference after your resource is created.
 
 - `id` - (String) The unique identifier of the IKE Policy. The ID is composed of `<power_instance_id>/<policy_id>`.
@@ -70,8 +78,8 @@ In addition to all argument reference list, you can access the following attribu
 
 The `ibm_pi_ike_policy` resource can be imported by using `power_instance_id` and `policy_id`.
 
-**Example**
+### Example
 
-```
-$ terraform import ibm_pi_ike_policy.example d7bec597-4726-451f-8a63-e62e6f19c32c/cea6651a-bc0a-4438-9f8a-a0770bbf451f
+```bash
+terraform import ibm_pi_ike_policy.example d7bec597-4726-451f-8a63-e62e6f19c32c/cea6651a-bc0a-4438-9f8a-a0770bbf451f
 ```

--- a/website/docs/r/pi_vpn_ipsec_policy.html.markdown
+++ b/website/docs/r/pi_vpn_ipsec_policy.html.markdown
@@ -8,30 +8,35 @@ description: |-
 ---
 
 # ibm_pi_ipsec_policy
+
+~> This resource is deprecated and will be removed in the next major version. This resource has reached end of life.
+
 Create, update, or delete a IPSec Policy. For more information, about IBM power virtual server cloud, see [getting started with IBM Power Systems Virtual Servers](https://cloud.ibm.com/docs/power-iaas?topic=power-iaas-getting-started).
 
-## Example usage
+## Example Usage
+
 The following example creates a IPSec Policy.
 
 ```terraform
-	resource "ibm_pi_ipsec_policy" "example" {
-		pi_cloud_instance_id    = "<value of the cloud_instance_id>"
-		pi_policy_name          = "test"
-		pi_policy_dh_group = 1
-		pi_policy_encryption = "aes-256-cbc"
-		pi_policy_key_lifetime = 28800
-		pi_policy_pfs = true
-		pi_policy_authentication = "hmac-sha-256-128"
-	}
+  resource "ibm_pi_ipsec_policy" "example" {
+    pi_cloud_instance_id    = "<value of the cloud_instance_id>"
+    pi_policy_name          = "test"
+    pi_policy_dh_group = 1
+    pi_policy_encryption = "aes-256-cbc"
+    pi_policy_key_lifetime = 28800
+    pi_policy_pfs = true
+    pi_policy_authentication = "hmac-sha-256-128"
+  }
 ```
 
-**Note**
-* Please find [supported Regions](https://cloud.ibm.com/apidocs/power-cloud#endpoint) for endpoints.
-* If a Power cloud instance is provisioned at `lon04`, The provider level attributes should be as follows:
-  * `region` - `lon`
-  * `zone` - `lon04`
+### Notes
 
-  Example usage:
+- Please find [supported Regions](https://cloud.ibm.com/apidocs/power-cloud#endpoint) for endpoints.
+- If a Power cloud instance is provisioned at `lon04`, The provider level attributes should be as follows:
+  - `region` - `lon`
+  - `zone` - `lon04`
+
+Example usage:
   
   ```terraform
     provider "ibm" {
@@ -48,8 +53,10 @@ ibm_pi_ipsec_policy provides the following [timeouts](https://www.terraform.io/d
 - **update** - (Default 10 minutes) Used for updating IPSec Policy.
 - **delete** - (Default 10 minutes) Used for deleting IPSec Policy.
 
-## Argument reference 
-Review the argument references that you can specify for your resource. 
+## Argument Reference
+
+Review the argument references that you can specify for your resource.
+
 - `pi_cloud_instance_id` - (Required, String) The GUID of the service instance associated with an account.
 - `pi_policy_authentication`  - (Optional, String) Authentication for the IPSec Policy. Supported values are `none`(Default), `hmac-sha-256-128`, `hmac-sha1-96`.
 - `pi_policy_dh_group` - (Required, Integer) DH group of the IPSec Policy. Supported values are `1`,`2`,`5`,`14`,`19`,`20`,`24`.
@@ -58,7 +65,8 @@ Review the argument references that you can specify for your resource.
 - `pi_policy_name` - (Required, String) Name of the IPSec Policy.
 - `pi_policy_pfs` - (Required, Boolean) Perfect Forward Secrecy.
 
-## Attribute reference
+## Attribute Reference
+
 In addition to all argument reference list, you can access the following attribute reference after your resource is created.
 
 - `id` - (String) The unique identifier of the IPSec Policy. The ID is composed of `<power_instance_id>/<policy_id>`.
@@ -68,8 +76,8 @@ In addition to all argument reference list, you can access the following attribu
 
 The `ibm_pi_ipsec_policy` resource can be imported by using `power_instance_id` and `policy_id`.
 
-**Example**
+### Example
 
-```
-$ terraform import ibm_pi_ipsec_policy.example d7bec597-4726-451f-8a63-e62e6f19c32c/ffag151a-bc0a-4438-9f8a-b0760bbf4u1u
+```bash
+terraform import ibm_pi_ipsec_policy.example d7bec597-4726-451f-8a63-e62e6f19c32c/ffag151a-bc0a-4438-9f8a-b0760bbf4u1u
 ```


### PR DESCRIPTION
## **This change is for the service broker release in July 21st. Please merge this for the terraform release that comes after date.**

Deprecate VPN resources for July. VPN has reached end of life in July.