### PR TITLE
[Resource] [Datasource] Add out_of_band_deleted attribute to ibm_pi_volume

### DIFF
--- a/ibm/service/power/data_source_ibm_pi_volume.go
+++ b/ibm/service/power/data_source_ibm_pi_volume.go
@@ -99,6 +99,11 @@ func DataSourceIBMPIVolume() *schema.Resource {
 				Description: "Mirroring state for replication enabled volume.",
 				Type:        schema.TypeString,
 			},
+			Attr_OutOfBandDeleted: {
+				Computed:    true,
+				Description: "Indicates if the volume does not exist on storage controller.",
+				Type:        schema.TypeBool,
+			},
 			Attr_PrimaryRole: {
 				Computed:    true,
 				Description: "Indicates whether master/auxiliary volume is playing the primary role.",
@@ -197,6 +202,7 @@ func dataSourceIBMPIVolumeRead(ctx context.Context, d *schema.ResourceData, meta
 	d.Set(Attr_LastUpdateDate, volumedata.LastUpdateDate.String())
 	d.Set(Attr_MasterVolumeName, volumedata.MasterVolumeName)
 	d.Set(Attr_MirroringState, volumedata.MirroringState)
+	d.Set(Attr_OutOfBandDeleted, volumedata.OutOfBandDeleted)
 	d.Set(Attr_PrimaryRole, volumedata.PrimaryRole)
 	d.Set(Attr_ReplicationEnabled, volumedata.ReplicationEnabled)
 	d.Set(Attr_ReplicationType, volumedata.ReplicationType)

--- a/ibm/service/power/ibm_pi_constants.go
+++ b/ibm/service/power/ibm_pi_constants.go
@@ -361,6 +361,7 @@ const (
 	Attr_Onboardings                     = "onboardings"
 	Attr_OperatingSystem                 = "operating_system"
 	Attr_OSType                          = "os_type"
+	Attr_OutOfBandDeleted                = "out_of_band_deleted"
 	Attr_PeerID                          = "peer_id"
 	Attr_PercentComplete                 = "percent_complete"
 	Attr_PIInstanceSharedProcessorPool   = "shared_processor_pool"

--- a/ibm/service/power/resource_ibm_pi_volume.go
+++ b/ibm/service/power/resource_ibm_pi_volume.go
@@ -188,6 +188,11 @@ func ResourceIBMPIVolume() *schema.Resource {
 				Description: "Mirroring state for replication enabled volume",
 				Type:        schema.TypeString,
 			},
+			Attr_OutOfBandDeleted: {
+				Computed:    true,
+				Description: "Indicates if the volume does not exist on storage controller.",
+				Type:        schema.TypeBool,
+			},
 			Attr_PrimaryRole: {
 				Computed:    true,
 				Description: "Indicates whether 'master'/'auxiliary' volume is playing the primary role.",
@@ -377,12 +382,13 @@ func resourceIBMPIVolumeRead(ctx context.Context, d *schema.ResourceData, meta i
 	if vol.DeleteOnTermination != nil {
 		d.Set(Attr_DeleteOnTermination, vol.DeleteOnTermination)
 	}
+	d.Set(Arg_ReplicationEnabled, vol.ReplicationEnabled)
 	d.Set(Attr_GroupID, vol.GroupID)
 	d.Set(Attr_IOThrottleRate, vol.IoThrottleRate)
 	d.Set(Attr_MasterVolumeName, vol.MasterVolumeName)
 	d.Set(Attr_MirroringState, vol.MirroringState)
+	d.Set(Attr_OutOfBandDeleted, vol.OutOfBandDeleted)
 	d.Set(Attr_PrimaryRole, vol.PrimaryRole)
-	d.Set(Arg_ReplicationEnabled, vol.ReplicationEnabled)
 	d.Set(Attr_ReplicationSites, vol.ReplicationSites)
 	d.Set(Attr_ReplicationStatus, vol.ReplicationStatus)
 	d.Set(Attr_ReplicationType, vol.ReplicationType)

--- a/website/docs/d/pi_volume.html.markdown
+++ b/website/docs/d/pi_volume.html.markdown
@@ -62,6 +62,7 @@ In addition to all argument reference list, you can access the following attribu
 - `last_update_date` - (String) The date when the volume last updated.
 - `master_volume_name` - (String) The master volume name.
 - `mirroring_state` - (String) Mirroring state for replication enabled volume.
+- `out_of_band_deleted` - (Bool) Indicates if the volume does not exist on storage controller.
 - `primary_role` - (String) Indicates whether `master`/`auxiliary` volume is playing the primary role.
 - `replication_enabled` - (Boolean) Indicates if the volume should be replication enabled or not.
 - `replication_sites` - (List) List of replication sites for volume replication.

--- a/website/docs/r/pi_volume.html.markdown
+++ b/website/docs/r/pi_volume.html.markdown
@@ -84,6 +84,7 @@ In addition to all argument reference list, you can access the following attribu
 - `io_throttle_rate` - (String) Amount of iops assigned to the volume.
 - `master_volume_name` - (String) The master volume name.
 - `mirroring_state` - (String) Mirroring state for replication enabled volume.
+- `out_of_band_deleted` - (Bool) Indicates if the volume does not exist on storage controller.
 - `primary_role` - (String) Indicates whether `master`/`auxiliary` volume is playing the primary role.
 - `replication_status` - (String) The replication status of the volume.
 - `replication_sites` - (List) List of replication sites for volume replication.


### PR DESCRIPTION
## **This change is for the service broker release in July 21st. Please merge this for the terraform release that comes after date.**

Add missing field that is returned by the volume model.

Output of acceptance tests:
```
--- PASS: TestAccIBMPIVolumeDataSource_basic (21.61s)
PASS

--- PASS: TestAccIBMPIVolumeDataSource_replication (16.51s)
PASS

--- PASS: TestAccIBMPIVolumebasic (100.18s)
PASS
```