### PR TITLE
Remove access_credential from logs-routing resources

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -25,7 +25,7 @@ require (
 	github.com/IBM/ibm-hpcs-uko-sdk v0.0.20-beta
 	github.com/IBM/keyprotect-go-client v0.15.1
 	github.com/IBM/logs-go-sdk v0.4.0
-	github.com/IBM/logs-router-go-sdk v1.0.7
+	github.com/IBM/logs-router-go-sdk v1.0.8
 	github.com/IBM/mqcloud-go-sdk v0.2.0
 	github.com/IBM/networking-go-sdk v0.51.7
 	github.com/IBM/platform-services-go-sdk v0.81.2

--- a/go.sum
+++ b/go.sum
@@ -145,6 +145,8 @@ github.com/IBM/logs-go-sdk v0.4.0 h1:CyUjm19EUtcJjf4mxsj6Rc7gkZDT8JEY5rLUIz8Eoag
 github.com/IBM/logs-go-sdk v0.4.0/go.mod h1:yv/GCXC4/p+MZEeXl4xjZAOMvDAVRwu61WyHZFKFXQM=
 github.com/IBM/logs-router-go-sdk v1.0.7 h1:uQjQAAcQdo3XvhY6MC7HakhZaXIUsGfUmKj2d5vkjnY=
 github.com/IBM/logs-router-go-sdk v1.0.7/go.mod h1:tCN2vFgu5xG0ob9iJcxi5M4bJ6mWmu3nhmRPnvlwev0=
+github.com/IBM/logs-router-go-sdk v1.0.8 h1:MU1TdYNdVbvVTUXeqeYPItu6BoiSV/NMN49ySqE7WIY=
+github.com/IBM/logs-router-go-sdk v1.0.8/go.mod h1:tCN2vFgu5xG0ob9iJcxi5M4bJ6mWmu3nhmRPnvlwev0=
 github.com/IBM/mqcloud-go-sdk v0.2.0 h1:QOWk8ZGk0QfIL0MOGTKzNdM3Qe0Hk+ifAFtNSFQo5HU=
 github.com/IBM/mqcloud-go-sdk v0.2.0/go.mod h1:VZQKMtqmcdXKhmLhLiPuS/UHMs/5yo2tA/nD83cQt9E=
 github.com/IBM/networking-go-sdk v0.51.7 h1:bZEJeogqri4TGT8vNVQJn/NeTMJVWRMCqBp4zjgFmY0=

--- a/ibm/service/logsrouting/data_source_ibm_logs-router_tenants_test.go
+++ b/ibm/service/logsrouting/data_source_ibm_logs-router_tenants_test.go
@@ -84,7 +84,6 @@ func TestDataSourceIBMLogsRouterTenantsTenantToMap(t *testing.T) {
 		model["updated_at"] = "2024-06-20T18:30:00.143156Z"
 		model["crn"] = "crn:v1:bluemix:public:logs:eu-de:a/3516b8fa0a174a71899f5affa4f18d78:3517d2ed-9429-af34-ad52-34278391cbc8::"
 		model["name"] = "my-logging-tenant"
-		model["type"] = "logs"
 		model["etag"] = "822b4b5423e225206c1d75666595714a11925cd0f82b229839864443d6c3c049"
 		model["targets"] = []map[string]interface{}{targetTypeModel}
 
@@ -109,7 +108,7 @@ func TestDataSourceIBMLogsRouterTenantsTenantToMap(t *testing.T) {
 	model.ID = CreateMockUUID("8717db99-2cfb-4ba6-a033-89c994c2e9f0")
 	model.CreatedAt = core.StringPtr("2024-06-20T18:30:00.143156Z")
 	model.UpdatedAt = core.StringPtr("2024-06-20T18:30:00.143156Z")
-	model.CRN = core.StringPtr("crn:v1:bluemix:public:logs-router:eu-de:a/3516b8fa0a174a71899f5affa4f18d78:3517d2ed-9429-af34-ad52-34278391cbc8::")
+	model.CRN = core.StringPtr("crn:v1:bluemix:public:logs:eu-de:a/3516b8fa0a174a71899f5affa4f18d78:3517d2ed-9429-af34-ad52-34278391cbc8::")
 	model.Name = core.StringPtr("my-logging-tenant")
 	model.Etag = core.StringPtr("822b4b5423e225206c1d75666595714a11925cd0f82b229839864443d6c3c049")
 	model.Targets = []ibmcloudlogsroutingv0.TargetTypeIntf{targetTypeModel}

--- a/ibm/service/logsrouting/resource_ibm_logs-router_tenant.go
+++ b/ibm/service/logsrouting/resource_ibm_logs-router_tenant.go
@@ -122,12 +122,6 @@ func ResourceIBMLogsRouterTenant() *schema.Resource {
 										Required:    true,
 										Description: "Network port of the log-sink.",
 									},
-									"access_credential": &schema.Schema{
-										Type:        schema.TypeString,
-										Optional:    true,
-										Sensitive:   true,
-										Description: "Secret to connect to the log-sink",
-									},
 								},
 							},
 						},
@@ -274,8 +268,6 @@ func resourceIBMLogsRouterTenantRead(context context.Context, d *schema.Resource
 		targets = append(targets, targetsItemMap)
 	}
 
-	saveCredsTarget0 := d.Get("targets.0.parameters.0.access_credential").(string)
-	saveCredsTarget1 := d.Get("targets.1.parameters.0.access_credential").(string)
 	if len(targets) == 2 {
 		if d.Get("targets.1.type").(string) == "logdna" {
 			targets[0], targets[1] = targets[1], targets[0]
@@ -313,7 +305,6 @@ func resourceIBMLogsRouterTenantRead(context context.Context, d *schema.Resource
 				portTarget0 := int64(d.Get("targets.0.parameters.0.port").(int))
 				model.Host = &hostTarget0
 				model.Port = &portTarget0
-				model.AccessCredential = &saveCredsTarget0
 				parameters0Map, err := ResourceIBMLogsRouterTenantTargetParametersTypeLogDnaToMapAccessCredential(model)
 				if err != nil {
 					return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_logs_router_tenant", "read", "set-access_credential").GetDiag()
@@ -333,7 +324,6 @@ func resourceIBMLogsRouterTenantRead(context context.Context, d *schema.Resource
 				portTarget1 := int64(d.Get("targets.1.parameters.0.port").(int))
 				model.Host = &hostTarget1
 				model.Port = &portTarget1
-				model.AccessCredential = &saveCredsTarget1
 				parameters1Map, err := ResourceIBMLogsRouterTenantTargetParametersTypeLogDnaToMapAccessCredential(model)
 				if err != nil {
 					return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_logs_router_tenant", "read", "set-access_credential").GetDiag()
@@ -674,7 +664,6 @@ func ResourceIBMLogsRouterTenantMapToTargetParametersTypeLogDnaPrototype(modelMa
 	model := &ibmcloudlogsroutingv0.TargetParametersTypeLogDnaPrototype{}
 	model.Host = core.StringPtr(modelMap["host"].(string))
 	model.Port = core.Int64Ptr(int64(modelMap["port"].(int)))
-	model.AccessCredential = core.StringPtr(modelMap["access_credential"].(string))
 	return model, nil
 }
 
@@ -766,7 +755,6 @@ func ResourceIBMLogsRouterTenantTargetParametersTypeLogDnaToMapAccessCredential(
 	modelMap := make(map[string]interface{})
 	modelMap["host"] = *model.Host
 	modelMap["port"] = flex.IntValue(model.Port)
-	modelMap["access_credential"] = *model.AccessCredential // pragma: whitelist secret
 	return modelMap, nil
 }
 
@@ -819,7 +807,6 @@ func ResourceIBMLogsRouterTargetMapToTargetParametersTypeLogDNAPrototype(modelMa
 	model := &ibmcloudlogsroutingv0.TargetParametersTypeLogDnaPrototype{}
 	model.Host = core.StringPtr(modelMap["host"].(string))
 	model.Port = core.Int64Ptr(int64(modelMap["port"].(int)))
-	model.AccessCredential = core.StringPtr(modelMap["access_credential"].(string))
 	return model, nil
 }
 

--- a/ibm/service/logsrouting/resource_ibm_logs-router_tenant_test.go
+++ b/ibm/service/logsrouting/resource_ibm_logs-router_tenant_test.go
@@ -359,7 +359,6 @@ func TestResourceIBMLogsRouterTenantMapToTargetTypePrototype(t *testing.T) {
 		targetParametersTypeLogDnaPrototypeModel := new(ibmcloudlogsroutingv0.TargetParametersTypeLogDnaPrototype)
 		targetParametersTypeLogDnaPrototypeModel.Host = core.StringPtr("www.example.com")
 		targetParametersTypeLogDnaPrototypeModel.Port = core.Int64Ptr(int64(1))
-		targetParametersTypeLogDnaPrototypeModel.AccessCredential = core.StringPtr("ingestion-secret")
 
 		model := new(ibmcloudlogsroutingv0.TargetTypePrototype)
 		model.LogSinkCRN = core.StringPtr("crn:v1:bluemix:public:logdna:eu-de:a/3516b8fa0a174a71899f5affa4f18d78:3517d2ed-9429-af34-ad52-34278391cbc8::")
@@ -389,7 +388,6 @@ func TestResourceIBMLogsRouterTenantMapToTargetParametersTypeLogDnaPrototype(t *
 		model := new(ibmcloudlogsroutingv0.TargetParametersTypeLogDnaPrototype)
 		model.Host = core.StringPtr("www.example.com")
 		model.Port = core.Int64Ptr(int64(1))
-		model.AccessCredential = core.StringPtr("ingestion-secret")
 
 		assert.Equal(t, result, model)
 	}
@@ -409,7 +407,6 @@ func TestResourceIBMLogsRouterTenantMapToTargetTypePrototypeTargetTypeLogDnaProt
 		targetParametersTypeLogDnaPrototypeModel := new(ibmcloudlogsroutingv0.TargetParametersTypeLogDnaPrototype)
 		targetParametersTypeLogDnaPrototypeModel.Host = core.StringPtr("www.example.com")
 		targetParametersTypeLogDnaPrototypeModel.Port = core.Int64Ptr(int64(8080))
-		targetParametersTypeLogDnaPrototypeModel.AccessCredential = core.StringPtr("an-ingestion-secret")
 
 		model := new(ibmcloudlogsroutingv0.TargetTypePrototypeTargetTypeLogDnaPrototype)
 		model.LogSinkCRN = core.StringPtr("crn:v1:bluemix:public:logdna:eu-de:a/3516b8fa0a174a71899f5affa4f18d78:3517d2ed-9429-af34-ad52-34278391cbc8::")


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/IBM-Cloud/terraform-provider-ibm/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->
This PR removes the now-unused field "access_credential" from the logs routing resource operations. This field was previously ignored by our API, but recently it started to return 'CreateTenantWithContext failed: Bad Request'. This PR fixes this issue. 
### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #6315

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test $(go list ./... |grep 'routing') -v  -timeout 700m
=== RUN   TestAccIBMLogsRouterTargetsDataSourceBasic
--- PASS: TestAccIBMLogsRouterTargetsDataSourceBasic (76.72s)
=== RUN   TestDataSourceIBMLogsRouterTargetsTargetTypeToMap
--- PASS: TestDataSourceIBMLogsRouterTargetsTargetTypeToMap (0.00s)
=== RUN   TestDataSourceIBMLogsRouterTargetsTargetParametersTypeLogDnaToMap
--- PASS: TestDataSourceIBMLogsRouterTargetsTargetParametersTypeLogDnaToMap (0.00s)
=== RUN   TestDataSourceIBMLogsRouterTargetsTargetTypeLogDnaToMap
--- PASS: TestDataSourceIBMLogsRouterTargetsTargetTypeLogDnaToMap (0.00s)
=== RUN   TestDataSourceIBMLogsRouterTargetsTargetTypeLogsToMap
--- PASS: TestDataSourceIBMLogsRouterTargetsTargetTypeLogsToMap (0.00s)
=== RUN   TestDataSourceIBMLogsRouterTargetsTargetParametersTypeLogsToMap
--- PASS: TestDataSourceIBMLogsRouterTargetsTargetParametersTypeLogsToMap (0.00s)
=== RUN   TestAccIBMLogsRouterTenantsDataSourceBasic
--- PASS: TestAccIBMLogsRouterTenantsDataSourceBasic (74.12s)
=== RUN   TestDataSourceIBMLogsRouterTenantsTenantToMap
--- PASS: TestDataSourceIBMLogsRouterTenantsTenantToMap (0.00s)
=== RUN   TestDataSourceIBMLogsRouterTenantsTargetTypeToMap
--- PASS: TestDataSourceIBMLogsRouterTenantsTargetTypeToMap (0.00s)
=== RUN   TestDataSourceIBMLogsRouterTenantsTargetParametersTypeLogDnaToMap
--- PASS: TestDataSourceIBMLogsRouterTenantsTargetParametersTypeLogDnaToMap (0.00s)
=== RUN   TestDataSourceIBMLogsRouterTenantsTargetTypeLogDnaToMap
--- PASS: TestDataSourceIBMLogsRouterTenantsTargetTypeLogDnaToMap (0.00s)
=== RUN   TestDataSourceIBMLogsRouterTenantsTargetTypeLogsToMap
--- PASS: TestDataSourceIBMLogsRouterTenantsTargetTypeLogsToMap (0.00s)
=== RUN   TestDataSourceIBMLogsRouterTenantsTargetParametersTypeLogsToMap
--- PASS: TestDataSourceIBMLogsRouterTenantsTargetParametersTypeLogsToMap (0.00s)
=== RUN   TestAccIBMLogsRouterTenantBasic
--- PASS: TestAccIBMLogsRouterTenantBasic (82.26s)
=== RUN   TestAccIBMLogsRouterTenantAllArgs
--- PASS: TestAccIBMLogsRouterTenantAllArgs (73.11s)
=== RUN   TestResourceIBMLogsRouterTenantTargetTypeToMap
--- PASS: TestResourceIBMLogsRouterTenantTargetTypeToMap (0.00s)
=== RUN   TestResourceIBMLogsRouterTenantTargetParametersTypeLogDnaToMap
--- PASS: TestResourceIBMLogsRouterTenantTargetParametersTypeLogDnaToMap (0.00s)
=== RUN   TestResourceIBMLogsRouterTenantTargetTypeLogDnaToMap
--- PASS: TestResourceIBMLogsRouterTenantTargetTypeLogDnaToMap (0.00s)
=== RUN   TestResourceIBMLogsRouterTenantTargetTypeLogsToMap
--- PASS: TestResourceIBMLogsRouterTenantTargetTypeLogsToMap (0.00s)
=== RUN   TestResourceIBMLogsRouterTenantTargetParametersTypeLogsToMap
--- PASS: TestResourceIBMLogsRouterTenantTargetParametersTypeLogsToMap (0.00s)
=== RUN   TestResourceIBMLogsRouterTenantMapToTargetTypePrototype
--- PASS: TestResourceIBMLogsRouterTenantMapToTargetTypePrototype (0.00s)
=== RUN   TestResourceIBMLogsRouterTenantMapToTargetParametersTypeLogDnaPrototype
--- PASS: TestResourceIBMLogsRouterTenantMapToTargetParametersTypeLogDnaPrototype (0.00s)
=== RUN   TestResourceIBMLogsRouterTenantMapToTargetTypePrototypeTargetTypeLogDnaPrototype
--- PASS: TestResourceIBMLogsRouterTenantMapToTargetTypePrototypeTargetTypeLogDnaPrototype (0.00s)
=== RUN   TestResourceIBMLogsRouterTenantMapToTargetTypePrototypeTargetTypeLogsPrototype
--- PASS: TestResourceIBMLogsRouterTenantMapToTargetTypePrototypeTargetTypeLogsPrototype (0.00s)
=== RUN   TestResourceIBMLogsRouterTenantMapToTargetParametersTypeLogsPrototype
--- PASS: TestResourceIBMLogsRouterTenantMapToTargetParametersTypeLogsPrototype (0.00s)
PASS
ok  	github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/logsrouting	310.101s

...
```
