### PR TITLE
skip service-id and trusted-profile-id validation when creating policies

### DIFF
--- a/ibm/provider/provider.go
+++ b/ibm/provider/provider.go
@@ -2184,9 +2184,7 @@ func Validator() validate.ValidatorDict {
 				"ibm_iam_service_api_key":                  iamidentity.ResourceIBMIAMServiceAPIKeyValidator(),
 				"ibm_iam_trusted_profile_identity":         iamidentity.ResourceIBMIamTrustedProfileIdentityValidator(),
 
-				"ibm_iam_trusted_profile_policy":  iampolicy.ResourceIBMIAMTrustedProfilePolicyValidator(),
 				"ibm_iam_access_group_policy":     iampolicy.ResourceIBMIAMAccessGroupPolicyValidator(),
-				"ibm_iam_service_policy":          iampolicy.ResourceIBMIAMServicePolicyValidator(),
 				"ibm_iam_authorization_policy":    iampolicy.ResourceIBMIAMAuthorizationPolicyValidator(),
 				"ibm_iam_policy_template":         iampolicy.ResourceIBMIAMPolicyTemplateValidator(),
 				"ibm_iam_policy_template_version": iampolicy.ResourceIBMIAMPolicyTemplateVersionValidator(),
@@ -2330,9 +2328,7 @@ func Validator() validate.ValidatorDict {
 				"ibm_iam_trusted_profile":             iamidentity.DataSourceIBMIamTrustedProfileValidator(),
 				"ibm_iam_trusted_profile_claim_rules": iamidentity.DataSourceIBMIamTrustedProfileClaimRulesValidator(),
 
-				"ibm_iam_access_group_policy":    iampolicy.DataSourceIBMIAMAccessGroupPolicyValidator(),
-				"ibm_iam_service_policy":         iampolicy.DataSourceIBMIAMServicePolicyValidator(),
-				"ibm_iam_trusted_profile_policy": iampolicy.DataSourceIBMIAMTrustedProfilePolicyValidator(),
+				"ibm_iam_access_group_policy": iampolicy.DataSourceIBMIAMAccessGroupPolicyValidator(),
 			},
 		}
 	})

--- a/ibm/service/iampolicy/data_source_ibm_iam_service_policy_test.go
+++ b/ibm/service/iampolicy/data_source_ibm_iam_service_policy_test.go
@@ -131,7 +131,7 @@ resource "ibm_resource_instance" "instance" {
 }
 
 resource "ibm_iam_service_policy" "policy" {
-  iam_service_id = ibm_iam_service_id.serviceID.id
+  iam_id = ibm_iam_service_id.serviceID.iam_id
   roles          = ["Manager", "Viewer", "Administrator"]
 
   resources {
@@ -141,7 +141,7 @@ resource "ibm_iam_service_policy" "policy" {
 }
 
 data "ibm_iam_service_policy" "testacc_ds_service_policy" {
-  iam_service_id = ibm_iam_service_policy.policy.iam_service_id
+  iam_id = ibm_iam_service_policy.policy.iam_id
 }`, name, name)
 
 }
@@ -162,7 +162,7 @@ resource "ibm_resource_instance" "instance" {
 }
 
 resource "ibm_iam_service_policy" "policy" {
-  iam_service_id = ibm_iam_service_id.serviceID.id
+  iam_id = ibm_iam_service_id.serviceID.iam_id
   roles          = ["Manager", "Viewer", "Administrator"]
 
   resources {
@@ -176,7 +176,7 @@ data "ibm_resource_group" "group" {
 }
 
 resource "ibm_iam_service_policy" "policy1" {
-  iam_service_id = ibm_iam_service_id.serviceID.id
+  iam_id = ibm_iam_service_id.serviceID.iam_id
   roles          = ["Viewer"]
 
   resources {
@@ -187,8 +187,8 @@ resource "ibm_iam_service_policy" "policy1" {
 
 
 data "ibm_iam_service_policy" "testacc_ds_service_policy" {
-  iam_service_id = ibm_iam_service_policy.policy.iam_service_id
-  sort = "id"
+  iam_id = ibm_iam_service_policy.policy.iam_id
+  sort = "created_at"
 }`, name, name)
 
 }
@@ -202,7 +202,7 @@ resource "ibm_iam_service_id" "serviceID" {
 }
 
 resource "ibm_iam_service_policy" "policy" {
-  iam_service_id = ibm_iam_service_id.serviceID.id
+  iam_id = ibm_iam_service_id.serviceID.iam_id
   roles          = ["Manager", "Viewer", "Administrator"]
 
   resource_attributes {
@@ -217,7 +217,7 @@ resource "ibm_iam_service_policy" "policy" {
 }
 
 data "ibm_iam_service_policy" "testacc_ds_service_policy" {
-  iam_service_id = ibm_iam_service_policy.policy.iam_service_id
+  iam_id = ibm_iam_service_policy.policy.iam_id
 }`, name)
 
 }
@@ -232,7 +232,7 @@ func testAccCheckIBMIAMServicePolicyDataSourceTimeBasedWeekly(name string) strin
 	}
 
 	resource "ibm_iam_service_policy" "policy" {
-		iam_service_id = ibm_iam_service_id.serviceID.id
+		iam_id = ibm_iam_service_id.serviceID.iam_id
 		roles  = ["Viewer"]
 		resources {
 			service = "kms"
@@ -246,7 +246,7 @@ func testAccCheckIBMIAMServicePolicyDataSourceTimeBasedWeekly(name string) strin
 		}
 
 	data "ibm_iam_service_policy" "testacc_ds_service_policy" {
-		iam_service_id = ibm_iam_service_policy.policy.iam_service_id
+		iam_id = ibm_iam_service_policy.policy.iam_id
 	}
 	`, name)
 }
@@ -261,7 +261,7 @@ func testAccCheckIBMIAMServicePolicyDataSourceTimeBasedCustom(name string) strin
 	}
 
 	resource "ibm_iam_service_policy" "policy" {
-		iam_service_id = ibm_iam_service_id.serviceID.id
+		iam_id = ibm_iam_service_id.serviceID.iam_id
 		roles  = ["Viewer"]
 		resources {
 			service = "kms"
@@ -286,7 +286,7 @@ func testAccCheckIBMIAMServicePolicyDataSourceTimeBasedCustom(name string) strin
 		}
 
 	data "ibm_iam_service_policy" "testacc_ds_service_policy" {
-		iam_service_id = ibm_iam_service_policy.policy.iam_service_id
+		iam_id = ibm_iam_service_policy.policy.iam_id
 	}
 	`, name)
 }
@@ -301,7 +301,7 @@ func testAccCheckIBMIAMServicePolicyDataSourceServiceGroupID(name string) string
 	}
 
 	resource "ibm_iam_service_policy" "policy" {
-		iam_service_id = ibm_iam_service_id.serviceID.id
+		iam_id = ibm_iam_service_id.serviceID.iam_id
 		roles  = ["Viewer"]
 		resources {
 			service_group_id = "IAM"
@@ -326,7 +326,7 @@ func testAccCheckIBMIAMServicePolicyDataSourceServiceGroupID(name string) string
 		}
 
 	data "ibm_iam_service_policy" "testacc_ds_service_policy" {
-		iam_service_id = ibm_iam_service_policy.policy.iam_service_id
+		iam_id = ibm_iam_service_policy.policy.iam_id
 	}
 	`, name)
 }

--- a/ibm/service/iampolicy/data_source_ibm_iam_trusted_profile_policy_test.go
+++ b/ibm/service/iampolicy/data_source_ibm_iam_trusted_profile_policy_test.go
@@ -131,7 +131,7 @@ resource "ibm_resource_instance" "instance" {
 }
 
 resource "ibm_iam_trusted_profile_policy" "policy" {
-  profile_id = ibm_iam_trusted_profile.profileID.id
+  iam_id = ibm_iam_trusted_profile.profileID.iam_id
   roles          = ["Manager", "Viewer", "Administrator"]
 
   resources {
@@ -141,7 +141,7 @@ resource "ibm_iam_trusted_profile_policy" "policy" {
 }
 
 data "ibm_iam_trusted_profile_policy" "policy" {
-  profile_id = ibm_iam_trusted_profile_policy.policy.profile_id
+  iam_id = ibm_iam_trusted_profile_policy.policy.iam_id
 }`, name, name)
 
 }
@@ -162,7 +162,7 @@ resource "ibm_resource_instance" "instance" {
 }
 
 resource "ibm_iam_trusted_profile_policy" "policy" {
-  profile_id = ibm_iam_trusted_profile.profileID.id
+  iam_id = ibm_iam_trusted_profile.profileID.iam_id
   roles          = ["Manager", "Viewer", "Administrator"]
 
   resources {
@@ -176,7 +176,7 @@ data "ibm_resource_group" "group" {
 }
 
 resource "ibm_iam_trusted_profile_policy" "policy1" {
-  profile_id = ibm_iam_trusted_profile.profileID.id
+  iam_id = ibm_iam_trusted_profile.profileID.iam_id
   roles          = ["Viewer"]
 
   resources {
@@ -186,8 +186,8 @@ resource "ibm_iam_trusted_profile_policy" "policy1" {
 }
 
 data "ibm_iam_trusted_profile_policy" "policy" {
-  profile_id = ibm_iam_trusted_profile_policy.policy.profile_id
-  sort = "id"
+  iam_id = ibm_iam_trusted_profile_policy.policy.iam_id
+  sort = "created_at"
 }`, name, name)
 
 }
@@ -200,7 +200,7 @@ resource "ibm_iam_trusted_profile" "profileID" {
 }
 
 resource "ibm_iam_trusted_profile_policy" "policy" {
-  profile_id = ibm_iam_trusted_profile.profileID.id
+  iam_id = ibm_iam_trusted_profile.profileID.iam_id
   roles          = ["Manager", "Viewer", "Administrator"]
 
   resource_attributes {
@@ -214,7 +214,7 @@ resource "ibm_iam_trusted_profile_policy" "policy" {
 }
 
 data "ibm_iam_trusted_profile_policy" "policy" {
-  profile_id = ibm_iam_trusted_profile_policy.policy.profile_id
+  iam_id = ibm_iam_trusted_profile_policy.policy.iam_id
 }`, name)
 
 }
@@ -229,7 +229,7 @@ func testAccCheckIBMIAMTrustedProfilePolicyDataSourceTimeBasedWeekly(name string
 	}
 
 	resource "ibm_iam_trusted_profile_policy" "policy" {
-		profile_id = ibm_iam_trusted_profile.profileID.id
+		iam_id = ibm_iam_trusted_profile.profileID.iam_id
 		roles  = ["Viewer"]
 		resources {
 			service = "kms"
@@ -243,7 +243,7 @@ func testAccCheckIBMIAMTrustedProfilePolicyDataSourceTimeBasedWeekly(name string
 		}
 
 	data "ibm_iam_trusted_profile_policy" "policy" {
-		profile_id = ibm_iam_trusted_profile_policy.policy.profile_id
+		iam_id = ibm_iam_trusted_profile_policy.policy.iam_id
 	}
 	`, name)
 }
@@ -258,7 +258,7 @@ func testAccCheckIBMIAMTrustedProfilePolicyDataSourceTimeBasedCustom(name string
 	}
 
 	resource "ibm_iam_trusted_profile_policy" "policy" {
-		profile_id = ibm_iam_trusted_profile.profileID.id
+		iam_id = ibm_iam_trusted_profile.profileID.iam_id
 		roles  = ["Viewer"]
 		resources {
 			service = "kms"
@@ -283,7 +283,7 @@ func testAccCheckIBMIAMTrustedProfilePolicyDataSourceTimeBasedCustom(name string
 		}
 
 	data "ibm_iam_trusted_profile_policy" "policy" {
-		profile_id = ibm_iam_trusted_profile_policy.policy.profile_id
+		iam_id = ibm_iam_trusted_profile_policy.policy.iam_id
 	}
 	`, name)
 }
@@ -298,7 +298,7 @@ func testAccCheckIBMIAMTrustedProfilePolicyDataSourceServiceGroupID(name string)
 	}
 
 	resource "ibm_iam_trusted_profile_policy" "policy" {
-		profile_id = ibm_iam_trusted_profile.profileID.id
+		iam_id = ibm_iam_trusted_profile.profileID.iam_id
 		roles  = ["Viewer"]
 		resources {
 			service_group_id = "IAM"
@@ -323,7 +323,7 @@ func testAccCheckIBMIAMTrustedProfilePolicyDataSourceServiceGroupID(name string)
 		}
 
 	data "ibm_iam_trusted_profile_policy" "policy" {
-		profile_id = ibm_iam_trusted_profile_policy.policy.profile_id
+		iam_id = ibm_iam_trusted_profile_policy.policy.iam_id
 	}
 	`, name)
 }

--- a/ibm/service/iampolicy/resource_ibm_iam_service_policy_test.go
+++ b/ibm/service/iampolicy/resource_ibm_iam_service_policy_test.go
@@ -602,7 +602,7 @@ func testAccCheckIBMIAMServicePolicyBasic(name string) string {
 	  	}
 	  
 	  	resource "ibm_iam_service_policy" "policy" {
-			iam_service_id = ibm_iam_service_id.serviceID.id
+			iam_id = ibm_iam_service_id.serviceID.iam_id
 			roles          = ["Viewer"]
 			tags           = ["tag1"]
 			description    = "IAM Service Policy Creation for test scenario"
@@ -619,7 +619,7 @@ func testAccCheckIBMIAMServicePolicyUpdateRole(name string) string {
 	  	}
 	  
 	  	resource "ibm_iam_service_policy" "policy" {
-			iam_service_id = ibm_iam_service_id.serviceID.id
+			iam_id = ibm_iam_service_id.serviceID.iam_id
 			roles          = ["Viewer", "Manager"]
 			tags           = ["tag1", "tag2"]
 			description    = "IAM Service Policy Update for test scenario"
@@ -635,7 +635,7 @@ func testAccCheckIBMIAMServicePolicyService(name string) string {
 	  	}
 	  
 	  	resource "ibm_iam_service_policy" "policy" {
-			iam_service_id = ibm_iam_service_id.serviceID.id
+			iam_id = ibm_iam_service_id.serviceID.iam_id
 			roles          = ["Viewer"]
 	  
 			resources {
@@ -653,7 +653,7 @@ func testAccCheckIBMIAMServicePolicyServiceType(name string) string {
 	  	}
 	  
 	  	resource "ibm_iam_service_policy" "policy" {
-			iam_service_id = ibm_iam_service_id.serviceID.id
+			iam_id = ibm_iam_service_id.serviceID.iam_id
 			roles          = ["Viewer"]
 	  
 			resources {
@@ -672,7 +672,7 @@ func testAccCheckIBMIAMServicePolicyUpdateServiceAndRegion(name string) string {
 	  	}
 	  
 	  	resource "ibm_iam_service_policy" "policy" {
-			iam_service_id = ibm_iam_service_id.serviceID.id
+			iam_id = ibm_iam_service_id.serviceID.iam_id
 			roles          = ["Viewer", "Manager"]
 	  
 			resources {
@@ -698,7 +698,7 @@ func testAccCheckIBMIAMServicePolicyResourceInstance(name string) string {
 	  	}
 	  
 	  	resource "ibm_iam_service_policy" "policy" {
-			iam_service_id = ibm_iam_service_id.serviceID.id
+			iam_id = ibm_iam_service_id.serviceID.iam_id
 			roles          = ["Manager", "Viewer", "Administrator"]
 	  
 			resources {
@@ -723,7 +723,7 @@ func testAccCheckIBMIAMServicePolicyResourceGroup(name string) string {
 	  	}
 	  
 	  	resource "ibm_iam_service_policy" "policy" {
-			iam_service_id = ibm_iam_service_id.serviceID.id
+			iam_id = ibm_iam_service_id.serviceID.iam_id
 			roles          = ["Viewer"]
 	  
 			resources {
@@ -748,7 +748,7 @@ func testAccCheckIBMIAMServicePolicyResourceType(name string) string {
 	  	}
 	  
 	  	resource "ibm_iam_service_policy" "policy" {
-			iam_service_id = ibm_iam_service_id.serviceID.id
+			iam_id = ibm_iam_service_id.serviceID.iam_id
 			roles          = ["Administrator"]
 	  
 			resources {
@@ -767,7 +767,7 @@ func testAccCheckIBMIAMServicePolicyImport(name string) string {
 	  	}
 	  
 	  	resource "ibm_iam_service_policy" "policy" {
-			iam_service_id = ibm_iam_service_id.serviceID.id
+			iam_id = ibm_iam_service_id.serviceID.iam_id
 			roles          = ["Viewer"]
 	  	}
 
@@ -782,7 +782,7 @@ func testAccCheckIBMIAMServicePolicyAccountManagement(name string) string {
 	  	}
 	  
 	  	resource "ibm_iam_service_policy" "policy" {
-			iam_service_id     = ibm_iam_service_id.serviceID.id
+			iam_id     = ibm_iam_service_id.serviceID.iam_id
 			roles              = ["Viewer"]
 			account_management = true
 	  	}
@@ -805,7 +805,7 @@ func testAccCheckIBMIAMServicePolicyWithCustomRole(name, crName, displayName str
 		}
 	  
 	  	resource "ibm_iam_service_policy" "policy" {
-			iam_service_id = ibm_iam_service_id.serviceID.id
+			iam_id = ibm_iam_service_id.serviceID.iam_id
 			roles          = [ibm_iam_custom_role.customrole.display_name,"Viewer"]
 			tags           = ["tag1"]
 			resources {
@@ -823,7 +823,7 @@ func testAccCheckIBMIAMServicePolicyResourceAttributes(name string) string {
 	  }
   
 	  resource "ibm_iam_service_policy" "policy" {
-		iam_service_id     = ibm_iam_service_id.serviceID.id
+		iam_id = ibm_iam_service_id.serviceID.iam_id
 		roles              = ["Viewer"]
 		resource_attributes {
 			name     = "resource"
@@ -844,7 +844,7 @@ func testAccCheckIBMIAMServicePolicyResourceAttributesUpdate(name string) string
 	  }
   
 	  resource "ibm_iam_service_policy" "policy" {
-		iam_service_id     = ibm_iam_service_id.serviceID.id
+		iam_id = ibm_iam_service_id.serviceID.iam_id
 		roles              = ["Viewer"]
 		resource_attributes {
 			name     = "resource"
@@ -865,7 +865,7 @@ func testAccCheckIBMIAMServicePolicyResourceTags(name string) string {
 	  	}
 	  
 	  	resource "ibm_iam_service_policy" "policy" {
-			iam_service_id = ibm_iam_service_id.serviceID.id
+			iam_id = ibm_iam_service_id.serviceID.iam_id
 			roles          = ["Viewer"]
 			
 			resource_tags {
@@ -884,7 +884,7 @@ func testAccCheckIBMIAMServicePolicyUpdateResourceTags(name string) string {
 	  	}
 	  
 	  	resource "ibm_iam_service_policy" "policy" {
-			iam_service_id = ibm_iam_service_id.serviceID.id
+			iam_id = ibm_iam_service_id.serviceID.iam_id
 			roles          = ["Viewer"]
 			
 			resource_tags {
@@ -907,7 +907,7 @@ func testAccCheckIBMIAMServicePolicyResourceTransactionId(name string) string {
 	  }
   
 	  resource "ibm_iam_service_policy" "policy" {
-		iam_service_id     = ibm_iam_service_id.serviceID.id
+		iam_id = ibm_iam_service_id.serviceID.iam_id
 		roles              = ["Viewer"]
 		transaction_id = "terrformServicePolicy"
 		resource_attributes {
@@ -930,7 +930,7 @@ func testAccCheckIBMIAMServicePolicyResourceTransactionIdUpdate(name string) str
 	  }
   
 	  resource "ibm_iam_service_policy" "policy" {
-		iam_service_id     = ibm_iam_service_id.serviceID.id
+		iam_id = ibm_iam_service_id.serviceID.iam_id
 		roles              = ["Viewer"]
 		transaction_id = "terrformServicePolicyUpdate"
 		resource_attributes {
@@ -952,7 +952,7 @@ func testAccCheckIBMIAMServicePolicyWeeklyCustomHours(name string) string {
 		  }
 
 		  resource "ibm_iam_service_policy" "policy" {
-			iam_service_id     = ibm_iam_service_id.serviceID.id
+			iam_id = ibm_iam_service_id.serviceID.iam_id
 			roles  = ["Viewer"]
 			resources {
 				 service = "kms"
@@ -986,7 +986,7 @@ func testAccCheckIBMIAMServicePolicyUpdateConditions(name string) string {
 			}
 
 			resource "ibm_iam_service_policy" "policy" {
-			iam_service_id     = ibm_iam_service_id.serviceID.id
+			iam_id = ibm_iam_service_id.serviceID.iam_id
 			roles  = ["Viewer", "Manager"]
 			resources {
 				 service = "kms"
@@ -1020,7 +1020,7 @@ func testAccCheckIBMIAMServicePolicyWeeklyAllDay(name string) string {
 			}
 
 			resource "ibm_iam_service_policy" "policy" {
-			iam_service_id     = ibm_iam_service_id.serviceID.id
+			iam_id = ibm_iam_service_id.serviceID.iam_id
 			roles  = ["Viewer"]
 			resources {
 				 service = "kms"
@@ -1044,7 +1044,7 @@ func testAccCheckIBMIAMServicePolicyTimeBasedOnce(name string) string {
 			}
 
 			resource "ibm_iam_service_policy" "policy" {
-			iam_service_id     = ibm_iam_service_id.serviceID.id
+			iam_id = ibm_iam_service_id.serviceID.iam_id
 			roles  = ["Viewer"]
 			resources {
 				 service = "kms"
@@ -1072,7 +1072,7 @@ func testAccCheckIBMIAMServicePolicyWithServiceGroupId(name string) string {
 				name = "%s"
 			}
 			resource "ibm_iam_service_policy" "policy" {
-				iam_service_id     = ibm_iam_service_id.serviceID.id
+				iam_id = ibm_iam_service_id.serviceID.iam_id
 				roles           = ["Service ID creator"]
     		resource_attributes {
          		name     = "service_group_id"
@@ -1102,7 +1102,7 @@ func testAccCheckIBMIAMServiceUpdatePolicyWithServiceGroupId(name string) string
 				name = "%s"
 			}
 			resource "ibm_iam_service_policy" "policy" {
-				iam_service_id     = ibm_iam_service_id.serviceID.id
+				iam_id = ibm_iam_service_id.serviceID.iam_id
 				roles           = ["Service ID creator", "User API key creator"]
     		resource_attributes {
          		name     = "service_group_id"
@@ -1133,7 +1133,7 @@ func testAccCheckIBMIAMServicePolicyAttributeBasedCondition(name string) string 
 		}
 
 		resource "ibm_iam_service_policy" "policy" {
-			iam_service_id     = ibm_iam_service_id.serviceID.id
+			iam_id = ibm_iam_service_id.serviceID.iam_id
 			roles  = ["Writer"]
 			resource_attributes {
 				value = "cloud-object-storage"
@@ -1200,7 +1200,7 @@ func testAccCheckIBMIAMServicePolicyUpdateAttributeBasedCondition(name string) s
 		}
 
 		resource "ibm_iam_service_policy" "policy" {
-			iam_service_id     = ibm_iam_service_id.serviceID.id
+			iam_id = ibm_iam_service_id.serviceID.iam_id
 			roles  = ["Reader", "Writer"]
 			resource_attributes {
 				value = "cloud-object-storage"
@@ -1267,7 +1267,7 @@ func testAccCheckIBMIAMServicePolicyResourceAttributesWithoutWildcard(name strin
 	  }
   
 	  resource "ibm_iam_service_policy" "policy" {
-		iam_service_id     = ibm_iam_service_id.serviceID.id
+		iam_id = ibm_iam_service_id.serviceID.iam_id
 		roles              = ["Viewer"]
 		resource_attributes {
 			name     = "resource"

--- a/ibm/service/iampolicy/resource_ibm_iam_trusted_profile_policy.go
+++ b/ibm/service/iampolicy/resource_ibm_iam_trusted_profile_policy.go
@@ -10,9 +10,7 @@ import (
 
 	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/conns"
 	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/flex"
-	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/validate"
 	"github.com/IBM/go-sdk-core/v5/core"
-	"github.com/IBM/platform-services-go-sdk/iamidentityv1"
 	"github.com/IBM/platform-services-go-sdk/iampolicymanagementv1"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -38,21 +36,11 @@ func ResourceIBMIAMTrustedProfilePolicy() *schema.Resource {
 		},
 
 		Schema: map[string]*schema.Schema{
-			"profile_id": {
-				Type:         schema.TypeString,
-				Optional:     true,
-				ExactlyOneOf: []string{"profile_id", "iam_id"},
-				Description:  "UUID of Trusted Profile",
-				ForceNew:     true,
-				ValidateFunc: validate.InvokeValidator("ibm_iam_trusted_profile_policy",
-					"profile_id"),
-			},
 			"iam_id": {
-				Type:         schema.TypeString,
-				Optional:     true,
-				ExactlyOneOf: []string{"profile_id", "iam_id"},
-				Description:  "IAM ID of Trusted Profile",
-				ForceNew:     true,
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "IAM ID of Trusted Profile",
+				ForceNew:    true,
 			},
 			"roles": {
 				Type:        schema.TypeList,
@@ -272,40 +260,9 @@ func ResourceIBMIAMTrustedProfilePolicy() *schema.Resource {
 	}
 }
 
-func ResourceIBMIAMTrustedProfilePolicyValidator() *validate.ResourceValidator {
-	validateSchema := make([]validate.ValidateSchema, 0)
-	validateSchema = append(validateSchema,
-		validate.ValidateSchema{
-			Identifier:                 "profile_id",
-			ValidateFunctionIdentifier: validate.ValidateCloudData,
-			Type:                       validate.TypeString,
-			CloudDataType:              "iam",
-			CloudDataRange:             []string{"service:trusted_profile", "resolved_to:id"},
-			Required:                   true})
-
-	iBMIAMTrustedProfilePolicyValidator := validate.ResourceValidator{ResourceName: "ibm_iam_trusted_profile_policy", Schema: validateSchema}
-	return &iBMIAMTrustedProfilePolicyValidator
-}
-
 func resourceIBMIAMTrustedProfilePolicyCreate(d *schema.ResourceData, meta interface{}) error {
 
 	var iamID string
-	if v, ok := d.GetOk("profile_id"); ok && v != nil {
-		profileIDUUID := v.(string)
-
-		iamClient, err := meta.(conns.ClientSession).IAMIdentityV1API()
-		if err != nil {
-			return err
-		}
-		getProfileOptions := &iamidentityv1.GetProfileOptions{
-			ProfileID: &profileIDUUID,
-		}
-		profileID, resp, err := iamClient.GetProfile(getProfileOptions)
-		if err != nil {
-			return fmt.Errorf("[ERROR] Error] Error getting trusted profile ID %s %s", err, resp)
-		}
-		iamID = *profileID.IamID
-	}
 	if v, ok := d.GetOk("iam_id"); ok && v != nil {
 		iamID = v.(string)
 	}
@@ -452,19 +409,13 @@ func resourceIBMIAMTrustedProfilePolicyCreate(d *schema.ResourceData, meta inter
 		_, _, err = iamPolicyManagementClient.GetV2Policy(getPolicyOptions)
 	}
 	if err != nil {
-		if v, ok := d.GetOk("profile_id"); ok && v != nil {
-			profileIDUUID := v.(string)
-			d.SetId(fmt.Sprintf("%s/%s", profileIDUUID, policyID))
-		} else if v, ok := d.GetOk("iam_id"); ok && v != nil {
+		if v, ok := d.GetOk("iam_id"); ok && v != nil {
 			iamID := v.(string)
 			d.SetId(fmt.Sprintf("%s/%s", iamID, policyID))
 		}
 		return fmt.Errorf("[ERROR] Error fetching trusted profile policy: %s", err)
 	}
-	if v, ok := d.GetOk("profile_id"); ok && v != nil {
-		profileIDUUID := v.(string)
-		d.SetId(fmt.Sprintf("%s/%s", profileIDUUID, policyID))
-	} else if v, ok := d.GetOk("iam_id"); ok && v != nil {
+	if v, ok := d.GetOk("iam_id"); ok && v != nil {
 		iamID := v.(string)
 		d.SetId(fmt.Sprintf("%s/%s", iamID, policyID))
 	}
@@ -513,11 +464,7 @@ func resourceIBMIAMTrustedProfilePolicyRead(d *schema.ResourceData, meta interfa
 	if err != nil || trustedProfilePolicy == nil || res == nil {
 		return fmt.Errorf("[ERROR] Error retrieving trusted profile policy: %s %s", err, res)
 	}
-	if strings.HasPrefix(profileIDUUID, "iam-") {
-		d.Set("iam_id", profileIDUUID)
-	} else {
-		d.Set("profile_id", profileIDUUID)
-	}
+	d.Set("iam_id", profileIDUUID)
 
 	roles, err := flex.GetRoleNamesFromPolicyResponse(*trustedProfilePolicy, d, meta)
 	d.Set("roles", roles)
@@ -570,22 +517,6 @@ func resourceIBMIAMTrustedProfilePolicyUpdate(d *schema.ResourceData, meta inter
 		trustedProfilePolicyID := parts[1]
 
 		var iamID string
-		if v, ok := d.GetOk("profile_id"); ok && v != nil {
-			profileIDUUID := v.(string)
-
-			iamClient, err := meta.(conns.ClientSession).IAMIdentityV1API()
-			if err != nil {
-				return err
-			}
-			getProfileIDOptions := iamidentityv1.GetProfileOptions{
-				ProfileID: &profileIDUUID,
-			}
-			profileID, resp, err := iamClient.GetProfile(&getProfileIDOptions)
-			if err != nil {
-				return fmt.Errorf("[ERROR] Error] Error getting trusted profile ID %s %s", err, resp)
-			}
-			iamID = *profileID.IamID
-		}
 		if v, ok := d.GetOk("iam_id"); ok && v != nil {
 			iamID = v.(string)
 		}

--- a/ibm/service/iampolicy/resource_ibm_iam_trusted_profile_policy_test.go
+++ b/ibm/service/iampolicy/resource_ibm_iam_trusted_profile_policy_test.go
@@ -295,6 +295,7 @@ func TestAccIBMIAMTrustedProfilePolicy_With_Resource_Attributes_Without_Wildcard
 func TestAccIBMIAMTrustedProfilePolicy_With_Resource_Tags(t *testing.T) {
 	var conf iampolicymanagementv1.V2PolicyTemplateMetaData
 	name := fmt.Sprintf("terraform_%d", acctest.RandIntRange(10, 100))
+	updatedName := fmt.Sprintf("terraform_%d", acctest.RandIntRange(10, 100))
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { acc.TestAccPreCheck(t) },
@@ -311,9 +312,9 @@ func TestAccIBMIAMTrustedProfilePolicy_With_Resource_Tags(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccCheckIBMIAMTrustedProfilePolicyUpdateResourceTags(name),
+				Config: testAccCheckIBMIAMTrustedProfilePolicyUpdateResourceTags(updatedName),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr("ibm_iam_trusted_profile.profileID", "name", name),
+					resource.TestCheckResourceAttr("ibm_iam_trusted_profile.profileID", "name", updatedName),
 					resource.TestCheckResourceAttr("ibm_iam_trusted_profile_policy.policy", "resource_tags.#", "2"),
 					resource.TestCheckResourceAttr("ibm_iam_trusted_profile_policy.policy", "roles.#", "1"),
 				),
@@ -435,6 +436,7 @@ func TestAccIBMIAMTrustedProfilePolicy_With_Time_Based_Conditions_Once(t *testin
 func TestAccIBMIAMTrustedProfilePolicy_With_Update_To_Time_Based_Conditions(t *testing.T) {
 	var conf iampolicymanagementv1.V2PolicyTemplateMetaData
 	name := fmt.Sprintf("terraform_%d", acctest.RandIntRange(10, 100))
+	updatedName := fmt.Sprintf("terraform_%d", acctest.RandIntRange(10, 100))
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { acc.TestAccPreCheck(t) },
@@ -450,7 +452,7 @@ func TestAccIBMIAMTrustedProfilePolicy_With_Update_To_Time_Based_Conditions(t *t
 				),
 			},
 			{
-				Config:      testAccCheckIBMIAMTrustedProfilePolicyUpdateConditions(name),
+				Config:      testAccCheckIBMIAMTrustedProfilePolicyUpdateConditions(updatedName),
 				ExpectError: regexp.MustCompile("Error: Cannot use rule_conditions, rule_operator, or pattern when updating v1/policy. Delete existing v1/policy and create using rule_conditions and pattern."),
 			},
 		},
@@ -593,7 +595,7 @@ func testAccCheckIBMIAMTrustedProfilePolicyBasic(name string) string {
 	  	}
 	  
 	  	resource "ibm_iam_trusted_profile_policy" "policy" {
-			profile_id = ibm_iam_trusted_profile.profileID.id
+			iam_id = ibm_iam_trusted_profile.profileID.iam_id
 			roles          = ["Viewer"]
 			tags           = ["tag1"]
 			description    = "IAM Trusted Profile Policy Creation for test scenario"
@@ -610,7 +612,7 @@ func testAccCheckIBMIAMTrustedProfilePolicyUpdateRole(name string) string {
 	  	}
 	  
 	  	resource "ibm_iam_trusted_profile_policy" "policy" {
-			profile_id = ibm_iam_trusted_profile.profileID.id
+			iam_id = ibm_iam_trusted_profile.profileID.iam_id
 			roles          = ["Viewer", "Manager"]
 			tags           = ["tag1", "tag2"]
 			description    = "IAM Trusted Profile Policy Update for test scenario"
@@ -626,7 +628,7 @@ func testAccCheckIBMIAMTrustedProfilePolicyService(name string) string {
 	  	}
 	  
 	  	resource "ibm_iam_trusted_profile_policy" "policy" {
-			profile_id = ibm_iam_trusted_profile.profileID.id
+			iam_id = ibm_iam_trusted_profile.profileID.iam_id
 			roles          = ["Viewer"]
 	  
 			resources {
@@ -644,7 +646,7 @@ func testAccCheckIBMIAMTrustedProfilePolicyServiceType(name string) string {
 	  	}
 	  
 	  	resource "ibm_iam_trusted_profile_policy" "policy" {
-			profile_id = ibm_iam_trusted_profile.profileID.id
+			iam_id = ibm_iam_trusted_profile.profileID.iam_id
 			roles          = ["Viewer"]
 	  
 			resources {
@@ -663,7 +665,7 @@ func testAccCheckIBMIAMTrustedProfilePolicyUpdateServiceAndRegion(name string) s
 	  	}
 	  
 	  	resource "ibm_iam_trusted_profile_policy" "policy" {
-			profile_id = ibm_iam_trusted_profile.profileID.id
+			iam_id = ibm_iam_trusted_profile.profileID.iam_id
 			roles          = ["Viewer", "Manager"]
 	  
 			resources {
@@ -689,7 +691,7 @@ func testAccCheckIBMIAMTrustedProfilePolicyResourceInstance(name string) string 
 	  	}
 	  
 	  	resource "ibm_iam_trusted_profile_policy" "policy" {
-			profile_id = ibm_iam_trusted_profile.profileID.id
+			iam_id = ibm_iam_trusted_profile.profileID.iam_id
 			roles          = ["Manager", "Viewer", "Administrator"]
 	  
 			resources {
@@ -714,7 +716,7 @@ func testAccCheckIBMIAMTrustedProfilePolicyResourceGroup(name string) string {
 	  	}
 	  
 	  	resource "ibm_iam_trusted_profile_policy" "policy" {
-			profile_id = ibm_iam_trusted_profile.profileID.id
+			iam_id = ibm_iam_trusted_profile.profileID.iam_id
 			roles          = ["Viewer"]
 	  
 			resources {
@@ -739,7 +741,7 @@ func testAccCheckIBMIAMTrustedProfilePolicyResourceType(name string) string {
 	  	}
 	  
 	  	resource "ibm_iam_trusted_profile_policy" "policy" {
-			profile_id = ibm_iam_trusted_profile.profileID.id
+			iam_id = ibm_iam_trusted_profile.profileID.iam_id
 			roles          = ["Administrator"]
 	  
 			resources {
@@ -758,7 +760,7 @@ func testAccCheckIBMIAMTrustedProfilePolicyImport(name string) string {
 	  	}
 	  
 	  	resource "ibm_iam_trusted_profile_policy" "policy" {
-			profile_id = ibm_iam_trusted_profile.profileID.id
+			iam_id = ibm_iam_trusted_profile.profileID.iam_id
 			roles          = ["Viewer"]
 	  	}
 
@@ -773,7 +775,7 @@ func testAccCheckIBMIAMTrustedProfilePolicyAccountManagement(name string) string
 	  	}
 	  
 	  	resource "ibm_iam_trusted_profile_policy" "policy" {
-			profile_id     = ibm_iam_trusted_profile.profileID.id
+			iam_id     = ibm_iam_trusted_profile.profileID.iam_id
 			roles              = ["Viewer"]
 			account_management = true
 	  	}
@@ -796,7 +798,7 @@ func testAccCheckIBMIAMTrustedProfilePolicyWithCustomRole(name, crName, displayN
 		}
 	  
 	  	resource "ibm_iam_trusted_profile_policy" "policy" {
-			profile_id = ibm_iam_trusted_profile.profileID.id
+			iam_id = ibm_iam_trusted_profile.profileID.iam_id
 			roles          = [ibm_iam_custom_role.customrole.display_name,"Viewer"]
 			tags           = ["tag1"]
 			resources {
@@ -814,7 +816,7 @@ func testAccCheckIBMIAMTrustedProfilePolicyResourceAttributes(name string) strin
 	  }
   
 	  resource "ibm_iam_trusted_profile_policy" "policy" {
-		profile_id     = ibm_iam_trusted_profile.profileID.id
+		iam_id     = ibm_iam_trusted_profile.profileID.iam_id
 		roles              = ["Viewer"]
 		resource_attributes {
 			name     = "resource"
@@ -836,7 +838,7 @@ func testAccCheckIBMIAMTrustedProfilePolicyResourceAttributesWithoutWildcard(nam
 	  }
   
 	  resource "ibm_iam_trusted_profile_policy" "policy" {
-		profile_id     = ibm_iam_trusted_profile.profileID.id
+		iam_id     = ibm_iam_trusted_profile.profileID.iam_id
 		roles              = ["Viewer"]
 		resource_attributes {
 			name     = "resource"
@@ -858,7 +860,7 @@ func testAccCheckIBMIAMTrustedProfilePolicyResourceAttributesUpdate(name string)
 	  }
   
 	  resource "ibm_iam_trusted_profile_policy" "policy" {
-		profile_id     = ibm_iam_trusted_profile.profileID.id
+		iam_id     = ibm_iam_trusted_profile.profileID.iam_id
 		roles              = ["Viewer"]
 		resource_attributes {
 			name     = "resource"
@@ -879,7 +881,7 @@ func testAccCheckIBMIAMTrustedProfilePolicyResourceTags(name string) string {
 	  	}
 	  
 	  	resource "ibm_iam_trusted_profile_policy" "policy" {
-			profile_id = ibm_iam_trusted_profile.profileID.id
+			iam_id = ibm_iam_trusted_profile.profileID.iam_id
 			roles          = ["Viewer"]
 			resource_tags {
 				name = "one"
@@ -896,7 +898,7 @@ func testAccCheckIBMIAMTrustedProfilePolicyTransactionId(name string) string {
 	  	}
 	  
 	  	resource "ibm_iam_trusted_profile_policy" "policy" {
-			profile_id = ibm_iam_trusted_profile.profileID.id
+			iam_id = ibm_iam_trusted_profile.profileID.iam_id
 			roles          = ["Viewer"]
 			transaction_id = "terrformTrustedPolicy"
 	  
@@ -914,7 +916,7 @@ func testAccCheckIBMIAMTrustedProfilePolicyUpdateResourceTags(name string) strin
 	  	}
 	  
 	  	resource "ibm_iam_trusted_profile_policy" "policy" {
-			profile_id = ibm_iam_trusted_profile.profileID.id
+			iam_id = ibm_iam_trusted_profile.profileID.iam_id
 			roles          = ["Viewer"]
 			resource_tags {
 				name = "one"
@@ -935,7 +937,7 @@ func testAccCheckIBMIAMTrustedProfilePolicyWeeklyCustomHours(name string) string
 		  }
 
 		  resource "ibm_iam_trusted_profile_policy" "policy" {
-			profile_id = ibm_iam_trusted_profile.profileID.id
+			iam_id = ibm_iam_trusted_profile.profileID.iam_id
 			roles  = ["Viewer"]
 			resources {
 				 service = "kms"
@@ -969,7 +971,7 @@ func testAccCheckIBMIAMTrustedProfilePolicyUpdateConditions(name string) string 
 			}
 
 			resource "ibm_iam_trusted_profile_policy" "policy" {
-			profile_id = ibm_iam_trusted_profile.profileID.id
+			iam_id = ibm_iam_trusted_profile.profileID.iam_id
 			roles  = ["Viewer", "Manager"]
 			resources {
 				 service = "kms"
@@ -1003,7 +1005,7 @@ func testAccCheckIBMIAMTrustedProfilePolicyWeeklyAllDay(name string) string {
 			}
 
 			resource "ibm_iam_trusted_profile_policy" "policy" {
-			profile_id = ibm_iam_trusted_profile.profileID.id
+			iam_id = ibm_iam_trusted_profile.profileID.iam_id
 			roles  = ["Viewer"]
 			resources {
 				 service = "kms"
@@ -1027,7 +1029,7 @@ func testAccCheckIBMIAMTrustedProfilePolicyTimeBasedOnce(name string) string {
 			}
 
 			resource "ibm_iam_trusted_profile_policy" "policy" {
-			profile_id = ibm_iam_trusted_profile.profileID.id
+			iam_id = ibm_iam_trusted_profile.profileID.iam_id
 			roles  = ["Viewer"]
 			resources {
 				 service = "kms"
@@ -1055,7 +1057,7 @@ func testAccCheckIBMIAMTrustedProfilePolicyWithServiceGroupId(name string) strin
 				name = "%s"
 			}
 			resource "ibm_iam_trusted_profile_policy" "policy" {
-				profile_id = ibm_iam_trusted_profile.profileID.id
+				iam_id = ibm_iam_trusted_profile.profileID.iam_id
 				roles           = ["Service ID creator"]
     		resource_attributes {
          		name     = "service_group_id"
@@ -1085,7 +1087,7 @@ func testAccCheckIBMIAMTrustedProfilePolicyUpdateWithServiceGroupId(name string)
 				name = "%s"
 			}
 			resource "ibm_iam_trusted_profile_policy" "policy" {
-				profile_id = ibm_iam_trusted_profile.profileID.id
+				iam_id = ibm_iam_trusted_profile.profileID.iam_id
 				roles           = ["Service ID creator", "User API key creator"]
     		resource_attributes {
          		name     = "service_group_id"
@@ -1116,7 +1118,7 @@ func testAccCheckIBMIAMTrustedProfilePolicyAttributeBasedCondition(name string) 
 		}
 
 		resource "ibm_iam_trusted_profile_policy" "policy" {
-			profile_id = ibm_iam_trusted_profile.profileID.id
+			iam_id = ibm_iam_trusted_profile.profileID.iam_id
 			roles  = ["Writer"]
 			resource_attributes {
 				value = "cloud-object-storage"
@@ -1183,7 +1185,7 @@ func testAccCheckIBMIAMTrustedProfilePolicyUpdateAttributeBasedCondition(name st
 		}
 
 		resource "ibm_iam_trusted_profile_policy" "policy" {
-			profile_id = ibm_iam_trusted_profile.profileID.id
+			iam_id = ibm_iam_trusted_profile.profileID.iam_id
 			roles  = ["Reader", "Writer"]
 			resource_attributes {
 				value = "cloud-object-storage"

--- a/website/docs/d/iam_service_policy.html.markdown
+++ b/website/docs/d/iam_service_policy.html.markdown
@@ -14,7 +14,7 @@ Retrieve information about an IAM service policy. For more information, about IA
 
 ```terraform
 resource "ibm_iam_service_policy" "policy" {
-  iam_service_id = "ServiceId-d7bec597-4726-451f-8a63-e62e6f19c32c"
+  iam_id = "iam-ServiceId-d7bec597-4726-451f-8a63-e62e6f19c32c"
   roles          = ["Manager", "Viewer", "Administrator"]
 
   resources {
@@ -25,7 +25,7 @@ resource "ibm_iam_service_policy" "policy" {
 }
 
 data "ibm_iam_service_policy" "testacc_ds_service_policy" {
-  iam_service_id = ibm_iam_service_policy.policy.iam_service_id
+  iam_id = ibm_iam_service_policy.policy.iam_id
   transaction_id = "terrformServicePolicy"
 }
 
@@ -35,8 +35,7 @@ data "ibm_iam_service_policy" "testacc_ds_service_policy" {
 
 Review the argument references that you can specify for your data source.
 
-- `iam_service_id` - (Required, String) The UUID of the service ID.
-- `iam_id` - (Optional, String) IAM ID of the service ID. One of the `iam_service_id` or `iam_id` is required argument. You can use to get cross account service ID policy.
+- `iam_id` - (Required, String) IAM ID of the service ID.
 - `sort`- Optional -  (String) The single field sort query for policies.
 - `transaction_id`- (Optional, String) The TransactionID can be passed to your request for the tracking calls.
 

--- a/website/docs/d/iam_trusted_profile_policy.html.markdown
+++ b/website/docs/d/iam_trusted_profile_policy.html.markdown
@@ -14,7 +14,7 @@ Retrieve information about an IAM trusted profile policy. For more information, 
 
 ```terraform
 resource "ibm_iam_trusted_profile_policy" "policy" {
-  profile_id = ibm_iam_trusted_profile_link.iam_trusted_profile_link.profile_id
+  profile_id = ibm_iam_trusted_profile_link.iam_trusted_profile_link.iam_id
   roles      = ["Manager", "Viewer", "Administrator"]
 
   resources {
@@ -25,7 +25,7 @@ resource "ibm_iam_trusted_profile_policy" "policy" {
 }
 
 data "ibm_iam_trusted_profile_policy" "policy" {
-  profile_id = ibm_iam_trusted_profile_policy.policy.profile_id
+  iam_id = ibm_iam_trusted_profile_policy.policy.iam_id
   transaction_id = "terrformTrustedPolicy"
 }
 
@@ -35,8 +35,7 @@ data "ibm_iam_trusted_profile_policy" "policy" {
 
 Review the argument references that you can specify for your data source.
 
-- `profile_id` - (Required, String) The UUID of the trusted profile. Either `profile_id` or `iam_id` is required.
-- `iam_id` - (Optional, String) IAM ID of the trusted profile. Either `profile_id` or `iam_id` is required.
+- `iam_id` - (Required, String) IAM ID of the trusted profile.
 - `sort`- Optional -  (String) The single field sort query for policies.
 - `transaction_id`- (Optional, String) The TransactionID can be passed to your request for the tracking calls.
 
@@ -48,7 +47,7 @@ In addition to all argument reference list, you can access the following attribu
 
   Nested scheme for `policies`:
   - `description`  (String) The description of the IAM trusted profile policy.
-  - `id` - (String) The unique identifier of the IAM trusted profile policy. The ID is composed of `<profile_id>/<profile_policy_id>`. If policy is created by using <profile_id>. The ID is composed of `<iam_id>/<profile_policy_id>` if policy is created by using <iam_id>.
+  - `id` - (String) The unique identifier of the IAM trusted profile policy.
   - `roles`-  (String) The roles that are assigned to the policy.
   - `resources`- (List of objects) A nested block describes the resources in the policy.
   

--- a/website/docs/r/iam_service_policy.html.markdown
+++ b/website/docs/r/iam_service_policy.html.markdown
@@ -21,7 +21,7 @@ resource "ibm_iam_service_id" "service_id" {
 }
 
 resource "ibm_iam_service_policy" "policy" {
-  iam_service_id = ibm_iam_service_id.service_id.id
+  iam_id = ibm_iam_service_id.service_id.iam_id
   roles          = ["Viewer"]
   description    = "IAM Service Policy"
   
@@ -43,7 +43,7 @@ resource "ibm_iam_service_id" "service_id" {
 }
 
 resource "ibm_iam_service_policy" "policy" {
-  iam_service_id = ibm_iam_service_id.service_id.id
+  iam_id = ibm_iam_service_id.service_id.iam_id
   roles          = ["Viewer", "Manager"]
 
   resources {
@@ -68,7 +68,7 @@ resource "ibm_resource_instance" "instance" {
 }
 
 resource "ibm_iam_service_policy" "policy" {
-  iam_service_id = ibm_iam_service_id.service_id.id
+  iam_id = ibm_iam_service_id.service_id.iam_id
   roles          = ["Manager", "Viewer", "Administrator"]
 
   resources {
@@ -91,7 +91,7 @@ data "ibm_resource_group" "group" {
 }
 
 resource "ibm_iam_service_policy" "policy" {
-  iam_service_id = ibm_iam_service_id.service_id.id
+  iam_id = ibm_iam_service_id.service_id.iam_id
   roles          = ["Viewer"]
 
   resources {
@@ -114,7 +114,7 @@ data "ibm_resource_group" "group" {
 }
 
 resource "ibm_iam_service_policy" "policy" {
-  iam_service_id = ibm_iam_service_id.service_id.id
+  iam_id = ibm_iam_service_id.service_id.iam_id
   roles          = ["Administrator"]
 
   resources {
@@ -137,7 +137,7 @@ data "ibm_resource_group" "group" {
 }
 
 resource "ibm_iam_service_policy" "policy" {
-  iam_service_id = ibm_iam_service_id.service_id.id
+  iam_id = ibm_iam_service_id.service_id.iam_id
   roles          = ["Administrator"]
 
   resources {
@@ -184,7 +184,7 @@ resource "ibm_iam_service_id" "service_id" {
   name = "test"
 }
 resource "ibm_iam_service_policy" "policy" {
-  iam_service_id = ibm_iam_service_id.service_id.id
+  iam_id = ibm_iam_service_id.service_id.iam_id
   roles           = ["Viewer"]
   resource_attributes {
     name  = "resource"
@@ -206,7 +206,7 @@ resource "ibm_iam_service_id" "service_id" {
 }
 
 resource "ibm_iam_service_policy" "policy" {
-  iam_service_id = ibm_iam_service_id.service_id.id
+  iam_id = ibm_iam_service_id.service_id.iam_id
   roles          = ["Viewer"]
 
   resources {
@@ -226,7 +226,7 @@ resource "ibm_iam_service_id" "service_id" {
 }
 
 resource "ibm_iam_service_policy" "policy" {
-  iam_service_id = ibm_iam_service_id.service_id.id
+  iam_id = ibm_iam_service_id.service_id.iam_id
   roles      = ["Viewer"]
   resources {
     service = "kms"
@@ -276,7 +276,7 @@ resource "ibm_iam_service_id" "service_id" {
   name = "test"
 }
 resource "ibm_iam_service_policy" "policy" {
-  iam_service_id = ibm_iam_service_id.service_id.id
+  iam_id = ibm_iam_service_id.service_id.iam_id
   roles  = ["Writer"]
   resource_attributes {
     value = "cloud-object-storage"
@@ -340,8 +340,7 @@ Review the argument references that you can specify for your resource.
 
 - `account_management` - (Optional, Bool) Gives access to all account management services if set to **true**. Default value is **false**. If you set this option, do not set `resources` at the same time.**Note** Conflicts with `resources` and `resource_attributes`.
 - `description`  (Optional, String) The description of the IAM Service Policy.
-- `iam_service_id` - (Required, Forces new resource, String) The UUID of the service ID.
-- `iam_id` - (Optional,  Forces new resource, String) IAM ID of the service ID. Used to assign cross account service ID policy. Either `iam_service_id` or `iam_id` is required.
+- `iam_id` - (Optional,  Forces new resource, String) IAM ID of the service ID.
 - `resources` - (List of Objects) Optional- A nested block describes the resource of this policy.**Note** Conflicts with `account_management` and `resource_attributes`.
 
   Nested scheme for `resources`:
@@ -391,23 +390,23 @@ Review the argument references that you can specify for your resource.
 ## Attribute reference
 In addition to all argument reference list, you can access the following attribute reference after your resource is created.
 
-- `id`  - (String) The unique identifier of the service policy. The ID is composed of `<iam_service_id>/<service_policy_id>`. If policy is created by using `<iam_service_id>`. The ID is composed of `<iam_id>/<service_policy_id>` if policy is created by using `<iam_id>`.
+- `id`  - (String) The unique identifier of the service policy.
 - `version`  - (String) The version of the service policy.
 
 ## Import
 
-The  `ibm_iam_service_policy` resource can be imported by using service ID and service policy ID or IAM ID and service policy ID.
+The  `ibm_iam_service_policy` resource can be imported by using IAM ID and service policy ID.
 
 **Syntax**
 
 ```
-$ terraform import ibm_iam_service_policy.example <service_ID>/<service_policy_ID>
+$ terraform import ibm_iam_service_policy.example <iam-service_ID>/<service_policy_ID>
 ```
 
 **Example**
 
 ```
-$ terraform import ibm_iam_service_policy.example ServiceId-d7bec597-4726-451f-8a63-e62e6f19c32c/cea6651a-bc0a-4438-9f8a-a0770bbf3ebb
+$ terraform import ibm_iam_service_policy.example iam-ServiceId-d7bec597-4726-451f-8a63-e62e6f19c32c/cea6651a-bc0a-4438-9f8a-a0770bbf3ebb
 
 ```
 

--- a/website/docs/r/iam_trusted_profile_policy.html.markdown
+++ b/website/docs/r/iam_trusted_profile_policy.html.markdown
@@ -21,7 +21,7 @@ resource "ibm_iam_trusted_profile" "profile_id" {
 }
 
 resource "ibm_iam_trusted_profile_policy" "policy" {
-  profile_id  = ibm_iam_trusted_profile.profile_id.id
+  iam_id  = ibm_iam_trusted_profile.profile_id.iam_id
   roles       = ["Viewer"]
   description = "IAM Trusted Profile Policy"
   
@@ -42,7 +42,7 @@ resource "ibm_iam_trusted_profile" "profile_id" {
 }
 
 resource "ibm_iam_trusted_profile_policy" "policy" {
-  profile_id = ibm_iam_trusted_profile.profile_id.id
+  iam_id = ibm_iam_trusted_profile.profile_id.iam_id
   roles      = ["Viewer", "Manager"]
 
   resources {
@@ -67,7 +67,7 @@ resource "ibm_resource_instance" "instance" {
 }
 
 resource "ibm_iam_trusted_profile_policy" "policy" {
-  profile_id = ibm_iam_trusted_profile.profile_id.id
+  iam_id = ibm_iam_trusted_profile.profile_id.iam_id
   roles      = ["Manager", "Viewer", "Administrator"]
 
   resources {
@@ -90,7 +90,7 @@ data "ibm_resource_group" "group" {
 }
 
 resource "ibm_iam_trusted_profile_policy" "policy" {
-  profile_id = ibm_iam_trusted_profile.profile_id.id
+  iam_id = ibm_iam_trusted_profile.profile_id.iam_id
   roles      = ["Viewer"]
 
   resources {
@@ -113,7 +113,7 @@ data "ibm_resource_group" "group" {
 }
 
 resource "ibm_iam_trusted_profile_policy" "policy" {
-  profile_id = ibm_iam_trusted_profile.profile_id.id
+  iam_id = ibm_iam_trusted_profile.profile_id.iam_id
   roles      = ["Administrator"]
 
   resources {
@@ -136,7 +136,7 @@ data "ibm_resource_group" "group" {
 }
 
 resource "ibm_iam_trusted_profile_policy" "policy" {
-  profile_id = ibm_iam_trusted_profile.profile_id.id
+  iam_id = ibm_iam_trusted_profile.profile_id.iam_id
   roles      = ["Administrator"]
 
   resources {
@@ -157,7 +157,7 @@ resource "ibm_iam_trusted_profile" "profile_id" {
   name = "test"
 }
 resource "ibm_iam_trusted_profile_policy" "policy" {
-  profile_id = ibm_iam_trusted_profile.profile_id.id
+  iam_id = ibm_iam_trusted_profile.profile_id.iam_id
   roles      = ["Viewer"]
   resource_attributes {
     name     = "resource"
@@ -176,7 +176,7 @@ resource "ibm_iam_trusted_profile" "profile_id" {
   name = "test"
 }
 resource "ibm_iam_trusted_profile_policy" "policy" {
-  profile_id = ibm_iam_trusted_profile.profile_id.id
+  iam_id = ibm_iam_trusted_profile.profile_id.iam_id
   roles      = ["Viewer"]
 
   resource_attributes {
@@ -198,7 +198,7 @@ resource "ibm_iam_trusted_profile" "profile_id" {
 }
 
 resource "ibm_iam_trusted_profile_policy" "policy" {
-  profile_id = ibm_iam_trusted_profile.profile_id.id
+  iam_id = ibm_iam_trusted_profile.profile_id.iam_id
   roles      = ["Viewer"]
 
   resources {
@@ -218,7 +218,7 @@ resource "ibm_iam_trusted_profile" "profile_id" {
 }
 
 resource "ibm_iam_trusted_profile_policy" "policy" {
-  profile_id = ibm_iam_trusted_profile.profile_id.id
+  iam_id = ibm_iam_trusted_profile.profile_id.iam_id
   roles      = ["Viewer"]
   resources {
     service = "kms"
@@ -269,7 +269,7 @@ resource "ibm_iam_trusted_profile" "profile_id" {
   name = "test"
 }
 resource "ibm_iam_trusted_profile_policy" "policy" {
-  profile_id = ibm_iam_trusted_profile.profile_id.id
+  iam_id = ibm_iam_trusted_profile.profile_id.iam_id
   roles  = ["Writer"]
   resource_attributes {
     value = "cloud-object-storage"
@@ -334,8 +334,7 @@ Review the argument references that you can specify for your resource.
 
 - `account_management` - (Optional, Bool) Gives access to all account management services if set to **true**. Default value is **false**. If you set this option, do not set `resources` at the same time.**Note** Conflicts with `resources` and `resource_attributes`.
 - `description`  (Optional, String) The description of the IAM Trusted Profile Policy.
-- `profile_id` - (Optional, Forces new resource, String) The UUID of the trusted profile. Either `profile_id` or `iam_id` is required.
-- `iam_id` - (Optional,  Forces new resource, String) IAM ID of the truestedprofile. Either `profile_id` or `iam_id` is required.
+- `iam_id` - (Required,  Forces new resource, String) IAM ID of the truestedprofile.
 - `resources` - (List of Objects) Optional- A nested block describes the resource of this policy.**Note** Conflicts with `account_management` and `resource_attributes`.
 
   Nested scheme for `resources`:
@@ -385,17 +384,17 @@ Review the argument references that you can specify for your resource.
 ## Attribute reference
 In addition to all argument reference list, you can access the following attribute reference after your resource is created.
 
-- `id`  - (String) The unique identifier of the trusted profile policy. The ID is composed of `<profile_id>/<profile_policy_id>`. If policy is created by using `<profile_id>`. The ID is composed of `<iam_id>/<profile_policy_id>` if policy is created by using `<iam_id>`.
+- `id`  - (String) The unique identifier of the trusted profile policy.
 - `version`  - (String) The version of the trusted profile policy.
 
 ## Import
 
-The  `ibm_iam_trusted_profile_policy` resource can be imported by using profile ID and trusted profile policy ID or IAM ID and trusted profile policy ID.
+The  `ibm_iam_trusted_profile_policy` resource can be imported by using IAM ID and trusted profile policy ID.
 
 **Syntax**
 
 ```
-$ terraform import ibm_iam_trusted_profile_policy.example <profile_id>/<profile_policy_id>
+$ terraform import ibm_iam_trusted_profile_policy.example <iam_id>/<profile_policy_id>
 ```
 
 **Example**
@@ -405,8 +404,3 @@ $ terraform import ibm_iam_trusted_profile_policy.example "iam-Profile-b75c9be6-
 
 ```
 
-or 
-
-```
-$ terraform import ibm_iam_trusted_profile_policy.example "Profile-b75c9be6-17f1-4089-aba8-62065b1c8cfe/4e7936c9-b555-4d01-b607-6ae69ccf85c0"
-```


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/IBM-Cloud/terraform-provider-ibm/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes https://github.ibm.com/IAM/AM-issues/issues/3414

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TEST=./ibm/service/iampolicy TESTARGS="-run TestAccIBMIAMServicePolicy"

=== RUN   TestAccIBMIAMServicePolicyDataSource_Basic
--- PASS: TestAccIBMIAMServicePolicyDataSource_Basic (51.93s)
=== RUN   TestAccIBMIAMServicePolicyDataSource_Multiple_Policies
--- PASS: TestAccIBMIAMServicePolicyDataSource_Multiple_Policies (54.47s)
=== RUN   TestAccIBMIAMServicePolicyDataSourceServiceSpecificAttributesConfig
--- PASS: TestAccIBMIAMServicePolicyDataSourceServiceSpecificAttributesConfig (24.73s)
=== RUN   TestAccIBMIAMServicePolicyDataSource_Time_Based_Conditions_Weekly
--- PASS: TestAccIBMIAMServicePolicyDataSource_Time_Based_Conditions_Weekly (46.87s)
=== RUN   TestAccIBMIAMServicePolicyDataSource_Time_Based_Conditions_Custom
--- PASS: TestAccIBMIAMServicePolicyDataSource_Time_Based_Conditions_Custom (24.74s)
=== RUN   TestAccIBMIAMServicePolicyDataSource_ServiceGroupID
--- PASS: TestAccIBMIAMServicePolicyDataSource_ServiceGroupID (23.02s)
=== RUN   TestAccIBMIAMServicePolicy_Basic
--- PASS: TestAccIBMIAMServicePolicy_Basic (35.90s)
=== RUN   TestAccIBMIAMServicePolicy_With_Service
--- PASS: TestAccIBMIAMServicePolicy_With_Service (33.73s)
=== RUN   TestAccIBMIAMServicePolicy_With_ServiceType
--- PASS: TestAccIBMIAMServicePolicy_With_ServiceType (18.48s)
=== RUN   TestAccIBMIAMServicePolicy_With_ResourceInstance
--- PASS: TestAccIBMIAMServicePolicy_With_ResourceInstance (46.92s)
=== RUN   TestAccIBMIAMServicePolicy_With_Resource_Group
--- PASS: TestAccIBMIAMServicePolicy_With_Resource_Group (21.95s)
=== RUN   TestAccIBMIAMServicePolicy_With_Resource_Type
--- PASS: TestAccIBMIAMServicePolicy_With_Resource_Type (23.37s)
=== RUN   TestAccIBMIAMServicePolicy_import
--- PASS: TestAccIBMIAMServicePolicy_import (23.20s)
=== RUN   TestAccIBMIAMServicePolicy_account_management
--- PASS: TestAccIBMIAMServicePolicy_account_management (20.43s)
=== RUN   TestAccIBMIAMServicePolicyWithCustomRole
--- PASS: TestAccIBMIAMServicePolicyWithCustomRole (20.40s)
=== RUN   TestAccIBMIAMServicePolicy_With_Resource_Attributes
--- PASS: TestAccIBMIAMServicePolicy_With_Resource_Attributes (35.25s)
=== RUN   TestAccIBMIAMServicePolicy_With_Resource_Tags
--- PASS: TestAccIBMIAMServicePolicy_With_Resource_Tags (36.40s)
=== RUN   TestAccIBMIAMServicePolicy_With_Transaction_Id
--- PASS: TestAccIBMIAMServicePolicy_With_Transaction_Id (37.86s)
=== RUN   TestAccIBMIAMServicePolicy_With_Time_Based_Conditions_Weekly_Custom
--- PASS: TestAccIBMIAMServicePolicy_With_Time_Based_Conditions_Weekly_Custom (37.10s)
=== RUN   TestAccIBMIAMServicePolicy_With_Time_Based_Conditions_Weekly_All_Day
--- PASS: TestAccIBMIAMServicePolicy_With_Time_Based_Conditions_Weekly_All_Day (19.56s)
=== RUN   TestAccIBMIAMServicePolicy_With_Time_Based_Conditions_Once
--- PASS: TestAccIBMIAMServicePolicy_With_Time_Based_Conditions_Once (19.50s)
=== RUN   TestAccIBMIAMServicePolicy_With_Update_To_Time_Based_Conditions
--- PASS: TestAccIBMIAMServicePolicy_With_Update_To_Time_Based_Conditions (27.01s)
=== RUN   TestAccIBMIAMServicePolicy_With_ServiceGroupID
--- PASS: TestAccIBMIAMServicePolicy_With_ServiceGroupID (35.97s)
=== RUN   TestAccIBMIAMServicePolicy_With_Attribute_Based_Condition
--- PASS: TestAccIBMIAMServicePolicy_With_Attribute_Based_Condition (37.22s)
=== RUN   TestAccIBMIAMServicePolicy_With_Resource_Attributes_Without_Wildcard
--- PASS: TestAccIBMIAMServicePolicy_With_Resource_Attributes_Without_Wildcard (19.10s)
PASS
ok  	github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/iampolicy	776.952s

make testacc TEST=./ibm/service/iampolicy TESTARGS="-run TestAccIBMIAMTrustedProfilePolicy"

=== RUN   TestAccIBMIAMTrustedProfilePolicyDataSource_Basic
--- PASS: TestAccIBMIAMTrustedProfilePolicyDataSource_Basic (68.96s)
=== RUN   TestAccIBMIAMTrustedProfilePolicyDataSource_Multiple_Policies
--- PASS: TestAccIBMIAMTrustedProfilePolicyDataSource_Multiple_Policies (69.03s)
=== RUN   TestAccIBMIAMTrustedProfilePolicyDataSourceServiceSpecificAttributesConfig
--- PASS: TestAccIBMIAMTrustedProfilePolicyDataSourceServiceSpecificAttributesConfig (36.19s)
=== RUN   TestAccIBMIAMTrustedProfilePolicyDataSource_Time_Based_Conditions_Weekly
--- PASS: TestAccIBMIAMTrustedProfilePolicyDataSource_Time_Based_Conditions_Weekly (35.50s)
=== RUN   TestAccIBMIAMTrustedProfilePolicyDataSource_Time_Based_Conditions_Custom
--- PASS: TestAccIBMIAMTrustedProfilePolicyDataSource_Time_Based_Conditions_Custom (36.16s)
=== RUN   TestAccIBMIAMTrustedProfilePolicyDataSource_ServiceGroupID
--- PASS: TestAccIBMIAMTrustedProfilePolicyDataSource_ServiceGroupID (34.48s)
=== RUN   TestAccIBMIAMTrustedProfilePolicyBasic
--- PASS: TestAccIBMIAMTrustedProfilePolicyBasic (53.29s)
=== RUN   TestAccIBMIAMTrustedProfilePolicy_With_Service
--- PASS: TestAccIBMIAMTrustedProfilePolicy_With_Service (55.06s)
=== RUN   TestAccIBMIAMTrustedProfilePolicy_With_ServiceType
--- PASS: TestAccIBMIAMTrustedProfilePolicy_With_ServiceType (28.42s)
=== RUN   TestAccIBMIAMTrustedProfilePolicy_With_ResourceInstance
--- PASS: TestAccIBMIAMTrustedProfilePolicy_With_ResourceInstance (57.02s)
=== RUN   TestAccIBMIAMTrustedProfilePolicy_With_Resource_Group
--- PASS: TestAccIBMIAMTrustedProfilePolicy_With_Resource_Group (36.69s)
=== RUN   TestAccIBMIAMTrustedProfilePolicy_With_Resource_Type
--- PASS: TestAccIBMIAMTrustedProfilePolicy_With_Resource_Type (38.64s)
=== RUN   TestAccIBMIAMTrustedProfilePolicy_import
--- PASS: TestAccIBMIAMTrustedProfilePolicy_import (32.52s)
=== RUN   TestAccIBMIAMTrustedProfilePolicy_account_management
--- PASS: TestAccIBMIAMTrustedProfilePolicy_account_management (28.55s)
=== RUN   TestAccIBMIAMTrustedProfilePolicyWithCustomRole
--- PASS: TestAccIBMIAMTrustedProfilePolicyWithCustomRole (25.99s)
=== RUN   TestAccIBMIAMTrustedProfilePolicy_With_Resource_Attributes
--- PASS: TestAccIBMIAMTrustedProfilePolicy_With_Resource_Attributes (52.72s)
=== RUN   TestAccIBMIAMTrustedProfilePolicy_With_Resource_Attributes_Without_Wildcard
--- PASS: TestAccIBMIAMTrustedProfilePolicy_With_Resource_Attributes_Without_Wildcard (28.60s)
=== RUN   TestAccIBMIAMTrustedProfilePolicy_With_Resource_Tags
--- PASS: TestAccIBMIAMTrustedProfilePolicy_With_Resource_Tags (57.38s)
=== RUN   TestAccIBMIAMTrustedProfilePolicy_With_Transaction_Id
--- PASS: TestAccIBMIAMTrustedProfilePolicy_With_Transaction_Id (29.26s)
=== RUN   TestAccIBMIAMTrustedProfilePolicy_With_Time_Based_Conditions_Weekly_Custom
--- PASS: TestAccIBMIAMTrustedProfilePolicy_With_Time_Based_Conditions_Weekly_Custom (52.50s)
=== RUN   TestAccIBMIAMTrustedProfilePolicy_With_Time_Based_Conditions_Weekly_All_Day
--- PASS: TestAccIBMIAMTrustedProfilePolicy_With_Time_Based_Conditions_Weekly_All_Day (27.83s)
=== RUN   TestAccIBMIAMTrustedProfilePolicy_With_Time_Based_Conditions_Once
--- PASS: TestAccIBMIAMTrustedProfilePolicy_With_Time_Based_Conditions_Once (28.31s)
=== RUN   TestAccIBMIAMTrustedProfilePolicy_With_Update_To_Time_Based_Conditions
--- PASS: TestAccIBMIAMTrustedProfilePolicy_With_Update_To_Time_Based_Conditions (42.99s)
=== RUN   TestAccIBMIAMTrustedProfilePolicy_With_ServiceGroupID
--- PASS: TestAccIBMIAMTrustedProfilePolicy_With_ServiceGroupID (52.68s)
=== RUN   TestAccIBMIAMTrustedProfilePolicy_With_Attribute_Based_Condition
--- PASS: TestAccIBMIAMTrustedProfilePolicy_With_Attribute_Based_Condition (55.06s)
PASS
ok  	github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/iampolicy	1066.438s

```
