### PR TITLE
deprecate iam_service_id and profile_id while creation of policies

### DIFF
--- a/ibm/service/iampolicy/data_source_ibm_iam_service_policy.go
+++ b/ibm/service/iampolicy/data_source_ibm_iam_service_policy.go
@@ -23,18 +23,17 @@ func DataSourceIBMIAMServicePolicy() *schema.Resource {
 
 		Schema: map[string]*schema.Schema{
 			"iam_service_id": {
-				Type:         schema.TypeString,
-				Optional:     true,
-				ExactlyOneOf: []string{"iam_service_id", "iam_id"},
-				Description:  "UUID of ServiceID",
+				Type:        schema.TypeString,
+				Optional:    true,
+				Deprecated:  "This field is deprecated and will be removed starting with this 1.82.0 release. Please use iam_id field instead.",
+				Description: "UUID of ServiceID",
 				ValidateFunc: validate.InvokeDataSourceValidator("ibm_iam_service_policy",
 					"iam_service_id"),
 			},
 			"iam_id": {
-				Type:         schema.TypeString,
-				Optional:     true,
-				ExactlyOneOf: []string{"iam_service_id", "iam_id"},
-				Description:  "IAM ID of ServiceID",
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "IAM ID of ServiceID",
 			},
 			"sort": {
 				Description: "Sort query for policies",

--- a/ibm/service/iampolicy/data_source_ibm_iam_trusted_profile_policy.go
+++ b/ibm/service/iampolicy/data_source_ibm_iam_trusted_profile_policy.go
@@ -23,18 +23,17 @@ func DataSourceIBMIAMTrustedProfilePolicy() *schema.Resource {
 
 		Schema: map[string]*schema.Schema{
 			"profile_id": {
-				Type:         schema.TypeString,
-				Optional:     true,
-				ExactlyOneOf: []string{"profile_id", "iam_id"},
-				Description:  "UUID of trusted profile",
+				Type:        schema.TypeString,
+				Optional:    true,
+				Deprecated:  "This field is deprecated and will be removed starting with this 1.82.0 release. Please use iam_id field instead.",
+				Description: "UUID of trusted profile",
 				ValidateFunc: validate.InvokeDataSourceValidator("ibm_iam_trusted_profile_policy",
 					"profile_id"),
 			},
 			"iam_id": {
-				Type:         schema.TypeString,
-				Optional:     true,
-				ExactlyOneOf: []string{"profile_id", "iam_id"},
-				Description:  "IAM ID of trusted profile",
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "IAM ID of trusted profile",
 			},
 			"sort": {
 				Description: "Sort query for policies",

--- a/ibm/service/iampolicy/resource_ibm_iam_service_policy.go
+++ b/ibm/service/iampolicy/resource_ibm_iam_service_policy.go
@@ -39,20 +39,19 @@ func ResourceIBMIAMServicePolicy() *schema.Resource {
 
 		Schema: map[string]*schema.Schema{
 			"iam_service_id": {
-				Type:         schema.TypeString,
-				Optional:     true,
-				ExactlyOneOf: []string{"iam_service_id", "iam_id"},
-				Description:  "UUID of ServiceID",
-				ForceNew:     true,
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "UUID of ServiceID",
+				ForceNew:    true,
+				Deprecated:  "This field is deprecated and will be removed starting with this 1.82.0 release. Please use iam_id field instead.",
 				ValidateFunc: validate.InvokeValidator("ibm_iam_service_policy",
 					"iam_service_id"),
 			},
 			"iam_id": {
-				Type:         schema.TypeString,
-				Optional:     true,
-				ExactlyOneOf: []string{"iam_service_id", "iam_id"},
-				Description:  "IAM ID of ServiceID",
-				ForceNew:     true,
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "IAM ID of ServiceID",
+				ForceNew:    true,
 			},
 			"roles": {
 				Type:        schema.TypeList,

--- a/ibm/service/iampolicy/resource_ibm_iam_trusted_profile_policy.go
+++ b/ibm/service/iampolicy/resource_ibm_iam_trusted_profile_policy.go
@@ -39,20 +39,19 @@ func ResourceIBMIAMTrustedProfilePolicy() *schema.Resource {
 
 		Schema: map[string]*schema.Schema{
 			"profile_id": {
-				Type:         schema.TypeString,
-				Optional:     true,
-				ExactlyOneOf: []string{"profile_id", "iam_id"},
-				Description:  "UUID of Trusted Profile",
-				ForceNew:     true,
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "UUID of Trusted Profile",
+				ForceNew:    true,
+				Deprecated:  "This field is deprecated and will be removed starting with this 1.82.0 release. Please use iam_id field instead.",
 				ValidateFunc: validate.InvokeValidator("ibm_iam_trusted_profile_policy",
 					"profile_id"),
 			},
 			"iam_id": {
-				Type:         schema.TypeString,
-				Optional:     true,
-				ExactlyOneOf: []string{"profile_id", "iam_id"},
-				Description:  "IAM ID of Trusted Profile",
-				ForceNew:     true,
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "IAM ID of Trusted Profile",
+				ForceNew:    true,
 			},
 			"roles": {
 				Type:        schema.TypeList,

--- a/website/docs/d/iam_service_policy.html.markdown
+++ b/website/docs/d/iam_service_policy.html.markdown
@@ -35,8 +35,8 @@ data "ibm_iam_service_policy" "testacc_ds_service_policy" {
 
 Review the argument references that you can specify for your data source.
 
-- `iam_service_id` - (Required, String) The UUID of the service ID.
-- `iam_id` - (Optional, String) IAM ID of the service ID. One of the `iam_service_id` or `iam_id` is required argument. You can use to get cross account service ID policy.
+- `iam_service_id` - (Optional, String) The UUID of the service ID. This field is deprecated and will be removed in future releases. Please use iam_id as a replacement.
+- `iam_id` - (Optional, String) IAM ID of the service ID.
 - `sort`- Optional -  (String) The single field sort query for policies.
 - `transaction_id`- (Optional, String) The TransactionID can be passed to your request for the tracking calls.
 

--- a/website/docs/d/iam_trusted_profile_policy.html.markdown
+++ b/website/docs/d/iam_trusted_profile_policy.html.markdown
@@ -35,8 +35,8 @@ data "ibm_iam_trusted_profile_policy" "policy" {
 
 Review the argument references that you can specify for your data source.
 
-- `profile_id` - (Required, String) The UUID of the trusted profile. Either `profile_id` or `iam_id` is required.
-- `iam_id` - (Optional, String) IAM ID of the trusted profile. Either `profile_id` or `iam_id` is required.
+- `profile_id` - (Optional, String) The UUID of the trusted profile. This field is deprecated and will be removed in future releases. Please use iam_id as a replacement.
+- `iam_id` - (Optional, String) IAM ID of the trusted profile.
 - `sort`- Optional -  (String) The single field sort query for policies.
 - `transaction_id`- (Optional, String) The TransactionID can be passed to your request for the tracking calls.
 

--- a/website/docs/r/iam_service_policy.html.markdown
+++ b/website/docs/r/iam_service_policy.html.markdown
@@ -340,7 +340,7 @@ Review the argument references that you can specify for your resource.
 
 - `account_management` - (Optional, Bool) Gives access to all account management services if set to **true**. Default value is **false**. If you set this option, do not set `resources` at the same time.**Note** Conflicts with `resources` and `resource_attributes`.
 - `description`  (Optional, String) The description of the IAM Service Policy.
-- `iam_service_id` - (Required, Forces new resource, String) The UUID of the service ID.
+- `iam_service_id` - (Optional, Forces new resource, String) The UUID of the service ID. This field is deprecated and will be removed in future releases. Please use iam_id as a replacement.
 - `iam_id` - (Optional,  Forces new resource, String) IAM ID of the service ID. Used to assign cross account service ID policy. Either `iam_service_id` or `iam_id` is required.
 - `resources` - (List of Objects) Optional- A nested block describes the resource of this policy.**Note** Conflicts with `account_management` and `resource_attributes`.
 

--- a/website/docs/r/iam_trusted_profile_policy.html.markdown
+++ b/website/docs/r/iam_trusted_profile_policy.html.markdown
@@ -334,8 +334,8 @@ Review the argument references that you can specify for your resource.
 
 - `account_management` - (Optional, Bool) Gives access to all account management services if set to **true**. Default value is **false**. If you set this option, do not set `resources` at the same time.**Note** Conflicts with `resources` and `resource_attributes`.
 - `description`  (Optional, String) The description of the IAM Trusted Profile Policy.
-- `profile_id` - (Optional, Forces new resource, String) The UUID of the trusted profile. Either `profile_id` or `iam_id` is required.
-- `iam_id` - (Optional,  Forces new resource, String) IAM ID of the truestedprofile. Either `profile_id` or `iam_id` is required.
+- `profile_id` - (Optional, Forces new resource, String) The UUID of the trusted profile. This field is deprecated and will be removed in future releases. Please use iam_id as a replacement.
+- `iam_id` - (Optional,  Forces new resource, String) IAM ID of the truestedprofile.
 - `resources` - (List of Objects) Optional- A nested block describes the resource of this policy.**Note** Conflicts with `account_management` and `resource_attributes`.
 
   Nested scheme for `resources`:


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/IBM-Cloud/terraform-provider-ibm/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #https://github.ibm.com/IAM/AM-issues/issues/3414

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
**warning message**
$ terraform apply
ibm_iam_service_policy.policy: Refreshing state... [id=ServiceId-cb8cef2d-91ff-4292-9a1c-0fa230630af0/7de59ff8-6ba1-4875-80de-beed040f5ae6]
╷
│ Warning: Argument is deprecated
│ 
│   with ibm_iam_service_policy.policy,
│   on test.tf line 2, in resource "ibm_iam_service_policy" "policy":
│    2: 	iam_service_id = "ServiceId-xxxxxxx" 
│ 
│ This field is deprecated and will be removed starting with this 1.82.0 release.

Warning: Deprecated attribute
│ 
│   on 1.tf line 24, in data "ibm_iam_trusted_profile_policy" "policy":
│   24:   profile_id = ibm_iam_trusted_profile_policy.policy.profile_id
│ 
│ The attribute "profile_id" is deprecated. Refer to the provider documentation for details.
...
```
