### PR TITLE
fix: handle nil pointer in VPN server route deletion wait

### DIFF
--- a/ibm/service/vpc/resource_ibm_is_vpn_server_route.go
+++ b/ibm/service/vpc/resource_ibm_is_vpn_server_route.go
@@ -415,8 +415,8 @@ func resourceIBMIsVPNServerRouteDelete(context context.Context, d *schema.Resour
 }
 
 func isWaitForVPNServerRouteDeleted(context context.Context, sess *vpcv1.VpcV1, d *schema.ResourceData) (interface{}, error) {
+	log.Printf("Waiting for VPN Server Route(%s) to be deleted.", d.Id())
 
-	log.Printf("Waiting for VPN Server  Route(%s) to be deleted.", d.Id())
 	stateConf := &resource.StateChangeConf{
 		Pending: []string{"retry", isVPNServerRouteStatusDeleting},
 		Target:  []string{isVPNServerStatusDeleted, isVPNServerRouteStatusFailed},
@@ -436,7 +436,7 @@ func isWaitForVPNServerRouteDeleted(context context.Context, sess *vpcv1.VpcV1, 
 				if response != nil && response.StatusCode == 404 {
 					return vpnServerRoute, isVPNServerRouteStatusDeleted, nil
 				}
-				return vpnServerRoute, *vpnServerRoute.LifecycleState, flex.TerraformErrorf(err, fmt.Sprintf("DeleteVPNServerRouteWithContext failed: %s", err.Error()), "ibm_is_vpn_server_route", "delete-wait")
+				return vpnServerRoute, isVPNServerRouteStatusFailed, flex.TerraformErrorf(err, fmt.Sprintf("GetVPNServerRouteWithContext failed: %s", err.Error()), "ibm_is_vpn_server_route", "delete-wait")
 			}
 			return vpnServerRoute, *vpnServerRoute.LifecycleState, nil
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/IBM-Cloud/terraform-provider-ibm/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #6368 

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```
