### PR TITLE
fix: prevent 409 errors in is_virtual_endpoint_gateway by locking on VPC ID during create

### DIFF
--- a/ibm/service/vpc/resource_ibm_is_virtual_endpoint_gateway.go
+++ b/ibm/service/vpc/resource_ibm_is_virtual_endpoint_gateway.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/conns"
 	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/flex"
 	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/validate"
 	"github.com/IBM/go-sdk-core/v5/core"
@@ -336,6 +337,11 @@ func resourceIBMisVirtualEndpointGatewayCreate(context context.Context, d *schem
 	vpcID := d.Get(isVirtualEndpointGatewayVpcID).(string)
 	vpcOpt := &vpcv1.VPCIdentity{
 		ID: core.StringPtr(vpcID),
+	}
+	if vpcID != "" {
+		isVPCKey := "vpe_vpc_key_" + vpcID
+		conns.IbmMutexKV.Lock(isVPCKey)
+		defer conns.IbmMutexKV.Unlock(isVPCKey)
 	}
 
 	// update option


### PR DESCRIPTION
…VPC ID during create

<!--- See what makes a good Pull Request at : https://github.com/IBM-Cloud/terraform-provider-ibm/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```
