### PR TITLE
Remove dhcp option and fix arp-broadcast bug

### DIFF
--- a/ibm/service/power/ibm_pi_constants.go
+++ b/ibm/service/power/ibm_pi_constants.go
@@ -558,7 +558,6 @@ const (
 	DeploymentTypeVMNoStorage = "VMNoStorage"
 	DestinationUnreach        = "destination-unreach"
 	Detach                    = "detach"
-	DHCPVlan                  = "dhcp-vlan"
 	Disable                   = "disable"
 	Echo                      = "echo"
 	EchoReply                 = "echo-reply"

--- a/ibm/service/power/resource_ibm_pi_network.go
+++ b/ibm/service/power/resource_ibm_pi_network.go
@@ -164,10 +164,10 @@ func ResourceIBMPINetwork() *schema.Resource {
 				Type:     schema.TypeList,
 			},
 			Arg_NetworkType: {
-				Description:  "The type of network that you want to create. Valid values are `pub-vlan`, `vlan` and `dhcp-vlan`.",
+				Description:  "The type of network that you want to create. Valid values are `pub-vlan`, and `vlan`.",
 				Required:     true,
 				Type:         schema.TypeString,
-				ValidateFunc: validate.ValidateAllowedStringValues([]string{DHCPVlan, PubVlan, Vlan}),
+				ValidateFunc: validate.ValidateAllowedStringValues([]string{PubVlan, Vlan}),
 			},
 			Arg_UserTags: {
 				Computed:    true,
@@ -252,7 +252,7 @@ func resourceIBMPINetworkCreate(ctx context.Context, d *schema.ResourceData, met
 		body.Peer = peerModel
 	}
 
-	if networktype == DHCPVlan || networktype == Vlan {
+	if networktype == Vlan {
 		var networkcidr string
 		var ipBodyRanges []*models.IPAddressRange
 		if v, ok := d.GetOk(Arg_Cidr); ok {

--- a/ibm/service/power/resource_ibm_pi_network_test.go
+++ b/ibm/service/power/resource_ibm_pi_network_test.go
@@ -120,38 +120,6 @@ func TestAccIBMPINetworkGatewaybasicSatellite(t *testing.T) {
 	})
 }
 
-func TestAccIBMPINetworkDHCPbasic(t *testing.T) {
-	name := fmt.Sprintf("tf-pi-network-%d", acctest.RandIntRange(10, 100))
-	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { acc.TestAccPreCheck(t) },
-		Providers:    acc.TestAccProviders,
-		CheckDestroy: testAccCheckIBMPINetworkDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccCheckIBMPINetworDHCPConfig(name),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckIBMPINetworkExists("ibm_pi_network.power_networks"),
-					resource.TestCheckResourceAttr(
-						"ibm_pi_network.power_networks", "pi_network_name", name),
-					resource.TestCheckResourceAttrSet("ibm_pi_network.power_networks", "pi_gateway"),
-					resource.TestCheckResourceAttrSet("ibm_pi_network.power_networks", "id"),
-					resource.TestCheckResourceAttrSet("ibm_pi_network.power_networks", "pi_ipaddress_range.#"),
-				),
-			},
-			{
-				Config: testAccCheckIBMPINetworkConfigGatewayDHCPUpdateDNS(name),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckIBMPINetworkExists("ibm_pi_network.power_networks"),
-					resource.TestCheckResourceAttr(
-						"ibm_pi_network.power_networks", "pi_network_name", name),
-					resource.TestCheckResourceAttr(
-						"ibm_pi_network.power_networks", "pi_dns.#", "1"),
-				),
-			},
-		},
-	})
-}
-
 func TestAccIBMPINetworkUserTags(t *testing.T) {
 	name := fmt.Sprintf("tf-pi-network-%d", acctest.RandIntRange(10, 100))
 	networkRes := "ibm_pi_network.power_networks"
@@ -354,30 +322,6 @@ func testAccCheckIBMPINetworkConfigGatewayUpdateDNS(name string) string {
 				pi_ending_ip_address = "192.168.17.254"
 				pi_starting_ip_address = "192.168.17.3"
 			}
-		}
-	`, acc.Pi_cloud_instance_id, name)
-}
-
-func testAccCheckIBMPINetworDHCPConfig(name string) string {
-	return fmt.Sprintf(`
-		resource "ibm_pi_network" "power_networks" {
-			pi_cloud_instance_id 		= "%s"
-			pi_network_name      		= "%s"
-			pi_network_type      		= "dhcp-vlan"
-			pi_cidr              		= "10.1.2.0/26"
-			pi_dns               		= ["10.1.0.68"]
-		}
-	`, acc.Pi_cloud_instance_id, name)
-}
-
-func testAccCheckIBMPINetworkConfigGatewayDHCPUpdateDNS(name string) string {
-	return fmt.Sprintf(`
-		resource "ibm_pi_network" "power_networks" {
-			pi_cloud_instance_id = "%s"
-			pi_network_name      = "%s"
-			pi_network_type      = "dhcp-vlan"
-			pi_cidr              = "10.1.2.0/26"
-			pi_dns               = ["10.1.0.69"]
 		}
 	`, acc.Pi_cloud_instance_id, name)
 }

--- a/ibm/service/power/resource_ibm_pi_network_test.go
+++ b/ibm/service/power/resource_ibm_pi_network_test.go
@@ -157,27 +157,6 @@ func TestAccIBMPINetworkUserTags(t *testing.T) {
 	})
 }
 
-func TestAccIBMPINetworkPeerOnPrem(t *testing.T) {
-	name := fmt.Sprintf("tf-pi-network-%d", acctest.RandIntRange(10, 100))
-	networkRes := "ibm_pi_network.power_network_peer"
-	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { acc.TestAccPreCheck(t) },
-		Providers:    acc.TestAccProviders,
-		CheckDestroy: testAccCheckIBMPINetworkDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccCheckIBMPINetworkPeerOnPrem(name),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckIBMPINetworkExists(networkRes),
-					resource.TestCheckResourceAttr(networkRes, "pi_network_name", name),
-					resource.TestCheckResourceAttrSet(networkRes, "id"),
-					resource.TestCheckResourceAttrSet(networkRes, "peer_id"),
-				),
-			},
-		},
-	})
-}
-
 func TestAccIBMPINetworkAdvertiseArpBroadcast(t *testing.T) {
 	name := fmt.Sprintf("tf-pi-network-%d", acctest.RandIntRange(10, 100))
 	networkRes := "ibm_pi_network.power_network_advertise_arpbroadcast"
@@ -335,22 +314,6 @@ func testAccCheckIBMPINetworkUserTagsConfig(name string, userTagsString string) 
 			pi_user_tags         = %s
 		}
 	`, acc.Pi_cloud_instance_id, name, userTagsString)
-}
-
-func testAccCheckIBMPINetworkPeerOnPrem(name string) string {
-	return fmt.Sprintf(`
-		resource "ibm_pi_network" "power_network_peer" {
-			pi_cloud_instance_id 		= "%s"
-			pi_network_name      		= "%s"
-			pi_network_type      		= "vlan"
-			pi_cidr                     = "192.168.17.0/24"
-			
-			pi_network_peer {
-				id = "2"
-				type = "L2"
-			}
-		}
-	`, acc.Pi_cloud_instance_id, name)
 }
 
 func testAccCheckIBMPINetworkAdvertiseArpBroadcast(name string) string {

--- a/website/docs/r/pi_network.html.markdown
+++ b/website/docs/r/pi_network.html.markdown
@@ -58,8 +58,8 @@ The `ibm_pi_network` provides the following [Timeouts](https://www.terraform.io/
 
 Review the argument references that you can specify for your resource.
 
-- `pi_advertise` - (Optional, String) Enable the network to be advertised. Only supported for `vlan` network type.
-- `pi_arp_broadcast` - (Optional, String) Enable ARP Broadcast. Only supported for `vlan` network type.
+- `pi_advertise` - (Optional, String) Enable the network to be advertised. Only supported for `vlan` network type on PER enabled workspaces. Default is `enable` and is only passed in supported workspaces.
+- `pi_arp_broadcast` - (Optional, String) Enable ARP Broadcast. Only supported for `vlan` network type on PER enabled workspaces. Default is `disable` and is only passed in supported workspaces.
 - `pi_cidr` - (Optional, String) The network CIDR. Required for `vlan` network type.
 - `pi_cloud_instance_id` - (Required, String) The GUID of the service instance associated with an account.
 - `pi_dns` - (Optional, Set of String) The DNS Servers for the network. If not specified, default is 127.0.0.1 for 'vlan' (private network) and 9.9.9.9 for 'pub-vlan' (public network). A maximum of one DNS server can be specified for private networks in Power Edge Router workspaces.

--- a/website/docs/r/pi_network.html.markdown
+++ b/website/docs/r/pi_network.html.markdown
@@ -69,7 +69,7 @@ Review the argument references that you can specify for your resource.
   - `pi_starting_ip_address` - (Required, String) The staring ip address. **Note** if the `pi_gateway` or `pi_ipaddress_range` is not provided, it will calculate the value based on CIDR respectively.
 - `pi_network_mtu` - (Optional, Integer) Maximum Transmission Unit option of the network. Minimum is 1450 and maximum is 9000.
 - `pi_network_name` - (Required, String) The name of the network.
-- `pi_network_type` - (Required, String) The type of network that you want to create. Valid values are `pub-vlan`, `vlan` and `dhcp-vlan`.
+- `pi_network_type` - (Required, String) The type of network that you want to create. Valid values are `pub-vlan`, and `vlan`.
 - `pi_network_peer` - (Optional, List) Network peer information (for on-prem locations only). Max items: 1.
 
   Nested schema for `pi_network_peer`:


### PR DESCRIPTION
This PR does a few things:
1. Removes dhcp option in the network resource that was supposed to have been removed earlier with the deprecation of the network fields.
2. Removes associated tests that no longer make sense to run.
3. Fixes corner case in arpbroad-cast code.


I have re-run tests on several private and public workspaces to verify.

Output from acceptance testing:

```
Non-PER public Workspace

--- PASS: TestAccIBMPINetworkbasic (76.35s)
PASS

--- PASS: TestAccIBMPINetworkGatewaybasic (81.14s)
PASS

--- PASS: TestAccIBMPINetworkUserTags (75.04s)
PASS


Non-PER private Workspace

--- PASS: TestAccIBMPINetworkGatewaybasic (73.55s)
PASS

--- PASS: TestAccIBMPINetworkGatewaybasicSatellite (74.40s)
PASS


Public PER Workspace

--- PASS: TestAccIBMPINetworkbasic (145.24s)
PASS

--- PASS: TestAccIBMPINetworkGatewaybasic (166.62s)
PASS

--- PASS: TestAccIBMPINetworkUserTags (147.08s)
PASS

--- PASS: TestAccIBMPINetworkAdvertiseArpBroadcast (270.51s)
PASS
```

This bug fix does apply to the July items. Please merge this as soon as possible.