### PR TITLE
Add .env to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,7 @@ website/node_modules
 *.test
 *.iml
 .vscode
+.env
 website/vendor
 *.attach
 *.xml


### PR DESCRIPTION
At least in PowerVS, the .env is where we set out environment variables to test. Although it is located in .vscode directory, which is already ignored, this will add an additional layer of protection against accidentally leaking credentials.
