### PR TITLE
feat: pre-defined templates and code engine templates support

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/IBM/configuration-aggregator-go-sdk v0.0.2
 	github.com/IBM/container-registry-go-sdk v1.1.0
 	github.com/IBM/continuous-delivery-go-sdk/v2 v2.0.3
-	github.com/IBM/event-notifications-go-admin-sdk v0.15.0
+	github.com/IBM/event-notifications-go-admin-sdk v0.18.0
 	github.com/IBM/eventstreams-go-sdk v1.4.0
 	github.com/IBM/go-sdk-core/v5 v5.20.1
 	github.com/IBM/ibm-backup-recovery-sdk-go v1.0.3

--- a/go.sum
+++ b/go.sum
@@ -116,8 +116,8 @@ github.com/IBM/container-registry-go-sdk v1.1.0 h1:sYyknIod8R4RJZQqAheiduP6wbSTp
 github.com/IBM/container-registry-go-sdk v1.1.0/go.mod h1:4TwsCnQtVfZ4Vkapy/KPvQBKFc3VOyUZYkwRU4FTPrs=
 github.com/IBM/continuous-delivery-go-sdk/v2 v2.0.3 h1:5oyqzqwywzVef30h1qjNEBcgxOvdDiX43ppsZyCTwik=
 github.com/IBM/continuous-delivery-go-sdk/v2 v2.0.3/go.mod h1:Iibf+4gRasEZHakDgnMm7TOX87xex0L+DfghUclcmcg=
-github.com/IBM/event-notifications-go-admin-sdk v0.15.0 h1:5rmEbZmGhJiS+WZOK+ABp83nXmlIG5nLL0b1dCswO1Y=
-github.com/IBM/event-notifications-go-admin-sdk v0.15.0/go.mod h1:9fG6k1gYRqiChZvmn1iRIjaKCXuDBCOlPH6xPJN+mMU=
+github.com/IBM/event-notifications-go-admin-sdk v0.18.0 h1:G4230wYVCjHnHFEcingfMVznjSJeUoSWzyEMsEFYCmo=
+github.com/IBM/event-notifications-go-admin-sdk v0.18.0/go.mod h1:9fG6k1gYRqiChZvmn1iRIjaKCXuDBCOlPH6xPJN+mMU=
 github.com/IBM/eventstreams-go-sdk v1.4.0 h1:yS/Ns29sBOe8W2tynQmz9HTKqQZ0ckse4Py5Oy/F2rM=
 github.com/IBM/eventstreams-go-sdk v1.4.0/go.mod h1:2tuAxaYLctfqfr5jvyqSrxxEQGMwYPm3yJGWSj85YVQ=
 github.com/IBM/go-sdk-core/v5 v5.0.0/go.mod h1:vyNdbFujJtdTj9HbihtvKwwS3k/GKSKpOx9ZIQ6MWDY=

--- a/ibm/provider/provider.go
+++ b/ibm/provider/provider.go
@@ -984,7 +984,7 @@ func Provider() *schema.Provider {
 			"ibm_en_destination_sn":             eventnotification.DataSourceIBMEnServiceNowDestination(),
 			"ibm_en_subscription_sn":            eventnotification.DataSourceIBMEnFCMSubscription(),
 			"ibm_en_destination_ce":             eventnotification.DataSourceIBMEnCodeEngineDestination(),
-			"ibm_en_subscription_ce":            eventnotification.DataSourceIBMEnFCMSubscription(),
+			"ibm_en_subscription_ce":            eventnotification.DataSourceIBMEnCodeEngineSubscription(),
 			"ibm_en_destination_cos":            eventnotification.DataSourceIBMEnCOSDestination(),
 			"ibm_en_subscription_cos":           eventnotification.DataSourceIBMEnFCMSubscription(),
 			"ibm_en_destination_huawei":         eventnotification.DataSourceIBMEnHuaweiDestination(),
@@ -1010,6 +1010,9 @@ func Provider() *schema.Provider {
 			"ibm_en_destination_event_streams":  eventnotification.DataSourceIBMEnEventStreamsDestination(),
 			"ibm_en_subscription_event_streams": eventnotification.DataSourceIBMEnEventStreamsSubscription(),
 			"ibm_en_event_streams_template":     eventnotification.DataSourceIBMEnEventStreamsTemplate(),
+			"ibm_en_pre_defined_template":       eventnotification.DataSourceIBMEnPreDefinedTemplate(),
+			"ibm_en_pre_defined_templates":      eventnotification.DataSourceIBMEnPreDefinedTemplates(),
+			"ibm_en_code_engine_template":       eventnotification.DataSourceIBMEnCodeEngineTemplate(),
 
 			// Added for Toolchain
 			"ibm_cd_toolchain":                         cdtoolchain.DataSourceIBMCdToolchain(),
@@ -1661,7 +1664,7 @@ func Provider() *schema.Provider {
 			"ibm_en_destination_sn":             eventnotification.ResourceIBMEnServiceNowDestination(),
 			"ibm_en_subscription_sn":            eventnotification.ResourceIBMEnFCMSubscription(),
 			"ibm_en_destination_ce":             eventnotification.ResourceIBMEnCodeEngineDestination(),
-			"ibm_en_subscription_ce":            eventnotification.ResourceIBMEnFCMSubscription(),
+			"ibm_en_subscription_ce":            eventnotification.ResourceIBMEnCodeEngineSubscription(),
 			"ibm_en_destination_cos":            eventnotification.ResourceIBMEnCOSDestination(),
 			"ibm_en_subscription_cos":           eventnotification.ResourceIBMEnFCMSubscription(),
 			"ibm_en_destination_huawei":         eventnotification.ResourceIBMEnHuaweiDestination(),
@@ -1683,6 +1686,7 @@ func Provider() *schema.Provider {
 			"ibm_en_destination_event_streams":  eventnotification.ResourceIBMEnEventStreamsDestination(),
 			"ibm_en_subscription_event_streams": eventnotification.ResourceIBMEnEventStreamsSubscription(),
 			"ibm_en_event_streams_template":     eventnotification.ResourceIBMEnEventStreamsTemplate(),
+			"ibm_en_code_engine_template":       eventnotification.ResourceIBMEnCodeEngineTemplate(),
 
 			// Added for Toolchain
 			"ibm_cd_toolchain":                         cdtoolchain.ResourceIBMCdToolchain(),

--- a/ibm/service/eventnotification/data_source_ibm_en_code_engine_subscription.go
+++ b/ibm/service/eventnotification/data_source_ibm_en_code_engine_subscription.go
@@ -1,0 +1,153 @@
+// Copyright IBM Corp. 2021 All Rights Reserved.
+// Licensed under the Mozilla Public License v2.0
+
+package eventnotification
+
+import (
+	"context"
+	"fmt"
+	"log"
+
+	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/conns"
+	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/flex"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	en "github.com/IBM/event-notifications-go-admin-sdk/eventnotificationsv1"
+)
+
+func DataSourceIBMEnCodeEngineSubscription() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceIBMEnCodeEngineSubscriptionRead,
+
+		Schema: map[string]*schema.Schema{
+			"instance_guid": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "Unique identifier for IBM Cloud Event Notifications instance.",
+			},
+			"subscription_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "Unique identifier for result.",
+			},
+			"name": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "Subscription name.",
+			},
+			"description": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "Subscription description.",
+			},
+			"destination_id": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The destination ID.",
+			},
+			"topic_id": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "Topic ID.",
+			},
+			"attributes": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"template_id_notification": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "The templete id for notification",
+						},
+					},
+				},
+			},
+			"updated_at": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "Last updated time.",
+			},
+		},
+	}
+}
+
+func dataSourceIBMEnCodeEngineSubscriptionRead(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	enClient, err := meta.(conns.ClientSession).EventNotificationsApiV1()
+	if err != nil {
+		tfErr := flex.TerraformErrorf(err, err.Error(), "(Data) ibm_en_subscription_ce", "read")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
+	}
+
+	getSubscriptionOptions := &en.GetSubscriptionOptions{}
+
+	getSubscriptionOptions.SetInstanceID(d.Get("instance_guid").(string))
+	getSubscriptionOptions.SetID(d.Get("subscription_id").(string))
+
+	result, _, err := enClient.GetSubscriptionWithContext(context, getSubscriptionOptions)
+	if err != nil {
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("GetIntegrationWithContext failed: %s", err.Error()), "(Data) ibm_en_subscription_ce", "read")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
+	}
+
+	d.SetId(fmt.Sprintf("%s/%s", *getSubscriptionOptions.InstanceID, *getSubscriptionOptions.ID))
+
+	if err = d.Set("name", result.Name); err != nil {
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("Error setting name: %s", err), "(Data) ibm_en_subscription_ce", "read")
+		return tfErr.GetDiag()
+	}
+
+	if result.Description != nil {
+		if err = d.Set("description", result.Description); err != nil {
+			tfErr := flex.TerraformErrorf(err, fmt.Sprintf("Error setting description: %s", err), "(Data) ibm_en_subscription_ce", "read")
+			return tfErr.GetDiag()
+		}
+	}
+	if err = d.Set("updated_at", result.UpdatedAt); err != nil {
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("Error setting updated_at: %s", err), "(Data) ibm_en_subscription_ce", "read")
+		return tfErr.GetDiag()
+	}
+
+	if err = d.Set("destination_id", result.DestinationID); err != nil {
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("Error setting destination_id: %s", err), "(Data) ibm_en_subscription_ce", "read")
+		return tfErr.GetDiag()
+	}
+
+	if err = d.Set("topic_id", result.TopicID); err != nil {
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("Error setting topic_id: %s", err), "(Data) ibm_en_subscription_ce", "read")
+		return tfErr.GetDiag()
+	}
+
+	if result.Attributes != nil {
+		if err = d.Set("attributes", enCodeEngineSubscriptionFlattenAttributes(result.Attributes)); err != nil {
+			tfErr := flex.TerraformErrorf(err, fmt.Sprintf("Error setting attributes: %s", err), "(Data) ibm_en_subscription_ce", "read")
+			return tfErr.GetDiag()
+		}
+	}
+
+	return nil
+}
+
+func enCodeEngineSubscriptionFlattenAttributes(result en.SubscriptionAttributesIntf) (finalList []map[string]interface{}) {
+	finalList = []map[string]interface{}{}
+
+	attributes := result.(*en.SubscriptionAttributes)
+
+	finalMap := enCodeEngineSubscriptionToMap(attributes)
+	finalList = append(finalList, finalMap)
+
+	return finalList
+}
+
+func enCodeEngineSubscriptionToMap(attributeItem *en.SubscriptionAttributes) (attributeMap map[string]interface{}) {
+	attributeMap = map[string]interface{}{}
+
+	if attributeItem.TemplateIDNotification != nil {
+		attributeMap["template_id_notification"] = attributeItem.TemplateIDNotification
+	}
+
+	return attributeMap
+}

--- a/ibm/service/eventnotification/data_source_ibm_en_code_engine_subscription_test.go
+++ b/ibm/service/eventnotification/data_source_ibm_en_code_engine_subscription_test.go
@@ -1,0 +1,87 @@
+// Copyright IBM Corp. 2021 All Rights Reserved.
+// Licensed under the Mozilla Public License v2.0
+
+package eventnotification_test
+
+import (
+	"fmt"
+	"testing"
+
+	acc "github.com/IBM-Cloud/terraform-provider-ibm/ibm/acctest"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+func TestAccIBMEnCodeEngineSubscriptionDataSourceAllArgs(t *testing.T) {
+	instanceName := fmt.Sprintf("tf_instance_%d", acctest.RandIntRange(10, 100))
+	name := fmt.Sprintf("tf_name_%d", acctest.RandIntRange(10, 100))
+	description := fmt.Sprintf("tf_description_%d", acctest.RandIntRange(10, 100))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { acc.TestAccPreCheck(t) },
+		Providers: acc.TestAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckIBMEnCodeEngineSubscriptionDataSourceConfig(instanceName, name, description),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet("data.ibm_en_subscription_ce.data_subscription_1", "id"),
+					resource.TestCheckResourceAttrSet("data.ibm_en_subscription_ce.data_subscription_1", "instance_guid"),
+					resource.TestCheckResourceAttrSet("data.ibm_en_subscription_ce.data_subscription_1", "subscription_id"),
+					resource.TestCheckResourceAttrSet("data.ibm_en_subscription_ce.data_subscription_1", "name"),
+					resource.TestCheckResourceAttrSet("data.ibm_en_subscription_ce.data_subscription_1", "description"),
+					resource.TestCheckResourceAttrSet("data.ibm_en_subscription_ce.data_subscription_1", "updated_at"),
+					resource.TestCheckResourceAttrSet("data.ibm_en_subscription_ce.data_subscription_1", "destination_type"),
+					resource.TestCheckResourceAttrSet("data.ibm_en_subscription_ce.data_subscription_1", "destination_id"),
+					resource.TestCheckResourceAttrSet("data.ibm_en_subscription_ce.data_subscription_1", "destination_name"),
+					resource.TestCheckResourceAttrSet("data.ibm_en_subscription_ce.data_subscription_1", "topic_id"),
+					resource.TestCheckResourceAttrSet("data.ibm_en_subscription_ce.data_subscription_1", "topic_name"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckIBMEnCodeEngineSubscriptionDataSourceConfig(instanceName, name, description string) string {
+	return fmt.Sprintf(`
+	resource "ibm_resource_instance" "en_subscription_datasource" {
+		name     = "%s"
+		location = "us-south"
+		plan     = "standard"
+		service  = "event-notifications"
+	}
+	
+	resource "ibm_en_topic" "en_topic_resource_4" {
+		instance_guid = ibm_resource_instance.en_subscription_datasource.guid
+		name        = "tf_topic_name_0664"
+		description = "tf_topic_description_0455"
+	}
+	
+	resource "ibm_en_destination_ce" "en_destination_resource_2" {
+		instance_guid = ibm_resource_instance.en_subscription_resource.guid
+		name        = "code_engine_destination"
+		type        = "ibmce"
+		description = "code engine destination tf"
+		config {
+			params {
+				type = "application"
+				verb = "POST"
+				url  = "https://test.codetestcodeengine.com"
+			}
+		}
+	}
+	resource "ibm_en_subscription_ce" "en_subscription_resource_1" {
+		name           = "%s"
+		description 	 = "%s"
+		instance_guid    = ibm_resource_instance.en_subscription_resource.guid
+		topic_id       = ibm_en_topic.en_topic_resource_2.topic_id
+		destination_id = ibm_en_destination_ce.en_destination_resource_2.destination_id
+	}
+
+	data "ibm_en_subscription_ce" "data_subscription_1" {
+		instance_guid     = ibm_resource_instance.en_subscription_datasource.guid
+		subscription_id = ibm_en_subscription_ce.en_subscription_resource_4.subscription_id
+	}
+
+	`, instanceName, name, description)
+}

--- a/ibm/service/eventnotification/data_source_ibm_en_code_engine_template.go
+++ b/ibm/service/eventnotification/data_source_ibm_en_code_engine_template.go
@@ -1,0 +1,128 @@
+// Copyright IBM Corp. 2021 All Rights Reserved.
+// Licensed under the Mozilla Public License v2.0
+
+package eventnotification
+
+import (
+	"context"
+	"fmt"
+	"log"
+
+	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/conns"
+	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/flex"
+	en "github.com/IBM/event-notifications-go-admin-sdk/eventnotificationsv1"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+func DataSourceIBMEnCodeEngineTemplate() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceIBMEnCodeEngineTemplateRead,
+
+		Schema: map[string]*schema.Schema{
+			"instance_guid": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "Unique identifier for IBM Cloud Event Notifications instance.",
+			},
+			"template_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "Unique identifier for Template.",
+			},
+			"name": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "Template name.",
+			},
+			"description": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "Template description.",
+			},
+			"type": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "Template type ibmcejob.notification or ibmceapp.notification",
+			},
+			"updated_at": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "Last updated time.",
+			},
+			"subscription_count": {
+				Type:        schema.TypeInt,
+				Computed:    true,
+				Description: "Number of subscriptions.",
+			},
+			"subscription_names": {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Description: "List of subscriptions.",
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
+			},
+		},
+	}
+}
+
+func dataSourceIBMEnCodeEngineTemplateRead(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	enClient, err := meta.(conns.ClientSession).EventNotificationsApiV1()
+	if err != nil {
+		tfErr := flex.TerraformErrorf(err, err.Error(), "(Data) ibm_en_code_engine_template", "read")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
+	}
+
+	options := &en.GetTemplateOptions{}
+
+	options.SetInstanceID(d.Get("instance_guid").(string))
+	options.SetID(d.Get("template_id").(string))
+
+	result, _, err := enClient.GetTemplateWithContext(context, options)
+	if err != nil {
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("GetTemplateWithContext failed: %s", err.Error()), "(Data) ibm_en_code_engine_template", "read")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
+	}
+
+	d.SetId(fmt.Sprintf("%s/%s", *options.InstanceID, *options.ID))
+
+	if err = d.Set("name", result.Name); err != nil {
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("Error setting name: %s", err), "(Data) ibm_en_code_engine_template", "read")
+		return tfErr.GetDiag()
+	}
+
+	if result.Description != nil {
+		if err = d.Set("description", result.Description); err != nil {
+			tfErr := flex.TerraformErrorf(err, fmt.Sprintf("Error setting description: %s", err), "(Data) ibm_en_code_engine_template", "read")
+			return tfErr.GetDiag()
+		}
+	}
+
+	if err = d.Set("type", result.Type); err != nil {
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("Error setting type: %s", err), "(Data) ibm_en_code_engine_template", "read")
+		return tfErr.GetDiag()
+	}
+
+	if result.SubscriptionNames != nil {
+		err = d.Set("subscription_names", result.SubscriptionNames)
+		if err != nil {
+			tfErr := flex.TerraformErrorf(err, fmt.Sprintf("Error setting subscription_names: %s", err), "(Data) ibm_en_code_engine_template", "read")
+			return tfErr.GetDiag()
+		}
+	}
+
+	if err = d.Set("updated_at", flex.DateTimeToString(result.UpdatedAt)); err != nil {
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("Error setting updated_at: %s", err), "(Data) ibm_en_code_engine_template", "read")
+		return tfErr.GetDiag()
+	}
+
+	if err = d.Set("subscription_count", flex.IntValue(result.SubscriptionCount)); err != nil {
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("Error setting subscription_count: %s", err), "(Data) ibm_en_code_engine_template", "read")
+		return tfErr.GetDiag()
+	}
+
+	return nil
+}

--- a/ibm/service/eventnotification/data_source_ibm_en_code_engine_template_test.go
+++ b/ibm/service/eventnotification/data_source_ibm_en_code_engine_template_test.go
@@ -1,0 +1,103 @@
+// Copyright IBM Corp. 2024 All Rights Reserved.
+// Licensed under the Mozilla Public License v2.0
+
+package eventnotification_test
+
+import (
+	"fmt"
+	"testing"
+
+	acc "github.com/IBM-Cloud/terraform-provider-ibm/ibm/acctest"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+func TestAccIBMEnCodeEngineTemplateDataSourceBasic(t *testing.T) {
+	templateInstanceID := fmt.Sprintf("tf_instance_id_%d", acctest.RandIntRange(10, 100))
+	templateName := fmt.Sprintf("tf_name_%d", acctest.RandIntRange(10, 100))
+	templateType := fmt.Sprintf("tf_type_%d", acctest.RandIntRange(10, 100))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { acc.TestAccPreCheck(t) },
+		Providers: acc.TestAccProviders,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccCheckIBMEnCodeEngineTemplateDataSourceConfigBasic(templateInstanceID, templateName, templateType),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet("data.ibm_en_code_engine_template.en_template_instance", "id"),
+					resource.TestCheckResourceAttrSet("data.ibm_en_code_engine_template.en_template_instance", "instance_id"),
+					resource.TestCheckResourceAttrSet("data.ibm_en_code_engine_template.en_template_instance", "template_id"),
+					resource.TestCheckResourceAttrSet("data.ibm_en_code_engine_template.en_template_instance", "name"),
+					resource.TestCheckResourceAttrSet("data.ibm_en_code_engine_template.en_template_instance", "description"),
+					resource.TestCheckResourceAttrSet("data.ibm_en_code_engine_template.en_template_instance", "type"),
+					resource.TestCheckResourceAttrSet("data.ibm_en_code_engine_template.en_template_instance", "subscription_count"),
+					resource.TestCheckResourceAttrSet("data.ibm_en_code_engine_template.en_template_instance", "subscription_names.#"),
+					resource.TestCheckResourceAttrSet("data.ibm_en_code_engine_template.en_template_instance", "updated_at"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccIBMEnCodeEngineTemplateDataSourceAllArgs(t *testing.T) {
+	templateInstanceID := fmt.Sprintf("tf_instance_id_%d", acctest.RandIntRange(10, 100))
+	templateName := fmt.Sprintf("tf_name_%d", acctest.RandIntRange(10, 100))
+	templateDescription := fmt.Sprintf("tf_description_%d", acctest.RandIntRange(10, 100))
+	templateType := fmt.Sprintf("tf_type_%d", acctest.RandIntRange(10, 100))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { acc.TestAccPreCheck(t) },
+		Providers: acc.TestAccProviders,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccCheckIBMEnCodeEngineTemplateDataSourceConfig(templateInstanceID, templateName, templateDescription, templateType),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet("data.ibm_en_code_engine_template.en_template_instance", "id"),
+					resource.TestCheckResourceAttrSet("data.ibm_en_code_engine_template.en_template_instance", "instance_id"),
+					resource.TestCheckResourceAttrSet("data.ibm_en_code_engine_template.en_template_instance", "template_id"),
+					resource.TestCheckResourceAttrSet("data.ibm_en_code_engine_template.en_template_instance", "name"),
+					resource.TestCheckResourceAttrSet("data.ibm_en_code_engine_template.en_template_instance", "description"),
+					resource.TestCheckResourceAttrSet("data.ibm_en_code_engine_template.en_template_instance", "type"),
+					resource.TestCheckResourceAttrSet("data.ibm_en_code_engine_template.en_template_instance", "subscription_count"),
+					resource.TestCheckResourceAttrSet("data.ibm_en_code_engine_template.en_template_instance", "subscription_names.#"),
+					resource.TestCheckResourceAttrSet("data.ibm_en_code_engine_template.en_template_instance", "updated_at"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckIBMEnCodeEngineTemplateDataSourceConfigBasic(templateInstanceID string, templateName string, templateType string) string {
+	return fmt.Sprintf(`
+		resource "ibm_en_code_engine_template" "en_template_instance" {
+			instance_id = "%s"
+			name = "%s"
+			type = "%s"
+		}
+
+		data "ibm_en_code_engine_template" "en_template_instance" {
+			instance_id = ibm_en_code_engine_template.en_template_instance.instance_id
+			template_id = ibm_en_code_engine_template.en_template_instance.template_id
+		}
+	`, templateInstanceID, templateName, templateType)
+}
+
+func testAccCheckIBMEnCodeEngineTemplateDataSourceConfig(templateInstanceID string, templateName string, templateDescription string, templateType string) string {
+	return fmt.Sprintf(`
+		resource "ibm_en_code_engine_template" "en_template_instance" {
+			instance_id = "%s"
+			name = "%s"
+			description = "%s"
+			type = "%s"
+			params {
+			    body = "ewogICJ2YXIxIjogInt7ZGF0YS52YXIxfX0iLAogICJ2YXIyIjogInt7ZGF0YS52YXIyfX0iCn0="
+			}
+		}
+
+		data "ibm_en_code_engine_template" "en_template_instance" {
+			instance_id = ibm_en_code_engine_template.en_template_instance.instance_id
+			en_template_id = ibm_en_code_engine_template.en_template_instance.template_id
+		}
+	`, templateInstanceID, templateName, templateDescription, templateType)
+}

--- a/ibm/service/eventnotification/data_source_ibm_en_pre_defined_template.go
+++ b/ibm/service/eventnotification/data_source_ibm_en_pre_defined_template.go
@@ -1,0 +1,120 @@
+// Copyright IBM Corp. 2021 All Rights Reserved.
+// Licensed under the Mozilla Public License v2.0
+
+package eventnotification
+
+import (
+	"context"
+	"fmt"
+	"log"
+
+	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/conns"
+	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/flex"
+	en "github.com/IBM/event-notifications-go-admin-sdk/eventnotificationsv1"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+func DataSourceIBMEnPreDefinedTemplate() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceIBMEnPreDefinedTemplateRead,
+
+		Schema: map[string]*schema.Schema{
+			"instance_guid": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "Unique identifier for IBM Cloud Event Notifications instance.",
+			},
+			"template_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "Unique identifier for Template.",
+			},
+			"name": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "Template name.",
+			},
+			"description": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "Templaten description.",
+			},
+			"type": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The type of template.",
+			},
+			"source": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The type of source.",
+			},
+			"params": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "Payload describing a Predefined template configuration.",
+			},
+			"updated_at": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "Last updated time.",
+			},
+		},
+	}
+}
+
+func dataSourceIBMEnPreDefinedTemplateRead(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	enClient, err := meta.(conns.ClientSession).EventNotificationsApiV1()
+	if err != nil {
+		tfErr := flex.TerraformErrorf(err, err.Error(), "(Data) ibm_en_pre_defined_template", "read")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
+	}
+
+	options := &en.GetPreDefinedTemplateOptions{}
+
+	options.SetInstanceID(d.Get("instance_guid").(string))
+	options.SetID(d.Get("template_id").(string))
+
+	result, _, err := enClient.GetPreDefinedTemplateWithContext(context, options)
+	if err != nil {
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("GetPreDefinedTemplateWithContext failed: %s", err.Error()), "(Data) ibm_en_pre_defined_template", "read")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
+	}
+
+	d.SetId(fmt.Sprintf("%s/%s", *options.InstanceID, *options.ID))
+
+	if err = d.Set("name", result.Name); err != nil {
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("Error setting name: %s", err), "(Data) ibm_en_pre_defined_template", "read")
+		return tfErr.GetDiag()
+	}
+
+	if result.Description != nil {
+		if err = d.Set("description", result.Description); err != nil {
+			tfErr := flex.TerraformErrorf(err, fmt.Sprintf("Error setting description: %s", err), "(Data) ibm_en_pre_defined_template", "read")
+			return tfErr.GetDiag()
+		}
+	}
+
+	if err = d.Set("type", result.Type); err != nil {
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("Error setting type: %s", err), "(Data) ibm_en_pre_defined_template", "read")
+		return tfErr.GetDiag()
+	}
+	if err = d.Set("source", result.Source); err != nil {
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("Error setting source: %s", err), "(Data) ibm_en_pre_defined_template", "read")
+		return tfErr.GetDiag()
+	}
+	if err = d.Set("params", result.Params.Body); err != nil {
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("Error setting params: %s", err), "(Data) ibm_en_pre_defined_template", "read")
+		return tfErr.GetDiag()
+	}
+
+	if err = d.Set("updated_at", flex.DateTimeToString(result.UpdatedAt)); err != nil {
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("Error setting updated_at %s", err), "(Data) ibm_en_pre_defined_template", "read")
+		return tfErr.GetDiag()
+	}
+
+	return nil
+}

--- a/ibm/service/eventnotification/data_source_ibm_en_pre_defined_template_test.go
+++ b/ibm/service/eventnotification/data_source_ibm_en_pre_defined_template_test.go
@@ -1,0 +1,44 @@
+// Copyright IBM Corp. 2025 All Rights Reserved.
+// Licensed under the Mozilla Public License v2.0
+
+package eventnotification_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	acc "github.com/IBM-Cloud/terraform-provider-ibm/ibm/acctest"
+)
+
+func TestAccIBMEnPreDefinedTemplateDataSourceBasic(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { acc.TestAccPreCheck(t) },
+		Providers: acc.TestAccProviders,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccCheckIBMEnPreDefinedTemplateDataSourceConfigBasic(),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet("data.ibm_en_pre_defined_template.en_pre_defined_template_instance", "id"),
+					resource.TestCheckResourceAttrSet("data.ibm_en_pre_defined_template.en_pre_defined_template_instance", "instance_id"),
+					resource.TestCheckResourceAttrSet("data.ibm_en_pre_defined_template.en_pre_defined_template_instance", "template_id"),
+					resource.TestCheckResourceAttrSet("data.ibm_en_pre_defined_template.en_pre_defined_template_instance", "name"),
+					resource.TestCheckResourceAttrSet("data.ibm_en_pre_defined_template.en_pre_defined_template_instance", "description"),
+					resource.TestCheckResourceAttrSet("data.ibm_en_pre_defined_template.en_pre_defined_template_instance", "source"),
+					resource.TestCheckResourceAttrSet("data.ibm_en_pre_defined_template.en_pre_defined_template_instance", "type"),
+					resource.TestCheckResourceAttrSet("data.ibm_en_pre_defined_template.en_pre_defined_template_instance", "updated_at"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckIBMEnPreDefinedTemplateDataSourceConfigBasic() string {
+	return fmt.Sprintf(`
+		data "ibm_en_pre_defined_template" "en_pre_defined_template_instance" {
+			instance_guid = "instance_id"
+			template_id = "id"
+		}
+	`)
+}

--- a/ibm/service/eventnotification/data_source_ibm_en_pre_defined_templates.go
+++ b/ibm/service/eventnotification/data_source_ibm_en_pre_defined_templates.go
@@ -1,0 +1,195 @@
+// Copyright IBM Corp. 2021 All Rights Reserved.
+// Licensed under the Mozilla Public License v2.0
+
+package eventnotification
+
+import (
+	"context"
+	"fmt"
+	"log"
+
+	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/conns"
+	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/flex"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	en "github.com/IBM/event-notifications-go-admin-sdk/eventnotificationsv1"
+)
+
+func DataSourceIBMEnPreDefinedTemplates() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceIBMEnPreDefinedTemplatesRead,
+
+		Schema: map[string]*schema.Schema{
+			"instance_guid": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "Unique identifier for IBM Cloud Event Notifications instance.",
+			},
+			"search_key": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "Filter the template by name or type.",
+			},
+			"total_count": {
+				Type:        schema.TypeInt,
+				Computed:    true,
+				Description: "Total number of templates.",
+			},
+			"type": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "The type of template.",
+			},
+			"source": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "The type of source.",
+			},
+			"templates": {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Description: "List of templates.",
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"id": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "Template ID.",
+						},
+						"name": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "Template name.",
+						},
+						"description": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "description of the template.",
+						},
+						"type": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "The type of template.",
+						},
+						"source": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "The type of source.",
+						},
+						"updated_at": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "Updated at.",
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func dataSourceIBMEnPreDefinedTemplatesRead(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	enClient, err := meta.(conns.ClientSession).EventNotificationsApiV1()
+	if err != nil {
+		tfErr := flex.TerraformErrorf(err, err.Error(), "(Data) ibm_en_pre_defined_templates", "list")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
+	}
+
+	options := &en.ListPreDefinedTemplatesOptions{}
+
+	options.SetInstanceID(d.Get("instance_guid").(string))
+
+	if _, ok := d.GetOk("search_key"); ok {
+		options.SetSearch(d.Get("search_key").(string))
+	}
+
+	if _, ok := d.GetOk("source"); ok {
+		options.SetSource(d.Get("source").(string))
+	}
+	if _, ok := d.GetOk("type"); ok {
+		options.SetType(d.Get("type").(string))
+	}
+	var templateList *en.PredefinedTemplatesList
+
+	finalList := []en.PredefinedTemplate{}
+
+	var offset int64 = 0
+	var limit int64 = 100
+
+	options.SetLimit(limit)
+
+	for {
+		options.SetOffset(offset)
+
+		result, _, err := enClient.ListPreDefinedTemplatesWithContext(context, options)
+
+		templateList = result
+
+		if err != nil {
+			tfErr := flex.TerraformErrorf(err, fmt.Sprintf("ListPreDefinedTemplatesWithContext failed: %s", err.Error()), "(Data) ibm_en_pre_defined_templates", "list")
+			log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+			return tfErr.GetDiag()
+		}
+
+		offset = offset + limit
+
+		finalList = append(finalList, result.Templates...)
+
+		if offset > *result.TotalCount {
+			break
+		}
+	}
+
+	templateList.Templates = finalList
+
+	d.SetId(fmt.Sprintf("Templates/%s", *options.InstanceID))
+
+	if err = d.Set("total_count", flex.IntValue(templateList.TotalCount)); err != nil {
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("Error setting total_count: %s", err), "(Data) ibm_en_pre_defined_templates", "list")
+		return tfErr.GetDiag()
+	}
+
+	if templateList.Templates != nil {
+		if err = d.Set("templates", enFlattenpredefinedtemplatesList(templateList.Templates)); err != nil {
+			tfErr := flex.TerraformErrorf(err, fmt.Sprintf("Error setting Templates: %s", err), "(Data) ibm_en_pre_defined_templates", "list")
+			return tfErr.GetDiag()
+		}
+	}
+
+	return nil
+}
+
+func enFlattenpredefinedtemplatesList(result []en.PredefinedTemplate) (templates []map[string]interface{}) {
+	for _, templateItem := range result {
+		templates = append(templates, enpredefinedTemplateListToMap(templateItem))
+	}
+
+	return templates
+}
+
+func enpredefinedTemplateListToMap(templateItem en.PredefinedTemplate) (template map[string]interface{}) {
+	template = map[string]interface{}{}
+
+	if templateItem.ID != nil {
+		template["id"] = templateItem.ID
+	}
+	if templateItem.Name != nil {
+		template["name"] = templateItem.Name
+	}
+	if templateItem.Description != nil {
+		template["description"] = templateItem.Description
+	}
+	if templateItem.Type != nil {
+		template["type"] = templateItem.Type
+	}
+	if templateItem.Source != nil {
+		template["source"] = templateItem.Source
+	}
+	if templateItem.UpdatedAt != nil {
+		template["updated_at"] = flex.DateTimeToString(templateItem.UpdatedAt)
+	}
+
+	return template
+}

--- a/ibm/service/eventnotification/data_source_ibm_en_pre_defined_templates_test.go
+++ b/ibm/service/eventnotification/data_source_ibm_en_pre_defined_templates_test.go
@@ -1,0 +1,58 @@
+// Copyright IBM Corp. 2021 All Rights Reserved.
+// Licensed under the Mozilla Public License v2.0
+
+package eventnotification_test
+
+import (
+	"fmt"
+	"testing"
+
+	acc "github.com/IBM-Cloud/terraform-provider-ibm/ibm/acctest"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+func TestAccIBMEnPreDefinedTemplatesDataSourceBasic(t *testing.T) {
+	name := fmt.Sprintf("tf_name_%d", acctest.RandIntRange(10, 100))
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { acc.TestAccPreCheck(t) },
+		Providers: acc.TestAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckIBMEnPreDefinedTemplatesDatasourceConfig(name),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet("data.ibm_en_pre_defined_templates.data_pre_defined_template_1", "id"),
+					resource.TestCheckResourceAttrSet("data.ibm_en_pre_defined_templates.data_pre_defined_template_1", "instance_guid"),
+					resource.TestCheckResourceAttrSet("data.ibm_en_pre_defined_templates.data_pre_defined_template_1", "total_count"),
+					resource.TestCheckResourceAttrSet("data.ibm_en_pre_defined_templates.data_pre_defined_template_1", "source"),
+					resource.TestCheckResourceAttrSet("data.ibm_en_pre_defined_templates.data_pre_defined_template_1", "type"),
+					resource.TestCheckResourceAttrSet("data.ibm_en_pre_defined_templates.data_pre_defined_template_1", "templates.#"),
+					resource.TestCheckResourceAttrSet("data.ibm_en_pre_defined_templates.data_pre_defined_template_1", "templates.0.name"),
+					resource.TestCheckResourceAttrSet("data.ibm_en_pre_defined_templates.data_pre_defined_template_1", "templates.0.source"),
+					resource.TestCheckResourceAttrSet("data.ibm_en_pre_defined_templates.data_pre_defined_template_1", "templates.0.updated_at"),
+					resource.TestCheckResourceAttrSet("data.ibm_en_pre_defined_templates.data_pre_defined_template_1", "templates.0.type"),
+					resource.TestCheckResourceAttrSet("data.ibm_en_pre_defined_templates.data_pre_defined_template_1", "templates.0.id"),
+					resource.TestCheckResourceAttrSet("data.ibm_en_pre_defined_templates.data_pre_defined_template_1", "templates.0.description"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckIBMEnPreDefinedTemplatesDatasourceConfig(name string) string {
+	return fmt.Sprintf(`
+	resource "ibm_resource_instance" "en_template_datasource" {
+		name     = "%s"
+		location = "us-south"
+		plan     = "standard"
+		service  = "event-notifications"
+	}
+
+	data "ibm_en_destinations" "data_pre_defined_template_1" {
+		instance_guid = ibm_resource_instance.en_template_datasource_1.guid
+		type        = "slack.notification"
+		source = "logs"
+	}
+	`, name)
+}

--- a/ibm/service/eventnotification/resource_ibm_en_code_engine_template.go
+++ b/ibm/service/eventnotification/resource_ibm_en_code_engine_template.go
@@ -1,0 +1,276 @@
+// Copyright IBM Corp. 2021 All Rights Reserved.
+// Licensed under the Mozilla Public License v2.0
+
+package eventnotification
+
+import (
+	"context"
+	"fmt"
+	"log"
+
+	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/conns"
+	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/flex"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	en "github.com/IBM/event-notifications-go-admin-sdk/eventnotificationsv1"
+	"github.com/IBM/go-sdk-core/v5/core"
+)
+
+func ResourceIBMEnCodeEngineTemplate() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceIBMEnCodeEngineTemplateCreate,
+		ReadContext:   resourceIBMEnCodeEngineTemplateRead,
+		UpdateContext: resourceIBMEnCodeEngineTemplateUpdate,
+		DeleteContext: resourceIBMEnCodeEngineTemplateDelete,
+		Importer:      &schema.ResourceImporter{},
+
+		Schema: map[string]*schema.Schema{
+			"instance_guid": {
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: "Unique identifier for IBM Cloud Event Notifications instance.",
+			},
+			"name": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "Subscription name.",
+			},
+			"description": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "Subscription description.",
+			},
+			"type": {
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: "The type of template.",
+			},
+			"params": {
+				Type:     schema.TypeList,
+				MaxItems: 1,
+				Required: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"body": {
+							Type:        schema.TypeString,
+							Required:    true,
+							Description: "The base64 Code Engine Template body.",
+						},
+					},
+				},
+			},
+			"template_id": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "Subscription ID.",
+			},
+			"subscription_count": {
+				Type:        schema.TypeInt,
+				Computed:    true,
+				Description: "Number of subscriptions.",
+			},
+			"updated_at": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "Last updated time.",
+			},
+			"subscription_names": {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Description: "List of subscriptions.",
+				Elem:        &schema.Schema{Type: schema.TypeString},
+			},
+		},
+	}
+}
+
+func resourceIBMEnCodeEngineTemplateCreate(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	enClient, err := meta.(conns.ClientSession).EventNotificationsApiV1()
+	if err != nil {
+		tfErr := flex.TerraformErrorf(err, err.Error(), "ibm_en_code_engine_template", "create")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
+	}
+
+	options := &en.CreateTemplateOptions{}
+
+	options.SetInstanceID(d.Get("instance_guid").(string))
+
+	options.SetName(d.Get("name").(string))
+	options.SetType(d.Get("type").(string))
+
+	if _, ok := d.GetOk("description"); ok {
+		options.SetDescription(d.Get("description").(string))
+	}
+
+	params := CodeEngineTemplateParamsMap(d.Get("params.0").(map[string]interface{}))
+	options.SetParams(&params)
+
+	result, _, err := enClient.CreateTemplateWithContext(context, options)
+	if err != nil {
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("CreateTemplateWithContext failed: %s", err.Error()), "ibm_en_code_engine_template", "create")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
+	}
+
+	d.SetId(fmt.Sprintf("%s/%s", *options.InstanceID, *result.ID))
+
+	return resourceIBMEnCodeEngineTemplateRead(context, d, meta)
+}
+
+func resourceIBMEnCodeEngineTemplateRead(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	enClient, err := meta.(conns.ClientSession).EventNotificationsApiV1()
+	if err != nil {
+		tfErr := flex.TerraformErrorf(err, err.Error(), "ibm_en_code_engine_template", "read")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
+	}
+
+	options := &en.GetTemplateOptions{}
+
+	parts, err := flex.SepIdParts(d.Id(), "/")
+	if err != nil {
+		tfErr := flex.TerraformErrorf(err, err.Error(), "ibm_en_code_engine_template", "update")
+		return tfErr.GetDiag()
+	}
+
+	options.SetInstanceID(parts[0])
+	options.SetID(parts[1])
+
+	result, response, err := enClient.GetTemplateWithContext(context, options)
+	if err != nil {
+		if response != nil && response.StatusCode == 404 {
+			d.SetId("")
+			return nil
+		}
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("GetTemplateWithContext failed: %s", err.Error()), "ibm_en_slack_template", "read")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
+	}
+
+	if err = d.Set("instance_guid", options.InstanceID); err != nil {
+		return diag.FromErr(fmt.Errorf("[ERROR] Error setting instance_guid: %s", err))
+	}
+
+	if err = d.Set("template_id", options.ID); err != nil {
+		return diag.FromErr(fmt.Errorf("[ERROR] Error setting template_id: %s", err))
+	}
+
+	if err = d.Set("name", result.Name); err != nil {
+		return diag.FromErr(fmt.Errorf("[ERROR] Error setting name: %s", err))
+	}
+
+	if result.Description != nil {
+		if err = d.Set("description", result.Description); err != nil {
+			return diag.FromErr(fmt.Errorf("[ERROR] Error setting description: %s", err))
+		}
+	}
+
+	if err = d.Set("type", result.Type); err != nil {
+		return diag.FromErr(fmt.Errorf("[ERROR] Error setting template type: %s", err))
+	}
+
+	if err = d.Set("subscription_count", flex.IntValue(result.SubscriptionCount)); err != nil {
+		return diag.FromErr(fmt.Errorf("[ERROR] Error setting subscription_count: %s", err))
+	}
+
+	if err = d.Set("subscription_names", result.SubscriptionNames); err != nil {
+		return diag.FromErr(fmt.Errorf("[ERROR] Error setting subscription_names: %s", err))
+	}
+
+	if err = d.Set("updated_at", flex.DateTimeToString(result.UpdatedAt)); err != nil {
+		return diag.FromErr(fmt.Errorf("[ERROR] Error setting updated_at: %s", err))
+	}
+	return nil
+}
+
+func resourceIBMEnCodeEngineTemplateUpdate(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	enClient, err := meta.(conns.ClientSession).EventNotificationsApiV1()
+	if err != nil {
+		tfErr := flex.TerraformErrorf(err, err.Error(), "ibm_en_code_engine_template", "update")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
+	}
+
+	options := &en.ReplaceTemplateOptions{}
+
+	parts, err := flex.SepIdParts(d.Id(), "/")
+	if err != nil {
+		tfErr := flex.TerraformErrorf(err, err.Error(), "ibm_en_code_engine_template", "update")
+		return tfErr.GetDiag()
+	}
+
+	options.SetInstanceID(parts[0])
+	options.SetID(parts[1])
+
+	options.SetType(d.Get("type").(string))
+
+	if ok := d.HasChanges("name", "description", "params"); ok {
+		options.SetName(d.Get("name").(string))
+
+		if _, ok := d.GetOk("description"); ok {
+			options.SetDescription(d.Get("description").(string))
+		}
+
+		params := CodeEngineTemplateParamsMap(d.Get("params.0").(map[string]interface{}))
+		options.SetParams(&params)
+
+		_, _, err := enClient.ReplaceTemplateWithContext(context, options)
+		if err != nil {
+			tfErr := flex.TerraformErrorf(err, fmt.Sprintf("ReplaceTemplateWithContext failed: %s", err.Error()), "ibm_en_slack_template", "update")
+			log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+			return tfErr.GetDiag()
+		}
+
+		return resourceIBMEnCodeEngineTemplateRead(context, d, meta)
+	}
+
+	return nil
+}
+
+func resourceIBMEnCodeEngineTemplateDelete(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	enClient, err := meta.(conns.ClientSession).EventNotificationsApiV1()
+	if err != nil {
+		tfErr := flex.TerraformErrorf(err, err.Error(), "ibm_en_code_engine_template", "delete")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
+	}
+
+	options := &en.DeleteTemplateOptions{}
+
+	parts, err := flex.SepIdParts(d.Id(), "/")
+	if err != nil {
+		tfErr := flex.TerraformErrorf(err, err.Error(), "ibm_en_code_engine_template", "delete")
+		return tfErr.GetDiag()
+	}
+
+	options.SetInstanceID(parts[0])
+	options.SetID(parts[1])
+
+	response, err := enClient.DeleteTemplateWithContext(context, options)
+	if err != nil {
+		if response != nil && response.StatusCode == 404 {
+			d.SetId("")
+			return nil
+		}
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("DeleteTemplateWithContext: failed: %s", err.Error()), "ibm_en_code_engine_template", "delete")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
+	}
+
+	d.SetId("")
+
+	return nil
+}
+
+func CodeEngineTemplateParamsMap(configParams map[string]interface{}) en.TemplateConfigOneOf {
+	params := new(en.TemplateConfigOneOf)
+	if configParams["body"] != nil {
+		params.Body = core.StringPtr(configParams["body"].(string))
+	}
+
+	return *params
+}

--- a/ibm/service/eventnotification/resource_ibm_en_code_engine_template_test.go
+++ b/ibm/service/eventnotification/resource_ibm_en_code_engine_template_test.go
@@ -1,0 +1,145 @@
+// Copyright IBM Corp. 2021 All Rights Reserved.
+// Licensed under the Mozilla Public License v2.0
+
+package eventnotification_test
+
+import (
+	"fmt"
+	"testing"
+
+	acc "github.com/IBM-Cloud/terraform-provider-ibm/ibm/acctest"
+	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/conns"
+	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/flex"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	en "github.com/IBM/event-notifications-go-admin-sdk/eventnotificationsv1"
+)
+
+func TestAccIBMEnCodeEngineTemplateAllArgs(t *testing.T) {
+	var params en.Template
+	name := fmt.Sprintf("tf_name_%d", acctest.RandIntRange(10, 100))
+	instanceName := fmt.Sprintf("tf_name_%d", acctest.RandIntRange(10, 100))
+	description := fmt.Sprintf("tf_description_%d", acctest.RandIntRange(10, 100))
+	newName := fmt.Sprintf("tf_name_%d", acctest.RandIntRange(10, 100))
+	newDescription := fmt.Sprintf("tf_description_%d", acctest.RandIntRange(10, 100))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { acc.TestAccPreCheck(t) },
+		Providers:    acc.TestAccProviders,
+		CheckDestroy: testAccCheckIBMEnEmailTemplateDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckIBMEnCodeEngineTemplateConfig(instanceName, name, description),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckIBMEnSlackTemplateExists("ibm_en_code_engine_template.en_template_resource_1", params),
+					resource.TestCheckResourceAttr("ibm_en_code_engine_template.en_template_resource_1", "name", name),
+					resource.TestCheckResourceAttr("ibm_en_code_engine_template.en_template_resource_1", "type", "ibmcejob.notification"),
+					resource.TestCheckResourceAttr("ibm_en_code_engine_template.en_template_resource_1", "description", description),
+				),
+			},
+			{
+				Config: testAccCheckIBMEnCodeEngineTemplateConfig(instanceName, newName, newDescription),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("ibm_en_code_engine_template.en_template_resource_1", "name", newName),
+					resource.TestCheckResourceAttr("ibm_en_code_engine_template.en_template_resource_1", "type", "ibmcejob.notification"),
+					resource.TestCheckResourceAttr("ibm_en_code_engine_template.en_template_resource_1", "description", newDescription),
+				),
+			},
+			{
+				ResourceName:      "ibm_en_code_engine_template.en_template_resource_1",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testAccCheckIBMEnCodeEngineTemplateConfig(instanceName, name, description string) string {
+	return fmt.Sprintf(`
+	resource "ibm_resource_instance" "en_template_resource" {
+		name     = "%s"
+		location = "us-south"
+		plan     = "standard"
+		service  = "event-notifications"
+	}
+	
+	resource "ibm_en_code_engine_template" "en_template_resource_1" {
+		instance_guid = ibm_resource_instance.en_template_resource.guid
+		name        = "%s"
+		type        = "ibmcejob.notification"
+		description = "%s"
+		params {
+			body  = "ewogInJ1bl9lbnZfdmFyaWFibGVzIjogWwogICB7ICJuYW1lIjogInJlZ2lvbiIsICJ2YWx1ZSI6ICJ7e2RhdGEucmVnaW9ufX0iLCJ0eXBlIjogImxpdGVyYWwifSwKeyJuYW1lIjoiVkFSMSIsInR5cGUiOiJsaXRlcmFsIiwidmFsdWUiOiJ7e2RhdGEudmFyMX19In0sCnsibmFtZSI6IlZBUjIiLCJ0eXBlIjoibGl0ZXJhbCIsInZhbHVlIjoie3tkYXRhLnZhcjJ9fSJ9Cl0KfQ=="
+		}
+	}
+	`, instanceName, name, description)
+}
+
+func testAccCheckIBMEnCodeEngineTemplateExists(n string, obj en.Template) resource.TestCheckFunc {
+
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+
+		enClient, err := acc.TestAccProvider.Meta().(conns.ClientSession).EventNotificationsApiV1()
+		if err != nil {
+			return err
+		}
+
+		options := &en.GetTemplateOptions{}
+
+		parts, err := flex.SepIdParts(rs.Primary.ID, "/")
+		if err != nil {
+			return err
+		}
+
+		options.SetInstanceID(parts[0])
+		options.SetID(parts[1])
+
+		result, _, err := enClient.GetTemplate(options)
+		if err != nil {
+			return err
+		}
+
+		obj = *result
+		return nil
+	}
+}
+
+func testAccCheckIBMEnCodeEngineTemplateDestroy(s *terraform.State) error {
+	enClient, err := acc.TestAccProvider.Meta().(conns.ClientSession).EventNotificationsApiV1()
+	if err != nil {
+		return err
+	}
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "en_template_resource_1" {
+			continue
+		}
+
+		options := &en.GetTemplateOptions{}
+
+		parts, err := flex.SepIdParts(rs.Primary.ID, "/")
+		if err != nil {
+			return err
+		}
+
+		options.SetInstanceID(parts[0])
+		options.SetID(parts[1])
+
+		// Try to find the key
+		_, response, err := enClient.GetTemplate(options)
+
+		if err == nil {
+			return fmt.Errorf("en_template_resource still exists: %s", rs.Primary.ID)
+		} else if response.StatusCode != 404 {
+			return fmt.Errorf("[ERROR] Error checking for en_template_resource_1 (%s) has been destroyed: %s", rs.Primary.ID, err)
+		}
+	}
+
+	return nil
+}

--- a/ibm/service/eventnotification/resource_ibm_en_subscription_code_engine.go
+++ b/ibm/service/eventnotification/resource_ibm_en_subscription_code_engine.go
@@ -1,0 +1,317 @@
+// Copyright IBM Corp. 2021 All Rights Reserved.
+// Licensed under the Mozilla Public License v2.0
+
+package eventnotification
+
+import (
+	"context"
+	"fmt"
+	"log"
+
+	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/conns"
+	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/flex"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	en "github.com/IBM/event-notifications-go-admin-sdk/eventnotificationsv1"
+	"github.com/IBM/go-sdk-core/v5/core"
+)
+
+func ResourceIBMEnCodeEngineSubscription() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceIBMEnCodeEngineSubscriptionCreate,
+		ReadContext:   resourceIBMEnCodeEngineSubscriptionRead,
+		UpdateContext: resourceIBMEnCodeEngineSubscriptionUpdate,
+		DeleteContext: resourceIBMEnCodeEngineSubscriptionUpdate,
+		Importer:      &schema.ResourceImporter{},
+
+		Schema: map[string]*schema.Schema{
+			"instance_guid": {
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: "Unique identifier for IBM Cloud Event Notifications instance.",
+			},
+			"name": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "Subscription name.",
+			},
+			"description": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "Subscription description.",
+			},
+			"destination_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: "Destination ID.",
+			},
+			"topic_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: "Topic ID.",
+			},
+			"attributes": {
+				Type:     schema.TypeList,
+				MaxItems: 1,
+				Optional: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"template_id_notification": {
+							Type:        schema.TypeString,
+							Optional:    true,
+							Description: "The template id for notification",
+						},
+					},
+				},
+			},
+			"subscription_id": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "Subscription ID.",
+			},
+			"destination_type": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The type of Destination.",
+			},
+			"destination_name": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The Destintion name.",
+			},
+			"topic_name": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "Name of the topic.",
+			},
+			"updated_at": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "Last updated time.",
+			},
+		},
+	}
+}
+
+func resourceIBMEnCodeEngineSubscriptionCreate(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	enClient, err := meta.(conns.ClientSession).EventNotificationsApiV1()
+	if err != nil {
+		tfErr := flex.TerraformErrorf(err, err.Error(), "ibm_en_subscription_ce", "create")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
+	}
+
+	options := &en.CreateSubscriptionOptions{}
+
+	options.SetInstanceID(d.Get("instance_guid").(string))
+
+	options.SetName(d.Get("name").(string))
+	options.SetTopicID(d.Get("topic_id").(string))
+	options.SetDestinationID(d.Get("destination_id").(string))
+
+	if _, ok := GetFieldExists(d, "description"); ok {
+		options.SetDescription(d.Get("description").(string))
+	}
+
+	attributes, _ := codeengineattributesMapToAttributes(d.Get("attributes.0").(map[string]interface{}))
+	options.SetAttributes(&attributes)
+
+	result, _, err := enClient.CreateSubscriptionWithContext(context, options)
+	if err != nil {
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("CreateSubscriptionWithContext failed: %s", err.Error()), "ibm_en_subscription_ce", "create")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
+	}
+
+	d.SetId(fmt.Sprintf("%s/%s", *options.InstanceID, *result.ID))
+
+	return resourceIBMEnCodeEngineSubscriptionRead(context, d, meta)
+}
+
+func resourceIBMEnCodeEngineSubscriptionRead(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	enClient, err := meta.(conns.ClientSession).EventNotificationsApiV1()
+	if err != nil {
+		tfErr := flex.TerraformErrorf(err, err.Error(), "ibm_en_subscription_ce", "read")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
+	}
+
+	options := &en.GetSubscriptionOptions{}
+
+	parts, err := flex.SepIdParts(d.Id(), "/")
+	if err != nil {
+		tfErr := flex.TerraformErrorf(err, err.Error(), "ibm_en_subscription_ce", "read")
+		return tfErr.GetDiag()
+	}
+
+	options.SetInstanceID(parts[0])
+	options.SetID(parts[1])
+
+	result, response, err := enClient.GetSubscriptionWithContext(context, options)
+	if err != nil {
+		if response != nil && response.StatusCode == 404 {
+			d.SetId("")
+			return nil
+		}
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("GetSubscriptionWithContext failed: %s", err.Error()), "ibm_en_subscription_ce", "read")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
+	}
+
+	if err = d.Set("instance_guid", options.InstanceID); err != nil {
+		return diag.FromErr(fmt.Errorf("[ERROR] Error setting instance_guid: %s", err))
+	}
+
+	if err = d.Set("subscription_id", result.ID); err != nil {
+		return diag.FromErr(fmt.Errorf("[ERROR] Error setting instance_guid: %s", err))
+	}
+
+	if err = d.Set("name", result.Name); err != nil {
+		return diag.FromErr(fmt.Errorf("[ERROR] Error setting name: %s", err))
+	}
+
+	if result.Description != nil {
+		if err = d.Set("description", result.Description); err != nil {
+			return diag.FromErr(fmt.Errorf("[ERROR] Error setting description: %s", err))
+		}
+	}
+
+	if result.From != nil {
+		if err = d.Set("from", result.From); err != nil {
+			return diag.FromErr(fmt.Errorf("[ERROR] Error setting from: %s", err))
+		}
+	}
+
+	if err = d.Set("destination_id", result.DestinationID); err != nil {
+		return diag.FromErr(fmt.Errorf("[ERROR] Error setting destination_id: %s", err))
+	}
+
+	if err = d.Set("destination_type", result.DestinationType); err != nil {
+		return diag.FromErr(fmt.Errorf("[ERROR] Error setting destination_type: %s", err))
+	}
+
+	if result.DestinationName != nil {
+		if err = d.Set("destination_name", result.DestinationName); err != nil {
+			return diag.FromErr(fmt.Errorf("[ERROR] Error setting destination_name: %s", err))
+		}
+	}
+
+	if err = d.Set("topic_id", result.TopicID); err != nil {
+		return diag.FromErr(fmt.Errorf("[ERROR] Error setting topic_id: %s", err))
+	}
+
+	if result.TopicName != nil {
+		if err = d.Set("topic_name", result.TopicName); err != nil {
+			return diag.FromErr(fmt.Errorf("[ERROR] Error setting topic_name: %s", err))
+		}
+	}
+
+	if err = d.Set("updated_at", result.UpdatedAt); err != nil {
+		return diag.FromErr(fmt.Errorf("[ERROR] Error setting updated_at: %s", err))
+	}
+
+	return nil
+}
+
+func resourceIBMEnCodeEngineSubscriptionUpdate(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	enClient, err := meta.(conns.ClientSession).EventNotificationsApiV1()
+	if err != nil {
+		tfErr := flex.TerraformErrorf(err, err.Error(), "ibm_en_subscription_ce", "update")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
+	}
+
+	options := &en.UpdateSubscriptionOptions{}
+
+	parts, err := flex.SepIdParts(d.Id(), "/")
+	if err != nil {
+		tfErr := flex.TerraformErrorf(err, err.Error(), "ibm_en_subscription_ce", "update")
+		return tfErr.GetDiag()
+	}
+
+	options.SetInstanceID(parts[0])
+	options.SetID(parts[1])
+
+	if ok := d.HasChanges("name", "description", "attributes"); ok {
+		options.SetName(d.Get("name").(string))
+
+		if _, ok := GetFieldExists(d, "description"); ok {
+			options.SetDescription(d.Get("description").(string))
+		}
+
+		attributes, err := resourceIBMEnSubscriptionMapToSubscriptioncodeengineUpdateAttributes(d.Get("attributes.0").(map[string]interface{}))
+		if err != nil {
+			tfErr := flex.TerraformErrorf(err, fmt.Sprintf("UpdateSubscriptionWithContext failed: %s", err.Error()), "ibm_en_subscription_ce", "update")
+			log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+			return tfErr.GetDiag()
+		}
+		options.SetAttributes(&attributes)
+
+		_, response, err := enClient.UpdateSubscriptionWithContext(context, options)
+		if err != nil {
+			return diag.FromErr(fmt.Errorf("UpdateSubscriptionWithContext failed %s\n%s", err, response))
+		}
+
+		return resourceIBMEnCodeEngineSubscriptionRead(context, d, meta)
+	}
+
+	return nil
+}
+
+func resourceIBMEnCodeEngineSubscriptionDelete(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	enClient, err := meta.(conns.ClientSession).EventNotificationsApiV1()
+	if err != nil {
+		tfErr := flex.TerraformErrorf(err, err.Error(), "ibm_en_subscription_ce", "delete")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
+	}
+
+	options := &en.DeleteSubscriptionOptions{}
+
+	parts, err := flex.SepIdParts(d.Id(), "/")
+	if err != nil {
+		tfErr := flex.TerraformErrorf(err, err.Error(), "ibm_en_subscription_ce", "delete")
+		return tfErr.GetDiag()
+	}
+
+	options.SetInstanceID(parts[0])
+	options.SetID(parts[1])
+
+	response, err := enClient.DeleteSubscriptionWithContext(context, options)
+	if err != nil {
+		if response != nil && response.StatusCode == 404 {
+			d.SetId("")
+			return nil
+		}
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("DeleteSubscriptionWithContext: failed: %s", err.Error()), "ibm_en_subscription_ce", "delete")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
+	}
+
+	d.SetId("")
+
+	return nil
+}
+
+func codeengineattributesMapToAttributes(modelMap map[string]interface{}) (en.SubscriptionCreateAttributes, error) {
+	model := en.SubscriptionCreateAttributes{}
+
+	if modelMap["template_id_notification"] != nil && modelMap["template_id_notification"].(string) != "" {
+		model.TemplateIDNotification = core.StringPtr(modelMap["template_id_notification"].(string))
+	}
+	return model, nil
+}
+
+func resourceIBMEnSubscriptionMapToSubscriptioncodeengineUpdateAttributes(modelMap map[string]interface{}) (en.SubscriptionUpdateAttributes, error) {
+	model := en.SubscriptionUpdateAttributes{}
+
+	if modelMap["template_id_notification"] != nil && modelMap["template_id_notification"].(string) != "" {
+		model.TemplateIDNotification = core.StringPtr(modelMap["template_id_notification"].(string))
+	}
+
+	return model, nil
+}

--- a/ibm/service/eventnotification/resource_ibm_en_subscription_code_engine_test.go
+++ b/ibm/service/eventnotification/resource_ibm_en_subscription_code_engine_test.go
@@ -1,0 +1,172 @@
+// Copyright IBM Corp. 2021 All Rights Reserved.
+// Licensed under the Mozilla Public License v2.0
+
+package eventnotification_test
+
+import (
+	"fmt"
+	"testing"
+
+	acc "github.com/IBM-Cloud/terraform-provider-ibm/ibm/acctest"
+	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/conns"
+	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/flex"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	en "github.com/IBM/event-notifications-go-admin-sdk/eventnotificationsv1"
+)
+
+func TestAccIBMEnCodeEngineSubscriptionAllArgs(t *testing.T) {
+	var conf en.Subscription
+	instanceName := fmt.Sprintf("tf_instance_%d", acctest.RandIntRange(10, 100))
+	name := fmt.Sprintf("tf_name_%d", acctest.RandIntRange(10, 100))
+	description := fmt.Sprintf("tf_description_%d", acctest.RandIntRange(10, 100))
+	newName := fmt.Sprintf("tf_name_%d", acctest.RandIntRange(10, 100))
+	newDescription := fmt.Sprintf("tf_description_%d", acctest.RandIntRange(10, 100))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { acc.TestAccPreCheck(t) },
+		Providers:    acc.TestAccProviders,
+		CheckDestroy: testAccCheckIBMEnSlackSubscriptionDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckIBMEnCodeEngineSubscriptionConfig(instanceName, name, description),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckIBMEnCodeEngineSubscriptionExists("ibm_en_subscription_ce.en_subscription_resource_1", conf),
+					resource.TestCheckResourceAttrSet("ibm_en_subscription_ce.en_subscription_resource_1", "name"),
+					resource.TestCheckResourceAttrSet("ibm_en_subscription_ce.en_subscription_resource_1", "description"),
+					resource.TestCheckResourceAttrSet("ibm_en_subscription_ce.en_subscription_resource_1", "topic_id"),
+					resource.TestCheckResourceAttrSet("ibm_en_subscription_ce.en_subscription_resource_1", "updated_at"),
+					resource.TestCheckResourceAttrSet("ibm_en_subscription_ce.en_subscription_resource_1", "instance_guid"),
+					resource.TestCheckResourceAttrSet("ibm_en_subscription_ce.en_subscription_resource_1", "destination_id"),
+					resource.TestCheckResourceAttrSet("ibm_en_subscription_ce.en_subscription_resource_1", "destination_type"),
+					resource.TestCheckResourceAttrSet("ibm_en_subscription_ce.en_subscription_resource_1", "subscription_id"),
+					resource.TestCheckResourceAttrSet("ibm_en_subscription_ce.en_subscription_resource_1", "attributes.#"),
+					resource.TestCheckResourceAttrSet("ibm_en_subscription_ce.en_subscription_resource_1", "attributes.0.signing_enabled"),
+				),
+			},
+			{
+				Config: testAccCheckIBMEnCodeEngineSubscriptionConfig(instanceName, newName, newDescription),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("ibm_en_subscription_ce.en_subscription_resource_1", "name", newName),
+					resource.TestCheckResourceAttr("ibm_en_subscription_ce.en_subscription_resource_1", "description", newDescription),
+				),
+			},
+			{
+				ResourceName:      "ibm_en_subscription_ce.en_subscription_resource_1",
+				ImportState:       true,
+				ImportStateVerify: false,
+			},
+		},
+	})
+}
+
+func testAccCheckIBMEnCodeEngineSubscriptionConfig(instanceName, name, description string) string {
+	return fmt.Sprintf(`
+	resource "ibm_resource_instance" "en_subscription_resource" {
+		name     = "%s"
+		location = "us-south"
+		plan     = "standard"
+		service  = "event-notifications"
+	}
+	
+	resource "ibm_en_topic" "en_topic_resource_2" {
+		instance_guid = ibm_resource_instance.en_subscription_resource.guid
+		name        = "tf_topic_name_0234"
+		description = "tf_topic_description_0235"
+	}
+
+	resource "ibm_en_destination_ce" "en_destination_resource_2" {
+		instance_guid = ibm_resource_instance.en_subscription_resource.guid
+		name        = "Tf_code_engine_dest"
+		type        = "ibmce"
+		description = "code_engine_destination"
+		config {
+			params {
+				type = "application"
+				verb = "POST"
+				url  = "https://test.codetestcodeengine.com"
+			}
+		}
+	}
+	resource "ibm_en_subscription_ce" "en_subscription_resource_1" {
+		name           = "%s"
+		description 	 = "%s"
+		instance_guid    = ibm_resource_instance.en_subscription_resource.guid
+		topic_id       = ibm_en_topic.en_topic_resource_2.topic_id
+		destination_id = ibm_en_destination_ce.en_destination_resource_2.destination_id
+		attributes {
+			template_id_notification = ibm_en_code_engine_template.en_template_resource_1.template_id
+		}
+	}
+	`, instanceName, name, description)
+}
+
+func testAccCheckIBMEnCodeEngineSubscriptionExists(n string, obj en.Subscription) resource.TestCheckFunc {
+
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+
+		enClient, err := acc.TestAccProvider.Meta().(conns.ClientSession).EventNotificationsApiV1()
+		if err != nil {
+			return err
+		}
+
+		options := &en.GetSubscriptionOptions{}
+
+		parts, err := flex.SepIdParts(rs.Primary.ID, "/")
+		if err != nil {
+			return err
+		}
+
+		options.SetInstanceID(parts[0])
+		options.SetID(parts[1])
+
+		subscription, _, err := enClient.GetSubscription(options)
+		if err != nil {
+			return err
+		}
+
+		obj = *subscription
+		return nil
+	}
+}
+
+func testAccCheckIBMEnCodeEngineSubscriptionDestroy(s *terraform.State) error {
+	enClient, err := acc.TestAccProvider.Meta().(conns.ClientSession).EventNotificationsApiV1()
+	if err != nil {
+		return err
+	}
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "en_subscription_resource_1" {
+			continue
+		}
+
+		options := &en.GetSubscriptionOptions{}
+
+		parts, err := flex.SepIdParts(rs.Primary.ID, "/")
+		if err != nil {
+			return err
+		}
+
+		options.SetInstanceID(parts[0])
+		options.SetID(parts[1])
+
+		// Try to find the key
+		_, response, err := enClient.GetSubscription(options)
+
+		if err == nil {
+			return fmt.Errorf("en_subscription_resource_1 still exists: %s", rs.Primary.ID)
+		} else if response.StatusCode != 404 {
+			return fmt.Errorf("[ERROR] Error checking for en_subscription_resource_1 (%s) has been destroyed: %s", rs.Primary.ID, err)
+		}
+	}
+
+	return nil
+}

--- a/ibm/service/eventnotification/resource_ibm_en_topic.go
+++ b/ibm/service/eventnotification/resource_ibm_en_topic.go
@@ -418,14 +418,14 @@ func resourceIBMEnTopicMapToRules(rulesMap map[string]interface{}) en.Rules {
 
 func resourceIBMEnTopicsMapToEventScheduleFilterAttributes(modelMap map[string]interface{}) (*eventnotificationsv1.EventScheduleFilterAttributes, error) {
 	model := &en.EventScheduleFilterAttributes{}
-	if modelMap["starts_at"] != nil {
+	if modelMap["starts_at"] != nil && modelMap["starts_at"].(string) != "" {
 		dateTime, err := core.ParseDateTime(modelMap["starts_at"].(string))
 		if err != nil {
 			return model, err
 		}
 		model.StartsAt = &dateTime
 	}
-	if modelMap["ends_at"] != nil {
+	if modelMap["ends_at"] != nil && modelMap["ends_at"].(string) != "" {
 		dateTime, err := core.ParseDateTime(modelMap["ends_at"].(string))
 		if err != nil {
 			return model, err

--- a/website/docs/d/en_code_engine_template.html.markdown
+++ b/website/docs/d/en_code_engine_template.html.markdown
@@ -1,0 +1,46 @@
+---
+subcategory: 'Event Notifications'
+layout: 'ibm'
+page_title: 'IBM : ibm_en_code_engine_template'
+description: |-
+  Get information about a Code Engine Template
+---
+
+# ibm_en_code_engine_template
+
+Provides a read-only data source for Code Engine template. You can then reference the fields of the data source in other resources within the same configuration using interpolation syntax.
+
+## Example usage
+
+```terraform
+data "ibm_en_code_engine_template" "ce_template" {
+  instance_guid  = ibm_resource_instance.en_terraform_test_resource.guid
+  template_id = ibm_en_code_engine_template.en_ce_job_template.template_id
+}
+```
+
+## Argument reference
+
+Review the argument reference that you can specify for your data source.
+
+- `instance_guid` - (Required, Forces new resource, String) Unique identifier for IBM Cloud Event Notifications instance.
+
+- `template_id` - (Required, String) Unique identifier for Template.
+
+## Attribute reference
+
+In addition to all argument references listed, you can access the following attribute references after your data source is created.
+
+- `id` - The unique identifier of the `ce_template`.
+
+- `name` - (String) The Template name.
+
+- `description` - (String) The template description.
+
+- `subscription_count` - (Integer) Number of subscriptions.
+
+- `subscription_names` - (List) List of subscriptions.
+
+- `type` - (String) Template type ibmcejob.notification/ibmceapp.notification.
+
+- `updated_at` - (String) Last updated time.

--- a/website/docs/d/en_pre_defined_template.html.markdown
+++ b/website/docs/d/en_pre_defined_template.html.markdown
@@ -1,0 +1,51 @@
+---
+layout: "ibm"
+page_title: "IBM : ibm_en_pre_defined_template"
+description: |-
+  Get information about en_pre_defined_template
+subcategory: "Event Notifications API"
+---
+
+# ibm_en_pre_defined_template
+
+Provides a read-only data source to retrieve information about an en_pre_defined_template. You can then reference the fields of the data source in other resources within the same configuration by using interpolation syntax.
+
+## Example Usage
+
+```hcl
+data "ibm_en_pre_defined_template" "en_pre_defined_template" {
+	template_id = "en_pre_defined_template_id"
+	instance_guid = "instance_id"
+}
+```
+
+## Argument Reference
+
+You can specify the following arguments for this data source.
+
+* `template_id` - (Required, Forces new resource, String) Unique identifier for Template.
+  * Constraints: The maximum length is `32` characters. The minimum length is `32` characters. The value must match regular expression `/[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}/`.
+* `instance_guid` - (Required, Forces new resource, String) Unique identifier for IBM Cloud Event Notifications instance.
+  * Constraints: The maximum length is `32` characters. The minimum length is `32` characters. The value must match regular expression `/[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}/`.
+
+## Attribute Reference
+
+After your data source is created, you can read values from the following attributes.
+
+* `id` - The unique identifier of the en_pre_defined_template.
+* `description` - (String) Template description.
+  * Constraints: The maximum length is `255` characters. The minimum length is `0` characters. The value must match regular expression `/[a-zA-Z 0-9-_\/.?:'";,+=!#@$%^&*() ]*/`.
+
+* `name` - (String) Template name.
+  * Constraints: The maximum length is `255` characters. The minimum length is `1` character. The value must match regular expression `/[a-zA-Z 0-9-_\/.?:'";,+=!#@$%^&*() ]*/`.
+
+* `source` - (String) The type of source.
+  * Constraints: The minimum length is `1` character. The value must match regular expression `/.*/`.
+
+- `params` - (String) base64 encoded template body
+
+* `type` - (String) The type of template.
+  * Constraints: The minimum length is `1` character. The value must match regular expression `/.*/`.
+
+* `updated_at` - (String) Updated at.
+

--- a/website/docs/d/en_pre_defined_templates.html.markdown
+++ b/website/docs/d/en_pre_defined_templates.html.markdown
@@ -1,0 +1,55 @@
+---
+subcategory: 'Event Notifications'
+layout: 'ibm'
+page_title: 'IBM : ibm_en_pre_defined_templates'
+description: |-
+  List all the Pre Defined Templates
+---
+
+# ibm_en_pre_defined_templates
+
+Provides a read-only data source for Pre Defined templates. You can then reference the fields of the data source in other resources within the same configuration using interpolation syntax.
+
+## Example usage
+
+```terraform
+data "ibm_en_pre_defined_templates" "pre_defined_templates" {
+  instance_guid = ibm_resource_instance.en_terraform_test_resource.guid
+  source = "logs"
+  type = "slack.notification"
+}
+```
+
+## Argument reference
+
+Review the argument reference that you can specify for your data source.
+
+- `instance_guid` - (Required, Forces new resource, String) Unique identifier for IBM Cloud Event Notifications instance.
+
+- `search_key` - (Optional, String) Filter the template by name or type.
+
+- `source` - (Required, String) Source Type.
+
+- `type` - (Required, String) Template type.
+
+## Attribute reference
+
+In addition to all argument references listed, you can access the following attribute references after your data source is created.
+
+- `id` - The unique identifier of the `pre_defined_templates`.
+
+- `templates` - (List) List of templates.
+
+  - `id` - The unique identifier of the `pre_defined_templates`.
+
+  - `name` - (String) The Template name.
+
+  - `description` - (String) The template description.
+
+  - `type` - (String) Template type.
+
+  - `source` - (String) Source Type.
+
+  - `updated_at` - (String) Last updated time.
+
+- `total_count` - (Integer) Total number of destinations.

--- a/website/docs/d/en_subscription_ce.html.markdown
+++ b/website/docs/d/en_subscription_ce.html.markdown
@@ -41,4 +41,8 @@ In addition to all argument references listed, you can access the following attr
 
 - `topic_id` - (String) Topic ID.
 
+- `attributes` - (List)
+
+  - `template_id_notification` - (String) The template id for notification
+
 - `updated_at` - (String) Last updated time.

--- a/website/docs/r/en_code_engine_template.html.markdown
+++ b/website/docs/r/en_code_engine_template.html.markdown
@@ -1,0 +1,74 @@
+---
+subcategory: 'Event Notifications'
+layout: 'ibm'
+page_title: 'IBM : ibm_en_code_engine_template'
+description: |-
+  Manages Event Notification Code Engine Template.
+---
+
+# ibm_en_code_engine_template
+
+Create, update, or delete Code Engine Template by using IBM Cloud™ Event Notifications.
+
+## Example usage
+
+```terraform
+resource "ibm_en_code_engine_template" "ce_template" {
+  instance_guid         = ibm_resource_instance.en_terraform_test_resource.guid
+  name                  = "Notification Template"
+  type                  = "ibmcejob.notification"
+  description           = "Code Engine Job Template for Notifications"
+      params {
+        body="ewogICJ2YXIxIjogInt7ZGF0YS52YXIxfX0iLAogICJ2YXIyIjogInt7ZGF0YS52YXIyfX0iCn0="
+    }
+}
+```         
+
+## Argument reference
+
+Review the argument reference that you can specify for your resource.
+
+- `instance_guid` - (Required, Forces new resource, String) Unique identifier for IBM Cloud Event Notifications instance.
+
+- `name` - (Required, String) The Message Template.
+
+- `description` - (Optional, String) The Template description.
+
+- `type` - (Required, String) ibmcejob.notification/ibmceapp.notification
+
+- `params` - (Required, List) Payload describing a template configuration
+
+  Nested scheme for **params**:
+
+  - `body` - (Required, String) The Body for Code Engine Template in base64 encoded format.
+
+## Attribute reference
+
+In addition to all argument references listed, you can access the following attribute references after your resource is created.
+
+- `id` - (String) The unique identifier of the `ce_template`.
+- `template_id` - (String) The unique identifier of the created Template.
+- `subscription_count` - (Integer) Number of subscriptions.
+  - Constraints: The minimum value is `0`.
+- `subscription_names` - (List) List of subscriptions.
+- `updated_at` - (String) Last updated time.
+
+## Import
+
+You can import the `ibm_en_code_engine_template` resource by using `id`.
+
+The `id` property can be formed from `instance_guid`, and `template_id` in the following format:
+
+```
+<instance_guid>/<template_id>
+```
+
+- `instance_guid`: A string. Unique identifier for IBM Cloud Event Notifications instance.
+
+- `template_id`: A string. Unique identifier for Template.
+
+**Example**
+
+```
+$ terraform import ibm_en_code_engine_template.ce_template <instance_guid>/<template_id>
+```

--- a/website/docs/r/en_subscription_ce.html.markdown
+++ b/website/docs/r/en_subscription_ce.html.markdown
@@ -19,6 +19,9 @@ resource "ibm_en_subscription_ce" "codeengine_subscription" {
   description      = "Code Engine destination Subscription for Event Notification"
   destination_id   = ibm_en_destination_ce.codeengine_destination.destination_id
   topic_id         = ibm_en_topic.topic1.topic_id
+  attributes {
+    template_id_notification = ibm_en_code_engine_template.en_ce_app_template.template_id
+  }
 }
 ```
 
@@ -35,6 +38,10 @@ Review the argument reference that you can specify for your resource.
 - `destination_id` - (Requires, String) Destination ID.
 
 - `topic_id` - (Required, String) Topic ID.
+
+- `attributes` - (Optional, List) Subscription attributes.
+  Nested scheme for **attributes**:
+    - `template_id_notification` - (Optional, String) The templete id for notification.
 
 
 ## Attribute reference


### PR DESCRIPTION
Tests: Conducted:

Pre-Defined Templates Data Sources:
<img width="1097" height="272" alt="Screenshot 2025-08-01 at 11 27 21 PM" src="https://github.com/user-attachments/assets/85de9e7d-e4fb-4039-854c-4f4046d632cd" />

List:
<img width="892" height="555" alt="Screenshot 2025-08-01 at 11 27 57 PM" src="https://github.com/user-attachments/assets/90d7a6c3-d83a-42f0-b514-6c1f89ac579b" />

Read:
<img width="1200" height="436" alt="Screenshot 2025-08-01 at 11 28 11 PM" src="https://github.com/user-attachments/assets/200a18d0-afc7-479e-834f-cba68507f962" />

Code Engine Templates:

<img width="1153" height="722" alt="Screenshot 2025-08-01 at 11 29 06 PM" src="https://github.com/user-attachments/assets/5dcad539-dbb3-4452-a63f-4c3ec877111b" />

<img width="1155" height="658" alt="Screenshot 2025-08-01 at 11 29 25 PM" src="https://github.com/user-attachments/assets/bc841539-e206-42b7-b2b1-6905c33ea63e" />

<img width="1150" height="712" alt="Screenshot 2025-08-01 at 11 29 41 PM" src="https://github.com/user-attachments/assets/41c1c22b-bec1-49ef-9990-1e43bcd45a80" />

Data Source:
<img width="1191" height="570" alt="Screenshot 2025-08-01 at 11 30 07 PM" src="https://github.com/user-attachments/assets/90cc7b23-1801-47a1-bbf2-288a737b58b2" />

Resource:
<img width="1170" height="522" alt="Screenshot 2025-08-01 at 11 30 50 PM" src="https://github.com/user-attachments/assets/79aa016b-790c-4c2b-aeb2-bbd8fa6d0bb8" />

Customer issue: https://ibm-cloudplatform.slack.com/archives/C0267256J4F/p1754578364321309?thread_ts=1754496531.581139&cid=C0267256J4F

The optional parameter starts_at and ends_at was setting default unix epoch time in case parameter was not provided
<img width="917" height="374" alt="Screenshot 2025-08-08 at 12 04 59 AM" src="https://github.com/user-attachments/assets/eb67dea6-fc2a-453d-8f8f-3f0f02ad0ce7" />

Fix Provided: fix additionally check for emtpy string along with nil value so that it does not result in invalid time value and subsequently values are not set to default time.

Tests:

Setting cron expression:
<img width="1098" height="647" alt="Screenshot 2025-08-08 at 12 06 43 AM" src="https://github.com/user-attachments/assets/18698268-96ff-42ce-a9bd-1d22211f6d0a" />

adding start time
<img width="1098" height="491" alt="Screenshot 2025-08-08 at 12 07 27 AM" src="https://github.com/user-attachments/assets/f4f1d486-a98c-466b-82d6-2569489c081f" />

adding end time
<img width="1090" height="666" alt="Screenshot 2025-08-08 at 12 07 39 AM" src="https://github.com/user-attachments/assets/dd714ad5-e033-4d98-ac9c-962a9f6c2a9d" />

removing time constraints
<img width="1102" height="693" alt="Screenshot 2025-08-08 at 12 07 53 AM" src="https://github.com/user-attachments/assets/26454358-2b3b-4a6f-8a9b-29e989bfa560" />
