### PR TITLE
 fix: bypassing scc refresh after deprecation 

### DIFF
--- a/ibm/service/resourcecontroller/resource_ibm_resource_instance.go
+++ b/ibm/service/resourcecontroller/resource_ibm_resource_instance.go
@@ -581,14 +581,14 @@ func ResourceIBMResourceInstanceRead(d *schema.ResourceData, meta interface{}) e
 	}
 	rsCatRepo := rsCatClient.ResourceCatalog()
 
-	if *instance.ResourceID != "compliance" {
+	if *instance.ResourceID == "compliance" {
+		d.Set("service", *instance.ResourceID)
+	} else {
 		serviceOff, err := rsCatRepo.GetServiceName(*instance.ResourceID)
 		if err != nil {
 			return fmt.Errorf("[ERROR] Error retrieving service offering: %s", err)
 		}
 		d.Set("service", serviceOff)
-	} else {
-		d.Set("service", *instance.ResourceID)
 	}
 
 	d.Set(flex.ResourceName, instance.Name)
@@ -602,14 +602,14 @@ func ResourceIBMResourceInstanceRead(d *schema.ResourceData, meta interface{}) e
 	}
 	d.Set(flex.ResourceControllerURL, rcontroller+"/services/")
 
-	if *instance.ResourceID != "compliance" {
+	if *instance.ResourceID == "compliance" {
+		d.Set("plan", "security-compliance-center-standard-plan")
+	} else {
 		servicePlan, err := rsCatRepo.GetServicePlanName(*instance.ResourcePlanID)
 		if err != nil {
 			return fmt.Errorf("[ERROR] Error retrieving plan: %s", err)
 		}
 		d.Set("plan", servicePlan)
-	} else {
-		d.Set("plan", *instance.ResourcePlanID)
 	}
 
 	d.Set("guid", instance.GUID)

--- a/ibm/service/resourcecontroller/resource_ibm_resource_instance.go
+++ b/ibm/service/resourcecontroller/resource_ibm_resource_instance.go
@@ -581,12 +581,15 @@ func ResourceIBMResourceInstanceRead(d *schema.ResourceData, meta interface{}) e
 	}
 	rsCatRepo := rsCatClient.ResourceCatalog()
 
-	serviceOff, err := rsCatRepo.GetServiceName(*instance.ResourceID)
-	if err != nil {
-		return fmt.Errorf("[ERROR] Error retrieving service offering: %s", err)
+	if *instance.ResourceID != "compliance" {
+		serviceOff, err := rsCatRepo.GetServiceName(*instance.ResourceID)
+		if err != nil {
+			return fmt.Errorf("[ERROR] Error retrieving service offering: %s", err)
+		}
+		d.Set("service", serviceOff)
+	} else {
+		d.Set("service", *instance.ResourceID)
 	}
-
-	d.Set("service", serviceOff)
 
 	d.Set(flex.ResourceName, instance.Name)
 	d.Set(flex.ResourceCRN, instance.CRN)
@@ -599,11 +602,16 @@ func ResourceIBMResourceInstanceRead(d *schema.ResourceData, meta interface{}) e
 	}
 	d.Set(flex.ResourceControllerURL, rcontroller+"/services/")
 
-	servicePlan, err := rsCatRepo.GetServicePlanName(*instance.ResourcePlanID)
-	if err != nil {
-		return fmt.Errorf("[ERROR] Error retrieving plan: %s", err)
+	if *instance.ResourceID != "compliance" {
+		servicePlan, err := rsCatRepo.GetServicePlanName(*instance.ResourcePlanID)
+		if err != nil {
+			return fmt.Errorf("[ERROR] Error retrieving plan: %s", err)
+		}
+		d.Set("plan", servicePlan)
+	} else {
+		d.Set("plan", *instance.ResourcePlanID)
 	}
-	d.Set("plan", servicePlan)
+
 	d.Set("guid", instance.GUID)
 	// ### Modificataion : Setting  "onetime_credentials"
 	d.Set("onetime_credentials", instance.OnetimeCredentials)


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/IBM-Cloud/terraform-provider-ibm/blob/master/.github/CONTRIBUTING.md --->

For: https://github.ibm.com/project-fortress/pm/issues/21811

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

**Test Evidence Summary:**

**Existing Behavior: Using the Latest Terraform Provider (v1.81.0):**

**1. Import Operation:**

> Cloudant: Successfully imported.
> Compliance: Import failed due to service deprecation and the instance's account not being allow-listed in the Global Catalog.
> 
> <img width="1720" height="767" alt="image" src="https://github.com/user-attachments/assets/54d76a27-6aa2-47dd-ba93-e882051d2510" />

**2. Read Operation:**

> Cloudant: Successfully read.
> Compliance: Read failed for the same reasons—service deprecation and account not allow-listed in the Global Catalog.
> 
> <img width="1457" height="714" alt="image" src="https://github.com/user-attachments/assets/24bf9cd2-dfcf-4966-b15f-05a2d4638b13" />


**Behavior after Fix: Using the Local Terraform Provider (v1.0.0):**

**1. Import Operation:**

> Cloudant & Compliance: Both resources were successfully imported. The local provider skips the Global Catalog call for compliance during refresh, avoiding the issue.
> 
> <img width="1720" height="873" alt="image" src="https://github.com/user-attachments/assets/56e01365-2c1b-49de-afaf-93a8265ed9f8" />

**2. Read Operation:**

**Cloudant & Compliance: Both resources were successfully read, again due to bypassing the Global Catalog call for compliance.

<img width="1448" height="441" alt="image" src="https://github.com/user-attachments/assets/432f5e05-b877-4073-a684-83293a520d12" />**

**3. Terraform Apply with Full .tfstate:**

**The overall refresh and apply operation completed successfully with all resources in the .tfstate file.

<img width="1717" height="905" alt="image" src="https://github.com/user-attachments/assets/a41cdb62-f706-4587-9d37-42388c9a87a3" />**



Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```
