### PR TITLE
Optionally disable SM crypto key tests

### DIFF
--- a/ibm/service/secretsmanager/data_source_ibm_sm_configurations_test.go
+++ b/ibm/service/secretsmanager/data_source_ibm_sm_configurations_test.go
@@ -28,19 +28,21 @@ func TestAccIbmSmConfigurationsDataSourceBasic(t *testing.T) {
 }
 
 func TestAccIbmSmConfigurationsDataSourceCryptoKey(t *testing.T) {
-	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { acc.TestAccPreCheck(t) },
-		Providers: acc.TestAccProviders,
-		Steps: []resource.TestStep{
-			resource.TestStep{
-				Config: testAccCheckIbmSmConfigurationsDataSourceConfigCryptoKey(),
-				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttrSet("data.ibm_sm_configurations.sm_configurations", "id"),
-					resource.TestCheckResourceAttrSet("data.ibm_sm_configurations.sm_configurations", "configurations.#"),
-				),
+	if acc.SecretsManagerPrivateCertificateConfigurationCryptoKeyProviderInstanceCrn != "" {
+		resource.Test(t, resource.TestCase{
+			PreCheck:  func() { acc.TestAccPreCheck(t) },
+			Providers: acc.TestAccProviders,
+			Steps: []resource.TestStep{
+				resource.TestStep{
+					Config: testAccCheckIbmSmConfigurationsDataSourceConfigCryptoKey(),
+					Check: resource.ComposeTestCheckFunc(
+						resource.TestCheckResourceAttrSet("data.ibm_sm_configurations.sm_configurations", "id"),
+						resource.TestCheckResourceAttrSet("data.ibm_sm_configurations.sm_configurations", "configurations.#"),
+					),
+				},
 			},
-		},
-	})
+		})
+	}
 }
 
 func testAccCheckIbmSmConfigurationsDataSourceConfigBasic() string {

--- a/ibm/service/secretsmanager/data_source_ibm_sm_private_certificate_configuration_intermediate_ca_test.go
+++ b/ibm/service/secretsmanager/data_source_ibm_sm_private_certificate_configuration_intermediate_ca_test.go
@@ -36,27 +36,29 @@ func TestAccIbmSmPrivateCertificateConfigurationIntermediateCADataSourceBasic(t 
 }
 
 func TestAccIbmSmPrivateCertificateConfigurationIntermediateCADataSourceCryptoKey(t *testing.T) {
-	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { acc.TestAccPreCheck(t) },
-		Providers: acc.TestAccProviders,
-		Steps: []resource.TestStep{
-			resource.TestStep{
-				Config: testAccCheckIbmSmPrivateCertificateConfigurationIntermediateCADataSourceConfigCryptoKey(),
-				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttrSet("data.ibm_sm_private_certificate_configuration_intermediate_ca.sm_private_certificate_configuration_intermediate_ca_crypto_key", "id"),
-					resource.TestCheckResourceAttrSet("data.ibm_sm_private_certificate_configuration_intermediate_ca.sm_private_certificate_configuration_intermediate_ca_crypto_key", "name"),
-					resource.TestCheckResourceAttrSet("data.ibm_sm_private_certificate_configuration_intermediate_ca.sm_private_certificate_configuration_intermediate_ca_crypto_key", "config_type"),
-					resource.TestCheckResourceAttrSet("data.ibm_sm_private_certificate_configuration_intermediate_ca.sm_private_certificate_configuration_intermediate_ca_crypto_key", "secret_type"),
-					//resource.TestCheckResourceAttrSet("data.ibm_sm_private_certificate_configuration_intermediate_ca.sm_private_certificate_configuration_intermediate_ca_crypto_key", "created_by"),
-					//resource.TestCheckResourceAttrSet("data.ibm_sm_private_certificate_configuration_intermediate_ca.sm_private_certificate_configuration_intermediate_ca_crypto_key", "created_at"),
-					//resource.TestCheckResourceAttrSet("data.ibm_sm_private_certificate_configuration_intermediate_ca.sm_private_certificate_configuration_intermediate_ca_crypto_key", "updated_at"),
-					resource.TestCheckResourceAttrSet("data.ibm_sm_private_certificate_configuration_intermediate_ca.sm_private_certificate_configuration_intermediate_ca_crypto_key", "signing_method"),
-					resource.TestCheckResourceAttrSet("data.ibm_sm_private_certificate_configuration_intermediate_ca.sm_private_certificate_configuration_intermediate_ca_crypto_key", "common_name"),
-					resource.TestCheckResourceAttrSet("data.ibm_sm_private_certificate_configuration_intermediate_ca.sm_private_certificate_configuration_intermediate_ca_crypto_key", "crypto_key.#"),
-				),
+	if acc.SecretsManagerPrivateCertificateConfigurationCryptoKeyProviderInstanceCrn != "" {
+		resource.Test(t, resource.TestCase{
+			PreCheck:  func() { acc.TestAccPreCheck(t) },
+			Providers: acc.TestAccProviders,
+			Steps: []resource.TestStep{
+				resource.TestStep{
+					Config: testAccCheckIbmSmPrivateCertificateConfigurationIntermediateCADataSourceConfigCryptoKey(),
+					Check: resource.ComposeTestCheckFunc(
+						resource.TestCheckResourceAttrSet("data.ibm_sm_private_certificate_configuration_intermediate_ca.sm_private_certificate_configuration_intermediate_ca_crypto_key", "id"),
+						resource.TestCheckResourceAttrSet("data.ibm_sm_private_certificate_configuration_intermediate_ca.sm_private_certificate_configuration_intermediate_ca_crypto_key", "name"),
+						resource.TestCheckResourceAttrSet("data.ibm_sm_private_certificate_configuration_intermediate_ca.sm_private_certificate_configuration_intermediate_ca_crypto_key", "config_type"),
+						resource.TestCheckResourceAttrSet("data.ibm_sm_private_certificate_configuration_intermediate_ca.sm_private_certificate_configuration_intermediate_ca_crypto_key", "secret_type"),
+						//resource.TestCheckResourceAttrSet("data.ibm_sm_private_certificate_configuration_intermediate_ca.sm_private_certificate_configuration_intermediate_ca_crypto_key", "created_by"),
+						//resource.TestCheckResourceAttrSet("data.ibm_sm_private_certificate_configuration_intermediate_ca.sm_private_certificate_configuration_intermediate_ca_crypto_key", "created_at"),
+						//resource.TestCheckResourceAttrSet("data.ibm_sm_private_certificate_configuration_intermediate_ca.sm_private_certificate_configuration_intermediate_ca_crypto_key", "updated_at"),
+						resource.TestCheckResourceAttrSet("data.ibm_sm_private_certificate_configuration_intermediate_ca.sm_private_certificate_configuration_intermediate_ca_crypto_key", "signing_method"),
+						resource.TestCheckResourceAttrSet("data.ibm_sm_private_certificate_configuration_intermediate_ca.sm_private_certificate_configuration_intermediate_ca_crypto_key", "common_name"),
+						resource.TestCheckResourceAttrSet("data.ibm_sm_private_certificate_configuration_intermediate_ca.sm_private_certificate_configuration_intermediate_ca_crypto_key", "crypto_key.#"),
+					),
+				},
 			},
-		},
-	})
+		})
+	}
 }
 
 func testAccCheckIbmSmPrivateCertificateConfigurationIntermediateCADataSourceConfigBasic() string {

--- a/ibm/service/secretsmanager/data_source_ibm_sm_private_certificate_configuration_root_ca_test.go
+++ b/ibm/service/secretsmanager/data_source_ibm_sm_private_certificate_configuration_root_ca_test.go
@@ -35,26 +35,28 @@ func TestAccIbmSmPrivateCertificateConfigurationRootCADataSourceBasic(t *testing
 }
 
 func TestAccIbmSmPrivateCertificateConfigurationRootCADataSourceCryptoKey(t *testing.T) {
-	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { acc.TestAccPreCheck(t) },
-		Providers: acc.TestAccProviders,
-		Steps: []resource.TestStep{
-			resource.TestStep{
-				Config: testAccCheckIbmSmPrivateCertificateConfigurationRootCADataSourceConfigCryptoKey(),
-				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttrSet("data.ibm_sm_private_certificate_configuration_root_ca.sm_private_certificate_configuration_root_ca_crypto_key", "id"),
-					resource.TestCheckResourceAttrSet("data.ibm_sm_private_certificate_configuration_root_ca.sm_private_certificate_configuration_root_ca_crypto_key", "name"),
-					resource.TestCheckResourceAttrSet("data.ibm_sm_private_certificate_configuration_root_ca.sm_private_certificate_configuration_root_ca_crypto_key", "config_type"),
-					resource.TestCheckResourceAttrSet("data.ibm_sm_private_certificate_configuration_root_ca.sm_private_certificate_configuration_root_ca_crypto_key", "secret_type"),
-					resource.TestCheckResourceAttrSet("data.ibm_sm_private_certificate_configuration_root_ca.sm_private_certificate_configuration_root_ca_crypto_key", "created_by"),
-					resource.TestCheckResourceAttrSet("data.ibm_sm_private_certificate_configuration_root_ca.sm_private_certificate_configuration_root_ca_crypto_key", "created_at"),
-					resource.TestCheckResourceAttrSet("data.ibm_sm_private_certificate_configuration_root_ca.sm_private_certificate_configuration_root_ca_crypto_key", "updated_at"),
-					resource.TestCheckResourceAttrSet("data.ibm_sm_private_certificate_configuration_root_ca.sm_private_certificate_configuration_root_ca_crypto_key", "common_name"),
-					resource.TestCheckResourceAttrSet("data.ibm_sm_private_certificate_configuration_root_ca.sm_private_certificate_configuration_root_ca_crypto_key", "crypto_key.#"),
-				),
+	if acc.SecretsManagerPrivateCertificateConfigurationCryptoKeyProviderInstanceCrn != "" {
+		resource.Test(t, resource.TestCase{
+			PreCheck:  func() { acc.TestAccPreCheck(t) },
+			Providers: acc.TestAccProviders,
+			Steps: []resource.TestStep{
+				resource.TestStep{
+					Config: testAccCheckIbmSmPrivateCertificateConfigurationRootCADataSourceConfigCryptoKey(),
+					Check: resource.ComposeTestCheckFunc(
+						resource.TestCheckResourceAttrSet("data.ibm_sm_private_certificate_configuration_root_ca.sm_private_certificate_configuration_root_ca_crypto_key", "id"),
+						resource.TestCheckResourceAttrSet("data.ibm_sm_private_certificate_configuration_root_ca.sm_private_certificate_configuration_root_ca_crypto_key", "name"),
+						resource.TestCheckResourceAttrSet("data.ibm_sm_private_certificate_configuration_root_ca.sm_private_certificate_configuration_root_ca_crypto_key", "config_type"),
+						resource.TestCheckResourceAttrSet("data.ibm_sm_private_certificate_configuration_root_ca.sm_private_certificate_configuration_root_ca_crypto_key", "secret_type"),
+						resource.TestCheckResourceAttrSet("data.ibm_sm_private_certificate_configuration_root_ca.sm_private_certificate_configuration_root_ca_crypto_key", "created_by"),
+						resource.TestCheckResourceAttrSet("data.ibm_sm_private_certificate_configuration_root_ca.sm_private_certificate_configuration_root_ca_crypto_key", "created_at"),
+						resource.TestCheckResourceAttrSet("data.ibm_sm_private_certificate_configuration_root_ca.sm_private_certificate_configuration_root_ca_crypto_key", "updated_at"),
+						resource.TestCheckResourceAttrSet("data.ibm_sm_private_certificate_configuration_root_ca.sm_private_certificate_configuration_root_ca_crypto_key", "common_name"),
+						resource.TestCheckResourceAttrSet("data.ibm_sm_private_certificate_configuration_root_ca.sm_private_certificate_configuration_root_ca_crypto_key", "crypto_key.#"),
+					),
+				},
 			},
-		},
-	})
+		})
+	}
 }
 
 func testAccCheckIbmSmPrivateCertificateConfigurationRootCADataSourceConfigBasic() string {

--- a/ibm/service/secretsmanager/resource_ibm_sm_private_certificate_configuration_intermediate_ca_test.go
+++ b/ibm/service/secretsmanager/resource_ibm_sm_private_certificate_configuration_intermediate_ca_test.go
@@ -77,28 +77,30 @@ func TestAccIbmSmPrivateCertificateConfigurationIntermediateCAllArgs(t *testing.
 }
 
 func TestAccIbmSmPrivateCertificateConfigurationIntermediateCACryptoKey(t *testing.T) {
-	resourceName := "ibm_sm_private_certificate_configuration_intermediate_ca.sm_private_cert_intermediate_ca_crypto_key"
+	if acc.SecretsManagerPrivateCertificateConfigurationCryptoKeyProviderInstanceCrn != "" {
+		resourceName := "ibm_sm_private_certificate_configuration_intermediate_ca.sm_private_cert_intermediate_ca_crypto_key"
 
-	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { acc.TestAccPreCheck(t) },
-		Providers:    acc.TestAccProviders,
-		CheckDestroy: testAccCheckIbmSmPrivateCertificateConfigurationIntermediateCADestroy,
-		Steps: []resource.TestStep{
-			resource.TestStep{
-				Config: privateCertificateIntermediateCAConfigCryptoKey(),
-				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckIbmSmPrivateCertificateConfigurationIntermediateCAExists(resourceName, 94680000., 259200, false, true, true),
-				),
+		resource.Test(t, resource.TestCase{
+			PreCheck:     func() { acc.TestAccPreCheck(t) },
+			Providers:    acc.TestAccProviders,
+			CheckDestroy: testAccCheckIbmSmPrivateCertificateConfigurationIntermediateCADestroy,
+			Steps: []resource.TestStep{
+				resource.TestStep{
+					Config: privateCertificateIntermediateCAConfigCryptoKey(),
+					Check: resource.ComposeAggregateTestCheckFunc(
+						testAccCheckIbmSmPrivateCertificateConfigurationIntermediateCAExists(resourceName, 94680000., 259200, false, true, true),
+					),
+				},
+				resource.TestStep{
+					ResourceName:      resourceName,
+					ImportState:       true,
+					ImportStateVerify: true,
+					ImportStateVerifyIgnore: []string{"crl_expiry", "max_ttl", "max_path_length",
+						"permitted_dns_domains", "ttl", "use_csr_values"},
+				},
 			},
-			resource.TestStep{
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
-				ImportStateVerifyIgnore: []string{"crl_expiry", "max_ttl", "max_path_length",
-					"permitted_dns_domains", "ttl", "use_csr_values"},
-			},
-		},
-	})
+		})
+	}
 }
 
 func rootCaConfig() string {

--- a/ibm/service/secretsmanager/resource_ibm_sm_private_certificate_configuration_root_ca_test.go
+++ b/ibm/service/secretsmanager/resource_ibm_sm_private_certificate_configuration_root_ca_test.go
@@ -80,27 +80,29 @@ func TestAccIbmSmPrivateCertificateConfigurationRootCAllArgs(t *testing.T) {
 }
 
 func TestAccIbmSmPrivateCertificateConfigurationRootCACryptoKey(t *testing.T) {
-	resourceName := "ibm_sm_private_certificate_configuration_root_ca.sm_private_cert_root_ca_crypto_key"
+	if acc.SecretsManagerPrivateCertificateConfigurationCryptoKeyProviderInstanceCrn != "" {
+		resourceName := "ibm_sm_private_certificate_configuration_root_ca.sm_private_cert_root_ca_crypto_key"
 
-	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { acc.TestAccPreCheck(t) },
-		Providers:    acc.TestAccProviders,
-		CheckDestroy: testAccCheckIbmSmPrivateCertificateConfigurationRootCADestroy,
-		Steps: []resource.TestStep{
-			resource.TestStep{
-				Config: privateCertificateRootCAConfigCryptoKey(),
-				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckIbmSmPrivateCertificateConfigurationRootCAExists(resourceName, 157788000, 259200, false, true, true),
-				),
+		resource.Test(t, resource.TestCase{
+			PreCheck:     func() { acc.TestAccPreCheck(t) },
+			Providers:    acc.TestAccProviders,
+			CheckDestroy: testAccCheckIbmSmPrivateCertificateConfigurationRootCADestroy,
+			Steps: []resource.TestStep{
+				resource.TestStep{
+					Config: privateCertificateRootCAConfigCryptoKey(),
+					Check: resource.ComposeAggregateTestCheckFunc(
+						testAccCheckIbmSmPrivateCertificateConfigurationRootCAExists(resourceName, 157788000, 259200, false, true, true),
+					),
+				},
+				resource.TestStep{
+					ResourceName:            resourceName,
+					ImportState:             true,
+					ImportStateVerify:       true,
+					ImportStateVerifyIgnore: []string{"crl_expiry", "max_ttl", "ttl"},
+				},
 			},
-			resource.TestStep{
-				ResourceName:            resourceName,
-				ImportState:             true,
-				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"crl_expiry", "max_ttl", "ttl"},
-			},
-		},
-	})
+		})
+	}
 }
 
 var rootCaBasicConfigFormat = `


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/IBM-Cloud/terraform-provider-ibm/blob/master/.github/CONTRIBUTING.md --->
Optionally disable crypto key tests. That is required because the tests work with HPCS and HPCS in staging suffers from serious delays and errors. We currently disable tests with HPCS when running in the staging environment. 
<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```
