### PR TITLE
Refactor terraform errors to use new toolchain in cloud connection, cloud instance, and datacenter data sources

### DIFF
--- a/ibm/service/power/data_source_ibm_pi_cloud_connection.go
+++ b/ibm/service/power/data_source_ibm_pi_cloud_connection.go
@@ -5,11 +5,13 @@ package power
 
 import (
 	"context"
+	"fmt"
 	"log"
 
 	"github.com/IBM-Cloud/power-go-client/clients/instance"
 	"github.com/IBM-Cloud/power-go-client/power/models"
 	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/conns"
+	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/flex"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
@@ -110,10 +112,12 @@ func DataSourceIBMPICloudConnection() *schema.Resource {
 	}
 }
 
-func dataSourceIBMPICloudConnectionRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func dataSourceIBMPICloudConnectionRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	sess, err := meta.(conns.ClientSession).IBMPISession()
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("IBMPISession failed: %s", err.Error()), "(Data) ibm_pi_cloud_connection", "read")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	cloudInstanceID := d.Get(Arg_CloudInstanceID).(string)
@@ -129,8 +133,9 @@ func dataSourceIBMPICloudConnectionRead(ctx context.Context, d *schema.ResourceD
 	// }
 	cloudConnections, err := client.GetAll()
 	if err != nil {
-		log.Printf("[DEBUG] get cloud connections failed %v", err)
-		return diag.FromErr(err)
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("GetAll failed: %s", err.Error()), "(Data) ibm_pi_cloud_connection", "read")
+		log.Printf("[DEBUG] get cloud connections failed %v\n%s", err, tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 	var cloudConnection *models.CloudConnection
 	if cloudConnections != nil {
@@ -142,14 +147,17 @@ func dataSourceIBMPICloudConnectionRead(ctx context.Context, d *schema.ResourceD
 		}
 	}
 	if cloudConnection == nil {
-		log.Printf("[DEBUG] cloud connection not found")
-		return diag.Errorf("failed to perform get cloud connection operation for name %s", cloudConnectionName)
+		err = flex.FmtErrorf("response returned empty")
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("failed to perform get cloud connection operation for name: %s", cloudConnectionName), "(Data) ibm_pi_cloud_connection", "read")
+		log.Printf("[DEBUG] cloud connection not found\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	cloudConnection, err = client.Get(*cloudConnection.CloudConnectionID)
 	if err != nil {
-		log.Printf("[DEBUG] get cloud connection failed %v", err)
-		return diag.FromErr(err)
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("Get failed: %s", err.Error()), "(Data) ibm_pi_cloud_connection", "read")
+		log.Printf("[DEBUG] get cloud connection failed \n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	d.SetId(*cloudConnection.CloudConnectionID)

--- a/ibm/service/power/data_source_ibm_pi_cloud_instance.go
+++ b/ibm/service/power/data_source_ibm_pi_cloud_instance.go
@@ -5,6 +5,7 @@ package power
 
 import (
 	"context"
+	"fmt"
 	"log"
 
 	"github.com/IBM-Cloud/power-go-client/clients/instance"
@@ -123,10 +124,12 @@ func DataSourceIBMPICloudInstance() *schema.Resource {
 	}
 }
 
-func dataSourceIBMPICloudInstanceRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func dataSourceIBMPICloudInstanceRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	sess, err := meta.(conns.ClientSession).IBMPISession()
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("IBMPISession failed: %s", err.Error()), "(Data) ibm_pi_cloud_instance", "read")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	cloudInstanceID := d.Get(Arg_CloudInstanceID).(string)
@@ -134,7 +137,9 @@ func dataSourceIBMPICloudInstanceRead(ctx context.Context, d *schema.ResourceDat
 	cloud_instance := instance.NewIBMPICloudInstanceClient(ctx, sess, cloudInstanceID)
 	cloud_instance_data, err := cloud_instance.Get(cloudInstanceID)
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("Get failed: %s", err.Error()), "(Data) ibm_pi_cloud_instance", "read")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	d.SetId(*cloud_instance_data.CloudInstanceID)
@@ -153,10 +158,10 @@ func dataSourceIBMPICloudInstanceRead(ctx context.Context, d *schema.ResourceDat
 	return nil
 }
 
-func flattenpvminstances(list []*models.PVMInstanceReference, meta interface{}) []map[string]interface{} {
-	pvms := make([]map[string]interface{}, 0)
+func flattenpvminstances(list []*models.PVMInstanceReference, meta any) []map[string]any {
+	pvms := make([]map[string]any, 0)
 	for _, lpars := range list {
-		l := map[string]interface{}{
+		l := map[string]any{
 			Attr_CreationDate: lpars.CreationDate.String(),
 			Attr_ID:           *lpars.PvmInstanceID,
 			Attr_Href:         *lpars.Href,


### PR DESCRIPTION
This PR does it for the cloud connection, cloud instance, and datacenter data sources.

Output of acceptance tests:
```
--- PASS: TestAccIBMPICloudConnectionsDataSourceBasic (11.54s)
PASS

--- PASS: TestAccIBMPICloudConnectionDataSource_basic (36.59s)
PASS

--- PASS: TestAccIBMPICloudInstanceDataSource_basic (10.01s)
PASS

--- PASS: TestAccIBMPIDatacenterDataSourceBasic (8.22s)
PASS

--- PASS: TestAccIBMPIDatacenterDataSourcePrivate (11.05s)
PASS

--- PASS: TestAccIBMPIDatacentersDataSourceBasic (7.89s)
PASS

--- PASS: TestAccIBMPIDatacentersDataSourcePrivate (10.27s)
PASS
```