### PR TITLE
Fix secret manager tests

### DIFF
--- a/ibm/service/secretsmanager/resource_ibm_sm_arbitrary_secret_test.go
+++ b/ibm/service/secretsmanager/resource_ibm_sm_arbitrary_secret_test.go
@@ -41,9 +41,10 @@ func TestAccIbmSmArbitrarySecretBasic(t *testing.T) {
 				),
 			},
 			{
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"updated_at"},
 			},
 		},
 	})
@@ -77,9 +78,10 @@ func TestAccIbmSmArbitrarySecretAllArgs(t *testing.T) {
 				),
 			},
 			{
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"updated_at"},
 			},
 		},
 	})

--- a/ibm/service/secretsmanager/resource_ibm_sm_custom_credentials_secret_test.go
+++ b/ibm/service/secretsmanager/resource_ibm_sm_custom_credentials_secret_test.go
@@ -49,9 +49,10 @@ func TestAccIbmSmCustomCredentialsSecretBasic(t *testing.T) {
 				),
 			},
 			resource.TestStep{
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"updated_at"},
 			},
 		},
 	})
@@ -97,9 +98,10 @@ func TestAccIbmSmCustomCredentialsSecretAllArgs(t *testing.T) {
 				),
 			},
 			resource.TestStep{
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"updated_at"},
 			},
 		},
 	})

--- a/ibm/service/secretsmanager/resource_ibm_sm_iam_credentials_secret_test.go
+++ b/ibm/service/secretsmanager/resource_ibm_sm_iam_credentials_secret_test.go
@@ -46,9 +46,10 @@ func TestAccIbmSmIamCredentialsSecretBasic(t *testing.T) {
 				),
 			},
 			resource.TestStep{
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"updated_at"},
 			},
 		},
 	})
@@ -88,9 +89,10 @@ func TestAccIbmSmIamCredentialsSecretAllArgs(t *testing.T) {
 				),
 			},
 			resource.TestStep{
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"updated_at"},
 			},
 		},
 	})

--- a/ibm/service/secretsmanager/resource_ibm_sm_imported_certificate_test.go
+++ b/ibm/service/secretsmanager/resource_ibm_sm_imported_certificate_test.go
@@ -51,9 +51,10 @@ func TestAccIbmSmImportedCertificateBasic(t *testing.T) {
 				),
 			},
 			resource.TestStep{
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"updated_at"},
 			},
 		},
 	})
@@ -101,9 +102,10 @@ func TestAccIbmSmImportedCertificateAllArgs(t *testing.T) {
 				),
 			},
 			resource.TestStep{
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"updated_at"},
 			},
 		},
 	})
@@ -184,9 +186,10 @@ func TestAccIbmSmImportedCertificateManagedCSR(t *testing.T) {
 				),
 			},
 			resource.TestStep{
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"updated_at"},
 			},
 		},
 	})

--- a/ibm/service/secretsmanager/resource_ibm_sm_kv_secret_test.go
+++ b/ibm/service/secretsmanager/resource_ibm_sm_kv_secret_test.go
@@ -43,9 +43,10 @@ func TestAccIbmSmKvSecretBasic(t *testing.T) {
 				),
 			},
 			resource.TestStep{
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"updated_at"},
 			},
 		},
 	})
@@ -80,9 +81,10 @@ func TestAccIbmSmKvSecretAllArgs(t *testing.T) {
 				),
 			},
 			resource.TestStep{
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"updated_at"},
 			},
 		},
 	})

--- a/ibm/service/secretsmanager/resource_ibm_sm_private_certificate_test.go
+++ b/ibm/service/secretsmanager/resource_ibm_sm_private_certificate_test.go
@@ -56,7 +56,7 @@ func TestAccIbmSmPrivateCertificateBasic(t *testing.T) {
 				ResourceName:            resourceName,
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"private_key_format", "ttl"},
+				ImportStateVerifyIgnore: []string{"private_key_format", "ttl", "updated_at"},
 			},
 		},
 	})
@@ -105,7 +105,7 @@ func TestAccIbmSmPrivateCertificateAllArgs(t *testing.T) {
 				ResourceName:            resourceName,
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"private_key_format", "ip_sans", "format", "exclude_cn_from_sans", "ttl"},
+				ImportStateVerifyIgnore: []string{"private_key_format", "ip_sans", "format", "exclude_cn_from_sans", "ttl", "updated_at"},
 			},
 		},
 	})

--- a/ibm/service/secretsmanager/resource_ibm_sm_public_certificate_test.go
+++ b/ibm/service/secretsmanager/resource_ibm_sm_public_certificate_test.go
@@ -55,9 +55,10 @@ func TestAccIbmSmPublicCertificateBasic(t *testing.T) {
 				),
 			},
 			resource.TestStep{
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"updated_at"},
 			},
 		},
 	})
@@ -106,9 +107,10 @@ func TestAccIbmSmPublicCertificateAllArgs(t *testing.T) {
 				),
 			},
 			resource.TestStep{
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"updated_at"},
 			},
 		},
 	})

--- a/ibm/service/secretsmanager/resource_ibm_sm_service_credentials_secret_test.go
+++ b/ibm/service/secretsmanager/resource_ibm_sm_service_credentials_secret_test.go
@@ -48,7 +48,7 @@ func TestAccIbmSmServiceCredentialsSecretBasic(t *testing.T) {
 				ResourceName:            resourceName,
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"ttl"},
+				ImportStateVerifyIgnore: []string{"ttl", "updated_at"},
 			},
 		},
 	})
@@ -88,7 +88,7 @@ func TestAccIbmSmServiceCredentialsSecretAllArgs(t *testing.T) {
 				ResourceName:            resourceName,
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"ttl"},
+				ImportStateVerifyIgnore: []string{"ttl", "updated_at"},
 			},
 		},
 	})

--- a/ibm/service/secretsmanager/resource_ibm_sm_username_password_secret_test.go
+++ b/ibm/service/secretsmanager/resource_ibm_sm_username_password_secret_test.go
@@ -61,9 +61,10 @@ func TestAccIbmSmUsernamePasswordSecretBasic(t *testing.T) {
 				),
 			},
 			resource.TestStep{
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"updated_at"},
 			},
 		},
 	})
@@ -99,9 +100,10 @@ func TestAccIbmSmUsernamePasswordSecretAllArgs(t *testing.T) {
 				),
 			},
 			resource.TestStep{
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"updated_at"},
 			},
 		},
 	})


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/IBM-Cloud/terraform-provider-ibm/blob/master/.github/CONTRIBUTING.md --->

A recent change in the API of Secrets Manager causes some side effect that is breaking some of the Secrets Manager tests. This PR fixes the breaking tests by a minor change in the validation in resource import tests.

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```
