### PR TITLE
added storage_generation attribute to is_volume

### DIFF
--- a/ibm/service/vpc/data_source_ibm_is_volume.go
+++ b/ibm/service/vpc/data_source_ibm_is_volume.go
@@ -169,6 +169,12 @@ func DataSourceIBMISVolume() *schema.Resource {
 				Description: "IOPS value for the Volume",
 			},
 
+			"storage_generation": {
+				Type:        schema.TypeInt,
+				Computed:    true,
+				Description: "storage_generation indicates which generation the profile family belongs to. For the custom and tiered profiles, this value is 1.",
+			},
+
 			isVolumeCrn: {
 				Type:        schema.TypeString,
 				Computed:    true,
@@ -479,6 +485,11 @@ func volumeGet(context context.Context, d *schema.ResourceData, meta interface{}
 	if err = d.Set("iops", flex.IntValue(volume.Iops)); err != nil {
 		return flex.DiscriminatedTerraformErrorf(err, fmt.Sprintf("Error setting iops: %s", err), "(Data) ibm_is_volume", "read", "set-iops").GetDiag()
 	}
+
+	if err = d.Set("storage_generation", flex.IntValue(volume.StorageGeneration)); err != nil {
+		return flex.DiscriminatedTerraformErrorf(err, fmt.Sprintf("Error setting storage_generation: %s", err), "(Data) ibm_is_volume", "read", "set-storage_generation").GetDiag()
+	}
+
 	if err = d.Set("capacity", flex.IntValue(volume.Capacity)); err != nil {
 		return flex.DiscriminatedTerraformErrorf(err, fmt.Sprintf("Error setting capacity: %s", err), "(Data) ibm_is_volume", "read", "set-capacity").GetDiag()
 	}

--- a/ibm/service/vpc/data_source_ibm_is_volume_test.go
+++ b/ibm/service/vpc/data_source_ibm_is_volume_test.go
@@ -206,6 +206,91 @@ ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCKVmnMOlHKcZK8tpt3MP1lqOLAcqcJzhsvJcjscgVE
 		},
 	})
 }
+func TestAccIBMISVolumeDatasource_storage_generation(t *testing.T) {
+
+	resName := "data.ibm_is_volume.testacc_dsvol"
+	resName1 := "data.ibm_is_volume.testacc_dsvolid"
+	resName2 := "data.ibm_is_volume.testacc_dsvol2"
+	resName3 := "data.ibm_is_volume.testacc_dsvol2id"
+	name := fmt.Sprintf("tf-vol-%d", acctest.RandIntRange(10, 100))
+	name1 := fmt.Sprintf("tf-vol2-%d", acctest.RandIntRange(10, 100))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { acc.TestAccPreCheck(t) },
+		Providers: acc.TestAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckIBMISVolumeDataSourceStorageGeneration(name, name1),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet(
+						resName, "active"),
+					resource.TestCheckResourceAttrSet(
+						resName, "attachment_state"),
+					resource.TestCheckResourceAttrSet(
+						resName, "bandwidth"),
+					resource.TestCheckResourceAttrSet(
+						resName, "busy"),
+					resource.TestCheckResourceAttrSet(
+						resName, "created_at"),
+					resource.TestCheckResourceAttrSet(
+						resName, "resource_group"),
+					resource.TestCheckResourceAttrSet(
+						resName, "profile"),
+					resource.TestCheckResourceAttrSet(
+						resName, "storage_generation"),
+					resource.TestCheckResourceAttrSet(
+						resName1, "active"),
+					resource.TestCheckResourceAttrSet(
+						resName1, "attachment_state"),
+					resource.TestCheckResourceAttrSet(
+						resName1, "bandwidth"),
+					resource.TestCheckResourceAttrSet(
+						resName1, "busy"),
+					resource.TestCheckResourceAttrSet(
+						resName1, "created_at"),
+					resource.TestCheckResourceAttrSet(
+						resName1, "resource_group"),
+					resource.TestCheckResourceAttrSet(
+						resName1, "profile"),
+					resource.TestCheckResourceAttrSet(
+						resName1, "storage_generation"),
+					resource.TestCheckResourceAttrSet(
+						resName2, "active"),
+					resource.TestCheckResourceAttrSet(
+						resName2, "attachment_state"),
+					resource.TestCheckResourceAttrSet(
+						resName2, "bandwidth"),
+					resource.TestCheckResourceAttrSet(
+						resName2, "busy"),
+					resource.TestCheckResourceAttrSet(
+						resName2, "created_at"),
+					resource.TestCheckResourceAttrSet(
+						resName2, "resource_group"),
+					resource.TestCheckResourceAttrSet(
+						resName2, "profile"),
+					resource.TestCheckResourceAttrSet(
+						resName2, "storage_generation"),
+					resource.TestCheckResourceAttrSet(
+						resName3, "active"),
+					resource.TestCheckResourceAttrSet(
+						resName3, "attachment_state"),
+					resource.TestCheckResourceAttrSet(
+						resName3, "bandwidth"),
+					resource.TestCheckResourceAttrSet(
+						resName3, "busy"),
+					resource.TestCheckResourceAttrSet(
+						resName3, "created_at"),
+					resource.TestCheckResourceAttrSet(
+						resName3, "resource_group"),
+					resource.TestCheckResourceAttrSet(
+						resName3, "profile"),
+					resource.TestCheckResourceAttrSet(
+						resName3, "storage_generation"),
+				),
+			},
+		},
+	})
+}
 func TestAccIBMISVolumeDatasourceWithCatalogOffering(t *testing.T) {
 
 	resName := "data.ibm_is_volume.testacc_dsvol"
@@ -243,6 +328,24 @@ func testAccCheckIBMISVolumeDataSourceFromSnapshotConfig(vpcname, subnetname, ss
 	data "ibm_is_volume" "testacc_dsvol" {
 		name = ibm_is_volume.storage.name
 	}`)
+}
+func testAccCheckIBMISVolumeDataSourceStorageGeneration(name, name1 string) string {
+	return testAccCheckIBMISVolumeStorageConfig(name, name1) + fmt.Sprintf(`
+	
+	data "ibm_is_volume" "testacc_dsvol" {
+		name = ibm_is_volume.storage.name
+	}
+	data "ibm_is_volume" "testacc_dsvolid" {
+		identifier = ibm_is_volume.storage2.id
+	}
+	data "ibm_is_volume" "testacc_dsvol2" {
+		name = ibm_is_volume.storage.name
+	}
+	data "ibm_is_volume" "testacc_dsvol2id" {
+		identifier = ibm_is_volume.storage2.id
+	}
+		
+	`)
 }
 func testAccCheckIBMISVolumeDataSourceConfig(name, zone string) string {
 	return fmt.Sprintf(`

--- a/ibm/service/vpc/data_source_ibm_is_volumes.go
+++ b/ibm/service/vpc/data_source_ibm_is_volumes.go
@@ -411,6 +411,11 @@ func DataSourceIBMIsVolumes() *schema.Resource {
 								Type: schema.TypeString,
 							},
 						},
+						"storage_generation": {
+							Type:        schema.TypeInt,
+							Computed:    true,
+							Description: "storage_generation indicates which generation the profile family belongs to. For the custom and tiered profiles, this value is 1.",
+						},
 						isVolumesStatus: &schema.Schema{
 							Type:        schema.TypeString,
 							Computed:    true,
@@ -798,6 +803,9 @@ func dataSourceVolumeCollectionVolumesToMap(volumesItem vpcv1.Volume, meta inter
 	}
 	if volumesItem.Iops != nil {
 		volumesMap[isVolumesIops] = volumesItem.Iops
+	}
+	if volumesItem.StorageGeneration != nil {
+		volumesMap["storage_generation"] = volumesItem.StorageGeneration
 	}
 	if volumesItem.Name != nil {
 		volumesMap[isVolumesName] = volumesItem.Name

--- a/ibm/service/vpc/data_source_ibm_is_volumes_test.go
+++ b/ibm/service/vpc/data_source_ibm_is_volumes_test.go
@@ -60,6 +60,27 @@ func TestAccIBMIsVolumesDataSourceSdpBasic(t *testing.T) {
 		},
 	})
 }
+func TestAccIBMIsVolumesDataSourceStorageGenerationBasic(t *testing.T) {
+	name := fmt.Sprintf("tf-vol-%d", acctest.RandIntRange(10, 100))
+	name1 := fmt.Sprintf("tf-vol2-%d", acctest.RandIntRange(10, 100))
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { acc.TestAccPreCheck(t) },
+		Providers: acc.TestAccProviders,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccCheckIBMIsVolumesDataSourceStorageGenerationConfig(name, name1),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet("data.ibm_is_volumes.is_volumes", "id"),
+					resource.TestCheckResourceAttrSet("data.ibm_is_volumes.is_volumes", "volumes.#"),
+					resource.TestCheckResourceAttrSet("data.ibm_is_volumes.is_volumes", "volumes.0.name"),
+					resource.TestCheckResourceAttrSet("data.ibm_is_volumes.is_volumes", "volumes.0.storage_generation"),
+					resource.TestCheckResourceAttrSet("data.ibm_is_volumes.is_volumes", "volumes.1.name"),
+					resource.TestCheckResourceAttrSet("data.ibm_is_volumes.is_volumes", "volumes.1.storage_generation"),
+				),
+			},
+		},
+	})
+}
 func TestAccIBMIsVolumesFromSnapshotDataSourceBasic(t *testing.T) {
 	resName := "data.ibm_is_volumes.is_volumes"
 	vpcname := fmt.Sprintf("tf-vpc-%d", acctest.RandIntRange(10, 100))
@@ -175,6 +196,13 @@ func testAccCheckIBMIsVolumesDataSourceConfigBasic() string {
 func testAccCheckIBMIsVolumesDataSourceSdpConfig() string {
 	return fmt.Sprintf(`
 		data "ibm_is_volumes" "is_volumes" {
+		}
+	`)
+}
+func testAccCheckIBMIsVolumesDataSourceStorageGenerationConfig(name, name1 string) string {
+	return testAccCheckIBMISVolumeStorageConfig(name, name1) + fmt.Sprintf(`
+		data "ibm_is_volumes" "is_volumes" {
+			depends_on = [ibm_is_volume.storage, ibm_is_volume.storage2]
 		}
 	`)
 }

--- a/ibm/service/vpc/resource_ibm_is_volume.go
+++ b/ibm/service/vpc/resource_ibm_is_volume.go
@@ -130,6 +130,11 @@ func ResourceIBMISVolume() *schema.Resource {
 				Computed:    true,
 				Description: "Volume encryption type info",
 			},
+			"storage_generation": {
+				Type:        schema.TypeInt,
+				Computed:    true,
+				Description: "storage_generation indicates which generation the profile family belongs to. For the custom and tiered profiles, this value is 1.",
+			},
 
 			isVolumeCapacity: {
 				Type:     schema.TypeInt,
@@ -683,6 +688,9 @@ func volGet(context context.Context, d *schema.ResourceData, meta interface{}, i
 			err = fmt.Errorf("Error setting name: %s", err)
 			return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_is_volume", "read", "set-name").GetDiag()
 		}
+	}
+	if err = d.Set("storage_generation", flex.IntValue(volume.StorageGeneration)); err != nil {
+		return flex.DiscriminatedTerraformErrorf(err, fmt.Sprintf("Error setting storage_generation: %s", err), "(Data) ibm_is_volume", "read", "set-storage_generation").GetDiag()
 	}
 	if !core.IsNil(volume.Profile) {
 		if err = d.Set("profile", *volume.Profile.Name); err != nil {

--- a/ibm/service/vpc/resource_ibm_is_volume_test.go
+++ b/ibm/service/vpc/resource_ibm_is_volume_test.go
@@ -48,6 +48,37 @@ func TestAccIBMISVolume_basic(t *testing.T) {
 		},
 	})
 }
+func TestAccIBMISVolume_storage_generation(t *testing.T) {
+	var vol string
+	name := fmt.Sprintf("tf-vol-%d", acctest.RandIntRange(10, 100))
+	name1 := fmt.Sprintf("tf-vol-tier-%d", acctest.RandIntRange(10, 100))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { acc.TestAccPreCheck(t) },
+		Providers:    acc.TestAccProviders,
+		CheckDestroy: testAccCheckIBMISVolumeDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckIBMISVolumeStorageConfig(name, name1),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckIBMISVolumeExists("ibm_is_volume.storage", vol),
+					resource.TestCheckResourceAttr(
+						"ibm_is_volume.storage", "name", name),
+					resource.TestCheckResourceAttr(
+						"ibm_is_volume.storage2", "name", name1),
+					resource.TestCheckResourceAttrSet(
+						"ibm_is_volume.storage", "storage_generation"),
+					resource.TestCheckResourceAttrSet(
+						"ibm_is_volume.storage2", "storage_generation"),
+					resource.TestCheckResourceAttr(
+						"ibm_is_volume.storage", "storage_generation", "1"),
+					resource.TestCheckResourceAttr(
+						"ibm_is_volume.storage2", "storage_generation", "2"),
+				),
+			},
+		},
+	})
+}
 func TestAccIBMISVolume_sdp(t *testing.T) {
 	var vol string
 	name := fmt.Sprintf("tf-vol-%d", acctest.RandIntRange(10, 100))
@@ -590,6 +621,25 @@ func testAccCheckIBMISVolumeConfig(name string) string {
 		# capacity= 200
 	}
 `, name)
+
+}
+func testAccCheckIBMISVolumeStorageConfig(name, name2 string) string {
+	return fmt.Sprintf(
+		`
+	resource "ibm_is_volume" "storage"{
+		name 			= "%s"
+		profile 		= "10iops-tier"
+		zone 			= "%s"
+		# capacity= 200
+	}
+	resource "ibm_is_volume" "storage2"{
+		name 			= "%s"
+		profile 		= "sdp"
+		zone 			= "%s"
+		capacity		= 100
+		bandwidth		= 6000
+	}
+`, name, acc.ISZoneName, name2, acc.ISZoneName)
 
 }
 

--- a/website/docs/d/is_volume.html.markdown
+++ b/website/docs/d/is_volume.html.markdown
@@ -111,6 +111,7 @@ In addition to all argument reference list, you can access the following attribu
   - `code` - (String)  A snake case string identifying the status reason.
   - `message` - (String)  An explanation of the status reason
   - `more_info` - (String) Link to documentation about this status reason
+- `storage_generation` - (Int) The storage generation indicates which generation the profile family belongs to. For the custom and tiered profiles, this value is 1. For the sdp profile, this value is 2.
 - `tags` - (String) User Tags associated with the volume. (https://cloud.ibm.com/apidocs/tagging#types-of-tags)
 - `unattached_capacity_update_supported` - (Boolean) Indicates whether the capacity for the volume can be changed when not attached to a running virtual server instance.
 - `unattached_iops_update_supported` - (Boolean) Indicates whether the IOPS for the volume can be changed when not attached to a running virtual server instance.

--- a/website/docs/d/is_volumes.html.markdown
+++ b/website/docs/d/is_volumes.html.markdown
@@ -143,6 +143,7 @@ In addition to all argument references listed, you can access the following attr
 		- `code` - (String) A snake case string succinctly identifying the status reason.
 		- `message` - (String) An explanation of the status reason.
 		- `more_info` - (Optional, String) Link to documentation about this status reason.
+	- `storage_generation` - (Int) The storage generation indicates which generation the profile family belongs to. For the custom and tiered profiles, this value is 1. For the sdp profile, this value is 2.
 	- `tags` - (String) User Tags associated with the volume. (https://cloud.ibm.com/apidocs/tagging#types-of-tags)
 	- `volume_attachments` - (List) The volume attachments for this volume.
 		Nested scheme for **volume_attachments**:

--- a/website/docs/r/is_volume.html.markdown
+++ b/website/docs/r/is_volume.html.markdown
@@ -156,6 +156,7 @@ In addition to all argument reference list, you can access the following attribu
     
       Nested schema for `deleted`:
         - `more_info`  - (String) Link to documentation about deleted resources.
+- `crn` - (String) The CRN for the volume.
 - `encryption_type` - (String) The type of encryption used in the volume [**provider_managed**, **user_managed**].
 - `health_reasons` - (List) The reasons for the current health_state (if any).
 
@@ -172,7 +173,7 @@ In addition to all argument reference list, you can access the following attribu
   - `code` - (String) A string with an underscore as a special character identifying the status reason.
   - `message` - (String) An explanation of the status reason.
   - `more_info` - (String) Link to documentation about this status reason
-- `crn` - (String) The CRN for the volume.
+- `storage_generation` - (Int) The storage generation indicates which generation the profile family belongs to. For the custom and tiered profiles, this value is 1. For the sdp profile, this value is 2.
 
 ## Import
 The `ibm_is_volume` resource can be imported by using volume ID.


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/IBM-Cloud/terraform-provider-ibm/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
--- PASS: TestAccIBMISVolume_storage_generation (58.97s)
PASS
ok      github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/vpc     60.825s
```
```
--- PASS: TestAccIBMISVolumeDatasource_storage_generation (63.10s)
PASS
ok      github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/vpc     64.936s
```
```
--- PASS: TestAccIBMIsVolumesDataSourceStorageGenerationBasic (66.48s)
PASS
ok      github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/vpc     68.315s
```