### PR TITLE
fix(CatalogManagement): bump platform go sdk, add new fields

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -28,7 +28,7 @@ require (
 	github.com/IBM/logs-router-go-sdk v1.0.8
 	github.com/IBM/mqcloud-go-sdk v0.3.0
 	github.com/IBM/networking-go-sdk v0.51.10
-	github.com/IBM/platform-services-go-sdk v0.84.4
+	github.com/IBM/platform-services-go-sdk v0.86.0
 	github.com/IBM/project-go-sdk v0.3.5
 	github.com/IBM/push-notifications-go-sdk v0.0.0-20210310100607-5790b96c47f5
 	github.com/IBM/sarama v1.45.0

--- a/go.sum
+++ b/go.sum
@@ -149,8 +149,8 @@ github.com/IBM/mqcloud-go-sdk v0.3.0 h1:zuRe+lu6IwIzsBsmoVKZT4JgX+GxH5PJG06r5y5X
 github.com/IBM/mqcloud-go-sdk v0.3.0/go.mod h1:7zigCUz6k3eRrNE8KOcDkY72oPppEmoQifF+SB0NPRM=
 github.com/IBM/networking-go-sdk v0.51.10 h1:7IKKU2U/kxd2xWDCuapkRdo91WwRT+5aRl5vwyiXKV8=
 github.com/IBM/networking-go-sdk v0.51.10/go.mod h1:iM2xvQYk6cG6ZED8+7iRqt/eKGFIAxy4/gYUdlFswMQ=
-github.com/IBM/platform-services-go-sdk v0.84.4 h1:HMq5E0DjAeta9OG4cEKEcHZLSaVj77t1+nJveJ8FIS4=
-github.com/IBM/platform-services-go-sdk v0.84.4/go.mod h1:aGD045m6I8pfcB77wft8w2cHqWOJjcM3YSSV55BX0Js=
+github.com/IBM/platform-services-go-sdk v0.86.0 h1:Uqne0Z/P9e++WfRt1aN8DD55kyo/T15+7EipYktRIDQ=
+github.com/IBM/platform-services-go-sdk v0.86.0/go.mod h1:aGD045m6I8pfcB77wft8w2cHqWOJjcM3YSSV55BX0Js=
 github.com/IBM/project-go-sdk v0.3.5 h1:L+YClFUa14foS0B/hOOY9n7sIdsT5/XQicnXOyJSpyM=
 github.com/IBM/project-go-sdk v0.3.5/go.mod h1:FOJM9ihQV3EEAY6YigcWiTNfVCThtdY8bLC/nhQHFvo=
 github.com/IBM/push-notifications-go-sdk v0.0.0-20210310100607-5790b96c47f5 h1:NPUhkoOCRuv3OFWt19PmwjXGGTKlvmbuPg9fUrBUNe4=

--- a/ibm/service/catalogmanagement/data_source_ibm_cm_account.go
+++ b/ibm/service/catalogmanagement/data_source_ibm_cm_account.go
@@ -298,7 +298,6 @@ func dataSourceIBMCmAccountRead(context context.Context, d *schema.ResourceData,
 				return flex.DiscriminatedTerraformErrorf(err, err.Error(), "(Data) ibm_cm_account", "read", "terraform_engines-to-map").GetDiag()
 			}
 			terraformEngines = append(terraformEngines, terraformEnginesItemMap)
-			fmt.Println("TF ENGINES: ", terraformEngines)
 		}
 		if err = d.Set("terraform_engines", terraformEngines); err != nil {
 			err = fmt.Errorf("Error setting terraform_engines: %s", err)

--- a/ibm/service/catalogmanagement/data_source_ibm_cm_account.go
+++ b/ibm/service/catalogmanagement/data_source_ibm_cm_account.go
@@ -134,6 +134,109 @@ func DataSourceIBMCmAccount() *schema.Resource {
 				Computed:    true,
 				Description: "Region filter string.",
 			},
+			"terraform_engines": &schema.Schema{
+				Type:        schema.TypeList,
+				Computed:    true,
+				Description: "List of terraform engines configured for this account.",
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"name": &schema.Schema{
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "User provided name for the specified engine.",
+						},
+						"type": &schema.Schema{
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "The terraform engine type. The only one supported at the moment is terraform-enterprise.",
+						},
+						"public_endpoint": &schema.Schema{
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "The public endpoint for the engine instance.",
+						},
+						"private_endpoint": &schema.Schema{
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "The private endpoint for the engine instance.",
+						},
+						"api_token": &schema.Schema{
+							Type:             schema.TypeString,
+							Optional:         true,
+							Computed:         true,
+							Sensitive:        true,
+							Description:      "The api key used to access the engine instance.",
+							DiffSuppressFunc: flex.ApplyOnce,
+						},
+						"da_creation": &schema.Schema{
+							Type:        schema.TypeList,
+							Computed:    true,
+							Description: "The settings that determines how deployable architectures are auto-created from workspaces in the terraform engine.",
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"enabled": &schema.Schema{
+										Type:        schema.TypeBool,
+										Computed:    true,
+										Description: "Determines whether deployable architectures are auto-created from workspaces in the engine.",
+									},
+									"default_private_catalog_id": &schema.Schema{
+										Type:        schema.TypeString,
+										Computed:    true,
+										Description: "Default private catalog to create the deployable architectures in.",
+									},
+									"polling_info": &schema.Schema{
+										Type:        schema.TypeList,
+										Computed:    true,
+										Description: "Determines which workspace scope to query to auto-create deployable architectures from.",
+										Elem: &schema.Resource{
+											Schema: map[string]*schema.Schema{
+												"scopes": &schema.Schema{
+													Type:        schema.TypeList,
+													Computed:    true,
+													Description: "List of scopes to auto-create deployable architectures from workspaces in the engine.",
+													Elem: &schema.Resource{
+														Schema: map[string]*schema.Schema{
+															"name": &schema.Schema{
+																Type:        schema.TypeString,
+																Computed:    true,
+																Description: "Identifier for the specified type in the scope.",
+															},
+															"type": &schema.Schema{
+																Type:        schema.TypeString,
+																Computed:    true,
+																Description: "Scope to auto-create deployable architectures from. The supported scopes today are workspace, org, and project.",
+															},
+														},
+													},
+												},
+												"last_polling_status": &schema.Schema{
+													Type:        schema.TypeList,
+													Computed:    true,
+													Description: "Last polling status of the engine scope.",
+													Elem: &schema.Resource{
+														Schema: map[string]*schema.Schema{
+															"code": &schema.Schema{
+																Type:        schema.TypeInt,
+																Computed:    true,
+																Description: "Status code of the last polling attempt.",
+															},
+															"message": &schema.Schema{
+																Type:        schema.TypeString,
+																Computed:    true,
+																Description: "Status message from the last polling attempt.",
+															},
+														},
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
 		},
 	}
 }
@@ -184,6 +287,22 @@ func dataSourceIBMCmAccountRead(context context.Context, d *schema.ResourceData,
 	if !core.IsNil(account.RegionFilter) {
 		if err = d.Set("region_filter", account.RegionFilter); err != nil {
 			return flex.DiscriminatedTerraformErrorf(err, fmt.Sprintf("Error setting region_filter: %s", err), "(Data) ibm_cm_account", "read", "set-region_filter").GetDiag()
+		}
+	}
+
+	if !core.IsNil(account.TerraformEngines) {
+		terraformEngines := []map[string]interface{}{}
+		for _, terraformEnginesItem := range account.TerraformEngines {
+			terraformEnginesItemMap, err := ResourceIBMCmAccountTerraformEnginesToMap(&terraformEnginesItem)
+			if err != nil {
+				return flex.DiscriminatedTerraformErrorf(err, err.Error(), "(Data) ibm_cm_account", "read", "terraform_engines-to-map").GetDiag()
+			}
+			terraformEngines = append(terraformEngines, terraformEnginesItemMap)
+			fmt.Println("TF ENGINES: ", terraformEngines)
+		}
+		if err = d.Set("terraform_engines", terraformEngines); err != nil {
+			err = fmt.Errorf("Error setting terraform_engines: %s", err)
+			return flex.DiscriminatedTerraformErrorf(err, err.Error(), "(Data) ibm_cm_account", "read", "set-terraform_engines").GetDiag()
 		}
 	}
 

--- a/ibm/service/catalogmanagement/data_source_ibm_cm_account_test.go
+++ b/ibm/service/catalogmanagement/data_source_ibm_cm_account_test.go
@@ -37,7 +37,29 @@ func TestAccIBMCmAccountDataSourceBasic(t *testing.T) {
 
 func testAccCheckIBMCmAccountDataSourceConfigBasic() string {
 	return fmt.Sprintf(`
+		resource "ibm_cm_catalog" "cm_catalog" {
+			label = "test_tf_account_catalog_label_1"
+			kind = "offering"
+		}
+
 		resource "ibm_cm_account" "cm_account_instance" {
+			terraform_engines {
+				name             = "my-tfe-instance"
+				type             = "terraform-enterprise"
+				public_endpoint  = "foo"
+				private_endpoint = "foo"
+				api_token        = "foo"
+				da_creation {
+					enabled                    = true
+					default_private_catalog_id = ibm_cm_catalog.cm_catalog.id
+					polling_info {
+						scopes {
+							name = "foo-project"
+							type = "project"
+						}
+					}
+				}
+			}
 		}
 
 		data "ibm_cm_account" "cm_account_instance" {

--- a/ibm/service/catalogmanagement/data_source_ibm_cm_version.go
+++ b/ibm/service/catalogmanagement/data_source_ibm_cm_version.go
@@ -164,6 +164,31 @@ func DataSourceIBMCmVersion() *schema.Resource {
 							Computed:    true,
 							Description: "Constraint associated with value, e.g., for string type - regx:[a-z].",
 						},
+						"value_constraints": &schema.Schema{
+							Type:        schema.TypeList,
+							Computed:    true,
+							Description: "Validation rules for this input value.",
+							ConfigMode:  schema.SchemaConfigModeAttr,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"type": &schema.Schema{
+										Type:        schema.TypeString,
+										Computed:    true,
+										Description: "Type of constraint.",
+									},
+									"value": &schema.Schema{
+										Type:        schema.TypeString,
+										Computed:    true,
+										Description: "Contstraint value.  For type regex, this is a regular expression in Javascript notation.",
+									},
+									"description": &schema.Schema{
+										Type:        schema.TypeString,
+										Computed:    true,
+										Description: "The value to display if the inptu value does not match the specified constraint.",
+									},
+								},
+							},
+						},
 						"description": &schema.Schema{
 							Type:        schema.TypeString,
 							Computed:    true,
@@ -2061,6 +2086,17 @@ func dataSourceIBMCmVersionConfigurationToMap(model *catalogmanagementv1.Configu
 	if model.ValueConstraint != nil {
 		modelMap["value_constraint"] = *model.ValueConstraint
 	}
+	if model.ValueConstraints != nil {
+		valueConstraints := []map[string]interface{}{}
+		for _, valueConstraintsItem := range model.ValueConstraints {
+			valueConstraintsItemMap, err := dataSourceIBMCmVersionValueConstraintToMap(&valueConstraintsItem) // #nosec G601
+			if err != nil {
+				return modelMap, err
+			}
+			valueConstraints = append(valueConstraints, valueConstraintsItemMap)
+		}
+		modelMap["value_constraints"] = valueConstraints
+	}
 	if model.Description != nil {
 		modelMap["description"] = *model.Description
 	}
@@ -2108,6 +2144,20 @@ func dataSourceIBMCmVersionRenderTypeToMap(model *catalogmanagementv1.RenderType
 			return modelMap, err
 		}
 		modelMap["associations"] = []map[string]interface{}{associationsMap}
+	}
+	return modelMap, nil
+}
+
+func dataSourceIBMCmVersionValueConstraintToMap(model *catalogmanagementv1.ValueConstraint) (map[string]interface{}, error) {
+	modelMap := make(map[string]interface{})
+	if model.Type != nil {
+		modelMap["type"] = *model.Type
+	}
+	if model.Value != nil {
+		modelMap["value"] = *model.Value
+	}
+	if model.Description != nil {
+		modelMap["description"] = *model.Description
 	}
 	return modelMap, nil
 }

--- a/ibm/service/catalogmanagement/data_source_ibm_cm_version_test.go
+++ b/ibm/service/catalogmanagement/data_source_ibm_cm_version_test.go
@@ -70,6 +70,19 @@ func testAccCheckIBMCmVersionDataSourceConfig(versionZipurl string, versionTarge
 			target_version = "%s"
 			include_config = %s
 			install {}
+			configuration {
+				default_value = "foo"
+				description = "The name to pass to the template."
+				key = "name"
+				type = "string"
+				hidden = false
+				required = false
+				value_constraints {
+					type  = "regex"
+					value = "*"
+					description = "Invalid name input"
+				}
+			}
 		}
 
 		data "ibm_cm_version" "cm_version" {

--- a/ibm/service/catalogmanagement/resource_ibm_cm_account.go
+++ b/ibm/service/catalogmanagement/resource_ibm_cm_account.go
@@ -349,7 +349,6 @@ func resourceIBMCmAccountRead(context context.Context, d *schema.ResourceData, m
 				return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cm_account", "read", "terraform_engines-to-map").GetDiag()
 			}
 			terraformEngines = append(terraformEngines, terraformEnginesItemMap)
-			fmt.Println("TF ENGINES: ", terraformEngines)
 		}
 		if err = d.Set("terraform_engines", terraformEngines); err != nil {
 			err = fmt.Errorf("Error setting terraform_engines: %s", err)

--- a/ibm/service/catalogmanagement/resource_ibm_cm_account.go
+++ b/ibm/service/catalogmanagement/resource_ibm_cm_account.go
@@ -148,6 +148,123 @@ func ResourceIBMCmAccount() *schema.Resource {
 				Optional:    true,
 				Description: "Region filter string.",
 			},
+			"terraform_engines": &schema.Schema{
+				Type:        schema.TypeList,
+				Computed:    true,
+				Optional:    true,
+				Description: "List of terraform engines configured for this account.",
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"name": &schema.Schema{
+							Type:        schema.TypeString,
+							Optional:    true,
+							Computed:    true,
+							Description: "User provided name for the specified engine.",
+						},
+						"type": &schema.Schema{
+							Type:        schema.TypeString,
+							Optional:    true,
+							Computed:    true,
+							Description: "The terraform engine type. The only one supported at the moment is terraform-enterprise.",
+						},
+						"public_endpoint": &schema.Schema{
+							Type:        schema.TypeString,
+							Optional:    true,
+							Computed:    true,
+							Description: "The public endpoint for the engine instance.",
+						},
+						"private_endpoint": &schema.Schema{
+							Type:        schema.TypeString,
+							Optional:    true,
+							Computed:    true,
+							Description: "The private endpoint for the engine instance.",
+						},
+						"api_token": &schema.Schema{
+							Type:             schema.TypeString,
+							Optional:         true,
+							Computed:         true,
+							Sensitive:        true,
+							Description:      "The api key used to access the engine instance.",
+							DiffSuppressFunc: flex.ApplyOnce,
+						},
+						"da_creation": &schema.Schema{
+							Type:        schema.TypeList,
+							Optional:    true,
+							Computed:    true,
+							MaxItems:    1,
+							Description: "The settings that determines how deployable architectures are auto-created from workspaces in the terraform engine.",
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"enabled": &schema.Schema{
+										Type:        schema.TypeBool,
+										Optional:    true,
+										Computed:    true,
+										Description: "Determines whether deployable architectures are auto-created from workspaces in the engine.",
+									},
+									"default_private_catalog_id": &schema.Schema{
+										Type:        schema.TypeString,
+										Optional:    true,
+										Computed:    true,
+										Description: "Default private catalog to create the deployable architectures in.",
+									},
+									"polling_info": &schema.Schema{
+										Type:        schema.TypeList,
+										Optional:    true,
+										Computed:    true,
+										MaxItems:    1,
+										Description: "Determines which workspace scope to query to auto-create deployable architectures from.",
+										Elem: &schema.Resource{
+											Schema: map[string]*schema.Schema{
+												"scopes": &schema.Schema{
+													Type:        schema.TypeList,
+													Optional:    true,
+													Computed:    true,
+													Description: "List of scopes to auto-create deployable architectures from workspaces in the engine.",
+													Elem: &schema.Resource{
+														Schema: map[string]*schema.Schema{
+															"name": &schema.Schema{
+																Type:        schema.TypeString,
+																Optional:    true,
+																Computed:    true,
+																Description: "Identifier for the specified type in the scope.",
+															},
+															"type": &schema.Schema{
+																Type:        schema.TypeString,
+																Optional:    true,
+																Computed:    true,
+																Description: "Scope to auto-create deployable architectures from. The supported scopes today are workspace, org, and project.",
+															},
+														},
+													},
+												},
+												"last_polling_status": &schema.Schema{
+													Type:        schema.TypeList,
+													Computed:    true,
+													Description: "Last polling status of the engine scope.",
+													Elem: &schema.Resource{
+														Schema: map[string]*schema.Schema{
+															"code": &schema.Schema{
+																Type:        schema.TypeInt,
+																Computed:    true,
+																Description: "Status code of the last polling attempt.",
+															},
+															"message": &schema.Schema{
+																Type:        schema.TypeString,
+																Computed:    true,
+																Description: "Status message from the last polling attempt.",
+															},
+														},
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
 		},
 	}
 }
@@ -224,6 +341,21 @@ func resourceIBMCmAccountRead(context context.Context, d *schema.ResourceData, m
 			return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cm_account", "read", "set-region_filter").GetDiag()
 		}
 	}
+	if !core.IsNil(account.TerraformEngines) {
+		terraformEngines := []map[string]interface{}{}
+		for _, terraformEnginesItem := range account.TerraformEngines {
+			terraformEnginesItemMap, err := ResourceIBMCmAccountTerraformEnginesToMap(&terraformEnginesItem)
+			if err != nil {
+				return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cm_account", "read", "terraform_engines-to-map").GetDiag()
+			}
+			terraformEngines = append(terraformEngines, terraformEnginesItemMap)
+			fmt.Println("TF ENGINES: ", terraformEngines)
+		}
+		if err = d.Set("terraform_engines", terraformEngines); err != nil {
+			err = fmt.Errorf("Error setting terraform_engines: %s", err)
+			return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cm_account", "read", "set-terraform_engines").GetDiag()
+		}
+	}
 
 	return nil
 }
@@ -279,6 +411,20 @@ func resourceIBMCmAccountUpdate(context context.Context, d *schema.ResourceData,
 		}
 	} else if account.AccountFilters != nil {
 		updateCatalogAccountOptions.SetAccountFilters(account.AccountFilters)
+	}
+
+	if d.HasChange("terraform_engines") {
+		if v, ok := d.GetOk("terraform_engines"); ok {
+			terraformEngines, err := resourceIBMCmAccountTerraformEnginesMapToStruct(v.([]interface{}))
+			if err != nil {
+				tfErr := flex.TerraformErrorf(err, err.Error(), "ibm_cm_account", "update")
+				log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+				return tfErr.GetDiag()
+			}
+			updateCatalogAccountOptions.SetTerraformEngines(terraformEngines)
+		}
+	} else if account.TerraformEngines != nil {
+		updateCatalogAccountOptions.SetTerraformEngines(account.TerraformEngines)
 	}
 
 	_, response, err = catalogManagementClient.UpdateCatalogAccountWithContext(context, updateCatalogAccountOptions)
@@ -368,6 +514,96 @@ func ResourceIBMCmAccountIDFilterToMap(model *catalogmanagementv1.IDFilter) (map
 	return modelMap, nil
 }
 
+func ResourceIBMCmAccountTerraformEnginesToMap(model *catalogmanagementv1.TerraformEngines) (map[string]interface{}, error) {
+	modelMap := make(map[string]interface{})
+	if model.Name != nil {
+		modelMap["name"] = *model.Name
+	}
+	if model.Type != nil {
+		modelMap["type"] = *model.Type
+	}
+	if model.PublicEndpoint != nil {
+		modelMap["public_endpoint"] = *model.PublicEndpoint
+	}
+	if model.PrivateEndpoint != nil {
+		modelMap["private_endpoint"] = *model.PrivateEndpoint
+	}
+	if model.APIToken != nil {
+		modelMap["api_token"] = *model.APIToken
+	}
+	if model.DaCreation != nil {
+		daCreationMap, err := ResourceIBMCmAccountDaCreationToMap(model.DaCreation)
+		if err != nil {
+			return modelMap, err
+		}
+		modelMap["da_creation"] = []map[string]interface{}{daCreationMap}
+	}
+	return modelMap, nil
+}
+
+func ResourceIBMCmAccountDaCreationToMap(model *catalogmanagementv1.DaCreation) (map[string]interface{}, error) {
+	modelMap := make(map[string]interface{})
+	if model.Enabled != nil {
+		modelMap["enabled"] = *model.Enabled
+	}
+	if model.DefaultPrivateCatalogID != nil {
+		modelMap["default_private_catalog_id"] = *model.DefaultPrivateCatalogID
+	}
+	if model.PollingInfo != nil {
+		pollingInfoMap, err := ResourceIBMCmAccountPollingInfoToMap(model.PollingInfo)
+		if err != nil {
+			return modelMap, err
+		}
+		modelMap["polling_info"] = []map[string]interface{}{pollingInfoMap}
+	}
+	return modelMap, nil
+}
+
+func ResourceIBMCmAccountPollingInfoToMap(model *catalogmanagementv1.PollingInfo) (map[string]interface{}, error) {
+	modelMap := make(map[string]interface{})
+	if model.Scopes != nil {
+		scopes := []map[string]interface{}{}
+		for _, scopesItem := range model.Scopes {
+			scopesItemMap, err := ResourceIBMCmAccountTerraformEngineScopeToMap(&scopesItem) // #nosec G601
+			if err != nil {
+				return modelMap, err
+			}
+			scopes = append(scopes, scopesItemMap)
+		}
+		modelMap["scopes"] = scopes
+	}
+	if model.LastPollingStatus != nil {
+		lastPollingStatusMap, err := ResourceIBMCmAccountPollingInfoLastPollingStatusToMap(model.LastPollingStatus)
+		if err != nil {
+			return modelMap, err
+		}
+		modelMap["last_polling_status"] = []map[string]interface{}{lastPollingStatusMap}
+	}
+	return modelMap, nil
+}
+
+func ResourceIBMCmAccountTerraformEngineScopeToMap(model *catalogmanagementv1.TerraformEngineScope) (map[string]interface{}, error) {
+	modelMap := make(map[string]interface{})
+	if model.Name != nil {
+		modelMap["name"] = *model.Name
+	}
+	if model.Type != nil {
+		modelMap["type"] = *model.Type
+	}
+	return modelMap, nil
+}
+
+func ResourceIBMCmAccountPollingInfoLastPollingStatusToMap(model *catalogmanagementv1.PollingInfoLastPollingStatus) (map[string]interface{}, error) {
+	modelMap := make(map[string]interface{})
+	if model.Code != nil {
+		modelMap["code"] = flex.IntValue(model.Code)
+	}
+	if model.Message != nil {
+		modelMap["message"] = *model.Message
+	}
+	return modelMap, nil
+}
+
 func resourceIBMCmAccountFiltersMapToFilters(modelMap map[string]interface{}) (*catalogmanagementv1.Filters, error) {
 	model := &catalogmanagementv1.Filters{}
 	if modelMap["include_all"] != nil {
@@ -420,5 +656,90 @@ func resourceIBMCmAccountMapToCategoryFilter(modelMap map[string]interface{}) (*
 		}
 		model.Filter = FilterModel
 	}
+	return model, nil
+}
+
+func resourceIBMCmAccountTerraformEnginesMapToStruct(enginesList []interface{}) ([]catalogmanagementv1.TerraformEngines, error) {
+	var engines []catalogmanagementv1.TerraformEngines
+
+	for _, item := range enginesList {
+		engineMap := item.(map[string]interface{})
+		engine := catalogmanagementv1.TerraformEngines{}
+
+		if engineMap["name"] != nil {
+			engine.Name = core.StringPtr(engineMap["name"].(string))
+		}
+		if engineMap["type"] != nil {
+			engine.Type = core.StringPtr(engineMap["type"].(string))
+		}
+		if engineMap["public_endpoint"] != nil {
+			engine.PublicEndpoint = core.StringPtr(engineMap["public_endpoint"].(string))
+		}
+		if engineMap["private_endpoint"] != nil {
+			engine.PrivateEndpoint = core.StringPtr(engineMap["private_endpoint"].(string))
+		}
+		if engineMap["api_token"] != nil {
+			engine.APIToken = core.StringPtr(engineMap["api_token"].(string))
+		}
+
+		if engineMap["da_creation"] != nil && len(engineMap["da_creation"].([]interface{})) > 0 {
+			daCreationMap := engineMap["da_creation"].([]interface{})[0].(map[string]interface{})
+			daCreation, err := resourceIBMCmTerraformEngineMapToDaCreation(daCreationMap)
+			if err != nil {
+				return nil, err
+			}
+			engine.DaCreation = daCreation
+		}
+
+		engines = append(engines, engine)
+	}
+
+	return engines, nil
+}
+
+func resourceIBMCmTerraformEngineMapToDaCreation(modelMap map[string]interface{}) (*catalogmanagementv1.DaCreation, error) {
+	model := &catalogmanagementv1.DaCreation{}
+
+	if modelMap["enabled"] != nil {
+		model.Enabled = core.BoolPtr(modelMap["enabled"].(bool))
+	}
+	if modelMap["default_private_catalog_id"] != nil {
+		model.DefaultPrivateCatalogID = core.StringPtr(modelMap["default_private_catalog_id"].(string))
+	}
+	if modelMap["polling_info"] != nil && len(modelMap["polling_info"].([]interface{})) > 0 {
+		pollingInfoMap := modelMap["polling_info"].([]interface{})[0].(map[string]interface{})
+		pollingInfo, err := resourceIBMCmTerraformEngineMapToPollingInfo(pollingInfoMap)
+		if err != nil {
+			return model, err
+		}
+		model.PollingInfo = pollingInfo
+	}
+
+	return model, nil
+}
+
+func resourceIBMCmTerraformEngineMapToPollingInfo(modelMap map[string]interface{}) (*catalogmanagementv1.PollingInfo, error) {
+	model := &catalogmanagementv1.PollingInfo{}
+
+	if modelMap["scopes"] != nil {
+		scopeList := modelMap["scopes"].([]interface{})
+		var scopes []catalogmanagementv1.TerraformEngineScope
+
+		for _, s := range scopeList {
+			scopeMap := s.(map[string]interface{})
+			scope := catalogmanagementv1.TerraformEngineScope{}
+
+			if scopeMap["name"] != nil {
+				scope.Name = core.StringPtr(scopeMap["name"].(string))
+			}
+			if scopeMap["type"] != nil {
+				scope.Type = core.StringPtr(scopeMap["type"].(string))
+			}
+
+			scopes = append(scopes, scope)
+		}
+		model.Scopes = scopes
+	}
+
 	return model, nil
 }

--- a/ibm/service/catalogmanagement/resource_ibm_cm_account_test.go
+++ b/ibm/service/catalogmanagement/resource_ibm_cm_account_test.go
@@ -43,7 +43,29 @@ func TestAccIBMCmAccountBasic(t *testing.T) {
 
 func testAccCheckIBMCmAccountConfigBasic() string {
 	return fmt.Sprintf(`
+		resource "ibm_cm_catalog" "cm_catalog" {
+			label = "test_tf_account_catalog_label_1"
+			kind = "offering"
+		}
+
 		resource "ibm_cm_account" "cm_account" {
+			terraform_engines {
+				name             = "my-tfe-instance"
+				type             = "terraform-enterprise"
+				public_endpoint  = "foo"
+				private_endpoint = "foo"
+				api_token        = "foo"
+				da_creation {
+					enabled                    = true
+					default_private_catalog_id = ibm_cm_catalog.cm_catalog.id
+					polling_info {
+						scopes {
+							name = "foo-project"
+							type = "project"
+						}
+					}
+				}
+			}
 		}
 	`)
 }

--- a/ibm/service/catalogmanagement/resource_ibm_cm_version_test.go
+++ b/ibm/service/catalogmanagement/resource_ibm_cm_version_test.go
@@ -211,6 +211,19 @@ func testAccCheckIBMCmVersionComplexConfig(zipurl string, targetVersion string, 
 				label = "Standard"
 				index = 1
 			}
+			configuration {
+				default_value = "foo"
+				description = "The name to pass to the template."
+				key = "name"
+				type = "string"
+				hidden = false
+				required = false
+				value_constraints {
+					type  = "regex"
+					value = "*"
+					description = "Invalid name input"
+				}
+			}
 			install {
 				instructions = "%s"
 			}

--- a/ibm/service/iamidentity/data_source_ibm_iam_account_settings_template_assignment.go
+++ b/ibm/service/iamidentity/data_source_ibm_iam_account_settings_template_assignment.go
@@ -458,9 +458,9 @@ func dataSourceIBMAccountSettingsTemplateAssignmentTemplateAssignmentResponseRes
 		}
 		modelMap["account_settings"] = []map[string]interface{}{accountSettingsMap}
 	}
-	if model.PolicyTemplateRefs != nil {
+	if model.PolicyTemplateReferences != nil {
 		var policyTemplateRefs []map[string]interface{}
-		for _, policyTemplateRefsItem := range model.PolicyTemplateRefs {
+		for _, policyTemplateRefsItem := range model.PolicyTemplateReferences {
 			policyTemplateRefsItemMap, err := dataSourceIBMAccountSettingsTemplateAssignmentTemplateAssignmentResponseResourceDetailToMap(&policyTemplateRefsItem)
 			if err != nil {
 				return modelMap, err

--- a/ibm/service/iamidentity/data_source_ibm_iam_trusted_profile_template_assignment.go
+++ b/ibm/service/iamidentity/data_source_ibm_iam_trusted_profile_template_assignment.go
@@ -525,9 +525,9 @@ func dataSourceIBMTrustedProfileTemplateAssignmentTemplateAssignmentResponseReso
 		}
 		modelMap["account_settings"] = []map[string]interface{}{accountSettingsMap}
 	}
-	if model.PolicyTemplateRefs != nil {
+	if model.PolicyTemplateReferences != nil {
 		var policyTemplateRefs []map[string]interface{}
-		for _, policyTemplateRefsItem := range model.PolicyTemplateRefs {
+		for _, policyTemplateRefsItem := range model.PolicyTemplateReferences {
 			policyTemplateRefsItemMap, err := dataSourceIBMTrustedProfileTemplateAssignmentTemplateAssignmentResponseResourceDetailToMap(&policyTemplateRefsItem)
 			if err != nil {
 				return modelMap, err

--- a/ibm/service/iamidentity/resource_ibm_iam_account_settings_template_assignment.go
+++ b/ibm/service/iamidentity/resource_ibm_iam_account_settings_template_assignment.go
@@ -530,9 +530,9 @@ func resourceIBMAccountSettingsTemplateAssignmentTemplateAssignmentResponseResou
 		}
 		modelMap["account_settings"] = []map[string]interface{}{accountSettingsMap}
 	}
-	if model.PolicyTemplateRefs != nil {
+	if model.PolicyTemplateReferences != nil {
 		var policyTemplateRefs []map[string]interface{}
-		for _, policyTemplateRefsItem := range model.PolicyTemplateRefs {
+		for _, policyTemplateRefsItem := range model.PolicyTemplateReferences {
 			policyTemplateRefsItemMap, err := resourceIBMAccountSettingsTemplateAssignmentTemplateAssignmentResponseResourceDetailToMap(&policyTemplateRefsItem)
 			if err != nil {
 				return modelMap, err

--- a/ibm/service/iamidentity/resource_ibm_iam_trusted_profile_template_assignment.go
+++ b/ibm/service/iamidentity/resource_ibm_iam_trusted_profile_template_assignment.go
@@ -672,9 +672,9 @@ func resourceIBMTrustedProfileTemplateAssignmentTemplateAssignmentResponseResour
 		}
 		modelMap["profile"] = []map[string]interface{}{profileMap}
 	}
-	if model.PolicyTemplateRefs != nil {
+	if model.PolicyTemplateReferences != nil {
 		policyTemplateRefs := []map[string]interface{}{}
-		for _, policyTemplateRefsItem := range model.PolicyTemplateRefs {
+		for _, policyTemplateRefsItem := range model.PolicyTemplateReferences {
 			policyTemplateRefsItemMap, err := resourceIBMTrustedProfileTemplateAssignmentTemplateAssignmentResponseResourceDetailToMap(&policyTemplateRefsItem)
 			if err != nil {
 				return modelMap, err

--- a/website/docs/d/cm_account.html.markdown
+++ b/website/docs/d/cm_account.html.markdown
@@ -44,4 +44,25 @@ Nested schema for **account_filters**:
 * `hide_ibm_cloud_catalog` - (Boolean) Hide the public catalog in this account.
 * `region_filter` - (String) Region filter string.
 * `rev` - (String) Cloudant revision.
+* `terraform_engines` - (List) List of terraform engines configured for this account.
+Nested schema for **terraform_engines**:
+	* `api_token` - (String) The api key used to access the engine instance.
+	* `da_creation` - (List) The settings that determines how deployable architectures are auto-created from workspaces in the terraform engine.
+	Nested schema for **da_creation**:
+		* `default_private_catalog_id` - (String) Default private catalog to create the deployable architectures in.
+		* `enabled` - (Boolean) Determines whether deployable architectures are auto-created from workspaces in the engine.
+		* `polling_info` - (List) Determines which workspace scope to query to auto-create deployable architectures from.
+		Nested schema for **polling_info**:
+			* `last_polling_status` - (List) Last polling status of the engine scope.
+			Nested schema for **last_polling_status**:
+				* `code` - (Integer) Status code of the last polling attempt.
+				* `message` - (String) Status message from the last polling attempt.
+			* `scopes` - (List) List of scopes to auto-create deployable architectures from workspaces in the engine.
+			Nested schema for **scopes**:
+				* `name` - (String) Identifier for the specified type in the scope.
+				* `type` - (String) Scope to auto-create deployable architectures from. The supported scopes today are workspace, org, and project.
+	* `name` - (String) User provided name for the specified engine.
+	* `private_endpoint` - (String) The private endpoint for the engine instance.
+	* `public_endpoint` - (String) The public endpoint for the engine instance.
+	* `type` - (String) The terraform engine type. The only one supported at the moment is terraform-enterprise.
 

--- a/website/docs/d/cm_version.html.markdown
+++ b/website/docs/d/cm_version.html.markdown
@@ -56,6 +56,11 @@ Nested scheme for **configuration**:
 	* `type` - (String) Value type (string, boolean, int).
 	* `type_metadata` - (String) The original type, as found in the source being onboarded.
 	* `value_constraint` - (String) Constraint associated with value, e.g., for string type - regx:[a-z].
+	* `value_constraints` - (List) Validation rules for this input value.
+	Nested scheme for **value_constraints**:
+		* `description` - (String) The value to display if the inptu value does not match the specified constraint.
+		* `type` - (String) Type of constraint.
+		* `value` - (String) Contstraint value. For type regex, this is a regular expression in Javascript notation.
 
 * `created` - (String) The date and time this version was created.
 

--- a/website/docs/r/cm_account.html.markdown
+++ b/website/docs/r/cm_account.html.markdown
@@ -47,6 +47,24 @@ resource "ibm_cm_account" "cm_account_instance" {
     }
     include_all = true
   }
+
+  terraform_engines {
+    name = "my-tfe-instance"
+    type = "terraform-enterprise"
+    public_endpoint = "<public_endpoint>"
+    private_endpoint = "<private_endpoint>"
+    api_token = "<api_token>"
+    da_creation {
+      enabled = true
+      default_private_catalog_id = "<catalog_id>"
+      polling_info {
+        scopes {
+          name = "<project_name>"
+          type = "project"
+        }
+      }
+    }
+  }
 }
 ```
 
@@ -77,6 +95,27 @@ Nested schema for **account_filters**:
 * `hide_ibm_cloud_catalog` - (Boolean, Optional) Hide the public catalog in this account.
 * `region_filter` - (String, Optional) Region filter string.
 * `rev` - (String) Cloudant revision.
+* `terraform_engines` - (List) List of terraform engines configured for this account.
+Nested schema for **terraform_engines**:
+	* `api_token` - (String) The api key used to access the engine instance.
+	* `da_creation` - (List) The settings that determines how deployable architectures are auto-created from workspaces in the terraform engine.
+	Nested schema for **da_creation**:
+		* `default_private_catalog_id` - (String) Default private catalog to create the deployable architectures in.
+		* `enabled` - (Boolean) Determines whether deployable architectures are auto-created from workspaces in the engine.
+		* `polling_info` - (List) Determines which workspace scope to query to auto-create deployable architectures from.
+		Nested schema for **polling_info**:
+			* `last_polling_status` - (List) Last polling status of the engine scope.
+			Nested schema for **last_polling_status**:
+				* `code` - (Integer) Status code of the last polling attempt.
+				* `message` - (String) Status message from the last polling attempt.
+			* `scopes` - (List) List of scopes to auto-create deployable architectures from workspaces in the engine.
+			Nested schema for **scopes**:
+				* `name` - (String) Identifier for the specified type in the scope.
+				* `type` - (String) Scope to auto-create deployable architectures from. The supported scopes today are workspace, org, and project.
+	* `name` - (String) User provided name for the specified engine.
+	* `private_endpoint` - (String) The private endpoint for the engine instance.
+	* `public_endpoint` - (String) The public endpoint for the engine instance.
+	* `type` - (String) The terraform engine type. The only one supported at the moment is terraform-enterprise.
 
 
 ## Import

--- a/website/docs/r/cm_version.html.markdown
+++ b/website/docs/r/cm_version.html.markdown
@@ -62,6 +62,19 @@ resource "ibm_cm_version" "cm_version" {
 		label = "label"
 		index = 1
   }
+  configuration {
+    default_value = "foo"
+    description = "The name to pass to the template."
+    key = "name"
+    type = "string"
+    hidden = false
+    required = false
+    value_constraints {
+      type = "regex"
+      value = "*"
+      description = "Invalid name input updated"
+    }
+  }
 }
 ```
 
@@ -94,7 +107,12 @@ Nested scheme for **configuration**:
 	* `required` - (Optional, Boolean) Is key required to install.
 	* `type` - (Optional, String) Value type (string, boolean, int).
 	* `type_metadata` - (Optional, String) The original type, as found in the source being onboarded.
-	* `value_constraint` - (Optional, String) Constraint associated with value, e.g., for string type - regx:[a-z].
+	* `value_constraint` - (Optional, String) This field is deprecated. Use value_constraints instead.
+	* `value_constraints` - (Optional, List) Validation rules for this input value.
+	Nested scheme for **value_constraints**:
+		* `description` - (Optional, String) The value to display if the inptu value does not match the specified constraint.
+		* `type` - (Optional, String) Type of constraint.
+		* `value` - (Optional, String) Contstraint value. For type regex, this is a regular expression in Javascript notation.
 * `deprecate` - (Optional, Boolean) Specify if this version should be deprecated.
 * `flavor` - (Optional, Forces new resource, List) Version Flavor Information.  Only supported for Product kind Solution.
 Nested scheme for **flavor**:
@@ -240,6 +258,11 @@ Nested scheme for **configuration**:
 	* `type` - (String) Value type (string, boolean, int).
 	* `type_metadata` - (String) The original type, as found in the source being onboarded.
 	* `value_constraint` - (String) Constraint associated with value, e.g., for string type - regx:[a-z].
+	* `value_constraints` - (List) Validation rules for this input value.
+	Nested scheme for **value_constraints**:
+		* `description` - (String) The value to display if the inptu value does not match the specified constraint.
+		* `type` - (String) Type of constraint.
+		* `value` - (String) Contstraint value. For type regex, this is a regular expression in Javascript notation.
 * `created` - (String) The date and time this version was created.
 * `crn` - (String) Version's CRN.
 * `deprecate_pending` - (List) Deprecation information for an Offering.


### PR DESCRIPTION
- Bumps `platform-services-go-sdk`, adds new fields from SDK update to catalog management account and version resources.

@hkantare @Daniel-Byrne: I was getting errors from `ibm_iam_trusted_profile_template_assignment` and `ibm_iam_account_settings_template_assignment` when bumping the go SDK to the latest version. It looks like there was a change in a previous SDK release that changed `PolicyTemplateRefs` to `PolicyTemplateReferences`.

@Daniel-Byrne Would you mind taking a look at the changes I made here to confirm if they are correct?

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->


Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
TF_ACC=1 go test $(go list ./... |grep -v 'vendor') -v -run TestAccIBMCmVersionBasic -timeout 700m 
=== RUN   TestAccIBMCmVersionBasic
--- PASS: TestAccIBMCmVersionBasic (24.13s)

TF_ACC=1 go test $(go list ./... |grep -v 'vendor') -v -run TestAccIBMCmVersionSimpleArgs -timeout 700m 
=== RUN   TestAccIBMCmVersionSimpleArgs
--- PASS: TestAccIBMCmVersionSimpleArgs (18.94s)

TF_ACC=1 go test $(go list ./... |grep -v 'vendor') -v -run TestAccIBMCmVersionDataSourceSimpleArgs -timeout 700m 
=== RUN   TestAccIBMCmVersionDataSourceSimpleArgs
--- PASS: TestAccIBMCmVersionDataSourceSimpleArgs (21.13s)

TF_ACC=1 go test $(go list ./... |grep -v 'vendor') -v -run TestAccIBMCmAccountBasic -timeout 700m 
=== RUN   TestAccIBMCmAccountBasic
--- PASS: TestAccIBMCmAccountBasic (17.41s)

TF_ACC=1 go test $(go list ./... |grep -v 'vendor') -v -run TestAccIBMCmAccountDataSourceBasic -timeout 700m 
=== RUN   TestAccIBMCmAccountDataSourceBasic
--- PASS: TestAccIBMCmAccountDataSourceBasic (14.32s)
```
