### PR TITLE
Refactor terraform errors to use new toolchain in dhcp, disaster recovery location, and host group data sources

### DIFF
--- a/ibm/service/power/data_source_ibm_pi_available_hosts.go
+++ b/ibm/service/power/data_source_ibm_pi_available_hosts.go
@@ -60,7 +60,7 @@ func DataSourceIBMPIAvailableHosts() *schema.Resource {
 	}
 }
 
-func dataSourceIBMPIAvailableHostsRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func dataSourceIBMPIAvailableHostsRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	sess, err := meta.(conns.ClientSession).IBMPISession()
 	if err != nil {
 		return diag.FromErr(err)
@@ -71,10 +71,10 @@ func dataSourceIBMPIAvailableHostsRead(ctx context.Context, d *schema.ResourceDa
 	if err != nil {
 		return diag.FromErr(err)
 	}
-	availableHosts := []map[string]interface{}{}
+	availableHosts := []map[string]any{}
 	for _, value := range hostlist {
 		if value.Capacity != nil {
-			availableHosts = append(availableHosts, map[string]interface{}{
+			availableHosts = append(availableHosts, map[string]any{
 				Attr_Count:           int(value.Count),
 				Attr_SysType:         value.SysType,
 				Attr_AvailableCores:  value.Capacity.Cores.Total,

--- a/ibm/service/power/data_source_ibm_pi_catalog_images.go
+++ b/ibm/service/power/data_source_ibm_pi_catalog_images.go
@@ -136,7 +136,7 @@ func DataSourceIBMPICatalogImages() *schema.Resource {
 	}
 }
 
-func dataSourceIBMPICatalogImagesRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func dataSourceIBMPICatalogImagesRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	sess, err := meta.(conns.ClientSession).IBMPISession()
 	if err != nil {
 		return diag.FromErr(err)
@@ -151,9 +151,9 @@ func dataSourceIBMPICatalogImagesRead(ctx context.Context, d *schema.ResourceDat
 		return diag.FromErr(err)
 	}
 
-	images := make([]map[string]interface{}, 0)
+	images := make([]map[string]any, 0)
 	for _, i := range stockImages.Images {
-		image := make(map[string]interface{})
+		image := make(map[string]any)
 		image[Attr_ImageID] = *i.ImageID
 		image[Attr_Name] = *i.Name
 

--- a/ibm/service/power/data_source_ibm_pi_dhcp.go
+++ b/ibm/service/power/data_source_ibm_pi_dhcp.go
@@ -81,7 +81,7 @@ func DataSourceIBMPIDhcp() *schema.Resource {
 func dataSourceIBMPIDhcpRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	sess, err := meta.(conns.ClientSession).IBMPISession()
 	if err != nil {
-		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("IBMPISession failed: %s", err.Error()), "ibm_pi_dhcp", "read")
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("IBMPISession failed: %s", err.Error()), "(Data) ibm_pi_dhcp", "read")
 		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
 		return tfErr.GetDiag()
 	}
@@ -91,7 +91,7 @@ func dataSourceIBMPIDhcpRead(ctx context.Context, d *schema.ResourceData, meta a
 	client := instance.NewIBMPIDhcpClient(ctx, sess, cloudInstanceID)
 	dhcpServer, err := client.Get(dhcpID)
 	if err != nil {
-		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("Get failed: %s", err.Error()), "ibm_pi_dhcp", "read")
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("Get failed: %s", err.Error()), "(Data) ibm_pi_dhcp", "read")
 		log.Printf("[DEBUG] get DHCP failed \n%s", tfErr.GetDebugMessage())
 		return tfErr.GetDiag()
 	}

--- a/ibm/service/power/data_source_ibm_pi_dhcp.go
+++ b/ibm/service/power/data_source_ibm_pi_dhcp.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/IBM-Cloud/power-go-client/clients/instance"
 	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/conns"
+	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/flex"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
@@ -77,10 +78,12 @@ func DataSourceIBMPIDhcp() *schema.Resource {
 	}
 }
 
-func dataSourceIBMPIDhcpRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func dataSourceIBMPIDhcpRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	sess, err := meta.(conns.ClientSession).IBMPISession()
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("IBMPISession failed: %s", err.Error()), "ibm_pi_dhcp", "read")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	cloudInstanceID := d.Get(Arg_CloudInstanceID).(string)
@@ -88,8 +91,9 @@ func dataSourceIBMPIDhcpRead(ctx context.Context, d *schema.ResourceData, meta i
 	client := instance.NewIBMPIDhcpClient(ctx, sess, cloudInstanceID)
 	dhcpServer, err := client.Get(dhcpID)
 	if err != nil {
-		log.Printf("[DEBUG] get DHCP failed %v", err)
-		return diag.FromErr(err)
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("Get failed: %s", err.Error()), "ibm_pi_dhcp", "read")
+		log.Printf("[DEBUG] get DHCP failed \n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	d.SetId(fmt.Sprintf("%s/%s", cloudInstanceID, *dhcpServer.ID))

--- a/ibm/service/power/data_source_ibm_pi_dhcps.go
+++ b/ibm/service/power/data_source_ibm_pi_dhcps.go
@@ -67,7 +67,7 @@ func DataSourceIBMPIDhcps() *schema.Resource {
 func dataSourceIBMPIDhcpServersRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	sess, err := meta.(conns.ClientSession).IBMPISession()
 	if err != nil {
-		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("IBMPISession failed: %s", err.Error()), "(Data) ibm_pi_dhcps", "create")
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("IBMPISession failed: %s", err.Error()), "(Data) ibm_pi_dhcps", "read")
 		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
 		return tfErr.GetDiag()
 	}
@@ -76,7 +76,7 @@ func dataSourceIBMPIDhcpServersRead(ctx context.Context, d *schema.ResourceData,
 	client := instance.NewIBMPIDhcpClient(ctx, sess, cloudInstanceID)
 	dhcpServers, err := client.GetAll()
 	if err != nil {
-		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("GetAll failed: %s", err.Error()), "(Data) ibm_pi_dhcps", "")
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("GetAll failed: %s", err.Error()), "(Data) ibm_pi_dhcps", "read")
 		log.Printf("[DEBUG] get all DHCP failed \n%s", tfErr.GetDebugMessage())
 		return tfErr.GetDiag()
 	}

--- a/ibm/service/power/data_source_ibm_pi_dhcps.go
+++ b/ibm/service/power/data_source_ibm_pi_dhcps.go
@@ -5,10 +5,12 @@ package power
 
 import (
 	"context"
+	"fmt"
 	"log"
 
 	"github.com/IBM-Cloud/power-go-client/clients/instance"
 	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/conns"
+	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/flex"
 	"github.com/hashicorp/go-uuid"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -62,23 +64,26 @@ func DataSourceIBMPIDhcps() *schema.Resource {
 	}
 }
 
-func dataSourceIBMPIDhcpServersRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func dataSourceIBMPIDhcpServersRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	sess, err := meta.(conns.ClientSession).IBMPISession()
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("IBMPISession failed: %s", err.Error()), "(Data) ibm_pi_dhcps", "create")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	cloudInstanceID := d.Get(Arg_CloudInstanceID).(string)
 	client := instance.NewIBMPIDhcpClient(ctx, sess, cloudInstanceID)
 	dhcpServers, err := client.GetAll()
 	if err != nil {
-		log.Printf("[DEBUG] get all DHCP failed %v", err)
-		return diag.FromErr(err)
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("GetAll failed: %s", err.Error()), "(Data) ibm_pi_dhcps", "")
+		log.Printf("[DEBUG] get all DHCP failed \n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
-	servers := make([]map[string]interface{}, 0, len(dhcpServers))
+	servers := make([]map[string]any, 0, len(dhcpServers))
 	for _, dhcpServer := range dhcpServers {
-		server := map[string]interface{}{
+		server := map[string]any{
 			Attr_DhcpID: *dhcpServer.ID,
 			Attr_Status: *dhcpServer.Status,
 		}


### PR DESCRIPTION
This PR does it for the dhcp, disaster recovery location, and host group data sources.

Output of acceptance testing:
```
--- PASS: TestAccIBMPIDhcpServersDataSourceBasic (28.35s)
PASS

--- PASS: TestAccIBMPIDisasterRecoveryLocationsDataSourceBasic (7.98s)
PASS

--- PASS: TestAccIBMPIDisasterRecoveryLocationDataSourceBasic (7.79s)
PASS

--- PASS: TestAccIBMPIHostGroupsDataSourceBasic (12.66s)
PASS
```