### PR TITLE
Refactor terraform errors to use new toolchain in host, image location, and instance console language data sources

### DIFF
--- a/ibm/service/power/data_source_ibm_pi_hosts.go
+++ b/ibm/service/power/data_source_ibm_pi_hosts.go
@@ -5,16 +5,16 @@ package power
 
 import (
 	"context"
+	"fmt"
 	"log"
-
-	"github.com/hashicorp/go-uuid"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 
 	"github.com/IBM-Cloud/power-go-client/clients/instance"
 	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/conns"
 	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/flex"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 )
 
 func DataSourceIBMPIHosts() *schema.Resource {
@@ -29,7 +29,8 @@ func DataSourceIBMPIHosts() *schema.Resource {
 				Type:         schema.TypeString,
 				ValidateFunc: validation.NoZeroValues,
 			},
-			//Attribute
+
+			// Attributes
 			Attr_Hosts: {
 				Computed:    true,
 				Description: "List of hosts",
@@ -138,25 +139,29 @@ func DataSourceIBMPIHosts() *schema.Resource {
 	}
 }
 
-func dataSourceIBMPIHostsRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func dataSourceIBMPIHostsRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	sess, err := meta.(conns.ClientSession).IBMPISession()
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("IBMPISession failed: %s", err.Error()), "(Data) ibm_pi_hosts", "read")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
+
 	cloudInstanceID := d.Get(Arg_CloudInstanceID).(string)
 	client := instance.NewIBMPIHostGroupsClient(ctx, sess, cloudInstanceID)
-
 	hosts, err := client.GetHosts()
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("GetHosts failed: %s", err.Error()), "(Data) ibm_pi_hosts", "read")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
+
 	var clientgenU, _ = uuid.GenerateUUID()
 	d.SetId(clientgenU)
-	hostList := make([]map[string]interface{}, 0, len(hosts))
+	hostList := make([]map[string]any, 0, len(hosts))
 	for _, host := range hosts {
 		if host != nil {
-
-			hs := map[string]interface{}{}
+			hs := map[string]any{}
 			if host.Capacity != nil {
 				hs[Attr_Capacity] = hostCapacityToMap(host.Capacity)
 			}

--- a/ibm/service/power/data_source_ibm_pi_image.go
+++ b/ibm/service/power/data_source_ibm_pi_image.go
@@ -5,6 +5,7 @@ package power
 
 import (
 	"context"
+	"fmt"
 	"log"
 
 	"github.com/IBM-Cloud/power-go-client/clients/instance"
@@ -95,10 +96,12 @@ func DataSourceIBMPIImage() *schema.Resource {
 	}
 }
 
-func dataSourceIBMPIImagesRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func dataSourceIBMPIImagesRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	sess, err := meta.(conns.ClientSession).IBMPISession()
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("IBMPISession failed: %s", err.Error()), "(Data) ibm_pi_image", "read")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	cloudInstanceID := d.Get(Arg_CloudInstanceID).(string)
@@ -106,7 +109,9 @@ func dataSourceIBMPIImagesRead(ctx context.Context, d *schema.ResourceData, meta
 	imageC := instance.NewIBMPIImageClient(ctx, sess, cloudInstanceID)
 	imagedata, err := imageC.Get(d.Get(Arg_ImageName).(string))
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("Get failed: %s", err.Error()), "(Data) ibm_pi_image", "read")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	d.SetId(*imagedata.ImageID)

--- a/ibm/service/power/data_source_ibm_pi_instance_console_languages.go
+++ b/ibm/service/power/data_source_ibm_pi_instance_console_languages.go
@@ -5,9 +5,12 @@ package power
 
 import (
 	"context"
+	"fmt"
+	"log"
 
 	"github.com/IBM-Cloud/power-go-client/clients/instance"
 	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/conns"
+	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/flex"
 	"github.com/hashicorp/go-uuid"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -57,10 +60,12 @@ func DataSourceIBMPIInstanceConsoleLanguages() *schema.Resource {
 	}
 }
 
-func dataSourceIBMPIInstanceConsoleLanguagesRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func dataSourceIBMPIInstanceConsoleLanguagesRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	sess, err := meta.(conns.ClientSession).IBMPISession()
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("IBMPISession failed: %s", err.Error()), "(Data) ibm_pi_instance_console_languages", "read")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	cloudInstanceID := d.Get(Arg_CloudInstanceID).(string)
@@ -69,16 +74,18 @@ func dataSourceIBMPIInstanceConsoleLanguagesRead(ctx context.Context, d *schema.
 	client := instance.NewIBMPIInstanceClient(ctx, sess, cloudInstanceID)
 	languages, err := client.GetConsoleLanguages(instanceName)
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("GetConsoleLanguages failed: %s", err.Error()), "(Data) ibm_pi_instance_console_languages", "read")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	var clientgenU, _ = uuid.GenerateUUID()
 	d.SetId(clientgenU)
 
 	if len(languages.ConsoleLanguages) > 0 {
-		result := make([]map[string]interface{}, 0, len(languages.ConsoleLanguages))
+		result := make([]map[string]any, 0, len(languages.ConsoleLanguages))
 		for _, language := range languages.ConsoleLanguages {
-			l := map[string]interface{}{
+			l := map[string]any{
 				Attr_Code:     *language.Code,
 				Attr_Language: language.Language,
 			}


### PR DESCRIPTION
This PR does it for the host, image location, and instance console language data sources.

Output of acceptance testing:
```
--- PASS: TestAccIBMPIHostsDataSourceBasic (14.79s)
PASS

--- PASS: TestAccIBMPIImagesDataSource_basic (203.41s)
PASS

--- PASS: TestAccIBMPIImageDataSource_basic (34.00s)
PASS

--- PASS: TestAccIBMPIInstanceConsoleLanguages (15.14s)
PASS
```