### PR TITLE
[R]Remove default value for image import type

### DIFF
--- a/ibm/service/power/resource_ibm_pi_image.go
+++ b/ibm/service/power/resource_ibm_pi_image.go
@@ -100,7 +100,6 @@ func ResourceIBMPIImage() *schema.Resource {
 			},
 			Arg_ImageBucketAccess: {
 				ConflictsWith: []string{Arg_ImageID},
-				Default:       Public,
 				Description:   "Indicates if the bucket has public or private access",
 				ForceNew:      true,
 				Optional:      true,

--- a/website/docs/r/pi_image.html.markdown
+++ b/website/docs/r/pi_image.html.markdown
@@ -75,7 +75,7 @@ Review the argument references that you can specify for your resource.
   - Either `pi_image_bucket_name` or `pi_image_id` is required.
 - `pi_image_access_key` - (Optional, String, Sensitive) Cloud Object Storage access key; required for buckets with private access.
   - `pi_image_access_key` is required with `pi_image_secret_key`
-- `pi_image_bucket_access` - (Optional, String) Indicates if the bucket has public or private access. The default value is `public`.
+- `pi_image_bucket_access` - (Optional, String) Indicates if the bucket has public or private access.
 - `pi_image_bucket_file_name` - (Optional, String) Cloud Object Storage image filename
   - `pi_image_bucket_file_name` is required with `pi_image_bucket_name`
 - `pi_image_bucket_region` - (Optional, String) Cloud Object Storage region. Supported COS regions are: `au-syd`, `br-sao`, `ca-tor`, `che01`, `eu-de`, `eu-es`, `eu-gb`, `jp-osa`, `jp-tok`, `us-east`, `us-south`.


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/IBM-Cloud/terraform-provider-ibm/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000
When running terraform plan, pi_image_bucket_access is set to a default value which conflicts pi_image_id

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
=== RUN TestAccIBMPIImagebasic
--- PASS: TestAccIBMPIImagebasic (66.90s)
PASS

...
```
