### PR TITLE
fix(vsi): handled absent device on vsis

### DIFF
--- a/ibm/service/vpc/data_source_ibm_is_instance_volume_attachment.go
+++ b/ibm/service/vpc/data_source_ibm_is_instance_volume_attachment.go
@@ -165,8 +165,10 @@ func instanceVolumeAttachmentGetByName(context context.Context, d *schema.Resour
 			if err = d.Set("delete_volume_on_instance_delete", volumeAttachment.DeleteVolumeOnInstanceDelete); err != nil {
 				return flex.DiscriminatedTerraformErrorf(err, fmt.Sprintf("Error setting delete_volume_on_instance_delete: %s", err), "(Data) ibm_is_instance_volume_attachment", "read", "set-delete_volume_on_instance_delete").GetDiag()
 			}
-			if err = d.Set("device", *volumeAttachment.Device.ID); err != nil {
-				return flex.DiscriminatedTerraformErrorf(err, fmt.Sprintf("Error setting device: %s", err), "(Data) ibm_is_instance_volume_attachment", "read", "set-device").GetDiag()
+			if volumeAttachment.Device != nil {
+				if err = d.Set("device", *volumeAttachment.Device.ID); err != nil {
+					return flex.DiscriminatedTerraformErrorf(err, fmt.Sprintf("Error setting device: %s", err), "(Data) ibm_is_instance_volume_attachment", "read", "set-device").GetDiag()
+				}
 			}
 			if err = d.Set("href", volumeAttachment.Href); err != nil {
 				return flex.DiscriminatedTerraformErrorf(err, fmt.Sprintf("Error setting href: %s", err), "(Data) ibm_is_instance_volume_attachment", "read", "set-href").GetDiag()

--- a/ibm/service/vpc/data_source_ibm_is_instance_volume_attachment_test.go
+++ b/ibm/service/vpc/data_source_ibm_is_instance_volume_attachment_test.go
@@ -23,7 +23,7 @@ func TestAccIBMISInstanceVolumeAttDataSource_basic(t *testing.T) {
 ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCKVmnMOlHKcZK8tpt3MP1lqOLAcqcJzhsvJcjscgVERRN7/9484SOBJ3HSKxxNG5JN8owAjy5f9yYwcUg+JaUVuytn5Pv3aeYROHGGg+5G346xaq3DAwX6Y5ykr2fvjObgncQBnuU5KHWCECO/4h8uWuwh/kfniXPVjFToc+gnkqA+3RKpAecZhFXwfalQ9mMuYGFxn+fwn8cYEApsJbsEmb0iJwPiZ5hjFC8wREuiTlhPHDgkBLOiycd20op2nXzDbHfCHInquEe/gYxEitALONxm0swBOwJZwlTDOB7C6y2dzlrtxr1L59m7pCkWI4EtTRLvleehBoj3u7jB4usR
 `)
 	sshname := fmt.Sprintf("tf-ssh-%d", acctest.RandIntRange(10, 100))
-	resName := fmt.Sprintf("data.ibm_is_instance_volume_attachment.ds_vol_att")
+	resName := "data.ibm_is_instance_volume_attachment.ds_vol_att"
 	resource.Test(t, resource.TestCase{
 		PreCheck:  func() { acc.TestAccPreCheck(t) },
 		Providers: acc.TestAccProviders,
@@ -82,4 +82,104 @@ func testAccCheckIBMISInstanceVolumeAttachmentDataSourceConfig(vpcname, subnetna
 	  }
 	 
 	  `, vpcname, subnetname, acc.ISZoneName, sshname, publicKey, name, acc.IsImage, acc.InstanceProfileName, acc.ISZoneName)
+}
+
+func TestAccIBMISInstanceVolumeAttDataSource_nodevice(t *testing.T) {
+	vpcname := fmt.Sprintf("tf-vpc-%d", acctest.RandIntRange(10, 100))
+	name := fmt.Sprintf("tf-instance-%d", acctest.RandIntRange(10, 100))
+	subnetname := fmt.Sprintf("tf-subnet-%d", acctest.RandIntRange(10, 100))
+
+	publicKey := strings.TrimSpace(`
+ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCKVmnMOlHKcZK8tpt3MP1lqOLAcqcJzhsvJcjscgVERRN7/9484SOBJ3HSKxxNG5JN8owAjy5f9yYwcUg+JaUVuytn5Pv3aeYROHGGg+5G346xaq3DAwX6Y5ykr2fvjObgncQBnuU5KHWCECO/4h8uWuwh/kfniXPVjFToc+gnkqA+3RKpAecZhFXwfalQ9mMuYGFxn+fwn8cYEApsJbsEmb0iJwPiZ5hjFC8wREuiTlhPHDgkBLOiycd20op2nXzDbHfCHInquEe/gYxEitALONxm0swBOwJZwlTDOB7C6y2dzlrtxr1L59m7pCkWI4EtTRLvleehBoj3u7jB4usR
+`)
+	sshname := fmt.Sprintf("tf-ssh-%d", acctest.RandIntRange(10, 100))
+	action1 := "stop"
+	action2 := "start"
+	resName := "data.ibm_is_instance_volume_attachment.ds_vol_att"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { acc.TestAccPreCheck(t) },
+		Providers: acc.TestAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckIBMISInstanceVolumeAttachmentDataSourceNodeviceConfig(
+					vpcname, subnetname, sshname, publicKey, name, action1,
+				),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet(resName, "name"),
+					resource.TestCheckResourceAttrSet(resName, "href"),
+					resource.TestCheckResourceAttrSet(resName, "id"),
+					resource.TestCheckResourceAttrSet(resName, "bandwidth"),
+					resource.TestCheckResourceAttr(resName, "type", "data"),
+				),
+			},
+			{
+				Config: testAccCheckIBMISInstanceVolumeAttachmentDataSourceNodeviceConfig(
+					vpcname, subnetname, sshname, publicKey, name, action2,
+				),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet(resName, "name"),
+					resource.TestCheckResourceAttrSet(resName, "href"),
+					resource.TestCheckResourceAttrSet(resName, "id"),
+					resource.TestCheckResourceAttrSet(resName, "bandwidth"),
+					resource.TestCheckResourceAttrSet(resName, "device"),
+					resource.TestCheckResourceAttr(resName, "type", "data"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckIBMISInstanceVolumeAttachmentDataSourceNodeviceConfig(vpcname, subnetname, sshname, publicKey, name, action string) string {
+	return fmt.Sprintf(`
+resource "ibm_is_vpc" "testacc_vpc" {
+  name = "%s"
+}
+
+resource "ibm_is_subnet" "testacc_subnet" {
+  name                     = "%s"
+  vpc                      = ibm_is_vpc.testacc_vpc.id
+  zone                     = "%s"
+  total_ipv4_address_count = 16
+}
+
+resource "ibm_is_ssh_key" "testacc_sshkey" {
+  name       = "%s"
+  public_key = "%s"
+}
+
+resource "ibm_is_instance" "testacc_instance" {
+  name    = "%s"
+  image   = "%s"
+  profile = "%s"
+
+  primary_network_interface {
+    subnet = ibm_is_subnet.testacc_subnet.id
+  }
+
+  vpc  = ibm_is_vpc.testacc_vpc.id
+  zone = "%s"
+  keys = [ibm_is_ssh_key.testacc_sshkey.id]
+
+  // Add second (data) volume so .1 is valid
+  volume_prototypes {
+    name                             = "%s-data-vol"
+    delete_volume_on_instance_delete = true
+    volume_name                      = "%s-data-vol"
+    volume_capacity                  = 20
+    volume_profile                   = "general-purpose"
+  }
+}
+resource "ibm_is_instance_action" "is_instance_action" {
+	  depends_on = [ibm_is_instance.testacc_instance]
+	  action = "%s"
+	  instance = ibm_is_instance.testacc_instance.id
+}
+data "ibm_is_instance_volume_attachment" "ds_vol_att" {
+  depends_on = [ibm_is_instance_action.is_instance_action]
+  instance = ibm_is_instance.testacc_instance.id
+  name     = ibm_is_instance.testacc_instance.volume_attachments.1.name
+}
+`, vpcname, subnetname, acc.ISZoneName, sshname, publicKey, name,
+		acc.IsImage, acc.InstanceProfileName, acc.ISZoneName, name, name, action)
 }

--- a/ibm/service/vpc/data_source_ibm_is_instance_volume_attachments.go
+++ b/ibm/service/vpc/data_source_ibm_is_instance_volume_attachments.go
@@ -153,7 +153,9 @@ func instanceGetVolumeAttachments(context context.Context, d *schema.ResourceDat
 		// bandwidth changes
 		currentVolAtt["bandwidth"] = *volumeAtt.Bandwidth
 		currentVolAtt[isInstanceVolumeDeleteOnInstanceDelete] = *volumeAtt.DeleteVolumeOnInstanceDelete
-		currentVolAtt[isInstanceVolumeAttDevice] = *volumeAtt.Device.ID
+		if volumeAtt.Device != nil {
+			currentVolAtt[isInstanceVolumeAttDevice] = volumeAtt.Device.ID
+		}
 		currentVolAtt[isInstanceVolumeAttHref] = *volumeAtt.Href
 		currentVolAtt[isInstanceVolAttId] = *volumeAtt.ID
 		currentVolAtt[isInstanceVolumeAttStatus] = *volumeAtt.Status


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/IBM-Cloud/terraform-provider-ibm/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
--- PASS: TestAccIBMISInstanceVolumeAttDataSource_nodevice (311.68s)
PASS
ok      github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/vpc     313.573s
```
```
--- PASS: TestAccIBMISInstanceVolumeAttsDataSource_nodevice (326.34s)
PASS
ok      github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/vpc     328.211s
```