### PR TITLE
add way to test admin config

### DIFF
--- a/ibm/acctest/acctest.go
+++ b/ibm/acctest/acctest.go
@@ -24,10 +24,20 @@ const (
 
 var (
 	AccountId                       string
+	ActionID                        string
+	ActivityTrackerInstanceCRN      string
+	AgentID                         string
 	AppIDTenantID                   string
 	AppIDTestUserEmail              string
-	BackupPolicyJobID               string
 	BackupPolicyID                  string
+	BackupPolicyJobID               string
+	BackupVaultCrn                  string
+	BackupVaultCrn2                 string
+	BackupVaultName                 string
+	BackupVaultName2                string
+	BucketCRN                       string
+	BucketName                      string
+	CertCRN                         string
 	CfOrganization                  string
 	CfSpace                         string
 	CisDomainStatic                 string
@@ -35,112 +45,102 @@ var (
 	CisInstance                     string
 	CisResourceGroup                string
 	CloudShellAccountID             string
-	CosCRN                          string
 	CosBackupPolicyID               string
-	BucketCRN                       string
-	BackupVaultName                 string
-	BackupVaultName2                string
-	BackupVaultCrn                  string
-	BackupVaultCrn2                 string
-	ActivityTrackerInstanceCRN      string
-	MetricsMonitoringCRN            string
-	KmsKeyCrn                       string
-	BucketName                      string
+	CosCRN                          string
 	CosName                         string
-	Ibmid1                          string
-	Ibmid2                          string
-	IAMUser                         string
+	CsRegion                        string
+	Customerpeerip                  string
+	Customersubnetid                string
+	DNSInstanceCRN                  string
+	DNSInstanceCRN1                 string
+	DNSZoneID                       string
+	DNSZoneID1                      string
+	Datacenter                      string
+	DedicatedHostGroupClass         string
+	DedicatedHostGroupFamily        string
+	DedicatedHostGroupID            string
+	DedicatedHostID                 string
+	DedicatedHostName               string
+	DedicatedHostProfileName        string
+	EnterpriseCRN                   string
+	ExtendedHardwareTesting         bool
+	FloatingIpID                    string
+	HpcsInstanceID                  string
+	HpcsInstanceName                string
 	IAMAccountId                    string
 	IAMServiceId                    string
 	IAMTrustedProfileID             string
-	Datacenter                      string
-	MachineType                     string
-	trustedMachineType              string
-	PublicVlanID                    string
-	PrivateVlanID                   string
-	PrivateSubnetID                 string
-	PublicSubnetID                  string
-	SubnetID                        string
+	IAMUser                         string
+	ISAddressPrefixCIDR             string
+	ISBootSnapshotID                string
+	ISCIDR                          string
+	ISCIDR2                         string
+	ISCatalogImageName              string
+	ISIPV4Address                   string
+	ISPrivateSSHKeyFilePath         string
+	ISPublicSSHKeyFilePath          string
+	ISResourceCrn                   string
+	ISRouteDestination              string
+	ISRouteNextHop                  string
+	ISSnapshotCRN                   string
+	ISZoneName                      string
+	ISZoneName2                     string
+	ISZoneName3                     string
+	Ibmid1                          string
+	Ibmid2                          string
+	InstanceCRN                     string
+	InstanceDiskProfileName         string
+	InstanceName                    string
+	InstanceProfileName             string
+	InstanceProfileNameUpdate       string
+	IpsecDatacenter                 string
+	IsAdminConfig                   string
+	IsBareMetalServerImage          string
+	IsBareMetalServerImage2         string
+	IsBareMetalServerProfileName    string
+	IsResourceGroupID               string
+	IsResourceGroupIDUpdate         string
+	JobID                           string
+	KmsKeyCrn                       string
+	KubeUpdateVersion               string
+	KubeVersion                     string
+	LbListerenerCertificateInstance string
 	LbaasDatacenter                 string
 	LbaasSubnetId                   string
-	LbListerenerCertificateInstance string
-	IpsecDatacenter                 string
-	Customersubnetid                string
-	Customerpeerip                  string
-	DedicatedHostName               string
-	DedicatedHostID                 string
-	KubeVersion                     string
-	KubeUpdateVersion               string
+	MachineType                     string
+	MetricsMonitoringCRN            string
+	PrivateSubnetID                 string
+	PrivateVlanID                   string
+	PublicSubnetID                  string
+	PublicVlanID                    string
+	RegionName                      string
+	RepoBranch                      string
+	RepoURL                         string
+	SecretCRN                       string
+	SecretCRN2                      string
+	SecretGroupID                   string
+	ShareEncryptionKey              string
+	ShareProfileName                string
+	SourceShareCRN                  string
+	SubnetID                        string
+	TemplateID                      string
+	ToolchainID                     string
+	UpdatedCertCRN                  string
+	VNIId                           string
+	VSIDataVolumeID                 string
+	VSIUnattachedBootVolumeID       string
+	VolumeProfileName               string
+	WorkerPoolSecondaryStorage      string
+	WorkspaceID                     string
 	Zone                            string
 	ZonePrivateVlan                 string
 	ZonePublicVlan                  string
 	ZoneUpdatePrivateVlan           string
 	ZoneUpdatePublicVlan            string
-	WorkerPoolSecondaryStorage      string
-	CsRegion                        string
-	ExtendedHardwareTesting         bool
 	err                             error
-	placementGroupName              string
-	CertCRN                         string
-	UpdatedCertCRN                  string
-	SecretCRN                       string
-	SecretCRN2                      string
-	EnterpriseCRN                   string
-	InstanceCRN                     string
-	SecretGroupID                   string
-	RegionName                      string
-	ISZoneName                      string
-	ISZoneName2                     string
-	ISZoneName3                     string
-	IsResourceGroupID               string
-	IsResourceGroupIDUpdate         string
-	ISResourceCrn                   string
-	ISCIDR                          string
-	ISCIDR2                         string
-	ISIPV4Address                   string
-	ISPublicSSHKeyFilePath          string
-	ISPrivateSSHKeyFilePath         string
-	ISAddressPrefixCIDR             string
-	InstanceName                    string
-	InstanceProfileName             string
-	InstanceProfileNameUpdate       string
-	ISCatalogImageName              string
-	ISBootSnapshotID                string
-	IsBareMetalServerProfileName    string
-	IsBareMetalServerImage          string
-	IsBareMetalServerImage2         string
-	DNSInstanceCRN                  string
-	DNSZoneID                       string
-	DNSInstanceCRN1                 string
-	DNSZoneID1                      string
-	DedicatedHostProfileName        string
-	DedicatedHostGroupID            string
-	InstanceDiskProfileName         string
-	DedicatedHostGroupFamily        string
-	DedicatedHostGroupClass         string
-	ShareProfileName                string
-	SourceShareCRN                  string
-	ShareEncryptionKey              string
-	VNIId                           string
-	FloatingIpID                    string
-	VolumeProfileName               string
-	VSIUnattachedBootVolumeID       string
-	VSIDataVolumeID                 string
-	ISRouteDestination              string
-	ISRouteNextHop                  string
-	ISSnapshotCRN                   string
-	WorkspaceID                     string
-	TemplateID                      string
-	AgentID                         string
-	ActionID                        string
-	JobID                           string
-	RepoURL                         string
-	RepoBranch                      string
-	imageName                       string
 	functionNamespace               string
-	HpcsInstanceID                  string
-	HpcsInstanceName                string
-	ToolchainID                     string
+	placementGroupName              string
+	trustedMachineType              string
 )
 
 // MQ on Cloud
@@ -2174,6 +2174,12 @@ func init() {
 	ToolchainID = os.Getenv("TOOLCHAIN_ID")
 	if ToolchainID == "" {
 		fmt.Println("[WARN] Set the environment variable TOOLCHAIN_ID for testing the COS toolchain integration tool else tests will fail if this is not set correctly")
+	}
+
+	IsAdminConfig = os.Getenv("IBM_IS_ADMIN_CONFIG")
+	if IsAdminConfig == "" {
+		IsAdminConfig = "false"
+		fmt.Println("[WARN] Set the environment variable IBM_IS_ADMIN_CONFIG for testing ibm_container_cluster_config datasource else tests will fail if this is not set correctly")
 	}
 }
 

--- a/ibm/service/kubernetes/data_source_ibm_container_cluster_config_test.go
+++ b/ibm/service/kubernetes/data_source_ibm_container_cluster_config_test.go
@@ -9,7 +9,6 @@ import (
 	"testing"
 
 	acc "github.com/IBM-Cloud/terraform-provider-ibm/ibm/acctest"
-
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/mitchellh/go-homedir"
@@ -88,18 +87,19 @@ func TestAccIBMContainer_ClusterConfigCalicoDataSourceBasic(t *testing.T) {
 func testAccCheckIBMContainerClusterDataSourceConfig(clustername string) string {
 	return fmt.Sprintf(`
 resource "ibm_container_cluster" "testacc_cluster" {
-  name        	   = "%s"
-  datacenter   	   = "%s"
-  machine_type     = "%s"
-  hardware         = "shared"
-  wait_till        = "normal"
-  public_vlan_id   = "%s"
-  private_vlan_id  = "%s"
+  name            = "%s"
+  datacenter      = "%s"
+  machine_type    = "%s"
+  hardware        = "shared"
+  wait_till       = "normal"
+  public_vlan_id  = "%s"
+  private_vlan_id = "%s"
 }
 
 data "ibm_container_cluster_config" "testacc_ds_cluster" {
   cluster_name_id = ibm_container_cluster.testacc_cluster.id
-}`, clustername, acc.Datacenter, acc.MachineType, acc.PublicVlanID, acc.PrivateVlanID)
+  admin           = %s
+}`, clustername, acc.Datacenter, acc.MachineType, acc.PublicVlanID, acc.PrivateVlanID, acc.IsAdminConfig)
 }
 
 func testAccCheckIBMContainerClusterDataSourceVpcConfig(clustername string) string {


### PR DESCRIPTION
- deleted `imageName` as it was unused and unexported
- sorted acctest variables alphabetically
- added `IsAdminConfig` set by `IBM_IS_ADMIN_CONFIG` env var, defaults to `"false"`

This would've caught the panic introduced by https://github.com/IBM-Cloud/bluemix-go/pull/463

<!--- See what makes a good Pull Request at : https://github.com/IBM-Cloud/terraform-provider-ibm/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
IBM_IS_ADMIN_CONFIG="banana" make testacc TEST=./ibm/service/kubernetes TESTARGS='-run "TestAccIBMContainer_ClusterConfigDataSourceBasic"'
=== RUN   TestAccIBMContainer_ClusterConfigDataSourceBasic
    data_source_ibm_container_cluster_config_test.go:23: Step 1/1 error: Error running pre-apply refresh: exit status 1

        Error: Invalid reference

          on terraform_plugin_test.tf line 15, in data "ibm_container_cluster_config" "testacc_ds_cluster":
          15:   admin           = banana

        A reference to a resource type must be followed by at least one attribute
        access, specifying the resource name.
--- FAIL: TestAccIBMContainer_ClusterConfigDataSourceBasic (3.67s)
FAIL
FAIL    github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/kubernetes      4.616s
FAIL
make: *** [testacc] Error 1

IBM_IS_ADMIN_CONFIG="true" make testacc TEST=./ibm/service/kubernetes TESTARGS='-run "TestAccIBMContainer_ClusterConfigDataSourceBasic"'
=== RUN   TestAccIBMContainer_ClusterConfigDataSourceBasic
--- PASS: TestAccIBMContainer_ClusterConfigDataSourceBasic (1217.91s)
PASS
ok      github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/kubernetes      1218.677s

make testacc TEST=./ibm/service/kubernetes TESTARGS='-run "TestAccIBMContainer_ClusterConfigDataSourceBasic"'
CURRENTLY RUNNING
```
