### PR TITLE
Add PER wait check on workspace creation for applicable workspaces

### DIFF
--- a/ibm/service/power/resource_ibm_pi_workspace.go
+++ b/ibm/service/power/resource_ibm_pi_workspace.go
@@ -95,7 +95,7 @@ func ResourceIBMPIWorkspace() *schema.Resource {
 func resourceIBMPIWorkspaceCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	sess, err := meta.(conns.ClientSession).IBMPISession()
 	if err != nil {
-		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("IBMPISession failed: %s", err.Error()), "(Resource) ibm_pi_workspace", "create")
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("IBMPISession failed: %s", err.Error()), "ibm_pi_workspace", "create")
 		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
 		return tfErr.GetDiag()
 	}
@@ -109,7 +109,7 @@ func resourceIBMPIWorkspaceCreate(ctx context.Context, d *schema.ResourceData, m
 	client := instance.NewIBMPIWorkspacesClient(ctx, sess, "")
 	controller, _, err := client.Create(name, datacenter, resourceGroup, plan)
 	if err != nil {
-		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("Create failed: %s", err.Error()), "(Resource) ibm_pi_workspace", "create")
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("Create failed: %s", err.Error()), "ibm_pi_workspace", "create")
 		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
 		return tfErr.GetDiag()
 	}
@@ -119,7 +119,7 @@ func resourceIBMPIWorkspaceCreate(ctx context.Context, d *schema.ResourceData, m
 
 	_, err = waitForResourceWorkspaceCreate(ctx, client, cloudInstanceID, d.Timeout(schema.TimeoutCreate))
 	if err != nil {
-		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("waitForResourceWorkspaceCreate failed: %s", err.Error()), "(Resource) ibm_pi_workspace", "create")
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("waitForResourceWorkspaceCreate failed: %s", err.Error()), "ibm_pi_workspace", "create")
 		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
 		return tfErr.GetDiag()
 	}
@@ -128,14 +128,14 @@ func resourceIBMPIWorkspaceCreate(ctx context.Context, d *schema.ResourceData, m
 		wsclient := instance.NewIBMPIWorkspacesClient(ctx, sess, cloudInstanceID)
 		wsData, err := wsclient.Get(cloudInstanceID)
 		if err != nil {
-			tfErr := flex.TerraformErrorf(err, fmt.Sprintf("Get failed: %s", err.Error()), "(Resource) ibm_pi_workspace", "create")
+			tfErr := flex.TerraformErrorf(err, fmt.Sprintf("Get failed: %s", err.Error()), "ibm_pi_workspace", "create")
 			log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
 			return tfErr.GetDiag()
 		}
 		if wsData.Capabilities[PER] {
 			_, err = waitForPERWorkspaceActive(ctx, wsclient, cloudInstanceID, d.Timeout(schema.TimeoutRead))
 			if err != nil {
-				tfErr := flex.TerraformErrorf(err, fmt.Sprintf("waitForPERWorkspaceActive failed: %s", err.Error()), "(Resource) ibm_pi_workspace", "create")
+				tfErr := flex.TerraformErrorf(err, fmt.Sprintf("waitForPERWorkspaceActive failed: %s", err.Error()), "ibm_pi_workspace", "create")
 				log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
 				return tfErr.GetDiag()
 			}
@@ -184,7 +184,7 @@ func resourceIBMPIWorkspaceRead(ctx context.Context, d *schema.ResourceData, met
 	// session
 	sess, err := meta.(conns.ClientSession).IBMPISession()
 	if err != nil {
-		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("IBMPISession failed: %s", err.Error()), "(Resource) ibm_pi_workspace", "read")
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("IBMPISession failed: %s", err.Error()), "ibm_pi_workspace", "read")
 		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
 		return tfErr.GetDiag()
 	}
@@ -193,7 +193,7 @@ func resourceIBMPIWorkspaceRead(ctx context.Context, d *schema.ResourceData, met
 	client := instance.NewIBMPIWorkspacesClient(ctx, sess, cloudInstanceID)
 	controller, _, err := client.GetRC(cloudInstanceID)
 	if err != nil {
-		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("GetRC failed: %s", err.Error()), "(Resource) ibm_pi_workspace", "read")
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("GetRC failed: %s", err.Error()), "ibm_pi_workspace", "read")
 		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
 		return tfErr.GetDiag()
 	}
@@ -219,7 +219,7 @@ func resourceIBMPIWorkspaceRead(ctx context.Context, d *schema.ResourceData, met
 func resourceIBMPIWorkspaceDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	sess, err := meta.(conns.ClientSession).IBMPISession()
 	if err != nil {
-		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("IBMPISession failed: %s", err.Error()), "(Resource) ibm_pi_workspace", "delete")
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("IBMPISession failed: %s", err.Error()), "ibm_pi_workspace", "delete")
 		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
 		return tfErr.GetDiag()
 	}
@@ -232,7 +232,7 @@ func resourceIBMPIWorkspaceDelete(ctx context.Context, d *schema.ResourceData, m
 	}
 	_, err = waitForResourceWorkspaceDelete(ctx, client, cloudInstanceID, d.Timeout(schema.TimeoutDelete))
 	if err != nil {
-		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("waitForResourceWorkspaceDelete failed: %s", err.Error()), "(Resource) ibm_pi_workspace", "delete")
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("waitForResourceWorkspaceDelete failed: %s", err.Error()), "ibm_pi_workspace", "delete")
 		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
 		return tfErr.GetDiag()
 	}

--- a/ibm/service/power/resource_ibm_pi_workspace_test.go
+++ b/ibm/service/power/resource_ibm_pi_workspace_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	acc "github.com/IBM-Cloud/terraform-provider-ibm/ibm/acctest"
+	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/flex"
 
 	"github.com/IBM-Cloud/power-go-client/clients/instance"
 	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/conns"
@@ -89,11 +90,11 @@ func testAccIBMPIWorkspaceDestroy(s *terraform.State) error {
 		workspace, resp, err := client.GetRC(cloudInstanceID)
 		if err == nil {
 			if *workspace.State == power.State_Active {
-				return fmt.Errorf("Resource Instance still exists: %s", rs.Primary.ID)
+				return flex.FmtErrorf("Resource Instance still exists: %s", rs.Primary.ID)
 			}
 		} else {
 			if !strings.Contains(err.Error(), "404") {
-				return fmt.Errorf("[ERROR] Error checking if Resource Instance (%s) has been destroyed: %s with resp code: %s", rs.Primary.ID, err, resp)
+				return flex.FmtErrorf("[ERROR] Error checking if Resource Instance (%s) has been destroyed: %s with resp code: %s", rs.Primary.ID, err, resp)
 			}
 		}
 	}
@@ -105,7 +106,7 @@ func testAccCheckIBMPIWorkspaceExists(n string) resource.TestCheckFunc {
 		rs, ok := s.RootModule().Resources[n]
 
 		if !ok {
-			return fmt.Errorf("Not found: %s", n)
+			return flex.FmtErrorf("Not found: %s", n)
 		}
 
 		if rs.Primary.ID == "" {


### PR DESCRIPTION
This pull request adds additional checking on PER workspaces to make sure the PER capability became available before declaring success. If PER does not become active in a workspace, it is essentially unusable.

Output of acceptance testing:

```
--- PASS: TestAccIBMPIWorkspaceBasic (635.76s)
PASS

--- PASS: TestAccIBMPIWorkspaceUserTags (688.72s)
PASS
```