### PR TITLE
Update: Pull in new icr SDK which adds new regions endpoints

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "go.mod|go.sum|.*.map|^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2025-08-10T14:26:04Z",
+  "generated_at": "2025-09-10T10:45:53Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -557,6 +557,16 @@
         "verified_result": null
       }
     ],
+    "examples/ibm-iam-identities/variables.tf": [
+      {
+        "hashed_secret": "a5fe052f5cc83f689bcb58774a49b43c01b0d725",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 31,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      }
+    ],
     "examples/ibm-iam_identity-apikeys/README.md": [
       {
         "hashed_secret": "c336f524d3f5d0638ca1952e4f63ce3f40cfbf4b",
@@ -822,7 +832,7 @@
         "hashed_secret": "731438016c5ab94431f61820f35e3ae5f8ad6004",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 539,
+        "line_number": 545,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -830,7 +840,7 @@
         "hashed_secret": "12da2e35d6b50c902c014f1ab9e3032650368df7",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 545,
+        "line_number": 551,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -838,7 +848,7 @@
         "hashed_secret": "165722fe6dd0ec0afbeefb51c8258a177497956b",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 837,
+        "line_number": 843,
         "type": "Hex High Entropy String",
         "verified_result": null
       },
@@ -846,7 +856,7 @@
         "hashed_secret": "813274ccae5b6b509379ab56982d862f7b5969b6",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1491,
+        "line_number": 1509,
         "type": "Base64 High Entropy String",
         "verified_result": null
       }
@@ -856,7 +866,7 @@
         "hashed_secret": "9184b0c38101bf24d78b2bb0d044deb1d33696fc",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 145,
+        "line_number": 146,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -864,7 +874,7 @@
         "hashed_secret": "c427f185ddcb2440be9b77c8e45f1cd487a2e790",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1559,
+        "line_number": 1574,
         "type": "Base64 High Entropy String",
         "verified_result": null
       },
@@ -872,7 +882,7 @@
         "hashed_secret": "1f7e33de15e22de9d2eaf502df284ed25ca40018",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1626,
+        "line_number": 1641,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -880,7 +890,7 @@
         "hashed_secret": "1f614c2eb6b3da22d89bd1b9fd47d7cb7c8fc670",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 3720,
+        "line_number": 3754,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -888,7 +898,7 @@
         "hashed_secret": "7abfce65b8504403afc25c9790f358d513dfbcc6",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 3733,
+        "line_number": 3767,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -896,7 +906,7 @@
         "hashed_secret": "0c2d85bf9a9b1579b16f220a4ea8c3d62b2e24b1",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 3775,
+        "line_number": 3809,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -934,7 +944,7 @@
         "hashed_secret": "c8b6f5ef11b9223ac35a5663975a466ebe7ebba9",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2411,
+        "line_number": 2462,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -942,33 +952,7 @@
         "hashed_secret": "8abf4899c01104241510ba87685ad4de76b0c437",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2417,
-        "type": "Secret Keyword",
-        "verified_result": null
-      }
-    ],
-    "ibm/service/apigateway/resource_ibm_api_gateway_endpoint_subscription.go": [
-      {
-        "hashed_secret": "a2a34b8bdbe4d81821c05f2467b5dcdfa72557b9",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 110,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "2d1782d8a065e113961a49011478089bf93115d9",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 115,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "ce1e10abfd561d0a80450a58ce9c4d620b46d39c",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 216,
+        "line_number": 2468,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -1544,7 +1528,7 @@
         "hashed_secret": "3046d9f6cfaaeea6eed9bb7a4ab010fe49b0cfd4",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 425,
+        "line_number": 435,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -1554,7 +1538,7 @@
         "hashed_secret": "731538be37450012c5fe92b7e86eff4959083a36",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 961,
+        "line_number": 971,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -1564,7 +1548,7 @@
         "hashed_secret": "3046d9f6cfaaeea6eed9bb7a4ab010fe49b0cfd4",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 243,
+        "line_number": 253,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1572,7 +1556,7 @@
         "hashed_secret": "17f5f58d3d8d9871c52ab032989df3d810d2443e",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 439,
+        "line_number": 461,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1580,7 +1564,7 @@
         "hashed_secret": "b732fb611fd46a38e8667f9972e0cde777fbe37f",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 441,
+        "line_number": 463,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -1590,7 +1574,7 @@
         "hashed_secret": "3046d9f6cfaaeea6eed9bb7a4ab010fe49b0cfd4",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 502,
+        "line_number": 512,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -1600,7 +1584,7 @@
         "hashed_secret": "731538be37450012c5fe92b7e86eff4959083a36",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 967,
+        "line_number": 981,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -1610,7 +1594,7 @@
         "hashed_secret": "3046d9f6cfaaeea6eed9bb7a4ab010fe49b0cfd4",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 205,
+        "line_number": 217,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1618,7 +1602,7 @@
         "hashed_secret": "b732fb611fd46a38e8667f9972e0cde777fbe37f",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 595,
+        "line_number": 625,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1626,7 +1610,7 @@
         "hashed_secret": "b5366a2d2ac98dae978423083f8b09e5cddc705d",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 994,
+        "line_number": 1040,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -2901,16 +2885,6 @@
         "verified_result": null
       }
     ],
-    "ibm/service/eventnotification/data_source_ibm_en_destination_pagerduty_test.go": [
-      {
-        "hashed_secret": "5a5241e2e938922ef2639bbbad51f5f0a6f5e4d9",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 58,
-        "type": "Secret Keyword",
-        "verified_result": null
-      }
-    ],
     "ibm/service/eventnotification/data_source_ibm_en_destination_safari.go": [
       {
         "hashed_secret": "4489f0af19dc8513caa9f822ba006d90095e492a",
@@ -3007,6 +2981,16 @@
         "verified_result": null
       }
     ],
+    "ibm/service/eventnotification/resource_ibm_en_code_engine_template_test.go": [
+      {
+        "hashed_secret": "c32beb1fc9baedd01445b61f5954ee70282c2685",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 75,
+        "type": "Base64 High Entropy String",
+        "verified_result": null
+      }
+    ],
     "ibm/service/eventnotification/resource_ibm_en_destination_apns_test.go": [
       {
         "hashed_secret": "2c3cbcd72f1d045c9511c23bb8dc003b61e83330",
@@ -3040,16 +3024,6 @@
     "ibm/service/eventnotification/resource_ibm_en_destination_huawei_test.go": [
       {
         "hashed_secret": "58c7a8d929a8cf81f3ae641961651f1564c28936",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 79,
-        "type": "Secret Keyword",
-        "verified_result": null
-      }
-    ],
-    "ibm/service/eventnotification/resource_ibm_en_destination_pagerduty_test.go": [
-      {
-        "hashed_secret": "5a5241e2e938922ef2639bbbad51f5f0a6f5e4d9",
         "is_secret": false,
         "is_verified": false,
         "line_number": 79,
@@ -3289,6 +3263,16 @@
         "verified_result": null
       }
     ],
+    "ibm/service/iamidentity/data_source_ibm_iam_trusted_profile_identities_test.go": [
+      {
+        "hashed_secret": "a5fe052f5cc83f689bcb58774a49b43c01b0d725",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 55,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      }
+    ],
     "ibm/service/iamidentity/resource_ibm_iam_account_settings.go": [
       {
         "hashed_secret": "b939bb67ee5f5b13f7997dba58c31813ce8033f0",
@@ -3380,6 +3364,16 @@
         "is_verified": false,
         "line_number": 168,
         "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "ibm/service/iamidentity/resource_ibm_iam_trusted_profile_identities_test.go": [
+      {
+        "hashed_secret": "a5fe052f5cc83f689bcb58774a49b43c01b0d725",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 77,
+        "type": "Hex High Entropy String",
         "verified_result": null
       }
     ],
@@ -3870,7 +3864,7 @@
         "hashed_secret": "347cd9c53ff77d41a7b22aa56c7b4efaf54658e3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 88,
+        "line_number": 90,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -3890,7 +3884,7 @@
         "hashed_secret": "49f3bb8f759241df51c899d3725d877bad58f66e",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 374,
+        "line_number": 393,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -3920,7 +3914,7 @@
         "hashed_secret": "3046d9f6cfaaeea6eed9bb7a4ab010fe49b0cfd4",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 189,
+        "line_number": 194,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -3930,7 +3924,7 @@
         "hashed_secret": "3046d9f6cfaaeea6eed9bb7a4ab010fe49b0cfd4",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 148,
+        "line_number": 153,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -3940,7 +3934,7 @@
         "hashed_secret": "347cd9c53ff77d41a7b22aa56c7b4efaf54658e3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 153,
+        "line_number": 157,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -3950,7 +3944,7 @@
         "hashed_secret": "347cd9c53ff77d41a7b22aa56c7b4efaf54658e3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 152,
+        "line_number": 157,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -3960,7 +3954,7 @@
         "hashed_secret": "3046d9f6cfaaeea6eed9bb7a4ab010fe49b0cfd4",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 359,
+        "line_number": 364,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -3970,7 +3964,7 @@
         "hashed_secret": "3046d9f6cfaaeea6eed9bb7a4ab010fe49b0cfd4",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 230,
+        "line_number": 235,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -3988,7 +3982,7 @@
         "hashed_secret": "3ad6a2f4e68613da801ef1ddc1baf6d5b25607b2",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 511,
+        "line_number": 515,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -4006,7 +4000,7 @@
         "hashed_secret": "9beb31de125498074813c6f31c0e4df3e54a5489",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 575,
+        "line_number": 579,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -4016,7 +4010,7 @@
         "hashed_secret": "3046d9f6cfaaeea6eed9bb7a4ab010fe49b0cfd4",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 299,
+        "line_number": 304,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -4076,7 +4070,7 @@
         "hashed_secret": "347cd9c53ff77d41a7b22aa56c7b4efaf54658e3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 46,
+        "line_number": 47,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -4086,7 +4080,7 @@
         "hashed_secret": "347cd9c53ff77d41a7b22aa56c7b4efaf54658e3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 48,
+        "line_number": 50,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -4096,7 +4090,7 @@
         "hashed_secret": "3046d9f6cfaaeea6eed9bb7a4ab010fe49b0cfd4",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 435,
+        "line_number": 440,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -4104,7 +4098,7 @@
         "hashed_secret": "d39b250468d54ca72b44af6ba25479701dd451c1",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 884,
+        "line_number": 897,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -4114,7 +4108,7 @@
         "hashed_secret": "3046d9f6cfaaeea6eed9bb7a4ab010fe49b0cfd4",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 201,
+        "line_number": 205,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -4124,7 +4118,7 @@
         "hashed_secret": "3046d9f6cfaaeea6eed9bb7a4ab010fe49b0cfd4",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 184,
+        "line_number": 189,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -4134,7 +4128,7 @@
         "hashed_secret": "3046d9f6cfaaeea6eed9bb7a4ab010fe49b0cfd4",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 186,
+        "line_number": 191,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -4162,7 +4156,7 @@
         "hashed_secret": "49f3bb8f759241df51c899d3725d877bad58f66e",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 462,
+        "line_number": 471,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -4192,7 +4186,7 @@
         "hashed_secret": "3046d9f6cfaaeea6eed9bb7a4ab010fe49b0cfd4",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 209,
+        "line_number": 214,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -4200,7 +4194,7 @@
         "hashed_secret": "108b310facc1a193833fc2971fd83081f775ea0c",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 435,
+        "line_number": 444,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -4210,7 +4204,7 @@
         "hashed_secret": "347cd9c53ff77d41a7b22aa56c7b4efaf54658e3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 136,
+        "line_number": 139,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -4228,7 +4222,7 @@
         "hashed_secret": "9beb31de125498074813c6f31c0e4df3e54a5489",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1101,
+        "line_number": 1110,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -4238,7 +4232,7 @@
         "hashed_secret": "1348b145fa1a555461c1b790a2f66614781091e9",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 283,
+        "line_number": 287,
         "type": "Private Key",
         "verified_result": null
       },
@@ -4246,7 +4240,7 @@
         "hashed_secret": "1ccdffdaa7d44feca6d6db090e83db7c58f64981",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 283,
+        "line_number": 287,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -4256,7 +4250,7 @@
         "hashed_secret": "3046d9f6cfaaeea6eed9bb7a4ab010fe49b0cfd4",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 297,
+        "line_number": 302,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -4302,7 +4296,7 @@
         "hashed_secret": "3046d9f6cfaaeea6eed9bb7a4ab010fe49b0cfd4",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 397,
+        "line_number": 402,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -4388,7 +4382,7 @@
         "hashed_secret": "347cd9c53ff77d41a7b22aa56c7b4efaf54658e3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 152,
+        "line_number": 155,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -4408,7 +4402,7 @@
         "hashed_secret": "3046d9f6cfaaeea6eed9bb7a4ab010fe49b0cfd4",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 122,
+        "line_number": 127,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -4426,7 +4420,7 @@
         "hashed_secret": "347cd9c53ff77d41a7b22aa56c7b4efaf54658e3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 127,
+        "line_number": 130,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -4534,7 +4528,7 @@
         "hashed_secret": "4d55af37dbbb6a42088d917caa1ca25428ec42c9",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 859,
+        "line_number": 897,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -4671,6 +4665,16 @@
         "is_secret": false,
         "is_verified": false,
         "line_number": 40,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      }
+    ],
+    "website/docs/d/mqcloud_queue_manager_status.html.markdown": [
+      {
+        "hashed_secret": "4626e4d6f8031018c0990bd025a2a25c06ac2596",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 19,
         "type": "Hex High Entropy String",
         "verified_result": null
       }
@@ -5343,6 +5347,24 @@
         "verified_result": null
       }
     ],
+    "website/docs/r/is_public_address_range.html.markdown": [
+      {
+        "hashed_secret": "13ef22c6a31093830639f12a9feb34a8acd9c34f",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 36,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "b93b47a3e2ea958f8ca87a70ebc9ad0f4d5ffa45",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 56,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      }
+    ],
     "website/docs/r/lb_vpx.html.markdown": [
       {
         "hashed_secret": "7f9e9d60560fbad72688c82e68cf42157a61bcad",
@@ -5404,6 +5426,26 @@
         "is_verified": false,
         "line_number": 79,
         "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "website/docs/r/mqcloud_keystore_certificate.html.markdown": [
+      {
+        "hashed_secret": "4626e4d6f8031018c0990bd025a2a25c06ac2596",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 21,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      }
+    ],
+    "website/docs/r/mqcloud_truststore_certificate.html.markdown": [
+      {
+        "hashed_secret": "4626e4d6f8031018c0990bd025a2a25c06ac2596",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 21,
+        "type": "Hex High Entropy String",
         "verified_result": null
       }
     ],
@@ -5498,7 +5540,7 @@
         "hashed_secret": "d47dcacc720a39e236679ac3e311a0d58bb6519e",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 105,
+        "line_number": 109,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -5506,7 +5548,7 @@
         "hashed_secret": "e66e7d67fdf3c596c435fc7828b13205e4950a0f",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 107,
+        "line_number": 111,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -5534,7 +5576,7 @@
         "hashed_secret": "d47dcacc720a39e236679ac3e311a0d58bb6519e",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 143,
+        "line_number": 146,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -5542,7 +5584,7 @@
         "hashed_secret": "e66e7d67fdf3c596c435fc7828b13205e4950a0f",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 145,
+        "line_number": 148,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -5596,7 +5638,7 @@
         "hashed_secret": "d47dcacc720a39e236679ac3e311a0d58bb6519e",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 129,
+        "line_number": 133,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -5604,7 +5646,7 @@
         "hashed_secret": "e66e7d67fdf3c596c435fc7828b13205e4950a0f",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 131,
+        "line_number": 135,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -5614,7 +5656,7 @@
         "hashed_secret": "d47dcacc720a39e236679ac3e311a0d58bb6519e",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 190,
+        "line_number": 194,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -5622,7 +5664,7 @@
         "hashed_secret": "e66e7d67fdf3c596c435fc7828b13205e4950a0f",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 192,
+        "line_number": 196,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -5632,7 +5674,7 @@
         "hashed_secret": "d47dcacc720a39e236679ac3e311a0d58bb6519e",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 103,
+        "line_number": 107,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -5640,7 +5682,7 @@
         "hashed_secret": "e66e7d67fdf3c596c435fc7828b13205e4950a0f",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 105,
+        "line_number": 109,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -5650,7 +5692,7 @@
         "hashed_secret": "d47dcacc720a39e236679ac3e311a0d58bb6519e",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 147,
+        "line_number": 151,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -5658,7 +5700,7 @@
         "hashed_secret": "e66e7d67fdf3c596c435fc7828b13205e4950a0f",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 149,
+        "line_number": 153,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -5722,7 +5764,7 @@
         "hashed_secret": "d47dcacc720a39e236679ac3e311a0d58bb6519e",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 168,
+        "line_number": 172,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -5730,7 +5772,7 @@
         "hashed_secret": "e66e7d67fdf3c596c435fc7828b13205e4950a0f",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 170,
+        "line_number": 174,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -5844,7 +5886,7 @@
         "hashed_secret": "d47dcacc720a39e236679ac3e311a0d58bb6519e",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 222,
+        "line_number": 226,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -5852,7 +5894,7 @@
         "hashed_secret": "e66e7d67fdf3c596c435fc7828b13205e4950a0f",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 224,
+        "line_number": 228,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -5870,7 +5912,7 @@
         "hashed_secret": "d47dcacc720a39e236679ac3e311a0d58bb6519e",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 134,
+        "line_number": 138,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -5878,7 +5920,7 @@
         "hashed_secret": "e66e7d67fdf3c596c435fc7828b13205e4950a0f",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 136,
+        "line_number": 140,
         "type": "Secret Keyword",
         "verified_result": null
       }

--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/IBM/cloudant-go-sdk v0.8.0
 	github.com/IBM/code-engine-go-sdk v0.0.0-20241217191651-e1821f8c58c3
 	github.com/IBM/configuration-aggregator-go-sdk v0.0.2
-	github.com/IBM/container-registry-go-sdk v1.1.0
+	github.com/IBM/container-registry-go-sdk v1.2.0
 	github.com/IBM/continuous-delivery-go-sdk/v2 v2.0.6
 	github.com/IBM/event-notifications-go-admin-sdk v0.18.0
 	github.com/IBM/eventstreams-go-sdk v1.4.0

--- a/go.sum
+++ b/go.sum
@@ -112,8 +112,8 @@ github.com/IBM/code-engine-go-sdk v0.0.0-20241217191651-e1821f8c58c3 h1:bNopmSDZ
 github.com/IBM/code-engine-go-sdk v0.0.0-20241217191651-e1821f8c58c3/go.mod h1:OiTumANXHfRr89a+0GjGWI70yzwZI+7ja2JFGpfnPFY=
 github.com/IBM/configuration-aggregator-go-sdk v0.0.2 h1:IRDIrGyLNXq+wQRj/js/Bzr74iQk7xaHiYB8g3TcMyY=
 github.com/IBM/configuration-aggregator-go-sdk v0.0.2/go.mod h1:Ql2N5j4d4Pj1/GoLzFwZw0DomCG4b1O33kKs3TZ+O+I=
-github.com/IBM/container-registry-go-sdk v1.1.0 h1:sYyknIod8R4RJZQqAheiduP6wbSTphE9Ag8ho28yXjc=
-github.com/IBM/container-registry-go-sdk v1.1.0/go.mod h1:4TwsCnQtVfZ4Vkapy/KPvQBKFc3VOyUZYkwRU4FTPrs=
+github.com/IBM/container-registry-go-sdk v1.2.0 h1:DX08GSKFvgCcUne9rWwb9+UttevV4WiG2YfEvKjY5HA=
+github.com/IBM/container-registry-go-sdk v1.2.0/go.mod h1:fE1iNfehccXBx1wmX/RUWksDteWOOOXJFtHWYlT4zKk=
 github.com/IBM/continuous-delivery-go-sdk/v2 v2.0.6 h1:CdJWGVzcHngf6un5N2C4KDgIzqViA2Md6pSeZNZzsLQ=
 github.com/IBM/continuous-delivery-go-sdk/v2 v2.0.6/go.mod h1:Iibf+4gRasEZHakDgnMm7TOX87xex0L+DfghUclcmcg=
 github.com/IBM/event-notifications-go-admin-sdk v0.18.0 h1:G4230wYVCjHnHFEcingfMVznjSJeUoSWzyEMsEFYCmo=


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/IBM-Cloud/terraform-provider-ibm/blob/master/.github/CONTRIBUTING.md --->

Updates container-registry SDK which adds support for eu-es and ca-mon

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Output from acceptance testing:

```
make testacc TEST=./ibm/service/registry TESTARGS='-run="TestAccIBMCr.*"'                                                                                                                                            
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./ibm/service/registry -v -run="TestAccIBMCr.*" -timeout 700m
=== RUN   TestAccIBMCrNamespacesDataSourceBasic
--- PASS: TestAccIBMCrNamespacesDataSourceBasic (31.07s)
=== RUN   TestAccIBMCrNamespaceBasic
--- PASS: TestAccIBMCrNamespaceBasic (44.79s)
=== RUN   TestAccIBMCrNamespaceAllArgs
--- PASS: TestAccIBMCrNamespaceAllArgs (72.48s)
=== RUN   TestAccIBMCrRetentionPolicyAllArgs
--- PASS: TestAccIBMCrRetentionPolicyAllArgs (36.61s)
PASS
ok      github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/registry        186.443s
```

