### PR TITLE
feat(bare-metal): Support for metadata service configuration

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -38,7 +38,7 @@ require (
 	github.com/IBM/secrets-manager-go-sdk/v2 v2.0.11
 	github.com/IBM/vmware-go-sdk v0.1.5
 	github.com/IBM/vpc-beta-go-sdk v0.8.0
-	github.com/IBM/vpc-go-sdk v0.70.1
+	github.com/IBM/vpc-go-sdk v0.71.1
 	github.com/ScaleFT/sshkeys v0.0.0-20200327173127-6142f742bca5
 	github.com/akamai/AkamaiOPEN-edgegrid-golang v1.2.2
 	github.com/akamai/AkamaiOPEN-edgegrid-golang/v5 v5.0.0

--- a/go.sum
+++ b/go.sum
@@ -171,6 +171,8 @@ github.com/IBM/vpc-beta-go-sdk v0.8.0 h1:cEPpv4iw3Ba5W2d0AWg3TIbKeJ8y1nPuUuibR5J
 github.com/IBM/vpc-beta-go-sdk v0.8.0/go.mod h1:hORgIyTFRzXrZIK9IohaWmCRBBlYiDRagsufi7M6akE=
 github.com/IBM/vpc-go-sdk v0.70.1 h1:6NsbRkiA5gDNxe7cjNx8Pi1j9s0PlhwNQj29wsKZxAo=
 github.com/IBM/vpc-go-sdk v0.70.1/go.mod h1:K3vVlje72PYE3ZRt1iouE+jSIq+vCyYzT1HiFC06hUA=
+github.com/IBM/vpc-go-sdk v0.71.1 h1:SP5/uQs5JDb1QRvSJ1QC2BzE+BHEMq4jd2+JEcRuieE=
+github.com/IBM/vpc-go-sdk v0.71.1/go.mod h1:K3vVlje72PYE3ZRt1iouE+jSIq+vCyYzT1HiFC06hUA=
 github.com/Logicalis/asn1 v0.0.0-20190312173541-d60463189a56 h1:vuquMR410psHNax14XKNWa0Ae/kYgWJcXi0IFuX60N0=
 github.com/Logicalis/asn1 v0.0.0-20190312173541-d60463189a56/go.mod h1:Zb3OT4l0mf7P/GOs2w2Ilj5sdm5Whoq3pa24dAEBHFc=
 github.com/Microsoft/go-winio v0.6.1 h1:9/kr64B9VUZrLm5YYwbGtUJnMgqWVOdUAXu6Migciow=

--- a/ibm/service/vpc/data_source_ibm_is_bare_metal_server.go
+++ b/ibm/service/vpc/data_source_ibm_is_bare_metal_server.go
@@ -76,6 +76,27 @@ func DataSourceIBMIsBareMetalServer() *schema.Resource {
 				},
 			},
 
+			isBareMetalServerMetadataService: {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Description: "The metadata service configuration",
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						isBareMetalServerMetadataServiceEnabled: {
+							Type:        schema.TypeBool,
+							Computed:    true,
+							Description: "Indicates whether the metadata service endpoint will be available to the bare metal server",
+						},
+
+						isBareMetalServerMetadataServiceProtocol: {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "The communication protocol to use for the metadata service endpoint. Applies only when the metadata service is enabled.",
+						},
+					},
+				},
+			},
+
 			isBareMetalServerBootTarget: {
 				Type:        schema.TypeString,
 				Computed:    true,
@@ -1429,6 +1450,20 @@ func dataSourceIBMISBareMetalServerRead(context context.Context, d *schema.Resou
 		resList = append(resList, res)
 		if err = d.Set(isReservation, resList); err != nil {
 			return flex.DiscriminatedTerraformErrorf(err, fmt.Sprintf("Error setting reservation: %s", err), "(Data) ibm_is_bare_metal_server", "read", "set-reservation").GetDiag()
+		}
+	}
+
+	if bareMetalServer.MetadataService != nil {
+		metadataServiceList := make([]map[string]interface{}, 0)
+		metadataServiceMap := map[string]interface{}{}
+
+		metadataServiceMap[isBareMetalServerMetadataServiceEnabled] = *bareMetalServer.MetadataService.Enabled
+		if bareMetalServer.MetadataService.Protocol != nil {
+			metadataServiceMap[isBareMetalServerMetadataServiceProtocol] = *bareMetalServer.MetadataService.Protocol
+		}
+		metadataServiceList = append(metadataServiceList, metadataServiceMap)
+		if err = d.Set(isBareMetalServerMetadataService, metadataServiceList); err != nil {
+			return flex.DiscriminatedTerraformErrorf(err, fmt.Sprintf("Error setting metadata service: %s", err), "(Data) ibm_is_bare_metal_server", "read", "set-metadata-service").GetDiag()
 		}
 	}
 

--- a/ibm/service/vpc/data_source_ibm_is_bare_metal_server_initialization_test.go
+++ b/ibm/service/vpc/data_source_ibm_is_bare_metal_server_initialization_test.go
@@ -32,7 +32,7 @@ ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCKVmnMOlHKcZK8tpt3MP1lqOLAcqcJzhsvJcjscgVE
 				Config: testAccCheckIBMISBareMetalServerInitializationDataSourceConfig(vpcname, subnetname, sshname, publicKey, name),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckIBMISBareMetalServerExists("ibm_is_bare_metal_server.testacc_bms", server),
-					resource.TestCheckResourceAttr(resName, "name", name),
+					resource.TestCheckResourceAttrSet(resName, "default_trusted_profile.#"),
 				),
 			},
 		},
@@ -41,7 +41,8 @@ ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCKVmnMOlHKcZK8tpt3MP1lqOLAcqcJzhsvJcjscgVE
 
 func testAccCheckIBMISBareMetalServerInitializationDataSourceConfig(vpcname, subnetname, sshname, publicKey, name string) string {
 	// status filter defaults to empty
-	return testAccCheckIBMISBareMetalServerConfig(vpcname, subnetname, sshname, publicKey, name) +
+	userdata1 := "a"
+	return testAccCheckIBMISBareMetalServerInitializationConfig(vpcname, subnetname, sshname, publicKey, name, acc.IsBareMetalServerImage, userdata1, true, "https", true) +
 		fmt.Sprintf(`
       data "ibm_is_bare_metal_server_initialization" "test1" {
 		  bare_metal_server = ibm_is_bare_metal_server.testacc_bms.id

--- a/ibm/service/vpc/data_source_ibm_is_bare_metal_server_test.go
+++ b/ibm/service/vpc/data_source_ibm_is_bare_metal_server_test.go
@@ -78,6 +78,42 @@ ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCKVmnMOlHKcZK8tpt3MP1lqOLAcqcJzhsvJcjscgVE
 		},
 	})
 }
+func TestAccIBMISBMSDataSource_MetadataService(t *testing.T) {
+	resName := "data.ibm_is_bare_metal_server.test1"
+	var server string
+	vpcname := fmt.Sprintf("tf-vpc-%d", acctest.RandIntRange(10, 100))
+	name := fmt.Sprintf("tf-server-%d", acctest.RandIntRange(10, 100))
+	subnetname := fmt.Sprintf("tfip-subnet-%d", acctest.RandIntRange(10, 100))
+	publicKey := strings.TrimSpace(`
+ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCKVmnMOlHKcZK8tpt3MP1lqOLAcqcJzhsvJcjscgVERRN7/9484SOBJ3HSKxxNG5JN8owAjy5f9yYwcUg+JaUVuytn5Pv3aeYROHGGg+5G346xaq3DAwX6Y5ykr2fvjObgncQBnuU5KHWCECO/4h8uWuwh/kfniXPVjFToc+gnkqA+3RKpAecZhFXwfalQ9mMuYGFxn+fwn8cYEApsJbsEmb0iJwPiZ5hjFC8wREuiTlhPHDgkBLOiycd20op2nXzDbHfCHInquEe/gYxEitALONxm0swBOwJZwlTDOB7C6y2dzlrtxr1L59m7pCkWI4EtTRLvleehBoj3u7jB4usR
+`)
+	sshname := fmt.Sprintf("tf-sshname-%d", acctest.RandIntRange(10, 100))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { acc.TestAccPreCheck(t) },
+		Providers: acc.TestAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckIBMISBMSDataSourceMetadataServiceConfig(vpcname, subnetname, sshname, publicKey, name, true, "https"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckIBMISBareMetalServerExists("ibm_is_bare_metal_server.testacc_bms", server),
+					resource.TestCheckResourceAttrSet(resName, "metadata_service.0.enabled"),
+					resource.TestCheckResourceAttrSet(resName, "metadata_service.0.protocol"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckIBMISBMSDataSourceMetadataServiceConfig(vpcname, subnetname, sshname, publicKey, name string, enabled bool, protocol string) string {
+	// status filter defaults to empty
+	return testAccCheckIBMISBareMetalServerMetadataServiceConfig(vpcname, subnetname, sshname, publicKey, name, enabled, protocol) + fmt.Sprintf(`
+      data "ibm_is_bare_metal_server" "test1" {
+	  	depends_on	= [ ibm_is_bare_metal_server.testacc_bms ]
+       name 			=	"%s"
+      }`, name)
+}
+
 func TestAccIBMISBMSDataSourceVNI_basic(t *testing.T) {
 	var server string
 	resName := "data.ibm_is_bare_metal_server.test1"

--- a/ibm/service/vpc/data_source_ibm_is_bare_metal_servers.go
+++ b/ibm/service/vpc/data_source_ibm_is_bare_metal_servers.go
@@ -119,6 +119,26 @@ func DataSourceIBMIsBareMetalServers() *schema.Resource {
 								},
 							},
 						},
+						isBareMetalServerMetadataService: {
+							Type:        schema.TypeList,
+							Computed:    true,
+							Description: "The metadata service configuration",
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									isBareMetalServerMetadataServiceEnabled: {
+										Type:        schema.TypeBool,
+										Computed:    true,
+										Description: "Indicates whether the metadata service endpoint will be available to the bare metal server",
+									},
+
+									isBareMetalServerMetadataServiceProtocol: {
+										Type:        schema.TypeString,
+										Computed:    true,
+										Description: "The communication protocol to use for the metadata service endpoint. Applies only when the metadata service is enabled.",
+									},
+								},
+							},
+						},
 						isBareMetalServerBootTarget: {
 							Type:        schema.TypeString,
 							Computed:    true,
@@ -1406,6 +1426,17 @@ func dataSourceIBMISBareMetalServersRead(context context.Context, d *schema.Reso
 			}
 			resList = append(resList, res)
 			l[isReservation] = resList
+		}
+		if bms.MetadataService != nil {
+			metadataServiceList := make([]map[string]interface{}, 0)
+			metadataServiceMap := map[string]interface{}{}
+
+			metadataServiceMap[isBareMetalServerMetadataServiceEnabled] = *bms.MetadataService.Enabled
+			if bms.MetadataService.Protocol != nil {
+				metadataServiceMap[isBareMetalServerMetadataServiceProtocol] = *bms.MetadataService.Protocol
+			}
+			metadataServiceList = append(metadataServiceList, metadataServiceMap)
+			l[isBareMetalServerMetadataService] = metadataServiceList
 		}
 		serversInfo = append(serversInfo, l)
 	}

--- a/ibm/service/vpc/data_source_ibm_is_bare_metal_servers_test.go
+++ b/ibm/service/vpc/data_source_ibm_is_bare_metal_servers_test.go
@@ -76,6 +76,41 @@ ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCKVmnMOlHKcZK8tpt3MP1lqOLAcqcJzhsvJcjscgVE
 	})
 }
 
+func TestAccIBMISBMSsDataSource_MetadataService(t *testing.T) {
+	resName := "data.ibm_is_bare_metal_servers.test1"
+	var server string
+	vpcname := fmt.Sprintf("tf-vpc-%d", acctest.RandIntRange(10, 100))
+	name := fmt.Sprintf("tf-server-%d", acctest.RandIntRange(10, 100))
+	subnetname := fmt.Sprintf("tfip-subnet-%d", acctest.RandIntRange(10, 100))
+	publicKey := strings.TrimSpace(`
+ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCKVmnMOlHKcZK8tpt3MP1lqOLAcqcJzhsvJcjscgVERRN7/9484SOBJ3HSKxxNG5JN8owAjy5f9yYwcUg+JaUVuytn5Pv3aeYROHGGg+5G346xaq3DAwX6Y5ykr2fvjObgncQBnuU5KHWCECO/4h8uWuwh/kfniXPVjFToc+gnkqA+3RKpAecZhFXwfalQ9mMuYGFxn+fwn8cYEApsJbsEmb0iJwPiZ5hjFC8wREuiTlhPHDgkBLOiycd20op2nXzDbHfCHInquEe/gYxEitALONxm0swBOwJZwlTDOB7C6y2dzlrtxr1L59m7pCkWI4EtTRLvleehBoj3u7jB4usR
+`)
+	sshname := fmt.Sprintf("tf-sshname-%d", acctest.RandIntRange(10, 100))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { acc.TestAccPreCheck(t) },
+		Providers: acc.TestAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckIBMISBMSsDataSourceMetadataServiceConfig(vpcname, subnetname, sshname, publicKey, name, true, "https"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckIBMISBareMetalServerExists("ibm_is_bare_metal_server.testacc_bms", server),
+					resource.TestCheckResourceAttrSet(resName, "servers.0.metadata_service.0.enabled"),
+					resource.TestCheckResourceAttrSet(resName, "servers.0.metadata_service.0.protocol"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckIBMISBMSsDataSourceMetadataServiceConfig(vpcname, subnetname, sshname, publicKey, name string, enabled bool, protocol string) string {
+	// status filter defaults to empty
+	return testAccCheckIBMISBareMetalServerMetadataServiceConfig(vpcname, subnetname, sshname, publicKey, name, enabled, protocol) + fmt.Sprintf(`
+      data "ibm_is_bare_metal_servers" "test1" {
+	  		depends_on = [ ibm_is_bare_metal_server.testacc_bms ]
+      }`)
+}
+
 func testAccCheckIBMISBMSsDataSourceConfig(vpcname, subnetname, sshname, publicKey, name string) string {
 	// status filter defaults to empty
 	return testAccCheckIBMISBareMetalServerConfig(vpcname, subnetname, sshname, publicKey, name) + fmt.Sprintf(`

--- a/ibm/service/vpc/resource_ibm_is_bare_metal_server.go
+++ b/ibm/service/vpc/resource_ibm_is_bare_metal_server.go
@@ -172,6 +172,7 @@ func ResourceIBMIsBareMetalServer() *schema.Resource {
 
 			isBareMetalServerMetadataService: {
 				Type:        schema.TypeList,
+				MaxItems:    1,
 				Optional:    true,
 				Computed:    true,
 				Description: "The metadata service configuration",

--- a/ibm/service/vpc/resource_ibm_is_bare_metal_server.go
+++ b/ibm/service/vpc/resource_ibm_is_bare_metal_server.go
@@ -66,6 +66,7 @@ const (
 	isBareMetalServerFirmwareUpdateTypeAvailable         = "firmware_update_type_available"
 	isBareMetalServerKeys                                = "keys"
 	isBareMetalServerUserData                            = "user_data"
+	isBareMetalServerDefaultTrustedProfile               = "default_trusted_profile"
 	isBareMetalServerNicName                             = "name"
 	isBareMetalServerNicPortSpeed                        = "port_speed"
 	isBareMetalServerNicAllowIPSpoofing                  = "allow_ip_spoofing"
@@ -84,6 +85,9 @@ const (
 	isBareMetalServerAccessTags                          = "access_tags"
 	isBareMetalServerUserTagType                         = "user"
 	isBareMetalServerAccessTagType                       = "access"
+	isBareMetalServerMetadataService                     = "metadata_service"
+	isBareMetalServerMetadataServiceEnabled              = "enabled"
+	isBareMetalServerMetadataServiceProtocol             = "protocol"
 )
 
 func ResourceIBMIsBareMetalServer() *schema.Resource {
@@ -161,6 +165,31 @@ func ResourceIBMIsBareMetalServer() *schema.Resource {
 							Set:         flex.ResourceIBMVPCHash,
 							Computed:    true,
 							Description: "The trusted platform module (TPM) mode:: disabled: No TPM functionality, tpm_2: TPM 2.0. The enumerated values for this property are expected to expand in the future. When processing this property, check for and log unknown values. Optionally halt processing and surface the error, or bypass the resource on which the unexpected property value was encountered. Enum: [ disabled, tpm_2 ]",
+						},
+					},
+				},
+			},
+
+			isBareMetalServerMetadataService: {
+				Type:        schema.TypeList,
+				Optional:    true,
+				Computed:    true,
+				Description: "The metadata service configuration",
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						isBareMetalServerMetadataServiceEnabled: {
+							Type:        schema.TypeBool,
+							Optional:    true,
+							Computed:    true,
+							Description: "Indicates whether the metadata service endpoint will be available to the bare metal server",
+						},
+
+						isBareMetalServerMetadataServiceProtocol: {
+							Type:         schema.TypeString,
+							Optional:     true,
+							Computed:     true,
+							Description:  "The communication protocol to use for the metadata service endpoint. Applies only when the metadata service is enabled.",
+							ValidateFunc: validate.InvokeValidator("ibm_is_bare_metal_server", isBareMetalServerMetadataServiceProtocol),
 						},
 					},
 				},
@@ -1107,6 +1136,44 @@ func ResourceIBMIsBareMetalServer() *schema.Resource {
 				Required:    true,
 				Description: "image id",
 			},
+
+			isBareMetalServerDefaultTrustedProfile: {
+				Type:     schema.TypeList,
+				Optional: true,
+				MaxItems: 1,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"auto_link": {
+							Type:        schema.TypeBool,
+							Optional:    true,
+							Description: "If set to true, the system will create a link to the specified target trusted profile during server creation. Regardless of whether a link is created by the system or manually using the IAM Identity service, it will be automatically deleted when the server is deleted.",
+						},
+						"target": {
+							Type:        schema.TypeList,
+							Optional:    true,
+							MaxItems:    1,
+							Description: "The default IAM trusted profile to use for this bare metal server",
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"id": {
+										Type:          schema.TypeString,
+										Optional:      true,
+										Description:   "The unique identifier for this trusted profile",
+										ConflictsWith: []string{"default_trusted_profile.0.target.0.crn"},
+									},
+									"crn": {
+										Type:          schema.TypeString,
+										Optional:      true,
+										Description:   "The CRN for this trusted profile",
+										ConflictsWith: []string{"default_trusted_profile.0.target.0.id"},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+
 			isBareMetalServerProfile: {
 				Type:        schema.TypeString,
 				ForceNew:    true,
@@ -1346,6 +1413,7 @@ func ResourceIBMIsBareMetalServerValidator() *validate.ResourceValidator {
 	bareMetalServerActions := "start, restart, stop"
 	tpmModes := "disabled, tpm_2"
 	interface_types := "pci, hipersocket"
+	metadataServiceProtocol := "https, http"
 	validateSchema := make([]validate.ValidateSchema, 1)
 
 	validateSchema = append(validateSchema,
@@ -1390,7 +1458,13 @@ func ResourceIBMIsBareMetalServerValidator() *validate.ResourceValidator {
 			Type:                       validate.TypeString,
 			Required:                   true,
 			AllowedValues:              tpmModes})
-
+	validateSchema = append(validateSchema,
+		validate.ValidateSchema{
+			Identifier:                 isBareMetalServerMetadataServiceProtocol,
+			ValidateFunctionIdentifier: validate.ValidateAllowedStringValue,
+			Type:                       validate.TypeString,
+			Optional:                   true,
+			AllowedValues:              metadataServiceProtocol})
 	validateSchema = append(validateSchema,
 		validate.ValidateSchema{
 			Identifier:                 "accesstag",
@@ -1458,6 +1532,53 @@ func resourceIBMISBareMetalServerCreate(context context.Context, d *schema.Resou
 			userdatastr := userdata.(string)
 			options.Initialization.UserData = &userdatastr
 		}
+
+		if defaultTrustedProfile, ok := d.GetOk(isBareMetalServerDefaultTrustedProfile); ok {
+			defaultTrustedProfilePrototype := &vpcv1.BareMetalServerInitializationDefaultTrustedProfilePrototype{}
+			defaultTrustedProfileMap := defaultTrustedProfile.([]interface{})[0].(map[string]interface{})
+			if autoLinkIntf, ok := defaultTrustedProfileMap["auto_link"]; ok {
+				if autolink, ok := autoLinkIntf.(bool); ok {
+					defaultTrustedProfilePrototype.AutoLink = &autolink
+				}
+			}
+
+			if targetIntf, ok := defaultTrustedProfileMap["target"]; ok {
+				if targetList, ok := targetIntf.([]interface{}); ok && len(targetList) > 0 {
+					if targetMap, ok := targetList[0].(map[string]interface{}); ok {
+						var id, crn *string
+						if crnStr, ok := targetMap["crn"].(string); ok && crnStr != "" {
+							crn = &crnStr
+						} else if idStr, ok := targetMap["id"].(string); ok && idStr != "" {
+							id = &idStr
+						}
+
+						if crn != nil || id != nil {
+							defaultTrustedProfilePrototype.Target = &vpcv1.TrustedProfileIdentity{
+								CRN: crn,
+								ID:  id,
+							}
+						}
+					}
+				}
+			}
+			options.Initialization.DefaultTrustedProfile = defaultTrustedProfilePrototype
+		}
+	}
+
+	if metadataServiceIntf, ok := d.GetOk(isBareMetalServerMetadataService); ok {
+		metadataService := &vpcv1.BareMetalServerMetadataServicePrototype{}
+		metadataServiceMap := metadataServiceIntf.([]interface{})[0].(map[string]interface{})
+		enabledIntf, ok := metadataServiceMap[isBareMetalServerMetadataServiceEnabled]
+		if ok {
+			enabled := enabledIntf.(bool)
+			metadataService.Enabled = &enabled
+		}
+		protocolIntf, ok := metadataServiceMap[isBareMetalServerMetadataServiceProtocol]
+		if ok && protocolIntf.(string) != "" {
+			protocol := protocolIntf.(string)
+			metadataService.Protocol = &protocol
+		}
+		options.MetadataService = metadataService
 	}
 
 	if name, ok := d.GetOk(isBareMetalServerName); ok {
@@ -2475,6 +2596,21 @@ func bareMetalServerGet(context context.Context, d *schema.ResourceData, meta in
 		err = fmt.Errorf("Error setting reservation: %s", err)
 		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_is_bare_metal_server", "read", "set-reservation").GetDiag()
 	}
+	if bms.MetadataService != nil {
+		metadataServiceList := make([]map[string]interface{}, 0)
+		metadataServiceMap := map[string]interface{}{}
+
+		metadataServiceMap[isBareMetalServerMetadataServiceEnabled] = *bms.MetadataService.Enabled
+		if bms.MetadataService.Protocol != nil {
+			metadataServiceMap[isBareMetalServerMetadataServiceProtocol] = *bms.MetadataService.Protocol
+		}
+		metadataServiceList = append(metadataServiceList, metadataServiceMap)
+		if err = d.Set(isBareMetalServerMetadataService, metadataServiceList); err != nil {
+			err = fmt.Errorf("Error setting metadata_service: %s", err)
+			return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_is_bare_metal_server", "read", "set-metadata_service").GetDiag()
+		}
+	}
+
 	if !core.IsNil(bms.PrimaryNetworkAttachment) {
 		pnaId := *bms.PrimaryNetworkAttachment.ID
 		getBareMetalServerNetworkAttachment := &vpcv1.GetBareMetalServerNetworkAttachmentOptions{
@@ -2741,7 +2877,7 @@ func bareMetalServerUpdate(context context.Context, d *schema.ResourceData, meta
 		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
 		return tfErr.GetDiag()
 	}
-	if d.HasChange("image") || d.HasChange("keys") || d.HasChange("user_data") {
+	if d.HasChange("image") || d.HasChange("keys") || d.HasChange("user_data") || d.HasChange("default_trusted_profile") {
 		stopServerIfStartingForInitialization := false
 		newImageId := d.Get("image").(string)
 		initializationPatch := &vpcv1.ReplaceBareMetalServerInitializationOptions{
@@ -2764,6 +2900,30 @@ func bareMetalServerUpdate(context context.Context, d *schema.ResourceData, meta
 				}
 			}
 			initializationPatch.Keys = keyobjs
+		}
+
+		defaultTrustedProfile := &vpcv1.BareMetalServerInitializationDefaultTrustedProfilePrototype{}
+		if d.HasChange("default_trusted_profile.0.auto_link") {
+			newAutoLink := d.Get("default_trusted_profile.0.auto_link").(bool)
+			defaultTrustedProfile.AutoLink = &newAutoLink
+		}
+
+		if d.HasChange("default_trusted_profile.0.target.0.id") {
+			newTargetID := d.Get("default_trusted_profile.0.target.0.id").(string)
+			defaultTrustedProfile.Target = &vpcv1.TrustedProfileIdentity{
+				ID: &newTargetID,
+			}
+		}
+
+		if d.HasChange("default_trusted_profile.0.target.0.crn") {
+			newTargetCRN := d.Get("default_trusted_profile.0.target.0.crn").(string)
+			defaultTrustedProfile.Target = &vpcv1.TrustedProfileIdentity{
+				CRN: &newTargetCRN,
+			}
+		}
+
+		if defaultTrustedProfile.AutoLink != nil || defaultTrustedProfile.Target != nil {
+			initializationPatch.DefaultTrustedProfile = defaultTrustedProfile
 		}
 
 		stopServerIfStartingForInitialization, err = resourceStopServerIfRunning(id, "hard", d, context, sess, stopServerIfStartingForInitialization)
@@ -3998,6 +4158,28 @@ func bareMetalServerUpdate(context context.Context, d *schema.ResourceData, meta
 		newEnableSecureBoot := d.Get(isBareMetalServerEnableSecureBoot).(bool)
 		bmsPatchModel.EnableSecureBoot = &newEnableSecureBoot
 		flag = true
+		isServerStopped, err = resourceStopServerIfRunning(id, "hard", d, context, sess, isServerStopped)
+		if err != nil {
+			tfErr := flex.TerraformErrorf(err, fmt.Sprintf("resourceStopServerIfRunning failed: %s", err.Error()), "ibm_is_bare_metal_server", "update")
+			log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+			return tfErr.GetDiag()
+		}
+	}
+
+	//MetadataService
+	if d.HasChange("metadata_service") {
+		bareMetalServerMetadataService := &vpcv1.BareMetalServerMetadataServicePatch{}
+		if d.HasChange("metadata_service.0.enabled") {
+			flag = true
+			metadataServiceEnabled := d.Get("metadata_service.0.enabled").(bool)
+			bareMetalServerMetadataService.Enabled = &metadataServiceEnabled
+		}
+		if d.HasChange("metadata_service.0.protocol") {
+			flag = true
+			metadataServiceProtocol := d.Get("metadata_service.0.protocol").(string)
+			bareMetalServerMetadataService.Protocol = &metadataServiceProtocol
+		}
+		bmsPatchModel.MetadataService = bareMetalServerMetadataService
 		isServerStopped, err = resourceStopServerIfRunning(id, "hard", d, context, sess, isServerStopped)
 		if err != nil {
 			tfErr := flex.TerraformErrorf(err, fmt.Sprintf("resourceStopServerIfRunning failed: %s", err.Error()), "ibm_is_bare_metal_server", "update")

--- a/ibm/service/vpc/resource_ibm_is_bare_metal_server_initialization.go
+++ b/ibm/service/vpc/resource_ibm_is_bare_metal_server_initialization.go
@@ -39,22 +39,23 @@ func ResourceIBMIsBareMetalServerInitialization() *schema.Resource {
 				Description: "Bare metal server identifier",
 			},
 			isBareMetalServerDefaultTrustedProfile: {
-				Type:     schema.TypeList,
-				Optional: true,
-				Computed: true,
-				MaxItems: 1,
+				Type:        schema.TypeList,
+				Optional:    true,
+				ForceNew:    true,
+				MaxItems:    1,
+				Description: "The default trusted profile configuration for the bare metal server",
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"auto_link": {
 							Type:        schema.TypeBool,
 							Optional:    true,
-							Computed:    true,
-							Description: "If set to true, the system will create a link to the specified target trusted profile during server creation. Regardless of whether a link is created by the system or manually using the IAM Identity service, it will be automatically deleted when the server is deleted.",
+							ForceNew:    true,
+							Description: "If set to true, the system will create a link to the specified target trusted profile during server initialization.",
 						},
 						"target": {
 							Type:        schema.TypeList,
 							Optional:    true,
-							Computed:    true,
+							ForceNew:    true,
 							MaxItems:    1,
 							Description: "The default IAM trusted profile to use for this bare metal server",
 							Elem: &schema.Resource{
@@ -62,14 +63,14 @@ func ResourceIBMIsBareMetalServerInitialization() *schema.Resource {
 									"id": {
 										Type:          schema.TypeString,
 										Optional:      true,
-										Computed:      true,
+										ForceNew:      true,
 										Description:   "The unique identifier for this trusted profile",
 										ConflictsWith: []string{"default_trusted_profile.0.target.0.crn"},
 									},
 									"crn": {
 										Type:          schema.TypeString,
 										Optional:      true,
-										Computed:      true,
+										ForceNew:      true,
 										Description:   "The CRN for this trusted profile",
 										ConflictsWith: []string{"default_trusted_profile.0.target.0.id"},
 									},

--- a/ibm/service/vpc/resource_ibm_is_bare_metal_server_initialization_test.go
+++ b/ibm/service/vpc/resource_ibm_is_bare_metal_server_initialization_test.go
@@ -40,6 +40,8 @@ ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCKVmnMOlHKcZK8tpt3MP1lqOLAcqcJzhsvJcjscgVE
 					resource.TestCheckResourceAttr(
 						"ibm_is_bare_metal_server.testacc_bms", "user_data", userdata),
 					resource.TestCheckResourceAttr(
+						"ibm_is_bare_metal_server.testacc_bms", "metadata_service.0.protocol", "https"),
+					resource.TestCheckResourceAttr(
 						"ibm_is_bare_metal_server.testacc_bms", "image", acc.IsBareMetalServerImage),
 				),
 			},
@@ -53,8 +55,51 @@ ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCKVmnMOlHKcZK8tpt3MP1lqOLAcqcJzhsvJcjscgVE
 						"ibm_is_bare_metal_server.testacc_bms", "zone", acc.ISZoneName),
 					resource.TestCheckResourceAttr(
 						"ibm_is_bare_metal_server.testacc_bms", "user_data", userdata),
+					resource.TestCheckResourceAttr(
+						"ibm_is_bare_metal_server.testacc_bms", "metadata_service.0.protocol", "https"),
 					resource.TestCheckResourceAttrSet(
 						"ibm_is_bare_metal_server_initialization.testacc_bms_initialization", "id"),
+					resource.TestCheckResourceAttrSet(
+						"ibm_is_bare_metal_server_initialization.testacc_bms_initialization", "metadata_service"),
+					resource.TestCheckResourceAttr(
+						"ibm_is_bare_metal_server.testacc_bms", "image", acc.IsBareMetalServerImage),
+				),
+			},
+		},
+	})
+}
+
+func TestAccIBMISBareMetalServerreInitWithDefaultTrustedProfile(t *testing.T) {
+	var server string
+	vpcname := fmt.Sprintf("tf-vpc-%d", acctest.RandIntRange(10, 100))
+	name := fmt.Sprintf("tf-server-%d", acctest.RandIntRange(10, 100))
+	subnetname := fmt.Sprintf("tfip-subnet-%d", acctest.RandIntRange(10, 100))
+	publicKey := strings.TrimSpace(`
+ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCKVmnMOlHKcZK8tpt3MP1lqOLAcqcJzhsvJcjscgVERRN7/9484SOBJ3HSKxxNG5JN8owAjy5f9yYwcUg+JaUVuytn5Pv3aeYROHGGg+5G346xaq3DAwX6Y5ykr2fvjObgncQBnuU5KHWCECO/4h8uWuwh/kfniXPVjFToc+gnkqA+3RKpAecZhFXwfalQ9mMuYGFxn+fwn8cYEApsJbsEmb0iJwPiZ5hjFC8wREuiTlhPHDgkBLOiycd20op2nXzDbHfCHInquEe/gYxEitALONxm0swBOwJZwlTDOB7C6y2dzlrtxr1L59m7pCkWI4EtTRLvleehBoj3u7jB4usR
+`)
+	sshname := fmt.Sprintf("tf-sshname-%d", acctest.RandIntRange(10, 100))
+	userdata := "a"
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { acc.TestAccPreCheck(t) },
+		Providers:    acc.TestAccProviders,
+		CheckDestroy: testAccCheckIBMISBareMetalServerDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckIBMISBareMetalMetaDataServerInitializationConfig(vpcname, subnetname, sshname, publicKey, name, userdata, userdata),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckIBMISBareMetalServerExists("ibm_is_bare_metal_server.testacc_bms", server),
+					resource.TestCheckResourceAttr(
+						"ibm_is_bare_metal_server.testacc_bms", "name", name),
+					resource.TestCheckResourceAttr(
+						"ibm_is_bare_metal_server.testacc_bms", "zone", acc.ISZoneName2),
+					resource.TestCheckResourceAttr(
+						"ibm_is_bare_metal_server.testacc_bms", "user_data", userdata),
+					resource.TestCheckResourceAttr(
+						"ibm_is_bare_metal_server.testacc_bms", "metadata_service.0.protocol", "https"),
+					resource.TestCheckResourceAttrSet(
+						"ibm_is_bare_metal_server_initialization.testacc_bms_initialization", "id"),
+					resource.TestCheckResourceAttrSet(
+						"ibm_is_bare_metal_server_initialization.testacc_bms_initialization", "default_trusted_profile.#"),
 					resource.TestCheckResourceAttr(
 						"ibm_is_bare_metal_server.testacc_bms", "image", acc.IsBareMetalServerImage),
 				),
@@ -134,7 +179,61 @@ func testAccCheckIBMISBareMetalServerInitializationReplaceConfigUpdate(vpcname, 
 			image				= "%s"
 			keys				= [ibm_is_ssh_key.testacc_sshkey.id]
 			user_data         	= "%s"
+			}
 		}
 		
 `, vpcname, subnetname, acc.ISZoneName, sshname, publicKey, acc.IsBareMetalServerProfileName, name, acc.IsBareMetalServerImage, acc.ISZoneName, userData1, acc.IsBareMetalServerImage2, userData2)
+}
+
+func testAccCheckIBMISBareMetalMetaDataServerInitializationConfig(vpcname, subnetname, sshname, publicKey, name, userData1, userData2 string) string {
+	return fmt.Sprintf(`
+		resource "ibm_is_vpc" "testacc_vpc" {
+			name = "%s"
+		}
+	  
+		resource "ibm_is_subnet" "testacc_subnet" {
+			name            			= "%s"
+			vpc             			= ibm_is_vpc.testacc_vpc.id
+			zone            			= "%s"
+			total_ipv4_address_count 	= 16
+		}
+	  
+		resource "ibm_is_ssh_key" "testacc_sshkey" {
+			name       			= "%s"
+			public_key 			= "%s"
+		}
+	  
+		resource "ibm_is_bare_metal_server" "testacc_bms" {
+			profile 			= "%s"
+			name 				= "%s"
+			image 				= "%s"
+			zone 				= "%s"
+			user_data         	= "%s"
+			keys 				= [ibm_is_ssh_key.testacc_sshkey.id]
+			primary_network_interface {
+				subnet     		= ibm_is_subnet.testacc_subnet.id
+			}
+			vpc 				= ibm_is_vpc.testacc_vpc.id
+			metadata_service {
+				enabled  = true
+				protocol = "https"
+			}
+			lifecycle {
+				ignore_changes = [ image, keys, user_data, metadata_service ]
+			}
+		}
+		resource "ibm_is_bare_metal_server_initialization" "testacc_bms_initialization" {
+			bare_metal_server 	= ibm_is_bare_metal_server.testacc_bms.id
+			image				= "%s"
+			keys				= [ibm_is_ssh_key.testacc_sshkey.id]
+			user_data         	= "%s"
+			default_trusted_profile {
+				auto_link = true
+				target {
+					id = "%s"
+				}
+			}
+		}
+		
+`, vpcname, subnetname, acc.ISZoneName2, sshname, publicKey, acc.IsBareMetalServerProfileName, name, acc.IsBareMetalServerImage, acc.ISZoneName2, userData1, acc.IsBareMetalServerImage, userData2, acc.IAMTrustedProfileID)
 }

--- a/ibm/service/vpc/resource_ibm_is_bare_metal_server_test.go
+++ b/ibm/service/vpc/resource_ibm_is_bare_metal_server_test.go
@@ -516,6 +516,120 @@ ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCKVmnMOlHKcZK8tpt3MP1lqOLAcqcJzhsvJcjscgVE
 	})
 }
 
+func TestAccIBMISBareMetalServer_MetadataService(t *testing.T) {
+	var server string
+	vpcname := fmt.Sprintf("tf-vpc-%d", acctest.RandIntRange(10, 100))
+	name := fmt.Sprintf("tf-server-%d", acctest.RandIntRange(10, 100))
+	subnetname := fmt.Sprintf("tfip-subnet-%d", acctest.RandIntRange(10, 100))
+	publicKey := strings.TrimSpace(`
+ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCKVmnMOlHKcZK8tpt3MP1lqOLAcqcJzhsvJcjscgVERRN7/9484SOBJ3HSKxxNG5JN8owAjy5f9yYwcUg+JaUVuytn5Pv3aeYROHGGg+5G346xaq3DAwX6Y5ykr2fvjObgncQBnuU5KHWCECO/4h8uWuwh/kfniXPVjFToc+gnkqA+3RKpAecZhFXwfalQ9mMuYGFxn+fwn8cYEApsJbsEmb0iJwPiZ5hjFC8wREuiTlhPHDgkBLOiycd20op2nXzDbHfCHInquEe/gYxEitALONxm0swBOwJZwlTDOB7C6y2dzlrtxr1L59m7pCkWI4EtTRLvleehBoj3u7jB4usR
+`)
+	sshname := fmt.Sprintf("tf-sshname-%d", acctest.RandIntRange(10, 100))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { acc.TestAccPreCheck(t) },
+		Providers:    acc.TestAccProviders,
+		CheckDestroy: testAccCheckIBMISBareMetalServerDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckIBMISBareMetalServerMetadataServiceConfig(vpcname, subnetname, sshname, publicKey, name, true, "https"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckIBMISBareMetalServerExists("ibm_is_bare_metal_server.testacc_bms", server),
+					resource.TestCheckResourceAttr(
+						"ibm_is_bare_metal_server.testacc_bms", "name", name),
+					resource.TestCheckResourceAttr(
+						"ibm_is_bare_metal_server.testacc_bms", "zone", acc.ISZoneName2),
+					resource.TestCheckResourceAttr(
+						"ibm_is_bare_metal_server.testacc_bms", "metadata_service.0.enabled", "true"),
+					resource.TestCheckResourceAttr(
+						"ibm_is_bare_metal_server.testacc_bms", "metadata_service.0.protocol", "https"),
+				),
+			},
+			{
+				Config: testAccCheckIBMISBareMetalServerMetadataServiceConfig(vpcname, subnetname, sshname, publicKey, name, true, "http"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckIBMISBareMetalServerExists("ibm_is_bare_metal_server.testacc_bms", server),
+					resource.TestCheckResourceAttr(
+						"ibm_is_bare_metal_server.testacc_bms", "name", name),
+					resource.TestCheckResourceAttr(
+						"ibm_is_bare_metal_server.testacc_bms", "zone", acc.ISZoneName2),
+					resource.TestCheckResourceAttr(
+						"ibm_is_bare_metal_server.testacc_bms", "metadata_service.0.enabled", "true"),
+					resource.TestCheckResourceAttr(
+						"ibm_is_bare_metal_server.testacc_bms", "metadata_service.0.protocol", "http"),
+				),
+			},
+		},
+	})
+}
+func testAccCheckIBMISBareMetalServerDefaultConfig(vpcname, subnetname, sshname, publicKey, name string) string {
+	return fmt.Sprintf(`
+		resource "ibm_is_vpc" "testacc_vpc" {
+			name = "%s"
+		}
+	  
+		resource "ibm_is_subnet" "testacc_subnet" {
+			name            			= "%s"
+			vpc             			= ibm_is_vpc.testacc_vpc.id
+			zone            			= "%s"
+			total_ipv4_address_count 	= 16
+		}
+	  
+		resource "ibm_is_ssh_key" "testacc_sshkey" {
+			name       			= "%s"
+			public_key 			= "%s"
+		}
+	  
+		resource "ibm_is_bare_metal_server" "testacc_bms" {
+			profile 			= "%s"
+			name 				= "%s"
+			image 				= "%s"
+			zone 				= "%s"
+			keys 				= [ibm_is_ssh_key.testacc_sshkey.id]
+			primary_network_interface {
+				subnet     		= ibm_is_subnet.testacc_subnet.id
+			}
+			vpc 				= ibm_is_vpc.testacc_vpc.id
+		}
+`, vpcname, subnetname, acc.ISZoneName, sshname, publicKey, acc.IsBareMetalServerProfileName, name, acc.IsBareMetalServerImage, acc.ISZoneName)
+}
+
+func testAccCheckIBMISBareMetalServerMetadataServiceConfig(vpcname, subnetname, sshname, publicKey, name string, enabled bool, protocol string) string {
+	return fmt.Sprintf(`
+		resource "ibm_is_vpc" "testacc_vpc" {
+			name = "%s"
+		}
+	  
+		resource "ibm_is_subnet" "testacc_subnet" {
+			name            			= "%s"
+			vpc             			= ibm_is_vpc.testacc_vpc.id
+			zone            			= "%s"
+			total_ipv4_address_count 	= 16
+		}
+	  
+		resource "ibm_is_ssh_key" "testacc_sshkey" {
+			name       			= "%s"
+			public_key 			= "%s"
+		}
+	  
+		resource "ibm_is_bare_metal_server" "testacc_bms" {
+			profile 			= "%s"
+			name 				= "%s"
+			image 				= "%s"
+			zone 				= "%s"
+			keys 				= [ibm_is_ssh_key.testacc_sshkey.id]
+			primary_network_interface {
+				subnet     		= ibm_is_subnet.testacc_subnet.id
+			}
+			vpc 				= ibm_is_vpc.testacc_vpc.id
+			metadata_service {
+				enabled     	= %t
+				protocol        = "%s"
+			}
+		}
+`, vpcname, subnetname, acc.ISZoneName2, sshname, publicKey, acc.IsBareMetalServerProfileName, name, acc.IsBareMetalServerImage, acc.ISZoneName2, enabled, protocol)
+}
+
 func testAccCheckIBMISBareMetalServerReservationConfig(vpcname, subnetname, sshname, publicKey, name string) string {
 	return fmt.Sprintf(`
 		resource "ibm_is_vpc" "testacc_vpc" {
@@ -594,6 +708,11 @@ func testAccCheckIBMISBareMetalServerExists(n, ip string) resource.TestCheckFunc
 			return err
 		}
 		ip = *bms.ID
+		println()
+		fmt.Printf("%+v", *bms)
+		fmt.Printf("%+v", *bms.MetadataService)
+		fmt.Printf("%+v", *bms.MetadataService.Enabled)
+		fmt.Printf("%+v", *bms.MetadataService.Protocol)
 		return nil
 	}
 }
@@ -1069,42 +1188,50 @@ ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCKVmnMOlHKcZK8tpt3MP1lqOLAcqcJzhsvJcjscgVE
 		CheckDestroy: testAccCheckIBMISBareMetalServerDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckIBMISBareMetalServerInitializationConfig(vpcname, subnetname, sshname, publicKey, name, acc.IsBareMetalServerImage, userdata1),
+				Config: testAccCheckIBMISBareMetalServerInitializationConfig(vpcname, subnetname, sshname, publicKey, name, acc.IsBareMetalServerImage, userdata1, true, "https", true),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckIBMISBareMetalServerExists("ibm_is_bare_metal_server.testacc_bms", server),
 					resource.TestCheckResourceAttr(
 						"ibm_is_bare_metal_server.testacc_bms", "name", name),
 					resource.TestCheckResourceAttr(
-						"ibm_is_bare_metal_server.testacc_bms", "zone", acc.ISZoneName),
+						"ibm_is_bare_metal_server.testacc_bms", "zone", acc.ISZoneName2),
 					resource.TestCheckResourceAttr(
 						"ibm_is_bare_metal_server.testacc_bms", "image", acc.IsBareMetalServerImage),
 					resource.TestCheckResourceAttrSet(
 						"ibm_is_bare_metal_server.testacc_bms", "keys.#"),
 					resource.TestCheckResourceAttr(
 						"ibm_is_bare_metal_server.testacc_bms", "user_data", userdata1),
+					resource.TestCheckResourceAttr(
+						"ibm_is_bare_metal_server.testacc_bms", "default_trusted_profile.0.auto_link", "true"),
+					resource.TestCheckResourceAttr(
+						"ibm_is_bare_metal_server.testacc_bms", "default_trusted_profile.0.target.0.id", acc.IAMTrustedProfileID),
 				),
 			},
 			{
-				Config: testAccCheckIBMISBareMetalServerInitializationConfig(vpcname, subnetname, sshname, publicKey, name, acc.IsBareMetalServerImage2, userdata2),
+				Config: testAccCheckIBMISBareMetalServerInitializationConfig(vpcname, subnetname, sshname, publicKey, name, acc.IsBareMetalServerImage2, userdata2, false, "http", true),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckIBMISBareMetalServerExists("ibm_is_bare_metal_server.testacc_bms", server),
 					resource.TestCheckResourceAttr(
 						"ibm_is_bare_metal_server.testacc_bms", "name", name),
 					resource.TestCheckResourceAttr(
-						"ibm_is_bare_metal_server.testacc_bms", "zone", acc.ISZoneName),
+						"ibm_is_bare_metal_server.testacc_bms", "zone", acc.ISZoneName2),
 					resource.TestCheckResourceAttr(
 						"ibm_is_bare_metal_server.testacc_bms", "image", acc.IsBareMetalServerImage2),
 					resource.TestCheckResourceAttrSet(
 						"ibm_is_bare_metal_server.testacc_bms", "keys.#"),
 					resource.TestCheckResourceAttr(
 						"ibm_is_bare_metal_server.testacc_bms", "user_data", userdata2),
+					resource.TestCheckResourceAttr(
+						"ibm_is_bare_metal_server.testacc_bms", "default_trusted_profile.0.auto_link", "true"),
+					resource.TestCheckResourceAttr(
+						"ibm_is_bare_metal_server.testacc_bms", "default_trusted_profile.0.target.0.id", acc.IAMTrustedProfileID),
 				),
 			},
 		},
 	})
 }
 
-func testAccCheckIBMISBareMetalServerInitializationConfig(vpcname, subnetname, sshname, publicKey, name, image, userdata string) string {
+func testAccCheckIBMISBareMetalServerInitializationConfig(vpcname, subnetname, sshname, publicKey, name, image, userdata string, metadataEnabled bool, metadataProtocol string, autolink bool) string {
 	return fmt.Sprintf(`
 		resource "ibm_is_vpc" "testacc_vpc" {
 			name = "%s"
@@ -1128,13 +1255,23 @@ func testAccCheckIBMISBareMetalServerInitializationConfig(vpcname, subnetname, s
 			image 				= "%s"
 			zone 				= "%s"
 			user_data 			= "%s"
+			metadata_service {
+				enabled  = %t
+				protocol = "%s"
+			}
+			default_trusted_profile {
+				target {
+					id = "%s"
+				}
+				auto_link = %t
+			}
 			keys 				= [ibm_is_ssh_key.testacc_sshkey.id]
 			primary_network_interface {
 				subnet     		= ibm_is_subnet.testacc_subnet.id
 			}
 			vpc 				= ibm_is_vpc.testacc_vpc.id
 		}
-`, vpcname, subnetname, acc.ISZoneName, sshname, publicKey, acc.IsBareMetalServerProfileName, name, image, acc.ISZoneName, userdata)
+`, vpcname, subnetname, acc.ISZoneName2, sshname, publicKey, acc.IsBareMetalServerProfileName, name, image, acc.ISZoneName2, userdata, metadataEnabled, metadataProtocol, acc.IAMTrustedProfileID, autolink)
 }
 
 func TestAccIBMISBareMetalServerMultiple(t *testing.T) {

--- a/website/docs/d/is_bare_metal_server.markdown
+++ b/website/docs/d/is_bare_metal_server.markdown
@@ -91,6 +91,12 @@ In addition to all argument reference list, you can access the following attribu
 - `image` - (String) Image used in the bare metal server.
 - `keys` - (String) Image used in the bare metal server.
 - `memory` - (Integer) The amount of memory, truncated to whole gibibytes
+- `metadata_service` - (List) The metadata service configuration for the bare metal server
+  Nested scheme for `metadata_service`:
+  - `enabled` - (Boolean) Indicates whether the metadata service endpoint is available to the bare metal server
+  - `protocol` - (String) The communication protocol to use for the metadata service endpoint. Applies only when the metadata service is enabled.
+    - **http: HTTP protocol (unencrypted)**
+    - **https:  HTTP Secure protocol**
 - `name` - (String) The name of the bare metal server.
 - `network_attachments` - (List) The network attachments for this bare metal server, including the primary network attachment.
   Nested schema for **network_attachments**:

--- a/website/docs/d/is_bare_metal_server_initialization.markdown
+++ b/website/docs/d/is_bare_metal_server_initialization.markdown
@@ -42,6 +42,15 @@ Review the argument references that you can specify for your data source.
 In addition to the argument reference list, you can access the following attribute references after your data source is created. 
 
 - `id` - (String) The unique identifier for this bare metal server.
+- `default_trusted_profile`- (Optional, List) The default trusted profile to be used when initializing the bare metal server.
+
+  Nested scheme for `default_trusted_profile`:
+  - `auto_link` - (Boolean) If set to true, the system will create a link to the specified target trusted profile during server creation. Regardless of whether a link is created by the system or manually using the IAM Identity service, it will be automatically deleted when the server is deleted.
+  - `target` - (List) The default IAM trusted profile to use for this bare metal server.
+    Nested `target` blocks have the following structure: 
+    - `id` - (String) The unique identifier for this trusted profile
+    - `crn` - (String) The CRN for this trusted profile
+    - `resource_type` - (String) The resource type
 - `image` - (String) The unique identifier for this image
 - `image_name` - (String) The user-defined or system-provided name for this image.
 - `keys` - (Array) List of public SSH keys used at initialization.

--- a/website/docs/d/is_bare_metal_servers.markdown
+++ b/website/docs/d/is_bare_metal_servers.markdown
@@ -83,6 +83,12 @@ Review the attribute references that you can access after you retrieve your data
   - `image` - (String) Image used in the bare metal server.
   - `keys` - (String) Image used in the bare metal server.
   - `memory` - (Integer) The amount of memory, truncated to whole gibibytes
+  - `metadata_service` - (List) The metadata service configuration for the bare metal server
+      Nested scheme for `metadata_service`:
+      - `enabled` - (Boolean) Indicates whether the metadata service endpoint is available to the bare metal server
+      - `protocol` - (String) The communication protocol to use for the metadata service endpoint. Applies only when the metadata service is enabled.
+        - **http: HTTP protocol (unencrypted)**
+        - **https:  HTTP Secure protocol**
   - `name` - (String) The name of the bare metal server.
   - `network_attachments` - (List) The network attachments for this bare metal server, including the primary network attachment.
       Nested schema for **network_attachments**:

--- a/website/docs/r/is_bare_metal_server_initialization.markdown
+++ b/website/docs/r/is_bare_metal_server_initialization.markdown
@@ -28,16 +28,44 @@ In the following example, you can update name of a Bare Metal Server disk:
 
 ```terraform
 resource "ibm_is_bare_metal_server_initialization" "initialization" {
-  bare_metal_server   = ibm_is_bare_metal_server.bms.id
-  image               = var.image_id
-  keys                = [ var.keys ]
-  user_data           = var.userdata
+  bare_metal_server = ibm_is_bare_metal_server.bms.id
+  image             = var.image_id
+  keys              = [var.keys]
+  user_data         = var.userdata
 }
+
 ## to avoid changes on the ibm_is_bare_metal_server resource, use lifecycle meta argument ignore_changes
 resource "ibm_is_bare_metal_server" "bms" {
   ....
   lifecycle{
     ignore_changes = [ image, keys, user_data ]
+  }
+}
+```
+
+## Default trusted profile Example
+
+In the following example, you can update default trusted profile of a Bare Metal Server disk:
+
+```terraform
+resource "ibm_is_bare_metal_server_initialization" "initialization" {
+  bare_metal_server = ibm_is_bare_metal_server.bms.id
+  image             = var.image_id
+  keys              = [var.keys]
+  user_data         = var.userdata
+  default_trusted_profile {
+    auto_link = true
+    target {
+      id = var.profile_id
+    }
+  }
+}
+
+## to avoid changes on the ibm_is_bare_metal_server resource, use lifecycle meta argument ignore_changes
+resource "ibm_is_bare_metal_server" "bms" {
+  ....
+  lifecycle{
+    ignore_changes = [ image, keys, user_data, default_trusted_profile ]
   }
 }
 ```
@@ -48,6 +76,14 @@ Review the argument references that you can specify for your resource.
 
 
 - `bare_metal_server` - (Required, String) Bare metal server identifier. 
+- `default_trusted_profile`- (Optional, List) The default trusted profile to be used when initializing the bare metal server.
+
+  Nested scheme for `default_trusted_profile`:
+  - `auto_link` - (Boolean) If set to true, the system will create a link to the specified target trusted profile during server creation. Regardless of whether a link is created by the system or manually using the IAM Identity service, it will be automatically deleted when the server is deleted.
+  - `target` - (List) The default IAM trusted profile to use for this bare metal server.
+     Nested scheme for `target`: 
+     - `id` - (String) The unique identifier for this trusted profile
+     - `crn`- (String) The CRN for this trusted profile
 - `image` - (Required, String) Image id to use to reinitialize the bare metal server. 
 - `keys` - (Required, Array) Keys ids to use to reinitialize the bare metal server. 
 - `user_data` - (Optional, String) User data to transfer to the server bare metal server. If unspecified, no user data will be made available. (For reload/reinitialize provide the same user data as at the time of provisioning)


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/IBM-Cloud/terraform-provider-ibm/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
make testacc TEST=./ibm/service/vpc TESTARGS='-run=TestAccIBMISBareMetalServer_updateInitialization'
--- PASS: TestAccIBMISBareMetalServer_updateInitialization (1646.38s)
PASS
ok github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/vpc 1648.013s

make testacc TEST=./ibm/service/vpc TESTARGS='-run=TestAccIBMISBareMetalServerreInitWithDefaultTrustedProfile'--- PASS: TestAccIBMISBareMetalServerreInitWithDefaultTrustedProfile (1560.60s)
PASS
ok github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/vpc 1562.592s

make testacc TEST=./ibm/service/vpc TESTARGS='-run=TestAccIBMISBareMetalServerInitializationDataSource_basic'
==> Checking that code complies with gofmt requirements...--- PASS: TestAccIBMISBareMetalServerInitializationDataSource_basic (841.77s)
PASS
ok github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/vpc 843.300s

make testacc TEST=./ibm/service/vpc TESTARGS='-run=TestAccIBMISBMSDataSource_MetadataService'
==> Checking that code complies with gofmt requirements...
--- PASS: TestAccIBMISBMSDataSource_MetadataService (813.24s)
PASS
ok github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/vpc 814.819s

make testacc TEST=./ibm/service/vpc TESTARGS='-run=TestAccIBMISBMSsDataSource_MetadataService'
==> Checking that code complies with gofmt requirements...
--- PASS: TestAccIBMISBMSsDataSource_MetadataService (840.70s)
PASS
ok github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/vpc 842.227s
...
```
