### PR TITLE
fix: check position index before updating CIS ruleset rule

### DIFF
--- a/ibm/service/cis/resource_ibm_cis_ruleset_rule.go
+++ b/ibm/service/cis/resource_ibm_cis_ruleset_rule.go
@@ -503,7 +503,9 @@ func ResourceIBMCISRulesetRuleUpdate(d *schema.ResourceData, meta interface{}) e
 		if positionError != nil {
 			return flex.FmtErrorf("[ERROR] Error while updating the zone Ruleset %s", err)
 		}
-		opt.SetPosition(&position)
+		if d.HasChange(CISRulesetsRule + ".0." + CISRulesetsRulePosition) {
+			opt.SetPosition(&position)
+		}
 
 		if v, ok := rulesetsRuleObject[CISRulesetsRuleRateLimit]; ok && v != nil {
 			ratelimit, ratelimitErr := expandCISRulesetsRulesRateLimits(v)

--- a/ibm/service/cis/resource_ibm_cis_ruleset_rule.go
+++ b/ibm/service/cis/resource_ibm_cis_ruleset_rule.go
@@ -499,11 +499,11 @@ func ResourceIBMCISRulesetRuleUpdate(d *schema.ResourceData, meta interface{}) e
 		opt.SetEnabled(rulesetsRuleObject[CISRulesetsRuleActionEnabled].(bool))
 		opt.SetExpression(rulesetsRuleObject[CISRulesetsRuleExpression].(string))
 		opt.SetRef(rulesetsRuleObject[CISRulesetsRuleRef].(string))
-		position, positionError := expandCISRulesetsRulesPositions(rulesetsRuleObject[CISRulesetsRulePosition])
-		if positionError != nil {
-			return flex.FmtErrorf("[ERROR] Error while updating the zone Ruleset %s", err)
-		}
 		if d.HasChange(CISRulesetsRule + ".0." + CISRulesetsRulePosition) {
+			position, positionError := expandCISRulesetsRulesPositions(rulesetsRuleObject[CISRulesetsRulePosition])
+			if positionError != nil {
+				return flex.FmtErrorf("[ERROR] Error while updating the zone Ruleset %s", positionError)
+			}
 			opt.SetPosition(&position)
 		}
 

--- a/ibm/service/cis/resource_ibm_cis_ruleset_rule.go
+++ b/ibm/service/cis/resource_ibm_cis_ruleset_rule.go
@@ -311,6 +311,7 @@ func ResourceIBMCISRulesetRule() *schema.Resource {
 				Type:        schema.TypeList,
 				Optional:    true,
 				Description: "Rules of the rulesets",
+				MaxItems:    1,
 				Elem:        CISRulesetsRulesObject,
 			},
 		},


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/IBM-Cloud/terraform-provider-ibm/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccIBMCISRulesetRule_Basic'

=== RUN   TestAccIBMCISRulesetRule_Basic
--- PASS: TestAccIBMCISRulesetRule_Basic (121.03ss)
PASS
ok      github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/cis     122.035s
```
