### PR TITLE
refactor(share): File share mount target assign none by default for dp2

### DIFF
--- a/ibm/service/vpc/resource_ibm_is_share.go
+++ b/ibm/service/vpc/resource_ibm_is_share.go
@@ -1435,10 +1435,14 @@ func resourceIbmIsShareMapToShareMountTargetPrototype(d *schema.ResourceData, sh
 		shareTargetPrototype.TransitEncryption = &transitEncryption
 	} else {
 		shareProfile := d.Get("profile").(string)
-		if shareProfile == "dp2" {
-			shareTargetPrototype.TransitEncryption = &[]string{"none"}[0]
-		} else if shareProfile == "rfs" {
+		accessControlMode := ""
+		if accessControlModeIntf, ok := d.GetOk("access_control_mode"); ok {
+			accessControlMode = accessControlModeIntf.(string)
+		}
+		if accessControlMode == "security_group" && shareProfile == "rfs" {
 			shareTargetPrototype.TransitEncryption = &[]string{"stunnel"}[0]
+		} else {
+			shareTargetPrototype.TransitEncryption = &[]string{"none"}[0]
 		}
 	}
 

--- a/ibm/service/vpc/resource_ibm_is_share_mount_target.go
+++ b/ibm/service/vpc/resource_ibm_is_share_mount_target.go
@@ -383,10 +383,10 @@ func resourceIBMIsShareMountTargetCreate(context context.Context, d *schema.Reso
 			return tfErr.GetDiag()
 		}
 		if share != nil && share.Profile != nil && share.Profile.Name != nil {
-			if *share.Profile.Name == "dp2" {
-				shareMountTargetPrototype.TransitEncryption = &[]string{"ipsec"}[0]
-			} else if *share.Profile.Name == "rfs" {
+			if share.AccessControlMode != nil && *share.AccessControlMode == "security_group" && *share.Profile.Name == "rfs" {
 				shareMountTargetPrototype.TransitEncryption = &[]string{"stunnel"}[0]
+			} else {
+				shareMountTargetPrototype.TransitEncryption = &[]string{"none"}[0]
 			}
 		}
 	}

--- a/ibm/service/vpc/resource_ibm_is_share_mount_target_test.go
+++ b/ibm/service/vpc/resource_ibm_is_share_mount_target_test.go
@@ -98,7 +98,7 @@ func TestAccIbmIsShareMountTargetVNISubnet(t *testing.T) {
 	vpcname := fmt.Sprintf("tf-vpc-name-%d", acctest.RandIntRange(10, 100))
 	targetName := fmt.Sprintf("tf-target-%d", acctest.RandIntRange(10, 100))
 	targetNameUpdate := fmt.Sprintf("tf-target-%d", acctest.RandIntRange(10, 100))
-	sname := fmt.Sprintf("tf-fs-name-%d", acctest.RandIntRange(10, 100))
+	sname := fmt.Sprintf("tf-fs-mt-vni-name-%d", acctest.RandIntRange(10, 100))
 	subnetName := fmt.Sprintf("tf-subnet-name-%d", acctest.RandIntRange(10, 100))
 	vniName := fmt.Sprintf("tf-vni-name-%d", acctest.RandIntRange(10, 100))
 	vniNameUpdated := fmt.Sprintf("tf-vni-name-updated-%d", acctest.RandIntRange(10, 100))
@@ -398,7 +398,6 @@ func testAccCheckIbmIsShareMountTargetConfigVNIProtocolStateFilteringMode(vpcNam
 			primary_ip {
 				name = "%s"
 				address = "${replace(ibm_is_subnet.testacc_subnet.ipv4_cidr_block, "0/24", "14")}"
-				auto_delete = %t
 			}
 			subnet = ibm_is_subnet.testacc_subnet.id
 			protocol_state_filtering_mode = "auto"
@@ -407,9 +406,9 @@ func testAccCheckIbmIsShareMountTargetConfigVNIProtocolStateFilteringMode(vpcNam
 		name = "%s"
 	}
 	data "ibm_is_virtual_network_interface" "is_virtual_network_interface" {
-		virtual_network_interface = ibm_is_share_mount_target.is_share_target.virtual_network_interface.0.id
+		virtual_network_interface = ibm_is_share_mount_target.is_share_target.virtual_network_interface[0].id
 	}
-	`, sname, acc.ShareProfileName, vpcName, subnetName, acc.ISCIDR, vniName, pIpName, false, targetName)
+	`, sname, acc.ShareProfileName, vpcName, subnetName, acc.ISCIDR, vniName, pIpName, targetName)
 }
 
 func testAccCheckIbmIsShareMountTargetConfigVNIProtocolStateFilteringModeUpdate(vpcName, sname, targetName, subnetName, vniName, pIpName string) string {
@@ -439,7 +438,6 @@ func testAccCheckIbmIsShareMountTargetConfigVNIProtocolStateFilteringModeUpdate(
 			primary_ip {
 				name = "%s"
 				address = "${replace(ibm_is_subnet.testacc_subnet.ipv4_cidr_block, "0/24", "14")}"
-				auto_delete = %t
 			}
 			subnet = ibm_is_subnet.testacc_subnet.id
 			protocol_state_filtering_mode = "enabled"
@@ -447,7 +445,10 @@ func testAccCheckIbmIsShareMountTargetConfigVNIProtocolStateFilteringModeUpdate(
 
 		name = "%s"
 	}
-	`, sname, acc.ShareProfileName, vpcName, subnetName, acc.ISCIDR, vniName, pIpName, false, targetName)
+	data "ibm_is_virtual_network_interface" "is_virtual_network_interface" {
+		virtual_network_interface = ibm_is_share_mount_target.is_share_target.virtual_network_interface[0].id
+	}
+	`, sname, acc.ShareProfileName, vpcName, subnetName, acc.ISCIDR, vniName, pIpName, targetName)
 }
 
 func testAccCheckIbmIsShareMountTargetConfigVNI(vpcName, sname, targetName, subnetName, vniName, pIpName string) string {
@@ -477,14 +478,13 @@ func testAccCheckIbmIsShareMountTargetConfigVNI(vpcName, sname, targetName, subn
 			primary_ip {
 				name = "%s"
 				address = "${replace(ibm_is_subnet.testacc_subnet.ipv4_cidr_block, "0/24", "14")}"
-				auto_delete = %t
 			}
 			subnet = ibm_is_subnet.testacc_subnet.id
 		}
 
 		name = "%s"
 	}
-	`, sname, acc.ShareProfileName, vpcName, subnetName, acc.ISCIDR, vniName, pIpName, false, targetName)
+	`, sname, acc.ShareProfileName, vpcName, subnetName, acc.ISCIDR, vniName, pIpName, targetName)
 }
 
 func testAccCheckIbmIsShareTargetConfig(vpcName, sname, targetName string) string {


### PR DESCRIPTION
```

$ make test-vpc TEST_NAME=TestAccIbmIsShareMountTarget
=== RUN   TestAccIbmIsShareMountTarget
--- PASS: TestAccIbmIsShareMountTarget (222.75s)
=== RUN   TestAccIbmIsShareMountTargetVNISubnet
--- PASS: TestAccIbmIsShareMountTargetVNISubnet (224.84s)
=== RUN   TestAccIbmIsShareMountTargetVNISubnetPrimaryIPID
--- PASS: TestAccIbmIsShareMountTargetVNISubnetPrimaryIPID (200.22s)
=== RUN   TestAccIbmIsShareMountTargetVNI
--- PASS: TestAccIbmIsShareMountTargetVNI (185.21s)
=== RUN   TestAccIbmIsShareMountTargetVNIProtocolStateFilteringMode
--- PASS: TestAccIbmIsShareMountTargetVNIProtocolStateFilteringMode (197.27s)
=== RUN   TestAccIbmIsShareMountTargetVNIID
--- PASS: TestAccIbmIsShareMountTargetVNIID (142.01s)
PASS
ok      github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/vpc     1174.671s
```